### PR TITLE
[rocprofiler-systems] Add trace_cache support for std::optional<T> serialization

### DIFF
--- a/projects/rocprofiler-systems/source/lib/core/trace_cache/cache_type_traits.hpp
+++ b/projects/rocprofiler-systems/source/lib/core/trace_cache/cache_type_traits.hpp
@@ -23,6 +23,7 @@
 #pragma once
 #include "common/span.hpp"
 #include <cstdint>
+#include <optional>
 #include <string_view>
 #include <tuple>
 #include <type_traits>
@@ -108,9 +109,20 @@ static constexpr bool is_string_view_v =
     std::is_same_v<std::decay_t<T>, std::string_view>;
 
 template <typename T>
+struct is_optional : std::false_type
+{};
+
+template <typename T>
+struct is_optional<std::optional<T>> : std::true_type
+{};
+
+template <typename T>
+inline constexpr bool is_optional_v = is_optional<T>::value;
+
+template <typename T>
 inline constexpr bool is_supported_type_v =
     is_span_v<T> || std::is_integral_v<T> || std::is_floating_point_v<T> ||
-    is_string_view_v<T> || is_vector_v<T>;
+    is_string_view_v<T> || is_vector_v<T> || is_optional_v<T>;
 
 template <typename T>
 struct is_enum_class

--- a/projects/rocprofiler-systems/source/lib/core/trace_cache/cacheable.hpp
+++ b/projects/rocprofiler-systems/source/lib/core/trace_cache/cacheable.hpp
@@ -92,6 +92,10 @@ get_size(Type&& val)
 
         return total_size + sizeof(size_t);
     }
+    else if constexpr(type_traits::is_optional_v<DecayedType>)
+    {
+        return sizeof(uint8_t) + sizeof(typename DecayedType::value_type);
+    }
     else
     {
         return sizeof(DecayedType);
@@ -125,6 +129,22 @@ store_value(const Type& value, uint8_t* buffer, size_t& position)
         *reinterpret_cast<size_t*>(dest) = data_size;
         std::memcpy(dest + sizeof(size_t), value.data(), data_size);
         position += total_size;
+    }
+    else if constexpr(type_traits::is_optional_v<DecayedType>)
+    {
+        *reinterpret_cast<uint8_t*>(dest) = value.has_value() ? 1 : 0;
+        dest += sizeof(uint8_t);
+
+        constexpr size_t value_size = sizeof(typename DecayedType::value_type);
+        if(value.has_value())
+        {
+            std::memcpy(dest, &value.value(), value_size);
+        }
+        else
+        {
+            std::memset(dest, 0, value_size);
+        }
+        position += sizeof(uint8_t) + value_size;
     }
     else
     {
@@ -167,6 +187,20 @@ parse_value(uint8_t*& data_pos, Type& arg)
         std::copy_n(reinterpret_cast<const typename ContainerType::value_type*>(data_pos),
                     total_size / item_size, std::back_inserter(arg));
         data_pos += total_size;
+    }
+    else if constexpr(type_traits::is_optional_v<DecayedType>)
+    {
+        const bool has_value = *reinterpret_cast<const uint8_t*>(data_pos);
+        data_pos += sizeof(uint8_t);
+        if(has_value)
+        {
+            arg = *reinterpret_cast<const typename DecayedType::value_type*>(data_pos);
+        }
+        else
+        {
+            arg = std::nullopt;
+        }
+        data_pos += sizeof(typename DecayedType::value_type);
     }
     else
     {

--- a/projects/rocprofiler-systems/source/lib/core/trace_cache/cacheable.hpp
+++ b/projects/rocprofiler-systems/source/lib/core/trace_cache/cacheable.hpp
@@ -94,6 +94,8 @@ get_size(Type&& val)
     }
     else if constexpr(type_traits::is_optional_v<DecayedType>)
     {
+        static_assert(!type_traits::is_optional_v<typename DecayedType::value_type>,
+                      "Nested std::optional is not supported");
         return sizeof(uint8_t) + (val.has_value() ? get_size(val.value()) : 0);
     }
     else
@@ -132,6 +134,8 @@ store_value(const Type& value, uint8_t* buffer, size_t& position)
     }
     else if constexpr(type_traits::is_optional_v<DecayedType>)
     {
+        static_assert(!type_traits::is_optional_v<typename DecayedType::value_type>,
+                      "Nested std::optional is not supported");
         buffer[position++] = value.has_value() ? 1 : 0;
 
         if(value.has_value())
@@ -183,6 +187,8 @@ parse_value(uint8_t*& data_pos, Type& arg)
     }
     else if constexpr(type_traits::is_optional_v<DecayedType>)
     {
+        static_assert(!type_traits::is_optional_v<typename DecayedType::value_type>,
+                      "Nested std::optional is not supported");
         const bool has_value = *data_pos++;
         if(has_value)
         {

--- a/projects/rocprofiler-systems/source/lib/core/trace_cache/cacheable.hpp
+++ b/projects/rocprofiler-systems/source/lib/core/trace_cache/cacheable.hpp
@@ -94,7 +94,7 @@ get_size(Type&& val)
     }
     else if constexpr(type_traits::is_optional_v<DecayedType>)
     {
-        return sizeof(uint8_t) + sizeof(typename DecayedType::value_type);
+        return sizeof(uint8_t) + (val.has_value() ? get_size(val.value()) : 0);
     }
     else
     {
@@ -132,19 +132,12 @@ store_value(const Type& value, uint8_t* buffer, size_t& position)
     }
     else if constexpr(type_traits::is_optional_v<DecayedType>)
     {
-        *reinterpret_cast<uint8_t*>(dest) = value.has_value() ? 1 : 0;
-        dest += sizeof(uint8_t);
+        buffer[position++] = value.has_value() ? 1 : 0;
 
-        constexpr size_t value_size = sizeof(typename DecayedType::value_type);
         if(value.has_value())
         {
-            std::memcpy(dest, &value.value(), value_size);
+            store_value(*value, buffer, position);
         }
-        else
-        {
-            std::memset(dest, 0, value_size);
-        }
-        position += sizeof(uint8_t) + value_size;
     }
     else
     {
@@ -190,17 +183,16 @@ parse_value(uint8_t*& data_pos, Type& arg)
     }
     else if constexpr(type_traits::is_optional_v<DecayedType>)
     {
-        const bool has_value = *reinterpret_cast<const uint8_t*>(data_pos);
-        data_pos += sizeof(uint8_t);
+        const bool has_value = *data_pos++;
         if(has_value)
         {
-            arg = *reinterpret_cast<const typename DecayedType::value_type*>(data_pos);
+            arg.emplace();
+            parse_value<typename DecayedType::value_type>(data_pos, *arg);
         }
         else
         {
-            arg = std::nullopt;
+            arg.reset();
         }
-        data_pos += sizeof(typename DecayedType::value_type);
     }
     else
     {

--- a/projects/rocprofiler-systems/source/lib/core/trace_cache/sample_type.hpp
+++ b/projects/rocprofiler-systems/source/lib/core/trace_cache/sample_type.hpp
@@ -541,7 +541,8 @@ struct pmc_event_with_sample : in_time_sample
                           size_t _stack_id, size_t _parent_stack_id,
                           size_t _correlation_id, std::string _call_stack,
                           std::string _line_info, uint32_t _device_id,
-                          uint8_t _device_type, std::string _pmc_info_name, double _value)
+                          uint8_t _device_type, std::string _pmc_info_name, double _value,
+                          std::optional<size_t> _system_tid)
     : in_time_sample(_category_enum_id, std::move(_track_name), _timestamp_ns,
                      std::move(_event_metadata), _stack_id, _parent_stack_id,
                      _correlation_id, std::move(_call_stack), std::move(_line_info))
@@ -549,12 +550,14 @@ struct pmc_event_with_sample : in_time_sample
     , device_type(_device_type)
     , pmc_info_name(std::move(_pmc_info_name))
     , value(_value)
+    , system_tid(_system_tid)
     {}
 
-    uint32_t    device_id;
-    uint8_t     device_type;
-    std::string pmc_info_name;
-    double      value;
+    uint32_t              device_id;
+    uint8_t               device_type;
+    std::string           pmc_info_name;
+    double                value;
+    std::optional<size_t> system_tid;
 };
 
 template <>
@@ -567,7 +570,7 @@ serialize(uint8_t* buffer, const pmc_event_with_sample& item)
         static_cast<uint64_t>(item.stack_id), static_cast<uint64_t>(item.parent_stack_id),
         static_cast<uint64_t>(item.correlation_id), std::string_view(item.call_stack),
         std::string_view(item.line_info), item.device_id, item.device_type,
-        std::string_view(item.pmc_info_name), item.value);
+        std::string_view(item.pmc_info_name), item.value, item.system_tid);
 }
 
 template <>
@@ -582,7 +585,8 @@ deserialize(uint8_t*& buffer)
     utility::parse_value(buffer, category_enum_id, track_name_view, timestamp_ns,
                          event_metadata_view, stack_id, parent_stack_id, correlation_id,
                          call_stack_view, line_info_view, item.device_id,
-                         item.device_type, pmc_info_name_view, item.value);
+                         item.device_type, pmc_info_name_view, item.value,
+                         item.system_tid);
     item.category_enum_id = category_enum_id;
     item.track_name       = std::string(track_name_view);
     item.timestamp_ns     = timestamp_ns;
