### PR TITLE
ROCM-1667 - Enable OpenCL build from rocm-systems for ROCr backend on Windows

### DIFF
--- a/projects/clr/opencl/tests/ocltst/env/CMakeLists.txt
+++ b/projects/clr/opencl/tests/ocltst/env/CMakeLists.txt
@@ -34,10 +34,14 @@ target_include_directories(ocltst
     PRIVATE
         $<TARGET_PROPERTY:Common,INTERFACE_INCLUDE_DIRECTORIES>)
 
-list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/../../../cmake")
-find_package(AMD_ICD)
-find_library(AMD_ICD_LIBRARY OpenCL HINTS "${AMD_ICD_LIBRARY_DIR}")
-target_link_libraries(ocltst PRIVATE ${AMD_ICD_LIBRARY})
+if(TARGET OpenCL)
+  target_link_libraries(ocltst PRIVATE OpenCL)
+else()
+  list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/../../../cmake")
+  find_package(AMD_ICD)
+  find_library(AMD_ICD_LIBRARY OpenCL HINTS "${AMD_ICD_LIBRARY_DIR}")
+  target_link_libraries(ocltst PRIVATE ${AMD_ICD_LIBRARY})
+endif()
 
 if (NOT WIN32)
   set(THREADS_PREFER_PTHREAD_FLAG ON)

--- a/projects/clr/opencl/tests/ocltst/module/gl/CMakeLists.txt
+++ b/projects/clr/opencl/tests/ocltst/module/gl/CMakeLists.txt
@@ -50,10 +50,14 @@ target_link_libraries(oclgl
         GLEW::GLEW
         ${OPENGL_LIBRARIES})
 
-list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/../../../../cmake")
-find_package(AMD_ICD)
-find_library(AMD_ICD_LIBRARY OpenCL HINTS "${AMD_ICD_LIBRARY_DIR}")
-target_link_libraries(oclgl PRIVATE ${AMD_ICD_LIBRARY})
+if(TARGET OpenCL)
+  target_link_libraries(oclgl PRIVATE OpenCL)
+else()
+  list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/../../../../cmake")
+  find_package(AMD_ICD)
+  find_library(AMD_ICD_LIBRARY OpenCL HINTS "${AMD_ICD_LIBRARY_DIR}")
+  target_link_libraries(oclgl PRIVATE ${AMD_ICD_LIBRARY})
+endif()
 
 if (NOT WIN32)
   set(THREADS_PREFER_PTHREAD_FLAG ON)

--- a/projects/clr/opencl/tests/ocltst/module/perf/CMakeLists.txt
+++ b/projects/clr/opencl/tests/ocltst/module/perf/CMakeLists.txt
@@ -95,10 +95,14 @@ target_include_directories(oclperf
     PRIVATE
         $<TARGET_PROPERTY:Common,INTERFACE_INCLUDE_DIRECTORIES>)
 
-list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/../../../../cmake")
-find_package(AMD_ICD)
-find_library(AMD_ICD_LIBRARY OpenCL HINTS "${AMD_ICD_LIBRARY_DIR}")
-target_link_libraries(oclperf PRIVATE ${AMD_ICD_LIBRARY})
+if(TARGET OpenCL)
+  target_link_libraries(oclperf PRIVATE OpenCL)
+else()
+  list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/../../../../cmake")
+  find_package(AMD_ICD)
+  find_library(AMD_ICD_LIBRARY OpenCL HINTS "${AMD_ICD_LIBRARY_DIR}")
+  target_link_libraries(oclperf PRIVATE ${AMD_ICD_LIBRARY})
+endif()
 if (NOT WIN32)
   set(THREADS_PREFER_PTHREAD_FLAG ON)
   find_package(Threads REQUIRED)

--- a/projects/clr/opencl/tests/ocltst/module/runtime/CMakeLists.txt
+++ b/projects/clr/opencl/tests/ocltst/module/runtime/CMakeLists.txt
@@ -70,10 +70,14 @@ target_include_directories(oclruntime
         $<TARGET_PROPERTY:Common,INTERFACE_INCLUDE_DIRECTORIES>)
 
 
