### PR TITLE
[rocprofiler-sdk][rel-7.2] Fix queues_init leak in on-demand queue mode

### DIFF
--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/counters/device_counting.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/counters/device_counting.cpp
@@ -23,6 +23,7 @@
 #include "lib/rocprofiler-sdk/counters/device_counting.hpp"
 #include "lib/common/environment.hpp"
 #include "lib/common/logging.hpp"
+#include "lib/common/static_object.hpp"
 #include "lib/common/utility.hpp"
 #include "lib/rocprofiler-sdk/buffer.hpp"
 #include "lib/rocprofiler-sdk/context/context.hpp"
@@ -95,6 +96,15 @@ submitPacket(hsa_queue_t* queue, const void* packet)
 
 namespace
 {
+// Tracks which queues have had set_profiler_active_on_queue called.
+// Accessor function avoids static initialization order issues.
+std::unordered_set<hsa_queue_t*>&
+get_queues_init()
+{
+    static auto& _v = *common::static_object<std::unordered_set<hsa_queue_t*>>::construct();
+    return _v;
+}
+
 // Returns true if device lock should be acquired at configuration time (OLD behavior).
 // Returns false if device lock should be acquired at context start time (NEW behavior, default).
 bool
@@ -260,9 +270,8 @@ init_callback_data(rocprofiler::counters::agent_callback_data& callback_data,
 
     // If we do not have a completion handle, this is our first time profiling this agent.
     // Setup our shared data structures.
-    static std::unordered_set<hsa_queue_t*> queues_init;
-    if(queues_init.find(callback_data.queue) != queues_init.end()) return;
-    queues_init.insert(callback_data.queue);
+    if(get_queues_init().find(callback_data.queue) != get_queues_init().end()) return;
+    get_queues_init().insert(callback_data.queue);
 
     // Set state of the queue to allow profiling (may not be needed since AQL
     // may do this in the future).
@@ -633,6 +642,7 @@ stop_agent_ctx(const context::context* ctx)
                 hsa::get_core_table()->hsa_signal_destroy_fn(callback_data.start_signal);
                 callback_data.start_signal.handle = 0;
             }
+            get_queues_init().erase(callback_data.queue);
             callback_data.packet.reset();
             callback_data.queue = nullptr;
             agent->destroy_device_counting_service_queue();


### PR DESCRIPTION
## Summary
- Fix unbounded growth and dangling pointer bug in `queues_init` static set when on-demand queue mode (`ROCPROFILER_ONDEMAND_QUEUE=1`) is enabled
- Move `queues_init` from function-static to file-scope (anonymous namespace) so `stop_agent_ctx` can erase entries
- Erase queue pointer from `queues_init` before destroying the queue in the on-demand cleanup path

## Problem
Each on-demand start/stop cycle creates a new HSA queue with a new pointer. The `queues_init` set (which tracks queues that have had `set_profiler_active_on_queue` called) was function-static inside `init_callback_data()`, so entries were never removed. This caused:
1. **Unbounded growth**: Old queue pointers accumulated forever (minor memory leak)
2. **Dangling pointers**: If HSA reused a queue address, the set would skip `set_profiler_active_on_queue` for the new queue, causing incorrect counter collection

## Test plan
- [x] Build with clang-tidy and `-Werror` on banff (ROCm 7.2, gfx942) — passed
- [ ] CI validation

🤖 Generated with [Claude Code](https://claude.com/claude-code)