### PR TITLE
Revert "memory: fix "contiguous_bytes" calculation in generic conversion"

### DIFF
--- a/projects/rocdbgapi/src/memory.cpp
+++ b/projects/rocdbgapi/src/memory.cpp
@@ -476,25 +476,8 @@ generic_address_space_t::convert (
   if (*generic_address == null_address ())
     return { null_address (), 0 };
 
-  amd_dbgapi_size_t contiguous_bytes;
-  auto kind = lowered_address_space.kind ();
-  if (kind == kind_t::private_swizzled
-      || kind == kind_t::private_unswizzled)
-    {
-      auto [scratch_base, scratch_size] = wave.scratch_memory_region ();
-
-      if (kind == kind_t::private_swizzled)
-        scratch_size /= wave.lane_count ();
-
-      contiguous_bytes = scratch_size - lowered_address;
-    }
-  else if (kind == kind_t::global)
-    contiguous_bytes
-      = lowered_address_space.last_address () - lowered_address + 1;
-  else
-    dbgapi_assert_not_reached ("unsupported address space for generic.");
-
-  return { *generic_address, contiguous_bytes };
+  return { *generic_address,
+           lowered_address_space.last_address () - lowered_address + 1 };
 }
 
 std::pair<const address_space_t &, amd_dbgapi_segment_address_t>


### PR DESCRIPTION
Reverts ROCm/rocm-systems#3285

PR #3285 contains a bug in the code change where it relies on a variable that is commented out, leading to a build failure.

A fix was proposed here: https://github.com/ROCm/rocm-systems/pull/3750/changes

But a revert provides more time to make sure the original changes pass validation before another merge attempt.