### PR TITLE
RCCL: normalize src CMake path references for subdirectory builds

### DIFF
--- a/projects/rccl/CMakeLists.txt
+++ b/projects/rccl/CMakeLists.txt
@@ -577,44 +577,6 @@ configure_file(src/nccl.h.in ${PROJECT_BINARY_DIR}/include/nccl.h)      # Used b
 #==================================================================================================
 add_subdirectory(src)
 
-## Setup librccl.so version
-rocm_set_soversion(rccl "1.0")
-
-# Used by the static-library link path below (expects a list).
-set(_rccl_cxxflags "${CMAKE_CXX_FLAGS} ${CMAKE_CXX_FLAGS_${CMAKE_BUILD_TYPE}}")
-separate_arguments(CXXFLAGS NATIVE_COMMAND "${_rccl_cxxflags}")
-
-if(NOT BUILD_SHARED_LIBS)
-  # To create a static lib with `-fgpu-rdc`, you need `--emit-static-lib` and `--hip-link`.
-  # You also need to invoke amdclang++ again to trigger GPU code generation.
-  set(static_link_flags
-    ${CXXFLAGS}
-    --hip-link
-    -fgpu-rdc
-    --emit-static-lib
-  )
-
-  # Find all the libraries we need to link at link time to include them in the clang link
-  # command line.
-  get_target_property(rccl_libs rccl LINK_LIBRARIES)
-  foreach(target ${rccl_libs})
-    if(TARGET ${target})
-      get_target_property(location ${target} LOCATION)
-      if(location)
-        LIST(APPEND static_link_flags -l${location})
-      endif()
-    endif()
-  endforeach()
-
-  foreach(target ${GPU_TARGETS})
-    list(APPEND static_link_flags --offload-arch=${target})
-  endforeach()
-  list(JOIN static_link_flags " " flags_str)
-
-  # Invoking amdclang++ this way will produce a static archive, so just override ARCHIVE_CREATE.
-  set(CMAKE_CXX_ARCHIVE_CREATE "<CMAKE_CXX_COMPILER> ${flags_str} -o <TARGET> <OBJECTS>")
-endif()
-
 # Install settings
 #==================================================================================================
 ## Specify install targets
@@ -678,8 +640,8 @@ License: See LICENSE.txt for license information\n")
   Optimized primitives for collective multi-GPU communication")
 endif()
 
-## Building RCCL RAS
-include(cmake/rcclRAS.cmake)
+## Install RCCL RAS client (built in src/CMakeLists.txt)
+rocm_install(TARGETS rcclras)
 
 if(BUILD_EXT_EXAMPLES AND NOT BUILD_TESTS)
   message(STATUS "BUILD_EXT_EXAMPLES is ON but BUILD_TESTS is OFF; skipping ext example builds.")

--- a/projects/rccl/src/CMakeLists.txt
+++ b/projects/rccl/src/CMakeLists.txt
@@ -4,6 +4,9 @@
 ## NOTE: This file intentionally keeps RCCL's current behavior (hipify flow,
 ## generated sources, options/flags, etc.). It's a refactor-only move.
 
+# Keep RCCL source-root references explicit when included as a subdirectory.
+set(RCCL_SOURCE_DIR "${PROJECT_SOURCE_DIR}")
+
 # Collect list of all source files
 #==================================================================================================
 # E.g: find src -type f \( -name "*.cc" -o -name "*.h" -o -name "*.hpp" \) | sort
@@ -350,8 +353,8 @@ set(HIPIFY_DIR "${PROJECT_BINARY_DIR}/hipify")
 ## Loop over each source file to hipify
 foreach(SRC_FILE ${SRC_FILES})
   # Check that file exists
-  if (NOT EXISTS ${PROJECT_SOURCE_DIR}/${SRC_FILE})
-    message(FATAL_ERROR "Unable to find file listed in CMakeLists.txt: ${PROJECT_SOURCE_DIR}/${SRC_FILE}")
+  if (NOT EXISTS ${RCCL_SOURCE_DIR}/${SRC_FILE})
+    message(FATAL_ERROR "Unable to find file listed in CMakeLists.txt: ${RCCL_SOURCE_DIR}/${SRC_FILE}")
   endif()
 
   # Establish hipified copy of the source file
