### PR TITLE
[CLR][NFCI] Optimize HIP kernel arguments setting

### DIFF
--- a/projects/clr/rocclr/platform/kernel.cpp
+++ b/projects/clr/rocclr/platform/kernel.cpp
@@ -118,7 +118,7 @@ bool KernelParameters::captureAndSet(void** kernelParams, address kernArgs, size
       value = &uint64_value;
     }
     Memory* memArg = nullptr;
-    if (desc.type_ == T_POINTER && (desc.addressQualifier_ != CL_KERNEL_ARG_ADDRESS_LOCAL)) {
+    if (desc.type_ == T_POINTER) {
       LP64_SWITCH(uint32_value, uint64_value) = *(LP64_SWITCH(uint32_t*, uint64_t*))value;
       memArg = amd::MemObjMap::FindMemObj(*reinterpret_cast<const void* const*>(value));
       memories[desc.info_.arrayIndex_] = memArg;
@@ -136,18 +136,10 @@ bool KernelParameters::captureAndSet(void** kernelParams, address kernArgs, size
     } else {
       switch (desc.size_) {
         case 4:
-          if (desc.addressQualifier_ == CL_KERNEL_ARG_ADDRESS_LOCAL) {
-            uint32_value = desc.size_;
-          } else {
-            uint32_value = *(static_cast<const uint32_t*>(value));
-          }
+          uint32_value = *(static_cast<const uint32_t*>(value));
           break;
         case 8:
-          if (desc.addressQualifier_ == CL_KERNEL_ARG_ADDRESS_LOCAL) {
-            uint64_value = desc.size_;
-          } else {
-            uint64_value = *(static_cast<const uint64_t*>(value));
-          }
+          uint64_value = *(static_cast<const uint64_t*>(value));
           break;
       }
     }


### PR DESCRIPTION
## Motivation

This is a first patch in a mini-series of changes intended to reduce kernel launch latency by optimizing the way how we set kernel arguments.

## Technical Details

Contrary to OpenCL, there could be no HIP kernel arguments that are qualified with local address space and as such all corresponding checks were removed.

## JIRA ID

N/A

## Test Plan

N/A, this change is intended to be non-functional

## Test Result

N/A, this change is intended to be non-functional

## Submission Checklist

- [X] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
