### PR TITLE
[rocprofiler-compute] Handle rocflop child process crashes gracefully - reduce vram usage of rocflop based tests for robustness

### DIFF
--- a/projects/rocprofiler-compute/sample/rocflop.cpp
+++ b/projects/rocprofiler-compute/sample/rocflop.cpp
@@ -529,6 +529,35 @@ pid_t fork_process(int device, int runs, uint32_t mask, int fd)
     exit(1);
 }
 
+std::vector<Result> read_records_from_pipe(int fd[2], size_t expected_count)
+{
+    int flags = fcntl(fd[0], F_GETFL, 0);
+    fcntl(fd[0], F_SETFL, flags | O_NONBLOCK);
+
+    std::vector<Result> results(expected_count);
+    ssize_t bytes_read = read(fd[0], results.data(), results.size() * sizeof(Result));
+
+    if(bytes_read < 0) {
+        std::cout << "Error reading results from child process(es): "
+                  << std::strerror(errno) << std::endl;
+        return {};
+    }
+
+    if(bytes_read == 0) {
+        std::cout << "No results received from child process(es)." << std::endl;
+        return {};
+    }
+
+    if(bytes_read % sizeof(Result) != 0) {
+        std::cout << "Warning: Incomplete result data received from child process(es); "
+                  << "some data may be ignored." << std::endl;
+    }
+
+    int count = static_cast<int>(bytes_read / sizeof(Result));
+    results.resize(count);
+    return results;
+}
+
 void run(std::vector<int>& devices, int runs, uint32_t mask)
 {
     std::vector<pid_t> pids;
@@ -554,15 +583,7 @@ void run(std::vector<int>& devices, int runs, uint32_t mask)
         waitpid(pid, &status, 0);
     }
 
-    // Set the read to non-blocking
-    int flags = fcntl(fd[0], F_GETFL, 0);
-    fcntl(fd[0], F_SETFL, flags | O_NONBLOCK);
-
-    // Read records from pipe
-    std::vector<Result> results(pids.size());
-    int count = read(fd[0], results.data(), results.size() * sizeof(Result)) / sizeof(Result);
-
-    results.resize(count);
+    std::vector<Result> results = read_records_from_pipe(fd, pids.size());
 
     // Sort results by GPU id
     std::sort(results.begin(), results.end());

--- a/projects/rocprofiler-compute/sample/rocflop.cpp
+++ b/projects/rocprofiler-compute/sample/rocflop.cpp
@@ -151,9 +151,14 @@ __global__ void sparse_matmul_fp16_throughput(vec4<float16>* input0, vec8<float1
 }
 #endif // !defined(__gfx906__) && !defined(__gfx908__) && !defined(__gfx90a__)
 
+int g_current_device = -1;
+
 void HIP_CALL(hipError_t err)
 {
     if(err != hipSuccess) {
+        if(g_current_device >= 0) {
+            std::cout << "[GPU " << g_current_device << "] ";
+        }
         std::cout << "HIP Error: " << (int)err << " " << hipGetErrorString(err) << std::endl;
         exit(1);
     }
@@ -421,12 +426,13 @@ void print_result(const Result& res, uint32_t mask)
 
 Result run_tests(int device, int runs, uint32_t mask)
 {
+    g_current_device = device;
     int device_count;
 
     HIP_CALL(hipGetDeviceCount(&device_count));
 
     if(device >= device_count) {
-        std::cout << "Device " << device << " does not exist. Skipping..." << std::endl;
+        std::cout << "[GPU " << device << "] Device does not exist. Skipping..." << std::endl;
         exit(1);
     }
 
@@ -525,7 +531,7 @@ pid_t fork_process(int device, int runs, uint32_t mask, int fd)
     };
 
     execv("/proc/self/exe", args);
-    std::cout << "execv() failed: " << std::strerror(errno) << std::endl;
+    std::cout << "[GPU " << device << "] execv() failed: " << std::strerror(errno) << std::endl;
     exit(1);
 }
 