@@ -371,19 +374,19 @@ foreach(SRC_FILE ${SRC_FILES})
     add_custom_command(
       OUTPUT ${HIP_FILE}
       COMMAND mkdir -p ${HIP_FILE_DIR}
-              && ${hipify-perl_executable} -quiet-warnings ${PROJECT_SOURCE_DIR}/${SRC_FILE} -o ${HIP_FILE}
-              && ${CMAKE_COMMAND} -E env bash ${PROJECT_SOURCE_DIR}/cmake/scripts/add_unroll.sh ${HIP_FILE}
-              && ${CMAKE_COMMAND} -E env bash ${PROJECT_SOURCE_DIR}/cmake/scripts/add_faults.sh ${HIP_FILE}
-      MAIN_DEPENDENCY ${PROJECT_SOURCE_DIR}/${SRC_FILE}
+              && ${hipify-perl_executable} -quiet-warnings ${RCCL_SOURCE_DIR}/${SRC_FILE} -o ${HIP_FILE}
+              && ${CMAKE_COMMAND} -E env bash ${RCCL_SOURCE_DIR}/cmake/scripts/add_unroll.sh ${HIP_FILE}
+              && ${CMAKE_COMMAND} -E env bash ${RCCL_SOURCE_DIR}/cmake/scripts/add_faults.sh ${HIP_FILE}
+      MAIN_DEPENDENCY ${RCCL_SOURCE_DIR}/${SRC_FILE}
       COMMENT "Hipifying ${SRC_FILE} -> ${HIP_FILE}"
     )
   else()
     add_custom_command(
       OUTPUT ${HIP_FILE}
       COMMAND mkdir -p ${HIP_FILE_DIR}
-              && ${hipify-perl_executable} -quiet-warnings ${PROJECT_SOURCE_DIR}/${SRC_FILE} -o ${HIP_FILE}
-              && ${CMAKE_COMMAND} -E env bash ${PROJECT_SOURCE_DIR}/cmake/scripts/add_unroll.sh ${HIP_FILE}
-      MAIN_DEPENDENCY ${PROJECT_SOURCE_DIR}/${SRC_FILE}
+              && ${hipify-perl_executable} -quiet-warnings ${RCCL_SOURCE_DIR}/${SRC_FILE} -o ${HIP_FILE}
+              && ${CMAKE_COMMAND} -E env bash ${RCCL_SOURCE_DIR}/cmake/scripts/add_unroll.sh ${HIP_FILE}
+      MAIN_DEPENDENCY ${RCCL_SOURCE_DIR}/${SRC_FILE}
       COMMENT "Hipifying ${SRC_FILE} -> ${HIP_FILE}"
     )
   endif()
@@ -414,27 +417,27 @@ endif()
 
 # Execute the python script to generate required collective functions
 execute_process(
-    COMMAND ${Python3_EXECUTABLE} ${PROJECT_SOURCE_DIR}/src/device/generate.py ${GEN_DIR} ${IFC_ENABLED} ${COLLTRACE} ${ENABLE_MSCCL_KERNEL} ${BUILD_LOCAL_GPU_TARGET_ONLY} ${ONLY_FUNCS}
-    WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
+    COMMAND ${Python3_EXECUTABLE} ${RCCL_SOURCE_DIR}/src/device/generate.py ${GEN_DIR} ${IFC_ENABLED} ${COLLTRACE} ${ENABLE_MSCCL_KERNEL} ${BUILD_LOCAL_GPU_TARGET_ONLY} ${ONLY_FUNCS}
+    WORKING_DIRECTORY ${RCCL_SOURCE_DIR}
     RESULT_VARIABLE gen_py_result
     ERROR_VARIABLE gen_py_error
 )
 if (gen_py_result)
   message(SEND_ERROR "Error: ${gen_py_error}")
