### PR TITLE
[RCCL][Tuner Plugin] Enable tuning of RCCL tuning constants

### DIFF
--- a/projects/rccl/ext-tuner/example/nccl/tuner.h
+++ b/projects/rccl/ext-tuner/example/nccl/tuner.h
@@ -75,8 +75,8 @@ typedef struct {
   double perChMaxRingLL128Bws [NCCL_NUM_COMPCAPS][NCCL_NUM_TUNING_SCALES];
   double perChMaxTreeLL128Bws [NCCL_NUM_COMPCAPS][NCCL_NUM_TUNING_SCALES];
   double perChMaxTreeBws [NCCL_NUM_COMPCAPS][NCCL_NUM_TUNING_SCALES];
-
-
+  double perChMaxNVLSTreeBws [NCCL_NUM_COMPCAPS][NCCL_NUM_TUNING_SCALES];
+  double bwRatio [2][NCCL_NUM_ALGORITHMS][NCCL_NUM_PROTOCOLS];
 } ncclTunerConstants_v5_t;
 
 // API to be implemented by external tuner

--- a/projects/rccl/ext-tuner/example/plugin.c
+++ b/projects/rccl/ext-tuner/example/plugin.c
@@ -299,14 +299,13 @@ __hidden ncclResult_t pluginInit(void** context, uint64_t commId, size_t nRanks,
     // Note: Example numbers are for reference only.
     //       Actual numbers may vary depending on the hardware and network topology.
     //       These numbers are not guaranteed to be optimal for all cases.
-    // Limit the tree bandwidth to 15GB/s
-    constants->perChMaxTreeBws[NCCL_BLACKWELL_COMPCAP_IDX][NCCL_TUNING_SCALE_4NODES] = 15.0;
 
-    // Limit the ring bandwidth to 20GB/s
-    constants->perChMaxRingLL128Bws[NCCL_BLACKWELL_COMPCAP_IDX][NCCL_TUNING_SCALE_4NODES] = 20.0;
-
-    // Set NVLSTree base network latency to 24us
-    constants->hwLatencies[NCCL_HW_NET][NCCL_ALGO_NVLS][NCCL_PROTO_SIMPLE] = 24.0;
+    // Limit the Ring/Simple bandwidth ratio to 70% for <=2 nodes
+    constants->bwRatio[0][NCCL_ALGO_RING][NCCL_PROTO_SIMPLE] = 0.70;
+    // Limit the Tree/Simple bandwidth ratio to 65% for >2 nodes
+    constants->bwRatio[1][NCCL_ALGO_TREE][NCCL_PROTO_SIMPLE] = 0.65;
+    // Set Ring/Simple base network latency to 280
+    constants->hwLatencies[NCCL_HW_NET][NCCL_ALGO_RING][NCCL_PROTO_SIMPLE] = 280.0;
   }
   
   TunerContext* ctx = (TunerContext*)malloc(sizeof(TunerContext));

