### PR TITLE
[rocprofiler-compute] Migrate CSV output to database workflow

### DIFF
--- a/projects/rocprofiler-compute/CHANGELOG.md
+++ b/projects/rocprofiler-compute/CHANGELOG.md
@@ -8,6 +8,12 @@ Full documentation for ROCm Compute Profiler is available at [https://rocm.docs.
 
 ### Changed
 
+* **CSV output format migration**: The `--output-format csv` option now uses the database workflow instead of the CLI workflow.
+  * CSV output now generates a single CSV file (e.g., `rocprof_compute_<uuid>.csv`) instead of a directory with multiple files.
+  * CSV output requires rocpd profiling format (same requirement as database output): profile with `--format-rocprof-output rocpd`.
+  * The CSV file contains all metric data for programmatic analysis.
+  * The `--output-name` parameter works the same way for both CSV and database formats, specifying the base name (without extension).
+
 ### Removed
 
 ### Optimized

--- a/projects/rocprofiler-compute/docs/how-to/analyze/cli.rst
+++ b/projects/rocprofiler-compute/docs/how-to/analyze/cli.rst
@@ -549,7 +549,7 @@ format is ``stdout``.
    * This is useful for further programmatic analysis of analysis reports.
    * NOTE: This option will disable output of analysis report to terminal.
 
-Default file name ``rocprofiler_compute_<uuid>`` can be overridden using ``--output-name <name>`` analyze mode option. For ``csv`` and ``db`` formats, this specifies the base name without extension (e.g., ``--output-name my_results`` creates ``my_results.csv`` or ``my_results.db``).
+Default file name ``rocprofiler_compute_<uuid>`` can be overridden using ``--output-name <name>`` analyze mode option.
 
 .. _analysis-database:
 

--- a/projects/rocprofiler-compute/docs/how-to/analyze/cli.rst
+++ b/projects/rocprofiler-compute/docs/how-to/analyze/cli.rst
@@ -531,10 +531,16 @@ format is ``stdout``.
    * NOTE: This option will disable output of analysis report to terminal.
 
 * ``csv`` format:
-   * Generate a folder named ``rocprof_compute_<uuid>`` in the current working directory.
-   * This folder contains multiple csv files representing the data in each metric table in the analysis report.
-   * This is useful for further programmatic analysis of analysis reports.
-   * NOTE: This will print the analysis report to the terminal as well.
+   * Generate a file named ``rocprof_compute_<uuid>.csv`` in the current working directory.
+   * This file contains all metric data in a single CSV file for programmatic analysis.
+
+   .. note::
+
+      This only works when provided workload paths are created using ``--format-rocprof-output rocpd`` profile mode option.
+
+   .. note::
+
+      This option will disable output of analysis report to terminal.
 
 * ``db`` format:
    * NOTE: This only works when provided workload paths are created using ``--format-rocprof-output rocpd`` profile mode option.
@@ -543,7 +549,7 @@ format is ``stdout``.
    * This is useful for further programmatic analysis of analysis reports.
    * NOTE: This option will disable output of analysis report to terminal.
 
-Default file/folder name ``rocprofiler_compute_<uuid>`` can be overriden using ``--output-name <name>`` analyze mode option.
+Default file name ``rocprofiler_compute_<uuid>`` can be overridden using ``--output-name <name>`` analyze mode option. For ``csv`` and ``db`` formats, this specifies the base name without extension (e.g., ``--output-name my_results`` creates ``my_results.csv`` or ``my_results.db``).
 
 .. _analysis-database:
 
@@ -617,15 +623,15 @@ PyTorch Operator Analysis
 --------------------------
 
 .. warning::
-   
-   PyTorch operator analysis is currently available only in CLI mode. GUI and TUI 
+
+   PyTorch operator analysis is currently available only in CLI mode. GUI and TUI
    will provide different interfaces for operator selection and visualization.
 
-   These options require ``--experimental``. After profiling with 
-   ``--experimental --torch-trace`` (see :ref:`torch-operator-profiling`), 
-   use ``rocprof-compute --experimental analyze ...`` with 
+   These options require ``--experimental``. After profiling with
+   ``--experimental --torch-trace`` (see :ref:`torch-operator-profiling`),
+   use ``rocprof-compute --experimental analyze ...`` with
    ``--list-torch-operators`` or ``--torch-operator`` as needed.
-   
+
 
 Listing All Operators
 ^^^^^^^^^^^^^^^^^^^^^^
@@ -641,7 +647,7 @@ Display all PyTorch operators captured during profiling:
    ================================================================================
 
      1. ResNet_layer1_conv1
-     2. ResNet_layer1_bn1  
+     2. ResNet_layer1_bn1
      3. ResNet_layer4_conv2
 
    ================================================================================

--- a/projects/rocprofiler-compute/src/rocprof_compute_analyze/analysis_db.py
+++ b/projects/rocprofiler-compute/src/rocprof_compute_analyze/analysis_db.py
@@ -245,14 +245,20 @@ class db_analysis(OmniAnalyze_Base):
                 )
             )
 
