### PR TITLE
[kpack/clr] Windows PE/COFF support for kpack artifact splitting and runtime loading.

### DIFF
--- a/projects/clr/rocclr/os/os_win32.cpp
+++ b/projects/clr/rocclr/os/os_win32.cpp
@@ -639,8 +639,31 @@ bool Os::MemoryMapFileTruncated(const char* fname, const void** mmap_ptr, size_t
 }
 
 bool Os::FindFileNameFromAddress(const void* image, std::string* fname_ptr, size_t* foffset_ptr) {
-  // TODO: Implementation on windows side pending.
-  return false;
+  HMODULE hm = NULL;
+  if (!GetModuleHandleExA(
+          GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS | GET_MODULE_HANDLE_EX_FLAG_UNCHANGED_REFCOUNT,
+          (LPCSTR)image, &hm)) {
+    return false;
+  }
+
+  // Use a growing buffer to support long paths beyond MAX_PATH.
+  DWORD cap = 512;
+  for (;;) {
+    fname_ptr->resize(cap);
+    DWORD len = GetModuleFileNameA(hm, &(*fname_ptr)[0], cap);
+    if (len == 0) {
+      return false;
+    }
+    if (len < cap) {
+      fname_ptr->resize(len);
+      break;
+    }
+    // Buffer was too small (len == cap means possible truncation).
+    cap *= 2;
+  }
+
+  *foffset_ptr = reinterpret_cast<uintptr_t>(image) - reinterpret_cast<uintptr_t>(hm);
+  return true;
 }
 
 int Os::getProcessId() { return ::_getpid(); }

--- a/shared/kpack/CMakeLists.txt
+++ b/shared/kpack/CMakeLists.txt
@@ -14,6 +14,22 @@ set(CMAKE_CXX_EXTENSIONS OFF)
 if(BUILD_RUNTIME)
     find_package(msgpack-cxx REQUIRED)
     find_package(zstd REQUIRED)
+    # System zstd packages may only provide zstd::libzstd_shared /
+    # zstd::libzstd_static instead of the zstd::libzstd alias that TheRock's
+    # bundled build exports.  Create the alias so downstream targets can link
+    # uniformly against zstd::libzstd.
+    if(NOT TARGET zstd::libzstd)
+        if(TARGET zstd::libzstd_shared)
+            add_library(zstd::libzstd ALIAS zstd::libzstd_shared)
+        elseif(TARGET zstd::libzstd_static)
+            add_library(zstd::libzstd ALIAS zstd::libzstd_static)
+        else()
+            message(
+                FATAL_ERROR
+                "find_package(zstd) succeeded but no known target found"
+            )
+        endif()
+    endif()
 endif()
 
 # Enable testing

--- a/shared/kpack/python/rocm_kpack/artifact_splitter.py
+++ b/shared/kpack/python/rocm_kpack/artifact_splitter.py
@@ -26,7 +26,7 @@ from rocm_kpack.binutils import BundledBinary, Toolchain
 from rocm_kpack.database_handlers import DatabaseHandler
 from rocm_kpack.kpack import PackedKernelArchive
 from rocm_kpack.compression import ZstdCompressor
-from rocm_kpack.elf import kpack_offload_binary, NotFatBinaryError
+from rocm_kpack.kpack_transform import kpack_offload_binary, NotFatBinaryError
 
 
 @dataclass
@@ -335,7 +335,7 @@ class ArtifactSplitter:
                         # Build source_binary_relpath with index suffix
                         # TOC always uses indexed format: "lib/foo.so#0", "lib/foo.so#1"
                         # This matches the co_index in wrapper's reserved1 field
-                        base_relpath = str(binary_path.relative_to(prefix_path))
+                        base_relpath = binary_path.relative_to(prefix_path).as_posix()
                         index = code_object_index[arch]
                         code_object_index[arch] += 1
                         indexed_relpath = f"{base_relpath}#{index}"
@@ -531,7 +531,7 @@ class ArtifactSplitter:
                     # Compute kernel_name to match TOC key format (without index):
                     # "{prefix}/{binary_relpath}" e.g. "rocrand/lib/librocrand.so.1.1"
                     # Runtime appends "#N" based on wrapper's reserved1 (co_index)
-                    binary_relpath = binary_path.relative_to(prefix_dir)
+                    binary_relpath = binary_path.relative_to(prefix_dir).as_posix()
                     kernel_name = f"{prefix}/{binary_relpath}"
 
                     # Add kpack search pattern and transform binary in one pass

