### PR TITLE
[clr] Fix memory leak in hipExternalMemoryGetMappedBuffer

### DIFF
--- a/projects/clr/hipamd/src/hip_memory.cpp
+++ b/projects/clr/hipamd/src/hip_memory.cpp
@@ -189,7 +189,6 @@ hipError_t hipExternalMemoryGetMappedBuffer(void** devPtr, hipExternalMemory_t e
   // Map the device memory to the user pointer
   *devPtr = reinterpret_cast<void*>(devMem->virtualAddress());
   amd::MemObjMap::AddMemObj(*devPtr, view);
-  view->retain();
 
   HIP_RETURN(hipSuccess);
 }


### PR DESCRIPTION
## Motivation

Asan detects a memory leak when running rocdecode samples that use hipImportExternalMemory / hipExternalMemoryGetMappedBuffer

## Technical Details

hipExternalMemoryGetMappedBuffer was calling retain() on the newly created object before returning it.
This causes a memory leak because the counter for the object becomes 2 but there is only one release()
call which happens when hipFree() is called. The fix is to remove the retain() call.

## JIRA ID

ROCM-3299

## Test Plan

* Local testing
* CI

## Test Result

Local Testing with Asan does not show memory leaks after this change.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
