### PR TITLE
Fix ring buffer indexing in AIE AQL queue SubmitPackets

### DIFF
--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_aie_aql_queue.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_aie_aql_queue.cpp
@@ -216,11 +216,14 @@ void AieAqlQueue::SubmitPackets() {
 
   auto& driver = static_cast<XdnaDriver&>(agent_.driver());
   void* queue_base = amd_queue_.hsa_queue.base_address;
+  const uint32_t queue_size = amd_queue_.hsa_queue.size;
 
   uint64_t cur_id = LoadReadIndexRelaxed();
   const uint64_t end = LoadWriteIndexAcquire();
   while (cur_id < end) {
-    auto* pkt = static_cast<hsa_amd_aie_ert_packet_t*>(queue_base) + cur_id;
+    // Use modulo to properly index into the ring buffer
+    const uint64_t pkt_idx = cur_id % queue_size;
+    auto* pkt = static_cast<hsa_amd_aie_ert_packet_t*>(queue_base) + pkt_idx;
 
     // Get the packet header information
     if (pkt->header.header != HSA_PACKET_TYPE_VENDOR_SPECIFIC ||
@@ -235,7 +238,8 @@ void AieAqlQueue::SubmitPackets() {
         // packets there are. All can be combined into a single chain.
         uint64_t num_cont_start_cu_pkts = 1;
         for (uint64_t peak_pkt_id = cur_id + 1; peak_pkt_id < end; peak_pkt_id++) {
-          auto* peak_pkt = static_cast<hsa_amd_aie_ert_packet_t*>(queue_base) + peak_pkt_id;
+          const uint64_t peak_pkt_idx = peak_pkt_id % queue_size;
+          auto* peak_pkt = static_cast<hsa_amd_aie_ert_packet_t*>(queue_base) + peak_pkt_idx;
           if (peak_pkt->opcode != HSA_AMD_AIE_ERT_START_CU) {
             break;
           }


### PR DESCRIPTION
## Motivation

 Fix a ring buffer overflow bug in the AIE AQL queue that causes out-of-bounds memory access when queue indices wrap around. The SubmitPackets function was using absolute packet indices (cur_id and peak_pkt_id) directly to access the ring buffer, without applying modulo. This caused crashes after the queue size (64 packets) was exceeded.

## Technical Details

In AieAqlQueue::SubmitPackets():
 - Added queue_size variable to cache the queue size
 - Changed packet access from queue_base + cur_id to queue_base + (cur_id % queue_size)
 - Changed lookahead packet access from queue_base + peak_pkt_id to queue_base + (peak_pkt_id % queue_size)

The producer side (eg. code in GGML https://github.com/ypapadop-amd/ggml/blob/68e0094019edabe519d9f50240d4aa5378bd01b3/src/ggml-hsa/aie-kernel.cpp#L29-L31) already correctly uses modulo when writing packets, but the consumer side (in ROCr-runtime: [here](https://github.com/ROCm/rocm-systems/blob/0651ab64b67b9a82127ac159b41b63146011c7b6/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_aie_aql_queue.cpp#L223) and [here](https://github.com/ROCm/rocm-systems/blob/0651ab64b67b9a82127ac159b41b63146011c7b6/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_aie_aql_queue.cpp#L238)) was not using modulo when reading packets, causing the mismatch.


## Test Plan

 - Ran a test that performs matrix multiplication operations that exceed 64 AIE kernel dispatches
 - Verified that dispatches beyond queue size 64 complete successfully
 - Previously, the test would crash after approximately 64 dispatches due to out-of-bounds memory access

## Test Result

Test passes with 100+ dispatches completing successfully. Queue IDs increment past the original crash point (64) and continue to work correctly with proper ring buffer wrap-around.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
