### PR TITLE
PR Patch Back Fixes

### DIFF
--- a/.github/scripts/pr_merge_sync_patches.py
+++ b/.github/scripts/pr_merge_sync_patches.py
@@ -81,7 +81,7 @@ def parse_arguments(argv: Optional[List[str]] = None) -> argparse.Namespace:
         "--keep-clone-dir",
         metavar="DIR",
         default=None,
-        help="Clone the subrepo into DIR instead of a temp dir (implies --no-push). Use with --no-push to inspect the result.",
+        help="Clone the subrepo into DIR instead of a temp dir (implies --no-push).",
     )
     parser.add_argument(
         "--debug", action="store_true", help="If set, enables detailed debug logging."
@@ -389,6 +389,11 @@ def apply_patch_to_subrepo(
     """
     if keep_clone_dir is not None:
         subrepo_path = Path(keep_clone_dir) / entry.name
+        if subrepo_path.exists():
+            raise RuntimeError(
+                f"Clone path already exists: {subrepo_path}. "
+                "Remove it or use a different --keep-clone-dir for a fresh clone."
+            )
         subrepo_path.parent.mkdir(parents=True, exist_ok=True)
         _clone_subrepo(entry.url, entry.branch, subrepo_path)
         tmpdir = None
@@ -406,8 +411,6 @@ def apply_patch_to_subrepo(
             return
 
         _configure_git_user(subrepo_path)
-        if not no_push:
-            _set_authenticated_remote(subrepo_path, entry.url)
 
         # Apply each patch and create separate commits (skip empty patches)
         committed = 0
@@ -429,7 +432,12 @@ def apply_patch_to_subrepo(
             logger.info(
                 f"[Mock run] Applied {committed} patch(es) and committed locally at {subrepo_path}; not pushed."
             )
+        elif committed == 0:
+            logger.info(
+                f"No commits created for {entry.url} (all patches were empty); nothing to push."
+            )
         else:
+            _set_authenticated_remote(subrepo_path, entry.url)
             _push_changes(subrepo_path, entry.branch)
             logger.info(
                 f"Applied {committed} patch(es), committed, and pushed to {entry.url} as {author_name} <{author_email}>"
@@ -463,6 +471,9 @@ def main(argv: Optional[List[str]] = None) -> None:
         return
     logger.debug(f"Base commit for PR #{args.pr} in {args.repo}: {base_sha}")
 
+    if args.keep_clone_dir:
+        args.no_push = True
+
     keep_clone_path = Path(args.keep_clone_dir) if args.keep_clone_dir else None
 
     for entry in relevant_subtrees:
@@ -472,6 +483,8 @@ def main(argv: Optional[List[str]] = None) -> None:
         if args.keep_patches_dir:
             patch_dir = Path(args.keep_patches_dir) / f"{entry.category}-{entry.name}"
             patch_dir.mkdir(parents=True, exist_ok=True)
+            for f in patch_dir.glob("*.patch"):
+                f.unlink()
         else:
             patch_dir = Path(tempfile.mkdtemp())
         patch_file = patch_dir / f"{entry.name}.patch"

--- a/.github/scripts/pr_merge_sync_patches.py
+++ b/.github/scripts/pr_merge_sync_patches.py
@@ -150,21 +150,14 @@ def _apply_patch(repo_path: Path, patch_path: Path) -> bool:
     Returns True if the patch applied with changes, False if it was empty/no-op.
     """
     _run_git(["apply", "--allow-empty", str(patch_path)], cwd=repo_path)
-    # Check if apply actually produced any changes (empty patches leave working tree unchanged)
-    has_changes = (
-        _run_git(
-            ["diff", "--cached", "--name-only"],
-            cwd=repo_path,
-        ).strip()
-        or _run_git(
-            ["diff", "--name-only"],
-            cwd=repo_path,
-        ).strip()
-    )
+    # git apply only modifies working tree; check for any changes
+    has_changes = _run_git(["diff", "--name-only"], cwd=repo_path).strip()
     if has_changes:
         logger.info(f"Applied patch to working tree at {repo_path}")
     else:
-        logger.debug(f"Patch produced no changes in working tree at {repo_path}, skipping commit")
+        logger.debug(
+            f"Patch produced no changes in working tree at {repo_path}, skipping commit"
+        )
     return bool(has_changes)
 
 

--- a/.github/scripts/pr_merge_sync_patches.py
+++ b/.github/scripts/pr_merge_sync_patches.py
@@ -164,7 +164,7 @@ def _apply_patch(repo_path: Path, patch_path: Path) -> bool:
     if has_changes:
         logger.info(f"Applied patch to working tree at {repo_path}")
     else:
-        logger.debug(f"Patch was empty (no hunks) at {repo_path}, skipping commit")
+        logger.debug(f"Patch produced no changes in working tree at {repo_path}, skipping commit")
     return bool(has_changes)
 
 

--- a/.github/scripts/pr_merge_sync_patches.py
+++ b/.github/scripts/pr_merge_sync_patches.py
@@ -22,13 +22,14 @@ Arguments:
     --debug     : If set, enables detailed debug logging.
 
 Example Usage:
-    python pr_merge_sync_patches.py --repo ROCm/rocm-systems --pr 123 --subtrees "$(printf 'projects/rocprofiler-sdk\nprojects/rocprofiler-register\projects/rocm-smi-lib')" --dry-run --debug
+    python pr_merge_sync_patches.py --repo ROCm/rocm-systems --pr 123 --subtrees "$(printf 'projects/rocprofiler-sdk\\nprojects/rocprofiler-register\\nprojects/rocm-smi-lib')" --dry-run --debug
 """
 
 import argparse
 import logging
 import os
 import re
+import shutil
 import subprocess
 import tempfile
 from typing import Optional, List
@@ -64,6 +65,23 @@ def parse_arguments(argv: Optional[List[str]] = None) -> argparse.Namespace:
         "--dry-run",
         action="store_true",
         help="If set, only logs actions without making changes.",
+    )
+    parser.add_argument(
+        "--no-push",
+        action="store_true",
+        help="Clone, apply patches, and commit locally but do not push to remote (mock run).",
+    )
+    parser.add_argument(
+        "--keep-patches-dir",
+        metavar="DIR",
+        default=None,
+        help="Write generated patch files to DIR (e.g. ./patches) for inspection instead of a temp dir.",
+    )
+    parser.add_argument(
+        "--keep-clone-dir",
+        metavar="DIR",
+        default=None,
+        help="Clone the subrepo into DIR instead of a temp dir (implies --no-push). Use with --no-push to inspect the result.",
     )
     parser.add_argument(
         "--debug", action="store_true", help="If set, enables detailed debug logging."
@@ -126,10 +144,28 @@ def _configure_git_user(repo_path: Path) -> None:
     )
 
 
-def _apply_patch(repo_path: Path, patch_path: Path) -> None:
-    """Apply a patch file to the working tree."""
-    _run_git(["apply", str(patch_path)], cwd=repo_path)
-    logger.info(f"Applied patch to working tree at {repo_path}")
+def _apply_patch(repo_path: Path, patch_path: Path) -> bool:
+    """Apply a patch file to the working tree. Use --allow-empty so patches that
+    touch no files in the subtree (e.g. empty or path-filtered) do not fail.
+    Returns True if the patch applied with changes, False if it was empty/no-op.
+    """
+    _run_git(["apply", "--allow-empty", str(patch_path)], cwd=repo_path)
+    # Check if apply actually produced any changes (empty patches leave working tree unchanged)
+    has_changes = (
+        _run_git(
+            ["diff", "--cached", "--name-only"],
+            cwd=repo_path,
+        ).strip()
+        or _run_git(
+            ["diff", "--name-only"],
+            cwd=repo_path,
+        ).strip()
+    )
+    if has_changes:
+        logger.info(f"Applied patch to working tree at {repo_path}")
+    else:
+        logger.debug(f"Patch was empty (no hunks) at {repo_path}, skipping commit")
+    return bool(has_changes)
 
 
 def _stage_changes(repo_path: Path) -> None:
@@ -198,60 +234,111 @@ def _push_changes(repo_path: Path, branch: str) -> None:
     logger.debug(f"Pushed changes from {repo_path} to origin")
 
 
+def _commits_touching_prefix(base_sha: str, merge_sha: str, prefix: str) -> List[str]:
+    """Return full SHAs of commits in base..merge that touch the prefix (oldest first)."""
+    path_arg = prefix.rstrip("/")
+    out = _run_git(
+        ["rev-list", "--reverse", f"{base_sha}..{merge_sha}", "--", path_arg]
+    )
+    return [s.strip() for s in out.splitlines() if s.strip()]
+
+
+def _patch_has_hunks(patch_path: Path) -> bool:
+    """Return True if the patch file contains at least one diff hunk (---/+++ and lines)."""
+    with open(patch_path, "r", encoding="utf-8") as f:
+        content = f.read()
+    # Git patch has "--- a/path" and "+++ b/path" then "@@ ... @@" hunks
+    return "--- " in content and "+++ " in content and "@@ " in content
+
+
+def _patch_touched_paths(patch_path: Path) -> List[str]:
+    """Return list of file paths touched in the patch (from --- / +++ lines)."""
+    paths = []
+    with open(patch_path, "r", encoding="utf-8") as f:
+        for line in f:
+            if line.startswith("--- ") or line.startswith("+++ "):
+                # "--- a/clr/foo.c" or "+++ b/clr/foo.c" -> clr/foo.c
+                p = line[4:].strip().split("\t")[0]
+                if p.startswith("a/") or p.startswith("b/"):
+                    p = p[2:]
+                if p != "/dev/null" and p not in paths:
+                    paths.append(p)
+    return paths
+
+
 def generate_patch(
-    prefix: str, merge_sha: str, patch_path: Path, base_sha: str
+    prefix: str,
+    merge_sha: str,
+    patch_path: Path,
+    base_sha: str,
+    debug: bool = False,
 ) -> Optional[List[Path]]:
     """Generate patch file(s) for a given subtree prefix from a merge commit.
+
+    Only commits that actually touch files under the prefix are included, so every
+    generated patch has at least one diff hunk and can be applied to the subrepo.
 
     Args:
         prefix: The subtree prefix (e.g., "projects/rocBLAS/")
         merge_sha: The merge commit SHA
         patch_path: Path where patch file(s) should be written
         base_sha: Base commit SHA. Required to properly handle both squash and rebase merges.
+        debug: If True, log which commits touch the prefix and each patch's paths.
 
     Returns:
-        List[Path]: List of patch file paths (single entry for squash merges, multiple for rebase merges)
-        None: If there are no commits to process
+        List[Path]: List of patch file paths (one per commit that touches the subtree)
+        None: If there are no commits that touch the prefix
     """
-    # Check how many commits are between base and merge_sha
-    commit_count = _run_git(["rev-list", "--count", f"{base_sha}..{merge_sha}"])
-    commit_count_int = int(commit_count)
+    path_arg = prefix.rstrip("/")
+    total_commits = int(_run_git(["rev-list", "--count", f"{base_sha}..{merge_sha}"]))
+    commits = _commits_touching_prefix(base_sha, merge_sha, prefix)
 
-    if commit_count_int == 0:
+    if debug:
         logger.debug(
-            f"No commits between {base_sha} and {merge_sha} for prefix '{prefix}', skipping"
+            f"Commit range {base_sha}..{merge_sha}: {total_commits} total commit(s), "
+            f"{len(commits)} commit(s) touch subtree '{path_arg}'"
+        )
+        for i, sha in enumerate(commits, 1):
+            subject = _run_git(["log", "-1", "--format=%s", sha])
+            logger.debug(f"  [{i}] {sha[:7]} {subject}")
+
+    if not commits:
+        logger.debug(
+            f"No commits in {base_sha}..{merge_sha} touch prefix '{prefix}', skipping"
         )
         return None
 
-    # Generate patches for all commits in the range (works for both single and multiple commits)
     patch_dir = patch_path.parent
-    # Use format-patch with range to generate patches
-    # Output will be numbered: 0001-<subject>.patch, 0002-<subject>.patch, etc.
-    args = [
-        "format-patch",
-        f"{base_sha}..{merge_sha}",
-        f"--relative={prefix}",
-        "--output-directory",
-        str(patch_dir),
-    ]
-    _run_git(args)
+    # Generate one patch per commit that touches the subtree (preserves order)
+    for i, sha in enumerate(commits, 1):
+        _run_git(
+            [
+                "format-patch",
+                "-1",
+                sha,
+                f"--relative={prefix}",
+                "--output-directory",
+                str(patch_dir),
+                "--start-number",
+                str(i),
+            ]
+        )
 
-    # Find all generated patch files (they'll be numbered)
-    # Note: With --relative, git only generates patches for commits that modify files
-    # within the prefix, so patch_files count may be less than commit_count_int
     patch_files = sorted(patch_dir.glob("*.patch"))
     if not patch_files:
-        logger.error(
-            f"No patch files generated for range {base_sha}..{merge_sha} with prefix '{prefix}'"
-        )
         raise RuntimeError(
-            f"No patch files were generated for range {base_sha}..{merge_sha} with prefix '{prefix}'. "
-            f"This is expected if none of the {commit_count_int} commits in this range modified files within this subtree, "
-            f"but may also indicate an issue with the commit range or prefix filter."
+            f"No patch files generated for range {base_sha}..{merge_sha} with prefix '{prefix}'."
         )
 
+    if debug:
+        for p in patch_files:
+            paths = _patch_touched_paths(p)
+            has_hunks = _patch_has_hunks(p)
+            logger.debug(f"Patch {p.name}: has_hunks={has_hunks}, paths={paths!r}")
+
     logger.debug(
-        f"Generated {len(patch_files)} patch file(s) for prefix '{prefix}' ({commit_count_int} commit(s) in range)"
+        f"Generated {len(patch_files)} patch file(s) for prefix '{prefix}' "
+        f"(all touch subtree; {total_commits} total commit(s) in range)"
     )
     return patch_files
 
@@ -283,6 +370,8 @@ def apply_patch_to_subrepo(
     author_email: str,
     merge_sha: str,
     dry_run: bool = False,
+    no_push: bool = False,
+    keep_clone_dir: Optional[Path] = None,
 ) -> None:
     """Clone the subrepo, apply patch(es), and attribute to the original author with commit message annotations.
 
@@ -295,10 +384,20 @@ def apply_patch_to_subrepo(
         author_email: Author email for commits
         merge_sha: Merge commit SHA
         dry_run: If True, only log actions without making changes
+        no_push: If True, do not push after committing (mock run)
+        keep_clone_dir: If set, clone into this path instead of a temp dir (dir/entry.name); not cleaned up
     """
-    with tempfile.TemporaryDirectory() as tmpdir:
-        subrepo_path = Path(tmpdir) / entry.name
+    if keep_clone_dir is not None:
+        subrepo_path = Path(keep_clone_dir) / entry.name
+        subrepo_path.parent.mkdir(parents=True, exist_ok=True)
         _clone_subrepo(entry.url, entry.branch, subrepo_path)
+        tmpdir = None
+    else:
+        tmpdir = tempfile.TemporaryDirectory()
+        subrepo_path = Path(tmpdir.name) / entry.name
+        _clone_subrepo(entry.url, entry.branch, subrepo_path)
+
+    try:
         if dry_run:
             patch_count = len(patch_paths)
             logger.info(
@@ -307,25 +406,37 @@ def apply_patch_to_subrepo(
             return
 
         _configure_git_user(subrepo_path)
-        _set_authenticated_remote(subrepo_path, entry.url)
+        if not no_push:
+            _set_authenticated_remote(subrepo_path, entry.url)
 
-        # Apply each patch and create separate commits
+        # Apply each patch and create separate commits (skip empty patches)
+        committed = 0
         for i, patch_path in enumerate(patch_paths, 1):
             logger.debug(f"Applying patch {i}/{len(patch_paths)}: {patch_path.name}")
-            _apply_patch(subrepo_path, patch_path)
+            had_changes = _apply_patch(subrepo_path, patch_path)
+            if not had_changes:
+                continue
             _stage_changes(subrepo_path)
             original_commit_msg = _extract_commit_message_from_patch(patch_path)
             commit_msg = _format_commit_message(
                 super_repo_url, super_repo_pr, merge_sha, original_commit_msg
             )
             _commit_changes(subrepo_path, commit_msg, author_name, author_email)
+            committed += 1
             logger.debug(f"Committed patch {i}/{len(patch_paths)}")
 
-        # Push all commits at once
-        _push_changes(subrepo_path, entry.branch)
-        logger.info(
-            f"Applied {len(patch_paths)} patch(es), committed, and pushed to {entry.url} as {author_name} <{author_email}>"
-        )
+        if no_push:
+            logger.info(
+                f"[Mock run] Applied {committed} patch(es) and committed locally at {subrepo_path}; not pushed."
+            )
+        else:
+            _push_changes(subrepo_path, entry.branch)
+            logger.info(
+                f"Applied {committed} patch(es), committed, and pushed to {entry.url} as {author_name} <{author_email}>"
+            )
+    finally:
+        if tmpdir is not None:
+            tmpdir.cleanup()
 
 
 def main(argv: Optional[List[str]] = None) -> None:
@@ -352,12 +463,23 @@ def main(argv: Optional[List[str]] = None) -> None:
         return
     logger.debug(f"Base commit for PR #{args.pr} in {args.repo}: {base_sha}")
 
+    keep_clone_path = Path(args.keep_clone_dir) if args.keep_clone_dir else None
+
     for entry in relevant_subtrees:
         prefix = f"{entry.category}/{entry.name}/"
         logger.debug(f"Processing subtree {prefix}")
-        with tempfile.TemporaryDirectory() as tmpdir:
-            patch_file = Path(tmpdir) / f"{entry.name}.patch"
-            patch_result = generate_patch(prefix, merge_sha, patch_file, base_sha)
+
+        if args.keep_patches_dir:
+            patch_dir = Path(args.keep_patches_dir) / f"{entry.category}-{entry.name}"
+            patch_dir.mkdir(parents=True, exist_ok=True)
+        else:
+            patch_dir = Path(tempfile.mkdtemp())
+        patch_file = patch_dir / f"{entry.name}.patch"
+
+        try:
+            patch_result = generate_patch(
+                prefix, merge_sha, patch_file, base_sha, debug=args.debug
+            )
             if patch_result is None:
                 logger.debug(f"No patches to apply for subtree {prefix}, skipping")
                 continue
@@ -370,8 +492,13 @@ def main(argv: Optional[List[str]] = None) -> None:
                 author_name,
                 author_email,
                 merge_sha,
-                args.dry_run,
+                dry_run=args.dry_run,
+                no_push=args.no_push,
+                keep_clone_dir=keep_clone_path,
             )
+        finally:
+            if not args.keep_patches_dir and patch_dir.exists():
+                shutil.rmtree(patch_dir, ignore_errors=True)
 
 
 if __name__ == "__main__":

--- a/.github/scripts/pr_merge_sync_patches.py
+++ b/.github/scripts/pr_merge_sync_patches.py
@@ -436,8 +436,12 @@ def apply_patch_to_subrepo(
                 f"Applied {committed} patch(es), committed, and pushed to {entry.url} as {author_name} <{author_email}>"
             )
     except Exception:
-        if keep_clone_dir is not None and subrepo_path.exists():
-            shutil.rmtree(subrepo_path, ignore_errors=True)
+        # Preserve the clone directory on error so it can be inspected when --keep-clone-dir is used.
+        logger.exception(
+            "Error while applying patches to %s; clone directory preserved at %s for inspection.",
+            entry.url,
+            subrepo_path,
+        )
         raise
     finally:
         if tmpdir is not None:

--- a/.github/scripts/pr_merge_sync_patches.py
+++ b/.github/scripts/pr_merge_sync_patches.py
@@ -150,8 +150,8 @@ def _apply_patch(repo_path: Path, patch_path: Path) -> bool:
     Returns True if the patch applied with changes, False if it was empty/no-op.
     """
     _run_git(["apply", "--allow-empty", str(patch_path)], cwd=repo_path)
-    # git apply only modifies working tree; check for any changes
-    has_changes = _run_git(["diff", "--name-only"], cwd=repo_path).strip()
+    # git apply only modifies working tree (does not stage); include untracked (new files)
+    has_changes = _run_git(["status", "--porcelain"], cwd=repo_path).strip()
     if has_changes:
         logger.info(f"Applied patch to working tree at {repo_path}")
     else:
@@ -320,7 +320,8 @@ def generate_patch(
     patch_files = sorted(patch_dir.glob("*.patch"))
     if not patch_files:
         raise RuntimeError(
-            f"No patch files generated for range {base_sha}..{merge_sha} with prefix '{prefix}'."
+            f"No patch files generated for range {base_sha}..{merge_sha} with prefix '{prefix}' "
+            f"(expected patches for {len(commits)} commit(s) touching subtree)."
         )
 
     if debug:
@@ -388,14 +389,13 @@ def apply_patch_to_subrepo(
                 "Remove it or use a different --keep-clone-dir for a fresh clone."
             )
         subrepo_path.parent.mkdir(parents=True, exist_ok=True)
-        _clone_subrepo(entry.url, entry.branch, subrepo_path)
         tmpdir = None
     else:
         tmpdir = tempfile.TemporaryDirectory()
         subrepo_path = Path(tmpdir.name) / entry.name
-        _clone_subrepo(entry.url, entry.branch, subrepo_path)
 
     try:
+        _clone_subrepo(entry.url, entry.branch, subrepo_path)
         if dry_run:
             patch_count = len(patch_paths)
             logger.info(
@@ -435,6 +435,10 @@ def apply_patch_to_subrepo(
             logger.info(
                 f"Applied {committed} patch(es), committed, and pushed to {entry.url} as {author_name} <{author_email}>"
             )
+    except Exception:
+        if keep_clone_dir is not None and subrepo_path.exists():
+            shutil.rmtree(subrepo_path, ignore_errors=True)
+        raise
     finally:
         if tmpdir is not None:
             tmpdir.cleanup()
@@ -467,7 +471,10 @@ def main(argv: Optional[List[str]] = None) -> None:
     if args.keep_clone_dir:
         args.no_push = True
 
-    keep_clone_path = Path(args.keep_clone_dir) if args.keep_clone_dir else None
+    # In dry-run do not write to keep_clone_dir (use temp clone only for logging)
+    keep_clone_path = (
+        Path(args.keep_clone_dir) if args.keep_clone_dir and not args.dry_run else None
+    )
 
     for entry in relevant_subtrees:
         prefix = f"{entry.category}/{entry.name}/"
@@ -480,14 +487,17 @@ def main(argv: Optional[List[str]] = None) -> None:
                 f.unlink()
         else:
             patch_dir = Path(tempfile.mkdtemp())
-        patch_file = patch_dir / f"{entry.name}.patch"
+        # generate_patch uses only the parent dir; path is a placeholder for patch_dir
+        patch_dir_anchor = patch_dir / f"{entry.name}.patch"
 
         try:
             patch_result = generate_patch(
-                prefix, merge_sha, patch_file, base_sha, debug=args.debug
+                prefix, merge_sha, patch_dir_anchor, base_sha, debug=args.debug
             )
             if patch_result is None:
                 logger.debug(f"No patches to apply for subtree {prefix}, skipping")
+                if args.keep_patches_dir and patch_dir.exists():
+                    shutil.rmtree(patch_dir, ignore_errors=True)
                 continue
             author_name, author_email = resolve_patch_author(client, args.repo, args.pr)
             apply_patch_to_subrepo(
@@ -503,7 +513,7 @@ def main(argv: Optional[List[str]] = None) -> None:
                 keep_clone_dir=keep_clone_path,
             )
         finally:
-            if not args.keep_patches_dir and patch_dir.exists():
+            if not args.keep_patches_dir:
                 shutil.rmtree(patch_dir, ignore_errors=True)
 
 


### PR DESCRIPTION
## Motivation
Script was failing with "No valid patches in input" when syncing to subrepos. It generated one patch per commit in the PR range; commits that didn't touch the subtree produced header-only patches and `git apply` failed.

## Changes
- **Path-filter patches:** Only generate patches for commits that touch the subtree (`git rev-list base..merge -- <path>`), so every patch has hunks.
- **Empty patches:** Use `git apply --allow-empty` and skip committing when a patch applies with no changes.
- **Docstring:** Fix invalid escape `\p` in the example (use `\\n`).
- **New options:** `--debug` (log commits/paths per patch), `--no-push` (apply and commit locally, don't push), `--keep-patches-dir`, `--keep-clone-dir` for inspection.

## Testing
Mock runs for PR 3292 (rocprofiler-compute) and PR 2367 (clr); 2367 patch applied cleanly. Pre-commit (black) run on script.