### PR TITLE
[rocprofiler-sdk-attach] Fix Race Condition in queue_registration_init#3842

### DIFF
--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-attach/queue_registration.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-attach/queue_registration.cpp
@@ -234,11 +234,7 @@ queue_registration_init(HsaApiTable* table)
     ROCP_TRACE << "Initializing Queue Registration";
     auto* registration = CHECK_NOTNULL(get_queue_registration());
 
-    CoreApiTable& core_table = *table->core_;
-
-    core_table.hsa_queue_create_fn  = create_queue;
-    core_table.hsa_queue_destroy_fn = destroy_queue;
-
+    // Save original functions first
     registration->hsa_amd_queue_intercept_create_fn =
         *table->amd_ext_->hsa_amd_queue_intercept_create_fn;
     registration->hsa_amd_profiling_set_profiler_enabled_fn =
@@ -246,6 +242,11 @@ queue_registration_init(HsaApiTable* table)
     registration->hsa_amd_queue_intercept_register_fn =
         *table->amd_ext_->hsa_amd_queue_intercept_register_fn;
     registration->hsa_status_string_fn = *table->core_->hsa_status_string_fn;
+
+    // Replace function pointers
+    CoreApiTable& core_table        = *table->core_;
+    core_table.hsa_queue_create_fn  = create_queue;
+    core_table.hsa_queue_destroy_fn = destroy_queue;
 }
 
 }  // namespace attach


### PR DESCRIPTION
## Motivation

Race condition was discovered when running a vLLM benchmark **BEFORE ATTACHMENT** when **ROCP_TOOL_ATTACH=1** is set. After vLLM server is setup with that environment variable set and client begins benchmark, the server can crash due to a worker process segfaulting.

## Technical Details

Initially assumed that error was occurring in rocprofiler-register. Enabled logging of rocprofiler-register and problem disappeared, leading to belief that this issue is a race condition. Further investigation of dmesg revealed that worker process was segfaulting due to libhsa pointer. After investigating rocprofiler-register, I began looking into `rocprofiler_attach_set_api_table` in `rocprofiler-sdk-attach` since error only occurs when `ROCP_TOOL_ATTACH=1` is set. After looking in `queue_registration_init`, I believe error occurred due to queue `create_queue` functions being set before hsa functions used in said functions. My current theory is that a fork is occurring after `create_queue` is set but before the has pointers are set, a worker process calls `hsa_queue_create`, and then segfaults due to the null HSA pointers. 

Changed order in queue_registration_init to save registration functions before updating the core_table table functions

## JIRA ID

N/A

## Test Plan

Ran test around 20 times after change and haven't had bug reoccur. Unfortunately, it is a race condition, so it's possible that this bug still exists.

## Test Result

Race condition should not resurface during stress test.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
