### PR TITLE
SWDEV-1 Explicitly set notifyState as uint32_t

### DIFF
--- a/projects/clr/rocclr/thread/monitor.hpp
+++ b/projects/clr/rocclr/thread/monitor.hpp
@@ -170,7 +170,7 @@ class Monitor {
  private:
   std::variant<std::monostate, std::mutex, std::recursive_mutex> mutex_;
 
-  enum class notifyState { notNotified = 0, oneNotified = 1, allNotified = 2 };
+  enum class notifyState : uint32_t { notNotified = 0, oneNotified = 1, allNotified = 2 };
   std::condition_variable cv_;  //!< The condition variable for sync on the mutex
   const bool recursive_;        //!< True if this is a recursive mutex, false otherwise.
   std::atomic<int> waits_;


### PR DESCRIPTION
## Motivation

Explicitly set enum class notifyState as uint32_t

## Technical Details

as above

## JIRA ID

SWDEV-1

## Test Plan

all test should pass

## Test Result

pass

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