@@ -578,16 +584,31 @@ void run(std::vector<int>& devices, int runs, uint32_t mask)
     }
 
     // Wait for all processes to finish
-    for(auto pid : pids) {
+    int failed = 0;
+    for(size_t i = 0; i < pids.size(); i++) {
         int status;
-        waitpid(pid, &status, 0);
+        waitpid(pids[i], &status, 0);
+        if(WIFEXITED(status) && WEXITSTATUS(status) != 0) {
+            std::cout << "Child process for device " << devices[i]
+                      << " exited with error (code " << WEXITSTATUS(status) << ")." << std::endl;
+            failed++;
+        } else if(WIFSIGNALED(status)) {
+            std::cout << "Child process for device " << devices[i]
+                      << " killed by signal " << WTERMSIG(status) << "." << std::endl;
+            failed++;
+        }
+    }
+
+    if(failed == (int)pids.size()) {
+        std::cout << "All " << pids.size() << " child process(es) failed. No results to report." << std::endl;
+        exit(1);
     }
 
     std::vector<Result> results = read_records_from_pipe(fd, pids.size());
 
     // Sort results by GPU id
     std::sort(results.begin(), results.end());
- 
+
     // Print results
     for(auto r : results) {
         std::cout << std::endl << "GPU " << r.device << std::endl;
@@ -606,6 +627,12 @@ void run(std::vector<int>& devices, int runs, uint32_t mask)
     }
     std::cout << std::endl << "System total" << std::endl;
     print_result(total, mask);
+
+    if(failed > 0) {
+        std::cout << std::endl << failed << " of " << pids.size()
+                  << " child process(es) failed." << std::endl;
+        exit(1);
+    }
 }
 
 

--- a/projects/rocprofiler-compute/tests/test_metric_validation.py
+++ b/projects/rocprofiler-compute/tests/test_metric_validation.py
@@ -55,11 +55,12 @@ VALIDATE_METRICS = {
                 # uses improved HBM3E instead of HBM3 used in
                 # MI 300X GPU. Hence, multiple expected values
                 # to cover both cases.
-                # MI 308 has lower bandwidth.
+                # MI 300A CPX and MI 308 have lower bandwidth.
                 # MI 300X: 3910.62 GB/s
                 # MI 325X: 4287.31 GB/s
                 # MI 308: 2003.45 GB/s
-                "expected_values": [2003.45, 3910.62, 4287.31],
+                # MI 300A CPX: 710.23 GB/s (per-partition, CPX/NPS1)
+                "expected_values": [710.23, 2003.45, 3910.62, 4287.31],
             },
         ],
         "MI350": [

--- a/projects/rocprofiler-compute/tests/test_profile_general.py
+++ b/projects/rocprofiler-compute/tests/test_profile_general.py
@@ -62,7 +62,7 @@ config["app_vcopy_multikernel_iter"] = [
     "--multikernel",
 ]
 config["app_mpi_aware_laplace_eqn"] = ["./tests/mpi_aware_laplace_eqn", "-i", "5"]
-config["rocflop"] = ["./tests/rocflop", "--device", "0"]
+config["rocflop"] = ["./tests/rocflop", "--device", "0", "--fp16"]
 config["cleanup"] = True
 config["COUNTER_LOGGING"] = False
 config["METRIC_COMPARE"] = False


### PR DESCRIPTION
## Motivation

Handle rocflop child process crashes gracefully

Reduce vram usage of rocflop based tests for robustness

## Technical Details

Update rocflop.cpp
Update test_metric_validation and rocflop command in test_profile_general.py

<!-- Explain the changes along with any relevant GitHub links. -->

## JIRA ID

AIPROFCOMP-273

## Test Plan

Re-compile rocflop.cpp and run all rocflop related tests case

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

Tests pass

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
