### PR TITLE
[rocdbgapi: mem-cache 7/8] Move cache_line_t::m_data to an external buffer

### DIFF
--- a/projects/rocdbgapi/src/memory.cpp
+++ b/projects/rocdbgapi/src/memory.cpp
@@ -546,7 +546,8 @@ memory_cache_t::contains_all (agent_address_t address,
 }
 
 void
-memory_cache_t::prefetch (agent_address_t address, amd_dbgapi_size_t size)
+memory_cache_t::prefetch (agent_address_t address, amd_dbgapi_size_t size,
+                          memory_pool_t &pool)
 {
   if (size == 0)
     return;
@@ -585,6 +586,7 @@ memory_cache_t::prefetch (agent_address_t address, amd_dbgapi_size_t size)
       [] (auto &&...) {}(success); /* Silence an unused variable warning when
                                       building without assertions enabled.  */
 
+      it->second.m_data = pool.alloc (cache_line_size);
       memcpy (&it->second.m_data[0],
               &staging_buffer[cache_line_address - cache_line_begin],
               cache_line_size);

--- a/projects/rocdbgapi/src/memory.h
+++ b/projects/rocdbgapi/src/memory.h
@@ -530,6 +530,41 @@ public:
                  void *value) const;
 };
 
+/* Simple pool used as backing store for memory_cache_t cache entries.
+   Each queue has its own pool, reserved for as many bytes the queue
+   might need at most.  The pool never grows beyond the initial
+   reservation.  */
+class memory_pool_t
+{
+private:
+  std::unique_ptr<std::byte[]> m_pool;
+  size_t m_used{ 0 };
+  size_t m_size{ 0 };
+
+public:
+  void clear () { m_used = 0; }
+  bool empty () const { return m_used == 0; }
+
+  void reserve (size_t size)
+  {
+    if (m_size >= size)
+      return;
+    m_pool = std::make_unique<std::byte[]> (size);
+    m_size = size;
+  }
+
+  std::byte *alloc (size_t size)
+  {
+    /* The pool never grows.  If more space is needed, the initial
+       reservation should have been larger.  */
+    dbgapi_assert (m_used + size <= m_size);
+
+    std::byte *ptr = m_pool.get () + m_used;
+    m_used += size;
+    return ptr;
+  }
+};
+
 /* A write-back memory cache.  Data is immediately updated in the cache, and
    later updated in memory when the cache is flushed.  */
 
@@ -545,7 +580,7 @@ private:
 
   struct cache_line_t
   {
-    std::array<std::byte, cache_line_size> m_data{};
+    std::byte *m_data;
     bool m_dirty{ false };
   };
 
@@ -568,7 +603,8 @@ public:
   bool contains_all (agent_address_t address, amd_dbgapi_size_t size) const;
 
   /* Create cache lines if not already valid, and immediately fill them in.  */
-  void prefetch (agent_address_t address, amd_dbgapi_size_t size);
+  void prefetch (agent_address_t address, amd_dbgapi_size_t size,
+                 memory_pool_t &pool);
 
   /* Discard all cache lines in the specified range.  If FORCE_DISCARD
      is true, dirty lines are silently dropped.  Otherwise it is an error to

--- a/projects/rocdbgapi/src/queue.cpp
+++ b/projects/rocdbgapi/src/queue.cpp
@@ -129,6 +129,11 @@ private:
      deleted, as these waves are no longer active.  */
   monotonic_counter_t<epoch_t, 1> m_next_wave_mark{};
 
+  /* Pool used by the memory cache, holding save-area data.  */
+  memory_pool_t m_save_area_pool;
+
+  void discard_save_area_cache ();
+
   std::optional<amd_dbgapi_os_queue_packet_id_t> get_os_queue_packet_id (
     const architecture_t::cwsr_record_t &cwsr_record) const;
 
@@ -361,6 +366,17 @@ aql_queue_t::aql_queue_t (amd_dbgapi_queue_id_t queue_id, const agent_t &agent,
     fatal_error ("queue ring size = %#zx is not supported", size ());
 }
 
+void
+aql_queue_t::discard_save_area_cache ()
+{
+  const auto xcc_count = agent ().os_info ().xcc_count;
+
+  agent ().memory_cache ().discard (
+    m_os_queue_info.ctx_save_restore_address,
+    xcc_count * m_os_queue_info.ctx_save_restore_area_size, true);
+  m_save_area_pool.clear ();
+}
+
 aql_queue_t::~aql_queue_t ()
 {
   process_t &process = this->process ();
@@ -388,12 +404,7 @@ aql_queue_t::~aql_queue_t ()
      want to see stale data, or for stale dirty data to corrupt the future use.
      If the process is being detached, then there's really no need to discard
      since the process will be destructed and the cache destructed.  */
-
-  const auto xcc_count = agent ().os_info ().xcc_count;
-
-  agent ().memory_cache ().discard (
-    m_os_queue_info.ctx_save_restore_address,
-    xcc_count * m_os_queue_info.ctx_save_restore_area_size, true);
+  discard_save_area_cache ();
 }
 
 compute_queue_t::displaced_instruction_ptr_t
@@ -522,9 +533,7 @@ aql_queue_t::queue_state_changed ()
       /* Discard the previously cached wave saved state lines.  The saved state
          areas may be mapped to a different address in this new context wave
          save.  */
-      agent ().memory_cache ().discard (
-        m_os_queue_info.ctx_save_restore_address,
-        xcc_count * m_os_queue_info.ctx_save_restore_area_size);
+      discard_save_area_cache ();
 
       /* Refresh the scratch_backing_memory_location and
          scratch_backing_memory_size everytime the queue is suspended.
@@ -643,7 +652,7 @@ aql_queue_t::update_waves ()
 
     dbgapi_assert (prefetch_end > prefetch_begin);
     cwsr_record->agent ().memory_cache ().prefetch (
-      prefetch_begin, prefetch_end - prefetch_begin);
+      prefetch_begin, prefetch_end - prefetch_begin, m_save_area_pool);
 
     wave_t *wave = nullptr;
 
@@ -786,6 +795,10 @@ aql_queue_t::update_waves ()
   /* Start with 0 running waves.  When iterating the control stack (below)
      each discovered wave in the running state will increment this count.  */
   m_waves_running.emplace (0);
+
+  dbgapi_assert (m_save_area_pool.empty ());
+  m_save_area_pool.reserve (agent ().os_info ().xcc_count
+                            * m_os_queue_info.ctx_save_restore_area_size);
 
   for (uint32_t xcc_id = 0; xcc_id < agent ().os_info ().xcc_count; ++xcc_id)
     {


### PR DESCRIPTION
The following patch in the series will switch the memory cache to
allocating cache entries of varying sizes instead of fixed-size cache
lines.

Since each cache entry will have its own size, the current approach of
inlining the cache line buffer in the cache_line_t object directly no
longer works.  Naively allocating the cache entry buffer on the heap
with one allocation per cache entry degrades performance
substantially, too, if the caller code continues doing many small
allocations.

The solution for that is to introduce a memory pool object, from which
buffer space for the cache entries is carved out.  The pool object is
allocated just once per queue.

With this commit, we still alway allocates cache_line_size-sized
lines, but this will allow changing that in the following patch.

Change-Id: Ie27d98c8036ff0c45f86d7dc842b8bb6f2abff72

---

**Stack**:
- #3804
- #3803 ⬅
- #3304
- #3303
- #3302
- #3301
- #4892
- #4894


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*