### PR TITLE
[CLR][NFC] Clearly name HIP & OpenCL set kernel arg code paths

### DIFF
--- a/projects/clr/hipamd/src/hip_module.cpp
+++ b/projects/clr/hipamd/src/hip_module.cpp
@@ -407,7 +407,7 @@ hipError_t ihipLaunchKernelCommand(amd::Command*& command, hipFunction_t f,
 
   if (DEBUG_HIP_KERNARG_COPY_OPT) {
     if (CL_SUCCESS !=
-        kernelCommand->AllocCaptureSetValidate(kernelParams, kernargs, kernargs_size)) {
+        kernelCommand->captureHIPArgsAndValidate(kernelParams, kernargs, kernargs_size)) {
       kernelCommand->release();
       return hipErrorOutOfMemory;
     }
@@ -429,7 +429,7 @@ hipError_t ihipLaunchKernelCommand(amd::Command*& command, hipFunction_t f,
     }
 
     // Capture the kernel arguments
-    if (CL_SUCCESS != kernelCommand->captureAndValidate()) {
+    if (CL_SUCCESS != kernelCommand->captureOpenCLArgsAndValidate()) {
       kernelCommand->release();
       return hipErrorOutOfMemory;
     }

--- a/projects/clr/opencl/amdocl/cl_execute.cpp
+++ b/projects/clr/opencl/amdocl/cl_execute.cpp
@@ -274,7 +274,7 @@ RUNTIME_ENTRY(cl_int, clEnqueueNDRangeKernel,
   // ndrange is now owned by command. Do not delete it!
 
   // Make sure we have memory for the command execution
-  cl_int result = command->captureAndValidate();
+  cl_int result = command->captureOpenCLArgsAndValidate();
   if (result != CL_SUCCESS) {
     delete command;
     return result;

--- a/projects/clr/rocclr/device/devprogram.cpp
+++ b/projects/clr/rocclr/device/devprogram.cpp
@@ -2188,7 +2188,7 @@ bool Program::runInitFiniKernel(const std::vector<const Kernel*>& kernels) const
       queue->release();
       return false;
     }
-    if (CL_SUCCESS != kernelCommand->captureAndValidate()) {
+    if (CL_SUCCESS != kernelCommand->captureOpenCLArgsAndValidate()) {
       LogError("Kernel Capture and Validate failed");
       kernelCommand->release();
       k->release();

--- a/projects/clr/rocclr/platform/command.cpp
+++ b/projects/clr/rocclr/platform/command.cpp
@@ -656,7 +656,7 @@ bool MigrateMemObjectsCommand::validateMemory() {
 }
 
 // =================================================================================================
-int32_t NDRangeKernelCommand::AllocCaptureSetValidate(void** kernelParams, address kernArgs,
+int32_t NDRangeKernelCommand::captureHIPArgsAndValidate(void** kernelParams, address kernArgs,
                                                       size_t kernArgsSize) {
   const amd::Device& device = queue()->device();
   // Validate the kernel before submission
@@ -670,14 +670,14 @@ int32_t NDRangeKernelCommand::AllocCaptureSetValidate(void** kernelParams, addre
     return CL_OUT_OF_RESOURCES;
   }
 
-  if (!kernel().parameters().captureAndSet(kernelParams, kernArgs, kernArgsSize, parameters_)) {
+  if (!kernel().parameters().captureHIPArgs(kernelParams, kernArgs, kernArgsSize, parameters_)) {
     LogError("Cannot capture and set the kernel parameters");
     return CL_OUT_OF_RESOURCES;
   }
   return CL_SUCCESS;
 }
 
-int32_t NDRangeKernelCommand::captureAndValidate() {
+int32_t NDRangeKernelCommand::captureOpenCLArgsAndValidate() {
   const amd::Device& device = queue()->device();
   // Validate the kernel before submission
   if (!queue()->device().validateKernel(kernel(), queue()->vdev(), cooperativeGroups())) {
@@ -686,8 +686,8 @@ int32_t NDRangeKernelCommand::captureAndValidate() {
 
   int32_t error;
   uint64_t lclMemSize = kernel().getDeviceKernel(device)->workGroupInfo()->localMemSize_;
-  parameters_ =
-      kernel().parameters().capture(*queue()->vdev(), sharedMemBytes_ + lclMemSize, &error);
+  parameters_ = kernel().parameters().captureOpenCLArgs(*queue()->vdev(),
+                                                        sharedMemBytes_ + lclMemSize, &error);
   return error;
 }
 

--- a/projects/clr/rocclr/platform/command.hpp
+++ b/projects/clr/rocclr/platform/command.hpp
@@ -1391,10 +1391,10 @@ class NDRangeKernelCommand : public Command {
   }
 
   // Capture kernel parameters and validate
-  int32_t captureAndValidate();
+  int32_t captureOpenCLArgsAndValidate();
 
   // Allocate, capture and set kernel parameters
-  int32_t AllocCaptureSetValidate(void** kernelParams, address kernArgs, size_t kernArgsSize);
+  int32_t captureHIPArgsAndValidate(void** kernelParams, address kernArgs, size_t kernArgsSize);
 };
 
 class NativeFnCommand : public Command {

--- a/projects/clr/rocclr/platform/kernel.cpp
+++ b/projects/clr/rocclr/platform/kernel.cpp
@@ -104,8 +104,8 @@ address KernelParameters::alloc(device::VirtualDevice& vDev) {
 }
 
 // =================================================================================================
-bool KernelParameters::captureAndSet(void** kernelParams, address kernArgs, size_t kernArgsSize,
-                                     address mem) {
+bool KernelParameters::captureHIPArgs(void** kernelParams, address kernArgs, size_t kernArgsSize,
+                                      address mem) {
   amd::Memory** memories = reinterpret_cast<amd::Memory**>(mem + memoryObjOffset());
   for (size_t idx = 0; idx < signature_.numParameters(); ++idx) {
     KernelParameterDescriptor& desc = signature_.params()[idx];
@@ -235,8 +235,8 @@ void KernelParameters::set(size_t index, size_t size, const void* value, bool sv
   desc.info_.defined_ = true;
 }
 
-address KernelParameters::capture(device::VirtualDevice& vDev, uint64_t lclMemSize,
-                                  int32_t* error) {
+address KernelParameters::captureOpenCLArgs(device::VirtualDevice& vDev, uint64_t lclMemSize,
+                                            int32_t* error) {
   const Device& device = vDev.device();
   *error = CL_SUCCESS;
 

--- a/projects/clr/rocclr/platform/kernel.hpp
+++ b/projects/clr/rocclr/platform/kernel.hpp
@@ -213,7 +213,11 @@ class KernelParameters : protected HeapObject {
   size_t localMemSize(size_t minDataTypeAlignment) const;
 
   //! Capture the state of the parameters and return the stack base pointer.
-  address capture(device::VirtualDevice& vDev, uint64_t lclMemSize, int32_t* error);
+  address captureOpenCLArgs(device::VirtualDevice& vDev, uint64_t lclMemSize, int32_t* error);
+
+  //! Capture the arguments from signature and set.
+  bool captureHIPArgs(void** kernelParams, address kernArgs, size_t kernArgsSize, address mem);
+
   //! Release the captured state of the parameters.
   void release(address parameters) const;
 
@@ -287,9 +291,6 @@ class KernelParameters : protected HeapObject {
 
   //! Allocate memory for kernel arguments to be set.
   address alloc(device::VirtualDevice& vDev);
-
-  //! Capture the arguments from signature and set.
-  bool captureAndSet(void** kernelParams, address kernArgs, size_t kernArgsSize, address mem);
 };
 
 /*! \brief Encapsulates a __kernel function and the argument values


### PR DESCRIPTION
## Motivation

Setting kernel arguments for HIP should be quicker, because there are less things to worry about (like samplers, or kernel arguments in local address space).
We already have two separate code paths for those, but names of corresponding functions aren't descriptive enough.

## Technical Details

This patch refactored the code so that it is clear which path is which to make context for future patches more obvious.

## JIRA ID

N/A

## Test Plan

N/A, this is a non-functional change

## Test Result

N/A, this is a non-functional change
## Submission Checklist

- [X] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
