### PR TITLE
rocr: Replace repeated 'kAqlProfileLib' probes for each GPU

### DIFF
--- a/projects/rocr-runtime/runtime/hsa-runtime/core/inc/runtime.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/inc/runtime.h
@@ -513,6 +513,7 @@ class Runtime {
   bool VirtualMemApiSupported() const { return virtual_mem_api_supported_; }
   bool XnackEnabled() const { return xnack_enabled_; }
   void XnackEnabled(bool enable) { xnack_enabled_ = enable; }
+  bool AqlProfileAvailable() const { return (aqlprofile_lib_ != nullptr); }
 
   Driver &AgentDriver(DriverType drv_type) {
     auto is_drv_type = [&](const std::unique_ptr<Driver> &d) {
@@ -927,6 +928,8 @@ class Runtime {
 
   bool virtual_mem_api_supported_;
   bool xnack_enabled_;
+
+  os::LibHandle aqlprofile_lib_;
 
   typedef void* ThunkHandle;
 

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_gpu_agent.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_gpu_agent.cpp
@@ -1682,8 +1682,7 @@ hsa_status_t GpuAgent::GetInfo(hsa_agent_info_t attribute, void* value) const {
         setFlag(HSA_EXTENSION_AMD_PC_SAMPLING);
       }
 
-      if (os::LibHandle lib = os::LoadLib(kAqlProfileLib)) {
-        os::CloseLib(lib);
+      if (core::Runtime::runtime_singleton_->AqlProfileAvailable()) {
         setFlag(HSA_EXTENSION_AMD_AQLPROFILE);
       }
 

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/runtime.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/runtime.cpp
@@ -757,8 +757,7 @@ hsa_status_t Runtime::GetSystemInfo(hsa_system_info_t attribute, void* value) {
         setFlag(HSA_EXTENSION_IMAGES);
       }
 
-      if (os::LibHandle lib = os::LoadLib(kAqlProfileLib)) {
-        os::CloseLib(lib);
+      if (aqlprofile_lib_ != nullptr) {
         setFlag(HSA_EXTENSION_AMD_AQLPROFILE);
       }
 
@@ -2369,6 +2368,7 @@ Runtime::Runtime()
       ipc_sock_server_fd_(0),
       ipc_sock_server_thread_(nullptr) {
   virtual_mem_api_supported_ = false;
+  aqlprofile_lib_ = nullptr;
   ipc_dmabuf_supported_ = false;
   xnack_enabled_ = false;
   g_use_interrupt_wait = true;
@@ -2426,6 +2426,9 @@ hsa_status_t Runtime::Load() {
   // Load extensions
   LoadExtensions();
 
+  // Probe aqlprofile availability once and cache the result
+  aqlprofile_lib_ = os::LoadLib(kAqlProfileLib);
+
   // Initialize per GPU scratch, blits, and trap handler
   for (core::Agent* agent : gpu_agents_) {
     hsa_status_t status =
@@ -2467,6 +2470,16 @@ void Runtime::Unload() {
 
   UnloadTools();
   UnloadExtensions();
+
+  // Close the aqlprofile probe handle. Skip the dlclose when
+  // running under Valgrind due to a Valgrind bug, see below:
+  // http://valgrind.org/docs/manual/faq.html#faq.unhelpful
+  if (aqlprofile_lib_ != nullptr) {
+    if (!flag_.running_valgrind()) {
+      os::CloseLib(aqlprofile_lib_);
+    }
+    aqlprofile_lib_ = nullptr;
+  }
 
   amd::hsa::loader::Loader::Destroy(loader_.get());
   loader_.reset();


### PR DESCRIPTION
Add one-time cached probe for AQL profile library availability and replace repeated probes in system and per-GPU queries.

## Motivation

The _aqlprofile_ library (_libhsa-amd-aqlprofile64.so_) was probed via `dlopen`/`dlclose` each time `HSA_AGENT_INFO_EXTENSIONS `was queried, which happens once per visible GPU during HIP runtime init. The library's constructor allocates 152 bytes that are never freed on `dlclose`, resulting in 152 × N_GPUs bytes definitely lost (1,216 bytes on an 8-GPU system).

## Technical Details

Cache the _aqlprofile_ availability check in a single probe during `Runtime::Load()` and reuse the cached flag in both the system-level (HSA_SYSTEM_INFO_EXTENSIONS) and per-agent (HSA_AGENT_INFO_EXTENSIONS) query handlers. The library handle is intentionally kept open, so the constructor's allocation remains reachable rather than orphaned, consistent with the existing pattern in hsa.cpp.

## JIRA ID

ROCM-2928 and ROCM-3846

## Test Result

Tested successfully on a MI-300X system with 8 GPU agents.