### PR TITLE
RCCL-tests: enable gfx1151 in default build targets

### DIFF
--- a/projects/rccl-tests/CMakeLists.txt
+++ b/projects/rccl-tests/CMakeLists.txt
@@ -37,6 +37,7 @@ set(DEFAULT_GPUS
       gfx1100
       gfx1101
       gfx1102
+      gfx1151
       gfx1200
       gfx1201)
 

--- a/projects/rccl-tests/install.sh
+++ b/projects/rccl-tests/install.sh
@@ -15,7 +15,7 @@ function display_help()
     echo "    [--rccl_home] Specify custom path for RCCL installation (default: /opt/rocm)"
     echo "    [--mpi_home] Specify path to your MPI installation."
     echo "    [--hip_compiler] Specify path to HIP compiler (default: /opt/rocm/llvm/bin/amdclang++)"
-    echo "    [--gpu_targets] Specify GPU targets (default:gfx906,gfx908,gfx90a,gfx942,gfx950,gfx1030,gfx1100,gfx1101,gfx1102,gfx1200,gfx1201)"
+    echo "    [--gpu_targets] Specify GPU targets (default:gfx906,gfx908,gfx90a,gfx942,gfx950,gfx1030,gfx1100,gfx1101,gfx1102,gfx1151,gfx1200,gfx1201)"
 }
 
 # #################################################

--- a/projects/rccl-tests/src/Makefile
+++ b/projects/rccl-tests/src/Makefile
@@ -42,7 +42,7 @@ HIP_MINOR = $(shell echo $(HIP_VERSION) | cut -d "." -f 2)
 
 # Better define GPU_TARGETS in your environment to the minimal set
 # of archs to reduce compile time.
-# Currently, supports gfx906,gfx908,gfx90a,gfx942,gfx950,gfx1030,gfx1100,gfx1101,gfx1102,gfx1200,gfx1201
+# Currently, supports gfx906,gfx908,gfx90a,gfx942,gfx950,gfx1030,gfx1100,gfx1101,gfx1102,gfx1151,gfx1200,gfx1201
 ifndef GPU_TARGETS
 GPU_TARGETS = gfx906 gfx908 gfx90a
   ifeq ($(shell test "0$(HIP_MAJOR)" -ge 7; echo $$?),0)
@@ -55,7 +55,7 @@ GPU_TARGETS = gfx906 gfx908 gfx90a
     GPU_TARGETS += gfx950
     endif
   endif
-GPU_TARGETS += gfx1030 gfx1100 gfx1101 gfx1102 gfx1200 gfx1201
+GPU_TARGETS += gfx1030 gfx1100 gfx1101 gfx1102 gfx1151 gfx1200 gfx1201
 endif
 
 GPU_TARGETS_FLAGS = $(foreach target,$(GPU_TARGETS),"--offload-arch=$(target)")


### PR DESCRIPTION
### Summary

- Adds `gfx1151` to default CMake targets in `projects/rccl-tests/CMakeLists.txt` (`DEFAULT_GPUS`).
- Adds `gfx1151` to default Makefile targets in `projects/rccl-tests/src/Makefile` (`GPU_TARGETS`) and updates the "Currently supports ..." comment.
- Updates `projects/rccl-tests/install.sh` help text default GPU list to include `gfx1151`.

### Why

- PR #3415 enables gfx1151 in rccl, hence `rccl-tests` default install/build behavior should include gfx1151 out of the box so users do not need to pass `--gpu_targets gfx1151` manually.

### Test plan

- Configure CMake defaults and verify target list includes `gfx1151`:
  - `cmake -S projects/rccl-tests -B projects/rccl-tests/build-gfx1151-default -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER=/opt/rocm/core-7.12/llvm/bin/amdclang++ -DROCM_PATH=/opt/rocm/core-7.12`
- Build one test binary with defaults:
  - `cmake --build projects/rccl-tests/build-gfx1151-default -j4 --target all_reduce_perf`
- Smoke test:
  - `projects/rccl-tests/build-gfx1151-default/all_reduce_perf -g 1 -b 8 -e 8M -f 2 -n 5`
- Makefile/install helper validation on this system:
  - `ROCM_PATH=/opt/rocm/core-7.12 ./projects/rccl-tests/install.sh --rocm_home /opt/rocm/core-7.12 --hip_compiler /opt/rocm/core-7.12/llvm/bin/amdclang++`