### PR TITLE
rocr/wsl: a library should not output to std::out by default

### DIFF
--- a/projects/rocr-runtime/libhsakmt/src/dxg/topology_win.cpp
+++ b/projects/rocr-runtime/libhsakmt/src/dxg/topology_win.cpp
@@ -42,7 +42,7 @@ static bool parse_cpu_model_name(char* cpu_model_name, size_t size) {
   }
 
   strncpy(cpu_model_name, value, size);
-  std::cout << "Processor Name: " << cpu_model_name << std::endl;
+  pr_debug("Processor Name: %s\n", cpu_model_name);
   return true;
 }
 


### PR DESCRIPTION
## Motivation
A library should not output std::cout by default. That can affect normal application execution or may break GUI application in Windows.

In my test, this issue made ctest not working in hip test.

## Technical Details

Change the output to an existing mechanism so the library won't output to stdout by default.

## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
