### PR TITLE
[rocprofiler-compute] Optimize data imputation for iteration multiplexing

### DIFF
--- a/projects/rocprofiler-compute/src/utils/utils.py
+++ b/projects/rocprofiler-compute/src/utils/utils.py
@@ -1889,8 +1889,8 @@ def impute_counters_iteration_multiplex(
 
         # Log imputation task summary before processing
         console_debug(
-            f"[impute] Performing data imputation on {len(df)} dispatches "
-            f"across {unique_occurences.ngroups} unique kernels"
+            f"Performing data imputation on {len(df)} dispatches "
+            f"across {unique_occurences.ngroups} unique kernel configurations"
         )
 
         for _, group in unique_occurences:
@@ -1928,12 +1928,13 @@ def impute_counters_iteration_multiplex(
             group_copy["__subgroup_id"] = np.arange(len(group_copy)) // subgroup_size
 
             # groupby().bfill() automatically excludes the grouping column from result
-            imputed_group = (
-                group_copy
+            group_copy[counter_columns] = (
+                group_copy[[*counter_columns, "__subgroup_id"]]
                 .groupby("__subgroup_id", group_keys=False)
                 .bfill()  # Propagate first valid value backward to start of subgroup
                 .ffill()  # Propagate forward to end of subgroup
             )
+            imputed_group = group_copy
 
             # Handle incomplete subgroup at the end
             # NOTE: This wont work if the first subgroup is itself incomplete

--- a/projects/rocprofiler-compute/src/utils/utils.py
+++ b/projects/rocprofiler-compute/src/utils/utils.py
@@ -1898,9 +1898,7 @@ def impute_counters_iteration_multiplex(
             counter_groups: set[frozenset[str]] = set()
             for _, row in group.iterrows():
                 # Set of counter column names with non empty values
-                cols_frozenset = frozenset(
-                    row[counter_columns][row[counter_columns].notna()].index
-                )
+                cols_frozenset = frozenset(row[counter_columns].dropna().index)
                 # If no counters found for this dispatch, continue
                 if not cols_frozenset:
                     continue
@@ -1916,17 +1914,12 @@ def impute_counters_iteration_multiplex(
 
             # Iterate over subgroups of dispatches containing
             # all counters and impute missing values
-            subgroup_size = len(counter_groups)
-            all_counters = {
-                counter for counter_group in counter_groups for counter in counter_group
-            }
-            num_subgroups = (len(group) + subgroup_size - 1) // subgroup_size
-
             # Create subgroup_id column for groupby: 0,0,0,...,1,1,1,...,2,2,2,...
             # Use numpy for vectorized operation
             group_copy = group.copy()
-            group_copy["__subgroup_id"] = np.arange(len(group_copy)) // subgroup_size
-
+            group_copy["__subgroup_id"] = np.arange(len(group_copy)) // len(
+                counter_groups
+            )
             # groupby().bfill() automatically excludes the grouping column from result
             group_copy[counter_columns] = (
                 group_copy[[*counter_columns, "__subgroup_id"]]
@@ -1934,42 +1927,7 @@ def impute_counters_iteration_multiplex(
                 .bfill()  # Propagate first valid value backward to start of subgroup
                 .ffill()  # Propagate forward to end of subgroup
             )
-            imputed_group = group_copy
-
-            # Handle incomplete subgroup at the end
-            # NOTE: This wont work if the first subgroup is itself incomplete
-            if num_subgroups > 1:
-                last_subgroup_start = (num_subgroups - 1) * subgroup_size
-                prev_subgroup_start = (num_subgroups - 2) * subgroup_size
-
-                # Check if last subgroup still has NaN values
-                last_subgroup = imputed_group.iloc[last_subgroup_start:]
-                if last_subgroup.isna().any().any():
-                    # Get first valid values from previous subgroup
-                    prev_subgroup = imputed_group.iloc[
-                        prev_subgroup_start:last_subgroup_start
-                    ]
-
-                    # Extract first row as fill values
-                    # (all rows identical after bfill+ffill)
-                    # Only include counter columns in fill values
-                    counter_cols = [
-                        c for c in prev_subgroup.columns if c in all_counters
-                    ]
-                    prev_fill_values = prev_subgroup[counter_cols].iloc[0].to_dict()
-
-                    # Remove NaN values from dict
-                    prev_fill_values = {
-                        k: v for k, v in prev_fill_values.items() if pd.notna(v)
-                    }
-
-                    # Apply to last subgroup only
-                    if prev_fill_values:
-                        imputed_group.iloc[last_subgroup_start:] = imputed_group.iloc[
-                            last_subgroup_start:
-                        ].fillna(prev_fill_values)
-
-            group_dfs.append(imputed_group)
+            group_dfs.append(group_copy)
 
         # Create a new dataframe by concatenating all groups
         result_dfs.append(

--- a/projects/rocprofiler-compute/src/utils/utils.py
+++ b/projects/rocprofiler-compute/src/utils/utils.py
@@ -48,6 +48,7 @@ from contextlib import contextmanager
 from pathlib import Path
 from typing import Any, Optional, Union, cast
 
+import numpy as np
 import pandas as pd
 import yaml
 
@@ -1886,6 +1887,12 @@ def impute_counters_iteration_multiplex(
         # Collect imputed groups as dataframes
         group_dfs = []
 
+        # Log imputation task summary before processing
+        console_debug(
+            f"[impute] Performing data imputation on {len(df)} dispatches "
+            f"across {unique_occurences.ngroups} unique kernels"
+        )
+
         for _, group in unique_occurences:
             # Identify counter buckets
             counter_groups: set[frozenset[str]] = set()
@@ -1913,45 +1920,55 @@ def impute_counters_iteration_multiplex(
             all_counters = {
                 counter for counter_group in counter_groups for counter in counter_group
             }
-            # Collect imputed sub-groups as dataframes
-            subgroup_dfs = []
-            previous_fill_values = {}
-            for i in range(0, len(group), subgroup_size):
-                subgroup = group.iloc[i : i + subgroup_size]
+            num_subgroups = (len(group) + subgroup_size - 1) // subgroup_size
 
-                # Build imputation mapping once for all counters in this subgroup
-                fill_values = {}
-                for counter in all_counters:
-                    valid_mask = subgroup[counter].notna()
-                    if valid_mask.any():
-                        # Get the first valid value for this counter
-                        fill_values[counter] = subgroup.loc[valid_mask, counter].iloc[0]
+            # Create subgroup_id column for groupby: 0,0,0,...,1,1,1,...,2,2,2,...
+            # Use numpy for vectorized operation
+            group_copy = group.copy()
+            group_copy["__subgroup_id"] = np.arange(len(group_copy)) // subgroup_size
 
-                # Apply all fills at once using vectorized fillna
-                if fill_values:
-                    subgroup = subgroup.fillna(fill_values)
+            # groupby().bfill() automatically excludes the grouping column from result
+            imputed_group = (
+                group_copy
+                .groupby("__subgroup_id", group_keys=False)
+                .bfill()  # Propagate first valid value backward to start of subgroup
+                .ffill()  # Propagate forward to end of subgroup
+            )
 
-                # If this is the last subgroup and it still has missing values,
-                # use previous subgroup's fill values
-                # NOTE: This wont work if the first subgroup is itself incomplete
-                is_last_subgroup = (i + subgroup_size) >= len(group)
-                # First any() returns bool pd.Series for every column,
-                # second any() returns single bool
-                if (
-                    is_last_subgroup
-                    and previous_fill_values
-                    and subgroup.isna().any().any()
-                ):
-                    # Use previous subgroup's fill values for remaining missing values
-                    subgroup = subgroup.fillna(previous_fill_values)
+            # Handle incomplete subgroup at the end
+            # NOTE: This wont work if the first subgroup is itself incomplete
+            if num_subgroups > 1:
+                last_subgroup_start = (num_subgroups - 1) * subgroup_size
+                prev_subgroup_start = (num_subgroups - 2) * subgroup_size
 
-                subgroup_dfs.append(subgroup)
-                previous_fill_values = fill_values
+                # Check if last subgroup still has NaN values
+                last_subgroup = imputed_group.iloc[last_subgroup_start:]
+                if last_subgroup.isna().any().any():
+                    # Get first valid values from previous subgroup
+                    prev_subgroup = imputed_group.iloc[
+                        prev_subgroup_start:last_subgroup_start
+                    ]
 
-            # Concatenate all subgroups for this group
-            if subgroup_dfs:
-                # Add the imputed group dataframe
-                group_dfs.append(pd.concat(subgroup_dfs, ignore_index=True))
+                    # Extract first row as fill values
+                    # (all rows identical after bfill+ffill)
+                    # Only include counter columns in fill values
+                    counter_cols = [
+                        c for c in prev_subgroup.columns if c in all_counters
+                    ]
+                    prev_fill_values = prev_subgroup[counter_cols].iloc[0].to_dict()
+
+                    # Remove NaN values from dict
+                    prev_fill_values = {
+                        k: v for k, v in prev_fill_values.items() if pd.notna(v)
+                    }
+
+                    # Apply to last subgroup only
+                    if prev_fill_values:
+                        imputed_group.iloc[last_subgroup_start:] = imputed_group.iloc[
+                            last_subgroup_start:
+                        ].fillna(prev_fill_values)
+
+            group_dfs.append(imputed_group)
 
         # Create a new dataframe by concatenating all groups
         result_dfs.append(

--- a/projects/rocprofiler-compute/tests/test_utils.py
+++ b/projects/rocprofiler-compute/tests/test_utils.py
@@ -7730,6 +7730,210 @@ def test_amdsmi_get_gpu_memory_partition():
 
 
 # =============================================================================
+# TESTS FOR ITERATION MULTIPLEXING
+# =============================================================================
+
+
+def test_impute_counters_iteration_multiplex():
+    """Test impute_counters_iteration_multiplex with sample DataFrame."""
+    import pandas as pd
+
+    data = {
+        ("file1", "Dispatch_ID"): [1, 2, 3],
+        ("file1", "GPU_ID"): [0, 0, 0],
+        ("file1", "Grid_Size"): [1024, 512, 1024],
+        ("file1", "Workgroup_Size"): [64, 64, 64],
+        ("file1", "LDS_Per_Workgroup"): [32, 32, 32],
+        ("file1", "Scratch_Per_Workitem"): [0, 0, 0],
+        ("file1", "Arch_VGPR"): [16, 16, 16],
+        ("file1", "Accum_VGPR"): [0, 0, 0],
+        ("file1", "SGPR"): [32, 32, 32],
+        ("file1", "Kernel_Name"): ["kernel_a", "kernel_a", "kernel_a"],
+        ("file1", "Start_Timestamp"): [1000, 1200, 1400],
+        ("file1", "End_Timestamp"): [1500, 1700, 1900],
+        ("file1", "Kernel_ID"): [1, 1, 1],
+        ("file1", "Counter1"): [100, None, None],
+        ("file1", "Counter2"): [None, 500, 300],
+    }
+
+    df = pd.DataFrame(data)
+    df.columns = pd.MultiIndex.from_tuples(df.columns)
+
+    # For "kernel" policy
+    result = utils.impute_counters_iteration_multiplex(df, "kernel")
+    # Sort by Dispatch_ID to ensure consistent order
+    result = result.sort_values(by=("file1", "Dispatch_ID"))
+    assert isinstance(result, pd.DataFrame)
+    assert len(result) == 3  # Ensure same number of rows
+    # Assert Counter1 and Counter2 imputed for first two dispatches
+    assert result[("file1", "Counter2")].iloc[0] == 500
+    assert result[("file1", "Counter1")].iloc[1] == 100
+
+    # For "kernel_launch_params" policy
+    result = utils.impute_counters_iteration_multiplex(df, "kernel_launch_params")
+    # Sort by Dispatch_ID to ensure consistent order
+    result = result.sort_values(by=("file1", "Dispatch_ID"))
+    # Assert Counter1 and Counter2 imputed for first and last dispatches
+    assert result[("file1", "Counter2")].iloc[0] == 300
+    assert result[("file1", "Counter1")].iloc[2] == 100
+
+    assert isinstance(result, pd.DataFrame)
+    assert len(result) == 3  # Ensure same number of rows
+
+    data = {
+        ("file1", "Dispatch_ID"): [1, 2, 3],
+        ("file1", "GPU_ID"): [0, 0, 0],
+        ("file1", "Grid_Size"): [1024, 1024, 1024],
+        ("file1", "Workgroup_Size"): [64, 64, 32],
+        ("file1", "LDS_Per_Workgroup"): [32, 24, 32],
+        ("file1", "Scratch_Per_Workitem"): [0, 0, 0],
+        ("file1", "Arch_VGPR"): [16, 16, 16],
+        ("file1", "Accum_VGPR"): [0, 0, 0],
+        ("file1", "SGPR"): [32, 32, 32],
+        ("file1", "Kernel_Name"): ["kernel_a", "kernel_a", "kernel_a"],
+        ("file1", "Start_Timestamp"): [1000, 1200, 1400],
+        ("file1", "End_Timestamp"): [1500, 1700, 1900],
+        ("file1", "Kernel_ID"): [1, 1, 1],
+        ("file1", "Counter1"): [100, None, 300],
+        ("file1", "Counter2"): [None, 500, None],
+    }
+
+    df = pd.DataFrame(data)
+    df.columns = pd.MultiIndex.from_tuples(df.columns)
+
+    result = utils.impute_counters_iteration_multiplex(df, "kernel_launch_params")
+    # Sort by Dispatch_ID to ensure consistent order
+    result = result.sort_values(by=("file1", "Dispatch_ID"))
+
+    assert isinstance(result, pd.DataFrame)
+    assert len(result) == 3  # Ensure same number of rows
+    # No imputation possible
+    assert pd.isna(result[("file1", "Counter2")].iloc[0])
+    assert pd.isna(result[("file1", "Counter1")].iloc[1])
+    assert pd.isna(result[("file1", "Counter2")].iloc[2])
+
+    # Test multi_kernel
+    data = {
+        ("file1", "Dispatch_ID"): [1, 2, 3],
+        ("file1", "GPU_ID"): [0, 0, 0],
+        ("file1", "Grid_Size"): [1024, 1024, 512],
+        ("file1", "Workgroup_Size"): [64, 64, 64],
+        ("file1", "LDS_Per_Workgroup"): [32, 32, 32],
+        ("file1", "Scratch_Per_Workitem"): [0, 0, 0],
+        ("file1", "Arch_VGPR"): [16, 16, 16],
+        ("file1", "Accum_VGPR"): [0, 0, 0],
+        ("file1", "SGPR"): [32, 32, 32],
+        ("file1", "Kernel_Name"): ["kernel_a", "kernel_b", "kernel_a"],
+        ("file1", "Start_Timestamp"): [1000, 1200, 1400],
+        ("file1", "End_Timestamp"): [1500, 1700, 1900],
+        ("file1", "Kernel_ID"): [1, 1, 1],
+        ("file1", "Counter1"): [100, None, None],
+        ("file1", "Counter2"): [None, 500, 300],
+    }
+
+    df = pd.DataFrame(data)
+    df.columns = pd.MultiIndex.from_tuples(df.columns)
+
+    # For "kernel" policy
+    result = utils.impute_counters_iteration_multiplex(df, "kernel")
+    # Sort by Dispatch_ID to ensure consistent order
+    result = result.sort_values(by=("file1", "Dispatch_ID"))
+    # Assert Counter1 and Counter2 imputed for first and last dispatches
+    assert result[("file1", "Counter2")].iloc[0] == 300
+    assert result[("file1", "Counter1")].iloc[2] == 100
+
+    assert isinstance(result, pd.DataFrame)
+    assert len(result) == 3  # Ensure same number of rows
+
+    # For "kernel_launch_params" policy
+    data = {
+        ("file1", "Dispatch_ID"): [1, 2, 3],
+        ("file1", "GPU_ID"): [0, 0, 0],
+        ("file1", "Grid_Size"): [1024, 1024, 1024],
+        ("file1", "Workgroup_Size"): [64, 64, 32],
+        ("file1", "LDS_Per_Workgroup"): [32, 24, 32],
+        ("file1", "Scratch_Per_Workitem"): [0, 0, 0],
+        ("file1", "Arch_VGPR"): [16, 16, 16],
+        ("file1", "Accum_VGPR"): [0, 0, 0],
+        ("file1", "SGPR"): [32, 32, 32],
+        ("file1", "Kernel_Name"): ["kernel_a", "kernel_a", "kernel_a"],
+        ("file1", "Start_Timestamp"): [1000, 1200, 1400],
+        ("file1", "End_Timestamp"): [1500, 1700, 1900],
+        ("file1", "Kernel_ID"): [1, 1, 1],
+        ("file1", "Counter1"): [100, None, 300],
+        ("file1", "Counter2"): [None, 500, None],
+    }
+
+    df = pd.DataFrame(data)
+    df.columns = pd.MultiIndex.from_tuples(df.columns)
+
+    result = utils.impute_counters_iteration_multiplex(df, "kernel_launch_params")
+    # Sort by Dispatch_ID to ensure consistent order
+    result = result.sort_values(by=("file1", "Dispatch_ID"))
+
+    assert isinstance(result, pd.DataFrame)
+    assert len(result) == 3  # Ensure same number of rows
+    # No imputation possible
+    assert pd.isna(result[("file1", "Counter2")].iloc[0])
+    assert pd.isna(result[("file1", "Counter1")].iloc[1])
+    assert pd.isna(result[("file1", "Counter2")].iloc[2])
+
+    # Test incomplete last subgroup handling and no cross-subgroup contamination
+    # Scenario: 3 counter buckets, 8 dispatches (2 complete subgroups + incomplete last)
+    # Subgroup 0: rows 0-2, Subgroup 1: rows 3-5, Subgroup 2 (incomplete): rows 6-7
+    data = {
+        ("file1", "Dispatch_ID"): [1, 2, 3, 4, 5, 6, 7, 8],
+        ("file1", "GPU_ID"): [0, 0, 0, 0, 0, 0, 0, 0],
+        ("file1", "Grid_Size"): [1024, 1024, 1024, 1024, 1024, 1024, 1024, 1024],
+        ("file1", "Workgroup_Size"): [64, 64, 64, 64, 64, 64, 64, 64],
+        ("file1", "LDS_Per_Workgroup"): [32, 32, 32, 32, 32, 32, 32, 32],
+        ("file1", "Scratch_Per_Workitem"): [0, 0, 0, 0, 0, 0, 0, 0],
+        ("file1", "Arch_VGPR"): [16, 16, 16, 16, 16, 16, 16, 16],
+        ("file1", "Accum_VGPR"): [0, 0, 0, 0, 0, 0, 0, 0],
+        ("file1", "SGPR"): [32, 32, 32, 32, 32, 32, 32, 32],
+        ("file1", "Kernel_Name"): ["kernel_a"] * 8,
+        ("file1", "Start_Timestamp"): [1000, 1200, 1400, 1600, 1800, 2000, 2200, 2400],
+        ("file1", "End_Timestamp"): [1100, 1300, 1500, 1700, 1900, 2100, 2300, 2500],
+        ("file1", "Kernel_ID"): [1, 1, 1, 1, 1, 1, 1, 1],
+        # Counter bucket pattern: A, B, C (repeats)
+        ("file1", "Counter_A"): [100, None, None, 200, None, None, 300, None],
+        ("file1", "Counter_B"): [None, 110, None, None, 210, None, None, 310],
+        ("file1", "Counter_C"): [None, None, 120, None, None, 220, None, None],
+    }
+
+    df = pd.DataFrame(data)
+    df.columns = pd.MultiIndex.from_tuples(df.columns)
+    result = utils.impute_counters_iteration_multiplex(df, "kernel_launch_params")
+    result = result.sort_values(by=("file1", "Dispatch_ID"))
+
+    # Verify complete subgroups: all rows should have all counters
+    assert result[("file1", "Counter_A")].iloc[0] == 100
+    assert result[("file1", "Counter_A")].iloc[1] == 100
+    assert result[("file1", "Counter_A")].iloc[2] == 100
+    assert result[("file1", "Counter_B")].iloc[0] == 110
+    assert result[("file1", "Counter_C")].iloc[0] == 120
+
+    # Verify no cross-subgroup contamination: subgroup 1 has its own values
+    assert result[("file1", "Counter_A")].iloc[3] == 200
+    assert result[("file1", "Counter_A")].iloc[4] == 200
+    assert result[("file1", "Counter_B")].iloc[3] == 210
+    assert result[("file1", "Counter_C")].iloc[3] == 220
+
+    # Verify incomplete last subgroup gets filled from previous subgroup
+    # Row 6-7 only have Counter_A and Counter_B, missing Counter_C
+    assert result[("file1", "Counter_A")].iloc[6] == 300
+    assert result[("file1", "Counter_A")].iloc[7] == 300
+    assert result[("file1", "Counter_B")].iloc[6] == 310
+    assert result[("file1", "Counter_B")].iloc[7] == 310
+    # Counter_C should be filled from previous subgroup via global ffill
+    assert result[("file1", "Counter_C")].iloc[6] == 220
+    assert result[("file1", "Counter_C")].iloc[7] == 220
+
+    assert isinstance(result, pd.DataFrame)
+    assert len(result) == 8  # Ensure same number of rows
+
+
+# =============================================================================
 # validate_roofline_csv TESTS
 # =============================================================================
 


### PR DESCRIPTION
## Motivation

### Problem
* The data imputation used nested python loops resulting in O(num_unique_kernels * num_subgroups * num_counters) time complexity
* This made data imputation prohibitively slow for workloads with large number of dispatches and uniquer kernels
* Data imputation took 12 minutes for workload with 12k dispatches and 9 unique kernels!


### Performance impact of implemented solution:
* Optimized: 0.0139 seconds per group
* Baseline: 3.57 seconds per group
* Speedup: ~260x

### Logging
* Added debug logging to indicate data imputation is being performed on X dispatches across Y kernels

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

* Eliminate per counter and per subgroup loop to reduce time complexity to O(num_unique_kernels)
* Instead use chained call `groupby().bfill().ffill()` which leverages pandas vectorized CPython routines
* Logic is preserved since for a given dispatch group and counter, only one valid non-null value exists
* Last incomplete dispatch group edge case handling is also preserved

<!-- Explain the changes along with any relevant GitHub links. -->

## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan
* All existing unit tests pass without modification
* Logic correctness verified via test_impute_counters_iteration_multiplex

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

* Tests pass

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
