### PR TITLE
SWDEV-567112 - Introduce new mechanism for tagging and disabling tests - Part 2

### DIFF
--- a/projects/hip-tests/catch/TypeQualifiers/hipManagedKeyword.cc
+++ b/projects/hip-tests/catch/TypeQualifiers/hipManagedKeyword.cc
@@ -38,7 +38,7 @@ static __global__ void managed_add(size_t size) {
 
 static __global__ void managed_inc() { atomicAdd(&m_X, 1.0f); }
 
-TEST_CASE("Unit_hipManagedKeyword_SingleGpu") {
+TEST_CASE(Unit_hipManagedKeyword_SingleGpu) {
   for (size_t i = 0; i < N; i++) {
     m_A[i] = 1.0f;
     m_B[i] = 2.0f;
@@ -58,7 +58,7 @@ TEST_CASE("Unit_hipManagedKeyword_SingleGpu") {
   }
 }
 
-TEST_CASE("Unit_hipManagedKeyword_MultiGpu") {
+TEST_CASE(Unit_hipManagedKeyword_MultiGpu) {
   int numDevices = 0;
   HIP_CHECK(hipGetDeviceCount(&numDevices));
 

--- a/projects/hip-tests/catch/config/check_sources.py
+++ b/projects/hip-tests/catch/config/check_sources.py
@@ -18,7 +18,7 @@ def find_source_test_cases(source_root, group, is_unit):
 
     test_names = set()
     pattern = re.compile(
-        r'(?:TEST_CASE|TEMPLATE_TEST_CASE)\(\s*"([^"]+)"\s*[,)]'
+        r'(?:TEST_CASE|TEMPLATE_TEST_CASE)\(\s*(?:"([^"]+)"|([A-Za-z_]\w*))\s*[,)]'
     )
     for root, _, files in os.walk(source_dir):
         for filename in files:
@@ -28,7 +28,7 @@ def find_source_test_cases(source_root, group, is_unit):
             with open(filepath, errors="replace") as f:
                 content = f.read()
             for match in pattern.finditer(content):
-                test_names.add(match.group(1))
+                test_names.add(match.group(1) or match.group(2))
 
     return test_names
 

--- a/projects/hip-tests/catch/config/configs/stress.yaml
+++ b/projects/hip-tests/catch/config/configs/stress.yaml
@@ -13,7 +13,9 @@ stress:
   Stress_deviceAllocation_new_loop_singlekernel: *level_2
   Stress_deviceAllocation_malloc_loop_multkernel: *level_2
   Stress_deviceAllocation_new_loop_multkernel: *level_2
-  Stress_hipMalloc: *level_2
+  Stress_hipMalloc:
+    <<: *level_2
+    tags: [DifferentSizes]
   Stress_hipMemcpy_multiDevice_AllAPIs: *level_2
   Stress_hipMallocManaged_MultiSize: *level_2
   Stress_hipMallocManaged_KrnlWth2MemTypes: *level_2

--- a/projects/hip-tests/catch/config/configs/unit/memory.yaml
+++ b/projects/hip-tests/catch/config/configs/unit/memory.yaml
@@ -272,7 +272,6 @@ memory:
   Unit_hipHostRegister_Chunks_RoundRobin: *level_2
   Unit_hipHostRegister_Perform_hipMemset: *level_2
   Unit_hipHostRegister_Perform_hipMemcpy: *level_2
-  Unit_hipHostRegister_Oversubscription: *level_2
   Unit_hipHostRegister_AsyncApis: *level_2
   Unit_hipHostRegister_Graphs: *level_2
   Unit_hipHostRegister_RegUnreg_Perf_SameChunk: *level_2
@@ -788,11 +787,6 @@ memory:
   Unit_hipMemset2DAsync_WithKernel: *level_2
   Unit_hipMemset2DAsync_MultiThread: *level_2
   Unit_hipMalloc_ArgumentValidation: *level_2
-  Unit_hipMalloc_LoopRegressionAllocFreeCycles: *level_2
-  Unit_hipMalloc_AllocateAndPoolBuffers: *level_2
-  Unit_hipMalloc_Multithreaded_MultiGPU:
-    <<: *level_2
-    tags: [multigpu]
   Unit_hipMemcpyDtoD_Basic:
     <<: *level_2
     tags: [multigpu]

--- a/projects/hip-tests/catch/multiproc/childMalloc.cc
+++ b/projects/hip-tests/catch/multiproc/childMalloc.cc
@@ -75,7 +75,7 @@ bool testMallocFromChild() {
 }
 
 
-TEST_CASE("ChildMalloc") {
+TEST_CASE(ChildMalloc) {
   auto res = testMallocFromChild();
   REQUIRE(res == true);
 }

--- a/projects/hip-tests/catch/multiproc/deviceAllocationMproc.cc
+++ b/projects/hip-tests/catch/multiproc/deviceAllocationMproc.cc
@@ -311,7 +311,7 @@ static bool testDeviceMemMulProc(bool testmalloc) {
 /**
  * Multiprocess device side malloc test.
  */
-TEST_CASE("Unit_deviceAllocation_Malloc_MultProcess") {
+TEST_CASE(Unit_deviceAllocation_Malloc_MultProcess) {
   auto res = testDeviceAllocMulProc(true);
   REQUIRE(res == true);
 }
@@ -319,7 +319,7 @@ TEST_CASE("Unit_deviceAllocation_Malloc_MultProcess") {
 /**
  * Multiprocess device side new test.
  */
-TEST_CASE("Unit_deviceAllocation_New_MultProcess") {
+TEST_CASE(Unit_deviceAllocation_New_MultProcess) {
   auto res = testDeviceAllocMulProc(false);
   REQUIRE(res == true);
 }
@@ -327,7 +327,7 @@ TEST_CASE("Unit_deviceAllocation_New_MultProcess") {
 /**
  * Multiprocess device side malloc, write and free test.
  */
-TEST_CASE("Unit_deviceAllocation_MallocFree_MultProcess") {
+TEST_CASE(Unit_deviceAllocation_MallocFree_MultProcess) {
   auto res = testDeviceMemMulProc(true);
   REQUIRE(res == true);
 }
@@ -335,7 +335,7 @@ TEST_CASE("Unit_deviceAllocation_MallocFree_MultProcess") {
 /**
  * Multiprocess device side new, write and delete test.
  */
-TEST_CASE("Unit_deviceAllocation_NewDelete_MultProcess") {
+TEST_CASE(Unit_deviceAllocation_NewDelete_MultProcess) {
   auto res = testDeviceMemMulProc(false);
   REQUIRE(res == true);
 }

--- a/projects/hip-tests/catch/multiproc/hipDeviceComputeCapabilityMproc.cc
+++ b/projects/hip-tests/catch/multiproc/hipDeviceComputeCapabilityMproc.cc
@@ -140,7 +140,7 @@ bool runMaskedDeviceTest(int actualNumGPUs) {
 /**
  * Validate behavior of hipDeviceComputeCapability for masked devices.
  */
-TEST_CASE("Unit_hipDeviceGet_MaskedDevices") {
+TEST_CASE(Unit_hipDeviceGet_MaskedDevices) {
   int count = -1;
   constexpr int ReqGPUs = 2;
   bool ret;

--- a/projects/hip-tests/catch/multiproc/hipDeviceGetPCIBusIdMproc.cc
+++ b/projects/hip-tests/catch/multiproc/hipDeviceGetPCIBusIdMproc.cc
@@ -154,7 +154,7 @@ bool getPciBusId(int deviceCount, char** hipDeviceList) {
 /**
  * Scenario: Validate behavior of hipDeviceGetPCIBusId for masked devices.
  */
-TEST_CASE("Unit_hipDeviceGetPCIBusId_MaskedDevices") {
+TEST_CASE(Unit_hipDeviceGetPCIBusId_MaskedDevices) {
   int count = -1;
   constexpr int ReqGPUs = 2;
   bool ret;
@@ -173,7 +173,7 @@ TEST_CASE("Unit_hipDeviceGetPCIBusId_MaskedDevices") {
  * hipDeviceGetPCIBusId vs lspci
  */
 
-TEST_CASE("Unit_hipDeviceGetPCIBusId_CheckPciBusIDWithLspci") {
+TEST_CASE(Unit_hipDeviceGetPCIBusId_CheckPciBusIDWithLspci) {
   auto are_devices_hidden = []() -> bool {
 #if HT_AMD
     auto env_res = std::getenv("HIP_VISIBLE_DEVICES");

--- a/projects/hip-tests/catch/multiproc/hipDeviceTotalMemMproc.cc
+++ b/projects/hip-tests/catch/multiproc/hipDeviceTotalMemMproc.cc
@@ -152,7 +152,7 @@ static bool getTotalMemoryOfMaskedDevices(int actualNumGPUs) {
  *  - Multi-device test
  *  - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_hipDeviceTotalMem_MaskedDevices") {
+TEST_CASE(Unit_hipDeviceTotalMem_MaskedDevices) {
   int count = -1;
   constexpr int ReqGPUs = 2;
   bool ret;

--- a/projects/hip-tests/catch/multiproc/hipGetDeviceAttributeMproc.cc
+++ b/projects/hip-tests/catch/multiproc/hipGetDeviceAttributeMproc.cc
@@ -146,7 +146,7 @@ static bool validateGetAttributeOfMaskedDevices(int actualNumGPUs) {
 /**
  * Scenario: Validate behavior of hipDeviceGetAttribute for masked devices.
  */
-TEST_CASE("Unit_hipDeviceGetAttribute_MaskedDevices") {
+TEST_CASE(Unit_hipDeviceGetAttribute_MaskedDevices) {
   int count = -1;
   constexpr int ReqGPUs = 2;
   bool ret;

--- a/projects/hip-tests/catch/multiproc/hipGetDeviceCountMproc.cc
+++ b/projects/hip-tests/catch/multiproc/hipGetDeviceCountMproc.cc
@@ -33,7 +33,7 @@ THE SOFTWARE.
 /**
  * Validate behavior of hipGetDeviceCount for masked devices.
  */
-TEST_CASE("Unit_hipGetDeviceCount_MaskedDevices") {
+TEST_CASE(Unit_hipGetDeviceCount_MaskedDevices) {
   int numDevices = 0;
   char visibleDeviceString[MAX_SIZE] = {};
   snprintf(visibleDeviceString, MAX_SIZE, "%d", VISIBLE_DEVICE);

--- a/projects/hip-tests/catch/multiproc/hipGetDevicePropertiesMproc.cc
+++ b/projects/hip-tests/catch/multiproc/hipGetDevicePropertiesMproc.cc
@@ -145,7 +145,7 @@ static bool validateGetPropsOfMaskedDevices(int actualNumGPUs) {
 /**
  * Scenario: Validate behavior of hipGetDeviceProperties for masked devices.
  */
-TEST_CASE("Unit_hipGetDeviceProperties_MaskedDevices") {
+TEST_CASE(Unit_hipGetDeviceProperties_MaskedDevices) {
   int count = -1;
   constexpr int ReqGPUs = 2;
   bool ret;

--- a/projects/hip-tests/catch/multiproc/hipIpcEventHandle.cc
+++ b/projects/hip-tests/catch/multiproc/hipIpcEventHandle.cc
@@ -238,7 +238,7 @@ void runMultiProcKernel(ipcEventInfo_t* shmEventInfo, int index) {
  * ------------------------
  *  - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_hipIpcEventHandle_Functional") {
+TEST_CASE(Unit_hipIpcEventHandle_Functional) {
   ipcDevices_t* shmDevices;
   ipcEventInfo_t* shmEventInfo;
   shmDevices = reinterpret_cast<ipcDevices_t*>(
@@ -333,7 +333,7 @@ TEST_CASE("Unit_hipIpcEventHandle_Functional") {
  *  - Host specific (LINUX)
  *  - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_hipIpcEventHandle_ParameterValidation") {
+TEST_CASE(Unit_hipIpcEventHandle_ParameterValidation) {
   hipEvent_t event;
   hipIpcEventHandle_t eventHandle;
   hipError_t ret;

--- a/projects/hip-tests/catch/multiproc/hipIpcMemAccessTest.cc
+++ b/projects/hip-tests/catch/multiproc/hipIpcMemAccessTest.cc
@@ -76,7 +76,7 @@ typedef struct mem_handle {
  *  - Host specific (LINUX)
  *  - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_hipIpcMemAccess_Semaphores") {
+TEST_CASE(Unit_hipIpcMemAccess_Semaphores) {
   hip_ipc_t* shrd_mem = NULL;
   pid_t pid;
   size_t N = 1024;
@@ -210,7 +210,7 @@ TEST_CASE("Unit_hipIpcMemAccess_Semaphores") {
  *  - Host specific (LINUX)
  *  - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_hipIpcMemAccess_ParameterValidation") {
+TEST_CASE(Unit_hipIpcMemAccess_ParameterValidation) {
   hipIpcMemHandle_t MemHandle;
   hipIpcMemHandle_t MemHandleUninit;
   void *Ad{}, *Ad2{};

--- a/projects/hip-tests/catch/multiproc/hipMallocConcurrencyMproc.cc
+++ b/projects/hip-tests/catch/multiproc/hipMallocConcurrencyMproc.cc
@@ -157,7 +157,7 @@ static bool validateMemoryOnGPU(int gpu, bool concurOnOneGPU = false) {
 /**
  * Parallel execution of parent and child on gpu0
  */
-TEST_CASE("Unit_hipMalloc_ChildConcurrencyDefaultGpu") {
+TEST_CASE(Unit_hipMalloc_ChildConcurrencyDefaultGpu) {
   int devCnt = 0, pid = 0;
   constexpr auto resSuccess = 1, resFailure = 2;
   bool TestPassed = true;
@@ -200,7 +200,7 @@ TEST_CASE("Unit_hipMalloc_ChildConcurrencyDefaultGpu") {
  * Parallel execution of api on multiple gpus from
  * different child processes.
  */
-TEST_CASE("Unit_hipMalloc_ChildConcurrencyMultiGpu") {
+TEST_CASE(Unit_hipMalloc_ChildConcurrencyMultiGpu) {
   int devCnt = 0, pid = 0;
   constexpr auto resSuccess = 1, resFailure = 2;
 

--- a/projects/hip-tests/catch/multiproc/hipMemCoherencyTstMProc.cc
+++ b/projects/hip-tests/catch/multiproc/hipMemCoherencyTstMProc.cc
@@ -101,7 +101,7 @@ bool static TstCoherency(int* Ptr, bool HmmMem) {
    behavior is observed or not with memory allocated using malloc()*/
 // The following test is failing on Nvidia platform hence disabled it for now
 #if HT_AMD
-TEST_CASE("Unit_malloc_CoherentTst") {
+TEST_CASE(Unit_malloc_CoherentTst) {
   CHECK_PCIE_ATOMIC_SUPPORT
   hipDeviceProp_t prop;
   HIPCHECK(hipGetDeviceProperties(&prop, 0));
@@ -132,7 +132,7 @@ TEST_CASE("Unit_malloc_CoherentTst") {
    behavior is observed or not with memory allocated using malloc()*/
 // The following test is failing on Nvidia platform hence disabling it for now
 #if HT_AMD
-TEST_CASE("Unit_malloc_CoherentTstWthAdvise") {
+TEST_CASE(Unit_malloc_CoherentTstWthAdvise) {
   hipDeviceProp_t prop;
   HIPCHECK(hipGetDeviceProperties(&prop, 0));
   char* p = NULL;
@@ -164,7 +164,7 @@ TEST_CASE("Unit_malloc_CoherentTstWthAdvise") {
    behavior is observed or not with memory allocated using mmap()*/
 // The following test is failing on Nvidia platform hence disabling it for now
 #if HT_AMD
-TEST_CASE("Unit_mmap_CoherentTst") {
+TEST_CASE(Unit_mmap_CoherentTst) {
   CHECK_PCIE_ATOMIC_SUPPORT
   hipDeviceProp_t prop;
   HIPCHECK(hipGetDeviceProperties(&prop, 0));
@@ -198,7 +198,7 @@ TEST_CASE("Unit_mmap_CoherentTst") {
    behavior is observed or not with memory allocated using mmap()*/
 // The following test is failing on Nvidia platform hence disabling it for now
 #if HT_AMD
-TEST_CASE("Unit_mmap_CoherentTstWthAdvise") {
+TEST_CASE(Unit_mmap_CoherentTstWthAdvise) {
   hipDeviceProp_t prop;
   HIPCHECK(hipGetDeviceProperties(&prop, 0));
   char* p = NULL;
@@ -242,7 +242,7 @@ TEST_CASE("Unit_mmap_CoherentTstWthAdvise") {
    accessible when HIP_HOST_COHERENT is set to 0*/
 // The following test is AMD specific test hence skipping for Nvidia
 #if HT_AMD
-TEST_CASE("Unit_hipHostMalloc_WthEnv0Flg1") {
+TEST_CASE(Unit_hipHostMalloc_WthEnv0Flg1) {
   if ((setenv("HIP_HOST_COHERENT", "0", 1)) != 0) {
     WARN("Unable to turn on HIP_HOST_COHERENT, hence terminating the Test case!");
     REQUIRE(false);
@@ -282,7 +282,7 @@ TEST_CASE("Unit_hipHostMalloc_WthEnv0Flg1") {
    accessible when HIP_HOST_COHERENT is set to 0*/
 // The following test is AMD specific test hence skipping for Nvidia
 #if HT_AMD
-TEST_CASE("Unit_hipHostMalloc_WthEnv0Flg2") {
+TEST_CASE(Unit_hipHostMalloc_WthEnv0Flg2) {
   if ((setenv("HIP_HOST_COHERENT", "0", 1)) != 0) {
     WARN("Unable to turn on HIP_HOST_COHERENT, hence terminating the Test case!");
     REQUIRE(false);
@@ -322,7 +322,7 @@ TEST_CASE("Unit_hipHostMalloc_WthEnv0Flg2") {
    accessible when HIP_HOST_COHERENT is set to 0*/
 // The following test is AMD specific test hence skipping for Nvidia
 #if HT_AMD
-TEST_CASE("Unit_hipHostMalloc_WthEnv0Flg3") {
+TEST_CASE(Unit_hipHostMalloc_WthEnv0Flg3) {
   if ((setenv("HIP_HOST_COHERENT", "0", 1)) != 0) {
     WARN("Unable to turn on HIP_HOST_COHERENT, hence terminating the Test case!");
     REQUIRE(false);
@@ -362,7 +362,7 @@ TEST_CASE("Unit_hipHostMalloc_WthEnv0Flg3") {
    accessible when HIP_HOST_COHERENT is set to 0*/
 // The following test is AMD specific test hence skipping for Nvidia
 #if HT_AMD
-TEST_CASE("Unit_hipHostMalloc_WthEnv0Flg4") {
+TEST_CASE(Unit_hipHostMalloc_WthEnv0Flg4) {
   if ((setenv("HIP_HOST_COHERENT", "0", 1)) != 0) {
     WARN("Unable to turn on HIP_HOST_COHERENT, hence terminating the Test case!");
     REQUIRE(false);
@@ -403,7 +403,7 @@ TEST_CASE("Unit_hipHostMalloc_WthEnv0Flg4") {
    fine grain behavior when HIP_HOST_COHERENT is set to 1*/
 // The following test is AMD specific test hence skipping for Nvidia
 #if HT_AMD
-TEST_CASE("Unit_hipHostMalloc_WthEnv1") {
+TEST_CASE(Unit_hipHostMalloc_WthEnv1) {
   if ((setenv("HIP_HOST_COHERENT", "1", 1)) != 0) {
     WARN("Unable to turn on HIP_HOST_COHERENT, hence terminating the Test case!");
     REQUIRE(false);
@@ -432,7 +432,7 @@ TEST_CASE("Unit_hipHostMalloc_WthEnv1") {
    fine grain behavior when HIP_HOST_COHERENT is set to 1*/
 // The following test is AMD specific test hence skipping for Nvidia
 #if HT_AMD
-TEST_CASE("Unit_hipHostMalloc_WthEnv1Flg1") {
+TEST_CASE(Unit_hipHostMalloc_WthEnv1Flg1) {
   if ((setenv("HIP_HOST_COHERENT", "1", 1)) != 0) {
     WARN("Unable to turn on HIP_HOST_COHERENT, hence terminating the Test case!");
     REQUIRE(false);
@@ -460,7 +460,7 @@ TEST_CASE("Unit_hipHostMalloc_WthEnv1Flg1") {
    fine grain behavior when HIP_HOST_COHERENT is set to 1*/
 // The following test is AMD specific test hence skipping for Nvidia
 #if HT_AMD
-TEST_CASE("Unit_hipHostMalloc_WthEnv1Flg2") {
+TEST_CASE(Unit_hipHostMalloc_WthEnv1Flg2) {
   if ((setenv("HIP_HOST_COHERENT", "1", 1)) != 0) {
     WARN("Unable to turn on HIP_HOST_COHERENT, hence terminating the Test case!");
     REQUIRE(false);
@@ -488,7 +488,7 @@ TEST_CASE("Unit_hipHostMalloc_WthEnv1Flg2") {
    fine grain behavior when HIP_HOST_COHERENT is set to 1*/
 // The following test is AMD specific test hence skipping for Nvidia
 #if HT_AMD
-TEST_CASE("Unit_hipHostMalloc_WthEnv1Flg3") {
+TEST_CASE(Unit_hipHostMalloc_WthEnv1Flg3) {
   if ((setenv("HIP_HOST_COHERENT", "1", 1)) != 0) {
     WARN("Unable to turn on HIP_HOST_COHERENT, hence terminating the Test case!");
     REQUIRE(false);

--- a/projects/hip-tests/catch/multiproc/hipMemGetInfoMProc.cc
+++ b/projects/hip-tests/catch/multiproc/hipMemGetInfoMProc.cc
@@ -34,7 +34,7 @@ THE SOFTWARE.
  * Fork() a child process and verify that 2 GB has been
  * allocated in parent process.
  */
-TEST_CASE("Unit_hipMemGetInfo_Functional_Scenario1") {
+TEST_CASE(Unit_hipMemGetInfo_Functional_Scenario1) {
   constexpr size_t size = 2147483648;  // 2GB
   int fd[2], fd1[2], status;
   status = pipe(fd);
@@ -94,7 +94,7 @@ TEST_CASE("Unit_hipMemGetInfo_Functional_Scenario1") {
  * 2 GB of device memory. Signal the parent process. Verify from the parent
  * process that 2 GB is allocated in the child process.
  */
-TEST_CASE("Unit_hipMemGetInfo_Functional_Scenario2") {
+TEST_CASE(Unit_hipMemGetInfo_Functional_Scenario2) {
   constexpr size_t size = 2147483648;  // 2GB
   int fd[2], fd2[2], status;
   status = pipe(fd);
@@ -151,7 +151,7 @@ TEST_CASE("Unit_hipMemGetInfo_Functional_Scenario2") {
  * child process. Verify from the parent process that 2 GB is
  * freed in the child process.
  */
-TEST_CASE("Unit_hipMemGetInfo_Functional_Scenario3") {
+TEST_CASE(Unit_hipMemGetInfo_Functional_Scenario3) {
   constexpr size_t size = 2147483648;  // 2GB
   int fd[2], status;
   status = pipe(fd);
@@ -193,7 +193,7 @@ TEST_CASE("Unit_hipMemGetInfo_Functional_Scenario3") {
  * 2 GB of device memory. Exit from child process. Verify from the parent
  * process that 2 GB is freed in the child process.
  */
-TEST_CASE("Unit_hipMemGetInfo_Functional_scenario4") {
+TEST_CASE(Unit_hipMemGetInfo_Functional_scenario4) {
   constexpr size_t size = 2147483648;  // 2GB
   pid_t child_pid;
   child_pid = fork();  // Create a new child process
@@ -219,7 +219,7 @@ TEST_CASE("Unit_hipMemGetInfo_Functional_scenario4") {
  * Fork() a child process and verify that 2 GB has been allocated from
  * parent process in every device.
  */
-TEST_CASE("Unit_hipMemGetInfo_Functional_MultiDevice_Scenario5") {
+TEST_CASE(Unit_hipMemGetInfo_Functional_MultiDevice_Scenario5) {
   constexpr size_t size = 2147483648;  // 2GB
   size_t free = 0, total = 0;
   int fd1[2], fd2[2], status;
@@ -367,7 +367,7 @@ static bool testHiddenFreeMemFromChild() {
  * in parent. Get free and total memory. Free memory available should be
  * actual (actual free - 4 GB).
  */
-TEST_CASE("Unit_hipMemGetInfo_SetHiddenFreeMemFromChild") {
+TEST_CASE(Unit_hipMemGetInfo_SetHiddenFreeMemFromChild) {
   REQUIRE(true == testHiddenFreeMemFromChild());
 }
 
@@ -375,7 +375,7 @@ TEST_CASE("Unit_hipMemGetInfo_SetHiddenFreeMemFromChild") {
  * Scenario: Set the HIP_HIDDEN_FREE_MEM to 4GB. Invoke hipMemGetInfo to
  * verify that 4GB free memory is hidden for all available GPUs.
  */
-TEST_CASE("Unit_hipMemGetInfo_VerifyHiddenFreeMemForAllGpu") {
+TEST_CASE(Unit_hipMemGetInfo_VerifyHiddenFreeMemForAllGpu) {
   int numDevices = 0;
   int64_t size_tohide = (FREE_MEM_TO_HIDE / (1024 * 1024));  // in MB
   // set environment variable from shell

--- a/projects/hip-tests/catch/multiproc/hipNoGpuTsts.cc
+++ b/projects/hip-tests/catch/multiproc/hipNoGpuTsts.cc
@@ -1321,256 +1321,256 @@ static bool NoGpuTst_Common(bool (*test_fn)()) {
 }
 
 // Tests
-TEST_CASE("Unit_NoGpuTst_hipGetDeviceCount") {
+TEST_CASE(Unit_NoGpuTst_hipGetDeviceCount) {
   REQUIRE(NoGpuTst_Common(NoGpuTst_hipGetDeviceCount));
 }
 
-TEST_CASE("Unit_NoGpuTst_hipSetDevice") { REQUIRE(NoGpuTst_Common(NoGpuTst_hipSetDevice)); }
+TEST_CASE(Unit_NoGpuTst_hipSetDevice) { REQUIRE(NoGpuTst_Common(NoGpuTst_hipSetDevice)); }
 
-TEST_CASE("Unit_NoGpuTst_hipDeviceGetAttribute") {
+TEST_CASE(Unit_NoGpuTst_hipDeviceGetAttribute) {
   REQUIRE(NoGpuTst_Common(NoGpuTst_hipDeviceGetAttribute));
 }
 
-TEST_CASE("Unit_NoGpuTst_hipDeviceGetP2PAttribute") {
+TEST_CASE(Unit_NoGpuTst_hipDeviceGetP2PAttribute) {
   REQUIRE(NoGpuTst_Common(NoGpuTst_hipDeviceGetP2PAttribute));
 }
 
-TEST_CASE("Unit_NoGpuTst_hipDeviceGetPCIBusId") {
+TEST_CASE(Unit_NoGpuTst_hipDeviceGetPCIBusId) {
   REQUIRE(NoGpuTst_Common(NoGpuTst_hipDeviceGetPCIBusId));
 }
 
-TEST_CASE("Unit_NoGpuTst_hipDeviceGetByPCIBusId") {
+TEST_CASE(Unit_NoGpuTst_hipDeviceGetByPCIBusId) {
   REQUIRE(NoGpuTst_Common(NoGpuTst_hipDeviceGetByPCIBusId));
 }
 
-TEST_CASE("Unit_NoGpuTst_hipDeviceTotalMem") {
+TEST_CASE(Unit_NoGpuTst_hipDeviceTotalMem) {
   REQUIRE(NoGpuTst_Common(NoGpuTst_hipDeviceTotalMem));
 }
 
-TEST_CASE("Unit_NoGpuTst_hipFuncSetSharedMemConfig") {
+TEST_CASE(Unit_NoGpuTst_hipFuncSetSharedMemConfig) {
   REQUIRE(NoGpuTst_Common(NoGpuTst_hipFuncSetSharedMemConfig));
 }
 
-TEST_CASE("Unit_NoGpuTst_hipStreamCreate") { REQUIRE(NoGpuTst_Common(NoGpuTst_hipStreamCreate)); }
+TEST_CASE(Unit_NoGpuTst_hipStreamCreate) { REQUIRE(NoGpuTst_Common(NoGpuTst_hipStreamCreate)); }
 
-TEST_CASE("Unit_NoGpuTst_hipStreamCreateWithPriority") {
+TEST_CASE(Unit_NoGpuTst_hipStreamCreateWithPriority) {
   REQUIRE(NoGpuTst_Common(NoGpuTst_hipStreamCreateWithPriority));
 }
 
-TEST_CASE("Unit_NoGpuTst_hipStreamSynchronize") {
+TEST_CASE(Unit_NoGpuTst_hipStreamSynchronize) {
   REQUIRE(NoGpuTst_Common(NoGpuTst_hipStreamSynchronize));
 }
 
-TEST_CASE("Unit_NoGpuTst_hipStreamGetFlags") {
+TEST_CASE(Unit_NoGpuTst_hipStreamGetFlags) {
   REQUIRE(NoGpuTst_Common(NoGpuTst_hipStreamGetFlags));
 }
 #if HT_AMD
-TEST_CASE("Unit_NoGpuTst_hipExtStreamCreateWithCUMask") {
+TEST_CASE(Unit_NoGpuTst_hipExtStreamCreateWithCUMask) {
   REQUIRE(NoGpuTst_Common(NoGpuTst_hipExtStreamCreateWithCUMask));
 }
 #endif
-TEST_CASE("Unit_NoGpuTst_hipStreamAddCallback") {
+TEST_CASE(Unit_NoGpuTst_hipStreamAddCallback) {
   REQUIRE(NoGpuTst_Common(NoGpuTst_hipStreamAddCallback));
 }
 
-TEST_CASE("Unit_NoGpuTst_hipEventCreateWithFlags") {
+TEST_CASE(Unit_NoGpuTst_hipEventCreateWithFlags) {
   REQUIRE(NoGpuTst_Common(NoGpuTst_hipEventCreateWithFlags));
 }
 
-TEST_CASE("Unit_NoGpuTst_hipDeviceSynchronize") {
+TEST_CASE(Unit_NoGpuTst_hipDeviceSynchronize) {
   REQUIRE(NoGpuTst_Common(NoGpuTst_hipDeviceSynchronize));
 }
 
-TEST_CASE("Unit_NoGpuTst_hipGetDevice") { REQUIRE(NoGpuTst_Common(NoGpuTst_hipGetDevice)); }
+TEST_CASE(Unit_NoGpuTst_hipGetDevice) { REQUIRE(NoGpuTst_Common(NoGpuTst_hipGetDevice)); }
 
-TEST_CASE("Unit_NoGpuTst_hipDeviceGetCacheConfig") {
+TEST_CASE(Unit_NoGpuTst_hipDeviceGetCacheConfig) {
   REQUIRE(NoGpuTst_Common(NoGpuTst_hipDeviceGetCacheConfig));
 }
 
-TEST_CASE("Unit_NoGpuTst_hipDeviceGetSharedMemConfig") {
+TEST_CASE(Unit_NoGpuTst_hipDeviceGetSharedMemConfig) {
   REQUIRE(NoGpuTst_Common(NoGpuTst_hipDeviceGetSharedMemConfig));
 }
 
-TEST_CASE("Unit_NoGpuTst_hipDeviceSetSharedMemConfig") {
+TEST_CASE(Unit_NoGpuTst_hipDeviceSetSharedMemConfig) {
   REQUIRE(NoGpuTst_Common(NoGpuTst_hipDeviceSetSharedMemConfig));
 }
 
-TEST_CASE("Unit_NoGpuTst_hipPointerGetAttributes") {
+TEST_CASE(Unit_NoGpuTst_hipPointerGetAttributes) {
   REQUIRE(NoGpuTst_Common(NoGpuTst_hipPointerGetAttributes));
 }
 #if HT_AMD
-TEST_CASE("Unit_NoGpuTst_hipExtMallocWithFlags") {
+TEST_CASE(Unit_NoGpuTst_hipExtMallocWithFlags) {
   REQUIRE(NoGpuTst_Common(NoGpuTst_hipExtMallocWithFlags));
 }
 #endif
-TEST_CASE("Unit_NoGpuTst_hipMallocManaged") { REQUIRE(NoGpuTst_Common(NoGpuTst_hipMallocManaged)); }
+TEST_CASE(Unit_NoGpuTst_hipMallocManaged) { REQUIRE(NoGpuTst_Common(NoGpuTst_hipMallocManaged)); }
 
-TEST_CASE("Unit_NoGpuTst_hipHostFree") { REQUIRE(NoGpuTst_Common(NoGpuTst_hipHostFree)); }
+TEST_CASE(Unit_NoGpuTst_hipHostFree) { REQUIRE(NoGpuTst_Common(NoGpuTst_hipHostFree)); }
 
-TEST_CASE("Unit_NoGpuTst_hipMemcpyWithStream") {
+TEST_CASE(Unit_NoGpuTst_hipMemcpyWithStream) {
   REQUIRE(NoGpuTst_Common(NoGpuTst_hipMemcpyWithStream));
 }
 
-TEST_CASE("Unit_NoGpuTst_hipMallocArray") { REQUIRE(NoGpuTst_Common(NoGpuTst_hipMallocArray)); }
+TEST_CASE(Unit_NoGpuTst_hipMallocArray) { REQUIRE(NoGpuTst_Common(NoGpuTst_hipMallocArray)); }
 #if HT_AMD
-TEST_CASE("Unit_NoGpuTst_hipMallocMipmappedArray") {
+TEST_CASE(Unit_NoGpuTst_hipMallocMipmappedArray) {
   REQUIRE(NoGpuTst_Common(NoGpuTst_hipMallocMipmappedArray));
 }
 #endif
-TEST_CASE("Unit_NoGpuTst_hipDeviceEnablePeerAccess") {
+TEST_CASE(Unit_NoGpuTst_hipDeviceEnablePeerAccess) {
   REQUIRE(NoGpuTst_Common(NoGpuTst_hipDeviceEnablePeerAccess));
 }
 
-TEST_CASE("Unit_NoGpuTst_hipHostMalloc") { REQUIRE(NoGpuTst_Common(NoGpuTst_hipHostMalloc)); }
+TEST_CASE(Unit_NoGpuTst_hipHostMalloc) { REQUIRE(NoGpuTst_Common(NoGpuTst_hipHostMalloc)); }
 
-TEST_CASE("Unit_NoGpuTst_hipMalloc") { REQUIRE(NoGpuTst_Common(NoGpuTst_hipMalloc)); }
+TEST_CASE(Unit_NoGpuTst_hipMalloc) { REQUIRE(NoGpuTst_Common(NoGpuTst_hipMalloc)); }
 
-TEST_CASE("Unit_NoGpuTst_hipHostRegister") { REQUIRE(NoGpuTst_Common(NoGpuTst_hipHostRegister)); }
+TEST_CASE(Unit_NoGpuTst_hipHostRegister) { REQUIRE(NoGpuTst_Common(NoGpuTst_hipHostRegister)); }
 
-TEST_CASE("Unit_NoGpuTst_hipMemcpy") { REQUIRE(NoGpuTst_Common(NoGpuTst_hipMemcpy)); }
+TEST_CASE(Unit_NoGpuTst_hipMemcpy) { REQUIRE(NoGpuTst_Common(NoGpuTst_hipMemcpy)); }
 
-TEST_CASE("Unit_NoGpuTst_hipMemAllocPitch") { REQUIRE(NoGpuTst_Common(NoGpuTst_hipMemAllocPitch)); }
+TEST_CASE(Unit_NoGpuTst_hipMemAllocPitch) { REQUIRE(NoGpuTst_Common(NoGpuTst_hipMemAllocPitch)); }
 
-TEST_CASE("Unit_NoGpuTst_hipMemGetInfo") { REQUIRE(NoGpuTst_Common(NoGpuTst_hipMemGetInfo)); }
+TEST_CASE(Unit_NoGpuTst_hipMemGetInfo) { REQUIRE(NoGpuTst_Common(NoGpuTst_hipMemGetInfo)); }
 
-TEST_CASE("Unit_NoGpuTst_hipMalloc3DArray") { REQUIRE(NoGpuTst_Common(NoGpuTst_hipMalloc3DArray)); }
+TEST_CASE(Unit_NoGpuTst_hipMalloc3DArray) { REQUIRE(NoGpuTst_Common(NoGpuTst_hipMalloc3DArray)); }
 
-TEST_CASE("Unit_NoGpuTst_hipDeviceCanAccessPeer") {
+TEST_CASE(Unit_NoGpuTst_hipDeviceCanAccessPeer) {
   REQUIRE(NoGpuTst_Common(NoGpuTst_hipDeviceCanAccessPeer));
 }
 
-TEST_CASE("Unit_NoGpuTst_hipDeviceDisablePeerAccess") {
+TEST_CASE(Unit_NoGpuTst_hipDeviceDisablePeerAccess) {
   REQUIRE(NoGpuTst_Common(NoGpuTst_hipDeviceDisablePeerAccess));
 }
 
-TEST_CASE("Unit_NoGpuTst_hipDeviceGet") { REQUIRE(NoGpuTst_Common(NoGpuTst_hipDeviceGet)); }
+TEST_CASE(Unit_NoGpuTst_hipDeviceGet) { REQUIRE(NoGpuTst_Common(NoGpuTst_hipDeviceGet)); }
 
-TEST_CASE("Unit_NoGpuTst_hipDeviceComputeCapability") {
+TEST_CASE(Unit_NoGpuTst_hipDeviceComputeCapability) {
   REQUIRE(NoGpuTst_Common(NoGpuTst_hipDeviceComputeCapability));
 }
 
-TEST_CASE("Unit_NoGpuTst_hipDeviceGetName") { REQUIRE(NoGpuTst_Common(NoGpuTst_hipDeviceGetName)); }
+TEST_CASE(Unit_NoGpuTst_hipDeviceGetName) { REQUIRE(NoGpuTst_Common(NoGpuTst_hipDeviceGetName)); }
 
-TEST_CASE("Unit_NoGpuTst_hipGetDeviceProperties") {
+TEST_CASE(Unit_NoGpuTst_hipGetDeviceProperties) {
   REQUIRE(NoGpuTst_Common(NoGpuTst_hipGetDeviceProperties));
 }
 
-TEST_CASE("Unit_NoGpuTst_hipChooseDevice") { REQUIRE(NoGpuTst_Common(NoGpuTst_hipChooseDevice)); }
+TEST_CASE(Unit_NoGpuTst_hipChooseDevice) { REQUIRE(NoGpuTst_Common(NoGpuTst_hipChooseDevice)); }
 
 #if HT_AMD
-TEST_CASE("Unit_NoGpuTst_hipExtGetLinkTypeAndHopCount") {
+TEST_CASE(Unit_NoGpuTst_hipExtGetLinkTypeAndHopCount) {
   REQUIRE(NoGpuTst_Common(NoGpuTst_hipExtGetLinkTypeAndHopCount));
 }
 
-TEST_CASE("Unit_NoGpuTst_hipExtStreamGetCUMask") {
+TEST_CASE(Unit_NoGpuTst_hipExtStreamGetCUMask) {
   REQUIRE(NoGpuTst_Common(NoGpuTst_hipExtStreamGetCUMask));
 }
 #endif
 
-TEST_CASE("Unit_NoGpuTst_hipFuncSetAttribute") {
+TEST_CASE(Unit_NoGpuTst_hipFuncSetAttribute) {
   REQUIRE(NoGpuTst_Common(NoGpuTst_hipFuncSetAttribute));
 }
 
-TEST_CASE("Unit_NoGpuTst_hipFuncSetCacheConfig") {
+TEST_CASE(Unit_NoGpuTst_hipFuncSetCacheConfig) {
   REQUIRE(NoGpuTst_Common(NoGpuTst_hipFuncSetCacheConfig));
 }
 
-TEST_CASE("Unit_NoGpuTst_hipStreamCreateWithFlags") {
+TEST_CASE(Unit_NoGpuTst_hipStreamCreateWithFlags) {
   REQUIRE(NoGpuTst_Common(NoGpuTst_hipStreamCreateWithFlags));
 }
 
-TEST_CASE("Unit_NoGpuTst_hipDeviceGetStreamPriorityRange") {
+TEST_CASE(Unit_NoGpuTst_hipDeviceGetStreamPriorityRange) {
   REQUIRE(NoGpuTst_Common(NoGpuTst_hipDeviceGetStreamPriorityRange));
 }
 
-TEST_CASE("Unit_NoGpuTst_hipEventCreate") { REQUIRE(NoGpuTst_Common(NoGpuTst_hipEventCreate)); }
+TEST_CASE(Unit_NoGpuTst_hipEventCreate) { REQUIRE(NoGpuTst_Common(NoGpuTst_hipEventCreate)); }
 
-TEST_CASE("Unit_NoGpuTst_hipStreamGetPriority") {
+TEST_CASE(Unit_NoGpuTst_hipStreamGetPriority) {
   REQUIRE(NoGpuTst_Common(NoGpuTst_hipStreamGetPriority));
 }
 
-TEST_CASE("Unit_NoGpuTst_hipDeviceReset") { REQUIRE(NoGpuTst_Common(NoGpuTst_hipDeviceReset)); }
+TEST_CASE(Unit_NoGpuTst_hipDeviceReset) { REQUIRE(NoGpuTst_Common(NoGpuTst_hipDeviceReset)); }
 
-TEST_CASE("Unit_NoGpuTst_hipDeviceSetCacheConfig") {
+TEST_CASE(Unit_NoGpuTst_hipDeviceSetCacheConfig) {
   REQUIRE(NoGpuTst_Common(NoGpuTst_hipDeviceSetCacheConfig));
 }
 
-TEST_CASE("Unit_NoGpuTst_hipDeviceGetLimit") {
+TEST_CASE(Unit_NoGpuTst_hipDeviceGetLimit) {
   REQUIRE(NoGpuTst_Common(NoGpuTst_hipDeviceGetLimit));
 }
 
-TEST_CASE("Unit_NoGpuTst_hipGetDeviceFlags") {
+TEST_CASE(Unit_NoGpuTst_hipGetDeviceFlags) {
   REQUIRE(NoGpuTst_Common(NoGpuTst_hipGetDeviceFlags));
 }
 
-TEST_CASE("Unit_NoGpuTst_hipSetDeviceFlags") {
+TEST_CASE(Unit_NoGpuTst_hipSetDeviceFlags) {
   REQUIRE(NoGpuTst_Common(NoGpuTst_hipSetDeviceFlags));
 }
 
-TEST_CASE("Unit_NoGpuTst_hipModuleLoad") { REQUIRE(NoGpuTst_Common(NoGpuTst_hipModuleLoad)); }
+TEST_CASE(Unit_NoGpuTst_hipModuleLoad) { REQUIRE(NoGpuTst_Common(NoGpuTst_hipModuleLoad)); }
 
-TEST_CASE("Unit_NoGpuTst_hipFuncGetAttributes") {
+TEST_CASE(Unit_NoGpuTst_hipFuncGetAttributes) {
   REQUIRE(NoGpuTst_Common(NoGpuTst_hipFuncGetAttributes));
 }
 
-TEST_CASE("Unit_NoGpuTst_hipModuleLoadData") {
+TEST_CASE(Unit_NoGpuTst_hipModuleLoadData) {
   REQUIRE(NoGpuTst_Common(NoGpuTst_hipModuleLoadData));
 }
 
-TEST_CASE("Unit_NoGpuTst_hipModuleLoadDataEx") {
+TEST_CASE(Unit_NoGpuTst_hipModuleLoadDataEx) {
   REQUIRE(NoGpuTst_Common(NoGpuTst_hipModuleLoadDataEx));
 }
 
-TEST_CASE("Unit_NoGpuTst_hipLaunchCooperativeKernel") {
+TEST_CASE(Unit_NoGpuTst_hipLaunchCooperativeKernel) {
   REQUIRE(NoGpuTst_Common(NoGpuTst_hipLaunchCooperativeKernel));
 }
 
 #if HT_AMD
-TEST_CASE("Unit_NoGpuTst_hipLaunchCooperativeKernelMultiDevice") {
+TEST_CASE(Unit_NoGpuTst_hipLaunchCooperativeKernelMultiDevice) {
   REQUIRE(NoGpuTst_Common(NoGpuTst_hipLaunchCooperativeKernelMultiDevice));
 }
-TEST_CASE("Unit_NoGpuTst_hipExtLaunchMultiKernelMultiDevice") {
+TEST_CASE(Unit_NoGpuTst_hipExtLaunchMultiKernelMultiDevice) {
   REQUIRE(NoGpuTst_Common(NoGpuTst_hipExtLaunchMultiKernelMultiDevice));
 }
 #endif
-TEST_CASE("Unit_NoGpuTst_hipOccupancyMaxActiveBlocksPerMultiprocessor") {
+TEST_CASE(Unit_NoGpuTst_hipOccupancyMaxActiveBlocksPerMultiprocessor) {
   REQUIRE(NoGpuTst_Common(NoGpuTst_hipOccupancyMaxActiveBlocksPerMultiprocessor));
 }
 
-TEST_CASE("Unit_NoGpuTst_hipOccupancyMaxActiveBlocksPerMultiprocessorFlags") {
+TEST_CASE(Unit_NoGpuTst_hipOccupancyMaxActiveBlocksPerMultiprocessorFlags) {
   REQUIRE(NoGpuTst_Common(NoGpuTst_hipOccupancyMaxActiveBlocksPerMultiprocessorFlags));
 }
 
-TEST_CASE("Unit_NoGpuTst_hipOccupancyMaxPotentialBlockSize") {
+TEST_CASE(Unit_NoGpuTst_hipOccupancyMaxPotentialBlockSize) {
   REQUIRE(NoGpuTst_Common(NoGpuTst_hipOccupancyMaxPotentialBlockSize));
 }
 
-TEST_CASE("Unit_NoGpuTst_hiprtcVersion") { REQUIRE(NoGpuTst_Common(NoGpuTst_hiprtcVersion)); }
+TEST_CASE(Unit_NoGpuTst_hiprtcVersion) { REQUIRE(NoGpuTst_Common(NoGpuTst_hiprtcVersion)); }
 
-TEST_CASE("Unit_NoGpuTst_hiprtcCreateProgram_DestroyProg") {
+TEST_CASE(Unit_NoGpuTst_hiprtcCreateProgram_DestroyProg) {
   REQUIRE(NoGpuTst_Common(NoGpuTst_hiprtcCreateProgram_DestroyProg));
 }
 
-TEST_CASE("Unit_NoGpuTst_hiprtcAddNameExpression") {
+TEST_CASE(Unit_NoGpuTst_hiprtcAddNameExpression) {
   REQUIRE(NoGpuTst_Common(NoGpuTst_hiprtcAddNameExpression));
 }
 
-TEST_CASE("Unit_NoGpuTst_hipMallocPitch") { REQUIRE(NoGpuTst_Common(NoGpuTst_hipMallocPitch)); }
+TEST_CASE(Unit_NoGpuTst_hipMallocPitch) { REQUIRE(NoGpuTst_Common(NoGpuTst_hipMallocPitch)); }
 
 #if HT_AMD
-TEST_CASE("Unit_NoGpuTst_hipMipmappedArrayCreate") {
+TEST_CASE(Unit_NoGpuTst_hipMipmappedArrayCreate) {
   REQUIRE(NoGpuTst_Common(NoGpuTst_hipMipmappedArrayCreate));
 }
 #endif
-TEST_CASE("Unit_NoGpuTst_hipMalloc3D") { REQUIRE(NoGpuTst_Common(NoGpuTst_hipMalloc3D)); }
+TEST_CASE(Unit_NoGpuTst_hipMalloc3D) { REQUIRE(NoGpuTst_Common(NoGpuTst_hipMalloc3D)); }
 
-TEST_CASE("Unit_NoGpuTst_hipGraphCreate") { REQUIRE(NoGpuTst_Common(NoGpuTst_hipGraphCreate)); }
+TEST_CASE(Unit_NoGpuTst_hipGraphCreate) { REQUIRE(NoGpuTst_Common(NoGpuTst_hipGraphCreate)); }
 
-TEST_CASE("Unit_NoGpuTst_hipStreamBeginCapture") {
+TEST_CASE(Unit_NoGpuTst_hipStreamBeginCapture) {
   REQUIRE(NoGpuTst_Common(NoGpuTst_hipStreamBeginCapture));
 }
 
-TEST_CASE("Unit_NoGpuTst_hipStreamIsCapturing") {
+TEST_CASE(Unit_NoGpuTst_hipStreamIsCapturing) {
   REQUIRE(NoGpuTst_Common(NoGpuTst_hipStreamIsCapturing));
 }
 #endif  // #ifdef __linux__

--- a/projects/hip-tests/catch/multiproc/hipSetGetDeviceMproc.cc
+++ b/projects/hip-tests/catch/multiproc/hipSetGetDeviceMproc.cc
@@ -397,7 +397,7 @@ static void testMinRvdMaxHvd(int numDevices, int* deviceList, int count) {
 /**
  * Scenario sets Invalid visible device list and checks behavior.
  */
-TEST_CASE("Unit_hipSetDevice_InvalidVisibleDeviceList") {
+TEST_CASE(Unit_hipSetDevice_InvalidVisibleDeviceList) {
   int numDevices = 0;
 
   getDeviceCount(&numDevices);
@@ -420,7 +420,7 @@ TEST_CASE("Unit_hipSetDevice_InvalidVisibleDeviceList") {
 /**
  * Scenario sets valid visible device list and checks behavior.
  */
-TEST_CASE("Unit_hipSetDevice_ValidVisibleDeviceList") {
+TEST_CASE(Unit_hipSetDevice_ValidVisibleDeviceList) {
   int numDevices = 0;
   std::vector<int> deviceList;
 
@@ -445,7 +445,7 @@ TEST_CASE("Unit_hipSetDevice_ValidVisibleDeviceList") {
 /**
  * Scenario sets subset of available devices and checks behavior.
  */
-TEST_CASE("Unit_hipSetDevice_SubsetOfAvailableDevices") {
+TEST_CASE(Unit_hipSetDevice_SubsetOfAvailableDevices) {
   int numDevices = 0;
   int deviceList[MAX_SIZE];
   int deviceListLength = 1;
@@ -471,7 +471,7 @@ TEST_CASE("Unit_hipSetDevice_SubsetOfAvailableDevices") {
  * Scenario tests getDevice behavior with Minimal Len of RVD
  * and Maximal Len of HVD
  */
-TEST_CASE("Unit_hipSetDevice_MinRvdMaxHvdDevicesList") {
+TEST_CASE(Unit_hipSetDevice_MinRvdMaxHvdDevicesList) {
   int numDevices = 0;
   std::vector<int> deviceList;
   int count = 0;
@@ -499,7 +499,7 @@ TEST_CASE("Unit_hipSetDevice_MinRvdMaxHvdDevicesList") {
  * Scenario tests getDevice behavior with Maximal Len of RVD
  * and Minimal Len of HVD
  */
-TEST_CASE("Unit_hipSetDevice_MaxRvdMinHvdDevicesList") {
+TEST_CASE(Unit_hipSetDevice_MaxRvdMinHvdDevicesList) {
   int numDevices = 0;
   std::vector<int> deviceList;
 
@@ -523,7 +523,7 @@ TEST_CASE("Unit_hipSetDevice_MaxRvdMinHvdDevicesList") {
 /**
  * Scenario tests getDevice behavior with combination of RVD and CVD
  */
-TEST_CASE("Unit_hipSetDevice_RvdCvdDevicesList") {
+TEST_CASE(Unit_hipSetDevice_RvdCvdDevicesList) {
   int numDevices = 0;
   int deviceList[MAX_SIZE];
   int count = 0;

--- a/projects/hip-tests/catch/performance/event/hipEventCreate.cc
+++ b/projects/hip-tests/catch/performance/event/hipEventCreate.cc
@@ -50,7 +50,7 @@ class HipEventCreateBenchmark : public Benchmark<HipEventCreateBenchmark> {
  * ------------------------
  *  - HIP_VERSION >= 5.2
  */
-TEST_CASE("Performance_hipEventCreate") {
+TEST_CASE(Performance_hipEventCreate) {
   HipEventCreateBenchmark benchmark;
   benchmark.Run();
 }

--- a/projects/hip-tests/catch/performance/event/hipEventCreateWithFlags.cc
+++ b/projects/hip-tests/catch/performance/event/hipEventCreateWithFlags.cc
@@ -75,7 +75,7 @@ static void RunBenchmark(unsigned flag) {
  * ------------------------
  *  - HIP_VERSION >= 5.2
  */
-TEST_CASE("Performance_hipEventCreateWithFlags") {
+TEST_CASE(Performance_hipEventCreateWithFlags) {
   const auto flag = GENERATE(
       hipEventDefault, hipEventBlockingSync,
       hipEventDisableTiming /*, hipEventInterprocess  disabled until fixed (EXSWHTEC-25) */);

--- a/projects/hip-tests/catch/performance/event/hipEventDestroy.cc
+++ b/projects/hip-tests/catch/performance/event/hipEventDestroy.cc
@@ -48,7 +48,7 @@ class HipEventDestroyBenchmark : public Benchmark<HipEventDestroyBenchmark> {
  * ------------------------
  *  - HIP_VERSION >= 5.2
  */
-TEST_CASE("Performance_hipEventDestroy") {
+TEST_CASE(Performance_hipEventDestroy) {
   HipEventDestroyBenchmark benchmark;
   benchmark.Run();
 }

--- a/projects/hip-tests/catch/performance/event/hipEventElapsedTime.cc
+++ b/projects/hip-tests/catch/performance/event/hipEventElapsedTime.cc
@@ -62,7 +62,7 @@ class HipEventElapsedTimeBenchmark : public Benchmark<HipEventElapsedTimeBenchma
  * ------------------------
  *  - HIP_VERSION >= 5.2
  */
-TEST_CASE("Performance_hipEventElapsedTime") {
+TEST_CASE(Performance_hipEventElapsedTime) {
   HipEventElapsedTimeBenchmark benchmark;
   benchmark.Run();
 }

--- a/projects/hip-tests/catch/performance/event/hipEventQuery.cc
+++ b/projects/hip-tests/catch/performance/event/hipEventQuery.cc
@@ -52,7 +52,7 @@ class HipEventQueryBenchmark : public Benchmark<HipEventQueryBenchmark> {
  * ------------------------
  *  - HIP_VERSION >= 5.2
  */
-TEST_CASE("Performance_hipEventQuery") {
+TEST_CASE(Performance_hipEventQuery) {
   HipEventQueryBenchmark benchmark;
   benchmark.Run();
 }

--- a/projects/hip-tests/catch/performance/event/hipEventRecord.cc
+++ b/projects/hip-tests/catch/performance/event/hipEventRecord.cc
@@ -63,7 +63,7 @@ static void RunBenchmark(hipStream_t stream) {
  * ------------------------
  *  - HIP_VERSION >= 5.2
  */
-TEST_CASE("Performance_hipEventRecord") {
+TEST_CASE(Performance_hipEventRecord) {
   SECTION("default stream") { RunBenchmark(nullptr); }
 
   SECTION("created stream") {

--- a/projects/hip-tests/catch/performance/event/hipEventSynchronize.cc
+++ b/projects/hip-tests/catch/performance/event/hipEventSynchronize.cc
@@ -64,7 +64,7 @@ static void RunBenchmark(unsigned flag) {
  * ------------------------
  *  - HIP_VERSION >= 5.2
  */
-TEST_CASE("Performance_hipEventSynchronize") {
+TEST_CASE(Performance_hipEventSynchronize) {
   const auto flag = GENERATE(hipEventDefault, hipEventBlockingSync);
   RunBenchmark(flag);
 }

--- a/projects/hip-tests/catch/performance/example/example.cc
+++ b/projects/hip-tests/catch/performance/example/example.cc
@@ -48,7 +48,7 @@ class ExampleBenchmark : public Benchmark<ExampleBenchmark> {
   }
 };
 
-TEST_CASE("Performance_Example") {
+TEST_CASE(Performance_Example) {
   ExampleBenchmark benchmark;
 
   // to override cmd options

--- a/projects/hip-tests/catch/performance/kernelLaunch/hipExtLaunchKernel.cc
+++ b/projects/hip-tests/catch/performance/kernelLaunch/hipExtLaunchKernel.cc
@@ -90,7 +90,7 @@ template <KernelType kernel_type, bool timer_type> static void RunBenchmark(bool
  * ------------------------
  *  - HIP_VERSION >= 5.2
  */
-TEST_CASE("Performance_hipExtLaunchKernel") {
+TEST_CASE(Performance_hipExtLaunchKernel) {
   bool sync = GENERATE(true, false);
 
   SECTION("null kernel") {

--- a/projects/hip-tests/catch/performance/kernelLaunch/hipExtLaunchKernelGGL.cc
+++ b/projects/hip-tests/catch/performance/kernelLaunch/hipExtLaunchKernelGGL.cc
@@ -170,7 +170,7 @@ static bool query_gpu_frequency(void (*kernel)(uint64_t* out, size_t maxIter, ui
  * ------------------------
  *  - HIP_VERSION >= 5.2
  */
-TEST_CASE("Performance_hipExtLaunchKernelGGL_QueryGPUFrequency") {
+TEST_CASE(Performance_hipExtLaunchKernelGGL_QueryGPUFrequency) {
   HIP_CHECK(hipSetDevice(0));
   int clock_rate = 0;       // in kHz
   int wall_clock_rate = 0;  // in kHz

--- a/projects/hip-tests/catch/performance/kernelLaunch/hipLaunchCooperativeKernel.cc
+++ b/projects/hip-tests/catch/performance/kernelLaunch/hipLaunchCooperativeKernel.cc
@@ -95,7 +95,7 @@ template <KernelType kernel_type, bool timer_type> static void RunBenchmark(bool
  *  - Device supports CooperativeLaunch
  *  - HIP_VERSION >= 5.2
  */
-TEST_CASE("Performance_hipLaunchCooperativeKernel") {
+TEST_CASE(Performance_hipLaunchCooperativeKernel) {
   if (!DeviceAttributesSupport(0, hipDeviceAttributeCooperativeLaunch)) {
     HipTest::HIP_SKIP_TEST("CooperativeLaunch not supported");
     return;

--- a/projects/hip-tests/catch/performance/kernelLaunch/hipLaunchKernel.cc
+++ b/projects/hip-tests/catch/performance/kernelLaunch/hipLaunchKernel.cc
@@ -88,7 +88,7 @@ template <KernelType kernel_type, bool timer_type> static void RunBenchmark(bool
  * ------------------------
  *  - HIP_VERSION >= 5.2
  */
-TEST_CASE("Performance_hipLaunchKernel") {
+TEST_CASE(Performance_hipLaunchKernel) {
   bool sync = GENERATE(true, false);
 
   SECTION("null kernel") {

--- a/projects/hip-tests/catch/performance/kernelLaunch/triple_chevron.cc
+++ b/projects/hip-tests/catch/performance/kernelLaunch/triple_chevron.cc
@@ -75,7 +75,7 @@ template <KernelType kernel_type, bool timer_type> static void RunBenchmark(bool
  * ------------------------
  *  - HIP_VERSION >= 5.2
  */
-TEST_CASE("Performance_Triple_Chevron") {
+TEST_CASE(Performance_Triple_Chevron) {
   bool sync = GENERATE(true, false);
 
   SECTION("null kernel") {

--- a/projects/hip-tests/catch/performance/memcpy/hipMemcpy.cc
+++ b/projects/hip-tests/catch/performance/memcpy/hipMemcpy.cc
@@ -77,7 +77,7 @@ static void RunBenchmark(LinearAllocs dst_allocation_type, LinearAllocs src_allo
  * ------------------------
  *  - HIP_VERSION >= 5.2
  */
-TEST_CASE("Performance_hipMemcpy_DeviceToHost") {
+TEST_CASE(Performance_hipMemcpy_DeviceToHost) {
   const auto allocation_size = GENERATE(4_KB, 4_MB, 16_MB);
   const auto src_allocation_type = LinearAllocs::hipMalloc;
   const auto dst_allocation_type = GENERATE(LinearAllocs::malloc, LinearAllocs::hipHostMalloc);
@@ -102,7 +102,7 @@ TEST_CASE("Performance_hipMemcpy_DeviceToHost") {
  * ------------------------
  *  - HIP_VERSION >= 5.2
  */
-TEST_CASE("Performance_hipMemcpy_HostToDevice") {
+TEST_CASE(Performance_hipMemcpy_HostToDevice) {
   const auto allocation_size = GENERATE(4_KB, 4_MB, 16_MB);
   const auto src_allocation_type = GENERATE(LinearAllocs::malloc, LinearAllocs::hipHostMalloc);
   const auto dst_allocation_type = LinearAllocs::hipMalloc;
@@ -127,7 +127,7 @@ TEST_CASE("Performance_hipMemcpy_HostToDevice") {
  * ------------------------
  *  - HIP_VERSION >= 5.2
  */
-TEST_CASE("Performance_hipMemcpy_HostToHost") {
+TEST_CASE(Performance_hipMemcpy_HostToHost) {
   const auto allocation_size = GENERATE(4_KB, 4_MB, 16_MB);
   const auto src_allocation_type = GENERATE(LinearAllocs::malloc, LinearAllocs::hipHostMalloc);
   const auto dst_allocation_type = GENERATE(LinearAllocs::malloc, LinearAllocs::hipHostMalloc);
@@ -154,7 +154,7 @@ TEST_CASE("Performance_hipMemcpy_HostToHost") {
  *  - Device supports Peer-to-Peer access
  *  - HIP_VERSION >= 5.2
  */
-TEST_CASE("Performance_hipMemcpy_DeviceToDevice_EnablePeerAccess") {
+TEST_CASE(Performance_hipMemcpy_DeviceToDevice_EnablePeerAccess) {
   if (HipTest::getDeviceCount() < 2) {
     HipTest::HIP_SKIP_TEST("This test requires 2 GPUs. Skipping.");
     return;
@@ -184,7 +184,7 @@ TEST_CASE("Performance_hipMemcpy_DeviceToDevice_EnablePeerAccess") {
  * ------------------------
  *  - HIP_VERSION >= 5.2
  */
-TEST_CASE("Performance_hipMemcpy_DeviceToDevice_DisablePeerAccess") {
+TEST_CASE(Performance_hipMemcpy_DeviceToDevice_DisablePeerAccess) {
   const auto allocation_size = GENERATE(4_KB, 4_MB, 16_MB);
   const auto src_allocation_type = LinearAllocs::hipMalloc;
   const auto dst_allocation_type = LinearAllocs::hipMalloc;

--- a/projects/hip-tests/catch/performance/memcpy/hipMemcpy2D.cc
+++ b/projects/hip-tests/catch/performance/memcpy/hipMemcpy2D.cc
@@ -92,7 +92,7 @@ static void RunBenchmark(size_t width, size_t height, hipMemcpyKind kind,
  * ------------------------
  *  - HIP_VERSION >= 5.2
  */
-TEST_CASE("Performance_hipMemcpy2D_DeviceToHost") {
+TEST_CASE(Performance_hipMemcpy2D_DeviceToHost) {
   CHECK_IMAGE_SUPPORT
   const auto width = GENERATE(4_KB, 4_MB, 16_MB);
   RunBenchmark(width, 32, hipMemcpyDeviceToHost);
@@ -113,7 +113,7 @@ TEST_CASE("Performance_hipMemcpy2D_DeviceToHost") {
  * ------------------------
  *  - HIP_VERSION >= 5.2
  */
-TEST_CASE("Performance_hipMemcpy2D_HostToDevice") {
+TEST_CASE(Performance_hipMemcpy2D_HostToDevice) {
   CHECK_IMAGE_SUPPORT
   const auto width = GENERATE(4_KB, 4_MB, 16_MB);
   RunBenchmark(width, 32, hipMemcpyHostToDevice);
@@ -134,7 +134,7 @@ TEST_CASE("Performance_hipMemcpy2D_HostToDevice") {
  * ------------------------
  *  - HIP_VERSION >= 5.2
  */
-TEST_CASE("Performance_hipMemcpy2D_HostToHost") {
+TEST_CASE(Performance_hipMemcpy2D_HostToHost) {
   const auto width = GENERATE(4_KB, 4_MB, 16_MB);
   RunBenchmark(width, 32, hipMemcpyHostToHost);
 }
@@ -154,7 +154,7 @@ TEST_CASE("Performance_hipMemcpy2D_HostToHost") {
  * ------------------------
  *  - HIP_VERSION >= 5.2
  */
-TEST_CASE("Performance_hipMemcpy2D_DeviceToDevice_DisablePeerAccess") {
+TEST_CASE(Performance_hipMemcpy2D_DeviceToDevice_DisablePeerAccess) {
   CHECK_IMAGE_SUPPORT
   const auto width = GENERATE(4_KB, 4_MB, 16_MB);
   RunBenchmark(width, 32, hipMemcpyDeviceToDevice);
@@ -177,7 +177,7 @@ TEST_CASE("Performance_hipMemcpy2D_DeviceToDevice_DisablePeerAccess") {
  *  - Device supports Peer-to-Peer access
  *  - HIP_VERSION >= 5.2
  */
-TEST_CASE("Performance_hipMemcpy2D_DeviceToDevice_EnablePeerAccess") {
+TEST_CASE(Performance_hipMemcpy2D_DeviceToDevice_EnablePeerAccess) {
   CHECK_IMAGE_SUPPORT
   if (HipTest::getDeviceCount() < 2) {
     HipTest::HIP_SKIP_TEST("This test requires 2 GPUs. Skipping.");

--- a/projects/hip-tests/catch/performance/memcpy/hipMemcpy2DAsync.cc
+++ b/projects/hip-tests/catch/performance/memcpy/hipMemcpy2DAsync.cc
@@ -97,7 +97,7 @@ static void RunBenchmark(size_t width, size_t height, hipMemcpyKind kind,
  * ------------------------
  *  - HIP_VERSION >= 5.2
  */
-TEST_CASE("Performance_hipMemcpy2DAsync_DeviceToHost") {
+TEST_CASE(Performance_hipMemcpy2DAsync_DeviceToHost) {
   CHECK_IMAGE_SUPPORT
   const auto width = GENERATE(4_KB, 4_MB, 16_MB);
   RunBenchmark(width, 32, hipMemcpyDeviceToHost);
@@ -118,7 +118,7 @@ TEST_CASE("Performance_hipMemcpy2DAsync_DeviceToHost") {
  * ------------------------
  *  - HIP_VERSION >= 5.2
  */
-TEST_CASE("Performance_hipMemcpy2DAsync_HostToDevice") {
+TEST_CASE(Performance_hipMemcpy2DAsync_HostToDevice) {
   CHECK_IMAGE_SUPPORT
   const auto width = GENERATE(4_KB, 4_MB, 16_MB);
   RunBenchmark(width, 32, hipMemcpyHostToDevice);
@@ -139,7 +139,7 @@ TEST_CASE("Performance_hipMemcpy2DAsync_HostToDevice") {
  * ------------------------
  *  - HIP_VERSION >= 5.2
  */
-TEST_CASE("Performance_hipMemcpy2DAsync_HostToHost") {
+TEST_CASE(Performance_hipMemcpy2DAsync_HostToHost) {
   const auto width = GENERATE(4_KB, 4_MB, 16_MB);
   RunBenchmark(width, 32, hipMemcpyHostToHost);
 }
@@ -159,7 +159,7 @@ TEST_CASE("Performance_hipMemcpy2DAsync_HostToHost") {
  * ------------------------
  *  - HIP_VERSION >= 5.2
  */
-TEST_CASE("Performance_hipMemcpy2DAsync_DeviceToDevice_DisablePeerAccess") {
+TEST_CASE(Performance_hipMemcpy2DAsync_DeviceToDevice_DisablePeerAccess) {
   CHECK_IMAGE_SUPPORT
   const auto width = GENERATE(4_KB, 4_MB, 16_MB);
   RunBenchmark(width, 32, hipMemcpyDeviceToDevice);
@@ -182,7 +182,7 @@ TEST_CASE("Performance_hipMemcpy2DAsync_DeviceToDevice_DisablePeerAccess") {
  *  - Device supports Peer-to-Peer access
  *  - HIP_VERSION >= 5.2
  */
-TEST_CASE("Performance_hipMemcpy2DAsync_DeviceToDevice_EnablePeerAccess") {
+TEST_CASE(Performance_hipMemcpy2DAsync_DeviceToDevice_EnablePeerAccess) {
   CHECK_IMAGE_SUPPORT
   if (HipTest::getDeviceCount() < 2) {
     HipTest::HIP_SKIP_TEST("This test requires 2 GPUs. Skipping.");

--- a/projects/hip-tests/catch/performance/memcpy/hipMemcpy2DFromArray.cc
+++ b/projects/hip-tests/catch/performance/memcpy/hipMemcpy2DFromArray.cc
@@ -78,7 +78,7 @@ static void RunBenchmark(size_t width, size_t height, hipMemcpyKind kind,
  * ------------------------
  *  - HIP_VERSION >= 5.2
  */
-TEST_CASE("Performance_hipMemcpy2DFromArray_DeviceToHost") {
+TEST_CASE(Performance_hipMemcpy2DFromArray_DeviceToHost) {
   CHECK_IMAGE_SUPPORT
 
   const auto width = GENERATE(4_KB, 8_KB, 16_KB);
@@ -100,7 +100,7 @@ TEST_CASE("Performance_hipMemcpy2DFromArray_DeviceToHost") {
  * ------------------------
  *  - HIP_VERSION >= 5.2
  */
-TEST_CASE("Performance_hipMemcpy2DFromArray_DeviceToDevice_DisablePeerAccess") {
+TEST_CASE(Performance_hipMemcpy2DFromArray_DeviceToDevice_DisablePeerAccess) {
   CHECK_IMAGE_SUPPORT
 
   const auto width = GENERATE(4_KB, 8_KB, 16_KB);
@@ -124,7 +124,7 @@ TEST_CASE("Performance_hipMemcpy2DFromArray_DeviceToDevice_DisablePeerAccess") {
  *  - Device supports Peer-to-Peer access
  *  - HIP_VERSION >= 5.2
  */
-TEST_CASE("Performance_hipMemcpy2DFromArray_DeviceToDevice_EnablePeerAccess") {
+TEST_CASE(Performance_hipMemcpy2DFromArray_DeviceToDevice_EnablePeerAccess) {
   CHECK_IMAGE_SUPPORT
 
   if (HipTest::getDeviceCount() < 2) {

--- a/projects/hip-tests/catch/performance/memcpy/hipMemcpy2DFromArrayAsync.cc
+++ b/projects/hip-tests/catch/performance/memcpy/hipMemcpy2DFromArrayAsync.cc
@@ -83,7 +83,7 @@ static void RunBenchmark(size_t width, size_t height, hipMemcpyKind kind,
  * ------------------------
  *  - HIP_VERSION >= 5.2
  */
-TEST_CASE("Performance_hipMemcpy2DFromArrayAsync_DeviceToHost") {
+TEST_CASE(Performance_hipMemcpy2DFromArrayAsync_DeviceToHost) {
   CHECK_IMAGE_SUPPORT
 
   const auto width = GENERATE(4_KB, 8_KB, 16_KB);
@@ -105,7 +105,7 @@ TEST_CASE("Performance_hipMemcpy2DFromArrayAsync_DeviceToHost") {
  * ------------------------
  *  - HIP_VERSION >= 5.2
  */
-TEST_CASE("Performance_hipMemcpy2DFromArrayAsync_DeviceToDevice_DisablePeerAccess") {
+TEST_CASE(Performance_hipMemcpy2DFromArrayAsync_DeviceToDevice_DisablePeerAccess) {
   CHECK_IMAGE_SUPPORT
 
   const auto width = GENERATE(4_KB, 8_KB, 16_KB);
@@ -129,7 +129,7 @@ TEST_CASE("Performance_hipMemcpy2DFromArrayAsync_DeviceToDevice_DisablePeerAcces
  *  - Device supports Peer-to-Peer access
  *  - HIP_VERSION >= 5.2
  */
-TEST_CASE("Performance_hipMemcpy2DFromArrayAsync_DeviceToDevice_EnablePeerAccess") {
+TEST_CASE(Performance_hipMemcpy2DFromArrayAsync_DeviceToDevice_EnablePeerAccess) {
   CHECK_IMAGE_SUPPORT
 
   if (HipTest::getDeviceCount() < 2) {

--- a/projects/hip-tests/catch/performance/memcpy/hipMemcpy2DToArray.cc
+++ b/projects/hip-tests/catch/performance/memcpy/hipMemcpy2DToArray.cc
@@ -78,7 +78,7 @@ static void RunBenchmark(size_t width, size_t height, hipMemcpyKind kind,
  * ------------------------
  *  - HIP_VERSION >= 5.2
  */
-TEST_CASE("Performance_hipMemcpy2DToArray_HostToDevice") {
+TEST_CASE(Performance_hipMemcpy2DToArray_HostToDevice) {
   CHECK_IMAGE_SUPPORT
 
   const auto width = GENERATE(4_KB, 8_KB, 16_KB);
@@ -100,7 +100,7 @@ TEST_CASE("Performance_hipMemcpy2DToArray_HostToDevice") {
  * ------------------------
  *  - HIP_VERSION >= 5.2
  */
-TEST_CASE("Performance_hipMemcpy2DToArray_DeviceToDevice_DisablePeerAccess") {
+TEST_CASE(Performance_hipMemcpy2DToArray_DeviceToDevice_DisablePeerAccess) {
   CHECK_IMAGE_SUPPORT
 
   const auto width = GENERATE(4_KB, 8_KB, 16_KB);
@@ -124,7 +124,7 @@ TEST_CASE("Performance_hipMemcpy2DToArray_DeviceToDevice_DisablePeerAccess") {
  *  - Device supports Peer-to-Peer access
  *  - HIP_VERSION >= 5.2
  */
-TEST_CASE("Performance_hipMemcpy2DToArray_DeviceToDevice_EnablePeerAccess") {
+TEST_CASE(Performance_hipMemcpy2DToArray_DeviceToDevice_EnablePeerAccess) {
   CHECK_IMAGE_SUPPORT
 
   if (HipTest::getDeviceCount() < 2) {

--- a/projects/hip-tests/catch/performance/memcpy/hipMemcpy2DToArrayAsync.cc
+++ b/projects/hip-tests/catch/performance/memcpy/hipMemcpy2DToArrayAsync.cc
@@ -83,7 +83,7 @@ static void RunBenchmark(size_t width, size_t height, hipMemcpyKind kind,
  * ------------------------
  *  - HIP_VERSION >= 5.2
  */
-TEST_CASE("Performance_hipMemcpy2DToArrayAsync_HostToDevice") {
+TEST_CASE(Performance_hipMemcpy2DToArrayAsync_HostToDevice) {
   CHECK_IMAGE_SUPPORT
 
   const auto width = GENERATE(4_KB, 8_KB, 16_KB);
@@ -105,7 +105,7 @@ TEST_CASE("Performance_hipMemcpy2DToArrayAsync_HostToDevice") {
  * ------------------------
  *  - HIP_VERSION >= 5.2
  */
-TEST_CASE("Performance_hipMemcpy2DToArrayAsync_DeviceToDevice_DisablePeerAccess") {
+TEST_CASE(Performance_hipMemcpy2DToArrayAsync_DeviceToDevice_DisablePeerAccess) {
   CHECK_IMAGE_SUPPORT
 
   const auto width = GENERATE(4_KB, 8_KB, 16_KB);
@@ -129,7 +129,7 @@ TEST_CASE("Performance_hipMemcpy2DToArrayAsync_DeviceToDevice_DisablePeerAccess"
  *  - Device supports Peer-to-Peer access
  *  - HIP_VERSION >= 5.2
  */
-TEST_CASE("Performance_hipMemcpy2DToArrayAsync_DeviceToDevice_EnablePeerAccess") {
+TEST_CASE(Performance_hipMemcpy2DToArrayAsync_DeviceToDevice_EnablePeerAccess) {
   CHECK_IMAGE_SUPPORT
 
   if (HipTest::getDeviceCount() < 2) {

--- a/projects/hip-tests/catch/performance/memcpy/hipMemcpy3D.cc
+++ b/projects/hip-tests/catch/performance/memcpy/hipMemcpy3D.cc
@@ -102,7 +102,7 @@ static void RunBenchmark(const hipExtent extent, hipMemcpyKind kind,
  * ------------------------
  *  - HIP_VERSION >= 5.2
  */
-TEST_CASE("Performance_hipMemcpy3D_DeviceToHost") {
+TEST_CASE(Performance_hipMemcpy3D_DeviceToHost) {
   CHECK_IMAGE_SUPPORT
   const auto width = GENERATE(4_KB, 4_MB, 16_MB);
   RunBenchmark(make_hipExtent(width, 16, 4), hipMemcpyDeviceToHost);
@@ -123,7 +123,7 @@ TEST_CASE("Performance_hipMemcpy3D_DeviceToHost") {
  * ------------------------
  *  - HIP_VERSION >= 5.2
  */
-TEST_CASE("Performance_hipMemcpy3D_HostToDevice") {
+TEST_CASE(Performance_hipMemcpy3D_HostToDevice) {
   CHECK_IMAGE_SUPPORT
   const auto width = GENERATE(4_KB, 4_MB, 16_MB);
   RunBenchmark(make_hipExtent(width, 16, 4), hipMemcpyHostToDevice);
@@ -144,7 +144,7 @@ TEST_CASE("Performance_hipMemcpy3D_HostToDevice") {
  * ------------------------
  *  - HIP_VERSION >= 5.2
  */
-TEST_CASE("Performance_hipMemcpy3D_HostToHost") {
+TEST_CASE(Performance_hipMemcpy3D_HostToHost) {
   CHECK_IMAGE_SUPPORT
   const auto width = GENERATE(4_KB, 4_MB, 16_MB);
   RunBenchmark(make_hipExtent(width, 16, 4), hipMemcpyHostToHost);
@@ -165,7 +165,7 @@ TEST_CASE("Performance_hipMemcpy3D_HostToHost") {
  * ------------------------
  *  - HIP_VERSION >= 5.2
  */
-TEST_CASE("Performance_hipMemcpy3D_DeviceToDevice_DisablePeerAccess") {
+TEST_CASE(Performance_hipMemcpy3D_DeviceToDevice_DisablePeerAccess) {
   CHECK_IMAGE_SUPPORT
   const auto width = GENERATE(4_KB, 4_MB, 16_MB);
   RunBenchmark(make_hipExtent(width, 16, 4), hipMemcpyDeviceToDevice);
@@ -188,7 +188,7 @@ TEST_CASE("Performance_hipMemcpy3D_DeviceToDevice_DisablePeerAccess") {
  *  - Device supports Peer-to-Peer access
  *  - HIP_VERSION >= 5.2
  */
-TEST_CASE("Performance_hipMemcpy3D_DeviceToDevice_EnablePeerAccess") {
+TEST_CASE(Performance_hipMemcpy3D_DeviceToDevice_EnablePeerAccess) {
   CHECK_IMAGE_SUPPORT
   if (HipTest::getDeviceCount() < 2) {
     HipTest::HIP_SKIP_TEST("This test requires 2 GPUs. Skipping.");

--- a/projects/hip-tests/catch/performance/memcpy/hipMemcpy3DAsync.cc
+++ b/projects/hip-tests/catch/performance/memcpy/hipMemcpy3DAsync.cc
@@ -105,7 +105,7 @@ static void RunBenchmark(const hipExtent extent, hipMemcpyKind kind,
  * ------------------------
  *  - HIP_VERSION >= 5.2
  */
-TEST_CASE("Performance_hipMemcpy3DAsync_DeviceToHost") {
+TEST_CASE(Performance_hipMemcpy3DAsync_DeviceToHost) {
   CHECK_IMAGE_SUPPORT
   const auto width = GENERATE(4_KB, 4_MB, 16_MB);
   RunBenchmark(make_hipExtent(width, 16, 4), hipMemcpyDeviceToHost);
@@ -126,7 +126,7 @@ TEST_CASE("Performance_hipMemcpy3DAsync_DeviceToHost") {
  * ------------------------
  *  - HIP_VERSION >= 5.2
  */
-TEST_CASE("Performance_hipMemcpy3DAsync_HostToDevice") {
+TEST_CASE(Performance_hipMemcpy3DAsync_HostToDevice) {
   CHECK_IMAGE_SUPPORT
   const auto width = GENERATE(4_KB, 4_MB, 16_MB);
   RunBenchmark(make_hipExtent(width, 16, 4), hipMemcpyHostToDevice);
@@ -147,7 +147,7 @@ TEST_CASE("Performance_hipMemcpy3DAsync_HostToDevice") {
  * ------------------------
  *  - HIP_VERSION >= 5.2
  */
-TEST_CASE("Performance_hipMemcpy3DAsync_HostToHost") {
+TEST_CASE(Performance_hipMemcpy3DAsync_HostToHost) {
   CHECK_IMAGE_SUPPORT
   const auto width = GENERATE(4_KB, 4_MB, 16_MB);
   RunBenchmark(make_hipExtent(width, 16, 4), hipMemcpyHostToHost);
@@ -168,7 +168,7 @@ TEST_CASE("Performance_hipMemcpy3DAsync_HostToHost") {
  * ------------------------
  *  - HIP_VERSION >= 5.2
  */
-TEST_CASE("Performance_hipMemcpy3DAsync_DeviceToDevice_DisablePeerAccess") {
+TEST_CASE(Performance_hipMemcpy3DAsync_DeviceToDevice_DisablePeerAccess) {
   CHECK_IMAGE_SUPPORT
   const auto width = GENERATE(4_KB, 4_MB, 16_MB);
   RunBenchmark(make_hipExtent(width, 16, 4), hipMemcpyDeviceToDevice);
@@ -189,7 +189,7 @@ TEST_CASE("Performance_hipMemcpy3DAsync_DeviceToDevice_DisablePeerAccess") {
  * ------------------------
  *  - HIP_VERSION >= 5.2
  */
-TEST_CASE("Performance_hipMemcpy3DAsync_DeviceToDevice_EnablePeerAccess") {
+TEST_CASE(Performance_hipMemcpy3DAsync_DeviceToDevice_EnablePeerAccess) {
   CHECK_IMAGE_SUPPORT
   if (HipTest::getDeviceCount() < 2) {
     HipTest::HIP_SKIP_TEST("This test requires 2 GPUs. Skipping.");

--- a/projects/hip-tests/catch/performance/memcpy/hipMemcpyAsync.cc
+++ b/projects/hip-tests/catch/performance/memcpy/hipMemcpyAsync.cc
@@ -82,7 +82,7 @@ static void RunBenchmark(LinearAllocs dst_allocation_type, LinearAllocs src_allo
  * ------------------------
  *  - HIP_VERSION >= 5.2
  */
-TEST_CASE("Performance_hipMemcpyAsync_DeviceToHost") {
+TEST_CASE(Performance_hipMemcpyAsync_DeviceToHost) {
   const auto allocation_size = GENERATE(4_KB, 4_MB, 16_MB);
   const auto src_allocation_type = LinearAllocs::hipMalloc;
   const auto dst_allocation_type = GENERATE(LinearAllocs::malloc, LinearAllocs::hipHostMalloc);
@@ -107,7 +107,7 @@ TEST_CASE("Performance_hipMemcpyAsync_DeviceToHost") {
  * ------------------------
  *  - HIP_VERSION >= 5.2
  */
-TEST_CASE("Performance_hipMemcpyAsync_HostToDevice") {
+TEST_CASE(Performance_hipMemcpyAsync_HostToDevice) {
   const auto allocation_size = GENERATE(4_KB, 4_MB, 16_MB);
   const auto src_allocation_type = GENERATE(LinearAllocs::malloc, LinearAllocs::hipHostMalloc);
   const auto dst_allocation_type = LinearAllocs::hipMalloc;
@@ -132,7 +132,7 @@ TEST_CASE("Performance_hipMemcpyAsync_HostToDevice") {
  * ------------------------
  *  - HIP_VERSION >= 5.2
  */
-TEST_CASE("Performance_hipMemcpyAsync_HostToHost") {
+TEST_CASE(Performance_hipMemcpyAsync_HostToHost) {
   const auto allocation_size = GENERATE(4_KB, 4_MB, 16_MB);
   const auto src_allocation_type = GENERATE(LinearAllocs::malloc, LinearAllocs::hipHostMalloc);
   const auto dst_allocation_type = GENERATE(LinearAllocs::malloc, LinearAllocs::hipHostMalloc);
@@ -157,7 +157,7 @@ TEST_CASE("Performance_hipMemcpyAsync_HostToHost") {
  * ------------------------
  *  - HIP_VERSION >= 5.2
  */
-TEST_CASE("Performance_hipMemcpyAsync_DeviceToDevice_DisablePeerAccess") {
+TEST_CASE(Performance_hipMemcpyAsync_DeviceToDevice_DisablePeerAccess) {
   const auto allocation_size = GENERATE(4_KB, 4_MB, 16_MB);
   const auto src_allocation_type = LinearAllocs::hipMalloc;
   const auto dst_allocation_type = LinearAllocs::hipMalloc;
@@ -184,7 +184,7 @@ TEST_CASE("Performance_hipMemcpyAsync_DeviceToDevice_DisablePeerAccess") {
  *  - Device supports Peer-to-Peer access
  *  - HIP_VERSION >= 5.2
  */
-TEST_CASE("Performance_hipMemcpyAsync_DeviceToDevice_EnablePeerAccess") {
+TEST_CASE(Performance_hipMemcpyAsync_DeviceToDevice_EnablePeerAccess) {
   if (HipTest::getDeviceCount() < 2) {
     HipTest::HIP_SKIP_TEST("This test requires 2 GPUs. Skipping.");
     return;

--- a/projects/hip-tests/catch/performance/memcpy/hipMemcpyAtoH.cc
+++ b/projects/hip-tests/catch/performance/memcpy/hipMemcpyAtoH.cc
@@ -60,7 +60,7 @@ static void RunBenchmark(LinearAllocs host_allocation_type, size_t width) {
  * ------------------------
  *  - HIP_VERSION >= 5.2
  */
-TEST_CASE("Performance_hipMemcpyAtoH") {
+TEST_CASE(Performance_hipMemcpyAtoH) {
   CHECK_IMAGE_SUPPORT
 
   const auto allocation_size = GENERATE(512, 1024, 4096);

--- a/projects/hip-tests/catch/performance/memcpy/hipMemcpyDtoD.cc
+++ b/projects/hip-tests/catch/performance/memcpy/hipMemcpyDtoD.cc
@@ -71,7 +71,7 @@ static void RunBenchmark(size_t size, bool enable_peer_access = false) {
  *  - Device supports Peer-to-Peer access
  *  - HIP_VERSION >= 5.2
  */
-TEST_CASE("Performance_hipMemcpyDtoD_PeerAccessEnabled") {
+TEST_CASE(Performance_hipMemcpyDtoD_PeerAccessEnabled) {
   if (HipTest::getDeviceCount() < 2) {
     HipTest::HIP_SKIP_TEST("This test requires 2 GPUs. Skipping.");
     return;
@@ -98,7 +98,7 @@ TEST_CASE("Performance_hipMemcpyDtoD_PeerAccessEnabled") {
  * ------------------------
  *  - HIP_VERSION >= 5.2
  */
-TEST_CASE("Performance_hipMemcpyDtoD_PeerAccessDisabled") {
+TEST_CASE(Performance_hipMemcpyDtoD_PeerAccessDisabled) {
   const auto allocation_size = GENERATE(4_KB, 4_MB, 16_MB);
   RunBenchmark(allocation_size);
 }

--- a/projects/hip-tests/catch/performance/memcpy/hipMemcpyDtoDAsync.cc
+++ b/projects/hip-tests/catch/performance/memcpy/hipMemcpyDtoDAsync.cc
@@ -76,7 +76,7 @@ static void RunBenchmark(size_t size, bool enable_peer_access = false) {
  *  - Device supports Peer-to-Peer access
  *  - HIP_VERSION >= 5.2
  */
-TEST_CASE("Performance_hipMemcpyDtoDAsync_PeerAccessEnabled") {
+TEST_CASE(Performance_hipMemcpyDtoDAsync_PeerAccessEnabled) {
   if (HipTest::getDeviceCount() < 2) {
     HipTest::HIP_SKIP_TEST("This test requires 2 GPUs. Skipping.");
     return;
@@ -103,7 +103,7 @@ TEST_CASE("Performance_hipMemcpyDtoDAsync_PeerAccessEnabled") {
  * ------------------------
  *  - HIP_VERSION >= 5.2
  */
-TEST_CASE("Performance_hipMemcpyDtoDAsync_PeerAccessDisabled") {
+TEST_CASE(Performance_hipMemcpyDtoDAsync_PeerAccessDisabled) {
   const auto allocation_size = GENERATE(4_KB, 4_MB, 16_MB);
   RunBenchmark(allocation_size);
 }

--- a/projects/hip-tests/catch/performance/memcpy/hipMemcpyDtoH.cc
+++ b/projects/hip-tests/catch/performance/memcpy/hipMemcpyDtoH.cc
@@ -62,7 +62,7 @@ static void RunBenchmark(LinearAllocs host_allocation_type, LinearAllocs device_
  * ------------------------
  *  - HIP_VERSION >= 5.2
  */
-TEST_CASE("Performance_hipMemcpyDtoH") {
+TEST_CASE(Performance_hipMemcpyDtoH) {
   const auto allocation_size = GENERATE(4_KB, 4_MB, 16_MB);
   const auto device_allocation_type = LinearAllocs::hipMalloc;
   const auto host_allocation_type = GENERATE(LinearAllocs::malloc, LinearAllocs::hipHostMalloc);

--- a/projects/hip-tests/catch/performance/memcpy/hipMemcpyDtoHAsync.cc
+++ b/projects/hip-tests/catch/performance/memcpy/hipMemcpyDtoHAsync.cc
@@ -67,7 +67,7 @@ static void RunBenchmark(LinearAllocs host_allocation_type, LinearAllocs device_
  * ------------------------
  *  - HIP_VERSION >= 5.2
  */
-TEST_CASE("Performance_hipMemcpyDtoHAsync") {
+TEST_CASE(Performance_hipMemcpyDtoHAsync) {
   const auto allocation_size = GENERATE(4_KB, 4_MB, 16_MB);
   const auto device_allocation_type = LinearAllocs::hipMalloc;
   const auto host_allocation_type = GENERATE(LinearAllocs::malloc, LinearAllocs::hipHostMalloc);

--- a/projects/hip-tests/catch/performance/memcpy/hipMemcpyFromSymbol.cc
+++ b/projects/hip-tests/catch/performance/memcpy/hipMemcpyFromSymbol.cc
@@ -57,7 +57,7 @@ static void RunBenchmark(const void* source, void* result, size_t size = 1, size
  * ------------------------
  *  - HIP_VERSION >= 5.2
  */
-TEST_CASE("Performance_hipMemcpyFromSymbol_SingularValue") {
+TEST_CASE(Performance_hipMemcpyFromSymbol_SingularValue) {
   int set{42};
   int result{0};
   RunBenchmark(&set, &result);
@@ -78,7 +78,7 @@ TEST_CASE("Performance_hipMemcpyFromSymbol_SingularValue") {
  * ------------------------
  *  - HIP_VERSION >= 5.2
  */
-TEST_CASE("Performance_hipMemcpyFromSymbol_ArrayValue") {
+TEST_CASE(Performance_hipMemcpyFromSymbol_ArrayValue) {
   size_t size = GENERATE(1_KB, 4_KB, 512_KB);
   std::vector<int> array(size);
   std::fill_n(array.data(), size, 42);
@@ -104,7 +104,7 @@ TEST_CASE("Performance_hipMemcpyFromSymbol_ArrayValue") {
  * ------------------------
  *  - HIP_VERSION >= 5.2
  */
-TEST_CASE("Performance_hipMemcpyFromSymbol_WithOffset") {
+TEST_CASE(Performance_hipMemcpyFromSymbol_WithOffset) {
   size_t size = GENERATE(1_KB, 4_KB, 512_KB);
   std::vector<int> array(size);
   std::fill_n(array.data(), size, 42);

--- a/projects/hip-tests/catch/performance/memcpy/hipMemcpyFromSymbolAsync.cc
+++ b/projects/hip-tests/catch/performance/memcpy/hipMemcpyFromSymbolAsync.cc
@@ -64,7 +64,7 @@ static void RunBenchmark(const void* source, void* result, size_t size = 1, size
  * ------------------------
  *  - HIP_VERSION >= 5.2
  */
-TEST_CASE("Performance_hipMemcpyFromSymbolAsync_SingularValue") {
+TEST_CASE(Performance_hipMemcpyFromSymbolAsync_SingularValue) {
   int set{42};
   int result{0};
   RunBenchmark(&set, &result);
@@ -85,7 +85,7 @@ TEST_CASE("Performance_hipMemcpyFromSymbolAsync_SingularValue") {
  * ------------------------
  *  - HIP_VERSION >= 5.2
  */
-TEST_CASE("Performance_hipMemcpyFromSymbolAsync_ArrayValue") {
+TEST_CASE(Performance_hipMemcpyFromSymbolAsync_ArrayValue) {
   size_t size = GENERATE(1_KB, 4_KB, 512_KB);
   std::vector<int> array(size);
   std::fill_n(array.data(), size, 42);
@@ -111,7 +111,7 @@ TEST_CASE("Performance_hipMemcpyFromSymbolAsync_ArrayValue") {
  * ------------------------
  *  - HIP_VERSION >= 5.2
  */
-TEST_CASE("Performance_hipMemcpyFromSymbolAsync_WithOffset") {
+TEST_CASE(Performance_hipMemcpyFromSymbolAsync_WithOffset) {
   size_t size = GENERATE(1_KB, 4_KB, 512_KB);
   std::vector<int> array(size);
   std::fill_n(array.data(), size, 42);

--- a/projects/hip-tests/catch/performance/memcpy/hipMemcpyHtoA.cc
+++ b/projects/hip-tests/catch/performance/memcpy/hipMemcpyHtoA.cc
@@ -60,7 +60,7 @@ static void RunBenchmark(LinearAllocs host_allocation_type, size_t width) {
  * ------------------------
  *  - HIP_VERSION >= 5.2
  */
-TEST_CASE("Performance_hipMemcpyHtoA") {
+TEST_CASE(Performance_hipMemcpyHtoA) {
   CHECK_IMAGE_SUPPORT
 
   const auto allocation_size = GENERATE(512, 1024, 4096);

--- a/projects/hip-tests/catch/performance/memcpy/hipMemcpyHtoD.cc
+++ b/projects/hip-tests/catch/performance/memcpy/hipMemcpyHtoD.cc
@@ -62,7 +62,7 @@ static void RunBenchmark(LinearAllocs host_allocation_type, LinearAllocs device_
  * ------------------------
  *  - HIP_VERSION >= 5.2
  */
-TEST_CASE("Performance_hipMemcpyHtoD") {
+TEST_CASE(Performance_hipMemcpyHtoD) {
   const auto allocation_size = GENERATE(4_KB, 4_MB, 16_MB);
   const auto device_allocation_type = LinearAllocs::hipMalloc;
   const auto host_allocation_type = GENERATE(LinearAllocs::malloc, LinearAllocs::hipHostMalloc);

--- a/projects/hip-tests/catch/performance/memcpy/hipMemcpyHtoDAsync.cc
+++ b/projects/hip-tests/catch/performance/memcpy/hipMemcpyHtoDAsync.cc
@@ -67,7 +67,7 @@ static void RunBenchmark(LinearAllocs host_allocation_type, LinearAllocs device_
  * ------------------------
  *  - HIP_VERSION >= 5.2
  */
-TEST_CASE("Performance_hipMemcpyHtoDAsync") {
+TEST_CASE(Performance_hipMemcpyHtoDAsync) {
   const auto allocation_size = GENERATE(4_KB, 4_MB, 16_MB);
   const auto device_allocation_type = LinearAllocs::hipMalloc;
   const auto host_allocation_type = GENERATE(LinearAllocs::malloc, LinearAllocs::hipHostMalloc);

--- a/projects/hip-tests/catch/performance/memcpy/hipMemcpyParam2D.cc
+++ b/projects/hip-tests/catch/performance/memcpy/hipMemcpyParam2D.cc
@@ -92,7 +92,7 @@ static void RunBenchmark(size_t width, size_t height, hipMemcpyKind kind,
  * ------------------------
  *  - HIP_VERSION >= 5.2
  */
-TEST_CASE("Performance_hipMemcpyParam2D_DeviceToHost") {
+TEST_CASE(Performance_hipMemcpyParam2D_DeviceToHost) {
   const auto width = GENERATE(4_KB, 4_MB, 16_MB);
   RunBenchmark(width, 32, hipMemcpyDeviceToHost);
 }
@@ -113,7 +113,7 @@ TEST_CASE("Performance_hipMemcpyParam2D_DeviceToHost") {
  * ------------------------
  *  - HIP_VERSION >= 5.2
  */
-TEST_CASE("Performance_hipMemcpyParam2D_HostToDevice") {
+TEST_CASE(Performance_hipMemcpyParam2D_HostToDevice) {
   CHECK_IMAGE_SUPPORT
   const auto width = GENERATE(4_KB, 4_MB, 16_MB);
   RunBenchmark(width, 32, hipMemcpyHostToDevice);
@@ -135,7 +135,7 @@ TEST_CASE("Performance_hipMemcpyParam2D_HostToDevice") {
  * ------------------------
  *  - HIP_VERSION >= 5.2
  */
-TEST_CASE("Performance_hipMemcpyParam2D_HostToHost") {
+TEST_CASE(Performance_hipMemcpyParam2D_HostToHost) {
   const auto width = GENERATE(4_KB, 4_MB, 16_MB);
   RunBenchmark(width, 32, hipMemcpyHostToHost);
 }
@@ -156,7 +156,7 @@ TEST_CASE("Performance_hipMemcpyParam2D_HostToHost") {
  * ------------------------
  *  - HIP_VERSION >= 5.2
  */
-TEST_CASE("Performance_hipMemcpyParam2D_DeviceToDevice_DisablePeerAccess") {
+TEST_CASE(Performance_hipMemcpyParam2D_DeviceToDevice_DisablePeerAccess) {
   CHECK_IMAGE_SUPPORT
   const auto width = GENERATE(4_KB, 4_MB, 16_MB);
   RunBenchmark(width, 32, hipMemcpyDeviceToDevice);
@@ -179,7 +179,7 @@ TEST_CASE("Performance_hipMemcpyParam2D_DeviceToDevice_DisablePeerAccess") {
  *  - Device supports Peer-to-Peer access
  *  - HIP_VERSION >= 5.2
  */
-TEST_CASE("Performance_hipMemcpyParam2D_DeviceToDevice_EnablePeerAccess") {
+TEST_CASE(Performance_hipMemcpyParam2D_DeviceToDevice_EnablePeerAccess) {
   CHECK_IMAGE_SUPPORT
   if (HipTest::getDeviceCount() < 2) {
     HipTest::HIP_SKIP_TEST("This test requires 2 GPUs. Skipping.");

--- a/projects/hip-tests/catch/performance/memcpy/hipMemcpyParam2DAsync.cc
+++ b/projects/hip-tests/catch/performance/memcpy/hipMemcpyParam2DAsync.cc
@@ -96,7 +96,7 @@ static void RunBenchmark(size_t width, size_t height, hipMemcpyKind kind,
  * ------------------------
  *  - HIP_VERSION >= 5.2
  */
-TEST_CASE("Performance_hipMemcpyParam2DAsync_DeviceToHost") {
+TEST_CASE(Performance_hipMemcpyParam2DAsync_DeviceToHost) {
   const auto width = GENERATE(4_KB, 4_MB, 16_MB);
   RunBenchmark(width, 32, hipMemcpyDeviceToHost);
 }
@@ -117,7 +117,7 @@ TEST_CASE("Performance_hipMemcpyParam2DAsync_DeviceToHost") {
  * ------------------------
  *  - HIP_VERSION >= 5.2
  */
-TEST_CASE("Performance_hipMemcpyParam2DAsync_HostToDevice") {
+TEST_CASE(Performance_hipMemcpyParam2DAsync_HostToDevice) {
   CHECK_IMAGE_SUPPORT
   const auto width = GENERATE(4_KB, 4_MB, 16_MB);
   RunBenchmark(width, 32, hipMemcpyHostToDevice);
@@ -139,7 +139,7 @@ TEST_CASE("Performance_hipMemcpyParam2DAsync_HostToDevice") {
  * ------------------------
  *  - HIP_VERSION >= 5.2
  */
-TEST_CASE("Performance_hipMemcpyParam2DAsync_HostToHost") {
+TEST_CASE(Performance_hipMemcpyParam2DAsync_HostToHost) {
   const auto width = GENERATE(4_KB, 4_MB, 16_MB);
   RunBenchmark(width, 32, hipMemcpyHostToHost);
 }
@@ -160,7 +160,7 @@ TEST_CASE("Performance_hipMemcpyParam2DAsync_HostToHost") {
  * ------------------------
  *  - HIP_VERSION >= 5.2
  */
-TEST_CASE("Performance_hipMemcpyParam2DAsync_DeviceToDevice_DisablePeerAccess") {
+TEST_CASE(Performance_hipMemcpyParam2DAsync_DeviceToDevice_DisablePeerAccess) {
   CHECK_IMAGE_SUPPORT
   const auto width = GENERATE(4_KB, 4_MB, 16_MB);
   RunBenchmark(width, 32, hipMemcpyDeviceToDevice);
@@ -183,7 +183,7 @@ TEST_CASE("Performance_hipMemcpyParam2DAsync_DeviceToDevice_DisablePeerAccess") 
  *  - Device supports Peer-to-Peer access
  *  - HIP_VERSION >= 5.2
  */
-TEST_CASE("Performance_hipMemcpyParam2DAsync_DeviceToDevice_EnablePeerAccess") {
+TEST_CASE(Performance_hipMemcpyParam2DAsync_DeviceToDevice_EnablePeerAccess) {
   CHECK_IMAGE_SUPPORT
   if (HipTest::getDeviceCount() < 2) {
     HipTest::HIP_SKIP_TEST("This test requires 2 GPUs. Skipping.");

--- a/projects/hip-tests/catch/performance/memcpy/hipMemcpyToSymbol.cc
+++ b/projects/hip-tests/catch/performance/memcpy/hipMemcpyToSymbol.cc
@@ -55,7 +55,7 @@ static void RunBenchmark(const void* source, size_t size = 1, size_t offset = 0)
  * ------------------------
  *  - HIP_VERSION >= 5.2
  */
-TEST_CASE("Performance_hipMemcpyToSymbol_SingularValue") {
+TEST_CASE(Performance_hipMemcpyToSymbol_SingularValue) {
   int set{42};
   RunBenchmark(&set);
 }
@@ -75,7 +75,7 @@ TEST_CASE("Performance_hipMemcpyToSymbol_SingularValue") {
  * ------------------------
  *  - HIP_VERSION >= 5.2
  */
-TEST_CASE("Performance_hipMemcpyToSymbol_ArrayValue") {
+TEST_CASE(Performance_hipMemcpyToSymbol_ArrayValue) {
   size_t size = GENERATE(1_KB, 4_KB, 1_MB);
   std::vector<int> array(size);
   std::fill_n(array.data(), size, 42);
@@ -99,7 +99,7 @@ TEST_CASE("Performance_hipMemcpyToSymbol_ArrayValue") {
  * ------------------------
  *  - HIP_VERSION >= 5.2
  */
-TEST_CASE("Performance_hipMemcpyToSymbol_WithOffset") {
+TEST_CASE(Performance_hipMemcpyToSymbol_WithOffset) {
   size_t size = GENERATE(1_KB, 4_KB, 1_MB);
   std::vector<int> array(size);
   std::fill_n(array.data(), size, 42);

--- a/projects/hip-tests/catch/performance/memcpy/hipMemcpyToSymbolAsync.cc
+++ b/projects/hip-tests/catch/performance/memcpy/hipMemcpyToSymbolAsync.cc
@@ -62,7 +62,7 @@ static void RunBenchmark(const void* source, size_t size = 1, size_t offset = 0)
  * ------------------------
  *  - HIP_VERSION >= 5.2
  */
-TEST_CASE("Performance_hipMemcpyToSymbolAsync_SingularValue") {
+TEST_CASE(Performance_hipMemcpyToSymbolAsync_SingularValue) {
   int set{42};
   RunBenchmark(&set);
 }
@@ -82,7 +82,7 @@ TEST_CASE("Performance_hipMemcpyToSymbolAsync_SingularValue") {
  * ------------------------
  *  - HIP_VERSION >= 5.2
  */
-TEST_CASE("Performance_hipMemcpyToSymbolAsync_ArrayValue") {
+TEST_CASE(Performance_hipMemcpyToSymbolAsync_ArrayValue) {
   size_t size = GENERATE(1_KB, 4_KB, 1_MB);
   std::vector<int> array(size);
   std::fill_n(array.data(), size, 42);
@@ -106,7 +106,7 @@ TEST_CASE("Performance_hipMemcpyToSymbolAsync_ArrayValue") {
  * ------------------------
  *  - HIP_VERSION >= 5.2
  */
-TEST_CASE("Performance_hipMemcpyToSymbolAsync_WithOffset") {
+TEST_CASE(Performance_hipMemcpyToSymbolAsync_WithOffset) {
   size_t size = GENERATE(1_KB, 4_KB, 1_MB);
   std::vector<int> array(size);
   std::fill_n(array.data(), size, 42);

--- a/projects/hip-tests/catch/performance/memcpy/hipMemcpyWithKernel.cc
+++ b/projects/hip-tests/catch/performance/memcpy/hipMemcpyWithKernel.cc
@@ -104,7 +104,7 @@ template <typename BenchmarkType> static void RunBenchmark(LinearAllocs host_all
  * ------------------------
  *  - HIP_VERSION >= 5.2
  */
-TEST_CASE("Performance_hipMemcpyHtoDKernelDtoHV1Async") {
+TEST_CASE(Performance_hipMemcpyHtoDKernelDtoHV1Async) {
   const auto allocation_size =
       GENERATE(16, 128, 1_KB, 4_KB, 16_KB, 256_KB, 512_KB, 1_MB, 4_MB, 16_MB, 128_MB);
   const auto device_allocation_type = LinearAllocs::hipMalloc;
@@ -112,7 +112,7 @@ TEST_CASE("Performance_hipMemcpyHtoDKernelDtoHV1Async") {
   RunBenchmark<MemcpyHtoDKernelDtoHv1AsyncBenchmark>(host_allocation_type, device_allocation_type,
                                                      allocation_size);
 }
-TEST_CASE("Performance_hipMemcpyHtoDKernelDtoHV2Async") {
+TEST_CASE(Performance_hipMemcpyHtoDKernelDtoHV2Async) {
   const auto allocation_size =
       GENERATE(16, 128, 1_KB, 4_KB, 16_KB, 256_KB, 512_KB, 1_MB, 4_MB, 16_MB, 128_MB);
   const auto device_allocation_type = LinearAllocs::hipMalloc;

--- a/projects/hip-tests/catch/performance/memcpy/hipMemcpyWithStream.cc
+++ b/projects/hip-tests/catch/performance/memcpy/hipMemcpyWithStream.cc
@@ -79,7 +79,7 @@ static void RunBenchmark(LinearAllocs dst_allocation_type, LinearAllocs src_allo
  * ------------------------
  *  - HIP_VERSION >= 5.2
  */
-TEST_CASE("Performance_hipMemcpyWithStream_DeviceToHost") {
+TEST_CASE(Performance_hipMemcpyWithStream_DeviceToHost) {
   const auto allocation_size = GENERATE(4_KB, 4_MB, 16_MB);
   const auto src_allocation_type = LinearAllocs::hipMalloc;
   const auto dst_allocation_type = GENERATE(LinearAllocs::malloc, LinearAllocs::hipHostMalloc);
@@ -104,7 +104,7 @@ TEST_CASE("Performance_hipMemcpyWithStream_DeviceToHost") {
  * ------------------------
  *  - HIP_VERSION >= 5.2
  */
-TEST_CASE("Performance_hipMemcpyWithStream_HostToDevice") {
+TEST_CASE(Performance_hipMemcpyWithStream_HostToDevice) {
   const auto allocation_size = GENERATE(4_KB, 4_MB, 16_MB);
   const auto src_allocation_type = GENERATE(LinearAllocs::malloc, LinearAllocs::hipHostMalloc);
   const auto dst_allocation_type = LinearAllocs::hipMalloc;
@@ -129,7 +129,7 @@ TEST_CASE("Performance_hipMemcpyWithStream_HostToDevice") {
  * ------------------------
  *  - HIP_VERSION >= 5.2
  */
-TEST_CASE("Performance_hipMemcpyWithStream_HostToHost") {
+TEST_CASE(Performance_hipMemcpyWithStream_HostToHost) {
   const auto allocation_size = GENERATE(4_KB, 4_MB, 16_MB);
   const auto src_allocation_type = GENERATE(LinearAllocs::malloc, LinearAllocs::hipHostMalloc);
   const auto dst_allocation_type = GENERATE(LinearAllocs::malloc, LinearAllocs::hipHostMalloc);
@@ -154,7 +154,7 @@ TEST_CASE("Performance_hipMemcpyWithStream_HostToHost") {
  * ------------------------
  *  - HIP_VERSION >= 5.2
  */
-TEST_CASE("Performance_hipMemcpyWithStream_DeviceToDevice_DisablePeerAccess") {
+TEST_CASE(Performance_hipMemcpyWithStream_DeviceToDevice_DisablePeerAccess) {
   const auto allocation_size = GENERATE(4_KB, 4_MB, 16_MB);
   const auto src_allocation_type = LinearAllocs::hipMalloc;
   const auto dst_allocation_type = LinearAllocs::hipMalloc;
@@ -181,7 +181,7 @@ TEST_CASE("Performance_hipMemcpyWithStream_DeviceToDevice_DisablePeerAccess") {
  *  - Device supports Peer-to-Peer access
  *  - HIP_VERSION >= 5.2
  */
-TEST_CASE("Performance_hipMemcpyWithStream_DeviceToDevice_EnablePeerAccess") {
+TEST_CASE(Performance_hipMemcpyWithStream_DeviceToDevice_EnablePeerAccess) {
   if (HipTest::getDeviceCount() < 2) {
     HipTest::HIP_SKIP_TEST("This test requires 2 GPUs. Skipping.");
     return;

--- a/projects/hip-tests/catch/performance/memset/hipMemset.cc
+++ b/projects/hip-tests/catch/performance/memset/hipMemset.cc
@@ -71,7 +71,7 @@ static void RunBenchmark(LinearAllocs allocation_type, size_t size) {
  * ------------------------
  *  - HIP_VERSION >= 5.2
  */
-TEST_CASE("Performance_hipMemset") {
+TEST_CASE(Performance_hipMemset) {
   const auto size = GENERATE(4_KB, 4_MB, 16_MB);
   const auto allocation_type = GENERATE(LinearAllocs::hipMalloc, LinearAllocs::hipHostMalloc,
                                         LinearAllocs::hipMallocManaged);

--- a/projects/hip-tests/catch/performance/memset/hipMemset2D.cc
+++ b/projects/hip-tests/catch/performance/memset/hipMemset2D.cc
@@ -65,7 +65,7 @@ static void RunBenchmark(size_t width, size_t height) {
  * ------------------------
  *  - HIP_VERSION >= 5.2
  */
-TEST_CASE("Performance_hipMemset2D") {
+TEST_CASE(Performance_hipMemset2D) {
   CHECK_IMAGE_SUPPORT
   const auto width = GENERATE(4_KB, 4_MB, 16_MB);
   RunBenchmark(width, 32);

--- a/projects/hip-tests/catch/performance/memset/hipMemset2DAsync.cc
+++ b/projects/hip-tests/catch/performance/memset/hipMemset2DAsync.cc
@@ -69,7 +69,7 @@ static void RunBenchmark(size_t width, size_t height) {
  * ------------------------
  *  - HIP_VERSION >= 5.2
  */
-TEST_CASE("Performance_hipMemset2DAsync") {
+TEST_CASE(Performance_hipMemset2DAsync) {
   CHECK_IMAGE_SUPPORT
   const auto width = GENERATE(4_KB, 4_MB, 16_MB);
   RunBenchmark(width, 32);

--- a/projects/hip-tests/catch/performance/memset/hipMemset3D.cc
+++ b/projects/hip-tests/catch/performance/memset/hipMemset3D.cc
@@ -66,7 +66,7 @@ static void RunBenchmark(size_t width, size_t height, size_t depth) {
  * ------------------------
  *  - HIP_VERSION >= 5.2
  */
-TEST_CASE("Performance_hipMemset3D") {
+TEST_CASE(Performance_hipMemset3D) {
   CHECK_IMAGE_SUPPORT
   const auto width = GENERATE(4_KB, 4_MB, 16_MB);
   RunBenchmark(width, 16, 4);

--- a/projects/hip-tests/catch/performance/memset/hipMemset3DAsync.cc
+++ b/projects/hip-tests/catch/performance/memset/hipMemset3DAsync.cc
@@ -69,7 +69,7 @@ static void RunBenchmark(size_t width, size_t height, size_t depth) {
  * ------------------------
  *  - HIP_VERSION >= 5.2
  */
-TEST_CASE("Performance_hipMemset3DAsync") {
+TEST_CASE(Performance_hipMemset3DAsync) {
   CHECK_IMAGE_SUPPORT
   const auto width = GENERATE(4_KB, 4_MB, 16_MB);
   RunBenchmark(width, 16, 4);

--- a/projects/hip-tests/catch/performance/memset/hipMemsetAsync.cc
+++ b/projects/hip-tests/catch/performance/memset/hipMemsetAsync.cc
@@ -74,7 +74,7 @@ static void RunBenchmark(LinearAllocs allocation_type, size_t size) {
  * ------------------------
  *  - HIP_VERSION >= 5.2
  */
-TEST_CASE("Performance_hipMemsetAsync") {
+TEST_CASE(Performance_hipMemsetAsync) {
   const auto size = GENERATE(4_KB, 4_MB, 16_MB);
   const auto allocation_type = GENERATE(LinearAllocs::hipMalloc, LinearAllocs::hipHostMalloc,
                                         LinearAllocs::hipMallocManaged);

--- a/projects/hip-tests/catch/performance/memset/hipMemsetD16.cc
+++ b/projects/hip-tests/catch/performance/memset/hipMemsetD16.cc
@@ -72,7 +72,7 @@ static void RunBenchmark(LinearAllocs allocation_type, size_t size) {
  * ------------------------
  *  - HIP_VERSION >= 5.2
  */
-TEST_CASE("Performance_hipMemsetD16") {
+TEST_CASE(Performance_hipMemsetD16) {
   const auto size = GENERATE(4_KB, 4_MB, 16_MB);
   const auto allocation_type = GENERATE(LinearAllocs::hipMalloc, LinearAllocs::hipHostMalloc,
                                         LinearAllocs::hipMallocManaged);

--- a/projects/hip-tests/catch/performance/memset/hipMemsetD16Async.cc
+++ b/projects/hip-tests/catch/performance/memset/hipMemsetD16Async.cc
@@ -75,7 +75,7 @@ static void RunBenchmark(LinearAllocs allocation_type, size_t size) {
  * ------------------------
  *  - HIP_VERSION >= 5.2
  */
-TEST_CASE("Performance_hipMemsetD16Async") {
+TEST_CASE(Performance_hipMemsetD16Async) {
   const auto size = GENERATE(4_KB, 4_MB, 16_MB);
   const auto allocation_type = GENERATE(LinearAllocs::hipMalloc, LinearAllocs::hipHostMalloc,
                                         LinearAllocs::hipMallocManaged);

--- a/projects/hip-tests/catch/performance/memset/hipMemsetD32.cc
+++ b/projects/hip-tests/catch/performance/memset/hipMemsetD32.cc
@@ -72,7 +72,7 @@ static void RunBenchmark(LinearAllocs allocation_type, size_t size) {
  * ------------------------
  *  - HIP_VERSION >= 5.2
  */
-TEST_CASE("Performance_hipMemsetD32") {
+TEST_CASE(Performance_hipMemsetD32) {
   const auto size = GENERATE(4_KB, 4_MB, 16_MB);
   const auto allocation_type = GENERATE(LinearAllocs::hipMalloc, LinearAllocs::hipHostMalloc,
                                         LinearAllocs::hipMallocManaged);

--- a/projects/hip-tests/catch/performance/memset/hipMemsetD32Async.cc
+++ b/projects/hip-tests/catch/performance/memset/hipMemsetD32Async.cc
@@ -75,7 +75,7 @@ static void RunBenchmark(LinearAllocs allocation_type, size_t size) {
  * ------------------------
  *  - HIP_VERSION >= 5.2
  */
-TEST_CASE("Performance_hipMemsetD32Async") {
+TEST_CASE(Performance_hipMemsetD32Async) {
   const auto size = GENERATE(4_KB, 4_MB, 16_MB);
   const auto allocation_type = GENERATE(LinearAllocs::hipMalloc, LinearAllocs::hipHostMalloc,
                                         LinearAllocs::hipMallocManaged);

--- a/projects/hip-tests/catch/performance/memset/hipMemsetD8.cc
+++ b/projects/hip-tests/catch/performance/memset/hipMemsetD8.cc
@@ -72,7 +72,7 @@ static void RunBenchmark(LinearAllocs allocation_type, size_t size) {
  * ------------------------
  *  - HIP_VERSION >= 5.2
  */
-TEST_CASE("Performance_hipMemsetD8") {
+TEST_CASE(Performance_hipMemsetD8) {
   const auto size = GENERATE(4_KB, 4_MB, 16_MB);
   const auto allocation_type = GENERATE(LinearAllocs::hipMalloc, LinearAllocs::hipHostMalloc,
                                         LinearAllocs::hipMallocManaged);

--- a/projects/hip-tests/catch/performance/memset/hipMemsetD8Async.cc
+++ b/projects/hip-tests/catch/performance/memset/hipMemsetD8Async.cc
@@ -75,7 +75,7 @@ static void RunBenchmark(LinearAllocs allocation_type, size_t size) {
  * ------------------------
  *  - HIP_VERSION >= 5.2
  */
-TEST_CASE("Performance_hipMemsetD8Async") {
+TEST_CASE(Performance_hipMemsetD8Async) {
   const auto size = GENERATE(4_KB, 4_MB, 16_MB);
   const auto allocation_type = GENERATE(LinearAllocs::hipMalloc, LinearAllocs::hipHostMalloc,
                                         LinearAllocs::hipMallocManaged);

--- a/projects/hip-tests/catch/performance/stream/hipExtStreamCreateWithCUMask.cc
+++ b/projects/hip-tests/catch/performance/stream/hipExtStreamCreateWithCUMask.cc
@@ -60,7 +60,7 @@ static void RunBenchmark() {
  *  - Platform specific (AMD)
  *  - HIP_VERSION >= 5.2
  */
-TEST_CASE("Performance_hipExtStreamCreateWithCUMask") { RunBenchmark(); }
+TEST_CASE(Performance_hipExtStreamCreateWithCUMask) { RunBenchmark(); }
 
 /**
  * End doxygen group PerformanceTest.

--- a/projects/hip-tests/catch/performance/stream/hipExtStreamGetCUMask.cc
+++ b/projects/hip-tests/catch/performance/stream/hipExtStreamGetCUMask.cc
@@ -62,7 +62,7 @@ static void RunBenchmark() {
  *  - Platform specific (AMD)
  *  - HIP_VERSION >= 5.2
  */
-TEST_CASE("Performance_hipExtStreamGetCUMask") { RunBenchmark(); }
+TEST_CASE(Performance_hipExtStreamGetCUMask) { RunBenchmark(); }
 
 /**
  * End doxygen group PerformanceTest.

--- a/projects/hip-tests/catch/performance/stream/hipFreeAsync.cc
+++ b/projects/hip-tests/catch/performance/stream/hipFreeAsync.cc
@@ -62,7 +62,7 @@ static void RunBenchmark(const size_t array_size) {
  * ------------------------
  *  - HIP_VERSION >= 5.2
  */
-TEST_CASE("Performance_hipFreeAsync") {
+TEST_CASE(Performance_hipFreeAsync) {
   size_t array_size = GENERATE(4_KB, 4_MB, 16_MB);
   RunBenchmark(array_size);
 }

--- a/projects/hip-tests/catch/performance/stream/hipMallocAsync.cc
+++ b/projects/hip-tests/catch/performance/stream/hipMallocAsync.cc
@@ -63,7 +63,7 @@ static void RunBenchmark(const size_t array_size) {
  * ------------------------
  *  - HIP_VERSION >= 5.2
  */
-TEST_CASE("Performance_hipMallocAsync") {
+TEST_CASE(Performance_hipMallocAsync) {
   size_t array_size = GENERATE(4_KB, 4_MB, 16_MB);
   RunBenchmark(array_size);
 }

--- a/projects/hip-tests/catch/performance/stream/hipMallocFromPoolAsync.cc
+++ b/projects/hip-tests/catch/performance/stream/hipMallocFromPoolAsync.cc
@@ -71,7 +71,7 @@ static void RunBenchmark(const size_t array_size) {
  *  - Device supports memory pools
  *  - HIP_VERSION >= 5.2
  */
-TEST_CASE("Performance_hipMallocFromPoolAsync") {
+TEST_CASE(Performance_hipMallocFromPoolAsync) {
   if (!AreMemPoolsSupported(0)) {
     HipTest::HIP_SKIP_TEST(
         "GPU 0 doesn't support hipDeviceAttributeMemoryPoolsSupported "

--- a/projects/hip-tests/catch/performance/stream/hipMemPoolCreate.cc
+++ b/projects/hip-tests/catch/performance/stream/hipMemPoolCreate.cc
@@ -59,7 +59,7 @@ static void RunBenchmark() {
  *  - Device supports memory pools
  *  - HIP_VERSION >= 5.2
  */
-TEST_CASE("Performance_hipMemPoolCreate") {
+TEST_CASE(Performance_hipMemPoolCreate) {
   if (!AreMemPoolsSupported(0)) {
     HipTest::HIP_SKIP_TEST(
         "GPU 0 doesn't support hipDeviceAttributeMemoryPoolsSupported "

--- a/projects/hip-tests/catch/performance/stream/hipMemPoolDestroy.cc
+++ b/projects/hip-tests/catch/performance/stream/hipMemPoolDestroy.cc
@@ -58,7 +58,7 @@ static void RunBenchmark() {
  *  - Device supports memory pools
  *  - HIP_VERSION >= 5.2
  */
-TEST_CASE("Performance_hipMemPoolDestroy") {
+TEST_CASE(Performance_hipMemPoolDestroy) {
   if (!AreMemPoolsSupported(0)) {
     HipTest::HIP_SKIP_TEST(
         "GPU 0 doesn't support hipDeviceAttributeMemoryPoolsSupported "

--- a/projects/hip-tests/catch/performance/stream/hipMemPoolExportPointer.cc
+++ b/projects/hip-tests/catch/performance/stream/hipMemPoolExportPointer.cc
@@ -71,7 +71,7 @@ static void RunBenchmark(const size_t array_size) {
  *  - Device supports memory pools
  *  - HIP_VERSION >= 5.2
  */
-TEST_CASE("Performance_hipMemPoolExportPointer") {
+TEST_CASE(Performance_hipMemPoolExportPointer) {
   if (!AreMemPoolsSupported(0)) {
     HipTest::HIP_SKIP_TEST(
         "GPU 0 doesn't support hipDeviceAttributeMemoryPoolsSupported "

--- a/projects/hip-tests/catch/performance/stream/hipMemPoolExportToShareableHandle.cc
+++ b/projects/hip-tests/catch/performance/stream/hipMemPoolExportToShareableHandle.cc
@@ -65,7 +65,7 @@ static void RunBenchmark() {
  *  - Device supports memory pools
  *  - HIP_VERSION >= 5.2
  */
-TEST_CASE("Performance_hipMemPoolExportToShareableHandle") {
+TEST_CASE(Performance_hipMemPoolExportToShareableHandle) {
   if (!AreMemPoolsSupported(0)) {
     HipTest::HIP_SKIP_TEST(
         "GPU 0 doesn't support hipDeviceAttributeMemoryPoolsSupported "

--- a/projects/hip-tests/catch/performance/stream/hipMemPoolGetAccess.cc
+++ b/projects/hip-tests/catch/performance/stream/hipMemPoolGetAccess.cc
@@ -61,7 +61,7 @@ static void RunBenchmark() {
  *  - Device supports memory pools
  *  - HIP_VERSION >= 5.2
  */
-TEST_CASE("Performance_hipMemPoolGetAccess") {
+TEST_CASE(Performance_hipMemPoolGetAccess) {
   if (!AreMemPoolsSupported(0)) {
     HipTest::HIP_SKIP_TEST(
         "GPU 0 doesn't support hipDeviceAttributeMemoryPoolsSupported "

--- a/projects/hip-tests/catch/performance/stream/hipMemPoolGetAttribute.cc
+++ b/projects/hip-tests/catch/performance/stream/hipMemPoolGetAttribute.cc
@@ -67,7 +67,7 @@ static void RunBenchmark(const hipMemPoolAttr attribute) {
  *  - Device supports memory pools
  *  - HIP_VERSION >= 5.2
  */
-TEST_CASE("Performance_hipMemPoolGetAttribute") {
+TEST_CASE(Performance_hipMemPoolGetAttribute) {
   if (!AreMemPoolsSupported(0)) {
     HipTest::HIP_SKIP_TEST(
         "GPU 0 doesn't support hipDeviceAttributeMemoryPoolsSupported "

--- a/projects/hip-tests/catch/performance/stream/hipMemPoolImportFromShareableHandle.cc
+++ b/projects/hip-tests/catch/performance/stream/hipMemPoolImportFromShareableHandle.cc
@@ -73,7 +73,7 @@ static void RunBenchmark() {
  *  - Device supports memory pools
  *  - HIP_VERSION >= 5.2
  */
-TEST_CASE("Performance_hipMemPoolImportFromShareableHandle") {
+TEST_CASE(Performance_hipMemPoolImportFromShareableHandle) {
   if (!AreMemPoolsSupported(0)) {
     HipTest::HIP_SKIP_TEST(
         "GPU 0 doesn't support hipDeviceAttributeMemoryPoolsSupported "

--- a/projects/hip-tests/catch/performance/stream/hipMemPoolImportPointer.cc
+++ b/projects/hip-tests/catch/performance/stream/hipMemPoolImportPointer.cc
@@ -77,7 +77,7 @@ static void RunBenchmark(const size_t array_size) {
  *  - Device supports memory pools
  *  - HIP_VERSION >= 5.2
  */
-TEST_CASE("Performance_hipMemPoolImportPointer") {
+TEST_CASE(Performance_hipMemPoolImportPointer) {
   if (!AreMemPoolsSupported(0)) {
     HipTest::HIP_SKIP_TEST(
         "GPU 0 doesn't support hipDeviceAttributeMemoryPoolsSupported "

--- a/projects/hip-tests/catch/performance/stream/hipMemPoolSetAccess.cc
+++ b/projects/hip-tests/catch/performance/stream/hipMemPoolSetAccess.cc
@@ -61,7 +61,7 @@ static void RunBenchmark() {
  *  - Device supports memory pools
  *  - HIP_VERSION >= 5.2
  */
-TEST_CASE("Performance_hipMemPoolSetAccess") {
+TEST_CASE(Performance_hipMemPoolSetAccess) {
   if (!AreMemPoolsSupported(0)) {
     HipTest::HIP_SKIP_TEST(
         "GPU 0 doesn't support hipDeviceAttributeMemoryPoolsSupported "

--- a/projects/hip-tests/catch/performance/stream/hipMemPoolSetAttribute.cc
+++ b/projects/hip-tests/catch/performance/stream/hipMemPoolSetAttribute.cc
@@ -75,7 +75,7 @@ static void RunBenchmark(const hipMemPoolAttr attribute) {
  *  - Device supports memory pools
  *  - HIP_VERSION >= 5.2
  */
-TEST_CASE("Performance_hipMemPoolSetAttribute") {
+TEST_CASE(Performance_hipMemPoolSetAttribute) {
   if (!AreMemPoolsSupported(0)) {
     HipTest::HIP_SKIP_TEST(
         "GPU 0 doesn't support hipDeviceAttributeMemoryPoolsSupported "

--- a/projects/hip-tests/catch/performance/stream/hipMemPoolTrimTo.cc
+++ b/projects/hip-tests/catch/performance/stream/hipMemPoolTrimTo.cc
@@ -64,7 +64,7 @@ static void RunBenchmark(const size_t min_bytes_to_hold) {
  *  - Device supports memory pools
  *  - HIP_VERSION >= 5.2
  */
-TEST_CASE("Performance_hipMemPoolTrimTo") {
+TEST_CASE(Performance_hipMemPoolTrimTo) {
   if (!AreMemPoolsSupported(0)) {
     HipTest::HIP_SKIP_TEST(
         "GPU 0 doesn't support hipDeviceAttributeMemoryPoolsSupported "

--- a/projects/hip-tests/catch/performance/stream/hipStreamAddCallback.cc
+++ b/projects/hip-tests/catch/performance/stream/hipStreamAddCallback.cc
@@ -54,7 +54,7 @@ static void RunBenchmark() {
  * ------------------------
  *  - HIP_VERSION >= 5.2
  */
-TEST_CASE("Performance_hipStreamAddCallback") { RunBenchmark(); }
+TEST_CASE(Performance_hipStreamAddCallback) { RunBenchmark(); }
 
 /**
  * End doxygen group PerformanceTest.

--- a/projects/hip-tests/catch/performance/stream/hipStreamBasic.cc
+++ b/projects/hip-tests/catch/performance/stream/hipStreamBasic.cc
@@ -148,7 +148,7 @@ class HipStreamCreateWithFlagsBenchmark : public Benchmark<HipStreamCreateWithFl
  * ------------------------
  *  - HIP_VERSION >= 5.2
  */
-TEST_CASE("Performance_hipStreamCreate") {
+TEST_CASE(Performance_hipStreamCreate) {
   HipStreamCreateBenchmark benchmark;
   benchmark.Run();
 }
@@ -179,7 +179,7 @@ static void RunBenchmarkWithPriority(unsigned flag) {
  * ------------------------
  *  - HIP_VERSION >= 5.2
  */
-TEST_CASE("Performance_hipStreamCreateWithFlags") {
+TEST_CASE(Performance_hipStreamCreateWithFlags) {
   const auto flag = GENERATE(hipStreamDefault, hipStreamNonBlocking);
   RunBenchmark(flag);
 }
@@ -198,7 +198,7 @@ TEST_CASE("Performance_hipStreamCreateWithFlags") {
  * ------------------------
  *  - HIP_VERSION >= 5.2
  */
-TEST_CASE("Performance_hipStreamCreateWithPriority") {
+TEST_CASE(Performance_hipStreamCreateWithPriority) {
   const auto flag = GENERATE(hipStreamDefault, hipStreamNonBlocking);
   RunBenchmarkWithPriority(flag);
 }
@@ -214,7 +214,7 @@ TEST_CASE("Performance_hipStreamCreateWithPriority") {
  * ------------------------
  *  - HIP_VERSION >= 5.2
  */
-TEST_CASE("Performance_hipStreamDestroy") {
+TEST_CASE(Performance_hipStreamDestroy) {
   HipStreamDestroyBenchmark benchmark;
   benchmark.Run();
 }
@@ -230,7 +230,7 @@ TEST_CASE("Performance_hipStreamDestroy") {
  * ------------------------
  *  - HIP_VERSION >= 5.2
  */
-TEST_CASE("Performance_hipDeviceGetStreamPriorityRange") {
+TEST_CASE(Performance_hipDeviceGetStreamPriorityRange) {
   HipDeviceGetStreamPriorityRangeBenchmark benchmark;
   benchmark.Run();
 }
@@ -246,7 +246,7 @@ TEST_CASE("Performance_hipDeviceGetStreamPriorityRange") {
  * ------------------------
  *  - HIP_VERSION >= 5.2
  */
-TEST_CASE("Performance_hipStreamQuery") {
+TEST_CASE(Performance_hipStreamQuery) {
   const auto perform_work = GENERATE(true, false);
   HipStreamQueryBenchmark benchmark;
   if (perform_work) {
@@ -268,7 +268,7 @@ TEST_CASE("Performance_hipStreamQuery") {
  * ------------------------
  *  - HIP_VERSION >= 5.2
  */
-TEST_CASE("Performance_hipStreamSynchronize") {
+TEST_CASE(Performance_hipStreamSynchronize) {
   HipStreamSynchronizeBenchmark benchmark;
   benchmark.Run();
 }

--- a/projects/hip-tests/catch/performance/stream/hipStreamGetFlags.cc
+++ b/projects/hip-tests/catch/performance/stream/hipStreamGetFlags.cc
@@ -67,7 +67,7 @@ static void RunBenchmark(unsigned int expected_flag) {
  * ------------------------
  *  - HIP_VERSION >= 5.2
  */
-TEST_CASE("Performance_hipStreamGetFlags") {
+TEST_CASE(Performance_hipStreamGetFlags) {
   unsigned int expected_flag = GENERATE(hipStreamDefault, hipStreamNonBlocking);
   RunBenchmark(expected_flag);
 }

--- a/projects/hip-tests/catch/performance/stream/hipStreamGetPriority.cc
+++ b/projects/hip-tests/catch/performance/stream/hipStreamGetPriority.cc
@@ -66,7 +66,7 @@ static void RunBenchmark(Streams stream_type) {
  * ------------------------
  *  - HIP_VERSION >= 5.2
  */
-TEST_CASE("Performance_hipStreamGetPriority") {
+TEST_CASE(Performance_hipStreamGetPriority) {
   Streams stream_type = GENERATE(Streams::nullstream, Streams::created);
   RunBenchmark(stream_type);
 }

--- a/projects/hip-tests/catch/performance/stream/hipStreamWaitEvent.cc
+++ b/projects/hip-tests/catch/performance/stream/hipStreamWaitEvent.cc
@@ -74,7 +74,7 @@ static void RunBenchmark(Streams stream_type) {
  * ------------------------
  *  - HIP_VERSION >= 5.2
  */
-TEST_CASE("Performance_hipStreamWaitEvent") {
+TEST_CASE(Performance_hipStreamWaitEvent) {
   Streams stream_type = GENERATE(Streams::nullstream, Streams::created);
   RunBenchmark(stream_type);
 }

--- a/projects/hip-tests/catch/performance/stream/hipStreamWaitValue.cc
+++ b/projects/hip-tests/catch/performance/stream/hipStreamWaitValue.cc
@@ -121,7 +121,7 @@ static void RunBenchmark(const size_t array_size, unsigned int flag) {
  *  - Device supports Stream Wait Value operations
  *  - HIP_VERSION >= 5.2
  */
-TEST_CASE("Performance_hipStreamWaitValue32") {
+TEST_CASE(Performance_hipStreamWaitValue32) {
 #if HT_AMD
   if (!IsStreamWaitValueSupported(0)) {
     HipTest::HIP_SKIP_TEST(
@@ -158,7 +158,7 @@ TEST_CASE("Performance_hipStreamWaitValue32") {
  *  - Device supports Stream Wait Value operations
  *  - HIP_VERSION >= 5.2
  */
-TEST_CASE("Performance_hipStreamWaitValue64") {
+TEST_CASE(Performance_hipStreamWaitValue64) {
   if (!IsStreamWaitValueSupported(0)) {
     HipTest::HIP_SKIP_TEST(
         "GPU 0 doesn't support hipStreamWaitValue64() function. "

--- a/projects/hip-tests/catch/performance/stream/hipStreamWriteValue.cc
+++ b/projects/hip-tests/catch/performance/stream/hipStreamWriteValue.cc
@@ -87,7 +87,7 @@ template <typename WriteValueBenchmark> static void RunBenchmark(const size_t ar
  * ------------------------
  *  - HIP_VERSION >= 5.2
  */
-TEST_CASE("Performance_hipStreamWriteValue32") {
+TEST_CASE(Performance_hipStreamWriteValue32) {
 #if HT_AMD
   size_t array_size = GENERATE(4_KB, 4_MB, 16_MB);
   RunBenchmark<StreamWriteValue32Benchmark>(array_size);
@@ -109,7 +109,7 @@ TEST_CASE("Performance_hipStreamWriteValue32") {
  * ------------------------
  *  - HIP_VERSION >= 5.2
  */
-TEST_CASE("Performance_hipStreamWriteValue64") {
+TEST_CASE(Performance_hipStreamWriteValue64) {
 #if HT_NVIDIA
   if (!IsStreamWriteValueSupported(0)) {
     HipTest::HIP_SKIP_TEST(

--- a/projects/hip-tests/catch/performance/warpSync/warpSync.cc
+++ b/projects/hip-tests/catch/performance/warpSync/warpSync.cc
@@ -326,42 +326,42 @@ template <class T, template <typename> class Op> struct ReduceBenchmark {
   }
 };
 
-TEMPLATE_TEST_CASE("Performance_Reduce_Sync_Add", "", int, unsigned int, unsigned long long,
+TEMPLATE_TEST_CASE(Performance_Reduce_Sync_Add, int, unsigned int, unsigned long long,
                    long long, float, half, double) {
   ReduceBenchmark<TestType, std::plus> benchmark;
 
   benchmark.Run();
 }
 
-TEMPLATE_TEST_CASE("Performance_Reduce_Sync_Min", "", int, unsigned int, unsigned long long,
+TEMPLATE_TEST_CASE(Performance_Reduce_Sync_Min, int, unsigned int, unsigned long long,
                    long long, float, half, double) {
   ReduceBenchmark<TestType, MinOp> benchmark;
 
   benchmark.Run();
 }
 
-TEMPLATE_TEST_CASE("Performance_Reduce_Sync_Max", "", int, unsigned int, unsigned long long,
+TEMPLATE_TEST_CASE(Performance_Reduce_Sync_Max, int, unsigned int, unsigned long long,
                    long long, float, half, double) {
   ReduceBenchmark<TestType, MaxOp> benchmark;
 
   benchmark.Run();
 }
 
-TEMPLATE_TEST_CASE("Performance_Reduce_Sync_And", "", int, unsigned int, unsigned long long,
+TEMPLATE_TEST_CASE(Performance_Reduce_Sync_And, int, unsigned int, unsigned long long,
                    long long) {
   ReduceBenchmark<TestType, AndOp> benchmark;
 
   benchmark.Run();
 }
 
-TEMPLATE_TEST_CASE("Performance_Reduce_Sync_Or", "", int, unsigned int, unsigned long long,
+TEMPLATE_TEST_CASE(Performance_Reduce_Sync_Or, int, unsigned int, unsigned long long,
                    long long) {
   ReduceBenchmark<TestType, OrOp> benchmark;
 
   benchmark.Run();
 }
 
-TEMPLATE_TEST_CASE("Performance_Reduce_Sync_Xor", "", int, unsigned int, unsigned long long,
+TEMPLATE_TEST_CASE(Performance_Reduce_Sync_Xor, int, unsigned int, unsigned long long,
                    long long) {
   ReduceBenchmark<TestType, XorOp> benchmark;
 

--- a/projects/hip-tests/catch/perftests/compute/hipPerfDotProduct.cc
+++ b/projects/hip-tests/catch/perftests/compute/hipPerfDotProduct.cc
@@ -230,7 +230,7 @@ void computeDotProduct(int n, const double* x, const double* y, double& result, 
  *  - HIP_VERSION >= 5.6
  */
 
-TEST_CASE("Perf_hipPerfDotProduct") {
+TEST_CASE(Perf_hipPerfDotProduct) {
   int nGpu = 0;
   int p_gpuDevice = 0;
   HIP_CHECK(hipGetDeviceCount(&nGpu));

--- a/projects/hip-tests/catch/perftests/compute/hipPerfMandelbrot.cc
+++ b/projects/hip-tests/catch/perftests/compute/hipPerfMandelbrot.cc
@@ -599,7 +599,7 @@ void hipPerfMandelBrot::checkData(uint* ptr) {
  *  - HIP_VERSION >= 5.6
  */
 
-TEST_CASE("Perf_hipPerfMandelbrot") {
+TEST_CASE(Perf_hipPerfMandelbrot) {
   hipPerfMandelBrot mandelbrotCompute;
   int deviceId = 0;
   mandelbrotCompute.open(deviceId);

--- a/projects/hip-tests/catch/perftests/dispatch/hipPerfDispatchSpeed.cc
+++ b/projects/hip-tests/catch/perftests/dispatch/hipPerfDispatchSpeed.cc
@@ -60,7 +60,7 @@ __global__ void _TimingKernel(uint64_t count) {
 
 enum TimingMode { TimingMode_WallTime, TimingMode_HIPEvent, TimingMode_NumModes };
 
-TEST_CASE("Perf_hipPerfDispatchAndExecutionSpeed") {
+TEST_CASE(Perf_hipPerfDispatchAndExecutionSpeed) {
   hipError_t err = hipSuccess;
 
   unsigned int testListSize = sizeof(testList) / sizeof(testList[0]);

--- a/projects/hip-tests/catch/perftests/event/hipEventOverFlowPerf.cc
+++ b/projects/hip-tests/catch/perftests/event/hipEventOverFlowPerf.cc
@@ -102,7 +102,7 @@ void thread_job(int dev, int virt) {
  * ------------------------
  * - HIP_VERSION >= 6.5
  */
-TEST_CASE("Unit_hipEventOverFlow_PerfTest") {
+TEST_CASE(Unit_hipEventOverFlow_PerfTest) {
   int mgpu = 0;
   HIP_CHECK_PERF(hipGetDeviceCount(&mgpu));
   stream_pool.resize(mgpu);

--- a/projects/hip-tests/catch/perftests/event/hipKernelLookUpPerf.cc
+++ b/projects/hip-tests/catch/perftests/event/hipKernelLookUpPerf.cc
@@ -75,7 +75,7 @@ void thread_jobs(int dev, int virt) {
  * ------------------------
  * - HIP_VERSION >= 6.5
  */
-TEST_CASE("Unit_hipKernelLookUp_PerfTest") {
+TEST_CASE(Unit_hipKernelLookUp_PerfTest) {
   int mgpu = 0;
   HIP_CHECK_PERF(hipGetDeviceCount(&mgpu));
   stream_pools.resize(mgpu);

--- a/projects/hip-tests/catch/perftests/graph/hipGraphTopology.cc
+++ b/projects/hip-tests/catch/perftests/graph/hipGraphTopology.cc
@@ -193,7 +193,7 @@ static void run_graph_topology_test(const TestOptions& opt) {
     
     int kernel_count = 0;
     int current_batch_size = 0;
-    int batch_number = 0;
+    [[maybe_unused]] int batch_number = 0;
     
     for (int i = 0; i < opt.length; ++i) {
       std::string node_type;
@@ -431,7 +431,7 @@ static void run_graph_topology_test(const TestOptions& opt) {
 /**
  * Test straight topology graph performance
  */
-TEST_CASE("Perf_GraphTopology_Straight") {
+TEST_CASE(Perf_GraphTopology_Straight) {
   TestOptions opt;
   opt.topology = "straight";
   opt.length = 50;
@@ -443,7 +443,7 @@ TEST_CASE("Perf_GraphTopology_Straight") {
 /**
  * Test parallel topology graph performance
  */
-TEST_CASE("Perf_GraphTopology_Parallel") {
+TEST_CASE(Perf_GraphTopology_Parallel) {
   TestOptions opt;
   opt.topology = "parallel";
   opt.length = 25;
@@ -456,7 +456,7 @@ TEST_CASE("Perf_GraphTopology_Parallel") {
 /**
  * Test hexagon topology graph performance
  */
-TEST_CASE("Perf_GraphTopology_Hexagon") {
+TEST_CASE(Perf_GraphTopology_Hexagon) {
   TestOptions opt;
   opt.topology = "hexagon";
   opt.straight_nodes = 20;
@@ -469,7 +469,7 @@ TEST_CASE("Perf_GraphTopology_Hexagon") {
 /**
  * Test mixed topology graph performance
  */
-TEST_CASE("Perf_GraphTopology_Mixed") {
+TEST_CASE(Perf_GraphTopology_Mixed) {
   TestOptions opt;
   opt.topology = "mixed";
   opt.length = 27; // 3 cycles of 9-step pattern  

--- a/projects/hip-tests/catch/perftests/graph/hipPerfGraphLaunch.cc
+++ b/projects/hip-tests/catch/perftests/graph/hipPerfGraphLaunch.cc
@@ -90,7 +90,7 @@ static __global__ void addKernel(int* arr1, int* arr2, int size) {
  * ------------------------
  * - HIP_VERSION >= 6.4
  */
-TEST_CASE("Perf_GraphWithMoreAllocFreeNodes_SingleBranchNoOperations") {
+TEST_CASE(Perf_GraphWithMoreAllocFreeNodes_SingleBranchNoOperations) {
   constexpr int numberOfNodes = 1024;
 
   int* devMem[numberOfNodes];
@@ -214,7 +214,7 @@ TEST_CASE("Perf_GraphWithMoreAllocFreeNodes_SingleBranchNoOperations") {
  * ------------------------
  * - HIP_VERSION >= 6.4
  */
-TEST_CASE("Perf_GraphWithMoreAllocFreeNodes_SerialNodesSingleBranchWithOps") {
+TEST_CASE(Perf_GraphWithMoreAllocFreeNodes_SerialNodesSingleBranchWithOps) {
   constexpr int SIZE = 100;
 
   char* dev[SIZE];
@@ -408,7 +408,7 @@ TEST_CASE("Perf_GraphWithMoreAllocFreeNodes_SerialNodesSingleBranchWithOps") {
  * ------------------------
  * - HIP_VERSION >= 6.4
  */
-TEST_CASE("Perf_GraphWithMoreAllocFreeNodes_MultipleBranches") {
+TEST_CASE(Perf_GraphWithMoreAllocFreeNodes_MultipleBranches) {
   constexpr int SIZE = 1024;
   constexpr size_t NBYTES = SIZE * sizeof(int);
   constexpr int BRANCHES = 10;
@@ -595,7 +595,7 @@ TEST_CASE("Perf_GraphWithMoreAllocFreeNodes_MultipleBranches") {
  * ------------------------
  * - HIP_VERSION >= 6.4
  */
-TEST_CASE("Perf_GraphWithMoreAllocFreeNodes_MultipleIndependentBranches") {
+TEST_CASE(Perf_GraphWithMoreAllocFreeNodes_MultipleIndependentBranches) {
   constexpr int BRANCHES = 10;
 
   char* dev[BRANCHES];
@@ -742,7 +742,7 @@ TEST_CASE("Perf_GraphWithMoreAllocFreeNodes_MultipleIndependentBranches") {
  * ------------------------
  * - HIP_VERSION >= 6.4
  */
-TEST_CASE("Perf_GraphWithMoreAllocFreeNodes_OneBranchNoOps_AutoFreeOnLaunch") {
+TEST_CASE(Perf_GraphWithMoreAllocFreeNodes_OneBranchNoOps_AutoFreeOnLaunch) {
   constexpr int SIZE = 1024;
 
   int* devMem[SIZE];

--- a/projects/hip-tests/catch/perftests/graph/parallelGraph.cc
+++ b/projects/hip-tests/catch/perftests/graph/parallelGraph.cc
@@ -59,7 +59,7 @@ template <typename T> __global__ void vectorADD(const T* A_d, const T* B_d, T* C
  * ------------------------
  * - HIP_VERSION >= 6.4
  */
-TEST_CASE("Unit_hipGraph_Performance_Improvement_ParallelGraph") {
+TEST_CASE(Unit_hipGraph_Performance_Improvement_ParallelGraph) {
   hipGraphNode_t memCpy1, memCpy2, memCpy3;
   std::vector<hipGraphNode_t> kNode(kNumNode);
   hipGraph_t graph;
@@ -135,7 +135,7 @@ TEST_CASE("Unit_hipGraph_Performance_Improvement_ParallelGraph") {
  * ------------------------
  * - HIP_VERSION >= 6.4
  */
-TEST_CASE("Unit_hipGraph_Performance_With_Stream_Operations") {
+TEST_CASE(Unit_hipGraph_Performance_With_Stream_Operations) {
   unsigned blocks = HipTest::setNumBlocks(blocksPerCU, threadsPerBlock, N);
   hipStream_t stream;
   HIP_CHECK(hipStreamCreate(&stream));
@@ -177,7 +177,7 @@ TEST_CASE("Unit_hipGraph_Performance_With_Stream_Operations") {
  * - HIP_VERSION >= 6.4
  */
 
-TEST_CASE("Unit_hipGraph_Performance_With_Stream_Capture") {
+TEST_CASE(Unit_hipGraph_Performance_With_Stream_Capture) {
   unsigned blocks = HipTest::setNumBlocks(blocksPerCU, threadsPerBlock, N);
   hipGraph_t graph;
   hipStream_t stream, streamForGraph;

--- a/projects/hip-tests/catch/perftests/memory/hipPerfBufferCopyInterGpuPerformance.cc
+++ b/projects/hip-tests/catch/perftests/memory/hipPerfBufferCopyInterGpuPerformance.cc
@@ -50,7 +50,7 @@ static constexpr int nIters = 10;                     // interation number for t
  * ------------------------
  * - HIP_VERSION >= 7.0
  */
-TEST_CASE("Perf_PerfBufferCopySpeedAll2All_Inter_GPU") {
+TEST_CASE(Perf_PerfBufferCopySpeedAll2All_Inter_GPU) {
   int nGpus = 0;
   HIP_CHECK(hipGetDeviceCount(&nGpus));
   if (nGpus < 2) {

--- a/projects/hip-tests/catch/perftests/memory/hipPerfBufferCopyRectSpeed.cc
+++ b/projects/hip-tests/catch/perftests/memory/hipPerfBufferCopyRectSpeed.cc
@@ -207,16 +207,16 @@ static bool hipPerfBufferCopyRectSpeed_test(int p_tests) {
 /**
  * Test Description
  * ------------------------
- *  - Verify hipPerfBufferCopy status.
+ *  - Verify hipPerfBufferCopy status.
  * Test source
  * ------------------------
- *  - perftests/memory/hipPerfBufferCopyRectSpeed.cc
+ *  - perftests/memory/hipPerfBufferCopyRectSpeed.cc
  * Test requirements
  * ------------------------
- *  - HIP_VERSION >= 5.6
+ *  - HIP_VERSION >= 5.6
  */
 
-TEST_CASE("Perf_hipPerfBufferCopyRectSpeed_test") {
+TEST_CASE(Perf_hipPerfBufferCopyRectSpeed_test) {
   int numDevices = 0;
   HIP_CHECK(hipGetDeviceCount(&numDevices));
 

--- a/projects/hip-tests/catch/perftests/memory/hipPerfBufferCopySpeed.cc
+++ b/projects/hip-tests/catch/perftests/memory/hipPerfBufferCopySpeed.cc
@@ -373,16 +373,16 @@ static bool hipPerfBufferCopySpeed_test(int p_tests) {
 /**
  * Test Description
  * ------------------------
- *  - Verify hipPerfBufferCopySpeed status.
+ *  - Verify hipPerfBufferCopySpeed status.
  * Test source
  * ------------------------
- *  - perftests/memory/hipPerfBufferCopySpeed.cc
+ *  - perftests/memory/hipPerfBufferCopySpeed.cc
  * Test requirements
  * ------------------------
- *  - HIP_VERSION >= 5.6
+ *  - HIP_VERSION >= 5.6
  */
 
-TEST_CASE("Perf_hipPerfBufferCopySpeed_test") {
+TEST_CASE(Perf_hipPerfBufferCopySpeed_test) {
   int numDevices = 0;
   HIP_CHECK(hipGetDeviceCount(&numDevices));
   if (numDevices <= 0) {

--- a/projects/hip-tests/catch/perftests/memory/hipPerfBufferCopySpeedAll2All.cc
+++ b/projects/hip-tests/catch/perftests/memory/hipPerfBufferCopySpeedAll2All.cc
@@ -267,7 +267,7 @@ static void testCopyPerf(bool toRemote, bool kernelCopy, bool onOneGpu) {
  * ------------------------
  * - HIP_VERSION >= 6.0
  */
-TEST_CASE("Perf_PerfBufferCopySpeedAll2All_test_hipMemcpyPeerAsync_remotes_to_local") {
+TEST_CASE(Perf_PerfBufferCopySpeedAll2All_test_hipMemcpyPeerAsync_remotes_to_local) {
   testCopyPerf(false, false, false);
 }
 
@@ -286,7 +286,7 @@ TEST_CASE("Perf_PerfBufferCopySpeedAll2All_test_hipMemcpyPeerAsync_remotes_to_lo
  * ------------------------
  * - HIP_VERSION >= 6.0
  */
-TEST_CASE("Perf_PerfBufferCopySpeedAll2All_test_hipMemcpyPeerAsync_local_to_remotes") {
+TEST_CASE(Perf_PerfBufferCopySpeedAll2All_test_hipMemcpyPeerAsync_local_to_remotes) {
   testCopyPerf(true, false, false);
 }
 
@@ -307,7 +307,7 @@ TEST_CASE("Perf_PerfBufferCopySpeedAll2All_test_hipMemcpyPeerAsync_local_to_remo
  * ------------------------
  * - HIP_VERSION >= 6.0
  */
-TEST_CASE("Perf_PerfBufferCopySpeedAll2All_test_kernel_copy_remotes_to_local") {
+TEST_CASE(Perf_PerfBufferCopySpeedAll2All_test_kernel_copy_remotes_to_local) {
   testCopyPerf(false, true, false);
 }
 
@@ -328,7 +328,7 @@ TEST_CASE("Perf_PerfBufferCopySpeedAll2All_test_kernel_copy_remotes_to_local") {
  * ------------------------
  * - HIP_VERSION >= 6.0
  */
-TEST_CASE("Perf_PerfBufferCopySpeedAll2All_test_kernel_copy_local_to_remotes") {
+TEST_CASE(Perf_PerfBufferCopySpeedAll2All_test_kernel_copy_local_to_remotes) {
   testCopyPerf(true, true, false);
 }
 
@@ -347,7 +347,7 @@ TEST_CASE("Perf_PerfBufferCopySpeedAll2All_test_kernel_copy_local_to_remotes") {
  * ------------------------
  * - HIP_VERSION >= 6.0
  */
-TEST_CASE("Perf_PerfBufferCopySpeedAll2One_test_hipMemcpyPeerAsync_remotes_to_local") {
+TEST_CASE(Perf_PerfBufferCopySpeedAll2One_test_hipMemcpyPeerAsync_remotes_to_local) {
   testCopyPerf(false, false, true);
 }
 
@@ -366,7 +366,7 @@ TEST_CASE("Perf_PerfBufferCopySpeedAll2One_test_hipMemcpyPeerAsync_remotes_to_lo
  * ------------------------
  * - HIP_VERSION >= 6.0
  */
-TEST_CASE("Perf_PerfBufferCopySpeedOne2All_test_hipMemcpyPeerAsync_local_to_remotes") {
+TEST_CASE(Perf_PerfBufferCopySpeedOne2All_test_hipMemcpyPeerAsync_local_to_remotes) {
   testCopyPerf(true, false, true);
 }
 
@@ -385,7 +385,7 @@ TEST_CASE("Perf_PerfBufferCopySpeedOne2All_test_hipMemcpyPeerAsync_local_to_remo
  * ------------------------
  * - HIP_VERSION >= 6.0
  */
-TEST_CASE("Perf_PerfBufferCopySpeedAll2One_test_kernel_copy_remotes_to_local") {
+TEST_CASE(Perf_PerfBufferCopySpeedAll2One_test_kernel_copy_remotes_to_local) {
   testCopyPerf(false, true, true);
 }
 
@@ -406,7 +406,7 @@ TEST_CASE("Perf_PerfBufferCopySpeedAll2One_test_kernel_copy_remotes_to_local") {
  * ------------------------
  * - HIP_VERSION >= 6.0
  */
-TEST_CASE("Perf_PerfBufferCopySpeedOne2All_test_kernel_copy_local_to_remotes") {
+TEST_CASE(Perf_PerfBufferCopySpeedOne2All_test_kernel_copy_local_to_remotes) {
   testCopyPerf(true, true, true);
 }
 

--- a/projects/hip-tests/catch/perftests/memory/hipPerfBufferCopySpeedP2P.cc
+++ b/projects/hip-tests/catch/perftests/memory/hipPerfBufferCopySpeedP2P.cc
@@ -456,13 +456,13 @@ static void testP2PBiDirMemPerf(const int iterations, const bool useHipMemcpyAsy
  * ------------------------
  *  - HIP_VERSION >= 6.0
  */
-TEST_CASE("Perf_hipTestP2PUniDirMemcpyAsync_test_Timing_CPU") {
+TEST_CASE(Perf_hipTestP2PUniDirMemcpyAsync_test_Timing_CPU) {
   const int iterations =
       cmd_options.iterations == 1000 ? defaultIterations : cmd_options.iterations;
   testP2PUniDirMemPerf(iterations, TIMING_MODE_CPU, true);
 }
 
-TEST_CASE("Perf_hipTestP2PUniDirMemcpyAsync_test_Timing_GPU") {
+TEST_CASE(Perf_hipTestP2PUniDirMemcpyAsync_test_Timing_GPU) {
   const int iterations =
       cmd_options.iterations == 1000 ? defaultIterations : cmd_options.iterations;
   testP2PUniDirMemPerf(iterations, TIMING_MODE_GPU, true);
@@ -481,13 +481,13 @@ TEST_CASE("Perf_hipTestP2PUniDirMemcpyAsync_test_Timing_GPU") {
  * ------------------------
  *  - HIP_VERSION >= 6.0
  */
-TEST_CASE("Perf_hipTestP2PUniDirKernelCopy_test_Timing_CPU") {
+TEST_CASE(Perf_hipTestP2PUniDirKernelCopy_test_Timing_CPU) {
   const int iterations =
       cmd_options.iterations == 1000 ? defaultIterations : cmd_options.iterations;
   testP2PUniDirMemPerf(iterations, TIMING_MODE_CPU, false);
 }
 
-TEST_CASE("Perf_hipTestP2PUniDirKernelCopy_test_Timing_GPU") {
+TEST_CASE(Perf_hipTestP2PUniDirKernelCopy_test_Timing_GPU) {
   const int iterations =
       cmd_options.iterations == 1000 ? defaultIterations : cmd_options.iterations;
   testP2PUniDirMemPerf(iterations, TIMING_MODE_GPU, false);
@@ -508,7 +508,7 @@ TEST_CASE("Perf_hipTestP2PUniDirKernelCopy_test_Timing_GPU") {
  * ------------------------
  *  - HIP_VERSION >= 6.0
  */
-TEST_CASE("Perf_hipTestP2PBiDirMemcpyAsync_test") {
+TEST_CASE(Perf_hipTestP2PBiDirMemcpyAsync_test) {
   const int iterations =
       cmd_options.iterations == 1000 ? defaultIterations : cmd_options.iterations;
   testP2PBiDirMemPerf(iterations, true);
@@ -527,7 +527,7 @@ TEST_CASE("Perf_hipTestP2PBiDirMemcpyAsync_test") {
  * ------------------------
  *  - HIP_VERSION >= 6.0
  */
-TEST_CASE("Perf_hipTestP2PBiDirKernelCopy_test") {
+TEST_CASE(Perf_hipTestP2PBiDirKernelCopy_test) {
   const int iterations =
       cmd_options.iterations == 1000 ? defaultIterations : cmd_options.iterations;
   testP2PBiDirMemPerf(iterations, false);
@@ -544,7 +544,7 @@ TEST_CASE("Perf_hipTestP2PBiDirKernelCopy_test") {
  * ------------------------
  *  - HIP_VERSION >= 6.0
  */
-TEST_CASE("Perf_hipCheckP2PSupport") { checkP2PSupport(); }
+TEST_CASE(Perf_hipCheckP2PSupport) { checkP2PSupport(); }
 
 /**
  * End doxygen group perfMemoryTest.

--- a/projects/hip-tests/catch/perftests/memory/hipPerfDevMemReadSpeed.cc
+++ b/projects/hip-tests/catch/perftests/memory/hipPerfDevMemReadSpeed.cc
@@ -132,16 +132,16 @@ static bool hipPerfDevMemReadSpeed_test() {
 /**
  * Test Description
  * ------------------------
- *  - Verify hipPerfDevMemReadSpeed status.
+ *  - Verify hipPerfDevMemReadSpeed status.
  * Test source
  * ------------------------
- *  - perftests/memory/hipPerfDevMemReadSpeed.cc
+ *  - perftests/memory/hipPerfDevMemReadSpeed.cc
  * Test requirements
  * ------------------------
- *  - HIP_VERSION >= 5.6
+ *  - HIP_VERSION >= 5.6
  */
 
-TEST_CASE("Perf_hipPerfDevMemReadSpeed_test") {
+TEST_CASE(Perf_hipPerfDevMemReadSpeed_test) {
   int numDevices = 0;
   HIP_CHECK(hipGetDeviceCount(&numDevices));
 

--- a/projects/hip-tests/catch/perftests/memory/hipPerfDevMemWriteSpeed.cc
+++ b/projects/hip-tests/catch/perftests/memory/hipPerfDevMemWriteSpeed.cc
@@ -124,16 +124,16 @@ static bool hipPerfDevMemWriteSpeed_test() {
 /**
  * Test Description
  * ------------------------
- *  - Verify hipPerfDevMemWriteSpeed status.
+ *  - Verify hipPerfDevMemWriteSpeed status.
  * Test source
  * ------------------------
- *  - perftests/memory/hipPerfDevMemWriteSpeed.cc
+ *  - perftests/memory/hipPerfDevMemWriteSpeed.cc
  * Test requirements
  * ------------------------
- *  - HIP_VERSION >= 5.6
+ *  - HIP_VERSION >= 5.6
  */
 
-TEST_CASE("Perf_hipPerfDevMemWriteSpeed_test") {
+TEST_CASE(Perf_hipPerfDevMemWriteSpeed_test) {
   int numDevices = 0;
   HIP_CHECK(hipGetDeviceCount(&numDevices));
 

--- a/projects/hip-tests/catch/perftests/memory/hipPerfDeviceHeapMemory.cc
+++ b/projects/hip-tests/catch/perftests/memory/hipPerfDeviceHeapMemory.cc
@@ -62,7 +62,7 @@ __global__ void mallocTest_1() {
  * ------------------------
  * - HIP_VERSION >= 6.5
  */
-TEST_CASE("Unit_Perf_Device_Heap_Memory_Allocation") {
+TEST_CASE(Unit_Perf_Device_Heap_Memory_Allocation) {
   HIP_CHECK(hipDeviceSetLimit(hipLimitMallocHeapSize, 128 * 1024 * 1024));
   hipEvent_t event;
   HIP_CHECK(hipEventCreate(&event));

--- a/projects/hip-tests/catch/perftests/memory/hipPerfHostNumaAlloc.cc
+++ b/projects/hip-tests/catch/perftests/memory/hipPerfHostNumaAlloc.cc
@@ -134,16 +134,16 @@ bool runTest(const int& cpuCount, const int& gpuCount, unsigned int hostMallocfl
 /**
  * Test Description
  * ------------------------
- *  - Verify hipPerfHostNumaAlloc status.
+ *  - Verify hipPerfHostNumaAlloc status.
  * Test source
  * ------------------------
- *  - perftests/memory/hipPerfHostNumaAlloc.cc
+ *  - perftests/memory/hipPerfHostNumaAlloc.cc
  * Test requirements
  * ------------------------
- *  - HIP_VERSION >= 5.6
+ *  - HIP_VERSION >= 5.6
  */
 
-TEST_CASE("Perf_hipPerfHostNumaAlloc_test") {
+TEST_CASE(Perf_hipPerfHostNumaAlloc_test) {
   int gpuCount = 0;
   HIP_CHECK(hipGetDeviceCount(&gpuCount));
   int cpuCount = numa_max_node() + 1; // number of numa nodes

--- a/projects/hip-tests/catch/perftests/memory/hipPerfHostNumaAllocWin.cc
+++ b/projects/hip-tests/catch/perftests/memory/hipPerfHostNumaAllocWin.cc
@@ -290,7 +290,7 @@ static void runTestPrefered(std::vector<NumaNodeInfo> &nodes, MallocType type, u
 }
 
 /* Test memory allocation on preferred host numa node on each CPU */
-TEST_CASE("Perf_hipPerfHostNumaAlloc_test_preferred_host_numa_node_on_each_GPU") {
+TEST_CASE(Perf_hipPerfHostNumaAlloc_test_preferred_host_numa_node_on_each_GPU) {
   std::vector<NumaNodeInfo> nodes;
   enumerateNumaNodes(nodes);
   if (nodes.empty()) {

--- a/projects/hip-tests/catch/perftests/memory/hipPerfMemFill.cc
+++ b/projects/hip-tests/catch/perftests/memory/hipPerfMemFill.cc
@@ -503,16 +503,16 @@ template <class T> class hipPerfMemFill {
 /**
  * Test Description
  * ------------------------
- *  - Verify hipPerfMemFill status.
+ *  - Verify hipPerfMemFill status.
  * Test source
  * ------------------------
- *  - perftests/memory/hipPerfMemFill.cc
+ *  - perftests/memory/hipPerfMemFill.cc
  * Test requirements
  * ------------------------
- *  - HIP_VERSION >= 5.6
+ *  - HIP_VERSION >= 5.6
  */
 
-TEST_CASE("Perf_hipPerfMemFill_test") {
+TEST_CASE(Perf_hipPerfMemFill_test) {
   std::cout << "Test int" << std::endl;
   hipPerfMemFill<int> hipPerfMemFillInt;
   REQUIRE(true == hipPerfMemFillInt.open(0));

--- a/projects/hip-tests/catch/perftests/memory/hipPerfMemMallocCpyFree.cc
+++ b/projects/hip-tests/catch/perftests/memory/hipPerfMemMallocCpyFree.cc
@@ -122,16 +122,16 @@ static bool hipPerfMemMallocCpyFree_test() {
 /**
  * Test Description
  * ------------------------
- *  - Verify hipPerfMemMallocCpyFree status.
+ *  - Verify hipPerfMemMallocCpyFree status.
  * Test source
  * ------------------------
- *  - perftests/memory/hipPerfMemMallocCpyFree.cc
+ *  - perftests/memory/hipPerfMemMallocCpyFree.cc
  * Test requirements
  * ------------------------
- *  - HIP_VERSION >= 5.6
+ *  - HIP_VERSION >= 5.6
  */
 
-TEST_CASE("Perf_hipPerfMemMallocCpyFree_test") {
+TEST_CASE(Perf_hipPerfMemMallocCpyFree_test) {
   int numDevices = 0;
   HIP_CHECK(hipGetDeviceCount(&numDevices));
 

--- a/projects/hip-tests/catch/perftests/memory/hipPerfMemcpy.cc
+++ b/projects/hip-tests/catch/perftests/memory/hipPerfMemcpy.cc
@@ -199,16 +199,16 @@ bool hipPerfMemcpy::run_d2d_nocu(unsigned int numTests) {
 /**
  * Test Description
  * ------------------------
- *  - Verify hipPerfMemcpy status.
+ *  - Verify hipPerfMemcpy status.
  * Test source
  * ------------------------
- *  - perftests/memory/hipPerfMemcpy.cc
+ *  - perftests/memory/hipPerfMemcpy.cc
  * Test requirements
  * ------------------------
- *  - HIP_VERSION >= 5.6
+ *  - HIP_VERSION >= 5.6
  */
 
-TEST_CASE("Perf_hipPerfMemcpy_test") {
+TEST_CASE(Perf_hipPerfMemcpy_test) {
   int numDevices = 0;
   HIP_CHECK(hipGetDeviceCount(&numDevices));
 

--- a/projects/hip-tests/catch/perftests/memory/hipPerfMemcpyAsyncSpeed.cc
+++ b/projects/hip-tests/catch/perftests/memory/hipPerfMemcpyAsyncSpeed.cc
@@ -41,7 +41,7 @@ void checkData(void* ptr, unsigned int size, char value) {
 }
 
 bool extraWarmup = true;
-TEST_CASE("Perf_hipPerfMemcpyAsyncSpeed_test") {
+TEST_CASE(Perf_hipPerfMemcpyAsyncSpeed_test) {
   hipDeviceProp_t props;
   HIP_CHECK(hipGetDeviceProperties(&props, 0));
   CONSOLE_PRINT("Set device to %d : %s\n", 0, props.name);

--- a/projects/hip-tests/catch/perftests/memory/hipPerfMempool.cc
+++ b/projects/hip-tests/catch/perftests/memory/hipPerfMempool.cc
@@ -64,7 +64,7 @@ void getAndPrintMemoryDetails(const hipMemPool_t& pool) {
  * - HIP_VERSION >= 6.5
  */
 
-TEST_CASE("Perf_MempoolManager_hipMallocAsync_hipFreeAsync") {
+TEST_CASE(Perf_MempoolManager_hipMallocAsync_hipFreeAsync) {
   size_t free = 0, total = 0;
   HIP_CHECK(hipMemGetInfo(&free, &total));
   if (free < 30_GB) {

--- a/projects/hip-tests/catch/perftests/memory/hipPerfMemset.cc
+++ b/projects/hip-tests/catch/perftests/memory/hipPerfMemset.cc
@@ -344,16 +344,16 @@ void hipPerfMemset::run3D(unsigned int test, T memsetval, enum MemsetType type, 
 /**
  * Test Description
  * ------------------------
- *  - Verify hipPerfMemset status.
+ *  - Verify hipPerfMemset status.
  * Test source
  * ------------------------
- *  - perftests/memory/hipPerfMemset.cc
+ *  - perftests/memory/hipPerfMemset.cc
  * Test requirements
  * ------------------------
- *  - HIP_VERSION >= 5.6
+ *  - HIP_VERSION >= 5.6
  */
 
-TEST_CASE("Perf_hipPerfMemset_test") {
+TEST_CASE(Perf_hipPerfMemset_test) {
   hipPerfMemset hipPerfMemset;
 
   int deviceId = 0;

--- a/projects/hip-tests/catch/perftests/memory/hipPerfMemsetAsyncSpeed.cc
+++ b/projects/hip-tests/catch/perftests/memory/hipPerfMemsetAsyncSpeed.cc
@@ -41,7 +41,7 @@ void checkData_(void* ptr, unsigned int size, char value) {
 }
 
 bool extraWarmup_ = true;
-TEST_CASE("Perf_hipPerfMemsetAsyncSpeed_test") {
+TEST_CASE(Perf_hipPerfMemsetAsyncSpeed_test) {
   hipDeviceProp_t props;
   HIP_CHECK(hipGetDeviceProperties(&props, 0));
   CONSOLE_PRINT("Set device to %d : %s", 0, props.name);

--- a/projects/hip-tests/catch/perftests/memory/hipPerfSampleRate.cc
+++ b/projects/hip-tests/catch/perftests/memory/hipPerfSampleRate.cc
@@ -278,16 +278,16 @@ void hipPerfSampleRate::checkData(uint* ptr) {
 /**
  * Test Description
  * ------------------------
- *  - Verify hipPerfSampleRate status.
+ *  - Verify hipPerfSampleRate status.
  * Test source
  * ------------------------
- *  - perftests/memory/hipPerfSampleRate.cc
+ *  - perftests/memory/hipPerfSampleRate.cc
  * Test requirements
  * ------------------------
- *  - HIP_VERSION >= 5.6
+ *  - HIP_VERSION >= 5.6
  */
 
-TEST_CASE("Perf_hipPerfSampleRate_test") {
+TEST_CASE(Perf_hipPerfSampleRate_test) {
   hipPerfSampleRate sampleTypes;
 
   REQUIRE(true == sampleTypes.open());

--- a/projects/hip-tests/catch/perftests/memory/hipPerfSharedMemReadSpeed.cc
+++ b/projects/hip-tests/catch/perftests/memory/hipPerfSharedMemReadSpeed.cc
@@ -237,16 +237,16 @@ static bool hipPerfSharedMemReadSpeed_test() {
 /**
  * Test Description
  * ------------------------
- *  - Verify hipPerfSharedMemReadSpeed status.
+ *  - Verify hipPerfSharedMemReadSpeed status.
  * Test source
  * ------------------------
- *  - perftests/memory/hipPerfSharedMemReadSpeed.cc
+ *  - perftests/memory/hipPerfSharedMemReadSpeed.cc
  * Test requirements
  * ------------------------
- *  - HIP_VERSION >= 5.6
+ *  - HIP_VERSION >= 5.6
  */
 
-TEST_CASE("Perf_hipPerfSharedMemReadSpeed_test") {
+TEST_CASE(Perf_hipPerfSharedMemReadSpeed_test) {
   int numDevices = 0;
   HIP_CHECK(hipGetDeviceCount(&numDevices));
 

--- a/projects/hip-tests/catch/perftests/stream/hipPerfDeviceConcurrency.cc
+++ b/projects/hip-tests/catch/perftests/stream/hipPerfDeviceConcurrency.cc
@@ -248,7 +248,7 @@ void hipPerfDeviceConcurrency::checkData(uint* ptr) {
  *  - HIP_VERSION >= 5.6
  */
 
-TEST_CASE("Perf_hipPerfDeviceConcurrency") {
+TEST_CASE(Perf_hipPerfDeviceConcurrency) {
   hipPerfDeviceConcurrency deviceConcurrency;
   deviceConcurrency.open();
   int nGpu = deviceConcurrency.getNumGpus();

--- a/projects/hip-tests/catch/perftests/stream/hipPerfIncreasingNumberOfStreams.cc
+++ b/projects/hip-tests/catch/perftests/stream/hipPerfIncreasingNumberOfStreams.cc
@@ -26,7 +26,7 @@ using namespace std;
 __global__ static void _noop_kernel() {}
 
 
-TEST_CASE("Perf_KernelLaunchLatency_IncreasingNumberOfStreams") {
+TEST_CASE(Perf_KernelLaunchLatency_IncreasingNumberOfStreams) {
   vector<int> streamsNumber{1, 10, 50, 100, 1000, 5000};
   hipError_t err = hipSuccess;
   hipEvent_t start, stop;

--- a/projects/hip-tests/catch/perftests/stream/hipPerfMultiStreamKernelLaunch.cc
+++ b/projects/hip-tests/catch/perftests/stream/hipPerfMultiStreamKernelLaunch.cc
@@ -108,7 +108,7 @@ class Experiment {
   std::vector<hipStream_t> streams_;
 };
 
-TEST_CASE("Perf_hipPerfMultiStreamKernelLaunch") {
+TEST_CASE(Perf_hipPerfMultiStreamKernelLaunch) {
   constexpr uint64_t KERNEL_SLEEP_US = 100;
   constexpr uint64_t KERNEL_DISPATCHES_PER_STREAM = 10;
   constexpr uint64_t WARMUP_KERNEL_DISPATCHES_PER_STREAM = 10;

--- a/projects/hip-tests/catch/perftests/stream/hipPerfStreamConcurrency.cc
+++ b/projects/hip-tests/catch/perftests/stream/hipPerfStreamConcurrency.cc
@@ -357,7 +357,7 @@ void hipPerfStreamConcurrency::checkData(uint* ptr) {
  *  - HIP_VERSION >= 5.6
  */
 
-TEST_CASE("Perf_hipPerfStreamConcurrency") {
+TEST_CASE(Perf_hipPerfStreamConcurrency) {
   hipPerfStreamConcurrency streamConcurrency;
   int deviceId = 0;
   REQUIRE(true == streamConcurrency.open(deviceId));

--- a/projects/hip-tests/catch/perftests/stream/hipPerfStreamCreateCopyDestroy.cc
+++ b/projects/hip-tests/catch/perftests/stream/hipPerfStreamCreateCopyDestroy.cc
@@ -139,7 +139,7 @@ bool hipPerfStreamCreateCopyDestroy::run(unsigned int testNumber) {
  *  - HIP_VERSION >= 5.6
  */
 
-TEST_CASE("Perf_hipPerfStreamCreateCopyDestroy") {
+TEST_CASE(Perf_hipPerfStreamCreateCopyDestroy) {
   hipPerfStreamCreateCopyDestroy streamCCD;
   int deviceId = 0;
   REQUIRE(true == streamCCD.open(deviceId));

--- a/projects/hip-tests/catch/perftests/vmm/hipPerfVMMAlloc.cc
+++ b/projects/hip-tests/catch/perftests/vmm/hipPerfVMMAlloc.cc
@@ -285,7 +285,7 @@ bool TestOnDevice(int deviceId) {
   return true;
 }
 
-TEST_CASE("Perf_hipPerfVMMAllocSpeed_test") {
+TEST_CASE(Perf_hipPerfVMMAllocSpeed_test) {
   int numDevices = 0;
   HIP_CHECK(hipGetDeviceCount(&numDevices));
   if (numDevices <= 0) {

--- a/projects/hip-tests/catch/stress/deviceallocation/Stress_deviceAllocationStress.cc
+++ b/projects/hip-tests/catch/stress/deviceallocation/Stress_deviceAllocationStress.cc
@@ -340,7 +340,7 @@ static bool TestMemoryAllocationInLoop(int test_type, bool isMultikernel = false
 /**
  * Scenario: Test malloc till nullptr is returned using even chunksize.
  */
-TEST_CASE("Stress_deviceAllocation_malloc_Even") {
+TEST_CASE(Stress_deviceAllocation_malloc_Even) {
   REQUIRE(true == TestAllocationOfAllAvailableMemory(TEST_MALLOC_FREE, NO_ALLOCATION_ONHOST,
                                                      MEMORY_CHUNK_SIZE));
 }
@@ -348,7 +348,7 @@ TEST_CASE("Stress_deviceAllocation_malloc_Even") {
 /**
  * Scenario: Test malloc till nullptr is returned using odd chunksize.
  */
-TEST_CASE("Stress_deviceAllocation_malloc_Odd") {
+TEST_CASE(Stress_deviceAllocation_malloc_Odd) {
   REQUIRE(true == TestAllocationOfAllAvailableMemory(TEST_MALLOC_FREE, NO_ALLOCATION_ONHOST,
                                                      MEMORY_CHUNK_SIZE_ODD));
 }
@@ -356,7 +356,7 @@ TEST_CASE("Stress_deviceAllocation_malloc_Odd") {
 /**
  * Scenario: Test new till nullptr is returned using even chunksize.
  */
-TEST_CASE("Stress_deviceAllocation_new_Even") {
+TEST_CASE(Stress_deviceAllocation_new_Even) {
   REQUIRE(true == TestAllocationOfAllAvailableMemory(TEST_NEW_DELETE, NO_ALLOCATION_ONHOST,
                                                      MEMORY_CHUNK_SIZE));
 }
@@ -364,7 +364,7 @@ TEST_CASE("Stress_deviceAllocation_new_Even") {
 /**
  * Scenario: Test new till nullptr is returned using odd chunksize.
  */
-TEST_CASE("Stress_deviceAllocation_new_Odd") {
+TEST_CASE(Stress_deviceAllocation_new_Odd) {
   REQUIRE(true == TestAllocationOfAllAvailableMemory(TEST_NEW_DELETE, NO_ALLOCATION_ONHOST,
                                                      MEMORY_CHUNK_SIZE_ODD));
 }
@@ -374,7 +374,7 @@ TEST_CASE("Stress_deviceAllocation_new_Odd") {
  * is returned. Device memory is also allocated using hipmallocmanaged
  * from host.
  */
-TEST_CASE("Stress_deviceAllocation_malloc_hipmallocmanaged") {
+TEST_CASE(Stress_deviceAllocation_malloc_hipmallocmanaged) {
   REQUIRE(true == TestAllocationOfAllAvailableMemory(
                       TEST_MALLOC_FREE, ALLOCATE_ONHOST_HIPMALLOCMANAGED, MEMORY_CHUNK_SIZE));
 }
@@ -384,7 +384,7 @@ TEST_CASE("Stress_deviceAllocation_malloc_hipmallocmanaged") {
  * is returned. Device memory is also allocated using hipmallocmanaged
  * from host.
  */
-TEST_CASE("Stress_deviceAllocation_new_hipmallocmanaged") {
+TEST_CASE(Stress_deviceAllocation_new_hipmallocmanaged) {
   REQUIRE(true == TestAllocationOfAllAvailableMemory(
                       TEST_NEW_DELETE, ALLOCATE_ONHOST_HIPMALLOCMANAGED, MEMORY_CHUNK_SIZE));
 }
@@ -393,7 +393,7 @@ TEST_CASE("Stress_deviceAllocation_new_hipmallocmanaged") {
  * Scenario: This test checks device allocation using malloc till nullptr
  * is returned. Device memory is also allocated using hipmalloc from host.
  */
-TEST_CASE("Stress_deviceAllocation_malloc_hipmalloc") {
+TEST_CASE(Stress_deviceAllocation_malloc_hipmalloc) {
   REQUIRE(true == TestAllocationOfAllAvailableMemory(TEST_MALLOC_FREE, ALLOCATE_ONHOST_HIPMALLOC,
                                                      MEMORY_CHUNK_SIZE));
 }
@@ -402,7 +402,7 @@ TEST_CASE("Stress_deviceAllocation_malloc_hipmalloc") {
  * Scenario: This test checks device allocation using new till nullptr
  * is returned. Device memory is also allocated using hipmalloc from host.
  */
-TEST_CASE("Stress_deviceAllocation_new_hipmalloc") {
+TEST_CASE(Stress_deviceAllocation_new_hipmalloc) {
   REQUIRE(true == TestAllocationOfAllAvailableMemory(TEST_NEW_DELETE, ALLOCATE_ONHOST_HIPMALLOC,
                                                      MEMORY_CHUNK_SIZE));
 }
@@ -411,7 +411,7 @@ TEST_CASE("Stress_deviceAllocation_new_hipmalloc") {
  * Scenario: This test validates device allocation negative scenario
  * when size > available memory.
  */
-TEST_CASE("Stress_deviceAllocation_Negative") {
+TEST_CASE(Stress_deviceAllocation_Negative) {
   int *ret_d{nullptr}, *ret_h{nullptr};
   size_t avail = 0, tot = 0;
   HIP_CHECK(hipMemGetInfo(&avail, &tot));
@@ -440,7 +440,7 @@ TEST_CASE("Stress_deviceAllocation_Negative") {
  * Scenario: This test performs stress test of malloc/free in a loop
  * using single kernel.
  */
-TEST_CASE("Stress_deviceAllocation_malloc_loop_singlekernel") {
+TEST_CASE(Stress_deviceAllocation_malloc_loop_singlekernel) {
   REQUIRE(true == TestMemoryAllocationInLoop(TEST_MALLOC_FREE, false));
 }
 
@@ -448,7 +448,7 @@ TEST_CASE("Stress_deviceAllocation_malloc_loop_singlekernel") {
  * Scenario: This test performs stress test of new/delete in a loop
  * using single kernel.
  */
-TEST_CASE("Stress_deviceAllocation_new_loop_singlekernel") {
+TEST_CASE(Stress_deviceAllocation_new_loop_singlekernel) {
   REQUIRE(true == TestMemoryAllocationInLoop(TEST_NEW_DELETE, false));
 }
 
@@ -456,7 +456,7 @@ TEST_CASE("Stress_deviceAllocation_new_loop_singlekernel") {
  * Scenario: This test performs stress test of malloc/free in a loop
  * using multiple kernel.
  */
-TEST_CASE("Stress_deviceAllocation_malloc_loop_multkernel") {
+TEST_CASE(Stress_deviceAllocation_malloc_loop_multkernel) {
   REQUIRE(true == TestMemoryAllocationInLoop(TEST_MALLOC_FREE, true));
 }
 
@@ -464,6 +464,6 @@ TEST_CASE("Stress_deviceAllocation_malloc_loop_multkernel") {
  * Scenario: This test performs stress test of new/delete in a loop
  * using multiple kernel.
  */
-TEST_CASE("Stress_deviceAllocation_new_loop_multkernel") {
+TEST_CASE(Stress_deviceAllocation_new_loop_multkernel) {
   REQUIRE(true == TestMemoryAllocationInLoop(TEST_NEW_DELETE, true));
 }

--- a/projects/hip-tests/catch/stress/memory/hipHmmOvrSubscriptionTst.cc
+++ b/projects/hip-tests/catch/stress/memory/hipHmmOvrSubscriptionTst.cc
@@ -34,7 +34,7 @@ __global__ void floatx2(float* ptr, size_t size) {
   }
 }
 
-TEST_CASE("Stress_HMM_OverSubscriptionTst") {
+TEST_CASE(Stress_HMM_OverSubscriptionTst) {
   int hmm = 0;
   HIP_CHECK(hipDeviceGetAttribute(&hmm, hipDeviceAttributeManagedMemory, 0));
 

--- a/projects/hip-tests/catch/stress/memory/hipHostMallocStress.cc
+++ b/projects/hip-tests/catch/stress/memory/hipHostMallocStress.cc
@@ -26,7 +26,7 @@ THE SOFTWARE.
 // Try to allocate as much memory as possible
 // But since max allocation can fail, we need to try the next value
 
-TEST_CASE("Stress_hipHostMalloc_MaxAllocation") {
+TEST_CASE(Stress_hipHostMalloc_MaxAllocation) {
   size_t devMemAvail{0}, devMemFree{0};
   HIP_CHECK(hipMemGetInfo(&devMemFree, &devMemAvail));
   auto hostMemFree = HipTest::getAvailableSystemMemoryInMB() * 1024 * 1024;  // In bytes
@@ -56,7 +56,7 @@ TEST_CASE("Stress_hipHostMalloc_MaxAllocation") {
 // Allocate more memory than total GPU memory in each available GPU.
 // hipHostMalloc should return hipSuccess.
 
-TEST_CASE("Stress_hipHostMalloc_MaxAllocation_AllGpu") {
+TEST_CASE(Stress_hipHostMalloc_MaxAllocation_AllGpu) {
   char* A = nullptr;
   size_t maxGpuMem = 0, availableMem = 0;
   int count = 0;

--- a/projects/hip-tests/catch/stress/memory/hipHostRegisterStress.cc
+++ b/projects/hip-tests/catch/stress/memory/hipHostRegisterStress.cc
@@ -55,7 +55,7 @@ static __global__ void Inc(uint8_t* Ad) {
  * ------------------------
  *    - HIP_VERSION >= 5.6
  */
-TEST_CASE("Stress_hipHostRegister_Oversubscription") {
+TEST_CASE(Stress_hipHostRegister_Oversubscription) {
   hipDeviceProp_t prop;
   HIP_CHECK(hipGetDeviceProperties(&prop, 0));
   std::string arch = prop.gcnArchName;

--- a/projects/hip-tests/catch/stress/memory/hipMalloc.cc
+++ b/projects/hip-tests/catch/stress/memory/hipMalloc.cc
@@ -27,7 +27,7 @@
  
 // Stress allocation tests
 // Try to allocate as much memory as possible, backing off gradually on failure.
-TEST_CASE("Stress_hipMalloc_HighSizeAlloc") {
+TEST_CASE(Stress_hipMalloc_HighSizeAlloc) {
   size_t devMemTotal{0}, devMemFree{0};
   HIP_CHECK(hipMemGetInfo(&devMemFree, &devMemTotal));
   REQUIRE(devMemFree > 0);

--- a/projects/hip-tests/catch/stress/memory/hipMallocConcurrency.cc
+++ b/projects/hip-tests/catch/stress/memory/hipMallocConcurrency.cc
@@ -210,7 +210,7 @@ static void threadFunc(int gpu) {
  * Regress hipMalloc()/hipFree() in loop for bigger chunks and
  * smaller chunks of memory allocation
  */
-TEST_CASE("Stress_hipMalloc_LoopRegressionAllocFreeCycles") {
+TEST_CASE(Stress_hipMalloc_LoopRegressionAllocFreeCycles) {
   int devCnt = 0;
 
   // Get GPU count
@@ -227,7 +227,7 @@ TEST_CASE("Stress_hipMalloc_LoopRegressionAllocFreeCycles") {
  * continuously, stores it for later use and then frees it at later point
  * of time.
  */
-TEST_CASE("Stress_hipMalloc_AllocateAndPoolBuffers") {
+TEST_CASE(Stress_hipMalloc_AllocateAndPoolBuffers) {
   size_t avail{0}, tot{0};
   bool ret{false};
   hipError_t err{};
@@ -268,7 +268,7 @@ TEST_CASE("Stress_hipMalloc_AllocateAndPoolBuffers") {
  * Exercise hipMalloc() api parellely on all gpus from
  * multiple threads and regress the api.
  */
-TEST_CASE("Stress_hipMalloc_Multithreaded_MultiGPU", "[multigpu]") {
+TEST_CASE(Stress_hipMalloc_Multithreaded_MultiGPU) {
   std::vector<std::thread> threadlist;
   int devCnt;
 

--- a/projects/hip-tests/catch/stress/memory/hipMallocManagedStress.cc
+++ b/projects/hip-tests/catch/stress/memory/hipMallocManagedStress.cc
@@ -143,7 +143,7 @@ static int HmmAttrPrint() {
 //  The following test case allocation, host access, device access of HMM
 //   memory from size 1 to 10KB
 
-TEST_CASE("Stress_hipMallocManaged_MultiSize") {
+TEST_CASE(Stress_hipMallocManaged_MultiSize) {
   IfTestPassed = true;
   int managed = HmmAttrPrint();
   if (managed == 1) {
@@ -190,7 +190,7 @@ TEST_CASE("Stress_hipMallocManaged_MultiSize") {
 // The following test case tests the behavior of kernel with a HMM memory and
 // hipMalloc memory
 
-TEST_CASE("Stress_hipMallocManaged_KrnlWth2MemTypes") {
+TEST_CASE(Stress_hipMallocManaged_KrnlWth2MemTypes) {
   IfTestPassed = true;
   int *Hmm = NULL, *Dptr = NULL, InitVal = 123;
   size_t NumElms = (1024 * 1024);
@@ -235,7 +235,7 @@ TEST_CASE("Stress_hipMallocManaged_KrnlWth2MemTypes") {
 
 // The following test case tests when the same Hmm memory is used for
 // launching multiple different kernels will results in any issue
-TEST_CASE("Stress_hipMallocManaged_MultiKrnlHmmAccess") {
+TEST_CASE(Stress_hipMallocManaged_MultiKrnlHmmAccess) {
   int managed = HmmAttrPrint();
   if (managed) {
     int InitVal = 123, NumElms = (1024 * 1024);
@@ -248,7 +248,7 @@ TEST_CASE("Stress_hipMallocManaged_MultiKrnlHmmAccess") {
 }
 
 // Testing the allocation of/scenarios around max possible memory
-TEST_CASE("Stress_hipMallocManaged_ExtremeSizes") {
+TEST_CASE(Stress_hipMallocManaged_ExtremeSizes) {
   int managed = HmmAttrPrint();
   if (managed == 1) {
     bool IfTestPassed = true;

--- a/projects/hip-tests/catch/stress/memory/hipMemPrftchAsyncStressTst.cc
+++ b/projects/hip-tests/catch/stress/memory/hipMemPrftchAsyncStressTst.cc
@@ -62,7 +62,7 @@ static void ReleaseResource(int* Hmm, hipStream_t* strm) {
 /* The following test allocates a managed memory and prefetch it in
    one-to-all and all-to-one fahsion followed by kernel launch within available
    devices*/
-TEST_CASE("Stress_hipMemPrefetchAsyncOneToAll") {
+TEST_CASE(Stress_hipMemPrefetchAsyncOneToAll) {
   int MangdMem = HmmAttrPrint();
   if (MangdMem == 1) {
     int *Hmm1 = nullptr, NumDevs, MemSz = (4096 * 4);

--- a/projects/hip-tests/catch/stress/memory/hipMemcpyMThreadMSize.cc
+++ b/projects/hip-tests/catch/stress/memory/hipMemcpyMThreadMSize.cc
@@ -241,7 +241,7 @@ template <typename TestType> void Memcpy_And_verify(int NUM_ELM) {
   }
 }
 
-TEMPLATE_TEST_CASE("Stress_hipMemcpy_multiDevice_AllAPIs", "", char, int, size_t, long double) {
+TEMPLATE_TEST_CASE(Stress_hipMemcpy_multiDevice_AllAPIs, char, int, size_t, long double) {
   auto diff_size = GENERATE(1, 5, 10, 100, 1024, 10 * 1024, 100 * 1024, 1024 * 1024,
                             10 * 1024 * 1024, 100 * 1024 * 1024, 1024 * 1024 * 1024);
   size_t free = 0, total = 0;

--- a/projects/hip-tests/catch/stress/memory/memcpy.cc
+++ b/projects/hip-tests/catch/stress/memory/memcpy.cc
@@ -1,6 +1,6 @@
 #include <hip_test_common.hh>
 
-TEST_CASE("Stress_hipMalloc", "DifferentSizes") {
+TEST_CASE(Stress_hipMalloc) {
   int* d_a = nullptr;
   SECTION("Size 10") {
     auto res = hipMalloc(&d_a, sizeof(10));

--- a/projects/hip-tests/catch/stress/module/hipModuleLoadUnload.cc
+++ b/projects/hip-tests/catch/stress/module/hipModuleLoadUnload.cc
@@ -102,7 +102,7 @@ void GetCodeObjectUsingRTC(size_t codeSize, std::vector<char>& code) {
  *    - HIP_VERSION >= 6.0
  */
 
-TEST_CASE("Stress_hipModuleLoadUnload") {
+TEST_CASE(Stress_hipModuleLoadUnload) {
   size_t code_size = 0;
   std::vector<char> code;
   GetCodeObjectUsingRTC(code_size, code);

--- a/projects/hip-tests/catch/stress/printf/Stress_printf_ComplexKernels.cc
+++ b/projects/hip-tests/catch/stress/printf/Stress_printf_ComplexKernels.cc
@@ -397,7 +397,7 @@ bool testPrintfMultGPU(int numOfGPUs, uint32_t num_blocks, uint32_t threads_per_
 #endif
 }  // namespace hipPrintfStressTest
 
-TEST_CASE("Stress_printf_ComplexKernelMultStream") {
+TEST_CASE(Stress_printf_ComplexKernelMultStream) {
 #ifdef __linux__
   printf("Test - Stress_printf_ComplexKernelMultStream start\n");
   bool TestPassed = true;
@@ -419,7 +419,7 @@ TEST_CASE("Stress_printf_ComplexKernelMultStream") {
 #endif
 }
 
-TEST_CASE("Stress_printf_ComplexKernelMultStreamMultGpu") {
+TEST_CASE(Stress_printf_ComplexKernelMultStreamMultGpu) {
 #ifdef __linux__
   printf("Test - Stress_printf_ComplexKernelMultStreamMultGpu start \n");
   bool TestPassed = true;

--- a/projects/hip-tests/catch/stress/printf/Stress_printf_SimpleKernels.cc
+++ b/projects/hip-tests/catch/stress/printf/Stress_printf_SimpleKernels.cc
@@ -592,7 +592,7 @@ bool test_synchronized_printf(uint32_t num_blocks, uint32_t threads_per_block,
 #endif
 }  // namespace hipPrintfStressTest
 
-TEST_CASE("Stress_printf_ConstStr") {
+TEST_CASE(Stress_printf_ConstStr) {
 #ifdef __linux__
   printf("Test: Stress_printf_ConstStr\n");
   bool TestPassed = true;
@@ -608,7 +608,7 @@ TEST_CASE("Stress_printf_ConstStr") {
 #endif
 }
 
-TEST_CASE("Stress_printf_IfElseConditionalStr") {
+TEST_CASE(Stress_printf_IfElseConditionalStr) {
 #ifdef __linux__
   printf("Test: Stress_printf_IfElseConditionalStr\n");
   bool TestPassed = true;
@@ -624,7 +624,7 @@ TEST_CASE("Stress_printf_IfElseConditionalStr") {
 #endif
 }
 
-TEST_CASE("Stress_printf_IfConditionalStr") {
+TEST_CASE(Stress_printf_IfConditionalStr) {
 #ifdef __linux__
   printf("Test: Stress_printf_IfConditionalStr\n");
   bool TestPassed = true;
@@ -640,7 +640,7 @@ TEST_CASE("Stress_printf_IfConditionalStr") {
 #endif
 }
 
-TEST_CASE("Stress_printf_VariableStr") {
+TEST_CASE(Stress_printf_VariableStr) {
 #ifdef __linux__
   printf("Test: Stress_printf_VariableStr\n");
   bool TestPassed = true;
@@ -655,7 +655,7 @@ TEST_CASE("Stress_printf_VariableStr") {
 #endif
 }
 
-TEST_CASE("Stress_printf_DependentCalc") {
+TEST_CASE(Stress_printf_DependentCalc) {
 #ifdef __linux__
   printf("Test: Stress_printf_DependentCalc\n");
   bool TestPassed = true;
@@ -670,7 +670,7 @@ TEST_CASE("Stress_printf_DependentCalc") {
 #endif
 }
 
-TEST_CASE("Stress_printf_DecimalStr") {
+TEST_CASE(Stress_printf_DecimalStr) {
 #ifdef __linux__
   printf("Test: Stress_printf_DecimalStr\n");
   bool TestPassed = true;
@@ -685,7 +685,7 @@ TEST_CASE("Stress_printf_DecimalStr") {
 #endif
 }
 
-TEST_CASE("Stress_printf_SharedMem") {
+TEST_CASE(Stress_printf_SharedMem) {
 #ifdef __linux__
   printf("Test: Stress_printf_SharedMem\n");
   bool TestPassed = true;
@@ -700,7 +700,7 @@ TEST_CASE("Stress_printf_SharedMem") {
 #endif
 }
 
-TEST_CASE("Stress_printf_SynchronizedPrintf") {
+TEST_CASE(Stress_printf_SynchronizedPrintf) {
 #ifdef __linux__
   printf("Test: Stress_printf_SynchronizedPrintf\n");
   bool TestPassed = true;
@@ -714,7 +714,7 @@ TEST_CASE("Stress_printf_SynchronizedPrintf") {
 #endif
 }
 
-TEST_CASE("Stress_printf_AtomicCalc") {
+TEST_CASE(Stress_printf_AtomicCalc) {
 #ifdef __linux__
   printf("Test: Stress_printf_AtomicCalc\n");
   bool TestPassed = true;

--- a/projects/hip-tests/catch/stress/stream/Stress_hipStreamCreate.cc
+++ b/projects/hip-tests/catch/stress/stream/Stress_hipStreamCreate.cc
@@ -152,14 +152,14 @@ void testhipStreamCreateFlags(int* stream_sequence, unsigned int flag) {
 }
 }  // namespace hipStreamCreateStressTest
 
-TEST_CASE("Stress_hipStreamCreate_SyncTest") {
+TEST_CASE(Stress_hipStreamCreate_SyncTest) {
   printf("hipStreamCreate stress test:\n");
   for (int i = 0; i < TOTALSEQ; i++) {
     hipStreamCreateStressTest::testhipStreamCreate(hipStreamCreateStressTest::stream_seq[i]);
   }
 }
 
-TEST_CASE("Stress_hipStreamCreatePriority_SyncTest") {
+TEST_CASE(Stress_hipStreamCreatePriority_SyncTest) {
   printf("hipStreamCreateWithPriority(hipStreamDefault) stress test:\n");
   for (int i = 0; i < TOTALSEQ; i++) {
     hipStreamCreateStressTest::testhipStreamCreatePriority(hipStreamCreateStressTest::stream_seq[i],
@@ -172,7 +172,7 @@ TEST_CASE("Stress_hipStreamCreatePriority_SyncTest") {
   }
 }
 
-TEST_CASE("Stress_hipStreamCreateWithFlags_SyncTest") {
+TEST_CASE(Stress_hipStreamCreateWithFlags_SyncTest) {
   printf("hipStreamCreateWithFlags(hipStreamDefault) stress test:\n");
   for (int i = 0; i < TOTALSEQ; i++) {
     hipStreamCreateStressTest::testhipStreamCreateFlags(hipStreamCreateStressTest::stream_seq[i],

--- a/projects/hip-tests/catch/stress/stream/streamEnqueue.cc
+++ b/projects/hip-tests/catch/stress/stream/streamEnqueue.cc
@@ -51,7 +51,7 @@ template <typename T> struct AtomicWrap {
 
 // Have multiple threads and enqueue commands from them on a single stream
 // Validate at the end that all commands have completed successfully
-TEST_CASE("Stress_StreamEnqueue_DifferentThreads") {
+TEST_CASE(Stress_StreamEnqueue_DifferentThreads) {
   auto hwThreads = std::thread::hardware_concurrency();
   hwThreads = (hwThreads >= 2) ? hwThreads : 2;  // Run atleast 2 threads
 
@@ -121,7 +121,7 @@ __global__ void doOperation(int* dPtr, int val) {
 
 // Allocate mulitple stream for same device.
 // Same device stream operate on same memory
-TEST_CASE("Stress_StreamEnqueue_DifferentThreads_MultiGPU") {
+TEST_CASE(Stress_StreamEnqueue_DifferentThreads_MultiGPU) {
   int deviceCount{0};
   HIP_CHECK(hipGetDeviceCount(&deviceCount));
   REQUIRE(deviceCount > 0);


### PR DESCRIPTION
## Motivation

Since the number of unit test cases is constantly growing, the execution time is also increasing. Specific tests are suited for non standard testing and there is no need to run them in the regular PSDB. Add a mechanism to easily disable/enable tests and easily categorize them.

Part 2 covers test name changes for following groups:
- multiproc tests
- performance tests
- perftests
- stress tests
- TypeQualifiers tests

## Technical Details

Explained in the ticket in the document attached.

## JIRA ID

SWDEV-567112

## Test Plan

Ensure build passes. All enabled tests pass, all disabled tests are not run

## Test Result

Local build passed, local enabled tests pass, disabled are not run

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
