### PR TITLE
[rocprofiler-sdk] Fix compile and requirements issue on rocprofiler-sdk CI

### DIFF
--- a/.github/workflows/rocprofiler-sdk-continuous_integration.yml
+++ b/.github/workflows/rocprofiler-sdk-continuous_integration.yml
@@ -691,7 +691,7 @@ jobs:
     # define this for containers
     env:
       GIT_DISCOVERY_ACROSS_FILESYSTEM: 1
-      GCC_COMPILER_VERSION: 13
+      GCC_COMPILER_VERSION: 12
       GPU_RUNNER: ${{ matrix.system.gpu }}
 
     steps:
@@ -750,20 +750,12 @@ jobs:
       run: |
         git config --global --add safe.directory '*'
         apt-get update
-        apt-get install -y software-properties-common
-        add-apt-repository -y ppa:ubuntu-toolchain-r/test
+        apt-get install -y build-essential cmake python3-pip libasan8 libtsan2 software-properties-common clang-15 libdw-dev libsqlite3-dev libdrm-dev file autoconf pkg-config
+        add-apt-repository ppa:ubuntu-toolchain-r/test
         apt-get update
-        apt-get install -y \
-          gcc-12 \
-          g++-12 \
-          libcc1-0 \
-          libgcc-12-dev \
-          libstdc++6 \
-          libstdc++-12-dev \
-          build-essential cmake python3-pip libasan8 libtsan2 \
-          software-properties-common clang-15 libdw-dev libsqlite3-dev \
-          libdrm-dev file autoconf pkg-config
-        update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-12 100 --slave /usr/bin/g++ g++ /usr/bin/g++-12 --slave /usr/bin/gcov gcov /usr/bin/gcov-12
+        apt-get upgrade -y
+        apt-get install -y gcc-${{ env.GCC_COMPILER_VERSION }} g++-${{ env.GCC_COMPILER_VERSION }}
+        update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-${{ env.GCC_COMPILER_VERSION }} 100 --slave /usr/bin/g++ g++ /usr/bin/g++-${{ env.GCC_COMPILER_VERSION }} --slave /usr/bin/gcov gcov /usr/bin/gcov-${{ env.GCC_COMPILER_VERSION }}
         python3 -m pip install -U --user -r requirements.txt
         rm -rf ${{ env.ROCM_PATH }}/lib/*rocprofiler-sdk* ${{ env.ROCM_PATH }}/lib/cmake/*rocprofiler-sdk* ${{ env.ROCM_PATH }}/share/*rocprofiler-sdk* ${{ env.ROCM_PATH }}/libexec/*rocprofiler-sdk* ${{ env.ROCM_PATH }}*/lib/python*/site-packages/roctx ${{ env.ROCM_PATH }}*/lib/python*/site-packages/rocpd
 

--- a/.github/workflows/rocprofiler-sdk-continuous_integration.yml
+++ b/.github/workflows/rocprofiler-sdk-continuous_integration.yml
@@ -753,10 +753,16 @@ jobs:
         apt-get install -y software-properties-common
         add-apt-repository -y ppa:ubuntu-toolchain-r/test
         apt-get update
-        apt-get dist-upgrade -y
-        apt-get install -y gcc-${{ env.GCC_COMPILER_VERSION }} g++-${{ env.GCC_COMPILER_VERSION }}
-        apt-get install -y build-essential cmake python3-pip libasan8 libtsan2 software-properties-common clang-15 libdw-dev libsqlite3-dev libdrm-dev file autoconf pkg-config
-        apt-get upgrade -y
+        apt-get install -y \
+          gcc-${{ env.GCC_COMPILER_VERSION }} \
+          g++-${{ env.GCC_COMPILER_VERSION }} \
+          libcc1-0 \
+          libgcc-${{ env.GCC_COMPILER_VERSION }}-dev \
+          libstdc++6 \
+          libstdc++-${{ env.GCC_COMPILER_VERSION }}-dev \
+          build-essential cmake python3-pip libasan8 libtsan2 \
+          software-properties-common clang-15 libdw-dev libsqlite3-dev \
+          libdrm-dev file autoconf pkg-config
         update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-${{ env.GCC_COMPILER_VERSION }} 100 --slave /usr/bin/g++ g++ /usr/bin/g++-${{ env.GCC_COMPILER_VERSION }} --slave /usr/bin/gcov gcov /usr/bin/gcov-${{ env.GCC_COMPILER_VERSION }}
         python3 -m pip install -U --user -r requirements.txt
         rm -rf ${{ env.ROCM_PATH }}/lib/*rocprofiler-sdk* ${{ env.ROCM_PATH }}/lib/cmake/*rocprofiler-sdk* ${{ env.ROCM_PATH }}/share/*rocprofiler-sdk* ${{ env.ROCM_PATH }}/libexec/*rocprofiler-sdk* ${{ env.ROCM_PATH }}*/lib/python*/site-packages/roctx ${{ env.ROCM_PATH }}*/lib/python*/site-packages/rocpd

