### PR TITLE
[rocshmem] Add barrier APIs and expose `ROCSHMEM_TEAM_WORLD` on device

### DIFF
--- a/projects/rocshmem/CHANGELOG.md
+++ b/projects/rocshmem/CHANGELOG.md
@@ -9,7 +9,7 @@
    * `rocshmem_barrier`
    * `rocshmem_barrier_wave`
    * `rocshmem_barrier_wg`
-* Added `ROCSHMEM_TEAM_WOLRD` for the device code
+* Added `ROCSHMEM_TEAM_WORLD` for the device code
 ### Changed
 * Use CQ collapsing for the Mellanox MLX5 GDA conduit
 

--- a/projects/rocshmem/CHANGELOG.md
+++ b/projects/rocshmem/CHANGELOG.md
@@ -3,6 +3,13 @@
 ### Added
 * Added new APIs:
    * `rocshmem_TYPENAME_alltoall_wg`
+   * `rocshmem_TYPENAME_alltoallv_wg`
+   * `rocshmem_team_my_pe`
+   * `rocshmem_team_n_pes`
+   * `rocshmem_barrier`
+   * `rocshmem_barrier_wave`
+   * `rocshmem_barrier_wg`
+* Added `ROCSHMEM_TEAM_WOLRD` for the device code
 ### Changed
 * Use CQ collapsing for the Mellanox MLX5 GDA conduit
 

--- a/projects/rocshmem/docs/api/coll.rst
+++ b/projects/rocshmem/docs/api/coll.rst
@@ -36,8 +36,8 @@ across all PEs in the system. The operation is enqueued on the specified stream 
 asynchronously. The caller must synchronize the stream (e.g., using ``hipStreamSynchronize``)
 to ensure completion.
 
-ROCSHMEM_TEAM_BARRIER
-----------------
+ROCSHMEM_CTX_BARRIER
+--------------------
 
 .. cpp:function:: __device__ void rocshmem_ctx_barrier(rocshmem_ctx_t ctx, rocshmem_team_t team)
 .. cpp:function:: __device__ void rocshmem_ctx_barrier_wave(rocshmem_ctx_t ctx, rocshmem_team_t team)
@@ -65,8 +65,8 @@ This routine performs a collective barrier between all PEs in the system. This i
 to calling ``rocshmem_ctx_barrier*`` on default context and team world. The caller is blocked
 until the barrier is resolved.
 
-ROCSHMEM_TEAM_SYNC
-------------------
+ROCSHMEM_CTX_SYNC
+-----------------
 
 .. cpp:function:: __device__ void rocshmem_ctx_sync(rocshmem_ctx_t ctx, rocshmem_team_t team)
 .. cpp:function:: __device__ void rocshmem_ctx_sync_wave(rocshmem_ctx_t ctx, rocshmem_team_t team)
@@ -80,8 +80,8 @@ ROCSHMEM_TEAM_SYNC
 This routine registers the arrival of a PE at a barrier.
 The caller is blocked until the synchronization is resolved.
 
-Unlike the ``rocshmem_ctx_barrier**`` routine, ``rocshmem_ctx_sync*`` only ensures the
-completion and visibility of previously issued memory stores, but does not
+Unlike the ``rocshmem_ctx_barrier*`` routines, ``rocshmem_ctx_sync*`` only ensure the
+completion and visibility of previously issued memory stores, but it does not
 ensure the completion of remote memory updates issued via OpenSHMEM routines.
 
 ROCSHMEM_SYNC_ALL
@@ -94,7 +94,7 @@ ROCSHMEM_SYNC_ALL
   :returns:    None.
 
 **Description:**
-These routines behaves the same way as ``rocshmem_ctx_sync_*`` when called on the world team.
+These routines behaves the same way as ``rocshmem_ctx_sync*`` when called on the world team.
 These APIs should be called from only one thread/wavefront/workgroup within the grid to avoid undefined behavior.
 
 ROSHMEM_ALLTOALL

