### PR TITLE
[rocprofiler-systems] Remove `Development.Embed` requirement and fix bug when building multiple python versions

### DIFF
--- a/projects/rocprofiler-systems/CMakeLists.txt
+++ b/projects/rocprofiler-systems/CMakeLists.txt
@@ -188,8 +188,8 @@ rocprofiler_systems_add_option(ROCPROFSYS_BUILD_FOR_THEROCK "Build rocprofiler-s
 )
 
 if(ROCPROFSYS_BUILD_FOR_THEROCK)
-    # TheRock injects these variables, causing problems when we need to discover
-    # multiple python versions. Unset them to prevent this.
+    # TheRock injects these variables, which takes precedence over our
+    # own python discovery, even when versions differ. Unset them to prevent this.
     unset(Python3_EXECUTABLE CACHE)
     unset(_Python3_ROOT_DIR_LAST CACHE)
 

--- a/projects/rocprofiler-systems/CMakeLists.txt
+++ b/projects/rocprofiler-systems/CMakeLists.txt
@@ -191,7 +191,6 @@ if(ROCPROFSYS_BUILD_FOR_THEROCK)
     # TheRock injects these variables, which takes precedence over our
     # own python discovery, even when versions differ. Unset them to prevent this.
     unset(Python3_EXECUTABLE CACHE)
