### PR TITLE
[rocprof-trace-decoder] Fix missing test dependency

### DIFF
--- a/projects/rocprof-trace-decoder/test/CMakeLists.txt
+++ b/projects/rocprof-trace-decoder/test/CMakeLists.txt
@@ -186,7 +186,9 @@ if(BUILD_INTEGRATION_TESTS)
                            WORKING_DIRECTORY
                            ${TEST_BIN_DIR}
                            FIXTURES_REQUIRED
-                           unpack_data)
+                           unpack_data
+                           DEPENDS
+                           ${DATA}_execute)
         endif()
     endforeach(DATA)
 endif()


### PR DESCRIPTION
## Motivation

Missing test dependency causes spurious test failures depending on test order or parallelism.

## Technical Details

Add dependency.

## JIRA ID

N/A, external contribution from distro maintainer

## Test Plan

ctest! should work on first try reliably without trying to run without data being available yet.

## Test Result

It works!

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