--- a/projects/rocshmem/docs/api/coll.rst
+++ b/projects/rocshmem/docs/api/coll.rst
@@ -36,7 +36,7 @@ across all PEs in the system. The operation is enqueued on the specified stream 
 asynchronously. The caller must synchronize the stream (e.g., using ``hipStreamSynchronize``)
 to ensure completion.
 
-ROCSHMEM_BARRIER
+ROCSHMEM_TEAM_BARRIER
 ----------------
 
 .. cpp:function:: __device__ void rocshmem_ctx_barrier(rocshmem_ctx_t ctx, rocshmem_team_t team)
@@ -47,8 +47,23 @@ ROCSHMEM_BARRIER
   :returns:   None.
 
 **Description:**
-This routine performs a collective barrier between all PEs in the system.
-The caller is blocked until the barrier is resolved.
+This routine performs a collective barrier between all PEs in the specified team using
+the provided rocshmem context. The caller is blocked until all PEs in the team have
+entered the barrier and the synchronization is complete.
+
+ROCSHMEM_BARRIER
+----------------
+
+.. cpp:function:: __device__ void rocshmem_barrier()
+.. cpp:function:: __device__ void rocshmem_barrier_wave()
+.. cpp:function:: __device__ void rocshmem_barrier_wg()
+
+  :returns:   None.
+
+**Description:**
+This routine performs a collective barrier between all PEs in the system. This is equivalent
+to calling ``rocshmem_ctx_barrier*`` on default context and team world. The caller is blocked
+until the barrier is resolved.
 
 ROCSHMEM_TEAM_SYNC
 ------------------
@@ -65,7 +80,7 @@ ROCSHMEM_TEAM_SYNC
 This routine registers the arrival of a PE at a barrier.
 The caller is blocked until the synchronization is resolved.
 
-Unlike the ``shmem_barrier_all`` routine, ``shmem_team_sync`` only ensures the
+Unlike the ``rocshmem_ctx_barrier**`` routine, ``rocshmem_ctx_sync*`` only ensures the
 completion and visibility of previously issued memory stores, but does not
 ensure the completion of remote memory updates issued via OpenSHMEM routines.
 
@@ -79,7 +94,7 @@ ROCSHMEM_SYNC_ALL
   :returns:    None.
 
 **Description:**
-These routines behaves the same way as ``rocshmem_team_sync_*`` when called on the world team.
+These routines behaves the same way as ``rocshmem_ctx_sync_*`` when called on the world team.
 These APIs should be called from only one thread/wavefront/workgroup within the grid to avoid undefined behavior.
 
 ROSHMEM_ALLTOALL

