### PR TITLE
Switch RCCL CI trigger from project JSON to modified file detection

### DIFF
--- a/.github/workflows/therock-rccl-ci.yml
+++ b/.github/workflows/therock-rccl-ci.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - develop
+      - users/arravikum/rccl-project-check
   pull_request:
     types:
       - labeled
@@ -44,17 +45,19 @@ jobs:
         id: configure
         run: python .github/scripts/therock_configure_ci.py
 
-      - name: "Check if RCCL project is affected"
+      - name: "Detect RCCL file changes"
         id: rccl_check
+        shell: bash
         run: |
-          echo "Projects JSON:"
-          echo '${{ steps.configure.outputs.projects }}'
+          echo "Changed files:"
+          git diff --name-only HEAD^
 
-          if echo '${{ steps.configure.outputs.projects }}' | \
-             jq -e '.[] | select(.project_to_test | test("rccl"))' > /dev/null; then
+          if git diff --name-only HEAD^ | grep -q '^projects/rccl/'; then
             echo "run_linux_ci=true" >> "$GITHUB_OUTPUT"
+            echo "RCCL changes detected"
           else
             echo "run_linux_ci=false" >> "$GITHUB_OUTPUT"
+            echo "No RCCL changes detected"
           fi
 
   therock-ci-linux:

--- a/.github/workflows/therock-rccl-ci.yml
+++ b/.github/workflows/therock-rccl-ci.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - develop
-      - users/arravikum/rccl-project-check
   pull_request:
     types:
       - labeled

--- a/projects/rccl/.github/workflows/therock-ci-linux.yml
+++ b/projects/rccl/.github/workflows/therock-ci-linux.yml
@@ -91,6 +91,7 @@ jobs:
       - name: Report
         #if: ${{ !cancelled() }}
         run: |
+          echo "Test"
           echo "Full SDK du:"
           echo "------------"
           du -h -d 1 build/dist/rocm

--- a/projects/rccl/.github/workflows/therock-ci-linux.yml
+++ b/projects/rccl/.github/workflows/therock-ci-linux.yml
@@ -91,7 +91,6 @@ jobs:
       - name: Report
         #if: ${{ !cancelled() }}
         run: |
-          echo "Test"
           echo "Full SDK du:"
           echo "------------"
           du -h -d 1 build/dist/rocm


### PR DESCRIPTION
Updates RCCL Linux CI triggering logic to rely on actual modified files (git diff HEAD^) instead of the project-level output from configure_ci.

The new step directly checks for changes under projects/rccl/, ensuring RCCL-related PRs, pushes, and merges correctly trigger Linux CI. This makes the behavior deterministic and aligned with the files modified in the PR.

Previously used project JSON used to detect changes was not working deterministically as seen in the below run for example

https://github.com/ROCm/rocm-systems/actions/runs/22316319702/job/64562137497