### PR TITLE
[rdc][rocprofiler-sdk] On-demand queue mode to prevent inference degradation

### DIFF
--- a/projects/rdc/rdc_libs/rdc_modules/rdc_rocp/RdcTelemetryLib.cc
+++ b/projects/rdc/rdc_libs/rdc_modules/rdc_rocp/RdcTelemetryLib.cc
@@ -153,6 +153,11 @@ rdc_status_t rdc_module_init(uint64_t /*flags*/) {
     RDC_LOG(RDC_DEBUG, "Using ROCPROFILER_METRICS_PATH from environment variable");
   }
 
+  // Use on-demand queue mode in rocprofiler-sdk to avoid persistent GPU queues
+  // that cause runlist oversubscription and inference performance degradation.
+  // Queues are created only during counter collection and destroyed immediately after.
+  setenv("ROCPROFILER_ONDEMAND_QUEUE", "1", 0);
+
   rocp_p = std::make_unique<amd::rdc::RdcRocpBase>();
   return RDC_ST_OK;
 }

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/counters/device_counting.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/counters/device_counting.cpp
@@ -441,6 +441,9 @@ start_agent_ctx(const context::context* ctx)
             break;
         }
 
+        // On-demand: create the profile queue now (destroyed in stop_agent_ctx)
+        agent->init_device_counting_service_queue(*hsa::get_core_table(), *hsa::get_amd_ext_table());
+
         // But if we have an agent cache, we need a profile queue.
         if(!agent->profile_queue())
         {
@@ -612,6 +615,19 @@ stop_agent_ctx(const context::context* ctx)
         {
             counters::counter_collection_device_unlock(agent->get_rocp_agent());
         }
+
+        // On-demand cleanup: destroy signals, reset packet, destroy queue
+        if(callback_data.completion.handle != 0) {
+            hsa::get_core_table()->hsa_signal_destroy_fn(callback_data.completion);
+            callback_data.completion.handle = 0;
+        }
+        if(callback_data.start_signal.handle != 0) {
+            hsa::get_core_table()->hsa_signal_destroy_fn(callback_data.start_signal);
+            callback_data.start_signal.handle = 0;
+        }
+        callback_data.packet.reset();
+        callback_data.queue = nullptr;
+        agent->destroy_device_counting_service_queue();
     }
 
     agent_ctx.status.exchange(rocprofiler::context::device_counting_service::state::DISABLED);

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/counters/device_counting.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/counters/device_counting.cpp
@@ -442,7 +442,11 @@ start_agent_ctx(const context::context* ctx)
         }
 
         // On-demand: create the profile queue now (destroyed in stop_agent_ctx)
-        agent->init_device_counting_service_queue(*hsa::get_core_table(), *hsa::get_amd_ext_table());
+        if(hsa::use_ondemand_queue())
+        {
+            agent->init_device_counting_service_queue(*hsa::get_core_table(),
+                                                      *hsa::get_amd_ext_table());
+        }
 
         // But if we have an agent cache, we need a profile queue.
         if(!agent->profile_queue())
@@ -617,17 +621,22 @@ stop_agent_ctx(const context::context* ctx)
         }
 
         // On-demand cleanup: destroy signals, reset packet, destroy queue
-        if(callback_data.completion.handle != 0) {
-            hsa::get_core_table()->hsa_signal_destroy_fn(callback_data.completion);
-            callback_data.completion.handle = 0;
+        if(hsa::use_ondemand_queue())
+        {
+            if(callback_data.completion.handle != 0)
+            {
+                hsa::get_core_table()->hsa_signal_destroy_fn(callback_data.completion);
+                callback_data.completion.handle = 0;
+            }
+            if(callback_data.start_signal.handle != 0)
+            {
+                hsa::get_core_table()->hsa_signal_destroy_fn(callback_data.start_signal);
+                callback_data.start_signal.handle = 0;
+            }
+            callback_data.packet.reset();
+            callback_data.queue = nullptr;
+            agent->destroy_device_counting_service_queue();
         }
-        if(callback_data.start_signal.handle != 0) {
-            hsa::get_core_table()->hsa_signal_destroy_fn(callback_data.start_signal);
-            callback_data.start_signal.handle = 0;
-        }
-        callback_data.packet.reset();
-        callback_data.queue = nullptr;
-        agent->destroy_device_counting_service_queue();
     }
 
     agent_ctx.status.exchange(rocprofiler::context::device_counting_service::state::DISABLED);

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/hsa/agent_cache.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/hsa/agent_cache.cpp
@@ -21,6 +21,7 @@
 // THE SOFTWARE.
 
 #include "lib/rocprofiler-sdk/hsa/agent_cache.hpp"
+#include "lib/common/environment.hpp"
 #include "lib/common/logging.hpp"
 
 #include <fmt/core.h>