--- a/projects/rocshmem/include/rocshmem/rocshmem_COLL.hpp
+++ b/projects/rocshmem/include/rocshmem/rocshmem_COLL.hpp
@@ -848,6 +848,36 @@ __device__ void rocshmem_ctx_barrier_wave(rocshmem_ctx_t ctx, rocshmem_team_t te
 __device__ void rocshmem_ctx_barrier_wg(rocshmem_ctx_t ctx, rocshmem_team_t team);
 
 /**
+ * @brief perform a collective barrier between all PEs in the team world.
+ * The caller is blocked until the barrier is resolved.
+ *
+ * This function must be invoked by a single thread within the PE.
+ *
+ * @return void
+ */
+__device__ void rocshmem_barrier();
+
+/**
+ * @brief perform a collective barrier between all PEs in the team world.
+ * The caller is blocked until the barrier is resolved.
+ *
+ * This function must be called as a wave-front collective.
+ *
+ * @return void
+ */
+__device__ void rocshmem_barrier_wave();
+
+/**
+ * @brief perform a collective barrier between all PEs in the team world.
+ * The caller is blocked until the barrier is resolved.
+ *
+ * This function must be called as a work-group collective.
+ *
+ * @return void
+ */
+__device__ void rocshmem_barrier_wg();
+
+/**
  * @brief registers the arrival of a PE at a barrier.
  * The caller is blocked until the synchronization is resolved.
  *

--- a/projects/rocshmem/include/rocshmem/rocshmem_common.hpp
+++ b/projects/rocshmem/include/rocshmem/rocshmem_common.hpp
@@ -161,6 +161,9 @@ using device::ROCSHMEM_TEAM_WORLD;
 using host::ROCSHMEM_TEAM_WORLD;
 #endif
 
+/**
+ * Used internally to update the ROCSHMEM_TEAM_WORLD constant
+ */
 void set_team_world(rocshmem_team_t *team_world);
 
 const rocshmem_team_t ROCSHMEM_TEAM_INVALID = nullptr;

--- a/projects/rocshmem/include/rocshmem/rocshmem_common.hpp
+++ b/projects/rocshmem/include/rocshmem/rocshmem_common.hpp
@@ -164,7 +164,7 @@ using host::ROCSHMEM_TEAM_WORLD;
 /**
  * Used internally to update the ROCSHMEM_TEAM_WORLD constant
  */
-void set_team_world(rocshmem_team_t *team_world);
+void set_team_world_device(rocshmem_team_t team_world);
 
 const rocshmem_team_t ROCSHMEM_TEAM_INVALID = nullptr;
 

--- a/projects/rocshmem/include/rocshmem/rocshmem_common.hpp
+++ b/projects/rocshmem/include/rocshmem/rocshmem_common.hpp
@@ -146,7 +146,22 @@ enum class BackendType { GDA_BACKEND, RO_BACKEND, IPC_BACKEND };
 BackendType get_backend_type();
 
 typedef uint64_t *rocshmem_team_t;
-extern rocshmem_team_t ROCSHMEM_TEAM_WORLD;
+
+namespace device {
+    extern __constant__ rocshmem_team_t ROCSHMEM_TEAM_WORLD;
+}
+
+namespace host {
+    extern rocshmem_team_t ROCSHMEM_TEAM_WORLD;
+}
+
+#if __HIP_DEVICE_COMPILE__
+using device::ROCSHMEM_TEAM_WORLD;
+#else
+using host::ROCSHMEM_TEAM_WORLD;
+#endif
+
+void set_team_world(rocshmem_team_t *team_world);
 
 const rocshmem_team_t ROCSHMEM_TEAM_INVALID = nullptr;
 

--- a/projects/rocshmem/include/rocshmem/rocshmem_common.hpp
+++ b/projects/rocshmem/include/rocshmem/rocshmem_common.hpp
@@ -148,7 +148,7 @@ BackendType get_backend_type();
 typedef uint64_t *rocshmem_team_t;
 
 namespace device {
-    extern __constant__ rocshmem_team_t ROCSHMEM_TEAM_WORLD;
+    extern __constant__ rocshmem_team_t __attribute__((visibility("default"))) ROCSHMEM_TEAM_WORLD;
 }
 
 namespace host {

--- a/projects/rocshmem/src/gda/backend_gda.cpp
+++ b/projects/rocshmem/src/gda/backend_gda.cpp
@@ -222,6 +222,7 @@ void GDABackend::setup_team_world() {
    * Copy the address to ROCSHMEM_TEAM_WORLD.
    */
   ROCSHMEM_TEAM_WORLD = reinterpret_cast<rocshmem_team_t>(team_world);
+  set_team_world(reinterpret_cast<rocshmem_team_t*>(&team_world));
 }
 
 void GDABackend::team_destroy(rocshmem_team_t team) {

--- a/projects/rocshmem/src/gda/backend_gda.cpp
+++ b/projects/rocshmem/src/gda/backend_gda.cpp
@@ -221,8 +221,8 @@ void GDABackend::setup_team_world() {
   /**
    * Copy the address to ROCSHMEM_TEAM_WORLD.
    */
-  ROCSHMEM_TEAM_WORLD = reinterpret_cast<rocshmem_team_t>(team_world);
-  set_team_world(reinterpret_cast<rocshmem_team_t*>(&team_world));
+  host::ROCSHMEM_TEAM_WORLD = reinterpret_cast<rocshmem_team_t>(team_world);
+  set_team_world_device(host::ROCSHMEM_TEAM_WORLD);
 }
 
 void GDABackend::team_destroy(rocshmem_team_t team) {

--- a/projects/rocshmem/src/ipc/backend_ipc.cpp
+++ b/projects/rocshmem/src/ipc/backend_ipc.cpp
@@ -219,7 +219,7 @@ void IPCBackend::setup_team_world() {
    * Copy the address to ROCSHMEM_TEAM_WORLD.
    */
   host::ROCSHMEM_TEAM_WORLD = reinterpret_cast<rocshmem_team_t>(team_world);
-  set_team_world(reinterpret_cast<rocshmem_team_t*>(&team_world));
+  set_team_world_device(host::ROCSHMEM_TEAM_WORLD);
 }
 
 void IPCBackend::team_destroy(rocshmem_team_t team) {

--- a/projects/rocshmem/src/ipc/backend_ipc.cpp
+++ b/projects/rocshmem/src/ipc/backend_ipc.cpp
@@ -112,8 +112,6 @@ IPCBackend::IPCBackend(TcpBootstrap *bootstrap):  Backend(bootstrap) {
 void IPCBackend::init() {
   ROCSHMEM_HOST_CTX_DEFAULT.ctx_opaque = default_host_ctx.get();
 
-  setup_team_world();
-
   setup_wrk_sync_buffers();
 
   rocshmem_collective_init();
@@ -121,6 +119,8 @@ void IPCBackend::init() {
   setup_fence_buffer();
 
   teams_init();
+
+  setup_team_world();
 
   TeamInfo *tinfo = team_tracker.get_team_world()->tinfo_wrt_world;
 
@@ -170,7 +170,7 @@ int IPCBackend::backend_can_run(MPI_Comm comm, TcpBootstrap* bootstrap) {
 }
 void IPCBackend::setup_ctxs() {
   CHECK_HIP(hipMalloc(&ctx_array, sizeof(IPCContext) * envvar::max_num_contexts));
-  // 0th context is default context
+  // 0th index is used for default context
   for (size_t i = 0; i < envvar::max_num_contexts; i++) {
     new (&ctx_array[i]) IPCContext(this, i + 1);
     ctx_free_list.get()->push_back(ctx_array + i);
@@ -218,7 +218,8 @@ void IPCBackend::setup_team_world() {
   /**
    * Copy the address to ROCSHMEM_TEAM_WORLD.
    */
-  ROCSHMEM_TEAM_WORLD = reinterpret_cast<rocshmem_team_t>(team_world);
+  host::ROCSHMEM_TEAM_WORLD = reinterpret_cast<rocshmem_team_t>(team_world);
+  set_team_world(reinterpret_cast<rocshmem_team_t*>(&team_world));
 }
 
 void IPCBackend::team_destroy(rocshmem_team_t team) {

--- a/projects/rocshmem/src/reverse_offload/backend_ro.cpp
+++ b/projects/rocshmem/src/reverse_offload/backend_ro.cpp
@@ -109,6 +109,7 @@ ROBackend::ROBackend(MPI_Comm comm)
 
   ROCSHMEM_TEAM_WORLD =
       reinterpret_cast<rocshmem_team_t>(team_world_proxy_->get());
+  set_team_world(reinterpret_cast<rocshmem_team_t*>(&ROCSHMEM_TEAM_WORLD));
 
   default_block_handle_proxy_ = DefaultBlockHandleProxyT(
                                 g_ret_buffer_.get(),

--- a/projects/rocshmem/src/reverse_offload/backend_ro.cpp
+++ b/projects/rocshmem/src/reverse_offload/backend_ro.cpp
@@ -107,9 +107,9 @@ ROBackend::ROBackend(MPI_Comm comm)
       this, transport_->get_world_comm(), my_pe, num_pes);
   team_tracker.set_team_world(team_world_proxy_->get());
 
-  ROCSHMEM_TEAM_WORLD =
+  host::ROCSHMEM_TEAM_WORLD =
       reinterpret_cast<rocshmem_team_t>(team_world_proxy_->get());
-  set_team_world(reinterpret_cast<rocshmem_team_t*>(&ROCSHMEM_TEAM_WORLD));
+  set_team_world_device(host::ROCSHMEM_TEAM_WORLD);
 
   default_block_handle_proxy_ = DefaultBlockHandleProxyT(
                                 g_ret_buffer_.get(),

--- a/projects/rocshmem/src/rocshmem_gpu.cpp
+++ b/projects/rocshmem/src/rocshmem_gpu.cpp
@@ -396,7 +396,6 @@ __host__ void set_internal_ctx(rocshmem_ctx_t *ctx) {
 }
 
 __host__ void set_team_world(rocshmem_team_t *team_world) {
-  printf("team world::: %p, %p\n", *team_world, team_world);
   CHECK_HIP(hipMemcpyToSymbol(HIP_SYMBOL(device::ROCSHMEM_TEAM_WORLD), team_world,
                               sizeof(rocshmem_team_t), 0,
                               hipMemcpyHostToDevice));
@@ -855,8 +854,6 @@ __device__ void rocshmem_barrier_all_wg() {
 
 __device__ void rocshmem_ctx_barrier(rocshmem_ctx_t ctx, rocshmem_team_t team) {
   GPU_DPRINTF("Function: rocshmem_ctx_barrier (ctx=%zd, team=%zd)\n",
-    ctx.ctx_opaque, team);
-  printf("Function: rocshmem_ctx_barrier (ctx=%p, team=%p)\n",
     ctx.ctx_opaque, team);
 
   get_internal_ctx(ctx)->barrier(team);

--- a/projects/rocshmem/src/rocshmem_gpu.cpp
+++ b/projects/rocshmem/src/rocshmem_gpu.cpp
@@ -395,8 +395,8 @@ __host__ void set_internal_ctx(rocshmem_ctx_t *ctx) {
                               hipMemcpyHostToDevice));
 }
 
-__host__ void set_team_world(rocshmem_team_t *team_world) {
-  CHECK_HIP(hipMemcpyToSymbol(HIP_SYMBOL(device::ROCSHMEM_TEAM_WORLD), team_world,
+__host__ void set_team_world_device(rocshmem_team_t team_world) {
+  CHECK_HIP(hipMemcpyToSymbol(HIP_SYMBOL(device::ROCSHMEM_TEAM_WORLD), &team_world,
                               sizeof(rocshmem_team_t), 0,
                               hipMemcpyHostToDevice));
 }

--- a/projects/rocshmem/src/rocshmem_gpu.cpp
+++ b/projects/rocshmem/src/rocshmem_gpu.cpp
@@ -79,6 +79,10 @@ __constant__ Backend *device_backend_proxy;
 
 __constant__ rocshmem_ctx_t ROCSHMEM_CTX_INVALID = {nullptr, nullptr};
 
+namespace device {
+    __device__ __constant__ rocshmem_team_t ROCSHMEM_TEAM_WORLD;
+}
+
 #if defined(ENABLE_IPC_BITCODE)
   typedef IPCContext ContextTy;
 #elif defined(ENABLE_IBGDA_BITCODE)
@@ -335,6 +339,18 @@ __device__ void rocshmem_atomic_xor(T *dest, T value, int pe) {
   rocshmem_atomic_xor(ROCSHMEM_CTX_DEFAULT, dest, value, pe);
 }
 
+__device__ void rocshmem_barrier() {
+  rocshmem_ctx_barrier(ROCSHMEM_CTX_DEFAULT, device::ROCSHMEM_TEAM_WORLD);
+}
+
+__device__ void rocshmem_barrier_wave() {
+  rocshmem_ctx_barrier_wave(ROCSHMEM_CTX_DEFAULT, device::ROCSHMEM_TEAM_WORLD);
+}
+
+__device__ void rocshmem_barrier_wg() {
+  rocshmem_ctx_barrier_wg(ROCSHMEM_CTX_DEFAULT, device::ROCSHMEM_TEAM_WORLD);
+}
+
 #define ROCSHMEM_PUTMEM_SIGNAL_DEF(SUFFIX)                                                      \
   __device__ void rocshmem_putmem_signal##SUFFIX(void *dest, const void *source, size_t nelems, \
                                                   uint64_t *sig_addr, uint64_t signal,           \
@@ -376,6 +392,13 @@ __device__ int translate_pe(rocshmem_ctx_t ctx, int pe) {
 __host__ void set_internal_ctx(rocshmem_ctx_t *ctx) {
   CHECK_HIP(hipMemcpyToSymbol(HIP_SYMBOL(ROCSHMEM_CTX_DEFAULT), ctx,
                               sizeof(rocshmem_ctx_t), 0,
+                              hipMemcpyHostToDevice));
+}
+
+__host__ void set_team_world(rocshmem_team_t *team_world) {
+  printf("team world::: %p, %p\n", *team_world, team_world);
+  CHECK_HIP(hipMemcpyToSymbol(HIP_SYMBOL(device::ROCSHMEM_TEAM_WORLD), team_world,
+                              sizeof(rocshmem_team_t), 0,
                               hipMemcpyHostToDevice));
 }
 
@@ -832,6 +855,8 @@ __device__ void rocshmem_barrier_all_wg() {
 
 __device__ void rocshmem_ctx_barrier(rocshmem_ctx_t ctx, rocshmem_team_t team) {
   GPU_DPRINTF("Function: rocshmem_ctx_barrier (ctx=%zd, team=%zd)\n",
+    ctx.ctx_opaque, team);
+  printf("Function: rocshmem_ctx_barrier (ctx=%p, team=%p)\n",
     ctx.ctx_opaque, team);
 
   get_internal_ctx(ctx)->barrier(team);

--- a/projects/rocshmem/src/rocshmem_gpu.cpp
+++ b/projects/rocshmem/src/rocshmem_gpu.cpp
@@ -73,14 +73,16 @@
 
 namespace rocshmem {
 
-__device__  rocshmem_ctx_t __attribute__((visibility("default"))) ROCSHMEM_CTX_DEFAULT{};
+__device__  rocshmem_ctx_t
+__attribute__((visibility("default"))) ROCSHMEM_CTX_DEFAULT{};
 
 __constant__ Backend *device_backend_proxy;
 
 __constant__ rocshmem_ctx_t ROCSHMEM_CTX_INVALID = {nullptr, nullptr};
 
 namespace device {
-    __device__ __constant__ rocshmem_team_t ROCSHMEM_TEAM_WORLD;
+    __constant__ rocshmem_team_t
+    __attribute__((visibility("default"))) ROCSHMEM_TEAM_WORLD;
 }
 
 #if defined(ENABLE_IPC_BITCODE)
@@ -129,67 +131,72 @@ __host__ void * rocshmem_get_device_ctx() {
   return ctx.ctx_opaque;
 }
 
+/**
+ * Copies a device symbol from rocSHMEM to the user's HIP module
+ * via device-to-device memcpy (graph-capture compatible).
+ * Returns 0 on success, ROCSHMEM_ERROR on failure.
+ */
+template <typename Symbol>
+static int copy_device_symbol_to_module(Symbol &builtin_symbol,
+    const char *module_symbol_name, size_t expected_size, hipModule_t module,
+    hipStream_t stream, const char *label) {
+  void *source {nullptr};
+  hipError_t err = hipGetSymbolAddress(&source, HIP_SYMBOL(builtin_symbol));
+  if (err != hipSuccess) {
+    fprintf(stderr,
+            "[rocSHMEM] Error: Failed to get address of built-in %s: %s\n",
+            label, hipGetErrorString(err));
+    return ROCSHMEM_ERROR;
+  }
+  if (source == nullptr) {
+    fprintf(stderr, "[rocSHMEM] Error: Built-in %s has null address\n", label);
+    return ROCSHMEM_ERROR;
+  }
+
+  void *target {nullptr};
+  size_t symbol_size {0};
+  err = hipModuleGetGlobal(&target, &symbol_size, module, module_symbol_name);
+  if (err != hipSuccess) {
+    fprintf(stderr,
+            "[rocSHMEM] Error: Failed to get %s symbol from module: %s\n",
+            label, hipGetErrorString(err));
+    return ROCSHMEM_ERROR;
+  }
+  if (symbol_size != expected_size) {
+    fprintf(stderr,
+            "[rocSHMEM] Error: Symbol size mismatch for %s. Expected %zu, "
+            "got %zu\n",
+            label, expected_size, symbol_size);
+    return ROCSHMEM_ERROR;
+  }
+
+  err = hipMemcpyAsync(target, source, expected_size,
+                       hipMemcpyDeviceToDevice, stream);
+  if (err != hipSuccess) {
+    fprintf(stderr, "[rocSHMEM] Error: Failed to copy %s to device: %s\n",
+            label, hipGetErrorString(err));
+    return ROCSHMEM_ERROR;
+  }
+  return ROCSHMEM_SUCCESS;
+}
+
 __host__ int rocshmem_hipmodule_init(hipModule_t module, hipStream_t stream) {
-  // Step 1: Get device address of rocSHMEM's built-in ROCSHMEM_CTX_DEFAULT symbol
-  // Use hipGetSymbolAddress for graph-capture compatibility (device-to-device path)
-  void *source_ctx_device = nullptr;
-  hipError_t err = hipGetSymbolAddress(&source_ctx_device, HIP_SYMBOL(ROCSHMEM_CTX_DEFAULT));
-
-  if (err != hipSuccess) {
-    fprintf(stderr, "[rocSHMEM] Error: Failed to get address of built-in ROCSHMEM_CTX_DEFAULT: %s\n",
-            hipGetErrorString(err));
-    return ROCSHMEM_ERROR;
-  }
-
-  if (source_ctx_device == nullptr) {
-    fprintf(stderr, "[rocSHMEM] Error: Built-in ROCSHMEM_CTX_DEFAULT has null address\n");
-    return ROCSHMEM_ERROR;
-  }
-
-  // Step 2: Query the device symbol address from the user's HIP module
-  void *target_ctx_device = nullptr;
-  size_t symbol_size = 0;
-
-  err = hipModuleGetGlobal(
-      &target_ctx_device,
-      &symbol_size,
-      module,
-      "ROCSHMEM_CTX_DEFAULT"
-  );
-
-  if (err != hipSuccess) {
-    fprintf(stderr, "[rocSHMEM] Error: Failed to get ROCSHMEM_CTX_DEFAULT symbol from module: %s\n",
-            hipGetErrorString(err));
-    return ROCSHMEM_ERROR;
-  }
-
-  if (symbol_size != sizeof(rocshmem_ctx_t)) {
-    fprintf(stderr, "[rocSHMEM] Error: Symbol size mismatch. Expected %zu, got %zu\n",
-            sizeof(rocshmem_ctx_t), symbol_size);
-    return ROCSHMEM_ERROR;
-  }
-
-  // Step 3: Device-to-device copy using stream-ordered memcpy
-  // This is fully graph-capture compatible since both source and target are device memory
   if (stream == nullptr) {
     stream = hipStreamPerThread;
   }
 
-  err = hipMemcpyAsync(
-      target_ctx_device,
-      source_ctx_device,
-      sizeof(rocshmem_ctx_t),
-      hipMemcpyDeviceToDevice,  // Device-to-device copy for graph capture compatibility
-      stream
-  );
-
-  if (err != hipSuccess) {
-    fprintf(stderr, "[rocSHMEM] Error: Failed to copy context to device: %s\n",
-            hipGetErrorString(err));
+  if (copy_device_symbol_to_module(ROCSHMEM_CTX_DEFAULT, "ROCSHMEM_CTX_DEFAULT",
+                                   sizeof(rocshmem_ctx_t), module, stream,
+                                   "ROCSHMEM_CTX_DEFAULT") != ROCSHMEM_SUCCESS) {
     return ROCSHMEM_ERROR;
   }
-
-  return 0;
+  if (copy_device_symbol_to_module(device::ROCSHMEM_TEAM_WORLD,
+                                   "ROCSHMEM_TEAM_WORLD",
+                                   sizeof(rocshmem_team_t), module, stream,
+                                   "ROCSHMEM_TEAM_WORLD") != ROCSHMEM_SUCCESS) {
+    return ROCSHMEM_ERROR;
+  }
+  return ROCSHMEM_SUCCESS;
 }
 
 /******************************************************************************

--- a/projects/rocshmem/src/team.cpp
+++ b/projects/rocshmem/src/team.cpp
@@ -33,7 +33,9 @@
 
 namespace rocshmem {
 
-rocshmem_team_t ROCSHMEM_TEAM_WORLD;
+namespace host {
+    rocshmem_team_t ROCSHMEM_TEAM_WORLD;
+}
 
 __host__ __device__ Team* get_internal_team(rocshmem_team_t team) {
   return reinterpret_cast<Team*>(team);

--- a/projects/rocshmem/tests/functional_tests/hipmodule_init_tester.cpp
+++ b/projects/rocshmem/tests/functional_tests/hipmodule_init_tester.cpp
@@ -53,9 +53,14 @@ typedef struct rocshmem_ctx {
   void *team_opaque;
 } rocshmem_ctx_t;
 
+typedef unsigned long long* rocshmem_team_t;
+
 // Define the ROCSHMEM_CTX_DEFAULT symbol. rocshmem_hipmodule_init() looks for
 // this device symbol in the given kernel module
 extern "C" __device__ rocshmem_ctx_t __attribute__((visibility("default"))) ROCSHMEM_CTX_DEFAULT{};
+
+// Define ROCSHMEM_TEAM_WORLD so rocshmem_hipmodule_init() can copy the team world into this module
+extern "C" __constant__ rocshmem_team_t __attribute__((visibility("default"))) ROCSHMEM_TEAM_WORLD {nullptr};
 
 // stub kernel function used for module verification
 extern "C" __global__ void simple_test_kernel(int *result) {


### PR DESCRIPTION
## Motivation
- This PR introduces device-level barrier APIs for thread, wave, and work-group scope to simplify collective synchronization in GPU kernels.
- It also exposes `ROCSHMEM_TEAM_WORLD` to device code

## Technical Details
- Added new device-level barrier APIs:
  - `rocshmem_barrier()` (single-thread collective)
  - `rocshmem_barrier_wave()` (wavefront collective)
  - `rocshmem_barrier_wg()` (work-group collective)
- These wrap the corresponding `rocshmem_ctx_barrier*` functions using:
  - `ROCSHMEM_CTX_DEFAULT`
  - `ROCSHMEM_TEAM_WORLD`
- Introduced a device-visible `__constant__` symbol for `ROCSHMEM_TEAM_WORLD`.
- Added `set_team_world()` to copy the host `ROCSHMEM_TEAM_WORLD` pointer to device constant memory via `hipMemcpyToSymbol`.
- Updated all backends (`GDA`, `IPC`, `RO`) to properly initialize both host and device versions of `ROCSHMEM_TEAM_WORLD`.
- Minor initialization ordering adjustment in `IPC` backend to ensure correct team setup.
- Added documentation for `rocshmem_barrier*` APIs

## JIRA ID
- AIROCSHMEM-298
  - Completes last 2 requirements of this ticket
  - #3413 covers the first 2 requitements

## Test Plan
- Built rocSHMEM with updated changes across supported backends (`GDA`, `IPC`, `RO`).
- Verified successful compilation for device code paths.
- Ran basic collective tests to confirm:
  - `rocshmem_barrier()` works in single-thread invocation.
  - `rocshmem_barrier_wave()` works correctly at wave scope.
  - `rocshmem_barrier_wg()` works correctly at work-group scope.
- Confirmed no regression in existing collective functionality.

## Test Result
- Build completed successfully.
- Collective barrier tests passed across tested configurations.
- No observed regressions in existing test suite.

## Submission Checklist
- [x] Code builds successfully across supported backends.
- [x] Relevant tests executed and passing.
- [x] No regressions observed in existing functionality.