--- a/.github/workflows/rocprofiler-sdk-continuous_integration.yml
+++ b/.github/workflows/rocprofiler-sdk-continuous_integration.yml
@@ -207,7 +207,7 @@ jobs:
           cmake -B build-rocdecode \
             -DCMAKE_INSTALL_PREFIX=${{ env.ROCM_PATH }}-${{ env.ROCM_VERSION }} \
             -DCMAKE_PREFIX_PATH=${{ env.ROCM_PATH }} \
-            -DCMAKE_CXX_COMPILER=${{ env.ROCM_PATH }}/bin/amdclang++ \
+            -DCMAKE_CXX_COMPILER=${{ env.ROCM_PATH }}/lib/llvm/bin/amdclang++ \
             -DCMAKE_C_COMPILER_LAUNCHER=/usr/bin/ccache \
             -DCMAKE_CXX_COMPILER_LAUNCHER=/usr/bin/ccache \
             ${GITHUB_WORKSPACE}/rocDecode
@@ -218,7 +218,7 @@ jobs:
           cmake -B build-rocjpeg \
             -DCMAKE_INSTALL_PREFIX=${{ env.ROCM_PATH }}-${{ env.ROCM_VERSION }} \
             -DCMAKE_PREFIX_PATH=${{ env.ROCM_PATH }} \
-            -DCMAKE_CXX_COMPILER=${{ env.ROCM_PATH }}/bin/amdclang++ \
+            -DCMAKE_CXX_COMPILER=${{ env.ROCM_PATH }}/lib/llvm/bin/amdclang++ \
             -DCMAKE_C_COMPILER_LAUNCHER=/usr/bin/ccache \
             -DCMAKE_CXX_COMPILER_LAUNCHER=/usr/bin/ccache \
             ${GITHUB_WORKSPACE}/rocJPEG

--- a/.github/workflows/rocprofiler-sdk-continuous_integration.yml
+++ b/.github/workflows/rocprofiler-sdk-continuous_integration.yml
@@ -672,10 +672,10 @@ jobs:
       fail-fast: false
       matrix:
         system:
-          - { sanitizer: 'AddressSanitizer', os: 'ubuntu-22.04', runner: 'linux-mi325-8gpu-ossci-rocm-sandbox', gpu: 'mi325', gpu-target: 'gfx94X', build-type: 'RelWithDebInfo' }
-          - { sanitizer: 'ThreadSanitizer', os: 'ubuntu-22.04', runner: 'linux-mi325-8gpu-ossci-rocm-sandbox', gpu: 'mi325', gpu-target: 'gfx94X', build-type: 'RelWithDebInfo' }
-          - { sanitizer: 'LeakSanitizer', os: 'ubuntu-22.04', runner: 'linux-mi325-8gpu-ossci-rocm-sandbox', gpu: 'mi325', gpu-target: 'gfx94X', build-type: 'RelWithDebInfo' }
-          - { sanitizer: 'UndefinedBehaviorSanitizer', os: 'ubuntu-22.04', runner: 'linux-mi325-8gpu-ossci-rocm-sandbox', gpu: 'mi325', gpu-target: 'gfx94X', build-type: 'RelWithDebInfo' }
+          - { sanitizer: 'AddressSanitizer', os: 'ubuntu-24.04', runner: 'linux-mi325-8gpu-ossci-rocm-sandbox', gpu: 'mi325', gpu-target: 'gfx94X', build-type: 'RelWithDebInfo' }
+          - { sanitizer: 'ThreadSanitizer', os: 'ubuntu-24.04', runner: 'linux-mi325-8gpu-ossci-rocm-sandbox', gpu: 'mi325', gpu-target: 'gfx94X', build-type: 'RelWithDebInfo' }
+          - { sanitizer: 'LeakSanitizer', os: 'ubuntu-24.04', runner: 'linux-mi325-8gpu-ossci-rocm-sandbox', gpu: 'mi325', gpu-target: 'gfx94X', build-type: 'RelWithDebInfo' }
+          - { sanitizer: 'UndefinedBehaviorSanitizer', os: 'ubuntu-24.04', runner: 'linux-mi325-8gpu-ossci-rocm-sandbox', gpu: 'mi325', gpu-target: 'gfx94X', build-type: 'RelWithDebInfo' }
 
     if: ${{ contains(github.event_name, 'pull_request') }}
     runs-on: ${{ matrix.system.runner }}

