### PR TITLE
clr: Eliminate unnecessary kernel name string copies

### DIFF
--- a/projects/clr/hipamd/src/hip_code_object.cpp
+++ b/projects/clr/hipamd/src/hip_code_object.cpp
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2015 - 2021 Advanced Micro Devices, Inc. All rights reserved.
+Copyright (c) 2026 Advanced Micro Devices, Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -103,7 +103,7 @@ DynCO::~DynCO() {
   delete fb_info_;
 }
 
-hipError_t DynCO::getDeviceVar(DeviceVar** dvar, std::string var_name) {
+hipError_t DynCO::getDeviceVar(DeviceVar** dvar, const std::string& var_name) {
   amd::ScopedLock lock(dclock_);
   IHIP_RETURN_ONFAIL(populateDynGlobalVars());
   auto it = vars_.find(var_name);
@@ -116,7 +116,7 @@ hipError_t DynCO::getDeviceVar(DeviceVar** dvar, std::string var_name) {
   return err;
 }
 
-hipError_t DynCO::getDynFunc(hipFunction_t* hfunc, std::string func_name) {
+hipError_t DynCO::getDynFunc(hipFunction_t* hfunc, const std::string& func_name) {
   amd::ScopedLock lock(dclock_);
 
   if (hfunc == nullptr) {

--- a/projects/clr/hipamd/src/hip_code_object.hpp
+++ b/projects/clr/hipamd/src/hip_code_object.hpp
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2015 - 2021 Advanced Micro Devices, Inc. All rights reserved.
+Copyright (c) 2026 Advanced Micro Devices, Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -115,12 +115,12 @@ public:
   hipModule_t getModule() const { return module_; };
 
   // Gets GlobalVar/Functions from a dynamically loaded code object
-  hipError_t getDynFunc(hipFunction_t* hfunc, std::string func_name);
+  hipError_t getDynFunc(hipFunction_t* hfunc, const std::string& func_name);
   hipError_t getFuncCount(unsigned int* count);
   bool isValidDynFunc(const void* hfunc);
-  hipError_t getDeviceVar(DeviceVar** dvar, std::string var_name);
+  hipError_t getDeviceVar(DeviceVar** dvar, const std::string& var_name);
 
-  hipError_t getManagedVarPointer(std::string name, void** pointer, size_t* size_ptr) {
+  hipError_t getManagedVarPointer(const std::string& name, void** pointer, size_t* size_ptr) {
     IHIP_RETURN_ONFAIL(populateDynGlobalVars());
     auto it = vars_.find(name);
     if (it != vars_.end() && it->second->getVarKind() == Var::DVK_Managed) {

--- a/projects/clr/hipamd/src/hip_graph_internal.cpp
+++ b/projects/clr/hipamd/src/hip_graph_internal.cpp
@@ -1,4 +1,4 @@
-/* Copyright (c) 2021 - 2025 Advanced Micro Devices, Inc.
+/* Copyright (c) 2026 Advanced Micro Devices, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal
@@ -1130,7 +1130,7 @@ hipError_t GraphExec::CaptureAndFormPacketsForGraph() {
           auto& currentNode = segment.nodes[j];
           // Capture packets for this node
           std::vector<uint8_t*> nodePackets;
-          std::vector<std::string> nodeKernelNames;
+          std::vector<const std::string*> nodeKernelNames;
           status = currentNode->CaptureAndFormPacket(GetKernelArgManager(), &nodePackets,
                                                      &nodeKernelNames);
 
@@ -1274,7 +1274,7 @@ hipError_t GraphExec::UpdateAQLPacket(hip::GraphNode* node) {
 
       // Capture new packets for this node
       std::vector<uint8_t*> newPackets;
-      std::vector<std::string> newKernelNames;
+      std::vector<const std::string*> newKernelNames;
       hipError_t status = node->CaptureAndFormPacket(kernArgManager_, &newPackets,
                                                                       &newKernelNames);
       if (status != hipSuccess) {
@@ -1301,7 +1301,7 @@ hipError_t GraphExec::UpdateAQLPacket(hip::GraphNode* node) {
                                              static_cast<size_t>(packetDelta), nullptr);
           packetBatch.dispatchKernelNames.insert(
               packetBatch.dispatchKernelNames.begin() + insertPos,
-              static_cast<size_t>(packetDelta), std::string());
+              static_cast<size_t>(packetDelta), nullptr);
         } else {
           // Negative packetDelta, remove excess packet slots from the end of this node's range
           const size_t removePos = range.startIndex + newPacketCount;
@@ -1701,7 +1701,7 @@ hipError_t GraphExec::EnqueueSegment(const Segment& segment, hip::Stream* stream
 
         // Select which vectors to dispatch based on whether nodes are disabled
         const std::vector<uint8_t*>* packetsToDispatch;
-        const std::vector<std::string>* kernelNamesToDispatch;
+        const std::vector<const std::string*>* kernelNamesToDispatch;
 
         if (packetBatch.disabledNodeCount == 0) {
           // No disabled nodes - use full batch

--- a/projects/clr/hipamd/src/hip_graph_internal.hpp
+++ b/projects/clr/hipamd/src/hip_graph_internal.hpp
@@ -1,4 +1,4 @@
-/* Copyright (c) 2021 - 2025 Advanced Micro Devices, Inc.
+/* Copyright (c) 2026 Advanced Micro Devices, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal
@@ -240,8 +240,8 @@ class GraphNode : public hipGraphNodeDOTAttribute {
   }
   // Return gpu packet address to update with actual packet under capture.
   std::vector<uint8_t*>& GetAqlPackets() { return gpuPackets_; }
-  void SetKernelName(const std::string& kernelName) { capturedKernelName_ = kernelName; }
-  const std::string& GetKernelName() const { return capturedKernelName_; }
+  void SetKernelName(const std::string* kernelName) { capturedKernelName_ = kernelName; }
+  const std::string* GetKernelName() const { return capturedKernelName_; }
   size_t GetKerArgSize() const { return alignedKernArgSize_; }
   size_t GetKernargSegmentByteSize() const { return kernargSegmentByteSize_; }
   size_t GetKernargSegmentAlignment() const { return kernargSegmentAlignment_; }
@@ -249,7 +249,7 @@ class GraphNode : public hipGraphNodeDOTAttribute {
   //! Capture packets and accumulate them into a batch if provided
   hipError_t CaptureAndFormPacket(GraphKernelArgManager* kernArgMgr,
                                   std::vector<uint8_t*>* batchPackets = nullptr,
-                                  std::vector<std::string>* batchKernelNames = nullptr) {
+                                  std::vector<const std::string*>* batchKernelNames = nullptr) {
     auto capture_stream = hip::getNullStream(g_devices[dev_id_]->devices()[0]->context(), false);
     hipError_t status = CreateCommand(capture_stream);
     if (status != hipSuccess) {
@@ -499,7 +499,7 @@ class GraphNode : public hipGraphNodeDOTAttribute {
   unsigned int isEnabled_;
   bool signal_is_required_ = false;   //!< This node requires a signal on the command
   std::vector<uint8_t*> gpuPackets_;  //!< GPU Packet to enqueue during graph launch
-  std::string capturedKernelName_;
+  const std::string* capturedKernelName_ = nullptr;
   size_t alignedKernArgSize_ = 256;       //!< Aligned size required for kernel args
   size_t kernargSegmentByteSize_ = 512;   //!< Kernel arg segment byte size
   size_t kernargSegmentAlignment_ = 256;  //!< Kernel arg segment alignment
@@ -1070,11 +1070,11 @@ class GraphExec : public amd::ReferenceCountedObject, public Graph {
   struct PacketBatch {
     // Main dispatch vectors - always ready for batch dispatch
     std::vector<uint8_t*> dispatchPackets;
-    std::vector<std::string> dispatchKernelNames;
+    std::vector<const std::string*> dispatchKernelNames;
 
     // Cached filtered lists - built on-demand when nodes are disabled
     std::vector<uint8_t*> enabledPackets;
-    std::vector<std::string> enabledKernelNames;
+    std::vector<const std::string*> enabledKernelNames;
 
     // Node tracking
     struct NodeRange {

--- a/projects/clr/rocclr/device/device.hpp
+++ b/projects/clr/rocclr/device/device.hpp
@@ -1,4 +1,4 @@
-/* Copyright (c) 2008 - 2025 Advanced Micro Devices, Inc.
+/* Copyright (c) 2026 Advanced Micro Devices, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal
@@ -1333,7 +1333,7 @@ class VirtualDevice : public amd::ReferenceCountedObject {
 
   //! Dispatches multiple AQL packets in a single batch operation
   virtual bool dispatchAqlPacketBatch(const std::vector<uint8_t*>& packets,
-                                      const std::vector<std::string>& kernelNames,
+                                      const std::vector<const std::string*>& kernelNames,
                                       amd::AccumulateCommand* vcmd = nullptr,
                                       bool attach_signal = false) = 0;
   //! Returns the number of outstanding HSA async handlers

--- a/projects/clr/rocclr/device/devprogram.cpp
+++ b/projects/clr/rocclr/device/devprogram.cpp
@@ -1,4 +1,4 @@
-/* Copyright (c) 2008 - 2022 Advanced Micro Devices, Inc.
+/* Copyright (c) 2026 Advanced Micro Devices, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal
@@ -1926,7 +1926,7 @@ bool Program::createKernelMetadataMap(void* binary, size_t binSize) {
     }
 
     if (status == AMD_COMGR_STATUS_SUCCESS) {
-      kernelMetadataMap_[kernelName] = kernelNode;
+      kernelMetadataMap_[std::move(kernelName)] = kernelNode;
     } else {
       if (hasKernelNode) {
         amd::Comgr::destroy_metadata(kernelNode);

--- a/projects/clr/rocclr/device/devprogram.hpp
+++ b/projects/clr/rocclr/device/devprogram.hpp
@@ -1,4 +1,4 @@
-/* Copyright (c) 2008 - 2021 Advanced Micro Devices, Inc.
+/* Copyright (c) 2026 Advanced Micro Devices, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal
@@ -244,7 +244,7 @@ class Program : public amd::HeapObject {
   amd_comgr_metadata_node_t metadata() const { return metadata_; }
 
   //! Get the kernel metadata
-  const bool getKernelMetadata(const std::string name, amd_comgr_metadata_node_t* meta) const {
+  const bool getKernelMetadata(const std::string& name, amd_comgr_metadata_node_t* meta) const {
     auto it = kernelMetadataMap_.find(name);
     if (it != kernelMetadataMap_.end()) {
       *meta = it->second;

--- a/projects/clr/rocclr/device/pal/palkernel.cpp
+++ b/projects/clr/rocclr/device/pal/palkernel.cpp
@@ -1,4 +1,4 @@
-/* Copyright (c) 2015 - 2022 Advanced Micro Devices, Inc.
+/* Copyright (c) 2026 Advanced Micro Devices, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal
@@ -85,7 +85,7 @@ bool Kernel::setKernelCode(amd::hsa::loader::Symbol* sym, amd_kernel_code_t* akc
   return true;
 }
 
-Kernel::Kernel(std::string name, pal::Program* prog, bool internalKernel)
+Kernel::Kernel(const std::string& name, pal::Program* prog, bool internalKernel)
     : device::Kernel(prog->device(), name, *prog), index_(0), code_(0), codeSize_(0) {
   flags_.hsa_ = true;
   flags_.internalKernel_ = internalKernel;

--- a/projects/clr/rocclr/device/pal/palkernel.hpp
+++ b/projects/clr/rocclr/device/pal/palkernel.hpp
@@ -1,4 +1,4 @@
-/* Copyright (c) 2015 - 2021 Advanced Micro Devices, Inc.
+/* Copyright (c) 2026 Advanced Micro Devices, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal
@@ -59,7 +59,7 @@ class Program;
  */
 class Kernel : public device::Kernel {
  public:
-  Kernel(std::string name, pal::Program* prog, bool internalKernel);
+  Kernel(const std::string& name, pal::Program* prog, bool internalKernel);
 
   virtual ~Kernel();
 

--- a/projects/clr/rocclr/device/pal/palvirtual.hpp
+++ b/projects/clr/rocclr/device/pal/palvirtual.hpp
@@ -1,4 +1,4 @@
-/* Copyright (c) 2015 - 2025 Advanced Micro Devices, Inc.
+/* Copyright (c) 2026 Advanced Micro Devices, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal
@@ -365,7 +365,7 @@ class VirtualGPU : public device::VirtualDevice {
 
   //! Dispatches multiple AQL packets in a single batch operation
   bool dispatchAqlPacketBatch(const std::vector<uint8_t*>& packets,
-                              const std::vector<std::string>& kernelNames,
+                              const std::vector<const std::string*>& kernelNames,
                               amd::AccumulateCommand* vcmd = nullptr, bool attach_signal = false) {
     return false;
   }

--- a/projects/clr/rocclr/device/rocm/rockernel.hpp
+++ b/projects/clr/rocclr/device/rocm/rockernel.hpp
@@ -1,4 +1,4 @@
-/* Copyright (c) 2009 - 2021 Advanced Micro Devices, Inc.
+/* Copyright (c) 2026 Advanced Micro Devices, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal
@@ -29,7 +29,7 @@ namespace amd::roc {
 
 class Kernel : public device::Kernel {
  public:
-  Kernel(std::string name, Program* prog) : device::Kernel(prog->device(), name, *prog) {}
+  Kernel(const std::string& name, Program* prog) : device::Kernel(prog->device(), name, *prog) {}
 
   virtual ~Kernel() {
     if (program() != nullptr) {

--- a/projects/clr/rocclr/device/rocm/rocvirtual.cpp
+++ b/projects/clr/rocclr/device/rocm/rocvirtual.cpp
@@ -1,4 +1,4 @@
-/* Copyright (c) 2013 - 2025 Advanced Micro Devices, Inc.
+/* Copyright (c) 2026 Advanced Micro Devices, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal
@@ -1267,7 +1267,7 @@ bool VirtualGPU::dispatchAqlPacket(hsa_barrier_and_packet_t* packet, uint16_t he
 template <typename AqlPacket>
 bool VirtualGPU::dispatchGenericAqlPacketBatch(const std::vector<AqlPacket*>& packets,
                                                bool blocking, bool attach_signal,
-                                               const std::vector<std::string>* kernelNames) {
+                                               const std::vector<const std::string*>* kernelNames) {
   if (packets.empty()) {
     return false;
   }
@@ -1405,7 +1405,7 @@ bool VirtualGPU::dispatchGenericAqlPacketBatch(const std::vector<AqlPacket*>& pa
             extractAqlBits(headerForPrint, HSA_PACKET_HEADER_TYPE, HSA_PACKET_HEADER_WIDTH_TYPE);
         if (packetType == HSA_PACKET_TYPE_KERNEL_DISPATCH) {
           ClPrint(amd::LOG_DETAIL_DEBUG, amd::LOG_KERN2, "Graph ShaderName : %s, device id : %u",
-                  (*kernelNames)[packetIndex].c_str(), dev().index());
+                  (*kernelNames)[packetIndex]->c_str(), dev().index());
 
           ClPrint(amd::LOG_DETAIL_DEBUG, amd::LOG_AQL,
                   "SWq=0x%zx, HWq=0x%zx, id=%d, Dispatch Header = "
@@ -1481,7 +1481,7 @@ bool VirtualGPU::dispatchGenericAqlPacketBatch(const std::vector<AqlPacket*>& pa
 
 // ================================================================================================
 bool VirtualGPU::dispatchAqlPacketBatch(const std::vector<uint8_t*>& packets,
-                                        const std::vector<std::string>& kernelNames,
+                                        const std::vector<const std::string*>& kernelNames,
                                         amd::AccumulateCommand* vcmd, bool attach_signal) {
   if (vcmd == nullptr || packets.empty() || packets.size() != kernelNames.size()) {
     return false;

--- a/projects/clr/rocclr/device/rocm/rocvirtual.hpp
+++ b/projects/clr/rocclr/device/rocm/rocvirtual.hpp
@@ -1,4 +1,4 @@
-/* Copyright (c) 2008 - 2025 Advanced Micro Devices, Inc.
+/* Copyright (c) 2026 Advanced Micro Devices, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal
@@ -512,15 +512,16 @@ class VirtualGPU : public device::VirtualDevice {
 
   //! Dispatches multiple AQL packets in a single batch operation
   bool dispatchAqlPacketBatch(const std::vector<uint8_t*>& packets,
-                              const std::vector<std::string>& kernelNames,
+                              const std::vector<const std::string*>& kernelNames,
                               amd::AccumulateCommand* vcmd = nullptr, bool attach_signal = false);
   template <typename AqlPacket> bool dispatchGenericAqlPacket(AqlPacket* packet, uint16_t header,
                                                               uint16_t rest, bool blocking,
                                                               bool attach_signal = false);
   //! Dispatches multiple AQL packets with a single doorbell ring
-  template <typename AqlPacket> bool dispatchGenericAqlPacketBatch(const std::vector<AqlPacket*>& packets,
-                                                                   bool blocking, bool attach_signal = false,
-                                                                   const std::vector<std::string>* kernelNames = nullptr);
+  template <typename AqlPacket>
+  bool dispatchGenericAqlPacketBatch(const std::vector<AqlPacket*>& packets, bool blocking,
+                                     bool attach_signal = false,
+                                     const std::vector<const std::string*>* kernelNames = nullptr);
 
   bool dispatchCounterAqlPacket(hsa_ext_amd_aql_pm4_packet_t* packet, const uint32_t gfxVersion,
                                 bool blocking, const hsa_ven_amd_aqlprofile_1_00_pfn_t* extApi);

--- a/projects/clr/rocclr/platform/activity.cpp
+++ b/projects/clr/rocclr/platform/activity.cpp
@@ -1,4 +1,4 @@
-/* Copyright (c) 2019 - 2021 Advanced Micro Devices, Inc.
+/* Copyright (c) 2026 Advanced Micro Devices, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal
@@ -103,13 +103,13 @@ void ReportActivity(const amd::Command& command) {
 
   if (command.type() == CL_COMMAND_TASK) {
     auto timestamps = static_cast<const amd::AccumulateCommand&>(command).getTimestamps();
-    std::vector<std::string> kernel_names =
+    const auto& kernel_names =
         static_cast<const amd::AccumulateCommand&>(command).getKernelNames();
     for (uint32_t i = 0; i < timestamps.size() && i < kernel_names.size(); i++) {
       auto it = timestamps[i];
       record.begin_ns = it.first;
       record.end_ns = it.second;
-      record.kernel_name = kernel_names[i].c_str();
+      record.kernel_name = kernel_names[i] != nullptr ? kernel_names[i]->c_str() : "";
       function(ACTIVITY_DOMAIN_HIP_OPS, operation_id, &record);
     }
   } else {

--- a/projects/clr/rocclr/platform/command.hpp
+++ b/projects/clr/rocclr/platform/command.hpp
@@ -1,4 +1,4 @@
-/* Copyright (c) 2010 - 2025 Advanced Micro Devices, Inc.
+/* Copyright (c) 2026 Advanced Micro Devices, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal
@@ -311,7 +311,7 @@ class Command : public Event {
   std::vector<uint8_t*>* gpuPackets_;  //!< GPU packets captured when graph capturing is enabled
   GraphKernelArgManager* graphKernArgMgr_ = nullptr;  //!< KernelMgr for graph
   address kernArgOffset_ = nullptr;  //!< KernelArg buffer to used when graph capturing is enabled
-  std::string* capturedKernelName_ = nullptr;  //!< Kenrnel under capture
+  const std::string** capturedKernelName_ = nullptr;  //!< Kernel under capture
  protected:
   bool cpu_wait_ = false;  //!< If true, then the command was issued for CPU/GPU sync
 
@@ -359,17 +359,17 @@ class Command : public Event {
   //! Sets AQL capture state, aql packet to capture and where to copy kernArgs
   void setPktCapturingState(bool state, std::vector<uint8_t*>* packet,
                             amd::GraphKernelArgManager* graphKernArgMgr,
-                            std::string* capturedKernelName) {
+                            const std::string** capturedKernelName) {
     packetCapturing_ = state;
     gpuPackets_ = packet;
     graphKernArgMgr_ = graphKernArgMgr;
     capturedKernelName_ = capturedKernelName;
   }
 
-  //! Updates kernel name with the captured kernel name
+  //! Updates kernel name with the captured kernel name (stores pointer, no copy)
   void SetKernelName(const std::string& kernelName) {
     if (capturedKernelName_ != nullptr) {
-      *capturedKernelName_ = kernelName;
+      *capturedKernelName_ = &kernelName;
     }
   }
 
@@ -1486,8 +1486,8 @@ class Marker : public Command {
 class AccumulateCommand : public Command {
  private:
   //! Kernel names and timestamps list for activity profiling
-  std::vector<std::string> kernelNames_;
-  const std::vector<std::string>* kernelNamesRef_ = nullptr;
+  std::vector<const std::string*> kernelNames_;
+  const std::vector<const std::string*>* kernelNamesRef_ = nullptr;
   std::vector<std::pair<uint64_t, uint64_t>> tsList_;
   //! HW events that need to be released when this command is destroyed
   std::unordered_map<Device*, std::vector<void*>> hw_events_;
@@ -1513,15 +1513,15 @@ class AccumulateCommand : public Command {
   }
 
   //! Add kernel name to the list if available
-  void addKernelName(const std::string& kernelName) { kernelNames_.push_back(kernelName); }
+  void addKernelName(const std::string* kernelName) { kernelNames_.push_back(kernelName); }
 
   //! Add multiple kernel names in bulk
-  void addKernelNames(const std::vector<std::string>& kernelNames) {
+  void addKernelNames(const std::vector<const std::string*>& kernelNames) {
     kernelNames_.insert(kernelNames_.end(), kernelNames.begin(), kernelNames.end());
   }
 
   //! Set kernel names by reference
-  void setKernelNamesRef(const std::vector<std::string>* kernelNames) {
+  void setKernelNamesRef(const std::vector<const std::string*>* kernelNames) {
     kernelNamesRef_ = kernelNames;
   }
 
@@ -1530,8 +1530,8 @@ class AccumulateCommand : public Command {
     tsList_.push_back(std::make_pair(startTs, endTs));
   }
 
-  //! Return the kernel names
-  const std::vector<std::string>& getKernelNames() const {
+  //! Return the kernel names (pointers to stable strings, no copies)
+  const std::vector<const std::string*>& getKernelNames() const {
     return kernelNamesRef_ != nullptr ? *kernelNamesRef_ : kernelNames_;
   }
 


### PR DESCRIPTION
Kernel names (often 2KB+ for mangled/demangled C++ symbols) were being copied by value at numerous points in the dispatch and graph capture paths.
- Pass-by-const-reference for lookup-only parameters
- Pointer-based kernel name propagation in graph capture

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
