### PR TITLE
WSL Workflow: Upload build artifacts to S3

### DIFF
--- a/.github/scripts/install_wsl_from_artifacts.py
+++ b/.github/scripts/install_wsl_from_artifacts.py
@@ -1,0 +1,126 @@
+#!/usr/bin/env python3
+"""
+Install WSL (libhsakmt) build from S3 artifacts.
+
+Downloads and extracts the WSL artifact tarball(s) from a given CI run
+(therock-wsl-artifacts-external bucket, path {run_id}-windows/artifacts/).
+Similar in spirit to TheRock's install_rocm_from_artifacts.py.
+
+Requires: AWS CLI on PATH. For public read, no credentials needed; otherwise
+configure AWS (e.g. same role as upload).
+
+Usage:
+  python install_wsl_from_artifacts.py --run-id RUN_ID [--output-dir DIR] [--s3-bucket BUCKET]
+  python install_wsl_from_artifacts.py --run-id 123456789 --output-dir ./wsl-libhsakmt
+
+Example (after ROCm install from TheRock script):
+  python install_rocm_from_artifacts.py --run-id R --amdgpu-family gfx94X-dcgpu --output-dir therock-build
+  python install_wsl_from_artifacts.py --run-id W --output-dir wsl-libhsakmt
+"""
+
+import argparse
+import shutil
+import subprocess
+import sys
+import tarfile
+from pathlib import Path
+
+
+def log(*args):
+    print(*args)
+    sys.stdout.flush()
+
+
+def run_cmd(cmd: list[str], cwd: Path | None = None) -> None:
+    log(f"++ $ {' '.join(cmd)}")
+    subprocess.run(cmd, check=True, cwd=cwd)
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Download and extract WSL (libhsakmt) artifacts from S3.",
+    )
+    parser.add_argument(
+        "--run-id",
+        required=True,
+        help="GitHub workflow run ID that produced the WSL artifacts.",
+    )
+    parser.add_argument(
+        "--output-dir",
+        type=Path,
+        default=Path("wsl-libhsakmt"),
+        help="Install prefix: libs/headers/bin will go here (default: wsl-libhsakmt).",
+    )
+    parser.add_argument(
+        "--s3-bucket",
+        default="therock-wsl-artifacts-external",
+        help="S3 bucket name (default: therock-wsl-artifacts-external).",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Only print what would be downloaded.",
+    )
+    args = parser.parse_args()
+
+    if not shutil.which("aws"):
+        log("ERROR: AWS CLI not found on PATH.")
+        sys.exit(1)
+
+    platform_suffix = "windows"
+    s3_prefix = f"s3://{args.s3_bucket}/{args.run_id}-{platform_suffix}/artifacts/"
+    # We upload only *.tar.xz; the WSL workflow produces wsl-libhsakmt-build.tar.xz
+    artifact_name = "wsl-libhsakmt-build.tar.xz"
+    s3_uri = f"{s3_prefix}{artifact_name}"
+
+    log(f"Run ID: {args.run_id}")
+    log(f"S3 prefix: {s3_prefix}")
+    log(f"Output dir: {args.output_dir.resolve()}")
+
+    if args.dry_run:
+        log("Dry run: would download", s3_uri, "and extract to", args.output_dir)
+        return
+
+    # Download to a temp dir; archive has top-level "build/" from CI.
+    tmp_dir = args.output_dir.parent / (args.output_dir.name + ".tmp")
+    tmp_dir.mkdir(parents=True, exist_ok=True)
+    try:
+        log("Downloading", s3_uri)
+        run_cmd(
+            [
+                "aws",
+                "s3",
+                "cp",
+                s3_uri,
+                str(tmp_dir / artifact_name),
+                "--region",
+                "us-east-2",
+            ],
+        )
+        archive_path = tmp_dir / artifact_name
+        if not archive_path.is_file():
+            log("ERROR: Download did not produce", archive_path)
+            sys.exit(1)
+
+        log("Extracting (install prefix:", args.output_dir, ")")
+        with tarfile.open(archive_path) as tf:
+            tf.extractall(tmp_dir)
+        archive_path.unlink(missing_ok=True)
+
+        # Archive contains top-level "build/"; use its contents as the install prefix.
+        inner_build = tmp_dir / "build"
+        if not inner_build.is_dir():
+            log("ERROR: Archive has no top-level 'build/' directory.")
+            sys.exit(1)
+        if args.output_dir.exists():
+            shutil.rmtree(args.output_dir)
+        shutil.move(str(inner_build), str(args.output_dir))
+    finally:
+        if tmp_dir.exists():
+            shutil.rmtree(tmp_dir)
+
+    log("Done. WSL libhsakmt installed to", args.output_dir.resolve())
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/scripts/wsl_artifact_upload.py
+++ b/.github/scripts/wsl_artifact_upload.py
@@ -1,0 +1,185 @@
+#!/usr/bin/env python3
+"""
+Standalone WSL artifact upload for the ROCR Runtime WSL workflow.
+
+Uploads staged build artifacts and logs to S3 using the same path shape as
+TheRock's post_build_upload.py. No dependency on TheRock; to be replaced by
+TheRock's post_build_upload.py once those changes are merged.
+
+Requires: --s3-bucket (when uploading), AWS CLI on PATH with credentials
+(e.g. OIDC role therock-wsl-artifacts-external). Bucket used by this workflow:
+therock-wsl-artifacts-external.
+
+Usage:
+  wsl_artifact_upload.py --run-id RUN_ID --artifact-group GROUP
+    [--build-dir DIR] [--upload | --no-upload] [--job-status STATUS]
+"""
+
+import argparse
+import os
+import shutil
+import subprocess
+import sys
+import tarfile
+from pathlib import Path
+
+
+def log(*args):
+    print(*args)
+    sys.stdout.flush()
+
+
+def run_command(cmd: list, cwd: Path | None = None):
+    log(f"++ Exec $ {' '.join(cmd)}")
+    subprocess.run(cmd, check=True, cwd=cwd or Path.cwd())
+
+
+def create_ninja_log_archive(build_dir: Path):
+    """Create logs/ninja_logs.tar.gz from any .ninja_log under build_dir."""
+    log_dir = build_dir / "logs"
+    log_dir.mkdir(parents=True, exist_ok=True)
+    found = list(build_dir.glob("**/.ninja_log"))
+    if not found:
+        log("No .ninja_log files found. Skipping ninja log archive.")
+        return
+    archive_path = log_dir / "ninja_logs.tar.gz"
+    with tarfile.open(archive_path, "w:gz") as tar:
+        for p in found:
+            tar.add(p)
+            log(f"[+] Add: {p}")
+    log(f"[*] Created {archive_path}")
+
+
+def upload_artifacts(build_dir: Path, bucket_uri: str, region: str = "us-east-2"):
+    """Upload artifacts/*.tar.xz to bucket_uri."""
+    artifacts_dir = build_dir / "artifacts"
+    if not artifacts_dir.is_dir():
+        log(f"[INFO] No artifacts dir at {artifacts_dir}. Skipping.")
+        return
+    run_command(
+        [
+            "aws",
+            "s3",
+            "cp",
+            str(artifacts_dir),
+            bucket_uri,
+            "--recursive",
+            "--no-follow-symlinks",
+            "--exclude",
+            "*",
+            "--include",
+            "*.tar.xz*",
+            "--region",
+            region,
+        ],
+    )
+
+
+def upload_logs(
+    artifact_group: str, build_dir: Path, bucket_uri: str, region: str = "us-east-2"
+):
+    """Upload logs/ to bucket_uri/logs/<artifact_group>/."""
+    log_dir = build_dir / "logs"
+    if not log_dir.is_dir():
+        log(f"[INFO] No log dir at {log_dir}. Skipping.")
+        return
+    s3_logs = f"{bucket_uri}/logs/{artifact_group}"
+    run_command(
+        ["aws", "s3", "cp", str(log_dir), s3_logs, "--recursive", "--region", region],
+    )
+
+
+def write_gha_summary(bucket_url: str, artifact_group: str, job_status: str):
+    """Append Build Logs and Artifacts links to GITHUB_STEP_SUMMARY."""
+    summary_file = os.getenv("GITHUB_STEP_SUMMARY")
+    if not summary_file:
+        log("GITHUB_STEP_SUMMARY not set. Skipping job summary.")
+        return
+    # Logs: link to logs subfolder (index.html may not exist until TheRock is used)
+    lines = [f"[Build Logs]({bucket_url}/logs/{artifact_group}/)"]
+    if not job_status or job_status == "success":
+        # Artifacts: link to run prefix (no index page in standalone mode)
+        lines.append(f"[Artifacts]({bucket_url}/)")
+    body = "\n".join(lines) + "\n\n"
+    with open(summary_file, "a") as f:
+        f.write(body)
+    log("Wrote job summary links.")
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Upload WSL build artifacts and logs to S3 (standalone for rocm-systems).",
+    )
+    parser.add_argument("--run-id", required=True, help="GitHub run ID")
+    parser.add_argument(
+        "--artifact-group",
+        required=True,
+        help="Artifact group name (e.g. wsl-libhsakmt)",
+    )
+    parser.add_argument(
+        "--build-dir",
+        type=Path,
+        default=Path(os.getenv("BUILD_DIR", "build")),
+        help="Staging dir with artifacts/ and logs/ (default: BUILD_DIR or 'build')",
+    )
+    parser.add_argument(
+        "--upload",
+        action=argparse.BooleanOptionalAction,
+        default=str(os.getenv("CI", "false")).lower() == "true",
+        help="Perform S3 upload (default: true if CI is set)",
+    )
+    parser.add_argument(
+        "--job-status", default="", help="Job status: success, failure, etc."
+    )
+    parser.add_argument(
+        "--s3-bucket",
+        default="",
+        help="S3 bucket name for uploads (required when --upload).",
+    )
+    args = parser.parse_args()
+
+    if not args.build_dir.is_dir():
+        log(f"Build dir not found: {args.build_dir}. Exiting.")
+        sys.exit(1)
+
+    log("Creating ninja log archive")
+    log("--------------------------")
+    create_ninja_log_archive(args.build_dir)
+
+    if not args.upload:
+        log("Upload disabled. Done.")
+        return
+
+    bucket = (args.s3_bucket or "").strip()
+    if not bucket:
+        log("--s3-bucket is required when uploading. Cannot upload.")
+        sys.exit(1)
+    if not shutil.which("aws"):
+        log("AWS CLI not found on PATH.")
+        sys.exit(1)
+
+    # Same path shape as TheRock: no repo prefix (dedicated bucket), run_id-PLATFORM
+    platform = "windows"
+    path_suffix = f"{args.run_id}-{platform}"
+    bucket_uri = f"s3://{bucket}/{path_suffix}"
+    bucket_url = f"https://{bucket}.s3.amazonaws.com/{path_suffix}"
+    region = "us-east-2"
+
+    log("Upload build artifacts")
+    log("----------------------")
+    if not args.job_status or args.job_status == "success":
+        upload_artifacts(args.build_dir, bucket_uri, region)
+    else:
+        log("Job did not succeed; skipping artifact upload.")
+
+    log("Upload logs")
+    log("----------")
+    upload_logs(args.artifact_group, args.build_dir, bucket_uri, region)
+
+    log("Write job summary")
+    log("-----------------")
+    write_gha_summary(bucket_url, args.artifact_group, args.job_status)
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/workflows/install_from_artifacts_wsl.yml
+++ b/.github/workflows/install_from_artifacts_wsl.yml
@@ -1,0 +1,73 @@
+# Install ROCm and/or WSL artifacts from S3 (workflow_dispatch).
+# Run TheRock's install_rocm_from_artifacts.py and/or our install_wsl_from_artifacts.py.
+name: Install from artifacts (WSL / ROCm)
+
+on:
+  workflow_dispatch:
+    inputs:
+      run_id_rocm:
+        description: "GitHub run ID for ROCm artifacts (leave empty to skip ROCm install)"
+        required: false
+        type: string
+      run_id_wsl:
+        description: "GitHub run ID for WSL libhsakmt artifacts (leave empty to skip WSL install)"
+        required: false
+        type: string
+      amdgpu_family:
+        description: "AMD GPU family for ROCm install (e.g. gfx94X-dcgpu, gfx110X-all)"
+        required: false
+        type: string
+        default: "gfx94X-dcgpu"
+      output_dir_rocm:
+        description: "Output directory for ROCm artifacts"
+        required: false
+        type: string
+        default: "therock-build"
+      output_dir_wsl:
+        description: "Install prefix for WSL libhsakmt (default wsl-libhsakmt)"
+        required: false
+        type: string
+        default: "wsl-libhsakmt"
+
+permissions:
+  contents: read
+
+jobs:
+  install-from-artifacts:
+    name: Install from artifacts
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+
+      - name: Checkout TheRock
+        if: ${{ inputs.run_id_rocm != '' }}
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          repository: "ROCm/TheRock"
+          path: "TheRock"
+
+      - name: Set up Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: "3.12"
+
+      - name: Install AWS CLI
+        run: sudo apt-get update -qq && sudo apt-get install -y -qq awscli
+
+      - name: Install ROCm from artifacts
+        if: ${{ inputs.run_id_rocm != '' }}
+        run: |
+          pip install -r TheRock/requirements.txt
+          python TheRock/build_tools/install_rocm_from_artifacts.py \
+            --run-id "${{ inputs.run_id_rocm }}" \
+            --amdgpu-family "${{ inputs.amdgpu_family }}" \
+            --output-dir "${{ inputs.output_dir_rocm }}" \
+            --flatten
+
+      - name: Install WSL from artifacts
+        if: ${{ inputs.run_id_wsl != '' }}
+        run: |
+          python .github/scripts/install_wsl_from_artifacts.py \
+            --run-id "${{ inputs.run_id_wsl }}" \
+            --output-dir "${{ inputs.output_dir_wsl }}"

