### PR TITLE
rocr: Remove ldrm_bo from AllocationRegion

### DIFF
--- a/projects/rocr-runtime/runtime/hsa-runtime/core/inc/runtime.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/inc/runtime.h
@@ -552,7 +552,6 @@ class Runtime {
           size_requested(0),
           alloc_flags(core::MemoryRegion::AllocateNoFlags),
           user_ptr(nullptr),
-          ldrm_bo(nullptr),
           thunk_bo(nullptr) {}
     AllocationRegion(const MemoryRegion* region_arg, size_t size_arg, size_t size_requested,
                      MemoryRegion::AllocateFlags alloc_flags)
@@ -561,7 +560,6 @@ class Runtime {
           size_requested(size_requested),
           alloc_flags(alloc_flags),
           user_ptr(nullptr),
-          ldrm_bo(nullptr),
           thunk_bo(nullptr) {}
 
     struct notifier_t {
@@ -576,7 +574,6 @@ class Runtime {
     MemoryRegion::AllocateFlags alloc_flags;
     void* user_ptr;
     std::unique_ptr<std::vector<notifier_t>> notifiers;
-    amdgpu_bo_handle ldrm_bo;
     HsaMemoryObjectHandle thunk_bo;
   };
 

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/runtime.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/runtime.cpp
@@ -362,8 +362,8 @@ hsa_status_t Runtime::FreeMemory(void* ptr) {
 
     notifiers = std::move(it->second.notifiers);
 
-    //track the exporter BO to clear meta data via set_metadata
-    //clear the set metadata here if possible if theres an existing ldrm_bo
+    // track the exporter BO to clear meta data via set_metadata
+    // clear the set metadata here if possible if theres an existing thunk_bo
     if (it->second.thunk_bo) {
       if (!thunkLoader()->IsDXG()) {
         //clear metadata

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/runtime.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/runtime.cpp
@@ -363,7 +363,7 @@ hsa_status_t Runtime::FreeMemory(void* ptr) {
     notifiers = std::move(it->second.notifiers);
 
     // track the exporter BO to clear meta data via set_metadata
-    // clear the set metadata here if possible if theres an existing thunk_bo
+    // clear the set metadata here if possible if there's an existing thunk_bo
     if (it->second.thunk_bo) {
       if (!thunkLoader()->IsDXG()) {
         //clear metadata


### PR DESCRIPTION
## Motivation

Removal of AllocationRegion::ldrm_bo as it is not used.

## Technical Details

It seems that ldrm_bo is no longer needed since amdgpu calls have moved out of Runtime.

## JIRA ID

NA

## Test Plan

Run roctst.

## Test Result

Success.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
