### PR TITLE
[rocprofiler-systems] Pass space separated GFX targets to RCCL build command

### DIFF
--- a/projects/rocprofiler-systems/examples/rccl/CMakeLists.txt
+++ b/projects/rocprofiler-systems/examples/rccl/CMakeLists.txt
@@ -76,6 +76,9 @@ if(hip_FOUND AND rccl_FOUND)
         return()
     endif()
 
+    # Convert CMake list (;-separated) to space-separated string for make
+    list(JOIN RCCL_GPU_TARGETS " " RCCL_GPU_TARGETS_STR)
+
     # Copy source to build directory
     file(COPY ${rccl-tests_SOURCE_DIR}/ DESTINATION ${rccl-tests_BUILD_DIR})
 
@@ -98,7 +101,7 @@ if(hip_FOUND AND rccl_FOUND)
             ${rccl-tests_BUILD_DIR}/build/sendrecv_perf
         COMMAND
             make HIP_HOME=${ROCM_PATH} RCCL_HOME=${rccl_ROOT_DIR}
-            GPU_TARGETS=${RCCL_GPU_TARGETS} -j
+            "GPU_TARGETS=${RCCL_GPU_TARGETS_STR}" -j
         WORKING_DIRECTORY ${rccl-tests_BUILD_DIR}
         COMMENT
             "Building rccl-tests with HIP_HOME=${ROCM_PATH} RCCL_HOME=${rccl_ROOT_DIR} ..."


### PR DESCRIPTION
## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

Noticed build failure when `ROCPROFSYS_GFX_TARGETS` had more than 1 target.
Since TheRock will be introducing `USE_TEST_AMDGPU_TARGETS`, we most likely need this change in to prevent build failure.

To reproduce:
```
cmake -B rocprof-sys-build -S .                                                  \
       -D CMAKE_INSTALL_PREFIX=/opt/rocprofiler-systems                          \
       -D ROCPROFSYS_USE_PYTHON=ON      -D ROCPROFSYS_BUILD_DYNINST=ON           \
       -D ROCPROFSYS_BUILD_TBB=ON       -D ROCPROFSYS_BUILD_BOOST=ON             \
       -D ROCPROFSYS_BUILD_ELFUTILS=ON  -D ROCPROFSYS_BUILD_LIBIBERTY=ON         \
       -D ROCPROFSYS_BUILD_TESTING=ON -D ROCPROFSYS_GFX_TARGETS="gfx1100;gfx942"
cmake --build rocprof-sys-build --target all --parallel 8
```

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

Pass space separated list to RCCL build command

## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

AIPROFSYST-221

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

This should be the default used on TheRock (multiple `ROCPROFSYS_GFX_TARGETS`).

## Test Result

Build does not fail

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