-  message(FATAL_ERROR "${PROJECT_SOURCE_DIR}/src/device/generate.py failed")
+  message(FATAL_ERROR "${RCCL_SOURCE_DIR}/src/device/generate.py failed")
 endif()
 
 if (GENERATE_SYM_KERNELS)
   # Execute the python script to generate required symmetric memory kernels
   execute_process(
-    COMMAND ${Python3_EXECUTABLE} ${PROJECT_SOURCE_DIR}/src/device/symmetric/generate.py ${GEN_SYM_DIR}
-    WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
+    COMMAND ${Python3_EXECUTABLE} ${RCCL_SOURCE_DIR}/src/device/symmetric/generate.py ${GEN_SYM_DIR}
+    WORKING_DIRECTORY ${RCCL_SOURCE_DIR}
     RESULT_VARIABLE gen_sym_py_result
     ERROR_VARIABLE gen_sym_py_error
   )
   if (gen_sym_py_result)
     message(SEND_ERROR "Error: ${gen_sym_py_error}")
-    message(FATAL_ERROR "${PROJECT_SOURCE_DIR}/src/device/symmetric/generate.py failed")
+    message(FATAL_ERROR "${RCCL_SOURCE_DIR}/src/device/symmetric/generate.py failed")
   endif()
 endif()
 
