### PR TITLE
[rocprofiler-sdk][testing] Fix ctest with --parallel option

### DIFF
--- a/.github/workflows/rocprofiler-sdk-continuous_integration.yml
+++ b/.github/workflows/rocprofiler-sdk-continuous_integration.yml
@@ -349,7 +349,9 @@ jobs:
             -DCPACK_PACKAGING_INSTALL_PREFIX="$(realpath ${{ env.ROCM_PATH }})" \
             -DPython3_EXECUTABLE=$(which python3) \
             -DCMAKE_PREFIX_PATH='${{ env.ROCM_PATH }};${{ env.ROCM_PATH }}/llvm' \
-            ${{ env.GLOBAL_CMAKE_OPTIONS }} -- \
+            ${{ env.GLOBAL_CMAKE_OPTIONS }} \
+            -- \
+            --parallel 4 \
             -LE "${${{ matrix.system.gpu }}_EXCLUDE_LABEL_REGEX}" \
             -E  "${${{ matrix.system.gpu }}_EXCLUDE_TESTS_REGEX}"
 
@@ -663,8 +665,9 @@ jobs:
             -DPython3_EXECUTABLE=$(which python3) \
             ${{ env.GLOBAL_CMAKE_OPTIONS }} \
             -- \
+            --parallel 4 \
             -LE "${${{ matrix.system.gpu }}_EXCLUDE_LABEL_REGEX}" \
-            -E "${${{ matrix.system.gpu }}_EXCLUDE_TESTS_REGEX}" \
+            -E "${${{ matrix.system.gpu }}_EXCLUDE_TESTS_REGEX}"
 
   sanitizers:
     name: ${{ matrix.system.sanitizer }} • ${{ matrix.system.gpu }} • ${{ matrix.system.os }}

--- a/projects/rocprofiler-sdk/tests/rocprofv3/rocpd/CMakeLists.txt
+++ b/projects/rocprofiler-sdk/tests/rocprofv3/rocpd/CMakeLists.txt
@@ -65,22 +65,6 @@ rocprofiler_add_integration_execute_test(
     FIXTURES_SETUP rocprofv3-test-rocpd-multiproc
     DISABLED "${MULTIPROC_IS_DISABLED}")
 
-# Can remove this test if MULTIPROC is re-enabled and rely on the multiproc databases for
-# packaging
-rocprofiler_add_integration_execute_test(
-    rocprofv3-test-rocpd-execute2
-    COMMAND
-        $<TARGET_FILE:rocprofiler-sdk::rocprofv3> -d
-        ${CMAKE_CURRENT_BINARY_DIR}/rocpd-input-data -o out2 --output-format rocpd
-        --runtime-trace --kernel-rename --pmc SQ_WAVES --
-        $<TARGET_FILE:reproducible-dispatch-count> 500 2
-    DEPENDS reproducible-dispatch-count
-    TIMEOUT 120
-    LABELS "integration-tests;rocpd"
-    ENVIRONMENT "${rocprofv3-rocpd-env}"
-    FAIL_REGULAR_EXPRESSION "${ROCPROFILER_DEFAULT_FAIL_REGEX}"
-    FIXTURES_SETUP rocprofv3-test-rocpd)
-
 #########################################################################################
 #
 # OTF2 generation
@@ -179,6 +163,7 @@ rocprofiler_add_integration_execute_test(
 # Summary generation
 #
 #########################################################################################
+
 rocprofiler_add_integration_execute_test(
     rocprofv3-test-rocpd-summary-generation
     COMMAND
@@ -244,10 +229,18 @@ rocprofiler_add_integration_validate_test(
 #
 #########################################################################################
 
+# make sure --copy is used with package generation. Package generation will move the
+# original databases by default, not copy them. The original databases may be needed for
+# tests that have not run yet at this point in the test graph...
+#
+# Example: when ctest is run with --parallel option, these tests may run before the
+# rocprofv3-test-rocpd-generation fixture and, without using --copy, those tests would
+# fail since the input database would no longer exist.
+
 rocprofiler_add_integration_execute_test(
     rocprofv3-test-rocpd-package-generation
     COMMAND
-        ${Python3_EXECUTABLE} -m rocpd package --consolidate -d
+        ${Python3_EXECUTABLE} -m rocpd package --consolidate --copy -d
         ${CMAKE_CURRENT_BINARY_DIR}/rocpd-input-data/test_package -i
         ${CMAKE_CURRENT_BINARY_DIR}/rocpd-input-data/out*.db
     DEPENDS rocprofiler-sdk::rocprofv3
@@ -261,7 +254,7 @@ rocprofiler_add_integration_execute_test(
 rocprofiler_add_integration_execute_test(
     rocprofv3-test-rocpd-package-generation-multiproc
     COMMAND
-        ${Python3_EXECUTABLE} -m rocpd package --consolidate -d
+        ${Python3_EXECUTABLE} -m rocpd package --consolidate --copy -d
         ${CMAKE_CURRENT_BINARY_DIR}/rocpd-input-data-multiproc/test_package_multi -i
         ${CMAKE_CURRENT_BINARY_DIR}/rocpd-input-data-multiproc/out*.db
     DEPENDS rocprofiler-sdk::rocprofv3


### PR DESCRIPTION
## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->
Certain rocpd output conversion tests would periodically fail when CTest was run with `--parallel N` option.

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->
- The rocprofv3-test-rocpd-package-generation test was deleting the database generated by rocprofv3-test-rocpd test.
- When ctest was run with --parallel N, if the package generation test was run before the rocprofv3-test-rocpd-(perfetto|csv|otf2)-generation tests, the latter tests would fail because of the missing database file
- Added --copy to the package generation tests so that the original databases are not removed

## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->
N/A

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->
N/A (fixes tests)

## Test Result

<!-- Briefly summarize test outcomes. -->
N/A (fixes tests)

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
