### PR TITLE
Adjust includes to match use

### DIFF
--- a/projects/rocr-runtime/libhsakmt/src/ais.c
+++ b/projects/rocr-runtime/libhsakmt/src/ais.c
@@ -25,8 +25,6 @@
 
 #include "libhsakmt.h"
 #include "hsakmt/linux/kfd_ioctl.h"
-#include <stdlib.h>
-#include <stdio.h>
 #include "fmm.h"
 
 

--- a/projects/rocr-runtime/libhsakmt/src/events.c
+++ b/projects/rocr-runtime/libhsakmt/src/events.c
@@ -26,11 +26,9 @@
 #include "libhsakmt.h"
 #include <stdlib.h>
 #include <string.h>
-#include <time.h>
 #include <errno.h>
 #include <unistd.h>
 #include <sys/mman.h>
-#include <stdio.h>
 #include "hsakmt/linux/kfd_ioctl.h"
 #include "fmm.h"
 #include "hsakmt/hsakmtmodel.h"

--- a/projects/rocr-runtime/libhsakmt/src/kfdcontext.c
+++ b/projects/rocr-runtime/libhsakmt/src/kfdcontext.c
@@ -24,12 +24,9 @@
  */
 
 #include "kfdcontext.h"
-#include "libhsakmt.h"
 #include <stdlib.h>
 #include <stddef.h>
 #include <assert.h>
-#include <stdio.h>
-#include <errno.h>
 
 void hsakmt_kfdcontext_init_context(int fd, HsaKFDContext *ctx)
 {

--- a/projects/rocr-runtime/libhsakmt/src/libhsakmt.c
+++ b/projects/rocr-runtime/libhsakmt/src/libhsakmt.c
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: MIT
  */
  
-#include <stdio.h>
 #include <errno.h>
 #include <sys/ioctl.h>
 

--- a/projects/rocr-runtime/libhsakmt/src/libhsakmt.h
+++ b/projects/rocr-runtime/libhsakmt/src/libhsakmt.h
@@ -33,6 +33,7 @@
 #include <pthread.h>
 #include <stdint.h>
 #include <limits.h>
+#include <stdio.h>
 
 extern int hsakmt_udmabuf_dev_fd;
 extern unsigned long hsakmt_kfd_open_count;

--- a/projects/rocr-runtime/libhsakmt/src/memory.c
+++ b/projects/rocr-runtime/libhsakmt/src/memory.c
@@ -26,7 +26,6 @@
 #include "libhsakmt.h"
 #include "hsakmt/linux/kfd_ioctl.h"
 #include <stdlib.h>
-#include <stdio.h>
 #include <string.h>
 #include <assert.h>
 #include <sys/types.h>

--- a/projects/rocr-runtime/libhsakmt/src/openclose.c
+++ b/projects/rocr-runtime/libhsakmt/src/openclose.c
@@ -37,7 +37,6 @@
 #include <sys/ioctl.h>
 #include <fcntl.h>
 #include <unistd.h>
-#include <stdio.h>
 #include <strings.h>
 #include "fmm.h"
 #include <dlfcn.h>

--- a/projects/rocr-runtime/libhsakmt/src/pc_sampling.c
+++ b/projects/rocr-runtime/libhsakmt/src/pc_sampling.c
@@ -25,8 +25,6 @@
 
 #include "libhsakmt.h"
 #include "hsakmt/linux/kfd_ioctl.h"
-#include <stdlib.h>
-#include <stdio.h>
 #include <assert.h>
 #include <errno.h>
 

--- a/projects/rocr-runtime/libhsakmt/src/pmc_table.c
+++ b/projects/rocr-runtime/libhsakmt/src/pmc_table.c
@@ -25,9 +25,6 @@
 
 #include <sys/types.h>
 #include <dirent.h>
-#include <stdio.h>
-#include <string.h>
-#include <stdlib.h>
 #include "libhsakmt.h"
 #include "pmc_table.h"
 

--- a/projects/rocr-runtime/libhsakmt/src/queues.c
+++ b/projects/rocr-runtime/libhsakmt/src/queues.c
@@ -29,7 +29,6 @@
 #include <stdlib.h>
 #include <string.h>
 #include <sys/mman.h>
-#include <math.h>
 #include <stdio.h>
 #include <sys/types.h>
 #include <sys/mman.h>

--- a/projects/rocr-runtime/libhsakmt/src/spm.c
+++ b/projects/rocr-runtime/libhsakmt/src/spm.c
@@ -25,8 +25,6 @@
 
 #include "libhsakmt.h"
 #include "hsakmt/linux/kfd_ioctl.h"
-#include <stdlib.h>
-#include <stdio.h>
 
 
 HSAKMT_STATUS HSAKMTAPI hsaKmtSPMAcquire(HSAuint32 PreferredNode)

--- a/projects/rocr-runtime/libhsakmt/src/svm.c
+++ b/projects/rocr-runtime/libhsakmt/src/svm.c
@@ -23,10 +23,9 @@
  * DEALINGS IN THE SOFTWARE.
  */
 #include "libhsakmt.h"
-#include <stdlib.h>
-#include <stdio.h>
 #include <string.h>
 #include <errno.h>
+#include <alloca.h>
 #include <fcntl.h>
 #include <unistd.h>
 #include <inttypes.h>

--- a/projects/rocr-runtime/libhsakmt/src/version.c
+++ b/projects/rocr-runtime/libhsakmt/src/version.c
@@ -24,8 +24,6 @@
  */
 
 #include "libhsakmt.h"
-#include <stdlib.h>
-#include <string.h>
 #include "hsakmt/linux/kfd_ioctl.h"
 
 HsaVersionInfo hsakmt_kfd_version_info;

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/driver/kfd/amd_kfd_driver.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/driver/kfd/amd_kfd_driver.cpp
@@ -42,10 +42,6 @@
 
 #include "core/inc/amd_kfd_driver.h"
 
-#include <cassert>
-#include <memory>
-#include <string>
-
 #if defined(__linux__)
 #include <amdgpu_drm.h>
 #include <link.h>

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/runtime.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/runtime.cpp
@@ -40,15 +40,9 @@
 //
 ////////////////////////////////////////////////////////////////////////////////
 
-#include <algorithm>
-#include <atomic>
-#include <climits>
 #include <cstring>
 #include <regex>
 #include <string>
-#include <vector>
-#include <list>
-#include <shared_mutex>
 #if defined(__linux__)
 #include <link.h>
 #include <dlfcn.h>
@@ -59,9 +53,6 @@
 #else
 #define debug_warning(__VA_ARGS__)
 #endif
-#include <iostream>
-#include <thread>
-#include <chrono>
 
 #include "core/inc/runtime.h"
 #include "core/inc/hsa_table_interface.h"


### PR DESCRIPTION
I noticed that several includes aren't actually needed for compilation or are in the wrong places. This corrects the ones I found.