### PR TITLE
[Rocprof-Compute] Refactoring  --list-torch-operators to use kernel ids from kernel top-stats table

### DIFF
--- a/projects/rocprofiler-compute/src/rocprof_compute_analyze/analysis_base.py
+++ b/projects/rocprofiler-compute/src/rocprof_compute_analyze/analysis_base.py
@@ -36,7 +36,7 @@ import pandas as pd
 
 import config
 from rocprof_compute_soc.soc_base import OmniSoC_Base
-from utils import file_io, parser, schema, tty
+from utils import file_io, parser, schema
 from utils.logger import (
     console_debug,
     console_error,
@@ -46,13 +46,10 @@ from utils.logger import (
 )
 from utils.roofline_calc import validate_roofline_csv
 from utils.utils import (
-    build_kernel_name_to_id,
-    compute_operator_prefix_stats,
     get_uuid,
     impute_counters_iteration_multiplex,
     is_workload_empty,
     merge_counters_spatial_multiplex,
-    process_torch_trace_output,
 )
 
 # the build-in config to list kernel names purpose only
@@ -153,72 +150,6 @@ class OmniAnalyze_Base:
         return self._arch_configs
 
     @demarcate
-    def list_torch_operators(self) -> None:
-        """
-        List PyTorch operators with hierarchy, numbering, and durations.
-
-        Displays each operator with hierarchy, operator/kernel
-        durations, and numbering.
-        """
-        workload_path = (
-            self.__args.path[0][0]
-            if isinstance(self.__args.path[0], list)
-            else self.__args.path[0]
-        )
-        process_torch_trace_output(workload_path)
-        torch_trace_dir = Path(workload_path) / "torch_trace"
-        all_files = list(torch_trace_dir.glob("*.csv"))
-        # Load each CSV, compute prefix_stats once, and derive
-        # total duration (highest first)
-        file_data: list[
-            tuple[Path, pd.DataFrame, dict[str, tuple[float, int]], float]
-        ] = []
-        for f in all_files:
-            try:
-                df = pd.read_csv(f)
-                ps = compute_operator_prefix_stats(df)
-                total_ms = sum(dur for key, (dur, _) in ps.items() if "/" not in key)
-                file_data.append((f, df, ps, total_ms))
-            except Exception as e:
-                console_error(f"Failed to read operator from {f.name}: {e}")
-        # Sort by total duration in descending order
-        file_data.sort(key=lambda x: x[3], reverse=True)
-        # Use default kernel verbosity = 1
-        kernel_verbose = getattr(self.__args, "kernel_verbose", 1)
-        kernel_name_to_id = build_kernel_name_to_id(
-            [df for _, df, _, _ in file_data], kernel_verbose
-        )
-        # print() is intentional: banner lines are display output that wraps
-        # tty.show_torch_operator_hierarchy (also print-based); console_log
-        # would prepend an INFO prefix in colored log modes.
-        print(f"\n{'=' * 80}")
-        print(f"PyTorch Operators in: {workload_path}")
-        if kernel_name_to_id:
-            print("Kernel (id N) can be used with -k for filtering.")
-        print(f"{'=' * 80}\n")
-        operator_count = 0
-        for idx, (f, df, ps, total_ms) in enumerate(file_data, start=1):
-            tty.show_torch_operator_hierarchy(
-                str(f.name).replace(".csv", ""),
-                df,
-                index=idx,
-                kernel_name_to_id=kernel_name_to_id,
-                kernel_verbose=kernel_verbose,
-                prefix_stats=ps,
-            )
-            operator_count += 1
-
-        if not operator_count:
-            console_warning(
-                "No PyTorch operator data found. "
-                "Please ensure profiling was done with --torch-trace option."
-            )
-
-        print(f"\n{'=' * 80}")
-        print(f"Total: {operator_count} operators")
-        print(f"{'=' * 80}\n")
-
-    @demarcate
     def load_options(self, normalization_filter: Optional[str]) -> None:
         args = self.get_args()
         profiling_config = self.get_profiling_config()
@@ -246,10 +177,6 @@ class OmniAnalyze_Base:
         self, normalization_filter: Optional[str] = None
     ) -> OrderedDict[str, schema.Workload]:
         args = self.get_args()