-        # Create views
-        for view_stmt in get_views():
-            Database.get_session().execute(view_stmt)
-
-        # Write database
-        Database.write()
-        console_debug("Completed writing database")
-        console_warning(f"Created file: {db_name}")
+        if self.get_args().output_format == "csv":
+            output_name = db_name.replace(".db", ".csv")
+            results = Database.get_session().execute(Database.get_metric_view()).fetchall()
+            columns = Database.get_metric_view().selected_columns.keys()
+            metric_df = pd.DataFrame(results, columns=columns)
+            metric_df.to_csv(output_name, index=False)
+            console_warning(f"Created file: {output_name}")
+            Database.get_session().close()
+        else:
+            for view_stmt in get_views():
+                Database.get_session().execute(view_stmt)
+            Database.write()
+            console_debug("Completed writing database")
+            console_warning(f"Created file: {db_name}")
 
     def calc_pmc_df_data(self) -> dict[str, pd.DataFrame]:
         pmc_df_per_workload: dict[str, pd.DataFrame] = {}

--- a/projects/rocprofiler-compute/src/rocprof_compute_base.py
+++ b/projects/rocprofiler-compute/src/rocprof_compute_base.py
@@ -139,7 +139,7 @@ class RocProfCompute:
             self.__analyze_mode = "web_ui"
         elif self.__args.tui:
             self.__analyze_mode = "tui"
-        elif self.__args.output_format == "db":
+        elif self.__args.output_format in ("db", "csv"):
             self.__analyze_mode = "db"
         else:
             self.__analyze_mode = "cli"

--- a/projects/rocprofiler-compute/src/utils/analysis_orm.py
+++ b/projects/rocprofiler-compute/src/utils/analysis_orm.py
@@ -22,6 +22,7 @@
 # SOFTWARE.
 ##############################################################################el
 
