### PR TITLE
[RCCL] [UT] Add ROCTX test

### DIFF
--- a/projects/rccl/test/AllReduceTests.cpp
+++ b/projects/rccl/test/AllReduceTests.cpp
@@ -251,6 +251,27 @@ namespace RcclUnitTesting
     callCollectiveForked(nranks, ncclCollAllReduce, sendBuff, recvBuff, expected, use_managed_mem);
   }
 
+  TEST(AllReduce, ROCTX)
+  {
+    // Set RCCL_LOG_ROCTX=1 to enable ROCTX logging
+    // Verify that ROCTX logging doesn't break functionality when enabled
+    setenv("RCCL_LOG_ROCTX", "1", 1);
+
+    const int nranks = 8;
+    size_t count = 2048;
+    std::vector<int> sendBuff(count, 0);
+    std::vector<int> recvBuff(count, 0);
+    std::vector<int> expected(count, 0);
+
+    for (int i = 0; i < count; ++i) {
+        sendBuff[i] = i;
+        expected[i] = i * nranks;
+    }
+    callCollectiveForked(nranks, ncclCollAllReduce, sendBuff, recvBuff, expected);
+
+    unsetenv("RCCL_LOG_ROCTX");
+  }
+
 #ifdef RCCL_ALLREDUCE_WITH_BIAS
   // Note: All bias tests require:
   // nRanks >= 2 (bias NOT supported for single rank)


### PR DESCRIPTION
## Motivation

This PR adds ROCTX testing to the RCCL UT suite. Previously, ROCTX was tested in the CI pipeline due to the need for additional compilation flags. Now that the ROCTX is enabled by default in RCCL builds, we can move this testing to the standard RCCL UT suite.

## Technical Details

Added the test in `test/AllReduceTests.cpp` using `callCollectiveForked()` by enabling ROCTX logging via `RCCL_LOG_ROCTX=1`.

## JIRA ID

AICOMRCCL-658

## Test Plan

Ran the full UT suite, including the newly added test.

## Test Result

Tests passed without any issues.

## Submission Checklist

- [X] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
