### PR TITLE
rocr: Isolate libhsakmt usage to KfdDriver

### DIFF
--- a/projects/rocr-runtime/runtime/hsa-runtime/core/driver/kfd/amd_kfd_driver.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/driver/kfd/amd_kfd_driver.cpp
@@ -775,5 +775,250 @@ hsa_status_t KfdDriver::GetQueueSaveAreaInfo(HSA_QUEUEID queue_id, void** addres
   return HSA_STATUS_SUCCESS;
 }
 
+hsa_status_t KfdDriver::CreateEvent(HsaEventDescriptor& event_descriptor, bool manual_reset,
+                                    HsaEvent** event) const {
+  if (HSAKMT_CALL(hsaKmtCreateEvent(&event_descriptor, manual_reset, false, event)) !=
+      HSAKMT_STATUS_SUCCESS)
+    return HSA_STATUS_ERROR;
+  return HSA_STATUS_SUCCESS;
+}
+
+hsa_status_t KfdDriver::DestroyEvent(HsaEvent* event) const {
+  HSAKMT_CALL(hsaKmtDestroyEvent(event));
+  return HSA_STATUS_SUCCESS;
+}
+
+hsa_status_t KfdDriver::WaitOnEvent(HsaEvent* event, uint32_t timeout_ms,
+                                    uint64_t* event_age) const {
+  HSAKMT_CALL(hsaKmtWaitOnEvent_Ext(event, timeout_ms, event_age));
+  return HSA_STATUS_SUCCESS;
+}
+
+hsa_status_t KfdDriver::WaitOnMultipleEvents(HsaEvent** events, uint32_t num_events,
+                                             bool wait_on_all, uint32_t timeout_ms,
+                                             uint64_t* event_age) const {
+  HSAKMT_CALL(
+      hsaKmtWaitOnMultipleEvents_Ext(events, num_events, wait_on_all, timeout_ms, event_age));
+  return HSA_STATUS_SUCCESS;
+}
+
+hsa_status_t KfdDriver::SetEvent(HsaEvent* event) const {
+  HSAKMT_CALL(hsaKmtSetEvent(event));
+  return HSA_STATUS_SUCCESS;
+}
+
+hsa_status_t KfdDriver::RingDoorbell(HSA_QUEUEID queue_id, uint64_t value) const {
+  HSAKMT_CALL(hsaKmtQueueRingDoorbell(queue_id, value));
+  return HSA_STATUS_SUCCESS;
+}
+
+hsa_status_t KfdDriver::QueryPointerInfo(const void* ptr, HsaPointerInfo* info) const {
+  if (HSAKMT_CALL(hsaKmtQueryPointerInfo(ptr, info)) != HSAKMT_STATUS_SUCCESS)
+    return HSA_STATUS_ERROR;
+  return HSA_STATUS_SUCCESS;
+}
+
+hsa_status_t KfdDriver::SetMemoryUserData(const void* ptr, void* user_data) const {
+  if (HSAKMT_CALL(hsaKmtSetMemoryUserData(ptr, user_data)) != HSAKMT_STATUS_SUCCESS)
+    return HSA_STATUS_ERROR;
+  return HSA_STATUS_SUCCESS;
+}
+
+hsa_status_t KfdDriver::FreeMemoryHandle(HsaMemoryObjectHandle handle) const {
+  if (HSAKMT_CALL(hsaKmtMemHandleFree(handle)) != HSAKMT_STATUS_SUCCESS) return HSA_STATUS_ERROR;
+  return HSA_STATUS_SUCCESS;
+}
+
+hsa_status_t KfdDriver::ReturnAsanHeaderPage(void* addr) const {
+  if (HSAKMT_CALL(hsaKmtReturnAsanHeaderPage(addr)) != HSAKMT_STATUS_SUCCESS)
+    return HSA_STATUS_ERROR;
+  return HSA_STATUS_SUCCESS;
+}
+
+hsa_status_t KfdDriver::MapMemoryToGPU(const void* mem, size_t size, uint64_t* alternate_va) const {
+  if (HSAKMT_CALL(hsaKmtMapMemoryToGPU(const_cast<void*>(mem), size, alternate_va)) !=
+      HSAKMT_STATUS_SUCCESS)
+    return HSA_STATUS_ERROR;
+  return HSA_STATUS_SUCCESS;
+}
+
+hsa_status_t KfdDriver::MapMemoryToGPUNodes(const void* mem, size_t size, uint64_t* alternate_va,
+                                            HsaMemMapFlags flags, uint32_t num_nodes,
+                                            const uint32_t* nodes) const {
+  if (HSAKMT_CALL(hsaKmtMapMemoryToGPUNodes(const_cast<void*>(mem), size, alternate_va, flags,
+                                            num_nodes, const_cast<uint32_t*>(nodes))) !=
+      HSAKMT_STATUS_SUCCESS)
+    return HSA_STATUS_ERROR;
+  return HSA_STATUS_SUCCESS;
+}
+
+hsa_status_t KfdDriver::GetMemoryCpuAddr(void* device_handle, void* mem_handle, int* drm_fd,
+                                         uint64_t* cpu_addr) const {
+  if (HSAKMT_CALL(hsaKmtMemoryGetCpuAddr(static_cast<HsaMemoryObjectHandle>(device_handle),
+                                         static_cast<HsaMemoryObjectHandle>(mem_handle), drm_fd,
+                                         cpu_addr)) != HSAKMT_STATUS_SUCCESS)
+    return HSA_STATUS_ERROR;
+  return HSA_STATUS_SUCCESS;
+}
+
+hsa_status_t KfdDriver::AllocateMemoryAlign(uint32_t node, size_t size, size_t alignment,
+                                            HsaMemFlags flags, void** mem) const {
+  if (HSAKMT_CALL(hsaKmtAllocMemoryAlign(node, size, alignment, flags, mem)) !=
+      HSAKMT_STATUS_SUCCESS)
+    return HSA_STATUS_ERROR;
+  return HSA_STATUS_SUCCESS;
+}
+
+hsa_status_t KfdDriver::MemoryCpuMap(HsaMemoryObjectHandle handle, void** cpu_ptr) const {
+  if (HSAKMT_CALL(hsaKmtMemoryCpuMap(handle, cpu_ptr)) != HSAKMT_STATUS_SUCCESS)
+    return HSA_STATUS_ERROR;
+  return HSA_STATUS_SUCCESS;
+}
+
+hsa_status_t KfdDriver::ExportDMABufHandle(const void* mem, size_t size, int* dmabuf_fd,
+                                           uint64_t* offset) const {
+  if (HSAKMT_CALL(hsaKmtExportDMABufHandle(const_cast<void*>(mem), size, dmabuf_fd, offset)) !=
+      HSAKMT_STATUS_SUCCESS)
+    return HSA_STATUS_ERROR;
+  return HSA_STATUS_SUCCESS;
+}
+
+hsa_status_t KfdDriver::HandleImport(const HsaExternalHandleDesc* desc,
+                                     HsaHandleImportResult* result,
+                                     HsaHandleImportFlags* flags) const {
+  if (HSAKMT_CALL(hsaKmtHandleImport(desc, result, flags)) != HSAKMT_STATUS_SUCCESS)
+    return HSA_STATUS_ERROR;
+  return HSA_STATUS_SUCCESS;
+}
+
+hsa_status_t KfdDriver::ShareMemory(void* mem, size_t size, HsaSharedMemoryHandle* handle) const {
+  if (HSAKMT_CALL(hsaKmtShareMemory(mem, size, handle)) != HSAKMT_STATUS_SUCCESS)
+    return HSA_STATUS_ERROR;
+  return HSA_STATUS_SUCCESS;
+}
+
+hsa_status_t KfdDriver::RegisterSharedHandle(const HsaSharedMemoryHandle* handle, void** address,
+                                             HSAuint64* size) const {
+  if (HSAKMT_CALL(hsaKmtRegisterSharedHandle(handle, address, size)) != HSAKMT_STATUS_SUCCESS)
+    return HSA_STATUS_ERROR;
+  return HSA_STATUS_SUCCESS;
+}
+
+hsa_status_t KfdDriver::RegisterGraphicsHandleToNodes(int dmabuf_fd, HsaGraphicsResourceInfo* info,
+                                                      uint32_t num_nodes, uint32_t* nodes) const {
+  if (HSAKMT_CALL(hsaKmtRegisterGraphicsHandleToNodes(dmabuf_fd, info, num_nodes, nodes)) !=
+      HSAKMT_STATUS_SUCCESS)
+    return HSA_STATUS_ERROR;
+  return HSA_STATUS_SUCCESS;
+}
+
+hsa_status_t KfdDriver::RegisterGraphicsHandleToNodesExt(HSAuint64 dmabuf_fd,
+                                                         HsaGraphicsResourceInfo* info,
+                                                         HSAuint64 num_nodes, uint32_t* nodes,
+                                                         HSA_REGISTER_MEM_FLAGS flags) const {
+  if (HSAKMT_CALL(hsaKmtRegisterGraphicsHandleToNodesExt(dmabuf_fd, info, num_nodes, nodes,
+                                                         flags)) != HSAKMT_STATUS_SUCCESS)
+    return HSA_STATUS_ERROR;
+  return HSA_STATUS_SUCCESS;
+}
+
+hsa_status_t KfdDriver::MemoryVaMap(HsaMemoryObjectHandle handle, uint64_t offset, uint64_t size,
+                                    uint64_t va, uint32_t access) const {
+  if (HSAKMT_CALL(
+          hsaKmtMemoryVaMap(handle, offset, size, va, static_cast<HsaMemoryMapFlags>(access))) !=
+      HSAKMT_STATUS_SUCCESS)
+    return HSA_STATUS_ERROR;
+  return HSA_STATUS_SUCCESS;
+}
+
+hsa_status_t KfdDriver::MemoryVaUnmap(HsaMemoryObjectHandle handle, uint64_t offset, uint64_t size,
+                                      uint64_t va) const {
+  if (HSAKMT_CALL(hsaKmtMemoryVaUnmap(handle, offset, size, va)) != HSAKMT_STATUS_SUCCESS)
+    return HSA_STATUS_ERROR;
+  return HSA_STATUS_SUCCESS;
+}
+
+hsa_status_t KfdDriver::SVMSetAttr(void* addr, size_t size, uint32_t count,
+                                   HSA_SVM_ATTRIBUTE* attrs) const {
+  if (HSAKMT_CALL(hsaKmtSVMSetAttr(addr, size, count, attrs)) != HSAKMT_STATUS_SUCCESS)
+    return HSA_STATUS_ERROR;
+  return HSA_STATUS_SUCCESS;
+}
+
+hsa_status_t KfdDriver::SVMGetAttr(void* addr, size_t size, uint32_t count,
+                                   HSA_SVM_ATTRIBUTE* attrs) const {
+  if (HSAKMT_CALL(hsaKmtSVMGetAttr(addr, size, count, attrs)) != HSAKMT_STATUS_SUCCESS)
+    return HSA_STATUS_ERROR;
+  return HSA_STATUS_SUCCESS;
+}
+
+hsa_status_t KfdDriver::PcSamplingQueryCapabilities(uint32_t node_id, void* sample_info,
+                                                    size_t size, uint32_t* count) const {
+  if (HSAKMT_CALL(hsaKmtPcSamplingQueryCapabilities(node_id, sample_info, size, count)) !=
+      HSAKMT_STATUS_SUCCESS)
+    return HSA_STATUS_ERROR;
+  return HSA_STATUS_SUCCESS;
+}
+
+hsa_status_t KfdDriver::PcSamplingCreate(uint32_t node_id, HsaPcSamplingInfo* sample_info,
+                                         HsaPcSamplingTraceId* trace_id) const {
+  HSAKMT_STATUS status = HSAKMT_CALL(hsaKmtPcSamplingCreate(node_id, sample_info, trace_id));
+  if (status == HSAKMT_STATUS_KERNEL_ALREADY_OPENED)
+    return (hsa_status_t)HSA_STATUS_ERROR_RESOURCE_BUSY;
+  if (status != HSAKMT_STATUS_SUCCESS) return HSA_STATUS_ERROR;
+  return HSA_STATUS_SUCCESS;
+}
+
+hsa_status_t KfdDriver::PcSamplingDestroy(uint32_t node_id, HsaPcSamplingTraceId trace_id) const {
+  if (HSAKMT_CALL(hsaKmtPcSamplingDestroy(node_id, trace_id)) != HSAKMT_STATUS_SUCCESS)
+    return HSA_STATUS_ERROR;
+  return HSA_STATUS_SUCCESS;
+}
+
+hsa_status_t KfdDriver::PcSamplingStart(uint32_t node_id, HsaPcSamplingTraceId trace_id) const {
+  if (HSAKMT_CALL(hsaKmtPcSamplingStart(node_id, trace_id)) != HSAKMT_STATUS_SUCCESS)
+    return HSA_STATUS_ERROR;
+  return HSA_STATUS_SUCCESS;
+}
+
+hsa_status_t KfdDriver::PcSamplingStop(uint32_t node_id, HsaPcSamplingTraceId trace_id) const {
+  if (HSAKMT_CALL(hsaKmtPcSamplingStop(node_id, trace_id)) != HSAKMT_STATUS_SUCCESS)
+    return HSA_STATUS_ERROR;
+  return HSA_STATUS_SUCCESS;
+}
+
+hsa_status_t KfdDriver::DbgEnable(void** runtime_ptr, uint32_t* runtime_size) const {
+  if (HSAKMT_CALL(hsaKmtDbgEnable(runtime_ptr, runtime_size)) != HSAKMT_STATUS_SUCCESS)
+    return HSA_STATUS_ERROR;
+  return HSA_STATUS_SUCCESS;
+}
+
+hsa_status_t KfdDriver::DbgDisable() const {
+  if (HSAKMT_CALL(hsaKmtDbgDisable()) != HSAKMT_STATUS_SUCCESS) return HSA_STATUS_ERROR;
+  return HSA_STATUS_SUCCESS;
+}
+
+hsa_status_t KfdDriver::DbgGetDeviceData(void** data, uint32_t* count, uint32_t* entry_size) const {
+  if (HSAKMT_CALL(hsaKmtDbgGetDeviceData(data, count, entry_size)) != HSAKMT_STATUS_SUCCESS)
+    return HSA_STATUS_ERROR;
+  return HSA_STATUS_SUCCESS;
+}
+
+hsa_status_t KfdDriver::DbgGetQueueData(void** data, uint32_t* count, uint32_t* entry_size,
+                                        bool suspend) const {
+  if (HSAKMT_CALL(hsaKmtDbgGetQueueData(data, count, entry_size, suspend)) != HSAKMT_STATUS_SUCCESS)
+    return HSA_STATUS_ERROR;
+  return HSA_STATUS_SUCCESS;
+}
+
+hsa_status_t KfdDriver::AisReadWriteFile(void* device_ptr, size_t size, int fd, int64_t file_offset,
+                                         HsaAisFlags operation, uint64_t* size_copied,
+                                         int32_t* status) const {
+  if (HSAKMT_CALL(hsaKmtAisReadWriteFile(device_ptr, size, fd, file_offset, operation, size_copied,
+                                         status)) != HSAKMT_STATUS_SUCCESS)
+    return HSA_STATUS_ERROR;
+  return HSA_STATUS_SUCCESS;
+}
+
 } // namespace AMD
 } // namespace rocr

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/driver/virtio/amd_kfd_virtio_driver.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/driver/virtio/amd_kfd_virtio_driver.cpp
@@ -600,5 +600,135 @@ hsa_status_t KfdVirtioDriver::GetQueueSaveAreaInfo(HSA_QUEUEID queue_id, void** 
   return HSA_STATUS_SUCCESS;
 }
 
