### PR TITLE
[CLR][NFCI] Drop unnecessary kernel arguments processing for HIP

### DIFF
--- a/projects/clr/rocclr/device/rocm/rocvirtual.cpp
+++ b/projects/clr/rocclr/device/rocm/rocvirtual.cpp
@@ -878,133 +878,137 @@ bool VirtualGPU::processMemObjects(const amd::Kernel& kernel, const_address para
     }
   }
 
-  // Check all parameters for the current kernel
-  for (size_t i = 0; i < signature.numParameters(); ++i) {
-    const amd::KernelParameterDescriptor& desc = signature.at(i);
-    Memory* gpuMem = nullptr;
-    amd::Memory* mem = nullptr;
+  if (!amd::IS_HIP) {
+    // Check all parameters for the current kernel
+    for (size_t i = 0; i < signature.numParameters(); ++i) {
+      const amd::KernelParameterDescriptor& desc = signature.at(i);
+      Memory* gpuMem = nullptr;
+      amd::Memory* mem = nullptr;
 
-    // Find if current argument is a buffer
-    if (desc.type_ == T_POINTER) {
-      if (desc.addressQualifier_ == CL_KERNEL_ARG_ADDRESS_LOCAL) {
-        // Align the LDS on the alignment requirement of type pointed to
-        ldsAddress = amd::alignUp(ldsAddress, desc.info_.arrayIndex_);
-        if (desc.size_ == 8) {
-          // Save the original LDS size
-          uint64_t ldsSize = *reinterpret_cast<const uint64_t*>(params + desc.offset_);
-          // Patch the LDS address in the original arguments with an LDS address(offset)
-          WriteAqlArgAt(const_cast<address>(params), ldsAddress, desc.size_, desc.offset_);
-          // Add the original size
-          ldsAddress += ldsSize;
-        } else {
-          // Save the original LDS size
-          uint32_t ldsSize = *reinterpret_cast<const uint32_t*>(params + desc.offset_);
-          // Patch the LDS address in the original arguments with an LDS address(offset)
-          uint32_t ldsAddr = ldsAddress;
-          WriteAqlArgAt(const_cast<address>(params), ldsAddr, desc.size_, desc.offset_);
-          // Add the original size
-          ldsAddress += ldsSize;
-        }
-      } else {
-        uint32_t index = desc.info_.arrayIndex_;
-        mem = memories[index];
-        const void* globalAddress = *reinterpret_cast<const void* const*>(params + desc.offset_);
-        if (mem == nullptr) {
-          ClPrint(amd::LOG_DEBUG, amd::LOG_KERN, "Arg%d: %s %s = ptr:%p ", i, desc.typeName_.c_str(),
-                  desc.name_.c_str(), globalAddress);
-          //! This condition is for SVM fine-grain
-          if (dev().isFineGrainedSystem(true)) {
-            // Sync AQL packets
-            setAqlHeader(dispatchPacketHeader_);
-            // Clear memory dependency state
-            const static bool All = true;
-            memoryDependency().clear(!All);
+      // Find if current argument is a buffer
+      if (desc.type_ == T_POINTER) {
+        if (desc.addressQualifier_ == CL_KERNEL_ARG_ADDRESS_LOCAL) {
+          // Align the LDS on the alignment requirement of type pointed to
+          ldsAddress = amd::alignUp(ldsAddress, desc.info_.arrayIndex_);
+          if (desc.size_ == 8) {
+            // Save the original LDS size
+            uint64_t ldsSize = *reinterpret_cast<const uint64_t*>(params + desc.offset_);
+            // Patch the LDS address in the original arguments with an LDS address(offset)
+            WriteAqlArgAt(const_cast<address>(params), ldsAddress, desc.size_, desc.offset_);
+            // Add the original size
+            ldsAddress += ldsSize;
+          } else {
+            // Save the original LDS size
+            uint32_t ldsSize = *reinterpret_cast<const uint32_t*>(params + desc.offset_);
+            // Patch the LDS address in the original arguments with an LDS address(offset)
+            uint32_t ldsAddr = ldsAddress;
+            WriteAqlArgAt(const_cast<address>(params), ldsAddr, desc.size_, desc.offset_);
+            // Add the original size
+            ldsAddress += ldsSize;
           }
         } else {
-          gpuMem = static_cast<Memory*>(mem->getDeviceMemory(dev()));
-
+          uint32_t index = desc.info_.arrayIndex_;
+          mem = memories[index];
           const void* globalAddress = *reinterpret_cast<const void* const*>(params + desc.offset_);
-          ClPrint(amd::LOG_DEBUG, amd::LOG_KERN, "Arg%d: %s %s = ptr:%p obj:[%p-%p]", i,
-                  desc.typeName_.c_str(), desc.name_.c_str(), globalAddress,
-                  gpuMem->getDeviceMemory(),
-                  reinterpret_cast<address>(gpuMem->getDeviceMemory()) + mem->getSize());
-
-          // Validate memory for a dependency in the queue
-          memoryDependency().validate(*this, gpuMem, (desc.info_.readOnly_ == 1));
-
-          assert((desc.addressQualifier_ == CL_KERNEL_ARG_ADDRESS_GLOBAL ||
-                  desc.addressQualifier_ == CL_KERNEL_ARG_ADDRESS_CONSTANT) &&
-                 "Unsupported address qualifier");
-
-          const bool readOnly = (desc.typeQualifier_ == CL_KERNEL_ARG_TYPE_CONST) ||
-                                ((mem->getMemFlags() & CL_MEM_READ_ONLY) != 0);
-
-          if (!readOnly) {
-            mem->signalWrite(&dev());
-          }
-
-          if (desc.info_.oclObject_ == amd::KernelParameterDescriptor::ImageObject) {
-            Image* image = static_cast<Image*>(mem->getDeviceMemory(dev()));
-
-            const uint64_t image_srd = image->getHsaImageObject().handle;
-            assert(amd::isMultipleOf(image_srd, sizeof(image_srd)));
-            WriteAqlArgAt(const_cast<address>(params), image_srd, sizeof(image_srd), desc.offset_);
-
-            // Check if synchronization has to be performed
-            if (image->CopyImageBuffer() != nullptr) {
-              Memory* devBuf = dev().getGpuMemory(mem->parent());
-              amd::Coord3D offs(0);
-              Image* devCpImg = static_cast<Image*>(dev().getGpuMemory(image->CopyImageBuffer()));
-              amd::Image* img = mem->asImage();
-
-              // Copy memory from the original image buffer into the backing store image
-              bool result =
-                  blitMgr().copyBufferToImage(*devBuf, *devCpImg, offs, offs, img->getRegion(),
-                                              true, img->getRowPitch(), img->getSlicePitch());
-              // Make sure the copy operation is done
+          if (mem == nullptr) {
+            ClPrint(amd::LOG_DEBUG, amd::LOG_KERN, "Arg%d: %s %s = ptr:%p ", i,
+                    desc.typeName_.c_str(), desc.name_.c_str(), globalAddress);
+            //! This condition is for SVM fine-grain
+            if (dev().isFineGrainedSystem(true)) {
+              // Sync AQL packets
               setAqlHeader(dispatchPacketHeader_);
-              // Use backing store SRD as the replacment
-              const uint64_t srd = devCpImg->getHsaImageObject().handle;
-              WriteAqlArgAt(const_cast<address>(params), srd, sizeof(srd), desc.offset_);
+              // Clear memory dependency state
+              const static bool All = true;
+              memoryDependency().clear(!All);
+            }
+          } else {
+            gpuMem = static_cast<Memory*>(mem->getDeviceMemory(dev()));
 
-              // If it's not a read only resource, then runtime has to write back
-              if (!desc.info_.readOnly_) {
-                wrtBackImageBuffer.push_back(mem->getDeviceMemory(dev()));
-                imageBufferWrtBack = true;
+            const void* globalAddress =
+                *reinterpret_cast<const void* const*>(params + desc.offset_);
+            ClPrint(amd::LOG_DEBUG, amd::LOG_KERN, "Arg%d: %s %s = ptr:%p obj:[%p-%p]", i,
+                    desc.typeName_.c_str(), desc.name_.c_str(), globalAddress,
+                    gpuMem->getDeviceMemory(),
+                    reinterpret_cast<address>(gpuMem->getDeviceMemory()) + mem->getSize());
+
+            // Validate memory for a dependency in the queue
+            memoryDependency().validate(*this, gpuMem, (desc.info_.readOnly_ == 1));
+
+            assert((desc.addressQualifier_ == CL_KERNEL_ARG_ADDRESS_GLOBAL ||
+                    desc.addressQualifier_ == CL_KERNEL_ARG_ADDRESS_CONSTANT) &&
+                   "Unsupported address qualifier");
+
+            const bool readOnly = (desc.typeQualifier_ == CL_KERNEL_ARG_TYPE_CONST) ||
+                                  ((mem->getMemFlags() & CL_MEM_READ_ONLY) != 0);
+
+            if (!readOnly) {
+              mem->signalWrite(&dev());
+            }
+
+            if (desc.info_.oclObject_ == amd::KernelParameterDescriptor::ImageObject) {
+              Image* image = static_cast<Image*>(mem->getDeviceMemory(dev()));
+
+              const uint64_t image_srd = image->getHsaImageObject().handle;
+              assert(amd::isMultipleOf(image_srd, sizeof(image_srd)));
+              WriteAqlArgAt(const_cast<address>(params), image_srd, sizeof(image_srd),
+                            desc.offset_);
+
+              // Check if synchronization has to be performed
+              if (image->CopyImageBuffer() != nullptr) {
+                Memory* devBuf = dev().getGpuMemory(mem->parent());
+                amd::Coord3D offs(0);
+                Image* devCpImg = static_cast<Image*>(dev().getGpuMemory(image->CopyImageBuffer()));
+                amd::Image* img = mem->asImage();
+
+                // Copy memory from the original image buffer into the backing store image
+                bool result =
+                    blitMgr().copyBufferToImage(*devBuf, *devCpImg, offs, offs, img->getRegion(),
+                                                true, img->getRowPitch(), img->getSlicePitch());
+                // Make sure the copy operation is done
+                setAqlHeader(dispatchPacketHeader_);
+                // Use backing store SRD as the replacment
+                const uint64_t srd = devCpImg->getHsaImageObject().handle;
+                WriteAqlArgAt(const_cast<address>(params), srd, sizeof(srd), desc.offset_);
+
+                // If it's not a read only resource, then runtime has to write back
+                if (!desc.info_.readOnly_) {
+                  wrtBackImageBuffer.push_back(mem->getDeviceMemory(dev()));
+                  imageBufferWrtBack = true;
+                }
               }
             }
           }
         }
+      } else if (desc.type_ == T_QUEUE) {
+        uint32_t index = desc.info_.arrayIndex_;
+        const amd::DeviceQueue* queue = reinterpret_cast<amd::DeviceQueue* const*>(
+            params + kernelParams.queueObjOffset())[index];
+
+        if (!createVirtualQueue(queue->size()) || !createSchedulerParam()) {
+          return false;
+        }
+        uint64_t vqVA = getVQVirtualAddress();
+        WriteAqlArgAt(const_cast<address>(params), vqVA, sizeof(vqVA), desc.offset_);
+      } else if (desc.type_ == T_VOID) {
+        const_address srcArgPtr = params + desc.offset_;
+        if (desc.info_.oclObject_ == amd::KernelParameterDescriptor::ReferenceObject) {
+          void* mem = allocKernArg(desc.size_, 128);
+          memcpy(mem, srcArgPtr, desc.size_);
+          const auto it = hsaKernel.patch().find(desc.offset_);
+          WriteAqlArgAt(const_cast<address>(params), mem, sizeof(void*), it->second);
+        }
+
+        LogVoidKernelArg(desc, srcArgPtr, i);
+      } else if (desc.type_ == T_SAMPLER) {
+        uint32_t index = desc.info_.arrayIndex_;
+        const amd::Sampler* sampler =
+            reinterpret_cast<amd::Sampler* const*>(params + kernelParams.samplerObjOffset())[index];
+
+        device::Sampler* devSampler = sampler->getDeviceSampler(dev());
+
+        uint64_t sampler_srd = devSampler->hwSrd();
+        WriteAqlArgAt(const_cast<address>(params), sampler_srd, sizeof(sampler_srd), desc.offset_);
       }
-    } else if (desc.type_ == T_QUEUE) {
-      uint32_t index = desc.info_.arrayIndex_;
-      const amd::DeviceQueue* queue =
-          reinterpret_cast<amd::DeviceQueue* const*>(params + kernelParams.queueObjOffset())[index];
-
-      if (!createVirtualQueue(queue->size()) || !createSchedulerParam()) {
-        return false;
-      }
-      uint64_t vqVA = getVQVirtualAddress();
-      WriteAqlArgAt(const_cast<address>(params), vqVA, sizeof(vqVA), desc.offset_);
-    } else if (desc.type_ == T_VOID) {
-      const_address srcArgPtr = params + desc.offset_;
-      if (desc.info_.oclObject_ == amd::KernelParameterDescriptor::ReferenceObject) {
-        void* mem = allocKernArg(desc.size_, 128);
-        memcpy(mem, srcArgPtr, desc.size_);
-        const auto it = hsaKernel.patch().find(desc.offset_);
-        WriteAqlArgAt(const_cast<address>(params), mem, sizeof(void*), it->second);
-      }
-
-      LogVoidKernelArg(desc, srcArgPtr, i);
-    } else if (desc.type_ == T_SAMPLER) {
-      uint32_t index = desc.info_.arrayIndex_;
-      const amd::Sampler* sampler =
-          reinterpret_cast<amd::Sampler* const*>(params + kernelParams.samplerObjOffset())[index];
-
-      device::Sampler* devSampler = sampler->getDeviceSampler(dev());
-
-      uint64_t sampler_srd = devSampler->hwSrd();
-      WriteAqlArgAt(const_cast<address>(params), sampler_srd, sizeof(sampler_srd), desc.offset_);
     }
   }
 

--- a/projects/clr/rocclr/device/rocm/rocvirtual.cpp
+++ b/projects/clr/rocclr/device/rocm/rocvirtual.cpp
@@ -756,6 +756,38 @@ void VirtualGPU::HwQueueTracker::ResetCurrentSignal() {
 }
 
 // ================================================================================================
+static void LogVoidKernelArg(const amd::KernelParameterDescriptor& desc, const_address argPtr,
+                             int argIndex) {
+  if (!IsLogEnabled(amd::LOG_INFO, amd::LOG_KERN)) {
+    return;
+  }
+
+  if (desc.size_ > 8) {
+    std::string bytes = "0x";
+    constexpr size_t kMaxBytes = 64;
+    for (size_t j = 0; j < std::min(desc.size_, kMaxBytes); j++) {
+      char byteStr[4];
+      snprintf(byteStr, sizeof(byteStr), "%02x ", reinterpret_cast<const uint8_t*>(argPtr)[j]);
+      bytes += byteStr;
+    }
+    if (desc.size_ > kMaxBytes) {
+      bytes += "...";
+    }
+    ClPrint(amd::LOG_DEBUG, amd::LOG_KERN, "Arg%d: %s %s = %s (size:0x%x)", argIndex,
+            desc.typeName_.c_str(), desc.name_.c_str(), bytes.c_str(), desc.size_);
+  } else {
+    ClPrint(amd::LOG_DEBUG, amd::LOG_KERN, "Arg%d: %s %s = val:0x%lx (size:0x%x)", argIndex,
+            desc.typeName_.c_str(), desc.name_.c_str(),
+            (desc.size_ == 1)   ? *reinterpret_cast<const uint8_t*>(argPtr)
+            : (desc.size_ == 2) ? *reinterpret_cast<const uint16_t*>(argPtr)
+            : (desc.size_ == 4) ? *reinterpret_cast<const uint32_t*>(argPtr)
+            : (desc.size_ == 8) ? *reinterpret_cast<const uint64_t*>(argPtr)
+                                : 0LL,
+            desc.size_);
+  }
+}
+
+// ================================================================================================
 bool VirtualGPU::processMemObjects(const amd::Kernel& kernel, const_address params,
                                    size_t& ldsAddress, bool cooperativeGroups,
                                    bool& imageBufferWrtBack,
@@ -963,32 +995,7 @@ bool VirtualGPU::processMemObjects(const amd::Kernel& kernel, const_address para
         WriteAqlArgAt(const_cast<address>(params), mem, sizeof(void*), it->second);
       }
 
-      if (IsLogEnabled(amd::LOG_INFO, amd::LOG_KERN)) {
-        if (desc.size_ > 8) {
-          std::string bytes = "0x";
-          constexpr size_t kMaxBytes = 64;
-          for (size_t j = 0; j < std::min(desc.size_, kMaxBytes); j++) {
-            char byteStr[4];
-            snprintf(byteStr, sizeof(byteStr), "%02x ",
-                     reinterpret_cast<const uint8_t*>(srcArgPtr)[j]);
-            bytes += byteStr;
-          }
-          if (desc.size_ > kMaxBytes) {
-            bytes += "...";
-          }
-          ClPrint(amd::LOG_DEBUG, amd::LOG_KERN, "Arg%d: %s %s = %s (size:0x%x)", i,
-                  desc.typeName_.c_str(), desc.name_.c_str(), bytes.c_str(), desc.size_);
-        } else {
-          ClPrint(amd::LOG_DEBUG, amd::LOG_KERN, "Arg%d: %s %s = val:0x%lx (size:0x%x)", i,
-                  desc.typeName_.c_str(), desc.name_.c_str(),
-                  (desc.size_ == 1)   ? *reinterpret_cast<const uint8_t*>(srcArgPtr)
-                  : (desc.size_ == 2) ? *reinterpret_cast<const uint16_t*>(srcArgPtr)
-                  : (desc.size_ == 4) ? *reinterpret_cast<const uint32_t*>(srcArgPtr)
-                  : (desc.size_ == 8) ? *reinterpret_cast<const uint64_t*>(srcArgPtr)
-                                      : 0LL,
-                  desc.size_);
-        }
-      }
+      LogVoidKernelArg(desc, srcArgPtr, i);
     } else if (desc.type_ == T_SAMPLER) {
       uint32_t index = desc.info_.arrayIndex_;
       const amd::Sampler* sampler =

--- a/projects/clr/rocclr/device/rocm/rocvirtual.cpp
+++ b/projects/clr/rocclr/device/rocm/rocvirtual.cpp
@@ -1010,6 +1010,19 @@ bool VirtualGPU::processMemObjects(const amd::Kernel& kernel, const_address para
         WriteAqlArgAt(const_cast<address>(params), sampler_srd, sizeof(sampler_srd), desc.offset_);
       }
     }
+  } else if (IsLogEnabled(amd::LOG_INFO, amd::LOG_KERN)) {
+    // HIP doesn't need any processing, but we still need logging.
+    for (size_t i = 0; i < signature.numParameters(); ++i) {
+      const amd::KernelParameterDescriptor& desc = signature.at(i);
+      if (desc.type_ == T_POINTER) {
+        const void* globalAddress = *reinterpret_cast<const void* const*>(params + desc.offset_);
+        ClPrint(amd::LOG_DEBUG, amd::LOG_KERN, "Arg%d: %s %s = ptr:%p ", i, desc.typeName_.c_str(),
+                desc.name_.c_str(), globalAddress);
+      } else {
+        assert(desc.type_ == T_VOID && "Unexpected HIP kernel argument type");
+        LogVoidKernelArg(desc, params + desc.offset_, i);
+      }
+    }
   }
 
   if (hsaKernel.program()->hasGlobalStores()) {


### PR DESCRIPTION
## Motivation

This patch belongs to a mini-series which intends to reduce kernel launch latency, specifically by optimizing the way we deal with HIP kernel arguments.

## Technical Details

HIP cannot have kernel arguments in local address spaces, kernels or samplers as arguments and after ROCm/rocm-systems#3524 it won't even have any memory objects passed to it via dedicated sub-section of `KernelParameters`.

## JIRA ID

N/A

## Test Plan

N/A, this change is intended to be non-functional

## Test Result

N/A, this change is intended to be non-functional

## Submission Checklist

- [X] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
