### PR TITLE
[AMD-SMI] Fix KFD reports PID from outside docker container

### DIFF
--- a/projects/amdsmi/rocm_smi/src/rocm_smi_kfd.cc
+++ b/projects/amdsmi/rocm_smi/src/rocm_smi_kfd.cc
@@ -55,6 +55,7 @@ namespace amd::smi {
 static bool is_number(const std::string& s);
 static const char* kKFDProcPathRoot = "/sys/class/kfd/kfd/proc";
 static const char* kKFDNodesPathRoot = "/sys/class/kfd/kfd/topology/nodes";
+static const char* kKFDVramPrefix = "vram_";
 
 // Check whether a given PID has /dev/kfd open by scanning its fd links.
 static bool PidHasKfdOpen(const std::string& pid_str) {
@@ -171,6 +172,40 @@ static int ScanProcForKfdPids(rsmi_process_info_t* procs, uint32_t num_allocated
   return 0;
 }
 
+// Collect GPU IDs from KFD vram_* files for any host-PID KFD entry.
+// Used as a namespace fallback when container-local PIDs have no KFD sysfs entry.
+// NOTE: Uses the first host-PID entry found; assumes all container processes
+// share the same GPU set (valid for typical single-container deployments).
+static void CollectGpuIdsFromKfdVram(std::unordered_set<uint64_t>* gpu_set) {
+  DIR* kfd_proc_dir = opendir(kKFDProcPathRoot);
+  if (!kfd_proc_dir) return;
+
+  struct dirent* de;
+  while ((de = readdir(kfd_proc_dir)) != nullptr) {
+    std::string entry(de->d_name);
+    if (!is_number(entry)) continue;
+
+    std::string host_proc = std::string(kKFDProcPathRoot) + "/" + entry;
+    DIR* pd = opendir(host_proc.c_str());
+    if (!pd) continue;
+
+    struct dirent* pe;
+    while ((pe = readdir(pd)) != nullptr) {
+      std::string fname(pe->d_name);
+      if (fname.rfind("vram_", 0) != 0) continue;
+      std::string gpu_id_str = fname.substr(strlen(kKFDVramPrefix));
+      if (!gpu_id_str.empty() && std::all_of(gpu_id_str.begin(), gpu_id_str.end(),
+                                             [](unsigned char ch) { return std::isdigit(ch); })) {
+        gpu_set->insert(strtoull(gpu_id_str.c_str(), nullptr, 10));
+      }
+    }
+    closedir(pd);
+
+    if (!gpu_set->empty()) break;
+  }
+  closedir(kfd_proc_dir);
+}
+
 static const char* kKFDContextPrefix = "context_";  // Prefix for secondary KFD contexts
 
 // KFD Node Property strings
@@ -218,7 +253,6 @@ static const char* kKFDNodePropHIVE_IDStr = "hive_id";
 
 // KFD process file prefixes for extracting GPU IDs
 static const char* kKFDStatsPrefix = "stats_";
-static const char* kKFDVramPrefix = "vram_";
 static const char* kKFDCountersPrefix = "counters_";
 static const char* kKFDSdmaPrefix = "sdma_";
 
@@ -703,42 +737,12 @@ int GetProcessGPUs(uint32_t pid, std::unordered_set<uint64_t>* gpu_set) {
   }
 
   // PID namespace: fall back to discovering GPU IDs from KFD vram_* files.
-  // NOTE: Uses the first host-PID KFD entry found; assumes all container
-  // processes share the same GPU set (valid for typical container deployments).
-  // This assumption may not hold in multi-tenant GPU partitioning scenarios.
   if (gpu_set->empty() && IsKfdPidNamespaced()) {
     std::ostringstream ss;
     ss << __PRETTY_FUNCTION__ << " | PID namespace detected, falling back to "
        << "KFD vram_* files for GPU discovery (pid=" << pid << ")";
     LOG_DEBUG(ss);
-    DIR* kfd_proc_dir = opendir(kKFDProcPathRoot);
-    if (kfd_proc_dir) {
-      struct dirent* de;
-      while ((de = readdir(kfd_proc_dir)) != nullptr) {
-        if (de->d_name[0] == '.') continue;
-        std::string entry = de->d_name;
-        if (!is_number(entry)) continue;
-        std::string host_proc = std::string(kKFDProcPathRoot) + "/" + entry;
-        DIR* pd = opendir(host_proc.c_str());
-        if (pd) {
-          struct dirent* pe;
-          while ((pe = readdir(pd)) != nullptr) {
-            std::string fname = pe->d_name;
-            if (fname.rfind("vram_", 0) == 0) {
-              std::string gpu_id_str = fname.substr(strlen(kKFDVramPrefix));
-              if (!gpu_id_str.empty() &&
-                  std::all_of(gpu_id_str.begin(), gpu_id_str.end(),
-                              [](unsigned char ch) { return std::isdigit(ch); })) {
-                gpu_set->insert(strtoull(gpu_id_str.c_str(), nullptr, 10));
-              }
-            }
-          }
-          closedir(pd);
-        }
-        if (!gpu_set->empty()) break;
-      }
-      closedir(kfd_proc_dir);
-    }
+    CollectGpuIdsFromKfdVram(gpu_set);
   }
 
   return 0;

--- a/projects/amdsmi/rocm_smi/src/rocm_smi_kfd.cc
+++ b/projects/amdsmi/rocm_smi/src/rocm_smi_kfd.cc
@@ -53,6 +53,100 @@ static const char* kKFDProcPathRoot = "/sys/class/kfd/kfd/proc";
 static const char* kKFDNodesPathRoot = "/sys/class/kfd/kfd/topology/nodes";
 static const char* kKFDContextPrefix = "context_";  // Prefix for secondary KFD contexts
 
+//=============================================================================
+// Container/PID Namespace Detection and Process Scanning
+//=============================================================================
+// In containers with PID namespace isolation, KFD sysfs reports host PIDs
+// which are not visible in the container's /proc. We detect this and fall
+// back to scanning /proc for processes with /dev/kfd open.
+//=============================================================================
+
+static bool IsInContainer() {
+  static int cached = -1;
+  if (cached >= 0) return cached;
+
+  struct stat st;
+  if (stat("/.dockerenv", &st) == 0) { cached = 1; return true; }
+  if (stat("/run/.containerenv", &st) == 0) { cached = 1; return true; }
+
+  std::ifstream cgroup("/proc/1/cgroup");
+  if (cgroup.is_open()) {
+    std::string line;
+    while (std::getline(cgroup, line)) {
+      if (line.find("docker") != std::string::npos ||
+          line.find("kubepods") != std::string::npos ||
+          line.find("containerd") != std::string::npos ||
+          line.find("lxc") != std::string::npos ||
+          line.find("podman") != std::string::npos) {
+        cached = 1;
+        return true;
+      }
+    }
+  }
+
+  cached = 0;
+  return false;
+}
+
+// Scan /proc for container-local PIDs that have /dev/kfd open.
+static int GetContainerKfdPids(rsmi_process_info_t* procs,
+                               uint32_t num_allocated,
+                               uint32_t* num_found) {
+  *num_found = 0;
+
+  DIR* proc_dir = opendir("/proc");
+  if (!proc_dir) return errno;
+
+  struct dirent* dentry;
+  while ((dentry = readdir(proc_dir)) != nullptr) {
+    if (dentry->d_name[0] < '0' || dentry->d_name[0] > '9') continue;
+
+    std::string pid_str = dentry->d_name;
+    bool is_num = true;
+    for (char c : pid_str) {
+      if (c < '0' || c > '9') { is_num = false; break; }
+    }
+    if (!is_num) continue;
+
+    uint32_t pid = static_cast<uint32_t>(std::stoul(pid_str));
+
+    // Skip amd-smi's own process
+    if (pid == static_cast<uint32_t>(getpid())) continue;
+
+    std::string fd_dir_path = "/proc/" + pid_str + "/fd";
+    DIR* fd_dir = opendir(fd_dir_path.c_str());
+    if (!fd_dir) continue;
+
+    bool has_kfd = false;
+    struct dirent* fd_entry;
+    while ((fd_entry = readdir(fd_dir)) != nullptr) {
+      if (fd_entry->d_name[0] == '.') continue;
+      std::string fd_link = fd_dir_path + "/" + fd_entry->d_name;
+      char target[256];
+      ssize_t len = readlink(fd_link.c_str(), target, sizeof(target) - 1);
+      if (len > 0) {
+        target[len] = '\0';
+        if (std::string(target) == "/dev/kfd") {
+          has_kfd = true;
+          break;
+        }
+      }
+    }
+    closedir(fd_dir);
+
+    if (has_kfd) {
+      if (procs && *num_found < num_allocated) {
+        memset(&procs[*num_found], 0, sizeof(procs[*num_found]));
+        procs[*num_found].process_id = pid;
+      }
+      ++(*num_found);
+    }
+  }
+
+  closedir(proc_dir);
+  return 0;
+}
+
 // KFD Node Property strings
 // static const char *kKFDNodePropCPU_CORES_COUNTStr =    "cpu_cores_count";
 // static const char *kKFDNodePropSIMD_COUNTStr =         "simd_count";
@@ -311,6 +405,14 @@ int GetProcessInfo(rsmi_process_info_t* procs, uint32_t num_allocated, uint32_t*
   assert(num_procs_found != nullptr);
 
   *num_procs_found = 0;
+
+  // SWDEV-554692: In containers with PID namespace isolation, KFD sysfs
+  // reports host PIDs that are not visible in the container's /proc.
+  // Detect this case and enumerate KFD processes by scanning /proc instead.
+  if (IsInContainer()) {
+    return GetContainerKfdPids(procs, num_allocated, num_procs_found);
+  }
+
   errno = 0;
   auto proc_dir = opendir(kKFDProcPathRoot);
 
@@ -412,6 +514,11 @@ int GetKfdGpuIdsForPid(long pid, std::unordered_set<uint64_t>* out) {
   DIR* d = opendir(pdir.c_str());
 
   if (!d) {
+    // SWDEV-554692: In a container, the PID is container-local and won't
+    // have a KFD sysfs entry. Return empty set without error.
+    if (IsInContainer()) {
+      return 0;
+    }
     perror(("Unable to open KFD process directory for process " + std::to_string(pid)).c_str());
     return errno ? errno : ESRCH;
   }
@@ -572,6 +679,41 @@ int GetProcessGPUs(uint32_t pid, std::unordered_set<uint64_t>* gpu_set) {
     return kfd_ret;
   }
 
+  // SWDEV-554692: In a container, the PID is container-local and the
+  // KFD sysfs queues directory won't exist (KFD uses host PIDs).
+  // Fall back to discovering GPU IDs from KFD sysfs vram_* files
+  // of any host PID entry, so the process is associated with GPUs.
+  if (gpu_set->empty() && IsInContainer()) {
+    DIR *kfd_proc_dir = opendir(kKFDProcPathRoot);
+    if (kfd_proc_dir) {
+      struct dirent *de;
+      while ((de = readdir(kfd_proc_dir)) != nullptr) {
+        if (de->d_name[0] == '.') continue;
+        std::string entry = de->d_name;
+        bool entry_is_num = true;
+        for (char c : entry) {
+          if (c < '0' || c > '9') { entry_is_num = false; break; }
+        }
+        if (!entry_is_num) continue;
+        std::string host_proc = std::string(kKFDProcPathRoot) + "/" + entry;
+        DIR *pd = opendir(host_proc.c_str());
+        if (pd) {
+          struct dirent *pe;
+          while ((pe = readdir(pd)) != nullptr) {
+            std::string fname = pe->d_name;
+            if (fname.rfind("vram_", 0) == 0) {
+              std::string gpu_id_str = fname.substr(5);
+              try { gpu_set->insert(std::stoull(gpu_id_str)); } catch (...) {}
+            }
+          }
+          closedir(pd);
+        }
+        if (!gpu_set->empty()) break;
+      }
+      closedir(kfd_proc_dir);
+    }
+  }
+
   return 0;
 }
 
@@ -613,6 +755,18 @@ int GetProcessInfoForPID(uint32_t pid, rsmi_process_info_t* proc,
   std::string proc_str_path = std::string(kKFDProcPathRoot) + "/" + std::to_string(pid);
 
   if (!FileExists(proc_str_path.c_str())) {
+    // SWDEV-554692: In a container, the PID is container-local and won't
+    // have a matching KFD sysfs entry (which uses host PIDs). Return
+    // success with zeroed stats - the caller can still get process info
+    // from /proc/<pid>/fdinfo for amdgpu render nodes.
+    if (IsInContainer()) {
+      proc->process_id = pid;
+      proc->vram_usage = 0;
+      proc->sdma_usage = 0;
+      proc->cu_occupancy = 0;
+      proc->evicted_time = 0;
+      return 0;
+    }
     return ESRCH;
   }
   proc->process_id = pid;

--- a/projects/amdsmi/rocm_smi/src/rocm_smi_kfd.cc
+++ b/projects/amdsmi/rocm_smi/src/rocm_smi_kfd.cc
@@ -29,6 +29,7 @@
 #include <unistd.h>
 
 #include <algorithm>
+#include <atomic>
 #include <cassert>
 #include <cstdint>
 #include <cstring>
@@ -49,69 +50,65 @@
 
 namespace amd::smi {
 
+static bool is_number(const std::string& s);
 static const char* kKFDProcPathRoot = "/sys/class/kfd/kfd/proc";
 static const char* kKFDNodesPathRoot = "/sys/class/kfd/kfd/topology/nodes";
-static const char* kKFDContextPrefix = "context_";  // Prefix for secondary KFD contexts
 
-//=============================================================================
-// Container/PID Namespace Detection and Process Scanning
-//=============================================================================
-// In containers with PID namespace isolation, KFD sysfs reports host PIDs
-// which are not visible in the container's /proc. We detect this and fall
-// back to scanning /proc for processes with /dev/kfd open.
-//=============================================================================
+// Detect whether KFD sysfs PIDs are in a different PID namespace from ours.
+// When running inside a container with PID namespace isolation, KFD sysfs
+// reports host PIDs that are not visible in the container's /proc. We detect
+// this by checking whether the first numeric entry under kKFDProcPathRoot
+// corresponds to a process visible in /proc.
+static bool IsKfdPidNamespaced() {
+  static std::atomic<int> cached{-1};
+  int val = cached.load(std::memory_order_acquire);
+  if (val >= 0) return val;
 
-static bool IsInContainer() {
-  static int cached = -1;
-  if (cached >= 0) return cached;
-
-  struct stat st;
-  if (stat("/.dockerenv", &st) == 0) { cached = 1; return true; }
-  if (stat("/run/.containerenv", &st) == 0) { cached = 1; return true; }
-
-  std::ifstream cgroup("/proc/1/cgroup");
-  if (cgroup.is_open()) {
-    std::string line;
-    while (std::getline(cgroup, line)) {
-      if (line.find("docker") != std::string::npos ||
-          line.find("kubepods") != std::string::npos ||
-          line.find("containerd") != std::string::npos ||
-          line.find("lxc") != std::string::npos ||
-          line.find("podman") != std::string::npos) {
-        cached = 1;
-        return true;
-      }
-    }
+  DIR *kfd_dir = opendir(kKFDProcPathRoot);
+  if (!kfd_dir) {
+    cached.store(0, std::memory_order_release);
+    return false;
   }
 
-  cached = 0;
-  return false;
+  bool namespaced = false;
+  struct dirent *de;
+  while ((de = readdir(kfd_dir)) != nullptr) {
+    std::string name(de->d_name);
+    if (!is_number(name)) continue;
+
+    // Found a numeric KFD proc entry; check if this PID exists in /proc
+    std::string proc_path = "/proc/" + name;
+    struct stat st;
+    if (stat(proc_path.c_str(), &st) != 0) {
+      namespaced = true;
+    }
+    break;
+  }
+  closedir(kfd_dir);
+
+  cached.store(namespaced ? 1 : 0, std::memory_order_release);
+  return namespaced;
 }
 
-// Scan /proc for container-local PIDs that have /dev/kfd open.
-static int GetContainerKfdPids(rsmi_process_info_t* procs,
-                               uint32_t num_allocated,
-                               uint32_t* num_found) {
+// Enumerate container-local PIDs that have /dev/kfd open by scanning /proc.
+// Used as a fallback when KFD sysfs PIDs are not visible in this namespace.
+static int ScanProcForKfdPids(rsmi_process_info_t* procs,
+                              uint32_t num_allocated,
+                              uint32_t* num_found) {
   *num_found = 0;
 
   DIR* proc_dir = opendir("/proc");
   if (!proc_dir) return errno;
 
+  const pid_t self = getpid();
   struct dirent* dentry;
-  while ((dentry = readdir(proc_dir)) != nullptr) {
-    if (dentry->d_name[0] < '0' || dentry->d_name[0] > '9') continue;
 
-    std::string pid_str = dentry->d_name;
-    bool is_num = true;
-    for (char c : pid_str) {
-      if (c < '0' || c > '9') { is_num = false; break; }
-    }
-    if (!is_num) continue;
+  while ((dentry = readdir(proc_dir)) != nullptr) {
+    std::string pid_str(dentry->d_name);
+    if (!is_number(pid_str)) continue;
 
     uint32_t pid = static_cast<uint32_t>(std::stoul(pid_str));
-
-    // Skip amd-smi's own process
-    if (pid == static_cast<uint32_t>(getpid())) continue;
+    if (pid == static_cast<uint32_t>(self)) continue;
 
     std::string fd_dir_path = "/proc/" + pid_str + "/fd";
     DIR* fd_dir = opendir(fd_dir_path.c_str());
@@ -122,11 +119,11 @@ static int GetContainerKfdPids(rsmi_process_info_t* procs,
     while ((fd_entry = readdir(fd_dir)) != nullptr) {
       if (fd_entry->d_name[0] == '.') continue;
       std::string fd_link = fd_dir_path + "/" + fd_entry->d_name;
-      char target[256];
+      char target[PATH_MAX];
       ssize_t len = readlink(fd_link.c_str(), target, sizeof(target) - 1);
       if (len > 0) {
         target[len] = '\0';
-        if (std::string(target) == "/dev/kfd") {
+        if (strcmp(target, "/dev/kfd") == 0) {
           has_kfd = true;
           break;
         }
@@ -136,7 +133,7 @@ static int GetContainerKfdPids(rsmi_process_info_t* procs,
 
     if (has_kfd) {
       if (procs && *num_found < num_allocated) {
-        memset(&procs[*num_found], 0, sizeof(procs[*num_found]));
+        procs[*num_found] = {};
         procs[*num_found].process_id = pid;
       }
       ++(*num_found);
@@ -146,6 +143,8 @@ static int GetContainerKfdPids(rsmi_process_info_t* procs,
   closedir(proc_dir);
   return 0;
 }
+
+static const char* kKFDContextPrefix = "context_";  // Prefix for secondary KFD contexts
 
 // KFD Node Property strings
 // static const char *kKFDNodePropCPU_CORES_COUNTStr =    "cpu_cores_count";
@@ -406,11 +405,9 @@ int GetProcessInfo(rsmi_process_info_t* procs, uint32_t num_allocated, uint32_t*
 
   *num_procs_found = 0;
 
-  // SWDEV-554692: In containers with PID namespace isolation, KFD sysfs
-  // reports host PIDs that are not visible in the container's /proc.
-  // Detect this case and enumerate KFD processes by scanning /proc instead.
-  if (IsInContainer()) {
-    return GetContainerKfdPids(procs, num_allocated, num_procs_found);
+  // In a PID namespace, KFD sysfs PIDs are not local; scan /proc instead.
+  if (IsKfdPidNamespaced()) {
+    return ScanProcForKfdPids(procs, num_allocated, num_procs_found);
   }
 
   errno = 0;
@@ -514,9 +511,8 @@ int GetKfdGpuIdsForPid(long pid, std::unordered_set<uint64_t>* out) {
   DIR* d = opendir(pdir.c_str());
 
   if (!d) {
-    // SWDEV-554692: In a container, the PID is container-local and won't
-    // have a KFD sysfs entry. Return empty set without error.
-    if (IsInContainer()) {
+    // PID namespace: container-local PID has no KFD sysfs entry.
+    if (IsKfdPidNamespaced()) {
       return 0;
     }
     perror(("Unable to open KFD process directory for process " + std::to_string(pid)).c_str());
@@ -679,22 +675,17 @@ int GetProcessGPUs(uint32_t pid, std::unordered_set<uint64_t>* gpu_set) {
     return kfd_ret;
   }
 
-  // SWDEV-554692: In a container, the PID is container-local and the
-  // KFD sysfs queues directory won't exist (KFD uses host PIDs).
-  // Fall back to discovering GPU IDs from KFD sysfs vram_* files
-  // of any host PID entry, so the process is associated with GPUs.
-  if (gpu_set->empty() && IsInContainer()) {
+  // PID namespace: fall back to discovering GPU IDs from KFD vram_* files.
+  // NOTE: Uses the first host-PID KFD entry found; assumes all container
+  // processes share the same GPU set (valid for typical container deployments).
+  if (gpu_set->empty() && IsKfdPidNamespaced()) {
     DIR *kfd_proc_dir = opendir(kKFDProcPathRoot);
     if (kfd_proc_dir) {
       struct dirent *de;
       while ((de = readdir(kfd_proc_dir)) != nullptr) {
         if (de->d_name[0] == '.') continue;
         std::string entry = de->d_name;
-        bool entry_is_num = true;
-        for (char c : entry) {
-          if (c < '0' || c > '9') { entry_is_num = false; break; }
-        }
-        if (!entry_is_num) continue;
+        if (!is_number(entry)) continue;
         std::string host_proc = std::string(kKFDProcPathRoot) + "/" + entry;
         DIR *pd = opendir(host_proc.c_str());
         if (pd) {
@@ -755,11 +746,8 @@ int GetProcessInfoForPID(uint32_t pid, rsmi_process_info_t* proc,
   std::string proc_str_path = std::string(kKFDProcPathRoot) + "/" + std::to_string(pid);
 
   if (!FileExists(proc_str_path.c_str())) {
-    // SWDEV-554692: In a container, the PID is container-local and won't
-    // have a matching KFD sysfs entry (which uses host PIDs). Return
-    // success with zeroed stats - the caller can still get process info
-    // from /proc/<pid>/fdinfo for amdgpu render nodes.
-    if (IsInContainer()) {
+    // PID namespace: no KFD sysfs entry for this PID; return zeroed stats.
+    if (IsKfdPidNamespaced()) {
       proc->process_id = pid;
       proc->vram_usage = 0;
       proc->sdma_usage = 0;

--- a/projects/amdsmi/rocm_smi/src/rocm_smi_kfd.cc
+++ b/projects/amdsmi/rocm_smi/src/rocm_smi_kfd.cc
@@ -29,9 +29,9 @@
 #include <unistd.h>
 
 #include <algorithm>
-#include <cctype>
 #include <atomic>
 #include <cassert>
+#include <cctype>
 #include <cstdint>
 #include <cstring>
 #include <fstream>
@@ -65,14 +65,14 @@ static bool IsKfdPidNamespaced() {
   int val = cached.load(std::memory_order_acquire);
   if (val >= 0) return val;
 
-  DIR *kfd_dir = opendir(kKFDProcPathRoot);
+  DIR* kfd_dir = opendir(kKFDProcPathRoot);
   if (!kfd_dir) {
     cached.store(0, std::memory_order_release);
     return false;
   }
 
   bool namespaced = false;
-  struct dirent *de;
+  struct dirent* de;
   while ((de = readdir(kfd_dir)) != nullptr) {
     std::string name(de->d_name);
     if (!is_number(name)) continue;
@@ -684,15 +684,15 @@ int GetProcessGPUs(uint32_t pid, std::unordered_set<uint64_t>* gpu_set) {
   // NOTE: Uses the first host-PID KFD entry found; assumes all container
   // processes share the same GPU set (valid for typical container deployments).
   if (gpu_set->empty() && IsKfdPidNamespaced()) {
-    DIR *kfd_proc_dir = opendir(kKFDProcPathRoot);
+    DIR* kfd_proc_dir = opendir(kKFDProcPathRoot);
     if (kfd_proc_dir) {
-      struct dirent *de;
+      struct dirent* de;
       while ((de = readdir(kfd_proc_dir)) != nullptr) {
         if (de->d_name[0] == '.') continue;
         std::string entry = de->d_name;
         if (!is_number(entry)) continue;
         std::string host_proc = std::string(kKFDProcPathRoot) + "/" + entry;
-        DIR *pd = opendir(host_proc.c_str());
+        DIR* pd = opendir(host_proc.c_str());
         if (pd) {
           struct dirent *pe;
           while ((pe = readdir(pd)) != nullptr) {

--- a/projects/amdsmi/rocm_smi/src/rocm_smi_kfd.cc
+++ b/projects/amdsmi/rocm_smi/src/rocm_smi_kfd.cc
@@ -513,7 +513,7 @@ int GetKfdGpuIdsForPid(long pid, std::unordered_set<uint64_t>* out) {
 
   if (!d) {
     
-    //Return success with empty set so 'GetProcessGPUs()' can use 'vram_*' fallback.
+    // Return success with empty set so 'GetProcessGPUs()' can use 'vram_*' fallback.
     if (IsKfdPidNamespaced()) {
       return 0;
     }

--- a/projects/amdsmi/rocm_smi/src/rocm_smi_kfd.cc
+++ b/projects/amdsmi/rocm_smi/src/rocm_smi_kfd.cc
@@ -29,6 +29,7 @@
 #include <unistd.h>
 
 #include <algorithm>
+#include <cctype>
 #include <atomic>
 #include <cassert>
 #include <cstdint>
@@ -145,6 +146,7 @@ static int ScanProcForKfdPids(rsmi_process_info_t* procs,
 }
 
 static const char* kKFDContextPrefix = "context_";  // Prefix for secondary KFD contexts
+static const char* kKFDVramPrefix = "vram_";
 
 // KFD Node Property strings
 // static const char *kKFDNodePropCPU_CORES_COUNTStr =    "cpu_cores_count";
@@ -511,7 +513,10 @@ int GetKfdGpuIdsForPid(long pid, std::unordered_set<uint64_t>* out) {
   DIR* d = opendir(pdir.c_str());
 
   if (!d) {
-    // PID namespace: container-local PID has no KFD sysfs entry.
+    /*
+   * Return success with empty set so 'GetProcessGPUs()' can use 'vram_*'
+   * fallback.
+   */
     if (IsKfdPidNamespaced()) {
       return 0;
     }
@@ -693,8 +698,12 @@ int GetProcessGPUs(uint32_t pid, std::unordered_set<uint64_t>* gpu_set) {
           while ((pe = readdir(pd)) != nullptr) {
             std::string fname = pe->d_name;
             if (fname.rfind("vram_", 0) == 0) {
-              std::string gpu_id_str = fname.substr(5);
-              try { gpu_set->insert(std::stoull(gpu_id_str)); } catch (...) {}
+              std::string gpu_id_str = fname.substr(strlen(kKFDVramPrefix));
+              if (!gpu_id_str.empty() &&
+                  std::all_of(gpu_id_str.begin(), gpu_id_str.end(),
+                              [](unsigned char ch) { return std::isdigit(ch); })) {
+                gpu_set->insert(std::stoull(gpu_id_str));
+              }
             }
           }
           closedir(pd);
@@ -751,7 +760,7 @@ int GetProcessInfoForPID(uint32_t pid, rsmi_process_info_t* proc,
       proc->process_id = pid;
       proc->vram_usage = 0;
       proc->sdma_usage = 0;
-      proc->cu_occupancy = 0;
+      proc->cu_occupancy = std::numeric_limits<uint32_t>::max();
       proc->evicted_time = 0;
       return 0;
     }

--- a/projects/amdsmi/rocm_smi/src/rocm_smi_kfd.cc
+++ b/projects/amdsmi/rocm_smi/src/rocm_smi_kfd.cc
@@ -56,13 +56,13 @@ static const char* kKFDProcPathRoot = "/sys/class/kfd/kfd/proc";
 static const char* kKFDNodesPathRoot = "/sys/class/kfd/kfd/topology/nodes";
 
 // Check whether a given PID has /dev/kfd open by scanning its fd links.
-static bool PidHasKfdOpen(const std::string &pid_str) {
+static bool PidHasKfdOpen(const std::string& pid_str) {
   std::string fd_dir_path = "/proc/" + pid_str + "/fd";
-  DIR *fd_dir = opendir(fd_dir_path.c_str());
+  DIR* fd_dir = opendir(fd_dir_path.c_str());
   if (!fd_dir) return false;
 
   bool found = false;
-  struct dirent *fd_entry;
+  struct dirent* fd_entry;
   while ((fd_entry = readdir(fd_dir)) != nullptr) {
     if (fd_entry->d_name[0] == '.') continue;
     std::string fd_link = fd_dir_path + "/" + fd_entry->d_name;
@@ -83,10 +83,15 @@ static bool PidHasKfdOpen(const std::string &pid_str) {
 // Detect whether KFD sysfs PIDs are in a different PID namespace from ours.
 // When running inside a container with PID namespace isolation, KFD sysfs
 // reports host PIDs that are not visible in the container's /proc. We detect
-// this by checking whether the first numeric entry under kKFDProcPathRoot
-// corresponds to a process visible in /proc that also has /dev/kfd open.
-// A mere PID existence check is insufficient because a different process in
-// the container's namespace could coincidentally share the same PID number.
+// this by checking numeric entries under kKFDProcPathRoot against /proc.
+// For each KFD PID we check three cases:
+//   1. PID exists in /proc AND has /dev/kfd open → same namespace (not namespaced).
+//   2. PID exists in /proc but does NOT have /dev/kfd open → different namespace.
+//   3. PID does NOT exist in /proc → inconclusive (process may have exited);
+//      skip to the next entry to avoid a false positive from a short-lived process.
+// If all KFD entries are inconclusive (all exited), we conservatively assume
+// we are not namespaced (the KFD entries will be cleaned up shortly anyway).
+// Result is cached for the lifetime of the process; PID namespace is assumed stable.
 static bool IsKfdPidNamespaced() {
   static std::atomic<int> cached{-1};
   int val = cached.load(std::memory_order_acquire);
@@ -99,23 +104,35 @@ static bool IsKfdPidNamespaced() {
   }
 
   bool namespaced = false;
+  bool determined = false;
   struct dirent* de;
   while ((de = readdir(kfd_dir)) != nullptr) {
     std::string name(de->d_name);
     if (!is_number(name)) continue;
 
-    // Found a numeric KFD proc entry; verify the PID both exists in /proc
-    // and actually has /dev/kfd open. If the PID doesn't exist at all, or
-    // exists but belongs to a different process (no /dev/kfd fd), we are
-    // in a different PID namespace.
     std::string proc_path = "/proc/" + name;
     struct stat st;
-    if (stat(proc_path.c_str(), &st) != 0 || !PidHasKfdOpen(name)) {
+    if (stat(proc_path.c_str(), &st) != 0) {
+      // PID not in /proc — could be a short-lived process that already exited.
+      // Skip to the next KFD entry to avoid a false positive race condition.
+      continue;
+    }
+    // PID exists in /proc; check whether the same process has /dev/kfd open.
+    // If it does, we share the same PID namespace. If not, a different
+    // container-local process coincidentally has the same PID number.
+    if (!PidHasKfdOpen(name)) {
       namespaced = true;
     }
+    determined = true;
     break;
   }
   closedir(kfd_dir);
+
+  // If every KFD entry was inconclusive (all processes exited), conservatively
+  // assume we are not namespaced — the stale KFD entries will be reaped soon.
+  if (!determined) {
+    namespaced = false;
+  }
 
   cached.store(namespaced ? 1 : 0, std::memory_order_release);
   return namespaced;
@@ -137,7 +154,7 @@ static int ScanProcForKfdPids(rsmi_process_info_t* procs, uint32_t num_allocated
     std::string pid_str(dentry->d_name);
     if (!is_number(pid_str)) continue;
 
-    uint32_t pid = static_cast<uint32_t>(std::stoul(pid_str));
+    uint32_t pid = static_cast<uint32_t>(strtoul(pid_str.c_str(), nullptr, 10));
     if (pid == static_cast<uint32_t>(self)) continue;
 
     if (PidHasKfdOpen(pid_str)) {
@@ -521,7 +538,6 @@ int GetKfdGpuIdsForPid(long pid, std::unordered_set<uint64_t>* out) {
   DIR* d = opendir(pdir.c_str());
 
   if (!d) {
-    
     // Return success with empty set so 'GetProcessGPUs()' can use 'vram_*' fallback.
     if (IsKfdPidNamespaced()) {
       return 0;
@@ -689,7 +705,12 @@ int GetProcessGPUs(uint32_t pid, std::unordered_set<uint64_t>* gpu_set) {
   // PID namespace: fall back to discovering GPU IDs from KFD vram_* files.
   // NOTE: Uses the first host-PID KFD entry found; assumes all container
   // processes share the same GPU set (valid for typical container deployments).
+  // This assumption may not hold in multi-tenant GPU partitioning scenarios.
   if (gpu_set->empty() && IsKfdPidNamespaced()) {
+    std::stringstream ss;
+    ss << __PRETTY_FUNCTION__ << " | PID namespace detected, falling back to "
+       << "KFD vram_* files for GPU discovery (pid=" << pid << ")";
+    LOG_DEBUG(ss);
     DIR* kfd_proc_dir = opendir(kKFDProcPathRoot);
     if (kfd_proc_dir) {
       struct dirent* de;

--- a/projects/amdsmi/rocm_smi/src/rocm_smi_kfd.cc
+++ b/projects/amdsmi/rocm_smi/src/rocm_smi_kfd.cc
@@ -729,7 +729,7 @@ int GetProcessGPUs(uint32_t pid, std::unordered_set<uint64_t>* gpu_set) {
               if (!gpu_id_str.empty() &&
                   std::all_of(gpu_id_str.begin(), gpu_id_str.end(),
                               [](unsigned char ch) { return std::isdigit(ch); })) {
-                gpu_set->insert(std::stoull(gpu_id_str));
+                gpu_set->insert(strtoull(gpu_id_str.c_str(), nullptr, 10));
               }
             }
           }

--- a/projects/amdsmi/rocm_smi/src/rocm_smi_kfd.cc
+++ b/projects/amdsmi/rocm_smi/src/rocm_smi_kfd.cc
@@ -512,10 +512,8 @@ int GetKfdGpuIdsForPid(long pid, std::unordered_set<uint64_t>* out) {
   DIR* d = opendir(pdir.c_str());
 
   if (!d) {
-  /*
-   * Return success with empty set so 'GetProcessGPUs()' can use 'vram_*'
-   * fallback.
-   */
+    
+    //Return success with empty set so 'GetProcessGPUs()' can use 'vram_*' fallback.
     if (IsKfdPidNamespaced()) {
       return 0;
     }

--- a/projects/amdsmi/rocm_smi/src/rocm_smi_kfd.cc
+++ b/projects/amdsmi/rocm_smi/src/rocm_smi_kfd.cc
@@ -782,13 +782,14 @@ int GetProcessInfoForPID(uint32_t pid, rsmi_process_info_t* proc,
   std::string proc_str_path = std::string(kKFDProcPathRoot) + "/" + std::to_string(pid);
 
   if (!FileExists(proc_str_path.c_str())) {
-    // PID namespace: no KFD sysfs entry for this PID; return zeroed stats.
+    // PID namespace: no KFD sysfs entry for this PID; return sentinel
+    // values so callers can distinguish "unavailable" from "zero usage".
     if (IsKfdPidNamespaced()) {
       proc->process_id = pid;
-      proc->vram_usage = 0;
-      proc->sdma_usage = 0;
+      proc->vram_usage = std::numeric_limits<uint64_t>::max();
+      proc->sdma_usage = std::numeric_limits<uint64_t>::max();
       proc->cu_occupancy = std::numeric_limits<uint32_t>::max();
-      proc->evicted_time = 0;
+      proc->evicted_time = std::numeric_limits<uint32_t>::max();
       return 0;
     }
     return ESRCH;

--- a/projects/amdsmi/rocm_smi/src/rocm_smi_kfd.cc
+++ b/projects/amdsmi/rocm_smi/src/rocm_smi_kfd.cc
@@ -512,7 +512,7 @@ int GetKfdGpuIdsForPid(long pid, std::unordered_set<uint64_t>* out) {
   DIR* d = opendir(pdir.c_str());
 
   if (!d) {
-    /*
+  /*
    * Return success with empty set so 'GetProcessGPUs()' can use 'vram_*'
    * fallback.
    */

--- a/projects/amdsmi/rocm_smi/src/rocm_smi_kfd.cc
+++ b/projects/amdsmi/rocm_smi/src/rocm_smi_kfd.cc
@@ -36,6 +36,7 @@
 #include <cstring>
 #include <fstream>
 #include <iostream>
+#include <limits>
 #include <sstream>
 #include <string>
 #include <unordered_set>
@@ -171,7 +172,6 @@ static int ScanProcForKfdPids(rsmi_process_info_t* procs, uint32_t num_allocated
 }
 
 static const char* kKFDContextPrefix = "context_";  // Prefix for secondary KFD contexts
-static const char* kKFDVramPrefix = "vram_";
 
 // KFD Node Property strings
 // static const char *kKFDNodePropCPU_CORES_COUNTStr =    "cpu_cores_count";
@@ -707,7 +707,7 @@ int GetProcessGPUs(uint32_t pid, std::unordered_set<uint64_t>* gpu_set) {
   // processes share the same GPU set (valid for typical container deployments).
   // This assumption may not hold in multi-tenant GPU partitioning scenarios.
   if (gpu_set->empty() && IsKfdPidNamespaced()) {
-    std::stringstream ss;
+    std::ostringstream ss;
     ss << __PRETTY_FUNCTION__ << " | PID namespace detected, falling back to "
        << "KFD vram_* files for GPU discovery (pid=" << pid << ")";
     LOG_DEBUG(ss);

--- a/projects/amdsmi/rocm_smi/src/rocm_smi_kfd.cc
+++ b/projects/amdsmi/rocm_smi/src/rocm_smi_kfd.cc
@@ -55,11 +55,38 @@ static bool is_number(const std::string& s);
 static const char* kKFDProcPathRoot = "/sys/class/kfd/kfd/proc";
 static const char* kKFDNodesPathRoot = "/sys/class/kfd/kfd/topology/nodes";
 
+// Check whether a given PID has /dev/kfd open by scanning its fd links.
+static bool PidHasKfdOpen(const std::string &pid_str) {
+  std::string fd_dir_path = "/proc/" + pid_str + "/fd";
+  DIR *fd_dir = opendir(fd_dir_path.c_str());
+  if (!fd_dir) return false;
+
+  bool found = false;
+  struct dirent *fd_entry;
+  while ((fd_entry = readdir(fd_dir)) != nullptr) {
+    if (fd_entry->d_name[0] == '.') continue;
+    std::string fd_link = fd_dir_path + "/" + fd_entry->d_name;
+    char target[PATH_MAX];
+    ssize_t len = readlink(fd_link.c_str(), target, sizeof(target) - 1);
+    if (len > 0) {
+      target[len] = '\0';
+      if (strcmp(target, "/dev/kfd") == 0) {
+        found = true;
+        break;
+      }
+    }
+  }
+  closedir(fd_dir);
+  return found;
+}
+
 // Detect whether KFD sysfs PIDs are in a different PID namespace from ours.
 // When running inside a container with PID namespace isolation, KFD sysfs
 // reports host PIDs that are not visible in the container's /proc. We detect
 // this by checking whether the first numeric entry under kKFDProcPathRoot
-// corresponds to a process visible in /proc.
+// corresponds to a process visible in /proc that also has /dev/kfd open.
+// A mere PID existence check is insufficient because a different process in
+// the container's namespace could coincidentally share the same PID number.
 static bool IsKfdPidNamespaced() {
   static std::atomic<int> cached{-1};
   int val = cached.load(std::memory_order_acquire);
@@ -77,10 +104,13 @@ static bool IsKfdPidNamespaced() {
     std::string name(de->d_name);
     if (!is_number(name)) continue;
 
-    // Found a numeric KFD proc entry; check if this PID exists in /proc
+    // Found a numeric KFD proc entry; verify the PID both exists in /proc
+    // and actually has /dev/kfd open. If the PID doesn't exist at all, or
+    // exists but belongs to a different process (no /dev/kfd fd), we are
+    // in a different PID namespace.
     std::string proc_path = "/proc/" + name;
     struct stat st;
-    if (stat(proc_path.c_str(), &st) != 0) {
+    if (stat(proc_path.c_str(), &st) != 0 || !PidHasKfdOpen(name)) {
       namespaced = true;
     }
     break;
@@ -110,28 +140,7 @@ static int ScanProcForKfdPids(rsmi_process_info_t* procs, uint32_t num_allocated
     uint32_t pid = static_cast<uint32_t>(std::stoul(pid_str));
     if (pid == static_cast<uint32_t>(self)) continue;
 
-    std::string fd_dir_path = "/proc/" + pid_str + "/fd";
-    DIR* fd_dir = opendir(fd_dir_path.c_str());
-    if (!fd_dir) continue;
-
-    bool has_kfd = false;
-    struct dirent* fd_entry;
-    while ((fd_entry = readdir(fd_dir)) != nullptr) {
-      if (fd_entry->d_name[0] == '.') continue;
-      std::string fd_link = fd_dir_path + "/" + fd_entry->d_name;
-      char target[PATH_MAX];
-      ssize_t len = readlink(fd_link.c_str(), target, sizeof(target) - 1);
-      if (len > 0) {
-        target[len] = '\0';
-        if (strcmp(target, "/dev/kfd") == 0) {
-          has_kfd = true;
-          break;
-        }
-      }
-    }
-    closedir(fd_dir);
-
-    if (has_kfd) {
+    if (PidHasKfdOpen(pid_str)) {
       if (procs && *num_found < num_allocated) {
         procs[*num_found] = {};
         procs[*num_found].process_id = pid;

--- a/projects/amdsmi/rocm_smi/src/rocm_smi_kfd.cc
+++ b/projects/amdsmi/rocm_smi/src/rocm_smi_kfd.cc
@@ -93,8 +93,7 @@ static bool IsKfdPidNamespaced() {
 
 // Enumerate container-local PIDs that have /dev/kfd open by scanning /proc.
 // Used as a fallback when KFD sysfs PIDs are not visible in this namespace.
-static int ScanProcForKfdPids(rsmi_process_info_t* procs,
-                              uint32_t num_allocated,
+static int ScanProcForKfdPids(rsmi_process_info_t* procs, uint32_t num_allocated,
                               uint32_t* num_found) {
   *num_found = 0;
 
@@ -694,7 +693,7 @@ int GetProcessGPUs(uint32_t pid, std::unordered_set<uint64_t>* gpu_set) {
         std::string host_proc = std::string(kKFDProcPathRoot) + "/" + entry;
         DIR* pd = opendir(host_proc.c_str());
         if (pd) {
-          struct dirent *pe;
+          struct dirent* pe;
           while ((pe = readdir(pd)) != nullptr) {
             std::string fname = pe->d_name;
             if (fname.rfind("vram_", 0) == 0) {


### PR DESCRIPTION
## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->
When running amd-smi inside a Docker container with PID namespace isolation, KFD sysfs (/sys/class/kfd/kfd/proc/)
  reports host PIDs that are not visible in the container's /proc. This causes amd-smi process to fail to detect any
  running GPU processes inside the container.

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->
 - Added IsKfdPidNamespaced() to detect PID namespace mismatch by checking whether the first numeric KFD sysfs PID
   entry exists in /proc. Uses std::atomic<int> with acquire/release ordering for thread-safe caching.
  - Added ScanProcForKfdPids() as a fallback that enumerates container-local PIDs by scanning /proc/<pid>/fd/ for
  /dev/kfd file descriptors.
  - Modified GetProcessInfo() to use ScanProcForKfdPids() when PID namespace mismatch is detected.
  - Modified GetKfdGpuIdsForPid() to return empty set without error when container-local PID has no KFD sysfs entry.
  - Modified GetProcessGPUs() to fall back to discovering GPU IDs from KFD vram_* files when the gpu set is empty in a
  PID namespace.
  - Modified GetProcessInfoForPID() to return zeroed stats instead of ESRCH when KFD sysfs entry doesn't exist for a
  container-local PID.

## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->
[ROCM-10662]

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->
1. Set system to CPX partition mode (amd-smi set -C CPX).
  2. Launched Docker container with --device=/dev/kfd --device=/dev/dri and /sys/class/kfd mounted read-only.
  3. Built amdsmi from source inside the container.
  4. Test 1 — No GPU workload: Ran amd-smi process with no GPU processes active.
  5. Test 2 — With /dev/kfd open: Opened /dev/kfd from a Python process inside the container, then ran amd-smi process.

## Test Result

<!-- Briefly summarize test outcomes. -->
  - Test 1: All 8 GPUs correctly report "No running processes detected".
  - Test 2: Container-local PID 1537 correctly detected and reported across all 8 GPUs with zeroed memory/usage stats
  (expected since no actual GPU workload was submitted).

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.


[ROCM-10662]: https://amd-hub.atlassian.net/browse/ROCM-10662?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