### PR TITLE
[clr] ASAN - Hide the retain under direct dispatch check

### DIFF
--- a/projects/clr/hipamd/src/hip_graph_internal.hpp
+++ b/projects/clr/hipamd/src/hip_graph_internal.hpp
@@ -2639,8 +2639,10 @@ class GraphMemAllocNode final : public GraphNode {
       size_t offset = 0;
       // Get memory object associated with the real allocation
       memory_ = getMemoryObject(dptr, offset);
-      // Retain memory object because command release will release it
-      memory_->retain();
+      if (!AMD_DIRECT_DISPATCH) {
+        // Retain memory object because command release will release it
+        memory_->retain();
+      }
       size_ = aligned_size;
       // Execute the original mapping command
       VirtualMapCommand::submit(device);


### PR DESCRIPTION
## Motivation

We do not need extra retain after a recent change made to how commands release the memory object associated with it.

## Technical Details

This shows up as a memory leak in tests, where the command's release is not called and the object is not released.

## JIRA ID

NA

## Test Plan

Existing tests should pass without leaks

## Test Result

Passed locally.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
