### PR TITLE
[ROCM-2678] Add src/commDump.cc to Meta license

### DIFF
--- a/projects/rccl/NOTICES.txt
+++ b/projects/rccl/NOTICES.txt
@@ -100,7 +100,7 @@ for more information and license details.
 
 _______________________________________________________________
 
-Dependencies on Latency Profiler (MIT License)
+Dependencies on Latency Profiler and ncclCommDump (MIT License)
 
     Copyright (c) Meta Platforms, Inc. and affiliates.
 
@@ -126,3 +126,4 @@ See:
 
     src/include/latency_profiler
     src/misc/latency_profiler
+    src/commDump.cc


### PR DESCRIPTION
Imported from [ROCm/rccl#2164] by @ahmd-k

## Motivation

Update the license provided by Meta to cover commDump.cc, code contributed by Meta (author @ahmd-k)

## Technical Details

Updated coverage in NOTICES.txt

## JIRA ID

ROCM-2678

## Test Plan

N/A

## Test Result

Passing copyright scan.

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