--- a/shared/kpack/python/rocm_kpack/artifact_utils.py
+++ b/shared/kpack/python/rocm_kpack/artifact_utils.py
@@ -6,11 +6,13 @@ including manifest handling, directory traversal, and file classification.
 """
 
 import os
-import subprocess
 from pathlib import Path
 from typing import Iterator, Tuple, Callable, Optional
 
 from rocm_kpack.binutils import Toolchain
+from rocm_kpack.coff.surgery import CoffSurgery
+from rocm_kpack.elf.surgery import ElfSurgery
+from rocm_kpack.format_detect import detect_binary_format, UnsupportedBinaryFormat
 
 
 def read_artifact_manifest(artifact_dir: Path) -> list[str]:
@@ -96,8 +98,8 @@ def is_fat_binary(file_path: Path, toolchain: Toolchain) -> bool:
     """
     Check if a file is a fat binary (contains GPU device code).
 
-    For ELF binaries, this checks for the presence of a .hip_fatbin section.
-    Performs a fast ELF magic byte check before running readelf.
+    For ELF binaries, checks for .hip_fatbin section.
+    For PE/COFF binaries, checks for .hip_fat section.
 
     Args:
         file_path: Path to the file to check
@@ -107,47 +109,29 @@ def is_fat_binary(file_path: Path, toolchain: Toolchain) -> bool:
         True if the file contains device code, False if it's not a fat binary
 
     Raises:
-        RuntimeError: If readelf fails (corrupted file, readelf crash, etc.)
+        RuntimeError: If binary analysis fails
         FileNotFoundError: If file doesn't exist
     """
     # Fast check: Is file empty?
     try:
         if file_path.stat().st_size == 0:
-            return False  # Empty file, definitely not a fat binary
+            return False
     except FileNotFoundError:
         raise
     except OSError as e:
         raise RuntimeError(f"Cannot stat file {file_path}: {e}") from e
 
-    # Fast check: Is this even an ELF file?
     try:
-        with open(file_path, "rb") as f:
-            magic = f.read(4)
-            if magic != b"\x7fELF":
-                return False  # Not an ELF file, definitely not a fat binary
-    except FileNotFoundError:
-        raise
-    except OSError as e:
-        raise RuntimeError(f"Cannot read file {file_path}: {e}") from e
+        fmt = detect_binary_format(file_path)
+    except UnsupportedBinaryFormat:
+        return False
 
-    # It's an ELF file, now check for .hip_fatbin section
-    try:
-        output = subprocess.check_output(
-            [str(toolchain.readelf), "-S", str(file_path)],
-            stderr=subprocess.STDOUT,
-            text=True,
-        )
-        return ".hip_fatbin" in output
-    except subprocess.CalledProcessError as e:
-        # readelf returns 1 for valid ELF files without sections we're looking for
-        # Returns 2+ for actual errors
-        if e.returncode == 1:
-            return False  # Valid ELF, just no .hip_fatbin section
-        raise RuntimeError(
-            f"readelf failed on {file_path} with code {e.returncode}: {e.output}"
-        ) from e
-    except FileNotFoundError as e:
-        raise RuntimeError(f"readelf not found: {toolchain.readelf}") from e
+    if fmt == "elf":
+        surgery = ElfSurgery.load(file_path)
+        return surgery.find_section(".hip_fatbin") is not None
+    else:
+        surgery = CoffSurgery.load(file_path)
+        return surgery.find_section(".hip_fat") is not None
 
 
 def extract_architecture_from_target(target: str) -> Optional[str]:

--- a/shared/kpack/python/rocm_kpack/binutils.py
+++ b/shared/kpack/python/rocm_kpack/binutils.py
@@ -9,13 +9,17 @@ from typing import Any
 import msgpack
 
 from rocm_kpack.ccob_parser import extract_code_objects_from_fatbin
+from rocm_kpack.coff.surgery import CoffSurgery
+from rocm_kpack.format_detect import detect_binary_format, UnsupportedBinaryFormat
 
 
 class BinaryType(Enum):
     """Type of bundled binary file."""
 
     STANDALONE = "standalone"  # .co files - directly in bundler format
-    BUNDLED = "bundled"  # Executables/libraries with .hip_fatbin ELF section
+    BUNDLED = (
+        "bundled"  # Executables/libraries with device code section (ELF or PE/COFF)
+    )
 
 
 class Toolchain:
@@ -239,11 +243,11 @@ class BundledBinary:
         return contents
 
     def _detect_binary_type(self) -> BinaryType:
-        """Detect if this is a standalone bundler file or bundled ELF binary.
+        """Detect if this is a standalone bundler file or a bundled binary.
 
-        Uses readelf to check for .hip_fatbin section to determine type.
-        Files with .hip_fatbin section are BUNDLED (executables, libraries).
-        Files without (or non-ELF files) are STANDALONE (.co files in bundler format).
+        For ELF, checks for .hip_fatbin section via readelf.
+        For PE/COFF, checks for .hip_fat section via CoffSurgery.
+        Files without device code sections are STANDALONE (.co files in bundler format).
 
         Returns:
             BinaryType indicating the file type
@@ -252,35 +256,47 @@ class BundledBinary:
             RuntimeError: For unexpected errors during detection
         """
         try:
-            result = subprocess.run(
-                [str(self.toolchain.readelf), "-S", str(self.file_path.resolve())],
-                capture_output=True,
-                text=True,
-                check=True,  # Raise CalledProcessError on non-zero exit
-            )
-            # readelf succeeded - this is an ELF file
-            # Check for .hip_fatbin section
-            if ".hip_fatbin" in result.stdout:
-                return BinaryType.BUNDLED
-            else:
-                # ELF file without .hip_fatbin section
-                return BinaryType.STANDALONE
-
-        except subprocess.CalledProcessError:
-            # readelf failed - likely not an ELF file
-            # Assume STANDALONE (bundler format file like .co)
+            fmt = detect_binary_format(self.file_path)
+        except UnsupportedBinaryFormat:
             return BinaryType.STANDALONE
-        except Exception as e:
-            # Unexpected error - fail fast
-            raise RuntimeError(
-                f"Unexpected error detecting binary type for {self.file_path}: {e}"
-            )
+
+        if fmt == "elf":
+            try:
+                result = subprocess.run(
+                    [str(self.toolchain.readelf), "-S", str(self.file_path.resolve())],
+                    capture_output=True,
+                    text=True,
+                    check=True,
+                )
+                if ".hip_fatbin" in result.stdout:
+                    return BinaryType.BUNDLED
+                else:
+                    return BinaryType.STANDALONE
+            except subprocess.CalledProcessError:
+                return BinaryType.STANDALONE
+            except Exception as e:
+                raise RuntimeError(
+                    f"Unexpected error detecting binary type for {self.file_path}: {e}"
+                ) from e
+        else:
+            # PE/COFF
+            try:
+                surgery = CoffSurgery.load(self.file_path)
+                if surgery.find_section(".hip_fat") is not None:
+                    return BinaryType.BUNDLED
+                else:
+                    return BinaryType.STANDALONE
+            except Exception as e:
+                raise RuntimeError(
+                    f"Unexpected error detecting binary type for {self.file_path}: {e}"
+                ) from e
 
     def _get_bundler_input(self) -> Path:
         """Get the file path to use as input to clang-offload-bundler.
 
         For STANDALONE files, returns the file path directly.
-        For BUNDLED binaries, extracts the .hip_fatbin section to a temp file.
+        For BUNDLED ELF binaries, extracts .hip_fatbin section via objcopy.
+        For BUNDLED PE/COFF binaries, extracts .hip_fat section via CoffSurgery.
 
         Returns:
             Path to file in bundler format
@@ -288,31 +304,41 @@ class BundledBinary:
         if self.binary_type == BinaryType.STANDALONE:
             return self.file_path
 
-        # Extract .hip_fatbin section from bundled binary
         if self._temp_dir is None:
             self._temp_dir = Path(tempfile.mkdtemp())
 
         fatbin_path = self._temp_dir / "fatbin.o"
-        # Resolve to absolute paths for objcopy
-        abs_file_path = self.file_path.resolve()
-        abs_fatbin_path = fatbin_path.resolve()
 
-        try:
-            self.toolchain.exec(
-                [
-                    self.toolchain.objcopy,
-                    "--dump-section",
-                    f".hip_fatbin={abs_fatbin_path}",
-                    abs_file_path,
-                ]
-            )
-        except subprocess.CalledProcessError as e:
-            # Include the actual stderr/stdout from objcopy
-            error_output = e.output.decode() if e.output else "(no output)"
-            raise RuntimeError(
-                f"Failed to extract .hip_fatbin section from {self.file_path}. "
-                f"objcopy exit code: {e.returncode}. Output: {error_output}"
-            ) from e
+        fmt = detect_binary_format(self.file_path)
+        if fmt == "coff":
+            surgery = CoffSurgery.load(self.file_path)
+            section = surgery.find_section(".hip_fat")
+            if section is None:
+                raise RuntimeError(
+                    f"PE binary {self.file_path} has no .hip_fat section"
+                )
+            content = surgery.get_section_content(section)
+            content = content[: section.virtual_size]
+            fatbin_path.write_bytes(content)
+        else:
+            # ELF: extract .hip_fatbin section via objcopy
+            abs_file_path = self.file_path.resolve()
+            abs_fatbin_path = fatbin_path.resolve()
+            try:
+                self.toolchain.exec(
+                    [
+                        self.toolchain.objcopy,
+                        "--dump-section",
+                        f".hip_fatbin={abs_fatbin_path}",
+                        abs_file_path,
+                    ]
+                )
+            except subprocess.CalledProcessError as e:
+                error_output = e.output.decode() if e.output else "(no output)"
+                raise RuntimeError(
+                    f"Failed to extract .hip_fatbin section from {self.file_path}. "
+                    f"objcopy exit code: {e.returncode}. Output: {error_output}"
+                ) from e
 
         return fatbin_path
 

--- a/shared/kpack/runtime/CMakeLists.txt
+++ b/shared/kpack/runtime/CMakeLists.txt
@@ -77,6 +77,7 @@ install(TARGETS rocm_kpack
     EXPORT rocm-kpack-targets
     LIBRARY DESTINATION lib
     ARCHIVE DESTINATION lib
+    RUNTIME DESTINATION bin
     PUBLIC_HEADER DESTINATION include/rocm_kpack
 )
 

--- a/shared/kpack/runtime/src/path_resolution.cpp
+++ b/shared/kpack/runtime/src/path_resolution.cpp
@@ -11,9 +11,8 @@
 #include <sstream>
 #include <string>
 #elif defined(_WIN32)
-// Windows headers would go here
-// #define WIN32_LEAN_AND_MEAN
-// #include <windows.h>
+#define WIN32_LEAN_AND_MEAN
+#include <windows.h>
 #endif
 
 extern "C" {
@@ -160,25 +159,30 @@ kpack_error_t kpack_discover_binary_path(const void* address_in_binary,
 
 #elif defined(_WIN32)
   // Windows implementation: use GetModuleHandleEx + GetModuleFileName
-  //
-  // TODO: Implement Windows support
-  // Pattern:
-  //   HMODULE hm = NULL;
-  //   if (GetModuleHandleExA(
-  //       GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS |
-  //       GET_MODULE_HANDLE_EX_FLAG_UNCHANGED_REFCOUNT,
-  //       (LPCSTR)address_in_binary, &hm)) {
-  //     char path[MAX_PATH];
-  //     if (GetModuleFileNameA(hm, path, sizeof(path))) {
-  //       // Copy to path_out
-  //       // offset_out = address_in_binary - hm
-  //     }
-  //   }
-  (void)address_in_binary;
-  (void)path_out;
-  (void)path_out_size;
-  (void)offset_out;
-  return KPACK_ERROR_NOT_IMPLEMENTED;
+  HMODULE hm = NULL;
+  if (!GetModuleHandleExA(GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS |
+                              GET_MODULE_HANDLE_EX_FLAG_UNCHANGED_REFCOUNT,
+                          (LPCSTR)address_in_binary, &hm)) {
+    return KPACK_ERROR_PATH_DISCOVERY_FAILED;
+  }
+
+  // Write directly into the caller's buffer.
+  DWORD len =
+      GetModuleFileNameA(hm, path_out, static_cast<DWORD>(path_out_size));
+  if (len == 0) {
+    return KPACK_ERROR_PATH_DISCOVERY_FAILED;
+  }
+  if (len >= path_out_size) {
+    // Caller's buffer too small (truncated).
+    return KPACK_ERROR_INVALID_ARGUMENT;
+  }
+
+  if (offset_out != nullptr) {
+    *offset_out = reinterpret_cast<uintptr_t>(address_in_binary) -
+                  reinterpret_cast<uintptr_t>(hm);
+  }
+
+  return KPACK_SUCCESS;
 
 #else
   // Unsupported platform

--- a/shared/kpack/runtime/tests/CMakeLists.txt
+++ b/shared/kpack/runtime/tests/CMakeLists.txt
@@ -3,40 +3,39 @@
 include(GoogleTest)
 
 # Runtime tests - single executable with multiple translation units
-add_executable(test_kpack_runtime
+add_executable(
+    test_kpack_runtime
     test_kpack_api.cpp
     test_utils_test.cpp
     test_archive_integration.cpp
     test_loader_api.cpp
     test_isa_target_match.cpp
 )
-target_link_libraries(test_kpack_runtime
-    PRIVATE
-        rocm_kpack
-        GTest::gtest
-        GTest::gtest_main
+target_link_libraries(
+    test_kpack_runtime
+    PRIVATE rocm_kpack msgpack-cxx zstd::libzstd GTest::gtest GTest::gtest_main
 )
 # Include internal headers for white-box testing
-target_include_directories(test_kpack_runtime
-    PRIVATE
-        ${CMAKE_CURRENT_SOURCE_DIR}/../src
+target_include_directories(
+    test_kpack_runtime
+    PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../src
 )
 
 # Apply ASAN to tests if enabled
 if(ENABLE_ASAN)
-    target_compile_options(test_kpack_runtime PRIVATE
-        -fsanitize=address
-        -fno-omit-frame-pointer
+    target_compile_options(
+        test_kpack_runtime
+        PRIVATE -fsanitize=address -fno-omit-frame-pointer
     )
-    target_link_options(test_kpack_runtime PRIVATE
-        -fsanitize=address
-    )
+    target_link_options(test_kpack_runtime PRIVATE -fsanitize=address)
 endif()
 
 # Discover tests and set environment variable for test data location
-gtest_discover_tests(test_kpack_runtime
+gtest_discover_tests(
+    test_kpack_runtime
     PROPERTIES
-        ENVIRONMENT "ROCM_KPACK_TEST_ASSETS_DIR=${CMAKE_CURRENT_SOURCE_DIR}/test_assets"
+        ENVIRONMENT
+            "ROCM_KPACK_TEST_ASSETS_DIR=${CMAKE_CURRENT_SOURCE_DIR}/test_assets"
 )
 
 # Compression test (will be implemented later)

--- a/shared/kpack/runtime/tests/test_archive_integration.cpp
+++ b/shared/kpack/runtime/tests/test_archive_integration.cpp
@@ -12,7 +12,7 @@
 
 TEST(ArchiveIntegrationTest, NoOpArchive) {
   std::string test_kpack =
-      test_utils::get_test_assets_dir() / "test_noop.kpack";
+      (test_utils::get_test_assets_dir() / "test_noop.kpack").string();
   ASSERT_TRUE(std::filesystem::exists(test_kpack))
       << "Test asset not found: " << test_kpack;
 
@@ -83,7 +83,7 @@ TEST(ArchiveIntegrationTest, NoOpArchive) {
 
 TEST(ArchiveIntegrationTest, ZstdArchive) {
   std::string test_kpack =
-      test_utils::get_test_assets_dir() / "test_zstd.kpack";
+      (test_utils::get_test_assets_dir() / "test_zstd.kpack").string();
   ASSERT_TRUE(std::filesystem::exists(test_kpack))
       << "Test asset not found: " << test_kpack;
 
@@ -146,7 +146,7 @@ TEST(ArchiveIntegrationTest, ZstdArchive) {
 // Test kpack_get_binary retrieves binary names correctly
 TEST(ArchiveIntegrationTest, GetBinaryNames) {
   std::string test_kpack =
-      test_utils::get_test_assets_dir() / "test_noop.kpack";
+      (test_utils::get_test_assets_dir() / "test_noop.kpack").string();
   ASSERT_TRUE(std::filesystem::exists(test_kpack))
       << "Test asset not found: " << test_kpack;
 
@@ -184,7 +184,7 @@ TEST(ArchiveIntegrationTest, GetBinaryNames) {
 // Test kpack_get_binary retrieves binaries from zstd archive
 TEST(ArchiveIntegrationTest, GetBinaryNames_Zstd) {
   std::string test_kpack =
-      test_utils::get_test_assets_dir() / "test_zstd.kpack";
+      (test_utils::get_test_assets_dir() / "test_zstd.kpack").string();
   ASSERT_TRUE(std::filesystem::exists(test_kpack))
       << "Test asset not found: " << test_kpack;
 
@@ -215,7 +215,7 @@ TEST(ArchiveIntegrationTest, GetBinaryNames_Zstd) {
 // Test that multiple kernel loads return independent copies
 TEST(ArchiveIntegrationTest, KernelCacheOverwrite) {
   std::string test_kpack =
-      test_utils::get_test_assets_dir() / "test_noop.kpack";
+      (test_utils::get_test_assets_dir() / "test_noop.kpack").string();
 
   kpack_archive_t archive;
   kpack_error_t err = kpack_open(test_kpack.c_str(), &archive);

--- a/shared/kpack/runtime/tests/test_kpack_api.cpp
+++ b/shared/kpack/runtime/tests/test_kpack_api.cpp
@@ -15,6 +15,17 @@
 
 #include "rocm_kpack/kpack.h"
 
+// Cross-platform packed struct support
+#ifdef _MSC_VER
+#define PACKED_STRUCT_BEGIN __pragma(pack(push, 1))
+#define PACKED_STRUCT_END __pragma(pack(pop))
+#define PACKED_ATTR
+#else
+#define PACKED_STRUCT_BEGIN
+#define PACKED_STRUCT_END
+#define PACKED_ATTR __attribute__((packed))
+#endif
+
 // Helper to create a temp file with specific content
 // Uses mkstemp() on POSIX for race-free temp file creation
 class TempFile {
@@ -242,12 +253,14 @@ TEST(KpackAPITest, InvalidArchive_EmptyFile) {
 TEST(KpackAPITest, InvalidArchive_WrongMagic) {
   // Create a file with wrong magic bytes
   // Header format: magic (4), version (4), compression (4), toc_offset (8)
-  struct __attribute__((packed)) FakeHeader {
+  PACKED_STRUCT_BEGIN
+  struct FakeHeader {
     char magic[4] = {'X', 'X', 'X', 'X'};  // Wrong magic
     uint32_t version = 1;
     uint32_t compression = 0;
     uint64_t toc_offset = 20;
-  };
+  } PACKED_ATTR;
+  PACKED_STRUCT_END
   FakeHeader header;
 
   TempFile bad_magic(&header, sizeof(header));
@@ -259,12 +272,14 @@ TEST(KpackAPITest, InvalidArchive_WrongMagic) {
 
 TEST(KpackAPITest, InvalidArchive_UnsupportedVersion) {
   // Create a file with correct magic but wrong version
-  struct __attribute__((packed)) FakeHeader {
+  PACKED_STRUCT_BEGIN
+  struct FakeHeader {
     char magic[4] = {'K', 'P', 'A', 'K'};  // Correct magic
     uint32_t version = 999;                // Unsupported version
     uint32_t compression = 0;
     uint64_t toc_offset = 20;
-  };
+  } PACKED_ATTR;
+  PACKED_STRUCT_END
   FakeHeader header;
 
   TempFile bad_version(&header, sizeof(header));
@@ -288,12 +303,14 @@ TEST(KpackAPITest, InvalidArchive_TruncatedHeader) {
 
 TEST(KpackAPITest, InvalidArchive_TOCOffsetBeyondFile) {
   // Create a file with valid header but TOC offset beyond file size
-  struct __attribute__((packed)) FakeHeader {
+  PACKED_STRUCT_BEGIN
+  struct FakeHeader {
     char magic[4] = {'K', 'P', 'A', 'K'};
     uint32_t version = 1;
     uint32_t compression = 0;
     uint64_t toc_offset = 999999;  // Way beyond file size
-  };
+  } PACKED_ATTR;
+  PACKED_STRUCT_END
   FakeHeader header;
 
   TempFile bad_offset(&header, sizeof(header));

--- a/shared/kpack/runtime/tests/test_loader_api.cpp
+++ b/shared/kpack/runtime/tests/test_loader_api.cpp
@@ -14,6 +14,13 @@
 #include "kpack_internal.h"
 #include "rocm_kpack/kpack.h"
 
+// Platform-appropriate path list separator (matches loader.cpp split_path_list)
+#ifdef _WIN32
+static const char PATH_SEP = ';';
+#else
+static const char PATH_SEP = ':';
+#endif
+
 // Helper to get test assets directory
 static std::string get_test_assets_dir() {
   const char* dir = std::getenv("ROCM_KPACK_TEST_ASSETS_DIR");
@@ -37,9 +44,24 @@ class CacheGuard {
   kpack_cache_t cache_;
 };
 
+// Cross-platform environment variable helpers
+static void env_set(const char* name, const char* value) {
+#ifdef _WIN32
+  _putenv_s(name, value);
+#else
+  setenv(name, value, 1);
+#endif
+}
+
+static void env_unset(const char* name) {
+#ifdef _WIN32
+  _putenv_s(name, "");
+#else
+  unsetenv(name);
+#endif
+}
+
 // RAII wrapper for environment variable
-// Note: setenv() and unsetenv() are POSIX, not C++ standard.
-// For Windows, use _putenv_s() instead.
 class EnvGuard {
  public:
   EnvGuard(const char* name, const char* value) : name_(name) {
@@ -50,14 +72,14 @@ class EnvGuard {
     } else {
       had_value_ = false;
     }
-    setenv(name, value, 1);
+    env_set(name, value);
   }
 
   ~EnvGuard() {
     if (had_value_) {
-      setenv(name_.c_str(), saved_.c_str(), 1);
+      env_set(name_.c_str(), saved_.c_str());
     } else {
-      unsetenv(name_.c_str());
+      env_unset(name_.c_str());
     }
   }
 
@@ -101,18 +123,11 @@ TEST(LoaderAPITest, DiscoverBinaryPath_ValidAddress) {
   kpack_error_t err =
       kpack_discover_binary_path(addr, path, sizeof(path), &offset);
 
-  // This should succeed on Linux
-#ifdef __linux__
   EXPECT_EQ(err, KPACK_SUCCESS);
   // Path should be non-empty and contain the test executable name
   EXPECT_GT(std::strlen(path), 0u);
-  // The path should end with the test executable name
   std::string path_str(path);
   EXPECT_NE(path_str.find("test_kpack_runtime"), std::string::npos);
-#else
-  // On Windows, we expect NOT_IMPLEMENTED until Windows support is added
-  EXPECT_EQ(err, KPACK_ERROR_NOT_IMPLEMENTED);
-#endif
 }
 
 TEST(LoaderAPITest, DiscoverBinaryPath_BufferTooSmall) {
@@ -122,12 +137,8 @@ TEST(LoaderAPITest, DiscoverBinaryPath_BufferTooSmall) {
   kpack_error_t err =
       kpack_discover_binary_path(addr, path, sizeof(path), nullptr);
 
-#ifdef __linux__
   // Should fail because buffer is too small
   EXPECT_EQ(err, KPACK_ERROR_INVALID_ARGUMENT);
-#else
-  EXPECT_EQ(err, KPACK_ERROR_NOT_IMPLEMENTED);
-#endif
 }
 
 //
@@ -153,7 +164,8 @@ TEST(LoaderAPITest, CacheDestroy_Null) {
 
 TEST(LoaderAPITest, CacheCreate_ResolvesEnvVars) {
   // Set environment variables before creating cache
-  EnvGuard path_guard("ROCM_KPACK_PATH", "/test/path1:/test/path2");
+  std::string path_val = std::string("/test/path1") + PATH_SEP + "/test/path2";
+  EnvGuard path_guard("ROCM_KPACK_PATH", path_val.c_str());
   EnvGuard prefix_guard("ROCM_KPACK_PATH_PREFIX", "/prefix/path");
 
   CacheGuard cache;
@@ -1157,9 +1169,10 @@ TEST(LoaderAPITest, EnvPath_EmptyComponents) {
     GTEST_SKIP() << "ROCM_KPACK_TEST_ASSETS_DIR not set";
   }
 
-  // Path with empty components: "path1::path2" should ignore empty
+  // Path with empty components: "path1<sep><sep>path2" should ignore empty
   std::string kpack_path = assets_dir + "/test_noop.kpack";
-  std::string path_with_empty = kpack_path + "::" + kpack_path;
+  std::string sep(2, PATH_SEP);
+  std::string path_with_empty = kpack_path + sep + kpack_path;
   EnvGuard env_guard("ROCM_KPACK_PATH", path_with_empty.c_str());
 
   CacheGuard cache;
@@ -1187,8 +1200,8 @@ TEST(LoaderAPITest, EnvPath_TrailingColon) {
     GTEST_SKIP() << "ROCM_KPACK_TEST_ASSETS_DIR not set";
   }
 
-  // Path with trailing colon should be parsed correctly
-  std::string kpack_path = assets_dir + "/test_noop.kpack:";
+  // Path with trailing separator should be parsed correctly
+  std::string kpack_path = assets_dir + "/test_noop.kpack" + PATH_SEP;
   EnvGuard env_guard("ROCM_KPACK_PATH", kpack_path.c_str());
 
   CacheGuard cache;

--- a/shared/kpack/tests/test_artifact_utils.py
+++ b/shared/kpack/tests/test_artifact_utils.py
@@ -6,10 +6,9 @@ handling, directory traversal, and file classification.
 """
 
 import os
