### PR TITLE
libhsakmt: ASAN fix: fix DRM fd and amdgpu handle leak

### DIFF
--- a/projects/rocr-runtime/libhsakmt/src/fmm.c
+++ b/projects/rocr-runtime/libhsakmt/src/fmm.c
@@ -3191,6 +3191,7 @@ static void fmm_cleanup_render_nodes(struct hsa_kfd_fmm_context *fmm_ctx)
 
 	for (i = 0; i <= DRM_LAST_RENDER_NODE - DRM_FIRST_RENDER_NODE; i++) {
 		if (fmm_ctx->amdgpu_handle[i]) {
+			pr_info("amdgpu_device_deinitialize: %x\n", fmm_ctx->amdgpu_handle[i]);
 			amdgpu_device_deinitialize(fmm_ctx->amdgpu_handle[i]);
 			fmm_ctx->amdgpu_handle[i] = NULL;
 		} else if (fmm_ctx->drm_render_fds[i]) {
@@ -3200,13 +3201,17 @@ static void fmm_cleanup_render_nodes(struct hsa_kfd_fmm_context *fmm_ctx)
 	}
 }
 
+void hsakmt_fmm_cleanup_drm_devices(HsaKFDContext *ctx)
+{
+	struct hsa_kfd_fmm_context *fmm_ctx = hsakmt_kfdcontext_get_fmm_context(ctx);
+	fmm_cleanup_render_nodes(fmm_ctx);
+}
+
 void hsakmt_fmm_destroy_process_apertures(HsaKFDContext *ctx)
 {
 	struct hsa_kfd_fmm_context *fmm_ctx = hsakmt_kfdcontext_get_fmm_context(ctx);
 
 	release_mmio(ctx);
-
-	fmm_cleanup_render_nodes(fmm_ctx);
 
 	if (fmm_ctx->all_gpu_id_array) {
 		free(fmm_ctx->all_gpu_id_array);

--- a/projects/rocr-runtime/libhsakmt/src/fmm.c
+++ b/projects/rocr-runtime/libhsakmt/src/fmm.c
@@ -3185,11 +3185,28 @@ gpu_mem_init_failed:
 	return ret;
 }
 
+static void fmm_cleanup_render_nodes(struct hsa_kfd_fmm_context *fmm_ctx)
+{
+	int i;
+
+	for (i = 0; i <= DRM_LAST_RENDER_NODE - DRM_FIRST_RENDER_NODE; i++) {
+		if (fmm_ctx->amdgpu_handle[i]) {
+			amdgpu_device_deinitialize(fmm_ctx->amdgpu_handle[i]);
+			fmm_ctx->amdgpu_handle[i] = NULL;
+		} else if (fmm_ctx->drm_render_fds[i]) {
+			close(fmm_ctx->drm_render_fds[i]);
+		}
+		fmm_ctx->drm_render_fds[i] = 0;
+	}
+}
+
 void hsakmt_fmm_destroy_process_apertures(HsaKFDContext *ctx)
 {
 	struct hsa_kfd_fmm_context *fmm_ctx = hsakmt_kfdcontext_get_fmm_context(ctx);
 
 	release_mmio(ctx);
+
+	fmm_cleanup_render_nodes(fmm_ctx);
 
 	if (fmm_ctx->all_gpu_id_array) {
 		free(fmm_ctx->all_gpu_id_array);
@@ -4703,16 +4720,7 @@ void hsakmt_fmm_clear_all_mem(HsaKFDContext *ctx)
 	
 	struct hsa_kfd_fmm_context *fmm_ctx = hsakmt_kfdcontext_get_fmm_context(ctx);
 	/* Close render node FDs. The child process needs to open new ones */
-	for (i = 0; i <= DRM_LAST_RENDER_NODE - DRM_FIRST_RENDER_NODE; i++) {
-
-		if (fmm_ctx->amdgpu_handle[i]) {
-			amdgpu_device_deinitialize(fmm_ctx->amdgpu_handle[i]);
-			fmm_ctx->amdgpu_handle[i] = NULL;
-		} else if (fmm_ctx->drm_render_fds[i]) {
-			close(fmm_ctx->drm_render_fds[i]);
-		}
-		fmm_ctx->drm_render_fds[i] = 0;
-	}
+	fmm_cleanup_render_nodes(fmm_ctx);
 
 	hsakmt_fmm_clear_all_aperture(ctx);
 }

--- a/projects/rocr-runtime/libhsakmt/src/fmm.h
+++ b/projects/rocr-runtime/libhsakmt/src/fmm.h
@@ -49,6 +49,7 @@ HSAKMT_STATUS hsakmt_fmm_get_amdgpu_device_handle(HsaKFDContext *ctx,
 						uint32_t node_id,  HsaAMDGPUDeviceHandle *DeviceHandle);
 HSAKMT_STATUS hsakmt_fmm_init_process_apertures(HsaKFDContext *ctx, unsigned int NumNodes);
 void hsakmt_fmm_destroy_process_apertures(HsaKFDContext *ctx);
+void hsakmt_fmm_cleanup_drm_devices(HsaKFDContext *ctx);
 
 /* Memory interface */
 // Memory allocation/free functions

--- a/projects/rocr-runtime/libhsakmt/src/openclose.c
+++ b/projects/rocr-runtime/libhsakmt/src/openclose.c
@@ -286,6 +286,7 @@ HSAKMT_STATUS HSAKMTAPI hsaKmtCloseKFDCtx(void)
 			hsakmt_destroy_counter_props(&hsakmt_primary_kfd_ctx);
 			hsakmt_destroy_device_debugging_memory(&hsakmt_primary_kfd_ctx);
 			hsakmt_fmm_clear_all_aperture(&hsakmt_primary_kfd_ctx);
+			hsakmt_fmm_cleanup_drm_devices(&hsakmt_primary_kfd_ctx);
 		}
 
 		result = HSAKMT_STATUS_SUCCESS;


### PR DESCRIPTION
DRM render node file descriptors and amdgpu device handles were not
being properly cleaned up when closing the KFD context via
hsaKmtCloseKFDCtx(). This could cause resource leaks and device
detection failures in subsequent GPU operations, resulting in
"no ROCm-capable device is detected" errors or SIGABRT in HIP RTC
tests.

Add hsakmt_fmm_cleanup_drm_devices() to explicitly deinitialize
amdgpu device handles and close render node file descriptors during
KFD context teardown. Consolidate the duplicate cleanup logic from
hsakmt_fmm_clear_all_mem() and hsakmt_fmm_destroy_process_apertures()
into the reusable fmm_cleanup_render_nodes() helper function.

From: Thong Thai <thong.thai@amd.com>
It's because with libdrm, it uses reference counting, and Mesa and libhsakmt
both use libdrm (libhsakmt calls libdrm first). So when the reference count for
libdrm doesn't go to 0 (because libhsakmt didn't call the deinitialize function),
the buffer object table doesn't get freed


## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