--- a/projects/rccl/ext-tuner/example/test/test_plugin.c
+++ b/projects/rccl/ext-tuner/example/test/test_plugin.c
@@ -169,9 +169,7 @@ int test_collective_matching() {
 
   // Create mock cost table
   float cost_table[NCCL_NUM_ALGORITHMS][NCCL_NUM_PROTOCOLS];
-  float* cost_table_ptr[NCCL_NUM_ALGORITHMS];
   for (int i = 0; i < NCCL_NUM_ALGORITHMS; i++) {
-    cost_table_ptr[i] = cost_table[i];
     for (int j = 0; j < NCCL_NUM_PROTOCOLS; j++) {
       cost_table[i][j] = 1.0; // Default high cost
     }
@@ -181,7 +179,7 @@ int test_collective_matching() {
 
   // Test allreduce matching (should match first config)
   ncclResult_t result = pluginGetCollInfo(context, ncclFuncAllReduce, 32768, 1,
-                                          cost_table_ptr, NCCL_NUM_ALGORITHMS, NCCL_NUM_PROTOCOLS,
+                                          (float**)cost_table, NCCL_NUM_ALGORITHMS, NCCL_NUM_PROTOCOLS,
                                           0, &nChannels);
 
   TEST_ASSERT(result == ncclSuccess, "GetCollInfo should succeed");
@@ -199,7 +197,7 @@ int test_collective_matching() {
   }
 
   result = pluginGetCollInfo(context, ncclFuncBroadcast, 16384, 1,
-                            cost_table_ptr, NCCL_NUM_ALGORITHMS, NCCL_NUM_PROTOCOLS,
+                            (float**)cost_table, NCCL_NUM_ALGORITHMS, NCCL_NUM_PROTOCOLS,
                             0, &nChannels);
   TEST_ASSERT(result == ncclSuccess, "GetCollInfo should succeed");
   mock_logger(NCCL_LOG_INFO, NCCL_ALL, __FILE__, __LINE__,
@@ -229,9 +227,7 @@ int test_size_matching() {
   pluginInit(&context, 0, 8, 1, mock_logger, NULL, NULL);
 
   float cost_table[NCCL_NUM_ALGORITHMS][NCCL_NUM_PROTOCOLS];
-  float* cost_table_ptr[NCCL_NUM_ALGORITHMS];
   for (int i = 0; i < NCCL_NUM_ALGORITHMS; i++) {
-    cost_table_ptr[i] = cost_table[i];
     for (int j = 0; j < NCCL_NUM_PROTOCOLS; j++) {
       cost_table[i][j] = 1.0;
     }
@@ -239,7 +235,7 @@ int test_size_matching() {
   int nChannels = 1;
 
   pluginGetCollInfo(context, ncclFuncAllReduce, 512, 1,
-                    cost_table_ptr, NCCL_NUM_ALGORITHMS, NCCL_NUM_PROTOCOLS,
+                    (float**)cost_table, NCCL_NUM_ALGORITHMS, NCCL_NUM_PROTOCOLS,
                     0, &nChannels);
   mock_logger(NCCL_LOG_INFO, NCCL_ALL, __FILE__, __LINE__,
               "DEBUG: Small message - checking cost_table[TREE][SIMPLE] (%p) = %.1f (expecting 0.0)",
@@ -255,7 +251,7 @@ int test_size_matching() {
   }
 
   pluginGetCollInfo(context, ncclFuncAllReduce, 32768, 1,
-                    cost_table_ptr, NCCL_NUM_ALGORITHMS, NCCL_NUM_PROTOCOLS,
+                    (float**)cost_table, NCCL_NUM_ALGORITHMS, NCCL_NUM_PROTOCOLS,
                     0, &nChannels);
   mock_logger(NCCL_LOG_INFO, NCCL_ALL, __FILE__, __LINE__,
               "DEBUG: Medium message - checking cost_table[RING][SIMPLE] (%p) = %.1f (expecting 0.0)",
@@ -271,7 +267,7 @@ int test_size_matching() {
   }
 
   pluginGetCollInfo(context, ncclFuncAllReduce, 1048576, 1,
-                    cost_table_ptr, NCCL_NUM_ALGORITHMS, NCCL_NUM_PROTOCOLS,
+                    (float**)cost_table, NCCL_NUM_ALGORITHMS, NCCL_NUM_PROTOCOLS,
                     0, &nChannels);
   mock_logger(NCCL_LOG_INFO, NCCL_ALL, __FILE__, __LINE__,
               "DEBUG: Large message - checking cost_table[RING][LL128] (%p) = %.1f (expecting 0.0)",
@@ -301,9 +297,7 @@ int test_topology_matching() {
   pluginInit(&context1, 0, 8, 1, mock_logger, NULL, NULL);  // 8 ranks, 1 node
 
   float cost_table[NCCL_NUM_ALGORITHMS][NCCL_NUM_PROTOCOLS];
-  float* cost_table_ptr[NCCL_NUM_ALGORITHMS];
   for (int i = 0; i < NCCL_NUM_ALGORITHMS; i++) {
-    cost_table_ptr[i] = cost_table[i];
     for (int j = 0; j < NCCL_NUM_PROTOCOLS; j++) {
       cost_table[i][j] = 1.0;
     }
@@ -311,7 +305,7 @@ int test_topology_matching() {
 
   int nChannels;
   pluginGetCollInfo(context1, ncclFuncAllReduce, 32768, 1,
-                    cost_table_ptr, NCCL_NUM_ALGORITHMS, NCCL_NUM_PROTOCOLS,
+                    (float**)cost_table, NCCL_NUM_ALGORITHMS, NCCL_NUM_PROTOCOLS,
                     0, &nChannels);
   TEST_ASSERT(cost_table[NCCL_ALGO_TREE][NCCL_PROTO_SIMPLE] == 0.0, "Single node: Should match tree config");
   TEST_ASSERT(nChannels == 2, "Single node: Should set 2 channels");
@@ -329,7 +323,7 @@ int test_topology_matching() {
   }
 
   pluginGetCollInfo(context2, ncclFuncAllReduce, 32768, 1,
-                    cost_table_ptr, NCCL_NUM_ALGORITHMS, NCCL_NUM_PROTOCOLS,
+                    (float**)cost_table, NCCL_NUM_ALGORITHMS, NCCL_NUM_PROTOCOLS,
                     0, &nChannels);
   TEST_ASSERT(cost_table[NCCL_ALGO_RING][NCCL_PROTO_SIMPLE] == 0.0, "4-node: Should match ring/simple config");
   TEST_ASSERT(nChannels == 4, "4-node: Should set 4 channels");
@@ -352,9 +346,7 @@ int test_default_channels() {
   pluginInit(&context, 0, 8, 1, mock_logger, NULL, NULL);
 
   float cost_table[NCCL_NUM_ALGORITHMS][NCCL_NUM_PROTOCOLS];
-  float* cost_table_ptr[NCCL_NUM_ALGORITHMS];
   for (int i = 0; i < NCCL_NUM_ALGORITHMS; i++) {
-    cost_table_ptr[i] = cost_table[i];
     for (int j = 0; j < NCCL_NUM_PROTOCOLS; j++) {
       cost_table[i][j] = 1.0;
     }
@@ -362,11 +354,11 @@ int test_default_channels() {
 
   int nChannels = 99;  // Set to known value
   pluginGetCollInfo(context, ncclFuncAllReduce, 32768, 1,
-                    cost_table_ptr, NCCL_NUM_ALGORITHMS, NCCL_NUM_PROTOCOLS,
+                    (float**)cost_table, NCCL_NUM_ALGORITHMS, NCCL_NUM_PROTOCOLS,
                     0, &nChannels);
 
   TEST_ASSERT(cost_table[NCCL_ALGO_TREE][NCCL_PROTO_SIMPLE] == 0.0, "Should apply algorithm/protocol");
-  TEST_ASSERT(nChannels == 1, "Should keep default channels (1) when config has -1");
+  TEST_ASSERT(nChannels == 0, "Should keep default channels (0) when config has -1");
 
   // Clean up
   pluginFinalize(context);
@@ -389,11 +381,6 @@ int test_regbuff_matching() {
   pluginInit(&context, 0, 8, 1, mock_logger, NULL, NULL);
 
   float cost_table[NCCL_NUM_ALGORITHMS][NCCL_NUM_PROTOCOLS];
-  float* cost_table_ptr[NCCL_NUM_ALGORITHMS];
-  for (int i = 0; i < NCCL_NUM_ALGORITHMS; i++) {
-    cost_table_ptr[i] = cost_table[i];
-  }
-
   int nChannels;
 
   // Test registered buffer (should match first config)
@@ -404,7 +391,7 @@ int test_regbuff_matching() {
   }
 
   pluginGetCollInfo(context, ncclFuncAllReduce, 32768, 1,
-                    cost_table_ptr, NCCL_NUM_ALGORITHMS, NCCL_NUM_PROTOCOLS,
+                    (float**)cost_table, NCCL_NUM_ALGORITHMS, NCCL_NUM_PROTOCOLS,
                     1, &nChannels);  // regBuff = 1 (registered)
   TEST_ASSERT(cost_table[NCCL_ALGO_TREE][NCCL_PROTO_SIMPLE] == 0.0, "Registered buffer: Tree/Simple should have low cost");
   TEST_ASSERT(nChannels == 2, "Registered buffer: Should set 2 channels");
@@ -417,7 +404,7 @@ int test_regbuff_matching() {
   }
 
   pluginGetCollInfo(context, ncclFuncAllReduce, 32768, 1,
-                    cost_table_ptr, NCCL_NUM_ALGORITHMS, NCCL_NUM_PROTOCOLS,
+                    (float**)cost_table, NCCL_NUM_ALGORITHMS, NCCL_NUM_PROTOCOLS,
                     0, &nChannels);  // regBuff = 0 (non-registered)
   TEST_ASSERT(cost_table[NCCL_ALGO_RING][NCCL_PROTO_SIMPLE] == 0.0, "Non-registered buffer: Ring/Simple should have low cost");
   TEST_ASSERT(nChannels == 4, "Non-registered buffer: Should set 4 channels");
@@ -431,7 +418,7 @@ int test_regbuff_matching() {
 
   // First try with regBuff=2 (unusual value, should match third config)
   pluginGetCollInfo(context, ncclFuncAllReduce, 32768, 1,
-                    cost_table_ptr, NCCL_NUM_ALGORITHMS, NCCL_NUM_PROTOCOLS,
+                    (float**)cost_table, NCCL_NUM_ALGORITHMS, NCCL_NUM_PROTOCOLS,
                     2, &nChannels);  // regBuff = 2 (only third config should match)
   TEST_ASSERT(cost_table[NCCL_ALGO_RING][NCCL_PROTO_LL128] == 0.0, "Any regBuff: Ring/LL128 should have low cost");
   TEST_ASSERT(nChannels == 8, "Any regBuff: Should set 8 channels");
@@ -457,11 +444,6 @@ int test_pipeops_matching() {
   pluginInit(&context, 0, 8, 1, mock_logger, NULL, NULL);
 
   float cost_table[NCCL_NUM_ALGORITHMS][NCCL_NUM_PROTOCOLS];
-  float* cost_table_ptr[NCCL_NUM_ALGORITHMS];
-  for (int i = 0; i < NCCL_NUM_ALGORITHMS; i++) {
-    cost_table_ptr[i] = cost_table[i];
-  }
-
   int nChannels;
 
   // Test single pipeline op (should match first config)
@@ -472,7 +454,7 @@ int test_pipeops_matching() {
   }
 
   pluginGetCollInfo(context, ncclFuncAllReduce, 32768, 1,
-                    cost_table_ptr, NCCL_NUM_ALGORITHMS, NCCL_NUM_PROTOCOLS,
+                    (float**)cost_table, NCCL_NUM_ALGORITHMS, NCCL_NUM_PROTOCOLS,
                     0, &nChannels);
   TEST_ASSERT(cost_table[NCCL_ALGO_TREE][NCCL_PROTO_SIMPLE] == 0.0, "Single pipeOp: Tree/Simple should have low cost");
   TEST_ASSERT(nChannels == 2, "Single pipeOp: Should set 2 channels");
@@ -485,7 +467,7 @@ int test_pipeops_matching() {
   }
 
   pluginGetCollInfo(context, ncclFuncAllReduce, 32768, 4,
-                    cost_table_ptr, NCCL_NUM_ALGORITHMS, NCCL_NUM_PROTOCOLS,
+                    (float**)cost_table, NCCL_NUM_ALGORITHMS, NCCL_NUM_PROTOCOLS,
                     0, &nChannels);
   TEST_ASSERT(cost_table[NCCL_ALGO_RING][NCCL_PROTO_SIMPLE] == 0.0, "Multiple pipeOps: Ring/Simple should have low cost");
   TEST_ASSERT(nChannels == 4, "Multiple pipeOps: Should set 4 channels");
@@ -498,7 +480,7 @@ int test_pipeops_matching() {
   }
 
   pluginGetCollInfo(context, ncclFuncAllReduce, 32768, 2,
-                    cost_table_ptr, NCCL_NUM_ALGORITHMS, NCCL_NUM_PROTOCOLS,
+                    (float**)cost_table, NCCL_NUM_ALGORITHMS, NCCL_NUM_PROTOCOLS,
                     0, &nChannels);
   TEST_ASSERT(cost_table[NCCL_ALGO_RING][NCCL_PROTO_LL128] == 0.0, "Any pipeOps: Ring/LL128 should have low cost");
   TEST_ASSERT(nChannels == 8, "Any pipeOps: Should set 8 channels");
@@ -522,9 +504,7 @@ int test_no_match_fallback() {
   pluginInit(&context, 0, 8, 1, mock_logger, NULL, NULL);
 
   float cost_table[NCCL_NUM_ALGORITHMS][NCCL_NUM_PROTOCOLS];
-  float* cost_table_ptr[NCCL_NUM_ALGORITHMS];
   for (int i = 0; i < NCCL_NUM_ALGORITHMS; i++) {
-    cost_table_ptr[i] = cost_table[i];
     for (int j = 0; j < NCCL_NUM_PROTOCOLS; j++) {
       cost_table[i][j] = 1.0;
     }
@@ -533,14 +513,14 @@ int test_no_match_fallback() {
   int nChannels;
   // Try allreduce (should not match, use fallback)
   pluginGetCollInfo(context, ncclFuncAllReduce, 32768, 1,
-                    cost_table_ptr, NCCL_NUM_ALGORITHMS, NCCL_NUM_PROTOCOLS,
+                    (float**)cost_table, NCCL_NUM_ALGORITHMS, NCCL_NUM_PROTOCOLS,
                     0, &nChannels);
 
   mock_logger(NCCL_LOG_INFO, NCCL_ALL, __FILE__, __LINE__,
               "DEBUG: Fallback test - checking cost_table[RING][SIMPLE] (%p) = %.1f (expecting 0.0)",
               &cost_table[NCCL_ALGO_RING][NCCL_PROTO_SIMPLE], cost_table[NCCL_ALGO_RING][NCCL_PROTO_SIMPLE]);
   TEST_ASSERT(cost_table[NCCL_ALGO_RING][NCCL_PROTO_SIMPLE] == 1.0, "Should use pass through unmodified");
-  TEST_ASSERT(nChannels == 1, "Should use default channels");
+  TEST_ASSERT(nChannels == 0, "Should use default channels");
 
   // Clean up
   pluginFinalize(context);
@@ -636,9 +616,7 @@ int test_large_config() {
 
   // Test that the plugin can still find matching configurations from the large set
   float cost_table[NCCL_NUM_ALGORITHMS][NCCL_NUM_PROTOCOLS];
-  float* cost_table_ptr[NCCL_NUM_ALGORITHMS];
   for (int i = 0; i < NCCL_NUM_ALGORITHMS; i++) {
-    cost_table_ptr[i] = cost_table[i];
     for (int j = 0; j < NCCL_NUM_PROTOCOLS; j++) {
       cost_table[i][j] = 1.0; // Default high cost
     }
@@ -647,7 +625,7 @@ int test_large_config() {
   int nChannels;
   // Try to find a matching configuration - should work with large config set
   result = pluginGetCollInfo(context, ncclFuncAllReduce, 32768, 1,
-                            cost_table_ptr, NCCL_NUM_ALGORITHMS, NCCL_NUM_PROTOCOLS,
+                            (float**)cost_table, NCCL_NUM_ALGORITHMS, NCCL_NUM_PROTOCOLS,
                             0, &nChannels);
   TEST_ASSERT(result == ncclSuccess, "GetCollInfo should work with large config set");
 
@@ -736,9 +714,7 @@ int test_empty_config() {
 
   // Test that plugin still works with no configurations (fallback behavior)
   float cost_table[NCCL_NUM_ALGORITHMS][NCCL_NUM_PROTOCOLS];
-  float* cost_table_ptr[NCCL_NUM_ALGORITHMS];
   for (int i = 0; i < NCCL_NUM_ALGORITHMS; i++) {
-    cost_table_ptr[i] = cost_table[i];
     for (int j = 0; j < NCCL_NUM_PROTOCOLS; j++) {
       cost_table[i][j] = 1.0;
     }
@@ -746,7 +722,7 @@ int test_empty_config() {
 
   int nChannels;
   result = pluginGetCollInfo(context, ncclFuncAllReduce, 32768, 1,
-                            cost_table_ptr, NCCL_NUM_ALGORITHMS, NCCL_NUM_PROTOCOLS,
+                            (float**)cost_table, NCCL_NUM_ALGORITHMS, NCCL_NUM_PROTOCOLS,
                             0, &nChannels);
   TEST_ASSERT(result == ncclSuccess, "GetCollInfo should work with empty config");
 
@@ -862,6 +838,30 @@ int test_tuner_constants() {
       {-1.0, -1.0, -1.0},  // Ampere: 1node, 2nodes, 4nodes
       {-1.0, -1.0, -1.0},  // Hopper: 1node, 2nodes, 4nodes
       {-1.0, -1.0, -1.0}   // Blackwell: 1node, 2nodes, 4nodes
+    },
+
+    // bwRatio: [2][NCCL_NUM_ALGORITHMS][NCCL_NUM_PROTOCOLS]
+    .bwRatio = {
+      // <=2 nodes
+      {
+        {-1.0, -1.0, -1.0},    // TREE
+        {-1.0, -1.0, -1.0},    // RING
+        {-1.0, -1.0, -1.0},    // COLLNET_DIRECT
+        {-1.0, -1.0, -1.0},    // COLLNET_CHAIN
+        {-1.0, -1.0, -1.0},    // NVLS
+        {-1.0, -1.0, -1.0},    // NVLS_TREE
+        {-1.0, -1.0, -1.0}     // PAT
+      },
+      // >2 nodes
+      {
+        {-1.0, -1.0, -1.0},    // TREE
+        {-1.0, -1.0, -1.0},    // RING
+        {-1.0, -1.0, -1.0},    // COLLNET_DIRECT
+        {-1.0, -1.0, -1.0},    // COLLNET_CHAIN
+        {-1.0, -1.0, -1.0},    // NVLS
+        {-1.0, -1.0, -1.0},    // NVLS_TREE
+        {-1.0, -1.0, -1.0}     // PAT
+      }
     }
   };
 
@@ -870,9 +870,9 @@ int test_tuner_constants() {
   TEST_ASSERT(result == ncclSuccess, "Plugin init with constants should succeed");
 
   // Test that the constants were set correctly
-  TEST_ASSERT(constants.perChMaxTreeBws[NCCL_BLACKWELL_COMPCAP_IDX][NCCL_TUNING_SCALE_4NODES] == 15.0, "Tree bandwidth should be 15GB/s");
-  TEST_ASSERT(constants.perChMaxRingLL128Bws[NCCL_BLACKWELL_COMPCAP_IDX][NCCL_TUNING_SCALE_4NODES] == 20.0, "Ring bandwidth should be 20GB/s");
-  TEST_ASSERT(constants.hwLatencies[NCCL_HW_NET][NCCL_ALGO_NVLS][NCCL_PROTO_SIMPLE] == 24.0, "NVLSTree base network latency should be 24us");
+  TEST_ASSERT(constants.bwRatio[0][NCCL_ALGO_RING][NCCL_PROTO_SIMPLE] == 0.70, "Ring/Simple bwRatio for <=2 nodes should be 0.70");
+  TEST_ASSERT(constants.bwRatio[1][NCCL_ALGO_TREE][NCCL_PROTO_SIMPLE] == 0.65, "Tree/Simple bwRatio for >2 nodes should be 0.65");
+  TEST_ASSERT(constants.hwLatencies[NCCL_HW_NET][NCCL_ALGO_RING][NCCL_PROTO_SIMPLE] == 280.0, "Ring/Simple base network latency should be 280");
 
   // Clean up
   pluginFinalize(context);

--- a/projects/rccl/src/graph/tuning.cc
+++ b/projects/rccl/src/graph/tuning.cc
@@ -580,6 +580,20 @@ ncclResult_t ncclTopoInitTunerConstants(struct ncclComm* comm) {
 
   comm->tunerConstants = ncclTunerConstantsDefaults;
 
+#if defined(__HIP_PLATFORM_AMD__) || defined(__HIPCC__)
+  for (int hw = 0; hw < NCCL_NUM_HW_LINKS; hw++)
+    for (int a = 0; a < NCCL_NUM_ALGORITHMS; a++)
+      for (int p = 0; p < NCCL_NUM_PROTOCOLS; p++)
+        comm->tunerConstants.hwLatencies[hw][a][p] =
+          rcclTuningModel[comm->topo->tuning].hwLat[hw][a][p];
+
+  for (int n = 0; n < 2; n++) // 0 = <=2 nodes, 1 = >2 nodes
+    for (int a = 0; a < NCCL_NUM_ALGORITHMS; a++)
+      for (int p = 0; p < NCCL_NUM_PROTOCOLS; p++)
+        comm->tunerConstants.bwRatio[n][a][p] =
+          rcclTuningModel[comm->topo->tuning].bwRatio[n][a][p];
+#endif
+
   return ncclSuccess;
 }
 
@@ -686,9 +700,9 @@ ncclResult_t ncclTopoTuneModel(struct ncclComm* comm, int minCompCap, int maxCom
         // Various model refinements
 #if defined(__HIP_PLATFORM_AMD__) || defined(__HIPCC__)
         if (nNodes <= 2)
-          busBw *= rcclTuningModel[comm->topo->tuning].bwRatio[0][a][p];
+          busBw *= comm->tunerConstants.bwRatio[0][a][p];
         else
-          busBw *= rcclTuningModel[comm->topo->tuning].bwRatio[1][a][p];
+          busBw *= comm->tunerConstants.bwRatio[1][a][p];
         if (a == NCCL_ALGO_RING && p == NCCL_PROTO_LL && (coll == ncclFuncBroadcast || coll == ncclFuncReduce) && (IsArchMatch(comm->topo->nodes[GPU].nodes[0].gpu.gcn, "gfx942") || IsArchMatch(comm->topo->nodes[GPU].nodes[0].gpu.gcn, "gfx950")) && comm->topo->nodes[GPU].count == comm->topo->nRanks) { busBw = busBw * 1.65; }
 #else
         if (a == NCCL_ALGO_RING && p == NCCL_PROTO_LL) { busBw = std::min(llMaxBw, busBw * .5); }
@@ -741,19 +755,19 @@ ncclResult_t ncclTopoTuneModel(struct ncclComm* comm, int minCompCap, int maxCom
         }
         comm->bandwidths[coll][a][p] = busBw;
         comm->latencies[coll][a][p] = baseLat[a][p];
-        float intraLat = rcclTuningModel[comm->topo->tuning].hwLat[intraHw[a]][a][p];
-        float interLat =  ppn == 1 ? rcclTuningModel[comm->topo->tuning].hwLat[NCCL_HW_NET][NCCL_ALGO_TREE][p] : rcclTuningModel[comm->topo->tuning].hwLat[NCCL_HW_NET][a][p];
+        float intraLat = comm->tunerConstants.hwLatencies[intraHw[a]][a][p];
+        float interLat =  ppn == 1 ? comm->tunerConstants.hwLatencies[NCCL_HW_NET][NCCL_ALGO_TREE][p] : comm->tunerConstants.hwLatencies[NCCL_HW_NET][a][p];
         interLat += graphs[a]->latencyInter;
         // Also add the flush extra latency
         if (p == NCCL_PROTO_SIMPLE) interLat += graphs[a]->latencyInter;
 
         if (a == NCCL_ALGO_RING) {
-          float lat = rcclTuningModel[comm->topo->tuning].hwLat[hw[a]][a][p];
+          float lat = comm->tunerConstants.hwLatencies[hw[a]][a][p];
           if ((coll == ncclFuncReduce || coll == ncclFuncBroadcast)) {
             if (graphs[a]->sameChannels) {
               comm->latencies[coll][a][p] += lat;
             } else {
-              if (p == NCCL_PROTO_SIMPLE) lat = rcclTuningModel[comm->topo->tuning].hwLat[hw[a]][NCCL_ALGO_TREE][p]; // Add some chunk latency, waiting for proper chunk modeling
+              if (p == NCCL_PROTO_SIMPLE) lat = comm->tunerConstants.hwLatencies[hw[a]][NCCL_ALGO_TREE][p]; // Add some chunk latency, waiting for proper chunk modeling
               comm->latencies[coll][a][p] += nsteps*lat;
             }
           } else {
@@ -778,9 +792,9 @@ ncclResult_t ncclTopoTuneModel(struct ncclComm* comm, int minCompCap, int maxCom
         } else if (a == NCCL_ALGO_COLLNET_CHAIN) {
           comm->latencies[coll][a][p] += 2 * (nRanks/nNodes-1) * intraLat + interLat;
         } else if (a == NCCL_ALGO_NVLS) {
-          if (nNodes > 1) comm->latencies[coll][a][p] += rcclTuningModel[comm->topo->tuning].hwLat[NCCL_HW_NET][a][p];
+          if (nNodes > 1) comm->latencies[coll][a][p] += comm->tunerConstants.hwLatencies[NCCL_HW_NET][a][p];
         } else if (a == NCCL_ALGO_NVLS_TREE) {
-          comm->latencies[coll][a][p] += 2*(nNodes-1)*rcclTuningModel[comm->topo->tuning].hwLat[NCCL_HW_NET][a][p];
+          comm->latencies[coll][a][p] += 2*(nNodes-1)*comm->tunerConstants.hwLatencies[NCCL_HW_NET][a][p];
         } else if (a == NCCL_ALGO_PAT) {
           if (coll == ncclFuncAllGather || coll == ncclFuncReduceScatter) {
             comm->latencies[coll][a][p] += log2i(nNodes) * (interLat/3.5) // Log latency

--- a/projects/rccl/src/include/plugin/tuner/tuner_v5.h
+++ b/projects/rccl/src/include/plugin/tuner/tuner_v5.h
@@ -30,8 +30,7 @@ typedef struct {
   double perChMaxTreeLL128Bws [NCCL_NUM_COMPCAPS_V5][NCCL_NUM_TUNING_SCALES_V5];
   double perChMaxTreeBws [NCCL_NUM_COMPCAPS_V5][NCCL_NUM_TUNING_SCALES_V5];
   double perChMaxNVLSTreeBws [NCCL_NUM_COMPCAPS_V5][NCCL_NUM_TUNING_SCALES_V5];
-
-
+  double bwRatio [2][NCCL_NUM_ALGORITHMS_V5][NCCL_NUM_PROTOCOLS_V5];
 } ncclTunerConstants_v5_t;
 
 // API to be implemented by external tuner


### PR DESCRIPTION
## Motivation

Enable tuner plugins to override tuning constants `bwRatio` & `hwLatencies` that were previously read directly from `rcclTuningModel`, bypassing the plugin API.

## Technical Details

Updated `ncclTopoTuneModel()` to read from `comm->tunerConstants` so plugin overrides take effect

## JIRA ID

AICOMRCCL-449

## Test Plan

Execute plugin against `rccl-tests`

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
