### PR TITLE
[RCCL] Tune message thresholds and nchannels for PAT algorithm

### DIFF
--- a/projects/rccl/src/enqueue.cc
+++ b/projects/rccl/src/enqueue.cc
@@ -2112,6 +2112,7 @@ static void initCollCostTable(float** collCostTable) {
 static ncclResult_t updateCollCostTable(
     struct ncclComm* comm, struct ncclTaskColl* info, size_t nBytes,
     int collNetSupport, int nvlsSupport, int numPipeOps,
+    int userAlgoInput,
     float** collCostTable) {
   float (*table)[NCCL_NUM_PROTOCOLS] = (float (*)[NCCL_NUM_PROTOCOLS])collCostTable;
 
@@ -2132,8 +2133,7 @@ static ncclResult_t updateCollCostTable(
     if (a == NCCL_ALGO_PAT && info->func == ncclFuncReduceScatter
         && (info->opDev.op == ncclDevPreMulSum || info->opDev.op == ncclDevSumPostDiv)) continue;
     if (a == NCCL_ALGO_PAT && (info->func == ncclFuncReduceScatter || info->func == ncclFuncAllGather)) {
-      static const char* algoEnv = ncclGetEnv("NCCL_ALGO");
-      if (!algoEnv) {
+      if (!userAlgoInput) {
         int nNodes = comm->nNodes;
         bool inRange = false;
         if (nNodes <= 4) {
@@ -2373,8 +2373,14 @@ rccl_static ncclResult_t getAlgoInfo(
   info->protocol = NCCL_PROTO_UNDEF;
   int nMaxChannels = 0;
   float collCostTable[NCCL_NUM_ALGORITHMS][NCCL_NUM_PROTOCOLS];
+
+  static int userAlgoInput = -2;
+  if (userAlgoInput == -2) {
+    const char* algoEnv = ncclGetEnv("NCCL_ALGO");
+    userAlgoInput = !algoEnv ? 0 : 1;
+  }
   initCollCostTable((float **)collCostTable);
-  NCCLCHECK(updateCollCostTable(comm, info, nBytes, collNetSupport, nvlsSupport, numPipeOps, (float **)collCostTable));
+  NCCLCHECK(updateCollCostTable(comm, info, nBytes, collNetSupport, nvlsSupport, numPipeOps, userAlgoInput, (float **)collCostTable));
   if (comm->tuner != NULL) {
     NCCLCHECK(ncclRegFind(comm, info->sendbuff, sendbuffSize, &regSendBuf));
     NCCLCHECK(ncclRegFind(comm, info->recvbuff, recvbuffSize, &regRecvBuf));
@@ -2389,16 +2395,13 @@ rccl_static ncclResult_t getAlgoInfo(
   } else {
     NCCLCHECK(topoGetAlgoInfo(comm, info, nBytes, (float **)collCostTable, simInfo));
     //override algo, tree doesn't work with fewer than 64 bytes
-    static int userAlgoInput = -2;
-    const char *algoStr = getenv("NCCL_ALGO");
-    userAlgoInput = !algoStr ? 0 : 1;
     size_t sizePerRank = rcclGetSizePerRank(info->func, nBytes, comm->nRanks);
     if (!userAlgoInput && IsArchMatch(comm->topo->nodes[GPU].nodes[0].gpu.gcn, "gfx950") && comm->nNodes == 1 && (info->func == ncclFuncAllReduce) && sizePerRank >= 64 && sizePerRank <= 262144){
       info->algorithm = NCCL_ALGO_TREE;
       info->protocol = NCCL_PROTO_LL;
     }
     // NCCL_CTA_POLICY_EFFICIENCY requires user (non-symmetric) buffer registration (currently unsupported with MNNVL)
-    if (comm->config.CTAPolicy == NCCL_CTA_POLICY_EFFICIENCY && ncclGetEnv("NCCL_ALGO") == NULL && ncclGetEnv("NCCL_PROTO") == NULL && !comm->MNNVL) {
+    if (comm->config.CTAPolicy == NCCL_CTA_POLICY_EFFICIENCY && !userAlgoInput && ncclGetEnv("NCCL_PROTO") == NULL && !comm->MNNVL) {
       // make algorithm selection based on buffer registration
       // there can be other specialized policies for algorithms and protocols pickup in the future
       NCCLCHECK(ncclRegFind(comm, info->sendbuff, sendbuffSize, &regSendBuf));

--- a/projects/rccl/src/enqueue.cc
+++ b/projects/rccl/src/enqueue.cc
@@ -2131,6 +2131,21 @@ static ncclResult_t updateCollCostTable(
     /* Tree reduceScatter doesn't support scaling yet */
     if (a == NCCL_ALGO_PAT && info->func == ncclFuncReduceScatter
         && (info->opDev.op == ncclDevPreMulSum || info->opDev.op == ncclDevSumPostDiv)) continue;
+    if (a == NCCL_ALGO_PAT && (info->func == ncclFuncReduceScatter || info->func == ncclFuncAllGather)) {
+      static const char* algoEnv = ncclGetEnv("NCCL_ALGO");
+      if (!algoEnv) {
+        int nNodes = comm->nNodes;
+        bool inRange = false;
+        if (nNodes <= 4) {
+          inRange = (nBytes >= (512 << 10) && nBytes <= (2 << 20));
+        } else if (nNodes <= 8) {
+          inRange = (nBytes >= (32 << 10) && nBytes <= (4 << 20));
+        } else {
+          inRange = (nBytes <= (32 << 20));
+        }
+        if (!inRange) continue;
+      }
+    }
     for (int p=0; p<NCCL_NUM_PROTOCOLS; p++) {
       if (p == NCCL_PROTO_LL128 && !(comm->topo->type & RCCL_TOPO_XGMI_ALL)) {
         table[a][p] = NCCL_ALGO_PROTO_IGNORE;
@@ -2241,6 +2256,17 @@ static ncclResult_t topoGetAlgoInfo(
       nc = std::min(comm->nvlsChannels, comm->nChannels);
     } else {
       nc = comm->nvlsChannels;
+    }
+  } else if (info->algorithm == NCCL_ALGO_PAT) {
+    nc = (nBytes <= (32 << 10)) ? 1 : (nBytes <= (64 << 10)) ? 2 : (nBytes <= (1 << 20)) ? 4 : comm->nChannels;
+
+    int minNChannels = ncclParamMinNchannels();
+    int maxNChannels = ncclParamMaxNchannels();
+    if (minNChannels > 0) {
+      nc = std::max(minNChannels, nc);
+    }
+    if (maxNChannels > 0) {
+      nc = std::min(maxNChannels, nc);
     }
   } else {
     rcclUpdateThreadThreshold(comm, nBytes, info, threadThreshold);

--- a/projects/rccl/src/rccl_wrap.cc
+++ b/projects/rccl/src/rccl_wrap.cc
@@ -205,6 +205,11 @@ ncclResult_t rcclOverrideChannels(struct ncclComm* comm, ncclFunc_t coll, size_t
     return ncclSuccess;
   }
 
+  if (comm->nRanks == comm->nNodes) {
+    INFO(NCCL_TUNING, "RCCL tunning model channel thresholds not applied for single GPU per node case");
+    return ncclSuccess;
+  }
+
   auto tunableIndex = rcclGetTunableIndex(coll);
   if(tunableIndex == RCCL_UNSUPPORTED_TUNABLE){
     INFO(NCCL_TUNING, "tunableIndex:%i not supported", tunableIndex);

--- a/projects/rccl/src/rccl_wrap.cc
+++ b/projects/rccl/src/rccl_wrap.cc
@@ -206,7 +206,7 @@ ncclResult_t rcclOverrideChannels(struct ncclComm* comm, ncclFunc_t coll, size_t
   }
 
   if (comm->nRanks == comm->nNodes) {
-    INFO(NCCL_TUNING, "RCCL tunning model channel thresholds not applied for single GPU per node case");
+    INFO(NCCL_TUNING, "RCCL tuning model channel thresholds not applied for single GPU per node case");
     return ncclSuccess;
   }
 


### PR DESCRIPTION
## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->
In tuning_model_6 (gfx950), enabling PAT for ReduceScatter and AllGather has no message size thresholds. The tuning model selects PAT for messages up to 1GB, well beyond the range where it is competitive. This PR tune the message threshold and channel count of PAT algorithm.

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->
1. Add message size thresholds based on number of nodes:

- <= 4 nodes: 512KB - 2MB
- <= 8 nodes: 32KB - 4MB
- \> 8 nodes: up to 32MB

If the user explicitly sets NCCL_ALGO=PAT, the thresholds are bypassed and PAT is used for all message sizes.

3. Add PAT specific channel tuning:
   - <= 32KB: 1 channel
   - <= 64KB: 2 channels
   - <= 1MB: 4 channels
   - \> 1MB: 8 channels
## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->
Resolves AICOMRCCL-572
## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
