### PR TITLE
[AICOMRCCL-697] Add --enable-mpi-tests and --cmake-options to install.sh

### DIFF
--- a/projects/rccl/docs/install/installation.rst
+++ b/projects/rccl/docs/install/installation.rst
@@ -52,31 +52,65 @@ The RCCL build and installation helper script options are as follows:
 .. code-block:: shell
 
        --address-sanitizer     Build with address sanitizer enabled
+    -c|--enable-code-coverage  Enable code coverage
     -d|--dependencies          Install RCCL dependencies
        --debug                 Build debug library
+       --debug-fast            Build debug library with lto optimization disabled (fast build times)
        --enable_backtrace      Build with custom backtrace support
        --disable-colltrace     Build without collective trace
-       --disable-msccl-kernel  Build without MSCCL kernels
+       --enable-msccl-kernel   Build with MSCCL kernels
+       --dump-asm              Disassemble code and dump assembly with inline code
        --enable-mscclpp        Build with MSCCL++ support
+       --enable-mscclpp-clip   Build MSCCL++ with clip wrapper on bfloat16 and half addition routines
+       --disable-roctx         Build without ROCTX logging
     -f|--fast                  Quick-build RCCL (local gpu arch only, no backtrace, and collective trace support)
     -h|--help                  Prints this help message
     -i|--install               Install RCCL library (see --prefix argument below)
-    -j|--jobs                  Specify how many parallel compilation jobs to run ($nproc by default)
+    -j|--jobs                  Specify how many parallel compilation jobs to run (128 by default)
+       --kernel-resource-use   Dump GPU kernel resource usage (e.g., VGPRs, scratch, spill) at link stage
     -l|--local_gpu_only        Only compile for local GPU architecture
        --amdgpu_targets        Only compile for specified GPU architecture(s). For multiple targets, separate by ';' (builds for all supported GPU architectures by default)
        --no_clean              Don't delete files if they already exist
        --npkit-enable          Compile with npkit enabled
+       --log-trace             Build with log trace enabled (i.e. NCCL_DEBUG=TRACE)
+       --enable-mpi-tests      Enable MPI-based tests (requires --debug and MPI installation; set MPI_PATH if not in /opt/ompi)
        --openmp-test-enable    Enable OpenMP in rccl unit tests
-       --roctx-enable          Compile with roctx enabled (example usage: rocprof --roctx-trace ./rccl-program)
     -p|--package_build         Build RCCL package
        --prefix                Specify custom directory to install RCCL to (default: `/opt/rocm`)
-       --rm-legacy-include-dir Remove legacy include dir Packaging added for file/folder reorg backward compatibility
        --run_tests_all         Run all rccl unit tests (must be built already)
     -r|--run_tests_quick       Run small subset of rccl unit tests (must be built already)
        --static                Build RCCL as a static library instead of shared library
     -t|--tests_build           Build rccl unit tests, but do not run
        --time-trace            Plot the build time of RCCL (requires `ninja-build` package installed on the system)
        --verbose               Show compile commands
+       --force-reduce-pipeline Force reduce_copy sw pipeline to be used for every reduce-based collectives and datatypes
+       --generate-sym-kernels  Generate symmetric memory kernels
+    -q|--quiet-warnings        Suppress majority of compiler warnings (not recommended)
+       --rocshmem              Build with rocSHMEM support
+       --cmake-options         Pass additional CMake options (e.g. --cmake-options "-DFOO=BAR -DBAZ=ON")
+
+  Available RCCL-specific CMake options for --cmake-options:
+    -DBUILD_EXT_EXAMPLES=ON               Build ext-{net,tuner,profiler} example plugins (default: OFF)
+    -DENABLE_MSCCLPP_EXECUTOR=ON          Enable MSCCL++ Executor (default: OFF)
+    -DENABLE_MSCCLPP_FORMAT_CHECKS=ON     Enable formatting checks in MSCCL++ (default: OFF)
+    -DMSCCLPP_APPLY_PATCHES=OFF           Disable source code patches for MSCCL++ (default: ON)
+    -DENABLE_IFC=ON                       Enable indirect function call (default: OFF)
+    -DPROFILE=ON                          Enable profiling (default: OFF)
+    -DTIMETRACE=ON                        Enable time-trace during compilation (default: OFF)
+    -DFAULT_INJECTION=OFF                 Disable fault injection (default: ON)
+    -DDWORDX4_INTRINSICS=OFF              Disable dwordx4 intrinsics (default: ON)
+    -DENABLE_COMPRESS=OFF                 Disable GPU code compression (default: ON)
+    -DRCCL_ROCPROFILER_REGISTER=OFF       Disable rocprofiler-register support (default: ON)
+
+  Environment variables:
+    ONLY_FUNCS                 Build only specified collective functions (debug builds only).
+                               Restricts GPU kernel generation to the listed collectives, significantly
+                               reducing build time during development. Use '|' to separate multiple functions.
+                               Example: ONLY_FUNCS="AllReduce|SendRecv" ./install.sh --debug -t
+                               Available: AllReduce, Broadcast, Reduce, AllGather, ReduceScatter,
+                                          AlltoAllPivot, SendRecv, AlltoAllGda, AlltoAllvGda
+                               Advanced: Specify algo, protocol, redop, and type per collective.
+                                 ONLY_FUNCS="AllReduce RING SIMPLE Sum f32|SendRecv"
 
 .. tip::
 

