### PR TITLE
[hip-tests] Enable hipMipmappedArrayGetMemoryRequirements test via cmake

### DIFF
--- a/projects/hip-tests/catch/unit/texture/CMakeLists.txt
+++ b/projects/hip-tests/catch/unit/texture/CMakeLists.txt
@@ -101,6 +101,7 @@ set(NOT_FOR_gfx90a_AND_ABOVE_TEST
     hipTexRefSetGetMipmapLevelBias.cc
     hipTexRefSetGetMipmapLevelClamp.cc
     hipTexRefSetGetMipmappedArray.cc
+    hipMipmappedArrayGetMemoryRequirements.cc
 )
 
 set(gfx90a_AND_ABOVE_TARGETS gfx90a gfx942 gfx950)


### PR DESCRIPTION
This test was implemented but not added to the cmake target

## Motivation
test wasn't executed in CI
<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details
Add the test file to the `TextureTest` cmake target
<!-- Explain the changes along with any relevant GitHub links. -->

## JIRA ID
AIRUNTIME-81
<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan
tested on local env
<!-- Explain any relevant testing done to verify this PR. -->

## Test Result
all tests from `TextureTest` suite pass
<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
