### PR TITLE
[rocprofiler-sdk] Fix missing amd_comgr linkage in pc-sampling integration test

### DIFF
--- a/projects/rocprofiler-sdk/tests/pc_sampling/CMakeLists.txt
+++ b/projects/rocprofiler-sdk/tests/pc_sampling/CMakeLists.txt
@@ -26,6 +26,16 @@ foreach(_TYPE DEBUG MINSIZEREL RELEASE RELWITHDEBINFO)
 endforeach()
 
 find_package(rocprofiler-sdk REQUIRED)
+find_package(
+    amd_comgr
+    REQUIRED
+    CONFIG
+    HINTS
+    ${rocm_version_DIR}
+    ${ROCM_PATH}
+    PATHS
+    ${rocm_version_DIR}
+    ${ROCM_PATH})
 
 add_library(pc-sampling-integration-test-client SHARED)
 target_sources(
@@ -49,7 +59,7 @@ target_sources(
 target_link_libraries(
     pc-sampling-integration-test-client
     PRIVATE rocprofiler-sdk::rocprofiler-sdk rocprofiler-sdk::tests-build-flags
-            rocprofiler-sdk::tests-common-library)
+            rocprofiler-sdk::tests-common-library amd_comgr)
 
 set_source_files_properties(main.cpp PROPERTIES LANGUAGE HIP)
 find_package(Threads REQUIRED)


### PR DESCRIPTION
The pc-sampling-integration-test-client uses disassembly.hpp header which calls amd_comgr functions (e.g., amd_comgr_create_data) but was not linking against the amd_comgr library, causing undefined symbol errors at runtime.

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
