### PR TITLE
[TheRock CI] Update windows ci subtree to include amdgpu-windows-interop

### DIFF
--- a/.github/scripts/therock_matrix.py
+++ b/.github/scripts/therock_matrix.py
@@ -61,5 +61,6 @@ trigger_windows_ci_for_subtrees_paths = [
     "projects/hip/*",
     "projects/hip-tests/*",
     "projects/rocr-runtime/*",
+    "shared/amdgpu-windows-interop/**",
     ".github/*/therock*"
 ]


### PR DESCRIPTION
## Motivation

Changes under `shared/amdgpu-windows-interop` like https://github.com/ROCm/rocm-systems/pull/3773 should trigger TheRock Windows CI

## Technical Details

added `shared/amdgpu-windows-interop/**` to the list of dirs that should trigger windows ci

## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan

Validate https://github.com/ROCm/rocm-systems/pull/3773 runs after rebasing

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
