### PR TITLE
RCCL: add NCCL CMake alias shim layer

### DIFF
--- a/projects/rccl/CMakeLists.txt
+++ b/projects/rccl/CMakeLists.txt
@@ -40,6 +40,7 @@ else()
 endif()
 
 add_compile_definitions(
+  NCCL_USE_CMAKE
   NCCL_MAJOR=${NCCL_MAJOR}
   NCCL_MINOR=${NCCL_MINOR}
   NCCL_PATCH=${NCCL_PATCH}
@@ -56,10 +57,35 @@ endif()
 # RCCL project
 #==================================================================================================
 project(rccl CXX)
+set(ENV{NCCL_USE_CMAKE} "1")
 
 # Build options
 #==================================================================================================
-option(BUILD_ADDRESS_SANITIZER                 "Enable address sanitizer"                      OFF)
+# NCCL compatibility options (aliases/shims). Defaults preserve existing RCCL behavior.
+option(DEBUG                                   "Enable debug build compatibility flag"         OFF)
+option(ASAN                                    "Enable address sanitizer compatibility flag"   OFF)
+option(WERROR                                  "Treat warnings as errors compatibility flag"   OFF)
+option(PROFAPI                                 "Enable profiling API compatibility flag"       OFF)
+option(NVTX                                    "Enable NVTX compatibility flag"                ON)
+option(BUILD_DEBIAN_PACKAGE                    "Build Debian package compatibility flag"       OFF)
+option(BUILD_REDHAT_PACKAGE                    "Build Redhat package compatibility flag"       OFF)
+option(BUILD_TXZ_PACKAGE                       "Build TXZ package compatibility flag"          OFF)
+option(BUILD_CONDA_PACKAGE                     "Build Conda package compatibility flag"        OFF)
+option(BUILD_SRCTXZ_PACKAGE                    "Build source TXZ package compatibility flag"   OFF)
+option(BUILD_DOC_PACKAGE                       "Build documentation package compatibility flag" OFF)
+option(BUILD_PACKAGES                          "Build all packages compatibility flag"          OFF)
+
+set(_rccl_default_build_address_sanitizer OFF)
+if(ASAN)
+  set(_rccl_default_build_address_sanitizer ON)
+endif()
+
+set(_rccl_default_roctx ON)
+if(NOT NVTX)
+  set(_rccl_default_roctx OFF)
+endif()
+
+option(BUILD_ADDRESS_SANITIZER                 "Enable address sanitizer"                      ${_rccl_default_build_address_sanitizer})
 option(BUILD_BFD                               "Enable custom backtrace (if bfd.h exists)"     OFF)
 option(BUILD_LOCAL_GPU_TARGET_ONLY             "Build only for GPUs detected on this machine"  OFF)
 option(BUILD_SHARED_LIBS                       "Build as shared library"                       ON)
@@ -79,7 +105,7 @@ option(ENABLE_IFC                              "Enable indirect function call"  
 option(GENERATE_SYM_KERNELS                    "Generate symmetric memory kernels"             OFF)
 option(INSTALL_DEPENDENCIES                    "Force install dependencies"                    OFF)
 option(REPORT_KERNEL_RESOURCE_USE              "Append -Rpass-analysis=kernel to CXX flags"    OFF)
-option(ROCTX                                   "Enable ROCTX"                                  ON)
+option(ROCTX                                   "Enable ROCTX"                                  ${_rccl_default_roctx})
 option(PROFILE                                 "Enable profiling"                              OFF)
 option(TIMETRACE                               "Enable time-trace during compilation"          OFF)
 option(TRACE                                   "Enable additional tracing"                     OFF)
@@ -87,6 +113,28 @@ option(FAULT_INJECTION                         "Enable fault injection"         
 option(QUIET_WARNINGS                          "Supress compiler warnings"                     OFF)
 option(ENABLE_ROCSHMEM                         "Enable rocSHMEM support in RCCL"               OFF)
 option(ENABLE_COMPRESS                         "Enable GPU code compression"                   ON)
+
+# Translate NCCL-compatible aliases into existing RCCL build knobs.
+if(DEBUG AND NOT CMAKE_BUILD_TYPE)
+  set(CMAKE_BUILD_TYPE Debug CACHE STRING "Build type" FORCE)
+endif()
+
+if(BUILD_PACKAGES)
+  set(BUILD_DEBIAN_PACKAGE ON)
+  set(BUILD_REDHAT_PACKAGE ON)
+  set(BUILD_TXZ_PACKAGE ON)
+  set(BUILD_CONDA_PACKAGE ON)
+  set(BUILD_SRCTXZ_PACKAGE ON)
+  set(BUILD_DOC_PACKAGE ON)
+endif()
+
+if(WERROR)
+  add_compile_options(-Werror)
+endif()
+
+if(PROFAPI)
+  add_compile_definitions(PROFAPI)
+endif()
 
 # Default GPU architectures to build
 #==================================================================================================
@@ -707,3 +755,14 @@ rocm_create_package(
   DESCRIPTION "ROCm Communication Collectives Library"
   MAINTAINER  "RCCL Maintainer <rccl-maintainer@amd.com>"
   LDCONFIG)
+
+# NCCL-like package target wrappers that forward to RCCL's package target.
+if(TARGET package)
+  add_custom_target(debian_build DEPENDS package)
+  add_custom_target(redhat_build DEPENDS package)
+  add_custom_target(txz_build DEPENDS package)
+  add_custom_target(conda_build DEPENDS package)
+  add_custom_target(srctxz_build DEPENDS package)
+  add_custom_target(doc_build DEPENDS package)
+  add_custom_target(build_packages DEPENDS package)
+endif()


### PR DESCRIPTION
### Summary

- Adds NCCL-compatible CMake option aliases/shims in RCCL root CMake for sync ergonomics.
- Preserves RCCL-native option behavior while accepting NCCL-facing knobs.
- Keeps install/package flow unchanged; this PR is focused on alias acceptance only.
- Prerequisite: #3667 (static export dependency fix).

### Why

NCCL sync branches now carry CMake-facing option names that diverge from RCCL naming. This alias layer reduces merge friction and keeps RCCL behavior stable while improving compatibility with incoming NCCL CMake deltas.

### Test plan

- Configure/build RCCL with default settings and NCCL-style alias options enabled.
- Verify no install/package behavior drift for standard flows.
- Run matrix test jobs:
  
  ```bash
	0 release_local_gpu_only|Release|0|-DBUILD_LOCAL_GPU_TARGET_ONLY=ON
	1 release_all_gpu_targets|Release|0|-DBUILD_LOCAL_GPU_TARGET_ONLY=OFF
	2 debug_local_gpu_only|Debug|0|-DBUILD_LOCAL_GPU_TARGET_ONLY=ON
	3 release_local_gpu_only_pkg|Release|1|-DBUILD_LOCAL_GPU_TARGET_ONLY=ON
	4 release_local_gpu_only_tests_pkg|Release|1|-DBUILD_LOCAL_GPU_TARGET_ONLY=ON -DBUILD_TESTS=ON
	5 release_local_gpu_only_static|Release|0|-DBUILD_LOCAL_GPU_TARGET_ONLY=ON ${CMAKE_STATIC_ARGS}
	6 release_local_gpu_only_tests_on|Release|0|-DBUILD_LOCAL_GPU_TARGET_ONLY=ON -DBUILD_TESTS=ON
	7 release_local_gpu_only_features_on|Release|0|-DBUILD_LOCAL_GPU_TARGET_ONLY=ON ${CMAKE_FEATURES_ON_ARGS}
	8 install_local_gpu_only|Release|0|-DBUILD_LOCAL_GPU_TARGET_ONLY=ON -DINSTALL_TARGETS=ON
	9 install_local_gpu_only_tests|Release|0|-DBUILD_LOCAL_GPU_TARGET_ONLY=ON -DBUILD_TESTS=ON -DINSTALL_TARGETS=ON
  ```
  
  Observed lanes in captured runs:

	- `release_local_gpu_only`
	- `release_all_gpu_targets`
	- `debug_local_gpu_only`
	- `release_local_gpu_only_pkg`
	- `release_local_gpu_only_tests_pkg`
	- `release_local_gpu_only_static`
	- `release_local_gpu_only_tests_on`
	- `release_local_gpu_only_features_on`
	- `./install.sh -l`
	- `./install.sh -t`
  
- Confirm parity checks remain green aside from known baseline-equivalent noise.