### PR TITLE
[rocDecode] fix mem leaks

### DIFF
--- a/projects/rocdecode/samples/rocdecDecode/rocdecdecode.cpp
+++ b/projects/rocdecode/samples/rocdecDecode/rocdecdecode.cpp
@@ -573,6 +573,8 @@ void decode_frames(DecoderInfo& dec_info, const std::vector<std::vector<uint8_t>
 }
 
 void destroy_decoder(DecoderInfo& dec_info) {
+    if (dec_info.decoder == nullptr)
+        return;
     if (dec_info.backend == DECODER_BACKEND_DEVICE) {
         CHECK(rocDecDestroyDecoder(dec_info.decoder));
     }
@@ -581,6 +583,7 @@ void destroy_decoder(DecoderInfo& dec_info) {
         CHECK(rocDecDestroyDecoderHost(dec_info.decoder));
     }
 #endif
+    dec_info.decoder = nullptr;
 }
 
 void destroy_parser(DecoderInfo& dec_info) {

--- a/projects/rocdecode/samples/videoDecode/videodecode.cpp
+++ b/projects/rocdecode/samples/videoDecode/videodecode.cpp
@@ -440,6 +440,10 @@ int main(int argc, char **argv) {
         } else if (bs_reader) {
             rocDecDestroyBitstreamReader(bs_reader);
         }
+        if (viddec) {
+            delete viddec;
+            viddec = nullptr;
+        }
     } catch (const std::exception &ex) {
       std::cout << ex.what() << std::endl;
       exit(1);

--- a/projects/rocdecode/samples/videoDecodeMultiFiles/videodecodemultifiles.cpp
+++ b/projects/rocdecode/samples/videoDecodeMultiFiles/videodecodemultifiles.cpp
@@ -266,9 +266,9 @@ int main(int argc, char **argv) {
             }
             std::cout << "\n";
         }
-        if(viddec) {
+        if (viddec) {
             delete viddec;
-            viddec = NULL;
+            viddec = nullptr;
         }
     } catch (const std::exception &ex) {
         std::cout << ex.what() << std::endl;

--- a/projects/rocdecode/samples/videoDecodePicFiles/videodecodepicfiles.cpp
+++ b/projects/rocdecode/samples/videoDecodePicFiles/videodecodepicfiles.cpp
@@ -388,6 +388,10 @@ int main(int argc, char **argv) {
             }
             delete md5_generator;
         }
