### PR TITLE
Add SPM Enable flag in build infrastructure

### DIFF
--- a/projects/rocprofiler-sdk/cmake/Modules/rocprofiler-sdk-utilities.cmake
+++ b/projects/rocprofiler-sdk/cmake/Modules/rocprofiler-sdk-utilities.cmake
@@ -109,3 +109,30 @@ function(rocprofiler_sdk_pc_sampling_stochastic_disabled _VAR)
         endif()
     endif()
 endfunction()
+
+function(rocprofiler_sdk_spm_disabled _VAR)
+    cmake_parse_arguments(ARG "ECHO" "PREFIX" "" ${ARGN})
+
+    set(CMAKE_MESSAGE_INDENT "[${PROJECT_NAME}]${ARG_PREFIX} ")
+
+    rocprofiler_sdk_get_gfx_architectures(rocprofiler-sdk-tests-gfx-info ECHO)
+    list(GET rocprofiler-sdk-tests-gfx-info 0 spm-gpu-0-gfx-info)
+
+    if("${spm-gpu-0-gfx-info}" MATCHES "^gfx94[0-9]$")
+        # spm is enabled on this architecture.
+        set(${_VAR}
+            FALSE
+            PARENT_SCOPE)
+        if(ARG_ECHO)
+            message(STATUS "SPM is enabled for ${spm-gpu-0-gfx-info}")
+        endif()
+    else()
+        # SPM is disabled on this architecture.
+        set(${_VAR}
+            TRUE
+            PARENT_SCOPE)
+        if(ARG_ECHO)
+            message(STATUS "SPM is disabled for ${spm-gpu-0-gfx-info}")
+        endif()
+    endif()
+endfunction()

--- a/projects/rocprofiler-sdk/cmake/Templates/rocprofiler-sdk-tests/config.cmake.in
+++ b/projects/rocprofiler-sdk/cmake/Templates/rocprofiler-sdk-tests/config.cmake.in
@@ -45,3 +45,11 @@ find_package_handle_standard_args(
     VERSION_VAR @PACKAGE_NAME@_VERSION
     REQUIRED_VARS @PACKAGE_NAME@_ROOT @PACKAGE_NAME@_VERSION
     HANDLE_COMPONENTS HANDLE_VERSION_RANGE)
+
+add_executable(@PACKAGE_NAME@::agent_hsaco_targets IMPORTED)
+set_property(
+    TARGET @PACKAGE_NAME@::agent_hsaco_targets
+    PROPERTY
+        IMPORTED_LOCATION
+        ${@PACKAGE_NAME@_ROOT_DIR}/${PACKAGE_NAME}/tests/unit-tests/bin
+    )

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/counters/tests/CMakeLists.txt
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/counters/tests/CMakeLists.txt
@@ -36,7 +36,7 @@ foreach(target_id ${GPU_TARGETS})
                    ${target_id}_agent_kernels.hsaco)
 endforeach()
 
-add_custom_target(agent_hasco_targets DEPENDS ${HSACO_TARGET_LIST})
+add_custom_target(agent_hsaco_targets DEPENDS ${HSACO_TARGET_LIST})
 
 install(
     FILES ${HSACO_TARGET_LIST}
@@ -69,7 +69,7 @@ add_executable(counter-tests)
 target_sources(counter-tests PRIVATE ${ROCPROFILER_LIB_COUNTER_TEST_SOURCES}
                                      ${ROCPROFILER_LIB_COUNTER_TEST_HEADERS})
 
-add_dependencies(counter-tests agent_hasco_targets)
+add_dependencies(counter-tests agent_hsaco_targets)
 
 target_link_libraries(
     counter-tests


### PR DESCRIPTION
## Motivation

Add SPM Enable flag in build infrastructure 

## Technical Details

1.  Adds a CMake function rocprofiler_sdk_spm_disabled() that checks GPU architecture to determine SPM support
2. Also adds an agent_hsaco_targets imported target in the test config template
3. Fixes a typo (agent_hasco_targets → agent_hsaco_targets), and updates counter test CMakeLists.txt to use the corrected target name

## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan

Existing tests should pass

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
