### PR TITLE
rocrtst: ASAN fixes: skip negative alloc tests under ASAN

### DIFF
--- a/projects/rocr-runtime/rocrtst/suites/negative/memory_allocate_negative_tests.cc
+++ b/projects/rocr-runtime/rocrtst/suites/negative/memory_allocate_negative_tests.cc
@@ -203,6 +203,16 @@ void MemoryAllocateNegativeTest::MaxMemoryAllocateTest(hsa_agent_t agent,
     return;
   }
 
+#ifdef ROCRTST_ASAN
+  // Under ASAN, hsa_amd_memory_pool_allocate is intercepted by the ASAN runtime and uses
+  // ASAN's own heap allocator. Attempting to allocate (max_size + gran_sz) bytes from ASAN's
+  // heap allocator causes an OOM abort that kills the entire process. Skip this check under ASAN.
+  if (verbosity() > 0) {
+    std::cout << "  Skipping MaxMemoryAllocate under ASAN (ASAN heap OOM)" << std::endl;
+    std::cout << kSubTestSeparator << std::endl;
+  }
+  return;
+#else
     char *memoryPtr;
   auto gran_sz = pool_i.alloc_granule;
   size_t max_size = pool_i.aggregate_alloc_max;
@@ -210,6 +220,7 @@ void MemoryAllocateNegativeTest::MaxMemoryAllocateTest(hsa_agent_t agent,
                                        reinterpret_cast<void**>(&memoryPtr));
     ASSERT_EQ(err, HSA_STATUS_ERROR_INVALID_ALLOCATION);
   return;
+#endif
 }
 
 
@@ -235,10 +246,21 @@ void MemoryAllocateNegativeTest::ZeroMemoryAllocateTest(hsa_agent_t agent,
                    HSA_AMD_MEMORY_POOL_INFO_RUNTIME_ALLOC_ALLOWED, &alloc);
 
   if (alloc) {
+#ifdef ROCRTST_ASAN
+    // Under ASAN, hsa_amd_memory_pool_allocate is intercepted by the ASAN runtime and
+    // internally calls malloc(0), which returns a non-null pointer (success). The real HSA
+    // runtime returns HSA_STATUS_ERROR_INVALID_ARGUMENT. Skip this check under ASAN.
+    if (verbosity() > 0) {
+      std::cout << "  Skipping ZeroMemoryAllocate under ASAN (ASAN interceptor masks HSA validation)" << std::endl;
+      std::cout << kSubTestSeparator << std::endl;
+    }
+    return;
+#else
     char *memoryPtr;
     err = hsa_amd_memory_pool_allocate(pool, 0, 0,
                                        reinterpret_cast<void**>(&memoryPtr));
     ASSERT_EQ(err, HSA_STATUS_ERROR_INVALID_ARGUMENT);
+#endif
   }
   return;
 }


### PR DESCRIPTION
MaxMemoryAllocate and ZeroMemoryAllocate produce false failures when built with ASAN: the intercepted allocator either OOM-aborts the process on an oversized request or returns non-null for size-0, masking the HSA error codes under test. Guard both subtests with ROCRTST_ASAN Cmake defined macro at rocrtst build time

## Motivation

MaxMemoryAllocateTest — process abort (OOM crash)

ASAN wraps all allocations via its interceptor. When hsa_amd_memory_pool_allocate(pool, max_size + granule, ...) is called, ROCR internally calls into ASAN's heap allocator to satisfy the request before it ever reaches the size-validation logic. On MI300A that request is ~125 GiB + granule. ASAN's shadow memory requires 1/8th of the requested virtual range to be reserved for its shadow map, so a 125 GiB allocation needs ~16 GiB of shadow space. The allocator calls mmap for that shadow region, gets ENOMEM, and calls abort() — killing the entire test process immediately with no GTest failure, no cleanup, and no output other than an ASAN fatal error message.

ZeroMemoryAllocateTest — silent wrong result 

ASAN intercepts malloc(0) (which is what the HSA allocator calls internally for a 0-byte request) and returns a valid non-null pointer rather than NULL. ROCR then sees a successful allocation and returns HSA_STATUS_SUCCESS. The test asserts err == HSA_STATUS_ERROR_INVALID_ARGUMENT —due tomismatch - Expected: HSA_STATUS_ERROR_INVALID_ARGUMENT vs Actual: HSA_STATUS_SUCCESS. The process doesn't crash — it just reports a false test failure and continues.

There is no other way to run these two tests under ASAN. So skipping these to prevent crashes in CI builds. 

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
