### PR TITLE
[AICOMRCCL-667] rccl: Change GDR selection logic.

### DIFF
--- a/projects/rccl/CHANGELOG.md
+++ b/projects/rccl/CHANGELOG.md
@@ -13,6 +13,7 @@ Full documentation for RCCL is available at [https://rccl.readthedocs.io](https:
 * Compatibility with NCCL 2.28.3.
 * The MSCCL feature is now disabled by default. The `--disable-msccl-kernel` build flag is replaced with `--enable-msccl-kernel` in the `rccl/install.sh` script.
 * MSCCL and NPKIT are deprecated and will be removed in a future release of RCCL.
+* Changed GPU Direct RDMA mode selection logic to prefer peermem over DMAbuf by default. `NCCL_DMABUF_ENABLE` now defaults to 1 (previously 0). When both peermem and DMAbuf are available, RCCL will use peermem. If peermem is unavailable, RCCL will automatically fall back to DMAbuf (if available and enabled). Setting `RCCL_FORCE_ENABLE_DMABUF=1` forces DMAbuf usage exclusively, skipping peermem even if available, and disables GPU Direct RDMA if DMAbuf is unavailable.
 
 ### Resolved Issues
 * Fixed MSCCLPP_ENABLE_CLIP CMake build flag, which was not being properly honored.

--- a/projects/rccl/ext-src/rocm_netib.patch
+++ b/projects/rccl/ext-src/rocm_netib.patch
@@ -1,7 +1,5 @@
-diff --git a/src/transport/net_ib.cc b/src/transport/net_ib.cc
-index 9bfd8dcf..4d3f0a08 100644
---- a/src/transport/net_ib.cc
-+++ b/src/transport/net_ib.cc
+--- a/src/transport/net_ib.cc	2026-02-28 15:31:50.589749118 -0500
++++ b/src/transport/net_ib.cc	2026-02-28 15:31:50.591749108 -0500
 @@ -29,6 +29,7 @@
  
  #include "ibvwrap.h"
@@ -10,7 +8,7 @@ index 9bfd8dcf..4d3f0a08 100644
  #include "graph/xml.h"
  
  #define MAXSUFFIXSIZE 16
-@@ -110,16 +111,38 @@ struct ncclIbMergedDev ncclIbMergedDevs[MAX_IB_VDEVS];
+@@ -110,6 +111,26 @@
  struct ncclIbDev ncclIbDevs[MAX_IB_DEVS];
  static std::mutex ncclIbMutex;
  static int ncclIbRelaxedOrderingEnabled = 0;
@@ -37,10 +35,7 @@ index 9bfd8dcf..4d3f0a08 100644
  
  // With ncclNet_v11_t the NCCL core initializes the network plugin per-communicator
  // rather than once for all communicators. However, the internal plugin implementation
- // still assumes the plugin is initialized only once across all communicators. The ref
- // counter makes sure the plugin internally initializes only once. When per communicator
- // context support is added to the plugin the ref counter can be removed.
- static int netRefCount;
+@@ -120,6 +141,8 @@
  
  #define NCCL_IB_LLSTR(ll) (((ll) == IBV_LINK_LAYER_INFINIBAND) ? "IB" : (((ll) == IBV_LINK_LAYER_ETHERNET) ? "RoCE" : "UNSPECIFIED"))
  
@@ -49,7 +44,7 @@ index 9bfd8dcf..4d3f0a08 100644
  #define NCCL_IB_SL_DEFAULT 0
  #define NCCL_IB_TC_DEFAULT 0
  
-@@ -141,6 +164,13 @@ NCCL_PARAM(IbEceEnable,"IB_ECE_ENABLE",1);
+@@ -141,6 +164,13 @@
  NCCL_PARAM(IbDataDirect,"IB_DATA_DIRECT",1);
  NCCL_PARAM(IbQpsPerConn, "IB_QPS_PER_CONNECTION", 1);
  RCCL_PARAM(IbQpsPerP2p, "IB_QPS_PER_P2P", 0);
@@ -63,7 +58,7 @@ index 9bfd8dcf..4d3f0a08 100644
  
  static ncclResult_t ncclIbStatsInit(struct ncclIbStats* stat) {
    __atomic_store_n(&stat->fatalErrorCount, 0, __ATOMIC_RELAXED);
-@@ -779,6 +809,10 @@ ncclResult_t ncclIbInit(void** ctx, uint64_t commId, ncclNetCommConfig_t* config
+@@ -779,6 +809,10 @@
    static int shownIbHcaEnv = 0;
    if(wrap_ibv_symbols() != ncclSuccess) { return ncclInternalError; }
    if(wrap_mlx5dv_symbols() != ncclSuccess) { INFO(NCCL_NET, "NET/IB : Failed to open mlx5dv symbols. Advance features like CX-8 Direct-NIC will be disabled."); }
@@ -74,7 +69,7 @@ index 9bfd8dcf..4d3f0a08 100644
  
    // Detect IB cards
    int nIbDevs = 0;
-@@ -944,6 +978,37 @@ ncclResult_t ncclIbInit(void** ctx, uint64_t commId, ncclNetCommConfig_t* config
+@@ -944,6 +978,37 @@
      INFO(NCCL_INIT|NCCL_NET, "NET/IB : Using%s %s; OOB %s:%s", line, ncclIbRelaxedOrderingEnabled ? "[RO]" : "",
            ncclIbIfName, ncclSocketToString(&ncclIbIfAddr, addrline));
  
@@ -112,7 +107,7 @@ index 9bfd8dcf..4d3f0a08 100644
    }
  exit:
    ibContext.trafficClass = config->trafficClass;
-@@ -1271,6 +1336,8 @@ struct ncclIbListenComm {
+@@ -1271,6 +1336,8 @@
    struct ncclIbCommStage stage;
  };
  
@@ -121,7 +116,7 @@ index 9bfd8dcf..4d3f0a08 100644
  struct alignas(64) ncclIbSendFifo {
    uint64_t addr;
    uint64_t size;
-@@ -1281,10 +1348,21 @@ struct alignas(64) ncclIbSendFifo {
+@@ -1281,10 +1348,21 @@
    char padding[16];
  };
  
@@ -143,7 +138,7 @@ index 9bfd8dcf..4d3f0a08 100644
  };
  
  struct ncclIbRemSizesFifo {
-@@ -1331,6 +1409,7 @@ struct ncclIbSendComm {
+@@ -1331,6 +1409,7 @@
    struct ncclIbNetCommBase base;
    // Start with fifo and ibv structs as they have alignment restrictions
    struct ncclIbSendFifo fifo[MAX_REQUESTS][NCCL_NET_IB_MAX_RECVS];
@@ -151,7 +146,7 @@ index 9bfd8dcf..4d3f0a08 100644
    struct ibv_sge sges[NCCL_NET_IB_MAX_RECVS];
    struct ibv_send_wr wrs[NCCL_NET_IB_MAX_RECVS + 1];
    // Each dev correlates to a mergedIbDev
-@@ -1346,6 +1425,7 @@ struct ncclIbSendComm {
+@@ -1346,6 +1425,7 @@
  static_assert((sizeof(struct ncclIbNetCommBase) % 32) == 0, "ncclIbNetCommBase size must be 32-byte multiple to ensure fifo is at proper offset");
  static_assert((offsetof(struct ncclIbSendComm, fifo) % 32) == 0, "ncclIbSendComm fifo must be 32-byte aligned");
  static_assert((sizeof(struct ncclIbSendFifo) % 32) == 0, "ncclIbSendFifo element size must be 32-byte multiples");
@@ -159,7 +154,7 @@ index 9bfd8dcf..4d3f0a08 100644
  static_assert((offsetof(struct ncclIbSendComm, sges) % 32) == 0, "sges must be 32-byte aligned");
  static_assert((offsetof(struct ncclIbSendComm, wrs) % 32) == 0, "wrs must be 32-byte aligned");
  
-@@ -1360,6 +1440,7 @@ struct ncclIbGpuFlush {
+@@ -1360,6 +1440,7 @@
  
  struct ncclIbRemFifo {
    struct ncclIbSendFifo elems[MAX_REQUESTS][NCCL_NET_IB_MAX_RECVS];
@@ -167,7 +162,7 @@ index 9bfd8dcf..4d3f0a08 100644
    uint64_t fifoTail;
    uint64_t addr;
    uint32_t flags;
-@@ -1415,20 +1496,59 @@ ncclResult_t ncclIbDestroyBase(struct ncclIbNetCommDevBase* base) {
+@@ -1415,20 +1496,59 @@
    return ncclSuccess;
  }
  
@@ -229,7 +224,7 @@ index 9bfd8dcf..4d3f0a08 100644
    struct ibv_qp_attr qpAttr;
    memset(&qpAttr, 0, sizeof(struct ibv_qp_attr));
    qpAttr.qp_state = IBV_QPS_INIT;
-@@ -1438,6 +1558,9 @@ ncclResult_t ncclIbCreateQp(uint8_t ib_port, struct ncclIbNetCommDevBase* base,
+@@ -1438,6 +1558,9 @@
    NCCLCHECK(wrap_ibv_modify_qp(qp->qp, &qpAttr, IBV_QP_STATE | IBV_QP_PKEY_INDEX | IBV_QP_PORT | IBV_QP_ACCESS_FLAGS));
    TRACE(NCCL_NET, "NET/IB : ncclIbCreateQp port=%d dev=%d devName=%s ndevs=%d nmdevs=%d qpn=%u pkey=%u pd=%p",
      ib_port, base->ibDevN, ncclIbDevs[base->ibDevN].devName, ncclNIbDevs, ncclNMergedIbDevs, qp->qp->qp_num, qpAttr.pkey_index, base->pd);
@@ -239,7 +234,7 @@ index 9bfd8dcf..4d3f0a08 100644
    return ncclSuccess;
  }
  
-@@ -1521,7 +1644,7 @@ fail:
+@@ -1521,7 +1644,7 @@
    goto exit;
  }
  
@@ -248,7 +243,7 @@ index 9bfd8dcf..4d3f0a08 100644
    ncclResult_t ret = ncclSuccess;
    struct ncclIbHandle* handle = (struct ncclIbHandle*) opaqueHandle;
    struct ncclIbCommStage* stage = &handle->stage;
-@@ -1529,8 +1652,13 @@ ncclResult_t ncclIbConnect(void* ctx, int dev, void* opaqueHandle, void** sendCo
+@@ -1529,8 +1652,13 @@
    int ready;
    uint8_t link_layer = IBV_LINK_LAYER_UNSPECIFIED;
    int isP2p = 0; 
@@ -262,7 +257,7 @@ index 9bfd8dcf..4d3f0a08 100644
    if (stage->state == ncclIbCommStateConnect)      goto ib_connect_check;
    if (stage->state == ncclIbCommStateSendDevList)  goto ib_send_dev_list;
    if (stage->state == ncclIbCommStateRecvDevList)  goto ib_recv_dev_list;
-@@ -1612,7 +1740,7 @@ ib_recv_dev_list:
+@@ -1612,7 +1740,7 @@
    for (int q = 0; q < comm->base.nqps; q++) {
      ncclIbSendCommDev* commDev = comm->devs + devIndex;
      ncclIbDev* ibDev = ncclIbDevs + commDev->base.ibDevN;
@@ -271,7 +266,7 @@ index 9bfd8dcf..4d3f0a08 100644
      comm->base.qps[q].devIndex = devIndex;
      meta.qpInfo[q].qpn      = comm->base.qps[q].qp->qp_num;
      meta.qpInfo[q].devIndex = comm->base.qps[q].devIndex;
-@@ -1637,7 +1765,11 @@ ib_recv_dev_list:
+@@ -1637,7 +1765,11 @@
      devInfo->lid           = ibDev->portAttr.lid;
      devInfo->ibv_dev_index = commDev->base.ibDevN;
      // Prepare my fifo
@@ -284,7 +279,7 @@ index 9bfd8dcf..4d3f0a08 100644
      devInfo->fifoRkey = commDev->fifoMr->rkey;
  
      // Pack local GID info
-@@ -1680,7 +1812,11 @@ ib_recv_dev_list:
+@@ -1680,7 +1812,11 @@
      }
    }
    config = (ncclNetCommConfig_t*)ctx;
@@ -297,7 +292,7 @@ index 9bfd8dcf..4d3f0a08 100644
    meta.sl = (ncclParamIbSl() != -1) ? ncclParamIbSl() : (config && config->trafficClass != NCCL_NET_TRAFFIC_CLASS_UNDEF) ? config->trafficClass : NCCL_IB_SL_DEFAULT;
    meta.tc = (ncclParamIbTc() != -1) ? ncclParamIbTc() : (config && config->trafficClass != NCCL_NET_TRAFFIC_CLASS_UNDEF) ? config->trafficClass : NCCL_IB_TC_DEFAULT;
    strncpy(meta.devName, mergedDev->devName, MAX_MERGED_DEV_NAME);
-@@ -1825,18 +1961,22 @@ ncclResult_t ncclIbCheckVProps(ncclNetVDeviceProps_t* vProps1, ncclNetVDevicePro
+@@ -1825,25 +1961,35 @@
    return ncclSuccess;
  }
  
@@ -312,7 +307,21 @@ index 9bfd8dcf..4d3f0a08 100644
    struct ncclIbRecvComm* rComm = (struct ncclIbRecvComm*)stage->comm;
    int ready;
    int link_layer = IBV_LINK_LAYER_UNSPECIFIED;
+-  // Pre-declare dmabuf variables because of goto
 +  int channel_id = 0;
++  // Pre-declare variables because of goto
++  struct ncclIbDev* ibDev;
++  int ibDevN;
++  struct ncclIbRecvCommDev* rCommDev;
++  struct ncclIbDevInfo* remDevInfo;
++  struct ncclIbQp* qp;
+   bool useDmaBuf = false;
+   bool peermemAvailable = false;
+   bool dmabufSupported = false;
+   bool dmabufEnabled = false;
+   bool dmabufAvailable = false;
+   bool forceDmaBuf = false;
++  struct ncclIbMergedDev* mergedDev;
    *recvComm = NULL;
  
 +  if (rcclAinicRoce) {
@@ -322,7 +331,29 @@ index 9bfd8dcf..4d3f0a08 100644
    if (stage->state == ncclIbCommStateAccept)   goto ib_accept_check;
    if (stage->state == ncclIbCommStateRecvDevList) goto ib_recv_dev_list;
    if (stage->state == ncclIbCommStateSendDevList) goto ib_send_dev_list;
-@@ -1966,7 +2106,7 @@ ib_recv:
+@@ -1885,7 +2031,6 @@
+   }
+ 
+   // Reduce the physical device list and store in the connection base
+-  struct ncclIbMergedDev* mergedDev;
+   mergedDev = ncclIbMergedDevs + lComm->dev;
+   NCCLCHECK(ncclIbCheckVProps(&mergedDev->vProps, &remoteVProps));
+   rComm->base.vProps = mergedDev->vProps;
+@@ -1909,13 +2054,6 @@
+   memcpy(&remMeta, stage->buffer, sizeof(struct ncclIbConnectionMetadata));
+ 
+   // IB setup
+-  // Pre-declare variables because of goto
+-  struct ncclIbDev* ibDev;
+-  int ibDevN;
+-  struct ncclIbRecvCommDev* rCommDev;
+-  struct ncclIbDevInfo* remDevInfo;
+-  struct ncclIbQp* qp;
+-
+   mergedDev = ncclIbMergedDevs + lComm->dev;
+   rComm->base.nRemDevs = remMeta.ndevs;
+   rComm->base.nqps = ncclIbCalculateNqps(remMeta.isP2p, rComm->base.vProps.ndevs, 
+@@ -1972,7 +2110,7 @@
      // Local ibDevN
      ibDevN = rComm->devs[devIndex].base.ibDevN;
      ibDev = ncclIbDevs + ibDevN;
@@ -331,12 +362,12 @@ index 9bfd8dcf..4d3f0a08 100644
      qp->devIndex = devIndex;
      devIndex = (devIndex + 1) % rComm->base.vProps.ndevs;
  
-@@ -1992,16 +2132,22 @@ ib_recv:
+@@ -2026,16 +2164,22 @@
+   }
  
-   useDmaBuf  = (ncclIbDmaBufSupport(lComm->dev) == ncclSuccess);
-   rComm->flushEnabled = ((ncclIbGdrSupport() == ncclSuccess || useDmaBuf)
+   rComm->flushEnabled = ((peermemAvailable || useDmaBuf)
 -                            && (ncclParamIbGdrFlushDisable() == 0)) ? 1 : 0;              
-+                            && (ncclIbGdrFlushDisable == 0)) ? 1 : 0;
++                            && (ncclIbGdrFlushDisable == 0)) ? 1 : 0;              
    for (int i = 0; i < rComm->base.vProps.ndevs; i++) {
      rCommDev = rComm->devs + i;
      ibDev = ncclIbDevs + rCommDev->base.ibDevN;
@@ -357,7 +388,7 @@ index 9bfd8dcf..4d3f0a08 100644
  
      // Allocate Flush dummy buffer for GPU Direct RDMA
      if (rComm->flushEnabled) {
-@@ -2039,7 +2185,7 @@ ib_recv:
+@@ -2073,7 +2217,7 @@
        rCommDev->gpuFlush.sge.addr = (uint64_t)&rComm->gpuFlushHostMem;
        rCommDev->gpuFlush.sge.length = 1;
        rCommDev->gpuFlush.sge.lkey = rCommDev->gpuFlush.hostMr->lkey;
@@ -366,7 +397,7 @@ index 9bfd8dcf..4d3f0a08 100644
        struct ncclIbDevInfo devInfo;
        devInfo.lid         = ibDev->portAttr.lid;
        devInfo.link_layer  = ibDev->portAttr.link_layer;
-@@ -2257,10 +2403,15 @@ ncclResult_t ncclIbDeregMr(void* comm, void* mhandle) {
+@@ -2295,10 +2439,15 @@
  
  NCCL_PARAM(IbSplitDataOnQps, "IB_SPLIT_DATA_ON_QPS", 0);
  
@@ -384,7 +415,7 @@ index 9bfd8dcf..4d3f0a08 100644
    if (nreqs > NCCL_NET_IB_MAX_RECVS) return ncclInternalError;
  
    uint64_t wr_id = 0ULL;
-@@ -2272,7 +2423,11 @@ ncclResult_t ncclIbMultiSend(struct ncclIbSendComm* comm, int slot) {
+@@ -2310,7 +2459,11 @@
      sge->addr=(uintptr_t)reqs[r]->send.data;
      wr->opcode = IBV_WR_RDMA_WRITE;
      wr->send_flags = 0;
@@ -397,7 +428,7 @@ index 9bfd8dcf..4d3f0a08 100644
      wr->next = wr + 1;
      wr_id += (reqs[r] - comm->base.reqs) << (r*8);
  #ifdef NCCL_ENABLE_NET_PROFILING
-@@ -2283,7 +2438,7 @@ ncclResult_t ncclIbMultiSend(struct ncclIbSendComm* comm, int slot) {
+@@ -2321,7 +2474,7 @@
    // Write size as immediate data. In the case of multi-send, only write
    // 0 or 1 as size to indicate whether there was data sent or received.
    uint32_t immData = 0;
@@ -406,7 +437,7 @@ index 9bfd8dcf..4d3f0a08 100644
      immData = reqs[0]->send.size;
    } else {
      int* sizes = comm->remSizesFifo.elems[slot];
-@@ -2293,22 +2448,24 @@ ncclResult_t ncclIbMultiSend(struct ncclIbSendComm* comm, int slot) {
+@@ -2331,22 +2484,24 @@
    }
  
    struct ibv_send_wr* lastWr = comm->wrs+nreqs-1;
@@ -444,7 +475,7 @@ index 9bfd8dcf..4d3f0a08 100644
    lastWr->next = NULL;
    lastWr->send_flags = IBV_SEND_SIGNALED;
  
-@@ -2324,7 +2481,11 @@ ncclResult_t ncclIbMultiSend(struct ncclIbSendComm* comm, int slot) {
+@@ -2362,7 +2517,11 @@
        //ncclIbAddEvent(reqs[r], devIndex, &comm->devs[devIndex].base);
  
        // Select proper rkey (needed even for 0-size send)
@@ -457,7 +488,7 @@ index 9bfd8dcf..4d3f0a08 100644
  
        int chunkSize = DIVUP(DIVUP(reqs[r]->send.size, nqps), align) * align;
        int length = std::min(reqs[r]->send.size-reqs[r]->send.offset, chunkSize);
-@@ -2340,7 +2501,7 @@ ncclResult_t ncclIbMultiSend(struct ncclIbSendComm* comm, int slot) {
+@@ -2378,7 +2537,7 @@
        }
      }
  
@@ -466,7 +497,7 @@ index 9bfd8dcf..4d3f0a08 100644
        // Also make sure lastWr writes remote sizes using the right lkey
        comm->remSizesFifo.sge.lkey = comm->remSizesFifo.mrs[devIndex]->lkey;
        lastWr->wr.rdma.rkey = comm->remSizesFifo.rkeys[devIndex];
-@@ -2398,32 +2559,46 @@ ncclResult_t ncclIbIsend(void* sendComm, void* data, size_t size, int tag, void*
+@@ -2436,32 +2595,46 @@
    NCCLCHECK(ncclIbStatsCheckFatalCount(&comm->base.stats,__func__));
  
    struct ncclIbMrHandle* mhandleWrapper = (struct ncclIbMrHandle*) mhandle;
@@ -503,7 +534,9 @@ index 9bfd8dcf..4d3f0a08 100644
 +  }
    for (int r=0; r<nreqs; r++) {
 -    if (reqs[r] != NULL || slots[r].tag != tag) continue;
--
++    if (!rcclCtsOffloadEnabled) {
++      if (reqs[r] != NULL || slots[r].tag != tag) continue;
+ 
 -    if (size > slots[r].size) size = slots[r].size;
 -    // Sanity checks
 -    if (slots[r].size < 0 || slots[r].addr == 0 || slots[r].rkeys[0] == 0) {
@@ -513,9 +546,6 @@ index 9bfd8dcf..4d3f0a08 100644
 -      WARN("NET/IB : req %d/%d tag %x peer %s posted incorrect receive info: size %ld addr %lx rkeys[0]=%x",
 -        r, nreqs, tag, ncclSocketToString(&addr, line), slots[r].size, slots[r].addr, slots[r].rkeys[0]);
 -      return ncclInternalError;
-+    if (!rcclCtsOffloadEnabled) {
-+      if (reqs[r] != NULL || slots[r].tag != tag) continue;
-+
 +      if (size > slots[r].size) size = slots[r].size;
 +      // Sanity checks
 +      if (slots[r].size < 0 || slots[r].addr == 0 || slots[r].rkeys[0] == 0) {
@@ -531,7 +561,7 @@ index 9bfd8dcf..4d3f0a08 100644
      }
  
      struct ncclIbRequest* req;
-@@ -2467,10 +2642,12 @@ ncclResult_t ncclIbIsend(void* sendComm, void* data, size_t size, int tag, void*
+@@ -2505,10 +2678,12 @@
      }
  
      TIME_START(0);
@@ -546,7 +576,7 @@ index 9bfd8dcf..4d3f0a08 100644
      memset(reqs, 0, NCCL_NET_IB_MAX_RECVS*sizeof(struct ncclIbRequest*));
      comm->fifoHead++;
      TIME_STOP(0);
-@@ -2483,30 +2660,60 @@ ncclResult_t ncclIbIsend(void* sendComm, void* data, size_t size, int tag, void*
+@@ -2521,30 +2696,60 @@
  
  ncclResult_t ncclIbPostFifo(struct ncclIbRecvComm* comm, int n, void** data, size_t* sizes, int* tags, void** mhandles, struct ncclIbRequest* req) {
    struct ibv_send_wr wr;
@@ -596,21 +626,22 @@ index 9bfd8dcf..4d3f0a08 100644
 +      localElemCtsInline[i].tag = tags[i];
 +      localElemCtsInline[i].idx = comm->remFifo.fifoTail+1;
 +      localElemRef = (uint64_t)localElemCtsInline;
-+
-+    } else {
-+      localElem[i].addr = (uint64_t)data[i];
  
 -    // Send all applicable rkeys
 -    for (int j = 0; j < comm->base.vProps.ndevs; j++)
 -      localElem[i].rkeys[j] = mhandleWrapper->mrs[j]->rkey;
-+      // Send all applicable rkeys
-+      for (int j = 0; j < comm->base.vProps.ndevs; j++)
-+        localElem[i].rkeys[j] = mhandleWrapper->mrs[j]->rkey;
- 
+-
 -    localElem[i].nreqs = n;
 -    localElem[i].size = sizes[i]; // Sanity/Debugging
 -    localElem[i].tag = tags[i];
 -    localElem[i].idx = comm->remFifo.fifoTail+1;
++    } else {
++      localElem[i].addr = (uint64_t)data[i];
++
++      // Send all applicable rkeys
++      for (int j = 0; j < comm->base.vProps.ndevs; j++)
++        localElem[i].rkeys[j] = mhandleWrapper->mrs[j]->rkey;
++
 +      localElem[i].nreqs = n;
 +      localElem[i].size = sizes[i]; // Sanity/Debugging
 +      localElem[i].tag = tags[i];
@@ -620,7 +651,7 @@ index 9bfd8dcf..4d3f0a08 100644
    }
    wr.wr.rdma.remote_addr = comm->remFifo.addr + slot*NCCL_NET_IB_MAX_RECVS*sizeof(struct ncclIbSendFifo);
  
-@@ -2514,8 +2721,12 @@ ncclResult_t ncclIbPostFifo(struct ncclIbRecvComm* comm, int n, void** data, siz
+@@ -2552,8 +2757,12 @@
    wr.wr.rdma.rkey = comm->base.remDevs[ctsQp->remDevIdx].fifoRkey;
  
    // Set the correct sge properties
@@ -635,7 +666,7 @@ index 9bfd8dcf..4d3f0a08 100644
    wr.sg_list = &comm->devs[ctsQp->devIndex].fifoSge;
    wr.num_sge = 1;
  
-@@ -2545,7 +2756,13 @@ ncclResult_t ncclIbPostFifo(struct ncclIbRecvComm* comm, int n, void** data, siz
+@@ -2583,7 +2792,13 @@
    //
    // slot == devIndex - When writing to fifo slot N, and this QP lives on device index N, it should send signalled.
    // This works out that each fifo posting QP gets drained
@@ -650,7 +681,7 @@ index 9bfd8dcf..4d3f0a08 100644
      wr.send_flags |= IBV_SEND_SIGNALED;
      wr.wr_id = req - comm->base.reqs;
      ncclIbAddEvent(req, ctsQp->devIndex, &comm->devs[ctsQp->devIndex].base);
-@@ -2560,10 +2777,16 @@ ncclResult_t ncclIbPostFifo(struct ncclIbRecvComm* comm, int n, void** data, siz
+@@ -2598,10 +2813,16 @@
  
    comm->remFifo.fifoTail++;
  
@@ -667,7 +698,7 @@ index 9bfd8dcf..4d3f0a08 100644
    struct ncclIbRecvComm* comm = (struct ncclIbRecvComm*)recvComm;
    if (comm->base.ready == 0) {
      WARN("NET/IB: ncclIbIrecv() called when comm->base.ready == 0");
-@@ -2573,6 +2796,11 @@ ncclResult_t ncclIbIrecv(void* recvComm, int n, void** data, size_t* sizes, int*
+@@ -2611,6 +2832,11 @@
    if (n > NCCL_NET_IB_MAX_RECVS) return ncclInternalError;
    NCCLCHECK(ncclIbStatsCheckFatalCount(&comm->base.stats,__func__));
  
@@ -679,7 +710,7 @@ index 9bfd8dcf..4d3f0a08 100644
    struct ncclIbRequest* req;
    NCCLCHECK(ncclIbGetRequest(&comm->base, &req));
    req->type = NCCL_NET_IB_REQ_RECV;
-@@ -2586,50 +2814,65 @@ ncclResult_t ncclIbIrecv(void* recvComm, int n, void** data, size_t* sizes, int*
+@@ -2624,50 +2850,65 @@
      req->devBases[i] = &comm->devs[i].base;
    }
  
@@ -688,6 +719,10 @@ index 9bfd8dcf..4d3f0a08 100644
 -  wr.wr_id = req - comm->base.reqs;
 -  wr.sg_list = NULL;
 -  wr.num_sge = 0;
+-
+-  TIME_START(1);
+-  // Select either all QPs, or one qp per-device
+-  const int nqps = ncclParamIbSplitDataOnQps() ? comm->base.nqps : comm->base.nDataQps;
 +  if (!netOptRecvCompletionEnabled) {
 +    struct ibv_recv_wr wr;
 +    memset(&wr, 0, sizeof(wr));
@@ -695,18 +730,15 @@ index 9bfd8dcf..4d3f0a08 100644
 +    wr.sg_list = NULL;
 +    wr.num_sge = 0;
  
--  TIME_START(1);
--  // Select either all QPs, or one qp per-device
--  const int nqps = ncclParamIbSplitDataOnQps() ? comm->base.nqps : comm->base.nDataQps;
-+    TIME_START(1);
-+    // Select either all QPs, or one qp per-device
-+    const int nqps = ncclParamIbSplitDataOnQps() ? comm->base.nqps : comm->base.nDataQps;
- 
 -  // Post recvs
 -  struct ibv_recv_wr* bad_wr;
 -  for (int i = 0; i < nqps; i++) {
 -    struct ncclIbQp* qp = comm->base.qps + comm->base.qpIndex;
 -    ncclIbAddEvent(req, qp->devIndex, &comm->devs[qp->devIndex].base);
++    TIME_START(1);
++    // Select either all QPs, or one qp per-device
++    const int nqps = ncclParamIbSplitDataOnQps() ? comm->base.nqps : comm->base.nDataQps;
++
 +    // Post recvs
 +    struct ibv_recv_wr* bad_wr;
 +    int qpIndex = comm->base.qpIndex;
@@ -777,7 +809,7 @@ index 9bfd8dcf..4d3f0a08 100644
  }
  
  ncclResult_t ncclIbIflush(void* recvComm, int n, void** data, int* sizes, void** mhandles, void** request) {
-@@ -2698,6 +2941,8 @@ static int getReqQpIndex(struct ncclIbRequest* req, int request, int qpNumber) {
+@@ -2736,6 +2977,8 @@
  }
  #endif
  
@@ -786,7 +818,7 @@ index 9bfd8dcf..4d3f0a08 100644
  ncclResult_t ncclIbTest(void* request, int* done, int* sizes) {
    struct ncclIbRequest *r = (struct ncclIbRequest*)request;
    *done = 0;
-@@ -2731,13 +2976,18 @@ ncclResult_t ncclIbTest(void* request, int* done, int* sizes) {
+@@ -2769,13 +3012,18 @@
  
      int totalWrDone = 0;
      int wrDone = 0;
@@ -807,7 +839,7 @@ index 9bfd8dcf..4d3f0a08 100644
          totalWrDone += wrDone;
          if (wrDone == 0) { TIME_CANCEL(3); } else { TIME_STOP(3); }
          if (wrDone == 0) continue;
-@@ -2889,7 +3139,7 @@ ncclResult_t rcclNetP2pPolicy(void* handle, int isP2p) {
+@@ -2927,7 +3175,7 @@
  }
  
  ncclNet_t ncclNetIb = {

--- a/projects/rccl/src/include/rocmwrap.h
+++ b/projects/rccl/src/include/rocmwrap.h
@@ -78,6 +78,7 @@ DECLARE_ROCM_PFN_EXTERN(hsa_status_string);
 
 extern int ncclCuMemEnable();
 extern int ncclCuMemHostEnable();
+extern int64_t rcclParamForceEnableDMABUF();
 
 // Handle type used for cuMemCreate()
 extern CUmemAllocationHandleType ncclCuMemHandleType;

--- a/projects/rccl/src/misc/rocmwrap.cc
+++ b/projects/rccl/src/misc/rocmwrap.cc
@@ -19,7 +19,7 @@
 #define DECLARE_ROCM_PFN(symbol) PFN_##symbol pfn_##symbol = nullptr
 
 DECLARE_ROCM_PFN(hsa_amd_portable_export_dmabuf); // DMA-BUF support
-NCCL_PARAM(DmaBufEnable, "DMABUF_ENABLE", 0);
+NCCL_PARAM(DmaBufEnable, "DMABUF_ENABLE", 1);
 RCCL_PARAM(ForceEnableDMABUF, "FORCE_ENABLE_DMABUF", 0);
 /* ROCr Driver functions loaded with dlsym() */
 DECLARE_ROCM_PFN(hsa_init);

--- a/projects/rccl/src/transport/net.cc
+++ b/projects/rccl/src/transport/net.cc
@@ -12,6 +12,7 @@
 #include "proxy.h"
 #include "collectives.h"
 #include "gdrwrap.h"
+#include "rocmwrap.h"
 #include "shmutils.h"
 #include "p2p.h"
 #include "profiler.h"
@@ -786,8 +787,15 @@ static ncclResult_t sendProxySetup(struct ncclProxyConnection* connection, struc
   resources->isP2p = req->isP2p;
   ncclNetProperties_t props;
   NCCLCHECK(proxyState->ncclNet->getProperties(req->netDev, &props));
-  /* DMA-BUF support */
-  resources->useDmaBuf = resources->useGdr && proxyState->dmaBufSupport && (props.ptrSupport & NCCL_PTR_DMABUF);
+  /* GDR mode selection: RCCL_FORCE_ENABLE_DMABUF=1 forces DMAbuf, otherwise prefer peermem */
+  bool peermemAvailable = (props.ptrSupport & NCCL_PTR_CUDA);
+  bool dmabufAvailable = (props.ptrSupport & NCCL_PTR_DMABUF) && proxyState->dmaBufSupport;
+  bool forceDmaBuf = rcclParamForceEnableDMABUF();
+  if (forceDmaBuf) {
+    resources->useDmaBuf = resources->useGdr && dmabufAvailable;
+  } else {
+    resources->useDmaBuf = resources->useGdr && !peermemAvailable && dmabufAvailable;
+  }
   resources->maxRecvs = props.maxRecvs;
   resources->netDeviceVersion = props.netDeviceVersion;
   resources->netDeviceType = props.netDeviceType;
@@ -826,8 +834,15 @@ static ncclResult_t recvProxySetup(struct ncclProxyConnection* connection, struc
   resources->curr_hdp_reg = req->curr_hdp_reg;
   ncclNetProperties_t props;
   NCCLCHECK(proxyState->ncclNet->getProperties(req->netDev, &props));
-  /* DMA-BUF support */
-  resources->useDmaBuf = resources->useGdr && proxyState->dmaBufSupport && (props.ptrSupport & NCCL_PTR_DMABUF);
+  /* GDR mode selection: RCCL_FORCE_ENABLE_DMABUF=1 forces DMAbuf, otherwise prefer peermem */
+  bool peermemAvailable = (props.ptrSupport & NCCL_PTR_CUDA);
+  bool dmabufAvailable = (props.ptrSupport & NCCL_PTR_DMABUF) && proxyState->dmaBufSupport;
+  bool forceDmaBuf = rcclParamForceEnableDMABUF();
+  if (forceDmaBuf) {
+    resources->useDmaBuf = resources->useGdr && dmabufAvailable;
+  } else {
+    resources->useDmaBuf = resources->useGdr && !peermemAvailable && dmabufAvailable;
+  }
   resources->maxRecvs = props.maxRecvs;
   resources->netDeviceVersion = props.netDeviceVersion;
   resources->netDeviceType = props.netDeviceType;

--- a/projects/rccl/src/transport/net_ib.cc
+++ b/projects/rccl/src/transport/net_ib.cc
@@ -1835,6 +1835,13 @@ ncclResult_t ncclIbAccept(void* listenComm, void** recvComm, ncclNetDeviceHandle
   struct ncclIbRecvComm* rComm = (struct ncclIbRecvComm*)stage->comm;
   int ready;
   int link_layer = IBV_LINK_LAYER_UNSPECIFIED;
+  // Pre-declare dmabuf variables because of goto
+  bool useDmaBuf = false;
+  bool peermemAvailable = false;
+  bool dmabufSupported = false;
+  bool dmabufEnabled = false;
+  bool dmabufAvailable = false;
+  bool forceDmaBuf = false;
   *recvComm = NULL;
 
   if (stage->state == ncclIbCommStateAccept)   goto ib_accept_check;
@@ -1908,12 +1915,6 @@ ib_recv:
   struct ncclIbRecvCommDev* rCommDev;
   struct ncclIbDevInfo* remDevInfo;
   struct ncclIbQp* qp;
-  bool useDmaBuf = false;
-  bool peermemAvailable = false;
-  bool dmabufSupported = false;
-  bool dmabufEnabled = false;
-  bool dmabufAvailable = false;
-  bool forceDmaBuf = false;
 
   mergedDev = ncclIbMergedDevs + lComm->dev;
   rComm->base.nRemDevs = remMeta.ndevs;

--- a/projects/rccl/src/transport/net_ib.cc
+++ b/projects/rccl/src/transport/net_ib.cc
@@ -1908,7 +1908,12 @@ ib_recv:
   struct ncclIbRecvCommDev* rCommDev;
   struct ncclIbDevInfo* remDevInfo;
   struct ncclIbQp* qp;
-  bool useDmaBuf;
+  bool useDmaBuf = false;
+  bool peermemAvailable = false;
+  bool dmabufSupported = false;
+  bool dmabufEnabled = false;
+  bool dmabufAvailable = false;
+  bool forceDmaBuf = false;
 
   mergedDev = ncclIbMergedDevs + lComm->dev;
   rComm->base.nRemDevs = remMeta.ndevs;
@@ -1990,8 +1995,36 @@ ib_recv:
     }
   }
 
-  useDmaBuf  = (ncclIbDmaBufSupport(lComm->dev) == ncclSuccess && ncclParamDmaBufEnable());
-  rComm->flushEnabled = ((ncclIbGdrSupport() == ncclSuccess || useDmaBuf)
+  // GDR mode selection logic
+  peermemAvailable = (ncclIbGdrSupport() == ncclSuccess);
+  dmabufSupported = (ncclIbDmaBufSupport(lComm->dev) == ncclSuccess);
+  dmabufEnabled = (ncclParamDmaBufEnable() != 0);
+  dmabufAvailable = dmabufSupported && dmabufEnabled;
+  forceDmaBuf = rcclParamForceEnableDMABUF();
+
+  if (forceDmaBuf) {
+    // RCCL_FORCE_ENABLE_DMABUF=1: always try DMAbuf, skip peermem
+    useDmaBuf = dmabufAvailable;
+    if (dmabufAvailable) {
+      INFO(NCCL_INIT|NCCL_NET, "NET/IB: Using GPU Direct RDMA (DMAbuf - forced) for device %d", lComm->dev);
+    } else {
+      WARN("NET/IB: RCCL_FORCE_ENABLE_DMABUF=1 but DMAbuf not available, GPU Direct RDMA disabled for device %d", lComm->dev);
+    }
+  } else {
+    // Normal path: prefer peermem over dmabuf
+    useDmaBuf = !peermemAvailable && dmabufAvailable;
+    if (peermemAvailable) {
+      INFO(NCCL_INIT|NCCL_NET, "NET/IB: Using GPU Direct RDMA (peermem) for device %d", lComm->dev);
+    } else if (useDmaBuf) {
+      WARN("NET/IB: Peermem not available, falling back to GPU Direct RDMA (DMAbuf) for device %d", lComm->dev);
+    } else if (!peermemAvailable && dmabufSupported && !dmabufEnabled) {
+      WARN("NET/IB: Peermem not available and DMAbuf is disabled (NCCL_DMABUF_ENABLE=0), GPU Direct RDMA disabled for device %d", lComm->dev);
+    } else {
+      WARN("NET/IB: GPU Direct RDMA not available for device %d", lComm->dev);
+    }
+  }
+
+  rComm->flushEnabled = ((peermemAvailable || useDmaBuf)
                             && (ncclParamIbGdrFlushDisable() == 0)) ? 1 : 0;              
   for (int i = 0; i < rComm->base.vProps.ndevs; i++) {
     rCommDev = rComm->devs + i;


### PR DESCRIPTION
## Motivation

Our customers have been confused by our GDR selection logic  between peermem and DMAbuf. This PR attempt to make it simpler and more verbose.

## Technical Details

Changed GPU Direct RDMA mode selection logic to prefer peermem over DMAbuf by default. `NCCL_DMABUF_ENABLE` now defaults to 1 (previously 0). When both peermem and DMAbuf are available, RCCL will use peermem. If peermem is unavailable, RCCL will automatically fall back to DMAbuf (if available and enabled). Setting `RCCL_FORCE_ENABLE_DMABUF=1` forces DMAbuf usage exclusively, skipping peermem even if available, and disables GPU Direct RDMA if DMAbuf is unavailable.

## JIRA ID
AICOMRCCL-667
<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
