### PR TITLE
[Rocprof-systems]: Fix Python example shebang to avoid hard dependency on build Python path

### DIFF
--- a/projects/rocprofiler-systems/examples/code-coverage/code-coverage.py
+++ b/projects/rocprofiler-systems/examples/code-coverage/code-coverage.py
@@ -1,4 +1,4 @@
-#!@PYTHON_EXECUTABLE@
+#!/usr/bin/env python3
 
 # Copyright (c) Advanced Micro Devices, Inc.
 # SPDX-License-Identifier: MIT

--- a/projects/rocprofiler-systems/examples/python/builtin.py
+++ b/projects/rocprofiler-systems/examples/python/builtin.py
@@ -1,4 +1,4 @@
-#!@PYTHON_EXECUTABLE@
+#!/usr/bin/env python3
 
 # Copyright (c) Advanced Micro Devices, Inc.
 # SPDX-License-Identifier: MIT

--- a/projects/rocprofiler-systems/examples/python/external.py
+++ b/projects/rocprofiler-systems/examples/python/external.py
@@ -1,4 +1,4 @@
-#!@PYTHON_EXECUTABLE@
+#!/usr/bin/env python3
 
 # Copyright (c) Advanced Micro Devices, Inc.
 # SPDX-License-Identifier: MIT

--- a/projects/rocprofiler-systems/examples/python/fill.py
+++ b/projects/rocprofiler-systems/examples/python/fill.py
@@ -1,4 +1,4 @@
-#!@PYTHON_EXECUTABLE@
+#!/usr/bin/env python3
 
 # Copyright (c) Advanced Micro Devices, Inc.
 # SPDX-License-Identifier: MIT

--- a/projects/rocprofiler-systems/examples/python/noprofile.py
+++ b/projects/rocprofiler-systems/examples/python/noprofile.py
@@ -1,4 +1,4 @@
-#!@PYTHON_EXECUTABLE@
+#!/usr/bin/env python3
 
 # Copyright (c) Advanced Micro Devices, Inc.
 # SPDX-License-Identifier: MIT

--- a/projects/rocprofiler-systems/examples/python/source-numpy.py
+++ b/projects/rocprofiler-systems/examples/python/source-numpy.py
@@ -1,4 +1,4 @@
-#!@PYTHON_EXECUTABLE@
+#!/usr/bin/env python3
 
 # Copyright (c) Advanced Micro Devices, Inc.
 # SPDX-License-Identifier: MIT

--- a/projects/rocprofiler-systems/examples/python/source.py
+++ b/projects/rocprofiler-systems/examples/python/source.py
@@ -1,4 +1,4 @@
-#!@PYTHON_EXECUTABLE@
+#!/usr/bin/env python3
 
 # Copyright (c) Advanced Micro Devices, Inc.
 # SPDX-License-Identifier: MIT


### PR DESCRIPTION
Replace CMake template variable @PYTHON_EXECUTABLE@ with standard
#!/usr/bin/env python3 shebang in Python example scripts. This fixes the
RPM packaging error "nothing provides /opt/python/cp312-cp312/bin/python3.12
needed by amdrocm-profiler" by removing hard dependency on the build
environment's Python interpreter path.

## Motivation
Installation of amdrocm-profiler RPM package is failing with the error due to hard coded path in shebang
"Nothing provides /opt/python/cp312-cp312/bin/python3.12 needed by amdrocm-profiler"

## Technical Details
The build is embedding the build‑time Python path into the shebangs of the example scripts, which causes them to fail in the runtime environment.

## JIRA ID

ROCM-3946

## Test Plan

Install amdrocm-profiler package

## Test Result

The artifacts (example scripts) don't have absolute paths in shebang.

## Submission Checklist

- [] Look over the contributing guidelines at 

