### PR TITLE
Add Python wheel splitter for host/device separation

### DIFF
--- a/shared/kpack/python/rocm_kpack/binutils.py
+++ b/shared/kpack/python/rocm_kpack/binutils.py
@@ -8,7 +8,7 @@ from typing import Any
 
 import msgpack
 
-from rocm_kpack.ccob_parser import extract_code_objects_from_fatbin
+from rocm_kpack.ccob_parser import ExtractedCodeObject, extract_code_objects_from_fatbin
 from rocm_kpack.coff.surgery import CoffSurgery
 from rocm_kpack.format_detect import detect_binary_format, UnsupportedBinaryFormat
 
@@ -226,17 +226,20 @@ class BundledBinary:
         to hold the unbundled files open for as long as needed.
         """
         if dest_dir is None:
-            dest_dir = Path(tempfile.TemporaryDirectory(delete=False).name)
-        target_list = self._list_bundled_targets(self.file_path)
+            dest_dir = Path(tempfile.mkdtemp())
+
+        # Extract code objects once, then derive both the target list and
+        # write the files from the same extraction result.
+        code_objects = self._extract_code_objects()
+        target_list = self._build_target_list(code_objects)
+
         contents = UnbundledContents(
             self, dest_dir, delete_on_close=delete_on_close, target_list=target_list
         )
         try:
             dest_dir.mkdir(parents=True, exist_ok=True)
-            self._unbundle(
-                targets=[kv[0] for kv in target_list],
-                outputs=[dest_dir / kv[1] for kv in target_list],
-            )
+            outputs = [dest_dir / kv[1] for kv in target_list]
+            self._write_code_objects(code_objects, outputs)
         except:
             contents.close()
             raise
@@ -342,20 +345,23 @@ class BundledBinary:
 
         return fatbin_path
 
-    def _list_bundled_targets(self, file_path: Path) -> list[tuple[str, str]]:
-        """Returns a list of (target_name, file_name) for all bundles.
+    def _extract_code_objects(self) -> list[ExtractedCodeObject]:
+        """Extract code objects from the fatbin data.
 
-        Uses our own bundle parser for all formats: CCOB-compressed, single
-        uncompressed, and concatenated uncompressed (RDC case).
+        Reads the bundler input once and parses all code objects.
+        """
+        bundler_input = self._get_bundler_input()
+        data = bundler_input.read_bytes()
+        return extract_code_objects_from_fatbin(data)
+
+    def _build_target_list(
+        self, code_objects: list[ExtractedCodeObject]
+    ) -> list[tuple[str, str]]:
+        """Build a list of (target_name, file_name) from extracted code objects.
 
         For concatenated bundles (RDC), filenames are indexed to distinguish
         multiple code objects with the same target triple.
         """
-        bundler_input = self._get_bundler_input()
-        data = bundler_input.read_bytes()
-        code_objects = extract_code_objects_from_fatbin(data)
-
-        # Check if we need indexed filenames (duplicate targets from RDC)
         targets = [obj.target for obj in code_objects]
         needs_indexing = len(targets) != len(set(targets))
 
@@ -370,28 +376,26 @@ class BundledBinary:
 
         return result
 
-    def _unbundle(self, *, targets: list[str], outputs: list[Path]):
-        """Unbundle targets from the binary.
-
-        Args:
-            targets: List of target names to unbundle
-            outputs: List of output paths (must match length of targets)
-        """
-        if not targets:
-            return
-
-        bundler_input = self._get_bundler_input()
-        data = bundler_input.read_bytes()
-        code_objects = extract_code_objects_from_fatbin(data)
-
+    def _write_code_objects(
+        self, code_objects: list[ExtractedCodeObject], outputs: list[Path]
+    ) -> None:
+        """Write extracted code objects to output files."""
         if len(code_objects) != len(outputs):
             raise ValueError(
                 f"Output count mismatch: {len(code_objects)} code objects "
                 f"but {len(outputs)} output paths"
             )
-
         for obj, output_path in zip(code_objects, outputs):
             output_path.write_bytes(obj.data)
+
+    def _list_bundled_targets(self, file_path: Path) -> list[tuple[str, str]]:
+        """Returns a list of (target_name, file_name) for all bundles.
+
+        Uses our own bundle parser for all formats: CCOB-compressed, single
+        uncompressed, and concatenated uncompressed (RDC case).
+        """
+        code_objects = self._extract_code_objects()
+        return self._build_target_list(code_objects)
 
     def list_bundles(self) -> list[str]:
         """List all architecture bundles in the binary.

--- a/shared/kpack/python/rocm_kpack/ccob_parser.py
+++ b/shared/kpack/python/rocm_kpack/ccob_parser.py
@@ -518,6 +518,19 @@ def extract_code_objects_by_target(
 CCOB_MAGIC = b"CCOB"
 
 
+def _find_next_magic(data: bytes, start: int) -> int:
+    """Find the next CCOB or uncompressed bundle magic starting at `start`.
+
+    Returns the offset, or -1 if neither is found.
+    """
+    next_ccob = data.find(CCOB_MAGIC, start)
+    next_uncompressed = data.find(UNCOMPRESSED_BUNDLE_MAGIC, start)
+    candidates = [c for c in [next_ccob, next_uncompressed] if c != -1]
+    if candidates:
+        return min(candidates)
+    return -1
+
+
 def parse_fatbin_data(data: bytes) -> list[UncompressedBundle]:
     """Parse fatbin data in any supported format.
 
@@ -531,6 +544,11 @@ def parse_fatbin_data(data: bytes) -> list[UncompressedBundle]:
     "__CLANG_OFFLOAD_BUNDLE__") to find bundle boundaries, advancing past
     each bundle to find the next. We replicate that here.
 
+    Note: All reads use index slicing with explicit offsets rather than
+    ``data[offset:]`` to avoid O(n) copies of the remaining buffer on
+    every iteration. For multi-MB fatbins with inter-block padding this
+    is the difference between seconds and hours.
+
     Args:
         data: Raw fatbin data bytes
 
@@ -541,41 +559,40 @@ def parse_fatbin_data(data: bytes) -> list[UncompressedBundle]:
         ValueError: If data format is not recognized
     """
     bundles: list[UncompressedBundle] = []
-    offset = 0
+    data_len = len(data)
+    offset = _find_next_magic(data, 0)
+    if offset == -1:
+        raise ValueError(f"Unrecognized fatbin format: first 4 bytes are {data[:4]!r}")
 
-    while offset < len(data):
-        remaining = data[offset:]
-
-        if remaining[:4] == CCOB_MAGIC:
-            # Compressed bundle. Use the totalSize field from the CCOB
-            # header to determine boundaries — this is more precise than
-            # magic scanning since compressed data can contain false
-            # positives. LLVM's extractOffloadBundle() scans for magic
-            # but doesn't parse the header in the outer loop; we can do
-            # better since decompress_ccob() already reads totalSize.
-            header = CCOBHeader.parse(remaining)
-            decompressed = decompress_ccob(remaining)
+    while 0 <= offset < data_len:
+        if data[offset : offset + 4] == CCOB_MAGIC:
+            # Compressed bundle. Parse header at offset (small slice)
+            # to get totalSize, then decompress just that range.
+            header = CCOBHeader.parse(data[offset : offset + 32])
+            decompressed = decompress_ccob(data[offset : offset + header.total_size])
             bundles.extend(parse_concatenated_bundles(decompressed))
             offset += header.total_size
 
-        elif remaining[:24] == UNCOMPRESSED_BUNDLE_MAGIC:
+        elif data[offset : offset + 24] == UNCOMPRESSED_BUNDLE_MAGIC:
             # Uncompressed bundle. Find next magic of either type.
-            # Matches LLVM: both CCOB and uncompressed can be interleaved.
-            next_uncompressed = remaining.find(UNCOMPRESSED_BUNDLE_MAGIC, 24)
-            next_ccob = remaining.find(CCOB_MAGIC, 24)
-
-            candidates = [c for c in [next_uncompressed, next_ccob] if c != -1]
-            if candidates:
-                chunk = remaining[: min(candidates)]
+            next_magic = _find_next_magic(data, offset + 24)
+            if next_magic != -1:
+                chunk = data[offset:next_magic]
             else:
-                chunk = remaining
+                chunk = data[offset:]
 
             bundles.extend(parse_concatenated_bundles(chunk))
             offset += len(chunk)
 
         else:
-            # Skip padding between page-aligned bundles.
+            # Should not happen since we always seek to next magic,
+            # but guard against it.
             offset += 1
+            continue
+
+        # Skip padding to next magic in one shot.
+        if offset < data_len:
+            offset = _find_next_magic(data, offset)
 
     if not bundles:
         raise ValueError(f"Unrecognized fatbin format: first 4 bytes are {data[:4]!r}")

--- a/shared/kpack/python/rocm_kpack/coff/surgery.py
+++ b/shared/kpack/python/rocm_kpack/coff/surgery.py
@@ -179,6 +179,54 @@ class CoffSurgery:
         data = bytearray(path.read_bytes())
         return cls(data, path)
 
+    @staticmethod
+    def has_fatbin_section(file_path: Path) -> bool:
+        """Fast check for .hip_fat section without loading the full binary.
+
+        Reads only the DOS header, PE signature, COFF header, and section
+        headers — a few KB total even for large binaries.
+        Returns False for non-PE files (wrong magic).
+        Raises on I/O errors or corrupt PE headers.
+        """
+        with open(file_path, "rb") as f:
+            dos = f.read(DOS_HEADER_SIZE)
+            if len(dos) < DOS_HEADER_SIZE:
+                return False
+            if dos[:2] != b"MZ":
+                return False
+
+            pe_offset = struct.unpack_from("<I", dos, 0x3C)[0]
+            f.seek(pe_offset)
+            pe_sig = f.read(4)
+            if pe_sig != PE_SIGNATURE:
+                return False
+
+            # COFF header: NumberOfSections at offset 2
+            coff = f.read(COFF_HEADER_SIZE)
+            if len(coff) < COFF_HEADER_SIZE:
+                return False
+            num_sections = struct.unpack_from("<H", coff, 2)[0]
+            opt_hdr_size = struct.unpack_from("<H", coff, 16)[0]
+
+            # Section headers start after optional header
+            section_offset = pe_offset + 4 + COFF_HEADER_SIZE + opt_hdr_size
+            f.seek(section_offset)
+            section_data = f.read(num_sections * SECTION_HEADER_SIZE)
+            if len(section_data) < num_sections * SECTION_HEADER_SIZE:
+                return False
+
+            # Check each section name for ".hip_fat"
+            target = b".hip_fat"
+            for i in range(num_sections):
+                name = section_data[
+                    i * SECTION_HEADER_SIZE : i * SECTION_HEADER_SIZE + 8
+                ]
+                # Section names are 8 bytes, null-padded
+                if name == target or name.rstrip(b"\x00") == target:
+                    return True
+
+            return False
+
     # =========================================================================
     # Properties
     # =========================================================================

--- a/shared/kpack/python/rocm_kpack/database_handlers.py
+++ b/shared/kpack/python/rocm_kpack/database_handlers.py
@@ -14,9 +14,23 @@ from typing import Optional, List
 
 
 # Compile regex patterns once at module level
-# TODO: Verify this pattern handles xnack (asan) kernels correctly
-# These have special syntax like gfx942:xnack+ or gfx90a:sramecc+:xnack-
-_GFX_ARCH_PATTERN = re.compile(r"gfx(\d+[a-z]*)")
+# Matches architecture IDs like gfx908, gfx90a, gfx942-xnack+, gfx90a-xnack-
+# Note: Tensile filenames use hyphens (gfx90a-xnack+), not colons (gfx90a:xnack+)
+_GFX_ARCH_PATTERN = re.compile(r"gfx\d+[a-z]*(?:-xnack[+-])?")
+
+# MIOpen-specific arch pattern. MIOpen filenames concatenate arch ID + CU count
+# without a separator (e.g., gfx90878 = gfx908 + 78 CUs, gfx942130 = gfx942 + 130).
+# Standard _GFX_ARCH_PATTERN would greedily consume too many digits, so we
+# enumerate known arch IDs explicitly. This list must be updated when new
+# architectures are added to ROCm. Ordered longest-first so alternation
+# matches correctly (e.g., gfx1151 before gfx1150 doesn't matter but
+# gfx90a before gfx900 ensures the letter variant is tried first).
+_MIOPEN_ARCH_PATTERN = re.compile(
+    r"gfx(?:"
+    r"90a|900|906|908|940|941|942|950"
+    r"|1010|1030|1100|1101|1102|1150|1151|1200|1201"
+    r")"
+)
 
 
 class DatabaseHandler(ABC):
@@ -35,16 +49,31 @@ class DatabaseHandler(ABC):
     @abstractmethod
     def detect(self, path: Path, prefix_root: Path) -> Optional[str]:
         """
-        Detect if a file belongs to this database type and extract architecture.
+        Detect if a file belongs to this database type and extract bundle key.
 
         Args:
-            path: Path to the file
+            path: Path to the file (must be under prefix_root)
             prefix_root: Root of the prefix for relative path computation
 
         Returns:
-            Architecture string (e.g., 'gfx1100') if file matches, None otherwise
+            Bundle key (e.g., 'gfx1100', 'gfx11', 'gfx12_0') if file matches,
+            None otherwise. Bundle keys correspond to entries in the
+            rocm-bootstrap hierarchy.
+
+        Raises:
+            ValueError: If path is not under prefix_root (caller bug).
         """
         pass
+
+    def _relative_path(self, path: Path, prefix_root: Path) -> str:
+        """Compute forward-slash relative path, raising on bad input."""
+        try:
+            return path.relative_to(prefix_root).as_posix()
+        except ValueError:
+            raise ValueError(
+                f"{self.name()} handler: path {path} is not under "
+                f"prefix_root {prefix_root}"
+            ) from None
 
     def should_move(self, path: Path) -> bool:
         """
@@ -72,31 +101,25 @@ class RocBLASHandler(DatabaseHandler):
 
         Pattern: lib/rocblas/library/*_gfx*.{co,hsaco,dat}
         """
-        try:
-            rel_path = path.relative_to(prefix_root)
-            # Use as_posix() for consistent forward-slash paths on all platforms
-            path_str = rel_path.as_posix()
+        path_str = self._relative_path(path, prefix_root)
 
-            # Check if it's in rocblas/library directory
-            if "rocblas/library" not in path_str:
-                return None
-
-            # Check file extension
-            if path.suffix not in [".co", ".hsaco", ".dat"]:
-                return None
-
-            # Extract architecture from filename
-            # Look for patterns like _gfx1100, _gfx1101, gfx1102, etc.
-            match = _GFX_ARCH_PATTERN.search(path.name)
-            if match:
-                return f"gfx{match.group(1)}"
-
-            # Some .dat files don't have architecture suffix but are generic
-            # We don't move those
+        # Check if it's in rocblas/library directory
+        if "rocblas/library" not in path_str:
             return None
 
-        except (ValueError, AttributeError):
+        # Check file extension
+        if path.suffix not in [".co", ".hsaco", ".dat"]:
             return None
+
+        # Extract architecture from filename
+        # Look for patterns like _gfx1100, _gfx1101, gfx1102, etc.
+        match = _GFX_ARCH_PATTERN.search(path.name)
+        if match:
+            return match.group(0)
+
+        # Some .dat files don't have architecture suffix but are generic
+        # We don't move those
+        return None
 
 
 class HipBLASLtHandler(DatabaseHandler):
@@ -111,72 +134,114 @@ class HipBLASLtHandler(DatabaseHandler):
 
         Pattern: lib/hipblaslt/library/*_gfx*.{co,hsaco,dat}
         """
-        try:
-            rel_path = path.relative_to(prefix_root)
-            # Use as_posix() for consistent forward-slash paths on all platforms
-            path_str = rel_path.as_posix()
+        path_str = self._relative_path(path, prefix_root)
 
-            # Check if it's in hipblaslt/library directory
-            if "hipblaslt/library" not in path_str:
-                return None
-
-            # Check file extension
-            if path.suffix not in [".co", ".hsaco", ".dat"]:
-                return None
-
-            # Extract architecture from filename
-            match = _GFX_ARCH_PATTERN.search(path.name)
-            if match:
-                return f"gfx{match.group(1)}"
-
+        # Check if it's in hipblaslt/library directory
+        if "hipblaslt/library" not in path_str:
             return None
 
-        except (ValueError, AttributeError):
+        # Check file extension
+        if path.suffix not in [".co", ".hsaco", ".dat"]:
             return None
+
+        # Extract architecture from filename
+        match = _GFX_ARCH_PATTERN.search(path.name)
+        if match:
+            return match.group(0)
+
+        return None
+
+
+class HipSparseLtHandler(DatabaseHandler):
+    """Handler for hipSPARSELt Tensile kernel files."""
+
+    def name(self) -> str:
+        return "hipsparselt"
+
+    def detect(self, path: Path, prefix_root: Path) -> Optional[str]:
+        """
+        Detect hipSPARSELt kernel database files.
+
+        Pattern: lib/hipsparselt/library/*_gfx*.{co,hsaco,dat}
+        """
+        path_str = self._relative_path(path, prefix_root)
+
+        if "hipsparselt/library" not in path_str:
+            return None
+
+        if path.suffix not in [".co", ".hsaco", ".dat"]:
+            return None
+
+        match = _GFX_ARCH_PATTERN.search(path.name)
+        if match:
+            return match.group(0)
+
+        return None
 
 
 class AotritonHandler(DatabaseHandler):
-    """Handler for AOTriton kernel directories."""
+    """Handler for AOTriton kernel image directories.
+
+    AOTriton ships precompiled kernel images in per-architecture directories:
+        lib/aotriton.images/amd-gfx942/flash/attn_fwd/kernel.aks2
+        lib/aotriton.images/amd-gfx11xx/flash/bwd_kernel_dk_dv/kernel.aks2
+
+    Architecture directories use family names (gfx11xx, gfx120x) for ISA
+    families, and specific chip names (gfx942, gfx90a, gfx950) for others.
+
+    Returns bundle keys from the rocm-bootstrap hierarchy:
+        gfx11xx → gfx11 (family), gfx120x → gfx12_0 (sub-family),
+        gfx942 → gfx942 (target), etc.
+    """
+
+    # Mapping from aotriton directory suffixes to rocm-bootstrap bundle keys.
+    # Entries are only needed for family/sub-family patterns that differ from
+    # the raw directory name. Target-level names (gfx942, gfx90a, etc.) pass
+    # through unchanged since they are already valid bundle keys.
+    _BUNDLE_MAP = {
+        "gfx11xx": "gfx11",
+        "gfx120x": "gfx12_0",
+    }
 
     def name(self) -> str:
         return "aotriton"
 
     def detect(self, path: Path, prefix_root: Path) -> Optional[str]:
         """
-        Detect AOTriton kernel files.
+        Detect AOTriton kernel image files.
 
-        Pattern: */aotriton/kernels/gfx*/
+        Pattern: */aotriton.images/amd-gfx*/...
+
+        Returns:
+            Bundle key (e.g., 'gfx11', 'gfx12_0', 'gfx942') or None.
         """
-        try:
-            rel_path = path.relative_to(prefix_root)
-            path_parts = rel_path.parts
+        path_str = self._relative_path(path, prefix_root)
+        path_parts = Path(path_str).parts
 
-            # Look for aotriton/kernels in the path
-            for i, part in enumerate(path_parts[:-1]):
-                if (
-                    part == "aotriton"
-                    and i + 1 < len(path_parts)
-                    and path_parts[i + 1] == "kernels"
-                ):
-                    # Check if next part is an architecture
-                    if i + 2 < len(path_parts):
-                        arch_part = path_parts[i + 2]
-                        if arch_part.startswith("gfx"):
-                            return arch_part
-                    break
+        for i, part in enumerate(path_parts[:-1]):
+            if part == "aotriton.images" and i + 1 < len(path_parts):
+                arch_dir = path_parts[i + 1]
+                if arch_dir.startswith("amd-gfx"):
+                    raw_name = arch_dir[4:]  # strip "amd-" prefix
+                    return self._BUNDLE_MAP.get(raw_name, raw_name)
+                break
 
-            return None
-
-        except (ValueError, AttributeError, IndexError):
-            return None
+        return None
 
 
 class MIOpenHandler(DatabaseHandler):
-    """Handler for MIOpen performance database/model files.
+    """Handler for MIOpen performance database and model files.
 
-    MIOpen installs tuning model files to share/miopen/db/ with filenames
-    prefixed by the target architecture (e.g., gfx942.tn.model,
-    gfx908_ConvAsm1x1U_decoder.ktn.model).
+    MIOpen installs files to share/miopen/db/ with filenames prefixed by
+    the target architecture:
+        gfx942130.db.txt          (gfx942 + 130 CUs)
+        gfx90878.HIP.fdb.txt      (gfx908 + 78 CUs)
+        gfx1030_36.db.txt         (gfx1030 + 36 CUs, underscore separator)
+        gfx908_ConvAsm1x1U_decoder.ktn.model
+        gfx908.tn.model
+
+    The arch + CU-count concatenation (no separator) requires a specific
+    regex that knows ROCm arch ID lengths — see _MIOPEN_ARCH_PATTERN.
     """
 
     def name(self) -> str:
