### PR TITLE
Switch RCCL auto-label from full regression to smoke

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -102,7 +102,7 @@
 - changed-files:
   - any-glob-to-any-file: 'shared/amdgpu-windows-interop/**/*'
 
-"ci: regression-detection":
+"ci: regression-detection-smoke":
 - changed-files:
   - any-glob-to-any-file: 'projects/rccl/**/*'
 

--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -28,6 +28,9 @@
 - name: ci:debug
   color: 73CAF8
   description: ''
+- name: ci: regression-detection-smoke
+  color: 13E349
+  description: Add rccl-regression smoke test to the PR.
 - name: ci:docs-only
   color: 24D116
   description: Docs only changes


### PR DESCRIPTION
  ## Summary
  - Update `.github/labeler.yml` so RCCL file changes auto-apply `ci: regression-detection-smoke` instead of `ci: regression-detection`.
  - Add `ci: regression-detection-smoke` to `.github/labels.yml` so the label is managed by repo label config.
  - This keeps RCCL PR auto-labeling enabled while shifting CI intent toward smoke runs.
  ## Test plan
  - [ ] Open or update an RCCL PR touching `projects/rccl/**/*`.
  - [ ] Confirm `ci: regression-detection-smoke` is auto-applied.
  - [ ] Confirm `ci: regression-detection` is no longer auto-applied by labeler rules.
  - [ ] (Optional) Run `Apply Labels` workflow to sync label definitions if needed.