### PR TITLE
[rocprofiler-sdk] Fix incorrect rocprofiler_context_is_valid documentation

### DIFF
--- a/projects/rocprofiler-sdk/source/include/rocprofiler-sdk/context.h
+++ b/projects/rocprofiler-sdk/source/include/rocprofiler-sdk/context.h
@@ -86,7 +86,7 @@ rocprofiler_context_is_active(rocprofiler_context_id_t context_id, int* status) 
  * @brief Query whether the context is valid
  *
  * @param [in] context_id Context identifier for the query
- * @param [out] status If context is invalid, this will be a nonzero value
+ * @param [out] status If context is valid, this will be a nonzero value
  * @return ::rocprofiler_status_t
  */
 rocprofiler_status_t

--- a/projects/rocprofiler-sdk/source/include/rocprofiler-sdk/registration.h
+++ b/projects/rocprofiler-sdk/source/include/rocprofiler-sdk/registration.h
@@ -159,7 +159,7 @@ rocprofiler_is_finalized(int* status) ROCPROFILER_API ROCPROFILER_NONNULL(1);
  *
  *      if(int valid_ctx = 0;
  *         rocprofiler_context_is_valid(ctx, &valid_ctx) != ROCPROFILER_STATUS_SUCCESS ||
- *         valid_ctx != 0)
+ *         valid_ctx == 0)
  *      {
  *          // notify rocprofiler that initialization failed
  *          // and all the contexts, buffers, etc. created


### PR DESCRIPTION
The documentation for rocprofiler_context_is_valid() incorrectly stated that the output parameter `status` would be non-zero when the context is invalid.

This patch corrects the parameter documentation in context.h and fixes an example in registration.h where the validity check used the wrong condition (`valid_ctx != 0` instead of `valid_ctx == 0`).

No functional changes.