### PR TITLE
[RCCL] Add GDA alltoallv via rocshmem integration

### DIFF
--- a/projects/rccl/cmake/ROCSHMEM.cmake
+++ b/projects/rccl/cmake/ROCSHMEM.cmake
@@ -72,7 +72,7 @@ function(add_rocshmem_targets)
             TEST_COMMAND        ""
             DEPENDS             rocshmem_checkout_submodule   
 
-            # Rocshmem submodule commit hash -> commit b28a56bd54ccc581d05a439ffa466c3dacb3385
+            # Rocshmem submodule commit hash -> commit f273bc0 "Add alltoallv"
             # The project has its own scripts; we replicate the README sequence:
             CONFIGURE_COMMAND   ""
             BUILD_COMMAND

--- a/projects/rccl/src/CMakeLists.txt
+++ b/projects/rccl/src/CMakeLists.txt
@@ -30,6 +30,7 @@ set(SRC_FILES
   src/device/all_reduce.h
   src/device/alltoall_pivot.h
   src/device/alltoall_gda.h
+  src/device/alltoallv_gda.h
   src/device/broadcast.h
   src/device/common.h
   src/device/common_kernel.h

--- a/projects/rccl/src/collectives.cc
+++ b/projects/rccl/src/collectives.cc
@@ -250,7 +250,7 @@ ncclResult_t ncclAlltoAllv_impl(const void *sendbuff, const size_t sendcounts[],
             sizes[2*nRanks + i] = recvcounts1[i];
             sizes[3*nRanks + i] = rdispls1[i];
         }
-
+	//TODO: move sizes to info or restructure kernels
         for (int i = 0; i < (4 * nRanks); i++) {
             comm->sizes[i] = sizes[i];
         }

--- a/projects/rccl/src/collectives.cc
+++ b/projects/rccl/src/collectives.cc
@@ -220,8 +220,61 @@ ncclResult_t ncclAlltoAllv_impl(const void *sendbuff, const size_t sendcounts[],
       0, datatype, 0, 0, ncclSum, mscclFuncAllToAllv, comm, stream);
   }
 
-  int nRanks;
+  int nRanks, rank;
+  ncclResult_t ret = ncclSuccess;
   NCCLCHECK(ncclCommCount(comm, &nRanks));
