### PR TITLE
[ROCM-3124-3125-3126] CUID file generation hangs on MI350 systems/CUID test failures/Segmentation fault in CUID example code

### DIFF
--- a/projects/cuid/example/main.cc
+++ b/projects/cuid/example/main.cc
@@ -169,9 +169,9 @@ int main() {
                   << " has derived CUID: " << amdcuid_id_to_string(device_handle) << std::endl;
         
         std::string example_bdf;
-        uint32_t bdf_length = 64;
-        char bdf_buffer[64] = {0};
-        status = amdcuid_query_device_property(gpu_handles[0], AMDCUID_QUERY_DEVICE_PATH, bdf_buffer, &bdf_length);
+        uint32_t bdf_length = 13; // typical length of BDF string "0000:00:00.0" + null terminator
+        char bdf_buffer[13] = {0};
+        status = amdcuid_query_device_property(gpu_handles[0], AMDCUID_QUERY_BDF, bdf_buffer, &bdf_length);
         if (status == AMDCUID_STATUS_SUCCESS) {
             example_bdf = bdf_buffer;
         } else {

--- a/projects/cuid/example/main.cc
+++ b/projects/cuid/example/main.cc
@@ -167,6 +167,31 @@ int main() {
         // handle itself is also the derived CUID, so we can print it directly
         std::cout << "Device at path " << example_device_path
                   << " has derived CUID: " << amdcuid_id_to_string(device_handle) << std::endl;
+     
+    
+        std::string example_bdf;
+        uint32_t bdf_length = 64;
+        char bdf_buffer[64] = {0};
+        status = amdcuid_query_device_property(gpu_handles[0], AMDCUID_QUERY_DEVICE_PATH, bdf_buffer, &bdf_length);
+        if (status == AMDCUID_STATUS_SUCCESS) {
+            example_bdf = bdf_buffer;
+        } else {
+            std::cerr << "Failed to get BDF query input from GPU #0. Error code: " << status
+                      << " (" << amdcuid_status_to_string(status) << ")" << std::endl;
+            return 1;
+        }
+
+        // example for getting a specific device handle by BDF and querying its properties
+        amdcuid_id_t bdf_device_handle = {};
+        err = amdcuid_get_handle_by_bdf(example_bdf.c_str(), AMDCUID_DEVICE_TYPE_GPU, &bdf_device_handle);
+        if (err != AMDCUID_STATUS_SUCCESS) {
+            std::cerr << "Failed to get device handle for BDF " << example_bdf
+                      << ". Error code: " << err << " (" << amdcuid_status_to_string(err) << ")" << std::endl;
+            return 1;
+        }
+
+        std::cout << "Device at BDF " << example_bdf
+                  << " has derived CUID: " << amdcuid_id_to_string(bdf_device_handle) << std::endl;
 
     } else {
         std::cout << "No GPU devices found; skipping GPU path/BDF lookup examples." << std::endl;

--- a/projects/cuid/example/main.cc
+++ b/projects/cuid/example/main.cc
@@ -167,8 +167,7 @@ int main() {
         // handle itself is also the derived CUID, so we can print it directly
         std::cout << "Device at path " << example_device_path
                   << " has derived CUID: " << amdcuid_id_to_string(device_handle) << std::endl;
-     
-    
+        
         std::string example_bdf;
         uint32_t bdf_length = 64;
         char bdf_buffer[64] = {0};

--- a/projects/cuid/example/main.cc
+++ b/projects/cuid/example/main.cc
@@ -167,6 +167,7 @@ int main() {
         // handle itself is also the derived CUID, so we can print it directly
         std::cout << "Device at path " << example_device_path
                   << " has derived CUID: " << amdcuid_id_to_string(device_handle) << std::endl;
+
     } else {
         std::cout << "No GPU devices found; skipping GPU path/BDF lookup examples." << std::endl;
     }

--- a/projects/cuid/example/main.cc
+++ b/projects/cuid/example/main.cc
@@ -144,37 +144,32 @@ int main() {
         std::cout << " Handle: " << amdcuid_id_to_string(cpu_handles[i]) << std::endl;
         std::cout << std::endl;
     }
-    std::string example_device_path;
-    uint32_t path_length = PATH_MAX;
-    amdcuid_status_t status = amdcuid_query_device_property(gpu_handles[0], AMDCUID_QUERY_DEVICE_PATH, &example_device_path, &path_length);
+    // Example handle lookup by device path (only if at least one GPU exists).
+    if (!gpu_handles.empty()) {
+        char example_device_path[PATH_MAX] = {0};
+        uint32_t path_length = sizeof(example_device_path);
+        amdcuid_status_t status = amdcuid_query_device_property(
+            gpu_handles[0], AMDCUID_QUERY_DEVICE_PATH, example_device_path, &path_length);
+        if (status != AMDCUID_STATUS_SUCCESS) {
+            std::cerr << "Failed to get device path for GPU #0. Error code: " << status
+                      << " (" << amdcuid_status_to_string(status) << ")" << std::endl;
+            return 1;
+        }
 
-    // example for getting specific device handle by device path and querying its properties
-    amdcuid_id_t device_handle = {};
-    err = amdcuid_get_handle_by_dev_path(example_device_path.c_str(), AMDCUID_DEVICE_TYPE_GPU, &device_handle);
-    if (err != AMDCUID_STATUS_SUCCESS) {
-        std::cerr << "Failed to get device handle for path " << example_device_path
-                  << ". Error code: " << err << " (" << amdcuid_status_to_string(err) << ")" << std::endl;
-        return 1;
+        amdcuid_id_t device_handle = {};
+        err = amdcuid_get_handle_by_dev_path(example_device_path, AMDCUID_DEVICE_TYPE_GPU, &device_handle);
+        if (err != AMDCUID_STATUS_SUCCESS) {
+            std::cerr << "Failed to get device handle for path " << example_device_path
+                      << ". Error code: " << err << " (" << amdcuid_status_to_string(err) << ")" << std::endl;
+            return 1;
+        }
+
+        // handle itself is also the derived CUID, so we can print it directly
+        std::cout << "Device at path " << example_device_path
+                  << " has derived CUID: " << amdcuid_id_to_string(device_handle) << std::endl;
+    } else {
+        std::cout << "No GPU devices found; skipping GPU path/BDF lookup examples." << std::endl;
     }
-
-    // handle itself is also the derived CUID, so we can print it directly
-    std::cout << "Device at path " << example_device_path << " has derived CUID: " << amdcuid_id_to_string(device_handle) << std::endl;
-
-    std::string example_bdf;
-    uint32_t bdf_length = 64;
-    status = amdcuid_query_device_property(gpu_handles[0], AMDCUID_QUERY_DEVICE_PATH, &example_bdf, &bdf_length);
-
-    // example for getting a specific device handle by BDF and querying its properties
-    amdcuid_id_t bdf_device_handle = {};
-    err = amdcuid_get_handle_by_bdf(example_bdf.c_str(), AMDCUID_DEVICE_TYPE_GPU, &bdf_device_handle);
-    if (err != AMDCUID_STATUS_SUCCESS) {
-        std::cerr << "Failed to get device handle for BDF " << example_bdf
-                  << ". Error code: " << err << " (" << amdcuid_status_to_string(err) << ")" << std::endl;
-        return 1;
-    }
-
-    // handle itself is also the derived CUID, so we can print it directly
-    std::cout << "Device at BDF " << example_bdf << " has derived CUID: " << amdcuid_id_to_string(bdf_device_handle) << std::endl;
 
     return 0;
 }

--- a/projects/cuid/lib/include/amd_cuid.h
+++ b/projects/cuid/lib/include/amd_cuid.h
@@ -34,7 +34,7 @@ extern "C" {
 #define AMDCUID_LIB_VERSION_MAJOR 0
 
 //! Minor version should be updated for each API change, but without changing headers
-#define AMDCUID_LIB_VERSION_MINOR 1
+#define AMDCUID_LIB_VERSION_MINOR 2
 
 //! Patch version should be updated for each bug fix or non-API change
 #define AMDCUID_LIB_VERSION_PATCH 1
@@ -259,7 +259,8 @@ typedef enum {
     AMDCUID_QUERY_CORE_ID = 12,               ///< Query the core ID (uint16_t). Supported by CPU device type.
     AMDCUID_QUERY_PHYSICAL_ID = 13,           ///< Query the physical package ID (uint16_t). Supported by CPU device type.
     AMDCUID_QUERY_PCI_CLASS = 14,             ///< Query the PCI class (uint16_t). Supported by GPU and NIC device types.
-    AMDCUID_QUERY_LAST = 14
+    AMDCUID_QUERY_BDF = 15,                   ///< Query the PCI BDF (string in format "bus:device.function", e.g. "0000:03:00.0"). Supported by GPU and NIC device types.
+    AMDCUID_QUERY_LAST = 15
 } amdcuid_query_t;
 
 /**

--- a/projects/cuid/lib/src/cuid.cc
+++ b/projects/cuid/lib/src/cuid.cc
@@ -178,23 +178,11 @@ amdcuid_status_t amdcuid_get_handle_by_dev_path(const char* dev_path, amdcuid_de
         return AMDCUID_STATUS_INVALID_ARGUMENT;
     }
 
-    std::string real_dev_path;
-    // For NIC paths (e.g., /sys/class/net/eth0) and GPU paths
-    // (e.g., /sys/class/drm/renderD128), use the path as-is since
-    // get_real_path resolves symlinks and appends "/device" which does not
-    // match how device_node paths are stored in CUID files.
-    std::string dev_path_str(dev_path);
-    if (device_type == AMDCUID_DEVICE_TYPE_NIC
-        || device_type == AMDCUID_DEVICE_TYPE_GPU
-        || dev_path_str.find("/sys/class/net/") != std::string::npos
-        || dev_path_str.find("/sys/class/drm/") != std::string::npos) {
-        real_dev_path = dev_path_str;
-    } else {
-        real_dev_path = CuidUtilities::get_real_path(dev_path);
-    }
-
+    const std::string input_dev_path(dev_path);
+    std::string real_dev_path = CuidUtilities::get_real_path(input_dev_path);
     if (real_dev_path.empty()) {
-         return AMDCUID_STATUS_DEVICE_NOT_FOUND;
+        // Not all valid sysfs inputs are guaranteed to resolve via realpath in all environments.
+        real_dev_path = input_dev_path;
     }
 
     amdcuid_status_t status;
@@ -205,7 +193,11 @@ amdcuid_status_t amdcuid_get_handle_by_dev_path(const char* dev_path, amdcuid_de
         if (status != AMDCUID_STATUS_SUCCESS) {
             continue;
         }
-        if (device_path == real_dev_path && device->type() == device_type) {
+        std::string device_real_path = CuidUtilities::get_real_path(device_path);
+        if ((device_path == input_dev_path ||
+             device_path == real_dev_path ||
+             (!device_real_path.empty() && device_real_path == real_dev_path)) &&
+            device->type() == device_type) {
             amdcuid_derived_id derived;
             status = device->get_derived_cuid(derived);
             if (status != AMDCUID_STATUS_SUCCESS) {
@@ -218,7 +210,10 @@ amdcuid_status_t amdcuid_get_handle_by_dev_path(const char* dev_path, amdcuid_de
 
     // next check cuid files for device
     DevicePtr device = nullptr;
-    status = mgr.get_device_from_file_by_dev_path(real_dev_path, device);
+    status = mgr.get_device_from_file_by_dev_path(input_dev_path, device);
+    if (status != AMDCUID_STATUS_SUCCESS && real_dev_path != input_dev_path) {
+        status = mgr.get_device_from_file_by_dev_path(real_dev_path, device);
+    }
     if (status == AMDCUID_STATUS_SUCCESS) {
         amdcuid_derived_id derived;
         status = device->get_derived_cuid(derived);

--- a/projects/cuid/lib/src/cuid.cc
+++ b/projects/cuid/lib/src/cuid.cc
@@ -179,10 +179,19 @@ amdcuid_status_t amdcuid_get_handle_by_dev_path(const char* dev_path, amdcuid_de
     }
 
     const std::string input_dev_path(dev_path);
-    std::string real_dev_path = CuidUtilities::get_real_path(input_dev_path);
-    if (real_dev_path.empty()) {
-        // Not all valid sysfs inputs are guaranteed to resolve via realpath in all environments.
-        real_dev_path = input_dev_path;
+    std::string real_dev_path;
+    // For NIC paths (e.g., /sys/class/net/eth0) and GPU paths
+    // (e.g., /sys/class/drm/renderD128), use the path as-is since
+    // get_real_path resolves symlinks and appends "/device" which does not
+    // match how device_node paths are stored in CUID files.
+    std::string dev_path_str(dev_path);
+    if (device_type == AMDCUID_DEVICE_TYPE_NIC
+        || device_type == AMDCUID_DEVICE_TYPE_GPU
+        || dev_path_str.find("/sys/class/net/") != std::string::npos
+        || dev_path_str.find("/sys/class/drm/") != std::string::npos) {
+        real_dev_path = dev_path_str;
+    } else {
+        real_dev_path = CuidUtilities::get_real_path(dev_path);
     }
 
     amdcuid_status_t status;

--- a/projects/cuid/lib/src/cuid.cc
+++ b/projects/cuid/lib/src/cuid.cc
@@ -604,6 +604,23 @@ amdcuid_status_t amdcuid_query_device_property(amdcuid_id_t handle, amdcuid_quer
                 *length = sizeof(uint16_t);
             }
             break;
+        case AMDCUID_QUERY_BDF: {
+                // only PCI devices (GPU, NIC) will return a valid BDF
+                std::string bdf;
+                status = device->get_bdf(bdf);
+                if (status != AMDCUID_STATUS_SUCCESS) {
+                    break;
+                }
+                uint32_t required_length = static_cast<uint32_t>(bdf.size() + 1); // include null terminator
+                if (*length < required_length) {
+                    *length = required_length;
+                    return AMDCUID_STATUS_INSUFFICIENT_SIZE;
+                }
+                if (data != nullptr)
+                    std::memcpy(data, bdf.c_str(), required_length);
+                *length = required_length;
+            }
+            break;
         default:
             status = AMDCUID_STATUS_INVALID_ARGUMENT;
             break;

--- a/projects/cuid/lib/src/cuid_file.cc
+++ b/projects/cuid/lib/src/cuid_file.cc
@@ -60,23 +60,22 @@ bool CuidFileLock::acquire() {
         return true;  // Already locked
     }
 
-    // For shared (read) locks, we only need O_RDONLY access
-    // For exclusive (write) locks, we need O_RDWR access
-    // This allows unprivileged users to acquire shared locks on files created by root
-    int open_flags = (lock_type_ == CuidLockType::EXCLUSIVE) ? (O_RDWR | O_CREAT) : O_RDONLY;
-    
-    // For exclusive locks (creating/writing), ensure proper permissions by clearing umask
+    // For shared (read) locks, we only need O_RDONLY access.
+    // For exclusive (write) locks, first open existing file with O_RDWR.
+    // Only create if missing to avoid sticky-dir O_CREAT restrictions in /tmp.
     if (lock_type_ == CuidLockType::EXCLUSIVE) {
-        mode_t old_umask = umask(0);
-        lock_fd_ = open(lock_file_path_.c_str(), open_flags, 0666);
-        umask(old_umask);
-        // Ensure permissions are correct even if file already existed
-        if (lock_fd_ >= 0) {
-            fchmod(lock_fd_, 0666);
+        lock_fd_ = open(lock_file_path_.c_str(), O_RDWR, 0666);
+        if (lock_fd_ < 0 && errno == ENOENT) {
+            mode_t old_umask = umask(0);
+            lock_fd_ = open(lock_file_path_.c_str(), O_RDWR | O_CREAT, 0666);
+            umask(old_umask);
+            if (lock_fd_ >= 0) {
+                fchmod(lock_fd_, 0666);
+            }
         }
     } else {
         // Try to open existing file for shared (read) lock
-        lock_fd_ = open(lock_file_path_.c_str(), open_flags, 0666);
+        lock_fd_ = open(lock_file_path_.c_str(), O_RDONLY, 0666);
     }
     
     // If file doesn't exist and we need a shared lock, try to create it
@@ -136,20 +135,21 @@ bool CuidFileLock::acquire_with_timeout(int timeout_seconds) {
         return true;  // Already locked
     }
 
-    // For shared (read) locks, we only need O_RDONLY access
-    // For exclusive (write) locks, we need O_RDWR access
-    int open_flags = (lock_type_ == CuidLockType::EXCLUSIVE) ? (O_RDWR | O_CREAT) : O_RDONLY;
-    
-    // For exclusive locks (creating/writing), ensure proper permissions by clearing umask
+    // For shared (read) locks, we only need O_RDONLY access.
+    // For exclusive (write) locks, first open existing file with O_RDWR.
+    // Only create if missing to avoid sticky-dir O_CREAT restrictions in /tmp.
     if (lock_type_ == CuidLockType::EXCLUSIVE) {
-        mode_t old_umask = umask(0);
-        lock_fd_ = open(lock_file_path_.c_str(), open_flags, 0666);
-        umask(old_umask);
-        if (lock_fd_ >= 0) {
-            fchmod(lock_fd_, 0666);
+        lock_fd_ = open(lock_file_path_.c_str(), O_RDWR, 0666);
+        if (lock_fd_ < 0 && errno == ENOENT) {
+            mode_t old_umask = umask(0);
+            lock_fd_ = open(lock_file_path_.c_str(), O_RDWR | O_CREAT, 0666);
+            umask(old_umask);
+            if (lock_fd_ >= 0) {
+                fchmod(lock_fd_, 0666);
+            }
         }
     } else {
-        lock_fd_ = open(lock_file_path_.c_str(), open_flags, 0666);
+        lock_fd_ = open(lock_file_path_.c_str(), O_RDONLY, 0666);
     }
     
     // If file doesn't exist and we need a shared lock, try to create it
@@ -218,20 +218,21 @@ bool CuidFileLock::try_acquire() {
         return true;  // Already locked
     }
 
-    // For shared (read) locks, we only need O_RDONLY access
-    // For exclusive (write) locks, we need O_RDWR access
-    int open_flags = (lock_type_ == CuidLockType::EXCLUSIVE) ? (O_RDWR | O_CREAT) : O_RDONLY;
-    
-    // For exclusive locks (creating/writing), ensure proper permissions by clearing umask
+    // For shared (read) locks, we only need O_RDONLY access.
+    // For exclusive (write) locks, first open existing file with O_RDWR.
+    // Only create if missing to avoid sticky-dir O_CREAT restrictions in /tmp.
     if (lock_type_ == CuidLockType::EXCLUSIVE) {
-        mode_t old_umask = umask(0);
-        lock_fd_ = open(lock_file_path_.c_str(), open_flags, 0666);
-        umask(old_umask);
-        if (lock_fd_ >= 0) {
-            fchmod(lock_fd_, 0666);
+        lock_fd_ = open(lock_file_path_.c_str(), O_RDWR, 0666);
+        if (lock_fd_ < 0 && errno == ENOENT) {
+            mode_t old_umask = umask(0);
+            lock_fd_ = open(lock_file_path_.c_str(), O_RDWR | O_CREAT, 0666);
+            umask(old_umask);
+            if (lock_fd_ >= 0) {
+                fchmod(lock_fd_, 0666);
+            }
         }
     } else {
-        lock_fd_ = open(lock_file_path_.c_str(), open_flags, 0666);
+        lock_fd_ = open(lock_file_path_.c_str(), O_RDONLY, 0666);
     }
     
     // If file doesn't exist and we need a shared lock, try to create it

--- a/projects/cuid/lib/src/cuid_gpu.cc
+++ b/projects/cuid/lib/src/cuid_gpu.cc
@@ -209,7 +209,7 @@ amdcuid_status_t CuidGpu::discover_single(amdcuid_gpu_info *gpu_info, const std:
 
     *gpu_info = info;
 
-    return AMDCUID_STATUS_DEVICE_NOT_FOUND;
+    return AMDCUID_STATUS_SUCCESS;
 }
 
 amdcuid_status_t CuidGpu::get_hardware_fingerprint(uint64_t& fingerprint) const {

--- a/projects/cuid/lib/src/pci_util.cc
+++ b/projects/cuid/lib/src/pci_util.cc
@@ -104,30 +104,39 @@ amdcuid_status_t PciUtil::get_pci_cap_offset(std::string bdf, uint32_t cap_id, u
         return status;
     }
 
-    // check the 4th bit in the status register first to determine if the capabilities list exists
-    uint8_t status_reg = config_space[0x06];
-    if ((status_reg & 0b10000) == 0)
-    {
-        return AMDCUID_STATUS_UNSUPPORTED;
-    }
-
-    // Get the capabilities pointer from the PCI config space
-    // Device Serial Number is a PCIE Extended Capability, so we need to look in the extended capabilities list
+    // Device Serial Number (cap_id 0x0003) is a PCIe Extended Capability.
+    // Traverse the extended capability list starting at offset 0x100.
     uint16_t cap_ptr = 0x100;
+    for (size_t hops = 0; hops < 1024; ++hops) {
+        if (cap_ptr < 0x100 || cap_ptr + 3 >= sizeof(config_space)) {
+            return AMDCUID_STATUS_UNSUPPORTED;
+        }
 
-    uint16_t cap_id_local = config_space[cap_ptr];
-    // Iterate through the capabilities list
-    while (cap_ptr != 0) {
-        // Check if this is the capability we're looking for
-        if (cap_id_local == cap_id) {
-            // Found the capability, set the offset to the capability's data
+        uint32_t header =
+            static_cast<uint32_t>(config_space[cap_ptr]) |
+            (static_cast<uint32_t>(config_space[cap_ptr + 1]) << 8) |
+            (static_cast<uint32_t>(config_space[cap_ptr + 2]) << 16) |
+            (static_cast<uint32_t>(config_space[cap_ptr + 3]) << 24);
+
+        uint16_t cap_id_local = static_cast<uint16_t>(header & 0xFFFF);
+        uint16_t next_ptr = static_cast<uint16_t>((header >> 20) & 0x0FFF);
+
+        if (cap_id_local == static_cast<uint16_t>(cap_id)) {
             offset = cap_ptr + 4;
             return AMDCUID_STATUS_SUCCESS;
         }
 
-        // Move to the next capability
-        cap_ptr = config_space[cap_ptr + 2];
-        cap_id_local = config_space[cap_ptr];
+        // End of list.
+        if (next_ptr == 0) {
+            break;
+        }
+
+        // Guard against malformed/cyclic lists.
+        if (next_ptr == cap_ptr) {
+            break;
+        }
+
+        cap_ptr = next_ptr;
     }
 
     return AMDCUID_STATUS_UNSUPPORTED;

--- a/projects/cuid/tests/unit/cuid_test.cc
+++ b/projects/cuid/tests/unit/cuid_test.cc
@@ -116,7 +116,7 @@ void test_get_handle_by_bdf() {
     amdcuid_device_type_t device_type = AMDCUID_DEVICE_TYPE_GPU;
     amdcuid_id_t handle;
 
-   amdcuid_status_t status = amdcuid_get_handle_by_bdf(test_bdf, device_type, &handle);
+    amdcuid_status_t status = amdcuid_get_handle_by_bdf(test_bdf, device_type, &handle);
     if (status == AMDCUID_STATUS_SUCCESS) {
         const char* id_str = amdcuid_id_to_string(handle);
         EXPECT_NE(id_str, nullptr);

--- a/projects/cuid/tests/unit/cuid_test.cc
+++ b/projects/cuid/tests/unit/cuid_test.cc
@@ -116,7 +116,7 @@ void test_get_handle_by_bdf() {
     amdcuid_device_type_t device_type = AMDCUID_DEVICE_TYPE_GPU;
     amdcuid_id_t handle;
 
-    amdcuid_status_t status = amdcuid_get_handle_by_dev_path(test_bdf, device_type, &handle);
+   amdcuid_status_t status = amdcuid_get_handle_by_bdf(test_bdf, device_type, &handle);
     if (status == AMDCUID_STATUS_SUCCESS) {
         const char* id_str = amdcuid_id_to_string(handle);
         EXPECT_NE(id_str, nullptr);
@@ -173,11 +173,15 @@ void test_refresh() {
 }
 
 void test_query_device_property() {
+    uint32_t count = 0;
+    amdcuid_status_t status = amdcuid_get_all_handles(nullptr, &count);
+    EXPECT_TRUE(status == AMDCUID_STATUS_INSUFFICIENT_SIZE || status == AMDCUID_STATUS_SUCCESS);
+    ASSERT_GT(count, 0u);
 
-    uint32_t count = 100;
-    amdcuid_id_t* handles = new amdcuid_id_t[count];
-    amdcuid_status_t status = amdcuid_get_all_handles(handles, &count);
+    std::vector<amdcuid_id_t> handles(count);
+    status = amdcuid_get_all_handles(handles.data(), &count);
     EXPECT_EQ(status, AMDCUID_STATUS_SUCCESS);
+    ASSERT_GT(count, 0u);
 
     // Query device type for the first handle
     amdcuid_device_type_t device_type;
@@ -185,8 +189,6 @@ void test_query_device_property() {
     status = amdcuid_query_device_property(handles[0], AMDCUID_QUERY_DEVICE_TYPE, &device_type, &length);
     EXPECT_EQ(status, AMDCUID_STATUS_SUCCESS);
     EXPECT_EQ(length, sizeof(device_type));
-
-    delete[] handles;
 }
 
 void test_set_hash_key() {


### PR DESCRIPTION
## Motivation
This PR fixes three issues in CUID

## Technical Details
Changes fix:
CUID file generation hangs on MI350 systems
CUID test failures: CUIDHandleTest.GetAllHandles, CUIDRefreshTest.RefreshDevices, CUIDQueryTest.QueryDeviceProperty
Segmentation fault in CUID example code

## JIRA ID
Solution is for these 3 tickets same order as the above:
https://amd-hub.atlassian.net/browse/ROCM-3124
https://amd-hub.atlassian.net/browse/ROCM-3125
https://amd-hub.atlassian.net/browse/ROCM-3126

## Test Plan
N/A

## Test Result
CUID file generation hangs on MI350 systems:
<img width="1163" height="980" alt="Screenshot 2026-02-25 152615" src="https://github.com/user-attachments/assets/2f0ffd68-40fb-4679-b670-d8bec6ddcde6" />

CUID test failures: CUIDHandleTest.GetAllHandles, CUIDRefreshTest.RefreshDevices, CUIDQueryTest.QueryDeviceProperty:
<img width="574" height="488" alt="image" src="https://github.com/user-attachments/assets/3b6b0d0c-d4cb-46e8-8cbf-90dcf96225d8" />

Segmentation fault in CUID example code:
<img width="589" height="483" alt="image" src="https://github.com/user-attachments/assets/d76afd8d-941b-48ab-bc6c-0c0efc3b4823" />

## Submission Checklist
N/A
