### PR TITLE
Handles when rocflop workload receives negative values from a child process

### DIFF
--- a/projects/rocprofiler-compute/sample/rocflop.cpp
+++ b/projects/rocprofiler-compute/sample/rocflop.cpp
@@ -560,9 +560,14 @@ void run(std::vector<int>& devices, int runs, uint32_t mask)
 
     // Read records from pipe
     std::vector<Result> results(pids.size());
-    int count = read(fd[0], results.data(), results.size() * sizeof(Result)) / sizeof(Result);
+    ssize_t bytes_read = read(fd[0], results.data(), results.size() * sizeof(Result));
+    int count = (bytes_read > 0) ? static_cast<int>(bytes_read / sizeof(Result)) : 0;
 
     results.resize(count);
+
+    if(count == 0) {
+        std::cerr << "No results received from child process(es)." << std::endl;
+    }
 
     // Sort results by GPU id
     std::sort(results.begin(), results.end());


### PR DESCRIPTION
## Motivation

Checks if bytes_read>0 else defaults to 0 when no data is received.

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## JIRA ID

AIPROFCOMP-273

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
