### PR TITLE
rocr: Update doc for hsa_amd_vmem_handle_create

### DIFF
--- a/projects/rocr-runtime/runtime/hsa-runtime/inc/hsa_ext_amd.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/inc/hsa_ext_amd.h
@@ -3544,7 +3544,7 @@ typedef enum {
  * To minimize internal memory fragmentation, align the size to the recommended allocation granule
  * size, see HSA_AMD_MEMORY_POOL_INFO_RUNTIME_ALLOC_REC_GRANULE
  *
- * @param[in] pool memory to use
+ * @param[in] pool memory to use. Only GPU agent pools are supported.
  * @param[in] size of the memory allocation
  * @param[in] type of memory
  * @param[in] flags - currently unsupported


### PR DESCRIPTION
Specify that only GPU agent pools are supported at the moment.