--- a/projects/rccl/install.sh
+++ b/projects/rccl/install.sh
@@ -33,6 +33,7 @@ enable_mscclpp_clip=false
 num_parallel_jobs=$(nproc)
 npkit_enabled=false
 openmp_test_enabled=false
+enable_mpi_tests=false
 kernel_resource_use=false
 roctx_enabled=true
 run_tests=false
@@ -43,6 +44,7 @@ generate_sym_kernels=false
 warp_speed_enabled=true # note that this flag will be overridden to false for non MI350/MI300 platforms
 quiet_warnings=false
 build_rocshmem_support=false
+custom_cmake_options=""
 
 # #################################################
 # helper functions
@@ -73,6 +75,7 @@ function display_help()
     echo "       --no_clean              Don't delete files if they already exist"
     echo "       --npkit-enable          Compile with npkit enabled"
     echo "       --log-trace             Build with log trace enabled (i.e. NCCL_DEBUG=TRACE)"
+    echo "       --enable-mpi-tests      Enable MPI-based tests (requires --debug and MPI installation; set MPI_PATH if not in /opt/ompi)"
     echo "       --openmp-test-enable    Enable OpenMP in rccl unit tests"
     echo "    -p|--package_build         Build RCCL package"
     echo "       --prefix                Specify custom directory to install RCCL to (default: \`/opt/rocm\`)"
@@ -86,6 +89,30 @@ function display_help()
     echo "       --generate-sym-kernels  Generate symmetric memory kernels"
     echo "    -q|--quiet-warnings        Suppress majority of compiler warnings (not recommended)"
     echo "       --rocshmem              Build with rocSHMEM support"
+    echo "       --cmake-options         Pass additional CMake options (e.g. --cmake-options \"-DFOO=BAR -DBAZ=ON\")"
+    echo ""
+    echo "  Available RCCL-specific CMake options for --cmake-options:"
+    echo "    -DBUILD_EXT_EXAMPLES=ON               Build ext-{net,tuner,profiler} example plugins (default: OFF)"
+    echo "    -DENABLE_MSCCLPP_EXECUTOR=ON          Enable MSCCL++ Executor (default: OFF)"
+    echo "    -DENABLE_MSCCLPP_FORMAT_CHECKS=ON     Enable formatting checks in MSCCL++ (default: OFF)"
+    echo "    -DMSCCLPP_APPLY_PATCHES=OFF           Disable source code patches for MSCCL++ (default: ON)"
+    echo "    -DENABLE_IFC=ON                       Enable indirect function call (default: OFF)"
+    echo "    -DPROFILE=ON                          Enable profiling (default: OFF)"
+    echo "    -DTIMETRACE=ON                        Enable time-trace during compilation (default: OFF)"
+    echo "    -DFAULT_INJECTION=OFF                 Disable fault injection (default: ON)"
+    echo "    -DDWORDX4_INTRINSICS=OFF              Disable dwordx4 intrinsics (default: ON)"
+    echo "    -DENABLE_COMPRESS=OFF                 Disable GPU code compression (default: ON)"
+    echo "    -DRCCL_ROCPROFILER_REGISTER=OFF       Disable rocprofiler-register support (default: ON)"
+    echo ""
+    echo "  Environment variables:"
+    echo "    ONLY_FUNCS                 Build only specified collective functions (debug builds only)."
+    echo "                               Restricts GPU kernel generation to the listed collectives, significantly"
+    echo "                               reducing build time during development. Use '|' to separate multiple functions."
+    echo "                               Example: ONLY_FUNCS=\"AllReduce|SendRecv\" ./install.sh --debug -t"
+    echo "                               Available: AllReduce, Broadcast, Reduce, AllGather, ReduceScatter,"
+    echo "                                          AlltoAllPivot, SendRecv, AlltoAllGda, AlltoAllvGda"
+    echo "                               Advanced: Specify algo, protocol, redop, and type per collective."
+    echo "                                 ONLY_FUNCS=\"AllReduce RING SIMPLE Sum f32|SendRecv\""
 }
 
 # #################################################
@@ -95,7 +122,7 @@ function display_help()
 # check if we have a modern version of getopt that can handle whitespace and long parameters
 getopt -T
 if [[ "$?" -eq 4 ]]; then
