### PR TITLE
[HIP] Fix process exit hang on Windows

### DIFF
--- a/projects/clr/hipamd/src/CMakeLists.txt
+++ b/projects/clr/hipamd/src/CMakeLists.txt
@@ -172,6 +172,10 @@ target_include_directories(amdhip64
 target_compile_definitions(amdhip64 PRIVATE __HIP_PLATFORM_AMD__)
 target_link_libraries(amdhip64 PRIVATE ${OPENGL_LIBRARIES})
 target_link_libraries(amdhip64 PRIVATE ${CMAKE_DL_LIBS})
+if(WIN32)
+  # ntdll.lib for RtlDllShutdownInProgress (process exit detection)
+  target_link_libraries(amdhip64 PRIVATE ntdll)
+endif()
 # Add link to comgr, hsa-runtime and other required libraries in target files
 # This is required for static libraries
 if(NOT BUILD_SHARED_LIBS)

--- a/projects/clr/hipamd/src/hip_platform.cpp
+++ b/projects/clr/hipamd/src/hip_platform.cpp
@@ -29,6 +29,12 @@
 #include <unordered_map>
 #include <mutex>
 
+#if defined(_WIN32)
+// ntdll function to check if the process is shutting down (ExitProcess).
+// Available on all Windows versions. Linked from ntdll.lib.
+extern "C" __declspec(dllimport) unsigned char __stdcall RtlDllShutdownInProgress(void);
+#endif
+
 namespace hip_impl {
 // ================================================================================================
 hipError_t ihipOccupancyMaxActiveBlocksPerMultiprocessor(
@@ -312,13 +318,30 @@ void __hipUnregisterFatBinary(void** modules) {
   static std::once_flag unregister_device_sync;
   // If SKIP ABORT is set and GPU is in error, dont need to sync streams.
   if (!HIP_SKIP_ABORT_ON_GPU_ERROR || !amd::Device::IsGPUInError()) {
-    std::call_once(unregister_device_sync, []() {
-      for (const auto& hipDevice : g_devices) {
-        // By synchronizing devices ensure that all HSA signal handlers
-        // complete before RemoveFatBinary
-        hipDevice->SyncAllStreams(true);
-      }
-    });
+#if defined(_WIN32)
+    // WORKAROUND: Skip SyncAllStreams during process exit to prevent a
+    // deadlock. __hipUnregisterFatBinary is called from compiler-generated
+    // atexit handlers in consumer DLLs (e.g. torch_hip.dll), which detach
+    // BEFORE amdhip64. By the time this runs, ExitProcess has already killed
+    // all worker threads, so SyncAllStreams deadlocks waiting on GPU work
+    // that can never complete. RtlDllShutdownInProgress() is used because
+    // the cross-DLL unload ordering means no in-process flag (e.g.
+    // LibraryDetached) can be set in time from amdhip64's own DllMain.
+    // During normal FreeLibrary (not process exit) this returns FALSE and
+    // SyncAllStreams runs as before. During process exit the OS reclaims
+    // all GPU resources regardless.
+    // Tracking: https://github.com/pytorch/pytorch/issues/160759
+    if (!RtlDllShutdownInProgress())
+#endif
+    {
+      std::call_once(unregister_device_sync, []() {
+        for (const auto& hipDevice : g_devices) {
+          // By synchronizing devices ensure that all HSA signal handlers
+          // complete before RemoveFatBinary
+          hipDevice->SyncAllStreams(true);
+        }
+      });
+    }
   }
   hipError_t err = PlatformState::Instance().StatCO().RemoveFatBinary(fat_binary_modules);
   guarantee((err == hipSuccess), "Cannot Unregister Fat Binary, error:%d", err);


### PR DESCRIPTION
On Windows, processes that use HIP through consumer DLLs (e.g. `torch_hip.dll`) hang on exit when those DLLs have registered fat binaries. The process completes its work successfully but never terminates, requiring a force kill.

The hang is in `__hipUnregisterFatBinary`, which is called from compiler-generated atexit handlers in consumer DLLs during `ExitProcess`. By that point, Windows has already terminated all threads except the one running `ExitProcess`, so `SyncAllStreams` deadlocks — there are no worker threads left to service the sync.

This can't be fixed with an in-process flag like `LibraryDetached` because of DLL detach ordering during `ExitProcess` — consumer DLLs detach before `amdhip64`, so the deadlock happens before amdhip64's `DllMain` ever runs. `RtlDllShutdownInProgress()` queries OS loader state directly and works from any DLL's context. It returns FALSE during normal `FreeLibrary`, so runtime unloads are unaffected.

Tracking: https://github.com/pytorch/pytorch/issues/160759

## Test results
Built via TheRock on Windows 11 (gfx1151), tested with PyTorch ROCm 2.12.0a0:
- Original DLL: 5/5 hangs
- Patched DLL: 8/8 clean exits
- Patched DLL + Triton heavy workload: 3/3 clean exits

## Hang stack trace (WinDbg)

```
ntdll!NtDelayExecution                          <- spin loop
KERNELBASE!SwitchToThread
amdhip64_7!...                                  <- SyncAllStreams spin
amdhip64_7!_hipUnregisterFatBinary+0x17
ucrtbase!execute_onexit_table                   <- CRT atexit handlers
torch_hip!dllmain_crt_process_detach            <- torch_hip.dll unloading
ntdll!LdrShutdownProcess                        <- ExitProcess (loader lock held)
ntdll!RtlExitUserProcess
kernel32!ExitProcessImplementation
python
```

`ExitProcess` kills all worker threads, then `LdrShutdownProcess` unloads DLLs. `torch_hip.dll` detaches before `amdhip64_7.dll`, and its CRT atexit handler calls `__hipUnregisterFatBinary` → `SyncAllStreams`, which spins forever because the threads it needs are already dead.

## Why this is Windows-only

When a Python script finishes, the process exits normally. On Linux, `exit()` runs atexit handlers while all threads are still alive, so `SyncAllStreams` completes normally. On Windows, the CRT calls `ExitProcess()`, which kills all threads first, then unloads DLLs. Each DLL's atexit handlers run during unload — by the time `torch_hip.dll`'s handler calls `__hipUnregisterFatBinary` → `SyncAllStreams`, the threads it needs are already gone.