### PR TITLE
[rocprofiler-compute] Removed --block recommendation with multi-rank profiling

### DIFF
--- a/projects/rocprofiler-compute/docs/how-to/profile/mode.rst
+++ b/projects/rocprofiler-compute/docs/how-to/profile/mode.rst
@@ -1373,13 +1373,6 @@ profiling modes:
 
      $ mpirun -n 4 rocprof-compute profile --name my_mpi_app --iteration-multiplexing -- ./my_mpi_app
 
-* ``--block <N>``: Profiles only specific metric block(s), reducing the number of
-  counters collected to fit in a single pass.
-
-  .. code-block:: shell-session
-
-     $ mpirun -n 4 rocprof-compute profile --name my_mpi_app --block 0 -- ./my_mpi_app
-
 * ``--set <name>``: Profiles a predefined counter set that fits in a single pass.
 
   .. code-block:: shell-session

--- a/projects/rocprofiler-compute/src/rocprof_compute_profile/profiler_base.py
+++ b/projects/rocprofiler-compute/src/rocprof_compute_profile/profiler_base.py
@@ -683,8 +683,6 @@ class RocProfCompute_Base:
                 "Consider using single-pass modes:\n"
                 "  --iteration-multiplexing  : Collect all counters in a "
                 "single application run\n"
-                "  --block <N>               : Profile specific block(s), "
-                "excluding block 21\n"
                 "  --set <name>              : Profile a predefined counter set\n"
                 "See documentation for more information."
             )
@@ -700,8 +698,6 @@ class RocProfCompute_Base:
                 "Consider using single-pass modes without PC sampling:\n"
                 "  --iteration-multiplexing  : Collect all counters in a "
                 "single application run\n"
-                "  --block <N>               : Profile specific block(s), "
-                "excluding block 21\n"
                 "  --set <name>              : Profile a predefined counter set\n"
                 "See documentation for more information."
             )

--- a/projects/rocprofiler-compute/tests/test_profile_general.py
+++ b/projects/rocprofiler-compute/tests/test_profile_general.py
@@ -3664,7 +3664,7 @@ def test_multi_rank_warning_application_replay(
     assert "Multi-rank application detected" in output
     assert "Application replay mode" in output
     assert "--iteration-multiplexing" in output
-    assert "--block" in output
+    assert "--block" not in output
     assert "--set" in output
 
     test_utils.clean_output_dir(config["cleanup"], workload_dir)
@@ -3699,7 +3699,7 @@ def test_multi_rank_warning_pc_sampling(
     output = stdout + stderr
     assert "Multi-rank application detected with PC sampling enabled" in output
     assert "--iteration-multiplexing" in output
-    assert "--block" in output
+    assert "--block" not in output
     assert "--set" in output
 
     test_utils.clean_output_dir(config["cleanup"], workload_dir)


### PR DESCRIPTION
## Motivation

Multi-rank profiling fails with `--block`

## Technical Details

Remove `--block` recommendation for mult-rank profiling

## JIRA ID

AIPROFCOMP-248

## Test Plan

- [X] Run multi_rank pytest

## Test Result

- [X] multi_rank pytest passes

## Submission Checklist

- [X] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
