### PR TITLE
[RCCL] Implicit launch order test for MPI unit test.

### DIFF
--- a/projects/rccl/test/CMakeLists.txt
+++ b/projects/rccl/test/CMakeLists.txt
@@ -229,6 +229,7 @@ if(BUILD_TESTS)
         transport/NetMPITests.cpp
         transport/ShmMPITests.cpp
         transport/NetIbMPITests.cpp
+        ImplicitLaunchOrderMPITests.cpp
       )
 
       # Create the MPI test executable

--- a/projects/rccl/test/ImplicitLaunchOrderMPITests.cpp
+++ b/projects/rccl/test/ImplicitLaunchOrderMPITests.cpp
@@ -20,10 +20,10 @@ using namespace RCCLTestHelpers;
 
 namespace ImplicitLaunchOrderConstants
 {
-constexpr size_t kBufferElements    = 64 * 1024;  // Larger buffers = longer kernel execution
+constexpr size_t kBufferElements    = 64 * 1024;
 constexpr size_t kBufferSize        = kBufferElements * sizeof(float);
-constexpr int    kChainLength       = 8;          // More operations = more race opportunities
-constexpr int    kIterations        = 20;         // More iterations = higher chance to catch races
+constexpr int    kNumCommunicators  = 4;
+constexpr int    kIterations        = 20;
 constexpr float  kValidationEpsilon = 1e-3f;
 } // namespace ImplicitLaunchOrderConstants
 
