### PR TITLE
[SWDEV-556456] Align HIP_UUID with rocminfo

### DIFF
--- a/projects/amdsmi/include/amd_smi/amdsmi.h
+++ b/projects/amdsmi/include/amd_smi/amdsmi.h
@@ -963,7 +963,7 @@ typedef struct {
     uint32_t subvendor_id;             //!< The subsystem vendor ID
     uint64_t device_id;                //!< The device ID of a GPU
     uint32_t rev_id;                   //!< The revision ID of a GPU
-    char asic_serial[AMDSMI_MAX_STRING_LENGTH];
+    char asic_serial[AMDSMI_MAX_STRING_LENGTH];  //!< The socket's unique serial number, 0xFFFFFFFF if not supported
     uint32_t oam_id;                   //!< Corresponds to socket number, 0xFFFFFFFF if not supported
     uint32_t num_of_compute_units;     //!< 0xFFFFFFFF if not supported
     uint64_t target_graphics_version;  //!< 0xFFFFFFFFFFFFFFFF if not supported

--- a/projects/amdsmi/include/amd_smi/impl/amd_smi_uuid.h
+++ b/projects/amdsmi/include/amd_smi/impl/amd_smi_uuid.h
@@ -32,7 +32,7 @@
  *
  *  \param [in]  did      Device ID
  *
- *  \param [in]  idx      PF/VF index
+ *  \param [in]  idx      PF/VF/Partition index
  *
  *  \return SMI_RET_CODE indicating result.
  */

--- a/projects/amdsmi/rocm_smi/include/rocm_smi/rocm_smi.h
+++ b/projects/amdsmi/rocm_smi/include/rocm_smi/rocm_smi.h
@@ -2122,6 +2122,29 @@ rsmi_status_t rsmi_dev_subsystem_vendor_id_get(uint32_t dv_ind, uint16_t *id);
 rsmi_status_t rsmi_dev_unique_id_get(uint32_t dv_ind, uint64_t *id);
 
 /**
+ *  @brief Get asic serial ID
+ *
+ *  @details Given a device index @p dv_ind and a pointer to a uint64_t @p
+ *  id, this function will write the asic serial ID of the GPU pointed to @p
+ *  id.
+ *
+ *  @param[in] dv_ind a device index
+ *
+ *  @param[inout] id a pointer to uint64_t to which the asic serial ID of the GPU
+ *  is written
+ *  If this parameter is nullptr, this function will return
+ *  ::RSMI_STATUS_INVALID_ARGS if the function is supported with the provided,
+ *  arguments and ::RSMI_STATUS_NOT_SUPPORTED if it is not supported with the
+ *  provided arguments.
+ *
+ *  @retval ::RSMI_STATUS_SUCCESS call was successful
+ *  @retval ::RSMI_STATUS_NOT_SUPPORTED installed software or hardware does not
+ *  support this function with the given arguments
+ *  @retval ::RSMI_STATUS_INVALID_ARGS the provided arguments are not valid
+ */
+rsmi_status_t rsmi_dev_asic_serial_get(uint32_t dv_ind, uint64_t *id);
+
+/**
  *  @brief Get the XGMI physical id associated with the device
  *
  *  @details Given a device index @p dv_ind and a pointer to a uint32_t to

--- a/projects/amdsmi/rocm_smi/src/rocm_smi.cc
+++ b/projects/amdsmi/rocm_smi/src/rocm_smi.cc
@@ -5081,21 +5081,14 @@ rsmi_dev_unique_id_get(uint32_t dv_ind, uint64_t *unique_id) {
     return RSMI_STATUS_INVALID_ARGS;
   }
   *unique_id = std::numeric_limits<uint64_t>::max();
-  ret = get_dev_value_int(amd::smi::kDevUniqueId, dv_ind, unique_id);
-
-  ss << __PRETTY_FUNCTION__
-     << (ret == RSMI_STATUS_SUCCESS ?
-      " | No fall back needed retrieved from KGD" : " | fall back needed")
-     << " | Device #: " << std::to_string(dv_ind)
-     << " | Data: unique_id = " << std::to_string(*unique_id)
-     << " | ret = " << getRSMIStatusString(ret, false);
-  LOG_DEBUG(ss);
-  // If the unique ID is not supported, use KFD's unique ID
-  if (ret != RSMI_STATUS_SUCCESS) {
-    GET_DEV_AND_KFDNODE_FROM_INDX
-    uint32_t node_id;
-    uint64_t kfd_unique_id;
-    int ret_kfd = kfd_node->get_node_id(&node_id);
+  GET_DEV_AND_KFDNODE_FROM_INDX
+  uint32_t node_id = 0;
+  uint64_t kfd_unique_id;
+  int ret_kfd = kfd_node->get_node_id(&node_id);
+  if (ret_kfd != 0) {
+    *unique_id = std::numeric_limits<uint64_t>::max();
+    ret = RSMI_STATUS_NOT_SUPPORTED;
+  } else {
     ret_kfd = amd::smi::read_node_properties(node_id, "unique_id", &kfd_unique_id);
     if (ret_kfd == 0) {
       *unique_id = kfd_unique_id;
@@ -5104,15 +5097,46 @@ rsmi_dev_unique_id_get(uint32_t dv_ind, uint64_t *unique_id) {
       *unique_id = std::numeric_limits<uint64_t>::max();
       ret = RSMI_STATUS_NOT_SUPPORTED;
     }
-    ss << __PRETTY_FUNCTION__
-       << " | Issue: Could not read unique_id from sysfs, falling back to KFD" << "\n"
-       << " ; Device #: " << std::to_string(dv_ind) << "\n"
-       << " ; ret_kfd: " << std::to_string(ret_kfd) << "\n"
-       << " ; node: " << std::to_string(node_id) << "\n"
-       << " ; Data: unique_id (from KFD)= " << std::to_string(*unique_id) << "\n"
-       << " ; ret = " << getRSMIStatusString(ret, false);
-    LOG_DEBUG(ss);
   }
+
+  ss << __PRETTY_FUNCTION__
+     << " ; Device #: " << std::to_string(dv_ind) << "\n"
+     << " ; ret_kfd: " << std::to_string(ret_kfd) << "\n"
+     << " ; node: " << std::to_string(node_id) << "\n"
+     << " ; Data: unique_id (from KFD)= " << std::to_string(*unique_id) << "\n"
+     << " ; Hex Data: unique_id (from KFD)= 0x" << std::hex << *unique_id << std::dec << "\n"
+     << " ; ret = " << getRSMIStatusString(ret, false);
+  LOG_DEBUG(ss);
+  return ret;
+
+  CATCH
+}
+
+rsmi_status_t
+rsmi_dev_asic_serial_get(uint32_t dv_ind, uint64_t *serial_id) {
+  TRY
+  rsmi_status_t ret;
+  std::ostringstream ss;
+  ss << __PRETTY_FUNCTION__ << "| ======= start =======";
+  LOG_TRACE(ss);
+
+  DEVICE_MUTEX
+  if (!serial_id) {
+    return RSMI_STATUS_INVALID_ARGS;
+  }
+  *serial_id = std::numeric_limits<uint64_t>::max();
+
+  uint64_t asic_serial_id;
+  ret = get_dev_value_int(amd::smi::kDevUniqueId, dv_ind, &asic_serial_id);
+  if (ret == RSMI_STATUS_SUCCESS) {
+    *serial_id = asic_serial_id;
+  }
+  ss << __PRETTY_FUNCTION__
+     << " ; Device #: " << std::to_string(dv_ind) << "\n"
+     << " ; Data: asic_serial_id = " << std::to_string(*serial_id) << "\n"
+     << " ; Hex Data: asic_serial_id = 0x" << std::hex << *serial_id << std::dec << "\n"
+     << " ; ret = " << getRSMIStatusString(ret, false);
+  LOG_DEBUG(ss);
   return ret;
 
   CATCH

--- a/projects/amdsmi/src/amd_smi/amd_smi.cc
+++ b/projects/amdsmi/src/amd_smi/amd_smi.cc
@@ -1272,6 +1272,7 @@ amdsmi_get_gpu_device_uuid(amdsmi_processor_handle processor_handle,
 
     uint64_t device_uuid = 0;
     uint16_t device_id = std::numeric_limits<uint16_t>::max();
+    uint8_t partition_idx = 0xff;
     amdsmi_status_t status;
     std::ostringstream ss;
 
@@ -1289,6 +1290,14 @@ amdsmi_get_gpu_device_uuid(amdsmi_processor_handle processor_handle,
        << "; rsmi_dev_id_get() status: "
        << smi_amdgpu_get_status_string(status, false) << "\n";
 
+    // Get partition index from KFD info for unique UUID generation
+    amdsmi_kfd_info_t kfd_info = {};
+    amdsmi_status_t kfd_status = amdsmi_get_gpu_kfd_info(processor_handle, &kfd_info);
+    if (kfd_status == AMDSMI_STATUS_SUCCESS
+        && kfd_info.current_partition_id != 0xFFFFFFFF) {
+        partition_idx = static_cast<uint8_t>(kfd_info.current_partition_id);
+    }
+
     status = rsmi_wrapper(rsmi_dev_unique_id_get, processor_handle, 0,
                             &device_uuid);
     if (status != AMDSMI_STATUS_SUCCESS) {
@@ -1300,11 +1309,10 @@ amdsmi_get_gpu_device_uuid(amdsmi_processor_handle processor_handle,
        << "; rsmi_dev_unique_id_get() status: "
        << smi_amdgpu_get_status_string(status, false) << "\n";
 
-    const uint8_t fcn = 0xff;
-
-    /* generate random UUID */
-    status = amdsmi_uuid_gen(uuid, device_uuid, device_id, fcn);
+    /* generate UUID with partition index */
+    status = amdsmi_uuid_gen(uuid, device_uuid, device_id, partition_idx);
     ss << "; uuid: " << uuid << "\n"
+       << "; partition_idx: " << static_cast<int>(partition_idx) << "\n"
        << "; amdsmi_uuid_gen() status: "
        << smi_amdgpu_get_status_string(status, false) << "\n";
     LOG_INFO(ss);

--- a/projects/amdsmi/src/amd_smi/amd_smi.cc
+++ b/projects/amdsmi/src/amd_smi/amd_smi.cc
@@ -2372,20 +2372,19 @@ amdsmi_get_gpu_asic_info(amdsmi_processor_handle processor_handle, amdsmi_asic_i
     // Ensure asic_serial defaults to an unsupported value
     std::string max_uint64_str = "ffffffffffffffff";
     smi_clear_char_and_reinitialize(info->asic_serial, AMDSMI_MAX_STRING_LENGTH, max_uint64_str);
-    uint64_t device_uuid = 0;
-    amdsmi_status_t status = rsmi_wrapper(rsmi_dev_unique_id_get, processor_handle, 0,
-                                          &device_uuid);
-    // Currently unique_id is not available for APUs
-    if (status == AMDSMI_STATUS_SUCCESS && device_uuid != 0) {
+    uint64_t asic_serial_id = 0;
+    amdsmi_status_t status = rsmi_wrapper(rsmi_dev_asic_serial_get, processor_handle, 0,
+                                          &asic_serial_id);
+    // Currently asic serial may not be available for APUs
+    if (status == AMDSMI_STATUS_SUCCESS && asic_serial_id != 0) {
         ss.clear();
-        ss << std::hex << std::setw(16) << std::setfill('0') << device_uuid;
+        ss << std::hex << std::setw(16) << std::setfill('0') << asic_serial_id;
         std::string asic_serial_str = ss.str();
         ss.clear();
         smi_clear_char_and_reinitialize(info->asic_serial, AMDSMI_MAX_STRING_LENGTH,
                                         asic_serial_str);
         ss << __PRETTY_FUNCTION__
-           << " | Retrieved unique_id from rsmi: " << processor_handle << "\n"
-           << " ; Successfully fell back to KFD's unique_id... \n"
+           << " | Retrieved asic serial from rsmi: " << processor_handle << "\n"
            << " ; info->asic_serial (hex): " << info->asic_serial << "\n"
            << " ; info->asic_serial (dec): " << std::dec
            << static_cast<uint64_t>(std::stoull(asic_serial_str, nullptr, 16));


### PR DESCRIPTION
Changes:
 - Align `amdsmi_get_gpu_device_uuid()` / `amdsmi_get_gpu_enumeration_info()`
   with HIP's UUID (KFD's unique_id)
 - Modify `amdsmi_asic_info_t.asic_serial` to only report per socket
   by using KGD's unique_id SYSFS

Signed-off-by: Charis Poag <charis.poag@amd.com>

## Motivation

Intended to replace #2269

Our UUID was off due to driver changes. 

Asic serial should be only applicable per OAM/Socket.

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## JIRA ID
SWDEV-556456

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
