### PR TITLE
[rocprofiler-compute] [bug fix] Showing actionable errors for invalid python scripts.

### DIFF
--- a/projects/rocprofiler-compute/CMakeLists.txt
+++ b/projects/rocprofiler-compute/CMakeLists.txt
@@ -601,6 +601,18 @@ add_test(
 )
 
 # -----------------------------------
+# Profiler base unit tests
+# -----------------------------------
+
+add_test(
+    NAME test_profiler_base
+    COMMAND
+        ${PYTHON_TEST_COMMAND} -m pytest ${STANDALONEBINARY_TEST_OPTION}
+        --junitxml=tests/test_profiler_base.xml ${COV_OPTION} tests/test_profiler_base.py
+        ${WORKING_DIR_OPTION}
+)
+
+# -----------------------------------
 # Generate coverage tests
 # -----------------------------------
 

--- a/projects/rocprofiler-compute/src/rocprof_compute_base.py
+++ b/projects/rocprofiler-compute/src/rocprof_compute_base.py
@@ -38,6 +38,7 @@ from utils.utils_common import (
     resolve_rocm_library_path,
     set_locale_encoding,
 )
+from utils.utils_exceptions import WorkloadCommandError
 from utils.utils_profile import get_submodules
 
 
@@ -497,7 +498,10 @@ class RocProfCompute:
 
         # instantiate desired profiler
         profiler = self.create_profiler()
-        profiler.sanitize()
+        try:
+            profiler.sanitize()
+        except WorkloadCommandError as e:
+            console_error(str(e))
 
         # Create workload directory if it does not exist
         p = Path(self.__args.path)

--- a/projects/rocprofiler-compute/src/rocprof_compute_profile/profiler_base.py
+++ b/projects/rocprofiler-compute/src/rocprof_compute_profile/profiler_base.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier:  MIT
 
 import argparse
+import re
 import shlex
 import shutil
 import sys
@@ -26,8 +27,89 @@ from utils.utils_common import (
     is_only_pc_sampling,
     print_status,
 )
+from utils.utils_exceptions import (
+    ExecutableNotFoundError,
+    NoScriptInCommandError,
+    PythonScriptNotFoundError,
+)
 from utils.utils_profile import gen_sysinfo, pc_sampling_prof, run_prof
 from vendored import yaml
+
+
+def _find_python_script_index(argv: list[str]) -> tuple[Optional[int], Optional[str]]:
+    """Locate the script argument in a Python command, skipping interpreter flags.
+
+    Returns (script_index, skip_flag).  skip_flag is the flag string ("-c"/"-m")
+    when injection should be skipped, or None when a script position was found
+    (or no arguments remain).
+    """
+    skip_next = False
+    for i, token in enumerate(argv[1:], start=1):
+        if skip_next:
+            skip_next = False
+            continue
+        if token in ("-c", "-m"):
+            return None, token
+        if token in ("-W", "-X"):
+            skip_next = True
+            continue
+        if token.startswith("-"):
+            continue
+        return i, None
+    return None, None
+
+
+def _prepare_torch_trace_injection(
+    remaining: list[str],
+    resolved_exec_path: Path,
+    is_python: bool,
+    script_index: Optional[int],
+    skip_flag: Optional[str],
+) -> None:
+    """Rewrite the workload command to inject ROCTX markers for --torch-trace.
+
+    Mutates *remaining* in-place.  Three cases:
+      1. Explicit Python interpreter  — insert inject_roctx.py before the script.
+      2. Direct .py script execution  — prepend sys.executable + inject_roctx.py.
+      3. Non-Python binary            — warn and leave the command untouched.
+    """
+    inject_script = Path(__file__).parent.parent / "utils" / "inject_roctx.py"
+    if not inject_script.exists():
+        console_error(
+            f"Cannot find inject_roctx.py at {inject_script}. "
+            "Please verify your installation."
+        )
+
+    if is_python:
+        if skip_flag:
+            console_warning(
+                f"Cannot inject ROCTX markers into 'python {skip_flag}' "
+                "invocations. Launching workload as-is; "
+                "--torch-trace may have no effect."
+            )
+        elif not Path(remaining[script_index]).is_file():
+            raise PythonScriptNotFoundError(remaining[script_index])
+        else:
+            remaining.insert(script_index, str(inject_script))
+    elif resolved_exec_path.suffix in (".py", ".pyw", ".pyc", ".pyo"):
+        remaining.insert(0, str(inject_script))
+        remaining.insert(0, sys.executable)
+    else:
+        console_warning(
+            "Command does not look like a Python entry point, "
+            "skipping ROCTX auto-injection and launching workload as-is. "
+            "Ensure the binary already initializes PyTorch/ROCTX markers, "
+            "otherwise --torch-trace will have no effect."
+        )
+
+    if (resolved_exec_path.parent / "_internal").is_dir():
+        console_warning(
+            "Workload appears to be a self-contained binary. "
+            "Such bundles typically ship private ROCm/HSA libraries, which "
+            "prevents --torch-trace from collecting data. "
+            "Rebuild without packaging libhsa/libhip or "
+            "adjust LD_LIBRARY_PATH to /opt/rocm before profiling."
+        )
 
 
 class RocProfCompute_Base:
