### PR TITLE
[rocprofiler-sdk] Fix rocprofv3 summary validation

### DIFF
--- a/projects/rocprofiler-sdk/tests/rocprofv3/summary/validate.py
+++ b/projects/rocprofiler-sdk/tests/rocprofv3/summary/validate.py
@@ -282,6 +282,15 @@ def test_summary_display_data(json_data, summary_data):
         # return rows x cols
         return [df.shape[0], df.shape[1]] if df is not None else [0, 0]
 
+    def compute_combined_dims(*args):
+        result = [0, 0]
+        for itr in args:
+            if itr is not None:
+                _dims = get_dims(itr)
+                result[0] += _dims[0]
+                result[1] = max(result[1], _dims[1])
+        return result
+
     hip = get_df("HIP_API")
     marker = get_df("MARKER_API")
     dispatch = get_df("KERNEL_DISPATCH")
@@ -292,6 +301,7 @@ def test_summary_display_data(json_data, summary_data):
     total = get_df("SUMMARY")
 
     expected_hip_and_marker_dims = [21, 9] if hip_and_marker is not None else [0, 0]
+    expected_total_dims = compute_combined_dims(hip, marker, memcpy, memalloc)
 
     assert get_dims(marker) == [7, 9], f"{marker}"
     assert get_dims(memcpy) == [2, 9], f"{memcpy}"
@@ -304,10 +314,7 @@ def test_summary_display_data(json_data, summary_data):
     # HIP_API rows vary: extra hipGetDeviceProperties* may appear depending on runtime/environment
     assert get_dims(hip) in ([14, 9], [15, 9]), f"{hip}"
     assert get_dims(hip_and_marker) == expected_hip_and_marker_dims, f"{hip_and_marker}"
-    if get_dims(memalloc) == [2, 9]:  # [2,9] when hip-runtime doesn't use vmem alloc.
-        assert get_dims(total) == [25, 9], f"{total}"
-    elif get_dims(memalloc) == [4, 9]:
-        assert get_dims(total) == [27, 9], f"{total}"
+    assert get_dims(total) == expected_total_dims, f"{total}"
 
 
 def test_perfetto_data(pftrace_data, json_data):

--- a/projects/rocprofiler-sdk/tests/rocprofv3/summary/validate.py
+++ b/projects/rocprofiler-sdk/tests/rocprofv3/summary/validate.py
@@ -300,7 +300,10 @@ def test_summary_display_data(json_data, summary_data):
     hip_and_marker = get_df("HIP_API + MARKER_API") if num_summary_grps > 1 else None
     total = get_df("SUMMARY")
 
-    expected_hip_and_marker_dims = [21, 9] if hip_and_marker is not None else [0, 0]
+    # HIP_API rows vary: extra hipGetDeviceProperties* may appear depending on runtime/environment
+    expected_hip_and_marker_dims = (
+        ([21, 9], [22, 9]) if hip_and_marker is not None else ([0, 0],)
+    )
     expected_total_dims = compute_combined_dims(hip, marker, memcpy, memalloc)
 
     assert get_dims(marker) == [7, 9], f"{marker}"
@@ -313,7 +316,7 @@ def test_summary_display_data(json_data, summary_data):
     assert get_dims(dispatch_and_copy) == [5, 9], f"{dispatch_and_copy}"
     # HIP_API rows vary: extra hipGetDeviceProperties* may appear depending on runtime/environment
     assert get_dims(hip) in ([14, 9], [15, 9]), f"{hip}"
-    assert get_dims(hip_and_marker) == expected_hip_and_marker_dims, f"{hip_and_marker}"
+    assert get_dims(hip_and_marker) in expected_hip_and_marker_dims, f"{hip_and_marker}"
     assert get_dims(total) == expected_total_dims, f"{total}"
 
 


### PR DESCRIPTION
## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->
Fix failing PSDB job

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->
https://github.com/ROCm/rocm-systems/pull/1881 accounted for hidden call to `hipGetDeviceProperties*` in the HIP summary check but did not account for it in `get_dims(total)` and `get_dims(hip_and_marker)`. 

## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->
N/A

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->
N/A. This is a testing fix.

## Test Result

<!-- Briefly summarize test outcomes. -->
N/A. This is a testing fix.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
