### PR TITLE
[ROCM-3538] Move PID check to CLI

### DIFF
--- a/projects/amdsmi/py-interface/amdsmi_interface.py
+++ b/projects/amdsmi/py-interface/amdsmi_interface.py
@@ -3056,8 +3056,16 @@ def amdsmi_get_gpu_process_list(
         )
     )
 
+    self_pid = os.getpid()
+
     result = []
     for index in range(max_processes.value):
+        pid = int(process_list[index].pid)
+
+        # Skip the amd-smi CLI process itself so it doesn't show up in output
+        if pid == self_pid:
+            continue
+    
         process_name = process_list[index].name.decode("utf-8").strip()
         if process_name == "":
             process_name = "N/A"

--- a/projects/amdsmi/rocm_smi/src/rocm_smi_kfd.cc
+++ b/projects/amdsmi/rocm_smi/src/rocm_smi_kfd.cc
@@ -478,11 +478,6 @@ int GetProcessGPUs(uint32_t pid, std::unordered_set<uint64_t> *gpu_set) {
     return RSMI_STATUS_INVALID_ARGS;
   }
 
-  // Skip amd-smi process itself
-  if (pid == static_cast<uint32_t>(getpid())) {
-    return 0;
-  }
-
   std::string proc_path = std::string(kKFDProcPathRoot) + "/" + std::to_string(pid);
 
   // Helper lambda to read GPU IDs from queues in a given base path


### PR DESCRIPTION
## Motivation

We would filter self processes for cli calls to get processes. We want to remove this and keep the check only at the CLI level.