### PR TITLE
[rccl] look for zcat in $PATH instead of hard coded paths

### DIFF
--- a/projects/rccl/src/misc/rocmwrap.cc
+++ b/projects/rccl/src/misc/rocmwrap.cc
@@ -253,7 +253,7 @@ static void initOnceFunc() {
     };
 
     // Check if zcat is available in the system
-    int has_zcat = (access("/usr/bin/zcat", X_OK) == 0 || access("/bin/zcat", X_OK) == 0);
+    int has_zcat = (system("which zcat > /dev/null 2>&1") == 0);
 
     for (const auto& path : possiblePaths) {
       // Reset flags for each file


### PR DESCRIPTION
## Motivation

continuation from earlier PR (https://github.com/ROCm/rocm-systems/pull/3423/changes).
The potentially issue is that with access() looks for hard coded path and does not search $PATH, so to avoid looking at only the hard-codes paths like /usr/bin/zcat and /bin/zcat, we would want to check if zcat can be found elsewhere if built by the admin elsewhere available on the system that is already available in $PATH.

It just provides a bit more flexibility for the the check to  report. Eventually if this check not able to detect, it will this zcat /proc/config.gz, continue down the list for other files for the 2 kernel params needed for the DMABUF check anyway. 

## JIRA ID
ROCM-2855

## Test Plan
verified with RCCL tests, using NCCL_DMABUF_ENABLE=1 and enable NCCL_DEBUG=INFO for verbose outputs is able to use zcat command.

## Test Result
with the fix check of /proc/config.gz works, with zcat is found.

## Submission Checklist
- [X] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.