### PR TITLE
[rocprofiler-compute] MFMA pre-processor guards for ipc.hip

### DIFF
--- a/projects/rocprofiler-compute/sample/ipc.hip
+++ b/projects/rocprofiler-compute/sample/ipc.hip
@@ -31,6 +31,11 @@ This example may not work on all CDNA accelerators, but has been verified on MI2
 
 #include "common.h"
 
+// Define MFMA support for CDNA2+ architectures (MI200, MI300, MI350 series)
+#if defined(__gfx90a__) || defined(__gfx940__) || defined(__gfx941__) || defined(__gfx942__) || defined(__gfx950__)
+#define HAS_MFMA_SUPPORT 1
+#endif
+
 template<int N=1000>
 __device__ void vrcp_op() {
     int dummy;
@@ -59,6 +64,7 @@ __global__ void vmov() {
     vmov_op<N>();
 }
 
+#ifdef HAS_MFMA_SUPPORT
 template<int N=1000>
 __device__ void mfma_op() {
     int dummy;
@@ -72,6 +78,7 @@ template<int N=1000>
 __global__ void mfma() {
     mfma_op<N>();
 }
+#endif
 
 template<int N=1000>
 __device__ void snop_op() {
@@ -112,14 +119,18 @@ int main() {
     // warmups, spam to all CUs
     vrcp<<<1024 * 1024, 1024>>>();
     vmov<<<1024 * 1024, 1024>>>();
+#ifdef HAS_MFMA_SUPPORT
     mfma<<<1024 * 1024, 1024>>>();
+#endif
     snop<<<1024 * 1024, 1024>>>();
     smov<<<1024 * 1024, 1024>>>();
     vmov_with_divergence<<<1024 * 1024, 1024>>>();
     hipCheck(hipDeviceSynchronize());
     vrcp<<<1024 * 1024, 1024>>>();
     vmov<<<1024 * 1024, 1024>>>();
+#ifdef HAS_MFMA_SUPPORT
     mfma<<<1024 * 1024, 1024>>>();
+#endif
     snop<<<1024 * 1024, 1024>>>();
     smov<<<1024 * 1024, 1024>>>();
     vmov_with_divergence<<<1024 * 1024, 1024>>>();


### PR DESCRIPTION
## Motivation

MFMA pre-processor guards for ipc.hip

This prevents build failures on < MI 200

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

MFMA pre-processor guards for ipc.hip

<!-- Explain the changes along with any relevant GitHub links. -->

## JIRA ID

AIPROFCOMP-308

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan

Build and run ipc.hip for gfx906, gfx908, gfx90a, gfx940, gfx941, gfx942, gfx950 and ensure successful build and run

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

Tests pass

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
