### PR TITLE
[hip-tests] ASAN Check for image support before we create context

### DIFF
--- a/projects/hip-tests/catch/unit/graph/hipDrvGraphAddMemsetNode.cc
+++ b/projects/hip-tests/catch/unit/graph/hipDrvGraphAddMemsetNode.cc
@@ -58,13 +58,13 @@ static char memSetVal = 'a';
  */
 TEMPLATE_TEST_CASE("Unit_hipDrvGraphAddMemsetNode_Positive_Basic", "", uint8_t, uint16_t,
                    uint32_t) {
+  CHECK_IMAGE_SUPPORT
+
   HIP_CHECK(hipInit(0));
   hipDevice_t device;
   hipCtx_t context;
   HIP_CHECK(hipDeviceGet(&device, 0));
   HIP_CHECK(hipCtxCreate(&context, 0, device));
-
-  CHECK_IMAGE_SUPPORT
 
   const auto f = [&context](hipMemsetParams* params) {
     hipGraph_t graph = nullptr;
@@ -163,13 +163,13 @@ TEST_CASE("Unit_hipDrvGraphAddMemsetNode_Negative_Parameters") {
  *    - HIP_VERSION >= 6.0
  */
 TEST_CASE("Unit_hipDrvGraphAddMemsetNode_hipMallocPitch_2D") {
+  CHECK_IMAGE_SUPPORT
+
   HIP_CHECK(hipInit(0));
   hipDevice_t device;
   hipCtx_t context;
   HIP_CHECK(hipDeviceGet(&device, 0));
   HIP_CHECK(hipCtxCreate(&context, 0, device));
-
-  CHECK_IMAGE_SUPPORT
 
   size_t width = SIZE * sizeof(char), numW{SIZE}, numH{SIZE}, pitch_A;
   char* A_d;
@@ -250,13 +250,13 @@ TEST_CASE("Unit_hipDrvGraphAddMemsetNode_hipMallocPitch_2D") {
  *    - HIP_VERSION >= 6.0
  */
 TEST_CASE("Unit_hipDrvGraphAddMemsetNode_hipMallocPitch_1D") {
+  CHECK_IMAGE_SUPPORT
+
   HIP_CHECK(hipInit(0));
   hipDevice_t device;
   hipCtx_t context;
   HIP_CHECK(hipDeviceGet(&device, 0));
   HIP_CHECK(hipCtxCreate(&context, 0, device));
-
-  CHECK_IMAGE_SUPPORT
 
   size_t width = SIZE * sizeof(char), numW{SIZE}, pitch_A;
   char* A_d;
@@ -331,13 +331,13 @@ TEST_CASE("Unit_hipDrvGraphAddMemsetNode_hipMallocPitch_1D") {
  *    - HIP_VERSION >= 6.0
  */
 TEST_CASE("Unit_hipDrvGraphAddMemsetNode_hipMalloc3D_2D") {
+  CHECK_IMAGE_SUPPORT
+
   HIP_CHECK(hipInit(0));
   hipDevice_t device;
   hipCtx_t context;
   HIP_CHECK(hipDeviceGet(&device, 0));
   HIP_CHECK(hipCtxCreate(&context, 0, device));
-
-  CHECK_IMAGE_SUPPORT
 
   size_t width = SIZE * sizeof(char);
   size_t numW = SIZE, numH = SIZE;
@@ -425,13 +425,13 @@ TEST_CASE("Unit_hipDrvGraphAddMemsetNode_hipMalloc3D_2D") {
  *    - HIP_VERSION >= 6.0
  */
 TEST_CASE("Unit_hipDrvGraphAddMemsetNode_hipMalloc3D_1D") {
+  CHECK_IMAGE_SUPPORT
+
   HIP_CHECK(hipInit(0));
   hipDevice_t device;
   hipCtx_t context;
   HIP_CHECK(hipDeviceGet(&device, 0));
   HIP_CHECK(hipCtxCreate(&context, 0, device));
-
-  CHECK_IMAGE_SUPPORT
 
   size_t width = SIZE * sizeof(char);
   size_t numW = SIZE;


### PR DESCRIPTION
## Motivation

Stop the memory leak of context

## Technical Details

The tests were checking for image support after context creation, which shows up as memory leaks.

## JIRA ID

NA

## Test Plan

Verified locally

## Test Result

Tests seem to pass

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