--- a/.github/workflows/rocr-runtime-wsl.yml
+++ b/.github/workflows/rocr-runtime-wsl.yml
@@ -26,15 +26,22 @@ jobs:
   rocr-runtime-wsl-test:
     name: ROCR Runtime WSL Test
     runs-on: rocr-runtime-libhsakmt-wsl
+    permissions:
+      contents: read
+      id-token: write
     defaults:
       run:
         shell: powershell
+    env:
+      BUILD_DIR: ${{ github.workspace }}/wsl-build-upload
+      ARTIFACT_GROUP: wsl-libhsakmt
     steps:
       - name: Checkout repository
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           sparse-checkout: |
             projects/rocr-runtime
+            .github/scripts
           sparse-checkout-cone-mode: true
 
       - name: Configure MSVC and Windows SDK
@@ -61,7 +68,7 @@ jobs:
         with:
           distribution: Ubuntu-24.04
           update: true
-          additional-packages: build-essential cmake ninja-build
+          additional-packages: build-essential cmake ninja-build xz-utils awscli python3
 
       - name: Copy repository into WSL
         shell: wsl-bash {0}
@@ -88,16 +95,16 @@ jobs:
         run: |
           set -euo pipefail
           cd ~/rocm-systems/projects/rocr-runtime/libhsakmt
