### PR TITLE
[HIP-TESTS] Enforce tracking of disabled tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .cline_storage
 /projects/hip/_build
+__pycache__

--- a/projects/hip-tests/catch/README.md
+++ b/projects/hip-tests/catch/README.md
@@ -55,6 +55,9 @@ Every test case has its own entry. Currently supported options are:
 - level : Specify to which level the case belongs to (e.g. Level_2 is a standard test)
 - tags : List all Catch2 tags that the case is associated with
 - disabled : List all platforms where the case should be disabled
+- tracker: Mandatory when a test is disabled on any of configurations. Should
+  contain either a JIRA key (`PROJECT-123`), or a GitHub issue reference
+  (`org/repo#12345`) which describes the failure causing a test to be disabled
 The group name is automatically added as a tag for every case.
 Changing the configuration file will retrigger the build, so we have an up to date configuration every time.
 

--- a/projects/hip-tests/catch/config/check_config.py
+++ b/projects/hip-tests/catch/config/check_config.py
@@ -1,11 +1,24 @@
 import sys
+import re
 
 from common import iter_group_configs
 
 
-def print_tests_list(tests):
-        for entry in tests:
-            print(entry, file=sys.stderr)
+def report(message, bad_tests):
+    if len(bad_tests) == 0:
+        return 0
+    print(f"ERROR: The following test cases {message}:", file=sys.stderr)
+    for entry in bad_tests:
+        print(entry, file=sys.stderr)
+    return 1
+
+
+def check_tracker_format(tracker_str):
+    jira_format = r'[A-Z]+\d+'  # PROJECT-123
+    gh_format = r'[\w\d-]+/[\w\d-]+#\d+'  # org/repo#123
+    if re.match(jira_format, tracker_str) is None and re.match(gh_format, tracker_str) is None:
+        return False
+    return True
 
 
 def main():
@@ -16,29 +29,26 @@ def main():
 
     missing_level = []
     missing_tracker = []
+    invalid_tracker_format = []
+
 
     for group, cases in iter_group_configs(config_path):
         for case_name, case_config in cases.items():
+            test = f"  {group}/{case_name}"
+
             if "level" not in case_config:
-                missing_level.append(f"  {group}/{case_name}")
-            if "disabled" in case_config and "tracker" not in case_config:
-                missing_tracker.append(f"  {group}/{case_name}")
+                missing_level.append(test)
+            if "disabled" in case_config:
+                if "tracker" not in case_config:
+                    missing_tracker.append(test)
+                elif not check_tracker_format(case_config["tracker"]):
+                    invalid_tracker_format.append(test)
 
-    if missing_level:
-        print(
-            "ERROR: The following test cases are missing a 'level' in their YAML config:",
-            file=sys.stderr,
-        )
-        print_tests_list(missing_level)
+    errors = report("are missing a 'level' in their YAML config", missing_level)
+    errors += report("are disabled, but lack a 'tracker' in their YAML config", missing_tracker)
+    errors += report("have 'tracker' in incorrect format, it should be ([A-Z]+\d+)|([\w\d-]+/[\w\d-]+#\d+)", invalid_tracker_format)
 
-    if missing_tracker:
-        print(
-            "ERROR: The following test cases are disabled, but lack a 'tracker' in their YAML config:",
-            file=sys.stderr,
-        )
-        print_tests_list(missing_tracker)
-
-    if missing_level or missing_tracker:
+    if errors != 0:
         sys.exit(1)
 
 

--- a/projects/hip-tests/catch/config/check_config.py
+++ b/projects/hip-tests/catch/config/check_config.py
@@ -14,7 +14,7 @@ def report(message, bad_tests):
 
 
 def check_tracker_format(tracker_str):
-    jira_format = r'[A-Z]+\d+'  # PROJECT-123
+    jira_format = r'[A-Z]+-\d+'  # PROJECT-123
     gh_format = r'[\w\d-]+/[\w\d-]+#\d+'  # org/repo#123
     if re.match(jira_format, tracker_str) is None and re.match(gh_format, tracker_str) is None:
         return False
@@ -42,11 +42,12 @@ def main():
                 if "tracker" not in case_config:
                     missing_tracker.append(test)
                 elif not check_tracker_format(case_config["tracker"]):
