### PR TITLE
[rocprofiler-systems] Improve incremental build time for external dependencies

### DIFF
--- a/projects/rocprofiler-systems/cmake/DyninstBoost.cmake
+++ b/projects/rocprofiler-systems/cmake/DyninstBoost.cmake
@@ -374,6 +374,8 @@ else()
         PREFIX ${Boost_ROOT_DIR}
         GIT_REPOSITORY https://github.com/boostorg/boost.git
         GIT_TAG boost-${ROCPROFSYS_BOOST_DOWNLOAD_VERSION}
+        GIT_SHALLOW TRUE
+        UPDATE_DISCONNECTED TRUE
         BUILD_IN_SOURCE 1
         CONFIGURE_COMMAND
             ${BOOST_BOOTSTRAP} --prefix=${Boost_ROOT_DIR}

--- a/projects/rocprofiler-systems/cmake/DyninstExternals.cmake
+++ b/projects/rocprofiler-systems/cmake/DyninstExternals.cmake
@@ -40,7 +40,11 @@ if(TARGET rocprofiler-systems-tbb-build AND TARGET external-prebuild)
         rocprofiler-systems-tbb-build
         PROPERTIES JOB_POOL_COMPILE external_deps_pool JOB_POOL_LINK external_deps_pool
     )
-    add_dependencies(external-prebuild rocprofiler-systems-tbb-build)
+    if(TARGET rocprofiler-systems-tbb-install)
+        add_dependencies(external-prebuild rocprofiler-systems-tbb-install)
+    else()
+        add_dependencies(external-prebuild rocprofiler-systems-tbb-build)
+    endif()
 endif()
 
 include(DyninstElfUtils)
@@ -58,7 +62,11 @@ if(TARGET rocprofiler-systems-libiberty-build AND TARGET external-prebuild)
         rocprofiler-systems-libiberty-build
         PROPERTIES JOB_POOL_COMPILE external_deps_pool JOB_POOL_LINK external_deps_pool
     )
-    add_dependencies(external-prebuild rocprofiler-systems-libiberty-build)
+    if(TARGET rocprofiler-systems-libiberty-install)
+        add_dependencies(external-prebuild rocprofiler-systems-libiberty-install)
+    else()
+        add_dependencies(external-prebuild rocprofiler-systems-libiberty-build)
+    endif()
 endif()
 
 # Final dependency check

--- a/projects/rocprofiler-systems/cmake/DyninstLibIberty.cmake
+++ b/projects/rocprofiler-systems/cmake/DyninstLibIberty.cmake
@@ -93,27 +93,23 @@ else()
             CXX=${CMAKE_CXX_COMPILER} CXXFLAGS=-fPIC\ -O3 <SOURCE_DIR>/configure
             --prefix=${_li_root}
         BUILD_COMMAND make