+hsa_status_t KfdVirtioDriver::CreateEvent(HsaEventDescriptor& event_descriptor, bool manual_reset,
+                                          HsaEvent** event) const {
+  if (vhsaKmtCreateEvent(&event_descriptor, manual_reset, false, event) != HSAKMT_STATUS_SUCCESS)
+    return HSA_STATUS_ERROR;
+  return HSA_STATUS_SUCCESS;
+}
+
+hsa_status_t KfdVirtioDriver::DestroyEvent(HsaEvent* event) const {
+  vhsaKmtDestroyEvent(event);
+  return HSA_STATUS_SUCCESS;
+}
+
+hsa_status_t KfdVirtioDriver::WaitOnEvent(HsaEvent* event, uint32_t timeout_ms,
+                                          uint64_t* event_age) const {
+  vhsaKmtWaitOnEvent_Ext(event, timeout_ms, event_age);
+  return HSA_STATUS_SUCCESS;
+}
+
+hsa_status_t KfdVirtioDriver::WaitOnMultipleEvents(HsaEvent** events, uint32_t num_events,
+                                                   bool wait_on_all, uint32_t timeout_ms,
+                                                   uint64_t* event_age) const {
+  vhsaKmtWaitOnMultipleEvents_Ext(events, num_events, wait_on_all, timeout_ms, event_age);
+  return HSA_STATUS_SUCCESS;
+}
+
+hsa_status_t KfdVirtioDriver::SetEvent(HsaEvent* event) const {
+  vhsaKmtSetEvent(event);
+  return HSA_STATUS_SUCCESS;
+}
+
+hsa_status_t KfdVirtioDriver::QueryPointerInfo(const void* ptr, HsaPointerInfo* info) const {
+  if (vhsaKmtQueryPointerInfo(ptr, info) != HSAKMT_STATUS_SUCCESS) return HSA_STATUS_ERROR;
+  return HSA_STATUS_SUCCESS;
+}
+
+hsa_status_t KfdVirtioDriver::SetMemoryUserData(const void* ptr, void* user_data) const {
+  if (vhsaKmtSetMemoryUserData(ptr, user_data) != HSAKMT_STATUS_SUCCESS) return HSA_STATUS_ERROR;
+  return HSA_STATUS_SUCCESS;
+}
+
+hsa_status_t KfdVirtioDriver::ReturnAsanHeaderPage(void* addr) const {
+  if (vhsaKmtReturnAsanHeaderPage(addr) != HSAKMT_STATUS_SUCCESS) return HSA_STATUS_ERROR;
+  return HSA_STATUS_SUCCESS;
+}
+
+hsa_status_t KfdVirtioDriver::MapMemoryToGPU(const void* mem, size_t size,
+                                             uint64_t* alternate_va) const {
+  if (vhsaKmtMapMemoryToGPU(const_cast<void*>(mem), size, alternate_va) != HSAKMT_STATUS_SUCCESS)
+    return HSA_STATUS_ERROR;
+  return HSA_STATUS_SUCCESS;
+}
+
+hsa_status_t KfdVirtioDriver::MapMemoryToGPUNodes(const void* mem, size_t size,
+                                                  uint64_t* alternate_va, HsaMemMapFlags flags,
+                                                  uint32_t num_nodes, const uint32_t* nodes) const {
+  if (vhsaKmtMapMemoryToGPUNodes(const_cast<void*>(mem), size, alternate_va, flags, num_nodes,
+                                 const_cast<uint32_t*>(nodes)) != HSAKMT_STATUS_SUCCESS)
+    return HSA_STATUS_ERROR;
+  return HSA_STATUS_SUCCESS;
+}
+
+hsa_status_t KfdVirtioDriver::AllocateMemoryAlign(uint32_t node, size_t size, size_t alignment,
+                                                  HsaMemFlags flags, void** mem) const {
+  if (vhsaKmtAllocMemoryAlign(node, size, alignment, flags, mem) != HSAKMT_STATUS_SUCCESS)
+    return HSA_STATUS_ERROR;
+  return HSA_STATUS_SUCCESS;
+}
+
+hsa_status_t KfdVirtioDriver::ExportDMABufHandle(const void* mem, size_t size, int* dmabuf_fd,
+                                                 uint64_t* offset) const {
+  if (vhsaKmtExportDMABufHandle(const_cast<void*>(mem), size, dmabuf_fd, offset) !=
+      HSAKMT_STATUS_SUCCESS)
+    return HSA_STATUS_ERROR;
+  return HSA_STATUS_SUCCESS;
+}
+
+hsa_status_t KfdVirtioDriver::ShareMemory(void* mem, size_t size,
+                                          HsaSharedMemoryHandle* handle) const {
+  if (vhsaKmtShareMemory(mem, size, handle) != HSAKMT_STATUS_SUCCESS) return HSA_STATUS_ERROR;
+  return HSA_STATUS_SUCCESS;
+}
+
+hsa_status_t KfdVirtioDriver::RegisterSharedHandle(const HsaSharedMemoryHandle* handle,
+                                                   void** address, HSAuint64* size) const {
+  if (vhsaKmtRegisterSharedHandle(handle, address, size) != HSAKMT_STATUS_SUCCESS)
+    return HSA_STATUS_ERROR;
+  return HSA_STATUS_SUCCESS;
+}
+
+hsa_status_t KfdVirtioDriver::RegisterGraphicsHandleToNodes(int dmabuf_fd,
+                                                            HsaGraphicsResourceInfo* info,
+                                                            uint32_t num_nodes,
+                                                            uint32_t* nodes) const {
+  if (vhsaKmtRegisterGraphicsHandleToNodes(dmabuf_fd, info, num_nodes, nodes) !=
+      HSAKMT_STATUS_SUCCESS)
+    return HSA_STATUS_ERROR;
+  return HSA_STATUS_SUCCESS;
+}
+
+hsa_status_t KfdVirtioDriver::RegisterGraphicsHandleToNodesExt(HSAuint64 dmabuf_fd,
+                                                               HsaGraphicsResourceInfo* info,
+                                                               HSAuint64 num_nodes, uint32_t* nodes,
+                                                               HSA_REGISTER_MEM_FLAGS flags) const {
+  if (vhsaKmtRegisterGraphicsHandleToNodesExt(dmabuf_fd, info, num_nodes, nodes, flags) !=
+      HSAKMT_STATUS_SUCCESS)
+    return HSA_STATUS_ERROR;
+  return HSA_STATUS_SUCCESS;
+}
+
+hsa_status_t KfdVirtioDriver::SVMSetAttr(void* addr, size_t size, uint32_t count,
+                                         HSA_SVM_ATTRIBUTE* attrs) const {
+  if (vhsaKmtSVMSetAttr(addr, size, count, attrs) != HSAKMT_STATUS_SUCCESS) return HSA_STATUS_ERROR;
+  return HSA_STATUS_SUCCESS;
+}
+
+hsa_status_t KfdVirtioDriver::SVMGetAttr(void* addr, size_t size, uint32_t count,
+                                         HSA_SVM_ATTRIBUTE* attrs) const {
+  if (vhsaKmtSVMGetAttr(addr, size, count, attrs) != HSAKMT_STATUS_SUCCESS) return HSA_STATUS_ERROR;
+  return HSA_STATUS_SUCCESS;
+}
+
+hsa_status_t KfdVirtioDriver::AisReadWriteFile(void* device_ptr, size_t size, int fd,
+                                               int64_t file_offset, HsaAisFlags operation,
+                                               uint64_t* size_copied, int32_t* status) const {
+  if (vhsaKmtAisReadWriteFile(device_ptr, size, fd, file_offset, operation, size_copied, status) !=
+      HSAKMT_STATUS_SUCCESS)
+    return HSA_STATUS_ERROR;
+  return HSA_STATUS_SUCCESS;
+}
+
 }  // namespace AMD
 }  // namespace rocr

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/inc/amd_gpu_agent.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/inc/amd_gpu_agent.h
@@ -3,7 +3,7 @@
 // The University of Illinois/NCSA
 // Open Source License (NCSA)
 //
-// Copyright (c) 2014-2025, Advanced Micro Devices, Inc. All rights reserved.
+// Copyright (c) 2014-2026, Advanced Micro Devices, Inc. All rights reserved.
 //
 // Developed by:
 //
@@ -49,7 +49,7 @@
 #include <list>
 #include <map>
 
-#include "hsakmt/hsakmt.h"
+#include "hsakmt/hsakmttypes.h"
 
 #include "core/inc/agent.h"
 #include "core/inc/blit.h"

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/inc/amd_kfd_driver.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/inc/amd_kfd_driver.h
@@ -3,7 +3,7 @@
 // The University of Illinois/NCSA
 // Open Source License (NCSA)
 //
-// Copyright (c) 2024-2025, Advanced Micro Devices, Inc. All rights reserved.
+// Copyright (c) 2024-2026, Advanced Micro Devices, Inc. All rights reserved.
 //
 // Developed by:
 //
@@ -46,7 +46,7 @@
 #include <memory>
 #include <string>
 
-#include "hsakmt/hsakmt.h"
+#include "hsakmt/hsakmttypes.h"
 
 #include "core/inc/driver.h"
 #include "core/inc/memory_region.h"
@@ -145,6 +145,71 @@ public:
   hsa_status_t IsModelEnabled(bool* enable) const override;
 
   hsa_status_t GetQueueSaveAreaInfo(HSA_QUEUEID queue_id, void** address, size_t* size) const override;
+
+  hsa_status_t CreateEvent(HsaEventDescriptor& event_descriptor, bool manual_reset,
+                           HsaEvent** event) const override;
+  hsa_status_t DestroyEvent(HsaEvent* event) const override;
+  hsa_status_t WaitOnEvent(HsaEvent* event, uint32_t timeout_ms,
+                           uint64_t* event_age) const override;
+  hsa_status_t WaitOnMultipleEvents(HsaEvent** events, uint32_t num_events, bool wait_on_all,
+                                    uint32_t timeout_ms, uint64_t* event_age) const override;
+  hsa_status_t SetEvent(HsaEvent* event) const override;
+
+  hsa_status_t RingDoorbell(HSA_QUEUEID queue_id, uint64_t value) const override;
+
+  hsa_status_t QueryPointerInfo(const void* ptr, HsaPointerInfo* info) const override;
+  hsa_status_t SetMemoryUserData(const void* ptr, void* user_data) const override;
+  hsa_status_t FreeMemoryHandle(HsaMemoryObjectHandle handle) const override;
+  hsa_status_t ReturnAsanHeaderPage(void* addr) const override;
+  hsa_status_t MapMemoryToGPU(const void* mem, size_t size, uint64_t* alternate_va) const override;
+  hsa_status_t MapMemoryToGPUNodes(const void* mem, size_t size, uint64_t* alternate_va,
+                                   HsaMemMapFlags flags, uint32_t num_nodes,
+                                   const uint32_t* nodes) const override;
+  hsa_status_t GetMemoryCpuAddr(void* device_handle, void* mem_handle, int* drm_fd,
+                                uint64_t* cpu_addr) const override;
+  hsa_status_t AllocateMemoryAlign(uint32_t node, size_t size, size_t alignment, HsaMemFlags flags,
+                                   void** mem) const override;
+  hsa_status_t MemoryCpuMap(HsaMemoryObjectHandle handle, void** cpu_ptr) const override;
+
+  hsa_status_t ExportDMABufHandle(const void* mem, size_t size, int* dmabuf_fd,
+                                  uint64_t* offset) const override;
+  hsa_status_t HandleImport(const HsaExternalHandleDesc* desc, HsaHandleImportResult* result,
+                            HsaHandleImportFlags* flags) const override;
+  hsa_status_t ShareMemory(void* mem, size_t size, HsaSharedMemoryHandle* handle) const override;
+  hsa_status_t RegisterSharedHandle(const HsaSharedMemoryHandle* handle, void** address,
+                                    HSAuint64* size) const override;
+  hsa_status_t RegisterGraphicsHandleToNodes(int dmabuf_fd, HsaGraphicsResourceInfo* info,
+                                             uint32_t num_nodes, uint32_t* nodes) const override;
+  hsa_status_t RegisterGraphicsHandleToNodesExt(HSAuint64 dmabuf_fd, HsaGraphicsResourceInfo* info,
+                                                HSAuint64 num_nodes, uint32_t* nodes,
+                                                HSA_REGISTER_MEM_FLAGS flags) const override;
+  hsa_status_t MemoryVaMap(HsaMemoryObjectHandle handle, uint64_t offset, uint64_t size,
+                           uint64_t va, uint32_t access) const override;
+  hsa_status_t MemoryVaUnmap(HsaMemoryObjectHandle handle, uint64_t offset, uint64_t size,
+                             uint64_t va) const override;
+
+  hsa_status_t SVMSetAttr(void* addr, size_t size, uint32_t count,
+                          HSA_SVM_ATTRIBUTE* attrs) const override;
+  hsa_status_t SVMGetAttr(void* addr, size_t size, uint32_t count,
+                          HSA_SVM_ATTRIBUTE* attrs) const override;
+
+  hsa_status_t PcSamplingQueryCapabilities(uint32_t node_id, void* sample_info, size_t size,
+                                           uint32_t* count) const override;
+  hsa_status_t PcSamplingCreate(uint32_t node_id, HsaPcSamplingInfo* sample_info,
+                                HsaPcSamplingTraceId* trace_id) const override;
+  hsa_status_t PcSamplingDestroy(uint32_t node_id, HsaPcSamplingTraceId trace_id) const override;
+  hsa_status_t PcSamplingStart(uint32_t node_id, HsaPcSamplingTraceId trace_id) const override;
+  hsa_status_t PcSamplingStop(uint32_t node_id, HsaPcSamplingTraceId trace_id) const override;
+
+  hsa_status_t DbgEnable(void** runtime_ptr, uint32_t* runtime_size) const override;
+  hsa_status_t DbgDisable() const override;
+  hsa_status_t DbgGetDeviceData(void** data, uint32_t* count, uint32_t* entry_size) const override;
+  hsa_status_t DbgGetQueueData(void** data, uint32_t* count, uint32_t* entry_size,
+                               bool suspend) const override;
+
+  hsa_status_t AisReadWriteFile(void* device_ptr, size_t size, int fd, int64_t file_offset,
+                                HsaAisFlags operation, uint64_t* size_copied,
+                                int32_t* status) const override;
 
  private:
   /// @brief Allocate agent accessible memory (system / local memory).

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/inc/amd_memory_region.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/inc/amd_memory_region.h
@@ -3,7 +3,7 @@
 // The University of Illinois/NCSA
 // Open Source License (NCSA)
 //
-// Copyright (c) 2014-2020, Advanced Micro Devices, Inc. All rights reserved.
+// Copyright (c) 2014-2026, Advanced Micro Devices, Inc. All rights reserved.
 //
 // Developed by:
 //
@@ -45,7 +45,7 @@
 #ifndef HSA_RUNTIME_CORE_INC_AMD_MEMORY_REGION_H_
 #define HSA_RUNTIME_CORE_INC_AMD_MEMORY_REGION_H_
 
-#include "hsakmt/hsakmt.h"
+#include "hsakmt/hsakmttypes.h"
 
 #include "core/inc/agent.h"
 #include "core/inc/runtime.h"

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/inc/amd_virtio_driver.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/inc/amd_virtio_driver.h
@@ -3,7 +3,7 @@
 // The University of Illinois/NCSA
 // Open Source License (NCSA)
 //
-// Copyright (c) 2024-2025, Advanced Micro Devices, Inc. All rights reserved.
+// Copyright (c) 2024-2026, Advanced Micro Devices, Inc. All rights reserved.
 //
 // Developed by:
 //
@@ -46,7 +46,7 @@
 #include <memory>
 #include <string>
 
-#include "hsakmt/hsakmt.h"
+#include "hsakmt/hsakmttypes.h"
 
 #include "core/inc/driver.h"
 #include "core/inc/memory_region.h"
@@ -121,6 +121,45 @@ class KfdVirtioDriver final : public core::Driver {
   hsa_status_t GetWallclockFrequency(uint32_t node_id, uint64_t* frequency) const;
   hsa_status_t IsModelEnabled(bool* enable) const override;
   hsa_status_t GetQueueSaveAreaInfo(HSA_QUEUEID queue_id, void** address, size_t* size) const override;
+
+  hsa_status_t CreateEvent(HsaEventDescriptor& event_descriptor, bool manual_reset,
+                           HsaEvent** event) const override;
+  hsa_status_t DestroyEvent(HsaEvent* event) const override;
+  hsa_status_t WaitOnEvent(HsaEvent* event, uint32_t timeout_ms,
+                           uint64_t* event_age) const override;
+  hsa_status_t WaitOnMultipleEvents(HsaEvent** events, uint32_t num_events, bool wait_on_all,
+                                    uint32_t timeout_ms, uint64_t* event_age) const override;
+  hsa_status_t SetEvent(HsaEvent* event) const override;
+
+  hsa_status_t QueryPointerInfo(const void* ptr, HsaPointerInfo* info) const override;
+  hsa_status_t SetMemoryUserData(const void* ptr, void* user_data) const override;
+  hsa_status_t ReturnAsanHeaderPage(void* addr) const override;
+  hsa_status_t MapMemoryToGPU(const void* mem, size_t size, uint64_t* alternate_va) const override;
+  hsa_status_t MapMemoryToGPUNodes(const void* mem, size_t size, uint64_t* alternate_va,
+                                   HsaMemMapFlags flags, uint32_t num_nodes,
+                                   const uint32_t* nodes) const override;
+  hsa_status_t AllocateMemoryAlign(uint32_t node, size_t size, size_t alignment, HsaMemFlags flags,
+                                   void** mem) const override;
+
+  hsa_status_t ExportDMABufHandle(const void* mem, size_t size, int* dmabuf_fd,
+                                  uint64_t* offset) const override;
+  hsa_status_t ShareMemory(void* mem, size_t size, HsaSharedMemoryHandle* handle) const override;
+  hsa_status_t RegisterSharedHandle(const HsaSharedMemoryHandle* handle, void** address,
+                                    HSAuint64* size) const override;
+  hsa_status_t RegisterGraphicsHandleToNodes(int dmabuf_fd, HsaGraphicsResourceInfo* info,
+                                             uint32_t num_nodes, uint32_t* nodes) const override;
+  hsa_status_t RegisterGraphicsHandleToNodesExt(HSAuint64 dmabuf_fd, HsaGraphicsResourceInfo* info,
+                                                HSAuint64 num_nodes, uint32_t* nodes,
+                                                HSA_REGISTER_MEM_FLAGS flags) const override;
+
+  hsa_status_t SVMSetAttr(void* addr, size_t size, uint32_t count,
+                          HSA_SVM_ATTRIBUTE* attrs) const override;
+  hsa_status_t SVMGetAttr(void* addr, size_t size, uint32_t count,
+                          HSA_SVM_ATTRIBUTE* attrs) const override;
+
+  hsa_status_t AisReadWriteFile(void* device_ptr, size_t size, int fd, int64_t file_offset,
+                                HsaAisFlags operation, uint64_t* size_copied,
+                                int32_t* status) const override;
 };
 
 }  // namespace AMD

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/inc/driver.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/inc/driver.h
@@ -3,7 +3,7 @@
 // The University of Illinois/NCSA
 // Open Source License (NCSA)
 //
-// Copyright (c) 2023-2025, Advanced Micro Devices, Inc. All rights reserved.
+// Copyright (c) 2023-2026, Advanced Micro Devices, Inc. All rights reserved.
 //
 // Developed by:
 //
@@ -383,6 +383,381 @@ public:
   /// @param[out] size Size of the used queue save area in bytes
   /// @return HSA_STATUS_SUCCESS if the driver successfully returns the queue save area information
   virtual hsa_status_t GetQueueSaveAreaInfo(HSA_QUEUEID queue_id, void** address, size_t* size) const = 0;
