### PR TITLE
[rocprofiler-sdk] Add float support to get_env and complete set_env specializations

### DIFF
--- a/projects/rocprofiler-sdk/source/lib/common/environment.cpp
+++ b/projects/rocprofiler-sdk/source/lib/common/environment.cpp
@@ -85,7 +85,9 @@ get_env(std::string_view env_id, bool _default)
 
 template <typename Tp>
 Tp
-get_env(std::string_view env_id, Tp _default, std::enable_if_t<std::is_integral<Tp>::value, sfinae>)
+get_env(std::string_view env_id,
+        Tp               _default,
+        std::enable_if_t<std::is_integral<Tp>::value || std::is_floating_point<Tp>::value, sfinae>)
 {
     static_assert(!std::is_same<Tp, bool>::value, "unexpected! should be using bool overload");
     static_assert(
@@ -98,11 +100,18 @@ get_env(std::string_view env_id, Tp _default, std::enable_if_t<std::is_integral<
     {
         try
         {
-            // use stol/stoul
-            if constexpr(std::is_signed<Tp>::value)
-                return static_cast<Tp>(std::stol(env_var));
-            else
-                return static_cast<Tp>(std::stoul(env_var));
+            if constexpr(std::is_integral<Tp>::value)
+            {
+                // use stol/stoul
+                if constexpr(std::is_signed<Tp>::value)
+                    return static_cast<Tp>(std::stol(env_var));
+                else
+                    return static_cast<Tp>(std::stoul(env_var));
+            }
+            else if constexpr(std::is_floating_point<Tp>::value)
+            {
+                return static_cast<Tp>(std::stof(env_var));
+            }
         } catch(std::exception& _e)
         {
             ROCP_ERROR << "[rocprofiler][get_env] Exception thrown converting getenv(\"" << env_id
@@ -133,8 +142,10 @@ set_env(std::string_view env_id,
 
 #define SPECIALIZE_GET_ENV(TYPE)                                                                   \
     template TYPE get_env<TYPE>(                                                                   \
-        std::string_view, TYPE, std::enable_if_t<std::is_integral<TYPE>::value, sfinae>);          \
-    template int set_env<TYPE>(std::string_view, TYPE, int);
+        std::string_view,                                                                          \
+        TYPE,                                                                                      \
+        std::enable_if_t<std::is_integral<TYPE>::value || std::is_floating_point<TYPE>::value,     \
+                         sfinae>);
 
 #define SPECIALIZE_SET_ENV(TYPE) template int set_env<TYPE>(std::string_view, TYPE, int);
 
@@ -146,12 +157,21 @@ SPECIALIZE_GET_ENV(uint8_t)
 SPECIALIZE_GET_ENV(uint16_t)
 SPECIALIZE_GET_ENV(uint32_t)
 SPECIALIZE_GET_ENV(uint64_t)
+SPECIALIZE_GET_ENV(float)
 
 SPECIALIZE_SET_ENV(const char*)
 SPECIALIZE_SET_ENV(std::string)
 SPECIALIZE_SET_ENV(std::string_view)
 SPECIALIZE_SET_ENV(float)
 SPECIALIZE_SET_ENV(double)
+SPECIALIZE_SET_ENV(int8_t)
+SPECIALIZE_SET_ENV(int16_t)
+SPECIALIZE_SET_ENV(int32_t)
+SPECIALIZE_SET_ENV(int64_t)
+SPECIALIZE_SET_ENV(uint8_t)
+SPECIALIZE_SET_ENV(uint16_t)
+SPECIALIZE_SET_ENV(uint32_t)
+SPECIALIZE_SET_ENV(uint64_t)
 }  // namespace impl
 
 env_store::env_store(std::initializer_list<env_config>&& _container)

--- a/projects/rocprofiler-sdk/source/lib/common/environment.hpp
+++ b/projects/rocprofiler-sdk/source/lib/common/environment.hpp
@@ -47,7 +47,10 @@ bool
 get_env(std::string_view, bool);
 
 template <typename Tp>
-Tp get_env(std::string_view, Tp, std::enable_if_t<std::is_integral<Tp>::value, sfinae> = {});
+Tp get_env(std::string_view,
+           Tp,
+           std::enable_if_t<std::is_integral<Tp>::value || std::is_floating_point<Tp>::value,
+                            sfinae> = {});
 
 int
 set_env(std::string_view, bool, int override = 0);


### PR DESCRIPTION
## Summary

- Extends the `get_env` template to support `float` (and other floating point types) in addition to integral types, using `std::stof` for parsing
- Adds missing `SPECIALIZE_SET_ENV` instantiations for all integer types (`int8_t` through `uint64_t`) to match the existing `SPECIALIZE_GET_ENV` set
- Adds `SPECIALIZE_GET_ENV(float)` for explicit template instantiation

## Context

This is **PR 1 of ~10** in a series of PRs splitting up the SPM (Streaming Performance Monitor) feature from [PR #922](https://github.com/ROCm/rocm-systems/pull/922). This PR contains standalone infrastructure changes with no SPM-specific dependencies.

The float environment variable support is needed by SPM for configuration parameters like sampling frequency (`ROCPROF_SPM_FREQUENCY`).

### PR Chain
1. **This PR** — Utility: float env var support
2. API header (`experimental/spm.h`)
3. AQL profile types + dlsym layer
4. Counter metadata SPM support flag
5. AQL packet construction + SPMPacket
6. SPM core runtime + context integration
7. Schema + cmake config
8. Output pipeline + DB schema
9. Tool integration + CLI
10. Tests, samples, docs

## Test plan

- [ ] Verify existing environment variable tests still pass
- [ ] Verify float parsing works correctly (e.g., `ROCPROF_SPM_FREQUENCY=0.5`)
- [ ] Build succeeds with no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)