@@ -606,7 +610,7 @@ get_size(const pmc_event_with_sample& item)
         static_cast<uint64_t>(item.stack_id), static_cast<uint64_t>(item.parent_stack_id),
         static_cast<uint64_t>(item.correlation_id), std::string_view(item.call_stack),
         std::string_view(item.line_info), item.device_id, item.device_type,
-        std::string_view(item.pmc_info_name), item.value);
+        std::string_view(item.pmc_info_name), item.value, item.system_tid);
 }
 
 struct amd_smi_sample : cacheable_t

--- a/projects/rocprofiler-systems/source/lib/core/trace_cache/sample_type.hpp
+++ b/projects/rocprofiler-systems/source/lib/core/trace_cache/sample_type.hpp
@@ -542,7 +542,7 @@ struct pmc_event_with_sample : in_time_sample
                           size_t _correlation_id, std::string _call_stack,
                           std::string _line_info, uint32_t _device_id,
                           uint8_t _device_type, std::string _pmc_info_name, double _value,
-                          std::optional<size_t> _system_tid)
+                          std::optional<int64_t> _system_tid)
     : in_time_sample(_category_enum_id, std::move(_track_name), _timestamp_ns,
                      std::move(_event_metadata), _stack_id, _parent_stack_id,
                      _correlation_id, std::move(_call_stack), std::move(_line_info))
@@ -553,11 +553,11 @@ struct pmc_event_with_sample : in_time_sample
     , system_tid(_system_tid)
     {}
 
-    uint32_t              device_id;
-    uint8_t               device_type;
-    std::string           pmc_info_name;
-    double                value;
-    std::optional<size_t> system_tid;
+    uint32_t               device_id;
+    uint8_t                device_type;
+    std::string            pmc_info_name;
+    double                 value;
+    std::optional<int64_t> system_tid;
 };
 
 template <>

--- a/projects/rocprofiler-systems/source/lib/core/trace_cache/tests/mocked_types.hpp
+++ b/projects/rocprofiler-systems/source/lib/core/trace_cache/tests/mocked_types.hpp
@@ -34,6 +34,7 @@ enum class test_type_identifier_t : uint32_t
     sample_type_2    = 2,
     sample_type_3    = 3,
     sample_type_4    = 4,
+    sample_type_5    = 5,
     fragmented_space = 0xFFFF
 };
 struct test_sample_1 : public rocprofsys::trace_cache::cacheable_t
@@ -111,6 +112,21 @@ struct test_sample_4 : public rocprofsys::trace_cache::cacheable_t
     std::vector<uint32_t> data;
 
     bool operator==(const test_sample_4& other) const { return data == other.data; }
+};
+
+struct test_sample_5 : public rocprofsys::trace_cache::cacheable_t
+{
+    static constexpr test_type_identifier_t type_identifier =
+        test_type_identifier_t::sample_type_5;
+
+    test_sample_5() = default;
+    test_sample_5(std::optional<uint32_t> d)
+    : data(d)
+    {}
+
+    std::optional<uint32_t> data;
+
+    bool operator==(const test_sample_5& other) const { return data == other.data; }
 };
 
 template <>
@@ -201,6 +217,29 @@ rocprofsys::trace_cache::deserialize(uint8_t*& buffer)
 template <>
 inline size_t
 rocprofsys::trace_cache::get_size(const test_sample_4& item)
+{
+    return rocprofsys::trace_cache::utility::get_size(item.data);
+}
+
+template <>
+inline void
+rocprofsys::trace_cache::serialize(uint8_t* buffer, const test_sample_5& item)
+{
+    rocprofsys::trace_cache::utility::store_value(buffer, item.data);
+}
+
+template <>
+inline test_sample_5
+rocprofsys::trace_cache::deserialize(uint8_t*& buffer)
+{
+    test_sample_5 result;
+    rocprofsys::trace_cache::utility::parse_value(buffer, result.data);
+    return result;
+}
+
+template <>
+inline size_t
+rocprofsys::trace_cache::get_size(const test_sample_5& item)
 {
     return rocprofsys::trace_cache::utility::get_size(item.data);
 }

--- a/projects/rocprofiler-systems/source/lib/core/trace_cache/tests/test_buffer_storage.cpp
+++ b/projects/rocprofiler-systems/source/lib/core/trace_cache/tests/test_buffer_storage.cpp
@@ -295,6 +295,43 @@ TEST_F(buffer_storage_test, MixedSampleTypes)
     EXPECT_EQ(buffer_pos, buffer_data.size());
 }
 
+TEST_F(buffer_storage_test, mixed_sample_types_with_optional)
+{
+    rocprofsys::trace_cache::buffer_storage<mock_worker_factory_t, test_type_identifier_t>
+        storage(test_file_path);
+    SetUpStartStopOnCall();
+    EXPECT_CALL(*g_mock_worker, start).Times(1);
+    EXPECT_CALL(*g_mock_worker, stop).Times(1);
+
+    storage.start();
+    test_sample_1 sample1(42, "event_data");
+    test_sample_5 sample5_with_value(std::optional<uint32_t>{ 99 });
+    test_sample_5 sample5_nullopt(std::nullopt);
+    test_sample_2 sample2(2.71828, 1002);
+
+    EXPECT_NO_THROW(storage.store(sample1));
+    EXPECT_NO_THROW(storage.store(sample5_with_value));
+    EXPECT_NO_THROW(storage.store(sample5_nullopt));
+    EXPECT_NO_THROW(storage.store(sample2));
+
+    g_mock_worker->execute_flush(true);
+
+    EXPECT_NO_THROW(storage.shutdown());
+
+    std::string buffer_data = g_mock_worker->m_output_string_stream.str();
+    ASSERT_FALSE(buffer_data.empty());
+
+    const uint8_t* buffer     = reinterpret_cast<const uint8_t*>(buffer_data.data());
+    size_t         buffer_pos = 0;
+
+    verify_buffer_contains(sample1, buffer, buffer_pos);
+    verify_buffer_contains(sample5_with_value, buffer, buffer_pos);
+    verify_buffer_contains(sample5_nullopt, buffer, buffer_pos);
+    verify_buffer_contains(sample2, buffer, buffer_pos);
+
+    EXPECT_EQ(buffer_pos, buffer_data.size());
+}
+
 TEST_F(buffer_storage_test, large_payload_handling)
 {
     rocprofsys::trace_cache::buffer_storage<mock_worker_factory_t, test_type_identifier_t>

--- a/projects/rocprofiler-systems/source/lib/core/trace_cache/tests/test_cache_integration.cpp
+++ b/projects/rocprofiler-systems/source/lib/core/trace_cache/tests/test_cache_integration.cpp
@@ -90,6 +90,18 @@ struct sample_4_hash
     }
 };
 
+struct sample_5_hash
+{
+    size_t operator()(const test_sample_5& s) const
+    {
+        if(s.data.has_value())
+        {
+            return std::hash<uint32_t>{}(s.data.value()) ^ 0x1;
+        }
+        return 0;
+    }
+};
+
 }  // namespace
 
 class integration_sample_processor_t
@@ -137,6 +149,16 @@ public:
         }
     }
 
+    void set_expected_samples_5(const std::vector<test_sample_5>& samples)
+    {
+        std::lock_guard<std::mutex> lock(m_data_mutex);
+        m_expected_samples_5.clear();
+        for(const auto& s : samples)
+        {
+            m_expected_samples_5[s]++;
+        }
+    }
+
     void execute_sample_processing(test_type_identifier_t type_identifier,
                                    const rocprofsys::trace_cache::cacheable_t& value)
     {
@@ -174,6 +196,14 @@ public:
                 check_sample_4(sample);
                 break;
             }
+            case test_type_identifier_t::sample_type_5:
+            {
+                const auto& sample = static_cast<const test_sample_5&>(value);
+                std::lock_guard<std::mutex> lock(m_data_mutex);
+                m_sample_5_count++;
+                check_sample_5(sample);
+                break;
+            }
             default: break;
         }
     }
@@ -182,11 +212,13 @@ public:
     int  get_sample_2_count() const { return m_sample_2_count.load(); }
     int  get_sample_3_count() const { return m_sample_3_count.load(); }
     int  get_sample_4_count() const { return m_sample_4_count.load(); }
+    int  get_sample_5_count() const { return m_sample_5_count.load(); }
     bool all_expected_samples_found() const
     {
         std::lock_guard<std::mutex> lock(m_data_mutex);
         return m_expected_samples_1.empty() && m_expected_samples_2.empty() &&
-               m_expected_samples_3.empty() && m_expected_samples_4.empty();
+               m_expected_samples_3.empty() && m_expected_samples_4.empty() &&
+               m_expected_samples_5.empty();
     }
 
 private:
@@ -246,14 +278,30 @@ private:
         }
     }
 
+    void check_sample_5(const test_sample_5& sample)
+    {
+        auto it = m_expected_samples_5.find(sample);
+        EXPECT_NE(it, m_expected_samples_5.end());
+        if(it != m_expected_samples_5.end())
+        {
+            it->second--;
+            if(it->second == 0)
+            {
+                m_expected_samples_5.erase(it);
+            }
+        }
+    }
+
     std::atomic<int>                                      m_sample_1_count{ 0 };
     std::atomic<int>                                      m_sample_2_count{ 0 };
     std::atomic<int>                                      m_sample_3_count{ 0 };
     std::atomic<int>                                      m_sample_4_count{ 0 };