-        BUILD_BYPRODUCTS ${_li_build_byproducts}
         INSTALL_COMMAND ""
     )
 
     add_custom_command(
-        TARGET ${_li_project_name}
-        POST_BUILD
+        OUTPUT ${_li_build_byproducts}
         COMMAND install
         ARGS -C ${_li_working_dir}/libiberty/libiberty.a ${_li_root}/lib
         COMMAND install
         ARGS -C ${_li_working_dir}/include/*.h ${_li_root}/include
+        DEPENDS ${_li_project_name}
         COMMENT "Installing LibIberty..."
     )
 
-    # target for re-executing the installation
     add_custom_target(
         rocprofiler-systems-libiberty-install
-        COMMAND install -C ${_li_working_dir}/libiberty/libiberty.a ${_li_root}/lib
-        COMMAND install ARGS -C ${_li_working_dir}/include/*.h ${_li_root}/include
-        WORKING_DIRECTORY ${_li_working_dir}
-        COMMENT "Installing LibIberty..."
+        ALL
+        DEPENDS ${_li_build_byproducts}
     )
 
     # For backward compatibility

--- a/projects/rocprofiler-systems/cmake/DyninstTBB.cmake
+++ b/projects/rocprofiler-systems/cmake/DyninstTBB.cmake
@@ -194,28 +194,25 @@ else()
             [=[LDFLAGS=-Wl,-rpath='$$ORIGIN']=] ${MAKE_EXECUTABLE} -C src
             ${_tbb_components_cfg} tbb_build_dir=${TBB_ROOT_DIR}/src tbb_build_prefix=tbb
             ${_tbb_compiler}
-        BUILD_BYPRODUCTS ${_tbb_build_byproducts}
         INSTALL_COMMAND ""
     )
 
-    # post-build target for installing build
+    # Install TBB libraries into staging prefix after build
     add_custom_command(
-        TARGET rocprofiler-systems-tbb-build
-        POST_BUILD
+        OUTPUT ${_tbb_build_byproducts}
         COMMAND ${CMAKE_COMMAND}
         ARGS
             -DLIBDIR=${TBB_LIBRARY_DIRS} -DINCDIR=${TBB_INCLUDE_DIRS}
             -DPREFIX=${TBB_ROOT_DIR} -DCMAKE_STRIP=${CMAKE_STRIP} -P
             ${CMAKE_CURRENT_LIST_DIR}/DyninstTBBInstall.cmake
+        DEPENDS rocprofiler-systems-tbb-build
         COMMENT "Installing TBB..."
     )
 
     add_custom_target(
         rocprofiler-systems-tbb-install
-        COMMAND
-            ${CMAKE_COMMAND} -DLIBDIR=${TBB_LIBRARY_DIRS} -DINCDIR=${TBB_INCLUDE_DIRS}
-            -DPREFIX=${TBB_ROOT_DIR} -P ${CMAKE_CURRENT_LIST_DIR}/DyninstTBBInstall.cmake
-        COMMENT "Installing TBB..."
+        ALL
+        DEPENDS ${_tbb_build_byproducts}
     )
 
     install(

--- a/projects/rocprofiler-systems/examples/rccl/CMakeLists.txt
+++ b/projects/rocprofiler-systems/examples/rccl/CMakeLists.txt
@@ -82,17 +82,33 @@ if(hip_FOUND AND rccl_FOUND)
     # Get RCCL root directory
     get_filename_component(rccl_ROOT_DIR "${rccl_INCLUDE_DIRS}" DIRECTORY)
 
-    # Create a custom target that builds rccl-tests at build-time
-    add_custom_target(
-        build-rccl-tests
-        ALL
+    # Build rccl-tests at build-time (using add_custom_command with OUTPUT so
+    # CMake can skip the step when outputs are already up-to-date)
+    add_custom_command(
+        OUTPUT
+            ${rccl-tests_BUILD_DIR}/build/all_gather_perf
+            ${rccl-tests_BUILD_DIR}/build/all_reduce_perf
+            ${rccl-tests_BUILD_DIR}/build/alltoall_perf
+            ${rccl-tests_BUILD_DIR}/build/alltoallv_perf
+            ${rccl-tests_BUILD_DIR}/build/broadcast_perf
+            ${rccl-tests_BUILD_DIR}/build/gather_perf
+            ${rccl-tests_BUILD_DIR}/build/reduce_perf
+            ${rccl-tests_BUILD_DIR}/build/reduce_scatter_perf
+            ${rccl-tests_BUILD_DIR}/build/scatter_perf
+            ${rccl-tests_BUILD_DIR}/build/sendrecv_perf
         COMMAND
             make HIP_HOME=${ROCM_PATH} RCCL_HOME=${rccl_ROOT_DIR}
             GPU_TARGETS=${RCCL_GPU_TARGETS} -j
         WORKING_DIRECTORY ${rccl-tests_BUILD_DIR}
         COMMENT
             "Building rccl-tests with HIP_HOME=${ROCM_PATH} RCCL_HOME=${rccl_ROOT_DIR} ..."
-        BYPRODUCTS
+    )
+
+    # Thin custom target so other targets can depend on the rccl-tests build
+    add_custom_target(
+        build-rccl-tests
+        ALL
+        DEPENDS
             ${rccl-tests_BUILD_DIR}/build/all_gather_perf
             ${rccl-tests_BUILD_DIR}/build/all_reduce_perf
             ${rccl-tests_BUILD_DIR}/build/alltoall_perf


### PR DESCRIPTION
## Motivation

Incremental (re)builds of rocprofiler-systems unnecessarily re-execute build and install steps for external dependencies (TBB, libiberty, Boost, rccl-tests) even when their outputs are already up-to-date. This slows down the developer edit-compile-test cycle.

## Technical Details
- Replace POST_BUILD `add_custom_command` with OUTPUT-based  `add_custom_command` for TBB and libiberty install steps. This lets CMake skip the install when the output artifacts already exist and are newer than their inputs.
- Convert the corresponding `add_custom_target` commands to depend on the output files rather than re-running the install unconditionally.
- In `DyninstExternals.cmake`, depend on the new `-install` targets (when available) instead of the `-build` targets so the dependency chain includes the install step.
- Add `GIT_SHALLOW TRUE` and `UPDATE_DISCONNECTED TRUE` to the Boost `ExternalProject_Add` to avoid re-fetching/updating the repo on every configure.
- Apply the same OUTPUT-based pattern to `rccl-tests`: move the build command into an `add_custom_command(OUTPUT ...)` and let the custom target depend on those outputs, replacing the unconditional rebuild via `BYPRODUCTS`.
- Update timemory submodule to `474bea3`.

## JIRA ID

AIPROFSYST-219

## Test Plan

- Clean build: verify all external dependencies (Boost, TBB, libiberty, rccl-tests) build and install correctly on a fresh configuration.
- Incremental rebuild: run a second `make`/`ninja` invocation with no source changes and confirm the external install/build steps are skipped (check build log for absence of "Installing TBB...", "Installing LibIberty...", "Building rccl-tests..." messages).
- Touch a source file in the main project and rebuild; verify external steps are still skipped while the main project recompiles.

## Test Result
- Clean build succeeds with all artifacts installed in the expected staging prefixes.
- Subsequent no-op rebuilds complete significantly faster, with CMake reporting nothing to do for external dependency install/build steps.


## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