+  NCCLCHECK(ncclCommUserRank(comm, &rank));
+
+  size_t sdispls1[nRanks];
+  size_t rdispls1[nRanks];
+  size_t sendcounts1[nRanks];
+  size_t recvcounts1[nRanks];
+
+  size_t sizes[4*nRanks];	//4 for sdispl, rdispl, scount, rcount
+#ifdef ENABLE_ROCSHMEM
+    for (int i = 0; i < nRanks; i++) {
+       sdispls1[i] = sdispls[i] * ncclTypeSize(datatype);
+       rdispls1[i] = rdispls[i] * ncclTypeSize(datatype);
+       sendcounts1[i] = sendcounts[i] * ncclTypeSize(datatype);
+       recvcounts1[i] = recvcounts[i] * ncclTypeSize(datatype);
+    }
+    size_t count = sdispls1[nRanks - 1] + sendcounts1[nRanks - 1];
+
+
+    //symmteric memory size 128M
+    if (comm->enableRocshmem && comm->nNodes > 1 && (comm->nRanks/comm->nNodes == 8) && count <= 128*1024*1024) {
+        for (int i = 0; i < nRanks; i++) {
+            sizes[i] = sendcounts1[i];
+            sizes[nRanks + i] = sdispls1[i];
+            sizes[2*nRanks + i] = recvcounts1[i];
+            sizes[3*nRanks + i] = rdispls1[i];
+        }
+
+        for (int i = 0; i < (4 * nRanks); i++) {
+            comm->sizes[i] = sizes[i];
+        }
+        count = count / ncclTypeSize(datatype);
+
+	//use CU for copy-in/copy-out for small <= 128KB sizes
+	if ((count * ncclTypeSize(datatype)) > 131072) {
+            hipMemcpyAsync(comm->sourceRshmem[comm->symId], sendbuff, count * ncclTypeSize(datatype),
+               hipMemcpyDeviceToDevice, stream);
+        }
+        struct ncclInfo info = { ncclFuncAllToAllvGda, "AllToAllvGda",
+        sendbuff, recvbuff, count, datatype, ncclSum, 0, comm, stream,
+        ALLTOALL_PIVOT_CHUNKSTEPS, ALLTOALL_PIVOT_SLICESTEPS, nullptr };
+
+        ret = ncclEnqueueCheck(&info);
+
+        if (ret == ncclSuccess && ((count * ncclTypeSize(datatype)) > 131072)) {
+            hipMemcpyAsync(recvbuff, comm->destRshmem[comm->symId], count * ncclTypeSize(datatype),
+                    hipMemcpyDeviceToDevice, stream);
+            comm->symId = (comm->symId + 1) % comm->numSymBuf;
+        }
+        return ret;
+    }
+#endif
+
   if (!mscclIsCaller()) Recorder::instance().skip(true);
   NCCLCHECK(ncclGroupStart());
   for (int r=0; r<nRanks; r++) {

--- a/projects/rccl/src/collectives.cc
+++ b/projects/rccl/src/collectives.cc
@@ -232,17 +232,17 @@ ncclResult_t ncclAlltoAllv_impl(const void *sendbuff, const size_t sendcounts[],
 
   size_t sizes[4*nRanks];	//4 for sdispl, rdispl, scount, rcount
 #ifdef ENABLE_ROCSHMEM
+  INFO(NCCL_INIT, "GDA alltoallv is supported for up to 128MB message size; Use ROCSHMEM_HEAP_SIZE=3GB for GDA support till 512MB");  
     for (int i = 0; i < nRanks; i++) {
        sdispls1[i] = sdispls[i] * ncclTypeSize(datatype);
        rdispls1[i] = rdispls[i] * ncclTypeSize(datatype);
        sendcounts1[i] = sendcounts[i] * ncclTypeSize(datatype);
        recvcounts1[i] = recvcounts[i] * ncclTypeSize(datatype);
     }
+
     size_t count = sdispls1[nRanks - 1] + sendcounts1[nRanks - 1];
 
-
-    //symmteric memory size 128M
-    if (comm->enableRocshmem && comm->nNodes > 1 && (comm->nRanks/comm->nNodes == 8) && count <= 128*1024*1024) {
+    if (comm->enableRocshmem && comm->nNodes > 1 && (comm->nRanks/comm->nNodes == 8)) {
         for (int i = 0; i < nRanks; i++) {
             sizes[i] = sendcounts1[i];
             sizes[nRanks + i] = sdispls1[i];
@@ -257,7 +257,8 @@ ncclResult_t ncclAlltoAllv_impl(const void *sendbuff, const size_t sendcounts[],
 
 	//use CU for copy-in/copy-out for small <= 128KB sizes
 	if ((count * ncclTypeSize(datatype)) > 131072) {
-            hipMemcpyAsync(comm->sourceRshmem[comm->symId], sendbuff, count * ncclTypeSize(datatype),
+	    void *dest = (char*)comm->sourceRshmem + comm->symId * comm->bufThreshold;
+            hipMemcpyAsync(dest, sendbuff, count * ncclTypeSize(datatype),
                hipMemcpyDeviceToDevice, stream);
         }
         struct ncclInfo info = { ncclFuncAllToAllvGda, "AllToAllvGda",
@@ -267,7 +268,8 @@ ncclResult_t ncclAlltoAllv_impl(const void *sendbuff, const size_t sendcounts[],
         ret = ncclEnqueueCheck(&info);
 
         if (ret == ncclSuccess && ((count * ncclTypeSize(datatype)) > 131072)) {
-            hipMemcpyAsync(recvbuff, comm->destRshmem[comm->symId], count * ncclTypeSize(datatype),
+	    void *src = (char*)comm->destRshmem + comm->symId * comm->bufThreshold;
+            hipMemcpyAsync(recvbuff, src, count * ncclTypeSize(datatype),
                     hipMemcpyDeviceToDevice, stream);
             comm->symId = (comm->symId + 1) % comm->numSymBuf;
         }

--- a/projects/rccl/src/collectives.cc
+++ b/projects/rccl/src/collectives.cc
@@ -184,8 +184,8 @@ ncclResult_t ncclAlltoAll_impl(const void* sendbuff, void* recvbuff, size_t coun
   } else {
       #ifdef ENABLE_ROCSHMEM
       size_t msgSize = count * ncclTypeSize(datatype) * comm->nRanks;
-      if (rcclUseAllToAllGda(comm) && msgSize <= comm->rocshmemThreshold) {	
-        struct ncclInfo info = { ncclFuncAllToAllGda, "AllToAllGda",
+      if (rcclUseAlltoAllGda(comm) && msgSize <= comm->rocshmemThreshold) {	
+        struct ncclInfo info = { ncclFuncAlltoAllGda, "AlltoAllGda",
               sendbuff, recvbuff, count, datatype, ncclSum, 0, comm, stream,
               ALLTOALL_PIVOT_CHUNKSTEPS, ALLTOALL_PIVOT_SLICESTEPS, nullptr };
             
@@ -260,10 +260,10 @@ ncclResult_t ncclAlltoAllv_impl(const void *sendbuff, const size_t sendcounts[],
 	//TODO: the threshold could be different for different number of nodes
 	if ((count * ncclTypeSize(datatype)) > 131072) {
 	    void *dest = (char*)comm->sourceRshmem + comm->symId * comm->bufThreshold;
-            hipMemcpyAsync(dest, sendbuff, count * ncclTypeSize(datatype),
-               hipMemcpyDeviceToDevice, stream);
+            CUDACHECK(hipMemcpyAsync(dest, sendbuff, count * ncclTypeSize(datatype),
+               hipMemcpyDeviceToDevice, stream));
         }
-        struct ncclInfo info = { ncclFuncAllToAllvGda, "AllToAllvGda",
+        struct ncclInfo info = { ncclFuncAlltoAllvGda, "AlltoAllvGda",
         sendbuff, recvbuff, count, datatype, ncclSum, 0, comm, stream,
         ALLTOALL_PIVOT_CHUNKSTEPS, ALLTOALL_PIVOT_SLICESTEPS, nullptr };
 
@@ -271,8 +271,8 @@ ncclResult_t ncclAlltoAllv_impl(const void *sendbuff, const size_t sendcounts[],
 
         if (ret == ncclSuccess && ((count * ncclTypeSize(datatype)) > 131072)) {
 	    void *src = (char*)comm->destRshmem + comm->symId * comm->bufThreshold;
-            hipMemcpyAsync(recvbuff, src, count * ncclTypeSize(datatype),
-                    hipMemcpyDeviceToDevice, stream);
+            CUDACHECK(hipMemcpyAsync(recvbuff, src, count * ncclTypeSize(datatype),
+                    hipMemcpyDeviceToDevice, stream));
             comm->symId = (comm->symId + 1) % comm->numSymBuf;
         }
         return ret;

--- a/projects/rccl/src/collectives.cc
+++ b/projects/rccl/src/collectives.cc
@@ -250,10 +250,6 @@ ncclResult_t ncclAlltoAllv_impl(const void *sendbuff, const size_t sendcounts[],
             sizes[2*nRanks + i] = recvcounts1[i];
             sizes[3*nRanks + i] = rdispls1[i];
         }
-	//TODO: move sizes to info or restructure kernels
-        for (int i = 0; i < (4 * nRanks); i++) {
-            comm->sizes[i] = sizes[i];
-        }
         count = count / ncclTypeSize(datatype);
 
 	//use CU for copy-in/copy-out for small <= 128KB sizes
@@ -266,6 +262,9 @@ ncclResult_t ncclAlltoAllv_impl(const void *sendbuff, const size_t sendcounts[],
         struct ncclInfo info = { ncclFuncAlltoAllvGda, "AlltoAllvGda",
         sendbuff, recvbuff, count, datatype, ncclSum, 0, comm, stream,
         ALLTOALL_PIVOT_CHUNKSTEPS, ALLTOALL_PIVOT_SLICESTEPS, nullptr };
+#ifdef ENABLE_ROCSHMEM
+        info.sizes = sizes.data();
+#endif
 
         ret = ncclEnqueueCheck(&info);
 

--- a/projects/rccl/src/collectives.cc
+++ b/projects/rccl/src/collectives.cc
@@ -225,14 +225,13 @@ ncclResult_t ncclAlltoAllv_impl(const void *sendbuff, const size_t sendcounts[],
   NCCLCHECK(ncclCommCount(comm, &nRanks));
   NCCLCHECK(ncclCommUserRank(comm, &rank));
 
-  size_t sdispls1[nRanks];
-  size_t rdispls1[nRanks];
-  size_t sendcounts1[nRanks];
-  size_t recvcounts1[nRanks];
+  std::vector<size_t> sdispls1(nRanks);
+  std::vector<size_t> rdispls1(nRanks);
+  std::vector<size_t> sendcounts1(nRanks);
+  std::vector<size_t> recvcounts1(nRanks);
 
-  size_t sizes[4*nRanks];	//4 for sdispl, rdispl, scount, rcount
+  std::vector<size_t> sizes(4*nRanks);	//4 for sdispl, rdispl, scount, rcount
 #ifdef ENABLE_ROCSHMEM
-  INFO(NCCL_INIT, "GDA alltoallv is supported for up to 128MB message size; Use ROCSHMEM_HEAP_SIZE=3GB for GDA support till 512MB");  
     for (int i = 0; i < nRanks; i++) {
        sdispls1[i] = sdispls[i] * ncclTypeSize(datatype);
        rdispls1[i] = rdispls[i] * ncclTypeSize(datatype);
@@ -243,6 +242,8 @@ ncclResult_t ncclAlltoAllv_impl(const void *sendbuff, const size_t sendcounts[],
     size_t count = sdispls1[nRanks - 1] + sendcounts1[nRanks - 1];
 
     if (comm->enableRocshmem && comm->nNodes > 1 && (comm->nRanks/comm->nNodes == 8)) {
+        INFO(NCCL_INIT, "GDA alltoallv is supported for up to 128MB message size; Use ROCSHMEM_HEAP_SIZE=3GB for GDA support till 512MB");  
+
         for (int i = 0; i < nRanks; i++) {
             sizes[i] = sendcounts1[i];
             sizes[nRanks + i] = sdispls1[i];
@@ -256,6 +257,7 @@ ncclResult_t ncclAlltoAllv_impl(const void *sendbuff, const size_t sendcounts[],
         count = count / ncclTypeSize(datatype);
 
 	//use CU for copy-in/copy-out for small <= 128KB sizes
+	//TODO: the threshold could be different for different number of nodes
 	if ((count * ncclTypeSize(datatype)) > 131072) {
 	    void *dest = (char*)comm->sourceRshmem + comm->symId * comm->bufThreshold;
             hipMemcpyAsync(dest, sendbuff, count * ncclTypeSize(datatype),

--- a/projects/rccl/src/device/alltoall_gda.h
+++ b/projects/rccl/src/device/alltoall_gda.h
@@ -12,7 +12,7 @@
 #include <rocshmem/rocshmem.hpp>
 
 template<typename T, typename RedOp>
-struct RunWorkColl<ncclFuncAllToAllGda, T, RedOp, NCCL_ALGO_RING, NCCL_PROTO_SIMPLE> {
+struct RunWorkColl<ncclFuncAlltoAllGda, T, RedOp, NCCL_ALGO_RING, NCCL_PROTO_SIMPLE> {
   __device__ __forceinline__ void run(int tid, int nThreads, struct ncclDevWorkColl* work) {
     if (blockIdx.x == 0) {
         int num_pes = rocshmem::rocshmem_n_pes();

--- a/projects/rccl/src/device/alltoallv_gda.h
+++ b/projects/rccl/src/device/alltoallv_gda.h
@@ -1,0 +1,50 @@
+/*************************************************************************
+ * Copyright (c) 2015-2021, NVIDIA CORPORATION. All rights reserved.
+ *
+ * See LICENSE.txt for license information
+ ************************************************************************/
+
+#include "device.h"
+#include "collectives.h"
+#include "primitives.h"
+
+#ifdef ENABLE_ROCSHMEM
+#include <rocshmem/rocshmem.hpp>
+
+template<typename T, typename RedOp>
+struct RunWorkColl<ncclFuncAllToAllvGda, T, RedOp, NCCL_ALGO_RING, NCCL_PROTO_SIMPLE> {
+  __device__ __forceinline__ void run(int tid, int nThreads, struct ncclDevWorkColl* work) {
+        int num_pes = rocshmem::rocshmem_n_pes();
+
+	if (blockIdx.x == 0) {
+	   if (work->size <= 131072) {
+	
+   		void *src = (T*)work->sendbuff;
+        	void *dst = (T*)work->sndbuff;		   
+
+		reduceCopy<COLL_UNROLL, USE_ACC, RedOp, T, 0,1, 1, 0, 1, 1, 0>(
+            	tid, nThreads, 0, nullptr, false, 1, (void **)&src, 1, (void **)&dst,
+            	work->size);
+	   }		   
+	   work->sendSizes = (size_t*)work->sizes;
+	   work->sendDispls = (size_t*)work->sizes + num_pes;
+           work->recvSizes = (size_t*)work->sizes + 2 * num_pes;
+           work->recvDispls = (size_t*)work->sizes + 3 * num_pes;
+
+	   rocshmem::rocshmem_char_alltoallv_wg(work->team, (char*)work->tempbuff, work->recvSizes, work->recvDispls, 
+			(char*)work->sndbuff, work->sendSizes, work->sendDispls);
+
+	   if (work->size <= 131072) {
+		void *srcR = (T*)work->tempbuff;
+        	void *dstR = (T*)work->recvbuff;
+
+        	reduceCopy<COLL_UNROLL, USE_ACC, RedOp, T, 0,1, 1, 0, 1, 1, 0>(
+            	tid, nThreads, 0, nullptr, false, 1, (void **)&srcR, 1, (void **)&dstR,
+            	work->size);
+	   }
+
+	}
+ }
+};
+#endif
+

--- a/projects/rccl/src/device/alltoallv_gda.h
+++ b/projects/rccl/src/device/alltoallv_gda.h
@@ -17,31 +17,28 @@ struct RunWorkColl<ncclFuncAllToAllvGda, T, RedOp, NCCL_ALGO_RING, NCCL_PROTO_SI
         int num_pes = rocshmem::rocshmem_n_pes();
 
 	if (blockIdx.x == 0) {
-	   if (work->size <= 131072) {
-	
-   		void *src = (T*)work->sendbuff;
-        	void *dst = (T*)work->sndbuff;		   
-
-		reduceCopy<COLL_UNROLL, USE_ACC, RedOp, T, 0,1, 1, 0, 1, 1, 0>(
+        if (work->size <= 131072) {
+           void *src = (T*)work->sendbuff;
+           void *dst = (T*)work->sndbuff;
+           reduceCopy<COLL_UNROLL, USE_ACC, RedOp, T, 0,1, 1, 0, 1, 1, 0>(
             	tid, nThreads, 0, nullptr, false, 1, (void **)&src, 1, (void **)&dst,
             	work->size);
-	   }		   
+        }		   
 	   work->sendSizes = (size_t*)work->sizes;
 	   work->sendDispls = (size_t*)work->sizes + num_pes;
-           work->recvSizes = (size_t*)work->sizes + 2 * num_pes;
-           work->recvDispls = (size_t*)work->sizes + 3 * num_pes;
+       work->recvSizes = (size_t*)work->sizes + 2 * num_pes;
+       work->recvDispls = (size_t*)work->sizes + 3 * num_pes;
 
-	   rocshmem::rocshmem_char_alltoallv_wg(work->team, (char*)work->tempbuff, work->recvSizes, work->recvDispls, 
+       rocshmem::rocshmem_char_alltoallv_wg(work->team, (char*)work->tempbuff, work->recvSizes, work->recvDispls, 
 			(char*)work->sndbuff, work->sendSizes, work->sendDispls);
 
 	   if (work->size <= 131072) {
-		void *srcR = (T*)work->tempbuff;
-        	void *dstR = (T*)work->recvbuff;
-
-        	reduceCopy<COLL_UNROLL, USE_ACC, RedOp, T, 0,1, 1, 0, 1, 1, 0>(
+           void *srcR = (T*)work->tempbuff;
+           void *dstR = (T*)work->recvbuff;
+           reduceCopy<COLL_UNROLL, USE_ACC, RedOp, T, 0,1, 1, 0, 1, 1, 0>(
             	tid, nThreads, 0, nullptr, false, 1, (void **)&srcR, 1, (void **)&dstR,
             	work->size);
-	   }
+       }
 
 	}
  }

--- a/projects/rccl/src/device/alltoallv_gda.h
+++ b/projects/rccl/src/device/alltoallv_gda.h
@@ -12,7 +12,7 @@
 #include <rocshmem/rocshmem.hpp>
 
 template<typename T, typename RedOp>
-struct RunWorkColl<ncclFuncAllToAllvGda, T, RedOp, NCCL_ALGO_RING, NCCL_PROTO_SIMPLE> {
+struct RunWorkColl<ncclFuncAlltoAllvGda, T, RedOp, NCCL_ALGO_RING, NCCL_PROTO_SIMPLE> {
   __device__ __forceinline__ void run(int tid, int nThreads, struct ncclDevWorkColl* work) {
         int num_pes = rocshmem::rocshmem_n_pes();
 

--- a/projects/rccl/src/device/generate.py
+++ b/projects/rccl/src/device/generate.py
@@ -6,6 +6,7 @@ from dataclasses import dataclass
 import shutil
 
 # Order of colls, redops, tys, protos, algos must match src/include/device.h
+# The empty entries are for collectives like Gather, Scatter, etc.
 all_colls     = ["Broadcast", "Reduce", "AllGather", "ReduceScatter", "AllReduce", "SendRecv", "", "", "", "", "", "AlltoAllPivot", "AllToAllGda", "AllToAllvGda"]
 all_redops    = ["Sum","Prod","MinMax","PreMulSum","SumPostDiv"]
 all_tys       = ["i8","u8","i32","u32","i64","u64","f16","f32","f64","bf16","f8e4m3","f8e5m2"]

--- a/projects/rccl/src/device/generate.py
+++ b/projects/rccl/src/device/generate.py
@@ -7,7 +7,7 @@ import shutil
 
 # Order of colls, redops, tys, protos, algos must match src/include/device.h
 # The empty entries are for collectives like Gather, Scatter, etc.
-all_colls     = ["Broadcast", "Reduce", "AllGather", "ReduceScatter", "AllReduce", "SendRecv", "", "", "", "", "", "AlltoAllPivot", "AllToAllGda", "AllToAllvGda"]
+all_colls     = ["Broadcast", "Reduce", "AllGather", "ReduceScatter", "AllReduce", "SendRecv", "", "", "", "", "", "AlltoAllPivot", "AlltoAllGda", "AlltoAllvGda"]
 all_redops    = ["Sum","Prod","MinMax","PreMulSum","SumPostDiv"]
 all_tys       = ["i8","u8","i32","u32","i64","u64","f16","f32","f64","bf16","f8e4m3","f8e5m2"]
 all_protos    = ["LL","LL128","SIMPLE"]
@@ -84,7 +84,7 @@ func_pattern = sys.argv[6:7]
 if func_pattern and func_pattern[0]:
   func_pattern = func_pattern[0]
 else:
-  func_pattern = "AllGather|AllReduce|AlltoAllPivot|AllToAllGda|AllToAllvGda|Broadcast|Reduce|ReduceScatter|SendRecv"
+  func_pattern = "AllGather|AllReduce|AlltoAllPivot|AlltoAllGda|AlltoAllvGda|Broadcast|Reduce|ReduceScatter|SendRecv"
 
 ################################################################################
 
@@ -92,8 +92,8 @@ algos_of_coll = {
   "AllGather":             ["RING", "PAT"],
   "AllReduce":             ["RING", "TREE"],
   "AlltoAllPivot":         ["RING"],
-  "AllToAllGda":           ["RING"],
-  "AllToAllvGda":          ["RING"],
+  "AlltoAllGda":           ["RING"],
+  "AlltoAllvGda":          ["RING"],
   "Broadcast":             ["RING"],
   "Reduce":                ["RING"],
   "ReduceScatter":         ["RING", "PAT"],
@@ -104,8 +104,8 @@ protos_of_coll = {
   "AllGather":              all_protos,
   "AllReduce":              all_protos,
   "AlltoAllPivot":          ["SIMPLE"],
-  "AllToAllGda":            ["SIMPLE"],
-  "AllToAllvGda":           ["SIMPLE"],
+  "AlltoAllGda":            ["SIMPLE"],
+  "AlltoAllvGda":           ["SIMPLE"],
   "Broadcast":              all_protos,
   "Reduce":                 all_protos,
   "ReduceScatter":          all_protos,
@@ -116,8 +116,8 @@ redops_of_coll = {
   "AllGather":            ["Sum"],
   "AllReduce":            all_redops,
   "AlltoAllPivot":        ["Sum"],
-  "AllToAllGda":          ["Sum"],
-  "AllToAllvGda":         ["Sum"],
+  "AlltoAllGda":          ["Sum"],
+  "AlltoAllvGda":         ["Sum"],
   "Broadcast":            ["Sum"],
   "Reduce":               all_redops,
   "ReduceScatter":        all_redops,
@@ -128,8 +128,8 @@ tys_of_coll = {
   "AllGather":             ["i8"],
   "AllReduce":             all_tys,
   "AlltoAllPivot":         ["i8"],
-  "AllToAllGda":           ["i8"],
-  "AllToAllvGda":          ["i8"],
+  "AlltoAllGda":           ["i8"],
+  "AlltoAllvGda":          ["i8"],
   "Broadcast":             ["i8"],
   "Reduce":                all_tys,
   "ReduceScatter":         all_tys,
@@ -140,8 +140,8 @@ acc_of_coll = {
   "AllGather":             ["0"],
   "AllReduce":             all_accs,
   "AlltoAllPivot":         ["0"],
-  "AllToAllGda":           ["0"],
-  "AllToAllvGda":          ["0"],
+  "AlltoAllGda":           ["0"],
+  "AlltoAllvGda":          ["0"],
   "Broadcast":             ["0"],
   "Reduce":                ["0"],
   "ReduceScatter":         ["0"],
@@ -152,8 +152,8 @@ pipelines_of_coll = {
   "AllGather":             ["0"],
   "AllReduce":             all_pipelines,
   "AlltoAllPivot":         ["0"],
-  "AllToAllGda":           ["0"],
-  "AllToAllvGda":          ["0"],
+  "AlltoAllGda":           ["0"],
+  "AlltoAllvGda":          ["0"],
   "Broadcast":             ["0"],
   "Reduce":                all_pipelines,
   "ReduceScatter":         all_pipelines,
@@ -165,8 +165,8 @@ coll_camel_to_lower = {
   "AllGather":             "all_gather",
   "AllReduce":             "all_reduce",
   "AlltoAllPivot":         "alltoall_pivot",
-  "AllToAllGda":           "alltoall_gda",
-  "AllToAllvGda":          "alltoallv_gda",
+  "AlltoAllGda":           "alltoall_gda",
+  "AlltoAllvGda":          "alltoallv_gda",
   "Broadcast":             "broadcast",
   "Reduce":                "reduce",
   "ReduceScatter":         "reduce_scatter",
@@ -522,7 +522,7 @@ with open(os.path.join(gensrc, "host_table.cpp"), "w") as f:
       )
       if fn.coll == "Broadcast":
         key = ((coll_idx & 0x3F) | ((proto_idx & 0x3F) << 8))
-      if fn.coll in ["SendRecv", "AlltoAllPivot", "AllToAllGda", "AllToAllvGda"]:
+      if fn.coll in ["SendRecv", "AlltoAllPivot", "AlltoAllGda", "AlltoAllvGda"]:
         key = ((coll_idx & 0x3F))
       
       out(f'  {{{key}, {fn_id}}}, {comment}\n')

--- a/projects/rccl/src/device/generate.py
+++ b/projects/rccl/src/device/generate.py
@@ -6,7 +6,7 @@ from dataclasses import dataclass
 import shutil
 
 # Order of colls, redops, tys, protos, algos must match src/include/device.h
-all_colls     = ["Broadcast", "Reduce", "AllGather", "ReduceScatter", "AllReduce", "SendRecv", "", "", "AlltoAllPivot", "AllToAllGda"]
+all_colls     = ["Broadcast", "Reduce", "AllGather", "ReduceScatter", "AllReduce", "SendRecv", "", "", "", "", "", "AlltoAllPivot", "AllToAllGda", "AllToAllvGda"]
 all_redops    = ["Sum","Prod","MinMax","PreMulSum","SumPostDiv"]
 all_tys       = ["i8","u8","i32","u32","i64","u64","f16","f32","f64","bf16","f8e4m3","f8e5m2"]
 all_protos    = ["LL","LL128","SIMPLE"]
@@ -83,7 +83,7 @@ func_pattern = sys.argv[6:7]
 if func_pattern and func_pattern[0]:
   func_pattern = func_pattern[0]
 else:
-  func_pattern = "AllGather|AllReduce|AlltoAllPivot|AllToAllGda|Broadcast|Reduce|ReduceScatter|SendRecv"
+  func_pattern = "AllGather|AllReduce|AlltoAllPivot|AllToAllGda|AllToAllvGda|Broadcast|Reduce|ReduceScatter|SendRecv"
 
 ################################################################################
 
@@ -92,6 +92,7 @@ algos_of_coll = {
   "AllReduce":             ["RING", "TREE"],
   "AlltoAllPivot":         ["RING"],
   "AllToAllGda":           ["RING"],
+  "AllToAllvGda":          ["RING"],
   "Broadcast":             ["RING"],
   "Reduce":                ["RING"],
   "ReduceScatter":         ["RING", "PAT"],
@@ -103,6 +104,7 @@ protos_of_coll = {
   "AllReduce":              all_protos,
   "AlltoAllPivot":          ["SIMPLE"],
   "AllToAllGda":            ["SIMPLE"],
+  "AllToAllvGda":           ["SIMPLE"],
   "Broadcast":              all_protos,
   "Reduce":                 all_protos,
   "ReduceScatter":          all_protos,
@@ -114,6 +116,7 @@ redops_of_coll = {
   "AllReduce":            all_redops,
   "AlltoAllPivot":        ["Sum"],
   "AllToAllGda":          ["Sum"],
+  "AllToAllvGda":         ["Sum"],
   "Broadcast":            ["Sum"],
   "Reduce":               all_redops,
   "ReduceScatter":        all_redops,
@@ -125,6 +128,7 @@ tys_of_coll = {
   "AllReduce":             all_tys,
   "AlltoAllPivot":         ["i8"],
   "AllToAllGda":           ["i8"],
+  "AllToAllvGda":          ["i8"],
   "Broadcast":             ["i8"],
   "Reduce":                all_tys,
   "ReduceScatter":         all_tys,
@@ -136,6 +140,7 @@ acc_of_coll = {
   "AllReduce":             all_accs,
   "AlltoAllPivot":         ["0"],
   "AllToAllGda":           ["0"],
+  "AllToAllvGda":          ["0"],
   "Broadcast":             ["0"],
   "Reduce":                ["0"],
   "ReduceScatter":         ["0"],
@@ -147,6 +152,7 @@ pipelines_of_coll = {
   "AllReduce":             all_pipelines,
   "AlltoAllPivot":         ["0"],
   "AllToAllGda":           ["0"],
+  "AllToAllvGda":          ["0"],
   "Broadcast":             ["0"],
   "Reduce":                all_pipelines,
   "ReduceScatter":         all_pipelines,
@@ -159,6 +165,7 @@ coll_camel_to_lower = {
   "AllReduce":             "all_reduce",
   "AlltoAllPivot":         "alltoall_pivot",
   "AllToAllGda":           "alltoall_gda",
+  "AllToAllvGda":          "alltoallv_gda",
   "Broadcast":             "broadcast",
   "Reduce":                "reduce",
   "ReduceScatter":         "reduce_scatter",
@@ -514,7 +521,7 @@ with open(os.path.join(gensrc, "host_table.cpp"), "w") as f:
       )
       if fn.coll == "Broadcast":
         key = ((coll_idx & 0x3F) | ((proto_idx & 0x3F) << 8))
-      if fn.coll in ["SendRecv", "AlltoAllPivot", "AllToAllGda"]:
+      if fn.coll in ["SendRecv", "AlltoAllPivot", "AllToAllGda", "AllToAllvGda"]:
         key = ((coll_idx & 0x3F))
       
       out(f'  {{{key}, {fn_id}}}, {comment}\n')

--- a/projects/rccl/src/enqueue.cc
+++ b/projects/rccl/src/enqueue.cc
@@ -416,8 +416,8 @@ ncclResult_t ncclTasksRegAndEnqueue(struct ncclComm* comm) {
         devWork.enableRocshmem = comm->enableRocshmem;
         devWork.team = comm->team_reduce_world_dup;
 
-        devWork.sndbuff = (void*)comm->sourceRshmem[comm->symId];
-        devWork.tempbuff = (void*)comm->destRshmem[comm->symId];
+        devWork.sndbuff = (void*)((char*)comm->sourceRshmem + comm->symId * comm->bufThreshold);
+        devWork.tempbuff = (void*)((char*)comm->destRshmem + comm->symId * comm->bufThreshold);
 
 	if (task->func == ncclFuncAllToAllGda || (task->func == ncclFuncAllToAllvGda && (task->count <= 131072))) {
             comm->symId = (comm->symId + 1) % comm->numSymBuf;

--- a/projects/rccl/src/enqueue.cc
+++ b/projects/rccl/src/enqueue.cc
@@ -418,7 +418,9 @@ ncclResult_t ncclTasksRegAndEnqueue(struct ncclComm* comm) {
         devWork.sndbuff = (void*)comm->sourceRshmem[comm->symId];
         devWork.tempbuff = (void*)comm->destRshmem[comm->symId];
 
-        comm->symId = (comm->symId + 1) % comm->numSymBuf;
+	if (task->func == ncclFuncAllToAllGda) {
+            comm->symId = (comm->symId + 1) % comm->numSymBuf;
+	}
 
         devWork.size = task->count;
     }

--- a/projects/rccl/src/enqueue.cc
+++ b/projects/rccl/src/enqueue.cc
@@ -426,7 +426,7 @@ ncclResult_t ncclTasksRegAndEnqueue(struct ncclComm* comm) {
         devWork.size = task->count;
 	if (task->func == ncclFuncAlltoAllvGda) {
             devWork.rank = comm->rank;
-            devWork.sizes = comm->sizes;
+            devWork.sizes = task->sizes;
         }
     }
 #endif
@@ -2950,6 +2950,11 @@ static ncclResult_t collTaskAppend(
   t->count = info->count;
   t->root = info->root;
   t->datatype = info->datatype;
+
+#ifdef ENABLE_ROCSHMEM
+  t->sizes = info->comm->sizes;
+#endif
+
   size_t elementSize = ncclTypeSize(t->datatype);
   if (t->func == ncclFuncAllGather || t->func == ncclFuncBroadcast || t->func == ncclFuncAlltoAllPivot || t->func == ncclFuncAlltoAllGda || t->func == ncclFuncAlltoAllvGda) {
     t->count *= elementSize;

--- a/projects/rccl/src/enqueue.cc
+++ b/projects/rccl/src/enqueue.cc
@@ -427,10 +427,6 @@ ncclResult_t ncclTasksRegAndEnqueue(struct ncclComm* comm) {
 	if (task->func == ncclFuncAllToAllvGda) {
             devWork.rank = comm->rank;
             devWork.sizes = comm->sizes;
-            devWork.sendSizes = comm->sendSizes;
-            devWork.sendDispls = comm->sendDispls;
-            devWork.recvSizes = comm->recvSizes;
-            devWork.recvDispls = comm->recvDispls;
         }
     }
 #endif

--- a/projects/rccl/src/enqueue.cc
+++ b/projects/rccl/src/enqueue.cc
@@ -157,7 +157,7 @@ static inline int ncclFuncTrafficPerByte(ncclFunc_t func, int nRanks) {
   case ncclFuncAllReduce: return 2;
   case ncclFuncAllGather: return nRanks;
   case ncclFuncReduceScatter: return nRanks;
-  case ncclFuncAllToAllvGda: return nRanks;			      
+  case ncclFuncAlltoAllvGda: return nRanks;			      
   default: return 1;
   }
 }
@@ -412,19 +412,19 @@ ncclResult_t ncclTasksRegAndEnqueue(struct ncclComm* comm) {
     //[Added-comment] opCount is missing for collDevWork, adding here
     devWork.opCount = task->opCount;
 #ifdef ENABLE_ROCSHMEM
-    if (comm->enableRocshmem && (task->func == ncclFuncAllToAllGda || task->func == ncclFuncAllToAllvGda)) {
+    if (comm->enableRocshmem && (task->func == ncclFuncAlltoAllGda || task->func == ncclFuncAlltoAllvGda)) {
         devWork.enableRocshmem = comm->enableRocshmem;
         devWork.team = comm->team_reduce_world_dup;
 
         devWork.sndbuff = (void*)((char*)comm->sourceRshmem + comm->symId * comm->bufThreshold);
         devWork.tempbuff = (void*)((char*)comm->destRshmem + comm->symId * comm->bufThreshold);
 
-	if (task->func == ncclFuncAllToAllGda || (task->func == ncclFuncAllToAllvGda && (task->count <= 131072))) {
+	if (task->func == ncclFuncAlltoAllGda || (task->func == ncclFuncAlltoAllvGda && (task->count <= 131072))) {
             comm->symId = (comm->symId + 1) % comm->numSymBuf;
 	}
 
         devWork.size = task->count;
-	if (task->func == ncclFuncAllToAllvGda) {
+	if (task->func == ncclFuncAlltoAllvGda) {
             devWork.rank = comm->rank;
             devWork.sizes = comm->sizes;
         }
@@ -762,7 +762,7 @@ static ncclResult_t scheduleCollTasksToPlan(
         // Set pattern to profiler to add a proxy profiler for kernel events
         // for Direct Reduce Scatter (DRS), we don't need to add proxy op
         bool isDRS = task->func == ncclFuncReduceScatter && comm->enableDirectReduceScatter;
-        if (!isDRS && task->func != ncclFuncAllToAllGda && task->func != ncclFuncAllToAllvGda) {
+        if (!isDRS && task->func != ncclFuncAlltoAllGda && task->func != ncclFuncAlltoAllvGda) {
             NCCLCHECK(addProxyOpIfNeeded(comm, plan, &proxyOp));
             NCCLCHECK(addProfilerProxyOpIfNeeded(comm, plan, &proxyOp));
         }
@@ -914,7 +914,7 @@ static ncclResult_t scheduleCollTasksToPlan(
         // coverity[uninit_use_in_call:FALSE]
         // for Direct Reduce Scatter (DRS), we don't need to add proxy op
         bool isDRS = task->func == ncclFuncReduceScatter && comm->enableDirectReduceScatter;
-        if (!isDRS && task->func != ncclFuncAllToAllGda && task->func != ncclFuncAllToAllvGda) {
+        if (!isDRS && task->func != ncclFuncAlltoAllGda && task->func != ncclFuncAlltoAllvGda) {
             NCCLCHECK(addProxyOpIfNeeded(comm, plan, proxyOp));
             NCCLCHECK(addProfilerProxyOpIfNeeded(comm, plan, proxyOp));
         }
@@ -2122,7 +2122,7 @@ static ncclResult_t updateCollCostTable(
     float** collCostTable) {
   float (*table)[NCCL_NUM_PROTOCOLS] = (float (*)[NCCL_NUM_PROTOCOLS])collCostTable;
 
-  if (comm->nRanks == 1 || info->func == ncclFuncAlltoAllPivot || info->func == ncclFuncAllToAllGda || info->func == ncclFuncAllToAllvGda) {
+  if (comm->nRanks == 1 || info->func == ncclFuncAlltoAllPivot || info->func == ncclFuncAlltoAllGda || info->func == ncclFuncAlltoAllvGda) {
     table[NCCL_ALGO_RING][NCCL_PROTO_SIMPLE] = 0.0;
     return ncclSuccess;
   }
@@ -2264,7 +2264,7 @@ static ncclResult_t topoGetAlgoInfo(
   }
 
 #ifdef ENABLE_ROCSHMEM
-  if (info->func == ncclFuncAllToAllvGda || info->func == ncclFuncAllToAllGda) {
+  if (info->func == ncclFuncAlltoAllvGda || info->func == ncclFuncAlltoAllGda) {
       nc = 1;
   }
 #endif
@@ -2443,10 +2443,10 @@ static ncclResult_t calcCollChunking(
   case ncclFuncAlltoAllPivot:
     pattern = ncclPatternRing;
     break;
-  case ncclFuncAllToAllGda:
+  case ncclFuncAlltoAllGda:
     pattern = ncclPatternRing;
     break;
-  case ncclFuncAllToAllvGda:
+  case ncclFuncAlltoAllvGda:
     pattern = ncclPatternRing;
     break;
   case ncclFuncAllReduce:
@@ -2951,7 +2951,7 @@ static ncclResult_t collTaskAppend(
   t->root = info->root;
   t->datatype = info->datatype;
   size_t elementSize = ncclTypeSize(t->datatype);
-  if (t->func == ncclFuncAllGather || t->func == ncclFuncBroadcast || t->func == ncclFuncAlltoAllPivot || t->func == ncclFuncAllToAllGda || t->func == ncclFuncAllToAllvGda) {
+  if (t->func == ncclFuncAllGather || t->func == ncclFuncBroadcast || t->func == ncclFuncAlltoAllPivot || t->func == ncclFuncAlltoAllGda || t->func == ncclFuncAlltoAllvGda) {
     t->count *= elementSize;
     t->datatype = ncclInt8;
     elementSize = 1;

--- a/projects/rccl/src/enqueue.cc
+++ b/projects/rccl/src/enqueue.cc
@@ -2270,8 +2270,6 @@ static ncclResult_t topoGetAlgoInfo(
 #ifdef ENABLE_ROCSHMEM
   if (info->func == ncclFuncAllToAllvGda || info->func == ncclFuncAllToAllGda) {
       nc = 1;
-      nc = std::min(nc, 32);
-      comm->nChannels = std::min(comm->nChannels, 32);
   }
 #endif
 

--- a/projects/rccl/src/enqueue.cc
+++ b/projects/rccl/src/enqueue.cc
@@ -2952,7 +2952,12 @@ static ncclResult_t collTaskAppend(
   t->datatype = info->datatype;
 
 #ifdef ENABLE_ROCSHMEM
-  t->sizes = info->comm->sizes;
+  if (t->func == ncclFuncAlltoAllvGda && info->sizes != nullptr) {
+    size_t nSizes = 4 * comm->nRanks;
+    CUDACHECK(hipMallocManaged((void**)&t->sizes, nSizes * sizeof(size_t)));
+    ncclCommPushCudaFree(comm, t->sizes);
+    memcpy(t->sizes, info->sizes, nSizes * sizeof(size_t));
+  }
 #endif
 
   size_t elementSize = ncclTypeSize(t->datatype);

--- a/projects/rccl/src/enqueue.cc
+++ b/projects/rccl/src/enqueue.cc
@@ -157,6 +157,7 @@ static inline int ncclFuncTrafficPerByte(ncclFunc_t func, int nRanks) {
   case ncclFuncAllReduce: return 2;
   case ncclFuncAllGather: return nRanks;
   case ncclFuncReduceScatter: return nRanks;
+  case ncclFuncAllToAllvGda: return nRanks;			      
   default: return 1;
   }
 }
@@ -411,18 +412,26 @@ ncclResult_t ncclTasksRegAndEnqueue(struct ncclComm* comm) {
     //[Added-comment] opCount is missing for collDevWork, adding here
     devWork.opCount = task->opCount;
 #ifdef ENABLE_ROCSHMEM
-    if (comm->enableRocshmem && task->func == ncclFuncAllToAllGda) {
+    if (comm->enableRocshmem && (task->func == ncclFuncAllToAllGda || task->func == ncclFuncAllToAllvGda)) {
         devWork.enableRocshmem = comm->enableRocshmem;
         devWork.team = comm->team_reduce_world_dup;
 
         devWork.sndbuff = (void*)comm->sourceRshmem[comm->symId];
         devWork.tempbuff = (void*)comm->destRshmem[comm->symId];
 
-	if (task->func == ncclFuncAllToAllGda) {
+	if (task->func == ncclFuncAllToAllGda || (task->func == ncclFuncAllToAllvGda && (task->count <= 131072))) {
             comm->symId = (comm->symId + 1) % comm->numSymBuf;
 	}
 
         devWork.size = task->count;
+	if (task->func == ncclFuncAllToAllvGda) {
+            devWork.rank = comm->rank;
+            devWork.sizes = comm->sizes;
+            devWork.sendSizes = comm->sendSizes;
+            devWork.sendDispls = comm->sendDispls;
+            devWork.recvSizes = comm->recvSizes;
+            devWork.recvDispls = comm->recvDispls;
+        }
     }
 #endif
     // Direct Reduce Scatter
@@ -757,7 +766,7 @@ static ncclResult_t scheduleCollTasksToPlan(
         // Set pattern to profiler to add a proxy profiler for kernel events
         // for Direct Reduce Scatter (DRS), we don't need to add proxy op
         bool isDRS = task->func == ncclFuncReduceScatter && comm->enableDirectReduceScatter;
-        if (!isDRS && task->func != ncclFuncAllToAllGda) {
+        if (!isDRS && task->func != ncclFuncAllToAllGda && task->func != ncclFuncAllToAllvGda) {
             NCCLCHECK(addProxyOpIfNeeded(comm, plan, &proxyOp));
             NCCLCHECK(addProfilerProxyOpIfNeeded(comm, plan, &proxyOp));
         }
@@ -909,7 +918,7 @@ static ncclResult_t scheduleCollTasksToPlan(
         // coverity[uninit_use_in_call:FALSE]
         // for Direct Reduce Scatter (DRS), we don't need to add proxy op
         bool isDRS = task->func == ncclFuncReduceScatter && comm->enableDirectReduceScatter;
-        if (!isDRS && task->func != ncclFuncAllToAllGda) {
+        if (!isDRS && task->func != ncclFuncAllToAllGda && task->func != ncclFuncAllToAllvGda) {
             NCCLCHECK(addProxyOpIfNeeded(comm, plan, proxyOp));
             NCCLCHECK(addProfilerProxyOpIfNeeded(comm, plan, proxyOp));
         }
@@ -2117,7 +2126,7 @@ static ncclResult_t updateCollCostTable(
     float** collCostTable) {
   float (*table)[NCCL_NUM_PROTOCOLS] = (float (*)[NCCL_NUM_PROTOCOLS])collCostTable;
 
-  if (comm->nRanks == 1 || info->func == ncclFuncAlltoAllPivot || info->func == ncclFuncAllToAllGda) {
+  if (comm->nRanks == 1 || info->func == ncclFuncAlltoAllPivot || info->func == ncclFuncAllToAllGda || info->func == ncclFuncAllToAllvGda) {
     table[NCCL_ALGO_RING][NCCL_PROTO_SIMPLE] = 0.0;
     return ncclSuccess;
   }
@@ -2257,6 +2266,14 @@ static ncclResult_t topoGetAlgoInfo(
     INFO(NCCL_INIT, "post-adjustment based on threadThreshold:%i nBytes:%lu nc:%i", threadThreshold, nBytes, nc);
     rcclOverrideChannels(comm, info->func, nBytes, nc);
   }
+
+#ifdef ENABLE_ROCSHMEM
+  if (info->func == ncclFuncAllToAllvGda || info->func == ncclFuncAllToAllGda) {
+      nc = 1;
+      nc = std::min(nc, 32);
+      comm->nChannels = std::min(comm->nChannels, 32);
+  }
+#endif
 
 #if defined(__HIP_PLATFORM_AMD__) || defined(__HIPCC__)
 #else
@@ -2433,6 +2450,9 @@ static ncclResult_t calcCollChunking(
     pattern = ncclPatternRing;
     break;
   case ncclFuncAllToAllGda:
+    pattern = ncclPatternRing;
+    break;
+  case ncclFuncAllToAllvGda:
     pattern = ncclPatternRing;
     break;
   case ncclFuncAllReduce:
@@ -2937,7 +2957,7 @@ static ncclResult_t collTaskAppend(
   t->root = info->root;
   t->datatype = info->datatype;
   size_t elementSize = ncclTypeSize(t->datatype);
-  if (t->func == ncclFuncAllGather || t->func == ncclFuncBroadcast || t->func == ncclFuncAlltoAllPivot || t->func == ncclFuncAllToAllGda) {
+  if (t->func == ncclFuncAllGather || t->func == ncclFuncBroadcast || t->func == ncclFuncAlltoAllPivot || t->func == ncclFuncAllToAllGda || t->func == ncclFuncAllToAllvGda) {
     t->count *= elementSize;
     t->datatype = ncclInt8;
     elementSize = 1;

--- a/projects/rccl/src/include/comm.h
+++ b/projects/rccl/src/include/comm.h
@@ -758,13 +758,17 @@ struct ncclComm {
 
 #ifdef ENABLE_ROCSHMEM
   // circular ring buffer in rocshmem symmetric heap
-  void** sourceRshmem;
-  void** destRshmem;
+  void* sourceRshmem;
+  void* destRshmem;
+
   rocshmem::rocshmem_team_t team_reduce_world_dup;
   int enableRocshmem;
   int rocshmemThreshold;
   int numSymBuf;
   int symId;
+  size_t bufThreshold;
+  
+  //parameters introduce for alltoallv
   size_t* sizes;
   size_t* sendSizes;
   size_t* sendDispls;

--- a/projects/rccl/src/include/comm.h
+++ b/projects/rccl/src/include/comm.h
@@ -770,9 +770,6 @@ struct ncclComm {
   int numSymBuf;
   int symId;
   size_t bufThreshold;
-  
-  //parameter introduced for alltoallv
-  size_t* sizes;
 #endif
 
   // Direct Reduce Scatter [RCCL]

--- a/projects/rccl/src/include/comm.h
+++ b/projects/rccl/src/include/comm.h
@@ -768,12 +768,8 @@ struct ncclComm {
   int symId;
   size_t bufThreshold;
   
-  //parameters introduce for alltoallv
+  //parameter introduced for alltoallv
   size_t* sizes;
-  size_t* sendSizes;
-  size_t* sendDispls;
-  size_t* recvSizes;
-  size_t* recvDispls;
 #endif
 
   // Direct Reduce Scatter [RCCL]

--- a/projects/rccl/src/include/comm.h
+++ b/projects/rccl/src/include/comm.h
@@ -765,6 +765,11 @@ struct ncclComm {
   int rocshmemThreshold;
   int numSymBuf;
   int symId;
+  size_t* sizes;
+  size_t* sendSizes;
+  size_t* sendDispls;
+  size_t* recvSizes;
+  size_t* recvDispls;
 #endif
 
   // Direct Reduce Scatter [RCCL]

--- a/projects/rccl/src/include/comm.h
+++ b/projects/rccl/src/include/comm.h
@@ -218,6 +218,9 @@ struct ncclTaskColl {
 #else
   int32_t nMaxChannels:8;
 #endif
+#ifdef ENABLE_ROCSHMEM
+  size_t* sizes;
+#endif
   int32_t nWarps:8;
   int32_t algorithm:8, protocol:8, pipeline:8;
   uint32_t isCollnet:1, isNvls:1, isSymLast:1;

--- a/projects/rccl/src/include/device.h
+++ b/projects/rccl/src/include/device.h
@@ -41,7 +41,7 @@
 #include <rocshmem/rocshmem.hpp>
 #endif
 
-extern const char* ncclFuncStr[NCCL_NUM_FUNCTIONS+3];
+extern const char* ncclFuncStr[NCCL_NUM_FUNCTIONS+4];
 
 extern const char* ncclAlgoStr[NCCL_NUM_ALGORITHMS];
 
@@ -428,6 +428,12 @@ struct alignas(16) ncclDevWorkColl {
   void* tempbuff;
   void* sndbuff;
   int size;
+  int rank;
+  size_t *sizes;
+  size_t *sendSizes;
+  size_t *sendDispls;
+  size_t *recvSizes;
+  size_t *recvDispls;
 #endif
 };
 
@@ -818,7 +824,7 @@ inline int ncclDevFuncId(int coll, int devRedOp, int type, int algo, int proto, 
   if (coll == ncclFuncBroadcast) {
     key = ((uint64_t)(coll     & RCCL_FUNC_ID_MASK) << RCCL_COLL_SHIFT ) |
           ((uint64_t)(proto    & RCCL_FUNC_ID_MASK) << RCCL_PROTO_SHIFT);
-  } else if (coll == ncclFuncSendRecv || coll == ncclFuncAlltoAllPivot || coll == ncclFuncAllToAllGda) {
+  } else if (coll == ncclFuncSendRecv || coll == ncclFuncAlltoAllPivot || coll == ncclFuncAllToAllGda || coll == ncclFuncAllToAllvGda) {
     key = ((uint64_t)(coll     & RCCL_FUNC_ID_MASK) << RCCL_COLL_SHIFT );
   } else {
     key = ((uint64_t)(coll     & RCCL_FUNC_ID_MASK) << RCCL_COLL_SHIFT ) |

--- a/projects/rccl/src/include/device.h
+++ b/projects/rccl/src/include/device.h
@@ -824,7 +824,7 @@ inline int ncclDevFuncId(int coll, int devRedOp, int type, int algo, int proto, 
   if (coll == ncclFuncBroadcast) {
     key = ((uint64_t)(coll     & RCCL_FUNC_ID_MASK) << RCCL_COLL_SHIFT ) |
           ((uint64_t)(proto    & RCCL_FUNC_ID_MASK) << RCCL_PROTO_SHIFT);
-  } else if (coll == ncclFuncSendRecv || coll == ncclFuncAlltoAllPivot || coll == ncclFuncAllToAllGda || coll == ncclFuncAllToAllvGda) {
+  } else if (coll == ncclFuncSendRecv || coll == ncclFuncAlltoAllPivot || coll == ncclFuncAlltoAllGda || coll == ncclFuncAlltoAllvGda) {
     key = ((uint64_t)(coll     & RCCL_FUNC_ID_MASK) << RCCL_COLL_SHIFT );
   } else {
     key = ((uint64_t)(coll     & RCCL_FUNC_ID_MASK) << RCCL_COLL_SHIFT ) |

--- a/projects/rccl/src/include/info.h
+++ b/projects/rccl/src/include/info.h
@@ -30,6 +30,10 @@ struct ncclInfo {
   int chunkSteps;
   int sliceSteps;
   const void* acc;
+#ifdef ENABLE_ROCSHMEM
+  // Optional per-operation metadata for rocSHMEM collectives.
+  size_t* sizes;
+#endif
 };
 
 #endif

--- a/projects/rccl/src/include/nccl_common.h
+++ b/projects/rccl/src/include/nccl_common.h
@@ -73,7 +73,8 @@ typedef enum {
   ncclFuncGather = 10,
   ncclFuncAlltoAllPivot = 11,
   ncclFuncAllToAllGda = 12,
-  ncclNumFuncs = 13
+  ncclFuncAllToAllvGda = 13,
+  ncclNumFuncs = 14
 } ncclFunc_t;
 
 

--- a/projects/rccl/src/include/nccl_common.h
+++ b/projects/rccl/src/include/nccl_common.h
@@ -72,8 +72,8 @@ typedef enum {
   ncclFuncScatter = 9,
   ncclFuncGather = 10,
   ncclFuncAlltoAllPivot = 11,
-  ncclFuncAllToAllGda = 12,
-  ncclFuncAllToAllvGda = 13,
+  ncclFuncAlltoAllGda = 12,
+  ncclFuncAlltoAllvGda = 13,
   ncclNumFuncs = 14
 } ncclFunc_t;
 

--- a/projects/rccl/src/include/rccl_common.h
+++ b/projects/rccl/src/include/rccl_common.h
@@ -119,7 +119,7 @@ NCCL_API(ncclResult_t, rcclGetAlgoName, int algo, const char** algoName);
 NCCL_API(ncclResult_t, rcclGetProtocolName, int protocol, const char** algoName);
 bool rcclUseAllGatherDirect(struct ncclComm* comm, size_t& msgSize);
 bool rcclUseReduceScatterDirect(struct ncclComm* comm, size_t& msgSize);
-bool rcclUseAllToAllGda(struct ncclComm* comm);
+bool rcclUseAlltoAllGda(struct ncclComm* comm);
 void rcclSetPxn(struct ncclComm* comm,  int& rcclPxnDisable);
 void rcclSetP2pNetChunkSize(struct ncclComm* comm,  int& rcclP2pNetChunkSize);
 ncclResult_t rcclFuncMaxSendRecvCount(ncclFunc_t func, int nRanks, size_t count, size_t& maxCount);

--- a/projects/rccl/src/init.cc
+++ b/projects/rccl/src/init.cc
@@ -2283,6 +2283,13 @@ static ncclResult_t ncclCommInitRankFunc(struct ncclAsyncJob* job_) {
     	comm->sourceRshmem[i] = (void *)rocshmem::rocshmem_malloc((size_t)(128*1024*1024));
     	comm->destRshmem[i] = (void *)rocshmem::rocshmem_malloc((size_t)(128*1024*1024));
     }
+    hipMallocManaged((void**)&comm->sizes, job->nranks * 4 * sizeof(size_t));
+
+    comm->sendSizes = (size_t*)rocshmem::rocshmem_malloc(job->nranks  * sizeof(size_t));
+    comm->sendDispls = (size_t*)rocshmem::rocshmem_malloc(job->nranks * sizeof(size_t));
+
+    comm->recvSizes = (size_t*)rocshmem::rocshmem_malloc(job->nranks * sizeof(size_t));
+    comm->recvDispls = (size_t*)rocshmem::rocshmem_malloc(job->nranks * sizeof(size_t));
 
     comm->enableRocshmem = rcclParamRocshmemEnabled();
     comm->rocshmemThreshold = rcclParamRocshmemThreshold();

--- a/projects/rccl/src/init.cc
+++ b/projects/rccl/src/init.cc
@@ -67,7 +67,7 @@
 
 #ifdef ENABLE_ROCSHMEM
 #include <rocshmem/rocshmem.hpp>
-#define NUM_SYM_BUF 8
+#define NUM_SYM_BUF 2
 #endif
 
 
@@ -95,7 +95,7 @@
 
 using namespace rccl;
 
-const char* ncclFuncStr[NCCL_NUM_FUNCTIONS+3] = { "AllGather", "AllReduce", "AlltoAllPivot", "AllToAllGda", "Broadcast", "Reduce", "ReduceScatter", "SendRecv"};
+const char* ncclFuncStr[NCCL_NUM_FUNCTIONS+4] = { "AllGather", "AllReduce", "AlltoAllPivot", "AllToAllGda", "AllToAllvGda", "Broadcast", "Reduce", "ReduceScatter", "SendRecv"};
 const char* ncclAlgoStr[NCCL_NUM_ALGORITHMS] = { "Tree", "Ring", "CollNetDirect", "CollNetChain", "NVLS", "NVLSTree", "PAT" };
 const char* ncclProtoStr[NCCL_NUM_PROTOCOLS] = { "LL", "LL128", "Simple" };
 const char* ncclDevRedOpStr[ncclNumDevRedOps] = { "Sum", "Prod", "MinMax", "PreMulSum", "SumPostDiv" };
@@ -2280,8 +2280,8 @@ static ncclResult_t ncclCommInitRankFunc(struct ncclAsyncJob* job_) {
     comm->destRshmem = (void**) malloc(NUM_SYM_BUF * sizeof(void *));
 
     for (int i = 0; i < NUM_SYM_BUF; i++) {
-    	comm->sourceRshmem[i] = (void *)rocshmem::rocshmem_malloc((size_t)(1*1024*1024));
-    	comm->destRshmem[i] = (void *)rocshmem::rocshmem_malloc((size_t)(1*1024*1024));
+    	comm->sourceRshmem[i] = (void *)rocshmem::rocshmem_malloc((size_t)(128*1024*1024));
+    	comm->destRshmem[i] = (void *)rocshmem::rocshmem_malloc((size_t)(128*1024*1024));
     }
 
     comm->enableRocshmem = rcclParamRocshmemEnabled();

--- a/projects/rccl/src/init.cc
+++ b/projects/rccl/src/init.cc
@@ -2296,8 +2296,6 @@ static ncclResult_t ncclCommInitRankFunc(struct ncclAsyncJob* job_) {
     comm->destRshmem = (void *)rocshmem::rocshmem_malloc(rocshmemHeapSize);
     INFO(NCCL_INIT, "Symmetric memory allocated: size %zu", rocshmemHeapSize); 
 
-    CUDACHECK(hipMallocManaged((void**)&comm->sizes, job->nranks * 4 * sizeof(size_t)));
-
     comm->enableRocshmem = rcclParamRocshmemEnabled();
     comm->rocshmemThreshold = rcclParamRocshmemThreshold();
     comm->numSymBuf = NUM_SYM_BUF;
@@ -3192,7 +3190,6 @@ ncclResult_t ncclCommDestroy_impl(ncclComm_t comm) {
   if (comm->enableRocshmem) {
     rocshmem::rocshmem_free(comm->sourceRshmem);
     rocshmem::rocshmem_free(comm->destRshmem);	 
-    CUDACHECK(hipFree(comm->sizes)); 
     //TODO: subcomm check
     rocshmem::rocshmem_team_t  team;
     if (!ncclCommToRshmemTeam.empty()) {

--- a/projects/rccl/src/init.cc
+++ b/projects/rccl/src/init.cc
@@ -2298,12 +2298,6 @@ static ncclResult_t ncclCommInitRankFunc(struct ncclAsyncJob* job_) {
 
     hipMallocManaged((void**)&comm->sizes, job->nranks * 4 * sizeof(size_t));
 
-    comm->sendSizes = (size_t*)rocshmem::rocshmem_malloc(job->nranks  * sizeof(size_t));
-    comm->sendDispls = (size_t*)rocshmem::rocshmem_malloc(job->nranks * sizeof(size_t));
-
-    comm->recvSizes = (size_t*)rocshmem::rocshmem_malloc(job->nranks * sizeof(size_t));
-    comm->recvDispls = (size_t*)rocshmem::rocshmem_malloc(job->nranks * sizeof(size_t));
-
     comm->enableRocshmem = rcclParamRocshmemEnabled();
     comm->rocshmemThreshold = rcclParamRocshmemThreshold();
     comm->numSymBuf = NUM_SYM_BUF;

--- a/projects/rccl/src/init.cc
+++ b/projects/rccl/src/init.cc
@@ -95,7 +95,7 @@
 
 using namespace rccl;
 
-const char* ncclFuncStr[NCCL_NUM_FUNCTIONS+4] = { "AllGather", "AllReduce", "AlltoAllPivot", "AllToAllGda", "AllToAllvGda", "Broadcast", "Reduce", "ReduceScatter", "SendRecv"};
+const char* ncclFuncStr[NCCL_NUM_FUNCTIONS+4] = { "AllGather", "AllReduce", "AlltoAllPivot", "AllToAllGda", "AllToAllvGda", "Broadcast", "Reduce", "ReduceScatter", "SendRecv"};	//Increased numFunc by 1 for AlltollvGda
 const char* ncclAlgoStr[NCCL_NUM_ALGORITHMS] = { "Tree", "Ring", "CollNetDirect", "CollNetChain", "NVLS", "NVLSTree", "PAT" };
 const char* ncclProtoStr[NCCL_NUM_PROTOCOLS] = { "LL", "LL128", "Simple" };
 const char* ncclDevRedOpStr[ncclNumDevRedOps] = { "Sum", "Prod", "MinMax", "PreMulSum", "SumPostDiv" };
@@ -2279,13 +2279,17 @@ static ncclResult_t ncclCommInitRankFunc(struct ncclAsyncJob* job_) {
     const char* inputStr = std::getenv("ROCSHMEM_HEAP_SIZE");
     size_t rocshmemHeapSize = 0;
 
-    if (inputStr != nullptr)
-    	rocshmemHeapSize = std::stoull(inputStr);
+    try {
+        if (inputStr != nullptr)
+    	    rocshmemHeapSize = std::stoull(inputStr);
+    } catch (const std::exception& e) {
+        std::cerr << "Error related to ROCSHMEM HEAP SIZE " << inputStr << ": " << e.what() << std::endl;
+    }
 
-    if (rocshmemHeapSize <= (size_t)(1073741824)) {
-	rocshmemHeapSize = (size_t)(256*1024*1024);
+    if (rocshmemHeapSize <= (size_t)(1073741824)) {	//default rocshmem heap size is 1GB
+	rocshmemHeapSize = (size_t)(256*1024*1024);	//default size of symmetric allocation 256MB
     } else if (rocshmemHeapSize > (size_t)(2147483648)) {
-	rocshmemHeapSize = (size_t)(1024*1024*1024);
+	rocshmemHeapSize = (size_t)(1024*1024*1024);	//increase symmetric allocation size for heap size > 2GB
     }
     
     comm->sourceRshmem = (void *)rocshmem::rocshmem_malloc(rocshmemHeapSize);
@@ -3193,8 +3197,7 @@ ncclResult_t ncclCommDestroy_impl(ncclComm_t comm) {
 #ifdef ENABLE_ROCSHMEM
   if (comm->enableRocshmem) {
     rocshmem::rocshmem_free(comm->sourceRshmem);
-    rocshmem::rocshmem_free(comm->destRshmem);
-	  
+    rocshmem::rocshmem_free(comm->destRshmem);	  
     //TODO: subcomm check
     rocshmem::rocshmem_team_t  team;
     if (!ncclCommToRshmemTeam.empty()) {

--- a/projects/rccl/src/init.cc
+++ b/projects/rccl/src/init.cc
@@ -95,7 +95,7 @@
 
 using namespace rccl;
 
-const char* ncclFuncStr[NCCL_NUM_FUNCTIONS+4] = { "AllGather", "AllReduce", "AlltoAllPivot", "AllToAllGda", "AllToAllvGda", "Broadcast", "Reduce", "ReduceScatter", "SendRecv"};	//Increased numFunc by 1 for AlltollvGda
+const char* ncclFuncStr[NCCL_NUM_FUNCTIONS+4] = { "AllGather", "AllReduce", "AlltoAllPivot", "AlltoAllGda", "AlltoAllvGda", "Broadcast", "Reduce", "ReduceScatter", "SendRecv"};	//Increased numFunc by 1 for AlltollvGda
 const char* ncclAlgoStr[NCCL_NUM_ALGORITHMS] = { "Tree", "Ring", "CollNetDirect", "CollNetChain", "NVLS", "NVLSTree", "PAT" };
 const char* ncclProtoStr[NCCL_NUM_PROTOCOLS] = { "LL", "LL128", "Simple" };
 const char* ncclDevRedOpStr[ncclNumDevRedOps] = { "Sum", "Prod", "MinMax", "PreMulSum", "SumPostDiv" };
@@ -2287,16 +2287,16 @@ static ncclResult_t ncclCommInitRankFunc(struct ncclAsyncJob* job_) {
     }
 
     if (rocshmemHeapSize <= (size_t)(1073741824)) {	//default rocshmem heap size is 1GB
-	rocshmemHeapSize = (size_t)(256*1024*1024);	//default size of symmetric allocation 256MB
+	    rocshmemHeapSize = (size_t)(256*1024*1024);	//default size of symmetric allocation 256MB
     } else if (rocshmemHeapSize > (size_t)(2147483648)) {
-	rocshmemHeapSize = (size_t)(1024*1024*1024);	//increase symmetric allocation size for heap size > 2GB
+	    rocshmemHeapSize = (size_t)(1024*1024*1024); //increase symmetric allocation size for heap size > 2GB
     }
     
     comm->sourceRshmem = (void *)rocshmem::rocshmem_malloc(rocshmemHeapSize);
     comm->destRshmem = (void *)rocshmem::rocshmem_malloc(rocshmemHeapSize);
     INFO(NCCL_INIT, "Symmetric memory allocated: size %zu", rocshmemHeapSize); 
 
-    hipMallocManaged((void**)&comm->sizes, job->nranks * 4 * sizeof(size_t));
+    CUDACHECK(hipMallocManaged((void**)&comm->sizes, job->nranks * 4 * sizeof(size_t)));
 
     comm->enableRocshmem = rcclParamRocshmemEnabled();
     comm->rocshmemThreshold = rcclParamRocshmemThreshold();
@@ -3191,7 +3191,8 @@ ncclResult_t ncclCommDestroy_impl(ncclComm_t comm) {
 #ifdef ENABLE_ROCSHMEM
   if (comm->enableRocshmem) {
     rocshmem::rocshmem_free(comm->sourceRshmem);
-    rocshmem::rocshmem_free(comm->destRshmem);	  
+    rocshmem::rocshmem_free(comm->destRshmem);	 
+    CUDACHECK(hipFree(comm->sizes)); 
     //TODO: subcomm check
     rocshmem::rocshmem_team_t  team;
     if (!ncclCommToRshmemTeam.empty()) {

--- a/projects/rccl/src/init.cc
+++ b/projects/rccl/src/init.cc
@@ -2248,7 +2248,7 @@ static ncclResult_t ncclCommInitRankFunc(struct ncclAsyncJob* job_) {
   NCCLCHECK(commSetUnrollFactor(comm));
 
 #ifdef ENABLE_ROCSHMEM
-  if (rcclParamRocshmemEnabled()) { // @TODO - This doesn't seem to disable when I set ROCSHMEM_ENABLE=0 on command line
+  if (!job->parent && rcclParamRocshmemEnabled()) {
     INFO(NCCL_INIT,"Initializing rocSHMEM inside of RCCL");
     int ret;
     rocshmem::rocshmem_uniqueid_t rocshmemUniqueId;
@@ -2276,13 +2276,22 @@ static ncclResult_t ncclCommInitRankFunc(struct ncclAsyncJob* job_) {
       return ncclSystemError;
     }
 
-    comm->sourceRshmem = (void**) malloc(NUM_SYM_BUF * sizeof(void *));
-    comm->destRshmem = (void**) malloc(NUM_SYM_BUF * sizeof(void *));
+    const char* inputStr = std::getenv("ROCSHMEM_HEAP_SIZE");
+    size_t rocshmemHeapSize = 0;
 
-    for (int i = 0; i < NUM_SYM_BUF; i++) {
-    	comm->sourceRshmem[i] = (void *)rocshmem::rocshmem_malloc((size_t)(128*1024*1024));
-    	comm->destRshmem[i] = (void *)rocshmem::rocshmem_malloc((size_t)(128*1024*1024));
+    if (inputStr != nullptr)
+    	rocshmemHeapSize = std::stoull(inputStr);
+
+    if (rocshmemHeapSize <= (size_t)(1073741824)) {
+	rocshmemHeapSize = (size_t)(256*1024*1024);
+    } else if (rocshmemHeapSize > (size_t)(2147483648)) {
+	rocshmemHeapSize = (size_t)(1024*1024*1024);
     }
+    
+    comm->sourceRshmem = (void *)rocshmem::rocshmem_malloc(rocshmemHeapSize);
+    comm->destRshmem = (void *)rocshmem::rocshmem_malloc(rocshmemHeapSize);
+    INFO(NCCL_INIT, "Symmetric memory allocated: size %zu", rocshmemHeapSize); 
+
     hipMallocManaged((void**)&comm->sizes, job->nranks * 4 * sizeof(size_t));
 
     comm->sendSizes = (size_t*)rocshmem::rocshmem_malloc(job->nranks  * sizeof(size_t));
@@ -2295,6 +2304,7 @@ static ncclResult_t ncclCommInitRankFunc(struct ncclAsyncJob* job_) {
     comm->rocshmemThreshold = rcclParamRocshmemThreshold();
     comm->numSymBuf = NUM_SYM_BUF;
     comm->symId = 0;
+    comm->bufThreshold = rocshmemHeapSize/2;
     //rocshmem::rocshmem_team_t team_reduce_world_dup;
     comm->team_reduce_world_dup = rocshmem::ROCSHMEM_TEAM_INVALID;
     rocshmem::rocshmem_team_split_strided(rocshmem::ROCSHMEM_TEAM_WORLD, 0, 1, job->nranks, nullptr, 0,
@@ -3182,13 +3192,9 @@ ncclResult_t ncclCommDestroy_impl(ncclComm_t comm) {
 
 #ifdef ENABLE_ROCSHMEM
   if (comm->enableRocshmem) {
-     for (int i = 0; i < NUM_SYM_BUF; i++) {
-     	rocshmem::rocshmem_free(comm->sourceRshmem[i]);
-     	rocshmem::rocshmem_free(comm->destRshmem[i]);
-     }
-     free(comm->sourceRshmem);
-     free(comm->destRshmem);
-
+    rocshmem::rocshmem_free(comm->sourceRshmem);
+    rocshmem::rocshmem_free(comm->destRshmem);
+	  
     //TODO: subcomm check
     rocshmem::rocshmem_team_t  team;
     if (!ncclCommToRshmemTeam.empty()) {

--- a/projects/rccl/src/rccl_wrap.cc
+++ b/projects/rccl/src/rccl_wrap.cc
@@ -398,9 +398,8 @@ ncclResult_t rcclGetProtocolName(int protocol, const char** protocolName) {
 
 bool rcclUseAllToAllGda(struct ncclComm* comm) {
 
-    //TODO: enable on MI350;  currently tested on MI300X
 #ifdef ENABLE_ROCSHMEM
-  if (comm->enableRocshmem && IsArchMatch(comm->topo->nodes[GPU].nodes[0].gpu.gcn, "gfx942") && comm->nNodes > 1 && (comm->nRanks/comm->nNodes == 8) && comm->rocshmemThreshold <= 1048576) {
+  if (comm->enableRocshmem && comm->nNodes > 1 && (comm->nRanks/comm->nNodes == 8) && comm->rocshmemThreshold <= 1048576) {
       INFO(NCCL_INIT, "Enabling GDA alltoall for RCCL");
       return true;
   }

--- a/projects/rccl/src/rccl_wrap.cc
+++ b/projects/rccl/src/rccl_wrap.cc
@@ -396,7 +396,7 @@ ncclResult_t rcclGetProtocolName(int protocol, const char** protocolName) {
   return ncclSuccess;
 }
 
-bool rcclUseAllToAllGda(struct ncclComm* comm) {
+bool rcclUseAlltoAllGda(struct ncclComm* comm) {
 
 #ifdef ENABLE_ROCSHMEM
   if (comm->enableRocshmem && comm->nNodes > 1 && (comm->nRanks/comm->nNodes == 8) && comm->rocshmemThreshold <= 1048576) {

--- a/projects/rccl/tools/topo_expl/utils.cpp
+++ b/projects/rccl/tools/topo_expl/utils.cpp
@@ -32,7 +32,7 @@
 #include "utils.h"
 #include "rocm_smi/rocm_smi.h"
 
-const char* ncclFuncStr[NCCL_NUM_FUNCTIONS+3] = { "AllGather", "AllReduce", "AlltoAllPivot", "AllToAllGda", "Broadcast", "Reduce", "ReduceScatter", "SendRecv" };
+const char* ncclFuncStr[NCCL_NUM_FUNCTIONS+4] = { "AllGather", "AllReduce", "AlltoAllPivot", "AlltoAllGda", "AlltoAllvGda", "Broadcast", "Reduce", "ReduceScatter", "SendRecv" };
 const char* ncclAlgoStr[NCCL_NUM_ALGORITHMS] = { "Tree", "Ring", "CollNetDirect", "CollNetChain", "NVLS", "NVLSTree", "PAT" };
 const char* ncclProtoStr[NCCL_NUM_PROTOCOLS] = { "LL", "LL128", "Simple" };
 


### PR DESCRIPTION
## Motivation
This PR adds GPU-Direct Async kernel initiated communication support for RCCL `alltoallv` via rocSHMEM integration.

## Technical Details
For large messages, it uses `hipMemcpyAsync()` for copy-in/copy-out to/from rocSHMEM symmetric memory. It also uses a single CU to launch the `alltoallv` kernel and invokes `rocshmem_alltoallv()`.

## JIRA ID
AICOMRCCL-576


## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result
Shows up to 20% improvement over vanilla RCCL `alltoallv` on 32 GPUs (MI300+Thor2)


## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
