### PR TITLE
Add config header generation to standalone test build readme

### DIFF
--- a/projects/hip-tests/.gitignore
+++ b/projects/hip-tests/.gitignore
@@ -7,6 +7,7 @@ lib
 packages
 build
 tags
+__pycache__
 samples/0_Intro/module_api/runKernel.hip.out
 samples/0_Intro/module_api/vcpy_isa.code
 samples/0_Intro/module_api/vcpy_isa.hsaco

--- a/projects/hip-tests/catch/README.md
+++ b/projects/hip-tests/catch/README.md
@@ -182,8 +182,13 @@ The process must be a standalone exe inside the same folder as other tests.
 Initially, the new tests can be enabled via using ```-DHIP_CATCH_TEST=1```. After porting existing tests, this will be turned on by default.
 
 ## Building a single test
+Generate `hip_tests_config.hh` before compilation
 ```bash
-hipcc <path_to_test.cpp> -I<HIP_SRC_DIR>/tests/catch/include <HIP_SRC_DIR>/tests/catch/hipTestMain/standalone_main.cc -I<HIP_SRC_DIR>/tests/catch/external/Catch2 -g -o <out_file_name>
+python3 <HIP_SRC_DIR>/catch/config/parse_config.py <HIP_SRC_DIR>/catch/config/configs <PLATFORM> <OS> <ARCH> <CONFIG_TARGET_DIR>/hip_tests_config.hh
+```
+
+```bash
+hipcc <path_to_test.cpp> -I<HIP_SRC_DIR>/tests/catch/include -I<CONFIG_TARGET_DIR> <HIP_SRC_DIR>/tests/catch/hipTestMain/standalone_main.cc -I<HIP_SRC_DIR>/tests/catch/external/Catch2 -g -o <out_file_name>
 ```
 
 ## Debugging support

--- a/projects/hip-tests/catch/README.md
+++ b/projects/hip-tests/catch/README.md
@@ -188,7 +188,7 @@ python3 <HIP_SRC_DIR>/catch/config/parse_config.py <HIP_SRC_DIR>/catch/config/co
 ```
 
 ```bash