@@ -454,7 +457,7 @@ file(WRITE ${PROJECT_BINARY_DIR}/git_version.cpp "")
 # Add a custom target that always runs at build time to update git version
 add_custom_target(update_git_version
   ALL
-  COMMAND ${CMAKE_COMMAND} -DRCCL_SOURCE_DIR=${PROJECT_SOURCE_DIR} -DRCCL_BINARY_DIR=${PROJECT_BINARY_DIR} -P ${PROJECT_SOURCE_DIR}/cmake/scripts/git_version.cmake
+  COMMAND ${CMAKE_COMMAND} -DRCCL_SOURCE_DIR=${RCCL_SOURCE_DIR} -DRCCL_BINARY_DIR=${PROJECT_BINARY_DIR} -P ${RCCL_SOURCE_DIR}/cmake/scripts/git_version.cmake
   BYPRODUCTS ${PROJECT_BINARY_DIR}/git_version.cpp
   COMMENT "Updating git version information"
   VERBATIM

--- a/projects/rccl/src/CMakeLists.txt
+++ b/projects/rccl/src/CMakeLists.txt
@@ -929,3 +929,61 @@ endif()
 
 ## Track linking time
 set_property(TARGET rccl PROPERTY RULE_LAUNCH_LINK "${CMAKE_COMMAND} -E time")
+
+## Setup librccl.so version
+rocm_set_soversion(rccl "1.0")
+
+# Used by the static-library link path below (expects a list).
+set(_rccl_cxxflags "${CMAKE_CXX_FLAGS} ${CMAKE_CXX_FLAGS_${CMAKE_BUILD_TYPE}}")
+separate_arguments(CXXFLAGS NATIVE_COMMAND "${_rccl_cxxflags}")
+
+if(NOT BUILD_SHARED_LIBS)
+  # To create a static lib with `-fgpu-rdc`, you need `--emit-static-lib` and `--hip-link`.
+  # You also need to invoke amdclang++ again to trigger GPU code generation.
+  set(static_link_flags
+    ${CXXFLAGS}
+    --hip-link
+    -fgpu-rdc
+    --emit-static-lib
+  )
+
+  # Find all the libraries we need to link at link time to include them in the clang link
+  # command line.
+  get_target_property(rccl_libs rccl LINK_LIBRARIES)
+  foreach(target ${rccl_libs})
+    if(TARGET ${target})
+      get_target_property(location ${target} LOCATION)
+      if(location)
+        list(APPEND static_link_flags -l${location})
+      endif()
+    endif()
+  endforeach()
+
+  foreach(target ${GPU_TARGETS})
+    list(APPEND static_link_flags --offload-arch=${target})
+  endforeach()
+  list(JOIN static_link_flags " " flags_str)
+
+  # Invoking amdclang++ this way will produce a static archive, so just override ARCHIVE_CREATE.
+  set(CMAKE_CXX_ARCHIVE_CREATE "<CMAKE_CXX_COMPILER> ${flags_str} -o <TARGET> <OBJECTS>")
+endif()
+
+# Build RCCL RAS client executable
+#==================================================================================================
+message("Building rccl RAS client executable")
+
+add_executable(rcclras "${RCCL_SOURCE_DIR}/src/ras/client.cc")
+
+target_include_directories(rcclras PRIVATE ${PROJECT_BINARY_DIR}/include)
+target_include_directories(rcclras PRIVATE ${RCCL_SOURCE_DIR}/src)
+target_include_directories(rcclras PRIVATE ${RCCL_SOURCE_DIR}/src/include)
+
+target_link_libraries(rcclras PRIVATE hip::host)
+target_link_libraries(rcclras PRIVATE dl)
+
+if(BUILD_SHARED_LIBS)
+  target_link_libraries(rcclras PRIVATE rccl hip::device)
+else()
+  add_dependencies(rcclras rccl)
+  target_link_libraries(rcclras PRIVATE dl rt -lrccl -L${PROJECT_BINARY_DIR} -lamdhip64 -L${ROCM_PATH}/lib)
+endif()


### PR DESCRIPTION
### Summary

- Normalizes `src/CMakeLists.txt` path references to consistently use `RCCL_SOURCE_DIR` for source/script/generator lookups.
- Keeps generated `net_ib_rocm.cc` staging behavior unchanged.
- No intended build/packaging behavior change; this is a mechanical path-consistency refactor.
- Stack order:
  - Prerequisite fix: #3667
  - Stack base: #3668
  - Direct parent: #3670

### Why

When RCCL is included as a subproject, mixed path conventions increase fragility and merge churn. Standardizing path roots in `src/CMakeLists.txt` reduces conflict risk and preserves behavior.

### Regression tests performed

Matrix coverage (same parity matrix used across this stack):

- `0 release_local_gpu_only|Release|0|-DBUILD_LOCAL_GPU_TARGET_ONLY=ON`
- `1 release_all_gpu_targets|Release|0|-DBUILD_LOCAL_GPU_TARGET_ONLY=OFF`
- `2 debug_local_gpu_only|Debug|0|-DBUILD_LOCAL_GPU_TARGET_ONLY=ON`
- `3 release_local_gpu_only_pkg|Release|1|-DBUILD_LOCAL_GPU_TARGET_ONLY=ON`
- `4 release_local_gpu_only_tests_pkg|Release|1|-DBUILD_LOCAL_GPU_TARGET_ONLY=ON -DBUILD_TESTS=ON`
- `5 release_local_gpu_only_static|Release|0|-DBUILD_LOCAL_GPU_TARGET_ONLY=ON ${CMAKE_STATIC_ARGS}`
- `6 release_local_gpu_only_tests_on|Release|0|-DBUILD_LOCAL_GPU_TARGET_ONLY=ON -DBUILD_TESTS=ON`
- `7 release_local_gpu_only_features_on|Release|0|-DBUILD_LOCAL_GPU_TARGET_ONLY=ON ${CMAKE_FEATURES_ON_ARGS}`
- `8 install_local_gpu_only|Release|0|-DBUILD_LOCAL_GPU_TARGET_ONLY=ON -DINSTALL_TARGETS=ON`
- `9 install_local_gpu_only_tests|Release|0|-DBUILD_LOCAL_GPU_TARGET_ONLY=ON -DBUILD_TESTS=ON -DINSTALL_TARGETS=ON`

### Test plan

Validation was executed with an internal out-of-tree automation harness (not part of this repo) that runs baseline-vs-candidate matrix builds and functional/conformance compares.

For reviewer context:
- Harness submits matrix build + compare jobs and reports per-lane parity.
- Relevant run artifacts / job IDs are attached in PR comments.
- In-repo smoke checks remain:
  - `./install.sh`
  - `./install.sh --debug`
  - `./install.sh --static`
  - `./install.sh -p`