### PR TITLE
Release queue outside of vgpusAccess lock

### DIFF
--- a/projects/clr/rocclr/device/rocm/rocvirtual.cpp
+++ b/projects/clr/rocclr/device/rocm/rocvirtual.cpp
@@ -1843,13 +1843,15 @@ VirtualGPU::~VirtualGPU() {
     virtualQueue_->release();
   }
 
-  // Lock the device to make the following thread safe
-  amd::ScopedLock lock(roc_device_.vgpusAccess());
+  {
+    // Lock the device to make the following thread safe
+    amd::ScopedLock lock(roc_device_.vgpusAccess());
 
-  --roc_device_.numOfVgpus_;  // Virtual gpu unique index decrementing
-  roc_device_.vgpus_.erase(roc_device_.vgpus_.begin() + index());
-  for (uint idx = index(); idx < roc_device_.vgpus().size(); ++idx) {
-    roc_device_.vgpus()[idx]->index_--;
+    --roc_device_.numOfVgpus_;  // Virtual gpu unique index decrementing
+    roc_device_.vgpus_.erase(roc_device_.vgpus_.begin() + index());
+    for (uint idx = index(); idx < roc_device_.vgpus().size(); ++idx) {
+      roc_device_.vgpus()[idx]->index_--;
+    }
   }
 
   if (gpu_queue_ != nullptr) {


### PR DESCRIPTION
## Motivation

There is a hang in Unit_hipLaunchCooperativeKernel_Verify_Capture that happens during runtime teardown caused by a deadlock.

## Technical Details

Deadlock happens when one thread tries to destroy AqlQueue while holding the queue and other thread tries to lock it again. Removing queue release outside of scope of the lock removes the hang.

## JIRA ID

Fixes ROCM-3160.

## Test Plan

Run Unit_hipLaunchCooperativeKernel_Verify_Capture 10k times.

## Test Result

Passed with no hangs.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
