### PR TITLE
Refactor AQL helpers to accept strings instead of Metric objects

### DIFF
--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/aql/helpers.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/aql/helpers.cpp
@@ -37,15 +37,15 @@ namespace rocprofiler
 namespace aql
 {
 hsa_ven_amd_aqlprofile_id_query_t
-get_query_info(rocprofiler_agent_id_t agent, const counters::Metric& metric)
+get_query_info(rocprofiler_agent_id_t agent, const std::string& block, const std::string& pmc_name)
 {
     auto                     aql_agent = *CHECK_NOTNULL(rocprofiler::agent::get_aql_agent(agent));
     aqlprofile_pmc_profile_t profile   = {.agent = aql_agent, .events = nullptr, .event_count = 0};
-    hsa_ven_amd_aqlprofile_id_query_t query = {metric.block().c_str(), 0, 0};
+    hsa_ven_amd_aqlprofile_id_query_t query = {block.c_str(), 0, 0};
     if(aqlprofile_get_pmc_info(&profile, AQLPROFILE_INFO_BLOCK_ID, &query) != HSA_STATUS_SUCCESS)
     {
-        ROCP_DFATAL << fmt::format("AQL failed to query info for counter {}", metric);
-        throw std::runtime_error(fmt::format("AQL failed to query info for counter {}", metric));
+        ROCP_DFATAL << fmt::format("AQL failed to query info for counter {}", pmc_name);
+        throw std::runtime_error(fmt::format("AQL failed to query info for counter {}", pmc_name));
     }
     return query;
 }

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/aql/helpers.hpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/aql/helpers.hpp
@@ -41,7 +41,7 @@ namespace aql
 using rocprofiler_profile_pkt_cb = std::function<void(hsa::rocprofiler_packet)>;
 // Query HSA_VEN_AMD_AQLPROFILE_INFO_BLOCK_ID from aqlprofile
 hsa_ven_amd_aqlprofile_id_query_t
-get_query_info(rocprofiler_agent_id_t agent, const counters::Metric& metric);
+get_query_info(rocprofiler_agent_id_t agent, const std::string& block, const std::string& name);
 
 // Query HSA_VEN_AMD_AQLPROFILE_INFO_BLOCK_COUNTERS from aqlprofiler
 uint32_t

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/aql/packet_construct.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/aql/packet_construct.cpp
@@ -50,7 +50,7 @@ CounterPacketConstruct::CounterPacketConstruct(rocprofiler_agent_id_t           
     // for the counter.
     for(const auto& x : metrics)
     {
-        auto query_info                = get_query_info(_agent, x);
+        auto query_info                = get_query_info(_agent, x.block(), x.name());
         _metrics.emplace_back().metric = x;
         uint64_t event_id              = 0;
         if(!x.event().empty()) event_id = std::stoul(x.event(), nullptr);

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/aql/tests/helpers.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/aql/tests/helpers.cpp
@@ -64,38 +64,6 @@ findDeviceMetrics(const rocprofiler_agent_t& agent, const std::unordered_set<std
     }
     return ret;
 }
-
-hsa_ven_amd_aqlprofile_id_query_t
-v1_get_query_info(hsa_agent_t agent, const counters::Metric& metric)
-{
-    hsa_ven_amd_aqlprofile_profile_t  profile = {.agent  = agent,
-                                                .type   = HSA_VEN_AMD_AQLPROFILE_EVENT_TYPE_PMC,
-                                                .events = nullptr,
-                                                .event_count     = 0,
-                                                .parameters      = nullptr,
-                                                .parameter_count = 0,
-                                                .output_buffer   = {nullptr, 0},
-                                                .command_buffer  = {nullptr, 0}};
-    hsa_ven_amd_aqlprofile_id_query_t query   = {metric.block().c_str(), 0, 0};
-    if(hsa_ven_amd_aqlprofile_get_info(&profile, HSA_VEN_AMD_AQLPROFILE_INFO_BLOCK_ID, &query) !=
-       HSA_STATUS_SUCCESS)
-    {
-        DLOG(FATAL) << fmt::format("AQL failed to query info for counter {}", metric);
-        throw std::runtime_error(fmt::format("AQL failed to query info for counter {}", metric));
-    }
-    return query;
-}
-
-void
-test_init()
-{
-    HsaApiTable table;
-    table.amd_ext_ = &get_ext_table();
-    table.core_    = &get_api_table();
-    agent::construct_agent_cache(&table);
-    ASSERT_TRUE(hsa::get_queue_controller() != nullptr);
-    hsa::get_queue_controller()->init(get_api_table(), get_ext_table());
-}
 }  // namespace
 
 TEST(aql_helpers, get_query_info)
@@ -112,41 +80,13 @@ TEST(aql_helpers, get_query_info)
 
         for(auto& metric : metrics)
         {
-            auto query = aql::get_query_info(agent->id, metric);
+            auto query = aql::get_query_info(agent->id, metric.block(), metric.name());
             ROCP_INFO << fmt::format("{},{},{}", query.id, query.name, query.instance_count);
             EXPECT_TRUE(query.name != nullptr);
             EXPECT_TRUE(query.instance_count != 0);
             EXPECT_TRUE(query.id < std::numeric_limits<uint32_t>().max());
         }
     }
-}
-
-TEST(aql_helpers, get_query_info_compare_v1)
-{
-    ASSERT_EQ(hsa_init(), HSA_STATUS_SUCCESS);
-    test_init();
-    auto agents = agent::get_agents();
-
-    ASSERT_FALSE(agents.empty());
-
-    for(auto agent : agents)
-    {
-        if(agent->type == ROCPROFILER_AGENT_TYPE_CPU) continue;
-        auto metrics = findDeviceMetrics(*agent, {});
-        ASSERT_FALSE(metrics.empty());
-
-        for(auto& metric : metrics)
-        {
-            auto query = aql::get_query_info(agent->id, metric);
-            auto query_v1 =
-                v1_get_query_info(agent::get_agent_cache(agent)->get_hsa_agent(), metric);
-            // v1 query with hsa_agent
-
-            EXPECT_EQ(query.id, query_v1.id);
-            EXPECT_EQ(std::string(query.name), std::string(query_v1.name));
-        }
-    }
-    hsa_shut_down();
 }
 
 TEST(aql_helpers, get_block_counters)
@@ -162,7 +102,7 @@ TEST(aql_helpers, get_block_counters)
 
         for(auto& metric : metrics)
         {
-            auto query = aql::get_query_info(agent->id, metric);
+            auto query = aql::get_query_info(agent->id, metric.block(), metric.name());
             for(unsigned block_index = 0; block_index < query.instance_count; ++block_index)
             {
                 aqlprofile_pmc_event_t event = {
@@ -190,7 +130,7 @@ TEST(aql_helpers, get_dim_info)
 
         for(auto& metric : metrics)
         {
-            auto query = aql::get_query_info(agent->id, metric);
+            auto query = aql::get_query_info(agent->id, metric.block(), metric.name());
             for(unsigned block_index = 0; block_index < query.instance_count; ++block_index)
             {
                 aqlprofile_pmc_event_t event = {


### PR DESCRIPTION
## Motivation

Refactor AQL helpers to accept strings instead of Metric objects

## Technical Details

1. Changes get_query_info() signature from taking a const counters::Metric& to taking const std::string& block, const std::string& name
2. Calling functions are updated to pass  metric.block() and metric.name() explicitly.
3. This decouples function from metrics class

## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan
Tests have been updated

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