-import subprocess
 import tempfile
 from pathlib import Path
-from unittest.mock import Mock, patch, MagicMock
+from unittest.mock import Mock, patch
 
 import pytest
 
@@ -187,9 +186,9 @@ class TestIsFatBinary:
     """Tests for fat binary detection.
 
     These tests verify that is_fat_binary() correctly identifies:
-    - Fat binaries (ELF files with .hip_fatbin section) -> True
-    - Host-only binaries (ELF files without .hip_fatbin) -> False
-    - Non-ELF files -> False
+    - Fat binaries (ELF with .hip_fatbin / PE with .hip_fat) -> True
+    - Host-only binaries (no device code section) -> False
+    - Non-binary files -> False
     - Empty files -> False
     - Missing files -> raises FileNotFoundError
     """
@@ -254,78 +253,68 @@ class TestIsFatBinary:
         result = is_fat_binary(fat_binary, toolchain)
         assert result is True
 
-    def test_is_fat_binary_with_hip_fatbin(self, tmp_path):
-        """Test detecting a binary with .hip_fatbin section."""
-        # Create a real file with ELF magic bytes
-        elf_file = tmp_path / "binary.so"
-        elf_file.write_bytes(b"\x7fELF" + b"\x00" * 100)  # ELF magic + padding
+    def test_is_fat_binary_with_hip_fatbin(self, test_assets_dir, toolchain):
+        """Test detecting a fat binary with .hip_fatbin section (ELF)."""
+        fat_binary = (
+            test_assets_dir / "bundled_binaries/linux/cov5/test_kernel_single.exe"
+        )
+        assert fat_binary.exists(), f"Test asset not found: {fat_binary}"
 
