### PR TITLE
[rocprofiler-systems] Add pause/resume support for gotcha components

### DIFF
--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library.cpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library.cpp
@@ -404,6 +404,29 @@ rocprofsys_preinit_hidden()
     _preinit_callback();
     _preinit_callback = []() {};
 }
+
+void
+pause_gotcha_components()
+{
+    component::mpi_gotcha::pause();
+    component::ucx_gotcha::pause();
+    component::shmem_gotcha<rocprofsys::DefaultSHMEMPolicy>::pause();
+    component::vaapi_gotcha::pause();
+    ::rocprofsys::pthread_gotcha::pause();
+    component::numa_gotcha::pause();
+}
+
+void
+resume_gotcha_components()
+{
+    component::mpi_gotcha::resume();
+    component::ucx_gotcha::resume();
+    component::shmem_gotcha<rocprofsys::DefaultSHMEMPolicy>::resume();
+    component::vaapi_gotcha::resume();
+    ::rocprofsys::pthread_gotcha::resume();
+    component::numa_gotcha::resume();
+}
+
 }  // namespace
 
 extern "C" void
@@ -637,6 +660,13 @@ rocprofsys_init_tooling_hidden(void)
             ROCPROFSYS_SCOPED_SAMPLING_ON_CHILD_THREADS(false);
             trace_cache::get_buffer_storage().start(getpid());
         }
+
+        // TODO: Uncomment this when we have config option to do selective tracing
+        // if(get_selective tracing())
+        // {
+        // LOG_INFO("Pausing gotcha components...");
+        // pause_gotcha_components();
+        // }
 
         set_state(State::Active);  // set to active as very last operation
     } };

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library/components/mpi_gotcha.cpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library/components/mpi_gotcha.cpp
@@ -212,6 +212,22 @@ mpi_gotcha::shutdown()
     update();
 }
 
+std::mutex mpi_gotcha::s_mutex = {};
+
+void
+mpi_gotcha::pause()
+{
+    std::unique_lock<std::mutex> _lk{ s_mutex };
+    mpi_gotcha_t::set_ready(false);
+}
+
+void
+mpi_gotcha::resume()
+{
+    std::unique_lock<std::mutex> _lk{ s_mutex };
+    mpi_gotcha_t::set_ready(true);
+}
+
 bool
 mpi_gotcha::update()
 {

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library/components/mpi_gotcha.hpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library/components/mpi_gotcha.hpp
@@ -49,6 +49,9 @@ struct mpi_gotcha : comp::base<mpi_gotcha, void>
     static void configure();
     static void shutdown();
 
+    static void pause();
+    static void resume();
+
     // called right before MPI_Init with that functions arguments
     static void audit(const gotcha_data_t& _data, audit::incoming, int*, char***);
 
@@ -88,6 +91,8 @@ private:
 
     static std::mutex                                           s_on_init_callbacks_mutex;
     static std::vector<std::function<void(int rank, int size)>> s_on_init_callbacks;
+
+    static std::mutex s_mutex;
 };
 }  // namespace component
 

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library/components/numa_gotcha.cpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library/components/numa_gotcha.cpp
@@ -97,6 +97,22 @@ numa_gotcha::shutdown()
     numa_gotcha_t::disable();
 }
 
+std::mutex numa_gotcha::s_mutex = {};
+
+void
+numa_gotcha::pause()
+{
+    std::unique_lock<std::mutex> _lk{ s_mutex };
+    numa_gotcha_t::set_ready(false);
+}
+
+void
+numa_gotcha::resume()
+{
+    std::unique_lock<std::mutex> _lk{ s_mutex };
+    numa_gotcha_t::set_ready(true);
+}
+
 void
 numa_gotcha::start()
 {

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library/components/numa_gotcha.hpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library/components/numa_gotcha.hpp
@@ -56,6 +56,9 @@ struct numa_gotcha : tim::component::base<numa_gotcha, void>
     static void start();
     static void stop();
 
+    static void pause();
+    static void resume();
+
     static void audit(const gotcha_data&, audit::incoming, void* start, unsigned long len,
                       int mode, const unsigned long* nmask, unsigned long maxnode,
                       unsigned flags);
@@ -72,6 +75,9 @@ struct numa_gotcha : tim::component::base<numa_gotcha, void>
     static void audit(const gotcha_data&, audit::outgoing, int);
     static void audit(const gotcha_data&, audit::outgoing, long);
     static void audit(const gotcha_data&, audit::outgoing, void*);
+
+private:
+    static std::mutex s_mutex;
 };
 }  // namespace component
 

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library/components/pthread_create_gotcha.cpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library/components/pthread_create_gotcha.cpp
@@ -515,6 +515,21 @@ pthread_create_gotcha::shutdown(int64_t _tid)
     }
 }
 
