### PR TITLE
[rocprofiler-compute] Fail dynamic attachment test quickly in case of hangs

### DIFF
--- a/projects/rocprofiler-compute/CMakeLists.txt
+++ b/projects/rocprofiler-compute/CMakeLists.txt
@@ -393,6 +393,7 @@ add_test(
         live_attach_detach --junitxml=tests/test_profile_live_attach_detach.xml
         ${COV_OPTION} tests/test_profile_general.py ${WORKING_DIR_OPTION}
 )
+set_tests_properties(test_profile_live_attach_detach PROPERTIES TIMEOUT 300)
 
 add_test(
     NAME test_profile_iteration_multiplexing_1
@@ -456,7 +457,6 @@ set_tests_properties(
     test_profile_section
     test_profile_pc_sampling
     test_profile_sets_func
-    test_profile_live_attach_detach
     test_profile_iteration_multiplexing_1
     test_profile_iteration_multiplexing_2
     test_profile_iteration_multiplexing_stochastic

--- a/projects/rocprofiler-compute/CMakeLists.txt
+++ b/projects/rocprofiler-compute/CMakeLists.txt
@@ -24,7 +24,8 @@ file(READ "${CMAKE_CURRENT_SOURCE_DIR}/VERSION" FULL_VERSION_STRING LIMIT_COUNT 
 string(REGEX REPLACE "(\n|\r)" "" FULL_VERSION_STRING "${FULL_VERSION_STRING}")
 set(ROCPROFCOMPUTE_FULL_VERSION "${FULL_VERSION_STRING}")
 string(
-    REGEX REPLACE "([0-9]+)\.([0-9]+)\.([0-9]+)(.*)"
+    REGEX REPLACE
+    "([0-9]+)\.([0-9]+)\.([0-9]+)(.*)"
     "\\1.\\2.\\3"
     ROCPROFCOMPUTE_VERSION
     "${FULL_VERSION_STRING}"
@@ -190,7 +191,7 @@ if(LOCALHOST MATCHES "TheraS01|.*\.thera\.amd\.com|thera-hn")
     file(READ ${PROJECT_SOURCE_DIR}/cmake/modfile.thera.mod mod_additions)
     file(
         APPEND
-            ${PROJECT_BINARY_DIR}/${MOD_INSTALL_PATH}/${ROCPROFCOMPUTE_FULL_VERSION}.lua
+        ${PROJECT_BINARY_DIR}/${MOD_INSTALL_PATH}/${ROCPROFCOMPUTE_FULL_VERSION}.lua
         ${mod_additions}
     )
     list(POP_BACK CMAKE_MESSAGE_INDENT)
@@ -395,10 +396,7 @@ add_test(
 )
 set_tests_properties(
     test_profile_live_attach_detach
-    PROPERTIES
-        TIMEOUT 300
-        LABELS "profile"
-        RESOURCE_GROUPS gpus:1
+    PROPERTIES TIMEOUT 300 LABELS "profile" RESOURCE_GROUPS gpus:1
 )
 
 add_test(
@@ -579,6 +577,9 @@ add_test(
         ${PYTHON_TEST_COMMAND} -m pytest ${STANDALONEBINARY_TEST_OPTION}
         --junitxml=tests/test_tui_components.xml ${COV_OPTION}
         tests/test_tui_components.py ${WORKING_DIR_OPTION}
+)
+
+# -----------------------------------
 # Torch trace tests
 # -----------------------------------
 
@@ -669,7 +670,8 @@ install(
         src/config.py
         src/rocprof_compute_base.py
         src/roofline.py
-        VERSION VERSION.sha
+        VERSION
+        VERSION.sha
     DESTINATION ${CMAKE_INSTALL_LIBEXECDIR}/${PROJECT_NAME}
     COMPONENT main
 )
@@ -1058,6 +1060,6 @@ set(CPACK_SOURCE_IGNORE_FILES
     /build
 )
 
-configure_pkg( ${PACKAGE_NAME} ${COMP_TYPE} ${CPACK_PACKAGE_VERSION} ${PKG_MAINTAINER_NM} ${PKG_MAINTAINER_EMAIL})
+configure_pkg(${PACKAGE_NAME} ${COMP_TYPE} ${CPACK_PACKAGE_VERSION} ${PKG_MAINTAINER_NM} ${PKG_MAINTAINER_EMAIL})
 
 include(CPack)

--- a/projects/rocprofiler-compute/CMakeLists.txt
+++ b/projects/rocprofiler-compute/CMakeLists.txt
@@ -393,7 +393,13 @@ add_test(
         live_attach_detach --junitxml=tests/test_profile_live_attach_detach.xml
         ${COV_OPTION} tests/test_profile_general.py ${WORKING_DIR_OPTION}
 )
-set_tests_properties(test_profile_live_attach_detach PROPERTIES TIMEOUT 300)
+set_tests_properties(
+    test_profile_live_attach_detach
+    PROPERTIES
+        TIMEOUT 300
+        LABELS "profile"
+        RESOURCE_GROUPS gpus:1
+)
 
 add_test(
     NAME test_profile_iteration_multiplexing_1


### PR DESCRIPTION
## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

Since TheRock now runs tests for rocprofiler-compute, we need to quickly fail in case of hanging tests like live attach detach to allow other tests to run

Linked issue: https://github.com/ROCm/TheRock/issues/3778

## Technical Details

Reduce timeout for test_profile_live_attach_detach from 1800 to 300 for quicker fail in case of hangs

<!-- Explain the changes along with any relevant GitHub links. -->

## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan

N/A because purely ctest timeout change

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

N/A because purely ctest timeout change

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
