### PR TITLE
Enforce CTS Offload/Inline mutual dependency and disable CTS Offload with NIC Fusion in net_ib_rocm

### DIFF
--- a/projects/rccl/ext-src/rocm_netib.patch
+++ b/projects/rccl/ext-src/rocm_netib.patch
@@ -59,7 +59,27 @@ diff --git a/src/transport/net_ib.cc b/src/transport/net_ib.cc
  
  static ncclResult_t ncclIbStatsInit(struct ncclIbStats* stat) {
    __atomic_store_n(&stat->fatalErrorCount, 0, __ATOMIC_RELAXED);
-@@ -779,6 +809,10 @@ ncclResult_t ncclIbInit(void** ctx, uint
+@@ -751,6 +781,19 @@ ncclResult_t ncclIbMakeVDeviceInternal(i
+     }
+   }
+ 
++  // CTS Offload and CTS Inline are not yet compatible with NIC Fusion
++  // (NCCL_IB_MERGE_NICS). Disable them when a multi-NIC vNIC is created.
++  if (props->ndevs > 1) {
++    if (rcclCtsInlineData) {
++      INFO(NCCL_INIT|NCCL_NET, "NET/IB : NIC Fusion (ndevs=%d) - disabling CTS Inline Data (not yet supported with merge)", props->ndevs);
++      rcclCtsInlineData = false;
++    }
++    if (rcclCtsOffloadEnabled) {
++      INFO(NCCL_INIT|NCCL_NET, "NET/IB : NIC Fusion (ndevs=%d) - disabling CTS Offload (not yet supported with merge)", props->ndevs);
++      rcclCtsOffloadEnabled = false;
++    }
++  }
++
+   *d = ncclNMergedIbDevs++;
+   INFO(NCCL_NET, "NET/IB : Made virtual device [%d] name=%s speed=%d ndevs=%d", *d, mDev->devName, mDev->speed, mDev->vProps.ndevs);
+   return ncclSuccess;
+@@ -779,6 +822,10 @@ ncclResult_t ncclIbInit(void** ctx, uint
    static int shownIbHcaEnv = 0;
    if(wrap_ibv_symbols() != ncclSuccess) { return ncclInternalError; }
    if(wrap_mlx5dv_symbols() != ncclSuccess) { INFO(NCCL_NET, "NET/IB : Failed to open mlx5dv symbols. Advance features like CX-8 Direct-NIC will be disabled."); }
@@ -70,7 +90,7 @@ diff --git a/src/transport/net_ib.cc b/src/transport/net_ib.cc
  
    // Detect IB cards
    int nIbDevs = 0;
-@@ -944,6 +978,37 @@ ncclResult_t ncclIbInit(void** ctx, uint
+@@ -944,6 +991,37 @@ ncclResult_t ncclIbInit(void** ctx, uint
      INFO(NCCL_INIT|NCCL_NET, "NET/IB : Using%s %s; OOB %s:%s", line, ncclIbRelaxedOrderingEnabled ? "[RO]" : "",
            ncclIbIfName, ncclSocketToString(&ncclIbIfAddr, addrline));
  
@@ -83,17 +103,17 @@ diff --git a/src/transport/net_ib.cc b/src/transport/net_ib.cc
 +      rcclCtsInlineData = ((rcclParamCtsInlineData() == 0) ? false : true);
 +      rcclCtsOffloadEnabled = ((rcclParamCtsOffloadEnabled() == 0) ? false : true);
 +
-+      // CTS Offload and CTS Inline are not yet compatible with NIC Fusion
-+      // (NCCL_IB_MERGE_NICS). Temporarily disable them when merge is enabled.
-+      if (ncclParamRocmIbMergeNics()) {
-+        if (rcclCtsInlineData) {
-+          INFO(NCCL_INIT|NCCL_NET, "NET/IB : NIC Fusion enabled - disabling CTS Inline Data (not yet supported with merge)");
-+          rcclCtsInlineData = false;
-+        }
++      // CTS Offload and CTS Inline are mutually dependent — both must be
++      // enabled for either to function. Disable both if either is missing.
++      if (!rcclCtsOffloadEnabled || !rcclCtsInlineData) {
 +        if (rcclCtsOffloadEnabled) {
-+          INFO(NCCL_INIT|NCCL_NET, "NET/IB : NIC Fusion enabled - disabling CTS Offload (not yet supported with merge)");
-+          rcclCtsOffloadEnabled = false;
++          INFO(NCCL_INIT|NCCL_NET, "NET/IB : CTS Inline disabled - disabling CTS Offload (requires CTS Inline)");
 +        }
++        if (rcclCtsInlineData) {
++          INFO(NCCL_INIT|NCCL_NET, "NET/IB : CTS Offload disabled - disabling CTS Inline (requires CTS Offload)");
++        }
++        rcclCtsOffloadEnabled = false;
++        rcclCtsInlineData = false;
 +      }
 +
 +      // for AINIC IbUseInline is enabled by default always
@@ -108,7 +128,7 @@ diff --git a/src/transport/net_ib.cc b/src/transport/net_ib.cc
    }
  exit:
    ibContext.trafficClass = config->trafficClass;
-@@ -1280,6 +1345,8 @@ struct ncclIbListenComm {
+@@ -1280,6 +1358,8 @@ struct ncclIbListenComm {
    struct ncclIbCommStage stage;
  };
  
@@ -117,7 +137,7 @@ diff --git a/src/transport/net_ib.cc b/src/transport/net_ib.cc
  struct alignas(64) ncclIbSendFifo {
    uint64_t addr;
    uint64_t size;
-@@ -1290,10 +1357,21 @@ struct alignas(64) ncclIbSendFifo {
+@@ -1290,10 +1370,21 @@ struct alignas(64) ncclIbSendFifo {
    char padding[16];
  };
  
@@ -139,7 +159,7 @@ diff --git a/src/transport/net_ib.cc b/src/transport/net_ib.cc
  };
  
  struct ncclIbRemSizesFifo {
-@@ -1340,6 +1418,7 @@ struct ncclIbSendComm {
+@@ -1340,6 +1431,7 @@ struct ncclIbSendComm {
    struct ncclIbNetCommBase base;
    // Start with fifo and ibv structs as they have alignment restrictions
    struct ncclIbSendFifo fifo[MAX_REQUESTS][NCCL_NET_IB_MAX_RECVS];
@@ -147,7 +167,7 @@ diff --git a/src/transport/net_ib.cc b/src/transport/net_ib.cc
    struct ibv_sge sges[NCCL_NET_IB_MAX_RECVS];
    struct ibv_send_wr wrs[NCCL_NET_IB_MAX_RECVS + 1];
    // Each dev correlates to a mergedIbDev
-@@ -1355,6 +1434,7 @@ struct ncclIbSendComm {
+@@ -1355,6 +1447,7 @@ struct ncclIbSendComm {
  static_assert((sizeof(struct ncclIbNetCommBase) % 32) == 0, "ncclIbNetCommBase size must be 32-byte multiple to ensure fifo is at proper offset");
  static_assert((offsetof(struct ncclIbSendComm, fifo) % 32) == 0, "ncclIbSendComm fifo must be 32-byte aligned");
  static_assert((sizeof(struct ncclIbSendFifo) % 32) == 0, "ncclIbSendFifo element size must be 32-byte multiples");
@@ -155,7 +175,7 @@ diff --git a/src/transport/net_ib.cc b/src/transport/net_ib.cc
  static_assert((offsetof(struct ncclIbSendComm, sges) % 32) == 0, "sges must be 32-byte aligned");
  static_assert((offsetof(struct ncclIbSendComm, wrs) % 32) == 0, "wrs must be 32-byte aligned");
  
-@@ -1369,6 +1449,7 @@ struct ncclIbGpuFlush {
+@@ -1369,6 +1462,7 @@ struct ncclIbGpuFlush {
  
  struct ncclIbRemFifo {
    struct ncclIbSendFifo elems[MAX_REQUESTS][NCCL_NET_IB_MAX_RECVS];
@@ -163,7 +183,7 @@ diff --git a/src/transport/net_ib.cc b/src/transport/net_ib.cc
    uint64_t fifoTail;
    uint64_t addr;
    uint32_t flags;
-@@ -1424,20 +1505,59 @@ ncclResult_t ncclIbDestroyBase(struct nc
+@@ -1424,20 +1518,59 @@ ncclResult_t ncclIbDestroyBase(struct nc
    return ncclSuccess;
  }
  
@@ -225,7 +245,7 @@ diff --git a/src/transport/net_ib.cc b/src/transport/net_ib.cc
    struct ibv_qp_attr qpAttr;
    memset(&qpAttr, 0, sizeof(struct ibv_qp_attr));
    qpAttr.qp_state = IBV_QPS_INIT;
-@@ -1447,6 +1567,9 @@ ncclResult_t ncclIbCreateQp(uint8_t ib_p
+@@ -1447,6 +1580,9 @@ ncclResult_t ncclIbCreateQp(uint8_t ib_p
    NCCLCHECK(wrap_ibv_modify_qp(qp->qp, &qpAttr, IBV_QP_STATE | IBV_QP_PKEY_INDEX | IBV_QP_PORT | IBV_QP_ACCESS_FLAGS));
    TRACE(NCCL_NET, "NET/IB : ncclIbCreateQp port=%d dev=%d devName=%s ndevs=%d nmdevs=%d qpn=%u pkey=%u pd=%p",
      ib_port, base->ibDevN, ncclIbDevs[base->ibDevN].devName, ncclNIbDevs, ncclNMergedIbDevs, qp->qp->qp_num, qpAttr.pkey_index, base->pd);
@@ -235,7 +255,7 @@ diff --git a/src/transport/net_ib.cc b/src/transport/net_ib.cc
    return ncclSuccess;
  }
  
-@@ -1530,16 +1653,21 @@ fail:
+@@ -1530,16 +1666,21 @@ fail:
    goto exit;
  }
  
@@ -259,7 +279,7 @@ diff --git a/src/transport/net_ib.cc b/src/transport/net_ib.cc
    if (stage->state == ncclIbCommStateConnect)      goto ib_connect_check;
    if (stage->state == ncclIbCommStateSendDevList)  goto ib_send_dev_list;
    if (stage->state == ncclIbCommStateRecvDevList)  goto ib_recv_dev_list;
-@@ -1621,7 +1749,7 @@ ib_recv_dev_list:
+@@ -1621,7 +1762,7 @@ ib_recv_dev_list:
    for (int q = 0; q < comm->base.nqps; q++) {
      ncclIbSendCommDev* commDev = comm->devs + devIndex;
      ncclIbDev* ibDev = ncclIbDevs + commDev->base.ibDevN;
@@ -268,7 +288,7 @@ diff --git a/src/transport/net_ib.cc b/src/transport/net_ib.cc
      comm->base.qps[q].devIndex = devIndex;
      meta.qpInfo[q].qpn      = comm->base.qps[q].qp->qp_num;
      meta.qpInfo[q].devIndex = comm->base.qps[q].devIndex;
-@@ -1646,7 +1774,11 @@ ib_recv_dev_list:
+@@ -1646,7 +1787,11 @@ ib_recv_dev_list:
      devInfo->lid           = ibDev->portAttr.lid;
      devInfo->ibv_dev_index = commDev->base.ibDevN;
      // Prepare my fifo
@@ -281,7 +301,7 @@ diff --git a/src/transport/net_ib.cc b/src/transport/net_ib.cc
      devInfo->fifoRkey = commDev->fifoMr->rkey;
  
      // Pack local GID info
-@@ -1689,7 +1821,11 @@ ib_recv_dev_list:
+@@ -1689,7 +1834,11 @@ ib_recv_dev_list:
      }
    }
    config = (ncclNetCommConfig_t*)ctx;
@@ -294,7 +314,7 @@ diff --git a/src/transport/net_ib.cc b/src/transport/net_ib.cc
    meta.sl = (ncclParamIbSl() != -1) ? ncclParamIbSl() : (config && config->trafficClass != NCCL_NET_TRAFFIC_CLASS_UNDEF) ? config->trafficClass : NCCL_IB_SL_DEFAULT;
    meta.tc = (ncclParamIbTc() != -1) ? ncclParamIbTc() : (config && config->trafficClass != NCCL_NET_TRAFFIC_CLASS_UNDEF) ? config->trafficClass : NCCL_IB_TC_DEFAULT;
    strncpy(meta.devName, mergedDev->devName, MAX_MERGED_DEV_NAME);
-@@ -1834,25 +1970,35 @@ ncclResult_t ncclIbCheckVProps(ncclNetVD
+@@ -1834,25 +1983,35 @@ ncclResult_t ncclIbCheckVProps(ncclNetVD
    return ncclSuccess;
  }
  
@@ -333,7 +353,7 @@ diff --git a/src/transport/net_ib.cc b/src/transport/net_ib.cc
    if (stage->state == ncclIbCommStateAccept)   goto ib_accept_check;
    if (stage->state == ncclIbCommStateRecvDevList) goto ib_recv_dev_list;
    if (stage->state == ncclIbCommStateSendDevList) goto ib_send_dev_list;
-@@ -1894,7 +2040,6 @@ ib_accept:
+@@ -1894,7 +2053,6 @@ ib_recv_dev_list:
    }
 
    // Reduce the physical device list and store in the connection base
@@ -341,7 +361,7 @@ diff --git a/src/transport/net_ib.cc b/src/transport/net_ib.cc
    mergedDev = ncclIbMergedDevs + lComm->dev;
    NCCLCHECK(ncclIbCheckVProps(&mergedDev->vProps, &remoteVProps));
    rComm->base.vProps = mergedDev->vProps;
-@@ -1918,13 +2063,6 @@ ib_recv_dev_list:
+@@ -1918,13 +2076,6 @@ ib_recv:
    memcpy(&remMeta, stage->buffer, sizeof(struct ncclIbConnectionMetadata));
 
    // IB setup
@@ -354,8 +374,8 @@ diff --git a/src/transport/net_ib.cc b/src/transport/net_ib.cc
 -
    mergedDev = ncclIbMergedDevs + lComm->dev;
    rComm->base.nRemDevs = remMeta.ndevs;
-   rComm->base.nqps = ncclIbCalculateNqps(remMeta.isP2p, rComm->base.vProps.ndevs,
-@@ -1981,7 +2119,7 @@ ib_recv:
+   rComm->base.nqps = ncclIbCalculateNqps(remMeta.isP2p, rComm->base.vProps.ndevs, 
+@@ -1981,7 +2132,7 @@ ib_recv:
      // Local ibDevN
      ibDevN = rComm->devs[devIndex].base.ibDevN;
      ibDev = ncclIbDevs + ibDevN;
@@ -364,7 +384,9 @@ diff --git a/src/transport/net_ib.cc b/src/transport/net_ib.cc
      qp->devIndex = devIndex;
      devIndex = (devIndex + 1) % rComm->base.vProps.ndevs;
  
-@@ -2036,14 +2176,20 @@ ib_recv:
+@@ -2035,16 +2186,22 @@ ib_recv:
+   }
+ 
    rComm->flushEnabled = ((peermemAvailable || useDmaBuf)
 -                            && (ncclParamIbGdrFlushDisable() == 0)) ? 1 : 0;              
 +                            && (ncclIbGdrFlushDisable == 0)) ? 1 : 0;
@@ -388,7 +410,7 @@ diff --git a/src/transport/net_ib.cc b/src/transport/net_ib.cc
 
      // Allocate Flush dummy buffer for GPU Direct RDMA
      if (rComm->flushEnabled) {
-@@ -2048,7 +2194,7 @@ ib_recv:
+@@ -2082,7 +2239,7 @@ ib_recv:
        rCommDev->gpuFlush.sge.addr = (uint64_t)&rComm->gpuFlushHostMem;
        rCommDev->gpuFlush.sge.length = 1;
        rCommDev->gpuFlush.sge.lkey = rCommDev->gpuFlush.hostMr->lkey;
@@ -397,7 +419,7 @@ diff --git a/src/transport/net_ib.cc b/src/transport/net_ib.cc
        struct ncclIbDevInfo devInfo;
        devInfo.lid         = ibDev->portAttr.lid;
        devInfo.link_layer  = ibDev->portAttr.link_layer;
-@@ -2270,11 +2416,16 @@ ncclResult_t ncclIbDeregMr(void* comm, v
+@@ -2304,11 +2461,16 @@ ncclResult_t ncclIbDeregMr(void* comm, v
  
  NCCL_PARAM(IbSplitDataOnQps, "IB_SPLIT_DATA_ON_QPS", 0);
  
@@ -416,7 +438,7 @@ diff --git a/src/transport/net_ib.cc b/src/transport/net_ib.cc
    if (nreqs > NCCL_NET_IB_MAX_RECVS) return ncclInternalError;
  
    uint64_t wr_id = 0ULL;
-@@ -2286,7 +2437,11 @@ ncclResult_t ncclIbMultiSend(struct nccl
+@@ -2320,7 +2482,11 @@ ncclResult_t ncclIbMultiSend(struct nccl
      sge->addr=(uintptr_t)reqs[r]->send.data;
      wr->opcode = IBV_WR_RDMA_WRITE;
      wr->send_flags = 0;
@@ -429,7 +451,7 @@ diff --git a/src/transport/net_ib.cc b/src/transport/net_ib.cc
      wr->next = wr + 1;
      wr_id += (reqs[r] - comm->base.reqs) << (r*8);
  #ifdef NCCL_ENABLE_NET_PROFILING
-@@ -2297,7 +2452,7 @@ ncclResult_t ncclIbMultiSend(struct nccl
+@@ -2331,7 +2497,7 @@ ncclResult_t ncclIbMultiSend(struct nccl
    // Write size as immediate data. In the case of multi-send, only write
    // 0 or 1 as size to indicate whether there was data sent or received.
    uint32_t immData = 0;
@@ -438,7 +460,7 @@ diff --git a/src/transport/net_ib.cc b/src/transport/net_ib.cc
      immData = reqs[0]->send.size;
    } else {
      int* sizes = comm->remSizesFifo.elems[slot];
-@@ -2307,22 +2462,24 @@ ncclResult_t ncclIbMultiSend(struct nccl
+@@ -2341,22 +2507,24 @@ ncclResult_t ncclIbMultiSend(struct nccl
    }
  
    struct ibv_send_wr* lastWr = comm->wrs+nreqs-1;
@@ -476,7 +498,7 @@ diff --git a/src/transport/net_ib.cc b/src/transport/net_ib.cc
    lastWr->next = NULL;
    lastWr->send_flags = IBV_SEND_SIGNALED;
  
-@@ -2338,7 +2495,11 @@ ncclResult_t ncclIbMultiSend(struct nccl
+@@ -2372,7 +2540,11 @@ ncclResult_t ncclIbMultiSend(struct nccl
        //ncclIbAddEvent(reqs[r], devIndex, &comm->devs[devIndex].base);
  
        // Select proper rkey (needed even for 0-size send)
@@ -489,7 +511,7 @@ diff --git a/src/transport/net_ib.cc b/src/transport/net_ib.cc
  
        int chunkSize = DIVUP(DIVUP(reqs[r]->send.size, nqps), align) * align;
        int length = std::min(reqs[r]->send.size-reqs[r]->send.offset, chunkSize);
-@@ -2354,7 +2515,7 @@ ncclResult_t ncclIbMultiSend(struct nccl
+@@ -2388,7 +2560,7 @@ ncclResult_t ncclIbMultiSend(struct nccl
        }
      }
  
@@ -498,7 +520,7 @@ diff --git a/src/transport/net_ib.cc b/src/transport/net_ib.cc
        // Also make sure lastWr writes remote sizes using the right lkey
        comm->remSizesFifo.sge.lkey = comm->remSizesFifo.mrs[devIndex]->lkey;
        lastWr->wr.rdma.rkey = comm->remSizesFifo.rkeys[devIndex];
-@@ -2414,6 +2575,11 @@ ncclResult_t ncclIbIsend(void* sendComm,
+@@ -2448,6 +2620,11 @@ ncclResult_t ncclIbIsend(void* sendComm,
    ncclResult_t ret = ncclSuccess;
    struct ncclIbRequest* req = NULL;
    struct ncclIbMrHandle* mhandleWrapper = (struct ncclIbMrHandle*) mhandle;
@@ -510,7 +532,7 @@ diff --git a/src/transport/net_ib.cc b/src/transport/net_ib.cc
    int nreqs = 0;
    volatile struct ncclIbSendFifo* slots = NULL;
    int slot = (comm->fifoHead) % MAX_REQUESTS;
-@@ -2427,26 +2593,36 @@ ncclResult_t ncclIbIsend(void* sendComm,
+@@ -2461,26 +2638,36 @@ ncclResult_t ncclIbIsend(void* sendComm,
    }
    NCCLCHECKGOTO(ncclIbStatsCheckFatalCount(&comm->base.stats,__func__), ret, fail);
  
@@ -564,7 +586,7 @@ diff --git a/src/transport/net_ib.cc b/src/transport/net_ib.cc
      }
  
      NCCLCHECKGOTO(ncclIbGetRequest(&comm->base, &req), ret, fail);
-@@ -2489,10 +2665,12 @@ ncclResult_t ncclIbIsend(void* sendComm,
+@@ -2523,10 +2710,12 @@ ncclResult_t ncclIbIsend(void* sendComm,
      }
  
      TIME_START(0);
@@ -579,7 +601,7 @@ diff --git a/src/transport/net_ib.cc b/src/transport/net_ib.cc
      memset(reqs, 0, NCCL_NET_IB_MAX_RECVS*sizeof(struct ncclIbRequest*));
      comm->fifoHead++;
      TIME_STOP(0);
-@@ -2527,30 +2705,60 @@ fail:
+@@ -2561,30 +2750,60 @@ fail:
  
  ncclResult_t ncclIbPostFifo(struct ncclIbRecvComm* comm, int n, void** data, size_t* sizes, int* tags, void** mhandles, struct ncclIbRequest* req) {
    struct ibv_send_wr wr;
@@ -654,7 +676,7 @@ diff --git a/src/transport/net_ib.cc b/src/transport/net_ib.cc
    }
    wr.wr.rdma.remote_addr = comm->remFifo.addr + slot*NCCL_NET_IB_MAX_RECVS*sizeof(struct ncclIbSendFifo);
  
-@@ -2558,8 +2766,12 @@ ncclResult_t ncclIbPostFifo(struct ncclI
+@@ -2592,8 +2811,12 @@ ncclResult_t ncclIbPostFifo(struct ncclI
    wr.wr.rdma.rkey = comm->base.remDevs[ctsQp->remDevIdx].fifoRkey;
  
    // Set the correct sge properties
@@ -669,7 +691,7 @@ diff --git a/src/transport/net_ib.cc b/src/transport/net_ib.cc
    wr.sg_list = &comm->devs[ctsQp->devIndex].fifoSge;
    wr.num_sge = 1;
  
-@@ -2589,7 +2801,13 @@ ncclResult_t ncclIbPostFifo(struct ncclI
+@@ -2623,7 +2846,13 @@ ncclResult_t ncclIbPostFifo(struct ncclI
    //
    // slot == devIndex - When writing to fifo slot N, and this QP lives on device index N, it should send signalled.
    // This works out that each fifo posting QP gets drained
@@ -684,7 +706,7 @@ diff --git a/src/transport/net_ib.cc b/src/transport/net_ib.cc
      wr.send_flags |= IBV_SEND_SIGNALED;
      wr.wr_id = req - comm->base.reqs;
      ncclIbAddEvent(req, ctsQp->devIndex, &comm->devs[ctsQp->devIndex].base);
-@@ -2610,10 +2828,16 @@ ncclResult_t ncclIbPostFifo(struct ncclI
+@@ -2644,10 +2873,16 @@ ncclResult_t ncclIbPostFifo(struct ncclI
  
    comm->remFifo.fifoTail++;
  
@@ -701,7 +723,7 @@ diff --git a/src/transport/net_ib.cc b/src/transport/net_ib.cc
    struct ncclIbRecvComm* comm = (struct ncclIbRecvComm*)recvComm;
    ncclResult_t ret = ncclSuccess;
    struct ncclIbRequest* req = NULL;
-@@ -2629,6 +2853,11 @@ ncclResult_t ncclIbIrecv(void* recvComm,
+@@ -2663,6 +2898,11 @@ ncclResult_t ncclIbIrecv(void* recvComm,
    if (n > NCCL_NET_IB_MAX_RECVS) return ncclInternalError;
    NCCLCHECKGOTO(ncclIbStatsCheckFatalCount(&comm->base.stats,__func__), ret, fail);
  
@@ -713,7 +735,7 @@ diff --git a/src/transport/net_ib.cc b/src/transport/net_ib.cc
    NCCLCHECKGOTO(ncclIbGetRequest(&comm->base, &req), ret, fail);
    req->type = NCCL_NET_IB_REQ_RECV;
    req->sock = &comm->base.sock;
-@@ -2641,40 +2870,50 @@ ncclResult_t ncclIbIrecv(void* recvComm,
+@@ -2675,40 +2915,50 @@ ncclResult_t ncclIbIrecv(void* recvComm,
      req->devBases[i] = &comm->devs[i].base;
    }
  
@@ -794,7 +816,7 @@ diff --git a/src/transport/net_ib.cc b/src/transport/net_ib.cc
  
    // Post to FIFO to notify sender
    TIME_START(2);
-@@ -2798,6 +3037,8 @@ static int getReqQpIndex(struct ncclIbRe
+@@ -2832,6 +3082,8 @@ static int getReqQpIndex(struct ncclIbRe
  }
  #endif
  
@@ -803,7 +825,7 @@ diff --git a/src/transport/net_ib.cc b/src/transport/net_ib.cc
  ncclResult_t ncclIbTest(void* request, int* done, int* sizes) {
    struct ncclIbRequest *r = (struct ncclIbRequest*)request;
    ncclResult_t ret = ncclSuccess;
-@@ -2841,13 +3082,17 @@ ncclResult_t ncclIbTest(void* request, i
+@@ -2875,13 +3127,17 @@ ncclResult_t ncclIbTest(void* request, i
  
      int totalWrDone = 0;
      int wrDone = 0;
@@ -823,7 +845,7 @@ diff --git a/src/transport/net_ib.cc b/src/transport/net_ib.cc
          if (ret != ncclSuccess) {
            failDevIdx = i;
            goto fail;
-@@ -3024,7 +3269,7 @@ ncclResult_t rcclNetP2pPolicy(void* hand
+@@ -3058,7 +3314,7 @@ ncclResult_t rcclNetP2pPolicy(void* hand
  }
  
  ncclNet_t ncclNetIb = {


### PR DESCRIPTION
## Motivation

1. CTS Offload and CTS Inline works only together
2. CTS Offload does not work with NIC Fusion (ndevs > 1) yet

## Technical Details

1. Disable CTS Offload and CTS Inline if one of them is already disabled. 
2. Move NIC Fusion check to rocmIbMakeVDeviceInternal. Check if we have more than one NIC per vNIC and disable CTS Offload in this case.

## JIRA ID

AICOMNET-99

## Test Plan

alltoall_perf test on the nodes with AINIC with different RCCL_CTS_OFFLOAD_ENABLED, RCCL_CTS_INLINE_DATA and NCCL_IB_MERGE_NICS values

## Test Result

The tests work as expected

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
