### PR TITLE
rccl/topo_expl: fix build issue.

### DIFF
--- a/projects/rccl/tools/topo_expl/Makefile
+++ b/projects/rccl/tools/topo_expl/Makefile
@@ -56,9 +56,11 @@ $(EXE): $(files)
 
 hipify:
 	rm -rf hipify_rccl
-	mkdir -p hipify_rccl/src/device/include hipify_rccl/include/network/unpack include
+	mkdir -p hipify_rccl/src/device/include hipify_rccl/include/network/unpack include/rccl
 	# Copy nccl.h.in from rccl source to always get latest API definitions
 	cp -a ../../src/nccl.h.in include/nccl.h
+	# Also copy to rccl/rccl.h for files that use #include <rccl/rccl.h>
+	cp -a ../../src/nccl.h.in include/rccl/rccl.h
 	cp -a ../../src/include/ hipify_rccl/
 	cp -a ../../src/graph/ hipify_rccl/
 	cp -a ../../src/device/*.h hipify_rccl/src/device/include


### PR DESCRIPTION
## Motivation

PR #3574 fixed the compilation issue but the [build is still failing when machine has no prior rccl installation](https://math-ci.amd.com/job/rocm-libraries/job/extra/job/rccl/job/develop/64/pipeline-overview/?selected-node=700). It is unlikely with proper ROCm installation but our CI is running on only base image. This PR is only to enable our CI pipeline to test building topo_expl. This commit fixed it by manually copying rccl.h to the build directory.

<img width="1035" height="205" alt="image" src="https://github.com/user-attachments/assets/a0f0de7b-ecd6-451a-871e-ac12e03f37c7" />


## Technical Details

Copying nccl.h.in to rccl/rccl.h in topo_expl build step.

## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
