### PR TITLE
[ROCM-2991] Improve CLI error handling and exit-code

### DIFF
--- a/projects/amdsmi/amdsmi_cli/amdsmi_cli.py
+++ b/projects/amdsmi/amdsmi_cli/amdsmi_cli.py
@@ -268,3 +268,9 @@ if __name__ == "__main__":
             amd_smi_commands.logger.destination,
         )
         sys.exit(abs(exc.value))
+    except PermissionError as e:
+        command = sys.argv[1] if len(sys.argv) > 1 else ''
+        outputformat = amd_smi_commands.logger.format
+        exc = amdsmi_cli_exceptions.AmdSmiPermissionDeniedException(command, outputformat)
+        _print_error(f"{type(exc).__module__}.{type(exc).__name__}: {str(exc)}", amd_smi_commands.logger.destination)
+        sys.exit(abs(exc.value))

--- a/projects/amdsmi/amdsmi_cli/amdsmi_cli.py
+++ b/projects/amdsmi/amdsmi_cli/amdsmi_cli.py
@@ -269,8 +269,11 @@ if __name__ == "__main__":
         )
         sys.exit(abs(exc.value))
     except PermissionError as e:
-        command = sys.argv[1] if len(sys.argv) > 1 else ''
+        command = sys.argv[1] if len(sys.argv) > 1 else ""
         outputformat = amd_smi_commands.logger.format
         exc = amdsmi_cli_exceptions.AmdSmiPermissionDeniedException(command, outputformat)
-        _print_error(f"{type(exc).__module__}.{type(exc).__name__}: {str(exc)}", amd_smi_commands.logger.destination)
+        _print_error(
+            f"{type(exc).__module__}.{type(exc).__name__}: {str(exc)}",
+            amd_smi_commands.logger.destination,
+        )
         sys.exit(abs(exc.value))

--- a/projects/amdsmi/amdsmi_cli/amdsmi_cli_exceptions.py
+++ b/projects/amdsmi/amdsmi_cli/amdsmi_cli_exceptions.py
@@ -179,7 +179,7 @@ class AmdSmiInvalidFilePathException(AmdSmiException):
 
 
 class AmdSmiInvalidParameterValueException(AmdSmiException):
-    def __init__(self, command, arg, outputformat: str):
+    def __init__(self, command, arg, outputformat: str, hint: str = None):
         super().__init__()
         self.value = -5
         self.command = command
@@ -187,6 +187,8 @@ class AmdSmiInvalidParameterValueException(AmdSmiException):
         self.output_format = outputformat
 
         common_message = f"Value '{self.arg}' is not of valid type or format. Run 'amd-smi {self.command} -h' for more info."
+        if hint:
+            common_message += f" {hint}"
 
         self.json_message["error"] = common_message
         self.json_message["code"] = self.value

--- a/projects/amdsmi/amdsmi_cli/amdsmi_parser.py
+++ b/projects/amdsmi/amdsmi_cli/amdsmi_parser.py
@@ -67,24 +67,29 @@ class AMDSMISubParser(argparse.ArgumentParser):
     def error(self, message):
         helpers = AMDSMIHelpers()
         outputformat = helpers.get_output_format()
-        command = sys.argv[1] if len(sys.argv) > 1 else ''
+        command = sys.argv[1] if len(sys.argv) > 1 else ""
 
         if ": invalid choice: " in message:
             # e.g. "argument --loglevel: invalid choice: 'DDEBUG' (choose from ...)"
             # or   "argument --process-isolation: invalid choice: 2 (choose from 0, 1)"
             _after = message.split(": invalid choice: ")[1]
             value = _after.split("'")[1] if _after.startswith("'") else _after.split(" ")[0]
-            hint = _after[_after.find(' ('):].rstrip() if ' (' in _after else None
+            hint = _after[_after.find(" (") :].rstrip() if " (" in _after else None
             raise amdsmi_cli_exceptions.AmdSmiInvalidParameterValueException(
-                command, value, outputformat, hint=hint)
+                command, value, outputformat, hint=hint
+            )
         elif ": expected" in message:
             # e.g. "argument --gpu: expected one argument"