+    std::atomic<int>                                      m_sample_5_count{ 0 };
     std::unordered_map<test_sample_1, int, sample_1_hash> m_expected_samples_1;
     std::unordered_map<test_sample_2, int, sample_2_hash> m_expected_samples_2;
     std::unordered_map<test_sample_3, int, sample_3_hash> m_expected_samples_3;
     std::unordered_map<test_sample_4, int, sample_4_hash> m_expected_samples_4;
+    std::unordered_map<test_sample_5, int, sample_5_hash> m_expected_samples_5;
     mutable std::mutex                                    m_data_mutex;
 };
 
@@ -692,5 +740,49 @@ TEST_F(trace_cache_module_integration_test, mixed_vector_element_sizes)
 
     EXPECT_EQ(processor->get_sample_3_count(), 50);
     EXPECT_EQ(processor->get_sample_4_count(), 50);
+    EXPECT_TRUE(processor->all_expected_samples_found());
+}
+
+TEST_F(trace_cache_module_integration_test, optional_field_roundtrip)
+{
+    std::string text_1 = "optional_test";
+
+    test_sample_1 sample1(42, text_1);
+    test_sample_5 sample5_with_value(std::optional<uint32_t>{ 12345 });
+    test_sample_5 sample5_nullopt(std::nullopt);
+    test_sample_2 sample2(2.71828, 999);
+
+    std::vector<test_sample_1> expected_1 = { sample1 };
+    std::vector<test_sample_2> expected_2 = { sample2 };
+    std::vector<test_sample_5> expected_5 = { sample5_with_value, sample5_nullopt };
+
+    {
+        rocprofsys::trace_cache::buffer_storage<
+            rocprofsys::trace_cache::flush_worker_factory_t, test_type_identifier_t>
+            storage(test_file_path);
+        storage.start();
+
+        storage.store(sample1);
+        storage.store(sample5_with_value);
+        storage.store(sample5_nullopt);
+        storage.store(sample2);
+
+        storage.shutdown();
+    }
+
+    auto processor = std::make_shared<integration_sample_processor_t>();
+    processor->set_expected_samples_1(expected_1);
+    processor->set_expected_samples_2(expected_2);
+    processor->set_expected_samples_5(expected_5);
+
+    rocprofsys::trace_cache::storage_parser<test_type_identifier_t, test_sample_1,
+                                            test_sample_2, test_sample_3, test_sample_4,
+                                            test_sample_5>
+        parser(test_file_path);
+    parser.load(processor);
+
+    EXPECT_EQ(processor->get_sample_1_count(), 1);
+    EXPECT_EQ(processor->get_sample_2_count(), 1);
+    EXPECT_EQ(processor->get_sample_5_count(), 2);
     EXPECT_TRUE(processor->all_expected_samples_found());
 }

--- a/projects/rocprofiler-systems/source/lib/core/trace_cache/tests/test_cacheable.cpp
+++ b/projects/rocprofiler-systems/source/lib/core/trace_cache/tests/test_cacheable.cpp
@@ -98,6 +98,24 @@ TEST_F(cacheable_test, store_value_string_literal)
     EXPECT_EQ(stored_value, "Hello World");
 }
 
+TEST_F(cacheable_test, store_value_optional)
+{
+    std::optional<double> value = 42.0;
+    rocprofsys::trace_cache::utility::store_value(value, buffer.data(), position);
+    EXPECT_EQ(position, sizeof(uint8_t) + sizeof(double));
+    EXPECT_EQ(buffer[0], 1);
+    EXPECT_DOUBLE_EQ(*reinterpret_cast<double*>(buffer.data() + sizeof(uint8_t)),
+                     value.value());
+}
+
+TEST_F(cacheable_test, store_value_optional_empty)
+{
+    std::optional<double> value = std::nullopt;
+    rocprofsys::trace_cache::utility::store_value(value, buffer.data(), position);
+    EXPECT_EQ(position, sizeof(uint8_t) + sizeof(double));
+    EXPECT_EQ(buffer[0], 0);
+}
+
 TEST_F(cacheable_test, store_value_empty_string)
 {
     auto value = ""sv;
@@ -220,6 +238,137 @@ TEST_F(cacheable_test, parse_value_empty_string)
     EXPECT_EQ(data_pos, buffer.data() + sizeof(size_t));
 }
 
+TEST_F(cacheable_test, parse_value_optional)
+{
+    std::optional<double> original_value = 42.0;
+    rocprofsys::trace_cache::utility::store_value(original_value, buffer.data(),
+                                                  position);
+
+    uint8_t*              data_pos = buffer.data();
+    std::optional<double> parsed_value;
+    rocprofsys::trace_cache::utility::parse_value(data_pos, parsed_value);
+
+    EXPECT_EQ(parsed_value, 42.0);
+    EXPECT_EQ(data_pos, buffer.data() + sizeof(uint8_t) + sizeof(double));
+}
+
+TEST_F(cacheable_test, parse_value_optional_empty)
+{
+    std::optional<double> original_value = std::nullopt;
+    rocprofsys::trace_cache::utility::store_value(original_value, buffer.data(),
+                                                  position);
+
+    uint8_t*              data_pos = buffer.data();
+    std::optional<double> parsed_value;
+    rocprofsys::trace_cache::utility::parse_value(data_pos, parsed_value);
+
+    EXPECT_EQ(parsed_value, std::nullopt);
+    EXPECT_EQ(data_pos, buffer.data() + sizeof(uint8_t) + sizeof(double));
+}
+
+TEST_F(cacheable_test, roundtrip_optional_uint32_with_value)
+{
+    std::optional<uint32_t> original_value = 42;
+    rocprofsys::trace_cache::utility::store_value(original_value, buffer.data(),
+                                                  position);
+
+    uint8_t*                data_pos = buffer.data();
+    std::optional<uint32_t> parsed_value;
+    rocprofsys::trace_cache::utility::parse_value(data_pos, parsed_value);
+
+    ASSERT_TRUE(parsed_value.has_value());
+    EXPECT_EQ(parsed_value.value(), 42);
+    EXPECT_EQ(data_pos, buffer.data() + sizeof(uint8_t) + sizeof(uint32_t));
+}
+
+TEST_F(cacheable_test, roundtrip_optional_uint32_nullopt)
+{
+    std::optional<uint32_t> original_value = std::nullopt;
+    rocprofsys::trace_cache::utility::store_value(original_value, buffer.data(),
+                                                  position);
+
+    uint8_t*                data_pos = buffer.data();
+    std::optional<uint32_t> parsed_value;
+    rocprofsys::trace_cache::utility::parse_value(data_pos, parsed_value);
+
+    EXPECT_FALSE(parsed_value.has_value());
+    EXPECT_EQ(parsed_value, std::nullopt);
+    EXPECT_EQ(data_pos, buffer.data() + sizeof(uint8_t) + sizeof(uint32_t));
+}
+
+TEST_F(cacheable_test, roundtrip_optional_uint64)
+{
+    std::optional<uint64_t> original_value = 0xDEADBEEFCAFEBABE;
+    rocprofsys::trace_cache::utility::store_value(original_value, buffer.data(),
+                                                  position);
+
+    uint8_t*                data_pos = buffer.data();
+    std::optional<uint64_t> parsed_value;
+    rocprofsys::trace_cache::utility::parse_value(data_pos, parsed_value);
+
+    ASSERT_TRUE(parsed_value.has_value());
+    EXPECT_EQ(parsed_value.value(), 0xDEADBEEFCAFEBABE);
+    EXPECT_EQ(data_pos, buffer.data() + sizeof(uint8_t) + sizeof(uint64_t));
+}
+
+TEST_F(cacheable_test, roundtrip_optional_float)
+{
+    std::optional<float> original_value = 3.14f;
+    rocprofsys::trace_cache::utility::store_value(original_value, buffer.data(),
+                                                  position);
+
+    uint8_t*             data_pos = buffer.data();
+    std::optional<float> parsed_value;
+    rocprofsys::trace_cache::utility::parse_value(data_pos, parsed_value);
+
+    ASSERT_TRUE(parsed_value.has_value());
+    EXPECT_FLOAT_EQ(parsed_value.value(), 3.14f);
+    EXPECT_EQ(data_pos, buffer.data() + sizeof(uint8_t) + sizeof(float));
+}
+
+TEST_F(cacheable_test, roundtrip_optional_int64_negative)
+{
+    std::optional<int64_t> original_value = -999999;
+    rocprofsys::trace_cache::utility::store_value(original_value, buffer.data(),
+                                                  position);
+
+    uint8_t*               data_pos = buffer.data();
+    std::optional<int64_t> parsed_value;
+    rocprofsys::trace_cache::utility::parse_value(data_pos, parsed_value);
+
+    ASSERT_TRUE(parsed_value.has_value());
+    EXPECT_EQ(parsed_value.value(), -999999);
+    EXPECT_EQ(data_pos, buffer.data() + sizeof(uint8_t) + sizeof(int64_t));
+}
+
+TEST_F(cacheable_test, parse_multiple_values_with_optional)
+{
+    int                     int_val   = 100;
+    std::optional<uint32_t> opt_val   = uint32_t{ 777 };
+    auto                    str_val   = "mixed"sv;
+    std::optional<double>   opt_empty = std::nullopt;
+
+    rocprofsys::trace_cache::utility::store_value(int_val, buffer.data(), position);
+    rocprofsys::trace_cache::utility::store_value(opt_val, buffer.data(), position);
+    rocprofsys::trace_cache::utility::store_value(str_val, buffer.data(), position);
+    rocprofsys::trace_cache::utility::store_value(opt_empty, buffer.data(), position);
+
+    uint8_t*                data_pos = buffer.data();
+    int                     parsed_int;
+    std::optional<uint32_t> parsed_opt;
+    std::string_view        parsed_str;
+    std::optional<double>   parsed_opt_empty;
+
+    rocprofsys::trace_cache::utility::parse_value(data_pos, parsed_int, parsed_opt,
+                                                  parsed_str, parsed_opt_empty);
+
+    EXPECT_EQ(parsed_int, 100);
+    ASSERT_TRUE(parsed_opt.has_value());
+    EXPECT_EQ(parsed_opt.value(), 777);
+    EXPECT_EQ(parsed_str, "mixed");
+    EXPECT_FALSE(parsed_opt_empty.has_value());
+}
+
 TEST_F(cacheable_test, parse_value_byte_array)
 {
     std::vector<uint8_t> original_value = { 10, 20, 30, 40, 50 };
@@ -296,6 +445,20 @@ TEST_F(cacheable_test, get_size_helper_string_literal)
     auto   value = "test string"sv;
     size_t size  = rocprofsys::trace_cache::utility::get_size(value);
     EXPECT_EQ(size, value.size() + sizeof(size_t));
+}
+
+TEST_F(cacheable_test, get_size_helper_optional)
+{
+    std::optional<int> value = 42;
+    size_t             size  = rocprofsys::trace_cache::utility::get_size(value);
+    EXPECT_EQ(size, sizeof(uint8_t) + sizeof(int));
+}
+
+TEST_F(cacheable_test, get_size_helper_optional_empty)
+{
+    std::optional<int> value = std::nullopt;
+    size_t             size  = rocprofsys::trace_cache::utility::get_size(value);
+    EXPECT_EQ(size, sizeof(uint8_t) + sizeof(int));
 }
 
 TEST_F(cacheable_test, get_size_helper_byte_array)