+
+  /// @brief Create a kernel event for signal implementation.
+  /// @param[in,out] event_descriptor Descriptor specifying event type and properties.
+  /// @param[in] manual_reset If true, event must be manually reset after signaling.
+  /// @param[out] event Pointer to the newly created event.
+  /// @retval HSA_STATUS_SUCCESS if the event was created successfully.
+  /// @retval HSA_STATUS_ERROR if event creation failed or is unsupported.
+  virtual hsa_status_t CreateEvent(HsaEventDescriptor& event_descriptor, bool manual_reset,
+                                   HsaEvent** event) const {
+    return HSA_STATUS_ERROR;
+  }
+
+  /// @brief Destroy a kernel event.
+  /// @param[in] event Event to destroy.
+  /// @retval HSA_STATUS_SUCCESS if the event was destroyed successfully.
+  /// @retval HSA_STATUS_ERROR if event destruction failed or is unsupported.
+  virtual hsa_status_t DestroyEvent(HsaEvent* event) const { return HSA_STATUS_ERROR; }
+
+  /// @brief Wait on a single event with timeout.
+  /// @param[in] event Event to wait on.
+  /// @param[in] timeout_ms Timeout in milliseconds.
+  /// @param[in,out] event_age Pointer to track event age across waits.
+  /// @retval HSA_STATUS_SUCCESS if the wait completed successfully.
+  /// @retval HSA_STATUS_ERROR if the wait failed or is unsupported.
+  virtual hsa_status_t WaitOnEvent(HsaEvent* event, uint32_t timeout_ms,
+                                   uint64_t* event_age) const {
+    return HSA_STATUS_ERROR;
+  }
+
+  /// @brief Wait on multiple events with timeout.
+  /// @param[in] events Array of events to wait on.
+  /// @param[in] num_events Number of events in the array.
+  /// @param[in] wait_on_all If true, wait for all events; otherwise wait for any.
+  /// @param[in] timeout_ms Timeout in milliseconds.
+  /// @param[in,out] event_age Pointer to track event age across waits.
+  /// @retval HSA_STATUS_SUCCESS if the wait completed successfully.
+  /// @retval HSA_STATUS_ERROR if the wait failed or is unsupported.
+  virtual hsa_status_t WaitOnMultipleEvents(HsaEvent** events, uint32_t num_events,
+                                            bool wait_on_all, uint32_t timeout_ms,
+                                            uint64_t* event_age) const {
+    return HSA_STATUS_ERROR;
+  }
+
+  /// @brief Signal an event to wake waiting threads.
+  /// @param[in] event Event to signal.
+  /// @retval HSA_STATUS_SUCCESS if the event was signaled successfully.
+  /// @retval HSA_STATUS_ERROR if signaling failed or is unsupported.
+  virtual hsa_status_t SetEvent(HsaEvent* event) const { return HSA_STATUS_ERROR; }
+
+  /// @brief Ring queue doorbell to notify the hardware of new work.
+  /// @param[in] queue_id Kernel-mode driver's assigned queue ID.
+  /// @param[in] value Doorbell value (typically the new write index).
+  /// @retval HSA_STATUS_SUCCESS if the doorbell was rung successfully.
+  /// @retval HSA_STATUS_ERROR if the operation failed or is unsupported.
+  virtual hsa_status_t RingDoorbell(HSA_QUEUEID queue_id, uint64_t value) const {
+    return HSA_STATUS_ERROR;
+  }
+
+  /// @brief Query information about a memory pointer.
+  /// @param[in] ptr Pointer to query.
+  /// @param[out] info Pointer information populated by the driver.
+  /// @retval HSA_STATUS_SUCCESS if the query was successful.
+  /// @retval HSA_STATUS_ERROR if the query failed or is unsupported.
+  virtual hsa_status_t QueryPointerInfo(const void* ptr, HsaPointerInfo* info) const {
+    return HSA_STATUS_ERROR;
+  }
+
+  /// @brief Associate user data with a memory allocation.
+  /// @param[in] ptr Pointer to the memory allocation.
+  /// @param[in] user_data User data to associate with the allocation.
+  /// @retval HSA_STATUS_SUCCESS if the user data was set successfully.
+  /// @retval HSA_STATUS_ERROR if the operation failed or is unsupported.
+  virtual hsa_status_t SetMemoryUserData(const void* ptr, void* user_data) const {
+    return HSA_STATUS_ERROR;
+  }
+
+  /// @brief Free a thunk memory object handle (buffer object).
+  /// @param[in] handle Memory object handle to free.
+  /// @retval HSA_STATUS_SUCCESS if the handle was freed successfully.
+  /// @retval HSA_STATUS_ERROR if the operation failed or is unsupported.
+  virtual hsa_status_t FreeMemoryHandle(HsaMemoryObjectHandle handle) const {
+    return HSA_STATUS_ERROR;
+  }
+
+  /// @brief Return an ASAN header page to the driver.
+  /// @param[in] addr Address of the ASAN header page.
+  /// @retval HSA_STATUS_SUCCESS if the page was returned successfully.
+  /// @retval HSA_STATUS_ERROR if the operation failed or is unsupported.
+  virtual hsa_status_t ReturnAsanHeaderPage(void* addr) const { return HSA_STATUS_ERROR; }
+
+  /// @brief Map memory to all GPUs in the system.
+  /// @param[in] mem Address of the memory to map.
+  /// @param[in] size Size of the memory in bytes.
+  /// @param[out] alternate_va Alternate virtual address for the mapping.
+  /// @retval HSA_STATUS_SUCCESS if the memory was mapped successfully.
+  /// @retval HSA_STATUS_ERROR if the mapping failed or is unsupported.
+  virtual hsa_status_t MapMemoryToGPU(const void* mem, size_t size, uint64_t* alternate_va) const {
+    return HSA_STATUS_ERROR;
+  }
+
+  /// @brief Map memory to specific GPU nodes.
+  /// @param[in] mem Address of the memory to map.
+  /// @param[in] size Size of the memory in bytes.
+  /// @param[out] alternate_va Alternate virtual address for the mapping.
+  /// @param[in] flags Memory mapping flags.
+  /// @param[in] num_nodes Number of nodes in the @p nodes array.
+  /// @param[in] nodes Array of node IDs to map the memory to.
+  /// @retval HSA_STATUS_SUCCESS if the memory was mapped successfully.
+  /// @retval HSA_STATUS_ERROR if the mapping failed or is unsupported.
+  virtual hsa_status_t MapMemoryToGPUNodes(const void* mem, size_t size, uint64_t* alternate_va,
+                                           HsaMemMapFlags flags, uint32_t num_nodes,
+                                           const uint32_t* nodes) const {
+    return HSA_STATUS_ERROR;
+  }
+
+  /// @brief Get DRM file descriptor and CPU address from a memory handle.
+  /// @param[in] device_handle Device handle for the GPU.
+  /// @param[in] mem_handle Memory object handle.
+  /// @param[out] drm_fd DRM file descriptor for the memory.
+  /// @param[out] cpu_addr CPU-accessible address for the memory.
+  /// @retval HSA_STATUS_SUCCESS if the address was retrieved successfully.
+  /// @retval HSA_STATUS_ERROR if the operation failed or is unsupported.
+  virtual hsa_status_t GetMemoryCpuAddr(void* device_handle, void* mem_handle, int* drm_fd,
+                                        uint64_t* cpu_addr) const {
+    return HSA_STATUS_ERROR;
+  }
+
+  /// @brief Allocate memory with a specified alignment.
+  /// @param[in] node Node ID for the allocation.
+  /// @param[in] size Size of the allocation in bytes.
+  /// @param[in] alignment Required alignment in bytes.
+  /// @param[in] flags Memory allocation flags.
+  /// @param[out] mem Pointer to the allocated memory.
+  /// @retval HSA_STATUS_SUCCESS if memory was allocated successfully.
+  /// @retval HSA_STATUS_ERROR if the allocation failed or is unsupported.
+  virtual hsa_status_t AllocateMemoryAlign(uint32_t node, size_t size, size_t alignment,
+                                           HsaMemFlags flags, void** mem) const {
+    return HSA_STATUS_ERROR;
+  }
+
+  /// @brief Create a CPU-accessible mapping for a memory object handle.
+  /// @param[in] handle Memory object handle to map.
+  /// @param[out] cpu_ptr CPU-accessible pointer to the mapped memory.
+  /// @retval HSA_STATUS_SUCCESS if the mapping was created successfully.
+  /// @retval HSA_STATUS_ERROR if the mapping failed or is unsupported.
+  virtual hsa_status_t MemoryCpuMap(HsaMemoryObjectHandle handle, void** cpu_ptr) const {
+    return HSA_STATUS_ERROR;
+  }
+
+  /// @brief Export memory as a DMA buffer file descriptor for IPC.
+  /// @param[in] mem Address of the memory to export.
+  /// @param[in] size Size of the memory in bytes.
+  /// @param[out] dmabuf_fd DMA buffer file descriptor.
+  /// @param[out] offset Offset within the DMA buffer.
+  /// @retval HSA_STATUS_SUCCESS if the export was successful.
+  /// @retval HSA_STATUS_ERROR if the export failed or is unsupported.
+  virtual hsa_status_t ExportDMABufHandle(const void* mem, size_t size, int* dmabuf_fd,
+                                          uint64_t* offset) const {
+    return HSA_STATUS_ERROR;
+  }
+
+  /// @brief Import an external memory handle.
+  /// @param[in] desc Descriptor for the external handle to import.
+  /// @param[out] result Import result containing the memory address and metadata.
+  /// @param[in,out] flags Import flags controlling behavior and receiving status.
+  /// @retval HSA_STATUS_SUCCESS if the import was successful.
+  /// @retval HSA_STATUS_ERROR if the import failed or is unsupported.
+  virtual hsa_status_t HandleImport(const HsaExternalHandleDesc* desc,
+                                    HsaHandleImportResult* result,
+                                    HsaHandleImportFlags* flags) const {
+    return HSA_STATUS_ERROR;
+  }
+
+  /// @brief Create a shareable memory handle for legacy (non-DMA buffer) IPC.
+  /// @param[in] mem Address of the memory to share.
+  /// @param[in] size Size of the memory in bytes.
+  /// @param[out] handle Shared memory handle for the allocation.
+  /// @retval HSA_STATUS_SUCCESS if the handle was created successfully.
+  /// @retval HSA_STATUS_ERROR if the operation failed or is unsupported.
+  virtual hsa_status_t ShareMemory(void* mem, size_t size, HsaSharedMemoryHandle* handle) const {
+    return HSA_STATUS_ERROR;
+  }
+
+  /// @brief Register a shared memory handle for legacy IPC import.
+  /// @param[in] handle Shared memory handle to register.
+  /// @param[out] address Address of the registered memory.
+  /// @param[out] size Size of the registered memory in bytes.
+  /// @retval HSA_STATUS_SUCCESS if the handle was registered successfully.
+  /// @retval HSA_STATUS_ERROR if the operation failed or is unsupported.
+  virtual hsa_status_t RegisterSharedHandle(const HsaSharedMemoryHandle* handle, void** address,
+                                            HSAuint64* size) const {
+    return HSA_STATUS_ERROR;
+  }
+
+  /// @brief Register a graphics/DMA-buf handle to GPU nodes.
+  /// @param[in] dmabuf_fd DMA buffer file descriptor.
+  /// @param[out] info Graphics resource information populated by the driver.
+  /// @param[in] num_nodes Number of nodes in the @p nodes array. Pass 0 to register to all nodes.
+  /// @param[in] nodes Array of node IDs to register the handle to. May be NULL if @p num_nodes is
+  /// 0.
+  /// @retval HSA_STATUS_SUCCESS if the handle was registered successfully.
+  /// @retval HSA_STATUS_ERROR if the operation failed or is unsupported.
+  virtual hsa_status_t RegisterGraphicsHandleToNodes(int dmabuf_fd, HsaGraphicsResourceInfo* info,
+                                                     uint32_t num_nodes, uint32_t* nodes) const {
+    return HSA_STATUS_ERROR;
+  }
+
+  /// @brief Register a graphics/DMA-buf handle to GPU nodes with extended flags.
+  /// @param[in] dmabuf_fd DMA buffer file descriptor.
+  /// @param[out] info Graphics resource information populated by the driver.
+  /// @param[in] num_nodes Number of nodes in the @p nodes array.
+  /// @param[in] nodes Array of node IDs to register the handle to.
+  /// @param[in] flags Registration flags controlling memory mapping behavior.
+  /// @retval HSA_STATUS_SUCCESS if the handle was registered successfully.
+  /// @retval HSA_STATUS_ERROR if the operation failed or is unsupported.
+  virtual hsa_status_t RegisterGraphicsHandleToNodesExt(HSAuint64 dmabuf_fd,
+                                                        HsaGraphicsResourceInfo* info,
+                                                        HSAuint64 num_nodes, uint32_t* nodes,
+                                                        HSA_REGISTER_MEM_FLAGS flags) const {
+    return HSA_STATUS_ERROR;
+  }
+
+  /// @brief Map a virtual address range to a memory object handle.
+  /// @param[in] handle Memory object handle.
+  /// @param[in] offset Offset within the memory object in bytes.
+  /// @param[in] size Size of the mapping in bytes.
+  /// @param[in] va Virtual address to map to.
+  /// @param[in] access Access flags for the mapping.
+  /// @retval HSA_STATUS_SUCCESS if the mapping was created successfully.
+  /// @retval HSA_STATUS_ERROR if the mapping failed or is unsupported.
+  virtual hsa_status_t MemoryVaMap(HsaMemoryObjectHandle handle, uint64_t offset, uint64_t size,
+                                   uint64_t va, uint32_t access) const {
+    return HSA_STATUS_ERROR;
+  }
+
+  /// @brief Unmap a virtual address range from a memory object handle.
+  /// @param[in] handle Memory object handle.
+  /// @param[in] offset Offset within the memory object in bytes.
+  /// @param[in] size Size of the mapping in bytes.
+  /// @param[in] va Virtual address to unmap.
+  /// @retval HSA_STATUS_SUCCESS if the unmapping was successful.
+  /// @retval HSA_STATUS_ERROR if the operation failed or is unsupported.
+  virtual hsa_status_t MemoryVaUnmap(HsaMemoryObjectHandle handle, uint64_t offset, uint64_t size,
+                                     uint64_t va) const {
+    return HSA_STATUS_ERROR;
+  }
+
+  /// @brief Set SVM (Shared Virtual Memory) attributes for an address range.
+  /// @param[in] addr Start address of the memory range.
+  /// @param[in] size Size of the memory range in bytes.
+  /// @param[in] count Number of attributes in the @p attrs array.
+  /// @param[in] attrs Array of SVM attributes to set.
+  /// @retval HSA_STATUS_SUCCESS if the attributes were set successfully.
+  /// @retval HSA_STATUS_ERROR if the operation failed or is unsupported.
+  virtual hsa_status_t SVMSetAttr(void* addr, size_t size, uint32_t count,
+                                  HSA_SVM_ATTRIBUTE* attrs) const {
+    return HSA_STATUS_ERROR;
+  }
+
+  /// @brief Get SVM (Shared Virtual Memory) attributes for an address range.
+  /// @param[in] addr Start address of the memory range.
+  /// @param[in] size Size of the memory range in bytes.
+  /// @param[in] count Number of attributes in the @p attrs array.
+  /// @param[in,out] attrs Array of SVM attributes to query. The type field specifies
+  ///   which attribute to query; the value field is populated by the driver.
+  /// @retval HSA_STATUS_SUCCESS if the attributes were retrieved successfully.
+  /// @retval HSA_STATUS_ERROR if the operation failed or is unsupported.
+  virtual hsa_status_t SVMGetAttr(void* addr, size_t size, uint32_t count,
+                                  HSA_SVM_ATTRIBUTE* attrs) const {
+    return HSA_STATUS_ERROR;
+  }
+
+  /// @brief Query PC sampling capabilities for a node.
+  /// @param[in] node_id Node ID of the agent.
+  /// @param[out] sample_info Buffer to receive sampling capability information.
+  /// @param[in] size Size of the @p sample_info buffer in bytes.
+  /// @param[in,out] count On input, number of entries that fit in @p sample_info.
+  ///   On output, number of entries available.
+  /// @retval HSA_STATUS_SUCCESS if the query was successful.
+  /// @retval HSA_STATUS_ERROR if the query failed or is unsupported.
+  virtual hsa_status_t PcSamplingQueryCapabilities(uint32_t node_id, void* sample_info, size_t size,
+                                                   uint32_t* count) const {
+    return HSA_STATUS_ERROR;
+  }
+
+  /// @brief Create a PC sampling session.
+  /// @param[in] node_id Node ID of the agent.
+  /// @param[in] sample_info Sampling configuration.
+  /// @param[out] trace_id Trace ID assigned to the new session.
+  /// @retval HSA_STATUS_SUCCESS if the session was created successfully.
+  /// @retval HSA_STATUS_ERROR_RESOURCE_BUSY if a session already exists.
+  /// @retval HSA_STATUS_ERROR if creation failed or is unsupported.
+  virtual hsa_status_t PcSamplingCreate(uint32_t node_id, HsaPcSamplingInfo* sample_info,
+                                        HsaPcSamplingTraceId* trace_id) const {
+    return HSA_STATUS_ERROR;
+  }
+
+  /// @brief Destroy a PC sampling session.
+  /// @param[in] node_id Node ID of the agent.
+  /// @param[in] trace_id Trace ID of the session to destroy.
+  /// @retval HSA_STATUS_SUCCESS if the session was destroyed successfully.
+  /// @retval HSA_STATUS_ERROR if destruction failed or is unsupported.
+  virtual hsa_status_t PcSamplingDestroy(uint32_t node_id, HsaPcSamplingTraceId trace_id) const {
+    return HSA_STATUS_ERROR;
+  }
+
+  /// @brief Start a PC sampling session.
+  /// @param[in] node_id Node ID of the agent.
+  /// @param[in] trace_id Trace ID of the session to start.
+  /// @retval HSA_STATUS_SUCCESS if the session was started successfully.
+  /// @retval HSA_STATUS_ERROR if starting failed or is unsupported.
+  virtual hsa_status_t PcSamplingStart(uint32_t node_id, HsaPcSamplingTraceId trace_id) const {
+    return HSA_STATUS_ERROR;
+  }
+
+  /// @brief Stop a PC sampling session.
+  /// @param[in] node_id Node ID of the agent.
+  /// @param[in] trace_id Trace ID of the session to stop.
+  /// @retval HSA_STATUS_SUCCESS if the session was stopped successfully.
+  /// @retval HSA_STATUS_ERROR if stopping failed or is unsupported.
+  virtual hsa_status_t PcSamplingStop(uint32_t node_id, HsaPcSamplingTraceId trace_id) const {
+    return HSA_STATUS_ERROR;
+  }
+
+  /// @brief Enable the debug interface for core dump collection.
+  /// @param[out] runtime_ptr Pointer to the runtime debug data.
+  /// @param[out] runtime_size Size of the runtime debug data in bytes.
+  /// @retval HSA_STATUS_SUCCESS if the debug interface was enabled successfully.
+  /// @retval HSA_STATUS_ERROR if enabling failed or is unsupported.
+  virtual hsa_status_t DbgEnable(void** runtime_ptr, uint32_t* runtime_size) const {
+    return HSA_STATUS_ERROR;
+  }
+
+  /// @brief Disable the debug interface.
+  /// @retval HSA_STATUS_SUCCESS if the debug interface was disabled successfully.
+  /// @retval HSA_STATUS_ERROR if disabling failed or is unsupported.
+  virtual hsa_status_t DbgDisable() const { return HSA_STATUS_ERROR; }
+
+  /// @brief Get a device data snapshot for core dump.
+  /// @param[out] data Pointer to the device data buffer allocated by the driver.
+  /// @param[out] count Number of device data entries.
+  /// @param[out] entry_size Size of each device data entry in bytes.
+  /// @retval HSA_STATUS_SUCCESS if the snapshot was captured successfully.
+  /// @retval HSA_STATUS_ERROR if the operation failed or is unsupported.
+  virtual hsa_status_t DbgGetDeviceData(void** data, uint32_t* count, uint32_t* entry_size) const {
+    return HSA_STATUS_ERROR;
+  }
+
+  /// @brief Get a queue data snapshot for core dump.
+  /// @param[out] data Pointer to the queue data buffer allocated by the driver.
+  /// @param[out] count Number of queue data entries.
+  /// @param[out] entry_size Size of each queue data entry in bytes.
+  /// @param[in] suspend If true, suspend queues before capturing the snapshot.
+  /// @retval HSA_STATUS_SUCCESS if the snapshot was captured successfully.
+  /// @retval HSA_STATUS_ERROR if the operation failed or is unsupported.
+  virtual hsa_status_t DbgGetQueueData(void** data, uint32_t* count, uint32_t* entry_size,
+                                       bool suspend) const {
+    return HSA_STATUS_ERROR;
+  }
+
+  /// @brief Read from or write to an AIS (AI Storage) file via the GPU.
+  /// @param[in] device_ptr Device memory address for the transfer.
+  /// @param[in] size Size of the transfer in bytes.
+  /// @param[in] fd File descriptor of the AIS file.
+  /// @param[in] file_offset Offset within the file in bytes.
+  /// @param[in] operation Read or write operation flag.
+  /// @param[out] size_copied Number of bytes actually transferred.
+  /// @param[out] status Driver-specific status code for the operation.
+  /// @retval HSA_STATUS_SUCCESS if the transfer completed successfully.
+  /// @retval HSA_STATUS_ERROR if the transfer failed or is unsupported.
+  virtual hsa_status_t AisReadWriteFile(void* device_ptr, size_t size, int fd, int64_t file_offset,
+                                        HsaAisFlags operation, uint64_t* size_copied,
+                                        int32_t* status) const {
+    return HSA_STATUS_ERROR;
+  }
 
   /// Unique identifier for supported kernel-mode drivers.
   const DriverType kernel_driver_type_;

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/inc/interrupt_signal.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/inc/interrupt_signal.h
@@ -3,7 +3,7 @@
 // The University of Illinois/NCSA
 // Open Source License (NCSA)
 //
