### PR TITLE
Fix rocm_smi64 exporting invalid absolute paths to consumers

### DIFF
--- a/projects/rocm-smi-lib/rocm_smi/CMakeLists.txt
+++ b/projects/rocm-smi-lib/rocm_smi/CMakeLists.txt
@@ -94,8 +94,6 @@ target_include_directories(${ROCM_SMI_TARGET}
                            "$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>"
 )
 
-target_include_directories(${ROCM_SMI_TARGET} INTERFACE ${DRM_INCLUDE_DIRS})
-
 ## Set the VERSION and SOVERSION values
 set_property(TARGET ${ROCM_SMI_TARGET} PROPERTY
              SOVERSION "${VERSION_MAJOR}")


### PR DESCRIPTION
## Motivation

Fix rocm_smi64 exporting invalid absolute paths to consumers

Fixes: ROCm/TheRock#3702

## Technical Details

Remove redundant target_include_directories() that exported build-time absolute paths without BUILD_INTERFACE protection. Lines 91-92 already handle this correctly.

## JIRA ID

N/A

## Test Plan

After the PR is merged, rerun the PyTorch build to verify that rocm_smi64 can be found.

## Test Result

N/A

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
