### PR TITLE
rocProfiler-SDK samples: Use `hipHostGetDevicePointer()` after `hipHostRegister()`

### DIFF
--- a/projects/rocprofiler-sdk/samples/api_buffered_tracing/main.cpp
+++ b/projects/rocprofiler-sdk/samples/api_buffered_tracing/main.cpp
@@ -372,7 +372,8 @@ run_migrate(int rank, int tid, hipStream_t stream, int, char** argv)
         itr = init_v;
 
     auto page_data_dev_ptr = static_cast<data_type*>(nullptr);
-    HIP_CHECK(hipHostGetDevicePointer(reinterpret_cast<void**>(&page_data_dev_ptr), page_data.data(), 0));
+    HIP_API_CALL(hipHostGetDevicePointer(
+        reinterpret_cast<void**>(&page_data_dev_ptr), page_data.data(), 0));
 
     test_page_migrate<<<1, 1024, 0, stream>>>(page_data_dev_ptr, incr_v);
     check_hip_error();

--- a/projects/rocprofiler-sdk/samples/api_buffered_tracing/main.cpp
+++ b/projects/rocprofiler-sdk/samples/api_buffered_tracing/main.cpp
@@ -371,11 +371,7 @@ run_migrate(int rank, int tid, hipStream_t stream, int, char** argv)
     for(auto& itr : page_data)
         itr = init_v;
 
-    auto page_data_dev_ptr = static_cast<data_type*>(nullptr);
-    HIP_API_CALL(
-        hipHostGetDevicePointer(reinterpret_cast<void**>(&page_data_dev_ptr), page_data.data(), 0));
-
-    test_page_migrate<<<1, 1024, 0, stream>>>(page_data_dev_ptr, incr_v);
+    test_page_migrate<<<1, 1024, 0, stream>>>(d_ptr, incr_v);
     check_hip_error();
 
     HIP_API_CALL(hipStreamSynchronize(stream));

--- a/projects/rocprofiler-sdk/samples/api_buffered_tracing/main.cpp
+++ b/projects/rocprofiler-sdk/samples/api_buffered_tracing/main.cpp
@@ -371,7 +371,10 @@ run_migrate(int rank, int tid, hipStream_t stream, int, char** argv)
     for(auto& itr : page_data)
         itr = init_v;
 
-    test_page_migrate<<<1, 1024, 0, stream>>>(d_ptr, incr_v);
+    auto page_data_dev_ptr = static_cast<data_type*>(nullptr);
+    HIP_CHECK(hipHostGetDevicePointer(reinterpret_cast<void**>(&page_data_dev_ptr), page_data.data(), 0));
+
+    test_page_migrate<<<1, 1024, 0, stream>>>(page_data_dev_ptr, incr_v);
     check_hip_error();
 
     HIP_API_CALL(hipStreamSynchronize(stream));

--- a/projects/rocprofiler-sdk/samples/api_buffered_tracing/main.cpp
+++ b/projects/rocprofiler-sdk/samples/api_buffered_tracing/main.cpp
@@ -372,8 +372,8 @@ run_migrate(int rank, int tid, hipStream_t stream, int, char** argv)
         itr = init_v;
 
     auto page_data_dev_ptr = static_cast<data_type*>(nullptr);
-    HIP_API_CALL(hipHostGetDevicePointer(
-        reinterpret_cast<void**>(&page_data_dev_ptr), page_data.data(), 0));
+    HIP_API_CALL(
+        hipHostGetDevicePointer(reinterpret_cast<void**>(&page_data_dev_ptr), page_data.data(), 0));
 
     test_page_migrate<<<1, 1024, 0, stream>>>(page_data_dev_ptr, incr_v);
     check_hip_error();

--- a/projects/rocprofiler-sdk/samples/external_correlation_id_request/main.cpp
+++ b/projects/rocprofiler-sdk/samples/external_correlation_id_request/main.cpp
@@ -358,9 +358,10 @@ run_migrate(int rank, int tid, hipStream_t stream, int, char** argv)
         itr = init_v;
 
     auto page_data_dev_ptr = static_cast<data_type*>(nullptr);
-    HIP_CHECK(hipHostGetDevicePointer(reinterpret_cast<void**>(&page_data_dev_ptr), page_data.data(), 0));
+    HIP_API_CALL(hipHostGetDevicePointer(
+        reinterpret_cast<void**>(&page_data_dev_ptr), page_data.data(), 0));
 
-    test_page_migrate<<<1, 1024, 0, stream>>>(page_data_dev_ptr, incr_v);test_page_migrate<<<1, 1024, 0, stream>>>(page_data.data(), incr_v);
+    test_page_migrate<<<1, 1024, 0, stream>>>(page_data_dev_ptr, incr_v);
 
     HIP_API_CALL(hipStreamSynchronize(stream));
 

--- a/projects/rocprofiler-sdk/samples/external_correlation_id_request/main.cpp
+++ b/projects/rocprofiler-sdk/samples/external_correlation_id_request/main.cpp
@@ -358,8 +358,8 @@ run_migrate(int rank, int tid, hipStream_t stream, int, char** argv)
         itr = init_v;
 
     auto page_data_dev_ptr = static_cast<data_type*>(nullptr);
-    HIP_API_CALL(hipHostGetDevicePointer(
-        reinterpret_cast<void**>(&page_data_dev_ptr), page_data.data(), 0));
+    HIP_API_CALL(
+        hipHostGetDevicePointer(reinterpret_cast<void**>(&page_data_dev_ptr), page_data.data(), 0));
 
     test_page_migrate<<<1, 1024, 0, stream>>>(page_data_dev_ptr, incr_v);
 

--- a/projects/rocprofiler-sdk/samples/external_correlation_id_request/main.cpp
+++ b/projects/rocprofiler-sdk/samples/external_correlation_id_request/main.cpp
@@ -357,7 +357,10 @@ run_migrate(int rank, int tid, hipStream_t stream, int, char** argv)
     for(auto& itr : page_data)
         itr = init_v;
 
-    test_page_migrate<<<1, 1024, 0, stream>>>(page_data.data(), incr_v);
+    auto page_data_dev_ptr = static_cast<data_type*>(nullptr);
+    HIP_CHECK(hipHostGetDevicePointer(reinterpret_cast<void**>(&page_data_dev_ptr), page_data.data(), 0));
+
+    test_page_migrate<<<1, 1024, 0, stream>>>(page_data_dev_ptr, incr_v);test_page_migrate<<<1, 1024, 0, stream>>>(page_data.data(), incr_v);
 
     HIP_API_CALL(hipStreamSynchronize(stream));
 


### PR DESCRIPTION
## Motivation

Two samples of the rocProfiler-SDK project are calling `hipHostRegister()` but not `hipHostGetDevicePointer()` afterwards. This can lead to crashes on systems where the device pointer and the host pointer are not the same.

## Technical Details

Adds a call to `hipHostGetDevicePointer()` where necessary.

## JIRA ID

Uncovered by ROCM-2861.

## Test Plan

Tested locally.

## Test Result

Crashes resolved.

## Submission Checklist

- [X] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