@@ -186,34 +251,52 @@ class MIOpenHandler(DatabaseHandler):
         """
         Detect MIOpen tuning database files.
 
-        Pattern: share/miopen/db/gfx*.{tn.model,ktn.model}
+        Pattern: share/miopen/db/gfx*.{db.txt,fdb.txt,model}
         """
-        try:
-            rel_path = path.relative_to(prefix_root)
-            path_str = rel_path.as_posix()
+        path_str = self._relative_path(path, prefix_root)
 
-            if "miopen/db" not in path_str:
-                return None
-
-            if not path.name.endswith(".model"):
-                return None
-
-            match = _GFX_ARCH_PATTERN.search(path.name)
-            if match:
-                return f"gfx{match.group(1)}"
-
+        if "miopen/db" not in path_str:
             return None
 
-        except (ValueError, AttributeError):
+        if not path.is_file():
             return None
+
+        # Match .model, .db.txt, .fdb.txt, .OpenCL.fdb.txt, .HIP.fdb.txt
+        name = path.name
+        if not (
+            name.endswith(".model")
+            or name.endswith(".db.txt")
+            or name.endswith(".fdb.txt")
+        ):
+            return None
+
+        match = _MIOPEN_ARCH_PATTERN.search(name)
+        if match:
+            return match.group(0)
+
+        return None
 
 
 # Registry of available handlers
 AVAILABLE_HANDLERS = {
     "rocblas": RocBLASHandler,
     "hipblaslt": HipBLASLtHandler,
+    "hipsparselt": HipSparseLtHandler,
     "aotriton": AotritonHandler,
     "miopen": MIOpenHandler,
+}
+
+
+# Wheel-type presets: each maps to the list of database handlers relevant
+# for that kind of wheel.
+WHEEL_TYPE_PRESETS = {
+    "torch-fat": [
+        "rocblas",
+        "hipblaslt",
+        "hipsparselt",
+        "aotriton",
+        "miopen",
+    ],
 }
 
 

--- a/shared/kpack/python/rocm_kpack/elf/phdr_manager.py
+++ b/shared/kpack/python/rocm_kpack/elf/phdr_manager.py
@@ -176,12 +176,20 @@ class ProgramHeaderManager:
     def _write_in_place(self) -> PhdrResizeResult:
         """Write program headers in place at current location."""
         ehdr = self._surgery.ehdr
+        new_count = len(self._phdrs)
+
+        # Update e_phnum BEFORE the write loop so that
+        # surgery.update_program_header() accepts new indices.
+        # Also extend surgery's internal phdr list to match — otherwise
+        # the list assignment in update_program_header() would IndexError.
+        self._surgery._ehdr.e_phnum = new_count
+        while len(self._surgery._phdrs) < new_count:
+            self._surgery._phdrs.append(self._phdrs[len(self._surgery._phdrs)])
 
         for i, phdr in enumerate(self._phdrs):
             self._surgery.update_program_header(i, phdr)
 
-        # Update e_phnum in ELF header
-        self._surgery._ehdr.e_phnum = len(self._phdrs)
+        # Flush the updated e_phnum to the binary buffer
         self._surgery.update_elf_header()
 
         spare = self._get_current_capacity() - len(self._phdrs)

--- a/shared/kpack/python/rocm_kpack/elf/surgery.py
+++ b/shared/kpack/python/rocm_kpack/elf/surgery.py
@@ -148,6 +148,85 @@ class ElfSurgery:
         data = bytearray(path.read_bytes())
         return cls(data, path)
 
+    @staticmethod
+    def has_fatbin_section(file_path: Path) -> bool:
+        """Fast check for .hip_fatbin section without loading the full binary.
+
+        Reads only the ELF header, section header table, and section name
+        string table — typically a few KB total even for multi-GB binaries.
+        Returns False for non-ELF files (wrong magic, too small, 32-bit).
+        Raises on I/O errors or corrupt ELF headers.
+        """
+        file_size = os.path.getsize(file_path)
+        if file_size < ELF64_EHDR_SIZE:
+            return False
+
+        with open(file_path, "rb") as f:
+            ehdr = f.read(ELF64_EHDR_SIZE)
+            if len(ehdr) < ELF64_EHDR_SIZE:
+                return False
+            if ehdr[:4] != b"\x7fELF":
+                return False
+            if ehdr[4] != 2:  # ELFCLASS64
+                return False
+
+            # All offsets and sizes below follow the System V ABI for ELF64.
+            # e_shoff:    offset 40 — file offset to section header table
+            # e_shentsize: offset 58 — size of each section header entry
+            # e_shnum:    offset 60 — number of section header entries
+            # e_shstrndx: offset 62 — index of the .shstrtab section header
+            e_shoff = struct.unpack_from("<Q", ehdr, 40)[0]
+            e_shentsize = struct.unpack_from("<H", ehdr, 58)[0]
+            e_shnum = struct.unpack_from("<H", ehdr, 60)[0]
+            e_shstrndx = struct.unpack_from("<H", ehdr, 62)[0]
+
+            if e_shoff == 0 or e_shnum == 0 or e_shstrndx >= e_shnum:
+                return False
+
+            # Bounds check section header table against file size
+            total_sht_size = e_shentsize * e_shnum
+            if (
+                e_shoff > file_size
+                or total_sht_size > file_size
+                or e_shoff + total_sht_size > file_size
+            ):
+                return False
+
+            # Read section header table
+            f.seek(e_shoff)
+            shtab = f.read(total_sht_size)
+            if len(shtab) < total_sht_size:
+                return False
+
+            # Read .shstrtab
+            strtab_entry = e_shstrndx * e_shentsize
+            sh_offset = struct.unpack_from("<Q", shtab, strtab_entry + 24)[0]
+            sh_size = struct.unpack_from("<Q", shtab, strtab_entry + 32)[0]
+
+            # Bounds check .shstrtab region against file size
+            if (
+                sh_offset > file_size
+                or sh_size > file_size
+                or sh_offset + sh_size > file_size
+            ):
+                return False
+
+            f.seek(sh_offset)
+            shstrtab = f.read(sh_size)
+
+            # Search for ".hip_fatbin" in section names
+            target = b".hip_fatbin\x00"
+            if target not in shstrtab:
+                return False
+
+            target_offset = shstrtab.index(target)
+            for i in range(e_shnum):
+                sh_name = struct.unpack_from("<I", shtab, i * e_shentsize)[0]
+                if sh_name == target_offset:
+                    return True
+
+            return False
+
     # =========================================================================
     # Properties
     # =========================================================================

--- a/shared/kpack/python/rocm_kpack/kpack_transform.py
+++ b/shared/kpack/python/rocm_kpack/kpack_transform.py
@@ -129,13 +129,15 @@ def read_kpack_ref_marker(binary_path: Path) -> dict | None:
 def is_fat_binary(binary_path: Path) -> bool:
     """Check if a binary contains HIP fat binary sections.
 
-    This is a quick check that doesn't require full parsing.
+    Fast-path: reads only headers (ELF section header table or PE section
+    headers), not the full binary. Works for both ELF and PE/COFF.
 
     Args:
         binary_path: Path to binary
 
     Returns:
-        True if binary appears to contain device code, False otherwise
+        True if binary contains a .hip_fatbin (ELF) or .hip_fat (COFF)
+        section, False otherwise (including non-ELF/non-PE files).
     """
     try:
         fmt = detect_binary_format(binary_path)
@@ -145,10 +147,8 @@ def is_fat_binary(binary_path: Path) -> bool:
     if fmt == "elf":
         from .elf.surgery import ElfSurgery
 
-        surgery = ElfSurgery.load(binary_path)
-        return surgery.find_section(".hip_fatbin") is not None
+        return ElfSurgery.has_fatbin_section(binary_path)
     else:
         from .coff.surgery import CoffSurgery
 
-        surgery = CoffSurgery.load(binary_path)
-        return surgery.find_section(".hip_fat") is not None
+        return CoffSurgery.has_fatbin_section(binary_path)

