### PR TITLE
Add level-based test parameter infrastructure

### DIFF
--- a/projects/hip-tests/catch/config/CMakeLists.txt
+++ b/projects/hip-tests/catch/config/CMakeLists.txt
@@ -28,6 +28,7 @@ set(CONFIG_PARSER_SCRIPT ${CMAKE_CURRENT_SOURCE_DIR}/parse_config.py)
 set(CONFIG_CHECK_SCRIPT ${CMAKE_CURRENT_SOURCE_DIR}/check_config.py)
 set(SOURCES_CHECK_SCRIPT ${CMAKE_CURRENT_SOURCE_DIR}/check_sources.py)
 set(HIP_TESTS_CONFIG_HEADER ${CATCH_INCLUDE_BINARY_DIR}/hip_tests_config.hh)
+set(HIP_TEST_PARAMETERS_HEADER ${CATCH_INCLUDE_BINARY_DIR}/hip_test_parameters.hh)
 
 file(GLOB HIP_TESTS_GROUP_CONFIGS ${HIP_TESTS_CONFIGS_DIR}/*.yaml)
 file(GLOB HIP_TESTS_UNIT_CONFIGS ${HIP_TESTS_CONFIGS_DIR}/unit/*.yaml)
@@ -42,14 +43,23 @@ add_custom_target(check_hip_tests_sources ALL
     COMMENT "Checking hip-tests sources for missing YAML configurations"
 )
 
+# Generate both test definitions and parameter headers from YAML
+# - hip_tests_config.hh: TEST_CASE macros with tags
+# - hip_test_parameters.hh: Compile-time constants for level parameters
 add_custom_command(
-    OUTPUT ${HIP_TESTS_CONFIG_HEADER}
-    COMMAND "${Python3_EXECUTABLE}" "${CONFIG_PARSER_SCRIPT}" "${HIP_TESTS_CONFIGS_DIR}" "${HIP_PLATFORM}" "${CONFIG_OS}" "${CONFIG_ARCH}" "${HIP_TESTS_CONFIG_HEADER}"
+    OUTPUT ${HIP_TESTS_CONFIG_HEADER} ${HIP_TEST_PARAMETERS_HEADER}
+    COMMAND "${Python3_EXECUTABLE}" "${CONFIG_PARSER_SCRIPT}"
+            "${HIP_TESTS_CONFIGS_DIR}"
+            "${HIP_PLATFORM}"
+            "${CONFIG_OS}"
+            "${CONFIG_ARCH}"
+            "${HIP_TESTS_CONFIG_HEADER}"
+            "${HIP_TEST_PARAMETERS_HEADER}"
     DEPENDS ${CONFIG_COMMON_MODULE} ${CONFIG_PARSER_SCRIPT} ${HIP_TESTS_UNIT_CONFIGS} ${HIP_TESTS_GROUP_CONFIGS}
-    COMMENT "Generating hip_tests_config.hh"
+    COMMENT "Generating hip_tests_config.hh and hip_test_parameters.hh"
 )
 
-# Ensure the generated header file is built before the main target
-add_custom_target(hip_tests_config DEPENDS ${HIP_TESTS_CONFIG_HEADER})
+# Ensure the generated header files are built before the main target
+add_custom_target(hip_tests_config DEPENDS ${HIP_TESTS_CONFIG_HEADER} ${HIP_TEST_PARAMETERS_HEADER})
 add_dependencies(hip_tests_config check_hip_tests_config check_hip_tests_sources)
-set_source_files_properties(${HIP_TESTS_CONFIG_HEADER} PROPERTIES GENERATED TRUE)
+set_source_files_properties(${HIP_TESTS_CONFIG_HEADER} ${HIP_TEST_PARAMETERS_HEADER} PROPERTIES GENERATED TRUE)

--- a/projects/hip-tests/catch/config/common.py
+++ b/projects/hip-tests/catch/config/common.py
@@ -45,7 +45,7 @@ def load_definitions(config_path):
     Returns:
         Dict with 'definitions' and 'cmd_options' keys
     """
-    definitions_path = os.path.join(config_path, "configs", "definitions.yaml")
+    definitions_path = os.path.join(config_path, "definitions.yaml")
     with open(definitions_path) as file:
         return yaml.safe_load(file)
 

--- a/projects/hip-tests/catch/config/common.py
+++ b/projects/hip-tests/catch/config/common.py
@@ -14,6 +14,42 @@ NON_UNIT_GROUPS = [
 ]
 
 
+def parse_size_string(size_str):
+    """Convert size string (1K, 1M, 1G) to bytes.
+    
+    Args:
+        size_str: Size as string ("1K", "1M", "1G") or int
+        
+    Returns:
+        Size in bytes as integer
+    """
+    # Handle integers directly (YAML may parse numbers as int)
+    if isinstance(size_str, int):
+        return size_str
+    
+    size_str = str(size_str).strip().upper()
+    multipliers = {'K': 1024, 'M': 1024*1024, 'G': 1024*1024*1024}
+    
+    for suffix, multiplier in multipliers.items():
+        if size_str.endswith(suffix):
+            return int(float(size_str[:-1]) * multiplier)
+    return int(size_str)
+
+
+def load_definitions(config_path):
+    """Load definitions.yaml and return the full config including cmd_options.
+    
+    Args:
+        config_path: Path to the config directory (containing configs/)
+        
+    Returns:
+        Dict with 'definitions' and 'cmd_options' keys
+    """
+    definitions_path = os.path.join(config_path, "configs", "definitions.yaml")
+    with open(definitions_path) as file:
+        return yaml.safe_load(file)
+
+
 def load_config(file_path, definitions_text):
     with open(file_path) as file:
         content = file.read()

--- a/projects/hip-tests/catch/config/configs/definitions.yaml
+++ b/projects/hip-tests/catch/config/configs/definitions.yaml
@@ -8,5 +8,65 @@ definitions:
     level: 2
   level_3: &level_3
     level: 3
-  level_5: &level_5
-    level: 5
+  level_4: &level_4
+    level: 4
+
+# ==============================================================================
+# LEVEL PARAMETERS - Test parameters for each level
+# These are converted to C++ compile-time constants at build time
+# ==============================================================================
+cmd_options:
+  # Level 0 - Quick/Smoke Tests
+  # Use case: PR validation, quick sanity checks
+  # Runtime: seconds
+  level_0:
+    memory_sizes: [1K, 1M, 10M]
+    block_sizes: [64, 256]
+    iterations: 100
+    warmups: 10
+    max_memory: 1G
+    reduction_factor: 0.1
+
+  # Level 1 - Standard Tests
+  # Use case: Nightly CI, regular regression testing
+  # Runtime: minutes
+  level_1:
+    memory_sizes: [1K, 4K, 64K, 1M, 10M, 50M, 100M]
+    block_sizes: [32, 64, 128, 256, 512, 1024]
+    iterations: 1000
+    warmups: 100
+    max_memory: 4G
+    reduction_factor: 0.1
+
+  # Level 2 - Comprehensive Tests
+  # Use case: Release validation, full coverage
+  # Runtime: hours
+  level_2:
+    memory_sizes: [64, 256, 1K, 4K, 16K, 64K, 256K, 1M, 10M, 50M, 100M, 500M, 1G, 2G]
+    block_sizes: [32, 64, 96, 128, 192, 256, 384, 512, 768, 1024]
+    iterations: 5
+    warmups: 5
+    max_memory: 8G
+    reduction_factor: 0.1
+
+  # Level 3 - Performance/Stress Tests
+  # Use case: Benchmarks, stress testing
+  # Runtime: variable
+  level_3:
+    memory_sizes: [100M, 1G, 2G]
+    block_sizes: [256, 512, 1024]
+    iterations: 5
+    warmups: 5
+    max_memory: 2G
+    reduction_factor: 100
+
+  # Level 4 - Extended Stress Tests
+  # Use case: Full system stress, extended validation
+  # Runtime: hours
+  level_4:
+    memory_sizes: [256M, 512M, 1G, 2G, 4G]
+    block_sizes: [256, 512, 1024]
+    iterations: 10
+    warmups: 5
+    max_memory: 4G
+    reduction_factor: 100

--- a/projects/hip-tests/catch/config/configs/definitions.yaml
+++ b/projects/hip-tests/catch/config/configs/definitions.yaml
@@ -14,10 +14,13 @@ definitions:
 # ==============================================================================
 # LEVEL PARAMETERS - Test parameters for each level
 # These are converted to C++ compile-time constants at build time
+# [TODO] Add description of each parameter and its purpose
+# [TODO] Add default values for each parameter
+# The values below are example defaults and should be replaced with the actual values.
 # ==============================================================================
 cmd_options:
   # Level 0 - Quick/Smoke Tests
-  # Use case: PR validation, quick sanity checks
+  # Use case: Emulation environment, PR validation, quick sanity checks
   # Runtime: seconds
   level_0:
     memory_sizes: [1K, 1M, 10M]

--- a/projects/hip-tests/catch/config/parse_config.py
+++ b/projects/hip-tests/catch/config/parse_config.py
@@ -1,6 +1,6 @@
 import argparse
 
-from common import iter_group_configs
+from common import iter_group_configs, load_definitions, parse_size_string
 
 
 def parse_args():
@@ -28,6 +28,12 @@ def parse_args():
         "header_path",
         help="Output path for the generated header file.",
     )
+    parser.add_argument(
+        "param_header_path",
+        nargs="?",
+        default=None,
+        help="Optional output path for the generated parameter header file.",
+    )
     return parser.parse_args()
 
 
@@ -50,6 +56,101 @@ def create_test_definition(group, case_name, case_config, platform, os_name, arc
     return f'#define {case_name} "{case_name}", "{tags_str}"'
 
 
+def generate_parameter_header(cmd_options, output_path):
+    """Generate C++ header with compile-time parameter constants.
+    
+    Args:
+        cmd_options: Dict of level_name -> parameters from definitions.yaml
+        output_path: Path to write hip_test_parameters.hh
+    """
+    with open(output_path, 'w') as f:
+        f.write("// Auto-generated from definitions.yaml\n")
+        f.write("// DO NOT EDIT - This file is generated at build time\n")
+        f.write("// Contains compile-time test parameters for each level\n\n")
+        f.write("#pragma once\n\n")
+        f.write("#include <vector>\n")
+        f.write("#include <cstddef>\n")
+        f.write("#include <string>\n")
+        f.write("#include <map>\n\n")
+        
+        f.write("namespace TestParameters {\n\n")
+        
+        levels_found = []
+        
+        for level_name, options in cmd_options.items():
+            levels_found.append(level_name)
+            f.write(f"// {'=' * 76}\n")
+            f.write(f"// {level_name.upper()} PARAMETERS\n")
+            f.write(f"// {'=' * 76}\n\n")
+            
+            # Memory sizes
+            if "memory_sizes" in options:
+                sizes = [parse_size_string(s) for s in options["memory_sizes"]]
+                f.write(f"inline const std::vector<size_t> {level_name}_memory_sizes = {{\n")
+                f.write("    " + ",\n    ".join(str(s) for s in sizes) + "\n")
+                f.write("};\n\n")
+            
+            # Block sizes
+            if "block_sizes" in options:
+                sizes = options["block_sizes"]
+                f.write(f"inline const std::vector<int> {level_name}_block_sizes = {{\n")
+                f.write("    " + ", ".join(str(s) for s in sizes) + "\n")
+                f.write("};\n\n")
+            
+            # Iterations
+            if "iterations" in options:
+                f.write(f"inline const int {level_name}_iterations = {options['iterations']};\n\n")
+            
+            # Warmups
+            if "warmups" in options:
+                f.write(f"inline const int {level_name}_warmups = {options['warmups']};\n\n")
+            
+            # Max memory
+            if "max_memory" in options:
+                max_mem = parse_size_string(str(options["max_memory"]))
+                f.write(f"inline const size_t {level_name}_max_memory = {max_mem};\n\n")
+            
+            # Reduction factor
+            if "reduction_factor" in options:
+                f.write(f"inline const double {level_name}_reduction_factor = {options['reduction_factor']};\n\n")
+        
+        # Generate LevelParameters struct and initialization function
+        f.write(f"// {'=' * 76}\n")
+        f.write("// LEVEL REGISTRY - Maps level names to their parameters\n")
+        f.write(f"// {'=' * 76}\n\n")
+        
+        f.write("struct LevelParameters {\n")
+        f.write("    std::vector<size_t> memory_sizes;\n")
+        f.write("    std::vector<int> block_sizes;\n")
+        f.write("    int iterations = 0;\n")
+        f.write("    int warmups = 0;\n")
+        f.write("    size_t max_memory = 0;\n")
+        f.write("    double reduction_factor = 0.0;\n")
+        f.write("};\n\n")
+        
+        f.write("inline std::map<std::string, LevelParameters> initializeLevelParameters() {\n")
+        f.write("    std::map<std::string, LevelParameters> params;\n\n")
+        
+        for level_name in levels_found:
+            f.write(f"    // {level_name}\n")
+            f.write(f"    params[\"{level_name}\"] = {{\n")
+            f.write(f"        {level_name}_memory_sizes,\n")
+            f.write(f"        {level_name}_block_sizes,\n")
+            f.write(f"        {level_name}_iterations,\n")
+            f.write(f"        {level_name}_warmups,\n")
+            f.write(f"        {level_name}_max_memory,\n")
+            f.write(f"        {level_name}_reduction_factor\n")
+            f.write(f"    }};\n\n")
+        
+        f.write("    return params;\n")
+        f.write("}\n\n")
+        
+        f.write("} // namespace TestParameters\n")
+    
+    print(f"[parse_config] Generated parameter header: {output_path}")
+    print(f"[parse_config]   Levels defined: {', '.join(levels_found)}")
+
+
 def main():
     args = parse_args()
 
@@ -58,6 +159,7 @@ def main():
     os_name = args.os_name
     arch = args.arch
     header_path = args.header_path
+    param_header_path = args.param_header_path
 
     test_macros = []
 
@@ -70,9 +172,23 @@ def main():
             )
 
     with open(header_path, "w") as file:
+        file.write("// Auto-generated from YAML config files\n")
+        file.write("// DO NOT EDIT - This file is generated at build time\n\n")
         for test_macro in test_macros:
             file.write(test_macro)
             file.write("\n")
+    
+    print(f"[parse_config] Generated test definitions: {header_path}")
+    print(f"[parse_config]   Test cases: {len(test_macros)}")
+
+    # Generate parameter header if path provided
+    if param_header_path:
+        definitions = load_definitions(configs_path)
+        cmd_options = definitions.get("cmd_options", {})
+        if cmd_options:
+            generate_parameter_header(cmd_options, param_header_path)
+        else:
+            print("[parse_config] Warning: No cmd_options found in definitions.yaml")
 
 
 if __name__ == "__main__":

--- a/projects/hip-tests/catch/hipTestMain/CMakeLists.txt
+++ b/projects/hip-tests/catch/hipTestMain/CMakeLists.txt
@@ -25,11 +25,17 @@ endif()
 set(MAIN_SRC
     main.cc
     hip_test_context.cc
-    hip_test_features.cc)
+    hip_test_features.cc
+    hip_test_params.cc
+    hip_test_listener.cc)
 add_library(Main_Object EXCLUDE_FROM_ALL OBJECT ${MAIN_SRC})
 set_source_files_properties(${MAIN_SRC} PROPERTIES LANGUAGE ${GPGPU_LANGUAGE})
 if(ENABLE_SPIRV)
   target_compile_definitions(Main_Object PRIVATE ENABLE_SPIRV)
 endif()
 target_link_libraries(Main_Object PRIVATE Catch2::Catch2 hip::host hip::device)
+
+# Include path for generated headers (hip_test_parameters.hh)
+target_include_directories(Main_Object PRIVATE ${CATCH_INCLUDE_BINARY_DIR})
+
 add_dependencies(Main_Object hip_tests_config)

--- a/projects/hip-tests/catch/hipTestMain/hip_test_listener.cc
+++ b/projects/hip-tests/catch/hipTestMain/hip_test_listener.cc
@@ -1,0 +1,187 @@
+/*
+Copyright (c) 2024 Advanced Micro Devices, Inc. All rights reserved.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+
+#include <catch2/reporters/catch_reporter_event_listener.hpp>
+#include <catch2/reporters/catch_reporter_registrars.hpp>
+#include <catch2/catch_test_case_info.hpp>
+#include <hip_test_params.hh>
+#include <hip_test_context.hh>
+#include <regex>
+#include <cstdlib>
+#include <fstream>
+
+/**
+ * @brief Event listener for HIP test parameter initialization
+ * 
+ * This listener hooks into Catch2 v3 events to:
+ * - Initialize test parameters before test execution
+ * - Detect level filter from command-line args
+ * - Load level-specific configs based on filter
+ * - Clean up resources after testing
+ * 
+ * Usage:
+ *   ./test "[level_0]"  -> Quick smoke tests (3 memory sizes)
+ *   ./test "[level_1]"  -> Standard regression (7 memory sizes)
+ *   ./test "[level_2]"  -> Comprehensive (14 memory sizes)
+ * 
+ * Or override via environment:
+ *   HIP_TEST_LEVEL=level_1 ./test "[device]"
+ */
+class HipTestParameterListener : public Catch::EventListenerBase {
+public:
+    using Catch::EventListenerBase::EventListenerBase;
+    
+private:
+    std::string filterLevel;
+    
+    /**
+     * @brief Extract level from a filter string like "[level_1]"
+     */
+    std::string extractLevelFromFilter(const std::string& filter) {
+        std::regex levelRegex("\\[level_(\\d+)\\]");
+        std::smatch match;
+        if (std::regex_search(filter, match, levelRegex)) {
+            return "level_" + match[1].str();
+        }
+        return "";
+    }
+    
+    /**
+     * @brief Detect level filter from environment or command line
+     * 
+     * Priority:
+     * 1. HIP_TEST_LEVEL environment variable
+     * 2. Command line argument (parsed from /proc/self/cmdline on Linux)
+     */
+    std::string detectLevelFilter() {
+        // Priority 1: Check environment variable
+        if (const char* envLevel = std::getenv("HIP_TEST_LEVEL")) {
+            std::string level = envLevel;
+            LogPrintf("[Level Filter] Detected from HIP_TEST_LEVEL: %s\n", level.c_str());
+            return level;
+        }
+        
+        // Priority 2: Read from /proc/self/cmdline on Linux
+        #ifdef __linux__
+        std::ifstream cmdline("/proc/self/cmdline");
+        if (cmdline) {
+            std::string arg;
+            while (std::getline(cmdline, arg, '\0')) {
+                std::string level = extractLevelFromFilter(arg);
+                if (!level.empty()) {
+                    LogPrintf("[Level Filter] Detected from command line: %s\n", level.c_str());
+                    return level;
+                }
+            }
+        }
+        #endif
+        
+        return "";
+    }
+
+public:
+
+    /**
+     * @brief Called once when the test run begins
+     * Initializes TestParameterStore and detects level filter
+     */
+    void testRunStarting(Catch::TestRunInfo const& testRunInfo) override {
+        TestParameterStore::instance().initialize();
+        
+        // Detect level filter from environment or command-line
+        filterLevel = detectLevelFilter();
+        
+        // If level was specified, load it immediately
+        if (!filterLevel.empty()) {
+            LogPrintf("[Level Filter] Applying global level: %s\n", filterLevel.c_str());
+            TestParameterStore::instance().loadLevelConfig(filterLevel);
+        }
+    }
+
+    /**
+     * @brief Called before each test case starts
+     * Uses filter level if specified, otherwise detects from test tags
+     */
+    void testCaseStarting(Catch::TestCaseInfo const& testInfo) override {
+        auto& params = TestParameterStore::instance();
+        
+        // Priority 1: Use filter level if explicitly set (from env or detected)
+        if (!filterLevel.empty()) {
+            // Filter level takes precedence - all tests use same parameters
+            if (params.currentTestLevel != filterLevel) {
+                LogPrintf("[Level Filter] Test: %s -> Using filter level: %s\n", 
+                          testInfo.name.c_str(), filterLevel.c_str());
+                params.loadLevelConfig(filterLevel);
+            }
+            return;
+        }
+        
+        // Priority 2: Auto-detect from first test's level tag (filter inference)
+        std::string detectedLevel = "";
+        for (const auto& tag : testInfo.tags) {
+            std::string tagStr = std::string(tag.original);
+            
+            // Remove brackets: "[level_0]" -> "level_0"
+            if (tagStr.size() > 2 && tagStr.front() == '[' && tagStr.back() == ']') {
+                tagStr = tagStr.substr(1, tagStr.size() - 2);
+            }
+            
+            // Check if it's a level tag
+            if (tagStr.find("level_") == 0) {
+                detectedLevel = tagStr;
+                break;
+            }
+        }
+        
+        // If this is the first test with a level tag, set it as filter level
+        if (!detectedLevel.empty() && filterLevel.empty()) {
+            filterLevel = detectedLevel;
+            LogPrintf("[Level Auto-Detection] Inferred filter level: %s from test: %s\n", 
+                      filterLevel.c_str(), testInfo.name.c_str());
+        }
+        
+        // Load level-specific config if detected
+        if (!detectedLevel.empty()) {
+            if (params.currentTestLevel != detectedLevel) {
+                LogPrintf("[Level Detection] Test: %s -> Level: %s\n", 
+                          testInfo.name.c_str(), detectedLevel.c_str());
+                params.loadLevelConfig(detectedLevel);
+            }
+        } else {
+            // Reset to defaults if no level tag
+            if (!params.currentTestLevel.empty()) {
+                params.currentTestLevel = "";
+            }
+        }
+    }
+
+    /**
+     * @brief Called when test run ends
+     * Cleanup resources
+     */
+    void testRunEnded(Catch::TestRunStats const& testRunStats) override {
+        TestParameterStore::instance().clear();
+    }
+};
+
+// Register the listener - it will be automatically activated
+CATCH_REGISTER_LISTENER(HipTestParameterListener)

--- a/projects/hip-tests/catch/hipTestMain/hip_test_params.cc
+++ b/projects/hip-tests/catch/hipTestMain/hip_test_params.cc
@@ -1,0 +1,134 @@
+/*
+Copyright (c) 2024 Advanced Micro Devices, Inc. All rights reserved.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+
+#include "hip_test_params.hh"
+#include "hip_test_parameters.hh"
+#include "hip_test_context.hh"
+
+void TestParameterStore::initialize() {
+    // Load all level parameters from generated compile-time constants
+    auto allParams = TestParameters::initializeLevelParameters();
+    
+    for (const auto& [levelName, params] : allParams) {
+        levelMemorySizes[levelName] = params.memory_sizes;
+        levelBlockSizes[levelName] = params.block_sizes;
+        levelIterations[levelName] = params.iterations;
+        levelWarmups[levelName] = params.warmups;
+        levelMaxMemory[levelName] = params.max_memory;
+        
+        LogPrintf("[TestParameterStore] %s: %zu memory sizes, %zu block sizes, %d iterations\n",
+                  levelName.c_str(), params.memory_sizes.size(), 
+                  params.block_sizes.size(), params.iterations);
+    }
+    
+    // Set defaults (use level_0 as fallback if available, otherwise hardcoded)
+    if (levelMemorySizes.count("level_0")) {
+        defaultMemorySizes = levelMemorySizes["level_0"];
+        defaultBlockSizes = levelBlockSizes["level_0"];
+        defaultIterations = levelIterations["level_0"];
+        defaultWarmups = levelWarmups["level_0"];
+    } else {
+        // Hardcoded fallback if no levels defined
+        defaultMemorySizes = {1024, 1048576, 10485760};  // 1K, 1M, 10M
+        defaultBlockSizes = {64, 256};
+        LogPrintf("[TestParameterStore] Warning: No level_0 defined, using hardcoded defaults\n%s", "");
+    }
+    
+    LogPrintf("[TestParameterStore] Initialization complete - %zu levels loaded\n", allParams.size());
+}
+
+void TestParameterStore::loadLevelConfig(const std::string& level) {
+    currentTestLevel = level;
+    
+    if (levelMemorySizes.count(level)) {
+        const auto& memSizes = levelMemorySizes.at(level);
+        const auto& blkSizes = levelBlockSizes.at(level);
+        
+        LogPrintf("[TestParameterStore] Activating level: %s\n", level.c_str());
+        
+        // Safely print memory sizes range
+        if (!memSizes.empty()) {
+            LogPrintf("[TestParameterStore]   Memory sizes: %zu (%zu bytes to %zu bytes)\n",
+                      memSizes.size(), memSizes.front(), memSizes.back());
+        } else {
+            LogPrintf("[TestParameterStore]   Memory sizes: 0 (empty)\n%s", "");
+        }
+        
+        // Safely print block sizes range
+        if (!blkSizes.empty()) {
+            LogPrintf("[TestParameterStore]   Block sizes: %zu (%d to %d)\n",
+                      blkSizes.size(), blkSizes.front(), blkSizes.back());
+        } else {
+            LogPrintf("[TestParameterStore]   Block sizes: 0 (empty)\n%s", "");
+        }
+        
+        if (levelIterations.count(level)) {
+            LogPrintf("[TestParameterStore]   Iterations: %d\n", levelIterations.at(level));
+        }
+    } else {
+        LogPrintf("[TestParameterStore] Warning: Level '%s' not found, using defaults\n", level.c_str());
+    }
+}
+
+const std::vector<size_t>& TestParameterStore::getMemorySizesForCurrentLevel() const {
+    if (!currentTestLevel.empty() && levelMemorySizes.count(currentTestLevel)) {
+        return levelMemorySizes.at(currentTestLevel);
+    }
+    return defaultMemorySizes;
+}
+
+const std::vector<int>& TestParameterStore::getBlockSizesForCurrentLevel() const {
+    if (!currentTestLevel.empty() && levelBlockSizes.count(currentTestLevel)) {
+        return levelBlockSizes.at(currentTestLevel);
+    }
+    return defaultBlockSizes;
+}
+
+int TestParameterStore::getIterationsForCurrentLevel() const {
+    if (!currentTestLevel.empty() && levelIterations.count(currentTestLevel)) {
+        return levelIterations.at(currentTestLevel);
+    }
+    return defaultIterations;
+}
+
+int TestParameterStore::getWarmupsForCurrentLevel() const {
+    if (!currentTestLevel.empty() && levelWarmups.count(currentTestLevel)) {
+        return levelWarmups.at(currentTestLevel);
+    }
+    return defaultWarmups;
+}
+
+size_t TestParameterStore::getMaxMemoryForCurrentLevel() const {
+    if (!currentTestLevel.empty() && levelMaxMemory.count(currentTestLevel)) {
+        return levelMaxMemory.at(currentTestLevel);
+    }
+    return defaultMaxMemory;
+}
+
+void TestParameterStore::clear() {
+    currentTestLevel.clear();
+    levelMemorySizes.clear();
+    levelBlockSizes.clear();
+    levelIterations.clear();
+    levelWarmups.clear();
+    levelMaxMemory.clear();
+}

--- a/projects/hip-tests/catch/include/hip_test_params.hh
+++ b/projects/hip-tests/catch/include/hip_test_params.hh
@@ -1,0 +1,144 @@
+/*
+Copyright (c) 2024 Advanced Micro Devices, Inc. All rights reserved.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+
+#pragma once
+
+#include <vector>
+#include <string>
+#include <map>
+#include <memory>
+
+/**
+ * @brief Global parameter store for test configuration.
+ * 
+ * Parameters are loaded from compile-time constants generated from 
+ * definitions.yaml at build time. The event listener detects the test
+ * level from command-line filters and loads appropriate parameters.
+ * 
+ * Thread Safety:
+ *   This class is designed for single-threaded test execution (Catch2 default).
+ *   Do not use with parallel test execution without adding synchronization.
+ * 
+ * Example usage:
+ * @code
+ * TEST_CASE(Unit_hipMemcpy_Functional) {
+ *     auto& params = TestParameterStore::instance();
+ *     
+ *     // Get parameters for current level (auto-detected from filter)
+ *     auto sizes = params.getMemorySizesForCurrentLevel();
+ *     auto size = GENERATE_COPY(from_range(sizes));
+ *     
+ *     // Test with level-appropriate sizes:
+ *     // level_0: [1K, 1M, 10M]
+ *     // level_1: [1K, 4K, 64K, 1M, 10M, 50M, 100M]
+ *     // level_2: [64, 256, 1K, ... 2G]
+ * }
+ * @endcode
+ */
+class TestParameterStore {
+public:
+    /**
+     * @brief Get singleton instance
+     */
+    static TestParameterStore& instance() {
+        static TestParameterStore inst;
+        return inst;
+    }
+
+    /**
+     * @brief Initialize parameter store from generated compile-time constants
+     * Called once at test startup by event listener
+     */
+    void initialize();
+
+    /**
+     * @brief Load parameters for a specific level
+     * Called by event listener when [level_X] tag is detected
+     * @param level Level name (e.g., "level_0", "level_1")
+     */
+    void loadLevelConfig(const std::string& level);
+
+    /**
+     * @brief Get memory sizes for current test level
+     * @return Vector of memory sizes in bytes
+     */
+    const std::vector<size_t>& getMemorySizesForCurrentLevel() const;
+
+    /**
+     * @brief Get block sizes for current test level
+     * @return Vector of block sizes
+     */
+    const std::vector<int>& getBlockSizesForCurrentLevel() const;
+
+    /**
+     * @brief Get iterations for current test level
+     * @return Number of iterations
+     */
+    int getIterationsForCurrentLevel() const;
+
+    /**
+     * @brief Get warmup iterations for current test level
+     * @return Number of warmup iterations
+     */
+    int getWarmupsForCurrentLevel() const;
+
+    /**
+     * @brief Get maximum memory for current test level
+     * @return Maximum memory in bytes
+     */
+    size_t getMaxMemoryForCurrentLevel() const;
+
+    /**
+     * @brief Clear all stored data
+     */
+    void clear();
+
+    /**
+     * @brief Current test level (set by event listener)
+     */
+    std::string currentTestLevel;
+
+    /**
+     * @brief Level-specific parameters (loaded from compile-time constants)
+     * Public for verification tests
+     */
+    std::map<std::string, std::vector<size_t>> levelMemorySizes;
+    std::map<std::string, std::vector<int>> levelBlockSizes;
+    std::map<std::string, int> levelIterations;
+    std::map<std::string, int> levelWarmups;
+    std::map<std::string, size_t> levelMaxMemory;
+
+private:
+    TestParameterStore() = default;
+    ~TestParameterStore() = default;
+    TestParameterStore(const TestParameterStore&) = delete;
+    TestParameterStore& operator=(const TestParameterStore&) = delete;
+    
+    /**
+     * @brief Fallback parameters (if no level specified)
+     */
+    std::vector<size_t> defaultMemorySizes;
+    std::vector<int> defaultBlockSizes;
+    int defaultIterations = 1000;
+    int defaultWarmups = 100;
+    size_t defaultMaxMemory = 2147483648; // 2GB
+};


### PR DESCRIPTION
## Motivation

Adds infrastructure for level-based test parameters, enabling tests to adapt their intensity based on the selected level filter.

Changes
1. Level Parameters in definitions.yaml
Added cmd_options section defining test parameters for 5 levels:
level_0 to level_4 (these are tentitive and can be changed as needed to match ROCk)
Each level defines example: memory_sizes, block_sizes, iterations, warmups, max_memory(these will change after examining actual test cases)

2. Code Generation (parse_config.py)
Extended to generate hip_test_parameters.hh with compile-time constants

3. Runtime Components
TestParameterStore: Singleton holding level parameters
HipTestParameterListener: Catch2 listener that detects level from [level_N] filter or HIP_TEST_LEVEL environment  variable

Usage
./test "[level_0]"              # Quick tests
./test "[level_1]"              # Standard tests
HIP_TEST_LEVEL=level_2 ./test   # Override via environment

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
