### PR TITLE
[hip-tests] ROCM-2280 - fix Unit_Coalesced_Group_Tiled_Partition_Sync…

### DIFF
--- a/projects/hip-tests/catch/unit/cooperativeGrps/coalesced_group_tiled_partition.cc
+++ b/projects/hip-tests/catch/unit/cooperativeGrps/coalesced_group_tiled_partition.cc
@@ -676,8 +676,7 @@ template <bool global_memory, typename T> void CoalescedGroupTiledPartitionSyncT
       const bool is_last_warp = ((j + 1) == warps_in_block);
       if (is_last_warp && tail > 0) {
         const uint32_t valid_lanes = warp_size - tail;
-        const uint64_t valid_mask =
-            (valid_lanes == 64) ? ~0ull : ((1ull << valid_lanes) - 1ull);
+        const uint64_t valid_mask = (1ull << valid_lanes) - 1ull;
         mask &= valid_mask;
       }
 

--- a/projects/hip-tests/catch/unit/cooperativeGrps/coalesced_group_tiled_partition.cc
+++ b/projects/hip-tests/catch/unit/cooperativeGrps/coalesced_group_tiled_partition.cc
@@ -668,9 +668,19 @@ template <bool global_memory, typename T> void CoalescedGroupTiledPartitionSyncT
     for (int j = 0u; j < warps_in_block; ++j) {
       const auto warp_idx = i * warps_in_block + j;
       auto mask = active_masks.ptr()[warp_idx];
-      const auto shift_amount =
-          (tail + 32 * TestContext::get().isNvidia()) * !((warp_idx + 1) % warps_in_block);
-      mask = (mask << shift_amount) >> shift_amount;
+      if (warp_size < 64) {
+        const uint64_t lane_mask = (1ull << warp_size) - 1ull;
+        mask &= lane_mask;
+      }
+
+      const bool is_last_warp = ((j + 1) == warps_in_block);
+      if (is_last_warp && tail > 0) {
+        const uint32_t valid_lanes = warp_size - tail;
+        const uint64_t valid_mask =
+            (valid_lanes == 64) ? ~0ull : ((1ull << valid_lanes) - 1ull);
+        mask &= valid_mask;
+      }
+
       const auto active_count = std::bitset<sizeof(mask) * 8>(mask).count();
       const auto start_offset = i * grid.threads_in_block_count_ + j * warp_size;
       const auto end_offset = start_offset + active_count;


### PR DESCRIPTION
…_Positive_Basic

## Motivation
Test was failing on navi cards
<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details
The test trimmed the active lane mask incorrectly. It used `isNvidia()` and only applied the upper‑bits trim on the last warp in a block. 

Fix:
- Trim the mask based on the actual warp_size for every warp (clear upper (64 - warp_size) bits when warp_size == 32)
- if it’s the last warp and the block is partial, clear the tail lanes at the top of that warp.
<!-- Explain the changes along with any relevant GitHub links. -->

## JIRA ID
ROCM-2280
<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan
local testing on gfx1100
<!-- Explain any relevant testing done to verify this PR. -->

## Test Result
all tests from cooperative test suite passes
<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
