### PR TITLE
fix: resolve CPU device path lookup in CLI query-device and library

### DIFF
--- a/projects/cuid/cli/amdcuid_tool.cc
+++ b/projects/cuid/cli/amdcuid_tool.cc
@@ -394,6 +394,15 @@ int query_device(const std::string& identifier, bool show_primary, const std::st
             std::cerr << "Valid types: platform, cpu, gpu, nic" << std::endl;
             return 1;
         }
+    } else {
+        // Infer device type from device path when --type is not specified
+        if (identifier.find("/sys/devices/system/cpu/") != std::string::npos) {
+            device_type = AMDCUID_DEVICE_TYPE_CPU;
+        } else if (identifier.find("/sys/class/net/") != std::string::npos) {
+            device_type = AMDCUID_DEVICE_TYPE_NIC;
+        } else if (identifier.find("/sys/class/drm/") != std::string::npos) {
+            device_type = AMDCUID_DEVICE_TYPE_GPU;
+        }
     }
     
     // Check if identifier looks like a BDF (contains ':' and '.')

--- a/projects/cuid/lib/src/cuid.cc
+++ b/projects/cuid/lib/src/cuid.cc
@@ -30,6 +30,7 @@
 #include "src/cuid_nic.h"
 #include "src/cuid_platform.h"
 #include "src/hmac.h"
+#include <climits>
 #include <cstring>
 #include <dirent.h>
 #include <sys/types.h>
@@ -127,6 +128,27 @@ amdcuid_status_t amdcuid_get_all_handles(amdcuid_id_t *handles, uint32_t *count)
 DevicePtr discover_device_by_path(const char* dev_path, amdcuid_device_type_t device_type) {
     DevicePtr device = nullptr;
     amdcuid_status_t status;
+
+    // CPU sysfs paths (e.g., /sys/devices/system/cpu/cpu0) are directories,
+    // not character/block devices, so real_dev_path_from_fd() cannot resolve
+    // them via /sys/dev/char or /sys/dev/block. Use the path directly,
+    // resolving symlinks with realpath but without appending "/device".
+    if (device_type == AMDCUID_DEVICE_TYPE_CPU) {
+        char buf[PATH_MAX];
+        std::string resolved_path;
+        if (realpath(dev_path, buf) != nullptr) {
+            resolved_path = std::string(buf);
+        } else {
+            resolved_path = dev_path;
+        }
+        amdcuid_cpu_info cpu_info = {};
+        status = CuidCpu::discover_single(&cpu_info, resolved_path);
+        if (status != AMDCUID_STATUS_SUCCESS) {
+            return nullptr;
+        }
+        return std::make_shared<CuidCpu>(cpu_info);
+    }
+
     int fd = open(dev_path, O_RDONLY);
     if (fd < 0) {
         // unable to open device path
@@ -140,15 +162,6 @@ DevicePtr discover_device_by_path(const char* dev_path, amdcuid_device_type_t de
         return nullptr;
     }
     switch (device_type) {
-        case AMDCUID_DEVICE_TYPE_CPU: {
-            amdcuid_cpu_info cpu_info = {};
-            status = CuidCpu::discover_single(&cpu_info, real_dev_path);
-            if (status != AMDCUID_STATUS_SUCCESS) {
-                return nullptr;
-            }
-            device = std::make_shared<CuidCpu>(cpu_info);
-            break;
-        }
         case AMDCUID_DEVICE_TYPE_GPU: {
             amdcuid_gpu_info gpu_info = {};
             status = CuidGpu::discover_single(&gpu_info, real_dev_path);
@@ -180,15 +193,21 @@ amdcuid_status_t amdcuid_get_handle_by_dev_path(const char* dev_path, amdcuid_de
 
     const std::string input_dev_path(dev_path);
     std::string real_dev_path;
-    // For NIC paths (e.g., /sys/class/net/eth0) and GPU paths
-    // (e.g., /sys/class/drm/renderD128), use the path as-is since
+    // For NIC paths (e.g., /sys/class/net/eth0), GPU paths
+    // (e.g., /sys/class/drm/renderD128), and CPU paths
+    // (e.g., /sys/devices/system/cpu/cpu0), use the path as-is since
     // get_real_path resolves symlinks and appends "/device" which does not
     // match how device_node paths are stored in CUID files.
+    // CPU and Platform sysfs paths are directories without a /device
+    // subdirectory, so the /device suffix would produce an invalid path.
     std::string dev_path_str(dev_path);
     if (device_type == AMDCUID_DEVICE_TYPE_NIC
         || device_type == AMDCUID_DEVICE_TYPE_GPU
+        || device_type == AMDCUID_DEVICE_TYPE_CPU
+        || device_type == AMDCUID_DEVICE_TYPE_PLATFORM
         || dev_path_str.find("/sys/class/net/") != std::string::npos
-        || dev_path_str.find("/sys/class/drm/") != std::string::npos) {
+        || dev_path_str.find("/sys/class/drm/") != std::string::npos
+        || dev_path_str.find("/sys/devices/system/cpu/") != std::string::npos) {
         real_dev_path = dev_path_str;
     } else {
         real_dev_path = CuidUtilities::get_real_path(dev_path);


### PR DESCRIPTION
## Motivation

The --query-device CLI option cannot find CPU devices by their device path, always returning DEVICE_NOT_FOUND. This prevents users from querying individual CPU CUIDs.

## Technical Details

The failure stems from three issues in the lookup pipeline:

1. Path resolution (cuid.cc) — get_real_path() appends /device to resolved paths, which is valid for GPU/NIC nodes but breaks CPU/Platform sysfs directories. Fixed by bypassing this for CPU and Platform device types.
2. Device discovery (cuid.cc) — Discovery resolves paths via fstat() + char major:minor lookup, which only works for char/block devices. CPU paths are plain directories, so this always fails. Fixed by using realpath() directly for CPU devices.
3. CLI type defaulting (amdcuid_tool.cc) — Without --type, the tool defaults to GPU, so CPU paths never match. Added path-based type inference from well-known sysfs prefixes. Explicit --type still takes priority.

## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan

- Clean rebuild across all targets (lib, CLI, daemon, example, tests) — zero errors/warnings.
- Full unit test suite execution.
- Manual validation of ./amdcuid_tool --query-device /sys/devices/system/cpu/cpu91 with and without --type cpu.

## Test Result

Build clean. 15/15 unit tests pass (2 skipped — root-only, 1 pre-existing unrelated failure). No regressions in GPU, NIC, or BDF query paths.


## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