@@ -120,6 +121,13 @@ namespace rocprofiler
 {
 namespace hsa
 {
+bool
+use_ondemand_queue()
+{
+    static bool value = rocprofiler::common::get_env("ROCPROFILER_ONDEMAND_QUEUE", false);
+    return value;
+}
+
 void
 AgentCache::init_device_counting_service_queue(const CoreApiTable& api,
                                                const AmdExtTable&  ext) const
@@ -172,7 +180,8 @@ AgentCache::AgentCache(const rocprofiler_agent_t* rocp_agent,
     {
         init_cpu_pool(ext_table, *this);
         init_gpu_pool(ext_table, *this);
-        // init_device_counting_service_queue(api, ext_table);  // Deferred to start_context for on-demand queue
+        // When on-demand queue mode is enabled, defer queue creation to start_context
+        if(!use_ondemand_queue()) init_device_counting_service_queue(api, ext_table);
     } catch(std::runtime_error& e)
     {
         ROCP_WARNING << fmt::format(
@@ -181,7 +190,6 @@ AgentCache::AgentCache(const rocprofiler_agent_t* rocp_agent,
             e.what());
     }
 }
-
 
 void
 AgentCache::destroy_device_counting_service_queue() const
@@ -192,8 +200,7 @@ AgentCache::destroy_device_counting_service_queue() const
     if(!m_profile_queue) return;
 
     auto* api = hsa::get_core_table();
-    if(api && api->hsa_queue_destroy_fn)
-        api->hsa_queue_destroy_fn(m_profile_queue);
+    if(api && api->hsa_queue_destroy_fn) api->hsa_queue_destroy_fn(m_profile_queue);
     m_profile_queue = nullptr;
 }
 

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/hsa/agent_cache.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/hsa/agent_cache.cpp
@@ -27,6 +27,7 @@
 #include <stdexcept>
 
 #include "lib/rocprofiler-sdk/context/context.hpp"
+#include "lib/rocprofiler-sdk/hsa/hsa.hpp"
 
 namespace
 {
@@ -171,7 +172,7 @@ AgentCache::AgentCache(const rocprofiler_agent_t* rocp_agent,
     {
         init_cpu_pool(ext_table, *this);
         init_gpu_pool(ext_table, *this);
-        init_device_counting_service_queue(api, ext_table);
+        // init_device_counting_service_queue(api, ext_table);  // Deferred to start_context for on-demand queue
     } catch(std::runtime_error& e)
     {
         ROCP_WARNING << fmt::format(
@@ -179,6 +180,21 @@ AgentCache::AgentCache(const rocprofiler_agent_t* rocp_agent,
             rocp_agent->node_id,
             e.what());
     }
+}
+
+
+void
+AgentCache::destroy_device_counting_service_queue() const
+{
+    static std::mutex           m_mutex;
+    std::lock_guard<std::mutex> lock(m_mutex);
+
+    if(!m_profile_queue) return;
+
+    auto* api = hsa::get_core_table();
+    if(api && api->hsa_queue_destroy_fn)
+        api->hsa_queue_destroy_fn(m_profile_queue);
+    m_profile_queue = nullptr;
 }
 
 }  // namespace hsa

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/hsa/agent_cache.hpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/hsa/agent_cache.hpp
@@ -74,6 +74,7 @@ public:
     size_t                     index() const { return m_index; }
 
     void init_device_counting_service_queue(const CoreApiTable& api, const AmdExtTable& ext) const;
+    void destroy_device_counting_service_queue() const;
     bool operator==(const rocprofiler_agent_t*) const;
     bool operator==(hsa_agent_t) const;
 

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/hsa/agent_cache.hpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/hsa/agent_cache.hpp
@@ -107,5 +107,11 @@ AgentCache::operator==(hsa_agent_t agent) const
 {
     return (agent.handle == m_hsa_agent.handle);
 }
+/// Returns true when ROCPROFILER_ONDEMAND_QUEUE=1|true is set.
+/// In on-demand mode, the profile queue is created in start_context
+/// and destroyed in stop_context instead of being persistent.
+bool
+use_ondemand_queue();
+
 }  // namespace hsa
 }  // namespace rocprofiler


### PR DESCRIPTION
## Summary

Cherry-pick of PRs #3586 and #3629 onto `release/rocm-rel-7.2`.

- **[rocprofiler-sdk]** Add on-demand GPU profile queue creation/destruction controlled by `ROCPROFILER_ONDEMAND_QUEUE` env var. When enabled, queues are created only during counter collection and destroyed immediately after, preventing persistent runlist overhead.
- **[rdc]** Set `ROCPROFILER_ONDEMAND_QUEUE=1` in RDC's rocp module init to activate on-demand mode by default.

## Background

Persistent HSA queues created by rocprofiler-sdk during counter collection remain in the GPU's MES runlist, causing HWS context-switching overhead that degrades inference workloads (~15% TTFT increase on MI300X with Qwen3-VL-235B). On-demand mode eliminates this by creating queues only for the duration of each collection cycle.

## Test Results (8x MI300X, Qwen3-VL-235B, PTL enabled)

| Scenario | Mean TTFT (ms) | Median TTFT (ms) | P99 TTFT (ms) | Output tok/s |
|---|---|---|---|---|
| Baseline (no RDC) | 840.53 | 839.77 | 844.19 | 90.46 |
| On-demand + RDC (10s intervals) | 843.11 | 840.51 | 858.82 | 88.90 |
| On-demand + RDC (2s intervals) | 913.15 | 850.42 | 1054.59 | 82.73 |

## Test plan
- [x] Verified cherry-picks apply cleanly to release/rocm-rel-7.2
- [x] Tested on 8x MI300X with Qwen3-VL-235B (results above from develop branch)

## Original PRs
- #3586 — [rocprofiler-sdk] On-demand GPU profile queue creation/destruction
- #3629 — [rdc] Enable on-demand queue mode to prevent inference degradation

🤖 Generated with [Claude Code](https://claude.com/claude-code)