--- a/shared/kpack/python/rocm_kpack/tools/split_python_wheels.py
+++ b/shared/kpack/python/rocm_kpack/tools/split_python_wheels.py
@@ -1,0 +1,241 @@
+#!/usr/bin/env python3
+
+"""
+Command-line tool for splitting Python wheels into host and per-arch device wheels.
+
+Processes fat Python wheels (e.g., PyTorch with embedded HIP device code) to separate
+host code from GPU device code, producing:
+- A host wheel with device code stripped and kpack references injected
+- One device wheel per GPU architecture containing .kpack archives
+"""
+
+import argparse
+import os
+import sys
+import traceback
+from pathlib import Path
+
+from rocm_kpack.binutils import Toolchain
+from rocm_kpack.database_handlers import (
+    WHEEL_TYPE_PRESETS,
+    get_database_handlers,
+    list_available_handlers,
+)
+
+try:
+    from rocm_kpack.wheel_splitter import WheelSplitter, WheelSplitError
+except ModuleNotFoundError as e:
+    raise SystemExit(
+        f"Required package not found: {e.name}\n"
+        "Wheel splitting requires: pip install rocm-bootstrap"
+    ) from e
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Split a Python wheel into host + per-arch device wheels",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""\
+Examples:
+  # Split a .whl file into .whl outputs
+  %(prog)s \\
+      --input torch-2.10.0+rocm7.1-cp313-cp313-manylinux_2_28_x86_64.whl \\
+      --output-dir dist/ \\
+      --device-package-prefix amd-torch-device \\
+      --overlay-root torch/
+
+  # Split an exploded directory, output as directories (fast iteration)
+  %(prog)s \\
+      --input /path/to/torch-exploded/ \\
+      --output-dir dist/ \\
+      --device-package-prefix amd-torch-device \\
+      --overlay-root torch/ \\
+      --output-format directory
+
+  # With device wheel dependencies
+  %(prog)s \\
+      --input torch.whl \\
+      --output-dir dist/ \\
+      --device-package-prefix amd-torch-device \\
+      --overlay-root torch/ \\
+      --device-requires-dist "rocm-sdk-device-@GFXARCH@ == 7.1"
+""",
+    )
+
+    parser.add_argument(
+        "--input",
+        type=Path,
+        required=True,
+        help="Input .whl file or exploded wheel directory",
+    )
+    parser.add_argument(
+        "--output-dir",
+        type=Path,
+        required=True,
+        help="Output directory for split wheels",
+    )
+    parser.add_argument(
+        "--device-package-prefix",
+        type=str,
+        required=True,
+        help="Package name prefix for device wheels (e.g., 'amd-torch-device')",
+    )
+    parser.add_argument(
+        "--overlay-root",
+        type=str,
+        required=True,
+        help="Directory within wheel where .kpack/ is placed (e.g., 'torch/')",
+    )
+    parser.add_argument(
+        "--device-requires-dist",
+        type=str,
+        nargs="*",
+        default=[],
+        help="Additional Requires-Dist entries for device wheels. "
+        "Use @GFXARCH@ as placeholder for architecture "
+        "(e.g., 'rocm-sdk-device-@GFXARCH@ == 7.1')",
+    )
+    parser.add_argument(
+        "--output-format",
+        choices=["wheel", "directory"],
+        default="wheel",
+        help="Output format: 'wheel' for .whl files, 'directory' for exploded dirs (default: wheel)",
+    )
+    preset_names = ", ".join(sorted(WHEEL_TYPE_PRESETS.keys()))
+    handler_names = ", ".join(list_available_handlers())
+    parser.add_argument(
+        "--wheel-type",
+        choices=sorted(WHEEL_TYPE_PRESETS.keys()),
+        default=None,
+        help=f"Preset wheel type that selects database handlers. Available: {preset_names}",
+    )
+    parser.add_argument(
+        "--databases",
+        nargs="*",
+        default=None,
+        help=f"Database handlers for arch-specific files. Overrides --wheel-type. "
+        f"Available: {handler_names}",
+    )
+    parser.add_argument(
+        "--compression",
+        choices=["none", "zstd"],
+        default="zstd",
+        help="Compression scheme for kpack archives (default: zstd)",
+    )
+    parser.add_argument(
+        "--compression-level",
+        type=int,
+        default=3,
+        help="Zstd compression level, 1-22 (default: 3)",
+    )
+    parser.add_argument(
+        "--tmp-dir",
+        type=Path,
+        default=None,
+        help="Temporary directory for intermediate files",
+    )
+    parser.add_argument(
+        "--verbose",
+        action="store_true",
+        help="Enable verbose output",
+    )
+    parser.add_argument(
+        "-j",
+        "--jobs",
+        type=int,
+        default=1,
+        help="Number of parallel workers for extraction and transformation (default: 1)",
+    )
+    parser.add_argument(
+        "--generate-variant-wheel",
+        action="store_true",
+        help="Also generate a PEP 817 variant wheel with variant_properties markers "
+        "for wheelnext-aware installers (e.g., uv with variant support)",
+    )
+    parser.add_argument(
+        "--variant-label",
+        type=str,
+        default="variant",
+        help="Label appended to variant wheel filename per PEP 817 "
+        "(e.g., 'amd' produces ...-amd.whl). Default: variant",
+    )
+
+    Toolchain.configure_argparse(parser)
+
+    args = parser.parse_args()
+
+    try:
+        # Validate input
+        if not args.input.exists():
+            raise WheelSplitError(f"Input does not exist: {args.input}")
+
+        # Set temporary directory
+        if args.tmp_dir:
+            os.environ["TMPDIR"] = str(args.tmp_dir)
+            if args.verbose:
+                print(f"Using temporary directory: {args.tmp_dir}")
+
+        # Create toolchain
+        toolchain = Toolchain.from_args(args)
+
+        # Resolve database handlers: --databases overrides --wheel-type
+        db_handler_names = None
+        if args.databases is not None:
+            db_handler_names = args.databases
+        elif args.wheel_type is not None:
+            db_handler_names = WHEEL_TYPE_PRESETS[args.wheel_type]
+
+        database_handlers = None
+        if db_handler_names:
+            database_handlers = get_database_handlers(db_handler_names)
+
+        # Create splitter and run
+        splitter = WheelSplitter(
+            device_package_prefix=args.device_package_prefix,
+            overlay_root=args.overlay_root,
+            toolchain=toolchain,
+            device_requires_dist=args.device_requires_dist,
+            database_handlers=database_handlers,
+            compression=args.compression,
+            compression_level=args.compression_level,
+            verbose=args.verbose,
+            jobs=args.jobs,
+            generate_variant_wheel=args.generate_variant_wheel,
+            variant_label=args.variant_label,
+        )
+
+        print(f"Input: {args.input}")
+        print(f"Output: {args.output_dir}")
+        print(f"Device package prefix: {args.device_package_prefix}")
+        print(f"Overlay root: {args.overlay_root}")
+        print(f"Output format: {args.output_format}")
+        if args.generate_variant_wheel:
+            print(f"Variant wheel: enabled")
+
+        result = splitter.split(args.input, args.output_dir, args.output_format)
+
+        # Print summary
+        print(f"\nSplit complete:")
+        print(f"  Fat binaries processed: {result.fat_binaries_processed}")
+        print(f"  Architectures: {', '.join(result.architectures_found)}")
+        print(f"  Host wheel: {result.host_wheel_path}")
+        if result.variant_wheel_path:
+            print(f"  Variant wheel: {result.variant_wheel_path}")
+        for arch, path in sorted(result.device_wheel_paths.items()):
+            print(f"  Device wheel ({arch}): {path}")
+
+        return 0
+
+    except WheelSplitError as e:
+        print(f"Error: {e}", file=sys.stderr)
+        if args.verbose:
+            traceback.print_exc()
+        return 1
+    except Exception as e:
+        print(f"Unexpected error: {e}", file=sys.stderr)
+        traceback.print_exc()
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/shared/kpack/python/rocm_kpack/wheel_splitter.py
+++ b/shared/kpack/python/rocm_kpack/wheel_splitter.py
@@ -1,0 +1,1608 @@
+"""
+Wheel splitter for separating host and device code in Python wheels.
+
+This module provides functionality to split a fat Python wheel (e.g., PyTorch
+with embedded HIP device code) into:
+- A host wheel: original package with device code stripped and kpack refs injected
+- Device wheels: one per GPU architecture, containing .kpack archives
+
+The device wheels overlay onto the host package's directory structure so that
+at install time, the .kpack/ directory merges with the host package tree.
+"""
+
+import hashlib
+import json
+import os
+import re
+import shutil
+import time
+import zipfile
+from collections import defaultdict
+from concurrent.futures import ProcessPoolExecutor, as_completed
+from dataclasses import dataclass, field
+from email.parser import HeaderParser
+from pathlib import Path
+
+try:
+    import rocm_bootstrap
+except ModuleNotFoundError as e:
+    raise ModuleNotFoundError(
+        "rocm-bootstrap is required for wheel splitting.\n"
+        "Install it with: pip install rocm-bootstrap"
+    ) from e
+
+from rocm_kpack.artifact_splitter import ExtractedKernel
+from rocm_kpack.artifact_utils import (
+    extract_architecture_from_target,
+    scan_directory,
+)
+from rocm_kpack.binutils import BundledBinary, Toolchain
+from rocm_kpack.compression import ZstdCompressor
+from rocm_kpack.database_handlers import DatabaseHandler, get_database_handlers
+from rocm_kpack.kpack import PackedKernelArchive
+from rocm_kpack.kpack_transform import (
+    NotFatBinaryError,
+    is_fat_binary,
+    kpack_offload_binary,
+)
+
+
+def _normalize_arch(arch: str) -> str:
+    """Normalize architecture name to canonical form (colons for xnack).
+
+    Tensile filenames use hyphens (gfx90a-xnack+) while ELF bundle targets
+    use colons (gfx90a:xnack+). Normalize to colons for consistency.
+    """
+    return arch.replace("-xnack", ":xnack")
+
+
+def _arch_to_bundle_key(arch: str) -> str:
+    """Strip xnack suffix to get the bare architecture (bundle key).
+
+    xnack+/- variants collapse into the same device wheel as the bare arch.
+    The individual kpack files preserve the full arch name.
+
+    Examples:
+        gfx942:xnack+ → gfx942
+        gfx90a:xnack- → gfx90a
+        gfx1100       → gfx1100
+        gfx11         → gfx11
+    """
+    return re.sub(r":xnack[+-]$", "", arch)
+
+
+class WheelSplitError(Exception):
+    """Base error for wheel splitting operations."""
+
+    pass
+
+
+class InvalidWheelError(WheelSplitError):
+    """Input is not a valid Python wheel."""
+
+    pass
+
+
+class NoFatBinariesError(WheelSplitError):
+    """No fat binaries found in wheel."""
+
+    pass
+
+
+@dataclass
+class WheelIdentity:
+    """Parsed wheel filename and dist-info fields."""
+
+    name: str  # e.g., "torch"
+    version: str  # e.g., "2.10.0+rocm7.1"
+    python_tag: str  # e.g., "cp313"
+    abi_tag: str  # e.g., "cp313"
+    platform_tag: str  # e.g., "manylinux_2_28_x86_64"
+    dist_info_name: str  # e.g., "torch-2.10.0+rocm7.1.dist-info"
+
+
+@dataclass
+class FatBinaryInfo:
+    """A fat binary found in the wheel."""
+
+    absolute_path: Path
+    overlay_relative_path: str  # relative to overlay root, e.g. "lib/libtorch_hip.so"
+
+
+@dataclass
+class SplitResult:
+    """Result of a wheel split operation."""
+
+    host_wheel_path: Path
+    variant_wheel_path: Path | None = None
+    device_wheel_paths: dict[str, Path] = field(default_factory=dict)
+    architectures_found: list[str] = field(default_factory=list)
+    fat_binaries_processed: int = 0
+
+
+@dataclass
+class TransformResult:
+    """Result of transforming a single fat binary."""
+
+    overlay_relative_path: str
+    original_size: int
+    new_size: int
+    skipped: bool
+
+
+@dataclass
+class DatabaseFileRef:
+    """A database file detected by a handler."""
+
+    absolute_path: Path
+    overlay_relative_path: str  # relative to overlay root
+    architecture: str  # normalized (colons for xnack)
+    handler_name: str
+
+
+@dataclass
+class ExtractedKernelRef:
+    """Lightweight reference to an extracted kernel stored on disk.
+
+    Used instead of ExtractedKernel for cross-process communication to avoid
+    pickling large kernel_data bytes through IPC pipes. The parent process
+    reads kernel data from disk when building kpack archives.
+    """
+
+    target_name: str
+    kernel_file: Path  # Path to kernel data on disk
+    kernel_size: int
+    source_binary_relpath: str
+    source_prefix: str
+    architecture: str
+
+
+@dataclass
+class TransformArgs:
+    """Arguments for a single fat binary transformation."""
+
+    binary_path: Path
+    temp_output: Path
+    search_pattern: str
+    kernel_name: str
+    overlay_relative_path: str
+
+
+def parse_wheel_identity(wheel_root: Path) -> WheelIdentity:
+    """Parse wheel identity from the dist-info directory.
+
+    Args:
+        wheel_root: Root directory of the (exploded) wheel.
+
+    Returns:
+        WheelIdentity with parsed fields.
+
+    Raises:
+        InvalidWheelError: If the wheel structure is invalid.
+    """
+    dist_info_dirs = list(wheel_root.glob("*.dist-info"))
+    if len(dist_info_dirs) != 1:
+        raise InvalidWheelError(
+            f"Expected exactly one .dist-info directory in {wheel_root}, "
+            f"found {len(dist_info_dirs)}"
+        )
+    dist_info_dir = dist_info_dirs[0]
+    dist_info_name = dist_info_dir.name
+
+    # Parse METADATA for authoritative Name and Version
+    metadata_file = dist_info_dir / "METADATA"
+    if not metadata_file.exists():
+        raise InvalidWheelError(f"No METADATA file in {dist_info_dir}")
+    metadata_text = metadata_file.read_text(encoding="utf-8")
+    parser = HeaderParser()
+    metadata = parser.parsestr(metadata_text)
+    name = metadata.get("Name")
+    version = metadata.get("Version")
+    if not name or not version:
+        raise InvalidWheelError(f"METADATA missing Name or Version in {dist_info_dir}")
+
+    # Parse WHEEL file for tags
+    wheel_file = dist_info_dir / "WHEEL"
+    if not wheel_file.exists():
+        raise InvalidWheelError(f"No WHEEL file in {dist_info_dir}")
+    wheel_text = wheel_file.read_text(encoding="utf-8")
+    wheel_meta = parser.parsestr(wheel_text)
+
+    # Get the first Tag: line (there may be multiple for multi-platform wheels)
+    tag = wheel_meta.get("Tag")
+    if not tag:
+        raise InvalidWheelError(f"WHEEL file missing Tag in {dist_info_dir}")
+
+    tag_parts = tag.split("-")
+    if len(tag_parts) != 3:
+        raise InvalidWheelError(
+            f"Invalid wheel Tag format '{tag}', expected 'python-abi-platform'"
+        )
+    python_tag, abi_tag, platform_tag = tag_parts
+
+    return WheelIdentity(
+        name=name,
+        version=version,
+        python_tag=python_tag,
+        abi_tag=abi_tag,
+        platform_tag=platform_tag,
+        dist_info_name=dist_info_name,
+    )
+
+
+def compute_wheel_filename(name: str, version: str, identity: WheelIdentity) -> str:
+    """Compute a PEP 427 wheel filename.
+
+    Args:
+        name: Distribution name (dashes are normalized to underscores).
+        version: Version string.
+        identity: WheelIdentity for tags.
+
+    Returns:
+        Filename like "amd_torch_device_gfx942-2.10.0+rocm7.1-cp313-cp313-manylinux_2_28_x86_64.whl"
+    """
+    normalized_name = name.replace("-", "_")
+    return (
+        f"{normalized_name}-{version}"
+        f"-{identity.python_tag}-{identity.abi_tag}-{identity.platform_tag}.whl"
+    )
+
+
+def compute_dist_info_name(name: str, version: str) -> str:
+    """Compute dist-info directory name per PEP 427.
+
+    Args:
+        name: Distribution name.
+        version: Version string.
+
+    Returns:
+        e.g. "amd_torch_device_gfx942-2.10.0+rocm7.1.dist-info"
+    """
+    normalized_name = name.replace("-", "_")
+    return f"{normalized_name}-{version}.dist-info"
+
+
+def generate_record(
+    wheel_root: Path, dist_info_dir_name: str, verbose: bool = False
+) -> str:
+    """Generate RECORD file content with SHA256 hashes for all files.
+
+    Uses streaming hash computation to avoid loading large files into memory.
+
+    Args:
+        wheel_root: Root directory of the wheel.
+        dist_info_dir_name: Name of the dist-info directory.
+        verbose: Print progress for large files.
+
+    Returns:
+        RECORD file content as a string.
+    """
+    lines: list[str] = []
+    for file_path in sorted(wheel_root.rglob("*")):
+        if not file_path.is_file():
+            continue
+        rel_path = file_path.relative_to(wheel_root).as_posix()
+        # RECORD itself has no hash
+        if rel_path == f"{dist_info_dir_name}/RECORD":
+            lines.append(f"{rel_path},,")
+            continue
+        size = file_path.stat().st_size
+        if verbose and size > 50 * 1024 * 1024:
+            print(f"    Hashing: {rel_path} ({size / (1024*1024):.0f} MB)")
+        # Stream hash to avoid loading entire file into memory
+        h = hashlib.sha256()
+        with open(file_path, "rb") as f:
+            while True:
+                chunk = f.read(1024 * 1024)  # 1MB chunks
+                if not chunk:
+                    break
+                h.update(chunk)
+        lines.append(f"{rel_path},sha256={h.hexdigest()},{size}")
+    return "\n".join(lines) + "\n"
+
+
+def _bundle_key_to_dist_name(device_package_prefix: str, bundle_key: str) -> str:
+    """Convert a bundle key to a dist package name via rocm_bootstrap.
+
+    Args:
+        device_package_prefix: Package name prefix, e.g. "amd-torch-device".
+        bundle_key: Bundle key, e.g. "gfx942", "gfx11", "gfx12_0".
+
+    Returns:
+        Dist name, e.g. "amd-torch-device-gfx942", "amd-torch-device-gfx12-0".
+    """
+    bundle = rocm_bootstrap.lookup_bundle(bundle_key)
+    return rocm_bootstrap.device_dist_name(device_package_prefix, bundle)
+
+
+def generate_device_metadata(
+    host_identity: WheelIdentity,
+    bundle_key: str,
+    device_package_prefix: str,
+    device_requires_dist: list[str],
+) -> str:
+    """Generate METADATA content for a device wheel.
+
+    Args:
+        host_identity: Identity of the host wheel.
+        bundle_key: Bundle key, e.g. "gfx942", "gfx11", "gfx12_0".
+        device_package_prefix: Package name prefix, e.g. "amd-torch-device".
+        device_requires_dist: Additional Requires-Dist entries (may contain @GFXARCH@).
+
+    Returns:
+        METADATA file content.
+    """
+    device_name = _bundle_key_to_dist_name(device_package_prefix, bundle_key)
+    bundle = rocm_bootstrap.lookup_bundle(bundle_key)
+    lines = [
+        "Metadata-Version: 2.4",
+        f"Name: {device_name}",
+        f"Version: {host_identity.version}",
+        f"Summary: AMD device kernels ({bundle.display_name}) for {host_identity.name}",
+        f"Requires-Dist: {host_identity.name} == {host_identity.version}",
+    ]
+    for dep in device_requires_dist:
+        expanded = dep.replace("@GFXARCH@", bundle_key)
+        lines.append(f"Requires-Dist: {expanded}")
+    return "\n".join(lines) + "\n"
+
+
+def generate_wheel_file(identity: WheelIdentity) -> str:
+    """Generate WHEEL file content for a device wheel.
+
+    Args:
+        identity: WheelIdentity for tags.
+
+    Returns:
+        WHEEL file content.
+    """
+    tag = f"{identity.python_tag}-{identity.abi_tag}-{identity.platform_tag}"
+    return (
+        f"Wheel-Version: 1.0\n"
+        f"Generator: rocm-kpack-split-python-wheels\n"
+        f"Root-Is-Purelib: false\n"
+        f"Tag: {tag}\n"
+    )
+
+
+def _copy_tree(src: Path, dst: Path) -> None:
+    """Copy a directory tree preserving metadata.
+
+    Symlinks are preserved as symlinks (not followed).
+    """
+    dst.mkdir(parents=True, exist_ok=True)
+    for dirpath, dirnames, filenames in os.walk(src):
+        src_dir = Path(dirpath)
+        rel = src_dir.relative_to(src)
+        dst_dir = dst / rel
+        dst_dir.mkdir(parents=True, exist_ok=True)
+        for fname in filenames:
+            src_file = src_dir / fname
+            dst_file = dst_dir / fname
+            if src_file.is_symlink():
+                link_target = os.readlink(src_file)
+                os.symlink(link_target, dst_file)
+            else:
+                shutil.copy2(src_file, dst_file)
+
+
+def zip_wheel(source_dir: Path, output_path: Path) -> None:
+    """Zip a directory into a .whl file.
+
+    Args:
+        source_dir: Root directory to zip.
+        output_path: Output .whl file path.
+    """
+    with zipfile.ZipFile(output_path, "w", zipfile.ZIP_DEFLATED) as zf:
+        for file_path in sorted(source_dir.rglob("*")):
+            if file_path.is_file():
+                arcname = file_path.relative_to(source_dir).as_posix()
+                zf.write(file_path, arcname)
+
+
+def _extract_single_binary(
+    fat_binary_path: Path,
+    overlay_relative_path: str,
+    kernel_staging_dir: Path,
+) -> list[ExtractedKernelRef]:
+    """Extract device kernels from a single fat binary to disk.
+
+    Module-level function for use with ProcessPoolExecutor. Writes kernel
+    data to files under kernel_staging_dir instead of returning bytes,
+    avoiding large IPC serialization overhead.
+
+    Args:
+        fat_binary_path: Absolute path to the fat binary.
+        overlay_relative_path: Path relative to the overlay root.
+        kernel_staging_dir: Directory to write kernel files into.
+
+    Returns:
+        List of ExtractedKernelRef objects with file paths.
+    """
+    binary = BundledBinary(fat_binary_path)
+    code_object_index: dict[str, int] = defaultdict(int)
+    refs: list[ExtractedKernelRef] = []
+
+    # Create a subdirectory per binary to avoid filename collisions
+    binary_name = Path(overlay_relative_path).name
+    binary_staging = kernel_staging_dir / binary_name
+    binary_staging.mkdir(parents=True, exist_ok=True)
+
+    with binary.unbundle() as unbundled:
+        for target_name, file_name in unbundled.target_list:
+            arch = extract_architecture_from_target(target_name)
+            if arch:
+                src_path = unbundled.dest_dir / file_name
+                index = code_object_index[arch]
+                code_object_index[arch] += 1
+                indexed_relpath = f"{overlay_relative_path}#{index}"
+
+                # Move kernel file to staging (avoids a copy since unbundle
+                # temp dir is cleaned up when the context manager exits)
+                dest_name = f"{arch}_{index}_{file_name}"
+                dest_path = binary_staging / dest_name
+                shutil.copy2(src_path, dest_path)
+                kernel_size = dest_path.stat().st_size
+
+                refs.append(
+                    ExtractedKernelRef(
+                        target_name=target_name,
+                        kernel_file=dest_path,
+                        kernel_size=kernel_size,
+                        source_binary_relpath=indexed_relpath,
+                        source_prefix="",
+                        architecture=arch,
+                    )
+                )
+
+    return refs
+
+
+def _transform_single_binary(
+    binary_path: Path,
+    temp_output: Path,
+    search_pattern: str,
+    kernel_name: str,
+    overlay_relative_path: str,
+    verbose: bool,
+) -> TransformResult:
+    """Transform a single fat binary in the host staging directory.
+
+    This is a module-level function so it can be submitted to a thread pool.
+    Each invocation operates on separate files with no shared mutable state.
+
+    Args:
+        binary_path: Path to the fat binary in the staging dir.
+        temp_output: Path for the temporary transformed output.
+        search_pattern: Kpack search pattern with @GFXARCH@ placeholder.
+        kernel_name: Kernel name for the kpack reference.
+        overlay_relative_path: For reporting.
+        verbose: Print transformation details.
+
+    Returns:
+        TransformResult with size info.
+    """
+    original_size = binary_path.stat().st_size
+    try:
+        kpack_offload_binary(
+            input_path=binary_path,
+            output_path=temp_output,
+            kpack_search_paths=[search_pattern],
+            kernel_name=kernel_name,
+            verbose=verbose,
+        )
+
+        os.replace(temp_output, binary_path)
+
+        if not binary_path.exists():
+            raise WheelSplitError(
+                f"Binary disappeared after transformation: {binary_path}"
+            )
+
+        new_size = binary_path.stat().st_size
+        return TransformResult(
+            overlay_relative_path=overlay_relative_path,
+            original_size=original_size,
+            new_size=new_size,
+            skipped=False,
+        )
+
+    except NotFatBinaryError:
+        return TransformResult(
+            overlay_relative_path=overlay_relative_path,
+            original_size=original_size,
+            new_size=original_size,
+            skipped=True,
+        )
+    finally:
+        if temp_output.exists():
+            temp_output.unlink()
+
+
+@dataclass
+class KpackResult:
+    """Result of creating a single kpack archive."""
+
+    arch: str
+    kpack_path: Path
+    kpack_size: int
+    num_kernels: int
+    elapsed: float
+
+
+def _create_single_kpack(
+    arch: str,
+    ref_list: list[ExtractedKernelRef],
+    group_name: str,
+    kpack_staging: Path,
+    compression: str,
+    compression_level: int,
+) -> KpackResult:
+    """Create a kpack archive for a single architecture.
+
+    Module-level function for use with ProcessPoolExecutor. Each arch is
+    fully independent — separate kernel files, separate output archive.
+    """
+    t0 = time.monotonic()
+
+    compressor = None
+    if compression == "zstd":
+        compressor = ZstdCompressor(compression_level=compression_level)
+
+    archive = PackedKernelArchive(
+        group_name=group_name,
+        gfx_arch_family=arch,
+        gfx_arches=[arch],
+        compressor=compressor,
+    )
+
+    for ref in ref_list:
+        hsaco_data = ref.kernel_file.read_bytes()
+        prepared = archive.prepare_kernel(
+            relative_path=ref.source_binary_relpath,
+            gfx_arch=ref.architecture,
+            hsaco_data=hsaco_data,
+        )
+        archive.add_kernel(prepared)
+
+    archive.finalize_archive()
+
+    kpack_file = kpack_staging / f"{group_name}_{arch}.kpack"
+    archive.write(kpack_file)
+
+    if not kpack_file.exists() or kpack_file.stat().st_size == 0:
+        raise WheelSplitError(f"Failed to create kpack archive: {kpack_file}")
+
+    elapsed = time.monotonic() - t0
+    return KpackResult(
+        arch=arch,
+        kpack_path=kpack_file,
+        kpack_size=kpack_file.stat().st_size,
+        num_kernels=len(ref_list),
+        elapsed=elapsed,
+    )
+
+
+class WheelSplitter:
+    """Splits a Python wheel into host + per-arch device wheels."""
+
+    def __init__(
+        self,
+        device_package_prefix: str,
+        overlay_root: str,
+        toolchain: Toolchain,
+        device_requires_dist: list[str] | None = None,
+        database_handlers: list[DatabaseHandler] | None = None,
+        compression: str = "zstd",
+        compression_level: int = 3,
+        verbose: bool = False,
+        jobs: int = 1,
+        generate_variant_wheel: bool = False,
+        variant_label: str = "variant",
+    ):
+        """
+        Args:
+            device_package_prefix: Package name prefix for device wheels (e.g., "amd-torch-device").
+            overlay_root: Directory within the wheel where .kpack/ is placed (e.g., "torch/").
+            toolchain: Toolchain instance for binary operations.
+            device_requires_dist: Additional Requires-Dist entries for device wheels.
+                Supports @GFXARCH@ placeholder.
+            database_handlers: Handlers for arch-specific database files (rocblas, hipblaslt, etc.).
+            compression: Compression scheme for kpack archives ("none" or "zstd").
+            compression_level: Zstd compression level (1-22).
+            verbose: Enable verbose output.
+            jobs: Number of parallel workers for extraction and transformation (default 1).
+            generate_variant_wheel: If True, also generate a PEP 817 variant wheel with
+                variant_properties markers. The classic wheel only uses extras.
+            variant_label: Label appended to the variant wheel filename per PEP 817
+                (e.g., "amd" produces ...-amd.whl). Default: "variant".
+        """
+        self.device_package_prefix = device_package_prefix
+        # Normalize overlay_root: strip trailing slash, ensure no leading slash
+        self.overlay_root = overlay_root.strip("/")
+        self.toolchain = toolchain
+        self.device_requires_dist = device_requires_dist or []
+        self.database_handlers = database_handlers or []
+        self.compression = compression
+        self.compression_level = compression_level
+        self.verbose = verbose
+        self.jobs = max(1, jobs)
+        self.generate_variant_wheel = generate_variant_wheel
+        self.variant_label = variant_label
+
+    def split(
+        self,
+        input_path: Path,
+        output_dir: Path,
+        output_format: str = "wheel",
+    ) -> SplitResult:
+        """Split a wheel into host and device components.
+
+        Args:
+            input_path: Path to input .whl file or exploded wheel directory.
+            output_dir: Output directory for generated wheels.
+            output_format: "wheel" for .whl files, "directory" for exploded dirs.
+
+        Returns:
+            SplitResult with paths to generated outputs.
+
+        Raises:
+            InvalidWheelError: If the input is not a valid wheel.
+            NoFatBinariesError: If no fat binaries are found.
+        """
+        output_dir.mkdir(parents=True, exist_ok=True)
+
+        # Phase 0: Resolve input
+        wheel_root, is_temporary = self._resolve_input(input_path)
+        try:
+            return self._split_impl(wheel_root, output_dir, output_format)
+        finally:
+            if is_temporary:
+                shutil.rmtree(wheel_root, ignore_errors=True)
+
+    def _resolve_input(self, input_path: Path) -> tuple[Path, bool]:
+        """Resolve input to a working directory.
+
+        Returns:
+            (wheel_root, is_temporary) — is_temporary means we extracted to a temp
+            dir that should be cleaned up.
+        """
+        if input_path.is_dir():
+            return input_path, False
+        elif input_path.is_file() and input_path.suffix == ".whl":
+            # Extract to a temp directory adjacent to the input
+            temp_dir = input_path.parent / (input_path.stem + ".tmp_extract")
+            if temp_dir.exists():
+                shutil.rmtree(temp_dir)
+            temp_dir.mkdir()
+            if self.verbose:
+                print(f"Extracting {input_path} to {temp_dir}")
+            with zipfile.ZipFile(input_path, "r") as zf:
+                zf.extractall(temp_dir)
+            return temp_dir, True
+        else:
+            raise InvalidWheelError(
+                f"Input must be a .whl file or directory, got: {input_path}"
+            )
+
+    def _split_impl(
+        self, wheel_root: Path, output_dir: Path, output_format: str
+    ) -> SplitResult:
+        """Core split implementation operating on an exploded wheel directory."""
+        # Phase 1: Parse identity
+        identity = parse_wheel_identity(wheel_root)
+        if self.verbose:
+            print(f"Wheel: {identity.name} {identity.version}")
+            print(
+                f"Tag: {identity.python_tag}-{identity.abi_tag}-{identity.platform_tag}"
+            )
+
+        overlay_dir = wheel_root / self.overlay_root
+        if not overlay_dir.exists():
+            raise InvalidWheelError(
+                f"Overlay root '{self.overlay_root}' does not exist in wheel"
+            )
+
+        # Phase 2: Scan for fat binaries
+        if self.verbose:
+            print(f"\nPhase 2: Scanning for fat binaries under {self.overlay_root}/")
+        fat_binaries = self._scan_fat_binaries(overlay_dir)
+        if not fat_binaries:
+            raise NoFatBinariesError(
+                f"No fat binaries found under {self.overlay_root}/"
+            )
+        if self.verbose:
+            print(f"Found {len(fat_binaries)} fat binaries")
+
+        # Sort largest first so the process pool starts the critical path early
+        fat_binaries.sort(key=lambda fb: fb.absolute_path.stat().st_size, reverse=True)
+
+        # Phase 2b: Scan for database files (rocblas, hipblaslt, etc.)
+        db_refs_by_arch: dict[str, list[DatabaseFileRef]] = defaultdict(list)
+        if self.database_handlers:
+            db_refs_by_arch = self._scan_database_files(overlay_dir)
+
+        # Phase 3: Extract kernels from fat binaries
+        if self.verbose:
+            print(f"\nPhase 3: Extracting device kernels")
+        kernel_staging_dir = output_dir / ".kernel_staging"
+        kernel_staging_dir.mkdir(parents=True, exist_ok=True)
+        try:
+            refs_by_arch = self._extract_kernels(fat_binaries, kernel_staging_dir)
+
+            # Merge architecture sets from ELF extraction and database scanning
+            all_arches: set[str] = set(refs_by_arch.keys())
+            all_arches.update(db_refs_by_arch.keys())
+            architectures = sorted(all_arches)
+
+            if self.verbose:
+                print(f"Architectures found: {', '.join(architectures)}")
+                for arch in architectures:
+                    parts = []
+                    if arch in refs_by_arch:
+                        parts.append(f"{len(refs_by_arch[arch])} kernels")
+                    if arch in db_refs_by_arch:
+                        parts.append(f"{len(db_refs_by_arch[arch])} db files")
+                    print(f"  {arch}: {', '.join(parts)}")
+
+            # Phase 4: Create kpack archives (staged to output_dir temporarily)
+            group_name = identity.name.lower().replace("-", "_")
+            kpack_by_arch = self._create_kpack_archives(
+                refs_by_arch, group_name, output_dir
+            )
+        finally:
+            shutil.rmtree(kernel_staging_dir, ignore_errors=True)
+
+        # Phase 4b: Group by bundle key (collapse xnack variants)
+        # kpack_by_arch may have keys like gfx942, gfx942:xnack+, gfx942:xnack-
+        # These all collapse into bundle key "gfx942" with multiple kpack files.
+        kpacks_by_bundle: dict[str, list[tuple[str, Path]]] = defaultdict(list)
+        for arch, kpack_path in kpack_by_arch.items():
+            bundle_key = _arch_to_bundle_key(arch)
+            kpacks_by_bundle[bundle_key].append((arch, kpack_path))
+
+        db_refs_by_bundle: dict[str, list[DatabaseFileRef]] = defaultdict(list)
+        for arch, refs in db_refs_by_arch.items():
+            bundle_key = _arch_to_bundle_key(arch)
+            db_refs_by_bundle[bundle_key].extend(refs)
+
+        bundle_keys = sorted(
+            set(kpacks_by_bundle.keys()) | set(db_refs_by_bundle.keys())
+        )
+
+        if self.verbose and bundle_keys != architectures:
+            print(f"  Bundle keys (after xnack collapse): {', '.join(bundle_keys)}")
+
+        # Phase 5: Create host wheel
+        host_filename = compute_wheel_filename(
+            identity.name, identity.version, identity
+        )
+        host_staging = output_dir / (host_filename.removesuffix(".whl") + ".staging")
+        if host_staging.exists():
+            shutil.rmtree(host_staging)
+
+        if self.verbose:
+            print(f"\nPhase 5: Creating host wheel: {host_filename}")
+            print(f"  Copying wheel contents to staging...")
+
+        _copy_tree(wheel_root, host_staging)
+        if self.verbose:
+            print(f"  Copy complete. Transforming fat binaries...")
+        self._transform_host_binaries(host_staging, fat_binaries, identity, group_name)
+
+        # Remove database files from host staging
+        if db_refs_by_arch:
+            self._remove_database_files_from_host(host_staging, db_refs_by_arch)
+
+        # Rewrite host METADATA (classic: extras only, no variant markers)
+        self._rewrite_host_metadata(
+            host_staging, identity, set(bundle_keys), include_variant_markers=False
+        )
+
+        # Regenerate RECORD for host wheel
+        if self.verbose:
+            print(f"  Generating RECORD (hashing all files)...")
+        record_content = generate_record(
+            host_staging, identity.dist_info_name, verbose=self.verbose
+        )
+        record_path = host_staging / identity.dist_info_name / "RECORD"
+        record_path.write_text(record_content, encoding="utf-8")
+
+        # Package host wheel
+        if output_format == "wheel":
+            host_output = output_dir / host_filename
+            if self.verbose:
+                print(f"  Zipping to {host_output}")
+            zip_wheel(host_staging, host_output)
+        else:
+            host_output = output_dir / host_filename.removesuffix(".whl")
+            if host_output.exists():
+                shutil.rmtree(host_output)
+            host_staging.rename(host_output)
+
+        # Phase 5b: Generate variant wheel (PEP 817) if requested
+        variant_output = None
+        if self.generate_variant_wheel:
+            variant_output = self._create_variant_wheel(
+                host_staging if output_format == "wheel" else host_output,
+                identity,
+                set(bundle_keys),
+                output_dir,
+                output_format,
+            )
+
+        # Clean up host staging (deferred until after variant wheel uses it)
+        if output_format == "wheel" and host_staging.exists():
+            shutil.rmtree(host_staging)
+
+        # Phase 6: Create device wheels (one per bundle key)
+        device_paths: dict[str, Path] = {}
+        for bundle_key in bundle_keys:
+            device_path = self._create_device_wheel(
+                bundle_key,
+                identity,
+                group_name,
+                kpacks_by_bundle.get(bundle_key, []),
+                db_refs_by_bundle.get(bundle_key, []),
+                output_dir,
+                output_format,
+            )
+            device_paths[bundle_key] = device_path
+
+        return SplitResult(
+            host_wheel_path=host_output,
+            variant_wheel_path=variant_output,
+            device_wheel_paths=device_paths,
+            architectures_found=architectures,
+            fat_binaries_processed=len(fat_binaries),
+        )
+
+    def _rewrite_host_metadata(
+        self,
+        host_staging: Path,
+        identity: WheelIdentity,
+        bundle_keys: set[str],
+        include_variant_markers: bool = False,
+    ) -> None:
+        """Rewrite host METADATA to add extras and deps.
+
+        Inserts into the existing METADATA header section:
+          - Requires-Dist: rocm-bootstrap
+          - Per-target Provides-Extra + Requires-Dist (extras-based)
+          - Provides-Extra: all (with all device wheels)
+          - If include_variant_markers: also adds variant_properties markers
+        """
+        metadata_path = host_staging / identity.dist_info_name / "METADATA"
+        existing = metadata_path.read_text(encoding="utf-8")
+
+        lines: list[str] = []
+        version = identity.version
+
+        # Add rocm-bootstrap dependency
+        lines.append("Requires-Dist: rocm-bootstrap")
+
+        # Collect target-level bundle keys (those are the ones we generate
+        # extras and variant markers for).
+        target_keys: list[str] = []
+        for key in sorted(bundle_keys):
+            bundle = rocm_bootstrap.lookup_bundle(key)
+            if bundle.level == rocm_bootstrap.PackagingLevel.TARGET:
+                target_keys.append(key)
+
+        # For each target, compute packaging chain and generate extras
+        all_device_dist_names: set[str] = set()
+        for target_name in target_keys:
+            chain = rocm_bootstrap.packaging_chain(target_name)
+            lines.append(f"Provides-Extra: {target_name}")
+
+            for chain_bundle in chain:
+                if chain_bundle.key not in bundle_keys:
+                    continue
+                dist_name = rocm_bootstrap.device_dist_name(
+                    self.device_package_prefix, chain_bundle
+                )
+                all_device_dist_names.add(dist_name)
+                # NOTE: This format is parsed verbatim by
+                # _add_variant_markers_to_metadata(). If you change it,
+                # update the regex there too.
+                lines.append(
+                    f"Requires-Dist: {dist_name} == {version}; "
+                    f'extra == "{target_name}"'
+                )
+                if include_variant_markers:
+                    lines.append(
+                        f"Requires-Dist: {dist_name} == {version}; "
+                        f'"amd :: gfx_arch :: {target_name}" in variant_properties'
+                    )
+
+        # Also add non-target bundle keys (family, sub-family) to the "all" set
+        for key in sorted(bundle_keys):
+            bundle = rocm_bootstrap.lookup_bundle(key)
+            if bundle.level != rocm_bootstrap.PackagingLevel.TARGET:
+                dist_name = rocm_bootstrap.device_dist_name(
+                    self.device_package_prefix, bundle
+                )
+                all_device_dist_names.add(dist_name)
+
+        # "all" extra: includes every device wheel
+        lines.append("Provides-Extra: all")
+        for dist_name in sorted(all_device_dist_names):
+            lines.append(f"Requires-Dist: {dist_name} == {version}; " f'extra == "all"')
+
+        # Insert new headers before the body (after the last header line).
+        # METADATA uses RFC 822 format: headers, blank line, body.
+        # Find the first blank line that separates headers from body.
+        header_end = existing.find("\n\n")
+        if header_end != -1:
+            header_section = existing[: header_end + 1]  # includes trailing \n
+            body_section = existing[header_end + 1 :]  # includes leading \n
+            new_content = header_section + "\n".join(lines) + "\n" + body_section
+        else:
+            # No body — just append
+            if not existing.endswith("\n"):
+                existing += "\n"
+            new_content = existing + "\n".join(lines) + "\n"
+
+        metadata_path.write_text(new_content, encoding="utf-8")
+
+        if self.verbose:
+            n_extras = len(target_keys) + 1  # +1 for "all"
+            n_device = len(all_device_dist_names)
+            label = "variant" if include_variant_markers else "classic"
+            print(
+                f"  Host metadata ({label}): {n_extras} extras, "
+                f"{n_device} device wheels referenced"
+            )
+
+    def _create_variant_wheel(
+        self,
+        host_staging_or_dir: Path,
+        identity: WheelIdentity,
+        bundle_keys: set[str],
+        output_dir: Path,
+        output_format: str,
+    ) -> Path:
+        """Create a PEP 817 variant wheel from the classic host staging.
+
+        The variant wheel has the same content as the classic host wheel but with:
+        - variant_properties markers in METADATA alongside extras
+        - variant.json in dist-info with provider/variant metadata
+
+        For .whl output, host_staging_or_dir is the staging dir (still present).
+        For directory output, it's the renamed output dir (we copy from it).
+        """
+        if self.verbose:
+            print(f"\nPhase 5b: Creating variant wheel")
+
+        # Create variant staging by copying classic host
+        variant_staging = output_dir / f"{identity.name}-{self.variant_label}.staging"
+        if variant_staging.exists():
+            shutil.rmtree(variant_staging)
+        _copy_tree(host_staging_or_dir, variant_staging)
+
+        # Rewrite METADATA with variant markers (overwrite the classic METADATA)
+        # We need to start from the original METADATA, not the already-rewritten one.
+        # But the staging already has the classic rewrite. So we re-run the rewrite
+        # on the copy — since _rewrite_host_metadata reads existing content and
+        # inserts headers, we need to start fresh. Easiest: restore original METADATA
+        # from the classic staging (which has extras already), then just add variant
+        # markers. Actually, simpler: just re-read the already-rewritten classic
+        # METADATA and add variant markers to it.
+        self._add_variant_markers_to_metadata(variant_staging, identity, bundle_keys)
+
+        # Add variant.json
+        self._write_variant_json(variant_staging, identity, bundle_keys)
+
+        # Regenerate RECORD
+        record_content = generate_record(
+            variant_staging, identity.dist_info_name, verbose=False
+        )
+        record_path = variant_staging / identity.dist_info_name / "RECORD"
+        record_path.write_text(record_content, encoding="utf-8")
+
+        # Package variant wheel
+        # PEP 817 filename: {name}-{ver}-{py}-{abi}-{plat}-{variant_label}.whl
+        variant_filename = compute_wheel_filename(
+            identity.name, identity.version, identity
+        ).replace(".whl", f"-{self.variant_label}.whl")
+
+        if output_format == "wheel":
+            variant_output = output_dir / variant_filename
+            if self.verbose:
+                print(f"  Zipping variant wheel to {variant_output}")
+            zip_wheel(variant_staging, variant_output)
+            shutil.rmtree(variant_staging)
+        else:
+            variant_output = output_dir / variant_filename.removesuffix(".whl")
+            if variant_output.exists():
+                shutil.rmtree(variant_output)
+            variant_staging.rename(variant_output)
+
+        if self.verbose:
+            print(f"  Variant wheel: {variant_output}")
+
+        return variant_output
+
+    def _add_variant_markers_to_metadata(
+        self,
+        staging: Path,
+        identity: WheelIdentity,
+        bundle_keys: set[str],
+    ) -> None:
+        """Add variant_properties markers to an already-rewritten METADATA.
+
+        The classic host METADATA already has extras-based Requires-Dist lines.
+        This adds the corresponding variant_properties marker lines after each
+        extras line for target-level bundle keys.
+        """
+        metadata_path = staging / identity.dist_info_name / "METADATA"
+        existing = metadata_path.read_text(encoding="utf-8")
+        version = identity.version
+
+        # Collect target keys and their packaging chains
+        new_lines: list[str] = []
+        for line in existing.splitlines():
+            new_lines.append(line)
+            # After each extras-based Requires-Dist for a device wheel,
+            # add the variant_properties version
+            if not line.startswith("Requires-Dist:") or "extra ==" not in line:
+                continue
+            if 'extra == "all"' in line:
+                continue
+            # Extract the dist requirement and target name.
+            # This regex must match the format generated by _rewrite_host_metadata():
+            #   f"Requires-Dist: {dist_name} == {version}; "
+            #   f'extra == "{target_name}"'
+            # If that format changes, this regex must be updated to match.
+            match = re.match(r'(Requires-Dist: .+ == .+); extra == "(\w+)"', line)
+            if match:
+                req_part = match.group(1)
+                target_name = match.group(2)
+                new_lines.append(
+                    f"{req_part}; "
+                    f'"amd :: gfx_arch :: {target_name}" in variant_properties'
+                )
+
+        metadata_path.write_text("\n".join(new_lines) + "\n", encoding="utf-8")
+
+        if self.verbose:
+            print(f"  Added variant markers to METADATA")
+
+    def _write_variant_json(
+        self,
+        staging: Path,
+        identity: WheelIdentity,
+        bundle_keys: set[str],
+    ) -> None:
+        """Write variant.json to the dist-info directory.
+
+        Contains PEP 817 variant provider and property metadata.
+        """
+        target_keys = []
+        for key in sorted(bundle_keys):
+            bundle = rocm_bootstrap.lookup_bundle(key)
+            if bundle.level == rocm_bootstrap.PackagingLevel.TARGET:
+                target_keys.append(key)
+
+        variants = {}
+        for target in target_keys:
+            variants[target] = {"amd": {"gfx_arch": [target]}}
+
+        variant_metadata = {
+            "providers": {
+                "amd": {
+                    "install-time": True,
+                    "plugin-api": "amd_variant_provider.plugin:AMDVariantPlugin",
+                    "requires": ["amd-variant-provider >= 1.0"],
+                }
+            },
+            "default-priorities": {
+                "namespace": ["amd"],
+                "property": {"amd": {"gfx_arch": target_keys}},
+            },
+            "variants": variants,
+        }
+
+        variant_json_path = staging / identity.dist_info_name / "variant.json"
+        variant_json_path.write_text(
+            json.dumps(variant_metadata, indent=2) + "\n", encoding="utf-8"
+        )
+
+        if self.verbose:
+            print(f"  Wrote variant.json ({len(target_keys)} targets)")
+
+    def _scan_fat_binaries(self, overlay_dir: Path) -> list[FatBinaryInfo]:
+        """Scan for fat binaries under the overlay root.
+
+        Uses a lightweight header scan (is_fat_binary) that reads only a few
+        KB per file — section headers for ELF, PE section table for COFF.
+        Non-binary files are rejected by magic number check without reading
+        further. Works for both Linux (ELF) and Windows (PE/COFF) wheels.
+        """
+        fat_binaries: list[FatBinaryInfo] = []
+        checked = 0
+        for file_path, direntry in scan_directory(overlay_dir):
+            if not direntry.is_file(follow_symlinks=False):
+                continue
+            checked += 1
+            if is_fat_binary(file_path):
+                rel_path = file_path.relative_to(overlay_dir).as_posix()
+                fat_binaries.append(
+                    FatBinaryInfo(
+                        absolute_path=file_path,
+                        overlay_relative_path=rel_path,
+                    )
+                )
+                if self.verbose:
+                    size_mb = file_path.stat().st_size / (1024 * 1024)
+                    print(f"  Fat binary: {rel_path} ({size_mb:.1f} MB)")
+        if self.verbose:
+            print(f"  Scanned {checked} files, found {len(fat_binaries)} fat binaries")
+        return fat_binaries
+
+    def _scan_database_files(
+        self, overlay_dir: Path
+    ) -> dict[str, list[DatabaseFileRef]]:
+        """Scan for arch-specific database files using registered handlers.
+
+        Returns:
+            Dict mapping normalized architecture to list of DatabaseFileRef.
+        """
+        if self.verbose:
+            print(f"\nPhase 2b: Scanning for database files")
+            print(f"  Handlers: {', '.join(h.name() for h in self.database_handlers)}")
+
+        refs_by_arch: dict[str, list[DatabaseFileRef]] = defaultdict(list)
+        counts_by_handler: dict[str, int] = defaultdict(int)
+        size_by_handler: dict[str, int] = defaultdict(int)
+
+        for file_path, direntry in scan_directory(overlay_dir):
+            if not direntry.is_file(follow_symlinks=False):
+                continue
+            for handler in self.database_handlers:
+                raw_arch = handler.detect(file_path, overlay_dir)
+                if raw_arch is not None:
+                    arch = _normalize_arch(raw_arch)
+                    rel_path = file_path.relative_to(overlay_dir).as_posix()
+                    refs_by_arch[arch].append(
+                        DatabaseFileRef(
+                            absolute_path=file_path,
+                            overlay_relative_path=rel_path,
+                            architecture=arch,
+                            handler_name=handler.name(),
+                        )
+                    )
+                    counts_by_handler[handler.name()] += 1
+                    size_by_handler[handler.name()] += direntry.stat().st_size
+                    break  # first handler wins
+
+        if self.verbose:
+            total_files = sum(counts_by_handler.values())
+            total_size = sum(size_by_handler.values())
+            print(
+                f"  Found {total_files} database files ({total_size / (1024*1024):.0f} MB)"
+            )
+            for name in sorted(counts_by_handler):
+                print(
+                    f"    {name}: {counts_by_handler[name]} files "
+                    f"({size_by_handler[name] / (1024*1024):.0f} MB)"
+                )
+
+        return refs_by_arch
+
+    def _remove_database_files_from_host(
+        self,
+        host_staging: Path,
+        db_refs_by_arch: dict[str, list[DatabaseFileRef]],
+    ) -> None:
+        """Remove database files from host staging directory."""
+        overlay_dir = host_staging / self.overlay_root
+        removed = 0
+        removed_bytes = 0
+        for refs in db_refs_by_arch.values():
+            for ref in refs:
+                host_file = overlay_dir / ref.overlay_relative_path
+                if host_file.exists():
+                    removed_bytes += host_file.stat().st_size
+                    host_file.unlink()
+                    removed += 1
+
+        # Clean up empty directories left behind
+        for dirpath, dirnames, filenames in os.walk(overlay_dir, topdown=False):
+            if not filenames and not dirnames:
+                try:
+                    Path(dirpath).rmdir()
+                except OSError:
+                    pass  # not empty or root
+
+        if self.verbose:
+            print(
+                f"  Removed {removed} database files from host "
+                f"({removed_bytes / (1024*1024):.0f} MB)"
+            )
+
+    def _extract_kernels(
+        self,
+        fat_binaries: list[FatBinaryInfo],
+        kernel_staging_dir: Path,
+    ) -> dict[str, list[ExtractedKernelRef]]:
+        """Extract device kernels from fat binaries to disk.
+
+        When jobs > 1, fat binaries are extracted in parallel using a process
+        pool. Kernel data is written to files under kernel_staging_dir to avoid
+        pickling large byte buffers through IPC.
+
+        Args:
+            fat_binaries: List of fat binaries to extract.
+            kernel_staging_dir: Directory for extracted kernel files.
+
+        Returns:
+            Dict mapping architecture to list of ExtractedKernelRef.
+        """
+        refs_by_arch: dict[str, list[ExtractedKernelRef]] = defaultdict(list)
+        total = len(fat_binaries)
+
+        phase_start = time.monotonic()
+
+        if self.jobs <= 1:
+            for idx, fb in enumerate(fat_binaries, 1):
+                if self.verbose:
+                    size_mb = fb.absolute_path.stat().st_size / (1024 * 1024)
+                    print(
+                        f"  [{idx}/{total}] Extracting: "
+                        f"{fb.overlay_relative_path} ({size_mb:.1f} MB)"
+                    )
+                t0 = time.monotonic()
+                refs = _extract_single_binary(
+                    fb.absolute_path,
+                    fb.overlay_relative_path,
+                    kernel_staging_dir,
+                )
+                elapsed = time.monotonic() - t0
+                for r in refs:
+                    refs_by_arch[r.architecture].append(r)
+                if self.verbose:
+                    size_mb = fb.absolute_path.stat().st_size / (1024 * 1024)
+                    archs = sorted({r.architecture for r in refs})
+                    print(
+                        f"    -> {len(refs)} kernels, {elapsed:.1f}s, "
+                        f"{size_mb:.1f} MB, arches: {', '.join(archs)}"
+                    )
+        else:
+            if self.verbose:
+                print(f"  Using {self.jobs} parallel workers")
+            with ProcessPoolExecutor(max_workers=self.jobs) as executor:
+                future_to_fb: dict[object, tuple[FatBinaryInfo, float]] = {}
+                for fb in fat_binaries:
+                    future = executor.submit(
+                        _extract_single_binary,
+                        fb.absolute_path,
+                        fb.overlay_relative_path,
+                        kernel_staging_dir,
+                    )
+                    future_to_fb[future] = (fb, time.monotonic())
+
+                completed = 0
+                for future in as_completed(future_to_fb):
+                    completed += 1
+                    fb, submit_time = future_to_fb[future]
+                    elapsed = time.monotonic() - submit_time
+                    refs = future.result()
+                    for r in refs:
+                        refs_by_arch[r.architecture].append(r)
+                    if self.verbose:
+                        size_mb = fb.absolute_path.stat().st_size / (1024 * 1024)
+                        archs = sorted({r.architecture for r in refs})
+                        print(
+                            f"  [{completed}/{total}] {fb.overlay_relative_path} "
+                            f"({len(refs)} kernels, {elapsed:.1f}s, "
+                            f"{size_mb:.1f} MB, arches: {', '.join(archs)})"
+                        )
+
+        if self.verbose:
+            total_elapsed = time.monotonic() - phase_start
+            total_kernels = sum(len(v) for v in refs_by_arch.values())
+            print(
+                f"  Extraction complete: {total_kernels} kernels in {total_elapsed:.1f}s"
+            )
+
+        return refs_by_arch
+
+    def _create_kpack_archives(
+        self,
+        refs_by_arch: dict[str, list[ExtractedKernelRef]],
+        group_name: str,
+        output_dir: Path,
+    ) -> dict[str, Path]:
+        """Create kpack archives, one per architecture.
+
+        Reads kernel data from files referenced by ExtractedKernelRef objects.
+        When jobs > 1, archives are created in parallel (each arch is independent).
+
+        Returns:
+            Dict of arch -> kpack file path (in a temp staging area under output_dir).
+        """
+        kpack_staging = output_dir / ".kpack_staging"
+        kpack_staging.mkdir(parents=True, exist_ok=True)
+
+        if self.verbose:
+            print(
+                f"\nPhase 4: Creating kpack archives ({len(refs_by_arch)} architectures)"
+            )
+
+        phase_start = time.monotonic()
+        kpack_paths: dict[str, Path] = {}
+
+        # Sort by kernel count descending so largest archives start first
+        sorted_arches = sorted(
+            refs_by_arch.items(), key=lambda kv: len(kv[1]), reverse=True
+        )
+
+        if self.jobs <= 1:
+            for arch, ref_list in sorted_arches:
+                result = _create_single_kpack(
+                    arch,
+                    ref_list,
+                    group_name,
+                    kpack_staging,
+                    self.compression,
+                    self.compression_level,
+                )
+                kpack_paths[result.arch] = result.kpack_path
+                if self.verbose:
+                    print(
+                        f"  {result.arch}: {result.num_kernels} kernels, "
+                        f"{result.kpack_size} bytes, {result.elapsed:.1f}s"
+                    )
+        else:
+            if self.verbose:
+                print(f"  Using {self.jobs} parallel workers")
+            total = len(sorted_arches)
+            with ProcessPoolExecutor(max_workers=self.jobs) as executor:
+                futures = {}
+                for arch, ref_list in sorted_arches:
+                    future = executor.submit(
+                        _create_single_kpack,
+                        arch,
+                        ref_list,
+                        group_name,
+                        kpack_staging,
+                        self.compression,
+                        self.compression_level,
+                    )
+                    futures[future] = arch
+
+                completed = 0
+                for future in as_completed(futures):
+                    completed += 1
+                    result = future.result()
+                    kpack_paths[result.arch] = result.kpack_path
+                    if self.verbose:
+                        print(
+                            f"  [{completed}/{total}] {result.arch}: "
+                            f"{result.num_kernels} kernels, "
+                            f"{result.kpack_size} bytes, {result.elapsed:.1f}s"
+                        )
+
+        if self.verbose:
+            total_elapsed = time.monotonic() - phase_start
+            total_size = sum(p.stat().st_size for p in kpack_paths.values())
+            print(
+                f"  Kpack complete: {len(kpack_paths)} archives, "
+                f"{total_size / (1024*1024):.0f} MB in {total_elapsed:.1f}s"
+            )
+
+        return kpack_paths
+
+    def _compute_kpack_search_pattern(
+        self, overlay_relative_path: str, group_name: str
+    ) -> str:
+        """Compute the @GFXARCH@ search pattern from a binary to its kpack file.
+
+        Args:
+            overlay_relative_path: Path relative to overlay root (e.g., "lib/libtorch_hip.so").
+            group_name: Group name for kpack files (e.g., "torch").
+
+        Returns:
+            Relative search pattern like "../.kpack/torch_@GFXARCH@.kpack".
+        """
+        parts = Path(overlay_relative_path).parts
+        # Depth = number of directory levels (excluding the file itself)
+        depth = len(parts) - 1
+
+        kpack_pattern = f".kpack/{group_name}_@GFXARCH@.kpack"
+        if depth == 0:
+            return kpack_pattern
+        up_path = "/".join([".."] * depth)
+        return f"{up_path}/{kpack_pattern}"
+
+    def _transform_host_binaries(
+        self,
+        host_staging: Path,
+        fat_binaries: list[FatBinaryInfo],
+        identity: WheelIdentity,
+        group_name: str,
+    ) -> None:
+        """Transform fat binaries in the host staging directory.
+
+        When jobs > 1, binary transformations run in parallel. Each binary
+        is transformed independently (separate input/output files, no shared
+        mutable state).
+        """
+        overlay_dir = host_staging / self.overlay_root
+
+        # Build per-binary arguments
+        all_args: list[TransformArgs] = []
+        for fb in fat_binaries:
+            binary_path = overlay_dir / fb.overlay_relative_path
+            if not binary_path.exists():
+                raise WheelSplitError(
+                    f"Fat binary not found in host staging: {fb.overlay_relative_path}"
+                )
+            all_args.append(
+                TransformArgs(
+                    binary_path=binary_path,
+                    temp_output=binary_path.with_suffix(
+                        binary_path.suffix + ".kpacked"
+                    ),
+                    search_pattern=self._compute_kpack_search_pattern(
+                        fb.overlay_relative_path, group_name
+                    ),
+                    kernel_name=fb.overlay_relative_path,
+                    overlay_relative_path=fb.overlay_relative_path,
+                )
+            )
+
+        if self.jobs <= 1:
+            # Serial path
+            for args in all_args:
+                if self.verbose:
+                    print(f"  Transforming: {args.overlay_relative_path}")
+                    print(f"    Search pattern: {args.search_pattern}")
+                result = _transform_single_binary(
+                    args.binary_path,
+                    args.temp_output,
+                    args.search_pattern,
+                    args.kernel_name,
+                    args.overlay_relative_path,
+                    self.verbose,
+                )
+                self._report_transform_result(result)
+        else:
+            # Parallel path
+            if self.verbose:
+                print(f"  Using {self.jobs} parallel workers for transformation")
+            with ProcessPoolExecutor(max_workers=self.jobs) as executor:
+                futures = {}
+                for args in all_args:
+                    future = executor.submit(
+                        _transform_single_binary,
+                        args.binary_path,
+                        args.temp_output,
+                        args.search_pattern,
+                        args.kernel_name,
+                        args.overlay_relative_path,
+                        False,  # verbose=False in workers
+                    )
+                    futures[future] = args.overlay_relative_path
+
+                completed = 0
+                total = len(futures)
+                for future in as_completed(futures):
+                    completed += 1
+                    result = future.result()
+                    if self.verbose:
+                        print(f"  [{completed}/{total}] ", end="")
+                        self._report_transform_result(result)
+
+    def _report_transform_result(self, result: TransformResult) -> None:
+        """Print verbose output for a single binary transformation."""
+        if not self.verbose:
+            return
+        if result.skipped:
+            print(f"  Skipping (no device code): {result.overlay_relative_path}")
+        else:
+            delta = result.new_size - result.original_size
+            if delta < 0:
+                print(
+                    f"  Transformed: {result.overlay_relative_path} "
+                    f"({result.new_size} bytes, saved {-delta} bytes)"
+                )
+            else:
+                print(
+                    f"  Transformed: {result.overlay_relative_path} "
+                    f"({result.new_size} bytes, +{delta} bytes overhead)"
+                )
+
+    def _create_device_wheel(
+        self,
+        bundle_key: str,
+        host_identity: WheelIdentity,
+        group_name: str,
+        kpack_entries: list[tuple[str, Path]],
+        db_refs: list[DatabaseFileRef],
+        output_dir: Path,
+        output_format: str,
+    ) -> Path:
+        """Create a device wheel for a specific bundle key.
+
+        Args:
+            bundle_key: Bundle key, e.g. "gfx942", "gfx11", "gfx12_0".
+            kpack_entries: List of (arch, kpack_path) tuples. Multiple entries
+                occur when xnack variants collapse into the same bundle key.
+            db_refs: Database files to include for this bundle.
+
+        Returns:
+            Path to the generated device wheel (file or directory).
+        """
+        device_name = _bundle_key_to_dist_name(self.device_package_prefix, bundle_key)
+        device_dist_info = compute_dist_info_name(device_name, host_identity.version)
+        device_filename = compute_wheel_filename(
+            device_name, host_identity.version, host_identity
+        )
+
+        if self.verbose:
+            print(f"\nCreating device wheel: {device_filename}")
+
+        # Create staging directory
+        staging = output_dir / (device_filename.removesuffix(".whl") + ".staging")
+        if staging.exists():
+            shutil.rmtree(staging)
+        staging.mkdir()
+
+        # Place kpack file(s) under overlay_root/.kpack/
+        # Multiple entries when xnack variants (gfx942, gfx942:xnack+, etc.)
+        # collapse into the same bundle key.
+        for arch, kpack_path in kpack_entries:
+            kpack_dest_dir = staging / self.overlay_root / ".kpack"
+            kpack_dest_dir.mkdir(parents=True, exist_ok=True)
+            kpack_dest = kpack_dest_dir / f"{group_name}_{arch}.kpack"
+            shutil.copy2(kpack_path, kpack_dest)
+
+        # Copy database files preserving their overlay-relative paths
+        for ref in db_refs:
+            dest = staging / self.overlay_root / ref.overlay_relative_path
+            dest.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copy2(ref.absolute_path, dest)
+
+        # Create dist-info
+        dist_info_dir = staging / device_dist_info
+        dist_info_dir.mkdir()
+
+        # METADATA
+        metadata_content = generate_device_metadata(
+            host_identity,
+            bundle_key,
+            self.device_package_prefix,
+            self.device_requires_dist,
+        )
+        (dist_info_dir / "METADATA").write_text(metadata_content, encoding="utf-8")
+
+        # WHEEL
+        wheel_content = generate_wheel_file(host_identity)
+        (dist_info_dir / "WHEEL").write_text(wheel_content, encoding="utf-8")
+
+        # top_level.txt
+        (dist_info_dir / "top_level.txt").write_text(
+            f"{self.overlay_root}\n", encoding="utf-8"
+        )
+
+        # RECORD (must be last)
+        record_content = generate_record(staging, device_dist_info)
+        (dist_info_dir / "RECORD").write_text(record_content, encoding="utf-8")
+
+        # Package
+        if output_format == "wheel":
+            device_output = output_dir / device_filename
+            zip_wheel(staging, device_output)
+            shutil.rmtree(staging)
+        else:
+            device_output = output_dir / device_filename.removesuffix(".whl")
+            if device_output.exists():
+                shutil.rmtree(device_output)
+            staging.rename(device_output)
+
+        if self.verbose:
+            print(f"  Written: {device_output}")
+
+        return device_output

--- a/shared/kpack/runtime/src/isa_target_match.h
+++ b/shared/kpack/runtime/src/isa_target_match.h
@@ -80,9 +80,10 @@ bool for_each_compatible_target(const char* agent_isa, Fn&& callback) {
     return callback(parsed.processor);
   }
 
-  // Iterate power set of features, descending cardinality (most specific first).
-  // Bit (n-1-i) corresponds to features[i], so descending mask order drops
-  // features from the right first — preserving the original feature ordering.
+  // Iterate power set of features, descending cardinality (most specific
+  // first). Bit (n-1-i) corresponds to features[i], so descending mask order
+  // drops features from the right first — preserving the original feature
+  // ordering.
   const unsigned full_mask = (1u << n) - 1;
   for (unsigned mask = full_mask;; --mask) {
     std::string candidate = parsed.processor;

--- a/shared/kpack/runtime/tests/test_isa_target_match.cpp
+++ b/shared/kpack/runtime/tests/test_isa_target_match.cpp
@@ -1,12 +1,12 @@
 // Copyright (c) 2025 Advanced Micro Devices, Inc.
 // SPDX-License-Identifier: MIT
 
-#include "isa_target_match.h"
-
 #include <gtest/gtest.h>
 
 #include <string>
 #include <vector>
+
+#include "isa_target_match.h"
 
 namespace {
 
@@ -25,8 +25,7 @@ using Vec = std::vector<std::string>;
 // --- strip_target_prefix ---
 
 TEST(StripTargetPrefix, StripsAmdgcnPrefix) {
-  EXPECT_EQ(kpack::strip_target_prefix("amdgcn-amd-amdhsa--gfx942"),
-            "gfx942");
+  EXPECT_EQ(kpack::strip_target_prefix("amdgcn-amd-amdhsa--gfx942"), "gfx942");
 }
 
 TEST(StripTargetPrefix, StripsAmdgcnPrefixWithFeatures) {
@@ -101,27 +100,27 @@ TEST(IsaTargetMatch, ConsumerCardGfx1100) {
 
 TEST(IsaTargetMatch, TwoFeaturesMostSpecificFirst) {
   EXPECT_EQ(expand("gfx942:sramecc+:xnack-"),
-            (Vec{"gfx942:sramecc+:xnack-", "gfx942:sramecc+",
-                 "gfx942:xnack-", "gfx942"}));
+            (Vec{"gfx942:sramecc+:xnack-", "gfx942:sramecc+", "gfx942:xnack-",
+                 "gfx942"}));
 }
 
 TEST(IsaTargetMatch, TwoFeaturesWithPrefix) {
   EXPECT_EQ(expand("amdgcn-amd-amdhsa--gfx942:sramecc+:xnack-"),
-            (Vec{"gfx942:sramecc+:xnack-", "gfx942:sramecc+",
-                 "gfx942:xnack-", "gfx942"}));
+            (Vec{"gfx942:sramecc+:xnack-", "gfx942:sramecc+", "gfx942:xnack-",
+                 "gfx942"}));
 }
 
 TEST(IsaTargetMatch, AsanAgent) {
   // ASAN requires xnack+, hardware also has sramecc+
   EXPECT_EQ(expand("gfx942:sramecc+:xnack+"),
-            (Vec{"gfx942:sramecc+:xnack+", "gfx942:sramecc+",
-                 "gfx942:xnack+", "gfx942"}));
+            (Vec{"gfx942:sramecc+:xnack+", "gfx942:sramecc+", "gfx942:xnack+",
+                 "gfx942"}));
 }
 
 TEST(IsaTargetMatch, MixedFeatureValues) {
   EXPECT_EQ(expand("gfx942:sramecc-:xnack+"),
-            (Vec{"gfx942:sramecc-:xnack+", "gfx942:sramecc-",
-                 "gfx942:xnack+", "gfx942"}));
+            (Vec{"gfx942:sramecc-:xnack+", "gfx942:sramecc-", "gfx942:xnack+",
+                 "gfx942"}));
 }
 
 // --- for_each_compatible_target: single feature ---
@@ -149,19 +148,15 @@ TEST(IsaTargetMatch, GenericIsaWithPrefix) {
 
 TEST(IsaTargetMatch, Gfx950TwoFeatures) {
   EXPECT_EQ(expand("gfx950:sramecc+:xnack-"),
-            (Vec{"gfx950:sramecc+:xnack-", "gfx950:sramecc+",
-                 "gfx950:xnack-", "gfx950"}));
+            (Vec{"gfx950:sramecc+:xnack-", "gfx950:sramecc+", "gfx950:xnack-",
+                 "gfx950"}));
 }
 
 // --- for_each_compatible_target: edge cases ---
 
-TEST(IsaTargetMatch, EmptyString) {
-  EXPECT_EQ(expand(""), Vec{});
-}
+TEST(IsaTargetMatch, EmptyString) { EXPECT_EQ(expand(""), Vec{}); }
 
-TEST(IsaTargetMatch, Nullptr) {
-  EXPECT_EQ(expand(nullptr), Vec{});
-}
+TEST(IsaTargetMatch, Nullptr) { EXPECT_EQ(expand(nullptr), Vec{}); }
 
 // --- for_each_compatible_target: early termination ---
 
@@ -199,11 +194,11 @@ TEST(IsaTargetMatch, EarlyTerminationOnThirdMatch) {
 TEST(IsaTargetMatch, NoMatchReturnsAllCandidates) {
   // No match — all candidates should be visited
   std::vector<std::string> seen;
-  bool found = kpack::for_each_compatible_target(
-      "gfx942:sramecc+:xnack-", [&](const std::string& t) {
-        seen.push_back(t);
-        return false;  // no match
-      });
+  bool found = kpack::for_each_compatible_target("gfx942:sramecc+:xnack-",
+                                                 [&](const std::string& t) {
+                                                   seen.push_back(t);
+                                                   return false;  // no match
+                                                 });
 
   EXPECT_FALSE(found);
   EXPECT_EQ(seen.size(), 4u);

--- a/shared/kpack/tests/elf/test_surgery.py
+++ b/shared/kpack/tests/elf/test_surgery.py
@@ -21,7 +21,21 @@ from rocm_kpack.elf import (
     PT_LOAD,
     SHF_ALLOC,
 )
-from rocm_kpack.elf.types import ProgramHeader, page_align_offset
+from rocm_kpack.elf.types import (
+    ElfHeader,
+    ProgramHeader,
+    ProgramHeader as PH,
+    SectionHeader as SH,
+    ELF64_EHDR_SIZE,
+    ELF64_PHDR_SIZE,
+    ELF64_SHDR_SIZE,
+    PF_R,
+    PF_X,
+    SHT_NULL,
+    SHT_STRTAB,
+    PAGE_SIZE,
+    page_align_offset,
+)
 
 
 class TestElfSurgery:
@@ -244,6 +258,142 @@ class TestZeroPage:
         assert verify_result.passed, f"Errors: {verify_result.errors}"
 
 
+def _build_synthetic_elf(phdr_capacity: int, phdr_count: int = 2) -> bytearray:
+    """Build a minimal valid ELF binary with controllable spare phdr slots.
+
+    Creates an ELF with:
+    - ELF header at offset 0
+    - phdr table at offset 64 with room for `phdr_capacity` entries
+    - `phdr_count` actual program headers (PT_LOAD covering ehdr+phdr, PT_LOAD for content)
+    - A .shstrtab section and section header table
+    - Content placed after the phdr gap so get_min_content_offset() works
+
+    Such ELF files with spare phdr slots are common in practice — prior ELF
+    transformations (notably patchelf) often enlarge the PHDR table, leaving
+    unused slots between e_phnum and the allocated capacity.
+
+    This is intentionally gross — it exists to test one specific corner case
+    in _write_in_place() where e_phnum < phdr_capacity.
+    """
+    assert phdr_count <= phdr_capacity
+
+    phdr_table_size = phdr_capacity * ELF64_PHDR_SIZE
+    # Content starts right after the phdr region (page-aligned)
+    content_offset = ELF64_EHDR_SIZE + phdr_table_size
+    # Pad to 8-byte alignment for section data
+    content_offset = (content_offset + 7) & ~7
+
+    # Section string table: "\0.shstrtab\0"
+    shstrtab_data = b"\x00.shstrtab\x00"
+    shstrtab_offset = content_offset
+    shstrtab_size = len(shstrtab_data)
+
+    # Some dummy content to act as a loadable segment
+    dummy_content = b"\xcc" * 64  # int3 padding
+    dummy_offset = shstrtab_offset + shstrtab_size
+    dummy_offset = (dummy_offset + 7) & ~7  # align
+
+    # Section headers go after all content
+    shdr_offset = dummy_offset + len(dummy_content)
+    shdr_offset = (shdr_offset + 7) & ~7  # align
+
+    # 3 section headers: SHT_NULL, .shstrtab, (we keep it minimal)
+    num_shdrs = 2
+
+    total_size = shdr_offset + num_shdrs * ELF64_SHDR_SIZE
+    data = bytearray(total_size)
+
+    # -- ELF Header --
+    e_ident = bytearray(16)
+    e_ident[0:4] = b"\x7fELF"
+    e_ident[4] = 2  # ELFCLASS64
+    e_ident[5] = 1  # ELFDATA2LSB
+    e_ident[6] = 1  # EV_CURRENT
+    ehdr = ElfHeader(
+        e_ident=bytes(e_ident),
+        e_type=3,  # ET_DYN (shared/PIE)
+        e_machine=0x3E,  # EM_X86_64
+        e_version=1,
+        e_entry=0,
+        e_phoff=ELF64_EHDR_SIZE,
+        e_shoff=shdr_offset,
+        e_flags=0,
+        e_ehsize=ELF64_EHDR_SIZE,
+        e_phentsize=ELF64_PHDR_SIZE,
+        e_phnum=phdr_count,
+        e_shentsize=ELF64_SHDR_SIZE,
+        e_shnum=num_shdrs,
+        e_shstrndx=1,  # .shstrtab is section 1
+    )
+    ehdr.write_to(data, 0)
+
+    # -- Program headers --
+    # PT_LOAD 0: covers ELF header + phdr table (vaddr 0x0)
+    ph0 = PH(
+        p_type=PT_LOAD,
+        p_flags=PF_R,
+        p_offset=0,
+        p_vaddr=0x0,
+        p_paddr=0x0,
+        p_filesz=content_offset,
+        p_memsz=content_offset,
+        p_align=PAGE_SIZE,
+    )
+    ph0.write_to(data, ELF64_EHDR_SIZE)
+
+    # PT_LOAD 1: covers dummy content
+    ph1 = PH(
+        p_type=PT_LOAD,
+        p_flags=PF_R | PF_X,
+        p_offset=dummy_offset,
+        p_vaddr=PAGE_SIZE + dummy_offset,  # at next page + same page offset
+        p_paddr=PAGE_SIZE + dummy_offset,
+        p_filesz=len(dummy_content),
+        p_memsz=len(dummy_content),
+        p_align=PAGE_SIZE,
+    )
+    ph1.write_to(data, ELF64_EHDR_SIZE + ELF64_PHDR_SIZE)
+
+    # Remaining phdr slots are zero (PT_NULL) — this is valid
+
+    # -- Section content --
+    data[shstrtab_offset : shstrtab_offset + shstrtab_size] = shstrtab_data
+    data[dummy_offset : dummy_offset + len(dummy_content)] = dummy_content
+
+    # -- Section headers --
+    # Section 0: SHT_NULL (required)
+    sh_null = SH(
+        sh_name=0,
+        sh_type=SHT_NULL,
+        sh_flags=0,
+        sh_addr=0,
+        sh_offset=0,
+        sh_size=0,
+        sh_link=0,
+        sh_info=0,
+        sh_addralign=0,
+        sh_entsize=0,
+    )
+    sh_null.write_to(data, shdr_offset)
+
+    # Section 1: .shstrtab
+    sh_strtab = SH(
+        sh_name=1,  # offset of ".shstrtab" in shstrtab_data
+        sh_type=SHT_STRTAB,
+        sh_flags=0,
+        sh_addr=0,
+        sh_offset=shstrtab_offset,
+        sh_size=shstrtab_size,
+        sh_link=0,
+        sh_info=0,
+        sh_addralign=1,
+        sh_entsize=0,
+    )
+    sh_strtab.write_to(data, shdr_offset + ELF64_SHDR_SIZE)
+
+    return data
+
+
 class TestProgramHeaderManager:
     """Tests for ProgramHeaderManager."""
 
@@ -280,6 +430,55 @@ class TestProgramHeaderManager:
         # Should be page-aligned and after all existing segments
         assert vaddr % 0x1000 == 0
         assert vaddr >= manager.get_max_vaddr()
+
+    def test_apply_in_place_with_added_header(self, tmp_path: Path):
+        """Adding a phdr when spare slots exist must write in place.
+
+        Regression test: _write_in_place() used to call
+        surgery.update_program_header(i) for the new index before updating
+        e_phnum, causing 'Invalid program header index' on binaries where
+        phdr capacity > phdr count (e.g. librccl.so with 13 headers and
+        418 available slots).
+        """
+        # Build a synthetic ELF: 2 phdrs used, room for 8
+        data = _build_synthetic_elf(phdr_capacity=8, phdr_count=2)
+        surgery = ElfSurgery(data)
+
+        assert surgery.ehdr.e_phnum == 2
+
+        manager = ProgramHeaderManager(surgery)
+
+        # Verify spare capacity exists (should not need relocation)
+        capacity = manager._get_current_capacity()
+        assert capacity >= 3, f"Expected spare slots, got capacity={capacity}"
+
+        # Add a new PT_LOAD
+        vaddr = manager.allocate_vaddr()
+        file_offset = page_align_offset(len(surgery.data), vaddr)
+        new_phdr = create_load_segment(
+            vaddr=vaddr, file_offset=file_offset, size=0x1000
+        )
+        manager.add_program_header(new_phdr)
+
+        # This is the line that fails without the fix:
+        # ValueError: Invalid program header index: 2
+        result = manager.apply()
+
+        assert not result.relocated, "Should have written in place, not relocated"
+        assert surgery.ehdr.e_phnum == 3
+
+        # Round-trip: save, reload, verify the new header persists
+        output = tmp_path / "synthetic.so"
+        surgery.save(output)
+        surgery2 = ElfSurgery.load(output)
+        assert surgery2.ehdr.e_phnum == 3
+
+        # Verify the new phdr was actually written
+        phdrs2 = list(surgery2.iter_program_headers())
+        assert len(phdrs2) == 3
+        _, written_phdr = phdrs2[2]
+        assert written_phdr.p_type == PT_LOAD
+        assert written_phdr.p_vaddr == vaddr
 
 
 class TestVerifyAll:

--- a/shared/kpack/tests/test_database_handlers.py
+++ b/shared/kpack/tests/test_database_handlers.py
@@ -7,8 +7,10 @@ import pytest
 from rocm_kpack.database_handlers import (
     RocBLASHandler,
     HipBLASLtHandler,
+    HipSparseLtHandler,
     AotritonHandler,
     MIOpenHandler,
+    WHEEL_TYPE_PRESETS,
     get_database_handlers,
     list_available_handlers,
 )
@@ -65,6 +67,8 @@ class TestRocBLASHandler:
             ("TensileLibrary_gfx90a.dat", "gfx90a"),
             ("TensileLibrary_gfx942.dat", "gfx942"),
             ("kernels_gfx1030.co", "gfx1030"),
+            ("TensileLibrary_lazy_gfx90a-xnack+.hsaco", "gfx90a-xnack+"),
+            ("Kernels.so-000-gfx942-xnack-.hsaco", "gfx942-xnack-"),
         ]
 
         for filename, expected_arch in test_cases:
@@ -74,6 +78,29 @@ class TestRocBLASHandler:
 
             result = handler.detect(file_path, prefix_root)
             assert result == expected_arch, f"Failed for {filename}"
+
+    def test_detect_xnack_plus(self, handler, prefix_root):
+        """Test detection of xnack+ suffix in filename."""
+        file_path = (
+            prefix_root
+            / "lib/rocblas/library/TensileLibrary_Type_HH_gfx90a-xnack+.hsaco"
+        )
+        file_path.parent.mkdir(parents=True, exist_ok=True)
+        file_path.touch()
+
+        result = handler.detect(file_path, prefix_root)
+        assert result == "gfx90a-xnack+"
+
+    def test_detect_xnack_minus(self, handler, prefix_root):
+        """Test detection of xnack- suffix in filename."""
+        file_path = (
+            prefix_root / "lib/rocblas/library/Kernels.so-000-gfx942-xnack-.hsaco"
+        )
+        file_path.parent.mkdir(parents=True, exist_ok=True)
+        file_path.touch()
+
+        result = handler.detect(file_path, prefix_root)
+        assert result == "gfx942-xnack-"
 
     def test_reject_wrong_directory(self, handler, prefix_root):
         """Test that files not in rocblas/library are rejected."""
@@ -103,11 +130,11 @@ class TestRocBLASHandler:
         assert result is None
 
     def test_reject_file_outside_prefix(self, handler, prefix_root):
-        """Test that files outside prefix root are rejected."""
+        """Files outside prefix root are a caller bug — must raise."""
         file_path = Path("/tmp/rocblas/library/TensileLibrary_gfx1100.dat")
 
-        result = handler.detect(file_path, prefix_root)
-        assert result is None
+        with pytest.raises(ValueError, match="is not under prefix_root"):
+            handler.detect(file_path, prefix_root)
 
 
 class TestHipBLASLtHandler:
@@ -161,6 +188,8 @@ class TestHipBLASLtHandler:
             ("TensileLibrary_gfx90a.dat", "gfx90a"),
             ("TensileLibrary_gfx942.dat", "gfx942"),
             ("kernels_gfx1030.co", "gfx1030"),
+            ("TensileLibrary_lazy_gfx90a-xnack+.hsaco", "gfx90a-xnack+"),
+            ("Kernels.so-000-gfx942-xnack-.hsaco", "gfx942-xnack-"),
         ]
 
         for filename, expected_arch in test_cases:
@@ -170,6 +199,29 @@ class TestHipBLASLtHandler:
 
             result = handler.detect(file_path, prefix_root)
             assert result == expected_arch, f"Failed for {filename}"
+
+    def test_detect_xnack_plus(self, handler, prefix_root):
+        """Test detection of xnack+ suffix in filename."""
+        file_path = (
+            prefix_root
+            / "lib/hipblaslt/library/TensileLibrary_Type_HH_gfx90a-xnack+.hsaco"
+        )
+        file_path.parent.mkdir(parents=True, exist_ok=True)
+        file_path.touch()
+
+        result = handler.detect(file_path, prefix_root)
+        assert result == "gfx90a-xnack+"
+
+    def test_detect_xnack_minus(self, handler, prefix_root):
+        """Test detection of xnack- suffix in filename."""
+        file_path = (
+            prefix_root / "lib/hipblaslt/library/Kernels.so-000-gfx942-xnack-.hsaco"
+        )
+        file_path.parent.mkdir(parents=True, exist_ok=True)
+        file_path.touch()
+
+        result = handler.detect(file_path, prefix_root)
+        assert result == "gfx942-xnack-"
 
     def test_reject_wrong_directory(self, handler, prefix_root):
         """Test that files not in hipblaslt/library are rejected."""
@@ -199,8 +251,67 @@ class TestHipBLASLtHandler:
         assert result is None
 
     def test_reject_file_outside_prefix(self, handler, prefix_root):
-        """Test that files outside prefix root are rejected."""
+        """Files outside prefix root are a caller bug — must raise."""
         file_path = Path("/tmp/hipblaslt/library/TensileLibrary_gfx1100.dat")
+
+        with pytest.raises(ValueError, match="is not under prefix_root"):
+            handler.detect(file_path, prefix_root)
+
+
+class TestHipSparseLtHandler:
+    """Tests for HipSparseLtHandler detection logic."""
+
+    @pytest.fixture
+    def handler(self):
+        return HipSparseLtHandler()
+
+    @pytest.fixture
+    def prefix_root(self, tmp_path):
+        root = tmp_path / "prefix"
+        root.mkdir()
+        return root
+
+    def test_name(self, handler):
+        assert handler.name() == "hipsparselt"
+
+    def test_detect_co_file(self, handler, prefix_root):
+        file_path = prefix_root / "lib/hipsparselt/library/extop_gfx942.co"
+        file_path.parent.mkdir(parents=True)
+        file_path.touch()
+
+        result = handler.detect(file_path, prefix_root)
+        assert result == "gfx942"
+
+    def test_detect_hsaco_file(self, handler, prefix_root):
+        file_path = prefix_root / "lib/hipsparselt/library/Kernels.so-000-gfx950.hsaco"
+        file_path.parent.mkdir(parents=True)
+        file_path.touch()
+
+        result = handler.detect(file_path, prefix_root)
+        assert result == "gfx950"
+
+    def test_detect_dat_file(self, handler, prefix_root):
+        file_path = (
+            prefix_root / "lib/hipsparselt/library/TensileLibrary_BB_BB_A_gfx942.dat"
+        )
+        file_path.parent.mkdir(parents=True)
+        file_path.touch()
+
+        result = handler.detect(file_path, prefix_root)
+        assert result == "gfx942"
+
+    def test_reject_wrong_directory(self, handler, prefix_root):
+        file_path = prefix_root / "lib/rocblas/library/something_gfx942.co"
+        file_path.parent.mkdir(parents=True)
+        file_path.touch()
+
+        result = handler.detect(file_path, prefix_root)
+        assert result is None
+
+    def test_reject_wrong_extension(self, handler, prefix_root):
+        file_path = prefix_root / "lib/hipsparselt/library/something_gfx942.so"
+        file_path.parent.mkdir(parents=True)
+        file_path.touch()
 
         result = handler.detect(file_path, prefix_root)
         assert result is None
@@ -224,53 +335,78 @@ class TestAotritonHandler:
         """Test handler name."""
         assert handler.name() == "aotriton"
 
-    def test_detect_file_in_gfx_directory(self, handler, prefix_root):
-        """Test detection of file in aotriton/kernels/gfx* directory."""
-        file_path = prefix_root / "lib/aotriton/kernels/gfx1100/kernel.hsaco"
-        file_path.parent.mkdir(parents=True)
-        file_path.touch()
-
-        result = handler.detect(file_path, prefix_root)
-        assert result == "gfx1100"
-
-    def test_detect_different_architecture(self, handler, prefix_root):
-        """Test detection of different gfx architecture."""
-        file_path = prefix_root / "share/aotriton/kernels/gfx1101/kernel.co"
-        file_path.parent.mkdir(parents=True)
-        file_path.touch()
-
-        result = handler.detect(file_path, prefix_root)
-        assert result == "gfx1101"
-
-    def test_detect_nested_path(self, handler, prefix_root):
-        """Test detection with nested path before aotriton."""
-        file_path = prefix_root / "lib/foo/bar/aotriton/kernels/gfx942/kernel.dat"
+    def test_detect_aks2_file(self, handler, prefix_root):
+        """Test detection of .aks2 file in aotriton.images layout."""
+        file_path = (
+            prefix_root / "lib/aotriton.images/amd-gfx942/flash/attn_fwd/kernel.aks2"
+        )
         file_path.parent.mkdir(parents=True)
         file_path.touch()
 
         result = handler.detect(file_path, prefix_root)
         assert result == "gfx942"
 
+    def test_detect_family_arch(self, handler, prefix_root):
+        """Test that family architecture names are mapped to bundle keys."""
+        file_path = (
+            prefix_root / "lib/aotriton.images/amd-gfx11xx/flash/attn_fwd/kernel.aks2"
+        )
+        file_path.parent.mkdir(parents=True)
+        file_path.touch()
+
+        result = handler.detect(file_path, prefix_root)
+        assert result == "gfx11"
+
     def test_detect_various_architectures(self, handler, prefix_root):
-        """Test detection of various gfx architecture formats."""
+        """Test detection of all real aotriton.images architecture directories.
+
+        Family/sub-family patterns are mapped to bundle keys:
+            gfx11xx → gfx11, gfx120x → gfx12_0.
+        Target names pass through unchanged.
+        """
         test_cases = [
-            ("gfx90a", "gfx90a"),
-            ("gfx942", "gfx942"),
-            ("gfx1030", "gfx1030"),
-            ("gfx1102", "gfx1102"),
+            ("amd-gfx90a", "gfx90a"),
+            ("amd-gfx942", "gfx942"),
+            ("amd-gfx950", "gfx950"),
+            ("amd-gfx11xx", "gfx11"),
+            ("amd-gfx120x", "gfx12_0"),
         ]
 
-        for arch_dir, expected_arch in test_cases:
-            file_path = prefix_root / f"lib/aotriton/kernels/{arch_dir}/kernel.hsaco"
+        for arch_dir, expected_bundle_key in test_cases:
+            file_path = (
+                prefix_root
+                / f"lib/aotriton.images/{arch_dir}/flash/attn_fwd/kernel.aks2"
+            )
             file_path.parent.mkdir(parents=True, exist_ok=True)
             file_path.touch()
 
             result = handler.detect(file_path, prefix_root)
-            assert result == expected_arch, f"Failed for {arch_dir}"
+            assert result == expected_bundle_key, f"Failed for {arch_dir}"
 
-    def test_reject_wrong_directory_structure(self, handler, prefix_root):
-        """Test that files not in aotriton/kernels are rejected."""
-        file_path = prefix_root / "lib/aotriton/other/gfx1100/kernel.hsaco"
+    def test_detect_signature_file(self, handler, prefix_root):
+        """Test that __signature__ file under arch dir is detected."""
+        file_path = prefix_root / "lib/aotriton.images/amd-gfx942/__signature__"
+        file_path.parent.mkdir(parents=True)
+        file_path.touch()
+
+        result = handler.detect(file_path, prefix_root)
+        assert result == "gfx942"
+
+    def test_detect_deeply_nested_file(self, handler, prefix_root):
+        """Test detection of file nested deep under architecture directory."""
+        file_path = (
+            prefix_root
+            / "lib/aotriton.images/amd-gfx950/flash/bwd_kernel_dk_dv/kernel.aks2"
+        )
+        file_path.parent.mkdir(parents=True)
+        file_path.touch()
+
+        result = handler.detect(file_path, prefix_root)
+        assert result == "gfx950"
+
+    def test_reject_no_amd_prefix(self, handler, prefix_root):
+        """Test that directories without amd- prefix are rejected."""
+        file_path = prefix_root / "lib/aotriton.images/gfx942/flash/kernel.aks2"
         file_path.parent.mkdir(parents=True)
         file_path.touch()
 
@@ -278,17 +414,8 @@ class TestAotritonHandler:
         assert result is None
 
     def test_reject_non_gfx_directory(self, handler, prefix_root):
-        """Test that files in non-gfx subdirectory are rejected."""
-        file_path = prefix_root / "lib/aotriton/kernels/common/kernel.hsaco"
-        file_path.parent.mkdir(parents=True)
-        file_path.touch()
-
-        result = handler.detect(file_path, prefix_root)
-        assert result is None
-
-    def test_reject_missing_kernels_directory(self, handler, prefix_root):
-        """Test that files not under kernels subdirectory are rejected."""
-        file_path = prefix_root / "lib/aotriton/gfx1100/kernel.hsaco"
+        """Test that non-gfx directories under aotriton.images are rejected."""
+        file_path = prefix_root / "lib/aotriton.images/amd-common/flash/kernel.aks2"
         file_path.parent.mkdir(parents=True)
         file_path.touch()
 
@@ -296,22 +423,20 @@ class TestAotritonHandler:
         assert result is None
 
     def test_reject_file_outside_prefix(self, handler, prefix_root):
-        """Test that files outside prefix root are rejected."""
-        file_path = Path("/tmp/aotriton/kernels/gfx1100/kernel.hsaco")
+        """Files outside prefix root are a caller bug — must raise."""
+        file_path = Path("/tmp/aotriton.images/amd-gfx942/kernel.aks2")
 
-        result = handler.detect(file_path, prefix_root)
-        assert result is None
+        with pytest.raises(ValueError, match="is not under prefix_root"):
+            handler.detect(file_path, prefix_root)
 
-    def test_detect_deeply_nested_file(self, handler, prefix_root):
-        """Test detection of file nested multiple levels under architecture directory."""
-        file_path = (
-            prefix_root / "lib/aotriton/kernels/gfx1100/subdir/deep/kernel.hsaco"
-        )
+    def test_reject_wrong_parent_directory(self, handler, prefix_root):
+        """Test that aotriton without .images suffix is rejected."""
+        file_path = prefix_root / "lib/aotriton/amd-gfx942/flash/kernel.aks2"
         file_path.parent.mkdir(parents=True)
         file_path.touch()
 
         result = handler.detect(file_path, prefix_root)
-        assert result == "gfx1100"
+        assert result is None
 
 
 class TestMIOpenHandler:
@@ -366,12 +491,45 @@ class TestMIOpenHandler:
         result = handler.detect(file_path, prefix_root)
         assert result == "gfx950"
 
+    def test_detect_db_txt(self, handler, prefix_root):
+        """MIOpen .db.txt files with concatenated arch+CU count."""
+        file_path = prefix_root / "share/miopen/db/gfx90878.db.txt"
+        file_path.parent.mkdir(parents=True)
+        file_path.touch()
+
+        result = handler.detect(file_path, prefix_root)
+        assert result == "gfx908"
+
+    def test_detect_fdb_txt(self, handler, prefix_root):
+        """MIOpen .HIP.fdb.txt files."""
+        file_path = prefix_root / "share/miopen/db/gfx942130.HIP.fdb.txt"
+        file_path.parent.mkdir(parents=True)
+        file_path.touch()
+
+        result = handler.detect(file_path, prefix_root)
+        assert result == "gfx942"
+
+    def test_detect_opencl_fdb_txt(self, handler, prefix_root):
+        file_path = prefix_root / "share/miopen/db/gfx900_56.OpenCL.fdb.txt"
+        file_path.parent.mkdir(parents=True)
+        file_path.touch()
+
+        result = handler.detect(file_path, prefix_root)
+        assert result == "gfx900"
+
     def test_detect_various_architectures(self, handler, prefix_root):
         test_cases = [
             ("gfx908.tn.model", "gfx908"),
             ("gfx90a_ConvHipIgemmGroupXdlops_encoder.ktn.model", "gfx90a"),
             ("gfx942_3d_metadata.tn.model", "gfx942"),
             ("gfx950_ConvHipImplicitGemm3DGroupFwdXdlops_metadata.tn.model", "gfx950"),
+            ("gfx90878.db.txt", "gfx908"),
+            ("gfx90a68.db.txt", "gfx90a"),
+            ("gfx942130.HIP.fdb.txt", "gfx942"),
+            ("gfx1030_36.db.txt", "gfx1030"),
+            ("gfx906_60.OpenCL.fdb.txt", "gfx906"),
+            ("gfx90a6e.HIP.fdb.txt", "gfx90a"),
+            ("gfx942e4.db.txt", "gfx942"),
         ]
 
         for filename, expected_arch in test_cases:
@@ -391,7 +549,7 @@ class TestMIOpenHandler:
         assert result is None
 
     def test_reject_wrong_extension(self, handler, prefix_root):
-        file_path = prefix_root / "share/miopen/db/gfx908.txt"
+        file_path = prefix_root / "share/miopen/db/gfx908.json"
         file_path.parent.mkdir(parents=True)
         file_path.touch()
 
@@ -407,10 +565,11 @@ class TestMIOpenHandler:
         assert result is None
 
     def test_reject_file_outside_prefix(self, handler, prefix_root):
+        """Files outside prefix root are a caller bug — must raise."""
         file_path = Path("/tmp/share/miopen/db/gfx908.tn.model")
 
-        result = handler.detect(file_path, prefix_root)
-        assert result is None
+        with pytest.raises(ValueError, match="is not under prefix_root"):
+            handler.detect(file_path, prefix_root)
 
 
 class TestDatabaseHandlerRegistry:
@@ -422,9 +581,10 @@ class TestDatabaseHandlerRegistry:
         assert isinstance(handlers, list)
         assert "rocblas" in handlers
         assert "hipblaslt" in handlers
+        assert "hipsparselt" in handlers
         assert "aotriton" in handlers
         assert "miopen" in handlers
-        assert len(handlers) == 4
+        assert len(handlers) == 5
 
     def test_get_database_handlers_single(self):
         """Test getting a single handler by name."""
@@ -441,12 +601,21 @@ class TestDatabaseHandlerRegistry:
 
     def test_get_database_handlers_all(self):
         """Test getting all handlers."""
-        handlers = get_database_handlers(["rocblas", "hipblaslt", "aotriton", "miopen"])
-        assert len(handlers) == 4
+        handlers = get_database_handlers(
+            ["rocblas", "hipblaslt", "hipsparselt", "aotriton", "miopen"]
+        )
+        assert len(handlers) == 5
         assert isinstance(handlers[0], RocBLASHandler)
         assert isinstance(handlers[1], HipBLASLtHandler)
-        assert isinstance(handlers[2], AotritonHandler)
-        assert isinstance(handlers[3], MIOpenHandler)
+        assert isinstance(handlers[2], HipSparseLtHandler)
+        assert isinstance(handlers[3], AotritonHandler)
+        assert isinstance(handlers[4], MIOpenHandler)
+
+    def test_wheel_type_preset(self):
+        """Test that wheel type presets resolve to valid handlers."""
+        names = WHEEL_TYPE_PRESETS["torch-fat"]
+        handlers = get_database_handlers(names)
+        assert len(handlers) == 5
 
     def test_get_database_handlers_unknown(self):
         """Test that unknown handler name raises ValueError."""

--- a/shared/kpack/tests/test_wheel_splitter.py
+++ b/shared/kpack/tests/test_wheel_splitter.py
@@ -1,0 +1,877 @@
+"""
+Tests for the wheel splitter.
+
+Unit tests verify metadata parsing and generation without requiring a toolchain.
+Integration tests use real fat binaries from test_assets to verify the full
+split pipeline.
+"""
+
+import hashlib
+import os
+import shutil
+from pathlib import Path
+
+import pytest
+
+from rocm_kpack.wheel_splitter import (
+    FatBinaryInfo,
+    InvalidWheelError,
+    NoFatBinariesError,
+    SplitResult,
+    WheelIdentity,
+    WheelSplitter,
+    WheelSplitError,
+    _arch_to_bundle_key,
+    _bundle_key_to_dist_name,
+    compute_dist_info_name,
+    compute_wheel_filename,
+    generate_device_metadata,
+    generate_record,
+    generate_wheel_file,
+    parse_wheel_identity,
+)
+
+
+# =============================================================================
+# Fixtures
+# =============================================================================
+
+
+@pytest.fixture
+def mock_wheel(tmp_path: Path):
+    """Create a minimal mock wheel directory structure (no fat binaries)."""
+    wheel_dir = tmp_path / "wheel"
+    wheel_dir.mkdir()
+
+    # Create torch/ overlay root with some files
+    torch_dir = wheel_dir / "torch"
+    torch_dir.mkdir()
+    (torch_dir / "__init__.py").write_text("# torch\n")
+    lib_dir = torch_dir / "lib"
+    lib_dir.mkdir()
+    (lib_dir / "libtorch_cpu.so").write_bytes(b"\x00" * 100)
+
+    # Create dist-info
+    dist_info = wheel_dir / "torch-2.10.0+rocm7.1.dist-info"
+    dist_info.mkdir()
+    (dist_info / "METADATA").write_text(
+        "Metadata-Version: 2.4\n"
+        "Name: torch\n"
+        "Version: 2.10.0+rocm7.1\n"
+        "Summary: Tensors and Dynamic neural networks\n"
+    )
+    (dist_info / "WHEEL").write_text(
+        "Wheel-Version: 1.0\n"
+        "Generator: setuptools 80.9.0\n"
+        "Root-Is-Purelib: false\n"
+        "Tag: cp313-cp313-manylinux_2_28_x86_64\n"
+    )
+    (dist_info / "RECORD").write_text("")
+    (dist_info / "top_level.txt").write_text("torch\n")
+
+    return wheel_dir
+
+
+@pytest.fixture
+def fat_binary_wheel(tmp_path: Path, test_assets_dir: Path):
+    """Create a mock wheel directory with a real fat binary from test assets."""
+    wheel_dir = tmp_path / "fat_wheel"
+    wheel_dir.mkdir()
+
+    # Create torch/ overlay root
+    torch_dir = wheel_dir / "torch"
+    torch_dir.mkdir()
+    (torch_dir / "__init__.py").write_text("# torch\n")
+    lib_dir = torch_dir / "lib"
+    lib_dir.mkdir()
+
+    # Copy a real fat binary as a simulated torch library
+    source_binary = (
+        test_assets_dir / "bundled_binaries/linux/cov5/libtest_kernel_single.so"
+    )
+    if not source_binary.exists():
+        pytest.skip("Test assets not available")
+    shutil.copy2(source_binary, lib_dir / "libfat_test.so")
+
+    # Also add a non-fat binary
+    (lib_dir / "libplain.so").write_bytes(b"\x00" * 100)
+
+    # Create dist-info
+    dist_info = wheel_dir / "torch-2.10.0+rocm7.1.dist-info"
+    dist_info.mkdir()
+    (dist_info / "METADATA").write_text(
+        "Metadata-Version: 2.4\n"
+        "Name: torch\n"
+        "Version: 2.10.0+rocm7.1\n"
+        "Summary: Tensors and Dynamic neural networks\n"
+    )
+    (dist_info / "WHEEL").write_text(
+        "Wheel-Version: 1.0\n"
+        "Generator: setuptools 80.9.0\n"
+        "Root-Is-Purelib: false\n"
+        "Tag: cp313-cp313-manylinux_2_28_x86_64\n"
+    )
+    (dist_info / "RECORD").write_text("")
+    (dist_info / "top_level.txt").write_text("torch\n")
+
+    return wheel_dir
+
+
+# =============================================================================
+# Unit tests — no toolchain needed
+# =============================================================================
+
+
+class TestParseWheelIdentity:
+    def test_basic(self, mock_wheel: Path):
+        identity = parse_wheel_identity(mock_wheel)
+        assert identity.name == "torch"
+        assert identity.version == "2.10.0+rocm7.1"
+        assert identity.python_tag == "cp313"
+        assert identity.abi_tag == "cp313"
+        assert identity.platform_tag == "manylinux_2_28_x86_64"
+        assert identity.dist_info_name == "torch-2.10.0+rocm7.1.dist-info"
+
+    def test_no_dist_info(self, tmp_path: Path):
+        empty_dir = tmp_path / "empty"
+        empty_dir.mkdir()
+        with pytest.raises(InvalidWheelError, match="Expected exactly one .dist-info"):
+            parse_wheel_identity(empty_dir)
+
+    def test_multiple_dist_info(self, tmp_path: Path):
+        wheel_dir = tmp_path / "multi"
+        wheel_dir.mkdir()
+        (wheel_dir / "a-1.0.dist-info").mkdir()
+        (wheel_dir / "b-2.0.dist-info").mkdir()
+        with pytest.raises(InvalidWheelError, match="Expected exactly one .dist-info"):
+            parse_wheel_identity(wheel_dir)
+
+    def test_missing_metadata(self, tmp_path: Path):
+        wheel_dir = tmp_path / "no_meta"
+        wheel_dir.mkdir()
+        dist_info = wheel_dir / "pkg-1.0.dist-info"
+        dist_info.mkdir()
+        (dist_info / "WHEEL").write_text("Tag: cp313-cp313-linux_x86_64\n")
+        with pytest.raises(InvalidWheelError, match="No METADATA"):
+            parse_wheel_identity(wheel_dir)
+
+    def test_missing_wheel_file(self, tmp_path: Path):
+        wheel_dir = tmp_path / "no_wheel"
+        wheel_dir.mkdir()
+        dist_info = wheel_dir / "pkg-1.0.dist-info"
+        dist_info.mkdir()
+        (dist_info / "METADATA").write_text("Name: pkg\nVersion: 1.0\n")
+        with pytest.raises(InvalidWheelError, match="No WHEEL"):
+            parse_wheel_identity(wheel_dir)
+
+
+class TestComputeWheelFilename:
+    def test_basic(self):
+        identity = WheelIdentity(
+            name="torch",
+            version="2.10.0+rocm7.1",
+            python_tag="cp313",
+            abi_tag="cp313",
+            platform_tag="manylinux_2_28_x86_64",
+            dist_info_name="torch-2.10.0+rocm7.1.dist-info",
+        )
+        filename = compute_wheel_filename(
+            "amd-torch-device-gfx942", "2.10.0+rocm7.1", identity
+        )
+        assert filename == (
+            "amd_torch_device_gfx942-2.10.0+rocm7.1"
+            "-cp313-cp313-manylinux_2_28_x86_64.whl"
+        )
+
+    def test_underscore_normalization(self):
+        identity = WheelIdentity(
+            name="pkg",
+            version="1.0",
+            python_tag="py3",
+            abi_tag="none",
+            platform_tag="any",
+            dist_info_name="pkg-1.0.dist-info",
+        )
+        filename = compute_wheel_filename("my-package", "1.0", identity)
+        assert filename == "my_package-1.0-py3-none-any.whl"
+
+
+class TestComputeDistInfoName:
+    def test_basic(self):
+        assert (
+            compute_dist_info_name("amd-torch-device-gfx942", "2.10.0+rocm7.1")
+            == "amd_torch_device_gfx942-2.10.0+rocm7.1.dist-info"
+        )
+
+
+class TestGenerateDeviceMetadata:
+    def test_target_level(self):
+        identity = WheelIdentity(
+            name="torch",
+            version="2.10.0+rocm7.1",
+            python_tag="cp313",
+            abi_tag="cp313",
+            platform_tag="manylinux_2_28_x86_64",
+            dist_info_name="torch-2.10.0+rocm7.1.dist-info",
+        )
+        metadata = generate_device_metadata(identity, "gfx942", "amd-torch-device", [])
+        assert "Name: amd-torch-device-gfx942" in metadata
+        assert "Version: 2.10.0+rocm7.1" in metadata
+        assert "Requires-Dist: torch == 2.10.0+rocm7.1" in metadata
+
+    def test_family_level(self):
+        identity = WheelIdentity(
+            name="torch",
+            version="2.10.0+rocm7.1",
+            python_tag="cp313",
+            abi_tag="cp313",
+            platform_tag="manylinux_2_28_x86_64",
+            dist_info_name="torch-2.10.0+rocm7.1.dist-info",
+        )
+        metadata = generate_device_metadata(identity, "gfx11", "amd-torch-device", [])
+        assert "Name: amd-torch-device-gfx11" in metadata
+
+    def test_sub_family_level(self):
+        identity = WheelIdentity(
+            name="torch",
+            version="2.10.0+rocm7.1",
+            python_tag="cp313",
+            abi_tag="cp313",
+            platform_tag="manylinux_2_28_x86_64",
+            dist_info_name="torch-2.10.0+rocm7.1.dist-info",
+        )
+        metadata = generate_device_metadata(identity, "gfx12_0", "amd-torch-device", [])
+        # gfx12_0 becomes gfx12-0 in dist name (underscore to hyphen)
+        assert "Name: amd-torch-device-gfx12-0" in metadata
+
+    def test_with_device_requires_dist(self):
+        identity = WheelIdentity(
+            name="torch",
+            version="2.10.0+rocm7.1",
+            python_tag="cp313",
+            abi_tag="cp313",
+            platform_tag="manylinux_2_28_x86_64",
+            dist_info_name="torch-2.10.0+rocm7.1.dist-info",
+        )
+        metadata = generate_device_metadata(
+            identity,
+            "gfx942",
+            "amd-torch-device",
+            ["rocm-sdk-device-@GFXARCH@ == 7.1"],
+        )
+        assert "Requires-Dist: rocm-sdk-device-gfx942 == 7.1" in metadata
+
+    def test_gfxarch_placeholder_expansion(self):
+        identity = WheelIdentity(
+            name="torch",
+            version="1.0",
+            python_tag="py3",
+            abi_tag="none",
+            platform_tag="any",
+            dist_info_name="torch-1.0.dist-info",
+        )
+        metadata = generate_device_metadata(
+            identity,
+            "gfx1100",
+            "amd-torch-device",
+            ["some-dep-@GFXARCH@ >= 2.0"],
+        )
+        assert "Requires-Dist: some-dep-gfx1100 >= 2.0" in metadata
+
+
+class TestArchToBundleKey:
+    def test_bare_arch(self):
+        assert _arch_to_bundle_key("gfx942") == "gfx942"
+
+    def test_xnack_plus(self):
+        assert _arch_to_bundle_key("gfx942:xnack+") == "gfx942"
+
+    def test_xnack_minus(self):
+        assert _arch_to_bundle_key("gfx90a:xnack-") == "gfx90a"
+
+    def test_no_xnack(self):
+        assert _arch_to_bundle_key("gfx1100") == "gfx1100"
+
+    def test_family_key(self):
+        assert _arch_to_bundle_key("gfx11") == "gfx11"
+
+    def test_sub_family_key(self):
+        assert _arch_to_bundle_key("gfx12_0") == "gfx12_0"
+
+
+class TestBundleKeyToDistName:
+    def test_target_level(self):
+        assert (
+            _bundle_key_to_dist_name("amd-torch-device", "gfx942")
+            == "amd-torch-device-gfx942"
+        )
+
+    def test_family_level(self):
+        assert (
+            _bundle_key_to_dist_name("amd-torch-device", "gfx11")
+            == "amd-torch-device-gfx11"
+        )
+
+    def test_sub_family_level(self):
+        # Underscore in bundle key becomes hyphen in dist name
+        assert (
+            _bundle_key_to_dist_name("amd-torch-device", "gfx12_0")
+            == "amd-torch-device-gfx12-0"
+        )
+
+    def test_various_targets(self):
+        cases = [
+            ("gfx900", "amd-torch-device-gfx900"),
+            ("gfx90a", "amd-torch-device-gfx90a"),
+            ("gfx1100", "amd-torch-device-gfx1100"),
+            ("gfx1151", "amd-torch-device-gfx1151"),
+            ("gfx9", "amd-torch-device-gfx9"),
+            ("gfx9_4", "amd-torch-device-gfx9-4"),
+        ]
+        for bundle_key, expected in cases:
+            assert (
+                _bundle_key_to_dist_name("amd-torch-device", bundle_key) == expected
+            ), f"Failed for {bundle_key}"
+
+
+class TestRewriteHostMetadata:
+    """Test _rewrite_host_metadata via WheelSplitter."""
+
+    def _make_host_staging(self, tmp_path: Path) -> tuple[Path, WheelIdentity]:
+        """Create a minimal host staging directory with METADATA."""
+        staging = tmp_path / "host_staging"
+        staging.mkdir()
+        dist_info = staging / "torch-2.10.0+rocm7.1.dist-info"
+        dist_info.mkdir()
+        (dist_info / "METADATA").write_text(
+            "Metadata-Version: 2.4\n"
+            "Name: torch\n"
+            "Version: 2.10.0+rocm7.1\n"
+            "Summary: Tensors and Dynamic neural networks\n"
+            "\n"
+            "A description body that comes after the header section.\n"
+        )
+        identity = WheelIdentity(
+            name="torch",
+            version="2.10.0+rocm7.1",
+            python_tag="cp313",
+            abi_tag="cp313",
+            platform_tag="manylinux_2_28_x86_64",
+            dist_info_name="torch-2.10.0+rocm7.1.dist-info",
+        )
+        return staging, identity
+
+    def _make_splitter(self) -> WheelSplitter:
+        from rocm_kpack.binutils import Toolchain
+
+        return WheelSplitter(
+            device_package_prefix="amd-torch-device",
+            overlay_root="torch/",
+            toolchain=Toolchain(),
+        )
+
+    def test_rocm_bootstrap_dep(self, tmp_path: Path):
+        staging, identity = self._make_host_staging(tmp_path)
+        splitter = self._make_splitter()
+        splitter._rewrite_host_metadata(staging, identity, {"gfx942"})
+
+        metadata = (staging / identity.dist_info_name / "METADATA").read_text()
+        assert "Requires-Dist: rocm-bootstrap" in metadata
+
+    def test_extras_for_single_target(self, tmp_path: Path):
+        staging, identity = self._make_host_staging(tmp_path)
+        splitter = self._make_splitter()
+        # gfx942 packaging chain: gfx942 -> gfx9_4 -> gfx9
+        # Only gfx942 has a device wheel (is in bundle_keys)
+        splitter._rewrite_host_metadata(staging, identity, {"gfx942"})
+
+        metadata = (staging / identity.dist_info_name / "METADATA").read_text()
+        assert "Provides-Extra: gfx942" in metadata
+        assert (
+            'Requires-Dist: amd-torch-device-gfx942 == 2.10.0+rocm7.1; extra == "gfx942"'
+            in metadata
+        )
+        assert "Provides-Extra: all" in metadata
+
+    def test_classic_has_no_variant_markers(self, tmp_path: Path):
+        staging, identity = self._make_host_staging(tmp_path)
+        splitter = self._make_splitter()
+        splitter._rewrite_host_metadata(staging, identity, {"gfx942"})
+
+        metadata = (staging / identity.dist_info_name / "METADATA").read_text()
+        assert "variant_properties" not in metadata
+
+    def test_variant_markers_when_enabled(self, tmp_path: Path):
+        staging, identity = self._make_host_staging(tmp_path)
+        splitter = self._make_splitter()
+        splitter._rewrite_host_metadata(
+            staging, identity, {"gfx942"}, include_variant_markers=True
+        )
+
+        metadata = (staging / identity.dist_info_name / "METADATA").read_text()
+        assert (
+            "Requires-Dist: amd-torch-device-gfx942 == 2.10.0+rocm7.1; "
+            '"amd :: gfx_arch :: gfx942" in variant_properties'
+        ) in metadata
+
+    def test_chain_with_family_wheel(self, tmp_path: Path):
+        staging, identity = self._make_host_staging(tmp_path)
+        splitter = self._make_splitter()
+        # gfx1100 chain: gfx1100 -> gfx11_0 -> gfx11
+        # If gfx11 and gfx1100 both have device wheels:
+        splitter._rewrite_host_metadata(staging, identity, {"gfx1100", "gfx11"})
+
+        metadata = (staging / identity.dist_info_name / "METADATA").read_text()
+        # Both should appear as deps under the gfx1100 extra
+        assert (
+            'Requires-Dist: amd-torch-device-gfx1100 == 2.10.0+rocm7.1; extra == "gfx1100"'
+            in metadata
+        )
+        assert (
+            'Requires-Dist: amd-torch-device-gfx11 == 2.10.0+rocm7.1; extra == "gfx1100"'
+            in metadata
+        )
+        # "all" should include both
+        assert (
+            'Requires-Dist: amd-torch-device-gfx11 == 2.10.0+rocm7.1; extra == "all"'
+            in metadata
+        )
+        assert (
+            'Requires-Dist: amd-torch-device-gfx1100 == 2.10.0+rocm7.1; extra == "all"'
+            in metadata
+        )
+
+    def test_family_only_not_target_extra(self, tmp_path: Path):
+        """Family-level bundle keys don't get their own Provides-Extra."""
+        staging, identity = self._make_host_staging(tmp_path)
+        splitter = self._make_splitter()
+        # gfx11 is a family, not a target - no Provides-Extra for it directly
+        splitter._rewrite_host_metadata(staging, identity, {"gfx11"})
+
+        metadata = (staging / identity.dist_info_name / "METADATA").read_text()
+        # No target-level extras since gfx11 is a family
+        assert "Provides-Extra: gfx11" not in metadata
+        # But "all" should still include it
+        assert "Provides-Extra: all" in metadata
+        assert (
+            'Requires-Dist: amd-torch-device-gfx11 == 2.10.0+rocm7.1; extra == "all"'
+            in metadata
+        )
+
+    def test_preserves_existing_metadata(self, tmp_path: Path):
+        staging, identity = self._make_host_staging(tmp_path)
+        splitter = self._make_splitter()
+        splitter._rewrite_host_metadata(staging, identity, {"gfx942"})
+
+        metadata = (staging / identity.dist_info_name / "METADATA").read_text()
+        # Original fields should still be there
+        assert "Name: torch" in metadata
+        assert "Version: 2.10.0+rocm7.1" in metadata
+        assert "Summary: Tensors and Dynamic neural networks" in metadata
+
+    def test_headers_before_body(self, tmp_path: Path):
+        staging, identity = self._make_host_staging(tmp_path)
+        splitter = self._make_splitter()
+        splitter._rewrite_host_metadata(staging, identity, {"gfx942"})
+
+        metadata = (staging / identity.dist_info_name / "METADATA").read_text()
+        # Split into header and body at the first blank line
+        header_body = metadata.split("\n\n", 1)
+        assert len(header_body) == 2, "METADATA should have header and body sections"
+        header_section, body_section = header_body
+        # All injected headers must be in the header section, not the body
+        assert "Requires-Dist: rocm-bootstrap" in header_section
+        assert "Provides-Extra: gfx942" in header_section
+        assert "Provides-Extra: all" in header_section
+        # Body should still contain the description
+        assert "description body" in body_section
+
+
+class TestVariantWheel:
+    """Tests for PEP 817 variant wheel generation."""
+
+    def _make_host_staging(self, tmp_path: Path) -> tuple[Path, WheelIdentity]:
+        staging = tmp_path / "host_staging"
+        staging.mkdir()
+        dist_info = staging / "torch-2.10.0+rocm7.1.dist-info"
+        dist_info.mkdir()
+        # Write a classic-rewritten METADATA (extras only, no variant markers)
+        (dist_info / "METADATA").write_text(
+            "Metadata-Version: 2.4\n"
+            "Name: torch\n"
+            "Version: 2.10.0+rocm7.1\n"
+            "Requires-Dist: rocm-bootstrap\n"
+            "Provides-Extra: gfx942\n"
+            'Requires-Dist: amd-torch-device-gfx942 == 2.10.0+rocm7.1; extra == "gfx942"\n'
+            "Provides-Extra: all\n"
+            'Requires-Dist: amd-torch-device-gfx942 == 2.10.0+rocm7.1; extra == "all"\n'
+            "\n"
+            "Description body.\n"
+        )
+        (dist_info / "WHEEL").write_text(
+            "Wheel-Version: 1.0\nTag: cp313-cp313-manylinux_2_28_x86_64\n"
+        )
+        (dist_info / "RECORD").write_text("")
+        # Add a dummy file so the wheel isn't empty
+        (staging / "torch").mkdir()
+        (staging / "torch" / "__init__.py").write_text("")
+        identity = WheelIdentity(
+            name="torch",
+            version="2.10.0+rocm7.1",
+            python_tag="cp313",
+            abi_tag="cp313",
+            platform_tag="manylinux_2_28_x86_64",
+            dist_info_name="torch-2.10.0+rocm7.1.dist-info",
+        )
+        return staging, identity
+
+    def _make_splitter(self) -> WheelSplitter:
+        from rocm_kpack.binutils import Toolchain
+
+        return WheelSplitter(
+            device_package_prefix="amd-torch-device",
+            overlay_root="torch/",
+            toolchain=Toolchain(),
+            generate_variant_wheel=True,
+        )
+
+    def test_add_variant_markers(self, tmp_path: Path):
+        staging, identity = self._make_host_staging(tmp_path)
+        splitter = self._make_splitter()
+        splitter._add_variant_markers_to_metadata(staging, identity, {"gfx942"})
+
+        metadata = (staging / identity.dist_info_name / "METADATA").read_text()
+        # Should have the extras line AND the variant marker line
+        assert 'extra == "gfx942"' in metadata
+        assert ('"amd :: gfx_arch :: gfx942" in variant_properties') in metadata
+        # "all" extra should NOT get variant markers
+        assert '"amd :: gfx_arch :: all"' not in metadata
+
+    def test_variant_json(self, tmp_path: Path):
+        import json
+
+        staging, identity = self._make_host_staging(tmp_path)
+        splitter = self._make_splitter()
+        splitter._write_variant_json(staging, identity, {"gfx942", "gfx11"})
+
+        variant_path = staging / identity.dist_info_name / "variant.json"
+        assert variant_path.exists()
+        data = json.loads(variant_path.read_text())
+        assert "providers" in data
+        assert "amd" in data["providers"]
+        assert "variants" in data
+        # gfx942 is a target, gfx11 is a family — only targets get variants
+        assert "gfx942" in data["variants"]
+        assert "gfx11" not in data["variants"]
+
+    def test_create_variant_wheel_directory(self, tmp_path: Path):
+        import json
+
+        staging, identity = self._make_host_staging(tmp_path)
+        splitter = self._make_splitter()
+        output_dir = tmp_path / "output"
+        output_dir.mkdir()
+
+        variant_path = splitter._create_variant_wheel(
+            staging, identity, {"gfx942"}, output_dir, "directory"
+        )
+
+        assert variant_path.exists()
+        assert "variant" in variant_path.name
+
+        # Check METADATA has variant markers
+        metadata = (variant_path / identity.dist_info_name / "METADATA").read_text()
+        assert "variant_properties" in metadata
+        assert 'extra == "gfx942"' in metadata
+
+        # Check variant.json exists
+        variant_json = variant_path / identity.dist_info_name / "variant.json"
+        assert variant_json.exists()
+        data = json.loads(variant_json.read_text())
+        assert "gfx942" in data["variants"]
+
+
+class TestGenerateWheelFile:
+    def test_basic(self):
+        identity = WheelIdentity(
+            name="torch",
+            version="2.10.0+rocm7.1",
+            python_tag="cp313",
+            abi_tag="cp313",
+            platform_tag="manylinux_2_28_x86_64",
+            dist_info_name="torch-2.10.0+rocm7.1.dist-info",
+        )
+        content = generate_wheel_file(identity)
+        assert "Wheel-Version: 1.0" in content
+        assert "Tag: cp313-cp313-manylinux_2_28_x86_64" in content
+        assert "Root-Is-Purelib: false" in content
+        assert "Generator: rocm-kpack-split-python-wheels" in content
+
+
+class TestGenerateRecord:
+    def test_basic(self, tmp_path: Path):
+        wheel_dir = tmp_path / "wheel"
+        wheel_dir.mkdir()
+        dist_info = wheel_dir / "pkg-1.0.dist-info"
+        dist_info.mkdir()
+
+        # Create a file with known content
+        test_content = b"hello world"
+        (wheel_dir / "test.py").write_bytes(test_content)
+        expected_hash = hashlib.sha256(test_content).hexdigest()
+
+        # Create empty RECORD
+        (dist_info / "RECORD").write_text("")
+
+        record = generate_record(wheel_dir, "pkg-1.0.dist-info")
+        lines = record.strip().split("\n")
+
+        # Should have 2 entries: test.py and RECORD itself
+        assert len(lines) == 2
+
+        # RECORD entry has no hash
+        record_line = [l for l in lines if "RECORD" in l][0]
+        assert record_line == "pkg-1.0.dist-info/RECORD,,"
+
+        # test.py has hash
+        test_line = [l for l in lines if "test.py" in l][0]
+        assert f"sha256={expected_hash}" in test_line
+        assert f",{len(test_content)}" in test_line
+
+
+class TestKpackSearchPattern:
+    """Test the search pattern computation logic."""
+
+    def _compute(self, overlay_relative_path: str, group_name: str) -> str:
+        """Helper to call the private method via a throwaway splitter."""
+        from rocm_kpack.binutils import Toolchain
+
+        splitter = WheelSplitter(
+            device_package_prefix="test",
+            overlay_root="torch/",
+            toolchain=Toolchain(),
+        )
+        return splitter._compute_kpack_search_pattern(overlay_relative_path, group_name)
+
+    def test_binary_in_subdir(self):
+        # lib/libtorch_hip.so -> depth=1 -> ../.kpack/torch_@GFXARCH@.kpack
+        pattern = self._compute("lib/libtorch_hip.so", "torch")
+        assert pattern == "../.kpack/torch_@GFXARCH@.kpack"
+
+    def test_binary_at_root(self):
+        # libtorch_hip.so -> depth=0 -> .kpack/torch_@GFXARCH@.kpack
+        pattern = self._compute("libtorch_hip.so", "torch")
+        assert pattern == ".kpack/torch_@GFXARCH@.kpack"
+
+    def test_binary_deeply_nested(self):
+        # a/b/c/binary.so -> depth=3 -> ../../../.kpack/torch_@GFXARCH@.kpack
+        pattern = self._compute("a/b/c/binary.so", "torch")
+        assert pattern == "../../../.kpack/torch_@GFXARCH@.kpack"
+
+
+# =============================================================================
+# Integration tests — require toolchain and test assets
+# =============================================================================
+
+
+class TestWheelSplitterIntegration:
+    """Integration tests that use real fat binaries from test_assets."""
+
+    def test_split_directory_to_directory(
+        self, fat_binary_wheel: Path, toolchain, tmp_path: Path
+    ):
+        """Test splitting an exploded wheel to exploded output directories."""
+        output_dir = tmp_path / "output"
+
+        splitter = WheelSplitter(
+            device_package_prefix="amd-torch-device",
+            overlay_root="torch/",
+            toolchain=toolchain,
+            verbose=True,
+        )
+
+        result = splitter.split(fat_binary_wheel, output_dir, output_format="directory")
+
+        # Should have found architectures
+        assert len(result.architectures_found) > 0
+        assert result.fat_binaries_processed == 1
+
+        # Host wheel directory should exist
+        assert result.host_wheel_path.exists()
+        assert result.host_wheel_path.is_dir()
+
+        # Host should have the original files (minus device code)
+        host_init = result.host_wheel_path / "torch" / "__init__.py"
+        assert host_init.exists()
+
+        # Host fat binary should still exist but be transformed
+        host_fat = result.host_wheel_path / "torch" / "lib" / "libfat_test.so"
+        assert host_fat.exists()
+
+        # Host RECORD should exist and be non-empty
+        host_record = (
+            result.host_wheel_path / "torch-2.10.0+rocm7.1.dist-info" / "RECORD"
+        )
+        assert host_record.exists()
+        assert host_record.stat().st_size > 0
+
+        # Device wheels should exist for each bundle key found
+        for bundle_key, device_path in result.device_wheel_paths.items():
+            assert device_path.exists()
+            assert device_path.is_dir()
+
+            # Device wheel should have at least one kpack file
+            kpack_dir = device_path / "torch" / ".kpack"
+            kpack_files = list(kpack_dir.glob("*.kpack"))
+            assert len(kpack_files) > 0
+            for kf in kpack_files:
+                assert kf.stat().st_size > 0
+
+            # Device wheel should have dist-info with correct naming
+            device_name = _bundle_key_to_dist_name("amd-torch-device", bundle_key)
+            device_dist_info_name = (
+                f"{device_name.replace('-', '_')}-2.10.0+rocm7.1.dist-info"
+            )
+            device_dist_info = device_path / device_dist_info_name
+            assert device_dist_info.exists()
+
+            # Check METADATA
+            metadata = (device_dist_info / "METADATA").read_text()
+            assert f"Name: {device_name}" in metadata
+            assert "Requires-Dist: torch == 2.10.0+rocm7.1" in metadata
+
+            # Check WHEEL
+            wheel_content = (device_dist_info / "WHEEL").read_text()
+            assert "Tag: cp313-cp313-manylinux_2_28_x86_64" in wheel_content
+
+            # Check RECORD
+            record = (device_dist_info / "RECORD").read_text()
+            assert ".kpack/" in record
+
+    def test_split_no_fat_binaries(self, mock_wheel: Path, toolchain, tmp_path: Path):
+        """Test that splitting a wheel with no fat binaries raises an error."""
+        output_dir = tmp_path / "output"
+
+        splitter = WheelSplitter(
+            device_package_prefix="amd-torch-device",
+            overlay_root="torch/",
+            toolchain=toolchain,
+        )
+
+        with pytest.raises(NoFatBinariesError):
+            splitter.split(mock_wheel, output_dir)
+
+    def test_split_invalid_overlay_root(
+        self, mock_wheel: Path, toolchain, tmp_path: Path
+    ):
+        """Test that an invalid overlay root raises an error."""
+        output_dir = tmp_path / "output"
+
+        splitter = WheelSplitter(
+            device_package_prefix="amd-torch-device",
+            overlay_root="nonexistent/",
+            toolchain=toolchain,
+        )
+
+        with pytest.raises(InvalidWheelError, match="Overlay root"):
+            splitter.split(mock_wheel, output_dir)
+
+    def test_host_record_integrity(
+        self, fat_binary_wheel: Path, toolchain, tmp_path: Path
+    ):
+        """Verify that the host wheel's RECORD has valid hashes."""
+        output_dir = tmp_path / "output"
+
+        splitter = WheelSplitter(
+            device_package_prefix="amd-torch-device",
+            overlay_root="torch/",
+            toolchain=toolchain,
+        )
+
+        result = splitter.split(fat_binary_wheel, output_dir, output_format="directory")
+
+        host_dir = result.host_wheel_path
+        dist_info_name = "torch-2.10.0+rocm7.1.dist-info"
+        record_path = host_dir / dist_info_name / "RECORD"
+        record_text = record_path.read_text()
+
+        for line in record_text.strip().split("\n"):
+            if not line:
+                continue
+            parts = line.split(",")
+            rel_path = parts[0]
+
+            if parts[1] == "":
+                # RECORD itself — no hash
+                assert rel_path.endswith("RECORD")
+                continue
+
+            # Verify hash
+            hash_part = parts[1]
+            size_part = parts[2]
+            assert hash_part.startswith("sha256=")
+            expected_hash = hash_part.removeprefix("sha256=")
+
+            file_path = host_dir / rel_path
+            assert file_path.exists(), f"RECORD references missing file: {rel_path}"
+            actual_hash = hashlib.sha256(file_path.read_bytes()).hexdigest()
+            assert actual_hash == expected_hash, f"Hash mismatch for {rel_path}"
+            assert int(size_part) == file_path.stat().st_size
+
+    def test_device_requires_dist(
+        self, fat_binary_wheel: Path, toolchain, tmp_path: Path
+    ):
+        """Test that --device-requires-dist with @GFXARCH@ expands correctly."""
+        output_dir = tmp_path / "output"
+
+        splitter = WheelSplitter(
+            device_package_prefix="amd-torch-device",
+            overlay_root="torch/",
+            toolchain=toolchain,
+            device_requires_dist=["rocm-sdk-device-@GFXARCH@ == 7.1"],
+        )
+
+        result = splitter.split(fat_binary_wheel, output_dir, output_format="directory")
+
+        for bundle_key, device_path in result.device_wheel_paths.items():
+            device_name = _bundle_key_to_dist_name("amd-torch-device", bundle_key)
+            dist_info_name = f"{device_name.replace('-', '_')}-2.10.0+rocm7.1.dist-info"
+            metadata = (device_path / dist_info_name / "METADATA").read_text()
+            assert f"Requires-Dist: rocm-sdk-device-{bundle_key} == 7.1" in metadata
+
+    def test_split_parallel(self, fat_binary_wheel: Path, toolchain, tmp_path: Path):
+        """Test that parallel splitting (jobs=2) produces correct results."""
+        output_dir = tmp_path / "output"
+
+        splitter = WheelSplitter(
+            device_package_prefix="amd-torch-device",
+            overlay_root="torch/",
+            toolchain=toolchain,
+            verbose=True,
+            jobs=2,
+        )
+
+        result = splitter.split(fat_binary_wheel, output_dir, output_format="directory")
+
+        # Same assertions as test_split_directory_to_directory
+        assert len(result.architectures_found) > 0
+        assert result.fat_binaries_processed == 1
+        assert result.host_wheel_path.exists()
+        assert result.host_wheel_path.is_dir()
+
+        host_fat = result.host_wheel_path / "torch" / "lib" / "libfat_test.so"
+        assert host_fat.exists()
+
+        host_record = (
+            result.host_wheel_path / "torch-2.10.0+rocm7.1.dist-info" / "RECORD"
+        )
+        assert host_record.exists()
+        assert host_record.stat().st_size > 0
+
+        for bundle_key, device_path in result.device_wheel_paths.items():
+            assert device_path.exists()
+            kpack_dir = device_path / "torch" / ".kpack"
+            kpack_files = list(kpack_dir.glob("*.kpack"))
+            assert len(kpack_files) > 0
+            for kf in kpack_files:
+                assert kf.stat().st_size > 0


