### PR TITLE
Fix CMake exported targets for rocm_smi64 and oam

### DIFF
--- a/projects/rocm-smi-lib/oam/CMakeLists.txt
+++ b/projects/rocm-smi-lib/oam/CMakeLists.txt
@@ -97,7 +97,7 @@ target_include_directories(${OAM_TARGET}
                            "$<BUILD_INTERFACE:${DRM_INCLUDE_DIRS}>"
                            "$<BUILD_INTERFACE:${AMDGPU_DRM_INCLUDE_DIRS}>"
                            "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
-                           "$<INSTALL_INTERFACE:{OAM_NAME}/include>")
+                           "$<INSTALL_INTERFACE:include>")
 
 ## Add the install directives for the runtime library.
 install(TARGETS ${OAM_TARGET}

--- a/projects/rocm-smi-lib/rocm_smi/CMakeLists.txt
+++ b/projects/rocm-smi-lib/rocm_smi/CMakeLists.txt
@@ -91,10 +91,11 @@ target_include_directories(${ROCM_SMI_TARGET}
                            "$<BUILD_INTERFACE:${DRM_INCLUDE_DIRS}>"
                            "$<BUILD_INTERFACE:${AMDGPU_DRM_INCLUDE_DIRS}>"
                            "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
-                           "$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>"
+                           "$<INSTALL_INTERFACE:include>"
 )
 
-target_include_directories(${ROCM_SMI_TARGET} INTERFACE ${DRM_INCLUDE_DIRS})
+
+## target_include_directories(${ROCM_SMI_TARGET} INTERFACE ${DRM_INCLUDE_DIRS})
 
 ## Set the VERSION and SOVERSION values
 set_property(TARGET ${ROCM_SMI_TARGET} PROPERTY


### PR DESCRIPTION
The exported CMake targets for `rocm_smi64` and `oam` contain hardcoded
absolute paths in their `INTERFACE_INCLUDE_DIRECTORIES`, which causes
CMake errors when installed using pip.

This breaks the nightly PyTorch wheel builds in TheRock CI with:

 ```
 CMake Error in caffe2/CMakeLists.txt:
    Imported target "rocm_smi64" includes non-existent path
```

Fix:
- Use literal relative paths in `INSTALL_INTERFACE` so CMake generates
  relocatable `${_IMPORT_PREFIX}/...` paths in the export file.
- Remove the bare `INTERFACE ${DRM_INCLUDE_DIRS}` line since it is already
  covered by the `$<BUILD_INTERFACE:...>` entry above it.
