### PR TITLE
[CLR] Fix Event::awaitCompletion deadlock when worker thread is dead

### DIFF
--- a/projects/clr/rocclr/platform/command.cpp
+++ b/projects/clr/rocclr/platform/command.cpp
@@ -260,7 +260,12 @@ bool Event::awaitCompletion() {
       // Active wait: yield in a tight loop. Check that the queue's worker
       // thread is still alive to prevent an infinite spin during process
       // exit — ExitProcess kills all threads before DLL_PROCESS_DETACH.
-      while (status() > CL_COMPLETE && Os::isThreadAlive(queue->thread())) {
+      // Only check when a real thread exists (handle != nullptr); in direct
+      // dispatch mode there is no worker thread to check.
+      while (status() > CL_COMPLETE) {
+        if (queue->thread().handle() != nullptr && !Os::isThreadAlive(queue->thread())) {
+          break;
+        }
         amd::Os::yield();
       }
     } else {
@@ -271,7 +276,8 @@ bool Event::awaitCompletion() {
       // condition variable — if the thread is dead, no one will signal
       // completion and we would block forever.
       while (status() > CL_COMPLETE) {
-        if (queue != nullptr && !Os::isThreadAlive(queue->thread())) {
+        if (queue != nullptr && queue->thread().handle() != nullptr
+            && !Os::isThreadAlive(queue->thread())) {
           break;
         }
         lock_.wait();

--- a/projects/clr/rocclr/platform/command.cpp
+++ b/projects/clr/rocclr/platform/command.cpp
@@ -257,14 +257,23 @@ bool Event::awaitCompletion() {
             this, status());
     auto* queue = command().queue();
     if ((queue != nullptr) && queue->vdev()->ActiveWait()) {
-      while (status() > CL_COMPLETE) {
+      // Active wait: yield in a tight loop. Check that the queue's worker
+      // thread is still alive to prevent an infinite spin during process
+      // exit — ExitProcess kills all threads before DLL_PROCESS_DETACH.
+      while (status() > CL_COMPLETE && Os::isThreadAlive(queue->thread())) {
         amd::Os::yield();
       }
     } else {
       ScopedLock lock(lock_);
 
       // Wait until the status becomes CL_COMPLETE or negative.
+      // Check that the worker thread is alive before blocking on the
+      // condition variable — if the thread is dead, no one will signal
+      // completion and we would block forever.
       while (status() > CL_COMPLETE) {
+        if (queue != nullptr && !Os::isThreadAlive(queue->thread())) {
+          break;
+        }
         lock_.wait();
       }
     }


### PR DESCRIPTION
`Event::awaitCompletion()` can deadlock if the queue's worker thread is no longer running. Both wait paths — the ActiveWait yield loop and the condition variable wait — spin/block indefinitely because no thread remains to set the event status to `CL_COMPLETE`.

This adds `Os::isThreadAlive(queue->thread())` checks to both wait paths, matching the existing pattern in `HostQueue::terminate()` ([ecea27eb](https://github.com/ROCm/clr/commit/ecea27eb2d935e467ce47b430fa8ef29dfce5f58)).

**Minimum reproducer (Windows):**

```python
import torch
tensor_gpu = torch.randn(1, 1, device="cuda")
# Process hangs on exit — never terminates
```

Adding an explicit `torch.cuda.synchronize()` or `print(tensor_gpu)` (which does an implicit sync via `hipMemcpy`) before exit masks the hang.

`ExitProcess` kills all worker threads before `DLL_PROCESS_DETACH`, then `__hipUnregisterFatBinary` (from a consumer DLL's atexit handler) calls `SyncAllStreams` -> `finish()` -> `awaitCompletion()`, which spins forever.

Tracking:
- https://github.com/pytorch/pytorch/issues/160759
- https://github.com/ROCm/TheRock/issues/999

## Testing

Windows 11, gfx1151, PyTorch ROCm, no Python-level workarounds.

| Test | Result |
|------|--------|
| Unpatched, `torch.randn(1,1,device="cuda")` + exit | Hangs (100%) |
| Patched, `torch.randn(1,1,device="cuda")` + exit | Clean exit (5/5) |
| Patched, heavy GPU workload (Triton JIT compilation + matmul) | Clean exit |

Not tested on Linux (hang does not occur there — `exit()` runs atexit handlers before thread teardown).

## Hang stack

```
ntdll!NtDelayExecution                          <- Os::yield() -> SwitchToThread
KERNELBASE!SwitchToThread
amdhip64_7!...                                  <- Event::awaitCompletion spin
amdhip64_7!_hipUnregisterFatBinary+0x17
ucrtbase!execute_onexit_table                   <- CRT atexit handlers
torch_hip!dllmain_crt_process_detach            <- torch_hip.dll unloading
ntdll!LdrShutdownProcess                        <- ExitProcess (loader lock held)
ntdll!RtlExitUserProcess
kernel32!ExitProcessImplementation
python
```

The deadlock is in `Event::awaitCompletion()` (command.cpp):

```cpp
while (status() > CL_COMPLETE) {   // worker thread is dead — status never
    amd::Os::yield();               // reaches CL_COMPLETE, spins forever
}
```

`HostQueue::finish()` creates a `Marker` command and calls `awaitCompletion()`. The worker thread that would process the Marker and set `status = CL_COMPLETE` was killed by `ExitProcess` before `DLL_PROCESS_DETACH`.