### PR TITLE
[rocprofiler-systems] Prevent scratch-memory example from failing TheRock build

### DIFF
--- a/projects/rocprofiler-systems/examples/scratch-memory/CMakeLists.txt
+++ b/projects/rocprofiler-systems/examples/scratch-memory/CMakeLists.txt
@@ -16,51 +16,32 @@ if(ROCPROFSYS_DISABLE_EXAMPLES)
     endif()
 endif()
 
-if(NOT CMAKE_HIP_COMPILER)
-    find_program(
-        amdclangpp_EXECUTABLE
-        NAMES amdclang++
-        HINTS ${ROCM_PATH}
-        ENV ROCM_PATH
-        /opt/rocm
-        PATHS ${ROCM_PATH}
-        ENV ROCM_PATH
-        /opt/rocm
-        PATH_SUFFIXES bin llvm/bin NO_CACHE
-    )
-    mark_as_advanced(amdclangpp_EXECUTABLE)
+find_program(
+    hipcc_EXECUTABLE
+    NAMES hipcc
+    HINTS ${ROCmVersion_DIR} ${ROCM_PATH}
+    ENV ROCM_PATH
+    /opt/rocm
+    PATHS ${ROCmVersion_DIR} ${ROCM_PATH}
+    ENV ROCM_PATH
+    /opt/rocm
+    NO_CACHE
+)
+mark_as_advanced(hipcc_EXECUTABLE)
 
-    if(amdclangpp_EXECUTABLE)
-        set(CMAKE_HIP_COMPILER "${amdclangpp_EXECUTABLE}")
-    endif()
-endif()
-
-if(CMAKE_HIP_COMPILER)
-    enable_language(HIP)
-else()
-    message(WARNING "HIP compiler not found. Cannot build scratch-memory target.")
+if(NOT hipcc_EXECUTABLE)
+    message(AUTHOR_WARNING "hipcc not found. Cannot build scratch-memory target.")
     return()
 endif()
-
-foreach(_TYPE DEBUG MINSIZEREL RELEASE RELWITHDEBINFO)
-    if("${CMAKE_HIP_FLAGS_${_TYPE}}" STREQUAL "")
-        set(CMAKE_HIP_FLAGS_${_TYPE} "${CMAKE_CXX_FLAGS_${_TYPE}}")
-    endif()
-endforeach()
 
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_EXTENSIONS OFF)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
-set(CMAKE_HIP_STANDARD 17)
-set(CMAKE_HIP_EXTENSIONS OFF)
-set(CMAKE_HIP_STANDARD_REQUIRED ON)
 
-set_source_files_properties(scratch-memory.cpp PROPERTIES LANGUAGE HIP)
-add_executable(scratch-memory)
-target_sources(scratch-memory PRIVATE scratch-memory.cpp)
+add_executable(scratch-memory scratch-memory.cpp)
 target_compile_options(
     scratch-memory
-    PRIVATE -W -Wall -Wextra -Wpedantic -Wshadow -Werror
+    PRIVATE -xhip -W -Wall -Wextra -Wpedantic -Wshadow -Werror
 )
 
 find_library(
@@ -85,6 +66,8 @@ endif()
 
 find_package(Threads REQUIRED)
 target_link_libraries(scratch-memory PRIVATE Threads::Threads ${HSA_RUNTIME_LIBRARY})
+
+rocprofiler_systems_custom_compilation(COMPILER ${hipcc_EXECUTABLE} TARGET scratch-memory)
 
 if(ROCPROFSYS_INSTALL_EXAMPLES AND TARGET scratch-memory)
     install(

--- a/projects/rocprofiler-systems/examples/scratch-memory/CMakeLists.txt
+++ b/projects/rocprofiler-systems/examples/scratch-memory/CMakeLists.txt
@@ -17,7 +17,7 @@ if(ROCPROFSYS_DISABLE_EXAMPLES)
 endif()
 
 find_program(
-    hipcc_EXECUTABLE
+    HIPCC_EXECUTABLE
     NAMES hipcc
     HINTS ${ROCmVersion_DIR} ${ROCM_PATH}
     ENV ROCM_PATH
@@ -27,11 +27,20 @@ find_program(
     /opt/rocm
     NO_CACHE
 )
-mark_as_advanced(hipcc_EXECUTABLE)
+mark_as_advanced(HIPCC_EXECUTABLE)
 
-if(NOT hipcc_EXECUTABLE)
+if(NOT HIPCC_EXECUTABLE)
     message(AUTHOR_WARNING "hipcc not found. Cannot build scratch-memory target.")
     return()
+endif()
+
+if(NOT CMAKE_CXX_COMPILER_IS_HIPCC)
+    if(
+        CMAKE_CXX_COMPILER STREQUAL HIPCC_EXECUTABLE
+        OR "${CMAKE_CXX_COMPILER}" MATCHES "hipcc"
+    )
+        set(CMAKE_CXX_COMPILER_IS_HIPCC 1 CACHE BOOL "HIP compiler")
+    endif()
 endif()
 
 set(CMAKE_CXX_STANDARD 17)
@@ -41,7 +50,7 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 add_executable(scratch-memory scratch-memory.cpp)
 target_compile_options(
     scratch-memory
-    PRIVATE -xhip -W -Wall -Wextra -Wpedantic -Wshadow -Werror
+    PRIVATE -W -Wall -Wextra -Wpedantic -Wshadow -Werror
 )
 
 find_library(
@@ -67,7 +76,14 @@ endif()
 find_package(Threads REQUIRED)
 target_link_libraries(scratch-memory PRIVATE Threads::Threads ${HSA_RUNTIME_LIBRARY})
 
-rocprofiler_systems_custom_compilation(COMPILER ${hipcc_EXECUTABLE} TARGET scratch-memory)
+foreach(arch IN LISTS ROCPROFSYS_GFX_TARGETS)
+    target_compile_options(scratch-memory PRIVATE --offload-arch=${arch})
+    target_link_options(scratch-memory PUBLIC --offload-arch=${arch})
+endforeach()
+
+if(NOT CMAKE_CXX_COMPILER_IS_HIPCC)
+    rocprofiler_systems_custom_compilation(COMPILER ${HIPCC_EXECUTABLE} TARGET scratch-memory)
+endif()
 
 if(ROCPROFSYS_INSTALL_EXAMPLES AND TARGET scratch-memory)
     install(


### PR DESCRIPTION
## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

Observed a build failure due to `enable_language(HIP)` when testing on TheRock.

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

Switched to using `rocprofiler_systems_custom_compilation` (lines up with the other examples that use HIP).

## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

N/A

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

Building on TheRock
Local build to ensure no CTests broken
rocm-systems workflows

## Test Result

<!-- Briefly summarize test outcomes. -->

Building on TheRock - **PASS** (`scratch-memory` binary is present)
 - Built with `gfx110X-all`

Local build to ensure no CTests broken - **PASS**
rocm-systems workflows - **see below**

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