+        if (viddec) {
+            delete viddec;
+            viddec = nullptr;
+        }
     } catch (const std::exception &ex) {
         std::cout << ex.what() << std::endl;
         exit(1);

--- a/projects/rocdecode/src/parser/hevc_parser.cpp
+++ b/projects/rocdecode/src/parser/hevc_parser.cpp
@@ -52,6 +52,8 @@ rocDecStatus HevcVideoParser::Initialize(RocdecParserParams *p_params) {
 
 rocDecStatus HevcVideoParser::UnInitialize() {
     //todo:: do any uninitialization here
+    slice_info_list_.clear();
+    slice_param_list_.clear();
     return ROCDEC_SUCCESS;
 }
 

--- a/projects/rocdecode/src/parser/hevc_parser.cpp
+++ b/projects/rocdecode/src/parser/hevc_parser.cpp
@@ -53,7 +53,9 @@ rocDecStatus HevcVideoParser::Initialize(RocdecParserParams *p_params) {
 rocDecStatus HevcVideoParser::UnInitialize() {
     //todo:: do any uninitialization here
     slice_info_list_.clear();
+    slice_info_list_.shrink_to_fit();
     slice_param_list_.clear();
+    slice_param_list_.shrink_to_fit();
     return ROCDEC_SUCCESS;
 }
 


### PR DESCRIPTION
## Motivation

Running with valgrind showed mem leaks on some samples under rocDecode. This PR fixes some of them.

## Technical Details
Deleted viddec object created in the samples for video decoding

## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan

All ctests must pass

## Test Result

```
lakshmi@kapu:~/work/rocm-systems/projects/rocdecode/build$ make test ARGS="-VV"
Running tests...
UpdateCTestConfiguration  from :/home/lakshmi/work/rocm-systems/projects/rocdecode/build/DartConfiguration.tcl
Parse Config file:/home/lakshmi/work/rocm-systems/projects/rocdecode/build/DartConfiguration.tcl
UpdateCTestConfiguration  from :/home/lakshmi/work/rocm-systems/projects/rocdecode/build/DartConfiguration.tcl
Parse Config file:/home/lakshmi/work/rocm-systems/projects/rocdecode/build/DartConfiguration.tcl
Test project /home/lakshmi/work/rocm-systems/projects/rocdecode/build
Constructing a list of tests
Done constructing a list of tests
Updating test list for fixtures
Added 0 tests to meet fixture requirements
Checking test dependency graph...
Checking test dependency graph end
test 1
      Start  1: video_decodeRaw-HEVC

1: Test command: /usr/local/bin/ctest "--build-and-test" "/opt/rocm/share/rocdecode/samples/videoDecodeRaw" "/home/lakshmi/work/rocm-systems/projects/rocdecode/build/test/videoDecodeRaw-HEVC" "--build-generator" "Unix Makefiles" "--test-command" "videodecoderaw" "-i" "/opt/rocm/share/rocdecode/video/AMD_driving_virtual_20-H265.265"
1: Working Directory: /home/lakshmi/work/rocm-systems/projects/rocdecode/build/test
1: Test timeout computed to be: 1500
1: Internal cmake changing into directory: /home/lakshmi/work/rocm-systems/projects/rocdecode/build/test/videoDecodeRaw-HEVC
1: ======== CMake output     ======
1: The C compiler identification is Clang 22.0.0
1: The CXX compiler identification is Clang 22.0.0
1: Detecting C compiler ABI info
1: Detecting C compiler ABI info - done
1: Check for working C compiler: /opt/rocm/lib/llvm/bin/amdclang - skipped
1: Detecting C compile features
1: Detecting C compile features - done
1: Detecting CXX compiler ABI info
1: Detecting CXX compiler ABI info - done
1: Check for working CXX compiler: /opt/rocm/lib/llvm/bin/amdclang++ - skipped
1: Detecting CXX compile features
1: Detecting CXX compile features - done
1: Performing Test HIP_CLANG_SUPPORTS_PARALLEL_JOBS
1: Performing Test HIP_CLANG_SUPPORTS_PARALLEL_JOBS - Success
1: Configuring done
1: Generating done
1: Build files have been written to: /home/lakshmi/work/rocm-systems/projects/rocdecode/build/test/videoDecodeRaw-HEVC
1: ======== End CMake output ======
1: Change Dir: /home/lakshmi/work/rocm-systems/projects/rocdecode/build/test/videoDecodeRaw-HEVC
1:
1: Run Clean Command:/usr/bin/gmake -f Makefile clean
1: gmake[1]: Entering directory '/home/lakshmi/work/rocm-systems/projects/rocdecode/build/test/videoDecodeRaw-HEVC'
1: gmake[2]: Entering directory '/home/lakshmi/work/rocm-systems/projects/rocdecode/build/test/videoDecodeRaw-HEVC'
1: gmake[3]: Entering directory '/home/lakshmi/work/rocm-systems/projects/rocdecode/build/test/videoDecodeRaw-HEVC'
1: gmake[3]: Leaving directory '/home/lakshmi/work/rocm-systems/projects/rocdecode/build/test/videoDecodeRaw-HEVC'
1: gmake[2]: Leaving directory '/home/lakshmi/work/rocm-systems/projects/rocdecode/build/test/videoDecodeRaw-HEVC'
1: gmake[1]: Leaving directory '/home/lakshmi/work/rocm-systems/projects/rocdecode/build/test/videoDecodeRaw-HEVC'
1:
1: Run Build Command(s):/usr/bin/gmake -f Makefile && gmake[1]: Entering directory '/home/lakshmi/work/rocm-systems/projects/rocdecode/build/test/videoDecodeRaw-HEVC'
1: gmake[2]: Entering directory '/home/lakshmi/work/rocm-systems/projects/rocdecode/build/test/videoDecodeRaw-HEVC'
1: gmake[3]: Entering directory '/home/lakshmi/work/rocm-systems/projects/rocdecode/build/test/videoDecodeRaw-HEVC'
1: gmake[3]: Leaving directory '/home/lakshmi/work/rocm-systems/projects/rocdecode/build/test/videoDecodeRaw-HEVC'
1: gmake[3]: Entering directory '/home/lakshmi/work/rocm-systems/projects/rocdecode/build/test/videoDecodeRaw-HEVC'
1: [ 33%] Building CXX object CMakeFiles/videodecoderaw.dir/videodecoderaw.cpp.o
1: [ 66%] Building CXX object CMakeFiles/videodecoderaw.dir/opt/rocm/share/rocdecode/utils/rocvideodecode/roc_video_dec.cpp.o
1: [100%] Linking CXX executable videodecoderaw
1: gmake[3]: Leaving directory '/home/lakshmi/work/rocm-systems/projects/rocdecode/build/test/videoDecodeRaw-HEVC'
1: [100%] Built target videodecoderaw
1: gmake[2]: Leaving directory '/home/lakshmi/work/rocm-systems/projects/rocdecode/build/test/videoDecodeRaw-HEVC'
1: gmake[1]: Leaving directory '/home/lakshmi/work/rocm-systems/projects/rocdecode/build/test/videoDecodeRaw-HEVC'
1:
1: Running test command: "/home/lakshmi/work/rocm-systems/projects/rocdecode/build/test/videoDecodeRaw-HEVC/videodecoderaw" "-i" "/opt/rocm/share/rocdecode/video/AMD_driving_virtual_20-H265.265"
1: info: Input file: AMD_driving_virtual_20-H265.265
1: info: Using built-in bitstream reader
1: info: Using GPU device 0 - Radeon RX 7900 XT[gfx1100] on PCI bus 03:00.0
1: info: decoding started, please wait!
1: Input Video Information
1:      Codec        : H.265/HEVC
1:      Frame rate   : 30000/1001 = 29.97 fps
1:      Sequence     : Progressive
1:      Coded size   : [2048, 1024]
1:      Display area : [0, 0, 2048, 1024]
1:      Chroma       : YUV 420
1:      Bit depth    : 8
1: Video Decoding Params:
1:      Num Surfaces : 7
1:      Crop         : [0, 0, 2048, 1024]
1:      Resize       : 2048x1024
1:
1: info: Total pictures decoded: 601
1: info: Total frames output/displayed: 601
1: info: avg decoding time per picture: 1.00619 ms
1: info: avg decode FPS: 993.847
1: info: avg output/display time per frame: 1.00619 ms
1: info: avg output/display FPS: 993.847
1:
 1/15 Test  #1: video_decodeRaw-HEVC .............   Passed    3.93 sec
test 2
      Start  2: video_decodeRaw-AVC

2: Test command: /usr/local/bin/ctest "--build-and-test" "/opt/rocm/share/rocdecode/samples/videoDecodeRaw" "/home/lakshmi/work/rocm-systems/projects/rocdecode/build/test/videoDecodeRaw-AVC" "--build-generator" "Unix Makefiles" "--test-command" "videodecoderaw" "-i" "/opt/rocm/share/rocdecode/video/AMD_driving_virtual_20-H264.264"
2: Working Directory: /home/lakshmi/work/rocm-systems/projects/rocdecode/build/test
2: Test timeout computed to be: 1500
2: Internal cmake changing into directory: /home/lakshmi/work/rocm-systems/projects/rocdecode/build/test/videoDecodeRaw-AVC
2: ======== CMake output     ======
2: The C compiler identification is Clang 22.0.0
2: The CXX compiler identification is Clang 22.0.0
2: Detecting C compiler ABI info
2: Detecting C compiler ABI info - done
2: Check for working C compiler: /opt/rocm/lib/llvm/bin/amdclang - skipped
2: Detecting C compile features
2: Detecting C compile features - done
2: Detecting CXX compiler ABI info
2: Detecting CXX compiler ABI info - done
2: Check for working CXX compiler: /opt/rocm/lib/llvm/bin/amdclang++ - skipped
2: Detecting CXX compile features
2: Detecting CXX compile features - done
2: Performing Test HIP_CLANG_SUPPORTS_PARALLEL_JOBS
2: Performing Test HIP_CLANG_SUPPORTS_PARALLEL_JOBS - Success
2: Configuring done
2: Generating done
2: Build files have been written to: /home/lakshmi/work/rocm-systems/projects/rocdecode/build/test/videoDecodeRaw-AVC
2: ======== End CMake output ======
2: Change Dir: /home/lakshmi/work/rocm-systems/projects/rocdecode/build/test/videoDecodeRaw-AVC
2:
2: Run Clean Command:/usr/bin/gmake -f Makefile clean
2: gmake[1]: Entering directory '/home/lakshmi/work/rocm-systems/projects/rocdecode/build/test/videoDecodeRaw-AVC'
2: gmake[2]: Entering directory '/home/lakshmi/work/rocm-systems/projects/rocdecode/build/test/videoDecodeRaw-AVC'
2: gmake[3]: Entering directory '/home/lakshmi/work/rocm-systems/projects/rocdecode/build/test/videoDecodeRaw-AVC'
2: gmake[3]: Leaving directory '/home/lakshmi/work/rocm-systems/projects/rocdecode/build/test/videoDecodeRaw-AVC'
2: gmake[2]: Leaving directory '/home/lakshmi/work/rocm-systems/projects/rocdecode/build/test/videoDecodeRaw-AVC'
2: gmake[1]: Leaving directory '/home/lakshmi/work/rocm-systems/projects/rocdecode/build/test/videoDecodeRaw-AVC'
2:
2: Run Build Command(s):/usr/bin/gmake -f Makefile && gmake[1]: Entering directory '/home/lakshmi/work/rocm-systems/projects/rocdecode/build/test/videoDecodeRaw-AVC'
2: gmake[2]: Entering directory '/home/lakshmi/work/rocm-systems/projects/rocdecode/build/test/videoDecodeRaw-AVC'
2: gmake[3]: Entering directory '/home/lakshmi/work/rocm-systems/projects/rocdecode/build/test/videoDecodeRaw-AVC'
2: gmake[3]: Leaving directory '/home/lakshmi/work/rocm-systems/projects/rocdecode/build/test/videoDecodeRaw-AVC'
2: gmake[3]: Entering directory '/home/lakshmi/work/rocm-systems/projects/rocdecode/build/test/videoDecodeRaw-AVC'
2: [ 33%] Building CXX object CMakeFiles/videodecoderaw.dir/videodecoderaw.cpp.o
2: [ 66%] Building CXX object CMakeFiles/videodecoderaw.dir/opt/rocm/share/rocdecode/utils/rocvideodecode/roc_video_dec.cpp.o
2: [100%] Linking CXX executable videodecoderaw
2: gmake[3]: Leaving directory '/home/lakshmi/work/rocm-systems/projects/rocdecode/build/test/videoDecodeRaw-AVC'
2: [100%] Built target videodecoderaw
2: gmake[2]: Leaving directory '/home/lakshmi/work/rocm-systems/projects/rocdecode/build/test/videoDecodeRaw-AVC'
2: gmake[1]: Leaving directory '/home/lakshmi/work/rocm-systems/projects/rocdecode/build/test/videoDecodeRaw-AVC'
2:
2: Running test command: "/home/lakshmi/work/rocm-systems/projects/rocdecode/build/test/videoDecodeRaw-AVC/videodecoderaw" "-i" "/opt/rocm/share/rocdecode/video/AMD_driving_virtual_20-H264.264"
2: info: Input file: AMD_driving_virtual_20-H264.264
2: info: Using built-in bitstream reader
2: info: Using GPU device 0 - Radeon RX 7900 XT[gfx1100] on PCI bus 03:00.0
2: info: decoding started, please wait!
2: Input Video Information
2:      Codec        : AVC/H.264
2:      Frame rate   : 60000/2002 = 29.97 fps
2:      Sequence     : Progressive
2:      Coded size   : [2048, 1024]
2:      Display area : [0, 0, 2048, 1024]
2:      Chroma       : YUV 420
2:      Bit depth    : 8
2: Video Decoding Params:
2:      Num Surfaces : 7
2:      Crop         : [0, 0, 2048, 1024]
2:      Resize       : 2048x1024
2:
2: info: Total pictures decoded: 601
2: info: Total frames output/displayed: 601
2: info: avg decoding time per picture: 0.876542 ms
2: info: avg decode FPS: 1140.85
2: info: avg output/display time per frame: 0.876542 ms
2: info: avg output/display FPS: 1140.85
2:
 2/15 Test  #2: video_decodeRaw-AVC ..............   Passed    3.87 sec
test 3
      Start  3: video_decodeRaw-AV1

3: Test command: /usr/local/bin/ctest "--build-and-test" "/opt/rocm/share/rocdecode/samples/videoDecodeRaw" "/home/lakshmi/work/rocm-systems/projects/rocdecode/build/test/videoDecodeRaw-AV1" "--build-generator" "Unix Makefiles" "--test-command" "videodecoderaw" "-i" "/opt/rocm/share/rocdecode/video/AMD_driving_virtual_20-AV1.ivf"
3: Working Directory: /home/lakshmi/work/rocm-systems/projects/rocdecode/build/test
3: Test timeout computed to be: 1500
3: Internal cmake changing into directory: /home/lakshmi/work/rocm-systems/projects/rocdecode/build/test/videoDecodeRaw-AV1
3: ======== CMake output     ======
3: The C compiler identification is Clang 22.0.0
3: The CXX compiler identification is Clang 22.0.0
3: Detecting C compiler ABI info
3: Detecting C compiler ABI info - done
3: Check for working C compiler: /opt/rocm/lib/llvm/bin/amdclang - skipped
3: Detecting C compile features
3: Detecting C compile features - done
3: Detecting CXX compiler ABI info
3: Detecting CXX compiler ABI info - done
3: Check for working CXX compiler: /opt/rocm/lib/llvm/bin/amdclang++ - skipped
3: Detecting CXX compile features
3: Detecting CXX compile features - done
3: Performing Test HIP_CLANG_SUPPORTS_PARALLEL_JOBS
3: Performing Test HIP_CLANG_SUPPORTS_PARALLEL_JOBS - Success
3: Configuring done
3: Generating done
3: Build files have been written to: /home/lakshmi/work/rocm-systems/projects/rocdecode/build/test/videoDecodeRaw-AV1
3: ======== End CMake output ======
3: Change Dir: /home/lakshmi/work/rocm-systems/projects/rocdecode/build/test/videoDecodeRaw-AV1
3:
3: Run Clean Command:/usr/bin/gmake -f Makefile clean
3: gmake[1]: Entering directory '/home/lakshmi/work/rocm-systems/projects/rocdecode/build/test/videoDecodeRaw-AV1'
3: gmake[2]: Entering directory '/home/lakshmi/work/rocm-systems/projects/rocdecode/build/test/videoDecodeRaw-AV1'
3: gmake[3]: Entering directory '/home/lakshmi/work/rocm-systems/projects/rocdecode/build/test/videoDecodeRaw-AV1'
3: gmake[3]: Leaving directory '/home/lakshmi/work/rocm-systems/projects/rocdecode/build/test/videoDecodeRaw-AV1'
3: gmake[2]: Leaving directory '/home/lakshmi/work/rocm-systems/projects/rocdecode/build/test/videoDecodeRaw-AV1'
3: gmake[1]: Leaving directory '/home/lakshmi/work/rocm-systems/projects/rocdecode/build/test/videoDecodeRaw-AV1'
3:
3: Run Build Command(s):/usr/bin/gmake -f Makefile && gmake[1]: Entering directory '/home/lakshmi/work/rocm-systems/projects/rocdecode/build/test/videoDecodeRaw-AV1'
3: gmake[2]: Entering directory '/home/lakshmi/work/rocm-systems/projects/rocdecode/build/test/videoDecodeRaw-AV1'
3: gmake[3]: Entering directory '/home/lakshmi/work/rocm-systems/projects/rocdecode/build/test/videoDecodeRaw-AV1'
3: gmake[3]: Leaving directory '/home/lakshmi/work/rocm-systems/projects/rocdecode/build/test/videoDecodeRaw-AV1'
3: gmake[3]: Entering directory '/home/lakshmi/work/rocm-systems/projects/rocdecode/build/test/videoDecodeRaw-AV1'
3: [ 33%] Building CXX object CMakeFiles/videodecoderaw.dir/videodecoderaw.cpp.o
3: [ 66%] Building CXX object CMakeFiles/videodecoderaw.dir/opt/rocm/share/rocdecode/utils/rocvideodecode/roc_video_dec.cpp.o
3: [100%] Linking CXX executable videodecoderaw
3: gmake[3]: Leaving directory '/home/lakshmi/work/rocm-systems/projects/rocdecode/build/test/videoDecodeRaw-AV1'
3: [100%] Built target videodecoderaw
3: gmake[2]: Leaving directory '/home/lakshmi/work/rocm-systems/projects/rocdecode/build/test/videoDecodeRaw-AV1'
3: gmake[1]: Leaving directory '/home/lakshmi/work/rocm-systems/projects/rocdecode/build/test/videoDecodeRaw-AV1'
3:
3: Running test command: "/home/lakshmi/work/rocm-systems/projects/rocdecode/build/test/videoDecodeRaw-AV1/videodecoderaw" "-i" "/opt/rocm/share/rocdecode/video/AMD_driving_virtual_20-AV1.ivf"
3: info: Input file: AMD_driving_virtual_20-AV1.ivf
3: info: Using built-in bitstream reader
3: info: Using GPU device 0 - Radeon RX 7900 XT[gfx1100] on PCI bus 03:00.0
3: info: decoding started, please wait!
3: Input Video Information
3:      Codec        : AV1
3:      Sequence     : Progressive
3:      Coded size   : [2048, 1024]
3:      Display area : [0, 0, 2048, 1024]
3:      Chroma       : YUV 420
3:      Bit depth    : 8
3: Video Decoding Params:
3:      Num Surfaces : 12
3:      Crop         : [0, 0, 2048, 1024]
3:      Resize       : 2048x1024
3:
3: info: Total pictures decoded: 602
3: info: Total frames output/displayed: 601
3: info: avg decoding time per picture: 1.00254 ms
3: info: avg decode FPS: 997.471
3: info: avg output/display time per frame: 1.0042 ms
3: info: avg output/display FPS: 995.814
3:
 3/15 Test  #3: video_decodeRaw-AV1 ..............   Passed    3.97 sec
test 4
      Start  4: video_decodeRaw-VP9

4: Test command: /usr/local/bin/ctest "--build-and-test" "/opt/rocm/share/rocdecode/samples/videoDecodeRaw" "/home/lakshmi/work/rocm-systems/projects/rocdecode/build/test/videoDecodeRaw-VP9" "--build-generator" "Unix Makefiles" "--test-command" "videodecoderaw" "-i" "/opt/rocm/share/rocdecode/video/AMD_driving_virtual_20-VP9.ivf"
4: Working Directory: /home/lakshmi/work/rocm-systems/projects/rocdecode/build/test
4: Test timeout computed to be: 1500
4: Internal cmake changing into directory: /home/lakshmi/work/rocm-systems/projects/rocdecode/build/test/videoDecodeRaw-VP9
4: ======== CMake output     ======
4: The C compiler identification is Clang 22.0.0
4: The CXX compiler identification is Clang 22.0.0
4: Detecting C compiler ABI info
4: Detecting C compiler ABI info - done
4: Check for working C compiler: /opt/rocm/lib/llvm/bin/amdclang - skipped
4: Detecting C compile features
4: Detecting C compile features - done
4: Detecting CXX compiler ABI info
4: Detecting CXX compiler ABI info - done
4: Check for working CXX compiler: /opt/rocm/lib/llvm/bin/amdclang++ - skipped
4: Detecting CXX compile features
4: Detecting CXX compile features - done
4: Performing Test HIP_CLANG_SUPPORTS_PARALLEL_JOBS
4: Performing Test HIP_CLANG_SUPPORTS_PARALLEL_JOBS - Success
4: Configuring done
4: Generating done
4: Build files have been written to: /home/lakshmi/work/rocm-systems/projects/rocdecode/build/test/videoDecodeRaw-VP9
4: ======== End CMake output ======
4: Change Dir: /home/lakshmi/work/rocm-systems/projects/rocdecode/build/test/videoDecodeRaw-VP9
4:
4: Run Clean Command:/usr/bin/gmake -f Makefile clean
4: gmake[1]: Entering directory '/home/lakshmi/work/rocm-systems/projects/rocdecode/build/test/videoDecodeRaw-VP9'
4: gmake[2]: Entering directory '/home/lakshmi/work/rocm-systems/projects/rocdecode/build/test/videoDecodeRaw-VP9'
4: gmake[3]: Entering directory '/home/lakshmi/work/rocm-systems/projects/rocdecode/build/test/videoDecodeRaw-VP9'
4: gmake[3]: Leaving directory '/home/lakshmi/work/rocm-systems/projects/rocdecode/build/test/videoDecodeRaw-VP9'
4: gmake[2]: Leaving directory '/home/lakshmi/work/rocm-systems/projects/rocdecode/build/test/videoDecodeRaw-VP9'
4: gmake[1]: Leaving directory '/home/lakshmi/work/rocm-systems/projects/rocdecode/build/test/videoDecodeRaw-VP9'
4:
4: Run Build Command(s):/usr/bin/gmake -f Makefile && gmake[1]: Entering directory '/home/lakshmi/work/rocm-systems/projects/rocdecode/build/test/videoDecodeRaw-VP9'
4: gmake[2]: Entering directory '/home/lakshmi/work/rocm-systems/projects/rocdecode/build/test/videoDecodeRaw-VP9'
4: gmake[3]: Entering directory '/home/lakshmi/work/rocm-systems/projects/rocdecode/build/test/videoDecodeRaw-VP9'
4: gmake[3]: Leaving directory '/home/lakshmi/work/rocm-systems/projects/rocdecode/build/test/videoDecodeRaw-VP9'
4: gmake[3]: Entering directory '/home/lakshmi/work/rocm-systems/projects/rocdecode/build/test/videoDecodeRaw-VP9'
4: [ 33%] Building CXX object CMakeFiles/videodecoderaw.dir/videodecoderaw.cpp.o
4: [ 66%] Building CXX object CMakeFiles/videodecoderaw.dir/opt/rocm/share/rocdecode/utils/rocvideodecode/roc_video_dec.cpp.o
4: [100%] Linking CXX executable videodecoderaw
4: gmake[3]: Leaving directory '/home/lakshmi/work/rocm-systems/projects/rocdecode/build/test/videoDecodeRaw-VP9'
4: [100%] Built target videodecoderaw
4: gmake[2]: Leaving directory '/home/lakshmi/work/rocm-systems/projects/rocdecode/build/test/videoDecodeRaw-VP9'
4: gmake[1]: Leaving directory '/home/lakshmi/work/rocm-systems/projects/rocdecode/build/test/videoDecodeRaw-VP9'
4:
4: Running test command: "/home/lakshmi/work/rocm-systems/projects/rocdecode/build/test/videoDecodeRaw-VP9/videodecoderaw" "-i" "/opt/rocm/share/rocdecode/video/AMD_driving_virtual_20-VP9.ivf"
4: info: Input file: AMD_driving_virtual_20-VP9.ivf
4: info: Using built-in bitstream reader
4: info: Using GPU device 0 - Radeon RX 7900 XT[gfx1100] on PCI bus 03:00.0
4: info: decoding started, please wait!
4: Input Video Information
4:      Codec        : VP9
4:      Sequence     : Progressive
4:      Coded size   : [2048, 1024]
4:      Display area : [0, 0, 2048, 1024]
4:      Chroma       : YUV 420
4:      Bit depth    : 8
4: Video Decoding Params:
4:      Num Surfaces : 12
4:      Crop         : [0, 0, 2048, 1024]
4:      Resize       : 2048x1024
4:
4: info: Total pictures decoded: 601
4: info: Total frames output/displayed: 601
4: info: avg decoding time per picture: 1.0823 ms
4: info: avg decode FPS: 923.958
4: info: avg output/display time per frame: 1.0823 ms
4: info: avg output/display FPS: 923.958
4:
 4/15 Test  #4: video_decodeRaw-VP9 ..............   Passed    4.04 sec
test 5
      Start  5: rocdec_Decode-HEVC

5: Test command: /usr/local/bin/ctest "--build-and-test" "/opt/rocm/share/rocdecode/samples/rocdecDecode" "/home/lakshmi/work/rocm-systems/projects/rocdecode/build/test/rocdecDecode" "--build-generator" "Unix Makefiles" "--test-command" "rocdecdecode" "-i" "/opt/rocm/share/rocdecode/frames"
5: Working Directory: /home/lakshmi/work/rocm-systems/projects/rocdecode/build/test
5: Test timeout computed to be: 1500
5: Internal cmake changing into directory: /home/lakshmi/work/rocm-systems/projects/rocdecode/build/test/rocdecDecode
5: ======== CMake output     ======
5: The C compiler identification is Clang 22.0.0
5: The CXX compiler identification is Clang 22.0.0
5: Detecting C compiler ABI info
5: Detecting C compiler ABI info - done
5: Check for working C compiler: /opt/rocm/lib/llvm/bin/amdclang - skipped
5: Detecting C compile features
5: Detecting C compile features - done
5: Detecting CXX compiler ABI info
5: Detecting CXX compiler ABI info - done
5: Check for working CXX compiler: /opt/rocm/lib/llvm/bin/amdclang++ - skipped
5: Detecting CXX compile features
5: Detecting CXX compile features - done
5: Performing Test HIP_CLANG_SUPPORTS_PARALLEL_JOBS
5: Performing Test HIP_CLANG_SUPPORTS_PARALLEL_JOBS - Success
5: Found PkgConfig: /usr/bin/pkg-config (found version "0.29.2")
5: Checking for module 'libavcodec'
5:   Found libavcodec, version 58.134.100
5: Checking for module 'libavformat'
5:   Found libavformat, version 58.76.100
5: Checking for module 'libavutil'
5:   Found libavutil, version 56.70.100
5: -- Using FFMPEG --
5:      Libraries:/usr/lib/x86_64-linux-gnu/libavcodec.so;/usr/lib/x86_64-linux-gnu/libavformat.so;/usr/lib/x86_64-linux-gnu/libavutil.so
5:      Includes:/usr/include/x86_64-linux-gnu
5: Configuring done
5: Generating done
5: Build files have been written to: /home/lakshmi/work/rocm-systems/projects/rocdecode/build/test/rocdecDecode
5: ======== End CMake output ======
5: Change Dir: /home/lakshmi/work/rocm-systems/projects/rocdecode/build/test/rocdecDecode
5:
5: Run Clean Command:/usr/bin/gmake -f Makefile clean
5: gmake[1]: Entering directory '/home/lakshmi/work/rocm-systems/projects/rocdecode/build/test/rocdecDecode'
5: gmake[2]: Entering directory '/home/lakshmi/work/rocm-systems/projects/rocdecode/build/test/rocdecDecode'
5: gmake[3]: Entering directory '/home/lakshmi/work/rocm-systems/projects/rocdecode/build/test/rocdecDecode'
5: gmake[3]: Leaving directory '/home/lakshmi/work/rocm-systems/projects/rocdecode/build/test/rocdecDecode'
5: gmake[2]: Leaving directory '/home/lakshmi/work/rocm-systems/projects/rocdecode/build/test/rocdecDecode'
5: gmake[1]: Leaving directory '/home/lakshmi/work/rocm-systems/projects/rocdecode/build/test/rocdecDecode'
5:
5: Run Build Command(s):/usr/bin/gmake -f Makefile && gmake[1]: Entering directory '/home/lakshmi/work/rocm-systems/projects/rocdecode/build/test/rocdecDecode'
5: gmake[2]: Entering directory '/home/lakshmi/work/rocm-systems/projects/rocdecode/build/test/rocdecDecode'
5: gmake[3]: Entering directory '/home/lakshmi/work/rocm-systems/projects/rocdecode/build/test/rocdecDecode'
5: gmake[3]: Leaving directory '/home/lakshmi/work/rocm-systems/projects/rocdecode/build/test/rocdecDecode'
5: gmake[3]: Entering directory '/home/lakshmi/work/rocm-systems/projects/rocdecode/build/test/rocdecDecode'
5: [ 50%] Building CXX object CMakeFiles/rocdecdecode.dir/rocdecdecode.cpp.o
5: [100%] Linking CXX executable rocdecdecode
5: gmake[3]: Leaving directory '/home/lakshmi/work/rocm-systems/projects/rocdecode/build/test/rocdecDecode'
5: [100%] Built target rocdecdecode
5: gmake[2]: Leaving directory '/home/lakshmi/work/rocm-systems/projects/rocdecode/build/test/rocdecDecode'
5: gmake[1]: Leaving directory '/home/lakshmi/work/rocm-systems/projects/rocdecode/build/test/rocdecDecode'
5:
5: Running test command: "/home/lakshmi/work/rocm-systems/projects/rocdecode/build/test/rocdecDecode/rocdecdecode" "-i" "/opt/rocm/share/rocdecode/frames"
5: Read 53 frames from disk.
5: Reading /opt/rocm/share/rocdecode/frames/AMD_driving_frame_0.265 for reading.
5: Reading /opt/rocm/share/rocdecode/frames/AMD_driving_frame_1.265 for reading.
5: Reading /opt/rocm/share/rocdecode/frames/AMD_driving_frame_2.265 for reading.
5: Reading /opt/rocm/share/rocdecode/frames/AMD_driving_frame_3.265 for reading.
5: Reading /opt/rocm/share/rocdecode/frames/AMD_driving_frame_4.265 for reading.
5: Reading /opt/rocm/share/rocdecode/frames/AMD_driving_frame_5.265 for reading.
5: Reading /opt/rocm/share/rocdecode/frames/AMD_driving_frame_6.265 for reading.
5: Reading /opt/rocm/share/rocdecode/frames/AMD_driving_frame_7.265 for reading.
5: Reading /opt/rocm/share/rocdecode/frames/AMD_driving_frame_8.265 for reading.
5: Reading /opt/rocm/share/rocdecode/frames/AMD_driving_frame_9.265 for reading.
5: Reading /opt/rocm/share/rocdecode/frames/AMD_driving_frame_10.265 for reading.
5: Reading /opt/rocm/share/rocdecode/frames/AMD_driving_frame_11.265 for reading.
5: Reading /opt/rocm/share/rocdecode/frames/AMD_driving_frame_12.265 for reading.
5: Reading /opt/rocm/share/rocdecode/frames/AMD_driving_frame_13.265 for reading.
5: Reading /opt/rocm/share/rocdecode/frames/AMD_driving_frame_14.265 for reading.
5: Reading /opt/rocm/share/rocdecode/frames/AMD_driving_frame_15.265 for reading.
5: Reading /opt/rocm/share/rocdecode/frames/AMD_driving_frame_16.265 for reading.
5: Reading /opt/rocm/share/rocdecode/frames/AMD_driving_frame_17.265 for reading.
5: Reading /opt/rocm/share/rocdecode/frames/AMD_driving_frame_18.265 for reading.
5: Reading /opt/rocm/share/rocdecode/frames/AMD_driving_frame_19.265 for reading.
5: Reading /opt/rocm/share/rocdecode/frames/AMD_driving_frame_20.265 for reading.
5: Reading /opt/rocm/share/rocdecode/frames/AMD_driving_frame_21.265 for reading.
5: Reading /opt/rocm/share/rocdecode/frames/AMD_driving_frame_22.265 for reading.
5: Reading /opt/rocm/share/rocdecode/frames/AMD_driving_frame_23.265 for reading.
5: Reading /opt/rocm/share/rocdecode/frames/AMD_driving_frame_24.265 for reading.
5: Reading /opt/rocm/share/rocdecode/frames/AMD_driving_frame_25.265 for reading.
5: Reading /opt/rocm/share/rocdecode/frames/AMD_driving_frame_26.265 for reading.
5: Reading /opt/rocm/share/rocdecode/frames/AMD_driving_frame_27.265 for reading.
5: Reading /opt/rocm/share/rocdecode/frames/AMD_driving_frame_28.265 for reading.
5: Reading /opt/rocm/share/rocdecode/frames/AMD_driving_frame_29.265 for reading.
5: Reading /opt/rocm/share/rocdecode/frames/AMD_driving_frame_30.265 for reading.
5: Reading /opt/rocm/share/rocdecode/frames/AMD_driving_frame_31.265 for reading.
5: Reading /opt/rocm/share/rocdecode/frames/AMD_driving_frame_32.265 for reading.
5: Reading /opt/rocm/share/rocdecode/frames/AMD_driving_frame_33.265 for reading.
5: Reading /opt/rocm/share/rocdecode/frames/AMD_driving_frame_34.265 for reading.
5: Reading /opt/rocm/share/rocdecode/frames/AMD_driving_frame_35.265 for reading.
5: Reading /opt/rocm/share/rocdecode/frames/AMD_driving_frame_36.265 for reading.
5: Reading /opt/rocm/share/rocdecode/frames/AMD_driving_frame_37.265 for reading.
5: Reading /opt/rocm/share/rocdecode/frames/AMD_driving_frame_38.265 for reading.
5: Reading /opt/rocm/share/rocdecode/frames/AMD_driving_frame_39.265 for reading.
5: Reading /opt/rocm/share/rocdecode/frames/AMD_driving_frame_40.265 for reading.
5: Reading /opt/rocm/share/rocdecode/frames/AMD_driving_frame_41.265 for reading.
5: Reading /opt/rocm/share/rocdecode/frames/AMD_driving_frame_42.265 for reading.
5: Reading /opt/rocm/share/rocdecode/frames/AMD_driving_frame_43.265 for reading.
5: Reading /opt/rocm/share/rocdecode/frames/AMD_driving_frame_44.265 for reading.
5: Reading /opt/rocm/share/rocdecode/frames/AMD_driving_frame_45.265 for reading.
5: Reading /opt/rocm/share/rocdecode/frames/AMD_driving_frame_46.265 for reading.
5: Reading /opt/rocm/share/rocdecode/frames/AMD_driving_frame_47.265 for reading.
5: Reading /opt/rocm/share/rocdecode/frames/AMD_driving_frame_48.265 for reading.
5: Reading /opt/rocm/share/rocdecode/frames/AMD_driving_frame_49.265 for reading.
5: Reading /opt/rocm/share/rocdecode/frames/AMD_driving_frame_50.265 for reading.
5: Reading /opt/rocm/share/rocdecode/frames/AMD_driving_frame_51.265 for reading.
5: Reading /opt/rocm/share/rocdecode/frames/AMD_driving_frame_52.265 for reading.
5: Input Video Information
5:      Codec        : 4
5:      Frame rate   : 30000/1001 = 29.97 fps
5:      Sequence     : Progressive
5:      Coded size   : [2048, 1024]
5:      Display area : [0, 0, 2048, 1024]
5:      Bit depth    : 8
5: Decoding time: 58572 microseconds
5: Success.
5:
5:
5:
 5/15 Test  #5: rocdec_Decode-HEVC ...............   Passed    2.46 sec
test 6
      Start  6: rocDecode_Negative_API_Tests

6: Test command: /usr/local/bin/ctest "--build-and-test" "/opt/rocm/share/rocdecode/test/rocDecodeNegativeApiTests" "/home/lakshmi/work/rocm-systems/projects/rocdecode/build/test/rocdecodenegativetest" "--build-generator" "Unix Makefiles" "--test-command" "rocdecodenegativetest"
6: Working Directory: /home/lakshmi/work/rocm-systems/projects/rocdecode/build/test
6: Test timeout computed to be: 1500
6: Internal cmake changing into directory: /home/lakshmi/work/rocm-systems/projects/rocdecode/build/test/rocdecodenegativetest
6: ======== CMake output     ======
6: The C compiler identification is Clang 22.0.0
6: The CXX compiler identification is Clang 22.0.0
6: Detecting C compiler ABI info
6: Detecting C compiler ABI info - done
6: Check for working C compiler: /opt/rocm/lib/llvm/bin/amdclang - skipped
6: Detecting C compile features
6: Detecting C compile features - done
6: Detecting CXX compiler ABI info
6: Detecting CXX compiler ABI info - done
6: Check for working CXX compiler: /opt/rocm/lib/llvm/bin/amdclang++ - skipped
6: Detecting CXX compile features
6: Detecting CXX compile features - done
6: Performing Test HIP_CLANG_SUPPORTS_PARALLEL_JOBS
6: Performing Test HIP_CLANG_SUPPORTS_PARALLEL_JOBS - Success
6: Configuring done
6: Generating done
6: Build files have been written to: /home/lakshmi/work/rocm-systems/projects/rocdecode/build/test/rocdecodenegativetest
6: ======== End CMake output ======
6: Change Dir: /home/lakshmi/work/rocm-systems/projects/rocdecode/build/test/rocdecodenegativetest
6:
6: Run Clean Command:/usr/bin/gmake -f Makefile clean
6: gmake[1]: Entering directory '/home/lakshmi/work/rocm-systems/projects/rocdecode/build/test/rocdecodenegativetest'
6: gmake[2]: Entering directory '/home/lakshmi/work/rocm-systems/projects/rocdecode/build/test/rocdecodenegativetest'
6: gmake[3]: Entering directory '/home/lakshmi/work/rocm-systems/projects/rocdecode/build/test/rocdecodenegativetest'
6: gmake[3]: Leaving directory '/home/lakshmi/work/rocm-systems/projects/rocdecode/build/test/rocdecodenegativetest'
6: gmake[2]: Leaving directory '/home/lakshmi/work/rocm-systems/projects/rocdecode/build/test/rocdecodenegativetest'
6: gmake[1]: Leaving directory '/home/lakshmi/work/rocm-systems/projects/rocdecode/build/test/rocdecodenegativetest'
6:
6: Run Build Command(s):/usr/bin/gmake -f Makefile && gmake[1]: Entering directory '/home/lakshmi/work/rocm-systems/projects/rocdecode/build/test/rocdecodenegativetest'
6: gmake[2]: Entering directory '/home/lakshmi/work/rocm-systems/projects/rocdecode/build/test/rocdecodenegativetest'
6: gmake[3]: Entering directory '/home/lakshmi/work/rocm-systems/projects/rocdecode/build/test/rocdecodenegativetest'
6: gmake[3]: Leaving directory '/home/lakshmi/work/rocm-systems/projects/rocdecode/build/test/rocdecodenegativetest'
6: gmake[3]: Entering directory '/home/lakshmi/work/rocm-systems/projects/rocdecode/build/test/rocdecodenegativetest'
6: [ 33%] Building CXX object CMakeFiles/rocdecodenegativetest.dir/rocdecodenegativetest.cpp.o
6: [ 66%] Building CXX object CMakeFiles/rocdecodenegativetest.dir/rocdecode_api_negative_tests.cpp.o
6: [100%] Linking CXX executable rocdecodenegativetest
6: gmake[3]: Leaving directory '/home/lakshmi/work/rocm-systems/projects/rocdecode/build/test/rocdecodenegativetest'
6: [100%] Built target rocdecodenegativetest
6: gmake[2]: Leaving directory '/home/lakshmi/work/rocm-systems/projects/rocdecode/build/test/rocdecodenegativetest'
6: gmake[1]: Leaving directory '/home/lakshmi/work/rocm-systems/projects/rocdecode/build/test/rocdecodenegativetest'
6:
6: Running test command: "/home/lakshmi/work/rocm-systems/projects/rocdecode/build/test/rocdecodenegativetest/rocdecodenegativetest"
6: info: Executing negative test cases for the rocDecCreateDecoder API
6: [Critical] InitializeDecoder(), Line 49: Invalid number of decode surfaces.
6: [Critical] InitHIP(), Line 817: ERROR: the requested device_id is not found!
6: [Critical] GetVaContext(), Line 536: Failed to initilize the HIP.
6: [Critical] CheckDecCapForCodecType(), Line 630: Failed to initilize.
6: Error: Failed to obtain decoder capabilities from driver.
6: [Critical] InitializeDecoder(), Line 66: The codec config combination is not supported.
6: [Critical] InitializeDecoder(), Line 58: Failed to initilize the VAAPI Video decoder.
6: [Critical] InitializeDecoder(), Line 66: The codec config combination is not supported.
6: [Critical] InitializeDecoder(), Line 58: Failed to initilize the VAAPI Video decoder.
6: [Critical] InitializeDecoder(), Line 66: The codec config combination is not supported.
6: [Critical] InitializeDecoder(), Line 58: Failed to initilize the VAAPI Video decoder.
6: [Critical] InitializeDecoder(), Line 66: The codec config combination is not supported.
6: [Critical] InitializeDecoder(), Line 58: Failed to initilize the VAAPI Video decoder.
6: [Critical] CheckDecCapForCodecType(), Line 697: VAAPI failure: vaCreateConfig(va_contexts_[va_ctx_id].va_display, va_contexts_[va_ctx_id].va_profile, VAEntrypointVLD, &va_config_attrib, 1, &va_contexts_[va_ctx_id].va_config_id) failed with 'status: 13: the requested VAEntryPoint is not supported' at /home/lakshmi/work/rocm-systems/projects/rocdecode/src/rocdecode/vaapi/vaapi_videodecoder.cpp:697
6: Error: Failed to obtain decoder capabilities from driver.
6: [Critical] InitializeDecoder(), Line 66: The codec config combination is not supported.
6: [Critical] InitializeDecoder(), Line 58: Failed to initilize the VAAPI Video decoder.
6: info: Executing negative test cases for the rocDecDestroyDecoder API
6: info: Executing negative test cases for the rocDecGetDecoderCaps API
6: info: Executing negative test cases for the rocDecDecodeFrame API
6: info: Executing negative test cases for the rocDecGetDecodeStatus API
6: info: Executing negative test cases for the rocDecReconfigureDecoder API
6: info: Executing negative test cases for the rocDecGetVideoFrame API
6: info: Executing negative test cases for the rocDecGetErrorName API
6: info: Executing negative test cases for the rocDecCreateVideoParser API
6: Error: The current version of rocDecode officially supports only the H.265 (HEVC), H.264 (AVC), AV1 and VP9 codecs.
6: info: Executing negative test cases for the rocDecParseVideoData API
6: info: Executing negative test cases for the rocDecDestroyVideoParser API
6: info: Executing negative test cases for the rocDecCreateBitstreamReader API
6: info: Executing negative test cases for the rocDecGetBitstreamCodecType API
6: info: Executing negative test cases for the rocDecGetBitstreamBitDepth API
6: info: Executing negative test cases for the rocDecGetBitstreamPicData API
6: info: Executing negative test cases for the rocDecDestroyBitstreamReader API
6: Test Passed!
6:
 6/15 Test  #6: rocDecode_Negative_API_Tests .....   Passed    2.04 sec
test 7
      Start  7: video_decode-HEVC

7: Test command: /usr/local/bin/ctest "--build-and-test" "/opt/rocm/share/rocdecode/samples/videoDecode" "/home/lakshmi/work/rocm-systems/projects/rocdecode/build/test/videoDecode-HEVC" "--build-generator" "Unix Makefiles" "--test-command" "videodecode" "-i" "/opt/rocm/share/rocdecode/video/AMD_driving_virtual_20-H265.mp4"
7: Working Directory: /home/lakshmi/work/rocm-systems/projects/rocdecode/build/test
7: Test timeout computed to be: 1500
7: Internal cmake changing into directory: /home/lakshmi/work/rocm-systems/projects/rocdecode/build/test/videoDecode-HEVC
7: ======== CMake output     ======
7: The C compiler identification is Clang 22.0.0
7: The CXX compiler identification is Clang 22.0.0
7: Detecting C compiler ABI info
7: Detecting C compiler ABI info - done
7: Check for working C compiler: /opt/rocm/lib/llvm/bin/amdclang - skipped
7: Detecting C compile features
7: Detecting C compile features - done
7: Detecting CXX compiler ABI info
7: Detecting CXX compiler ABI info - done
7: Check for working CXX compiler: /opt/rocm/lib/llvm/bin/amdclang++ - skipped
7: Detecting CXX compile features
7: Detecting CXX compile features - done
7: Performing Test HIP_CLANG_SUPPORTS_PARALLEL_JOBS
7: Performing Test HIP_CLANG_SUPPORTS_PARALLEL_JOBS - Success
7: Found PkgConfig: /usr/bin/pkg-config (found version "0.29.2")
7: Checking for module 'libavcodec'
7:   Found libavcodec, version 58.134.100
7: Checking for module 'libavformat'
7:   Found libavformat, version 58.76.100
7: Checking for module 'libavutil'
7:   Found libavutil, version 56.70.100
7: -- Using FFMPEG --
7:      Libraries:/usr/lib/x86_64-linux-gnu/libavcodec.so;/usr/lib/x86_64-linux-gnu/libavformat.so;/usr/lib/x86_64-linux-gnu/libavutil.so
7:      Includes:/usr/include/x86_64-linux-gnu
7: Found Threads: TRUE
7: Configuring done
7: Generating done
7: Build files have been written to: /home/lakshmi/work/rocm-systems/projects/rocdecode/build/test/videoDecode-HEVC
7: ======== End CMake output ======
7: Change Dir: /home/lakshmi/work/rocm-systems/projects/rocdecode/build/test/videoDecode-HEVC
7:
7: Run Clean Command:/usr/bin/gmake -f Makefile clean
7: gmake[1]: Entering directory '/home/lakshmi/work/rocm-systems/projects/rocdecode/build/test/videoDecode-HEVC'
7: gmake[2]: Entering directory '/home/lakshmi/work/rocm-systems/projects/rocdecode/build/test/videoDecode-HEVC'
7: gmake[3]: Entering directory '/home/lakshmi/work/rocm-systems/projects/rocdecode/build/test/videoDecode-HEVC'
7: gmake[3]: Leaving directory '/home/lakshmi/work/rocm-systems/projects/rocdecode/build/test/videoDecode-HEVC'
7: gmake[2]: Leaving directory '/home/lakshmi/work/rocm-systems/projects/rocdecode/build/test/videoDecode-HEVC'
7: gmake[1]: Leaving directory '/home/lakshmi/work/rocm-systems/projects/rocdecode/build/test/videoDecode-HEVC'
7:
7: Run Build Command(s):/usr/bin/gmake -f Makefile && gmake[1]: Entering directory '/home/lakshmi/work/rocm-systems/projects/rocdecode/build/test/videoDecode-HEVC'
7: gmake[2]: Entering directory '/home/lakshmi/work/rocm-systems/projects/rocdecode/build/test/videoDecode-HEVC'
7: gmake[3]: Entering directory '/home/lakshmi/work/rocm-systems/projects/rocdecode/build/test/videoDecode-HEVC'
7: gmake[3]: Leaving directory '/home/lakshmi/work/rocm-systems/projects/rocdecode/build/test/videoDecode-HEVC'
7: gmake[3]: Entering directory '/home/lakshmi/work/rocm-systems/projects/rocdecode/build/test/videoDecode-HEVC'
7: [ 25%] Building CXX object CMakeFiles/videodecode.dir/videodecode.cpp.o
7: [ 50%] Building CXX object CMakeFiles/videodecode.dir/opt/rocm/share/rocdecode/utils/rocvideodecode/roc_video_dec.cpp.o
7: [ 75%] Building CXX object CMakeFiles/videodecode.dir/opt/rocm/share/rocdecode/utils/ffmpegvideodecode/ffmpeg_video_dec.cpp.o
7: [100%] Linking CXX executable videodecode
7: gmake[3]: Leaving directory '/home/lakshmi/work/rocm-systems/projects/rocdecode/build/test/videoDecode-HEVC'
7: [100%] Built target videodecode
7: gmake[2]: Leaving directory '/home/lakshmi/work/rocm-systems/projects/rocdecode/build/test/videoDecode-HEVC'
7: gmake[1]: Leaving directory '/home/lakshmi/work/rocm-systems/projects/rocdecode/build/test/videoDecode-HEVC'
7:
7: Running test command: "/home/lakshmi/work/rocm-systems/projects/rocdecode/build/test/videoDecode-HEVC/videodecode" "-i" "/opt/rocm/share/rocdecode/video/AMD_driving_virtual_20-H265.mp4"
7: info: Input file: AMD_driving_virtual_20-H265.mp4
7: info: Using FFMPEG demuxer
7: info: Using GPU device 0 - Radeon RX 7900 XT[gfx1100] on PCI bus 03:00.0
7: info: decoding started, please wait!
7: Input Video Information
7:      Codec        : H.265/HEVC
7:      Frame rate   : 30000/1001 = 29.97 fps
7:      Sequence     : Progressive
7:      Coded size   : [2048, 1024]
7:      Display area : [0, 0, 2048, 1024]
7:      Chroma       : YUV 420
7:      Bit depth    : 8
7: Video Decoding Params:
7:      Num Surfaces : 7
7:      Crop         : [0, 0, 2048, 1024]
7:      Resize       : 2048x1024
7:
7: info: Total pictures decoded: 601
7: info: Total frames output/displayed: 601
7: info: avg decoding time per picture: 0.99267 ms
7: info: avg decode FPS: 1007.38
7: info: avg output/display time per frame: 0.99267 ms
7: info: avg output/display FPS: 1007.38
7:
 7/15 Test  #7: video_decode-HEVC ................   Passed    5.61 sec
test 8
      Start  8: video_decode-AVC

8: Test command: /usr/local/bin/ctest "--build-and-test" "/opt/rocm/share/rocdecode/samples/videoDecode" "/home/lakshmi/work/rocm-systems/projects/rocdecode/build/test/videoDecode-AVC" "--build-generator" "Unix Makefiles" "--test-command" "videodecode" "-i" "/opt/rocm/share/rocdecode/video/AMD_driving_virtual_20-H264.mp4"
8: Working Directory: /home/lakshmi/work/rocm-systems/projects/rocdecode/build/test
8: Test timeout computed to be: 1500
8: Internal cmake changing into directory: /home/lakshmi/work/rocm-systems/projects/rocdecode/build/test/videoDecode-AVC
8: ======== CMake output     ======
8: The C compiler identification is Clang 22.0.0
8: The CXX compiler identification is Clang 22.0.0
8: Detecting C compiler ABI info
8: Detecting C compiler ABI info - done
8: Check for working C compiler: /opt/rocm/lib/llvm/bin/amdclang - skipped
8: Detecting C compile features
8: Detecting C compile features - done
8: Detecting CXX compiler ABI info
8: Detecting CXX compiler ABI info - done
8: Check for working CXX compiler: /opt/rocm/lib/llvm/bin/amdclang++ - skipped
8: Detecting CXX compile features
8: Detecting CXX compile features - done
8: Performing Test HIP_CLANG_SUPPORTS_PARALLEL_JOBS
8: Performing Test HIP_CLANG_SUPPORTS_PARALLEL_JOBS - Success
8: Found PkgConfig: /usr/bin/pkg-config (found version "0.29.2")
8: Checking for module 'libavcodec'
8:   Found libavcodec, version 58.134.100
8: Checking for module 'libavformat'
8:   Found libavformat, version 58.76.100
8: Checking for module 'libavutil'
8:   Found libavutil, version 56.70.100
8: -- Using FFMPEG --
8:      Libraries:/usr/lib/x86_64-linux-gnu/libavcodec.so;/usr/lib/x86_64-linux-gnu/libavformat.so;/usr/lib/x86_64-linux-gnu/libavutil.so
8:      Includes:/usr/include/x86_64-linux-gnu
8: Found Threads: TRUE
8: Configuring done
8: Generating done
8: Build files have been written to: /home/lakshmi/work/rocm-systems/projects/rocdecode/build/test/videoDecode-AVC
8: ======== End CMake output ======
8: Change Dir: /home/lakshmi/work/rocm-systems/projects/rocdecode/build/test/videoDecode-AVC
8:
8: Run Clean Command:/usr/bin/gmake -f Makefile clean
8: gmake[1]: Entering directory '/home/lakshmi/work/rocm-systems/projects/rocdecode/build/test/videoDecode-AVC'
8: gmake[2]: Entering directory '/home/lakshmi/work/rocm-systems/projects/rocdecode/build/test/videoDecode-AVC'
8: gmake[3]: Entering directory '/home/lakshmi/work/rocm-systems/projects/rocdecode/build/test/videoDecode-AVC'
8: gmake[3]: Leaving directory '/home/lakshmi/work/rocm-systems/projects/rocdecode/build/test/videoDecode-AVC'
8: gmake[2]: Leaving directory '/home/lakshmi/work/rocm-systems/projects/rocdecode/build/test/videoDecode-AVC'
8: gmake[1]: Leaving directory '/home/lakshmi/work/rocm-systems/projects/rocdecode/build/test/videoDecode-AVC'
8:
8: Run Build Command(s):/usr/bin/gmake -f Makefile && gmake[1]: Entering directory '/home/lakshmi/work/rocm-systems/projects/rocdecode/build/test/videoDecode-AVC'
8: gmake[2]: Entering directory '/home/lakshmi/work/rocm-systems/projects/rocdecode/build/test/videoDecode-AVC'
8: gmake[3]: Entering directory '/home/lakshmi/work/rocm-systems/projects/rocdecode/build/test/videoDecode-AVC'
8: gmake[3]: Leaving directory '/home/lakshmi/work/rocm-systems/projects/rocdecode/build/test/videoDecode-AVC'
8: gmake[3]: Entering directory '/home/lakshmi/work/rocm-systems/projects/rocdecode/build/test/videoDecode-AVC'
8: [ 25%] Building CXX object CMakeFiles/videodecode.dir/videodecode.cpp.o
8: [ 50%] Building CXX object CMakeFiles/videodecode.dir/opt/rocm/share/rocdecode/utils/rocvideodecode/roc_video_dec.cpp.o
8: [ 75%] Building CXX object CMakeFiles/videodecode.dir/opt/rocm/share/rocdecode/utils/ffmpegvideodecode/ffmpeg_video_dec.cpp.o
8: [100%] Linking CXX executable videodecode
8: gmake[3]: Leaving directory '/home/lakshmi/work/rocm-systems/projects/rocdecode/build/test/videoDecode-AVC'
8: [100%] Built target videodecode
8: gmake[2]: Leaving directory '/home/lakshmi/work/rocm-systems/projects/rocdecode/build/test/videoDecode-AVC'
8: gmake[1]: Leaving directory '/home/lakshmi/work/rocm-systems/projects/rocdecode/build/test/videoDecode-AVC'
8:
8: Running test command: "/home/lakshmi/work/rocm-systems/projects/rocdecode/build/test/videoDecode-AVC/videodecode" "-i" "/opt/rocm/share/rocdecode/video/AMD_driving_virtual_20-H264.mp4"
8: info: Input file: AMD_driving_virtual_20-H264.mp4
8: info: Using FFMPEG demuxer
8: info: Using GPU device 0 - Radeon RX 7900 XT[gfx1100] on PCI bus 03:00.0
8: info: decoding started, please wait!
8: Input Video Information
8:      Codec        : AVC/H.264
8:      Frame rate   : 60000/2002 = 29.97 fps
8:      Sequence     : Progressive
8:      Coded size   : [2048, 1024]
8:      Display area : [0, 0, 2048, 1024]
8:      Chroma       : YUV 420
8:      Bit depth    : 8
8: Video Decoding Params:
8:      Num Surfaces : 7
8:      Crop         : [0, 0, 2048, 1024]
8:      Resize       : 2048x1024
8:
8: info: Total pictures decoded: 601
8: info: Total frames output/displayed: 601
8: info: avg decoding time per picture: 0.843027 ms
8: info: avg decode FPS: 1186.2
8: info: avg output/display time per frame: 0.843027 ms
8: info: avg output/display FPS: 1186.2
8:
 8/15 Test  #8: video_decode-AVC .................   Passed    5.58 sec
test 9
      Start  9: video_decode-AV1

9: Test command: /usr/local/bin/ctest "--build-and-test" "/opt/rocm/share/rocdecode/samples/videoDecode" "/home/lakshmi/work/rocm-systems/projects/rocdecode/build/test/videoDecode-AV1" "--build-generator" "Unix Makefiles" "--test-command" "videodecode" "-i" "/opt/rocm/share/rocdecode/video/AMD_driving_virtual_20-AV1.mp4"
9: Working Directory: /home/lakshmi/work/rocm-systems/projects/rocdecode/build/test
9: Test timeout computed to be: 1500
9: Internal cmake changing into directory: /home/lakshmi/work/rocm-systems/projects/rocdecode/build/test/videoDecode-AV1
9: ======== CMake output     ======
9: The C compiler identification is Clang 22.0.0
9: The CXX compiler identification is Clang 22.0.0
9: Detecting C compiler ABI info
9: Detecting C compiler ABI info - done
9: Check for working C compiler: /opt/rocm/lib/llvm/bin/amdclang - skipped
9: Detecting C compile features
9: Detecting C compile features - done
9: Detecting CXX compiler ABI info
9: Detecting CXX compiler ABI info - done
9: Check for working CXX compiler: /opt/rocm/lib/llvm/bin/amdclang++ - skipped
9: Detecting CXX compile features
9: Detecting CXX compile features - done
9: Performing Test HIP_CLANG_SUPPORTS_PARALLEL_JOBS
9: Performing Test HIP_CLANG_SUPPORTS_PARALLEL_JOBS - Success
9: Found PkgConfig: /usr/bin/pkg-config (found version "0.29.2")
9: Checking for module 'libavcodec'
9:   Found libavcodec, version 58.134.100
9: Checking for module 'libavformat'
9:   Found libavformat, version 58.76.100
9: Checking for module 'libavutil'
9:   Found libavutil, version 56.70.100
9: -- Using FFMPEG --
9:      Libraries:/usr/lib/x86_64-linux-gnu/libavcodec.so;/usr/lib/x86_64-linux-gnu/libavformat.so;/usr/lib/x86_64-linux-gnu/libavutil.so
9:      Includes:/usr/include/x86_64-linux-gnu
9: Found Threads: TRUE
9: Configuring done
9: Generating done
9: Build files have been written to: /home/lakshmi/work/rocm-systems/projects/rocdecode/build/test/videoDecode-AV1
9: ======== End CMake output ======
9: Change Dir: /home/lakshmi/work/rocm-systems/projects/rocdecode/build/test/videoDecode-AV1
9:
9: Run Clean Command:/usr/bin/gmake -f Makefile clean
9: gmake[1]: Entering directory '/home/lakshmi/work/rocm-systems/projects/rocdecode/build/test/videoDecode-AV1'
9: gmake[2]: Entering directory '/home/lakshmi/work/rocm-systems/projects/rocdecode/build/test/videoDecode-AV1'
9: gmake[3]: Entering directory '/home/lakshmi/work/rocm-systems/projects/rocdecode/build/test/videoDecode-AV1'
9: gmake[3]: Leaving directory '/home/lakshmi/work/rocm-systems/projects/rocdecode/build/test/videoDecode-AV1'
9: gmake[2]: Leaving directory '/home/lakshmi/work/rocm-systems/projects/rocdecode/build/test/videoDecode-AV1'
9: gmake[1]: Leaving directory '/home/lakshmi/work/rocm-systems/projects/rocdecode/build/test/videoDecode-AV1'
9:
9: Run Build Command(s):/usr/bin/gmake -f Makefile && gmake[1]: Entering directory '/home/lakshmi/work/rocm-systems/projects/rocdecode/build/test/videoDecode-AV1'
9: gmake[2]: Entering directory '/home/lakshmi/work/rocm-systems/projects/rocdecode/build/test/videoDecode-AV1'
9: gmake[3]: Entering directory '/home/lakshmi/work/rocm-systems/projects/rocdecode/build/test/videoDecode-AV1'
9: gmake[3]: Leaving directory '/home/lakshmi/work/rocm-systems/projects/rocdecode/build/test/videoDecode-AV1'
9: gmake[3]: Entering directory '/home/lakshmi/work/rocm-systems/projects/rocdecode/build/test/videoDecode-AV1'
9: [ 25%] Building CXX object CMakeFiles/videodecode.dir/videodecode.cpp.o
9: [ 50%] Building CXX object CMakeFiles/videodecode.dir/opt/rocm/share/rocdecode/utils/rocvideodecode/roc_video_dec.cpp.o
9: [ 75%] Building CXX object CMakeFiles/videodecode.dir/opt/rocm/share/rocdecode/utils/ffmpegvideodecode/ffmpeg_video_dec.cpp.o
9: [100%] Linking CXX executable videodecode
9: gmake[3]: Leaving directory '/home/lakshmi/work/rocm-systems/projects/rocdecode/build/test/videoDecode-AV1'
9: [100%] Built target videodecode
9: gmake[2]: Leaving directory '/home/lakshmi/work/rocm-systems/projects/rocdecode/build/test/videoDecode-AV1'
9: gmake[1]: Leaving directory '/home/lakshmi/work/rocm-systems/projects/rocdecode/build/test/videoDecode-AV1'
9:
9: Running test command: "/home/lakshmi/work/rocm-systems/projects/rocdecode/build/test/videoDecode-AV1/videodecode" "-i" "/opt/rocm/share/rocdecode/video/AMD_driving_virtual_20-AV1.mp4"
9: info: Input file: AMD_driving_virtual_20-AV1.mp4
9: info: Using FFMPEG demuxer
9: info: Using GPU device 0 - Radeon RX 7900 XT[gfx1100] on PCI bus 03:00.0
9: info: decoding started, please wait!
9: Input Video Information
9:      Codec        : AV1
9:      Sequence     : Progressive
9:      Coded size   : [2048, 1024]
9:      Display area : [0, 0, 2048, 1024]
9:      Chroma       : YUV 420
9:      Bit depth    : 8
9: Video Decoding Params:
9:      Num Surfaces : 12
9:      Crop         : [0, 0, 2048, 1024]
9:      Resize       : 2048x1024
9:
9: info: Total pictures decoded: 602
9: info: Total frames output/displayed: 601
9: info: avg decoding time per picture: 0.996639 ms
9: info: avg decode FPS: 1003.37
9: info: avg output/display time per frame: 0.998297 ms
9: info: avg output/display FPS: 1001.71
9:
 9/15 Test  #9: video_decode-AV1 .................   Passed    5.67 sec
test 10
      Start 10: video_decode-VP9

10: Test command: /usr/local/bin/ctest "--build-and-test" "/opt/rocm/share/rocdecode/samples/videoDecode" "/home/lakshmi/work/rocm-systems/projects/rocdecode/build/test/videoDecode-VP9" "--build-generator" "Unix Makefiles" "--test-command" "videodecode" "-i" "/opt/rocm/share/rocdecode/video/AMD_driving_virtual_20-VP9.ivf"
10: Working Directory: /home/lakshmi/work/rocm-systems/projects/rocdecode/build/test
10: Test timeout computed to be: 1500
10: Internal cmake changing into directory: /home/lakshmi/work/rocm-systems/projects/rocdecode/build/test/videoDecode-VP9
10: ======== CMake output     ======
10: The C compiler identification is Clang 22.0.0
10: The CXX compiler identification is Clang 22.0.0
10: Detecting C compiler ABI info
10: Detecting C compiler ABI info - done
10: Check for working C compiler: /opt/rocm/lib/llvm/bin/amdclang - skipped
10: Detecting C compile features
10: Detecting C compile features - done
10: Detecting CXX compiler ABI info
10: Detecting CXX compiler ABI info - done
10: Check for working CXX compiler: /opt/rocm/lib/llvm/bin/amdclang++ - skipped
10: Detecting CXX compile features
10: Detecting CXX compile features - done
10: Performing Test HIP_CLANG_SUPPORTS_PARALLEL_JOBS
10: Performing Test HIP_CLANG_SUPPORTS_PARALLEL_JOBS - Success
10: Found PkgConfig: /usr/bin/pkg-config (found version "0.29.2")
10: Checking for module 'libavcodec'
10:   Found libavcodec, version 58.134.100
10: Checking for module 'libavformat'
10:   Found libavformat, version 58.76.100
10: Checking for module 'libavutil'
10:   Found libavutil, version 56.70.100
10: -- Using FFMPEG --
10:     Libraries:/usr/lib/x86_64-linux-gnu/libavcodec.so;/usr/lib/x86_64-linux-gnu/libavformat.so;/usr/lib/x86_64-linux-gnu/libavutil.so
10:     Includes:/usr/include/x86_64-linux-gnu
10: Found Threads: TRUE
10: Configuring done
10: Generating done
10: Build files have been written to: /home/lakshmi/work/rocm-systems/projects/rocdecode/build/test/videoDecode-VP9
10: ======== End CMake output ======
10: Change Dir: /home/lakshmi/work/rocm-systems/projects/rocdecode/build/test/videoDecode-VP9
10:
10: Run Clean Command:/usr/bin/gmake -f Makefile clean
10: gmake[1]: Entering directory '/home/lakshmi/work/rocm-systems/projects/rocdecode/build/test/videoDecode-VP9'
10: gmake[2]: Entering directory '/home/lakshmi/work/rocm-systems/projects/rocdecode/build/test/videoDecode-VP9'
10: gmake[3]: Entering directory '/home/lakshmi/work/rocm-systems/projects/rocdecode/build/test/videoDecode-VP9'
10: gmake[3]: Leaving directory '/home/lakshmi/work/rocm-systems/projects/rocdecode/build/test/videoDecode-VP9'
10: gmake[2]: Leaving directory '/home/lakshmi/work/rocm-systems/projects/rocdecode/build/test/videoDecode-VP9'
10: gmake[1]: Leaving directory '/home/lakshmi/work/rocm-systems/projects/rocdecode/build/test/videoDecode-VP9'
10:
10: Run Build Command(s):/usr/bin/gmake -f Makefile && gmake[1]: Entering directory '/home/lakshmi/work/rocm-systems/projects/rocdecode/build/test/videoDecode-VP9'
10: gmake[2]: Entering directory '/home/lakshmi/work/rocm-systems/projects/rocdecode/build/test/videoDecode-VP9'
10: gmake[3]: Entering directory '/home/lakshmi/work/rocm-systems/projects/rocdecode/build/test/videoDecode-VP9'
10: gmake[3]: Leaving directory '/home/lakshmi/work/rocm-systems/projects/rocdecode/build/test/videoDecode-VP9'
10: gmake[3]: Entering directory '/home/lakshmi/work/rocm-systems/projects/rocdecode/build/test/videoDecode-VP9'
10: [ 25%] Building CXX object CMakeFiles/videodecode.dir/videodecode.cpp.o
10: [ 50%] Building CXX object CMakeFiles/videodecode.dir/opt/rocm/share/rocdecode/utils/rocvideodecode/roc_video_dec.cpp.o
10: [ 75%] Building CXX object CMakeFiles/videodecode.dir/opt/rocm/share/rocdecode/utils/ffmpegvideodecode/ffmpeg_video_dec.cpp.o
10: [100%] Linking CXX executable videodecode
10: gmake[3]: Leaving directory '/home/lakshmi/work/rocm-systems/projects/rocdecode/build/test/videoDecode-VP9'
10: [100%] Built target videodecode
10: gmake[2]: Leaving directory '/home/lakshmi/work/rocm-systems/projects/rocdecode/build/test/videoDecode-VP9'
10: gmake[1]: Leaving directory '/home/lakshmi/work/rocm-systems/projects/rocdecode/build/test/videoDecode-VP9'
10:
10: Running test command: "/home/lakshmi/work/rocm-systems/projects/rocdecode/build/test/videoDecode-VP9/videodecode" "-i" "/opt/rocm/share/rocdecode/video/AMD_driving_virtual_20-VP9.ivf"
10: info: Input file: AMD_driving_virtual_20-VP9.ivf
10: info: Using FFMPEG demuxer
10: info: Using GPU device 0 - Radeon RX 7900 XT[gfx1100] on PCI bus 03:00.0
10: info: decoding started, please wait!
10: Input Video Information
10:     Codec        : VP9
10:     Sequence     : Progressive
10:     Coded size   : [2048, 1024]
10:     Display area : [0, 0, 2048, 1024]
10:     Chroma       : YUV 420
10:     Bit depth    : 8
10: Video Decoding Params:
10:     Num Surfaces : 12
10:     Crop         : [0, 0, 2048, 1024]
10:     Resize       : 2048x1024
10:
10: info: Total pictures decoded: 601
10: info: Total frames output/displayed: 601
10: info: avg decoding time per picture: 1.07488 ms
10: info: avg decode FPS: 930.339
10: info: avg output/display time per frame: 1.07488 ms
10: info: avg output/display FPS: 930.339
10:
10/15 Test #10: video_decode-VP9 .................   Passed    5.64 sec
test 11
      Start 11: video_decodePerf-HEVC

11: Test command: /usr/local/bin/ctest "--build-and-test" "/opt/rocm/share/rocdecode/samples/videoDecodePerf" "/home/lakshmi/work/rocm-systems/projects/rocdecode/build/test/videoDecodePerf" "--build-generator" "Unix Makefiles" "--test-command" "videodecodeperf" "-i" "/opt/rocm/share/rocdecode/video/AMD_driving_virtual_20-H265.mp4"
11: Working Directory: /home/lakshmi/work/rocm-systems/projects/rocdecode/build/test
11: Test timeout computed to be: 1500
11: Internal cmake changing into directory: /home/lakshmi/work/rocm-systems/projects/rocdecode/build/test/videoDecodePerf
11: ======== CMake output     ======
11: The C compiler identification is Clang 22.0.0
11: The CXX compiler identification is Clang 22.0.0
11: Detecting C compiler ABI info
11: Detecting C compiler ABI info - done
11: Check for working C compiler: /opt/rocm/lib/llvm/bin/amdclang - skipped
11: Detecting C compile features
11: Detecting C compile features - done
11: Detecting CXX compiler ABI info
11: Detecting CXX compiler ABI info - done
11: Check for working CXX compiler: /opt/rocm/lib/llvm/bin/amdclang++ - skipped
11: Detecting CXX compile features
11: Detecting CXX compile features - done
11: Performing Test HIP_CLANG_SUPPORTS_PARALLEL_JOBS
11: Performing Test HIP_CLANG_SUPPORTS_PARALLEL_JOBS - Success
11: Found PkgConfig: /usr/bin/pkg-config (found version "0.29.2")
11: Checking for module 'libavcodec'
11:   Found libavcodec, version 58.134.100
11: Checking for module 'libavformat'
11:   Found libavformat, version 58.76.100
11: Checking for module 'libavutil'
11:   Found libavutil, version 56.70.100
11: -- Using FFMPEG --
11:     Libraries:/usr/lib/x86_64-linux-gnu/libavcodec.so;/usr/lib/x86_64-linux-gnu/libavformat.so;/usr/lib/x86_64-linux-gnu/libavutil.so
11:     Includes:/usr/include/x86_64-linux-gnu
11: Found Threads: TRUE
11: Configuring done
11: Generating done
11: Build files have been written to: /home/lakshmi/work/rocm-systems/projects/rocdecode/build/test/videoDecodePerf
11: ======== End CMake output ======
11: Change Dir: /home/lakshmi/work/rocm-systems/projects/rocdecode/build/test/videoDecodePerf
11:
11: Run Clean Command:/usr/bin/gmake -f Makefile clean
11: gmake[1]: Entering directory '/home/lakshmi/work/rocm-systems/projects/rocdecode/build/test/videoDecodePerf'
11: gmake[2]: Entering directory '/home/lakshmi/work/rocm-systems/projects/rocdecode/build/test/videoDecodePerf'
11: gmake[3]: Entering directory '/home/lakshmi/work/rocm-systems/projects/rocdecode/build/test/videoDecodePerf'
11: gmake[3]: Leaving directory '/home/lakshmi/work/rocm-systems/projects/rocdecode/build/test/videoDecodePerf'
11: gmake[2]: Leaving directory '/home/lakshmi/work/rocm-systems/projects/rocdecode/build/test/videoDecodePerf'
11: gmake[1]: Leaving directory '/home/lakshmi/work/rocm-systems/projects/rocdecode/build/test/videoDecodePerf'
11:
11: Run Build Command(s):/usr/bin/gmake -f Makefile && gmake[1]: Entering directory '/home/lakshmi/work/rocm-systems/projects/rocdecode/build/test/videoDecodePerf'
11: gmake[2]: Entering directory '/home/lakshmi/work/rocm-systems/projects/rocdecode/build/test/videoDecodePerf'
11: gmake[3]: Entering directory '/home/lakshmi/work/rocm-systems/projects/rocdecode/build/test/videoDecodePerf'
11: gmake[3]: Leaving directory '/home/lakshmi/work/rocm-systems/projects/rocdecode/build/test/videoDecodePerf'
11: gmake[3]: Entering directory '/home/lakshmi/work/rocm-systems/projects/rocdecode/build/test/videoDecodePerf'
11: [ 25%] Building CXX object CMakeFiles/videodecodeperf.dir/videodecodeperf.cpp.o
11: [ 50%] Building CXX object CMakeFiles/videodecodeperf.dir/opt/rocm/share/rocdecode/utils/rocvideodecode/roc_video_dec.cpp.o
11: [ 75%] Building CXX object CMakeFiles/videodecodeperf.dir/opt/rocm/share/rocdecode/utils/ffmpegvideodecode/ffmpeg_video_dec.cpp.o
11: [100%] Linking CXX executable videodecodeperf
11: gmake[3]: Leaving directory '/home/lakshmi/work/rocm-systems/projects/rocdecode/build/test/videoDecodePerf'
11: [100%] Built target videodecodeperf
11: gmake[2]: Leaving directory '/home/lakshmi/work/rocm-systems/projects/rocdecode/build/test/videoDecodePerf'
11: gmake[1]: Leaving directory '/home/lakshmi/work/rocm-systems/projects/rocdecode/build/test/videoDecodePerf'
11:
11: Running test command: "/home/lakshmi/work/rocm-systems/projects/rocdecode/build/test/videoDecodePerf/videodecodeperf" "-i" "/opt/rocm/share/rocdecode/video/AMD_driving_virtual_20-H265.mp4"
11: info: Input file: AMD_driving_virtual_20-H265.mp4
11: info: Number of threads: 1
11: info: stream 0 using GPU device 0 - Radeon RX 7900 XT[gfx1100] on PCI bus 03:00.0
11: info: decoding started for thread 0 ,please wait!
11: Input Video Information
11:     Codec        : H.265/HEVC
11:     Frame rate   : 30000/1001 = 29.97 fps
11:     Sequence     : Progressive
11:     Coded size   : [2048, 1024]
11:     Display area : [0, 0, 2048, 1024]
11:     Chroma       : YUV 420
11:     Bit depth    : 8
11: Video Decoding Params:
11:     Num Surfaces : 7
11:     Crop         : [0, 0, 2048, 1024]
11:     Resize       : 2048x1024
11:
11: info: Total pictures decoded: 601
11: info: Total frames output/displayed: 601
11: info: avg decoding time per picture: 0.989382 ms
11: info: avg decode FPS: 1010.73
11: info: avg output/display time per frame: 0.989382 ms
11: info: avg output/display FPS: 1010.73
11:
11/15 Test #11: video_decodePerf-HEVC ............   Passed    5.91 sec
test 12
      Start 12: video_decodeBatch

12: Test command: /usr/local/bin/ctest "--build-and-test" "/opt/rocm/share/rocdecode/samples/videoDecodeBatch" "/home/lakshmi/work/rocm-systems/projects/rocdecode/build/test/videoDecodeBatch" "--build-generator" "Unix Makefiles" "--test-command" "videodecodebatch" "-i" "/opt/rocm/share/rocdecode/video/" "-t" "2"
12: Working Directory: /home/lakshmi/work/rocm-systems/projects/rocdecode/build/test
12: Test timeout computed to be: 1500
12: Internal cmake changing into directory: /home/lakshmi/work/rocm-systems/projects/rocdecode/build/test/videoDecodeBatch
12: ======== CMake output     ======
12: The C compiler identification is Clang 22.0.0
12: The CXX compiler identification is Clang 22.0.0
12: Detecting C compiler ABI info
12: Detecting C compiler ABI info - done
12: Check for working C compiler: /opt/rocm/lib/llvm/bin/amdclang - skipped
12: Detecting C compile features
12: Detecting C compile features - done
12: Detecting CXX compiler ABI info
12: Detecting CXX compiler ABI info - done
12: Check for working CXX compiler: /opt/rocm/lib/llvm/bin/amdclang++ - skipped
12: Detecting CXX compile features
12: Detecting CXX compile features - done
12: Performing Test HIP_CLANG_SUPPORTS_PARALLEL_JOBS
12: Performing Test HIP_CLANG_SUPPORTS_PARALLEL_JOBS - Success
12: Found PkgConfig: /usr/bin/pkg-config (found version "0.29.2")
12: Checking for module 'libavcodec'
12:   Found libavcodec, version 58.134.100
12: Checking for module 'libavformat'
12:   Found libavformat, version 58.76.100
12: Checking for module 'libavutil'
12:   Found libavutil, version 56.70.100
12: -- Using FFMPEG --
12:     Libraries:/usr/lib/x86_64-linux-gnu/libavcodec.so;/usr/lib/x86_64-linux-gnu/libavformat.so;/usr/lib/x86_64-linux-gnu/libavutil.so
12:     Includes:/usr/include/x86_64-linux-gnu
12: Found Threads: TRUE
12: Configuring done
12: Generating done
12: Build files have been written to: /home/lakshmi/work/rocm-systems/projects/rocdecode/build/test/videoDecodeBatch
12: ======== End CMake output ======
12: Change Dir: /home/lakshmi/work/rocm-systems/projects/rocdecode/build/test/videoDecodeBatch
12:
12: Run Clean Command:/usr/bin/gmake -f Makefile clean
12: gmake[1]: Entering directory '/home/lakshmi/work/rocm-systems/projects/rocdecode/build/test/videoDecodeBatch'
12: gmake[2]: Entering directory '/home/lakshmi/work/rocm-systems/projects/rocdecode/build/test/videoDecodeBatch'
12: gmake[3]: Entering directory '/home/lakshmi/work/rocm-systems/projects/rocdecode/build/test/videoDecodeBatch'
12: gmake[3]: Leaving directory '/home/lakshmi/work/rocm-systems/projects/rocdecode/build/test/videoDecodeBatch'
12: gmake[2]: Leaving directory '/home/lakshmi/work/rocm-systems/projects/rocdecode/build/test/videoDecodeBatch'
12: gmake[1]: Leaving directory '/home/lakshmi/work/rocm-systems/projects/rocdecode/build/test/videoDecodeBatch'
12:
12: Run Build Command(s):/usr/bin/gmake -f Makefile && gmake[1]: Entering directory '/home/lakshmi/work/rocm-systems/projects/rocdecode/build/test/videoDecodeBatch'
12: gmake[2]: Entering directory '/home/lakshmi/work/rocm-systems/projects/rocdecode/build/test/videoDecodeBatch'
12: gmake[3]: Entering directory '/home/lakshmi/work/rocm-systems/projects/rocdecode/build/test/videoDecodeBatch'
12: gmake[3]: Leaving directory '/home/lakshmi/work/rocm-systems/projects/rocdecode/build/test/videoDecodeBatch'
12: gmake[3]: Entering directory '/home/lakshmi/work/rocm-systems/projects/rocdecode/build/test/videoDecodeBatch'
12: [ 33%] Building CXX object CMakeFiles/videodecodebatch.dir/videodecodebatch.cpp.o
12: [ 66%] Building CXX object CMakeFiles/videodecodebatch.dir/opt/rocm/share/rocdecode/utils/rocvideodecode/roc_video_dec.cpp.o
12: [100%] Linking CXX executable videodecodebatch
12: gmake[3]: Leaving directory '/home/lakshmi/work/rocm-systems/projects/rocdecode/build/test/videoDecodeBatch'
12: [100%] Built target videodecodebatch
12: gmake[2]: Leaving directory '/home/lakshmi/work/rocm-systems/projects/rocdecode/build/test/videoDecodeBatch'
12: gmake[1]: Leaving directory '/home/lakshmi/work/rocm-systems/projects/rocdecode/build/test/videoDecodeBatch'
12:
12: Running test command: "/home/lakshmi/work/rocm-systems/projects/rocdecode/build/test/videoDecodeBatch/videodecodebatch" "-i" "/opt/rocm/share/rocdecode/video/" "-t" "2"
12: info: Number of threads: 2
12: info: decoding AMD_driving_virtual_20-AV1.mp4 using GPU device 0 - Radeon RX 7900 XT[gfx1100] on PCI bus 03:00.0
12: info: decoding AMD_driving_virtual_20-H264.264 using GPU device 0 - Radeon RX 7900 XT[gfx1100] on PCI bus 03:00.0
12: Input Video Information
12:     Codec        : AV1
12:     Sequence     : Progressive
12:     Coded size   : [2048, 1024]
12:     Display area : [0, 0, 2048, 1024]
12:     Chroma       : YUV 420
12:     Bit depth    : 8
12: Video Decoding Params:
12:     Num Surfaces : 12
12:     Crop         : [0, 0, 2048, 1024]
12:     Resize       : 2048x1024
12:
12: Input Video Information
12:     Codec        : AVC/H.264
12:     Frame rate   : 60000/2002 = 29.97 fps
12:     Sequence     : Progressive
12:     Coded size   : [2048, 1024]
12:     Display area : [0, 0, 2048, 1024]
12:     Chroma       : YUV 420
12:     Bit depth    : 8
12: Video Decoding Params:
12:     Num Surfaces : 7
12:     Crop         : [0, 0, 2048, 1024]
12:     Resize       : 2048x1024
12:
12: info: decoding AMD_driving_virtual_20-AV1.ivf using GPU device 0 - Radeon RX 7900 XT[gfx1100] on PCI bus 03:00.0
12: info: decoding AMD_driving_virtual_20-H265.265 using GPU device 0 - Radeon RX 7900 XT[gfx1100] on PCI bus 03:00.0
12: Input Video Information
12:     Codec        : H.265/HEVC
12:     Frame rate   : 30000/1001 = 29.97 fps
12:     Sequence     : Progressive
12:     Coded size   : [2048, 1024]
12:     Display area : [0, 0, 2048, 1024]
12:     Chroma       : YUV 420
12:     Bit depth    : 8
12: Video Decoding Params:
12:     Num Surfaces : 7
12:     Crop         : [0, 0, 2048, 1024]
12:     Resize       : 2048x1024
12:
12: info: decoding AMD_driving_virtual_20-H265.mp4 using GPU device 0 - Radeon RX 7900 XT[gfx1100] on PCI bus 03:00.0
12: info: decoding AMD_driving_virtual_20-H264.mp4 using GPU device 0 - Radeon RX 7900 XT[gfx1100] on PCI bus 03:00.0
12: Input Video Information
12:     Codec        : AVC/H.264
12:     Frame rate   : 60000/2002 = 29.97 fps
12:     Sequence     : Progressive
12:     Coded size   : [2048, 1024]
12:     Display area : [0, 0, 2048, 1024]
12:     Chroma       : YUV 420
12:     Bit depth    : 8
12: Video Decoding Params:
12:     Num Surfaces : 7
12:     Crop         : [0, 0, 2048, 1024]
12:     Resize       : 2048x1024
12:
12: Input Video Information
12:     Codec        : H.265/HEVC
12:     Frame rate   : 30000/1001 = 29.97 fps
12:     Sequence     : Progressive
12:     Coded size   : [2048, 1024]
12:     Display area : [0, 0, 2048, 1024]
12:     Chroma       : YUV 420
12:     Bit depth    : 8
12: Video Decoding Params:
12:     Num Surfaces : 7
12:     Crop         : [0, 0, 2048, 1024]
12:     Resize       : 2048x1024
12:
12: info: decoding AMD_driving_virtual_20-VP9.ivf using GPU device 0 - Radeon RX 7900 XT[gfx1100] on PCI bus 03:00.0
12: Input Video Information
12:     Codec        : VP9
12:     Sequence     : Progressive
12:     Coded size   : [2048, 1024]
12:     Display area : [0, 0, 2048, 1024]
12:     Chroma       : YUV 420
12:     Bit depth    : 8
12: Video Decoding Params:
12:     Num Surfaces : 12
12:     Crop         : [0, 0, 2048, 1024]
12:     Resize       : 2048x1024
12:
12: info: Total frame decoded: 4207
12: info: avg decoding time per frame: 0.471176 ms
12: info: avg FPS: 2122.35
12:
12/15 Test #12: video_decodeBatch ................   Passed    7.28 sec
test 13
      Start 13: video_decodeRGB-HEVC

13: Test command: /usr/local/bin/ctest "--build-and-test" "/opt/rocm/share/rocdecode/samples/videoDecodeRGB" "/home/lakshmi/work/rocm-systems/projects/rocdecode/build/test/videoDecodeRGB" "--build-generator" "Unix Makefiles" "--test-command" "videodecodergb" "-i" "/opt/rocm/share/rocdecode/video/AMD_driving_virtual_20-H265.mp4" "-of" "rgb"
13: Working Directory: /home/lakshmi/work/rocm-systems/projects/rocdecode/build/test
13: Test timeout computed to be: 1500
13: Internal cmake changing into directory: /home/lakshmi/work/rocm-systems/projects/rocdecode/build/test/videoDecodeRGB
13: ======== CMake output     ======
13: The C compiler identification is Clang 22.0.0
13: The CXX compiler identification is Clang 22.0.0
13: Detecting C compiler ABI info
13: Detecting C compiler ABI info - done
13: Check for working C compiler: /opt/rocm/lib/llvm/bin/amdclang - skipped
13: Detecting C compile features
13: Detecting C compile features - done
13: Detecting CXX compiler ABI info
13: Detecting CXX compiler ABI info - done
13: Check for working CXX compiler: /opt/rocm/lib/llvm/bin/amdclang++ - skipped
13: Detecting CXX compile features
13: Detecting CXX compile features - done
13: -- videodecodergb -- AMD GPU_TARGETS: gfx908;gfx90a;gfx942;gfx1030;gfx1031;gfx1032;gfx1100;gfx1101;gfx1102;gfx950;gfx1151;gfx1200;gfx1201
13: Performing Test HIP_CLANG_SUPPORTS_PARALLEL_JOBS
13: Performing Test HIP_CLANG_SUPPORTS_PARALLEL_JOBS - Success
13: Found PkgConfig: /usr/bin/pkg-config (found version "0.29.2")
13: Checking for module 'libavcodec'
13:   Found libavcodec, version 58.134.100
13: Checking for module 'libavformat'
13:   Found libavformat, version 58.76.100
13: Checking for module 'libavutil'
13:   Found libavutil, version 56.70.100
13: -- Using FFMPEG --
13:     Libraries:/usr/lib/x86_64-linux-gnu/libavcodec.so;/usr/lib/x86_64-linux-gnu/libavformat.so;/usr/lib/x86_64-linux-gnu/libavutil.so
13:     Includes:/usr/include/x86_64-linux-gnu
13: Found Threads: TRUE
13: Configuring done
13: Generating done
13: Build files have been written to: /home/lakshmi/work/rocm-systems/projects/rocdecode/build/test/videoDecodeRGB
13: ======== End CMake output ======
13: Change Dir: /home/lakshmi/work/rocm-systems/projects/rocdecode/build/test/videoDecodeRGB
13:
13: Run Clean Command:/usr/bin/gmake -f Makefile clean
13: gmake[1]: Entering directory '/home/lakshmi/work/rocm-systems/projects/rocdecode/build/test/videoDecodeRGB'
13: gmake[2]: Entering directory '/home/lakshmi/work/rocm-systems/projects/rocdecode/build/test/videoDecodeRGB'
13: gmake[3]: Entering directory '/home/lakshmi/work/rocm-systems/projects/rocdecode/build/test/videoDecodeRGB'
13: gmake[3]: Leaving directory '/home/lakshmi/work/rocm-systems/projects/rocdecode/build/test/videoDecodeRGB'
13: gmake[2]: Leaving directory '/home/lakshmi/work/rocm-systems/projects/rocdecode/build/test/videoDecodeRGB'
13: gmake[1]: Leaving directory '/home/lakshmi/work/rocm-systems/projects/rocdecode/build/test/videoDecodeRGB'
13:
13: Run Build Command(s):/usr/bin/gmake -f Makefile && gmake[1]: Entering directory '/home/lakshmi/work/rocm-systems/projects/rocdecode/build/test/videoDecodeRGB'
13: gmake[2]: Entering directory '/home/lakshmi/work/rocm-systems/projects/rocdecode/build/test/videoDecodeRGB'
13: gmake[3]: Entering directory '/home/lakshmi/work/rocm-systems/projects/rocdecode/build/test/videoDecodeRGB'
13: gmake[3]: Leaving directory '/home/lakshmi/work/rocm-systems/projects/rocdecode/build/test/videoDecodeRGB'
13: gmake[3]: Entering directory '/home/lakshmi/work/rocm-systems/projects/rocdecode/build/test/videoDecodeRGB'
13: [ 20%] Building CXX object CMakeFiles/videodecodergb.dir/videodecrgb.cpp.o
13: [ 40%] Building CXX object CMakeFiles/videodecodergb.dir/opt/rocm/share/rocdecode/utils/rocvideodecode/roc_video_dec.cpp.o
13: [ 60%] Building CXX object CMakeFiles/videodecodergb.dir/opt/rocm/share/rocdecode/utils/colorspace_kernels.cpp.o
13: [ 80%] Building CXX object CMakeFiles/videodecodergb.dir/opt/rocm/share/rocdecode/utils/resize_kernels.cpp.o
13: [100%] Linking CXX executable videodecodergb
13: gmake[3]: Leaving directory '/home/lakshmi/work/rocm-systems/projects/rocdecode/build/test/videoDecodeRGB'
13: [100%] Built target videodecodergb
13: gmake[2]: Leaving directory '/home/lakshmi/work/rocm-systems/projects/rocdecode/build/test/videoDecodeRGB'
13: gmake[1]: Leaving directory '/home/lakshmi/work/rocm-systems/projects/rocdecode/build/test/videoDecodeRGB'
13:
13: Running test command: "/home/lakshmi/work/rocm-systems/projects/rocdecode/build/test/videoDecodeRGB/videodecodergb" "-i" "/opt/rocm/share/rocdecode/video/AMD_driving_virtual_20-H265.mp4" "-of" "rgb"
13: info: Using GPU device 0 Radeon RX 7900 XT[gfx1100] on PCI bus 03:00.0
13: info: decoding started, please wait!
13: Input Video Information
13:     Codec        : H.265/HEVC
13:     Frame rate   : 30000/1001 = 29.97 fps
13:     Sequence     : Progressive
13:     Coded size   : [2048, 1024]
13:     Display area : [0, 0, 2048, 1024]
13:     Chroma       : YUV 420
13:     Bit depth    : 8
13: Video Decoding Params:
13:     Num Surfaces : 7
13:     Crop         : [0, 0, 2048, 1024]
13:     Resize       : 2048x1024
13:
13: info: Total frame decoded: 601
13: info: avg decoding and post processing time per frame (ms): 1.05336
13: info: avg FPS: 949.346
13:
13/15 Test #13: video_decodeRGB-HEVC .............   Passed   76.27 sec
test 14
      Start 14: video_decodeMem-HEVC

14: Test command: /usr/local/bin/ctest "--build-and-test" "/opt/rocm/share/rocdecode/samples/videoDecodeMem" "/home/lakshmi/work/rocm-systems/projects/rocdecode/build/test/videoDecodeMem" "--build-generator" "Unix Makefiles" "--test-command" "videodecodemem" "-i" "/opt/rocm/share/rocdecode/video/AMD_driving_virtual_20-H265.mp4"
14: Working Directory: /home/lakshmi/work/rocm-systems/projects/rocdecode/build/test
14: Test timeout computed to be: 1500
14: Internal cmake changing into directory: /home/lakshmi/work/rocm-systems/projects/rocdecode/build/test/videoDecodeMem
14: ======== CMake output     ======
14: The C compiler identification is Clang 22.0.0
14: The CXX compiler identification is Clang 22.0.0
14: Detecting C compiler ABI info
14: Detecting C compiler ABI info - done
14: Check for working C compiler: /opt/rocm/lib/llvm/bin/amdclang - skipped
14: Detecting C compile features
14: Detecting C compile features - done
14: Detecting CXX compiler ABI info
14: Detecting CXX compiler ABI info - done
14: Check for working CXX compiler: /opt/rocm/lib/llvm/bin/amdclang++ - skipped
14: Detecting CXX compile features
14: Detecting CXX compile features - done
14: Performing Test HIP_CLANG_SUPPORTS_PARALLEL_JOBS
14: Performing Test HIP_CLANG_SUPPORTS_PARALLEL_JOBS - Success
14: Found PkgConfig: /usr/bin/pkg-config (found version "0.29.2")
14: Checking for module 'libavcodec'
14:   Found libavcodec, version 58.134.100
14: Checking for module 'libavformat'
14:   Found libavformat, version 58.76.100
14: Checking for module 'libavutil'
14:   Found libavutil, version 56.70.100
14: -- Using FFMPEG --
14:     Libraries:/usr/lib/x86_64-linux-gnu/libavcodec.so;/usr/lib/x86_64-linux-gnu/libavformat.so;/usr/lib/x86_64-linux-gnu/libavutil.so
14:     Includes:/usr/include/x86_64-linux-gnu
14: Configuring done
14: Generating done
14: Build files have been written to: /home/lakshmi/work/rocm-systems/projects/rocdecode/build/test/videoDecodeMem
14: ======== End CMake output ======
14: Change Dir: /home/lakshmi/work/rocm-systems/projects/rocdecode/build/test/videoDecodeMem
14:
14: Run Clean Command:/usr/bin/gmake -f Makefile clean
14: gmake[1]: Entering directory '/home/lakshmi/work/rocm-systems/projects/rocdecode/build/test/videoDecodeMem'
14: gmake[2]: Entering directory '/home/lakshmi/work/rocm-systems/projects/rocdecode/build/test/videoDecodeMem'
14: gmake[3]: Entering directory '/home/lakshmi/work/rocm-systems/projects/rocdecode/build/test/videoDecodeMem'
14: gmake[3]: Leaving directory '/home/lakshmi/work/rocm-systems/projects/rocdecode/build/test/videoDecodeMem'
14: gmake[2]: Leaving directory '/home/lakshmi/work/rocm-systems/projects/rocdecode/build/test/videoDecodeMem'
14: gmake[1]: Leaving directory '/home/lakshmi/work/rocm-systems/projects/rocdecode/build/test/videoDecodeMem'
14:
14: Run Build Command(s):/usr/bin/gmake -f Makefile && gmake[1]: Entering directory '/home/lakshmi/work/rocm-systems/projects/rocdecode/build/test/videoDecodeMem'
14: gmake[2]: Entering directory '/home/lakshmi/work/rocm-systems/projects/rocdecode/build/test/videoDecodeMem'
14: gmake[3]: Entering directory '/home/lakshmi/work/rocm-systems/projects/rocdecode/build/test/videoDecodeMem'
14: gmake[3]: Leaving directory '/home/lakshmi/work/rocm-systems/projects/rocdecode/build/test/videoDecodeMem'
14: gmake[3]: Entering directory '/home/lakshmi/work/rocm-systems/projects/rocdecode/build/test/videoDecodeMem'
14: [ 33%] Building CXX object CMakeFiles/videodecodemem.dir/videodecodemem.cpp.o
14: [ 66%] Building CXX object CMakeFiles/videodecodemem.dir/opt/rocm/share/rocdecode/utils/rocvideodecode/roc_video_dec.cpp.o
14: [100%] Linking CXX executable videodecodemem
14: gmake[3]: Leaving directory '/home/lakshmi/work/rocm-systems/projects/rocdecode/build/test/videoDecodeMem'
14: [100%] Built target videodecodemem
14: gmake[2]: Leaving directory '/home/lakshmi/work/rocm-systems/projects/rocdecode/build/test/videoDecodeMem'
14: gmake[1]: Leaving directory '/home/lakshmi/work/rocm-systems/projects/rocdecode/build/test/videoDecodeMem'
14:
14: Running test command: "/home/lakshmi/work/rocm-systems/projects/rocdecode/build/test/videoDecodeMem/videodecodemem" "-i" "/opt/rocm/share/rocdecode/video/AMD_driving_virtual_20-H265.mp4"
14: info: Using GPU device 0 - Radeon RX 7900 XT[gfx1100] on PCI bus 03:00.0
14: info: decoding started, please wait!
14: Input Video Information
14:     Codec        : H.265/HEVC
14:     Frame rate   : 30000/1001 = 29.97 fps
14:     Sequence     : Progressive
14:     Coded size   : [2048, 1024]
14:     Display area : [0, 0, 2048, 1024]
14:     Chroma       : YUV 420
14:     Bit depth    : 8
14: Video Decoding Params:
14:     Num Surfaces : 7
14:     Crop         : [0, 0, 2048, 1024]
14:     Resize       : 2048x1024
14:
14: info: Total frame decoded: 601
14: info: avg decoding time per frame (ms): 0.994141
14: info: avg FPS: 1005.89
14:
14/15 Test #14: video_decodeMem-HEVC .............   Passed    4.31 sec
test 15
      Start 15: video_decodeRGB-Resize

15: Test command: /usr/local/bin/ctest "--build-and-test" "/opt/rocm/share/rocdecode/samples/videoDecodeRGB" "/home/lakshmi/work/rocm-systems/projects/rocdecode/build/test/videoDecodeRGB-Resize" "--build-generator" "Unix Makefiles" "--test-command" "videodecodergb" "-i" "/opt/rocm/share/rocdecode/video/AMD_driving_virtual_20-H265.mp4" "-resize" "640x360" "-of" "rgb"
15: Working Directory: /home/lakshmi/work/rocm-systems/projects/rocdecode/build/test
15: Test timeout computed to be: 1500
15: Internal cmake changing into directory: /home/lakshmi/work/rocm-systems/projects/rocdecode/build/test/videoDecodeRGB-Resize
15: ======== CMake output     ======
15: The C compiler identification is Clang 22.0.0
15: The CXX compiler identification is Clang 22.0.0
15: Detecting C compiler ABI info
15: Detecting C compiler ABI info - done
15: Check for working C compiler: /opt/rocm/lib/llvm/bin/amdclang - skipped
15: Detecting C compile features
15: Detecting C compile features - done
15: Detecting CXX compiler ABI info
15: Detecting CXX compiler ABI info - done
15: Check for working CXX compiler: /opt/rocm/lib/llvm/bin/amdclang++ - skipped
15: Detecting CXX compile features
15: Detecting CXX compile features - done
15: -- videodecodergb -- AMD GPU_TARGETS: gfx908;gfx90a;gfx942;gfx1030;gfx1031;gfx1032;gfx1100;gfx1101;gfx1102;gfx950;gfx1151;gfx1200;gfx1201
15: Performing Test HIP_CLANG_SUPPORTS_PARALLEL_JOBS
15: Performing Test HIP_CLANG_SUPPORTS_PARALLEL_JOBS - Success
15: Found PkgConfig: /usr/bin/pkg-config (found version "0.29.2")
15: Checking for module 'libavcodec'
15:   Found libavcodec, version 58.134.100
15: Checking for module 'libavformat'
15:   Found libavformat, version 58.76.100
15: Checking for module 'libavutil'
15:   Found libavutil, version 56.70.100
15: -- Using FFMPEG --
15:     Libraries:/usr/lib/x86_64-linux-gnu/libavcodec.so;/usr/lib/x86_64-linux-gnu/libavformat.so;/usr/lib/x86_64-linux-gnu/libavutil.so
15:     Includes:/usr/include/x86_64-linux-gnu
15: Found Threads: TRUE
15: Configuring done
15: Generating done
15: Build files have been written to: /home/lakshmi/work/rocm-systems/projects/rocdecode/build/test/videoDecodeRGB-Resize
15: ======== End CMake output ======
15: Change Dir: /home/lakshmi/work/rocm-systems/projects/rocdecode/build/test/videoDecodeRGB-Resize
15:
15: Run Clean Command:/usr/bin/gmake -f Makefile clean
15: gmake[1]: Entering directory '/home/lakshmi/work/rocm-systems/projects/rocdecode/build/test/videoDecodeRGB-Resize'
15: gmake[2]: Entering directory '/home/lakshmi/work/rocm-systems/projects/rocdecode/build/test/videoDecodeRGB-Resize'
15: gmake[3]: Entering directory '/home/lakshmi/work/rocm-systems/projects/rocdecode/build/test/videoDecodeRGB-Resize'
15: gmake[3]: Leaving directory '/home/lakshmi/work/rocm-systems/projects/rocdecode/build/test/videoDecodeRGB-Resize'
15: gmake[2]: Leaving directory '/home/lakshmi/work/rocm-systems/projects/rocdecode/build/test/videoDecodeRGB-Resize'
15: gmake[1]: Leaving directory '/home/lakshmi/work/rocm-systems/projects/rocdecode/build/test/videoDecodeRGB-Resize'
15:
15: Run Build Command(s):/usr/bin/gmake -f Makefile && gmake[1]: Entering directory '/home/lakshmi/work/rocm-systems/projects/rocdecode/build/test/videoDecodeRGB-Resize'
15: gmake[2]: Entering directory '/home/lakshmi/work/rocm-systems/projects/rocdecode/build/test/videoDecodeRGB-Resize'
15: gmake[3]: Entering directory '/home/lakshmi/work/rocm-systems/projects/rocdecode/build/test/videoDecodeRGB-Resize'
15: gmake[3]: Leaving directory '/home/lakshmi/work/rocm-systems/projects/rocdecode/build/test/videoDecodeRGB-Resize'
15: gmake[3]: Entering directory '/home/lakshmi/work/rocm-systems/projects/rocdecode/build/test/videoDecodeRGB-Resize'
15: [ 20%] Building CXX object CMakeFiles/videodecodergb.dir/videodecrgb.cpp.o
15: [ 40%] Building CXX object CMakeFiles/videodecodergb.dir/opt/rocm/share/rocdecode/utils/rocvideodecode/roc_video_dec.cpp.o
15: [ 60%] Building CXX object CMakeFiles/videodecodergb.dir/opt/rocm/share/rocdecode/utils/colorspace_kernels.cpp.o
15: [ 80%] Building CXX object CMakeFiles/videodecodergb.dir/opt/rocm/share/rocdecode/utils/resize_kernels.cpp.o
15: [100%] Linking CXX executable videodecodergb
15: gmake[3]: Leaving directory '/home/lakshmi/work/rocm-systems/projects/rocdecode/build/test/videoDecodeRGB-Resize'
15: [100%] Built target videodecodergb
15: gmake[2]: Leaving directory '/home/lakshmi/work/rocm-systems/projects/rocdecode/build/test/videoDecodeRGB-Resize'
15: gmake[1]: Leaving directory '/home/lakshmi/work/rocm-systems/projects/rocdecode/build/test/videoDecodeRGB-Resize'
15:
15: Running test command: "/home/lakshmi/work/rocm-systems/projects/rocdecode/build/test/videoDecodeRGB-Resize/videodecodergb" "-i" "/opt/rocm/share/rocdecode/video/AMD_driving_virtual_20-H265.mp4" "-resize" "640x360" "-of" "rgb"
15: info: Using GPU device 0 Radeon RX 7900 XT[gfx1100] on PCI bus 03:00.0
15: info: decoding started, please wait!
15: Input Video Information
15:     Codec        : H.265/HEVC
15:     Frame rate   : 30000/1001 = 29.97 fps
15:     Sequence     : Progressive
15:     Coded size   : [2048, 1024]
15:     Display area : [0, 0, 2048, 1024]
15:     Chroma       : YUV 420
15:     Bit depth    : 8
15: Video Decoding Params:
15:     Num Surfaces : 7
15:     Crop         : [0, 0, 2048, 1024]
15:     Resize       : 2048x1024
15:
15: info: Total frame decoded: 601
15: info: avg decoding and post processing time per frame (ms): 1.04653
15: info: avg FPS: 955.537
15:
15/15 Test #15: video_decodeRGB-Resize ...........   Passed   76.57 sec

100% tests passed, 0 tests failed out of 15

Total Test time (real) = 213.18 sec
```



## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