-    GETOPT_PARSE=$(getopt --name "${0}" --options cdfhij:lprtq --longoptions address-sanitizer,dependencies,debug,debug-fast,dump-asm,enable-code-coverage,enable_backtrace,disable-colltrace,disable-msccl-kernel,enable-mscclpp,fast,help,install,jobs:,kernel-resource-use,local_gpu_only,amdgpu_targets:,no_clean,npkit-enable,log-trace,openmp-test-enable,roctx-enable,package_build,prefix:,rm-legacy-include-dir,run_tests_all,run_tests_quick,static,tests_build,time-trace,force-reduce-pipeline,generate-sym-kernels,quiet-warnings,disable-warp-speed,verbose,rocshmem -- "$@")
+    GETOPT_PARSE=$(getopt --name "${0}" --options cdfhij:lprtq --longoptions address-sanitizer,dependencies,debug,debug-fast,dump-asm,enable-code-coverage,enable_backtrace,disable-colltrace,disable-msccl-kernel,enable-mscclpp,enable-mpi-tests,fast,help,install,jobs:,kernel-resource-use,local_gpu_only,amdgpu_targets:,no_clean,npkit-enable,log-trace,openmp-test-enable,roctx-enable,package_build,prefix:,rm-legacy-include-dir,run_tests_all,run_tests_quick,static,tests_build,time-trace,force-reduce-pipeline,generate-sym-kernels,quiet-warnings,disable-warp-speed,verbose,rocshmem,cmake-options: -- "$@")
 else
     echo "Need a new version of getopt"
     exit 1
@@ -121,6 +148,7 @@ while true; do
          --dump-asm)                 dump_asm=true;                                                                                    shift ;;
          --enable-mscclpp)           mscclpp_enabled=true;                                                                             shift ;;
          --enable-mscclpp-clip)      enable_mscclpp_clip=true;                                                                         shift ;;
+         --enable-mpi-tests)         enable_mpi_tests=true;                                                                            shift ;;
          --disable-roctx)            roctx_enabled=false;                                                                              shift ;;
     -f | --fast)                     build_local_gpu_only=true; collective_trace=false; msccl_kernel_enabled=false;                    shift ;;
     -h | --help)                     display_help;                                                                                     exit 0 ;;
@@ -146,6 +174,7 @@ while true; do
          --disable-warp-speed)       warp_speed_enabled=false;                                                                         shift ;;
     -q | --quiet-warnings)           quiet_warnings=true;                                                                              shift ;;
          --rocshmem)                 build_rocshmem_support=true;                                                                      shift ;;
+         --cmake-options)            custom_cmake_options=${2};                                                                         shift 2 ;;
     --) shift ; break ;;
     *)  echo "Unexpected command line parameter received; aborting";
         exit 1
@@ -313,6 +342,15 @@ if [[ "${openmp_test_enabled}" == true ]]; then
     cmake_common_options="${cmake_common_options} -DOPENMP_TESTS_ENABLED=ON"
 fi
 
+# Enable MPI tests (debug only)
+if [[ "${enable_mpi_tests}" == true ]]; then
+    if [[ "${build_release}" == true ]]; then
+        echo "ERROR: --enable-mpi-tests requires --debug. Please re-run with --debug."
+        exit 1
+    fi
+    cmake_common_options="${cmake_common_options} -DENABLE_MPI_TESTS=ON"
+fi
+
 # Force Reduce pipeline
 if [[ "${force_reduce_pipeline}" == true ]]; then
     cmake_common_options="${cmake_common_options} -DFORCE_REDUCE_PIPELINING=ON"
@@ -372,6 +410,11 @@ fi
 
 # Add build directory to RPATH for packaging dependency resolution
 cmake_common_options="${cmake_common_options} -DCMAKE_EXE_LINKER_FLAGS=\"-Wl,-rpath,${PWD}\""
+
+# Append any custom CMake options passed via --cmake-options
+if [[ ! -z "${custom_cmake_options}" ]]; then
+    cmake_common_options="${cmake_common_options} ${custom_cmake_options}"
+fi
 
 # Initiate RCCL CMake
 # Passing ONLY_FUNCS separately (not as part of ${cmake_common_options}) as

--- a/projects/rccl/test/CMakeLists.txt
+++ b/projects/rccl/test/CMakeLists.txt
@@ -40,9 +40,11 @@ if(BUILD_TESTS)
 
   # MPI configuration
   if(ENABLE_MPI_TESTS)
-    # Set default MPI path, allow user to override
-    if(NOT DEFINED MPI_PATH)
-        set(MPI_PATH "/opt/ompi" CACHE PATH "Path to MPI installation")
+    # Set MPI path: 1) environment variable (always wins), 2) CMake variable, 3) default
+    if(DEFINED ENV{MPI_PATH})
+      set(MPI_PATH "$ENV{MPI_PATH}" CACHE PATH "Path to MPI installation" FORCE)
+    elseif(NOT DEFINED MPI_PATH)
+      set(MPI_PATH "/opt/ompi" CACHE PATH "Path to MPI installation")
     endif()
 
     # Verify MPI path exists


### PR DESCRIPTION
## Motivation

- Add --enable-mpi-tests flag (requires --debug; MPI tests reference internal RCCL symbols hidden in release builds)
- Add --cmake-options pass-through for arbitrary CMake -D options
- Update docs/install/installation.rst with new options and environment variable documentation (ONLY_FUNCS)

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## JIRA ID

AICOMRCCL-697

## Test Plan

Verified that --enable-mpi-tests correctly gates on --debug and passes -DENABLE_MPI_TESTS=ON to CMake. Verified --cmake-options appends options to the CMake invocation.

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
