### PR TITLE
[rdc] Enable on-demand queue mode to prevent inference degradation

### DIFF
--- a/projects/rdc/rdc_libs/rdc_modules/rdc_rocp/RdcTelemetryLib.cc
+++ b/projects/rdc/rdc_libs/rdc_modules/rdc_rocp/RdcTelemetryLib.cc
@@ -153,6 +153,11 @@ rdc_status_t rdc_module_init(uint64_t /*flags*/) {
     RDC_LOG(RDC_DEBUG, "Using ROCPROFILER_METRICS_PATH from environment variable");
   }
 
+  // Use on-demand queue mode in rocprofiler-sdk to avoid persistent GPU queues
+  // that cause runlist oversubscription and inference performance degradation.
+  // Queues are created only during counter collection and destroyed immediately after.
+  setenv("ROCPROFILER_ONDEMAND_QUEUE", "1", 0);
+
   rocp_p = std::make_unique<amd::rdc::RdcRocpBase>();
   return RDC_ST_OK;
 }


### PR DESCRIPTION
## Summary

- Sets `ROCPROFILER_ONDEMAND_QUEUE=1` in RDC's rocp module init so rocprofiler-sdk creates GPU queues only during counter collection windows and destroys them immediately after
- Prevents persistent HSA queues from remaining in the GPU hardware scheduler runlist, which causes context-switching overhead and degrades inference performance

## Background

When RDC monitors GPU counters via rocprofiler-sdk, the SDK creates one HSA queue per GPU during initialization. These queues persist in the GPU's MES (Micro Engine Scheduler) runlist, causing hardware context-switching overhead even when idle. On systems running large inference workloads (e.g., Qwen3-VL-235B on 8x MI300X), this results in ~15% TTFT degradation and ~15% throughput reduction.

The `ROCPROFILER_ONDEMAND_QUEUE` environment variable (added in rocprofiler-sdk PR #3586) defers queue creation to the start of each counter collection cycle and destroys queues immediately after, eliminating persistent runlist overhead.

## Test Results (8x MI300X, Qwen3-VL-235B inference, PTL enabled)

| Scenario | Mean TTFT (ms) | Median TTFT (ms) | P99 TTFT (ms) | Output tok/s |
|---|---|---|---|---|
| Baseline (no RDC) | 840.53 | 839.77 | 844.19 | 90.46 |
| On-demand + RDC (10s intervals) | 843.11 | 840.51 | 858.82 | 88.90 |
| On-demand + RDC (2s intervals) | 913.15 | 850.42 | 1054.59 | 82.73 |

- **10-second intervals**: +0.3% mean TTFT, -1.7% throughput — essentially zero overhead
- **2-second intervals**: +8.6% mean TTFT, -8.5% throughput — acceptable for aggressive monitoring

## Test plan
- [x] Build rocprofiler-sdk with on-demand queue support (PR #3586)
- [x] Build RDC from origin/develop with this change
- [x] Verify counters produce non-zero values during GPU workload
- [x] Verify baseline TTFT matches expected ~840ms
- [x] Verify 10-second interval overhead is minimal
- [x] Verify 2-second interval overhead is acceptable
- [x] Verify PTL remains enabled throughout

🤖 Generated with [Claude Code](https://claude.com/claude-code)