### PR TITLE
ROCM-2957 - Workaround for Unit_Grid_Group_Sync_Positive_Basic test hang on Strix Halo

### DIFF
--- a/projects/hip-tests/catch/include/hip_test_common.hh
+++ b/projects/hip-tests/catch/include/hip_test_common.hh
@@ -304,6 +304,27 @@ static inline bool IsNavi4X() {
 #endif
 }
 
+static inline bool IsStrixHalo() {
+#if HT_NVIDIA
+  return false;
+#elif HT_AMD
+  int device = -1;
+  hipDeviceProp_t props{};
+  HIP_CHECK(hipGetDevice(&device));
+  HIP_CHECK(hipGetDeviceProperties(&props, device));
+  // Get GCN Arch Name and compare to check if it is gfx1151
+  std::string arch = std::string(props.gcnArchName);
+  if (arch.find("gfx1151") != std::string::npos) {
+    return true;
+  } else {
+    return false;
+  }
+#else
+  std::cout << "Have to be either Nvidia or AMD platform, asserting" << std::endl;
+  assert(false);
+#endif
+}
+
 // Utility Functions
 namespace HipTest {
 static inline int getDeviceCount() {

--- a/projects/hip-tests/catch/unit/cooperativeGrps/grid_group.cc
+++ b/projects/hip-tests/catch/unit/cooperativeGrps/grid_group.cc
@@ -273,8 +273,17 @@ TEST_CASE("Unit_Grid_Group_Sync_Positive_Basic") {
   }
 
   auto loops = GENERATE(2, 4, 8, 16);
-  const auto blocks = GenerateBlockDimensions();
-  const auto threads = GenerateThreadDimensions();
+  dim3 blocks;
+  dim3 threads;
+  if (IsStrixHalo()) {
+    // Launch params for this test are hardcoded as a workaround for an issue reported
+    // ROCM-2957. When fixed, please enable calls to GenerateBlock/ThreadDimensions()
+    blocks = GENERATE_COPY(dim3(5,5,5), dim3(40,1,1), dim3(1, 40, 1), dim3(1, 1, 40));
+    threads = GENERATE_COPY(dim3(64,1,1), dim3(33,3,3), dim3(64, 8, 2), dim3(16, 16, 3));
+  } else {
+    blocks = GenerateBlockDimensions();
+    threads = GenerateThreadDimensions();
+  }
   if (!CheckDimensions(device, sync_kernel, blocks, threads)) return;
   INFO("Grid dimensions: x " << blocks.x << ", y " << blocks.y << ", z " << blocks.z);
   INFO("Block dimensions: x " << threads.x << ", y " << threads.y << ", z " << threads.z);


### PR DESCRIPTION
## Motivation

https://github.com/ROCm/rocm-systems/pull/2027 had enabled launching of sync_kernel using extensive block & thread dimensions in Unit_Grid_Group_Sync_Positive_Basic testcase.
For some of those dimensions, Unit_Grid_Group_Sync_Positive_Basic hangs on Strix Halo.
The hang could be due to lower layers & would require more time to investigate & fix.
As a workaround for ROCm 7.12 this PR uses limited hardcoded set of block & thread dimensions for Strix Halo.

## Technical Details
Use limited hardcoded set of block & thread dimensions to launch  sync_kernel on Strix Halo.

## JIRA ID

ROCM-2957

## Test Plan

Verified the fix on QA shared Strix Halo machine.

## Test Result

The test is passing.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