@@ -500,6 +663,26 @@ TEST(type_traits_test, is_vector_v)
     EXPECT_FALSE(rocprofsys::trace_cache::type_traits::is_vector_v<std::string_view>);
 }
 
+TEST(type_traits_test, is_optional_v)
+{
+    EXPECT_TRUE(rocprofsys::trace_cache::type_traits::is_optional_v<std::optional<int>>);
+    EXPECT_TRUE(
+        rocprofsys::trace_cache::type_traits::is_optional_v<std::optional<uint32_t>>);
+    EXPECT_TRUE(
+        rocprofsys::trace_cache::type_traits::is_optional_v<std::optional<double>>);
+    EXPECT_TRUE(
+        rocprofsys::trace_cache::type_traits::is_optional_v<std::optional<uint64_t>>);
+    EXPECT_TRUE(
+        rocprofsys::trace_cache::type_traits::is_optional_v<std::optional<float>>);
+
+    EXPECT_FALSE(rocprofsys::trace_cache::type_traits::is_optional_v<int>);
+    EXPECT_FALSE(rocprofsys::trace_cache::type_traits::is_optional_v<double>);
+    EXPECT_FALSE(rocprofsys::trace_cache::type_traits::is_optional_v<std::vector<int>>);
+    EXPECT_FALSE(rocprofsys::trace_cache::type_traits::is_optional_v<std::string_view>);
+    EXPECT_FALSE(
+        rocprofsys::trace_cache::type_traits::is_optional_v<rocprofsys::span<int>>);
+}
+
 TEST(type_traits_test, is_supported_type_v)
 {
     EXPECT_TRUE(rocprofsys::trace_cache::type_traits::is_supported_type_v<int>);
@@ -516,6 +699,12 @@ TEST(type_traits_test, is_supported_type_v)
         rocprofsys::trace_cache::type_traits::is_supported_type_v<rocprofsys::span<int>>);
     EXPECT_TRUE(rocprofsys::trace_cache::type_traits::is_supported_type_v<
                 rocprofsys::span<uint8_t>>);
+    EXPECT_TRUE(
+        rocprofsys::trace_cache::type_traits::is_supported_type_v<std::optional<int>>);
+    EXPECT_TRUE(rocprofsys::trace_cache::type_traits::is_supported_type_v<
+                std::optional<uint32_t>>);
+    EXPECT_TRUE(
+        rocprofsys::trace_cache::type_traits::is_supported_type_v<std::optional<double>>);
 
     struct custom_type
     {};

--- a/projects/rocprofiler-systems/source/lib/core/trace_cache/tests/test_cacheable.cpp
+++ b/projects/rocprofiler-systems/source/lib/core/trace_cache/tests/test_cacheable.cpp
@@ -112,7 +112,7 @@ TEST_F(cacheable_test, store_value_optional_empty)
 {
     std::optional<double> value = std::nullopt;
     rocprofsys::trace_cache::utility::store_value(value, buffer.data(), position);
-    EXPECT_EQ(position, sizeof(uint8_t) + sizeof(double));
+    EXPECT_EQ(position, sizeof(uint8_t));
     EXPECT_EQ(buffer[0], 0);
 }
 
@@ -263,7 +263,7 @@ TEST_F(cacheable_test, parse_value_optional_empty)
     rocprofsys::trace_cache::utility::parse_value(data_pos, parsed_value);
 
     EXPECT_EQ(parsed_value, std::nullopt);
-    EXPECT_EQ(data_pos, buffer.data() + sizeof(uint8_t) + sizeof(double));
+    EXPECT_EQ(data_pos, buffer.data() + sizeof(uint8_t));
 }
 
 TEST_F(cacheable_test, roundtrip_optional_uint32_with_value)
@@ -293,7 +293,7 @@ TEST_F(cacheable_test, roundtrip_optional_uint32_nullopt)
 
     EXPECT_FALSE(parsed_value.has_value());
     EXPECT_EQ(parsed_value, std::nullopt);
-    EXPECT_EQ(data_pos, buffer.data() + sizeof(uint8_t) + sizeof(uint32_t));
+    EXPECT_EQ(data_pos, buffer.data() + sizeof(uint8_t));
 }
 
 TEST_F(cacheable_test, roundtrip_optional_uint64)
@@ -367,6 +367,157 @@ TEST_F(cacheable_test, parse_multiple_values_with_optional)
     EXPECT_EQ(parsed_opt.value(), 777);
     EXPECT_EQ(parsed_str, "mixed");
     EXPECT_FALSE(parsed_opt_empty.has_value());