+                    print(case_config["tracker"])
                     invalid_tracker_format.append(test)
 
     errors = report("are missing a 'level' in their YAML config", missing_level)
     errors += report("are disabled, but lack a 'tracker' in their YAML config", missing_tracker)
-    errors += report("have 'tracker' in incorrect format, it should be ([A-Z]+\d+)|([\w\d-]+/[\w\d-]+#\d+)", invalid_tracker_format)
+    errors += report("have 'tracker' in incorrect format, it should be ([A-Z]+-\d+)|([\w\d-]+/[\w\d-]+#\d+)", invalid_tracker_format)
 
     if errors != 0:
         sys.exit(1)

--- a/projects/hip-tests/catch/config/check_config.py
+++ b/projects/hip-tests/catch/config/check_config.py
@@ -3,26 +3,42 @@ import sys
 from common import iter_group_configs
 
 
+def print_tests_list(tests):
+        for entry in tests:
+            print(entry, file=sys.stderr)
+
+
 def main():
     if not len(sys.argv) == 2:
         raise ValueError("1 argument expected")
 
     config_path = sys.argv[1]
 
-    missing = []
+    missing_level = []
+    missing_tracker = []
 
     for group, cases in iter_group_configs(config_path):
         for case_name, case_config in cases.items():
             if "level" not in case_config:
-                missing.append(f"  {group}/{case_name}")
+                missing_level.append(f"  {group}/{case_name}")
+            if "disabled" in case_config and "tracker" not in case_config:
+                missing_tracker.append(f"  {group}/{case_name}")
 
-    if missing:
+    if missing_level:
         print(
             "ERROR: The following test cases are missing a 'level' in their YAML config:",
             file=sys.stderr,
         )
-        for entry in missing:
-            print(entry, file=sys.stderr)
+        print_tests_list(missing_level)
+
+    if missing_tracker:
+        print(
+            "ERROR: The following test cases are disabled, but lack a 'tracker' in their YAML config:",
+            file=sys.stderr,
+        )
+        print_tests_list(missing_tracker)
+
+    if missing_level or missing_tracker:
         sys.exit(1)
 
 

--- a/projects/hip-tests/catch/config/configs/unit/device.yaml
+++ b/projects/hip-tests/catch/config/configs/unit/device.yaml
@@ -111,12 +111,12 @@ device:
   Unit_hipDeviceSetLimit_Negative_MallocHeapSize: *level_2
   Unit_hipDeviceSetLimit_Negative_Parameters:
     <<: *level_2
-    # Below 2 tests are disabled due to defect EXSWHTEC-342
     disabled: [nvidia_windows]
+    tracker: EXSWHTEC-342
   Unit_hipDeviceGetLimit_Negative_Parameters:
     <<: *level_2
-    # Below 2 tests are disabled due to defect EXSWHTEC-342
     disabled: [nvidia_windows]
+    tracker: EXSWHTEC-342
   Unit_hipDeviceGetSetLimit_Scratch_Negative: *level_2
   Unit_hipDeviceGetSetLimit_Scratch_SetMinAndMaxAsCurrent: *level_2
   Unit_hipDeviceGetSetLimit_Scratch_DecreaseIncrease: *level_2
@@ -199,8 +199,8 @@ device:
     disabled: [amd_linux, amd_wsl]
   Unit_hipIpcGetMemHandle_Positive_Unique_Handles_Separate_Allocations:
     <<: *level_2
-    # Note: Test disabled due to defect - EXSWHTEC-207
     disabled: [amd_wsl]
+    tracker: EXSWHTEC-207
   Unit_hipIpcGetMemHandle_Positive_Unique_Handles_Reused_Memory:
     <<: *level_2
     # Note: hsa_amd_ipc_ is dummy

--- a/projects/hip-tests/catch/config/configs/unit/graph.yaml
+++ b/projects/hip-tests/catch/config/configs/unit/graph.yaml
@@ -37,8 +37,8 @@ graph:
   Unit_hipGraphAddMemcpyNode_Positive_Basic: *level_2
   Unit_hipGraphAddMemcpyNode_Negative_Parameters:
     <<: *level_2
