### PR TITLE
[AIRUNTIME-89][CLR] Fix a typo for hipInfo

### DIFF
--- a/projects/clr/rocclr/device/pal/paldevice.cpp
+++ b/projects/clr/rocclr/device/pal/paldevice.cpp
@@ -239,7 +239,7 @@ bool NullDevice::create(const char* palName, const amd::Isa& isa, Pal::GfxIpLeve
   properties.revision = asicRevision;
   properties.gfxLevel = ipLevel;
   properties.gfxTriple.major = isa.versionMajor();
-  properties.gfxTriple.major = isa.versionMinor();
+  properties.gfxTriple.minor = isa.versionMinor();
   properties.gfxTriple.stepping = isa.versionStepping();
   uint subtarget = 0;
 


### PR DESCRIPTION
Fixed a typo on minor version of pal device property for hipInfo.

    ## Motivation
    Fixed a typo.

    ## Technical Details

    hipInfo failed due to this typo, which caused pal device no found

    ## JIRA ID
   AIRUNTIME-89

    ## Test Plan

  hipInfo pass.

    ## Test Result

hipInfo passed on gfx1201.

    ## Submission Checklist

    - [X ] Look over the contributing guidelines at
    https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.