### PR TITLE
Fix amdsmi build errors and warnings with GCC 14

### DIFF
--- a/projects/amdsmi/src/amd_smi/amd_smi.cc
+++ b/projects/amdsmi/src/amd_smi/amd_smi.cc
@@ -5710,7 +5710,13 @@ amdsmi_status_t amdsmi_get_pcie_info(amdsmi_processor_handle processor_handle, a
         gpu_device->get_gpu_path() + "/device/max_link_width";
     fp = fopen(path_max_link_width.c_str(), "r");
     if (fp) {
-        fscanf(fp, "%d", &pcie_width);
+        if (fscanf(fp, "%d", &pcie_width) != 1) {
+            fclose(fp);
+            ss << __PRETTY_FUNCTION__
+               << " | Failed to parse: " << path_max_link_width;
+            LOG_ERROR(ss);
+            return AMDSMI_STATUS_API_FAILED;
+        }
         fclose(fp);
     } else {
         ss << __PRETTY_FUNCTION__
@@ -5725,7 +5731,14 @@ amdsmi_status_t amdsmi_get_pcie_info(amdsmi_processor_handle processor_handle, a
         gpu_device->get_gpu_path() + "/device/max_link_speed";
     fp = fopen(path_max_link_speed.c_str(), "r");
     if (fp) {
-        fscanf(fp, "%lf %s", &pcie_speed, buff);
+        if (fscanf(fp, "%lf %s", &pcie_speed, buff) != 2) {
+            fclose(fp);
+            std::ostringstream ss;
+            ss << __PRETTY_FUNCTION__
+                << " | Failed to parse: " << path_max_link_speed;
+            LOG_ERROR(ss);
+            return AMDSMI_STATUS_API_FAILED;
+        }
         fclose(fp);
     } else {
         std::ostringstream ss;
@@ -6028,7 +6041,8 @@ amdsmi_get_link_topology_nearest(amdsmi_processor_handle processor_handle,
     /*
      *  Note: The link topology table is sorted by the number of hops and link weight.
      */
-    topology_nearest_info->processor_list[AMDSMI_MAX_DEVICES * AMDSMI_MAX_NUM_XCP] = {nullptr};
+    std::fill(std::begin(topology_nearest_info->processor_list),
+              std::end(topology_nearest_info->processor_list), nullptr);
     topology_nearest_info->count = static_cast<uint32_t>(link_topology_order.size());
     auto topology_nearest_counter = uint32_t(0);
     while (!link_topology_order.empty()) {

--- a/projects/amdsmi/src/amd_smi/amd_smi_cper.cc
+++ b/projects/amdsmi/src/amd_smi/amd_smi_cper.cc
@@ -270,7 +270,7 @@ static int cper_dump_nonstd_err(const struct cper_sec_nonstd_err *nonstd_err, co
 {
     std::ostringstream ss;
 
-    struct cper_sec_nonstd_err_body *body;
+    struct cper_sec_nonstd_err_body *body = nullptr;
 
     ss << __PRETTY_FUNCTION__ << "\n:" << __LINE__ << "[AFIDS]\n~~~~NON STANDARD SECTION~~~\n";
 
@@ -297,6 +297,9 @@ exit:
     ss << std::dec << "~~~~NON STANDARD SECTION~~~\n\n";
 
     LOG_DEBUG(ss);
+
+    if (!body)
+        return -1;
 
     return aca_decode_corrected_error(body->err_ctx.reg_dump, sizeof(body->err_ctx.reg_dump)/sizeof(body->err_ctx.reg_dump[0]),
         section->flags_mask, section->revision_major, body->err_ctx.reg_ctx_type);

--- a/projects/amdsmi/src/nic/ai-nic/amdsmi_unified/src/smi_sysfs.cpp
+++ b/projects/amdsmi/src/nic/ai-nic/amdsmi_unified/src/smi_sysfs.cpp
@@ -51,9 +51,9 @@ SmiSysfsReader::SysfsStatus SmiSysfsReader::readAll(const std::string& filepath,
 			try {
 				if (token.find("0x") == 0 || token.find("0X") == 0) {
 					int hex_value = std::stoi(token, nullptr, 16);
-					content.push_back(hex_value);
+					content.emplace_back(std::in_place_type<int>, hex_value);
 				} else if (std::all_of(token.begin(), token.end(), ::isdigit)) {
-					content.push_back(std::stoi(token));
+					content.emplace_back(std::in_place_type<int>, std::stoi(token));
 				} else {
 					content.push_back(token);
 				}

--- a/projects/amdsmi/tests/amd_smi_test/functional/perf_cntr_read_write.cc
+++ b/projects/amdsmi/tests/amd_smi_test/functional/perf_cntr_read_write.cc
@@ -241,9 +241,9 @@ TestPerfCntrReadWrite::testEventsSimultaneously(amdsmi_processor_handle dv_ind) 
     }
     CHK_ERR_ASRT(ret)
 
-    std::shared_ptr<amdsmi_event_handle_t> evt_handle =
-                    std::shared_ptr<amdsmi_event_handle_t>(
-                                     new amdsmi_event_handle_t[avail_counters]);
+    std::shared_ptr<amdsmi_event_handle_t> evt_handle(
+                                     new amdsmi_event_handle_t[avail_counters],
+                                     std::default_delete<amdsmi_event_handle_t[]>());
 
     uint32_t tmp, j;
     uint32_t num_created = 0;


### PR DESCRIPTION
## Summary
- Fix `-Werror=maybe-uninitialized` build error in `smi_sysfs.cpp` when pushing `int` into `vector<variant<int, string>>` — GCC 14 false positive through variant move constructor. Use `emplace_back(std::in_place_type<int>, ...)` instead.
- Fix unchecked `fscanf` return values in `amd_smi.cc` — now returns error on parse failure.
- Fix out-of-bounds array write in `amd_smi.cc` (`processor_list[256]` on a 256-element array). This is an actual out of bounds memory write *and* failing to zero init the array.
- Fix uninitialized `body` pointer in `amd_smi_cper.cc` when `goto` skips assignment.
- Fix mismatched `new[]`/`delete` in `perf_cntr_read_write.cc` test.

Additional warnings in `rocm_smi/` (forked component) left for upstream:
- `rocm_smi_binary_parser.cc`: uninitialized `v` and `cur_smn`
- `rocm_smi_kfd_data_manager.cc`: ignored `read`/`write` return values in forked child processes

## Test plan
- [x] Verify clean build with GCC 14 and `-Werror`
- [x] Verify no regressions on standard CI (GCC 12/13)

🤖 Generated with [Claude Code](https://claude.com/claude-code)