### PR TITLE
[rocprofiler-sdk] Add SPM experimental public API header

### DIFF
--- a/projects/rocprofiler-sdk/source/include/rocprofiler-sdk/experimental/CMakeLists.txt
+++ b/projects/rocprofiler-sdk/source/include/rocprofiler-sdk/experimental/CMakeLists.txt
@@ -2,7 +2,7 @@
 # Experimental components of the ROCProfiler SDK API.
 #
 
-set(ROCPROFILER_EXPERIMENTAL_HEADER_FILES counters.h registration.h thread_trace.h)
+set(ROCPROFILER_EXPERIMENTAL_HEADER_FILES counters.h registration.h thread_trace.h spm.h)
 
 install(
     FILES ${ROCPROFILER_EXPERIMENTAL_HEADER_FILES}

--- a/projects/rocprofiler-sdk/source/include/rocprofiler-sdk/experimental/spm.h
+++ b/projects/rocprofiler-sdk/source/include/rocprofiler-sdk/experimental/spm.h
@@ -30,17 +30,95 @@
 ROCPROFILER_EXTERN_C_INIT
 
 /**
- * @brief (experimental) SPM parameter type and value.
- *
+ * @brief (experimental) SPM parameter types for configuring sampling behavior.
  **/
-typedef struct ROCPROFILER_SDK_EXPERIMENTAL rocprofiler_spm_configuration_t
+typedef enum
 {
-    size_t size;       ///< Size of this struct
-    double frequency;  ///< Input frequency (in GHz) is estimated to number of scclock count. Used
-                       ///< to determine sample interval.
-    uint64_t buffer_size;  ///< Buffer size of user mode buffer in KB
-    uint64_t timeout;      ///< Timeout for the user mode buffer in ms
-} rocprofiler_spm_configuration_t;
+    ROCPROFILER_SPM_PARAMETER_TYPE_NONE = 0,
+    ROCPROFILER_SPM_PARAMETER_TYPE_SAMPLE_INTERVAL_SCLK_CYCLES,
+} rocprofiler_spm_parameter_type_t;
+
+/**
+ * @brief (experimental) SPM configuration parameter.
+ * @brief (experimental) Describes an available SPM configuration for an agent.
+ *
+ * Returned via ::rocprofiler_query_spm_agent_configurations to describe the
+ * supported SPM parameter types and their valid value ranges for a given agent.
+ * @var size
+ * @brief Size of this struct.
+ * @var type
+ * @brief The SPM parameter type this configuration describes.
+ * @var min_interval
+ * @brief Minimum supported value for this parameter
+ * @var max_interval
+ * @brief Maximum supported value for this parameter
+ **/
+typedef struct ROCPROFILER_SDK_EXPERIMENTAL rocprofiler_spm_available_configuration_t
+{
+    uint64_t                         size;
+    rocprofiler_spm_parameter_type_t type;
+    uint64_t                         min_interval;
+    uint64_t                         max_interval;
+} rocprofiler_spm_available_configuration_t;
+
+/**
+ * @brief (experimental) Callback that provides the available SPM configurations for an agent.
+ *        The config array is owned by rocprofiler and should not be freed.
+ *
+ * @param [in] config Array of pointers to available SPM configurations
+ * @param [in] num_config Number of configurations in the array
+ * @param [in] user_data User data supplied by ::rocprofiler_query_spm_agent_configurations
+ */
+
+ROCPROFILER_SDK_EXPERIMENTAL
+typedef rocprofiler_status_t (*rocprofiler_spm_available_configurations_cb_t)(
+    const rocprofiler_spm_available_configuration_t** config,
+    size_t                                            num_config,
+    void*                                             user_data);
+
+/**
+ *  @brief (experimental) Query supported agent configurations for SPM.
+ *       Supported configurations are returned in a callback.
+ *
+ * @param [in] agent_id agent for which the configurations are queried for
+ * @param [in] cb  callback in which configurations are returned
+ * @param [in] user_data user data to be passed to the callback
+ * @return ::rocprofiler_status_t
+ * @retval ROCPROFILER_STATUS_SUCCESS if configurations were successfully queried
+ * @retval ROCPROFILER_STATUS_ERROR if configurations could not be queried
+ * @retval ROCPROFILER_STATUS_ERROR_AGENT_NOT_FOUND if agent not found
+ * @retval ROCPROFILER_STATUS_ERROR_INCOMPATIBLE_ABI incompatible aqlprofile version is used
+ **/
+
+ROCPROFILER_SDK_EXPERIMENTAL
+rocprofiler_status_t
+rocprofiler_query_spm_agent_configurations(rocprofiler_agent_id_t                        agent_id,
+                                           rocprofiler_spm_available_configurations_cb_t cb,
+                                           void* user_data) ROCPROFILER_API
+    ROCPROFILER_NONNULL(2, 3);
+
+/**
+ * @brief (experimental) SPM configuration parameter used to configure sampling behavior.
+ *
+ * Passed to ::rocprofiler_spm_create_counter_config to specify SPM sampling parameters.
+ * The valid range of values for a given parameter type can be queried via
+ * ::rocprofiler_query_spm_agent_configurations.
+ *
+ * @var size
+ * @brief Size of this struct.
+ *
+ * @var type
+ * @brief The SPM parameter type.
+ *
+ * @var value
+ * @brief The value for this parameter.
+ */
+typedef struct ROCPROFILER_SDK_EXPERIMENTAL rocprofiler_spm_parameters_t
+{
+    uint64_t                         size;  ///< Size of this struct
+    rocprofiler_spm_parameter_type_t type;
+    uint64_t                         value;  ///< Number of sclock cycles
+} rocprofiler_spm_parameters_t;
 
 /**
  * @brief (experimental) Create SPM Counter Configuration. A config is bound to an agent but can
@@ -49,7 +127,7 @@ typedef struct ROCPROFILER_SDK_EXPERIMENTAL rocprofiler_spm_configuration_t
  *        counters for an agent can be queried using
  *        ::rocprofiler_iterate_spm_supported_counters. An existing config
  *        may be supplied via config_id to use as a base for the new config.
- *        All counters and parameters in the existing config will be copied over to the new
+ *        All counters in the existing config will be copied over to the new
  *        config. The existing config will remain unmodified and usable with
  *        the new config id being returned in config_id.
  *
@@ -58,11 +136,10 @@ typedef struct ROCPROFILER_SDK_EXPERIMENTAL rocprofiler_spm_configuration_t
  * @param [in] counters_count Size of counters list
  * @param [in] parameters SPM parameter configuration
  * @param [in,out] config_id Identifier for GPU SPM counters group. If an existing
-                   config is supplied, that profiles counters and parameters will be copied
+                   config is supplied, that counters will be copied
                    over to a new config (returned via this id)
  * @return ::rocprofiler_status_t
  * @retval ROCPROFILER_STATUS_SUCCESS if config created
- * @retval ROCPROFILER_STATUS_ERROR if config could not be created
  * @retval ROCPROFILER_STATUS_ERROR_METRIC_NOT_VALID_FOR_AGENT if agent does not support an input
  counter
  * @retval ROCPROFILER_STATUS_ERROR_INVALID_ARGUMENT if counters count is zero and no existing
@@ -79,9 +156,10 @@ rocprofiler_status_t
 rocprofiler_spm_create_counter_config(rocprofiler_agent_id_t           agent_id,
                                       rocprofiler_counter_id_t*        counters_list,
                                       size_t                           counters_count,
-                                      rocprofiler_spm_configuration_t* parameters,
+                                      rocprofiler_spm_parameters_t**   parameters,
+                                      size_t                           parameters_count,
                                       rocprofiler_counter_config_id_t* config_id) ROCPROFILER_API
-    ROCPROFILER_NONNULL(2, 5);
+    ROCPROFILER_NONNULL(2, 4, 6);
 
 /**
  * @brief (experimental) Destroy SPM Profile Configuration.
@@ -102,10 +180,9 @@ rocprofiler_spm_destroy_counter_config(rocprofiler_counter_config_id_t config_id
  **/
 typedef enum ROCPROFILER_SDK_EXPERIMENTAL rocprofiler_spm_record_flag_t
 {
-    ROCPROFILER_SPM_RECORD_FLAG_DATA_NONE = 0,  ///< records with data loss
+    ROCPROFILER_SPM_RECORD_FLAG_DATA_NONE = 0,  ///< flag value none
     ROCPROFILER_SPM_RECORD_FLAG_DATA,           ///< records with data
-    ROCPROFILER_SPM_RECORD_FLAG_END,            ///< End of agent service
-    ROCPROFILER_SPM_RECORD_FLAG_DATA_LOST,      ///< flag value none
+    ROCPROFILER_SPM_RECORD_FLAG_DATA_LOST,      ///< records with data loss
     ROCPROFILER_SPM_RECORD_FLAG_LAST,
 } rocprofiler_spm_record_flag_t;
 
