### PR TITLE
AIRUNTIME-129 - Fix Ocl test failures of 2D image with pitches.

### DIFF
--- a/projects/rocr-runtime/runtime/hsa-runtime/image/image_manager_ai.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/image/image_manager_ai.cpp
@@ -534,6 +534,7 @@ uint32_t ImageManagerAi::GetAddrlibSurfaceInfoAi(
   in.height = height;
   in.numSlices = num_slice;
   in.numMipLevels = num_mipmap_levels;
+  in.pitchInElement = image_data_row_pitch / image_prop.element_size;
 
   switch(desc.geometry) {
   case HSA_EXT_IMAGE_GEOMETRY_1D:

--- a/projects/rocr-runtime/runtime/hsa-runtime/image/image_manager_gfx11.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/image/image_manager_gfx11.cpp
@@ -652,6 +652,7 @@ uint32_t ImageManagerGfx11::GetAddrlibSurfaceInfoNv(
   in.height = height;
   in.numSlices = num_slice;
   in.numMipLevels = num_mipmap_levels;
+  in.pitchInElement = image_data_row_pitch / image_prop.element_size;
 
   switch (desc.geometry) {
     case HSA_EXT_IMAGE_GEOMETRY_1D:

--- a/projects/rocr-runtime/runtime/hsa-runtime/image/image_manager_gfx12.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/image/image_manager_gfx12.cpp
@@ -688,6 +688,7 @@ uint32_t ImageManagerGfx12::GetAddrlibSurfaceInfoNv(
   in.height = height;
   in.numSlices = num_slice;
   in.numMipLevels = num_mipmap_levels;
+  in.pitchInElement = image_data_row_pitch / image_prop.element_size;
 
   switch (desc.geometry) {
     case HSA_EXT_IMAGE_GEOMETRY_1D:

--- a/projects/rocr-runtime/runtime/hsa-runtime/image/image_manager_nv.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/image/image_manager_nv.cpp
@@ -648,6 +648,7 @@ uint32_t ImageManagerNv::GetAddrlibSurfaceInfoNv(
   in.height = height;
   in.numSlices = num_slice;
   in.numMipLevels = num_mipmap_levels;
+  in.pitchInElement = image_data_row_pitch / image_prop.element_size;
 
   switch (desc.geometry) {
     case HSA_EXT_IMAGE_GEOMETRY_1D:


### PR DESCRIPTION
## Motivation

Fix CTS "test_kernel_read_write 2D" failure with pitches.
The failed type is buffered 2D images.
It is due to an error in previous rocr patch on mipmap.
 
## Technical Details

Fix previous errors

## JIRA ID

AIRUNTIME-129 

## Test Plan

All pass

## Test Result

pass 

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