-            arg = message[len("argument "):].split(":")[0] if message.startswith("argument ") else message
-            raise amdsmi_cli_exceptions.AmdSmiMissingParameterValueException(
-                arg, outputformat)
+            arg = (
+                message[len("argument ") :].split(":")[0]
+                if message.startswith("argument ")
+                else message
+            )
+            raise amdsmi_cli_exceptions.AmdSmiMissingParameterValueException(arg, outputformat)
         else:
             raise amdsmi_cli_exceptions.AmdSmiInvalidParameterException(
-                command, message, outputformat)
+                command, message, outputformat
+            )
 
 
 class AMDSMIParser(argparse.ArgumentParser):
@@ -196,10 +201,7 @@ class AMDSMIParser(argparse.ArgumentParser):
 
         # Setup subparsers
         self.subparsers = self.add_subparsers(
-            title="AMD-SMI Commands",
-            parser_class=AMDSMISubParser,
-            help="Descriptions:",
-            metavar="",
+            title="AMD-SMI Commands", parser_class=AMDSMISubParser, help="Descriptions:", metavar=""
         )
 
         # Store possible subcommands & aliases for later errors
@@ -3269,13 +3271,21 @@ class AMDSMIParser(argparse.ArgumentParser):
             # or unquoted integer (e.g., argument --process-isolation: invalid choice: 2 ...)
             _after = message.split(": invalid choice: ")[1]
             value = _after.split("'")[1] if _after.startswith("'") else _after.split(" ")[0]
-            hint = _after[_after.find(' ('):].rstrip() if ' (' in _after else None
-            command = sys.argv[1] if len(sys.argv) > 1 else ''
-            raise amdsmi_cli_exceptions.AmdSmiInvalidParameterValueException(command, value, outputformat, hint=hint)
+            hint = _after[_after.find(" (") :].rstrip() if " (" in _after else None
+            command = sys.argv[1] if len(sys.argv) > 1 else ""
+            raise amdsmi_cli_exceptions.AmdSmiInvalidParameterValueException(
+                command, value, outputformat, hint=hint
+            )
         elif ": expected" in message:
             # Named argument missing its value (e.g., argument --gpu: expected one argument)
-            arg = message[len("argument "):].split(":")[0] if message.startswith("argument ") else message
+            arg = (
+                message[len("argument ") :].split(":")[0]
+                if message.startswith("argument ")
+                else message
+            )
             raise amdsmi_cli_exceptions.AmdSmiMissingParameterValueException(arg, outputformat)
         else:
-            command = sys.argv[1] if len(sys.argv) > 1 else ''
-            raise amdsmi_cli_exceptions.AmdSmiInvalidParameterException(command, message, outputformat)
+            command = sys.argv[1] if len(sys.argv) > 1 else ""
+            raise amdsmi_cli_exceptions.AmdSmiInvalidParameterException(
+                command, message, outputformat
+            )

--- a/projects/amdsmi/amdsmi_cli/amdsmi_parser.py
+++ b/projects/amdsmi/amdsmi_cli/amdsmi_parser.py
@@ -57,6 +57,36 @@ class AMDSMISubparserHelpFormatter(argparse.RawTextHelpFormatter):
         return ", ".join(action.option_strings) + " " + args_string
 
 