-    # NOTE: The following test is disabled due to defect - EXSWHTEC-245
     disabled: [amd_windows]
+    tracker: EXSWHTEC-245
   Unit_hipGraphClone_Negative: *level_2
   Unit_hipGraphClone_Functional:
     <<: *level_2
@@ -128,8 +128,8 @@ graph:
     tags: [multigpu]
   Unit_hipGraphExecMemsetNodeSetParams_Negative_Updating_Non1D_Node:
     <<: *level_2
-    # Note: Test disabled due to defect - EXSWHTEC-207
     disabled: [amd_windows, amd_wsl]
+    tracker: EXSWHTEC-207
   Unit_hipGraphMemcpyNodeSetParamsToSymbol_Negative: *level_2
   Unit_hipGraphMemcpyNodeSetParamsToSymbol_Positive_Basic:
     <<: *level_2
@@ -251,8 +251,8 @@ graph:
   Unit_hipGraphMemsetNodeGetParams_Negative_Parameters: *level_2
   Unit_hipGraphMemsetNodeSetParams_Positive_Basic:
     <<: *level_2
-    # Note: Following four tests disabled due to defect - EXSWHTEC-203
     disabled: [amd_windows, amd_wsl]
+    tracker: EXSWHTEC-203
   Unit_hipGraphMemsetNodeSetParams_Negative_Parameters: *level_2
   Unit_hipGraphMultiDevice: *level_2
   Unit_hipGraphExecMemcpyNodeSetParamsFromSymbol_Negative: *level_2
@@ -506,8 +506,8 @@ graph:
   Unit_hipGraphDestroy_Negative_Parameters: *level_2
   Unit_hipStreamSetCaptureDependencies_Positive_Functional:
     <<: *level_2
-    # Note: Following four tests disabled due to defect - EXSWHTEC-203
     disabled: [amd_windows, amd_wsl]
+    tracker: EXSWHTEC-203
   Unit_hipStreamAddCaptureDependencies_Positive_Functional: *level_2
   Unit_hipStreamUpdateCaptureDependencies_Positive_Parameters: *level_2
   Unit_hipStreamUpdateCaptureDependencies_Negative_Parameters: *level_2

--- a/projects/hip-tests/catch/config/configs/unit/memory.yaml
+++ b/projects/hip-tests/catch/config/configs/unit/memory.yaml
@@ -333,12 +333,12 @@ memory:
   Unit_hipMemRangeGetAttribute_Positive_LastPrefetchLocation_Partial_Range: *level_2
   Unit_hipMemRangeGetAttribute_Positive_AccessedBy_Basic:
     <<: *level_2
-    # NOTE: The following 2 tests are disabled due to defect - EXSWHTEC-238
     disabled: [amd_linux, amd_wsl]
+    tracker: EXSWHTEC-238
   Unit_hipMemRangeGetAttribute_Positive_AccessedBy_Partial_Range:
     <<: *level_2
-    # NOTE: The following 2 tests are disabled due to defect - EXSWHTEC-238
     disabled: [amd_linux, amd_wsl]
+    tracker: EXSWHTEC-238
   Unit_hipMemRangeGetAttribute_Positive_AccessedBy_MultiDevice: *level_2
   Unit_hipMemRangeGetAttribute_Negative_Parameters: *level_2
   Unit_hipMemRangeGetAttribute_TstCountParam: *level_2
@@ -507,8 +507,8 @@ memory:
   Unit_hipMemAdvise_v2_Negative: *level_2
   Unit_hipPointerSetAttribute_Positive_SyncMemops:
     <<: *level_2
-    # Below test is disabled due to defect EXSWHTEC-347
     disabled: [amd_windows]
+    tracker: EXSWHTEC-347
   Unit_hipPointerSetAttribute_Negative_Parameters: *level_2
   Unit_hipMemcpyFromToSymbol_Negative: *level_2
   Unit_hipMemcpyToFromSymbol_SyncAndAsync: *level_2
@@ -880,8 +880,8 @@ memory:
   Unit_hipDrvMemcpy3D_Positive_Parameters: *level_2
   Unit_hipDrvMemcpy3D_Positive_Array:
     <<: *level_2