-    unset(_Python3_ROOT_DIR_LAST CACHE)
 
     set(ROCPROFSYS_INSTALL_TESTING
         ON

--- a/projects/rocprofiler-systems/CMakeLists.txt
+++ b/projects/rocprofiler-systems/CMakeLists.txt
@@ -188,6 +188,11 @@ rocprofiler_systems_add_option(ROCPROFSYS_BUILD_FOR_THEROCK "Build rocprofiler-s
 )
 
 if(ROCPROFSYS_BUILD_FOR_THEROCK)
+    # TheRock injects these variables, causing problems when we need to discover
+    # multiple python versions. Unset them to prevent this.
+    unset(Python3_EXECUTABLE CACHE)
+    unset(_Python3_ROOT_DIR_LAST CACHE)
+
     set(ROCPROFSYS_INSTALL_TESTING
         ON
         CACHE BOOL

--- a/projects/rocprofiler-systems/cmake/Packages.cmake
+++ b/projects/rocprofiler-systems/cmake/Packages.cmake
@@ -1086,18 +1086,17 @@ if(ROCPROFSYS_USE_PYTHON)
     include(ConfigPython)
     include(PyBind11Tools)
 
-    set(_ROCPROFSYS_USER_PYTHON_VERSIONS "${ROCPROFSYS_PYTHON_VERSIONS}")
-
     rocprofiler_systems_watch_for_change(ROCPROFSYS_PYTHON_ROOT_DIRS _PYTHON_DIRS_CHANGED)
     rocprofiler_systems_watch_for_change(ROCPROFSYS_PYTHON_VERSIONS _PYTHON_VERS_CHANGED)
 
     if(_PYTHON_DIRS_CHANGED)
         unset(ROCPROFSYS_PYTHON_VERSION CACHE)
-        # On first configure, if both VERSIONS and ROOT_DIRS are set, then
-        # _PYTHON_DIRS_CHANGED=ON and it unsets ROCPROFSYS_PYTHON_VERSIONS
-        # Prevent this by checking that user set ROCPROFSYS_PYTHON_VERSIONS
-        # and _PYTHON_VERS_CHANGED=ON
-        if(NOT _PYTHON_VERS_CHANGED OR NOT _ROCPROFSYS_USER_PYTHON_VERSIONS)
+        # Only discard cached versions if the user did not explicitly
+        # provide/change them on this configure run. This prevents a fresh
+        # build (where watch_for_change treats all new values as "changed")
+        # from discarding user-supplied versions while still allowing
+        # re-discovery when only root dirs change between reconfigures.
+        if(NOT _PYTHON_VERS_CHANGED OR NOT ROCPROFSYS_PYTHON_VERSIONS)
             unset(ROCPROFSYS_PYTHON_VERSIONS CACHE)
         endif()
         unset(ROCPROFSYS_INSTALL_PYTHONDIR CACHE)

--- a/projects/rocprofiler-systems/cmake/Packages.cmake
+++ b/projects/rocprofiler-systems/cmake/Packages.cmake
@@ -1132,7 +1132,9 @@ if(ROCPROFSYS_USE_PYTHON)
         set(ROCPROFSYS_PYTHON_VERSIONS "${ROCPROFSYS_PYTHON_VERSION}")
 
         if(NOT ROCPROFSYS_PYTHON_ROOT_DIRS)
-            rocprofiler_systems_find_python(_PY VERSION ${ROCPROFSYS_PYTHON_VERSION})
+            rocprofiler_systems_find_python(_PY VERSION ${ROCPROFSYS_PYTHON_VERSION}
+                COMPONENTS Interpreter
+            )
             set(ROCPROFSYS_PYTHON_ROOT_DIRS "${_PY_ROOT_DIR}" CACHE INTERNAL "" FORCE)
         endif()
 
@@ -1146,7 +1148,9 @@ if(ROCPROFSYS_USE_PYTHON)
         set(_PY_VERSIONS)
 
         foreach(_DIR ${ROCPROFSYS_PYTHON_ROOT_DIRS})
-            rocprofiler_systems_find_python(_PY ROOT_DIR ${_DIR})
+            rocprofiler_systems_find_python(_PY ROOT_DIR ${_DIR}
+                COMPONENTS Interpreter
+            )
 
             if(NOT _PY_FOUND)
                 continue()
@@ -1163,7 +1167,7 @@ if(ROCPROFSYS_USE_PYTHON)
         AND NOT ROCPROFSYS_PYTHON_VERSION
         AND NOT ROCPROFSYS_PYTHON_ROOT_DIRS
     )
-        rocprofiler_systems_find_python(_PY REQUIRED)
+        rocprofiler_systems_find_python(_PY REQUIRED COMPONENTS Interpreter)
         set(ROCPROFSYS_PYTHON_ROOT_DIRS "${_PY_ROOT_DIR}" CACHE INTERNAL "" FORCE)
         set(ROCPROFSYS_PYTHON_VERSIONS "${_PY_VERSION}" CACHE INTERNAL "" FORCE)
     endif()

--- a/projects/rocprofiler-systems/cmake/Packages.cmake
+++ b/projects/rocprofiler-systems/cmake/Packages.cmake
@@ -1086,11 +1086,20 @@ if(ROCPROFSYS_USE_PYTHON)
     include(ConfigPython)
     include(PyBind11Tools)
 
+    set(_ROCPROFSYS_USER_PYTHON_VERSIONS "${ROCPROFSYS_PYTHON_VERSIONS}")
+
     rocprofiler_systems_watch_for_change(ROCPROFSYS_PYTHON_ROOT_DIRS _PYTHON_DIRS_CHANGED)
+    rocprofiler_systems_watch_for_change(ROCPROFSYS_PYTHON_VERSIONS _PYTHON_VERS_CHANGED)
 
     if(_PYTHON_DIRS_CHANGED)
         unset(ROCPROFSYS_PYTHON_VERSION CACHE)
-        unset(ROCPROFSYS_PYTHON_VERSIONS CACHE)
+        # On first configure, if both VERSIONS and ROOT_DIRS are set, then
+        # _PYTHON_DIRS_CHANGED=ON and it unsets ROCPROFSYS_PYTHON_VERSIONS
+        # Prevent this by checking that user set ROCPROFSYS_PYTHON_VERSIONS
+        # and _PYTHON_VERS_CHANGED=ON
+        if(NOT _PYTHON_VERS_CHANGED OR NOT _ROCPROFSYS_USER_PYTHON_VERSIONS)
+            unset(ROCPROFSYS_PYTHON_VERSIONS CACHE)
+        endif()
         unset(ROCPROFSYS_INSTALL_PYTHONDIR CACHE)
     else()
         foreach(_VAR PREFIX ENVS)

--- a/projects/rocprofiler-systems/source/python/cmake/Modules/FindPyBind11Python.cmake
+++ b/projects/rocprofiler-systems/source/python/cmake/Modules/FindPyBind11Python.cmake
@@ -65,7 +65,9 @@ if(NOT DEFINED PyBind11Python_PYTHON)
     endif()
 endif()
 
-if(NOT PyBind11Python_COMPONENTS)
+if(PyBind11Python_FIND_COMPONENTS)
+    set(PyBind11Python_COMPONENTS ${PyBind11Python_FIND_COMPONENTS})
+elseif(NOT PyBind11Python_COMPONENTS)
     set(PyBind11Python_COMPONENTS Interpreter Development)
 endif()
 

--- a/projects/rocprofiler-systems/source/python/cmake/PyBind11Tools.cmake
+++ b/projects/rocprofiler-systems/source/python/cmake/PyBind11Tools.cmake
@@ -206,6 +206,7 @@ function(ROCPROFILER_SYSTEMS_PYBIND11_ADD_MODULE target_name)
     endif()
 
     list(INSERT CMAKE_MODULE_PATH 0 "${PROJECT_SOURCE_DIR}/source/python/cmake/Modules")
+    set(PyBind11Python_COMPONENTS Interpreter Development.Module)
     find_package(PyBind11Python ${ARG_PYTHON_VERSION})
 
     target_include_directories(

--- a/projects/rocprofiler-systems/source/python/cmake/PyBind11Tools.cmake
+++ b/projects/rocprofiler-systems/source/python/cmake/PyBind11Tools.cmake
@@ -206,8 +206,11 @@ function(ROCPROFILER_SYSTEMS_PYBIND11_ADD_MODULE target_name)
     endif()
 
     list(INSERT CMAKE_MODULE_PATH 0 "${PROJECT_SOURCE_DIR}/source/python/cmake/Modules")
-    set(PyBind11Python_COMPONENTS Interpreter Development.Module)
-    find_package(PyBind11Python ${ARG_PYTHON_VERSION})
+    find_package(
+        PyBind11Python
+        ${ARG_PYTHON_VERSION}
+        COMPONENTS Interpreter Development.Module
+    )
 
     target_include_directories(
         ${target_name}


### PR DESCRIPTION
## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

For https://github.com/ROCm/TheRock/pull/3541

There are **3** problems:

**Problem 1**:
`install.rst` tells us that if we want to build with multiple Python versions, to do:
```
to build multiple Python versions, use
``ROCPROFSYS_PYTHON_VERSIONS="<MAJOR>.<MINOR>;[<MAJOR>.<MINOR>]"``,
and ``ROCPROFSYS_PYTHON_ROOT_DIRS="/path/to/version;[/path/to/version]"`` instead of just ``ROCPROFSYS_PYTHON_VERSIONS``
```
On my system, I have both python `3.8` and `3.12` under `/usr/bin/...`. Building with the following command:
```
cmake -B rocprof-sys-build -S . \
    -D CMAKE_INSTALL_PREFIX=/opt/rocprofiler-systems \
    -D ROCPROFSYS_USE_PYTHON=ON \
    -D ROCPROFSYS_BUILD_DYNINST=ON \
    -D ROCPROFSYS_BUILD_TBB=ON \
    -D ROCPROFSYS_BUILD_BOOST=ON \
    -D ROCPROFSYS_BUILD_ELFUTILS=ON \
    -D ROCPROFSYS_BUILD_LIBIBERTY=ON \
    -D ROCPROFSYS_PYTHON_VERSIONS="3.8;3.12" \
    -D ROCPROFSYS_PYTHON_ROOT_DIRS="/usr;/usr"
```

Produces a build failure that says:
```
[rocprofiler-systems] Error! Number of python versions != number of python
  root directories
```

This should be impossible considering they match in the build command.

**Oddly enough, if you rebuild again without `rm -rf` the build directory, the configure succeeds**... Indeed:
```
-- Found Python3: /usr/bin/python3.8 (found suitable exact version "3.8.20") found components: Interpreter Development Development.Module Development.Embed 
-- Found Python3: /usr/bin/python3 (found suitable exact version "3.12.3") found components: Interpreter Development Development.Module Development.Embed 
```

**Problem 2**:
Per @lumachad observations, we don't seem to require anything that links against `libpython`, however, our project fails to build without it.

**Problem 3**: 
Suppose a user was trying to build our project, and they passed in `Python3_EXECUTABLE` (this is *essentially* what TheRock does). For example:
```
cmake -B rocprof-sys-build -S . \
    -D CMAKE_INSTALL_PREFIX=/opt/rocprofiler-systems \
    -D ROCPROFSYS_USE_PYTHON=ON \
    -D ROCPROFSYS_BUILD_DYNINST=ON \
    -D ROCPROFSYS_BUILD_TBB=ON \
    -D ROCPROFSYS_BUILD_BOOST=ON \
    -D ROCPROFSYS_BUILD_ELFUTILS=ON \
    -D ROCPROFSYS_BUILD_LIBIBERTY=ON \
    -D ROCPROFSYS_PYTHON_VERSIONS="3.8;3.12" \
    -D ROCPROFSYS_PYTHON_ROOT_DIRS="/usr;/usr" \
    -D Python3_EXECUTABLE=/usr/bin/python3.8
```
Notice that it screws up our Python detection.
```
-- Found Python3: /usr/bin/python3.8 (found suitable exact version "3.8.20") found components: Interpreter Development Development.Module Development.Embed 
-- Could NOT find Python3: Found unsuitable version "3.8.20", but required is exact version "3.12" (found /usr/bin/python3.8, found components: Interpreter Development Development.Module Development.Embed)
```
This causes quite a severe headache on TheRock.

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

**Problem 1**: Solution

The root cause of this build failure is in the `if(ROCPROFSYS_USE_PYTHON)` block in `Packages.cmake`. 
On first build, the code calls `rocprofiler_systems_watch_for_change(ROCPROFSYS_PYTHON_ROOT_DIRS _PYTHON_DIRS_CHANGED)`, and `_PYTHON_DIRS_CHANGED` will be **true** (user defines it and the function detects that it was never set, which is a "change"). 
As a direct consequence, it **unsets ROCPROFSYS_PYTHON_VERSIONS**. It then falls back to auto detecting the python version from the root dirs, which both have `/usr`, and it only finds `python3.12`. 1 version and 2 root dirs = length mismatch causing build failure.

The solution is to store `ROCPROFSYS_PYTHON_VERSIONS` and then check for change in `ROCPROFSYS_PYTHON_VERSIONS` (which will be true on first configure). If so, do NOT unset `ROCPROFSYS_PYTHON_VERSIONS`. With this change, we do not see the build failure anymore. 

**Problem 2**: Solution

We seem to not *really* require `libpython`. Upon investigation, the code that controls all of this was written BEFORE cmake `3.18` was released. This is important as before this version, cmake did not allow specifying `Development.Embed` and `Development.Module`. 

Updating the code in both `PyBind11Tools.cmake` and calls to `rocprofiler_systems_find_python` to specifically not require `Development.Embed` results in no build failures. The standard python bindings are built and no linking to `libpython` is required. Thus, a python install with shared libraries is no longer required. 

**Problem 3**: Solution

Just unset it. For now, I'll only do this if `ROCPROFSYS_BUILD_FOR_THEROCK=ON`, but I don't think it would hurt to have this be done in every case. 

## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

Manual build
Building on TheRock with https://github.com/ROCm/TheRock/pull/3541

## Test Result

<!-- Briefly summarize test outcomes. -->

Manual build - Passes and both 3.8 and 3.12 python requirements are present
Building on TheRock - Builds and requires artifacts are present (**LOCAL BUILD**)
 - Verified using commit 2112caa295e689d461501fb9623714f7b8a7232b

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
