### PR TITLE
[rocprofiler-compute] Fix test coverage path handling for install mode

### DIFF
--- a/.github/workflows/rocprofiler-compute-formatting.yml
+++ b/.github/workflows/rocprofiler-compute-formatting.yml
@@ -101,7 +101,7 @@ jobs:
       run: |
         sudo apt-get update
         sudo apt-get install -y python3-pip
-        python3 -m pip install clang-format
+        python3 -m pip install clang-format==22.1.0
     - name: clang-format
       working-directory: projects/rocprofiler-compute
       run: |

--- a/projects/rocprofiler-compute/CMakeLists.txt
+++ b/projects/rocprofiler-compute/CMakeLists.txt
@@ -265,7 +265,9 @@ endif()
 
 if(TEST_FROM_INSTALL)
     # When testing from install, write coverage to install directory
-    set(COVERAGE_XML_PATH "${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBEXECDIR}/${PACKAGE_NAME}/coverage.xml")
+    set(COVERAGE_XML_PATH
+        "${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBEXECDIR}/${PACKAGE_NAME}/coverage.xml"
+    )
 else()
     # When testing from build, write coverage to build directory
     set(COVERAGE_XML_PATH "${CMAKE_BINARY_DIR}/coverage.xml")

--- a/projects/rocprofiler-compute/CMakeLists.txt
+++ b/projects/rocprofiler-compute/CMakeLists.txt
@@ -221,13 +221,6 @@ if(${ENABLE_COVERAGE})
     )
 
     set(CTEST_COVERAGE_COMMAND "python3")
-    set(CTEST_COVERAGE_EXTRA_FLAGS
-        "-m"
-        "coverage"
-        "xml"
-        "-o"
-        "${CMAKE_BINARY_DIR}/coverage.xml"
-    )
 endif()
 message(STATUS "Code coverage: ${ENABLE_COVERAGE}")
 
@@ -263,10 +256,19 @@ option(
     "Test from install directory rather than from source directory"
     OFF
 )
+
 if(TEST_FROM_INSTALL OR STANDALONEBINARY)
     set(WORKING_DIR_OPTION "")
 else()
     set(WORKING_DIR_OPTION WORKING_DIRECTORY ${PROJECT_SOURCE_DIR})
+endif()
+
+if(TEST_FROM_INSTALL)
+    # When testing from install, write coverage to install directory
+    set(COVERAGE_XML_PATH "${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBEXECDIR}/${PACKAGE_NAME}/coverage.xml")
+else()
+    # When testing from build, write coverage to build directory
+    set(COVERAGE_XML_PATH "${CMAKE_BINARY_DIR}/coverage.xml")
 endif()
 
 set(STANDALONEBINARY_EXTRACT_DIR
@@ -584,7 +586,7 @@ if(${ENABLE_COVERAGE})
     add_test(
         NAME generate_coverage_report
         COMMAND
-            ${PYTHON_TEST_COMMAND} -m coverage xml -o ${CMAKE_BINARY_DIR}/coverage.xml
+            ${PYTHON_TEST_COMMAND} -m coverage xml -o ${COVERAGE_XML_PATH}
             ${WORKING_DIR_OPTION}
     )
 

--- a/projects/rocprofiler-compute/tests/conftest.py
+++ b/projects/rocprofiler-compute/tests/conftest.py
@@ -42,10 +42,12 @@ try:
     rocprof_compute = SourceFileLoader(
         "rocprof-compute", "src/rocprof-compute"
     ).load_module()
+    rocprof_compute_script_path = "src/rocprof-compute"
 except Exception:
     rocprof_compute = SourceFileLoader(
         "rocprof-compute", "rocprof-compute"
     ).load_module()
+    rocprof_compute_script_path = "rocprof-compute"
 
 
 def pytest_addoption(parser):
@@ -230,8 +232,8 @@ def binary_handler_profile_rocprof_compute(request):
 
             # For multi-rank, use mpirun to run the command
             if num_ranks > 1:
-                # Use src/rocprof-compute instead of rocprof-compute
-                command_rocprof_compute[0] = "src/rocprof-compute"
+                # Use rocprof_compute_script_path instead of rocprof-compute
+                command_rocprof_compute[0] = rocprof_compute_script_path
                 command_rocprof_compute = [
                     "mpirun",
                     "-n",
@@ -240,9 +242,9 @@ def binary_handler_profile_rocprof_compute(request):
 
             # For capture_output or multi-rank, run the command with subprocess
             if capture_output or num_ranks > 1:
-                # Use src/rocprof-compute instead of rocprof-compute
+                # Use rocprof_compute_script_path instead of rocprof-compute
                 if num_ranks == 1:
-                    command_rocprof_compute[0] = "src/rocprof-compute"
+                    command_rocprof_compute[0] = rocprof_compute_script_path
 
                 process = subprocess.run(
                     command_rocprof_compute,


### PR DESCRIPTION
## Motivation

* Fix coverage report generation to write to the correct location when `TEST_FROM_INSTALL` is enabled

* Fix conftest.py to use the correct rocprof-compute script path matching the module import location when invoking mpirun subprocess for multi rank tests

* Pin version of clang-format packages in github workflow formatting

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

- Remove unused `CTEST_COVERAGE_EXTRA_FLAGS` variable in CMakeLists.txt
- Add `COVERAGE_XML_PATH` variable that dynamically points to:
  - Install directory when `TEST_FROM_INSTALL=ON`
  - Build directory otherwise
- Update conftest.py to store and reuse the script path that successfully loaded the module, preventing path mismatches in subprocess execution

- Pin version of clang-format packages in github workflow formatting

<!-- Explain the changes along with any relevant GitHub links. -->

## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan

- Build and install with cmake flag TEST_FROM_INSTALL=ON
- cd to install/libexec/rocprofiler-compute folder
- Run pytest -s --verbose -k test_multi_rank_profiling_no_mpi_comm tests/test_profile_general.py and ensure pass
- Run ctest -R generate_coverage_report and ensure coverage.xml is created in the same directory and not build directory

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

Tests pass

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.