### PR TITLE
ROCM-3147 - Add Support for sub buffer export to dmabuf_fd

### DIFF
--- a/projects/clr/rocclr/device/rocm/rocdevice.cpp
+++ b/projects/clr/rocclr/device/rocm/rocdevice.cpp
@@ -2399,7 +2399,7 @@ bool Device::ExportShareableVMMHandle(amd::Memory& amd_mem_obj, int flags, void*
     return false;
   }
 
-  if ((hsa_status = Hsa::vmem_export_shareable_handle(&dmabuf_fd, hsa_vmem_handle, flags)) !=
+  if ((hsa_status = Hsa::vmem_export_shareable_handle(&dmabuf_fd, hsa_vmem_handle, flags, 0)) !=
       HSA_STATUS_SUCCESS) {
     LogPrintfError("Failed hsa_vmem_export_shareable_handle with status: %d", hsa_status);
     return false;

--- a/projects/clr/rocclr/device/rocm/rocmemory.cpp
+++ b/projects/clr/rocclr/device/rocm/rocmemory.cpp
@@ -1073,7 +1073,7 @@ bool Buffer::GetFDHandleForMem(void* dev_ptr, size_t size, bool vmm, void* handl
     hsa_amd_vmem_alloc_handle_t mem_handle;
 
     // Retrieve the corresponding phys_mem handle for the mapped dev_ptr.
-    hsa_status_t hsa_status = Hsa::vmem_retain_alloc_handle(&mem_handle, dev_ptr);
+    hsa_status_t hsa_status = Hsa::vmem_retain_alloc_handle(&mem_handle, dev_ptr, size);
     if (hsa_status != HSA_STATUS_SUCCESS) {
       LogPrintfError("Cannot retain alloc handle for dev_ptr: 0x%x hsa returned status: %d",
                      dev_ptr, hsa_status);
@@ -1081,7 +1081,7 @@ bool Buffer::GetFDHandleForMem(void* dev_ptr, size_t size, bool vmm, void* handl
     }
 
     // Now, retrieve the shareable handle (fd in linux) for the phys_mem handle.
-    hsa_status = Hsa::vmem_export_shareable_handle(&dmabuffd, mem_handle, 0);
+    hsa_status = Hsa::vmem_export_shareable_handle(&dmabuffd, mem_handle, 0, size);
     if (hsa_status != HSA_STATUS_SUCCESS) {
       LogPrintfError("Cannot get shareable handle for mem_handle: %lu, hsa returned status: %d",
                      mem_handle, hsa_status);

--- a/projects/clr/rocclr/device/rocm/rocrctx.hpp
+++ b/projects/clr/rocclr/device/rocm/rocrctx.hpp
@@ -483,16 +483,16 @@ class Hsa : public amd::AllStatic {
     return ROCR_DYN(hsa_amd_vmem_get_access)(va, flags, agent_handle);
   }
   static hsa_status_t vmem_export_shareable_handle(int* dmabuf_fd,
-    hsa_amd_vmem_alloc_handle_t handle, uint64_t flags) {
-    return ROCR_DYN(hsa_amd_vmem_export_shareable_handle)(dmabuf_fd, handle, flags);
+    hsa_amd_vmem_alloc_handle_t handle, uint64_t flags, size_t bufsize) {
+    return ROCR_DYN(hsa_amd_vmem_export_shareable_handle)(dmabuf_fd, handle, flags, bufsize);
   }
   static hsa_status_t vmem_import_shareable_handle(int dmabuf_fd,
     hsa_amd_vmem_alloc_handle_t* handle) {
     return ROCR_DYN(hsa_amd_vmem_import_shareable_handle)(dmabuf_fd, handle);
   }
   static hsa_status_t vmem_retain_alloc_handle(hsa_amd_vmem_alloc_handle_t* allocHandle,
-    void* addr) {
-    return ROCR_DYN(hsa_amd_vmem_retain_alloc_handle)(allocHandle, addr);
+    void* addr, size_t size) {
+    return ROCR_DYN(hsa_amd_vmem_retain_alloc_handle)(allocHandle, addr, size);
   }
   static hsa_status_t agent_set_async_scratch_limit(hsa_agent_t agent, size_t threshold) {
     return ROCR_DYN(hsa_amd_agent_set_async_scratch_limit)(agent, threshold);

--- a/projects/rocprofiler-sdk/source/include/rocprofiler-sdk/hsa/api_args.h
+++ b/projects/rocprofiler-sdk/source/include/rocprofiler-sdk/hsa/api_args.h
@@ -1365,6 +1365,7 @@ typedef union rocprofiler_hsa_api_args_t
         int*                        dmabuf_fd;
         hsa_amd_vmem_alloc_handle_t handle;
         uint64_t                    flags;
+        size_t                      bufsize;
     } hsa_amd_vmem_export_shareable_handle;
     struct
     {
@@ -1375,6 +1376,7 @@ typedef union rocprofiler_hsa_api_args_t
     {
         hsa_amd_vmem_alloc_handle_t* handle;
         void*                        addr;
+        size_t                       size;
     } hsa_amd_vmem_retain_alloc_handle;
     struct
     {

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/hsa/hsa.def.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/hsa/hsa.def.cpp
@@ -406,7 +406,8 @@ HSA_API_INFO_DEFINITION_V(ROCPROFILER_HSA_TABLE_ID_AmdExt,
                           hsa_amd_vmem_export_shareable_handle_fn,
                           dmabuf_fd,
                           handle,
-                          flags)
+                          flags,
+                          bufsize)
 HSA_API_INFO_DEFINITION_V(ROCPROFILER_HSA_TABLE_ID_AmdExt,
                           ROCPROFILER_HSA_AMD_EXT_API_ID_hsa_amd_vmem_import_shareable_handle,
                           hsa_amd_vmem_import_shareable_handle,
@@ -418,7 +419,8 @@ HSA_API_INFO_DEFINITION_V(ROCPROFILER_HSA_TABLE_ID_AmdExt,
                           hsa_amd_vmem_retain_alloc_handle,
                           hsa_amd_vmem_retain_alloc_handle_fn,
                           handle,
-                          addr)
+                          addr,
+                          size)
 HSA_API_INFO_DEFINITION_V(
     ROCPROFILER_HSA_TABLE_ID_AmdExt,
     ROCPROFILER_HSA_AMD_EXT_API_ID_hsa_amd_vmem_get_alloc_properties_from_handle,

--- a/projects/rocr-runtime/rocrtst/suites/functional/virtual_memory.cc
+++ b/projects/rocr-runtime/rocrtst/suites/functional/virtual_memory.cc
@@ -346,7 +346,7 @@ void VirtMemoryTestBasic::TestRefCount(hsa_agent_t agent, hsa_amd_memory_pool_t 
 
   /* Allocate duplicate handle */
   hsa_amd_vmem_alloc_handle_t mem_handleA1Dup;
-  ASSERT_SUCCESS(hsa_amd_vmem_retain_alloc_handle(&mem_handleA1Dup, addrRange));
+  ASSERT_SUCCESS(hsa_amd_vmem_retain_alloc_handle(&mem_handleA1Dup, addrRange, 10 * granule_size));
 
   /* Try to unmap with incorrect size */
   err = hsa_amd_vmem_unmap(addrRange, 5 * granule_size);
@@ -1579,7 +1579,7 @@ void VirtMemoryTestInterProcess::ParentProcessImpl() {
                                             MEMORY_TYPE_NONE, 0, &exported_handle));
 
   int dmabuf_fd;
-  ASSERT_SUCCESS(hsa_amd_vmem_export_shareable_handle(&dmabuf_fd, exported_handle, 0));
+  ASSERT_SUCCESS(hsa_amd_vmem_export_shareable_handle(&dmabuf_fd, exported_handle, 0, 20 * rec_gpu_mem_granule));
   ASSERT_GE(dmabuf_fd, 0);
 
   // Signal child process that the gpu buffer is ready to read.

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/common/hsa_table_interface.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/common/hsa_table_interface.cpp
@@ -1298,8 +1298,8 @@ hsa_status_t HSA_API hsa_amd_vmem_get_access(void* va, hsa_access_permission_t* 
 
 hsa_status_t HSA_API hsa_amd_vmem_export_shareable_handle(int* dmabuf_fd,
                                                           hsa_amd_vmem_alloc_handle_t handle,
-                                                          uint64_t flags) {
-  return amdExtTable->hsa_amd_vmem_export_shareable_handle_fn(dmabuf_fd, handle, flags);
+                                                          uint64_t flags, size_t bufsize) {
+  return amdExtTable->hsa_amd_vmem_export_shareable_handle_fn(dmabuf_fd, handle, flags, bufsize);
 }
 
 hsa_status_t HSA_API hsa_amd_vmem_import_shareable_handle(int dmabuf_fd,
@@ -1308,8 +1308,8 @@ hsa_status_t HSA_API hsa_amd_vmem_import_shareable_handle(int dmabuf_fd,
 }
 
 hsa_status_t HSA_API hsa_amd_vmem_retain_alloc_handle(hsa_amd_vmem_alloc_handle_t* handle,
-                                                      void* addr) {
-  return amdExtTable->hsa_amd_vmem_retain_alloc_handle_fn(handle, addr);
+                                                      void* addr, size_t size) {
+  return amdExtTable->hsa_amd_vmem_retain_alloc_handle_fn(handle, addr, size);
 }
 
 hsa_status_t HSA_API hsa_amd_vmem_get_alloc_properties_from_handle(

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/inc/hsa_ext_amd_impl.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/inc/hsa_ext_amd_impl.h
@@ -350,14 +350,14 @@ hsa_status_t hsa_amd_vmem_get_access(void* va, hsa_access_permission_t* flags,
 // Mirrors Amd Extension Apis
 hsa_status_t hsa_amd_vmem_export_shareable_handle(int* dmabuf_fd,
                                                   hsa_amd_vmem_alloc_handle_t handle,
-                                                  uint64_t flags);
+                                                  uint64_t flags, size_t bufsize);
 
 // Mirrors Amd Extension Apis
 hsa_status_t hsa_amd_vmem_import_shareable_handle(int dmabuf_fd,
                                                   hsa_amd_vmem_alloc_handle_t* handle);
 
 // Mirrors Amd Extension Apis
-hsa_status_t hsa_amd_vmem_retain_alloc_handle(hsa_amd_vmem_alloc_handle_t* allocHandle, void* addr);
+hsa_status_t hsa_amd_vmem_retain_alloc_handle(hsa_amd_vmem_alloc_handle_t* allocHandle, void* addr, size_t size);
 
 // Mirrors Amd Extension Apis
 hsa_status_t hsa_amd_vmem_get_alloc_properties_from_handle(hsa_amd_vmem_alloc_handle_t allocHandle,

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/inc/runtime.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/inc/runtime.h
@@ -409,12 +409,12 @@ class Runtime {
 
   hsa_status_t VMemoryExportShareableHandle(int* dmabuf_fd,
                                             const hsa_amd_vmem_alloc_handle_t handle,
-                                            const uint64_t flags);
+                                            const uint64_t flags, size_t bufsize);
 
   hsa_status_t VMemoryImportShareableHandle(const int dmabuf_fd,
                                             hsa_amd_vmem_alloc_handle_t* handle);
 
-  hsa_status_t VMemoryRetainAllocHandle(hsa_amd_vmem_alloc_handle_t* memoryHandle, void* addr);
+  hsa_status_t VMemoryRetainAllocHandle(hsa_amd_vmem_alloc_handle_t* memoryHandle, void* addr, size_t size);
 
   hsa_status_t VMemoryGetAllocPropertiesFromHandle(const hsa_amd_vmem_alloc_handle_t memoryHandle,
                                                    const core::MemoryRegion** mem_region,

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/hsa_ext_amd.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/hsa_ext_amd.cpp
@@ -1455,12 +1455,12 @@ hsa_status_t hsa_amd_vmem_get_access(void* va, hsa_access_permission_t* perms,
 
 hsa_status_t hsa_amd_vmem_export_shareable_handle(int* dmabuf_fd,
                                                   hsa_amd_vmem_alloc_handle_t handle,
-                                                  uint64_t flags) {
+                                                  uint64_t flags, size_t bufsize) {
   TRY;
   IS_OPEN();
   IS_BAD_PTR(dmabuf_fd);
 
-  return core::Runtime::runtime_singleton_->VMemoryExportShareableHandle(dmabuf_fd, handle, flags);
+  return core::Runtime::runtime_singleton_->VMemoryExportShareableHandle(dmabuf_fd, handle, flags, bufsize);
   CATCH;
 }
 
@@ -1475,12 +1475,12 @@ hsa_status_t hsa_amd_vmem_import_shareable_handle(int dmabuf_fd,
 }
 
 hsa_status_t hsa_amd_vmem_retain_alloc_handle(hsa_amd_vmem_alloc_handle_t* allocHandle,
-                                              void* addr) {
+                                              void* addr, size_t size) {
   TRY;
   IS_OPEN();
   IS_BAD_PTR(addr);
 
-  return core::Runtime::runtime_singleton_->VMemoryRetainAllocHandle(allocHandle, addr);
+  return core::Runtime::runtime_singleton_->VMemoryRetainAllocHandle(allocHandle, addr, size);
   CATCH;
 }
 

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/runtime.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/runtime.cpp
@@ -4043,18 +4043,38 @@ hsa_status_t Runtime::VMemoryGetAccess(const void* va, hsa_access_permission_t* 
 
 hsa_status_t Runtime::VMemoryExportShareableHandle(int* dmabuf_fd,
                                                    hsa_amd_vmem_alloc_handle_t handle,
-                                                   uint64_t flags) {
+                                                   uint64_t flags, size_t bufsize) {
   *dmabuf_fd = -1;
-  auto memoryHandle = memory_handle_map_.find(MemoryHandle::Convert(handle));
-  if (memoryHandle == memory_handle_map_.end()) {
+  ThunkHandle memHandle = MemoryHandle::Convert(handle);
+  bool validateHandle = false;
+
+  auto memoryHandleIt = memory_handle_map_.upper_bound(memHandle);
+  if (memoryHandleIt == memory_handle_map_.begin()) {
     debug_warning(false && "Can't find memory handle");
     return HSA_STATUS_ERROR_INVALID_ALLOCATION;
+  } 
+
+  memoryHandleIt--;
+  auto& alloc = memoryHandleIt->second;
+  if (reinterpret_cast<uint64_t>(memHandle) >=  reinterpret_cast<uint64_t>(memoryHandleIt->first) &&
+     (reinterpret_cast<const char*>(memHandle) + bufsize) <=
+     (reinterpret_cast<const char*>(memoryHandleIt->first) + alloc.size)) {
+    validateHandle = true;
+  }
+  
+  if (!validateHandle) {
+    return HSA_STATUS_ERROR_INVALID_ALLOCATION;
+  }
+
+  // use default value from map
+  if (bufsize == 0) { 
+    bufsize = memoryHandleIt->second.size;
   }
 
   uint64_t offset;
 
-  hsa_status_t err = memoryHandle->second.region->owner()->driver().ExportDMABuf(
-      memoryHandle->second.thunk_handle, memoryHandle->second.size, dmabuf_fd, &offset);
+  hsa_status_t err = memoryHandleIt->second.region->owner()->driver().ExportDMABuf(
+      memHandle, bufsize, dmabuf_fd, &offset);
   if (err != HSA_STATUS_SUCCESS) return err;
 
   return HSA_STATUS_SUCCESS;
@@ -4127,15 +4147,26 @@ hsa_status_t Runtime::VMemoryImportShareableHandle(int dmabuf_fd,
 }
 
 hsa_status_t Runtime::VMemoryRetainAllocHandle(hsa_amd_vmem_alloc_handle_t* mapped_handle,
-                                               void* va) {
-  auto mappedHandleIt = mapped_handle_map_.find(va);
-  if (mappedHandleIt == mapped_handle_map_.end()) return HSA_STATUS_ERROR_INVALID_ALLOCATION;
-
-  MemoryHandle* memoryHandle = mappedHandleIt->second.mem_handle;
-  memoryHandle->ref_count++;
-  *mapped_handle = MemoryHandle::Convert(memoryHandle->thunk_handle);
-
-  return HSA_STATUS_SUCCESS;
+                                               void* va, size_t size) {
+  auto mappedHandleIt = mapped_handle_map_.upper_bound(va);
+  if (mappedHandleIt == mapped_handle_map_.begin()) {
+    return HSA_STATUS_ERROR_INVALID_ALLOCATION;
+  } 
+  // find va in range mapped_va : mapped_va + size
+  mappedHandleIt--;
+  auto& alloc = mappedHandleIt->second;
+  if (va >= mappedHandleIt->first &&
+     (reinterpret_cast<const char*>(va) + size) <=
+     (reinterpret_cast<const char*>(mappedHandleIt->first) + alloc.size)) {
+    uint64_t offset = reinterpret_cast<uint64_t>(va) - reinterpret_cast<uint64_t>(mappedHandleIt->first);
+    MemoryHandle* memoryHandle = mappedHandleIt->second.mem_handle ;
+    memoryHandle->ref_count++;
+    ThunkHandle mhandle = reinterpret_cast<ThunkHandle>(reinterpret_cast<uint64_t>(memoryHandle->thunk_handle) + offset);
+    *mapped_handle = MemoryHandle::Convert(mhandle);
+    return HSA_STATUS_SUCCESS;
+  }
+  
+  return HSA_STATUS_ERROR_INVALID_ALLOCATION;
 }
 
 hsa_status_t Runtime::VMemoryGetAllocPropertiesFromHandle(hsa_amd_vmem_alloc_handle_t allocHandle,

--- a/projects/rocr-runtime/runtime/hsa-runtime/inc/hsa_ext_amd.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/inc/hsa_ext_amd.h
@@ -3552,6 +3552,7 @@ hsa_status_t hsa_amd_vmem_get_access(void* va, hsa_access_permission_t* perms,
  * @param[out] dmabuf_fd shareable handle
  * @param[in] handle previously allocated virtual memory handle
  * @param[in] flags Currently unsupported
+ * @param[in] bufsize Size of buffer to export
  *
  * @retval ::HSA_STATUS_SUCCESS
  *
@@ -3563,7 +3564,7 @@ hsa_status_t hsa_amd_vmem_get_access(void* va, hsa_access_permission_t* perms,
  */
 hsa_status_t hsa_amd_vmem_export_shareable_handle(int* dmabuf_fd,
                                                   hsa_amd_vmem_alloc_handle_t handle,
-                                                  uint64_t flags);
+                                                  uint64_t flags, size_t bufsize);
 /**
  * @brief Import a shareable handle
  *
@@ -3593,13 +3594,14 @@ hsa_status_t hsa_amd_vmem_import_shareable_handle(int dmabuf_fd,
  *
  * @param[out] memory_handle memory handle for this mapped address
  * @param[in] mapped address
+ * @param[in] size size of memory for the handle
  *
  * @retval ::HSA_STATUS_SUCCESS
  *
  * @retval ::HSA_STATUS_ERROR_INVALID_ALLOCATION Invalid address
  */
 hsa_status_t hsa_amd_vmem_retain_alloc_handle(hsa_amd_vmem_alloc_handle_t* memory_handle,
-                                              void* addr);
+                                              void* addr, size_t size);
 
 /**
  * @brief Returns the current allocation properties of a handle


### PR DESCRIPTION
## Motivation
1. hipMemGetHandleForAddressRange doesn't support exporting fd for sub buffers.

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## JIRA ID

https://amd-hub.atlassian.net/browse/ROCM-3147


## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