-          
+
           echo "Building libhsakmt in WSL with Windows SDK..."
-          
+
           # Use the detected Windows SDK version from the host
           WIN_SDK_VERSION="${WIN_SDK_VERSION:-10.0.26100.0}"
           export win_sdk="/mnt/c/Program Files (x86)/Windows Kits/10/Include/${WIN_SDK_VERSION}/"
-          
+
           echo "Using Windows SDK version: ${WIN_SDK_VERSION}"
           echo "Windows SDK path: ${win_sdk}"
-          
+
           # Verify the Windows SDK is accessible from WSL
           if [ ! -d "${win_sdk}" ]; then
             echo "ERROR: Windows SDK not found at ${win_sdk}"
@@ -105,11 +112,55 @@ jobs:
             ls -la "/mnt/c/Program Files (x86)/Windows Kits/10/Include/" || echo "SDK directory not accessible"
             exit 1
           fi
-          
+
           # Build the library
           mkdir -p build
           cd build
           cmake .. -G Ninja -DWIN_SDK="${win_sdk}/shared"
           ninja
-          
+
           echo "libhsakmt build completed successfully!"
+
+      - name: Prepare staging directory and copy artifacts from WSL
+        shell: wsl-bash {0}
+        env:
+          GITHUB_WORKSPACE: ${{ github.workspace }}
+        run: |
+          set -euo pipefail
+          WSL_WS=$(wslpath -u "$(echo "$GITHUB_WORKSPACE" | tr '\\' '/')")
+          STAGING="$WSL_WS/wsl-build-upload"
+          mkdir -p "$STAGING/artifacts" "$STAGING/logs" "$STAGING/libhsakmt-build"
+          # Copy ninja log so wsl_artifact_upload can create ninja_logs archive
+          if [ -f ~/rocm-systems/projects/rocr-runtime/libhsakmt/build/.ninja_log ]; then
+            cp ~/rocm-systems/projects/rocr-runtime/libhsakmt/build/.ninja_log "$STAGING/libhsakmt-build/"
+          fi
+          # Package libhsakmt build for artifacts upload (wsl_artifact_upload expects *.tar.xz in artifacts/)
+          tar -C ~/rocm-systems/projects/rocr-runtime/libhsakmt -cJf "$STAGING/artifacts/wsl-libhsakmt-build.tar.xz" build
+          echo "Staging contents:"
+          ls -laR "$STAGING"
+
+      - name: Configure AWS Credentials
+        if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.head.repo.fork }}
+        uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 # v6.0.0
+        with:
+          aws-region: us-east-2
+          # IAM role for WSL artifact upload; must have write access to therock-wsl-artifacts-external
+          role-to-assume: arn:aws:iam::692859939525:role/therock-wsl-artifacts-external
+          special-characters-workaround: true
+
+      - name: Post Build Upload
+        if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.head.repo.fork }}
+        shell: wsl-bash {0}
+        env:
+          GITHUB_WORKSPACE: ${{ github.workspace }}
+        run: |
+          set -euo pipefail
+          GITHUB_WORKSPACE_WSL=$(wslpath -u "$(echo "$GITHUB_WORKSPACE" | tr '\\' '/')")
+          BUILD_DIR="$GITHUB_WORKSPACE_WSL/wsl-build-upload"
+          python3 "$GITHUB_WORKSPACE_WSL/.github/scripts/wsl_artifact_upload.py" \
+            --run-id ${{ github.run_id }} \
+            --artifact-group ${{ env.ARTIFACT_GROUP }} \
+            --build-dir "$BUILD_DIR" \
+            --s3-bucket therock-wsl-artifacts-external \
+            --upload \
+            --job-status ${{ job.status }}