--- a/.github/workflows/rocprofiler-sdk-continuous_integration.yml
+++ b/.github/workflows/rocprofiler-sdk-continuous_integration.yml
@@ -750,11 +750,11 @@ jobs:
       run: |
         git config --global --add safe.directory '*'
         apt-get update
-        apt-get install -y build-essential cmake python3-pip libasan8 libtsan2 software-properties-common clang-15 libdw-dev libsqlite3-dev libdrm-dev file autoconf pkg-config
-        add-apt-repository ppa:ubuntu-toolchain-r/test
+        add-apt-repository -y ppa:ubuntu-toolchain-r/test
         apt-get update
-        apt-get upgrade -y
         apt-get install -y gcc-${{ env.GCC_COMPILER_VERSION }} g++-${{ env.GCC_COMPILER_VERSION }}
+        apt-get install -y build-essential cmake python3-pip libasan8 libtsan2 software-properties-common clang-15 libdw-dev libsqlite3-dev libdrm-dev file autoconf pkg-config
+        apt-get upgrade -y
         update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-${{ env.GCC_COMPILER_VERSION }} 100 --slave /usr/bin/g++ g++ /usr/bin/g++-${{ env.GCC_COMPILER_VERSION }} --slave /usr/bin/gcov gcov /usr/bin/gcov-${{ env.GCC_COMPILER_VERSION }}
         python3 -m pip install -U --user -r requirements.txt
         rm -rf ${{ env.ROCM_PATH }}/lib/*rocprofiler-sdk* ${{ env.ROCM_PATH }}/lib/cmake/*rocprofiler-sdk* ${{ env.ROCM_PATH }}/share/*rocprofiler-sdk* ${{ env.ROCM_PATH }}/libexec/*rocprofiler-sdk* ${{ env.ROCM_PATH }}*/lib/python*/site-packages/roctx ${{ env.ROCM_PATH }}*/lib/python*/site-packages/rocpd

--- a/.github/workflows/rocprofiler-sdk-continuous_integration.yml
+++ b/.github/workflows/rocprofiler-sdk-continuous_integration.yml
@@ -750,8 +750,10 @@ jobs:
       run: |
         git config --global --add safe.directory '*'
         apt-get update
+        apt-get install -y software-properties-common
         add-apt-repository -y ppa:ubuntu-toolchain-r/test
         apt-get update
+        apt-get dist-upgrade -y
         apt-get install -y gcc-${{ env.GCC_COMPILER_VERSION }} g++-${{ env.GCC_COMPILER_VERSION }}
         apt-get install -y build-essential cmake python3-pip libasan8 libtsan2 software-properties-common clang-15 libdw-dev libsqlite3-dev libdrm-dev file autoconf pkg-config
         apt-get upgrade -y

--- a/.github/workflows/rocprofiler-sdk-continuous_integration.yml
+++ b/.github/workflows/rocprofiler-sdk-continuous_integration.yml
@@ -672,10 +672,10 @@ jobs:
       fail-fast: false
       matrix:
         system:
-          - { sanitizer: 'AddressSanitizer', os: 'ubuntu-24.04', runner: 'linux-mi325-8gpu-ossci-rocm-sandbox', gpu: 'mi325', gpu-target: 'gfx94X', build-type: 'RelWithDebInfo' }
-          - { sanitizer: 'ThreadSanitizer', os: 'ubuntu-24.04', runner: 'linux-mi325-8gpu-ossci-rocm-sandbox', gpu: 'mi325', gpu-target: 'gfx94X', build-type: 'RelWithDebInfo' }
-          - { sanitizer: 'LeakSanitizer', os: 'ubuntu-24.04', runner: 'linux-mi325-8gpu-ossci-rocm-sandbox', gpu: 'mi325', gpu-target: 'gfx94X', build-type: 'RelWithDebInfo' }
-          - { sanitizer: 'UndefinedBehaviorSanitizer', os: 'ubuntu-24.04', runner: 'linux-mi325-8gpu-ossci-rocm-sandbox', gpu: 'mi325', gpu-target: 'gfx94X', build-type: 'RelWithDebInfo' }
+          - { sanitizer: 'AddressSanitizer', os: 'ubuntu-22.04', runner: 'linux-mi325-8gpu-ossci-rocm-sandbox', gpu: 'mi325', gpu-target: 'gfx94X', build-type: 'RelWithDebInfo' }
+          - { sanitizer: 'ThreadSanitizer', os: 'ubuntu-22.04', runner: 'linux-mi325-8gpu-ossci-rocm-sandbox', gpu: 'mi325', gpu-target: 'gfx94X', build-type: 'RelWithDebInfo' }
+          - { sanitizer: 'LeakSanitizer', os: 'ubuntu-22.04', runner: 'linux-mi325-8gpu-ossci-rocm-sandbox', gpu: 'mi325', gpu-target: 'gfx94X', build-type: 'RelWithDebInfo' }
+          - { sanitizer: 'UndefinedBehaviorSanitizer', os: 'ubuntu-22.04', runner: 'linux-mi325-8gpu-ossci-rocm-sandbox', gpu: 'mi325', gpu-target: 'gfx94X', build-type: 'RelWithDebInfo' }
 
     if: ${{ contains(github.event_name, 'pull_request') }}
     runs-on: ${{ matrix.system.runner }}
@@ -754,16 +754,16 @@ jobs:
         add-apt-repository -y ppa:ubuntu-toolchain-r/test
         apt-get update
         apt-get install -y \
-          gcc-${{ env.GCC_COMPILER_VERSION }} \
-          g++-${{ env.GCC_COMPILER_VERSION }} \
+          gcc-12 \
+          g++-12 \
           libcc1-0 \
-          libgcc-${{ env.GCC_COMPILER_VERSION }}-dev \
+          libgcc-12-dev \
           libstdc++6 \
-          libstdc++-${{ env.GCC_COMPILER_VERSION }}-dev \
+          libstdc++-12-dev \
           build-essential cmake python3-pip libasan8 libtsan2 \
           software-properties-common clang-15 libdw-dev libsqlite3-dev \
           libdrm-dev file autoconf pkg-config
-        update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-${{ env.GCC_COMPILER_VERSION }} 100 --slave /usr/bin/g++ g++ /usr/bin/g++-${{ env.GCC_COMPILER_VERSION }} --slave /usr/bin/gcov gcov /usr/bin/gcov-${{ env.GCC_COMPILER_VERSION }}
+        update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-12 100 --slave /usr/bin/g++ g++ /usr/bin/g++-12 --slave /usr/bin/gcov gcov /usr/bin/gcov-12
         python3 -m pip install -U --user -r requirements.txt
         rm -rf ${{ env.ROCM_PATH }}/lib/*rocprofiler-sdk* ${{ env.ROCM_PATH }}/lib/cmake/*rocprofiler-sdk* ${{ env.ROCM_PATH }}/share/*rocprofiler-sdk* ${{ env.ROCM_PATH }}/libexec/*rocprofiler-sdk* ${{ env.ROCM_PATH }}*/lib/python*/site-packages/roctx ${{ env.ROCM_PATH }}*/lib/python*/site-packages/rocpd
 


### PR DESCRIPTION
## Motivation

CI failure from https://github.com/ROCm/rocm-systems/pull/3233

## Technical Details

- Switch CI back to GCC 12 on Ubuntu 22.04 (Jammy) to avoid broken GCC 13 dependencies.
-  -DCMAKE_CXX_COMPILER entries to rocDecode/rocJPEG configure to use from /rocm/lib/llvm/bin/amdclang++ path.

## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