-
-        if getattr(args, "list_torch_operators", False):
-            self.list_torch_operators()
-            sys.exit(0)
 
         def get_sysinfo_path(data_path: str) -> Optional[str]:
             return (

--- a/projects/rocprofiler-compute/src/rocprof_compute_analyze/analysis_cli.py
+++ b/projects/rocprofiler-compute/src/rocprof_compute_analyze/analysis_cli.py
@@ -23,11 +23,16 @@
 
 ##############################################################################
 
+import sys
+from pathlib import Path
+
+import pandas as pd
+
 from rocprof_compute_analyze.analysis_base import OmniAnalyze_Base
 from utils import file_io, parser, tty
 from utils.kernel_name_shortener import kernel_name_shortener
 from utils.logger import console_error, console_log, demarcate
-from utils.utils import sanitize_torch_operator_key
+from utils.utils import process_torch_trace_output
 
 
 class cli_analysis(OmniAnalyze_Base):
@@ -77,6 +82,18 @@ class cli_analysis(OmniAnalyze_Base):
                 kernel_verbose=args.kernel_verbose,
             )
 
+            if getattr(args, "list_torch_operators", False):
+                kernel_top_df = pd.read_csv(
+                    Path(path_info[0]) / "pmc_kernel_top.csv"
+                )
+                file_data = process_torch_trace_output(
+                    path_info[0],
+                    kernel_top_df=kernel_top_df,
+                    kernel_verbose=args.kernel_verbose,
+                )
+                tty.list_torch_operators(path_info[0], file_data)
+                sys.exit(0)
+
             # demangle and overwrite original 'Kernel_Name'
             kernel_name_shortener(workload.raw_pmc, args.kernel_verbose)
 
@@ -125,7 +142,7 @@ class cli_analysis(OmniAnalyze_Base):
             for op in operator_list:
                 is_hierarchy = "/" in op
                 lookup = op.split("/")[-1] if is_hierarchy else op
-                op_key = sanitize_torch_operator_key(lookup)
+                op_key = lookup.replace("torch.", "").replace(".", "_")
                 df = torch_ops.get(op_key)
                 if df is None:
                     console_log(f"No data for operator: {op}")

