### PR TITLE
[AMD-SMI] Display N/A for cu_occupancy when file is unavailable

### DIFF
--- a/projects/amdsmi/rocm_smi/src/rocm_smi.cc
+++ b/projects/amdsmi/rocm_smi/src/rocm_smi.cc
@@ -5322,9 +5322,10 @@ rsmi_compute_process_info_get(rsmi_process_info_t *procs,
           procs[i].process_id, &procs[i], &gpu_set);
       // Non-fatal: if a process disappeared between enumeration
       // and info collection (ESRCH), zero-fill stats but keep process_id
+      // cu_occupancy uses KFD_STATS_INVALID to signal N/A.
       if (proc_err_code == ESRCH) {
         const auto pid = procs[i].process_id;
-        procs[i] = rsmi_process_info_t{pid, 0, 0, 0, 0};
+        procs[i] = rsmi_process_info_t{pid, 0, 0, KFD_STATS_INVALID, 0};
       } else if (proc_err_code) {
         return amd::smi::ErrnoToRsmiStatus(proc_err_code);
       }

--- a/projects/amdsmi/rocm_smi/src/rocm_smi_kfd.cc
+++ b/projects/amdsmi/rocm_smi/src/rocm_smi_kfd.cc
@@ -634,7 +634,8 @@ int GetProcessInfoForPID(uint32_t pid, rsmi_process_info_t *proc,
 
   proc->vram_usage = 0;
   proc->sdma_usage = 0;
-  proc->cu_occupancy = 0;
+  // Default to invalid to display N/A if cu_occupancy file is unavailable
+  proc->cu_occupancy = KFD_STATS_INVALID;
   proc->evicted_time = 0;
 
   // Collect all paths to read metrics from: primary process + secondary contexts
@@ -718,7 +719,8 @@ int GetProcessInfoForPID(uint32_t pid, rsmi_process_info_t *proc,
         }
       } else {
         // Aggregate cu_occupancy (use max value as it represents peak usage)
-        if (kfd_stat != KFD_STATS_INVALID && kfd_stat > proc->cu_occupancy) {
+        if (kfd_stat != KFD_STATS_INVALID &&
+            (proc->cu_occupancy == KFD_STATS_INVALID || kfd_stat > proc->cu_occupancy)) {
           proc->cu_occupancy = kfd_stat;
         }
       }

--- a/projects/amdsmi/tests/amd_smi_test/functional/process_info_read.cc
+++ b/projects/amdsmi/tests/amd_smi_test/functional/process_info_read.cc
@@ -183,7 +183,7 @@ void TestProcInfoRead::Run(void) {
                                    " SDMA Usage: " <<
                                    proc_info.sdma_usage <<
                                    " Compute Unit Usage: " <<
-                                   proc_info.cu_occupancy <<
+                                   (proc_info.cu_occupancy == UINT32_MAX ? "N/A" : std::to_string(proc_info.cu_occupancy)) <<
                                    " Evicted Time: " <<
                                    proc_info.evicted_time << std::endl <<
                                    std::endl;


### PR DESCRIPTION

## Motivation

cu_occupancy shows 0.0 % when the sysfs file is unavailable.

## Technical Details

Initialize process cu_occupancy to INVALID instead of zero to display N/A rather than misleading 0%.

## JIRA ID

N/A

## Test Plan

Run a process - rvs
amd-smi monitor -q
amd-smi process

## Test Result

**process output:**
<img width="155" height="285" alt="image" src="https://github.com/user-attachments/assets/52a43e34-181e-451a-abae-d39ff06195fa" />

<img width="222" height="288" alt="image" src="https://github.com/user-attachments/assets/71bab14a-15b9-4189-a5eb-ff4784ee4911" />


**monitor output:**
<img width="799" height="181" alt="image" src="https://github.com/user-attachments/assets/72f5f1b4-96be-4b8d-84cb-bf706af000dd" />


<img width="506" height="213" alt="image" src="https://github.com/user-attachments/assets/fd09bf5e-c088-4cde-9b6e-44359d108032" />

<img width="494" height="215" alt="image" src="https://github.com/user-attachments/assets/fd148db1-aec7-4fed-bc50-455b8a41de7e" />

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
