### PR TITLE
Consolidate RCCL CI under therock-ci.yml and enforce exclusive RCCL gating

### DIFF
--- a/.github/workflows/therock-ci.yml
+++ b/.github/workflows/therock-ci.yml
@@ -38,6 +38,7 @@ jobs:
       BASE_REF: HEAD^
     outputs:
       projects: ${{ steps.projects.outputs.projects }}
+      run_linux_rccl_ci: ${{ steps.rccl_check.outputs.run_linux_rccl_ci }}
     steps:
       - name: Checkout code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -75,13 +76,28 @@ jobs:
         run: |
           python .github/scripts/therock_configure_ci.py
 
+      - name: "Detect RCCL file changes"
+        id: rccl_check
+        shell: bash
+        run: |
+          echo "Changed files:"
+          git diff --name-only HEAD^
+
+          if git diff --name-only HEAD^ | grep -q '^projects/rccl/'; then
+            echo "run_linux_rccl_ci=true" >> "$GITHUB_OUTPUT"
+            echo "RCCL changes detected"
+          else
+            echo "run_linux_rccl_ci=false" >> "$GITHUB_OUTPUT"
+            echo "No RCCL changes detected"
+          fi
+
   therock-ci-linux:
     name: Linux (${{ matrix.projects.projects_to_test }})
     permissions:
       contents: read
       id-token: write
     needs: setup
-    if: ${{ needs.setup.outputs.projects != '[]' }}
+    if: ${{ needs.setup.outputs.projects != '[]' && needs.setup.outputs.run_linux_rccl_ci != 'true' }}
     strategy:
       fail-fast: false
       matrix:
@@ -92,13 +108,37 @@ jobs:
       cmake_options: ${{ matrix.projects.cmake_options }}
       projects_to_test: ${{ matrix.projects.projects_to_test }}
 
+  therock-rccl-ci-linux:
+    name: TheRock CI Linux
+    needs: setup
+    if: ${{ needs.setup.outputs.run_linux_rccl_ci == 'true' }}
+    permissions:
+      contents: read
+      id-token: write
+    strategy:
+      fail-fast: false
+      matrix:
+        amdgpu_family: [gfx94X-dcgpu, gfx950-dcgpu]
+    uses: ./.github/workflows/therock-rccl-ci-linux.yml
+    secrets: inherit
+    with:
+      amdgpu_families: ${{ matrix.amdgpu_family }}
+      artifact_group: ${{ matrix.amdgpu_family }}
+      extra_cmake_options: >
+        -DTHEROCK_ENABLE_ALL=OFF 
+        -DTHEROCK_BUILD_TESTING=ON 
+        -DTHEROCK_BUNDLE_SYSDEPS=ON 
+        -DTHEROCK_ENABLE_COMM_LIBS=ON 
+        -DTHEROCK_ENABLE_ROCPROFV3=ON
+        -DTHEROCK_ENABLE_MPI=ON
+
   therock-ci-windows:
     name: Windows (${{ matrix.projects.projects_to_test }})
     permissions:
       contents: read
       id-token: write
     needs: setup
-    if: ${{ needs.setup.outputs.projects != '[]' }}
+    if: ${{ needs.setup.outputs.projects != '[]' && needs.setup.outputs.run_linux_rccl_ci != 'true' }}
     strategy:
       fail-fast: false
       matrix:
@@ -115,6 +155,7 @@ jobs:
     needs:
       - setup
       - therock-ci-linux
+      - therock-rccl-ci-linux
       - therock-ci-windows
     runs-on: ubuntu-24.04
     steps:

--- a/.github/workflows/therock-ci.yml
+++ b/.github/workflows/therock-ci.yml
@@ -109,7 +109,7 @@ jobs:
       projects_to_test: ${{ matrix.projects.projects_to_test }}
 
   therock-rccl-ci-linux:
-    name: TheRock CI Linux
+    name: TheRock RCCL CI Linux
     needs: setup
     if: ${{ needs.setup.outputs.run_linux_rccl_ci == 'true' }}
     permissions:

--- a/.github/workflows/therock-rccl-ci.yml
+++ b/.github/workflows/therock-rccl-ci.yml
@@ -1,14 +1,14 @@
 name: TheRock CI for rccl
 
-on:
-  push:
-    branches:
-      - develop
-  pull_request:
-    types:
-      - labeled
-      - opened
-      - synchronize
+# on:
+#   push:
+#     branches:
+#       - develop
+#   pull_request:
+#     types:
+#       - labeled
+#       - opened
+#       - synchronize
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/therock-rccl-ci.yml
+++ b/.github/workflows/therock-rccl-ci.yml
@@ -1,14 +1,6 @@
 name: TheRock CI for rccl
 
-# on:
-#   push:
-#     branches:
-#       - develop
-#   pull_request:
-#     types:
-#       - labeled
-#       - opened
-#       - synchronize
+on:
   workflow_dispatch:
 
 permissions:

--- a/projects/rccl/.github/workflows/therock-ci-linux.yml
+++ b/projects/rccl/.github/workflows/therock-ci-linux.yml
@@ -91,6 +91,7 @@ jobs:
       - name: Report
         #if: ${{ !cancelled() }}
         run: |
+          echo "Test"
           echo "Full SDK du:"
           echo "------------"
           du -h -d 1 build/dist/rocm

--- a/projects/rccl/.github/workflows/therock-ci-linux.yml
+++ b/projects/rccl/.github/workflows/therock-ci-linux.yml
@@ -91,7 +91,6 @@ jobs:
       - name: Report
         #if: ${{ !cancelled() }}
         run: |
-          echo "Test"
           echo "Full SDK du:"
           echo "------------"
           du -h -d 1 build/dist/rocm


### PR DESCRIPTION
This PR consolidates therock-rccl-ci-linux into therock-ci.yml and introduces file-level RCCL detection to control CI execution.

Changes

1. Moved therock-rccl-ci-linux as a job within therock-ci.yml
2. Added a step to detect changes under projects/rccl/
3. Skip therock-ci-linux and therock-ci-windows when RCCL changes are detected
4. Run only therock-rccl-ci-linux for RCCL-specific changes
5. Removed PR triggers from therock-rccl-ci.yml (now triggered via therock-ci.yml)

Result

1. RCCL and default CI jobs are mutually exclusive
2. CI behavior aligns with modified files
3. Required/gating checks are centralized under therock-ci.yml