### PR TITLE
[rocprofiler-systems] Decode OMPT "flags" argument into human-readable form

### DIFF
--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library/rocprofiler-sdk.cpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library/rocprofiler-sdk.cpp
@@ -30,6 +30,7 @@
 #include <timemory/hash/types.hpp>
 #include <timemory/unwind/processed_entry.hpp>
 #include <timemory/variadic/lightweight_tuple.hpp>
+#include <type_traits>
 
 #include <rocprofiler-sdk/agent.h>
 #include <rocprofiler-sdk/callback_tracing.h>
@@ -953,6 +954,154 @@ get_kernel_dispatch_timestamps()
 
 #if(ROCPROFILER_VERSION >= 600)
 
+/**
+ * @brief rocprofiler_iterate_callback_tracing_kind_operation_args wrapper for OMPT
+ * callbacks.
+ *
+ * Certain OMPT callbacks have a "flags" argument that contains a bitmask of flags.
+ * This function decodes the "flags" into a human readable form.
+ * Works with both callback_arg_array_t (perfetto) and function_args_t (rocpd).
+ */
+template <typename ArgsT>
+void
+ompt_iterate_operation_args(const rocprofiler_callback_tracing_record_t& record,
+                            ArgsT&                                       args)
+{
+    static_assert(std::is_same_v<ArgsT, callback_arg_array_t> ||
+                      std::is_same_v<ArgsT, function_args_t>,
+                  "ompt_iterate_operation_args: ArgsT must be callback_arg_array_t or "
+                  "function_args_t");
+
+    auto ompt_operation_type =
+        static_cast<rocprofiler_ompt_operation_t>(record.operation);
+    auto max_deref = (record.phase == ROCPROFILER_CALLBACK_PHASE_ENTER) ? 1 : 2;
+
+    // Perform standard iteration of arguments
+    if constexpr(std::is_same_v<ArgsT, callback_arg_array_t>)
+        rocprofiler_iterate_callback_tracing_kind_operation_args(record, save_args,
+                                                                 max_deref, &args);
+    else
+        rocprofiler_iterate_callback_tracing_kind_operation_args(
+            record, iterate_args_callback, max_deref, &args);
+
+    static const auto ompt_has_flags = std::set<rocprofiler_ompt_operation_t>{
+        ROCPROFILER_OMPT_ID_parallel_begin, ROCPROFILER_OMPT_ID_parallel_end,
+        ROCPROFILER_OMPT_ID_task_create,    ROCPROFILER_OMPT_ID_implicit_task,
+        ROCPROFILER_OMPT_ID_cancel,
+    };
+    if(ompt_has_flags.find(ompt_operation_type) == ompt_has_flags.end()) return;
+
+    // Extract flags value from arguments
+    int flags_val = 0;
+    for(const auto& entry : args)
+    {
+        if constexpr(std::is_same_v<ArgsT, callback_arg_array_t>)
+        {
+            if(entry.first == "flags")
+            {
+                flags_val = std::stoi(entry.second);
+                break;
+            }
+        }
+        else
+        {
+            if(entry.arg_name == "flags")
+            {
+                flags_val = std::stoi(entry.arg_value);
+                break;
+            }
+        }
+    }
+    if(flags_val == 0) return;
+
+    auto append = [&args](const std::string& flag_type, const std::string& key,
+                          const std::string& val) {
+        if constexpr(std::is_same_v<ArgsT, callback_arg_array_t>)
+            args.emplace_back(key, val);
+        else
+            args.emplace_back(
+                argument_info{ static_cast<uint32_t>(args.size()), flag_type, key, val });
+    };
+
+    // Textual representation of flags follows from OMPT 5.0 specification
+    switch(ompt_operation_type)
+    {
+        case ROCPROFILER_OMPT_ID_parallel_begin:  // ompt_parallel_flag_t
+        case ROCPROFILER_OMPT_ID_parallel_end:    // ompt_parallel_flag_t
+        {
+            const auto ft = std::string{ "ompt_parallel_flag_t" };
+            if(flags_val & ompt_parallel_invoker_program)
+                append(ft, "invoker", "program");
+            else if(flags_val & ompt_parallel_invoker_runtime)
+                append(ft, "invoker", "runtime");
+
+            if(flags_val & ompt_parallel_league)
+                append(ft, "invoker_cause", "teams_construct");
+            else if(flags_val & ompt_parallel_team)
+                append(ft, "invoker_cause", "parallel_construct");
+            break;
+        }
+        case ROCPROFILER_OMPT_ID_task_create:  // ompt_task_flag_t
+        {
+            const auto ft = std::string{ "ompt_task_flag_t" };
+            if(flags_val & ompt_task_initial)
+                append(ft, "classification", "initial");
+            else if(flags_val & ompt_task_implicit)
+                append(ft, "classification", "implicit");
+            else if(flags_val & ompt_task_explicit)
+                append(ft, "classification", "explicit");
+            else if(flags_val & ompt_task_target)
+                append(ft, "classification", "target");
+
+            // Multiple/none can be set
+            std::string task_properties;
+            if(flags_val & ompt_task_undeferred) task_properties += "undeferred, ";
+            if(flags_val & ompt_task_untied) task_properties += "untied, ";
+            if(flags_val & ompt_task_final) task_properties += "final, ";
+            if(flags_val & ompt_task_mergeable) task_properties += "mergeable, ";
+            if(flags_val & ompt_task_merged) task_properties += "merged, ";
+
+            if(!task_properties.empty())
+                task_properties.erase(task_properties.size() - 2);
+            else
+                task_properties = "none";
+            append(ft, "properties", task_properties);
+            break;
+        }
+        case ROCPROFILER_OMPT_ID_implicit_task:  // initial (1) or implicit (2)
+        {
+            const auto ft = std::string{ "flags" };
+            // As of now, implicit_tasks with ompt_task_initial are filtered out
+            if(flags_val & ompt_task_initial)
+                append(ft, "kind", "initial");
+            else if(flags_val & ompt_task_implicit)
+                append(ft, "kind", "implicit");
+            break;
+        }
+        case ROCPROFILER_OMPT_ID_cancel:  // ompt_cancel_flag_t
+        {
+            const auto ft = std::string{ "ompt_cancel_flag_t" };
+            if(flags_val & ompt_cancel_parallel)
+                append(ft, "construct", "parallel");
+            else if(flags_val & ompt_cancel_sections)
+                append(ft, "construct", "sections");
+            else if(flags_val & ompt_cancel_loop)
+                append(ft, "construct", "loop");
+            else if(flags_val & ompt_cancel_taskgroup)
+                append(ft, "construct", "taskgroup");
+
+            if(flags_val & ompt_cancel_activated)
+                append(ft, "state", "activated");
+            else if(flags_val & ompt_cancel_detected)
+                append(ft, "state", "detected");
+            else if(flags_val & ompt_cancel_discarded_task)
+                append(ft, "state", "discarded_task");
+            break;
+        }
+        default: break;
+    }
+}
+
 // An instant event is one that has its beg_ts = end_ts
 void
 ompt_cache_instant_event(
@@ -960,8 +1109,7 @@ ompt_cache_instant_event(
     std::optional<std::vector<tim::unwind::processed_entry>>& _bt_data)
 {
     auto args = function_args_t{};
-    rocprofiler_iterate_callback_tracing_kind_operation_args(
-        record, iterate_args_callback, 2, &args);
+    ompt_iterate_operation_args(record, args);
     auto call_stack = get_backtrace(_bt_data);
 
     cache_category<category::rocm_ompt_api>();
@@ -1017,8 +1165,7 @@ ompt_push_standard_callback(const rocprofiler_callback_tracing_record_t& record,
                             const rocprofiler_timestamp_t&               _beg_ts)
 {
     auto args = function_args_t{};
-    rocprofiler_iterate_callback_tracing_kind_operation_args(
-        record, iterate_args_callback, 1, &args);
+    ompt_iterate_operation_args(record, args);
     get_ompt_standard_cb_storage().emplace(
         record.correlation_id.internal,
         rocprofsys_ompt_data_storage_t{ record, _beg_ts, args });
@@ -1035,8 +1182,7 @@ ompt_pop_standard_callback(
     if(it == get_ompt_standard_cb_storage().end())
     {
         auto args = function_args_t{};
-        rocprofiler_iterate_callback_tracing_kind_operation_args(
-            record, iterate_args_callback, 2, &args);
+        ompt_iterate_operation_args(record, args);
         ompt_cache_orphan_event(rocprofsys_ompt_data_storage_t{ record, _end_ts, args },
                                 _bt_data);
         return;
@@ -1062,8 +1208,7 @@ ompt_push_parallel_callback(const rocprofiler_callback_tracing_record_t& record,
     const void* parallel_data_address = payload_data->args.parallel_begin.parallel_data;
 
     auto args = function_args_t{};
-    rocprofiler_iterate_callback_tracing_kind_operation_args(
-        record, iterate_args_callback, 1, &args);
+    ompt_iterate_operation_args(record, args);
     get_ompt_parallel_cb_storage().emplace(
         reinterpret_cast<uintptr_t>(parallel_data_address),
         rocprofsys_ompt_data_storage_t{ record, _beg_ts, args });
@@ -1085,8 +1230,7 @@ ompt_pop_parallel_callback(
     if(it == get_ompt_parallel_cb_storage().end())
     {
         auto args = function_args_t{};
-        rocprofiler_iterate_callback_tracing_kind_operation_args(
-            record, iterate_args_callback, 2, &args);
+        ompt_iterate_operation_args(record, args);
         ompt_cache_orphan_event(rocprofsys_ompt_data_storage_t{ record, _end_ts, args },
                                 _bt_data);
         return;
@@ -1141,8 +1285,7 @@ ompt_tracing_callback_start(rocprofiler_callback_tracing_record_t record,
         auto args = callback_arg_array_t{};
         if(config::get_perfetto_annotations())
         {
-            rocprofiler_iterate_callback_tracing_kind_operation_args(record, save_args, 1,
-                                                                     &args);
+            ompt_iterate_operation_args(record, args);
         }
 
         uint64_t _beg_ts   = ts;
@@ -1187,8 +1330,7 @@ ompt_tracing_callback_stop(
         auto args = callback_arg_array_t{};
         if(config::get_perfetto_annotations())
         {
-            rocprofiler_iterate_callback_tracing_kind_operation_args(record, save_args, 2,
-                                                                     &args);
+            ompt_iterate_operation_args(record, args);
         }
 
         uint64_t _end_ts = ts;

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library/rocprofiler-sdk.cpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library/rocprofiler-sdk.cpp
@@ -26,6 +26,7 @@
 #include "library/tracing.hpp"
 
 #include <algorithm>
+#include <set>
 #include <timemory/components/timing/wall_clock.hpp>
 #include <timemory/hash/types.hpp>
 #include <timemory/unwind/processed_entry.hpp>
@@ -974,6 +975,8 @@ ompt_iterate_operation_args(const rocprofiler_callback_tracing_record_t& record,
 
     auto ompt_operation_type =
         static_cast<rocprofiler_ompt_operation_t>(record.operation);
+    // ROCProfiler-SDK documentation recommends using 1 for the ENTER phase to avoid seg.
+    // faults.
     auto max_deref = (record.phase == ROCPROFILER_CALLBACK_PHASE_ENTER ||
                       ompt_operation_type == ROCPROFILER_OMPT_ID_parallel_begin)
                          ? 1
@@ -994,23 +997,6 @@ ompt_iterate_operation_args(const rocprofiler_callback_tracing_record_t& record,
     };
     if(ompt_has_flags.find(ompt_operation_type) == ompt_has_flags.end()) return;
 
-    // Extract flags value from arguments
-    auto it = std::find_if(args.begin(), args.end(), [](const auto& entry) {
-        if constexpr(std::is_same_v<ArgsT, callback_arg_array_t>)
-            return entry.first == "flags";
-        else
-            return entry.arg_name == "flags";
-    });
-
-    int flags_val = 0;
-    if(it != args.end())
-    {
-        if constexpr(std::is_same_v<ArgsT, callback_arg_array_t>)
-            flags_val = std::stoi(it->second);
-        else
-            flags_val = std::stoi(it->arg_value);
-    }
-
     auto append = [&args](const std::string& flag_type, const std::string& key,
                           const std::string& val) {
         if constexpr(std::is_same_v<ArgsT, callback_arg_array_t>)
@@ -1020,7 +1006,33 @@ ompt_iterate_operation_args(const rocprofiler_callback_tracing_record_t& record,
                 argument_info{ static_cast<uint32_t>(args.size()), flag_type, key, val });
     };
 
-    // Textual representation of flags follows from OMPT 5.0 specification
+    int   flags_val = 0;
+    auto* payload_data =
+        static_cast<rocprofiler_callback_tracing_ompt_data_t*>(record.payload);
+    if(!payload_data) return;
+
+    // Extract flags value
+    switch(ompt_operation_type)
+    {
+        case ROCPROFILER_OMPT_ID_parallel_begin:
+            flags_val = payload_data->args.parallel_begin.flags;
+            break;
+        case ROCPROFILER_OMPT_ID_parallel_end:
+            flags_val = payload_data->args.parallel_end.flags;
+            break;
+        case ROCPROFILER_OMPT_ID_task_create:
+            flags_val = payload_data->args.task_create.flags;
+            break;
+        case ROCPROFILER_OMPT_ID_implicit_task:
+            flags_val = payload_data->args.implicit_task.flags;
+            break;
+        case ROCPROFILER_OMPT_ID_cancel:
+            flags_val = payload_data->args.cancel.flags;
+            break;
+        default: break;
+    }
+
+    // Textual representation of flags adapted from OMPT 5.0 specification
     switch(ompt_operation_type)
     {
         case ROCPROFILER_OMPT_ID_parallel_begin:  // ompt_parallel_flag_t
@@ -1053,6 +1065,7 @@ ompt_iterate_operation_args(const rocprofiler_callback_tracing_record_t& record,
 
             // Multiple/none can be set
             std::string task_properties;
+            task_properties.reserve(60);
             if(flags_val & ompt_task_undeferred) task_properties += "undeferred, ";
             if(flags_val & ompt_task_untied) task_properties += "untied, ";
             if(flags_val & ompt_task_final) task_properties += "final, ";
@@ -1424,6 +1437,7 @@ tool_tracing_callback(rocprofiler_callback_tracing_record_t record,
     {
         auto* payload_data =
             static_cast<rocprofiler_callback_tracing_ompt_data_t*>(record.payload);
+        if(!payload_data) return;
         switch(record.operation)
         {
             case ROCPROFILER_OMPT_ID_implicit_task:

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library/rocprofiler-sdk.cpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library/rocprofiler-sdk.cpp
@@ -995,25 +995,20 @@ ompt_iterate_operation_args(const rocprofiler_callback_tracing_record_t& record,
     if(ompt_has_flags.find(ompt_operation_type) == ompt_has_flags.end()) return;
 
     // Extract flags value from arguments
+    auto it = std::find_if(args.begin(), args.end(), [](const auto& entry) {
+        if constexpr(std::is_same_v<ArgsT, callback_arg_array_t>)
+            return entry.first == "flags";
+        else
+            return entry.arg_name == "flags";
+    });
+
     int flags_val = 0;
-    for(const auto& entry : args)
+    if(it != args.end())
     {
         if constexpr(std::is_same_v<ArgsT, callback_arg_array_t>)
-        {
-            if(entry.first == "flags")
-            {
-                flags_val = std::stoi(entry.second);
-                break;
-            }
-        }
+            flags_val = std::stoi(it->second);
         else
-        {
-            if(entry.arg_name == "flags")
-            {
-                flags_val = std::stoi(entry.arg_value);
-                break;
-            }
-        }
+            flags_val = std::stoi(it->arg_value);
     }
 
     auto append = [&args](const std::string& flag_type, const std::string& key,
@@ -1029,7 +1024,8 @@ ompt_iterate_operation_args(const rocprofiler_callback_tracing_record_t& record,
     switch(ompt_operation_type)
     {
         case ROCPROFILER_OMPT_ID_parallel_begin:  // ompt_parallel_flag_t
-        case ROCPROFILER_OMPT_ID_parallel_end:    // ompt_parallel_flag_t
+            [[fallthrough]];
+        case ROCPROFILER_OMPT_ID_parallel_end:  // ompt_parallel_flag_t
         {
             const auto ft = std::string{ "ompt_parallel_flag_t" };
             if(flags_val & ompt_parallel_invoker_program)

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library/rocprofiler-sdk.cpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library/rocprofiler-sdk.cpp
@@ -974,7 +974,10 @@ ompt_iterate_operation_args(const rocprofiler_callback_tracing_record_t& record,
 
     auto ompt_operation_type =
         static_cast<rocprofiler_ompt_operation_t>(record.operation);
-    auto max_deref = (record.phase == ROCPROFILER_CALLBACK_PHASE_ENTER) ? 1 : 2;
+    auto max_deref = (record.phase == ROCPROFILER_CALLBACK_PHASE_ENTER ||
+                      ompt_operation_type == ROCPROFILER_OMPT_ID_parallel_begin)
+                         ? 1
+                         : 2;
 
     // Perform standard iteration of arguments
     if constexpr(std::is_same_v<ArgsT, callback_arg_array_t>)
@@ -1012,7 +1015,6 @@ ompt_iterate_operation_args(const rocprofiler_callback_tracing_record_t& record,
             }
         }
     }
-    if(flags_val == 0) return;
 
     auto append = [&args](const std::string& flag_type, const std::string& key,
                           const std::string& val) {


### PR DESCRIPTION
## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

Certain OpenMP Tools (OMPT) callbacks contain a `flags` argument. This `flags` is a generic `int` that represents the disjunction of multiple bitmasks for OMPT flag types. Currently, the user would just see an `int` in the `flags` field. For example:

An `omp_parallel` track in perfetto would show:
```
flags -2147483646
```
A user would have to manually decode the flag to understand it. The goal of this PR is to turn this into human readable form. For the example above, the information actually encoded is: `invoker = runtime` and `invoker_cause = parallel_construct`.


## Technical Details

Currently, the following callbacks have `flags`:
 - `parallel_begin` and `parallel_end`: Encodes `ompt_parallel_flag_t`
 - `task_create`: Encodes `ompt_task_flag_t`
 - `implicit_task`: Encodes the `kind` (either initial or implicit). Note that as of now, we filter our all `implicit_task` callbacks with `kind = initial`.
 - `cancel`: Encodes `ompt_cancel_flag_t` (note that LLVM v20 doesn't even support this callback, but `rocprofiler-sdk` implements it, so we add the logic for it anyways).

**NOTE**
I would like to note that the details of the new arguments do not always have a strict definition in the OpenMP spec. For example, consider the example with `omp_parallel` with `flags = -2147483646`. It corresponds to `ompt_parallel_invoker_runtime` and `ompt_parallel_team` (both from `ompt-parallel_flag_t`). The spec dictates:
```
The value ompt_parallel_league indicates that the callback is invoked due to the creation of a league of teams by a teams construct.
The value ompt_parallel_team indicates that the callback is invoked due to the creation of a team of threads by a parallel construct
```
I translate this as: `invoker = runtime` and `invoker_cause = parallel_construct`.

<!-- Explain the changes along with any relevant GitHub links. -->

## JIRA ID

AIPROFSYST-90

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

Tested locally and verified results on perfetto and rocpd. Note that I could not verify `cancel` construct because the current version of LLVM installed on my machine does not support the construct at all.

## Test Result

<!-- Briefly summarize test outcomes. -->

`omp_parallel`

**BEFORE**
<img width="744" height="169" alt="image" src="https://github.com/user-attachments/assets/6bfa8c2e-3565-4181-b9c2-265463d52245" />

**AFTER**
<img width="743" height="246" alt="image" src="https://github.com/user-attachments/assets/41604ee2-806e-4663-9fd9-0ba7436e88d3" />

`omp_implicit_task`

**BEFORE**
<img width="426" height="196" alt="image" src="https://github.com/user-attachments/assets/14c5ee17-36d1-4034-b59b-937d32de1550" />

**AFTER**
<img width="360" height="229" alt="image" src="https://github.com/user-attachments/assets/b35fc066-dafd-45b0-ada3-28fe5ff78bf1" />

`omp_task_create`

**BEFORE**
<img width="812" height="207" alt="image" src="https://github.com/user-attachments/assets/57258ec4-3d4d-4bbd-89a0-efa16d33f4f3" />

**AFTER**
<img width="818" height="250" alt="image" src="https://github.com/user-attachments/assets/bee06a5e-a027-4ad6-9972-7b1d1f313fab" />

**NOTE**
Also verified output on rocpd:

For example, with `omp_parallel`
<img width="744" height="199" alt="image" src="https://github.com/user-attachments/assets/74809db2-f319-4d70-9f0c-e02020c6ab57" />


## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
