### PR TITLE
Make TRACE_ENTRY/TRACE_EXIT print time the function took

### DIFF
--- a/projects/rocdbgapi/src/logging.h
+++ b/projects/rocdbgapi/src/logging.h
@@ -26,6 +26,7 @@
 #include "format_printf.h"
 #include "utils.h"
 
+#include <chrono>
 #include <cinttypes>
 #include <cstdarg>
 #include <cstddef>
@@ -53,6 +54,8 @@
 #elif defined (_WIN32)
 #define PROCESS_ID_FORMAT "%lu"
 #endif
+
+#define TRACER_TOOK_MS_FORMAT " (took %.6f ms)"
 
 namespace amd::dbgapi
 {
@@ -614,9 +617,19 @@ to_cstring (T &&value, std::string &&tmp = {})
 namespace detail
 {
 
+/* Floating-point duration representing milliseconds.  */
+using fmilliseconds = std::chrono::duration<double, std::milli>;
+
+/* Common data for tracer_closure and its specializations.  */
+struct tracer_closure_base
+{
+  /* How long the call took.  */
+  fmilliseconds elapsed;
+};
+
 template <typename Functor,
           typename Result = decltype (std::declval<Functor> () ())>
-struct tracer_closure
+struct tracer_closure : tracer_closure_base
 {
   Result m_result;
 
@@ -629,7 +642,8 @@ struct tracer_closure
   std::string str () const { return to_string (m_result); }
 };
 
-template <typename Functor> struct tracer_closure<Functor, void>
+template <typename Functor>
+struct tracer_closure<Functor, void> : tracer_closure_base
 {
   tracer_closure (Functor &&f) { std::forward<Functor> (f) (); }
   void operator() () && {}
@@ -676,14 +690,28 @@ tracer<LogLevel>::enter (std::tuple<Args...> &&in_args, Functor &&func)
                to_cstring (std::move (in_args)));
   ++detail::log_indent_depth;
 
+  using clock = std::chrono::steady_clock;
+
+  auto start = clock::now ();
+
   try
     {
-      return detail::tracer_closure (std::forward<Functor> (func));
+      auto res = detail::tracer_closure (std::forward<Functor> (func));
+
+      auto end = clock::now ();
+
+      res.elapsed = end - start;
+      return res;
     }
   catch (...)
     {
+      auto end = clock::now ();
+      detail::fmilliseconds elapsed = end - start;
+
       --detail::log_indent_depth;
-      dbgapi_log (LogLevel, "%s} throw", m_prefix);
+
+      dbgapi_log (LogLevel, "%s} %s throw" TRACER_TOOK_MS_FORMAT, m_prefix,
+                  m_function, elapsed.count ());
       throw;
     }
 }
@@ -711,7 +739,9 @@ tracer<LogLevel>::leave (std::tuple<Args...> &&out_args,
           results_str += ", " + out_args_str;
 
       --detail::log_indent_depth;
-      detail::log (LogLevel, "%s} = %s", m_prefix, results_str.c_str ());
+
+      detail::log (LogLevel, "%s} %s = %s" TRACER_TOOK_MS_FORMAT, m_prefix,
+                   m_function, results_str.c_str (), result.elapsed.count ());
     }
 
   return std::move (result) ();


### PR DESCRIPTION
This commit makes dbgapi function tracing include the time each call
took.  This is very useful to diagnose performance problems.

In addition, it prints the name of the function on the exit side too,
so that it's much easier to grep for the time of the call you are
interested in.

For example, before:

[amd-dbgapi-lib] amd_dbgapi_read_memory (process_id=process_1, wave_id=wave_1, lane_id=0, address_space_id=address_space_70 <private_lane>, segment_address=0x8, value_size=4@0x7ffd4e7cdd68, value=0x63d1cd5ca580) {
[amd-dbgapi-lib] } = STATUS_SUCCESS, *value_size=4, *value=[0x1,0x0,0x0,0x0]

After:

[amd-dbgapi-lib] amd_dbgapi_read_memory (process_id=process_1, wave_id=wave_1, lane_id=0, address_space_id=address_space_70 <private_lane>, segment_address=0x8, value_size=4@0x7ffc5f20bdf8, value=0x5ed7de1eb8b0) {
[amd-dbgapi-lib] } amd_dbgapi_read_memory = STATUS_SUCCESS, *value_size=4, *value=[0x1,0x0,0x0,0x0] (took 0.071165 ms)

Printing the name at the end also makes it much easier to find the
matching exit brace of a call's entry, especially if there are nested
calls in between, making the end brace appear much later in the log.

I considered making printing the time optional with a new CMake
option, to make it less noisy to e.g., diff two logs, but decided
against it since it's trivial to sed away the "(took ... ms)" bit
before comparing logs.

Change-Id: I6e8f56dc936f089fafebeeb8eb0970beccd0cc91