### PR TITLE
[aqlprofile][rocprofiler-sdk] Add asymmetric CU/WGP dimension support

### DIFF
--- a/projects/aqlprofile/src/core/aql_profile.cpp
+++ b/projects/aqlprofile/src/core/aql_profile.cpp
@@ -645,13 +645,7 @@ hsa_ven_amd_aqlprofile_iterate_data(const hsa_ven_amd_aqlprofile_profile_t* prof
             return HSA_STATUS_ERROR;
 
           // non-MI300A-AID counter event.
-          uint32_t block_samples_count = 1;
-          if (pm4_factory->GetBlockInfo(p)->attr & CounterBlockSeAttr)
-            block_samples_count *= se_number;
-          if (pm4_factory->GetBlockInfo(p)->attr & CounterBlockSaAttr)
-            block_samples_count *= sa_number;
-          if (pm4_factory->GetBlockInfo(p)->attr & CounterBlockWgpAttr)
-            block_samples_count *= pm4_factory->GetNumWGPs();
+          uint32_t block_samples_count = pm4_factory->GetNumEvents(p->block_name);
 
           for (uint32_t blk = 0; blk < block_samples_count; ++blk) {
             hsa_ven_amd_aqlprofile_info_data_t sample_info;

--- a/projects/aqlprofile/src/core/counter_dimensions.hpp
+++ b/projects/aqlprofile/src/core/counter_dimensions.hpp
@@ -29,6 +29,7 @@
 
 #include <cstdint>
 #include <string>
+#include <type_traits>
 #include <vector>
 #include <unordered_map>
 #include <memory>
@@ -112,6 +113,30 @@ class EventAttribDimension {
     cu_num = (pm4_factory->GetComputeUnitNumber() + sarrays - 1) / sarrays;
     wgp_num = (pm4_factory->GetComputeUnitNumber() / 2 + sarrays - 1) / sarrays;
 
+    // Check for per-SE/SA CU bitmap (v2 agent registration)
+    // Only available when agent is aqlprofile_agent_handle_t (not legacy hsa_agent_t)
+    if constexpr (std::is_same_v<AgentType, aqlprofile_agent_handle_t>) {
+      const AgentInfo* agent_ptr = aql_profile::GetAgentInfo(agent);
+      bool has_cu_bitmap = false;
+      if (agent_ptr) {
+        for (uint32_t se = 0; se < 4 && !has_cu_bitmap; se++)
+          for (uint32_t sa = 0; sa < 4 && !has_cu_bitmap; sa++)
+            if (agent_ptr->cu_bitmap[se][sa] != 0) has_cu_bitmap = true;
+      }
+      if (has_cu_bitmap) {
+        uint32_t sa_per_se = pm4_factory->GetShaderArraysNumber();
+        uint32_t se_per_xcc = se_num / (num_xccs > 0 ? num_xccs : 1);
+        uint32_t max_wgp = 0;
+        for (uint32_t se = 0; se < se_per_xcc; se++)
+          for (uint32_t sa = 0; sa < sa_per_se; sa++) {
+            uint32_t cu_count = __builtin_popcount(agent_ptr->cu_bitmap[se][sa]);
+            wgp_per_sa_array[se][sa] = cu_count / 2;
+            if (wgp_per_sa_array[se][sa] > max_wgp) max_wgp = wgp_per_sa_array[se][sa];
+          }
+        if (max_wgp > 0) wgp_num = max_wgp;
+      }
+    }
+
     if (HasAttr(CounterBlockUmcAttr))
       block_instance_count = block_info->instance_count / num_aid;
     else if (compute_unit)
@@ -158,6 +183,11 @@ class EventAttribDimension {
 
   size_t get_num_instances() const { return block_instance_count; }
 
+  uint32_t get_wgp_count(uint32_t se, uint32_t sa) const {
+    if (wgp_per_sa_array[se][sa] > 0) return wgp_per_sa_array[se][sa];
+    return static_cast<uint32_t>(wgp_num);
+  }
+
  private:
   bool HasAttr(CounterBlockAttr attr) const { return (block_info->attr & attr) != 0; }
 
@@ -181,6 +211,7 @@ class EventAttribDimension {
   size_t cu_num = 1;
   size_t wgp_num = 1;
   size_t block_instance_count = 1;
+  uint32_t wgp_per_sa_array[4][4] = {};
 
   std::vector<EventDimension> dimensions;
 

--- a/projects/aqlprofile/src/core/counter_dimensions.hpp
+++ b/projects/aqlprofile/src/core/counter_dimensions.hpp
@@ -127,11 +127,12 @@ class EventAttribDimension {
         uint32_t sa_per_se = pm4_factory->GetShaderArraysNumber();
         uint32_t se_per_xcc = se_num / (num_xccs > 0 ? num_xccs : 1);
         uint32_t max_wgp = 0;
-        for (uint32_t se = 0; se < se_per_xcc; se++)
-          for (uint32_t sa = 0; sa < sa_per_se; sa++) {
+        for (uint32_t se = 0; se < se_per_xcc && se < 4; se++)
+          for (uint32_t sa = 0; sa < sa_per_se && sa < 4; sa++) {
             uint32_t cu_count = __builtin_popcount(agent_ptr->cu_bitmap[se][sa]);
-            wgp_per_sa_array[se][sa] = cu_count / 2;
-            if (wgp_per_sa_array[se][sa] > max_wgp) max_wgp = wgp_per_sa_array[se][sa];
+            wgp_per_sa_array.at(se).at(sa) = cu_count / 2;
+            if (wgp_per_sa_array.at(se).at(sa) > max_wgp)
+              max_wgp = wgp_per_sa_array.at(se).at(sa);
           }
         if (max_wgp > 0) wgp_num = max_wgp;
       }
@@ -184,7 +185,7 @@ class EventAttribDimension {
   size_t get_num_instances() const { return block_instance_count; }
 
   uint32_t get_wgp_count(uint32_t se, uint32_t sa) const {
-    if (wgp_per_sa_array[se][sa] > 0) return wgp_per_sa_array[se][sa];
+    if (wgp_per_sa_array.at(se).at(sa) > 0) return wgp_per_sa_array.at(se).at(sa);
     return static_cast<uint32_t>(wgp_num);
   }
 
@@ -211,7 +212,7 @@ class EventAttribDimension {
   size_t cu_num = 1;
   size_t wgp_num = 1;
   size_t block_instance_count = 1;
-  uint32_t wgp_per_sa_array[4][4] = {};
+  std::array<std::array<uint32_t, 4>, 4> wgp_per_sa_array = {};
 
   std::vector<EventDimension> dimensions;
 

--- a/projects/aqlprofile/src/core/counters.cpp
+++ b/projects/aqlprofile/src/core/counters.cpp
@@ -386,6 +386,10 @@ PUBLIC_API hsa_status_t aqlprofile_register_agent_info(aqlprofile_agent_handle_t
         *agent_id =
             aql_profile::RegisterAgent(static_cast<const aqlprofile_agent_info_v1_t*>(agent_info));
       } break;
+      case AQLPROFILE_AGENT_VERSION_V2: {
+        *agent_id =
+            aql_profile::RegisterAgent(static_cast<const aqlprofile_agent_info_v2_t*>(agent_info));
+      } break;
       case AQLPROFILE_AGENT_VERSION_NONE:
       case AQLPROFILE_AGENT_VERSION_LAST:
         return HSA_STATUS_ERROR_INVALID_ARGUMENT;

--- a/projects/aqlprofile/src/core/include/aqlprofile-sdk/aql_profile_v2.h
+++ b/projects/aqlprofile/src/core/include/aqlprofile-sdk/aql_profile_v2.h
@@ -49,6 +49,7 @@ typedef enum {
   AQLPROFILE_AGENT_VERSION_NONE = 0,
   AQLPROFILE_AGENT_VERSION_V0 = 1,
   AQLPROFILE_AGENT_VERSION_V1 = 2,
+  AQLPROFILE_AGENT_VERSION_V2 = 3,
   AQLPROFILE_AGENT_VERSION_LAST
 } aqlprofile_agent_version_t;
 
@@ -209,6 +210,21 @@ typedef struct {
   uint32_t location_id; /**< BDF (Bus/Device/function number) of the GPU agent
                            (HSA_AMD_AGENT_INFO_BDFID or KFD.location_id)*/
 } aqlprofile_agent_info_v1_t;
+
+/**
+ * @brief Struct containing information about the agent, including per-SE/SA CU bitmaps
+ * for asymmetric CU/WGP configurations.
+ */
+typedef struct {
+  const char* agent_gfxip;
+  uint32_t xcc_num;
+  uint32_t se_num;
+  uint32_t cu_num;
+  uint32_t shader_arrays_per_se;
+  uint32_t domain;
+  uint32_t location_id;
+  uint32_t cu_bitmap[4][4];  /**< Per-SE/SA active CU bitmask (DRM AMDGPU_INFO_DEV_INFO) */
+} aqlprofile_agent_info_v2_t;
 
 /**
  * @brief Struct containing a handle to a registered agent

--- a/projects/aqlprofile/src/core/pm4_factory.cpp
+++ b/projects/aqlprofile/src/core/pm4_factory.cpp
@@ -72,6 +72,28 @@ aqlprofile_agent_handle_t RegisterAgent(const aqlprofile_agent_info_v1_t* agent_
   return agent_id;
 }
 
+aqlprofile_agent_handle_t RegisterAgent(const aqlprofile_agent_info_v2_t* agent_info) {
+  aqlprofile_agent_handle_t agent_id;
+  AgentInfo int_agent_info;
+  int_agent_info.cu_num = agent_info->cu_num;
+  int_agent_info.se_num = agent_info->se_num;
+  int_agent_info.xcc_num = agent_info->xcc_num;
+  int_agent_info.shader_arrays_per_se = agent_info->shader_arrays_per_se;
+  int_agent_info.domain = agent_info->domain;
+  int_agent_info.bdf_id = agent_info->location_id;
+  memcpy(int_agent_info.cu_bitmap, agent_info->cu_bitmap, sizeof(int_agent_info.cu_bitmap));
+
+  auto len = strlen(agent_info->agent_gfxip);
+  memset(int_agent_info.name, 0, sizeof(int_agent_info.name));
+  memcpy(int_agent_info.name, agent_info->agent_gfxip,
+         (len >= sizeof(int_agent_info.name) ? sizeof(int_agent_info.name) - 1 : len));
+  memset(int_agent_info.gfxip, 0, sizeof(int_agent_info.gfxip));
+  memcpy(int_agent_info.gfxip, agent_info->agent_gfxip,
+         (len >= sizeof(int_agent_info.gfxip) ? sizeof(int_agent_info.gfxip) - 1 : len));
+  get_cache().add(agent_id.handle, int_agent_info);
+  return agent_id;
+}
+
 const AgentInfo* GetAgentInfo(aqlprofile_agent_handle_t agent_id) {
   return get_cache().get(agent_id.handle);
 }

--- a/projects/aqlprofile/src/core/pm4_factory.cpp
+++ b/projects/aqlprofile/src/core/pm4_factory.cpp
@@ -49,6 +49,16 @@ locked_agent_cache& get_cache() {
   static auto* cache = new locked_agent_cache{};
   return *cache;
 }
+
+
+auto copy_gfxip = [](AgentInfo& dst, const char* gfxip) {
+  auto len = strnlen(gfxip, sizeof(dst.name));
+  memset(dst.name, 0, sizeof(dst.name));
+  memcpy(dst.name, gfxip, (len >= sizeof(dst.name) ? sizeof(dst.name) - 1 : len));
+  memset(dst.gfxip, 0, sizeof(dst.gfxip));
+  memcpy(dst.gfxip, gfxip, (len >= sizeof(dst.gfxip) ? sizeof(dst.gfxip) - 1 : len));
+};
+
 }  // namespace
 
 aqlprofile_agent_handle_t RegisterAgent(const aqlprofile_agent_info_v1_t* agent_info) {
@@ -60,14 +70,7 @@ aqlprofile_agent_handle_t RegisterAgent(const aqlprofile_agent_info_v1_t* agent_
   int_agent_info.shader_arrays_per_se = agent_info->shader_arrays_per_se;
   int_agent_info.domain = agent_info->domain;
   int_agent_info.bdf_id = agent_info->location_id;
-
-  auto len = strlen(agent_info->agent_gfxip);
-  memset(int_agent_info.name, 0, sizeof(int_agent_info.name));
-  memcpy(int_agent_info.name, agent_info->agent_gfxip,
-         (len >= sizeof(int_agent_info.name) ? sizeof(int_agent_info.name) - 1 : len));
-  memset(int_agent_info.gfxip, 0, sizeof(int_agent_info.gfxip));
-  memcpy(int_agent_info.gfxip, agent_info->agent_gfxip,
-         (len >= sizeof(int_agent_info.gfxip) ? sizeof(int_agent_info.gfxip) - 1 : len));
+  copy_gfxip(int_agent_info, agent_info->agent_gfxip);
   get_cache().add(agent_id.handle, int_agent_info);
   return agent_id;
 }
@@ -82,14 +85,7 @@ aqlprofile_agent_handle_t RegisterAgent(const aqlprofile_agent_info_v2_t* agent_
   int_agent_info.domain = agent_info->domain;
   int_agent_info.bdf_id = agent_info->location_id;
   memcpy(int_agent_info.cu_bitmap, agent_info->cu_bitmap, sizeof(int_agent_info.cu_bitmap));
-
-  auto len = strlen(agent_info->agent_gfxip);
-  memset(int_agent_info.name, 0, sizeof(int_agent_info.name));
-  memcpy(int_agent_info.name, agent_info->agent_gfxip,
-         (len >= sizeof(int_agent_info.name) ? sizeof(int_agent_info.name) - 1 : len));
-  memset(int_agent_info.gfxip, 0, sizeof(int_agent_info.gfxip));
-  memcpy(int_agent_info.gfxip, agent_info->agent_gfxip,
-         (len >= sizeof(int_agent_info.gfxip) ? sizeof(int_agent_info.gfxip) - 1 : len));
+  copy_gfxip(int_agent_info, agent_info->agent_gfxip);
   get_cache().add(agent_id.handle, int_agent_info);
   return agent_id;
 }

--- a/projects/aqlprofile/src/core/pm4_factory.h
+++ b/projects/aqlprofile/src/core/pm4_factory.h
@@ -57,6 +57,7 @@ struct pm4_agent_info {
 const AgentInfo* GetAgentInfo(aqlprofile_agent_handle_t agent_id);
 
 aqlprofile_agent_handle_t RegisterAgent(const aqlprofile_agent_info_v1_t* agent_info);
+aqlprofile_agent_handle_t RegisterAgent(const aqlprofile_agent_info_v2_t* agent_info);
 
 // GPU enumeration
 enum gpu_id_t {
@@ -195,12 +196,24 @@ class Pm4Factory {
     size_t block_samples_count = 1;
     auto* block_info = GetBlockInfo(block_name);
 
-    if (block_info->attr & CounterBlockSeAttr)
-      block_samples_count *= se_number;
-    if (block_info->attr & CounterBlockSaAttr)
-      block_samples_count *= sa_number;
-    if (block_info->attr & CounterBlockWgpAttr)
-      block_samples_count *= GetNumWGPs();
+    if (block_info->attr & CounterBlockWgpAttr) {
+      // For WGP-scoped blocks, use actual per-SE/SA WGP counts for total samples.
+      // This accounts for asymmetric CU/WGP configurations.
+      if (pmc_builder_) {
+        block_samples_count = pmc_builder_->GetTotalWGPSamples(se_number, sa_number);
+      } else {
+        if (block_info->attr & CounterBlockSeAttr)
+          block_samples_count *= se_number;
+        if (block_info->attr & CounterBlockSaAttr)
+          block_samples_count *= sa_number;
+        block_samples_count *= GetNumWGPs();
+      }
+    } else {
+      if (block_info->attr & CounterBlockSeAttr)
+        block_samples_count *= se_number;
+      if (block_info->attr & CounterBlockSaAttr)
+        block_samples_count *= sa_number;
+    }
     return block_samples_count;
   }
 

--- a/projects/aqlprofile/src/core/tests/pm4_factory_tests.cpp
+++ b/projects/aqlprofile/src/core/tests/pm4_factory_tests.cpp
@@ -35,6 +35,56 @@ TEST(Pm4FactoryTest, RegisterAgentAndGetAgentInfo) {
     EXPECT_EQ(info->shader_arrays_per_se, 2u);
 }
 
+// Test: Register agent with v2 struct including cu_bitmap
+TEST(Pm4FactoryTest, RegisterAgentV2WithCuBitmap) {
+    aqlprofile_agent_info_v2_t info_v2{};
+    info_v2.agent_gfxip = "gfx942";
+    info_v2.cu_num = 304;
+    info_v2.se_num = 32;
+    info_v2.xcc_num = 8;
+    info_v2.shader_arrays_per_se = 1;
+    info_v2.domain = 0;
+    info_v2.location_id = 0x5678;
+    // Set asymmetric cu_bitmap: SE0 has 0x3FFFF (18 CUs), SE1 has 0xFFFF (16 CUs)
+    info_v2.cu_bitmap[0][0] = 0x3FFFF;
+    info_v2.cu_bitmap[1][0] = 0xFFFF;
+
+    aqlprofile_agent_handle_t handle = RegisterAgent(&info_v2);
+    const AgentInfo* info = GetAgentInfo(handle);
+    ASSERT_NE(info, nullptr);
+    EXPECT_EQ(info->cu_num, 304u);
+    EXPECT_EQ(info->se_num, 32u);
+    EXPECT_EQ(info->xcc_num, 8u);
+    EXPECT_EQ(info->cu_bitmap[0][0], 0x3FFFFu);
+    EXPECT_EQ(info->cu_bitmap[1][0], 0xFFFFu);
+    EXPECT_EQ(info->cu_bitmap[2][0], 0u);
+}
+
+// Test: v2 registration via RegisterAgent directly
+TEST(Pm4FactoryTest, RegisterAgentInfoV2) {
+    aqlprofile_agent_info_v2_t info_v2{};
+    info_v2.agent_gfxip = "gfx900";
+    info_v2.cu_num = 64;
+    info_v2.se_num = 4;
+    info_v2.xcc_num = 1;
+    info_v2.shader_arrays_per_se = 2;
+    info_v2.domain = 1;
+    info_v2.location_id = 0xABCD;
+    info_v2.cu_bitmap[0][0] = 0xFFFF;
+    info_v2.cu_bitmap[0][1] = 0xFFFF;
+    info_v2.cu_bitmap[1][0] = 0xFFFF;
+    info_v2.cu_bitmap[1][1] = 0xFFFF;
+
+    aqlprofile_agent_handle_t handle = RegisterAgent(&info_v2);
+
+    const AgentInfo* info = GetAgentInfo(handle);
+    ASSERT_NE(info, nullptr);
+    EXPECT_EQ(info->cu_num, 64u);
+    EXPECT_EQ(info->cu_bitmap[0][0], 0xFFFFu);
+    EXPECT_EQ(info->cu_bitmap[1][1], 0xFFFFu);
+    EXPECT_EQ(info->bdf_id, 0xABCDu);
+}
+
 // Test: GetAgentInfo returns nullptr for invalid handle
 TEST(Pm4FactoryTest, GetAgentInfoInvalidHandleReturnsNull) {
     aqlprofile_agent_handle_t invalidHandle{};

--- a/projects/aqlprofile/src/pm4/pmc_builder.h
+++ b/projects/aqlprofile/src/pm4/pmc_builder.h
@@ -109,6 +109,7 @@ class PmcBuilder {
   virtual uint32_t Read(CmdBuffer* cmd_buffer, const counters_vector& counters_vec,
                         void* data_buffer) = 0;
   virtual int GetNumWGPs() = 0;
+  virtual size_t GetTotalWGPSamples(uint32_t se_count, uint32_t sa_count) = 0;
 };
 
 // PMC PM4 commands builder template
@@ -122,6 +123,8 @@ class GpuPmcBuilder : public PmcBuilder, protected Primitives {
   uint32_t sarrays_per_se;
   // XCC number on the GPU
   uint32_t xcc_number_;
+  // Per-SE/SA WGP counts from cu_bitmap (0 means use uniform wgp_per_sa)
+  uint32_t wgp_per_sa_array[4][4] = {};
   Builder builder;
 
   void DebugTrace(uint32_t value) {
@@ -141,6 +144,11 @@ class GpuPmcBuilder : public PmcBuilder, protected Primitives {
     base_index =
         (block_info->attr & CounterBlockExplInstAttr) ? base_index * block_info->counter_count : 0;
     return &(block_info->counter_reg_info[base_index]);
+  }
+
+  uint32_t get_wgp_count_for_sa(uint32_t se, uint32_t sa) const {
+    if (se < 4 && sa < 4 && wgp_per_sa_array[se][sa] > 0) return wgp_per_sa_array[se][sa];
+    return wgp_per_sa;
   }
 
   uint32_t GetAidNumber() const { return (xcc_number_ > 1) ? 4 : 1; }
@@ -206,6 +214,18 @@ class GpuPmcBuilder : public PmcBuilder, protected Primitives {
         sarrays_per_se(agent_info->shader_arrays_per_se) {
     this->wgp_per_sa =
         (agent_info->cu_num / 2 + sarrays_per_se * se_number_ - 1) / (se_number_ * sarrays_per_se);
+
+    // Populate per-SE/SA WGP counts from cu_bitmap if available
+    bool has_bitmap = false;
+    for (uint32_t se = 0; se < 4 && !has_bitmap; se++)
+      for (uint32_t sa = 0; sa < 4 && !has_bitmap; sa++)
+        if (agent_info->cu_bitmap[se][sa] != 0) has_bitmap = true;
+    if (has_bitmap) {
+      for (uint32_t se = 0; se < se_number_ && se < 4; se++)
+        for (uint32_t sa = 0; sa < sarrays_per_se && sa < 4; sa++)
+          wgp_per_sa_array[se][sa] = __builtin_popcount(agent_info->cu_bitmap[se][sa]) / 2;
+    }
+
     // Due to MI300 CP firmware issue we need to use mem_mapped_register mode to patch for GCEA
     // hang. Otherwise both perfcounters mode and mem_mapped_register mode should work.
     builder.bUsePerfCounterMode = (xcc_number_ > 1) ? false : true;
@@ -215,6 +235,15 @@ class GpuPmcBuilder : public PmcBuilder, protected Primitives {
     if (Primitives::GFXIP_LEVEL >= 11) return wgp_per_sa;
     return 1;
   };
+
+  size_t GetTotalWGPSamples(uint32_t se_count, uint32_t sa_count) override {
+    if (Primitives::GFXIP_LEVEL < 11) return se_count * sa_count;
+    size_t total = 0;
+    for (uint32_t se = 0; se < se_count; se++)
+      for (uint32_t sa = 0; sa < sa_count; sa++)
+        total += get_wgp_count_for_sa(se, sa);
+    return total;
+  }
 
   // Build PMC enable PM4 comands - enable CP counting for a specific queue
   void Enable(CmdBuffer* cmd_buffer) {
@@ -599,7 +628,8 @@ class GpuPmcBuilder : public PmcBuilder, protected Primitives {
                 Primitives::GFXIP_LEVEL >= 12 && (block_info->attr & CounterBlockWgpAttr);
 
             if (bIsWGPcounter11) {
-              for (int wgp = 0; wgp < wgp_per_sa; wgp++) {
+              int wgp_count = get_wgp_count_for_sa(se_index, sarray);
+              for (int wgp = 0; wgp < wgp_count; wgp++) {
                 grbm_value = Primitives::grbm_se_sh_wgp_index_value(se_index, sarray, wgp);
                 SetGrbmGfxIndex(cmd_buffer, grbm_value);
                 builder.BuildCopyCounterDataPacket(
@@ -608,7 +638,8 @@ class GpuPmcBuilder : public PmcBuilder, protected Primitives {
                 read_counter += 2;
               }
             } else if (bIsWGPcounter12) {
-              for (int wgp = 0; wgp < wgp_per_sa; wgp++) {
+              int wgp_count = get_wgp_count_for_sa(se_index, sarray);
+              for (int wgp = 0; wgp < wgp_count; wgp++) {
                 if (block_info->instance_count > 1)
                   grbm_value = Primitives::grbm_inst_se_sh_wgp_index_value(block_des.index,
                                                                            se_index, sarray, wgp);

--- a/projects/aqlprofile/src/pm4/pmc_builder.h
+++ b/projects/aqlprofile/src/pm4/pmc_builder.h
@@ -125,6 +125,9 @@ class GpuPmcBuilder : public PmcBuilder, protected Primitives {
   uint32_t xcc_number_;
   // Per-SE/SA WGP counts from cu_bitmap (0 means use uniform wgp_per_sa)
   uint32_t wgp_per_sa_array[4][4] = {};
+  // Per-SE/SA CU bitmaps for logical-to-physical WGP mapping
+  uint32_t cu_bitmap[4][4] = {};
+  bool has_cu_bitmap = false;
   Builder builder;
 
   void DebugTrace(uint32_t value) {
@@ -149,6 +152,26 @@ class GpuPmcBuilder : public PmcBuilder, protected Primitives {
   uint32_t get_wgp_count_for_sa(uint32_t se, uint32_t sa) const {
     if (se < 4 && sa < 4 && wgp_per_sa_array[se][sa] > 0) return wgp_per_sa_array[se][sa];
     return wgp_per_sa;
+  }
+
+  // Convert logical WGP index (0..N-1) to physical WGP index using cu_bitmap.
+  // Each pair of consecutive CU bits represents one WGP: WGP i = CU bits 2i and 2i+1.
+  // Returns the physical WGP index of the Nth active WGP, or logical_wgp if no bitmap.
+  uint32_t logical_to_physical_wgp(uint32_t se, uint32_t sa, uint32_t logical_wgp) const {
+    if (!has_cu_bitmap || se >= 4 || sa >= 4 || cu_bitmap[se][sa] == 0)
+      return logical_wgp;
+
+    uint32_t bitmap = cu_bitmap[se][sa];
+    uint32_t count = 0;
+    for (uint32_t phys_wgp = 0; phys_wgp < 32; phys_wgp++) {
+      // A WGP is active if either of its CU pair bits is set
+      uint32_t cu_pair = (bitmap >> (phys_wgp * 2)) & 0x3;
+      if (cu_pair != 0) {
+        if (count == logical_wgp) return phys_wgp;
+        count++;
+      }
+    }
+    return logical_wgp;
   }
 
   uint32_t GetAidNumber() const { return (xcc_number_ > 1) ? 4 : 1; }
@@ -215,12 +238,12 @@ class GpuPmcBuilder : public PmcBuilder, protected Primitives {
     this->wgp_per_sa =
         (agent_info->cu_num / 2 + sarrays_per_se * se_number_ - 1) / (se_number_ * sarrays_per_se);
 
-    // Populate per-SE/SA WGP counts from cu_bitmap if available
-    bool has_bitmap = false;
-    for (uint32_t se = 0; se < 4 && !has_bitmap; se++)
-      for (uint32_t sa = 0; sa < 4 && !has_bitmap; sa++)
-        if (agent_info->cu_bitmap[se][sa] != 0) has_bitmap = true;
-    if (has_bitmap) {
+    // Populate per-SE/SA WGP counts and store cu_bitmap for logical-to-physical mapping
+    for (uint32_t se = 0; se < 4 && !has_cu_bitmap; se++)
+      for (uint32_t sa = 0; sa < 4 && !has_cu_bitmap; sa++)
+        if (agent_info->cu_bitmap[se][sa] != 0) has_cu_bitmap = true;
+    if (has_cu_bitmap) {
+      memcpy(cu_bitmap, agent_info->cu_bitmap, sizeof(cu_bitmap));
       for (uint32_t se = 0; se < se_number_ && se < 4; se++)
         for (uint32_t sa = 0; sa < sarrays_per_se && sa < 4; sa++)
           wgp_per_sa_array[se][sa] = __builtin_popcount(agent_info->cu_bitmap[se][sa]) / 2;
@@ -237,7 +260,7 @@ class GpuPmcBuilder : public PmcBuilder, protected Primitives {
   };
 
   size_t GetTotalWGPSamples(uint32_t se_count, uint32_t sa_count) override {
-    if (Primitives::GFXIP_LEVEL < 11) return se_count * sa_count;
+    if (Primitives::GFXIP_LEVEL < 11) return static_cast<size_t>(se_count) * sa_count;
     size_t total = 0;
     for (uint32_t se = 0; se < se_count; se++)
       for (uint32_t sa = 0; sa < sa_count; sa++)
@@ -630,7 +653,8 @@ class GpuPmcBuilder : public PmcBuilder, protected Primitives {
             if (bIsWGPcounter11) {
               int wgp_count = get_wgp_count_for_sa(se_index, sarray);
               for (int wgp = 0; wgp < wgp_count; wgp++) {
-                grbm_value = Primitives::grbm_se_sh_wgp_index_value(se_index, sarray, wgp);
+                uint32_t phys_wgp = logical_to_physical_wgp(se_index, sarray, wgp);
+                grbm_value = Primitives::grbm_se_sh_wgp_index_value(se_index, sarray, phys_wgp);
                 SetGrbmGfxIndex(cmd_buffer, grbm_value);
                 builder.BuildCopyCounterDataPacket(
                     cmd_buffer, reg_info.register_addr_lo, reg_info.register_addr_hi,
@@ -640,11 +664,12 @@ class GpuPmcBuilder : public PmcBuilder, protected Primitives {
             } else if (bIsWGPcounter12) {
               int wgp_count = get_wgp_count_for_sa(se_index, sarray);
               for (int wgp = 0; wgp < wgp_count; wgp++) {
+                uint32_t phys_wgp = logical_to_physical_wgp(se_index, sarray, wgp);
                 if (block_info->instance_count > 1)
                   grbm_value = Primitives::grbm_inst_se_sh_wgp_index_value(block_des.index,
-                                                                           se_index, sarray, wgp);
+                                                                           se_index, sarray, phys_wgp);
                 else
-                  grbm_value = Primitives::grbm_se_sh_wgp_index_value(se_index, sarray, wgp);
+                  grbm_value = Primitives::grbm_se_sh_wgp_index_value(se_index, sarray, phys_wgp);
                 SetGrbmGfxIndex(cmd_buffer, grbm_value);
                 uint32_t dw_mask = reg_info.register_addr_hi.offset ? 3 : 1;
                 builder.BuildCopyCounterDataPacket(

--- a/projects/aqlprofile/src/util/hsa_rsrc_factory.h
+++ b/projects/aqlprofile/src/util/hsa_rsrc_factory.h
@@ -127,6 +127,9 @@ struct AgentInfo {
   // Number of Shader Arrays Per Shader Engines in Gpu
   uint32_t shader_arrays_per_se{};
 
+  // Per-SE/SA active CU bitmask for asymmetric WGP configurations
+  uint32_t cu_bitmap[4][4] = {};
+
   // Timestamp frequency for realtime clock
   uint32_t timestamp_freq{0};
 };

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/agent.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/agent.cpp
@@ -948,16 +948,63 @@ get_aql_handles()
             std::vector<aqlprofile_agent_handle_t> agent_handles;
             for(auto& agent : get_agents())
             {
-                aqlprofile_agent_info_t agent_info = {
-                    .agent_gfxip          = agent->name,
-                    .xcc_num              = agent->num_xcc,
-                    .se_num               = agent->num_shader_banks,
-                    .cu_num               = agent->cu_count,
-                    .shader_arrays_per_se = agent->simd_arrays_per_engine};
                 aqlprofile_agent_handle_t handle = {.handle = 0};
-                if(aqlprofile_register_agent(&handle, &agent_info) != HSA_STATUS_SUCCESS)
+                bool registered = false;
+
+                // Try v2 registration with cu_bitmap from DRM
+                if(agent->type == ROCPROFILER_AGENT_TYPE_GPU &&
+                   agent->drm_render_minor > 0)
                 {
-                    ROCP_WARNING << "Failed to register agent " << agent->name;
+                    int drm_fd = drmOpenRender(agent->drm_render_minor);
+                    if(drm_fd >= 0)
+                    {
+                        uint32_t             major_version = 0;
+                        uint32_t             minor_version = 0;
+                        amdgpu_device_handle device_handle = nullptr;
+                        if(amdgpu_device_initialize(
+                               drm_fd, &major_version, &minor_version, &device_handle) == 0)
+                        {
+                            amdgpu_gpu_info gpu_info = {};
+                            if(amdgpu_query_gpu_info(device_handle, &gpu_info) == 0)
+                            {
+                                aqlprofile_agent_info_v2_t info_v2 = {};
+                                info_v2.agent_gfxip          = agent->name;
+                                info_v2.xcc_num              = agent->num_xcc;
+                                info_v2.se_num               = agent->num_shader_banks;
+                                info_v2.cu_num               = agent->cu_count;
+                                info_v2.shader_arrays_per_se = agent->simd_arrays_per_engine;
+                                info_v2.domain               = agent->domain;
+                                info_v2.location_id          = agent->location_id;
+                                memcpy(info_v2.cu_bitmap,
+                                       gpu_info.cu_bitmap,
+                                       sizeof(info_v2.cu_bitmap));
+
+                                if(aqlprofile_register_agent_info(
+                                       &handle, &info_v2, AQLPROFILE_AGENT_VERSION_V2) ==
+                                   HSA_STATUS_SUCCESS)
+                                {
+                                    registered = true;
+                                }
+                            }
+                            amdgpu_device_deinitialize(device_handle);
+                        }
+                        drmClose(drm_fd);
+                    }
+                }
+
+                // Fallback to v0 registration
+                if(!registered)
+                {
+                    aqlprofile_agent_info_t agent_info = {
+                        .agent_gfxip          = agent->name,
+                        .xcc_num              = agent->num_xcc,
+                        .se_num               = agent->num_shader_banks,
+                        .cu_num               = agent->cu_count,
+                        .shader_arrays_per_se = agent->simd_arrays_per_engine};
+                    if(aqlprofile_register_agent(&handle, &agent_info) != HSA_STATUS_SUCCESS)
+                    {
+                        ROCP_WARNING << "Failed to register agent " << agent->name;
+                    }
                 }
                 agent_handles.push_back(handle);
             }

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/agent.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/agent.cpp
@@ -948,12 +948,11 @@ get_aql_handles()
             std::vector<aqlprofile_agent_handle_t> agent_handles;
             for(auto& agent : get_agents())
             {
-                aqlprofile_agent_handle_t handle = {.handle = 0};
-                bool registered = false;
+                aqlprofile_agent_handle_t handle     = {.handle = 0};
+                bool                      registered = false;
 
                 // Try v2 registration with cu_bitmap from DRM
-                if(agent->type == ROCPROFILER_AGENT_TYPE_GPU &&
-                   agent->drm_render_minor > 0)
+                if(agent->type == ROCPROFILER_AGENT_TYPE_GPU && agent->drm_render_minor > 0)
                 {
                     int drm_fd = drmOpenRender(agent->drm_render_minor);
                     if(drm_fd >= 0)
@@ -968,13 +967,13 @@ get_aql_handles()
                             if(amdgpu_query_gpu_info(device_handle, &gpu_info) == 0)
                             {
                                 aqlprofile_agent_info_v2_t info_v2 = {};
-                                info_v2.agent_gfxip          = agent->name;
-                                info_v2.xcc_num              = agent->num_xcc;
-                                info_v2.se_num               = agent->num_shader_banks;
-                                info_v2.cu_num               = agent->cu_count;
-                                info_v2.shader_arrays_per_se = agent->simd_arrays_per_engine;
-                                info_v2.domain               = agent->domain;
-                                info_v2.location_id          = agent->location_id;
+                                info_v2.agent_gfxip                = agent->name;
+                                info_v2.xcc_num                    = agent->num_xcc;
+                                info_v2.se_num                     = agent->num_shader_banks;
+                                info_v2.cu_num                     = agent->cu_count;
+                                info_v2.shader_arrays_per_se       = agent->simd_arrays_per_engine;
+                                info_v2.domain                     = agent->domain;
+                                info_v2.location_id                = agent->location_id;
                                 memcpy(info_v2.cu_bitmap,
                                        gpu_info.cu_bitmap,
                                        sizeof(info_v2.cu_bitmap));

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/aql/aql_profile_v2.h
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/aql/aql_profile_v2.h
@@ -133,6 +133,27 @@ typedef struct
                                       KFD.simd_arrays_per_engine)*/
 } aqlprofile_agent_info_t;
 
+/**
+ * @brief Struct containing information about the agent. User code sets these values
+ * to the describe the agent to profile. Information can be obtained either from HSA
+ * (if loaded) or the KFD topology.
+ */
+typedef struct
+{
+    const char* agent_gfxip; /**< Agent GFXIP (HSA_AGENT_INFO_NAME or KFD.product_name) */
+    uint32_t    xcc_num;     /**< XCC's on the agent (HSA_AMD_AGENT_INFO_NUM_XCC or KFD.num_xcc) */
+    uint32_t    se_num;      /**< SE's on the agent (HSA_AMD_AGENT_INFO_NUM_SHADER_ENGINES or
+                                KFD.num_shader_banks) */
+    uint32_t
+        cu_num; /**< CU's on the agent (HSA_AMD_AGENT_INFO_COMPUTE_UNIT_COUNT or KFD.cu_count) */
+    uint32_t shader_arrays_per_se; /**< Shader arrays per SE of agent
+                                      (HSA_AMD_AGENT_INFO_NUM_SHADER_ARRAYS_PER_SE or
+                                      KFD.simd_arrays_per_engine)*/
+    uint32_t domain; /**< PCI domain of the GPU agent (HSA_AMD_AGENT_INFO_DOMAIN or KFD.domain) */
+    uint32_t location_id; /**< BDF (Bus/Device/function number) of the GPU agent
+                             (HSA_AMD_AGENT_INFO_BDFID or KFD.location_id)*/
+} aqlprofile_agent_info_v1_t;
+
 typedef enum
 {
     AQLPROFILE_AGENT_VERSION_NONE = 0,

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/aql/aql_profile_v2.h
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/aql/aql_profile_v2.h
@@ -133,6 +133,31 @@ typedef struct
                                       KFD.simd_arrays_per_engine)*/
 } aqlprofile_agent_info_t;
 
+typedef enum
+{
+    AQLPROFILE_AGENT_VERSION_NONE = 0,
+    AQLPROFILE_AGENT_VERSION_V0   = 1,
+    AQLPROFILE_AGENT_VERSION_V1   = 2,
+    AQLPROFILE_AGENT_VERSION_V2   = 3,
+    AQLPROFILE_AGENT_VERSION_LAST
+} aqlprofile_agent_version_t;
+
+/**
+ * @brief Struct containing information about the agent, including per-SE/SA CU bitmaps
+ * for asymmetric CU/WGP configurations.
+ */
+typedef struct
+{
+    const char* agent_gfxip;
+    uint32_t    xcc_num;
+    uint32_t    se_num;
+    uint32_t    cu_num;
+    uint32_t    shader_arrays_per_se;
+    uint32_t    domain;
+    uint32_t    location_id;
+    uint32_t    cu_bitmap[4][4]; /**< Per-SE/SA active CU bitmask (DRM AMDGPU_INFO_DEV_INFO) */
+} aqlprofile_agent_info_v2_t;
+
 /**
  * @brief Struct containing a handle to a registered agent
  *
@@ -152,6 +177,19 @@ typedef struct
 hsa_status_t
 aqlprofile_register_agent(aqlprofile_agent_handle_t*     agent_id,
                           const aqlprofile_agent_info_t* agent_info);
+
+/**
+ * @brief Registers an agent to be used with AQL profile (versioned).
+ * @param[out] agent_id Handle to newly registered agent
+ * @param[in] agent_info Info to register a new agent with AQL Profiler
+ * @param[in] version Version of the agent info structure
+ * @retval HSA_STATUS_SUCCESS registration ok
+ * @retval HSA_STATUS_ERROR registration failed
+ */
+hsa_status_t
+aqlprofile_register_agent_info(aqlprofile_agent_handle_t*  agent_id,
+                               const void*                 agent_info,
+                               aqlprofile_agent_version_t  version);
 
 /**
  * @brief AQLprofile struct containing information for perfmon events

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/aql/aql_profile_v2.h
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/aql/aql_profile_v2.h
@@ -187,9 +187,9 @@ aqlprofile_register_agent(aqlprofile_agent_handle_t*     agent_id,
  * @retval HSA_STATUS_ERROR registration failed
  */
 hsa_status_t
-aqlprofile_register_agent_info(aqlprofile_agent_handle_t*  agent_id,
-                               const void*                 agent_info,
-                               aqlprofile_agent_version_t  version);
+aqlprofile_register_agent_info(aqlprofile_agent_handle_t* agent_id,
+                               const void*                agent_info,
+                               aqlprofile_agent_version_t version);
 
 /**
  * @brief AQLprofile struct containing information for perfmon events

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/counters/tests/dimension.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/counters/tests/dimension.cpp
@@ -333,4 +333,48 @@ TEST(dimension, block_dim_test)
 
     hsa_shut_down();
 }
+TEST(dimension, cu_bitmap_wgp_extraction)
+{
+    // Test the popcount/2 logic used for WGP extraction from CU bitmaps.
+    // This tests the computation independently of AQLProfile internals.
+
+    auto cu_bitmap_to_wgp = [](uint32_t bitmap) -> uint32_t {
+        return __builtin_popcount(bitmap) / 2;
+    };
+
+    // Symmetric: 16 CUs = 8 WGPs
+    EXPECT_EQ(cu_bitmap_to_wgp(0xFFFF), 8);
+
+    // Asymmetric: 18 CUs = 9 WGPs
+    EXPECT_EQ(cu_bitmap_to_wgp(0x3FFFF), 9);
+
+    // Post-harvest: 14 CUs = 7 WGPs
+    EXPECT_EQ(cu_bitmap_to_wgp(0x3FFF), 7);
+
+    // Non-contiguous gaps: 10 CUs set = 5 WGPs
+    EXPECT_EQ(cu_bitmap_to_wgp(0b10101010101010101010), 5);
+
+    // Edge: all zeros = 0 WGPs
+    EXPECT_EQ(cu_bitmap_to_wgp(0x0), 0);
+
+    // Full 32-bit = 16 WGPs
+    EXPECT_EQ(cu_bitmap_to_wgp(0xFFFFFFFF), 16);
+
+    // Max extent should be max across all SE/SA pairs
+    uint32_t cu_bitmap[4][4] = {};
+    cu_bitmap[0][0] = 0x3FFFF;  // 9 WGPs
+    cu_bitmap[0][1] = 0xFFFF;   // 8 WGPs
+    cu_bitmap[1][0] = 0x3FFFF;  // 9 WGPs
+    cu_bitmap[1][1] = 0x3FFF;   // 7 WGPs (post-harvest)
+
+    uint32_t max_wgp = 0;
+    for(int se = 0; se < 4; se++)
+        for(int sa = 0; sa < 4; sa++)
+        {
+            uint32_t wgp = cu_bitmap_to_wgp(cu_bitmap[se][sa]);
+            if(wgp > max_wgp) max_wgp = wgp;
+        }
+    EXPECT_EQ(max_wgp, 9);
+}
+
 #pragma GCC diagnostic pop

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/counters/tests/dimension.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/counters/tests/dimension.cpp
@@ -651,4 +651,302 @@ TEST(dimension, symmetric_cu_bitmap_backward_compat)
     }
 }
 
+// --- GFX11 tests: WGP dimension is only active on GFX11+ ---
+// These tests verify AQLProfile's decoding of asymmetric CU bitmap data
+// using GFX11 agents where the WGP dimension is present in coordinate decomposition.
+
+TEST(dimension, gfx11_wgp_dimension_present)
+{
+    // Register a GFX11 agent and verify SQ block has WGP dimension
+    aqlprofile_agent_handle_t  handle{};
+    aqlprofile_agent_info_v2_t info{};
+    info.agent_gfxip          = "gfx1100";
+    info.cu_num               = 16;
+    info.se_num               = 2;
+    info.xcc_num              = 1;
+    info.shader_arrays_per_se = 2;
+    info.domain               = 0;
+    info.location_id          = 0;
+
+    auto status = aqlprofile_register_agent_info(&handle, &info, AQLPROFILE_AGENT_VERSION_V2);
+    ASSERT_EQ(status, HSA_STATUS_SUCCESS);
+
+    aqlprofile_pmc_event_t event{};
+    event.block_name  = HSA_VEN_AMD_AQLPROFILE_BLOCK_NAME_SQ;
+    event.block_index = 0;
+    event.event_id    = 0;
+    event.flags.raw   = 0;
+
+    std::vector<CoordEntry> coords;
+    status = aqlprofile_iterate_event_coord(handle, event, 0, coord_callback, &coords);
+    ASSERT_EQ(status, HSA_STATUS_SUCCESS);
+
+    // GFX11 SQ should have dimensions: WGP, INSTANCE, SE, SA
+    ASSERT_EQ(coords.size(), 4u);
+    EXPECT_EQ(coords[0].name, "WGP");
+    EXPECT_EQ(coords[1].name, "INSTANCE");
+    EXPECT_EQ(coords[2].name, "SE");
+    EXPECT_EQ(coords[3].name, "SA");
+
+    // Uniform: wgp_num = (16/2 + 4-1) / 4 = 2
+    EXPECT_EQ(coords[0].extent, 2);  // WGP
+    EXPECT_EQ(coords[1].extent, 1);  // INSTANCE (SQ has instance_count=1)
+    EXPECT_EQ(coords[2].extent, 2);  // SE
+    EXPECT_EQ(coords[3].extent, 2);  // SA
+}
+
+TEST(dimension, gfx11_asymmetric_wgp_extent)
+{
+    // Register GFX11 agent with asymmetric cu_bitmap and verify WGP extent = max(popcount/2)
+    aqlprofile_agent_handle_t  handle{};
+    aqlprofile_agent_info_v2_t info{};
+    info.agent_gfxip          = "gfx1100";
+    info.cu_num               = 34;  // total: 9+8+9+8 = 34
+    info.se_num               = 2;
+    info.xcc_num              = 1;
+    info.shader_arrays_per_se = 2;
+    info.domain               = 0;
+    info.location_id          = 0;
+    // Asymmetric layout:
+    info.cu_bitmap[0][0] = 0x3FFFF;  // 18 CUs = 9 WGPs
+    info.cu_bitmap[0][1] = 0xFFFF;   // 16 CUs = 8 WGPs
+    info.cu_bitmap[1][0] = 0x3FFFF;  // 18 CUs = 9 WGPs
+    info.cu_bitmap[1][1] = 0xFFFF;   // 16 CUs = 8 WGPs
+
+    auto status = aqlprofile_register_agent_info(&handle, &info, AQLPROFILE_AGENT_VERSION_V2);
+    ASSERT_EQ(status, HSA_STATUS_SUCCESS);
+
+    aqlprofile_pmc_event_t event{};
+    event.block_name  = HSA_VEN_AMD_AQLPROFILE_BLOCK_NAME_SQ;
+    event.block_index = 0;
+    event.event_id    = 0;
+    event.flags.raw   = 0;
+
+    std::vector<CoordEntry> coords;
+    status = aqlprofile_iterate_event_coord(handle, event, 0, coord_callback, &coords);
+    ASSERT_EQ(status, HSA_STATUS_SUCCESS);
+
+    ASSERT_EQ(coords.size(), 4u);
+    EXPECT_EQ(coords[0].name, "WGP");
+    // WGP extent should be max(9, 8, 9, 8) = 9
+    EXPECT_EQ(coords[0].extent, 9);
+    EXPECT_EQ(coords[2].name, "SE");
+    EXPECT_EQ(coords[2].extent, 2);
+    EXPECT_EQ(coords[3].name, "SA");
+    EXPECT_EQ(coords[3].extent, 2);
+}
+
+TEST(dimension, gfx11_asymmetric_all_samples_valid)
+{
+    // Register GFX11 agent with asymmetric cu_bitmap,
+    // iterate ALL sample IDs and verify coordinates are in bounds
+    aqlprofile_agent_handle_t  handle{};
+    aqlprofile_agent_info_v2_t info{};
+    info.agent_gfxip          = "gfx1100";
+    info.cu_num               = 33;  // 9+8+9+7 = 33
+    info.se_num               = 2;
+    info.xcc_num              = 1;
+    info.shader_arrays_per_se = 2;
+    info.domain               = 0;
+    info.location_id          = 0;
+    // Asymmetric + harvest:
+    info.cu_bitmap[0][0] = 0x3FFFF;  // 9 WGPs
+    info.cu_bitmap[0][1] = 0xFFFF;   // 8 WGPs
+    info.cu_bitmap[1][0] = 0x3FFFF;  // 9 WGPs
+    info.cu_bitmap[1][1] = 0x3FFF;   // 7 WGPs (post-harvest)
+
+    auto status = aqlprofile_register_agent_info(&handle, &info, AQLPROFILE_AGENT_VERSION_V2);
+    ASSERT_EQ(status, HSA_STATUS_SUCCESS);
+
+    aqlprofile_pmc_event_t event{};
+    event.block_name  = HSA_VEN_AMD_AQLPROFILE_BLOCK_NAME_SQ;
+    event.block_index = 0;
+    event.event_id    = 0;
+    event.flags.raw   = 0;
+
+    // Get dimension extents from sample 0
+    std::vector<CoordEntry> first_coords;
+    status = aqlprofile_iterate_event_coord(handle, event, 0, coord_callback, &first_coords);
+    ASSERT_EQ(status, HSA_STATUS_SUCCESS);
+    ASSERT_EQ(first_coords.size(), 4u);
+    EXPECT_EQ(first_coords[0].name, "WGP");
+    // Max WGP = max(9, 8, 9, 7) = 9
+    EXPECT_EQ(first_coords[0].extent, 9);
+
+    // Total samples in the max-extent cartesian space
+    size_t total_samples = 1;
+    for(const auto& c : first_coords)
+        total_samples *= static_cast<size_t>(c.extent);
+
+    // 9 * 1 * 2 * 2 = 36
+    EXPECT_EQ(total_samples, 36u);
+
+    // Verify every sample ID produces valid in-bounds coordinates
+    for(size_t sample_id = 0; sample_id < total_samples; sample_id++)
+    {
+        std::vector<CoordEntry> coords;
+        status = aqlprofile_iterate_event_coord(handle, event, sample_id, coord_callback, &coords);
+        ASSERT_EQ(status, HSA_STATUS_SUCCESS) << "Failed at sample_id=" << sample_id;
+        ASSERT_EQ(coords.size(), first_coords.size());
+
+        for(size_t i = 0; i < coords.size(); i++)
+        {
+            EXPECT_GE(coords[i].coordinate, 0);
+            EXPECT_LT(coords[i].coordinate, coords[i].extent)
+                << "sample_id=" << sample_id << " dim=" << coords[i].name;
+            EXPECT_EQ(coords[i].extent, first_coords[i].extent);
+            EXPECT_EQ(coords[i].name, first_coords[i].name);
+        }
+    }
+}
+
+TEST(dimension, gfx11_noncontiguous_harvest_wgp_extent)
+{
+    // Test non-contiguous harvesting: gaps in the bitmap
+    // Verifies WGP count is based on popcount, not bit position
+    aqlprofile_agent_handle_t  handle{};
+    aqlprofile_agent_info_v2_t info{};
+    info.agent_gfxip          = "gfx1100";
+    info.cu_num               = 20;
+    info.se_num               = 2;
+    info.xcc_num              = 1;
+    info.shader_arrays_per_se = 2;
+    info.domain               = 0;
+    info.location_id          = 0;
+    // Non-contiguous: gaps between active CU pairs
+    // 0b110011001100110011 = WGPs at physical indices 0,2,4,6,8 → 5 WGPs (bits set in pairs)
+    info.cu_bitmap[0][0] = 0x33333;  // popcount=10 → 5 WGPs
+    info.cu_bitmap[0][1] = 0x33333;  // popcount=10 → 5 WGPs
+    info.cu_bitmap[1][0] = 0x33333;  // popcount=10 → 5 WGPs
+    info.cu_bitmap[1][1] = 0x33333;  // popcount=10 → 5 WGPs
+
+    auto status = aqlprofile_register_agent_info(&handle, &info, AQLPROFILE_AGENT_VERSION_V2);
+    ASSERT_EQ(status, HSA_STATUS_SUCCESS);
+
+    aqlprofile_pmc_event_t event{};
+    event.block_name  = HSA_VEN_AMD_AQLPROFILE_BLOCK_NAME_SQ;
+    event.block_index = 0;
+    event.event_id    = 0;
+    event.flags.raw   = 0;
+
+    std::vector<CoordEntry> coords;
+    status = aqlprofile_iterate_event_coord(handle, event, 0, coord_callback, &coords);
+    ASSERT_EQ(status, HSA_STATUS_SUCCESS);
+
+    ASSERT_EQ(coords.size(), 4u);
+    EXPECT_EQ(coords[0].name, "WGP");
+    EXPECT_EQ(coords[0].extent, 5);  // popcount(0x33333)=10, /2=5
+}
+
+TEST(dimension, gfx11_symmetric_bitmap_matches_uniform)
+{
+    // Verify that a symmetric cu_bitmap produces the same WGP extent
+    // as the uniform calculation from cu_num
+    aqlprofile_agent_handle_t  handle_no_bitmap{};
+    aqlprofile_agent_info_v2_t info_no_bitmap{};
+    info_no_bitmap.agent_gfxip          = "gfx1100";
+    info_no_bitmap.cu_num               = 16;
+    info_no_bitmap.se_num               = 2;
+    info_no_bitmap.xcc_num              = 1;
+    info_no_bitmap.shader_arrays_per_se = 2;
+    info_no_bitmap.domain               = 0;
+    info_no_bitmap.location_id          = 0;
+    // No cu_bitmap — uses uniform calculation
+
+    auto status = aqlprofile_register_agent_info(
+        &handle_no_bitmap, &info_no_bitmap, AQLPROFILE_AGENT_VERSION_V2);
+    ASSERT_EQ(status, HSA_STATUS_SUCCESS);
+
+    aqlprofile_agent_handle_t  handle_bitmap{};
+    aqlprofile_agent_info_v2_t info_bitmap{};
+    info_bitmap.agent_gfxip          = "gfx1100";
+    info_bitmap.cu_num               = 16;
+    info_bitmap.se_num               = 2;
+    info_bitmap.xcc_num              = 1;
+    info_bitmap.shader_arrays_per_se = 2;
+    info_bitmap.domain               = 0;
+    info_bitmap.location_id          = 0;
+    // Symmetric bitmap: 4 CUs per SA = 2 WGPs per SA (same as uniform)
+    info_bitmap.cu_bitmap[0][0] = 0xF;  // 4 CUs = 2 WGPs
+    info_bitmap.cu_bitmap[0][1] = 0xF;
+    info_bitmap.cu_bitmap[1][0] = 0xF;
+    info_bitmap.cu_bitmap[1][1] = 0xF;
+
+    status =
+        aqlprofile_register_agent_info(&handle_bitmap, &info_bitmap, AQLPROFILE_AGENT_VERSION_V2);
+    ASSERT_EQ(status, HSA_STATUS_SUCCESS);
+
+    aqlprofile_pmc_event_t event{};
+    event.block_name  = HSA_VEN_AMD_AQLPROFILE_BLOCK_NAME_SQ;
+    event.block_index = 0;
+    event.event_id    = 0;
+    event.flags.raw   = 0;
+
+    std::vector<CoordEntry> coords_no_bitmap;
+    std::vector<CoordEntry> coords_bitmap;
+    aqlprofile_iterate_event_coord(handle_no_bitmap, event, 0, coord_callback, &coords_no_bitmap);
+    aqlprofile_iterate_event_coord(handle_bitmap, event, 0, coord_callback, &coords_bitmap);
+
+    ASSERT_EQ(coords_no_bitmap.size(), coords_bitmap.size());
+    for(size_t i = 0; i < coords_no_bitmap.size(); i++)
+    {
+        EXPECT_EQ(coords_no_bitmap[i].name, coords_bitmap[i].name);
+        EXPECT_EQ(coords_no_bitmap[i].extent, coords_bitmap[i].extent)
+            << "Mismatch in dim " << coords_no_bitmap[i].name;
+    }
+}
+
+TEST(dimension, logical_to_physical_wgp_mapping)
+{
+    // Test the logical-to-physical WGP mapping computation directly.
+    // This mirrors the logic in GpuPmcBuilder::logical_to_physical_wgp().
+    // With non-contiguous harvesting, logical WGP indices must map to
+    // the correct physical positions by walking CU pairs in the bitmap.
+
+    auto logical_to_physical_wgp = [](uint32_t bitmap, uint32_t logical_wgp) -> uint32_t {
+        if(bitmap == 0) return logical_wgp;
+        uint32_t count = 0;
+        for(uint32_t phys_wgp = 0; phys_wgp < 16; phys_wgp++)
+        {
+            uint32_t cu_pair = (bitmap >> (phys_wgp * 2)) & 0x3;
+            if(cu_pair != 0)
+            {
+                if(count == logical_wgp) return phys_wgp;
+                count++;
+            }
+        }
+        return logical_wgp;
+    };
+
+    // Contiguous: 0xFF = WGPs at physical 0,1,2,3
+    EXPECT_EQ(logical_to_physical_wgp(0xFF, 0), 0u);
+    EXPECT_EQ(logical_to_physical_wgp(0xFF, 1), 1u);
+    EXPECT_EQ(logical_to_physical_wgp(0xFF, 2), 2u);
+    EXPECT_EQ(logical_to_physical_wgp(0xFF, 3), 3u);
+
+    // Gap at WGP 1: 0b11000011 = WGPs at physical 0, 3
+    EXPECT_EQ(logical_to_physical_wgp(0xC3, 0), 0u);
+    EXPECT_EQ(logical_to_physical_wgp(0xC3, 1), 3u);
+
+    // Gap at WGP 0: 0b00001100 = WGP at physical 1
+    EXPECT_EQ(logical_to_physical_wgp(0x0C, 0), 1u);
+
+    // Non-contiguous pattern: 0x33333 = pairs at physical 0,2,4,6,8
+    EXPECT_EQ(logical_to_physical_wgp(0x33333, 0), 0u);
+    EXPECT_EQ(logical_to_physical_wgp(0x33333, 1), 2u);
+    EXPECT_EQ(logical_to_physical_wgp(0x33333, 2), 4u);
+    EXPECT_EQ(logical_to_physical_wgp(0x33333, 3), 6u);
+    EXPECT_EQ(logical_to_physical_wgp(0x33333, 4), 8u);
+
+    // Harvest at end: 0x3FFFF = 9 WGPs at physical 0..8
+    for(uint32_t i = 0; i < 9; i++)
+        EXPECT_EQ(logical_to_physical_wgp(0x3FFFF, i), i);
+
+    // Single WGP at high position: 0x30000 = physical WGP 8
+    EXPECT_EQ(logical_to_physical_wgp(0x30000, 0), 8u);
+
+    // Zero bitmap falls back to identity
+    EXPECT_EQ(logical_to_physical_wgp(0, 5), 5u);
+}
+
 #pragma GCC diagnostic pop

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/counters/tests/dimension.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/counters/tests/dimension.cpp
@@ -362,10 +362,10 @@ TEST(dimension, cu_bitmap_wgp_extraction)
 
     // Max extent should be max across all SE/SA pairs
     uint32_t cu_bitmap[4][4] = {};
-    cu_bitmap[0][0] = 0x3FFFF;  // 9 WGPs
-    cu_bitmap[0][1] = 0xFFFF;   // 8 WGPs
-    cu_bitmap[1][0] = 0x3FFFF;  // 9 WGPs
-    cu_bitmap[1][1] = 0x3FFF;   // 7 WGPs (post-harvest)
+    cu_bitmap[0][0]          = 0x3FFFF;  // 9 WGPs
+    cu_bitmap[0][1]          = 0xFFFF;   // 8 WGPs
+    cu_bitmap[1][0]          = 0x3FFFF;  // 9 WGPs
+    cu_bitmap[1][1]          = 0x3FFF;   // 7 WGPs (post-harvest)
 
     uint32_t max_wgp = 0;
     for(int se = 0; se < 4; se++)

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/counters/tests/dimension.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/counters/tests/dimension.cpp
@@ -26,6 +26,7 @@
 
 #include "lib/common/utility.hpp"
 #include "lib/rocprofiler-sdk/agent.hpp"
+#include "lib/rocprofiler-sdk/aql/aql_profile_v2.h"
 #include "lib/rocprofiler-sdk/aql/packet_construct.hpp"
 #include "lib/rocprofiler-sdk/counters/dimensions.hpp"
 #include "lib/rocprofiler-sdk/counters/id_decode.hpp"
@@ -375,6 +376,279 @@ TEST(dimension, cu_bitmap_wgp_extraction)
             if(wgp > max_wgp) max_wgp = wgp;
         }
     EXPECT_EQ(max_wgp, 9);
+}
+
+// --- GPU-free AQLProfile agent registration and coordinate tests ---
+
+namespace
+{
+struct CoordEntry
+{
+    int         position;
+    int         id;
+    int         extent;
+    int         coordinate;
+    std::string name;
+};
+
+hsa_status_t
+coord_callback(int position, int id, int extent, int coordinate, const char* name, void* userdata)
+{
+    auto& coords = *static_cast<std::vector<CoordEntry>*>(userdata);
+    coords.push_back({position, id, extent, coordinate, std::string(name)});
+    return HSA_STATUS_SUCCESS;
+}
+}  // namespace
+
+TEST(dimension, register_agent_v0)
+{
+    aqlprofile_agent_handle_t handle{};
+    aqlprofile_agent_info_t   info{};
+    info.agent_gfxip          = "gfx900";
+    info.cu_num               = 64;
+    info.se_num               = 4;
+    info.xcc_num              = 1;
+    info.shader_arrays_per_se = 2;
+
+    auto status = aqlprofile_register_agent_info(&handle, &info, AQLPROFILE_AGENT_VERSION_V0);
+    EXPECT_EQ(status, HSA_STATUS_SUCCESS);
+}
+
+TEST(dimension, register_agent_v1)
+{
+    aqlprofile_agent_handle_t  handle{};
+    aqlprofile_agent_info_v1_t info{};
+    info.agent_gfxip          = "gfx900";
+    info.cu_num               = 64;
+    info.se_num               = 4;
+    info.xcc_num              = 1;
+    info.shader_arrays_per_se = 2;
+    info.domain               = 0;
+    info.location_id          = 0x1234;
+
+    auto status = aqlprofile_register_agent_info(&handle, &info, AQLPROFILE_AGENT_VERSION_V1);
+    EXPECT_EQ(status, HSA_STATUS_SUCCESS);
+}
+
+TEST(dimension, register_agent_v2_with_cu_bitmap)
+{
+    aqlprofile_agent_handle_t  handle{};
+    aqlprofile_agent_info_v2_t info{};
+    info.agent_gfxip          = "gfx900";
+    info.cu_num               = 64;
+    info.se_num               = 4;
+    info.xcc_num              = 1;
+    info.shader_arrays_per_se = 2;
+    info.domain               = 0;
+    info.location_id          = 0x5678;
+    info.cu_bitmap[0][0]      = 0x3FFFF;  // 18 CUs = 9 WGPs
+    info.cu_bitmap[1][0]      = 0xFFFF;   // 16 CUs = 8 WGPs
+
+    auto status = aqlprofile_register_agent_info(&handle, &info, AQLPROFILE_AGENT_VERSION_V2);
+    EXPECT_EQ(status, HSA_STATUS_SUCCESS);
+}
+
+TEST(dimension, register_agent_null_info_fails)
+{
+    aqlprofile_agent_handle_t handle{};
+    auto status = aqlprofile_register_agent_info(&handle, nullptr, AQLPROFILE_AGENT_VERSION_V0);
+    EXPECT_NE(status, HSA_STATUS_SUCCESS);
+}
+
+TEST(dimension, register_agent_invalid_version_fails)
+{
+    aqlprofile_agent_handle_t handle{};
+    aqlprofile_agent_info_t   info{};
+    info.agent_gfxip          = "gfx900";
+    info.cu_num               = 64;
+    info.se_num               = 4;
+    info.xcc_num              = 1;
+    info.shader_arrays_per_se = 2;
+
+    auto status = aqlprofile_register_agent_info(&handle, &info, AQLPROFILE_AGENT_VERSION_NONE);
+    EXPECT_NE(status, HSA_STATUS_SUCCESS);
+
+    status = aqlprofile_register_agent_info(&handle, &info, AQLPROFILE_AGENT_VERSION_LAST);
+    EXPECT_NE(status, HSA_STATUS_SUCCESS);
+}
+
+TEST(dimension, iterate_event_coord_gfx900)
+{
+    // Register a gfx900 agent and verify coordinate decomposition for SQ block
+    aqlprofile_agent_handle_t handle{};
+    aqlprofile_agent_info_t   info{};
+    info.agent_gfxip          = "gfx900";
+    info.cu_num               = 64;
+    info.se_num               = 4;
+    info.xcc_num              = 1;
+    info.shader_arrays_per_se = 2;
+
+    auto status = aqlprofile_register_agent_info(&handle, &info, AQLPROFILE_AGENT_VERSION_V0);
+    ASSERT_EQ(status, HSA_STATUS_SUCCESS);
+
+    aqlprofile_pmc_event_t event{};
+    event.block_name  = HSA_VEN_AMD_AQLPROFILE_BLOCK_NAME_SQ;
+    event.block_index = 0;
+    event.event_id    = 0;
+    event.flags.raw   = 0;
+
+    // Sample ID 0 should return valid coordinates
+    std::vector<CoordEntry> coords;
+    status = aqlprofile_iterate_event_coord(handle, event, 0, coord_callback, &coords);
+    ASSERT_EQ(status, HSA_STATUS_SUCCESS);
+    EXPECT_GT(coords.size(), 0u);
+
+    // Verify all coordinates are within bounds
+    for(const auto& c : coords)
+    {
+        EXPECT_GE(c.coordinate, 0);
+        EXPECT_LT(c.coordinate, c.extent) << "Coord " << c.name << " out of bounds";
+        EXPECT_FALSE(c.name.empty());
+    }
+}
+
+TEST(dimension, iterate_event_coord_all_samples_valid)
+{
+    // Register agent, then iterate all sample IDs and verify coordinates are in bounds
+    aqlprofile_agent_handle_t handle{};
+    aqlprofile_agent_info_t   info{};
+    info.agent_gfxip          = "gfx900";
+    info.cu_num               = 64;
+    info.se_num               = 4;
+    info.xcc_num              = 1;
+    info.shader_arrays_per_se = 2;
+
+    auto status = aqlprofile_register_agent_info(&handle, &info, AQLPROFILE_AGENT_VERSION_V0);
+    ASSERT_EQ(status, HSA_STATUS_SUCCESS);
+
+    aqlprofile_pmc_event_t event{};
+    event.block_name  = HSA_VEN_AMD_AQLPROFILE_BLOCK_NAME_SQ;
+    event.block_index = 0;
+    event.event_id    = 0;
+    event.flags.raw   = 0;
+
+    // Get dimension extents from sample 0
+    std::vector<CoordEntry> first_coords;
+    status = aqlprofile_iterate_event_coord(handle, event, 0, coord_callback, &first_coords);
+    ASSERT_EQ(status, HSA_STATUS_SUCCESS);
+    ASSERT_GT(first_coords.size(), 0u);
+
+    // Calculate total samples from extents
+    size_t total_samples = 1;
+    for(const auto& c : first_coords)
+        total_samples *= static_cast<size_t>(c.extent);
+
+    // Verify every sample ID produces valid coordinates
+    for(size_t sample_id = 0; sample_id < total_samples; sample_id++)
+    {
+        std::vector<CoordEntry> coords;
+        status = aqlprofile_iterate_event_coord(handle, event, sample_id, coord_callback, &coords);
+        ASSERT_EQ(status, HSA_STATUS_SUCCESS) << "Failed at sample_id=" << sample_id;
+        ASSERT_EQ(coords.size(), first_coords.size());
+
+        for(size_t i = 0; i < coords.size(); i++)
+        {
+            EXPECT_GE(coords[i].coordinate, 0);
+            EXPECT_LT(coords[i].coordinate, coords[i].extent)
+                << "sample_id=" << sample_id << " dim=" << coords[i].name;
+            EXPECT_EQ(coords[i].extent, first_coords[i].extent);
+            EXPECT_EQ(coords[i].name, first_coords[i].name);
+        }
+    }
+}
+
+TEST(dimension, iterate_event_coord_v2_asymmetric_bitmap)
+{
+    // Register with V2 + asymmetric cu_bitmap, verify coordinate decomposition
+    aqlprofile_agent_handle_t  handle{};
+    aqlprofile_agent_info_v2_t info{};
+    info.agent_gfxip          = "gfx900";
+    info.cu_num               = 64;
+    info.se_num               = 4;
+    info.xcc_num              = 1;
+    info.shader_arrays_per_se = 2;
+    info.domain               = 0;
+    info.location_id          = 0xABCD;
+    // Asymmetric: SE0 has 9 WGPs, SE1 has 8, SE2 has 9, SE3 has 7
+    info.cu_bitmap[0][0] = 0x3FFFF;  // 18 CUs = 9 WGPs
+    info.cu_bitmap[0][1] = 0xFFFF;   // 16 CUs = 8 WGPs
+    info.cu_bitmap[1][0] = 0x3FFFF;  // 18 CUs = 9 WGPs
+    info.cu_bitmap[1][1] = 0x3FFF;   // 14 CUs = 7 WGPs
+
+    auto status = aqlprofile_register_agent_info(&handle, &info, AQLPROFILE_AGENT_VERSION_V2);
+    ASSERT_EQ(status, HSA_STATUS_SUCCESS);
+
+    aqlprofile_pmc_event_t event{};
+    event.block_name  = HSA_VEN_AMD_AQLPROFILE_BLOCK_NAME_SQ;
+    event.block_index = 0;
+    event.event_id    = 0;
+    event.flags.raw   = 0;
+
+    std::vector<CoordEntry> coords;
+    status = aqlprofile_iterate_event_coord(handle, event, 0, coord_callback, &coords);
+    ASSERT_EQ(status, HSA_STATUS_SUCCESS);
+    EXPECT_GT(coords.size(), 0u);
+
+    // Verify coordinates are valid
+    for(const auto& c : coords)
+    {
+        EXPECT_GE(c.coordinate, 0);
+        EXPECT_LT(c.coordinate, c.extent) << "Coord " << c.name << " out of bounds";
+    }
+}
+
+TEST(dimension, symmetric_cu_bitmap_backward_compat)
+{
+    // Register with V2 but symmetric cu_bitmap — should behave like V0
+    aqlprofile_agent_handle_t handle_v0{};
+    aqlprofile_agent_info_t   info_v0{};
+    info_v0.agent_gfxip          = "gfx900";
+    info_v0.cu_num               = 64;
+    info_v0.se_num               = 4;
+    info_v0.xcc_num              = 1;
+    info_v0.shader_arrays_per_se = 2;
+
+    auto status = aqlprofile_register_agent_info(&handle_v0, &info_v0, AQLPROFILE_AGENT_VERSION_V0);
+    ASSERT_EQ(status, HSA_STATUS_SUCCESS);
+
+    aqlprofile_agent_handle_t  handle_v2{};
+    aqlprofile_agent_info_v2_t info_v2{};
+    info_v2.agent_gfxip          = "gfx900";
+    info_v2.cu_num               = 64;
+    info_v2.se_num               = 4;
+    info_v2.xcc_num              = 1;
+    info_v2.shader_arrays_per_se = 2;
+    info_v2.domain               = 0;
+    info_v2.location_id          = 0;
+    // Symmetric: all SEs/SAs have same CU count
+    for(int se = 0; se < 4; se++)
+        for(int sa = 0; sa < 2; sa++)
+            info_v2.cu_bitmap[se][sa] = 0xFF;  // 8 CUs per SA
+
+    status = aqlprofile_register_agent_info(&handle_v2, &info_v2, AQLPROFILE_AGENT_VERSION_V2);
+    ASSERT_EQ(status, HSA_STATUS_SUCCESS);
+
+    aqlprofile_pmc_event_t event{};
+    event.block_name  = HSA_VEN_AMD_AQLPROFILE_BLOCK_NAME_SQ;
+    event.block_index = 0;
+    event.event_id    = 0;
+    event.flags.raw   = 0;
+
+    std::vector<CoordEntry> coords_v0;
+    std::vector<CoordEntry> coords_v2;
+    aqlprofile_iterate_event_coord(handle_v0, event, 0, coord_callback, &coords_v0);
+    aqlprofile_iterate_event_coord(handle_v2, event, 0, coord_callback, &coords_v2);
+
+    // Same number of dimensions
+    ASSERT_EQ(coords_v0.size(), coords_v2.size());
+
+    // Same dimension names and extents
+    for(size_t i = 0; i < coords_v0.size(); i++)
+    {
+        EXPECT_EQ(coords_v0[i].name, coords_v2[i].name);
+        EXPECT_EQ(coords_v0[i].extent, coords_v2[i].extent)
+            << "Mismatch in dim " << coords_v0[i].name;
+    }
 }
 
 #pragma GCC diagnostic pop

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/counters/tests/evaluate_ast_test.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/counters/tests/evaluate_ast_test.cpp
@@ -434,8 +434,7 @@ TEST(evaluate_ast, asymmetric_wgp_arithmetic)
         {"COUNTER_A", Metric("gfx9", "COUNTER_A", "a", "1", "a", "", "", 0)},
         {"COUNTER_B", Metric("gfx9", "COUNTER_B", "a", "1", "a", "", "", 1)},
         {"SUM_AB", Metric("gfx9", "SUM_AB", "a", "1", "a", "COUNTER_A+COUNTER_B", "", 2)},
-        {"DIV_A",
-         Metric("gfx9", "DIV_A", "a", "1", "a", "COUNTER_A/5", "", 3)},
+        {"DIV_A", Metric("gfx9", "DIV_A", "a", "1", "a", "COUNTER_A/5", "", 3)},
     };
 
     // Create 17 records (asymmetric 9+8) for each counter
@@ -509,8 +508,7 @@ TEST(evaluate_ast, asymmetric_wgp_reduction)
     // 17 records simulating asymmetric 9+8 WGPs across 2 SEs
     std::unordered_map<std::string, Metric> metrics = {
         {"COUNTER_A", Metric("gfx9", "COUNTER_A", "a", "1", "a", "", "", 0)},
-        {"REDUCED_A",
-         Metric("gfx9", "REDUCED_A", "a", "1", "a", "reduce(COUNTER_A, sum)", "", 1)},
+        {"REDUCED_A", Metric("gfx9", "REDUCED_A", "a", "1", "a", "reduce(COUNTER_A, sum)", "", 1)},
     };
 
     std::unordered_map<std::string, std::vector<rocprofiler_record_counter_t>> base_counter_data = {

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/counters/tests/evaluate_ast_test.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/counters/tests/evaluate_ast_test.cpp
@@ -419,6 +419,142 @@ divide_vec(std::vector<rocprofiler_record_counter_t>        a,
 
 }  // namespace
 
+TEST(evaluate_ast, asymmetric_wgp_arithmetic)
+{
+    using namespace rocprofiler::counters;
+
+    auto get_base_rec_id = [](uint64_t counter_id) {
+        rocprofiler_counter_instance_id_t base_id = 0;
+        set_counter_in_rec(base_id, {.handle = counter_id});
+        return base_id;
+    };
+
+    // Simulate asymmetric WGP layout: SE0 has 9 WGPs, SE1 has 8 WGPs = 17 total
+    std::unordered_map<std::string, Metric> metrics = {
+        {"COUNTER_A", Metric("gfx9", "COUNTER_A", "a", "1", "a", "", "", 0)},
+        {"COUNTER_B", Metric("gfx9", "COUNTER_B", "a", "1", "a", "", "", 1)},
+        {"SUM_AB", Metric("gfx9", "SUM_AB", "a", "1", "a", "COUNTER_A+COUNTER_B", "", 2)},
+        {"DIV_A",
+         Metric("gfx9", "DIV_A", "a", "1", "a", "COUNTER_A/5", "", 3)},
+    };
+
+    // Create 17 records (asymmetric 9+8) for each counter
+    std::unordered_map<std::string, std::vector<rocprofiler_record_counter_t>> base_counter_data = {
+        {"COUNTER_A",
+         construct_test_data_dim(get_base_rec_id(0), {ROCPROFILER_DIMENSION_NONE}, 17)},
+        {"COUNTER_B",
+         construct_test_data_dim(get_base_rec_id(1), {ROCPROFILER_DIMENSION_NONE}, 17)},
+    };
+
+    std::unordered_map<std::string, std::unordered_map<std::string, EvaluateAST>> asts;
+    for(const auto& [val, metric] : metrics)
+    {
+        RawAST* ast = nullptr;
+        auto*   buf = yy_scan_string(metric.expression().empty() ? metric.name().c_str()
+                                                                 : metric.expression().c_str());
+        yyparse(&ast);
+        ASSERT_TRUE(ast);
+        asts.emplace("gfx9", std::unordered_map<std::string, EvaluateAST>{})
+            .first->second.emplace(val,
+                                   EvaluateAST({.handle = metric.id()}, metrics, *ast, "gfx9"));
+        yy_delete_buffer(buf);
+        delete ast;
+    }
+
+    std::unordered_map<uint64_t, std::vector<rocprofiler_record_counter_t>> base_counter_decode;
+    for(const auto& [name, base_counter_v] : base_counter_data)
+    {
+        base_counter_decode[metrics[name].id()] = base_counter_v;
+    }
+
+    // A + B with 17 records should produce 17 records
+    {
+        std::vector<std::unique_ptr<std::vector<rocprofiler_record_counter_t>>> cache;
+        asts.at("gfx9").at("SUM_AB").expand_derived(asts.at("gfx9"));
+        auto ret = asts.at("gfx9").at("SUM_AB").evaluate(base_counter_decode, cache);
+        ASSERT_TRUE(ret);
+        EXPECT_EQ(ret->size(), 17);
+        auto expected = plus_vec(base_counter_data["COUNTER_A"], base_counter_data["COUNTER_B"]);
+        for(size_t i = 0; i < ret->size(); i++)
+        {
+            EXPECT_FLOAT_EQ((*ret)[i].counter_value, expected[i].counter_value);
+        }
+    }
+
+    // A / scalar with 17 records should produce 17 records
+    {
+        std::vector<std::unique_ptr<std::vector<rocprofiler_record_counter_t>>> cache;
+        asts.at("gfx9").at("DIV_A").expand_derived(asts.at("gfx9"));
+        auto ret = asts.at("gfx9").at("DIV_A").evaluate(base_counter_decode, cache);
+        ASSERT_TRUE(ret);
+        EXPECT_EQ(ret->size(), 17);
+        for(size_t i = 0; i < ret->size(); i++)
+        {
+            EXPECT_FLOAT_EQ((*ret)[i].counter_value,
+                            base_counter_data["COUNTER_A"][i].counter_value / 5.0);
+        }
+    }
+}
+
+TEST(evaluate_ast, asymmetric_wgp_reduction)
+{
+    using namespace rocprofiler::counters;
+
+    auto get_base_rec_id = [](uint64_t counter_id) {
+        rocprofiler_counter_instance_id_t base_id = 0;
+        set_counter_in_rec(base_id, {.handle = counter_id});
+        return base_id;
+    };
+
+    // 17 records simulating asymmetric 9+8 WGPs across 2 SEs
+    std::unordered_map<std::string, Metric> metrics = {
+        {"COUNTER_A", Metric("gfx9", "COUNTER_A", "a", "1", "a", "", "", 0)},
+        {"REDUCED_A",
+         Metric("gfx9", "REDUCED_A", "a", "1", "a", "reduce(COUNTER_A, sum)", "", 1)},
+    };
+
+    std::unordered_map<std::string, std::vector<rocprofiler_record_counter_t>> base_counter_data = {
+        {"COUNTER_A",
+         construct_test_data_dim(get_base_rec_id(0), {ROCPROFILER_DIMENSION_NONE}, 17)},
+    };
+
+    std::unordered_map<std::string, std::unordered_map<std::string, EvaluateAST>> asts;
+    for(const auto& [val, metric] : metrics)
+    {
+        RawAST* ast = nullptr;
+        auto*   buf = yy_scan_string(metric.expression().empty() ? metric.name().c_str()
+                                                                 : metric.expression().c_str());
+        yyparse(&ast);
+        ASSERT_TRUE(ast);
+        asts.emplace("gfx9", std::unordered_map<std::string, EvaluateAST>{})
+            .first->second.emplace(val,
+                                   EvaluateAST({.handle = metric.id()}, metrics, *ast, "gfx9"));
+        yy_delete_buffer(buf);
+        delete ast;
+    }
+
+    std::unordered_map<uint64_t, std::vector<rocprofiler_record_counter_t>> base_counter_decode;
+    for(const auto& [name, base_counter_v] : base_counter_data)
+    {
+        base_counter_decode[metrics[name].id()] = base_counter_v;
+    }
+
+    // Sum reduction of 17 records should produce 1 record with sum of all 17
+    {
+        std::vector<std::unique_ptr<std::vector<rocprofiler_record_counter_t>>> cache;
+        asts.at("gfx9").at("REDUCED_A").expand_derived(asts.at("gfx9"));
+        auto ret = asts.at("gfx9").at("REDUCED_A").evaluate(base_counter_decode, cache);
+        ASSERT_TRUE(ret);
+        EXPECT_EQ(ret->size(), 1);
+        double expected_sum = 0.0;
+        for(const auto& r : base_counter_data["COUNTER_A"])
+        {
+            expected_sum += r.counter_value;
+        }
+        EXPECT_FLOAT_EQ((*ret)[0].counter_value, expected_sum);
+    }
+}
+
 TEST(evaluate_ast, evaluate_simple_counters)
 {
     using namespace rocprofiler::counters;


### PR DESCRIPTION
## Summary
- Add v2 agent registration (`aqlprofile_agent_info_v2_t`) with per-SE/SA `cu_bitmap[4][4]` to support GPUs with asymmetric WGP configurations
- Propagate CU bitmaps from DRM `amdgpu_query_gpu_info` through rocprofiler-sdk agent registration to AQLProfile
- Use per-SA WGP counts (via `__builtin_popcount(cu_bitmap) / 2`) in PM4 command generation and dimension reporting

## Changes

### AQLProfile (9 files)
| File | Change |
|------|--------|
| `aql_profile_v2.h` | Add `aqlprofile_agent_info_v2_t` struct with `cu_bitmap[4][4]`, `AQLPROFILE_AGENT_VERSION_V2` enum value |
| `hsa_rsrc_factory.h` | Add `cu_bitmap[4][4]` to internal `AgentInfo` struct |
| `pm4_factory.cpp` | Add `RegisterAgent(const aqlprofile_agent_info_v2_t*)` overload |
| `pm4_factory.h` | Add `RegisterAgent` v2 declaration, `GetTotalWGPSamples`-based `GetNumEvents` for WGP blocks |
| `counters.cpp` | Handle `AQLPROFILE_AGENT_VERSION_V2` in `aqlprofile_register_agent_info()` |
| `counter_dimensions.hpp` | Compute per-SE/SA WGP counts from cu_bitmap, add `wgp_per_sa_array`, `get_wgp_count()` |
| `pmc_builder.h` | Per-SA WGP loops in PM4 read, `GetTotalWGPSamples()` virtual method |
| `aql_profile.cpp` | Use `pm4_factory->GetNumEvents()` for consistent buffer sizing |
| `pm4_factory_tests.cpp` | 3 new unit tests for v2 registration and cu_bitmap |

### rocprofiler-sdk (4 files)
| File | Change |
|------|--------|
| `aql_profile_v2.h` | Mirror of AQLProfile v2 header |
| `agent.cpp` | Query cu_bitmap via `amdgpu_query_gpu_info`, register with v2 info, fallback to v0 |
| `dimension.cpp` | New `cu_bitmap_wgp_extraction` test |
| `evaluate_ast_test.cpp` | New `asymmetric_wgp_arithmetic` and `asymmetric_wgp_reduction` tests |

## Test plan
- [x] AQLProfile unit tests: 4/4 pass (3 new)
- [x] rocprofiler-sdk evaluate_ast tests: 19/19 pass (2 new)
- [x] rocprofiler-sdk dimension tests: `set_get` and `cu_bitmap_wgp_extraction` pass (1 new)
- [ ] `dimension.block_dim_test` requires live GPU + HSA runtime (pre-existing failure in test container)
- [ ] Full CI validation

🤖 Generated with [Claude Code](https://claude.com/claude-code)