-        mock_toolchain = Mock(spec=Toolchain)
-        mock_toolchain.readelf = "/usr/bin/readelf"
+        assert (
+            is_fat_binary(fat_binary, toolchain) is True
+        ), f"Expected fat binary: {fat_binary}"
 
-        # Mock subprocess to return output with .hip_fatbin
-        with patch("subprocess.check_output") as mock_check:
-            mock_check.return_value = """
-                Section Headers:
-                  [Nr] Name              Type
-                  [ 0]                   NULL
-                  [ 1] .text             PROGBITS
-                  [ 2] .hip_fatbin       PROGBITS
-                  [ 3] .data             PROGBITS
-            """
+    def test_is_fat_binary_without_hip_fatbin(self, test_assets_dir, toolchain):
+        """Test detecting a host-only binary without device code (ELF)."""
+        host_only = test_assets_dir / "bundled_binaries/linux/cov5/host_only.exe"
+        assert host_only.exists(), f"Test asset not found: {host_only}"
 
-            result = is_fat_binary(elf_file, mock_toolchain)
-            assert result is True
-
-    def test_is_fat_binary_without_hip_fatbin(self, tmp_path):
-        """Test detecting a regular binary without .hip_fatbin."""
-        # Create a real file with ELF magic bytes
-        elf_file = tmp_path / "binary.so"
-        elf_file.write_bytes(b"\x7fELF" + b"\x00" * 100)  # ELF magic + padding
-
-        mock_toolchain = Mock(spec=Toolchain)
-        mock_toolchain.readelf = "/usr/bin/readelf"
-
-        with patch("subprocess.check_output") as mock_check:
-            mock_check.return_value = """
-                Section Headers:
-                  [Nr] Name              Type
-                  [ 0]                   NULL
-                  [ 1] .text             PROGBITS
-                  [ 2] .data             PROGBITS
-            """
-
-            result = is_fat_binary(elf_file, mock_toolchain)
-            assert result is False
+        assert (
+            is_fat_binary(host_only, toolchain) is False
+        ), f"Expected host-only binary: {host_only}"
 
     def test_is_fat_binary_not_elf(self, tmp_path):