@@ -218,12 +295,10 @@ rocprofiler_iterate_spm_supported_counters(rocprofiler_agent_id_t              a
  * @param [in] record_callback  Record callback for completed profile data
  * @param [in] record_callback_args Callback args for record callback
  * @return ::rocprofiler_status_t
- *
- * @return ::rocprofiler_status_t
  * @retval ROCPROFILER_STATUS_SUCCESS if the context can be configured for SPM dispatch service
- * @retval ROCPROFILER_STATUS_ERROR if the context cannot be configured for SPM dispatch service
  * @retval ROCPROFILER_STATUS_ERROR_NOT_IMPLEMENTED if the ROCPROFILER_SPM_BETA_ENABLED is not set
  * @retval ROCPROFILER_STATUS_ERROR_CONFIGURATION_LOCKED for configuration locked
+ * @retval ROCPROFILER_STATUS_ERROR_AGENT_DISPATCH_CONFLICT
  * @retval ROCPROFILER_STATUS_ERROR_INCOMPATIBLE_ABI incompatible aqlprofile version is used
  * @retval ROCPROFILER_STATUS_ERROR_CONTEXT_INVALID invalid input context has not already been
  * created
@@ -238,7 +313,6 @@ rocprofiler_configure_callback_spm_dispatch_service(
     void*                                          dispatch_callback_args,
     rocprofiler_spm_dispatch_counting_record_cb_t  record_callback,
     void* record_callback_args) ROCPROFILER_API ROCPROFILER_NONNULL(2, 4);
-;
 
 /**
  * @brief (experimental) Configure buffered dispatch spm service.
@@ -252,14 +326,19 @@ rocprofiler_configure_callback_spm_dispatch_service(
  * @param [in] callback callback to perform when dispatch is enqueued
  * @param [in] callback_data_args callback data
  * @return ::rocprofiler_status_t
- * @retval ROCPROFILER_STATUS_ERROR_BUFFER_NOT_FOUND
- * @retval ROCPROFILER_STATUS_ERROR_CONTEXT_INVALID invalid input context has not already been
- * @retval ROCPROFILER_STATUS_ERROR_AGENT_DISPATCH_CONFLICT
  * @retval ROCPROFILER_STATUS_SUCCESS if the context can be configured for SPM buffer dispatch
  * service
+ * @retval ROCPROFILER_STATUS_ERROR_BUFFER_NOT_FOUND if the buffer is not found
+ * @retval ROCPROFILER_STATUS_ERROR_CONTEXT_INVALID invalid input context has not already been
+ * created
+ * @retval ROCPROFILER_STATUS_ERROR_AGENT_DISPATCH_CONFLICT
+ * @retval ROCPROFILER_STATUS_ERROR_CONTEXT_CONFLICT conflicting services being enabled in the
+ * context
+ * @retval ROCPROFILER_STATUS_ERROR_NOT_IMPLEMENTED if the ROCPROFILER_SPM_BETA_ENABLED is not set
+ * @retval ROCPROFILER_STATUS_ERROR_INCOMPATIBLE_ABI incompatible aqlprofile version is used
  */
 
-rocprofiler_status_t
+ROCPROFILER_SDK_EXPERIMENTAL rocprofiler_status_t
 rocprofiler_configure_buffer_spm_dispatch_service(
     rocprofiler_context_id_t                       context_id,
     rocprofiler_buffer_id_t                        buffer_id,

--- a/projects/rocprofiler-sdk/source/include/rocprofiler-sdk/experimental/spm.h
+++ b/projects/rocprofiler-sdk/source/include/rocprofiler-sdk/experimental/spm.h
@@ -81,7 +81,7 @@ rocprofiler_spm_create_counter_config(rocprofiler_agent_id_t           agent_id,
                                       size_t                           counters_count,
                                       rocprofiler_spm_configuration_t* parameters,
                                       rocprofiler_counter_config_id_t* config_id) ROCPROFILER_API
-    ROCPROFILER_NONNULL(2);
+    ROCPROFILER_NONNULL(2, 5);
 
 /**
  * @brief (experimental) Destroy SPM Profile Configuration.

--- a/projects/rocprofiler-sdk/source/include/rocprofiler-sdk/experimental/spm.h
+++ b/projects/rocprofiler-sdk/source/include/rocprofiler-sdk/experimental/spm.h
@@ -48,17 +48,25 @@ typedef enum
  * @brief Size of this struct.
  * @var type
  * @brief The SPM parameter type this configuration describes.
- * @var min_interval
+ * @var interval
+ * @brief Interval configuration for sample interval parameter types.
+ * @var interval.min_interval
  * @brief Minimum supported value for this parameter
- * @var max_interval
+ * @var interval.max_interval
  * @brief Maximum supported value for this parameter
  **/
 typedef struct ROCPROFILER_SDK_EXPERIMENTAL rocprofiler_spm_available_configuration_t
 {
     uint64_t                         size;
     rocprofiler_spm_parameter_type_t type;
-    uint64_t                         min_interval;
-    uint64_t                         max_interval;
+    union
+    {
+        struct
+        {
+            uint64_t min_interval;
+            uint64_t max_interval;
+        } interval;
+    };
 } rocprofiler_spm_available_configuration_t;
 
 /**

--- a/projects/rocprofiler-sdk/source/include/rocprofiler-sdk/experimental/spm.h
+++ b/projects/rocprofiler-sdk/source/include/rocprofiler-sdk/experimental/spm.h
@@ -39,35 +39,24 @@ typedef enum ROCPROFILER_SDK_EXPERIMENTAL rocprofiler_spm_parameter_type_t
 } rocprofiler_spm_parameter_type_t;
 
 /**
- * @brief (experimental) SPM configuration parameter.
  * @brief (experimental) Describes an available SPM configuration for an agent.
  *
- * Returned via ::rocprofiler_query_spm_agent_configurations to describe the
+ * Returned via ::rocprofiler_query_agent_spm_configurations to describe the
  * supported SPM parameter types and their valid value ranges for a given agent.
- * @var size
- * @brief Size of this struct.
- * @var type
- * @brief The SPM parameter type this configuration describes.
- * @var interval
- * @brief Interval configuration for sample interval parameter types.
- * @var interval.min_interval
- * @brief Minimum supported value for this parameter
- * @var interval.max_interval
- * @brief Maximum supported value for this parameter
  **/
-typedef struct ROCPROFILER_SDK_EXPERIMENTAL rocprofiler_spm_available_configuration_t
+typedef struct ROCPROFILER_SDK_EXPERIMENTAL rocprofiler_available_spm_configuration_t
 {
-    uint64_t                         size;
-    rocprofiler_spm_parameter_type_t type;
+    uint64_t                         size;          ///< Size of this struct
+    rocprofiler_spm_parameter_type_t type;          ///< The SPM parameter type
     union
     {
         struct
         {
-            uint64_t min_interval;
-            uint64_t max_interval;
-        } interval;
+            uint64_t min_interval;  ///< Minimum supported value for this parameter
+            uint64_t max_interval;  ///< Maximum supported value for this parameter
+        } interval;                 ///< Interval configuration for sample interval parameter types
     };
-} rocprofiler_spm_available_configuration_t;
+} rocprofiler_available_spm_configuration_t;
 
 /**
  * @brief (experimental) Callback that provides the available SPM configurations for an agent.
@@ -75,12 +64,12 @@ typedef struct ROCPROFILER_SDK_EXPERIMENTAL rocprofiler_spm_available_configurat
  *
  * @param [in] config Array of pointers to available SPM configurations
  * @param [in] num_config Number of configurations in the array
- * @param [in] user_data User data supplied by ::rocprofiler_query_spm_agent_configurations
+ * @param [in] user_data User data supplied by ::rocprofiler_query_agent_spm_configurations
  */
 
 ROCPROFILER_SDK_EXPERIMENTAL
