### PR TITLE
opencl: Add prefix-relative install for ICD and ld.so.conf.d files for ROCK artifacts

### DIFF
--- a/projects/clr/opencl/CMakeLists.txt
+++ b/projects/clr/opencl/CMakeLists.txt
@@ -112,6 +112,13 @@ install(
   COMPONENT binary
   EXCLUDE_FROM_ALL
 )
+# Install to CMAKE_INSTALL_PREFIX path. ROCK artifacts use files from prefix paths, not from /etc.
+install(
+  FILES ${CMAKE_BINARY_DIR}/opencl/packages/opencl/${OPENCL_AMD_ICD_FILE}
+  DESTINATION ${CMAKE_INSTALL_SYSCONFDIR}/OpenCL/vendors
+  COMPONENT binary
+)
+
 
 configure_file(
   packaging/rocm-opencl.conf
@@ -123,6 +130,12 @@ install(
   DESTINATION /${CMAKE_INSTALL_SYSCONFDIR}/ld.so.conf.d
   COMPONENT binary
   EXCLUDE_FROM_ALL
+)
+# Install to CMAKE_INSTALL_PREFIX path. ROCK artifacts use files from prefix paths, not from /etc.
+install(
+  FILES ${CMAKE_BINARY_DIR}/opencl/packages/opencl/10-rocm-opencl.conf
+  DESTINATION ${CMAKE_INSTALL_SYSCONFDIR}/ld.so.conf.d
+  COMPONENT binary
 )
 
 #Package: rocm-opencl,rocm-opencl-dev/devel,rocm-ocl-icd


### PR DESCRIPTION
Add prefix-relative install commands for:
  - AMD ICD loader file (amdocl64.icd )
  - 10-rocm-opencl.conf (ld.so.conf.d configuration)

  These files are now installed to both:
  1. /etc (absolute path)
  2. CMAKE_INSTALL_PREFIX/etc (relative path) - for ROCK artifacts

  The prefix-relative installs ensure files are captured in the stage
  directory and included in ROCK artifacts.

## Motivation
10-rocm-opencl.conf and amdocl64.icd  files are missing in ROCk artifacts

## Technical Details

The files are installed in absolute paths(/etc) rather than in prefix paths. ROCK artifacts are populated with files from prefix paths

## JIRA ID

https://github.com/ROCm/TheRock/issues/3806

## Test Plan

Verify the ROCK artifacts by including etc folder in artifact-core-ocl.toml

## Test Result

10-rocm-opencl.conf and amdocl64.icd  files are getting added to ROCk artifacts

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
