### PR TITLE
[AMD-SMI][SWDEV-581081] Catch invalid handles

### DIFF
--- a/projects/amdsmi/src/amd_smi/amd_smi.cc
+++ b/projects/amdsmi/src/amd_smi/amd_smi.cc
@@ -2202,6 +2202,7 @@ amdsmi_status_t amdsmi_get_fw_info(amdsmi_processor_handle processor_handle,
 
   AMDSMI_CHECK_INIT();
 
+  // Fail-fast: validate handle before work; rsmi_wrapper also validates internally
   amd::smi::AMDSmiGPUDevice* gpu_device = nullptr;
   amdsmi_status_t status = get_gpu_device_from_handle(processor_handle, &gpu_device);
   if (status != AMDSMI_STATUS_SUCCESS) {
@@ -2554,6 +2555,7 @@ amdsmi_status_t amdsmi_get_gpu_kfd_info(amdsmi_processor_handle processor_handle
   }
 
   // default to 0xffffffffffffffff as not supported
+  // Fail-fast: validate handle before work; rsmi_wrapper also validates internally
   amd::smi::AMDSmiGPUDevice* gpu_device = nullptr;
   amdsmi_status_t status = get_gpu_device_from_handle(processor_handle, &gpu_device);
   if (status != AMDSMI_STATUS_SUCCESS) {

--- a/projects/amdsmi/src/amd_smi/amd_smi.cc
+++ b/projects/amdsmi/src/amd_smi/amd_smi.cc
@@ -2207,6 +2207,7 @@ amdsmi_status_t amdsmi_get_fw_info(amdsmi_processor_handle processor_handle,
   if (status != AMDSMI_STATUS_SUCCESS) {
     return status;
   }
+  (void)gpu_device;  // Only used for handle validation
 
   if (info == nullptr) {
     return AMDSMI_STATUS_INVAL;
@@ -2558,6 +2559,7 @@ amdsmi_status_t amdsmi_get_gpu_kfd_info(amdsmi_processor_handle processor_handle
   if (status != AMDSMI_STATUS_SUCCESS) {
     return status;
   }
+  (void)gpu_device;  // Only used for handle validation
   info->kfd_id = std::numeric_limits<uint64_t>::max();
   auto tmp_kfd_id = uint64_t(0);
   status = rsmi_wrapper(rsmi_dev_guid_get, processor_handle, 0, &(tmp_kfd_id));

--- a/projects/amdsmi/src/amd_smi/amd_smi.cc
+++ b/projects/amdsmi/src/amd_smi/amd_smi.cc
@@ -2202,14 +2202,22 @@ amdsmi_status_t amdsmi_get_fw_info(amdsmi_processor_handle processor_handle,
 
   AMDSMI_CHECK_INIT();
 
-  if (info == nullptr) return AMDSMI_STATUS_INVAL;
+  amd::smi::AMDSmiGPUDevice* gpu_device = nullptr;
+  amdsmi_status_t status = get_gpu_device_from_handle(processor_handle, &gpu_device);
+  if (status != AMDSMI_STATUS_SUCCESS) {
+    return status;
+  }
+
+  if (info == nullptr) {
+    return AMDSMI_STATUS_INVAL;
+  }
   memset(info, 0, sizeof(amdsmi_fw_info_t));
 
   // collect all rsmi supported fw block
   for (auto ite = fw_in_rsmi.begin(); ite != fw_in_rsmi.end(); ite++) {
-    auto status = rsmi_wrapper(rsmi_dev_firmware_version_get, processor_handle, 0, (*ite).second,
-                               &(info->fw_info_list[info->num_fw_info].fw_version));
-    if (status == AMDSMI_STATUS_SUCCESS) {
+    auto r = rsmi_wrapper(rsmi_dev_firmware_version_get, processor_handle, 0, (*ite).second,
+                          &(info->fw_info_list[info->num_fw_info].fw_version));
+    if (r == AMDSMI_STATUS_SUCCESS) {
       info->fw_info_list[info->num_fw_info].fw_id = (*ite).first;
       info->num_fw_info++;
     }
@@ -2544,8 +2552,12 @@ amdsmi_status_t amdsmi_get_gpu_kfd_info(amdsmi_processor_handle processor_handle
     return AMDSMI_STATUS_INVAL;
   }
 
-  amdsmi_status_t status;
   // default to 0xffffffffffffffff as not supported
+  amd::smi::AMDSmiGPUDevice* gpu_device = nullptr;
+  amdsmi_status_t status = get_gpu_device_from_handle(processor_handle, &gpu_device);
+  if (status != AMDSMI_STATUS_SUCCESS) {
+    return status;
+  }
   info->kfd_id = std::numeric_limits<uint64_t>::max();
   auto tmp_kfd_id = uint64_t(0);
   status = rsmi_wrapper(rsmi_dev_guid_get, processor_handle, 0, &(tmp_kfd_id));


### PR DESCRIPTION
These Api's " amdsmi_get_gpu_kfd_info" & "amdsmi_get_fw_info" do not return NOT_FOUND when wrong handle is passed.

After this code changes, they will provide response as below.

<img width="700" height="355" alt="swd_581081" src="https://github.com/user-attachments/assets/65b6215d-cee3-421a-84c4-6e1bb5f2523a" />