-    # NOTE: The following 2 tests are disabled due to defect - EXSWHTEC-238
     disabled: [amd_windows, amd_wsl]
+    defect: EXSWHTEC-238
   Unit_hipDrvMemcpy3D_Negative_Parameters: *level_2
   Unit_hipDrvMemcpy3D_Capture: *level_2
   Unit_hipDrvMemcpy3D_MultipleDataTypes: *level_2
@@ -902,8 +902,8 @@ memory:
   Unit_hipDrvMemcpy3DAsync_Positive_Parameters: *level_2
   Unit_hipDrvMemcpy3DAsync_Positive_Array:
     <<: *level_2
-    # NOTE: The following 2 tests are disabled due to defect - EXSWHTEC-238
     disabled: [amd_windows, amd_wsl]
+    defect: EXSWHTEC-238
   Unit_hipDrvMemcpy3DAsync_Negative_Parameters: *level_2
   Unit_hipDrvMemcpy3DAsync_Capture: *level_2
   Unit_hipDrvMemcpy3DAsync_H2DDeviceContextChange:
@@ -979,8 +979,8 @@ memory:
     disabled: [amd_wsl]
   Unit_hipMemset3DSync:
     <<: *level_2
-    # Note: Following four tests disabled due to defect - EXSWHTEC-203
     disabled: [amd_wsl]
+    defect: EXSWHTEC-203
   Unit_hipMemsetASyncMulti: *level_2
   Unit_hipMemsetDASyncMulti: *level_2
   Unit_hipMemset2DASyncMulti: *level_2
@@ -1011,6 +1011,7 @@ memory:
     # (amd_windows) Note: intermittent Seg fault failure
     # (amd_wsl) Note: intermittent Seg fault failure
     disabled: [amd_linux, amd_windows, amd_wsl]
+    defect: EXSWHTEC-234
   Unit_hipMemAdvise_Rounding: *level_2
   Unit_hipMemAdvise_Flags_Do_Not_Cause_Prefetch: *level_2
   Unit_hipMemAdvise_Read_Write_After_Advise:

--- a/projects/hip-tests/catch/config/configs/unit/module.yaml
+++ b/projects/hip-tests/catch/config/configs/unit/module.yaml
@@ -41,8 +41,8 @@ module:
     disabled: [nvidia_windows]
   Unit_hipModuleLoadDataEx_Negative_Image_Is_An_Empty_String:
     <<: *level_2
-    # Note: Following two tests disabled due to defect - EXSWHTEC-153
     disabled: [amd_windows]
+    tracker: EXSWHTEC-153
   Unit_hipGetFuncBySymbol_PositiveTest: *level_2
   Unit_hipGetFuncBySymbol_NegativeTests: *level_2
   Unit_hipGetFuncBySymbol_InChildProcess: *level_2
@@ -81,8 +81,8 @@ module:
     disabled: [nvidia_windows]
   Unit_hipModuleLoadData_Negative_Image_Is_An_Empty_String:
     <<: *level_2
-    # Note: Following two tests disabled due to defect - EXSWHTEC-153
     disabled: [amd_windows]
+    tracker: EXSWHTEC-153
   Unit_hipModuleLoadData_Functional: *level_2
   Unit_hipModuleLoad_Positive_Basic:
     <<: *level_2
@@ -96,8 +96,8 @@ module:
   Unit_hipFuncSetSharedMemConfig_functional: *level_2
   Unit_hipModuleUnload_Negative_Module_Is_Nullptr:
     <<: *level_2
-    # Note: Test disabled due to defect - EXSWHTEC-152
     disabled: [amd_windows]
+    tracker: EXSWHTEC-152
   Unit_hipModuleUnload_Negative_Double_Unload:
     <<: *level_2
     # Below test fails in external CI for PR https://github.com/ROCm-Developer-Tools/hip-tests/pull/215
@@ -136,16 +136,16 @@ module:
   Unit_hipModuleGetGlobal_Negative_Parameters: *level_2
   Unit_hipModuleGetGlobal_Negative_Hmod_Is_Nullptr:
     <<: *level_2
-    # Note: Test disabled due to defect - EXSWHTEC-163
     disabled: [amd_windows]
+    tracker: EXSWHTEC-163
   Unit_hipModuleGetGlobal_Negative_Name_Is_Empty_String:
     <<: *level_2