+}
+
+TEST_F(cacheable_test, roundtrip_optional_vector_uint8_with_value)
+{
+    std::optional<std::vector<uint8_t>> original = std::vector<uint8_t>{ 10, 20, 30 };
+    rocprofsys::trace_cache::utility::store_value(original, buffer.data(), position);
+
+    const size_t expected_size =
+        sizeof(uint8_t) + sizeof(size_t) + original->size() * sizeof(uint8_t);
+    EXPECT_EQ(position, expected_size);
+
+    uint8_t*                            data_pos = buffer.data();
+    std::optional<std::vector<uint8_t>> parsed;
+    rocprofsys::trace_cache::utility::parse_value(data_pos, parsed);
+
+    ASSERT_TRUE(parsed.has_value());
+    EXPECT_EQ(*parsed, *original);
+    EXPECT_EQ(data_pos, buffer.data() + expected_size);
+}
+
+TEST_F(cacheable_test, roundtrip_optional_vector_uint8_nullopt)
+{
+    std::optional<std::vector<uint8_t>> original = std::nullopt;
+    rocprofsys::trace_cache::utility::store_value(original, buffer.data(), position);
+
+    EXPECT_EQ(position, sizeof(uint8_t));
+
+    uint8_t*                            data_pos = buffer.data();
+    std::optional<std::vector<uint8_t>> parsed;
+    rocprofsys::trace_cache::utility::parse_value(data_pos, parsed);
+
+    EXPECT_FALSE(parsed.has_value());
+    EXPECT_EQ(data_pos, buffer.data() + sizeof(uint8_t));
+}
+
+TEST_F(cacheable_test, roundtrip_optional_vector_uint32_with_value)
+{
+    std::optional<std::vector<uint32_t>> original =
+        std::vector<uint32_t>{ 0xDEAD, 0xBEEF, 0xCAFE };
+    rocprofsys::trace_cache::utility::store_value(original, buffer.data(), position);
+
+    const size_t expected_size =
+        sizeof(uint8_t) + sizeof(size_t) + original->size() * sizeof(uint32_t);
+    EXPECT_EQ(position, expected_size);
+
+    uint8_t*                             data_pos = buffer.data();
+    std::optional<std::vector<uint32_t>> parsed;
+    rocprofsys::trace_cache::utility::parse_value(data_pos, parsed);
+
+    ASSERT_TRUE(parsed.has_value());
+    EXPECT_EQ(*parsed, *original);
+    EXPECT_EQ(data_pos, buffer.data() + expected_size);
+}
+
+TEST_F(cacheable_test, roundtrip_optional_vector_empty_vector)
+{
+    std::optional<std::vector<uint8_t>> original = std::vector<uint8_t>{};
+    rocprofsys::trace_cache::utility::store_value(original, buffer.data(), position);
+
+    const size_t expected_size = sizeof(uint8_t) + sizeof(size_t);
+    EXPECT_EQ(position, expected_size);
+
+    uint8_t*                            data_pos = buffer.data();
+    std::optional<std::vector<uint8_t>> parsed;
+    rocprofsys::trace_cache::utility::parse_value(data_pos, parsed);
+
+    ASSERT_TRUE(parsed.has_value());
+    EXPECT_TRUE(parsed->empty());
+    EXPECT_EQ(data_pos, buffer.data() + expected_size);
+}
+
+TEST_F(cacheable_test, roundtrip_optional_string_view_with_value)
+{
+    std::optional<std::string_view> original = "hello optional"sv;
+    rocprofsys::trace_cache::utility::store_value(original, buffer.data(), position);
+
+    const size_t expected_size = sizeof(uint8_t) + sizeof(size_t) + original->size();
+    EXPECT_EQ(position, expected_size);
+
+    uint8_t*                        data_pos = buffer.data();
+    std::optional<std::string_view> parsed;
+    rocprofsys::trace_cache::utility::parse_value(data_pos, parsed);
+
+    ASSERT_TRUE(parsed.has_value());
+    EXPECT_EQ(*parsed, *original);
+    EXPECT_EQ(data_pos, buffer.data() + expected_size);
+}
+
+TEST_F(cacheable_test, roundtrip_optional_string_view_nullopt)
+{
+    std::optional<std::string_view> original = std::nullopt;
+    rocprofsys::trace_cache::utility::store_value(original, buffer.data(), position);
+
+    EXPECT_EQ(position, sizeof(uint8_t));
+
+    uint8_t*                        data_pos = buffer.data();
+    std::optional<std::string_view> parsed;
+    rocprofsys::trace_cache::utility::parse_value(data_pos, parsed);
+
+    EXPECT_FALSE(parsed.has_value());
+    EXPECT_EQ(data_pos, buffer.data() + sizeof(uint8_t));
+}
+
+TEST_F(cacheable_test, roundtrip_optional_string_view_empty_string)
+{
+    std::optional<std::string_view> original = ""sv;
+    rocprofsys::trace_cache::utility::store_value(original, buffer.data(), position);
+
+    const size_t expected_size = sizeof(uint8_t) + sizeof(size_t);
+    EXPECT_EQ(position, expected_size);
+
+    uint8_t*                        data_pos = buffer.data();
+    std::optional<std::string_view> parsed;
+    rocprofsys::trace_cache::utility::parse_value(data_pos, parsed);
+
+    ASSERT_TRUE(parsed.has_value());
+    EXPECT_EQ(*parsed, "");
+    EXPECT_EQ(data_pos, buffer.data() + expected_size);
+}
+
+TEST_F(cacheable_test, parse_multiple_values_with_optional_vector_and_string_view)
+{
+    int                                 int_val     = 42;
+    std::optional<std::vector<uint8_t>> opt_vec     = std::vector<uint8_t>{ 1, 2, 3 };
+    std::optional<std::string_view>     opt_str     = "nested"sv;
+    std::optional<std::vector<uint8_t>> opt_nullvec = std::nullopt;
+    std::optional<std::string_view>     opt_nullstr = std::nullopt;
+
+    rocprofsys::trace_cache::utility::store_value(int_val, buffer.data(), position);
+    rocprofsys::trace_cache::utility::store_value(opt_vec, buffer.data(), position);
+    rocprofsys::trace_cache::utility::store_value(opt_str, buffer.data(), position);
+    rocprofsys::trace_cache::utility::store_value(opt_nullvec, buffer.data(), position);
+    rocprofsys::trace_cache::utility::store_value(opt_nullstr, buffer.data(), position);
+
+    uint8_t*                            data_pos = buffer.data();
+    int                                 parsed_int;
+    std::optional<std::vector<uint8_t>> parsed_vec;
+    std::optional<std::string_view>     parsed_str;
+    std::optional<std::vector<uint8_t>> parsed_nullvec;
+    std::optional<std::string_view>     parsed_nullstr;
+
+    rocprofsys::trace_cache::utility::parse_value(
+        data_pos, parsed_int, parsed_vec, parsed_str, parsed_nullvec, parsed_nullstr);
+
+    EXPECT_EQ(parsed_int, 42);
+    ASSERT_TRUE(parsed_vec.has_value());
+    EXPECT_EQ(*parsed_vec, (std::vector<uint8_t>{ 1, 2, 3 }));
+    ASSERT_TRUE(parsed_str.has_value());
+    EXPECT_EQ(*parsed_str, "nested");
+    EXPECT_FALSE(parsed_nullvec.has_value());
+    EXPECT_FALSE(parsed_nullstr.has_value());
 }
 
 TEST_F(cacheable_test, parse_value_byte_array)
@@ -458,7 +609,7 @@ TEST_F(cacheable_test, get_size_helper_optional_empty)
 {
     std::optional<int> value = std::nullopt;
     size_t             size  = rocprofsys::trace_cache::utility::get_size(value);
-    EXPECT_EQ(size, sizeof(uint8_t) + sizeof(int));
+    EXPECT_EQ(size, sizeof(uint8_t));
 }
 
 TEST_F(cacheable_test, get_size_helper_byte_array)
@@ -466,6 +617,34 @@ TEST_F(cacheable_test, get_size_helper_byte_array)
     std::vector<uint8_t> value = { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 };
     size_t               size  = rocprofsys::trace_cache::utility::get_size(value);
     EXPECT_EQ(size, value.size() + sizeof(size_t));
+}
+
+TEST_F(cacheable_test, get_size_optional_vector)
+{
+    std::optional<std::vector<uint8_t>> val = std::vector<uint8_t>{ 1, 2, 3 };
+    size_t size = rocprofsys::trace_cache::utility::get_size(val);
+    EXPECT_EQ(size, sizeof(uint8_t) + sizeof(size_t) + 3 * sizeof(uint8_t));
+}
+
+TEST_F(cacheable_test, get_size_optional_vector_nullopt)
+{
+    std::optional<std::vector<uint8_t>> val = std::nullopt;
+    size_t size = rocprofsys::trace_cache::utility::get_size(val);
+    EXPECT_EQ(size, sizeof(uint8_t));
+}
+
+TEST_F(cacheable_test, get_size_optional_string_view)
+{
+    std::optional<std::string_view> val = "test"sv;
+    size_t size                         = rocprofsys::trace_cache::utility::get_size(val);
+    EXPECT_EQ(size, sizeof(uint8_t) + sizeof(size_t) + 4);
+}
+
+TEST_F(cacheable_test, get_size_optional_string_view_nullopt)
+{
+    std::optional<std::string_view> val = std::nullopt;
+    size_t size                         = rocprofsys::trace_cache::utility::get_size(val);
+    EXPECT_EQ(size, sizeof(uint8_t));
 }
 
 TEST_F(cacheable_test, store_value_span_uint8)

--- a/projects/rocprofiler-systems/source/lib/core/trace_cache/tests/test_cacheable.cpp
+++ b/projects/rocprofiler-systems/source/lib/core/trace_cache/tests/test_cacheable.cpp
@@ -647,6 +647,46 @@ TEST_F(cacheable_test, get_size_optional_string_view_nullopt)
     EXPECT_EQ(size, sizeof(uint8_t));
 }
 
+// Tests for size consistency of optional types. The value returned by get_size()
+//  must match the actual bytes written by store_value().
+TEST_F(cacheable_test, size_consistency_optional_with_value)
+{
+    std::optional<uint64_t> value = 0xDEADBEEF;
+    // Calculate size
+    size_t calculated_size = rocprofsys::trace_cache::utility::get_size(value);
+    // Store and track actual bytes written
+    size_t position = 0;
+    rocprofsys::trace_cache::utility::store_value(value, buffer.data(), position);
+    // These MUST match exactly
+    EXPECT_EQ(position, calculated_size)
+        << "get_size() and store_value() wrote different amounts";
+}
+TEST_F(cacheable_test, size_consistency_optional_nullopt)
+{
+    std::optional<uint64_t> value = std::nullopt;
+    size_t calculated_size        = rocprofsys::trace_cache::utility::get_size(value);
+    size_t position               = 0;
+    rocprofsys::trace_cache::utility::store_value(value, buffer.data(), position);
+    EXPECT_EQ(position, calculated_size)
+        << "get_size() and store_value() wrote different amounts for nullopt";
+}
+TEST_F(cacheable_test, size_consistency_optional_vector_with_value)
+{
+    std::optional<std::vector<uint32_t>> value = std::vector<uint32_t>{ 1, 2, 3, 4, 5 };
+    size_t calculated_size = rocprofsys::trace_cache::utility::get_size(value);
+    size_t position        = 0;
+    rocprofsys::trace_cache::utility::store_value(value, buffer.data(), position);
+    EXPECT_EQ(position, calculated_size);
+}
+TEST_F(cacheable_test, size_consistency_optional_vector_nullopt)
+{
+    std::optional<std::vector<uint32_t>> value = std::nullopt;
+    size_t calculated_size = rocprofsys::trace_cache::utility::get_size(value);
+    size_t position        = 0;
+    rocprofsys::trace_cache::utility::store_value(value, buffer.data(), position);
+    EXPECT_EQ(position, calculated_size);
+}
+
 TEST_F(cacheable_test, store_value_span_uint8)
 {
     std::vector<uint8_t>      data = { 1, 2, 3, 4, 5 };

--- a/projects/rocprofiler-systems/source/lib/core/trace_cache/tests/test_sample_type.cpp
+++ b/projects/rocprofiler-systems/source/lib/core/trace_cache/tests/test_sample_type.cpp
@@ -293,6 +293,46 @@ TEST_F(sample_type_test, pmc_event_with_sample_get_size)
     EXPECT_EQ(get_size(sample), expected_size);
 }
 
