### PR TITLE
RCCL: enforce root/src CMake ownership boundary for rccl targets

### DIFF
--- a/projects/rccl/CMakeLists.txt
+++ b/projects/rccl/CMakeLists.txt
@@ -577,44 +577,6 @@ configure_file(src/nccl.h.in ${PROJECT_BINARY_DIR}/include/nccl.h)      # Used b
 #==================================================================================================
 add_subdirectory(src)
 
-## Setup librccl.so version
-rocm_set_soversion(rccl "1.0")
-
-# Used by the static-library link path below (expects a list).
-set(_rccl_cxxflags "${CMAKE_CXX_FLAGS} ${CMAKE_CXX_FLAGS_${CMAKE_BUILD_TYPE}}")
-separate_arguments(CXXFLAGS NATIVE_COMMAND "${_rccl_cxxflags}")
-
-if(NOT BUILD_SHARED_LIBS)
-  # To create a static lib with `-fgpu-rdc`, you need `--emit-static-lib` and `--hip-link`.
-  # You also need to invoke amdclang++ again to trigger GPU code generation.
-  set(static_link_flags
-    ${CXXFLAGS}
-    --hip-link
-    -fgpu-rdc
-    --emit-static-lib
-  )
-
-  # Find all the libraries we need to link at link time to include them in the clang link
-  # command line.
-  get_target_property(rccl_libs rccl LINK_LIBRARIES)
-  foreach(target ${rccl_libs})
-    if(TARGET ${target})
-      get_target_property(location ${target} LOCATION)
-      if(location)
-        LIST(APPEND static_link_flags -l${location})
-      endif()
-    endif()
-  endforeach()
-
-  foreach(target ${GPU_TARGETS})
-    list(APPEND static_link_flags --offload-arch=${target})
-  endforeach()
-  list(JOIN static_link_flags " " flags_str)
-
-  # Invoking amdclang++ this way will produce a static archive, so just override ARCHIVE_CREATE.
-  set(CMAKE_CXX_ARCHIVE_CREATE "<CMAKE_CXX_COMPILER> ${flags_str} -o <TARGET> <OBJECTS>")
-endif()
-
 # Install settings
 #==================================================================================================
 ## Specify install targets
@@ -678,8 +640,8 @@ License: See LICENSE.txt for license information\n")
   Optimized primitives for collective multi-GPU communication")
 endif()
 
-## Building RCCL RAS
-include(cmake/rcclRAS.cmake)
+## Install RCCL RAS client (built in src/CMakeLists.txt)
+rocm_install(TARGETS rcclras)
 
 if(BUILD_EXT_EXAMPLES AND NOT BUILD_TESTS)
   message(STATUS "BUILD_EXT_EXAMPLES is ON but BUILD_TESTS is OFF; skipping ext example builds.")

--- a/projects/rccl/src/CMakeLists.txt
+++ b/projects/rccl/src/CMakeLists.txt
@@ -929,3 +929,61 @@ endif()
 
 ## Track linking time
 set_property(TARGET rccl PROPERTY RULE_LAUNCH_LINK "${CMAKE_COMMAND} -E time")
+
+## Setup librccl.so version
+rocm_set_soversion(rccl "1.0")
+
+# Used by the static-library link path below (expects a list).
+set(_rccl_cxxflags "${CMAKE_CXX_FLAGS} ${CMAKE_CXX_FLAGS_${CMAKE_BUILD_TYPE}}")
+separate_arguments(CXXFLAGS NATIVE_COMMAND "${_rccl_cxxflags}")
+
+if(NOT BUILD_SHARED_LIBS)
+  # To create a static lib with `-fgpu-rdc`, you need `--emit-static-lib` and `--hip-link`.
+  # You also need to invoke amdclang++ again to trigger GPU code generation.
+  set(static_link_flags
+    ${CXXFLAGS}
+    --hip-link
+    -fgpu-rdc
+    --emit-static-lib
+  )
+
+  # Find all the libraries we need to link at link time to include them in the clang link
+  # command line.
+  get_target_property(rccl_libs rccl LINK_LIBRARIES)
+  foreach(target ${rccl_libs})
+    if(TARGET ${target})
+      get_target_property(location ${target} LOCATION)
+      if(location)
+        list(APPEND static_link_flags -l${location})
+      endif()
+    endif()
+  endforeach()
+
+  foreach(target ${GPU_TARGETS})
+    list(APPEND static_link_flags --offload-arch=${target})
+  endforeach()
+  list(JOIN static_link_flags " " flags_str)
+
+  # Invoking amdclang++ this way will produce a static archive, so just override ARCHIVE_CREATE.
+  set(CMAKE_CXX_ARCHIVE_CREATE "<CMAKE_CXX_COMPILER> ${flags_str} -o <TARGET> <OBJECTS>")
+endif()
+
+# Build RCCL RAS client executable
+#==================================================================================================
+message("Building rccl RAS client executable")
+
+add_executable(rcclras "${RCCL_SOURCE_DIR}/src/ras/client.cc")
+
+target_include_directories(rcclras PRIVATE ${PROJECT_BINARY_DIR}/include)
+target_include_directories(rcclras PRIVATE ${RCCL_SOURCE_DIR}/src)
+target_include_directories(rcclras PRIVATE ${RCCL_SOURCE_DIR}/src/include)
+
+target_link_libraries(rcclras PRIVATE hip::host)
+target_link_libraries(rcclras PRIVATE dl)
+
+if(BUILD_SHARED_LIBS)
+  target_link_libraries(rcclras PRIVATE rccl hip::device)
+else()
+  add_dependencies(rcclras rccl)
+  target_link_libraries(rcclras PRIVATE dl rt -lrccl -L${PROJECT_BINARY_DIR} -lamdhip64 -L${ROCM_PATH}/lib)
+endif()


