### PR TITLE
rocrtst: ASAN fixes for memory_basic and memory_access tests

### DIFF
--- a/projects/rocr-runtime/rocrtst/common/common.h
+++ b/projects/rocr-runtime/rocrtst/common/common.h
@@ -232,5 +232,13 @@ hsa_status_t DumpPointerInfo(void* ptr);
 hsa_status_t GetAgentPools(
                     std::vector<std::shared_ptr<agent_pools_t>> *agent_pools);
 
+#ifdef ROCRTST_ASAN
+/// Maximum single allocation size used by tests running under ASAN.
+/// ASAN's shadow-memory VMA overhead prevents large contiguous
+/// allocations. Using 512 MB because, it is safely below the typical
+/// ASAN shadow limit.
+static constexpr size_t kMaxTestAllocAsan = 512ULL * 1024 * 1024;  // 512 MB
+#endif
+
 }  // namespace rocrtst
 #endif  // ROCRTST_COMMON_COMMON_H_

--- a/projects/rocr-runtime/rocrtst/suites/functional/memory_access.cc
+++ b/projects/rocr-runtime/rocrtst/suites/functional/memory_access.cc
@@ -58,10 +58,6 @@
 #include "gtest/gtest.h"
 #include "hsa/hsa.h"
 
-#ifdef ROCRTST_ASAN
-static const size_t kMaxTestAllocAsan = 512ULL * 1024 * 1024;
-#endif
-
 #define RET_IF_HSA_ERR(err) { \
   if ((err) != HSA_STATUS_SUCCESS) { \
     const char* msg = 0; \
@@ -398,10 +394,8 @@ void MemoryAccessTest::CPUAccessToGPUMemoryTest(hsa_agent_t cpuAgent,
       auto pool_sz = pool_i.size / gran_sz;
       auto max_alloc_size = pool_sz/2;
 #ifdef ROCRTST_ASAN
-      if (max_alloc_size > kMaxTestAllocAsan) {
-	/* Under ASAN the allocator's shadow memory overhead can cause OOM on large-VRAM GPUs where pool_sz/2 exceeds host capacity. */
-	max_alloc_size = (kMaxTestAllocAsan / gran_sz) * gran_sz;
-      }
+      // Under ASAN use kMaxTestAllocAsan to avoid shadow-memory OOM on large-VRAM GPUs
+      max_alloc_size = std::min(max_alloc_size, rocrtst::kMaxTestAllocAsan / gran_sz);
 #endif
       unsigned int max_element = max_alloc_size/sizeof(unsigned int);
       unsigned int *gpu_data;

--- a/projects/rocr-runtime/rocrtst/suites/functional/memory_basic.cc
+++ b/projects/rocr-runtime/rocrtst/suites/functional/memory_basic.cc
@@ -44,7 +44,6 @@
  */
 
 #include <algorithm>
-#include <chrono>
 #include <iostream>
 #include <vector>
 #include <memory>
@@ -231,11 +230,34 @@ void MemoryTest::MaxSingleAllocationTest(hsa_agent_t ag,
   auto pool_sz = pool_i.aggregate_alloc_max / gran_sz;
 
   // Neg. test: Try to allocate more than the pool size
+#ifdef ROCRTST_ASAN
+  // Under ASAN, hsa_amd_memory_pool_allocate is intercepted by the ASAN runtime.
+  // Requesting (max_size + granule) from ASANs heap allocator (~125 GiB on MI300A)
+  // triggers allocation-size-too-big and calls abort(), killing the process.
+  if (verbosity() > 0) {
+    std::cout << "  Skipping over-max negative alloc under ASAN (abort risk)" << std::endl;
+  }
+#else
   err = TestAllocate(pool, pool_sz*gran_sz + gran_sz);
   EXPECT_EQ(HSA_STATUS_ERROR_INVALID_ALLOCATION, err);
+#endif
 
   const bool is_system_ram = (ag_type == HSA_DEVICE_TYPE_CPU) || (ag_type == HSA_DEVICE_TYPE_AIE);
   pool_sz = is_system_ram ? std::min(pool_sz, info.totalram / gran_sz) : pool_sz;
+
+#ifdef ROCRTST_ASAN
+  // ASAN's shadow-memory VMA consumption exhausts the contiguous virtual address
+  // ranges that hsa_amd_memory_pool_allocate needs for both system-RAM (APU unified
+  // memory) and GPU HBM pools.  The binary search always converges to zero, producing
+  // a spurious ASSERT failure.  Skip the positive binary-search for ALL pools under
+  // ASAN; allocation correctness is covered by MemoryAllocateAndFreeTest and others.
+  if (verbosity() > 0) {
+    std::cout << "  Skipping max-alloc binary search under ASAN "
+              << "(shadow VMA exhaustion prevents large pool allocations)" << std::endl;
+    std::cout << kSubTestSeparator << std::endl;
+  }
+  return;
+#endif
 
   // Reduce upper_bound by 30% or 10% for system-RAM, depending on pool size limit. Otherwise
   // Linux OOM-Killer app can be triggered if system has allocated all available physical
@@ -296,41 +318,12 @@ void MemoryTest::MaxSingleAllocationTest(void) {
   ASSERT_EQ(err, HSA_STATUS_SUCCESS);
 
   auto pool_idx = 0;
-  auto total_start = std::chrono::steady_clock::now();
-
   for (auto a : agent_pools) {
-    hsa_device_type_t ag_type;
-    err = hsa_agent_get_info(a->agent, HSA_AGENT_INFO_DEVICE, &ag_type);
-    ASSERT_EQ(err, HSA_STATUS_SUCCESS);
-
-    // For CPU agents, only test node 0. NUMA nodes > 0 share the same allocator
-    // paths as node 0, so testing them adds no coverage but significant runtime
-    // cost (especially under ASAN). All GPU agents are always tested to ensure
-    // full multi-GPU coverage.
-    if (ag_type == HSA_DEVICE_TYPE_CPU) {
-      uint32_t node_id;
-      err = hsa_agent_get_info(a->agent, HSA_AGENT_INFO_NODE, &node_id);
-      ASSERT_EQ(err, HSA_STATUS_SUCCESS);
-      if (node_id > 0) {
-        continue;
-      }
-    }
-
     for (auto p : a->pools) {
       std::cout << "  Pool " << pool_idx++ << ":" << std::endl;
-      auto pool_start = std::chrono::steady_clock::now();
       MaxSingleAllocationTest(a->agent, p);
-      auto pool_elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(
-          std::chrono::steady_clock::now() - pool_start).count();
-      std::cout << "  Pool " << (pool_idx - 1) << " time: "
-                << pool_elapsed / 60000 << "m " << (pool_elapsed % 60000) / 1000 << "s" << std::endl;
     }
   }
-
-  auto total_elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(
-      std::chrono::steady_clock::now() - total_start).count();
-  std::cout << "  Total MaxSingleAllocationTest time: "
-            << total_elapsed / 60000 << "m " << (total_elapsed % 60000) / 1000 << "s" << std::endl;
 }
 
 void MemoryTest::MemAvailableTest(hsa_agent_t ag, hsa_amd_memory_pool_t pool) {
@@ -388,6 +381,13 @@ void MemoryTest::MemAvailableTest(hsa_agent_t ag, hsa_amd_memory_pool_t pool) {
 
   // Try to allocate half
   uint64_t allocate_sz1 = (pool_sz / 2) * gran_sz;
+#ifdef ROCRTST_ASAN
+  // ASAN's intercepted allocator cannot handle huge allocations.  Cap each
+  // allocation to 512 MiB so the memory-accounting logic is still exercised.
+  static const uint64_t kMaxAsanAllocBytes = 512ULL << 20;  // 512 MiB
+  if (allocate_sz1 > kMaxAsanAllocBytes)
+    allocate_sz1 = (kMaxAsanAllocBytes / gran_sz) * gran_sz;
+#endif
 
   err = hsa_amd_memory_pool_allocate(pool, allocate_sz1, 0, &memPtr1);
   ASSERT_EQ(err, HSA_STATUS_SUCCESS);
@@ -410,7 +410,14 @@ void MemoryTest::MemAvailableTest(hsa_agent_t ag, hsa_amd_memory_pool_t pool) {
   hsa_amd_pointer_info_t info2 = {};
   info2.size = sizeof(info2);
   ASSERT_SUCCESS(hsa_amd_pointer_info((reinterpret_cast<uint8_t *>(memPtr1) + allocate_sz1 + 1), &info2, NULL, 0, NULL));
+#ifndef ROCRTST_ASAN
+  // Under ASAN, heap allocations are padded with red zones so the byte one past
+  // the user-visible end of |memPtr1| still falls within the ASAN-extended
+  // backing block; hsa_amd_pointer_info therefore reports it as
+  // HSA_EXT_POINTER_TYPE_HSA rather than HSA_EXT_POINTER_TYPE_UNKNOWN.
+  // Skip this check under ASAN to avoid a spurious failure.
   ASSERT_EQ(info2.type, HSA_EXT_POINTER_TYPE_UNKNOWN);
+#endif
 
   // Simulate case where ROCr has added extra parameters to hsa_amd_pointer_info.
   // i.e ROCr's hsa_amd_pointer_info is bigger than user's hsa_amd_pointer_info
@@ -433,10 +440,18 @@ void MemoryTest::MemAvailableTest(hsa_agent_t ag, hsa_amd_memory_pool_t pool) {
     allocate_sz2 = (0.3 * ag_avail_memory_after * gran_sz) / gran_sz;
   else
     allocate_sz2 = (0.8 * ag_avail_memory_after * gran_sz) / gran_sz;
+#ifdef ROCRTST_ASAN
+  if (allocate_sz2 > kMaxAsanAllocBytes)
+    allocate_sz2 = (kMaxAsanAllocBytes / gran_sz) * gran_sz;
+#endif
 
 
   err = hsa_amd_memory_pool_allocate(pool, allocate_sz2, 0, &memPtr2);
+#ifdef ROCRTST_ASAN
+  if (err != HSA_STATUS_SUCCESS) hsa_amd_memory_pool_free(memPtr1);
+#else
   if (err != HSA_STATUS_SUCCESS) hsa_memory_free(memPtr1);
+#endif
   ASSERT_EQ(err, HSA_STATUS_SUCCESS);
 
   err = hsa_agent_get_info(ag, (hsa_agent_info_t)HSA_AMD_AGENT_INFO_MEMORY_AVAIL,
@@ -453,10 +468,22 @@ void MemoryTest::MemAvailableTest(hsa_agent_t ag, hsa_amd_memory_pool_t pool) {
     std::cout << "   Available memory after: " << ag_avail_memory_after << std::endl;
   }
 
+#ifdef ROCRTST_ASAN
+  // Under ASAN, hsa_amd_memory_pool_allocate returns base+PAGE_SIZE (ASAN header offset).
+  // hsa_memory_free is not intercepted by the ASAN runtime, so it receives the offset pointer
+  // and fails to find it in allocation_map_. Use hsa_amd_memory_pool_free which IS intercepted
+  // and correctly strips the PAGE_SIZE offset before calling into ROCr.
+  err = hsa_amd_memory_pool_free(memPtr1);
+#else
   err = hsa_memory_free(memPtr1);
+#endif
   ASSERT_EQ(err, HSA_STATUS_SUCCESS);
 
+#ifdef ROCRTST_ASAN
+  err = hsa_amd_memory_pool_free(memPtr2);
+#else
   err = hsa_memory_free(memPtr2);
+#endif
   ASSERT_EQ(err, HSA_STATUS_SUCCESS);
 
   err = hsa_agent_get_info(ag, (hsa_agent_info_t)HSA_AMD_AGENT_INFO_MEMORY_AVAIL,

--- a/projects/rocr-runtime/rocrtst/suites/functional/memory_basic.cc
+++ b/projects/rocr-runtime/rocrtst/suites/functional/memory_basic.cc
@@ -232,8 +232,8 @@ void MemoryTest::MaxSingleAllocationTest(hsa_agent_t ag,
   // Neg. test: Try to allocate more than the pool size
 #ifdef ROCRTST_ASAN
   // Under ASAN, hsa_amd_memory_pool_allocate is intercepted by the ASAN runtime.
-  // Requesting (max_size + granule) from ASANs heap allocator (~125 GiB on MI300A)
-  // triggers allocation-size-too-big and calls abort(), killing the process.
+  // Requesting (max_size + granule) from ASANs heap allocator triggers
+  // allocation-size-too-big and calls abort(), killing the process.
   if (verbosity() > 0) {
     std::cout << "  Skipping over-max negative alloc under ASAN (abort risk)" << std::endl;
   }
@@ -245,20 +245,6 @@ void MemoryTest::MaxSingleAllocationTest(hsa_agent_t ag,
   const bool is_system_ram = (ag_type == HSA_DEVICE_TYPE_CPU) || (ag_type == HSA_DEVICE_TYPE_AIE);
   pool_sz = is_system_ram ? std::min(pool_sz, info.totalram / gran_sz) : pool_sz;
 
-#ifdef ROCRTST_ASAN
-  // ASAN's shadow-memory VMA consumption exhausts the contiguous virtual address
-  // ranges that hsa_amd_memory_pool_allocate needs for both system-RAM (APU unified
-  // memory) and GPU HBM pools.  The binary search always converges to zero, producing
-  // a spurious ASSERT failure.  Skip the positive binary-search for ALL pools under
-  // ASAN; allocation correctness is covered by MemoryAllocateAndFreeTest and others.
-  if (verbosity() > 0) {
-    std::cout << "  Skipping max-alloc binary search under ASAN "
-              << "(shadow VMA exhaustion prevents large pool allocations)" << std::endl;
-    std::cout << kSubTestSeparator << std::endl;
-  }
-  return;
-#endif
-
   // Reduce upper_bound by 30% or 10% for system-RAM, depending on pool size limit. Otherwise
   // Linux OOM-Killer app can be triggered if system has allocated all available physical
   // memory and swap space, and so killing this process.
@@ -268,6 +254,11 @@ void MemoryTest::MaxSingleAllocationTest(hsa_agent_t ag,
   }
 
   uint64_t upper_bound = pool_size_limit_ratio * pool_sz;
+#ifdef ROCRTST_ASAN
+  // Under ASAN, on large-VRAM GPUs, cap the search range to kMaxTestAllocAsan to avoid
+  // shadow-memory OOM errors.
+  upper_bound = std::min(upper_bound, rocrtst::kMaxTestAllocAsan / gran_sz);
+#endif
   uint64_t lower_bound = 0;
   auto max_alloc_size = upper_bound;
 
@@ -296,6 +287,9 @@ void MemoryTest::MaxSingleAllocationTest(hsa_agent_t ag,
                                                "% of the total." << std::endl;
   }
 
+#ifndef ROCRTST_ASAN
+  // Under ASAN the search range is capped to kMaxTestAllocAsan so the result
+  // is not comparable to the full pool size.
   if (ag_type == HSA_DEVICE_TYPE_GPU) {
     if (pool_sz <= 536870912) {
       EXPECT_GE((float)max_alloc_size/pool_sz, (float)6/10);
@@ -303,6 +297,7 @@ void MemoryTest::MaxSingleAllocationTest(hsa_agent_t ag,
       EXPECT_GE((float)max_alloc_size/pool_sz, (float)3/4);
     }
   }
+#endif
   if (verbosity() > 0) {
     std::cout << kSubTestSeparator << std::endl;
   }
@@ -383,10 +378,9 @@ void MemoryTest::MemAvailableTest(hsa_agent_t ag, hsa_amd_memory_pool_t pool) {
   uint64_t allocate_sz1 = (pool_sz / 2) * gran_sz;
 #ifdef ROCRTST_ASAN
   // ASAN's intercepted allocator cannot handle huge allocations.  Cap each
-  // allocation to 512 MiB so the memory-accounting logic is still exercised.
-  static const uint64_t kMaxAsanAllocBytes = 512ULL << 20;  // 512 MiB
-  if (allocate_sz1 > kMaxAsanAllocBytes)
-    allocate_sz1 = (kMaxAsanAllocBytes / gran_sz) * gran_sz;
+  // allocation to kMaxTestAllocAsan.
+  if (allocate_sz1 > rocrtst::kMaxTestAllocAsan)
+    allocate_sz1 = (rocrtst::kMaxTestAllocAsan / gran_sz) * gran_sz;
 #endif
 
   err = hsa_amd_memory_pool_allocate(pool, allocate_sz1, 0, &memPtr1);
@@ -413,9 +407,9 @@ void MemoryTest::MemAvailableTest(hsa_agent_t ag, hsa_amd_memory_pool_t pool) {
 #ifndef ROCRTST_ASAN
   // Under ASAN, heap allocations are padded with red zones so the byte one past
   // the user-visible end of |memPtr1| still falls within the ASAN-extended
-  // backing block; hsa_amd_pointer_info therefore reports it as
+  // backing block. hsa_amd_pointer_info therefore reports it as
   // HSA_EXT_POINTER_TYPE_HSA rather than HSA_EXT_POINTER_TYPE_UNKNOWN.
-  // Skip this check under ASAN to avoid a spurious failure.
+  // Skip this check under ASAN to avoid a false-positive failure.
   ASSERT_EQ(info2.type, HSA_EXT_POINTER_TYPE_UNKNOWN);
 #endif
 
@@ -441,13 +435,19 @@ void MemoryTest::MemAvailableTest(hsa_agent_t ag, hsa_amd_memory_pool_t pool) {
   else
     allocate_sz2 = (0.8 * ag_avail_memory_after * gran_sz) / gran_sz;
 #ifdef ROCRTST_ASAN
-  if (allocate_sz2 > kMaxAsanAllocBytes)
-    allocate_sz2 = (kMaxAsanAllocBytes / gran_sz) * gran_sz;
+  // ASAN's intercepted allocator cannot handle huge allocations.  Cap each
+  // allocation to kMaxTestAllocAsan.
+  if (allocate_sz2 > rocrtst::kMaxTestAllocAsan)
+    allocate_sz2 = (rocrtst::kMaxTestAllocAsan / gran_sz) * gran_sz;
 #endif
 
 
   err = hsa_amd_memory_pool_allocate(pool, allocate_sz2, 0, &memPtr2);
 #ifdef ROCRTST_ASAN
+  // Under ASAN, hsa_amd_memory_pool_allocate returns base+PAGE_SIZE (ASAN header offset).
+  // hsa_memory_free is not intercepted by the ASAN runtime, so it receives the offset pointer
+  // and fails to find it in allocation_map_. Use hsa_amd_memory_pool_free which IS intercepted
+  // and correctly strips the PAGE_SIZE offset before calling into ROCr.
   if (err != HSA_STATUS_SUCCESS) hsa_amd_memory_pool_free(memPtr1);
 #else
   if (err != HSA_STATUS_SUCCESS) hsa_memory_free(memPtr1);
@@ -480,6 +480,11 @@ void MemoryTest::MemAvailableTest(hsa_agent_t ag, hsa_amd_memory_pool_t pool) {
   ASSERT_EQ(err, HSA_STATUS_SUCCESS);
 
 #ifdef ROCRTST_ASAN
+  // Under ASAN, hsa_amd_memory_pool_allocate returns base+PAGE_SIZE (ASAN header offset).
+  // hsa_memory_free is not intercepted by the ASAN runtime, so it receives the offset pointer
+  // and fails to find it in allocation_map_. Use hsa_amd_memory_pool_free which IS intercepted
+  // and correctly strips the PAGE_SIZE offset before calling into ROCr.
+
   err = hsa_amd_memory_pool_free(memPtr2);
 #else
   err = hsa_memory_free(memPtr2);


### PR DESCRIPTION
Cap large pool allocations to kMaxTestAllocAsan (512 MB) under ASAN.
Guard the over-max negative-alloc test and the out-of-bounds pointer-info
check.
Use hsa_amd_memory_pool_free in place of hsa_memory_free under ASAN to
handle the PAGE_SIZE header offset.
Move kMaxTestAllocAsan to common header so all tests share it.


## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