+import sqlite3
 from typing import Any, Optional
 
 from sqlalchemy import (
@@ -190,13 +191,15 @@ class Metadata(Base):
 class Database:
     _session: Optional[Session] = None
     _engine: Optional[Engine] = None
+    _db_name: Optional[str] = None
 
     @classmethod
     def init(cls, db_name: str) -> str:
-        cls._engine = create_engine(f"sqlite:///{db_name}")
+        cls._engine = create_engine("sqlite:///:memory:")
         Base.metadata.create_all(cls._engine)
         cls._session = sessionmaker(bind=cls._engine)()
-        console_debug(f"SQLite database initialized with name: {db_name}")
+        cls._db_name = db_name
+        console_debug(f"SQLite database initialized in memory (target file: {db_name})")
         return db_name
 
     @classmethod
@@ -210,12 +213,43 @@ class Database:
 
         try:
             cls._session.commit()
+
+            memory_conn = cls._engine.raw_connection()
+            disk_conn = sqlite3.connect(cls._db_name)
+            memory_conn.backup(disk_conn)
+            disk_conn.close()
         except Exception as e:
             cls._session.rollback()
             console_error(f"Error writing analysis database: {e}")
         finally:
             cls._session.close()
             cls._session = None
+
+    @classmethod
+    def get_metric_view(cls) -> Select[Any]:
+        """Return the metric view query for CSV export or view creation."""
+        return (
+            select(
+                Workload.workload_id.label("workload_id"),
+                Workload.name.label("workload_name"),
+                Kernel.kernel_uuid.label("kernel_uuid"),
+                Kernel.kernel_name,
+                MetricDefinition.metric_uuid.label("metric_uuid"),
+                MetricDefinition.name.label("metric_name"),
+                MetricDefinition.metric_id,
+                MetricDefinition.description,
+                MetricDefinition.table_name,
+                MetricDefinition.sub_table_name,
+                MetricDefinition.unit,
+                MetricValue.value_uuid.label("value_uuid"),
+                MetricValue.value_name,
+                MetricValue.value,
+            )
+            .select_from(MetricDefinition)
+            .join(Workload, MetricDefinition.workload_id == Workload.workload_id)
+            .join(MetricValue, MetricDefinition.metric_uuid == MetricValue.metric_uuid)
+            .join(Kernel, MetricValue.kernel_uuid == Kernel.kernel_uuid)
+        )
 
 
 def get_views() -> list[TextClause]:
@@ -283,26 +317,7 @@ def get_views() -> list[TextClause]:
         .group_by(
             Kernel.kernel_uuid, Kernel.workload_id, Workload.name, Kernel.kernel_name
         ),
-        "metric_view": select(
-            Workload.workload_id.label("workload_id"),
-            Workload.name.label("workload_name"),
-            Kernel.kernel_uuid.label("kernel_uuid"),
-            Kernel.kernel_name,
-            MetricDefinition.metric_uuid.label("metric_uuid"),
-            MetricDefinition.name.label("metric_name"),
-            MetricDefinition.metric_id,
-            MetricDefinition.description,
-            MetricDefinition.table_name,
-            MetricDefinition.sub_table_name,
-            MetricDefinition.unit,
-            MetricValue.value_uuid.label("value_uuid"),
-            MetricValue.value_name,
-            MetricValue.value,
-        )
-        .select_from(MetricDefinition)
-        .join(Workload, MetricDefinition.workload_id == Workload.workload_id)
-        .join(MetricValue, MetricDefinition.metric_uuid == MetricValue.metric_uuid)
-        .join(Kernel, MetricValue.kernel_uuid == Kernel.kernel_uuid),
+        "metric_view": Database.get_metric_view(),
     }
 
     return [

--- a/projects/rocprofiler-compute/src/utils/tty.py
+++ b/projects/rocprofiler-compute/src/utils/tty.py
@@ -26,7 +26,6 @@
 import argparse
 import copy
 import textwrap
-from pathlib import Path
 from typing import Any, Optional, TextIO
 
 import pandas as pd
@@ -40,7 +39,6 @@ from utils.utils import (
     METRIC_ID_RE,
     convert_metric_id_to_panel_info,
     get_panel_alias,
-    get_uuid,
 )
 
 
@@ -540,7 +538,6 @@ def format_table_output(
     df: pd.DataFrame,
     table_type: str,
     runs: dict[str, Any],
-    csv_dir: Optional[Path] = None,
 ) -> str:
     """Format table for output, handling special cases and saving to files if needed."""
 
@@ -561,14 +558,6 @@ def format_table_output(
 
     if "title" in table_config and table_config["title"]:
         content += f"{table_id_str} {table_config['title']}\n"
-
-    if args.output_format == "csv" and csv_dir and csv_dir.is_dir():
-        if "title" in table_config and table_config["title"]:
-            table_id_str += f"_{table_config['title']}"
-
-        csv_filename = csv_dir / f"{table_id_str.replace(' ', '_')}.csv"
-        df.to_csv(csv_filename, index=False)
-        console_warning(f"Created file: {csv_filename}")
 
     # Only show top N kernels (as specified in --max-kernel-num)
     # in "Top Stats" section
@@ -621,7 +610,6 @@ def show_all(
     """
     comparable_columns = parser.build_comparable_columns(args.time_unit)
     raw_filter_panel_ids = profiling_config.get("filter_blocks", [])
-    csv_dir = None
 
     if isinstance(raw_filter_panel_ids, dict):
         # For backward compatibility
@@ -652,14 +640,6 @@ def show_all(
         hidden_cols = list(set(config.HIDDEN_COLUMNS_CLI) - set(args.include_cols))
     else:
         hidden_cols = config.HIDDEN_COLUMNS_CLI
-
-    if args.output_format == "csv":
-        if args.output_name:
-            csv_dir = Path(f"{args.output_name}")
-        else:
-            csv_dir = Path(f"rocprof_compute_{get_uuid()}")
-        if not csv_dir.exists():
-            csv_dir.mkdir()
 
     # Check for valid roofline data once (used to skip roofline tables in the loop)
     has_valid_roofline = any(
@@ -765,7 +745,7 @@ def show_all(
 
                 if not processed_df.empty:
                     panel_content += format_table_output(
-                        args, table_config, processed_df, table_type, runs, csv_dir
+                        args, table_config, processed_df, table_type, runs
                     )
 
         # Roofline printing is handled separately above in is_roofline_shown

--- a/projects/rocprofiler-compute/summary.md
+++ b/projects/rocprofiler-compute/summary.md
@@ -1,0 +1,319 @@
+# Implementation Summary: Migrate CSV Output to Database Workflow
+
+## Overview
+Successfully migrated CSV output generation from the CLI workflow to the database workflow.
+Instead of creating a directory with multiple CSV files, the system now generates a single
+CSV file using the database workflow's data model.
+
+## Behavioral Changes
+
+### Before:
+- `--output-format csv` → Routed to CLI workflow → Created directory with multiple CSV files
+- Each table was saved as a separate CSV file in the output directory
+- Worked with all profiling output formats
+
+### After:
+- `--output-format csv` → Routed to DB workflow → Creates single CSV file
+- CSV file has the same base name as DB file but with .csv extension
+- No .db file is created when CSV format is specified
+- Single CSV contains all metrics from the metric_view
+- **Requires rocpd profiling output format** (same as database output format)
+
+---
+
+## Files Modified
+
+### 1. src/rocprof_compute_base.py (Lines 137-145)
+**Purpose**: Route CSV format to database workflow
+
+**Change**: Modified `detect_analyze()` method
+- Changed condition from `self.__args.output_format == "db"`
+- To: `self.__args.output_format in ("db", "csv")`
+- Now both "db" and "csv" formats use the database workflow
+
+---
+
+### 2. src/utils/analysis_orm.py
+**Purpose**: Add reusable metric view query for CSV export and in-memory database support
+
+**Changes**:
+a) Added `sqlite3` import at top of file
+   - Required for backing up in-memory database to file
+
+b) Added `_db_name` class variable to Database class
+   - Stores target filename for database file
+
+c) Modified `Database.init()` to always use in-memory SQLite
+   - Changed from `sqlite:///{db_name}` to `sqlite:///:memory:`
+   - Stores db_name in `_db_name` class variable for later use
+   - Prevents file creation during CSV export
+
+d) Modified `Database.write()` to backup in-memory database to file
+   - Uses SQLite's backup API to write in-memory database to disk
+   - Only called for DB format, not CSV format
+
+e) Added new class method `get_metric_view()` (after line 219)
+   - Returns the metric view query as a SQLAlchemy Select object
+   - Query joins Workload, Kernel, MetricDefinition, and MetricValue tables
+   - Returns all metric data in a flattened format
+
+f) Updated `get_views()` function (line 312-331)
+   - Replaced duplicated query definition with call to `Database.get_metric_view()`
+   - Reduces code duplication and ensures consistency
+
+**Columns in metric_view**:
+- workload_id, workload_name
+- kernel_uuid, kernel_name
+- metric_uuid, metric_name, metric_id
+- description, table_name, sub_table_name, unit
+- value_uuid, value_name, value
+
+---
+
+### 3. src/rocprof_compute_analyze/analysis_db.py (Lines 248-273)
+**Purpose**: Write CSV file when CSV format is specified
+
+**Changes**: Added conditional output writing logic
+- **For CSV format**:
+  * Generate CSV filename: `db_name.replace(".db", ".csv")`
+  * Execute `Database.get_metric_view()` query using session.execute().fetchall()
+  * Get column names from query and create DataFrame
+  * Write DataFrame to CSV file with `metric_df.to_csv(output_name, index=False)`
+  * Close session without committing
+  * No .db file is created (database is in-memory only)
+
+- **For DB format**:
+  * Create SQL views using `get_views()`
+  * Call `Database.write()` to commit and backup in-memory database to .db file
+
+**Key insight**: Using in-memory SQLite database for both CSV and DB workflows. For CSV, we query the in-memory database directly and write to CSV. For DB, we backup the in-memory database to disk file. This prevents unwanted .db file creation during CSV export.
+
+---
+
+### 4. src/utils/tty.py
+**Purpose**: Remove CSV handling from CLI display layer
+
+**Changes**:
+a) Removed CSV directory creation logic (previously lines 656-662)
+   - No longer creates output directory for CSV files
+
+b) Removed CSV file writing logic (previously lines 565-571)
+   - No longer writes individual CSV files per table
+
+c) Removed `csv_dir` parameter from `format_table_output()` function signature
+   - Function no longer needs to know about CSV output
+
+d) Removed `csv_dir` argument from `format_table_output()` call (line 757)
+   - Cleaned up function invocation
+
+e) Removed `csv_dir = None` initialization in `show_all()` function
+   - Variable no longer needed
+
+f) Removed unused import: `from pathlib import Path`
+   - No longer needed after CSV handling removal
+
+---
+
+### 5. tests/test_profile_general.py
+**Purpose**: Add test for CSV output with rocpd profiling format
+
+**Changes**: Added new test `test_save_csv` after `test_analyze_rocpd` (after line 1355)
+
+**Test implementation**:
+- Profiles workload using rocpd format: `--format-rocprof-output rocpd`
+- Analyzes profiled data with CSV output format
+- Verifies single CSV file is created: `{output_name}.csv`
+- Validates CSV contains data (len(df.index) >= 1)
+- Checks for expected columns from metric_view:
+  * workload_name, kernel_name, metric_name, value
+- Verifies NO database file is created (no `{output_name}.db`)
+- Cleanup: Removes CSV file and workload directory
+
+**Note**: Test moved from test_analyze_commands.py because CSV output requires rocpd profiling format
+
+---
+
+### 6. tests/test_analyze_commands.py (Lines 689-726)
+**Purpose**: Remove old CSV test that used non-rocpd format
+
+**Changes**: Removed `test_save_dfs` test
+- Old test tried to use CSV output on non-rocpd profiled data
+- CSV output now requires rocpd format, so test was moved to test_profile_general.py
+
+---
+
+### 7. tests/test_metric_validation.py (Lines 116-144)
+**Purpose**: Update metric validation test for new CSV format
+
+**Changes**: Modified metric value validation logic
+
+**Old behavior**:
+- Read from multiple CSV files: `{analysis_workload_dir}/{metric['csv_file']}`
+- Each metric had its own CSV file specified in test data
+
+**New behavior**:
+- Read single CSV file: `{output_file}.csv`
+- Filter DataFrame by metric_id to find specific metrics
+- Added assertion to verify metric exists in CSV before validating value
+- Same validation logic (5% tolerance) applied to filtered data
+
+**Key change**:
+```python
+# Old:
+actual = pd.read_csv(f"{analysis_workload_dir}/{metric['csv_file']}")[
+    metric["column"]
+].values[0]
+
+# New:
+csv_file = f"{output_file}.csv"
+df = pd.read_csv(csv_file)
+metric_data = df[df['metric_id'] == metric['metric_id']]
+actual = metric_data[metric["column"]].values[0]
+```
+
+---
+
+## Technical Implementation Details
+
+### Database Session Lifecycle for CSV Output:
+1. Initialize database engine with `Database.init(db_name)` (.db extension)
+2. Populate session with ORM objects (Workload, Kernel, MetricValue, etc.)
+3. Flush session to make ORM data visible to SQL queries
+4. Query metric data directly using `Database.get_metric_view()`
+5. Write DataFrame to CSV file
+6. Close session WITHOUT commit (prevents .db file creation)
+
+**Key Insight**: The database is used as an in-memory data transformation layer,
+leveraging existing ORM models, but not persisted to disk for CSV format.
+
+### Naming Convention:
+- Input: `--output-name my_results`
+- CSV output: `my_results.csv`
+- DB output: `my_results.db`
+- Default naming: `rocprof_compute_{uuid}.csv` or `rocprof_compute_{uuid}.db`
+
+---
+
+## Benefits
+
+1. **Single CSV file** - Much easier to handle than a directory with multiple files
+2. **Consistent naming** - Same base name with different extension (.csv vs .db)
+3. **Code reuse** - CSV and DB workflows share all metric calculations and data transformations
+4. **Cleaner architecture** - CSV is now an export format, not a display concern
+5. **Better data model** - Uses ORM objects and SQL views instead of ad-hoc table formatting
+6. **No duplication** - Removed CSV-specific logic from display layer (tty.py)
+7. **Maintainability** - Single source of truth for metric data structure
+
+---
+
+## Verification
+
+All modified files pass Python syntax validation:
+✓ src/rocprof_compute_base.py
+✓ src/utils/analysis_orm.py
+✓ src/rocprof_compute_analyze/analysis_db.py
+✓ src/utils/tty.py
+✓ tests/test_analyze_commands.py
+✓ tests/test_metric_validation.py
+
+---
+
+## Usage Examples
+
+### Generate CSV output:
+```bash
+# Step 1: Profile with rocpd format (required)
+rocprof-compute profile --format-rocprof-output rocpd <application>
+
+# Step 2: Analyze and create CSV
+rocprof-compute analyze --output-format csv --path <workload_dir>
+# Creates: rocprof_compute_<uuid>.csv
+```
+
+### Generate CSV with custom name:
+```bash
+# Step 1: Profile with rocpd format (required)
+rocprof-compute profile --format-rocprof-output rocpd <application>
+
+# Step 2: Analyze with custom output name
+rocprof-compute analyze --output-format csv --output-name my_results --path <workload_dir>
+# Creates: my_results.csv
+```
+
+### Generate database (unchanged):
+```bash
+rocprof-compute analyze --output-format db --path <workload>
+# Creates: rocprof_compute_<uuid>.db
+```
+
+### Display to stdout (unchanged):
+```bash
+rocprof-compute analyze --output-format stdout --path <workload>
+# Displays to console, no files created
+```
+
+---
+
+## Migration Notes
+
+### Important Requirement
+- **CSV output now requires rocpd profiling format**
+- Profile with: `rocprof-compute profile --format-rocprof-output rocpd <application>`
+- Analyze with: `rocprof-compute analyze --output-format csv --path <workload_dir>`
+- This is the same requirement as database output format
+
+### Other Changes
+- `--output-name` parameter works the same way - it specifies the base name for the output
+- CSV output format changed: now creates a single CSV file instead of a directory with multiple files
+- Tests that relied on multiple CSV files have been updated to work with single CSV
+- The metric data structure in the CSV is now consistent with the database schema
+- No impact on profiling workflow or roofline CSV files (those are created during profiling)
+
+---
+
+---
+
+## Documentation Updates
+
+### 1. docs/how-to/analyze/cli.rst
+
+**Section**: Analysis output format (Lines 533-558)
+
+Updated CSV format documentation to reflect new behavior:
+
+**Changes**:
+- Documented single CSV file output instead of directory
+- Simplified description to focus on programmatic analysis without specifying schema details
+- Added note blocks (following RST `.. note::` convention) for:
+  * rocpd profiling format requirement
+  * Terminal output being disabled
+- Updated "Default file name" section to clarify behavior for CSV and DB formats
+- Fixed typo: "overriden" → "overridden"
+
+**Rationale**:
+- Schema details (column names) are intentionally omitted as they may change over time
+- Documentation focuses on usage and requirements rather than implementation details
+
+---
+
+## CHANGELOG Updates
+
+### CHANGELOG.md - Unreleased section
+
+**Section**: Changed
+
+**Entry Added**:
+```markdown
+* **CSV output format migration**: The `--output-format csv` option now uses the database workflow instead of the CLI workflow.
+  * CSV output now generates a single CSV file (e.g., `rocprof_compute_<uuid>.csv`) instead of a directory with multiple files.
+  * CSV output requires rocpd profiling format (same requirement as database output): profile with `--format-rocprof-output rocpd`.
+  * The CSV file contains all metric data for programmatic analysis.
+  * The `--output-name` parameter works the same way for both CSV and database formats, specifying the base name (without extension).
+```
+
+**Rationale**: Placed under "Changed" rather than "Added" because this modifies existing CSV functionality rather than introducing a new feature.
+
+---
+
+## Implementation Date
+2026-02-25

--- a/projects/rocprofiler-compute/tests/test_analyze_commands.py
+++ b/projects/rocprofiler-compute/tests/test_analyze_commands.py
@@ -685,32 +685,6 @@ def test_decimal_3(binary_handler_analyze_rocprof_compute):
         test_utils.clean_output_dir(config["cleanup"], workload_dir)
 
 
-@pytest.mark.misc
-def test_save_dfs(binary_handler_analyze_rocprof_compute):
-    output_path = test_utils.get_output_dir()
-    for dir in indirs:
-        workload_dir = test_utils.setup_workload_dir(dir)
-        code = binary_handler_analyze_rocprof_compute([
-            "analyze",
-            "--path",
-            workload_dir,
-            "--output-format",
-            "csv",
-            "--output-name",
-            output_path,
-        ])
-        assert code == 0
-
-        files_in_workload = os.listdir(output_path)
-        for file_name in files_in_workload:
-            df = pd.read_csv(output_path + "/" + file_name)
-            assert len(df.index) >= 1
-
-        shutil.rmtree(output_path)
-        test_utils.clean_output_dir(config["cleanup"], workload_dir)
-    test_utils.clean_output_dir(config["cleanup"], output_path)
-
-
 @pytest.mark.col
 def test_col_1(binary_handler_analyze_rocprof_compute):
     for dir in indirs:
@@ -1267,7 +1241,6 @@ def test_apply_filters_direct():
 @pytest.mark.misc
 def test_missing_files_scenarios(binary_handler_analyze_rocprof_compute):
     """Test scenarios with missing files to cover error paths"""
-    import shutil
     import tempfile
 
     for dir in ["tests/workloads/vcopy/MI100", "tests/workloads/vcopy/MI200"]:

--- a/projects/rocprofiler-compute/tests/test_metric_validation.py
+++ b/projects/rocprofiler-compute/tests/test_metric_validation.py
@@ -113,10 +113,11 @@ def test_validate_metrics(
             )
 
             # Check whether metric values are correct
+            output_file = f"{analysis_workload_dir}"
             code = binary_handler_analyze_rocprof_compute([
                 "analyze",
                 "--output-name",
-                f"{analysis_workload_dir}",
+                output_file,
                 "--output-format",
                 "csv",
                 "-b",
@@ -126,10 +127,18 @@ def test_validate_metrics(
             ])
             assert code == 0
 
+            # Read the single CSV file
+            csv_file = f"{output_file}.csv"
+            df = pd.read_csv(csv_file)
+
             for metric in metrics:
-                actual = pd.read_csv(f"{analysis_workload_dir}/{metric['csv_file']}")[
-                    metric["column"]
-                ].values[0]
+                # Filter the dataframe for the specific metric by metric_id
+                metric_data = df[df["metric_id"] == metric["metric_id"]]
+                assert not metric_data.empty, (
+                    f"Metric {metric['name']} ({metric['metric_id']}) not found in CSV"
+                )
+
+                actual = metric_data[metric["column"]].values[0]
                 expected_values = metric["expected_values"]
                 # 5% tolerance in checking - assert if actual matches any expected value
                 matches = [

--- a/projects/rocprofiler-compute/tests/test_profile_general.py
+++ b/projects/rocprofiler-compute/tests/test_profile_general.py
@@ -1355,6 +1355,50 @@ def test_analyze_rocpd(
     test_utils.clean_output_dir(config["cleanup"], workload_dir)
 
 
+@pytest.mark.misc
+def test_save_csv(
+    binary_handler_profile_rocprof_compute, binary_handler_analyze_rocprof_compute
+):
+    """Test CSV output format creates a single CSV file with metric data."""
+    workload_dir = test_utils.get_output_dir()
+    options = ["--device", "0", "--format-rocprof-output", "rocpd"]
+    binary_handler_profile_rocprof_compute(config, workload_dir, options)
+
+    output_name = "test_output"
+    code = binary_handler_analyze_rocprof_compute([
+        "analyze",
+        "--output-format",
+        "csv",
+        "--output-name",
+        output_name,
+        "--path",
+        workload_dir,
+    ])
+    assert code == 0
+
+    # Check that CSV file was created
+    csv_file = f"{output_name}.csv"
+    assert os.path.exists(csv_file), f"Expected CSV file {csv_file} not found"
+
+    # Verify it's a valid CSV with data
+    df = pd.read_csv(csv_file)
+    assert len(df.index) >= 1, "CSV file is empty"
+
+    # Verify expected columns from metric_view
+    expected_columns = ["workload_name", "kernel_name", "metric_name", "value"]
+    for col in expected_columns:
+        assert col in df.columns, f"Expected column '{col}' not found in CSV"
+
+    # Verify no database file was created
+    db_file = f"{output_name}.db"
+    assert not os.path.exists(db_file), "Database file should not exist for CSV format"
+
+    # Cleanup
+    if os.path.exists(csv_file):
+        os.remove(csv_file)
+    test_utils.clean_output_dir(config["cleanup"], workload_dir)
+
+
 @pytest.mark.roofline_1
 def test_roofline_workload_dir_not_set_error():
     """


### PR DESCRIPTION
## Motivation

Migrates CSV output generation from the CLI workflow to the database workflow. Instead of creating a directory with multiple CSV files, the system now generates a single CSV file using the database workflow's data model.

- [ ] `test_metric_validation.py` - Verify metric validation with new CSV format
- [ ] Remove `summary.md`
- [ ] Remove unnecessary columns from csv
- [ ] Use workload level view if per kernel metric is not required

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

- **CSV output format**: Now creates a single CSV file (e.g., `rocprof_compute_<uuid>.csv`) instead of a directory with multiple files
- **Database workflow integration**: Both `--output-format csv` and `--output-format db` now use the database workflow
- **In-memory database**: Implemented in-memory SQLite with backup to disk for DB format
- **Code cleanup**: Removed CSV handling from CLI display layer (tty.py)
- **rocpd requirement**: CSV output now requires rocpd profiling format (same as database output)

<!-- Explain the changes along with any relevant GitHub links. -->

## JIRA ID

AIPROFCOMP-213

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan

- [x] `test_save_csv` - Verify single CSV file creation with rocpd profiling
- [x] `test_analyze_rocpd` - Verify .db file backup is working
- [ ] `test_metric_validation.py` - Verify metric validation with new CSV format

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

Tests pass

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.