-    # Note: Test disabled due to defect - EXSWHTEC-164
     disabled: [amd_windows]
+    tracker: EXSWHTEC-164
   Unit_hipModuleGetGlobal_Negative_Dptr_And_Bytes_Are_Nullptr:
     <<: *level_2
-    # Note: Test disabled due to defect - EXSWHTEC-165
     disabled: [amd_windows]
+    tracker: EXSWHTEC-165
   Unit_hipModuleGetGlobal_DiffDevice: *level_2
   Unit_hipModule_Functional: *level_2
   Unit_hipModuleGetTexRef_Positive_Basic:
@@ -159,12 +159,12 @@ module:
     disabled: [amd_windows]
   Unit_hipModuleGetTexRef_Negative_Hmod_Is_Nullptr:
     <<: *level_2
-    # Note: Test disabled due to defect - EXSWHTEC-166
     disabled: [amd_windows]
+    tracker: EXSWHTEC-166
   Unit_hipModuleGetTexRef_Negative_Name_Is_Empty_String:
     <<: *level_2
-    # Note: Test disabled due to defect - EXSWHTEC-167
     disabled: [amd_windows]
+    tracker: EXSWHTEC-167
   Unit_hipFuncSetAttribute_Basic: *level_2
   Unit_hipExtModuleLaunchKernel_CheckCodeObjAttr: *level_2
   Unit_hipExtModuleLaunchKernel_NonUniformWorkGroup:

--- a/projects/hip-tests/catch/config/configs/unit/stream.yaml
+++ b/projects/hip-tests/catch/config/configs/unit/stream.yaml
@@ -27,6 +27,7 @@ stream:
     # (amd_windows) Disabling below tests temporarily due to change in API behavior
     # (amd_wsl) Note: Following four tests disabled due to defect - EXSWHTEC-203
     disabled: [amd_windows, amd_wsl]
+    defect: EXSWHTEC-203
   Unit_hipStreamCreateWithPriority_FunctionalForAllPriorities: *level_2
   Unit_hipStreamCreateWithPriority_MulthreadDefaultflag:
     <<: *level_2
@@ -187,6 +188,7 @@ stream:
     # (amd_windows) SWDEV-400049 tdr intermittently
     # (amd_wsl) Note: Following four tests disabled due to defect - EXSWHTEC-203
     disabled: [amd_windows, amd_wsl]
+    defect: EXSWHTEC-203
   Unit_hipLaunchHostFunc_basic: *level_2
   Unit_hipLaunchHostFunc_Negative: *level_2
   Unit_hipLaunchHostFunc_streams:

--- a/projects/hip-tests/catch/config/configs/unit/virtualMemoryManagement.yaml
+++ b/projects/hip-tests/catch/config/configs/unit/virtualMemoryManagement.yaml
@@ -52,12 +52,14 @@ virtualMemoryManagement:
     # (amd_windows) NOTE: The following test is disabled due to defect - EXSWHTEC-244
     # (amd_wsl) Patch which removes the typetraits implementation from std namespace in hiprtc is reverted
     disabled: [amd_windows, amd_wsl]
+    defect: EXSWHTEC-244
   Unit_hipMemAddressFree_Capture: *level_2
   Unit_hipMemAddressReserve_AlignmentTest:
     <<: *level_2
     # (amd_windows) NOTE: The following test is disabled due to defect - EXSWHTEC-245
     # (amd_wsl) Patch which removes the typetraits implementation from std namespace in hiprtc is reverted
     disabled: [amd_windows, amd_wsl]
+    defect: EXSWHTEC-245
   Unit_hipMemAddressReserve_Negative: *level_2
   Unit_hipMemAddressReserve_Capture: *level_2
   Unit_hipMemCreate_BasicAllocateDeAlloc_MultGranularity:


### PR DESCRIPTION
## Motivation

Prevent tests to be silently disabled and then forgotten forever.

## Technical Details

If a test is disabled, then its configuration file must contain a reference to a tracker which is submitted to address the failure and re-enable the test.

## JIRA ID

N/A

## Test Plan

N/A

## Test Result

N/A

## Submission Checklist

- [X] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
