### PR TITLE
[rocprofiler-compute][bugfix] fix duplicated generate_machine_specs() call

### DIFF
--- a/projects/rocprofiler-compute/src/rocprof_compute_base.py
+++ b/projects/rocprofiler-compute/src/rocprof_compute_base.py
@@ -88,7 +88,15 @@ class RocProfCompute:
 
         self.sanitize()
 
-        if self.__mode != "analyze":
+        # Skip machine specs generation for general list options that don't need it
+        # or will generate it themselves
+        skip_machine_specs = (
+            self.__args.specs
+            or self.__args.list_metrics is not None
+            or self.__args.list_blocks is not None
+        )
+
+        if self.__mode != "analyze" and not skip_machine_specs:
             self.generate_machine_specs()
 
         self.handle_list_args()

--- a/projects/rocprofiler-compute/src/rocprof_compute_base.py
+++ b/projects/rocprofiler-compute/src/rocprof_compute_base.py
@@ -91,7 +91,7 @@ class RocProfCompute:
         # Skip machine specs generation for general list options that don't need it
         # or will generate it themselves
         skip_machine_specs = (
-            self.__args.specs
+            getattr(self.__args, "specs", False)
             or self.__args.list_metrics is not None
             or self.__args.list_blocks is not None
         )


### PR DESCRIPTION
## Motivation

`generate_machine_specs()` calls are not needed for `--list-blocks` and `--list-metrics`.

## Technical Details

skip `generate_machine_specs()` where appropriate.

## JIRA ID

N/A

## Test Plan

local ctest
local pytest

## Test Result

- [x] local ctest
- [x] local pytest

Shared test result with #3507 

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