-// Copyright (c) 2014-2020, Advanced Micro Devices, Inc. All rights reserved.
+// Copyright (c) 2014-2026, Advanced Micro Devices, Inc. All rights reserved.
 //
 // Developed by:
 //
@@ -48,7 +48,7 @@
 #include <memory>
 #include <vector>
 
-#include "hsakmt/hsakmt.h"
+#include "hsakmt/hsakmttypes.h"
 
 #include "core/inc/signal.h"
 #include "core/util/utils.h"
@@ -62,7 +62,7 @@ namespace core {
 /// Breaks common/vendor separation - signals in general needs to be re-worked
 /// at the foundation level to make sense in a multi-device system.
 /// Supports only one waiter for now.
-/// KFD changes are needed to support multiple waiters and have device
+/// Driver changes are needed to support multiple waiters and have device
 /// signaling.
 class InterruptSignal : private LocalSignal, public Signal {
  public:
@@ -194,7 +194,7 @@ class InterruptSignal : private LocalSignal, public Signal {
   bool _IsA(rtti_t id) const { return id == &rtti_id(); }
 
  private:
-  /// @variable KFD event on which the interrupt signal is based on.
+  /// @variable driver event on which the interrupt signal is based on.
   HsaEvent* event_;
 
   /// @variable Indicates whether the signal should release the event when it

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/inc/queue.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/inc/queue.h
@@ -3,7 +3,7 @@
 // The University of Illinois/NCSA
 // Open Source License (NCSA)
 //
-// Copyright (c) 2014-2020, Advanced Micro Devices, Inc. All rights reserved.
+// Copyright (c) 2014-2026, Advanced Micro Devices, Inc. All rights reserved.
 //
 // Developed by:
 //
@@ -53,7 +53,7 @@
 #include "core/util/utils.h"
 #include "inc/amd_hsa_queue.h"
 #include "inc/hsa_ext_amd.h"
-#include "hsakmt/hsakmt.h"
+#include "hsakmt/hsakmttypes.h"
 
 namespace rocr {
 namespace core {

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/inc/runtime.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/inc/runtime.h
@@ -3,7 +3,7 @@
 // The University of Illinois/NCSA
 // Open Source License (NCSA)
 //
-// Copyright (c) 2014-2025, Advanced Micro Devices, Inc. All rights reserved.
+// Copyright (c) 2014-2026, Advanced Micro Devices, Inc. All rights reserved.
 //
 // Developed by:
 //
@@ -794,7 +794,7 @@ class Runtime {
 
   // Mutex object to protect multithreaded access to ::allocation_map_.
   // Also ensures atomicity of pointer info queries by interlocking
-  // KFD map/unmap, register/unregister, and access to hsaKmtQueryPointerInfo
+  // KFD map/unmap, register/unregister, and access to Driver::QueryPointerInfo
   // registered & mapped arrays.
   std::shared_mutex memory_lock_;
 

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/inc/signal.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/inc/signal.h
@@ -3,7 +3,7 @@
 // The University of Illinois/NCSA
 // Open Source License (NCSA)
 //
-// Copyright (c) 2014-2024, Advanced Micro Devices, Inc. All rights reserved.
+// Copyright (c) 2014-2026, Advanced Micro Devices, Inc. All rights reserved.
 //
 // Developed by:
 //
@@ -52,7 +52,7 @@
 #include <utility>
 #include <mutex>
 
-#include "hsakmt/hsakmt.h"
+#include "hsakmt/hsakmttypes.h"
 
 #include "core/common/shared.h"
 
@@ -430,9 +430,10 @@ class Signal {
                                bool wait_on_all);
 
   /// @brief Dedicated funtion to wait on signals that are not of type HSA_EVENTTYPE_SIGNAL
-  /// these events can only be received by calling the underlying driver (i.e via the hsaKmtWaitOnMultipleEvents_Ext
-  /// function call). We still need to have 1 signal of type HSA_EVENT_TYPE_SIGNAL attached to the list of signals
-  /// to be able to force hsaKmtWaitOnMultipleEvents_Ext to return.
+  /// these events can only be received by calling the underlying driver (i.e via the
+  /// Driver::WaitOnMultipleEvents function call). We still need to have 1 signal of type
+  /// HSA_EVENT_TYPE_SIGNAL attached to the list of signals to be able to force
+  /// Driver::WaitOnMultipleEvents to return.
   /// @param signal_count Number of hsa_signals
   /// @param hsa_signals Pointer to array of signals. All signals should have a valid EopEvent()
   /// @param conds list of conditions

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/inc/thunk_loader.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/inc/thunk_loader.h
@@ -3,7 +3,7 @@
 // The University of Illinois/NCSA
 // Open Source License (NCSA)
 //
-// Copyright (c) 2014-2020, Advanced Micro Devices, Inc. All rights reserved.
+// Copyright (c) 2014-2026, Advanced Micro Devices, Inc. All rights reserved.
 //
 // Developed by:
 //

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_aql_queue.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_aql_queue.cpp
@@ -257,7 +257,7 @@ AqlQueue::AqlQueue(core::SharedQueue* shared_queue, GpuAgent* agent, size_t req_
   }
 
   // Make sure the queue signal always has a waiting_ > 0 so that
-  // so that we call hsakmtSetEvent to force hsaKmtWaitOnEvent to return.
+  // so that we call Driver::SetEvent to force Driver::WaitOnEvent to return.
   exception_signal_->WaitingInc();
 
   // Ensure the amd_queue_ is fully initialized before creating the KFD queue.
@@ -471,7 +471,7 @@ uint64_t AqlQueue::AddWriteIndexRelease(uint64_t value) {
 void AqlQueue::StoreRelaxed(hsa_signal_value_t value) {
   if (core::Runtime::runtime_singleton_->thunkLoader()->IsDTIF() ||
         core::Runtime::runtime_singleton_->thunkLoader()->IsDXG()) {
-    HSAKMT_CALL(hsaKmtQueueRingDoorbell(queue_id_, value));
+    agent_->driver().RingDoorbell(queue_id_, value);
   } else {
     // Hardware doorbell supports AQL semantics.
     _mm_sfence();
@@ -508,7 +508,7 @@ hsa_status_t AqlQueue::GetInfo(hsa_queue_info_attribute_t attribute, void* value
       break;
     case HSA_QUEUE_INFO_HW_ID:
       // Return the hardware queue ID for both counted and non-counted queues
-      *static_cast<uint32_t*>(value) = public_handle()->id; 
+      *static_cast<uint32_t*>(value) = public_handle()->id;
       break;
     default:
       return HSA_STATUS_ERROR_INVALID_ARGUMENT;

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_blit_sdma.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_blit_sdma.cpp
@@ -1221,7 +1221,7 @@ void BlitSdma<useGCR>::UpdateWriteAndDoorbellRegister(uint64_t curr_index, uint6
       *reinterpret_cast<uint64_t*>(queue_resource_.Queue_DoorBell) = new_index;
       if (core::Runtime::runtime_singleton_->thunkLoader()->IsDXG() ||
           core::Runtime::runtime_singleton_->thunkLoader()->IsDTIF()) {
-        HSAKMT_CALL(hsaKmtQueueRingDoorbell(queue_resource_.QueueId, new_index));
+        agent_->driver().RingDoorbell(queue_resource_.QueueId, new_index);
       }
 
       atomic::Store(&cached_commit_index_, new_index, std::memory_order_release);

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_gpu_agent.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_gpu_agent.cpp
@@ -3,7 +3,7 @@
 // The University of Illinois/NCSA
 // Open Source License (NCSA)
 //
-// Copyright (c) 2014-2025, Advanced Micro Devices, Inc. All rights reserved.
+// Copyright (c) 2014-2026, Advanced Micro Devices, Inc. All rights reserved.
 //
 // Developed by:
 //
@@ -1898,15 +1898,15 @@ hsa_status_t GpuAgent::GetInfo(hsa_agent_info_t attribute, void* value) const {
       *((uint64_t*)value) = scratch_limit_async_threshold_;
       break;
     case HSA_AMD_AGENT_INFO_CLOCK_COUNTERS: {
-      HsaClockCounters hsakmt_counters = {};
+      HsaClockCounters driver_counters = {};
       hsa_amd_clock_counters_t* counters = static_cast<hsa_amd_clock_counters_t*>(value);
 
-      hsa_status_t err = driver().GetClockCounters(node_id(), &hsakmt_counters);
+      hsa_status_t err = driver().GetClockCounters(node_id(), &driver_counters);
       if (err == HSA_STATUS_SUCCESS) {
-        counters->cpu_clock_counter = hsakmt_counters.CPUClockCounter;
-        counters->gpu_clock_counter = hsakmt_counters.GPUClockCounter;
-        counters->system_clock_counter = hsakmt_counters.SystemClockCounter;
-        counters->system_clock_frequency = hsakmt_counters.SystemClockFrequencyHz;
+        counters->cpu_clock_counter = driver_counters.CPUClockCounter;
+        counters->gpu_clock_counter = driver_counters.GPUClockCounter;
+        counters->system_clock_counter = driver_counters.SystemClockCounter;
+        counters->system_clock_frequency = driver_counters.SystemClockFrequencyHz;
         break;
       }
       return HSA_STATUS_ERROR;
@@ -2775,40 +2775,40 @@ core::Agent* GpuAgent::GetNearestCpuAgent() const {
   return nearCpu;
 }
 
-hsa_status_t ConvertHsaKmtPcSamplingInfoToHsa(HsaPcSamplingInfo* hsaKmtPcSampling,
-                                              hsa_ven_amd_pcs_configuration_t* hsaPcSampling) {
-  assert(hsaKmtPcSampling && "Invalid hsaKmtPcSampling");
-  assert(hsaPcSampling && "Invalid hsaPcSampling");
+hsa_status_t ConvertDriverPcSamplingInfoToHsa(HsaPcSamplingInfo* driver_pc_sampling,
+                                              hsa_ven_amd_pcs_configuration_t* hsa_pc_sampling) {
+  assert(driver_pc_sampling && "Invalid driver_pc_ampling");
+  assert(hsa_pc_sampling && "Invalid hsa_pc_sampling");
 
-  switch (hsaKmtPcSampling->method) {
+  switch (driver_pc_sampling->method) {
     case HSA_PC_SAMPLING_METHOD_KIND_HOSTTRAP_V1:
-      hsaPcSampling->method = HSA_VEN_AMD_PCS_METHOD_HOSTTRAP_V1;
+      hsa_pc_sampling->method = HSA_VEN_AMD_PCS_METHOD_HOSTTRAP_V1;
       break;
     case HSA_PC_SAMPLING_METHOD_KIND_STOCHASTIC_V1:
-      hsaPcSampling->method = HSA_VEN_AMD_PCS_METHOD_STOCHASTIC_V1;
+      hsa_pc_sampling->method = HSA_VEN_AMD_PCS_METHOD_STOCHASTIC_V1;
       break;
     default:
       // Sampling method not supported do not return this method to the user
       return HSA_STATUS_ERROR;
   }
-  switch (hsaKmtPcSampling->units) {
+  switch (driver_pc_sampling->units) {
     case HSA_PC_SAMPLING_UNIT_INTERVAL_MICROSECONDS:
-      hsaPcSampling->units = HSA_VEN_AMD_PCS_INTERVAL_UNITS_MICRO_SECONDS;
+      hsa_pc_sampling->units = HSA_VEN_AMD_PCS_INTERVAL_UNITS_MICRO_SECONDS;
       break;
     case HSA_PC_SAMPLING_UNIT_INTERVAL_CYCLES:
-      hsaPcSampling->units = HSA_VEN_AMD_PCS_INTERVAL_UNITS_CLOCK_CYCLES;
+      hsa_pc_sampling->units = HSA_VEN_AMD_PCS_INTERVAL_UNITS_CLOCK_CYCLES;
       break;
     case HSA_PC_SAMPLING_UNIT_INTERVAL_INSTRUCTIONS:
-      hsaPcSampling->units = HSA_VEN_AMD_PCS_INTERVAL_UNITS_INSTRUCTIONS;
+      hsa_pc_sampling->units = HSA_VEN_AMD_PCS_INTERVAL_UNITS_INSTRUCTIONS;
       break;
     default:
       // Sampling unit not supported do not return this method to the user
       return HSA_STATUS_ERROR;
   }
 
-  hsaPcSampling->min_interval = hsaKmtPcSampling->value_min;
-  hsaPcSampling->max_interval = hsaKmtPcSampling->value_max;
-  hsaPcSampling->flags = hsaKmtPcSampling->flags;
+  hsa_pc_sampling->min_interval = driver_pc_sampling->value_min;
+  hsa_pc_sampling->max_interval = driver_pc_sampling->value_max;
+  hsa_pc_sampling->flags = driver_pc_sampling->flags;
   return HSA_STATUS_SUCCESS;
 }
 
@@ -2820,20 +2820,21 @@ hsa_status_t GpuAgent::PcSamplingIterateConfig(hsa_ven_amd_pcs_iterate_configura
     return HSA_STATUS_ERROR;
 
   // First query to get size of list needed
-  HSAKMT_STATUS ret = HSAKMT_CALL(hsaKmtPcSamplingQueryCapabilities(node_id(), NULL, 0, &size));
-  if (ret != HSAKMT_STATUS_SUCCESS || size == 0) return HSA_STATUS_ERROR;
+  if (driver().PcSamplingQueryCapabilities(node_id(), NULL, 0, &size) != HSA_STATUS_SUCCESS ||
+      size == 0)
+    return HSA_STATUS_ERROR;
 
   std::vector<HsaPcSamplingInfo> sampleInfoList(size);
-  ret = HSAKMT_CALL(hsaKmtPcSamplingQueryCapabilities(node_id(), sampleInfoList.data(), sampleInfoList.size(),
-                                          &size));
-
-  if (ret != HSAKMT_STATUS_SUCCESS) return HSA_STATUS_ERROR;
+  if (driver().PcSamplingQueryCapabilities(node_id(), sampleInfoList.data(), sampleInfoList.size(),
+                                           &size) != HSA_STATUS_SUCCESS)
+    return HSA_STATUS_ERROR;
 
   for (uint32_t i = 0; i < size; i++) {
     hsa_ven_amd_pcs_configuration_t hsaPcSampling;
-    if (ConvertHsaKmtPcSamplingInfoToHsa(&sampleInfoList[i], &hsaPcSampling) == HSA_STATUS_SUCCESS
-        && cb(&hsaPcSampling, cb_data) == HSA_STATUS_INFO_BREAK)
-          return HSA_STATUS_SUCCESS;
+    if (ConvertDriverPcSamplingInfoToHsa(&sampleInfoList[i], &hsaPcSampling) ==
+            HSA_STATUS_SUCCESS &&
+        cb(&hsaPcSampling, cb_data) == HSA_STATUS_INFO_BREAK)
+      return HSA_STATUS_SUCCESS;
   }
   return HSA_STATUS_SUCCESS;
 }
@@ -2849,14 +2850,13 @@ hsa_status_t GpuAgent::PcSamplingCreate(pcs::PcsRuntime::PcSamplingSession& sess
   if (ret != HSA_STATUS_SUCCESS) return ret;
 
   // Obtain the sampling information from the session.
-  session.GetHsaKmtSamplingInfo(&sampleInfo);
+  session.GetDriverSamplingInfo(&sampleInfo);
 
   // Pass the sampling information to the kernel driver to create PC
   // sampling session.
-  HSAKMT_STATUS retkmt = HSAKMT_CALL(hsaKmtPcSamplingCreate(node_id(), &sampleInfo, &thunkId));
-  if (retkmt != HSAKMT_STATUS_SUCCESS) {
-    return (retkmt == HSAKMT_STATUS_KERNEL_ALREADY_OPENED) ? (hsa_status_t)HSA_STATUS_ERROR_RESOURCE_BUSY
-            : HSA_STATUS_ERROR;
+  hsa_status_t pcs_ret = driver().PcSamplingCreate(node_id(), &sampleInfo, &thunkId);
+  if (pcs_ret != HSA_STATUS_SUCCESS) {
+    return pcs_ret;
   }
 
   debug_print("Created PC sampling session with thunkId:%d\n", thunkId);
@@ -3062,7 +3062,7 @@ hsa_status_t GpuAgent::PcSamplingCreateFromId(HsaPcSamplingTraceId ioctlId,
 hsa_status_t GpuAgent::PcSamplingDestroy(pcs::PcsRuntime::PcSamplingSession& session) {
   if (PcSamplingStop(session) != HSA_STATUS_SUCCESS) return HSA_STATUS_ERROR;
 
-  HSAKMT_STATUS retKmt = HSAKMT_CALL(hsaKmtPcSamplingDestroy(node_id(), session.ThunkId()));
+  hsa_status_t ret_driver = driver().PcSamplingDestroy(node_id(), session.ThunkId());
   hsa_ven_amd_pcs_method_kind_t sampling_method = session.method();
 
   pcs_data_t* pcs_data = nullptr;
@@ -3094,7 +3094,7 @@ hsa_status_t GpuAgent::PcSamplingDestroy(pcs::PcsRuntime::PcSamplingSession& ses
   // Update the trap handler to clear any associated device data
   UpdateTrapHandlerWithPCS(nullptr, nullptr);
 
-  return (retKmt == HSAKMT_STATUS_SUCCESS) ? HSA_STATUS_SUCCESS : HSA_STATUS_ERROR;
+  return ret_driver;
 }
 
 hsa_status_t GpuAgent::PcSamplingStart(pcs::PcsRuntime::PcSamplingSession& session) {
@@ -3161,7 +3161,7 @@ hsa_status_t GpuAgent::PcSamplingStart(pcs::PcsRuntime::PcSamplingSession& sessi
   }
 
   // Start the sampling session in the kernel driver
-  if (HSAKMT_CALL(hsaKmtPcSamplingStart(node_id(), session.ThunkId())) == HSAKMT_STATUS_SUCCESS)
+  if (driver().PcSamplingStart(node_id(), session.ThunkId()) == HSA_STATUS_SUCCESS)
     return HSA_STATUS_SUCCESS;
 
   debug_print("Failed to start PC sampling session with thunkId:%d\n", session.ThunkId());
@@ -3182,8 +3182,7 @@ hsa_status_t GpuAgent::PcSamplingStop(pcs::PcsRuntime::PcSamplingSession& sessio
   session.stop();
 
   // Stop PC sampling in the kernel driver
-  HSAKMT_STATUS retKmt = HSAKMT_CALL(hsaKmtPcSamplingStop(node_id(), session.ThunkId()));
-  if (retKmt != HSAKMT_STATUS_SUCCESS)
+  if (driver().PcSamplingStop(node_id(), session.ThunkId()) != HSA_STATUS_SUCCESS)
     throw AMD::hsa_exception(HSA_STATUS_ERROR, "Failed to stop PC Sampling session.");
 
   // Determine the sampling method and corresponding data

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_topology.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_topology.cpp
@@ -3,7 +3,7 @@
 // The University of Illinois/NCSA
 // Open Source License (NCSA)
 //
-// Copyright (c) 2014-2025, Advanced Micro Devices, Inc. All rights reserved.
+// Copyright (c) 2014-2026, Advanced Micro Devices, Inc. All rights reserved.
 //
 // Developed by:
 //

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/hsa_ext_amd.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/hsa_ext_amd.cpp
@@ -1671,13 +1671,10 @@ hsa_status_t hsa_amd_ais_file_write(hsa_amd_ais_file_handle_t handle, void *devi
     return HSA_STATUS_ERROR_INVALID_ARGUMENT;
   }
 
-  // Call the kernel module function through the thunk layer
-  HSAKMT_STATUS ret = HSAKMT_CALL(hsaKmtAisReadWriteFile)(devicePtr, size, handle.fd,
-                                                          file_offset, HSA_AIS_WRITE,
-                                                          size_copied, status);
-
-  return (ret == HSAKMT_STATUS_SUCCESS) ?
-                            HSA_STATUS_SUCCESS : HSA_STATUS_ERROR;
+  // Call the kernel module function through the driver layer
+  return core::Runtime::runtime_singleton_->AgentDriver(core::DriverType::KFD)
+      .AisReadWriteFile(devicePtr, size, handle.fd, file_offset, HSA_AIS_WRITE, size_copied,
+                        status);
   CATCH;
 }
 
@@ -1691,12 +1688,9 @@ hsa_status_t hsa_amd_ais_file_read(hsa_amd_ais_file_handle_t handle, void *devic
     return HSA_STATUS_ERROR_INVALID_ARGUMENT;
   }
 
-  // Call the kernel module function through the thunk layer
-  HSAKMT_STATUS ret = HSAKMT_CALL(hsaKmtAisReadWriteFile)(devicePtr, size, handle.fd,
-                                                          file_offset, HSA_AIS_READ,
-                                                          size_copied, status);
-
-  return (ret == HSAKMT_STATUS_SUCCESS) ? HSA_STATUS_SUCCESS : HSA_STATUS_ERROR;
+  // Call the kernel module function through the driver layer
+  return core::Runtime::runtime_singleton_->AgentDriver(core::DriverType::KFD)
+      .AisReadWriteFile(devicePtr, size, handle.fd, file_offset, HSA_AIS_READ, size_copied, status);
   CATCH;
 }
 

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/interrupt_signal.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/interrupt_signal.cpp
@@ -76,8 +76,9 @@ HsaEvent* InterruptSignal::CreateEvent(HSA_EVENTTYPE type, bool manual_reset) {
   event_descriptor.NodeId = 0;
 
   HsaEvent* ret = NULL;
-  if (HSAKMT_STATUS_SUCCESS ==
-      HSAKMT_CALL(hsaKmtCreateEvent(&event_descriptor, manual_reset, false, &ret))) {
+  if (HSA_STATUS_SUCCESS ==
+      Runtime::runtime_singleton_->AgentDriver(DriverType::KFD)
+          .CreateEvent(event_descriptor, manual_reset, &ret)) {
     if (type == HSA_EVENTTYPE_MEMORY) {
       memset(&ret->EventData.EventData.MemoryAccessFault.Failure, 0,
              sizeof(HsaAccessAttributeFailure));
@@ -89,7 +90,9 @@ HsaEvent* InterruptSignal::CreateEvent(HSA_EVENTTYPE type, bool manual_reset) {
   return ret;
 }
 
-void InterruptSignal::DestroyEvent(HsaEvent* evt) { HSAKMT_CALL(hsaKmtDestroyEvent(evt)); }
+void InterruptSignal::DestroyEvent(HsaEvent* evt) {
+  Runtime::runtime_singleton_->AgentDriver(DriverType::KFD).DestroyEvent(evt);
+}
 
 InterruptSignal::InterruptSignal(hsa_signal_value_t initial_value, HsaEvent* use_event)
     : LocalSignal(initial_value, false), Signal(signal()) {
@@ -194,7 +197,8 @@ hsa_signal_value_t InterruptSignal::WaitRelaxed(hsa_signal_condition_t condition
       static_cast<uint32_t>(signal_abort_timeout ? signal_abort_timeout * 1000 : 0xFFFFFFFFUL)
     );
 
-    HSAKMT_CALL(hsaKmtWaitOnEvent_Ext(event_, wait_ms, &event_age));
+    Runtime::runtime_singleton_->AgentDriver(DriverType::KFD)
+        .WaitOnEvent(event_, wait_ms, &event_age);
   }
 }
 
@@ -372,7 +376,7 @@ hsa_signal_value_t InterruptSignal::CasAcqRel(hsa_signal_value_t expected,
 }
   /// @brief Notify driver of signal value change if necessary.
   void InterruptSignal::SetEvent() {
-    if (InWaiting()) HSAKMT_CALL(hsaKmtSetEvent(event_));
+    if (InWaiting()) Runtime::runtime_singleton_->AgentDriver(DriverType::KFD).SetEvent(event_);
   }
 
 }  // namespace core

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/runtime.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/runtime.cpp
@@ -3,7 +3,7 @@
 // The University of Illinois/NCSA
 // Open Source License (NCSA)
 //
-// Copyright (c) 2014-2025, Advanced Micro Devices, Inc. All rights reserved.
+// Copyright (c) 2014-2026, Advanced Micro Devices, Inc. All rights reserved.
 //
 // Developed by:
 //
@@ -367,8 +367,8 @@ hsa_status_t Runtime::FreeMemory(void* ptr) {
     if (it->second.thunk_bo) {
       if (!thunkLoader()->IsDXG()) {
         //clear metadata
-        HSAKMT_STATUS status = HSAKMT_CALL(hsaKmtMemHandleFree(it->second.thunk_bo));
-        if (status != HSAKMT_STATUS_SUCCESS) {
+        if (AgentDriver(DriverType::KFD).FreeMemoryHandle(it->second.thunk_bo) !=
+            HSA_STATUS_SUCCESS) {
           return HSA_STATUS_ERROR;
         }
       }
@@ -387,11 +387,11 @@ hsa_status_t Runtime::FreeMemory(void* ptr) {
   }
 
   if (alloc_flags & core::MemoryRegion::AllocateAsan)
-    assert(HSAKMT_CALL(hsaKmtReturnAsanHeaderPage(ptr)) == HSAKMT_STATUS_SUCCESS);
+    assert(AgentDriver(DriverType::KFD).ReturnAsanHeaderPage(ptr) == HSA_STATUS_SUCCESS);
 
   const hsa_status_t err = region->Free(ptr, size);
   if (err != HSA_STATUS_SUCCESS) {
-    // hsaKmtFreeMemory failed to free this pointer. Throw a memory error event
+    // Driver::FreeMemory failed to free this pointer. Throw a memory error event
 
     // Note: This should be treated as a fatal exception by the System Event Handler because:
     //  - This leaves allocation_map_ in an inconsistent state as this pointer entry has already
@@ -401,7 +401,7 @@ hsa_status_t Runtime::FreeMemory(void* ptr) {
     //
     // But this is a very unlikely use case and calling region->Free(..) before updating
     // allocation_map_ would require us to hold the memory_lock_ for much longer and we would not be
-    // able to call hsaKmtReturnAsanHeaderPage after calling region->Free(..)
+    // able to call Driver::ReturnAsanHeaderPage after calling region->Free(..)
 
     const core::Agent* agentOwner = region->owner();
     hsa_status_t custom_handler_status = HSA_STATUS_ERROR;
@@ -885,8 +885,9 @@ hsa_status_t Runtime::InteropMap(uint32_t num_agents, Agent** agents, hsa_handle
       .ui32 = {.kmtHandle = ((flags & HSA_INTEROP_MAP_FLAG_KMT_HANDLE) != 0)}};
 
   auto status =
-      hsaKmtRegisterGraphicsHandleToNodesExt(resource_handle, &info, num_agents, nodes, reg_flags);
-  if (status != HSAKMT_STATUS_SUCCESS) return HSA_STATUS_ERROR;
+      AgentDriver(DriverType::KFD)
+          .RegisterGraphicsHandleToNodesExt(resource_handle, &info, num_agents, nodes, reg_flags);
+  if (status != HSA_STATUS_SUCCESS) return HSA_STATUS_ERROR;
 
   assert(num_agents > 0);
   auto& driver = agents[0]->driver();
@@ -1045,7 +1046,7 @@ hsa_status_t Runtime::PtrInfo(const void* ptr, hsa_amd_pointer_info_t* info, voi
        * For SVM allocations, the VA is reserved using hsa_amd_vmem_address_reserve with
        * HSA_AMD_VMEM_ADDRESS_NO_REGISTER flag. So for SVM allocations, we do not return
        * yet as we can check whether this address was registered via hsa_amd_svm_attributes_set
-       * and provide additional information from hsaKmtQueryPointerInfo.
+       * and provide additional information from Driver::QueryPointerInfo.
        */
       if (!(retInfo.type == HSA_EXT_POINTER_TYPE_RESERVED_ADDR && !retInfo.registered)) {
         memcpy(info, &retInfo, retInfo.size);
@@ -1055,8 +1056,8 @@ hsa_status_t Runtime::PtrInfo(const void* ptr, hsa_amd_pointer_info_t* info, voi
 
     // We don't care if this returns an error code.
     // The type will be HSA_EXT_POINTER_TYPE_UNKNOWN if so.
-    auto err = HSAKMT_CALL(hsaKmtQueryPointerInfo(ptr, &thunkInfo));
-    if (err != HSAKMT_STATUS_SUCCESS || thunkInfo.Type == HSA_POINTER_UNKNOWN) {
+    auto err = AgentDriver(DriverType::KFD).QueryPointerInfo(ptr, &thunkInfo);
+    if (err != HSA_STATUS_SUCCESS || thunkInfo.Type == HSA_POINTER_UNKNOWN) {
       if (retInfo.type == HSA_EXT_POINTER_TYPE_RESERVED_ADDR) {
         /* This is an address that was reserved using hsa_amd_vmem_address_reserve with
          * the HSA_AMD_VMEM_ADDRESS_NO_REGISTER flag, but the address was not registered
@@ -1186,7 +1187,7 @@ hsa_status_t Runtime::SetPtrInfoData(const void* ptr, void* userptr) {
     }
   }
   // Cover entries not in the allocation map (graphics, lock,...)
-  if (HSAKMT_CALL(hsaKmtSetMemoryUserData(ptr, userptr)) == HSAKMT_STATUS_SUCCESS)
+  if (AgentDriver(DriverType::KFD).SetMemoryUserData(ptr, userptr) == HSA_STATUS_SUCCESS)
     return HSA_STATUS_SUCCESS;
   return HSA_STATUS_ERROR_INVALID_ARGUMENT;
 }
@@ -1301,10 +1302,11 @@ void Runtime::AsyncIPCSockServerConnLoop(void*) {
      if (!ptr) continue;
 
      // Export DMA Buf FD and wait for client import
-     int err = HSAKMT_CALL(hsaKmtExportDMABufHandle(ptr, len, &dmabuf_fd, &fragOffset));
-     if (err != HSAKMT_STATUS_SUCCESS) continue;
+     if (runtime_singleton_->AgentDriver(DriverType::KFD)
+             .ExportDMABufHandle(ptr, len, &dmabuf_fd, &fragOffset) != HSA_STATUS_SUCCESS)
+       continue;
      SendDmaBufFd(connection_fd, dmabuf_fd);
-     err = read(connection_fd, buf, sizeof(buf));
+     int err = read(connection_fd, buf, sizeof(buf));
      close(dmabuf_fd);
      if (err == -1) break; // Client failed to confirm import so end server
    }
@@ -1347,7 +1349,8 @@ hsa_status_t Runtime::IPCCreate(void* ptr, size_t len, hsa_amd_ipc_memory_t* han
 
   if (!ipc_dmabuf_supported_) {
     HsaSharedMemoryHandle *sHandle = reinterpret_cast<HsaSharedMemoryHandle*>(handle);
-    if (HSAKMT_CALL(hsaKmtShareMemory(block.base, block.length, sHandle)) != HSAKMT_STATUS_SUCCESS)
+    if (AgentDriver(DriverType::KFD).ShareMemory(block.base, block.length, sHandle) !=
+        HSA_STATUS_SUCCESS)
       return HSA_STATUS_ERROR_INVALID_ARGUMENT;
 
     hsa_status_t err = HSA_STATUS_SUCCESS;
@@ -1404,8 +1407,7 @@ hsa_status_t Runtime::IPCCreate(void* ptr, size_t len, hsa_amd_ipc_memory_t* han
       hflags.ui32.SysMem = handle->handle[3];
       hflags.ui32.UpdateMetadata = 1;
       HsaHandleImportResult res;
-      HSAKMT_STATUS status = HSAKMT_CALL(hsaKmtHandleImport(&desc, &res, &hflags));
-      if (status == HSAKMT_STATUS_ERROR) {
+      if (AgentDriver(DriverType::KFD).HandleImport(&desc, &res, &hflags) != HSA_STATUS_SUCCESS) {
         close(dmabuf_fd);
         return HSA_STATUS_ERROR;
       }
@@ -1535,13 +1537,14 @@ int Runtime::IPCClientImport(uint32_t conn_handle, uint64_t dmabuf_fd_handle,
     HsaGraphicsResourceInfo info;
     HSA_REGISTER_MEM_FLAGS regFlags;
     regFlags.ui32.requiresVAddr = !isDmabufSysmem;
-    int err = HSAKMT_CALL(hsaKmtRegisterGraphicsHandleToNodesExt(dmabuf_fd, &info, numNodes, nodes, regFlags));
-    if (err == HSAKMT_STATUS_SUCCESS) {
+    hsa_status_t err =
+        AgentDriver(DriverType::KFD)
+            .RegisterGraphicsHandleToNodesExt(dmabuf_fd, &info, numNodes, nodes, regFlags);
+    if (err == HSA_STATUS_SUCCESS) {
       *importAddress = info.MemoryAddress;
       *importSize = info.SizeInBytes;
 
-      if (isDmabufSysmem)
-        HSAKMT_CALL(hsaKmtDeregisterMemory(*importAddress));
+      if (isDmabufSysmem) AgentDriver(DriverType::KFD).DeregisterMemory(*importAddress);
 
       AMD::GpuAgent* agent = reinterpret_cast<AMD::GpuAgent*>(agents_by_node_[info.NodeId][0]);
 
@@ -1555,8 +1558,7 @@ int Runtime::IPCClientImport(uint32_t conn_handle, uint64_t dmabuf_fd_handle,
       hflags.ui32.SysMem = isDmabufSysmem;
       hflags.ui32.UpdateMetadata = 0;
       HsaHandleImportResult res;
-      HSAKMT_STATUS status = HSAKMT_CALL(hsaKmtHandleImport(&desc, &res, &hflags));
-      if (status != HSAKMT_STATUS_SUCCESS) {
+      if (AgentDriver(DriverType::KFD).HandleImport(&desc, &res, &hflags) != HSA_STATUS_SUCCESS) {
         fprintf(stderr, "IPC Client Import: Invalid IPC handle! expected %u, got %u\n",
                 shared_handle, res.metadata);
         close(dmabuf_fd);
@@ -1564,12 +1566,10 @@ int Runtime::IPCClientImport(uint32_t conn_handle, uint64_t dmabuf_fd_handle,
       }
 
       // Store the buffer object handle in allocation map for later use
-      if (status == HSAKMT_STATUS_SUCCESS) {
-        std::lock_guard<std::shared_mutex> lock(memory_lock_);
-        allocation_map_[*importAddress] =
-            AllocationRegion(nullptr, *importSize, *importSize, core::MemoryRegion::AllocateNoFlags);
-        allocation_map_[*importAddress].thunk_bo = res.buf_handle;
-      }
+      std::lock_guard<std::shared_mutex> lock(memory_lock_);
+      allocation_map_[*importAddress] =
+          AllocationRegion(nullptr, *importSize, *importSize, core::MemoryRegion::AllocateNoFlags);
+      allocation_map_[*importAddress].thunk_bo = res.buf_handle;
       close(dmabuf_fd);
     }
 
@@ -1601,39 +1601,41 @@ hsa_status_t Runtime::IPCAttach(const hsa_amd_ipc_memory_t* handle, size_t len, 
     allocation_map_[importAddress].thunk_bo = thunk_bo;
   };
 
-  auto importMemory = [&](unsigned int numNodes, HSAuint32 *nodes, bool isSysMem) {
+  auto importMemory = [&](unsigned int numNodes, HSAuint32* nodes, bool isSysMem) {
+    int ret = ipc_dmabuf_supported_
+        ? IPCClientImport(importHandle.handle[2], dmaBufFDHandle, numNodes, nodes, &importAddress,
+                          &importSize, isSysMem, importHandle.handle[7])
+        : static_cast<int>(AgentDriver(DriverType::KFD)
+                               .RegisterSharedHandle(
+                                   reinterpret_cast<const HsaSharedMemoryHandle*>(&importHandle),
+                                   &importAddress, &importSize));
 
-      int ret = ipc_dmabuf_supported_ ? IPCClientImport(importHandle.handle[2], dmaBufFDHandle, numNodes,
-                                                        nodes, &importAddress, &importSize, isSysMem,
-                                                        importHandle.handle[7]) :
-                                                        HSAKMT_CALL(hsaKmtRegisterSharedHandle(
-                                                        reinterpret_cast<const HsaSharedMemoryHandle*>(&importHandle),
-                                                        &importAddress, &importSize
-                                                        ));
-
-      if (ret) {
-        return HSA_STATUS_ERROR_INVALID_ARGUMENT;
-      }
-      return HSA_STATUS_SUCCESS;
-    };
+    if (ret) {
+      return HSA_STATUS_ERROR_INVALID_ARGUMENT;
+    }
+    return HSA_STATUS_SUCCESS;
+  };
 
   auto mapMemoryToNodes = [&](unsigned int numNodes, HSAuint32 *nodes) {
     HSAuint64 altAddress;
     if (!numNodes) {
-      if (HSAKMT_CALL(hsaKmtMapMemoryToGPU(importAddress, importSize, &altAddress)) != HSAKMT_STATUS_SUCCESS) {
-        HSAKMT_CALL(hsaKmtDeregisterMemory(importAddress));
+      if (AgentDriver(DriverType::KFD).MapMemoryToGPU(importAddress, importSize, &altAddress) !=
+          HSA_STATUS_SUCCESS) {
+        AgentDriver(DriverType::KFD).DeregisterMemory(importAddress);
         return HSA_STATUS_ERROR_OUT_OF_RESOURCES;
       }
     } else {
       HsaMemMapFlags map_flags;
       map_flags.Value = 0;
       map_flags.ui32.PageSize = HSA_PAGE_SIZE_64KB;
-      if (HSAKMT_CALL(hsaKmtMapMemoryToGPUNodes(importAddress, importSize, &altAddress, map_flags, numNodes,
-                                    nodes)) != HSAKMT_STATUS_SUCCESS) {
+      if (AgentDriver(DriverType::KFD)
+              .MapMemoryToGPUNodes(importAddress, importSize, &altAddress, map_flags, numNodes,
+                                   nodes) != HSA_STATUS_SUCCESS) {
         map_flags.ui32.PageSize = HSA_PAGE_SIZE_4KB;
-        if (HSAKMT_CALL(hsaKmtMapMemoryToGPUNodes(importAddress, importSize, &altAddress, map_flags, numNodes,
-                                      nodes)) != HSAKMT_STATUS_SUCCESS) {
-          HSAKMT_CALL(hsaKmtDeregisterMemory(importAddress));
+        if (AgentDriver(DriverType::KFD)
+                .MapMemoryToGPUNodes(importAddress, importSize, &altAddress, map_flags, numNodes,
+                                     nodes) != HSA_STATUS_SUCCESS) {
+          AgentDriver(DriverType::KFD).DeregisterMemory(importAddress);
           return HSA_STATUS_ERROR_OUT_OF_RESOURCES;
         }
       }
@@ -1664,22 +1666,21 @@ hsa_status_t Runtime::IPCAttach(const hsa_amd_ipc_memory_t* handle, size_t len, 
     if (!isDmabufSysMem) return mapMemoryToNodes(0, NULL);
 
     // System memory DMA Buf import
-    auto errCleanup = [&](HsaMemoryObjectHandle bo)
-    {
-      HSAKMT_CALL(hsaKmtMemHandleFree(bo));
+    auto errCleanup = [&](HsaMemoryObjectHandle bo) {
+      AgentDriver(DriverType::KFD).FreeMemoryHandle(bo);
       return HSA_STATUS_ERROR;
     };
 
     // Create a shared cpu access pointer for user
     void *cpuPtr;
     HsaMemoryObjectHandle bo = allocation_map_[importAddress].thunk_bo;
-    HSAKMT_STATUS status = HSAKMT_CALL(hsaKmtMemoryCpuMap(bo, &cpuPtr));
-    if (status != HSAKMT_STATUS_SUCCESS) {
+    if (AgentDriver(DriverType::KFD).MemoryCpuMap(bo, &cpuPtr) != HSA_STATUS_SUCCESS) {
       return errCleanup(bo);
     }
-    status = HSAKMT_CALL(hsaKmtMemoryVaMap(bo, 0, static_cast<HSAuint64>(importSize),
-                                           reinterpret_cast<HSAuint64>(cpuPtr), HSA_MEMORY_ACCESS_NONE));
-    if (status != HSAKMT_STATUS_SUCCESS) {
+    if (AgentDriver(DriverType::KFD)
+            .MemoryVaMap(bo, 0, static_cast<HSAuint64>(importSize),
+                         reinterpret_cast<HSAuint64>(cpuPtr),
+                         HSA_MEMORY_ACCESS_NONE) != HSA_STATUS_SUCCESS) {
       return errCleanup(bo);
     }
     importAddress = cpuPtr;
@@ -1720,14 +1721,13 @@ hsa_status_t Runtime::IPCDetach(void* ptr) {
       if (it->second.region != nullptr) return HSA_STATUS_ERROR_INVALID_ARGUMENT;
 #if defined(__linux__)
       if (it->second.thunk_bo) {
-        HSAKMT_STATUS status = HSAKMT_CALL(hsaKmtMemoryVaUnmap(it->second.thunk_bo, 0,
-                                                               static_cast<HSAuint64>(it->second.size),
-                                                               reinterpret_cast<HSAuint64>(ptr)));
-        if (status != HSAKMT_STATUS_SUCCESS) {
+        if (AgentDriver(DriverType::KFD)
+                .MemoryVaUnmap(it->second.thunk_bo, 0, static_cast<HSAuint64>(it->second.size),
+                               reinterpret_cast<HSAuint64>(ptr)) != HSA_STATUS_SUCCESS) {
           return HSA_STATUS_ERROR_INVALID_ARGUMENT;
         }
-        status = HSAKMT_CALL(hsaKmtMemHandleFree(it->second.thunk_bo));
-        if (status != HSAKMT_STATUS_SUCCESS) {
+        if (AgentDriver(DriverType::KFD).FreeMemoryHandle(it->second.thunk_bo) !=
+            HSA_STATUS_SUCCESS) {
           return HSA_STATUS_ERROR_INVALID_ARGUMENT;
         }
         ldrmImportCleaned = true;
@@ -1748,9 +1748,9 @@ hsa_status_t Runtime::IPCDetach(void* ptr) {
   }
 
   if (!ldrmImportCleaned) {
-    if (HSAKMT_CALL(hsaKmtUnmapMemoryToGPU(ptr)) != HSAKMT_STATUS_SUCCESS)
+    if (AgentDriver(DriverType::KFD).MakeMemoryUnresident(ptr) != HSA_STATUS_SUCCESS)
       return HSA_STATUS_ERROR_INVALID_ARGUMENT;
-    if (HSAKMT_CALL(hsaKmtDeregisterMemory(ptr)) != HSAKMT_STATUS_SUCCESS)
+    if (AgentDriver(DriverType::KFD).DeregisterMemory(ptr) != HSA_STATUS_SUCCESS)
       return HSA_STATUS_ERROR_INVALID_ARGUMENT;
   }
   return HSA_STATUS_SUCCESS;
@@ -1805,12 +1805,13 @@ void Runtime::AsyncEventsLoop(void* _eventsInfo) {
   };
 
   // KFD will move this thread into sleep, until any event from the list is complete or
-  // if ROCR can wake it up with hsaKmtSetEvent()
+  // if ROCR can wake it up with Driver::SetEvent()
   auto WaitForInterrupt = [&]() {
     constexpr uint32_t wait_ms = 0xFFFFFFFEu;
     HsaEvent** end = std::unique(&hsa_events[0], &hsa_events[0] + unique_evts);
     unique_evts = uint32_t(end - &hsa_events[0]);
-    HSAKMT_CALL(hsaKmtWaitOnMultipleEvents_Ext(&hsa_events[0], unique_evts, false, wait_ms, &event_age[0]));
+    runtime_singleton_->AgentDriver(DriverType::KFD)
+        .WaitOnMultipleEvents(&hsa_events[0], unique_evts, false, wait_ms, &event_age[0]);
   };
 
   while (!async_events_control_.exit) {
@@ -2959,7 +2960,7 @@ hsa_status_t Runtime::SetSvmAttrib(void* ptr, size_t size,
     set_attribs |= (1 << attrib);
   };
 
-  auto kmtPair = [](uint32_t attrib, uint32_t value) {
+  auto driver_pair = [](uint32_t attrib, uint32_t value) {
     HSA_SVM_ATTRIBUTE pair = {attrib, value};
     return pair;
   };
@@ -3004,16 +3005,16 @@ hsa_status_t Runtime::SetSvmAttrib(void* ptr, size_t size,
         Check(attrib);
         // Max migration size is 1GB.
         if (value > 18) value = 18;
-        attribs.push_back(kmtPair(HSA_SVM_ATTR_GRANULARITY, value));
+        attribs.push_back(driver_pair(HSA_SVM_ATTR_GRANULARITY, value));
         break;
       }
       case HSA_AMD_SVM_ATTRIB_PREFERRED_LOCATION: {
         Check(attrib);
         Agent* agent = ConvertAllowNull(value);
         if (agent == nullptr)
-          attribs.push_back(kmtPair(HSA_SVM_ATTR_PREFERRED_LOC, INVALID_NODEID));
+          attribs.push_back(driver_pair(HSA_SVM_ATTR_PREFERRED_LOC, INVALID_NODEID));
         else
-          attribs.push_back(kmtPair(HSA_SVM_ATTR_PREFERRED_LOC, agent->node_id()));
+          attribs.push_back(driver_pair(HSA_SVM_ATTR_PREFERRED_LOC, agent->node_id()));
         break;
       }
       case HSA_AMD_SVM_ATTRIB_READ_MOSTLY: {
@@ -3038,7 +3039,7 @@ hsa_status_t Runtime::SetSvmAttrib(void* ptr, size_t size,
         if (agent->device_type() == Agent::kAmdCpuDevice) {
           set_flags |= HSA_SVM_FLAG_HOST_ACCESS;
         } else {
-          attribs.push_back(kmtPair(HSA_SVM_ATTR_ACCESS, agent->node_id()));
+          attribs.push_back(driver_pair(HSA_SVM_ATTR_ACCESS, agent->node_id()));
         }
         break;
       }
@@ -3048,7 +3049,7 @@ hsa_status_t Runtime::SetSvmAttrib(void* ptr, size_t size,
         if (agent->device_type() == Agent::kAmdCpuDevice) {
           set_flags |= HSA_SVM_FLAG_HOST_ACCESS;
         } else {
-          attribs.push_back(kmtPair(HSA_SVM_ATTR_ACCESS_IN_PLACE, agent->node_id()));
+          attribs.push_back(driver_pair(HSA_SVM_ATTR_ACCESS_IN_PLACE, agent->node_id()));
         }
         break;
       }
@@ -3058,7 +3059,7 @@ hsa_status_t Runtime::SetSvmAttrib(void* ptr, size_t size,
         if (agent->device_type() == Agent::kAmdCpuDevice) {
           clear_flags |= HSA_SVM_FLAG_HOST_ACCESS;
         } else {
-          attribs.push_back(kmtPair(HSA_SVM_ATTR_NO_ACCESS, agent->node_id()));
+          attribs.push_back(driver_pair(HSA_SVM_ATTR_NO_ACCESS, agent->node_id()));
         }
         break;
       }
@@ -3073,15 +3074,15 @@ hsa_status_t Runtime::SetSvmAttrib(void* ptr, size_t size,
   if (set_flags & HSA_SVM_FLAG_HOST_ACCESS) clear_flags &= ~HSA_SVM_FLAG_HOST_ACCESS;
 
   // Add flag updates
-  if (clear_flags) attribs.push_back(kmtPair(HSA_SVM_ATTR_CLR_FLAGS, clear_flags));
-  if (set_flags) attribs.push_back(kmtPair(HSA_SVM_ATTR_SET_FLAGS, set_flags));
+  if (clear_flags) attribs.push_back(driver_pair(HSA_SVM_ATTR_CLR_FLAGS, clear_flags));
+  if (set_flags) attribs.push_back(driver_pair(HSA_SVM_ATTR_SET_FLAGS, set_flags));
 
   uint8_t* base = AlignDown((uint8_t*)ptr, 4096);
   uint8_t* end = AlignUp((uint8_t*)ptr + size, 4096);
   size_t len = end - base;
-  HSAKMT_STATUS error = HSAKMT_CALL(hsaKmtSVMSetAttr(base, len, attribs.size(), &attribs[0]));
-  if (error != HSAKMT_STATUS_SUCCESS)
-    throw AMD::hsa_exception(HSA_STATUS_ERROR, "hsaKmtSVMSetAttr failed.");
+  if (AgentDriver(DriverType::KFD).SVMSetAttr(base, len, attribs.size(), &attribs[0]) !=
+      HSA_STATUS_SUCCESS)
+    throw AMD::hsa_exception(HSA_STATUS_ERROR, "Driver::SVMSetAttr failed.");
 
   return HSA_STATUS_SUCCESS;
 }
@@ -3092,7 +3093,7 @@ hsa_status_t Runtime::GetSvmAttrib(void* ptr, size_t size,
   std::vector<HSA_SVM_ATTRIBUTE> attribs;
   attribs.reserve(attribute_count);
 
-  std::vector<int> kmtIndices(attribute_count);
+  std::vector<int> driver_indices(attribute_count);
 
   bool getFlags = false;
 
@@ -3105,7 +3106,7 @@ hsa_status_t Runtime::GetSvmAttrib(void* ptr, size_t size,
     return agent;
   };
 
-  auto kmtPair = [](uint32_t attrib, uint32_t value) {
+  auto driver_pair = [](uint32_t attrib, uint32_t value) {
     HSA_SVM_ATTRIBUTE pair = {attrib, value};
     return pair;
   };
@@ -3120,32 +3121,32 @@ hsa_status_t Runtime::GetSvmAttrib(void* ptr, size_t size,
       case HSA_AMD_SVM_ATTRIB_HIVE_LOCAL:
       case HSA_AMD_SVM_ATTRIB_READ_MOSTLY: {
         getFlags = true;
-        kmtIndices[i] = -1;
+        driver_indices[i] = -1;
         break;
       }
       case HSA_AMD_SVM_ATTRIB_MIGRATION_GRANULARITY: {
-        kmtIndices[i] = attribs.size();
-        attribs.push_back(kmtPair(HSA_SVM_ATTR_GRANULARITY, 0));
+        driver_indices[i] = attribs.size();
+        attribs.push_back(driver_pair(HSA_SVM_ATTR_GRANULARITY, 0));
         break;
       }
       case HSA_AMD_SVM_ATTRIB_PREFERRED_LOCATION: {
-        kmtIndices[i] = attribs.size();
-        attribs.push_back(kmtPair(HSA_SVM_ATTR_PREFERRED_LOC, 0));
+        driver_indices[i] = attribs.size();
+        attribs.push_back(driver_pair(HSA_SVM_ATTR_PREFERRED_LOC, 0));
         break;
       }
       case HSA_AMD_SVM_ATTRIB_PREFETCH_LOCATION: {
         value = Agent::Convert(GetSVMPrefetchAgent(ptr, size)).handle;
-        kmtIndices[i] = -1;
+        driver_indices[i] = -1;
         break;
       }
       case HSA_AMD_SVM_ATTRIB_ACCESS_QUERY: {
         Agent* agent = Convert(value);
         if (agent->device_type() == Agent::kAmdCpuDevice) {
           getFlags = true;
-          kmtIndices[i] = -1;
+          driver_indices[i] = -1;
         } else {
-          kmtIndices[i] = attribs.size();
-          attribs.push_back(kmtPair(HSA_SVM_ATTR_ACCESS, agent->node_id()));
+          driver_indices[i] = attribs.size();
+          attribs.push_back(driver_pair(HSA_SVM_ATTR_ACCESS, agent->node_id()));
         }
         break;
       }
@@ -3157,17 +3158,17 @@ hsa_status_t Runtime::GetSvmAttrib(void* ptr, size_t size,
 
   if (getFlags) {
     // Order is important to later code.
-    attribs.push_back(kmtPair(HSA_SVM_ATTR_CLR_FLAGS, 0));
-    attribs.push_back(kmtPair(HSA_SVM_ATTR_SET_FLAGS, 0));
+    attribs.push_back(driver_pair(HSA_SVM_ATTR_CLR_FLAGS, 0));
+    attribs.push_back(driver_pair(HSA_SVM_ATTR_SET_FLAGS, 0));
   }
 
   uint8_t* base = AlignDown((uint8_t*)ptr, 4096);
   uint8_t* end = AlignUp((uint8_t*)ptr + size, 4096);
   size_t len = end - base;
   if (attribs.size() != 0) {
-    HSAKMT_STATUS error = HSAKMT_CALL(hsaKmtSVMGetAttr(base, len, attribs.size(), &attribs[0]));
-    if (error != HSAKMT_STATUS_SUCCESS)
-      throw AMD::hsa_exception(HSA_STATUS_ERROR, "hsaKmtSVMGetAttr failed.");
+    if (AgentDriver(DriverType::KFD).SVMGetAttr(base, len, attribs.size(), &attribs[0]) !=
+        HSA_STATUS_SUCCESS)
+      throw AMD::hsa_exception(HSA_STATUS_ERROR, "Driver::SVMGetAttr failed.");
   }
 
   for (uint32_t i = 0; i < attribute_count; i++) {
@@ -3195,11 +3196,11 @@ hsa_status_t Runtime::GetSvmAttrib(void* ptr, size_t size,
         break;
       }
       case HSA_AMD_SVM_ATTRIB_MIGRATION_GRANULARITY: {
-        value = attribs[kmtIndices[i]].value;
+        value = attribs[driver_indices[i]].value;
         break;
       }
       case HSA_AMD_SVM_ATTRIB_PREFERRED_LOCATION: {
-        uint64_t node = attribs[kmtIndices[i]].value;
+        uint64_t node = attribs[driver_indices[i]].value;
         Agent* agent = nullptr;
         if (node != INVALID_NODEID) agent = agents_by_node_[node][0];
         value = Agent::Convert(agent).handle;
@@ -3213,11 +3214,11 @@ hsa_status_t Runtime::GetSvmAttrib(void* ptr, size_t size,
         break;
       }
       case HSA_AMD_SVM_ATTRIB_ACCESS_QUERY: {
-        if (kmtIndices[i] == -1) {
+        if (driver_indices[i] == -1) {
           if (attribs[attribs.size() - 1].value & HSA_SVM_FLAG_HOST_ACCESS)
             attrib = HSA_AMD_SVM_ATTRIB_AGENT_ACCESSIBLE;
         } else {
-          switch (attribs[kmtIndices[i]].type) {
+          switch (attribs[driver_indices[i]].type) {
             case HSA_SVM_ATTR_ACCESS:
               attrib = HSA_AMD_SVM_ATTRIB_AGENT_ACCESSIBLE;
               break;
@@ -3352,8 +3353,9 @@ hsa_status_t Runtime::SvmPrefetch(void* ptr, size_t size, hsa_agent_t agent,
     HSA_SVM_ATTRIBUTE attrib;
     attrib.type = HSA_SVM_ATTR_PREFETCH_LOC;
     attrib.value = op->node_id;
-    HSAKMT_STATUS error = HSAKMT_CALL(hsaKmtSVMSetAttr(op->base, op->size, 1, &attrib));
-    assert(error == HSAKMT_STATUS_SUCCESS && "KFD Prefetch failed.");
+    assert(Runtime::runtime_singleton_->AgentDriver(DriverType::KFD)
+                   .SVMSetAttr(op->base, op->size, 1, &attrib) == HSA_STATUS_SUCCESS &&
+           "KFD Prefetch failed.");
 
     removePrefetchRanges(op);
 
@@ -3421,9 +3423,10 @@ Agent* Runtime::GetSVMPrefetchAgent(void* ptr, size_t size) {
   HSA_SVM_ATTRIBUTE attrib;
   attrib.type = HSA_SVM_ATTR_PREFETCH_LOC;
   for (auto& range : holes) {
-    HSAKMT_STATUS error =
-        HSAKMT_CALL(hsaKmtSVMGetAttr(reinterpret_cast<void*>(range.first), range.second, 1, &attrib));
-    assert(error == HSAKMT_STATUS_SUCCESS && "KFD prefetch query failed.");
+    assert(AgentDriver(DriverType::KFD)
+                   .SVMGetAttr(reinterpret_cast<void*>(range.first), range.second, 1, &attrib) ==
+               HSA_STATUS_SUCCESS &&
+           "KFD prefetch query failed.");
 
     if (attrib.value == -1) return nullptr;
     if (prefetch_node == -2) prefetch_node = attrib.value;
@@ -3528,10 +3531,12 @@ hsa_status_t Runtime::VMemoryAddressReserve(void** va, size_t size, uint64_t add
   memFlags.ui32.FixedAddress = 1;
 
   /* Try to reserving the VA requested by user */
-  if (HSAKMT_CALL(hsaKmtAllocMemoryAlign(0, size, alignment, memFlags, &addr)) != HSAKMT_STATUS_SUCCESS) {
+  if (AgentDriver(DriverType::KFD).AllocateMemoryAlign(0, size, alignment, memFlags, &addr) !=
+      HSA_STATUS_SUCCESS) {
     memFlags.ui32.FixedAddress = 0;
     /* Could not reserved VA requested, allocate alternate VA */
-    if (HSAKMT_CALL(hsaKmtAllocMemoryAlign(0, size, alignment, memFlags, &addr)) != HSAKMT_STATUS_SUCCESS)
+    if (AgentDriver(DriverType::KFD).AllocateMemoryAlign(0, size, alignment, memFlags, &addr) !=
+        HSA_STATUS_SUCCESS)
       return HSA_STATUS_ERROR_OUT_OF_RESOURCES;
   }
 
@@ -3554,7 +3559,7 @@ hsa_status_t Runtime::VMemoryAddressFree(void* va, size_t size) {
   if (it->second.use_count > 0) return HSA_STATUS_ERROR_RESOURCE_FREE;
 
   if (it->second.registered) {
-    if (HSAKMT_CALL(hsaKmtFreeMemory(it->second.os_addr, size)) != HSAKMT_STATUS_SUCCESS)
+    if (AgentDriver(DriverType::KFD).FreeMemory(it->second.os_addr, size) != HSA_STATUS_SUCCESS)
       return HSA_STATUS_ERROR;
   }
   else if (!rocr::os::ReleaseMemory(it->second.os_addr, size))
@@ -4065,8 +4070,9 @@ hsa_status_t Runtime::VMemoryImportShareableHandle(int dmabuf_fd,
   };
 
   HsaGraphicsResourceInfo info;
-  int ret = HSAKMT_CALL(hsaKmtRegisterGraphicsHandleToNodes(dmabuf_fd, &info, 0, NULL));
-  if (ret) return HSA_STATUS_ERROR_INCOMPATIBLE_ARGUMENTS;
+  if (AgentDriver(DriverType::KFD).RegisterGraphicsHandleToNodes(dmabuf_fd, &info, 0, NULL) !=
+      HSA_STATUS_SUCCESS)
+    return HSA_STATUS_ERROR_INCOMPATIBLE_ARGUMENTS;
 
   ThunkHandle thunk_handle = info.MemoryAddress;
   size_t size = info.SizeInBytes;
@@ -4086,8 +4092,9 @@ hsa_status_t Runtime::VMemoryImportShareableHandle(int dmabuf_fd,
   if (!region) return HSA_STATUS_ERROR_INVALID_ALLOCATION;
 
   HsaPointerInfo ptrInfo;
-  ret = HSAKMT_CALL(hsaKmtQueryPointerInfo(info.MemoryAddress, &ptrInfo));
-  if (ret != HSA_STATUS_SUCCESS || ptrInfo.Type == HSA_POINTER_UNKNOWN)
+  if (AgentDriver(DriverType::KFD).QueryPointerInfo(info.MemoryAddress, &ptrInfo) !=
+          HSA_STATUS_SUCCESS ||
+      ptrInfo.Type == HSA_POINTER_UNKNOWN)
     return HSA_STATUS_ERROR_INVALID_ALLOCATION;
 
   MemoryRegion::AllocateFlags alloc_flag = core::MemoryRegion::AllocateNoFlags;

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/signal.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/signal.cpp
@@ -326,7 +326,8 @@ uint32_t Signal::WaitMultiple(uint32_t signal_count, const hsa_signal_t* hsa_sig
     uint64_t ct=timer::duration_cast<std::chrono::milliseconds>(
       time_remaining).count();
     wait_ms = (ct>0xFFFFFFFEu) ? 0xFFFFFFFEu : ct;
-    HSAKMT_CALL(hsaKmtWaitOnMultipleEvents_Ext(evts, unique_evts, wait_on_all, wait_ms, event_age));
+    Runtime::runtime_singleton_->AgentDriver(DriverType::KFD)
+        .WaitOnMultipleEvents(evts, unique_evts, wait_on_all, wait_ms, event_age);
   }
 }
 
@@ -434,7 +435,8 @@ uint32_t Signal::WaitAnyExceptions(uint32_t signal_count, const hsa_signal_t* hs
       }
     }
 
-    HSAKMT_CALL(hsaKmtWaitOnMultipleEvents_Ext(evts, unique_evts, false, wait_ms, event_age));
+    Runtime::runtime_singleton_->AgentDriver(DriverType::KFD)
+        .WaitOnMultipleEvents(evts, unique_evts, false, wait_ms, event_age);
   } //while
 }
 

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/thunk_loader.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/thunk_loader.cpp
@@ -3,7 +3,7 @@
 // The University of Illinois/NCSA
 // Open Source License (NCSA)
 //
-// Copyright (c) 2014-2025, Advanced Micro Devices, Inc. All rights reserved.
+// Copyright (c) 2014-2026, Advanced Micro Devices, Inc. All rights reserved.
 //
 // Developed by:
 //
@@ -42,6 +42,7 @@
 
 #include "core/inc/thunk_loader.h"
 #include "core/inc/runtime.h"
+#include "hsakmt/hsakmt.h"
 
 #include <core/util/os.h>
 #include <iostream>

--- a/projects/rocr-runtime/runtime/hsa-runtime/image/image_manager_ai.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/image/image_manager_ai.cpp
@@ -3,7 +3,7 @@
 // The University of Illinois/NCSA
 // Open Source License (NCSA)
 //
-// Copyright (c) 2014-2020, Advanced Micro Devices, Inc. All rights reserved.
+// Copyright (c) 2014-2026, Advanced Micro Devices, Inc. All rights reserved.
 //
 // Developed by:
 //
@@ -48,7 +48,7 @@
 #include <climits>
 
 #include "core/inc/runtime.h"
-#include "hsakmt/hsakmt.h"
+#include "hsakmt/hsakmttypes.h"
 #include "inc/hsa_ext_amd.h"
 #include "core/inc/hsa_internal.h"
 #include "addrlib/src/core/addrlib.h"
@@ -197,7 +197,7 @@ hsa_status_t ImageManagerAi::PopulateImageSrd(Image& image, const metadata_amd_t
       ((SQ_IMG_RSRC_WORD3*)(&image.srd[3]))->bits.TYPE =
           ImageLut().MapGeometry(image.desc.geometry);
     }
-    
+
     // Imported metadata holds the offset to metadata, add the image base address.
     uintptr_t meta = uintptr_t(((SQ_IMG_RSRC_WORD5*)(&image.srd[5]))->bits.META_DATA_ADDRESS_HI) << 40;
     meta |= uintptr_t(((SQ_IMG_RSRC_WORD7*)(&image.srd[7]))->bits.META_DATA_ADDRESS) << 8;
@@ -597,12 +597,11 @@ uint32_t ImageManagerAi::GetAddrlibSurfaceInfoAi(
   prefSettingsInput.resourceType    = in.resourceType;
 
   // Disallow all swizzles but linear.
-  if (tileMode == Image::TileMode::LINEAR) 
-  {
-      prefSettingsInput.forbiddenBlock.macroThin4KB = 1;
-      prefSettingsInput.forbiddenBlock.macroThick4KB = 1;
-      prefSettingsInput.forbiddenBlock.macroThin64KB = 1;
-      prefSettingsInput.forbiddenBlock.macroThick64KB = 1;
+  if (tileMode == Image::TileMode::LINEAR) {
+    prefSettingsInput.forbiddenBlock.macroThin4KB = 1;
+    prefSettingsInput.forbiddenBlock.macroThick4KB = 1;
+    prefSettingsInput.forbiddenBlock.macroThin64KB = 1;
+    prefSettingsInput.forbiddenBlock.macroThick64KB = 1;
   }
 
   prefSettingsInput.forbiddenBlock.micro = 1; // but don't ever allow the 256b swizzle modes
@@ -770,19 +769,19 @@ hsa_status_t ImageManagerAi::PopulateMipmapSrd(MipmappedArray& mipmap) const {
 hsa_status_t ImageManagerAi::PopulateMipmapSrd(MipmappedArray& mipmap_array, const metadata_amd_t* desc) const {
   const metadata_amd_ai_t* desc_ai = reinterpret_cast<const metadata_amd_ai_t*>(desc);
   const void* mipmap_data_addr = mipmap_array.data;
-  
+
   ImageProperty mipmap_prop = ImageLut().MapFormat(mipmap_array.desc.format, mipmap_array.desc.geometry);
   if (mipmap_prop.cap == HSA_EXT_IMAGE_CAPABILITY_NOT_SUPPORTED || mipmap_prop.element_size == 0) {
     return (hsa_status_t)HSA_EXT_STATUS_ERROR_IMAGE_FORMAT_UNSUPPORTED;
   }
-  
+
   const Swizzle swizzle = ImageLut().MapSwizzle(mipmap_array.desc.format.channel_order);
-  
+
   if (IsLocalMemory(mipmap_array.data)) {
     mipmap_data_addr = reinterpret_cast<const void*>(
         reinterpret_cast<uintptr_t>(mipmap_array.data) - local_memory_base_address_);
   }
-  
+
   // Copy the pre-computed SRD words 0-7 from metadata
   mipmap_array.srd[0] = desc_ai->word0.u32All;
   mipmap_array.srd[1] = desc_ai->word1.u32All;
@@ -792,13 +791,13 @@ hsa_status_t ImageManagerAi::PopulateMipmapSrd(MipmappedArray& mipmap_array, con
   mipmap_array.srd[5] = desc_ai->word5.u32All;
   mipmap_array.srd[6] = desc_ai->word6.u32All;
   mipmap_array.srd[7] = desc_ai->word7.u32All;
-  
+
   // Override specific fields after copying
   uint32_t hwPixelSize = ImageLut().GetPixelSize(mipmap_prop.data_format, mipmap_prop.data_type);
   if (mipmap_prop.element_size != hwPixelSize) {
     return (hsa_status_t)HSA_EXT_STATUS_ERROR_IMAGE_FORMAT_UNSUPPORTED;
   }
-  
+
   reinterpret_cast<SQ_IMG_RSRC_WORD0*>(&mipmap_array.srd[0])->bits.BASE_ADDRESS = PtrLow40Shift8(mipmap_data_addr);
   reinterpret_cast<SQ_IMG_RSRC_WORD1*>(&mipmap_array.srd[1])->bits.BASE_ADDRESS_HI = PtrHigh64Shift40(mipmap_data_addr);
   reinterpret_cast<SQ_IMG_RSRC_WORD1*>(&mipmap_array.srd[1])->bits.DATA_FORMAT = mipmap_prop.data_format;
@@ -808,49 +807,48 @@ hsa_status_t ImageManagerAi::PopulateMipmapSrd(MipmappedArray& mipmap_array, con
   reinterpret_cast<SQ_IMG_RSRC_WORD3*>(&mipmap_array.srd[3])->bits.DST_SEL_Z = swizzle.z;
   reinterpret_cast<SQ_IMG_RSRC_WORD3*>(&mipmap_array.srd[3])->bits.DST_SEL_W = swizzle.w;
   reinterpret_cast<SQ_IMG_RSRC_WORD5*>(&mipmap_array.srd[5])->bits.MAX_MIP = mipmap_array.num_levels - 1;
-  
+
   if (mipmap_array.desc.geometry == HSA_EXT_IMAGE_GEOMETRY_1DA ||
       mipmap_array.desc.geometry == HSA_EXT_IMAGE_GEOMETRY_1D) {
     reinterpret_cast<SQ_IMG_RSRC_WORD3*>(&mipmap_array.srd[3])->bits.TYPE =
         ImageLut().MapGeometry(mipmap_array.desc.geometry);
   }
-  
+
   // Looks like this is only used for CPU copies.
   mipmap_array.row_pitch = 0;
   mipmap_array.slice_pitch = 0;
-  
+
   // Store mipmap-specific metadata
   mipmap_array.srd[8] = mipmap_array.desc.format.channel_type;
   mipmap_array.srd[9] = mipmap_array.desc.format.channel_order;
   mipmap_array.srd[10] = static_cast<uint32_t>(mipmap_array.desc.width);
   mipmap_array.srd[11] = mipmap_array.num_levels;
-  
+
   // Allocate and populate pMipInfo from metadata mip_offsets (ADDR2 for Ai/GFX9)
   ADDR2_MIP_INFO* mip_info_storage = new ADDR2_MIP_INFO[mipmap_array.num_levels];
   memset(mip_info_storage, 0, sizeof(ADDR2_MIP_INFO) * mipmap_array.num_levels);
-  
+
   // Extract per-level information from mip_offsets array
   for (uint32_t level = 0; level < mipmap_array.num_levels; level++) {
     // mip_offsets contains offset bits [39:8], shift left by 8 to get actual byte offset
     mip_info_storage[level].offset = static_cast<uint64_t>(desc_ai->mip_offsets[level]) << 8;
-    
+
     // Calculate dimensions for this level (halve at each level)
     mip_info_storage[level].pitch = std::max(1u, static_cast<uint32_t>(mipmap_array.desc.width >> level));
     mip_info_storage[level].height = std::max(1u, static_cast<uint32_t>(mipmap_array.desc.height >> level));
     mip_info_storage[level].depth = std::max(1u, static_cast<uint32_t>(mipmap_array.desc.depth >> level));
   }
-  
+
   // Store pMipInfo in addr_output for later use by PopulateMipLevelSrd
   mipmap_array.addr_output.addr2.pMipInfo = mip_info_storage;
-  
+
   // Total size calculation from metadata
   uint32_t last_level = mipmap_array.num_levels - 1;
-  uint64_t last_level_size = mip_info_storage[last_level].pitch * 
-                             mip_info_storage[last_level].height * 
-                             mip_info_storage[last_level].depth * 
-                             mipmap_prop.element_size;
+  uint64_t last_level_size = mip_info_storage[last_level].pitch *
+      mip_info_storage[last_level].height * mip_info_storage[last_level].depth *
+      mipmap_prop.element_size;
   mipmap_array.size = mip_info_storage[last_level].offset + last_level_size;
-  
+
   return HSA_STATUS_SUCCESS;
 }
 
@@ -876,12 +874,12 @@ void ImageManagerAi::printSRDDetailed(const uint32_t* srd) const {
     }
     printf(")\n");
   }
-        
+
   // WORD 0: BASE_ADDRESS (bits 39:8)
   sq_img_rsrc_word0_u word0;
   word0.val = srd[0];
   printf("\nWORD 0: BASE_ADDRESS (bits 39:8) = 0x%08x\n", word0.f.base_address);
-  
+
   // WORD 1: Contains BASE_ADDRESS_HI, MIN_LOD, DATA_FORMAT, NUM_FORMAT
   sq_img_rsrc_word1_u word1;
   word1.val = srd[1];
@@ -889,18 +887,18 @@ void ImageManagerAi::printSRDDetailed(const uint32_t* srd) const {
   printf("        MIN_LOD                = %u\n", word1.f.min_lod);
   printf("        DATA_FORMAT            = %u\n", word1.f.data_format);
   printf("        NUM_FORMAT             = %u\n", word1.f.num_format);
-  
+
   // Calculate full address (GFX9 uses 40-bit shifted by 8)
   uint64_t base_addr = ((uint64_t)word1.f.base_address_hi << 32) | ((uint64_t)word0.f.base_address << 8);
   printf("        → Full Base Address    = 0x%016lx\n", base_addr);
-  
+
   // WORD 2: WIDTH, HEIGHT, PERF_MOD
   sq_img_rsrc_word2_u word2;
   word2.val = srd[2];
   printf("WORD 2: WIDTH                  = %u (actual: %u)\n", word2.f.width, word2.f.width + 1);
   printf("        HEIGHT                 = %u (actual: %u)\n", word2.f.height, word2.f.height + 1);
   printf("        PERF_MOD               = %u\n", word2.f.perf_mod);
-  
+
   // WORD 3: Channel selectors, SW_MODE, BASE_LEVEL, LAST_LEVEL, TYPE
   sq_img_rsrc_word3_u word3;
   word3.val = srd[3];
@@ -918,14 +916,14 @@ void ImageManagerAi::printSRDDetailed(const uint32_t* srd) const {
   printSwizzleMode(word3.f.sw_mode);
   printf("        TYPE                   = %u ", word3.f.type);
   printResourceType(word3.f.type);
-  
+
   // WORD 4: DEPTH, PITCH, BC_SWIZZLE
   sq_img_rsrc_word4_u word4;
   word4.val = srd[4];
   printf("WORD 4: DEPTH                  = %u\n", word4.f.depth);
   printf("        PITCH                  = %u (actual: %u)\n", word4.f.pitch, word4.f.pitch + 1);
   printf("        BC_SWIZZLE             = %u\n", word4.f.bc_swizzle);
-  
+
   // Calculate effective depth based on geometry
   uint32_t type = word3.f.type;
   if (type == 10) { // 3D
@@ -933,18 +931,18 @@ void ImageManagerAi::printSRDDetailed(const uint32_t* srd) const {
   } else if (type == 13 || type == 12) { // Arrays
     printf("        → Array Size           = %u (actual: %u)\n", word4.f.depth, word4.f.depth + 1);
   }
-  
+
   // WORD 5-7: Usually zero for basic images, but may contain metadata addresses
   printf("WORD 5: META_DATA_ADDRESS_HI   = 0x%08x\n", srd[5]);
   printf("WORD 6: Reserved               = 0x%08x\n", srd[6]);
   printf("WORD 7: META_DATA_ADDRESS      = 0x%08x\n", srd[7]);
-  
+
   // Additional mipmap information
   printf("WORD 8: CHANNEL_TYPE           = 0x%08x\n", srd[8]);
   printf("WORD 9: CHANNEL_ORDER          = 0x%08x\n", srd[9]);
   printf("WORD 10: WIDTH_ORIGINAL        = 0x%08x\n", srd[10]);
   printf("WORD 11: NUM_LEVELS            = 0x%08x\n", srd[11]);
-  
+
   // Mipmap analysis
   if (word3.f.last_level > word3.f.base_level || word3.f.last_level > 0) {
     printf("\nMIPMAP ANALYSIS:\n");

--- a/projects/rocr-runtime/runtime/hsa-runtime/image/image_manager_kv.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/image/image_manager_kv.cpp
@@ -3,7 +3,7 @@
 // The University of Illinois/NCSA
 // Open Source License (NCSA)
 //
-// Copyright (c) 2014-2020, Advanced Micro Devices, Inc. All rights reserved.
+// Copyright (c) 2014-2026, Advanced Micro Devices, Inc. All rights reserved.
 //
 // Developed by:
 //
@@ -48,7 +48,7 @@
 #include <climits>
 
 #include "core/inc/runtime.h"
-#include "hsakmt/hsakmt.h"
+#include "hsakmt/hsakmttypes.h"
 #include "inc/hsa_ext_amd.h"
 #include "core/inc/hsa_internal.h"
 #include "core/inc/hsa_ext_amd_impl.h"
@@ -752,12 +752,12 @@ void ImageManagerKv::printSRDDetailed(const uint32_t* srd) const {
     }
     printf(")\n");
   }
-        
+
   // WORD 0: BASE_ADDRESS (bits 39:8)
   SQ_IMG_RSRC_WORD0 word0;
   word0.u32_all = srd[0];
   printf("\nWORD 0: BASE_ADDRESS (bits 39:8) = 0x%08x\n", word0.bits.base_address);
-  
+
   // WORD 1: Contains BASE_ADDRESS_HI, MIN_LOD, DATA_FORMAT, NUM_FORMAT, MTYPE
   SQ_IMG_RSRC_WORD1 word1;
   word1.u32_all = srd[1];
@@ -766,11 +766,11 @@ void ImageManagerKv::printSRDDetailed(const uint32_t* srd) const {
   printf("        DATA_FORMAT            = %u\n", word1.bits.data_format);
   printf("        NUM_FORMAT             = %u\n", word1.bits.num_format);
   printf("        MTYPE                  = %u\n", word1.bits.mtype);
-  
+
   // Calculate full address (KV uses 40-bit shifted by 8)
   uint64_t base_addr = ((uint64_t)word1.bits.base_address_hi << 40) | ((uint64_t)word0.bits.base_address << 8);
   printf("        → Full Base Address    = 0x%016lx\n", base_addr);
-  
+
   // WORD 2: WIDTH, HEIGHT, PERF_MOD, INTERLACED
   SQ_IMG_RSRC_WORD2 word2;
   word2.u32_all = srd[2];
@@ -778,7 +778,7 @@ void ImageManagerKv::printSRDDetailed(const uint32_t* srd) const {
   printf("        HEIGHT                 = %u (actual: %u)\n", word2.bits.height, word2.bits.height + 1);
   printf("        PERF_MOD               = %u\n", word2.bits.perf_mod);
   printf("        INTERLACED             = %u\n", word2.bits.interlaced);
-  
+
   // WORD 3: Channel selectors, TILING_INDEX, POW2_PAD, TYPE, ATC
   SQ_IMG_RSRC_WORD3 word3;
   word3.u32_all = srd[3];
@@ -795,13 +795,13 @@ void ImageManagerKv::printSRDDetailed(const uint32_t* srd) const {
   printf("        TYPE                   = %u ", word3.bits.type);
   printResourceType(word3.bits.type);
   printf("        ATC                    = %u ◄──── Address translation cache\n", word3.bits.atc);
-  
+
   // WORD 4: DEPTH, PITCH
   SQ_IMG_RSRC_WORD4 word4;
   word4.u32_all = srd[4];
   printf("WORD 4: DEPTH                  = %u\n", word4.bits.depth);
   printf("        PITCH                  = %u (actual: %u)\n", word4.bits.pitch, word4.bits.pitch + 1);
-  
+
   // Calculate effective depth/pitch based on geometry
   uint32_t type = word3.bits.type;
   if (type == 10) { // 3D
@@ -809,22 +809,22 @@ void ImageManagerKv::printSRDDetailed(const uint32_t* srd) const {
   } else if (type == 13 || type == 12) { // Arrays
     printf("        → Array Size           = %u (actual: %u)\n", word4.bits.depth, word4.bits.depth + 1);
   }
-  
+
   // WORD 5: LAST_ARRAY
   SQ_IMG_RSRC_WORD5 word5;
   word5.u32_all = srd[5];
   printf("WORD 5: LAST_ARRAY             = %u ◄──── Last array slice\n", word5.bits.last_array);
-  
+
   // WORD 6-7: Usually zero for basic images
   printf("WORD 6: Reserved               = 0x%08x\n", srd[6]);
   printf("WORD 7: Reserved               = 0x%08x\n", srd[7]);
-  
+
   // Additional information (HSA extension fields)
   printf("WORD 8: CHANNEL_TYPE           = 0x%08x\n", srd[8]);
   printf("WORD 9: CHANNEL_ORDER          = 0x%08x\n", srd[9]);
   printf("WORD 10: WIDTH_ORIGINAL        = 0x%08x\n", srd[10]);
   printf("WORD 11: NUM_LEVELS            = 0x%08x\n", srd[11]);
-  
+
   // Mipmap analysis (KV architecture limitations)
   printf("\nMIPMAP ANALYSIS:\n");
   printf("        Total Levels           = %u\n", srd[11]);

--- a/projects/rocr-runtime/runtime/hsa-runtime/libamdhsacode/lnx/amd_core_dump.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/libamdhsacode/lnx/amd_core_dump.cpp
@@ -3,7 +3,7 @@
 // The University of Illinois/NCSA
 // Open Source License (NCSA)
 //
-// Copyright (c) 2023-2025, Advanced Micro Devices, Inc. All rights reserved.
+// Copyright (c) 2023-2026, Advanced Micro Devices, Inc. All rights reserved.
 //
 // Developed by:
 //
@@ -60,7 +60,7 @@
 #include "core/inc/agent.h"
 #include "./amd_hsa_code_util.hpp"
 #include "core/inc/amd_core_dump.hpp"
-#include "hsakmt/hsakmt.h"
+#include "hsakmt/hsakmttypes.h"
 #include "core/inc/amd_gpu_agent.h"
 #include "core/inc/amd_aql_queue.h"
 
@@ -264,7 +264,7 @@ public:
   struct AddressRange {
     uint64_t start;
     uint64_t end;
-    
+
     bool contains(uint64_t addr, uint64_t size) const {
       uint64_t addr_end = addr + size;
         // Check if the segment overlaps with this range
@@ -281,7 +281,7 @@ public:
       if (it->second.contains(addr, size)) {
         return true;
       }
-    }     
+    }
     return false;
   }
 
@@ -316,14 +316,14 @@ static hsa_status_t build_lightweight_coredump_ranges(MemoryRegionFilter& filter
   for(const core::Agent* agent : gpu_agents) {
     const AMD::GpuAgent* gpu_agent = static_cast<const AMD::GpuAgent*>(agent);
 
-    // Add scratch memory range for this agent by getting the 
+    // Add scratch memory range for this agent by getting the
     // size and base_address from agent's scratch_pool_
     void* scratch_base = nullptr;
     size_t scratch_size = 0;
     gpu_agent->GetScratchAperture(&scratch_base, &scratch_size);
 
     if (scratch_base && scratch_size > 0) {
-      // Filter will hold all of the reserved address range, even if unused 
+      // Filter will hold all of the reserved address range, even if unused
       filter.add_scratch_range(reinterpret_cast<uint64_t>(scratch_base), scratch_size);
       debug_print("Added scratch range: 0x%lx - 0x%lx (size: %zu)\n",
                   reinterpret_cast<uint64_t>(scratch_base),
@@ -369,15 +369,19 @@ struct NoteSegmentBuilder : public SegmentBuilder {
     uint32_t runtime_size, agents_size, queue_size, n_entries, entry_size;
     HsaVersionInfo versionInfo = {0};
 
-    if (HSAKMT_CALL(hsaKmtDbgEnable(&runtime_ptr, &runtime_size))) {
+    if (rocr::core::Runtime::runtime_singleton_->AgentDriver(rocr::core::DriverType::KFD)
+            .DbgEnable(&runtime_ptr, &runtime_size) != HSA_STATUS_SUCCESS) {
       fprintf(stderr, "Failed to enable debug interface, "
               "debugger might be already attached.\n");
       return HSA_STATUS_ERROR;
     }
     std::unique_ptr<void, decltype(std::free) *> runtime_info(runtime_ptr, std::free);
 
-    if (HSAKMT_CALL(hsaKmtGetVersion(&versionInfo))) {
-      HSAKMT_CALL(hsaKmtDbgDisable());
+    versionInfo =
+        rocr::core::Runtime::runtime_singleton_->AgentDriver(rocr::core::DriverType::KFD).Version();
+    if (versionInfo.KernelInterfaceMajorVersion == std::numeric_limits<uint32_t>::max()) {
+      rocr::core::Runtime::runtime_singleton_->AgentDriver(rocr::core::DriverType::KFD)
+          .DbgDisable();
       fprintf(stderr, "Failed to fetch driver ABI version.\n");
       return HSA_STATUS_ERROR;
     }
@@ -390,10 +394,12 @@ struct NoteSegmentBuilder : public SegmentBuilder {
     /* Store runtime_info_size in PT_NOTE package */
     note_package_builder_.Write<uint64_t>(runtime_size);
 
-    if (HSAKMT_CALL(hsaKmtDbgGetDeviceData(&agents_ptr, &n_entries, &entry_size))) {
-       HSAKMT_CALL(hsaKmtDbgDisable());
-       fprintf(stderr, "Failed to fetch agents snapshot.\n");
-       return HSA_STATUS_ERROR;
+    if (rocr::core::Runtime::runtime_singleton_->AgentDriver(rocr::core::DriverType::KFD)
+            .DbgGetDeviceData(&agents_ptr, &n_entries, &entry_size) != HSA_STATUS_SUCCESS) {
+      rocr::core::Runtime::runtime_singleton_->AgentDriver(rocr::core::DriverType::KFD)
+          .DbgDisable();
+      fprintf(stderr, "Failed to fetch agents snapshot.\n");
+      return HSA_STATUS_ERROR;
     }
     agents_size = n_entries * entry_size;
     std::unique_ptr<void, decltype(std::free) *> agents_info(agents_ptr, std::free);
@@ -402,10 +408,12 @@ struct NoteSegmentBuilder : public SegmentBuilder {
     /* Store agent_info_entry_size in PT_NOTE package */
     note_package_builder_.Write<uint32_t>(entry_size);
 
-    if (HSAKMT_CALL(hsaKmtDbgGetQueueData(&queues_ptr, &n_entries, &entry_size, true))) {
-       HSAKMT_CALL(hsaKmtDbgDisable());
-       fprintf(stderr, "Failed to fetch queues snapshot.\n");
-       return HSA_STATUS_ERROR;
+    if (rocr::core::Runtime::runtime_singleton_->AgentDriver(rocr::core::DriverType::KFD)
+            .DbgGetQueueData(&queues_ptr, &n_entries, &entry_size, true) != HSA_STATUS_SUCCESS) {
+      rocr::core::Runtime::runtime_singleton_->AgentDriver(rocr::core::DriverType::KFD)
+          .DbgDisable();
+      fprintf(stderr, "Failed to fetch queues snapshot.\n");
+      return HSA_STATUS_ERROR;
     }
     queue_size = n_entries * entry_size;
     std::unique_ptr<void, decltype(std::free) *> queues_info(queues_ptr, std::free);
@@ -417,7 +425,8 @@ struct NoteSegmentBuilder : public SegmentBuilder {
     PushInfo(runtime_info.get(), runtime_size);
     PushInfo(agents_info.get(), agents_size);
     PushInfo(queues_info.get(), queue_size);
-    if (HSAKMT_CALL(hsaKmtDbgDisable())) {
+    if (rocr::core::Runtime::runtime_singleton_->AgentDriver(rocr::core::DriverType::KFD)
+            .DbgDisable() != HSA_STATUS_SUCCESS) {
       fprintf(stderr, "Failed to disable debug interface.\n");
       return HSA_STATUS_ERROR;
     }
@@ -483,7 +492,7 @@ struct LoadSegmentBuilder : public SegmentBuilder {
         return status;
       }
     }
-    
+
     const std::string maps_path = "/proc/self/maps";
     std::ifstream maps(maps_path);
     if (!maps.is_open()) {

--- a/projects/rocr-runtime/runtime/hsa-runtime/pcs/pcs_runtime.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/pcs/pcs_runtime.cpp
@@ -3,7 +3,7 @@
 // The University of Illinois/NCSA
 // Open Source License (NCSA)
 //
-// Copyright (c) 2023, Advanced Micro Devices, Inc. All rights reserved.
+// Copyright (c) 2023-2026, Advanced Micro Devices, Inc. All rights reserved.
 //
 // Developed by:
 //
@@ -138,7 +138,7 @@ PcsRuntime::PcSamplingSession::PcSamplingSession(
   data_rdy.buf2_sz = 0;
 }
 
-void PcsRuntime::PcSamplingSession::GetHsaKmtSamplingInfo(HsaPcSamplingInfo* sampleInfo) {
+void PcsRuntime::PcSamplingSession::GetDriverSamplingInfo(HsaPcSamplingInfo* sampleInfo) {
   sampleInfo->value_min = 0;
   sampleInfo->value_max = 0;
   sampleInfo->flags = 0;

--- a/projects/rocr-runtime/runtime/hsa-runtime/pcs/pcs_runtime.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/pcs/pcs_runtime.h
@@ -3,7 +3,7 @@
 // The University of Illinois/NCSA
 // Open Source License (NCSA)
 //
-// Copyright (c) 2014-2020, Advanced Micro Devices, Inc. All rights reserved.
+// Copyright (c) 2014-2026, Advanced Micro Devices, Inc. All rights reserved.
 //
 // Developed by:
 //
@@ -47,7 +47,7 @@
 #include <map>
 #include <mutex>
 
-#include "hsakmt/hsakmt.h"
+#include "hsakmt/hsakmttypes.h"
 
 #include "hsa_ven_amd_pc_sampling.h"
 #include "core/inc/agent.h"
@@ -85,7 +85,7 @@ class PcsRuntime {
     size_t latency() const { return csd.latency; }
     size_t sample_size() const { return sample_size_; }
 
-    void GetHsaKmtSamplingInfo(HsaPcSamplingInfo* sampleInfo);
+    void GetDriverSamplingInfo(HsaPcSamplingInfo* sampleInfo);
     hsa_status_t HandleSampleData(uint8_t* buf1, size_t buf1_sz, uint8_t* buf2, size_t buf2_sz,
                                   size_t lost_sample_count);
     hsa_status_t DataCopyCallback(uint8_t* buffer, size_t buffer_size);


### PR DESCRIPTION
Removes all remaining usage of the libhsakmt API from core driver objects and isolates it to the KfdDriver implementations.

## Motivation

Removes direct usage of hsakmt in favor of core::Driver API to generalize the runtime and
allow for future deprecation of the hsakmt API in favor of core::Driver.

## Technical Details

Migrated calls to hsakmt to the relevant KFD/VirtIO drivers.

## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan

Ran rocrtst

## Test Result

Passed

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
