### PR TITLE
[CLR][NFC] Deduplicate `KernelParameters::alloc` code

### DIFF
--- a/projects/clr/rocclr/platform/kernel.cpp
+++ b/projects/clr/rocclr/platform/kernel.cpp
@@ -240,17 +240,10 @@ address KernelParameters::capture(device::VirtualDevice& vDev, uint64_t lclMemSi
   const Device& device = vDev.device();
   *error = CL_SUCCESS;
 
-  //! Information about which arguments are SVM pointers is stored after
-  // the actual parameters, but only if the device has any SVM capability
-  const size_t execInfoSize = getNumberOfSvmPtr() * sizeof(void*);
-
-  address mem = vDev.allocKernelArguments(totalSize_ + execInfoSize, 128);
-  if (mem == nullptr) {
-    mem = reinterpret_cast<address>(
-        AlignedMemory::allocate(totalSize_ + execInfoSize, PARAMETERS_MIN_ALIGNMENT));
-  } else {
-    deviceKernelArgs_ = true;
-  }
+  // We need to make another allocation for kernel arguments, because the same
+  // kernel may be submitted once again, but with different arguments
+  // immediately after the current dispatch.
+  address mem = alloc(vDev);
 
   if (mem != nullptr) {
     ::memcpy(mem, values_, totalSize_);
@@ -309,6 +302,9 @@ address KernelParameters::capture(device::VirtualDevice& vDev, uint64_t lclMemSi
       }
     }
 
+    //! Information about which arguments are SVM pointers is stored after
+    // the actual parameters, but only if the device has any SVM capability
+    const size_t execInfoSize = getNumberOfSvmPtr() * sizeof(void*);
     address last = mem + totalSize_;
     if (0 != execInfoSize) {
       ::memcpy(last, &execSvmPtr_[0], execInfoSize);


### PR DESCRIPTION
## Motivation

To reduce amount of duplicated code.

## Technical Details

The helper function was most likely produced by copying the original code in `KernelParameters::capture`, but by some reason the original code was not replaced with a call to the new helper.

This commit resolves that, thus reducing code duplication a little bit.

## JIRA ID

N/A

## Test Plan

N/A, this is a non-functional change

## Test Result

N/A, this is a non-functional change

## Submission Checklist

- [X] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