@@ -104,55 +186,28 @@ class RocProfCompute_Base:
             # Ensure that command points to an executable
             exec_candidate = shutil.which(args.remaining[0])
             if not exec_candidate:
-                console_error(
-                    f"Your command {args.remaining[0]} doesn't point to a executable. "
-                    "Please verify."
-                )
+                raise ExecutableNotFoundError(args.remaining[0])
             resolved_exec_path = Path(exec_candidate).resolve()
 
-            # Appending a wrapper for injecting roctx-markers
+            # Detect bare Python interpreter (no script, no -c/-m) regardless
+            # of --torch-trace — this always hangs the profiler.
+            is_python = re.match(r"^python[0-9.]*$", resolved_exec_path.name)
+            script_index: Optional[int] = None
+            skip_flag: Optional[str] = None
+            if is_python:
+                script_index, skip_flag = _find_python_script_index(args.remaining)
+                if script_index is None and skip_flag is None:
+                    raise NoScriptInCommandError(args.remaining)
+
             if getattr(args, "torch_trace", False):
-                # Find the inject_roctx.py script in src/utils
-                inject_script = (
-                    Path(__file__).parent.parent / "utils" / "inject_roctx.py"
+                _prepare_torch_trace_injection(
+                    args.remaining,
+                    resolved_exec_path,
+                    bool(is_python),
+                    script_index,
+                    skip_flag,
                 )
-                if not inject_script.exists():
-                    console_error(
-                        f"Cannot find inject_roctx.py at {inject_script}. "
-                        "Please verify your installation."
-                    )
-
-                # Case 1: Explicit python command (python, python3, etc.)
-                if args.remaining[0].startswith("python"):
-                    # Insert inject_roctx.py after the python interpreter
-                    args.remaining.insert(1, str(inject_script))
-                # Case 2: Direct Python script execution (./main.py, /path/to/script.py)
-                elif args.remaining[0].endswith((".py", ".pyw", ".pyc", ".pyo")):
-                    # Use current Python interpreter
-                    args.remaining.insert(0, str(inject_script))
-                    args.remaining.insert(0, sys.executable)
-                else:
-                    console_warning(
-                        "Command does not look like a Python entry point, "
-                        "skipping ROCTX auto-injection and launching workload as-is."
-                    )
-                    console_warning(
-                        "Ensure the binary already initializes PyTorch/ROCTX markers, "
-                        "otherwise --torch-trace will have no effect."
-                    )
-
-                if (
-                    resolved_exec_path
-                    and (resolved_exec_path.parent / "_internal").is_dir()
-                ):
-                    console_warning(
-                        "Workload appears to be a self-contained binary. "
-                        "Such bundles typically ship private ROCm/HSA libraries, which "
-                        "prevents --torch-trace from collecting data."
-                        "Rebuild without packaging libhsa/libhip or "
-                        "adjust LD_LIBRARY_PATH to /opt/rocm) before profiling."
-                    )
-            args.remaining = " ".join(args.remaining)
+            args.remaining = shlex.join(args.remaining)
         elif not args.attach_pid:
             console_error(
                 "Profiling command required. Pass application executable after -- "

--- a/projects/rocprofiler-compute/src/utils/utils_exceptions.py
+++ b/projects/rocprofiler-compute/src/utils/utils_exceptions.py
@@ -1,0 +1,34 @@
+# Copyright (c) Advanced Micro Devices, Inc.
+# SPDX-License-Identifier:  MIT
+
+import shlex
+
+
+class WorkloadCommandError(Exception):
+    """Base for all workload command validation errors raised by sanitize()."""
+
+
+class ExecutableNotFoundError(WorkloadCommandError, FileNotFoundError):
+    """The command could not be resolved to an executable via PATH."""
+
+    def __init__(self, command: str) -> None:
+        self.command = command
+        super().__init__(f"'{command}' doesn't point to an executable. Please verify.")
+
+
+class PythonScriptNotFoundError(WorkloadCommandError, FileNotFoundError):
+    """A Python script was specified but does not exist on disk."""
+
+    def __init__(self, script: str) -> None:
+        self.script = script
+        super().__init__(f"Python script not found: {script}")
+
+
+class NoScriptInCommandError(WorkloadCommandError, ValueError):
+    """A Python interpreter was invoked without a script argument."""
+
+    def __init__(self, argv: list[str]) -> None:
+        self.argv = argv
+        super().__init__(
+            f"No Python script found in the workload command: {shlex.join(argv)}"
+        )

--- a/projects/rocprofiler-compute/src/utils/utils_profile.py
+++ b/projects/rocprofiler-compute/src/utils/utils_profile.py
@@ -3,7 +3,6 @@
 
 import glob
 import importlib
-import logging
 import os
 import pkgutil
 import re
@@ -32,6 +31,23 @@ from utils.utils_common import (
     perform_attach_detach,
 )
 from vendored import yaml
+
+_PROFILER_INTERNAL_RE = re.compile(
+    r"^\[rocprofiler"  # rocprofiler-sdk and rocprofiler-compute tool messages
+    r"|^[WI]\d{8}\s"  # glog-style timestamps (W/I followed by YYYYMMDD)
+)
+
+
+def _classify_output_line(line: str) -> None:
+    """Log a subprocess output line at the appropriate level.
+
+    Profiler-internal messages go to DEBUG (visible with -v).
+    Everything else goes to ERROR (always visible on failure).
+    """
+    if _PROFILER_INTERNAL_RE.match(line):
+        console_debug(line)
+    else:
+        console_error(line, exit=False)
 
 
 def run_prof(
@@ -176,9 +192,10 @@ def run_prof(
         shutil.rmtree(new_env["ROCPROFILER_METRICS_PATH"], ignore_errors=True)
 
     if (not is_mode_live_attach) and (not success):
-        if loglevel > logging.INFO:
-            for line in output.splitlines():
-                console_error(line, exit=False)
+        for line in output.splitlines():
+            stripped = line.strip()
+            if stripped:
+                _classify_output_line(stripped)
         console_error("Profiling execution failed.")
 
     results_files: list[str] = []
@@ -206,41 +223,54 @@ def run_prof(
             workload_dir + f"/out/pmc_1/{fbase}_counter_collection.csv",
             workload_dir + f"/out/pmc_1/{fbase}_marker_api_trace.csv",
         )
-        # Read CSV as list of dicts
-        combined_rows, _ = csv_ops.read_csv_as_dicts(
-            workload_dir + f"/out/pmc_1/{fbase}_counter_collection.csv"
-        )
-        # Reset Dispatch_ID based on PID, Kernel_Name, Grid_Size,
-        # Workgroup_Size, LDS_Per_Workgroup, Start_Timestamp, End_Timestamp
-        csv_ops.assign_group_ids(
-            combined_rows,
-            [
-                "PID",
-                "Kernel_Name",
-                "Grid_Size",
-                "Workgroup_Size",
-                "LDS_Per_Workgroup",
-                "Start_Timestamp",
-                "End_Timestamp",
-            ],
-            "Dispatch_ID",
-        )
-        # Reset Kernel_ID based on Kernel_Name, Grid_Size,
-        # Workgroup_Size, LDS_Per_Workgroup
-        csv_ops.assign_group_ids(
-            combined_rows,
-            ["Kernel_Name", "Grid_Size", "Workgroup_Size", "LDS_Per_Workgroup"],
-            "Kernel_ID",
-        )
-        # Drop PID since its not required
-        csv_ops.drop_column_from_rows(combined_rows, "PID")
-        # Write back to CSV
-        csv_ops.write_csv_from_dicts(
-            workload_dir + f"/out/pmc_1/{fbase}_counter_collection.csv", combined_rows
-        )
-        csv_ops.write_csv_from_dicts(
-            workload_dir + f"/results_{fbase}.csv", combined_rows
-        )
+        # Subprocess succeeded but may have dispatched zero GPU kernels,
+        # in which case the CSV is missing or has no data rows.
+        try:
+            combined_rows, _ = csv_ops.read_csv_as_dicts(
+                workload_dir + f"/out/pmc_1/{fbase}_counter_collection.csv"
+            )
+        except (FileNotFoundError, ValueError):
+            combined_rows = []
+        if not combined_rows:
+            console_warning(
+                "No GPU kernel data collected. "
+                "The workload may not have dispatched any GPU kernels."
+            )
+            shutil.rmtree(f"{workload_dir}/out", ignore_errors=True)
+            return
+        else:
+            # Reset Dispatch_ID based on PID, Kernel_Name, Grid_Size,
+            # Workgroup_Size, LDS_Per_Workgroup, Start_Timestamp, End_Timestamp
+            csv_ops.assign_group_ids(
+                combined_rows,
+                [
+                    "PID",
+                    "Kernel_Name",
+                    "Grid_Size",
+                    "Workgroup_Size",
+                    "LDS_Per_Workgroup",
+                    "Start_Timestamp",
+                    "End_Timestamp",
+                ],
+                "Dispatch_ID",
+            )
+            # Reset Kernel_ID based on Kernel_Name, Grid_Size,
+            # Workgroup_Size, LDS_Per_Workgroup
+            csv_ops.assign_group_ids(
+                combined_rows,
+                ["Kernel_Name", "Grid_Size", "Workgroup_Size", "LDS_Per_Workgroup"],
+                "Kernel_ID",
+            )
+            # Drop PID since its not required
+            csv_ops.drop_column_from_rows(combined_rows, "PID")
+            # Write back to CSV
+            csv_ops.write_csv_from_dicts(
+                workload_dir + f"/out/pmc_1/{fbase}_counter_collection.csv",
+                combined_rows,
+            )
+            csv_ops.write_csv_from_dicts(
+                workload_dir + f"/results_{fbase}.csv", combined_rows
+            )
         if torch_trace_enabled:
             # move counter collection and marker trace to workload dir
             save_torch_trace_inputs(workload_dir, fbase, format_rocprof_output)

--- a/projects/rocprofiler-compute/tests/test_profile_general.py
+++ b/projects/rocprofiler-compute/tests/test_profile_general.py
@@ -3390,3 +3390,141 @@ def test_multi_rank_no_warning_with_iteration_multiplexing(
     assert "Application replay mode" not in output
 
     test_utils.clean_output_dir(config["cleanup"], workload_dir)
+
+
+@pytest.mark.torch_trace
+@pytest.mark.parametrize(
+    "workload_cmd, expected_exit",
+    [
+        pytest.param(
+            ["python3", "nonexistent_script_abc.py"],
+            1,
+            id="missing_script",
+        ),
+        pytest.param(
+            ["python3"],
+            1,
+            id="bare_interpreter",
+        ),
+        pytest.param(
+            ["python3", "-u", "-v"],
+            1,
+            id="flags_only",
+        ),
+        pytest.param(
+            ["python3", "-u", "nonexistent_script_abc.py"],
+            1,
+            id="missing_script_after_flags",
+        ),
+        pytest.param(
+            ["nonexistentpython3", "script.py"],
+            1,
+            id="nonexistent_executable",
+        ),
+        pytest.param(
+            ["./no_such_binary"],
+            1,
+            id="nonexistent_binary",
+        ),
+    ],
+)
+def test_profile_invalid_workloads_torch_trace(
+    binary_handler_profile_rocprof_compute,
+    workload_cmd,
+    expected_exit,
+    request,
+):
+    """Integration test: workload validation exit codes with --torch-trace."""
+    app_name = "test_invalid_workload"
+    test_config = {**config, app_name: workload_cmd}
+
+    workload_dir = test_utils.get_output_dir(
+        param_id=f"invalid_wl_{request.node.callspec.id}"
+    )
+
+    returncode, stdout, stderr = binary_handler_profile_rocprof_compute(
+        test_config,
+        workload_dir,
+        options=["--experimental", "--torch-trace"],
+        check_success=False,
+        app_name=app_name,
+        capture_output=True,
+    )
+
+    assert returncode == expected_exit, (
+        f"Expected exit code {expected_exit} for {workload_cmd}, "
+        f"got {returncode}.\nstdout: {stdout}\nstderr: {stderr}"
+    )
+
+    test_utils.clean_output_dir(config["cleanup"], workload_dir)
+
+
+@pytest.mark.parametrize(
+    "workload_cmd, expected_exit",
+    [
+        pytest.param(
+            ["python3", "nonexistent_script_abc.py"],
+            1,
+            id="missing_script",
+        ),
+        pytest.param(
+            ["python3"],
+            1,
+            id="bare_interpreter",
+        ),
+        pytest.param(
+            ["python3", "-u", "-v"],
+            1,
+            id="flags_only",
+        ),
+        pytest.param(
+            ["python3", "-u", "nonexistent_script_abc.py"],
+            1,
+            id="missing_script_after_flags",
+        ),
+        pytest.param(
+            ["nonexistentpython3", "script.py"],
+            1,
+            id="nonexistent_executable",
+        ),
+        pytest.param(
+            ["./no_such_binary"],
+            1,
+            id="nonexistent_binary",
+        ),
+        pytest.param(
+            ["python3", "-c", "print('hello')"],
+            0,
+            id="non_gpu_workload",
+        ),
+    ],
+)
+def test_profile_invalid_workloads_no_torch_trace(
+    binary_handler_profile_rocprof_compute,
+    workload_cmd,
+    expected_exit,
+    request,
+):
+    """Integration test: workload validation exit codes without --torch-trace."""
+    app_name = "test_invalid_workload"
+    test_config = {**config, app_name: workload_cmd}
+
+    workload_dir = test_utils.get_output_dir(
+        param_id=f"invalid_wl_{request.node.callspec.id}"
+    )
+
+    returncode, stdout, stderr = binary_handler_profile_rocprof_compute(
+        test_config,
+        workload_dir,
+        options=[],
+        check_success=False,
+        app_name=app_name,
+        capture_output=True,
+    )
+
+    assert returncode == expected_exit, (
+        f"Expected exit code {expected_exit} for {workload_cmd}, "
+        f"got {returncode}.\nstdout: {stdout}\nstderr: {stderr}"
+    )
+
+    test_utils.clean_output_dir(config["cleanup"], workload_dir)

--- a/projects/rocprofiler-compute/tests/test_profiler_base.py
+++ b/projects/rocprofiler-compute/tests/test_profiler_base.py
@@ -1,0 +1,224 @@
+# Copyright (c) Advanced Micro Devices, Inc.
+# SPDX-License-Identifier:  MIT
+
+import argparse
+
+import pytest
+
+from rocprof_compute_profile.profiler_base import RocProfCompute_Base
+from utils.utils_exceptions import (
+    ExecutableNotFoundError,
+    NoScriptInCommandError,
+    PythonScriptNotFoundError,
+)
+
+
+def _make_sanitize_args(remaining, torch_trace=False):
+    """Build a minimal argparse.Namespace for sanitize() unit tests."""
+    return argparse.Namespace(
+        filter_blocks=[],
+        set_selected=None,
+        roof_only=False,
+        path="/tmp/test_workload",
+        no_native_tool=False,
+        iteration_multiplexing=None,
+        attach_pid=None,
+        remaining=["--"] + remaining,
+        torch_trace=torch_trace,
+    )
+
+
+def _setup_test_files(tmp_path, remaining, setup):
+    """Create temporary files and substitute placeholders in remaining."""
+    if setup == "script":
+        script = tmp_path / "good_script.py"
+        script.write_text("print('ok')\n")
+        return [s.replace("{script}", str(script)) for s in remaining]
+    elif setup == "exec_script":
+        script = tmp_path / "main.py"
+        script.write_text("print('ok')\n")
+        script.chmod(0o755)
+        return [s.replace("{exec_script}", str(script)) for s in remaining]
+    elif setup == "binary":
+        binary = tmp_path / "my_binary"
+        binary.write_text("#!/bin/sh\necho hello\n")
+        binary.chmod(0o755)
+        return [s.replace("{binary}", str(binary)) for s in remaining]
+    return remaining
+
+
+# ---------------------------------------------------------------------------
+# sanitize() with --torch-trace
+# ---------------------------------------------------------------------------
+@pytest.mark.torch_trace
+@pytest.mark.parametrize(
+    "remaining, expected_exception, setup",
+    [
+        # Should raise
+        pytest.param(
+            ["python3", "nonexistent_script_abc.py"],
+            PythonScriptNotFoundError,
+            None,
+            id="missing_script",
+        ),
+        pytest.param(
+            ["python3"],
+            NoScriptInCommandError,
+            None,
+            id="bare_interpreter",
+        ),
+        pytest.param(
+            ["python3", "-u", "-v"],
+            NoScriptInCommandError,
+            None,
+            id="flags_only",
+        ),
+        pytest.param(
+            ["python3", "-u", "nonexistent_script_abc.py"],
+            PythonScriptNotFoundError,
+            None,
+            id="missing_script_after_flags",
+        ),
+        pytest.param(
+            ["nonexistentpython3", "script.py"],
+            ExecutableNotFoundError,
+            None,
+            id="nonexistent_executable",
+        ),
+        pytest.param(
+            ["./no_such_binary"],
+            ExecutableNotFoundError,
+            None,
+            id="nonexistent_binary",
+        ),
+        # Should not raise
+        pytest.param(
+            ["python3", "-c", "print(1)"],
+            None,
+            None,
+            id="dash_c",
+        ),
+        pytest.param(
+            ["python3", "-m", "json.tool", "--help"],
+            None,
+            None,
+            id="dash_m",
+        ),
+        pytest.param(
+            ["python3", "-u", "{script}"],
+            None,
+            "script",
+            id="script_after_single_flag",
+        ),
+        pytest.param(
+            ["python3", "-W", "ignore", "-u", "{script}"],
+            None,
+            "script",
+            id="script_after_multi_flags",
+        ),
+        pytest.param(
+            ["{exec_script}"],
+            None,
+            "exec_script",
+            id="direct_py_script",
+        ),
+        pytest.param(
+            ["{binary}"],
+            None,
+            "binary",
+            id="non_python_binary",
+        ),
+    ],
+)
+def test_sanitize_torch_trace(tmp_path, remaining, expected_exception, setup):
+    """Unit test: sanitize() behavior with --torch-trace enabled."""
+    remaining = _setup_test_files(tmp_path, remaining, setup)
+    args = _make_sanitize_args(remaining, torch_trace=True)
+    profiler = RocProfCompute_Base(args, profiler_mode="rocprofiler-sdk", soc=None)
+    if expected_exception:
+        with pytest.raises(expected_exception):
+            profiler.sanitize()
+    else:
+        profiler.sanitize()
+
+
+# ---------------------------------------------------------------------------
+# sanitize() without --torch-trace
+# ---------------------------------------------------------------------------
+@pytest.mark.parametrize(
+    "remaining, expected_exception, setup",
+    [
+        # Should raise
+        pytest.param(
+            ["python3"],
+            NoScriptInCommandError,
+            None,
+            id="bare_interpreter",
+        ),
+        pytest.param(
+            ["python3", "-u", "-v"],
+            NoScriptInCommandError,
+            None,
+            id="flags_only",
+        ),
+        pytest.param(
+            ["nonexistentpython3", "script.py"],
+            ExecutableNotFoundError,
+            None,
+            id="nonexistent_executable",
+        ),
+        pytest.param(
+            ["./no_such_binary"],
+            ExecutableNotFoundError,
+            None,
+            id="nonexistent_binary",
+        ),
+        # Should not raise
+        pytest.param(
+            ["python3", "-c", "print(1)"],
+            None,
+            None,
+            id="dash_c",
+        ),
+        pytest.param(
+            ["python3", "-m", "json.tool", "--help"],
+            None,
+            None,
+            id="dash_m",
+        ),
+        pytest.param(
+            ["python3", "nonexistent_script_abc.py"],
+            None,
+            None,
+            id="missing_script",
+        ),
+        pytest.param(
+            ["python3", "-u", "nonexistent_script_abc.py"],
+            None,
+            None,
+            id="missing_script_after_flags",
+        ),
+        pytest.param(
+            ["python3", "-u", "{script}"],
+            None,
+            "script",
+            id="script_after_single_flag",
+        ),
+        pytest.param(
+            ["python3", "-W", "ignore", "-u", "{script}"],
+            None,
+            "script",
+            id="script_after_multi_flags",
+        ),
+    ],
+)
+def test_sanitize_no_torch_trace(tmp_path, remaining, expected_exception, setup):
+    """Unit test: sanitize() behavior without --torch-trace."""
+    remaining = _setup_test_files(tmp_path, remaining, setup)
+    args = _make_sanitize_args(remaining, torch_trace=False)
+    profiler = RocProfCompute_Base(args, profiler_mode="rocprofiler-sdk", soc=None)
+    if expected_exception:
+        with pytest.raises(expected_exception):
+            profiler.sanitize()
+    else:
+        profiler.sanitize()


### PR DESCRIPTION
## Motivation

1. **inject_roctx.py placed at wrong position with interpreter flags** — `python3 -u script.py` becomes `python3 inject_roctx.py -u script.py` because the original code naively inserts at index 1, ignoring flags like `-u`, `-W`, `-X`.
2. **`python -c` and `python -m` break silently under `--torch-trace`** — injection assumes a script file exists, so inline commands and module invocations either crash or produce wrong behavior with no explanation.
3. **Argument quoting destroyed by `" ".join`** — `python3 -c "import sys; print(sys.version)"` loses its quotes, causing `SyntaxError`. Affects all `-c`/`-m` commands with multi-word arguments, regardless of `--torch-trace`.
4. **Bare Python interpreter hangs the profiler** — `rocprof-compute profile -- python3` (no script, no `-c`/`-m`) opens an interactive REPL, causing the profiling run to hang indefinitely.
5. **Profiling failures produce noisy, unactionable output** — error surfacing dumped raw subprocess output including rocprofiler-sdk internal timing/init logs, burying the actual workload error.
6. **Zero-GPU-kernel workloads crash with a traceback** — workloads that run successfully but dispatch no GPU kernels (e.g. `python3 -c "print('hello')"`) hit a `FileNotFoundError` on the missing CSV, producing an unhandled traceback instead of a clean warning.

## Technical Details

1. **Custom exception hierarchy:** Introduced `ExecutableNotFoundError` (`FileNotFoundError`), `PythonScriptNotFoundError` (`FileNotFoundError`), and `NoScriptInCommandError` (`ValueError`) in `utils_exceptions.py` for structured error handling — tests assert on exception type, not message strings.
2. **Flag-aware injection:** `_find_python_script_index()` walks past Python interpreter flags (`-u`, `-v`, `-W <arg>`, `-X <arg>`) to find the actual script position before inserting `inject_roctx.py`.
3. **Bare interpreter detection:** Detects `python3` without a script, `-c`, or `-m` regardless of `--torch-trace` and raises `NoScriptInCommandError` to prevent profiler hangs.
4. **Missing script validation:** Before injecting under `--torch-trace`, verifies the script argument exists on disk; fails early with `PythonScriptNotFoundError`.
5. **`shlex.join` instead of `" ".join`:** Preserves quoting for multi-word arguments so `python3 -c "import sys; print(sys.version)"` survives the round-trip.
6. **Error surfacing filter:** Replaced raw output dump with a regex classifier (`_PROFILER_INTERNAL_RE`) that demotes rocprofiler-sdk internal logs to `DEBUG` and surfaces only workload errors as `ERROR`.
7. **Extracted `_prepare_torch_trace_injection()`:** Torch-trace injection logic moved from `sanitize()` into a standalone module-level function for clarity.

## JIRA ID

AIPROFCOMP-203

## Test Plan

```
# Integration tests (in test_profile_general.py)
pytest tests/test_profile_general.py::test_profile_invalid_workloads_torch_trace -v
pytest tests/test_profile_general.py::test_profile_invalid_workloads_no_torch_trace -v

# Unit tests (in test_profiler_base.py)
pytest tests/test_profiler_base.py::test_sanitize_torch_trace -v
pytest tests/test_profiler_base.py::test_sanitize_no_torch_trace -v

```
## Test Result

All 35 tests pass.

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