+std::mutex pthread_create_gotcha::s_mutex = {};
+
+void
+pthread_create_gotcha::pause()
+{
+    std::unique_lock<std::mutex> _lk{ s_mutex };
+    pthread_create_gotcha_t::set_ready(false);
+}
+void
+pthread_create_gotcha::resume()
+{
+    std::unique_lock<std::mutex> _lk{ s_mutex };
+    pthread_create_gotcha_t::set_ready(true);
+}
+
 void
 pthread_create_gotcha::set_data(wrappee_t _v)
 {

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library/components/pthread_create_gotcha.hpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library/components/pthread_create_gotcha.hpp
@@ -77,6 +77,9 @@ struct pthread_create_gotcha : tim::component::base<pthread_create_gotcha, void>
     static void shutdown();
     static void shutdown(int64_t);
 
+    static void pause();
+    static void resume();
+
     // pthread_create
     int operator()(pthread_t* thread, const pthread_attr_t* attr,
                    void* (*start_routine)(void*), void*     arg) const;
@@ -88,7 +91,8 @@ private:
 
     static std::set<native_handle_t> get_native_handles();
 
-    wrappee_t m_wrappee = &pthread_create;
+    wrappee_t         m_wrappee = &pthread_create;
+    static std::mutex s_mutex;
 };
 
 using pthread_create_gotcha_t =

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library/components/pthread_gotcha.cpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library/components/pthread_gotcha.cpp
@@ -114,6 +114,20 @@ pthread_gotcha::stop()
     get_bundle()->stop();
 }
 
+void
+pthread_gotcha::pause()
+{
+    ::rocprofsys::component::pthread_mutex_gotcha::pause();
+    ::rocprofsys::component::pthread_create_gotcha::pause();
+}
+
+void
+pthread_gotcha::resume()
+{
+    ::rocprofsys::component::pthread_mutex_gotcha::resume();
+    ::rocprofsys::component::pthread_create_gotcha::resume();
+}
+
 std::set<pthread_gotcha::native_handle_t>
 pthread_gotcha::get_native_handles()
 {

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library/components/pthread_gotcha.hpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library/components/pthread_gotcha.hpp
@@ -48,6 +48,9 @@ struct pthread_gotcha : tim::component::base<pthread_gotcha, void>
     static void start();
     static void stop();
 
+    static void pause();
+    static void resume();
+
     static std::set<native_handle_t> get_native_handles();
 };
 }  // namespace rocprofsys

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library/components/pthread_mutex_gotcha.cpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library/components/pthread_mutex_gotcha.cpp
@@ -169,6 +169,22 @@ pthread_mutex_gotcha::shutdown()
     pthread_mutex_gotcha_t::disable();
 }
 
+std::mutex pthread_mutex_gotcha::s_mutex = {};
+
+void
+pthread_mutex_gotcha::pause()
+{
+    std::unique_lock<std::mutex> _lk{ s_mutex };
+    pthread_mutex_gotcha_t::set_ready(false);
+}
+
+void
+pthread_mutex_gotcha::resume()
+{
+    std::unique_lock<std::mutex> _lk{ s_mutex };
+    pthread_mutex_gotcha_t::set_ready(true);
+}
+
 pthread_mutex_gotcha::pthread_mutex_gotcha(const gotcha_data_t& _data)
 : m_data{ &_data }
 {}

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library/components/pthread_mutex_gotcha.hpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library/components/pthread_mutex_gotcha.hpp
@@ -55,6 +55,9 @@ struct pthread_mutex_gotcha : comp::base<pthread_mutex_gotcha, void>
     static void configure();
     static void shutdown();
 
