### PR TITLE
Release memory from mempool which shows up as a leak with ASAN

### DIFF
--- a/projects/clr/hipamd/src/hip_device.cpp
+++ b/projects/clr/hipamd/src/hip_device.cpp
@@ -340,10 +340,12 @@ Device::~Device() {
   clearAllTrackedObjects();
 
   if (graph_mem_pool_ != nullptr) {
+    graph_mem_pool_->ReleaseAllMemory();
     graph_mem_pool_->release();
   }
 
   if (default_managed_mem_pool_ != nullptr) {
+    default_managed_mem_pool_->ReleaseAllMemory();
     default_managed_mem_pool_->release();
   }
 

--- a/projects/clr/hipamd/src/hip_mempool_impl.cpp
+++ b/projects/clr/hipamd/src/hip_mempool_impl.cpp
@@ -322,6 +322,15 @@ bool MemoryPool::FreeMemory(amd::Memory* memory, Stream* stream, Event* event) {
 void MemoryPool::ReleaseAllMemory() {
   constexpr bool kSafeRelease = true;
   free_heap_.ReleaseAllMemory(0, kSafeRelease);
+  // When we move heap to busy, we do a retain.
+  // To release, we need to decrement it by that number
+  {
+    amd::ScopedLock lock(lock_pool_ops_);
+    size_t count = busy_heap_.Allocations().size();
+    for (size_t i = 0; i < count; i++) {
+      release();
+    }
+  }
   busy_heap_.ReleaseAllMemory(0, kSafeRelease);
 }
 


### PR DESCRIPTION
## Motivation

Fix for mempool memory leak, seen with ASAN.

## Technical Details

When we move memory object from busy to free, we create a new event and that event gets leaked.

## JIRA ID

NA

## Test Plan

Existing tests should run fine.

## Test Result

Tested locally, removed the signal leak seen

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
