### PR TITLE
ROCM-22232 - Support the fp4, fp6, ocp hip headers with HIPRTC

### DIFF
--- a/projects/clr/hipamd/include/hip/amd_detail/amd_hip_fp4.h
+++ b/projects/clr/hipamd/include/hip/amd_detail/amd_hip_fp4.h
@@ -4,12 +4,8 @@
  * SPDX-License-Identifier: MIT
  */
 
-#pragma once
-
-#include "amd_hip_mx_common.h"
-#include "amd_hip_fp8.h"
-
-#include "amd_hip_ocp_host.hpp"
+#ifndef _HIP_INCLUDE_HIP_AMD_DETAIL_HIP_FP4_H_
+#define _HIP_INCLUDE_HIP_AMD_DETAIL_HIP_FP4_H_
 
 #if defined(__HIPCC_RTC__)
 #define __FP4_HOST_DEVICE__ __device__
@@ -17,15 +13,19 @@
 #else
 #define __FP4_HOST_DEVICE__ __host__ __device__
 #define __FP4_HOST_DEVICE_STATIC__ __FP4_HOST_DEVICE__ static inline
+#include "amd_hip_mx_common.h"
+#include "amd_hip_fp8.h"
+
+#include "amd_hip_ocp_host.hpp"
 #endif  // __HIPCC_RTC__
 
 typedef __hip_fp8_storage_t __hip_fp4_storage_t;
 typedef __hip_fp8_storage_t __hip_fp4x2_storage_t;
 typedef __hip_fp8x2_storage_t __hip_fp4x4_storage_t;
 