@@ -32,18 +32,29 @@ using namespace ImplicitLaunchOrderConstants;
 class ImplicitLaunchOrderMPITest : public MPITestBase
 {
 protected:
+    std::vector<ncclComm_t>  comms_;
     std::vector<hipStream_t> streams_;
     std::vector<void*>       buffers_;
 
     void SetUp() override
     {
         MPITestBase::SetUp();
+        comms_.clear();
         streams_.clear();
         buffers_.clear();
     }
 
     void TearDown() override
     {
+        for(auto& comm : comms_)
+        {
+            if(comm)
+            {
+                ncclCommDestroy(comm);
+                comm = nullptr;
+            }
+        }
+
         for(auto& buf : buffers_)
         {
             if(buf)
@@ -71,9 +82,7 @@ protected:
         for(int i = 0; i < num_streams; i++)
         {
             if(hipStreamCreate(&streams_[i]) != hipSuccess)
-            {
                 return false;
-            }
         }
         return true;
     }
@@ -84,7 +93,34 @@ protected:
         for(int i = 0; i < num_buffers; i++)
         {
             if(hipMalloc(&buffers_[i], kBufferSize) != hipSuccess)
+                return false;
+        }
+        return true;
+    }
+
+    bool createMultipleCommunicators(int num_comms)
+    {
+        comms_.resize(num_comms);
+        int rank = MPIEnvironment::world_rank;
+        int size = MPIEnvironment::world_size;
+
+        for(int i = 0; i < num_comms; i++)
+        {
+            ncclUniqueId id;
+            if(rank == 0)
             {
+                ncclGetUniqueId(&id);
+            }
+            MPI_Bcast(&id, sizeof(id), MPI_BYTE, 0, MPI_COMM_WORLD);
+
+            ncclResult_t result = ncclCommInitRank(&comms_[i], size, id, rank);
+            if(result != ncclSuccess)
+            {
+                if(MPIEnvironment::world_rank == 0)
+                {
+                    TEST_INFO("Failed to create communicator %d: %s",
+                              i, ncclGetErrorString(result));
+                }
                 return false;
             }
         }
@@ -97,8 +133,9 @@ protected:
         return env != nullptr && atoi(env) != 0;
     }
 
-    bool runDependentChain(int nranks, float& actual_value)
+    bool runMultiCommChain(int nranks, float& actual_value)
     {
+        // Initialize first buffer with rank value
         hipError_t err = initializeBufferWithPattern<float>(
             buffers_[0],
             kBufferElements,
@@ -107,7 +144,7 @@ protected:
             });
         if(err != hipSuccess) return false;
 
-        for(int i = 1; i <= kChainLength; i++)
+        for(int i = 1; i <= kNumCommunicators; i++)
         {
             if(hipMemset(buffers_[i], 0, kBufferSize) != hipSuccess)
                 return false;
@@ -116,20 +153,22 @@ protected:
         if(hipDeviceSynchronize() != hipSuccess) return false;
         MPI_Barrier(MPI_COMM_WORLD);
 
-        // Launch all operations as fast as possible without waiting
-        for(int i = 0; i < kChainLength; i++)
+        // Launch chain using DIFFERENT COMMUNICATORS
+        // Each communicator's operation reads from previous buffer, writes to next
+        // Without implicit ordering, later comms might start before earlier finish
+        for(int i = 0; i < kNumCommunicators; i++)
         {
             ncclResult_t result = ncclAllReduce(buffers_[i],
                                                  buffers_[i + 1],
                                                  kBufferElements,
                                                  ncclFloat,
                                                  ncclSum,
-                                                 getActiveCommunicator(),
+                                                 comms_[i],
                                                  streams_[i]);
             if(result != ncclSuccess) return false;
         }
 
-        for(int i = 0; i < kChainLength; i++)
+        for(int i = 0; i < kNumCommunicators; i++)
         {
             if(hipStreamSynchronize(streams_[i]) != hipSuccess)
                 return false;
@@ -138,7 +177,7 @@ protected:
         MPI_Barrier(MPI_COMM_WORLD);
 
         if(hipMemcpy(&actual_value,
-                     buffers_[kChainLength],
+                     buffers_[kNumCommunicators],
                      sizeof(float),
                      hipMemcpyDeviceToHost) != hipSuccess)
             return false;
@@ -147,7 +186,7 @@ protected:
     }
 };
 
-TEST_F(ImplicitLaunchOrderMPITest, DependentOperationsChain)
+TEST_F(ImplicitLaunchOrderMPITest, MultiCommunicatorChain)
 {
     ASSERT_TRUE(validateTestPrerequisites(kMinProcessesForMPI,
                                           kNoProcessLimit,
@@ -161,19 +200,19 @@ TEST_F(ImplicitLaunchOrderMPITest, DependentOperationsChain)
     if(MPIEnvironment::world_rank == 0)
     {
         TEST_INFO("NCCL_LAUNCH_ORDER_IMPLICIT=%s", implicit_order_enabled ? "1" : "0");
-        TEST_INFO("Chain length: %d, Buffer: %zu KB, Iterations: %d",
-                  kChainLength, kBufferSize / 1024, kIterations);
+        TEST_INFO("Communicators: %d, Buffer: %zu KB, Iterations: %d",
+                  kNumCommunicators, kBufferSize / 1024, kIterations);
     }
 
-    ASSERT_TRUE(allocateStreams(kChainLength));
-    ASSERT_TRUE(allocateBuffers(kChainLength + 1));
-    ASSERT_EQ(ncclSuccess, createTestCommunicator());
+    ASSERT_TRUE(allocateStreams(kNumCommunicators));
+    ASSERT_TRUE(allocateBuffers(kNumCommunicators + 1));
+    ASSERT_TRUE(createMultipleCommunicators(kNumCommunicators));
 
     int nranks = MPIEnvironment::world_size;
 
-    // Expected: sum(1..nranks) * nranks^(chainLength-1)
+    // Expected: sum(1..nranks) * nranks^(numComms-1)
     double expected_value = static_cast<double>(nranks * (nranks + 1) / 2);
-    for(int i = 1; i < kChainLength; i++)
+    for(int i = 1; i < kNumCommunicators; i++)
     {
         expected_value *= static_cast<double>(nranks);
     }
@@ -186,7 +225,7 @@ TEST_F(ImplicitLaunchOrderMPITest, DependentOperationsChain)
     for(int iter = 0; iter < kIterations; iter++)
     {
         float actual_value = 0.0f;
-        ASSERT_TRUE(runDependentChain(nranks, actual_value));
+        ASSERT_TRUE(runMultiCommChain(nranks, actual_value));
 
         bool correct = (std::abs(actual_value - expected_value) < kValidationEpsilon * expected_value);
         if(correct)

--- a/projects/rccl/test/ImplicitLaunchOrderMPITests.cpp
+++ b/projects/rccl/test/ImplicitLaunchOrderMPITests.cpp
@@ -46,6 +46,7 @@ protected:
 
     void TearDown() override
     {
+        // Destroy split communicators (parent is handled by base class)
         for(auto& comm : comms_)
         {
             if(comm)
@@ -98,27 +99,26 @@ protected:
         return true;
     }
 
-    bool createMultipleCommunicators(int num_comms)
+    bool splitCommunicators(int num_comms)
     {
         comms_.resize(num_comms);
+        ncclComm_t parent = getActiveCommunicator();
         int rank = MPIEnvironment::world_rank;
-        int size = MPIEnvironment::world_size;
 
         for(int i = 0; i < num_comms; i++)
         {
-            ncclUniqueId id;
-            if(rank == 0)
-            {
-                ncclGetUniqueId(&id);
-            }
-            MPI_Bcast(&id, sizeof(id), MPI_BYTE, 0, MPI_COMM_WORLD);
-
-            ncclResult_t result = ncclCommInitRank(&comms_[i], size, id, rank);
+            // Split with same color (0) = all ranks in same group
+            // Use rank as key to maintain rank ordering
+            ncclResult_t result = ncclCommSplit(parent,
+                                                 0,        // color
+                                                 rank,     // key
+                                                 &comms_[i],
+                                                 nullptr); // config
             if(result != ncclSuccess)
             {
                 if(MPIEnvironment::world_rank == 0)
                 {
-                    TEST_INFO("Failed to create communicator %d: %s",
+                    TEST_INFO("Failed to split communicator %d: %s",
                               i, ncclGetErrorString(result));
                 }
                 return false;
@@ -135,7 +135,6 @@ protected:
 
     bool runMultiCommChain(int nranks, float& actual_value)
     {
-        // Initialize first buffer with rank value
         hipError_t err = initializeBufferWithPattern<float>(
             buffers_[0],
             kBufferElements,
@@ -153,9 +152,7 @@ protected:
         if(hipDeviceSynchronize() != hipSuccess) return false;
         MPI_Barrier(MPI_COMM_WORLD);
 
-        // Launch chain using DIFFERENT COMMUNICATORS
-        // Each communicator's operation reads from previous buffer, writes to next
-        // Without implicit ordering, later comms might start before earlier finish
+        // Launch chain using DIFFERENT COMMUNICATORS (split from parent)
         for(int i = 0; i < kNumCommunicators; i++)
         {
             ncclResult_t result = ncclAllReduce(buffers_[i],
@@ -206,7 +203,12 @@ TEST_F(ImplicitLaunchOrderMPITest, MultiCommunicatorChain)
 
     ASSERT_TRUE(allocateStreams(kNumCommunicators));
     ASSERT_TRUE(allocateBuffers(kNumCommunicators + 1));
-    ASSERT_TRUE(createMultipleCommunicators(kNumCommunicators));
+
+    // Create parent communicator using MPITestCore
+    ASSERT_EQ(ncclSuccess, createTestCommunicator());
+
+    // Split into multiple child communicators
+    ASSERT_TRUE(splitCommunicators(kNumCommunicators));
 
     int nranks = MPIEnvironment::world_size;
 

--- a/projects/rccl/test/ImplicitLaunchOrderMPITests.cpp
+++ b/projects/rccl/test/ImplicitLaunchOrderMPITests.cpp
@@ -1,0 +1,233 @@
+/*************************************************************************
+ * Copyright (c) 2025 Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * See LICENSE.txt for license information
+ ************************************************************************/
+
+#include "DeviceBufferHelpers.hpp"
+#include "MPITestBase.hpp"
+#include "ResourceGuards.hpp"
+#include "TestChecks.hpp"
+
+#include <cstdlib>
+#include <vector>
+
+#ifdef MPI_TESTS_ENABLED
+
+using namespace MPITestConstants;
+using namespace RCCLTestGuards;
+using namespace RCCLTestHelpers;
+
+namespace ImplicitLaunchOrderConstants
+{
+constexpr size_t kBufferElements    = 64 * 1024;  // Larger buffers = longer kernel execution
+constexpr size_t kBufferSize        = kBufferElements * sizeof(float);
+constexpr int    kChainLength       = 8;          // More operations = more race opportunities
+constexpr int    kIterations        = 20;         // More iterations = higher chance to catch races
+constexpr float  kValidationEpsilon = 1e-3f;
+} // namespace ImplicitLaunchOrderConstants
+
+using namespace ImplicitLaunchOrderConstants;
+
+class ImplicitLaunchOrderMPITest : public MPITestBase
+{
+protected:
+    std::vector<hipStream_t> streams_;
+    std::vector<void*>       buffers_;
+
+    void SetUp() override
+    {
+        MPITestBase::SetUp();
+        streams_.clear();
+        buffers_.clear();
+    }
+
+    void TearDown() override
+    {
+        for(auto& buf : buffers_)
+        {
+            if(buf)
+            {
+                hipFree(buf);
+                buf = nullptr;
+            }
+        }
+
+        for(auto& stream : streams_)
+        {
+            if(stream)
+            {
+                hipStreamDestroy(stream);
+                stream = nullptr;
+            }
+        }
+
+        MPITestBase::TearDown();
+    }
+
+    bool allocateStreams(int num_streams)
+    {
+        streams_.resize(num_streams);
+        for(int i = 0; i < num_streams; i++)
+        {
+            if(hipStreamCreate(&streams_[i]) != hipSuccess)
+            {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    bool allocateBuffers(int num_buffers)
+    {
+        buffers_.resize(num_buffers);
+        for(int i = 0; i < num_buffers; i++)
+        {
+            if(hipMalloc(&buffers_[i], kBufferSize) != hipSuccess)
+            {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    static bool isImplicitLaunchOrderEnabled()
+    {
+        const char* env = getenv("NCCL_LAUNCH_ORDER_IMPLICIT");
+        return env != nullptr && atoi(env) != 0;
+    }
+
+    bool runDependentChain(int nranks, float& actual_value)
+    {
+        hipError_t err = initializeBufferWithPattern<float>(
+            buffers_[0],
+            kBufferElements,
+            [rank = MPIEnvironment::world_rank](size_t) {
+                return static_cast<float>(rank + 1);
+            });
+        if(err != hipSuccess) return false;
+
+        for(int i = 1; i <= kChainLength; i++)
+        {
+            if(hipMemset(buffers_[i], 0, kBufferSize) != hipSuccess)
+                return false;
+        }
+
+        if(hipDeviceSynchronize() != hipSuccess) return false;
+        MPI_Barrier(MPI_COMM_WORLD);
+
+        // Launch all operations as fast as possible without waiting
+        for(int i = 0; i < kChainLength; i++)
+        {
+            ncclResult_t result = ncclAllReduce(buffers_[i],
+                                                 buffers_[i + 1],
+                                                 kBufferElements,
+                                                 ncclFloat,
+                                                 ncclSum,
+                                                 getActiveCommunicator(),
+                                                 streams_[i]);
+            if(result != ncclSuccess) return false;
+        }
+
+        for(int i = 0; i < kChainLength; i++)
+        {
+            if(hipStreamSynchronize(streams_[i]) != hipSuccess)
+                return false;
+        }
+
+        MPI_Barrier(MPI_COMM_WORLD);
+
+        if(hipMemcpy(&actual_value,
+                     buffers_[kChainLength],
+                     sizeof(float),
+                     hipMemcpyDeviceToHost) != hipSuccess)
+            return false;
+
+        return true;
+    }
+};
+
+TEST_F(ImplicitLaunchOrderMPITest, DependentOperationsChain)
+{
+    ASSERT_TRUE(validateTestPrerequisites(kMinProcessesForMPI,
+                                          kNoProcessLimit,
+                                          kNoPowerOfTwoRequired,
+                                          1,
+                                          kRequireSingleNode))
+        << "Test requirements not met";
+
+    bool implicit_order_enabled = isImplicitLaunchOrderEnabled();
+
+    if(MPIEnvironment::world_rank == 0)
+    {
+        TEST_INFO("NCCL_LAUNCH_ORDER_IMPLICIT=%s", implicit_order_enabled ? "1" : "0");
+        TEST_INFO("Chain length: %d, Buffer: %zu KB, Iterations: %d",
+                  kChainLength, kBufferSize / 1024, kIterations);
+    }
+
+    ASSERT_TRUE(allocateStreams(kChainLength));
+    ASSERT_TRUE(allocateBuffers(kChainLength + 1));
+    ASSERT_EQ(ncclSuccess, createTestCommunicator());
+
+    int nranks = MPIEnvironment::world_size;
+
+    // Expected: sum(1..nranks) * nranks^(chainLength-1)
+    double expected_value = static_cast<double>(nranks * (nranks + 1) / 2);
+    for(int i = 1; i < kChainLength; i++)
+    {
+        expected_value *= static_cast<double>(nranks);
+    }
+
+    int   correct_count = 0;
+    int   wrong_count   = 0;
+    bool  all_same      = true;
+    float first_result  = 0.0f;
+
+    for(int iter = 0; iter < kIterations; iter++)
+    {
+        float actual_value = 0.0f;
+        ASSERT_TRUE(runDependentChain(nranks, actual_value));
+
+        bool correct = (std::abs(actual_value - expected_value) < kValidationEpsilon * expected_value);
+        if(correct)
+            correct_count++;
+        else
+            wrong_count++;
+
+        if(iter == 0)
+            first_result = actual_value;
+        else if(std::abs(actual_value - first_result) > kValidationEpsilon * expected_value)
+            all_same = false;
+    }
+
+    if(MPIEnvironment::world_rank == 0)
+    {
+        TEST_INFO("Expected: %.0f, Correct: %d/%d, Consistent: %s",
+                  expected_value, correct_count, kIterations, all_same ? "yes" : "no");
+    }
+
+    if(implicit_order_enabled)
+    {
+        EXPECT_EQ(correct_count, kIterations)
+            << "With NCCL_LAUNCH_ORDER_IMPLICIT=1, all iterations should be correct";
+        EXPECT_TRUE(all_same)
+            << "With NCCL_LAUNCH_ORDER_IMPLICIT=1, results should be consistent";
+    }
+    else
+    {
+        if(MPIEnvironment::world_rank == 0)
+        {
+            if(wrong_count > 0 || !all_same)
+            {
+                TEST_INFO("Race detected: %d wrong, %s",
+                          wrong_count, all_same ? "consistent" : "inconsistent");
+            }
+            else
+            {
+                TEST_INFO("No race detected (non-deterministic)");
+            }
+        }
+    }
+}
+
+#endif // MPI_TESTS_ENABLED

--- a/projects/rccl/test/ImplicitLaunchOrderMPITests.cpp
+++ b/projects/rccl/test/ImplicitLaunchOrderMPITests.cpp
@@ -1,5 +1,5 @@
 /*************************************************************************
- * Copyright (c) 2025 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
  *
  * See LICENSE.txt for license information
  ************************************************************************/
@@ -32,99 +32,64 @@ using namespace ImplicitLaunchOrderConstants;
 class ImplicitLaunchOrderMPITest : public MPITestBase
 {
 protected:
-    std::vector<ncclComm_t>  comms_;
-    std::vector<hipStream_t> streams_;
-    std::vector<void*>       buffers_;
+    std::vector<NcclCommAutoGuard>     comm_guards_;
+    std::vector<HipStreamAutoGuard>    stream_guards_;
+    std::vector<DeviceBufferAutoGuard> buffer_guards_;
 
     void SetUp() override
     {
         MPITestBase::SetUp();
-        comms_.clear();
-        streams_.clear();
-        buffers_.clear();
+        comm_guards_.clear();
+        stream_guards_.clear();
+        buffer_guards_.clear();
     }
 
     void TearDown() override
     {
-        // Destroy split communicators (parent is handled by base class)
-        for(auto& comm : comms_)
-        {
-            if(comm)
-            {
-                ncclCommDestroy(comm);
-                comm = nullptr;
-            }
-        }
-
-        for(auto& buf : buffers_)
-        {
-            if(buf)
-            {
-                hipFree(buf);
-                buf = nullptr;
-            }
-        }
-
-        for(auto& stream : streams_)
-        {
-            if(stream)
-            {
-                hipStreamDestroy(stream);
-                stream = nullptr;
-            }
-        }
-
+        // Destroy child comms before parent (cleaned up by base class)
+        comm_guards_.clear();
+        buffer_guards_.clear();
+        stream_guards_.clear();
         MPITestBase::TearDown();
     }
 
-    bool allocateStreams(int num_streams)
+    ncclResult_t allocateStreams(int num_streams)
     {
-        streams_.resize(num_streams);
+        stream_guards_.reserve(num_streams);
         for(int i = 0; i < num_streams; i++)
         {
-            if(hipStreamCreate(&streams_[i]) != hipSuccess)
-                return false;
+            hipStream_t stream{};
+            HIPCHECK(hipStreamCreate(&stream));
+            stream_guards_.push_back(makeStreamAutoGuard(stream));
         }
-        return true;
+        return ncclSuccess;
     }
 
-    bool allocateBuffers(int num_buffers)
+    ncclResult_t allocateBuffers(int num_buffers)
     {
-        buffers_.resize(num_buffers);
+        buffer_guards_.reserve(num_buffers);
         for(int i = 0; i < num_buffers; i++)
         {
-            if(hipMalloc(&buffers_[i], kBufferSize) != hipSuccess)
-                return false;
+            void* buf = nullptr;
+            HIPCHECK(hipMalloc(&buf, kBufferSize));
+            buffer_guards_.push_back(makeDeviceBufferAutoGuard(buf));
         }
-        return true;
+        return ncclSuccess;
     }
 
-    bool splitCommunicators(int num_comms)
+    ncclResult_t splitCommunicators(int num_comms)
     {
-        comms_.resize(num_comms);
+        comm_guards_.reserve(num_comms);
         ncclComm_t parent = getActiveCommunicator();
-        int rank = MPIEnvironment::world_rank;
+        int        rank   = MPIEnvironment::world_rank;
 
         for(int i = 0; i < num_comms; i++)
         {
-            // Split with same color (0) = all ranks in same group
-            // Use rank as key to maintain rank ordering
-            ncclResult_t result = ncclCommSplit(parent,
-                                                 0,        // color
-                                                 rank,     // key
-                                                 &comms_[i],
-                                                 nullptr); // config
-            if(result != ncclSuccess)
-            {
-                if(MPIEnvironment::world_rank == 0)
-                {
-                    TEST_INFO("Failed to split communicator %d: %s",
-                              i, ncclGetErrorString(result));
-                }
-                return false;
-            }
+            ncclComm_t comm{};
+            RCCL_TEST_CHECK(ncclCommSplit(parent, 0, rank, &comm, nullptr));
+            comm_guards_.push_back(makeCommAutoGuard(comm));
         }
-        return true;
+        return ncclSuccess;
     }
 
     static bool isImplicitLaunchOrderEnabled()
@@ -133,53 +98,37 @@ protected:
         return env != nullptr && atoi(env) != 0;
     }
 
-    bool runMultiCommChain(int nranks, float& actual_value)
+    ncclResult_t runMultiCommChain()
     {
-        hipError_t err = initializeBufferWithPattern<float>(
-            buffers_[0],
+        HIPCHECK(initializeBufferWithPattern<float>(
+            buffer_guards_[0].get(),
             kBufferElements,
             [rank = MPIEnvironment::world_rank](size_t) {
                 return static_cast<float>(rank + 1);
-            });
-        if(err != hipSuccess) return false;
+            }));
 
         for(int i = 1; i <= kNumCommunicators; i++)
         {
-            if(hipMemset(buffers_[i], 0, kBufferSize) != hipSuccess)
-                return false;
-        }
-
-        if(hipDeviceSynchronize() != hipSuccess) return false;
-        MPI_Barrier(MPI_COMM_WORLD);
-
-        // Launch chain using DIFFERENT COMMUNICATORS (split from parent)
-        for(int i = 0; i < kNumCommunicators; i++)
-        {
-            ncclResult_t result = ncclAllReduce(buffers_[i],
-                                                 buffers_[i + 1],
-                                                 kBufferElements,
-                                                 ncclFloat,
-                                                 ncclSum,
-                                                 comms_[i],
-                                                 streams_[i]);
-            if(result != ncclSuccess) return false;
+            HIPCHECK(zeroInitializeBuffer<float>(buffer_guards_[i].get(), kBufferElements));
         }
 
         for(int i = 0; i < kNumCommunicators; i++)
         {
-            if(hipStreamSynchronize(streams_[i]) != hipSuccess)
-                return false;
+            RCCL_TEST_CHECK(ncclAllReduce(buffer_guards_[i].get(),
+                                          buffer_guards_[i + 1].get(),
+                                          kBufferElements,
+                                          getNcclDataType<float>(),
+                                          ncclSum,
+                                          comm_guards_[i].get(),
+                                          stream_guards_[i].get()));
         }
 
-        MPI_Barrier(MPI_COMM_WORLD);
+        for(int i = 0; i < kNumCommunicators; i++)
+        {
+            HIPCHECK(hipStreamSynchronize(stream_guards_[i].get()));
+        }
 
-        if(hipMemcpy(&actual_value,
-                     buffers_[kNumCommunicators],
-                     sizeof(float),
-                     hipMemcpyDeviceToHost) != hipSuccess)
-            return false;
-
-        return true;
+        return ncclSuccess;
     }
 };
 
@@ -194,21 +143,14 @@ TEST_F(ImplicitLaunchOrderMPITest, MultiCommunicatorChain)
 
     bool implicit_order_enabled = isImplicitLaunchOrderEnabled();
 
-    if(MPIEnvironment::world_rank == 0)
-    {
-        TEST_INFO("NCCL_LAUNCH_ORDER_IMPLICIT=%s", implicit_order_enabled ? "1" : "0");
-        TEST_INFO("Communicators: %d, Buffer: %zu KB, Iterations: %d",
-                  kNumCommunicators, kBufferSize / 1024, kIterations);
-    }
+    TEST_INFO("NCCL_LAUNCH_ORDER_IMPLICIT=%s", implicit_order_enabled ? "1" : "0");
+    TEST_INFO("Communicators: %d, Buffer: %zu KB, Iterations: %d",
+              kNumCommunicators, kBufferSize / 1024, kIterations);
 
-    ASSERT_TRUE(allocateStreams(kNumCommunicators));
-    ASSERT_TRUE(allocateBuffers(kNumCommunicators + 1));
-
-    // Create parent communicator using MPITestCore
-    ASSERT_EQ(ncclSuccess, createTestCommunicator());
-
-    // Split into multiple child communicators
-    ASSERT_TRUE(splitCommunicators(kNumCommunicators));
+    ASSERT_MPI_EQ(ncclSuccess, allocateStreams(kNumCommunicators));
+    ASSERT_MPI_EQ(ncclSuccess, allocateBuffers(kNumCommunicators + 1));
+    ASSERT_MPI_EQ(ncclSuccess, createTestCommunicator());
+    ASSERT_MPI_EQ(ncclSuccess, splitCommunicators(kNumCommunicators));
 
     int nranks = MPIEnvironment::world_size;
 
@@ -219,6 +161,8 @@ TEST_F(ImplicitLaunchOrderMPITest, MultiCommunicatorChain)
         expected_value *= static_cast<double>(nranks);
     }
 
+    float expected_f = static_cast<float>(expected_value);
+
     int   correct_count = 0;
     int   wrong_count   = 0;
     bool  all_same      = true;
@@ -226,26 +170,32 @@ TEST_F(ImplicitLaunchOrderMPITest, MultiCommunicatorChain)
 
     for(int iter = 0; iter < kIterations; iter++)
     {
-        float actual_value = 0.0f;
-        ASSERT_TRUE(runMultiCommChain(nranks, actual_value));
+        ASSERT_MPI_EQ(ncclSuccess, runMultiCommChain());
 
-        bool correct = (std::abs(actual_value - expected_value) < kValidationEpsilon * expected_value);
+        bool correct = verifyBufferData<float>(
+            buffer_guards_[kNumCommunicators].get(),
+            kBufferElements,
+            [expected_f](size_t) { return expected_f; },
+            0,
+            static_cast<double>(kValidationEpsilon * expected_value));
+
         if(correct)
             correct_count++;
         else
             wrong_count++;
 
+        auto [dl_err, host_data] = downloadBuffer<float>(
+            buffer_guards_[kNumCommunicators].get(), 1);
+        ASSERT_MPI_EQ(dl_err, hipSuccess);
+
         if(iter == 0)
-            first_result = actual_value;
-        else if(std::abs(actual_value - first_result) > kValidationEpsilon * expected_value)
+            first_result = host_data[0];
+        else if(std::abs(host_data[0] - first_result) > kValidationEpsilon * expected_value)
             all_same = false;
     }
 
-    if(MPIEnvironment::world_rank == 0)
-    {
-        TEST_INFO("Expected: %.0f, Correct: %d/%d, Consistent: %s",
-                  expected_value, correct_count, kIterations, all_same ? "yes" : "no");
-    }
+    TEST_INFO("Expected: %.0f, Correct: %d/%d, Consistent: %s",
+              expected_value, correct_count, kIterations, all_same ? "yes" : "no");
 
     if(implicit_order_enabled)
     {
@@ -256,17 +206,14 @@ TEST_F(ImplicitLaunchOrderMPITest, MultiCommunicatorChain)
     }
     else
     {
-        if(MPIEnvironment::world_rank == 0)
+        if(wrong_count > 0 || !all_same)
         {
-            if(wrong_count > 0 || !all_same)
-            {
-                TEST_INFO("Race detected: %d wrong, %s",
-                          wrong_count, all_same ? "consistent" : "inconsistent");
-            }
-            else
-            {
-                TEST_INFO("No race detected (non-deterministic)");
-            }
+            TEST_INFO("Race detected: %d wrong, %s",
+                      wrong_count, all_same ? "consistent" : "inconsistent");
+        }
+        else
+        {
+            TEST_INFO("No race detected (non-deterministic)");
         }
     }
 }

--- a/projects/rccl/tools/scripts/test_runner/configs/mi300x_mellanox_ib.json
+++ b/projects/rccl/tools/scripts/test_runner/configs/mi300x_mellanox_ib.json
@@ -433,6 +433,25 @@
           "test_filter": "AltRsmiTest.*"
         }
       ]
+    },
+    "implicit_launch_order": {
+      "extends": "default",
+      "is_gtest": true,
+      "binary": "rccl-UnitTestsMPI",
+      "num_ranks": 8,
+      "num_nodes": 1,
+      "num_gpus": 8,
+      "timeout": 300,
+      "env_variables": {
+        "NCCL_LAUNCH_ORDER_IMPLICIT": "1"
+      },
+      "tests": [
+        {
+          "name": "ImplicitLaunchOrder_MultiCommunicatorChain",
+          "description": "Test NCCL_LAUNCH_ORDER_IMPLICIT serialization across multiple communicators",
+          "test_filter": "ImplicitLaunchOrderMPITest.MultiCommunicatorChain"
+        }
+      ]
     }
   },
   "test_suites": [
@@ -500,6 +519,12 @@
       "name": "AltRsmi Tests - Complete Suite",
       "description": "All Alternative RSMI tests using public API only",
       "config": "alt_rsmi_tests",
+      "enabled": true
+    },
+    {
+      "name": "Implicit Launch Order Tests",
+      "description": "Test NCCL_LAUNCH_ORDER_IMPLICIT for multi-communicator serialization",
+      "config": "implicit_launch_order",
       "enabled": true
     }
   ]


### PR DESCRIPTION
## Motivation

Adding a test to ensure `NCCL_LAUNCH_ORDER_IMPLICIT` works as expected.

## Technical Details

Test covers both on and off cases for the environment variable to replicate behavior if the environment variable is not set, this is case in not set in the test runner config though and would only be applicable if some is running the test in the MPI-TEST-FRAMEWORK alone.

## JIRA ID

AICOMRCCL-551

## Test Plan

Launched the test manually.

## Test Result

Test worked as expected in both cases

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
