### PR TITLE
Enable AI NIC by default

### DIFF
--- a/projects/rocprofiler-systems/CMakeLists.txt
+++ b/projects/rocprofiler-systems/CMakeLists.txt
@@ -224,7 +224,7 @@ rocprofiler_systems_add_option(CMAKE_CXX_STANDARD_REQUIRED
                                "Require C++ language standard" ON
 )
 rocprofiler_systems_add_option(ROCPROFSYS_USE_AINIC
-                               "Enable AI NIC profiling through AMD SMI" OFF
+                               "Enable AI NIC profiling through AMD SMI" ON
 )
 rocprofiler_systems_add_option(CMAKE_CXX_EXTENSIONS
                                "Compiler specific language extensions" OFF


### PR DESCRIPTION
## Motivation
<!-- Explain the purpose of this PR and the goals it aims to achieve. -->
Enable AI-NIC profiling in ROCm builds

## Technical Details
<!-- Explain the changes along with any relevant GitHub links. -->
CMake option, `ROCPROFSYS_USE_AINIC`, is now `ON` by default. 

## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->
AIPROFSYST-218
AIPROFSYST-3

## Test Plan
<!-- Explain any relevant testing done to verify this PR. -->
Manual validation on system with AI-NIC.
Run workflows.

## Test Result
<!-- Briefly summarize test outcomes. -->
Manual testing passed.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