+TEST_F(sample_type_test, pmc_event_with_sample_serialize_deserialize_nullopt)
+{
+    pmc_event_with_sample original(42, "CPU:0", 60000, "counter_sample", 200, 199, 1600,
+                                   "entry\nexit", "counter.cpp:100", 5, 1,
+                                   "PERF_COUNT_HW_CPU_CYCLES", 12345.67, std::nullopt);
+
+    serialize(buffer.data(), original);
+
+    uint8_t* buffer_ptr   = buffer.data();
+    auto     deserialized = deserialize<pmc_event_with_sample>(buffer_ptr);
+
+    EXPECT_EQ(deserialized.category_enum_id, original.category_enum_id);
+    EXPECT_EQ(deserialized.track_name, original.track_name);
+    EXPECT_EQ(deserialized.timestamp_ns, original.timestamp_ns);
+    EXPECT_EQ(deserialized.event_metadata, original.event_metadata);
+    EXPECT_EQ(deserialized.stack_id, original.stack_id);
+    EXPECT_EQ(deserialized.parent_stack_id, original.parent_stack_id);
+    EXPECT_EQ(deserialized.correlation_id, original.correlation_id);
+    EXPECT_EQ(deserialized.call_stack, original.call_stack);
+    EXPECT_EQ(deserialized.line_info, original.line_info);
+    EXPECT_EQ(deserialized.device_id, original.device_id);
+    EXPECT_EQ(deserialized.device_type, original.device_type);
+    EXPECT_EQ(deserialized.pmc_info_name, original.pmc_info_name);
+    EXPECT_DOUBLE_EQ(deserialized.value, original.value);
+    EXPECT_FALSE(deserialized.system_tid.has_value());
+}
+
+TEST_F(sample_type_test, pmc_event_with_sample_get_size_nullopt)
+{
+    pmc_event_with_sample sample(42, "CPU:0", 60000, "counter_sample", 200, 199, 1600,
+                                 "entry\nexit", "counter.cpp:100", 5, 1,
+                                 "PERF_COUNT_HW_CPU_CYCLES", 12345.67, std::nullopt);
+
+    size_t expected_size = sizeof(size_t) * 6 + 5 + 14 + 10 + 15 + 24 +
+                           sizeof(uint64_t) * 4 + sizeof(uint32_t) + sizeof(uint8_t) +
+                           sizeof(double) + sizeof(uint8_t);
+
+    EXPECT_EQ(get_size(sample), expected_size);
+}
+
 TEST_F(sample_type_test, pmc_event_with_sample_type_identifier)
 {
     EXPECT_EQ(pmc_event_with_sample::type_identifier,

--- a/projects/rocprofiler-systems/source/lib/core/trace_cache/tests/test_sample_type.cpp
+++ b/projects/rocprofiler-systems/source/lib/core/trace_cache/tests/test_sample_type.cpp
@@ -255,7 +255,8 @@ TEST_F(sample_type_test, pmc_event_with_sample_serialize_deserialize)
 {
     pmc_event_with_sample original(42, "CPU:0", 60000, "counter_sample", 200, 199, 1600,
                                    "entry\nexit", "counter.cpp:100", 5, 1,
-                                   "PERF_COUNT_HW_CPU_CYCLES", 12345.67);
+                                   "PERF_COUNT_HW_CPU_CYCLES", 12345.67,
+                                   std::make_optional<size_t>(135));
 
     serialize(buffer.data(), original);
 
@@ -275,17 +276,19 @@ TEST_F(sample_type_test, pmc_event_with_sample_serialize_deserialize)
     EXPECT_EQ(deserialized.device_type, original.device_type);
     EXPECT_EQ(deserialized.pmc_info_name, original.pmc_info_name);
     EXPECT_DOUBLE_EQ(deserialized.value, original.value);
+    EXPECT_EQ(deserialized.system_tid, original.system_tid);
 }
 
 TEST_F(sample_type_test, pmc_event_with_sample_get_size)
 {
     pmc_event_with_sample sample(42, "CPU:0", 60000, "counter_sample", 200, 199, 1600,
                                  "entry\nexit", "counter.cpp:100", 5, 1,
-                                 "PERF_COUNT_HW_CPU_CYCLES", 12345.67);
+                                 "PERF_COUNT_HW_CPU_CYCLES", 12345.67,
+                                 std::make_optional<size_t>(135));
 
     size_t expected_size = sizeof(size_t) * 6 + 5 + 14 + 10 + 15 + 24 +
                            sizeof(uint64_t) * 4 + sizeof(uint32_t) + sizeof(uint8_t) +
-                           sizeof(double);
+                           sizeof(double) + sizeof(size_t) + sizeof(uint8_t);
 
     EXPECT_EQ(get_size(sample), expected_size);
 }

--- a/projects/rocprofiler-systems/source/lib/core/trace_cache/tests/test_sample_type.cpp
+++ b/projects/rocprofiler-systems/source/lib/core/trace_cache/tests/test_sample_type.cpp
@@ -286,9 +286,19 @@ TEST_F(sample_type_test, pmc_event_with_sample_get_size)
                                  "PERF_COUNT_HW_CPU_CYCLES", 12345.67,
                                  std::make_optional<size_t>(135));
 
-    size_t expected_size = sizeof(size_t) * 6 + 5 + 14 + 10 + 15 + 24 +
-                           sizeof(uint64_t) * 4 + sizeof(uint32_t) + sizeof(uint8_t) +
-                           sizeof(double) + sizeof(size_t) + sizeof(uint8_t);
+    size_t expected_size =
+        sizeof(size_t) +                      // category_enum_id
+        sizeof(size_t) + 5 +                  // track_name "CPU:0"
+        sizeof(uint64_t) +                    // timestamp_ns
+        sizeof(size_t) + 14 +                 // event_metadata "counter_sample"
+        (sizeof(uint64_t) * 3) +              // stack_id, parent_stack_id, correlation_id
+        sizeof(size_t) + 10 +                 // call_stack "entry\nexit"
+        sizeof(size_t) + 15 +                 // line_info "counter.cpp:100"
+        sizeof(uint32_t) +                    // device_id
+        sizeof(uint8_t) +                     // device_type
+        sizeof(size_t) + 24 +                 // pmc_info_name "PERF_COUNT_HW_CPU_CYCLES"
+        sizeof(double) +                      // value
+        (sizeof(uint8_t) + sizeof(int64_t));  // system_tid (has-value flag + value)
 
     EXPECT_EQ(get_size(sample), expected_size);
 }
@@ -320,15 +330,87 @@ TEST_F(sample_type_test, pmc_event_with_sample_serialize_deserialize_nullopt)
     EXPECT_FALSE(deserialized.system_tid.has_value());
 }
 