-        """Test handling non-ELF files."""
-        # Create a real non-ELF file (text file)
+        """Test handling non-ELF/non-PE files."""
         text_file = tmp_path / "text.txt"
-        text_file.write_text("This is not an ELF file")
+        text_file.write_text("This is not a binary file")
 
         mock_toolchain = Mock(spec=Toolchain)
-        mock_toolchain.readelf = "/usr/bin/readelf"
-
-        # Should return False immediately after checking magic bytes, without calling readelf
         result = is_fat_binary(text_file, mock_toolchain)
         assert result is False
 
-    def test_is_fat_binary_readelf_not_found(self, tmp_path):
-        """Test handling when readelf is not available."""
-        # Create a real file with ELF magic bytes
+    def test_is_fat_binary_truncated_elf(self, tmp_path):
+        """Test that truncated ELF files are handled gracefully."""
         elf_file = tmp_path / "binary.so"
-        elf_file.write_bytes(b"\x7fELF" + b"\x00" * 100)  # ELF magic + padding
+        elf_file.write_bytes(b"\x7fELF" + b"\x00" * 10)  # Too short for real ELF
 
         mock_toolchain = Mock(spec=Toolchain)
-        mock_toolchain.readelf = "/nonexistent/readelf"
+        # Should not crash — either returns False or raises a sensible error
+        try:
+            assert (
+                is_fat_binary(elf_file, mock_toolchain) is False
+            ), f"Truncated ELF should not be detected as fat: {elf_file}"
+        except (RuntimeError, ValueError):
+            pass  # Also acceptable for corrupt files
 