-static_assert(sizeof(__hip_fp4_storage_t[4]) == sizeof(uint32_t), "");
-static_assert(sizeof(__hip_fp4x2_storage_t[4]) == sizeof(uint32_t), "");
-static_assert(sizeof(__hip_fp4x4_storage_t[2]) == sizeof(uint32_t), "");
+static_assert(sizeof(__hip_fp4_storage_t[4]) == sizeof(__hip_uint32_t), "");
+static_assert(sizeof(__hip_fp4x2_storage_t[4]) == sizeof(__hip_uint32_t), "");
+static_assert(sizeof(__hip_fp4x4_storage_t[2]) == sizeof(__hip_uint32_t), "");
 
 enum __hip_fp4_interpretation_t {
   __HIP_E2M1 = 0,
@@ -38,7 +38,7 @@ __FP4_HOST_DEVICE_STATIC__ __hip_fp4_storage_t __hip_cvt_bfloat16raw_to_fp4(
     const __hip_bfloat16_raw x, const __hip_fp4_interpretation_t /* fp4_interpretation */,
     const enum hipRoundMode /* rounding */) {
   union {
-    uint32_t ui32;
+    __hip_uint32_t ui32;
     __hip_fp4_storage_t fp4[4];
   } u{0};
 #if HIP_ENABLE_GFX950_OCP_BUILTINS
@@ -67,7 +67,7 @@ __FP4_HOST_DEVICE_STATIC__ __hip_fp4x2_storage_t __hip_cvt_bfloat16raw2_to_fp4x2
     const __hip_bfloat162_raw x, const __hip_fp4_interpretation_t /* fp4_interpretation */,
     const enum hipRoundMode /* rounding */) {
   union {
-    uint32_t ui32;
+    __hip_uint32_t ui32;
     __hip_fp4x2_storage_t fp4x2[4];
   } u{0};
 #if HIP_ENABLE_GFX950_OCP_BUILTINS
@@ -97,7 +97,7 @@ __FP4_HOST_DEVICE_STATIC__ __hip_fp4_storage_t
 __hip_cvt_double_to_fp4(const double x, const __hip_fp4_interpretation_t /* fp4_interpretation */,
                         const enum hipRoundMode /* rounding */) {
   union {
-    uint32_t ui32;
+    __hip_uint32_t ui32;
     __hip_fp4_storage_t fp4[4];
   } u{0};
 #if HIP_ENABLE_GFX950_OCP_BUILTINS
@@ -120,7 +120,7 @@ __FP4_HOST_DEVICE_STATIC__ __hip_fp4x2_storage_t __hip_cvt_double2_to_fp4x2(
     const double2 x, const __hip_fp4_interpretation_t /* fp4_interpretation */,
     const enum hipRoundMode /* rounding */) {
   union {
-    uint32_t ui32;
+    __hip_uint32_t ui32;
     __hip_fp4x2_storage_t fp4x2[4];
   } u{0};
 #if HIP_ENABLE_GFX950_OCP_BUILTINS
@@ -146,7 +146,7 @@ __FP4_HOST_DEVICE_STATIC__ __hip_fp4_storage_t
 __hip_cvt_float_to_fp4(const float x, const __hip_fp4_interpretation_t /* fp4_interpretation */,
                        const enum hipRoundMode /* rounding */) {
   union {
-    uint32_t ui32;
+    __hip_uint32_t ui32;
     __hip_fp4_storage_t fp4[4];
   } u{0};
 #if HIP_ENABLE_GFX950_OCP_BUILTINS
@@ -168,7 +168,7 @@ __FP4_HOST_DEVICE_STATIC__ __hip_fp4x2_storage_t
 __hip_cvt_float2_to_fp4x2(const float2 x, const __hip_fp4_interpretation_t /* fp4_interpretation */,
                           const enum hipRoundMode /* rounding */) {
   union {
-    uint32_t ui32;
+    __hip_uint32_t ui32;
     __hip_fp4x2_storage_t fp4x2[4];
   } u{0};
 #if HIP_ENABLE_GFX950_OCP_BUILTINS
@@ -256,7 +256,7 @@ __FP4_HOST_DEVICE_STATIC__ __hip_fp4_storage_t __hip_cvt_halfraw_to_fp4(
     const __half_raw x, const __hip_fp4_interpretation_t /* fp4_interpretation */,
     const enum hipRoundMode /* rounding */) {
   union {
-    uint32_t ui32;
+    __hip_uint32_t ui32;
     __hip_fp4_storage_t fp4[4];
   } u{0};
 #if HIP_ENABLE_GFX950_OCP_BUILTINS
@@ -281,7 +281,7 @@ __FP4_HOST_DEVICE_STATIC__ __hip_fp4x2_storage_t __hip_cvt_halfraw2_to_fp4x2(
     const __half2_raw x, const __hip_fp4_interpretation_t /* fp4_interpretation */,
     const enum hipRoundMode /* rounding */) {
   union {
-    uint32_t ui32;
+    __hip_uint32_t ui32;
     __hip_fp4x2_storage_t fp4x2[4];
   } u{0};
 #if HIP_ENABLE_GFX950_OCP_BUILTINS
@@ -587,3 +587,5 @@ struct __hip_fp4x4_e2m1 {
   }
 #endif  // !defined(__HIP_NO_FP4_CONVERSION_OPERATORS__)
 };
+
+#endif  // _HIP_INCLUDE_HIP_AMD_DETAIL_HIP_FP4_H_

--- a/projects/clr/hipamd/include/hip/amd_detail/amd_hip_fp4.h
+++ b/projects/clr/hipamd/include/hip/amd_detail/amd_hip_fp4.h
@@ -4,12 +4,8 @@
  * SPDX-License-Identifier: MIT
  */
 
-#pragma once
-
-#include "amd_hip_mx_common.h"
-#include "amd_hip_fp8.h"
-
-#include "amd_hip_ocp_host.hpp"
+#ifndef _HIP_INCLUDE_HIP_AMD_DETAIL_HIP_FP4_H_
+#define _HIP_INCLUDE_HIP_AMD_DETAIL_HIP_FP4_H_
 
 #if defined(__HIPCC_RTC__)
 #define __FP4_HOST_DEVICE__ __device__
@@ -17,15 +13,19 @@
 #else
 #define __FP4_HOST_DEVICE__ __host__ __device__
 #define __FP4_HOST_DEVICE_STATIC__ __FP4_HOST_DEVICE__ static inline
+#include "amd_hip_mx_common.h"
+#include "amd_hip_fp8.h"
+
+#include "amd_hip_ocp_host.hpp"
 #endif  // __HIPCC_RTC__
 
 typedef __hip_fp8_storage_t __hip_fp4_storage_t;
 typedef __hip_fp8_storage_t __hip_fp4x2_storage_t;
 typedef __hip_fp8x2_storage_t __hip_fp4x4_storage_t;
 
-static_assert(sizeof(__hip_fp4_storage_t[4]) == sizeof(uint32_t), "");
-static_assert(sizeof(__hip_fp4x2_storage_t[4]) == sizeof(uint32_t), "");
-static_assert(sizeof(__hip_fp4x4_storage_t[2]) == sizeof(uint32_t), "");
+static_assert(sizeof(__hip_fp4_storage_t[4]) == sizeof(__hip_uint32_t), "");
+static_assert(sizeof(__hip_fp4x2_storage_t[4]) == sizeof(__hip_uint32_t), "");
+static_assert(sizeof(__hip_fp4x4_storage_t[2]) == sizeof(__hip_uint32_t), "");
 
 enum __hip_fp4_interpretation_t {
   __HIP_E2M1 = 0,
@@ -38,7 +38,7 @@ __FP4_HOST_DEVICE_STATIC__ __hip_fp4_storage_t __hip_cvt_bfloat16raw_to_fp4(
     const __hip_bfloat16_raw x, const __hip_fp4_interpretation_t /* fp4_interpretation */,
     const enum hipRoundMode /* rounding */) {
   union {
-    uint32_t ui32;
+    __hip_uint32_t ui32;
     __hip_fp4_storage_t fp4[4];
   } u{0};
 #if __gfx950__
@@ -56,7 +56,7 @@ __FP4_HOST_DEVICE_STATIC__ __hip_fp4x2_storage_t __hip_cvt_bfloat16raw2_to_fp4x2
     const __hip_bfloat162_raw x, const __hip_fp4_interpretation_t /* fp4_interpretation */,
     const enum hipRoundMode /* rounding */) {
   union {
-    uint32_t ui32;
+    __hip_uint32_t ui32;
     __hip_fp4x2_storage_t fp4x2[4];
   } u{0};
 #if __gfx950__
@@ -78,7 +78,7 @@ __FP4_HOST_DEVICE_STATIC__ __hip_fp4_storage_t
 __hip_cvt_double_to_fp4(const double x, const __hip_fp4_interpretation_t /* fp4_interpretation */,
                         const enum hipRoundMode /* rounding */) {
   union {
-    uint32_t ui32;
+    __hip_uint32_t ui32;
     __hip_fp4_storage_t fp4[4];
   } u{0};
 #if __gfx950__
@@ -94,7 +94,7 @@ __FP4_HOST_DEVICE_STATIC__ __hip_fp4x2_storage_t __hip_cvt_double2_to_fp4x2(
     const double2 x, const __hip_fp4_interpretation_t /* fp4_interpretation */,
     const enum hipRoundMode /* rounding */) {
   union {
-    uint32_t ui32;
+    __hip_uint32_t ui32;
     __hip_fp4x2_storage_t fp4x2[4];
   } u{0};
 #if __gfx950__
@@ -113,7 +113,7 @@ __FP4_HOST_DEVICE_STATIC__ __hip_fp4_storage_t
 __hip_cvt_float_to_fp4(const float x, const __hip_fp4_interpretation_t /* fp4_interpretation */,
                        const enum hipRoundMode /* rounding */) {
   union {
-    uint32_t ui32;
+    __hip_uint32_t ui32;
     __hip_fp4_storage_t fp4[4];
   } u{0};
 #if __gfx950__
@@ -129,7 +129,7 @@ __FP4_HOST_DEVICE_STATIC__ __hip_fp4x2_storage_t
 __hip_cvt_float2_to_fp4x2(const float2 x, const __hip_fp4_interpretation_t /* fp4_interpretation */,
                           const enum hipRoundMode /* rounding */) {
   union {
-    uint32_t ui32;
+    __hip_uint32_t ui32;
     __hip_fp4x2_storage_t fp4x2[4];
   } u{0};
 #if __gfx950__
@@ -175,7 +175,7 @@ __FP4_HOST_DEVICE_STATIC__ __hip_fp4_storage_t __hip_cvt_halfraw_to_fp4(
     const __half_raw x, const __hip_fp4_interpretation_t /* fp4_interpretation */,
     const enum hipRoundMode /* rounding */) {
   union {
-    uint32_t ui32;
+    __hip_uint32_t ui32;
     __hip_fp4_storage_t fp4[4];
   } u{0};
 #if __gfx950__
@@ -193,7 +193,7 @@ __FP4_HOST_DEVICE_STATIC__ __hip_fp4x2_storage_t __hip_cvt_halfraw2_to_fp4x2(
     const __half2_raw x, const __hip_fp4_interpretation_t /* fp4_interpretation */,
     const enum hipRoundMode /* rounding */) {
   union {
-    uint32_t ui32;
+    __hip_uint32_t ui32;
     __hip_fp4x2_storage_t fp4x2[4];
   } u{0};
 #if __gfx950__
@@ -408,3 +408,5 @@ struct __hip_fp4x4_e2m1 {
   }
 #endif  // !defined(__HIP_NO_FP4_CONVERSION_OPERATORS__)
 };
+
+#endif  // _HIP_INCLUDE_HIP_AMD_DETAIL_HIP_FP4_H_

--- a/projects/clr/hipamd/include/hip/amd_detail/amd_hip_fp6.h
+++ b/projects/clr/hipamd/include/hip/amd_detail/amd_hip_fp6.h
@@ -335,7 +335,7 @@ __FP6_HOST_DEVICE_STATIC__ __half_raw __hip_cvt_fp6_to_halfraw(
 #elif HIP_ENABLE_GFX1250_OCP_BUILTINS
   __amd_fp16x16_storage_t out{};
   __amd_fp6x16_storage_t in{};
-  in[0] = (uint32_t)x;
+  in[0] = (__hip_uint32_t)x;
   if (fp6_interpretation_t == __HIP_E2M3) {
     if (__builtin_amdgcn_is_invocable(__builtin_amdgcn_cvt_scale_pk16_f16_fp6))
       out = __builtin_amdgcn_cvt_scale_pk16_f16_fp6(in, 0x7F7Fu /* scale e8m0 = 1.0 */, 0);
@@ -545,7 +545,7 @@ struct __hip_fp6_e2m3 {
 #elif HIP_ENABLE_GFX1250_OCP_BUILTINS
     __amd_fp6x16_storage_t in{};
     __amd_bf16x16_storage_t out{};
-    in[0] = (uint32_t)__x;
+    in[0] = (__hip_uint32_t)__x;
     if (__builtin_amdgcn_is_invocable(__builtin_amdgcn_cvt_scale_pk16_bf16_fp6))
       out = __builtin_amdgcn_cvt_scale_pk16_bf16_fp6(in, 0x7F7Fu /* scale e8m0 = 1.0 */, 0);
     u.bf16 = out[0];
@@ -566,7 +566,7 @@ struct __hip_fp6_e2m3 {
 #elif HIP_ENABLE_GFX1250_OCP_BUILTINS
     __amd_fp6x16_storage_t in{};
     __amd_floatx16_storage_t out{};
-    in[0] = (uint32_t)__x;
+    in[0] = (__hip_uint32_t)__x;
     if (__builtin_amdgcn_is_invocable(__builtin_amdgcn_cvt_scale_pk16_f32_fp6))
       out = __builtin_amdgcn_cvt_scale_pk16_f32_fp6(in, 0x7F7Fu /* scale e8m0 = 1.0 */, 0);
     auto ret = out[0];
@@ -630,7 +630,7 @@ struct __hip_fp6_e3m2 {
 #elif HIP_ENABLE_GFX1250_OCP_BUILTINS
     __amd_fp6x16_storage_t in{};
     __amd_bf16x16_storage_t out{};
-    in[0] = (uint32_t)__x;
+    in[0] = (__hip_uint32_t)__x;
     if (__builtin_amdgcn_is_invocable(__builtin_amdgcn_cvt_scale_pk16_bf16_bf6))
       out = __builtin_amdgcn_cvt_scale_pk16_bf16_bf6(in, 0x7F7Fu /* scale e8m0 = 1.0 */, 0);
     u.bf16 = out[0];
@@ -651,7 +651,7 @@ struct __hip_fp6_e3m2 {
 #elif HIP_ENABLE_GFX1250_OCP_BUILTINS
     __amd_fp6x16_storage_t in{};
     __amd_floatx16_storage_t out{};
-    in[0] = (uint32_t)__x;
+    in[0] = (__hip_uint32_t)__x;
     if (__builtin_amdgcn_is_invocable(__builtin_amdgcn_cvt_scale_pk16_f32_bf6))
       out = __builtin_amdgcn_cvt_scale_pk16_f32_bf6(in, 0x7F7Fu /* scale e8m0 = 1.0 */, 0);
     auto ret = out[0];

--- a/projects/clr/hipamd/include/hip/amd_detail/amd_hip_fp6.h
+++ b/projects/clr/hipamd/include/hip/amd_detail/amd_hip_fp6.h
@@ -4,12 +4,8 @@
  * SPDX-License-Identifier: MIT
  */
 
-#pragma once
-
-#include "amd_hip_mx_common.h"
-#include "amd_hip_fp8.h"
-
-#include "amd_hip_ocp_host.hpp"
+#ifndef _HIP_INCLUDE_HIP_AMD_DETAIL_HIP_FP6_H_
+#define _HIP_INCLUDE_HIP_AMD_DETAIL_HIP_FP6_H_
 
 #if defined(__HIPCC_RTC__)
 #define __FP6_HOST_DEVICE__ __device__
@@ -17,15 +13,19 @@
 #else
 #define __FP6_HOST_DEVICE__ __host__ __device__
 #define __FP6_HOST_DEVICE_STATIC__ __FP6_HOST_DEVICE__ static inline
+#include "amd_hip_mx_common.h"
+#include "amd_hip_fp8.h"
+
+#include "amd_hip_ocp_host.hpp"
 #endif  // __HIPCC_RTC__
 
 typedef __hip_fp8_storage_t __hip_fp6_storage_t;
 typedef __hip_fp8x2_storage_t __hip_fp6x2_storage_t;
 typedef __hip_fp8x4_storage_t __hip_fp6x4_storage_t;
 
-static_assert(sizeof(__hip_fp6_storage_t[4]) == sizeof(uint32_t), "");
-static_assert(sizeof(__hip_fp6x2_storage_t[2]) == sizeof(uint32_t), "");
-static_assert(sizeof(__hip_fp6x4_storage_t[2]) == sizeof(uint64_t), "");
+static_assert(sizeof(__hip_fp6_storage_t[4]) == sizeof(__hip_uint32_t), "");
+static_assert(sizeof(__hip_fp6x2_storage_t[2]) == sizeof(__hip_uint32_t), "");
+static_assert(sizeof(__hip_fp6x4_storage_t[2]) == sizeof(__hip_uint64_t), "");
 
 enum __hip_fp6_interpretation_t {
   __HIP_E3M2 = 0, /**< FP6 E3M2 Type*/
@@ -39,7 +39,7 @@ __FP6_HOST_DEVICE_STATIC__ __hip_fp6_storage_t __hip_cvt_bfloat16raw_to_fp6(
     const __hip_bfloat16_raw x, const __hip_fp6_interpretation_t fp6_interpretation,
     const enum hipRoundMode /* rounding */) {
   union {
-    uint32_t ui32;
+    __hip_uint32_t ui32;
     __hip_fp6_storage_t fp6[4];
   } u{0};
 #if HIP_ENABLE_GFX950_OCP_BUILTINS
@@ -82,7 +82,7 @@ __FP6_HOST_DEVICE_STATIC__ __hip_fp6x2_storage_t __hip_cvt_bfloat16raw2_to_fp6x2
     const __hip_bfloat162_raw x, const __hip_fp6_interpretation_t fp6_interpretation,
     const enum hipRoundMode /* rounding */) {
   union {
-    uint32_t ui32;
+    __hip_uint32_t ui32;
     __hip_fp6x2_storage_t fp6x2[2];
   } u{0};
 #if HIP_ENABLE_GFX950_OCP_BUILTINS
@@ -132,7 +132,7 @@ __FP6_HOST_DEVICE_STATIC__ __hip_fp6_storage_t
 __hip_cvt_double_to_fp6(const double x, const __hip_fp6_interpretation_t fp6_interpretation_t,
                         const enum hipRoundMode /* rounding */) {
   union {
-    uint32_t ui32;
+    __hip_uint32_t ui32;
     __hip_fp6_storage_t fp6[4];
   } u{0};
 #if HIP_ENABLE_GFX950_OCP_BUILTINS
@@ -176,7 +176,7 @@ __FP6_HOST_DEVICE_STATIC__ __hip_fp6x2_storage_t
 __hip_cvt_double2_to_fp6x2(const double2 x, const __hip_fp6_interpretation_t fp6_interpretation_t,
                            const enum hipRoundMode /* rounding */) {
   union {
-    uint32_t ui32;
+    __hip_uint32_t ui32;
     __hip_fp6x2_storage_t fp6x2[2];
   } u{0};
 #if HIP_ENABLE_GFX950_OCP_BUILTINS
@@ -227,7 +227,7 @@ __FP6_HOST_DEVICE_STATIC__ __hip_fp6_storage_t
 __hip_cvt_float_to_fp6(const float x, const __hip_fp6_interpretation_t fp6_interpretation_t,
                        const enum hipRoundMode /* rounding */) {
   union {
-    uint32_t ui32;
+    __hip_uint32_t ui32;
     __hip_fp6_storage_t fp6[4];
   } u{0};
 #if HIP_ENABLE_GFX950_OCP_BUILTINS
@@ -270,7 +270,7 @@ __FP6_HOST_DEVICE_STATIC__ __hip_fp6x2_storage_t
 __hip_cvt_float2_to_fp6x2(const float2 x, const __hip_fp6_interpretation_t fp6_interpretation_t,
                           const enum hipRoundMode /* rounding */) {
   union {
-    uint32_t ui32;
+    __hip_uint32_t ui32;
     __hip_fp6x2_storage_t fp6x2[2];
   } u{0};
 #if HIP_ENABLE_GFX950_OCP_BUILTINS
@@ -323,7 +323,7 @@ __FP6_HOST_DEVICE_STATIC__ __half_raw __hip_cvt_fp6_to_halfraw(
 #if HIP_ENABLE_GFX950_OCP_BUILTINS
   __amd_fp16x32_storage_t out{};
   __amd_fp6x32_storage_t in{};
-  in[0] = (uint32_t)x;
+  in[0] = (__hip_uint32_t)x;
   if (fp6_interpretation_t == __HIP_E2M3) {
     if (__builtin_amdgcn_is_invocable(__builtin_amdgcn_cvt_scalef32_pk32_f16_fp6))
       out = __builtin_amdgcn_cvt_scalef32_pk32_f16_fp6(in, 1.0f);
@@ -401,7 +401,7 @@ __FP6_HOST_DEVICE_STATIC__ __hip_fp6_storage_t
 __hip_cvt_halfraw_to_fp6(const __half_raw x, const __hip_fp6_interpretation_t fp6_interpretation_t,
                          const enum hipRoundMode /* rounding */) {
   union {
-    uint32_t ui32;
+    __hip_uint32_t ui32;
     __hip_fp6_storage_t fp6[4];
   } u{0};
 #if HIP_ENABLE_GFX950_OCP_BUILTINS
@@ -445,7 +445,7 @@ __FP6_HOST_DEVICE_STATIC__ __hip_fp6x2_storage_t __hip_cvt_halfraw2_to_fp6x2(
     const __half2_raw x, const __hip_fp6_interpretation_t fp6_interpretation_t,
     const enum hipRoundMode /* rounding */) {
   union {
-    uint32_t ui32;
+    __hip_uint32_t ui32;
     __hip_fp6x2_storage_t fp6x2[2];
   } u{0};
 #if HIP_ENABLE_GFX950_OCP_BUILTINS
@@ -538,7 +538,7 @@ struct __hip_fp6_e2m3 {
 #if HIP_ENABLE_GFX950_OCP_BUILTINS
     __amd_fp6x32_storage_t in{};
     __amd_bf16x32_storage_t out{};
-    in[0] = (uint32_t)__x;
+    in[0] = (__hip_uint32_t)__x;
     if (__builtin_amdgcn_is_invocable(__builtin_amdgcn_cvt_scalef32_pk32_bf16_fp6))
       out = __builtin_amdgcn_cvt_scalef32_pk32_bf16_fp6(in, 1.0f /* scale */);
     u.bf16 = out[0];
@@ -559,7 +559,7 @@ struct __hip_fp6_e2m3 {
 #if HIP_ENABLE_GFX950_OCP_BUILTINS
     __amd_fp6x32_storage_t in{};
     __amd_floatx32_storage_t out{};
-    in[0] = (uint32_t)__x;
+    in[0] = (__hip_uint32_t)__x;
     if (__builtin_amdgcn_is_invocable(__builtin_amdgcn_cvt_scalef32_pk32_f32_fp6))
       out = __builtin_amdgcn_cvt_scalef32_pk32_f32_fp6(in, 1.0f /* scale */);
     auto ret = out[0];
@@ -623,7 +623,7 @@ struct __hip_fp6_e3m2 {
 #if HIP_ENABLE_GFX950_OCP_BUILTINS
     __amd_fp6x32_storage_t in{};
     __amd_bf16x32_storage_t out{};
-    in[0] = (uint32_t)__x;
+    in[0] = (__hip_uint32_t)__x;
     if (__builtin_amdgcn_is_invocable(__builtin_amdgcn_cvt_scalef32_pk32_bf16_bf6))
       out = __builtin_amdgcn_cvt_scalef32_pk32_bf16_bf6(in, 1.0f /* scale */);
     u.bf16 = out[0];
@@ -644,7 +644,7 @@ struct __hip_fp6_e3m2 {
 #if HIP_ENABLE_GFX950_OCP_BUILTINS
     __amd_fp6x32_storage_t in{};
     __amd_floatx32_storage_t out{};
-    in[0] = (uint32_t)__x;
+    in[0] = (__hip_uint32_t)__x;
     if (__builtin_amdgcn_is_invocable(__builtin_amdgcn_cvt_scalef32_pk32_f32_bf6))
       out = __builtin_amdgcn_cvt_scalef32_pk32_f32_bf6(in, 1.0f /* scale */);
     auto ret = out[0];
@@ -940,3 +940,5 @@ struct __hip_fp6x4_e3m2 {
   }
 #endif  // !defined(__HIP_NO_FP6_CONVERSION_OPERATORS__)
 };
+
+#endif  // _HIP_INCLUDE_HIP_AMD_DETAIL_HIP_FP6_H_

--- a/projects/clr/hipamd/include/hip/amd_detail/amd_hip_fp6.h
+++ b/projects/clr/hipamd/include/hip/amd_detail/amd_hip_fp6.h
@@ -4,12 +4,8 @@
  * SPDX-License-Identifier: MIT
  */
 
-#pragma once
-
-#include "amd_hip_mx_common.h"
-#include "amd_hip_fp8.h"
-
-#include "amd_hip_ocp_host.hpp"
+#ifndef _HIP_INCLUDE_HIP_AMD_DETAIL_HIP_FP6_H_
+#define _HIP_INCLUDE_HIP_AMD_DETAIL_HIP_FP6_H_
 
 #if defined(__HIPCC_RTC__)
 #define __FP6_HOST_DEVICE__ __device__
@@ -17,15 +13,19 @@
 #else
 #define __FP6_HOST_DEVICE__ __host__ __device__
 #define __FP6_HOST_DEVICE_STATIC__ __FP6_HOST_DEVICE__ static inline
+#include "amd_hip_mx_common.h"
+#include "amd_hip_fp8.h"
+
+#include "amd_hip_ocp_host.hpp"
 #endif  // __HIPCC_RTC__
 
 typedef __hip_fp8_storage_t __hip_fp6_storage_t;
 typedef __hip_fp8x2_storage_t __hip_fp6x2_storage_t;
 typedef __hip_fp8x4_storage_t __hip_fp6x4_storage_t;
 
-static_assert(sizeof(__hip_fp6_storage_t[4]) == sizeof(uint32_t), "");
-static_assert(sizeof(__hip_fp6x2_storage_t[2]) == sizeof(uint32_t), "");
-static_assert(sizeof(__hip_fp6x4_storage_t[2]) == sizeof(uint64_t), "");
+static_assert(sizeof(__hip_fp6_storage_t[4]) == sizeof(__hip_uint32_t), "");
+static_assert(sizeof(__hip_fp6x2_storage_t[2]) == sizeof(__hip_uint32_t), "");
+static_assert(sizeof(__hip_fp6x4_storage_t[2]) == sizeof(__hip_uint64_t), "");
 
 enum __hip_fp6_interpretation_t {
   __HIP_E3M2 = 0, /**< FP6 E3M2 Type*/
@@ -39,7 +39,7 @@ __FP6_HOST_DEVICE_STATIC__ __hip_fp6_storage_t __hip_cvt_bfloat16raw_to_fp6(
     const __hip_bfloat16_raw x, const __hip_fp6_interpretation_t fp6_interpretation,
     const enum hipRoundMode /* rounding */) {
   union {
-    uint32_t ui32;
+    __hip_uint32_t ui32;
     __hip_fp6_storage_t fp6[4];
   } u{0};
 #if __gfx950__
@@ -66,7 +66,7 @@ __FP6_HOST_DEVICE_STATIC__ __hip_fp6x2_storage_t __hip_cvt_bfloat16raw2_to_fp6x2
     const __hip_bfloat162_raw x, const __hip_fp6_interpretation_t fp6_interpretation,
     const enum hipRoundMode /* rounding */) {
   union {
-    uint32_t ui32;
+    __hip_uint32_t ui32;
     __hip_fp6x2_storage_t fp6x2[2];
   } u{0};
 #if __gfx950__
@@ -99,7 +99,7 @@ __FP6_HOST_DEVICE_STATIC__ __hip_fp6_storage_t
 __hip_cvt_double_to_fp6(const double x, const __hip_fp6_interpretation_t fp6_interpretation_t,
                         const enum hipRoundMode /* rounding */) {
   union {
-    uint32_t ui32;
+    __hip_uint32_t ui32;
     __hip_fp6_storage_t fp6[4];
   } u{0};
 #if __gfx950__
@@ -127,7 +127,7 @@ __FP6_HOST_DEVICE_STATIC__ __hip_fp6x2_storage_t
 __hip_cvt_double2_to_fp6x2(const double2 x, const __hip_fp6_interpretation_t fp6_interpretation_t,
                            const enum hipRoundMode /* rounding */) {
   union {
-    uint32_t ui32;
+    __hip_uint32_t ui32;
     __hip_fp6x2_storage_t fp6x2[2];
   } u{0};
 #if __gfx950__
@@ -160,7 +160,7 @@ __FP6_HOST_DEVICE_STATIC__ __hip_fp6_storage_t
 __hip_cvt_float_to_fp6(const float x, const __hip_fp6_interpretation_t fp6_interpretation_t,
                        const enum hipRoundMode /* rounding */) {
   union {
-    uint32_t ui32;
+    __hip_uint32_t ui32;
     __hip_fp6_storage_t fp6[4];
   } u{0};
 #if __gfx950__
@@ -187,7 +187,7 @@ __FP6_HOST_DEVICE_STATIC__ __hip_fp6x2_storage_t
 __hip_cvt_float2_to_fp6x2(const float2 x, const __hip_fp6_interpretation_t fp6_interpretation_t,
                           const enum hipRoundMode /* rounding */) {
   union {
-    uint32_t ui32;
+    __hip_uint32_t ui32;
     __hip_fp6x2_storage_t fp6x2[2];
   } u{0};
 #if __gfx950__
@@ -222,7 +222,7 @@ __FP6_HOST_DEVICE_STATIC__ __half_raw __hip_cvt_fp6_to_halfraw(
 #if __gfx950__
   __amd_fp16x32_storage_t out;
   __amd_fp6x32_storage_t in;
-  in[0] = (uint32_t)x;
+  in[0] = (__hip_uint32_t)x;
   if (fp6_interpretation_t == __HIP_E2M3)
     out = __builtin_amdgcn_cvt_scalef32_pk32_f16_fp6(in, 1.0f);
   else if (fp6_interpretation_t == __HIP_E3M2)
@@ -269,7 +269,7 @@ __FP6_HOST_DEVICE_STATIC__ __hip_fp6_storage_t
 __hip_cvt_halfraw_to_fp6(const __half_raw x, const __hip_fp6_interpretation_t fp6_interpretation_t,
                          const enum hipRoundMode /* rounding */) {
   union {
-    uint32_t ui32;
+    __hip_uint32_t ui32;
     __hip_fp6_storage_t fp6[4];
   } u{0};
 #if __gfx950__
@@ -297,7 +297,7 @@ __FP6_HOST_DEVICE_STATIC__ __hip_fp6x2_storage_t __hip_cvt_halfraw2_to_fp6x2(
     const __half2_raw x, const __hip_fp6_interpretation_t fp6_interpretation_t,
     const enum hipRoundMode /* rounding */) {
   union {
-    uint32_t ui32;
+    __hip_uint32_t ui32;
     __hip_fp6x2_storage_t fp6x2[2];
   } u{0};
 #if __gfx950__
@@ -372,7 +372,7 @@ struct __hip_fp6_e2m3 {
 #if HIP_ENABLE_GFX950_OCP_BUILTINS
     __amd_fp6x32_storage_t in;
     __amd_bf16x32_storage_t out;
-    in[0] = (uint32_t)__x;
+    in[0] = (__hip_uint32_t)__x;
     out = __builtin_amdgcn_cvt_scalef32_pk32_bf16_fp6(in, 1.0f /* scale */);
     u.bf16 = out[0];
 #else
@@ -385,7 +385,7 @@ struct __hip_fp6_e2m3 {
 #if HIP_ENABLE_GFX950_OCP_BUILTINS
     __amd_fp6x32_storage_t in;
     __amd_floatx32_storage_t out;
-    in[0] = (uint32_t)__x;
+    in[0] = (__hip_uint32_t)__x;
     out = __builtin_amdgcn_cvt_scalef32_pk32_f32_fp6(in, 1.0f /* scale */);
     auto ret = out[0];
 #else
@@ -441,7 +441,7 @@ struct __hip_fp6_e3m2 {
 #if HIP_ENABLE_GFX950_OCP_BUILTINS
     __amd_fp6x32_storage_t in;
     __amd_bf16x32_storage_t out;
-    in[0] = (uint32_t)__x;
+    in[0] = (__hip_uint32_t)__x;
     out = __builtin_amdgcn_cvt_scalef32_pk32_bf16_bf6(in, 1.0f /* scale */);
     u.bf16 = out[0];
 #else
@@ -454,7 +454,7 @@ struct __hip_fp6_e3m2 {
 #if HIP_ENABLE_GFX950_OCP_BUILTINS
     __amd_fp6x32_storage_t in;
     __amd_floatx32_storage_t out;
-    in[0] = (uint32_t)__x;
+    in[0] = (__hip_uint32_t)__x;
     out = __builtin_amdgcn_cvt_scalef32_pk32_f32_bf6(in, 1.0f /* scale */);
     auto ret = out[0];
 #else
@@ -682,3 +682,5 @@ struct __hip_fp6x4_e3m2 {
   }
 #endif  // !defined(__HIP_NO_FP6_CONVERSION_OPERATORS__)
 };
+
+#endif  // _HIP_INCLUDE_HIP_AMD_DETAIL_HIP_FP6_H_

--- a/projects/clr/hipamd/include/hip/amd_detail/amd_hip_ocp_fp.hpp
+++ b/projects/clr/hipamd/include/hip/amd_detail/amd_hip_ocp_fp.hpp
@@ -230,7 +230,7 @@ __amd_extract_fp4x2(const __amd_fp4x8_storage_t x, const size_t index) {
  * @return float embed with E8M0 in its exponent
  */
 __OCP_FP_HOST_DEVICE_STATIC__ float __amd_scale_to_float(const __amd_scale_t scale_exp) {
-  constexpr __hip_uint8_t OCP_SCALE_EXP_NAN = -128;
+  constexpr __hip_int8_t OCP_SCALE_EXP_NAN = -128;
   const __hip_uint32_t SCALE_EXP_BIAS = 127;  // OCP MX E8M0 "scale" bias
 
   // On gfx950 the "scale" operand is encoded in the exponent bits of
@@ -435,9 +435,9 @@ __OCP_FP_HOST_DEVICE_STATIC__ __amd_floatx2_storage_t __amd_cvt_fp8x2_to_floatx2
   __amd_floatx2_storage_t ret;
   if (interpret == __AMD_OCP_E4M3) {
     ret[0] =
-        to_float<float, Encoding::E4M3, false>(static_cast<__hip_uint32_t>(__amd_extract_fp8(val, 0)), 0);
+        to_float<float, Encoding::E4M3, true>(static_cast<__hip_uint32_t>(__amd_extract_fp8(val, 0)), 0);
     ret[1] =
-        to_float<float, Encoding::E4M3, false>(static_cast<__hip_uint32_t>(__amd_extract_fp8(val, 1)), 0);
+        to_float<float, Encoding::E4M3, true>(static_cast<__hip_uint32_t>(__amd_extract_fp8(val, 1)), 0);
   } else {
     ret[0] =
         to_float<float, Encoding::E5M2, true>(static_cast<__hip_uint32_t>(__amd_extract_fp8(val, 0)), 0);

--- a/projects/clr/hipamd/include/hip/amd_detail/amd_hip_ocp_fp.hpp
+++ b/projects/clr/hipamd/include/hip/amd_detail/amd_hip_ocp_fp.hpp
@@ -4,7 +4,8 @@
  * SPDX-License-Identifier: MIT
  */
 
-#pragma once
+#ifndef _HIP_INCLUDE_HIP_AMD_DETAIL_HIP_OCP_FP_HPP_
+#define _HIP_INCLUDE_HIP_AMD_DETAIL_HIP_OCP_FP_HPP_
 
 #if !defined(__HIPCC_RTC__)
 #include "amd_hip_common.h"
@@ -17,10 +18,10 @@
 #include <climits>
 #include <cstdio>
 
-static_assert(sizeof(uint8_t) * CHAR_BIT == 8);
-static_assert(sizeof(uint16_t) * CHAR_BIT == 16);
-static_assert(sizeof(uint32_t) * CHAR_BIT == 32);
-static_assert(sizeof(uint64_t) * CHAR_BIT == 64);
+static_assert(sizeof(__hip_uint8_t) * CHAR_BIT == 8);
+static_assert(sizeof(__hip_uint16_t) * CHAR_BIT == 16);
+static_assert(sizeof(__hip_uint32_t) * CHAR_BIT == 32);
+static_assert(sizeof(__hip_uint64_t) * CHAR_BIT == 64);
 #endif  // !defined(__HIPCC_RTC__)
 
 // HW Detection
@@ -117,8 +118,8 @@ __amd_create_fp8x2(const __amd_fp8_storage_t x, const __amd_fp8_storage_t y) {
  * @param y
  * @return __amd_fp4x2_storage_t
  */
-__OCP_FP_HOST_DEVICE_STATIC__ __amd_fp4x2_storage_t __amd_create_fp4x2(const uint8_t x,
-                                                                       const uint8_t y) {
+__OCP_FP_HOST_DEVICE_STATIC__ __amd_fp4x2_storage_t __amd_create_fp4x2(const __hip_uint8_t x,
+                                                                       const __hip_uint8_t y) {
   __amd_fp4x2_storage_t ret = 0;
   ret = x | (y << 4);
   return ret;
@@ -202,9 +203,9 @@ __amd_extract_fp8x2(const __amd_fp8x8_storage_t x, const size_t index) {
  *
  * @param x __amd_fp4x2_storage_t type
  * @param index 0 or 1
- * @return uint8_t populated with 4 bits of fp4 number
+ * @return __hip_uint8_t populated with 4 bits of fp4 number
  */
-__OCP_FP_HOST_DEVICE_STATIC__ uint8_t __amd_extract_fp4(const __amd_fp4x2_storage_t x,
+__OCP_FP_HOST_DEVICE_STATIC__ __hip_uint8_t __amd_extract_fp4(const __amd_fp4x2_storage_t x,
                                                         const size_t index) {
   if (index == 0) return (x & 0xFu);
   return (x >> 4);
@@ -229,18 +230,18 @@ __amd_extract_fp4x2(const __amd_fp4x8_storage_t x, const size_t index) {
  * @return float embed with E8M0 in its exponent
  */
 __OCP_FP_HOST_DEVICE_STATIC__ float __amd_scale_to_float(const __amd_scale_t scale_exp) {
-  constexpr int8_t OCP_SCALE_EXP_NAN = -128;
-  const uint32_t SCALE_EXP_BIAS = 127;  // OCP MX E8M0 "scale" bias
+  constexpr __hip_uint8_t OCP_SCALE_EXP_NAN = -128;
+  const __hip_uint32_t SCALE_EXP_BIAS = 127;  // OCP MX E8M0 "scale" bias
 
   // On gfx950 the "scale" operand is encoded in the exponent bits of
   // an IEEE-754 float - always in the form: 1.0 * 2**scale.
   const size_t SCALE_EXP_SHIFT = 23;  // IEEE-754 "float" mantissa bits
 
-  uint32_t s;
+  __hip_uint32_t s;
   if (scale_exp == OCP_SCALE_EXP_NAN)
     s = 0xff;
   else
-    s = ((uint32_t)scale_exp + SCALE_EXP_BIAS) & 0xffu;
+    s = ((__hip_uint32_t)scale_exp + SCALE_EXP_BIAS) & 0xffu;
 
   return fcbx::F32(s << SCALE_EXP_SHIFT);
 }
@@ -281,9 +282,9 @@ __OCP_FP_HOST_DEVICE_STATIC__ float __amd_cvt_fp8_to_float(
 #else  // Host
   using namespace fcbx;
   if (interpret == __AMD_OCP_E4M3) {
-    return to_float<float, Encoding::E4M3, true>(static_cast<uint32_t>(val), 0);
+    return to_float<float, Encoding::E4M3, true>(static_cast<__hip_uint32_t>(val), 0);
   } else {
-    return to_float<float, Encoding::E5M2, true>(static_cast<uint32_t>(val), 0);
+    return to_float<float, Encoding::E5M2, true>(static_cast<__hip_uint32_t>(val), 0);
   }
 #endif
 }
@@ -299,10 +300,10 @@ __OCP_FP_HOST_DEVICE_STATIC__ float __amd_cvt_fp8_to_float(
 __OCP_FP_HOST_DEVICE_STATIC__ __amd_fp8_storage_t __amd_cvt_float_to_fp8_sr(
     const float val, const __amd_fp8_interpretation_t interpret, const unsigned int seed) {
   static_assert(sizeof(float) == sizeof(__amd_fp8_storage_t[4]));
-  static_assert(sizeof(unsigned int) == sizeof(uint32_t));
+  static_assert(sizeof(unsigned int) == sizeof(__hip_uint32_t));
   union {
     unsigned int ui32;
-    uint32_t ui32t;
+    __hip_uint32_t ui32t;
     float f32;
     __amd_fp8_storage_t fp8[4];
   } u{0};
@@ -354,8 +355,8 @@ __OCP_FP_HOST_DEVICE_STATIC__ float __amd_cvt_fp8_to_float_scale(
 #else
   using namespace fcbx;
   return interpret == __AMD_OCP_E4M3
-             ? to_float<float, Encoding::E4M3Mx, true>(static_cast<uint32_t>(val), scale)
-             : to_float<float, Encoding::E5M2Mx, true>(static_cast<uint32_t>(val), scale);
+             ? to_float<float, Encoding::E4M3Mx, true>(static_cast<__hip_uint32_t>(val), scale)
+             : to_float<float, Encoding::E5M2Mx, true>(static_cast<__hip_uint32_t>(val), scale);
 #endif
 }
 
@@ -401,9 +402,9 @@ __amd_cvt_float_to_fp8_sr_scale(const float val, const __amd_fp8_interpretation_
   }
   return u.fp8[0];
 #else
-  static_assert(sizeof(uint32_t) == sizeof(unsigned int));
+  static_assert(sizeof(__hip_uint32_t) == sizeof(unsigned int));
   union u {
-    uint32_t ui32t;
+    __hip_uint32_t ui32t;
     __amd_fp8_storage_t fp8[4];
   } u{0};
   using namespace fcbx;
@@ -434,14 +435,14 @@ __OCP_FP_HOST_DEVICE_STATIC__ __amd_floatx2_storage_t __amd_cvt_fp8x2_to_floatx2
   __amd_floatx2_storage_t ret;
   if (interpret == __AMD_OCP_E4M3) {
     ret[0] =
-        to_float<float, Encoding::E4M3, true>(static_cast<uint32_t>(__amd_extract_fp8(val, 0)), 0);
+        to_float<float, Encoding::E4M3, false>(static_cast<__hip_uint32_t>(__amd_extract_fp8(val, 0)), 0);
     ret[1] =
-        to_float<float, Encoding::E4M3, true>(static_cast<uint32_t>(__amd_extract_fp8(val, 1)), 0);
+        to_float<float, Encoding::E4M3, false>(static_cast<__hip_uint32_t>(__amd_extract_fp8(val, 1)), 0);
   } else {
     ret[0] =
-        to_float<float, Encoding::E5M2, true>(static_cast<uint32_t>(__amd_extract_fp8(val, 0)), 0);
+        to_float<float, Encoding::E5M2, true>(static_cast<__hip_uint32_t>(__amd_extract_fp8(val, 0)), 0);
     ret[1] =
-        to_float<float, Encoding::E5M2, true>(static_cast<uint32_t>(__amd_extract_fp8(val, 1)), 0);
+        to_float<float, Encoding::E5M2, true>(static_cast<__hip_uint32_t>(__amd_extract_fp8(val, 1)), 0);
   }
   return ret;
 #endif
@@ -511,9 +512,9 @@ __OCP_FP_HOST_DEVICE_STATIC__ __amd_fp4x2_storage_t __amd_cvt_floatx2_to_fp4x2_s
                                                        __amd_scale_to_float(scale), 1);
   return u.fp4x2[1];
 #else
-  static_assert(sizeof(__amd_fp4x2_storage_t[4]) == sizeof(uint32_t));
+  static_assert(sizeof(__amd_fp4x2_storage_t[4]) == sizeof(__hip_uint32_t));
   union u {
-    uint32_t ui32t;
+    __hip_uint32_t ui32t;
     __amd_fp4x2_storage_t fp4x2[4];
   } u{0};
   using namespace fcbx;
@@ -671,7 +672,7 @@ __OCP_FP_HOST_DEVICE_STATIC__ __amd_fp8x2_storage_t __amd_cvt_floatx2_to_fp8x2_s
   return u.fp8x2[0];
 #else
   using namespace fcbx;
-  uint8_t l, r;
+  __hip_uint8_t l, r;
   if (interpret == __AMD_OCP_E4M3) {
     l = from_float<float, Encoding::E4M3Mx, true>(val[0], scale);
     r = from_float<float, Encoding::E4M3Mx, true>(val[1], scale);
@@ -1645,7 +1646,7 @@ __OCP_FP_HOST_DEVICE_STATIC__ __amd_fp8x2_storage_t __amd_cvt_fp16x2_to_fp8x2_sc
   return u.fp8x2[0];
 #elif HIP_ENABLE_GFX950_OCP_BUILTINS
   static_assert(sizeof(__amd_shortx2_storage_t) == sizeof(__amd_fp8x2_storage_t[2]));
-  static_assert(sizeof(uint32_t) == sizeof(__amd_fp8x2_storage_t[2]));
+  static_assert(sizeof(__hip_uint32_t) == sizeof(__amd_fp8x2_storage_t[2]));
   union {
     __amd_shortx2_storage_t shortx2;
     __amd_fp8x2_storage_t fp8x2[2];
@@ -1655,10 +1656,10 @@ __OCP_FP_HOST_DEVICE_STATIC__ __amd_fp8x2_storage_t __amd_cvt_fp16x2_to_fp8x2_sc
       : __builtin_amdgcn_cvt_scalef32_pk_bf8_f16(u.shortx2, in, __amd_scale_to_float(scale), false);
   return u.fp8x2[0];
 #else
-  static_assert(sizeof(__amd_fp8x2_storage_t[2]) == sizeof(uint32_t));
+  static_assert(sizeof(__amd_fp8x2_storage_t[2]) == sizeof(__hip_uint32_t));
   using namespace fcbx;
   union {
-    uint32_t ui32;
+    __hip_uint32_t ui32;
     __amd_fp8x2_storage_t fp8x2[2];
   } u{0};
   if (interpret == __AMD_OCP_E4M3) {
@@ -1714,7 +1715,7 @@ __OCP_FP_HOST_DEVICE_STATIC__ __amd_fp8x2_storage_t __amd_cvt_bf16x2_to_fp8x2_sc
 #else
   using namespace fcbx;
   union {
-    uint32_t ui32;
+    __hip_uint32_t ui32;
     __amd_fp8x2_storage_t fp8x2[2];
   } u{0};
   if (interpret == __AMD_OCP_E4M3) {
@@ -3858,3 +3859,5 @@ __amd_cvt_hipbf162_to_bf16x2(const __hip_bfloat162 val) {
   } u{val};
   return u.bf16;
 }
+
+#endif  // _HIP_INCLUDE_HIP_AMD_DETAIL_HIP_OCP_FP_HPP_

--- a/projects/clr/hipamd/include/hip/amd_detail/amd_hip_ocp_fp.hpp
+++ b/projects/clr/hipamd/include/hip/amd_detail/amd_hip_ocp_fp.hpp
@@ -4,7 +4,8 @@
  * SPDX-License-Identifier: MIT
  */
 
-#pragma once
+#ifndef _HIP_INCLUDE_HIP_AMD_DETAIL_HIP_OCP_FP_HPP_
+#define _HIP_INCLUDE_HIP_AMD_DETAIL_HIP_OCP_FP_HPP_
 
 #if !defined(__HIPCC_RTC__)
 #include "amd_hip_common.h"
@@ -17,10 +18,10 @@
 #include <climits>
 #include <cstdio>
 
-static_assert(sizeof(uint8_t) * CHAR_BIT == 8);
-static_assert(sizeof(uint16_t) * CHAR_BIT == 16);
-static_assert(sizeof(uint32_t) * CHAR_BIT == 32);
-static_assert(sizeof(uint64_t) * CHAR_BIT == 64);
+static_assert(sizeof(__hip_uint8_t) * CHAR_BIT == 8);
+static_assert(sizeof(__hip_uint16_t) * CHAR_BIT == 16);
+static_assert(sizeof(__hip_uint32_t) * CHAR_BIT == 32);
+static_assert(sizeof(__hip_uint64_t) * CHAR_BIT == 64);
 #endif  // !defined(__HIPCC_RTC__)
 
 // HW Detection
@@ -117,8 +118,8 @@ __amd_create_fp8x2(const __amd_fp8_storage_t x, const __amd_fp8_storage_t y) {
  * @param y
  * @return __amd_fp4x2_storage_t
  */
-__OCP_FP_HOST_DEVICE_STATIC__ __amd_fp4x2_storage_t __amd_create_fp4x2(const uint8_t x,
-                                                                       const uint8_t y) {
+__OCP_FP_HOST_DEVICE_STATIC__ __amd_fp4x2_storage_t __amd_create_fp4x2(const __hip_uint8_t x,
+                                                                       const __hip_uint8_t y) {
   __amd_fp4x2_storage_t ret = 0;
   ret = x | (y << 4);
   return ret;
@@ -202,9 +203,9 @@ __amd_extract_fp8x2(const __amd_fp8x8_storage_t x, const size_t index) {
  *
  * @param x __amd_fp4x2_storage_t type
  * @param index 0 or 1
- * @return uint8_t populated with 4 bits of fp4 number
+ * @return __hip_uint8_t populated with 4 bits of fp4 number
  */
-__OCP_FP_HOST_DEVICE_STATIC__ uint8_t __amd_extract_fp4(const __amd_fp4x2_storage_t x,
+__OCP_FP_HOST_DEVICE_STATIC__ __hip_uint8_t __amd_extract_fp4(const __amd_fp4x2_storage_t x,
                                                         const size_t index) {
   if (index == 0) return (x & 0xFu);
   return (x >> 4);
@@ -229,18 +230,18 @@ __amd_extract_fp4x2(const __amd_fp4x8_storage_t x, const size_t index) {
  * @return float embed with E8M0 in its exponent
  */
 __OCP_FP_HOST_DEVICE_STATIC__ float __amd_scale_to_float(const __amd_scale_t scale_exp) {
-  constexpr int8_t OCP_SCALE_EXP_NAN = -128;
-  const uint32_t SCALE_EXP_BIAS = 127;  // OCP MX E8M0 "scale" bias
+  constexpr __hip_uint8_t OCP_SCALE_EXP_NAN = -128;
+  const __hip_uint32_t SCALE_EXP_BIAS = 127;  // OCP MX E8M0 "scale" bias
 
   // On gfx950 the "scale" operand is encoded in the exponent bits of
   // an IEEE-754 float - always in the form: 1.0 * 2**scale.
   const size_t SCALE_EXP_SHIFT = 23;  // IEEE-754 "float" mantissa bits
 
-  uint32_t s;
+  __hip_uint32_t s;
   if (scale_exp == OCP_SCALE_EXP_NAN)
     s = 0xff;
   else
-    s = ((uint32_t)scale_exp + SCALE_EXP_BIAS) & 0xffu;
+    s = ((__hip_uint32_t)scale_exp + SCALE_EXP_BIAS) & 0xffu;
 
   return fcbx::F32(s << SCALE_EXP_SHIFT);
 }
@@ -281,9 +282,9 @@ __OCP_FP_HOST_DEVICE_STATIC__ float __amd_cvt_fp8_to_float(
 #else  // Host
   using namespace fcbx;
   if (interpret == __AMD_OCP_E4M3) {
-    return to_float<float, Encoding::E4M3, true>(static_cast<uint32_t>(val), 0);
+    return to_float<float, Encoding::E4M3, true>(static_cast<__hip_uint32_t>(val), 0);
   } else {
-    return to_float<float, Encoding::E5M2, true>(static_cast<uint32_t>(val), 0);
+    return to_float<float, Encoding::E5M2, true>(static_cast<__hip_uint32_t>(val), 0);
   }
 #endif
 }
@@ -299,10 +300,10 @@ __OCP_FP_HOST_DEVICE_STATIC__ float __amd_cvt_fp8_to_float(
 __OCP_FP_HOST_DEVICE_STATIC__ __amd_fp8_storage_t __amd_cvt_float_to_fp8_sr(
     const float val, const __amd_fp8_interpretation_t interpret, const unsigned int seed) {
   static_assert(sizeof(float) == sizeof(__amd_fp8_storage_t[4]));
-  static_assert(sizeof(unsigned int) == sizeof(uint32_t));
+  static_assert(sizeof(unsigned int) == sizeof(__hip_uint32_t));
   union {
     unsigned int ui32;
-    uint32_t ui32t;
+    __hip_uint32_t ui32t;
     float f32;
     __amd_fp8_storage_t fp8[4];
   } u{0};
@@ -355,8 +356,8 @@ __OCP_FP_HOST_DEVICE_STATIC__ float __amd_cvt_fp8_to_float_scale(
 #else
   using namespace fcbx;
   return interpret == __AMD_OCP_E4M3
-             ? to_float<float, Encoding::E4M3Mx, true>(static_cast<uint32_t>(val), scale)
-             : to_float<float, Encoding::E5M2Mx, true>(static_cast<uint32_t>(val), scale);
+             ? to_float<float, Encoding::E4M3Mx, true>(static_cast<__hip_uint32_t>(val), scale)
+             : to_float<float, Encoding::E5M2Mx, true>(static_cast<__hip_uint32_t>(val), scale);
 #endif
 }
 
@@ -402,9 +403,9 @@ __amd_cvt_float_to_fp8_sr_scale(const float val, const __amd_fp8_interpretation_
   }
   return u.fp8[0];
 #else
-  static_assert(sizeof(uint32_t) == sizeof(unsigned int));
+  static_assert(sizeof(__hip_uint32_t) == sizeof(unsigned int));
   union u {
-    uint32_t ui32t;
+    __hip_uint32_t ui32t;
     __amd_fp8_storage_t fp8[4];
   } u{0};
   using namespace fcbx;
@@ -435,14 +436,14 @@ __OCP_FP_HOST_DEVICE_STATIC__ __amd_floatx2_storage_t __amd_cvt_fp8x2_to_floatx2
   __amd_floatx2_storage_t ret;
   if (interpret == __AMD_OCP_E4M3) {
     ret[0] =
-        to_float<float, Encoding::E4M3, true>(static_cast<uint32_t>(__amd_extract_fp8(val, 0)), 0);
+        to_float<float, Encoding::E4M3, false>(static_cast<__hip_uint32_t>(__amd_extract_fp8(val, 0)), 0);
     ret[1] =
-        to_float<float, Encoding::E4M3, true>(static_cast<uint32_t>(__amd_extract_fp8(val, 1)), 0);
+        to_float<float, Encoding::E4M3, false>(static_cast<__hip_uint32_t>(__amd_extract_fp8(val, 1)), 0);
   } else {
     ret[0] =
-        to_float<float, Encoding::E5M2, true>(static_cast<uint32_t>(__amd_extract_fp8(val, 0)), 0);
+        to_float<float, Encoding::E5M2, true>(static_cast<__hip_uint32_t>(__amd_extract_fp8(val, 0)), 0);
     ret[1] =
-        to_float<float, Encoding::E5M2, true>(static_cast<uint32_t>(__amd_extract_fp8(val, 1)), 0);
+        to_float<float, Encoding::E5M2, true>(static_cast<__hip_uint32_t>(__amd_extract_fp8(val, 1)), 0);
   }
   return ret;
 #endif
@@ -512,9 +513,9 @@ __OCP_FP_HOST_DEVICE_STATIC__ __amd_fp4x2_storage_t __amd_cvt_floatx2_to_fp4x2_s
                                                        __amd_scale_to_float(scale), 1);
   return u.fp4x2[1];
 #else
-  static_assert(sizeof(__amd_fp4x2_storage_t[4]) == sizeof(uint32_t));
+  static_assert(sizeof(__amd_fp4x2_storage_t[4]) == sizeof(__hip_uint32_t));
   union u {
-    uint32_t ui32t;
+    __hip_uint32_t ui32t;
     __amd_fp4x2_storage_t fp4x2[4];
   } u{0};
   using namespace fcbx;
@@ -672,7 +673,7 @@ __OCP_FP_HOST_DEVICE_STATIC__ __amd_fp8x2_storage_t __amd_cvt_floatx2_to_fp8x2_s
   return u.fp8x2[0];
 #else
   using namespace fcbx;
-  uint8_t l, r;
+  __hip_uint8_t l, r;
   if (interpret == __AMD_OCP_E4M3) {
     l = from_float<float, Encoding::E4M3Mx, true>(val[0], scale);
     r = from_float<float, Encoding::E4M3Mx, true>(val[1], scale);
@@ -1646,7 +1647,7 @@ __OCP_FP_HOST_DEVICE_STATIC__ __amd_fp8x2_storage_t __amd_cvt_fp16x2_to_fp8x2_sc
   return u.fp8x2[0];
 #elif HIP_ENABLE_GFX950_OCP_BUILTINS
   static_assert(sizeof(__amd_shortx2_storage_t) == sizeof(__amd_fp8x2_storage_t[2]));
-  static_assert(sizeof(uint32_t) == sizeof(__amd_fp8x2_storage_t[2]));
+  static_assert(sizeof(__hip_uint32_t) == sizeof(__amd_fp8x2_storage_t[2]));
   union {
     __amd_shortx2_storage_t shortx2;
     __amd_fp8x2_storage_t fp8x2[2];
@@ -1656,10 +1657,10 @@ __OCP_FP_HOST_DEVICE_STATIC__ __amd_fp8x2_storage_t __amd_cvt_fp16x2_to_fp8x2_sc
       : __builtin_amdgcn_cvt_scalef32_pk_bf8_f16(u.shortx2, in, __amd_scale_to_float(scale), false);
   return u.fp8x2[0];
 #else
-  static_assert(sizeof(__amd_fp8x2_storage_t[2]) == sizeof(uint32_t));
+  static_assert(sizeof(__amd_fp8x2_storage_t[2]) == sizeof(__hip_uint32_t));
   using namespace fcbx;
   union {
-    uint32_t ui32;
+    __hip_uint32_t ui32;
     __amd_fp8x2_storage_t fp8x2[2];
   } u{0};
   if (interpret == __AMD_OCP_E4M3) {
@@ -1715,7 +1716,7 @@ __OCP_FP_HOST_DEVICE_STATIC__ __amd_fp8x2_storage_t __amd_cvt_bf16x2_to_fp8x2_sc
 #else
   using namespace fcbx;
   union {
-    uint32_t ui32;
+    __hip_uint32_t ui32;
     __amd_fp8x2_storage_t fp8x2[2];
   } u{0};
   if (interpret == __AMD_OCP_E4M3) {
@@ -3859,3 +3860,5 @@ __amd_cvt_hipbf162_to_bf16x2(const __hip_bfloat162 val) {
   } u{val};
   return u.bf16;
 }
+
+#endif  // _HIP_INCLUDE_HIP_AMD_DETAIL_HIP_OCP_FP_HPP_

--- a/projects/clr/hipamd/include/hip/amd_detail/amd_hip_ocp_fp_cxx.hpp
+++ b/projects/clr/hipamd/include/hip/amd_detail/amd_hip_ocp_fp_cxx.hpp
@@ -4,9 +4,12 @@
  * SPDX-License-Identifier: MIT
  */
 
-#pragma once
+#ifndef _HIP_INCLUDE_HIP_AMD_DETAIL_HIP_OCP_FP_CXX_HPP_
+#define _HIP_INCLUDE_HIP_AMD_DETAIL_HIP_OCP_FP_CXX_HPP_
 
+#if !defined(__HIPCC_RTC__)
 #include "amd_hip_ocp_host.hpp"
+#endif
 
 static_assert(sizeof(__amd_shortx2_storage_t) == sizeof(__amd_fp8x2_storage_t[2]));
 
@@ -29,7 +32,7 @@ struct __hipext_ocp_fp8_e4m3 {
     using namespace fcbx;
     static_assert(sizeof(uint32_t) == sizeof(__amd_fp8_storage_t[4]));
     union {
-      uint32_t ui32;
+      __hip_uint32_t ui32;
       __amd_fp8_storage_t fp8[4];
     } u{0};
     u.ui32 = from_float<float, Encoding::E4M3, true>(in, 0 /*scale*/);
@@ -50,7 +53,7 @@ struct __hipext_ocp_fp8_e4m3 {
     using namespace fcbx;
     static_assert(sizeof(uint32_t) == sizeof(__amd_fp8_storage_t[4]));
     union {
-      uint32_t ui32;
+      __hip_uint32_t ui32;
       __amd_fp8_storage_t fp8[4];
     } u{0};
     u.ui32 = from_float_sr<float, Encoding::E4M3, true>(in, seed, 0 /*scale*/);
@@ -73,7 +76,7 @@ struct __hipext_ocp_fp8_e4m3 {
     using namespace fcbx;
     static_assert(sizeof(uint32_t) == sizeof(__amd_fp8_storage_t[4]));
     union {
-      uint32_t ui32;
+      __hip_uint32_t ui32;
       __amd_fp8_storage_t fp8[4];
     } u{0};
     u.ui32 = from_float_sr<float, Encoding::E4M3Mx, true>(in, seed, scale);
@@ -97,7 +100,7 @@ struct __hipext_ocp_fp8_e4m3 {
     using namespace fcbx;
     static_assert(sizeof(uint32_t) == sizeof(__amd_fp8_storage_t[4]));
     union {
-      uint32_t ui32;
+      __hip_uint32_t ui32;
       __amd_fp8_storage_t fp8[4];
     } u{0};
     u.ui32 = from_float_sr<__amd_fp16_storage_t, Encoding::E4M3Mx, true>(in, seed, scale);
@@ -121,7 +124,7 @@ struct __hipext_ocp_fp8_e4m3 {
     using namespace fcbx;
     static_assert(sizeof(uint32_t) == sizeof(__amd_fp8_storage_t[4]));
     union {
-      uint32_t ui32;
+      __hip_uint32_t ui32;
       __amd_fp8_storage_t fp8[4];
     } u{0};
     u.ui32 = from_float_sr<__amd_bf16_storage_t, Encoding::E4M3Mx, true>(in, seed, scale);
@@ -195,7 +198,7 @@ struct __hipext_ocp_fp8_e5m2 {
     using namespace fcbx;
     static_assert(sizeof(uint32_t) == sizeof(__amd_fp8_storage_t[4]));
     union {
-      uint32_t ui32;
+      __hip_uint32_t ui32;
       __amd_fp8_storage_t fp8[4];
     } u{0};
     u.ui32 = from_float<float, Encoding::E5M2, true>(in, 0 /*scale*/);
@@ -216,7 +219,7 @@ struct __hipext_ocp_fp8_e5m2 {
     using namespace fcbx;
     static_assert(sizeof(uint32_t) == sizeof(__amd_fp8_storage_t[4]));
     union {
-      uint32_t ui32;
+      __hip_uint32_t ui32;
       __amd_fp8_storage_t fp8[4];
     } u{0};
     u.ui32 = from_float_sr<float, Encoding::E5M2, true>(in, seed, 0 /*scale*/);
@@ -239,7 +242,7 @@ struct __hipext_ocp_fp8_e5m2 {
     using namespace fcbx;
     static_assert(sizeof(uint32_t) == sizeof(__amd_fp8_storage_t[4]));
     union {
-      uint32_t ui32;
+      __hip_uint32_t ui32;
       __amd_fp8_storage_t fp8[4];
     } u{0};
     u.ui32 = from_float_sr<float, Encoding::E5M2Mx, true>(in, seed, scale);
@@ -263,7 +266,7 @@ struct __hipext_ocp_fp8_e5m2 {
     using namespace fcbx;
     static_assert(sizeof(uint32_t) == sizeof(__amd_fp8_storage_t[4]));
     union {
-      uint32_t ui32;
+      __hip_uint32_t ui32;
       __amd_fp8_storage_t fp8[4];
     } u{0};
     u.ui32 = from_float_sr<__amd_fp16_storage_t, Encoding::E5M2Mx, true>(in, seed, scale);
@@ -287,7 +290,7 @@ struct __hipext_ocp_fp8_e5m2 {
     using namespace fcbx;
     static_assert(sizeof(uint32_t) == sizeof(__amd_fp8_storage_t[4]));
     union {
-      uint32_t ui32;
+      __hip_uint32_t ui32;
       __amd_fp8_storage_t fp8[4];
     } u{0};
     u.ui32 = from_float_sr<__amd_bf16_storage_t, Encoding::E5M2Mx, true>(in, seed, scale);
@@ -361,7 +364,7 @@ struct __hipext_ocp_fp8x2_e4m3 {
     using namespace fcbx;
     static_assert(sizeof(uint32_t) == sizeof(__amd_fp8x2_storage_t[2]));
     union {
-      uint32_t ui32;
+      __hip_uint32_t ui32;
       __amd_fp8x2_storage_t fp8x2[2];
     } u{0};
     u.ui32 = from_float<float, Encoding::E4M3, true>(b, 0 /*scale*/);
@@ -388,7 +391,7 @@ struct __hipext_ocp_fp8x2_e4m3 {
     using namespace fcbx;
     static_assert(sizeof(uint32_t) == sizeof(__amd_fp8x2_storage_t[2]));
     union {
-      uint32_t ui32;
+      __hip_uint32_t ui32;
       __amd_fp8x2_storage_t fp8x2[2];
     } u{0};
     u.ui32 = from_float<float, Encoding::E4M3Mx, true>(b, scale);
@@ -417,7 +420,7 @@ struct __hipext_ocp_fp8x2_e4m3 {
     using namespace fcbx;
     static_assert(sizeof(uint32_t) == sizeof(__amd_fp8x2_storage_t[2]));
     union {
-      uint32_t ui32;
+      __hip_uint32_t ui32;
       __amd_fp8x2_storage_t fp8x2[2];
     } u{0};
     u.ui32 = from_float<__amd_fp16_storage_t, Encoding::E4M3Mx, true>(in[1], scale);
@@ -441,7 +444,7 @@ struct __hipext_ocp_fp8x2_e4m3 {
     using namespace fcbx;
     static_assert(sizeof(uint32_t) == sizeof(__amd_fp8x2_storage_t[2]));
     union {
-      uint32_t ui32;
+      __hip_uint32_t ui32;
       __amd_fp8x2_storage_t fp8x2[2];
     } u{0};
     u.ui32 = from_float<__amd_bf16_storage_t, Encoding::E4M3Mx, true>(in[1], scale);
@@ -533,7 +536,7 @@ struct __hipext_ocp_fp8x2_e5m2 {
     using namespace fcbx;
     static_assert(sizeof(uint32_t) == sizeof(__amd_fp8x2_storage_t[2]));
     union {
-      uint32_t ui32;
+      __hip_uint32_t ui32;
       __amd_fp8x2_storage_t fp8x2[2];
     } u{0};
     u.ui32 = from_float<float, Encoding::E5M2, true>(b, 0 /*scale*/);
@@ -560,7 +563,7 @@ struct __hipext_ocp_fp8x2_e5m2 {
     using namespace fcbx;
     static_assert(sizeof(uint32_t) == sizeof(__amd_fp8x2_storage_t[2]));
     union {
-      uint32_t ui32;
+      __hip_uint32_t ui32;
       __amd_fp8x2_storage_t fp8x2[2];
     } u{0};
     u.ui32 = from_float<float, Encoding::E5M2Mx, true>(b, scale);
@@ -588,7 +591,7 @@ struct __hipext_ocp_fp8x2_e5m2 {
     using namespace fcbx;
     static_assert(sizeof(uint32_t) == sizeof(__amd_fp8x2_storage_t[2]));
     union {
-      uint32_t ui32;
+      __hip_uint32_t ui32;
       __amd_fp8x2_storage_t fp8x2[2];
     } u{0};
     u.ui32 = from_float<__amd_fp16_storage_t, Encoding::E5M2Mx, true>(in[1], scale);
@@ -612,7 +615,7 @@ struct __hipext_ocp_fp8x2_e5m2 {
     using namespace fcbx;
     static_assert(sizeof(uint32_t) == sizeof(__amd_fp8x2_storage_t[2]));
     union {
-      uint32_t ui32;
+      __hip_uint32_t ui32;
       __amd_fp8x2_storage_t fp8x2[2];
     } u{0};
     u.ui32 = from_float<__amd_bf16_storage_t, Encoding::E5M2Mx, true>(in[1], scale);
@@ -984,9 +987,9 @@ struct __hipext_ocp_fp4x2_e2m1 {
                                                          __amd_scale_to_float(scale), 1);
     __x = u.fp4x2[1];
 #else
-    static_assert(sizeof(__amd_fp4x2_storage_t[4]) == sizeof(uint32_t));
+    static_assert(sizeof(__amd_fp4x2_storage_t[4]) == sizeof(__hip_uint32_t));
     union u {
-      uint32_t ui32t;
+      __hip_uint32_t ui32t;
       __amd_fp4x2_storage_t fp4x2[4];
     } u{0};
     using namespace fcbx;
@@ -1011,9 +1014,9 @@ struct __hipext_ocp_fp4x2_e2m1 {
                                                           __amd_scale_to_float(scale), 1);
     __x = u.fp4x2[1];
 #else
-    static_assert(sizeof(__amd_fp4x2_storage_t[4]) == sizeof(uint32_t));
+    static_assert(sizeof(__amd_fp4x2_storage_t[4]) == sizeof(__hip_uint32_t));
     union u {
-      uint32_t ui32t;
+      __hip_uint32_t ui32t;
       __amd_fp4x2_storage_t fp4x2[4];
     } u{0};
     using namespace fcbx;
@@ -1038,9 +1041,9 @@ struct __hipext_ocp_fp4x2_e2m1 {
                                                          __amd_scale_to_float(scale), 1);
     __x = u.fp4x2[1];
 #else
-    static_assert(sizeof(__amd_fp4x2_storage_t[4]) == sizeof(uint32_t));
+    static_assert(sizeof(__amd_fp4x2_storage_t[4]) == sizeof(__hip_uint32_t));
     union u {
-      uint32_t ui32t;
+      __hip_uint32_t ui32t;
       __amd_fp4x2_storage_t fp4x2[4];
     } u{0};
     using namespace fcbx;
@@ -1089,3 +1092,5 @@ struct __hipext_ocp_fp4x2_e2m1 {
 #endif
   }
 };
+
+#endif  // _HIP_INCLUDE_HIP_AMD_DETAIL_HIP_OCP_FP_CXX_HPP_

--- a/projects/clr/hipamd/include/hip/amd_detail/amd_hip_ocp_fp_cxx.hpp
+++ b/projects/clr/hipamd/include/hip/amd_detail/amd_hip_ocp_fp_cxx.hpp
@@ -4,14 +4,17 @@
  * SPDX-License-Identifier: MIT
  */
 
-#pragma once
+#ifndef _HIP_INCLUDE_HIP_AMD_DETAIL_HIP_OCP_FP_CXX_HPP_
+#define _HIP_INCLUDE_HIP_AMD_DETAIL_HIP_OCP_FP_CXX_HPP_
 
+#if !defined(__HIPCC_RTC__)
 #include "amd_hip_ocp_host.hpp"
+#endif
 
 static_assert(sizeof(unsigned int) == sizeof(__amd_fp8_storage_t[4]));
-static_assert(sizeof(uint32_t) == sizeof(__amd_fp8_storage_t[4]));
+static_assert(sizeof(__hip_uint32_t) == sizeof(__amd_fp8_storage_t[4]));
 static_assert(sizeof(int) == sizeof(__amd_fp8x2_storage_t[2]));
-static_assert(sizeof(uint32_t) == sizeof(__amd_fp8x2_storage_t[2]));
+static_assert(sizeof(__hip_uint32_t) == sizeof(__amd_fp8x2_storage_t[2]));
 static_assert(sizeof(__amd_shortx2_storage_t) == sizeof(__amd_fp8x2_storage_t[2]));
 
 struct __hipext_ocp_fp8_e4m3 {
@@ -31,7 +34,7 @@ struct __hipext_ocp_fp8_e4m3 {
 #else
     using namespace fcbx;
     union {
-      uint32_t ui32;
+      __hip_uint32_t ui32;
       __amd_fp8_storage_t fp8[4];
     } u{0};
     u.ui32 = from_float<float, Encoding::E4M3, true>(in, 0 /*scale*/);
@@ -50,7 +53,7 @@ struct __hipext_ocp_fp8_e4m3 {
 #else
     using namespace fcbx;
     union {
-      uint32_t ui32;
+      __hip_uint32_t ui32;
       __amd_fp8_storage_t fp8[4];
     } u{0};
     u.ui32 = from_float_sr<float, Encoding::E4M3, true>(in, seed, 0 /*scale*/);
@@ -71,7 +74,7 @@ struct __hipext_ocp_fp8_e4m3 {
 #else
     using namespace fcbx;
     union {
-      uint32_t ui32;
+      __hip_uint32_t ui32;
       __amd_fp8_storage_t fp8[4];
     } u{0};
     u.ui32 = from_float_sr<float, Encoding::E4M3, true>(in, seed, scale);
@@ -93,7 +96,7 @@ struct __hipext_ocp_fp8_e4m3 {
 #else
     using namespace fcbx;
     union {
-      uint32_t ui32;
+      __hip_uint32_t ui32;
       __amd_fp8_storage_t fp8[4];
     } u{0};
     u.ui32 = from_float_sr<__amd_fp16_storage_t, Encoding::E4M3, true>(in, seed, scale);
@@ -116,7 +119,7 @@ struct __hipext_ocp_fp8_e4m3 {
 #else
     using namespace fcbx;
     union {
-      uint32_t ui32;
+      __hip_uint32_t ui32;
       __amd_fp8_storage_t fp8[4];
     } u{0};
     u.ui32 = from_float_sr<__amd_bf16_storage_t, Encoding::E4M3, true>(in, seed, scale);
@@ -188,7 +191,7 @@ struct __hipext_ocp_fp8_e5m2 {
 #else
     using namespace fcbx;
     union {
-      uint32_t ui32;
+      __hip_uint32_t ui32;
       __amd_fp8_storage_t fp8[4];
     } u{0};
     u.ui32 = from_float<float, Encoding::E5M2, true>(in, 0 /*scale*/);
@@ -207,7 +210,7 @@ struct __hipext_ocp_fp8_e5m2 {
 #else
     using namespace fcbx;
     union {
-      uint32_t ui32;
+      __hip_uint32_t ui32;
       __amd_fp8_storage_t fp8[4];
     } u{0};
     u.ui32 = from_float_sr<float, Encoding::E5M2, true>(in, seed, 0 /*scale*/);
@@ -228,7 +231,7 @@ struct __hipext_ocp_fp8_e5m2 {
 #else
     using namespace fcbx;
     union {
-      uint32_t ui32;
+      __hip_uint32_t ui32;
       __amd_fp8_storage_t fp8[4];
     } u{0};
     u.ui32 = from_float_sr<float, Encoding::E5M2, true>(in, seed, scale);
@@ -250,7 +253,7 @@ struct __hipext_ocp_fp8_e5m2 {
 #else
     using namespace fcbx;
     union {
-      uint32_t ui32;
+      __hip_uint32_t ui32;
       __amd_fp8_storage_t fp8[4];
     } u{0};
     u.ui32 = from_float_sr<__amd_fp16_storage_t, Encoding::E5M2, true>(in, seed, scale);
@@ -272,7 +275,7 @@ struct __hipext_ocp_fp8_e5m2 {
 #else
     using namespace fcbx;
     union {
-      uint32_t ui32;
+      __hip_uint32_t ui32;
       __amd_fp8_storage_t fp8[4];
     } u{0};
     u.ui32 = from_float_sr<__amd_bf16_storage_t, Encoding::E5M2, true>(in, seed, scale);
@@ -344,7 +347,7 @@ struct __hipext_ocp_fp8x2_e4m3 {
 #else
     using namespace fcbx;
     union {
-      uint32_t ui32;
+      __hip_uint32_t ui32;
       __amd_fp8x2_storage_t fp8x2[2];
     } u{0};
     u.ui32 = from_float<float, Encoding::E4M3, true>(b, 0 /*scale*/);
@@ -370,7 +373,7 @@ struct __hipext_ocp_fp8x2_e4m3 {
 #else
     using namespace fcbx;
     union {
-      uint32_t ui32;
+      __hip_uint32_t ui32;
       __amd_fp8x2_storage_t fp8x2[2];
     } u{0};
     u.ui32 = from_float<float, Encoding::E4M3, true>(b, scale);
@@ -398,7 +401,7 @@ struct __hipext_ocp_fp8x2_e4m3 {
 #else
     using namespace fcbx;
     union {
-      uint32_t ui32;
+      __hip_uint32_t ui32;
       __amd_fp8x2_storage_t fp8x2[2];
     } u{0};
     u.ui32 = from_float<__amd_fp16_storage_t, Encoding::E4M3, true>(in[1], scale);
@@ -421,7 +424,7 @@ struct __hipext_ocp_fp8x2_e4m3 {
 #else
     using namespace fcbx;
     union {
-      uint32_t ui32;
+      __hip_uint32_t ui32;
       __amd_fp8x2_storage_t fp8x2[2];
     } u{0};
     u.ui32 = from_float<__amd_bf16_storage_t, Encoding::E4M3, true>(in[1], scale);
@@ -509,7 +512,7 @@ struct __hipext_ocp_fp8x2_e5m2 {
 #else
     using namespace fcbx;
     union {
-      uint32_t ui32;
+      __hip_uint32_t ui32;
       __amd_fp8x2_storage_t fp8x2[2];
     } u{0};
     u.ui32 = from_float<float, Encoding::E5M2, true>(b, 0 /*scale*/);
@@ -535,7 +538,7 @@ struct __hipext_ocp_fp8x2_e5m2 {
 #else
     using namespace fcbx;
     union {
-      uint32_t ui32;
+      __hip_uint32_t ui32;
       __amd_fp8x2_storage_t fp8x2[2];
     } u{0};
     u.ui32 = from_float<float, Encoding::E5M2, true>(b, scale);
@@ -562,7 +565,7 @@ struct __hipext_ocp_fp8x2_e5m2 {
 #else
     using namespace fcbx;
     union {
-      uint32_t ui32;
+      __hip_uint32_t ui32;
       __amd_fp8x2_storage_t fp8x2[2];
     } u{0};
     u.ui32 = from_float<__amd_fp16_storage_t, Encoding::E5M2, true>(in[1], scale);
@@ -585,7 +588,7 @@ struct __hipext_ocp_fp8x2_e5m2 {
 #else
     using namespace fcbx;
     union {
-      uint32_t ui32;
+      __hip_uint32_t ui32;
       __amd_fp8x2_storage_t fp8x2[2];
     } u{0};
     u.ui32 = from_float<__amd_bf16_storage_t, Encoding::E5M2, true>(in[1], scale);
@@ -955,9 +958,9 @@ struct __hipext_ocp_fp4x2_e2m1 {
                                                          __amd_scale_to_float(scale), 1);
     __x = u.fp4x2[1];
 #else
-    static_assert(sizeof(__amd_fp4x2_storage_t[4]) == sizeof(uint32_t));
+    static_assert(sizeof(__amd_fp4x2_storage_t[4]) == sizeof(__hip_uint32_t));
     union u {
-      uint32_t ui32t;
+      __hip_uint32_t ui32t;
       __amd_fp4x2_storage_t fp4x2[4];
     } u{0};
     using namespace fcbx;
@@ -982,9 +985,9 @@ struct __hipext_ocp_fp4x2_e2m1 {
                                                           __amd_scale_to_float(scale), 1);
     __x = u.fp4x2[1];
 #else
-    static_assert(sizeof(__amd_fp4x2_storage_t[4]) == sizeof(uint32_t));
+    static_assert(sizeof(__amd_fp4x2_storage_t[4]) == sizeof(__hip_uint32_t));
     union u {
-      uint32_t ui32t;
+      __hip_uint32_t ui32t;
       __amd_fp4x2_storage_t fp4x2[4];
     } u{0};
     using namespace fcbx;
@@ -1009,9 +1012,9 @@ struct __hipext_ocp_fp4x2_e2m1 {
                                                          __amd_scale_to_float(scale), 1);
     __x = u.fp4x2[1];
 #else
-    static_assert(sizeof(__amd_fp4x2_storage_t[4]) == sizeof(uint32_t));
+    static_assert(sizeof(__amd_fp4x2_storage_t[4]) == sizeof(__hip_uint32_t));
     union u {
-      uint32_t ui32t;
+      __hip_uint32_t ui32t;
       __amd_fp4x2_storage_t fp4x2[4];
     } u{0};
     using namespace fcbx;
@@ -1060,3 +1063,5 @@ struct __hipext_ocp_fp4x2_e2m1 {
 #endif
   }
 };
+
+#endif  // _HIP_INCLUDE_HIP_AMD_DETAIL_HIP_OCP_FP_CXX_HPP_

--- a/projects/clr/hipamd/include/hip/amd_detail/amd_hip_ocp_host.hpp
+++ b/projects/clr/hipamd/include/hip/amd_detail/amd_hip_ocp_host.hpp
@@ -94,8 +94,18 @@ constexpr __OCP_FP_HOST_DEVICE_STATIC__ __hip_uint32_t bitmask(__hip_uint32_t bi
   return ((__hip_uint32_t)1 << bits) - 1;
 }
 
-constexpr __hip_internal::array<Float, (size_t)Encoding::NumEncodings> init() {
-  __hip_internal::array<Float, (size_t)Encoding::NumEncodings> a{};
+struct EncodingTable {
+  Float __elements[(size_t)Encoding::NumEncodings];
+#if __cplusplus >= 201402L
+  constexpr Float& operator[](size_t i) { return __elements[i]; }
+#else
+  Float& operator[](size_t i) { return __elements[i]; }
+#endif
+  constexpr const Float& operator[](size_t i) const { return __elements[i]; }
+};
+
+constexpr EncodingTable init() {
+  EncodingTable a{};
 
   a[(size_t)Encoding::E2M1] = {
       .ExpBias = 1,

--- a/projects/clr/hipamd/include/hip/amd_detail/amd_hip_ocp_host.hpp
+++ b/projects/clr/hipamd/include/hip/amd_detail/amd_hip_ocp_host.hpp
@@ -68,8 +68,8 @@ struct Float {
   bool HasInf;
 };
 
-static const float ieee754_nan = __hip_internal::numeric_limits<float>::quiet_NaN();
-static const float ieee754_inf = __hip_internal::numeric_limits<float>::infinity();
+static const float ieee754_nan = __hip_internal::NumericLimits<float>::quiet_NaN();
+static const float ieee754_inf = __hip_internal::NumericLimits<float>::infinity();
 
 __OCP_FP_HOST_DEVICE_STATIC__ __hip_uint32_t U32(float f) {
   static_assert(sizeof(__hip_uint32_t) == sizeof(float), "");
@@ -769,6 +769,27 @@ __OCP_FP_HOST_DEVICE_STATIC__ __hip_uint32_t from_float(T f, __hip_int8_t scale_
     return inf<E, sat>(signBit);
 }
 
+// Manual little-endian, LSB-first 6-bit packing.
+__OCP_FP_HOST_DEVICE_STATIC__ void pack_fp6(__hip_uint8_t* buf, int idx, __hip_uint8_t val) {
+  const unsigned bit = static_cast<unsigned>(idx) * 6u;
+  const unsigned byte = bit >> 3;
+  const unsigned off = bit & 7u;
+  val &= 0x3f;
+  buf[byte] = static_cast<__hip_uint8_t>((buf[byte] & ~(0x3f << off)) | (val << off));
+  if (off > 2u)
+    buf[byte + 1] = static_cast<__hip_uint8_t>((buf[byte + 1] & ~(0x3f >> (8u - off))) |
+                                               (val >> (8u - off)));
+}
+
+__OCP_FP_HOST_DEVICE_STATIC__ __hip_uint8_t unpack_fp6(const __hip_uint8_t* buf, int idx) {
+  const unsigned bit = static_cast<unsigned>(idx) * 6u;
+  const unsigned byte = bit >> 3;
+  const unsigned off = bit & 7u;
+  unsigned v = static_cast<unsigned>(buf[byte]) >> off;
+  if (off > 2u) v |= static_cast<unsigned>(buf[byte + 1]) << (8u - off);
+  return static_cast<__hip_uint8_t>(v & 0x3f);
+}
+
 // ------------
 template <typename InType, typename OutType, typename float_base_t, Encoding in_encode,
           Encoding out_encode, bool sr = false>
@@ -780,105 +801,32 @@ __OCP_FP_HOST_DEVICE_STATIC__ OutType fp6_cvt_packedx16(InType in, __hip_int8_t 
       __hip_internal::is_same<InType, __amd_bf16x16_storage_t>::value;
   using other_type = __hip_internal::conditional<in_float, OutType, InType>::type;
 
-  struct fp6x16_packed {
-    __hip_uint8_t val1 : 6;
-    __hip_uint8_t val2 : 6;
-    __hip_uint8_t val3 : 6;
-    __hip_uint8_t val4 : 6;
-    __hip_uint8_t val5 : 6;
-    __hip_uint8_t val6 : 6;
-    __hip_uint8_t val7 : 6;
-    __hip_uint8_t val8 : 6;
-    __hip_uint8_t val9 : 6;
-    __hip_uint8_t val10 : 6;
-    __hip_uint8_t val11 : 6;
-    __hip_uint8_t val12 : 6;
-    __hip_uint8_t val13 : 6;
-    __hip_uint8_t val14 : 6;
-    __hip_uint8_t val15 : 6;
-    __hip_uint8_t val16 : 6;
-    unsigned int padded;
-  } __attribute__((packed, gcc_struct));
-
-  static_assert(sizeof(other_type) == sizeof(fp6x16_packed));
   union {
     other_type o;
-    fp6x16_packed fp6;
+    __hip_uint8_t bytes[sizeof(other_type)];
   } u;
 
-  // TODO maybe make it simpler
   if constexpr (in_float) {
-    if constexpr (sr) {
-      u.fp6.val1 =
-          static_cast<__hip_uint8_t>(from_float_sr<float_base_t, out_encode, true>(in[0], seed, scale));
-      u.fp6.val2 =
-          static_cast<__hip_uint8_t>(from_float_sr<float_base_t, out_encode, true>(in[1], seed, scale));
-      u.fp6.val3 =
-          static_cast<__hip_uint8_t>(from_float_sr<float_base_t, out_encode, true>(in[2], seed, scale));
-      u.fp6.val4 =
-          static_cast<__hip_uint8_t>(from_float_sr<float_base_t, out_encode, true>(in[3], seed, scale));
-      u.fp6.val5 =
-          static_cast<__hip_uint8_t>(from_float_sr<float_base_t, out_encode, true>(in[4], seed, scale));
-      u.fp6.val6 =
-          static_cast<__hip_uint8_t>(from_float_sr<float_base_t, out_encode, true>(in[5], seed, scale));
-      u.fp6.val7 =
-          static_cast<__hip_uint8_t>(from_float_sr<float_base_t, out_encode, true>(in[6], seed, scale));
-      u.fp6.val8 =
-          static_cast<__hip_uint8_t>(from_float_sr<float_base_t, out_encode, true>(in[7], seed, scale));
-      u.fp6.val9 =
-          static_cast<__hip_uint8_t>(from_float_sr<float_base_t, out_encode, true>(in[8], seed, scale));
-      u.fp6.val10 =
-          static_cast<__hip_uint8_t>(from_float_sr<float_base_t, out_encode, true>(in[9], seed, scale));
-      u.fp6.val11 =
-          static_cast<__hip_uint8_t>(from_float_sr<float_base_t, out_encode, true>(in[10], seed, scale));
-      u.fp6.val12 =
-          static_cast<__hip_uint8_t>(from_float_sr<float_base_t, out_encode, true>(in[11], seed, scale));
-      u.fp6.val13 =
-          static_cast<__hip_uint8_t>(from_float_sr<float_base_t, out_encode, true>(in[12], seed, scale));
-      u.fp6.val14 =
-          static_cast<__hip_uint8_t>(from_float_sr<float_base_t, out_encode, true>(in[13], seed, scale));
-      u.fp6.val15 =
-          static_cast<__hip_uint8_t>(from_float_sr<float_base_t, out_encode, true>(in[14], seed, scale));
-      u.fp6.val16 =
-          static_cast<__hip_uint8_t>(from_float_sr<float_base_t, out_encode, true>(in[15], seed, scale));
-    } else {
-      u.fp6.val1 = from_float<float_base_t, out_encode, true>(in[0], scale);
-      u.fp6.val2 = from_float<float_base_t, out_encode, true>(in[1], scale);
-      u.fp6.val3 = from_float<float_base_t, out_encode, true>(in[2], scale);
-      u.fp6.val4 = from_float<float_base_t, out_encode, true>(in[3], scale);
-      u.fp6.val5 = from_float<float_base_t, out_encode, true>(in[4], scale);
-      u.fp6.val6 = from_float<float_base_t, out_encode, true>(in[5], scale);
-      u.fp6.val7 = from_float<float_base_t, out_encode, true>(in[6], scale);
-      u.fp6.val8 = from_float<float_base_t, out_encode, true>(in[7], scale);
-      u.fp6.val9 = from_float<float_base_t, out_encode, true>(in[8], scale);
-      u.fp6.val10 = from_float<float_base_t, out_encode, true>(in[9], scale);
-      u.fp6.val11 = from_float<float_base_t, out_encode, true>(in[10], scale);
-      u.fp6.val12 = from_float<float_base_t, out_encode, true>(in[11], scale);
-      u.fp6.val13 = from_float<float_base_t, out_encode, true>(in[12], scale);
-      u.fp6.val14 = from_float<float_base_t, out_encode, true>(in[13], scale);
-      u.fp6.val15 = from_float<float_base_t, out_encode, true>(in[14], scale);
-      u.fp6.val16 = from_float<float_base_t, out_encode, true>(in[15], scale);
+    for (int i = 0; i < static_cast<int>(sizeof(other_type)); ++i) {
+       u.bytes[i] = 0;
+    }
+    for (int i = 0; i < 16; ++i) {
+      __hip_uint8_t v;
+      if constexpr (sr) {
+        v = static_cast<__hip_uint8_t>(
+            from_float_sr<float_base_t, out_encode, true>(in[i], seed, scale));
+      } else {
+        v = static_cast<__hip_uint8_t>(from_float<float_base_t, out_encode, true>(in[i], scale));
+      }
+      pack_fp6(u.bytes, i, v);
     }
     return u.o;
   } else {
     OutType ret;
     u.o = in;
-    ret[0] = to_float<float_base_t, in_encode, true>(u.fp6.val1, scale);
-    ret[1] = to_float<float_base_t, in_encode, true>(u.fp6.val2, scale);
-    ret[2] = to_float<float_base_t, in_encode, true>(u.fp6.val3, scale);
-    ret[3] = to_float<float_base_t, in_encode, true>(u.fp6.val4, scale);
-    ret[4] = to_float<float_base_t, in_encode, true>(u.fp6.val5, scale);
-    ret[5] = to_float<float_base_t, in_encode, true>(u.fp6.val6, scale);
-    ret[6] = to_float<float_base_t, in_encode, true>(u.fp6.val7, scale);
-    ret[7] = to_float<float_base_t, in_encode, true>(u.fp6.val8, scale);
-    ret[8] = to_float<float_base_t, in_encode, true>(u.fp6.val9, scale);
-    ret[9] = to_float<float_base_t, in_encode, true>(u.fp6.val10, scale);
-    ret[10] = to_float<float_base_t, in_encode, true>(u.fp6.val11, scale);
-    ret[11] = to_float<float_base_t, in_encode, true>(u.fp6.val12, scale);
-    ret[12] = to_float<float_base_t, in_encode, true>(u.fp6.val13, scale);
-    ret[13] = to_float<float_base_t, in_encode, true>(u.fp6.val14, scale);
-    ret[14] = to_float<float_base_t, in_encode, true>(u.fp6.val15, scale);
-    ret[15] = to_float<float_base_t, in_encode, true>(u.fp6.val16, scale);
+    for (int i = 0; i < 16; ++i) {
+      ret[i] = to_float<float_base_t, in_encode, true>(unpack_fp6(u.bytes, i), scale);
+    }
     return ret;
   }
 }
@@ -894,185 +842,32 @@ __OCP_FP_HOST_DEVICE_STATIC__ OutType fp6_cvt_packedx32(InType in, __hip_int8_t 
                             __hip_internal::is_same<InType, __amd_bf16x32_storage_t>::value;
   using other_type = __hip_internal::conditional<in_float, OutType, InType>::type;
 
-  struct fp6x32_packed {
-    __hip_uint8_t val1 : 6;
-    __hip_uint8_t val2 : 6;
-    __hip_uint8_t val3 : 6;
-    __hip_uint8_t val4 : 6;
-    __hip_uint8_t val5 : 6;
-    __hip_uint8_t val6 : 6;
-    __hip_uint8_t val7 : 6;
-    __hip_uint8_t val8 : 6;
-    __hip_uint8_t val9 : 6;
-    __hip_uint8_t val10 : 6;
-    __hip_uint8_t val11 : 6;
-    __hip_uint8_t val12 : 6;
-    __hip_uint8_t val13 : 6;
-    __hip_uint8_t val14 : 6;
-    __hip_uint8_t val15 : 6;
-    __hip_uint8_t val16 : 6;
-    __hip_uint8_t val17 : 6;
-    __hip_uint8_t val18 : 6;
-    __hip_uint8_t val19 : 6;
-    __hip_uint8_t val20 : 6;
-    __hip_uint8_t val21 : 6;
-    __hip_uint8_t val22 : 6;
-    __hip_uint8_t val23 : 6;
-    __hip_uint8_t val24 : 6;
-    __hip_uint8_t val25 : 6;
-    __hip_uint8_t val26 : 6;
-    __hip_uint8_t val27 : 6;
-    __hip_uint8_t val28 : 6;
-    __hip_uint8_t val29 : 6;
-    __hip_uint8_t val30 : 6;
-    __hip_uint8_t val31 : 6;
-    __hip_uint8_t val32 : 6;
-    unsigned long long padded;
-  } __attribute__((packed, gcc_struct));
-
-  static_assert(sizeof(other_type) == sizeof(fp6x32_packed), "");
   union {
     other_type o;
-    fp6x32_packed fp6;
+    __hip_uint8_t bytes[sizeof(other_type)];
   } u;
 
-  // TODO maybe make it simpler
   if constexpr (in_float) {
-    if constexpr (sr) {
-      u.fp6.val1 =
-          static_cast<__hip_uint8_t>(from_float_sr<float_base_t, out_encode, true>(in[0], seed, scale));
-      u.fp6.val2 =
-          static_cast<__hip_uint8_t>(from_float_sr<float_base_t, out_encode, true>(in[1], seed, scale));
-      u.fp6.val3 =
-          static_cast<__hip_uint8_t>(from_float_sr<float_base_t, out_encode, true>(in[2], seed, scale));
-      u.fp6.val4 =
-          static_cast<__hip_uint8_t>(from_float_sr<float_base_t, out_encode, true>(in[3], seed, scale));
-      u.fp6.val5 =
-          static_cast<__hip_uint8_t>(from_float_sr<float_base_t, out_encode, true>(in[4], seed, scale));
-      u.fp6.val6 =
-          static_cast<__hip_uint8_t>(from_float_sr<float_base_t, out_encode, true>(in[5], seed, scale));
-      u.fp6.val7 =
-          static_cast<__hip_uint8_t>(from_float_sr<float_base_t, out_encode, true>(in[6], seed, scale));
-      u.fp6.val8 =
-          static_cast<__hip_uint8_t>(from_float_sr<float_base_t, out_encode, true>(in[7], seed, scale));
-      u.fp6.val9 =
-          static_cast<__hip_uint8_t>(from_float_sr<float_base_t, out_encode, true>(in[8], seed, scale));
-      u.fp6.val10 =
-          static_cast<__hip_uint8_t>(from_float_sr<float_base_t, out_encode, true>(in[9], seed, scale));
-      u.fp6.val11 =
-          static_cast<__hip_uint8_t>(from_float_sr<float_base_t, out_encode, true>(in[10], seed, scale));
-      u.fp6.val12 =
-          static_cast<__hip_uint8_t>(from_float_sr<float_base_t, out_encode, true>(in[11], seed, scale));
-      u.fp6.val13 =
-          static_cast<__hip_uint8_t>(from_float_sr<float_base_t, out_encode, true>(in[12], seed, scale));
-      u.fp6.val14 =
-          static_cast<__hip_uint8_t>(from_float_sr<float_base_t, out_encode, true>(in[13], seed, scale));
-      u.fp6.val15 =
-          static_cast<__hip_uint8_t>(from_float_sr<float_base_t, out_encode, true>(in[14], seed, scale));
-      u.fp6.val16 =
-          static_cast<__hip_uint8_t>(from_float_sr<float_base_t, out_encode, true>(in[15], seed, scale));
-      u.fp6.val17 =
-          static_cast<__hip_uint8_t>(from_float_sr<float_base_t, out_encode, true>(in[16], seed, scale));
-      u.fp6.val18 =
-          static_cast<__hip_uint8_t>(from_float_sr<float_base_t, out_encode, true>(in[17], seed, scale));
-      u.fp6.val19 =
-          static_cast<__hip_uint8_t>(from_float_sr<float_base_t, out_encode, true>(in[18], seed, scale));
-      u.fp6.val20 =
-          static_cast<__hip_uint8_t>(from_float_sr<float_base_t, out_encode, true>(in[19], seed, scale));
-      u.fp6.val21 =
-          static_cast<__hip_uint8_t>(from_float_sr<float_base_t, out_encode, true>(in[20], seed, scale));
-      u.fp6.val22 =
-          static_cast<__hip_uint8_t>(from_float_sr<float_base_t, out_encode, true>(in[21], seed, scale));
-      u.fp6.val23 =
-          static_cast<__hip_uint8_t>(from_float_sr<float_base_t, out_encode, true>(in[22], seed, scale));
-      u.fp6.val24 =
-          static_cast<__hip_uint8_t>(from_float_sr<float_base_t, out_encode, true>(in[23], seed, scale));
-      u.fp6.val25 =
-          static_cast<__hip_uint8_t>(from_float_sr<float_base_t, out_encode, true>(in[24], seed, scale));
-      u.fp6.val26 =
-          static_cast<__hip_uint8_t>(from_float_sr<float_base_t, out_encode, true>(in[25], seed, scale));
-      u.fp6.val27 =
-          static_cast<__hip_uint8_t>(from_float_sr<float_base_t, out_encode, true>(in[26], seed, scale));
-      u.fp6.val28 =
-          static_cast<__hip_uint8_t>(from_float_sr<float_base_t, out_encode, true>(in[27], seed, scale));
-      u.fp6.val29 =
-          static_cast<__hip_uint8_t>(from_float_sr<float_base_t, out_encode, true>(in[28], seed, scale));
-      u.fp6.val30 =
-          static_cast<__hip_uint8_t>(from_float_sr<float_base_t, out_encode, true>(in[29], seed, scale));
-      u.fp6.val31 =
-          static_cast<__hip_uint8_t>(from_float_sr<float_base_t, out_encode, true>(in[30], seed, scale));
-      u.fp6.val32 =
-          static_cast<__hip_uint8_t>(from_float_sr<float_base_t, out_encode, true>(in[31], seed, scale));
-    } else {
-      u.fp6.val1 = from_float<float_base_t, out_encode, true>(in[0], scale);
-      u.fp6.val2 = from_float<float_base_t, out_encode, true>(in[1], scale);
-      u.fp6.val3 = from_float<float_base_t, out_encode, true>(in[2], scale);
-      u.fp6.val4 = from_float<float_base_t, out_encode, true>(in[3], scale);
-      u.fp6.val5 = from_float<float_base_t, out_encode, true>(in[4], scale);
-      u.fp6.val6 = from_float<float_base_t, out_encode, true>(in[5], scale);
-      u.fp6.val7 = from_float<float_base_t, out_encode, true>(in[6], scale);
-      u.fp6.val8 = from_float<float_base_t, out_encode, true>(in[7], scale);
-      u.fp6.val9 = from_float<float_base_t, out_encode, true>(in[8], scale);
-      u.fp6.val10 = from_float<float_base_t, out_encode, true>(in[9], scale);
-      u.fp6.val11 = from_float<float_base_t, out_encode, true>(in[10], scale);
-      u.fp6.val12 = from_float<float_base_t, out_encode, true>(in[11], scale);
-      u.fp6.val13 = from_float<float_base_t, out_encode, true>(in[12], scale);
-      u.fp6.val14 = from_float<float_base_t, out_encode, true>(in[13], scale);
-      u.fp6.val15 = from_float<float_base_t, out_encode, true>(in[14], scale);
-      u.fp6.val16 = from_float<float_base_t, out_encode, true>(in[15], scale);
-      u.fp6.val17 = from_float<float_base_t, out_encode, true>(in[16], scale);
-      u.fp6.val18 = from_float<float_base_t, out_encode, true>(in[17], scale);
-      u.fp6.val19 = from_float<float_base_t, out_encode, true>(in[18], scale);
-      u.fp6.val20 = from_float<float_base_t, out_encode, true>(in[19], scale);
-      u.fp6.val21 = from_float<float_base_t, out_encode, true>(in[20], scale);
-      u.fp6.val22 = from_float<float_base_t, out_encode, true>(in[21], scale);
-      u.fp6.val23 = from_float<float_base_t, out_encode, true>(in[22], scale);
-      u.fp6.val24 = from_float<float_base_t, out_encode, true>(in[23], scale);
-      u.fp6.val25 = from_float<float_base_t, out_encode, true>(in[24], scale);
-      u.fp6.val26 = from_float<float_base_t, out_encode, true>(in[25], scale);
-      u.fp6.val27 = from_float<float_base_t, out_encode, true>(in[26], scale);
-      u.fp6.val28 = from_float<float_base_t, out_encode, true>(in[27], scale);
-      u.fp6.val29 = from_float<float_base_t, out_encode, true>(in[28], scale);
-      u.fp6.val30 = from_float<float_base_t, out_encode, true>(in[29], scale);
-      u.fp6.val31 = from_float<float_base_t, out_encode, true>(in[30], scale);
-      u.fp6.val32 = from_float<float_base_t, out_encode, true>(in[31], scale);
+    for (int i = 0; i < static_cast<int>(sizeof(other_type)); ++i) {
+      u.bytes[i] = 0;
+    }
+    for (int i = 0; i < 32; ++i) {
+      __hip_uint8_t v;
+      if constexpr (sr) {
+        v = static_cast<__hip_uint8_t>(
+            from_float_sr<float_base_t, out_encode, true>(in[i], seed, scale));
+      } else {
+        v = static_cast<__hip_uint8_t>(from_float<float_base_t, out_encode, true>(in[i], scale));
+      }
+      pack_fp6(u.bytes, i, v);
     }
     return u.o;
   } else {
     OutType ret;
     u.o = in;
-    ret[0] = to_float<float_base_t, in_encode, true>(u.fp6.val1, scale);
-    ret[1] = to_float<float_base_t, in_encode, true>(u.fp6.val2, scale);
-    ret[2] = to_float<float_base_t, in_encode, true>(u.fp6.val3, scale);
-    ret[3] = to_float<float_base_t, in_encode, true>(u.fp6.val4, scale);
-    ret[4] = to_float<float_base_t, in_encode, true>(u.fp6.val5, scale);
-    ret[5] = to_float<float_base_t, in_encode, true>(u.fp6.val6, scale);
-    ret[6] = to_float<float_base_t, in_encode, true>(u.fp6.val7, scale);
-    ret[7] = to_float<float_base_t, in_encode, true>(u.fp6.val8, scale);
-    ret[8] = to_float<float_base_t, in_encode, true>(u.fp6.val9, scale);
-    ret[9] = to_float<float_base_t, in_encode, true>(u.fp6.val10, scale);
-    ret[10] = to_float<float_base_t, in_encode, true>(u.fp6.val11, scale);
-    ret[11] = to_float<float_base_t, in_encode, true>(u.fp6.val12, scale);
-    ret[12] = to_float<float_base_t, in_encode, true>(u.fp6.val13, scale);
-    ret[13] = to_float<float_base_t, in_encode, true>(u.fp6.val14, scale);
-    ret[14] = to_float<float_base_t, in_encode, true>(u.fp6.val15, scale);
-    ret[15] = to_float<float_base_t, in_encode, true>(u.fp6.val16, scale);
-    ret[16] = to_float<float_base_t, in_encode, true>(u.fp6.val17, scale);
-    ret[17] = to_float<float_base_t, in_encode, true>(u.fp6.val18, scale);
-    ret[18] = to_float<float_base_t, in_encode, true>(u.fp6.val19, scale);
-    ret[19] = to_float<float_base_t, in_encode, true>(u.fp6.val20, scale);
-    ret[20] = to_float<float_base_t, in_encode, true>(u.fp6.val21, scale);
-    ret[21] = to_float<float_base_t, in_encode, true>(u.fp6.val22, scale);
-    ret[22] = to_float<float_base_t, in_encode, true>(u.fp6.val23, scale);
-    ret[23] = to_float<float_base_t, in_encode, true>(u.fp6.val24, scale);
-    ret[24] = to_float<float_base_t, in_encode, true>(u.fp6.val25, scale);
-    ret[25] = to_float<float_base_t, in_encode, true>(u.fp6.val26, scale);
-    ret[26] = to_float<float_base_t, in_encode, true>(u.fp6.val27, scale);
-    ret[27] = to_float<float_base_t, in_encode, true>(u.fp6.val28, scale);
-    ret[28] = to_float<float_base_t, in_encode, true>(u.fp6.val29, scale);
-    ret[29] = to_float<float_base_t, in_encode, true>(u.fp6.val30, scale);
-    ret[30] = to_float<float_base_t, in_encode, true>(u.fp6.val31, scale);
-    ret[31] = to_float<float_base_t, in_encode, true>(u.fp6.val32, scale);
+    for (int i = 0; i < 32; ++i) {
+      ret[i] = to_float<float_base_t, in_encode, true>(unpack_fp6(u.bytes, i), scale);
+    }
     return ret;
   }
 }

--- a/projects/clr/hipamd/include/hip/amd_detail/amd_hip_ocp_host.hpp
+++ b/projects/clr/hipamd/include/hip/amd_detail/amd_hip_ocp_host.hpp
@@ -6,9 +6,8 @@
 
 #pragma once
 
-#include "amd_hip_ocp_types.h"
-
 #if !defined(__HIPCC_RTC__)
+#include "amd_hip_ocp_types.h"
 #include <cstdint>
 #include <limits>
 #include <cstdlib>
@@ -16,7 +15,7 @@
 #endif
 
 namespace fcbx {
-constexpr int8_t OCP_SCALE_EXP_NAN = -128;
+constexpr __hip_int8_t OCP_SCALE_EXP_NAN = -128;
 
 enum class Encoding : size_t {
   E2M1 = 0,
@@ -37,50 +36,50 @@ enum class Encoding : size_t {
   // Keep this one last
   NumEncodings,
 };
-enum fp16 : uint16_t {};
-enum bf16 : uint16_t {};
+enum fp16 : __hip_uint16_t {};
+enum bf16 : __hip_uint16_t {};
 
 struct Float {
-  int32_t ExpBias;
-  uint32_t ExpBits;
-  uint32_t ExpMask;
-  uint32_t ManBits;
-  uint32_t ManMask;
-  int32_t MaxExp;
-  int32_t MinExp;
+  __hip_int32_t ExpBias;
+  __hip_uint32_t ExpBits;
+  __hip_uint32_t ExpMask;
+  __hip_uint32_t ManBits;
+  __hip_uint32_t ManMask;
+  __hip_int32_t MaxExp;
+  __hip_int32_t MinExp;
   bool MxScale;
   bool HasNaN;
   bool HasInf;
 };
 
-static const float ieee754_nan = std::numeric_limits<float>::quiet_NaN();
-static const float ieee754_inf = std::numeric_limits<float>::infinity();
+static const float ieee754_nan = __hip_internal::numeric_limits<float>::quiet_NaN();
+static const float ieee754_inf = __hip_internal::numeric_limits<float>::infinity();
 
-__OCP_FP_HOST_DEVICE_STATIC__ uint32_t U32(float f) {
-  static_assert(sizeof(uint32_t) == sizeof(float), "");
+__OCP_FP_HOST_DEVICE_STATIC__ __hip_uint32_t U32(float f) {
+  static_assert(sizeof(__hip_uint32_t) == sizeof(float), "");
   union {
     float f32;
-    uint32_t ui32;
+    __hip_uint32_t ui32;
   } u{f};
   return u.ui32;
 }
 
-__OCP_FP_HOST_DEVICE_STATIC__ float F32(uint32_t u32) {
-  static_assert(sizeof(uint32_t) == sizeof(float), "");
+__OCP_FP_HOST_DEVICE_STATIC__ float F32(__hip_uint32_t u32) {
+  static_assert(sizeof(__hip_uint32_t) == sizeof(float), "");
   union {
-    uint32_t ui32;
+    __hip_uint32_t ui32;
     float f32;
   } u{u32};
   return u.f32;
 }
 
-constexpr __OCP_FP_HOST_DEVICE_STATIC__ uint32_t bitmask(uint32_t bits) {
+constexpr __OCP_FP_HOST_DEVICE_STATIC__ __hip_uint32_t bitmask(__hip_uint32_t bits) {
   if (bits < 1) return 0;
-  return ((uint32_t)1 << bits) - 1;
+  return ((__hip_uint32_t)1 << bits) - 1;
 }
 
-constexpr std::array<Float, (size_t)Encoding::NumEncodings> init() {
-  std::array<Float, (size_t)Encoding::NumEncodings> a{};
+constexpr __hip_internal::array<Float, (size_t)Encoding::NumEncodings> init() {
+  __hip_internal::array<Float, (size_t)Encoding::NumEncodings> a{};
 
   a[(size_t)Encoding::E2M1] = {
       .ExpBias = 1,
@@ -243,17 +242,17 @@ constexpr std::array<Float, (size_t)Encoding::NumEncodings> init() {
 
 static constexpr auto encodings = init();
 
-template <Encoding E, bool sat> __OCP_FP_HOST_DEVICE_STATIC__ uint32_t exponentbits(uint32_t val) {
+template <Encoding E, bool sat> __OCP_FP_HOST_DEVICE_STATIC__ __hip_uint32_t exponentbits(__hip_uint32_t val) {
   const auto& enc = encodings[(size_t)E];
   return (val >> enc.ManBits) & enc.ExpMask;
 }
 
-template <Encoding E, bool sat> __OCP_FP_HOST_DEVICE_STATIC__ uint32_t mantissa(uint32_t val) {
+template <Encoding E, bool sat> __OCP_FP_HOST_DEVICE_STATIC__ __hip_uint32_t mantissa(__hip_uint32_t val) {
   const auto& enc = encodings[(size_t)E];
   return val & enc.ManMask;
 }
 
-template <Encoding E, bool sat> __OCP_FP_HOST_DEVICE_STATIC__ bool issubnorm(uint32_t val) {
+template <Encoding E, bool sat> __OCP_FP_HOST_DEVICE_STATIC__ bool issubnorm(__hip_uint32_t val) {
   switch (E) {
     default:
       return exponentbits<E, sat>(val) == 0 && mantissa<E, sat>(val) != 0;
@@ -264,19 +263,19 @@ template <Encoding E, bool sat> __OCP_FP_HOST_DEVICE_STATIC__ bool issubnorm(uin
   return false;
 }
 
-template <Encoding E, bool sat> __OCP_FP_HOST_DEVICE_STATIC__ int32_t exponent(uint32_t val) {
+template <Encoding E, bool sat> __OCP_FP_HOST_DEVICE_STATIC__ __hip_int32_t exponent(__hip_uint32_t val) {
   const auto& enc = encodings[(size_t)E];
   auto unbiased_exp = exponentbits<E, sat>(val);
   unbiased_exp = issubnorm<E, sat>(val) ? 1 : unbiased_exp;
-  return (int32_t)unbiased_exp - enc.ExpBias;
+  return (__hip_int32_t)unbiased_exp - enc.ExpBias;
 }
 
-template <Encoding E, bool sat> __OCP_FP_HOST_DEVICE_STATIC__ uint32_t signbit(uint32_t val) {
+template <Encoding E, bool sat> __OCP_FP_HOST_DEVICE_STATIC__ __hip_uint32_t signbit(__hip_uint32_t val) {
   const auto& enc = encodings[(size_t)E];
   return (val >> (enc.ExpBits + enc.ManBits)) & 1;
 }
 
-template <Encoding E, bool sat> __OCP_FP_HOST_DEVICE_STATIC__ uint32_t nan(uint32_t sign) {
+template <Encoding E, bool sat> __OCP_FP_HOST_DEVICE_STATIC__ __hip_uint32_t nan(__hip_uint32_t sign) {
   const auto& enc = encodings[(size_t)E];
 
   switch (E) {
@@ -298,14 +297,14 @@ template <Encoding E, bool sat> __OCP_FP_HOST_DEVICE_STATIC__ uint32_t nan(uint3
     case Encoding::E8M7:
       return (sign << (enc.ExpBits + enc.ManBits)) | (enc.ExpMask << enc.ManBits) | enc.ManMask;
     case Encoding::IEEE754:
-      return U32(sign ? std::copysign(ieee754_nan, -1.0F) : ieee754_nan);
+      return U32(sign ? __hip_internal::copysign(ieee754_nan, -1.0F) : ieee754_nan);
     default:
       __builtin_trap();
       return 0;
   }
 }
 
-template <Encoding E, bool sat> __OCP_FP_HOST_DEVICE_STATIC__ uint32_t zero(uint32_t sign) {
+template <Encoding E, bool sat> __OCP_FP_HOST_DEVICE_STATIC__ __hip_uint32_t zero(__hip_uint32_t sign) {
   const auto& enc = encodings[(size_t)E];
 
   switch (E) {
@@ -323,14 +322,14 @@ template <Encoding E, bool sat> __OCP_FP_HOST_DEVICE_STATIC__ uint32_t zero(uint
     case Encoding::E5M2Nanoo:
       return 0;
     case Encoding::IEEE754:
-      return U32(sign ? std::copysign(0.0F, -1.0F) : 0.0F);
+      return U32(sign ? __hip_internal::copysign(0.0F, -1.0F) : 0.0F);
     default:
       __builtin_trap();
       return 0;
   }
 }
 
-template <Encoding E, bool sat> __OCP_FP_HOST_DEVICE_STATIC__ uint32_t inf(uint32_t sign) {
+template <Encoding E, bool sat> __OCP_FP_HOST_DEVICE_STATIC__ __hip_uint32_t inf(__hip_uint32_t sign) {
   const auto& enc = encodings[(size_t)E];
 
   switch (E) {
@@ -361,14 +360,14 @@ template <Encoding E, bool sat> __OCP_FP_HOST_DEVICE_STATIC__ uint32_t inf(uint3
       sign <<= enc.ExpBits + enc.ManBits;
       return sign | (enc.ExpMask << enc.ManBits) | 0;
     case Encoding::IEEE754:
-      return U32(sign ? std::copysign(ieee754_inf, -1.0F) : ieee754_inf);
+      return U32(sign ? __hip_internal::copysign(ieee754_inf, -1.0F) : ieee754_inf);
     default:
       __builtin_trap();
       return 0;
   }
 }
 
-template <Encoding E, bool sat> __OCP_FP_HOST_DEVICE_STATIC__ bool isnan(uint32_t val) {
+template <Encoding E, bool sat> __OCP_FP_HOST_DEVICE_STATIC__ bool isnan(__hip_uint32_t val) {
   const auto& enc = encodings[(size_t)E];
   if (!enc.HasNaN) return false;
 
@@ -379,7 +378,7 @@ template <Encoding E, bool sat> __OCP_FP_HOST_DEVICE_STATIC__ bool isnan(uint32_
   return exponentbits<E, sat>(val) == enc.ExpMask && mantissa<E, sat>(val) != 0;
 }
 
-template <Encoding E, bool sat> __OCP_FP_HOST_DEVICE_STATIC__ bool isinf(uint32_t val) {
+template <Encoding E, bool sat> __OCP_FP_HOST_DEVICE_STATIC__ bool isinf(__hip_uint32_t val) {
   const auto& enc = encodings[(size_t)E];
   if (!enc.HasInf) return false;
 
@@ -390,15 +389,15 @@ template <Encoding E, bool sat> __OCP_FP_HOST_DEVICE_STATIC__ bool isinf(uint32_
   return inf<E, sat>(signbit<E, sat>(val)) == val;
 }
 
-template <Encoding E, bool sat> __OCP_FP_HOST_DEVICE_STATIC__ bool iszero(uint32_t val) {
+template <Encoding E, bool sat> __OCP_FP_HOST_DEVICE_STATIC__ bool iszero(__hip_uint32_t val) {
   return zero<E, sat>(signbit<E, sat>(val)) == val;
 }
 
-template <Encoding E, bool sat> __OCP_FP_HOST_DEVICE_STATIC__ bool inrange(uint32_t val) {
+template <Encoding E, bool sat> __OCP_FP_HOST_DEVICE_STATIC__ bool inrange(__hip_uint32_t val) {
   return !(isnan<E, sat>(val) || isinf<E, sat>(val));
 }
 
-template <typename T> __OCP_FP_HOST_DEVICE_STATIC__ T makenan(Encoding E, uint32_t sign) {
+template <typename T> __OCP_FP_HOST_DEVICE_STATIC__ T makenan(Encoding E, __hip_uint32_t sign) {
   switch (E) {
     case Encoding::E5M10:
       return (T)nan<Encoding::E5M10, false>(sign);
@@ -413,7 +412,7 @@ template <typename T> __OCP_FP_HOST_DEVICE_STATIC__ T makenan(Encoding E, uint32
   }
 }
 
-template <typename T> __OCP_FP_HOST_DEVICE_STATIC__ T makeinf(Encoding E, uint32_t sign) {
+template <typename T> __OCP_FP_HOST_DEVICE_STATIC__ T makeinf(Encoding E, __hip_uint32_t sign) {
   switch (E) {
     case Encoding::E5M10:
       return (T)inf<Encoding::E5M10, false>(sign);
@@ -428,7 +427,7 @@ template <typename T> __OCP_FP_HOST_DEVICE_STATIC__ T makeinf(Encoding E, uint32
   }
 }
 
-template <typename T> __OCP_FP_HOST_DEVICE_STATIC__ T makezero(Encoding E, uint32_t sign) {
+template <typename T> __OCP_FP_HOST_DEVICE_STATIC__ T makezero(Encoding E, __hip_uint32_t sign) {
   switch (E) {
     case Encoding::E5M10:
       return (T)zero<Encoding::E5M10, false>(sign);
@@ -444,17 +443,17 @@ template <typename T> __OCP_FP_HOST_DEVICE_STATIC__ T makezero(Encoding E, uint3
 }
 
 template <typename T, Encoding E, bool sat>
-__OCP_FP_HOST_DEVICE_STATIC__ T to_float(uint32_t u32, int8_t scale_exp) {
+__OCP_FP_HOST_DEVICE_STATIC__ T to_float(__hip_uint32_t u32, __hip_int8_t scale_exp) {
   // We do not support bf16/fp16 <-> float
   static_assert(E != Encoding::IEEE754 && E != Encoding::E5M10 && E != Encoding::E8M7, "");
 
   const auto& enc = encodings[(size_t)E];
   const auto dstE = []() -> Encoding {
-    if constexpr (std::is_same<T, float>())
+    if constexpr (__hip_internal::is_same<T, float>())
       return Encoding::IEEE754;
-    else if constexpr (std::is_same<T, __amd_fp16_storage_t>())
+    else if constexpr (__hip_internal::is_same<T, __amd_fp16_storage_t>())
       return Encoding::E5M10;
-    else if constexpr (std::is_same<T, __amd_bf16_storage_t>())
+    else if constexpr (__hip_internal::is_same<T, __amd_bf16_storage_t>())
       return Encoding::E8M7;
     else
       __builtin_trap();
@@ -469,11 +468,11 @@ __OCP_FP_HOST_DEVICE_STATIC__ T to_float(uint32_t u32, int8_t scale_exp) {
   if (iszero<E, sat>(u32)) return makezero<T>(dstE, signbit<E, sat>(u32));
 
   auto dstMan = mantissa<E, sat>(u32) << (dstEnc.ManBits - enc.ManBits);
-  auto dstExp = (uint32_t)(exponent<E, sat>(u32) + dstEnc.ExpBias);
+  auto dstExp = (__hip_uint32_t)(exponent<E, sat>(u32) + dstEnc.ExpBias);
   dstExp &= dstEnc.ExpMask;
 
   if (issubnorm<E, sat>(u32)) {
-    auto leadbit = (uint32_t)1 << dstEnc.ManBits;
+    auto leadbit = (__hip_uint32_t)1 << dstEnc.ManBits;
     while ((dstMan & leadbit) == 0) {
       dstMan <<= 1;
       dstExp -= 1;
@@ -485,8 +484,8 @@ __OCP_FP_HOST_DEVICE_STATIC__ T to_float(uint32_t u32, int8_t scale_exp) {
   auto sign = signbit<E, sat>(u32) << (dstEnc.ExpBits + dstEnc.ManBits);
 
   if (enc.MxScale) {
-    int32_t exp = dstExp - dstEnc.ExpBias;
-    int32_t tmp = exp + (int32_t)scale_exp;
+    __hip_int32_t exp = dstExp - dstEnc.ExpBias;
+    __hip_int32_t tmp = exp + (__hip_int32_t)scale_exp;
     size_t diff = abs(tmp - dstEnc.MinExp);
 
 
@@ -494,24 +493,24 @@ __OCP_FP_HOST_DEVICE_STATIC__ T to_float(uint32_t u32, int8_t scale_exp) {
       if (diff > dstEnc.ManBits + 1) return makezero<T>(dstE, signbit<E, sat>(u32));
 
       dstExp = 0;  // Subnormal
-      dstMan |= (uint32_t)1 << dstEnc.ManBits;
+      dstMan |= (__hip_uint32_t)1 << dstEnc.ManBits;
 
       auto roundBitShift = diff - 1;
-      auto roundBit = (dstMan & ((uint32_t)1 << roundBitShift)) != 0;
-      auto stickyMask = ((uint32_t)1 << roundBitShift) - 1;
+      auto roundBit = (dstMan & ((__hip_uint32_t)1 << roundBitShift)) != 0;
+      auto stickyMask = ((__hip_uint32_t)1 << roundBitShift) - 1;
       auto stickyBits = dstMan & stickyMask;
-      auto odd = (dstMan & ((uint32_t)1 << diff)) != 0;
+      auto odd = (dstMan & ((__hip_uint32_t)1 << diff)) != 0;
 
       dstMan >>= diff;
 
       if ((roundBit && stickyBits != 0) || (roundBit && odd)) {
         ++dstMan;
-        if ((dstMan & ((uint32_t)1 << dstEnc.ManBits)) != 0) ++dstExp;
+        if ((dstMan & ((__hip_uint32_t)1 << dstEnc.ManBits)) != 0) ++dstExp;
       }
 
       dstMan &= dstEnc.ManMask;
     } else {
-      dstExp = (uint32_t)(exp + scale_exp + dstEnc.ExpBias);
+      dstExp = (__hip_uint32_t)(exp + scale_exp + dstEnc.ExpBias);
 
       // Overflow: return infinity (gfx950 HW behavior)
       if (dstExp >= dstEnc.ExpMask) return makeinf<T>(dstE, signbit<E, sat>(u32));
@@ -526,21 +525,21 @@ __OCP_FP_HOST_DEVICE_STATIC__ T to_float(uint32_t u32, int8_t scale_exp) {
     float f32;
     __amd_fp16_storage_t fp16[2];
     __amd_bf16_storage_t bf16[2];
-    uint32_t u32;
+    __hip_uint32_t u32;
   } u;
   u.u32 = dst;
-  if constexpr (std::is_same<T, float>())
+  if constexpr (__hip_internal::is_same<T, float>())
     return u.f32;
-  else if constexpr (std::is_same<T, __amd_fp16_storage_t>())
+  else if constexpr (__hip_internal::is_same<T, __amd_fp16_storage_t>())
     return u.fp16[0];
-  else if constexpr (std::is_same<T, __amd_bf16_storage_t>())
+  else if constexpr (__hip_internal::is_same<T, __amd_bf16_storage_t>())
     return u.bf16[0];
   else
     __builtin_trap();
 }
 
 template <typename T, Encoding E, bool sat>
-__OCP_FP_HOST_DEVICE_STATIC__ uint32_t from_float_sr(T f, uint32_t seed, int8_t scale_exp) {
+__OCP_FP_HOST_DEVICE_STATIC__ __hip_uint32_t from_float_sr(T f, __hip_uint32_t seed, __hip_int8_t scale_exp) {
   // We do not support bf16/fp16 <-> float
   static_assert(E != Encoding::IEEE754 && E != Encoding::E5M10 && E != Encoding::E8M7, "");
   static_assert(sizeof(__amd_fp16_storage_t[2]) == sizeof(float), "");
@@ -549,32 +548,32 @@ __OCP_FP_HOST_DEVICE_STATIC__ uint32_t from_float_sr(T f, uint32_t seed, int8_t 
     float f32;
     __amd_fp16_storage_t fp16[2];
     __amd_bf16_storage_t bf16[2];
-    uint32_t u32;
+    __hip_uint32_t u32;
   } u{0};
 
-  if constexpr (std::is_same<T, float>())
+  if constexpr (__hip_internal::is_same<T, float>())
     u.f32 = f;
-  else if constexpr (std::is_same<T, __amd_fp16_storage_t>())
+  else if constexpr (__hip_internal::is_same<T, __amd_fp16_storage_t>())
     u.fp16[0] = f;
-  else if constexpr (std::is_same<T, __amd_bf16_storage_t>())
+  else if constexpr (__hip_internal::is_same<T, __amd_bf16_storage_t>())
     u.bf16[0] = f;
   else
     __builtin_trap();
 
   const auto& enc = encodings[(size_t)E];
   const auto srcE = []() -> Encoding {
-    if constexpr (std::is_same<T, float>())
+    if constexpr (__hip_internal::is_same<T, float>())
       return Encoding::IEEE754;
-    else if constexpr (std::is_same<T, __amd_fp16_storage_t>())
+    else if constexpr (__hip_internal::is_same<T, __amd_fp16_storage_t>())
       return Encoding::E5M10;
-    else if constexpr (std::is_same<T, __amd_bf16_storage_t>())
+    else if constexpr (__hip_internal::is_same<T, __amd_bf16_storage_t>())
       return Encoding::E8M7;
     else
       __builtin_trap();
   }();
   const auto& srcEnc = encodings[(size_t)srcE];
 
-  auto srcU32 = u.u32;  // (srcE == Encoding::IEEE754) ? U32(f) : (uint32_t)f;
+  auto srcU32 = u.u32;  // (srcE == Encoding::IEEE754) ? U32(f) : (__hip_uint32_t)f;
   auto signBit = signbit<srcE, false>(srcU32);
   auto sign = signBit << (enc.ExpBits + enc.ManBits);
 
@@ -589,7 +588,7 @@ __OCP_FP_HOST_DEVICE_STATIC__ uint32_t from_float_sr(T f, uint32_t seed, int8_t 
   auto srcExp = exponent<srcE, false>(srcU32);
   if (enc.MxScale) {
     if (issubnorm<srcE, false>(srcU32)) {
-      auto leadbit = (uint32_t)1 << srcEnc.ManBits;
+      auto leadbit = (__hip_uint32_t)1 << srcEnc.ManBits;
       while ((srcMan & leadbit) == 0) {
         srcMan <<= 1;
         srcExp -= 1;
@@ -613,12 +612,12 @@ __OCP_FP_HOST_DEVICE_STATIC__ uint32_t from_float_sr(T f, uint32_t seed, int8_t 
     subnorm = true;
     exp = 0;
 
-    auto diff = (uint32_t)(enc.MinExp - srcExp);
+    auto diff = (__hip_uint32_t)(enc.MinExp - srcExp);
     if (diff >= 32) {
       man = 0;
       srcMan = 0;
     } else {
-      srcMan |= (uint32_t)1 << srcEnc.ManBits;
+      srcMan |= (__hip_uint32_t)1 << srcEnc.ManBits;
       srcMan >>= diff;
     }
 
@@ -633,14 +632,14 @@ __OCP_FP_HOST_DEVICE_STATIC__ uint32_t from_float_sr(T f, uint32_t seed, int8_t 
   man += seed >> sr_shift;
 
   // Increment exponent when mantissa overflows due to rounding
-  if (man >= (uint32_t)1 << srcEnc.ManBits) ++exp;
+  if (man >= (__hip_uint32_t)1 << srcEnc.ManBits) ++exp;
   man >>= (srcEnc.ManBits - enc.ManBits);
   man &= enc.ManMask;
 
   if (exp > enc.MaxExp) return inf<E, sat>(signBit);
 
-  auto biasedExp = (uint32_t)exp;
-  if (!subnorm) biasedExp = (uint32_t)(exp + enc.ExpBias);
+  auto biasedExp = (__hip_uint32_t)exp;
+  if (!subnorm) biasedExp = (__hip_uint32_t)(exp + enc.ExpBias);
   biasedExp &= enc.ExpMask;
 
   auto val = sign | biasedExp << enc.ManBits | man;
@@ -654,7 +653,7 @@ __OCP_FP_HOST_DEVICE_STATIC__ uint32_t from_float_sr(T f, uint32_t seed, int8_t 
 
 
 template <typename T, Encoding E, bool sat>
-__OCP_FP_HOST_DEVICE_STATIC__ uint32_t from_float(T f, int8_t scale_exp) {
+__OCP_FP_HOST_DEVICE_STATIC__ __hip_uint32_t from_float(T f, __hip_int8_t scale_exp) {
   // We do not support bf16/fp16 <-> float
   static_assert(E != Encoding::IEEE754 && E != Encoding::E5M10 && E != Encoding::E8M7, "");
   static_assert(sizeof(__amd_fp16_storage_t[2]) == sizeof(float), "");
@@ -663,32 +662,32 @@ __OCP_FP_HOST_DEVICE_STATIC__ uint32_t from_float(T f, int8_t scale_exp) {
     float f32;
     __amd_fp16_storage_t fp16[2];
     __amd_bf16_storage_t bf16[2];
-    uint32_t u32;
+    __hip_uint32_t u32;
   } u{0};
 
-  if constexpr (std::is_same<T, float>())
+  if constexpr (__hip_internal::is_same<T, float>())
     u.f32 = f;
-  else if constexpr (std::is_same<T, __amd_fp16_storage_t>())
+  else if constexpr (__hip_internal::is_same<T, __amd_fp16_storage_t>())
     u.fp16[0] = f;
-  else if constexpr (std::is_same<T, __amd_bf16_storage_t>())
+  else if constexpr (__hip_internal::is_same<T, __amd_bf16_storage_t>())
     u.bf16[0] = f;
   else
     __builtin_trap();
 
   const auto& enc = encodings[(size_t)E];
   const auto srcE = []() -> Encoding {
-    if constexpr (std::is_same<T, float>())
+    if constexpr (__hip_internal::is_same<T, float>())
       return Encoding::IEEE754;
-    else if constexpr (std::is_same<T, __amd_fp16_storage_t>())
+    else if constexpr (__hip_internal::is_same<T, __amd_fp16_storage_t>())
       return Encoding::E5M10;
-    else if constexpr (std::is_same<T, __amd_bf16_storage_t>())
+    else if constexpr (__hip_internal::is_same<T, __amd_bf16_storage_t>())
       return Encoding::E8M7;
     else
       __builtin_trap();
   }();
   const auto& srcEnc = encodings[(size_t)srcE];
 
-  auto srcU32 = u.u32;  // (srcE == Encoding::IEEE754) ? U32(f) : (uint32_t)f;
+  auto srcU32 = u.u32;  // (srcE == Encoding::IEEE754) ? U32(f) : (__hip_uint32_t)f;
   auto signBit = signbit<srcE, false>(srcU32);
   auto sign = signBit << (enc.ExpBits + enc.ManBits);
 
@@ -703,7 +702,7 @@ __OCP_FP_HOST_DEVICE_STATIC__ uint32_t from_float(T f, int8_t scale_exp) {
   auto srcExp = exponent<srcE, false>(srcU32);
   if (enc.MxScale) {
     if (issubnorm<srcE, false>(srcU32)) {
-      auto leadbit = (uint32_t)1 << srcEnc.ManBits;
+      auto leadbit = (__hip_uint32_t)1 << srcEnc.ManBits;
       while ((srcMan & leadbit) == 0) {
         srcMan <<= 1;
         srcExp -= 1;
@@ -717,7 +716,7 @@ __OCP_FP_HOST_DEVICE_STATIC__ uint32_t from_float(T f, int8_t scale_exp) {
 
   auto exp = srcExp;
   auto man = srcMan;
-  uint32_t stickyBits = 0;
+  __hip_uint32_t stickyBits = 0;
   bool subnorm = false;
 
   if (exp > enc.MaxExp) {
@@ -728,13 +727,13 @@ __OCP_FP_HOST_DEVICE_STATIC__ uint32_t from_float(T f, int8_t scale_exp) {
     subnorm = true;
     exp = 0;
 
-    auto diff = (uint32_t)(enc.MinExp - srcExp);
+    auto diff = (__hip_uint32_t)(enc.MinExp - srcExp);
     if (diff >= 32) {
       man = 0;
       srcMan = 0;
     } else {
-      srcMan |= (uint32_t)1 << srcEnc.ManBits;
-      stickyBits = srcMan & (((uint32_t)1 << diff) - (uint32_t)1);
+      srcMan |= (__hip_uint32_t)1 << srcEnc.ManBits;
+      stickyBits = srcMan & (((__hip_uint32_t)1 << diff) - (__hip_uint32_t)1);
       srcMan >>= diff;
 
       man = srcMan;
@@ -745,19 +744,19 @@ __OCP_FP_HOST_DEVICE_STATIC__ uint32_t from_float(T f, int8_t scale_exp) {
 
   auto roundBitShift = srcEnc.ManBits - (enc.ManBits + 1);
   auto roundBit = ((srcMan >> roundBitShift) & 1) != 0;
-  stickyBits |= srcMan & (((uint32_t)1 << roundBitShift) - 1);
+  stickyBits |= srcMan & (((__hip_uint32_t)1 << roundBitShift) - 1);
   auto odd = (man & 1) != 0;
 
   if ((roundBit && stickyBits != 0) || (roundBit && odd)) {
     ++man;
-    if ((man & ((uint32_t)1 << enc.ManBits)) != 0) ++exp;
+    if ((man & ((__hip_uint32_t)1 << enc.ManBits)) != 0) ++exp;
     man &= enc.ManMask;
   }
 
   if (exp > enc.MaxExp) return inf<E, sat>(signBit);
 
-  auto biasedExp = (uint32_t)exp;
-  if (!subnorm) biasedExp = (uint32_t)(exp + enc.ExpBias);
+  auto biasedExp = (__hip_uint32_t)exp;
+  if (!subnorm) biasedExp = (__hip_uint32_t)(exp + enc.ExpBias);
   biasedExp &= enc.ExpMask;
 
   auto val = sign | biasedExp << enc.ManBits | man;
@@ -886,47 +885,47 @@ __OCP_FP_HOST_DEVICE_STATIC__ OutType fp6_cvt_packedx16(InType in, int8_t scale 
 
 template <typename InType, typename OutType, typename float_base_t, Encoding in_encode,
           Encoding out_encode, bool sr = false>
-__OCP_FP_HOST_DEVICE_STATIC__ OutType fp6_cvt_packedx32(InType in, int8_t scale = 0,
-                                                        uint32_t seed = 0) {
+__OCP_FP_HOST_DEVICE_STATIC__ OutType fp6_cvt_packedx32(InType in, __hip_int8_t scale = 0,
+                                                        __hip_uint32_t seed = 0) {
   // This is tightly coupled with the definitions of the amd_ocp_types
-  constexpr bool in_float = std::is_same<InType, __amd_floatx32_storage_t>::value ||
-                            std::is_same<InType, __amd_fp16x32_storage_t>::value ||
-                            std::is_same<InType, __amd_bf16x32_storage_t>::value;
-  using other_type = std::conditional<in_float, OutType, InType>::type;
+  constexpr bool in_float = __hip_internal::is_same<InType, __amd_floatx32_storage_t>::value ||
+                            __hip_internal::is_same<InType, __amd_fp16x32_storage_t>::value ||
+                            __hip_internal::is_same<InType, __amd_bf16x32_storage_t>::value;
+  using other_type = __hip_internal::conditional<in_float, OutType, InType>::type;
 
   struct fp6x32_packed {
-    uint8_t val1 : 6;
-    uint8_t val2 : 6;
-    uint8_t val3 : 6;
-    uint8_t val4 : 6;
-    uint8_t val5 : 6;
-    uint8_t val6 : 6;
-    uint8_t val7 : 6;
-    uint8_t val8 : 6;
-    uint8_t val9 : 6;
-    uint8_t val10 : 6;
-    uint8_t val11 : 6;
-    uint8_t val12 : 6;
-    uint8_t val13 : 6;
-    uint8_t val14 : 6;
-    uint8_t val15 : 6;
-    uint8_t val16 : 6;
-    uint8_t val17 : 6;
-    uint8_t val18 : 6;
-    uint8_t val19 : 6;
-    uint8_t val20 : 6;
-    uint8_t val21 : 6;
-    uint8_t val22 : 6;
-    uint8_t val23 : 6;
-    uint8_t val24 : 6;
-    uint8_t val25 : 6;
-    uint8_t val26 : 6;
-    uint8_t val27 : 6;
-    uint8_t val28 : 6;
-    uint8_t val29 : 6;
-    uint8_t val30 : 6;
-    uint8_t val31 : 6;
-    uint8_t val32 : 6;
+    __hip_uint8_t val1 : 6;
+    __hip_uint8_t val2 : 6;
+    __hip_uint8_t val3 : 6;
+    __hip_uint8_t val4 : 6;
+    __hip_uint8_t val5 : 6;
+    __hip_uint8_t val6 : 6;
+    __hip_uint8_t val7 : 6;
+    __hip_uint8_t val8 : 6;
+    __hip_uint8_t val9 : 6;
+    __hip_uint8_t val10 : 6;
+    __hip_uint8_t val11 : 6;
+    __hip_uint8_t val12 : 6;
+    __hip_uint8_t val13 : 6;
+    __hip_uint8_t val14 : 6;
+    __hip_uint8_t val15 : 6;
+    __hip_uint8_t val16 : 6;
+    __hip_uint8_t val17 : 6;
+    __hip_uint8_t val18 : 6;
+    __hip_uint8_t val19 : 6;
+    __hip_uint8_t val20 : 6;
+    __hip_uint8_t val21 : 6;
+    __hip_uint8_t val22 : 6;
+    __hip_uint8_t val23 : 6;
+    __hip_uint8_t val24 : 6;
+    __hip_uint8_t val25 : 6;
+    __hip_uint8_t val26 : 6;
+    __hip_uint8_t val27 : 6;
+    __hip_uint8_t val28 : 6;
+    __hip_uint8_t val29 : 6;
+    __hip_uint8_t val30 : 6;
+    __hip_uint8_t val31 : 6;
+    __hip_uint8_t val32 : 6;
     unsigned long long padded;
   } __attribute__((packed));
 
@@ -940,69 +939,69 @@ __OCP_FP_HOST_DEVICE_STATIC__ OutType fp6_cvt_packedx32(InType in, int8_t scale 
   if constexpr (in_float) {
     if constexpr (sr) {
       u.fp6.val1 =
-          static_cast<uint8_t>(from_float_sr<float_base_t, out_encode, true>(in[0], seed, scale));
+          static_cast<__hip_uint8_t>(from_float_sr<float_base_t, out_encode, true>(in[0], seed, scale));
       u.fp6.val2 =
-          static_cast<uint8_t>(from_float_sr<float_base_t, out_encode, true>(in[1], seed, scale));
+          static_cast<__hip_uint8_t>(from_float_sr<float_base_t, out_encode, true>(in[1], seed, scale));
       u.fp6.val3 =
-          static_cast<uint8_t>(from_float_sr<float_base_t, out_encode, true>(in[2], seed, scale));
+          static_cast<__hip_uint8_t>(from_float_sr<float_base_t, out_encode, true>(in[2], seed, scale));
       u.fp6.val4 =
-          static_cast<uint8_t>(from_float_sr<float_base_t, out_encode, true>(in[3], seed, scale));
+          static_cast<__hip_uint8_t>(from_float_sr<float_base_t, out_encode, true>(in[3], seed, scale));
       u.fp6.val5 =
-          static_cast<uint8_t>(from_float_sr<float_base_t, out_encode, true>(in[4], seed, scale));
+          static_cast<__hip_uint8_t>(from_float_sr<float_base_t, out_encode, true>(in[4], seed, scale));
       u.fp6.val6 =
-          static_cast<uint8_t>(from_float_sr<float_base_t, out_encode, true>(in[5], seed, scale));
+          static_cast<__hip_uint8_t>(from_float_sr<float_base_t, out_encode, true>(in[5], seed, scale));
       u.fp6.val7 =
-          static_cast<uint8_t>(from_float_sr<float_base_t, out_encode, true>(in[6], seed, scale));
+          static_cast<__hip_uint8_t>(from_float_sr<float_base_t, out_encode, true>(in[6], seed, scale));
       u.fp6.val8 =
-          static_cast<uint8_t>(from_float_sr<float_base_t, out_encode, true>(in[7], seed, scale));
+          static_cast<__hip_uint8_t>(from_float_sr<float_base_t, out_encode, true>(in[7], seed, scale));
       u.fp6.val9 =
-          static_cast<uint8_t>(from_float_sr<float_base_t, out_encode, true>(in[8], seed, scale));
+          static_cast<__hip_uint8_t>(from_float_sr<float_base_t, out_encode, true>(in[8], seed, scale));
       u.fp6.val10 =
-          static_cast<uint8_t>(from_float_sr<float_base_t, out_encode, true>(in[9], seed, scale));
+          static_cast<__hip_uint8_t>(from_float_sr<float_base_t, out_encode, true>(in[9], seed, scale));
       u.fp6.val11 =
-          static_cast<uint8_t>(from_float_sr<float_base_t, out_encode, true>(in[10], seed, scale));
+          static_cast<__hip_uint8_t>(from_float_sr<float_base_t, out_encode, true>(in[10], seed, scale));
       u.fp6.val12 =
-          static_cast<uint8_t>(from_float_sr<float_base_t, out_encode, true>(in[11], seed, scale));
+          static_cast<__hip_uint8_t>(from_float_sr<float_base_t, out_encode, true>(in[11], seed, scale));
       u.fp6.val13 =
-          static_cast<uint8_t>(from_float_sr<float_base_t, out_encode, true>(in[12], seed, scale));
+          static_cast<__hip_uint8_t>(from_float_sr<float_base_t, out_encode, true>(in[12], seed, scale));
       u.fp6.val14 =
-          static_cast<uint8_t>(from_float_sr<float_base_t, out_encode, true>(in[13], seed, scale));
+          static_cast<__hip_uint8_t>(from_float_sr<float_base_t, out_encode, true>(in[13], seed, scale));
       u.fp6.val15 =
-          static_cast<uint8_t>(from_float_sr<float_base_t, out_encode, true>(in[14], seed, scale));
+          static_cast<__hip_uint8_t>(from_float_sr<float_base_t, out_encode, true>(in[14], seed, scale));
       u.fp6.val16 =
-          static_cast<uint8_t>(from_float_sr<float_base_t, out_encode, true>(in[15], seed, scale));
+          static_cast<__hip_uint8_t>(from_float_sr<float_base_t, out_encode, true>(in[15], seed, scale));
       u.fp6.val17 =
-          static_cast<uint8_t>(from_float_sr<float_base_t, out_encode, true>(in[16], seed, scale));
+          static_cast<__hip_uint8_t>(from_float_sr<float_base_t, out_encode, true>(in[16], seed, scale));
       u.fp6.val18 =
-          static_cast<uint8_t>(from_float_sr<float_base_t, out_encode, true>(in[17], seed, scale));
+          static_cast<__hip_uint8_t>(from_float_sr<float_base_t, out_encode, true>(in[17], seed, scale));
       u.fp6.val19 =
-          static_cast<uint8_t>(from_float_sr<float_base_t, out_encode, true>(in[18], seed, scale));
+          static_cast<__hip_uint8_t>(from_float_sr<float_base_t, out_encode, true>(in[18], seed, scale));
       u.fp6.val20 =
-          static_cast<uint8_t>(from_float_sr<float_base_t, out_encode, true>(in[19], seed, scale));
+          static_cast<__hip_uint8_t>(from_float_sr<float_base_t, out_encode, true>(in[19], seed, scale));
       u.fp6.val21 =
-          static_cast<uint8_t>(from_float_sr<float_base_t, out_encode, true>(in[20], seed, scale));
+          static_cast<__hip_uint8_t>(from_float_sr<float_base_t, out_encode, true>(in[20], seed, scale));
       u.fp6.val22 =
-          static_cast<uint8_t>(from_float_sr<float_base_t, out_encode, true>(in[21], seed, scale));
+          static_cast<__hip_uint8_t>(from_float_sr<float_base_t, out_encode, true>(in[21], seed, scale));
       u.fp6.val23 =
-          static_cast<uint8_t>(from_float_sr<float_base_t, out_encode, true>(in[22], seed, scale));
+          static_cast<__hip_uint8_t>(from_float_sr<float_base_t, out_encode, true>(in[22], seed, scale));
       u.fp6.val24 =
-          static_cast<uint8_t>(from_float_sr<float_base_t, out_encode, true>(in[23], seed, scale));
+          static_cast<__hip_uint8_t>(from_float_sr<float_base_t, out_encode, true>(in[23], seed, scale));
       u.fp6.val25 =
-          static_cast<uint8_t>(from_float_sr<float_base_t, out_encode, true>(in[24], seed, scale));
+          static_cast<__hip_uint8_t>(from_float_sr<float_base_t, out_encode, true>(in[24], seed, scale));
       u.fp6.val26 =
-          static_cast<uint8_t>(from_float_sr<float_base_t, out_encode, true>(in[25], seed, scale));
+          static_cast<__hip_uint8_t>(from_float_sr<float_base_t, out_encode, true>(in[25], seed, scale));
       u.fp6.val27 =
-          static_cast<uint8_t>(from_float_sr<float_base_t, out_encode, true>(in[26], seed, scale));
+          static_cast<__hip_uint8_t>(from_float_sr<float_base_t, out_encode, true>(in[26], seed, scale));
       u.fp6.val28 =
-          static_cast<uint8_t>(from_float_sr<float_base_t, out_encode, true>(in[27], seed, scale));
+          static_cast<__hip_uint8_t>(from_float_sr<float_base_t, out_encode, true>(in[27], seed, scale));
       u.fp6.val29 =
-          static_cast<uint8_t>(from_float_sr<float_base_t, out_encode, true>(in[28], seed, scale));
+          static_cast<__hip_uint8_t>(from_float_sr<float_base_t, out_encode, true>(in[28], seed, scale));
       u.fp6.val30 =
-          static_cast<uint8_t>(from_float_sr<float_base_t, out_encode, true>(in[29], seed, scale));
+          static_cast<__hip_uint8_t>(from_float_sr<float_base_t, out_encode, true>(in[29], seed, scale));
       u.fp6.val31 =
-          static_cast<uint8_t>(from_float_sr<float_base_t, out_encode, true>(in[30], seed, scale));
+          static_cast<__hip_uint8_t>(from_float_sr<float_base_t, out_encode, true>(in[30], seed, scale));
       u.fp6.val32 =
-          static_cast<uint8_t>(from_float_sr<float_base_t, out_encode, true>(in[31], seed, scale));
+          static_cast<__hip_uint8_t>(from_float_sr<float_base_t, out_encode, true>(in[31], seed, scale));
     } else {
       u.fp6.val1 = from_float<float_base_t, out_encode, true>(in[0], scale);
       u.fp6.val2 = from_float<float_base_t, out_encode, true>(in[1], scale);

--- a/projects/clr/hipamd/include/hip/amd_detail/amd_hip_ocp_host.hpp
+++ b/projects/clr/hipamd/include/hip/amd_detail/amd_hip_ocp_host.hpp
@@ -39,6 +39,22 @@ enum class Encoding : size_t {
 enum fp16 : __hip_uint16_t {};
 enum bf16 : __hip_uint16_t {};
 
+// Map a source storage type to its Encoding as a true compile-time constant.
+// Using a traits struct (rather than an IIFE assigned to `const auto`) guarantees
+// the value is usable as a non-type template argument across all supported
+// toolchains, including the comgr-bundled Clang used by HIPRTC on Windows where
+// implicit-constexpr lambda rules differ from the Linux host toolchain.
+template <typename T> struct EncodingOf;
+template <> struct EncodingOf<float> {
+  static constexpr Encoding value = Encoding::IEEE754;
+};
+template <> struct EncodingOf<__amd_fp16_storage_t> {
+  static constexpr Encoding value = Encoding::E5M10;
+};
+template <> struct EncodingOf<__amd_bf16_storage_t> {
+  static constexpr Encoding value = Encoding::E8M7;
+};
+
 struct Float {
   __hip_int32_t ExpBias;
   __hip_uint32_t ExpBits;
@@ -448,16 +464,11 @@ __OCP_FP_HOST_DEVICE_STATIC__ T to_float(__hip_uint32_t u32, __hip_int8_t scale_
   static_assert(E != Encoding::IEEE754 && E != Encoding::E5M10 && E != Encoding::E8M7, "");
 
   const auto& enc = encodings[(size_t)E];
-  const auto dstE = []() -> Encoding {
-    if constexpr (__hip_internal::is_same<T, float>())
-      return Encoding::IEEE754;
-    else if constexpr (__hip_internal::is_same<T, __amd_fp16_storage_t>())
-      return Encoding::E5M10;
-    else if constexpr (__hip_internal::is_same<T, __amd_bf16_storage_t>())
-      return Encoding::E8M7;
-    else
-      __builtin_trap();
-  }();
+  static_assert(__hip_internal::is_same<T, float>() ||
+                    __hip_internal::is_same<T, __amd_fp16_storage_t>() ||
+                    __hip_internal::is_same<T, __amd_bf16_storage_t>(),
+                "to_float: unsupported destination type T");
+  constexpr Encoding dstE = EncodingOf<T>::value;
   const auto& dstEnc = encodings[(size_t)dstE];
 
   if (isnan<E, sat>(u32) || (enc.MxScale && scale_exp == OCP_SCALE_EXP_NAN))
@@ -561,16 +572,11 @@ __OCP_FP_HOST_DEVICE_STATIC__ __hip_uint32_t from_float_sr(T f, __hip_uint32_t s
     __builtin_trap();
 
   const auto& enc = encodings[(size_t)E];
-  const auto srcE = []() -> Encoding {
-    if constexpr (__hip_internal::is_same<T, float>())
-      return Encoding::IEEE754;
-    else if constexpr (__hip_internal::is_same<T, __amd_fp16_storage_t>())
-      return Encoding::E5M10;
-    else if constexpr (__hip_internal::is_same<T, __amd_bf16_storage_t>())
-      return Encoding::E8M7;
-    else
-      __builtin_trap();
-  }();
+  static_assert(__hip_internal::is_same<T, float>() ||
+                    __hip_internal::is_same<T, __amd_fp16_storage_t>() ||
+                    __hip_internal::is_same<T, __amd_bf16_storage_t>(),
+                "from_float_sr: unsupported source type T");
+  constexpr Encoding srcE = EncodingOf<T>::value;
   const auto& srcEnc = encodings[(size_t)srcE];
 
   auto srcU32 = u.u32;  // (srcE == Encoding::IEEE754) ? U32(f) : (__hip_uint32_t)f;
@@ -675,16 +681,11 @@ __OCP_FP_HOST_DEVICE_STATIC__ __hip_uint32_t from_float(T f, __hip_int8_t scale_
     __builtin_trap();
 
   const auto& enc = encodings[(size_t)E];
-  const auto srcE = []() -> Encoding {
-    if constexpr (__hip_internal::is_same<T, float>())
-      return Encoding::IEEE754;
-    else if constexpr (__hip_internal::is_same<T, __amd_fp16_storage_t>())
-      return Encoding::E5M10;
-    else if constexpr (__hip_internal::is_same<T, __amd_bf16_storage_t>())
-      return Encoding::E8M7;
-    else
-      __builtin_trap();
-  }();
+  static_assert(__hip_internal::is_same<T, float>() ||
+                    __hip_internal::is_same<T, __amd_fp16_storage_t>() ||
+                    __hip_internal::is_same<T, __amd_bf16_storage_t>(),
+                "from_float: unsupported source type T");
+  constexpr Encoding srcE = EncodingOf<T>::value;
   const auto& srcEnc = encodings[(size_t)srcE];
 
   auto srcU32 = u.u32;  // (srcE == Encoding::IEEE754) ? U32(f) : (__hip_uint32_t)f;
@@ -797,7 +798,7 @@ __OCP_FP_HOST_DEVICE_STATIC__ OutType fp6_cvt_packedx16(InType in, __hip_int8_t 
     __hip_uint8_t val15 : 6;
     __hip_uint8_t val16 : 6;
     unsigned int padded;
-  } __attribute__((packed));
+  } __attribute__((packed, gcc_struct));
 
   static_assert(sizeof(other_type) == sizeof(fp6x16_packed));
   union {
@@ -927,7 +928,7 @@ __OCP_FP_HOST_DEVICE_STATIC__ OutType fp6_cvt_packedx32(InType in, __hip_int8_t 
     __hip_uint8_t val31 : 6;
     __hip_uint8_t val32 : 6;
     unsigned long long padded;
-  } __attribute__((packed));
+  } __attribute__((packed, gcc_struct));
 
   static_assert(sizeof(other_type) == sizeof(fp6x32_packed), "");
   union {

--- a/projects/clr/hipamd/include/hip/amd_detail/amd_hip_ocp_host.hpp
+++ b/projects/clr/hipamd/include/hip/amd_detail/amd_hip_ocp_host.hpp
@@ -771,31 +771,31 @@ __OCP_FP_HOST_DEVICE_STATIC__ __hip_uint32_t from_float(T f, __hip_int8_t scale_
 // ------------
 template <typename InType, typename OutType, typename float_base_t, Encoding in_encode,
           Encoding out_encode, bool sr = false>
-__OCP_FP_HOST_DEVICE_STATIC__ OutType fp6_cvt_packedx16(InType in, int8_t scale = 0,
-                                                        uint32_t seed = 0) {
+__OCP_FP_HOST_DEVICE_STATIC__ OutType fp6_cvt_packedx16(InType in, __hip_int8_t scale = 0,
+                                                        __hip_uint32_t seed = 0) {
   // This is tightly coupled with the definitions of the amd_ocp_types
-  constexpr bool in_float = std::is_same<InType, __amd_floatx16_storage_t>::value ||
-      std::is_same<InType, __amd_fp16x16_storage_t>::value ||
-      std::is_same<InType, __amd_bf16x16_storage_t>::value;
-  using other_type = std::conditional<in_float, OutType, InType>::type;
+  constexpr bool in_float = __hip_internal::is_same<InType, __amd_floatx16_storage_t>::value ||
+      __hip_internal::is_same<InType, __amd_fp16x16_storage_t>::value ||
+      __hip_internal::is_same<InType, __amd_bf16x16_storage_t>::value;
+  using other_type = __hip_internal::conditional<in_float, OutType, InType>::type;
 
   struct fp6x16_packed {
-    uint8_t val1 : 6;
-    uint8_t val2 : 6;
-    uint8_t val3 : 6;
-    uint8_t val4 : 6;
-    uint8_t val5 : 6;
-    uint8_t val6 : 6;
-    uint8_t val7 : 6;
-    uint8_t val8 : 6;
-    uint8_t val9 : 6;
-    uint8_t val10 : 6;
-    uint8_t val11 : 6;
-    uint8_t val12 : 6;
-    uint8_t val13 : 6;
-    uint8_t val14 : 6;
-    uint8_t val15 : 6;
-    uint8_t val16 : 6;
+    __hip_uint8_t val1 : 6;
+    __hip_uint8_t val2 : 6;
+    __hip_uint8_t val3 : 6;
+    __hip_uint8_t val4 : 6;
+    __hip_uint8_t val5 : 6;
+    __hip_uint8_t val6 : 6;
+    __hip_uint8_t val7 : 6;
+    __hip_uint8_t val8 : 6;
+    __hip_uint8_t val9 : 6;
+    __hip_uint8_t val10 : 6;
+    __hip_uint8_t val11 : 6;
+    __hip_uint8_t val12 : 6;
+    __hip_uint8_t val13 : 6;
+    __hip_uint8_t val14 : 6;
+    __hip_uint8_t val15 : 6;
+    __hip_uint8_t val16 : 6;
     unsigned int padded;
   } __attribute__((packed));
 
@@ -809,37 +809,37 @@ __OCP_FP_HOST_DEVICE_STATIC__ OutType fp6_cvt_packedx16(InType in, int8_t scale 
   if constexpr (in_float) {
     if constexpr (sr) {
       u.fp6.val1 =
-          static_cast<uint8_t>(from_float_sr<float_base_t, out_encode, true>(in[0], seed, scale));
+          static_cast<__hip_uint8_t>(from_float_sr<float_base_t, out_encode, true>(in[0], seed, scale));
       u.fp6.val2 =
-          static_cast<uint8_t>(from_float_sr<float_base_t, out_encode, true>(in[1], seed, scale));
+          static_cast<__hip_uint8_t>(from_float_sr<float_base_t, out_encode, true>(in[1], seed, scale));
       u.fp6.val3 =
-          static_cast<uint8_t>(from_float_sr<float_base_t, out_encode, true>(in[2], seed, scale));
+          static_cast<__hip_uint8_t>(from_float_sr<float_base_t, out_encode, true>(in[2], seed, scale));
       u.fp6.val4 =
-          static_cast<uint8_t>(from_float_sr<float_base_t, out_encode, true>(in[3], seed, scale));
+          static_cast<__hip_uint8_t>(from_float_sr<float_base_t, out_encode, true>(in[3], seed, scale));
       u.fp6.val5 =
-          static_cast<uint8_t>(from_float_sr<float_base_t, out_encode, true>(in[4], seed, scale));
+          static_cast<__hip_uint8_t>(from_float_sr<float_base_t, out_encode, true>(in[4], seed, scale));
       u.fp6.val6 =
-          static_cast<uint8_t>(from_float_sr<float_base_t, out_encode, true>(in[5], seed, scale));
+          static_cast<__hip_uint8_t>(from_float_sr<float_base_t, out_encode, true>(in[5], seed, scale));
       u.fp6.val7 =
-          static_cast<uint8_t>(from_float_sr<float_base_t, out_encode, true>(in[6], seed, scale));
+          static_cast<__hip_uint8_t>(from_float_sr<float_base_t, out_encode, true>(in[6], seed, scale));
       u.fp6.val8 =
-          static_cast<uint8_t>(from_float_sr<float_base_t, out_encode, true>(in[7], seed, scale));
+          static_cast<__hip_uint8_t>(from_float_sr<float_base_t, out_encode, true>(in[7], seed, scale));
       u.fp6.val9 =
-          static_cast<uint8_t>(from_float_sr<float_base_t, out_encode, true>(in[8], seed, scale));
+          static_cast<__hip_uint8_t>(from_float_sr<float_base_t, out_encode, true>(in[8], seed, scale));
       u.fp6.val10 =
-          static_cast<uint8_t>(from_float_sr<float_base_t, out_encode, true>(in[9], seed, scale));
+          static_cast<__hip_uint8_t>(from_float_sr<float_base_t, out_encode, true>(in[9], seed, scale));
       u.fp6.val11 =
-          static_cast<uint8_t>(from_float_sr<float_base_t, out_encode, true>(in[10], seed, scale));
+          static_cast<__hip_uint8_t>(from_float_sr<float_base_t, out_encode, true>(in[10], seed, scale));
       u.fp6.val12 =
-          static_cast<uint8_t>(from_float_sr<float_base_t, out_encode, true>(in[11], seed, scale));
+          static_cast<__hip_uint8_t>(from_float_sr<float_base_t, out_encode, true>(in[11], seed, scale));
       u.fp6.val13 =
-          static_cast<uint8_t>(from_float_sr<float_base_t, out_encode, true>(in[12], seed, scale));
+          static_cast<__hip_uint8_t>(from_float_sr<float_base_t, out_encode, true>(in[12], seed, scale));
       u.fp6.val14 =
-          static_cast<uint8_t>(from_float_sr<float_base_t, out_encode, true>(in[13], seed, scale));
+          static_cast<__hip_uint8_t>(from_float_sr<float_base_t, out_encode, true>(in[13], seed, scale));
       u.fp6.val15 =
-          static_cast<uint8_t>(from_float_sr<float_base_t, out_encode, true>(in[14], seed, scale));
+          static_cast<__hip_uint8_t>(from_float_sr<float_base_t, out_encode, true>(in[14], seed, scale));
       u.fp6.val16 =
-          static_cast<uint8_t>(from_float_sr<float_base_t, out_encode, true>(in[15], seed, scale));
+          static_cast<__hip_uint8_t>(from_float_sr<float_base_t, out_encode, true>(in[15], seed, scale));
     } else {
       u.fp6.val1 = from_float<float_base_t, out_encode, true>(in[0], scale);
       u.fp6.val2 = from_float<float_base_t, out_encode, true>(in[1], scale);

--- a/projects/clr/hipamd/include/hip/amd_detail/host_defines.h
+++ b/projects/clr/hipamd/include/hip/amd_detail/host_defines.h
@@ -355,17 +355,6 @@ struct NumericLimits<double> {
   static constexpr double minimum()    { return -maximum(); }
 };
 
-template <typename T, size_t N> struct array {
-  T __elements[N];
-#if __cplusplus >= 201402L
-  constexpr T& operator[](size_t i) { return __elements[i]; }
-#else
-  T& operator[](size_t i) { return __elements[i]; }
-#endif
-  constexpr const T& operator[](size_t i) const { return __elements[i]; }
-  constexpr size_t size() const { return N; }
-};
-
 #if defined(_MSC_VER) && !defined(__clang__)
 // MSVC lacks __builtin_copysignf. Copy the sign bit of y onto x bit-for-bit;
 // this matches the behavior of the GCC/Clang intrinsic exactly.

--- a/projects/clr/hipamd/include/hip/amd_detail/host_defines.h
+++ b/projects/clr/hipamd/include/hip/amd_detail/host_defines.h
@@ -345,6 +345,8 @@ template <>
 struct NumericLimits<float> {
   static constexpr float maximum()    { return __builtin_bit_cast(float, 0x7f800000); }
   static constexpr float minimum()    { return -maximum(); }
+  static constexpr float quiet_NaN()  { return __builtin_nanf(""); }
+  static constexpr float infinity()   { return __builtin_huge_valf(); }
 };
 
 template <>
@@ -352,6 +354,15 @@ struct NumericLimits<double> {
   static constexpr double maximum()    { return __builtin_bit_cast(double, 0x7FF0000000000000LL); }
   static constexpr double minimum()    { return -maximum(); }
 };
+
+template <typename T, size_t N> struct array {
+  T __elements[N];
+  constexpr T& operator[](size_t i) { return __elements[i]; }
+  constexpr const T& operator[](size_t i) const { return __elements[i]; }
+  constexpr size_t size() const { return N; }
+};
+
+inline constexpr float copysign(float x, float y) { return __builtin_copysignf(x, y); }
 
 }  // namespace __hip_internal
 typedef __hip_internal::uint8_t __hip_uint8_t;

--- a/projects/clr/hipamd/include/hip/amd_detail/host_defines.h
+++ b/projects/clr/hipamd/include/hip/amd_detail/host_defines.h
@@ -357,12 +357,28 @@ struct NumericLimits<double> {
 
 template <typename T, size_t N> struct array {
   T __elements[N];
+#if __cplusplus >= 201402L
   constexpr T& operator[](size_t i) { return __elements[i]; }
+#else
+  T& operator[](size_t i) { return __elements[i]; }
+#endif
   constexpr const T& operator[](size_t i) const { return __elements[i]; }
   constexpr size_t size() const { return N; }
 };
 
+#if defined(_MSC_VER) && !defined(__clang__)
+// MSVC lacks __builtin_copysignf. Copy the sign bit of y onto x bit-for-bit;
+// this matches the behavior of the GCC/Clang intrinsic exactly.
+inline float copysign(float x, float y) {
+  union { float f; unsigned int u; } ux, uy;
+  ux.f = x;
+  uy.f = y;
+  ux.u = (ux.u & 0x7FFFFFFFu) | (uy.u & 0x80000000u);
+  return ux.f;
+}
+#else
 inline constexpr float copysign(float x, float y) { return __builtin_copysignf(x, y); }
+#endif
 
 }  // namespace __hip_internal
 typedef __hip_internal::uint8_t __hip_uint8_t;

--- a/projects/clr/hipamd/include/hip/amd_detail/host_defines.h
+++ b/projects/clr/hipamd/include/hip/amd_detail/host_defines.h
@@ -212,6 +212,22 @@ template <size_t... Ints>
 constexpr index_sequence<Ints...> make_index_sequence_value(index_sequence<Ints...>) {
   return {};
 }
+
+template <typename T> struct numeric_limits {};
+template <> struct numeric_limits<float> {
+  static constexpr float quiet_NaN() { return __builtin_nanf(""); }
+  static constexpr float infinity() { return __builtin_huge_valf(); }
+};
+
+template <typename T, size_t N> struct array {
+  T __elements[N];
+  constexpr T& operator[](size_t i) { return __elements[i]; }
+  constexpr const T& operator[](size_t i) const { return __elements[i]; }
+  constexpr size_t size() const { return N; }
+};
+
+inline constexpr float copysign(float x, float y) { return __builtin_copysignf(x, y); }
+
 }  // namespace __hip_internal
 typedef __hip_internal::uint8_t __hip_uint8_t;
 typedef __hip_internal::uint16_t __hip_uint16_t;

--- a/projects/clr/hipamd/include/hip/amd_detail/host_defines.h
+++ b/projects/clr/hipamd/include/hip/amd_detail/host_defines.h
@@ -221,12 +221,28 @@ template <> struct numeric_limits<float> {
 
 template <typename T, size_t N> struct array {
   T __elements[N];
+#if __cplusplus >= 201402L
   constexpr T& operator[](size_t i) { return __elements[i]; }
+#else
+  T& operator[](size_t i) { return __elements[i]; }
+#endif
   constexpr const T& operator[](size_t i) const { return __elements[i]; }
   constexpr size_t size() const { return N; }
 };
 
+#if defined(_MSC_VER) && !defined(__clang__)
+// MSVC lacks __builtin_copysignf. Copy the sign bit of y onto x bit-for-bit;
+// this matches the behavior of the GCC/Clang intrinsic exactly.
+inline float copysign(float x, float y) {
+  union { float f; unsigned int u; } ux, uy;
+  ux.f = x;
+  uy.f = y;
+  ux.u = (ux.u & 0x7FFFFFFFu) | (uy.u & 0x80000000u);
+  return ux.f;
+}
+#else
 inline constexpr float copysign(float x, float y) { return __builtin_copysignf(x, y); }
+#endif
 
 }  // namespace __hip_internal
 typedef __hip_internal::uint8_t __hip_uint8_t;

--- a/projects/clr/hipamd/src/hiprtc/CMakeLists.txt
+++ b/projects/clr/hipamd/src/hiprtc/CMakeLists.txt
@@ -179,8 +179,6 @@ ${PROJECT_SOURCE_DIR}/include/hip/amd_detail/amd_hip_fp8.h
 ${PROJECT_SOURCE_DIR}/include/hip/amd_detail/amd_hip_ocp_host.hpp
 ${PROJECT_SOURCE_DIR}/include/hip/amd_detail/amd_hip_fp6.h
 ${PROJECT_SOURCE_DIR}/include/hip/amd_detail/amd_hip_fp4.h
-${PROJECT_SOURCE_DIR}/include/hip/amd_detail/amd_hip_ocp_fp.hpp
-${PROJECT_SOURCE_DIR}/include/hip/amd_detail/amd_hip_ocp_fp_cxx.hpp
 )
 
 # Generate required HIPRTC files.

--- a/projects/clr/hipamd/src/hiprtc/CMakeLists.txt
+++ b/projects/clr/hipamd/src/hiprtc/CMakeLists.txt
@@ -176,6 +176,11 @@ ${PROJECT_SOURCE_DIR}/include/hip/amd_detail/amd_hip_bf16.h
 ${PROJECT_SOURCE_DIR}/include/hip/amd_detail/amd_hip_ocp_types.h
 ${PROJECT_SOURCE_DIR}/include/hip/amd_detail/amd_hip_mx_common.h
 ${PROJECT_SOURCE_DIR}/include/hip/amd_detail/amd_hip_fp8.h
+${PROJECT_SOURCE_DIR}/include/hip/amd_detail/amd_hip_ocp_host.hpp
+${PROJECT_SOURCE_DIR}/include/hip/amd_detail/amd_hip_fp6.h
+${PROJECT_SOURCE_DIR}/include/hip/amd_detail/amd_hip_fp4.h
+${PROJECT_SOURCE_DIR}/include/hip/amd_detail/amd_hip_ocp_fp.hpp
+${PROJECT_SOURCE_DIR}/include/hip/amd_detail/amd_hip_ocp_fp_cxx.hpp
 )
 
 # Generate required HIPRTC files.

--- a/projects/clr/hipamd/src/hiprtc/CMakeLists.txt
+++ b/projects/clr/hipamd/src/hiprtc/CMakeLists.txt
@@ -171,6 +171,11 @@ ${PROJECT_SOURCE_DIR}/include/hip/amd_detail/amd_hip_bf16.h
 ${PROJECT_SOURCE_DIR}/include/hip/amd_detail/amd_hip_ocp_types.h
 ${PROJECT_SOURCE_DIR}/include/hip/amd_detail/amd_hip_mx_common.h
 ${PROJECT_SOURCE_DIR}/include/hip/amd_detail/amd_hip_fp8.h
+${PROJECT_SOURCE_DIR}/include/hip/amd_detail/amd_hip_ocp_host.hpp
+${PROJECT_SOURCE_DIR}/include/hip/amd_detail/amd_hip_fp6.h
+${PROJECT_SOURCE_DIR}/include/hip/amd_detail/amd_hip_fp4.h
+${PROJECT_SOURCE_DIR}/include/hip/amd_detail/amd_hip_ocp_fp.hpp
+${PROJECT_SOURCE_DIR}/include/hip/amd_detail/amd_hip_ocp_fp_cxx.hpp
 )
 
 # Generate required HIPRTC files.

--- a/projects/hip-tests/catch/unit/rtc/CMakeLists.txt
+++ b/projects/hip-tests/catch/unit/rtc/CMakeLists.txt
@@ -34,6 +34,8 @@ set(AMD_TEST_SRC
     hiprtc_bfloat16_HeaderTst.cc
     hiprtc_fp8.cc
     hipRtcSpirvCompilation.cc
+    hiprtc_fp4.cc
+    hiprtc_fp6.cc
 )
 
 if(UNIX)

--- a/projects/hip-tests/catch/unit/rtc/CMakeLists.txt
+++ b/projects/hip-tests/catch/unit/rtc/CMakeLists.txt
@@ -33,6 +33,8 @@ set(AMD_TEST_SRC
     hiprtc_Bitcode_UndefinedFn.cc
     hiprtc_bfloat16_HeaderTst.cc
     hiprtc_fp8.cc
+    hiprtc_fp4.cc
+    hiprtc_fp6.cc
 )
 
 add_custom_target(copyRtcHeaders ALL

--- a/projects/hip-tests/catch/unit/rtc/hiprtc_fp4.cc
+++ b/projects/hip-tests/catch/unit/rtc/hiprtc_fp4.cc
@@ -1,0 +1,118 @@
+/*
+Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+
+
+#include <hip_test_common.hh>
+
+#include <vector>
+#include <string>
+
+#include <hip/hiprtc.h>
+#include <hip/hip_fp4.h>
+
+// FP4 has only one OCP encoding: E2M1.
+// Representable magnitudes in E2M1: {0, 0.5, 1.0, 1.5, 2.0, 3.0, 4.0, 6.0}.
+// We feed only exactly-representable values so GPU output (which may take the
+// gfx950 hardware path) matches CPU output (which always takes the software
+// fcbx::* fallback) bit-for-bit, with no rounding ambiguity.
+TEST_CASE("Unit_hiprtc_fp4_simple") {
+  constexpr const char* source = R"(
+extern "C" __global__ void float_to_fp4_to_float(float* out, float* in, size_t size) {
+  size_t i = threadIdx.x;
+  if (i < size) {
+    __hip_fp4_e2m1 tmp = __hip_fp4_e2m1(in[i]);
+    out[i] = float(tmp);
+  }
+}
+)";
+
+  hiprtcProgram prog;
+  HIPRTC_CHECK(hiprtcCreateProgram(&prog, source, "fp4.cu", 0, nullptr, nullptr));
+  hipDeviceProp_t props;
+  int device = 0;
+  HIP_CHECK(hipGetDeviceProperties(&props, device));
+#ifdef __HIP_PLATFORM_AMD__
+  std::string sarg = std::string("--gpu-architecture=") + props.gcnArchName;
+#else
+  std::string sarg = std::string("--fmad=false");
+#endif
+  const char* options[] = {sarg.c_str()};
+  hiprtcResult compileResult{hiprtcCompileProgram(prog, 1, options)};
+  size_t logSize;
+  HIPRTC_CHECK(hiprtcGetProgramLogSize(prog, &logSize));
+  if (logSize) {
+    std::string log(logSize, '\0');
+    HIPRTC_CHECK(hiprtcGetProgramLog(prog, &log[0]));
+    std::cout << log << '\n';
+  }
+  REQUIRE(compileResult == HIPRTC_SUCCESS);
+
+  size_t codeSize{};
+  HIPRTC_CHECK(hiprtcGetCodeSize(prog, &codeSize));
+
+  std::vector<char> code(codeSize);
+  HIPRTC_CHECK(hiprtcGetCode(prog, code.data()));
+
+  HIPRTC_CHECK(hiprtcDestroyProgram(&prog));
+
+  // Inputs: every value below is exactly representable in FP4 E2M1, so no
+  // rounding occurs in either direction of the round-trip.
+  std::vector<float> in = {0.0f,  0.5f, -0.5f, 1.0f, -1.0f,
+                           1.5f, -1.5f,  2.0f, 3.0f,  4.0f};
+  const size_t size = in.size();
+
+  float *d_in, *d_out;
+  HIP_CHECK(hipMalloc(&d_in, size * sizeof(float)));
+  HIP_CHECK(hipMalloc(&d_out, size * sizeof(float)));
+
+  hipModule_t module;
+  hipFunction_t kernel;
+  HIP_CHECK(hipModuleLoadData(&module, code.data()));
+  HIP_CHECK(hipModuleGetFunction(&kernel, module, "float_to_fp4_to_float"));
+
+  HIP_CHECK(hipMemcpy(d_in, in.data(), size * sizeof(float), hipMemcpyHostToDevice));
+  HIP_CHECK(hipMemset(d_out, 0, size * sizeof(float)));
+
+  struct {
+    float* out;
+    float* in;
+    size_t size;
+  } args{d_out, d_in, size};
+
+  auto arg_size = sizeof(args);
+  void* config[] = {HIP_LAUNCH_PARAM_BUFFER_POINTER, &args, HIP_LAUNCH_PARAM_BUFFER_SIZE, &arg_size,
+                    HIP_LAUNCH_PARAM_END};
+
+  HIP_CHECK(hipModuleLaunchKernel(kernel, 1, 1, 1, size, 1, 1, 0, nullptr, nullptr, config));
+
+  std::vector<float> out(size, 0.0f);
+  HIP_CHECK(hipMemcpy(out.data(), d_out, size * sizeof(float), hipMemcpyDeviceToHost));
+
+  for (size_t i = 0; i < size; i++) {
+    __hip_fp4_e2m1 tmp = __hip_fp4_e2m1(in[i]);
+    float cpu_out = float(tmp);
+    INFO("Index: " << i << " in: " << in[i] << " GPU: " << out[i] << " cpu: " << cpu_out);
+    REQUIRE(cpu_out == out[i]);
+  }
+
+  HIP_CHECK(hipFree(d_in));
+  HIP_CHECK(hipFree(d_out));
+
+  HIP_CHECK(hipModuleUnload(module));
+}

--- a/projects/hip-tests/catch/unit/rtc/hiprtc_fp4.cc
+++ b/projects/hip-tests/catch/unit/rtc/hiprtc_fp4.cc
@@ -26,18 +26,13 @@ THE SOFTWARE.
 #include <hip/hiprtc.h>
 #include <hip/hip_fp4.h>
 
-// FP4 has only one OCP encoding: E2M1.
-// Representable magnitudes in E2M1: {0, 0.5, 1.0, 1.5, 2.0, 3.0, 4.0, 6.0}.
-// We feed only exactly-representable values so GPU output (which may take the
-// gfx950 hardware path) matches CPU output (which always takes the software
-// fcbx::* fallback) bit-for-bit, with no rounding ambiguity.
 TEST_CASE("Unit_hiprtc_fp4_simple") {
   constexpr const char* source = R"(
 extern "C" __global__ void float_to_fp4_to_float(float* out, float* in, size_t size) {
   size_t i = threadIdx.x;
   if (i < size) {
     __hip_fp4_e2m1 tmp = __hip_fp4_e2m1(in[i]);
-    out[i] = float(tmp);
+    out[i] = tmp;
   }
 }
 )";
@@ -72,7 +67,7 @@ extern "C" __global__ void float_to_fp4_to_float(float* out, float* in, size_t s
   HIPRTC_CHECK(hiprtcDestroyProgram(&prog));
 
   // Inputs: every value below is exactly representable in FP4 E2M1, so no
-  // rounding occurs in either direction of the round-trip.
+  // rounding occurs in either direction.
   std::vector<float> in = {0.0f,  0.5f, -0.5f, 1.0f, -1.0f,
                            1.5f, -1.5f,  2.0f, 3.0f,  4.0f};
   const size_t size = in.size();
@@ -106,7 +101,7 @@ extern "C" __global__ void float_to_fp4_to_float(float* out, float* in, size_t s
 
   for (size_t i = 0; i < size; i++) {
     __hip_fp4_e2m1 tmp = __hip_fp4_e2m1(in[i]);
-    float cpu_out = float(tmp);
+    float cpu_out = tmp;
     INFO("Index: " << i << " in: " << in[i] << " GPU: " << out[i] << " cpu: " << cpu_out);
     REQUIRE(cpu_out == out[i]);
   }

--- a/projects/hip-tests/catch/unit/rtc/hiprtc_fp6.cc
+++ b/projects/hip-tests/catch/unit/rtc/hiprtc_fp6.cc
@@ -1,0 +1,137 @@
+/*
+Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+
+
+#include <hip_test_common.hh>
+
+#include <vector>
+#include <string>
+
+#include <hip/hiprtc.h>
+#include <hip/hip_fp6.h>
+
+// FP6 has two OCP encodings: E2M3 and E3M2.
+// Inputs below are exactly representable in BOTH encodings (and also in
+// FP4 E2M1, in case the test is reused as a reference). This eliminates
+// rounding ambiguity, so the round-trip is equal regardless of whether the
+// kernel takes the gfx950 hardware path or the fcbx::* software fallback.
+TEST_CASE("Unit_hiprtc_fp6_simple") {
+  constexpr const char* source = R"(
+extern "C" __global__ void float_to_fp6_to_float(float* out, float* in, bool e2m3, size_t size) {
+  size_t i = threadIdx.x;
+  if (i < size) {
+    if (e2m3) {
+      __hip_fp6_e2m3 tmp = __hip_fp6_e2m3(in[i]);
+      out[i] = float(tmp);
+    } else {
+      __hip_fp6_e3m2 tmp = __hip_fp6_e3m2(in[i]);
+      out[i] = float(tmp);
+    }
+  }
+}
+)";
+
+  hiprtcProgram prog;
+  HIPRTC_CHECK(hiprtcCreateProgram(&prog, source, "fp6.cu", 0, nullptr, nullptr));
+  hipDeviceProp_t props;
+  int device = 0;
+  HIP_CHECK(hipGetDeviceProperties(&props, device));
+#ifdef __HIP_PLATFORM_AMD__
+  std::string sarg = std::string("--gpu-architecture=") + props.gcnArchName;
+#else
+  std::string sarg = std::string("--fmad=false");
+#endif
+  const char* options[] = {sarg.c_str()};
+  hiprtcResult compileResult{hiprtcCompileProgram(prog, 1, options)};
+  size_t logSize;
+  HIPRTC_CHECK(hiprtcGetProgramLogSize(prog, &logSize));
+  if (logSize) {
+    std::string log(logSize, '\0');
+    HIPRTC_CHECK(hiprtcGetProgramLog(prog, &log[0]));
+    std::cout << log << '\n';
+  }
+  REQUIRE(compileResult == HIPRTC_SUCCESS);
+
+  size_t codeSize{};
+  HIPRTC_CHECK(hiprtcGetCodeSize(prog, &codeSize));
+
+  std::vector<char> code(codeSize);
+  HIPRTC_CHECK(hiprtcGetCode(prog, code.data()));
+
+  HIPRTC_CHECK(hiprtcDestroyProgram(&prog));
+
+  // Values exactly representable in both FP6 E2M3 and E3M2.
+  std::vector<float> in = {0.0f,  0.5f, -0.5f, 1.0f, -1.0f,
+                           1.5f, -1.5f,  2.0f, 3.0f,  4.0f};
+  const size_t size = in.size();
+
+  float *d_in, *d_out;
+  HIP_CHECK(hipMalloc(&d_in, size * sizeof(float)));
+  HIP_CHECK(hipMalloc(&d_out, size * sizeof(float)));
+
+  hipModule_t module;
+  hipFunction_t kernel;
+  HIP_CHECK(hipModuleLoadData(&module, code.data()));
+  HIP_CHECK(hipModuleGetFunction(&kernel, module, "float_to_fp6_to_float"));
+
+  HIP_CHECK(hipMemcpy(d_in, in.data(), size * sizeof(float), hipMemcpyHostToDevice));
+  HIP_CHECK(hipMemset(d_out, 0, size * sizeof(float)));
+
+  struct {
+    float* out;
+    float* in;
+    bool e2m3;
+    size_t size;
+  } args{d_out, d_in, true, size};
+
+  auto arg_size = sizeof(args);
+  void* config[] = {HIP_LAUNCH_PARAM_BUFFER_POINTER, &args, HIP_LAUNCH_PARAM_BUFFER_SIZE, &arg_size,
+                    HIP_LAUNCH_PARAM_END};
+
+  // ---- E2M3 ----
+  HIP_CHECK(hipModuleLaunchKernel(kernel, 1, 1, 1, size, 1, 1, 0, nullptr, nullptr, config));
+
+  std::vector<float> out(size, 0.0f);
+  HIP_CHECK(hipMemcpy(out.data(), d_out, size * sizeof(float), hipMemcpyDeviceToHost));
+
+  for (size_t i = 0; i < size; i++) {
+    __hip_fp6_e2m3 tmp = __hip_fp6_e2m3(in[i]);
+    float cpu_out = float(tmp);
+    INFO("E2M3 Index: " << i << " in: " << in[i] << " GPU: " << out[i] << " cpu: " << cpu_out);
+    REQUIRE(cpu_out == out[i]);
+  }
+
+  // ---- E3M2 ----
+  args.e2m3 = false;
+  HIP_CHECK(hipMemset(d_out, 0, size * sizeof(float)));
+  HIP_CHECK(hipModuleLaunchKernel(kernel, 1, 1, 1, size, 1, 1, 0, nullptr, nullptr, config));
+
+  HIP_CHECK(hipMemcpy(out.data(), d_out, size * sizeof(float), hipMemcpyDeviceToHost));
+  for (size_t i = 0; i < size; i++) {
+    __hip_fp6_e3m2 tmp = __hip_fp6_e3m2(in[i]);
+    float cpu_out = float(tmp);
+    INFO("E3M2 Index: " << i << " in: " << in[i] << " GPU: " << out[i] << " cpu: " << cpu_out);
+    REQUIRE(cpu_out == out[i]);
+  }
+
+  HIP_CHECK(hipFree(d_in));
+  HIP_CHECK(hipFree(d_out));
+
+  HIP_CHECK(hipModuleUnload(module));
+}

--- a/projects/hip-tests/catch/unit/rtc/hiprtc_fp6.cc
+++ b/projects/hip-tests/catch/unit/rtc/hiprtc_fp6.cc
@@ -26,11 +26,6 @@ THE SOFTWARE.
 #include <hip/hiprtc.h>
 #include <hip/hip_fp6.h>
 
-// FP6 has two OCP encodings: E2M3 and E3M2.
-// Inputs below are exactly representable in BOTH encodings (and also in
-// FP4 E2M1, in case the test is reused as a reference). This eliminates
-// rounding ambiguity, so the round-trip is equal regardless of whether the
-// kernel takes the gfx950 hardware path or the fcbx::* software fallback.
 TEST_CASE("Unit_hiprtc_fp6_simple") {
   constexpr const char* source = R"(
 extern "C" __global__ void float_to_fp6_to_float(float* out, float* in, bool e2m3, size_t size) {
@@ -38,10 +33,10 @@ extern "C" __global__ void float_to_fp6_to_float(float* out, float* in, bool e2m
   if (i < size) {
     if (e2m3) {
       __hip_fp6_e2m3 tmp = __hip_fp6_e2m3(in[i]);
-      out[i] = float(tmp);
+      out[i] = tmp;
     } else {
       __hip_fp6_e3m2 tmp = __hip_fp6_e3m2(in[i]);
-      out[i] = float(tmp);
+      out[i] = tmp;
     }
   }
 }
@@ -112,7 +107,7 @@ extern "C" __global__ void float_to_fp6_to_float(float* out, float* in, bool e2m
 
   for (size_t i = 0; i < size; i++) {
     __hip_fp6_e2m3 tmp = __hip_fp6_e2m3(in[i]);
-    float cpu_out = float(tmp);
+    float cpu_out = tmp;
     INFO("E2M3 Index: " << i << " in: " << in[i] << " GPU: " << out[i] << " cpu: " << cpu_out);
     REQUIRE(cpu_out == out[i]);
   }
@@ -125,7 +120,7 @@ extern "C" __global__ void float_to_fp6_to_float(float* out, float* in, bool e2m
   HIP_CHECK(hipMemcpy(out.data(), d_out, size * sizeof(float), hipMemcpyDeviceToHost));
   for (size_t i = 0; i < size; i++) {
     __hip_fp6_e3m2 tmp = __hip_fp6_e3m2(in[i]);
-    float cpu_out = float(tmp);
+    float cpu_out = tmp;
     INFO("E3M2 Index: " << i << " in: " << in[i] << " GPU: " << out[i] << " cpu: " << cpu_out);
     REQUIRE(cpu_out == out[i]);
   }


### PR DESCRIPTION
## Motivation

Few apps are including hip headers like fp4, fp6 in HIPRTC kernels causing issues.

Adds the support of the hip headers fp4, fp6 to HIPRTC. Apps should be able to use fp4, fp6 types in hiprtc kernels provided by the HIPRTC default header.

## Technical Details

Append the fp4, fp6 headers to HIPRTC cmake and use datatypes from __hip_internal namespace instead of standard std namespace to avoid errors when the apps include these headers.

## JIRA ID

JIRA ID : ROCM-22232 (SWDEV-568272)

## Test Plan

Sample test which incudes fp4, fp6 headers in HIPRTC kernel. Also verified by using fp4, fp6 types in HIPRTC kernel even without including these headers explictly.  These should work since they are part of default header.

## Test Result

Pass

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