+// Tests for size consistency of pmc_event_with_sample with system_tid.
+// The value returned by get_size() must match the actual bytes written by serialize().
+TEST_F(sample_type_test, size_consistency_with_system_tid)
+{
+    pmc_event_with_sample sample_with_tid{
+        1,          "track",
+        1000,       "metadata",
+        2,          3,
+        4,          "callstack",
+        "lineinfo", 0,
+        0,          "counter",
+        42.0,       std::optional<size_t>{ 12345 }  // has system_tid
+    };
+    size_t               calculated_size = get_size(sample_with_tid);
+    std::vector<uint8_t> buf(calculated_size);
+    serialize(buf.data(), sample_with_tid);
+    // Deserialize and verify
+    uint8_t* buffer_ptr   = buf.data();
+    auto     deserialized = deserialize<pmc_event_with_sample>(buffer_ptr);
+    ASSERT_TRUE(deserialized.system_tid.has_value());
+    EXPECT_EQ(deserialized.system_tid.value(), 12345);
+    // Verify we consumed exactly calculated_size bytes
+    EXPECT_EQ(buffer_ptr - buf.data(), static_cast<std::ptrdiff_t>(calculated_size));
+}
+// Tests for size consistency of pmc_event_with_sample without system_tid.
+// The value returned by get_size() must match the actual bytes written by serialize().
+TEST_F(sample_type_test, size_consistency_without_system_tid)
+{
+    pmc_event_with_sample sample_no_tid{
+        1,           "track",    1000, "metadata", 2,         3,    4,
+        "callstack", "lineinfo", 0,    0,          "counter", 42.0,
+        std::nullopt  // no system_tid
+    };
+    size_t               calculated_size = get_size(sample_no_tid);
+    std::vector<uint8_t> buf(calculated_size);
+    serialize(buf.data(), sample_no_tid);
+    uint8_t* buffer_ptr   = buf.data();
+    auto     deserialized = deserialize<pmc_event_with_sample>(buffer_ptr);
+    EXPECT_FALSE(deserialized.system_tid.has_value());
+    EXPECT_EQ(buffer_ptr - buf.data(), static_cast<std::ptrdiff_t>(calculated_size));
+}
+// Tests for the difference in size between pmc_event_with_sample with and without
+// system_tid. The value returned by get_size() must be different for the two cases.
+TEST_F(sample_type_test, different_sizes_based_on_optional_state)
+{
+    pmc_event_with_sample with_tid{ 1,          "track",
+                                    1000,       "metadata",
+                                    2,          3,
+                                    4,          "callstack",
+                                    "lineinfo", 0,
+                                    0,          "counter",
+                                    42.0,       std::optional<size_t>{ 12345 } };
+    pmc_event_with_sample without_tid{ 1, "track",   1000,        "metadata",  2,
+                                       3, 4,         "callstack", "lineinfo",  0,
+                                       0, "counter", 42.0,        std::nullopt };
+    size_t                size_with    = get_size(with_tid);
+    size_t                size_without = get_size(without_tid);
+    // Variable-size: with_tid should be larger by sizeof(size_t)
+    EXPECT_EQ(size_with, size_without + sizeof(size_t))
+        << "Variable-size encoding should differ by inner type size";
+}
+
 TEST_F(sample_type_test, pmc_event_with_sample_get_size_nullopt)
 {
     pmc_event_with_sample sample(42, "CPU:0", 60000, "counter_sample", 200, 199, 1600,
                                  "entry\nexit", "counter.cpp:100", 5, 1,
                                  "PERF_COUNT_HW_CPU_CYCLES", 12345.67, std::nullopt);
 
-    size_t expected_size = sizeof(size_t) * 6 + 5 + 14 + 10 + 15 + 24 +
-                           sizeof(uint64_t) * 4 + sizeof(uint32_t) + sizeof(uint8_t) +
-                           sizeof(double) + sizeof(uint8_t);
+    size_t expected_size =
+        sizeof(size_t) +          // category_enum_id
+        sizeof(size_t) + 5 +      // track_name "CPU:0"
+        sizeof(uint64_t) +        // timestamp_ns
+        sizeof(size_t) + 14 +     // event_metadata "counter_sample"
+        (sizeof(uint64_t) * 3) +  // stack_id, parent_stack_id, correlation_id
+        sizeof(size_t) + 10 +     // call_stack "entry\nexit"
+        sizeof(size_t) + 15 +     // line_info "counter.cpp:100"
+        sizeof(uint32_t) +        // device_id
+        sizeof(uint8_t) +         // device_type
+        sizeof(size_t) + 24 +     // pmc_info_name "PERF_COUNT_HW_CPU_CYCLES"
+        sizeof(double) +          // value
+        sizeof(uint8_t);          // system_tid (has-value flag only, nullopt)
 
     EXPECT_EQ(get_size(sample), expected_size);
 }

--- a/projects/rocprofiler-systems/source/lib/core/trace_cache/tests/test_sample_type.cpp
+++ b/projects/rocprofiler-systems/source/lib/core/trace_cache/tests/test_sample_type.cpp
@@ -256,7 +256,7 @@ TEST_F(sample_type_test, pmc_event_with_sample_serialize_deserialize)
     pmc_event_with_sample original(42, "CPU:0", 60000, "counter_sample", 200, 199, 1600,
                                    "entry\nexit", "counter.cpp:100", 5, 1,
                                    "PERF_COUNT_HW_CPU_CYCLES", 12345.67,
-                                   std::make_optional<size_t>(135));
+                                   std::make_optional<int64_t>(135));
 
     serialize(buffer.data(), original);
 
@@ -284,7 +284,7 @@ TEST_F(sample_type_test, pmc_event_with_sample_get_size)
     pmc_event_with_sample sample(42, "CPU:0", 60000, "counter_sample", 200, 199, 1600,
                                  "entry\nexit", "counter.cpp:100", 5, 1,
                                  "PERF_COUNT_HW_CPU_CYCLES", 12345.67,
-                                 std::make_optional<size_t>(135));
+                                 std::make_optional<int64_t>(135));
 
     size_t expected_size =
         sizeof(size_t) +                      // category_enum_id
@@ -341,7 +341,7 @@ TEST_F(sample_type_test, size_consistency_with_system_tid)
         4,          "callstack",
         "lineinfo", 0,
         0,          "counter",
-        42.0,       std::optional<size_t>{ 12345 }  // has system_tid
+        42.0,       std::optional<int64_t>{ 12345 }  // has system_tid
     };
     size_t               calculated_size = get_size(sample_with_tid);
     std::vector<uint8_t> buf(calculated_size);
@@ -381,14 +381,14 @@ TEST_F(sample_type_test, different_sizes_based_on_optional_state)
                                     4,          "callstack",
                                     "lineinfo", 0,
                                     0,          "counter",
-                                    42.0,       std::optional<size_t>{ 12345 } };
+                                    42.0,       std::optional<int64_t>{ 12345 } };
     pmc_event_with_sample without_tid{ 1, "track",   1000,        "metadata",  2,
                                        3, 4,         "callstack", "lineinfo",  0,
                                        0, "counter", 42.0,        std::nullopt };
     size_t                size_with    = get_size(with_tid);
     size_t                size_without = get_size(without_tid);
-    // Variable-size: with_tid should be larger by sizeof(size_t)
-    EXPECT_EQ(size_with, size_without + sizeof(size_t))
+    // Variable-size: with_tid should be larger by sizeof(int64_t)
+    EXPECT_EQ(size_with, size_without + sizeof(int64_t))
         << "Variable-size encoding should differ by inner type size";
 }
 

--- a/projects/rocprofiler-systems/source/lib/core/trace_cache/tests/test_storage_parser.cpp
+++ b/projects/rocprofiler-systems/source/lib/core/trace_cache/tests/test_storage_parser.cpp
@@ -60,6 +60,12 @@ public:
         m_expected_samples_4 = samples;
     }
 
+    void set_expected_samples_5(const std::vector<test_sample_5>& samples)
+    {
+        std::lock_guard<std::mutex> lock(m_data_mutex);
+        m_expected_samples_5 = samples;
+    }
+
     void execute_sample_processing(test_type_identifier_t type_identifier,
                                    const rocprofsys::trace_cache::cacheable_t& value)
     {
@@ -97,6 +103,14 @@ public:
                 check_sample_4(idx, sample);
                 break;
             }
+            case test_type_identifier_t::sample_type_5:
+            {
+                const auto& sample = static_cast<const test_sample_5&>(value);
+                std::lock_guard<std::mutex> lock(m_data_mutex);
+                size_t                      idx = m_sample_5_count++;
+                check_sample_5(idx, sample);
+                break;
+            }
             default: m_unknown_count++; break;
         }
     }
@@ -105,6 +119,7 @@ public:
     int get_sample_2_count() const { return m_sample_2_count.load(); }
     int get_sample_3_count() const { return m_sample_3_count.load(); }
     int get_sample_4_count() const { return m_sample_4_count.load(); }
+    int get_sample_5_count() const { return m_sample_5_count.load(); }
     int get_unknown_count() const { return m_unknown_count.load(); }
 
 private:
@@ -140,15 +155,25 @@ private:
         }
     }
 
+    void check_sample_5(size_t index, const test_sample_5& sample)
+    {
+        if(index < m_expected_samples_5.size())
+        {
+            EXPECT_EQ(m_expected_samples_5[index], sample);
+        }
+    }
+
     std::atomic<int>           m_sample_1_count{ 0 };
     std::atomic<int>           m_sample_2_count{ 0 };
     std::atomic<int>           m_sample_3_count{ 0 };
     std::atomic<int>           m_sample_4_count{ 0 };
+    std::atomic<int>           m_sample_5_count{ 0 };
     std::atomic<int>           m_unknown_count{ 0 };
     std::vector<test_sample_1> m_expected_samples_1;
     std::vector<test_sample_2> m_expected_samples_2;
     std::vector<test_sample_3> m_expected_samples_3;
     std::vector<test_sample_4> m_expected_samples_4;
+    std::vector<test_sample_5> m_expected_samples_5;
     std::mutex                 m_data_mutex;
 };
 
@@ -486,6 +511,34 @@ TEST_F(storage_parser_test, read_fragmented_space)
     EXPECT_EQ(processor->get_sample_1_count(), 1);
     EXPECT_EQ(processor->get_sample_2_count(), 2);
     EXPECT_EQ(processor->get_sample_3_count(), 1);
+
+    EXPECT_EQ(std::remove(test_file_path.c_str()), 0);
+}
+
+TEST_F(storage_parser_test, load_sample_type_5_optional)
+{
+    std::vector<test_sample_5> samples_5 = {
+        test_sample_5(std::optional<uint32_t>{ 123 }), test_sample_5(std::nullopt)
+    };
+
+    {
+        std::ofstream ofs(test_file_path, std::ios::binary);
+        ASSERT_TRUE(ofs.is_open());
+        write_vector(ofs, samples_5, test_type_identifier_t::sample_type_5);
+        ofs.close();
+    }
+
+    auto processor = std::make_shared<sample_processor_t>();
+    processor->set_expected_samples_5(samples_5);
+
+    rocprofsys::trace_cache::storage_parser<test_type_identifier_t, test_sample_1,
+                                            test_sample_2, test_sample_3, test_sample_4,
+                                            test_sample_5>
+        parser(test_file_path);
+
+    EXPECT_NO_THROW(parser.load(processor));
+
+    EXPECT_EQ(processor->get_sample_5_count(), 2);
 
     EXPECT_EQ(std::remove(test_file_path.c_str()), 0);
 }

