### PR TITLE
Revert "Auto Labeler: Add ci:regression-detection label to rccl PRs"

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -102,10 +102,6 @@
 - changed-files:
   - any-glob-to-any-file: 'shared/amdgpu-windows-interop/**/*'
 
-"ci: regression-detection":
-- changed-files:
-  - any-glob-to-any-file: 'projects/rccl/**/*'
-
 documentation:
 - changed-files:
   - any-glob-to-any-file:


### PR DESCRIPTION
Reverts ROCm/rocm-systems#3543

We are designing a new way of testing and will only use label manually. There is other pipeline that will cover this kind of test automatically on all PR.
