### PR TITLE
disabling rccl from full build (linux), covered in RCCL CI

### DIFF
--- a/.github/scripts/therock_matrix.py
+++ b/.github/scripts/therock_matrix.py
@@ -43,15 +43,15 @@ project_map = {
     #     "projects_to_test": "", # "rocdecode-tests, rocjpeg-tests",
     # },
     "dc_tools": {
-        "cmake_options": "-DTHEROCK_ENABLE_DC_TOOLS=ON -DTHEROCK_ENABLE_ALL=OFF",
+        "cmake_options": "-DTHEROCK_ENABLE_DC_TOOLS=ON",
         "projects_to_test": "", # rdc-tests is not built by TheRock build system - TBD
     },
     "debug_tools": {
-        "cmake_options": "-DTHEROCK_ENABLE_DEBUG_TOOLS=ON -DTHEROCK_ENABLE_ALL=OFF",
+        "cmake_options": "-DTHEROCK_ENABLE_DEBUG_TOOLS=ON",
         "projects_to_test": "", # rocdbgapi-tests is not built by TheRock build system - TBD
     },
     "all": {
-        "cmake_options": "-DTHEROCK_ENABLE_ALL=ON -DTHEROCK_ENABLE_RCCL=OFF",
+        "cmake_options": "-DTHEROCK_ENABLE_ALL=ON",
         "projects_to_test": "hip-tests, rocprofiler-tests",
     },
 }

--- a/.github/scripts/therock_matrix.py
+++ b/.github/scripts/therock_matrix.py
@@ -30,11 +30,11 @@ subtree_to_project_map = {
 
 project_map = {
     "core": {
-        "cmake_options": "-DTHEROCK_ENABLE_ALL=ON",
+        "cmake_options": "-DTHEROCK_ENABLE_ALL=ON -DTHEROCK_ENABLE_RCCL=OFF",
         "projects_to_test": "hip-tests",
     },
     "profiler": {
-        "cmake_options": "-DTHEROCK_ENABLE_ALL=ON",
+        "cmake_options": "-DTHEROCK_ENABLE_ALL=ON -DTHEROCK_ENABLE_RCCL=OFF",
         "projects_to_test": "rocprofiler-tests",
     },
     # media libs to be enabled in following PR
@@ -51,7 +51,7 @@ project_map = {
         "projects_to_test": "", # rocdbgapi-tests is not built by TheRock build system - TBD
     },
     "all": {
-        "cmake_options": "-DTHEROCK_ENABLE_ALL=ON",
+        "cmake_options": "-DTHEROCK_ENABLE_ALL=ON -DTHEROCK_ENABLE_RCCL=OFF",
         "projects_to_test": "hip-tests, rocprofiler-tests",
     },
 }

--- a/.github/scripts/therock_matrix.py
+++ b/.github/scripts/therock_matrix.py
@@ -30,11 +30,11 @@ subtree_to_project_map = {
 
 project_map = {
     "core": {
-        "cmake_options": "-DTHEROCK_ENABLE_ALL=ON -DTHEROCK_ENABLE_RCCL=OFF",
+        "cmake_options": "-DTHEROCK_ENABLE_ALL=ON",
         "projects_to_test": "hip-tests",
     },
     "profiler": {
-        "cmake_options": "-DTHEROCK_ENABLE_ALL=ON -DTHEROCK_ENABLE_RCCL=OFF",
+        "cmake_options": "-DTHEROCK_ENABLE_ALL=ON",
         "projects_to_test": "rocprofiler-tests",
     },
     # media libs to be enabled in following PR
@@ -43,11 +43,11 @@ project_map = {
     #     "projects_to_test": "", # "rocdecode-tests, rocjpeg-tests",
     # },
     "dc_tools": {
-        "cmake_options": "-DTHEROCK_ENABLE_DC_TOOLS=ON",
+        "cmake_options": "-DTHEROCK_ENABLE_DC_TOOLS=ON -DTHEROCK_ENABLE_ALL=OFF",
         "projects_to_test": "", # rdc-tests is not built by TheRock build system - TBD
     },
     "debug_tools": {
-        "cmake_options": "-DTHEROCK_ENABLE_DEBUG_TOOLS=ON",
+        "cmake_options": "-DTHEROCK_ENABLE_DEBUG_TOOLS=ON -DTHEROCK_ENABLE_ALL=OFF",
         "projects_to_test": "", # rocdbgapi-tests is not built by TheRock build system - TBD
     },
     "all": {

--- a/.github/workflows/therock-ci-linux.yml
+++ b/.github/workflows/therock-ci-linux.yml
@@ -76,7 +76,7 @@ jobs:
         env:
           amdgpu_families: ${{ env.AMDGPU_FAMILIES }}
           package_version: ADHOCBUILD
-          extra_cmake_options: "-DTHEROCK_ROCM_SYSTEMS_SOURCE_DIR=../ ${{ inputs.cmake_options }}"
+          extra_cmake_options: "-DTHEROCK_ROCM_SYSTEMS_SOURCE_DIR=../ -DTHEROCK_ENABLE_RCCL=OFF ${{ inputs.cmake_options }}"
           BUILD_DIR: build
         run: |
           python TheRock/build_tools/github_actions/build_configure.py


### PR DESCRIPTION
## Motivation

Seeing rccl-test-configure failure after PR3182 which enabled the full build by default and for hip/runtime and profiler projects. 
RCCL CI is any way seperate and covered as part of 

https://github.com/ROCm/rocm-systems/blob/develop/.github/workflows/therock-rccl-ci-linux.yml
https://github.com/ROCm/rocm-systems/blob/develop/.github/workflows/therock-ci.yml#L122

The PR can be reverted once rccl-test-configure fix is available

CI Runs where issues are observed 
https://github.com/ROCm/rocm-systems/actions/runs/22678969199
https://github.com/ROCm/rocm-systems/actions/runs/22688924172?pr=3709
https://github.com/ROCm/rocm-systems/actions/runs/22683526891?pr=3749


The PSDB for PR3182 did not catch it
https://github.com/ROCm/rocm-systems/actions/runs/22649465133
