### PR TITLE
AIRUNTIME-92: Add stream capture checks to external semaphore APIs

### DIFF
--- a/projects/clr/hipamd/src/hip_memory.cpp
+++ b/projects/clr/hipamd/src/hip_memory.cpp
@@ -1,4 +1,4 @@
-/* Copyright (c) 2015 - 2025 Advanced Micro Devices, Inc.
+/* Copyright (c) 2015 - 2026 Advanced Micro Devices, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/projects/clr/hipamd/src/hip_memory.cpp
+++ b/projects/clr/hipamd/src/hip_memory.cpp
@@ -210,6 +210,7 @@ hipError_t hipDestroyExternalMemory(hipExternalMemory_t extMem) {
 hipError_t hipImportExternalSemaphore(hipExternalSemaphore_t* extSem_out,
                                       const hipExternalSemaphoreHandleDesc* semHandleDesc) {
   HIP_INIT_API(hipImportExternalSemaphore, extSem_out, semHandleDesc);
+  CHECK_STREAM_CAPTURE_SUPPORTED();
   if (extSem_out == nullptr || semHandleDesc == nullptr) {
     HIP_RETURN(hipErrorInvalidValue);
   }
@@ -309,6 +310,7 @@ hipError_t hipWaitExternalSemaphoresAsync(const hipExternalSemaphore_t* extSemAr
 
 hipError_t hipDestroyExternalSemaphore(hipExternalSemaphore_t extSem) {
   HIP_INIT_API(hipDestroyExternalSemaphore, extSem);
+  CHECK_STREAM_CAPTURE_SUPPORTED();
   if (extSem == nullptr) {
     HIP_RETURN(hipErrorInvalidValue);
   }


### PR DESCRIPTION
## Motivation

The external semaphore APIs `hipImportExternalSemaphore` and `hipDestroyExternalSemaphore` are missing `CHECK_STREAM_CAPTURE_SUPPORTED()` guards, causing Vulkan capture unit tests to fail.

## Technical Details

- Add `CHECK_STREAM_CAPTURE_SUPPORTED()` to `hipImportExternalSemaphore` and `hipDestroyExternalSemaphore` in `hip_memory.cpp`
- Update copyright year to 2026

## JIRA ID

AIRUNTIME-92

## Test Plan

Validate via hip-tests:
- Unit_hipImportExternalSemaphore_Vulkan_Capture
- Unit_hipDestroyExternalSemaphore_Vulkan_Capture

## Test Result

All tests passed.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.