### PR TITLE
[rocprofiler-compute] Restructure --list-torch-operators to show unified call tree grouped by source location

### DIFF
--- a/projects/rocprofiler-compute/docs/how-to/analyze/cli.rst
+++ b/projects/rocprofiler-compute/docs/how-to/analyze/cli.rst
@@ -637,19 +637,20 @@ Display all PyTorch operators captured during profiling:
    $ rocprof-compute --experimental analyze --path ./workload --list-torch-operators
 
    ================================================================================
-   PyTorch Operators in: ./workload
+   PyTorch Operator Call Tree: ./workload
+   Grouped by source location, sorted by total GPU kernel duration.
    ================================================================================
 
-     1. nn.Module.Net.forward/nn.Module.Conv2d.forward/torch.nn.functional.conv2d
-     2. nn.Module.Net.forward/nn.Module.Linear.forward/torch.nn.functional.linear
-     3. nn.Module.Net.forward/torch.nn.functional.relu
+   main.py:60 (kernel_launches: 110, total_duration: 59.31 ms)
+   └─ nn.Module.Net.forward (kernel_launches: 110, total_duration: 59.31 ms)
+      ├─ nn.Module.Conv2d.forward
+      |  └─ torch.nn.functional.conv2d (kernel_launches: 40, total_duration: 27.08 ms)
+      └─ nn.Module.Linear.forward
+         └─ torch.nn.functional.linear (kernel_launches: 20, total_duration: 15.41 ms)
 
-   ================================================================================
-   Total: 3 operators
-   ================================================================================
-
-Listed names are the full operator names (hierarchy with ``/``). Per-operator CSVs
-in ``torch_trace/`` are named from the **last** segment of each name (sanitized);
+Output is grouped by source location (``file:line``) and shows full operator
+hierarchy (``/``-separated) and kernel stats. Per-operator CSVs in ``torch_trace/``
+are named from the **last** segment of each name (sanitized);
 see :ref:`torch-operator-profiling` for naming details.
 
 Filtering by Operator

--- a/projects/rocprofiler-compute/src/argparser.py
+++ b/projects/rocprofiler-compute/src/argparser.py
@@ -751,7 +751,8 @@ Examples:
         experimental_enabled=experimental_enabled,
         feature_label="List torch operators",
         help=(
-            "\t\tList PyTorch operators with hierarchy, numbering, and durations. "
+            "\t\tList PyTorch operators as a unified call tree grouped by "
+            "source location with kernel launch stats. "
             "Recreates torch_trace output directory."
         ),
     )

--- a/projects/rocprofiler-compute/src/rocprof_compute_analyze/analysis_cli.py
+++ b/projects/rocprofiler-compute/src/rocprof_compute_analyze/analysis_cli.py
@@ -32,7 +32,11 @@ from rocprof_compute_analyze.analysis_base import OmniAnalyze_Base
 from utils import file_io, parser, tty
 from utils.kernel_name_shortener import kernel_name_shortener
 from utils.logger import console_error, console_log, demarcate
-from utils.utils import process_torch_trace_output
+from utils.utils import (
+    build_call_trees_with_kernel_ids,
+    process_torch_trace_output,
+    write_torch_trace_operator_csvs,
+)
 
 
 class cli_analysis(OmniAnalyze_Base):
@@ -84,12 +88,16 @@ class cli_analysis(OmniAnalyze_Base):
 
             if getattr(args, "list_torch_operators", False):
                 kernel_top_df = pd.read_csv(Path(path_info[0]) / "pmc_kernel_top.csv")
