### PR TITLE
[rocprofiler-compute] [Bugfix:] Handle native tool path detection gracefully

### DIFF
--- a/projects/rocprofiler-compute/src/rocprof_compute_profile/profiler_base.py
+++ b/projects/rocprofiler-compute/src/rocprof_compute_profile/profiler_base.py
@@ -602,7 +602,10 @@ class RocProfCompute_Base:
             # Use native counter collection tool
             # Use lib* glob pattern to handle CMAKE_INSTALL_LIBDIR variations
             # (lib, lib64, lib32, etc. depending on distribution)
-            native_tool_base_path = Path(sys.argv[0]).resolve().parents[2]
+            script_path = Path(sys.argv[0]).resolve()
+            native_tool_base_path = (
+                script_path.parents[2] if len(script_path.parents) >= 3 else Path()
+            )
             native_tool_glob_pattern = (
                 "lib*/rocprofiler-compute/librocprofiler-compute-tool.so"
             )

--- a/projects/rocprofiler-compute/src/rocprof_compute_profile/profiler_base.py
+++ b/projects/rocprofiler-compute/src/rocprof_compute_profile/profiler_base.py
@@ -615,7 +615,9 @@ class RocProfCompute_Base:
                 )
             except Exception as e:
                 console_debug(
-                    f"Could not find pre-built native tool: {e}. "
+                    f"Could not find pre-built native tool: {e}.\n"
+                    f"Search path: {native_tool_base_path}\n"
+                    f"Glob pattern: {native_tool_glob_pattern}\n"
                     "Building native tool now."
                 )
                 native_tool_path = None


### PR DESCRIPTION
## Motivation

Handle native tool path detection gracefully

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

This fixes the issue where the standalone binary does not run if at least three parent directories are not available in cwd

With this change, we will be gracefully handling such issues instead of crashing.

<!-- Explain the changes along with any relevant GitHub links. -->

## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan

Create standalone binary with this PR and try to run it from /root and ensure no crash

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

Tests pass

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