+    static void pause();
+    static void resume();
+
     int operator()(int (*)(pthread_mutex_t*), pthread_mutex_t*) const;
     int operator()(int (*)(pthread_spinlock_t*), pthread_spinlock_t*) const;
     int operator()(int (*)(pthread_rwlock_t*), pthread_rwlock_t*) const;
@@ -70,6 +73,7 @@ private:
 
     mutable bool         m_protect = false;
     const gotcha_data_t* m_data    = nullptr;
+    static std::mutex    s_mutex;
 };
 
 using pthread_mutex_gotcha_t = comp::gotcha<pthread_mutex_gotcha::gotcha_capacity,

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library/components/shmem_gotcha.hpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library/components/shmem_gotcha.hpp
@@ -199,6 +199,9 @@ struct shmem_gotcha : tim::component::base<shmem_gotcha<SHMEMPolicy>, void>
     static void start();
     static void stop();
 
+    static void pause();
+    static void resume();
+
     template <typename... Args>
     static void audit(const typename SHMEMPolicy::gotcha_data& _data, audit::incoming,
                       Args...)
@@ -213,6 +216,9 @@ struct shmem_gotcha : tim::component::base<shmem_gotcha<SHMEMPolicy>, void>
     static void audit(const typename SHMEMPolicy::gotcha_data&, audit::outgoing, void*);
     static void audit(const typename SHMEMPolicy::gotcha_data&, audit::outgoing, int);
     static void audit(const typename SHMEMPolicy::gotcha_data&, audit::outgoing, long);
+
+private:
+    static std::mutex s_mutex;
 };
 
 namespace detail
@@ -518,6 +524,27 @@ template <typename SHMEMPolicy>
 void
 shmem_gotcha<SHMEMPolicy>::stop()
 {}
+
+template <typename SHMEMPolicy>
+std::mutex shmem_gotcha<SHMEMPolicy>::s_mutex = {};
+
+template <typename SHMEMPolicy>
+void
+shmem_gotcha<SHMEMPolicy>::pause()
+{
+    std::unique_lock<std::mutex> _lk{ s_mutex };
+    using shmem_gotcha_t = typename SHMEMPolicy::shmem_gotcha_t;
+    shmem_gotcha_t::set_ready(false);
+}
+
+template <typename SHMEMPolicy>
+void
+shmem_gotcha<SHMEMPolicy>::resume()
+{
+    std::unique_lock<std::mutex> _lk{ s_mutex };
+    using shmem_gotcha_t = typename SHMEMPolicy::shmem_gotcha_t;
+    shmem_gotcha_t::set_ready(true);
+}
 
 template <typename SHMEMPolicy>
 void

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library/components/ucx_gotcha.cpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library/components/ucx_gotcha.cpp
@@ -262,6 +262,22 @@ void
 ucx_gotcha::stop()
 {}
 
+std::mutex ucx_gotcha::s_mutex = {};
+
+void
+ucx_gotcha::pause()
+{
+    std::unique_lock<std::mutex> _lk{ s_mutex };
+    ucx_gotcha_t::set_ready(false);
+}
+
+void
+ucx_gotcha::resume()
+{
+    std::unique_lock<std::mutex> _lk{ s_mutex };
+    ucx_gotcha_t::set_ready(true);
+}
+
 // Generic audit functions now handled by template in header
 
 // Specific audit functions for tag operations

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library/components/ucx_gotcha.hpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library/components/ucx_gotcha.hpp
@@ -57,6 +57,9 @@ struct ucx_gotcha : tim::component::base<ucx_gotcha, void>
     static void start();
     static void stop();
 
+    static void pause();
+    static void resume();
+
     // Generic template audit function for UCX operations with void* parameters
     template <typename... Args>
     static void audit(const gotcha_data& _data, audit::incoming, Args...)
