### PR TITLE
Fix ROCPD SIGSEGV crash during finalization

### DIFF
--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library.cpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library.cpp
@@ -1060,6 +1060,13 @@ rocprofsys_finalize_hidden(void)
     LOG_DEBUG("Flushing pending region cache entries...");
     rocprofsys_flush_pending_region_cache_hidden();
 
+    // Shutdown cache manager to join all worker threads before post-processing.
+    // Must happen after pending region flush and before post-processing.
+    {
+        auto& _manager = rocprofsys::trace_cache::cache_manager::get_instance();
+        _manager.shutdown();
+    }
+
     bool _perfetto_output_error = false;
     if(get_use_perfetto())
     {
@@ -1070,7 +1077,6 @@ rocprofsys_finalize_hidden(void)
 
     {
         auto& _manager = rocprofsys::trace_cache::cache_manager::get_instance();
-        _manager.shutdown();
         _manager.post_process_bulk();
     }
 


### PR DESCRIPTION
## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->
Race condition during finalization - worker threads responsible for writing ROCPD database files were not being properly joined before cleanup, causing memory corruption when signal handlers were modified during program exit.                                                                                                                            

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->
File Modified: source/lib/rocprof-sys/library.cpp
Change: Moved cache_manager::shutdown() call from line 1073 to line 1062 to ensure it executes:                           
  - After pending region flush (which writes final data to cache)                                                           
  - Before post-processing (which reads from cache files)                                                                   

This guarantees all worker threads (including ROCPD flushing threads) are joined before any subsequent cleanup operations, eliminating the race condition.      
      
## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->
AIPROFSYST-108

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->
Tested on MI300
Test Coverage:                                                                                                            
- 7 Triton AI workloads: vector_add, matmul, layernorm, GPT-4 GEMM, flash attention, MAD exact GPT-4, MAD exact flash attention                                                                                                                 
- Two profiling modes tested for each workload:                                                                           
- Standard mode (Perfetto output) - Regression check                                                                    
- ROCPD mode (Database + Perfetto output) - Fix verification

Verification:                                                                                                             
1. Exit code verification (0 = success, 139 = SIGSEGV)                                                                    
2. Database file generation and integrity (sqlite3 verification)                                                          
3. Perfetto trace generation                                                                                              
4. Event counts in database

## Test Result

<!-- Briefly summarize test outcomes. -->
ROCPD Mode (Fix Verification):                                                                                            
- Before Fix: Exit code 139 (SIGSEGV) - 0/7 workloads succeeded                                                           
- After Fix: Exit code 0 - 7/7 workloads succeeded 
                                                                                                                            
Standard Mode (Regression Check):                                                                                         
- Exit code 0 - 7/7 workloads succeeded
- No regression detected                                                                                                  
                                                                                                                            
Sample Output:                                                                                                            
- Database files: rocpd-*.db generated successfully (verified with sqlite3)                                               
- Perfetto traces: Generated in both modes                                                                                
- Event counts: Valid (1000+ events per workload)

Evidence:
rocpd output 
<img width="1511" height="736" alt="image" src="https://github.com/user-attachments/assets/8a5020ef-330c-4613-be7e-39f4d512a15d" />

perfetto output
<img width="1667" height="745" alt="image" src="https://github.com/user-attachments/assets/0ecd3682-827d-4027-a541-151944207d84" />
<img width="1625" height="838" alt="image" src="https://github.com/user-attachments/assets/0be02972-db8d-42a5-8656-819a9c4c2aff" />


## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
