### PR TITLE
[rocdecode] - update rocdecode ctest

### DIFF
--- a/projects/rocdecode/samples/rocdecDecode/CMakeLists.txt
+++ b/projects/rocdecode/samples/rocdecDecode/CMakeLists.txt
@@ -30,6 +30,13 @@ elseif(ROCM_PATH)
 else()
   set(ROCM_PATH /opt/rocm CACHE PATH "Default ROCm installation path")
 endif()
+
+# Check if lib/rocm_sysdeps/lib exists in the ROCm path which indicates ROCm installation via TheRock
+set(USING_THE_ROCK OFF)
+if(EXISTS "${ROCM_PATH}/lib/rocm_sysdeps/lib")
+  set(USING_THE_ROCK ON)
+endif()
+
 # Set AMD Clang as default compiler
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED On)
@@ -70,13 +77,13 @@ if(HIP_FOUND AND rocdecode_FOUND)
     # HIP
     set(LINK_LIBRARY_LIST ${LINK_LIBRARY_LIST} hip::host)
 
-    if(FFMPEG_FOUND)
+    if(FFMPEG_FOUND AND NOT USING_THE_ROCK)
       # FFMPEG
       include_directories(${AVUTIL_INCLUDE_DIR} ${AVCODEC_INCLUDE_DIR}
                           ${AVFORMAT_INCLUDE_DIR})
       set(LINK_LIBRARY_LIST ${LINK_LIBRARY_LIST} ${FFMPEG_LIBRARIES})
     endif()
-    if(rocdecode-host_FOUND)
+    if(rocdecode-host_FOUND AND NOT USING_THE_ROCK)
       # rocdecode-host
       include_directories(${rocdecode-host_INCLUDE_DIR})
       set(LINK_LIBRARY_LIST ${LINK_LIBRARY_LIST} rocdecode::rocdecode-host)
@@ -94,7 +101,7 @@ if(HIP_FOUND AND rocdecode_FOUND)
     list(APPEND SOURCES ${PROJECT_SOURCE_DIR} rocdecdecode.cpp)
     add_executable(${PROJECT_NAME} ${SOURCES})
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=gnu++17")
-    if(FFMPEG_FOUND AND rocdecode-host_FOUND)
+    if(FFMPEG_FOUND AND rocdecode-host_FOUND AND NOT USING_THE_ROCK)
       target_compile_definitions(${PROJECT_NAME} PUBLIC ENABLE_HOST_DECODE=1)
     else()
       target_compile_definitions(${PROJECT_NAME} PUBLIC ENABLE_HOST_DECODE=0)

--- a/projects/rocdecode/test/CMakeLists.txt
+++ b/projects/rocdecode/test/CMakeLists.txt
@@ -93,6 +93,12 @@ else()
 endif(BUILD_FROM_SOURCE)
 find_package(FFmpeg QUIET)
 
+# Check if lib/rocm_sysdeps/lib exists in the ROCm path which indicates ROCm installation via TheRock
+set(USING_THE_ROCK OFF)
+if(EXISTS "${ROCM_PATH}/lib/rocm_sysdeps/lib")
+  set(USING_THE_ROCK ON)
+endif()
+
 # 1 - videoDecodeRaw HEVC
 add_test(
   NAME
@@ -170,7 +176,7 @@ add_test(
             --test-command "rocdecodenegativetest"
 )
 
-if(FFMPEG_FOUND)
+if(FFMPEG_FOUND AND NOT USING_THE_ROCK)
   message("-- ${Green}${PROJECT_NAME} FFmpeg found - rocdecode tests requiring FFmpeg added")
   # 7 - videoDecode HEVC
   add_test(
@@ -308,4 +314,4 @@ if(FFMPEG_FOUND)
   endif(rocdecode-host_FOUND)
 else()
   message("-- ${Yellow}${PROJECT_NAME} FFmpeg NOT found. rocdecode tests requiring FFmpeg excluded")
-endif(FFMPEG_FOUND)
+endif(FFMPEG_FOUND AND NOT USING_THE_ROCK)


### PR DESCRIPTION
## Motivation

This PR modifies the rocdecode CTEST configuration for execution on the TheRock platform. Tests that require FFMPEG are disabled when running on TheRock, since FFMPEG support is not yet fully implemented for this environment.

## Technical Details



## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