--- a/projects/rocprofiler-systems/source/lib/core/trace_cache/tests/test_type_registry.cpp
+++ b/projects/rocprofiler-systems/source/lib/core/trace_cache/tests/test_type_registry.cpp
@@ -124,3 +124,49 @@ TEST_F(type_registry_test, test_multiple_calls_same_type)
     EXPECT_EQ(sample_1_2.value, 200);
     EXPECT_EQ(sample_1_2.text, "second");
 }
+
+class type_registry_optional_test : public ::testing::Test
+{
+protected:
+    rocprofsys::trace_cache::type_registry<test_type_identifier_t, test_sample_1,
+                                           test_sample_2, test_sample_5>
+        type_registry;
+};
+
+TEST_F(type_registry_optional_test, test_get_type_sample_5_with_value)
+{
+    test_sample_5        test_value{ std::optional<uint32_t>{ 42 } };
+    size_t               buffer_size = rocprofsys::trace_cache::get_size(test_value);
+    std::vector<uint8_t> buffer(buffer_size);
+    rocprofsys::trace_cache::serialize(buffer.data(), test_value);
+
+    auto* buffer_data = buffer.data();
+    auto  result =
+        type_registry.get_type(test_type_identifier_t::sample_type_5, buffer_data);
+
+    ASSERT_TRUE(result.has_value());
+    ASSERT_TRUE(std::holds_alternative<test_sample_5>(result.value()));
+
+    auto sample_5 = std::get<test_sample_5>(result.value());
+    ASSERT_TRUE(sample_5.data.has_value());
+    EXPECT_EQ(sample_5.data.value(), 42);
+}
+
+TEST_F(type_registry_optional_test, test_get_type_sample_5_nullopt)
+{
+    test_sample_5        test_value{ std::nullopt };
+    size_t               buffer_size = rocprofsys::trace_cache::get_size(test_value);
+    std::vector<uint8_t> buffer(buffer_size);
+    rocprofsys::trace_cache::serialize(buffer.data(), test_value);
+
+    auto* buffer_data = buffer.data();
+    auto  result =
+        type_registry.get_type(test_type_identifier_t::sample_type_5, buffer_data);
+
+    ASSERT_TRUE(result.has_value());
+    ASSERT_TRUE(std::holds_alternative<test_sample_5>(result.value()));
+
+    auto sample_5 = std::get<test_sample_5>(result.value());
+    EXPECT_FALSE(sample_5.data.has_value());
+    EXPECT_EQ(sample_5.data, std::nullopt);
+}

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library/components/backtrace_metrics.cpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library/components/backtrace_metrics.cpp
@@ -265,15 +265,11 @@ cache_backtrace_metrics_events(const uint32_t device_id, uint64_t timestamp_ns,
     const auto* call_stack      = "";
     const auto* line_info       = "";
 
-    std::optional<size_t> _system_tid;
+    std::optional<size_t> _system_tid{ std::nullopt };
     const auto&           _thread_info = thread_info::get(_tid, SequentTID);
     if(_thread_info.has_value())
     {
         _system_tid = _thread_info->index_data->system_value;
-    }
-    else
-    {
-        _system_tid = std::nullopt;
     }
 
     auto insert_event_and_sample = [&](const char* _track_name, double _value) {

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library/components/backtrace_metrics.cpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library/components/backtrace_metrics.cpp
@@ -265,12 +265,23 @@ cache_backtrace_metrics_events(const uint32_t device_id, uint64_t timestamp_ns,
     const auto* call_stack      = "";
     const auto* line_info       = "";
 
+    std::optional<size_t> _system_tid;
+    const auto&           _thread_info = thread_info::get(_tid, SequentTID);
+    if(_thread_info.has_value())
+    {
+        _system_tid = _thread_info->index_data->system_value;
+    }
+    else
+    {
+        _system_tid = std::nullopt;
+    }
+
     auto insert_event_and_sample = [&](const char* _track_name, double _value) {
         trace_cache::get_buffer_storage().store(trace_cache::pmc_event_with_sample{
             static_cast<size_t>(category_enum_id<Category>::value), _track_name,
             timestamp_ns, event_metadata, stack_id, parent_stack_id, correlation_id,
             call_stack, line_info, device_id, static_cast<uint8_t>(agent_type::CPU),
-            _track_name, _value });
+            _track_name, _value, _system_tid });
     };
 
     if constexpr(std::is_same_v<Category, category::thread_hardware_counter>)

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library/components/backtrace_metrics.cpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library/components/backtrace_metrics.cpp
@@ -265,8 +265,8 @@ cache_backtrace_metrics_events(const uint32_t device_id, uint64_t timestamp_ns,
     const auto* call_stack      = "";
     const auto* line_info       = "";
 
-    std::optional<size_t> _system_tid{ std::nullopt };
-    const auto&           _thread_info = thread_info::get(_tid, SequentTID);
+    std::optional<int64_t> _system_tid{ std::nullopt };
+    const auto&            _thread_info = thread_info::get(_tid, SequentTID);
     if(_thread_info.has_value())
     {
         _system_tid = _thread_info->index_data->system_value;

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library/components/comm_data.cpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library/components/comm_data.cpp
@@ -166,7 +166,7 @@ cache_comm_data_events(const uint32_t device_id, int bytes)
         track_name.c_str(), timestamp_ns, event_metadata.c_str(), stack_id,
         parent_stack_id, correlation_id, call_stack.c_str(), line_info.c_str(), device_id,
         static_cast<uint8_t>(agent_type::CPU), track_name.c_str(),
-        static_cast<double>(value) });
+        static_cast<double>(value), std::nullopt });
 }
 
 }  // namespace

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library/rocprofiler-sdk/counters.cpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library/rocprofiler-sdk/counters.cpp
@@ -113,7 +113,7 @@ counter_event::operator()(const client_data* tool_data, ::perfetto::CounterTrack
             parent_stack_id, correlation_id, call_stack.c_str(), line_info.c_str(),
             static_cast<uint32_t>(agent.device_type_index),
             static_cast<uint8_t>(agent.type), track_name.c_str(),
-            static_cast<double>(value) });
+            static_cast<double>(value), std::nullopt });
     }
 }
 

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library/rocprofiler-sdk/rccl.cpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library/rocprofiler-sdk/rccl.cpp
@@ -217,7 +217,7 @@ cache_rccl_comm_data_events(uint32_t rccl_device_idx, size_t bytes, uint64_t tim
         static_cast<size_t>(category_enum_id<category::comm_data>::value), Track::label,
         timestamp_ns, event_metadata.c_str(), stack_id, parent_stack_id, correlation_id,
         call_stack, line_info, rccl_device_idx, static_cast<uint8_t>(agent_type::GPU),
-        pmc_label.c_str(), static_cast<double>(cumulative) });
+        pmc_label.c_str(), static_cast<double>(cumulative), std::nullopt });
 }
 
 rccl_gpu_tracking_state&


### PR DESCRIPTION
## Motivation

The trace_cache binary serialization framework only supported primitive types, strings, spans, and vectors. Adding `std::optional<T>` support enables nullable fields in cached sample types, which is needed for the `pmc_event_with_sample` struct to carry an optional `system_tid` (system thread ID) that is only available when thread info can be resolved.

# Technical details

- Added `is_optional` / `is_optional_v` type trait to `cache_type_traits.hpp` and included `std::optional` in the `is_supported_type_v` check.
- Extended `cacheable.hpp` with `get_size`, `store_value`, and `parse_value` overloads for `std::optional<T>`. The wire format is a `uint8_t` has-value flag followed by the inner value when present (zero bytes when nullopt). Nested `std::optional` is rejected at compile time via `static_assert`.
- Added `system_tid` (`std::optional<int64_t>`) field to `pmc_event_with_sample` and updated its serialize/deserialize/get_size specializations.
- Updated all `pmc_event_with_sample` construction sites (`backtrace_metrics.cpp`, `comm_data.cpp`, `counters.cpp`, `rccl.cpp`) to pass the new field. `backtrace_metrics` resolves the system TID from `thread_info`; other call sites pass `std::nullopt`.


# Test plan

- Unit tests for `is_optional_v` type trait (positive and negative cases).
- Unit tests for `get_size`, `store_value`, and `parse_value` with various optional types (`uint32_t`, `uint64_t`, `double`, `float`, `int64_t`) including both valued and nullopt states.
- Mixed multi-field roundtrip test combining optional with other supported types.
- `test_sample_5` mock type with `std::optional<uint32_t>` field exercised through buffer_storage, storage_parser, type_registry, and full integration tests.
- Updated existing `pmc_event_with_sample` serialization/deserialization and size tests.

# Test result

- All new and existing trace_cache unit tests should pass.
- `pmc_event_with_sample` roundtrip preserves `system_tid` when set and correctly yields `std::nullopt` when absent.
- Binary buffer sizes match expected calculations (`sizeof(uint8_t) + sizeof(T)` per optional when valued, `sizeof(uint8_t)` when nullopt).

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
