### PR TITLE
Disable hipHostRegister_Negative test for ASAN

### DIFF
--- a/projects/hip-tests/catch/hipTestMain/config/config_amd_linux
+++ b/projects/hip-tests/catch/hipTestMain/config/config_amd_linux
@@ -188,6 +188,7 @@
         "Unit_hipMallocAsync_MThread_ThreadLocalStream",
         "Unit_hipMallocAsync_StreamEvent_CrissCross",
         "Unit_hipMemGetHandleForAddressRange_MulProc_Socket_DeviceMem",
+        "Unit_hipHostRegister_Negative"
     #endif
     #if defined gfx90a || defined gfx942 || defined gfx950 || defined amdgcnspirv
         "Unit_Warp_Shfl_Up_Positive_Basic - int",


### PR DESCRIPTION
## Motivation

This test is failing when run with ASAN enabled.

## Technical Details

ASAN instruments the memory allocation and this seems to prevent the driver from detecting that the memory being registered is invalid. This causes the call to hipHostRegister to return hipSuccess instead of hipErrorInvalidValue.

## JIRA ID

N/A

## Test Plan

Test locally

## Test Result

N/A

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
