### PR TITLE
[ROCM-2950] Improve virtualization detection

### DIFF
--- a/projects/amdsmi/CHANGELOG.md
+++ b/projects/amdsmi/CHANGELOG.md
@@ -220,6 +220,9 @@ Full documentation for amd_smi_lib is available at [https://rocm.docs.amd.com/pr
 - **Fixed shared mutex and self-heal**.  
   - Improved self-heal logic to correctly identify and recover from corrupted or uninitialized mutex state.
 
+- **Fixed virtualization detection utilities when libDRM version < 3.62.0**.  
+  - Enables `amdsmi_get_gpu_virtualization_mode()` to work when libDRM is outdated, improving virtualization detection reliability.
+
 - **Fixed `cu_occupancy` displaying `0%` instead of `N/A` when file is unavailable**.  
   - Process `cu_occupancy` is now initialized to `INVALID` instead of zero, so `amd-smi process` displays `N/A` rather than a misleading `0%` when the sysfs file is not accessible.
 

--- a/projects/amdsmi/CHANGELOG.md
+++ b/projects/amdsmi/CHANGELOG.md
@@ -34,6 +34,9 @@ Full documentation for amd_smi_lib is available at [https://rocm.docs.amd.com/pr
 
 ### Resolved Issues
 
+- **Fixed virtualization detection utilities when libDRM version < 3.62.0**.  
+  - Enables `amdsmi_get_gpu_virtualization_mode()` to work when libDRM is outdated, improving virtualization detection reliability.
+
 - **Fixed `amdsmi_get_gpu_cper_entries()` crash (`free(): invalid pointer` / `SIGABRT`) when the CPER node reports zero bytes**.  
   - debugfs CPER nodes (`/sys/kernel/debug/dri/<N>/amdgpu_ring_cper`) report `st_size == 0` because their content is generated on read. The previous `std::ifstream`-based read allocated a zero-byte buffer and left an STL `basic_filebuf` whose destructor could perform an invalid free across the library boundary when `libamd_smi.so` is `LD_PRELOAD`-ed alongside a different host libstdc++ (the device-metrics-exporter / `gpuagent` scenario), aborting the process and zeroing all GPU metrics.
   - Reverted the CPER file read to POSIX `open`/`read`/`close`, which performs no STL allocation across the library boundary and returns `AMDSMI_STATUS_FILE_ERROR` cleanly on zero-byte or short reads. The file descriptor is now closed on every exit path, also fixing a latent fd leak on the short-read branch.
@@ -219,9 +222,6 @@ Full documentation for amd_smi_lib is available at [https://rocm.docs.amd.com/pr
 
 - **Fixed shared mutex and self-heal**.  
   - Improved self-heal logic to correctly identify and recover from corrupted or uninitialized mutex state.
-
-- **Fixed virtualization detection utilities when libDRM version < 3.62.0**.  
-  - Enables `amdsmi_get_gpu_virtualization_mode()` to work when libDRM is outdated, improving virtualization detection reliability.
 
 - **Fixed `cu_occupancy` displaying `0%` instead of `N/A` when file is unavailable**.  
   - Process `cu_occupancy` is now initialized to `INVALID` instead of zero, so `amd-smi process` displays `N/A` rather than a misleading `0%` when the sysfs file is not accessible.

--- a/projects/amdsmi/CHANGELOG.md
+++ b/projects/amdsmi/CHANGELOG.md
@@ -4,6 +4,13 @@ Full documentation for amd_smi_lib is available at [https://rocm.docs.amd.com/pr
 
 ***All information listed below is for reference and subject to change.***
 
+## amd_smi_lib for ROCm 7.14.0
+
+### Resolved Issues
+
+- **Fixed virtualization detection utilities when libDRM version < 3.62.0**.  
+  - Enables `amdsmi_get_gpu_virtualization_mode()` to work when libDRM is outdated, improving virtualization detection reliability.
+
 ## amd_smi_lib for ROCm 7.13.0
 
 ### Changed
@@ -114,9 +121,6 @@ Full documentation for amd_smi_lib is available at [https://rocm.docs.amd.com/pr
 
 - **Fixed shared mutex and self-heal**.  
   - Improved self-heal logic to correctly identify and recover from corrupted or uninitialized mutex state.
-
-- **Fixed virtualization detection utilities when libDRM version < 3.62.0**.  
-  - Enables `amdsmi_get_gpu_virtualization_mode()` to work when libDRM is outdated, improving virtualization detection reliability.
 
 - **Fixed `cu_occupancy` displaying `0%` instead of `N/A` when file is unavailable**.  
   - Process `cu_occupancy` is now initialized to `INVALID` instead of zero, so `amd-smi process` displays `N/A` rather than a misleading `0%` when the sysfs file is not accessible.

--- a/projects/amdsmi/CHANGELOG.md
+++ b/projects/amdsmi/CHANGELOG.md
@@ -115,6 +115,9 @@ Full documentation for amd_smi_lib is available at [https://rocm.docs.amd.com/pr
 - **Fixed shared mutex and self-heal**.  
   - Improved self-heal logic to correctly identify and recover from corrupted or uninitialized mutex state.
 
+- **Fixed virtualization detection utilities when libDRM version < 3.62.0**.  
+  - Enables `amdsmi_get_gpu_virtualization_mode()` to work when libDRM is outdated, improving virtualization detection reliability.
+
 - **Fixed `cu_occupancy` displaying `0%` instead of `N/A` when file is unavailable**.  
   - Process `cu_occupancy` is now initialized to `INVALID` instead of zero, so `amd-smi process` displays `N/A` rather than a misleading `0%` when the sysfs file is not accessible.
 

--- a/projects/amdsmi/rocm_smi/include/rocm_smi/rocm_smi_utils.h
+++ b/projects/amdsmi/rocm_smi/include/rocm_smi/rocm_smi_utils.h
@@ -55,7 +55,15 @@
 #endif
 
 namespace amd::smi {
+constexpr uint32_t kSMI_MAX_STRING_LENGTH = 256;  // matches AMDSMI_MAX_STRING_LENGTH
 
+struct VirtModeDetectionResult {
+  bool is_vm_guest = false;       // hypervisor flag in /proc/cpuinfo
+  bool is_container = false;      // running inside docker/lxc/podman container
+  bool has_active_vfs = false;    // VFs are provisioned (sriov_numvfs > 0) -> indicates HOST
+  bool is_vfio_bound = false;     // device bound to vfio-pci driver -> passthrough candidate
+  bool sysfs_accessible = false;  // device sysfs path accessible
+};
 pthread_mutex_t* GetMutex(uint32_t dv_ind);
 int SameFile(const std::string fileA, const std::string fileB);
 bool FileExists(char const* filename);
@@ -110,6 +118,12 @@ std::string print_rsmi_od_volt_freq_regions(uint32_t num_regions, rsmi_freq_volt
 bool is_sudo_user();
 rsmi_status_t rsmi_get_gfx_target_version(uint32_t dv_ind, std::string* gfx_version);
 rsmi_status_t rsmi_dev_number_of_computes_get(uint32_t dv_ind, uint32_t* num_computes);
+
+VirtModeDetectionResult detect_virtualization_mode_sysfs(const std::string& render_path);
+
+inline auto contains(std::string_view text, std::string_view substr) -> bool {
+  return text.find(substr) != std::string_view::npos;
+}
 
 std::string leftTrim(const std::string& s);
 std::string rightTrim(const std::string& s);

--- a/projects/amdsmi/rocm_smi/include/rocm_smi/rocm_smi_utils.h
+++ b/projects/amdsmi/rocm_smi/include/rocm_smi/rocm_smi_utils.h
@@ -55,7 +55,6 @@
 #endif
 
 namespace amd::smi {
-constexpr uint32_t kSMI_MAX_STRING_LENGTH = 256;  // matches AMDSMI_MAX_STRING_LENGTH
 
 struct VirtModeDetectionResult {
   bool is_vm_guest = false;       // hypervisor flag in /proc/cpuinfo

--- a/projects/amdsmi/rocm_smi/include/rocm_smi/rocm_smi_utils.h
+++ b/projects/amdsmi/rocm_smi/include/rocm_smi/rocm_smi_utils.h
@@ -120,10 +120,6 @@ rsmi_status_t rsmi_dev_number_of_computes_get(uint32_t dv_ind, uint32_t* num_com
 
 VirtModeDetectionResult detect_virtualization_mode_sysfs(const std::string& render_path);
 
-inline auto contains(std::string_view text, std::string_view substr) -> bool {
-  return text.find(substr) != std::string_view::npos;
-}
-
 std::string leftTrim(const std::string& s);
 std::string rightTrim(const std::string& s);
 std::string trim(const std::string& s);

--- a/projects/amdsmi/rocm_smi/include/rocm_smi/rocm_smi_utils.h
+++ b/projects/amdsmi/rocm_smi/include/rocm_smi/rocm_smi_utils.h
@@ -55,7 +55,15 @@
 #endif
 
 namespace amd::smi {
+constexpr uint32_t kSMI_MAX_STRING_LENGTH = 256;  // matches AMDSMI_MAX_STRING_LENGTH
 
+struct VirtModeDetectionResult {
+  bool is_vm_guest = false;       // hypervisor flag in /proc/cpuinfo
+  bool is_container = false;      // running inside docker/lxc/podman container
+  bool has_active_vfs = false;    // VFs are provisioned (sriov_numvfs > 0) -> indicates HOST
+  bool is_vfio_bound = false;     // device bound to vfio-pci driver -> passthrough candidate
+  bool sysfs_accessible = false;  // device sysfs path accessible
+};
 pthread_mutex_t* GetMutex(uint32_t dv_ind);
 int SameFile(const std::string fileA, const std::string fileB);
 bool FileExists(char const* filename);
@@ -111,6 +119,12 @@ std::string print_rsmi_od_volt_freq_regions(uint32_t num_regions, rsmi_freq_volt
 bool is_sudo_user();
 rsmi_status_t rsmi_get_gfx_target_version(uint32_t dv_ind, std::string* gfx_version);
 rsmi_status_t rsmi_dev_number_of_computes_get(uint32_t dv_ind, uint32_t* num_computes);
+
+VirtModeDetectionResult detect_virtualization_mode_sysfs(const std::string& render_path);
+
+inline auto contains(std::string_view text, std::string_view substr) -> bool {
+  return text.find(substr) != std::string_view::npos;
+}
 
 std::string leftTrim(const std::string& s);
 std::string rightTrim(const std::string& s);

--- a/projects/amdsmi/rocm_smi/src/rocm_smi_utils.cc
+++ b/projects/amdsmi/rocm_smi/src/rocm_smi_utils.cc
@@ -39,6 +39,7 @@
 #include <cstdint>
 #include <cstring>
 #include <ctime>
+#include <filesystem>
 #include <fstream>
 #include <iomanip>
 #include <iostream>
@@ -1512,33 +1513,21 @@ bool is_device_vfio_bound(const std::string& pci_sysfs_path) {
   // Virtualization detection indicators
   constexpr std::string_view kVFIO_PCI = "vfio-pci";
 
-  constexpr size_t kMAX_DRIVER_SYMLINK_LEN = 1024;  // Linux kernel limits symlink targets to
-                                                    // 4096 bytes (on most filesystems)
-                                                    // Size (sweet spot): ~512-1024 bytes
-
   std::string driver_link = pci_sysfs_path + "/driver";
-  char buf[kMAX_DRIVER_SYMLINK_LEN];
+  std::error_code ec;
+  auto target = std::filesystem::read_symlink(driver_link, ec);
+  if (ec) {
+    return false;
+  }
 
-  ssize_t len = readlink(driver_link.c_str(), buf, sizeof(buf) - 1);
-  if (len > 0) {
-    // Reject if readlink truncated the data
-    if (static_cast<std::size_t>(len) >= (sizeof(buf) - 1)) {
-      ss << __PRETTY_FUNCTION__ << " | [WARNING] Driver path truncated (len=" << len
-         << "), cannot reliably detect vfio-pci (passthrough)";
-      LOG_WARN(ss);
-      return false;
-    }
+  std::string driver = target.string();
+  ss << __PRETTY_FUNCTION__ << " | Device driver: " << driver;
+  LOG_DEBUG(ss);
 
-    buf[len] = '\0';
-    std::string driver(buf);
-    ss << __PRETTY_FUNCTION__ << " | Device driver: " << driver;
-    LOG_DEBUG(ss);
-
-    if (amd::smi::contains(driver, kVFIO_PCI)) {
-      ss << __PRETTY_FUNCTION__ << " | Device bound to vfio-pci (passthrough)";
-      LOG_INFO(ss);
-      return true;
-    }
+  if (amd::smi::contains(driver, kVFIO_PCI)) {
+    ss << __PRETTY_FUNCTION__ << " | Device bound to vfio-pci (passthrough)";
+    LOG_INFO(ss);
+    return true;
   }
   return false;
 }

--- a/projects/amdsmi/rocm_smi/src/rocm_smi_utils.cc
+++ b/projects/amdsmi/rocm_smi/src/rocm_smi_utils.cc
@@ -1446,6 +1446,184 @@ uint64_t get_multiplier_from_char(char units_char) {
   return multiplier;
 }
 
+// Check if running inside a container (Docker, LXC, Podman, etc.)
+// This is important because container environments can give false positives
+// for VM detection since they may not have access to all sysfs paths
+bool is_running_in_container() {
+  std::ostringstream ss;
+
+  // Container detection indicators
+  constexpr std::string_view kDOCKER_ENV_PATH = "/.dockerenv";
+  constexpr std::string_view kCONTAINER_ENV_PATH = "/run/.containerenv";
+  constexpr std::string_view kCGROUP_PATH = "/proc/1/cgroup";
+  constexpr std::string_view kCONTAINER_ENV_VAR = "container";
+
+  constexpr std::string_view kDOCKER = "docker";
+  constexpr std::string_view kLXC = "lxc";
+  constexpr std::string_view kKUBEPODS = "kubepods";
+  constexpr std::string_view kCONTAINERD = "containerd";
+  constexpr std::string_view kPODMAN = "podman";
+
+  // Check for Docker
+  if (FileExists(kDOCKER_ENV_PATH.data())) {
+    ss << __PRETTY_FUNCTION__ << " | Detected Docker container (/.dockerenv exists)";
+    LOG_DEBUG(ss);
+    return true;
+  }
+
+  // Check for Podman/other container runtimes
+  if (FileExists(kCONTAINER_ENV_PATH.data())) {
+    ss << __PRETTY_FUNCTION__ << " | Detected container (/run/.containerenv exists)";
+    LOG_DEBUG(ss);
+    return true;
+  }
+
+  // Check cgroup for container indicators
+  std::ifstream cgroup_file(kCGROUP_PATH.data());
+  if (cgroup_file.is_open()) {
+    std::string line;
+    while (std::getline(cgroup_file, line)) {
+      if (amd::smi::contains(line, kDOCKER) || amd::smi::contains(line, kLXC) ||
+          amd::smi::contains(line, kKUBEPODS) || amd::smi::contains(line, kCONTAINERD) ||
+          amd::smi::contains(line, kPODMAN)) {
+        ss << __PRETTY_FUNCTION__ << " | Detected container via cgroup: " << line;
+        LOG_DEBUG(ss);
+        return true;
+      }
+    }
+  }
+
+  // Check for container environment variables (less reliable but useful)
+  const char* container_env = std::getenv(kCONTAINER_ENV_VAR.data());
+  if (container_env != nullptr) {
+    ss << __PRETTY_FUNCTION__ << " | Detected container via $container env var: " << container_env;
+    LOG_DEBUG(ss);
+    return true;
+  }
+
+  return false;
+}
+
+// Check if device is bound to vfio-pci driver (passthrough indicator)
+// pci_sysfs_path should be like "/sys/class/drm/renderD128/device"
+bool is_device_vfio_bound(const std::string& pci_sysfs_path) {
+  std::ostringstream ss;
+
+  // Virtualization detection indicators
+  constexpr std::string_view kVFIO_PCI = "vfio-pci";
+
+  constexpr size_t kMAX_DRIVER_SYMLINK_LEN = 1024;  // Linux kernel limits symlink targets to
+                                                    // 4096 bytes (on most filesystems)
+                                                    // Size (sweet spot): ~512-1024 bytes
+
+  std::string driver_link = pci_sysfs_path + "/driver";
+  char buf[kMAX_DRIVER_SYMLINK_LEN];
+
+  ssize_t len = readlink(driver_link.c_str(), buf, sizeof(buf) - 1);
+  if (len > 0) {
+    // Reject if readlink truncated the data
+    if (static_cast<std::size_t>(len) >= (sizeof(buf) - 1)) {
+      ss << __PRETTY_FUNCTION__ << " | [WARNING] Driver path truncated (len=" << len
+         << "), cannot reliably detect vfio-pci (passthrough)";
+      LOG_WARN(ss);
+      return false;
+    }
+
+    buf[len] = '\0';
+    std::string driver(buf);
+    ss << __PRETTY_FUNCTION__ << " | Device driver: " << driver;
+    LOG_DEBUG(ss);
+
+    if (amd::smi::contains(driver, kVFIO_PCI)) {
+      ss << __PRETTY_FUNCTION__ << " | Device bound to vfio-pci (passthrough)";
+      LOG_INFO(ss);
+      return true;
+    }
+  }
+  return false;
+}
+
+// Check SR-IOV status for a device
+// pci_sysfs_path should be like "/sys/class/drm/renderD128/device"
+// Returns: True if device has active VFs (HOST mode), false otherwise
+//
+// Note: A device may support SR-IOV (sriov_totalvfs > 0)
+// but have no active VFs (sriov_numvfs = 0) if not in HOST mode
+// Example of this is partitions in BM mode - they support SR-IOV but will not
+// have active VFs since they are not in HOST mode
+bool get_sriov_status(const std::string& pci_sysfs_path) {
+  std::ostringstream ss;
+  [[maybe_unused]] bool has_capability = false;  // if device supports SR-IOV (sriov_totalvfs > 0)
+  bool has_active_vfs = false;                   // only true in HOST mode (sriov_numvfs > 0)
+
+  // Check for SR-IOV total VFs (capability)
+  std::string sriov_total_path = pci_sysfs_path + "/sriov_totalvfs";
+  std::ifstream total_file(sriov_total_path);
+  if (total_file.is_open()) {
+    int total_vfs = 0;
+    total_file >> total_vfs;
+    total_file.close();
+
+    if (total_vfs > 0) {
+      has_capability = true;
+      ss << __PRETTY_FUNCTION__ << " | sriov_totalvfs (" << sriov_total_path << ") = " << total_vfs;
+      LOG_DEBUG(ss);
+    }
+  }
+
+  // Check for active VFs (indicates HOST mode)
+  std::string sriov_num_path = pci_sysfs_path + "/sriov_numvfs";
+  std::ifstream num_file(sriov_num_path);
+  if (num_file.is_open()) {
+    int num_vfs = 0;
+    num_file >> num_vfs;
+    num_file.close();
+
+    if (num_vfs > 0) {
+      has_active_vfs = true;
+      ss << __PRETTY_FUNCTION__ << " | sriov_numvfs (" << sriov_num_path << ") = " << num_vfs
+         << " (HOST mode)";
+      LOG_INFO(ss);
+    }
+  }
+
+  return has_active_vfs;
+}
+
+// Comprehensive virtualization mode detection via sysfs (no root required)
+// render_path: the render node name, e.g., "renderD128"
+// Returns VirtModeDetectionResult
+VirtModeDetectionResult detect_virtualization_mode_sysfs(const std::string& render_path) {
+  std::ostringstream ss;
+  VirtModeDetectionResult result{};
+  result.is_vm_guest = is_vm_guest();
+  result.is_container = is_running_in_container();
+
+  // If render_path is empty, we can only provide VM/container info
+  if (render_path.empty()) {
+    ss << __PRETTY_FUNCTION__ << " | render_path is empty, cannot check sysfs";
+    LOG_INFO(ss);
+    return result;
+  }
+
+  // Build the PCI device sysfs path
+  std::string pci_sysfs_path = "/sys/class/drm/" + render_path + "/device";
+
+  // Check if we can access sysfs at all (for container awareness)
+  struct stat st;
+  if (stat(pci_sysfs_path.c_str(), &st) == 0) {
+    result.sysfs_accessible = true;
+  }
+
+  // Check SR-IOV HOST status
+  result.has_active_vfs = get_sriov_status(pci_sysfs_path);
+
+  // Check if device is bound to vfio-pci (passthrough indicator)
+  result.is_vfio_bound = is_device_vfio_bound(pci_sysfs_path);
+
+  return result;
+}
+
 uint64_t bdfid_from_domain(uint64_t bdfid, uint64_t domain) {
   assert((domain & 0xFFFFFFFF00000000) == 0);
   (bdfid) &= 0xFFFFFFFF;                 // keep bottom 32 bits of pci_id

--- a/projects/amdsmi/rocm_smi/src/rocm_smi_utils.cc
+++ b/projects/amdsmi/rocm_smi/src/rocm_smi_utils.cc
@@ -1454,39 +1454,39 @@ bool is_running_in_container() {
   std::ostringstream ss;
 
   // Container detection indicators
-  constexpr std::string_view kDOCKER_ENV_PATH = "/.dockerenv";
-  constexpr std::string_view kCONTAINER_ENV_PATH = "/run/.containerenv";
-  constexpr std::string_view kCGROUP_PATH = "/proc/1/cgroup";
-  constexpr std::string_view kCONTAINER_ENV_VAR = "container";
+  const std::string kDOCKER_ENV_PATH = "/.dockerenv";
+  const std::string kCONTAINER_ENV_PATH = "/run/.containerenv";
+  const std::string kCGROUP_PATH = "/proc/1/cgroup";
+  const std::string kCONTAINER_ENV_VAR = "container";
 
-  constexpr std::string_view kDOCKER = "docker";
-  constexpr std::string_view kLXC = "lxc";
-  constexpr std::string_view kKUBEPODS = "kubepods";
-  constexpr std::string_view kCONTAINERD = "containerd";
-  constexpr std::string_view kPODMAN = "podman";
+  const std::string kDOCKER = "docker";
+  const std::string kLXC = "lxc";
+  const std::string kKUBEPODS = "kubepods";
+  const std::string kCONTAINERD = "containerd";
+  const std::string kPODMAN = "podman";
 
   // Check for Docker
-  if (FileExists(kDOCKER_ENV_PATH.data())) {
+  if (FileExists(kDOCKER_ENV_PATH.c_str())) {
     ss << __PRETTY_FUNCTION__ << " | Detected Docker container (/.dockerenv exists)";
     LOG_DEBUG(ss);
     return true;
   }
 
   // Check for Podman/other container runtimes
-  if (FileExists(kCONTAINER_ENV_PATH.data())) {
+  if (FileExists(kCONTAINER_ENV_PATH.c_str())) {
     ss << __PRETTY_FUNCTION__ << " | Detected container (/run/.containerenv exists)";
     LOG_DEBUG(ss);
     return true;
   }
 
   // Check cgroup for container indicators
-  std::ifstream cgroup_file(kCGROUP_PATH.data());
+  std::ifstream cgroup_file(kCGROUP_PATH);
   if (cgroup_file.is_open()) {
     std::string line;
     while (std::getline(cgroup_file, line)) {
-      if (amd::smi::contains(line, kDOCKER) || amd::smi::contains(line, kLXC) ||
-          amd::smi::contains(line, kKUBEPODS) || amd::smi::contains(line, kCONTAINERD) ||
-          amd::smi::contains(line, kPODMAN)) {
+      if (containsString(line, kDOCKER) || containsString(line, kLXC) ||
+          containsString(line, kKUBEPODS) || containsString(line, kCONTAINERD) ||
+          containsString(line, kPODMAN)) {
         ss << __PRETTY_FUNCTION__ << " | Detected container via cgroup: " << line;
         LOG_DEBUG(ss);
         return true;
@@ -1495,7 +1495,7 @@ bool is_running_in_container() {
   }
 
   // Check for container environment variables (less reliable but useful)
-  const char* container_env = std::getenv(kCONTAINER_ENV_VAR.data());
+  const char* container_env = std::getenv(kCONTAINER_ENV_VAR.c_str());
   if (container_env != nullptr) {
     ss << __PRETTY_FUNCTION__ << " | Detected container via $container env var: " << container_env;
     LOG_DEBUG(ss);
@@ -1511,7 +1511,7 @@ bool is_device_vfio_bound(const std::string& pci_sysfs_path) {
   std::ostringstream ss;
 
   // Virtualization detection indicators
-  constexpr std::string_view kVFIO_PCI = "vfio-pci";
+  const std::string kVFIO_PCI = "vfio-pci";
 
   std::string driver_link = pci_sysfs_path + "/driver";
   std::error_code ec;
@@ -1524,7 +1524,7 @@ bool is_device_vfio_bound(const std::string& pci_sysfs_path) {
   ss << __PRETTY_FUNCTION__ << " | Device driver: " << driver;
   LOG_DEBUG(ss);
 
-  if (amd::smi::contains(driver, kVFIO_PCI)) {
+  if (containsString(driver, kVFIO_PCI)) {
     ss << __PRETTY_FUNCTION__ << " | Device bound to vfio-pci (passthrough)";
     LOG_INFO(ss);
     return true;

--- a/projects/amdsmi/rocm_smi/src/rocm_smi_utils.cc
+++ b/projects/amdsmi/rocm_smi/src/rocm_smi_utils.cc
@@ -1462,6 +1462,184 @@ uint64_t get_multiplier_from_char(char units_char) {
   return multiplier;
 }
 
+// Check if running inside a container (Docker, LXC, Podman, etc.)
+// This is important because container environments can give false positives
+// for VM detection since they may not have access to all sysfs paths
+bool is_running_in_container() {
+  std::ostringstream ss;
+
+  // Container detection indicators
+  constexpr std::string_view kDOCKER_ENV_PATH = "/.dockerenv";
+  constexpr std::string_view kCONTAINER_ENV_PATH = "/run/.containerenv";
+  constexpr std::string_view kCGROUP_PATH = "/proc/1/cgroup";
+  constexpr std::string_view kCONTAINER_ENV_VAR = "container";
+
+  constexpr std::string_view kDOCKER = "docker";
+  constexpr std::string_view kLXC = "lxc";
+  constexpr std::string_view kKUBEPODS = "kubepods";
+  constexpr std::string_view kCONTAINERD = "containerd";
+  constexpr std::string_view kPODMAN = "podman";
+
+  // Check for Docker
+  if (FileExists(kDOCKER_ENV_PATH.data())) {
+    ss << __PRETTY_FUNCTION__ << " | Detected Docker container (/.dockerenv exists)";
+    LOG_DEBUG(ss);
+    return true;
+  }
+
+  // Check for Podman/other container runtimes
+  if (FileExists(kCONTAINER_ENV_PATH.data())) {
+    ss << __PRETTY_FUNCTION__ << " | Detected container (/run/.containerenv exists)";
+    LOG_DEBUG(ss);
+    return true;
+  }
+
+  // Check cgroup for container indicators
+  std::ifstream cgroup_file(kCGROUP_PATH.data());
+  if (cgroup_file.is_open()) {
+    std::string line;
+    while (std::getline(cgroup_file, line)) {
+      if (amd::smi::contains(line, kDOCKER) || amd::smi::contains(line, kLXC) ||
+          amd::smi::contains(line, kKUBEPODS) || amd::smi::contains(line, kCONTAINERD) ||
+          amd::smi::contains(line, kPODMAN)) {
+        ss << __PRETTY_FUNCTION__ << " | Detected container via cgroup: " << line;
+        LOG_DEBUG(ss);
+        return true;
+      }
+    }
+  }
+
+  // Check for container environment variables (less reliable but useful)
+  const char* container_env = std::getenv(kCONTAINER_ENV_VAR.data());
+  if (container_env != nullptr) {
+    ss << __PRETTY_FUNCTION__ << " | Detected container via $container env var: " << container_env;
+    LOG_DEBUG(ss);
+    return true;
+  }
+
+  return false;
+}
+
+// Check if device is bound to vfio-pci driver (passthrough indicator)
+// pci_sysfs_path should be like "/sys/class/drm/renderD128/device"
+bool is_device_vfio_bound(const std::string& pci_sysfs_path) {
+  std::ostringstream ss;
+
+  // Virtualization detection indicators
+  constexpr std::string_view kVFIO_PCI = "vfio-pci";
+
+  constexpr size_t kMAX_DRIVER_SYMLINK_LEN = 1024;  // Linux kernel limits symlink targets to
+                                                    // 4096 bytes (on most filesystems)
+                                                    // Size (sweet spot): ~512-1024 bytes
+
+  std::string driver_link = pci_sysfs_path + "/driver";
+  char buf[kMAX_DRIVER_SYMLINK_LEN];
+
+  ssize_t len = readlink(driver_link.c_str(), buf, sizeof(buf) - 1);
+  if (len > 0) {
+    // Reject if readlink truncated the data
+    if (static_cast<std::size_t>(len) >= (sizeof(buf) - 1)) {
+      ss << __PRETTY_FUNCTION__ << " | [WARNING] Driver path truncated (len=" << len
+         << "), cannot reliably detect vfio-pci (passthrough)";
+      LOG_WARN(ss);
+      return false;
+    }
+
+    buf[len] = '\0';
+    std::string driver(buf);
+    ss << __PRETTY_FUNCTION__ << " | Device driver: " << driver;
+    LOG_DEBUG(ss);
+
+    if (amd::smi::contains(driver, kVFIO_PCI)) {
+      ss << __PRETTY_FUNCTION__ << " | Device bound to vfio-pci (passthrough)";
+      LOG_INFO(ss);
+      return true;
+    }
+  }
+  return false;
+}
+
+// Check SR-IOV status for a device
+// pci_sysfs_path should be like "/sys/class/drm/renderD128/device"
+// Returns: True if device has active VFs (HOST mode), false otherwise
+//
+// Note: A device may support SR-IOV (sriov_totalvfs > 0)
+// but have no active VFs (sriov_numvfs = 0) if not in HOST mode
+// Example of this is partitions in BM mode - they support SR-IOV but will not
+// have active VFs since they are not in HOST mode
+bool get_sriov_status(const std::string& pci_sysfs_path) {
+  std::ostringstream ss;
+  [[maybe_unused]] bool has_capability = false;  // if device supports SR-IOV (sriov_totalvfs > 0)
+  bool has_active_vfs = false;                   // only true in HOST mode (sriov_numvfs > 0)
+
+  // Check for SR-IOV total VFs (capability)
+  std::string sriov_total_path = pci_sysfs_path + "/sriov_totalvfs";
+  std::ifstream total_file(sriov_total_path);
+  if (total_file.is_open()) {
+    int total_vfs = 0;
+    total_file >> total_vfs;
+    total_file.close();
+
+    if (total_vfs > 0) {
+      has_capability = true;
+      ss << __PRETTY_FUNCTION__ << " | sriov_totalvfs (" << sriov_total_path << ") = " << total_vfs;
+      LOG_DEBUG(ss);
+    }
+  }
+
+  // Check for active VFs (indicates HOST mode)
+  std::string sriov_num_path = pci_sysfs_path + "/sriov_numvfs";
+  std::ifstream num_file(sriov_num_path);
+  if (num_file.is_open()) {
+    int num_vfs = 0;
+    num_file >> num_vfs;
+    num_file.close();
+
+    if (num_vfs > 0) {
+      has_active_vfs = true;
+      ss << __PRETTY_FUNCTION__ << " | sriov_numvfs (" << sriov_num_path << ") = " << num_vfs
+         << " (HOST mode)";
+      LOG_INFO(ss);
+    }
+  }
+
+  return has_active_vfs;
+}
+
+// Comprehensive virtualization mode detection via sysfs (no root required)
+// render_path: the render node name, e.g., "renderD128"
+// Returns VirtModeDetectionResult
+VirtModeDetectionResult detect_virtualization_mode_sysfs(const std::string& render_path) {
+  std::ostringstream ss;
+  VirtModeDetectionResult result{};
+  result.is_vm_guest = is_vm_guest();
+  result.is_container = is_running_in_container();
+
+  // If render_path is empty, we can only provide VM/container info
+  if (render_path.empty()) {
+    ss << __PRETTY_FUNCTION__ << " | render_path is empty, cannot check sysfs";
+    LOG_INFO(ss);
+    return result;
+  }
+
+  // Build the PCI device sysfs path
+  std::string pci_sysfs_path = "/sys/class/drm/" + render_path + "/device";
+
+  // Check if we can access sysfs at all (for container awareness)
+  struct stat st;
+  if (stat(pci_sysfs_path.c_str(), &st) == 0) {
+    result.sysfs_accessible = true;
+  }
+
+  // Check SR-IOV HOST status
+  result.has_active_vfs = get_sriov_status(pci_sysfs_path);
+
+  // Check if device is bound to vfio-pci (passthrough indicator)
+  result.is_vfio_bound = is_device_vfio_bound(pci_sysfs_path);
+
+  return result;
+}
+
 uint64_t bdfid_from_domain(uint64_t bdfid, uint64_t domain) {
   assert((domain & 0xFFFFFFFF00000000) == 0);
   (bdfid) &= 0xFFFFFFFF;                 // keep bottom 32 bits of pci_id

--- a/projects/amdsmi/src/amd_smi/amd_smi.cc
+++ b/projects/amdsmi/src/amd_smi/amd_smi.cc
@@ -5818,6 +5818,48 @@ amdsmi_status_t amdsmi_get_gpu_virtualization_mode(amdsmi_processor_handle proce
   amdsmi_status_t status;
   SMIGPUDEVICE_MUTEX(gpu_device->get_mutex())
 
+  auto get_virt_mode_fallback = [&ss, gpu_device](
+                                    const std::string& render_name,
+                                    amdsmi_virtualization_mode_t* mode) -> amdsmi_status_t {
+    std::string render_name_local;
+    if (render_name.empty()) {
+      render_name_local = "renderD" + std::to_string(gpu_device->get_drm_render_minor());
+    } else {
+      render_name_local = render_name;
+    }
+    auto result = amd::smi::detect_virtualization_mode_sysfs(render_name_local);
+
+    ss << __PRETTY_FUNCTION__ << " | sysfs fallback detection"
+       << " | render_path: " << (render_name_local.empty() ? "<empty>" : render_name_local)
+       << " | (HOST) has_active_vfs: " << std::boolalpha << result.has_active_vfs
+       << " | (PASSTHROUGH) is_vfio_bound: " << std::boolalpha << result.is_vfio_bound
+       << " | is_vm_guest: " << std::boolalpha << result.is_vm_guest
+       << " | is_container: " << std::boolalpha << result.is_container
+       << " | sysfs_accessible: " << std::boolalpha << result.sysfs_accessible;
+    LOG_INFO(ss);
+
+    if (result.has_active_vfs) {
+      // Device has active VFs = HOST mode
+      *mode = AMDSMI_VIRTUALIZATION_MODE_HOST;
+    } else if (result.is_vfio_bound) {
+      // Device bound to vfio-pci = PASSTHROUGH mode
+      // Note: In nested virtualization (VM within VM), this reports the device's
+      // operational mode (PASSTHROUGH) rather than system context (GUEST).
+      // This aligns with DRM driver reporting and reflects device capabilities.
+      *mode = AMDSMI_VIRTUALIZATION_MODE_PASSTHROUGH;
+    } else if (result.is_vm_guest) {
+      // hypervisor flag = GUEST (containers inherit this correctly)
+      *mode = AMDSMI_VIRTUALIZATION_MODE_GUEST;
+    } else if (!result.is_vm_guest) {
+      // Not VM, safe to say BAREMETAL
+      *mode = AMDSMI_VIRTUALIZATION_MODE_BAREMETAL;
+    } else {
+      // Can't determine reliably, return UNKNOWN
+      *mode = AMDSMI_VIRTUALIZATION_MODE_UNKNOWN;
+    }
+    return AMDSMI_STATUS_SUCCESS;
+  };
+
   std::string render_name = gpu_device->get_gpu_path();
   std::string path = "/dev/dri/" + render_name;
   if (render_name.empty()) {
@@ -5888,7 +5930,7 @@ amdsmi_status_t amdsmi_get_gpu_virtualization_mode(amdsmi_processor_handle proce
      << "\n"
      << "; Returning: "
      << (isDRMVersionSupported ? smi_amdgpu_get_status_string(AMDSMI_STATUS_SUCCESS, false)
-                               : smi_amdgpu_get_status_string(AMDSMI_STATUS_NOT_SUPPORTED, false));
+                               : "Need to use fallback method");
   LOG_INFO(ss);
 
   // Check if the version is supported
@@ -5896,7 +5938,7 @@ amdsmi_status_t amdsmi_get_gpu_virtualization_mode(amdsmi_processor_handle proce
   if (isDRMVersionSupported == false) {
     drm_free_version(drm_version);
     libdrm.unload();
-    return AMDSMI_STATUS_NOT_SUPPORTED;
+    return get_virt_mode_fallback(render_name, mode);
   }
 
   // Get the device info

--- a/projects/amdsmi/src/amd_smi/amd_smi.cc
+++ b/projects/amdsmi/src/amd_smi/amd_smi.cc
@@ -5850,11 +5850,13 @@ amdsmi_status_t amdsmi_get_gpu_virtualization_mode(amdsmi_processor_handle proce
     } else if (result.is_vm_guest) {
       // hypervisor flag = GUEST (containers inherit this correctly)
       *mode = AMDSMI_VIRTUALIZATION_MODE_GUEST;
-    } else if (!result.is_vm_guest) {
-      // Not VM, safe to say BAREMETAL
+    } else if (result.sysfs_accessible) {
+      // sysfs was readable and showed no active VFs, no vfio-pci binding, and
+      // no hypervisor flag = BAREMETAL
       *mode = AMDSMI_VIRTUALIZATION_MODE_BAREMETAL;
     } else {
-      // Can't determine reliably, return UNKNOWN
+      // sysfs was not accessible and there is no hypervisor flag, so HOST,
+      // PASSTHROUGH, and BAREMETAL cannot be distinguished = UNKNOWN
       *mode = AMDSMI_VIRTUALIZATION_MODE_UNKNOWN;
     }
     return AMDSMI_STATUS_SUCCESS;

--- a/projects/amdsmi/src/amd_smi/amd_smi.cc
+++ b/projects/amdsmi/src/amd_smi/amd_smi.cc
@@ -46,6 +46,7 @@
 #include <set>
 #include <sstream>
 #include <string>
+#include <tuple>
 #include <vector>
 
 #include "amd_smi/amdsmi.h"
@@ -5920,11 +5921,12 @@ amdsmi_status_t amdsmi_get_gpu_virtualization_mode(amdsmi_processor_handle proce
   int major_version = 3;
   int minor_version = 62;
   int patch_version = 0;
-  bool isDRMVersionSupported = false;
-  ((drm_version->version_major >= major_version) && (drm_version->version_minor >= minor_version) &&
-           (drm_version->version_patchlevel >= patch_version)
-       ? isDRMVersionSupported = true
-       : isDRMVersionSupported = false);
+  // Lexicographic compare so that e.g. 4.0.0 >= 3.62.0 (major dominates, then
+  // minor, then patch) rather than requiring every component to independently
+  // meet or exceed the minimum.
+  bool isDRMVersionSupported = std::tie(drm_version->version_major, drm_version->version_minor,
+                                        drm_version->version_patchlevel) >=
+                               std::tie(major_version, minor_version, patch_version);
   ss << __PRETTY_FUNCTION__ << " | drm_version: " << std::dec << drm_version->version_major << "."
      << drm_version->version_minor << "." << drm_version->version_patchlevel << "\n"
      << " | isDRMVersionSupported: " << (isDRMVersionSupported ? "TRUE" : "FALSE") << "\n"

--- a/projects/amdsmi/src/amd_smi/amd_smi.cc
+++ b/projects/amdsmi/src/amd_smi/amd_smi.cc
@@ -5893,6 +5893,48 @@ amdsmi_status_t amdsmi_get_gpu_virtualization_mode(amdsmi_processor_handle proce
   amdsmi_status_t status;
   SMIGPUDEVICE_MUTEX(gpu_device->get_mutex())
 
+  auto get_virt_mode_fallback = [&ss, gpu_device](
+                                    const std::string& render_name,
+                                    amdsmi_virtualization_mode_t* mode) -> amdsmi_status_t {
+    std::string render_name_local;
+    if (render_name.empty()) {
+      render_name_local = "renderD" + std::to_string(gpu_device->get_drm_render_minor());
+    } else {
+      render_name_local = render_name;
+    }
+    auto result = amd::smi::detect_virtualization_mode_sysfs(render_name_local);
+
+    ss << __PRETTY_FUNCTION__ << " | sysfs fallback detection"
+       << " | render_path: " << (render_name_local.empty() ? "<empty>" : render_name_local)
+       << " | (HOST) has_active_vfs: " << std::boolalpha << result.has_active_vfs
+       << " | (PASSTHROUGH) is_vfio_bound: " << std::boolalpha << result.is_vfio_bound
+       << " | is_vm_guest: " << std::boolalpha << result.is_vm_guest
+       << " | is_container: " << std::boolalpha << result.is_container
+       << " | sysfs_accessible: " << std::boolalpha << result.sysfs_accessible;
+    LOG_INFO(ss);
+
+    if (result.has_active_vfs) {
+      // Device has active VFs = HOST mode
+      *mode = AMDSMI_VIRTUALIZATION_MODE_HOST;
+    } else if (result.is_vfio_bound) {
+      // Device bound to vfio-pci = PASSTHROUGH mode
+      // Note: In nested virtualization (VM within VM), this reports the device's
+      // operational mode (PASSTHROUGH) rather than system context (GUEST).
+      // This aligns with DRM driver reporting and reflects device capabilities.
+      *mode = AMDSMI_VIRTUALIZATION_MODE_PASSTHROUGH;
+    } else if (result.is_vm_guest) {
+      // hypervisor flag = GUEST (containers inherit this correctly)
+      *mode = AMDSMI_VIRTUALIZATION_MODE_GUEST;
+    } else if (!result.is_vm_guest) {
+      // Not VM, safe to say BAREMETAL
+      *mode = AMDSMI_VIRTUALIZATION_MODE_BAREMETAL;
+    } else {
+      // Can't determine reliably, return UNKNOWN
+      *mode = AMDSMI_VIRTUALIZATION_MODE_UNKNOWN;
+    }
+    return AMDSMI_STATUS_SUCCESS;
+  };
+
   std::string render_name = gpu_device->get_gpu_path();
   std::string path = "/dev/dri/" + render_name;
   if (render_name.empty()) {
@@ -5963,7 +6005,7 @@ amdsmi_status_t amdsmi_get_gpu_virtualization_mode(amdsmi_processor_handle proce
      << "\n"
      << "; Returning: "
      << (isDRMVersionSupported ? smi_amdgpu_get_status_string(AMDSMI_STATUS_SUCCESS, false)
-                               : smi_amdgpu_get_status_string(AMDSMI_STATUS_NOT_SUPPORTED, false));
+                               : "Need to use fallback method");
   LOG_INFO(ss);
 
   // Check if the version is supported
@@ -5971,7 +6013,7 @@ amdsmi_status_t amdsmi_get_gpu_virtualization_mode(amdsmi_processor_handle proce
   if (isDRMVersionSupported == false) {
     drm_free_version(drm_version);
     libdrm.unload();
-    return AMDSMI_STATUS_NOT_SUPPORTED;
+    return get_virt_mode_fallback(render_name, mode);
   }
 
   // Get the device info


### PR DESCRIPTION
## Motivation

Follow up from #2987 

This PR ( #3595 ) was divided into 3 others (4 total w/ this one):
1. #5630 
2. #5631  
3. #5632  

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## JIRA ID

ROCM-2950

## Test Plan

- Verify virtualization detection utilities when libDRM version < 3.62.0
- Verify `rsmi_dev_device_identifiers_get()` (direct indexing + bounds check):
  original functionality should still work
- Verify `amd-smi` default command alignment
- Verify board manufacturer string normalization for AMD vendor ID (0x1002)

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