### PR DESCRIPTION
### Summary

- Finalizes root/src CMake ownership boundaries:
  - root `CMakeLists.txt` keeps orchestration/install/package flow
  - `src/CMakeLists.txt` owns `rccl` target-construction details
- Moves `rccl` target-owned pieces into `src`:
  - `rocm_set_soversion(rccl "1.0")`
  - static archive link path (`CMAKE_CXX_ARCHIVE_CREATE` flow)
  - `rcclras` target definition and linking
- Root now installs `rcclras` target produced by `src`.
- No intended packaging/output behavior change; this is ownership alignment for mergeability.

### Why

Root/src overlap in rccl target ownership is a recurring merge-conflict hotspot during NCCL syncs. Consolidating target ownership in `src` while keeping root as orchestration/package owner reduces conflict surface and makes review/CI failures more localized.

### Stack dependencies

- Prerequisite fix: #3667
- Stack base: #3668
- Direct parent: #3670
- Direct parent for this PR: #3671

### Regression tests performed

Matrix coverage (same parity matrix used across this stack):

- `0 release_local_gpu_only|Release|0|-DBUILD_LOCAL_GPU_TARGET_ONLY=ON`
- `1 release_all_gpu_targets|Release|0|-DBUILD_LOCAL_GPU_TARGET_ONLY=OFF`
- `2 debug_local_gpu_only|Debug|0|-DBUILD_LOCAL_GPU_TARGET_ONLY=ON`
- `3 release_local_gpu_only_pkg|Release|1|-DBUILD_LOCAL_GPU_TARGET_ONLY=ON`
- `4 release_local_gpu_only_tests_pkg|Release|1|-DBUILD_LOCAL_GPU_TARGET_ONLY=ON -DBUILD_TESTS=ON`
- `5 release_local_gpu_only_static|Release|0|-DBUILD_LOCAL_GPU_TARGET_ONLY=ON ${CMAKE_STATIC_ARGS}`
- `6 release_local_gpu_only_tests_on|Release|0|-DBUILD_LOCAL_GPU_TARGET_ONLY=ON -DBUILD_TESTS=ON`
- `7 release_local_gpu_only_features_on|Release|0|-DBUILD_LOCAL_GPU_TARGET_ONLY=ON ${CMAKE_FEATURES_ON_ARGS}`
- `8 install_local_gpu_only|Release|0|-DBUILD_LOCAL_GPU_TARGET_ONLY=ON -DINSTALL_TARGETS=ON`
- `9 install_local_gpu_only_tests|Release|0|-DBUILD_LOCAL_GPU_TARGET_ONLY=ON -DBUILD_TESTS=ON -DINSTALL_TARGETS=ON`

### Test plan

Validation was executed with an internal out-of-tree automation harness (not part of this repo) that runs baseline-vs-candidate matrix builds and functional/conformance compares.

For reviewer context:
- Harness submits matrix build + compare jobs and reports per-lane parity.
- Relevant run artifacts / job IDs are attached in PR comments.
- In-repo smoke checks remain:
  - `./install.sh`
  - `./install.sh --debug`
  - `./install.sh --static`
  - `./install.sh -p`