### PR TITLE
RCCL: export rocprofiler-register dependency for static consumers

### DIFF
--- a/projects/rccl/CMakeLists.txt
+++ b/projects/rccl/CMakeLists.txt
@@ -623,10 +623,15 @@ file(COPY tools/msccl-unit-test-algorithms DESTINATION ${PROJECT_BINARY_DIR})
 rocm_install(DIRECTORY ${PROJECT_BINARY_DIR}/msccl-algorithms DESTINATION ${CMAKE_INSTALL_DATADIR}/rccl)
 rocm_install(DIRECTORY ${PROJECT_BINARY_DIR}/msccl-unit-test-algorithms DESTINATION ${CMAKE_INSTALL_DATADIR}/rccl)
 
+set(RCCL_EXPORT_DEPENDENCIES hip)
+if(RCCL_ROCPROFILER_REGISTER)
+  list(APPEND RCCL_EXPORT_DEPENDENCIES rocprofiler-register)
+endif()
+
 rocm_export_targets(
   NAMESPACE roc::
   TARGETS   rccl
-  DEPENDS   hip)
+  DEPENDS   ${RCCL_EXPORT_DEPENDENCIES})
 
 ## Set package dependencies
 if(BUILD_ADDRESS_SANITIZER)


### PR DESCRIPTION
### Summary

- Resolves static consumer import failure in `release_local_gpu_only_static` by exporting optional `rocprofiler-register` package dependency when `RCCL_ROCPROFILER_REGISTER=ON`.
- Updates `rocm_export_targets(...)` to use a dependency list (`hip` + conditional `rocprofiler-register`) instead of hardcoding only `hip`.
- Keeps runtime/build behavior unchanged for non-rocprofiler-register configurations.
- This PR is a prerequisite fix for the CMake sync stack.

### Why

Latest functional compare runs show `release_local_gpu_only_static` consumer-smoke failing in due to package export metadata mismatch: `rccl-targets.cmake` references `rocprofiler-register::rocprofiler-register`, but `rccl-config.cmake` did not ensure that dependency package target is loaded before importing RCCL targets.

This patch makes exported dependency metadata consistent so downstream static consumers can reliably use `find_package(rccl)`.

### Test plan

- Reproduce lane failure context from functional compare run: `release_local_gpu_only_static`.
- Validate static consumer import path via `find_package(rccl)` using exported package config/targets.
- Run matrix compare submit workflow:
- Confirm static consumer-smoke lane no longer fails due to missing `rocprofiler-register` target import.
