### PR TITLE
rocrtst: AddressSanitizer fix series - fixes hsa_memory_free mismatches

### DIFF
--- a/projects/rocr-runtime/rocrtst/suites/functional/gpu_coredump.cc
+++ b/projects/rocr-runtime/rocrtst/suites/functional/gpu_coredump.cc
@@ -108,7 +108,7 @@ public:
   ~HSAResourceGuard() {
     // Cleanup in reverse order of typical acquisition
     if (signal.handle) hsa_signal_destroy(signal);
-    if (kernarg_buffer) hsa_memory_free(kernarg_buffer);
+    if (kernarg_buffer) hsa_amd_memory_pool_free(kernarg_buffer);
     if (executable.handle) hsa_executable_destroy(executable);
     if (code_obj_rdr.handle) hsa_code_object_reader_destroy(code_obj_rdr);
     if (file_fd != -1) close(file_fd);

--- a/projects/rocr-runtime/rocrtst/suites/functional/memory_atomics.cc
+++ b/projects/rocr-runtime/rocrtst/suites/functional/memory_atomics.cc
@@ -489,15 +489,19 @@ void MemoryAtomic::MemoryAtomicTest(hsa_agent_t cpuAgent,
   }
 
   if (refSysdata) {
-    err = hsa_memory_free(refSysdata);
+    err = hsa_amd_memory_pool_free(refSysdata);
     ASSERT_EQ(err, HSA_STATUS_SUCCESS);
   }
   if (oldrefdata) {
-    err = hsa_memory_free(oldrefdata);
+    err = hsa_amd_memory_pool_free(oldrefdata);
     ASSERT_EQ(err, HSA_STATUS_SUCCESS);
   }
   if (oldValues) {
-    err = hsa_memory_free(oldValues);
+    err = hsa_amd_memory_pool_free(oldValues);
+    ASSERT_EQ(err, HSA_STATUS_SUCCESS);
+  }
+  if (expecteddata) {
+    err = hsa_amd_memory_pool_free(expecteddata);
     ASSERT_EQ(err, HSA_STATUS_SUCCESS);
   }
   if (access == HSA_AMD_MEMORY_POOL_ACCESS_NEVER_ALLOWED) {
@@ -507,16 +511,16 @@ void MemoryAtomic::MemoryAtomicTest(hsa_agent_t cpuAgent,
     err = hsa_signal_destroy(copy_signal);
     ASSERT_EQ(err, HSA_STATUS_SUCCESS);
     if (g_gpuRefData) {
-      err = hsa_memory_free(g_gpuRefData);
+      err = hsa_amd_memory_pool_free(g_gpuRefData);
       ASSERT_EQ(err, HSA_STATUS_SUCCESS);
     }
   }
   if (gpuRefData) {
-    err = hsa_memory_free(gpuRefData);
+    err = hsa_amd_memory_pool_free(gpuRefData);
     ASSERT_EQ(err, HSA_STATUS_SUCCESS);
   }
   if (kernArguments) {
-    err = hsa_memory_free(kernArguments);
+    err = hsa_amd_memory_pool_free(kernArguments);
     ASSERT_EQ(err, HSA_STATUS_SUCCESS);
   }
   if (queue) {

--- a/projects/rocr-runtime/rocrtst/suites/functional/svm_memory.cc
+++ b/projects/rocr-runtime/rocrtst/suites/functional/svm_memory.cc
@@ -288,7 +288,7 @@ void SvmMemoryTestBasic::TestCreateDestroy(hsa_agent_t agent, hsa_amd_memory_poo
   }
 
   if (kernArgs) {
-    hsa_memory_free(kernArgs);
+    hsa_amd_memory_pool_free(kernArgs);
   }
 
   if (signal.handle) {

--- a/projects/rocr-runtime/rocrtst/suites/stress/memory_concurrent_tests.cc
+++ b/projects/rocr-runtime/rocrtst/suites/stress/memory_concurrent_tests.cc
@@ -94,7 +94,7 @@ static void CallbackHSAMemoryFreeFunc(void *data) {
   hsa_status_t err;
   cb_t *cb = static_cast<cb_t*>(data);
 
-  err = hsa_memory_free(cb->alloc_pointer);
+  err = hsa_amd_memory_pool_free(cb->alloc_pointer);
   ASSERT_EQ(err, HSA_STATUS_SUCCESS);
 
   return;
@@ -342,7 +342,7 @@ void MemoryConcurrentTest::MemoryConcurrentAllocate(hsa_agent_t agent,
     }
 
     for (uint32_t ii = 0; ii < kNumThreads; ii++) {
-      err = hsa_memory_free(cb[ii].alloc_pointer);
+      err = hsa_amd_memory_pool_free(cb[ii].alloc_pointer);
       ASSERT_EQ(err, HSA_STATUS_SUCCESS);
     }
   }


### PR DESCRIPTION
Replace hsa_memory_free with hsa_amd_memory_pool_free for all buffers allocated via hsa_amd_memory_pool_allocate. Add missing free for expecteddata in MemoryAtomicTest.

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
