### PR TITLE
rocr: Enable DXG detection by default

### DIFF
--- a/projects/rocr-runtime/runtime/hsa-runtime/core/util/flag.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/util/flag.h
@@ -297,7 +297,7 @@ class Flag {
 
     // This allows detecting if the dxg driver is loaded.
     var = os::GetEnvVar("HSA_ENABLE_DXG_DETECTION");
-    enable_dxg_detection_ = (var == "1") ? true : false;
+    enable_dxg_detection_ = (var == "0") ? false : true;
 
     var = os::GetEnvVar("HSA_CO_DMACOPY_SIZE");
     co_dmacopy_size_ = var.empty() ? 1024*1024 : atoi(var.c_str());


### PR DESCRIPTION
This change updates the DXG detection flag handling to use default-on behavior. When HSA_ENABLE_DXG_DETECTION is not set, DXG detection is treated as enabled.