@@ -104,6 +107,9 @@ public:
     // Outgoing audit for return values
     static void audit(const gotcha_data&, audit::outgoing, void*);
     static void audit(const gotcha_data&, audit::outgoing, int);
+
+private:
+    static std::mutex s_mutex;
 };
 }  // namespace component
 

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library/components/vaapi_gotcha.cpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library/components/vaapi_gotcha.cpp
@@ -141,6 +141,22 @@ void
 vaapi_gotcha::stop()
 {}
 
+std::mutex vaapi_gotcha::s_mutex = {};
+
+void
+vaapi_gotcha::pause()
+{
+    std::unique_lock<std::mutex> _lk{ s_mutex };
+    vaapi_gotcha_t::set_ready(false);
+}
+
+void
+vaapi_gotcha::resume()
+{
+    std::unique_lock<std::mutex> _lk{ s_mutex };
+    vaapi_gotcha_t::set_ready(true);
+}
+
 // vaBeginPicture
 void
 vaapi_gotcha::audit(const gotcha_data& _data, audit::incoming, VADisplay dpy,

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library/components/vaapi_gotcha.hpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library/components/vaapi_gotcha.hpp
@@ -71,6 +71,9 @@ struct vaapi_gotcha : tim::component::base<vaapi_gotcha, void>
     static void start();
     static void stop();
 
+    static void pause();
+    static void resume();
+
     static void audit(const gotcha_data&, audit::incoming, VADisplay dpy,
                       VAContextID context, VASurfaceID render_target);
     static void audit(const gotcha_data&, audit::incoming, VADisplay dpy,
@@ -130,6 +133,9 @@ struct vaapi_gotcha : tim::component::base<vaapi_gotcha, void>
     static void audit(const gotcha_data& _data, audit::incoming, VADisplay dpy);
 
     static void audit(const gotcha_data&, audit::outgoing, VAStatus);
+
+private:
+    static std::mutex s_mutex;
 };
 }  // namespace component
 


### PR DESCRIPTION
## Motivation

Enable the ability to pause and resume gotcha instrumentation wrappers at runtime. This is a prerequisite for selective tracing, where gotcha interception can be temporarily disabled and re-enabled during specific phases of program execution, reducing overhead when instrumentation is not needed.

## Technical Details

- Added static `pause()` and `resume()` methods to all gotcha component classes: `mpi_gotcha`, `ucx_gotcha`, `shmem_gotcha`, `vaapi_gotcha`, `numa_gotcha`, `pthread_create_gotcha`, `pthread_mutex_gotcha`, and the composite `pthread_gotcha`.
- Each `pause()` calls `set_ready(false)` on the underlying gotcha type to disable interception, and `resume()` calls `set_ready(true)` to re-enable it.
- `pthread_gotcha::pause()`/`resume()` acts as a composite, delegating to both `pthread_mutex_gotcha` and `pthread_create_gotcha`.
- Added centralized `pause_gotcha_components()` and `resume_gotcha_components()` helper functions in `library.cpp` that orchestrate pausing/resuming all gotcha components together.
- Integration with the tooling init path is stubbed out behind a TODO for a future selective tracing config option.

## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan

- Verify that calling `pause_gotcha_components()` disables all gotcha wrappers (intercepted calls pass through to the original functions without instrumentation).
- Verify that calling `resume_gotcha_components()` re-enables all gotcha wrappers (intercepted calls are instrumented again).
- Test individual component `pause()`/`resume()` independently (e.g., pause only MPI gotcha while others remain active).
- Test pause/resume across multiple threads to ensure thread safety of `set_ready()`.
- Ensure no regressions in existing gotcha functionality when pause/resume are not used.

## Test Result

- When paused, profiled applications should show no trace events from gotcha-wrapped functions (MPI, UCX, SHMEM, VAAPI, NUMA, pthread).
- When resumed, trace events should reappear in Perfetto/RocPD output as before.
- Existing tests and examples (e.g., MPI example, NUMA test) should produce unchanged output when pause/resume is not invoked.
## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