-list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/../../../../cmake")
-find_package(AMD_ICD)
-find_library(AMD_ICD_LIBRARY OpenCL HINTS "${AMD_ICD_LIBRARY_DIR}")
-target_link_libraries(oclruntime PRIVATE ${AMD_ICD_LIBRARY})
+if(TARGET OpenCL)
+  target_link_libraries(oclruntime PRIVATE OpenCL)
+else()
+  list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/../../../../cmake")
+  find_package(AMD_ICD)
+  find_library(AMD_ICD_LIBRARY OpenCL HINTS "${AMD_ICD_LIBRARY_DIR}")
+  target_link_libraries(oclruntime PRIVATE ${AMD_ICD_LIBRARY})
+endif()
 
 if (NOT WIN32)
   set(THREADS_PREFER_PTHREAD_FLAG ON)

--- a/projects/clr/opencl/tools/clinfo/CMakeLists.txt
+++ b/projects/clr/opencl/tools/clinfo/CMakeLists.txt
@@ -1,15 +1,25 @@
+if(TARGET OpenCL)
+  set(CLINFO_OPENCL_LIB OpenCL)
+else()
+  list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/../../cmake")
+  find_package(AMD_ICD)
+  find_library(AMD_ICD_LIBRARY OpenCL HINTS "${AMD_ICD_LIBRARY_DIR}")
+  if(AMD_ICD_LIBRARY)
+    set(CLINFO_OPENCL_LIB ${AMD_ICD_LIBRARY})
+  else()
+    message(WARNING "OpenCL ICD loader not found, skipping clinfo build.")
+    return()
+  endif()
+endif()
+
 add_executable(clinfo clinfo.cpp)
 
 target_compile_definitions(clinfo PRIVATE CL_TARGET_OPENCL_VERSION=220 HAVE_CL2_HPP)
 
-list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/../../cmake")
-find_package(AMD_ICD)
-
 #todo: to be updated to use header files from other repos
 target_include_directories(clinfo PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/../../khronos/headers/opencl2.2")
 
-find_library(AMD_ICD_LIBRARY OpenCL HINTS "${AMD_ICD_LIBRARY_DIR}")
-target_link_libraries(clinfo PRIVATE ${AMD_ICD_LIBRARY})
+target_link_libraries(clinfo PRIVATE ${CLINFO_OPENCL_LIB})
 
 INSTALL(TARGETS clinfo
   RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})

--- a/projects/clr/rocclr/cmake/ROCclr.cmake
+++ b/projects/clr/rocclr/cmake/ROCclr.cmake
@@ -110,7 +110,7 @@ if(WIN32)
   ${ROCCLR_SRC_DIR}/platform/interop_d3d9.cpp
   ${ROCCLR_SRC_DIR}/platform/interop_d3d10.cpp
   ${ROCCLR_SRC_DIR}/platform/interop_d3d11.cpp)
-  target_link_libraries(rocclr PUBLIC dxguid.lib)
+  target_link_libraries(rocclr PRIVATE dxguid.lib)
   target_compile_definitions(rocclr PUBLIC ATI_OS_WIN)
 else()
   target_compile_definitions(rocclr PUBLIC ATI_OS_LINUX)

--- a/projects/clr/rocclr/cmake/ROCclr.cmake
+++ b/projects/clr/rocclr/cmake/ROCclr.cmake
@@ -110,6 +110,7 @@ if(WIN32)
   ${ROCCLR_SRC_DIR}/platform/interop_d3d9.cpp
   ${ROCCLR_SRC_DIR}/platform/interop_d3d10.cpp
   ${ROCCLR_SRC_DIR}/platform/interop_d3d11.cpp)
+  target_link_libraries(rocclr PUBLIC dxguid.lib)
   target_compile_definitions(rocclr PUBLIC ATI_OS_WIN)
 else()
   target_compile_definitions(rocclr PUBLIC ATI_OS_LINUX)


### PR DESCRIPTION
## Motivation

ROCr on Windows

## Technical Details

Allow OpenCL build from open source in rocm-systems on Windows

## JIRA ID

ROCM-1667

## Test Plan

Make sure the build works with CMake using ROCr backend (-DROCCLR_ENABLE_HSA=ON) 

## Test Result

Builds fine

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
