### PR TITLE
Don't wait on command completion if worker thread is destroyed

### DIFF
--- a/projects/clr/rocclr/platform/commandqueue.cpp
+++ b/projects/clr/rocclr/platform/commandqueue.cpp
@@ -172,6 +172,12 @@ void HostQueue::finish(bool cpu_wait) {
       ClPrint(LOG_DEBUG, LOG_CMD, "No command awaiting completion on host");
       return;
     }
+
+    if (!AMD_DIRECT_DISPATCH && !Os::isThreadAlive(thread_)) {
+      command->release();
+      return;
+    }
+
     // Force blocking wait if requested. That allows to avoid a build up of unreleased CPU commands
     if ((DEBUG_HIP_BLOCK_SYNC > 0) &&
         (vdev()->QueuedAsyncHandlers().load() > DEBUG_HIP_BLOCK_SYNC)) {


### PR DESCRIPTION
## Motivation

Pytorch test hangs with stacktrace: 
```
amdhip64_7!amd::Os::yield
amdhip64_7!amd::Event::awaitCompletion
amdhip64_7!amd::HostQueue::finish
amdhip64_7!hip::Device::SyncAllStreams
amdhip64_7!hip::__hipUnregisterFatBinary::<lambda>::operator()
amdhip64_7!std::call_once<lambda>
amdhip64_7!hip::__hipUnregisterFatBinary
amdhip64_7!__hipUnregisterFatBinary
torch_hip!<atexit handler>
```

## Technical Details

If worker thread gets destroyed before all async work is done, main thread could hang waiting on completion signal.

## JIRA ID

ROCM-1547

## Test Plan

/ 

## Test Result

/ 

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