-        with patch("subprocess.check_output") as mock_check:
-            mock_check.side_effect = FileNotFoundError("No such file")
+    def test_is_fat_binary_coff_fat(self, test_assets_dir, toolchain):
+        """Test detecting a fat binary with .hip_fat section (PE/COFF)."""
+        fat_binary = (
+            test_assets_dir / "bundled_binaries/windows/cov5/test_kernel_single.exe"
+        )
+        assert fat_binary.exists(), f"Test asset not found: {fat_binary}"
 
-            # Should raise RuntimeError when readelf is not found
-            with pytest.raises(RuntimeError, match="readelf not found"):
-                is_fat_binary(elf_file, mock_toolchain)
+        assert (
+            is_fat_binary(fat_binary, toolchain) is True
+        ), f"Expected fat binary: {fat_binary}"
+
+    def test_is_fat_binary_coff_host_only(self, test_assets_dir, toolchain):
+        """Test detecting a host-only PE/COFF binary."""
+        host_only = test_assets_dir / "bundled_binaries/windows/cov5/host_only.exe"
+        assert host_only.exists(), f"Test asset not found: {host_only}"
+
+        assert (
+            is_fat_binary(host_only, toolchain) is False
+        ), f"Expected host-only binary: {host_only}"
 
 
 class TestExtractArchitectureFromTarget:


### PR DESCRIPTION
With this patch, the kpack splitter and runtime support works on Windows.

- artifact_utils: Make is_fat_binary() format-agnostic (ELF .hip_fatbin / COFF .hip_fat)
- artifact_splitter: Fix ELF-only import, use kpack_transform dispatcher; fix backslash path separators in TOC keys and kernel_name on Windows (.as_posix())
- binutils: Add PE/COFF support to BundledBinary detection and section extraction via CoffSurgery, replacing readelf/objcopy which caused hangs on Windows DLLs
- os_win32: Implement FindFileNameFromAddress using GetModuleHandleExA/GetModuleFileNameA
- path_resolution: Implement kpack_discover_binary_path for Windows
- CMakeLists: Add RUNTIME DESTINATION bin so rocm_kpack.dll is installed on Windows

Tested:
- [x] Windows KPACK unit tests (python and C++)
- [x] Linux KPACK unit tests (python and C++)
- [x] rocrand tests with KPACK enabled on Windows/gfx1151
- [ ] Full CI pipeline with this patched in

Fixes ROCm/TheRock#3740
Fixes ROCm/TheRock#3327
