### PR TITLE
[RCCL-tests] [UT] Rerun failed tests with delay to handle intermittent CI failures

### DIFF
--- a/projects/rccl-tests/test/test_AllGather.py
+++ b/projects/rccl-tests/test/test_AllGather.py
@@ -25,6 +25,7 @@ import itertools
 import math
 
 import pytest
+from .test_utils import run_with_retry
 
 ngpus = 0
 if os.environ.get('ROCR_VISIBLE_DEVICES') is not None:
@@ -64,7 +65,7 @@ def test_AllGatherSingleProcess(nthreads, ngpus_single, byte_range, op, step_fac
         if memory_type == "fine":
             args.insert(0, "HSA_FORCE_FINE_GRAIN_PCIE=1")
         args_str = " ".join(args)
-        rccl_test = subprocess.run(args_str, stdout=subprocess.PIPE, universal_newlines=True, shell=True)
+        rccl_test = run_with_retry(args_str)
     except subprocess.CalledProcessError as err:
         print(rccl_test.stdout)
         pytest.fail("AllGather test error(s) detected.")
@@ -101,7 +102,7 @@ def test_AllGatherMPI(request, nthreads, nprocs, ngpus_mpi, byte_range, op, step
                     "-d", datatype]
         args_str = " ".join(args)
         print(args_str)
-        rccl_test = subprocess.run(args_str, universal_newlines=True, shell=True)
+        rccl_test = run_with_retry(args_str)
     except subprocess.CalledProcessError as err:
         print(rccl_test.stdout)
         pytest.fail("AllGather test error(s) detected.")

--- a/projects/rccl-tests/test/test_AllReduce.py
+++ b/projects/rccl-tests/test/test_AllReduce.py
@@ -25,6 +25,7 @@ import itertools
 import math
 
 import pytest
+from .test_utils import run_with_retry
 
 ngpus = 0
 if os.environ.get('ROCR_VISIBLE_DEVICES') is not None:
@@ -64,7 +65,7 @@ def test_AllReduceSingleProcess(nthreads, ngpus_single, byte_range, op, step_fac
         if memory_type == "fine":
             args.insert(0, "HSA_FORCE_FINE_GRAIN_PCIE=1")
         args_str = " ".join(args)
-        rccl_test = subprocess.run(args_str, stdout=subprocess.PIPE, universal_newlines=True, shell=True)
+        rccl_test = run_with_retry(args_str)
     except subprocess.CalledProcessError as err:
         print(rccl_test.stdout)
         pytest.fail("AllReduce test error(s) detected.")
@@ -101,7 +102,7 @@ def test_AllReduceMPI(request, nthreads, nprocs, ngpus_mpi, byte_range, op, step
                     "-d", datatype]
         args_str = " ".join(args)
         print(args_str)
-        rccl_test = subprocess.run(args_str, universal_newlines=True, shell=True)
+        rccl_test = run_with_retry(args_str)
     except subprocess.CalledProcessError as err:
         print(rccl_test.stdout)
         pytest.fail("AllReduce test error(s) detected.")

--- a/projects/rccl-tests/test/test_Broadcast.py
+++ b/projects/rccl-tests/test/test_Broadcast.py
@@ -25,6 +25,7 @@ import itertools
 import math
 
 import pytest
+from .test_utils import run_with_retry
 
 ngpus = 0
 if os.environ.get('ROCR_VISIBLE_DEVICES') is not None:
@@ -64,7 +65,7 @@ def test_BroadcastSingleProcess(nthreads, ngpus_single, byte_range, op, step_fac
         if memory_type == "fine":
             args.insert(0, "HSA_FORCE_FINE_GRAIN_PCIE=1")
         args_str = " ".join(args)
-        rccl_test = subprocess.run(args_str, stdout=subprocess.PIPE, universal_newlines=True, shell=True)
+        rccl_test = run_with_retry(args_str)
     except subprocess.CalledProcessError as err:
         print(rccl_test.stdout)
         pytest.fail("Broadcast test error(s) detected.")
@@ -101,7 +102,7 @@ def test_BroadcastMPI(request, nthreads, nprocs, ngpus_mpi, byte_range, op, step
                     "-d", datatype]
         args_str = " ".join(args)
         print(args_str)
-        rccl_test = subprocess.run(args_str, universal_newlines=True, shell=True)
+        rccl_test = run_with_retry(args_str)
     except subprocess.CalledProcessError as err:
         print(rccl_test.stdout)
         pytest.fail("Broadcast test error(s) detected.")

--- a/projects/rccl-tests/test/test_Reduce.py
+++ b/projects/rccl-tests/test/test_Reduce.py
@@ -25,6 +25,7 @@ import itertools
 import math
 
 import pytest
+from .test_utils import run_with_retry
 
 ngpus = 0
 if os.environ.get('ROCR_VISIBLE_DEVICES') is not None:
@@ -64,7 +65,7 @@ def test_ReduceSingleProcess(nthreads, ngpus_single, byte_range, op, step_factor
         if memory_type == "fine":
             args.insert(0, "HSA_FORCE_FINE_GRAIN_PCIE=1")
         args_str = " ".join(args)
-        rccl_test = subprocess.run(args_str, stdout=subprocess.PIPE, universal_newlines=True, shell=True)
+        rccl_test = run_with_retry(args_str)
     except subprocess.CalledProcessError as err:
         print(rccl_test.stdout)
         pytest.fail("Reduce test error(s) detected.")
@@ -101,7 +102,7 @@ def test_ReduceMPI(request, nthreads, nprocs, ngpus_mpi, byte_range, op, step_fa
                     "-d", datatype]
         args_str = " ".join(args)
         print(args_str)
-        rccl_test = subprocess.run(args_str, universal_newlines=True, shell=True)
+        rccl_test = run_with_retry(args_str)
     except subprocess.CalledProcessError as err:
         print(rccl_test.stdout)
         pytest.fail("Reduce test error(s) detected.")

--- a/projects/rccl-tests/test/test_ReduceScatter.py
+++ b/projects/rccl-tests/test/test_ReduceScatter.py
@@ -25,6 +25,7 @@ import itertools
 import math
 
 import pytest
+from .test_utils import run_with_retry
 
 ngpus = 0
 if os.environ.get('ROCR_VISIBLE_DEVICES') is not None:
@@ -64,7 +65,7 @@ def test_ReduceScatterSingleProcess(nthreads, ngpus_single, byte_range, op, step
         if memory_type == "fine":
             args.insert(0, "HSA_FORCE_FINE_GRAIN_PCIE=1")
         args_str = " ".join(args)
-        rccl_test = subprocess.run(args_str, stdout=subprocess.PIPE, universal_newlines=True, shell=True)
+        rccl_test = run_with_retry(args_str)
     except subprocess.CalledProcessError as err:
         print(rccl_test.stdout)
         pytest.fail("ReduceScatter test error(s) detected.")
@@ -101,7 +102,7 @@ def test_ReduceScatterMPI(request, nthreads, nprocs, ngpus_mpi, byte_range, op, 
                     "-d", datatype]
         args_str = " ".join(args)
         print(args_str)
-        rccl_test = subprocess.run(args_str, universal_newlines=True, shell=True)
+        rccl_test = run_with_retry(args_str)
     except subprocess.CalledProcessError as err:
         print(rccl_test.stdout)
         pytest.fail("ReduceScatter test error(s) detected.")

--- a/projects/rccl-tests/test/test_utils.py
+++ b/projects/rccl-tests/test/test_utils.py
@@ -1,0 +1,39 @@
+#################################################################################
+# Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell cop-
+# ies of the Software, and to permit persons to whom the Software is furnished
+# to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IM-
+# PLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+# FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+# COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+# IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNE-
+# CTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+################################################################################
+
+import subprocess
+import time
+
+def run_with_retry(cmd, retry_delay=0.4):
+    result = subprocess.run(cmd, stdout=subprocess.PIPE, 
+                           stderr=subprocess.PIPE, 
+                           universal_newlines=True, shell=True)
+    
+    if result.returncode == 0:
+        return result
+    
+    # Retry once with delay
+    time.sleep(retry_delay)
+    result = subprocess.run(cmd, stdout=subprocess.PIPE, 
+                           stderr=subprocess.PIPE, 
+                           universal_newlines=True, shell=True)
+    
+    return result


### PR DESCRIPTION
## Motivation

When running all unit tests together, tests fail intermittently in the CI. 

Issues:
- Tests pass when run individually
- Tests fail intermittently when run together
- Different tests fail on different runs

Possible reason:
When tests are run in quick succession, GPU cleanup operations from the previous test may not complete before the next test starts, potentially leading to invalid GPU state.

## Technical Details

Add retry logic that reruns failed tests once with a 0.4s delay. Reruns only for failed tests.

## JIRA ID

Internal

## Test Plan

Ran SingleProcess and MPI-based UTs.

## Test Result

No issues observed

## Submission Checklist

- [X] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