--- a/projects/rocprofiler-compute/src/utils/tty.py
+++ b/projects/rocprofiler-compute/src/utils/tty.py
@@ -35,15 +35,12 @@ from tabulate import tabulate
 import config
 from utils import mem_chart, parser, schema
 from utils.kernel_name_shortener import (
-    MAX_SHORTENING_LEVEL,
     kernel_name_shortener,
-    process_single_kernel_name,
 )
 from utils.logger import console_error, console_log, console_warning
 from utils.utils import (
     METRIC_ID_RE,
     NS_TO_MS,
-    compute_operator_prefix_stats,
     convert_metric_id_to_panel_info,
     get_panel_alias,
     get_uuid,
@@ -317,24 +314,53 @@ def show_torch_operator_table(operator_name: str, df: pd.DataFrame) -> None:
     console_log(table_str)
 
 
+def list_torch_operators(
+    workload_path: str,
+    file_data: list[tuple[str, pd.DataFrame, dict[str, tuple[float, int]], float]],
+) -> None:
+    """Display the full PyTorch operator listing.
+
+    Pure display function: receives pre-loaded data and prints the banner,
+    per-operator hierarchies, and totals.
+    """
+    print(f"\n{'=' * 80}")
+    print(f"PyTorch Operators in: {workload_path}")
+    print("Kernel (id N) can be used with -k for filtering.")
+    print(f"{'=' * 80}\n")
+    operator_count = 0
+    for idx, (operator_name, df, prefix_stats, _) in enumerate(file_data, start=1):
+        show_torch_operator_hierarchy(
+            operator_name,
+            df,
+            index=idx,
+            prefix_stats=prefix_stats,
+        )
+        operator_count += 1
+
+    if not operator_count:
+        console_warning(
+            "No PyTorch operator data found. "
+            "Please ensure profiling was done with --torch-trace option."
+        )
+
+    print(f"\n{'=' * 80}")
+    print(f"Total: {operator_count} operators")
+    print(f"{'=' * 80}\n")
+
+
 def show_torch_operator_hierarchy(
     operator_name: str,
     df: pd.DataFrame,
+    prefix_stats: dict[str, tuple[float, int]],
     index: Optional[int] = None,
-    kernel_name_to_id: Optional[dict[str, int]] = None,
-    kernel_verbose: int = 1,
-    prefix_stats: Optional[dict[str, tuple[float, int]]] = None,
 ) -> None:
     """
     Display the PyTorch operator listing with hierarchy, numbering, and durations.
 
-    Kernel names are shortened using the same logic as analyze-mode tables (and -k)
-    so they match; kernel_verbose controls shortening (default 1, overridable by user).
     Shows Operator N: 'name', then for each hierarchy path: full_name
     (total_duration, count), the hierarchy tree, and kernel launches with
     optional kernel durations (total_duration ms) when timestamps are present.
-    If kernel_name_to_id is provided, each kernel line shows (id N) for use with -k.
-    If prefix_stats is provided, it is used directly; otherwise computed from df.
+    Each kernel line shows (id N) for use with -k.
     """
     print(f"\n{'-' * 80}")
     if index is not None:
@@ -354,8 +380,6 @@ def show_torch_operator_hierarchy(
     # "Context_Id", etc. Optional: Start_Timestamp_function, End_Timestamp_function,
     # Start_Timestamp_kernel, End_Timestamp_kernel for durations.
 
-    if prefix_stats is None:
-        prefix_stats = compute_operator_prefix_stats(df)
     has_duration = bool(prefix_stats)
 
     unique_op_hierarchies = df["Operator_Name"].unique()
@@ -398,24 +422,19 @@ def show_torch_operator_hierarchy(
         kernel_counts: dict[str, int] = {}
         kernel_duration_ns: dict[str, float] = {}
         kernel_context: dict[str, dict[str, Any]] = {}
+        kernel_ids: dict[str, int] = {}
+        has_kernel_id = "Kernel_ID" in df.columns
         for _, row in op_data.iterrows():
-            full_kernel_name = str(row["Kernel_Name"]).strip()
-            if not full_kernel_name:
+            kernel_name = str(row["Kernel_Name"]).strip()
+            if not kernel_name:
                 continue
-            if kernel_verbose >= MAX_SHORTENING_LEVEL:
-                kernel_name = full_kernel_name
-            else:
-                kernel_name = process_single_kernel_name(
-                    full_kernel_name, kernel_verbose
-                )
 
             if kernel_name not in kernel_counts:
                 kernel_counts[kernel_name] = 0
                 kernel_duration_ns[kernel_name] = 0.0
-                kernel_context[kernel_name] = {
-                    "full_name": full_kernel_name,
-                    "contexts": {},
-                }
+                kernel_context[kernel_name] = {"contexts": {}}
+                if has_kernel_id and pd.notna(row["Kernel_ID"]):
+                    kernel_ids[kernel_name] = int(row["Kernel_ID"])
             kernel_counts[kernel_name] += 1
             if has_kernel_ts:
                 kernel_duration_ns[kernel_name] += float(
@@ -431,14 +450,13 @@ def show_torch_operator_hierarchy(
             if ":" not in location:
                 continue
             file_name, line_num = location.split(":", 1)
-            ctx = kernel_context[kernel_name]["contexts"]
-            ctx.setdefault(file_name, {})
-            ctx[file_name][line_num] = ctx[file_name].get(line_num, 0) + 1
+            contexts = kernel_context[kernel_name]["contexts"]
+            contexts.setdefault(file_name, {})
+            contexts[file_name][line_num] = contexts[file_name].get(line_num, 0) + 1
 
         for kernel_name, num_launches in kernel_counts.items():
-            id_suffix = ""
-            if kernel_name_to_id is not None and kernel_name in kernel_name_to_id:
-                id_suffix = f" (id {kernel_name_to_id[kernel_name]})"
+            kernel_id = kernel_ids.get(kernel_name)
+            id_suffix = f" (id {kernel_id})" if kernel_id is not None else ""
             display_name = simplify_kernel_name(kernel_name)
             total_ms = None
             if has_kernel_ts and kernel_name in kernel_duration_ns:

--- a/projects/rocprofiler-compute/src/utils/utils.py
+++ b/projects/rocprofiler-compute/src/utils/utils.py
@@ -1399,11 +1399,9 @@ def save_torch_trace_inputs(
 def simplify_kernel_name(full_kernel_name: str) -> str:
     """Simplify a kernel name for display by stripping templates and namespaces.
 
-    Intended as a last-resort readability pass *after* the standard
-    kernel_name_shortener / process_single_kernel_name pipeline.  Strips
-    ``void`` prefix, template parameters, and namespace qualifiers so that
-    e.g. ``void at::native::vectorized_elementwise_kernel<4, ...>`` becomes
-    ``vectorized_elementwise_kernel``.
+    Strips ``void`` prefix, template parameters, and namespace qualifiers so
+    that e.g. ``void at::native::vectorized_elementwise_kernel<4, ...>``
+    becomes ``vectorized_elementwise_kernel``.
     """
     name = full_kernel_name.strip()
     if name.startswith("void "):
@@ -1421,15 +1419,6 @@ def simplify_kernel_name(full_kernel_name: str) -> str:
         return function_name if function_name else name.strip()
 
     return main_part.strip()
-
-
-def sanitize_torch_operator_key(name: str) -> str:
-    """Normalize a user-supplied operator name to match torch_trace CSV filename stems.
-
-    Strips the ``torch.`` prefix and replaces dots with underscores so that
-    inputs like ``torch.nn.functional.conv2d`` become ``nn_functional_conv2d``.
-    """
-    return name.replace("torch.", "").replace(".", "_")
 
 
 def get_unique_invocations(df: pd.DataFrame) -> Optional[pd.DataFrame]:
@@ -1499,39 +1488,30 @@ def compute_operator_prefix_stats(
     return prefix_stats
 
 
-def build_kernel_name_to_id(
-    dfs: list[pd.DataFrame], kernel_verbose: int = 1
-) -> Optional[dict[str, int]]:
-    """Build a mapping from shortened kernel name to a stable numeric ID.
-
-    Collects every unique Kernel_Name across the supplied DataFrames,
-    shortens them with kernel_name_shortener, and assigns sequential IDs
-    in alphabetical order.  Returns None when no kernel names are found.
-    """
-    all_kernel_names: set[str] = set()
-    for df in dfs:
-        if "Kernel_Name" in df.columns:
-            all_kernel_names.update(df["Kernel_Name"].dropna().unique())
-    if not all_kernel_names:
-        return None
-    kernel_df = pd.DataFrame({"Kernel_Name": sorted(all_kernel_names)})
-    kernel_df = kernel_name_shortener(kernel_df.copy(), kernel_verbose)
-    if kernel_df is None:
-        return None
-    return {str(row["Kernel_Name"]).strip(): i for i, row in kernel_df.iterrows()}
-
-
 @demarcate
 def process_torch_trace_output(
     workload_dir: str,
-) -> None:
+    kernel_top_df: pd.DataFrame,
+    kernel_verbose: int = 0,
+) -> list[tuple[str, pd.DataFrame, dict[str, tuple[float, int]], float]]:
     """
     Joins counter_collection and marker_api_trace data for PyTorch operator listing.
 
     - Performs inner join on Correlation_ID, filtering out unmatched entries
     - Consolidates data across passes and groups by Operator_Name, saving one CSV
       per operator under workload_dir/torch_trace/
+    - Maps kernel names to IDs (adding a Kernel_ID column) by shortening torch
+      trace names with kernel_name_shortener to match the shortened names in
+      pmc_kernel_top.csv
+    - Computes prefix_stats per operator in-memory and returns the assembled
+      file_data list sorted by total duration (descending)
+
+    Returns list of (operator_name, DataFrame, prefix_stats, total_ms) tuples.
     """
+    kernel_name_to_id = {
+        str(row["Kernel_Name"]).strip(): idx
+        for idx, row in kernel_top_df.iterrows()
+    }
     console_log(f"Looking for marker and counter csv files in {workload_dir}")
     marker_api_trace_csvs = list(
         Path(workload_dir).glob("**/torch_trace*_marker_api_trace.csv")
@@ -1560,12 +1540,12 @@ def process_torch_trace_output(
                 "No marker files with corresponding counter files found. "
                 "Ensure profiling was done with '--torch-trace'.",
             )
-        return
-    if Path(f"{workload_dir}/torch_trace").exists():
-        shutil.rmtree(Path(f"{workload_dir}/torch_trace"))
-        console_log(
-            f"Removed previous torch_trace directory: {workload_dir}/torch_trace"
-        )
+        return []
+    torch_trace_path = Path(f"{workload_dir}/torch_trace")
+    if torch_trace_path.exists():
+        shutil.rmtree(torch_trace_path)
+        console_log(f"Removed previous torch_trace directory: {torch_trace_path}")
+    torch_trace_path.mkdir(parents=True, exist_ok=True)
 
     # Join marker and counter data
     def _merge_pair(
@@ -1622,11 +1602,11 @@ def process_torch_trace_output(
         console_error(
             f"Consolidated torch trace is missing required columns {missing_columns}"
         )
-        return
+        return []
     consolidated_df = consolidated_df[required_columns]
     if consolidated_df.isnull().values.any():
         console_warning("Consolidated torch trace contains missing values")
-        return
+        return []
     consolidated_df = consolidated_df.sort_values(by=["Function", "Counter_Name"])
     split_columns = consolidated_df["Function"].str.split(":#", expand=True)
     consolidated_df["Operator_Name"] = (
@@ -1654,22 +1634,36 @@ def process_torch_trace_output(
             "Missing values in consolidated torch trace after splitting ",
             "the Function name.",
         )
-        return
+        return []
     grouped = consolidated_df.groupby("Operator_Name")
+    file_data: list[tuple[str, pd.DataFrame, dict[str, tuple[float, int]], float]] = []
     for operator_name, group in grouped:
-        # Extract the operator name from hierarchy
         last_operator = operator_name.split("/")[-1]
         sanitized_operator_name = last_operator.replace("torch.", "").replace(".", "_")
-        # Ensure output directory exists
-        Path(f"{workload_dir}/torch_trace").mkdir(parents=True, exist_ok=True)
-        output_file = f"{workload_dir}/torch_trace/{sanitized_operator_name}.csv"
-        # If the file already exists, append to it, else create new file.
+        output_file = f"{torch_trace_path}/{sanitized_operator_name}.csv"
         if Path(output_file).is_file():
             group.to_csv(output_file, mode="a", header=False, index=False)
             console_log(f"Appended trace to existing file {output_file}")
         else:
             group.to_csv(output_file, index=False)
             console_log(f"Saved consolidated trace to {output_file}")
+
+        group = group.copy()
+        shortened = kernel_name_shortener(
+            pd.DataFrame({"Kernel_Name": group["Kernel_Name"]}),
+            kernel_verbose,
+        )
+        group["Kernel_ID"] = (
+            shortened["Kernel_Name"].str.strip().map(kernel_name_to_id)
+        )
+        prefix_stats = compute_operator_prefix_stats(group)
+        total_ms = sum(
+            dur for key, (dur, _) in prefix_stats.items() if "/" not in key
+        )
+        file_data.append((sanitized_operator_name, group, prefix_stats, total_ms))
+
+    file_data.sort(key=lambda x: x[3], reverse=True)
+    return file_data
 
 
 @demarcate

--- a/projects/rocprofiler-compute/tests/test_profile_general.py
+++ b/projects/rocprofiler-compute/tests/test_profile_general.py
@@ -3593,7 +3593,24 @@ if __name__ == "__main__":
         f"  Got:      {displayed_names}"
     )
 
-    # ---- Verify analysis output from --torch-operator (check 15) ----
+    # 15. --list-torch-operators succeeds at every --kernel-verbose level 0-4
+    #     (level 5 is the baseline run above)
+    for verbose_level in range(5):
+        capsys.readouterr()
+        rc = binary_handler_analyze_rocprof_compute([
+            "--experimental",
+            "analyze",
+            "--path",
+            workload_dir,
+            "--list-torch-operators",
+            "--kernel-verbose",
+            str(verbose_level),
+        ])
+        assert rc == 0, (
+            f"--list-torch-operators failed with --kernel-verbose {verbose_level}"
+        )
+
+    # ---- Verify analysis output from --torch-operator (check 16) ----
 
     # Analyze with --torch-operator needs --experimental flag
     returncode_analyze_relu = binary_handler_analyze_rocprof_compute([
@@ -3604,7 +3621,7 @@ if __name__ == "__main__":
         "--torch-operator",
         "relu",
     ])
-    # 15. Analyze with --torch-operator relu succeeds
+    # 16. Analyze with --torch-operator relu succeeds
     assert returncode_analyze_relu == 0, "Analyze with --torch-operator relu failed"
 
     test_utils.clean_output_dir(config["cleanup"], workload_dir)

--- a/projects/rocprofiler-compute/tests/test_torch_trace.py
+++ b/projects/rocprofiler-compute/tests/test_torch_trace.py
@@ -371,6 +371,13 @@ def read_operator_csvs(torch_trace_dir):
     return result
 
 
+def build_kernel_top_df():
+    """Build a kernel top stats DataFrame matching the test kernel names."""
+    return pd.DataFrame({
+        "Kernel_Name": sorted({r[12] for r in COUNTER_ROWS}),
+    })
+
+
 def test_torch_trace_output_same_for_rocpd_and_csv():
     """Test that the torch trace output is the same for rocpd and csv files."""
     rocpd_dir = test_utils.get_output_dir(suffix="_rocpd")
@@ -382,8 +389,9 @@ def test_torch_trace_output_same_for_rocpd_and_csv():
     write_rocpd_layout(rocpd_dir)
     write_csv_layout(csv_dir)
 
-    process_torch_trace_output(rocpd_dir)
-    process_torch_trace_output(csv_dir)
+    kernel_top_df = build_kernel_top_df()
+    process_torch_trace_output(rocpd_dir, kernel_top_df)
+    process_torch_trace_output(csv_dir, kernel_top_df)
 
     rocpd_results = read_operator_csvs(Path(rocpd_dir) / "torch_trace")
     csv_results = read_operator_csvs(Path(csv_dir) / "torch_trace")


### PR DESCRIPTION
## Motivation

the kernel IDs shown by --list-torch-operators should match the IDs in the kernel top-stats table.

## Technical Details

1. Moves `--list-torch-operators` handling to `cli_analysis.pre_processing(`), after `create_df_kernel_top_stats` with early `sys.exit(0)`
2. Reads `pmc_kernel_top.csv` directly for kernel ID mapping (the same table backing -k filtering)
3. Applies `kernel_name_shortener `to torch trace Kernel_Name before mapping against `pmc_kernel_top.csv` so both sides use shortened names
4. Adds `--kernel-verbose` verbosity sweep test to `test_torch_trace_profile`

## JIRA ID

AIPROFCOMP-311
## Test Plan

Comparing the `id`s from `--list-torch-operators` with those in `pmc_kernel_top.csv`

`python3 -m pytest tests/test_profile_general.py::test_torch_trace_profile -v`

## Test Result
Test PASSES.

The `id`s match.

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