-                file_data = process_torch_trace_output(
-                    path_info[0],
+                consolidated_df, torch_trace_path = process_torch_trace_output(
+                    path_info[0]
+                )
+                write_torch_trace_operator_csvs(consolidated_df, torch_trace_path)
+                call_trees = build_call_trees_with_kernel_ids(
+                    consolidated_df,
                     kernel_top_df=kernel_top_df,
                     kernel_verbose=args.kernel_verbose,
                 )
-                tty.list_torch_operators(path_info[0], file_data)
+                tty.list_torch_operators(path_info[0], call_trees)
                 sys.exit(0)
 
             # demangle and overwrite original 'Kernel_Name'

--- a/projects/rocprofiler-compute/src/utils/tty.py
+++ b/projects/rocprofiler-compute/src/utils/tty.py
@@ -25,6 +25,7 @@
 
 import argparse
 import copy
+import shutil
 import textwrap
 from pathlib import Path
 from typing import Any, Optional, TextIO
@@ -41,6 +42,7 @@ from utils.logger import console_error, console_log, console_warning
 from utils.utils import (
     METRIC_ID_RE,
     NS_TO_MS,
+    CallTreeNode,
     convert_metric_id_to_panel_info,
     get_panel_alias,
     get_uuid,
@@ -316,180 +318,187 @@ def show_torch_operator_table(operator_name: str, df: pd.DataFrame) -> None:
 
 def list_torch_operators(
     workload_path: str,
-    file_data: list[tuple[str, pd.DataFrame, dict[str, tuple[float, int]], float]],
+    call_trees: dict[str, CallTreeNode],
 ) -> None:
-    """Display the full PyTorch operator listing.
-
-    Pure display function: receives pre-loaded data and prints the banner,
-    per-operator hierarchies, and totals.
-    """
-    print(f"\n{'=' * 80}")
-    print(f"PyTorch Operators in: {workload_path}")
-    print("Kernel (id N) can be used with -k for filtering.")
-    print(f"{'=' * 80}\n")
-    operator_count = 0
-    for idx, (operator_name, df, prefix_stats, _) in enumerate(file_data, start=1):
-        show_torch_operator_hierarchy(
-            operator_name,
-            df,
-            index=idx,
-            prefix_stats=prefix_stats,
-        )
-        operator_count += 1
-
-    if not operator_count:
+    """Display PyTorch operators as a unified call tree grouped by source location."""
+    if not call_trees:
         console_warning(
             "No PyTorch operator data found. "
             "Please ensure profiling was done with --torch-trace option."
         )
-
-    print(f"\n{'=' * 80}")
-    print(f"Total: {operator_count} operators")
-    print(f"{'=' * 80}\n")
-
-
-def show_torch_operator_hierarchy(
-    operator_name: str,
-    df: pd.DataFrame,
-    prefix_stats: dict[str, tuple[float, int]],
-    index: Optional[int] = None,
-) -> None:
-    """
-    Display the PyTorch operator listing with hierarchy, numbering, and durations.
-
-    Shows Operator N: 'name', then for each hierarchy path: full_name
-    (total_duration, count), the hierarchy tree, and kernel launches with
-    optional kernel durations (total_duration ms) when timestamps are present.
-    Each kernel line shows (id N) for use with -k.
-    """
-    print(f"\n{'-' * 80}")
-    if index is not None:
-        print(f"Operator {index}:  '{operator_name}'")
-    else:
-        print(f"Operator:  '{operator_name}'")
-    print("-" * 80)
-
-    if "Operator_Name" not in df.columns or "Kernel_Name" not in df.columns:
-        console_log("Torch operator CSV missing Operator_Name or Kernel_Name columns.")
         return
 
-    # Indent for content under each hierarchy so it's clear it belongs to that hierarchy
-    hierarchy_indent = " " * 7
+    print(f"\n{'=' * 80}")
+    print(f"PyTorch Operator Call Tree: {workload_path}")
+    print("Grouped by source location, sorted by total GPU kernel duration.")
+    print(f"{'=' * 80}")
+    show_call_tree(call_trees)
+    print(f"\n{'=' * 80}")
 
-    # Expect the DataFrame to have columns "Operator_Name", "Kernel_Name",
-    # "Context_Id", etc. Optional: Start_Timestamp_function, End_Timestamp_function,
-    # Start_Timestamp_kernel, End_Timestamp_kernel for durations.
 
-    has_duration = bool(prefix_stats)
+def format_stats(launches: int, duration_ms: float) -> str:
+    """Format launch count and duration as an inline parenthesized string."""
+    if duration_ms < 0.01:
+        formatted_duration = f"{duration_ms * 1000:.2f} us"
+    else:
+        formatted_duration = f"{duration_ms:.2f} ms"
+    return f"(kernel_launches: {launches}, total_duration: {formatted_duration})"
 
-    unique_op_hierarchies = df["Operator_Name"].unique()
-    left_col_width = 50
-    inner_width = left_col_width - len(hierarchy_indent)
-    for i, op in enumerate(unique_op_hierarchies, start=1):
-        stats_str = ""
-        if has_duration and op in prefix_stats:
-            total_ms, count = prefix_stats[op]
-            stats_str = f" (total_duration: {total_ms:.2f} ms, count: {count})"
-        print(f"{hierarchy_indent}Hierarchy {i}:  {op}{stats_str}")
-        kernel_header = (
-            "Kernels Launched" if not has_duration else "Kernels Launched (duration)"
+
+def get_tree_wrap_width(min_width: int = 72, max_width: int = 120) -> int:
+    """Pick wrap width based on terminal size to avoid terminal hard-wrap artifacts."""
+    terminal_cols = shutil.get_terminal_size((max_width, 20)).columns
+    safe_width = max(terminal_cols - 2, min_width)
+    return min(safe_width, max_width)
+
+
+def print_wrapped_tree_line(
+    prefix: str,
+    body: str,
+    width: Optional[int] = None,
+    break_long_words: bool = False,
+) -> None:
+    """Print a tree line and wrap continuation lines to preserve indentation."""
+    effective_width = get_tree_wrap_width() if width is None else width
+    print(
+        textwrap.fill(
+            body,
+            width=effective_width,
+            initial_indent=prefix,
+            subsequent_indent=" " * len(prefix),
+            break_long_words=break_long_words,
+            break_on_hyphens=False,
         )
-        print(
-            f"{hierarchy_indent}\n{hierarchy_indent}"
-            + "Operator Hierarchy".ljust(inner_width)
-            + kernel_header
-        )
-        print(f"{hierarchy_indent}{'-' * (80 - len(hierarchy_indent))}")
-        parts = str(op).split("/")
+    )
 
-        hierarchy_lines = []
-        for level, part in enumerate(parts):
-            if level == 0:
-                line = f"{part}"
+
+def print_wrapped_kernel_line(
+    prefix: str,
+    kernel_name: str,
+    suffix: str,
+    width: Optional[int] = None,
+    continuation_prefix: str = "",
+) -> None:
+    """Wrap long kernel names while keeping suffix attached to final name chunk."""
+    effective_width = get_tree_wrap_width() if width is None else width
+    content_width = max(effective_width - len(prefix), 20)
+
+    inline = f"{kernel_name} {suffix}"
+    if len(inline) <= content_width:
+        print(f"{prefix}{inline}")
+        return
+
+    # Reserve room so suffix is never detached on its own line.
+    name_width = max(content_width - len(suffix) - 1, 8)
+    wrapped_name = textwrap.wrap(
+        kernel_name,
+        width=name_width,
+        break_long_words=True,
+        break_on_hyphens=False,
+    )
+    if not wrapped_name:
+        print(f"{prefix}{suffix}")
+        return
+
+    # Build continuation with vertical pipes from parent levels
+    # Preserve parent pipes but replace branch character with spaces
+    if len(continuation_prefix) > 0:
+        # continuation_prefix has pipes, add spaces for branch chars
+        spaces_needed = len(prefix) - len(continuation_prefix)
+        continuation = continuation_prefix + " " * spaces_needed
+    else:
+        # No parent pipes, just use spaces matching the prefix
+        continuation = " " * len(prefix)
+
+    for i, chunk in enumerate(wrapped_name):
+        if i == 0:
+            if len(wrapped_name) == 1:
+                print(f"{prefix}{chunk} {suffix}")
             else:
-                indent = "  " * level
-                prefix_char = "└─ "
-                line = f"{indent}{prefix_char}{part}"
-            hierarchy_lines.append(line)
+                print(f"{prefix}{chunk}")
+        elif i == len(wrapped_name) - 1:
+            print(f"{continuation}{chunk} {suffix}")
+        else:
+            print(f"{continuation}{chunk}")
 
-        # Get kernels for this operator hierarchy
-        kernels_info = []
-        op_data = df[df["Operator_Name"] == op]
-        has_kernel_ts = (
-            "Start_Timestamp_kernel" in df.columns
-            and "End_Timestamp_kernel" in df.columns
+
+def show_call_tree(call_trees: dict[str, CallTreeNode]) -> None:
+    """Print the unified call tree grouped by source location."""
+    sorted_locations = sorted(
+        call_trees.items(), key=lambda kv: kv[1].total_duration_ms, reverse=True
+    )
+    for i, (location, root) in enumerate(sorted_locations):
+        if i > 0:
+            print(f"\n{'- ' * 40}")
+        stats = format_stats(root.kernel_launches, root.total_duration_ms)
+        print(f"\n{location} {stats}")
+        for child in sorted(
+            root.children.values(),
+            key=lambda c: c.total_duration_ms,
+            reverse=True,
+        ):
+            print_operator_node(child)
+
+
+def print_operator_node(
+    node: CallTreeNode, is_last: bool = True, parent_pipes: str = ""
+) -> None:
+    # Build indent with vertical pipes for parent levels
+    indent = parent_pipes
+    is_branching = len(node.children) + len(node.kernels) > 1
+
+    # Use ├─ for non-last items, └─ for last items
+    branch_char = "└─ " if is_last else "├─ "
+    node_prefix = f"{indent}{branch_char}"
+
+    if is_branching:
+        stats = format_stats(node.kernel_launches, node.total_duration_ms)
+        print_wrapped_tree_line(node_prefix, f"{node.name} {stats}")
+    else:
+        print_wrapped_tree_line(node_prefix, node.name)
+
+    # Build new parent_pipes for children
+    if is_last:
+        new_parent_pipes = parent_pipes + "   "  # 3 spaces
+    else:
+        new_parent_pipes = parent_pipes + "|  "  # pipe + 2 spaces
+
+    # Process child nodes
+    children = sorted(
+        node.children.values(), key=lambda c: c.total_duration_ms, reverse=True
+    )
+    for i, child in enumerate(children):
+        # A child is last if it's the final child AND there are no kernels after it
+        child_is_last = (i == len(children) - 1) and (len(node.kernels) == 0)
+        print_operator_node(child, is_last=child_is_last, parent_pipes=new_parent_pipes)
+
+    # Process kernels
+    for i, (kernel_name, kernel_stats) in enumerate(
+        sorted(
+            node.kernels.items(),
+            key=lambda kv: kv[1].total_duration_ns,
+            reverse=True,
         )
-        kernel_counts: dict[str, int] = {}
-        kernel_duration_ns: dict[str, float] = {}
-        kernel_context: dict[str, dict[str, Any]] = {}
-        kernel_ids: dict[str, int] = {}
-        has_kernel_id = "Kernel_ID" in df.columns
-        for _, row in op_data.iterrows():
-            kernel_name = str(row["Kernel_Name"]).strip()
-            if not kernel_name:
-                continue
+    ):
+        launches = kernel_stats.launches
+        duration_ns = kernel_stats.total_duration_ns
+        kernel_id = kernel_stats.kernel_id
+        id_suffix = f" (id {kernel_id})" if kernel_id is not None else ""
+        display_name = simplify_kernel_name(kernel_name)
+        total_ms = duration_ns * NS_TO_MS
+        stats = format_stats(launches, total_ms)
 
-            if kernel_name not in kernel_counts:
-                kernel_counts[kernel_name] = 0
-                kernel_duration_ns[kernel_name] = 0.0
-                kernel_context[kernel_name] = {"contexts": {}}
-                if has_kernel_id and pd.notna(row["Kernel_ID"]):
-                    kernel_ids[kernel_name] = int(row["Kernel_ID"])
-            kernel_counts[kernel_name] += 1
-            if has_kernel_ts:
-                kernel_duration_ns[kernel_name] += float(
-                    row["End_Timestamp_kernel"]
-                ) - float(row["Start_Timestamp_kernel"])
-            context_id = row.get("Context_Id")
-            if pd.isna(context_id) or not str(context_id).strip():
-                continue
-            topmost_location = str(context_id).split("/")[0]
-            if "@" not in topmost_location:
-                continue
-            _, location = topmost_location.split("@", 1)
-            if ":" not in location:
-                continue
-            file_name, line_num = location.split(":", 1)
-            contexts = kernel_context[kernel_name]["contexts"]
-            contexts.setdefault(file_name, {})
-            contexts[file_name][line_num] = contexts[file_name].get(line_num, 0) + 1
+        # Last kernel gets └─, others get ├─
+        kernel_is_last = i == len(node.kernels) - 1
+        kernel_branch_char = "└─ " if kernel_is_last else "├─ "
+        kernel_prefix = f"{new_parent_pipes}{kernel_branch_char}"
 
-        for kernel_name, num_launches in kernel_counts.items():
-            kernel_id = kernel_ids.get(kernel_name)
-            id_suffix = f" (id {kernel_id})" if kernel_id is not None else ""
-            display_name = simplify_kernel_name(kernel_name)
-            total_ms = None
-            if has_kernel_ts and kernel_name in kernel_duration_ns:
-                total_ms = kernel_duration_ns[kernel_name] * NS_TO_MS
-            if total_ms is not None and not pd.isna(total_ms):
-                kernel_info = (
-                    f"|--> {display_name}{id_suffix} ({num_launches} launches, "
-                    f"total_duration: {total_ms:.2f} ms)\n"
-                )
-            else:
-                kernel_info = (
-                    f"|--> {display_name}{id_suffix} ({num_launches} launches)\n"
-                )
-            kernels_info.append(kernel_info)
-            for file_name, line_count in kernel_context[kernel_name][
-                "contexts"
-            ].items():
-                for line_num, count in line_count.items():
-                    kernels_info.append(
-                        f"      {file_name}:{line_num} ({count} launches)\n"
-                    )
-
-        # Print hierarchy lines (left column), indented under this hierarchy
-        for line in hierarchy_lines:
-            print(f"{hierarchy_indent}{line.ljust(inner_width)}|")
-
-        # Print kernel lines aligned to the deepest level, indented under this hierarchy
-        deepest_indent = "  " * len(parts)
-        for kernel_line in kernels_info:
-            left_padding = deepest_indent + "    "
-            print(f"{hierarchy_indent}{left_padding.ljust(inner_width)}{kernel_line}")
-
-        print()
+        print_wrapped_kernel_line(
+            kernel_prefix,
+            display_name,
+            f"{id_suffix} {stats}".strip(),
+            continuation_prefix=new_parent_pipes,
+        )
 
 
 def process_table_data(

--- a/projects/rocprofiler-compute/src/utils/utils.py
+++ b/projects/rocprofiler-compute/src/utils/utils.py
@@ -45,6 +45,7 @@ import traceback
 import uuid
 from collections.abc import Generator
 from contextlib import contextmanager
+from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Optional, Union, cast
 
@@ -68,6 +69,31 @@ NS_TO_MS = 1.0 / 1_000_000.0
 
 rocprof_cmd = ""
 rocprof_args = ""
+
+
+@dataclass
+class KernelStats:
+    """Aggregated kernel launch stats for one kernel name."""
+
+    launches: int = 0
+    total_duration_ns: float = 0.0
+    kernel_id: Optional[int] = None
+
+
+@dataclass
+class CallTreeNode:
+    """A node in the operator call tree.
+
+    Children are ordered operator sub-calls; kernels maps each kernel name to
+    a ``KernelStats`` record. ``kernel_launches``
+    and ``total_duration_ms`` are inclusive (rolled up from all descendants).
+    """
+
+    name: str
+    children: dict[str, "CallTreeNode"] = field(default_factory=dict)
+    kernels: dict[str, KernelStats] = field(default_factory=dict)
+    kernel_launches: int = 0
+    total_duration_ms: float = 0.0
 
 
 def version_to_numeric(version_parts: list[int], max_len: int) -> int:
@@ -1421,96 +1447,160 @@ def simplify_kernel_name(full_kernel_name: str) -> str:
     return main_part.strip()
 
 
-def get_unique_invocations(df: pd.DataFrame) -> Optional[pd.DataFrame]:
-    """Deduplicate operator invocations from trace rows.
+def parse_top_level_location(context_id: object) -> str:
+    """Extract 'file:line' from the first entry of a Context_Id string.
 
-    Each trace row represents one (operator, kernel, counter) combination, so a
-    single operator invocation appears in many rows.  Deduplication uses
-    (Operator_Name, Context_Id, Start_Timestamp_function) when Context_Id is
-    present; otherwise falls back to
-    (Operator_Name, Start_Timestamp_function, End_Timestamp_function).
-
-    Returns a DataFrame with at least Operator_Name, Start_Timestamp_function,
-    and End_Timestamp_function columns, or None when timestamps are missing.
+    Context_Id format: ``10@main.py:60/#10@main.py:21/...``
+    Returns ``main.py:60`` or ``unknown:0`` on failure.
     """
-    has_ts = (
-        "Start_Timestamp_function" in df.columns
-        and "End_Timestamp_function" in df.columns
-    )
-    if not has_ts:
-        return None
-
-    use_context = "Context_Id" in df.columns and df["Context_Id"].notna().any()
-    if use_context:
-        return df[
-            [
-                "Operator_Name",
-                "Context_Id",
-                "Start_Timestamp_function",
-                "End_Timestamp_function",
-            ]
-        ].drop_duplicates(
-            subset=["Operator_Name", "Context_Id", "Start_Timestamp_function"]
-        )
-    return df[
-        ["Operator_Name", "Start_Timestamp_function", "End_Timestamp_function"]
-    ].drop_duplicates()
+    if pd.isna(context_id) or not str(context_id).strip():
+        return "unknown:0"
+    first_entry = str(context_id).split("/")[0]
+    if "@" not in first_entry:
+        return "unknown:0"
+    _, location = first_entry.split("@", 1)
+    return location if ":" in location else "unknown:0"
 
 
-def compute_operator_prefix_stats(
+def rollup_node_stats(node: CallTreeNode) -> tuple[int, float]:
+    """Bottom-up rollup: set kernel_launches and total_duration_ms inclusive."""
+    launches = sum(stats.launches for stats in node.kernels.values())
+    duration_ns = sum(stats.total_duration_ns for stats in node.kernels.values())
+
+    for child in node.children.values():
+        child_launches, child_duration_ns = rollup_node_stats(child)
+        launches += child_launches
+        duration_ns += child_duration_ns
+
+    node.kernel_launches = launches
+    node.total_duration_ms = duration_ns * NS_TO_MS
+    return launches, duration_ns
+
+
+def build_call_trees(
     df: pd.DataFrame,
-) -> dict[str, tuple[float, int]]:
-    """Compute total duration (ms) and invocation count per operator path prefix.
+) -> dict[str, CallTreeNode]:
+    """Build per-source-location call trees from a consolidated torch trace DataFrame.
 
-    Hierarchy semantics: the trace only has the full path per row (e.g. A/B/C).
-    We attribute each invocation's duration to every prefix along its path, so
-    stats at each node are inclusive.
-    Returns dict: prefix -> (total_duration_ms, count).
+    Returns a dict mapping ``file:line`` to a CallTreeNode root whose
+    children form the full operator/kernel hierarchy.
+
+    Each kernel entry is stored as a ``KernelStats`` record.
+    Full kernel names are used; shortening is left to the display layer.
     """
-    invocations = get_unique_invocations(df)
-    if invocations is None:
+    required = {"Operator_Name", "Kernel_Name"}
+    if df.empty or not required.issubset(df.columns):
         return {}
 
-    prefix_stats: dict[str, tuple[float, int]] = {}
-    for _, row in invocations.iterrows():
-        op = str(row["Operator_Name"])
-        duration_ns = float(row["End_Timestamp_function"]) - float(
-            row["Start_Timestamp_function"]
-        )
-        duration_ms = duration_ns * NS_TO_MS
-        parts = op.split("/")
-        for i in range(1, len(parts) + 1):
-            prefix = "/".join(parts[:i])
-            if prefix not in prefix_stats:
-                prefix_stats[prefix] = (0.0, 0)
-            prev_dur, prev_cnt = prefix_stats[prefix]
-            prefix_stats[prefix] = (prev_dur + duration_ms, prev_cnt + 1)
-    return prefix_stats
+    has_kernel_timestamps = (
+        "Start_Timestamp_kernel" in df.columns and "End_Timestamp_kernel" in df.columns
+    )
+    has_context_id = "Context_Id" in df.columns
+    has_kernel_id = "Kernel_ID" in df.columns
+
+    deduplication_columns = ["Operator_Name", "Kernel_Name"]
+    if has_kernel_timestamps:
+        deduplication_columns.append("Start_Timestamp_kernel")
+    if has_context_id:
+        deduplication_columns.append("Context_Id")
+    dispatches = df.drop_duplicates(subset=deduplication_columns)
+
+    call_trees: dict[str, CallTreeNode] = {}
+
+    for row in dispatches.itertuples(index=False):
+        op_path = str(row.Operator_Name).strip()
+        kernel_name = str(row.Kernel_Name).strip()
+        if not op_path or not kernel_name:
+            continue
+
+        context_id = getattr(row, "Context_Id", None) if has_context_id else None
+        location = parse_top_level_location(context_id)
+
+        duration_ns = 0.0
+        if has_kernel_timestamps:
+            try:
+                duration_ns = float(row.End_Timestamp_kernel) - float(
+                    row.Start_Timestamp_kernel
+                )
+            except (ValueError, TypeError):
+                pass
+
+        if location not in call_trees:
+            call_trees[location] = CallTreeNode(name=location)
+        location_root = call_trees[location]
+
+        current_node = location_root
+        for path_segment in op_path.split("/"):
+            if path_segment not in current_node.children:
+                current_node.children[path_segment] = CallTreeNode(name=path_segment)
+            current_node = current_node.children[path_segment]
+
+        if kernel_name not in current_node.kernels:
+            kernel_id = None
+            kernel_id_value = getattr(row, "Kernel_ID", None) if has_kernel_id else None
+            if pd.notna(kernel_id_value):
+                kernel_id = int(kernel_id_value)
+            current_node.kernels[kernel_name] = KernelStats(kernel_id=kernel_id)
+        current_node.kernels[kernel_name].launches += 1
+        current_node.kernels[kernel_name].total_duration_ns += duration_ns
+
+    for location_root in call_trees.values():
+        rollup_node_stats(location_root)
+
+    return call_trees
+
+
+def write_torch_trace_operator_csvs(
+    consolidated_df: pd.DataFrame,
+    torch_trace_path: Path,
+) -> None:
+    """Write one consolidated torch trace CSV per operator."""
+    grouped = consolidated_df.groupby("Operator_Name")
+    for operator_name, group in grouped:
+        last_operator = operator_name.split("/")[-1]
+        sanitized_operator_name = last_operator.replace("torch.", "").replace(".", "_")
+        output_file = f"{torch_trace_path}/{sanitized_operator_name}.csv"
+        if Path(output_file).is_file():
+            group.to_csv(output_file, mode="a", header=False, index=False)
+            console_log(f"Appended trace to existing file {output_file}")
+        else:
+            group.to_csv(output_file, index=False)
+            console_log(f"Saved consolidated trace to {output_file}")
+
+
+def build_call_trees_with_kernel_ids(
+    consolidated_df: pd.DataFrame,
+    kernel_top_df: pd.DataFrame,
+    kernel_verbose: int = 0,
+) -> dict[str, CallTreeNode]:
+    """Attach Kernel_ID values and build call trees from consolidated trace rows."""
+    kernel_name_to_id = {
+        str(row["Kernel_Name"]).strip(): idx for idx, row in kernel_top_df.iterrows()
+    }
+    shortened = kernel_name_shortener(
+        pd.DataFrame({"Kernel_Name": consolidated_df["Kernel_Name"]}),
+        kernel_verbose,
+    )
+    consolidated_with_ids = consolidated_df.copy()
+    consolidated_with_ids["Kernel_ID"] = (
+        shortened["Kernel_Name"].str.strip().map(kernel_name_to_id)
+    )
+    return build_call_trees(consolidated_with_ids)
 
 
 @demarcate
 def process_torch_trace_output(
     workload_dir: str,
-    kernel_top_df: pd.DataFrame,
-    kernel_verbose: int = 0,
-) -> list[tuple[str, pd.DataFrame, dict[str, tuple[float, int]], float]]:
+) -> tuple[pd.DataFrame, Path]:
     """
-    Joins counter_collection and marker_api_trace data for PyTorch operator listing.
+    Build consolidated torch trace rows and prepare output directory.
 
     - Performs inner join on Correlation_ID, filtering out unmatched entries
-    - Consolidates data across passes and groups by Operator_Name, saving one CSV
-      per operator under workload_dir/torch_trace/
-    - Maps kernel names to IDs (adding a Kernel_ID column) by shortening torch
-      trace names with kernel_name_shortener to match the shortened names in
-      pmc_kernel_top.csv
-    - Computes prefix_stats per operator in-memory and returns the assembled
-      file_data list sorted by total duration (descending)
+    - Consolidates data across passes and normalizes required columns
+    - Prepares a clean workload_dir/torch_trace/ directory for output files
 
-    Returns list of (operator_name, DataFrame, prefix_stats, total_ms) tuples.
+    Returns (consolidated_df, torch_trace_path) on success.
     """
-    kernel_name_to_id = {
-        str(row["Kernel_Name"]).strip(): idx for idx, row in kernel_top_df.iterrows()
-    }
     console_log(f"Looking for marker and counter csv files in {workload_dir}")
     marker_api_trace_csvs = list(
         Path(workload_dir).glob("**/torch_trace*_marker_api_trace.csv")
@@ -1527,19 +1617,15 @@ def process_torch_trace_output(
     ]
 
     if not existing_csv_files:
-        if Path(f"{workload_dir}/torch_trace").exists():
-            console_log(
-                "torch trace",
-                "Torch data has already been processed and saved to "
-                f"{workload_dir}/torch_trace",
-            )
-        else:
-            console_warning(
-                "torch trace",
-                "No marker files with corresponding counter files found. "
-                "Ensure profiling was done with '--torch-trace'.",
-            )
-        return []
+        console_warning(
+            "No marker files with corresponding counter files found. "
+            "Ensure profiling was done with '--torch-trace'."
+        )
+        raise ValueError(
+            "No marker files with corresponding counter files found. "
+            "Ensure profiling was done with '--torch-trace'."
+        )
+
     torch_trace_path = Path(f"{workload_dir}/torch_trace")
     if torch_trace_path.exists():
         shutil.rmtree(torch_trace_path)
@@ -1601,11 +1687,13 @@ def process_torch_trace_output(
         console_error(
             f"Consolidated torch trace is missing required columns {missing_columns}"
         )
-        return []
+        raise ValueError(
+            f"Consolidated torch trace is missing required columns {missing_columns}"
+        )
     consolidated_df = consolidated_df[required_columns]
     if consolidated_df.isnull().values.any():
         console_warning("Consolidated torch trace contains missing values")
-        return []
+        raise ValueError("Consolidated torch trace contains missing values")
     consolidated_df = consolidated_df.sort_values(by=["Function", "Counter_Name"])
     split_columns = consolidated_df["Function"].str.split(":#", expand=True)
     consolidated_df["Operator_Name"] = (
@@ -1633,32 +1721,9 @@ def process_torch_trace_output(
             "Missing values in consolidated torch trace after splitting ",
             "the Function name.",
         )
-        return []
-    grouped = consolidated_df.groupby("Operator_Name")
-    file_data: list[tuple[str, pd.DataFrame, dict[str, tuple[float, int]], float]] = []
-    for operator_name, group in grouped:
-        last_operator = operator_name.split("/")[-1]
-        sanitized_operator_name = last_operator.replace("torch.", "").replace(".", "_")
-        output_file = f"{torch_trace_path}/{sanitized_operator_name}.csv"
-        if Path(output_file).is_file():
-            group.to_csv(output_file, mode="a", header=False, index=False)
-            console_log(f"Appended trace to existing file {output_file}")
-        else:
-            group.to_csv(output_file, index=False)
-            console_log(f"Saved consolidated trace to {output_file}")
+        raise ValueError("Missing values in consolidated torch trace after splitting")
 
-        group = group.copy()
-        shortened = kernel_name_shortener(
-            pd.DataFrame({"Kernel_Name": group["Kernel_Name"]}),
-            kernel_verbose,
-        )
-        group["Kernel_ID"] = shortened["Kernel_Name"].str.strip().map(kernel_name_to_id)
-        prefix_stats = compute_operator_prefix_stats(group)
-        total_ms = sum(dur for key, (dur, _) in prefix_stats.items() if "/" not in key)
-        file_data.append((sanitized_operator_name, group, prefix_stats, total_ms))
-
-    file_data.sort(key=lambda x: x[3], reverse=True)
-    return file_data
+    return consolidated_df, torch_trace_path
 
 
 @demarcate

--- a/projects/rocprofiler-compute/tests/test_profile_general.py
+++ b/projects/rocprofiler-compute/tests/test_profile_general.py
@@ -3336,9 +3336,9 @@ def test_torch_trace_profile(
     Runs profiling with --torch-trace, verifies profile outputs (pmc_perf, marker
     and counter CSVs), then runs analyze with --list-torch-operators and
     --torch-operator relu, and verifies torch_trace directory, operator CSV
-    contents (hierarchy, kernel, counters), and CLI output format (numbering,
-    durations, kernel IDs, sort order). Requires PyTorch and GPU; not included
-    in default suite.
+    contents (hierarchy, kernel, counters), and CLI output format (call tree
+    grouped by source location, aggregated stats, kernel IDs, sort order).
+    Requires PyTorch and GPU; not included in default suite.
     """
     workload_dir = test_utils.get_output_dir(param_id="torch_trace")
     Path(workload_dir).mkdir(parents=True, exist_ok=True)
@@ -3384,6 +3384,7 @@ if __name__ == "__main__":
     options = [
         "--experimental",
         "--torch-trace",
+        "--iteration-multiplexing",
     ]
 
     returncode = binary_handler_profile_rocprof_compute(
@@ -3543,54 +3544,42 @@ if __name__ == "__main__":
 
     # ---- Verify --list-torch-operators CLI output format (checks 9–14) ----
 
-    # 9. Banner and footer
-    assert "PyTorch Operators in:" in list_output, "Missing banner line"
-    assert re.search(r"Total: \d+ operators", list_output), "Missing footer count"
+    # 9. Banner
+    assert "PyTorch Operator Call Tree:" in list_output, "Missing banner line"
 
-    # 10. Sequential operator numbering
-    op_numbers = re.findall(r"Operator (\d+):", list_output)
-    assert op_numbers, "No operator numbering found in output"
-    assert op_numbers == [str(i) for i in range(1, len(op_numbers) + 1)], (
-        f"Operator numbering not sequential: {op_numbers}"
+    # 10. Source-location grouping (file:line headers)
+    location_headers = re.findall(
+        r"^(\S+:\d+)\s+\(kernel_launches:", list_output, re.MULTILINE
+    )
+    assert location_headers, "No source-location headers found in output"
+
+    # 11. Aggregated stats on tree nodes
+    assert re.search(r"\(kernel_launches:\s+\d+,\s+total_duration:", list_output), (
+        "No aggregated stats found in output"
     )
 
-    # 11. Operator duration stats
-    op_durations = re.findall(
-        r"\(total_duration:\s+([\d.]+)\s+ms,\s+count:\s+\d+\)", list_output
-    )
-    assert op_durations, "No operator duration stats found in output"
-
-    # 12. Kernel IDs and usage-hint banner
+    # 12. Kernel IDs
     kernel_ids = re.findall(r"\(id (\d+)\)", list_output)
     assert kernel_ids, "No kernel IDs found in output"
-    assert "Kernel (id N) can be used with -k" in list_output, (
-        "Missing kernel ID banner hint"
-    )
 
     # 13. Kernel launch durations
-    assert re.search(r"launches, total_duration:", list_output), (
+    assert re.search(r"kernel_launches:\s+\d+,\s+total_duration:", list_output), (
         "No kernel duration info in output"
     )
 
-    # 14. Descending duration sort order — recompute the same sort key used by
-    #     list_torch_operators (sum of root-prefix durations per CSV) and verify
-    #     the CLI output lists operators in that order.
-    from utils.utils import compute_operator_prefix_stats
-
-    csv_sort_keys: list[tuple[str, float]] = []
-    for op_file in operator_csv_files:
-        op_df = pd.read_csv(op_file)
-        ps = compute_operator_prefix_stats(op_df)
-        total_ms = sum(dur for key, (dur, _) in ps.items() if "/" not in key)
-        csv_sort_keys.append((op_file.stem, total_ms))
-    csv_sort_keys.sort(key=lambda x: x[1], reverse=True)
-    expected_order = [name for name, _ in csv_sort_keys]
-
-    displayed_names = re.findall(r"Operator \d+:\s+'([^']+)'", list_output)
-    assert displayed_names == expected_order, (
-        f"Operators not sorted by descending duration.\n"
-        f"  Expected: {expected_order}\n"
-        f"  Got:      {displayed_names}"
+    # 14. Source locations sorted by descending total duration
+    location_durations = re.findall(
+        r"^(\S+:\d+)\s+\(kernel_launches:\s+\d+,\s+total_duration:\s+([\d.]+)\s+(ms|us)\)",
+        list_output,
+        re.MULTILINE,
+    )
+    assert location_durations, "No location durations found for sort-order check"
+    durations_ms = [
+        float(val) if unit == "ms" else float(val) / 1000.0
+        for _, val, unit in location_durations
+    ]
+    assert durations_ms == sorted(durations_ms, reverse=True), (
+        f"Source locations not sorted by descending duration: {location_durations}"
     )
 
     # 15. --list-torch-operators succeeds at every --kernel-verbose level 0-4

--- a/projects/rocprofiler-compute/tests/test_torch_trace.py
+++ b/projects/rocprofiler-compute/tests/test_torch_trace.py
@@ -35,7 +35,11 @@ from utils.rocpd_data import (
     MARKER_API_TRACE_QUERY,
     convert_dbs_to_csv,
 )
-from utils.utils import process_torch_trace_output
+from utils.utils import (
+    build_call_trees_with_kernel_ids,
+    process_torch_trace_output,
+    write_torch_trace_operator_csvs,
+)
 
 GUID = "abc-1234-def"
 
@@ -390,8 +394,35 @@ def test_torch_trace_output_same_for_rocpd_and_csv():
     write_csv_layout(csv_dir)
 
     kernel_top_df = build_kernel_top_df()
-    process_torch_trace_output(rocpd_dir, kernel_top_df)
-    process_torch_trace_output(csv_dir, kernel_top_df)
+    rocpd_output = process_torch_trace_output(rocpd_dir)
+    csv_output = process_torch_trace_output(csv_dir)
+    assert rocpd_output is not None
+    assert csv_output is not None
+    rocpd_df, rocpd_trace_path = rocpd_output
+    csv_df, csv_trace_path = csv_output
+
+    write_torch_trace_operator_csvs(rocpd_df, rocpd_trace_path)
+    write_torch_trace_operator_csvs(csv_df, csv_trace_path)
+    rocpd_trees = build_call_trees_with_kernel_ids(rocpd_df, kernel_top_df)
+    csv_trees = build_call_trees_with_kernel_ids(csv_df, kernel_top_df)
+
+    for trees in (rocpd_trees, csv_trees):
+        assert "test.py:10" in trees
+        assert "test.py:15" in trees
+
+        linear_root = trees["test.py:10"]
+        assert linear_root.kernel_launches == 2
+        assert "nn.Module.Linear.forward" in linear_root.children
+        linear_node = linear_root.children["nn.Module.Linear.forward"]
+        assert "kernel_gemm" in linear_node.kernels
+        assert linear_node.kernels["kernel_gemm"].launches == 2
+
+        mm_root = trees["test.py:15"]
+        assert mm_root.kernel_launches == 1
+        assert "torch.mm" in mm_root.children
+        mm_node = mm_root.children["torch.mm"]
+        assert "kernel_mm" in mm_node.kernels
+        assert mm_node.kernels["kernel_mm"].launches == 1
 
     rocpd_results = read_operator_csvs(Path(rocpd_dir) / "torch_trace")
     csv_results = read_operator_csvs(Path(csv_dir) / "torch_trace")

--- a/projects/rocprofiler-compute/tests/test_utils.py
+++ b/projects/rocprofiler-compute/tests/test_utils.py
@@ -41,6 +41,18 @@ import pandas as pd
 import pytest
 
 import utils.utils as utils
+from utils.tty import (
+    format_stats,
+    print_operator_node,
+    show_call_tree,
+)
+from utils.utils import (
+    CallTreeNode,
+    KernelStats,
+    build_call_trees,
+    parse_top_level_location,
+    rollup_node_stats,
+)
 
 SUPPORTED_ARCHS = {
     "gfx908": {"mi100": ["MI100"]},
@@ -7938,6 +7950,313 @@ def test_gpu_benchmark_locking(tmp_path, monkeypatch, capsys):
     assert "Waiting for GPU 0" in output
     assert "another rocprof-compute benchmark is in progress" in output
     assert "Acquired lock for GPU 0" in output
+
+
+# ---------------------------------------------------------------------------
+# Tests for call-tree functions (build/display)
+# ---------------------------------------------------------------------------
+
+
+def test_parse_location_normal():
+    assert parse_top_level_location("10@main.py:60/#10@main.py:21") == "main.py:60"
+
+
+def test_parse_location_single_entry():
+    assert parse_top_level_location("5@train.py:42") == "train.py:42"
+
+
+def test_parse_location_nan():
+    assert parse_top_level_location(float("nan")) == "unknown:0"
+
+
+def test_parse_location_none():
+    assert parse_top_level_location(None) == "unknown:0"
+
+
+def test_parse_location_empty():
+    assert parse_top_level_location("") == "unknown:0"
+    assert parse_top_level_location("   ") == "unknown:0"
+
+
+def test_parse_location_no_at_sign():
+    assert parse_top_level_location("no_at_sign") == "unknown:0"
+
+
+def test_parse_location_no_colon():
+    assert parse_top_level_location("10@mainpy") == "unknown:0"
+
+
+def test_format_stats_microseconds():
+    assert "us" in format_stats(1, 0.005)
+
+
+def test_format_stats_milliseconds():
+    assert "1.50 ms" in format_stats(1, 1.5)
+
+
+def test_format_stats_boundary():
+    assert "ms" in format_stats(1, 0.01)
+
+
+def test_format_stats_basic():
+    result = format_stats(3, 1.5)
+    assert "kernel_launches: 3" in result
+    assert "total_duration: 1.50 ms" in result
+
+
+def test_rollup_leaf_node():
+    node = CallTreeNode(name="leaf")
+    node.kernels["kern_a"] = KernelStats(launches=2, total_duration_ns=1000.0)
+    launches, dur_ns = rollup_node_stats(node)
+    assert launches == 2
+    assert dur_ns == 1000.0
+    assert node.kernel_launches == 2
+
+
+def test_rollup_parent_rolls_up_children():
+    child = CallTreeNode(name="child")
+    child.kernels["kern_a"] = KernelStats(launches=3, total_duration_ns=3000.0)
+    parent = CallTreeNode(name="parent")
+    parent.children["child"] = child
+    parent.kernels["kern_b"] = KernelStats(launches=1, total_duration_ns=500.0)
+    rollup_node_stats(parent)
+    assert parent.kernel_launches == 4
+    assert child.kernel_launches == 3
+
+
+def test_rollup_deep_hierarchy():
+    grandchild = CallTreeNode(name="grandchild")
+    grandchild.kernels["k"] = KernelStats(launches=1, total_duration_ns=100.0)
+    child = CallTreeNode(name="child")
+    child.children["grandchild"] = grandchild
+    child.kernels["k2"] = KernelStats(launches=2, total_duration_ns=200.0)
+    root = CallTreeNode(name="root")
+    root.children["child"] = child
+    rollup_node_stats(root)
+    assert grandchild.kernel_launches == 1
+    assert child.kernel_launches == 3
+    assert root.kernel_launches == 3
+
+
+def test_build_call_trees_empty_df():
+    assert build_call_trees(pd.DataFrame()) == {}
+
+
+def test_build_call_trees_missing_columns():
+    assert build_call_trees(pd.DataFrame([{"Operator_Name": "a"}])) == {}
+
+
+def test_build_call_trees_single_dispatch():
+    df = pd.DataFrame([
+        {
+            "Operator_Name": "torch.nn.Linear",
+            "Kernel_Name": "gemm_kernel",
+            "Context_Id": "10@train.py:42",
+            "Start_Timestamp_kernel": 1000,
+            "End_Timestamp_kernel": 2000,
+        }
+    ])
+    call_trees = build_call_trees(df)
+    assert "train.py:42" in call_trees
+    assert call_trees["train.py:42"].kernel_launches == 1
+    assert "torch.nn.Linear" in call_trees["train.py:42"].children
+
+
+def test_build_call_trees_hierarchy_split():
+    df = pd.DataFrame([
+        {
+            "Operator_Name": "aten/linear/addmm",
+            "Kernel_Name": "gemm_kernel",
+            "Context_Id": "10@file.py:1",
+            "Start_Timestamp_kernel": 0,
+            "End_Timestamp_kernel": 1000,
+        }
+    ])
+    call_trees = build_call_trees(df)
+    root = call_trees["file.py:1"]
+    assert "aten" in root.children
+    assert "linear" in root.children["aten"].children
+    assert "addmm" in root.children["aten"].children["linear"].children
+
+
+def test_build_call_trees_multiple_dispatches_same_kernel():
+    rows = [
+        {
+            "Operator_Name": "op_a",
+            "Kernel_Name": "kern",
+            "Context_Id": "10@f.py:1",
+            "Start_Timestamp_kernel": i * 1000,
+            "End_Timestamp_kernel": (i + 1) * 1000,
+        }
+        for i in range(3)
+    ]
+    call_trees = build_call_trees(pd.DataFrame(rows))
+    assert call_trees["f.py:1"].kernel_launches == 3
+    assert call_trees["f.py:1"].children["op_a"].kernels["kern"].launches == 3
+
+
+def test_build_call_trees_dedup_identical_timestamps():
+    row = {
+        "Operator_Name": "op",
+        "Kernel_Name": "kern",
+        "Context_Id": "10@f.py:1",
+        "Start_Timestamp_kernel": 1000,
+        "End_Timestamp_kernel": 2000,
+    }
+    assert build_call_trees(pd.DataFrame([row, row]))["f.py:1"].kernel_launches == 1
+
+
+def test_build_call_trees_no_context_id():
+    df = pd.DataFrame([
+        {
+            "Operator_Name": "op",
+            "Kernel_Name": "kern",
+            "Start_Timestamp_kernel": 0,
+            "End_Timestamp_kernel": 1000,
+        }
+    ])
+    assert "unknown:0" in build_call_trees(df)
+
+
+def test_build_call_trees_duration_rollup():
+    df = pd.DataFrame([
+        {
+            "Operator_Name": "parent/child",
+            "Kernel_Name": "kern_a",
+            "Context_Id": "10@f.py:1",
+            "Start_Timestamp_kernel": 0,
+            "End_Timestamp_kernel": 1_000_000,
+        },
+        {
+            "Operator_Name": "parent",
+            "Kernel_Name": "kern_b",
+            "Context_Id": "10@f.py:1",
+            "Start_Timestamp_kernel": 2_000_000,
+            "End_Timestamp_kernel": 3_000_000,
+        },
+    ])
+    call_trees = build_call_trees(df)
+    root = call_trees["f.py:1"]
+    assert root.kernel_launches == 2
+    assert root.children["parent"].kernel_launches == 2
+    assert root.children["parent"].children["child"].kernel_launches == 1
+
+
+def test_build_call_trees_multiple_source_locations():
+    df = pd.DataFrame([
+        {
+            "Operator_Name": "op_a",
+            "Kernel_Name": "kern",
+            "Context_Id": "10@a.py:1",
+            "Start_Timestamp_kernel": 0,
+            "End_Timestamp_kernel": 1000,
+        },
+        {
+            "Operator_Name": "op_b",
+            "Kernel_Name": "kern",
+            "Context_Id": "10@b.py:2",
+            "Start_Timestamp_kernel": 0,
+            "End_Timestamp_kernel": 1000,
+        },
+    ])
+    call_trees = build_call_trees(df)
+    assert "a.py:1" in call_trees
+    assert "b.py:2" in call_trees
+
+
+def test_show_call_tree_prints_location_and_stats(capsys):
+    root = CallTreeNode(name="main.py:10")
+    root.kernel_launches = 1
+    root.total_duration_ms = 0.5
+    child = CallTreeNode(name="op_a")
+    child.kernel_launches = 1
+    child.total_duration_ms = 0.5
+    child.kernels["kern"] = KernelStats(launches=1, total_duration_ns=500_000.0)
+    root.children["op_a"] = child
+    show_call_tree({"main.py:10": root})
+    output = capsys.readouterr().out
+    assert "main.py:10" in output
+    assert "kernel_launches: 1" in output
+    assert "kern" in output
+
+
+def test_show_call_tree_sorted_by_duration(capsys):
+    root_a = CallTreeNode(name="a.py:1")
+    root_a.total_duration_ms = 10.0
+    root_a.kernel_launches = 1
+    root_b = CallTreeNode(name="b.py:1")
+    root_b.total_duration_ms = 20.0
+    root_b.kernel_launches = 2
+    show_call_tree({"a.py:1": root_a, "b.py:1": root_b})
+    output = capsys.readouterr().out
+    assert output.index("b.py:1") < output.index("a.py:1")
+
+
+def test_show_call_tree_kernel_id_printed(capsys):
+    root = CallTreeNode(name="f.py:1")
+    root.kernel_launches = 1
+    root.total_duration_ms = 1.0
+    child = CallTreeNode(name="op")
+    child.kernel_launches = 1
+    child.total_duration_ms = 1.0
+    child.kernels["kern_x"] = KernelStats(
+        launches=1, total_duration_ns=1_000_000.0, kernel_id=42
+    )
+    root.children["op"] = child
+    show_call_tree({"f.py:1": root})
+    output = capsys.readouterr().out
+    assert "(id 42)" in output
+
+
+def test_print_operator_node_branching_shows_stats(capsys):
+    node = CallTreeNode(name="branch")
+    node.kernel_launches = 2
+    node.total_duration_ms = 5.0
+    node.kernels["k1"] = KernelStats(launches=1, total_duration_ns=2_500_000.0)
+    node.kernels["k2"] = KernelStats(launches=1, total_duration_ns=2_500_000.0)
+    print_operator_node(node)
+    output = capsys.readouterr().out
+    assert "kernel_launches: 2" in output
+    assert "k1" in output
+    assert "k2" in output
+
+
+def test_print_operator_node_non_branching_omits_stats(capsys):
+    node = CallTreeNode(name="single")
+    node.kernel_launches = 1
+    node.total_duration_ms = 1.0
+    node.kernels["k1"] = KernelStats(launches=1, total_duration_ns=1_000_000.0)
+    print_operator_node(node)
+    output = capsys.readouterr().out
+    lines = output.strip().split("\n")
+    assert "└─ single" in lines[0]
+    assert "kernel_launches" not in lines[0]
+
+
+def test_print_operator_node_long_kernel_wraps(capsys):
+    node = CallTreeNode(name="single")
+    node.kernel_launches = 1
+    node.total_duration_ms = 1.0
+    long_kernel_name = "K" * 220
+    node.kernels[long_kernel_name] = KernelStats(
+        launches=1,
+        total_duration_ns=1_000_000.0,
+        kernel_id=7,
+    )
+    print_operator_node(node)
+    output_lines = capsys.readouterr().out.splitlines()
+    assert any("└─ single" in line for line in output_lines)
+    kernel_lines = [
+        line for line in output_lines if "(id 7)" in line or line.startswith("   ")
+    ]
+    assert any(line.startswith("   └─ ") for line in kernel_lines)
+    wrapped_kernel_lines = [
+        line
+        for line in kernel_lines
+        if line.startswith("   ") and not line.startswith("   └─ ")
+    ]
+    assert wrapped_kernel_lines
+    assert not any(line.strip().startswith("(id 7)") for line in output_lines)
 
 
 # =============================================================================


### PR DESCRIPTION

## Motivation

Enhancing the `--list-torch-operator `display to help understand which source locations dominate GPU execution time

## Technical Details

1. `build_torch_trace_call_trees()` returns a dict mapping source locations to call tree roots, for `--list-torch-operators`
2. `process_torch_trace_output()` now handles only torch-trace preparation and is paired with `write_torch_trace_operator_csvs()` (CSV emission) and `build_torch_trace_call_trees()` (kernel-ID mapping + call-tree construction) to complete the --list-torch-operators flow.
3. `build_call_trees()` constructs a per-source-location `CallTreeNode` tree from the consolidated DataFrame, deduplicating kernel dispatches and rolling up launch counts and durations bottom-up via `rollup_node_stats()`
4. `show_call_tree()` shows _**adaptive us/ms formatting**_ for sub-millisecond durations.
5. **`--list-torch-operators` is handled in `pre_processing()`** right after `create_df_kernel_top_stats`(), reading `pmc_kernel_top.csv` directly and exiting early.

## JIRA ID

AIPROFCOMP-204
## Test Plan

`python3 -m pytest tests/test_profile_general.py -k test_torch_trace_profile -v`

`python3 -m pytest tests/test_utils.py -k "parse_location or format_stats or rollup or build_call_trees or show_call_tree or print_operator_node" -v`

`python3 -m pytest tests/test_torch_trace.py -v`

## Test Result
All tests PASS

Sample output shown below..

<img width="810" height="552" alt="Screenshot 2026-03-17 150209" src="https://github.com/user-attachments/assets/7b987f7e-cbff-492d-9b8e-5e0f1e618d29" />


## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