-typedef rocprofiler_status_t (*rocprofiler_spm_available_configurations_cb_t)(
-    const rocprofiler_spm_available_configuration_t** config,
+typedef rocprofiler_status_t (*rocprofiler_available_spm_configurations_cb_t)(
+    const rocprofiler_available_spm_configuration_t** config,
     size_t                                            num_config,
     void*                                             user_data);
 
@@ -100,15 +89,15 @@ typedef rocprofiler_status_t (*rocprofiler_spm_available_configurations_cb_t)(
 
 ROCPROFILER_SDK_EXPERIMENTAL
 rocprofiler_status_t
-rocprofiler_query_spm_agent_configurations(rocprofiler_agent_id_t                        agent_id,
-                                           rocprofiler_spm_available_configurations_cb_t cb,
+rocprofiler_query_agent_spm_configurations(rocprofiler_agent_id_t                        agent_id,
+                                           rocprofiler_available_spm_configurations_cb_t cb,
                                            void* user_data) ROCPROFILER_API ROCPROFILER_NONNULL(2);
 
 /**
  * @brief (experimental) SPM configuration parameter used to configure sampling behavior.
  *
- * Passed to ::rocprofiler_spm_create_counter_config to specify SPM sampling parameters.
- * Supported configurations can be queried via ::rocprofiler_query_spm_agent_configurations.
+ * Passed to ::rocprofiler_create_spm_counter_config to specify SPM sampling parameters.
+ * Supported configurations can be queried via ::rocprofiler_query_agent_spm_configurations.
  * @var size
  * @brief Size of this struct.
  *
@@ -130,7 +119,7 @@ typedef struct ROCPROFILER_SDK_EXPERIMENTAL rocprofiler_spm_parameters_t
  *        be used across many contexts. The config has a fixed set of counters
  *        that are collected (and specified by counter_list) and parameters. The available
  *        counters for an agent can be queried using
- *        ::rocprofiler_iterate_spm_supported_counters. An existing config
+ *        ::rocprofiler_iterate_agent_spm_supported_counters. An existing config
  *        may be supplied via config_id to use as a base for the new config.
  *        All counters in the existing config will be copied over to the new
  *        config. The existing config will remain unmodified and usable with
@@ -156,7 +145,7 @@ typedef struct ROCPROFILER_SDK_EXPERIMENTAL rocprofiler_spm_parameters_t
  */
 ROCPROFILER_SDK_EXPERIMENTAL
 rocprofiler_status_t
-rocprofiler_spm_create_counter_config(rocprofiler_agent_id_t           agent_id,
+rocprofiler_create_spm_counter_config(rocprofiler_agent_id_t           agent_id,
                                       rocprofiler_counter_id_t*        counters_list,
                                       size_t                           counters_count,
                                       rocprofiler_spm_parameters_t**   parameters,
@@ -175,7 +164,7 @@ rocprofiler_spm_create_counter_config(rocprofiler_agent_id_t           agent_id,
  */
 ROCPROFILER_SDK_EXPERIMENTAL
 rocprofiler_status_t
-rocprofiler_spm_destroy_counter_config(rocprofiler_counter_config_id_t config_id) ROCPROFILER_API;
+rocprofiler_destroy_spm_counter_config(rocprofiler_counter_config_id_t config_id) ROCPROFILER_API;
 
 /**
  * @brief (experimental) SPM record flags.
@@ -183,10 +172,10 @@ rocprofiler_spm_destroy_counter_config(rocprofiler_counter_config_id_t config_id
  **/
 typedef enum ROCPROFILER_SDK_EXPERIMENTAL rocprofiler_spm_record_flag_t
 {
-    ROCPROFILER_SPM_RECORD_FLAG_DATA_NONE = 0,  ///< flag value none
-    ROCPROFILER_SPM_RECORD_FLAG_DATA,           ///< records with data
-    ROCPROFILER_SPM_RECORD_FLAG_DATA_LOST,      ///< records with data loss
-    ROCPROFILER_SPM_RECORD_FLAG_LAST,
+    ROCPROFILER_SPM_RECORD_FLAG_NONE      = 0,      ///< flag value none
+    ROCPROFILER_SPM_RECORD_FLAG_DATA      = 1 << 0, ///< records with data
+    ROCPROFILER_SPM_RECORD_FLAG_DATA_LOSS = 1 << 1, ///< records with data loss
+    ROCPROFILER_SPM_RECORD_FLAG_LAST      = 1 << 2,
 } rocprofiler_spm_record_flag_t;
 
 /**
@@ -209,24 +198,6 @@ typedef struct ROCPROFILER_SDK_EXPERIMENTAL rocprofiler_spm_counter_record_t
     rocprofiler_agent_id_t            agent_id;   ///< Agent on which the record is collected
     rocprofiler_timestamp_t           timestamp;  ///< timestamp of the sample
     double value;  ///< SPM sample for the counter with counter instance id: id
-    /// @var id
-    /// @brief counter id, ROCPROFILER_DIMENSION_XCC,
-    ///  ROCPROFILER_DIMENSION_INSTANCE, ROCPROFILER_DIMENSION_SHADER_ENGINE embedded in it
-    /// @var agent id
-    /// @brief identifies the agent on which SPM data was collected
-    /// @var timestamp
-    /// @brief GPU timestamp when sample was collected
-    /// @var value
-    /// @brief sampled counter value
-    /// @var dispatch_id
-    /// @brief A value greater than zero indicates that this counter record is associated with a
-    /// specific dispatch.
-    ///
-    /// This value can be mapped to a dispatch via the `dispatch_info` field (@see
-    /// ::rocprofiler_kernel_dispatch_info_t) of a
-    /// ::rocprofiler_spm_dispatch_counting_service_data_t
-    /// ::rocprofiler_spm_dispatch_counting_service_data_t records (which will be insert into the
-    /// buffer prior to the associated ::rocprofiler_spm_counter_record_t records).
 } rocprofiler_spm_counter_record_t;
 
 /**
@@ -249,7 +220,7 @@ typedef void (*rocprofiler_spm_dispatch_counting_record_cb_t)(
     const rocprofiler_spm_dispatch_counting_service_data_t* dispatch_data,
     const rocprofiler_spm_counter_record_t**                records,
     size_t                                                  record_count,
-    int                                                     flags,
+    rocprofiler_spm_record_flag_t                           flags,
     rocprofiler_user_data_t                                 userdata,
     void*                                                   record_callback_args);
 /**
@@ -284,7 +255,7 @@ typedef void (*rocprofiler_spm_dispatch_counting_service_cb_t)(
  * @retval ROCPROFILER_STATUS_ERROR_AGENT_ARCH_NOT_SUPPORTED agent has no supported SPM counter
  */
 ROCPROFILER_SDK_EXPERIMENTAL rocprofiler_status_t
-rocprofiler_iterate_spm_supported_counters(rocprofiler_agent_id_t              agent_id,
+rocprofiler_iterate_agent_spm_supported_counters(rocprofiler_agent_id_t              agent_id,
                                            rocprofiler_available_counters_cb_t cb,
                                            void* user_data) ROCPROFILER_API ROCPROFILER_NONNULL(2);
 

--- a/projects/rocprofiler-sdk/source/include/rocprofiler-sdk/experimental/spm.h
+++ b/projects/rocprofiler-sdk/source/include/rocprofiler-sdk/experimental/spm.h
@@ -1,6 +1,6 @@
 // MIT License
 //
-// Copyright (c) 2025 Advanced Micro Devices, Inc. All rights reserved.
+// Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -32,7 +32,7 @@ ROCPROFILER_EXTERN_C_INIT
 /**
  * @brief (experimental) SPM parameter types for configuring sampling behavior.
  **/
-typedef enum
+typedef enum ROCPROFILER_SDK_EXPERIMENTAL rocprofiler_spm_parameter_type_t
 {
     ROCPROFILER_SPM_PARAMETER_TYPE_NONE = 0,
     ROCPROFILER_SPM_PARAMETER_TYPE_SAMPLE_INTERVAL_SCLK_CYCLES,
@@ -102,16 +102,13 @@ ROCPROFILER_SDK_EXPERIMENTAL
 rocprofiler_status_t
 rocprofiler_query_spm_agent_configurations(rocprofiler_agent_id_t                        agent_id,
                                            rocprofiler_spm_available_configurations_cb_t cb,
-                                           void* user_data) ROCPROFILER_API
-    ROCPROFILER_NONNULL(2, 3);
+                                           void* user_data) ROCPROFILER_API ROCPROFILER_NONNULL(2);
 
 /**
  * @brief (experimental) SPM configuration parameter used to configure sampling behavior.
  *
  * Passed to ::rocprofiler_spm_create_counter_config to specify SPM sampling parameters.
- * The valid range of values for a given parameter type can be queried via
- * ::rocprofiler_query_spm_agent_configurations.
- *
+ * Supported configurations can be queried via ::rocprofiler_query_spm_agent_configurations.
  * @var size
  * @brief Size of this struct.
  *
@@ -123,9 +120,9 @@ rocprofiler_query_spm_agent_configurations(rocprofiler_agent_id_t               
  */
 typedef struct ROCPROFILER_SDK_EXPERIMENTAL rocprofiler_spm_parameters_t
 {
-    uint64_t                         size;  ///< Size of this struct
+    uint64_t                         size;
     rocprofiler_spm_parameter_type_t type;
-    uint64_t                         value;  ///< Number of sclock cycles
+    uint64_t                         value;
 } rocprofiler_spm_parameters_t;
 
 /**
@@ -149,9 +146,7 @@ typedef struct ROCPROFILER_SDK_EXPERIMENTAL rocprofiler_spm_parameters_t
  * @return ::rocprofiler_status_t
  * @retval ROCPROFILER_STATUS_SUCCESS if config created
  * @retval ROCPROFILER_STATUS_ERROR_METRIC_NOT_VALID_FOR_AGENT if agent does not support an input
- counter
- * @retval ROCPROFILER_STATUS_ERROR_INVALID_ARGUMENT if counters count is zero and no existing
- config is supplied
+ counter for sampling
  * @retval ROCPROFILER_STATUS_ERROR_INCOMPATIBLE_ABI incompatible aqlprofile version is used
  * @retval ROCPROFILER_STATUS_ERROR_NOT_IMPLEMENTED if the ROCPROFILER_SPM_BETA_ENABLED is not set
  * @retval ROCPROFILER_STATUS_ERROR_EXCEEDS_HW_LIMIT if input counters exceed the hardware limit
@@ -230,7 +225,7 @@ typedef struct ROCPROFILER_SDK_EXPERIMENTAL rocprofiler_spm_counter_record_t
     /// This value can be mapped to a dispatch via the `dispatch_info` field (@see
     /// ::rocprofiler_kernel_dispatch_info_t) of a
     /// ::rocprofiler_spm_dispatch_counting_service_data_t
-    /// ::rocprofiler_spm_dispatch_counting_service_record_t records (which will be insert into the
+    /// ::rocprofiler_spm_dispatch_counting_service_data_t records (which will be insert into the
     /// buffer prior to the associated ::rocprofiler_spm_counter_record_t records).
 } rocprofiler_spm_counter_record_t;
 
@@ -285,6 +280,7 @@ typedef void (*rocprofiler_spm_dispatch_counting_service_cb_t)(
  * @return ::rocprofiler_status_t
  * @retval ROCPROFILER_STATUS_SUCCESS if all counters found for agent
  * @retval ROCPROFILER_STATUS_ERROR_AGENT_NOT_FOUND invalid agent
+ * @retval ROCPROFILER_STATUS_ERROR_INCOMPATIBLE_ABI incompatible aqlprofile version is used
  * @retval ROCPROFILER_STATUS_ERROR_AGENT_ARCH_NOT_SUPPORTED agent has no supported SPM counter
  */
 ROCPROFILER_SDK_EXPERIMENTAL rocprofiler_status_t
@@ -305,11 +301,8 @@ rocprofiler_iterate_spm_supported_counters(rocprofiler_agent_id_t              a
  * @return ::rocprofiler_status_t
  * @retval ROCPROFILER_STATUS_SUCCESS if the context can be configured for SPM dispatch service
  * @retval ROCPROFILER_STATUS_ERROR_NOT_IMPLEMENTED if the ROCPROFILER_SPM_BETA_ENABLED is not set
- * @retval ROCPROFILER_STATUS_ERROR_CONFIGURATION_LOCKED for configuration locked
- * @retval ROCPROFILER_STATUS_ERROR_AGENT_DISPATCH_CONFLICT
  * @retval ROCPROFILER_STATUS_ERROR_INCOMPATIBLE_ABI incompatible aqlprofile version is used
- * @retval ROCPROFILER_STATUS_ERROR_CONTEXT_INVALID invalid input context has not already been
- * created
+ * @retval ROCPROFILER_STATUS_ERROR_CONTEXT_INVALID Invalid context
  * @retval ROCPROFILER_STATUS_ERROR_CONTEXT_CONFLICT conflicting services being enabled in the
  * context
  */
@@ -325,8 +318,8 @@ rocprofiler_configure_callback_spm_dispatch_service(
 /**
  * @brief (experimental) Configure buffered dispatch spm service.
  *        Collects the counters in dispatch packets and stores them
- *        in a buffer with @p buffer_id. The buffer may contain packets from more than
- *        one dispatch (denoted by correlation id). Will trigger the
+ *        in a buffer with buffer_id. The buffer may contain packets from more than
+ *        one dispatch (denoted by dispatch id). Will trigger the
  *        callback based on the parameters setup in buffer_id_t.
  *
  * @param [in] context_id context id
@@ -337,9 +330,7 @@ rocprofiler_configure_callback_spm_dispatch_service(
  * @retval ROCPROFILER_STATUS_SUCCESS if the context can be configured for SPM buffer dispatch
  * service
  * @retval ROCPROFILER_STATUS_ERROR_BUFFER_NOT_FOUND if the buffer is not found
- * @retval ROCPROFILER_STATUS_ERROR_CONTEXT_INVALID invalid input context has not already been
- * created
- * @retval ROCPROFILER_STATUS_ERROR_AGENT_DISPATCH_CONFLICT
+ * @retval ROCPROFILER_STATUS_ERROR_CONTEXT_INVALID invalid input context
  * @retval ROCPROFILER_STATUS_ERROR_CONTEXT_CONFLICT conflicting services being enabled in the
  * context
  * @retval ROCPROFILER_STATUS_ERROR_NOT_IMPLEMENTED if the ROCPROFILER_SPM_BETA_ENABLED is not set

--- a/projects/rocprofiler-sdk/source/include/rocprofiler-sdk/experimental/spm.h
+++ b/projects/rocprofiler-sdk/source/include/rocprofiler-sdk/experimental/spm.h
@@ -76,12 +76,12 @@ typedef struct ROCPROFILER_SDK_EXPERIMENTAL rocprofiler_spm_configuration_t
  */
 ROCPROFILER_SDK_EXPERIMENTAL
 rocprofiler_status_t
-rocprofiler_spm_create_counter_config(rocprofiler_agent_id_t               agent_id,
-                                      rocprofiler_counter_id_t*            counters_list,
-                                      size_t                               counters_count,
-                                      rocprofiler_spm_configuration_t*     parameters,
-                                      rocprofiler_counter_config_id_t* config_id)
-    ROCPROFILER_API ROCPROFILER_NONNULL(2);
+rocprofiler_spm_create_counter_config(rocprofiler_agent_id_t           agent_id,
+                                      rocprofiler_counter_id_t*        counters_list,
+                                      size_t                           counters_count,
+                                      rocprofiler_spm_configuration_t* parameters,
+                                      rocprofiler_counter_config_id_t* config_id) ROCPROFILER_API
+    ROCPROFILER_NONNULL(2);
 
 /**
  * @brief (experimental) Destroy SPM Profile Configuration.
@@ -94,8 +94,7 @@ rocprofiler_spm_create_counter_config(rocprofiler_agent_id_t               agent
  */
 ROCPROFILER_SDK_EXPERIMENTAL
 rocprofiler_status_t
-rocprofiler_spm_destroy_counter_config(rocprofiler_counter_config_id_t config_id)
-    ROCPROFILER_API;
+rocprofiler_spm_destroy_counter_config(rocprofiler_counter_config_id_t config_id) ROCPROFILER_API;
 
 /**
  * @brief (experimental) SPM record flags.
@@ -131,9 +130,9 @@ typedef struct ROCPROFILER_SDK_EXPERIMENTAL rocprofiler_spm_counter_record_t
     rocprofiler_timestamp_t           timestamp;  ///< timestamp of the sample
     double value;  ///< SPM sample for the counter with counter instance id: id
     /// @var id
-    /// @brief counter id, ROCPROFILER_DIMENSION_XCC, 
+    /// @brief counter id, ROCPROFILER_DIMENSION_XCC,
     ///  ROCPROFILER_DIMENSION_INSTANCE, ROCPROFILER_DIMENSION_SHADER_ENGINE embedded in it
-    /// @var agent id 
+    /// @var agent id
     /// @brief identifies the agent on which SPM data was collected
     /// @var timestamp
     /// @brief GPU timestamp when sample was collected
@@ -144,7 +143,8 @@ typedef struct ROCPROFILER_SDK_EXPERIMENTAL rocprofiler_spm_counter_record_t
     /// specific dispatch.
     ///
     /// This value can be mapped to a dispatch via the `dispatch_info` field (@see
-    /// ::rocprofiler_kernel_dispatch_info_t) of a ::rocprofiler_spm_dispatch_counting_service_data_t
+    /// ::rocprofiler_kernel_dispatch_info_t) of a
+    /// ::rocprofiler_spm_dispatch_counting_service_data_t
     /// ::rocprofiler_spm_dispatch_counting_service_record_t records (which will be insert into the
     /// buffer prior to the associated ::rocprofiler_spm_counter_record_t records).
 } rocprofiler_spm_counter_record_t;
@@ -176,8 +176,8 @@ typedef void (*rocprofiler_spm_dispatch_counting_record_cb_t)(
  * @brief (experimental) Kernel Dispatch Callback. This is a callback that is invoked before the
  * kernel is enqueued into the HSA queue. What counters to collect for a kernel are set via passing
  * back a profile config (config) in this callback. These counters will be collected and emplaced in
- * the buffer with ::rocprofiler_buffer_id_t used when setting up this callback or will be returned via 
- * a callback used when setting up this callback
+ * the buffer with ::rocprofiler_buffer_id_t used when setting up this callback or will be returned
+ * via a callback used when setting up this callback
  *
  * @param [in] dispatch_data kernel dispatch data
  * @param [out] config  spm counter config
@@ -187,7 +187,7 @@ typedef void (*rocprofiler_spm_dispatch_counting_record_cb_t)(
 ROCPROFILER_SDK_EXPERIMENTAL
 typedef void (*rocprofiler_spm_dispatch_counting_service_cb_t)(
     const rocprofiler_spm_dispatch_counting_service_data_t* dispatch_data,
-    rocprofiler_counter_config_id_t*                    config,
+    rocprofiler_counter_config_id_t*                        config,
     rocprofiler_user_data_t*                                user_data,
     void*                                                   callback_data_args);
 

--- a/projects/rocprofiler-sdk/source/include/rocprofiler-sdk/experimental/spm.h
+++ b/projects/rocprofiler-sdk/source/include/rocprofiler-sdk/experimental/spm.h
@@ -69,7 +69,7 @@ typedef struct ROCPROFILER_SDK_EXPERIMENTAL rocprofiler_spm_available_configurat
  */
 
 ROCPROFILER_SDK_EXPERIMENTAL
-typedef rocprofiler_status_t (*rocprofiler_available_spm_configurations_cb_t)(
+typedef rocprofiler_status_t (*rocprofiler_spm_available_configurations_cb_t)(
     const rocprofiler_spm_available_configuration_t** config,
     size_t                                            num_config,
     void*                                             user_data);
@@ -91,7 +91,7 @@ typedef rocprofiler_status_t (*rocprofiler_available_spm_configurations_cb_t)(
 ROCPROFILER_SDK_EXPERIMENTAL
 rocprofiler_status_t
 rocprofiler_spm_query_agent_configurations(rocprofiler_agent_id_t                        agent_id,
-                                           rocprofiler_available_spm_configurations_cb_t cb,
+                                           rocprofiler_spm_available_configurations_cb_t cb,
                                            void* user_data) ROCPROFILER_API ROCPROFILER_NONNULL(2);
 
 /**
@@ -130,6 +130,7 @@ typedef struct ROCPROFILER_SDK_EXPERIMENTAL rocprofiler_spm_parameters_t
  * @param [in] counters_list List of GPU counters
  * @param [in] counters_count Size of counters list
  * @param [in] parameters SPM parameter configuration
+ * @param [in] parameters_count Number of parameters
  * @param [in,out] config_id Identifier for GPU SPM counters group. If an existing
                    config is supplied, that counters will be copied
                    over to a new config (returned via this id)

--- a/projects/rocprofiler-sdk/source/include/rocprofiler-sdk/experimental/spm.h
+++ b/projects/rocprofiler-sdk/source/include/rocprofiler-sdk/experimental/spm.h
@@ -30,15 +30,6 @@
 ROCPROFILER_EXTERN_C_INIT
 
 /**
- * @brief SPM Profile Configurations
- * @see rocprofiler_spm_create_counter_config for how to create.
- */
-typedef struct ROCPROFILER_SDK_EXPERIMENTAL rocprofiler_spm_counter_config_id_t
-{
-    uint64_t handle;  ///< Opaque handle
-} rocprofiler_spm_counter_config_id_t;
-
-/**
  * @brief (experimental) SPM parameter type and value.
  *
  **/
@@ -49,7 +40,6 @@ typedef struct ROCPROFILER_SDK_EXPERIMENTAL rocprofiler_spm_configuration_t
                        ///< to determine sample interval.
     uint64_t buffer_size;  ///< Buffer size of user mode buffer in KB
     uint64_t timeout;      ///< Timeout for the user mode buffer in ms
-
 } rocprofiler_spm_configuration_t;
 
 /**
@@ -90,7 +80,7 @@ rocprofiler_spm_create_counter_config(rocprofiler_agent_id_t               agent
                                       rocprofiler_counter_id_t*            counters_list,
                                       size_t                               counters_count,
                                       rocprofiler_spm_configuration_t*     parameters,
-                                      rocprofiler_spm_counter_config_id_t* config_id)
+                                      rocprofiler_counter_config_id_t* config_id)
     ROCPROFILER_API ROCPROFILER_NONNULL(2);
 
 /**
@@ -99,11 +89,12 @@ rocprofiler_spm_create_counter_config(rocprofiler_agent_id_t               agent
  * @param [in] config_id
  * @return ::rocprofiler_status_t
  * @retval ROCPROFILER_STATUS_SUCCESS if config destroyed
+ * @retval ROCPROFILER_STATUS_ERROR_PROFILE_NOT_FOUND if the profile is not found
  * @retval ROCPROFILER_STATUS_ERROR if config could not be destroyed
  */
 ROCPROFILER_SDK_EXPERIMENTAL
 rocprofiler_status_t
-rocprofiler_spm_destroy_counter_config(rocprofiler_spm_counter_config_id_t config_id)
+rocprofiler_spm_destroy_counter_config(rocprofiler_counter_config_id_t config_id)
     ROCPROFILER_API;
 
 /**
@@ -112,10 +103,10 @@ rocprofiler_spm_destroy_counter_config(rocprofiler_spm_counter_config_id_t confi
  **/
 typedef enum ROCPROFILER_SDK_EXPERIMENTAL rocprofiler_spm_record_flag_t
 {
-    ROCPROFILER_SPM_RECORD_FLAG_DATA_LOST = 0,  ///< records with data loss
+    ROCPROFILER_SPM_RECORD_FLAG_DATA_NONE = 0,  ///< records with data loss
     ROCPROFILER_SPM_RECORD_FLAG_DATA,           ///< records with data
     ROCPROFILER_SPM_RECORD_FLAG_END,            ///< End of agent service
-    ROCPROFILER_SPM_RECORD_FLAG_DATA_NONE,      //< flag value none
+    ROCPROFILER_SPM_RECORD_FLAG_DATA_LOST,      ///< flag value none
     ROCPROFILER_SPM_RECORD_FLAG_LAST,
 } rocprofiler_spm_record_flag_t;
 
@@ -130,10 +121,6 @@ typedef struct ROCPROFILER_SDK_EXPERIMENTAL rocprofiler_spm_dispatch_counting_se
     rocprofiler_kernel_dispatch_info_t dispatch_info;   ///< Dispatch info
 } rocprofiler_spm_dispatch_counting_service_data_t;
 
-/**
- * @brief (experimental) SPM record counter record.
- *
- **/
 typedef struct ROCPROFILER_SDK_EXPERIMENTAL rocprofiler_spm_counter_record_t
 {
     uint64_t size;  ///< Size of this structure. Used for versioning and validation.
@@ -143,10 +130,30 @@ typedef struct ROCPROFILER_SDK_EXPERIMENTAL rocprofiler_spm_counter_record_t
     rocprofiler_agent_id_t            agent_id;   ///< Agent on which the record is collected
     rocprofiler_timestamp_t           timestamp;  ///< timestamp of the sample
     uint64_t value;  ///< SPM sample for the counter with counter instance id: id
+    /// @var id
+    /// @brief counter id, ROCPROFILER_DIMENSION_XCC, 
+    ///  ROCPROFILER_DIMENSION_INSTANCE, ROCPROFILER_DIMENSION_SHADER_ENGINE embedded in it
+    /// @var agent id 
+    /// @brief identifies the agent on which SPM data was collected
+    /// @var timestamp
+    /// @brief GPU timestamp when sample was collected
+    /// @var value
+    /// @brief sampled counter value
+    /// @var dispatch_id
+    /// @brief A value greater than zero indicates that this counter record is associated with a
+    /// specific dispatch.
+    ///
+    /// This value can be mapped to a dispatch via the `dispatch_info` field (@see
+    /// ::rocprofiler_kernel_dispatch_info_t) of a ::rocprofiler_spm_dispatch_counting_service_data_t
+    /// ::rocprofiler_spm_dispatch_counting_service_record_t records (which will be insert into the
+    /// buffer prior to the associated ::rocprofiler_spm_counter_record_t records).
 } rocprofiler_spm_counter_record_t;
 
 /**
- * @brief (experimental) Callback to receive SPM data
+ * @brief (experimental) Counting record callback. This is a callback is invoked when the kernel
+ *        execution is complete and contains the counter profile data requested in
+ *        ::rocprofiler_spm_dispatch_counting_service_cb_t. Only used with
+ *        ::rocprofiler_configure_callback_spm_dispatch_service
  *
  * @param [in] dispatch_data kernel dispatch data
  * @param [in] records array of pointers to the rocprofiler_spm_counter_record_t.
@@ -166,7 +173,11 @@ typedef void (*rocprofiler_spm_dispatch_counting_record_cb_t)(
     rocprofiler_user_data_t                                 userdata,
     void*                                                   record_callback_args);
 /**
- * @brief (experimental) Callback query if dispatch should be profiled
+ * @brief (experimental) Kernel Dispatch Callback. This is a callback that is invoked before the
+ * kernel is enqueued into the HSA queue. What counters to collect for a kernel are set via passing
+ * back a profile config (config) in this callback. These counters will be collected and emplaced in
+ * the buffer with ::rocprofiler_buffer_id_t used when setting up this callback or will be returned via 
+ * a callback used when setting up this callback
  *
  * @param [in] dispatch_data kernel dispatch data
  * @param [out] config  spm counter config
@@ -176,7 +187,7 @@ typedef void (*rocprofiler_spm_dispatch_counting_record_cb_t)(
 ROCPROFILER_SDK_EXPERIMENTAL
 typedef void (*rocprofiler_spm_dispatch_counting_service_cb_t)(
     const rocprofiler_spm_dispatch_counting_service_data_t* dispatch_data,
-    rocprofiler_spm_counter_config_id_t*                    config,
+    rocprofiler_counter_config_id_t*                    config,
     rocprofiler_user_data_t*                                user_data,
     void*                                                   callback_data_args);
 
@@ -197,7 +208,9 @@ rocprofiler_iterate_spm_supported_counters(rocprofiler_agent_id_t              a
                                            void* user_data) ROCPROFILER_API ROCPROFILER_NONNULL(2);
 
 /**
- * @brief (experimental) Configure SPM in dispatch monitoring mode
+ * @brief (experimental) Configure callback dispatch profile Counting Service.
+ *        Collects the counters in dispatch packets and calls a callback
+ *        with the counters collected during that dispatch.
  *
  * @param [in] context_id context id
  * @param [in] dispatch_callback callback to perform when dispatch is enqueued

--- a/projects/rocprofiler-sdk/source/include/rocprofiler-sdk/experimental/spm.h
+++ b/projects/rocprofiler-sdk/source/include/rocprofiler-sdk/experimental/spm.h
@@ -67,7 +67,6 @@ typedef struct ROCPROFILER_SDK_EXPERIMENTAL rocprofiler_spm_available_configurat
  * @param [in] num_config Number of configurations in the array
  * @param [in] user_data User data supplied by ::rocprofiler_spm_query_agent_configurations
  */
-
 ROCPROFILER_SDK_EXPERIMENTAL
 typedef rocprofiler_status_t (*rocprofiler_spm_available_configurations_cb_t)(
     const rocprofiler_spm_available_configuration_t** config,
@@ -87,7 +86,6 @@ typedef rocprofiler_status_t (*rocprofiler_spm_available_configurations_cb_t)(
  * @retval ROCPROFILER_STATUS_ERROR_AGENT_NOT_FOUND if agent not found
  * @retval ROCPROFILER_STATUS_ERROR_INCOMPATIBLE_ABI incompatible aqlprofile version is used
  **/
-
 ROCPROFILER_SDK_EXPERIMENTAL
 rocprofiler_status_t
 rocprofiler_spm_query_agent_configurations(rocprofiler_agent_id_t                        agent_id,
@@ -215,7 +213,6 @@ typedef struct ROCPROFILER_SDK_EXPERIMENTAL rocprofiler_spm_counter_record_t
  * @param [in] flags  rocprofiler_spm_record_flag_t
  * @param [in] userdata user data supplied by dispatch callback
  * @param [in] record Callback data supplied via dispatch configure service
-
  */
 ROCPROFILER_SDK_EXPERIMENTAL
 typedef void (*rocprofiler_spm_dispatch_counting_record_cb_t)(
@@ -225,6 +222,7 @@ typedef void (*rocprofiler_spm_dispatch_counting_record_cb_t)(
     rocprofiler_spm_record_flag_t                           flags,
     rocprofiler_user_data_t                                 userdata,
     void*                                                   record_callback_args);
+    
 /**
  * @brief (experimental) Kernel Dispatch Callback. This is a callback that is invoked before the
  * kernel is enqueued into the HSA queue. What counters to collect for a kernel are set via passing
@@ -280,7 +278,6 @@ rocprofiler_spm_iterate_agent_supported_counters(rocprofiler_agent_id_t         
  * @retval ROCPROFILER_STATUS_ERROR_CONTEXT_CONFLICT conflicting services being enabled in the
  * context
  */
-
 ROCPROFILER_SDK_EXPERIMENTAL rocprofiler_status_t
 rocprofiler_spm_configure_callback_dispatch_service(
     rocprofiler_context_id_t                       context_id,
@@ -310,7 +307,6 @@ rocprofiler_spm_configure_callback_dispatch_service(
  * @retval ROCPROFILER_STATUS_ERROR_NOT_IMPLEMENTED if the ROCPROFILER_SPM_BETA_ENABLED is not set
  * @retval ROCPROFILER_STATUS_ERROR_INCOMPATIBLE_ABI incompatible aqlprofile version is used
  */
-
 ROCPROFILER_SDK_EXPERIMENTAL rocprofiler_status_t
 rocprofiler_spm_configure_buffer_dispatch_service(
     rocprofiler_context_id_t                       context_id,

--- a/projects/rocprofiler-sdk/source/include/rocprofiler-sdk/experimental/spm.h
+++ b/projects/rocprofiler-sdk/source/include/rocprofiler-sdk/experimental/spm.h
@@ -222,7 +222,7 @@ typedef void (*rocprofiler_spm_dispatch_counting_record_cb_t)(
     rocprofiler_spm_record_flag_t                           flags,
     rocprofiler_user_data_t                                 userdata,
     void*                                                   record_callback_args);
-    
+
 /**
  * @brief (experimental) Kernel Dispatch Callback. This is a callback that is invoked before the
  * kernel is enqueued into the HSA queue. What counters to collect for a kernel are set via passing

--- a/projects/rocprofiler-sdk/source/include/rocprofiler-sdk/experimental/spm.h
+++ b/projects/rocprofiler-sdk/source/include/rocprofiler-sdk/experimental/spm.h
@@ -129,7 +129,7 @@ typedef struct ROCPROFILER_SDK_EXPERIMENTAL rocprofiler_spm_counter_record_t
     rocprofiler_counter_instance_id_t id;         ///< Counter instance id
     rocprofiler_agent_id_t            agent_id;   ///< Agent on which the record is collected
     rocprofiler_timestamp_t           timestamp;  ///< timestamp of the sample
-    uint64_t value;  ///< SPM sample for the counter with counter instance id: id
+    double value;  ///< SPM sample for the counter with counter instance id: id
     /// @var id
     /// @brief counter id, ROCPROFILER_DIMENSION_XCC, 
     ///  ROCPROFILER_DIMENSION_INSTANCE, ROCPROFILER_DIMENSION_SHADER_ENGINE embedded in it

--- a/projects/rocprofiler-sdk/source/include/rocprofiler-sdk/experimental/spm.h
+++ b/projects/rocprofiler-sdk/source/include/rocprofiler-sdk/experimental/spm.h
@@ -36,18 +36,19 @@ typedef enum ROCPROFILER_SDK_EXPERIMENTAL rocprofiler_spm_parameter_type_t
 {
     ROCPROFILER_SPM_PARAMETER_TYPE_NONE = 0,
     ROCPROFILER_SPM_PARAMETER_TYPE_SAMPLE_INTERVAL_SCLK_CYCLES,
+    ROCPROFILER_SPM_PARAMETER_TYPE_LAST,
 } rocprofiler_spm_parameter_type_t;
 
 /**
  * @brief (experimental) Describes an available SPM configuration for an agent.
  *
- * Returned via ::rocprofiler_query_agent_spm_configurations to describe the
+ * Returned via ::rocprofiler_spm_query_agent_configurations to describe the
  * supported SPM parameter types and their valid value ranges for a given agent.
  **/
-typedef struct ROCPROFILER_SDK_EXPERIMENTAL rocprofiler_available_spm_configuration_t
+typedef struct ROCPROFILER_SDK_EXPERIMENTAL rocprofiler_spm_available_configuration_t
 {
-    uint64_t                         size;          ///< Size of this struct
-    rocprofiler_spm_parameter_type_t type;          ///< The SPM parameter type
+    uint64_t                         size;  ///< Size of this struct
+    rocprofiler_spm_parameter_type_t type;  ///< The SPM parameter type; used to tag the union below
     union
     {
         struct
@@ -56,7 +57,7 @@ typedef struct ROCPROFILER_SDK_EXPERIMENTAL rocprofiler_available_spm_configurat
             uint64_t max_interval;  ///< Maximum supported value for this parameter
         } interval;                 ///< Interval configuration for sample interval parameter types
     };
-} rocprofiler_available_spm_configuration_t;
+} rocprofiler_spm_available_configuration_t;
 
 /**
  * @brief (experimental) Callback that provides the available SPM configurations for an agent.
@@ -64,12 +65,12 @@ typedef struct ROCPROFILER_SDK_EXPERIMENTAL rocprofiler_available_spm_configurat
  *
  * @param [in] config Array of pointers to available SPM configurations
  * @param [in] num_config Number of configurations in the array
- * @param [in] user_data User data supplied by ::rocprofiler_query_agent_spm_configurations
+ * @param [in] user_data User data supplied by ::rocprofiler_spm_query_agent_configurations
  */
 
 ROCPROFILER_SDK_EXPERIMENTAL
 typedef rocprofiler_status_t (*rocprofiler_available_spm_configurations_cb_t)(
-    const rocprofiler_available_spm_configuration_t** config,
+    const rocprofiler_spm_available_configuration_t** config,
     size_t                                            num_config,
     void*                                             user_data);
 
@@ -89,15 +90,15 @@ typedef rocprofiler_status_t (*rocprofiler_available_spm_configurations_cb_t)(
 
 ROCPROFILER_SDK_EXPERIMENTAL
 rocprofiler_status_t
-rocprofiler_query_agent_spm_configurations(rocprofiler_agent_id_t                        agent_id,
+rocprofiler_spm_query_agent_configurations(rocprofiler_agent_id_t                        agent_id,
                                            rocprofiler_available_spm_configurations_cb_t cb,
                                            void* user_data) ROCPROFILER_API ROCPROFILER_NONNULL(2);
 
 /**
  * @brief (experimental) SPM configuration parameter used to configure sampling behavior.
  *
- * Passed to ::rocprofiler_create_spm_counter_config to specify SPM sampling parameters.
- * Supported configurations can be queried via ::rocprofiler_query_agent_spm_configurations.
+ * Passed to ::rocprofiler_spm_create_counter_config to specify SPM sampling parameters.
+ * Supported configurations can be queried via ::rocprofiler_spm_query_agent_configurations.
  * @var size
  * @brief Size of this struct.
  *
@@ -119,7 +120,7 @@ typedef struct ROCPROFILER_SDK_EXPERIMENTAL rocprofiler_spm_parameters_t
  *        be used across many contexts. The config has a fixed set of counters
  *        that are collected (and specified by counter_list) and parameters. The available
  *        counters for an agent can be queried using
- *        ::rocprofiler_iterate_agent_spm_supported_counters. An existing config
+ *        ::rocprofiler_spm_iterate_agent_supported_counters. An existing config
  *        may be supplied via config_id to use as a base for the new config.
  *        All counters in the existing config will be copied over to the new
  *        config. The existing config will remain unmodified and usable with
@@ -145,7 +146,7 @@ typedef struct ROCPROFILER_SDK_EXPERIMENTAL rocprofiler_spm_parameters_t
  */
 ROCPROFILER_SDK_EXPERIMENTAL
 rocprofiler_status_t
-rocprofiler_create_spm_counter_config(rocprofiler_agent_id_t           agent_id,
+rocprofiler_spm_create_counter_config(rocprofiler_agent_id_t           agent_id,
                                       rocprofiler_counter_id_t*        counters_list,
                                       size_t                           counters_count,
                                       rocprofiler_spm_parameters_t**   parameters,
@@ -164,7 +165,7 @@ rocprofiler_create_spm_counter_config(rocprofiler_agent_id_t           agent_id,
  */
 ROCPROFILER_SDK_EXPERIMENTAL
 rocprofiler_status_t
-rocprofiler_destroy_spm_counter_config(rocprofiler_counter_config_id_t config_id) ROCPROFILER_API;
+rocprofiler_spm_destroy_counter_config(rocprofiler_counter_config_id_t config_id) ROCPROFILER_API;
 
 /**
  * @brief (experimental) SPM record flags.
@@ -172,9 +173,9 @@ rocprofiler_destroy_spm_counter_config(rocprofiler_counter_config_id_t config_id
  **/
 typedef enum ROCPROFILER_SDK_EXPERIMENTAL rocprofiler_spm_record_flag_t
 {
-    ROCPROFILER_SPM_RECORD_FLAG_NONE      = 0,      ///< flag value none
-    ROCPROFILER_SPM_RECORD_FLAG_DATA      = 1 << 0, ///< records with data
-    ROCPROFILER_SPM_RECORD_FLAG_DATA_LOSS = 1 << 1, ///< records with data loss
+    ROCPROFILER_SPM_RECORD_FLAG_NONE      = 0,       ///< flag value none
+    ROCPROFILER_SPM_RECORD_FLAG_DATA      = 1 << 0,  ///< records with data
+    ROCPROFILER_SPM_RECORD_FLAG_DATA_LOSS = 1 << 1,  ///< records with data loss
     ROCPROFILER_SPM_RECORD_FLAG_LAST      = 1 << 2,
 } rocprofiler_spm_record_flag_t;
 
@@ -204,7 +205,7 @@ typedef struct ROCPROFILER_SDK_EXPERIMENTAL rocprofiler_spm_counter_record_t
  * @brief (experimental) Counting record callback. This is a callback is invoked when the kernel
  *        execution is complete and contains the counter profile data requested in
  *        ::rocprofiler_spm_dispatch_counting_service_cb_t. Only used with
- *        ::rocprofiler_configure_callback_spm_dispatch_service
+ *        ::rocprofiler_spm_configure_callback_dispatch_service
  *
  * @param [in] dispatch_data kernel dispatch data
  * @param [in] records array of pointers to the rocprofiler_spm_counter_record_t.
@@ -255,9 +256,10 @@ typedef void (*rocprofiler_spm_dispatch_counting_service_cb_t)(
  * @retval ROCPROFILER_STATUS_ERROR_AGENT_ARCH_NOT_SUPPORTED agent has no supported SPM counter
  */
 ROCPROFILER_SDK_EXPERIMENTAL rocprofiler_status_t
-rocprofiler_iterate_agent_spm_supported_counters(rocprofiler_agent_id_t              agent_id,
-                                           rocprofiler_available_counters_cb_t cb,
-                                           void* user_data) ROCPROFILER_API ROCPROFILER_NONNULL(2);
+rocprofiler_spm_iterate_agent_supported_counters(rocprofiler_agent_id_t              agent_id,
+                                                 rocprofiler_available_counters_cb_t cb,
+                                                 void* user_data) ROCPROFILER_API
+    ROCPROFILER_NONNULL(2);
 
 /**
  * @brief (experimental) Configure callback dispatch profile Counting Service.
@@ -279,7 +281,7 @@ rocprofiler_iterate_agent_spm_supported_counters(rocprofiler_agent_id_t         
  */
 
 ROCPROFILER_SDK_EXPERIMENTAL rocprofiler_status_t
-rocprofiler_configure_callback_spm_dispatch_service(
+rocprofiler_spm_configure_callback_dispatch_service(
     rocprofiler_context_id_t                       context_id,
     rocprofiler_spm_dispatch_counting_service_cb_t dispatch_callback,
     void*                                          dispatch_callback_args,
@@ -309,7 +311,7 @@ rocprofiler_configure_callback_spm_dispatch_service(
  */
 
 ROCPROFILER_SDK_EXPERIMENTAL rocprofiler_status_t
-rocprofiler_configure_buffer_spm_dispatch_service(
+rocprofiler_spm_configure_buffer_dispatch_service(
     rocprofiler_context_id_t                       context_id,
     rocprofiler_buffer_id_t                        buffer_id,
     rocprofiler_spm_dispatch_counting_service_cb_t callback,

--- a/projects/rocprofiler-sdk/source/include/rocprofiler-sdk/experimental/spm.h
+++ b/projects/rocprofiler-sdk/source/include/rocprofiler-sdk/experimental/spm.h
@@ -1,0 +1,256 @@
+// MIT License
+//
+// Copyright (c) 2025 Advanced Micro Devices, Inc. All rights reserved.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#pragma once
+
+#include <rocprofiler-sdk/agent.h>
+#include <rocprofiler-sdk/counters.h>
+#include <rocprofiler-sdk/defines.h>
+#include <rocprofiler-sdk/fwd.h>
+
+ROCPROFILER_EXTERN_C_INIT
+
+/**
+ * @brief SPM Profile Configurations
+ * @see rocprofiler_spm_create_counter_config for how to create.
+ */
+typedef struct ROCPROFILER_SDK_EXPERIMENTAL rocprofiler_spm_counter_config_id_t
+{
+    uint64_t handle;  ///< Opaque handle
+} rocprofiler_spm_counter_config_id_t;
+
+/**
+ * @brief (experimental) SPM parameter type and value.
+ *
+ **/
+typedef struct ROCPROFILER_SDK_EXPERIMENTAL rocprofiler_spm_configuration_t
+{
+    size_t size;       ///< Size of this struct
+    double frequency;  ///< Input frequency (in GHz) is estimated to number of scclock count. Used
+                       ///< to determine sample interval.
+    uint64_t buffer_size;  ///< Buffer size of user mode buffer in KB
+    uint64_t timeout;      ///< Timeout for the user mode buffer in ms
+
+} rocprofiler_spm_configuration_t;
+
+/**
+ * @brief (experimental) Create SPM Counter Configuration. A config is bound to an agent but can
+ *        be used across many contexts. The config has a fixed set of counters
+ *        that are collected (and specified by counter_list) and parameters. The available
+ *        counters for an agent can be queried using
+ *        ::rocprofiler_iterate_spm_supported_counters. An existing config
+ *        may be supplied via config_id to use as a base for the new config.
+ *        All counters and parameters in the existing config will be copied over to the new
+ *        config. The existing config will remain unmodified and usable with
+ *        the new config id being returned in config_id.
+ *
+ * @param [in] agent_id Agent identifier
+ * @param [in] counters_list List of GPU counters
+ * @param [in] counters_count Size of counters list
+ * @param [in] parameters SPM parameter configuration
+ * @param [in,out] config_id Identifier for GPU SPM counters group. If an existing
+                   config is supplied, that profiles counters and parameters will be copied
+                   over to a new config (returned via this id)
+ * @return ::rocprofiler_status_t
+ * @retval ROCPROFILER_STATUS_SUCCESS if config created
+ * @retval ROCPROFILER_STATUS_ERROR if config could not be created
+ * @retval ROCPROFILER_STATUS_ERROR_METRIC_NOT_VALID_FOR_AGENT if agent does not support an input
+ counter
+ * @retval ROCPROFILER_STATUS_ERROR_INVALID_ARGUMENT if counters count is zero and no existing
+ config is supplied
+ * @retval ROCPROFILER_STATUS_ERROR_INCOMPATIBLE_ABI incompatible aqlprofile version is used
+ * @retval ROCPROFILER_STATUS_ERROR_NOT_IMPLEMENTED if the ROCPROFILER_SPM_BETA_ENABLED is not set
+ * @retval ROCPROFILER_STATUS_ERROR_EXCEEDS_HW_LIMIT if input counters exceed the hardware limit
+ * @retval ROCPROFILER_STATUS_ERROR_AGENT_NOT_FOUND if agent not found
+ * @retval ROCPROFILER_STATUS_ERROR_COUNTER_NOT_FOUND if an input counter is not found in metrics
+ file
+ */
+ROCPROFILER_SDK_EXPERIMENTAL
+rocprofiler_status_t
+rocprofiler_spm_create_counter_config(rocprofiler_agent_id_t               agent_id,
+                                      rocprofiler_counter_id_t*            counters_list,
+                                      size_t                               counters_count,
+                                      rocprofiler_spm_configuration_t*     parameters,
+                                      rocprofiler_spm_counter_config_id_t* config_id)
+    ROCPROFILER_API ROCPROFILER_NONNULL(2);
+
+/**
+ * @brief (experimental) Destroy SPM Profile Configuration.
+ *
+ * @param [in] config_id
+ * @return ::rocprofiler_status_t
+ * @retval ROCPROFILER_STATUS_SUCCESS if config destroyed
+ * @retval ROCPROFILER_STATUS_ERROR if config could not be destroyed
+ */
+ROCPROFILER_SDK_EXPERIMENTAL
+rocprofiler_status_t
+rocprofiler_spm_destroy_counter_config(rocprofiler_spm_counter_config_id_t config_id)
+    ROCPROFILER_API;
+
+/**
+ * @brief (experimental) SPM record flags.
+ *
+ **/
+typedef enum ROCPROFILER_SDK_EXPERIMENTAL rocprofiler_spm_record_flag_t
+{
+    ROCPROFILER_SPM_RECORD_FLAG_DATA_LOST = 0,  ///< records with data loss
+    ROCPROFILER_SPM_RECORD_FLAG_DATA,           ///< records with data
+    ROCPROFILER_SPM_RECORD_FLAG_END,            ///< End of agent service
+    ROCPROFILER_SPM_RECORD_FLAG_DATA_NONE,      //< flag value none
+    ROCPROFILER_SPM_RECORD_FLAG_LAST,
+} rocprofiler_spm_record_flag_t;
+
+/**
+ * @brief (experimental) Kernel dispatch data for profile counting callbacks.
+ *
+ */
+typedef struct ROCPROFILER_SDK_EXPERIMENTAL rocprofiler_spm_dispatch_counting_service_data_t
+{
+    uint64_t                           size;            ///< Size of this struct
+    rocprofiler_async_correlation_id_t correlation_id;  ///< Correlation ID for this dispatch
+    rocprofiler_kernel_dispatch_info_t dispatch_info;   ///< Dispatch info
+} rocprofiler_spm_dispatch_counting_service_data_t;
+
+/**
+ * @brief (experimental) SPM record counter record.
+ *
+ **/
+typedef struct ROCPROFILER_SDK_EXPERIMENTAL rocprofiler_spm_counter_record_t
+{
+    uint64_t size;  ///< Size of this structure. Used for versioning and validation.
+    rocprofiler_dispatch_id_t
+        dispatch_id;  ///< dispatch id used to determine the dispatch this record belongs to.
+    rocprofiler_counter_instance_id_t id;         ///< Counter instance id
+    rocprofiler_agent_id_t            agent_id;   ///< Agent on which the record is collected
+    rocprofiler_timestamp_t           timestamp;  ///< timestamp of the sample
+    uint64_t value;  ///< SPM sample for the counter with counter instance id: id
+} rocprofiler_spm_counter_record_t;
+
+/**
+ * @brief (experimental) Callback to receive SPM data
+ *
+ * @param [in] dispatch_data kernel dispatch data
+ * @param [in] records array of pointers to the rocprofiler_spm_counter_record_t.
+          Memory of records is managed by the SDK. It is valid only within this callback
+ * @param [in] record_count  size of the record array
+ * @param [in] flags  rocprofiler_spm_record_flag_t
+ * @param [in] userdata user data supplied by dispatch callback
+ * @param [in] record Callback data supplied via dispatch configure service
+
+ */
+ROCPROFILER_SDK_EXPERIMENTAL
+typedef void (*rocprofiler_spm_dispatch_counting_record_cb_t)(
+    const rocprofiler_spm_dispatch_counting_service_data_t* dispatch_data,
+    const rocprofiler_spm_counter_record_t**                records,
+    size_t                                                  record_count,
+    int                                                     flags,
+    rocprofiler_user_data_t                                 userdata,
+    void*                                                   record_callback_args);
+/**
+ * @brief (experimental) Callback query if dispatch should be profiled
+ *
+ * @param [in] dispatch_data kernel dispatch data
+ * @param [out] config  spm counter config
+ * @param [out] user_data User data unique to this dispatch. Returned in record callback
+ * @param [in] callback_data_args Callback supplied via dispatch configure service
+ */
+ROCPROFILER_SDK_EXPERIMENTAL
+typedef void (*rocprofiler_spm_dispatch_counting_service_cb_t)(
+    const rocprofiler_spm_dispatch_counting_service_data_t* dispatch_data,
+    rocprofiler_spm_counter_config_id_t*                    config,
+    rocprofiler_user_data_t*                                user_data,
+    void*                                                   callback_data_args);
+
+/**
+ * @brief (experimental) Query Agent SPM Counters Availability.
+ *
+ * @param [in] agent_id GPU agent identifier
+ * @param [in] cb callback to caller to get counters
+ * @param [in] user_data data to pass into the callback
+ * @return ::rocprofiler_status_t
+ * @retval ROCPROFILER_STATUS_SUCCESS if all counters found for agent
+ * @retval ROCPROFILER_STATUS_ERROR_AGENT_NOT_FOUND invalid agent
+ * @retval ROCPROFILER_STATUS_ERROR_AGENT_ARCH_NOT_SUPPORTED agent has no supported SPM counter
+ */
+ROCPROFILER_SDK_EXPERIMENTAL rocprofiler_status_t
+rocprofiler_iterate_spm_supported_counters(rocprofiler_agent_id_t              agent_id,
+                                           rocprofiler_available_counters_cb_t cb,
+                                           void* user_data) ROCPROFILER_API ROCPROFILER_NONNULL(2);
+
+/**
+ * @brief (experimental) Configure SPM in dispatch monitoring mode
+ *
+ * @param [in] context_id context id
+ * @param [in] dispatch_callback callback to perform when dispatch is enqueued
+ * @param [in] dispatch_callback_args callback data for dispatch callback
+ * @param [in] record_callback  Record callback for completed profile data
+ * @param [in] record_callback_args Callback args for record callback
+ * @return ::rocprofiler_status_t
+ *
+ * @return ::rocprofiler_status_t
+ * @retval ROCPROFILER_STATUS_SUCCESS if the context can be configured for SPM dispatch service
+ * @retval ROCPROFILER_STATUS_ERROR if the context cannot be configured for SPM dispatch service
+ * @retval ROCPROFILER_STATUS_ERROR_NOT_IMPLEMENTED if the ROCPROFILER_SPM_BETA_ENABLED is not set
+ * @retval ROCPROFILER_STATUS_ERROR_CONFIGURATION_LOCKED for configuration locked
+ * @retval ROCPROFILER_STATUS_ERROR_INCOMPATIBLE_ABI incompatible aqlprofile version is used
+ * @retval ROCPROFILER_STATUS_ERROR_CONTEXT_INVALID invalid input context has not already been
+ * created
+ * @retval ROCPROFILER_STATUS_ERROR_CONTEXT_CONFLICT conflicting services being enabled in the
+ * context
+ */
+
+ROCPROFILER_SDK_EXPERIMENTAL rocprofiler_status_t
+rocprofiler_configure_callback_spm_dispatch_service(
+    rocprofiler_context_id_t                       context_id,
+    rocprofiler_spm_dispatch_counting_service_cb_t dispatch_callback,
+    void*                                          dispatch_callback_args,
+    rocprofiler_spm_dispatch_counting_record_cb_t  record_callback,
+    void* record_callback_args) ROCPROFILER_API ROCPROFILER_NONNULL(2, 4);
+;
+
+/**
+ * @brief (experimental) Configure buffered dispatch spm service.
+ *        Collects the counters in dispatch packets and stores them
+ *        in a buffer with @p buffer_id. The buffer may contain packets from more than
+ *        one dispatch (denoted by correlation id). Will trigger the
+ *        callback based on the parameters setup in buffer_id_t.
+ *
+ * @param [in] context_id context id
+ * @param [in] buffer_id id of the buffer to use for the counting service
+ * @param [in] callback callback to perform when dispatch is enqueued
+ * @param [in] callback_data_args callback data
+ * @return ::rocprofiler_status_t
+ * @retval ROCPROFILER_STATUS_ERROR_BUFFER_NOT_FOUND
+ * @retval ROCPROFILER_STATUS_ERROR_CONTEXT_INVALID invalid input context has not already been
+ * @retval ROCPROFILER_STATUS_ERROR_AGENT_DISPATCH_CONFLICT
+ * @retval ROCPROFILER_STATUS_SUCCESS if the context can be configured for SPM buffer dispatch
+ * service
+ */
+
+rocprofiler_status_t
+rocprofiler_configure_buffer_spm_dispatch_service(
+    rocprofiler_context_id_t                       context_id,
+    rocprofiler_buffer_id_t                        buffer_id,
+    rocprofiler_spm_dispatch_counting_service_cb_t callback,
+    void* callback_data_args) ROCPROFILER_API ROCPROFILER_NONNULL(3);
+
+ROCPROFILER_EXTERN_C_FINI

--- a/projects/rocprofiler-sdk/source/include/rocprofiler-sdk/spm.h
+++ b/projects/rocprofiler-sdk/source/include/rocprofiler-sdk/spm.h
@@ -22,48 +22,8 @@
 
 #pragma once
 
-#include <rocprofiler-sdk/defines.h>
-#include <rocprofiler-sdk/fwd.h>
+#if defined(ROCPROFILER_SDK_EXPERIMENTAL_WARNINGS)
+#    warning "rocprofiler-sdk/experimental/spm.h should be included for now"
+#endif
 
-ROCPROFILER_EXTERN_C_INIT
-
-/**
- * @defgroup SPM_SERVICE SPM Service
- * @brief Streaming Performance Monitoring
- *
- * @{
- */
-
-/**
- * @brief (experimental) ROCProfiler SPM Record.
- *
- */
-typedef struct ROCPROFILER_SDK_EXPERIMENTAL rocprofiler_spm_record_t
-{
-    /**
-     * Counters, including identifiers to get counter information and Counters
-     * values
-     */
-    rocprofiler_counter_record_t* counters;
-    uint64_t                      counters_count;
-} rocprofiler_spm_record_t;
-
-/**
- * @brief Configure SPM Service.
- *
- * @param [in] context_id
- * @param [in] buffer_id
- * @param [in] counter_config
- * @param [in] interval
- * @return ::rocprofiler_status_t
- */
-ROCPROFILER_SDK_EXPERIMENTAL
-rocprofiler_status_t
-rocprofiler_configure_spm_service(rocprofiler_context_id_t        context_id,
-                                  rocprofiler_buffer_id_t         buffer_id,
-                                  rocprofiler_counter_config_id_t counter_config,
-                                  uint64_t                        interval) ROCPROFILER_API;
-
-/** @} */
-
-ROCPROFILER_EXTERN_C_FINI
+#include <rocprofiler-sdk/experimental/spm.h>


### PR DESCRIPTION
## Motivation

 Add SPM experimental public API header

## Technical Details

The new header has declarations:

1.   Config types: rocprofiler_spm_counter_config_id_t, rocprofiler_spm_configuration_t 
2.    Record types: rocprofiler_spm_record_flag_t, rocprofiler_spm_dispatch_counting_service_data_t, rocprofiler_spm_counter_record_t
3.    Callbacks: rocprofiler_spm_dispatch_counting_record_cb_t, rocprofiler_spm_dispatch_counting_service_cb_t
4.   API functions: rocprofiler_spm_create_counter_config, rocprofiler_spm_destroy_counter_config, rocprofiler_spm_iterate_agent_supported_counters, rocprofiler_spm_configure_buffer_dispatch_service, rocprofiler_spm_configure_callback_dispatch_service

## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan

Existing tests should pass

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