### PR DESCRIPTION
## Summary

Adds `split_python_wheels` tool that post-processes fat PyTorch ROCm wheels into a host wheel (device code stripped) and per-arch device wheels containing `.kpack` archives and arch-specific database files. Also generates PEP 817 variant wheels for wheelnext-aware installers.

Tested against `torch-2.10.0+rocm7.1` (5.1 GB compressed): host wheel shrinks to 431 MB, with 16 device wheels generated. A user installing for a single GPU downloads 87% less for lightweight targets (gfx1100: 672 MB), 67% less for the heaviest (gfx942: 2.0 GB).

**Full split report**: https://gist.github.com/stellaraccident/105d58437d903218c476594c2ba33cce

## Catalog of changes

**Please review per-commit.** This PR will be landed as a merge commit to preserve history.

### Commit 1: Add fast-path fatbin detection and fix PHDR in-place write regression

- \`elf/surgery.py\`: Add \`ElfSurgery.has_fatbin_section()\` — lightweight \`.hip_fatbin\` section scan reading only ELF headers (a few KB vs loading multi-GB binaries)
- \`coff/surgery.py\`: Add \`CoffSurgery.has_fatbin_section()\` — equivalent for PE/COFF \`.hip_fat\` sections
- \`kpack_transform.py\`: \`is_fat_binary()\` now dispatches to fast-path methods instead of loading full binaries
- \`tests/elf/test_surgery.py\`: Move inline imports to top-level; add docstring noting that spare PHDR slots (tested by \`_build_synthetic_elf\`) are commonly the result of prior patchelf transformations

### Commit 2: Add database handlers for wheel splitting with arch-aware file detection

- \`database_handlers.py\`: Five handlers for arch-specific file detection:
  - **RocBLAS/HipBLASLt/HipSparseLt**: Tensile library files by gfx pattern in filename
  - **AOTriton**: Kernel image directories — maps family names (\`gfx11xx\` → \`gfx11\`, \`gfx120x\` → \`gfx12_0\`) to rocm-bootstrap bundle keys. Coded to match the actual arrangement in the torch wheel (earlier version was from abstract spec)
  - **MIOpen**: Tuning databases with concatenated arch+CU filenames (e.g., \`gfx90878\` = gfx908 + 78 CUs). Uses explicit arch-ID regex. This handler is interim — we plan to adapt the MIOpen database format to be more amenable to splitting soon
- Removed catch-all exception handlers from all \`detect()\` methods; added \`_relative_path()\` base class method with explicit \`ValueError\` when path is not under \`prefix_root\` (contract enforcement vs silent fallthrough)
- \`tests/test_database_handlers.py\`: Updated outside-prefix tests to assert explicit error message

### Commit 3: Add Python wheel splitter for host/device separation

- \`wheel_splitter.py\`: Core \`WheelSplitter\` class:
  - Scans fat binaries via fast-path \`is_fat_binary()\` (cross-platform ELF/COFF)
  - Extracts device kernels into per-arch \`.kpack\` archives with zstd compression
  - Transforms host binaries (HIPF→HIPK magic rewrite, pointer redirection, zero-page)
  - Rewrites host METADATA with extras-based \`Requires-Dist\` per target architecture
  - Hierarchy-aware bundling: collapses xnack variants into bundle keys, generates correct dependency chains (e.g., \`gfx1100\` extra depends on both \`gfx1100\` and \`gfx11\` device wheels)
  - PEP 817 variant wheel generation (\`--generate-variant-wheel\`): adds \`variant_properties\` markers and \`variant.json\` with AMD variant provider metadata
  - \`rocm_bootstrap\` guarded as optional import
  - Replaced loose tuples with \`TransformArgs\` dataclass
  - Added cross-reference comments between METADATA generation and variant marker parsing
- \`tools/split_python_wheels.py\`: CLI with \`--wheel-type\` presets, \`--databases\` for handler selection, \`--compression\`, parallel workers (\`-j\`), \`--generate-variant-wheel\`, \`--variant-label\`
- \`tests/test_wheel_splitter.py\`: Comprehensive test suite including variant wheel tests

### Commit 4: Format C++ kpack runtime ISA target matching code

- Style-only: comment reflow to 80-col, include reordering (gtest before project headers), clang-format on test assertions and lambda formatting

## What gets split

1. **ELF fat binary device code** (3.8 GB) → extracted into per-arch \`.kpack\` archives; host binaries rewritten with kpack load references
2. **Kernel database files** (6.2 GB) — rocBLAS, hipBLASLt, hipSPARSELt Tensile libraries, AOTriton images, MIOpen tuning DBs — relocated to per-arch device wheels

## Test plan

- [x] \`python -m pytest tests/ -x -q\` — 456 tests pass, 2 skipped
- [x] End-to-end wheel→wheel split of real torch wheel with variant generation
- [x] Verify host wheel has no arch-specific content remaining
- [x] Verify device wheels contain correct kpack + database files per arch

🤖 Generated with [Claude Code](https://claude.com/claude-code)