### PR TITLE
Auto Labeler: Add ci:regression-detection label to rccl PRs

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -98,7 +98,7 @@
 - changed-files:
   - any-glob-to-any-file: 'shared/amdgpu-windows-interop/**/*'
 
-"ci:regression-detection"
+"ci:regression-detection":
 - changed-files:
   - any-glob-to-any-file: 'projects/rccl/**/*'
 

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -98,7 +98,7 @@
 - changed-files:
   - any-glob-to-any-file: 'shared/amdgpu-windows-interop/**/*'
 
-"ci:regression-detection":
+"ci: regression-detection":
 - changed-files:
   - any-glob-to-any-file: 'projects/rccl/**/*'
 

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -98,6 +98,10 @@
 - changed-files:
   - any-glob-to-any-file: 'shared/amdgpu-windows-interop/**/*'
 
+"ci:regression-detection"
+- changed-files:
+  - any-glob-to-any-file: 'projects/rccl/**/*'
+
 documentation:
 - changed-files:
   - any-glob-to-any-file:


### PR DESCRIPTION
## Motivation

Adds ci:regression-detection so that math-ci regression job automatically runs against rccl PRs

## Technical Details

- Config change added to labeler.yml

## Test Plan

Needs to be tested after merge