-hipcc <path_to_test.cpp> -I<HIP_SRC_DIR>/tests/catch/include -I<CONFIG_TARGET_DIR> <HIP_SRC_DIR>/tests/catch/hipTestMain/standalone_main.cc -I<HIP_SRC_DIR>/tests/catch/external/Catch2 -g -o <out_file_name>
+hipcc -I <HIP_SRC_DIR>/catch/include -I <HIP_SRC_DIR>/catch/external/picojson -I <CONFIG_TARGET_DIR> <HIP_SRC_DIR>/catch/hipTestMain/main.cc <HIP_SRC_DIR>/catch/hipTestMain/hip_test_context.cc -I <CATCH2_INCLUDE_DIR> -L <CATCH2_LIB_DIR> -lCatch2 -I $HIP_PATH/include -O1 -ggdb <PATH_TO_TEST.cc> -o <OUT_FILE_NAME>
 ```
 
 ## Debugging support

--- a/projects/hip-tests/catch/config/CMakeLists.txt
+++ b/projects/hip-tests/catch/config/CMakeLists.txt
@@ -22,23 +22,15 @@ else()
     endforeach()
 endif()
 
-set(HIP_TESTS_CONFIG_DIR ${CMAKE_CURRENT_SOURCE_DIR})
-set(HIP_TESTS_CONFIGS_DIR ${HIP_TESTS_CONFIG_DIR}/configs)
-set(CONFIG_COMMON_MODULE ${HIP_TESTS_CONFIG_DIR}/common.py)
-set(CONFIG_PARSER_SCRIPT ${HIP_TESTS_CONFIG_DIR}/parse_config.py)
-set(CONFIG_CHECK_SCRIPT ${HIP_TESTS_CONFIG_DIR}/check_config.py)
-set(SOURCES_CHECK_SCRIPT ${HIP_TESTS_CONFIG_DIR}/check_sources.py)
+set(HIP_TESTS_CONFIGS_DIR ${CMAKE_CURRENT_SOURCE_DIR}/configs)
+set(CONFIG_COMMON_MODULE ${CMAKE_CURRENT_SOURCE_DIR}/common.py)
+set(CONFIG_PARSER_SCRIPT ${CMAKE_CURRENT_SOURCE_DIR}/parse_config.py)
+set(CONFIG_CHECK_SCRIPT ${CMAKE_CURRENT_SOURCE_DIR}/check_config.py)
+set(SOURCES_CHECK_SCRIPT ${CMAKE_CURRENT_SOURCE_DIR}/check_sources.py)
 set(HIP_TESTS_CONFIG_HEADER ${CATCH_INCLUDE_BINARY_DIR}/hip_tests_config.hh)
 
-file(GLOB HIP_TESTS_UNIT_CONFIGS ${HIP_TESTS_CONFIGS_DIR}/unit/*.yaml)
 file(GLOB HIP_TESTS_GROUP_CONFIGS ${HIP_TESTS_CONFIGS_DIR}/*.yaml)
-file(GLOB_RECURSE HIP_TESTS_SOURCES ${CMAKE_SOURCE_DIR}/unit/*.cc
-                                     ${CMAKE_SOURCE_DIR}/ABM/*.cc
-                                     ${CMAKE_SOURCE_DIR}/multiproc/*.cc
-                                     ${CMAKE_SOURCE_DIR}/performance/*.cc
-                                     ${CMAKE_SOURCE_DIR}/perftests/*.cc
-                                     ${CMAKE_SOURCE_DIR}/stress/*.cc
-                                     ${CMAKE_SOURCE_DIR}/TypeQualifiers/*.cc)
+file(GLOB HIP_TESTS_UNIT_CONFIGS ${HIP_TESTS_CONFIGS_DIR}/unit/*.yaml)
 
 add_custom_target(check_hip_tests_config ALL
     COMMAND "${Python3_EXECUTABLE}" "${CONFIG_CHECK_SCRIPT}" "${HIP_TESTS_CONFIGS_DIR}"
@@ -46,7 +38,7 @@ add_custom_target(check_hip_tests_config ALL
 )
 
 add_custom_target(check_hip_tests_sources ALL
-    COMMAND "${Python3_EXECUTABLE}" "${SOURCES_CHECK_SCRIPT}" "${HIP_TESTS_CONFIGS_DIR}"
+    COMMAND "${Python3_EXECUTABLE}" "${SOURCES_CHECK_SCRIPT}" "${HIP_TESTS_CONFIGS_DIR}" "${CMAKE_SOURCE_DIR}"
     COMMENT "Checking hip-tests sources for missing YAML configurations"
 )
 

--- a/projects/hip-tests/catch/config/CMakeLists.txt
+++ b/projects/hip-tests/catch/config/CMakeLists.txt
@@ -23,14 +23,15 @@ else()
 endif()
 
 set(HIP_TESTS_CONFIG_DIR ${CMAKE_CURRENT_SOURCE_DIR})
+set(HIP_TESTS_CONFIGS_DIR ${HIP_TESTS_CONFIG_DIR}/configs)
 set(CONFIG_COMMON_MODULE ${HIP_TESTS_CONFIG_DIR}/common.py)
 set(CONFIG_PARSER_SCRIPT ${HIP_TESTS_CONFIG_DIR}/parse_config.py)
 set(CONFIG_CHECK_SCRIPT ${HIP_TESTS_CONFIG_DIR}/check_config.py)
 set(SOURCES_CHECK_SCRIPT ${HIP_TESTS_CONFIG_DIR}/check_sources.py)
 set(HIP_TESTS_CONFIG_HEADER ${CATCH_INCLUDE_BINARY_DIR}/hip_tests_config.hh)
 
-file(GLOB HIP_TESTS_UNIT_CONFIGS ${HIP_TESTS_CONFIG_DIR}/configs/unit/*.yaml)
-file(GLOB HIP_TESTS_GROUP_CONFIGS ${HIP_TESTS_CONFIG_DIR}/configs/*.yaml)
+file(GLOB HIP_TESTS_UNIT_CONFIGS ${HIP_TESTS_CONFIGS_DIR}/unit/*.yaml)
+file(GLOB HIP_TESTS_GROUP_CONFIGS ${HIP_TESTS_CONFIGS_DIR}/*.yaml)
 file(GLOB_RECURSE HIP_TESTS_SOURCES ${CMAKE_SOURCE_DIR}/unit/*.cc
                                      ${CMAKE_SOURCE_DIR}/ABM/*.cc
                                      ${CMAKE_SOURCE_DIR}/multiproc/*.cc
@@ -40,18 +41,18 @@ file(GLOB_RECURSE HIP_TESTS_SOURCES ${CMAKE_SOURCE_DIR}/unit/*.cc
                                      ${CMAKE_SOURCE_DIR}/TypeQualifiers/*.cc)
 
 add_custom_target(check_hip_tests_config ALL
-    COMMAND "${Python3_EXECUTABLE}" "${CONFIG_CHECK_SCRIPT}" "${HIP_TESTS_CONFIG_DIR}"
+    COMMAND "${Python3_EXECUTABLE}" "${CONFIG_CHECK_SCRIPT}" "${HIP_TESTS_CONFIGS_DIR}"
     COMMENT "Validating hip-tests YAML configurations"
 )
 
 add_custom_target(check_hip_tests_sources ALL
-    COMMAND "${Python3_EXECUTABLE}" "${SOURCES_CHECK_SCRIPT}" "${HIP_TESTS_CONFIG_DIR}"
+    COMMAND "${Python3_EXECUTABLE}" "${SOURCES_CHECK_SCRIPT}" "${HIP_TESTS_CONFIGS_DIR}"
     COMMENT "Checking hip-tests sources for missing YAML configurations"
 )
 
 add_custom_command(
     OUTPUT ${HIP_TESTS_CONFIG_HEADER}
-    COMMAND "${Python3_EXECUTABLE}" "${CONFIG_PARSER_SCRIPT}" "${HIP_TESTS_CONFIG_DIR}" "${HIP_PLATFORM}" "${CONFIG_OS}" "${CONFIG_ARCH}" "${HIP_TESTS_CONFIG_HEADER}"
+    COMMAND "${Python3_EXECUTABLE}" "${CONFIG_PARSER_SCRIPT}" "${HIP_TESTS_CONFIGS_DIR}" "${HIP_PLATFORM}" "${CONFIG_OS}" "${CONFIG_ARCH}" "${HIP_TESTS_CONFIG_HEADER}"
     DEPENDS ${CONFIG_COMMON_MODULE} ${CONFIG_PARSER_SCRIPT} ${HIP_TESTS_UNIT_CONFIGS} ${HIP_TESTS_GROUP_CONFIGS}
     COMMENT "Generating hip_tests_config.hh"
 )

--- a/projects/hip-tests/catch/config/check_config.py
+++ b/projects/hip-tests/catch/config/check_config.py
@@ -1,17 +1,29 @@
+import argparse
 import sys
 
 from common import iter_group_configs
 
 
-def main():
-    if not len(sys.argv) == 2:
-        raise ValueError("1 argument expected")
+def parse_args():
+    parser = argparse.ArgumentParser(
+        description="Check that every test case in the YAML configs has a "
+        "'level' field defined.",
+    )
+    parser.add_argument(
+        "configs_path",
+        help="Path to the directory containing YAML config files.",
+    )
+    return parser.parse_args()
 
-    config_path = sys.argv[1]
+
+def main():
+    args = parse_args()
+
+    configs_path = args.configs_path
 
     missing = []
 
-    for group, cases in iter_group_configs(config_path):
+    for group, cases in iter_group_configs(configs_path):
         for case_name, case_config in cases.items():
             if "level" not in case_config:
                 missing.append(f"  {group}/{case_name}")

--- a/projects/hip-tests/catch/config/check_sources.py
+++ b/projects/hip-tests/catch/config/check_sources.py
@@ -1,3 +1,4 @@
+import argparse
 import os
 import re
 import sys
@@ -37,16 +38,31 @@ def is_unit_group(group):
     return group not in NON_UNIT_GROUPS
 
 
-def main():
-    if not len(sys.argv) == 2:
-        raise ValueError("1 argument expected")
+def parse_args():
+    parser = argparse.ArgumentParser(
+        description="Check that every Catch2 test case found in the source "
+        "tree has a corresponding entry in the YAML configs.",
+    )
+    parser.add_argument(
+        "configs_path",
+        help="Path to the directory containing YAML config files.",
+    )
+    parser.add_argument(
+        "source_root",
+        help="Root directory of the Catch2 test source files.",
+    )
+    return parser.parse_args()
 
-    config_path = sys.argv[1]
-    source_root = os.path.dirname(config_path)
+
+def main():
+    args = parse_args()
+
+    configs_path = args.configs_path
+    source_root = args.source_root
 
     missing = []
 
-    for group, cases in iter_group_configs(config_path):
+    for group, cases in iter_group_configs(configs_path):
         yaml_names = set(cases.keys())
         source_names = find_source_test_cases(
             source_root, group, is_unit=is_unit_group(group)

--- a/projects/hip-tests/catch/config/common.py
+++ b/projects/hip-tests/catch/config/common.py
@@ -23,13 +23,12 @@ def load_config(file_path, definitions_text):
     return yaml.safe_load(combined)
 
 
-def iter_group_configs(config_path):
+def iter_group_configs(configs_path):
     """Yield (group, config) pairs for all unit and non-unit config files.
 
     Iterates unit configs first (sorted alphabetically), then non-unit groups
     in the order defined by NON_UNIT_GROUPS.
     """
-    configs_path = os.path.join(config_path, "configs")
     definitions_path = os.path.join(configs_path, "definitions.yaml")
     with open(definitions_path) as file:
         definitions_text = file.read()

--- a/projects/hip-tests/catch/config/parse_config.py
+++ b/projects/hip-tests/catch/config/parse_config.py
@@ -31,7 +31,6 @@ def main():
     os_name = sys.argv[3]
     arch = sys.argv[4]
     header_path = sys.argv[5]
-    print(configs_path)
 
     test_macros = []
 

--- a/projects/hip-tests/catch/config/parse_config.py
+++ b/projects/hip-tests/catch/config/parse_config.py
@@ -26,15 +26,16 @@ def main():
     if not len(sys.argv) == 6:
         raise ValueError("5 arguments expected")
 
-    config_path = sys.argv[1]
+    configs_path = sys.argv[1]
     platform = sys.argv[2]
     os_name = sys.argv[3]
     arch = sys.argv[4]
     header_path = sys.argv[5]
+    print(configs_path)
 
     test_macros = []
 
-    for group, cases in iter_group_configs(config_path):
+    for group, cases in iter_group_configs(configs_path):
         for case_name, case_config in cases.items():
             test_macros.append(
                 create_test_definition(

--- a/projects/hip-tests/catch/config/parse_config.py
+++ b/projects/hip-tests/catch/config/parse_config.py
@@ -1,6 +1,34 @@
-import sys
+import argparse
 
 from common import iter_group_configs
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(
+        description="Parse YAML test configs and generate a C/C++ header with "
+        "Catch2 TEST_CASE macro definitions.",
+    )
+    parser.add_argument(
+        "configs_path",
+        help="Path to the directory containing YAML config files.",
+    )
+    parser.add_argument(
+        "platform",
+        help="Target platform (e.g. amd, nvidia).",
+    )
+    parser.add_argument(
+        "os_name",
+        help="Target operating system (e.g. linux, windows).",
+    )
+    parser.add_argument(
+        "arch",
+        help="Target architecture (e.g. gfx90a, gfx942).",
+    )
+    parser.add_argument(
+        "header_path",
+        help="Output path for the generated header file.",
+    )
+    return parser.parse_args()
 
 
 def create_test_definition(group, case_name, case_config, platform, os_name, arch):
@@ -23,14 +51,13 @@ def create_test_definition(group, case_name, case_config, platform, os_name, arc
 
 
 def main():
-    if not len(sys.argv) == 6:
-        raise ValueError("5 arguments expected")
+    args = parse_args()
 
-    configs_path = sys.argv[1]
-    platform = sys.argv[2]
-    os_name = sys.argv[3]
-    arch = sys.argv[4]
-    header_path = sys.argv[5]
+    configs_path = args.configs_path
+    platform = args.platform
+    os_name = args.os_name
+    arch = args.arch
+    header_path = args.header_path
 
     test_macros = []
 


### PR DESCRIPTION
## Motivation

Explain in the README how can standalone tests be compiled by manually generating hip_tests_config.hh

## Technical Details

None

## JIRA ID

None

## Test Plan

Build should pass. Standalone tests can be compiled using the instructions

## Test Result

Local build passes. Standalone tests can be compiled locally

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
