### PR TITLE
kfdtest: Disable XNACK on older ASICs.

### DIFF
--- a/projects/rocr-runtime/libhsakmt/tests/kfdtest/src/KFDBaseComponentTest.cpp
+++ b/projects/rocr-runtime/libhsakmt/tests/kfdtest/src/KFDBaseComponentTest.cpp
@@ -72,6 +72,9 @@ void KFDBaseComponentTest::SetUp() {
     /* m_FamilyId is default gpu family id, keep it to support old test method */
     m_FamilyId = FamilyIdFromNode(nodeProperties);
 
+    /* Check if XNACK is supported on the ASIC */
+    m_is_xnack_supported = m_FamilyId < FAMILY_AL ? false : true;
+
     /* these values are for default gpu, keep them to support old test method */
     GetHwQueueInfo(nodeProperties, &m_numCpQueues, &m_numSdmaEngines,
                     &m_numSdmaXgmiEngines, &m_numSdmaQueuesPerEngine);
@@ -98,7 +101,7 @@ void KFDBaseComponentTest::SetUp() {
         while ((end = g_ConcurrentNodes.find(',', start)) != std::string::npos) {
             std::string token = g_ConcurrentNodes.substr(start, end - start);
             if (!token.empty()) {
-                int node = std::stoi(token); 
+                int node = std::stoi(token);
             
                 if (std::find(gpuNodes.begin(), gpuNodes.end(), node) != gpuNodes.end()) 
                     uniqueIndices.insert(node);
@@ -279,7 +282,6 @@ bool KFDBaseComponentTest::SVMAPISupported_GPU(unsigned int gpuNode) {
     return supported;
 }
 
-
 /*
  * Some asics need CWSR workround for DEGFX11_12113
  */
@@ -359,6 +361,8 @@ HsaNodeInfo* KFDBaseComponentTest::Get_NodeInfo() {
 HsaMemFlags& KFDBaseComponentTest::GetHsaMemFlags() {
     return m_MemoryFlags;
 }
+
+bool KFDBaseComponentTest::XNACKSupported() { return m_is_xnack_supported; }
 
 static void* KFDTest_GPU(void* ptr) {
 

--- a/projects/rocr-runtime/libhsakmt/tests/kfdtest/src/KFDBaseComponentTest.hpp
+++ b/projects/rocr-runtime/libhsakmt/tests/kfdtest/src/KFDBaseComponentTest.hpp
@@ -92,6 +92,7 @@ class KFDBaseComponentTest : public testing::Test {
     HsaNodeInfo* Get_NodeInfo();
     HsaMemFlags& GetHsaMemFlags();
     bool SVMAPISupported_GPU(unsigned int nodeId);
+    bool XNACKSupported();
 
     inline unsigned int Get_NumCpQueues(int gpuIndex){
         return m_numCpQueues_GPU[gpuIndex];
@@ -109,8 +110,8 @@ class KFDBaseComponentTest : public testing::Test {
         return m_numSdmaXgmiEngines_GPU[gpuIndex];
     }
 
-    HSAKMT_STATUS KFDTestMultiGPU(std::function<void(int)> test_func, 
-                                            const std::vector<int>& gpuNodes, 
+    HSAKMT_STATUS KFDTestMultiGPU(std::function<void(int)> test_func,
+                                            const std::vector<int>& gpuNodes,
                                             unsigned int gpu_num);
 
     HSAKMT_STATUS KFDTestLaunch(std::function<void(int)> test_func);
@@ -126,6 +127,7 @@ class KFDBaseComponentTest : public testing::Test {
     HsaMemFlags m_MemoryFlags;
     HsaNodeInfo m_NodeInfo;
     HSAint32 m_xnack;
+    bool m_is_xnack_supported;
     Assembler* m_pAsm;
 
     Assembler* m_pAsmGPU[MAX_GPU];
@@ -153,7 +155,10 @@ class KFDBaseComponentTest : public testing::Test {
     void SVMSetXNACKMode(int xnack_override = -1) {
         if (!SVMAPISupported())
             return;
-
+        if (!m_is_xnack_supported) {
+            LOG() << "Skipping test: XNACK not supported on this ASIC" << std::endl;
+            return;
+        }
         m_xnack = -1;
         HSAKMT_STATUS ret = hsaKmtGetXNACKMode(&m_xnack);
         if (ret != HSAKMT_STATUS_SUCCESS) {
@@ -172,9 +177,9 @@ class KFDBaseComponentTest : public testing::Test {
         else
                 return;
 
-	// No need to set XNACK if it's already the current value
-	if (xnack_on == m_xnack)
-		return;
+        // No need to set XNACK if it's already the current value
+        if (xnack_on == m_xnack)
+            return;
 
         ret = hsaKmtSetXNACKMode(xnack_on);
         if (ret != HSAKMT_STATUS_SUCCESS)

--- a/projects/rocr-runtime/libhsakmt/tests/kfdtest/src/KFDSVMEvictTest.cpp
+++ b/projects/rocr-runtime/libhsakmt/tests/kfdtest/src/KFDSVMEvictTest.cpp
@@ -40,7 +40,6 @@ void KFDSVMEvictTest::SetUp() {
     ROUTINE_START
 
     KFDLocalMemoryTest::SetUp();
-
     SVMSetXNACKMode(GetParam());
 
     ROUTINE_END
@@ -235,12 +234,13 @@ TEST_P(KFDSVMEvictTest, BasicTest) {
 
     if (!SVMAPISupported())
         return;
-
-    HSAint32 xnack_enable = 0;
-    EXPECT_SUCCESS(hsaKmtGetXNACKMode(&xnack_enable));
-    if (!xnack_enable) {
+    if (m_is_xnack_supported) {
+        HSAint32 xnack_enable = 0;
+        EXPECT_SUCCESS(hsaKmtGetXNACKMode(&xnack_enable));
+        if (!xnack_enable) {
 	    LOG() << std::hex << "Test is skipped with xnack off" << std::endl;
             return;
+        }
     }
 
     HSAuint32 defaultGPUNode = m_NodeInfo.HsaDefaultGPUNode();
@@ -309,12 +309,13 @@ TEST_P(KFDSVMEvictTest, QueueTest) {
 
     if (!SVMAPISupported())
         return;
-
     HSAint32 xnack_enable = 0;
-    EXPECT_SUCCESS(hsaKmtGetXNACKMode(&xnack_enable));
-    if (!xnack_enable) {
-	LOG() << std::hex << "Test is skipped with xnack off" << std::endl;
-        return;
+    if (m_is_xnack_supported) {
+        EXPECT_SUCCESS(hsaKmtGetXNACKMode(&xnack_enable));
+        if (!xnack_enable) {
+            LOG() << std::hex << "Test is skipped with xnack off" << std::endl;
+            return;
+        }
     }
 
     HSAuint32 defaultGPUNode = m_NodeInfo.HsaDefaultGPUNode();

--- a/projects/rocr-runtime/libhsakmt/tests/kfdtest/src/KFDSVMRangeTest.cpp
+++ b/projects/rocr-runtime/libhsakmt/tests/kfdtest/src/KFDSVMRangeTest.cpp
@@ -36,7 +36,6 @@ void KFDSVMRangeTest::SetUp() {
     ROUTINE_START
 
     KFDBaseComponentTest::SetUp();
-
     SVMSetXNACKMode(GetParam());
 
     ROUTINE_END
@@ -194,6 +193,8 @@ TEST_P(KFDSVMRangeTest, XNACKModeTest) {
     TEST_START(TESTPROFILE_RUNALL);
 
     if (!SVMAPISupported())
+        return;
+    if (!m_is_xnack_supported)
         return;
 
     HSAuint32 i, j;


### PR DESCRIPTION
Older ASICs before MI200x (gfx90a) does not need to run kfdtest with XNACK ON due to a hardware bug.  So this PR explicitly turns it OFF for those ASICs.

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

Please see details in the description here: https://amd-hub.atlassian.net/browse/ROCM-3769
<!-- Explain the changes along with any relevant GitHub links. -->

## JIRA ID
https://amd-hub.atlassian.net/browse/ROCM-3769

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