--- a/.github/workflows/rocr-runtime-wsl.yml
+++ b/.github/workflows/rocr-runtime-wsl.yml
@@ -68,7 +68,7 @@ jobs:
         with:
           distribution: Ubuntu-24.04
           update: true
-          additional-packages: build-essential cmake ninja-build xz-utils awscli python3
+          additional-packages: build-essential cmake ninja-build xz-utils python3 python3-pip
 
       - name: Copy repository into WSL
         shell: wsl-bash {0}
@@ -155,6 +155,8 @@ jobs:
           GITHUB_WORKSPACE: ${{ github.workspace }}
         run: |
           set -euo pipefail
+          python3 -m pip install --user -q awscli
+          export PATH="$HOME/.local/bin:$PATH"
           GITHUB_WORKSPACE_WSL=$(wslpath -u "$(echo "$GITHUB_WORKSPACE" | tr '\\' '/')")
           BUILD_DIR="$GITHUB_WORKSPACE_WSL/wsl-build-upload"
           python3 "$GITHUB_WORKSPACE_WSL/.github/scripts/wsl_artifact_upload.py" \


### PR DESCRIPTION
- Requires creation of WSL bucket and IAM role first.
- As the bucket-related scripts in TheRock are being refactored, temporary solution is to strip out needed functionality into rocm-systems through a new script.