### PR TITLE
Fix rocpd perfetto generation test

### DIFF
--- a/projects/rocprofiler-sdk/source/lib/python/rocpd/source/common.hpp
+++ b/projects/rocprofiler-sdk/source/lib/python/rocpd/source/common.hpp
@@ -22,6 +22,7 @@
 
 #pragma once
 
+#include "lib/common/logging.hpp"
 #include "lib/output/agent_info.hpp"
 #include "lib/output/kernel_symbol_info.hpp"
 #include "lib/output/metadata.hpp"
@@ -31,6 +32,7 @@
 
 #include <cstdint>
 #include <deque>
+#include <exception>
 #include <sstream>
 #include <string>
 #include <utility>
@@ -45,10 +47,19 @@ read_json_string(const std::string& inp, FuncT&& _func, Args&&... _args)
 {
     using json_archive = cereal::JSONInputArchive;
 
+    try
     {
-        auto json_ss = std::stringstream{inp};
-        auto ar      = json_archive{json_ss};
+        std::stringstream json_ss{inp};
+        json_archive      ar{json_ss};
         std::forward<FuncT>(_func)(ar, std::forward<Args>(_args)...);
+    } catch(const std::exception& e)
+    {
+        ROCP_WARNING << "Skipping malformed JSON payload while decoding rocpd extdata. "
+                     << "Payload size: " << inp.size() << ", exception: " << e.what();
+    } catch(...)
+    {
+        ROCP_WARNING << "Skipping malformed JSON payload while decoding rocpd extdata. "
+                     << "Payload size: " << inp.size() << ", exception: unknown";
     }
 }
 }  // namespace common


### PR DESCRIPTION
## Motivation

There is new test failure seen on MI355, the failure was observed when the tests were built from source. Below is error observed when the rocprofv3-test-rocpd-perfetto-generation test is executed.
RuntimeError: rapidjson internal assertion failure: IsObject()

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

rocpd convert reads DB rows and decodes extdata JSON through cereal::JSONInputArchive in read_json_string(...).
Some extdata payloads of MI355-generated DB were not in the object shape the decoder expected.
RapidJSON then hit an internal IsObject() assertion, which bubbled up as: **RuntimeError: rapidjson internal assertion failure: IsObject()**

Now read_json_string wraps parse/decode in try/catch, So when a malformed or non-object extdata value appears, the decode is skipped instead of aborting conversion.
The output generation continues with default/empty decoded fields, and the pftrace file is still produced.

<!-- Explain the changes along with any relevant GitHub links. -->

## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