+class AMDSMISubParser(argparse.ArgumentParser):
+    """Subcommand parser with custom error handling for AMDSMI CLI.
+    Used as parser_class for subcommands so that argparse errors on
+    subcommand arguments (e.g., --loglevel INVALID) are routed through
+    the same AmdSmiException framework instead of calling sys.exit(2).
+    """
+
+    def error(self, message):
+        helpers = AMDSMIHelpers()
+        outputformat = helpers.get_output_format()
+        command = sys.argv[1] if len(sys.argv) > 1 else ''
+
+        if ": invalid choice: " in message:
+            # e.g. "argument --loglevel: invalid choice: 'DDEBUG' (choose from ...)"
+            # or   "argument --process-isolation: invalid choice: 2 (choose from 0, 1)"
+            _after = message.split(": invalid choice: ")[1]
+            value = _after.split("'")[1] if _after.startswith("'") else _after.split(" ")[0]
+            hint = _after[_after.find(' ('):].rstrip() if ' (' in _after else None
+            raise amdsmi_cli_exceptions.AmdSmiInvalidParameterValueException(
+                command, value, outputformat, hint=hint)
+        elif ": expected" in message:
+            # e.g. "argument --gpu: expected one argument"
+            arg = message[len("argument "):].split(":")[0] if message.startswith("argument ") else message
+            raise amdsmi_cli_exceptions.AmdSmiMissingParameterValueException(
+                arg, outputformat)
+        else:
+            raise amdsmi_cli_exceptions.AmdSmiInvalidParameterException(
+                command, message, outputformat)
+
+
 class AMDSMIParser(argparse.ArgumentParser):
     """Unified Parser for AMDSMI CLI.
         This parser doesn't access amdsmi's lib directly,but via AMDSMIHelpers,
@@ -167,7 +197,7 @@ class AMDSMIParser(argparse.ArgumentParser):
         # Setup subparsers
         self.subparsers = self.add_subparsers(
             title="AMD-SMI Commands",
-            parser_class=argparse.ArgumentParser,
+            parser_class=AMDSMISubParser,
             help="Descriptions:",
             metavar="",
         )
@@ -3234,5 +3264,18 @@ class AMDSMIParser(argparse.ArgumentParser):
             raise amdsmi_cli_exceptions.AmdSmiInvalidParameterException(
                 sys.argv[1], message, outputformat
             )
+        elif ": invalid choice: " in message:
+            # Named argument with invalid choice (e.g., argument --loglevel: invalid choice: ...)
+            # or unquoted integer (e.g., argument --process-isolation: invalid choice: 2 ...)
+            _after = message.split(": invalid choice: ")[1]
+            value = _after.split("'")[1] if _after.startswith("'") else _after.split(" ")[0]
+            hint = _after[_after.find(' ('):].rstrip() if ' (' in _after else None
+            command = sys.argv[1] if len(sys.argv) > 1 else ''
+            raise amdsmi_cli_exceptions.AmdSmiInvalidParameterValueException(command, value, outputformat, hint=hint)
+        elif ": expected" in message:
+            # Named argument missing its value (e.g., argument --gpu: expected one argument)
+            arg = message[len("argument "):].split(":")[0] if message.startswith("argument ") else message
+            raise amdsmi_cli_exceptions.AmdSmiMissingParameterValueException(arg, outputformat)
         else:
-            print(message)
+            command = sys.argv[1] if len(sys.argv) > 1 else ''
+            raise amdsmi_cli_exceptions.AmdSmiInvalidParameterException(command, message, outputformat)


### PR DESCRIPTION
## Motivation

Invalid return codes on a few AMDSMI CLI runs. Most of the failures with numeric error code would be fixed by PR - https://github.com/ROCm/rocm-systems/pull/3606
This PR is to fix the remaining ones mentioned in the ticket.

## Technical Details

Improve AMDSMI CLI argument and runtime error handling so failures are routed through the existing exception framework with consistent, expected return codes. This also preserves clearer user-facing error output, including invalid-choice guidance, while handling permission-related failures more cleanly.

## JIRA ID

ROCM-2991

## Test Plan

	amd-smi metric --loglevel DDEBUG           : Failure: Received rc = (  2), returned ec = ('CRITICAL')), stream=std_err
    amd-smi metric --loglevel DEBUGG           : Failure: Received rc = (  2), returned ec = ('CRITICAL')), stream=std_err
    amd-smi metric --loglevel BADLEVEL         : Failure: Received rc = (  2), returned ec = ('CRITICAL')), stream=std_err
    amd-smi set --perf-level INVALID           : Failure: Received rc = (  2), returned ec = ('UNKNOWN')), stream=std_err
    amd-smi set --profile INVALID              : Failure: Received PASS (  0), returned FAIL (profiles), stream=std_out
    amd-smi set --compute-partition INVALID    : Failure: Received rc = (  1), returned ec = (-11), stream=std_err
    amd-smi set --memory-partition NPS3        : Failure: Received rc = (  2), returned ec = ('NPS8')), stream=std_err
    amd-smi set --memory-partition INVALID     : Failure: Received rc = (  2), returned ec = ('NPS8')), stream=std_err
    amd-smi set --clk-limit INVALID            : Failure: Received rc = (  2), returned ec = (arguments), stream=std_err
    amd-smi set --clk-limit SCLK INVALID       : Failure: Received rc = (  2), returned ec = (arguments), stream=std_err
    amd-smi set --clk-limit MCLK INVALID       : Failure: Received rc = (  2), returned ec = (arguments), stream=std_err
    amd-smi set --clk-limit SCLK MIN           : Failure: Received rc = (  2), returned ec = (arguments), stream=std_err
    amd-smi set --clk-limit MCLK MAX           : Failure: Received rc = (  2), returned ec = (arguments), stream=std_err
    amd-smi set --clk-level INVALID            : Failure: Received rc = (  1), returned ec = ( -2), stream=std_err
    amd-smi set --clk-level SCLK INVALID       : Failure: Received rc = (  1), returned ec = ( -5), stream=std_err
    amd-smi set --clk-level MCLK INVALID       : Failure: Received rc = (  1), returned ec = ( -5), stream=std_err
    amd-smi set --clk-level FCLK INVALID       : Failure: Received rc = (  1), returned ec = ( -5), stream=std_err
    amd-smi set --clk-level SOCCLK INVALID     : Failure: Received rc = (  1), returned ec = ( -5), stream=std_err
    amd-smi set --clk-level PCIE INVALID       : Failure: Received rc = (  1), returned ec = ( -5), stream=std_err
    amd-smi process --pid NOT_A_NUMBER         : Failure: Received rc = (  1), returned ec = ( -5), stream=std_err
    amd-smi ras --cper INVALID                 : Failure: Received rc = (  1), returned ec = ( -2), stream=std_err
    amd-smi ras --cper --severity INVALID      : Failure: Received rc = (  2), returned ec = ('all')), stream=std_err
    amd-smi ras --afid INVALID                 : Failure: Received rc = (  1), returned ec = ( -2), stream=std_err


    amd-smi set --fan 500                      : Failure: Received rc = (  2), returned ec = (0-255), stream=std_err
    amd-smi set --power-cap 271 ppt0 --gpu 0   : Failure: Received PASS (  0), returned FAIL (350W), stream=std_out
    amd-smi set --power-cap 351 ppt0 --gpu 0   : Failure: Received PASS (  0), returned FAIL (350W), stream=std_out
    amd-smi set --power-cap 385 ppt0 --gpu 0   : Failure: Received PASS (  0), returned FAIL (350W), stream=std_out
    amd-smi set --process-isolation 2          : Failure: Received rc = (  2), returned ec = ( 1)), stream=std_errbsol

## Test Result

<img width="930" height="233" alt="image" src="https://github.com/user-attachments/assets/f4fbcb83-5cda-4962-a9bc-f7fa5e2be98e" />

<img width="930" height="432" alt="image" src="https://github.com/user-attachments/assets/9f0fe3d7-4226-4462-82ba-1a58ad86782a" />

<img width="783" height="428" alt="image" src="https://github.com/user-attachments/assets/a97ebd90-e662-440b-8561-38fb6bc1b926" />

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
