### PR TITLE
SWDEV-567112 - Introduce new mechanism for tagging and disabling tests - Part 4

### DIFF
--- a/projects/hip-tests/catch/config/configs/unit/memory.yaml
+++ b/projects/hip-tests/catch/config/configs/unit/memory.yaml
@@ -200,7 +200,6 @@ memory:
   Unit_hipHostRegister_Perform_hipMemcpy: *level_2
   Unit_hipHostRegister_AsyncApis: *level_2
   Unit_hipHostRegister_Graphs: *level_2
-  Unit_hipHostRegister_RegUnreg_Perf_SameChunk: *level_2
   Unit_hipHostRegister_RegUnreg_Perf_DiffChunk: *level_2
   Unit_hipHostRegister_RegUnreg_Perf_SameChunk_MGPU: *level_2
   Unit_hipHostRegister_MemAdvise_SetGet: *level_2
@@ -690,7 +689,6 @@ memory:
   Unit_hipMemsetAsync_VerifyExecutionWithKernel: *level_2
   Unit_hipMemset2DAsync_WithKernel: *level_2
   Unit_hipMemset2DAsync_MultiThread: *level_2
-  Unit_hipMalloc_ArgumentValidation: *level_2
   Unit_hipMemcpyDtoD_Basic:
     <<: *level_2
     tags: [multigpu]
@@ -1035,7 +1033,10 @@ memory:
   Unit_hipFreeHost_InvalidMemory: *level_2
   Unit_hipFreeHost_DoubleFree: *level_2
   Unit_hipFreeHost_Multithreading: *level_2
-  Unit_hipFreeHost_Capture: *level_2
+  Unit_hipFreeHost_Capture_negative:
+    <<: *level_2
+    # Huge memory usage, no point enabling them with ASAN
+    disabled: [amd_linux]
   Unit_hipMallocAsync_Basic_OneAlloc: *level_2
   Unit_hipMallocAsync_Basic_TwoAllocs: *level_2
   Unit_hipMallocAsync_Basic_Reuse: *level_2
@@ -1241,7 +1242,3 @@ memory:
   Unit_hipMemGetMemPool_Basic: *level_2
   Unit_hipMemSetMemPool_Negative: *level_2
   Unit_hipMemSetMemPool_Basic: *level_2
-  Unit_hipFreeHost_Capture_negative:
-    <<: *level_2
-    # Huge memory usage, no point enabling them with ASAN
-    disabled: [amd_linux]

--- a/projects/hip-tests/catch/unit/graph/hipDeviceGetGraphMemAttribute.cc
+++ b/projects/hip-tests/catch/unit/graph/hipDeviceGetGraphMemAttribute.cc
@@ -108,7 +108,7 @@ static void ResetGraphMemAttribute(unsigned deviceId = 0) {
  * ------------------------
  *  - HIP_VERSION >= 6.0
  */
-TEST_CASE("Unit_hipDeviceGetGraphMemAttribute_Positive_DoubleMemory") {
+TEST_CASE(Unit_hipDeviceGetGraphMemAttribute_Positive_DoubleMemory) {
   hipGraphExec_t graph_exec1, graph_exec2;
   int *dev_p1, *dev_p2;
 
@@ -154,7 +154,7 @@ TEST_CASE("Unit_hipDeviceGetGraphMemAttribute_Positive_DoubleMemory") {
  * ------------------------
  *  - HIP_VERSION >= 6.0
  */
-TEST_CASE("Unit_hipDeviceGetGraphMemAttribute_Negative_Parameters") {
+TEST_CASE(Unit_hipDeviceGetGraphMemAttribute_Negative_Parameters) {
   int device_id = 0;
   HIP_CHECK(hipSetDevice(device_id));
 
@@ -305,12 +305,11 @@ static void hipDeviceGetGraphMemAttribute_Functional_Test(unsigned deviceId = 0)
   ResetGraphMemAttribute(deviceId);
 }
 
-TEST_CASE("Unit_hipDeviceGetGraphMemAttribute_Functional") {
+TEST_CASE(Unit_hipDeviceGetGraphMemAttribute_Functional) {
   hipDeviceGetGraphMemAttribute_Functional_Test();
 }
 
-TEST_CASE("Unit_hipDeviceGetGraphMemAttribute_Functional_Multi_Device",
-          "[multigpu]") {
+TEST_CASE(Unit_hipDeviceGetGraphMemAttribute_Functional_Multi_Device) {
   int numDevices = 0;
   HIP_CHECK(hipGetDeviceCount(&numDevices));
 
@@ -339,7 +338,7 @@ TEST_CASE("Unit_hipDeviceGetGraphMemAttribute_Functional_Multi_Device",
  *  - HIP_VERSION >= 6.1
  */
 
-TEST_CASE("Unit_hipDeviceGetGraphMemAttribute_Negative") {
+TEST_CASE(Unit_hipDeviceGetGraphMemAttribute_Negative) {
   size_t value = 0;
   hipError_t ret;
   SECTION("Pass device id as negative value") {
@@ -379,7 +378,7 @@ TEST_CASE("Unit_hipDeviceGetGraphMemAttribute_Negative") {
  *  - HIP_VERSION >= 6.1
  */
 
-TEST_CASE("Unit_hipDeviceSetGraphMemAttribute_Negative") {
+TEST_CASE(Unit_hipDeviceSetGraphMemAttribute_Negative) {
   size_t value = 0;
   hipError_t ret;
   SECTION("Pass device id as negative value") {

--- a/projects/hip-tests/catch/unit/graph/hipDeviceGraphMemTrim.cc
+++ b/projects/hip-tests/catch/unit/graph/hipDeviceGraphMemTrim.cc
@@ -41,7 +41,7 @@ THE SOFTWARE.
  * ------------------------
  *  - HIP_VERSION >= 6.0
  */
-TEST_CASE("Unit_hipDeviceGraphMemTrim_Positive_Default") {
+TEST_CASE(Unit_hipDeviceGraphMemTrim_Positive_Default) {
   const auto device = GENERATE(range(0, HipTest::getDeviceCount()));
 
   // Check for each device
@@ -60,7 +60,7 @@ TEST_CASE("Unit_hipDeviceGraphMemTrim_Positive_Default") {
  * ------------------------
  *  - HIP_VERSION >= 6.0
  */
-TEST_CASE("Unit_hipDeviceGraphMemTrim_Negative_Parameters") {
+TEST_CASE(Unit_hipDeviceGraphMemTrim_Negative_Parameters) {
   int device_id = 0;
   HIP_CHECK(hipSetDevice(device_id));
 

--- a/projects/hip-tests/catch/unit/graph/hipDeviceSetGraphMemAttribute.cc
+++ b/projects/hip-tests/catch/unit/graph/hipDeviceSetGraphMemAttribute.cc
@@ -48,7 +48,7 @@ static void GraphSetGetAttribute(int device, hipGraphMemAttributeType attr, size
  * ------------------------
  *  - HIP_VERSION >= 6.0
  */
-TEST_CASE("Unit_hipDeviceSetGraphMemAttribute_Positive_Default") {
+TEST_CASE(Unit_hipDeviceSetGraphMemAttribute_Positive_Default) {
   const auto device = GENERATE(range(0, HipTest::getDeviceCount()));
   const auto attr_type = GENERATE(hipGraphMemAttrUsedMemHigh, hipGraphMemAttrReservedMemHigh);
 
@@ -74,7 +74,7 @@ TEST_CASE("Unit_hipDeviceSetGraphMemAttribute_Positive_Default") {
  * ------------------------
  *  - HIP_VERSION >= 6.0
  */
-TEST_CASE("Unit_hipDeviceSetGraphMemAttribute_Negative_Parameters") {
+TEST_CASE(Unit_hipDeviceSetGraphMemAttribute_Negative_Parameters) {
   int device_id = 0;
   HIP_CHECK(hipSetDevice(device_id));
 

--- a/projects/hip-tests/catch/unit/graph/hipDrvGraphAddMemFreeNode.cc
+++ b/projects/hip-tests/catch/unit/graph/hipDrvGraphAddMemFreeNode.cc
@@ -46,7 +46,7 @@ THE SOFTWARE.
  * ------------------------
  *  - HIP_VERSION >= 6.4
  */
-TEST_CASE("Unit_hipDrvGraphAddMemFreeNode_Negative_Params") {
+TEST_CASE(Unit_hipDrvGraphAddMemFreeNode_Negative_Params) {
   constexpr size_t N = 1024;
   hipGraph_t graph;
   hipGraphNode_t alloc_node, free_node;
@@ -101,7 +101,7 @@ TEST_CASE("Unit_hipDrvGraphAddMemFreeNode_Negative_Params") {
  * ------------------------
  *  - HIP_VERSION >= 6.4
  */
-TEST_CASE("Unit_hipDrvGraphAddMemFreeNode_Positive") {
+TEST_CASE(Unit_hipDrvGraphAddMemFreeNode_Positive) {
   constexpr size_t N = 1024;
   hipGraph_t graph;
   hipGraphExec_t graphExec;

--- a/projects/hip-tests/catch/unit/graph/hipDrvGraphAddMemcpyNode.cc
+++ b/projects/hip-tests/catch/unit/graph/hipDrvGraphAddMemcpyNode.cc
@@ -64,7 +64,7 @@ THE SOFTWARE.
  *  - HIP_VERSION >= 6.1
  */
 #if HT_AMD
-TEST_CASE("Unit_hipDrvGraphAddMemcpyNode_Negative") {
+TEST_CASE(Unit_hipDrvGraphAddMemcpyNode_Negative) {
   CHECK_IMAGE_SUPPORT
 
   constexpr size_t size = 1024;
@@ -347,7 +347,7 @@ static void hipDrvGraphAddMemcpyNode_test(int deviceid = 0) {
  *  - HIP_VERSION >= 6.1
  */
 
-TEST_CASE("Unit_hipDrvGraphAddMemcpyNode_test") {
+TEST_CASE(Unit_hipDrvGraphAddMemcpyNode_test) {
   CHECK_IMAGE_SUPPORT
 
   hipDrvGraphAddMemcpyNode_test();
@@ -368,7 +368,7 @@ TEST_CASE("Unit_hipDrvGraphAddMemcpyNode_test") {
  *  - HIP_VERSION >= 6.1
  */
 
-TEST_CASE("Unit_hipDrvGraphAddMemcpyNode_MulitDevice", "[multigpu]") {
+TEST_CASE(Unit_hipDrvGraphAddMemcpyNode_MulitDevice) {
   CHECK_IMAGE_SUPPORT
 
   int numDevices = 0;
@@ -398,7 +398,7 @@ TEST_CASE("Unit_hipDrvGraphAddMemcpyNode_MulitDevice", "[multigpu]") {
  *    - HIP_VERSION >= 6.0
  */
 
-TEST_CASE("Unit_hipDrvGraphAddMemcpyNode_Positive_Basic") {
+TEST_CASE(Unit_hipDrvGraphAddMemcpyNode_Positive_Basic) {
   using namespace std::placeholders;
 
   constexpr bool async = false;
@@ -438,7 +438,7 @@ TEST_CASE("Unit_hipDrvGraphAddMemcpyNode_Positive_Basic") {
   HIP_CHECK(hipCtxDestroy(context));
 }
 
-TEST_CASE("Unit_hipDrvGraphAddMemcpyNode_Positive_Array") {
+TEST_CASE(Unit_hipDrvGraphAddMemcpyNode_Positive_Array) {
   CHECK_IMAGE_SUPPORT
 
   using namespace std::placeholders;
@@ -493,7 +493,7 @@ TEST_CASE("Unit_hipDrvGraphAddMemcpyNode_Positive_Array") {
  * ------------------------
  *    - HIP_VERSION >= 6.0
  */
-TEST_CASE("Unit_hipDrvGraphAddMemcpyNode_Negative_Parameters") {
+TEST_CASE(Unit_hipDrvGraphAddMemcpyNode_Negative_Parameters) {
   using namespace std::placeholders;
 
   HIP_CHECK(hipInit(0));

--- a/projects/hip-tests/catch/unit/graph/hipDrvGraphAddMemsetNode.cc
+++ b/projects/hip-tests/catch/unit/graph/hipDrvGraphAddMemsetNode.cc
@@ -56,7 +56,7 @@ static char memSetVal = 'a';
  * ------------------------
  *    - HIP_VERSION >= 6.0
  */
-TEMPLATE_TEST_CASE("Unit_hipDrvGraphAddMemsetNode_Positive_Basic", "", uint8_t, uint16_t,
+TEMPLATE_TEST_CASE(Unit_hipDrvGraphAddMemsetNode_Positive_Basic, uint8_t, uint16_t,
                    uint32_t) {
   CHECK_IMAGE_SUPPORT
 
@@ -116,7 +116,7 @@ TEMPLATE_TEST_CASE("Unit_hipDrvGraphAddMemsetNode_Positive_Basic", "", uint8_t, 
  * ------------------------
  *    - HIP_VERSION >= 6.0
  */
-TEST_CASE("Unit_hipDrvGraphAddMemsetNode_Negative_Parameters") {
+TEST_CASE(Unit_hipDrvGraphAddMemsetNode_Negative_Parameters) {
   using namespace std::placeholders;
 
   HIP_CHECK(hipInit(0));
@@ -511,7 +511,7 @@ TEST_CASE("Unit_hipDrvGraphAddMemsetNode_hipMalloc3D_1D") {
  * ------------------------
  *    - HIP_VERSION >= 6.0
  */
-TEST_CASE("Unit_hipDrvGraphAddMemsetNode_hipMalloc_1D") {
+TEST_CASE(Unit_hipDrvGraphAddMemsetNode_hipMalloc_1D) {
   HIP_CHECK(hipInit(0));
   hipDevice_t device;
   hipCtx_t context;
@@ -594,7 +594,7 @@ TEST_CASE("Unit_hipDrvGraphAddMemsetNode_hipMalloc_1D") {
  * ------------------------
  *    - HIP_VERSION >= 6.0
  */
-TEST_CASE("Unit_hipDrvGraphAddMemsetNode_hipMallocManaged") {
+TEST_CASE(Unit_hipDrvGraphAddMemsetNode_hipMallocManaged) {
   HIP_CHECK(hipInit(0));
   hipDevice_t device;
   hipCtx_t context;

--- a/projects/hip-tests/catch/unit/graph/hipDrvGraphExecMemcpyNodeSetParams.cc
+++ b/projects/hip-tests/catch/unit/graph/hipDrvGraphExecMemcpyNodeSetParams.cc
@@ -42,7 +42,7 @@ THE SOFTWARE.
  * ------------------------
  *  - HIP_VERSION >= 6.4
  */
-TEST_CASE("Unit_hipDrvGraphExecMemcpyNodeSetParams_Negative") {
+TEST_CASE(Unit_hipDrvGraphExecMemcpyNodeSetParams_Negative) {
   size_t size = 10;
   size_t numW = size * sizeof(int);
   // Host Vectors
@@ -120,7 +120,7 @@ TEST_CASE("Unit_hipDrvGraphExecMemcpyNodeSetParams_Negative") {
  *  - HIP_VERSION >= 6.4
  */
 
-TEST_CASE("Unit_hipDrvGraphExecMemcpyNodeSetParams_Positive") {
+TEST_CASE(Unit_hipDrvGraphExecMemcpyNodeSetParams_Positive) {
   size_t size = 10;
   size_t numW = size * sizeof(int);
   // Host Vectors

--- a/projects/hip-tests/catch/unit/graph/hipDrvGraphExecMemsetNodeSetParams.cc
+++ b/projects/hip-tests/catch/unit/graph/hipDrvGraphExecMemsetNodeSetParams.cc
@@ -47,7 +47,7 @@ const int value = 120;
  * ------------------------
  * - catch/unit/memory/hipDrvGraphExecMemsetNodeSetParams.cc
  */
-TEST_CASE("Unit_hipDrvGraphExecMemsetNodeSetParams_BasicPositive") {
+TEST_CASE(Unit_hipDrvGraphExecMemsetNodeSetParams_BasicPositive) {
   CHECK_IMAGE_SUPPORT
 
   HIP_CHECK(hipInit(0));
@@ -156,7 +156,7 @@ TEST_CASE("Unit_hipDrvGraphExecMemsetNodeSetParams_BasicPositive") {
  * ------------------------
  * - catch/unit/memory/hipDrvGraphExecMemsetNodeSetParams.cc
  */
-TEST_CASE("Unit_hipDrvGraphExecMemsetNodeSetParams_Negative") {
+TEST_CASE(Unit_hipDrvGraphExecMemsetNodeSetParams_Negative) {
   CHECK_IMAGE_SUPPORT
 
   HIP_CHECK(hipInit(0));

--- a/projects/hip-tests/catch/unit/graph/hipDrvGraphMemcpyNodeGetParams.cc
+++ b/projects/hip-tests/catch/unit/graph/hipDrvGraphMemcpyNodeGetParams.cc
@@ -50,7 +50,7 @@ THE SOFTWARE.
  * ------------------------
  *    - HIP_VERSION >= 6.0
  */
-TEST_CASE("Unit_hipDrvGraphMemcpyNodeGetParams_Negative_Parameters") {
+TEST_CASE(Unit_hipDrvGraphMemcpyNodeGetParams_Negative_Parameters) {
   HIP_CHECK(hipInit(0));
   hipDevice_t device;
   hipCtx_t context;
@@ -105,7 +105,7 @@ TEST_CASE("Unit_hipDrvGraphMemcpyNodeGetParams_Negative_Parameters") {
  *    - HIP_VERSION >= 6.4
  */
 
-TEST_CASE("Unit_hipDrvGraphMemcpyNodeGetParams_Positive") {
+TEST_CASE(Unit_hipDrvGraphMemcpyNodeGetParams_Positive) {
   size_t size = 10;
   size_t numW = size * sizeof(int);
   // Host Vectors

--- a/projects/hip-tests/catch/unit/graph/hipDrvGraphMemcpyNodeSetParams.cc
+++ b/projects/hip-tests/catch/unit/graph/hipDrvGraphMemcpyNodeSetParams.cc
@@ -49,7 +49,7 @@ THE SOFTWARE.
  * ------------------------
  *    - HIP_VERSION >= 6.0
  */
-TEST_CASE("Unit_hipDrvGraphMemcpyNodeSetParams_Positive_Basic") {
+TEST_CASE(Unit_hipDrvGraphMemcpyNodeSetParams_Positive_Basic) {
   using namespace std::placeholders;
 
   constexpr bool async = false;
@@ -94,7 +94,7 @@ TEST_CASE("Unit_hipDrvGraphMemcpyNodeSetParams_Positive_Basic") {
   HIP_CHECK(hipCtxDestroy(context));
 }
 
-TEST_CASE("Unit_hipDrvGraphMemcpyNodeSetParams_Positive_Array") {
+TEST_CASE(Unit_hipDrvGraphMemcpyNodeSetParams_Positive_Array) {
   CHECK_IMAGE_SUPPORT
 
   using namespace std::placeholders;
@@ -144,7 +144,7 @@ TEST_CASE("Unit_hipDrvGraphMemcpyNodeSetParams_Positive_Array") {
  * ------------------------
  *    - HIP_VERSION >= 6.0
  */
-TEST_CASE("Unit_hipDrvGraphMemcpyNodeSetParams_Negative_Parameters") {
+TEST_CASE(Unit_hipDrvGraphMemcpyNodeSetParams_Negative_Parameters) {
   using namespace std::placeholders;
 
   HIP_CHECK(hipInit(0));

--- a/projects/hip-tests/catch/unit/graph/hipGetProcAddressGraphApis.cc
+++ b/projects/hip-tests/catch/unit/graph/hipGetProcAddressGraphApis.cc
@@ -37,7 +37,7 @@ THE SOFTWARE.
  * ------------------------
  *  - HIP_VERSION >= 6.2
  */
-TEST_CASE("Unit_hipGetProcAddress_GraphAPIs_StreamCapture") {
+TEST_CASE(Unit_hipGetProcAddress_GraphAPIs_StreamCapture) {
   void* hipStreamBeginCapture_ptr = nullptr;
   void* hipStreamIsCapturing_ptr = nullptr;
   void* hipStreamEndCapture_ptr = nullptr;
@@ -161,7 +161,7 @@ TEST_CASE("Unit_hipGetProcAddress_GraphAPIs_StreamCapture") {
  * ------------------------
  *  - HIP_VERSION >= 6.2
  */
-TEST_CASE("Unit_hipGetProcAddress_GraphAPIs_AddMemcpy1DKernelNodes") {
+TEST_CASE(Unit_hipGetProcAddress_GraphAPIs_AddMemcpy1DKernelNodes) {
   void* hipGraphAddMemcpyNode1D_ptr = nullptr;
   void* hipGraphAddKernelNode_ptr = nullptr;
 
@@ -257,7 +257,7 @@ TEST_CASE("Unit_hipGetProcAddress_GraphAPIs_AddMemcpy1DKernelNodes") {
  * ------------------------
  *  - HIP_VERSION >= 6.2
  */
-TEST_CASE("Unit_hipGetProcAddress_GraphAPIs_AddMemsetMemcpyNodes") {
+TEST_CASE(Unit_hipGetProcAddress_GraphAPIs_AddMemsetMemcpyNodes) {
   CHECK_IMAGE_SUPPORT
 
   void* hipGraphAddMemsetNode_ptr = nullptr;
@@ -353,7 +353,7 @@ TEST_CASE("Unit_hipGetProcAddress_GraphAPIs_AddMemsetMemcpyNodes") {
  * ------------------------
  *  - HIP_VERSION >= 6.2
  */
-TEST_CASE("Unit_hipGetProcAddress_GraphAPIs_SetGetParamsMemsetMemcpy") {
+TEST_CASE(Unit_hipGetProcAddress_GraphAPIs_SetGetParamsMemsetMemcpy) {
   CHECK_IMAGE_SUPPORT
 
   void* hipGraphMemsetNodeSetParams_ptr = nullptr;
@@ -561,7 +561,7 @@ TEST_CASE("Unit_hipGetProcAddress_GraphAPIs_SetGetParamsMemsetMemcpy") {
  * ------------------------
  *  - HIP_VERSION >= 6.2
  */
-TEST_CASE("Unit_hipGetProcAddress_GraphAPIs_KernelNodeSetGetParams") {
+TEST_CASE(Unit_hipGetProcAddress_GraphAPIs_KernelNodeSetGetParams) {
   void* hipGraphKernelNodeGetParams_ptr = nullptr;
   void* hipGraphKernelNodeSetParams_ptr = nullptr;
 
@@ -703,7 +703,7 @@ TEST_CASE("Unit_hipGetProcAddress_GraphAPIs_KernelNodeSetGetParams") {
  * ------------------------
  *  - HIP_VERSION >= 6.2
  */
-TEST_CASE("Unit_hipGetProcAddress_GraphAPIs_KernelNodeSetGetAttribute") {
+TEST_CASE(Unit_hipGetProcAddress_GraphAPIs_KernelNodeSetGetAttribute) {
   void* hipGraphKernelNodeSetAttribute_ptr = nullptr;
   void* hipGraphKernelNodeGetAttribute_ptr = nullptr;
 
@@ -777,7 +777,7 @@ TEST_CASE("Unit_hipGetProcAddress_GraphAPIs_KernelNodeSetGetAttribute") {
  * ------------------------
  *  - HIP_VERSION >= 6.2
  */
-TEST_CASE("Unit_hipGetProcAddress_GraphAPIs_HostNode") {
+TEST_CASE(Unit_hipGetProcAddress_GraphAPIs_HostNode) {
   void* hipGraphAddHostNode_ptr = nullptr;
   void* hipGraphHostNodeGetParams_ptr = nullptr;
   void* hipGraphHostNodeSetParams_ptr = nullptr;
@@ -927,7 +927,7 @@ TEST_CASE("Unit_hipGetProcAddress_GraphAPIs_HostNode") {
  * ------------------------
  *  - HIP_VERSION >= 6.2
  */
-TEST_CASE("Unit_hipGetProcAddress_GraphAPIs_ExecUpdate") {
+TEST_CASE(Unit_hipGetProcAddress_GraphAPIs_ExecUpdate) {
   void* hipGraphExecUpdate_ptr = nullptr;
 
   int currentHipVersion = 0;
@@ -1001,7 +1001,7 @@ TEST_CASE("Unit_hipGetProcAddress_GraphAPIs_ExecUpdate") {
  * ------------------------
  *  - HIP_VERSION >= 6.2
  */
-TEST_CASE("Unit_hipGetProcAddress_GraphAPIs_Memcpy1DSetParams") {
+TEST_CASE(Unit_hipGetProcAddress_GraphAPIs_Memcpy1DSetParams) {
   void* hipGraphMemcpyNodeSetParams1D_ptr = nullptr;
   void* hipGraphExecMemcpyNodeSetParams1D_ptr = nullptr;
 
@@ -1122,7 +1122,7 @@ TEST_CASE("Unit_hipGetProcAddress_GraphAPIs_Memcpy1DSetParams") {
  * ------------------------
  *  - HIP_VERSION >= 6.2
  */
-TEST_CASE("Unit_hipGetProcAddress_GraphAPIs_MemAllocAndFree") {
+TEST_CASE(Unit_hipGetProcAddress_GraphAPIs_MemAllocAndFree) {
   void* hipGraphAddMemAllocNode_ptr = nullptr;
   void* hipGraphAddMemFreeNode_ptr = nullptr;
   void* hipGraphMemAllocNodeGetParams_ptr = nullptr;
@@ -1270,7 +1270,7 @@ TEST_CASE("Unit_hipGetProcAddress_GraphAPIs_MemAllocAndFree") {
  * ------------------------
  *  - HIP_VERSION >= 6.2
  */
-TEST_CASE("Unit_hipGetProcAddress_GraphAPIs_ExecMemsetMemcpySetParams") {
+TEST_CASE(Unit_hipGetProcAddress_GraphAPIs_ExecMemsetMemcpySetParams) {
   CHECK_IMAGE_SUPPORT
 
   void* hipGraphExecMemsetNodeSetParams_ptr = nullptr;

--- a/projects/hip-tests/catch/unit/graph/hipGraph.cc
+++ b/projects/hip-tests/catch/unit/graph/hipGraph.cc
@@ -300,7 +300,7 @@ static void hipGraphsManual(float* inputVec_h, float* inputVec_d, double* output
  * Tests basic functionality of hipGraph APIs by
  * Execution Without HIPGraphs, Manual HIPGraph, HIPGraphs Using StreamCapture.
  */
-TEST_CASE("Unit_hipGraph_BasicFunctional") {
+TEST_CASE(Unit_hipGraph_BasicFunctional) {
   constexpr size_t size = 1 << 12;
   constexpr size_t maxBlocks = 512;
   float *inputVec_d{nullptr}, *inputVec_h{nullptr};

--- a/projects/hip-tests/catch/unit/graph/hipGraphAddBatchMemOpNode.cc
+++ b/projects/hip-tests/catch/unit/graph/hipGraphAddBatchMemOpNode.cc
@@ -39,7 +39,7 @@ THE SOFTWARE.
  * ------------------------
  *    - HIP_VERSION >= 6.4
  */
-TEST_CASE("Unit_hipGraphAddBatchMemOpNode_NegativeTsts") {
+TEST_CASE(Unit_hipGraphAddBatchMemOpNode_NegativeTsts) {
   HIP_CHECK(hipInit(0));
   hipGraph_t graph;
   hipCtx_t ctx;

--- a/projects/hip-tests/catch/unit/graph/hipGraphAddChildGraphNode.cc
+++ b/projects/hip-tests/catch/unit/graph/hipGraphAddChildGraphNode.cc
@@ -76,7 +76,7 @@ Negative:
 This testcase verifies the negative scenarios of
 hipGraphAddChildGraphNode API
 */
-TEST_CASE("Unit_hipGraphAddChildGraphNode_Negative") {
+TEST_CASE(Unit_hipGraphAddChildGraphNode_Negative) {
   constexpr size_t N = 1024;
   constexpr size_t Nbytes = N * sizeof(int);
   hipGraph_t graph, childgraph1;
@@ -120,7 +120,7 @@ This testcase verifies the following scenario
 Creates the graph, add the graph as a child node
 and verify the number of the nodes in the original graph
 */
-TEST_CASE("Unit_hipGraphAddChildGraphNode_OrgGraphAsChildGraph") {
+TEST_CASE(Unit_hipGraphAddChildGraphNode_OrgGraphAsChildGraph) {
   constexpr size_t N = 1024;
   constexpr size_t Nbytes = N * sizeof(int);
   hipGraph_t graph, childGraph;
@@ -163,7 +163,7 @@ This testcase verifies the following scenario
 Create graph, Add child nodes to the graph and execute only the
 child graph node and verify the behaviour
 */
-TEST_CASE("Unit_hipGraphAddChildGraphNode_ExecuteChildGraph") {
+TEST_CASE(Unit_hipGraphAddChildGraphNode_ExecuteChildGraph) {
   constexpr size_t N = 1024;
   constexpr size_t Nbytes = N * sizeof(int);
   hipGraph_t graph, childgraph1;
@@ -214,7 +214,7 @@ This testcase verifies the following scenario
 creates graph, Add child nodes to graph, clone the graph and execute
 the cloned graph
 */
-TEST_CASE("Unit_hipGraphAddChildGraphNode_CloneChildGraph") {
+TEST_CASE(Unit_hipGraphAddChildGraphNode_CloneChildGraph) {
   constexpr size_t N = 1024;
   constexpr size_t Nbytes = N * sizeof(int);
   hipGraph_t graph, childgraph1, clonedgraph;
@@ -266,7 +266,7 @@ This testcase verifies the following scenario
 Create graph, add multiple child nodes and validates the
 behaviour
 */
-TEST_CASE("Unit_hipGraphAddChildGraphNode_MultipleChildNodes") {
+TEST_CASE(Unit_hipGraphAddChildGraphNode_MultipleChildNodes) {
   constexpr size_t N = 1024;
   constexpr size_t Nbytes = N * sizeof(int);
   constexpr auto blocksPerCU = 6;  // to hide latency
@@ -329,7 +329,7 @@ TEST_CASE("Unit_hipGraphAddChildGraphNode_MultipleChildNodes") {
  This testcase verifies hipGraphAddChildGraphNode functionality
  where root node is the child node.
  */
-TEST_CASE("Unit_hipGraphAddChildGraphNode_SingleChildNode") {
+TEST_CASE(Unit_hipGraphAddChildGraphNode_SingleChildNode) {
   constexpr size_t N = 1024;
   constexpr size_t Nbytes = N * sizeof(int);
   constexpr auto blocksPerCU = 6;  // to hide latency
@@ -720,7 +720,7 @@ typedef class nestedGraph {
  Parent graph containing child graph, which in turn, contains another
  child graph.
  */
-TEST_CASE("Unit_hipGraphAddChildGraphNode_Cmplx_NestedGraphs") {
+TEST_CASE(Unit_hipGraphAddChildGraphNode_Cmplx_NestedGraphs) {
   hipGraph_t* graph;
   hipStream_t streamForGraph;
   hipGraphExec_t graphExec;
@@ -743,7 +743,7 @@ TEST_CASE("Unit_hipGraphAddChildGraphNode_Cmplx_NestedGraphs") {
  Complex Scenario: This testcase verifies cloned nested graph functionality.
  Clone the nested graph and execute the clone graph.
  */
-TEST_CASE("Unit_hipGraphAddChildGraphNode_CmplxClone_NestedGraphs") {
+TEST_CASE(Unit_hipGraphAddChildGraphNode_CmplxClone_NestedGraphs) {
   hipGraph_t *graph, clonedGraph;
   hipStream_t streamForGraph;
   hipGraphExec_t graphExec;
@@ -767,7 +767,7 @@ TEST_CASE("Unit_hipGraphAddChildGraphNode_CmplxClone_NestedGraphs") {
 /**
  Scenario: Adding an empty graph to Child Graph Node.
  */
-TEST_CASE("Unit_hipGraphAddChildGraphNode_EmptyGraphAsChildNode") {
+TEST_CASE(Unit_hipGraphAddChildGraphNode_EmptyGraphAsChildNode) {
   hipGraph_t graph, graphChild;
   hipGraphNode_t child_node;
   HIP_CHECK(hipGraphCreate(&graph, 0));
@@ -782,7 +782,7 @@ TEST_CASE("Unit_hipGraphAddChildGraphNode_EmptyGraphAsChildNode") {
  when one of the child graph node is updated. In this test the kernel node
  function is updated to a different function.
  */
-TEST_CASE("Unit_hipGraphAddChildGraphNode_CmplxNstGrph_UpdKerFun") {
+TEST_CASE(Unit_hipGraphAddChildGraphNode_CmplxNstGrph_UpdKerFun) {
   hipGraph_t* graph;
   hipStream_t streamForGraph;
   hipGraphExec_t graphExec;
@@ -806,7 +806,7 @@ TEST_CASE("Unit_hipGraphAddChildGraphNode_CmplxNstGrph_UpdKerFun") {
  function is updated to a different function and the nested graph is cloned.
  Execute the cloned graph and validate the results.
  */
-TEST_CASE("Unit_hipGraphAddChildGraphNode_CmplxNstGrph_UpdKerFun_Clone") {
+TEST_CASE(Unit_hipGraphAddChildGraphNode_CmplxNstGrph_UpdKerFun_Clone) {
   hipGraph_t *graph, clonedGraph;
   hipStream_t streamForGraph;
   hipGraphExec_t graphExec;
@@ -831,7 +831,7 @@ TEST_CASE("Unit_hipGraphAddChildGraphNode_CmplxNstGrph_UpdKerFun_Clone") {
  when one of the child graph node is updated. In this test the kernel node
  parameters - blocksize and gridsize are updated.
  */
-TEST_CASE("Unit_hipGraphAddChildGraphNode_CmplxNstGrph_UpdKerDim") {
+TEST_CASE(Unit_hipGraphAddChildGraphNode_CmplxNstGrph_UpdKerDim) {
   hipGraph_t* graph;
   hipStream_t streamForGraph;
   hipGraphExec_t graphExec;
@@ -854,7 +854,7 @@ TEST_CASE("Unit_hipGraphAddChildGraphNode_CmplxNstGrph_UpdKerDim") {
  when one of the nodes inside a child graph node is deleted and replaced with
  a new node.
  */
-TEST_CASE("Unit_hipGraphAddChildGraphNode_CmplxNstGrph_DelAddNode") {
+TEST_CASE(Unit_hipGraphAddChildGraphNode_CmplxNstGrph_DelAddNode) {
   hipGraph_t* graph;
   hipStream_t streamForGraph;
   hipGraphExec_t graphExec;
@@ -878,7 +878,7 @@ TEST_CASE("Unit_hipGraphAddChildGraphNode_CmplxNstGrph_DelAddNode") {
  replaced with a new node. After modifying the original graph it is cloned
  and the cloned graph is executed and validated.
  */
-TEST_CASE("Unit_hipGraphAddChildGraphNode_CmplxNstGrph_AddNode_Clone") {
+TEST_CASE(Unit_hipGraphAddChildGraphNode_CmplxNstGrph_AddNode_Clone) {
   hipGraph_t *graph, clonedGraph;
   hipStream_t streamForGraph;
   hipGraphExec_t graphExec;
@@ -903,7 +903,7 @@ TEST_CASE("Unit_hipGraphAddChildGraphNode_CmplxNstGrph_AddNode_Clone") {
  when one of the nodes inside a child graph node is deleted and replaced with
  a new child graph node.
  */
-TEST_CASE("Unit_hipGraphAddChildGraphNode_CmplxNstGrph_AddChdNode") {
+TEST_CASE(Unit_hipGraphAddChildGraphNode_CmplxNstGrph_AddChdNode) {
   hipGraph_t* graph;
   hipStream_t streamForGraph;
   hipGraphExec_t graphExec;
@@ -926,7 +926,7 @@ TEST_CASE("Unit_hipGraphAddChildGraphNode_CmplxNstGrph_AddChdNode") {
  when one of the nodes inside a child graph node is deleted and replaced with
  a new child graph node.
  */
-TEST_CASE("Unit_hipGraphAddChildGraphNode_CmplxNstGrph_AddChdNode_Clone") {
+TEST_CASE(Unit_hipGraphAddChildGraphNode_CmplxNstGrph_AddChdNode_Clone) {
   hipGraph_t *graph, clonedGraph;
   hipStream_t streamForGraph;
   hipGraphExec_t graphExec;
@@ -962,7 +962,7 @@ static void validateResults(int* A1_h, int* A2_h, size_t N) {
  memcpy d2h nodes. Graph1, graph2 and graph3 are added as child nodes in
  graph4. Graph4 is validated for functionality.
  */
-TEST_CASE("Unit_hipGraphAddChildGraphNode_MultGraphsAsSingleGraph") {
+TEST_CASE(Unit_hipGraphAddChildGraphNode_MultGraphsAsSingleGraph) {
   size_t size = 1024;
   constexpr auto blocksPerCU = 6;
   constexpr auto threadsPerBlock = 256;
@@ -1084,7 +1084,7 @@ TEST_CASE("Unit_hipGraphAddChildGraphNode_MultGraphsAsSingleGraph") {
  in multi GPU environment. Create one nested graph per GPU context. Execute
  all the created graphs in their respective GPUs and validate the output.
  */
-TEST_CASE("Unit_hipGraphAddChildGraphNode_CmplxNstGrph_MultGPU", "[multigpu]") {
+TEST_CASE(Unit_hipGraphAddChildGraphNode_CmplxNstGrph_MultGPU) {
   int devcount = 0;
   HIP_CHECK(hipGetDeviceCount(&devcount));
   // If only single GPU is detected then return

--- a/projects/hip-tests/catch/unit/graph/hipGraphAddDependencies.cc
+++ b/projects/hip-tests/catch/unit/graph/hipGraphAddDependencies.cc
@@ -45,7 +45,7 @@ THE SOFTWARE.
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_hipGraphAddDependencies_Positive_Functional") {
+TEST_CASE(Unit_hipGraphAddDependencies_Positive_Functional) {
   constexpr size_t N = 1024;
   hipGraph_t graph;
   hipStream_t streamForGraph;
@@ -110,7 +110,7 @@ TEST_CASE("Unit_hipGraphAddDependencies_Positive_Functional") {
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_hipGraphAddDependencies_Positive_Parameters") {
+TEST_CASE(Unit_hipGraphAddDependencies_Positive_Parameters) {
   constexpr size_t Nbytes = 1024;
   hipGraphNode_t memcpyH2D_A;
   hipGraphNode_t memcpyD2H_A;
@@ -191,7 +191,7 @@ TEST_CASE("Unit_hipGraphAddDependencies_Positive_Parameters") {
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_hipGraphAddDependencies_Negative_Parameters") {
+TEST_CASE(Unit_hipGraphAddDependencies_Negative_Parameters) {
   // Initialize
   constexpr size_t Nbytes = 1024;
   hipGraph_t graph;

--- a/projects/hip-tests/catch/unit/graph/hipGraphAddEmptyNode.cc
+++ b/projects/hip-tests/catch/unit/graph/hipGraphAddEmptyNode.cc
@@ -36,7 +36,7 @@ Testcase Scenarios :
 /**
  * Functional Test to add empty node with dependencies
  */
-TEST_CASE("Unit_hipGraphAddEmptyNode_Functional") {
+TEST_CASE(Unit_hipGraphAddEmptyNode_Functional) {
   char* pOutBuff_d{};
   constexpr size_t size = 1024;
   hipGraph_t graph{};
@@ -66,7 +66,7 @@ TEST_CASE("Unit_hipGraphAddEmptyNode_Functional") {
 /**
  * Negative Scenarios hipGraphAddEmptyNode
  */
-TEST_CASE("Unit_hipGraphAddEmptyNode_NegTest") {
+TEST_CASE(Unit_hipGraphAddEmptyNode_NegTest) {
   char* pOutBuff_d{};
   constexpr size_t size = 1024;
   hipGraph_t graph;
@@ -124,7 +124,7 @@ static void validateOutData(int* A1_h, int* A2_h, size_t N) {
 /**
  * Functional Test to use empty node as barrier to wait for multiple nodes.
  */
-TEST_CASE("Unit_hipGraphAddEmptyNode_BarrierFunc") {
+TEST_CASE(Unit_hipGraphAddEmptyNode_BarrierFunc) {
   size_t size = 1024;
   constexpr auto blocksPerCU = 6;
   constexpr auto threadsPerBlock = 256;

--- a/projects/hip-tests/catch/unit/graph/hipGraphAddEventRecordNode.cc
+++ b/projects/hip-tests/catch/unit/graph/hipGraphAddEventRecordNode.cc
@@ -64,7 +64,7 @@ Verify that hipEventElapsedTime() returns error.
  * Scenario 1: Create s simple graph with just one event record
  * node and instantiate and launch the graph.
  */
-TEST_CASE("Unit_hipGraphAddEventRecordNode_Functional_Simple") {
+TEST_CASE(Unit_hipGraphAddEventRecordNode_Functional_Simple) {
   hipGraph_t graph;
   hipStream_t streamForGraph;
   hipGraphExec_t graphExec;
@@ -200,7 +200,7 @@ static void validateAddEventRecordNode(bool measureTime, bool withFlags, int nst
 /**
  * Scenario 2: Validate event record nodes created without flags.
  */
-TEST_CASE("Unit_hipGraphAddEventRecordNode_Functional_WithoutFlags") {
+TEST_CASE(Unit_hipGraphAddEventRecordNode_Functional_WithoutFlags) {
   // Create events without flags using hipEventCreate and
   // elapsed time is not validated
   validateAddEventRecordNode(false, false, 1);
@@ -209,7 +209,7 @@ TEST_CASE("Unit_hipGraphAddEventRecordNode_Functional_WithoutFlags") {
 /**
  * Scenario 3: Validate elapsed time between 2 recorded events.
  */
-TEST_CASE("Unit_hipGraphAddEventRecordNode_Functional_ElapsedTime") {
+TEST_CASE(Unit_hipGraphAddEventRecordNode_Functional_ElapsedTime) {
   // Create events without flags using hipEventCreate and
   // elapsed time is validated
   validateAddEventRecordNode(true, false, 1);
@@ -219,7 +219,7 @@ TEST_CASE("Unit_hipGraphAddEventRecordNode_Functional_ElapsedTime") {
  * Scenario 4: Validate event record nodes created with different
  * event flags.
  */
-TEST_CASE("Unit_hipGraphAddEventRecordNode_Functional_WithFlags") {
+TEST_CASE(Unit_hipGraphAddEventRecordNode_Functional_WithFlags) {
   // Create events with different flags using hipEventCreate and
   // elapsed time is not validated
   SECTION("Flag = hipEventDefault") { validateAddEventRecordNode(false, true, 1, hipEventDefault); }
@@ -237,14 +237,14 @@ TEST_CASE("Unit_hipGraphAddEventRecordNode_Functional_WithFlags") {
  * Scenario 5: Validate hipGraphAddEventRecordNode by executing graph
  * 100 times in a loop.
  */
-TEST_CASE("Unit_hipGraphAddEventRecordNode_MultipleRun") {
+TEST_CASE(Unit_hipGraphAddEventRecordNode_MultipleRun) {
   validateAddEventRecordNode(false, false, 100);
 }
 
 /**
  * Scenario 6: Validate hipGraphAddEventRecordNode with time disabled events.
  */
-TEST_CASE("Unit_hipGraphAddEventRecordNode_Functional_TimingDisabled") {
+TEST_CASE(Unit_hipGraphAddEventRecordNode_Functional_TimingDisabled) {
   constexpr size_t Nbytes = 1024;
   hipGraph_t graph;
   hipStream_t streamForGraph;
@@ -297,7 +297,7 @@ TEST_CASE("Unit_hipGraphAddEventRecordNode_Functional_TimingDisabled") {
 /**
  * Scenario 7: Positive parameter tests
  */
-TEST_CASE("Unit_hipGraphAddEventRecordNode_Positive_Parameters") {
+TEST_CASE(Unit_hipGraphAddEventRecordNode_Positive_Parameters) {
   hipGraph_t graph;
   HIP_CHECK(hipGraphCreate(&graph, 0));
   hipEvent_t event;
@@ -336,7 +336,7 @@ TEST_CASE("Unit_hipGraphAddEventRecordNode_Positive_Parameters") {
 /**
  * Scenario 8: All negative tests
  */
-TEST_CASE("Unit_hipGraphAddEventRecordNode_Negative") {
+TEST_CASE(Unit_hipGraphAddEventRecordNode_Negative) {
   using namespace std::placeholders;
   hipGraph_t graph;
   HIP_CHECK(hipGraphCreate(&graph, 0));

--- a/projects/hip-tests/catch/unit/graph/hipGraphAddEventWaitNode.cc
+++ b/projects/hip-tests/catch/unit/graph/hipGraphAddEventWaitNode.cc
@@ -55,7 +55,7 @@ both graphs.
 /**
  * Scenario 1
  */
-TEST_CASE("Unit_hipGraphAddEventWaitNode_Functional_Simple") {
+TEST_CASE(Unit_hipGraphAddEventWaitNode_Functional_Simple) {
   hipGraph_t graph;
   hipStream_t streamForGraph;
   hipGraphExec_t graphExec;
@@ -216,28 +216,28 @@ static void validate_hipGraphAddEventWaitNode_internodedep(int test, int nstep,
 /**
  * Scenario 2
  */
-TEST_CASE("Unit_hipGraphAddEventWaitNode_MultGraphMultStrmDependency") {
+TEST_CASE(Unit_hipGraphAddEventWaitNode_MultGraphMultStrmDependency) {
   validate_hipGraphAddEventWaitNode_internodedep(0, 1);
 }
 
 /**
  * Scenario 3
  */
-TEST_CASE("Unit_hipGraphAddEventWaitNode_MultipleRun") {
+TEST_CASE(Unit_hipGraphAddEventWaitNode_MultipleRun) {
   validate_hipGraphAddEventWaitNode_internodedep(0, 100);
 }
 
 /**
  * Scenario 4
  */
-TEST_CASE("Unit_hipGraphAddEventWaitNode_MultGraphOneStrmDependency") {
+TEST_CASE(Unit_hipGraphAddEventWaitNode_MultGraphOneStrmDependency) {
   validate_hipGraphAddEventWaitNode_internodedep(1, 1);
 }
 
 /**
  * Scenario 5
  */
-TEST_CASE("Unit_hipGraphAddEventWaitNode_differentFlags") {
+TEST_CASE(Unit_hipGraphAddEventWaitNode_differentFlags) {
   SECTION("flag = hipEventBlockingSync") {
     validate_hipGraphAddEventWaitNode_internodedep(0, 1, hipEventBlockingSync);
   }
@@ -249,7 +249,7 @@ TEST_CASE("Unit_hipGraphAddEventWaitNode_differentFlags") {
 /**
  * Scenario 6: Positive parameter tests
  */
-TEST_CASE("Unit_hipGraphAddEventWaitNode_Positive_Parameters") {
+TEST_CASE(Unit_hipGraphAddEventWaitNode_Positive_Parameters) {
   hipGraph_t graph;
   HIP_CHECK(hipGraphCreate(&graph, 0));
   hipEvent_t event;
@@ -288,7 +288,7 @@ TEST_CASE("Unit_hipGraphAddEventWaitNode_Positive_Parameters") {
 /**
  * Scenario 7
  */
-TEST_CASE("Unit_hipGraphAddEventWaitNode_Negative") {
+TEST_CASE(Unit_hipGraphAddEventWaitNode_Negative) {
   using namespace std::placeholders;
   hipGraph_t graph;
   HIP_CHECK(hipGraphCreate(&graph, 0));

--- a/projects/hip-tests/catch/unit/graph/hipGraphAddHostNode.cc
+++ b/projects/hip-tests/catch/unit/graph/hipGraphAddHostNode.cc
@@ -77,7 +77,7 @@ static void vectorsquare_callback(void* ptr) {
 This test case verifies the negative scenarios of
 hipGraphAddHostNode API
 */
-TEST_CASE("Unit_hipGraphAddHostNode_Negative") {
+TEST_CASE(Unit_hipGraphAddHostNode_Negative) {
   constexpr size_t N = 1024;
   hipGraph_t graph;
   int *A_d{nullptr}, *C_d{nullptr};
@@ -127,7 +127,7 @@ This test case verifies hipGraphAddHostNode API in cloned graph
 Creates graph, Add graph nodes and clone the graph
 Add HostNode to the cloned graph and validate the result
 */
-TEST_CASE("Unit_hipGraphAddHostNode_ClonedGraphWithHostNode") {
+TEST_CASE(Unit_hipGraphAddHostNode_ClonedGraphWithHostNode) {
   constexpr size_t N = 1024;
   constexpr size_t Nbytes = N * sizeof(int);
   hipGraph_t graph;
@@ -190,7 +190,7 @@ This test case verifies the square of number by
 creating graph, Add kernel node which does the square
 of number and the result is validated by hipGraphAddHostNode API
 */
-TEST_CASE("Unit_hipGraphAddHostNode_VectorSquare") {
+TEST_CASE(Unit_hipGraphAddHostNode_VectorSquare) {
   constexpr size_t N = 1024;
   constexpr size_t Nbytes = N * sizeof(int);
   hipGraph_t graph;
@@ -248,7 +248,7 @@ Create graph, calls the host function and updates
 the parameters in the callback function and
 validates it.
 */
-TEST_CASE("Unit_hipGraphAddHostNode_BasicFunc") {
+TEST_CASE(Unit_hipGraphAddHostNode_BasicFunc) {
   constexpr size_t N = 1024;
   constexpr size_t Nbytes = N * sizeof(int);
   hipGraph_t graph;

--- a/projects/hip-tests/catch/unit/graph/hipGraphAddKernelNode.cc
+++ b/projects/hip-tests/catch/unit/graph/hipGraphAddKernelNode.cc
@@ -57,7 +57,7 @@ THE SOFTWARE.
 constexpr size_t size = 1 << 12;
 enum fnType { normal, object };
 
-TEST_CASE("Unit_hipGraphAddKernelNode_Negative") {
+TEST_CASE(Unit_hipGraphAddKernelNode_Negative) {
   constexpr int N = 1024;
   size_t NElem{N};
   constexpr auto blocksPerCU = 6;  // to hide latency
@@ -225,7 +225,7 @@ static void kernelFnChange(int* A_d, int* A_h, int* B_d, int* B_h, int* C_d, int
  * ------------------------
  * - HIP_VERSION >= 5.6
  */
-TEST_CASE("Unit_hipGraphAddKernelNode_moduleLoadKernelFn_graphNclonedGraph") {
+TEST_CASE(Unit_hipGraphAddKernelNode_moduleLoadKernelFn_graphNclonedGraph) {
   int *A_d, *B_d, *C_d;
   int *A_h, *B_h, *C_h;
   HipTest::initArrays<int>(&A_d, &B_d, &C_d, &A_h, &B_h, &C_h, size, false);
@@ -296,7 +296,7 @@ TEST_CASE("Unit_hipGraphAddKernelNode_moduleLoadKernelFn_graphNclonedGraph") {
  * ------------------------
  * - HIP_VERSION >= 5.6
  */
-TEST_CASE("Unit_hipGraphAddKernelNode_moduleLoadKernelFn_kernelFnUpdate") {
+TEST_CASE(Unit_hipGraphAddKernelNode_moduleLoadKernelFn_kernelFnUpdate) {
   size_t maxBlocks = 512;
   int *A_d, *B_d, *C_d;  // Device pointers
   int *A_h, *B_h, *C_h;  // Host Pointers
@@ -324,7 +324,7 @@ TEST_CASE("Unit_hipGraphAddKernelNode_moduleLoadKernelFn_kernelFnUpdate") {
  * ------------------------
  * - HIP_VERSION >= 5.6
  */
-TEST_CASE("Unit_hipGraphAddKernelNode_moduleLoadKernelFn_childGraph") {
+TEST_CASE(Unit_hipGraphAddKernelNode_moduleLoadKernelFn_childGraph) {
   int *A_d, *B_d, *C_d;  // Device pointers
   int *A_h, *B_h, *C_h;  // Host Pointers
   HipTest::initArrays<int>(&A_d, &B_d, &C_d, &A_h, &B_h, &C_h, size, false);
@@ -401,7 +401,7 @@ TEST_CASE("Unit_hipGraphAddKernelNode_moduleLoadKernelFn_childGraph") {
  * ------------------------
  * - HIP_VERSION >= 5.6
  */
-TEST_CASE("Unit_hipGraphAddKernelNode_moduleLoadKernelFn_streamCapture") {
+TEST_CASE(Unit_hipGraphAddKernelNode_moduleLoadKernelFn_streamCapture) {
   size_t maxBlocks = 512;
   size_t Nbytes = sizeof(int) * maxBlocks;
 

--- a/projects/hip-tests/catch/unit/graph/hipGraphAddMemAllocNode.cc
+++ b/projects/hip-tests/catch/unit/graph/hipGraphAddMemAllocNode.cc
@@ -68,7 +68,7 @@ __global__ void validateGPU(int* const vec, const int value, size_t N, unsigned 
  * ------------------------
  *  - HIP_VERSION >= 6.0
  */
-TEST_CASE("Unit_hipGraphAddMemAllocNode_Negative_Params") {
+TEST_CASE(Unit_hipGraphAddMemAllocNode_Negative_Params) {
   constexpr size_t N = 1024;
   hipGraph_t graph;
   hipGraphNode_t alloc_node;
@@ -169,7 +169,7 @@ TEST_CASE("Unit_hipGraphAddMemAllocNode_Negative_Params") {
  * ------------------------
  *  - HIP_VERSION >= 6.0
  */
-TEST_CASE("Unit_hipGraphAddMemAllocNode_Negative_NotSupported") {
+TEST_CASE(Unit_hipGraphAddMemAllocNode_Negative_NotSupported) {
   constexpr size_t N = 1024;
   hipGraph_t graph;
   hipGraphNode_t alloc_node;
@@ -292,7 +292,7 @@ static void createFreeGraph(hipGraphExec_t* graph_exec, int* device_alloc) {
  * ------------------------
  *  - HIP_VERSION >= 6.0
  */
-TEST_CASE("Unit_hipGraphAddMemAllocNode_Positive_FreeInGraph") {
+TEST_CASE(Unit_hipGraphAddMemAllocNode_Positive_FreeInGraph) {
   hipGraphExec_t graph_exec;
 
   LinearAllocGuard<int> host_alloc =
@@ -324,7 +324,7 @@ TEST_CASE("Unit_hipGraphAddMemAllocNode_Positive_FreeInGraph") {
  * ------------------------
  *  - HIP_VERSION >= 6.0
  */
-TEST_CASE("Unit_hipGraphAddMemAllocNode_Positive_FreeOutsideStream") {
+TEST_CASE(Unit_hipGraphAddMemAllocNode_Positive_FreeOutsideStream) {
   hipGraphExec_t graph_exec;
 
   LinearAllocGuard<int> host_alloc(LinearAllocs::malloc, element_count * sizeof(int));
@@ -370,7 +370,7 @@ TEST_CASE("Unit_hipGraphAddMemAllocNode_Positive_FreeOutsideStream") {
  * ------------------------
  *  - HIP_VERSION >= 6.0
  */
-TEST_CASE("Unit_hipGraphAddMemAllocNode_Positive_FreeOutsideGraph") {
+TEST_CASE(Unit_hipGraphAddMemAllocNode_Positive_FreeOutsideGraph) {
   hipGraphExec_t graph_exec;
 
   LinearAllocGuard<int> host_alloc(LinearAllocs::malloc, element_count * sizeof(int));
@@ -416,7 +416,7 @@ TEST_CASE("Unit_hipGraphAddMemAllocNode_Positive_FreeOutsideGraph") {
  * ------------------------
  *  - HIP_VERSION >= 6.0
  */
-TEST_CASE("Unit_hipGraphAddMemAllocNode_Positive_FreeSeparateGraph") {
+TEST_CASE(Unit_hipGraphAddMemAllocNode_Positive_FreeSeparateGraph) {
   hipGraphExec_t graph_exec1, graph_exec2;
 
   LinearAllocGuard<int> host_alloc(LinearAllocs::malloc, element_count * sizeof(int));
@@ -466,7 +466,7 @@ TEST_CASE("Unit_hipGraphAddMemAllocNode_Positive_FreeSeparateGraph") {
  *  - HIP_VERSION >= 6.1
  */
 
-TEST_CASE("Unit_hipGraphAddMemAllocNode_Functional_1") {
+TEST_CASE(Unit_hipGraphAddMemAllocNode_Functional_1) {
   int mem_pool_support = 0;
   HIP_CHECK(hipDeviceGetAttribute(&mem_pool_support, hipDeviceAttributeMemoryPoolsSupported, 0));
   if (!mem_pool_support) {
@@ -576,7 +576,7 @@ TEST_CASE("Unit_hipGraphAddMemAllocNode_Functional_1") {
 * ------------------------
 *  - HIP_VERSION >= 6.1
 */
-TEST_CASE("Unit_hipGraphAddMemAllocNode_Functional_2", "[multigpu]") {
+TEST_CASE(Unit_hipGraphAddMemAllocNode_Functional_2) {
   int mem_pool_support = 0;
   HIP_CHECK(hipDeviceGetAttribute(&mem_pool_support, hipDeviceAttributeMemoryPoolsSupported, 0));
   if (!mem_pool_support) {
@@ -645,7 +645,7 @@ TEST_CASE("Unit_hipGraphAddMemAllocNode_Functional_2", "[multigpu]") {
  * ------------------------
  * - HIP_VERSION >= 6.1
  */
-TEST_CASE("Unit_hipGraphAddMemAllocNode_Functional_3", "[multigpu]") {
+TEST_CASE(Unit_hipGraphAddMemAllocNode_Functional_3) {
   int mem_pool_support = 0;
   HIP_CHECK(hipDeviceGetAttribute(&mem_pool_support, hipDeviceAttributeMemoryPoolsSupported, 0));
   if (!mem_pool_support) {
@@ -719,7 +719,7 @@ TEST_CASE("Unit_hipGraphAddMemAllocNode_Functional_3", "[multigpu]") {
  * ------------------------
  * - HIP_VERSION >= 6.1
  */
-TEST_CASE("Unit_hipGraphAddMemAllocNode_Functional_4", "[multigpu]") {
+TEST_CASE(Unit_hipGraphAddMemAllocNode_Functional_4) {
   int mem_pool_support = 0;
   HIP_CHECK(hipDeviceGetAttribute(&mem_pool_support, hipDeviceAttributeMemoryPoolsSupported, 0));
   if (!mem_pool_support) {
@@ -808,7 +808,7 @@ TEST_CASE("Unit_hipGraphAddMemAllocNode_Functional_4", "[multigpu]") {
 * ------------------------
 *  - HIP_VERSION >= 6.1
 */
-TEST_CASE("Unit_hipGraphAddMemAllocNode_Argument_Check") {
+TEST_CASE(Unit_hipGraphAddMemAllocNode_Argument_Check) {
   int mem_pool_support = 0;
   HIP_CHECK(hipDeviceGetAttribute(&mem_pool_support, hipDeviceAttributeMemoryPoolsSupported, 0));
   if (!mem_pool_support) {
@@ -1028,7 +1028,7 @@ TEST_CASE("Unit_hipGraphAddMemAllocNode_Argument_Check") {
  * ------------------------
  * - HIP_VERSION >= 6.1
  */
-TEST_CASE("Unit_hipGraphAddMemAllocNode_Negative_Instanciate_Graph_Again") {
+TEST_CASE(Unit_hipGraphAddMemAllocNode_Negative_Instanciate_Graph_Again) {
   int mem_pool_support = 0;
   HIP_CHECK(hipDeviceGetAttribute(&mem_pool_support, hipDeviceAttributeMemoryPoolsSupported, 0));
   if (!mem_pool_support) {
@@ -1090,7 +1090,7 @@ TEST_CASE("Unit_hipGraphAddMemAllocNode_Negative_Instanciate_Graph_Again") {
 * ------------------------
 * - HIP_VERSION >= 6.1
 */
-TEST_CASE("Unit_hipGraphAddMemAllocNode_Negative_Free_Alloc_Memory_Again") {
+TEST_CASE(Unit_hipGraphAddMemAllocNode_Negative_Free_Alloc_Memory_Again) {
   int mem_pool_support = 0;
   HIP_CHECK(hipDeviceGetAttribute(&mem_pool_support, hipDeviceAttributeMemoryPoolsSupported, 0));
   if (!mem_pool_support) {
@@ -1155,7 +1155,7 @@ TEST_CASE("Unit_hipGraphAddMemAllocNode_Negative_Free_Alloc_Memory_Again") {
 * ------------------------
 * - HIP_VERSION >= 6.1
 */
-TEST_CASE("Unit_hipGraphAddMemAllocNode_Negative_With_Cloneed_Graph") {
+TEST_CASE(Unit_hipGraphAddMemAllocNode_Negative_With_Cloneed_Graph) {
   int mem_pool_support = 0;
   HIP_CHECK(hipDeviceGetAttribute(&mem_pool_support, hipDeviceAttributeMemoryPoolsSupported, 0));
   if (!mem_pool_support) {

--- a/projects/hip-tests/catch/unit/graph/hipGraphAddMemFreeNode.cc
+++ b/projects/hip-tests/catch/unit/graph/hipGraphAddMemFreeNode.cc
@@ -50,7 +50,7 @@ THE SOFTWARE.
  * ------------------------
  *  - HIP_VERSION >= 6.0
  */
-TEST_CASE("Unit_hipGraphAddMemFreeNode_Negative_Params") {
+TEST_CASE(Unit_hipGraphAddMemFreeNode_Negative_Params) {
   constexpr size_t N = 1024;
   hipGraph_t graph;
   hipGraphNode_t alloc_node, free_node;
@@ -128,7 +128,7 @@ TEST_CASE("Unit_hipGraphAddMemFreeNode_Negative_Params") {
  * ------------------------
  *  - HIP_VERSION >= 6.0
  */
-TEST_CASE("Unit_hipGraphAddMemFreeNode_Negative_NotSupported") {
+TEST_CASE(Unit_hipGraphAddMemFreeNode_Negative_NotSupported) {
   constexpr size_t N = 1024;
   hipGraph_t graph1, graph2;
   hipGraphNode_t alloc_node, free_node;
@@ -201,7 +201,7 @@ TEST_CASE("Unit_hipGraphAddMemFreeNode_Negative_NotSupported") {
  * ------------------------
  * - HIP_VERSION >= 6.1
  */
-TEST_CASE("Unit_hipGraphAddMemFreeNode_Functional") {
+TEST_CASE(Unit_hipGraphAddMemFreeNode_Functional) {
   int mem_pool_support = 0;
   HIP_CHECK(hipDeviceGetAttribute(&mem_pool_support, hipDeviceAttributeMemoryPoolsSupported, 0));
   if (!mem_pool_support) {

--- a/projects/hip-tests/catch/unit/graph/hipGraphAddMemcpyNode.cc
+++ b/projects/hip-tests/catch/unit/graph/hipGraphAddMemcpyNode.cc
@@ -51,7 +51,7 @@ THE SOFTWARE.
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_hipGraphAddMemcpyNode_Positive_Basic") {
+TEST_CASE(Unit_hipGraphAddMemcpyNode_Positive_Basic) {
   CHECK_IMAGE_SUPPORT
 
   constexpr bool async = false;
@@ -127,7 +127,7 @@ TEST_CASE("Unit_hipGraphAddMemcpyNode_Positive_Basic") {
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_hipGraphAddMemcpyNode_Negative_Parameters") {
+TEST_CASE(Unit_hipGraphAddMemcpyNode_Negative_Parameters) {
   CHECK_IMAGE_SUPPORT
 
   using namespace std::placeholders;

--- a/projects/hip-tests/catch/unit/graph/hipGraphAddMemcpyNode1D.cc
+++ b/projects/hip-tests/catch/unit/graph/hipGraphAddMemcpyNode1D.cc
@@ -50,7 +50,7 @@ THE SOFTWARE.
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_hipGraphAddMemcpyNode1D_Positive_Basic") {
+TEST_CASE(Unit_hipGraphAddMemcpyNode1D_Positive_Basic) {
   constexpr auto f = [](void* dst, void* src, size_t count, hipMemcpyKind direction) {
     hipGraph_t graph = nullptr;
     HIP_CHECK(hipGraphCreate(&graph, 0));
@@ -142,7 +142,7 @@ TEST_CASE("Unit_hipGraphAddMemcpyNode1D_Positive_Basic") {
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_hipGraphAddMemcpyNode1D_Negative_Parameters") {
+TEST_CASE(Unit_hipGraphAddMemcpyNode1D_Negative_Parameters) {
   using namespace std::placeholders;
   hipGraph_t graph = nullptr;
   HIP_CHECK(hipGraphCreate(&graph, 0));

--- a/projects/hip-tests/catch/unit/graph/hipGraphAddMemcpyNode1D_old.cc
+++ b/projects/hip-tests/catch/unit/graph/hipGraphAddMemcpyNode1D_old.cc
@@ -115,7 +115,7 @@ static void validateMemcpyNode1DArray(bool peerAccess,
  * For Peer device test: Memory allocations happen on device(0) and memcpy operations
  * are performed from device(1).
  */
-TEST_CASE("Unit_hipGraphAddMemcpyNode1D_Functional", "[multigpu]") {
+TEST_CASE(Unit_hipGraphAddMemcpyNode1D_Functional) {
   SECTION("Memcpy with 1D array on default device") { validateMemcpyNode1DArray(false); }
   SECTION("Memcpy with 1D array using DeviceToDeviceNoCU") {
     validateMemcpyNode1DArray(false, hipMemcpyDeviceToDeviceNoCU);
@@ -139,7 +139,7 @@ TEST_CASE("Unit_hipGraphAddMemcpyNode1D_Functional", "[multigpu]") {
 /**
  * Negative Test for API hipGraphAddMemcpyNode1D
  */
-TEST_CASE("Unit_hipGraphAddMemcpyNode1D_Negative") {
+TEST_CASE(Unit_hipGraphAddMemcpyNode1D_Negative) {
   constexpr size_t N = 1024;
   constexpr size_t Nbytes = N * sizeof(int);
   int *A_d, *A_h;
@@ -205,7 +205,7 @@ TEST_CASE("Unit_hipGraphAddMemcpyNode1D_Negative") {
  * hipGraphAddMemcpyNode1D with data transfer kind hipMemcpyHostToHost.
  * Validate the output.
  */
-TEST_CASE("Unit_hipGraphAddMemcpyNode1D_HostToHost") {
+TEST_CASE(Unit_hipGraphAddMemcpyNode1D_HostToHost) {
   constexpr size_t size = 1024;
   size_t numBytes{size * sizeof(int)};
 

--- a/projects/hip-tests/catch/unit/graph/hipGraphAddMemcpyNodeFromSymbol.cc
+++ b/projects/hip-tests/catch/unit/graph/hipGraphAddMemcpyNodeFromSymbol.cc
@@ -85,7 +85,7 @@ void GraphMemcpyFromSymbolShell(void* symbol, size_t offset, const std::vector<T
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_hipGraphAddMemcpyNodeFromSymbol_Positive_Basic") {
+TEST_CASE(Unit_hipGraphAddMemcpyNodeFromSymbol_Positive_Basic) {
   SECTION("char") {
     HIP_GRAPH_ADD_MEMCPY_NODE_TO_FROM_SYMBOL_TEST(GraphMemcpyFromSymbolShell, 1, char);
   }
@@ -127,7 +127,7 @@ TEST_CASE("Unit_hipGraphAddMemcpyNodeFromSymbol_Positive_Basic") {
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_hipGraphAddMemcpyNodeFromSymbol_Negative_Parameters") {
+TEST_CASE(Unit_hipGraphAddMemcpyNodeFromSymbol_Negative_Parameters) {
   using namespace std::placeholders;
   hipGraph_t graph = nullptr;
   HIP_CHECK(hipGraphCreate(&graph, 0));

--- a/projects/hip-tests/catch/unit/graph/hipGraphAddMemcpyNodeFromSymbol_old.cc
+++ b/projects/hip-tests/catch/unit/graph/hipGraphAddMemcpyNodeFromSymbol_old.cc
@@ -69,7 +69,7 @@ __global__ void MemcpyFromSymbolKernel(int* B_d) {
 
 /* This testcase verifies negative scenarios of
    hipGraphAddMemcpyNodeFromSymbol API */
-TEST_CASE("Unit_hipGraphAddMemcpyNodeFromSymbol_Negative") {
+TEST_CASE(Unit_hipGraphAddMemcpyNodeFromSymbol_Negative) {
   constexpr size_t Nbytes = SIZE * sizeof(int);
   int *A_d{nullptr}, *B_d{nullptr};
   int *A_h{nullptr}, *B_h{nullptr};
@@ -235,7 +235,7 @@ This testcase verifies allocating global symbol memory,
 add the MemcpyNodeFromSymbol node to the graph and
 erifying the result
 */
-TEST_CASE("Unit_hipGraphAddMemcpyNodeFromSymbol_GlobalMemory") {
+TEST_CASE(Unit_hipGraphAddMemcpyNodeFromSymbol_GlobalMemory) {
   hipGraphAddMemcpyNodeFromSymbol_GlobalMemory(false, false);
 }
 
@@ -245,7 +245,7 @@ add the MemcpyNodeFromSymbol node to the graph and
 verifying the result
 */
 
-TEST_CASE("Unit_hipGraphAddMemcpyNodeFromSymbol_GlobalConstMemory") {
+TEST_CASE(Unit_hipGraphAddMemcpyNodeFromSymbol_GlobalConstMemory) {
   hipGraphAddMemcpyNodeFromSymbol_GlobalMemory(false, true);
 }
 
@@ -255,8 +255,7 @@ in GPU-0 and add the MemcpyNodeFromSymbol node to the graph and
 verifying the result in GPU-1
 */
 #if HT_NVIDIA
-TEST_CASE("Unit_hipGraphAddMemcpyNodeFromSymbol_GlobalMemoryPeerDevice",
-          "[multigpu]") {
+TEST_CASE(Unit_hipGraphAddMemcpyNodeFromSymbol_GlobalMemoryPeerDevice) {
   int numDevices = 0;
   int canAccessPeer = 0;
   if (numDevices > 1) {
@@ -277,8 +276,7 @@ in GPU-0 and add the MemcpyNodeFromSymbol node to the graph and
 verifying the result in GPU-1
 */
 
-TEST_CASE("Unit_hipGraphAddMemcpyNodeFromSymbol_GlobalConstMemoryPeerDevice",
-          "[multigpu]") {
+TEST_CASE(Unit_hipGraphAddMemcpyNodeFromSymbol_GlobalConstMemoryPeerDevice) {
   int numDevices = 0;
   int canAccessPeer = 0;
   if (numDevices > 1) {
@@ -298,7 +296,7 @@ This testcaser verifies allocating global memory,
 Add MemcpyFromSymbolNode,KernelNode and memcpynode and validating
 the behaviour
 */
-TEST_CASE("Unit_hipGraphAddMemcpyNodeFromSymbol_GlobalMemoryWithKernel") {
+TEST_CASE(Unit_hipGraphAddMemcpyNodeFromSymbol_GlobalMemoryWithKernel) {
   constexpr size_t Nbytes = SIZE * sizeof(int);
   constexpr auto blocksPerCU = 6;  // to hide latency
   constexpr auto threadsPerBlock = 256;

--- a/projects/hip-tests/catch/unit/graph/hipGraphAddMemcpyNodeToSymbol.cc
+++ b/projects/hip-tests/catch/unit/graph/hipGraphAddMemcpyNodeToSymbol.cc
@@ -88,7 +88,7 @@ void GraphMemcpyToSymbolShell(const void* symbol, size_t offset, const std::vect
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_hipGraphAddMemcpyNodeToSymbol_Positive_Basic") {
+TEST_CASE(Unit_hipGraphAddMemcpyNodeToSymbol_Positive_Basic) {
   SECTION("char") {
     HIP_GRAPH_ADD_MEMCPY_NODE_TO_FROM_SYMBOL_TEST(GraphMemcpyToSymbolShell, 10, char);
   }
@@ -130,7 +130,7 @@ TEST_CASE("Unit_hipGraphAddMemcpyNodeToSymbol_Positive_Basic") {
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_hipGraphAddMemcpyNodeToSymbol_Negative_Parameters") {
+TEST_CASE(Unit_hipGraphAddMemcpyNodeToSymbol_Negative_Parameters) {
   using namespace std::placeholders;
   hipGraph_t graph = nullptr;
   HIP_CHECK(hipGraphCreate(&graph, 0));

--- a/projects/hip-tests/catch/unit/graph/hipGraphAddMemcpyNodeToSymbol_old.cc
+++ b/projects/hip-tests/catch/unit/graph/hipGraphAddMemcpyNodeToSymbol_old.cc
@@ -62,7 +62,7 @@ __global__ void MemcpyToSymbolKernel(int* B_d) {
 
 /* This testcase verifies negative scenarios of
    hipGraphAddMemcpyNodeToSymbol API */
-TEST_CASE("Unit_hipGraphAddMemcpyNodeToSymbol_Negative") {
+TEST_CASE(Unit_hipGraphAddMemcpyNodeToSymbol_Negative) {
   constexpr size_t Nbytes = SIZE * sizeof(int);
   int* A_d{nullptr};
   int *A_h{nullptr}, *B_h{nullptr};
@@ -218,7 +218,7 @@ This testcase verifies allocating global symbol memory,
 add the MemcpyNodeToSymbol node to the graph and
 erifying the result
 */
-TEST_CASE("Unit_hipGraphAddMemcpyNodeToSymbol_GlobalMemory") {
+TEST_CASE(Unit_hipGraphAddMemcpyNodeToSymbol_GlobalMemory) {
   hipGraphAddMemcpyNodeToSymbol_GlobalMemory(false, false);
 }
 
@@ -227,7 +227,7 @@ This testcase verifies allocating global const symbol memory,
 add the MemcpyNodeToSymbol node to the graph and
 verifying the result
 */
-TEST_CASE("Unit_hipGraphAddMemcpyNodeToSymbol_GlobalConstMemory") {
+TEST_CASE(Unit_hipGraphAddMemcpyNodeToSymbol_GlobalConstMemory) {
   hipGraphAddMemcpyNodeToSymbol_GlobalMemory(false, true);
 }
 
@@ -237,7 +237,7 @@ This testcase verifies allocating global symbol memory and device variables
 in GPU-0 and add the MemcpyNodeToSymbol node to the graph and
 verifying the result in GPU-1
 */
-TEST_CASE("Unit_hipGraphAddMemcpyNodeToSymbol_GlobalMemoryPeerDevice") {
+TEST_CASE(Unit_hipGraphAddMemcpyNodeToSymbol_GlobalMemoryPeerDevice) {
   int numDevices = 0;
   int canAccessPeer = 0;
   HIP_CHECK(hipGetDeviceCount(&numDevices));
@@ -257,8 +257,7 @@ This testcase verifies allocating global const symbol memory and device variable
 in GPU-0 and add the MemcpyNodeToSymbol node to the graph and
 verifying the result in GPU-1
 */
-TEST_CASE("Unit_hipGraphAddMemcpyNodeToSymbol_GlobalConstMemoryPeerDevice",
-          "[multigpu]") {
+TEST_CASE(Unit_hipGraphAddMemcpyNodeToSymbol_GlobalConstMemoryPeerDevice) {
   int numDevices = 0;
   int canAccessPeer = 0;
   HIP_CHECK(hipGetDeviceCount(&numDevices));
@@ -279,8 +278,7 @@ This testcaser verifies allocating global memory,
 Add MemcpyToSymbolNode,KernelNode and memcpynode and validating
 the behaviour
 */
-TEST_CASE("Unit_hipGraphAddMemcpyNodeToSymbol_MemcpyToSymbolNodeWithKernel",
-          "[multigpu]") {
+TEST_CASE(Unit_hipGraphAddMemcpyNodeToSymbol_MemcpyToSymbolNodeWithKernel) {
   constexpr size_t Nbytes = SIZE * sizeof(int);
   constexpr auto blocksPerCU = 6;  // to hide latency
   constexpr auto threadsPerBlock = 256;

--- a/projects/hip-tests/catch/unit/graph/hipGraphAddMemsetNode.cc
+++ b/projects/hip-tests/catch/unit/graph/hipGraphAddMemsetNode.cc
@@ -54,7 +54,7 @@ static char memSetVal = 'a';
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEMPLATE_TEST_CASE("Unit_hipGraphAddMemsetNode_Positive_Basic", "", uint8_t, uint16_t, uint32_t) {
+TEMPLATE_TEST_CASE(Unit_hipGraphAddMemsetNode_Positive_Basic, uint8_t, uint16_t, uint32_t) {
   CHECK_IMAGE_SUPPORT
 
   const auto f = [](hipMemsetParams* params) {
@@ -104,7 +104,7 @@ TEMPLATE_TEST_CASE("Unit_hipGraphAddMemsetNode_Positive_Basic", "", uint8_t, uin
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_hipGraphAddMemsetNode_Negative_Parameters") {
+TEST_CASE(Unit_hipGraphAddMemsetNode_Negative_Parameters) {
   using namespace std::placeholders;
   hipGraph_t graph = nullptr;
   HIP_CHECK(hipGraphCreate(&graph, 0));
@@ -129,7 +129,7 @@ TEST_CASE("Unit_hipGraphAddMemsetNode_Negative_Parameters") {
  * using hipGraphAddMemsetNode. Copy the values in device memory to host using
  * hipGraphAddMemcpyNode. Verify the results.
  */
-TEST_CASE("Unit_hipGraphAddMemsetNode_hipMallocPitch_2D") {
+TEST_CASE(Unit_hipGraphAddMemsetNode_hipMallocPitch_2D) {
   CHECK_IMAGE_SUPPORT
 
   size_t width = SIZE * sizeof(char), numW{SIZE}, numH{SIZE}, pitch_A;
@@ -196,7 +196,7 @@ TEST_CASE("Unit_hipGraphAddMemsetNode_hipMallocPitch_2D") {
  * hipGraphAddMemsetNode. Copy the values in device memory to host using
  * hipGraphAddMemcpyNode. Verify the results.
  */
-TEST_CASE("Unit_hipGraphAddMemsetNode_hipMallocPitch_1D") {
+TEST_CASE(Unit_hipGraphAddMemsetNode_hipMallocPitch_1D) {
   CHECK_IMAGE_SUPPORT
 
   size_t width = SIZE * sizeof(char), numW{SIZE}, pitch_A;
@@ -257,7 +257,7 @@ TEST_CASE("Unit_hipGraphAddMemsetNode_hipMallocPitch_1D") {
  * hipGraphAddMemsetNode. Copy the values in device memory to host using
  * hipGraphAddMemcpyNode. Verify the results.
  */
-TEST_CASE("Unit_hipGraphAddMemsetNode_hipMalloc3D_2D") {
+TEST_CASE(Unit_hipGraphAddMemsetNode_hipMalloc3D_2D) {
   CHECK_IMAGE_SUPPORT
 
   size_t width = SIZE * sizeof(char);
@@ -334,7 +334,7 @@ TEST_CASE("Unit_hipGraphAddMemsetNode_hipMalloc3D_2D") {
  * memory using hipGraphAddMemsetNode. Copy the values in device
  * memory to host using hipGraphAddMemcpyNode. Verify the results.
  */
-TEST_CASE("Unit_hipGraphAddMemsetNode_hipMalloc3D_1D") {
+TEST_CASE(Unit_hipGraphAddMemsetNode_hipMalloc3D_1D) {
   CHECK_IMAGE_SUPPORT
 
   size_t width = SIZE * sizeof(char);
@@ -404,7 +404,7 @@ TEST_CASE("Unit_hipGraphAddMemsetNode_hipMalloc3D_1D") {
  * hipGraphAddMemsetNode. Copy the values in device memory to host using
  * hipGraphAddMemcpyNode. Verify the results.
  */
-TEST_CASE("Unit_hipGraphAddMemsetNode_hipMalloc_1D") {
+TEST_CASE(Unit_hipGraphAddMemsetNode_hipMalloc_1D) {
   char* A_d;
   size_t NumW = SIZE;
   size_t Nbytes1D = SIZE * sizeof(char);
@@ -463,7 +463,7 @@ TEST_CASE("Unit_hipGraphAddMemsetNode_hipMalloc_1D") {
   HIP_CHECK(hipFree(A_d));
 }
 
-TEST_CASE("Unit_hipGraphAddMemsetNode_hipMallocManaged") {
+TEST_CASE(Unit_hipGraphAddMemsetNode_hipMallocManaged) {
   int managed = 0;
   HIP_CHECK(hipDeviceGetAttribute(&managed, hipDeviceAttributeManagedMemory, 0));
   INFO("hipDeviceAttributeManagedMemory: " << managed);

--- a/projects/hip-tests/catch/unit/graph/hipGraphAddNode.cc
+++ b/projects/hip-tests/catch/unit/graph/hipGraphAddNode.cc
@@ -71,7 +71,7 @@ static void __global__ vector_square(int* A_d) {
  * ------------------------
  *    - HIP_VERSION >= 6.0
  */
-TEMPLATE_TEST_CASE("Unit_hipGraphAddNodeTypeMemset_Positive_Basic", "", uint8_t, uint16_t,
+TEMPLATE_TEST_CASE(Unit_hipGraphAddNodeTypeMemset_Positive_Basic, uint8_t, uint16_t,
                    uint32_t) {
   const auto f = [](hipMemsetParams* params) {
     hipGraph_t graph = nullptr;
@@ -115,7 +115,7 @@ TEMPLATE_TEST_CASE("Unit_hipGraphAddNodeTypeMemset_Positive_Basic", "", uint8_t,
  * ------------------------
  *    - HIP_VERSION >= 6.0
  */
-TEST_CASE("Unit_hipGraphAddNodeTypeKernel_Positive_Basic") {
+TEST_CASE(Unit_hipGraphAddNodeTypeKernel_Positive_Basic) {
   constexpr size_t allocation_size = N * sizeof(int);
   hipGraph_t graph;
   hipGraphExec_t graphExec;
@@ -182,7 +182,7 @@ TEST_CASE("Unit_hipGraphAddNodeTypeKernel_Positive_Basic") {
  * ------------------------
  *    - HIP_VERSION >= 6.0
  */
-TEST_CASE("Unit_hipGraphAddNodeTypeHost_Positive_Basic") {
+TEST_CASE(Unit_hipGraphAddNodeTypeHost_Positive_Basic) {
   constexpr size_t allocation_size = N * sizeof(int);
   hipGraph_t graph;
   hipGraphExec_t graphExec;
@@ -230,7 +230,7 @@ TEST_CASE("Unit_hipGraphAddNodeTypeHost_Positive_Basic") {
  * ------------------------
  *    - HIP_VERSION >= 6.0
  */
-TEST_CASE("Unit_hipGraphAddNodeTypeChildGraph_Positive_Basic") {
+TEST_CASE(Unit_hipGraphAddNodeTypeChildGraph_Positive_Basic) {
   constexpr size_t allocation_size = N * sizeof(int);
   hipGraph_t graph, childgraph;
   hipGraphExec_t graphExec;
@@ -325,7 +325,7 @@ static hipError_t MemcpyType3DWrapper(PtrVariant dst_ptr, hipPos dst_pos, PtrVar
  * ------------------------
  *    - HIP_VERSION >= 6.0
  */
-TEST_CASE("Unit_hipGraphAddNodeTypeMemcpy_Positive_Basic") {
+TEST_CASE(Unit_hipGraphAddNodeTypeMemcpy_Positive_Basic) {
   CHECK_IMAGE_SUPPORT
 
   constexpr bool async = false;
@@ -384,7 +384,7 @@ TEST_CASE("Unit_hipGraphAddNodeTypeMemcpy_Positive_Basic") {
  * ------------------------
  *    - HIP_VERSION >= 6.0
  */
-TEST_CASE("Unit_hipGraphAddNodeTypeEventRecord_Positive_Basic") {
+TEST_CASE(Unit_hipGraphAddNodeTypeEventRecord_Positive_Basic) {
   hipGraph_t graph;
   hipStream_t streamForGraph;
   hipGraphExec_t graphExec;
@@ -422,7 +422,7 @@ TEST_CASE("Unit_hipGraphAddNodeTypeEventRecord_Positive_Basic") {
  * ------------------------
  *    - HIP_VERSION >= 6.0
  */
-TEST_CASE("Unit_hipGraphAddNodeTypeEventWait_Positive_Basic") {
+TEST_CASE(Unit_hipGraphAddNodeTypeEventWait_Positive_Basic) {
   hipGraph_t graph;
   hipStream_t streamForGraph;
   hipGraphExec_t graphExec;
@@ -468,7 +468,7 @@ TEST_CASE("Unit_hipGraphAddNodeTypeEventWait_Positive_Basic") {
  * ------------------------
  *  - HIP_VERSION >= 6.0
  */
-TEST_CASE("Unit_hipGraphAddNodeTypeMemAlloc_Positive_Basic") {
+TEST_CASE(Unit_hipGraphAddNodeTypeMemAlloc_Positive_Basic) {
   constexpr size_t allocation_size = N * sizeof(int);
   hipGraph_t graph;
   hipStream_t streamForGraph;
@@ -525,7 +525,7 @@ TEST_CASE("Unit_hipGraphAddNodeTypeMemAlloc_Positive_Basic") {
  * ------------------------
  *  - HIP_VERSION >= 6.0
  */
-TEST_CASE("Unit_hipGraphAddNode_Negative_Parameters") {
+TEST_CASE(Unit_hipGraphAddNode_Negative_Parameters) {
   using namespace std::placeholders;
   hipGraph_t graph = nullptr;
   HIP_CHECK(hipGraphCreate(&graph, 0));

--- a/projects/hip-tests/catch/unit/graph/hipGraphAddNodeBeginCapture.cc
+++ b/projects/hip-tests/catch/unit/graph/hipGraphAddNodeBeginCapture.cc
@@ -84,7 +84,7 @@ static void CpuCallback(void* args) {
  *  - HIP_VERSION >= 5.6
  */
 
-TEST_CASE("Unit_hipStreamBeginCapture_with_hipGraphAddHostNode") {
+TEST_CASE(Unit_hipStreamBeginCapture_with_hipGraphAddHostNode) {
   hipGraph_t graph;
   hipGraphExec_t graphExec;
   hipGraphNode_t cpuGraphNode;
@@ -141,7 +141,7 @@ TEST_CASE("Unit_hipStreamBeginCapture_with_hipGraphAddHostNode") {
  *  - HIP_VERSION >= 5.6
  */
 
-TEST_CASE("Unit_hipStreamEndCapture_later_and_add_a_node_inbetween") {
+TEST_CASE(Unit_hipStreamEndCapture_later_and_add_a_node_inbetween) {
   hipGraphExec_t graphExec;
   hipGraphNode_t memcpyD2H_C;
   hipStream_t stream;
@@ -487,7 +487,7 @@ TEST_CASE("Unit_hipStreamEndCapture_later_and_add_a_node_inbetween") {
  *  - HIP_VERSION >= 5.6
  */
 
-TEST_CASE("Unit_hipStreamEndCapture_first_and_add_a_node_later") {
+TEST_CASE(Unit_hipStreamEndCapture_first_and_add_a_node_later) {
   hipGraph_t graph;
   hipGraphExec_t graphExec;
   hipGraphNode_t memcpyD2H_C;
@@ -785,7 +785,7 @@ TEST_CASE("Unit_hipStreamEndCapture_first_and_add_a_node_later") {
  *  - HIP_VERSION >= 5.6
  */
 
-TEST_CASE("Unit_hipStreamEndCapture_first_and_add_other_graph_node_later") {
+TEST_CASE(Unit_hipStreamEndCapture_first_and_add_other_graph_node_later) {
   hipGraph_t graph;
   hipGraphExec_t graphExec;
   hipGraphNode_t memcpyH2D_A, memcpyH2D_B, memcpyD2H_AC, memcpyH2D_C;
@@ -853,7 +853,7 @@ TEST_CASE("Unit_hipStreamEndCapture_first_and_add_other_graph_node_later") {
  *  - HIP_VERSION >= 5.6
  */
 
-TEST_CASE("Unit_hipStreamEndCapture_later_and_addEmptyNode") {
+TEST_CASE(Unit_hipStreamEndCapture_later_and_addEmptyNode) {
   hipGraphExec_t graphExec;
   hipGraphNode_t memcpyD2H_C;
   hipStream_t stream;

--- a/projects/hip-tests/catch/unit/graph/hipGraphAsyncUserObj.cc
+++ b/projects/hip-tests/catch/unit/graph/hipGraphAsyncUserObj.cc
@@ -114,7 +114,7 @@ void hipUserObjectCreate_int_float_Objects(T* hostArr, T* devArr, void destroyOb
  * ------------------------
  * - HIP_VERSION >= 6.3
  */
-TEST_CASE("Unit_hipGraphUserObj_Int_float_Objects") {
+TEST_CASE(Unit_hipGraphUserObj_Int_float_Objects) {
   SECTION("Called with Int Obj") {
     std::thread t1(threadFunc_dltMemory);
     int* hostArr = nullptr;
@@ -162,7 +162,7 @@ void destroyHostRegObj(void* ptr) {
  * ------------------------
  * - HIP_VERSION >= 6.3
  */
-TEST_CASE("Unit_hipGraphUserObj_HostRegister") {
+TEST_CASE(Unit_hipGraphUserObj_HostRegister) {
   int clockrate = 0;
   HIP_CHECK(hipDeviceGetAttribute(&clockrate, hipDeviceAttributeMemoryClockRate, 0));
   int* A_h = new int();
@@ -249,7 +249,7 @@ template <typename T> void hipUserObjectCreate_Struct_Class_Objects(T* Obj_h, T*
  * ------------------------
  * - HIP_VERSION >= 6.3
  */
-TEST_CASE("Unit_hipGraphUserObj_Struct_Class_Ojects") {
+TEST_CASE(Unit_hipGraphUserObj_Struct_Class_Ojects) {
   SECTION("Called with Struct Object") {
     std::thread t1(threadFunc_dltMemory);
     BoxStruct* structObj_h;
@@ -291,7 +291,7 @@ TEST_CASE("Unit_hipGraphUserObj_Struct_Class_Ojects") {
  * ------------------------
  * - HIP_VERSION >= 6.3
  */
-TEST_CASE("Unit_hipGraphUserObj_ClonedGraph") {
+TEST_CASE(Unit_hipGraphUserObj_ClonedGraph) {
   int clockrate = 0;
   HIP_CHECK(hipDeviceGetAttribute(&clockrate, hipDeviceAttributeMemoryClockRate, 0));
   std::thread t1(threadFunc_dltMemory);
@@ -362,7 +362,7 @@ __global__ void ManualGraphKernelFn(int* Ad, int clockrate, int WaitSecs) {
  * ------------------------
  * - HIP_VERSION >= 6.3
  */
-TEST_CASE("Unit_hipGraphUserObj_ManualGraph") {
+TEST_CASE(Unit_hipGraphUserObj_ManualGraph) {
   int clockrate = 0;
   HIP_CHECK(hipDeviceGetAttribute(&clockrate, hipDeviceAttributeMemoryClockRate, 0));
   std::thread t1(threadFunc_dltMemory);

--- a/projects/hip-tests/catch/unit/graph/hipGraphBatchMemOpNodeSetParams.cc
+++ b/projects/hip-tests/catch/unit/graph/hipGraphBatchMemOpNodeSetParams.cc
@@ -38,7 +38,7 @@ THE SOFTWARE.
  * ------------------------
  *    - HIP_VERSION >= 6.4
  */
-TEST_CASE("Unit_hipGraphBatchMemOpNodeSetParams_NegativeTsts") {
+TEST_CASE(Unit_hipGraphBatchMemOpNodeSetParams_NegativeTsts) {
   HIP_CHECK(hipInit(0));
   hipGraph_t graph;
   hipCtx_t ctx;
@@ -129,7 +129,7 @@ TEST_CASE("Unit_hipGraphBatchMemOpNodeSetParams_NegativeTsts") {
  * ------------------------
  *    - HIP_VERSION >= 6.4
  */
-TEST_CASE("Unit_hipGraphBatchMemOpNodeGetParams_NegativeTsts") {
+TEST_CASE(Unit_hipGraphBatchMemOpNodeGetParams_NegativeTsts) {
   hipBatchMemOpNodeParams retrievedNodeParams;
   HIP_CHECK_ERROR(hipGraphBatchMemOpNodeGetParams(nullptr, &retrievedNodeParams),
                   hipErrorInvalidValue);

--- a/projects/hip-tests/catch/unit/graph/hipGraphChildGraphNodeGetGraph.cc
+++ b/projects/hip-tests/catch/unit/graph/hipGraphChildGraphNodeGetGraph.cc
@@ -39,7 +39,7 @@ Create graph, add multiple child nodes and gets the
 graph of one of the child nodes using hipGraphChildGraphNodeGetGraph API
 executes it and validates the results
 */
-TEST_CASE("Unit_hipGraphChildGraphNodeGetGraph_Functional") {
+TEST_CASE(Unit_hipGraphChildGraphNodeGetGraph_Functional) {
   constexpr size_t N = 1024;
   constexpr size_t Nbytes = N * sizeof(int);
   constexpr auto blocksPerCU = 6;  // to hide latency
@@ -109,7 +109,7 @@ TEST_CASE("Unit_hipGraphChildGraphNodeGetGraph_Functional") {
 This testcase verifies the negative scenarios
 of hipGraphChildGraphNodeGetGraph API
 */
-TEST_CASE("Unit_hipGraphChildGraphNodeGetGraph_Negative") {
+TEST_CASE(Unit_hipGraphChildGraphNodeGetGraph_Negative) {
   constexpr size_t N = 1024;
   constexpr size_t Nbytes = N * sizeof(int);
   hipGraph_t graph, childgraph1;

--- a/projects/hip-tests/catch/unit/graph/hipGraphClone.cc
+++ b/projects/hip-tests/catch/unit/graph/hipGraphClone.cc
@@ -43,7 +43,7 @@ Functional:
 /* This test covers the negative scenarios of
    hipGraphClone API */
 
-TEST_CASE("Unit_hipGraphClone_Negative") {
+TEST_CASE(Unit_hipGraphClone_Negative) {
   SECTION("Passing nullptr to Cloned graph") {
     hipGraph_t graph;
     HIP_CHECK(hipGraphCreate(&graph, 0));
@@ -229,7 +229,7 @@ This testcase verifies following scenarios
    validate the result of the cloned graph
 3. Device context change for cloned graph
 */
-TEST_CASE("Unit_hipGraphClone_Functional", "[multigpu]") {
+TEST_CASE(Unit_hipGraphClone_Functional) {
   SECTION("hipGraphClone Basic Functionality") { hipGraphClone_Func(); }
   SECTION("hipGraphClone Modify Original graph") { hipGraphClone_Func(true); }
 
@@ -258,7 +258,7 @@ hipGraphClone is failing in CUDA in multi threaded
 scenario so excluded for nvidia
 */
 #if HT_AMD
-TEST_CASE("Unit_hipGraphClone_MultiThreaded") {
+TEST_CASE(Unit_hipGraphClone_MultiThreaded) {
   constexpr size_t N = 1024;
   constexpr size_t Nbytes = N * sizeof(int);
   hipGraph_t graph;

--- a/projects/hip-tests/catch/unit/graph/hipGraphCloneComplx.cc
+++ b/projects/hip-tests/catch/unit/graph/hipGraphCloneComplx.cc
@@ -229,7 +229,7 @@ static void hipGraphClone_Test_hipGraphKernelNodeSetParams() {
   HIP_CHECK(hipGraphDestroy(clonedGraph));
 }
 
-TEST_CASE("Unit_hipGraphClone_Test_hipGraphKernelNodeSetParams") {
+TEST_CASE(Unit_hipGraphClone_Test_hipGraphKernelNodeSetParams) {
   hipGraphClone_Test_hipGraphKernelNodeSetParams();
 }
 
@@ -276,7 +276,7 @@ static void hipGraphClone_Test_hipGraphExecKernelNodeSetParams() {
   HIP_CHECK(hipGraphDestroy(clonedGraph));
 }
 
-TEST_CASE("Unit_hipGraphClone_Test_hipGraphExecKernelNodeSetParams") {
+TEST_CASE(Unit_hipGraphClone_Test_hipGraphExecKernelNodeSetParams) {
   hipGraphClone_Test_hipGraphExecKernelNodeSetParams();
 }
 
@@ -339,7 +339,7 @@ static void hipGraphClone_Test_hipGraphAddMemcpy_and_memset() {
   HIP_CHECK(hipGraphDestroy(clonedGraph));
 }
 
-TEST_CASE("Unit_hipGraphClone_Test_hipGraphAddMemcpy_and_memset") {
+TEST_CASE(Unit_hipGraphClone_Test_hipGraphAddMemcpy_and_memset) {
   hipGraphClone_Test_hipGraphAddMemcpy_and_memset();
 }
 
@@ -449,7 +449,7 @@ static void hipGraphClone_Test_hipGraphMemcpyNodeSetParams() {
   HipTest::freeArrays<int>(nullptr, nullptr, nullptr, hData, hDataTemp, hOutputData, false);
 }
 
-TEST_CASE("Unit_hipGraphClone_Test_hipGraphMemcpyNodeSetParams") {
+TEST_CASE(Unit_hipGraphClone_Test_hipGraphMemcpyNodeSetParams) {
   CHECK_IMAGE_SUPPORT
 
   hipGraphClone_Test_hipGraphMemcpyNodeSetParams();
@@ -564,7 +564,7 @@ static void hipGraphClone_Test_hipGraphExecMemcpyNodeSetParams() {
   HIP_CHECK(hipFreeArray(devArray3));
 }
 
-TEST_CASE("Unit_hipGraphClone_Test_hipGraphExecMemcpyNodeSetParams") {
+TEST_CASE(Unit_hipGraphClone_Test_hipGraphExecMemcpyNodeSetParams) {
   CHECK_IMAGE_SUPPORT
 
   hipGraphClone_Test_hipGraphExecMemcpyNodeSetParams();
@@ -645,7 +645,7 @@ static void hipGraphClone_Test_hipGraphMemcpyNodeSetParams1D_and_exec() {
   HIP_CHECK(hipGraphDestroy(clonedGraph_2));
 }
 
-TEST_CASE("Unit_hipGraphClone_Test_hipGraphMemcpyNodeSetParams1D_and_exec") {
+TEST_CASE(Unit_hipGraphClone_Test_hipGraphMemcpyNodeSetParams1D_and_exec) {
   hipGraphClone_Test_hipGraphMemcpyNodeSetParams1D_and_exec();
 }
 
@@ -739,7 +739,7 @@ static void hipGraphClone_hipGraphMemcpyNodeSetParamsFromSymbol_exec() {
   HIP_CHECK(hipGraphDestroy(clonedGraph_2));
 }
 
-TEST_CASE("Unit_hipGraphClone_hipGraphMemcpyNodeSetParamsFromSymbol_exec") {
+TEST_CASE(Unit_hipGraphClone_hipGraphMemcpyNodeSetParamsFromSymbol_exec) {
   hipGraphClone_hipGraphMemcpyNodeSetParamsFromSymbol_exec();
 }
 
@@ -832,7 +832,7 @@ static void hipGraphClone_hipGraphMemcpyNodeSetParamsToSymbol_exec() {
   HIP_CHECK(hipGraphDestroy(clonedGraph_2));
 }
 
-TEST_CASE("Unit_hipGraphClone_hipGraphMemcpyNodeSetParamsToSymbol_exec") {
+TEST_CASE(Unit_hipGraphClone_hipGraphMemcpyNodeSetParamsToSymbol_exec) {
   hipGraphClone_hipGraphMemcpyNodeSetParamsToSymbol_exec();
 }
 
@@ -944,7 +944,7 @@ static void hipGraphClone_Test_hipGraphMemsetNodeSetParams_exec() {
   HIP_CHECK(hipGraphDestroy(clonedGraph_2));
 }
 
-TEST_CASE("Unit_hipGraphClone_Test_hipGraphMemsetNodeSetParams_exec") {
+TEST_CASE(Unit_hipGraphClone_Test_hipGraphMemsetNodeSetParams_exec) {
   hipGraphClone_Test_hipGraphMemsetNodeSetParams_exec();
 }
 
@@ -1013,7 +1013,7 @@ static void hipGraphClone_Test_hipGraphRemoveDependencies() {
   HIP_CHECK(hipGraphDestroy(clonedGraph));
 }
 
-TEST_CASE("Unit_hipGraphClone_Test_hipGraphRemoveDependencies") {
+TEST_CASE(Unit_hipGraphClone_Test_hipGraphRemoveDependencies) {
   hipGraphClone_Test_hipGraphRemoveDependencies();
 }
 #endif
@@ -1112,7 +1112,7 @@ static void hipGraphClone_Test_hipGraphExecChildGraphNodeSetParams() {
   HIP_CHECK(hipGraphDestroy(childgraph2));
 }
 
-TEST_CASE("Unit_hipGraphClone_Test_hipGraphExecChildGraphNodeSetParams") {
+TEST_CASE(Unit_hipGraphClone_Test_hipGraphExecChildGraphNodeSetParams) {
   hipGraphClone_Test_hipGraphExecChildGraphNodeSetParams();
 }
 
@@ -1306,7 +1306,7 @@ static void hipGraphClone_Test_hipGraphEventRecordNodeSetEvent_and_Exec() {
   HIP_CHECK(hipEventDestroy(event_end));
 }
 
-TEST_CASE("Unit_hipGraphClone_Test_hipGraphEventRecordNodeSetEvent_and_Exec") {
+TEST_CASE(Unit_hipGraphClone_Test_hipGraphEventRecordNodeSetEvent_and_Exec) {
   hipGraphClone_Test_hipGraphEventRecordNodeSetEvent_and_Exec();
 }
 
@@ -1480,7 +1480,7 @@ static void hipGraphClone_Test_hipGraphEventWaitNodeSetEvent_and_Exec() {
   HIP_CHECK(hipEventDestroy(event_1));
 }
 
-TEST_CASE("Unit_hipGraphClone_Test_hipGraphEventWaitNodeSetEvent_and_Exec") {
+TEST_CASE(Unit_hipGraphClone_Test_hipGraphEventWaitNodeSetEvent_and_Exec) {
   hipGraphClone_Test_hipGraphEventWaitNodeSetEvent_and_Exec();
 }
 
@@ -1490,7 +1490,7 @@ TEST_CASE("Unit_hipGraphClone_Test_hipGraphEventWaitNodeSetEvent_and_Exec") {
  Execute both original graph and cloned graph in loop: with multiple device.
  Loop: Update input data -> Launch Graph -> Validate output data -> Goto Loop */
 
-TEST_CASE("Unit_hipGraphClone_address_change_in_loop", "[multigpu]") {
+TEST_CASE(Unit_hipGraphClone_address_change_in_loop) {
   constexpr size_t Nbytes = N * sizeof(int);
   constexpr auto blocksPerCU = 6;  // to hide latency
   constexpr auto threadsPerBlock = 256;
@@ -1644,7 +1644,7 @@ static void hipGraphClone_address_change_in_thread(hipGraph_t* graph, hipGraphNo
  memory addresses in each Node and create executable graphs.
  Launch the graphs in their respective GPUs. Validate the outputs. */
 
-TEST_CASE("Unit_hipGraphClone_address_change_in_thread", "[multigpu]") {
+TEST_CASE(Unit_hipGraphClone_address_change_in_thread) {
   constexpr size_t Nbytes = N * sizeof(int);
   constexpr auto blocksPerCU = 6;  // to hide latency
   constexpr auto threadsPerBlock = 256;
@@ -1735,7 +1735,7 @@ static void hipGraphClone_Test_All_API(int dev) {
  Create a graph with Memcpy and Kernel nodes. and its cloned graph.
  Run all the above writen test cases for multiple GPU scenarios */
 
-TEST_CASE("Unit_hipGraphClone_multi_GPU_test", "[multigpu]") {
+TEST_CASE(Unit_hipGraphClone_multi_GPU_test) {
   // FIXME: This test tests 3D as well, decouple it
   CHECK_IMAGE_SUPPORT
 
@@ -1768,7 +1768,7 @@ static void destroyFloatObj(void* ptr) {
  Launch the graphs. Validate the outputs. Release the reference by calling
  hipGraphReleaseUserObject with count. */
 
-TEST_CASE("Unit_hipGraphClone_hipUserObject_hipGraphUserObject") {
+TEST_CASE(Unit_hipGraphClone_hipUserObject_hipGraphUserObject) {
   ComplexGrph cg;  // This will create skeleton of Graph and ClonedGraph
 
   int* object_i = new int();
@@ -1805,7 +1805,7 @@ TEST_CASE("Unit_hipGraphClone_hipUserObject_hipGraphUserObject") {
  (Negative - Check this should give error and reference was created for
  Oroginal graph and releasing it for other graph)*/
 
-TEST_CASE("Unit_hipGraphClone_hipUserObject_hipGraphUserObject_Negative") {
+TEST_CASE(Unit_hipGraphClone_hipUserObject_hipGraphUserObject_Negative) {
   ComplexGrph cg;  // This will create skeleton of Graph and ClonedGraph
 
   int* object_i = new int();
@@ -1847,7 +1847,7 @@ TEST_CASE("Unit_hipGraphClone_hipUserObject_hipGraphUserObject_Negative") {
  (Negative - Check this should give error and reference was created for
  Oroginal graph and releasing it for other graph) */
 
-TEST_CASE("Unit_hipGraphChild_hipUserObject_hipGraphUserObject") {
+TEST_CASE(Unit_hipGraphChild_hipUserObject_hipGraphUserObject) {
   constexpr size_t Nbytes = N * sizeof(int);
   constexpr auto blocksPerCU = 6;  // to hide latency
   constexpr auto threadsPerBlock = 256;

--- a/projects/hip-tests/catch/unit/graph/hipGraphCreate.cc
+++ b/projects/hip-tests/catch/unit/graph/hipGraphCreate.cc
@@ -40,7 +40,7 @@ THE SOFTWARE.
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_hipGraphCreate_Negative_Parameters") {
+TEST_CASE(Unit_hipGraphCreate_Negative_Parameters) {
   hipGraph_t graph = nullptr;
 
   SECTION("pGraph is nullptr") {
@@ -62,7 +62,7 @@ TEST_CASE("Unit_hipGraphCreate_Negative_Parameters") {
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_hipGraphCreate_Positive_Basic") {
+TEST_CASE(Unit_hipGraphCreate_Positive_Basic) {
   hipGraph_t graph = nullptr;
 
   HIP_CHECK(hipGraphCreate(&graph, 0));

--- a/projects/hip-tests/catch/unit/graph/hipGraphCycle.cc
+++ b/projects/hip-tests/catch/unit/graph/hipGraphCycle.cc
@@ -34,7 +34,7 @@ Testcase Scenarios :
  * Adding manual empty nodes
  * Cyclic graph, cycle formation first, then adding more nodes
  */
-TEST_CASE("Unit_hipGraph_BasicCyclic1") {
+TEST_CASE(Unit_hipGraph_BasicCyclic1) {
   hipGraph_t graph;
   hipStream_t streamForGraph;
   hipGraphExec_t graphExec;
@@ -64,7 +64,7 @@ TEST_CASE("Unit_hipGraph_BasicCyclic1") {
  * Adding manual empty nodes
  * Cyclic graph, cycle formation first, Remove edge to resolve cycle
  */
-TEST_CASE("Unit_hipGraph_BasicCyclic2") {
+TEST_CASE(Unit_hipGraph_BasicCyclic2) {
   hipGraph_t graph;
   hipStream_t streamForGraph;
   hipGraphExec_t graphExec;
@@ -95,7 +95,7 @@ TEST_CASE("Unit_hipGraph_BasicCyclic2") {
  * Cyclic graph, cycle formation first, Remove edge causes disconnected graph which is still
  * cyclic
  */
-TEST_CASE("Unit_hipGraph_BasicCyclic3") {
+TEST_CASE(Unit_hipGraph_BasicCyclic3) {
   hipGraph_t graph;
   hipStream_t streamForGraph;
   hipGraphExec_t graphExec;
@@ -126,7 +126,7 @@ TEST_CASE("Unit_hipGraph_BasicCyclic3") {
  * Adding manual empty nodes
  * Uncyclic graph, removing edge from middle of linear graph
  */
-TEST_CASE("Unit_hipGraph_BasicCyclic4") {
+TEST_CASE(Unit_hipGraph_BasicCyclic4) {
   int N = 1024 * 1024;
   int Nbytes = N * sizeof(int);
   hipGraph_t graph;
@@ -185,7 +185,7 @@ TEST_CASE("Unit_hipGraph_BasicCyclic4") {
  * Adding manual empty nodes
  * cyclic graph, removing edge to resolve cycle and remove edge from middle of graph
  */
-TEST_CASE("Unit_hipGraph_BasicCyclic5") {
+TEST_CASE(Unit_hipGraph_BasicCyclic5) {
   int N = 1024 * 1024;
   int Nbytes = N * sizeof(int);
   hipGraph_t graph;

--- a/projects/hip-tests/catch/unit/graph/hipGraphDebugDotPrint.cc
+++ b/projects/hip-tests/catch/unit/graph/hipGraphDebugDotPrint.cc
@@ -282,7 +282,7 @@ static void hipGraphDebugDotPrint_Functional(const char* fName, unsigned int fla
    Call hipGraphDebugDotPrint and provice path where to write the DOT file.
    Verify that DOT file get created or not for each flag passed. */
 
-TEST_CASE("Unit_hipGraphDebugDotPrint_Functional") {
+TEST_CASE(Unit_hipGraphDebugDotPrint_Functional) {
   CHECK_IMAGE_SUPPORT
 
   SECTION("Call with hipGraphDebugDotFlagsVerbose flag") {
@@ -343,7 +343,7 @@ TEST_CASE("Unit_hipGraphDebugDotPrint_Functional") {
 
 #define DOT_FILE_PATH_NEG "./graphDotFileNeg.dot"
 
-TEST_CASE("Unit_hipGraphDebugDotPrint_Argument_Check") {
+TEST_CASE(Unit_hipGraphDebugDotPrint_Argument_Check) {
   hipGraph_t graph;
   hipError_t ret;
 

--- a/projects/hip-tests/catch/unit/graph/hipGraphDestroy.cc
+++ b/projects/hip-tests/catch/unit/graph/hipGraphDestroy.cc
@@ -39,7 +39,7 @@ THE SOFTWARE.
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_hipGraphDestroy_Positive_Basic") {
+TEST_CASE(Unit_hipGraphDestroy_Positive_Basic) {
   hipGraph_t graph = nullptr;
 
   HIP_CHECK(hipGraphCreate(&graph, 0));
@@ -60,7 +60,7 @@ TEST_CASE("Unit_hipGraphDestroy_Positive_Basic") {
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_hipGraphDestroy_Negative_Parameters") {
+TEST_CASE(Unit_hipGraphDestroy_Negative_Parameters) {
   HIP_CHECK_ERROR(hipGraphDestroy(static_cast<hipGraph_t>(nullptr)), hipErrorInvalidValue);
 }
 

--- a/projects/hip-tests/catch/unit/graph/hipGraphDestroyNode.cc
+++ b/projects/hip-tests/catch/unit/graph/hipGraphDestroyNode.cc
@@ -56,7 +56,7 @@ static __global__ void dummyKernel() { return; }
 
 /* This test covers the negative scenarios of
    hipGraphDestroyNode API */
-TEST_CASE("Unit_hipGraphDestroyNode_Negative") {
+TEST_CASE(Unit_hipGraphDestroyNode_Negative) {
   SECTION("Passing nullptr to graph Node") {
     REQUIRE(hipGraphDestroyNode(nullptr) == hipErrorInvalidValue);
   }
@@ -66,7 +66,7 @@ TEST_CASE("Unit_hipGraphDestroyNode_Negative") {
    hipGraphDestroyNode API where we create and destroy
    the node
 */
-TEST_CASE("Unit_hipGraphDestroyNode_BasicFunctionality") {
+TEST_CASE(Unit_hipGraphDestroyNode_BasicFunctionality) {
   char* pOutBuff_d{};
   constexpr size_t size = 1024;
   hipGraph_t graph{};
@@ -92,7 +92,7 @@ This testcase verifies the following scenario where
 graph is created with dependencies and one of the dependency is
 destroyed before execute the graph
 */
-TEST_CASE("Unit_hipGraphDestroyNode_DestroyDependencyNode") {
+TEST_CASE(Unit_hipGraphDestroyNode_DestroyDependencyNode) {
   constexpr size_t N = 1024;
   constexpr size_t Nbytes = N * sizeof(int);
   constexpr auto blocksPerCU = 6;  // to hide latency
@@ -157,7 +157,7 @@ TEST_CASE("Unit_hipGraphDestroyNode_DestroyDependencyNode") {
  * Functional Test to test hipGraphDestroyNode using hipGraphGetNodes
  * and hipGraphGetEdges APIs.
  */
-TEST_CASE("Unit_hipGraphDestroyNode_Complx_ChkNumOfNodesNDep") {
+TEST_CASE(Unit_hipGraphDestroyNode_Complx_ChkNumOfNodesNDep) {
   hipGraph_t graph;
   hipGraphNode_t kernelnode[NUM_OF_DUMMY_NODES];
   hipKernelNodeParams kernelNodeParams[NUM_OF_DUMMY_NODES];
@@ -197,7 +197,7 @@ TEST_CASE("Unit_hipGraphDestroyNode_Complx_ChkNumOfNodesNDep") {
  * Functional Test to test hipGraphDestroyNode using hipGraphGetNodes
  * and hipGraphGetEdges APIs on a cloned graph
  */
-TEST_CASE("Unit_hipGraphDestroyNode_Complx_ChkNumOfNodesNDep_ClonedGrph") {
+TEST_CASE(Unit_hipGraphDestroyNode_Complx_ChkNumOfNodesNDep_ClonedGrph) {
   hipGraph_t graph, clonedgraph;
   hipGraphNode_t kernelnode[NUM_OF_DUMMY_NODES];
   hipKernelNodeParams kernelNodeParams[NUM_OF_DUMMY_NODES];
@@ -243,7 +243,7 @@ TEST_CASE("Unit_hipGraphDestroyNode_Complx_ChkNumOfNodesNDep_ClonedGrph") {
  * Functional Test to test hipGraphDestroyNode on child node using
  * hipGraphGetNodes and hipGraphGetEdges APIs on a cloned graph.
  */
-TEST_CASE("Unit_hipGraphDestroyNode_Complx_ChkNumOfNodesNDep_ChldNode") {
+TEST_CASE(Unit_hipGraphDestroyNode_Complx_ChkNumOfNodesNDep_ChldNode) {
   hipGraph_t graph0, graph1;
   hipGraphNode_t kernelnode[NUM_OF_DUMMY_NODES], childGraphNode;
   hipKernelNodeParams kernelNodeParams[NUM_OF_DUMMY_NODES];

--- a/projects/hip-tests/catch/unit/graph/hipGraphEventRecordNodeGetEvent.cc
+++ b/projects/hip-tests/catch/unit/graph/hipGraphEventRecordNodeGetEvent.cc
@@ -55,7 +55,7 @@ static void validateEventRecordNodeGetEvent(unsigned flag) {
 /**
  * Scenario: Validate scenario 1 for different event flags.
  */
-TEST_CASE("Unit_hipGraphEventRecordNodeGetEvent_Functional") {
+TEST_CASE(Unit_hipGraphEventRecordNodeGetEvent_Functional) {
   // Create event nodes with different flags and validate with
   // hipGraphEventRecordNodeGetEvent.
   SECTION("Flag = hipEventDefault") { validateEventRecordNodeGetEvent(hipEventDefault); }
@@ -70,7 +70,7 @@ TEST_CASE("Unit_hipGraphEventRecordNodeGetEvent_Functional") {
 /**
  * Scenario 2: Negative tests.
  */
-TEST_CASE("Unit_hipGraphEventRecordNodeGetEvent_Negative") {
+TEST_CASE(Unit_hipGraphEventRecordNodeGetEvent_Negative) {
   hipGraph_t graph;
   HIP_CHECK(hipGraphCreate(&graph, 0));
   hipEvent_t event_out;

--- a/projects/hip-tests/catch/unit/graph/hipGraphEventRecordNodeSetEvent.cc
+++ b/projects/hip-tests/catch/unit/graph/hipGraphEventRecordNodeSetEvent.cc
@@ -86,7 +86,7 @@ static void setEventWaitNode() {
 /**
  * Scenario 2: Validate Change of event property in event record node.
  */
-TEST_CASE("Unit_hipGraphEventRecordNodeSetEvent_SetEventProperty") {
+TEST_CASE(Unit_hipGraphEventRecordNodeSetEvent_SetEventProperty) {
   hipGraph_t graph;
   HIP_CHECK(hipGraphCreate(&graph, 0));
   // Create events
@@ -155,7 +155,7 @@ TEST_CASE("Unit_hipGraphEventRecordNodeSetEvent_SetEventProperty") {
 /**
  * Scenario 1: Validate Set Get test for all Event flags
  */
-TEST_CASE("Unit_hipGraphEventRecordNodeSetEvent_SetGet") {
+TEST_CASE(Unit_hipGraphEventRecordNodeSetEvent_SetGet) {
   SECTION("Flag = hipEventDefault") { validateEventRecordNodeSetEvent(hipEventDefault); }
 
   SECTION("Flag = hipEventBlockingSync") { validateEventRecordNodeSetEvent(hipEventBlockingSync); }
@@ -168,7 +168,7 @@ TEST_CASE("Unit_hipGraphEventRecordNodeSetEvent_SetGet") {
 /**
  * Scenario 3: Negative Tests
  */
-TEST_CASE("Unit_hipGraphEventRecordNodeSetEvent_Negative") {
+TEST_CASE(Unit_hipGraphEventRecordNodeSetEvent_Negative) {
   hipGraph_t graph;
   HIP_CHECK(hipGraphCreate(&graph, 0));
   hipEvent_t event1, event2;

--- a/projects/hip-tests/catch/unit/graph/hipGraphEventWaitNodeGetEvent.cc
+++ b/projects/hip-tests/catch/unit/graph/hipGraphEventWaitNodeGetEvent.cc
@@ -56,7 +56,7 @@ static void validateEventWaitNodeGetEvent(unsigned flag) {
 /**
  * Scenario 1
  */
-TEST_CASE("Unit_hipGraphEventWaitNodeGetEvent_Functional") {
+TEST_CASE(Unit_hipGraphEventWaitNodeGetEvent_Functional) {
   // Create event nodes with different flags and validate with
   // hipGraphEventWaitNodeGetEvent.
   SECTION("Flag = hipEventDefault") { validateEventWaitNodeGetEvent(hipEventDefault); }
@@ -69,7 +69,7 @@ TEST_CASE("Unit_hipGraphEventWaitNodeGetEvent_Functional") {
 /**
  * Scenario 2
  */
-TEST_CASE("Unit_hipGraphEventWaitNodeGetEvent_Negative") {
+TEST_CASE(Unit_hipGraphEventWaitNodeGetEvent_Negative) {
   hipGraph_t graph;
   HIP_CHECK(hipGraphCreate(&graph, 0));
   hipEvent_t event_out;

--- a/projects/hip-tests/catch/unit/graph/hipGraphEventWaitNodeSetEvent.cc
+++ b/projects/hip-tests/catch/unit/graph/hipGraphEventWaitNodeSetEvent.cc
@@ -88,7 +88,7 @@ static void setEventRecordNode() {
 /**
  * Scenario 2
  */
-TEST_CASE("Unit_hipGraphEventWaitNodeSetEvent_SetProp") {
+TEST_CASE(Unit_hipGraphEventWaitNodeSetEvent_SetProp) {
   constexpr size_t N = 512;
   size_t memsize = N * sizeof(int);
   constexpr auto blocksPerCU = 6;  // to hide latency
@@ -218,7 +218,7 @@ TEST_CASE("Unit_hipGraphEventWaitNodeSetEvent_SetProp") {
 /**
  * Scenario 1
  */
-TEST_CASE("Unit_hipGraphEventWaitNodeSetEvent_SetGet") {
+TEST_CASE(Unit_hipGraphEventWaitNodeSetEvent_SetGet) {
   SECTION("Flag = hipEventDefault") { validateEventWaitNodeSetEvent(hipEventDefault); }
 
   SECTION("Flag = hipEventBlockingSync") { validateEventWaitNodeSetEvent(hipEventBlockingSync); }
@@ -229,7 +229,7 @@ TEST_CASE("Unit_hipGraphEventWaitNodeSetEvent_SetGet") {
 /**
  * Scenario 3
  */
-TEST_CASE("Unit_hipGraphEventWaitNodeSetEvent_Negative") {
+TEST_CASE(Unit_hipGraphEventWaitNodeSetEvent_Negative) {
   hipGraph_t graph;
   HIP_CHECK(hipGraphCreate(&graph, 0));
   hipEvent_t event1, event2;

--- a/projects/hip-tests/catch/unit/graph/hipGraphExecBatchMemOpNodeSetParams.cc
+++ b/projects/hip-tests/catch/unit/graph/hipGraphExecBatchMemOpNodeSetParams.cc
@@ -39,7 +39,7 @@ THE SOFTWARE.
  * ------------------------
  *    - HIP_VERSION >= 6.4
  */
-TEST_CASE("Unit_hipGraphExecBatchMemOpNodeSetParams_NegativeTsts") {
+TEST_CASE(Unit_hipGraphExecBatchMemOpNodeSetParams_NegativeTsts) {
   HIP_CHECK(hipInit(0));
   hipGraph_t graph, graph1;
   hipGraphExec_t graphExec;

--- a/projects/hip-tests/catch/unit/graph/hipGraphExecChildGraphNodeSetParams.cc
+++ b/projects/hip-tests/catch/unit/graph/hipGraphExecChildGraphNodeSetParams.cc
@@ -40,7 +40,7 @@ THE SOFTWARE.
 #include <hip_test_kernels.hh>
 
 
-TEST_CASE("Unit_hipGraphExecChildGraphNodeSetParams_Negative") {
+TEST_CASE(Unit_hipGraphExecChildGraphNodeSetParams_Negative) {
   constexpr size_t N = 1024;
   constexpr size_t Nbytes = N * sizeof(int);
   hipGraph_t graph, childgraph1, childgraph2;
@@ -122,7 +122,7 @@ TEST_CASE("Unit_hipGraphExecChildGraphNodeSetParams_Negative") {
    using hipGraphExecChildGraphNodeSetParams API
    and execute it
    */
-TEST_CASE("Unit_hipGraphExecChildGraphNodeSetParams_BasicFunc") {
+TEST_CASE(Unit_hipGraphExecChildGraphNodeSetParams_BasicFunc) {
   constexpr size_t N = 1024;
   constexpr size_t Nbytes = N * sizeof(int);
   hipGraph_t graph, childgraph1, childgraph2;
@@ -194,7 +194,7 @@ TEST_CASE("Unit_hipGraphExecChildGraphNodeSetParams_BasicFunc") {
    using hipGraphExecChildGraphNodeSetParams API
    and execute it
    */
-TEST_CASE("Unit_hipGraphExecChildGraphNodeSetParams_ChildTopology") {
+TEST_CASE(Unit_hipGraphExecChildGraphNodeSetParams_ChildTopology) {
   constexpr size_t N = 1024;
   constexpr size_t Nbytes = N * sizeof(int);
   constexpr auto blocksPerCU = 6;  // to hide latency

--- a/projects/hip-tests/catch/unit/graph/hipGraphExecDestroy.cc
+++ b/projects/hip-tests/catch/unit/graph/hipGraphExecDestroy.cc
@@ -40,7 +40,7 @@ THE SOFTWARE.
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_hipGraphExecDestroy_Negative_Parameters") {
+TEST_CASE(Unit_hipGraphExecDestroy_Negative_Parameters) {
   SECTION("Pass hipGraphExecDestroy with nullptr") {
     HIP_CHECK_ERROR(hipGraphExecDestroy(nullptr), hipErrorInvalidValue);
   }
@@ -63,7 +63,7 @@ TEST_CASE("Unit_hipGraphExecDestroy_Negative_Parameters") {
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_hipGraphExecDestroy_Positive_Basic") {
+TEST_CASE(Unit_hipGraphExecDestroy_Positive_Basic) {
   hipGraph_t graph;
   hipGraphExec_t graphExec;
   hipStream_t streamForGraph;

--- a/projects/hip-tests/catch/unit/graph/hipGraphExecEventRecordNodeSetEvent.cc
+++ b/projects/hip-tests/catch/unit/graph/hipGraphExecEventRecordNodeSetEvent.cc
@@ -65,7 +65,7 @@ static __global__ void copy_ker_func(int* a, int* b, size_t N) {
 /**
  * Scenario 1: Functional scenario (See description Above)
  */
-TEST_CASE("Unit_hipGraphExecEventRecordNodeSetEvent_Functional") {
+TEST_CASE(Unit_hipGraphExecEventRecordNodeSetEvent_Functional) {
   constexpr size_t gridSize = 512;
   constexpr size_t blockSize = 512;
   constexpr size_t N = gridSize * blockSize;
@@ -162,7 +162,7 @@ TEST_CASE("Unit_hipGraphExecEventRecordNodeSetEvent_Functional") {
  * Scenario 2: This test verifies that changes to executable graph does
  * not impact the original graph.
  */
-TEST_CASE("Unit_hipGraphExecEventRecordNodeSetEvent_VerifyEventNotChanged") {
+TEST_CASE(Unit_hipGraphExecEventRecordNodeSetEvent_VerifyEventNotChanged) {
   hipGraph_t graph;
   HIP_CHECK(hipGraphCreate(&graph, 0));
   hipEvent_t event1, event2, event_out;
@@ -187,8 +187,7 @@ TEST_CASE("Unit_hipGraphExecEventRecordNodeSetEvent_VerifyEventNotChanged") {
  * Scenario 3: This test verifies event in node of the executable graph can be changed to event on
  * different device
  */
-TEST_CASE("Unit_hipGraphExecEventRecordNodeSetEvent_Positive_DifferentDevices",
-          "[multigpu]") {
+TEST_CASE(Unit_hipGraphExecEventRecordNodeSetEvent_Positive_DifferentDevices) {
   const auto device_count = HipTest::getDeviceCount();
   if (device_count < 2) {
     HipTest::HIP_SKIP_TEST("Skipping because devices < 2");
@@ -228,7 +227,7 @@ TEST_CASE("Unit_hipGraphExecEventRecordNodeSetEvent_Positive_DifferentDevices",
 /**
  * Scenario 4: Negative Parameter Tests
  */
-TEST_CASE("Unit_hipGraphExecEventRecordNodeSetEvent_Negative") {
+TEST_CASE(Unit_hipGraphExecEventRecordNodeSetEvent_Negative) {
   hipGraph_t graph;
   HIP_CHECK(hipGraphCreate(&graph, 0));
   hipEvent_t event1, event2;

--- a/projects/hip-tests/catch/unit/graph/hipGraphExecEventWaitNodeSetEvent.cc
+++ b/projects/hip-tests/catch/unit/graph/hipGraphExecEventWaitNodeSetEvent.cc
@@ -62,7 +62,7 @@ static __global__ void sqr_ker_func(int* a, int* b, size_t N) {
 /**
  * Scenario 1: Test to validate setting different events in executable graph.
  */
-TEST_CASE("Unit_hipGraphExecEventWaitNodeSetEvent_SetAndVerifyMemory") {
+TEST_CASE(Unit_hipGraphExecEventWaitNodeSetEvent_SetAndVerifyMemory) {
   constexpr size_t gridSize = 64;
   constexpr size_t blockSize = 256;
   constexpr size_t N = gridSize * blockSize;
@@ -176,7 +176,7 @@ TEST_CASE("Unit_hipGraphExecEventWaitNodeSetEvent_SetAndVerifyMemory") {
  * Scenario 2: Test to validate setting a different event in an executable
  * graph does not impact the original graph and nodes.
  */
-TEST_CASE("Unit_hipGraphExecEventWaitNodeSetEvent_VerifyEventNotChanged") {
+TEST_CASE(Unit_hipGraphExecEventWaitNodeSetEvent_VerifyEventNotChanged) {
   hipGraph_t graph;
   HIP_CHECK(hipGraphCreate(&graph, 0));
   hipEvent_t event1, event2, event_out;
@@ -200,7 +200,7 @@ TEST_CASE("Unit_hipGraphExecEventWaitNodeSetEvent_VerifyEventNotChanged") {
 /**
  * Scenario 3: Negative and Parameter Tests.
  */
-TEST_CASE("Unit_hipGraphExecEventWaitNodeSetEvent_Negative") {
+TEST_CASE(Unit_hipGraphExecEventWaitNodeSetEvent_Negative) {
   hipGraph_t graph;
   HIP_CHECK(hipGraphCreate(&graph, 0));
   hipEvent_t event1, event2;

--- a/projects/hip-tests/catch/unit/graph/hipGraphExecGetFlags.cc
+++ b/projects/hip-tests/catch/unit/graph/hipGraphExecGetFlags.cc
@@ -38,7 +38,7 @@ THE SOFTWARE.
  * ------------------------
  *    - HIP_VERSION >= 6.4
  */
-TEST_CASE("Unit_hipGraphExecGetFlags_Negative") {
+TEST_CASE(Unit_hipGraphExecGetFlags_Negative) {
   hipGraphExec_t graphExec;
   unsigned long long flags;  // NOLINT
   constexpr size_t Nbytes = 10 * sizeof(int);
@@ -77,7 +77,7 @@ TEST_CASE("Unit_hipGraphExecGetFlags_Negative") {
  * ------------------------
  *    - HIP_VERSION >= 6.4
  */
-TEST_CASE("Unit_hipGraphExecGetFlags_Positive") {
+TEST_CASE(Unit_hipGraphExecGetFlags_Positive) {
   hipGraphExec_t graphExec;
   unsigned long long flags;  // NOLINT
   hipGraph_t graph;

--- a/projects/hip-tests/catch/unit/graph/hipGraphExecHostNodeSetParams.cc
+++ b/projects/hip-tests/catch/unit/graph/hipGraphExecHostNodeSetParams.cc
@@ -62,7 +62,7 @@ void callbackfunc_setparams(void* B_h) {
 This test case verifies the negative scenarios of
 hipGraphExecHostNodeSetParams API
 */
-TEST_CASE("Unit_hipGraphExecHostNodeSetParams_Negative") {
+TEST_CASE(Unit_hipGraphExecHostNodeSetParams_Negative) {
   constexpr size_t N = 1024;
   constexpr size_t Nbytes = N * sizeof(int);
   hipGraph_t graph;
@@ -154,7 +154,7 @@ Creates graph, Add graph nodes and clone the graph
 Add HostNode to the cloned graph,update the host params using
 hipGraphExecHostNodeSetParams API and validates the result
 */
-TEST_CASE("Unit_hipGraphExecHostNodeSetParams_ClonedGraphWithHostNode") {
+TEST_CASE(Unit_hipGraphExecHostNodeSetParams_ClonedGraphWithHostNode) {
   constexpr size_t N = 1024;
   constexpr size_t Nbytes = N * sizeof(int);
   hipGraph_t graph;
@@ -217,7 +217,7 @@ Create graph, Adds host node to the graph,
 updates the host params using hipGraphExecHostNodeSetParams API
 and validates the result
 */
-TEST_CASE("Unit_hipGraphExecHostNodeSetParams_BasicFunc") {
+TEST_CASE(Unit_hipGraphExecHostNodeSetParams_BasicFunc) {
   constexpr size_t N = 1024;
   constexpr size_t Nbytes = N * sizeof(int);
   hipGraph_t graph;

--- a/projects/hip-tests/catch/unit/graph/hipGraphExecKernelNodeSetParams.cc
+++ b/projects/hip-tests/catch/unit/graph/hipGraphExecKernelNodeSetParams.cc
@@ -39,7 +39,7 @@ Functional -
 /**
  * Negative Test for API hipGraphExecKernelNodeSetParams
  */
-TEST_CASE("Unit_hipGraphExecKernelNodeSetParams_Negative") {
+TEST_CASE(Unit_hipGraphExecKernelNodeSetParams_Negative) {
   constexpr size_t N = 1024;
   constexpr auto blocksPerCU = 6;  // to hide latency
   constexpr auto threadsPerBlock = 256;
@@ -128,7 +128,7 @@ TEST_CASE("Unit_hipGraphExecKernelNodeSetParams_Negative") {
 /**
  * Functional Test for API Exec Kernel Params
  */
-TEST_CASE("Unit_hipGraphExecKernelNodeSetParams_Functional") {
+TEST_CASE(Unit_hipGraphExecKernelNodeSetParams_Functional) {
   constexpr size_t N = 1024;
   constexpr size_t Nbytes = N * sizeof(int);
   constexpr auto blocksPerCU = 6;  // to hide latency

--- a/projects/hip-tests/catch/unit/graph/hipGraphExecMemcpyNodeSetParams.cc
+++ b/projects/hip-tests/catch/unit/graph/hipGraphExecMemcpyNodeSetParams.cc
@@ -51,7 +51,7 @@ THE SOFTWARE.
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_hipGraphExecMemcpyNodeSetParams_Positive_Basic") {
+TEST_CASE(Unit_hipGraphExecMemcpyNodeSetParams_Positive_Basic) {
   constexpr auto f = [](void* dst, void* src, size_t count, hipMemcpyKind direction) {
     hipGraph_t graph = nullptr;
     HIP_CHECK(hipGraphCreate(&graph, 0));
@@ -158,7 +158,7 @@ TEST_CASE("Unit_hipGraphExecMemcpyNodeSetParams_Positive_Basic") {
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_hipGraphExecMemcpyNodeSetParams_Negative_Parameters") {
+TEST_CASE(Unit_hipGraphExecMemcpyNodeSetParams_Negative_Parameters) {
   using namespace std::placeholders;
   hipGraph_t graph = nullptr;
   HIP_CHECK(hipGraphCreate(&graph, 0));
@@ -230,7 +230,7 @@ TEST_CASE("Unit_hipGraphExecMemcpyNodeSetParams_Negative_Parameters") {
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_hipGraphExecMemcpyNodeSetParams_Negative_Changing_Memcpy_Direction") {
+TEST_CASE(Unit_hipGraphExecMemcpyNodeSetParams_Negative_Changing_Memcpy_Direction) {
   int *host, *dev, *src, *dst;
   HIP_CHECK(hipHostMalloc(&host, sizeof(int)));
   HIP_CHECK(hipMalloc(&dev, sizeof(int)));

--- a/projects/hip-tests/catch/unit/graph/hipGraphExecMemcpyNodeSetParams1D.cc
+++ b/projects/hip-tests/catch/unit/graph/hipGraphExecMemcpyNodeSetParams1D.cc
@@ -50,7 +50,7 @@ THE SOFTWARE.
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_hipGraphExecMemcpyNodeSetParams1D_Positive_Basic") {
+TEST_CASE(Unit_hipGraphExecMemcpyNodeSetParams1D_Positive_Basic) {
   constexpr auto f = [](void* dst, void* src, size_t count, hipMemcpyKind direction) {
     hipGraph_t graph = nullptr;
     HIP_CHECK(hipGraphCreate(&graph, 0));
@@ -151,7 +151,7 @@ TEST_CASE("Unit_hipGraphExecMemcpyNodeSetParams1D_Positive_Basic") {
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_hipGraphExecMemcpyNodeSetParams1D_Negative_Parameters") {
+TEST_CASE(Unit_hipGraphExecMemcpyNodeSetParams1D_Negative_Parameters) {
   using namespace std::placeholders;
   hipGraph_t graph = nullptr;
   HIP_CHECK(hipGraphCreate(&graph, 0));
@@ -217,7 +217,7 @@ TEST_CASE("Unit_hipGraphExecMemcpyNodeSetParams1D_Negative_Parameters") {
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_hipGraphExecMemcpyNodeSetParams1D_Negative_Changing_Memcpy_Direction") {
+TEST_CASE(Unit_hipGraphExecMemcpyNodeSetParams1D_Negative_Changing_Memcpy_Direction) {
   int *host1, *host2, *dev1, *dev2;
   HIP_CHECK(hipHostMalloc(&host1, sizeof(int)));
   HIP_CHECK(hipHostMalloc(&host2, sizeof(int)));

--- a/projects/hip-tests/catch/unit/graph/hipGraphExecMemcpyNodeSetParams1D_old.cc
+++ b/projects/hip-tests/catch/unit/graph/hipGraphExecMemcpyNodeSetParams1D_old.cc
@@ -45,7 +45,7 @@ the hipMemcpyKind from H2D to D2H but allocate pointer memory for H2D, api shoul
 
 /* Test verifies hipGraphExecMemcpyNodeSetParams1D API Functional scenarios.
  */
-TEST_CASE("Unit_hipGraphExecMemcpyNodeSetParams1D_Functional") {
+TEST_CASE(Unit_hipGraphExecMemcpyNodeSetParams1D_Functional) {
   constexpr size_t N = 1024;
   constexpr size_t Nbytes = N * sizeof(int);
   constexpr auto blocksPerCU = 6;  // to hide latency
@@ -117,7 +117,7 @@ TEST_CASE("Unit_hipGraphExecMemcpyNodeSetParams1D_Functional") {
 
 /* Test verifies hipGraphExecMemcpyNodeSetParams1D API Negative scenarios.
  */
-TEST_CASE("Unit_hipGraphExecMemcpyNodeSetParams1D_Negative") {
+TEST_CASE(Unit_hipGraphExecMemcpyNodeSetParams1D_Negative) {
   constexpr size_t N = 1024;
   constexpr size_t Nbytes = N * sizeof(int);
 

--- a/projects/hip-tests/catch/unit/graph/hipGraphExecMemcpyNodeSetParamsFromSymbol.cc
+++ b/projects/hip-tests/catch/unit/graph/hipGraphExecMemcpyNodeSetParamsFromSymbol.cc
@@ -98,7 +98,7 @@ void GraphExecMemcpyFromSymbolSetParamsShell(const void* symbol, const void* alt
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_hipGraphExecMemcpyNodeSetParamsFromSymbol_Positive_Basic") {
+TEST_CASE(Unit_hipGraphExecMemcpyNodeSetParamsFromSymbol_Positive_Basic) {
   SECTION("char") {
     HIP_GRAPH_MEMCPY_NODE_SET_PARAMS_TO_FROM_SYMBOL_TEST(GraphExecMemcpyFromSymbolSetParamsShell, 1,
                                                          char);
@@ -142,7 +142,7 @@ TEST_CASE("Unit_hipGraphExecMemcpyNodeSetParamsFromSymbol_Positive_Basic") {
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_hipGraphExecMemcpyNodeSetParamsFromSymbol_Negative_Parameters") {
+TEST_CASE(Unit_hipGraphExecMemcpyNodeSetParamsFromSymbol_Negative_Parameters) {
   using namespace std::placeholders;
   hipGraph_t graph = nullptr;
   HIP_CHECK(hipGraphCreate(&graph, 0));

--- a/projects/hip-tests/catch/unit/graph/hipGraphExecMemcpyNodeSetParamsFromSymbol_old.cc
+++ b/projects/hip-tests/catch/unit/graph/hipGraphExecMemcpyNodeSetParamsFromSymbol_old.cc
@@ -51,7 +51,7 @@ __device__ __constant__ int globalConst[SIZE];
 
 /* Test verifies hipGraphExecMemcpyNodeSetParamsFromSymbol API Negative scenarios.
  */
-TEST_CASE("Unit_hipGraphExecMemcpyNodeSetParamsFromSymbol_Negative") {
+TEST_CASE(Unit_hipGraphExecMemcpyNodeSetParamsFromSymbol_Negative) {
   constexpr size_t Nbytes = SIZE * sizeof(int);
   int *A_d{nullptr}, *B_d{nullptr};
   int *A_h{nullptr}, *B_h{nullptr};
@@ -232,7 +232,7 @@ static void hipGraphExecMemcpyNodeSetParamsFromSymbol_GlobalMem(bool useConstVar
   obtain executable graph and update the node params with set exec api call.
   Make sure they are taking effect.
  */
-TEST_CASE("Unit_hipGraphExecMemcpyNodeSetParamsFromSymbol_Functional") {
+TEST_CASE(Unit_hipGraphExecMemcpyNodeSetParamsFromSymbol_Functional) {
   SECTION("Check and update with Global Device Symbol Memory") {
     hipGraphExecMemcpyNodeSetParamsFromSymbol_GlobalMem(false);
   }

--- a/projects/hip-tests/catch/unit/graph/hipGraphExecMemcpyNodeSetParamsToSymbol.cc
+++ b/projects/hip-tests/catch/unit/graph/hipGraphExecMemcpyNodeSetParamsToSymbol.cc
@@ -98,7 +98,7 @@ void GraphExecMemcpyToSymbolSetParamsShell(const void* symbol, const void* alt_s
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_hipGraphExecMemcpyNodeSetParamsToSymbol_Positive_Basic") {
+TEST_CASE(Unit_hipGraphExecMemcpyNodeSetParamsToSymbol_Positive_Basic) {
   SECTION("char") {
     HIP_GRAPH_MEMCPY_NODE_SET_PARAMS_TO_FROM_SYMBOL_TEST(GraphExecMemcpyToSymbolSetParamsShell, 10,
                                                          char);
@@ -142,8 +142,7 @@ TEST_CASE("Unit_hipGraphExecMemcpyNodeSetParamsToSymbol_Positive_Basic") {
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_hipGraphExecMemcpyNodeSetParamsToSymbol_Negative_Parameters",
-          "[multigpu]") {
+TEST_CASE(Unit_hipGraphExecMemcpyNodeSetParamsToSymbol_Negative_Parameters) {
   using namespace std::placeholders;
   hipGraph_t graph = nullptr;
   HIP_CHECK(hipGraphCreate(&graph, 0));

--- a/projects/hip-tests/catch/unit/graph/hipGraphExecMemcpyNodeSetParamsToSymbol_old.cc
+++ b/projects/hip-tests/catch/unit/graph/hipGraphExecMemcpyNodeSetParamsToSymbol_old.cc
@@ -61,7 +61,7 @@ __global__ void MemcpyToConstSymbolExecKernel(int* B_d) {
 
 /* This testcase verifies negative scenarios of
    hipGraphExecMemcpyNodeSetParamsToSymbol API */
-TEST_CASE("Unit_hipGraphExecMemcpyNodeSetParamsToSymbol_Negative") {
+TEST_CASE(Unit_hipGraphExecMemcpyNodeSetParamsToSymbol_Negative) {
   constexpr size_t Nbytes = SIZE * sizeof(int);
   int *A_d{nullptr}, *B_d{nullptr}, *C_d{nullptr};
   int *A_h{nullptr}, *B_h{nullptr};
@@ -251,7 +251,7 @@ static void hipGraphExecMemcpyNodeSetParamsToSymbol_GlobalMem(bool useConstVar) 
   obtain executable graph and update the node params with set exec api call.
   Make sure they are taking effect.
  */
-TEST_CASE("Unit_hipGraphExecMemcpyNodeSetParamsToSymbol_Functional") {
+TEST_CASE(Unit_hipGraphExecMemcpyNodeSetParamsToSymbol_Functional) {
   SECTION("Check and update with Global Device Symbol Memory") {
     hipGraphExecMemcpyNodeSetParamsToSymbol_GlobalMem(false);
   }

--- a/projects/hip-tests/catch/unit/graph/hipGraphExecMemcpyNodeSetParams_old.cc
+++ b/projects/hip-tests/catch/unit/graph/hipGraphExecMemcpyNodeSetParams_old.cc
@@ -38,7 +38,7 @@ verify api returns error code.
 
 /* Test verifies hipGraphExecMemcpyNodeSetParams API Negative scenarios.
  */
-TEST_CASE("Unit_hipGraphExecMemcpyNodeSetParams_Negative") {
+TEST_CASE(Unit_hipGraphExecMemcpyNodeSetParams_Negative) {
   CHECK_IMAGE_SUPPORT
 
   constexpr int width{10}, height{10}, depth{10};
@@ -151,7 +151,7 @@ TEST_CASE("Unit_hipGraphExecMemcpyNodeSetParams_Negative") {
 
 /* Test verifies hipGraphExecMemcpyNodeSetParams API Functional scenarios.
  */
-TEST_CASE("Unit_hipGraphExecMemcpyNodeSetParams_Functional") {
+TEST_CASE(Unit_hipGraphExecMemcpyNodeSetParams_Functional) {
   CHECK_IMAGE_SUPPORT
 
   constexpr int XSIZE = 1024;

--- a/projects/hip-tests/catch/unit/graph/hipGraphExecMemsetNodeSetParams.cc
+++ b/projects/hip-tests/catch/unit/graph/hipGraphExecMemsetNodeSetParams.cc
@@ -53,7 +53,7 @@ THE SOFTWARE.
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEMPLATE_TEST_CASE("Unit_hipGraphExecMemsetNodeSetParams_Positive_Basic", "", uint8_t, uint16_t,
+TEMPLATE_TEST_CASE(Unit_hipGraphExecMemsetNodeSetParams_Positive_Basic, uint8_t, uint16_t,
                    uint32_t) {
   CHECK_IMAGE_SUPPORT
 
@@ -129,8 +129,7 @@ TEMPLATE_TEST_CASE("Unit_hipGraphExecMemsetNodeSetParams_Positive_Basic", "", ui
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_hipGraphExecMemsetNodeSetParams_Negative_Parameters",
-          "[multigpu]") {
+TEST_CASE(Unit_hipGraphExecMemsetNodeSetParams_Negative_Parameters) {
   // FIXME: this test tests 1D/2D/3D stuff in one single go, need to decouple it so that it can run
   // on devices with no image support
   CHECK_IMAGE_SUPPORT
@@ -192,7 +191,7 @@ TEST_CASE("Unit_hipGraphExecMemsetNodeSetParams_Negative_Parameters",
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_hipGraphExecMemsetNodeSetParams_Negative_Updating_Non1D_Node") {
+TEST_CASE(Unit_hipGraphExecMemsetNodeSetParams_Negative_Updating_Non1D_Node) {
   CHECK_IMAGE_SUPPORT
 
   hipGraph_t graph = nullptr;

--- a/projects/hip-tests/catch/unit/graph/hipGraphExecNodeSetParams.cc
+++ b/projects/hip-tests/catch/unit/graph/hipGraphExecNodeSetParams.cc
@@ -46,7 +46,7 @@ THE SOFTWARE.
  * ------------------------
  *    - HIP_VERSION >= 6.4
  */
-TEST_CASE("Unit_hipGraphExecNodeSetParams_Negative_Parameters") {
+TEST_CASE(Unit_hipGraphExecNodeSetParams_Negative_Parameters) {
   hipGraph_t graph;
   hipGraphExec_t graphExec;
   hipGraphNode_t node;
@@ -97,7 +97,7 @@ TEST_CASE("Unit_hipGraphExecNodeSetParams_Negative_Parameters") {
  * ------------------------
  *    - HIP_VERSION >= 6.4
  */
-TEST_CASE("Unit_hipGraphExecNodeSetParams_Positive") {
+TEST_CASE(Unit_hipGraphExecNodeSetParams_Positive) {
   hipGraph_t graph;
   hipGraphExec_t graphExec;
   hipGraphNode_t node;

--- a/projects/hip-tests/catch/unit/graph/hipGraphExecUpdate.cc
+++ b/projects/hip-tests/catch/unit/graph/hipGraphExecUpdate.cc
@@ -42,7 +42,7 @@ THE SOFTWARE.
  * ------------------------
  *  - HIP_VERSION >= 6.0
  */
-TEST_CASE("Unit_hipGraphExecUpdate_Negative_Basic") {
+TEST_CASE(Unit_hipGraphExecUpdate_Negative_Basic) {
   hipError_t ret;
   hipGraph_t graph{};
   hipGraphExec_t graphExec{};
@@ -79,7 +79,7 @@ TEST_CASE("Unit_hipGraphExecUpdate_Negative_Basic") {
  *  - HIP_VERSION >= 6.0
  */
 
-TEST_CASE("Unit_hipGraphExecUpdate_Negative_TypeChange") {
+TEST_CASE(Unit_hipGraphExecUpdate_Negative_TypeChange) {
   constexpr size_t N = 1024;
   constexpr size_t Nbytes = N * sizeof(char);
   constexpr size_t val = 0;
@@ -135,7 +135,7 @@ TEST_CASE("Unit_hipGraphExecUpdate_Negative_TypeChange") {
  *  - HIP_VERSION >= 6.0
  */
 
-TEST_CASE("Unit_hipGraphExecUpdate_Negative_CountDiffer") {
+TEST_CASE(Unit_hipGraphExecUpdate_Negative_CountDiffer) {
   constexpr size_t N = 1024;
   constexpr size_t Nbytes = N * sizeof(int);
   constexpr auto blocksPerCU = 6;  // to hide latency
@@ -231,7 +231,7 @@ TEST_CASE("Unit_hipGraphExecUpdate_Negative_CountDiffer") {
  *  - HIP_VERSION >= 6.0
  */
 
-TEST_CASE("Unit_hipGraphExecUpdate_Functional") {
+TEST_CASE(Unit_hipGraphExecUpdate_Functional) {
   constexpr size_t N = 1024;
   constexpr size_t Nbytes = N * sizeof(int);
   constexpr auto blocksPerCU = 6;  // to hide latency
@@ -336,7 +336,7 @@ TEST_CASE("Unit_hipGraphExecUpdate_Functional") {
  *  - HIP_VERSION >= 6.0
  */
 
-TEST_CASE("Unit_hipGraphExecUpdate_Negative_Functional_ParametersChanged") {
+TEST_CASE(Unit_hipGraphExecUpdate_Negative_Functional_ParametersChanged) {
   constexpr size_t N = 1024;
   constexpr size_t Nbytes = N * sizeof(int);
   int *A_d, *B_d, *C_d, *A_h, *B_h, *C_h;
@@ -390,7 +390,7 @@ TEST_CASE("Unit_hipGraphExecUpdate_Negative_Functional_ParametersChanged") {
  *  - HIP_VERSION >= 6.0
  */
 
-TEST_CASE("Unit_hipGraphExecUpdate_Negative_Functional_CountDiffer_1") {
+TEST_CASE(Unit_hipGraphExecUpdate_Negative_Functional_CountDiffer_1) {
   constexpr size_t N = 1024;
   constexpr size_t Nbytes = N * sizeof(int);
   int *A_d, *B_d, *C_d, *A_h, *B_h, *C_h;
@@ -444,7 +444,7 @@ TEST_CASE("Unit_hipGraphExecUpdate_Negative_Functional_CountDiffer_1") {
  *  - HIP_VERSION >= 6.0
  */
 
-TEST_CASE("Unit_hipGraphExecUpdate_Negative_Functional_CountDiffer_2") {
+TEST_CASE(Unit_hipGraphExecUpdate_Negative_Functional_CountDiffer_2) {
   constexpr size_t N = 1024;
   constexpr size_t Nbytes = N * sizeof(int);
   int *A_d, *B_d, *C_d, *A_h, *B_h, *C_h;
@@ -519,7 +519,7 @@ TEST_CASE("Unit_hipGraphExecUpdate_Negative_Functional_CountDiffer_2") {
  *  - HIP_VERSION >= 6.0
  */
 
-TEST_CASE("Unit_hipGraphExecUpdate_Negative_Dependent_NodesDiffer") {
+TEST_CASE(Unit_hipGraphExecUpdate_Negative_Dependent_NodesDiffer) {
   constexpr size_t N = 1024;
   constexpr size_t Nbytes = N * sizeof(int);
   int *A_d, *B_d, *C_d, *A_h, *B_h, *C_h;
@@ -578,7 +578,7 @@ TEST_CASE("Unit_hipGraphExecUpdate_Negative_Dependent_NodesDiffer") {
  *  - HIP_VERSION >= 6.0
  */
 
-TEST_CASE("Unit_hipGraphExecUpdate_Negative_NodeType_Changed") {
+TEST_CASE(Unit_hipGraphExecUpdate_Negative_NodeType_Changed) {
   constexpr size_t N = 1024;
   constexpr size_t Nbytes = N * sizeof(int);
   int *A_d, *B_d, *C_d, *A_h, *B_h, *C_h;
@@ -639,8 +639,7 @@ TEST_CASE("Unit_hipGraphExecUpdate_Negative_NodeType_Changed") {
  *  - HIP_VERSION >= 6.0
  */
 
-TEST_CASE("Unit_hipGraphExecUpdate_Negative_MultiDevice_Context_Changed",
-          "[multigpu]") {
+TEST_CASE(Unit_hipGraphExecUpdate_Negative_MultiDevice_Context_Changed) {
   constexpr size_t N = 1024;
   constexpr size_t Nbytes = N * sizeof(int);
   constexpr auto blocksPerCU = 6;  // to hide latency
@@ -740,7 +739,7 @@ TEST_CASE("Unit_hipGraphExecUpdate_Negative_MultiDevice_Context_Changed",
  *  - HIP_VERSION >= 6.0
  */
 
-TEST_CASE("Unit_hipGraphExecUpdate_Functional_KernelFunction_Changed") {
+TEST_CASE(Unit_hipGraphExecUpdate_Functional_KernelFunction_Changed) {
   constexpr size_t N = 1024;
   constexpr size_t Nbytes = N * sizeof(int);
   constexpr auto blocksPerCU = 6;  // to hide latency

--- a/projects/hip-tests/catch/unit/graph/hipGraphGetEdges.cc
+++ b/projects/hip-tests/catch/unit/graph/hipGraphGetEdges.cc
@@ -104,7 +104,7 @@ static void validate_hipGraphGetEdges_fromto(size_t testNumEdges, GraphGetNodesT
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_hipGraphGetEdges_Positive_Functional") {
+TEST_CASE(Unit_hipGraphGetEdges_Positive_Functional) {
   constexpr size_t N = 1024;
   hipGraph_t graph;
   int *A_d, *B_d, *C_d;
@@ -173,7 +173,7 @@ TEST_CASE("Unit_hipGraphGetEdges_Positive_Functional") {
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_hipGraphGetEdges_Positive_CapturedStream") {
+TEST_CASE(Unit_hipGraphGetEdges_Positive_CapturedStream) {
   hipGraph_t graph{nullptr};
   constexpr size_t N = 1024;
   constexpr int numMemcpy[2]{2, 3}, numKernel[2]{2, 3}, numMemset[2]{2, 0};
@@ -253,7 +253,7 @@ TEST_CASE("Unit_hipGraphGetEdges_Positive_CapturedStream") {
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_hipGraphGetEdges_Negative_Parameters") {
+TEST_CASE(Unit_hipGraphGetEdges_Negative_Parameters) {
   hipGraph_t graph{}, graph_uninit{};
   HIP_CHECK(hipGraphCreate(&graph, 0));
   hipGraphNode_t nodes_from[kNumOfEdges]{}, nodes_to[kNumOfEdges]{};

--- a/projects/hip-tests/catch/unit/graph/hipGraphGetNodes.cc
+++ b/projects/hip-tests/catch/unit/graph/hipGraphGetNodes.cc
@@ -54,7 +54,7 @@ inline constexpr size_t kNumOfNodes = 7;
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_hipGraphGetNodes_Positive_Functional") {
+TEST_CASE(Unit_hipGraphGetNodes_Positive_Functional) {
   using namespace std::placeholders;
   constexpr size_t N = 1024;
   hipGraph_t graph;
@@ -137,7 +137,7 @@ TEST_CASE("Unit_hipGraphGetNodes_Positive_Functional") {
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_hipGraphGetNodes_Positive_CapturedStream") {
+TEST_CASE(Unit_hipGraphGetNodes_Positive_CapturedStream) {
   hipGraph_t graph{nullptr};
   hipGraphExec_t graphExec{nullptr};
   constexpr size_t N = 1000000;
@@ -237,7 +237,7 @@ TEST_CASE("Unit_hipGraphGetNodes_Positive_CapturedStream") {
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_hipGraphGetNodes_Negative_Parameters") {
+TEST_CASE(Unit_hipGraphGetNodes_Negative_Parameters) {
   hipGraph_t graph{nullptr};
   size_t numNodes{0};
 

--- a/projects/hip-tests/catch/unit/graph/hipGraphGetRootNodes.cc
+++ b/projects/hip-tests/catch/unit/graph/hipGraphGetRootNodes.cc
@@ -54,7 +54,7 @@ inline constexpr size_t kNumOfRootNodes = 3;
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_hipGraphGetRootNodes_Positive_Functional") {
+TEST_CASE(Unit_hipGraphGetRootNodes_Positive_Functional) {
   using namespace std::placeholders;
   constexpr size_t N = 1024;
   hipGraph_t graph;
@@ -140,7 +140,7 @@ TEST_CASE("Unit_hipGraphGetRootNodes_Positive_Functional") {
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_hipGraphGetRootNodes_Positive_CapturedStream") {
+TEST_CASE(Unit_hipGraphGetRootNodes_Positive_CapturedStream) {
   hipStream_t streamForGraph{nullptr};
   hipGraph_t graph{nullptr};
   hipGraphExec_t graphExec{nullptr};
@@ -226,7 +226,7 @@ TEST_CASE("Unit_hipGraphGetRootNodes_Positive_CapturedStream") {
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_hipGraphGetRootNodes_Negative_Parameters") {
+TEST_CASE(Unit_hipGraphGetRootNodes_Negative_Parameters) {
   hipGraph_t graph{nullptr};
   size_t numRootNodes{0};
 

--- a/projects/hip-tests/catch/unit/graph/hipGraphGetRootNodes_old.cc
+++ b/projects/hip-tests/catch/unit/graph/hipGraphGetRootNodes_old.cc
@@ -52,7 +52,7 @@ static __global__ void dummyKernel() { return; }
 /**
  * Functional Test for API fetching root node list
  */
-TEST_CASE("Unit_hipGraphGetRootNodes_Functional") {
+TEST_CASE(Unit_hipGraphGetRootNodes_Functional) {
   constexpr size_t N = 1024;
   constexpr size_t Nbytes = N * sizeof(int);
   constexpr auto blocksPerCU = 6;  // to hide latency
@@ -155,7 +155,7 @@ TEST_CASE("Unit_hipGraphGetRootNodes_Functional") {
  * Create a graph with stream capture done on multiple dependent streams. Verify root nodes
  * of created graph are matching the operations pushed which doesn't have dependencies.
  */
-TEST_CASE("Unit_hipGraphGetRootNodes_CapturedStream") {
+TEST_CASE(Unit_hipGraphGetRootNodes_CapturedStream) {
   hipStream_t stream1{nullptr}, stream2{nullptr}, mstream{nullptr};
   hipStream_t streamForGraph{nullptr};
   hipEvent_t memsetEvent1, memsetEvent2, forkStreamEvent;
@@ -261,7 +261,7 @@ TEST_CASE("Unit_hipGraphGetRootNodes_CapturedStream") {
  * as input and output parameters and validates the behavior.
  * Test will include both negative and positive scenarios.
  */
-TEST_CASE("Unit_hipGraphGetRootNodes_ParamValidation") {
+TEST_CASE(Unit_hipGraphGetRootNodes_ParamValidation) {
   hipStream_t stream1{nullptr}, stream2{nullptr}, mstream{nullptr};
   hipEvent_t memsetEvent1, memsetEvent2, forkStreamEvent;
   hipGraph_t graph{nullptr};
@@ -358,7 +358,7 @@ TEST_CASE("Unit_hipGraphGetRootNodes_ParamValidation") {
  * Functional Test to validate number of root nodes when dependencies
  * in the graph are dynamically varied.
  */
-TEST_CASE("Unit_hipGraphGetRootNodes_Complx_NumRootNodes") {
+TEST_CASE(Unit_hipGraphGetRootNodes_Complx_NumRootNodes) {
   hipGraph_t graph;
   hipGraphNode_t kernelnode[NUM_OF_DUMMY_NODES];
   hipKernelNodeParams kernelNodeParams[NUM_OF_DUMMY_NODES];
@@ -391,7 +391,7 @@ TEST_CASE("Unit_hipGraphGetRootNodes_Complx_NumRootNodes") {
  * Functional Test to validate number of root nodes when dependencies
  * in the graph are dynamically varied in a cloned graph.
  */
-TEST_CASE("Unit_hipGraphGetRootNodes_Complx_NumRootNodes_ClonedGrph") {
+TEST_CASE(Unit_hipGraphGetRootNodes_Complx_NumRootNodes_ClonedGrph) {
   hipGraph_t graph, clonedgraph;
   hipGraphNode_t kernelnode[NUM_OF_DUMMY_NODES];
   hipKernelNodeParams kernelNodeParams[NUM_OF_DUMMY_NODES];
@@ -429,7 +429,7 @@ TEST_CASE("Unit_hipGraphGetRootNodes_Complx_NumRootNodes_ClonedGrph") {
  * Functional Test to validate number of root nodes when a graph with N
  * independent nodes is added as a child node to another graph.
  */
-TEST_CASE("Unit_hipGraphGetRootNodes_Complx_NRootNodesAsChildGraph") {
+TEST_CASE(Unit_hipGraphGetRootNodes_Complx_NRootNodesAsChildGraph) {
   hipGraph_t graph, graph1;
   hipGraphNode_t kernelnode[NUM_OF_DUMMY_NODES];
   hipKernelNodeParams kernelNodeParams[NUM_OF_DUMMY_NODES];

--- a/projects/hip-tests/catch/unit/graph/hipGraphHostNodeGetParams.cc
+++ b/projects/hip-tests/catch/unit/graph/hipGraphHostNodeGetParams.cc
@@ -59,7 +59,7 @@ static void callbackfunc_setparams(void* B_h) {
 This test case verifies the negative scenarios of
 hipGraphHostNodeGetParams API
 */
-TEST_CASE("Unit_hipGraphHostNodeGetParams_Negative") {
+TEST_CASE(Unit_hipGraphHostNodeGetParams_Negative) {
   constexpr size_t N = 1024;
   hipGraph_t graph;
   int *A_d{nullptr}, *C_d{nullptr};
@@ -102,7 +102,7 @@ Add HostNode to the cloned graph, update hostNode using hipGraphHostNodeSetParam
 then get the host node params using hipGraphHostNodeGetParams API  and
 compare it.
 */
-TEST_CASE("Unit_hipGraphHostNodeGetParams_ClonedGraphWithHostNode") {
+TEST_CASE(Unit_hipGraphHostNodeGetParams_ClonedGraphWithHostNode) {
   constexpr size_t N = 1024;
   constexpr size_t Nbytes = N * sizeof(int);
   hipGraph_t graph;
@@ -246,7 +246,7 @@ This test case verifies hipGraphHostNodeGetParams API by
 adding host node to graph and gets the host params and
 validates it
 */
-TEST_CASE("Unit_hipGraphHostNodeGetParams_BasicFunc") { hipGraphHostNodeGetParams_func(false); }
+TEST_CASE(Unit_hipGraphHostNodeGetParams_BasicFunc) { hipGraphHostNodeGetParams_func(false); }
 
 /*
 This test case verifies hipGraphHostNodeGetParams API by
@@ -254,4 +254,4 @@ adding host node to graph, updates host node params
 using hipGraphHostNodeSetParams  and gets the host params
 validates it
 */
-TEST_CASE("Unit_hipGraphHostNodeGetParams_SetParams") { hipGraphHostNodeGetParams_func(true); }
+TEST_CASE(Unit_hipGraphHostNodeGetParams_SetParams) { hipGraphHostNodeGetParams_func(true); }

--- a/projects/hip-tests/catch/unit/graph/hipGraphHostNodeSetParams.cc
+++ b/projects/hip-tests/catch/unit/graph/hipGraphHostNodeSetParams.cc
@@ -59,7 +59,7 @@ static void callbackfunc_setparams(void* B_h) {
 This test case verifies the negative scenarios of
 hipGraphHostNodeSetParams API
 */
-TEST_CASE("Unit_hipGraphHostNodeSetParams_Negative") {
+TEST_CASE(Unit_hipGraphHostNodeSetParams_Negative) {
   constexpr size_t N = 1024;
   hipGraph_t graph;
   int *A_d{nullptr}, *C_d{nullptr};
@@ -110,7 +110,7 @@ Creates graph, Add graph nodes and clone the graph
 Add HostNode to the cloned graph,update the host params using
 hipGraphHostNodeSetParams API and validates the result
 */
-TEST_CASE("Unit_hipGraphHostNodeSetParams_ClonedGraphWithHostNode") {
+TEST_CASE(Unit_hipGraphHostNodeSetParams_ClonedGraphWithHostNode) {
   constexpr size_t N = 1024;
   constexpr size_t Nbytes = N * sizeof(int);
   hipGraph_t graph;
@@ -170,7 +170,7 @@ Create graph, Adds host node to the graph,
 updates the host params using hipGraphHostNodeSetParams API
 and validates the result
 */
-TEST_CASE("Unit_hipGraphHostNodeSetParams_BasicFunc") {
+TEST_CASE(Unit_hipGraphHostNodeSetParams_BasicFunc) {
   constexpr size_t N = 1024;
   constexpr size_t Nbytes = N * sizeof(int);
   hipGraph_t graph;

--- a/projects/hip-tests/catch/unit/graph/hipGraphInstantiate.cc
+++ b/projects/hip-tests/catch/unit/graph/hipGraphInstantiate.cc
@@ -53,7 +53,7 @@ Negative -
 /* Test verifies hipGraphInstantiate API Negative scenarios.
  */
 
-TEST_CASE("Unit_hipGraphInstantiate_Negative") {
+TEST_CASE(Unit_hipGraphInstantiate_Negative) {
   hipError_t ret;
   hipGraphExec_t gExec{};
   hipGraph_t graph;
@@ -83,7 +83,7 @@ TEST_CASE("Unit_hipGraphInstantiate_Negative") {
 /* Test verifies hipGraphInstantiate Basic scenarios.
 Create a graph and then used it for hipGraphInstantiate without adding any node to graph.
  */
-TEST_CASE("Unit_hipGraphInstantiate_Basic") {
+TEST_CASE(Unit_hipGraphInstantiate_Basic) {
   hipGraph_t graph;
   hipGraphExec_t graphExec;
 
@@ -98,7 +98,7 @@ TEST_CASE("Unit_hipGraphInstantiate_Basic") {
 /* Test Functional Scenario 2.a, 2.b, 2.c with hipGraphInstantiate and
 hipGraphInstantiateWithFlags.
 */
-TEST_CASE("Unit_hipGraphInstantiate_InvalidCyclicGraph") {
+TEST_CASE(Unit_hipGraphInstantiate_InvalidCyclicGraph) {
   hipGraph_t graph;
   hipGraphExec_t graphExec;
   HIP_CHECK(hipGraphCreate(&graph, 0));
@@ -194,7 +194,7 @@ static void init_input(int* a, size_t size) {
 
 /* Test Functional Scenario 3.a, 3.b and 3.c.
  */
-TEST_CASE("Unit_hipGraphInstantiate_functionalScenarios") {
+TEST_CASE(Unit_hipGraphInstantiate_functionalScenarios) {
   hipGraph_t graph;
   hipGraphExec_t graphExec[NUM_OF_INSTANCES];
   HIP_CHECK(hipGraphCreate(&graph, 0));

--- a/projects/hip-tests/catch/unit/graph/hipGraphInstantiateWithFlags.cc
+++ b/projects/hip-tests/catch/unit/graph/hipGraphInstantiateWithFlags.cc
@@ -65,7 +65,7 @@ static __global__ void doubleKernel(int* arr, int size) {
 
 /* This test covers the negative scenarios of
    hipGraphInstantiateWithFlags API */
-TEST_CASE("Unit_hipGraphInstantiateWithFlags_Negative") {
+TEST_CASE(Unit_hipGraphInstantiateWithFlags_Negative) {
   SECTION("Passing nullptr pGraphExec") {
     hipGraph_t graph;
     HIP_CHECK(hipGraphCreate(&graph, 0));
@@ -259,7 +259,7 @@ This testcase verifies hipGraphInstantiateWithFlags API
 by creating dependency graph and instantiate, launching and verifying
 the result
 */
-TEST_CASE("Unit_hipGraphInstantiateWithFlags_DependencyGraph") {
+TEST_CASE(Unit_hipGraphInstantiateWithFlags_DependencyGraph) {
   GraphInstantiateWithFlags_DependencyGraph();
 }
 
@@ -268,7 +268,7 @@ This testcase verifies hipGraphInstantiateWithFlags API
 by creating dependency graph on GPU-0 and instantiate, launching and verifying
 the result on GPU-1
 */
-TEST_CASE("Unit_hipGraphInstantiateWithFlags_DependencyGraphDeviceCtxtChg", "[multigpu]") {
+TEST_CASE(Unit_hipGraphInstantiateWithFlags_DependencyGraphDeviceCtxtChg) {
   int numDevices = 0;
   int canAccessPeer = 0;
   HIP_CHECK(hipGetDeviceCount(&numDevices));
@@ -289,7 +289,7 @@ This testcase verifies hipGraphInstantiateWithFlags API
 by creating capture graph and instantiate, launching and verifying
 the result
 */
-TEST_CASE("Unit_hipGraphInstantiateWithFlags_StreamCapture") {
+TEST_CASE(Unit_hipGraphInstantiateWithFlags_StreamCapture) {
   int numDevices = 0;
   int canAccessPeer = 0;
   HIP_CHECK(hipGetDeviceCount(&numDevices));
@@ -310,7 +310,7 @@ This testcase verifies hipGraphInstantiateWithFlags API
 by creating capture graph on GPU-0 and instantiate, launching and verifying
 the result on GPU-1
 */
-TEST_CASE("Unit_hipGraphInstantiateWithFlags_StreamCaptureDeviceContextChg", "[multigpu]") {
+TEST_CASE(Unit_hipGraphInstantiateWithFlags_StreamCaptureDeviceContextChg) {
   int numDevices = 0;
   int canAccessPeer = 0;
   HIP_CHECK(hipGetDeviceCount(&numDevices));
@@ -335,7 +335,7 @@ Note - This test case is just to check if hipGraphInstantiateFlagAutoFreeOnLaunc
        is not resulting in compilation error or api failure. Real functional test
        will be added once the feature is fully implemented.
 */
-TEST_CASE("Unit_hipGraphInstantiateWithFlags_FlagAutoFreeOnLaunch_check") {
+TEST_CASE(Unit_hipGraphInstantiateWithFlags_FlagAutoFreeOnLaunch_check) {
   constexpr size_t size = 512 * 1024 * 1024;
   constexpr size_t Nbytes = size * sizeof(int);
 
@@ -408,7 +408,7 @@ TEST_CASE("Unit_hipGraphInstantiateWithFlags_FlagAutoFreeOnLaunch_check") {
  * ------------------------
  * - unit/graph/hipGraphInstantiateWithFlags.cc
  */
-TEST_CASE("Unit_hipGraphInstantiateWithFlags_AutoFreeOnLaunchInLoop") {
+TEST_CASE(Unit_hipGraphInstantiateWithFlags_AutoFreeOnLaunchInLoop) {
   constexpr size_t NBytes = 1024 * 1024 * 1024;
 
   void* devMem = nullptr;
@@ -470,7 +470,7 @@ TEST_CASE("Unit_hipGraphInstantiateWithFlags_AutoFreeOnLaunchInLoop") {
  * ------------------------
  * - unit/graph/hipGraphInstantiateWithFlags.cc
  */
-TEST_CASE("Unit_hipGraphInstantiateWithFlags_AutoFreeOnLaunchFillKernel") {
+TEST_CASE(Unit_hipGraphInstantiateWithFlags_AutoFreeOnLaunchFillKernel) {
   int value = 100;
 
   int* hostMemDst = new int[SIZE];
@@ -563,7 +563,7 @@ TEST_CASE("Unit_hipGraphInstantiateWithFlags_AutoFreeOnLaunchFillKernel") {
  * ------------------------
  * - unit/graph/hipGraphInstantiateWithFlags.cc
  */
-TEST_CASE("Unit_hipGraphInstantiateWithFlags_AutoFreeOnLaunchDoubleKernel") {
+TEST_CASE(Unit_hipGraphInstantiateWithFlags_AutoFreeOnLaunchDoubleKernel) {
   int* hostMemSrc = new int[SIZE];
   REQUIRE(hostMemSrc != nullptr);
 
@@ -670,7 +670,7 @@ TEST_CASE("Unit_hipGraphInstantiateWithFlags_AutoFreeOnLaunchDoubleKernel") {
  * ------------------------
  * - unit/graph/hipGraphInstantiateWithFlags.cc
  */
-TEST_CASE("Unit_hipGraphInstantiateWithFlags_WithDefaultAndAutoFreeOnLaunch") {
+TEST_CASE(Unit_hipGraphInstantiateWithFlags_WithDefaultAndAutoFreeOnLaunch) {
   int* hostMem1 = new int[SIZE];
   REQUIRE(hostMem1 != nullptr);
   int* hostMem2 = new int[SIZE];

--- a/projects/hip-tests/catch/unit/graph/hipGraphInstantiateWithParams.cc
+++ b/projects/hip-tests/catch/unit/graph/hipGraphInstantiateWithParams.cc
@@ -51,7 +51,7 @@ constexpr size_t N = 1000000;
 * ------------------------
 * - HIP_VERSION >= 6.2
 */
-TEST_CASE("Unit_hipGraphInstantiateWithParams_Negative") {
+TEST_CASE(Unit_hipGraphInstantiateWithParams_Negative) {
   SECTION("Passing nullptr pGraphExec") {
     hipGraph_t graph;
     hipGraphInstantiateParams params;
@@ -256,7 +256,7 @@ void GraphInstantiateWithParams_StreamCapture() {
  * ------------------------
  * - HIP_VERSION >= 6.2
  */
-TEST_CASE("Unit_hipGraphInstantiateWithParams_DependencyGraph") {
+TEST_CASE(Unit_hipGraphInstantiateWithParams_DependencyGraph) {
   GraphInstantiateWithParams_DependencyGraph();
 }
 
@@ -274,7 +274,7 @@ TEST_CASE("Unit_hipGraphInstantiateWithParams_DependencyGraph") {
  * ------------------------
  * - HIP_VERSION >= 6.2
  */
-TEST_CASE("Unit_hipGraphInstantiateWithParams_StreamCapture") {
+TEST_CASE(Unit_hipGraphInstantiateWithParams_StreamCapture) {
   GraphInstantiateWithParams_StreamCapture();
 }
 

--- a/projects/hip-tests/catch/unit/graph/hipGraphKernelNodeCopyAttributes.cc
+++ b/projects/hip-tests/catch/unit/graph/hipGraphKernelNodeCopyAttributes.cc
@@ -58,7 +58,7 @@ static bool validateKernelNodeAttrValue(hipKernelNodeAttrValue in, hipKernelNode
   return true;
 }
 
-TEST_CASE("Unit_hipGraphKernelNodeCopyAttributes_Functional") {
+TEST_CASE(Unit_hipGraphKernelNodeCopyAttributes_Functional) {
   constexpr size_t N = 1024;
   constexpr size_t Nbytes = N * sizeof(int);
   constexpr auto blocksPerCU = 6;  // to hide latency
@@ -212,7 +212,7 @@ TEST_CASE("Unit_hipGraphKernelNodeCopyAttributes_Functional") {
  *  - HIP_VERSION >= 5.6
  */
 
-TEST_CASE("Unit_hipGraphKernelNodeCopyAttributes_Attribute_Negative") {
+TEST_CASE(Unit_hipGraphKernelNodeCopyAttributes_Attribute_Negative) {
   constexpr size_t N = 1024;
   constexpr size_t Nbytes = N * sizeof(int);
   constexpr auto blocksPerCU = 6;  // to hide latency

--- a/projects/hip-tests/catch/unit/graph/hipGraphKernelNodeGetAttribute.cc
+++ b/projects/hip-tests/catch/unit/graph/hipGraphKernelNodeGetAttribute.cc
@@ -25,7 +25,7 @@ THE SOFTWARE.
 
 #define THREADS_PER_BLOCK 512
 
-TEST_CASE("Unit_hipGraphKernelNodeGetAttribute_Negative_Parameters") {
+TEST_CASE(Unit_hipGraphKernelNodeGetAttribute_Negative_Parameters) {
   constexpr int N = 1024;
 
   int *A_d, *B_d, *C_d;

--- a/projects/hip-tests/catch/unit/graph/hipGraphKernelNodeGetParams.cc
+++ b/projects/hip-tests/catch/unit/graph/hipGraphKernelNodeGetParams.cc
@@ -38,7 +38,7 @@ Functional -
 
 /* Test verifies hipGraphKernelNodeGetParams API Negative scenarios.
  */
-TEST_CASE("Unit_hipGraphKernelNodeGetParams_Negative") {
+TEST_CASE(Unit_hipGraphKernelNodeGetParams_Negative) {
   constexpr int N = 1024;
   size_t NElem{N};
   int *A_d, *B_d, *C_d;
@@ -106,7 +106,7 @@ static bool node_compare(hipKernelNodeParams* kNode1, hipKernelNodeParams* kNode
 
 /* Test verifies hipGraphKernelNodeGetParams API Functional scenarios.
  */
-TEST_CASE("Unit_hipGraphKernelNodeGetParams_Functional") {
+TEST_CASE(Unit_hipGraphKernelNodeGetParams_Functional) {
   constexpr int N = 1024;
   size_t NElem{N};
   int *A_d, *B_d, *C_d;

--- a/projects/hip-tests/catch/unit/graph/hipGraphKernelNodeSetAttribute.cc
+++ b/projects/hip-tests/catch/unit/graph/hipGraphKernelNodeSetAttribute.cc
@@ -39,7 +39,7 @@ static bool CompareAccessPolicyWindow(const hipKernelNodeAttrValue& lhs,
          lhs.accessPolicyWindow.missProp == rhs.accessPolicyWindow.missProp;
 }
 
-TEST_CASE("Unit_hipGraphKernelNodeSetAttribute_Positive_AccessPolicyWindow") {
+TEST_CASE(Unit_hipGraphKernelNodeSetAttribute_Positive_AccessPolicyWindow) {
   constexpr int N = 1024;
 
   const auto hit_prop = GENERATE(from_range(begin(kAccessProperties), end(kAccessProperties)));
@@ -93,7 +93,7 @@ TEST_CASE("Unit_hipGraphKernelNodeSetAttribute_Positive_AccessPolicyWindow") {
   HIP_CHECK(hipFree(C_d));
 }
 
-TEST_CASE("Unit_hipGraphKernelNodeSetAttribute_Positive_Cooperative") {
+TEST_CASE(Unit_hipGraphKernelNodeSetAttribute_Positive_Cooperative) {
   constexpr int N = 1024;
 
   int *A_d, *B_d, *C_d;
@@ -135,7 +135,7 @@ TEST_CASE("Unit_hipGraphKernelNodeSetAttribute_Positive_Cooperative") {
   HIP_CHECK(hipFree(C_d));
 }
 
-TEST_CASE("Unit_hipGraphKernelNodeSetAttribute_Negative_Parameters") {
+TEST_CASE(Unit_hipGraphKernelNodeSetAttribute_Negative_Parameters) {
   constexpr int N = 1024;
 
   int *A_d, *B_d, *C_d;

--- a/projects/hip-tests/catch/unit/graph/hipGraphKernelNodeSetAttribute_old.cc
+++ b/projects/hip-tests/catch/unit/graph/hipGraphKernelNodeSetAttribute_old.cc
@@ -57,7 +57,7 @@ static bool validateKernelNodeAttrValue(hipKernelNodeAttrValue in, hipKernelNode
   return true;
 }
 
-TEST_CASE("Unit_hipGraphKernelNodeSetAttribute_Functional") {
+TEST_CASE(Unit_hipGraphKernelNodeSetAttribute_Functional) {
   constexpr size_t N = 1024;
   constexpr size_t Nbytes = N * sizeof(int);
   constexpr auto blocksPerCU = 6;  // to hide latency
@@ -206,7 +206,7 @@ TEST_CASE("Unit_hipGraphKernelNodeSetAttribute_Functional") {
  *  - HIP_VERSION >= 5.6
  */
 
-TEST_CASE("Unit_hipGraphKernelNodeSetAttribute_Negative") {
+TEST_CASE(Unit_hipGraphKernelNodeSetAttribute_Negative) {
   constexpr size_t N = 1024;
   constexpr size_t Nbytes = N * sizeof(int);
   constexpr auto blocksPerCU = 6;  // to hide latency

--- a/projects/hip-tests/catch/unit/graph/hipGraphKernelNodeSetParams.cc
+++ b/projects/hip-tests/catch/unit/graph/hipGraphKernelNodeSetParams.cc
@@ -38,7 +38,7 @@ Functional -
 
 /* Test verifies hipGraphKernelNodeSetParams API Negative scenarios.
  */
-TEST_CASE("Unit_hipGraphKernelNodeSetParams_Negative") {
+TEST_CASE(Unit_hipGraphKernelNodeSetParams_Negative) {
   constexpr int N = 1024;
   size_t NElem{N};
   constexpr auto blocksPerCU = 6;  // to hide latency
@@ -101,7 +101,7 @@ TEST_CASE("Unit_hipGraphKernelNodeSetParams_Negative") {
 /**
  * Functional Test for API Set Kernel Params
  */
-TEST_CASE("Unit_hipGraphKernelNodeSetParams_Functional") {
+TEST_CASE(Unit_hipGraphKernelNodeSetParams_Functional) {
   constexpr size_t N = 1024;
   constexpr size_t Nbytes = N * sizeof(int);
   constexpr auto blocksPerCU = 6;  // to hide latency
@@ -264,7 +264,7 @@ class GraphKernelNodeGetSetParam {
   }
 };
 
-TEST_CASE("Unit_hipGraphKernelNodeGetSetParams_Functional") {
+TEST_CASE(Unit_hipGraphKernelNodeGetSetParams_Functional) {
   hipGraph_t* graph;
   hipStream_t streamForGraph;
   hipGraphExec_t graphExec;

--- a/projects/hip-tests/catch/unit/graph/hipGraphLaunch.cc
+++ b/projects/hip-tests/catch/unit/graph/hipGraphLaunch.cc
@@ -85,7 +85,7 @@ static void HipGraphLaunch_Positive_Simple(hipStream_t stream) {
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_hipGraphLaunch_Positive") {
+TEST_CASE(Unit_hipGraphLaunch_Positive) {
   SECTION("stream as a created stream") {
     hipStream_t stream;
     HIP_CHECK(hipStreamCreate(&stream));
@@ -113,7 +113,7 @@ TEST_CASE("Unit_hipGraphLaunch_Positive") {
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_hipGraphLaunch_Negative_Parameters") {
+TEST_CASE(Unit_hipGraphLaunch_Negative_Parameters) {
   SECTION("graphExec is nullptr and stream is a created stream") {
     hipStream_t stream;
     hipError_t ret;

--- a/projects/hip-tests/catch/unit/graph/hipGraphLaunch_old.cc
+++ b/projects/hip-tests/catch/unit/graph/hipGraphLaunch_old.cc
@@ -105,7 +105,7 @@ static void hipGraphLaunch_test() {
   HIP_CHECK(hipStreamDestroy(streamForGraph));
 }
 
-TEST_CASE("Unit_hipGraphLaunch_Functional_multidevice_test", "[multigpu]") {
+TEST_CASE(Unit_hipGraphLaunch_Functional_multidevice_test) {
   int numDevices = 0;
   HIP_CHECK(hipGetDeviceCount(&numDevices));
 
@@ -141,7 +141,7 @@ static void validateOutData(int* A1_h, int* A2_h, size_t N) {
  * 2.Create a graph with multiple nodes. Create an executable graph.
  * Verify if an executable graph be launched on null stream.
  */
-TEST_CASE("Unit_hipGraphLaunch_Functional_MultipleLaunch") {
+TEST_CASE(Unit_hipGraphLaunch_Functional_MultipleLaunch) {
   size_t memSize = SIZE;
   constexpr auto blocksPerCU = 6;  // to hide latency
   constexpr auto threadsPerBlock = 256;

--- a/projects/hip-tests/catch/unit/graph/hipGraphMemAllocNodeGetParams.cc
+++ b/projects/hip-tests/catch/unit/graph/hipGraphMemAllocNodeGetParams.cc
@@ -131,12 +131,11 @@ static void hipGraphMemAllocNodeGetParams_Functional(unsigned deviceId = 0) {
  *  - HIP_VERSION >= 6.0
  */
 
-TEST_CASE("Unit_hipGraphMem_Alloc_Free_NodeGetParams_Functional") {
+TEST_CASE(Unit_hipGraphMem_Alloc_Free_NodeGetParams_Functional) {
   hipGraphMemAllocNodeGetParams_Functional();
 }
 
-TEST_CASE("Unit_hipGraphMem_Alloc_Free_NodeGetParams_Functional_MultiDevice",
-          "[multigpu]") {
+TEST_CASE(Unit_hipGraphMem_Alloc_Free_NodeGetParams_Functional_MultiDevice) {
   int numDevices = 0;
   HIP_CHECK(hipGetDeviceCount(&numDevices));
 
@@ -164,7 +163,7 @@ TEST_CASE("Unit_hipGraphMem_Alloc_Free_NodeGetParams_Functional_MultiDevice",
  *  - HIP_VERSION >= 6.0
  */
 
-TEST_CASE("Unit_hipGraphMem_Alloc_Free_NodeGetParams_Functional_2") {
+TEST_CASE(Unit_hipGraphMem_Alloc_Free_NodeGetParams_Functional_2) {
   constexpr size_t N = 1024 * 1024;
   constexpr size_t Nbytes = N * sizeof(int);
   constexpr auto blocksPerCU = 6;  // to hide latency
@@ -277,7 +276,7 @@ TEST_CASE("Unit_hipGraphMem_Alloc_Free_NodeGetParams_Functional_2") {
  * ------------------------
  *  - HIP_VERSION >= 6.0
  */
-TEST_CASE("Unit_hipGraphMem_Alloc_Free_NodeGetParams_Functional_3") {
+TEST_CASE(Unit_hipGraphMem_Alloc_Free_NodeGetParams_Functional_3) {
   constexpr auto element_count{512 * 1024 * 1024};
   constexpr size_t num_bytes = element_count * sizeof(int);
 
@@ -370,7 +369,7 @@ TEST_CASE("Unit_hipGraphMem_Alloc_Free_NodeGetParams_Functional_3") {
  * ------------------------
  *  - HIP_VERSION >= 6.0
  */
-TEST_CASE("Unit_hipGraphMem_Alloc_Free_NodeGetParams_Negative") {
+TEST_CASE(Unit_hipGraphMem_Alloc_Free_NodeGetParams_Negative) {
   hipError_t ret;
   constexpr size_t N = 1024 * 1024;
   constexpr size_t Nbytes = N * sizeof(int);

--- a/projects/hip-tests/catch/unit/graph/hipGraphMemFreeNodeGetParams.cc
+++ b/projects/hip-tests/catch/unit/graph/hipGraphMemFreeNodeGetParams.cc
@@ -38,7 +38,7 @@ THE SOFTWARE.
  * ------------------------
  *  - HIP_VERSION >= 6.1
  */
-TEST_CASE("Unit_hipGraphMemFreeNodeGetParams_ValidArgs") {
+TEST_CASE(Unit_hipGraphMemFreeNodeGetParams_ValidArgs) {
   hipGraphNode_t allocNode, freeNode;
   hipGraph_t graph;
   hipGraphExec_t graphExec;
@@ -85,7 +85,7 @@ TEST_CASE("Unit_hipGraphMemFreeNodeGetParams_ValidArgs") {
  * ------------------------
  *  - HIP_VERSION >= 6.1
  */
-TEST_CASE("Unit_hipGraphMemFreeNodeGetParams_InvalidArgs") {
+TEST_CASE(Unit_hipGraphMemFreeNodeGetParams_InvalidArgs) {
   hipGraphNode_t allocNode, freeNode;
   hipMemAllocNodeParams allocParam;
   hipGraph_t graph;

--- a/projects/hip-tests/catch/unit/graph/hipGraphMemcpyNodeGetParams.cc
+++ b/projects/hip-tests/catch/unit/graph/hipGraphMemcpyNodeGetParams.cc
@@ -49,7 +49,7 @@ THE SOFTWARE.
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_hipGraphMemcpyNodeGetParams_Negative_Parameters") {
+TEST_CASE(Unit_hipGraphMemcpyNodeGetParams_Negative_Parameters) {
   CHECK_IMAGE_SUPPORT
   constexpr hipExtent extent{128 * sizeof(int), 128, 8};
 

--- a/projects/hip-tests/catch/unit/graph/hipGraphMemcpyNodeGetParams_old.cc
+++ b/projects/hip-tests/catch/unit/graph/hipGraphMemcpyNodeGetParams_old.cc
@@ -38,7 +38,7 @@ Functional -
 
 /* Test verifies hipGraphMemcpyNodeGetParams API Negative scenarios.
  */
-TEST_CASE("Unit_hipGraphMemcpyNodeGetParams_Negative") {
+TEST_CASE(Unit_hipGraphMemcpyNodeGetParams_Negative) {
   CHECK_IMAGE_SUPPORT
 
   constexpr int width{SIZE}, height{SIZE}, depth{SIZE};
@@ -134,7 +134,7 @@ static bool memcpyNodeCompare(hipMemcpy3DParms* mNode1, hipMemcpy3DParms* mNode2
   return true;
 }
 
-TEST_CASE("Unit_hipGraphMemcpyNodeGetParams_Functional") {
+TEST_CASE(Unit_hipGraphMemcpyNodeGetParams_Functional) {
   CHECK_IMAGE_SUPPORT
 
   constexpr int width{SIZE}, height{SIZE}, depth{SIZE};

--- a/projects/hip-tests/catch/unit/graph/hipGraphMemcpyNodeSetParams.cc
+++ b/projects/hip-tests/catch/unit/graph/hipGraphMemcpyNodeSetParams.cc
@@ -51,7 +51,7 @@ THE SOFTWARE.
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_hipGraphMemcpyNodeSetParams_Positive_Basic") {
+TEST_CASE(Unit_hipGraphMemcpyNodeSetParams_Positive_Basic) {
   CHECK_IMAGE_SUPPORT
 
   constexpr bool async = false;
@@ -134,7 +134,7 @@ TEST_CASE("Unit_hipGraphMemcpyNodeSetParams_Positive_Basic") {
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_hipGraphMemcpyNodeSetParams_Negative_Parameters") {
+TEST_CASE(Unit_hipGraphMemcpyNodeSetParams_Negative_Parameters) {
   CHECK_IMAGE_SUPPORT
 
   using namespace std::placeholders;

--- a/projects/hip-tests/catch/unit/graph/hipGraphMemcpyNodeSetParams1D.cc
+++ b/projects/hip-tests/catch/unit/graph/hipGraphMemcpyNodeSetParams1D.cc
@@ -61,7 +61,7 @@ static inline hipMemcpyKind ReverseMemcpyDirection(const hipMemcpyKind direction
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_hipGraphMemcpyNodeSetParams1D_Positive_Basic") {
+TEST_CASE(Unit_hipGraphMemcpyNodeSetParams1D_Positive_Basic) {
   constexpr auto f = [](void* dst, void* src, size_t count, hipMemcpyKind direction) {
     hipGraph_t graph = nullptr;
     HIP_CHECK(hipGraphCreate(&graph, 0));
@@ -154,7 +154,7 @@ TEST_CASE("Unit_hipGraphMemcpyNodeSetParams1D_Positive_Basic") {
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_hipGraphMemcpyNodeSetParams1D_Negative_Parameters") {
+TEST_CASE(Unit_hipGraphMemcpyNodeSetParams1D_Negative_Parameters) {
   using namespace std::placeholders;
   hipGraph_t graph = nullptr;
   HIP_CHECK(hipGraphCreate(&graph, 0));

--- a/projects/hip-tests/catch/unit/graph/hipGraphMemcpyNodeSetParams1D_old.cc
+++ b/projects/hip-tests/catch/unit/graph/hipGraphMemcpyNodeSetParams1D_old.cc
@@ -38,7 +38,7 @@ size for source and destination ptr, api should return error code.
 
 /* Test verifies hipGraphMemcpyNodeSetParams1D API Negative scenarios.
  */
-TEST_CASE("Unit_hipGraphMemcpyNodeSetParams1D_Negative") {
+TEST_CASE(Unit_hipGraphMemcpyNodeSetParams1D_Negative) {
   constexpr size_t N = 1024;
   constexpr size_t Nbytes = N * sizeof(int);
   int *A_d, *A_h;
@@ -107,7 +107,7 @@ TEST_CASE("Unit_hipGraphMemcpyNodeSetParams1D_Negative") {
 
 /* Test verifies hipGraphMemcpyNodeSetParams1D API Functional scenarios.
  */
-TEST_CASE("Unit_hipGraphMemcpyNodeSetParams1D_Functional") {
+TEST_CASE(Unit_hipGraphMemcpyNodeSetParams1D_Functional) {
   constexpr size_t N = 1024;
   constexpr size_t Nbytes = N * sizeof(int);
   constexpr auto blocksPerCU = 6;  // to hide latency

--- a/projects/hip-tests/catch/unit/graph/hipGraphMemcpyNodeSetParamsFromSymbol.cc
+++ b/projects/hip-tests/catch/unit/graph/hipGraphMemcpyNodeSetParamsFromSymbol.cc
@@ -95,7 +95,7 @@ void GraphMemcpyFromSymbolSetParamsShell(const void* symbol, const void* alt_sym
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_hipGraphMemcpyNodeSetParamsFromSymbol_Positive_Basic") {
+TEST_CASE(Unit_hipGraphMemcpyNodeSetParamsFromSymbol_Positive_Basic) {
   SECTION("char") {
     HIP_GRAPH_MEMCPY_NODE_SET_PARAMS_TO_FROM_SYMBOL_TEST(GraphMemcpyFromSymbolSetParamsShell, 1,
                                                          char);
@@ -136,7 +136,7 @@ TEST_CASE("Unit_hipGraphMemcpyNodeSetParamsFromSymbol_Positive_Basic") {
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_hipGraphMemcpyNodeSetParamsFromSymbol_Negative_Parameters") {
+TEST_CASE(Unit_hipGraphMemcpyNodeSetParamsFromSymbol_Negative_Parameters) {
   using namespace std::placeholders;
   hipGraph_t graph = nullptr;
   HIP_CHECK(hipGraphCreate(&graph, 0));

--- a/projects/hip-tests/catch/unit/graph/hipGraphMemcpyNodeSetParamsFromSymbol_old.cc
+++ b/projects/hip-tests/catch/unit/graph/hipGraphMemcpyNodeSetParamsFromSymbol_old.cc
@@ -50,7 +50,7 @@ __device__ __constant__ int globalConst[SIZE];
 
 /* Test verifies hipGraphMemcpyNodeSetParamsFromSymbol API Negative scenarios.
  */
-TEST_CASE("Unit_hipGraphMemcpyNodeSetParamsFromSymbol_Negative") {
+TEST_CASE(Unit_hipGraphMemcpyNodeSetParamsFromSymbol_Negative) {
   constexpr size_t Nbytes = SIZE * sizeof(int);
   int *A_d{nullptr}, *B_d{nullptr};
   int *A_h{nullptr}, *B_h{nullptr};

--- a/projects/hip-tests/catch/unit/graph/hipGraphMemcpyNodeSetParamsToSymbol.cc
+++ b/projects/hip-tests/catch/unit/graph/hipGraphMemcpyNodeSetParamsToSymbol.cc
@@ -96,7 +96,7 @@ template <typename T> void GraphMemcpyToSymbolSetParamsShell(const void* symbol,
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_hipGraphMemcpyNodeSetParamsToSymbol_Positive_Basic") {
+TEST_CASE(Unit_hipGraphMemcpyNodeSetParamsToSymbol_Positive_Basic) {
   SECTION("char") {
     HIP_GRAPH_MEMCPY_NODE_SET_PARAMS_TO_FROM_SYMBOL_TEST(GraphMemcpyToSymbolSetParamsShell, 10,
                                                          char);
@@ -137,7 +137,7 @@ TEST_CASE("Unit_hipGraphMemcpyNodeSetParamsToSymbol_Positive_Basic") {
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_hipGraphMemcpyNodeSetParamsToSymbol_Negative_Parameters") {
+TEST_CASE(Unit_hipGraphMemcpyNodeSetParamsToSymbol_Negative_Parameters) {
   using namespace std::placeholders;
   hipGraph_t graph = nullptr;
   HIP_CHECK(hipGraphCreate(&graph, 0));

--- a/projects/hip-tests/catch/unit/graph/hipGraphMemcpyNodeSetParamsToSymbol_old.cc
+++ b/projects/hip-tests/catch/unit/graph/hipGraphMemcpyNodeSetParamsToSymbol_old.cc
@@ -59,7 +59,7 @@ __global__ void CpyToConstSymbolKernel(int* B_d) {
 
 /* This testcase verifies negative scenarios of
    hipGraphMemcpyNodeSetParamsToSymbol API */
-TEST_CASE("Unit_hipGraphMemcpyNodeSetParamsToSymbol_Negative") {
+TEST_CASE(Unit_hipGraphMemcpyNodeSetParamsToSymbol_Negative) {
   constexpr size_t Nbytes = SIZE * sizeof(int);
   int *A_d{nullptr}, *B_d{nullptr};
   int *A_h{nullptr}, *B_h{nullptr};

--- a/projects/hip-tests/catch/unit/graph/hipGraphMemsetNodeGetParams.cc
+++ b/projects/hip-tests/catch/unit/graph/hipGraphMemsetNodeGetParams.cc
@@ -48,7 +48,7 @@ THE SOFTWARE.
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_hipGraphMemsetNodeGetParams_Negative_Parameters") {
+TEST_CASE(Unit_hipGraphMemsetNodeGetParams_Negative_Parameters) {
   CHECK_IMAGE_SUPPORT
 
   LinearAllocGuard2D<int> alloc(1, 1);

--- a/projects/hip-tests/catch/unit/graph/hipGraphMemsetNodeSetParams.cc
+++ b/projects/hip-tests/catch/unit/graph/hipGraphMemsetNodeSetParams.cc
@@ -51,7 +51,7 @@ THE SOFTWARE.
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEMPLATE_TEST_CASE("Unit_hipGraphMemsetNodeSetParams_Positive_Basic", "", uint8_t, uint16_t,
+TEMPLATE_TEST_CASE(Unit_hipGraphMemsetNodeSetParams_Positive_Basic, uint8_t, uint16_t,
                    uint32_t) {
   CHECK_IMAGE_SUPPORT
 
@@ -122,7 +122,7 @@ TEMPLATE_TEST_CASE("Unit_hipGraphMemsetNodeSetParams_Positive_Basic", "", uint8_
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_hipGraphMemsetNodeSetParams_Negative_Parameters") {
+TEST_CASE(Unit_hipGraphMemsetNodeSetParams_Negative_Parameters) {
   using namespace std::placeholders;
 
   hipGraph_t graph = nullptr;

--- a/projects/hip-tests/catch/unit/graph/hipGraphMultiDevice.cc
+++ b/projects/hip-tests/catch/unit/graph/hipGraphMultiDevice.cc
@@ -64,7 +64,7 @@ static void init_input(int* a, size_t size) {
 }
 
 
-TEST_CASE("Unit_hipGraphMultiDevice") {
+TEST_CASE(Unit_hipGraphMultiDevice) {
   int nGpus = 0;
   HIP_CHECK(hipGetDeviceCount(&nGpus));
   if (nGpus < 2) {

--- a/projects/hip-tests/catch/unit/graph/hipGraphNodeFindInClone.cc
+++ b/projects/hip-tests/catch/unit/graph/hipGraphNodeFindInClone.cc
@@ -58,7 +58,7 @@ again, then try to find the newly added graph node  from the cloned graph
  * - Finds a cloned version of a node.
  */
 
-TEST_CASE("Unit_hipGraphNodeFindInClone_Negative") {
+TEST_CASE(Unit_hipGraphNodeFindInClone_Negative) {
   hipGraph_t graph;
   hipGraph_t clonedgraph;
   hipGraphNode_t graphnode, newnode;
@@ -206,7 +206,7 @@ void hipGraphNodeFindInClone_Func(bool ModifyOrigGraph = false) {
   HIP_CHECK(hipGraphDestroy(clonedgraph));
 }
 
-TEST_CASE("Unit_hipGraphNodeFindInClone_Functional") {
+TEST_CASE(Unit_hipGraphNodeFindInClone_Functional) {
   SECTION("hipGraphNodeFindInClone Basic Functionality") { hipGraphNodeFindInClone_Func(); }
   SECTION("hipGraphNodeFindInClone Modify Original graph") { hipGraphNodeFindInClone_Func(true); }
 }
@@ -277,7 +277,7 @@ void hipGraphNodeFindInClone_DoubleClone(bool ModifyOrigGraph = false) {
  * ------------------------
  *    - HIP_VERSION >= 6.4
  */
-TEST_CASE("Unit_hipGraphNodeFindInClone_MultipleClone") {
+TEST_CASE(Unit_hipGraphNodeFindInClone_MultipleClone) {
   SECTION("hipGraphNodeFindInClone Back to Back clone") { hipGraphNodeFindInClone_DoubleClone(); }
   SECTION("hipGraphNodeFindInClone Modify Orig Graph After 2nd Clone") {
     hipGraphNodeFindInClone_DoubleClone(true);

--- a/projects/hip-tests/catch/unit/graph/hipGraphNodeGetDependencies.cc
+++ b/projects/hip-tests/catch/unit/graph/hipGraphNodeGetDependencies.cc
@@ -49,7 +49,7 @@ THE SOFTWARE.
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_hipGraphNodeGetDependencies_Positive_Functional") {
+TEST_CASE(Unit_hipGraphNodeGetDependencies_Positive_Functional) {
   using namespace std::placeholders;
   constexpr size_t N = 1024;
   constexpr size_t Nbytes = N * sizeof(int);
@@ -212,7 +212,7 @@ TEST_CASE("Unit_hipGraphNodeGetDependencies_Positive_Functional") {
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_hipGraphNodeGetDependencies_Negative_Parameters") {
+TEST_CASE(Unit_hipGraphNodeGetDependencies_Negative_Parameters) {
   hipGraph_t graph{};
   const int numBytes = 100;
   size_t numDeps{1};

--- a/projects/hip-tests/catch/unit/graph/hipGraphNodeGetDependentNodes.cc
+++ b/projects/hip-tests/catch/unit/graph/hipGraphNodeGetDependentNodes.cc
@@ -49,7 +49,7 @@ THE SOFTWARE.
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_hipGraphNodeGetDependentNodes_Positive_Functional") {
+TEST_CASE(Unit_hipGraphNodeGetDependentNodes_Positive_Functional) {
   using namespace std::placeholders;
   constexpr size_t N = 1024;
   constexpr size_t Nbytes = N * sizeof(int);
@@ -210,7 +210,7 @@ TEST_CASE("Unit_hipGraphNodeGetDependentNodes_Positive_Functional") {
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_hipGraphNodeGetDependentNodes_Negative_Parameters") {
+TEST_CASE(Unit_hipGraphNodeGetDependentNodes_Negative_Parameters) {
   hipGraph_t graph{};
   const int numBytes = 100;
   size_t numDeps{1};

--- a/projects/hip-tests/catch/unit/graph/hipGraphNodeGetEnabled.cc
+++ b/projects/hip-tests/catch/unit/graph/hipGraphNodeGetEnabled.cc
@@ -43,7 +43,7 @@ static void callbackfunc(void* A_h) {
   }
 }
 
-TEST_CASE("Unit_hipGraphNodeGetEnabled_Functional_Basic") {
+TEST_CASE(Unit_hipGraphNodeGetEnabled_Functional_Basic) {
   constexpr size_t Nbytes = N * sizeof(int);
   constexpr auto blocksPerCU = 6;  // to hide latency
   constexpr auto threadsPerBlock = 256;
@@ -161,7 +161,7 @@ TEST_CASE("Unit_hipGraphNodeGetEnabled_Functional_Basic") {
  12) Create graphExec and then delete the graphExec and verify a node
  */
 
-TEST_CASE("Unit_hipGraphNodeGetEnabled_Negative_Functional") {
+TEST_CASE(Unit_hipGraphNodeGetEnabled_Negative_Functional) {
   constexpr size_t Nbytes = N * sizeof(int);
   constexpr auto blocksPerCU = 6;  // to hide latency
   constexpr auto threadsPerBlock = 256;

--- a/projects/hip-tests/catch/unit/graph/hipGraphNodeGetType.cc
+++ b/projects/hip-tests/catch/unit/graph/hipGraphNodeGetType.cc
@@ -62,7 +62,7 @@ static void callbackfunc(void* A_h) {
   }
 }
 
-TEST_CASE("Unit_hipGraphNodeGetType_Negative") {
+TEST_CASE(Unit_hipGraphNodeGetType_Negative) {
   SECTION("Pass nullptr to graph node") {
     hipGraphNodeType nodeType;
     REQUIRE(hipGraphNodeGetType(nullptr, &nodeType) == hipErrorInvalidValue);
@@ -84,7 +84,7 @@ TEST_CASE("Unit_hipGraphNodeGetType_Negative") {
   }
 }
 
-TEST_CASE("Unit_hipGraphNodeGetType_Functional") {
+TEST_CASE(Unit_hipGraphNodeGetType_Functional) {
   constexpr size_t N = 1024;
   hipGraphNodeType nodeType;
   hipGraph_t graph;
@@ -131,7 +131,7 @@ constexpr size_t Nbytes = N * sizeof(int);
 constexpr auto blocksPerCU = 6;  // to hide latency
 constexpr auto threadsPerBlock = 256;
 
-TEST_CASE("Unit_hipGraphNodeGetType_NodeType") {
+TEST_CASE(Unit_hipGraphNodeGetType_NodeType) {
   hipGraph_t graph;
   int *A_d, *B_d, *C_d;
   int *A_h, *B_h, *C_h;
@@ -304,7 +304,7 @@ static void thread_func(hipGraph_t graph, std::map<hipGraphNodeType, int>* numNo
  * 2.Create a graph with different types of nodes. Pass the graph to a thread. In the
  * thread, verify node types of all the nodes in the graph
  */
-TEST_CASE("Unit_hipGraphNodeGetType_NodeTypeOfClonedGraph_NodeTypeInThread") {
+TEST_CASE(Unit_hipGraphNodeGetType_NodeTypeOfClonedGraph_NodeTypeInThread) {
   hipGraph_t graph, childGraph, clonedGraph;
   int *A_d, *B_d, *C_d;
   int *A_h, *B_h, *C_h;
@@ -423,7 +423,7 @@ TEST_CASE("Unit_hipGraphNodeGetType_NodeTypeOfClonedGraph_NodeTypeInThread") {
  * few nodes and X as child graph. Now verify each of nodes of Y including
  * the nodes inside child graph using hipGraphNodeGetType()
  */
-TEST_CASE("Unit_hipGraphNodeGetType_NodeTypeOfChildGraph") {
+TEST_CASE(Unit_hipGraphNodeGetType_NodeTypeOfChildGraph) {
   hipGraph_t graph, childGraph, getGraph;
   int *A_d, *B_d, *C_d;
   int *A_h, *B_h, *C_h;
@@ -570,7 +570,7 @@ static void thread_func1(hipGraph_t graph, enum graphType type) {
  * graph using hipGraphNodeGetType.
  * 2.Pass the graph to thread and verify each type of node in the graph
  * */
-TEST_CASE("Unit_hipGraphNodeGetType_ClonedGraph_InThread_WithDependencies") {
+TEST_CASE(Unit_hipGraphNodeGetType_ClonedGraph_InThread_WithDependencies) {
   hipGraph_t graph, childGraph, clonedGraph;
   int *A_d, *B_d, *C_d;
   int *A_h, *B_h, *C_h;
@@ -666,7 +666,7 @@ TEST_CASE("Unit_hipGraphNodeGetType_ClonedGraph_InThread_WithDependencies") {
  * Now verify each of nodes of Y including the nodes inside child graph using
  * hipGraphNodeGetType()
  */
-TEST_CASE("Unit_hipGraphNodeGetType_NodeTypeOfChildGraph_WithDependency") {
+TEST_CASE(Unit_hipGraphNodeGetType_NodeTypeOfChildGraph_WithDependency) {
   hipGraph_t graph, childGraph, getGraph;
   int *A_d, *B_d, *C_d;
   int *A_h, *B_h, *C_h;

--- a/projects/hip-tests/catch/unit/graph/hipGraphNodeSetEnabled.cc
+++ b/projects/hip-tests/catch/unit/graph/hipGraphNodeSetEnabled.cc
@@ -63,7 +63,7 @@ static void callbackfunc(void* A_h) {
   }
 }
 
-TEST_CASE("Unit_hipGraphNodeSetEnabled_Functional_Basic") {
+TEST_CASE(Unit_hipGraphNodeSetEnabled_Functional_Basic) {
   constexpr size_t Nbytes = N * sizeof(int);
   constexpr auto blocksPerCU = 6;  // to hide latency
   constexpr auto threadsPerBlock = 256;
@@ -191,7 +191,7 @@ TEST_CASE("Unit_hipGraphNodeSetEnabled_Functional_Basic") {
  11) Make ClonedGraph and disabled the kernel node in ClonedGraph and verify
  12) Enable the Kernel node in ClonedGraph and verify the result */
 
-TEST_CASE("Unit_hipGraphNodeSetEnabled_Functional_KernelNode") {
+TEST_CASE(Unit_hipGraphNodeSetEnabled_Functional_KernelNode) {
   constexpr size_t Nbytes = N * sizeof(int);
   constexpr auto blocksPerCU = 6;  // to hide latency
   constexpr auto threadsPerBlock = 256;
@@ -310,7 +310,7 @@ TEST_CASE("Unit_hipGraphNodeSetEnabled_Functional_KernelNode") {
  15) Make ClonedGraph and disabled the MemSet node in ClonedGraph and verify
  16) Enable the MemSet node in ClonedGraph and verify the result */
 
-TEST_CASE("Unit_hipGraphNodeSetEnabled_Functional_MemSet") {
+TEST_CASE(Unit_hipGraphNodeSetEnabled_Functional_MemSet) {
   constexpr size_t Nbytes = N * sizeof(char);
   constexpr size_t val = 9;
   hipGraph_t graph, clonedGraph;
@@ -427,7 +427,7 @@ TEST_CASE("Unit_hipGraphNodeSetEnabled_Functional_MemSet") {
  19) Make ClonedGraph and disabled the MemCpy node in ClonedGraph and verify
  20) Enable the MemCpy node in ClonedGraph and verify the result */
 
-TEST_CASE("Unit_hipGraphNodeSetEnabled_Functional_MemCpy") {
+TEST_CASE(Unit_hipGraphNodeSetEnabled_Functional_MemCpy) {
   constexpr size_t Nbytes = N * sizeof(int);
   constexpr auto blocksPerCU = 6;  // to hide latency
   constexpr auto threadsPerBlock = 256;
@@ -556,7 +556,7 @@ TEST_CASE("Unit_hipGraphNodeSetEnabled_Functional_MemCpy") {
  12) Create graphExec and then delete the graphExec and verify a node
  */
 
-TEST_CASE("Unit_hipGraphNodeSetEnabled_Negative_Functional") {
+TEST_CASE(Unit_hipGraphNodeSetEnabled_Negative_Functional) {
   constexpr size_t Nbytes = N * sizeof(int);
   constexpr auto blocksPerCU = 6;  // to hide latency
   constexpr auto threadsPerBlock = 256;

--- a/projects/hip-tests/catch/unit/graph/hipGraphNodeSetParams.cc
+++ b/projects/hip-tests/catch/unit/graph/hipGraphNodeSetParams.cc
@@ -44,7 +44,7 @@ THE SOFTWARE.
  * ------------------------
  *    - HIP_VERSION >= 6.4
  */
-TEST_CASE("Unit_hipGraphNodeSetParams_Negative_Parameters") {
+TEST_CASE(Unit_hipGraphNodeSetParams_Negative_Parameters) {
   hipGraph_t graph;
   hipGraphExec_t graphExec;
   hipGraphNode_t node;
@@ -104,7 +104,7 @@ TEST_CASE("Unit_hipGraphNodeSetParams_Negative_Parameters") {
  * ------------------------
  *    - HIP_VERSION >= 6.4
  */
-TEST_CASE("Unit_hipGraphNodeSetParams_Positive") {
+TEST_CASE(Unit_hipGraphNodeSetParams_Positive) {
   hipGraph_t graph;
   hipGraphExec_t graphExec;
   hipGraphNode_t node;

--- a/projects/hip-tests/catch/unit/graph/hipGraphPerf.cc
+++ b/projects/hip-tests/catch/unit/graph/hipGraphPerf.cc
@@ -501,7 +501,7 @@ static void checkGraphEventcontinuousKernelCallIn2Blocks(const unsigned int kNum
  *  - HIP_VERSION >= 6.1
  */
 
-TEST_CASE("Unit_hipGraph_PerfCheck_MemcpyKernelMixCall") {
+TEST_CASE(Unit_hipGraph_PerfCheck_MemcpyKernelMixCall) {
   if ((setenv("DEBUG_CLR_GRAPH_PACKET_CAPTURE", "true", 1)) != 0) {
     HipTest::HIP_SKIP_TEST(
         "Unable to turn on "
@@ -614,8 +614,7 @@ static void hipGraph_PerfCheck_hipGraphExecKernelNodeSetParams(const hipStream_t
  * ------------------------
  *  - HIP_VERSION >= 6.1
  */
-TEST_CASE("Unit_hipGraph_PerfCheck_hipGraphExecKernelNodeSetParams",
-          "[multigpu]") {
+TEST_CASE(Unit_hipGraph_PerfCheck_hipGraphExecKernelNodeSetParams) {
   if ((setenv("DEBUG_CLR_GRAPH_PACKET_CAPTURE", "true", 1)) != 0) {
     HipTest::HIP_SKIP_TEST(
         "Unable to turn on "
@@ -733,8 +732,7 @@ static void hipGraph_PerfCheck_hipGraphExecKernelNodeSetParams_inLoop(const hipS
  * ------------------------
  *  - HIP_VERSION >= 6.1
  */
-TEST_CASE("Unit_hipGraph_PerfCheck_hipGraphExecKernelNodeSetParams_inLoop",
-          "[multigpu]") {
+TEST_CASE(Unit_hipGraph_PerfCheck_hipGraphExecKernelNodeSetParams_inLoop) {
   if ((setenv("DEBUG_CLR_GRAPH_PACKET_CAPTURE", "true", 1)) != 0) {
     HipTest::HIP_SKIP_TEST(
         "Unable to turn on "
@@ -783,7 +781,7 @@ TEST_CASE("Unit_hipGraph_PerfCheck_hipGraphExecKernelNodeSetParams_inLoop",
  *  - HIP_VERSION >= 6.1
  */
 
-TEST_CASE("Unit_hipGraph_PerfCheck_hipGraphExecMemcpyNodeSetParams") {
+TEST_CASE(Unit_hipGraph_PerfCheck_hipGraphExecMemcpyNodeSetParams) {
   if ((setenv("DEBUG_CLR_GRAPH_PACKET_CAPTURE", "true", 1)) != 0) {
     HipTest::HIP_SKIP_TEST(
         "Unable to turn on "
@@ -956,8 +954,7 @@ static void hipGraph_PerfCheck_hipGraphExecMemcpyNodeSetParams_inLoop(const hipS
  *  - HIP_VERSION >= 6.1
  */
 
-TEST_CASE("Unit_hipGraph_PerfCheck_hipGraphExecMemcpyNodeSetParams_inLoop",
-          "[multigpu]") {
+TEST_CASE(Unit_hipGraph_PerfCheck_hipGraphExecMemcpyNodeSetParams_inLoop) {
   if ((setenv("DEBUG_CLR_GRAPH_PACKET_CAPTURE", "true", 1)) != 0) {
     HipTest::HIP_SKIP_TEST(
         "Unable to turn on "
@@ -1073,8 +1070,7 @@ static void hipGraph_PerfCheck_hipGraphExecMemcpyNodeSetParams1D_inLoop(const hi
  *  - HIP_VERSION >= 6.1
  */
 
-TEST_CASE("Unit_hipGraph_PerfCheck_hipGraphExecMemcpyNodeSetParams1D_inLoop",
-          "[multigpu]") {
+TEST_CASE(Unit_hipGraph_PerfCheck_hipGraphExecMemcpyNodeSetParams1D_inLoop) {
   if ((setenv("DEBUG_CLR_GRAPH_PACKET_CAPTURE", "true", 1)) != 0) {
     HipTest::HIP_SKIP_TEST(
         "Unable to turn on "
@@ -1182,8 +1178,7 @@ static void hipGraph_PerfCheck_hipGraphExecMemcpyNodeSetParamsFrmSymbol(const hi
  *  - HIP_VERSION >= 6.1
  */
 
-TEST_CASE("Unit_hipGraph_PerfCheck_hipGraphExecMemcpyNodeSetParamsFrmSymbol",
-          "[multigpu]") {
+TEST_CASE(Unit_hipGraph_PerfCheck_hipGraphExecMemcpyNodeSetParamsFrmSymbol) {
   if ((setenv("DEBUG_CLR_GRAPH_PACKET_CAPTURE", "true", 1)) != 0) {
     HipTest::HIP_SKIP_TEST(
         "Unable to turn on "
@@ -1290,8 +1285,7 @@ static void hipGraph_PerfCheck_hipGraphExecMemcpyNodeSetParamsToSymbol(const hip
  * ------------------------
  *  - HIP_VERSION >= 6.1
  */
-TEST_CASE("Unit_hipGraph_PerfCheck_hipGraphExecMemcpyNodeSetParamsToSymbol",
-          "[multigpu]") {
+TEST_CASE(Unit_hipGraph_PerfCheck_hipGraphExecMemcpyNodeSetParamsToSymbol) {
   if ((setenv("DEBUG_CLR_GRAPH_PACKET_CAPTURE", "true", 1)) != 0) {
     HipTest::HIP_SKIP_TEST(
         "Unable to turn on "
@@ -1444,8 +1438,7 @@ static void hipGraph_PerfCheck_hipGraphExecMemsetNodeSetParams(const hipStream_t
  * ------------------------
  *  - HIP_VERSION >= 6.1
  */
-TEST_CASE("Unit_hipGraph_PerfCheck_hipGraphExecMemsetNodeSetParams",
-          "[multigpu]") {
+TEST_CASE(Unit_hipGraph_PerfCheck_hipGraphExecMemsetNodeSetParams) {
   if ((setenv("DEBUG_CLR_GRAPH_PACKET_CAPTURE", "true", 1)) != 0) {
     HipTest::HIP_SKIP_TEST(
         "Unable to turn on "
@@ -1878,8 +1871,7 @@ static void hipGraph_PerfCheck_hipGraphExecChildGraphNodeSetParams_mKernel(
  * ------------------------
  *  - HIP_VERSION >= 6.1
  */
-TEST_CASE("Unit_hipGraph_PerfCheck_hipGraphExecChildGraphNodeSetParams",
-          "[multigpu]") {
+TEST_CASE(Unit_hipGraph_PerfCheck_hipGraphExecChildGraphNodeSetParams) {
   if ((setenv("DEBUG_CLR_GRAPH_PACKET_CAPTURE", "true", 1)) != 0) {
     HipTest::HIP_SKIP_TEST(
         "Unable to turn on "
@@ -2026,8 +2018,7 @@ static void hipGraph_PerfCheck_hipGraphExecEventRecordNodeSetEvent(const hipStre
  * ------------------------
  *  - HIP_VERSION >= 6.1
  */
-TEST_CASE("Unit_hipGraph_PerfCheck_hipGraphExecEventRecordNodeSetEvent",
-          "[multigpu]") {
+TEST_CASE(Unit_hipGraph_PerfCheck_hipGraphExecEventRecordNodeSetEvent) {
   if ((setenv("DEBUG_CLR_GRAPH_PACKET_CAPTURE", "true", 1)) != 0) {
     HipTest::HIP_SKIP_TEST(
         "Unable to turn on "
@@ -2214,8 +2205,7 @@ static void hipGraph_PerfCheck_hipGraphExecEventWaitNodeSetEvent(const hipStream
  * ------------------------
  *  - HIP_VERSION >= 6.1
  */
-TEST_CASE("Unit_hipGraph_PerfCheck_hipGraphExecEventWaitNodeSetEvent",
-          "[multigpu]") {
+TEST_CASE(Unit_hipGraph_PerfCheck_hipGraphExecEventWaitNodeSetEvent) {
   if ((setenv("DEBUG_CLR_GRAPH_PACKET_CAPTURE", "true", 1)) != 0) {
     HipTest::HIP_SKIP_TEST(
         "Unable to turn on "
@@ -2369,8 +2359,7 @@ static void hipGraph_PerfCheck_hipGraphExecHostNodeSetParams(const hipStream_t& 
  * ------------------------
  *  - HIP_VERSION >= 6.1
  */
-TEST_CASE("Unit_hipGraph_PerfCheck_hipGraphExecHostNodeSetParams",
-          "[multigpu]") {
+TEST_CASE(Unit_hipGraph_PerfCheck_hipGraphExecHostNodeSetParams) {
   if ((setenv("DEBUG_CLR_GRAPH_PACKET_CAPTURE", "true", 1)) != 0) {
     HipTest::HIP_SKIP_TEST(
         "Unable to turn on "
@@ -2493,7 +2482,7 @@ static void hipGraph_PerfCheck_hipGraphExecUpdate(const hipStream_t& stream) {
  * ------------------------
  *  - HIP_VERSION >= 6.1
  */
-TEST_CASE("Unit_hipGraph_PerfCheck_hipGraphExecUpdate", "[multigpu]") {
+TEST_CASE(Unit_hipGraph_PerfCheck_hipGraphExecUpdate) {
   if ((setenv("DEBUG_CLR_GRAPH_PACKET_CAPTURE", "true", 1)) != 0) {
     HipTest::HIP_SKIP_TEST(
         "Unable to turn on "
@@ -2637,8 +2626,7 @@ static void hipGraph_PerfCheck_hipGraphExecUpdate_kernel_inLoop(const hipStream_
  * ------------------------
  *  - HIP_VERSION >= 6.1
  */
-TEST_CASE("Unit_hipGraph_PerfCheck_hipGraphExecUpdate_kernel_inLoop",
-          "[multigpu]") {
+TEST_CASE(Unit_hipGraph_PerfCheck_hipGraphExecUpdate_kernel_inLoop) {
   if ((setenv("DEBUG_CLR_GRAPH_PACKET_CAPTURE", "true", 1)) != 0) {
     HipTest::HIP_SKIP_TEST(
         "Unable to turn on "

--- a/projects/hip-tests/catch/unit/graph/hipGraphReleaseUserObject.cc
+++ b/projects/hip-tests/catch/unit/graph/hipGraphReleaseUserObject.cc
@@ -31,7 +31,7 @@ THE SOFTWARE.
  3) Pass initialRefcount as 0
  4) Pass initialRefcount as INT_MAX
  */
-TEST_CASE("Unit_hipGraphReleaseUserObject_Negative") {
+TEST_CASE(Unit_hipGraphReleaseUserObject_Negative) {
   hipGraph_t graph;
   HIP_CHECK(hipGraphCreate(&graph, 0));
 

--- a/projects/hip-tests/catch/unit/graph/hipGraphRemoveDependencies.cc
+++ b/projects/hip-tests/catch/unit/graph/hipGraphRemoveDependencies.cc
@@ -67,7 +67,7 @@ static __global__ void vector_square(int* A_d, size_t N_ELMTS) {
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_hipGraphRemoveDependencies_Positive_Functional") {
+TEST_CASE(Unit_hipGraphRemoveDependencies_Positive_Functional) {
   constexpr size_t N = 1024;
   hipGraph_t graph;
   int *A_d, *B_d, *C_d;
@@ -161,7 +161,7 @@ TEST_CASE("Unit_hipGraphRemoveDependencies_Positive_Functional") {
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_hipGraphRemoveDependenciesPositive_CapturedStream") {
+TEST_CASE(Unit_hipGraphRemoveDependenciesPositive_CapturedStream) {
   hipGraph_t graph;
   constexpr size_t N = 1024;
   int *A_d, *B_d, *C_d;
@@ -217,7 +217,7 @@ TEST_CASE("Unit_hipGraphRemoveDependenciesPositive_CapturedStream") {
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_hipGraphRemoveDependencies_Positive_ChangeComputeFunc") {
+TEST_CASE(Unit_hipGraphRemoveDependencies_Positive_ChangeComputeFunc) {
   hipStream_t streamForGraph;
   HIP_CHECK(hipStreamCreate(&streamForGraph));
   constexpr size_t N = 1024;
@@ -329,7 +329,7 @@ TEST_CASE("Unit_hipGraphRemoveDependencies_Positive_ChangeComputeFunc") {
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_hipGraphRemoveDependencies_Positive_Parameters") {
+TEST_CASE(Unit_hipGraphRemoveDependencies_Positive_Parameters) {
   constexpr size_t Nbytes = 1024;
   hipGraphNode_t memcpyH2D_A;
   hipGraphNode_t memcpyD2H_A;
@@ -417,7 +417,7 @@ TEST_CASE("Unit_hipGraphRemoveDependencies_Positive_Parameters") {
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_hipGraphRemoveDependencies_Negative_Parameters") {
+TEST_CASE(Unit_hipGraphRemoveDependencies_Negative_Parameters) {
   hipGraph_t graph{};
   HIP_CHECK(hipGraphCreate(&graph, 0));
   hipEvent_t event_start, event_end;

--- a/projects/hip-tests/catch/unit/graph/hipGraphRetainUserObject.cc
+++ b/projects/hip-tests/catch/unit/graph/hipGraphRetainUserObject.cc
@@ -47,7 +47,7 @@ static void hipGraphRetainUserObject_Functional_1(void* object, void destroyObj(
   HIP_CHECK(hipGraphDestroy(graph));
 }
 
-TEST_CASE("Unit_hipGraphRetainUserObject_Functional_1") {
+TEST_CASE(Unit_hipGraphRetainUserObject_Functional_1) {
   SECTION("Called with int Object") {
     int* object = new int();
     REQUIRE(object != nullptr);
@@ -72,7 +72,7 @@ TEST_CASE("Unit_hipGraphRetainUserObject_Functional_1") {
 
 /* 2) Create UserObject and GraphUserObject and retain using custom reference
       count and release it by calling hipGraphReleaseUserObject with count. */
-TEST_CASE("Unit_hipGraphRetainUserObject_Functional_2") {
+TEST_CASE(Unit_hipGraphRetainUserObject_Functional_2) {
   constexpr size_t N = 1024;
   constexpr size_t Nbytes = N * sizeof(int);
   constexpr auto blocksPerCU = 6;  // to hide latency
@@ -151,7 +151,7 @@ TEST_CASE("Unit_hipGraphRetainUserObject_Functional_2") {
  5) Pass flag as 0
  6) Pass flag as INT_MAX
  */
-TEST_CASE("Unit_hipGraphRetainUserObject_Negative") {
+TEST_CASE(Unit_hipGraphRetainUserObject_Negative) {
   hipGraph_t graph;
   HIP_CHECK(hipGraphCreate(&graph, 0));
 
@@ -187,7 +187,7 @@ TEST_CASE("Unit_hipGraphRetainUserObject_Negative") {
   HIP_CHECK(hipGraphDestroy(graph));
 }
 
-TEST_CASE("Unit_hipGraphRetainUserObject_Negative_Basic") {
+TEST_CASE(Unit_hipGraphRetainUserObject_Negative_Basic) {
   hipGraph_t graph;
   HIP_CHECK(hipGraphCreate(&graph, 0));
 

--- a/projects/hip-tests/catch/unit/graph/hipGraphUpload.cc
+++ b/projects/hip-tests/catch/unit/graph/hipGraphUpload.cc
@@ -135,7 +135,7 @@ static void hipGraphUploadFunctional_with_stream(hipStream_t stream) {
   HIP_CHECK(hipGraphDestroy(graph));
 }
 
-TEST_CASE("Unit_hipGraphUpload_Functional") {
+TEST_CASE(Unit_hipGraphUpload_Functional) {
   SECTION("Pass a stream") {
     hipStream_t stream;
     HIP_CHECK(hipStreamCreate(&stream));
@@ -153,7 +153,7 @@ TEST_CASE("Unit_hipGraphUpload_Functional") {
   }
 }
 
-TEST_CASE("Unit_hipGraphUpload_Functional_multidevice_test", "[multigpu]") {
+TEST_CASE(Unit_hipGraphUpload_Functional_multidevice_test) {
   int numDevices = 0;
   HIP_CHECK(hipGetDeviceCount(&numDevices));
 
@@ -215,7 +215,7 @@ TEST_CASE("Unit_hipGraphUpload_Functional_multidevice_test", "[multigpu]") {
    Upload the graph into high priority stream and execute the graph and verify.
  */
 
-TEST_CASE("Unit_hipGraphUpload_Functional_With_Priority_Stream") {
+TEST_CASE(Unit_hipGraphUpload_Functional_With_Priority_Stream) {
   constexpr size_t N = 1024;
   constexpr size_t Nbytes = N * sizeof(int);
   hipGraph_t graph;
@@ -262,7 +262,7 @@ TEST_CASE("Unit_hipGraphUpload_Functional_With_Priority_Stream") {
 4) Graphexec is destroyed before upload
 */
 
-TEST_CASE("Unit_hipGraphUpload_Negative_Parameters") {
+TEST_CASE(Unit_hipGraphUpload_Negative_Parameters) {
   hipGraphExec_t graphExec{};
   hipError_t ret;
 

--- a/projects/hip-tests/catch/unit/graph/hipLaunchHostFuncWithGraph.cc
+++ b/projects/hip-tests/catch/unit/graph/hipLaunchHostFuncWithGraph.cc
@@ -55,7 +55,7 @@ static void hostNodeCallback(void* data) {
  * ------------------------
  *    - HIP_VERSION >= 5.3
  */
-TEST_CASE("Unit_hipLaunchHostFunc_Negative_Parameters") {
+TEST_CASE(Unit_hipLaunchHostFunc_Negative_Parameters) {
   StreamGuard stream_guard(Streams::created);
   hipStream_t stream = stream_guard.stream();
   hipGraph_t graph{nullptr};
@@ -85,7 +85,7 @@ TEST_CASE("Unit_hipLaunchHostFunc_Negative_Parameters") {
  * ------------------------
  *    - HIP_VERSION >= 5.3
  */
-TEST_CASE("Unit_hipLaunchHostFunc_Positive_Functional") {
+TEST_CASE(Unit_hipLaunchHostFunc_Positive_Functional) {
   LinearAllocGuard<float> A_h(LinearAllocs::malloc, sizeof(float));
   LinearAllocGuard<float> B_h(LinearAllocs::malloc, sizeof(float));
   LinearAllocGuard<float> A_d(LinearAllocs::hipMalloc, sizeof(float));
@@ -138,7 +138,7 @@ static void thread_func_pos(hipStream_t* stream, hipHostFn_t fn, float** data){
  * ------------------------
  *    - HIP_VERSION >= 5.3
  */
-TEST_CASE("Unit_hipLaunchHostFunc_Positive_Thread") {
+TEST_CASE(Unit_hipLaunchHostFunc_Positive_Thread) {
   LinearAllocGuard<float> A_h(LinearAllocs::malloc, sizeof(float));
   LinearAllocGuard<float> B_h(LinearAllocs::malloc, sizeof(float));
   LinearAllocGuard<float> A_d(LinearAllocs::hipMalloc, sizeof(float));
@@ -195,7 +195,7 @@ static void set_vector(void* args) {
 }
 }  // namespace
 
-TEST_CASE("Unit_hipLaunchHostFunc_H2D_Kernel_D2H_Capture") {
+TEST_CASE(Unit_hipLaunchHostFunc_H2D_Kernel_D2H_Capture) {
   constexpr int numOfBlocks = 1024;
   constexpr int threadsPerBlock = 1024;
   constexpr size_t arraySize = 1U << 20;  // 1,048,576

--- a/projects/hip-tests/catch/unit/graph/hipSimpleGraphWithKernel.cc
+++ b/projects/hip-tests/catch/unit/graph/hipSimpleGraphWithKernel.cc
@@ -149,7 +149,7 @@ static void hipTestWithoutGraph() {
 /**
  * Simple test to demonstrate usage of graph.
  */
-TEST_CASE("Unit_hipGraph_SimpleGraphWithKernel") {
+TEST_CASE(Unit_hipGraph_SimpleGraphWithKernel) {
   // Sections run test with and without graph.
   SECTION("Run Test Without Graph") { hipTestWithoutGraph(); }
 

--- a/projects/hip-tests/catch/unit/graph/hipStreamBeginCapture.cc
+++ b/projects/hip-tests/catch/unit/graph/hipStreamBeginCapture.cc
@@ -137,7 +137,7 @@ void captureStreamAndLaunchGraph(F graphFunc, hipStreamCaptureMode mode, hipStre
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_hipStreamBeginCapture_Positive_Functional") {
+TEST_CASE(Unit_hipStreamBeginCapture_Positive_Functional) {
   const auto stream_type = GENERATE(Streams::perThread, Streams::created);
   StreamGuard stream_guard(stream_type);
   hipStream_t stream = stream_guard.stream();
@@ -182,7 +182,7 @@ TEST_CASE("Unit_hipStreamBeginCapture_Positive_Functional") {
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_hipStreamBeginCapture_Negative_Parameters") {
+TEST_CASE(Unit_hipStreamBeginCapture_Negative_Parameters) {
   const auto stream_type = GENERATE(Streams::created);
   StreamGuard stream_guard(stream_type);
   hipStream_t stream = stream_guard.stream();
@@ -216,7 +216,7 @@ TEST_CASE("Unit_hipStreamBeginCapture_Negative_Parameters") {
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_hipStreamBeginCapture_Positive_Basic") {
+TEST_CASE(Unit_hipStreamBeginCapture_Positive_Basic) {
   hipGraph_t graph{nullptr};
   const auto stream_type = GENERATE(Streams::perThread, Streams::created);
   StreamGuard stream_guard(stream_type);
@@ -460,7 +460,7 @@ static void multithreadedTest(hipStreamCaptureMode mode) {
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_hipStreamBeginCapture_Positive_InterStrmEventSync_Flags") {
+TEST_CASE(Unit_hipStreamBeginCapture_Positive_InterStrmEventSync_Flags) {
   const auto stream_flags1 = GENERATE(hipStreamDefault, hipStreamNonBlocking);
   const auto stream_flags2 = GENERATE(hipStreamDefault, hipStreamNonBlocking);
   StreamGuard stream_guard1(Streams::withFlags, stream_flags1);
@@ -486,7 +486,7 @@ TEST_CASE("Unit_hipStreamBeginCapture_Positive_InterStrmEventSync_Flags") {
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_hipStreamBeginCapture_Positive_InterStrmEventSync_Priority") {
+TEST_CASE(Unit_hipStreamBeginCapture_Positive_InterStrmEventSync_Priority) {
   int minPriority = 0, maxPriority = 0;
   HIP_CHECK(hipDeviceGetStreamPriorityRange(&minPriority, &maxPriority));
   StreamGuard stream_guard1(Streams::withPriority, hipStreamDefault, minPriority);
@@ -511,7 +511,7 @@ TEST_CASE("Unit_hipStreamBeginCapture_Positive_InterStrmEventSync_Priority") {
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_hipStreamBeginCapture_Positive_ColligatedStrmCapture_Flags") {
+TEST_CASE(Unit_hipStreamBeginCapture_Positive_ColligatedStrmCapture_Flags) {
   const auto stream_flags1 = GENERATE(hipStreamDefault, hipStreamNonBlocking);
   const auto stream_flags2 = GENERATE(hipStreamDefault, hipStreamNonBlocking);
   StreamGuard stream_guard1(Streams::withFlags, stream_flags1);
@@ -537,7 +537,7 @@ TEST_CASE("Unit_hipStreamBeginCapture_Positive_ColligatedStrmCapture_Flags") {
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_hipStreamBeginCapture_Positive_ColligatedStrmCapture_Prio") {
+TEST_CASE(Unit_hipStreamBeginCapture_Positive_ColligatedStrmCapture_Prio) {
   int minPriority = 0, maxPriority = 0;
   HIP_CHECK(hipDeviceGetStreamPriorityRange(&minPriority, &maxPriority));
   StreamGuard stream_guard1(Streams::withPriority, hipStreamDefault, minPriority);
@@ -561,7 +561,7 @@ TEST_CASE("Unit_hipStreamBeginCapture_Positive_ColligatedStrmCapture_Prio") {
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_hipStreamBeginCapture_Positive_ColligatedStrmCaptureFunc") {
+TEST_CASE(Unit_hipStreamBeginCapture_Positive_ColligatedStrmCaptureFunc) {
   StreamGuard stream_guard1(Streams::created);
   hipStream_t stream1 = stream_guard1.stream();
   StreamGuard stream_guard2(Streams::created);
@@ -582,7 +582,7 @@ TEST_CASE("Unit_hipStreamBeginCapture_Positive_ColligatedStrmCaptureFunc") {
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_hipStreamBeginCapture_Positive_Multithreaded") {
+TEST_CASE(Unit_hipStreamBeginCapture_Positive_Multithreaded) {
   const hipStreamCaptureMode captureMode = GENERATE(
       hipStreamCaptureModeGlobal, hipStreamCaptureModeThreadLocal, hipStreamCaptureModeRelaxed);
   multithreadedTest(captureMode);
@@ -606,7 +606,7 @@ TEST_CASE("Unit_hipStreamBeginCapture_Positive_Multithreaded") {
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_hipStreamBeginCapture_Positive_Multiplestrms") {
+TEST_CASE(Unit_hipStreamBeginCapture_Positive_Multiplestrms) {
   StreamsGuard streams(3);
   hipGraph_t graphs[3];
 
@@ -679,7 +679,7 @@ TEST_CASE("Unit_hipStreamBeginCapture_Positive_Multiplestrms") {
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_hipStreamBeginCapture_Positive_CapturingFromWithinStrms") {
+TEST_CASE(Unit_hipStreamBeginCapture_Positive_CapturingFromWithinStrms) {
   constexpr int INCREMENT_KERNEL_FINALEXP_VAL = 7;
 
   hipGraph_t graph{nullptr};
@@ -745,7 +745,7 @@ TEST_CASE("Unit_hipStreamBeginCapture_Positive_CapturingFromWithinStrms") {
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_hipStreamBeginCapture_Negative_DetectingInvalidCapture") {
+TEST_CASE(Unit_hipStreamBeginCapture_Negative_DetectingInvalidCapture) {
   StreamsGuard streams(2);
   EventsGuard events(1);
   hipEvent_t event = events[0];
@@ -774,7 +774,7 @@ TEST_CASE("Unit_hipStreamBeginCapture_Negative_DetectingInvalidCapture") {
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_hipStreamBeginCapture_Positive_CapturingMultGraphsFrom1Strm") {
+TEST_CASE(Unit_hipStreamBeginCapture_Positive_CapturingMultGraphsFrom1Strm) {
   hipGraph_t graphs[3];
 
   StreamGuard stream_guard(Streams::created);
@@ -823,7 +823,7 @@ TEST_CASE("Unit_hipStreamBeginCapture_Positive_CapturingMultGraphsFrom1Strm") {
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_hipStreamBeginCapture_Negative_CheckingSyncDuringCapture") {
+TEST_CASE(Unit_hipStreamBeginCapture_Negative_CheckingSyncDuringCapture) {
   const hipStreamCaptureMode captureMode = GENERATE(
       hipStreamCaptureModeGlobal, hipStreamCaptureModeThreadLocal, hipStreamCaptureModeRelaxed);
   const unsigned int stream_flag = GENERATE(hipStreamDefault, hipStreamNonBlocking);
@@ -873,7 +873,7 @@ TEST_CASE("Unit_hipStreamBeginCapture_Negative_CheckingSyncDuringCapture") {
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_hipStreamBeginCapture_Negative_Concurrent_CheckingSyncDuringCapture") {
+TEST_CASE(Unit_hipStreamBeginCapture_Negative_Concurrent_CheckingSyncDuringCapture) {
   const hipStreamCaptureMode captureMode = GENERATE(
       hipStreamCaptureModeGlobal, hipStreamCaptureModeThreadLocal, hipStreamCaptureModeRelaxed);
   const unsigned int stream_flag = GENERATE(hipStreamDefault, hipStreamNonBlocking);
@@ -974,7 +974,7 @@ TEST_CASE("Unit_hipStreamBeginCapture_Negative_Concurrent_CheckingSyncDuringCapt
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_hipStreamBeginCapture_Negative_UnsafeCallsDuringCapture") {
+TEST_CASE(Unit_hipStreamBeginCapture_Negative_UnsafeCallsDuringCapture) {
   StreamGuard stream_guard(Streams::created);
   hipStream_t stream = stream_guard.stream();
 
@@ -1018,7 +1018,7 @@ TEST_CASE("Unit_hipStreamBeginCapture_Negative_UnsafeCallsDuringCapture") {
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_hipStreamBeginCapture_Negative_EndingCapwhenCapInProg") {
+TEST_CASE(Unit_hipStreamBeginCapture_Negative_EndingCapwhenCapInProg) {
   hipGraph_t graph{nullptr};
 
   StreamsGuard streams_guard(2);
@@ -1064,7 +1064,7 @@ TEST_CASE("Unit_hipStreamBeginCapture_Negative_EndingCapwhenCapInProg") {
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_hipStreamBeginCapture_Positive_MultiGPU", "[multigpu]") {
+TEST_CASE(Unit_hipStreamBeginCapture_Positive_MultiGPU) {
   int devcount = 0;
   HIP_CHECK(hipGetDeviceCount(&devcount));
   // If only single GPU is detected then return
@@ -1142,7 +1142,7 @@ TEST_CASE("Unit_hipStreamBeginCapture_Positive_MultiGPU", "[multigpu]") {
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_hipStreamBeginCapture_Positive_nestedStreamCapture") {
+TEST_CASE(Unit_hipStreamBeginCapture_Positive_nestedStreamCapture) {
   constexpr int INCREMENT_KERNEL_FINALEXP_VAL = 7;
 
   hipGraph_t graph{nullptr};
@@ -1204,7 +1204,7 @@ TEST_CASE("Unit_hipStreamBeginCapture_Positive_nestedStreamCapture") {
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_hipStreamBeginCapture_Positive_streamReuse") {
+TEST_CASE(Unit_hipStreamBeginCapture_Positive_streamReuse) {
   constexpr int increment_kernel_vals[3] = {7, 3, 5};
 
   hipGraph_t graphs[3];
@@ -1290,7 +1290,7 @@ TEST_CASE("Unit_hipStreamBeginCapture_Positive_streamReuse") {
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_hipStreamBeginCapture_Positive_captureComplexGraph") {
+TEST_CASE(Unit_hipStreamBeginCapture_Positive_captureComplexGraph) {
   constexpr int GRIDSIZE = 256;
   constexpr int BLOCKSIZE = 256;
   constexpr int CONST_KER1_VAL = 3;
@@ -1377,7 +1377,7 @@ TEST_CASE("Unit_hipStreamBeginCapture_Positive_captureComplexGraph") {
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_hipStreamBeginCapture_Positive_captureEmptyStreams") {
+TEST_CASE(Unit_hipStreamBeginCapture_Positive_captureEmptyStreams) {
   hipGraph_t graph{nullptr};
 
   // Stream and event create
@@ -1414,7 +1414,7 @@ TEST_CASE("Unit_hipStreamBeginCapture_Positive_captureEmptyStreams") {
  *    - HIP_VERSION >= 5.6
  */
 
-TEST_CASE("Unit_hipStreamBeginCapture_StreamSync_OngoingCapture") {
+TEST_CASE(Unit_hipStreamBeginCapture_StreamSync_OngoingCapture) {
   hipStreamCaptureMode flag = hipStreamCaptureModeRelaxed;
   constexpr int GRIDSIZE = 1;
   constexpr int BLOCKSIZE = 512;
@@ -1540,7 +1540,7 @@ static void captureStrmThread(hipGraph_t* graph, int* Ah, int* Ad, int* Bh, int*
   }
 }
 
-TEST_CASE("Unit_hipStreamBeginCapture_StreamSync_OngoingCapture_MThread") {
+TEST_CASE(Unit_hipStreamBeginCapture_StreamSync_OngoingCapture_MThread) {
   constexpr int GRIDSIZE = 1;
   constexpr int BLOCKSIZE = 512;
   constexpr int VALUE1 = 7, VALUE2 = 11;
@@ -1626,7 +1626,7 @@ TEST_CASE("Unit_hipStreamBeginCapture_StreamSync_OngoingCapture_MThread") {
  * ------------------------
  *    - HIP_VERSION >= 5.6
  */
-TEST_CASE("Unit_hipStreamBeginCapture_MultipleStreams_ReuseEvent") {
+TEST_CASE(Unit_hipStreamBeginCapture_MultipleStreams_ReuseEvent) {
   // Allocate streams
   hipStream_t str0, str1, str2;
   hipEvent_t ev0, ev1, ev2;

--- a/projects/hip-tests/catch/unit/graph/hipStreamBeginCaptureToGraph.cc
+++ b/projects/hip-tests/catch/unit/graph/hipStreamBeginCaptureToGraph.cc
@@ -112,7 +112,7 @@ static bool CaptureStreamAndLaunchGraph(int* A_d, int* B_d, int* C_d, int* A_h, 
  * ------------------------
  *    - HIP_VERSION >= 6.2
  */
-TEST_CASE("Unit_hipStreamBeginCaptureToGraph_BasicFunctional") {
+TEST_CASE(Unit_hipStreamBeginCaptureToGraph_BasicFunctional) {
   int *A_d, *B_d, *C_d;
   std::vector<int> A_h(N), B_h(N), C_h(N);
   size_t Nbytes = N * sizeof(int);
@@ -179,7 +179,7 @@ TEST_CASE("Unit_hipStreamBeginCaptureToGraph_BasicFunctional") {
  * ------------------------
  *    - HIP_VERSION >= 6.2
  */
-TEST_CASE("Unit_hipStreamBeginCaptureToGraph_CaptureIndepGraph") {
+TEST_CASE(Unit_hipStreamBeginCaptureToGraph_CaptureIndepGraph) {
   int *A1_d, *B1_d, *C1_d;
   std::vector<int> A1_h(N), B1_h(N), C1_h(N);
   int *A2_d, *B2_d, *C2_d;
@@ -276,7 +276,7 @@ TEST_CASE("Unit_hipStreamBeginCaptureToGraph_CaptureIndepGraph") {
  *    - HIP_VERSION >= 6.2
  */
 #ifdef __linux__
-TEST_CASE("Unit_hipStreamBeginCaptureToGraph_CaptureDepGraph") {
+TEST_CASE(Unit_hipStreamBeginCaptureToGraph_CaptureDepGraph) {
   hipGraphExec_t graphExec{nullptr};
   int *A1_d, *B1_d, *C1_d, *C2_d;
   std::vector<int> A1_h(N), B1_h(N), C1_h(N), C2_h(N);
@@ -374,7 +374,7 @@ TEST_CASE("Unit_hipStreamBeginCaptureToGraph_CaptureDepGraph") {
  * ------------------------
  *    - HIP_VERSION >= 6.2
  */
-TEST_CASE("Unit_hipStreamBeginCaptureToGraph_ComplexGraph") {
+TEST_CASE(Unit_hipStreamBeginCaptureToGraph_ComplexGraph) {
   int *A_d, *B_d, *C_d, *D_d;
   std::vector<int> A_h(N), B_h(N), C_h(N), D_h(N);
   size_t Nbytes = N * sizeof(int);
@@ -475,7 +475,7 @@ TEST_CASE("Unit_hipStreamBeginCaptureToGraph_ComplexGraph") {
  * ------------------------
  *    - HIP_VERSION >= 6.2
  */
-TEST_CASE("Unit_hipStreamBeginCaptureToGraph_CaptureTwice") {
+TEST_CASE(Unit_hipStreamBeginCaptureToGraph_CaptureTwice) {
   bool useSameAPI = GENERATE(true, false);
   int *A_d, *B_d, *C_d, *D_d;
   std::vector<int> A_h(N), B_h(N), C_h(N), D_h(N);
@@ -573,7 +573,7 @@ TEST_CASE("Unit_hipStreamBeginCaptureToGraph_CaptureTwice") {
  * ------------------------
  *    - HIP_VERSION >= 6.2
  */
-TEST_CASE("Unit_hipStreamBeginCaptureToGraph_ModifyCloneGraph") {
+TEST_CASE(Unit_hipStreamBeginCaptureToGraph_ModifyCloneGraph) {
   int *A_d, *B_d, *C_d, *D_d;
   std::vector<int> A_h(N), B_h(N), C_h(N), D_h(N);
   size_t Nbytes = N * sizeof(int);
@@ -668,7 +668,7 @@ TEST_CASE("Unit_hipStreamBeginCaptureToGraph_ModifyCloneGraph") {
  * ------------------------
  *    - HIP_VERSION >= 6.2
  */
-TEST_CASE("Unit_hipStreamBeginCaptureToGraph_CaptureChildpGraph") {
+TEST_CASE(Unit_hipStreamBeginCaptureToGraph_CaptureChildpGraph) {
   int *A_d, *B_d, *C_d, *D_d;
   std::vector<int> A_h(N), B_h(N), C_h(N), D_h(N);
   size_t Nbytes = N * sizeof(int);
@@ -762,7 +762,7 @@ TEST_CASE("Unit_hipStreamBeginCaptureToGraph_CaptureChildpGraph") {
  * ------------------------
  *    - HIP_VERSION >= 6.2
  */
-TEST_CASE("Unit_hipStreamBeginCaptureToGraph_ModifyChildpGraph") {
+TEST_CASE(Unit_hipStreamBeginCaptureToGraph_ModifyChildpGraph) {
   int *A_d, *B_d, *C_d, *D_d;
   std::vector<int> A_h(N), B_h(N), C_h(N), D_h(N);
   size_t Nbytes = N * sizeof(int);
@@ -856,7 +856,7 @@ TEST_CASE("Unit_hipStreamBeginCaptureToGraph_ModifyChildpGraph") {
  * ------------------------
  *    - HIP_VERSION >= 6.2
  */
-TEST_CASE("Unit_hipStreamBeginCaptureToGraph_Negative") {
+TEST_CASE(Unit_hipStreamBeginCaptureToGraph_Negative) {
   // Create streams and graph
   hipStream_t stream;
   hipGraph_t graph{nullptr};
@@ -899,7 +899,7 @@ TEST_CASE("Unit_hipStreamBeginCaptureToGraph_Negative") {
  * ------------------------
  *    - HIP_VERSION >= 6.2
  */
-TEST_CASE("Unit_hipStreamBeginCaptureToGraph_StateTesting") {
+TEST_CASE(Unit_hipStreamBeginCaptureToGraph_StateTesting) {
   // Create streams and graph
   hipStream_t stream1, stream2;
   hipEvent_t e;
@@ -941,7 +941,7 @@ TEST_CASE("Unit_hipStreamBeginCaptureToGraph_StateTesting") {
  * ------------------------
  *    - HIP_VERSION >= 6.2
  */
-TEST_CASE("Unit_hipStreamBeginCaptureToGraph_GetCaptureInfo") {
+TEST_CASE(Unit_hipStreamBeginCaptureToGraph_GetCaptureInfo) {
   // Create streams and graph
   hipStream_t stream1, stream2;
   hipEvent_t e;
@@ -987,7 +987,7 @@ TEST_CASE("Unit_hipStreamBeginCaptureToGraph_GetCaptureInfo") {
  * ------------------------
  *    - HIP_VERSION >= 6.2
  */
-TEST_CASE("Unit_hipStreamBeginCaptureToGraph_EndingWhileCaptureInProgress") {
+TEST_CASE(Unit_hipStreamBeginCaptureToGraph_EndingWhileCaptureInProgress) {
   hipStream_t stream1, stream2;
   hipGraph_t graph{nullptr};
   HIP_CHECK(hipGraphCreate(&graph, 0));
@@ -1050,7 +1050,7 @@ TEST_CASE("Unit_hipStreamBeginCaptureToGraph_EndingWhileCaptureInProgress") {
  */
 enum class strmFlag { defFlag, sameFlag, diffFlag, diffPrio };
 
-TEST_CASE("Unit_hipStreamBeginCaptureToGraph_MultipleFlags") {
+TEST_CASE(Unit_hipStreamBeginCaptureToGraph_MultipleFlags) {
   strmFlag flag =
       GENERATE(strmFlag::defFlag, strmFlag::sameFlag, strmFlag::diffFlag, strmFlag::diffPrio);
   int *A_d, *B_d, *C_d;
@@ -1136,7 +1136,7 @@ static void threadCaptureStart(hipStream_t* streamCapt, hipStream_t* streamFork,
   HIP_CHECK(hipEventDestroy(e));
 }
 
-TEST_CASE("Unit_hipStreamBeginCaptureToGraph_CapturePartialInThreads") {
+TEST_CASE(Unit_hipStreamBeginCaptureToGraph_CapturePartialInThreads) {
   int *A_d, *B_d, *C_d;
   std::vector<int> A_h(N), B_h(N), C_h(N);
   size_t Nbytes = N * sizeof(int);
@@ -1206,7 +1206,7 @@ void threadCaptureExec(int* A_d, int* B_d, int* C_d, int* A_h, int* B_h, int* C_
   retValG.fetch_and(val);
 }
 
-TEST_CASE("Unit_hipStreamBeginCaptureToGraph_IndepGraphsThreads") {
+TEST_CASE(Unit_hipStreamBeginCaptureToGraph_IndepGraphsThreads) {
   int *A1_d, *B1_d, *C1_d;
   std::vector<int> A1_h(N), B1_h(N), C1_h(N);
   int *A2_d, *B2_d, *C2_d;
@@ -1265,6 +1265,6 @@ TEST_CASE("Unit_hipStreamBeginCaptureToGraph_IndepGraphsThreads") {
   HIP_CHECK(hipFree(A2_d));
   HIP_CHECK(hipFree(B2_d));
   HIP_CHECK(hipFree(C2_d));
-  fprintf(stderr, "Unit_hipStreamBeginCaptureToGraph_IndepGraphsThreads\n");
+  fprintf(stderr, "hipStreamBeginCaptureToGraph_IndepGraphsThreads\n");
 }
 #endif

--- a/projects/hip-tests/catch/unit/graph/hipStreamBeginCapture_old.cc
+++ b/projects/hip-tests/catch/unit/graph/hipStreamBeginCapture_old.cc
@@ -182,7 +182,7 @@ bool CaptureStreamAndLaunchGraph(float* A_d, float* C_d, float* A_h, float* C_h,
  * Stream capture with different modes behave the same when supported/
  * safe apis are used in sequence.
  */
-TEST_CASE("Unit_hipStreamBeginCapture_BasicFunctional") {
+TEST_CASE(Unit_hipStreamBeginCapture_BasicFunctional) {
   float *A_d, *C_d;
   float *A_h, *C_h;
   size_t Nbytes = N * sizeof(float);
@@ -230,7 +230,7 @@ TEST_CASE("Unit_hipStreamBeginCapture_BasicFunctional") {
 /**
  * Perform capture on hipStreamPerThread, launch the graph and verify results.
  */
-TEST_CASE("Unit_hipStreamBeginCapture_hipStreamPerThread") {
+TEST_CASE(Unit_hipStreamBeginCapture_hipStreamPerThread) {
   float *A_d, *C_d;
   float *A_h, *C_h;
   size_t Nbytes = N * sizeof(float);
@@ -277,7 +277,7 @@ TEST_CASE("Unit_hipStreamBeginCapture_hipStreamPerThread") {
 /* Test verifies hipStreamBeginCapture API Negative scenarios.
  */
 
-TEST_CASE("Unit_hipStreamBeginCapture_Negative") {
+TEST_CASE(Unit_hipStreamBeginCapture_Negative) {
   hipError_t ret;
   hipStream_t stream{};
   HIP_CHECK(hipStreamCreate(&stream));
@@ -301,7 +301,7 @@ TEST_CASE("Unit_hipStreamBeginCapture_Negative") {
   HIP_CHECK(hipStreamDestroy(stream));
 }
 
-TEST_CASE("Unit_hipStreamBeginCapture_Basic") {
+TEST_CASE(Unit_hipStreamBeginCapture_Basic) {
   hipStream_t s1, s2, s3;
 
   HIP_CHECK(hipStreamCreate(&s1));
@@ -543,7 +543,7 @@ static void multithreadedTest(hipStreamCaptureMode mode) {
 }
 /* Test scenario 5.1
  */
-TEST_CASE("Unit_hipStreamBeginCapture_InterStrmEventSync_defaultflag") {
+TEST_CASE(Unit_hipStreamBeginCapture_InterStrmEventSync_defaultflag) {
   hipStream_t stream1, stream2;
   HIP_CHECK(hipStreamCreate(&stream1));
   HIP_CHECK(hipStreamCreate(&stream2));
@@ -553,7 +553,7 @@ TEST_CASE("Unit_hipStreamBeginCapture_InterStrmEventSync_defaultflag") {
 }
 /* Test scenario 5.2
  */
-TEST_CASE("Unit_hipStreamBeginCapture_InterStrmEventSync_blockingflag") {
+TEST_CASE(Unit_hipStreamBeginCapture_InterStrmEventSync_blockingflag) {
   hipStream_t stream1, stream2;
   HIP_CHECK(hipStreamCreateWithFlags(&stream1, hipStreamNonBlocking));
   HIP_CHECK(hipStreamCreateWithFlags(&stream2, hipStreamNonBlocking));
@@ -563,7 +563,7 @@ TEST_CASE("Unit_hipStreamBeginCapture_InterStrmEventSync_blockingflag") {
 }
 /* Test scenario 5.3
  */
-TEST_CASE("Unit_hipStreamBeginCapture_InterStrmEventSync_diffflags") {
+TEST_CASE(Unit_hipStreamBeginCapture_InterStrmEventSync_diffflags) {
   hipStream_t stream1, stream2;
   HIP_CHECK(hipStreamCreateWithFlags(&stream1, hipStreamNonBlocking));
   HIP_CHECK(hipStreamCreateWithFlags(&stream2, hipStreamDefault));
@@ -573,7 +573,7 @@ TEST_CASE("Unit_hipStreamBeginCapture_InterStrmEventSync_diffflags") {
 }
 /* Test scenario 5.4
  */
-TEST_CASE("Unit_hipStreamBeginCapture_InterStrmEventSync_diffprio") {
+TEST_CASE(Unit_hipStreamBeginCapture_InterStrmEventSync_diffprio) {
   hipStream_t stream1, stream2;
   int minPriority = 0, maxPriority = 0;
   HIP_CHECK(hipDeviceGetStreamPriorityRange(&minPriority, &maxPriority));
@@ -585,7 +585,7 @@ TEST_CASE("Unit_hipStreamBeginCapture_InterStrmEventSync_diffprio") {
 }
 /* Test scenario 6.1
  */
-TEST_CASE("Unit_hipStreamBeginCapture_ColligatedStrmCapture_defaultflag") {
+TEST_CASE(Unit_hipStreamBeginCapture_ColligatedStrmCapture_defaultflag) {
   hipStream_t stream1, stream2;
   HIP_CHECK(hipStreamCreate(&stream1));
   HIP_CHECK(hipStreamCreate(&stream2));
@@ -595,7 +595,7 @@ TEST_CASE("Unit_hipStreamBeginCapture_ColligatedStrmCapture_defaultflag") {
 }
 /* Test scenario 6.2
  */
-TEST_CASE("Unit_hipStreamBeginCapture_ColligatedStrmCapture_blockingflag") {
+TEST_CASE(Unit_hipStreamBeginCapture_ColligatedStrmCapture_blockingflag) {
   hipStream_t stream1, stream2;
   HIP_CHECK(hipStreamCreateWithFlags(&stream1, hipStreamNonBlocking));
   HIP_CHECK(hipStreamCreateWithFlags(&stream2, hipStreamNonBlocking));
@@ -605,7 +605,7 @@ TEST_CASE("Unit_hipStreamBeginCapture_ColligatedStrmCapture_blockingflag") {
 }
 /* Test scenario 6.3
  */
-TEST_CASE("Unit_hipStreamBeginCapture_ColligatedStrmCapture_diffflags") {
+TEST_CASE(Unit_hipStreamBeginCapture_ColligatedStrmCapture_diffflags) {
   hipStream_t stream1, stream2;
   HIP_CHECK(hipStreamCreateWithFlags(&stream1, hipStreamNonBlocking));
   HIP_CHECK(hipStreamCreateWithFlags(&stream2, hipStreamDefault));
@@ -615,7 +615,7 @@ TEST_CASE("Unit_hipStreamBeginCapture_ColligatedStrmCapture_diffflags") {
 }
 /* Test scenario 6.4
  */
-TEST_CASE("Unit_hipStreamBeginCapture_ColligatedStrmCapture_diffprio") {
+TEST_CASE(Unit_hipStreamBeginCapture_ColligatedStrmCapture_diffprio) {
   hipStream_t stream1, stream2;
   int minPriority = 0, maxPriority = 0;
   HIP_CHECK(hipDeviceGetStreamPriorityRange(&minPriority, &maxPriority));
@@ -627,7 +627,7 @@ TEST_CASE("Unit_hipStreamBeginCapture_ColligatedStrmCapture_diffprio") {
 }
 /* Test scenario 7
  */
-TEST_CASE("Unit_hipStreamBeginCapture_multiplestrms") {
+TEST_CASE(Unit_hipStreamBeginCapture_multiplestrms) {
   hipStream_t stream1, stream2, stream3;
   HIP_CHECK(hipStreamCreate(&stream1));
   HIP_CHECK(hipStreamCreate(&stream2));
@@ -695,7 +695,7 @@ TEST_CASE("Unit_hipStreamBeginCapture_multiplestrms") {
 }
 /* Test scenario 8
  */
-TEST_CASE("Unit_hipStreamBeginCapture_ColligatedStrmCapture_func") {
+TEST_CASE(Unit_hipStreamBeginCapture_ColligatedStrmCapture_func) {
   hipStream_t stream1, stream2;
   HIP_CHECK(hipStreamCreate(&stream1));
   HIP_CHECK(hipStreamCreate(&stream2));
@@ -705,22 +705,22 @@ TEST_CASE("Unit_hipStreamBeginCapture_ColligatedStrmCapture_func") {
 }
 /* Test scenario 9.1
  */
-TEST_CASE("Unit_hipStreamBeginCapture_Multithreaded_Global") {
+TEST_CASE(Unit_hipStreamBeginCapture_Multithreaded_Global) {
   multithreadedTest(hipStreamCaptureModeGlobal);
 }
 /* Test scenario 9.2
  */
-TEST_CASE("Unit_hipStreamBeginCapture_Multithreaded_ThreadLocal") {
+TEST_CASE(Unit_hipStreamBeginCapture_Multithreaded_ThreadLocal) {
   multithreadedTest(hipStreamCaptureModeThreadLocal);
 }
 /* Test scenario 9.3
  */
-TEST_CASE("Unit_hipStreamBeginCapture_Multithreaded_Relaxed") {
+TEST_CASE(Unit_hipStreamBeginCapture_Multithreaded_Relaxed) {
   multithreadedTest(hipStreamCaptureModeRelaxed);
 }
 /* Test scenario 10
  */
-TEST_CASE("Unit_hipStreamBeginCapture_CapturingFromWithinStrms") {
+TEST_CASE(Unit_hipStreamBeginCapture_CapturingFromWithinStrms) {
   hipGraph_t graph;
   hipStream_t stream1, stream2, stream3;
   HIP_CHECK(hipStreamCreate(&stream1));
@@ -780,7 +780,7 @@ TEST_CASE("Unit_hipStreamBeginCapture_CapturingFromWithinStrms") {
 }
 /* Test scenario 11
  */
-TEST_CASE("Unit_hipStreamBeginCapture_DetectingInvalidCapture") {
+TEST_CASE(Unit_hipStreamBeginCapture_DetectingInvalidCapture) {
   hipStream_t stream1, stream2;
   HIP_CHECK(hipStreamCreate(&stream1));
   HIP_CHECK(hipStreamCreate(&stream2));
@@ -802,7 +802,7 @@ TEST_CASE("Unit_hipStreamBeginCapture_DetectingInvalidCapture") {
 }
 /* Test scenario 12
  */
-TEST_CASE("Unit_hipStreamBeginCapture_CapturingMultGraphsFrom1Strm") {
+TEST_CASE(Unit_hipStreamBeginCapture_CapturingMultGraphsFrom1Strm) {
   hipStream_t stream1;
   HIP_CHECK(hipStreamCreate(&stream1));
   hipGraph_t graph[3];
@@ -850,7 +850,7 @@ TEST_CASE("Unit_hipStreamBeginCapture_CapturingMultGraphsFrom1Strm") {
 #if HT_NVIDIA
 /* Test scenario 13
  */
-TEST_CASE("Unit_hipStreamBeginCapture_CheckingSyncDuringCapture") {
+TEST_CASE(Unit_hipStreamBeginCapture_CheckingSyncDuringCapture) {
   hipStream_t stream;
   HIP_CHECK(hipStreamCreate(&stream));
   SECTION("Synchronize stream during capture") {
@@ -894,7 +894,7 @@ TEST_CASE("Unit_hipStreamBeginCapture_CheckingSyncDuringCapture") {
 #endif
 /* Test scenario 14
  */
-TEST_CASE("Unit_hipStreamBeginCapture_EndingCapturewhenCaptureInProgress") {
+TEST_CASE(Unit_hipStreamBeginCapture_EndingCapturewhenCaptureInProgress) {
   hipStream_t stream1, stream2;
   hipGraph_t graph;
   HIP_CHECK(hipStreamCreate(&stream1));
@@ -932,7 +932,7 @@ TEST_CASE("Unit_hipStreamBeginCapture_EndingCapturewhenCaptureInProgress") {
 
 /* Test scenario 15
  */
-TEST_CASE("Unit_hipStreamBeginCapture_MultiGPU", "[multigpu]") {
+TEST_CASE(Unit_hipStreamBeginCapture_MultiGPU) {
   int devcount = 0;
   HIP_CHECK(hipGetDeviceCount(&devcount));
   // If only single GPU is detected then return
@@ -995,7 +995,7 @@ TEST_CASE("Unit_hipStreamBeginCapture_MultiGPU", "[multigpu]") {
 }
 /* Test scenario 16
  */
-TEST_CASE("Unit_hipStreamBeginCapture_nestedStreamCapture") {
+TEST_CASE(Unit_hipStreamBeginCapture_nestedStreamCapture) {
   hipGraph_t graph;
   hipStream_t stream1, stream2, stream3;
   HIP_CHECK(hipStreamCreate(&stream1));
@@ -1055,7 +1055,7 @@ TEST_CASE("Unit_hipStreamBeginCapture_nestedStreamCapture") {
 }
 /* Test scenario 17
  */
-TEST_CASE("Unit_hipStreamBeginCapture_streamReuse") {
+TEST_CASE(Unit_hipStreamBeginCapture_streamReuse) {
   hipGraph_t graph1, graph2, graph3;
   hipStream_t stream1, stream2, stream3;
   HIP_CHECK(hipStreamCreate(&stream1));
@@ -1149,7 +1149,7 @@ TEST_CASE("Unit_hipStreamBeginCapture_streamReuse") {
 
 /* Test scenario 18
  */
-TEST_CASE("Unit_hipStreamBeginCapture_captureComplexGraph") {
+TEST_CASE(Unit_hipStreamBeginCapture_captureComplexGraph) {
   hipGraph_t graph;
   hipStream_t stream1, stream2, stream3, stream4, stream5;
   // Stream and event create
@@ -1239,7 +1239,7 @@ TEST_CASE("Unit_hipStreamBeginCapture_captureComplexGraph") {
 }
 /* Test scenario 19
  */
-TEST_CASE("Unit_hipStreamBeginCapture_captureEmptyStreams") {
+TEST_CASE(Unit_hipStreamBeginCapture_captureEmptyStreams) {
   hipGraph_t graph;
   hipStream_t stream1, stream2, stream3;
   // Stream and event create

--- a/projects/hip-tests/catch/unit/graph/hipStreamCaptureExtModuleLaunchKernel.cc
+++ b/projects/hip-tests/catch/unit/graph/hipStreamCaptureExtModuleLaunchKernel.cc
@@ -177,7 +177,7 @@ bool GraphModuleLaunchKernel::extModuleKernelExecutionMatmulwithStreamCapture(
   return testStatus;
 }
 
-TEST_CASE("Unit_hipStreamCapture_ExtModuleLaunchKernel") {
+TEST_CASE(Unit_hipStreamCapture_ExtModuleLaunchKernel) {
   struct stat fileStat;
   if (stat(GraphModuleLaunchKernel::fileName, &fileStat) || !(fileStat.st_mode & S_IFREG)) {
     FAIL("module file " << GraphModuleLaunchKernel::fileName << " doesn't exist! aborted! \n"

--- a/projects/hip-tests/catch/unit/graph/hipStreamEndCapture.cc
+++ b/projects/hip-tests/catch/unit/graph/hipStreamEndCapture.cc
@@ -45,7 +45,7 @@ THE SOFTWARE.
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_hipStreamEndCapture_Negative_Parameters") {
+TEST_CASE(Unit_hipStreamEndCapture_Negative_Parameters) {
   hipGraph_t graph{nullptr};
   const auto stream_type = GENERATE(Streams::perThread, Streams::created);
   StreamGuard stream_guard(stream_type);
@@ -76,7 +76,7 @@ TEST_CASE("Unit_hipStreamEndCapture_Negative_Parameters") {
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_hipStreamEndCapture_Positive_GraphDestroy") {
+TEST_CASE(Unit_hipStreamEndCapture_Positive_GraphDestroy) {
   hipGraph_t graph{nullptr};
   constexpr size_t N = 1000000;
   size_t Nbytes = N * sizeof(float);
@@ -116,7 +116,7 @@ static void thread_func_neg(hipStream_t stream, hipGraph_t graph) {
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_hipStreamEndCapture_Negative_Thread") {
+TEST_CASE(Unit_hipStreamEndCapture_Negative_Thread) {
   constexpr size_t N = 1000000;
   size_t Nbytes = N * sizeof(float);
 
@@ -160,7 +160,7 @@ static void thread_func_pos(hipStream_t stream, hipGraph_t* graph) {
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_hipStreamEndCapture_Positive_Thread") {
+TEST_CASE(Unit_hipStreamEndCapture_Positive_Thread) {
   constexpr size_t N = 1000000;
   size_t Nbytes = N * sizeof(float);
 

--- a/projects/hip-tests/catch/unit/graph/hipStreamEndCapture_old.cc
+++ b/projects/hip-tests/catch/unit/graph/hipStreamEndCapture_old.cc
@@ -52,7 +52,7 @@ Negative Testcase Scenarios :
 #include <hip_test_common.hh>
 #include <hip_test_kernels.hh>
 
-TEST_CASE("Unit_hipStreamEndCapture_Negative") {
+TEST_CASE(Unit_hipStreamEndCapture_Negative) {
   hipError_t ret;
   SECTION("Pass stream as nullptr") {
     hipGraph_t graph;
@@ -160,7 +160,7 @@ static void StreamEndCaptureThreadNegative(float* A_d, float* A_h, float* C_d, f
   HIP_CHECK(hipStreamDestroy(stream));
   HIP_CHECK(hipGraphDestroy(graph));
 }
-TEST_CASE("Unit_hipStreamEndCapture_Thread_Negative") {
+TEST_CASE(Unit_hipStreamEndCapture_Thread_Negative) {
   constexpr size_t N = 100000;
   size_t Nbytes = N * sizeof(float);
   float *A_d, *C_d;
@@ -205,7 +205,7 @@ static void thread_func1(hipStream_t stream, hipGraph_t* graph, size_t Nbytes, f
  * stream1 and return the captured graph. Wait for the thread in main function.
  * Create an executable graph and launch the graph on input data and validate the output.
  * */
-TEST_CASE("Unit_hipStreamEndCapture_mode_hipStreamCaptureModeRelaxed") {
+TEST_CASE(Unit_hipStreamEndCapture_mode_hipStreamCaptureModeRelaxed) {
   hipStream_t stream{nullptr}, streamForGraph{nullptr};
   hipGraph_t graph{nullptr};
   constexpr unsigned threadsPerBlock = 256;
@@ -276,7 +276,7 @@ static __global__ void increment(int* A_d) { atomicAdd(A_d, 1); }
  * (like increment kernel) on both s1 and s2. End the stream capture
  * on s2 and verify the error returned by the End capture.
  */
-TEST_CASE("Unit_hipStreamEndCapture_chkError_on_wrongStream") {
+TEST_CASE(Unit_hipStreamEndCapture_chkError_on_wrongStream) {
   int *A_d{nullptr}, *A_h{nullptr};
   hipStream_t stream1{nullptr}, stream2{nullptr};
   hipEvent_t forkStreamEvent{nullptr};
@@ -336,7 +336,7 @@ static void thread_func4(hipStream_t stream1, hipStream_t stream2, hipEvent_t ev
  * stream capture in s1. Create an executable graph and launch the graph on input
  * data and validate the output.
  * */
-TEST_CASE("Unit_hipStreamEndCapture_streamMerge_in_thread") {
+TEST_CASE(Unit_hipStreamEndCapture_streamMerge_in_thread) {
   // Device Pointers
   int *A_d, *B_d, *C_d;
   // Host Pointers

--- a/projects/hip-tests/catch/unit/graph/hipStreamGetCaptureInfo.cc
+++ b/projects/hip-tests/catch/unit/graph/hipStreamGetCaptureInfo.cc
@@ -95,7 +95,7 @@ void checkStreamCaptureInfo(hipStreamCaptureMode mode, hipStream_t stream) {
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_hipStreamGetCaptureInfo_Positive_Functional") {
+TEST_CASE(Unit_hipStreamGetCaptureInfo_Positive_Functional) {
   const auto stream_type = GENERATE(Streams::perThread, Streams::created);
   StreamGuard stream_guard(stream_type);
   hipStream_t stream = stream_guard.stream();
@@ -118,7 +118,7 @@ TEST_CASE("Unit_hipStreamGetCaptureInfo_Positive_Functional") {
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_hipStreamGetCaptureInfo_Positive_UniqueID") {
+TEST_CASE(Unit_hipStreamGetCaptureInfo_Positive_UniqueID) {
   constexpr int numStreams = 100;
   hipStreamCaptureStatus captureStatus{hipStreamCaptureStatusNone};
   std::vector<int> idlist;
@@ -164,7 +164,7 @@ TEST_CASE("Unit_hipStreamGetCaptureInfo_Positive_UniqueID") {
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_hipStreamGetCaptureInfo_Negative_Parameters") {
+TEST_CASE(Unit_hipStreamGetCaptureInfo_Negative_Parameters) {
 #if HT_NVIDIA
   hipStreamCaptureStatus cStatus;
 #endif

--- a/projects/hip-tests/catch/unit/graph/hipStreamGetCaptureInfo_old.cc
+++ b/projects/hip-tests/catch/unit/graph/hipStreamGetCaptureInfo_old.cc
@@ -84,7 +84,7 @@ constexpr int LAUNCH_ITERS = 1;
  * capture info (status and id) of both s1 and s2 are identical.
  * The above scenario using hipStreamGetCaptureInfo_v2 API
  */
-TEST_CASE("Unit_hipStreamGetCaptureInfo_ParentAndForkedStrm_CaptureStatus") {
+TEST_CASE(Unit_hipStreamGetCaptureInfo_ParentAndForkedStrm_CaptureStatus) {
   hipStream_t stream1{nullptr}, stream2{nullptr};
   hipEvent_t event2{nullptr}, forkStreamEvent{nullptr};
   hipGraph_t graph{nullptr};
@@ -216,7 +216,7 @@ static void thread_func(hipStream_t stream, unsigned long long capSequenceID1,  
  * thread is same as capture id in main function. Exit the thread and end the capture
  * The above scenario using hipStreamGetCaptureInfo_v2 API
  */
-TEST_CASE("Unit_hipStreamGetCaptureInfo_CaptureStatus_InThread") {
+TEST_CASE(Unit_hipStreamGetCaptureInfo_CaptureStatus_InThread) {
   hipStream_t stream{nullptr};
   hipGraph_t graph{nullptr};
 
@@ -246,7 +246,7 @@ TEST_CASE("Unit_hipStreamGetCaptureInfo_CaptureStatus_InThread") {
  * capture info. Verify that all the capture info are identical.
  * The above scenario using hipStreamGetCaptureInfo_v2 API
  */
-TEST_CASE("Unit_hipStreamGetCaptureInfo_CaptureStatus_Througout_Capture") {
+TEST_CASE(Unit_hipStreamGetCaptureInfo_CaptureStatus_Througout_Capture) {
   hipStream_t stream{nullptr};
   hipGraph_t graph{nullptr};
   float *A_d, *B_d, *C_d, *D_d;
@@ -340,7 +340,7 @@ TEST_CASE("Unit_hipStreamGetCaptureInfo_CaptureStatus_Througout_Capture") {
  * graph and verify the output from the operations.
  * The above scenario using hipStreamGetCaptureInfo_v2 API
  */
-TEST_CASE("Unit_hipStreamGetCaptureInfo_Nullstream_CaptureInfo") {
+TEST_CASE(Unit_hipStreamGetCaptureInfo_Nullstream_CaptureInfo) {
   hipStream_t stream{nullptr}, streamForGraph{nullptr};
   hipGraph_t graph{nullptr};
   hipError_t ret;

--- a/projects/hip-tests/catch/unit/graph/hipStreamGetCaptureInfo_v2.cc
+++ b/projects/hip-tests/catch/unit/graph/hipStreamGetCaptureInfo_v2.cc
@@ -148,7 +148,7 @@ void checkStreamCaptureInfo_v2(hipStreamCaptureMode mode, hipStream_t stream) {
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_hipStreamGetCaptureInfo_v2_Positive_Functional") {
+TEST_CASE(Unit_hipStreamGetCaptureInfo_v2_Positive_Functional) {
   const auto stream_type = GENERATE(Streams::perThread, Streams::created);
   StreamGuard stream_guard(stream_type);
   hipStream_t stream = stream_guard.stream();
@@ -171,7 +171,7 @@ TEST_CASE("Unit_hipStreamGetCaptureInfo_v2_Positive_Functional") {
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_hipStreamGetCaptureInfo_v2_Positive_UniqueID") {
+TEST_CASE(Unit_hipStreamGetCaptureInfo_v2_Positive_UniqueID) {
   constexpr int numStreams = 100;
   hipStreamCaptureStatus captureStatus{hipStreamCaptureStatusNone};
   std::vector<int> idlist;
@@ -218,7 +218,7 @@ TEST_CASE("Unit_hipStreamGetCaptureInfo_v2_Positive_UniqueID") {
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_hipStreamGetCaptureInfo_v2_Negative_Parameters") {
+TEST_CASE(Unit_hipStreamGetCaptureInfo_v2_Negative_Parameters) {
   hipGraph_t capInfoGraph{};
 #if HT_NVIDIA
   hipStreamCaptureStatus captureStatus;

--- a/projects/hip-tests/catch/unit/graph/hipStreamIsCapturing.cc
+++ b/projects/hip-tests/catch/unit/graph/hipStreamIsCapturing.cc
@@ -44,7 +44,7 @@ THE SOFTWARE.
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_hipStreamIsCapturing_Negative_Parameters") {
+TEST_CASE(Unit_hipStreamIsCapturing_Negative_Parameters) {
   const auto stream_type = GENERATE(Streams::perThread, Streams::created);
   StreamGuard stream_guard(stream_type);
   hipStream_t stream = stream_guard.stream();
@@ -76,7 +76,7 @@ TEST_CASE("Unit_hipStreamIsCapturing_Negative_Parameters") {
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_hipStreamIsCapturing_Positive_Basic") {
+TEST_CASE(Unit_hipStreamIsCapturing_Positive_Basic) {
   hipStreamCaptureStatus cStatus;
   const auto stream_type = GENERATE(Streams::perThread, Streams::created);
   StreamGuard stream_guard(stream_type);
@@ -144,7 +144,7 @@ void checkStreamCaptureStatus(hipStreamCaptureMode mode, hipStream_t stream) {
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_hipStreamIsCapturing_Positive_Functional") {
+TEST_CASE(Unit_hipStreamIsCapturing_Positive_Functional) {
   const auto stream_type = GENERATE(Streams::perThread, Streams::created);
   StreamGuard stream_guard(stream_type);
   hipStream_t stream = stream_guard.stream();
@@ -174,7 +174,7 @@ static void thread_func(hipStream_t stream) {
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_hipStreamIsCapturing_Positive_Thread") {
+TEST_CASE(Unit_hipStreamIsCapturing_Positive_Thread) {
   constexpr size_t N = 1000000;
   size_t Nbytes = N * sizeof(float);
 

--- a/projects/hip-tests/catch/unit/graph/hipStreamIsCapturing_old.cc
+++ b/projects/hip-tests/catch/unit/graph/hipStreamIsCapturing_old.cc
@@ -71,7 +71,7 @@ verify the output from the operations.
  * Invoke hipStreamIsCapturing on both streams. Verify that the capture info(status)
  * of both s1 and s2 are identical.
  */
-TEST_CASE("Unit_hipStreamIsCapturing_ParentAndForkedStream") {
+TEST_CASE(Unit_hipStreamIsCapturing_ParentAndForkedStream) {
   hipStream_t stream1{nullptr}, stream2{nullptr};
   hipEvent_t event2{nullptr}, forkStreamEvent{nullptr};
   hipGraph_t graph{nullptr};
@@ -167,7 +167,7 @@ TEST_CASE("Unit_hipStreamIsCapturing_ParentAndForkedStream") {
  * operatoins. End the capture on the created stream. Execute the graph and verify the output from
  * the operations.
  */
-TEST_CASE("Unit_hipStreamIsCapturing_ChkNullStrmStatus") {
+TEST_CASE(Unit_hipStreamIsCapturing_ChkNullStrmStatus) {
   hipStream_t stream{nullptr}, streamForGraph{nullptr};
   hipGraph_t graph{nullptr};
   hipError_t ret;

--- a/projects/hip-tests/catch/unit/graph/hipStreamUpdateCaptureDependencies.cc
+++ b/projects/hip-tests/catch/unit/graph/hipStreamUpdateCaptureDependencies.cc
@@ -306,7 +306,7 @@ static void UpdateStreamCaptureDependenciesAdd(hipStream_t stream,
  * ------------------------
  *    - HIP_VERSION >= 5.3
  */
-TEST_CASE("Unit_hipStreamSetCaptureDependencies_Positive_Functional") {
+TEST_CASE(Unit_hipStreamSetCaptureDependencies_Positive_Functional) {
   const auto stream_type = GENERATE(Streams::perThread, Streams::created);
   StreamGuard stream_guard(stream_type);
   hipStream_t stream = stream_guard.stream();
@@ -333,7 +333,7 @@ TEST_CASE("Unit_hipStreamSetCaptureDependencies_Positive_Functional") {
  * ------------------------
  *    - HIP_VERSION >= 5.3
  */
-TEST_CASE("Unit_hipStreamAddCaptureDependencies_Positive_Functional") {
+TEST_CASE(Unit_hipStreamAddCaptureDependencies_Positive_Functional) {
   const auto stream_type = GENERATE(Streams::perThread, Streams::created);
   StreamGuard stream_guard(stream_type);
   hipStream_t stream = stream_guard.stream();
@@ -356,7 +356,7 @@ TEST_CASE("Unit_hipStreamAddCaptureDependencies_Positive_Functional") {
  * ------------------------
  *    - HIP_VERSION >= 5.3
  */
-TEST_CASE("Unit_hipStreamUpdateCaptureDependencies_Positive_Parameters") {
+TEST_CASE(Unit_hipStreamUpdateCaptureDependencies_Positive_Parameters) {
   hipGraph_t graph{nullptr};
 
   const auto stream_type = GENERATE(Streams::perThread, Streams::created);
@@ -393,7 +393,7 @@ TEST_CASE("Unit_hipStreamUpdateCaptureDependencies_Positive_Parameters") {
  * ------------------------
  *    - HIP_VERSION >= 5.3
  */
-TEST_CASE("Unit_hipStreamUpdateCaptureDependencies_Negative_Parameters") {
+TEST_CASE(Unit_hipStreamUpdateCaptureDependencies_Negative_Parameters) {
   const int Nbytes = 100;
   hipGraph_t capInfoGraph{nullptr};
   hipGraph_t graph{nullptr};

--- a/projects/hip-tests/catch/unit/graph/hipThreadExchangeStreamCaptureMode.cc
+++ b/projects/hip-tests/catch/unit/graph/hipThreadExchangeStreamCaptureMode.cc
@@ -98,7 +98,7 @@ void threadFuncCaptureMode(hipStream_t stream, hipStreamCaptureMode mode) {
  * ------------------------
  *    - HIP_VERSION >= 5.3
  */
-TEST_CASE("Unit_hipThreadExchangeStreamCaptureMode_Positive_Functional") {
+TEST_CASE(Unit_hipThreadExchangeStreamCaptureMode_Positive_Functional) {
   StreamGuard stream_guard(Streams::created);
   hipStream_t stream = stream_guard.stream();
 
@@ -128,7 +128,7 @@ TEST_CASE("Unit_hipThreadExchangeStreamCaptureMode_Positive_Functional") {
  *    - HIP_VERSION >= 5.3
  */
 #if HT_AMD  // getting error in Cuda Setup
-TEST_CASE("Unit_hipThreadExchangeStreamCaptureMode_Negative_Parameters") {
+TEST_CASE(Unit_hipThreadExchangeStreamCaptureMode_Negative_Parameters) {
   hipStreamCaptureMode mode;
 
   SECTION("Pass Mode as nullptr") {

--- a/projects/hip-tests/catch/unit/graph/hipUserObjectCreate.cc
+++ b/projects/hip-tests/catch/unit/graph/hipUserObjectCreate.cc
@@ -44,7 +44,7 @@ static void hipUserObjectCreate_Functional_1(void* object, void destroyObj(void*
   HIP_CHECK(hipUserObjectRelease(hObject));
 }
 
-TEST_CASE("Unit_hipUserObjectCreate_Functional_1") {
+TEST_CASE(Unit_hipUserObjectCreate_Functional_1) {
   SECTION("Called with int Object") {
     int* object = new int();
     REQUIRE(object != nullptr);
@@ -78,7 +78,7 @@ static void hipUserObjectCreate_Functional_2(void* object, void destroyObj(void*
   HIP_CHECK(hipUserObjectRelease(hObject, refCount));
 }
 
-TEST_CASE("Unit_hipUserObjectCreate_Functional_2") {
+TEST_CASE(Unit_hipUserObjectCreate_Functional_2) {
   SECTION("Called with int Object") {
     int* object = new int();
     REQUIRE(object != nullptr);
@@ -112,7 +112,7 @@ static void hipUserObjectCreate_Functional_3(void* object, void destroyObj(void*
   HIP_CHECK(hipUserObjectRelease(hObject));
 }
 
-TEST_CASE("Unit_hipUserObjectCreate_Functional_3") {
+TEST_CASE(Unit_hipUserObjectCreate_Functional_3) {
   SECTION("Called with int Object") {
     int* object = new int();
     REQUIRE(object != nullptr);
@@ -149,7 +149,7 @@ static void hipUserObjectCreate_Functional_4(void* object, void destroyObj(void*
   HIP_CHECK(hipUserObjectRelease(hObject, refCount + refCountRetain));
 }
 
-TEST_CASE("Unit_hipUserObjectCreate_Functional_4") {
+TEST_CASE(Unit_hipUserObjectCreate_Functional_4) {
   SECTION("Called with int Object") {
     int* object = new int();
     REQUIRE(object != nullptr);
@@ -181,7 +181,7 @@ TEST_CASE("Unit_hipUserObjectCreate_Functional_4") {
  5) Pass initialRefcount as INT_MAX
  6) Pass flag other than hipUserObjectNoDestructorSync
  */
-TEST_CASE("Unit_hipUserObjectCreate_Negative") {
+TEST_CASE(Unit_hipUserObjectCreate_Negative) {
   int* object = new int();
   REQUIRE(object != nullptr);
 
@@ -222,7 +222,7 @@ TEST_CASE("Unit_hipUserObjectCreate_Negative") {
   }
 }
 
-TEST_CASE("Unit_hipUserObj_Negative_Test") {
+TEST_CASE(Unit_hipUserObj_Negative_Test) {
   int* object = new int();
   REQUIRE(object != nullptr);
 

--- a/projects/hip-tests/catch/unit/graph/hipUserObjectRelease.cc
+++ b/projects/hip-tests/catch/unit/graph/hipUserObjectRelease.cc
@@ -30,7 +30,7 @@ THE SOFTWARE.
  2) Pass initialRefcount as 0
  3) Pass initialRefcount as INT_MAX
  */
-TEST_CASE("Unit_hipUserObjectRelease_Negative") {
+TEST_CASE(Unit_hipUserObjectRelease_Negative) {
   int* object = new int();
   REQUIRE(object != nullptr);
 

--- a/projects/hip-tests/catch/unit/graph/hipUserObjectRetain.cc
+++ b/projects/hip-tests/catch/unit/graph/hipUserObjectRetain.cc
@@ -30,7 +30,7 @@ THE SOFTWARE.
  2) Pass initialRefcount as 0
  3) Pass initialRefcount as INT_MAX
  */
-TEST_CASE("Unit_hipUserObjectRetain_Negative") {
+TEST_CASE(Unit_hipUserObjectRetain_Negative) {
   int* object = new int();
   REQUIRE(object != nullptr);
 

--- a/projects/hip-tests/catch/unit/hip_specific/hip_check_VGPRs.cpp
+++ b/projects/hip-tests/catch/unit/hip_specific/hip_check_VGPRs.cpp
@@ -71,7 +71,7 @@ void test_vgprs_value() {
   REQUIRE(true);
 }
 
-TEST_CASE("Unit_Device__hip_check_VGPRs") {
+TEST_CASE(Unit_Device__hip_check_VGPRs) {
   hipDeviceProp_t props;
   hipFuncAttributes attr;
   int maxAvailableVgprsPerThread = 0;

--- a/projects/hip-tests/catch/unit/hip_specific/hip_hc_8pk.cc
+++ b/projects/hip-tests/catch/unit/hip_specific/hip_hc_8pk.cc
@@ -45,7 +45,7 @@ __global__ void __hip_hc_add8pk_kernel(char4* out, char4 in1, char4 in2) {
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_Device__hip_hc_add8pk_Sanity_Positive") {
+TEST_CASE(Unit_Device__hip_hc_add8pk_Sanity_Positive) {
   const char input1[] = {-0x70, -0x50, -0x30, -0x0f, 0x0, 0x01, 0x10, 0x20, 0x70, 0x7f};
   const char input2[] = {-0x05, -0x11, -0x20, -0x03, 0x0, 0x30, 0x05, 0x33, 0x0f, 0x7a};
   const char reference[] = {-0x75, -0x61, -0x50, -0x12, 0x0, 0x31, 0x15, 0x53, 0x7f, -0x07};
@@ -78,7 +78,7 @@ __global__ void __hip_hc_sub8pk_kernel(char4* out, char4 in1, char4 in2) {
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_Device__hip_hc_sub8pk_Sanity_Positive") {
+TEST_CASE(Unit_Device__hip_hc_sub8pk_Sanity_Positive) {
   const char input1[] = {-0x70, -0x50, -0x30, -0x0f, 0x0, 0x30, 0x10, 0x33, 0x70, 0x7a};
   const char input2[] = {-0x05, -0x11, -0x20, -0x03, 0x0, 0x01, 0x05, 0x20, 0x0f, 0x7f};
   const char reference[] = {-0x6b, -0x3f, -0x10, -0x0c, 0x0, 0x2f, 0x0b, 0x13, 0x61, -0x05};
@@ -111,7 +111,7 @@ __global__ void __hip_hc_mul8pk_kernel(char4* out, char4 in1, char4 in2) {
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_Device__hip_hc_mul8pk_Sanity_Positive") {
+TEST_CASE(Unit_Device__hip_hc_mul8pk_Sanity_Positive) {
   const char input1[] = {-0x70, -0x50, -0x30, -0x0f, 0x0, 0x01, 0x10, 0x20, 0x70, 0x7f};
   const char input2[] = {0x05, -0x11, 0x22, -0x03, 0x0, 0x30, 0x05, 0x33, 0x0f, 0x7a};
   const char reference[] = {-0x30, 0x50, -0x60, 0x2d, 0x0, 0x30, 0x50, 0x60, -0x70, -0x7a};
@@ -140,7 +140,7 @@ TEST_CASE("Unit_Device__hip_hc_mul8pk_Sanity_Positive") {
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_Device__hip_hc_8pk_Negative_Parameters_RTC") {
+TEST_CASE(Unit_Device__hip_hc_8pk_Negative_Parameters_RTC) {
   hiprtcProgram program{};
 
   const auto program_source = GENERATE(kHipHcAdd8pkBasic, kHipHcAdd8pkVector, kHipHcSub8pkBasic,

--- a/projects/hip-tests/catch/unit/kernel/hipAutoThreadIdx.cc
+++ b/projects/hip-tests/catch/unit/kernel/hipAutoThreadIdx.cc
@@ -50,7 +50,7 @@ static __global__ void vecSqrSingBlk(int* A_d, size_t NELEM) {
  * ------------------------
  * - HIP_VERSION >= 6.1
  */
-TEST_CASE("Unit_kernel_Assign_threadIdx_to_auto") {
+TEST_CASE(Unit_kernel_Assign_threadIdx_to_auto) {
   int* A_d;
   const unsigned blocks = 256;
   const unsigned threadsPerBlock = 128;

--- a/projects/hip-tests/catch/unit/kernel/hipConfigureCall.cc
+++ b/projects/hip-tests/catch/unit/kernel/hipConfigureCall.cc
@@ -30,7 +30,7 @@ THE SOFTWARE.
  * ------------------------
  *  - HIP_VERSION >= 6.0
  */
-TEST_CASE("Unit_ConfigureCall") {
+TEST_CASE(Unit_ConfigureCall) {
   struct dim3 grid_dim{};
   struct dim3 block_dim{};
   size_t shared_memory_size = 1024;
@@ -49,7 +49,7 @@ TEST_CASE("Unit_ConfigureCall") {
  * ------------------------
  *  - HIP_VERSION >= 6.0
  */
-TEST_CASE("Unit_ConfigureCall_CheckParams") {
+TEST_CASE(Unit_ConfigureCall_CheckParams) {
   struct dim3 grid_dim{16, 8, 1};
   struct dim3 test_grid_dim{};
   struct dim3 block_dim{16, 8, 1};

--- a/projects/hip-tests/catch/unit/kernel/hipDynamicShared.cc
+++ b/projects/hip-tests/catch/unit/kernel/hipDynamicShared.cc
@@ -124,7 +124,7 @@ template <typename T> void testExternShared(size_t N, unsigned groupElements) {
  *    - HIP_VERSION >= 5.5
  */
 
-TEST_CASE("Unit_hipDynamicShared") {
+TEST_CASE(Unit_hipDynamicShared) {
   SECTION("test case with float for least size") {
     testExternShared<float>(1024, 4);
     testExternShared<float>(1024, 8);

--- a/projects/hip-tests/catch/unit/kernel/hipDynamicShared2.cc
+++ b/projects/hip-tests/catch/unit/kernel/hipDynamicShared2.cc
@@ -57,7 +57,7 @@ __global__ void vectorAdd(float* Ad, float* Bd) {
  *    - HIP_VERSION >= 5.5
  */
 
-TEST_CASE("Unit_hipDynamicShared2") {
+TEST_CASE(Unit_hipDynamicShared2) {
   float *A, *B, *Ad, *Bd;
   A = new float[LEN];
   B = new float[LEN];

--- a/projects/hip-tests/catch/unit/kernel/hipEmptyKernel.cc
+++ b/projects/hip-tests/catch/unit/kernel/hipEmptyKernel.cc
@@ -48,7 +48,7 @@ __global__ void Empty(int param) {}
  *    - HIP_VERSION >= 5.5
  */
 
-TEST_CASE("Unit_hipEmptyKernel") {
+TEST_CASE(Unit_hipEmptyKernel) {
   hipLaunchKernelGGL(HIP_KERNEL_NAME(Empty), dim3(1), dim3(1), 0, 0, 0);
   HIP_CHECK(hipDeviceSynchronize());
 }

--- a/projects/hip-tests/catch/unit/kernel/hipExtLaunchKernelGGLBasic.cc
+++ b/projects/hip-tests/catch/unit/kernel/hipExtLaunchKernelGGLBasic.cc
@@ -118,7 +118,7 @@ arguments
  *    - HIP_VERSION >= 5.5
  */
 
-TEST_CASE("Unit_hipExtLaunchKernelGGL") {
+TEST_CASE(Unit_hipExtLaunchKernelGGL) {
   SECTION("test run") {
     size_t N = 4 * 1024 * 1024;
     test(N);

--- a/projects/hip-tests/catch/unit/kernel/hipGridLaunch.cc
+++ b/projects/hip-tests/catch/unit/kernel/hipGridLaunch.cc
@@ -103,7 +103,7 @@ int test_triple_chevron(size_t N) {
  *    - HIP_VERSION >= 5.5
  */
 
-TEST_CASE("Unit_hipGridLaunch") {
+TEST_CASE(Unit_hipGridLaunch) {
   size_t N = 4 * 1024 * 1024;
   SECTION("Test test_gl2") { test_gl2(N); }
 

--- a/projects/hip-tests/catch/unit/kernel/hipLanguageExtensions.cc
+++ b/projects/hip-tests/catch/unit/kernel/hipLanguageExtensions.cc
@@ -98,7 +98,7 @@ template <typename T> __global__ void vectorADD(T __restrict__* A_d, T* B_d, T* 
  *    - HIP_VERSION >= 5.5
  */
 
-TEST_CASE("Unit_hipLanguageExtensions") { REQUIRE(true); }
+TEST_CASE(Unit_hipLanguageExtensions) { REQUIRE(true); }
 
 /**
  * End doxygen group KernelTest.

--- a/projects/hip-tests/catch/unit/kernel/hipLaunchBounds.cc
+++ b/projects/hip-tests/catch/unit/kernel/hipLaunchBounds.cc
@@ -58,7 +58,7 @@ static bool verify(int N, int* x, int val) {
   return true;
 }
 
-TEST_CASE("Unit_hipLaunchBounds_With_maxThreadsPerBlock_Check") {
+TEST_CASE(Unit_hipLaunchBounds_With_maxThreadsPerBlock_Check) {
   constexpr size_t N = 10000;
   hipError_t ret;
   int* x;
@@ -98,7 +98,7 @@ TEST_CASE("Unit_hipLaunchBounds_With_maxThreadsPerBlock_Check") {
   HIP_CHECK(hipFree(x));
 }
 
-TEST_CASE("Unit_hipLaunchBounds_With_maxThreadsPerBlock_blocksPerCU_Check") {
+TEST_CASE(Unit_hipLaunchBounds_With_maxThreadsPerBlock_blocksPerCU_Check) {
   constexpr size_t N = 10000;
   hipError_t ret;
   int* x;

--- a/projects/hip-tests/catch/unit/kernel/hipLaunchBoundsBasic.cc
+++ b/projects/hip-tests/catch/unit/kernel/hipLaunchBoundsBasic.cc
@@ -51,7 +51,7 @@ __global__ void __launch_bounds__(256, 2) myKern(int* C, const int* A, int N) {
  * - HIP_VERSION >= 5.6
  */
 
-TEST_CASE("Unit_kernel_LaunchBounds_Functional") {
+TEST_CASE(Unit_kernel_LaunchBounds_Functional) {
   size_t Nbytes = N * sizeof(int);
   int *A_d, *C_d, *A_h, *C_h;
   HIPCHECK(hipMalloc(&A_d, Nbytes));

--- a/projects/hip-tests/catch/unit/kernel/hipLaunchKernelEx.cc
+++ b/projects/hip-tests/catch/unit/kernel/hipLaunchKernelEx.cc
@@ -137,7 +137,7 @@ __global__ void normalKernel(int* output, int totalThreads) {
  * ------------------------
  *    - HIP_VERSION >= 6.5
  */
-TEST_CASE("Unit_hipLaunchKernelExC_NegetiveTsts") {
+TEST_CASE(Unit_hipLaunchKernelExC_NegetiveTsts) {
   if (!DeviceAttributesSupport(0, hipDeviceAttributeCooperativeLaunch)) {
     HipTest::HIP_SKIP_TEST("CooperativeLaunch not supported");
     return;
@@ -207,7 +207,7 @@ TEST_CASE("Unit_hipLaunchKernelExC_NegetiveTsts") {
  *    - HIP_VERSION >= 6.5
  */
 
-TEST_CASE("Unit_hipLaunchKernelEx_NegetiveTsts") {
+TEST_CASE(Unit_hipLaunchKernelEx_NegetiveTsts) {
   if (!DeviceAttributesSupport(0, hipDeviceAttributeCooperativeLaunch)) {
     HipTest::HIP_SKIP_TEST("CooperativeLaunch not supported");
     return;
@@ -330,7 +330,7 @@ bool runTest(const char* testName, const void* kernelFunc, int totalThreads, int
  * ------------------------
  *    - HIP_VERSION >= 6.5
  */
-TEST_CASE("Unit_hipLaunchKernelEx_Functional") {
+TEST_CASE(Unit_hipLaunchKernelEx_Functional) {
   if (!DeviceAttributesSupport(0, hipDeviceAttributeCooperativeLaunch)) {
     HipTest::HIP_SKIP_TEST("CooperativeLaunch not supported");
     return;
@@ -362,7 +362,7 @@ TEST_CASE("Unit_hipLaunchKernelEx_Functional") {
  * ------------------------
  *  - HIP_VERSION >= 6.5
  */
-TEST_CASE("Unit_hipLaunchKernelEx_With_Different_Kernels") {
+TEST_CASE(Unit_hipLaunchKernelEx_With_Different_Kernels) {
   if (!DeviceAttributesSupport(0, hipDeviceAttributeCooperativeLaunch)) {
     HipTest::HIP_SKIP_TEST("CooperativeLaunch not supported");
     return;
@@ -434,7 +434,7 @@ TEST_CASE("Unit_hipLaunchKernelEx_With_Different_Kernels") {
  * ------------------------
  *  - HIP_VERSION >= 6.5
  */
-TEST_CASE("Unit_hipLaunchKernelEx_With_CooperativeKernelWithArgs") {
+TEST_CASE(Unit_hipLaunchKernelEx_With_CooperativeKernelWithArgs) {
   if (!DeviceAttributesSupport(0, hipDeviceAttributeCooperativeLaunch)) {
     HipTest::HIP_SKIP_TEST("CooperativeLaunch not supported");
     return;
@@ -497,7 +497,7 @@ TEST_CASE("Unit_hipLaunchKernelEx_With_CooperativeKernelWithArgs") {
  * ------------------------
  *  - HIP_VERSION >= 6.5
  */
-TEST_CASE("Unit_hipLaunchKernelEx_With_MaxBlockDims") {
+TEST_CASE(Unit_hipLaunchKernelEx_With_MaxBlockDims) {
   if (!DeviceAttributesSupport(0, hipDeviceAttributeCooperativeLaunch)) {
     HipTest::HIP_SKIP_TEST("CooperativeLaunch not supported");
     return;

--- a/projects/hip-tests/catch/unit/kernel/hipLaunchParm.cc
+++ b/projects/hip-tests/catch/unit/kernel/hipLaunchParm.cc
@@ -542,7 +542,7 @@ template <class T1, class T2> __global__ void myKernel(T1 a, T2 b) {}
  *    - HIP_VERSION >= 5.5
  */
 
-TEST_CASE("Unit_hipLaunchParm") {
+TEST_CASE(Unit_hipLaunchParm) {
   hipMallocError = hipMalloc(reinterpret_cast<void**>(&result_d), BLOCK_DIM_SIZE * sizeof(bool));
   hipHostMallocError =
       hipHostMalloc(reinterpret_cast<void**>(&result_h), BLOCK_DIM_SIZE * sizeof(bool));

--- a/projects/hip-tests/catch/unit/kernel/hipLaunchParmFunctor.cc
+++ b/projects/hip-tests/catch/unit/kernel/hipLaunchParmFunctor.cc
@@ -402,7 +402,7 @@ void HipFunctorTests::TestForFunctorContainInStructObj(void) {
  *    - HIP_VERSION >= 5.5
  */
 
-TEST_CASE("Unit_hipLaunchParmFunctor") {
+TEST_CASE(Unit_hipLaunchParmFunctor) {
   HipFunctorTests FunctorTests;
 
   SECTION("test for simple class functor") { FunctorTests.TestForSimpleClassFunctor(); }

--- a/projects/hip-tests/catch/unit/kernel/hipMemFaultStackAllocation.cc
+++ b/projects/hip-tests/catch/unit/kernel/hipMemFaultStackAllocation.cc
@@ -63,7 +63,7 @@ static bool verify(const int* C_d, const int* A_d) {
   return true;
 }
 
-TEST_CASE("Unit_hipMemFaultStackAllocation_Check") {
+TEST_CASE(Unit_hipMemFaultStackAllocation_Check) {
   hipError_t ret;
   int *A_d, *C_d;
   const size_t Nbytes = N * sizeof(int);

--- a/projects/hip-tests/catch/unit/kernel/hipPrintfKernel.cc
+++ b/projects/hip-tests/catch/unit/kernel/hipPrintfKernel.cc
@@ -45,7 +45,7 @@ __global__ void run_printf() { printf("Hello World"); }
  * ------------------------
  * - HIP_VERSION >= 5.6
  */
-TEST_CASE("Unit_kernel_ChkPrintf", "[multigpu]") {
+TEST_CASE(Unit_kernel_ChkPrintf) {
   int device_count = 0;
   HIP_CHECK(hipGetDeviceCount(&device_count));
   CaptureStream capture;

--- a/projects/hip-tests/catch/unit/kernel/hipSetupArgument.cc
+++ b/projects/hip-tests/catch/unit/kernel/hipSetupArgument.cc
@@ -27,7 +27,7 @@ __global__ void add_vectors(int* a, int* b, int* result, int size) {
   }
 }
 
-TEST_CASE("Unit_hipSetupArgument_Simple") {
+TEST_CASE(Unit_hipSetupArgument_Simple) {
   dim3 grid_dim(1, 1, 1);
   dim3 block_dim(1, 1, 1);
 
@@ -48,7 +48,7 @@ TEST_CASE("Unit_hipSetupArgument_Simple") {
  * ------------------------
  *  - unit/kernel/hipSetupArgument.cc
  */
-TEST_CASE("Unit_hipSetupArgument_Execute_Kernel_And_Check_Result") {
+TEST_CASE(Unit_hipSetupArgument_Execute_Kernel_And_Check_Result) {
   constexpr auto block_size = 32;
   auto vec_size = 256;
   size_t block_num = static_cast<size_t>(std::ceil(static_cast<float>(vec_size) / block_size));

--- a/projects/hip-tests/catch/unit/kernel/hipTestConstant.cc
+++ b/projects/hip-tests/catch/unit/kernel/hipTestConstant.cc
@@ -50,7 +50,7 @@ static __global__ void Get(int* Ad) {
  * - HIP_VERSION >= 5.6
  */
 
-TEST_CASE("Unit_kernel_chkConstantViaKernel") {
+TEST_CASE(Unit_kernel_chkConstantViaKernel) {
   int *A, *B, *Ad;
   A = new int[LEN];
   B = new int[LEN];

--- a/projects/hip-tests/catch/unit/kernel/hipTestGlobalVariable.cc
+++ b/projects/hip-tests/catch/unit/kernel/hipTestGlobalVariable.cc
@@ -95,7 +95,7 @@ void runTestGlobalArray() {
   HIP_CHECK(hipFree(Ad));
 }
 
-TEST_CASE("Unit_kernel_chkGlobalArrAndGlobalVaribleViaKernelFn") {
+TEST_CASE(Unit_kernel_chkGlobalArrAndGlobalVaribleViaKernelFn) {
   runTestConstantGlobalVar();
   runTestGlobalArray();
 }

--- a/projects/hip-tests/catch/unit/kernel/hipTestMemKernel.cc
+++ b/projects/hip-tests/catch/unit/kernel/hipTestMemKernel.cc
@@ -96,7 +96,7 @@ __global__ void MemSet12(uint8_t* In) {
  * - HIP_VERSION >= 5.6
  */
 
-TEST_CASE("Unit_kernel_MemoryOperationsViaKernels") {
+TEST_CASE(Unit_kernel_MemoryOperationsViaKernels) {
   uint8_t *A, *Ad, *B, *Bd, *C, *Cd;
   A = new uint8_t[LEN8];
   B = new uint8_t[LEN8];

--- a/projects/hip-tests/catch/unit/launchBounds/launch_bounds.cc
+++ b/projects/hip-tests/catch/unit/launchBounds/launch_bounds.cc
@@ -96,7 +96,7 @@ template <bool out_of_bounds> void LaunchBoundsWrapper(const int threads_per_blo
  * ------------------------
  *  - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_Kernel_Launch_bounds_Positive_Basic") {
+TEST_CASE(Unit_Kernel_Launch_bounds_Positive_Basic) {
   auto threads_per_block = GENERATE(1, kMaxThreadsPerBlock / 2, kMaxThreadsPerBlock);
   LaunchBoundsWrapper<false>(threads_per_block);
 }
@@ -116,7 +116,7 @@ TEST_CASE("Unit_Kernel_Launch_bounds_Positive_Basic") {
  * ------------------------
  *  - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_Kernel_Launch_bounds_Negative_OutOfBounds") {
+TEST_CASE(Unit_Kernel_Launch_bounds_Negative_OutOfBounds) {
   auto threads_per_block =
       GENERATE(-1 * kMaxThreadsPerBlock, -1, kMaxThreadsPerBlock + 1, 2 * kMaxThreadsPerBlock);
   LaunchBoundsWrapper<true>(threads_per_block);
@@ -138,7 +138,7 @@ TEST_CASE("Unit_Kernel_Launch_bounds_Negative_OutOfBounds") {
  * ------------------------
  *  - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_Kernel_Launch_bounds_Negative_Parameters_RTC") {
+TEST_CASE(Unit_Kernel_Launch_bounds_Negative_Parameters_RTC) {
   hiprtcProgram program{};
 
   const auto program_source = GENERATE(kMaxThreadsNotInt, kMinWarpsNotInt);

--- a/projects/hip-tests/catch/unit/library/library_negative.cc
+++ b/projects/hip-tests/catch/unit/library/library_negative.cc
@@ -22,7 +22,7 @@ THE SOFTWARE.
 
 #include <hip_test_common.hh>
 
-TEST_CASE("Unit_library_negative") {
+TEST_CASE(Unit_library_negative) {
   SECTION("load negative") {
     HIP_CHECK_ERROR(hipLibraryLoadData(nullptr, nullptr, nullptr, nullptr, 0, nullptr, nullptr, 0),
                     hipErrorInvalidValue);

--- a/projects/hip-tests/catch/unit/library/loadlib_co.cc
+++ b/projects/hip-tests/catch/unit/library/loadlib_co.cc
@@ -23,7 +23,7 @@ THE SOFTWARE.
 #include <hip_test_common.hh>
 
 
-TEST_CASE("Unit_hip_library_load_co") {
+TEST_CASE(Unit_hip_library_load_co) {
   constexpr size_t size = 32;
   constexpr size_t num_kernels = 3;
   std::vector<float> input1, input2;
@@ -213,7 +213,7 @@ TEST_CASE("Unit_hip_library_load_co") {
   HIP_CHECK(hipFree(d_out));
 }
 
-TEST_CASE("Unit_hipKernelGetParamInfo_Negative") {
+TEST_CASE(Unit_hipKernelGetParamInfo_Negative) {
   size_t offset, paramsize;
 
   SECTION("Kernel as nullptr") {

--- a/projects/hip-tests/catch/unit/library/loadlib_rtc.cc
+++ b/projects/hip-tests/catch/unit/library/loadlib_rtc.cc
@@ -44,7 +44,7 @@ static std::vector<char> compile_using_hiprtc(const std::string& code, std::stri
   return res;
 }
 
-TEST_CASE("Unit_hip_library_load_rtc") {
+TEST_CASE(Unit_hip_library_load_rtc) {
   constexpr size_t size = 32;
   const std::string kernel1 =
       "extern \"C\" __global__ void add_kernel(float* out, float*a, float*b) { size_t i = "

--- a/projects/hip-tests/catch/unit/math/binary_common.hh
+++ b/projects/hip-tests/catch/unit/math/binary_common.hh
@@ -131,7 +131,7 @@ void BinaryFloatingPointTest(kernel_sig<T, TArg, TArg> kernel, ref_sig<RT, RTArg
 #define MATH_BINARY_WITHIN_ULP_TEST_DEF(kern_name, ref_func, sp_ulp, dp_ulp)                       \
   MATH_BINARY_KERNEL_DEF(kern_name)                                                                \
                                                                                                    \
-  TEMPLATE_TEST_CASE("Unit_Device_" #kern_name "_Accuracy_Positive", "", float, double) {          \
+  TEMPLATE_TEST_CASE(Unit_Device_##kern_name##_Accuracy_Positive, float, double) {          \
     using RT = RefType_t<TestType>;                                                                \
     RT (*ref)(RT, RT) = ref_func;                                                                  \
     const auto ulp = std::is_same_v<float, TestType> ? sp_ulp : dp_ulp;                            \

--- a/projects/hip-tests/catch/unit/math/casting_double_funcs.cc
+++ b/projects/hip-tests/catch/unit/math/casting_double_funcs.cc
@@ -32,7 +32,7 @@ THE SOFTWARE.
   CAST_KERNEL_DEF(kern_name, T, double)                                                            \
   CAST_F2I_REF_DEF(kern_name, T, double, ref_func)                                                 \
                                                                                                    \
-  TEST_CASE("Unit_Device_" #kern_name "_Positive") {                                               \
+  TEST_CASE(Unit_Device_##kern_name##_Positive) {                                               \
     T (*ref)(double) = kern_name##_ref;                                                            \
     CastDoublePrecisionTest(kern_name##_kernel, ref, EqValidatorBuilderFactory<T>());              \
   }
@@ -41,7 +41,7 @@ THE SOFTWARE.
   CAST_KERNEL_DEF(kern_name, T, double)                                                            \
   CAST_F2I_RZ_REF_DEF(kern_name, T, double)                                                        \
                                                                                                    \
-  TEST_CASE("Unit_Device_" #kern_name "_Positive") {                                               \
+  TEST_CASE(Unit_Device_##kern_name##_Positive) {                                               \
     T (*ref)(double) = kern_name##_ref;                                                            \
     CastDoublePrecisionTest(kern_name##_kernel, ref, EqValidatorBuilderFactory<T>());              \
   }
@@ -122,7 +122,7 @@ CAST_DOUBLE2INT_RZ_TEST_DEF(__double2int_rz, int)
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_Device___double2int_Negative_RTC") { NegativeTestRTCWrapper<12>(kDouble2Int); }
+TEST_CASE(Unit_Device___double2int_Negative_RTC) { NegativeTestRTCWrapper<12>(kDouble2Int); }
 
 /**
  * Test Description
@@ -200,13 +200,13 @@ CAST_DOUBLE2INT_RZ_TEST_DEF(__double2uint_rz, unsigned int)
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_Device___double2uint_Negative_RTC") { NegativeTestRTCWrapper<12>(kDouble2Uint); }
+TEST_CASE(Unit_Device___double2uint_Negative_RTC) { NegativeTestRTCWrapper<12>(kDouble2Uint); }
 
 #define CAST_DOUBLE2LL_TEST_DEF(kern_name, T, ref_func)                                            \
   CAST_KERNEL_DEF(kern_name, T, double)                                                            \
   CAST_F2I_REF_DEF(kern_name, T, double, ref_func)                                                 \
                                                                                                    \
-  TEST_CASE("Unit_Device_" #kern_name "_Positive") {                                               \
+  TEST_CASE(Unit_Device_##kern_name##_Positive) {                                               \
     T (*ref)(double) = kern_name##_ref;                                                            \
     UnaryDoublePrecisionBruteForceTest(kern_name##_kernel, ref, EqValidatorBuilderFactory<T>(),    \
                                        static_cast<double>(std::numeric_limits<T>::min()),         \
@@ -217,7 +217,7 @@ TEST_CASE("Unit_Device___double2uint_Negative_RTC") { NegativeTestRTCWrapper<12>
   CAST_KERNEL_DEF(kern_name, T, double)                                                            \
   CAST_F2I_RZ_REF_DEF(kern_name, T, double)                                                        \
                                                                                                    \
-  TEST_CASE("Unit_Device_" #kern_name "_Positive") {                                               \
+  TEST_CASE(Unit_Device_##kern_name##_Positive) {                                               \
     T (*ref)(double) = kern_name##_ref;                                                            \
     UnaryDoublePrecisionBruteForceTest(kern_name##_kernel, ref, EqValidatorBuilderFactory<T>(),    \
                                        static_cast<double>(std::numeric_limits<T>::min()),         \
@@ -300,7 +300,7 @@ CAST_DOUBLE2LL_RZ_TEST_DEF(__double2ll_rz, long long int)
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_Device___double2ll_Negative_RTC") { NegativeTestRTCWrapper<12>(kDouble2LL); }
+TEST_CASE(Unit_Device___double2ll_Negative_RTC) { NegativeTestRTCWrapper<12>(kDouble2LL); }
 
 /**
  * Test Description
@@ -378,13 +378,13 @@ CAST_DOUBLE2LL_RZ_TEST_DEF(__double2ull_rz, unsigned long long int)
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_Device___double2ull_Negative_RTC") { NegativeTestRTCWrapper<12>(kDouble2ULL); }
+TEST_CASE(Unit_Device___double2ull_Negative_RTC) { NegativeTestRTCWrapper<12>(kDouble2ULL); }
 
 #define CAST_DOUBLE2FLOAT_TEST_DEF(kern_name, round_dir)                                           \
   CAST_KERNEL_DEF(kern_name, float, double)                                                        \
   CAST_RND_REF_DEF(kern_name, float, double, round_dir)                                            \
                                                                                                    \
-  TEST_CASE("Unit_Device_" #kern_name "_Positive") {                                               \
+  TEST_CASE(Unit_Device_##kern_name##_Positive) {                                               \
     float (*ref)(double) = kern_name##_ref;                                                        \
     CastDoublePrecisionTest(kern_name##_kernel, ref, EqValidatorBuilderFactory<float>());          \
   }
@@ -393,7 +393,7 @@ TEST_CASE("Unit_Device___double2ull_Negative_RTC") { NegativeTestRTCWrapper<12>(
   CAST_KERNEL_DEF(kern_name, float, double)                                                        \
   CAST_REF_DEF(kern_name, float, double)                                                           \
                                                                                                    \
-  TEST_CASE("Unit_Device_" #kern_name "_Positive") {                                               \
+  TEST_CASE(Unit_Device_##kern_name##_Positive) {                                               \
     float (*ref)(double) = kern_name##_ref;                                                        \
     CastDoublePrecisionTest(kern_name##_kernel, ref, EqValidatorBuilderFactory<float>());          \
   }
@@ -474,7 +474,7 @@ CAST_DOUBLE2FLOAT_TEST_DEF(__double2float_rz, FE_TOWARDZERO)
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_Device___double2float_Negative_RTC") { NegativeTestRTCWrapper<12>(kDouble2Float); }
+TEST_CASE(Unit_Device___double2float_Negative_RTC) { NegativeTestRTCWrapper<12>(kDouble2Float); }
 
 CAST_KERNEL_DEF(__double2hiint, int, double)
 
@@ -498,7 +498,7 @@ int __double2hiint_ref(double arg) {
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_Device___double2hiint_Positive") {
+TEST_CASE(Unit_Device___double2hiint_Positive) {
   int (*ref)(double) = __double2hiint_ref;
   CastDoublePrecisionTest(__double2hiint_kernel, ref, EqValidatorBuilderFactory<int>());
 }
@@ -515,7 +515,7 @@ TEST_CASE("Unit_Device___double2hiint_Positive") {
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_Device___double2hiint_Negative_RTC") { NegativeTestRTCWrapper<3>(kDouble2Hiint); }
+TEST_CASE(Unit_Device___double2hiint_Negative_RTC) { NegativeTestRTCWrapper<3>(kDouble2Hiint); }
 
 CAST_KERNEL_DEF(__double2loint, int, double)
 
@@ -539,7 +539,7 @@ int __double2loint_ref(double arg) {
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_Device___double2loint_Positive") {
+TEST_CASE(Unit_Device___double2loint_Positive) {
   int (*ref)(double) = __double2loint_ref;
   CastDoublePrecisionTest(__double2loint_kernel, ref, EqValidatorBuilderFactory<int>());
 }
@@ -556,7 +556,7 @@ TEST_CASE("Unit_Device___double2loint_Positive") {
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_Device___double2loint_Negative_RTC") { NegativeTestRTCWrapper<3>(kDouble2Loint); }
+TEST_CASE(Unit_Device___double2loint_Negative_RTC) { NegativeTestRTCWrapper<3>(kDouble2Loint); }
 
 CAST_KERNEL_DEF(__double_as_longlong, long long int, double)
 
@@ -574,7 +574,7 @@ CAST_KERNEL_DEF(__double_as_longlong, long long int, double)
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_Device___double_as_longlong_Positive") {
+TEST_CASE(Unit_Device___double_as_longlong_Positive) {
   long long int (*ref)(double) = type2_as_type1_ref<long long int, double>;
   CastDoublePrecisionTest(__double_as_longlong_kernel, ref,
                           EqValidatorBuilderFactory<long long int>());
@@ -592,7 +592,7 @@ TEST_CASE("Unit_Device___double_as_longlong_Positive") {
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_Device___double_as_longlong_Negative_RTC") {
+TEST_CASE(Unit_Device___double_as_longlong_Negative_RTC) {
   NegativeTestRTCWrapper<3>(kDoubleAsLonglong);
 }
 

--- a/projects/hip-tests/catch/unit/math/casting_float_funcs.cc
+++ b/projects/hip-tests/catch/unit/math/casting_float_funcs.cc
@@ -32,7 +32,7 @@ THE SOFTWARE.
   CAST_KERNEL_DEF(kern_name, T, float)                                                             \
   CAST_F2I_REF_DEF(kern_name, T, float, ref_func)                                                  \
                                                                                                    \
-  TEST_CASE("Unit_Device_" #kern_name "_Positive") {                                               \
+  TEST_CASE(Unit_Device_##kern_name##_Positive) {                                               \
     T (*ref)(float) = kern_name##_ref;                                                             \
     UnarySinglePrecisionRangeTest(kern_name##_kernel, ref, EqValidatorBuilderFactory<T>(),         \
                                   std::numeric_limits<float>::lowest(),                            \
@@ -43,7 +43,7 @@ THE SOFTWARE.
   CAST_KERNEL_DEF(kern_name, T, float)                                                             \
   CAST_F2I_RZ_REF_DEF(kern_name, T, float)                                                         \
                                                                                                    \
-  TEST_CASE("Unit_Device_" #kern_name "_Positive") {                                               \
+  TEST_CASE(Unit_Device_##kern_name##_Positive) {                                               \
     T (*ref)(float) = kern_name##_ref;                                                             \
     UnarySinglePrecisionRangeTest(kern_name##_kernel, ref, EqValidatorBuilderFactory<T>(),         \
                                   std::numeric_limits<float>::lowest(),                            \
@@ -122,7 +122,7 @@ CAST_FLOAT2INT_TEST_DEF(__float2int_rz, int, std::trunc)
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_Device___float2int_Negative_RTC") { NegativeTestRTCWrapper<12>(kFloat2Int); }
+TEST_CASE(Unit_Device___float2int_Negative_RTC) { NegativeTestRTCWrapper<12>(kFloat2Int); }
 
 /**
  * Test Description
@@ -197,13 +197,13 @@ CAST_FLOAT2INT_RZ_TEST_DEF(__float2uint_rz, unsigned int)
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_Device___float2uint_Negative_RTC") { NegativeTestRTCWrapper<12>(kFloat2Uint); }
+TEST_CASE(Unit_Device___float2uint_Negative_RTC) { NegativeTestRTCWrapper<12>(kFloat2Uint); }
 
 #define CAST_FLOAT2LL_TEST_DEF(kern_name, T, ref_func)                                             \
   CAST_KERNEL_DEF(kern_name, T, float)                                                             \
   CAST_F2I_REF_DEF(kern_name, T, float, ref_func)                                                  \
                                                                                                    \
-  TEST_CASE("Unit_Device_" #kern_name "_Positive") {                                               \
+  TEST_CASE(Unit_Device_##kern_name##_Positive) {                                               \
     T (*ref)(float) = kern_name##_ref;                                                             \
     UnarySinglePrecisionRangeTest(kern_name##_kernel, ref, EqValidatorBuilderFactory<T>(),         \
                                   static_cast<float>(std::numeric_limits<T>::min()),               \
@@ -214,7 +214,7 @@ TEST_CASE("Unit_Device___float2uint_Negative_RTC") { NegativeTestRTCWrapper<12>(
   CAST_KERNEL_DEF(kern_name, T, float)                                                             \
   CAST_F2I_RZ_REF_DEF(kern_name, T, float)                                                         \
                                                                                                    \
-  TEST_CASE("Unit_Device_" #kern_name "_Positive") {                                               \
+  TEST_CASE(Unit_Device_##kern_name##_Positive) {                                               \
     T (*ref)(float) = kern_name##_ref;                                                             \
     UnarySinglePrecisionRangeTest(kern_name##_kernel, ref, EqValidatorBuilderFactory<T>(),         \
                                   static_cast<float>(std::numeric_limits<T>::min()),               \
@@ -294,7 +294,7 @@ CAST_FLOAT2LL_RZ_TEST_DEF(__float2ll_rz, long long int)
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_Device___float2ll_Negative_RTC") { NegativeTestRTCWrapper<12>(kFloat2LL); }
+TEST_CASE(Unit_Device___float2ll_Negative_RTC) { NegativeTestRTCWrapper<12>(kFloat2LL); }
 
 /**
  * Test Description
@@ -369,7 +369,7 @@ CAST_FLOAT2LL_RZ_TEST_DEF(__float2ull_rz, unsigned long long int)
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_Device___float2ull_Negative_RTC") { NegativeTestRTCWrapper<12>(kFloat2ULL); }
+TEST_CASE(Unit_Device___float2ull_Negative_RTC) { NegativeTestRTCWrapper<12>(kFloat2ULL); }
 
 CAST_KERNEL_DEF(__float_as_int, int, float)
 
@@ -386,7 +386,7 @@ CAST_KERNEL_DEF(__float_as_int, int, float)
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_Device___float_as_int_Positive") {
+TEST_CASE(Unit_Device___float_as_int_Positive) {
   int (*ref)(float) = type2_as_type1_ref<int, float>;
   UnarySinglePrecisionTest(__float_as_int_kernel, ref, EqValidatorBuilderFactory<int>());
 }
@@ -403,7 +403,7 @@ TEST_CASE("Unit_Device___float_as_int_Positive") {
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_Device___float_as_int_Negative_RTC") { NegativeTestRTCWrapper<3>(kFloatAsInt); }
+TEST_CASE(Unit_Device___float_as_int_Negative_RTC) { NegativeTestRTCWrapper<3>(kFloatAsInt); }
 
 CAST_KERNEL_DEF(__float_as_uint, unsigned int, float)
 
@@ -420,7 +420,7 @@ CAST_KERNEL_DEF(__float_as_uint, unsigned int, float)
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_Device___float_as_uint_Positive") {
+TEST_CASE(Unit_Device___float_as_uint_Positive) {
   unsigned int (*ref)(float) = type2_as_type1_ref<unsigned int, float>;
   UnarySinglePrecisionTest(__float_as_uint_kernel, ref, EqValidatorBuilderFactory<unsigned int>());
 }
@@ -437,7 +437,7 @@ TEST_CASE("Unit_Device___float_as_uint_Positive") {
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_Device___float_as_uint_Negative_RTC") { NegativeTestRTCWrapper<3>(kFloatAsUint); }
+TEST_CASE(Unit_Device___float_as_uint_Negative_RTC) { NegativeTestRTCWrapper<3>(kFloatAsUint); }
 
 /**
  * End doxygen group MathTest.

--- a/projects/hip-tests/catch/unit/math/casting_half2_funcs.cc
+++ b/projects/hip-tests/catch/unit/math/casting_half2_funcs.cc
@@ -49,7 +49,7 @@ static __half2 __half2half2_ref(Float16 x) { return __half2{x, x}; }
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_Device___half2half2_Accuracy_Positive") {
+TEST_CASE(Unit_Device___half2half2_Accuracy_Positive) {
   UnaryHalfPrecisionTest(__half2half2_kernel, __half2half2_ref,
                          Half2ValidatorBuilderFactory(EqValidatorBuilderFactory<Float16>()));
 }
@@ -72,7 +72,7 @@ static __half2 make_half2_ref(Float16 x, Float16 y) { return __half2{x, y}; }
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_Device_make_half2_Accuracy_Positive") {
+TEST_CASE(Unit_Device_make_half2_Accuracy_Positive) {
   BinaryFloatingPointTest(make_half2_kernel, make_half2_ref,
                           Half2ValidatorBuilderFactory(EqValidatorBuilderFactory<Float16>()));
 }
@@ -95,7 +95,7 @@ static __half2 __halves2half2_ref(Float16 x, Float16 y) { return __half2{x, y}; 
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_Device___halves2half2_Accuracy_Positive") {
+TEST_CASE(Unit_Device___halves2half2_Accuracy_Positive) {
   BinaryFloatingPointTest(__halves2half2_kernel, __halves2half2_ref,
                           Half2ValidatorBuilderFactory(EqValidatorBuilderFactory<Float16>()));
 }
@@ -120,7 +120,7 @@ static Float16 __low2half_ref(Float16 x) { return x; }
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_Device___low2half_Accuracy_Positive") {
+TEST_CASE(Unit_Device___low2half_Accuracy_Positive) {
   UnaryHalfPrecisionTest(__low2half_kernel, __low2half_ref, EqValidatorBuilderFactory<Float16>());
 }
 
@@ -141,7 +141,7 @@ static Float16 __high2half_ref(Float16 x) { return -x; }
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_Device___high2half_Accuracy_Positive") {
+TEST_CASE(Unit_Device___high2half_Accuracy_Positive) {
   UnaryHalfPrecisionTest(__high2half_kernel, __high2half_ref, EqValidatorBuilderFactory<Float16>());
 }
 
@@ -164,7 +164,7 @@ static __half2 __low2half2_ref(Float16 x) { return __half2{x, x}; }
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_Device___low2half2_Accuracy_Positive") {
+TEST_CASE(Unit_Device___low2half2_Accuracy_Positive) {
   UnaryHalfPrecisionTest(__low2half2_kernel, __low2half2_ref,
                          Half2ValidatorBuilderFactory(EqValidatorBuilderFactory<Float16>()));
 }
@@ -186,7 +186,7 @@ static __half2 __high2half2_ref(Float16 x) { return __half2{-x, -x}; }
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_Device___high2half2_Accuracy_Positive") {
+TEST_CASE(Unit_Device___high2half2_Accuracy_Positive) {
   UnaryHalfPrecisionTest(__high2half2_kernel, __high2half2_ref,
                          Half2ValidatorBuilderFactory(EqValidatorBuilderFactory<Float16>()));
 }
@@ -209,7 +209,7 @@ static __half2 __lowhigh2highlow_ref(Float16 x) { return __half2{-x, x}; }
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_Device___lowhigh2highlow_Accuracy_Positive") {
+TEST_CASE(Unit_Device___lowhigh2highlow_Accuracy_Positive) {
   UnaryHalfPrecisionTest(__lowhigh2highlow_kernel, __lowhigh2highlow_ref,
                          Half2ValidatorBuilderFactory(EqValidatorBuilderFactory<Float16>()));
 }
@@ -232,7 +232,7 @@ static __half2 __lows2half2_ref(Float16 x, Float16 y) { return __half2{x, y}; }
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_Device___lows2half2_Accuracy_Positive") {
+TEST_CASE(Unit_Device___lows2half2_Accuracy_Positive) {
   BinaryFloatingPointTest(__lows2half2_kernel, __lows2half2_ref,
                           Half2ValidatorBuilderFactory(EqValidatorBuilderFactory<Float16>()));
 }
@@ -255,7 +255,7 @@ static __half2 __highs2half2_ref(Float16 x, Float16 y) { return __half2{-x, -y};
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_Device___highs2half2_Accuracy_Positive") {
+TEST_CASE(Unit_Device___highs2half2_Accuracy_Positive) {
   BinaryFloatingPointTest(__highs2half2_kernel, __highs2half2_ref,
                           Half2ValidatorBuilderFactory(EqValidatorBuilderFactory<Float16>()));
 }
@@ -282,7 +282,7 @@ static __half2 __float2half2_rn_ref(float x) {
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_Device___float2half2_rn_Accuracy_Positive") {
+TEST_CASE(Unit_Device___float2half2_rn_Accuracy_Positive) {
   UnarySinglePrecisionTest(__float2half2_rn_kernel, __float2half2_rn_ref,
                            Half2ValidatorBuilderFactory(EqValidatorBuilderFactory<Float16>()));
 }
@@ -307,7 +307,7 @@ static __half2 __floats2half2_rn_ref(float x, float y) {
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_Device___floats2half2_rn_Accuracy_Positive") {
+TEST_CASE(Unit_Device___floats2half2_rn_Accuracy_Positive) {
   BinaryFloatingPointTest(__floats2half2_rn_kernel, __floats2half2_rn_ref,
                           Half2ValidatorBuilderFactory(EqValidatorBuilderFactory<Float16>()));
 }
@@ -341,7 +341,7 @@ static __half2 __float22half2_rn_ref(float x) {
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_Device___float22half2_rn_Accuracy_Positive") {
+TEST_CASE(Unit_Device___float22half2_rn_Accuracy_Positive) {
   UnarySinglePrecisionTest(__float22half2_rn_kernel, __float22half2_rn_ref,
                            Half2ValidatorBuilderFactory(EqValidatorBuilderFactory<Float16>()));
 }
@@ -366,7 +366,7 @@ static float __low2float_ref(Float16 x) { return static_cast<float>(x); }
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_Device___low2float_Accuracy_Positive") {
+TEST_CASE(Unit_Device___low2float_Accuracy_Positive) {
   UnaryHalfPrecisionTest(__low2float_kernel, __low2float_ref, EqValidatorBuilderFactory<float>());
 }
 
@@ -388,7 +388,7 @@ static float __high2float_ref(Float16 x) { return static_cast<float>(-x); }
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_Device___high2float_Accuracy_Positive") {
+TEST_CASE(Unit_Device___high2float_Accuracy_Positive) {
   UnaryHalfPrecisionTest(__high2float_kernel, __high2float_ref, EqValidatorBuilderFactory<float>());
 }
 
@@ -413,7 +413,7 @@ static float2 __half22float2_ref(Float16 x) {
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_Device___half22float2_Accuracy_Positive") {
+TEST_CASE(Unit_Device___half22float2_Accuracy_Positive) {
   UnaryHalfPrecisionTest(__half22float2_kernel, __half22float2_ref,
                          Float2ValidatorBuilderFactory(EqValidatorBuilderFactory<float>()));
 }

--- a/projects/hip-tests/catch/unit/math/casting_half2int_funcs.cc
+++ b/projects/hip-tests/catch/unit/math/casting_half2int_funcs.cc
@@ -33,7 +33,7 @@ THE SOFTWARE.
   CAST_KERNEL_DEF(kern_name, T, Float16)                                                           \
   CAST_F2I_RZ_REF_DEF(kern_name, T, Float16)                                                       \
                                                                                                    \
-  TEST_CASE("Unit_Device_" #kern_name "_Accuracy_Positive") {                                      \
+  TEST_CASE(Unit_Device_##kern_name##_Accuracy_Positive) {                                      \
     T (*ref)(Float16) = kern_name##_ref;                                                           \
     CastUnaryHalfPrecisionTest(kern_name##_kernel, ref, EqValidatorBuilderFactory<T>());           \
   }
@@ -413,7 +413,7 @@ CAST_KERNEL_DEF(__half_as_short, short, Float16)
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_Device___half_as_short_Accuracy_Positive") {
+TEST_CASE(Unit_Device___half_as_short_Accuracy_Positive) {
   short (*ref)(Float16) = type2_as_type1_ref<short, Float16>;
   CastUnaryHalfPrecisionTest(__half_as_short_kernel, ref, EqValidatorBuilderFactory<short>());
 }
@@ -433,7 +433,7 @@ CAST_KERNEL_DEF(__half_as_ushort, unsigned short, Float16)
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_Device___half_as_ushort_Accuracy_Positive") {
+TEST_CASE(Unit_Device___half_as_ushort_Accuracy_Positive) {
   unsigned short (*ref)(Float16) = type2_as_type1_ref<unsigned short, Float16>;
   CastUnaryHalfPrecisionTest(__half_as_ushort_kernel, ref,
                              EqValidatorBuilderFactory<unsigned short>());

--- a/projects/hip-tests/catch/unit/math/casting_half_float_funcs.cc
+++ b/projects/hip-tests/catch/unit/math/casting_half_float_funcs.cc
@@ -33,7 +33,7 @@ THE SOFTWARE.
   CAST_KERNEL_DEF(kern_name, Float16, float)                                                       \
   CAST_RND_REF_DEF(kern_name, Float16, float, round_dir)                                           \
                                                                                                    \
-  TEST_CASE("Unit_Device_" #kern_name "_Accuracy_Limited_Positive") {                              \
+  TEST_CASE(Unit_Device_##kern_name##_Accuracy_Limited_Positive) {                              \
     Float16 (*ref)(float) = kern_name##_ref;                                                       \
     UnarySinglePrecisionRangeTest(kern_name##_kernel, ref, EqValidatorBuilderFactory<Float16>(),   \
                                   std::numeric_limits<float>::lowest(), 0.f);                      \
@@ -45,7 +45,7 @@ THE SOFTWARE.
   CAST_KERNEL_DEF(kern_name, Float16, float)                                                       \
   CAST_REF_DEF(kern_name, Float16, float)                                                          \
                                                                                                    \
-  TEST_CASE("Unit_Device_" #kern_name "_Accuracy_Positive") {                                      \
+  TEST_CASE(Unit_Device_##kern_name##_Accuracy_Positive) {                                      \
     Float16 (*ref)(float) = kern_name##_ref;                                                       \
     UnarySinglePrecisionRangeTest(kern_name##_kernel, ref, EqValidatorBuilderFactory<Float16>(),   \
                                   std::numeric_limits<float>::lowest(),                            \
@@ -145,7 +145,7 @@ CAST_FLOAT2HALF_TEST_DEF(__float2half_rz, FE_TOWARDZERO)
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_Device___float2half_rd_SmallVals_Sanity_Positive") {
+TEST_CASE(Unit_Device___float2half_rd_SmallVals_Sanity_Positive) {
   const float input[] = {0.8859e-06f, 1.5454e-07f, 6.5955e-08f, 2.7955e-08f,
                          3.7956e-09f, 4.8995e-10f, 5.7997e-15f, 6.2117e-20f,
                          7.4999e-25f, 8.9999e-30f, 9.0001e-35f};
@@ -175,7 +175,7 @@ TEST_CASE("Unit_Device___float2half_rd_SmallVals_Sanity_Positive") {
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_Device___float2half_ru_SmallVals_Sanity_Positive") {
+TEST_CASE(Unit_Device___float2half_ru_SmallVals_Sanity_Positive) {
   const float input[] = {0.8859e-06f, 1.5454e-07f, 6.5955e-08f, 2.7955e-08f,
                          3.7956e-09f, 4.8995e-10f, 5.7997e-15f, 6.2117e-20f,
                          7.4999e-25f, 8.9999e-30f, 9.0001e-35f};
@@ -207,7 +207,7 @@ TEST_CASE("Unit_Device___float2half_ru_SmallVals_Sanity_Positive") {
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_Device___float2half_rz_SmallVals_Sanity_Positive") {
+TEST_CASE(Unit_Device___float2half_rz_SmallVals_Sanity_Positive) {
   const float input[] = {0.8859e-06f, 1.5454e-07f, 6.5955e-08f, 2.7955e-08f,
                          3.7956e-09f, 4.8995e-10f, 5.7997e-15f, 6.2117e-20f,
                          7.4999e-25f, 8.9999e-30f, 9.0001e-35f};
@@ -241,7 +241,7 @@ CAST_REF_DEF(__half2float, float, Float16)
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_Device___half2float_Accuracy_Positive") {
+TEST_CASE(Unit_Device___half2float_Accuracy_Positive) {
   float (*ref)(Float16) = __half2float_ref;
   UnaryHalfPrecisionTest(__half2float_kernel, ref, EqValidatorBuilderFactory<float>());
 }

--- a/projects/hip-tests/catch/unit/math/casting_int2half_funcs.cc
+++ b/projects/hip-tests/catch/unit/math/casting_int2half_funcs.cc
@@ -33,7 +33,7 @@ THE SOFTWARE.
   CAST_KERNEL_DEF(kern_name, Float16, T)                                                           \
   CAST_REF_DEF(kern_name, Float16, T)                                                              \
                                                                                                    \
-  TEST_CASE("Unit_Device_" #kern_name "_Accuracy_Positive") {                                      \
+  TEST_CASE(Unit_Device_##kern_name##_Accuracy_Positive) {                                      \
     Float16 (*ref)(T) = kern_name##_ref;                                                           \
     CastIntRangeTest(kern_name##_kernel, ref, EqValidatorBuilderFactory<Float16>());               \
   }
@@ -282,7 +282,7 @@ CAST_INT2HALF_RN_TEST_DEF(__ushort2half_ru, unsigned short)
   CAST_KERNEL_DEF(kern_name, Float16, T)                                                           \
   CAST_REF_DEF(kern_name, Float16, T)                                                              \
                                                                                                    \
-  TEST_CASE("Unit_Device_" #kern_name "_Accuracy_Positive") {                                      \
+  TEST_CASE(Unit_Device_##kern_name##_Accuracy_Positive) {                                      \
     Float16 (*ref)(T) = kern_name##_ref;                                                           \
     CastIntBruteForceTest(kern_name##_kernel, ref, EqValidatorBuilderFactory<Float16>());          \
   }
@@ -422,7 +422,7 @@ CAST_KERNEL_DEF(__short_as_half, Float16, short)
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_Device___short_as_half_Accuracy_Positive") {
+TEST_CASE(Unit_Device___short_as_half_Accuracy_Positive) {
   Float16 (*ref)(short) = type2_as_type1_ref<Float16, short>;
   CastIntBruteForceTest(__short_as_half_kernel, ref, EqValidatorBuilderFactory<Float16>());
 }
@@ -442,7 +442,7 @@ CAST_KERNEL_DEF(__ushort_as_half, Float16, unsigned short)
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_Device___ushort_as_half_Accuracy_Positive") {
+TEST_CASE(Unit_Device___ushort_as_half_Accuracy_Positive) {
   Float16 (*ref)(unsigned short) = type2_as_type1_ref<Float16, unsigned short>;
   CastIntBruteForceTest(__ushort_as_half_kernel, ref, EqValidatorBuilderFactory<Float16>());
 }

--- a/projects/hip-tests/catch/unit/math/casting_int_funcs.cc
+++ b/projects/hip-tests/catch/unit/math/casting_int_funcs.cc
@@ -32,7 +32,7 @@ THE SOFTWARE.
   CAST_KERNEL_DEF(kern_name, T1, T2)                                                               \
   CAST_RND_REF_DEF(kern_name, T1, T2, round_dir)                                                   \
                                                                                                    \
-  TEST_CASE("Unit_Device_" #kern_name "_Positive") {                                               \
+  TEST_CASE(Unit_Device_##kern_name##_Positive) {                                               \
     T1 (*ref)(T2) = kern_name##_ref;                                                               \
     CastIntRangeTest(kern_name##_kernel, ref, EqValidatorBuilderFactory<T1>());                    \
   }
@@ -41,7 +41,7 @@ THE SOFTWARE.
   CAST_KERNEL_DEF(kern_name, T1, T2)                                                               \
   CAST_REF_DEF(kern_name, T1, T2)                                                                  \
                                                                                                    \
-  TEST_CASE("Unit_Device_" #kern_name "_Positive") {                                               \
+  TEST_CASE(Unit_Device_##kern_name##_Positive) {                                               \
     T1 (*ref)(T2) = kern_name##_ref;                                                               \
     CastIntRangeTest(kern_name##_kernel, ref, EqValidatorBuilderFactory<T1>());                    \
   }
@@ -118,7 +118,7 @@ CAST_INT2FLOAT_TEST_DEF(__int2float_rz, float, int, FE_TOWARDZERO)
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_Device_int2float___Negative_RTC") { NegativeTestRTCWrapper<12>(kInt2Float); }
+TEST_CASE(Unit_Device_int2float___Negative_RTC) { NegativeTestRTCWrapper<12>(kInt2Float); }
 
 /**
  * Test Description
@@ -192,7 +192,7 @@ CAST_INT2FLOAT_TEST_DEF(__uint2float_rz, float, unsigned int, FE_TOWARDZERO)
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_Device___uint2float_Negative_RTC") { NegativeTestRTCWrapper<12>(kUint2Float); }
+TEST_CASE(Unit_Device___uint2float_Negative_RTC) { NegativeTestRTCWrapper<12>(kUint2Float); }
 
 /**
  * Test Description
@@ -221,7 +221,7 @@ CAST_INT2FLOAT_RN_TEST_DEF(__int2double_rn, double, int)
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_Device___int2double_Negative_RTC") { NegativeTestRTCWrapper<3>(kInt2Double); }
+TEST_CASE(Unit_Device___int2double_Negative_RTC) { NegativeTestRTCWrapper<3>(kInt2Double); }
 
 /**
  * Test Description
@@ -250,13 +250,13 @@ CAST_INT2FLOAT_RN_TEST_DEF(__uint2double_rn, double, unsigned int)
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_Device___uint2double_Negative_RTC") { NegativeTestRTCWrapper<3>(kUint2Double); }
+TEST_CASE(Unit_Device___uint2double_Negative_RTC) { NegativeTestRTCWrapper<3>(kUint2Double); }
 
 #define CAST_LL2FLOAT_TEST_DEF(kern_name, T1, T2, round_dir)                                       \
   CAST_KERNEL_DEF(kern_name, T1, T2)                                                               \
   CAST_RND_REF_DEF(kern_name, T1, T2, round_dir)                                                   \
                                                                                                    \
-  TEST_CASE("Unit_Device_" #kern_name "_Positive") {                                               \
+  TEST_CASE(Unit_Device_##kern_name##_Positive) {                                               \
     T1 (*ref)(T2) = kern_name##_ref;                                                               \
     CastIntBruteForceTest(kern_name##_kernel, ref, EqValidatorBuilderFactory<T1>());               \
   }
@@ -265,7 +265,7 @@ TEST_CASE("Unit_Device___uint2double_Negative_RTC") { NegativeTestRTCWrapper<3>(
   CAST_KERNEL_DEF(kern_name, T1, T2)                                                               \
   CAST_REF_DEF(kern_name, T1, T2)                                                                  \
                                                                                                    \
-  TEST_CASE("Unit_Device_" #kern_name "_Positive") {                                               \
+  TEST_CASE(Unit_Device_##kern_name##_Positive) {                                               \
     T1 (*ref)(T2) = kern_name##_ref;                                                               \
     CastIntBruteForceTest(kern_name##_kernel, ref, EqValidatorBuilderFactory<T1>());               \
   }
@@ -345,7 +345,7 @@ CAST_LL2FLOAT_TEST_DEF(__ll2float_rz, float, long long int, FE_TOWARDZERO)
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_Device___ll2float_Negative_RTC") { NegativeTestRTCWrapper<12>(kLL2Float); }
+TEST_CASE(Unit_Device___ll2float_Negative_RTC) { NegativeTestRTCWrapper<12>(kLL2Float); }
 
 /**
  * Test Description
@@ -422,7 +422,7 @@ CAST_LL2FLOAT_TEST_DEF(__ull2float_rz, float, unsigned long long int, FE_TOWARDZ
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_Device___ull2float_Negative_RTC") { NegativeTestRTCWrapper<12>(kULL2Float); }
+TEST_CASE(Unit_Device___ull2float_Negative_RTC) { NegativeTestRTCWrapper<12>(kULL2Float); }
 
 /**
  * Test Description
@@ -499,7 +499,7 @@ CAST_LL2FLOAT_TEST_DEF(__ll2double_rz, double, long long int, FE_TOWARDZERO)
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_Device___ll2double_Negative_RTC") { NegativeTestRTCWrapper<12>(kLL2Double); }
+TEST_CASE(Unit_Device___ll2double_Negative_RTC) { NegativeTestRTCWrapper<12>(kLL2Double); }
 
 /**
  * Test Description
@@ -576,7 +576,7 @@ CAST_LL2FLOAT_TEST_DEF(__ull2double_rz, double, unsigned long long int, FE_TOWAR
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_Device___ull2double_Negative_RTC") { NegativeTestRTCWrapper<12>(kULL2Double); }
+TEST_CASE(Unit_Device___ull2double_Negative_RTC) { NegativeTestRTCWrapper<12>(kULL2Double); }
 
 CAST_KERNEL_DEF(__int_as_float, float, int)
 
@@ -593,7 +593,7 @@ CAST_KERNEL_DEF(__int_as_float, float, int)
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_Device___int_as_float_Positive") {
+TEST_CASE(Unit_Device___int_as_float_Positive) {
   float (*ref)(int) = type2_as_type1_ref<float, int>;
   CastIntRangeTest(__int_as_float_kernel, ref, EqValidatorBuilderFactory<float>());
 }
@@ -610,7 +610,7 @@ TEST_CASE("Unit_Device___int_as_float_Positive") {
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_Device___int_as_float_Negative_RTC") { NegativeTestRTCWrapper<3>(kIntAsFloat); }
+TEST_CASE(Unit_Device___int_as_float_Negative_RTC) { NegativeTestRTCWrapper<3>(kIntAsFloat); }
 
 CAST_KERNEL_DEF(__uint_as_float, float, unsigned int)
 
@@ -627,7 +627,7 @@ CAST_KERNEL_DEF(__uint_as_float, float, unsigned int)
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_Device___uint_as_float_Positive") {
+TEST_CASE(Unit_Device___uint_as_float_Positive) {
   float (*ref)(unsigned int) = type2_as_type1_ref<float, unsigned int>;
   CastIntRangeTest(__uint_as_float_kernel, ref, EqValidatorBuilderFactory<float>());
 }
@@ -644,7 +644,7 @@ TEST_CASE("Unit_Device___uint_as_float_Positive") {
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_Device___uint_as_float_Negative_RTC") { NegativeTestRTCWrapper<3>(kUintAsFloat); }
+TEST_CASE(Unit_Device___uint_as_float_Negative_RTC) { NegativeTestRTCWrapper<3>(kUintAsFloat); }
 
 CAST_KERNEL_DEF(__longlong_as_double, double, long long int)
 
@@ -662,7 +662,7 @@ CAST_KERNEL_DEF(__longlong_as_double, double, long long int)
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_Device___longlong_as_double_Positive") {
+TEST_CASE(Unit_Device___longlong_as_double_Positive) {
   double (*ref)(long long int) = type2_as_type1_ref<double, long long int>;
   CastIntBruteForceTest(__longlong_as_double_kernel, ref, EqValidatorBuilderFactory<double>());
 }
@@ -679,7 +679,7 @@ TEST_CASE("Unit_Device___longlong_as_double_Positive") {
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_Device___longlong_as_double_Negative_RTC") {
+TEST_CASE(Unit_Device___longlong_as_double_Negative_RTC) {
   NegativeTestRTCWrapper<3>(kLonglongAsDouble);
 }
 
@@ -715,7 +715,7 @@ double __hiloint2double_ref(int hi, int lo) {
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_Device___hiloint2double_Positive") {
+TEST_CASE(Unit_Device___hiloint2double_Positive) {
   double (*ref)(int, int) = __hiloint2double_ref;
   CastBinaryIntRangeTest(__hiloint2double_kernel, ref, EqValidatorBuilderFactory<double>());
 }
@@ -732,7 +732,7 @@ TEST_CASE("Unit_Device___hiloint2double_Positive") {
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_Device___hiloint2double_Negative_RTC") { NegativeTestRTCWrapper<5>(kHilo2Double); }
+TEST_CASE(Unit_Device___hiloint2double_Negative_RTC) { NegativeTestRTCWrapper<5>(kHilo2Double); }
 
 /**
  * End doxygen group MathTest.

--- a/projects/hip-tests/catch/unit/math/double_precision_intrinsics.cc
+++ b/projects/hip-tests/catch/unit/math/double_precision_intrinsics.cc
@@ -39,7 +39,7 @@ THE SOFTWARE.
   }
 
 #define MATH_UNARY_DP_TEST_DEF_IMPL(func_name, ref_func, validator_builder)                        \
-  TEST_CASE("Unit_Device_" #func_name "_Accuracy_Positive") {                                      \
+  TEST_CASE(Unit_Device_##func_name##_Accuracy_Positive) {                                      \
     UnaryDoublePrecisionTest(func_name##_kernel, ref_func, validator_builder);                     \
   }
 
@@ -106,7 +106,7 @@ MATH_UNARY_DP_TEST_DEF_IMPL(__dsqrt_rn, static_cast<double (*)(double)>(std::sqr
   }
 
 #define MATH_BINARY_DP_TEST_DEF_IMPL(func_name, ref_func, validator_builder)                       \
-  TEST_CASE("Unit_Device_" #func_name "_Accuracy_Positive") {                                      \
+  TEST_CASE(Unit_Device_##func_name##_Accuracy_Positive) {                                      \
     BinaryFloatingPointTest(func_name##_kernel, ref_func, validator_builder);                      \
   }
 
@@ -212,7 +212,7 @@ MATH_BINARY_DP_TEST_DEF_IMPL(__ddiv_rn, __ddiv_rn_ref, EqValidatorBuilderFactory
   }
 
 #define MATH_TERNARY_DP_TEST_DEF_IMPL(func_name, ref_func, validator_builder)                      \
-  TEST_CASE("Unit_Device_" #func_name "_Accuracy_Positive") {                                      \
+  TEST_CASE(Unit_Device_##func_name##_Accuracy_Positive) {                                      \
     TernaryFloatingPointTest(func_name##_kernel, ref_func, validator_builder);                     \
   }
 

--- a/projects/hip-tests/catch/unit/math/half_precision_common.hh
+++ b/projects/hip-tests/catch/unit/math/half_precision_common.hh
@@ -40,7 +40,7 @@ THE SOFTWARE.
   }
 
 #define MATH_UNARY_HP_TEST_DEF_IMPL(func_name, ref_func, validator_builder)                        \
-  TEST_CASE("Unit_Device_" #func_name "_Accuracy_Positive") {                                      \
+  TEST_CASE(Unit_Device_##func_name##_Accuracy_Positive) {                                      \
     UnaryHalfPrecisionTest(func_name##_kernel, ref_func, validator_builder);                       \
   }
 
@@ -65,7 +65,7 @@ THE SOFTWARE.
   }
 
 #define MATH_BINARY_HP_TEST_DEF_IMPL(func_name, ref_func, validator_builder)                       \
-  TEST_CASE("Unit_Device_" #func_name "_Accuracy_Positive") {                                      \
+  TEST_CASE(Unit_Device_##func_name##_Accuracy_Positive) {                                      \
     BinaryFloatingPointTest(func_name##_kernel, ref_func, validator_builder);                      \
   }
 
@@ -91,7 +91,7 @@ THE SOFTWARE.
   }
 
 #define MATH_TERNARY_HP_TEST_DEF_IMPL(func_name, ref_func, validator_builder)                      \
-  TEST_CASE("Unit_Device_" #func_name "_Accuracy_Positive") {                                      \
+  TEST_CASE(Unit_Device_##func_name##_Accuracy_Positive) {                                      \
     TernaryFloatingPointTest(func_name##_kernel, ref_func, validator_builder);                     \
   }
 

--- a/projects/hip-tests/catch/unit/math/half_precision_comparison.cc
+++ b/projects/hip-tests/catch/unit/math/half_precision_comparison.cc
@@ -40,7 +40,7 @@ THE SOFTWARE.
     }                                                                                              \
   }                                                                                                \
                                                                                                    \
-  TEST_CASE("Unit_Device_" #func_name "_Accuracy_Positive") {                                      \
+  TEST_CASE(Unit_Device_##func_name##_Accuracy_Positive) {                                      \
     UnaryHalfPrecisionTest(func_name##_kernel, ref_func, EqValidatorBuilderFactory<bool>());       \
   }
 
@@ -125,7 +125,7 @@ MATH_UNARY_HP_TEST_DEF_IMPL(__hisnan2, __hisnan2_ref, EqValidatorBuilderFactory<
     }                                                                                              \
   }                                                                                                \
                                                                                                    \
-  TEST_CASE("Unit_Device_" #func_name "_Accuracy_Positive") {                                      \
+  TEST_CASE(Unit_Device_##func_name##_Accuracy_Positive) {                                      \
     BinaryFloatingPointTest(func_name##_kernel, ref_func<nan_value, RT>,                           \
                             EqValidatorBuilderFactory<RT>());                                      \
   }

--- a/projects/hip-tests/catch/unit/math/integer_intrinsics.cc
+++ b/projects/hip-tests/catch/unit/math/integer_intrinsics.cc
@@ -37,7 +37,7 @@ __global__ void __brev_kernel(unsigned int* y, unsigned int x) { y[0] = __brev(x
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_Device___brev_Sanity_Positive") {
+TEST_CASE(Unit_Device___brev_Sanity_Positive) {
   LinearAllocGuard<unsigned int> y(LinearAllocs::hipMallocManaged, sizeof(unsigned int));
 
   __brev_kernel<<<1, 1>>>(y.ptr(), 0xAAAAAAAA);
@@ -62,7 +62,7 @@ __global__ void __brevll_kernel(unsigned long long int* y, unsigned long long in
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_Device___brevll_Sanity_Positive") {
+TEST_CASE(Unit_Device___brevll_Sanity_Positive) {
   LinearAllocGuard<unsigned long long int> y(LinearAllocs::hipMallocManaged,
                                              sizeof(unsigned long long int));
 
@@ -86,7 +86,7 @@ template <typename T> __global__ void __clz_kernel(T* y, T x) { y[0] = __clz(x);
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEMPLATE_TEST_CASE("Unit_Device___clz_Sanity_Positive", "", int, unsigned int) {
+TEMPLATE_TEST_CASE(Unit_Device___clz_Sanity_Positive, int, unsigned int) {
   LinearAllocGuard<TestType> y(LinearAllocs::hipMallocManaged, sizeof(TestType));
 
   __clz_kernel<<<1, 1>>>(y.ptr(), static_cast<TestType>(0));
@@ -118,7 +118,7 @@ template <typename T> __global__ void __clzll_kernel(T* y, T x) { y[0] = __clzll
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEMPLATE_TEST_CASE("Unit_Device___clzll_Sanity_Positive", "", long long int,
+TEMPLATE_TEST_CASE(Unit_Device___clzll_Sanity_Positive, long long int,
                    unsigned long long int) {
   LinearAllocGuard<TestType> y(LinearAllocs::hipMallocManaged, sizeof(TestType));
 
@@ -150,7 +150,7 @@ template <typename T> __global__ void __ffs_kernel(T* y, T x) { y[0] = __ffs(x);
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEMPLATE_TEST_CASE("Unit_Device___ffs_Sanity_Positive", "", int, unsigned int) {
+TEMPLATE_TEST_CASE(Unit_Device___ffs_Sanity_Positive, int, unsigned int) {
   LinearAllocGuard<TestType> y(LinearAllocs::hipMallocManaged, sizeof(TestType));
 
   __ffs_kernel<<<1, 1>>>(y.ptr(), static_cast<TestType>(0));
@@ -182,7 +182,7 @@ template <typename T> __global__ void __ffsll_kernel(T* y, T x) { y[0] = __ffsll
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEMPLATE_TEST_CASE("Unit_Device___ffsll_Sanity_Positive", "", long long int,
+TEMPLATE_TEST_CASE(Unit_Device___ffsll_Sanity_Positive, long long int,
                    unsigned long long int) {
   LinearAllocGuard<TestType> y(LinearAllocs::hipMallocManaged, sizeof(TestType));
 
@@ -214,7 +214,7 @@ __global__ void __popc_kernel(unsigned int* y, unsigned int x) { y[0] = __popc(x
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_Device___popc_Sanity_Positive") {
+TEST_CASE(Unit_Device___popc_Sanity_Positive) {
   LinearAllocGuard<unsigned int> y(LinearAllocs::hipMallocManaged, sizeof(unsigned int));
 
   __popc_kernel<<<1, 1>>>(y.ptr(), 0);
@@ -247,7 +247,7 @@ __global__ void __popcll_kernel(unsigned long long int* y, unsigned long long in
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_Device___popcll_Sanity_Positive") {
+TEST_CASE(Unit_Device___popcll_Sanity_Positive) {
   LinearAllocGuard<unsigned long long int> y(LinearAllocs::hipMallocManaged,
                                              sizeof(unsigned long long int));
 
@@ -279,7 +279,7 @@ __global__ void __mul24_kernel(int* y, int x1, int x2) { y[0] = __mul24(x1, x2);
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_Device___mul24_Sanity_Positive") {
+TEST_CASE(Unit_Device___mul24_Sanity_Positive) {
   LinearAllocGuard<int> y(LinearAllocs::hipMallocManaged, sizeof(int));
 
   int x1 = GENERATE(0, -42, 42, 0xFFFFFFFF);
@@ -307,7 +307,7 @@ __global__ void __umul24_kernel(unsigned int* y, unsigned int x1, unsigned int x
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_Device___umul24_Sanity_Positive") {
+TEST_CASE(Unit_Device___umul24_Sanity_Positive) {
   LinearAllocGuard<unsigned int> y(LinearAllocs::hipMallocManaged, sizeof(unsigned int));
 
   unsigned int x1 = GENERATE(0, 42, 0xFFFFFF);
@@ -336,7 +336,7 @@ __global__ void __funnelshift_l_kernel(unsigned int* y, unsigned int lo, unsigne
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_Device___funnelshift_l_Sanity_Positive") {
+TEST_CASE(Unit_Device___funnelshift_l_Sanity_Positive) {
   LinearAllocGuard<unsigned int> y(LinearAllocs::hipMallocManaged, sizeof(unsigned int));
 
   const unsigned int lo = 0xAAAAAAAA, hi = 0xBBBBBBBB;
@@ -368,7 +368,7 @@ __global__ void __funnelshift_lc_kernel(unsigned int* y, unsigned int lo, unsign
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_Device___funnelshift_lc_Sanity_Positive") {
+TEST_CASE(Unit_Device___funnelshift_lc_Sanity_Positive) {
   LinearAllocGuard<unsigned int> y(LinearAllocs::hipMallocManaged, sizeof(unsigned int));
 
   const unsigned int lo = 0xAAAAAAAA, hi = 0xBBBBBBBB;
@@ -400,7 +400,7 @@ __global__ void __funnelshift_r_kernel(unsigned int* y, unsigned int lo, unsigne
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_Device___funnelshift_r_Sanity_Positive") {
+TEST_CASE(Unit_Device___funnelshift_r_Sanity_Positive) {
   LinearAllocGuard<unsigned int> y(LinearAllocs::hipMallocManaged, sizeof(unsigned int));
 
   const unsigned int lo = 0xAAAAAAAA, hi = 0xBBBBBBBB;
@@ -432,7 +432,7 @@ __global__ void __funnelshift_rc_kernel(unsigned int* y, unsigned int lo, unsign
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_Device___funnelshift_rc_Sanity_Positive") {
+TEST_CASE(Unit_Device___funnelshift_rc_Sanity_Positive) {
   LinearAllocGuard<unsigned int> y(LinearAllocs::hipMallocManaged, sizeof(unsigned int));
 
   const unsigned int lo = 0xAAAAAAAA, hi = 0xBBBBBBBB;
@@ -461,7 +461,7 @@ __global__ void __hadd_kernel(int* y, int x1, int x2) { y[0] = __hadd(x1, x2); }
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_Device___hadd_Sanity_Positive") {
+TEST_CASE(Unit_Device___hadd_Sanity_Positive) {
   LinearAllocGuard<int> y(LinearAllocs::hipMallocManaged, sizeof(int));
 
   int x1 = GENERATE(0, -42, 42, 0xFFFFFFFF);
@@ -491,7 +491,7 @@ __global__ void __uhadd_kernel(unsigned int* y, unsigned int x1, unsigned int x2
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_Device___uhadd_Sanity_Positive") {
+TEST_CASE(Unit_Device___uhadd_Sanity_Positive) {
   LinearAllocGuard<unsigned int> y(LinearAllocs::hipMallocManaged, sizeof(unsigned int));
 
   unsigned int x1 = GENERATE(0, 42, 0xFFFFFFFF);
@@ -519,7 +519,7 @@ __global__ void __rhadd_kernel(int* y, int x1, int x2) { y[0] = __rhadd(x1, x2);
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_Device___rhadd_Sanity_Positive") {
+TEST_CASE(Unit_Device___rhadd_Sanity_Positive) {
   LinearAllocGuard<int> y(LinearAllocs::hipMallocManaged, sizeof(int));
 
   int x1 = GENERATE(0, -42, 42, 0xFFFFFFFF);
@@ -549,7 +549,7 @@ __global__ void __urhadd_kernel(unsigned int* y, unsigned int x1, unsigned int x
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_Device___urhadd_Sanity_Positive") {
+TEST_CASE(Unit_Device___urhadd_Sanity_Positive) {
   LinearAllocGuard<unsigned int> y(LinearAllocs::hipMallocManaged, sizeof(unsigned int));
 
   unsigned int x1 = GENERATE(0, 42, 0xFFFFFFFF);
@@ -578,7 +578,7 @@ __global__ void __mulhi_kernel(int* y, int x1, int x2) { y[0] = __mulhi(x1, x2);
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_Device___mulhi_Sanity_Positive") {
+TEST_CASE(Unit_Device___mulhi_Sanity_Positive) {
   LinearAllocGuard<int> y(LinearAllocs::hipMallocManaged, sizeof(int));
 
   int x1 = GENERATE(0, -42, 42, 0xFFFFFFFF);
@@ -609,7 +609,7 @@ __global__ void __umulhi_kernel(unsigned int* y, unsigned int x1, unsigned int x
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_Device___umulhi_Sanity_Positive") {
+TEST_CASE(Unit_Device___umulhi_Sanity_Positive) {
   LinearAllocGuard<unsigned int> y(LinearAllocs::hipMallocManaged, sizeof(unsigned int));
 
   unsigned int x1 = GENERATE(0, 42, 0xFFFFFFFF);
@@ -640,7 +640,7 @@ __global__ void __mul64hi_kernel(long long* y, long long x1, long long x2) {
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_Device___mul64hi_Sanity_Positive") {
+TEST_CASE(Unit_Device___mul64hi_Sanity_Positive) {
   LinearAllocGuard<long long> y(LinearAllocs::hipMallocManaged, sizeof(long long));
 
   long long x1 = GENERATE(0, -42, 42, 0xFFFFFFFF);
@@ -672,7 +672,7 @@ __global__ void __umul64hi_kernel(unsigned long long* y, unsigned long long x1,
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_Device___umul64hi_Sanity_Positive") {
+TEST_CASE(Unit_Device___umul64hi_Sanity_Positive) {
   LinearAllocGuard<unsigned long long> y(LinearAllocs::hipMallocManaged,
                                          sizeof(unsigned long long));
 
@@ -704,7 +704,7 @@ __global__ void __sad_kernel(unsigned int* y, int x1, int x2, unsigned int x3) {
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_Device___sad_Sanity_Positive") {
+TEST_CASE(Unit_Device___sad_Sanity_Positive) {
   LinearAllocGuard<unsigned int> y(LinearAllocs::hipMallocManaged, sizeof(unsigned int));
 
   int x1 = GENERATE(0, -42, 42, 0xFFFFFFFF);
@@ -735,7 +735,7 @@ __global__ void __usad_kernel(unsigned int* y, unsigned int x1, unsigned int x2,
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_Device___usad_Sanity_Positive") {
+TEST_CASE(Unit_Device___usad_Sanity_Positive) {
   LinearAllocGuard<unsigned int> y(LinearAllocs::hipMallocManaged, sizeof(unsigned int));
 
   unsigned int x1 = GENERATE(0, 42, 0xFFFFFFFF);
@@ -768,7 +768,7 @@ __global__ void __byte_perm(unsigned int* y, unsigned int x1, unsigned int x2, u
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_Device___byte_perm_Sanity_Positive") {
+TEST_CASE(Unit_Device___byte_perm_Sanity_Positive) {
   LinearAllocGuard<unsigned int> y(LinearAllocs::hipMallocManaged, sizeof(unsigned int));
 
   unsigned int bytes[] = {0x88, 0x99, 0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF};

--- a/projects/hip-tests/catch/unit/math/log_funcs.cc
+++ b/projects/hip-tests/catch/unit/math/log_funcs.cc
@@ -59,7 +59,7 @@ MATH_UNARY_WITHIN_ULP_STL_REF_TEST_DEF(log, 2, 1)
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_Device_log_logf_Negative_RTC") { NegativeTestRTCWrapper<4>(kLog); }
+TEST_CASE(Unit_Device_log_logf_Negative_RTC) { NegativeTestRTCWrapper<4>(kLog); }
 
 /**
  * Test Description
@@ -89,7 +89,7 @@ MATH_UNARY_WITHIN_ULP_STL_REF_TEST_DEF(log2, 1, 1)
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_Device_log2_log2f_Negative_RTC") { NegativeTestRTCWrapper<4>(kLog2); }
+TEST_CASE(Unit_Device_log2_log2f_Negative_RTC) { NegativeTestRTCWrapper<4>(kLog2); }
 
 /**
  * Test Description
@@ -120,7 +120,7 @@ MATH_UNARY_WITHIN_ULP_STL_REF_TEST_DEF(log10, 2, 1)
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_Device_log10_log10f_Negative_RTC") { NegativeTestRTCWrapper<4>(kLog10); }
+TEST_CASE(Unit_Device_log10_log10f_Negative_RTC) { NegativeTestRTCWrapper<4>(kLog10); }
 
 /**
  * Test Description
@@ -150,7 +150,7 @@ MATH_UNARY_WITHIN_ULP_STL_REF_TEST_DEF(log1p, 1, 1)
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_Device_log1p_log1pf_Negative_RTC") { NegativeTestRTCWrapper<4>(kLog1p); }
+TEST_CASE(Unit_Device_log1p_log1pf_Negative_RTC) { NegativeTestRTCWrapper<4>(kLog1p); }
 
 /**
  * Test Description
@@ -180,7 +180,7 @@ MATH_UNARY_WITHIN_ULP_STL_REF_TEST_DEF(logb, 0, 0)
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_Device_logb_logbf_Negative_RTC") { NegativeTestRTCWrapper<4>(kLogb); }
+TEST_CASE(Unit_Device_logb_logbf_Negative_RTC) { NegativeTestRTCWrapper<4>(kLogb); }
 
 
 template <typename T>
@@ -222,7 +222,7 @@ template <typename T> int ilogb_ref(T arg) {
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_Device_ilogbf_Accuracy_Positive") {
+TEST_CASE(Unit_Device_ilogbf_Accuracy_Positive) {
   UnarySinglePrecisionTest(ilogb_kernel<float>, ilogb_ref<double>,
                            EqValidatorBuilderFactory<int>());
 }
@@ -241,7 +241,7 @@ TEST_CASE("Unit_Device_ilogbf_Accuracy_Positive") {
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_Device_ilogb_Accuracy_Positive") {
+TEST_CASE(Unit_Device_ilogb_Accuracy_Positive) {
   UnaryDoublePrecisionTest(ilogb_kernel<double>, ilogb_ref<long double>,
                            EqValidatorBuilderFactory<int>());
 }
@@ -258,7 +258,7 @@ TEST_CASE("Unit_Device_ilogb_Accuracy_Positive") {
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_Device_ilogb_ilogbf_Negative_RTC") { NegativeTestRTCWrapper<4>(kIlogb); }
+TEST_CASE(Unit_Device_ilogb_ilogbf_Negative_RTC) { NegativeTestRTCWrapper<4>(kIlogb); }
 
 /**
  * End doxygen group MathTest.

--- a/projects/hip-tests/catch/unit/math/misc_funcs.cc
+++ b/projects/hip-tests/catch/unit/math/misc_funcs.cc
@@ -26,24 +26,24 @@ THE SOFTWARE.
 #include "ternary_common.hh"
 
 MATH_UNARY_WITHIN_ULP_TEST_DEF(fabs, std::fabs, 0, 0)
-TEST_CASE("Unit_Device_fabs_fabsf_Negative_RTC") { NegativeTestRTCWrapper<4>(kFabs); }
+TEST_CASE(Unit_Device_fabs_fabsf_Negative_RTC) { NegativeTestRTCWrapper<4>(kFabs); }
 
 MATH_BINARY_WITHIN_ULP_TEST_DEF(copysign, std::copysign, 0, 0)
-TEST_CASE("Unit_Device_copysign_copysignf_Negative_RTC") { NegativeTestRTCWrapper<8>(kCopySign); }
+TEST_CASE(Unit_Device_copysign_copysignf_Negative_RTC) { NegativeTestRTCWrapper<8>(kCopySign); }
 
 MATH_BINARY_WITHIN_ULP_TEST_DEF(fmax, std::fmax, 0, 0)
-TEST_CASE("Unit_Device_fmax_fmaxf_Negative_RTC") { NegativeTestRTCWrapper<8>(kFmax); }
+TEST_CASE(Unit_Device_fmax_fmaxf_Negative_RTC) { NegativeTestRTCWrapper<8>(kFmax); }
 
 MATH_BINARY_WITHIN_ULP_TEST_DEF(fmin, std::fmin, 0, 0)
-TEST_CASE("Unit_Device_fmin_fminf_Negative_RTC") { NegativeTestRTCWrapper<8>(kFmin); }
+TEST_CASE(Unit_Device_fmin_fminf_Negative_RTC) { NegativeTestRTCWrapper<8>(kFmin); }
 
 MATH_BINARY_WITHIN_ULP_TEST_DEF(nextafter, std::nextafter, 1, 1)
-TEST_CASE("Unit_Device_nextafter_nextafterf_Negative_RTC") {
+TEST_CASE(Unit_Device_nextafter_nextafterf_Negative_RTC) {
   NegativeTestRTCWrapper<8>(kNextAfter);
 }
 
 MATH_TERNARY_WITHIN_ULP_TEST_DEF(fma, std::fma, 0, 1)
-TEST_CASE("Unit_Device_fma_fmaf_Negative_RTC") { NegativeTestRTCWrapper<12>(kFma); }
+TEST_CASE(Unit_Device_fma_fmaf_Negative_RTC) { NegativeTestRTCWrapper<12>(kFma); }
 
 __global__ void fdividef_kernel(float* const ys, const size_t num_xs, float* const x1s,
                                 float* const x2s) {
@@ -55,12 +55,12 @@ __global__ void fdividef_kernel(float* const ys, const size_t num_xs, float* con
   }
 }
 
-TEST_CASE("Unit_Device_fdividef_Accuracy_Positive") {
+TEST_CASE(Unit_Device_fdividef_Accuracy_Positive) {
   double (*ref)(double, double) = [](double x1, double x2) { return x1 / x2; };
   BinaryFloatingPointTest(fdividef_kernel, ref, ULPValidatorBuilderFactory<float>(0));
 }
 
-TEST_CASE("Unit_Device_fdividef_Negative_RTC") { NegativeTestRTCWrapper<4>(kFdividef); }
+TEST_CASE(Unit_Device_fdividef_Negative_RTC) { NegativeTestRTCWrapper<4>(kFdividef); }
 
 #define MATH_BOOL_RETURNING_FUNCTION_TEST_DEF(kern_name, ref_func)                                 \
   template <typename T>                                                                            \
@@ -73,24 +73,24 @@ TEST_CASE("Unit_Device_fdividef_Negative_RTC") { NegativeTestRTCWrapper<4>(kFdiv
     }                                                                                              \
   }                                                                                                \
                                                                                                    \
-  TEST_CASE("Unit_Device_" #kern_name "_Accuracy_Positive - float") {                              \
+  TEST_CASE(Unit_Device_##kern_name##_Accuracy_Positive_float) {                                   \
     bool (*ref)(double) = ref_func;                                                                \
     UnarySinglePrecisionTest(kern_name##_kernel<float>, ref, EqValidatorBuilderFactory<bool>());   \
   }                                                                                                \
                                                                                                    \
-  TEST_CASE("Unit_Device_" #kern_name "_Accuracy_Positive - double") {                             \
+  TEST_CASE(Unit_Device_##kern_name##_Accuracy_Positive_double) {                                  \
     bool (*ref)(long double) = ref_func;                                                           \
     UnaryDoublePrecisionTest(kern_name##_kernel<double>, ref, EqValidatorBuilderFactory<bool>());  \
   }
 
 MATH_BOOL_RETURNING_FUNCTION_TEST_DEF(isfinite, std::isfinite)
-TEST_CASE("Unit_Device_isfinite_Negative_RTC") { NegativeTestRTCWrapper<4>(kIsFinite); }
+TEST_CASE(Unit_Device_isfinite_Negative_RTC) { NegativeTestRTCWrapper<4>(kIsFinite); }
 
 MATH_BOOL_RETURNING_FUNCTION_TEST_DEF(isinf, std::isinf)
-TEST_CASE("Unit_Device_isinf_Negative_RTC") { NegativeTestRTCWrapper<4>(kIsInf); }
+TEST_CASE(Unit_Device_isinf_Negative_RTC) { NegativeTestRTCWrapper<4>(kIsInf); }
 
 MATH_BOOL_RETURNING_FUNCTION_TEST_DEF(isnan, std::isnan)
-TEST_CASE("Unit_Device_isnan_Negative_RTC") { NegativeTestRTCWrapper<4>(kIsNan); }
+TEST_CASE(Unit_Device_isnan_Negative_RTC) { NegativeTestRTCWrapper<4>(kIsNan); }
 
 MATH_BOOL_RETURNING_FUNCTION_TEST_DEF(signbit, std::signbit)
-TEST_CASE("Unit_Device_signbit_Negative_RTC") { NegativeTestRTCWrapper<4>(kSignBit); }
+TEST_CASE(Unit_Device_signbit_Negative_RTC) { NegativeTestRTCWrapper<4>(kSignBit); }

--- a/projects/hip-tests/catch/unit/math/pow_funcs.cc
+++ b/projects/hip-tests/catch/unit/math/pow_funcs.cc
@@ -61,7 +61,7 @@ MATH_UNARY_WITHIN_ULP_STL_REF_TEST_DEF(exp, 2, 1)
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_Device_exp_expf_Negative_RTC") { NegativeTestRTCWrapper<4>(kExp); }
+TEST_CASE(Unit_Device_exp_expf_Negative_RTC) { NegativeTestRTCWrapper<4>(kExp); }
 
 /**
  * Test Description
@@ -92,7 +92,7 @@ MATH_UNARY_WITHIN_ULP_STL_REF_TEST_DEF(exp2, 2, 1)
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_Device_exp2_exp2f_Negative_RTC") { NegativeTestRTCWrapper<4>(kExp2); }
+TEST_CASE(Unit_Device_exp2_exp2f_Negative_RTC) { NegativeTestRTCWrapper<4>(kExp2); }
 
 /**
  * Test Description
@@ -122,7 +122,7 @@ MATH_UNARY_WITHIN_ULP_STL_REF_TEST_DEF(expm1, 1, 1)
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_Device_expm1_expm1f_Negative_RTC") { NegativeTestRTCWrapper<4>(kExpm1); }
+TEST_CASE(Unit_Device_expm1_expm1f_Negative_RTC) { NegativeTestRTCWrapper<4>(kExpm1); }
 
 MATH_UNARY_KERNEL_DEF(exp10)
 
@@ -139,7 +139,7 @@ MATH_UNARY_KERNEL_DEF(exp10)
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_Device_exp10f_Accuracy_Positive") {
+TEST_CASE(Unit_Device_exp10f_Accuracy_Positive) {
   auto exp10_ref = [](double arg) -> double { return std::pow(10, arg); };
   double (*ref)(double) = exp10_ref;
   UnarySinglePrecisionTest(exp10_kernel<float>, ref, ULPValidatorBuilderFactory<float>(2));
@@ -158,7 +158,7 @@ TEST_CASE("Unit_Device_exp10f_Accuracy_Positive") {
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_Device_exp10_Accuracy_Positive") {
+TEST_CASE(Unit_Device_exp10_Accuracy_Positive) {
   auto exp10_ref = [](long double arg) -> long double { return std::pow(10, arg); };
   long double (*ref)(long double) = exp10_ref;
   UnaryDoublePrecisionTest(exp10_kernel<double>, ref, ULPValidatorBuilderFactory<double>(1));
@@ -176,7 +176,7 @@ TEST_CASE("Unit_Device_exp10_Accuracy_Positive") {
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_Device_exp10_exp10f_Negative_RTC") { NegativeTestRTCWrapper<4>(kExp10); }
+TEST_CASE(Unit_Device_exp10_exp10f_Negative_RTC) { NegativeTestRTCWrapper<4>(kExp10); }
 
 template <typename T>
 __global__ void frexp_kernel(std::pair<T, int>* const ys, const size_t num_xs, T* const xs) {
@@ -212,7 +212,7 @@ template <typename T> std::pair<T, int> frexp_ref(T arg) {
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_Device_frexpf_Accuracy_Positive") {
+TEST_CASE(Unit_Device_frexpf_Accuracy_Positive) {
   UnarySinglePrecisionTest(
       frexp_kernel<float>, frexp_ref<double>,
       PairValidatorBuilderFactory<float, int>(ULPValidatorBuilderFactory<float>(0),
@@ -234,7 +234,7 @@ TEST_CASE("Unit_Device_frexpf_Accuracy_Positive") {
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_Device_frexp_Accuracy_Positive") {
+TEST_CASE(Unit_Device_frexp_Accuracy_Positive) {
   UnaryDoublePrecisionTest(
       frexp_kernel<double>, frexp_ref<long double>,
       PairValidatorBuilderFactory<double, int>(ULPValidatorBuilderFactory<double>(0),
@@ -253,7 +253,7 @@ TEST_CASE("Unit_Device_frexp_Accuracy_Positive") {
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_Device_frexp_frexpf_Negative_RTC") { NegativeTestRTCWrapper<20>(kFrexp); }
+TEST_CASE(Unit_Device_frexp_frexpf_Negative_RTC) { NegativeTestRTCWrapper<20>(kFrexp); }
 
 
 /********** Binary Functions **********/
@@ -275,7 +275,7 @@ MATH_BINARY_KERNEL_DEF(pow)
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEMPLATE_TEST_CASE("Unit_Device_pow_Accuracy_Positive", "", float, double) {
+TEMPLATE_TEST_CASE(Unit_Device_pow_Accuracy_Positive, float, double) {
   using RT = RefType_t<TestType>;
   auto pow_ref = [](RT arg1, RT arg2) -> RT {
     if (std::isinf(arg1) && arg2 < 0) return 0;
@@ -298,7 +298,7 @@ TEMPLATE_TEST_CASE("Unit_Device_pow_Accuracy_Positive", "", float, double) {
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_Device_pow_powf_Negative_RTC") { NegativeTestRTCWrapper<8>(kPow); }
+TEST_CASE(Unit_Device_pow_powf_Negative_RTC) { NegativeTestRTCWrapper<8>(kPow); }
 
 MATH_POW_INT_KERNEL_DEF(ldexp)
 
@@ -316,7 +316,7 @@ MATH_POW_INT_KERNEL_DEF(ldexp)
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEMPLATE_TEST_CASE("Unit_Device_ldexp_Accuracy_Positive", "", float, double) {
+TEMPLATE_TEST_CASE(Unit_Device_ldexp_Accuracy_Positive, float, double) {
   using RT = RefType_t<TestType>;
   RT (*ref)(RT, int) = std::ldexp;
   PowIntFloatingPointTest(ldexp_kernel<TestType, int>, ref,
@@ -335,7 +335,7 @@ TEMPLATE_TEST_CASE("Unit_Device_ldexp_Accuracy_Positive", "", float, double) {
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_Device_ldexp_ldexpf_Negative_RTC") { NegativeTestRTCWrapper<8>(kLdexp); }
+TEST_CASE(Unit_Device_ldexp_ldexpf_Negative_RTC) { NegativeTestRTCWrapper<8>(kLdexp); }
 
 MATH_POW_INT_KERNEL_DEF(powi)
 
@@ -354,7 +354,7 @@ MATH_POW_INT_KERNEL_DEF(powi)
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEMPLATE_TEST_CASE("Unit_Device_powi_Accuracy_Positive", "", float, double) {
+TEMPLATE_TEST_CASE(Unit_Device_powi_Accuracy_Positive, float, double) {
   using RT = RefType_t<TestType>;
   auto pow_ref = [](RT arg1, int arg2) -> RT {
     if (std::isinf(arg1) && arg2 < 0) return 0;
@@ -378,7 +378,7 @@ TEMPLATE_TEST_CASE("Unit_Device_powi_Accuracy_Positive", "", float, double) {
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_Device_powi_powif_Negative_RTC") { NegativeTestRTCWrapper<8>(kPowi); }
+TEST_CASE(Unit_Device_powi_powif_Negative_RTC) { NegativeTestRTCWrapper<8>(kPowi); }
 
 MATH_POW_INT_KERNEL_DEF(scalbn)
 
@@ -396,7 +396,7 @@ MATH_POW_INT_KERNEL_DEF(scalbn)
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEMPLATE_TEST_CASE("Unit_Device_scalbn_Accuracy_Positive", "", float, double) {
+TEMPLATE_TEST_CASE(Unit_Device_scalbn_Accuracy_Positive, float, double) {
   using RT = RefType_t<TestType>;
   RT (*ref)(RT, int) = std::scalbn;
   PowIntFloatingPointTest(scalbn_kernel<TestType, int>, ref,
@@ -415,7 +415,7 @@ TEMPLATE_TEST_CASE("Unit_Device_scalbn_Accuracy_Positive", "", float, double) {
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_Device_scalbn_scalbnf_Negative_RTC") { NegativeTestRTCWrapper<8>(kScalbn); }
+TEST_CASE(Unit_Device_scalbn_scalbnf_Negative_RTC) { NegativeTestRTCWrapper<8>(kScalbn); }
 
 MATH_POW_INT_KERNEL_DEF(scalbln)
 
@@ -433,7 +433,7 @@ MATH_POW_INT_KERNEL_DEF(scalbln)
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEMPLATE_TEST_CASE("Unit_Device_scalbln_Accuracy_Positive", "", float, double) {
+TEMPLATE_TEST_CASE(Unit_Device_scalbln_Accuracy_Positive, float, double) {
   using RT = RefType_t<TestType>;
   RT (*ref)(RT, long int) = std::scalbln;
   PowIntFloatingPointTest(scalbln_kernel<TestType, long int>, ref,
@@ -452,7 +452,7 @@ TEMPLATE_TEST_CASE("Unit_Device_scalbln_Accuracy_Positive", "", float, double) {
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_Device_scalbln_scalblnf_Negative_RTC") { NegativeTestRTCWrapper<8>(kScalbln); }
+TEST_CASE(Unit_Device_scalbln_scalblnf_Negative_RTC) { NegativeTestRTCWrapper<8>(kScalbln); }
 
 /**
  * End doxygen group MathTest.

--- a/projects/hip-tests/catch/unit/math/quaternary_common.hh
+++ b/projects/hip-tests/catch/unit/math/quaternary_common.hh
@@ -236,7 +236,7 @@ void QuaternaryFloatingPointTest(kernel_sig<T, TArg, TArg, TArg, TArg> kernel,
 #define MATH_QUATERNARY_WITHIN_ULP_TEST_DEF(kern_name, ref_func, sp_ulp, dp_ulp)                   \
   MATH_QUATERNARY_KERNEL_DEF(kern_name)                                                            \
                                                                                                    \
-  TEMPLATE_TEST_CASE("Unit_Device_" #kern_name "_Accuracy_Positive", "", float, double) {          \
+  TEMPLATE_TEST_CASE(Unit_Device_##kern_name##_Accuracy_Positive, "", float, double) {          \
     using RT = RefType_t<TestType>;                                                                \
     RT (*ref)(RT, RT, RT, RT) = ref_func;                                                          \
     const auto ulp = std::is_same_v<float, TestType> ? sp_ulp : dp_ulp;                            \

--- a/projects/hip-tests/catch/unit/math/remainder_and_rounding_funcs.cc
+++ b/projects/hip-tests/catch/unit/math/remainder_and_rounding_funcs.cc
@@ -24,39 +24,39 @@ THE SOFTWARE.
 #include "math_remainder_rounding_negative_kernels_rtc.hh"
 
 MATH_BINARY_WITHIN_ULP_TEST_DEF(fmod, std::fmod, 0, 0)
-TEST_CASE("Unit_Device_fmod_fmodf_Negative_RTC") { NegativeTestRTCWrapper<8>(kFmod); }
+TEST_CASE(Unit_Device_fmod_fmodf_Negative_RTC) { NegativeTestRTCWrapper<8>(kFmod); }
 
 MATH_BINARY_WITHIN_ULP_TEST_DEF(remainder, std::remainder, 0, 0)
-TEST_CASE("Unit_Device_remainder_remainder_Negative_RTC") { NegativeTestRTCWrapper<8>(kRemainder); }
+TEST_CASE(Unit_Device_remainder_remainder_Negative_RTC) { NegativeTestRTCWrapper<8>(kRemainder); }
 
 MATH_BINARY_WITHIN_ULP_TEST_DEF(fdim, std::fdim, 0, 0)
-TEST_CASE("Unit_Device_fdim_fdimf_Negative_RTC") { NegativeTestRTCWrapper<8>(kFdim); }
+TEST_CASE(Unit_Device_fdim_fdimf_Negative_RTC) { NegativeTestRTCWrapper<8>(kFdim); }
 
 MATH_UNARY_WITHIN_ULP_TEST_DEF(trunc, std::trunc, 0, 0)
-TEST_CASE("Unit_Device_trunc_truncf_Negative_RTC") { NegativeTestRTCWrapper<4>(kTrunc); }
+TEST_CASE(Unit_Device_trunc_truncf_Negative_RTC) { NegativeTestRTCWrapper<4>(kTrunc); }
 
 MATH_UNARY_WITHIN_ULP_TEST_DEF(round, std::round, 0, 0)
-TEST_CASE("Unit_Device_round_roundf_Negative_RTC") { NegativeTestRTCWrapper<4>(kRound); }
+TEST_CASE(Unit_Device_round_roundf_Negative_RTC) { NegativeTestRTCWrapper<4>(kRound); }
 
 MATH_UNARY_WITHIN_ULP_TEST_DEF(rint, std::rint, 0, 0)
-TEST_CASE("Unit_Device_rint_rintf_Negative_RTC") { NegativeTestRTCWrapper<4>(kRint); }
+TEST_CASE(Unit_Device_rint_rintf_Negative_RTC) { NegativeTestRTCWrapper<4>(kRint); }
 
 MATH_UNARY_WITHIN_ULP_TEST_DEF(nearbyint, std::nearbyint, 0, 0)
-TEST_CASE("Unit_Device_nearbyint_nearbyintf_Negative_RTC") {
+TEST_CASE(Unit_Device_nearbyint_nearbyintf_Negative_RTC) {
   NegativeTestRTCWrapper<4>(kNearbyint);
 }
 
 MATH_UNARY_WITHIN_ULP_TEST_DEF(ceil, std::ceil, 0, 0)
-TEST_CASE("Unit_Device_ceil_ceilf_Negative_RTC") { NegativeTestRTCWrapper<4>(kCeil); }
+TEST_CASE(Unit_Device_ceil_ceilf_Negative_RTC) { NegativeTestRTCWrapper<4>(kCeil); }
 
 MATH_UNARY_WITHIN_ULP_TEST_DEF(floor, std::floor, 0, 0)
-TEST_CASE("Unit_Device_floor_floorf_Negative_RTC") { NegativeTestRTCWrapper<4>(kFloor); }
+TEST_CASE(Unit_Device_floor_floorf_Negative_RTC) { NegativeTestRTCWrapper<4>(kFloor); }
 
 
 #define LONG_CONVERSION_FUNCTION_TEST_DEF(kern_name, ref_func, lt)                                 \
   MATH_UNARY_KERNEL_DEF(kern_name)                                                                 \
                                                                                                    \
-  TEST_CASE("Unit_Device_" #kern_name "_Accuracy_Positive - float") {                              \
+  TEST_CASE(Unit_Device_##kern_name##_Accuracy_Positive_float) {                                   \
     lt (*ref)(double) = ref_func;                                                                  \
     UnarySinglePrecisionRangeTest(kern_name##_kernel<float, lt>, ref,                              \
                                   EqValidatorBuilderFactory<lt>(),                                 \
@@ -64,7 +64,7 @@ TEST_CASE("Unit_Device_floor_floorf_Negative_RTC") { NegativeTestRTCWrapper<4>(k
                                   static_cast<float>(std::numeric_limits<lt>::max()));             \
   }                                                                                                \
                                                                                                    \
-  TEST_CASE("Unit_Device_" #kern_name "_Accuracy_Positive - double") {                             \
+  TEST_CASE(Unit_Device_##kern_name##_Accuracy_Positive_double) {                                  \
     lt (*ref)(long double) = ref_func;                                                             \
     UnaryDoublePrecisionBruteForceTest(kern_name##_kernel<double, lt>, ref,                        \
                                        EqValidatorBuilderFactory<lt>(),                            \
@@ -73,16 +73,16 @@ TEST_CASE("Unit_Device_floor_floorf_Negative_RTC") { NegativeTestRTCWrapper<4>(k
   }
 
 LONG_CONVERSION_FUNCTION_TEST_DEF(lrint, std::lrint, long)
-TEST_CASE("Unit_Device_lrint_lrintf_Negative_RTC") { NegativeTestRTCWrapper<4>(kLrint); }
+TEST_CASE(Unit_Device_lrint_lrintf_Negative_RTC) { NegativeTestRTCWrapper<4>(kLrint); }
 
 LONG_CONVERSION_FUNCTION_TEST_DEF(lround, std::lround, long)
-TEST_CASE("Unit_Device_lround_lroundf_Negative_RTC") { NegativeTestRTCWrapper<4>(kLround); }
+TEST_CASE(Unit_Device_lround_lroundf_Negative_RTC) { NegativeTestRTCWrapper<4>(kLround); }
 
 LONG_CONVERSION_FUNCTION_TEST_DEF(llrint, std::llrint, long long)
-TEST_CASE("Unit_Device_llrint_llrintf_Negative_RTC") { NegativeTestRTCWrapper<4>(kLlrint); }
+TEST_CASE(Unit_Device_llrint_llrintf_Negative_RTC) { NegativeTestRTCWrapper<4>(kLlrint); }
 
 LONG_CONVERSION_FUNCTION_TEST_DEF(llround, std::llround, long long)
-TEST_CASE("Unit_Device_llround_llroundf_Negative_RTC") { NegativeTestRTCWrapper<4>(kLlround); }
+TEST_CASE(Unit_Device_llround_llroundf_Negative_RTC) { NegativeTestRTCWrapper<4>(kLlround); }
 
 
 template <typename T> __global__ void remquo_kernel(std::pair<T, int>* const ys,
@@ -106,7 +106,7 @@ template <typename T> std::pair<T, int> remquo_wrapper(T x1, T x2) {
   return ret;
 }
 
-TEMPLATE_TEST_CASE("Unit_Device_remquo_Accuracy_Positive", "", float, double) {
+TEMPLATE_TEST_CASE(Unit_Device_remquo_Accuracy_Positive, float, double) {
   using RT = RefType_t<TestType>;
   std::pair<RT, int> (*ref)(RT, RT) = remquo_wrapper;
   const auto ulp_builder = ULPValidatorBuilderFactory<TestType>(0);
@@ -116,7 +116,7 @@ TEMPLATE_TEST_CASE("Unit_Device_remquo_Accuracy_Positive", "", float, double) {
                           PairValidatorBuilderFactory<TestType, int>(ulp_builder, eq_builder));
 }
 
-TEST_CASE("Unit_Device_remquo_remquof_Negative_RTC") { NegativeTestRTCWrapper<24>(kRemquo); }
+TEST_CASE(Unit_Device_remquo_remquof_Negative_RTC) { NegativeTestRTCWrapper<24>(kRemquo); }
 
 template <typename T>
 __global__ void modf_kernel(std::pair<T, T>* const ys, const size_t num_xs, T* const xs) {
@@ -138,16 +138,16 @@ template <typename T> std::pair<T, T> modf_wrapper(T x) {
   return ret;
 }
 
-TEST_CASE("Unit_Device_modf_Accuracy_Positive_float") {
+TEST_CASE(Unit_Device_modf_Accuracy_Positive_float) {
   UnarySinglePrecisionTest(
       modf_kernel<float>, modf_wrapper<double>,
       PairValidatorBuilderFactory<float>(ULPValidatorBuilderFactory<float>(0)));
 }
 
-TEST_CASE("Unit_Device_modf_Accuracy_Positive_double") {
+TEST_CASE(Unit_Device_modf_Accuracy_Positive_double) {
   UnaryDoublePrecisionTest(
       modf_kernel<double>, modf_wrapper<long double>,
       PairValidatorBuilderFactory<double>(ULPValidatorBuilderFactory<double>(0)));
 }
 
-TEST_CASE("Unit_Device_modf_modff_Negative_RTC") { NegativeTestRTCWrapper<19>(kModf); }
+TEST_CASE(Unit_Device_modf_modff_Negative_RTC) { NegativeTestRTCWrapper<19>(kModf); }

--- a/projects/hip-tests/catch/unit/math/root_funcs.cc
+++ b/projects/hip-tests/catch/unit/math/root_funcs.cc
@@ -48,7 +48,7 @@ MATH_UNARY_KERNEL_DEF(sqrt)
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_Device_sqrtf_Accuracy_Positive") {
+TEST_CASE(Unit_Device_sqrtf_Accuracy_Positive) {
   float (*ref)(float) = std::sqrt;
   UnarySinglePrecisionTest(sqrt_kernel<float>, ref, ULPValidatorBuilderFactory<float>(1));
 }
@@ -68,7 +68,7 @@ TEST_CASE("Unit_Device_sqrtf_Accuracy_Positive") {
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_Device_sqrt_Accuracy_Positive") {
+TEST_CASE(Unit_Device_sqrt_Accuracy_Positive) {
   double (*ref)(double) = std::sqrt;
   UnaryDoublePrecisionTest<double>(sqrt_kernel<double>, ref, ULPValidatorBuilderFactory<double>(0));
 }
@@ -85,7 +85,7 @@ TEST_CASE("Unit_Device_sqrt_Accuracy_Positive") {
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_Device_sqrt_sqrtf_Negative_RTC") { NegativeTestRTCWrapper<4>(kSqrt); }
+TEST_CASE(Unit_Device_sqrt_sqrtf_Negative_RTC) { NegativeTestRTCWrapper<4>(kSqrt); }
 
 MATH_UNARY_KERNEL_DEF(rsqrt)
 
@@ -102,7 +102,7 @@ MATH_UNARY_KERNEL_DEF(rsqrt)
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_Device_rsqrtf_Accuracy_Positive") {
+TEST_CASE(Unit_Device_rsqrtf_Accuracy_Positive) {
   auto rsqrt_ref = [](double arg) -> double { return 1. / std::sqrt(arg); };
   double (*ref)(double) = rsqrt_ref;
   UnarySinglePrecisionTest(rsqrt_kernel<float>, ref, ULPValidatorBuilderFactory<float>(2));
@@ -121,7 +121,7 @@ TEST_CASE("Unit_Device_rsqrtf_Accuracy_Positive") {
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_Device_rsqrt_Accuracy_Positive") {
+TEST_CASE(Unit_Device_rsqrt_Accuracy_Positive) {
   auto rsqrt_ref = [](long double arg) -> long double { return 1.L / std::sqrt(arg); };
   long double (*ref)(long double) = rsqrt_ref;
   UnaryDoublePrecisionTest(rsqrt_kernel<double>, ref, ULPValidatorBuilderFactory<double>(1));
@@ -139,7 +139,7 @@ TEST_CASE("Unit_Device_rsqrt_Accuracy_Positive") {
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_Device_rsqrt_rsqrtf_Negative_RTC") { NegativeTestRTCWrapper<4>(kRsqrt); }
+TEST_CASE(Unit_Device_rsqrt_rsqrtf_Negative_RTC) { NegativeTestRTCWrapper<4>(kRsqrt); }
 
 /**
  * Test Description
@@ -169,7 +169,7 @@ MATH_UNARY_WITHIN_ULP_TEST_DEF(cbrt, std::cbrt, 1, 1)
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_Device_cbrt_cbrtf_Negative_RTC") { NegativeTestRTCWrapper<4>(kCbrt); }
+TEST_CASE(Unit_Device_cbrt_cbrtf_Negative_RTC) { NegativeTestRTCWrapper<4>(kCbrt); }
 
 MATH_UNARY_KERNEL_DEF(rcbrt)
 
@@ -186,7 +186,7 @@ MATH_UNARY_KERNEL_DEF(rcbrt)
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_Device_rcbrtf_Accuracy_Positive") {
+TEST_CASE(Unit_Device_rcbrtf_Accuracy_Positive) {
   auto rcbrt_ref = [](double arg) -> double { return 1. / std::cbrt(arg); };
   double (*ref)(double) = rcbrt_ref;
   UnarySinglePrecisionTest(rcbrt_kernel<float>, ref, ULPValidatorBuilderFactory<float>(1));
@@ -205,7 +205,7 @@ TEST_CASE("Unit_Device_rcbrtf_Accuracy_Positive") {
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_Device_rcbrt_Accuracy_Positive") {
+TEST_CASE(Unit_Device_rcbrt_Accuracy_Positive) {
   auto rcbrt_ref = [](long double arg) -> long double { return 1. / std::cbrt(arg); };
   long double (*ref)(long double) = rcbrt_ref;
   UnaryDoublePrecisionTest(rcbrt_kernel<double>, ref, ULPValidatorBuilderFactory<double>(1));
@@ -223,7 +223,7 @@ TEST_CASE("Unit_Device_rcbrt_Accuracy_Positive") {
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_Device_rcbrt_rcbrtf_Negative_RTC") { NegativeTestRTCWrapper<4>(kRcbrt); }
+TEST_CASE(Unit_Device_rcbrt_rcbrtf_Negative_RTC) { NegativeTestRTCWrapper<4>(kRcbrt); }
 
 /********** Binary Functions **********/
 
@@ -256,7 +256,7 @@ MATH_BINARY_WITHIN_ULP_TEST_DEF(hypot, std::hypot, 3, 2)
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_Device_hypot_hypotf_Negative_RTC") { NegativeTestRTCWrapper<8>(kHypot); }
+TEST_CASE(Unit_Device_hypot_hypotf_Negative_RTC) { NegativeTestRTCWrapper<8>(kHypot); }
 
 MATH_BINARY_KERNEL_DEF(rhypot)
 
@@ -274,7 +274,7 @@ MATH_BINARY_KERNEL_DEF(rhypot)
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEMPLATE_TEST_CASE("Unit_Device_rhypot_Accuracy_Positive", "", float, double) {
+TEMPLATE_TEST_CASE(Unit_Device_rhypot_Accuracy_Positive, float, double) {
   using RT = RefType_t<TestType>;
   auto rhypot_ref = [](RT arg1, RT arg2) -> RT { return 1. / std::hypot(arg1, arg2); };
   RT (*ref)(RT, RT) = rhypot_ref;
@@ -294,7 +294,7 @@ TEMPLATE_TEST_CASE("Unit_Device_rhypot_Accuracy_Positive", "", float, double) {
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_Device_rhypot_rhypotf_Negative_RTC") { NegativeTestRTCWrapper<8>(kRhypot); }
+TEST_CASE(Unit_Device_rhypot_rhypotf_Negative_RTC) { NegativeTestRTCWrapper<8>(kRhypot); }
 
 /********** Ternary Functions **********/
 
@@ -314,7 +314,7 @@ MATH_TERNARY_KERNEL_DEF(norm3d)
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEMPLATE_TEST_CASE("Unit_Device_norm3d_Accuracy_Positive", "", float, double) {
+TEMPLATE_TEST_CASE(Unit_Device_norm3d_Accuracy_Positive, float, double) {
   using RT = RefType_t<TestType>;
   auto norm3d_ref = [](RT arg1, RT arg2, RT arg3) -> RT {
     if (std::isinf(arg1) || std::isinf(arg2) || std::isinf(arg3)) {
@@ -339,7 +339,7 @@ TEMPLATE_TEST_CASE("Unit_Device_norm3d_Accuracy_Positive", "", float, double) {
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_Device_norm3d_norm3df_Negative_RTC") { NegativeTestRTCWrapper<12>(kNorm3D); }
+TEST_CASE(Unit_Device_norm3d_norm3df_Negative_RTC) { NegativeTestRTCWrapper<12>(kNorm3D); }
 
 MATH_TERNARY_KERNEL_DEF(rnorm3d)
 
@@ -357,7 +357,7 @@ MATH_TERNARY_KERNEL_DEF(rnorm3d)
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEMPLATE_TEST_CASE("Unit_Device_rnorm3d_Accuracy_Positive", "", float, double) {
+TEMPLATE_TEST_CASE(Unit_Device_rnorm3d_Accuracy_Positive, float, double) {
   using RT = RefType_t<TestType>;
   auto rnorm3d_ref = [](RT arg1, RT arg2, RT arg3) -> RT {
     if (std::isinf(arg1) || std::isinf(arg2) || std::isinf(arg3)) {
@@ -383,7 +383,7 @@ TEMPLATE_TEST_CASE("Unit_Device_rnorm3d_Accuracy_Positive", "", float, double) {
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_Device_rnorm3d_rnorm3df_Negative_RTC") { NegativeTestRTCWrapper<12>(kRnorm3D); }
+TEST_CASE(Unit_Device_rnorm3d_rnorm3df_Negative_RTC) { NegativeTestRTCWrapper<12>(kRnorm3D); }
 
 /********** Quaternary Functions **********/
 
@@ -403,7 +403,7 @@ MATH_QUATERNARY_KERNEL_DEF(norm4d)
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEMPLATE_TEST_CASE("Unit_Device_norm4d_Accuracy_Positive", "", float, double) {
+TEMPLATE_TEST_CASE(Unit_Device_norm4d_Accuracy_Positive, float, double) {
   using RT = RefType_t<TestType>;
   auto norm4d_ref = [](RT arg1, RT arg2, RT arg3, RT arg4) -> RT {
     if (std::isinf(arg1) || std::isinf(arg2) || std::isinf(arg3) || std::isinf(arg4)) {
@@ -429,7 +429,7 @@ TEMPLATE_TEST_CASE("Unit_Device_norm4d_Accuracy_Positive", "", float, double) {
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_Device_norm4d_norm4df_Negative_RTC") { NegativeTestRTCWrapper<16>(kNorm4D); }
+TEST_CASE(Unit_Device_norm4d_norm4df_Negative_RTC) { NegativeTestRTCWrapper<16>(kNorm4D); }
 
 MATH_QUATERNARY_KERNEL_DEF(rnorm4d)
 
@@ -447,7 +447,7 @@ MATH_QUATERNARY_KERNEL_DEF(rnorm4d)
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEMPLATE_TEST_CASE("Unit_Device_rnorm4d_Accuracy_Positive", "", float, double) {
+TEMPLATE_TEST_CASE(Unit_Device_rnorm4d_Accuracy_Positive, float, double) {
   using RT = RefType_t<TestType>;
   auto rnorm4d_ref = [](RT arg1, RT arg2, RT arg3, RT arg4) -> RT {
     if (std::isinf(arg1) || std::isinf(arg2) || std::isinf(arg3) || std::isinf(arg4)) {
@@ -473,7 +473,7 @@ TEMPLATE_TEST_CASE("Unit_Device_rnorm4d_Accuracy_Positive", "", float, double) {
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_Device_rnorm4d_rnorm4df_Negative_RTC") { NegativeTestRTCWrapper<16>(kRnorm4D); }
+TEST_CASE(Unit_Device_rnorm4d_rnorm4df_Negative_RTC) { NegativeTestRTCWrapper<16>(kRnorm4D); }
 
 /********** norm Function **********/
 
@@ -531,7 +531,7 @@ MATH_NORM_KERNEL_DEF(norm)
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEMPLATE_TEST_CASE("Unit_Device_norm_Sanity_Positive", "", float, double) {
+TEMPLATE_TEST_CASE(Unit_Device_norm_Sanity_Positive, float, double) {
   using RT = RefType_t<TestType>;
   auto norm_ref = [](int dim, TestType* args) -> RT {
     RT sum = 0;
@@ -558,7 +558,7 @@ TEMPLATE_TEST_CASE("Unit_Device_norm_Sanity_Positive", "", float, double) {
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_Device_norm_normf_Negative_RTC") { NegativeTestRTCWrapper<18>(kNorm); }
+TEST_CASE(Unit_Device_norm_normf_Negative_RTC) { NegativeTestRTCWrapper<18>(kNorm); }
 
 MATH_NORM_KERNEL_DEF(rnorm)
 
@@ -574,7 +574,7 @@ MATH_NORM_KERNEL_DEF(rnorm)
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEMPLATE_TEST_CASE("Unit_Device_rnorm_Sanity_Positive", "", float, double) {
+TEMPLATE_TEST_CASE(Unit_Device_rnorm_Sanity_Positive, float, double) {
   using RT = RefType_t<TestType>;
   auto rnorm_ref = [](int dim, TestType* args) -> RT {
     RT sum = 0;
@@ -601,7 +601,7 @@ TEMPLATE_TEST_CASE("Unit_Device_rnorm_Sanity_Positive", "", float, double) {
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_Device_rnorm_rnormf_Negative_RTC") { NegativeTestRTCWrapper<18>(kRnorm); }
+TEST_CASE(Unit_Device_rnorm_rnormf_Negative_RTC) { NegativeTestRTCWrapper<18>(kRnorm); }
 
 /**
  * End doxygen group MathTest.

--- a/projects/hip-tests/catch/unit/math/single_precision_intrinsics.cc
+++ b/projects/hip-tests/catch/unit/math/single_precision_intrinsics.cc
@@ -39,7 +39,7 @@ THE SOFTWARE.
   }
 
 #define MATH_UNARY_SP_TEST_DEF_IMPL(func_name, ref_func, validator_builder)                        \
-  TEST_CASE("Unit_Device_" #func_name "_Accuracy_Positive") {                                      \
+  TEST_CASE(Unit_Device_##func_name##_Accuracy_Positive) {                                      \
     UnarySinglePrecisionTest(func_name##_kernel, ref_func, validator_builder);                     \
   }
 
@@ -365,7 +365,7 @@ MATH_UNARY_SP_TEST_DEF_IMPL(__sincosf_cos, static_cast<double (*)(double)>(std::
   }
 
 #define MATH_BINARY_SP_TEST_DEF_IMPL(func_name, ref_func, validator_builder)                       \
-  TEST_CASE("Unit_Device_" #func_name "_Accuracy_Positive") {                                      \
+  TEST_CASE(Unit_Device_##func_name##_Accuracy_Positive) {                                      \
     BinaryFloatingPointTest(func_name##_kernel, ref_func, validator_builder);                      \
   }
 
@@ -499,7 +499,7 @@ MATH_BINARY_SP_TEST_DEF(__fdividef, __fdiv_rn_ref);
   }
 
 #define MATH_TERNARY_SP_TEST_DEF_IMPL(func_name, ref_func, validator_builder)                      \
-  TEST_CASE("Unit_Device_" #func_name "_Accuracy_Positive") {                                      \
+  TEST_CASE(Unit_Device_##func_name##_Accuracy_Positive) {                                      \
     TernaryFloatingPointTest(func_name##_kernel, ref_func, validator_builder);                     \
   }
 

--- a/projects/hip-tests/catch/unit/math/special_funcs.cc
+++ b/projects/hip-tests/catch/unit/math/special_funcs.cc
@@ -62,7 +62,7 @@ MATH_UNARY_WITHIN_ULP_STL_REF_TEST_DEF(erf, 2, 2)
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_Device_erf_erff_Negative_RTC") { NegativeTestRTCWrapper<4>(kErf); }
+TEST_CASE(Unit_Device_erf_erff_Negative_RTC) { NegativeTestRTCWrapper<4>(kErf); }
 
 /**
  * Test Description
@@ -93,7 +93,7 @@ MATH_UNARY_WITHIN_ULP_STL_REF_TEST_DEF(erfc, 4, 5)
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_Device_erfc_erfcf_Negative_RTC") { NegativeTestRTCWrapper<4>(kErfc); }
+TEST_CASE(Unit_Device_erfc_erfcf_Negative_RTC) { NegativeTestRTCWrapper<4>(kErfc); }
 
 MATH_UNARY_KERNEL_DEF(erfinv)
 
@@ -111,7 +111,7 @@ MATH_UNARY_KERNEL_DEF(erfinv)
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_Device_erfinvf_Accuracy_Positive") {
+TEST_CASE(Unit_Device_erfinvf_Accuracy_Positive) {
   auto erfinv_ref = [](double arg) -> double {
     if (arg == 0) return 0;
     if (arg == 1)
@@ -141,7 +141,7 @@ TEST_CASE("Unit_Device_erfinvf_Accuracy_Positive") {
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_Device_erfinv_Accuracy_Positive") {
+TEST_CASE(Unit_Device_erfinv_Accuracy_Positive) {
   auto erfinv_ref = [](long double arg) -> long double {
     if (arg == 0) return 0;
     if (arg == 1)
@@ -168,7 +168,7 @@ TEST_CASE("Unit_Device_erfinv_Accuracy_Positive") {
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_Device_erfinv_erfinvf_Negative_RTC") { NegativeTestRTCWrapper<4>(kErfinv); }
+TEST_CASE(Unit_Device_erfinv_erfinvf_Negative_RTC) { NegativeTestRTCWrapper<4>(kErfinv); }
 
 MATH_UNARY_KERNEL_DEF(erfcinv)
 
@@ -186,7 +186,7 @@ MATH_UNARY_KERNEL_DEF(erfcinv)
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_Device_erfcinvf_Accuracy_Positive") {
+TEST_CASE(Unit_Device_erfcinvf_Accuracy_Positive) {
   auto erfcinv_ref = [](double arg) -> double {
     if (arg == 0)
       return std::numeric_limits<double>::infinity();
@@ -215,7 +215,7 @@ TEST_CASE("Unit_Device_erfcinvf_Accuracy_Positive") {
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_Device_erfcinv_Accuracy_Positive") {
+TEST_CASE(Unit_Device_erfcinv_Accuracy_Positive) {
   auto erfcinv_ref = [](long double arg) -> long double {
     if (arg == 0)
       return std::numeric_limits<long double>::infinity();
@@ -241,7 +241,7 @@ TEST_CASE("Unit_Device_erfcinv_Accuracy_Positive") {
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_Device_erfcinv_erfcinvf_Negative_RTC") { NegativeTestRTCWrapper<4>(kErfcinv); }
+TEST_CASE(Unit_Device_erfcinv_erfcinvf_Negative_RTC) { NegativeTestRTCWrapper<4>(kErfcinv); }
 
 MATH_UNARY_KERNEL_DEF(erfcx)
 
@@ -257,7 +257,7 @@ MATH_UNARY_KERNEL_DEF(erfcx)
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_Device_erfcxf_Sanity_Positive") {
+TEST_CASE(Unit_Device_erfcxf_Sanity_Positive) {
   constexpr std::array<float, 11> input{-std::numeric_limits<float>::infinity(),
                                         -1000.f,
                                         -100.f,
@@ -296,7 +296,7 @@ TEST_CASE("Unit_Device_erfcxf_Sanity_Positive") {
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_Device_erfcx_Sanity_Positive") {
+TEST_CASE(Unit_Device_erfcx_Sanity_Positive) {
   constexpr std::array<double, 11> input{
       -std::numeric_limits<double>::infinity(), -1000., -100., -5., -0.5, 0., 0.75, 15., 200., 500.,
       std::numeric_limits<double>::infinity()};
@@ -327,7 +327,7 @@ TEST_CASE("Unit_Device_erfcx_Sanity_Positive") {
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_Device_erfcx_erfcxf_Negative_RTC") { NegativeTestRTCWrapper<4>(kErfcx); }
+TEST_CASE(Unit_Device_erfcx_erfcxf_Negative_RTC) { NegativeTestRTCWrapper<4>(kErfcx); }
 
 MATH_UNARY_KERNEL_DEF(normcdf)
 
@@ -344,7 +344,7 @@ MATH_UNARY_KERNEL_DEF(normcdf)
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_Device_normcdff_Accuracy_Positive") {
+TEST_CASE(Unit_Device_normcdff_Accuracy_Positive) {
   auto normcdf_ref = [](double arg) -> double { return std::erfc(-arg / std::sqrt(2)) / 2; };
   double (*ref)(double) = normcdf_ref;
   UnarySinglePrecisionTest(normcdf_kernel<float>, ref, ULPValidatorBuilderFactory<float>(5));
@@ -363,7 +363,7 @@ TEST_CASE("Unit_Device_normcdff_Accuracy_Positive") {
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_Device_normcdf_Accuracy_Positive") {
+TEST_CASE(Unit_Device_normcdf_Accuracy_Positive) {
   auto normcdf_ref = [](long double arg) -> long double {
     return std::erfc(-arg / std::sqrt(2.L)) / 2;
   };
@@ -383,7 +383,7 @@ TEST_CASE("Unit_Device_normcdf_Accuracy_Positive") {
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_Device_normcdf_normcdff_Negative_RTC") { NegativeTestRTCWrapper<4>(kNormcdf); }
+TEST_CASE(Unit_Device_normcdf_normcdff_Negative_RTC) { NegativeTestRTCWrapper<4>(kNormcdf); }
 
 MATH_UNARY_KERNEL_DEF(normcdfinv)
 
@@ -399,7 +399,7 @@ MATH_UNARY_KERNEL_DEF(normcdfinv)
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_Device_normcdfinvf_Sanity_Positive") {
+TEST_CASE(Unit_Device_normcdfinvf_Sanity_Positive) {
   constexpr std::array<float, 9> input{0.f, 0.1f, 0.25f, 0.4f, 0.5f, 0.6f, 0.75f, 0.9f, 1.f};
   constexpr std::array<float, 9> reference{-std::numeric_limits<float>::infinity(),
                                            -1.28155160f,
@@ -426,7 +426,7 @@ TEST_CASE("Unit_Device_normcdfinvf_Sanity_Positive") {
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_Device_normcdfinv_Sanity_Positive") {
+TEST_CASE(Unit_Device_normcdfinv_Sanity_Positive) {
   constexpr std::array<double, 9> input{0., 0.1, 0.25, 0.4, 0.5, 0.6, 0.75, 0.9, 1.};
   constexpr std::array<double, 9> reference{-std::numeric_limits<float>::infinity(),
                                             -1.2815515655446004,
@@ -453,7 +453,7 @@ TEST_CASE("Unit_Device_normcdfinv_Sanity_Positive") {
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_Device_normcdfinv_normcdfinvf_Negative_RTC") {
+TEST_CASE(Unit_Device_normcdfinv_normcdfinvf_Negative_RTC) {
   NegativeTestRTCWrapper<4>(kNormcdfinv);
 }
 
@@ -474,7 +474,7 @@ MATH_UNARY_KERNEL_DEF(tgamma)
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_Device_tgammaf_Accuracy_Limited_Positive") {
+TEST_CASE(Unit_Device_tgammaf_Accuracy_Limited_Positive) {
   double (*ref)(double) = std::tgamma;
   UnarySinglePrecisionRangeTest(tgamma_kernel<float>, ref, ULPValidatorBuilderFactory<float>(5),
                                 std::numeric_limits<float>::lowest(), -0.001f);
@@ -497,7 +497,7 @@ TEST_CASE("Unit_Device_tgammaf_Accuracy_Limited_Positive") {
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_Device_tgamma_Accuracy_Limited_Positive") {
+TEST_CASE(Unit_Device_tgamma_Accuracy_Limited_Positive) {
   long double (*ref)(long double) = std::tgamma;
   UnaryDoublePrecisionTest(tgamma_kernel<double>, ref, ULPValidatorBuilderFactory<double>(10));
 }
@@ -514,7 +514,7 @@ TEST_CASE("Unit_Device_tgamma_Accuracy_Limited_Positive") {
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_Device_tgamma_tgammaf_Negative_RTC") { NegativeTestRTCWrapper<4>(kTgamma); }
+TEST_CASE(Unit_Device_tgamma_tgammaf_Negative_RTC) { NegativeTestRTCWrapper<4>(kTgamma); }
 
 MATH_UNARY_KERNEL_DEF(lgamma)
 
@@ -532,7 +532,7 @@ MATH_UNARY_KERNEL_DEF(lgamma)
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_Device_lgammaf_Accuracy_Limited_Positive") {
+TEST_CASE(Unit_Device_lgammaf_Accuracy_Limited_Positive) {
   double (*ref)(double) = std::lgamma;
   UnarySinglePrecisionRangeTest(lgamma_kernel<float>, ref, ULPValidatorBuilderFactory<float>(7),
                                 std::numeric_limits<float>::lowest(), -11.0001f);
@@ -555,7 +555,7 @@ TEST_CASE("Unit_Device_lgammaf_Accuracy_Limited_Positive") {
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_Device_lgamma_Accuracy_Limited_Positive") {
+TEST_CASE(Unit_Device_lgamma_Accuracy_Limited_Positive) {
   long double (*ref)(long double) = std::lgamma;
   UnaryDoublePrecisionBruteForceTest(lgamma_kernel<double>, ref,
                                      ULPValidatorBuilderFactory<double>(4),
@@ -577,7 +577,7 @@ TEST_CASE("Unit_Device_lgamma_Accuracy_Limited_Positive") {
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_Device_lgamma_lgammaf_Negative_RTC") { NegativeTestRTCWrapper<4>(kLgamma); }
+TEST_CASE(Unit_Device_lgamma_lgammaf_Negative_RTC) { NegativeTestRTCWrapper<4>(kLgamma); }
 
 MATH_UNARY_KERNEL_DEF(cyl_bessel_i0)
 
@@ -595,7 +595,7 @@ MATH_UNARY_KERNEL_DEF(cyl_bessel_i0)
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_Device_cyl_bessel_i0f_Accuracy_Limited_Positive") {
+TEST_CASE(Unit_Device_cyl_bessel_i0f_Accuracy_Limited_Positive) {
   auto cyl_bessel_i0_ref = [](double arg) -> double { return std::cyl_bessel_i(0, arg); };
   double (*ref)(double) = cyl_bessel_i0_ref;
   UnarySinglePrecisionRangeTest(cyl_bessel_i0_kernel<float>, ref,
@@ -617,7 +617,7 @@ TEST_CASE("Unit_Device_cyl_bessel_i0f_Accuracy_Limited_Positive") {
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_Device_cyl_bessel_i0_Accuracy_Limited_Positive") {
+TEST_CASE(Unit_Device_cyl_bessel_i0_Accuracy_Limited_Positive) {
   auto cyl_bessel_i0_ref = [](long double arg) -> long double { return std::cyl_bessel_i(0, arg); };
   long double (*ref)(long double) = cyl_bessel_i0_ref;
   UnaryDoublePrecisionBruteForceTest(cyl_bessel_i0_kernel<double>, ref,
@@ -636,7 +636,7 @@ TEST_CASE("Unit_Device_cyl_bessel_i0_Accuracy_Limited_Positive") {
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_Device_cyl_bessel_i0_cyl_bessel_i0f_Negative_RTC") {
+TEST_CASE(Unit_Device_cyl_bessel_i0_cyl_bessel_i0f_Negative_RTC) {
   NegativeTestRTCWrapper<4>(kCylBesselI0);
 }
 
@@ -656,7 +656,7 @@ MATH_UNARY_KERNEL_DEF(cyl_bessel_i1)
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_Device_cyl_bessel_i1f_Accuracy_Limited_Positive") {
+TEST_CASE(Unit_Device_cyl_bessel_i1f_Accuracy_Limited_Positive) {
   auto cyl_bessel_i1_ref = [](double arg) -> double { return std::cyl_bessel_i(1, arg); };
   double (*ref)(double) = cyl_bessel_i1_ref;
   UnarySinglePrecisionRangeTest(cyl_bessel_i1_kernel<float>, ref,
@@ -678,7 +678,7 @@ TEST_CASE("Unit_Device_cyl_bessel_i1f_Accuracy_Limited_Positive") {
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_Device_cyl_bessel_i1_Accuracy_Limited_Positive") {
+TEST_CASE(Unit_Device_cyl_bessel_i1_Accuracy_Limited_Positive) {
   auto cyl_bessel_i1_ref = [](long double arg) -> long double { return std::cyl_bessel_i(1, arg); };
   long double (*ref)(long double) = cyl_bessel_i1_ref;
   UnaryDoublePrecisionBruteForceTest(cyl_bessel_i1_kernel<double>, ref,
@@ -697,7 +697,7 @@ TEST_CASE("Unit_Device_cyl_bessel_i1_Accuracy_Limited_Positive") {
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_Device_cyl_bessel_i1_cyl_bessel_i1f_Negative_RTC") {
+TEST_CASE(Unit_Device_cyl_bessel_i1_cyl_bessel_i1f_Negative_RTC) {
   NegativeTestRTCWrapper<4>(kCylBesselI1);
 }
 
@@ -719,7 +719,7 @@ MATH_UNARY_KERNEL_DEF(y0)
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_Device_y0f_Accuracy_Limited_Positive") {
+TEST_CASE(Unit_Device_y0f_Accuracy_Limited_Positive) {
 #ifdef __unix__
   double (*ref)(double) = y0;
 #elif _WIN64
@@ -746,7 +746,7 @@ TEST_CASE("Unit_Device_y0f_Accuracy_Limited_Positive") {
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_Device_y0_Accuracy_Limited_Positive") {
+TEST_CASE(Unit_Device_y0_Accuracy_Limited_Positive) {
 #ifdef __unix__
   long double (*ref)(long double) = y0l;
 #elif _WIN64
@@ -769,7 +769,7 @@ TEST_CASE("Unit_Device_y0_Accuracy_Limited_Positive") {
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_Device_y0_y0f_Negative_RTC") { NegativeTestRTCWrapper<4>(kY0); }
+TEST_CASE(Unit_Device_y0_y0f_Negative_RTC) { NegativeTestRTCWrapper<4>(kY0); }
 
 MATH_UNARY_KERNEL_DEF(y1)
 
@@ -787,7 +787,7 @@ MATH_UNARY_KERNEL_DEF(y1)
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_Device_y1f_Accuracy_Limited_Positive") {
+TEST_CASE(Unit_Device_y1f_Accuracy_Limited_Positive) {
 #ifdef __unix__
   double (*ref)(double) = y1;
 #elif _WIN64
@@ -814,7 +814,7 @@ TEST_CASE("Unit_Device_y1f_Accuracy_Limited_Positive") {
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_Device_y1_Accuracy_Limited_Positive") {
+TEST_CASE(Unit_Device_y1_Accuracy_Limited_Positive) {
 #ifdef __unix__
   long double (*ref)(long double) = y1l;
 #elif _WIN64
@@ -837,7 +837,7 @@ TEST_CASE("Unit_Device_y1_Accuracy_Limited_Positive") {
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_Device_y1_y1f_Negative_RTC") { NegativeTestRTCWrapper<4>(kY1); }
+TEST_CASE(Unit_Device_y1_y1f_Negative_RTC) { NegativeTestRTCWrapper<4>(kY1); }
 
 MATH_BESSEL_N_KERNEL_DEF(yn)
 
@@ -855,7 +855,7 @@ MATH_BESSEL_N_KERNEL_DEF(yn)
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_Device_ynf_Accuracy_Limited_Positive") {
+TEST_CASE(Unit_Device_ynf_Accuracy_Limited_Positive) {
 #ifdef __unix__
   double (*ref)(int, double) = yn;
 #elif _WIN64
@@ -881,7 +881,7 @@ TEST_CASE("Unit_Device_ynf_Accuracy_Limited_Positive") {
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_Device_yn_Accuracy_Limited_Positive") {
+TEST_CASE(Unit_Device_yn_Accuracy_Limited_Positive) {
 #ifdef __unix__
   long double (*ref)(int, long double) = ynl;
 #elif _WIN64
@@ -905,7 +905,7 @@ TEST_CASE("Unit_Device_yn_Accuracy_Limited_Positive") {
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_Device_yn_ynf_Negative_RTC") { NegativeTestRTCWrapper<8>(kYn); }
+TEST_CASE(Unit_Device_yn_ynf_Negative_RTC) { NegativeTestRTCWrapper<8>(kYn); }
 
 MATH_UNARY_KERNEL_DEF(j0)
 
@@ -923,7 +923,7 @@ MATH_UNARY_KERNEL_DEF(j0)
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_Device_j0f_Accuracy_Limited_Positive") {
+TEST_CASE(Unit_Device_j0f_Accuracy_Limited_Positive) {
 #ifdef __unix__
   double (*ref)(double) = j0;
 #elif _WIN64
@@ -952,7 +952,7 @@ TEST_CASE("Unit_Device_j0f_Accuracy_Limited_Positive") {
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_Device_j0_Accuracy_Limited_Positive") {
+TEST_CASE(Unit_Device_j0_Accuracy_Limited_Positive) {
 #ifdef __unix__
   long double (*ref)(long double) = j0l;
 #elif _WIN64
@@ -975,7 +975,7 @@ TEST_CASE("Unit_Device_j0_Accuracy_Limited_Positive") {
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_Device_j0_j0f_Negative_RTC") { NegativeTestRTCWrapper<4>(kJ0); }
+TEST_CASE(Unit_Device_j0_j0f_Negative_RTC) { NegativeTestRTCWrapper<4>(kJ0); }
 
 MATH_UNARY_KERNEL_DEF(j1)
 
@@ -993,7 +993,7 @@ MATH_UNARY_KERNEL_DEF(j1)
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_Device_j1f_Accuracy_Limited_Positive") {
+TEST_CASE(Unit_Device_j1f_Accuracy_Limited_Positive) {
 #ifdef __unix__
   double (*ref)(double) = j1;
 #elif _WIN64
@@ -1022,7 +1022,7 @@ TEST_CASE("Unit_Device_j1f_Accuracy_Limited_Positive") {
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_Device_j1_Accuracy_Limited_Positive") {
+TEST_CASE(Unit_Device_j1_Accuracy_Limited_Positive) {
 #ifdef __unix__
   long double (*ref)(long double) = j1l;
 #elif _WIN64
@@ -1045,7 +1045,7 @@ TEST_CASE("Unit_Device_j1_Accuracy_Limited_Positive") {
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_Device_j1_j1f_Negative_RTC") { NegativeTestRTCWrapper<4>(kJ1); }
+TEST_CASE(Unit_Device_j1_j1f_Negative_RTC) { NegativeTestRTCWrapper<4>(kJ1); }
 
 MATH_BESSEL_N_KERNEL_DEF(jn)
 
@@ -1063,7 +1063,7 @@ MATH_BESSEL_N_KERNEL_DEF(jn)
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_Device_jnf_Accuracy_Limited_Positive") {
+TEST_CASE(Unit_Device_jnf_Accuracy_Limited_Positive) {
 #ifdef __unix__
   double (*ref)(int, double) = jn;
 #elif _WIN64
@@ -1089,7 +1089,7 @@ TEST_CASE("Unit_Device_jnf_Accuracy_Limited_Positive") {
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_Device_jn_Accuracy_Limited_Positive") {
+TEST_CASE(Unit_Device_jn_Accuracy_Limited_Positive) {
 #ifdef __unix__
   long double (*ref)(int, long double) = jnl;
 #elif _WIN64
@@ -1113,7 +1113,7 @@ TEST_CASE("Unit_Device_jn_Accuracy_Limited_Positive") {
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_Device_jn_jnf_Negative_RTC") { NegativeTestRTCWrapper<8>(kJn); }
+TEST_CASE(Unit_Device_jn_jnf_Negative_RTC) { NegativeTestRTCWrapper<8>(kJn); }
 
 /**
  * End doxygen group MathTest.

--- a/projects/hip-tests/catch/unit/math/ternary_common.hh
+++ b/projects/hip-tests/catch/unit/math/ternary_common.hh
@@ -141,7 +141,7 @@ void TernaryFloatingPointTest(kernel_sig<T, TArg, TArg, TArg> kernel,
 #define MATH_TERNARY_WITHIN_ULP_TEST_DEF(kern_name, ref_func, sp_ulp, dp_ulp)                      \
   MATH_TERNARY_KERNEL_DEF(kern_name)                                                               \
                                                                                                    \
-  TEMPLATE_TEST_CASE("Unit_Device_" #kern_name "_Accuracy_Positive", "", float, double) {          \
+  TEMPLATE_TEST_CASE(Unit_Device_##kern_name##_Accuracy_Positive, float, double) {                 \
     using RT = RefType_t<TestType>;                                                                \
     RT (*ref)(RT, RT, RT) = ref_func;                                                              \
     const auto ulp = std::is_same_v<float, TestType> ? sp_ulp : dp_ulp;                            \

--- a/projects/hip-tests/catch/unit/math/trig_funcs.cc
+++ b/projects/hip-tests/catch/unit/math/trig_funcs.cc
@@ -27,49 +27,49 @@ THE SOFTWARE.
 
 
 MATH_UNARY_WITHIN_ULP_TEST_DEF(sin, std::sin, 2, 2);
-TEST_CASE("Unit_Device_sin_sinf_Negative_RTC") { NegativeTestRTCWrapper<4>(kSin); }
+TEST_CASE(Unit_Device_sin_sinf_Negative_RTC) { NegativeTestRTCWrapper<4>(kSin); }
 
 MATH_UNARY_WITHIN_ULP_TEST_DEF(cos, std::cos, 2, 2)
-TEST_CASE("Unit_Device_cos_cosf_Negative_RTC") { NegativeTestRTCWrapper<4>(kCos); }
+TEST_CASE(Unit_Device_cos_cosf_Negative_RTC) { NegativeTestRTCWrapper<4>(kCos); }
 
 MATH_UNARY_WITHIN_ULP_TEST_DEF(tan, std::tan, 4, 2)
-TEST_CASE("Unit_Device_tan_tanf_Negative_RTC") { NegativeTestRTCWrapper<4>(kTan); }
+TEST_CASE(Unit_Device_tan_tanf_Negative_RTC) { NegativeTestRTCWrapper<4>(kTan); }
 
 MATH_UNARY_WITHIN_ULP_TEST_DEF(asin, std::asin, 3, 2)
-TEST_CASE("Unit_Device_asin_asinf_Negative_RTC") { NegativeTestRTCWrapper<4>(kAsin); }
+TEST_CASE(Unit_Device_asin_asinf_Negative_RTC) { NegativeTestRTCWrapper<4>(kAsin); }
 
 MATH_UNARY_WITHIN_ULP_TEST_DEF(acos, std::acos, 2, 2)
-TEST_CASE("Unit_Device_acos_acosf_Negative_RTC") { NegativeTestRTCWrapper<4>(kAcos); }
+TEST_CASE(Unit_Device_acos_acosf_Negative_RTC) { NegativeTestRTCWrapper<4>(kAcos); }
 
 MATH_UNARY_WITHIN_ULP_TEST_DEF(atan, std::atan, 2, 2)
-TEST_CASE("Unit_Device_atan_atanf_Negative_RTC") { NegativeTestRTCWrapper<4>(kAtan); }
+TEST_CASE(Unit_Device_atan_atanf_Negative_RTC) { NegativeTestRTCWrapper<4>(kAtan); }
 
 MATH_UNARY_WITHIN_ULP_TEST_DEF(sinh, std::sinh, 3, 2)
-TEST_CASE("Unit_Device_sinh_sinhf_Negative_RTC") { NegativeTestRTCWrapper<4>(kSinh); }
+TEST_CASE(Unit_Device_sinh_sinhf_Negative_RTC) { NegativeTestRTCWrapper<4>(kSinh); }
 
 MATH_UNARY_WITHIN_ULP_TEST_DEF(cosh, std::cosh, 2, 1)
-TEST_CASE("Unit_Device_cosh_coshf_Negative_RTC") { NegativeTestRTCWrapper<4>(kCosh); }
+TEST_CASE(Unit_Device_cosh_coshf_Negative_RTC) { NegativeTestRTCWrapper<4>(kCosh); }
 
 MATH_UNARY_WITHIN_ULP_TEST_DEF(tanh, std::tanh, 2, 1)
-TEST_CASE("Unit_Device_tanh_tanhf_Negative_RTC") { NegativeTestRTCWrapper<4>(kTanh); }
+TEST_CASE(Unit_Device_tanh_tanhf_Negative_RTC) { NegativeTestRTCWrapper<4>(kTanh); }
 
 MATH_UNARY_WITHIN_ULP_TEST_DEF(asinh, std::asinh, 3, 2)
-TEST_CASE("Unit_Device_asinh_asinhf_Negative_RTC") { NegativeTestRTCWrapper<4>(kAsinh); }
+TEST_CASE(Unit_Device_asinh_asinhf_Negative_RTC) { NegativeTestRTCWrapper<4>(kAsinh); }
 
 MATH_UNARY_WITHIN_ULP_TEST_DEF(acosh, std::acosh, 4, 2)
-TEST_CASE("Unit_Device_acosh_acoshf_Negative_RTC") { NegativeTestRTCWrapper<4>(kAcosh); }
+TEST_CASE(Unit_Device_acosh_acoshf_Negative_RTC) { NegativeTestRTCWrapper<4>(kAcosh); }
 
 MATH_UNARY_WITHIN_ULP_TEST_DEF(atanh, std::atanh, 3, 2)
-TEST_CASE("Unit_Device_atanh_atanhf_Negative_RTC") { NegativeTestRTCWrapper<4>(kAtanh); }
+TEST_CASE(Unit_Device_atanh_atanhf_Negative_RTC) { NegativeTestRTCWrapper<4>(kAtanh); }
 
 MATH_UNARY_WITHIN_ULP_TEST_DEF(sinpi, math_reference::sin_pi, 2, 2);
-TEST_CASE("Unit_Device_sinpi_sinpif_Negative_RTC") { NegativeTestRTCWrapper<4>(kSinpi); }
+TEST_CASE(Unit_Device_sinpi_sinpif_Negative_RTC) { NegativeTestRTCWrapper<4>(kSinpi); }
 
 MATH_UNARY_WITHIN_ULP_TEST_DEF(cospi, math_reference::cos_pi, 2, 2);
-TEST_CASE("Unit_Device_cospi_cospif_Negative_RTC") { NegativeTestRTCWrapper<4>(kCospi); }
+TEST_CASE(Unit_Device_cospi_cospif_Negative_RTC) { NegativeTestRTCWrapper<4>(kCospi); }
 
 MATH_BINARY_WITHIN_ULP_TEST_DEF(atan2, std::atan2, 3, 2);
-TEST_CASE("Unit_Device_atan2_atan2f_Negative_RTC") { NegativeTestRTCWrapper<8>(kAtan2); }
+TEST_CASE(Unit_Device_atan2_atan2f_Negative_RTC) { NegativeTestRTCWrapper<8>(kAtan2); }
 
 
 template <typename T>
@@ -88,19 +88,19 @@ __global__ void sincos_kernel(std::pair<T, T>* const ys, const size_t num_xs, T*
 
 template <typename T> std::pair<T, T> sincos(T x) { return {std::sin(x), std::cos(x)}; }
 
-TEST_CASE("Unit_Device_sincos_Accuracy_Positive_float") {
+TEST_CASE(Unit_Device_sincos_Accuracy_Positive_float) {
   UnarySinglePrecisionTest(
       sincos_kernel<float>, sincos<double>,
       PairValidatorBuilderFactory<float>(ULPValidatorBuilderFactory<float>(2)));
 }
 
-TEST_CASE("Unit_Device_sincos_Accuracy_Positive_double") {
+TEST_CASE(Unit_Device_sincos_Accuracy_Positive_double) {
   const auto validator_builder =
       PairValidatorBuilderFactory<double>(ULPValidatorBuilderFactory<double>(2));
   UnaryDoublePrecisionTest(sincos_kernel<double>, sincos<long double>, validator_builder);
 }
 
-TEST_CASE("Unit_Device_sincos_sincosf_Negative_RTC") { NegativeTestRTCWrapper<36>(kSincos); }
+TEST_CASE(Unit_Device_sincos_sincosf_Negative_RTC) { NegativeTestRTCWrapper<36>(kSincos); }
 
 
 template <typename T>
@@ -121,16 +121,16 @@ template <typename T> std::pair<T, T> sincospi(T x) {
   return {math_reference::sin_pi(x), math_reference::cos_pi(x)};
 }
 
-TEST_CASE("Unit_Device_sincospi_Accuracy_Positive_float") {
+TEST_CASE(Unit_Device_sincospi_Accuracy_Positive_float) {
   UnarySinglePrecisionTest(
       sincospi_kernel<float>, sincospi<double>,
       PairValidatorBuilderFactory<float>(ULPValidatorBuilderFactory<float>(2)));
 }
 
-TEST_CASE("Unit_Device_sincospi_Accuracy_Positive_double") {
+TEST_CASE(Unit_Device_sincospi_Accuracy_Positive_double) {
   const auto validator_builder =
       PairValidatorBuilderFactory<double>(ULPValidatorBuilderFactory<double>(2));
   UnaryDoublePrecisionTest(sincospi_kernel<double>, sincospi<long double>, validator_builder);
 }
 
-TEST_CASE("Unit_Device_sincospi_sincospif_Negative_RTC") { NegativeTestRTCWrapper<36>(kSincospi); }
+TEST_CASE(Unit_Device_sincospi_sincospif_Negative_RTC) { NegativeTestRTCWrapper<36>(kSincospi); }

--- a/projects/hip-tests/catch/unit/math/unary_common.hh
+++ b/projects/hip-tests/catch/unit/math/unary_common.hh
@@ -235,13 +235,13 @@ void UnaryDoublePrecisionTest(kernel_sig<T, double> kernel, ref_sig<RT, RTArg> r
 #define MATH_UNARY_WITHIN_ULP_TEST_DEF(kern_name, ref_func, sp_ulp, dp_ulp)                        \
   MATH_UNARY_KERNEL_DEF(kern_name)                                                                 \
                                                                                                    \
-  TEST_CASE("Unit_Device_" #kern_name "_Accuracy_Positive - float") {                              \
+  TEST_CASE(Unit_Device_##kern_name##_Accuracy_Positive_float) {                                   \
     double (*ref)(double) = ref_func;                                                              \
     UnarySinglePrecisionTest(kern_name##_kernel<float>, ref,                                       \
                              ULPValidatorBuilderFactory<float>(sp_ulp));                           \
   }                                                                                                \
                                                                                                    \
-  TEST_CASE("Unit_Device_" #kern_name "_Accuracy_Positive - double") {                             \
+  TEST_CASE(Unit_Device_##kern_name##_Accuracy_Positive_double) {                                  \
     long double (*ref)(long double) = ref_func;                                                    \
     UnaryDoublePrecisionTest(kern_name##_kernel<double>, ref,                                      \
                              ULPValidatorBuilderFactory<double>(dp_ulp));                          \

--- a/projects/hip-tests/catch/unit/memory/hipArray.cc
+++ b/projects/hip-tests/catch/unit/memory/hipArray.cc
@@ -17,7 +17,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 #include <hip_test_common.hh>
-TEST_CASE("Unit_hipArray_Valid") {
+TEST_CASE(Unit_hipArray_Valid) {
   CHECK_IMAGE_SUPPORT
 
   hipArray_t array = nullptr;
@@ -30,7 +30,7 @@ TEST_CASE("Unit_hipArray_Valid") {
   HIP_CHECK(hipFreeArray(array));
 }
 
-TEST_CASE("Unit_hipArray_Invalid") {
+TEST_CASE(Unit_hipArray_Invalid) {
   CHECK_IMAGE_SUPPORT
 
   void* data = malloc(sizeof(char));
@@ -38,13 +38,13 @@ TEST_CASE("Unit_hipArray_Invalid") {
   REQUIRE(hipFreeArray(arrayPtr) == hipErrorContextIsDestroyed);
   free(data);
 }
-TEST_CASE("Unit_hipArray_Nullptr") {
+TEST_CASE(Unit_hipArray_Nullptr) {
   CHECK_IMAGE_SUPPORT
 
   hipArray_t array = nullptr;
   REQUIRE(hipFreeArray(array) == hipErrorInvalidValue);
 }
-TEST_CASE("Unit_hipArray_DoubleFree") {
+TEST_CASE(Unit_hipArray_DoubleFree) {
   CHECK_IMAGE_SUPPORT
 
   hipArray_t array = nullptr;
@@ -57,7 +57,7 @@ TEST_CASE("Unit_hipArray_DoubleFree") {
   HIP_CHECK(hipFreeArray(array));
   REQUIRE(hipFreeArray(array) == hipErrorContextIsDestroyed);
 }
-TEST_CASE("Unit_hipArray_TrippleDestroy") {
+TEST_CASE(Unit_hipArray_TrippleDestroy) {
   CHECK_IMAGE_SUPPORT
 
   hipArray_t array = nullptr;
@@ -71,14 +71,14 @@ TEST_CASE("Unit_hipArray_TrippleDestroy") {
   REQUIRE(hipArrayDestroy(array) == hipErrorContextIsDestroyed);
   REQUIRE(hipArrayDestroy(array) == hipErrorContextIsDestroyed);
 }
-TEST_CASE("Unit_hipArray_DoubleNullptr") {
+TEST_CASE(Unit_hipArray_DoubleNullptr) {
   CHECK_IMAGE_SUPPORT
 
   hipArray_t array = nullptr;
   REQUIRE(hipFreeArray(array) == hipErrorInvalidValue);
   REQUIRE(hipFreeArray(array) == hipErrorInvalidValue);
 }
-TEST_CASE("Unit_hipArray_DoubleInvalid") {
+TEST_CASE(Unit_hipArray_DoubleInvalid) {
   CHECK_IMAGE_SUPPORT
 
   void* data = malloc(sizeof(char));

--- a/projects/hip-tests/catch/unit/memory/hipArray3DCreate.cc
+++ b/projects/hip-tests/catch/unit/memory/hipArray3DCreate.cc
@@ -48,7 +48,7 @@ void testInvalidDescription(HIP_ARRAY3D_DESCRIPTOR desc) {
 }
 }  // namespace
 
-TEMPLATE_TEST_CASE("Unit_hipArray3DCreate_happy", "", char, uchar2, uint2, int4, short4, float,
+TEMPLATE_TEST_CASE(Unit_hipArray3DCreate_happy, char, uchar2, uint2, int4, short4, float,
                    float2, float4) {
   CHECK_IMAGE_SUPPORT
 
@@ -88,7 +88,7 @@ TEMPLATE_TEST_CASE("Unit_hipArray3DCreate_happy", "", char, uchar2, uint2, int4,
   }
 }
 
-TEMPLATE_TEST_CASE("Unit_hipArray3DCreate_MaxTexture", "", int, uint4, short, ushort2,
+TEMPLATE_TEST_CASE(Unit_hipArray3DCreate_MaxTexture, int, uint4, short, ushort2,
                    unsigned char, float, float4) {
   CHECK_IMAGE_SUPPORT
 
@@ -210,7 +210,7 @@ constexpr HIP_ARRAY3D_DESCRIPTOR defaultDescriptor(unsigned int flags, size_t si
 }
 
 // Providing the array pointer as nullptr should return an error
-TEST_CASE("Unit_hipArray3DCreate_Negative_NullArrayPtr") {
+TEST_CASE(Unit_hipArray3DCreate_Negative_NullArrayPtr) {
   CHECK_IMAGE_SUPPORT
 
   auto desc = defaultDescriptor(0, 64);
@@ -220,7 +220,7 @@ TEST_CASE("Unit_hipArray3DCreate_Negative_NullArrayPtr") {
 }
 
 // Providing the description pointer as nullptr should return an error
-TEST_CASE("Unit_hipArray3DCreate_Negative_NullDescPtr") {
+TEST_CASE(Unit_hipArray3DCreate_Negative_NullDescPtr) {
   CHECK_IMAGE_SUPPORT
 
   DriverContext ctx;
@@ -230,7 +230,7 @@ TEST_CASE("Unit_hipArray3DCreate_Negative_NullDescPtr") {
 
 
 // Zero width arrays are not allowed
-TEST_CASE("Unit_hipArray3DCreate_Negative_ZeroWidth") {
+TEST_CASE(Unit_hipArray3DCreate_Negative_ZeroWidth) {
   CHECK_IMAGE_SUPPORT
 
   DriverContext ctx;
@@ -244,7 +244,7 @@ TEST_CASE("Unit_hipArray3DCreate_Negative_ZeroWidth") {
 }
 
 // Zero height arrays are only allowed for 1D arrays and layered arrays
-TEST_CASE("Unit_hipArray3DCreate_Negative_ZeroHeight") {
+TEST_CASE(Unit_hipArray3DCreate_Negative_ZeroHeight) {
   CHECK_IMAGE_SUPPORT
 
   DriverContext ctx;
@@ -266,7 +266,7 @@ TEST_CASE("Unit_hipArray3DCreate_Negative_ZeroHeight") {
 }
 
 // Arrays must be created with a valid data format
-TEST_CASE("Unit_hipArray3DCreate_Negative_InvalidFormat") {
+TEST_CASE(Unit_hipArray3DCreate_Negative_InvalidFormat) {
   CHECK_IMAGE_SUPPORT
 
   DriverContext ctx;
@@ -282,7 +282,7 @@ TEST_CASE("Unit_hipArray3DCreate_Negative_InvalidFormat") {
 }
 
 // An array must have either 1,2, or 4 channels
-TEST_CASE("Unit_hipArray3DCreate_Negative_NumChannels") {
+TEST_CASE(Unit_hipArray3DCreate_Negative_NumChannels) {
   CHECK_IMAGE_SUPPORT
 
   DriverContext ctx;
@@ -294,7 +294,7 @@ TEST_CASE("Unit_hipArray3DCreate_Negative_NumChannels") {
 }
 
 // Using invalid flags should result in an error
-TEST_CASE("Unit_hipArray3DCreate_Negative_InvalidFlags") {
+TEST_CASE(Unit_hipArray3DCreate_Negative_InvalidFlags) {
   CHECK_IMAGE_SUPPORT
 
   DriverContext ctx;
@@ -321,7 +321,7 @@ TEST_CASE("Unit_hipArray3DCreate_Negative_InvalidFlags") {
 
 
 // hipArray3DCreate should handle the max numeric value gracefully.
-TEST_CASE("Unit_hipArray3DCreate_Negative_NumericLimit") {
+TEST_CASE(Unit_hipArray3DCreate_Negative_NumericLimit) {
   CHECK_IMAGE_SUPPORT
 
   DriverContext ctx;
@@ -333,7 +333,7 @@ TEST_CASE("Unit_hipArray3DCreate_Negative_NumericLimit") {
 }
 
 // texture gather arrays may only be 2D
-TEMPLATE_TEST_CASE("Unit_hipArray3DCreate_Negative_Non2DTextureGather", "", char, uint2, int4,
+TEMPLATE_TEST_CASE(Unit_hipArray3DCreate_Negative_Non2DTextureGather, char, uint2, int4,
                    float2, float4) {
   CHECK_IMAGE_SUPPORT
 

--- a/projects/hip-tests/catch/unit/memory/hipArray3DGetDescriptor.cc
+++ b/projects/hip-tests/catch/unit/memory/hipArray3DGetDescriptor.cc
@@ -42,7 +42,7 @@ THE SOFTWARE.
  * ------------------------
  *  - HIP_VERSION >= 5.7
  */
-TEST_CASE("Unit_hipArray3DGetDescriptor_Positive_Basic") {
+TEST_CASE(Unit_hipArray3DGetDescriptor_Positive_Basic) {
   CHECK_IMAGE_SUPPORT
   DrvArrayAllocGuard<float> array(make_hipExtent(1024, 4, 2));
 
@@ -69,7 +69,7 @@ TEST_CASE("Unit_hipArray3DGetDescriptor_Positive_Basic") {
  * ------------------------
  *  - HIP_VERSION >= 5.7
  */
-TEST_CASE("Unit_hipArray3DGetDescriptor_Negative_Parameters") {
+TEST_CASE(Unit_hipArray3DGetDescriptor_Negative_Parameters) {
   CHECK_IMAGE_SUPPORT
   DrvArrayAllocGuard<float> array(make_hipExtent(1024, 4, 2));
 

--- a/projects/hip-tests/catch/unit/memory/hipArrayCreate.cc
+++ b/projects/hip-tests/catch/unit/memory/hipArrayCreate.cc
@@ -73,7 +73,7 @@ static void ArrayCreate_DiffSizes(int gpu) {
 }
 
 /* This testcase verifies hipArrayCreate API for small and big chunks data*/
-TEST_CASE("Unit_hipArrayCreate_DiffSizes") {
+TEST_CASE(Unit_hipArrayCreate_DiffSizes) {
   CHECK_IMAGE_SUPPORT
 
   ArrayCreate_DiffSizes(0);
@@ -85,7 +85,7 @@ This testcase verifies the hipArrayCreate API in multithreaded
 scenario by launching threads in parallel on multiple GPUs
 and verifies the hipArrayCreate API with small and big chunks data
 */
-TEST_CASE("Unit_hipArrayCreate_MultiThread", "[multigpu]") {
+TEST_CASE(Unit_hipArrayCreate_MultiThread) {
   CHECK_IMAGE_SUPPORT
 
   std::vector<std::thread> threadlist;
@@ -200,7 +200,7 @@ void testArrayAsTexture(hipArray_t array, const size_t width, const size_t heigh
 
 // Selection of types chosen since trying all types would be slow to compile
 // Test the happy path of the hipArrayCreate
-TEMPLATE_TEST_CASE("Unit_hipArrayCreate_happy", "", uint, int, int4, ushort, short2, char, uchar2,
+TEMPLATE_TEST_CASE(Unit_hipArrayCreate_happy, uint, int, int4, ushort, short2, char, uchar2,
                    char4, float, float2, float4) {
   CHECK_IMAGE_SUPPORT
 
@@ -225,7 +225,7 @@ TEMPLATE_TEST_CASE("Unit_hipArrayCreate_happy", "", uint, int, int4, ushort, sho
 
 
 // Only widths and Heights up to the maxTexture size is supported
-TEMPLATE_TEST_CASE("Unit_hipArrayCreate_maxTexture", "", uint, int, int4, ushort, short2, char,
+TEMPLATE_TEST_CASE(Unit_hipArrayCreate_maxTexture, uint, int, int4, ushort, short2, char,
                    uchar2, char4, float, float2, float4) {
   CHECK_IMAGE_SUPPORT
 
@@ -286,7 +286,7 @@ TEMPLATE_TEST_CASE("Unit_hipArrayCreate_maxTexture", "", uint, int, int4, ushort
 }
 
 // zero-width array is not supported
-TEST_CASE("Unit_hipArrayCreate_ZeroWidth") {
+TEST_CASE(Unit_hipArrayCreate_ZeroWidth) {
   CHECK_IMAGE_SUPPORT
 
   DriverContext ctx;
@@ -302,7 +302,7 @@ TEST_CASE("Unit_hipArrayCreate_ZeroWidth") {
 }
 
 // HipArrayCreate will return an error when nullptr is used as the array argument
-TEST_CASE("Unit_hipArrayCreate_Nullptr") {
+TEST_CASE(Unit_hipArrayCreate_Nullptr) {
   CHECK_IMAGE_SUPPORT
 
   DriverContext ctx;
@@ -322,7 +322,7 @@ TEST_CASE("Unit_hipArrayCreate_Nullptr") {
 }
 
 // Only elements with 1,2, or 4 channels is supported
-TEST_CASE("Unit_hipArrayCreate_BadNumberChannelElement") {
+TEST_CASE(Unit_hipArrayCreate_BadNumberChannelElement) {
   CHECK_IMAGE_SUPPORT
 
   DriverContext ctx;
@@ -340,7 +340,7 @@ TEST_CASE("Unit_hipArrayCreate_BadNumberChannelElement") {
 }
 
 // Only certain channel formats are acceptable.
-TEST_CASE("Unit_hipArrayCreate_BadChannelFormat") {
+TEST_CASE(Unit_hipArrayCreate_BadChannelFormat) {
   CHECK_IMAGE_SUPPORT
 
   DriverContext ctx;

--- a/projects/hip-tests/catch/unit/memory/hipArrayGetDescriptor.cc
+++ b/projects/hip-tests/catch/unit/memory/hipArrayGetDescriptor.cc
@@ -233,7 +233,7 @@ float* funcToChkArray(hipArray_t array) {
  * ------------------------
  * - HIP_VERSION >= 5.6
  */
-TEST_CASE("Unit_hipArrayGetDescriptor_1D_2D_ArrayParameterChk", "[multigpu]") {
+TEST_CASE(Unit_hipArrayGetDescriptor_1D_2D_ArrayParameterChk) {
   CHECK_IMAGE_SUPPORT
 
   int numDevices = 0;
@@ -318,8 +318,7 @@ TEST_CASE("Unit_hipArrayGetDescriptor_1D_2D_ArrayParameterChk", "[multigpu]") {
  * ------------------------
  * - HIP_VERSION >= 5.6
  */
-TEST_CASE("Unit_hipArrayGetDescriptor_MultiThreadScenarioFor1D_2D_Array",
-          "[multigpu]") {
+TEST_CASE(Unit_hipArrayGetDescriptor_MultiThreadScenarioFor1D_2D_Array) {
   CHECK_IMAGE_SUPPORT
 
   int numDevices = 0;
@@ -369,7 +368,7 @@ TEST_CASE("Unit_hipArrayGetDescriptor_MultiThreadScenarioFor1D_2D_Array",
  * ------------------------
  * - HIP_VERSION >= 5.6
  */
-TEST_CASE("Unit_hipArrayGetDescriptor_Host2Array_Array2Host", "[multigpu]") {
+TEST_CASE(Unit_hipArrayGetDescriptor_Host2Array_Array2Host) {
   CHECK_IMAGE_SUPPORT
 
   int numDevices = 0;
@@ -439,7 +438,7 @@ TEST_CASE("Unit_hipArrayGetDescriptor_Host2Array_Array2Host", "[multigpu]") {
  * ------------------------
  * - HIP_VERSION >= 5.6
  */
-TEST_CASE("Unit_hipArrayGetDescriptor_Negative_Scenarios") {
+TEST_CASE(Unit_hipArrayGetDescriptor_Negative_Scenarios) {
   hipError_t error;
   HIP_ARRAY_DESCRIPTOR desc_Neg;
   SECTION("Array Address As Nullptr") {
@@ -477,7 +476,7 @@ TEST_CASE("Unit_hipArrayGetDescriptor_Negative_Scenarios") {
  * ------------------------
  *  - HIP_VERSION >= 5.7
  */
-TEST_CASE("Unit_hipArrayGetDescriptor_Positive_Basic") {
+TEST_CASE(Unit_hipArrayGetDescriptor_Positive_Basic) {
   CHECK_IMAGE_SUPPORT
 
   HIP_ARRAY_DESCRIPTOR expected_desc{};
@@ -512,7 +511,7 @@ TEST_CASE("Unit_hipArrayGetDescriptor_Positive_Basic") {
  * ------------------------
  *  - HIP_VERSION >= 5.7
  */
-TEST_CASE("Unit_hipArrayGetDescriptor_Negative_Parameters") {
+TEST_CASE(Unit_hipArrayGetDescriptor_Negative_Parameters) {
   CHECK_IMAGE_SUPPORT
 
   HIP_ARRAY_DESCRIPTOR expected_desc{};

--- a/projects/hip-tests/catch/unit/memory/hipArrayGetInfo.cc
+++ b/projects/hip-tests/catch/unit/memory/hipArrayGetInfo.cc
@@ -42,7 +42,7 @@ THE SOFTWARE.
  * ------------------------
  *  - HIP_VERSION >= 5.7
  */
-TEST_CASE("Unit_hipArrayGetInfo_Positive_Basic") {
+TEST_CASE(Unit_hipArrayGetInfo_Positive_Basic) {
   CHECK_IMAGE_SUPPORT
 
   ArrayAllocGuard<float> array(make_hipExtent(1024, 4, 2));
@@ -78,7 +78,7 @@ TEST_CASE("Unit_hipArrayGetInfo_Positive_Basic") {
  * ------------------------
  *  - HIP_VERSION >= 5.7
  */
-TEST_CASE("Unit_hipArrayGetInfo_Negative_Parameters") {
+TEST_CASE(Unit_hipArrayGetInfo_Negative_Parameters) {
   CHECK_IMAGE_SUPPORT
   ArrayAllocGuard<float> array(make_hipExtent(1024, 4, 4));
 

--- a/projects/hip-tests/catch/unit/memory/hipDeviceGetMemPool.cc
+++ b/projects/hip-tests/catch/unit/memory/hipDeviceGetMemPool.cc
@@ -73,7 +73,7 @@ static bool checkMallocAsync() {
  * ------------------------
  *    - HIP_VERSION >= 6.2
  */
-TEST_CASE("Unit_hipDeviceGetMemPool_Basic") {
+TEST_CASE(Unit_hipDeviceGetMemPool_Basic) {
   checkMempoolSupported(0) hipMemPool_t mem_pool_device = nullptr, mem_pool_default = nullptr;
   SECTION("Check current mempool is default mempool") {
     // assign default mem pool to device
@@ -113,7 +113,7 @@ TEST_CASE("Unit_hipDeviceGetMemPool_Basic") {
  * ------------------------
  *    - HIP_VERSION >= 6.2
  */
-TEST_CASE("Unit_hipDeviceGetMemPool_Functional") {
+TEST_CASE(Unit_hipDeviceGetMemPool_Functional) {
   hipMemPool_t mem_pool = nullptr;
   checkMempoolSupported(0)
       // assign current mem pool to device
@@ -137,7 +137,7 @@ TEST_CASE("Unit_hipDeviceGetMemPool_Functional") {
  * ------------------------
  *    - HIP_VERSION >= 6.2
  */
-TEST_CASE("Unit_hipDeviceGetMemPool_Multidevice", "[multigpu]") {
+TEST_CASE(Unit_hipDeviceGetMemPool_Multidevice) {
   int num_devices;
   HIP_CHECK(hipGetDeviceCount(&num_devices));
 
@@ -165,7 +165,7 @@ TEST_CASE("Unit_hipDeviceGetMemPool_Multidevice", "[multigpu]") {
  * ------------------------
  *    - HIP_VERSION >= 6.2
  */
-TEST_CASE("Unit_hipDeviceGetDefaultMemPool_Functional") {
+TEST_CASE(Unit_hipDeviceGetDefaultMemPool_Functional) {
   hipMemPool_t mem_pool = nullptr;
   checkMempoolSupported(0)
       // assign current mem pool to device

--- a/projects/hip-tests/catch/unit/memory/hipDeviceSetMemPool.cc
+++ b/projects/hip-tests/catch/unit/memory/hipDeviceSetMemPool.cc
@@ -74,7 +74,7 @@ static bool checkMallocAsync() {
  * ------------------------
  *    - HIP_VERSION >= 6.2
  */
-TEST_CASE("Unit_hipDeviceSetMemPool_Basic") {
+TEST_CASE(Unit_hipDeviceSetMemPool_Basic) {
   int num_devices;
   HIP_CHECK(hipGetDeviceCount(&num_devices));
   for (int dev = 0; dev < num_devices; dev++) {
@@ -108,7 +108,7 @@ TEST_CASE("Unit_hipDeviceSetMemPool_Basic") {
  * ------------------------
  *    - HIP_VERSION >= 6.2
  */
-TEST_CASE("Unit_hipDeviceSetMemPool_DestroyCurrentMempool", "[multigpu]") {
+TEST_CASE(Unit_hipDeviceSetMemPool_DestroyCurrentMempool) {
   int num_devices;
   HIP_CHECK(hipGetDeviceCount(&num_devices));
   for (int dev = 0; dev < num_devices; dev++) {
@@ -144,7 +144,7 @@ TEST_CASE("Unit_hipDeviceSetMemPool_DestroyCurrentMempool", "[multigpu]") {
  * ------------------------
  *    - HIP_VERSION >= 6.2
  */
-TEST_CASE("Unit_hipDeviceSetMemPool_functional") {
+TEST_CASE(Unit_hipDeviceSetMemPool_functional) {
   checkMempoolSupported(0) hipMemPool_t mem_pool = nullptr;
   // create explicit mem pool
   hipMemPoolProps PoolProps{};
@@ -171,7 +171,7 @@ TEST_CASE("Unit_hipDeviceSetMemPool_functional") {
  * ------------------------
  *    - HIP_VERSION >= 6.2
  */
-TEST_CASE("Unit_hipDeviceSetMemPool_functionalAttribute") {
+TEST_CASE(Unit_hipDeviceSetMemPool_functionalAttribute) {
   checkMempoolSupported(0) hipMemPool_t mem_pool = nullptr;
   // create explicit mem pool
   hipMemPoolProps PoolProps{};

--- a/projects/hip-tests/catch/unit/memory/hipDrvMemcpy2DUnaligned.cc
+++ b/projects/hip-tests/catch/unit/memory/hipDrvMemcpy2DUnaligned.cc
@@ -41,7 +41,7 @@ THE SOFTWARE.
  * ------------------------
  *  - HIP_VERSION >= 6.0
  */
-TEST_CASE("Unit_hipDrvMemcpy2DUnaligned_NegTst") {
+TEST_CASE(Unit_hipDrvMemcpy2DUnaligned_NegTst) {
   // declare host and device arrays
   int rows, cols;
   rows = GENERATE(3, 4, 100);
@@ -183,7 +183,7 @@ TEST_CASE("Unit_hipDrvMemcpy2DUnaligned_NegTst") {
  * ------------------------
  *  - HIP_VERSION >= 6.0
  */
-TEST_CASE("Unit_hipDrvMemcpy2DUnaligned_FuncTst") {
+TEST_CASE(Unit_hipDrvMemcpy2DUnaligned_FuncTst) {
   SECTION(
       "Different types of memory transfers functional tests to check if\
           copied array contains correct values") {
@@ -269,7 +269,7 @@ TEST_CASE("Unit_hipDrvMemcpy2DUnaligned_FuncTst") {
  * ------------------------
  *  - HIP_VERSION >= 6.0
  */
-TEST_CASE("Unit_hipDrvMemcpy2DUnaligned_Positive_Basic", "[multigpu]") {
+TEST_CASE(Unit_hipDrvMemcpy2DUnaligned_Positive_Basic) {
   CHECK_IMAGE_SUPPORT
 
   SECTION("Device to Device") {
@@ -298,7 +298,7 @@ TEST_CASE("Unit_hipDrvMemcpy2DUnaligned_Positive_Basic", "[multigpu]") {
  * ------------------------
  *  - HIP_VERSION >= 6.0
  */
-TEST_CASE("Unit_hipDrvMemcpy2DUnaligned_Positive_Synchronization_Behavior") {
+TEST_CASE(Unit_hipDrvMemcpy2DUnaligned_Positive_Synchronization_Behavior) {
   CHECK_IMAGE_SUPPORT
 
   HIP_CHECK(hipDeviceSynchronize());
@@ -325,6 +325,6 @@ TEST_CASE("Unit_hipDrvMemcpy2DUnaligned_Positive_Synchronization_Behavior") {
  * ------------------------
  *  - HIP_VERSION >= 6.0
  */
-TEST_CASE("Unit_hipDrvMemcpy2DUnaligned_Positive_Parameters") {
+TEST_CASE(Unit_hipDrvMemcpy2DUnaligned_Positive_Parameters) {
   Memcpy2DZeroWidthHeight<false, true>(DrvMemcpy2DUnalignedAdapter());
 }

--- a/projects/hip-tests/catch/unit/memory/hipDrvMemcpy3D.cc
+++ b/projects/hip-tests/catch/unit/memory/hipDrvMemcpy3D.cc
@@ -28,7 +28,7 @@ THE SOFTWARE.
 #include <resource_guards.hh>
 #include <utils.hh>
 
-TEST_CASE("Unit_hipDrvMemcpy3D_Positive_Basic") {
+TEST_CASE(Unit_hipDrvMemcpy3D_Positive_Basic) {
   CHECK_IMAGE_SUPPORT
 
   constexpr bool async = false;
@@ -53,7 +53,7 @@ TEST_CASE("Unit_hipDrvMemcpy3D_Positive_Basic") {
 #endif
 }
 
-TEST_CASE("Unit_hipDrvMemcpy3D_Positive_Synchronization_Behavior") {
+TEST_CASE(Unit_hipDrvMemcpy3D_Positive_Synchronization_Behavior) {
   CHECK_IMAGE_SUPPORT
 
   HIP_CHECK(hipDeviceSynchronize());
@@ -71,7 +71,7 @@ TEST_CASE("Unit_hipDrvMemcpy3D_Positive_Synchronization_Behavior") {
   SECTION("Host to Host") { Memcpy3DHtoHSyncBehavior(DrvMemcpy3DWrapper<>, true); }
 }
 
-TEST_CASE("Unit_hipDrvMemcpy3D_Positive_Parameters") {
+TEST_CASE(Unit_hipDrvMemcpy3D_Positive_Parameters) {
   CHECK_IMAGE_SUPPORT
 
   constexpr bool async = false;
@@ -79,7 +79,7 @@ TEST_CASE("Unit_hipDrvMemcpy3D_Positive_Parameters") {
 }
 
 // Disabled on AMD due to defect - EXSWHTEC-238
-TEST_CASE("Unit_hipDrvMemcpy3D_Positive_Array") {
+TEST_CASE(Unit_hipDrvMemcpy3D_Positive_Array) {
   CHECK_IMAGE_SUPPORT
 
   constexpr bool async = false;
@@ -87,7 +87,7 @@ TEST_CASE("Unit_hipDrvMemcpy3D_Positive_Array") {
   SECTION("Array from/to Device") { DrvMemcpy3DArrayDeviceShell<async>(DrvMemcpy3DWrapper<>); }
 }
 
-TEST_CASE("Unit_hipDrvMemcpy3D_Negative_Parameters") {
+TEST_CASE(Unit_hipDrvMemcpy3D_Negative_Parameters) {
   CHECK_IMAGE_SUPPORT
 
   constexpr hipExtent extent{128 * sizeof(int), 128, 8};
@@ -226,7 +226,7 @@ TEST_CASE("Unit_hipDrvMemcpy3D_Negative_Parameters") {
   }
 }
 
-TEST_CASE("Unit_hipDrvMemcpy3D_Capture") {
+TEST_CASE(Unit_hipDrvMemcpy3D_Capture) {
   CHECK_IMAGE_SUPPORT
 
   constexpr hipExtent extent{128 * sizeof(int), 128, 8};

--- a/projects/hip-tests/catch/unit/memory/hipDrvMemcpy3DAsync.cc
+++ b/projects/hip-tests/catch/unit/memory/hipDrvMemcpy3DAsync.cc
@@ -28,7 +28,7 @@ THE SOFTWARE.
 #include <resource_guards.hh>
 #include <utils.hh>
 
-TEST_CASE("Unit_hipDrvMemcpy3DAsync_Positive_Basic") {
+TEST_CASE(Unit_hipDrvMemcpy3DAsync_Positive_Basic) {
   CHECK_IMAGE_SUPPORT
 
   constexpr bool async = true;
@@ -57,7 +57,7 @@ TEST_CASE("Unit_hipDrvMemcpy3DAsync_Positive_Basic") {
 #endif
 }
 
-TEST_CASE("Unit_hipDrvMemcpy3DAsync_Positive_Synchronization_Behavior") {
+TEST_CASE(Unit_hipDrvMemcpy3DAsync_Positive_Synchronization_Behavior) {
   CHECK_IMAGE_SUPPORT
 
   constexpr bool async = true;
@@ -85,7 +85,7 @@ TEST_CASE("Unit_hipDrvMemcpy3DAsync_Positive_Synchronization_Behavior") {
 #endif
 }
 
-TEST_CASE("Unit_hipDrvMemcpy3DAsync_Positive_Parameters") {
+TEST_CASE(Unit_hipDrvMemcpy3DAsync_Positive_Parameters) {
   CHECK_IMAGE_SUPPORT
 
   constexpr bool async = true;
@@ -93,7 +93,7 @@ TEST_CASE("Unit_hipDrvMemcpy3DAsync_Positive_Parameters") {
 }
 
 // Disabled on AMD due to defect - EXSWHTEC-238
-TEST_CASE("Unit_hipDrvMemcpy3DAsync_Positive_Array") {
+TEST_CASE(Unit_hipDrvMemcpy3DAsync_Positive_Array) {
   CHECK_IMAGE_SUPPORT
 
   constexpr bool async = true;
@@ -101,7 +101,7 @@ TEST_CASE("Unit_hipDrvMemcpy3DAsync_Positive_Array") {
   SECTION("Array from/to Device") { DrvMemcpy3DArrayDeviceShell<async>(DrvMemcpy3DWrapper<async>); }
 }
 
-TEST_CASE("Unit_hipDrvMemcpy3DAsync_Negative_Parameters") {
+TEST_CASE(Unit_hipDrvMemcpy3DAsync_Negative_Parameters) {
   CHECK_IMAGE_SUPPORT
 
   constexpr bool async = true;
@@ -253,7 +253,7 @@ TEST_CASE("Unit_hipDrvMemcpy3DAsync_Negative_Parameters") {
   }
 }
 
-TEST_CASE("Unit_hipDrvMemcpy3DAsync_Capture") {
+TEST_CASE(Unit_hipDrvMemcpy3DAsync_Capture) {
   CHECK_IMAGE_SUPPORT
 
   constexpr hipExtent kExtent{128 * sizeof(int), 128, 8};

--- a/projects/hip-tests/catch/unit/memory/hipDrvMemcpy3DAsync_old.cc
+++ b/projects/hip-tests/catch/unit/memory/hipDrvMemcpy3DAsync_old.cc
@@ -459,7 +459,7 @@ template <typename T> void DrvMemcpy3DAsync<T>::DeAllocateMemory() {
  *  - HIP_VERSION >= 6.0
  */
 
-TEST_CASE("Unit_hipDrvMemcpy3DAsync_H2DDeviceContextChange", "[multigpu]") {
+TEST_CASE(Unit_hipDrvMemcpy3DAsync_H2DDeviceContextChange) {
   CHECK_IMAGE_SUPPORT
   int numDevices = 0;
   HIP_CHECK(hipGetDeviceCount(&numDevices));
@@ -484,8 +484,7 @@ TEST_CASE("Unit_hipDrvMemcpy3DAsync_H2DDeviceContextChange", "[multigpu]") {
  *  - HIP_VERSION >= 6.0
  */
 
-TEST_CASE("Unit_hipDrvMemcpy3DAsync_Host2ArrayDeviceContextChange",
-          "[multigpu]") {
+TEST_CASE(Unit_hipDrvMemcpy3DAsync_Host2ArrayDeviceContextChange) {
   CHECK_IMAGE_SUPPORT
   int numDevices = 0;
   HIP_CHECK(hipGetDeviceCount(&numDevices));
@@ -513,8 +512,7 @@ TEST_CASE("Unit_hipDrvMemcpy3DAsync_Host2ArrayDeviceContextChange",
  *  - HIP_VERSION >= 6.0
  */
 
-TEST_CASE("Unit_hipDrvMemcpy3DAsync_multiDevice_Basic_Size_Test",
-          "[multigpu]") {
+TEST_CASE(Unit_hipDrvMemcpy3DAsync_multiDevice_Basic_Size_Test) {
   CHECK_IMAGE_SUPPORT
   constexpr int size_128b = 128, size_256b = 256;
   int numDevices = 0;

--- a/projects/hip-tests/catch/unit/memory/hipDrvMemcpy3D_old.cc
+++ b/projects/hip-tests/catch/unit/memory/hipDrvMemcpy3D_old.cc
@@ -440,7 +440,7 @@ template <typename T> void DrvMemcpy3D<T>::DeAllocateMemory() {
  *  - HIP_VERSION >= 6.0
  */
 
-TEMPLATE_TEST_CASE("Unit_hipDrvMemcpy3D_MultipleDataTypes", "", uint8_t, int, float) {
+TEMPLATE_TEST_CASE(Unit_hipDrvMemcpy3D_MultipleDataTypes, uint8_t, int, float) {
   CHECK_IMAGE_SUPPORT
   for (int i = 1; i < 25; i++) {
     if (std::is_same<TestType, float>::value) {
@@ -468,7 +468,7 @@ TEMPLATE_TEST_CASE("Unit_hipDrvMemcpy3D_MultipleDataTypes", "", uint8_t, int, fl
  *  - HIP_VERSION >= 6.0
  */
 
-TEST_CASE("Unit_hipDrvMemcpy3D_HosttoDevice") {
+TEST_CASE(Unit_hipDrvMemcpy3D_HosttoDevice) {
   CHECK_IMAGE_SUPPORT
   DrvMemcpy3D<float> memcpy3d_D2H_float(10, 10, 1, HIP_AD_FORMAT_FLOAT);
   memcpy3d_D2H_float.HostDevice_DrvMemcpy3D();
@@ -487,7 +487,7 @@ TEST_CASE("Unit_hipDrvMemcpy3D_HosttoDevice") {
  *  - HIP_VERSION >= 6.0
  */
 
-TEST_CASE("Unit_hipDrvMemcpy3D_Negative") {
+TEST_CASE(Unit_hipDrvMemcpy3D_Negative) {
   DrvMemcpy3D<float> memcpy3d(10, 10, 1, HIP_AD_FORMAT_FLOAT);
   memcpy3d.NegativeTests();
 }
@@ -505,7 +505,7 @@ TEST_CASE("Unit_hipDrvMemcpy3D_Negative") {
  *  - HIP_VERSION >= 6.0
  */
 
-TEST_CASE("Unit_hipDrvMemcpy3D_ExtentValidation") {
+TEST_CASE(Unit_hipDrvMemcpy3D_ExtentValidation) {
   CHECK_IMAGE_SUPPORT
   DrvMemcpy3D<float> memcpy3d(10, 10, 1, HIP_AD_FORMAT_FLOAT);
   memcpy3d.Extent_Validation();
@@ -524,7 +524,7 @@ TEST_CASE("Unit_hipDrvMemcpy3D_ExtentValidation") {
  *  - HIP_VERSION >= 6.0
  */
 
-TEST_CASE("Unit_hipDrvMemcpy3D_H2DDeviceContextChange", "[multigpu]") {
+TEST_CASE(Unit_hipDrvMemcpy3D_H2DDeviceContextChange) {
   CHECK_IMAGE_SUPPORT
   int numDevices = 0;
   HIP_CHECK(hipGetDeviceCount(&numDevices));
@@ -549,7 +549,7 @@ TEST_CASE("Unit_hipDrvMemcpy3D_H2DDeviceContextChange", "[multigpu]") {
  *  - HIP_VERSION >= 6.0
  */
 
-TEST_CASE("Unit_hipDrvMemcpy3D_Host2ArrayDeviceContextChange", "[multigpu]") {
+TEST_CASE(Unit_hipDrvMemcpy3D_Host2ArrayDeviceContextChange) {
   CHECK_IMAGE_SUPPORT
   int numDevices = 0;
   HIP_CHECK(hipGetDeviceCount(&numDevices));
@@ -577,7 +577,7 @@ TEST_CASE("Unit_hipDrvMemcpy3D_Host2ArrayDeviceContextChange", "[multigpu]") {
  *  - HIP_VERSION >= 6.0
  */
 
-TEST_CASE("Unit_hipDrvMemcpy3D_multiDevice_Basic_Size_Test", "[multigpu]") {
+TEST_CASE(Unit_hipDrvMemcpy3D_multiDevice_Basic_Size_Test) {
   CHECK_IMAGE_SUPPORT
   constexpr int size_128b = 128, size_256b = 256;
   int numDevices = 0;

--- a/projects/hip-tests/catch/unit/memory/hipDrvPtrGetAttributes.cc
+++ b/projects/hip-tests/catch/unit/memory/hipDrvPtrGetAttributes.cc
@@ -42,7 +42,7 @@ constexpr size_t N{1000000};
 
 /* This testcase verifies Negative Scenarios of
  * hipDrvPointerGetAttributes API */
-TEST_CASE("Unit_hipDrvPtrGetAttributes_Negative") {
+TEST_CASE(Unit_hipDrvPtrGetAttributes_Negative) {
   HIP_CHECK(hipSetDevice(0));
   Nbytes = N * sizeof(int);
   int deviceId;
@@ -97,7 +97,7 @@ TEST_CASE("Unit_hipDrvPtrGetAttributes_Negative") {
 }
 
 // Testcase verifies functional scenarios of hipDrvPointerGetAttributes API
-TEST_CASE("Unit_hipDrvPtrGetAttributes_Functional") {
+TEST_CASE(Unit_hipDrvPtrGetAttributes_Functional) {
   HIP_CHECK(hipSetDevice(0));
   Nbytes = N * sizeof(int);
   int deviceId;

--- a/projects/hip-tests/catch/unit/memory/hipExtMallocWithFlags.cc
+++ b/projects/hip-tests/catch/unit/memory/hipExtMallocWithFlags.cc
@@ -24,7 +24,7 @@ THE SOFTWARE.
 #include <hip/hip_runtime_api.h>
 #include <utils.hh>
 
-TEST_CASE("Unit_hipExtMallocWithFlags_Positive_Basic") {
+TEST_CASE(Unit_hipExtMallocWithFlags_Positive_Basic) {
   void* ptr = nullptr;
 
   SECTION("hipDeviceMallocDefault") {
@@ -56,14 +56,14 @@ TEST_CASE("Unit_hipExtMallocWithFlags_Positive_Basic") {
   }
 }
 
-TEST_CASE("Unit_hipExtMallocWithFlags_Positive_Zero_Size") {
+TEST_CASE(Unit_hipExtMallocWithFlags_Positive_Zero_Size) {
   void* ptr = reinterpret_cast<void*>(0x1);
   const auto flag = GENERATE(hipDeviceMallocDefault, hipDeviceMallocFinegrained);
   HIP_CHECK(hipExtMallocWithFlags(&ptr, 0, flag));
   REQUIRE(ptr == nullptr);
 }
 
-TEST_CASE("Unit_hipExtMallocWithFlags_Positive_Alignment") {
+TEST_CASE(Unit_hipExtMallocWithFlags_Positive_Alignment) {
   void *ptr1 = nullptr, *ptr2 = nullptr;
   const auto flag = GENERATE(hipDeviceMallocDefault, hipDeviceMallocFinegrained);
   if (flag == hipDeviceMallocFinegrained &&
@@ -79,7 +79,7 @@ TEST_CASE("Unit_hipExtMallocWithFlags_Positive_Alignment") {
   HIP_CHECK(hipFree(ptr2));
 }
 
-TEST_CASE("Unit_hipExtMallocWithFlags_Negative_Parameters") {
+TEST_CASE(Unit_hipExtMallocWithFlags_Negative_Parameters) {
   SECTION("Invalid flags") {
     void* ptr = nullptr;
     HIP_CHECK_ERROR(

--- a/projects/hip-tests/catch/unit/memory/hipFree.cc
+++ b/projects/hip-tests/catch/unit/memory/hipFree.cc
@@ -48,7 +48,7 @@ enum class FreeType { DevFree, ArrayFree, ArrayDestroy, HostFree };
 using namespace std::chrono_literals;
 constexpr size_t numAllocs = 10;
 
-TEST_CASE("Unit_hipFreeImplicitSyncDev") {
+TEST_CASE(Unit_hipFreeImplicitSyncDev) {
   int* devPtr{};
   size_t size_mult = GENERATE(1, 32, 64, 128, 256);
   HIP_CHECK(hipMalloc(&devPtr, sizeof(*devPtr) * size_mult));
@@ -65,7 +65,7 @@ TEST_CASE("Unit_hipFreeImplicitSyncDev") {
   HIP_CHECK(hipStreamQuery(nullptr));
 }
 
-TEST_CASE("Unit_hipFreeImplicitSyncHost") {
+TEST_CASE(Unit_hipFreeImplicitSyncHost) {
   int* hostPtr{};
   size_t size_mult = GENERATE(1, 32, 64, 128, 256);
 
@@ -84,7 +84,7 @@ TEST_CASE("Unit_hipFreeImplicitSyncHost") {
 }
 
 #if HT_NVIDIA
-TEMPLATE_TEST_CASE("Unit_hipFreeImplicitSyncArray", "", char, float, float2, float4) {
+TEMPLATE_TEST_CASE(Unit_hipFreeImplicitSyncArray, char, float, float2, float4) {
   CHECK_IMAGE_SUPPORT
 
   using vec_info = vector_info<TestType>;
@@ -124,7 +124,7 @@ TEMPLATE_TEST_CASE("Unit_hipFreeImplicitSyncArray", "", char, float, float2, flo
 }
 #else  // AMD
 
-TEMPLATE_TEST_CASE("Unit_hipFreeImplicitSyncArray", "", char, float, float2, float4) {
+TEMPLATE_TEST_CASE(Unit_hipFreeImplicitSyncArray, char, float, float2, float4) {
   CHECK_IMAGE_SUPPORT
 
   hipArray_t arrayPtr{};
@@ -156,7 +156,7 @@ TEMPLATE_TEST_CASE("Unit_hipFreeImplicitSyncArray", "", char, float, float2, flo
 #endif
 
 // Freeing a invalid pointer with on device
-TEST_CASE("Unit_hipFreeNegativeDev") {
+TEST_CASE(Unit_hipFreeNegativeDev) {
   SECTION("InvalidPtr") {
     char value;
     HIP_CHECK_ERROR(hipFree(&value), hipErrorInvalidValue);
@@ -165,7 +165,7 @@ TEST_CASE("Unit_hipFreeNegativeDev") {
 }
 
 // Freeing a invalid pointer with on host
-TEST_CASE("Unit_hipFreeNegativeHost") {
+TEST_CASE(Unit_hipFreeNegativeHost) {
   SECTION("NullPtr") { HIP_CHECK(hipHostFree(nullptr)); }
   SECTION("InvalidPtr") {
     char hostPtr;
@@ -193,7 +193,7 @@ TEST_CASE("Unit_hipFreeNegativeHost") {
 }
 
 #if HT_NVIDIA
-TEST_CASE("Unit_hipFreeNegativeArray") {
+TEST_CASE(Unit_hipFreeNegativeArray) {
   DriverContext ctx;
 
   SECTION("ArrayFree") { HIP_CHECK(hipFreeArray(nullptr)); }
@@ -204,14 +204,14 @@ TEST_CASE("Unit_hipFreeNegativeArray") {
 #else
 
 // Freeing a invalid pointer with array
-TEST_CASE("Unit_hipFreeNegativeArray") {
+TEST_CASE(Unit_hipFreeNegativeArray) {
   SECTION("ArrayFree") { HIP_CHECK_ERROR(hipFreeArray(nullptr), hipErrorInvalidValue); }
   SECTION("ArrayDestroy") { HIP_CHECK_ERROR(hipArrayDestroy(nullptr), hipErrorInvalidValue); }
 }
 
 #endif
 
-TEST_CASE("Unit_hipFreeDoubleDevice") {
+TEST_CASE(Unit_hipFreeDoubleDevice) {
   size_t width = GENERATE(32, 512, 1024);
   char* ptr{};
   size_t size_mult = width;
@@ -221,7 +221,7 @@ TEST_CASE("Unit_hipFreeDoubleDevice") {
   HIP_CHECK_ERROR(hipFree(ptr), hipErrorInvalidValue);
 }
 
-TEST_CASE("Unit_hipFreeDoubleHost") {
+TEST_CASE(Unit_hipFreeDoubleHost) {
   size_t width = GENERATE(32, 512, 1024);
   char* ptr{};
   size_t size_mult = width;
@@ -233,7 +233,7 @@ TEST_CASE("Unit_hipFreeDoubleHost") {
 }
 
 #if HT_NVIDIA
-TEST_CASE("Unit_hipFreeDoubleArrayFree") {
+TEST_CASE(Unit_hipFreeDoubleArrayFree) {
   HipTest::HIP_SKIP_TEST("EXSWCPHIPT-120");
   return;
 
@@ -251,7 +251,7 @@ TEST_CASE("Unit_hipFreeDoubleArrayFree") {
   HIP_CHECK_ERROR(hipFreeArray(arrayPtr), hipErrorContextIsDestroyed);
 }
 
-TEST_CASE("Unit_hipFreeDoubleArrayDestroy") {
+TEST_CASE(Unit_hipFreeDoubleArrayDestroy) {
   HipTest::HIP_SKIP_TEST("EXSWCPHIPT-120");
   return;
   using vec_info = vector_info<char>;
@@ -273,7 +273,7 @@ TEST_CASE("Unit_hipFreeDoubleArrayDestroy") {
 
 #else  // AMD
 
-TEST_CASE("Unit_hipFreeDoubleArray") {
+TEST_CASE(Unit_hipFreeDoubleArray) {
   CHECK_IMAGE_SUPPORT
 
   size_t width = GENERATE(32, 512, 1024);
@@ -299,7 +299,7 @@ TEST_CASE("Unit_hipFreeDoubleArray") {
 #endif
 
 
-TEMPLATE_TEST_CASE("Unit_hipFreeMultiTDev", "", char, int, float2, float4) {
+TEMPLATE_TEST_CASE(Unit_hipFreeMultiTDev, char, int, float2, float4) {
   std::vector<TestType*> ptrs(numAllocs);
   size_t allocSize = sizeof(TestType) * GENERATE(1, 32, 64, 128);
 
@@ -322,7 +322,7 @@ TEMPLATE_TEST_CASE("Unit_hipFreeMultiTDev", "", char, int, float2, float4) {
   HIP_CHECK_THREAD_FINALIZE();
 }
 
-TEMPLATE_TEST_CASE("Unit_hipFreeMultiTHost", "", char, int, float2, float4) {
+TEMPLATE_TEST_CASE(Unit_hipFreeMultiTHost, char, int, float2, float4) {
   std::vector<TestType*> ptrs(numAllocs);
   size_t allocSize = sizeof(TestType) * GENERATE(1, 32, 64, 128);
 
@@ -346,7 +346,7 @@ TEMPLATE_TEST_CASE("Unit_hipFreeMultiTHost", "", char, int, float2, float4) {
 }
 
 #if HT_NVIDIA
-TEMPLATE_TEST_CASE("Unit_hipFreeMultiTArray", "", char, int, float2, float4) {
+TEMPLATE_TEST_CASE(Unit_hipFreeMultiTArray, char, int, float2, float4) {
   using vec_info = vector_info<TestType>;
 
   size_t width = GENERATE(32, 128, 256, 512, 1024);
@@ -406,7 +406,7 @@ TEMPLATE_TEST_CASE("Unit_hipFreeMultiTArray", "", char, int, float2, float4) {
 }
 #else
 
-TEMPLATE_TEST_CASE("Unit_hipFreeMultiTArray", "", char, int, float2, float4) {
+TEMPLATE_TEST_CASE(Unit_hipFreeMultiTArray, char, int, float2, float4) {
   CHECK_IMAGE_SUPPORT
 
   using vec_info = vector_info<TestType>;

--- a/projects/hip-tests/catch/unit/memory/hipFreeArray.cc
+++ b/projects/hip-tests/catch/unit/memory/hipFreeArray.cc
@@ -29,7 +29,7 @@ hipFreeArray API test scenarios
 #include <hip_array_common.hh>
 
 
-TEMPLATE_TEST_CASE("Unit_hipFreeArray_DifferentSizes", "", uchar2, char, ushort, short, short4,
+TEMPLATE_TEST_CASE(Unit_hipFreeArray_DifferentSizes, uchar2, char, ushort, short, short4,
                    uint, int, int4, float, float4) {
   CHECK_IMAGE_SUPPORT
 
@@ -46,7 +46,7 @@ TEMPLATE_TEST_CASE("Unit_hipFreeArray_DifferentSizes", "", uchar2, char, ushort,
   HIP_CHECK(hipFreeArray(arrayPtr));
 }
 
-TEST_CASE("Unit_hipFreeArray_NegativeArray") {
+TEST_CASE(Unit_hipFreeArray_NegativeArray) {
 #if HT_NVIDIA
   HIP_CHECK(hipFreeArray(nullptr));
 #else
@@ -54,7 +54,7 @@ TEST_CASE("Unit_hipFreeArray_NegativeArray") {
 #endif
 }
 
-TEST_CASE("Unit_hipFreeArray_DoubleFree") {
+TEST_CASE(Unit_hipFreeArray_DoubleFree) {
 #if HT_NVIDIA
   HipTest::HIP_SKIP_TEST("EXSWCPHIPT-120");
   return;
@@ -83,7 +83,7 @@ TEST_CASE("Unit_hipFreeArray_DoubleFree") {
  *    arrays of different types and size and then call hipFreeArray for each array
  */
 
-TEMPLATE_TEST_CASE("Unit_hipFreeArray_MultiThreaded", "", char, int, float2, float4) {
+TEMPLATE_TEST_CASE(Unit_hipFreeArray_MultiThreaded, char, int, float2, float4) {
   CHECK_IMAGE_SUPPORT
 
   constexpr size_t arr_size = 1024;

--- a/projects/hip-tests/catch/unit/memory/hipFreeAsync.cc
+++ b/projects/hip-tests/catch/unit/memory/hipFreeAsync.cc
@@ -48,7 +48,7 @@ THE SOFTWARE.
  * ------------------------
  *  - HIP_VERSION >= 6.0
  */
-TEST_CASE("Unit_hipFreeAsync_Negative_Parameters") {
+TEST_CASE(Unit_hipFreeAsync_Negative_Parameters) {
   int device_id = 0;
   HIP_CHECK(hipSetDevice(device_id));
 
@@ -86,7 +86,7 @@ TEST_CASE("Unit_hipFreeAsync_Negative_Parameters") {
  * ------------------------
  *  - HIP_VERSION >= 6.0
  */
-TEST_CASE("Unit_hipFreeAsync_capturehipFreeAsync") {
+TEST_CASE(Unit_hipFreeAsync_capturehipFreeAsync) {
   HIP_CHECK(hipSetDevice(0));
   hipGraph_t graph{nullptr};
   hipGraphExec_t graphExec{nullptr};

--- a/projects/hip-tests/catch/unit/memory/hipFreeHost.cc
+++ b/projects/hip-tests/catch/unit/memory/hipFreeHost.cc
@@ -34,7 +34,7 @@ THE SOFTWARE.
  * ------------------------
  *  - HIP_VERSION >= 6.0
  */
-TEST_CASE("Unit_hipFreeHost_InvalidMemory") {
+TEST_CASE(Unit_hipFreeHost_InvalidMemory) {
   SECTION("Nullptr") { HIP_CHECK(hipFreeHost(nullptr)); }
 
   SECTION("Invalid ptr") {
@@ -76,7 +76,7 @@ TEST_CASE("Unit_hipFreeHost_InvalidMemory") {
  * ------------------------
  *  - HIP_VERSION >= 6.0
  */
-TEST_CASE("Unit_hipFreeHost_DoubleFree") {
+TEST_CASE(Unit_hipFreeHost_DoubleFree) {
   void* ptr = NULL;
   size_t ptr_size = 1024;
 
@@ -96,7 +96,7 @@ TEST_CASE("Unit_hipFreeHost_DoubleFree") {
  * ------------------------
  *  - HIP_VERSION >= 6.0
  */
-TEST_CASE("Unit_hipFreeHost_Multithreading") {
+TEST_CASE(Unit_hipFreeHost_Multithreading) {
   std::vector<unsigned long*> ptrs(10);
   size_t ptr_size = 1024;
 
@@ -119,7 +119,7 @@ TEST_CASE("Unit_hipFreeHost_Multithreading") {
   HIP_CHECK_THREAD_FINALIZE();
 }
 
-TEST_CASE("Unit_hipFreeHost_Capture_negative") {
+TEST_CASE(Unit_hipFreeHost_Capture_negative) {
   void* ptr = nullptr;
   constexpr size_t kPtrSize = 1024;
 

--- a/projects/hip-tests/catch/unit/memory/hipFreeMipmappedArray.cc
+++ b/projects/hip-tests/catch/unit/memory/hipFreeMipmappedArray.cc
@@ -36,7 +36,7 @@ THE SOFTWARE.
  * 4. Call hipFreeMipmappedArray twice on the same pointer and check that the implementation handles
  * the second call correctly.
  */
-TEMPLATE_TEST_CASE("Unit_hipFreeMipmappedArrayImplicitSyncArray", "", char, float) {
+TEMPLATE_TEST_CASE(Unit_hipFreeMipmappedArrayImplicitSyncArray, char, float) {
   hipMipmappedArray_t arrayPtr{};
   hipExtent extent{};
   hipChannelFormatDesc desc = hipCreateChannelDesc<TestType>();
@@ -84,7 +84,7 @@ TEMPLATE_TEST_CASE("Unit_hipFreeMipmappedArrayImplicitSyncArray", "", char, floa
   }
 }
 
-TEST_CASE("Unit_hipFreeMipmappedArray_Negative_Nullptr") {
+TEST_CASE(Unit_hipFreeMipmappedArray_Negative_Nullptr) {
 #if HT_AMD
   HIP_CHECK_ERROR(hipFreeMipmappedArray(nullptr), hipErrorInvalidValue);
 #else
@@ -92,7 +92,7 @@ TEST_CASE("Unit_hipFreeMipmappedArray_Negative_Nullptr") {
 #endif
 }
 
-TEMPLATE_TEST_CASE("Unit_hipFreeMipmappedArrayMultiTArray", "", char, int) {
+TEMPLATE_TEST_CASE(Unit_hipFreeMipmappedArrayMultiTArray, char, int) {
   constexpr size_t numAllocs = 10;
   std::vector<std::thread> threads;
   std::vector<hipMipmappedArray_t> ptrs(numAllocs);

--- a/projects/hip-tests/catch/unit/memory/hipGetProcAddressMemoryApis.cc
+++ b/projects/hip-tests/catch/unit/memory/hipGetProcAddressMemoryApis.cc
@@ -37,7 +37,7 @@ THE SOFTWARE.
  * ------------------------
  *  - HIP_VERSION >= 6.2
  */
-TEST_CASE("Unit_hipGetProcAddress_MemoryApisMallocFree") {
+TEST_CASE(Unit_hipGetProcAddress_MemoryApisMallocFree) {
   void* hipMalloc_ptr = nullptr;
   void* hipFree_ptr = nullptr;
   void* hipExtMallocWithFlags_ptr = nullptr;
@@ -353,7 +353,7 @@ TEST_CASE("Unit_hipGetProcAddress_MemoryApisMallocFree") {
  * ------------------------
  *  - HIP_VERSION >= 6.2
  */
-TEST_CASE("Unit_hipGetProcAddress_MemoryApisRegisterUnReg") {
+TEST_CASE(Unit_hipGetProcAddress_MemoryApisRegisterUnReg) {
   void* hipHostRegister_ptr = nullptr;
   void* hipHostUnregister_ptr = nullptr;
 
@@ -408,7 +408,7 @@ TEST_CASE("Unit_hipGetProcAddress_MemoryApisRegisterUnReg") {
  * ------------------------
  *  - HIP_VERSION >= 6.2
  */
-TEST_CASE("Unit_hipGetProcAddress_MemoryApisArrayRelated") {
+TEST_CASE(Unit_hipGetProcAddress_MemoryApisArrayRelated) {
   CHECK_IMAGE_SUPPORT
 
   void* hipMallocArray_ptr = nullptr;
@@ -830,7 +830,7 @@ TEST_CASE("Unit_hipGetProcAddress_MemoryApisArrayRelated") {
  * ------------------------
  *  - HIP_VERSION >= 6.2
  */
-TEST_CASE("Unit_hipGetProcAddress_MemoryApisSetAndGetAttributes") {
+TEST_CASE(Unit_hipGetProcAddress_MemoryApisSetAndGetAttributes) {
   void* hipPointerGetAttribute_ptr = nullptr;
   void* hipPointerGetAttributes_ptr = nullptr;
   void* hipDrvPointerGetAttributes_ptr = nullptr;
@@ -1184,7 +1184,7 @@ TEST_CASE("Unit_hipGetProcAddress_MemoryApisSetAndGetAttributes") {
  * ------------------------
  *  - HIP_VERSION >= 6.2
  */
-TEST_CASE("Unit_hipGetProcAddress_MemoryApisMemCopy") {
+TEST_CASE(Unit_hipGetProcAddress_MemoryApisMemCopy) {
   void* hipMemcpyHtoD_ptr = nullptr;
   void* hipMemcpyDtoH_ptr = nullptr;
   void* hipMemcpyDtoD_ptr = nullptr;
@@ -1414,7 +1414,7 @@ TEST_CASE("Unit_hipGetProcAddress_MemoryApisMemCopy") {
  * ------------------------
  *  - HIP_VERSION >= 6.2
  */
-TEST_CASE("Unit_hipGetProcAddress_MemoryApisMemCopyWithStreams") {
+TEST_CASE(Unit_hipGetProcAddress_MemoryApisMemCopyWithStreams) {
   void* hipMemcpyHtoDAsync_ptr = nullptr;
   void* hipMemcpyDtoHAsync_ptr = nullptr;
   void* hipMemcpyDtoDAsync_ptr = nullptr;
@@ -2192,7 +2192,7 @@ TEST_CASE("Unit_hipGetProcAddress_MemoryApisMemCopyWithStreams") {
  * ------------------------
  *  - HIP_VERSION >= 6.2
  */
-TEST_CASE("Unit_hipGetProcAddress_MemoryApisMemset") {
+TEST_CASE(Unit_hipGetProcAddress_MemoryApisMemset) {
   void* hipMemsetD8_ptr = nullptr;
   void* hipMemsetD16_ptr = nullptr;
   void* hipMemsetD32_ptr = nullptr;
@@ -2485,7 +2485,7 @@ TEST_CASE("Unit_hipGetProcAddress_MemoryApisMemset") {
  * ------------------------
  *  - HIP_VERSION >= 6.2
  */
-TEST_CASE("Unit_hipGetProcAddress_MemoryApisMemset2D3D") {
+TEST_CASE(Unit_hipGetProcAddress_MemoryApisMemset2D3D) {
   CHECK_IMAGE_SUPPORT
 
   void* hipMemset2D_ptr = nullptr;
@@ -2663,7 +2663,7 @@ TEST_CASE("Unit_hipGetProcAddress_MemoryApisMemset2D3D") {
  * ------------------------
  *  - HIP_VERSION >= 6.2
  */
-TEST_CASE("Unit_hipGetProcAddress_MemoryApisGetMemInfoRelated") {
+TEST_CASE(Unit_hipGetProcAddress_MemoryApisGetMemInfoRelated) {
   void* hipMemGetInfo_ptr = nullptr;
   void* hipMemPtrGetInfo_ptr = nullptr;
 
@@ -2714,7 +2714,7 @@ TEST_CASE("Unit_hipGetProcAddress_MemoryApisGetMemInfoRelated") {
  * ------------------------
  *  - HIP_VERSION >= 6.2
  */
-TEST_CASE("Unit_hipGetProcAddress_MemoryApisMemcpy2DRelated", "[multigpu]") {
+TEST_CASE(Unit_hipGetProcAddress_MemoryApisMemcpy2DRelated) {
   CHECK_IMAGE_SUPPORT
 
   void* hipMemcpy2D_ptr = nullptr;
@@ -4491,7 +4491,7 @@ TEST_CASE("Unit_hipGetProcAddress_MemoryApisMemcpy2DRelated", "[multigpu]") {
  * ------------------------
  *  - HIP_VERSION >= 6.2
  */
-TEST_CASE("Unit_hipGetProcAddress_MemoryApisMemcpy3DRelated") {
+TEST_CASE(Unit_hipGetProcAddress_MemoryApisMemcpy3DRelated) {
   CHECK_IMAGE_SUPPORT
 
   void* hipMemcpy3D_ptr = nullptr;
@@ -5347,7 +5347,7 @@ TEST_CASE("Unit_hipGetProcAddress_MemoryApisMemcpy3DRelated") {
  * ------------------------
  *  - HIP_VERSION >= 6.2
  */
-TEST_CASE("Unit_hipGetProcAddress_MemoryApisAddressRelated") {
+TEST_CASE(Unit_hipGetProcAddress_MemoryApisAddressRelated) {
   int currentHipVersion = 0;
   HIP_CHECK(hipRuntimeGetVersion(&currentHipVersion));
 
@@ -5389,7 +5389,7 @@ TEST_CASE("Unit_hipGetProcAddress_MemoryApisAddressRelated") {
  * ------------------------
  *  - HIP_VERSION >= 6.2
  */
-TEST_CASE("Unit_hipGetProcAddress_MemoryApisManagedMemory") {
+TEST_CASE(Unit_hipGetProcAddress_MemoryApisManagedMemory) {
   if (HmmAttrPrint() != 1) {
     HipTest::HIP_SKIP_TEST("Skipping test since managed memory not supported");
     return;
@@ -5678,7 +5678,7 @@ TEST_CASE("Unit_hipGetProcAddress_MemoryApisManagedMemory") {
  * ------------------------
  *  - HIP_VERSION >= 6.2
  */
-TEST_CASE("Unit_hipGetProcAddress_MemoryApisStreamOrderedMemory") {
+TEST_CASE(Unit_hipGetProcAddress_MemoryApisStreamOrderedMemory) {
   HIP_CHECK(hipSetDevice(0));
   int mem_pool_support = 0;
 
@@ -6024,7 +6024,7 @@ TEST_CASE("Unit_hipGetProcAddress_MemoryApisStreamOrderedMemory") {
  * ------------------------
  *  - HIP_VERSION >= 6.2
  */
-TEST_CASE("Unit_hipGetProcAddress_MemoryApisPeerToPeer", "[multigpu]") {
+TEST_CASE(Unit_hipGetProcAddress_MemoryApisPeerToPeer) {
   int deviceCount = 0;
   HIP_CHECK(hipGetDeviceCount(&deviceCount));
 

--- a/projects/hip-tests/catch/unit/memory/hipGetSymbolSizeAddress.cc
+++ b/projects/hip-tests/catch/unit/memory/hipGetSymbolSizeAddress.cc
@@ -87,14 +87,14 @@ static void HipGetSymbolSizeAddressTest(const void* symbol) {
   HipGetSymbolSizeAddressTest<type, kArraySize, type##_arr_address_validation_kernel>(             \
       SYMBOL(type##_arr));
 
-TEST_CASE("Unit_hipGetSymbolSizeAddress_Positive_Basic") {
+TEST_CASE(Unit_hipGetSymbolSizeAddress_Positive_Basic) {
   SECTION("int") { HIP_GET_SYMBOL_SIZE_ADDRESS_TEST(int); }
   SECTION("float") { HIP_GET_SYMBOL_SIZE_ADDRESS_TEST(float); }
   SECTION("char") { HIP_GET_SYMBOL_SIZE_ADDRESS_TEST(char); }
   SECTION("double") { HIP_GET_SYMBOL_SIZE_ADDRESS_TEST(double); }
 }
 
-TEST_CASE("Unit_hipGetSymbolAddress_Negative_Parameters") {
+TEST_CASE(Unit_hipGetSymbolAddress_Negative_Parameters) {
 // Causes a segfault in CUDA
 #if HT_AMD
   SECTION("devPtr == nullptr") {
@@ -108,7 +108,7 @@ TEST_CASE("Unit_hipGetSymbolAddress_Negative_Parameters") {
   }
 }
 
-TEST_CASE("Unit_hipGetSymbolSize_Negative_Parameters") {
+TEST_CASE(Unit_hipGetSymbolSize_Negative_Parameters) {
 // Causes a segfault in CUDA
 #if HT_AMD
   SECTION("size == nullptr") {

--- a/projects/hip-tests/catch/unit/memory/hipHostAlloc.cc
+++ b/projects/hip-tests/catch/unit/memory/hipHostAlloc.cc
@@ -103,7 +103,7 @@ int get_flags() {
                   hipHostMallocPortable | hipHostMallocMapped | hipHostMallocWriteCombined);
 }
 
-TEST_CASE("Unit_hipHostAlloc_Positive") {
+TEST_CASE(Unit_hipHostAlloc_Positive) {
   int* host_memory = nullptr;
   int flags = get_flags();
 
@@ -114,7 +114,7 @@ TEST_CASE("Unit_hipHostAlloc_Positive") {
   HIP_CHECK(hipFreeHost(host_memory));
 }
 
-TEST_CASE("Unit_hipHostAlloc_DataValidation") {
+TEST_CASE(Unit_hipHostAlloc_DataValidation) {
   int validation_number = 10;
   int* host_memory = nullptr;
   int* device_memory = nullptr;
@@ -145,7 +145,7 @@ TEST_CASE("Unit_hipHostAlloc_DataValidation") {
   HIP_CHECK(hipFreeHost(host_memory));
 }
 
-TEST_CASE("Unit_hipHostAlloc_Negative") {
+TEST_CASE(Unit_hipHostAlloc_Negative) {
   int* host_memory = nullptr;
   int flags = get_flags();
 
@@ -179,7 +179,7 @@ TEST_CASE("Unit_hipHostAlloc_Negative") {
  * ------------------------
  *  - HIP_VERSION >= 6.3
  */
-TEST_CASE("Unit_hipHostAlloc_Basic") {
+TEST_CASE(Unit_hipHostAlloc_Basic) {
   static constexpr auto LEN{1024 * 1024};
   static constexpr auto SIZE{LEN * sizeof(float)};
 
@@ -237,7 +237,7 @@ TEST_CASE("Unit_hipHostAlloc_Basic") {
  * using different synchronization techniquies
  * validates the result.
  */
-TEST_CASE("Unit_hipHostAlloc_Default") {
+TEST_CASE(Unit_hipHostAlloc_Default) {
   int* A = nullptr;
   HIP_CHECK(hipHostAlloc(reinterpret_cast<void**>(&A), SIZEBYTES, hipHostMallocDefault));
   std::string kPtrType{"default"};
@@ -262,7 +262,7 @@ TEST_CASE("Unit_hipHostAlloc_Default") {
  *  - HIP_VERSION >= 6.3
  */
 #if HT_AMD
-TEST_CASE("Unit_hipHostAlloc_Negative_NonCoherent") {
+TEST_CASE(Unit_hipHostAlloc_Negative_NonCoherent) {
   int* A = nullptr;
   REQUIRE(hipHostAlloc(reinterpret_cast<void**>(&A), SIZEBYTES, hipHostMallocNonCoherent) ==
           hipErrorInvalidValue);
@@ -285,7 +285,7 @@ TEST_CASE("Unit_hipHostAlloc_Negative_NonCoherent") {
  *  - HIP_VERSION >= 6.3
  */
 #if HT_AMD
-TEST_CASE("Unit_hipHostAlloc_Negative_Coherent") {
+TEST_CASE(Unit_hipHostAlloc_Negative_Coherent) {
   int* A = nullptr;
   REQUIRE(hipHostAlloc(reinterpret_cast<void**>(&A), SIZEBYTES, hipHostMallocCoherent) ==
           hipErrorInvalidValue);
@@ -308,7 +308,7 @@ TEST_CASE("Unit_hipHostAlloc_Negative_Coherent") {
  *  - HIP_VERSION >= 6.3
  */
 #if HT_AMD
-TEST_CASE("Unit_hipHostAlloc_Negative_NumaUser") {
+TEST_CASE(Unit_hipHostAlloc_Negative_NumaUser) {
   int* A = nullptr;
   REQUIRE(hipHostAlloc(reinterpret_cast<void**>(&A), SIZEBYTES, hipHostMallocNumaUser) ==
           hipErrorInvalidValue);
@@ -329,7 +329,7 @@ TEST_CASE("Unit_hipHostAlloc_Negative_NumaUser") {
  * ------------------------
  *  - HIP_VERSION >= 6.3
  */
-TEST_CASE("Unit_hipHostAlloc_AllocateMoreThanTotalSystemMemory") {
+TEST_CASE(Unit_hipHostAlloc_AllocateMoreThanTotalSystemMemory) {
   char* host_ptr = nullptr;
   const size_t total_ram_mb = HipTest::getTotalSystemMemoryInMB();
   if (total_ram_mb == 0) {
@@ -361,7 +361,7 @@ TEST_CASE("Unit_hipHostAlloc_AllocateMoreThanTotalSystemMemory") {
  * ------------------------
  *  - HIP_VERSION >= 6.3
  */
-TEST_CASE("Unit_hipHostAlloc_ArgValidation") {
+TEST_CASE(Unit_hipHostAlloc_ArgValidation) {
   constexpr size_t allocSize = 1000;
   char* ptr;
 
@@ -382,7 +382,7 @@ TEST_CASE("Unit_hipHostAlloc_ArgValidation") {
   }
 }
 
-TEST_CASE("Unit_hipHostAlloc_Capture") {
+TEST_CASE(Unit_hipHostAlloc_Capture) {
   int* host_memory = nullptr;
   int flags = get_flags();
 

--- a/projects/hip-tests/catch/unit/memory/hipHostFree.cc
+++ b/projects/hip-tests/catch/unit/memory/hipHostFree.cc
@@ -33,7 +33,7 @@ THE SOFTWARE.
  * ------------------------
  *  - HIP_VERSION >= 6.0
  */
-TEST_CASE("Unit_hipHostFree_InvalidMemory") {
+TEST_CASE(Unit_hipHostFree_InvalidMemory) {
   SECTION("Nullptr") { HIP_CHECK(hipHostFree(nullptr)); }
 
   SECTION("Invalid ptr") {
@@ -76,7 +76,7 @@ TEST_CASE("Unit_hipHostFree_InvalidMemory") {
  * ------------------------
  *  - HIP_VERSION >= 6.0
  */
-TEST_CASE("Unit_hipHostFree_DoubleFree") {
+TEST_CASE(Unit_hipHostFree_DoubleFree) {
   void* ptr = NULL;
   size_t ptr_size = 1024;
 
@@ -96,7 +96,7 @@ TEST_CASE("Unit_hipHostFree_DoubleFree") {
  * ------------------------
  *  - HIP_VERSION >= 6.0
  */
-TEST_CASE("Unit_hipHostFree_Multithreading") {
+TEST_CASE(Unit_hipHostFree_Multithreading) {
   std::vector<unsigned long*> ptrs(10);
   size_t ptr_size = 1024;
 
@@ -119,7 +119,7 @@ TEST_CASE("Unit_hipHostFree_Multithreading") {
   HIP_CHECK_THREAD_FINALIZE();
 }
 
-TEST_CASE("Unit_hipHostFree_Capture") {
+TEST_CASE(Unit_hipHostFree_Capture) {
   void* host_ptr = nullptr;
   constexpr size_t kAllocSize = 1024;
   HIP_CHECK(hipHostMalloc(&host_ptr, kAllocSize));

--- a/projects/hip-tests/catch/unit/memory/hipHostGetDevicePointer.cc
+++ b/projects/hip-tests/catch/unit/memory/hipHostGetDevicePointer.cc
@@ -23,7 +23,7 @@ THE SOFTWARE.
 #include <hip_test_common.hh>
 #include <utils.hh>
 
-TEST_CASE("Unit_hipHostGetDevicePointer_Negative") {
+TEST_CASE(Unit_hipHostGetDevicePointer_Negative) {
   int* hPtr{nullptr};
   int* dPtr{nullptr};
   HIP_CHECK(hipHostMalloc(&hPtr, sizeof(int)));
@@ -61,7 +61,7 @@ TEST_CASE("Unit_hipHostGetDevicePointer_Negative") {
 
 template <typename T> __global__ void set(T* ptr, T val) { *ptr = val; }
 
-TEST_CASE("Unit_hipHostGetDevicePointer_UseCase") {
+TEST_CASE(Unit_hipHostGetDevicePointer_UseCase) {
   if (!DeviceAttributesSupport(0, hipDeviceAttributeCanMapHostMemory)) {
     HipTest::HIP_SKIP_TEST("Device does not support mapping host memory");
     return;
@@ -101,7 +101,7 @@ TEST_CASE("Unit_hipHostGetDevicePointer_UseCase") {
   HIP_CHECK(hipHostFree(hPtr));
 }
 
-TEST_CASE("Unit_hipHostGetDevicePointer_Capture") {
+TEST_CASE(Unit_hipHostGetDevicePointer_Capture) {
   if (!DeviceAttributesSupport(0, hipDeviceAttributeCanMapHostMemory)) {
     HipTest::HIP_SKIP_TEST("Device does not support mapping host memory");
     return;

--- a/projects/hip-tests/catch/unit/memory/hipHostGetFlags.cc
+++ b/projects/hip-tests/catch/unit/memory/hipHostGetFlags.cc
@@ -85,7 +85,7 @@ inline void checkFlags(unsigned int expected, unsigned int obtained) {
   REQUIRE(expected == obtained);
 }
 
-TEST_CASE("Unit_hipHostGetFlags_flagCombos") {
+TEST_CASE(Unit_hipHostGetFlags_flagCombos) {
   constexpr auto SIZE{LEN * sizeof(int)};
   int* A_h{nullptr};
 
@@ -118,7 +118,7 @@ TEST_CASE("Unit_hipHostGetFlags_flagCombos") {
 }
 
 // Test Allocation with flags and getting flags in another thread
-TEST_CASE("Unit_hipHostGetFlags_DifferentThreads") {
+TEST_CASE(Unit_hipHostGetFlags_DifferentThreads) {
   constexpr auto SIZE{LEN * sizeof(int)};
   int* A_h{nullptr};
 
@@ -151,7 +151,7 @@ TEST_CASE("Unit_hipHostGetFlags_DifferentThreads") {
 }
 
 // Test behaviour of hipHostGetFlags with invalid args
-TEST_CASE("Unit_hipHostGetFlags_InvalidArgs") {
+TEST_CASE(Unit_hipHostGetFlags_InvalidArgs) {
   constexpr auto SIZE{LEN * sizeof(int)};
   int* A_h{nullptr};
 
@@ -221,7 +221,7 @@ TEST_CASE("Unit_hipHostGetFlags_InvalidArgs") {
   }
 }
 
-TEST_CASE("Unit_hipHostGetFlags_Capture") {
+TEST_CASE(Unit_hipHostGetFlags_Capture) {
   unsigned int host_flags = 0;
   void* host_ptr = nullptr;
   constexpr size_t kAllocSize = 1024;

--- a/projects/hip-tests/catch/unit/memory/hipHostMalloc.cc
+++ b/projects/hip-tests/catch/unit/memory/hipHostMalloc.cc
@@ -109,7 +109,7 @@ Allocates the memory using hipHostMalloc API
 Launches the kernel and performs vector addition.
 validates thes result.
 */
-TEST_CASE("Unit_hipHostMalloc_Basic") {
+TEST_CASE(Unit_hipHostMalloc_Basic) {
   static constexpr auto LEN{1024 * 1024};
   static constexpr auto SIZE{LEN * sizeof(float)};
 
@@ -163,7 +163,7 @@ TEST_CASE("Unit_hipHostMalloc_Basic") {
 This testcase verifies the hipHostMalloc API by passing nullptr
 to the pointer variable
 */
-TEST_CASE("Unit_hipHostMalloc_Negative") {
+TEST_CASE(Unit_hipHostMalloc_Negative) {
 #if HT_AMD
   {
     // Stimulate error condition:
@@ -182,7 +182,7 @@ This testcase verifies the hipHostMalloc API by
    techniquies
 3. validates the result.
 */
-TEST_CASE("Unit_hipHostMalloc_NonCoherent") {
+TEST_CASE(Unit_hipHostMalloc_NonCoherent) {
   int* A = nullptr;
   HIP_CHECK(hipHostMalloc(reinterpret_cast<void**>(&A), sizeBytes, hipHostMallocNonCoherent));
   const char* ptrType = "non-coherent";
@@ -200,7 +200,7 @@ This testcase verifies the hipHostMalloc API by
    techniquies
 3. validates the result.
 */
-TEST_CASE("Unit_hipHostMalloc_Coherent") {
+TEST_CASE(Unit_hipHostMalloc_Coherent) {
   int* A = nullptr;
   if (hipHostMalloc(reinterpret_cast<void**>(&A), sizeBytes, hipHostMallocCoherent) == hipSuccess) {
     const char* ptrType = "coherent";
@@ -226,7 +226,7 @@ This testcase verifies the hipHostMalloc API by
    techniquies
 3. validates the result.
 */
-TEST_CASE("Unit_hipHostMalloc_Default") {
+TEST_CASE(Unit_hipHostMalloc_Default) {
   int* A = nullptr;
   HIP_CHECK(hipHostMalloc(reinterpret_cast<void**>(&A), sizeBytes));
   const char* ptrType = "default";
@@ -240,7 +240,7 @@ TEST_CASE("Unit_hipHostMalloc_Default") {
 This testcase verifies the hipHostMalloc API by
 1. Allocating more memory than total system RAM. Should return hipErrorOutOfMemory.
 */
-TEST_CASE("Unit_hipHostMalloc_AllocateMoreThanTotalSystemMemory") {
+TEST_CASE(Unit_hipHostMalloc_AllocateMoreThanTotalSystemMemory) {
   char* host_ptr = nullptr;
   const size_t total_ram_mb = HipTest::getTotalSystemMemoryInMB();
   if (total_ram_mb == 0) {
@@ -255,7 +255,7 @@ TEST_CASE("Unit_hipHostMalloc_AllocateMoreThanTotalSystemMemory") {
   REQUIRE(host_ptr == nullptr);
 }
 
-TEST_CASE("Unit_hipHostMalloc_Capture") {
+TEST_CASE(Unit_hipHostMalloc_Capture) {
   int* host_ptr = nullptr;
   hipError_t capture_error = hipSuccess;
 

--- a/projects/hip-tests/catch/unit/memory/hipHostMallocTests.cc
+++ b/projects/hip-tests/catch/unit/memory/hipHostMallocTests.cc
@@ -34,7 +34,7 @@ Testcase Scenarios :
 /**
  * Performs argument validation of hipHostMalloc api.
  */
-TEST_CASE("Unit_hipHostMalloc_ArgValidation") {
+TEST_CASE(Unit_hipHostMalloc_ArgValidation) {
 #if HT_NVIDIA
   HipTest::HIP_SKIP_TEST("TODO: Need to debug");
 #endif

--- a/projects/hip-tests/catch/unit/memory/hipHostRegister.cc
+++ b/projects/hip-tests/catch/unit/memory/hipHostRegister.cc
@@ -110,7 +110,7 @@ void doMemCopy(size_t numElements, int offset, T* A, T* Bh, T* Bd, bool internal
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_hipHostRegister_ReferenceFromKernelandhipMemset") {
+TEST_CASE(Unit_hipHostRegister_ReferenceFromKernelandhipMemset) {
   size_t sizeBytes{LEN * sizeof(int)};
   int *A, **Ad;
   int num_devices = 0;
@@ -176,7 +176,7 @@ TEST_CASE("Unit_hipHostRegister_ReferenceFromKernelandhipMemset") {
  * ------------------------
  *    - HIP_VERSION >= 5.6
  */
-TEST_CASE("Unit_hipHostRegister_DirectReferenceFromKernel") {
+TEST_CASE(Unit_hipHostRegister_DirectReferenceFromKernel) {
   auto flags = GENERATE(hipHostRegisterDefault, hipHostRegisterPortable, hipHostRegisterMapped);
   size_t sizeBytes{LEN * sizeof(int)};
   int* A;
@@ -214,7 +214,7 @@ TEST_CASE("Unit_hipHostRegister_DirectReferenceFromKernel") {
  * ------------------------
  *    - HIP_VERSION >= 5.6
  */
-TEST_CASE("Unit_hipHostRegister_DirectReferenceMultGpu") {
+TEST_CASE(Unit_hipHostRegister_DirectReferenceMultGpu) {
   // 1 refers to doing hipHostRegister once for all devices
   // 0 refers to doing hipHostRegister for each device
   auto register_once = GENERATE(0, 1);
@@ -269,7 +269,7 @@ TEST_CASE("Unit_hipHostRegister_DirectReferenceMultGpu") {
  * ------------------------
  *    - HIP_VERSION >= 5.6
  */
-TEST_CASE("Unit_hipHostRegister_SameChunkRepeat") {
+TEST_CASE(Unit_hipHostRegister_SameChunkRepeat) {
   size_t sizeBytes{LEN * sizeof(uint8_t)};
   uint8_t* A;
   A = reinterpret_cast<uint8_t*>(malloc(sizeBytes));
@@ -306,7 +306,7 @@ TEST_CASE("Unit_hipHostRegister_SameChunkRepeat") {
  * ------------------------
  *    - HIP_VERSION >= 5.6
  */
-TEST_CASE("Unit_hipHostRegister_Chunks_SingleAttempt") {
+TEST_CASE(Unit_hipHostRegister_Chunks_SingleAttempt) {
   size_t sizeBytes{LARGE_CHUNK_LEN * sizeof(uint8_t)};
   size_t sizeBytesChunk{SMALL_CHUNK_LEN * sizeof(uint8_t)};
   uint8_t* A;
@@ -352,7 +352,7 @@ TEST_CASE("Unit_hipHostRegister_Chunks_SingleAttempt") {
  * ------------------------
  *    - HIP_VERSION >= 5.6
  */
-TEST_CASE("Unit_hipHostRegister_Chunks_RoundRobin") {
+TEST_CASE(Unit_hipHostRegister_Chunks_RoundRobin) {
   size_t sizeBytes{LARGE_CHUNK_LEN * sizeof(int)};
   size_t sizeBytesChunk{SMALL_CHUNK_LEN * sizeof(int)};
   int* A;
@@ -390,7 +390,7 @@ TEST_CASE("Unit_hipHostRegister_Chunks_RoundRobin") {
  * ------------------------
  *    - HIP_VERSION >= 5.6
  */
-TEST_CASE("Unit_hipHostRegister_Perform_hipMemset") {
+TEST_CASE(Unit_hipHostRegister_Perform_hipMemset) {
   size_t sizeBytes{LEN * sizeof(uint8_t)};
   uint8_t* A;
   uint8_t* dPtr = nullptr;
@@ -424,7 +424,7 @@ TEST_CASE("Unit_hipHostRegister_Perform_hipMemset") {
  * ------------------------
  *    - HIP_VERSION >= 5.6
  */
-TEST_CASE("Unit_hipHostRegister_Perform_hipMemcpy") {
+TEST_CASE(Unit_hipHostRegister_Perform_hipMemcpy) {
   size_t sizeBytes{LEN * sizeof(uint8_t)};
   uint8_t *A, *B, *dPtr;
   A = reinterpret_cast<uint8_t*>(malloc(sizeBytes));
@@ -464,7 +464,7 @@ TEST_CASE("Unit_hipHostRegister_Perform_hipMemcpy") {
  * ------------------------
  *    - HIP_VERSION >= 5.6
  */
-TEST_CASE("Unit_hipHostRegister_AsyncApis") {
+TEST_CASE(Unit_hipHostRegister_AsyncApis) {
   size_t sizeBytes{LEN * sizeof(uint32_t)};
   uint32_t *A, *B, *dPtr;
   A = reinterpret_cast<uint32_t*>(malloc(sizeBytes));
@@ -506,7 +506,7 @@ TEST_CASE("Unit_hipHostRegister_AsyncApis") {
  * ------------------------
  *    - HIP_VERSION >= 5.6
  */
-TEST_CASE("Unit_hipHostRegister_Graphs") {
+TEST_CASE(Unit_hipHostRegister_Graphs) {
   size_t sizeBytes{LEN * sizeof(uint32_t)};
   uint32_t *A, *B, *dPtr;
   A = reinterpret_cast<uint32_t*>(malloc(sizeBytes));
@@ -574,7 +574,7 @@ TEST_CASE("Unit_hipHostRegister_Graphs") {
  * ------------------------
  *    - HIP_VERSION >= 5.6
  */
-TEST_CASE("Unit_hipHostRegister_MemAdvise_SetGet") {
+TEST_CASE(Unit_hipHostRegister_MemAdvise_SetGet) {
   hipDeviceProp_t prop;
   HIP_CHECK(hipGetDeviceProperties(&prop, 0));
   if (prop.concurrentManagedAccess == 0) {
@@ -643,7 +643,7 @@ TEST_CASE("Unit_hipHostRegister_MemAdvise_SetGet") {
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_hipHostRegister_Memcpy") {
+TEST_CASE(Unit_hipHostRegister_Memcpy) {
   // 1 refers to hipHostRegister
   // 0 refers to malloc
   auto mem_type = GENERATE(0, 1);
@@ -687,7 +687,7 @@ TEST_CASE("Unit_hipHostRegister_Memcpy") {
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_hipHostRegister_Flags") {
+TEST_CASE(Unit_hipHostRegister_Flags) {
   size_t sizeBytes = 1 * sizeof(int);
   int* hostPtr = reinterpret_cast<int*>(malloc(sizeBytes));
 
@@ -737,7 +737,7 @@ TEST_CASE("Unit_hipHostRegister_Flags") {
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_hipHostRegister_Negative") {
+TEST_CASE(Unit_hipHostRegister_Negative) {
   int* hostPtr = nullptr;
 
   size_t sizeBytes = 1 * sizeof(int);
@@ -772,7 +772,7 @@ TEST_CASE("Unit_hipHostRegister_Negative") {
   }
 }
 
-TEST_CASE("Unit_hipHostRegister_Capture") {
+TEST_CASE(Unit_hipHostRegister_Capture) {
   constexpr size_t kBufferSize = 1024;
   auto buffer = std::make_unique<int[]>(kBufferSize);
   hipError_t capture_error = hipSuccess;

--- a/projects/hip-tests/catch/unit/memory/hipHostUnregister.cc
+++ b/projects/hip-tests/catch/unit/memory/hipHostUnregister.cc
@@ -45,7 +45,7 @@ inline bool hipHostRegisterSupported() {
 }
 
 
-TEST_CASE("Unit_hipHostUnregister_MemoryNotAccessableAfterUnregister") {
+TEST_CASE(Unit_hipHostUnregister_MemoryNotAccessableAfterUnregister) {
   if (!hipHostRegisterSupported()) {
     return;
   }
@@ -64,23 +64,23 @@ TEST_CASE("Unit_hipHostUnregister_MemoryNotAccessableAfterUnregister") {
   }
 }
 
-TEST_CASE("Unit_hipHostUnregister_NullPtr") {
+TEST_CASE(Unit_hipHostUnregister_NullPtr) {
   HIP_CHECK_ERROR(hipHostUnregister(nullptr), hipErrorInvalidValue);
 }
 
-TEST_CASE("Unit_hipHostUnregister_Ptr_Different_Than_Specified_To_Register") {
+TEST_CASE(Unit_hipHostUnregister_Ptr_Different_Than_Specified_To_Register) {
   std::vector<int> alloc(2);
   HIP_CHECK(hipHostRegister(alloc.data(), alloc.size(), 0));
   HIP_CHECK_ERROR(hipHostUnregister(&alloc.data()[1]), hipErrorHostMemoryNotRegistered);
   HIP_CHECK(hipHostUnregister(alloc.data()));
 }
 
-TEST_CASE("Unit_hipHostUnregister_NotRegisteredPointer") {
+TEST_CASE(Unit_hipHostUnregister_NotRegisteredPointer) {
   auto x = std::unique_ptr<int>(new int);
   HIP_CHECK_ERROR(hipHostUnregister(x.get()), hipErrorHostMemoryNotRegistered);
 }
 
-TEST_CASE("Unit_hipHostUnregister_AlreadyUnregisteredPointer") {
+TEST_CASE(Unit_hipHostUnregister_AlreadyUnregisteredPointer) {
   if (!hipHostRegisterSupported()) {
     return;
   }
@@ -95,7 +95,7 @@ TEST_CASE("Unit_hipHostUnregister_AlreadyUnregisteredPointer") {
   }
 }
 
-TEST_CASE("Unit_hipHostUnregister_Capture") {
+TEST_CASE(Unit_hipHostUnregister_Capture) {
   constexpr size_t kBufferSize = 1024;
   auto buffer = std::make_unique<int[]>(kBufferSize);
   hipError_t capture_error = hipSuccess;

--- a/projects/hip-tests/catch/unit/memory/hipMalloc.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMalloc.cc
@@ -36,7 +36,7 @@ THE SOFTWARE.
 
 static constexpr size_t ONE_MB = 1024 * 1024;
 
-TEST_CASE("Unit_hipMalloc_Positive_Basic") {
+TEST_CASE(Unit_hipMalloc_Positive_Basic) {
   constexpr size_t page_size = 4096;
   void* ptr = nullptr;
   const auto alloc_size =
@@ -47,13 +47,13 @@ TEST_CASE("Unit_hipMalloc_Positive_Basic") {
   HIP_CHECK(hipFree(ptr));
 }
 
-TEST_CASE("Unit_hipMalloc_Positive_Zero_Size") {
+TEST_CASE(Unit_hipMalloc_Positive_Zero_Size) {
   void* ptr = reinterpret_cast<void*>(0x1);
   HIP_CHECK(hipMalloc(&ptr, 0));
   REQUIRE(ptr == nullptr);
 }
 
-TEST_CASE("Unit_hipMalloc_Positive_Alignment") {
+TEST_CASE(Unit_hipMalloc_Positive_Alignment) {
   void *ptr1 = nullptr, *ptr2 = nullptr;
   HIP_CHECK(hipMalloc(&ptr1, 1));
   HIP_CHECK(hipMalloc(&ptr2, 10));
@@ -63,7 +63,7 @@ TEST_CASE("Unit_hipMalloc_Positive_Alignment") {
   HIP_CHECK(hipFree(ptr2));
 }
 
-TEST_CASE("Unit_hipMalloc_Negative_Parameters") {
+TEST_CASE(Unit_hipMalloc_Negative_Parameters) {
   SECTION("ptr == nullptr") { HIP_CHECK_ERROR(hipMalloc(nullptr, 4096), hipErrorInvalidValue); }
   SECTION("size == max size_t") {
     void* ptr;
@@ -153,7 +153,7 @@ static void performOperations(char* devMem, size_t size) {
  * ------------------------
  * - unit/memory/hipMalloc.cc
  */
-TEST_CASE("Unit_hipMalloc_Allocate90PercentOfDeviceMemory") {
+TEST_CASE(Unit_hipMalloc_Allocate90PercentOfDeviceMemory) {
   char* devMem = nullptr;
   size_t freeVRAM = 0, totalVRAM = 0;
   HIP_CHECK(hipMemGetInfo(&freeVRAM, &totalVRAM));
@@ -193,7 +193,7 @@ TEST_CASE("Unit_hipMalloc_Allocate90PercentOfDeviceMemory") {
  * ------------------------
  * - HIP_VERSION >= 6.4
  */
-TEST_CASE("Unit_hipMalloc_Allocate110PercentOfDeviceMemory") {
+TEST_CASE(Unit_hipMalloc_Allocate110PercentOfDeviceMemory) {
   char *devMem = nullptr;
   size_t freeVRAM = 0, totalVRAM = 0;
   HIP_CHECK(hipMemGetInfo(&freeVRAM, &totalVRAM));
@@ -266,7 +266,7 @@ TEST_CASE("Unit_hipMalloc_Allocate110PercentOfDeviceMemory") {
  * ------------------------
  * - HIP_VERSION >= 6.4
  */
-TEST_CASE("Unit_hipMalloc_AllocateAvailableVRAMAndPossibleRAM") {
+TEST_CASE(Unit_hipMalloc_AllocateAvailableVRAMAndPossibleRAM) {
   char *devMem = nullptr;
   size_t freeVRAM = 0, totalVRAM = 0;
   HIP_CHECK(hipMemGetInfo(&freeVRAM, &totalVRAM));
@@ -327,7 +327,7 @@ TEST_CASE("Unit_hipMalloc_AllocateAvailableVRAMAndPossibleRAM") {
  * ------------------------
  * - HIP_VERSION >= 6.4
  */
-TEST_CASE("Unit_hipMalloc_AllocateMoreThanTotalRAM") {
+TEST_CASE(Unit_hipMalloc_AllocateMoreThanTotalRAM) {
   char *devMem = nullptr;
 
   size_t totalRAM = getTotalRAM();
@@ -356,7 +356,7 @@ TEST_CASE("Unit_hipMalloc_AllocateMoreThanTotalRAM") {
  * ------------------------
  * - HIP_VERSION >= 6.4
  */
-TEST_CASE("Unit_hipMalloc_AllocateMoreThanTotalVRAM") {
+TEST_CASE(Unit_hipMalloc_AllocateMoreThanTotalVRAM) {
   char *devMem = nullptr;
 
   size_t freeVRAM = 0, totalVRAM = 0;

--- a/projects/hip-tests/catch/unit/memory/hipMalloc3D.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMalloc3D.cc
@@ -67,7 +67,7 @@ static void Malloc3DThreadFunc(int gpu) { MemoryAlloc3DDiffSizes(gpu); }
  * allocation whose combined size goes over PalSettings::subAllocationChunkSize_;
  * hipMemGetInfo() should indicate the memory went down after we hipFree() all of them
  */
-TEST_CASE("Unit_hipMalloc3D_Basic") {
+TEST_CASE(Unit_hipMalloc3D_Basic) {
   CHECK_IMAGE_SUPPORT
 
   static constexpr int ChunkSize = 64;  // (in megabytes)
@@ -116,7 +116,7 @@ TEST_CASE("Unit_hipMalloc3D_Basic") {
 This testcase verifies the hipMalloc3D API by allocating
 smaller and big chunk data.
 */
-TEST_CASE("Unit_hipMalloc3D_SmallandBigChunks") {
+TEST_CASE(Unit_hipMalloc3D_SmallandBigChunks) {
   CHECK_IMAGE_SUPPORT
 
   MemoryAlloc3DDiffSizes(0);
@@ -127,7 +127,7 @@ This testcase verifies the hipMalloc3D API in multithreaded
 scenario by launching threads in parallel on multiple GPUs
 and verifies the hipMalloc3D API with small and big chunks data
 */
-TEST_CASE("Unit_hipMalloc3D_MultiThread", "[multigpu]") {
+TEST_CASE(Unit_hipMalloc3D_MultiThread) {
   CHECK_IMAGE_SUPPORT
 
   std::vector<std::thread> threadlist;

--- a/projects/hip-tests/catch/unit/memory/hipMalloc3DArray.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMalloc3DArray.cc
@@ -66,7 +66,7 @@ static void Malloc3DArray_DiffSizes(int gpu) {
   }
 }
 
-TEST_CASE("Unit_hipMalloc3DArray_DiffSizes") {
+TEST_CASE(Unit_hipMalloc3DArray_DiffSizes) {
   CHECK_IMAGE_SUPPORT
 
   Malloc3DArray_DiffSizes(0);
@@ -78,7 +78,7 @@ This testcase verifies the hipMalloc3DArray API in multithreaded
 scenario by launching threads in parallel on multiple GPUs
 and verifies the hipMalloc3DArray API with small and big chunks data
 */
-TEST_CASE("Unit_hipMalloc3DArray_MultiThread", "[multigpu]") {
+TEST_CASE(Unit_hipMalloc3DArray_MultiThread) {
   CHECK_IMAGE_SUPPORT
 
   std::vector<std::thread> threadlist;
@@ -124,7 +124,7 @@ void checkArrayIsExpected(hipArray_t array, const hipChannelFormatDesc& expected
 }
 }  // namespace
 
-TEMPLATE_TEST_CASE("Unit_hipMalloc3DArray_happy", "", char, uchar2, uint2, int4, short4, float,
+TEMPLATE_TEST_CASE(Unit_hipMalloc3DArray_happy, char, uchar2, uint2, int4, short4, float,
                    float2, float4) {
   CHECK_IMAGE_SUPPORT
 
@@ -155,7 +155,7 @@ TEMPLATE_TEST_CASE("Unit_hipMalloc3DArray_happy", "", char, uchar2, uint2, int4,
   }
 }
 
-TEMPLATE_TEST_CASE("Unit_hipMalloc3DArray_MaxTexture", "", int, uint4, short, ushort2,
+TEMPLATE_TEST_CASE(Unit_hipMalloc3DArray_MaxTexture, int, uint4, short, ushort2,
                    unsigned char, float, float4) {
   CHECK_IMAGE_SUPPORT
 
@@ -248,7 +248,7 @@ hipExtent makeExtent(unsigned int flag, size_t s) {
 
 
 // Providing the array pointer as nullptr should return an error
-TEST_CASE("Unit_hipMalloc3DArray_Negative_NullArrayPtr") {
+TEST_CASE(Unit_hipMalloc3DArray_Negative_NullArrayPtr) {
   CHECK_IMAGE_SUPPORT
 
   hipChannelFormatDesc desc = hipCreateChannelDesc<float4>();
@@ -260,7 +260,7 @@ TEST_CASE("Unit_hipMalloc3DArray_Negative_NullArrayPtr") {
 }
 
 // Providing the description pointer as nullptr should return an error
-TEST_CASE("Unit_hipMalloc3DArray_Negative_NullDescPtr") {
+TEST_CASE(Unit_hipMalloc3DArray_Negative_NullDescPtr) {
   CHECK_IMAGE_SUPPORT
 
   constexpr size_t s = 6;  // 6 to keep cubemap happy
@@ -273,7 +273,7 @@ TEST_CASE("Unit_hipMalloc3DArray_Negative_NullDescPtr") {
 }
 
 // Zero width arrays are not allowed
-TEST_CASE("Unit_hipMalloc3DArray_Negative_ZeroWidth") {
+TEST_CASE(Unit_hipMalloc3DArray_Negative_ZeroWidth) {
   CHECK_IMAGE_SUPPORT
 
   constexpr size_t s = 6;  // 6 to keep cubemap happy
@@ -287,7 +287,7 @@ TEST_CASE("Unit_hipMalloc3DArray_Negative_ZeroWidth") {
 }
 
 // Zero height arrays are only allowed for 1D arrays and layered arrays
-TEST_CASE("Unit_hipMalloc3DArray_Negative_ZeroHeight") {
+TEST_CASE(Unit_hipMalloc3DArray_Negative_ZeroHeight) {
   CHECK_IMAGE_SUPPORT
 
   constexpr size_t s = 6;  // 6 to keep cubemap happy
@@ -305,7 +305,7 @@ TEST_CASE("Unit_hipMalloc3DArray_Negative_ZeroHeight") {
   }
 }
 
-TEST_CASE("Unit_hipMalloc3DArray_Negative_InvalidFlags") {
+TEST_CASE(Unit_hipMalloc3DArray_Negative_InvalidFlags) {
   CHECK_IMAGE_SUPPORT
 
   constexpr size_t s = 6;  // 6 to keep cubemap happy
@@ -342,7 +342,7 @@ void testInvalidDescription(hipChannelFormatDesc desc) {
   HIP_CHECK_ERROR(hipMalloc3DArray(&array, &desc, makeExtent(flag, s), flag), expectedError);
 }
 
-TEST_CASE("Unit_hipMalloc3DArray_Negative_InvalidFormat") {
+TEST_CASE(Unit_hipMalloc3DArray_Negative_InvalidFormat) {
   CHECK_IMAGE_SUPPORT
 
   hipChannelFormatDesc desc = hipCreateChannelDesc<float4>();
@@ -350,7 +350,7 @@ TEST_CASE("Unit_hipMalloc3DArray_Negative_InvalidFormat") {
   testInvalidDescription(desc);
 }
 
-TEST_CASE("Unit_hipMalloc3DArray_Negative_BadChannelLayout") {
+TEST_CASE(Unit_hipMalloc3DArray_Negative_BadChannelLayout) {
   CHECK_IMAGE_SUPPORT
 
   const int bits = GENERATE(8, 16, 32);
@@ -373,7 +373,7 @@ TEST_CASE("Unit_hipMalloc3DArray_Negative_BadChannelLayout") {
   testInvalidDescription(desc);
 }
 
-TEST_CASE("Unit_hipMalloc3DArray_Negative_8BitFloat") {
+TEST_CASE(Unit_hipMalloc3DArray_Negative_8BitFloat) {
   CHECK_IMAGE_SUPPORT
 
   hipChannelFormatDesc desc = GENERATE(hipCreateChannelDesc(8, 0, 0, 0, hipChannelFormatKindFloat),
@@ -383,7 +383,7 @@ TEST_CASE("Unit_hipMalloc3DArray_Negative_8BitFloat") {
   testInvalidDescription(desc);
 }
 
-TEST_CASE("Unit_hipMalloc3DArray_Negative_DifferentChannelSizes") {
+TEST_CASE(Unit_hipMalloc3DArray_Negative_DifferentChannelSizes) {
   CHECK_IMAGE_SUPPORT
 
   const int bitsX = GENERATE(8, 16, 32);
@@ -408,7 +408,7 @@ TEST_CASE("Unit_hipMalloc3DArray_Negative_DifferentChannelSizes") {
   testInvalidDescription(desc);
 }
 
-TEST_CASE("Unit_hipMalloc3DArray_Negative_BadChannelSize") {
+TEST_CASE(Unit_hipMalloc3DArray_Negative_BadChannelSize) {
   CHECK_IMAGE_SUPPORT
 
   const int badBits = GENERATE(-1, 0, 10, 100);
@@ -423,7 +423,7 @@ TEST_CASE("Unit_hipMalloc3DArray_Negative_BadChannelSize") {
 
 
 // hipMalloc3DArray should handle the max numeric value gracefully.
-TEST_CASE("Unit_hipMalloc3DArray_Negative_NumericLimit") {
+TEST_CASE(Unit_hipMalloc3DArray_Negative_NumericLimit) {
   CHECK_IMAGE_SUPPORT
 
   hipArray_t arrayPtr;
@@ -436,7 +436,7 @@ TEST_CASE("Unit_hipMalloc3DArray_Negative_NumericLimit") {
 }
 
 // texture gather arrays are only allowed to be 2D
-TEMPLATE_TEST_CASE("Unit_hipMalloc3DArray_Negative_Non2DTextureGather", "", char, uchar2, short4,
+TEMPLATE_TEST_CASE(Unit_hipMalloc3DArray_Negative_Non2DTextureGather, char, uchar2, short4,
                    float2, float4) {
 #if HT_AMD
   HipTest::HIP_SKIP_TEST("Texture Gather arrays not supported using AMD backend");

--- a/projects/hip-tests/catch/unit/memory/hipMallocArray.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMallocArray.cc
@@ -68,7 +68,7 @@ static void MallocArray_DiffSizes(int gpu) {
   }
 }
 
-TEST_CASE("Unit_hipMallocArray_DiffSizes") {
+TEST_CASE(Unit_hipMallocArray_DiffSizes) {
   CHECK_IMAGE_SUPPORT
 
   MallocArray_DiffSizes(0);
@@ -80,7 +80,7 @@ This testcase verifies the hipMallocArray API in multithreaded
 scenario by launching threads in parallel on multiple GPUs
 and verifies the hipMallocArray API with small and big chunks data
 */
-TEST_CASE("Unit_hipMallocArray_MultiThread", "[multigpu]") {
+TEST_CASE(Unit_hipMallocArray_MultiThread) {
   CHECK_IMAGE_SUPPORT
 
   std::vector<std::thread> threadlist;
@@ -376,7 +376,7 @@ void testArrayAsSurface(hipArray_t arrayPtr, const size_t width, const size_t he
 
 // The happy path of a default array and a SurfaceLoadStore array should work
 // Selection of types chosen to reduce compile times
-TEMPLATE_TEST_CASE("Unit_hipMallocArray_happy", "", uint, int, int4, ushort, short2, char, uchar2,
+TEMPLATE_TEST_CASE(Unit_hipMallocArray_happy, uint, int, int4, ushort, short2, char, uchar2,
                    char4, float, float2, float4) {
   CHECK_IMAGE_SUPPORT
 
@@ -431,7 +431,7 @@ TEMPLATE_TEST_CASE("Unit_hipMallocArray_happy", "", uint, int, int4, ushort, sho
 
 // Arrays can be up to the size of maxTexture* but no bigger
 // EXSWCPHIPT-71 - no equivalent value for maxSurface and maxTexture2DGather.
-TEMPLATE_TEST_CASE("Unit_hipMallocArray_MaxTexture_Default", "", uint, int4, ushort, short2, char,
+TEMPLATE_TEST_CASE(Unit_hipMallocArray_MaxTexture_Default, uint, int4, ushort, short2, char,
                    char4, float2, float4) {
   CHECK_IMAGE_SUPPORT
 
@@ -491,7 +491,7 @@ TEMPLATE_TEST_CASE("Unit_hipMallocArray_MaxTexture_Default", "", uint, int4, ush
 
 
 // Arrays with channels of different size are not allowed.
-TEST_CASE("Unit_hipMallocArray_Negative_DifferentChannelSizes") {
+TEST_CASE(Unit_hipMallocArray_Negative_DifferentChannelSizes) {
   CHECK_IMAGE_SUPPORT
 
   const int bitsX = GENERATE(8, 16, 32);
@@ -532,7 +532,7 @@ TEST_CASE("Unit_hipMallocArray_Negative_DifferentChannelSizes") {
 }
 
 // Zero-width array is not supported
-TEST_CASE("Unit_hipMallocArray_Negative_ZeroWidth") {
+TEST_CASE(Unit_hipMallocArray_Negative_ZeroWidth) {
   CHECK_IMAGE_SUPPORT
 
   hipChannelFormatDesc desc = hipCreateChannelDesc<float4>();
@@ -548,7 +548,7 @@ TEST_CASE("Unit_hipMallocArray_Negative_ZeroWidth") {
 }
 
 // Providing the array pointer as nullptr should return an error
-TEST_CASE("Unit_hipMallocArray_Negative_NullArrayPtr") {
+TEST_CASE(Unit_hipMallocArray_Negative_NullArrayPtr) {
   CHECK_IMAGE_SUPPORT
 
   hipChannelFormatDesc desc = hipCreateChannelDesc<float4>();
@@ -557,7 +557,7 @@ TEST_CASE("Unit_hipMallocArray_Negative_NullArrayPtr") {
 }
 
 // Providing the desc pointer as nullptr should return an error
-TEST_CASE("Unit_hipMallocArray_Negative_NullDescPtr") {
+TEST_CASE(Unit_hipMallocArray_Negative_NullDescPtr) {
   CHECK_IMAGE_SUPPORT
 
   hipArray_t arrayPtr;
@@ -566,7 +566,7 @@ TEST_CASE("Unit_hipMallocArray_Negative_NullDescPtr") {
 }
 
 // Inappropriate but related flags should still return an error
-TEST_CASE("Unit_hipMallocArray_Negative_BadFlags") {
+TEST_CASE(Unit_hipMallocArray_Negative_BadFlags) {
   CHECK_IMAGE_SUPPORT
 
   hipChannelFormatDesc desc = hipCreateChannelDesc<float4>();
@@ -594,7 +594,7 @@ TEST_CASE("Unit_hipMallocArray_Negative_BadFlags") {
 }
 
 // 8-bit float channels are not supported
-TEMPLATE_TEST_CASE("Unit_hipMallocArray_Negative_8bitFloat", "", float, float2, float4) {
+TEMPLATE_TEST_CASE(Unit_hipMallocArray_Negative_8bitFloat, float, float2, float4) {
   CHECK_IMAGE_SUPPORT
 
   hipChannelFormatDesc desc = GENERATE(hipCreateChannelDesc(8, 0, 0, 0, hipChannelFormatKindFloat),
@@ -615,7 +615,7 @@ TEMPLATE_TEST_CASE("Unit_hipMallocArray_Negative_8bitFloat", "", float, float2, 
 }
 
 // Only 8, 16, and 32 bit channels are supported
-TEST_CASE("Unit_hipMallocArray_Negative_BadNumberOfBits") {
+TEST_CASE(Unit_hipMallocArray_Negative_BadNumberOfBits) {
   CHECK_IMAGE_SUPPORT
 
   const int badBits = GENERATE(-1, 0, 10, 100);
@@ -644,7 +644,7 @@ TEST_CASE("Unit_hipMallocArray_Negative_BadNumberOfBits") {
 }
 
 // creating elements with 3 channels is not supported.
-TEST_CASE("Unit_hipMallocArray_Negative_3ChannelElement") {
+TEST_CASE(Unit_hipMallocArray_Negative_3ChannelElement) {
   CHECK_IMAGE_SUPPORT
 
   const int bits = GENERATE(8, 16, 32);
@@ -673,7 +673,7 @@ TEST_CASE("Unit_hipMallocArray_Negative_3ChannelElement") {
 }
 
 // The bit channel description should not allow any channels after a zero channel
-TEST_CASE("Unit_hipMallocArray_Negative_ChannelAfterZeroChannel") {
+TEST_CASE(Unit_hipMallocArray_Negative_ChannelAfterZeroChannel) {
   CHECK_IMAGE_SUPPORT
 
   const int bits = GENERATE(8, 16, 32);
@@ -703,7 +703,7 @@ TEST_CASE("Unit_hipMallocArray_Negative_ChannelAfterZeroChannel") {
 }
 
 // The channel format should be one of the defined formats
-TEST_CASE("Unit_hipMallocArray_Negative_InvalidChannelFormat") {
+TEST_CASE(Unit_hipMallocArray_Negative_InvalidChannelFormat) {
   CHECK_IMAGE_SUPPORT
 
   const int bits = 32;
@@ -730,7 +730,7 @@ TEST_CASE("Unit_hipMallocArray_Negative_InvalidChannelFormat") {
 
 
 // hipMallocArray should handle the max numeric value gracefully.
-TEST_CASE("Unit_hipMallocArray_Negative_NumericLimit") {
+TEST_CASE(Unit_hipMallocArray_Negative_NumericLimit) {
   CHECK_IMAGE_SUPPORT
 
   hipArray_t arrayPtr;

--- a/projects/hip-tests/catch/unit/memory/hipMallocAsync.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMallocAsync.cc
@@ -47,7 +47,7 @@ static constexpr int streamPerAsic = 2;
  * ------------------------
  *  - HIP_VERSION >= 6.2
  */
-TEST_CASE("Unit_hipMallocAsync_Basic_OneAlloc") {
+TEST_CASE(Unit_hipMallocAsync_Basic_OneAlloc) {
   MallocMemPoolAsync_OneAlloc(
       [](void** dev_ptr, size_t size, hipMemPool_t mem_pool, hipStream_t stream) {
         return hipMallocAsync(dev_ptr, size, stream);
@@ -67,7 +67,7 @@ TEST_CASE("Unit_hipMallocAsync_Basic_OneAlloc") {
  * ------------------------
  *  - HIP_VERSION >= 6.2
  */
-TEST_CASE("Unit_hipMallocAsync_Basic_TwoAllocs") {
+TEST_CASE(Unit_hipMallocAsync_Basic_TwoAllocs) {
   MallocMemPoolAsync_TwoAllocs(
       [](void** dev_ptr, size_t size, hipMemPool_t mem_pool, hipStream_t stream) {
         return hipMallocAsync(dev_ptr, size, stream);
@@ -86,7 +86,7 @@ TEST_CASE("Unit_hipMallocAsync_Basic_TwoAllocs") {
  * ------------------------
  *  - HIP_VERSION >= 6.2
  */
-TEST_CASE("Unit_hipMallocAsync_Basic_Reuse") {
+TEST_CASE(Unit_hipMallocAsync_Basic_Reuse) {
   MallocMemPoolAsync_Reuse([](void** dev_ptr, size_t size, hipMemPool_t mem_pool,
                               hipStream_t stream) { return hipMallocAsync(dev_ptr, size, stream); },
                            MemPools::dev_default);
@@ -108,7 +108,7 @@ TEST_CASE("Unit_hipMallocAsync_Basic_Reuse") {
  * ------------------------
  *  - HIP_VERSION >= 6.2
  */
-TEST_CASE("Unit_hipMallocAsync_Negative_Parameters") {
+TEST_CASE(Unit_hipMallocAsync_Negative_Parameters) {
   int device_id = 0;
   HIP_CHECK(hipSetDevice(device_id));
   checkMempoolSupported(0)
@@ -165,7 +165,7 @@ static bool checkMallocAsync(hipStream_t stream) {
  * ------------------------
  *    - HIP_VERSION >= 6.2
  */
-TEST_CASE("Unit_hipMallocAsync_basic") {
+TEST_CASE(Unit_hipMallocAsync_basic) {
   checkMempoolSupported(0);
   // create a stream
   hipStream_t stream;
@@ -187,7 +187,7 @@ TEST_CASE("Unit_hipMallocAsync_basic") {
  * ------------------------
  *    - HIP_VERSION >= 6.2
  */
-TEST_CASE("Unit_hipMallocAsync_Multistream_Concurrent") {
+TEST_CASE(Unit_hipMallocAsync_Multistream_Concurrent) {
   checkMempoolSupported(0) streamMemAllocTest testObj1(NUM_ELM), testObj2(NUM_ELM);
   // create multiple streams
   hipStream_t stream1, stream2;
@@ -234,7 +234,7 @@ TEST_CASE("Unit_hipMallocAsync_Multistream_Concurrent") {
  * ------------------------
  *    - HIP_VERSION >= 6.2
  */
-TEST_CASE("Unit_hipMallocAsync_StreamEvent_CrissCross") {
+TEST_CASE(Unit_hipMallocAsync_StreamEvent_CrissCross) {
   checkMempoolSupported(0) streamMemAllocTest testObj1(NUM_ELM), testObj2(NUM_ELM);
   // create two streams.
   hipStream_t stream1, stream2;
@@ -291,7 +291,7 @@ TEST_CASE("Unit_hipMallocAsync_StreamEvent_CrissCross") {
  * ------------------------
  *    - HIP_VERSION >= 6.2
  */
-TEST_CASE("Unit_hipMallocAsync_Multidevice", "[multigpu]") {
+TEST_CASE(Unit_hipMallocAsync_Multidevice) {
   int num_devices;
   HIP_CHECK(hipGetDeviceCount(&num_devices));
   for (int i = 0; i < num_devices; i++) {
@@ -331,7 +331,7 @@ static void threadQAsyncCommands(streamMemAllocTest* testObj, hipStream_t strm, 
   testObj->freeDevBuf(strm);
 }
 
-TEST_CASE("Unit_hipMallocAsync_Multidevice_Concurrent", "[multigpu]") {
+TEST_CASE(Unit_hipMallocAsync_Multidevice_Concurrent) {
   int num_devices;
   HIP_CHECK(hipGetDeviceCount(&num_devices));
   checkIfMultiDev(num_devices) hipStream_t* stream_buf = new hipStream_t[num_devices];
@@ -380,7 +380,7 @@ TEST_CASE("Unit_hipMallocAsync_Multidevice_Concurrent", "[multigpu]") {
  * ------------------------
  *    - HIP_VERSION >= 6.2
  */
-TEST_CASE("Unit_hipMallocAsync_Multidevice_MultiStream", "[multigpu]") {
+TEST_CASE(Unit_hipMallocAsync_Multidevice_MultiStream) {
   int num_devices;
   HIP_CHECK(hipGetDeviceCount(&num_devices));
   checkIfMultiDev(num_devices)
@@ -438,7 +438,7 @@ TEST_CASE("Unit_hipMallocAsync_Multidevice_MultiStream", "[multigpu]") {
  * ------------------------
  *    - HIP_VERSION >= 6.2
  */
-TEST_CASE("Unit_hipMallocAsync_ByUsinghipMalloc") {
+TEST_CASE(Unit_hipMallocAsync_ByUsinghipMalloc) {
   checkMempoolSupported(0) size_t byte_size = NUM_ELM * sizeof(float);
   // create a stream
   hipStream_t stream;
@@ -484,7 +484,7 @@ TEST_CASE("Unit_hipMallocAsync_ByUsinghipMalloc") {
  * ------------------------
  *    - HIP_VERSION >= 6.2
  */
-TEST_CASE("Unit_hipMallocAsync_ByUsinghipFree") {
+TEST_CASE(Unit_hipMallocAsync_ByUsinghipFree) {
   size_t byte_size = NUM_ELM * sizeof(float);
   checkMempoolSupported(0)
       // create a stream
@@ -557,7 +557,7 @@ static bool testhipMallocAsyncMThreadLocalStrm() {
   return status;
 }
 
-TEST_CASE("Unit_hipMallocAsync_MThread_ThreadLocalStream") {
+TEST_CASE(Unit_hipMallocAsync_MThread_ThreadLocalStream) {
   checkMempoolSupported(0) REQUIRE(true == testhipMallocAsyncMThreadLocalStrm());
 }
 
@@ -595,7 +595,7 @@ static bool testhipMallocAsyncMThreadLocalStrm(hipStream_t stream) {
   return status;
 }
 
-TEST_CASE("Unit_hipMallocAsync_MThread_ThreadSharedStream") {
+TEST_CASE(Unit_hipMallocAsync_MThread_ThreadSharedStream) {
   checkMempoolSupported(0) hipStream_t stream;
   HIP_CHECK(hipStreamCreate(&stream));
   REQUIRE(true == testhipMallocAsyncMThreadLocalStrm(stream));
@@ -614,7 +614,7 @@ TEST_CASE("Unit_hipMallocAsync_MThread_ThreadSharedStream") {
  * ------------------------
  *    - HIP_VERSION >= 6.2
  */
-TEST_CASE("Unit_hipMallocAsync_DefaultStreams_Concurrent") {
+TEST_CASE(Unit_hipMallocAsync_DefaultStreams_Concurrent) {
   checkMempoolSupported(0) streamMemAllocTest testObj[3] = {
       streamMemAllocTest(NUM_ELM), streamMemAllocTest(NUM_ELM), streamMemAllocTest(NUM_ELM)};
   // create multiple streams

--- a/projects/hip-tests/catch/unit/memory/hipMallocFromPoolAsync.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMallocFromPoolAsync.cc
@@ -46,7 +46,7 @@ static hipMemPool_t mem_pool_common;
  * ------------------------
  *  - HIP_VERSION >= 6.2
  */
-TEST_CASE("Unit_hipMallocFromPoolAsync_Basic_OneAlloc") {
+TEST_CASE(Unit_hipMallocFromPoolAsync_Basic_OneAlloc) {
   MallocMemPoolAsync_OneAlloc(
       [](void** dev_ptr, size_t size, hipMemPool_t mem_pool, hipStream_t stream) {
         return hipMallocFromPoolAsync(dev_ptr, size, mem_pool, stream);
@@ -67,7 +67,7 @@ TEST_CASE("Unit_hipMallocFromPoolAsync_Basic_OneAlloc") {
  * ------------------------
  *  - HIP_VERSION >= 6.2
  */
-TEST_CASE("Unit_hipMallocFromPoolAsync_Basic_TwoAllocs") {
+TEST_CASE(Unit_hipMallocFromPoolAsync_Basic_TwoAllocs) {
   MallocMemPoolAsync_TwoAllocs(
       [](void** dev_ptr, size_t size, hipMemPool_t mem_pool, hipStream_t stream) {
         return hipMallocFromPoolAsync(dev_ptr, size, mem_pool, stream);
@@ -86,7 +86,7 @@ TEST_CASE("Unit_hipMallocFromPoolAsync_Basic_TwoAllocs") {
  * ------------------------
  *  - HIP_VERSION >= 6.2
  */
-TEST_CASE("Unit_hipMallocFromPoolAsync_Basic_Reuse") {
+TEST_CASE(Unit_hipMallocFromPoolAsync_Basic_Reuse) {
   MallocMemPoolAsync_Reuse(
       [](void** dev_ptr, size_t size, hipMemPool_t mem_pool, hipStream_t stream) {
         return hipMallocFromPoolAsync(dev_ptr, size, mem_pool, stream);
@@ -110,7 +110,7 @@ TEST_CASE("Unit_hipMallocFromPoolAsync_Basic_Reuse") {
  * ------------------------
  *  - HIP_VERSION >= 6.2
  */
-TEST_CASE("Unit_hipMallocFromPoolAsync_Negative_Parameters") {
+TEST_CASE(Unit_hipMallocFromPoolAsync_Negative_Parameters) {
   int device_id = 0;
   HIP_CHECK(hipSetDevice(device_id));
 
@@ -287,7 +287,7 @@ static bool checkMaximumAndDefaultThreshold(hipStream_t stream, int N, enum eTes
  * ------------------------
  *    - HIP_VERSION >= 6.2
  */
-TEST_CASE("Unit_hipMallocFromPoolAsync_ReleaseThreshold") {
+TEST_CASE(Unit_hipMallocFromPoolAsync_ReleaseThreshold) {
   checkMempoolSupported(0)
       // create a stream
       hipStream_t stream;
@@ -308,7 +308,7 @@ TEST_CASE("Unit_hipMallocFromPoolAsync_ReleaseThreshold") {
  * ------------------------
  *    - HIP_VERSION >= 6.2
  */
-TEST_CASE("Unit_hipMallocFromPoolAsync_NullStream") {
+TEST_CASE(Unit_hipMallocFromPoolAsync_NullStream) {
   checkMempoolSupported(0) constexpr int N = 1 << 20;
   REQUIRE(true == checkMaximumAndDefaultThreshold(0, N, testdefault));
   REQUIRE(true == checkMaximumAndDefaultThreshold(0, N, testMaximum));
@@ -324,7 +324,7 @@ TEST_CASE("Unit_hipMallocFromPoolAsync_NullStream") {
  * ------------------------
  *    - HIP_VERSION >= 6.2
  */
-TEST_CASE("Unit_hipMallocFromPoolAsync_hipStreamPerThread") {
+TEST_CASE(Unit_hipMallocFromPoolAsync_hipStreamPerThread) {
   checkMempoolSupported(0) constexpr int N = 1 << 20;
   REQUIRE(true == checkMaximumAndDefaultThreshold(hipStreamPerThread, N, testdefault));
   REQUIRE(true == checkMaximumAndDefaultThreshold(hipStreamPerThread, N, testMaximum));
@@ -340,7 +340,7 @@ TEST_CASE("Unit_hipMallocFromPoolAsync_hipStreamPerThread") {
  * ------------------------
  *    - HIP_VERSION >= 6.2
  */
-TEST_CASE("Unit_hipMallocFromPoolAsync_ReleaseThreshold_Mgpu", "[multigpu]") {
+TEST_CASE(Unit_hipMallocFromPoolAsync_ReleaseThreshold_Mgpu) {
   constexpr int N = 1 << 20;
   int numDevices = 0;
   HIP_CHECK(hipGetDeviceCount(&numDevices));
@@ -575,7 +575,7 @@ static bool checkReuseAllowOtherFlags(int N, hipMemPoolAttr attr, enum eTestValu
  *    - HIP_VERSION >= 6.2
  */
 #if HT_AMD
-TEST_CASE("Unit_hipMallocFromPoolAsync_Multidevice_Concurrent", "[multigpu]") {
+TEST_CASE(Unit_hipMallocFromPoolAsync_Multidevice_Concurrent) {
   auto testType = GENERATE(testdefault, testMaximum);
   constexpr int N = 1 << 20;
   int num_devices;
@@ -627,7 +627,7 @@ TEST_CASE("Unit_hipMallocFromPoolAsync_Multidevice_Concurrent", "[multigpu]") {
  * ------------------------
  *    - HIP_VERSION >= 6.2
  */
-TEST_CASE("Unit_hipMallocFromPoolAsync_Multidevice_MultiStream", "[multigpu]") {
+TEST_CASE(Unit_hipMallocFromPoolAsync_Multidevice_MultiStream) {
   int num_devices;
   auto testType = GENERATE(testdefault, testMaximum);
   constexpr int N = 1 << 20;
@@ -694,11 +694,11 @@ TEST_CASE("Unit_hipMallocFromPoolAsync_Multidevice_MultiStream", "[multigpu]") {
  * ------------------------
  *    - HIP_VERSION >= 6.2
  */
-TEST_CASE("Unit_hipMallocFromPoolAsync_MThread_DefaultThresh") {
+TEST_CASE(Unit_hipMallocFromPoolAsync_MThread_DefaultThresh) {
   checkMempoolSupported(0) REQUIRE(true == test_hipMallocFromPoolAsync_MThread(testdefault));
 }
 
-TEST_CASE("Unit_hipMallocFromPoolAsync_MThread_MaxThresh") {
+TEST_CASE(Unit_hipMallocFromPoolAsync_MThread_MaxThresh) {
   checkMempoolSupported(0) REQUIRE(true == test_hipMallocFromPoolAsync_MThread(testMaximum));
 }
 
@@ -714,12 +714,12 @@ TEST_CASE("Unit_hipMallocFromPoolAsync_MThread_MaxThresh") {
  * ------------------------
  *    - HIP_VERSION >= 6.2
  */
-TEST_CASE("Unit_hipMallocFromPoolAsync_MThread_CommonMpool_DefaultMempool") {
+TEST_CASE(Unit_hipMallocFromPoolAsync_MThread_CommonMpool_DefaultMempool) {
   checkMempoolSupported(0)
       REQUIRE(true == test_hipMallocFromPoolAsync_MThread_CommonMpool(testdefault, true));
 }
 
-TEST_CASE("Unit_hipMallocFromPoolAsync_MThread_CommonMpool_MaxThresh") {
+TEST_CASE(Unit_hipMallocFromPoolAsync_MThread_CommonMpool_MaxThresh) {
   checkMempoolSupported(0)
       REQUIRE(true == test_hipMallocFromPoolAsync_MThread_CommonMpool(testMaximum, false));
 }
@@ -737,7 +737,7 @@ TEST_CASE("Unit_hipMallocFromPoolAsync_MThread_CommonMpool_MaxThresh") {
  * ------------------------
  *    - HIP_VERSION >= 6.2
  */
-TEST_CASE("Unit_hipMallocFromPoolAsync_MultStream_Sync") {
+TEST_CASE(Unit_hipMallocFromPoolAsync_MultStream_Sync) {
   checkMempoolSupported(0) constexpr int N = 1 << 20;
   REQUIRE(true == checkMempoolMultStreamSync(N));
 }
@@ -755,7 +755,7 @@ TEST_CASE("Unit_hipMallocFromPoolAsync_MultStream_Sync") {
  * ------------------------
  *    - HIP_VERSION >= 6.2
  */
-TEST_CASE("Unit_hipMallocFromPoolAsync_MultStream_DefaultStreams") {
+TEST_CASE(Unit_hipMallocFromPoolAsync_MultStream_DefaultStreams) {
   checkMempoolSupported(0) constexpr int N = 1 << 20;
   REQUIRE(true == checkMempoolMultStreamConcurrentExec(N, true));
 }
@@ -772,7 +772,7 @@ TEST_CASE("Unit_hipMallocFromPoolAsync_MultStream_DefaultStreams") {
  * ------------------------
  *    - HIP_VERSION >= 6.2
  */
-TEST_CASE("Unit_hipMallocFromPoolAsync_MultStream_UserStreams") {
+TEST_CASE(Unit_hipMallocFromPoolAsync_MultStream_UserStreams) {
   checkMempoolSupported(0) constexpr int N = 1 << 20;
   REQUIRE(true == checkMempoolMultStreamConcurrentExec(N, false));
 }
@@ -788,7 +788,7 @@ TEST_CASE("Unit_hipMallocFromPoolAsync_MultStream_UserStreams") {
  * ------------------------
  *    - HIP_VERSION >= 6.2
  */
-TEST_CASE("Unit_hipMallocFromPoolAsync_ReuseFollowEventDependencies") {
+TEST_CASE(Unit_hipMallocFromPoolAsync_ReuseFollowEventDependencies) {
   checkMempoolSupported(0) constexpr int N = 1 << 20;
   REQUIRE(true == checkReuseFollowEventDepFlag(N, testDisabled));
   REQUIRE(true == checkReuseFollowEventDepFlag(N, testEnabled));
@@ -805,7 +805,7 @@ TEST_CASE("Unit_hipMallocFromPoolAsync_ReuseFollowEventDependencies") {
  * ------------------------
  *    - HIP_VERSION >= 6.2
  */
-TEST_CASE("Unit_hipMallocFromPoolAsync_ReuseAllowOpportunistic") {
+TEST_CASE(Unit_hipMallocFromPoolAsync_ReuseAllowOpportunistic) {
   checkMempoolSupported(0) constexpr int N = 1 << 20;
   REQUIRE(true == checkReuseAllowOtherFlags(N, hipMemPoolReuseAllowOpportunistic, testDisabled));
   REQUIRE(true == checkReuseAllowOtherFlags(N, hipMemPoolReuseAllowOpportunistic, testEnabled));
@@ -822,7 +822,7 @@ TEST_CASE("Unit_hipMallocFromPoolAsync_ReuseAllowOpportunistic") {
  * ------------------------
  *    - HIP_VERSION >= 6.2
  */
-TEST_CASE("Unit_hipMallocFromPoolAsync_ReuseAllowInternalDependencies") {
+TEST_CASE(Unit_hipMallocFromPoolAsync_ReuseAllowInternalDependencies) {
   checkMempoolSupported(0) constexpr int N = 1 << 20;
   REQUIRE(true ==
           checkReuseAllowOtherFlags(N, hipMemPoolReuseAllowInternalDependencies, testDisabled));

--- a/projects/hip-tests/catch/unit/memory/hipMallocHost.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMallocHost.cc
@@ -24,7 +24,7 @@ THE SOFTWARE.
 
 static __global__ void write_integer(int* memory, int value) { *memory = value; }
 
-TEST_CASE("Unit_hipMallocHost_Positive") {
+TEST_CASE(Unit_hipMallocHost_Positive) {
   int* host_memory = nullptr;
 
   HIP_CHECK(hipMallocHost(reinterpret_cast<void**>(&host_memory), sizeof(int)));
@@ -32,7 +32,7 @@ TEST_CASE("Unit_hipMallocHost_Positive") {
   HIP_CHECK(hipHostFree(host_memory));
 }
 
-TEST_CASE("Unit_hipMallocHost_DataValidation") {
+TEST_CASE(Unit_hipMallocHost_DataValidation) {
   int validation_number = 10;
   int* host_memory = nullptr;
   hipEvent_t event = nullptr;
@@ -60,7 +60,7 @@ TEST_CASE("Unit_hipMallocHost_DataValidation") {
   HIP_CHECK(hipHostFree(host_memory));
 }
 
-TEST_CASE("Unit_hipMallocHost_Negative") {
+TEST_CASE(Unit_hipMallocHost_Negative) {
   int* host_memory = nullptr;
 
   SECTION("host memory is nullptr") {
@@ -72,7 +72,7 @@ TEST_CASE("Unit_hipMallocHost_Negative") {
   }
 }
 
-TEST_CASE("Unit_hipMallocHost_Capture") {
+TEST_CASE(Unit_hipMallocHost_Capture) {
   int* host_memory = nullptr;
 
   hipError_t capture_error = hipSuccess;

--- a/projects/hip-tests/catch/unit/memory/hipMallocManaged.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMallocManaged.cc
@@ -57,7 +57,7 @@ static unsigned threadsPerBlock{256};
 /*
    This testcase verifies the hipMallocManaged basic scenario - supported on all devices
  */
-TEST_CASE("Unit_hipMallocManaged_Basic") {
+TEST_CASE(Unit_hipMallocManaged_Basic) {
   auto managed = HmmAttrPrint();
   if (managed != 1) {
     WARN(
@@ -79,7 +79,7 @@ TEST_CASE("Unit_hipMallocManaged_Basic") {
    This testcase verifies the hipMallocManaged advanced scenario - supported only on HMM enabled
    devices
  */
-TEST_CASE("Unit_hipMallocManaged_Advanced") {
+TEST_CASE(Unit_hipMallocManaged_Advanced) {
   auto managed = HmmAttrPrint();
   if (managed != 1) {
     HipTest::HIP_SKIP_TEST("GPU doesn't support managed memory so skipping test.");
@@ -151,7 +151,7 @@ TEST_CASE("Unit_hipMallocManaged_Advanced") {
    This testcase verifies that hipMallocManaged returns an OutOfMemory error for allocations much
    larger than the available memory - supported on all devices
  */
-TEST_CASE("Unit_hipMallocManaged_Large") {
+TEST_CASE(Unit_hipMallocManaged_Large) {
   auto managed = HmmAttrPrint();
   if (managed != 1) {
     WARN(

--- a/projects/hip-tests/catch/unit/memory/hipMallocManagedFlagsTst.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMallocManagedFlagsTst.cc
@@ -31,7 +31,7 @@ __global__ void MallcMangdFlgTst(int n, float* x, float* y) {
 }
 
 // The following section tests working of hipMallocManaged with flag parameters
-TEST_CASE("Unit_hipMallocManaged_FlgParam", "[multigpu]") {
+TEST_CASE(Unit_hipMallocManaged_FlgParam) {
   auto managed = HmmAttrPrint();
   if (managed != 1) {
     HipTest::HIP_SKIP_TEST("GPU doesn't support managed memory so skipping test.");
@@ -119,7 +119,7 @@ TEST_CASE("Unit_hipMallocManaged_FlgParam", "[multigpu]") {
 
 // The following function tests Memory access allocated using hipMallocManaged
 // in multiple streams
-TEST_CASE("Unit_hipMallocManaged_AccessMultiStream", "[multigpu]") {
+TEST_CASE(Unit_hipMallocManaged_AccessMultiStream) {
   auto managed = HmmAttrPrint();
   if (managed != 1) {
     HipTest::HIP_SKIP_TEST("GPU doesn't support managed memory so skipping test.");

--- a/projects/hip-tests/catch/unit/memory/hipMallocManaged_MultiScenario.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMallocManaged_MultiScenario.cc
@@ -73,7 +73,7 @@ void HostKernelDouble(float* Hmm, float* hPtr, size_t n) {
 /*
    This testcase verifies the concurrent access of hipMallocManaged Memory on host and device.
  */
-TEST_CASE("Unit_hipMallocManaged_HostDeviceConcurrent") {
+TEST_CASE(Unit_hipMallocManaged_HostDeviceConcurrent) {
   auto managed = HmmAttrPrint();
   if (managed != 1) {
     HipTest::HIP_SKIP_TEST("GPU doesn't support managed memory so skipping test.");
@@ -110,7 +110,7 @@ TEST_CASE("Unit_hipMallocManaged_HostDeviceConcurrent") {
 // Equal parts of Hmm is accessed and
 // kernel is launched on acessed chunk of hmm memory
 // and checks if there are any inconsistencies or access issues
-TEST_CASE("Unit_hipMallocManaged_MultiChunkSingleDevice") {
+TEST_CASE(Unit_hipMallocManaged_MultiChunkSingleDevice) {
   auto managed = HmmAttrPrint();
   if (managed != 1) {
     HipTest::HIP_SKIP_TEST("GPU doesn't support managed memory so skipping test.");
@@ -162,7 +162,7 @@ TEST_CASE("Unit_hipMallocManaged_MultiChunkSingleDevice") {
 // Equal parts of Hmm is accessed on available gpus and
 // kernel is launched on acessed chunk of hmm memory
 // and checks if there are any inconsistencies or access issues
-TEST_CASE("Unit_hipMallocManaged_MultiChunkMultiDevice", "[multigpu]") {
+TEST_CASE(Unit_hipMallocManaged_MultiChunkMultiDevice) {
   auto managed = HmmAttrPrint();
   if (managed != 1) {
     HipTest::HIP_SKIP_TEST("GPU doesn't support managed memory so skipping test.");
@@ -218,7 +218,7 @@ TEST_CASE("Unit_hipMallocManaged_MultiChunkMultiDevice", "[multigpu]") {
 }
 
 // The following tests oversubscription hipMallocManaged() api
-TEST_CASE("Unit_hipMallocManaged_OverSubscription") {
+TEST_CASE(Unit_hipMallocManaged_OverSubscription) {
   auto managed = HmmAttrPrint();
   if (managed != 1) {
     HipTest::HIP_SKIP_TEST("GPU doesn't support managed memory so skipping test.");
@@ -245,7 +245,7 @@ TEST_CASE("Unit_hipMallocManaged_OverSubscription") {
 
 // The following test does negative testing of hipMallocManaged() api
 // by passing invalid values and check if the behavior is as expected
-TEST_CASE("Unit_hipMallocManaged_Negative") {
+TEST_CASE(Unit_hipMallocManaged_Negative) {
   void* A;
   size_t total = 0, free = 0;
   HIP_CHECK(hipMemGetInfo(&free, &total));
@@ -305,7 +305,7 @@ TEST_CASE("Unit_hipMallocManaged_Negative") {
 // Allocate two pointers using hipMallocManaged(), initialize,
 // then launch kernel using these pointers directly and
 // later validate the content without using any Memcpy.
-TEMPLATE_TEST_CASE("Unit_hipMallocManaged_TwoPointers", "[multigpu]", int,
+TEMPLATE_TEST_CASE(Unit_hipMallocManaged_TwoPointers, int,
                    float, double) {
   auto managed = HmmAttrPrint();
   if (managed != 1) {
@@ -346,7 +346,7 @@ TEMPLATE_TEST_CASE("Unit_hipMallocManaged_TwoPointers", "[multigpu]", int,
 // to all other devices. This include verification and Device two Device
 // transfers and kernel launch o discover if there any access issues.
 
-TEMPLATE_TEST_CASE("Unit_hipMallocManaged_DeviceContextChange", "[multigpu]",
+TEMPLATE_TEST_CASE(Unit_hipMallocManaged_DeviceContextChange,
                    unsigned char, int, float, double) {
   auto managed = HmmAttrPrint();
   if (managed != 1) {

--- a/projects/hip-tests/catch/unit/memory/hipMallocMipmappedArray.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMallocMipmappedArray.cc
@@ -75,7 +75,7 @@ static void MallocMipmappedArray_DiffSizes(int gpu) {
   }
 }
 
-TEST_CASE("Unit_hipMallocMipmappedArray_DiffSizes") {
+TEST_CASE(Unit_hipMallocMipmappedArray_DiffSizes) {
   MallocMipmappedArray_DiffSizes(0);
   HIP_CHECK_THREAD_FINALIZE();
 }
@@ -85,7 +85,7 @@ This testcase verifies the hipMallocMipmappedArray API in multithreaded
 scenario by launching threads in parallel on multiple GPUs
 and verifies the hipMallocMipmappedArray API with small and big chunks data
 */
-TEST_CASE("Unit_hipMallocMipmappedArray_MultiThread", "[multigpu]") {
+TEST_CASE(Unit_hipMallocMipmappedArray_MultiThread) {
   std::vector<std::thread> threadlist;
   int devCnt = 0;
   devCnt = HipTest::getDeviceCount();
@@ -131,7 +131,7 @@ void checkMipmappedArrayIsExpected(hipArray_t level_array,
 }
 }  // namespace
 
-TEMPLATE_TEST_CASE("Unit_hipMallocMipmappedArray_happy", "", char, uint2, int4, short4, float) {
+TEMPLATE_TEST_CASE(Unit_hipMallocMipmappedArray_happy, char, uint2, int4, short4, float) {
   hipMipmappedArray_t array;
   const auto desc = hipCreateChannelDesc<TestType>();
 #if HT_AMD
@@ -185,7 +185,7 @@ hipExtent makeMipmappedExtent(unsigned int flag, size_t s) {
 }
 
 // Providing the array pointer as nullptr should return an error
-TEST_CASE("Unit_hipMallocMipmappedArray_Negative_NullArrayPtr") {
+TEST_CASE(Unit_hipMallocMipmappedArray_Negative_NullArrayPtr) {
   hipChannelFormatDesc desc = hipCreateChannelDesc<float4>();
   unsigned int numLevels = 1;
   constexpr size_t s = 6;
@@ -197,7 +197,7 @@ TEST_CASE("Unit_hipMallocMipmappedArray_Negative_NullArrayPtr") {
 }
 
 // Providing the description pointer as nullptr should return an error
-TEST_CASE("Unit_hipMallocMipmappedArray_Negative_NullDescPtr") {
+TEST_CASE(Unit_hipMallocMipmappedArray_Negative_NullDescPtr) {
   constexpr size_t s = 6;  // 6 to keep cubemap happy
   unsigned int numLevels = 1;
   hipMipmappedArray_t array;
@@ -210,7 +210,7 @@ TEST_CASE("Unit_hipMallocMipmappedArray_Negative_NullDescPtr") {
 }
 
 // Zero width arrays are not allowed
-TEST_CASE("Unit_hipMallocMipmappedArray_Negative_ZeroWidth") {
+TEST_CASE(Unit_hipMallocMipmappedArray_Negative_ZeroWidth) {
   constexpr size_t s = 6;  // 6 to keep cubemap happy
   unsigned int numLevels = 1;
   hipMipmappedArray_t array;
@@ -223,7 +223,7 @@ TEST_CASE("Unit_hipMallocMipmappedArray_Negative_ZeroWidth") {
 }
 
 // Zero height arrays are only allowed for 1D arrays and layered arrays
-TEST_CASE("Unit_hipMallocMipmappedArray_Negative_ZeroHeight") {
+TEST_CASE(Unit_hipMallocMipmappedArray_Negative_ZeroHeight) {
   constexpr size_t s = 6;  // 6 to keep cubemap happy
   unsigned int numLevels = 1;
   hipMipmappedArray_t array;
@@ -241,7 +241,7 @@ TEST_CASE("Unit_hipMallocMipmappedArray_Negative_ZeroHeight") {
   }
 }
 
-TEST_CASE("Unit_hipMallocMipmappedArray_Negative_InvalidFlags") {
+TEST_CASE(Unit_hipMallocMipmappedArray_Negative_InvalidFlags) {
   constexpr size_t s = 6;  // 6 to keep cubemap happy
   unsigned int numLevels = 1;
   hipMipmappedArray_t array;
@@ -282,13 +282,13 @@ void testInvalidDescriptionMipmapped(hipChannelFormatDesc desc) {
       expectedError, hipErrorNotSupported);
 }
 
-TEST_CASE("Unit_hipMallocMipmappedArray_Negative_InvalidFormat") {
+TEST_CASE(Unit_hipMallocMipmappedArray_Negative_InvalidFormat) {
   hipChannelFormatDesc desc = hipCreateChannelDesc<float4>();
   desc.f = GENERATE(hipChannelFormatKindNone, 0xBEEF);
   testInvalidDescriptionMipmapped(desc);
 }
 
-TEST_CASE("Unit_hipMallocMipmappedArray_Negative_BadChannelLayout") {
+TEST_CASE(Unit_hipMallocMipmappedArray_Negative_BadChannelLayout) {
   const int bits = GENERATE(8, 16, 32);
   const hipChannelFormatKind formatKind =
       GENERATE(hipChannelFormatKindSigned, hipChannelFormatKindUnsigned, hipChannelFormatKindFloat);
@@ -309,7 +309,7 @@ TEST_CASE("Unit_hipMallocMipmappedArray_Negative_BadChannelLayout") {
   testInvalidDescriptionMipmapped(desc);
 }
 
-TEST_CASE("Unit_hipMallocMipmappedArray_Negative_8BitFloat") {
+TEST_CASE(Unit_hipMallocMipmappedArray_Negative_8BitFloat) {
   hipChannelFormatDesc desc = GENERATE(hipCreateChannelDesc(8, 0, 0, 0, hipChannelFormatKindFloat),
                                        hipCreateChannelDesc(8, 8, 0, 0, hipChannelFormatKindFloat),
                                        hipCreateChannelDesc(8, 8, 8, 8, hipChannelFormatKindFloat));
@@ -317,7 +317,7 @@ TEST_CASE("Unit_hipMallocMipmappedArray_Negative_8BitFloat") {
   testInvalidDescriptionMipmapped(desc);
 }
 
-TEST_CASE("Unit_hipMallocMipmappedArray_Negative_DifferentChannelSizes") {
+TEST_CASE(Unit_hipMallocMipmappedArray_Negative_DifferentChannelSizes) {
   const int bitsX = GENERATE(8, 16, 32);
   const int bitsY = GENERATE(8, 16, 32);
   const int bitsZ = GENERATE(8, 16, 32);
@@ -340,7 +340,7 @@ TEST_CASE("Unit_hipMallocMipmappedArray_Negative_DifferentChannelSizes") {
   testInvalidDescriptionMipmapped(desc);
 }
 
-TEST_CASE("Unit_hipMallocMipmappedArray_Negative_BadChannelSize") {
+TEST_CASE(Unit_hipMallocMipmappedArray_Negative_BadChannelSize) {
   const int badBits = GENERATE(-1, 0, 10, 100);
   const hipChannelFormatKind formatKind =
       GENERATE(hipChannelFormatKindSigned, hipChannelFormatKindUnsigned, hipChannelFormatKindFloat);
@@ -353,7 +353,7 @@ TEST_CASE("Unit_hipMallocMipmappedArray_Negative_BadChannelSize") {
 
 
 // hipMallocMipmappedArray should handle the max numeric value gracefully.
-TEST_CASE("Unit_hipMallocMipmappedArray_Negative_NumericLimit") {
+TEST_CASE(Unit_hipMallocMipmappedArray_Negative_NumericLimit) {
   hipMipmappedArray_t arrayPtr;
   unsigned int numLevels = 1;
   hipChannelFormatDesc desc = hipCreateChannelDesc<float>();
@@ -366,7 +366,7 @@ TEST_CASE("Unit_hipMallocMipmappedArray_Negative_NumericLimit") {
 }
 
 // texture gather arrays are only allowed to be 2D
-TEMPLATE_TEST_CASE("Unit_hipMallocMipmappedArray_Negative_Non2DTextureGather", "", char, uchar2,
+TEMPLATE_TEST_CASE(Unit_hipMallocMipmappedArray_Negative_Non2DTextureGather, char, uchar2,
                    float2) {
 #if HT_AMD
   HipTest::HIP_SKIP_TEST("Texture Gather arrays not supported using AMD backend");
@@ -384,7 +384,7 @@ TEMPLATE_TEST_CASE("Unit_hipMallocMipmappedArray_Negative_Non2DTextureGather", "
                   hipErrorInvalidValue);
 }
 
-TEST_CASE("Unit_hipMallocMipmappedArray_Negative_NumLevels") {
+TEST_CASE(Unit_hipMallocMipmappedArray_Negative_NumLevels) {
   hipMipmappedArray_t array;
   constexpr size_t size = 6;
   unsigned int numLevels = floor(log2(size)) + 2;
@@ -401,7 +401,7 @@ TEST_CASE("Unit_hipMallocMipmappedArray_Negative_NumLevels") {
 #endif
 }
 
-TEST_CASE("Unit_hipGetMipmappedArrayLevel_Negative") {
+TEST_CASE(Unit_hipGetMipmappedArrayLevel_Negative) {
   constexpr size_t s = 6;
   unsigned int numLevels = 1;
   hipMipmappedArray_t array;

--- a/projects/hip-tests/catch/unit/memory/hipMallocMngdMultiThread.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMallocMngdMultiThread.cc
@@ -297,7 +297,7 @@ static void AllocateHmmMemory(int flag, int device) {
   }
 }
 
-TEST_CASE("Unit_hipMallocManaged_MultiThread", "[multigpu]") {
+TEST_CASE(Unit_hipMallocManaged_MultiThread) {
   auto managed = HmmAttrPrint();
   if (managed != 1) {
     HipTest::HIP_SKIP_TEST("GPU doesn't support managed memory so skipping test.");
@@ -351,7 +351,7 @@ TEST_CASE("Unit_hipMallocManaged_MultiThread", "[multigpu]") {
 
 // The following test checks what happens when same Hmm memory is used to
 // launch multiple threads over multiple gpus
-TEST_CASE("Unit_hipMallocManaged_MGpuMThread", "[multigpu]") {
+TEST_CASE(Unit_hipMallocManaged_MGpuMThread) {
   auto managed = HmmAttrPrint();
   if (managed != 1) {
     HipTest::HIP_SKIP_TEST("GPU doesn't support managed memory so skipping test.");
@@ -394,7 +394,7 @@ TEST_CASE("Unit_hipMallocManaged_MGpuMThread", "[multigpu]") {
 
 // The following test checks what happens when multiple kernels are launched
 // with same Hmm memory
-TEST_CASE("Unit_hipMallocManaged_MultiKrnlComnHmm") {
+TEST_CASE(Unit_hipMallocManaged_MultiKrnlComnHmm) {
   auto managed = HmmAttrPrint();
   if (managed != 1) {
     HipTest::HIP_SKIP_TEST("GPU doesn't support managed memory so skipping test.");
@@ -429,7 +429,7 @@ TEST_CASE("Unit_hipMallocManaged_MultiKrnlComnHmm") {
 
 // The following test checks what happens when multiple kernels are launched
 // with same hipMalloc() memory
-TEST_CASE("Unit_hipMallocManaged_MultiKrnlComnMalloc") {
+TEST_CASE(Unit_hipMallocManaged_MultiKrnlComnMalloc) {
   auto managed = HmmAttrPrint();
   if (managed != 1) {
     HipTest::HIP_SKIP_TEST("GPU doesn't support managed memory so skipping test.");
@@ -460,7 +460,7 @@ TEST_CASE("Unit_hipMallocManaged_MultiKrnlComnMalloc") {
 
 //  The following section tests the scenario wherein multiple threads use their
 //  own stream to launch kernel on common Hmm memory
-TEST_CASE("Unit_hipMallocManaged_MultiThrdMultiStrm") {
+TEST_CASE(Unit_hipMallocManaged_MultiThrdMultiStrm) {
   auto managed = HmmAttrPrint();
   if (managed != 1) {
     HipTest::HIP_SKIP_TEST("GPU doesn't support managed memory so skipping test.");
@@ -494,7 +494,7 @@ TEST_CASE("Unit_hipMallocManaged_MultiThrdMultiStrm") {
 
 //  The following section tests the scenario wherein two threads each use
 //  different kernel but common HMM memory
-TEST_CASE("Unit_hipMallocManaged_TwoKrnlsComnHmmMem") {
+TEST_CASE(Unit_hipMallocManaged_TwoKrnlsComnHmmMem) {
   auto managed = HmmAttrPrint();
   if (managed != 1) {
     HipTest::HIP_SKIP_TEST("GPU doesn't support managed memory so skipping test.");

--- a/projects/hip-tests/catch/unit/memory/hipMallocPitch.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMallocPitch.cc
@@ -131,7 +131,7 @@ hipExtent generateExtent(AllocationApi api) {
 }
 
 
-TEST_CASE("Unit_hipMalloc3D_ValidatePitch") {
+TEST_CASE(Unit_hipMalloc3D_ValidatePitch) {
   CHECK_IMAGE_SUPPORT
 
   hipPitchedPtr hipPitchedPtr;
@@ -142,7 +142,7 @@ TEST_CASE("Unit_hipMalloc3D_ValidatePitch") {
   HIP_CHECK(hipFree(hipPitchedPtr.ptr));
 }
 
-TEST_CASE("Unit_hipMemAllocPitch_ValidatePitch") {
+TEST_CASE(Unit_hipMemAllocPitch_ValidatePitch) {
   CHECK_IMAGE_SUPPORT
 
   size_t pitch = 0;
@@ -163,7 +163,7 @@ TEST_CASE("Unit_hipMemAllocPitch_ValidatePitch") {
   HIP_CHECK(hipFree(reinterpret_cast<void*>(ptr)));
 }
 
-TEST_CASE("Unit_hipMallocPitch_ValidatePitch") {
+TEST_CASE(Unit_hipMallocPitch_ValidatePitch) {
   CHECK_IMAGE_SUPPORT
 
   size_t pitch = 0;
@@ -174,7 +174,7 @@ TEST_CASE("Unit_hipMallocPitch_ValidatePitch") {
   HIP_CHECK(hipFree(ptr));
 }
 
-TEST_CASE("Unit_hipMalloc3D_Negative") {
+TEST_CASE(Unit_hipMalloc3D_Negative) {
   CHECK_IMAGE_SUPPORT
 
   SECTION("Invalid ptr") {
@@ -212,7 +212,7 @@ TEST_CASE("Unit_hipMalloc3D_Negative") {
 #endif
 }
 
-TEST_CASE("Unit_hipMallocPitch_Negative") {
+TEST_CASE(Unit_hipMallocPitch_Negative) {
   CHECK_IMAGE_SUPPORT
 
   size_t pitch = 0;
@@ -239,7 +239,7 @@ TEST_CASE("Unit_hipMallocPitch_Negative") {
   }
 }
 
-TEST_CASE("Unit_hipMallocPitch_Zero_Dims") {
+TEST_CASE(Unit_hipMallocPitch_Zero_Dims) {
   CHECK_IMAGE_SUPPORT
 
   void* ptr = nullptr;
@@ -256,7 +256,7 @@ TEST_CASE("Unit_hipMallocPitch_Zero_Dims") {
   }
 }
 
-TEST_CASE("Unit_hipMemAllocPitch_Negative") {
+TEST_CASE(Unit_hipMemAllocPitch_Negative) {
   CHECK_IMAGE_SUPPORT
 
   size_t pitch = 0;
@@ -389,7 +389,7 @@ static void threadFunc(int gpu) { MemoryAllocDiffSizes<float>(gpu); }
  * hipMallocPitch API for different datatypes
  *
  */
-TEMPLATE_TEST_CASE("Unit_hipMallocPitch_Basic", "[hipMallocPitch]", int, unsigned int, float) {
+TEMPLATE_TEST_CASE(Unit_hipMallocPitch_Basic, int, unsigned int, float) {
   CHECK_IMAGE_SUPPORT
 
   TestType* A_d;
@@ -404,7 +404,7 @@ TEMPLATE_TEST_CASE("Unit_hipMallocPitch_Basic", "[hipMallocPitch]", int, unsigne
  * This testcase verifies hipMallocPitch API for small
  * and big chunks of data.
  */
-TEMPLATE_TEST_CASE("Unit_hipMallocPitch_SmallandBigChunks", "[hipMallocPitch]", int, unsigned int,
+TEMPLATE_TEST_CASE(Unit_hipMallocPitch_SmallandBigChunks, int, unsigned int,
                    float) {
   CHECK_IMAGE_SUPPORT
 
@@ -415,7 +415,7 @@ TEMPLATE_TEST_CASE("Unit_hipMallocPitch_SmallandBigChunks", "[hipMallocPitch]", 
  * This testcase verifies the memory allocated by hipMallocPitch API
  * by performing Memcpy2D on the allocated memory.
  */
-TEMPLATE_TEST_CASE("Unit_hipMallocPitch_Memcpy2D", "", int, float, double) {
+TEMPLATE_TEST_CASE(Unit_hipMallocPitch_Memcpy2D, int, float, double) {
   CHECK_IMAGE_SUPPORT
 
   HIP_CHECK(hipSetDevice(0));
@@ -460,7 +460,7 @@ scenario by launching threads in parallel on multiple GPUs
 and verifies the hipMallocPitch API with small and big chunks data
 */
 
-TEST_CASE("Unit_hipMallocPitch_MultiThread", "[multigpu]") {
+TEST_CASE(Unit_hipMallocPitch_MultiThread) {
   CHECK_IMAGE_SUPPORT
 
   std::vector<std::thread> threadlist;
@@ -483,7 +483,7 @@ TEST_CASE("Unit_hipMallocPitch_MultiThread", "[multigpu]") {
  *     variable to another kernel variable.
  *  3. Validating the result
  */
-TEMPLATE_TEST_CASE("Unit_hipMallocPitch_KernelLaunch", "", int, float, double) {
+TEMPLATE_TEST_CASE(Unit_hipMallocPitch_KernelLaunch, int, float, double) {
   CHECK_IMAGE_SUPPORT
 
   HIP_CHECK(hipSetDevice(0));

--- a/projects/hip-tests/catch/unit/memory/hipMemAdvise.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemAdvise.cc
@@ -65,7 +65,7 @@ std::vector<int> GetDevicesWithAdviseSupport() {
   return supported_devices;
 }
 
-TEST_CASE("Unit_hipMemAdvise_Set_Unset_Basic") {
+TEST_CASE(Unit_hipMemAdvise_Set_Unset_Basic) {
   auto supported_devices = GetDevicesWithAdviseSupport();
   if (supported_devices.empty()) {
     HipTest::HIP_SKIP_TEST("Test needs at least 1 device that supports managed memory");
@@ -95,7 +95,7 @@ TEST_CASE("Unit_hipMemAdvise_Set_Unset_Basic") {
   SECTION("hipMemAdviseSetPreferredLocation") { SetUnset(hipMemAdviseSetPreferredLocation); }
 }
 
-TEST_CASE("Unit_hipMemAdvise_No_Flag_Interference") {
+TEST_CASE(Unit_hipMemAdvise_No_Flag_Interference) {
   auto supported_devices = GetDevicesWithAdviseSupport();
   if (supported_devices.empty()) {
     HipTest::HIP_SKIP_TEST("Test needs at least 1 device that supports managed memory");
@@ -123,7 +123,7 @@ TEST_CASE("Unit_hipMemAdvise_No_Flag_Interference") {
   }
 }
 
-TEST_CASE("Unit_hipMemAdvise_Rounding") {
+TEST_CASE(Unit_hipMemAdvise_Rounding) {
   auto supported_devices = GetDevicesWithAdviseSupport();
   if (supported_devices.empty()) {
     HipTest::HIP_SKIP_TEST("Test needs at least 1 device that supports managed memory");
@@ -155,7 +155,7 @@ TEST_CASE("Unit_hipMemAdvise_Rounding") {
           static_cast<int>(attribute));
 }
 
-TEST_CASE("Unit_hipMemAdvise_Flags_Do_Not_Cause_Prefetch") {
+TEST_CASE(Unit_hipMemAdvise_Flags_Do_Not_Cause_Prefetch) {
   auto supported_devices = GetDevicesWithAdviseSupport();
   if (supported_devices.empty()) {
     HipTest::HIP_SKIP_TEST("Test needs at least 1 device that supports managed memory");
@@ -182,7 +182,7 @@ TEST_CASE("Unit_hipMemAdvise_Flags_Do_Not_Cause_Prefetch") {
 #endif
 }
 
-TEST_CASE("Unit_hipMemAdvise_Read_Write_After_Advise", "[multigpu]") {
+TEST_CASE(Unit_hipMemAdvise_Read_Write_After_Advise) {
   auto supported_devices = GetDevicesWithAdviseSupport();
   if (supported_devices.empty()) {
     HipTest::HIP_SKIP_TEST("Test needs at least 1 device that supports managed memory");
@@ -227,7 +227,7 @@ TEST_CASE("Unit_hipMemAdvise_Read_Write_After_Advise", "[multigpu]") {
 #endif
 }
 
-TEST_CASE("Unit_hipMemAdvise_Prefetch_After_Advise") {
+TEST_CASE(Unit_hipMemAdvise_Prefetch_After_Advise) {
   auto supported_devices = GetDevicesWithAdviseSupport();
   if (supported_devices.empty()) {
     HipTest::HIP_SKIP_TEST("Test needs at least 1 device that supports managed memory");
@@ -259,7 +259,7 @@ TEST_CASE("Unit_hipMemAdvise_Prefetch_After_Advise") {
   REQUIRE((advice == hipMemAdviseSetReadMostly ? 1 : device) == attribute);
 }
 
-TEST_CASE("Unit_hipMemAdvise_AccessedBy_All_Devices") {
+TEST_CASE(Unit_hipMemAdvise_AccessedBy_All_Devices) {
   auto supported_devices = GetDevicesWithAdviseSupport();
   if (supported_devices.empty()) {
     HipTest::HIP_SKIP_TEST("Test needs at least 1 device that supports managed memory");
@@ -279,7 +279,7 @@ TEST_CASE("Unit_hipMemAdvise_AccessedBy_All_Devices") {
   REQUIRE_THAT(accessed_by, Catch::Matchers::Equals(supported_devices));
 }
 
-TEST_CASE("Unit_hipMemAdvise_Negative_Parameters") {
+TEST_CASE(Unit_hipMemAdvise_Negative_Parameters) {
   auto supported_devices = GetDevicesWithAdviseSupport();
   if (supported_devices.empty()) {
     HipTest::HIP_SKIP_TEST("Test needs at least 1 device that supports managed memory");

--- a/projects/hip-tests/catch/unit/memory/hipMemAdviseMmap.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemAdviseMmap.cc
@@ -30,7 +30,7 @@ THE SOFTWARE.
    hipMemAdvise() works with mmap() memory
 */
 
-TEST_CASE("Unit_hipMemAdvise_MmapMem") {
+TEST_CASE(Unit_hipMemAdvise_MmapMem) {
   int managed = 0, PageableMem = 0;
   INFO(
       "The following are the attribute values related to HMM for"

--- a/projects/hip-tests/catch/unit/memory/hipMemAdvise_old.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemAdvise_old.cc
@@ -123,7 +123,7 @@ static int HmmAttrPrint() {
 // The following function tests if peers can set hipMemAdviseSetAccessedBy flag
 // on HMM memory prefetched on each of the other gpus
 #if HT_AMD
-TEST_CASE("Unit_hipMemAdvise_TstAccessedByPeer", "[multigpu]") {
+TEST_CASE(Unit_hipMemAdvise_TstAccessedByPeer) {
   int MangdMem = HmmAttrPrint();
   if (MangdMem == 1) {
     bool IfTestPassed = true;
@@ -180,7 +180,7 @@ TEST_CASE("Unit_hipMemAdvise_TstAccessedByPeer", "[multigpu]") {
 /* Set AccessedBy flag to device 0 on Hmm memory and prefetch the memory to
    device 1, then probe for AccessedBy flag using hipMemRangeGetAttribute()
    we should still see the said flag is set for device 0*/
-TEST_CASE("Unit_hipMemAdvise_TstAccessedByFlg2") {
+TEST_CASE(Unit_hipMemAdvise_TstAccessedByFlg2) {
   int managed = HmmAttrPrint();
   if (managed == 1) {
     int *Hmm = NULL, data = 999, Ngpus = 0;
@@ -216,7 +216,7 @@ TEST_CASE("Unit_hipMemAdvise_TstAccessedByFlg2") {
    PreferredLocation to device 1, check for AccessedBy flag using
    hipMemRangeGetAttribute() it should return 1*/
 
-TEST_CASE("Unit_hipMemAdvise_TstAccessedByFlg3") {
+TEST_CASE(Unit_hipMemAdvise_TstAccessedByFlg3) {
   int managed = HmmAttrPrint();
   if (managed == 1) {
     int *Hmm = NULL, data = 999, Ngpus = 0;
@@ -253,7 +253,7 @@ TEST_CASE("Unit_hipMemAdvise_TstAccessedByFlg3") {
 /* Set AccessedBy flag to HMM memory launch a kernel and then unset
    AccessedBy, launch kernel. We should not have any access issues*/
 
-TEST_CASE("Unit_hipMemAdvise_TstAccessedByFlg4") {
+TEST_CASE(Unit_hipMemAdvise_TstAccessedByFlg4) {
   int managed = HmmAttrPrint();
   if (managed == 1) {
     int *Hmm = NULL, NumElms = (1024 * 1024), InitVal = 123, blockSize = 64;
@@ -311,7 +311,7 @@ TEST_CASE("Unit_hipMemAdvise_TstAccessedByFlg4") {
    the allocated memory and launch a kernel. Kernel should get executed
    successfully without hang or segfault*/
 #if __linux__ && HT_AMD
-TEST_CASE("Unit_hipMemAdvise_TstAlignedAllocMem") {
+TEST_CASE(Unit_hipMemAdvise_TstAlignedAllocMem) {
   // The following code block checks for xnack+
   // so as to skip if the device is not xnack+
   hipDeviceProp_t prop;
@@ -357,7 +357,7 @@ TEST_CASE("Unit_hipMemAdvise_TstAlignedAllocMem") {
   }
 }
 
-TEST_CASE("Unit_hipMemAdvise_TstAlignedAllocMem_XNACK") {
+TEST_CASE(Unit_hipMemAdvise_TstAlignedAllocMem_XNACK) {
   if (setenv("HSA_XNACK", "1", 1) != 0) {
     HipTest::HIP_SKIP_TEST("Unable to set xnack on environment variable.");
     return;
@@ -384,7 +384,7 @@ TEST_CASE("Unit_hipMemAdvise_TstAlignedAllocMem_XNACK") {
   access denial case arising due to setting ReadMostly only to a particular
   gpu*/
 
-TEST_CASE("Unit_hipMemAdvise_ReadMosltyMgpuTst", "[multigpu]") {
+TEST_CASE(Unit_hipMemAdvise_ReadMosltyMgpuTst) {
   int managed = HmmAttrPrint();
   if (managed == 1) {
     int Ngpus = 0;

--- a/projects/hip-tests/catch/unit/memory/hipMemAdvise_v2.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemAdvise_v2.cc
@@ -70,7 +70,7 @@ static std::vector<int> getSupportedDevices() {
  * ------------------------
  *  - HIP_VERSION >= 7.1
  */
-TEST_CASE("Unit_hipMemAdvise_v2_Device_Host", "[multigpu]") {
+TEST_CASE(Unit_hipMemAdvise_v2_Device_Host) {
   auto supportedDevices = getSupportedDevices();
   if (supportedDevices.empty()) {
     HipTest::HIP_SKIP_TEST(
@@ -158,7 +158,7 @@ TEST_CASE("Unit_hipMemAdvise_v2_Device_Host", "[multigpu]") {
  *  - HIP_VERSION >= 7.1
  */
 #if __linux__
-TEST_CASE("Unit_hipMemAdvise_v2_HostNuma_HostNumaCurrent") {
+TEST_CASE(Unit_hipMemAdvise_v2_HostNuma_HostNumaCurrent) {
   auto supportedDevices = getSupportedDevices();
   if (supportedDevices.empty() || numa_available() < 0) {
     HipTest::HIP_SKIP_TEST("Skipping as System does not have managed memory "
@@ -235,7 +235,7 @@ TEST_CASE("Unit_hipMemAdvise_v2_HostNuma_HostNumaCurrent") {
  * ------------------------
  *  - HIP_VERSION >= 7.1
  */
-TEST_CASE("Unit_hipMemAdvise_v2_Negative") {
+TEST_CASE(Unit_hipMemAdvise_v2_Negative) {
   auto supportedDevices = getSupportedDevices();
   if (supportedDevices.empty()) {
     HipTest::HIP_SKIP_TEST(

--- a/projects/hip-tests/catch/unit/memory/hipMemAllocHost.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemAllocHost.cc
@@ -24,7 +24,7 @@ THE SOFTWARE.
 
 static __global__ void write_integer(int* memory, int value) { *memory = value; }
 
-TEST_CASE("Unit_hipMemAllocHost_Positive") {
+TEST_CASE(Unit_hipMemAllocHost_Positive) {
   int* host_memory = nullptr;
   hipCtx_t ctx;
   hipDevice_t device;
@@ -37,7 +37,7 @@ TEST_CASE("Unit_hipMemAllocHost_Positive") {
   HIP_CHECK(hipCtxDestroy(ctx));
 }
 
-TEST_CASE("Unit_hipMemAllocHost_DataValidation") {
+TEST_CASE(Unit_hipMemAllocHost_DataValidation) {
   int validation_number = 10;
   int* host_memory = nullptr;
   hipEvent_t event = nullptr;
@@ -70,7 +70,7 @@ TEST_CASE("Unit_hipMemAllocHost_DataValidation") {
   HIP_CHECK(hipCtxDestroy(ctx));
 }
 
-TEST_CASE("Unit_hipMemAllocHost_Negative") {
+TEST_CASE(Unit_hipMemAllocHost_Negative) {
   int* host_memory = nullptr;
   hipCtx_t ctx;
   hipDevice_t device;
@@ -93,7 +93,7 @@ TEST_CASE("Unit_hipMemAllocHost_Negative") {
 /*
  * Verify that a device can read/write to the memory of another device
  */
-TEST_CASE("Unit_hipMemAllocHost_VerifyAccess", "[multigpu]") {
+TEST_CASE(Unit_hipMemAllocHost_VerifyAccess) {
   int devices_number = 0;
   HIP_CHECK(hipGetDeviceCount(&devices_number));
   std::vector<int*> devices_memories(devices_number);
@@ -137,7 +137,7 @@ TEST_CASE("Unit_hipMemAllocHost_VerifyAccess", "[multigpu]") {
   }
 }
 
-TEST_CASE("Unit_hipMemAllocHost_Capture") {
+TEST_CASE(Unit_hipMemAllocHost_Capture) {
   int* host_memory = nullptr;
 
   hipError_t capture_error = hipSuccess;

--- a/projects/hip-tests/catch/unit/memory/hipMemCoherencyTst.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemCoherencyTst.cc
@@ -104,7 +104,7 @@ static void TstCoherency(int* ptr, MemoryType type) {
 
 /* Test case description: The following test validates if fine grain
    behavior is observed or not with memory allocated using hipHostMalloc()*/
-TEST_CASE("Unit_hipHostMalloc_CoherentTst") {
+TEST_CASE(Unit_hipHostMalloc_CoherentTst) {
   HIP_CHECK(hipSetDevice(0));
   CHECK_PCIE_ATOMIC_SUPPORT;
 
@@ -130,7 +130,7 @@ TEST_CASE("Unit_hipHostMalloc_CoherentTst") {
 // The following tests are disabled for Nvidia as they are not consistently
 // passing
 #if HT_AMD
-TEST_CASE("Unit_hipMallocManaged_CoherentTst") {
+TEST_CASE(Unit_hipMallocManaged_CoherentTst) {
   HIP_CHECK(hipSetDevice(0));
   CHECK_PCIE_ATOMIC_SUPPORT;
 
@@ -160,7 +160,7 @@ TEST_CASE("Unit_hipMallocManaged_CoherentTst") {
 
 /* Test case description: The following test validates if memory access is fine
    with memory allocated using hipMallocManaged() and CoarseGrain Advise*/
-TEST_CASE("Unit_hipMallocManaged_CoherentTstWthAdvise") {
+TEST_CASE(Unit_hipMallocManaged_CoherentTstWthAdvise) {
   HIP_CHECK(hipSetDevice(0));
   int *Ptr = nullptr, SIZE = sizeof(int), managed = 0;
   YES_COHERENT = false;
@@ -203,7 +203,7 @@ TEST_CASE("Unit_hipMallocManaged_CoherentTstWthAdvise") {
    using hipMalloc() are of type Coarse Grain*/
 // The following tests are disabled for Nvidia as they are not applicable
 #if HT_AMD
-TEST_CASE("Unit_hipMalloc_CoherentTst") {
+TEST_CASE(Unit_hipMalloc_CoherentTst) {
   HIP_CHECK(hipSetDevice(0));
   int *Ptr = nullptr, SIZE = sizeof(int);
   uint32_t svm_attrib = 0;
@@ -223,7 +223,7 @@ TEST_CASE("Unit_hipMalloc_CoherentTst") {
    behavior is observed or not with memory allocated using
    hipExtMallocWithFlags()*/
 #if HT_AMD
-TEST_CASE("Unit_hipExtMallocWithFlags_CoherentTst") {
+TEST_CASE(Unit_hipExtMallocWithFlags_CoherentTst) {
   HIP_CHECK(hipSetDevice(0));
   int *Ptr = nullptr, SIZE = sizeof(int), InitVal = 9, Pageable = 0, managed = 0, finegrain = 0;
   bool FineGrain = true;

--- a/projects/hip-tests/catch/unit/memory/hipMemGetAddressRange.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemGetAddressRange.cc
@@ -45,7 +45,7 @@ THE SOFTWARE.
  * ------------------------
  *  - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_hipMemGetAddressRange_Positive") {
+TEST_CASE(Unit_hipMemGetAddressRange_Positive) {
   hipDeviceptr_t base_ptr;
   size_t mem_size = 0;
   const auto allocation_size = GENERATE(kPageSize / 2, kPageSize, kPageSize * 2);
@@ -100,7 +100,7 @@ TEST_CASE("Unit_hipMemGetAddressRange_Positive") {
  * ------------------------
  *  - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_hipMemGetAddressRange_Negative") {
+TEST_CASE(Unit_hipMemGetAddressRange_Negative) {
   hipDeviceptr_t base_ptr;
   size_t mem_size = 0;
   const auto allocation_size = kPageSize / 2;

--- a/projects/hip-tests/catch/unit/memory/hipMemGetInfo.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemGetInfo.cc
@@ -19,7 +19,7 @@ THE SOFTWARE.
 
 #include <hip_test_common.hh>
 
-TEST_CASE("Unit_hipMemGetInfo_FreeLessThanTotal") {
+TEST_CASE(Unit_hipMemGetInfo_FreeLessThanTotal) {
   unsigned int* A_mem{nullptr};
   size_t freeMemInit, totalMemInit;
   size_t freeMem, totalMem;

--- a/projects/hip-tests/catch/unit/memory/hipMemPoolApi.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemPoolApi.cc
@@ -43,7 +43,7 @@ void initMemPoolProps() {
    This testcase verifies HIP Mem Pool API basic scenario - supported on all devices
  */
 
-TEST_CASE("Unit_hipMemPoolApi_Basic") {
+TEST_CASE(Unit_hipMemPoolApi_Basic) {
   int mem_pool_support = 0;
   HIP_CHECK(hipDeviceGetAttribute(&mem_pool_support, hipDeviceAttributeMemoryPoolsSupported, 0));
   if (!mem_pool_support) {
@@ -98,7 +98,7 @@ TEST_CASE("Unit_hipMemPoolApi_Basic") {
   HIP_CHECK(hipStreamDestroy(stream));
 }
 
-TEST_CASE("Unit_hipMemPoolApi_BasicAlloc") {
+TEST_CASE(Unit_hipMemPoolApi_BasicAlloc) {
   int mem_pool_support = 0;
   HIP_CHECK(hipSetDevice(0));
 
@@ -189,7 +189,7 @@ TEST_CASE("Unit_hipMemPoolApi_BasicAlloc") {
   HIP_CHECK(hipHostFree(notified));
 }
 
-TEST_CASE("Unit_hipMemPoolApi_BasicTrim") {
+TEST_CASE(Unit_hipMemPoolApi_BasicTrim) {
   int mem_pool_support = 0;
   HIP_CHECK(hipDeviceGetAttribute(&mem_pool_support, hipDeviceAttributeMemoryPoolsSupported, 0));
   if (!mem_pool_support) {
@@ -277,7 +277,7 @@ TEST_CASE("Unit_hipMemPoolApi_BasicTrim") {
   HIP_CHECK(hipHostFree(notified));
 }
 
-TEST_CASE("Unit_hipMemPoolApi_BasicReuse") {
+TEST_CASE(Unit_hipMemPoolApi_BasicReuse) {
   int mem_pool_support = 0;
   HIP_CHECK(hipDeviceGetAttribute(&mem_pool_support, hipDeviceAttributeMemoryPoolsSupported, 0));
   if (!mem_pool_support) {
@@ -352,7 +352,7 @@ TEST_CASE("Unit_hipMemPoolApi_BasicReuse") {
   HIP_CHECK(hipHostFree(notified));
 }
 
-TEST_CASE("Unit_hipMemPoolApi_Opportunistic") {
+TEST_CASE(Unit_hipMemPoolApi_Opportunistic) {
   int mem_pool_support = 0;
   HIP_CHECK(hipDeviceGetAttribute(&mem_pool_support, hipDeviceAttributeMemoryPoolsSupported, 0));
   if (!mem_pool_support) {
@@ -509,7 +509,7 @@ TEST_CASE("Unit_hipMemPoolApi_Opportunistic") {
   HIP_CHECK(hipHostFree(notified2));
 }
 
-TEST_CASE("Unit_hipMemPoolApi_Default") {
+TEST_CASE(Unit_hipMemPoolApi_Default) {
   int mem_pool_support = 0;
   HIP_CHECK(hipDeviceGetAttribute(&mem_pool_support, hipDeviceAttributeMemoryPoolsSupported, 0));
   if (!mem_pool_support) {

--- a/projects/hip-tests/catch/unit/memory/hipMemPoolCreate.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemPoolCreate.cc
@@ -45,7 +45,7 @@
  * ------------------------
  *  - HIP_VERSION >= 6.2
  */
-TEST_CASE("Unit_hipMemPoolCreate_Negative_Parameter") {
+TEST_CASE(Unit_hipMemPoolCreate_Negative_Parameter) {
   checkMempoolSupported(0)
 
       int num_dev = 0;
@@ -88,7 +88,7 @@ TEST_CASE("Unit_hipMemPoolCreate_Negative_Parameter") {
   }
 }
 
-TEST_CASE("Unit_hipMemPoolCreate_With_maxSize") {
+TEST_CASE(Unit_hipMemPoolCreate_With_maxSize) {
   checkMempoolSupported(0) hipMemPoolProps pool_props;
   memset(&pool_props, 0, sizeof(pool_props));
   pool_props.allocType = hipMemAllocationTypePinned;
@@ -119,7 +119,7 @@ TEST_CASE("Unit_hipMemPoolCreate_With_maxSize") {
   HIP_CHECK(hipStreamDestroy(stream));
 }
 
-TEST_CASE("Unit_hipMemPoolCreate_Without_maxSize") {
+TEST_CASE(Unit_hipMemPoolCreate_Without_maxSize) {
   checkMempoolSupported(0) hipMemPoolProps pool_props;
   memset(&pool_props, 0, sizeof(pool_props));
   pool_props.allocType = hipMemAllocationTypePinned;
@@ -159,7 +159,7 @@ static __global__ void setKer(int* devptr) {
  * ------------------------
  *    - HIP_VERSION >= 6.2
  */
-TEST_CASE("Unit_hipMemPoolCreate_DeviceTest", "[multigpu]") {
+TEST_CASE(Unit_hipMemPoolCreate_DeviceTest) {
   checkMempoolSupported(0) int num_devices = 0;
   HIP_CHECK(hipGetDeviceCount(&num_devices));
   checkIfMultiDev(num_devices)

--- a/projects/hip-tests/catch/unit/memory/hipMemPoolDestroy.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemPoolDestroy.cc
@@ -42,7 +42,7 @@
  * ------------------------
  *  - HIP_VERSION >= 6.2
  */
-TEST_CASE("Unit_hipMemPoolDestroy_Negative_Parameter") {
+TEST_CASE(Unit_hipMemPoolDestroy_Negative_Parameter) {
   checkMempoolSupported(0)
 
       hipMemPool_t mem_pool = nullptr;

--- a/projects/hip-tests/catch/unit/memory/hipMemPoolExportPointer.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemPoolExportPointer.cc
@@ -44,7 +44,7 @@ constexpr size_t byte_size = DATA_SIZE * sizeof(int);
  *    - Host specific (LINUX)
  *    - HIP_VERSION >= 6.2
  */
-TEST_CASE("Unit_hipMemPoolExportPointer_Negative") {
+TEST_CASE(Unit_hipMemPoolExportPointer_Negative) {
   hipMemPoolPtrExportData ptrExp;
   hipShareableHdl sharedHandle;
   hipMemPoolProps pool_props{};

--- a/projects/hip-tests/catch/unit/memory/hipMemPoolExportToShareableHandle.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemPoolExportToShareableHandle.cc
@@ -70,7 +70,7 @@ static void fill_data(std::vector<int>& A_h, std::vector<int>& B_h, std::vector<
  *    - Host specific (LINUX)
  *    - HIP_VERSION >= 6.2
  */
-TEST_CASE("Unit_hipMemPoolExportToShareableHandle_SameProc") {
+TEST_CASE(Unit_hipMemPoolExportToShareableHandle_SameProc) {
   hipMemPoolPtrExportData ptrExp;
   hipShareableHdl sharedHandle;
   std::vector<int> A_h(DATA_SIZE), B_h(DATA_SIZE), C_h(DATA_SIZE);
@@ -130,7 +130,7 @@ TEST_CASE("Unit_hipMemPoolExportToShareableHandle_SameProc") {
  *    - Host specific (LINUX)
  *    - HIP_VERSION >= 6.2
  */
-TEST_CASE("Unit_hipMemPoolExportToShareableHandle_ChldUseHdl") {
+TEST_CASE(Unit_hipMemPoolExportToShareableHandle_ChldUseHdl) {
   std::vector<int> A_h(DATA_SIZE), B_h(DATA_SIZE), C_h(DATA_SIZE);
   fill_data(A_h, B_h, C_h);
   int fd[2], fdSig[2];
@@ -237,7 +237,7 @@ TEST_CASE("Unit_hipMemPoolExportToShareableHandle_ChldUseHdl") {
  *    - HIP_VERSION >= 6.2
  */
 #if HT_AMD
-TEST_CASE("Unit_hipMemPoolExportToShareableHandle_ChldCheckAccess") {
+TEST_CASE(Unit_hipMemPoolExportToShareableHandle_ChldCheckAccess) {
   int fd[2], fdSig[2];
   REQUIRE(pipe(fd) == 0);
   REQUIRE(pipe(fdSig) == 0);
@@ -340,7 +340,7 @@ TEST_CASE("Unit_hipMemPoolExportToShareableHandle_ChldCheckAccess") {
  *    - Host specific (LINUX)
  *    - HIP_VERSION >= 6.2
  */
-TEST_CASE("Unit_hipMemPoolExportToShareableHandle_GrndChldUseHdl") {
+TEST_CASE(Unit_hipMemPoolExportToShareableHandle_GrndChldUseHdl) {
   std::vector<int> A_h(DATA_SIZE), B_h(DATA_SIZE), C_h(DATA_SIZE);
   fill_data(A_h, B_h, C_h);
   int fd[2], fdSig[2], fdpid[2];
@@ -457,7 +457,7 @@ TEST_CASE("Unit_hipMemPoolExportToShareableHandle_GrndChldUseHdl") {
  *    - Host specific (LINUX)
  *    - HIP_VERSION >= 6.2
  */
-TEST_CASE("Unit_hipMemPoolExportToShareableHandle_Negative") {
+TEST_CASE(Unit_hipMemPoolExportToShareableHandle_Negative) {
   hipShareableHdl sharedHandle;
   hipMemPoolProps pool_props{};
   hipMemPool_t mempoolPfd, mempoolwoPfd;

--- a/projects/hip-tests/catch/unit/memory/hipMemPoolImportFromShareableHandle.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemPoolImportFromShareableHandle.cc
@@ -45,7 +45,7 @@ THE SOFTWARE.
  *    - Host specific (LINUX)
  *    - HIP_VERSION >= 6.2
  */
-TEST_CASE("Unit_hipMemPoolImportFromShareableHandle_Negative") {
+TEST_CASE(Unit_hipMemPoolImportFromShareableHandle_Negative) {
   hipShareableHdl sharedHandle;
   hipMemPoolProps pool_props{};
   hipMemPool_t mempoolPfd;

--- a/projects/hip-tests/catch/unit/memory/hipMemPoolImportPointer.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemPoolImportPointer.cc
@@ -47,7 +47,7 @@ constexpr size_t byte_size = DATA_SIZE * sizeof(int);
  *    - Host specific (LINUX)
  *    - HIP_VERSION >= 6.2
  */
-TEST_CASE("Unit_hipMemPoolImportPointer_Negative") {
+TEST_CASE(Unit_hipMemPoolImportPointer_Negative) {
   hipMemPoolPtrExportData ptrExp;
   hipShareableHdl sharedHandle;
   hipMemPoolProps pool_props{};

--- a/projects/hip-tests/catch/unit/memory/hipMemPoolMaxAlloc.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemPoolMaxAlloc.cc
@@ -7400,4 +7400,4 @@ hipError_t Test() {
 }
 
 
-TEST_CASE("Unit_hipMemPoolMaxAlloc") { HIP_CHECK(Test()); }
+TEST_CASE(Unit_hipMemPoolMaxAlloc) { HIP_CHECK(Test()); }

--- a/projects/hip-tests/catch/unit/memory/hipMemPoolSetGetAccess.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemPoolSetGetAccess.cc
@@ -66,7 +66,7 @@ static void MemPoolSetGetAccess(const MemPools mempool_type, int src_device, int
  * ------------------------
  *  - HIP_VERSION >= 6.2
  */
-TEST_CASE("Unit_hipMemPoolSetGetAccess_Positive_Basic") {
+TEST_CASE(Unit_hipMemPoolSetGetAccess_Positive_Basic) {
   const auto device = GENERATE(range(0, HipTest::getDeviceCount()));
 
   checkMempoolSupported(device)
@@ -98,7 +98,7 @@ int CheckP2PMemPoolSupport(int src_device, int dst_device) {
  * ------------------------
  *  - HIP_VERSION >= 6.2
  */
-TEST_CASE("Unit_hipMemPoolSetGetAccess_Positive_MultipleGPU", "[multigpu]") {
+TEST_CASE(Unit_hipMemPoolSetGetAccess_Positive_MultipleGPU) {
   const auto device_count = HipTest::getDeviceCount();
   if (device_count < 2) {
     HipTest::HIP_SKIP_TEST("Skipping because devices < 2");
@@ -213,7 +213,7 @@ void MemPoolSetGetAccess_P2P(const MemPools mempool_type) {
  * ------------------------
  *  - HIP_VERSION >= 6.2
  */
-TEST_CASE("Unit_hipMemPoolSetGetAccess_Positive_P2P", "[multigpu]") {
+TEST_CASE(Unit_hipMemPoolSetGetAccess_Positive_P2P) {
   const auto device_count = HipTest::getDeviceCount();
   if (device_count < 2) {
     HipTest::HIP_SKIP_TEST("Skipping because devices < 2");
@@ -243,7 +243,7 @@ TEST_CASE("Unit_hipMemPoolSetGetAccess_Positive_P2P", "[multigpu]") {
  * ------------------------
  *  - HIP_VERSION >= 6.2
  */
-TEST_CASE("Unit_hipMemPoolSetAccess_Negative_Parameters") {
+TEST_CASE(Unit_hipMemPoolSetAccess_Negative_Parameters) {
   CHECK_IMAGE_SUPPORT
   int device_id = 0;
   HIP_CHECK(hipSetDevice(device_id));
@@ -409,7 +409,7 @@ static void getDevicePairs(std::vector<std::pair<int, int>>* p2p_pairs, int numD
  * ------------------------
  *    - HIP_VERSION >= 6.2
  */
-TEST_CASE("Unit_hipMemPoolSetAccess_SetAccess", "[multigpu]") {
+TEST_CASE(Unit_hipMemPoolSetAccess_SetAccess) {
   constexpr int N = 1 << 14;
   int numDevices = 0;
   HIP_CHECK(hipGetDeviceCount(&numDevices));
@@ -438,7 +438,7 @@ TEST_CASE("Unit_hipMemPoolSetAccess_SetAccess", "[multigpu]") {
  * ------------------------
  *    - HIP_VERSION >= 6.2
  */
-TEST_CASE("Unit_hipMemPoolSetAccess_NegTst") {
+TEST_CASE(Unit_hipMemPoolSetAccess_NegTst) {
   checkMempoolSupported(0) hipMemPool_t mem_pool;
   hipMemPoolProps pool_props{};
   pool_props.allocType = hipMemAllocationTypePinned;
@@ -518,7 +518,7 @@ TEST_CASE("Unit_hipMemPoolSetAccess_NegTst") {
  * ------------------------
  *  - HIP_VERSION >= 6.2
  */
-TEST_CASE("Unit_hipMemPoolGetAccess_Negative_Parameters") {
+TEST_CASE(Unit_hipMemPoolGetAccess_Negative_Parameters) {
   int device_id = 0;
   HIP_CHECK(hipSetDevice(device_id));
   checkMempoolSupported(device_id) MemPoolGuard mempool(MemPools::dev_default, device_id);
@@ -628,7 +628,7 @@ static bool checkMempoolSetAccessWithGetUsingArray(int dev0, int dev1) {
  * ------------------------
  *    - HIP_VERSION >= 6.2
  */
-TEST_CASE("Unit_hipMemPoolGetAccess_SetGet") {
+TEST_CASE(Unit_hipMemPoolGetAccess_SetGet) {
   int numDevices = 0;
   HIP_CHECK(hipGetDeviceCount(&numDevices));
   checkIfMultiDev(numDevices) for (int dev = 0; dev < numDevices; dev++){
@@ -658,7 +658,7 @@ TEST_CASE("Unit_hipMemPoolGetAccess_SetGet") {
  * ------------------------
  *    - HIP_VERSION >= 6.2
  */
-TEST_CASE("Unit_hipMemPoolGetAccess_GetDefMempoolOfEachDevice") {
+TEST_CASE(Unit_hipMemPoolGetAccess_GetDefMempoolOfEachDevice) {
   int numDevices = 0;
   HIP_CHECK(hipGetDeviceCount(&numDevices));
   for (int dev = 0; dev < numDevices; dev++) {

--- a/projects/hip-tests/catch/unit/memory/hipMemPoolSetGetAttribute.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemPoolSetGetAttribute.cc
@@ -47,7 +47,7 @@ template <typename T> static void MemPoolSetGetAttribute(const hipMemPool_t memp
  * ------------------------
  *  - HIP_VERSION >= 6.2
  */
-TEST_CASE("Unit_hipMemPoolSetGetAttribute_Positive_Default") {
+TEST_CASE(Unit_hipMemPoolSetGetAttribute_Positive_Default) {
   const auto device = GENERATE(range(0, HipTest::getDeviceCount()));
 
   checkMempoolSupported(device)
@@ -80,7 +80,7 @@ TEST_CASE("Unit_hipMemPoolSetGetAttribute_Positive_Default") {
  * ------------------------
  *  - HIP_VERSION >= 6.2
  */
-TEST_CASE("Unit_hipMemPoolSetGetAttribute_Positive_MemBasic") {
+TEST_CASE(Unit_hipMemPoolSetGetAttribute_Positive_MemBasic) {
   const auto device = GENERATE(range(0, HipTest::getDeviceCount()));
 
   checkMempoolSupported(device)
@@ -115,7 +115,7 @@ TEST_CASE("Unit_hipMemPoolSetGetAttribute_Positive_MemBasic") {
  * ------------------------
  *  - HIP_VERSION >= 6.2
  */
-TEST_CASE("Unit_hipMemPoolSetAttribute_Opportunistic") {
+TEST_CASE(Unit_hipMemPoolSetAttribute_Opportunistic) {
   int device_id = 0;
   HIP_CHECK(hipSetDevice(device_id));
   checkMempoolSupported(device_id)
@@ -310,7 +310,7 @@ TEST_CASE("Unit_hipMemPoolSetAttribute_Opportunistic") {
  * ------------------------
  *  - HIP_VERSION >= 6.2
  */
-TEST_CASE("Unit_hipMemPoolSetAttribute_EventDependencies") {
+TEST_CASE(Unit_hipMemPoolSetAttribute_EventDependencies) {
   int device_id = 0;
   HIP_CHECK(hipSetDevice(device_id));
 
@@ -437,7 +437,7 @@ TEST_CASE("Unit_hipMemPoolSetAttribute_EventDependencies") {
  * ------------------------
  *  - HIP_VERSION >= 6.2
  */
-TEST_CASE("Unit_hipMemPoolSetAttribute_Negative_Parameters") {
+TEST_CASE(Unit_hipMemPoolSetAttribute_Negative_Parameters) {
   int device_id = 0;
   HIP_CHECK(hipSetDevice(device_id));
   checkMempoolSupported(device_id) MemPoolGuard mempool(MemPools::dev_default, device_id);
@@ -496,7 +496,7 @@ static void resetHighValue(hipMemPool_t& memPool) {
  * ------------------------
  *    - HIP_VERSION >= 6.2
  */
-TEST_CASE("Unit_hipMemPoolSetAttribute_ResetMemHighAttr") {
+TEST_CASE(Unit_hipMemPoolSetAttribute_ResetMemHighAttr) {
   checkMempoolSupported(0)
       // Create mempool
       hipMemPool_t mem_pool;
@@ -556,7 +556,7 @@ TEST_CASE("Unit_hipMemPoolSetAttribute_ResetMemHighAttr") {
  * ------------------------
  *  - HIP_VERSION >= 6.2
  */
-TEST_CASE("Unit_hipMemPoolGetAttribute_Negative_Parameters") {
+TEST_CASE(Unit_hipMemPoolGetAttribute_Negative_Parameters) {
   int device_id = 0;
   HIP_CHECK(hipSetDevice(device_id));
   checkMempoolSupported(device_id) MemPoolGuard mempool(MemPools::dev_default, device_id);
@@ -666,7 +666,7 @@ static bool checkhipMemPoolSetAttribute(hipMemPoolAttr attr, int dev) {
  * ------------------------
  *    - HIP_VERSION >= 6.2
  */
-TEST_CASE("Unit_hipMemPoolGetAttribute_SetGet") {
+TEST_CASE(Unit_hipMemPoolGetAttribute_SetGet) {
   int numDevices = 0;
   HIP_CHECK(hipGetDeviceCount(&numDevices));
   for (int dev = 0; dev < numDevices; dev++) {
@@ -688,7 +688,7 @@ TEST_CASE("Unit_hipMemPoolGetAttribute_SetGet") {
  * ------------------------
  *    - HIP_VERSION >= 6.2
  */
-TEST_CASE("Unit_hipMemPoolGetAttribute_UsedMem") {
+TEST_CASE(Unit_hipMemPoolGetAttribute_UsedMem) {
   checkMempoolSupported(0) constexpr int N = 1 << 14;
   hipMemPool_t mem_pool;
   hipMemPoolProps pool_props{};
@@ -776,7 +776,7 @@ TEST_CASE("Unit_hipMemPoolGetAttribute_UsedMem") {
  * ------------------------
  *    - HIP_VERSION >= 6.2
  */
-TEST_CASE("Unit_hipMemPoolGetAttribute_ReservedMem") {
+TEST_CASE(Unit_hipMemPoolGetAttribute_ReservedMem) {
   checkMempoolSupported(0) constexpr int N = 1 << 14;
   hipMemPool_t mem_pool;
   hipMemPoolProps pool_props{};
@@ -819,7 +819,7 @@ TEST_CASE("Unit_hipMemPoolGetAttribute_ReservedMem") {
  * ------------------------
  *    - HIP_VERSION >= 6.2
  */
-TEST_CASE("Unit_hipMemPoolGetAttribute_UsageStatistics") {
+TEST_CASE(Unit_hipMemPoolGetAttribute_UsageStatistics) {
   checkMempoolSupported(0) struct mempoolUsgStat stats;
   // Create mempool
   hipMemPool_t mem_pool;
@@ -891,7 +891,7 @@ TEST_CASE("Unit_hipMemPoolGetAttribute_UsageStatistics") {
  * ------------------------
  *    - HIP_VERSION >= 6.2
  */
-TEST_CASE("Unit_hipMemPoolGetAttribute_hipMalloc_DefMempool") {
+TEST_CASE(Unit_hipMemPoolGetAttribute_hipMalloc_DefMempool) {
   checkMempoolSupported(0) struct mempoolUsgStat stats;
   // Create mempool
   hipMemPool_t mem_pool;
@@ -927,7 +927,7 @@ TEST_CASE("Unit_hipMemPoolGetAttribute_hipMalloc_DefMempool") {
  * ------------------------
  *    - HIP_VERSION >= 6.2
  */
-TEST_CASE("Unit_hipMemPoolGetAttribute_CheckDefaultValues") {
+TEST_CASE(Unit_hipMemPoolGetAttribute_CheckDefaultValues) {
   int numDevices = 0;
   HIP_CHECK(hipGetDeviceCount(&numDevices));
   for (int dev = 0; dev < numDevices; dev++) {

--- a/projects/hip-tests/catch/unit/memory/hipMemPoolTrimTo.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemPoolTrimTo.cc
@@ -44,7 +44,7 @@
  * ------------------------
  *  - HIP_VERSION >= 6.2
  */
-TEST_CASE("Unit_hipMemPoolTrimTo_Negative_Parameter") {
+TEST_CASE(Unit_hipMemPoolTrimTo_Negative_Parameter) {
   int device_id = 0;
   HIP_CHECK(hipSetDevice(device_id));
   checkMempoolSupported(device_id) size_t trim_size = 1024;
@@ -66,7 +66,7 @@ TEST_CASE("Unit_hipMemPoolTrimTo_Negative_Parameter") {
  * ------------------------
  *  - HIP_VERSION >= 6.2
  */
-TEST_CASE("Unit_hipMemPoolTrimTo_Positive_Basic") {
+TEST_CASE(Unit_hipMemPoolTrimTo_Positive_Basic) {
   int device_id = 0;
   HIP_CHECK(hipSetDevice(device_id));
   checkMempoolSupported(device_id) unsigned int* notified = nullptr;
@@ -198,7 +198,7 @@ static bool checkhipMemPoolTrimTo(hipStream_t stream, int N, int dev = 0) {
  * ------------------------
  *    - HIP_VERSION >= 6.2
  */
-TEST_CASE("Unit_hipMemPoolTrimTo_VaryingMinBytesToHold") {
+TEST_CASE(Unit_hipMemPoolTrimTo_VaryingMinBytesToHold) {
   checkMempoolSupported(0)
       // create a stream
       hipStream_t stream;
@@ -218,7 +218,7 @@ TEST_CASE("Unit_hipMemPoolTrimTo_VaryingMinBytesToHold") {
  * ------------------------
  *    - HIP_VERSION >= 6.2
  */
-TEST_CASE("Unit_hipMemPoolTrimTo_MGpuVaryingMinBytesToHold") {
+TEST_CASE(Unit_hipMemPoolTrimTo_MGpuVaryingMinBytesToHold) {
   constexpr int N = 1 << 20;
   int numDevices = 0;
   HIP_CHECK(hipGetDeviceCount(&numDevices));

--- a/projects/hip-tests/catch/unit/memory/hipMemPrefetchAsync.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemPrefetchAsync.cc
@@ -47,7 +47,7 @@ __global__ void MemPrefetchAsyncKernel(int* C_d, const int* A_d, size_t N) {
   }
 }
 
-TEST_CASE("Unit_hipMemPrefetchAsync_Basic_AllDevices", "[multigpu]") {
+TEST_CASE(Unit_hipMemPrefetchAsync_Basic_AllDevices) {
   const auto supported_devices = GetDevicesWithPrefetchSupport();
   if (supported_devices.empty()) {
     HipTest::HIP_SKIP_TEST("Test need at least one device with managed memory support");
@@ -77,7 +77,7 @@ TEST_CASE("Unit_hipMemPrefetchAsync_Basic_AllDevices", "[multigpu]") {
   ArrayFindIfNot(alloc1.ptr(), fill_value, count);
 }
 
-TEST_CASE("Unit_hipMemPrefetchAsync_Sync_Behavior") {
+TEST_CASE(Unit_hipMemPrefetchAsync_Sync_Behavior) {
   const auto supported_devices = GetDevicesWithPrefetchSupport();
   if (supported_devices.empty()) {
     HipTest::HIP_SKIP_TEST("Test need at least one device with managed memory support");
@@ -94,7 +94,7 @@ TEST_CASE("Unit_hipMemPrefetchAsync_Sync_Behavior") {
   HIP_CHECK(hipStreamSynchronize(sg.stream()));
 }
 
-TEST_CASE("Unit_hipMemPrefetchAsync_Rounding_Behavior") {
+TEST_CASE(Unit_hipMemPrefetchAsync_Rounding_Behavior) {
   auto supported_devices = GetDevicesWithPrefetchSupport();
   if (supported_devices.empty()) {
     HipTest::HIP_SKIP_TEST("Test need at least one device with managed memory support");
@@ -127,7 +127,7 @@ TEST_CASE("Unit_hipMemPrefetchAsync_Rounding_Behavior") {
           static_cast<int>(attribute));
 }
 
-TEST_CASE("Unit_hipMemPrefetchAsync_Negative_Parameters") {
+TEST_CASE(Unit_hipMemPrefetchAsync_Negative_Parameters) {
   auto supported_devices = GetDevicesWithPrefetchSupport();
   if (supported_devices.empty()) {
     HipTest::HIP_SKIP_TEST("Test need at least one device with managed memory support");

--- a/projects/hip-tests/catch/unit/memory/hipMemPrefetchAsyncExtTsts.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemPrefetchAsyncExtTsts.cc
@@ -68,7 +68,7 @@ static int HmmAttrPrint() {
    call hipMemAdvise() on the memory and apply the flags ReadMostly,
    AccessedBy, and PreferredLocation for gpus other than gpu 0 and verify
    the flags using hipMemGetAttribute()*/
-TEST_CASE("Unit_hipMemPrefetchAsyncAdviseFlgTst") {
+TEST_CASE(Unit_hipMemPrefetchAsyncAdviseFlgTst) {
   int NGpus = 0;
   HIP_CHECK(hipGetDeviceCount(&NGpus));
   if (NGpus >= 2) {
@@ -133,7 +133,7 @@ TEST_CASE("Unit_hipMemPrefetchAsyncAdviseFlgTst") {
     AccessedBy using hipMemGetAttribute() and validate if AccessedBy is still
     set to gpu1. Similar tests are done with ReadMostly and PreferredLocation
     flags */
-TEST_CASE("Unit_hipMemPrefetchAsyncAccsdByTst") {
+TEST_CASE(Unit_hipMemPrefetchAsyncAccsdByTst) {
   int NGpus = 0;
   HIP_CHECK(hipGetDeviceCount(&NGpus));
   if (NGpus >= 2) {
@@ -224,7 +224,7 @@ TEST_CASE("Unit_hipMemPrefetchAsyncAccsdByTst") {
 }
 
 /*Test Case description: Negative testing with hipMemPrefetchAsync() api*/
-TEST_CASE("Unit_hipMemPrefetchAsyncNegativeTst") {
+TEST_CASE(Unit_hipMemPrefetchAsyncNegativeTst) {
   int MangdMem = HmmAttrPrint();
   if (MangdMem == 1) {
     int *Hmm = nullptr, MemSz = 4096 * 4, NumElms = MemSz / 4, InitVal = 123;
@@ -325,7 +325,7 @@ TEST_CASE("Unit_hipMemPrefetchAsyncNegativeTst") {
 /* Test Case description: In this test case I am trying to allocate HMM memory
    which is not multiple of page Size, but still trying to launch kernel and
    see if we are getting values as expected.*/
-TEST_CASE("Unit_hipMemPrefetchAsync_NonPageSz") {
+TEST_CASE(Unit_hipMemPrefetchAsync_NonPageSz) {
   int *Hmm = nullptr, NumElms = 4096 * 2, InitVal = 123;
   hipStream_t strm;
   bool IfTestPassed = true;

--- a/projects/hip-tests/catch/unit/memory/hipMemPrefetchAsync_v2.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemPrefetchAsync_v2.cc
@@ -70,7 +70,7 @@ static std::vector<int> getSupportedDevices() {
  * ------------------------
  *  - HIP_VERSION >= 7.1
  */
-TEST_CASE("Unit_hipMemPrefetchAsync_v2_Device_Host", "[multigpu]") {
+TEST_CASE(Unit_hipMemPrefetchAsync_v2_Device_Host) {
   auto supportedDevices = getSupportedDevices();
   if (supportedDevices.empty()) {
     HipTest::HIP_SKIP_TEST(
@@ -183,7 +183,7 @@ TEST_CASE("Unit_hipMemPrefetchAsync_v2_Device_Host", "[multigpu]") {
  *  - HIP_VERSION >= 7.1
  */
 #if __linux__
-TEST_CASE("Unit_hipMemPrefetchAsync_v2_HostNuma_HostNumaCurrent") {
+TEST_CASE(Unit_hipMemPrefetchAsync_v2_HostNuma_HostNumaCurrent) {
   auto supportedDevices = getSupportedDevices();
   if (supportedDevices.empty() || numa_available() < 0) {
     HipTest::HIP_SKIP_TEST("Skipping as System does not have managed memory "
@@ -303,7 +303,7 @@ TEST_CASE("Unit_hipMemPrefetchAsync_v2_HostNuma_HostNumaCurrent") {
  * ------------------------
  *  - HIP_VERSION >= 7.1
  */
-TEST_CASE("Unit_hipMemPrefetchAsync_v2_Negative") {
+TEST_CASE(Unit_hipMemPrefetchAsync_v2_Negative) {
   auto supportedDevices = getSupportedDevices();
   if (supportedDevices.empty()) {
     HipTest::HIP_SKIP_TEST(

--- a/projects/hip-tests/catch/unit/memory/hipMemPtrGetInfo.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemPtrGetInfo.cc
@@ -37,7 +37,7 @@ hipMemPtrGetInfo API
 2. Gets the allocated size of that variable using hipMemPtrGetInfo API
 3. Validates the initial size and allocated size
 */
-TEST_CASE("Unit_hipMemPtrGetInfo_Basic") {
+TEST_CASE(Unit_hipMemPtrGetInfo_Basic) {
   int* iPtr;
   float* fPtr;
   MemInfo* sPtr;
@@ -61,7 +61,7 @@ TEST_CASE("Unit_hipMemPtrGetInfo_Basic") {
 This testcase verifies the scenario of
 hipMemPtrGetInfo API being called on a zero-sized allocation.
 */
-TEST_CASE("Unit_hipMemPtrGetInfo_SizeZeroAllocation") {
+TEST_CASE(Unit_hipMemPtrGetInfo_SizeZeroAllocation) {
   int* iPtr;
   size_t sSetSize = 0, sGetSize;
   HIP_CHECK(hipMalloc(&iPtr, sSetSize));

--- a/projects/hip-tests/catch/unit/memory/hipMemRangeGetAttribute.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemRangeGetAttribute.cc
@@ -25,7 +25,7 @@ THE SOFTWARE.
 #include <resource_guards.hh>
 #include <utils.hh>
 
-TEST_CASE("Unit_hipMemRangeGetAttribute_Positive_ReadMostly_Basic") {
+TEST_CASE(Unit_hipMemRangeGetAttribute_Positive_ReadMostly_Basic) {
   if (!DeviceAttributesSupport(0, hipDeviceAttributeManagedMemory)) {
     HipTest::HIP_SKIP_TEST("Managed memory not supported");
     return;
@@ -46,7 +46,7 @@ TEST_CASE("Unit_hipMemRangeGetAttribute_Positive_ReadMostly_Basic") {
   REQUIRE(data == 1);
 }
 
-TEST_CASE("Unit_hipMemRangeGetAttribute_Positive_ReadMostly_Partial_Range") {
+TEST_CASE(Unit_hipMemRangeGetAttribute_Positive_ReadMostly_Partial_Range) {
   if (!DeviceAttributesSupport(0, hipDeviceAttributeManagedMemory)) {
     HipTest::HIP_SKIP_TEST("Managed memory not supported");
     return;
@@ -68,7 +68,7 @@ TEST_CASE("Unit_hipMemRangeGetAttribute_Positive_ReadMostly_Partial_Range") {
   REQUIRE(data == 1);
 }
 
-TEST_CASE("Unit_hipMemRangeGetAttribute_Positive_PreferredLocation_Basic") {
+TEST_CASE(Unit_hipMemRangeGetAttribute_Positive_PreferredLocation_Basic) {
   if (!DeviceAttributesSupport(0, hipDeviceAttributeManagedMemory)) {
     HipTest::HIP_SKIP_TEST("Managed memory not supported");
     return;
@@ -89,7 +89,7 @@ TEST_CASE("Unit_hipMemRangeGetAttribute_Positive_PreferredLocation_Basic") {
   REQUIRE(data == 0);
 }
 
-TEST_CASE("Unit_hipMemRangeGetAttribute_Positive_PreferredLocation_CPU") {
+TEST_CASE(Unit_hipMemRangeGetAttribute_Positive_PreferredLocation_CPU) {
   if (!DeviceAttributesSupport(0, hipDeviceAttributeManagedMemory)) {
     HipTest::HIP_SKIP_TEST("Managed memory not supported");
     return;
@@ -107,7 +107,7 @@ TEST_CASE("Unit_hipMemRangeGetAttribute_Positive_PreferredLocation_CPU") {
   REQUIRE(data == hipCpuDeviceId);
 }
 
-TEST_CASE("Unit_hipMemRangeGetAttribute_Positive_PreferredLocation_Partial_Range") {
+TEST_CASE(Unit_hipMemRangeGetAttribute_Positive_PreferredLocation_Partial_Range) {
   if (!DeviceAttributesSupport(0, hipDeviceAttributeManagedMemory)) {
     HipTest::HIP_SKIP_TEST("Managed memory not supported");
     return;
@@ -129,7 +129,7 @@ TEST_CASE("Unit_hipMemRangeGetAttribute_Positive_PreferredLocation_Partial_Range
   REQUIRE(data == 0);
 }
 
-TEST_CASE("Unit_hipMemRangeGetAttribute_Positive_LastPrefetchLocation_Basic") {
+TEST_CASE(Unit_hipMemRangeGetAttribute_Positive_LastPrefetchLocation_Basic) {
   if (!DeviceAttributesSupport(0, hipDeviceAttributeManagedMemory)) {
     HipTest::HIP_SKIP_TEST("Managed memory not supported");
     return;
@@ -150,7 +150,7 @@ TEST_CASE("Unit_hipMemRangeGetAttribute_Positive_LastPrefetchLocation_Basic") {
   REQUIRE(data == 0);
 }
 
-TEST_CASE("Unit_hipMemRangeGetAttribute_Positive_LastPrefetchLocation_CPU") {
+TEST_CASE(Unit_hipMemRangeGetAttribute_Positive_LastPrefetchLocation_CPU) {
   if (!DeviceAttributesSupport(0, hipDeviceAttributeManagedMemory)) {
     HipTest::HIP_SKIP_TEST("Managed memory not supported");
     return;
@@ -167,7 +167,7 @@ TEST_CASE("Unit_hipMemRangeGetAttribute_Positive_LastPrefetchLocation_CPU") {
   REQUIRE(data == hipCpuDeviceId);
 }
 
-TEST_CASE("Unit_hipMemRangeGetAttribute_Positive_LastPrefetchLocation_Partial_Range") {
+TEST_CASE(Unit_hipMemRangeGetAttribute_Positive_LastPrefetchLocation_Partial_Range) {
   if (!DeviceAttributesSupport(0, hipDeviceAttributeManagedMemory)) {
     HipTest::HIP_SKIP_TEST("Managed memory not supported");
     return;
@@ -189,7 +189,7 @@ TEST_CASE("Unit_hipMemRangeGetAttribute_Positive_LastPrefetchLocation_Partial_Ra
   REQUIRE(data == 0);
 }
 
-TEST_CASE("Unit_hipMemRangeGetAttribute_Positive_AccessedBy_Basic") {
+TEST_CASE(Unit_hipMemRangeGetAttribute_Positive_AccessedBy_Basic) {
   if (!DeviceAttributesSupport(0, hipDeviceAttributeManagedMemory)) {
     HipTest::HIP_SKIP_TEST("Managed memory not supported");
     return;
@@ -220,7 +220,7 @@ TEST_CASE("Unit_hipMemRangeGetAttribute_Positive_AccessedBy_Basic") {
   }
 }
 
-TEST_CASE("Unit_hipMemRangeGetAttribute_Positive_AccessedBy_Partial_Range") {
+TEST_CASE(Unit_hipMemRangeGetAttribute_Positive_AccessedBy_Partial_Range) {
   if (!DeviceAttributesSupport(0, hipDeviceAttributeManagedMemory)) {
     HipTest::HIP_SKIP_TEST("Managed memory not supported");
     return;
@@ -252,7 +252,7 @@ TEST_CASE("Unit_hipMemRangeGetAttribute_Positive_AccessedBy_Partial_Range") {
   }
 }
 
-TEST_CASE("Unit_hipMemRangeGetAttribute_Positive_AccessedBy_MultiDevice") {
+TEST_CASE(Unit_hipMemRangeGetAttribute_Positive_AccessedBy_MultiDevice) {
   if (!DeviceAttributesSupport(0, hipDeviceAttributeManagedMemory)) {
     HipTest::HIP_SKIP_TEST("Managed memory not supported");
     return;
@@ -287,7 +287,7 @@ TEST_CASE("Unit_hipMemRangeGetAttribute_Positive_AccessedBy_MultiDevice") {
   }
 }
 
-TEST_CASE("Unit_hipMemRangeGetAttribute_Negative_Parameters") {
+TEST_CASE(Unit_hipMemRangeGetAttribute_Negative_Parameters) {
   if (!DeviceAttributesSupport(0, hipDeviceAttributeManagedMemory)) {
     HipTest::HIP_SKIP_TEST("Managed memory not supported");
     return;

--- a/projects/hip-tests/catch/unit/memory/hipMemRangeGetAttribute_old.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemRangeGetAttribute_old.cc
@@ -54,7 +54,7 @@ static int HmmAttrPrint() {
 // hipMemRangeGetAttribute api by passing possible extreme values.
 // Curently the only way to test if count param working properly is to verify
 // the first parameter of hipMemRangeGetAttribute() api has value 1 stored
-TEST_CASE("Unit_hipMemRangeGetAttribute_TstCountParam") {
+TEST_CASE(Unit_hipMemRangeGetAttribute_TstCountParam) {
   int MangdMem = HmmAttrPrint();
   if (MangdMem == 1) {
 #if HT_AMD
@@ -116,7 +116,7 @@ TEST_CASE("Unit_hipMemRangeGetAttribute_TstCountParam") {
 
 /* This test case checks the behavior of hipMemRangeGetAttribute() with
    AccessedBy flag is consistent with cuda's counter part*/
-TEST_CASE("Unit_hipMemRangeGetAttribute_AccessedBy1") {
+TEST_CASE(Unit_hipMemRangeGetAttribute_AccessedBy1) {
   int managed = HmmAttrPrint();
   if (managed == 1) {
     int Ngpus = 0, *Hmm = NULL, MEM_SZ = 4096, RND_NUM = 999;
@@ -173,7 +173,7 @@ TEST_CASE("Unit_hipMemRangeGetAttribute_AccessedBy1") {
    by hipMemAdvise() but being probed using hipMemRangeGetAttribute() should
    not result in a crash*/
 
-TEST_CASE("Unit_hipMemRangeGetAttribute_4") {
+TEST_CASE(Unit_hipMemRangeGetAttribute_4) {
   int managed = HmmAttrPrint();
   if (managed == 1) {
     int *Hmm = NULL, PageSz = 4096, Ngpus, RND_NUM = 999;

--- a/projects/hip-tests/catch/unit/memory/hipMemRangeGetAttributes.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemRangeGetAttributes.cc
@@ -25,7 +25,7 @@ THE SOFTWARE.
 #include <resource_guards.hh>
 #include <utils.hh>
 
-TEST_CASE("Unit_hipMemRangeGetAttributes_Positive_Basic") {
+TEST_CASE(Unit_hipMemRangeGetAttributes_Positive_Basic) {
   if (!DeviceAttributesSupport(0, hipDeviceAttributeManagedMemory)) {
     HipTest::HIP_SKIP_TEST("Managed memory not supported");
     return;
@@ -63,7 +63,7 @@ TEST_CASE("Unit_hipMemRangeGetAttributes_Positive_Basic") {
   }
 }
 
-TEST_CASE("Unit_hipMemRangeGetAttributes_Negative_Parameters") {
+TEST_CASE(Unit_hipMemRangeGetAttributes_Negative_Parameters) {
   if (!DeviceAttributesSupport(0, hipDeviceAttributeManagedMemory)) {
     HipTest::HIP_SKIP_TEST("Managed memory not supported");
     return;

--- a/projects/hip-tests/catch/unit/memory/hipMemVmm.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemVmm.cc
@@ -36,7 +36,7 @@
     This testcase verifies HIP Mem VMM API basic scenario - supported on all devices
  */
 
-TEST_CASE("Unit_hipMemVmm_Basic") {
+TEST_CASE(Unit_hipMemVmm_Basic) {
   int vmm = 0;
   HIP_CHECK(hipDeviceGetAttribute(&vmm, hipDeviceAttributeVirtualMemoryManagementSupported, 0));
   INFO("hipDeviceAttributeVirtualMemoryManagementSupported: " << vmm);
@@ -96,7 +96,7 @@ TEST_CASE("Unit_hipMemVmm_Basic") {
  */
 
 #if HT_AMD
-TEST_CASE("Unit_hipMemVmm_Uncached") {
+TEST_CASE(Unit_hipMemVmm_Uncached) {
   int vmm = 0;
   HIP_CHECK(hipDeviceGetAttribute(&vmm, hipDeviceAttributeVirtualMemoryManagementSupported, 0));
   INFO("hipDeviceAttributeVirtualMemoryManagementSupported: " << vmm);

--- a/projects/hip-tests/catch/unit/memory/hipMemcpy2D.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemcpy2D.cc
@@ -27,7 +27,7 @@ THE SOFTWARE.
 #include <resource_guards.hh>
 #include <utils.hh>
 
-TEST_CASE("Unit_hipMemcpy2D_Positive_Basic", "[multigpu]") {
+TEST_CASE(Unit_hipMemcpy2D_Positive_Basic) {
   CHECK_IMAGE_SUPPORT
   constexpr bool async = false;
 
@@ -42,7 +42,7 @@ TEST_CASE("Unit_hipMemcpy2D_Positive_Basic", "[multigpu]") {
   SECTION("Host to Host") { Memcpy2DHostToHostShell<async>(hipMemcpy2D); }
 }
 
-TEST_CASE("Unit_hipMemcpy2D_Positive_Synchronization_Behavior") {
+TEST_CASE(Unit_hipMemcpy2D_Positive_Synchronization_Behavior) {
   HIP_CHECK(hipDeviceSynchronize());
 
   SECTION("Host to Device") { Memcpy2DHtoDSyncBehavior(hipMemcpy2D, true); }
@@ -65,13 +65,13 @@ TEST_CASE("Unit_hipMemcpy2D_Positive_Synchronization_Behavior") {
 #endif
 }
 
-TEST_CASE("Unit_hipMemcpy2D_Positive_Parameters") {
+TEST_CASE(Unit_hipMemcpy2D_Positive_Parameters) {
   CHECK_IMAGE_SUPPORT
   constexpr bool async = false;
   Memcpy2DZeroWidthHeight<async>(hipMemcpy2D);
 }
 
-TEST_CASE("Unit_hipMemcpy2D_Negative_Parameters") {
+TEST_CASE(Unit_hipMemcpy2D_Negative_Parameters) {
   CHECK_IMAGE_SUPPORT
   constexpr size_t cols = 128;
   constexpr size_t rows = 128;
@@ -152,7 +152,7 @@ TEST_CASE("Unit_hipMemcpy2D_Negative_Parameters") {
   }
 }
 
-TEST_CASE("Unit_hipMemcpy2D_Capture") {
+TEST_CASE(Unit_hipMemcpy2D_Capture) {
   CHECK_IMAGE_SUPPORT
 
   constexpr size_t width = 16;

--- a/projects/hip-tests/catch/unit/memory/hipMemcpy2DArrayToArray.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemcpy2DArrayToArray.cc
@@ -32,7 +32,7 @@ bool compare_arrays(int* arr1, int* arr2, int width, int height) {
   return true;
 }
 
-TEST_CASE("Unit_hipMemcpy2DArrayToArray_Negative") {
+TEST_CASE(Unit_hipMemcpy2DArrayToArray_Negative) {
   CHECK_IMAGE_SUPPORT
 
   constexpr int width = 256;
@@ -112,7 +112,7 @@ TEST_CASE("Unit_hipMemcpy2DArrayToArray_Negative") {
   HIP_CHECK(hipFreeArray(d_dst_arr));
 }
 
-TEST_CASE("Unit_hipMemcpy2DArrayToArray_Positive") {
+TEST_CASE(Unit_hipMemcpy2DArrayToArray_Positive) {
   CHECK_IMAGE_SUPPORT
 
   constexpr int width = 4;
@@ -167,7 +167,7 @@ TEST_CASE("Unit_hipMemcpy2DArrayToArray_Positive") {
  * ------------------------
  *    - HIP_VERSION >= 6.2
  */
-TEST_CASE("Unit_hipMemcpy2DArrayToArray_BasicPositive") {
+TEST_CASE(Unit_hipMemcpy2DArrayToArray_BasicPositive) {
   CHECK_IMAGE_SUPPORT
 
   const size_t width = 1024;

--- a/projects/hip-tests/catch/unit/memory/hipMemcpy2DAsync.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemcpy2DAsync.cc
@@ -27,7 +27,7 @@ THE SOFTWARE.
 #include <resource_guards.hh>
 #include <utils.hh>
 
-TEST_CASE("Unit_hipMemcpy2DAsync_Positive_Basic", "[multigpu]") {
+TEST_CASE(Unit_hipMemcpy2DAsync_Positive_Basic) {
   using namespace std::placeholders;
 
   constexpr bool async = true;
@@ -63,7 +63,7 @@ TEST_CASE("Unit_hipMemcpy2DAsync_Positive_Basic", "[multigpu]") {
   }
 }
 
-TEST_CASE("Unit_hipMemcpy2DAsync_Positive_Synchronization_Behavior") {
+TEST_CASE(Unit_hipMemcpy2DAsync_Positive_Synchronization_Behavior) {
   CHECK_IMAGE_SUPPORT
   using namespace std::placeholders;
 
@@ -99,14 +99,14 @@ TEST_CASE("Unit_hipMemcpy2DAsync_Positive_Synchronization_Behavior") {
 #endif
 }
 
-TEST_CASE("Unit_hipMemcpy2DAsync_Positive_Parameters") {
+TEST_CASE(Unit_hipMemcpy2DAsync_Positive_Parameters) {
   CHECK_IMAGE_SUPPORT
   using namespace std::placeholders;
   constexpr bool async = true;
   Memcpy2DZeroWidthHeight<async>(std::bind(hipMemcpy2DAsync, _1, _2, _3, _4, _5, _6, _7, nullptr));
 }
 
-TEST_CASE("Unit_hipMemcpy2DAsync_Negative_Parameters") {
+TEST_CASE(Unit_hipMemcpy2DAsync_Negative_Parameters) {
   CHECK_IMAGE_SUPPORT
   constexpr size_t cols = 128;
   constexpr size_t rows = 128;
@@ -193,7 +193,7 @@ TEST_CASE("Unit_hipMemcpy2DAsync_Negative_Parameters") {
  * ------------------------
  *  - HIP_VERSION >= 6.0
  */
-TEMPLATE_TEST_CASE("Unit_hipMemcpy2DAsync_Capture", "", int, float, double) {
+TEMPLATE_TEST_CASE(Unit_hipMemcpy2DAsync_Capture, int, float, double) {
   using ValueType = TestType;
   constexpr int kNumRowsOptions[] = {3, 4, 100};
   constexpr int kNumColsOptions[] = {3, 4, 100};

--- a/projects/hip-tests/catch/unit/memory/hipMemcpy2DAsync_old.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemcpy2DAsync_old.cc
@@ -57,7 +57,7 @@ static constexpr auto ROWS{6};
  *  - HIP_VERSION >= 6.1
  */
 
-TEMPLATE_TEST_CASE("Unit_hipMemcpy2DAsync_Host_N_PinnedMem", "", int, float, double) {
+TEMPLATE_TEST_CASE(Unit_hipMemcpy2DAsync_Host_N_PinnedMem, int, float, double) {
   CHECK_IMAGE_SUPPORT
   // 1 refers to pinned host memory
   auto mem_type = GENERATE(0, 1);
@@ -266,7 +266,7 @@ static void hipMemcpy2DAsync_Basic_Size_Test(size_t inc) {
  *  - HIP_VERSION >= 6.0
  */
 
-TEST_CASE("Unit_hipMemcpy2DAsync_multiDevice_Basic_Size_Test", "[multigpu]") {
+TEST_CASE(Unit_hipMemcpy2DAsync_multiDevice_Basic_Size_Test) {
   CHECK_IMAGE_SUPPORT
   size_t input = 1 << 20;
   int numDevices = 0;

--- a/projects/hip-tests/catch/unit/memory/hipMemcpy2DFromArray.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemcpy2DFromArray.cc
@@ -34,7 +34,7 @@ invalid
 #include <resource_guards.hh>
 #include <utils.hh>
 
-TEST_CASE("Unit_hipMemcpy2DFromArray_Positive_Default", "[multigpu]") {
+TEST_CASE(Unit_hipMemcpy2DFromArray_Positive_Default) {
   CHECK_IMAGE_SUPPORT
 
   using namespace std::placeholders;
@@ -87,7 +87,7 @@ TEST_CASE("Unit_hipMemcpy2DFromArray_Positive_Default", "[multigpu]") {
 #endif
 }
 
-TEST_CASE("Unit_hipMemcpy2DFromArray_Positive_Synchronization_Behavior") {
+TEST_CASE(Unit_hipMemcpy2DFromArray_Positive_Synchronization_Behavior) {
   CHECK_IMAGE_SUPPORT
 
   using namespace std::placeholders;
@@ -116,7 +116,7 @@ TEST_CASE("Unit_hipMemcpy2DFromArray_Positive_Synchronization_Behavior") {
 #endif
 }
 
-TEST_CASE("Unit_hipMemcpy2DFromArray_Positive_ZeroWidthHeight") {
+TEST_CASE(Unit_hipMemcpy2DFromArray_Positive_ZeroWidthHeight) {
   CHECK_IMAGE_SUPPORT
 
   using namespace std::placeholders;
@@ -151,7 +151,7 @@ TEST_CASE("Unit_hipMemcpy2DFromArray_Positive_ZeroWidthHeight") {
   }
 }
 
-TEST_CASE("Unit_hipMemcpy2DFromArray_Negative_Parameters") {
+TEST_CASE(Unit_hipMemcpy2DFromArray_Negative_Parameters) {
   CHECK_IMAGE_SUPPORT
 
   using namespace std::placeholders;
@@ -260,7 +260,7 @@ TEST_CASE("Unit_hipMemcpy2DFromArray_Negative_Parameters") {
   }
 }
 
-TEST_CASE("Unit_hipMemcpy2DFromArray_Capture") {
+TEST_CASE(Unit_hipMemcpy2DFromArray_Capture) {
   CHECK_IMAGE_SUPPORT
 
   const auto width = 16;

--- a/projects/hip-tests/catch/unit/memory/hipMemcpy2DFromArrayAsync.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemcpy2DFromArrayAsync.cc
@@ -34,7 +34,7 @@ of hipMemcpy2DFromArrayAsync api when parameters are invalid
 #include <resource_guards.hh>
 #include <utils.hh>
 
-TEST_CASE("Unit_hipMemcpy2DFromArrayAsync_Positive_Default", "[multigpu]") {
+TEST_CASE(Unit_hipMemcpy2DFromArrayAsync_Positive_Default) {
   CHECK_IMAGE_SUPPORT
 
   using namespace std::placeholders;
@@ -92,7 +92,7 @@ TEST_CASE("Unit_hipMemcpy2DFromArrayAsync_Positive_Default", "[multigpu]") {
 #endif
 }
 
-TEST_CASE("Unit_hipMemcpy2DFromArrayAsync_Positive_Synchronization_Behavior") {
+TEST_CASE(Unit_hipMemcpy2DFromArrayAsync_Positive_Synchronization_Behavior) {
   CHECK_IMAGE_SUPPORT
 
   using namespace std::placeholders;
@@ -122,7 +122,7 @@ TEST_CASE("Unit_hipMemcpy2DFromArrayAsync_Positive_Synchronization_Behavior") {
   }
 }
 
-TEST_CASE("Unit_hipMemcpy2DFromArrayAsync_Positive_ZeroWidthHeight") {
+TEST_CASE(Unit_hipMemcpy2DFromArrayAsync_Positive_ZeroWidthHeight) {
   CHECK_IMAGE_SUPPORT
 
   using namespace std::placeholders;
@@ -162,7 +162,7 @@ TEST_CASE("Unit_hipMemcpy2DFromArrayAsync_Positive_ZeroWidthHeight") {
   }
 }
 
-TEST_CASE("Unit_hipMemcpy2DFromArrayAsync_Negative_Parameters") {
+TEST_CASE(Unit_hipMemcpy2DFromArrayAsync_Negative_Parameters) {
   CHECK_IMAGE_SUPPORT
 
   using namespace std::placeholders;

--- a/projects/hip-tests/catch/unit/memory/hipMemcpy2DFromArrayAsync_old.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemcpy2DFromArrayAsync_old.cc
@@ -32,8 +32,7 @@ static constexpr auto NUM_H{10};
            then A_d-->E_h  in GPU1
  * OUTPUT: validating the result by comparing A_h and E_h
  */
-TEST_CASE("Unit_hipMemcpy2DFromArrayAsync_multiDevicePinnedHostMem",
-          "[multigpu]") {
+TEST_CASE(Unit_hipMemcpy2DFromArrayAsync_multiDevicePinnedHostMem) {
   CHECK_IMAGE_SUPPORT
 
   int numDevices = 0;
@@ -92,8 +91,7 @@ TEST_CASE("Unit_hipMemcpy2DFromArrayAsync_multiDevicePinnedHostMem",
  *         --> A_h host variable
  *         and verifying A_h with Phi
  * */
-TEST_CASE("Unit_hipMemcpy2DFromArrayAsync_multiDeviceContextChange",
-          "[multigpu]") {
+TEST_CASE(Unit_hipMemcpy2DFromArrayAsync_multiDeviceContextChange) {
   CHECK_IMAGE_SUPPORT
 
   int numDevices = 0;
@@ -149,7 +147,7 @@ TEST_CASE("Unit_hipMemcpy2DFromArrayAsync_multiDeviceContextChange",
 * ------------------------
 *  - HIP_VERSION >= 6.0
 */
-TEST_CASE("Unit_hipMemcpy2DFromArrayAsync_Capture") {
+TEST_CASE(Unit_hipMemcpy2DFromArrayAsync_Capture) {
   CHECK_IMAGE_SUPPORT
 
   constexpr int kTestSizes[] = {3, 4, 100};

--- a/projects/hip-tests/catch/unit/memory/hipMemcpy2DFromArray_old.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemcpy2DFromArray_old.cc
@@ -22,7 +22,6 @@ THE SOFTWARE.
 
 static constexpr auto NUM_W{10};
 static constexpr auto NUM_H{10};
-
 /*
  * This Scenario Verifies hipMemcpy2DFromArray API by copying the
  * data from pinned host memory to device from Peer GPU.
@@ -33,8 +32,7 @@ static constexpr auto NUM_H{10};
  *         --> E_h host variable
  *         and verifying A_h with E_h
  */
-TEST_CASE("Unit_hipMemcpy2DFromArray_multiDevicePinnedMemPeerGpu",
-          "[multigpu]") {
+TEST_CASE(Unit_hipMemcpy2DFromArray_multiDevicePinnedMemPeerGpu) {
   CHECK_IMAGE_SUPPORT
 
   int numDevices = 0;
@@ -87,7 +85,7 @@ TEST_CASE("Unit_hipMemcpy2DFromArray_multiDevicePinnedMemPeerGpu",
  *         --> A_h host variable
  *         and verifying A_h with Phi
  * */
-TEST_CASE("Unit_hipMemcpy2DFromArray_multiDeviceContextChange", "[multigpu]") {
+TEST_CASE(Unit_hipMemcpy2DFromArray_multiDeviceContextChange) {
   CHECK_IMAGE_SUPPORT
 
   int numDevices = 0;

--- a/projects/hip-tests/catch/unit/memory/hipMemcpy2DToArray.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemcpy2DToArray.cc
@@ -33,7 +33,7 @@ unsuccessful execution of hipMemcpy2DToArray api when parameters are invalid
 #include <resource_guards.hh>
 #include <utils.hh>
 
-TEST_CASE("Unit_hipMemcpy2DToArray_Positive_Default", "[multigpu]") {
+TEST_CASE(Unit_hipMemcpy2DToArray_Positive_Default) {
   CHECK_IMAGE_SUPPORT
 
   using namespace std::placeholders;
@@ -85,7 +85,7 @@ TEST_CASE("Unit_hipMemcpy2DToArray_Positive_Default", "[multigpu]") {
 #endif
 }
 
-TEST_CASE("Unit_hipMemcpy2DToArray_Positive_Synchronization_Behavior") {
+TEST_CASE(Unit_hipMemcpy2DToArray_Positive_Synchronization_Behavior) {
   CHECK_IMAGE_SUPPORT
 
   using namespace std::placeholders;
@@ -111,7 +111,7 @@ TEST_CASE("Unit_hipMemcpy2DToArray_Positive_Synchronization_Behavior") {
 #endif
 }
 
-TEST_CASE("Unit_hipMemcpy2DToArray_Positive_ZeroWidthHeight") {
+TEST_CASE(Unit_hipMemcpy2DToArray_Positive_ZeroWidthHeight) {
   CHECK_IMAGE_SUPPORT
 
   using namespace std::placeholders;
@@ -146,7 +146,7 @@ TEST_CASE("Unit_hipMemcpy2DToArray_Positive_ZeroWidthHeight") {
   }
 }
 
-TEST_CASE("Unit_hipMemcpy2DToArray_Negative_Parameters") {
+TEST_CASE(Unit_hipMemcpy2DToArray_Negative_Parameters) {
   CHECK_IMAGE_SUPPORT
 
   using namespace std::placeholders;
@@ -255,7 +255,7 @@ TEST_CASE("Unit_hipMemcpy2DToArray_Negative_Parameters") {
   }
 }
 
-TEST_CASE("Unit_hipMemcpy2DToArray_Capture") {
+TEST_CASE(Unit_hipMemcpy2DToArray_Capture) {
   CHECK_IMAGE_SUPPORT
 
   const auto width = 16;

--- a/projects/hip-tests/catch/unit/memory/hipMemcpy2DToArrayAsync.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemcpy2DToArrayAsync.cc
@@ -34,7 +34,7 @@ of hipMemcpy2DToArrayAsync api when parameters are invalid
 #include <resource_guards.hh>
 #include <utils.hh>
 
-TEST_CASE("Unit_hipMemcpy2DToArrayAsync_Positive_Default", "[multigpu]") {
+TEST_CASE(Unit_hipMemcpy2DToArrayAsync_Positive_Default) {
   CHECK_IMAGE_SUPPORT
 
   using namespace std::placeholders;
@@ -92,7 +92,7 @@ TEST_CASE("Unit_hipMemcpy2DToArrayAsync_Positive_Default", "[multigpu]") {
 #endif
 }
 
-TEST_CASE("Unit_hipMemcpy2DToArrayAsync_Positive_Synchronization_Behavior") {
+TEST_CASE(Unit_hipMemcpy2DToArrayAsync_Positive_Synchronization_Behavior) {
   CHECK_IMAGE_SUPPORT
 
   using namespace std::placeholders;
@@ -117,7 +117,7 @@ TEST_CASE("Unit_hipMemcpy2DToArrayAsync_Positive_Synchronization_Behavior") {
   }
 }
 
-TEST_CASE("Unit_hipMemcpy2DToArrayAsync_Positive_ZeroWidthHeight") {
+TEST_CASE(Unit_hipMemcpy2DToArrayAsync_Positive_ZeroWidthHeight) {
   CHECK_IMAGE_SUPPORT
 
   using namespace std::placeholders;
@@ -156,7 +156,7 @@ TEST_CASE("Unit_hipMemcpy2DToArrayAsync_Positive_ZeroWidthHeight") {
   }
 }
 
-TEST_CASE("Unit_hipMemcpy2DToArrayAsync_Negative_Parameters") {
+TEST_CASE(Unit_hipMemcpy2DToArrayAsync_Negative_Parameters) {
   CHECK_IMAGE_SUPPORT
 
   using namespace std::placeholders;
@@ -279,7 +279,7 @@ TEST_CASE("Unit_hipMemcpy2DToArrayAsync_Negative_Parameters") {
 static constexpr int kNumWidth = 10;
 static constexpr int kNumHeight = 10;
 
-TEST_CASE("Unit_hipMemcpy2DToArrayAsync_Capture") {
+TEST_CASE(Unit_hipMemcpy2DToArrayAsync_Capture) {
   CHECK_IMAGE_SUPPORT
 
   constexpr size_t kHostRowBytes = sizeof(float) * kNumWidth;

--- a/projects/hip-tests/catch/unit/memory/hipMemcpy2DToArrayAsync_old.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemcpy2DToArrayAsync_old.cc
@@ -34,8 +34,7 @@ static constexpr auto NUM_H{10};
  *         --> A_h host variable
  *         and verifying A_h with E_h[0]+i(i.e., 10+i)
  */
-TEST_CASE("Unit_hipMemcpy2DToArrayAsync_multiDevicePinnedHostMem",
-          "[multigpu]") {
+TEST_CASE(Unit_hipMemcpy2DToArrayAsync_multiDevicePinnedHostMem) {
   CHECK_IMAGE_SUPPORT
 
   int numDevices = 0;
@@ -95,8 +94,7 @@ TEST_CASE("Unit_hipMemcpy2DToArrayAsync_multiDevicePinnedHostMem",
  *         --> A_h host variable
  *         and verifying A_h with Phi
  * */
-TEST_CASE("Unit_hipMemcpy2DToArrayAsync_multiDeviceDeviceContextChange",
-          "[multigpu]") {
+TEST_CASE(Unit_hipMemcpy2DToArrayAsync_multiDeviceDeviceContextChange) {
   CHECK_IMAGE_SUPPORT
 
   int numDevices = 0;

--- a/projects/hip-tests/catch/unit/memory/hipMemcpy2DToArray_old.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemcpy2DToArray_old.cc
@@ -22,7 +22,6 @@ THE SOFTWARE.
 
 static constexpr auto NUM_W{10};
 static constexpr auto NUM_H{10};
-
 /*
  * This Scenario Verifies hipMemcpy2DToArray API by copying the
  * data from pinned host memory to device from Peer GPU.
@@ -34,7 +33,7 @@ static constexpr auto NUM_H{10};
  *         --> A_h host variable
  *         and verifying A_h with E_h[0]+i(i.e., 10+i)
  */
-TEST_CASE("Unit_hipMemcpy2DToArray_multiDevicePinnedMemPeerGpu", "[multigpu]") {
+TEST_CASE(Unit_hipMemcpy2DToArray_multiDevicePinnedMemPeerGpu) {
   CHECK_IMAGE_SUPPORT
 
   int numDevices = 0;
@@ -88,8 +87,7 @@ TEST_CASE("Unit_hipMemcpy2DToArray_multiDevicePinnedMemPeerGpu", "[multigpu]") {
  *         --> A_h host variable
  *         and verifying A_h with Phi
  * */
-TEST_CASE("Unit_hipMemcpy2DToArray_multiDeviceDeviceContextChange",
-          "[multigpu]") {
+TEST_CASE(Unit_hipMemcpy2DToArray_multiDeviceDeviceContextChange) {
   CHECK_IMAGE_SUPPORT
 
   int numDevices = 0;

--- a/projects/hip-tests/catch/unit/memory/hipMemcpy2D_old.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemcpy2D_old.cc
@@ -57,7 +57,7 @@ static constexpr auto ROWS{8};
  *  - HIP_VERSION >= 6.1
  */
 
-TEMPLATE_TEST_CASE("Unit_hipMemcpy2D_H2D_D2D_D2H", "", int, float, double) {
+TEMPLATE_TEST_CASE(Unit_hipMemcpy2D_H2D_D2D_D2H, int, float, double) {
   CHECK_IMAGE_SUPPORT
   // 1 refers to pinned host memory
   auto mem_type = GENERATE(0, 1);
@@ -133,7 +133,7 @@ TEMPLATE_TEST_CASE("Unit_hipMemcpy2D_H2D_D2D_D2H", "", int, float, double) {
  *  - HIP_VERSION >= 6.1
  */
 
-TEMPLATE_TEST_CASE("Unit_hipMemcpy2D_H2D_D2D_D2H_WithOffset", "", int, float, double) {
+TEMPLATE_TEST_CASE(Unit_hipMemcpy2D_H2D_D2D_D2H_WithOffset, int, float, double) {
   CHECK_IMAGE_SUPPORT
   // 1 refers to pinned host memory
   auto mem_type = GENERATE(0, 1);
@@ -213,7 +213,7 @@ TEMPLATE_TEST_CASE("Unit_hipMemcpy2D_H2D_D2D_D2H_WithOffset", "", int, float, do
  * ------------------------
  *  - HIP_VERSION >= 6.0
  */
-TEMPLATE_TEST_CASE("Unit_hipMemcpy2D_H2D_D2D_D2H_Managed_WithOffset", "", int, float, double) {
+TEMPLATE_TEST_CASE(Unit_hipMemcpy2D_H2D_D2D_D2H_Managed_WithOffset, int, float, double) {
   CHECK_IMAGE_SUPPORT
   // 1 refers to pinned host memory
   auto mem_type = GENERATE(0, 1);
@@ -326,7 +326,7 @@ static void hipMemcpy2D_Basic_Size_Test(size_t inc) {
  *  - HIP_VERSION >= 6.0
  */
 
-TEST_CASE("Unit_hipMemcpy2D_multiDevice_Basic_Size_Test", "[multigpu]") {
+TEST_CASE(Unit_hipMemcpy2D_multiDevice_Basic_Size_Test) {
   CHECK_IMAGE_SUPPORT
   size_t input = 1 << 20;
   int numDevices = 0;

--- a/projects/hip-tests/catch/unit/memory/hipMemcpy3D.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemcpy3D.cc
@@ -30,7 +30,7 @@ THE SOFTWARE.
 
 #pragma clang diagnostic ignored "-Wunused-variable"
 
-TEST_CASE("Unit_hipMemcpy3D_Positive_Basic") {
+TEST_CASE(Unit_hipMemcpy3D_Positive_Basic) {
   CHECK_IMAGE_SUPPORT
 
   constexpr bool async = false;
@@ -49,7 +49,7 @@ TEST_CASE("Unit_hipMemcpy3D_Positive_Basic") {
   SECTION("Host to Host") { Memcpy3DHostToHostShell<async>(Memcpy3DWrapper<>); }
 }
 
-TEST_CASE("Unit_hipMemcpy3D_Positive_Synchronization_Behavior") {
+TEST_CASE(Unit_hipMemcpy3D_Positive_Synchronization_Behavior) {
   CHECK_IMAGE_SUPPORT
 
   HIP_CHECK(hipDeviceSynchronize());
@@ -63,7 +63,7 @@ TEST_CASE("Unit_hipMemcpy3D_Positive_Synchronization_Behavior") {
   SECTION("Host to Host") { Memcpy3DHtoHSyncBehavior(Memcpy3DWrapper<>, true); }
 }
 
-TEST_CASE("Unit_hipMemcpy3D_Positive_DeviceToDevice_Synchronization_Behavior") {
+TEST_CASE(Unit_hipMemcpy3D_Positive_DeviceToDevice_Synchronization_Behavior) {
   CHECK_IMAGE_SUPPORT
 
   LinearAllocGuard3D<int> src_alloc(make_hipExtent(32 * sizeof(int), 32, 8));
@@ -89,14 +89,14 @@ TEST_CASE("Unit_hipMemcpy3D_Positive_DeviceToDevice_Synchronization_Behavior") {
   REQUIRE(hipStreamQuery(kernel_stream) == hipSuccess);
 }
 
-TEST_CASE("Unit_hipMemcpy3D_Positive_Parameters") {
+TEST_CASE(Unit_hipMemcpy3D_Positive_Parameters) {
   CHECK_IMAGE_SUPPORT
 
   constexpr bool async = false;
   Memcpy3DZeroWidthHeightDepth<async>(Memcpy3DWrapper<>);
 }
 
-TEST_CASE("Unit_hipMemcpy3D_Positive_Array") {
+TEST_CASE(Unit_hipMemcpy3D_Positive_Array) {
   CHECK_IMAGE_SUPPORT
 
   constexpr bool async = false;
@@ -106,7 +106,7 @@ TEST_CASE("Unit_hipMemcpy3D_Positive_Array") {
 #endif
 }
 
-TEST_CASE("Unit_hipMemcpy3D_Negative_Parameters") {
+TEST_CASE(Unit_hipMemcpy3D_Negative_Parameters) {
   CHECK_IMAGE_SUPPORT
 
   constexpr hipExtent extent{128 * sizeof(int), 128, 8};
@@ -255,7 +255,7 @@ TEST_CASE("Unit_hipMemcpy3D_Negative_Parameters") {
   }
 }
 
-TEST_CASE("Unit_hipMemcpy3D_Capture") {
+TEST_CASE(Unit_hipMemcpy3D_Capture) {
   CHECK_IMAGE_SUPPORT
 
   constexpr hipExtent extent{16 * sizeof(int), 16, 16};

--- a/projects/hip-tests/catch/unit/memory/hipMemcpy3DAsync.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemcpy3DAsync.cc
@@ -30,7 +30,7 @@ THE SOFTWARE.
 
 #pragma clang diagnostic ignored "-Wunused-variable"
 
-TEST_CASE("Unit_hipMemcpy3DAsync_Positive_Basic") {
+TEST_CASE(Unit_hipMemcpy3DAsync_Positive_Basic) {
   CHECK_IMAGE_SUPPORT
 
   constexpr bool async = true;
@@ -55,7 +55,7 @@ TEST_CASE("Unit_hipMemcpy3DAsync_Positive_Basic") {
   SECTION("Host to Host") { Memcpy3DHostToHostShell<async>(Memcpy3DWrapper<async>, stream); }
 }
 
-TEST_CASE("Unit_hipMemcpy3DAsync_Positive_Synchronization_Behavior") {
+TEST_CASE(Unit_hipMemcpy3DAsync_Positive_Synchronization_Behavior) {
   CHECK_IMAGE_SUPPORT
 
   constexpr bool async = true;
@@ -77,14 +77,14 @@ TEST_CASE("Unit_hipMemcpy3DAsync_Positive_Synchronization_Behavior") {
   SECTION("Host to Host") { Memcpy3DHtoHSyncBehavior(Memcpy3DWrapper<async>, true); }
 }
 
-TEST_CASE("Unit_hipMemcpy3DAsync_Positive_Parameters") {
+TEST_CASE(Unit_hipMemcpy3DAsync_Positive_Parameters) {
   CHECK_IMAGE_SUPPORT
 
   constexpr bool async = true;
   Memcpy3DZeroWidthHeightDepth<async>(Memcpy3DWrapper<async>);
 }
 
-TEST_CASE("Unit_hipMemcpy3DAsync_Positive_Array") {
+TEST_CASE(Unit_hipMemcpy3DAsync_Positive_Array) {
   CHECK_IMAGE_SUPPORT
 
   constexpr bool async = true;
@@ -94,7 +94,7 @@ TEST_CASE("Unit_hipMemcpy3DAsync_Positive_Array") {
 #endif
 }
 
-TEST_CASE("Unit_hipMemcpy3DAsync_Negative_Parameters") {
+TEST_CASE(Unit_hipMemcpy3DAsync_Negative_Parameters) {
   CHECK_IMAGE_SUPPORT
 
   constexpr bool async = true;
@@ -244,7 +244,7 @@ TEST_CASE("Unit_hipMemcpy3DAsync_Negative_Parameters") {
   }
 }
 
-TEST_CASE("Unit_hipMemcpy3DAsync_Capture") {
+TEST_CASE(Unit_hipMemcpy3DAsync_Capture) {
   CHECK_IMAGE_SUPPORT
 
   constexpr hipExtent kExtent{128 * sizeof(int), 128, 8};

--- a/projects/hip-tests/catch/unit/memory/hipMemcpy3DAsync_old.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemcpy3DAsync_old.cc
@@ -636,7 +636,7 @@ template <typename T> void Memcpy3DAsync<T>::simple_Memcpy3DAsync() {
  *  - HIP_VERSION >= 6.0
  */
 
-TEST_CASE("Unit_hipMemcpy3DAsync_multiDevice_Negative") {
+TEST_CASE(Unit_hipMemcpy3DAsync_multiDevice_Negative) {
   CHECK_IMAGE_SUPPORT
   int numDevices = 0;
   HIP_CHECK(hipGetDeviceCount(&numDevices));
@@ -661,7 +661,7 @@ TEST_CASE("Unit_hipMemcpy3DAsync_multiDevice_Negative") {
  *  - HIP_VERSION >= 6.0
  */
 
-TEST_CASE("Unit_hipMemcpy3DAsync_multiDevice_DiffStream", "[multigpu]") {
+TEST_CASE(Unit_hipMemcpy3DAsync_multiDevice_DiffStream) {
   CHECK_IMAGE_SUPPORT
   int numDevices = 0;
   HIP_CHECK(hipGetDeviceCount(&numDevices));

--- a/projects/hip-tests/catch/unit/memory/hipMemcpy3DBatchAsync.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemcpy3DBatchAsync.cc
@@ -68,7 +68,7 @@ void checkArrayContent(hipArray_t array, size_t width, size_t height,
  * ------------------------
  *  - HIP_VERSION >= 7.1
  */
-TEMPLATE_TEST_CASE("Unit_hipMemcpy3DBatchAsync_Ptr2PtrBatchOps", "", char, int,
+TEMPLATE_TEST_CASE(Unit_hipMemcpy3DBatchAsync_Ptr2PtrBatchOps, char, int,
                    float) {
   constexpr auto kfloatval1 = -1.5f;
   constexpr auto kfloatval2 = 2.25f;
@@ -211,7 +211,7 @@ TEMPLATE_TEST_CASE("Unit_hipMemcpy3DBatchAsync_Ptr2PtrBatchOps", "", char, int,
  * ------------------------
  *  - HIP_VERSION >= 7.1
  */
-TEMPLATE_TEST_CASE("Unit_hipMemcpy3DBatchAsync_ArrayMemCpyBatchOps", "", char,
+TEMPLATE_TEST_CASE(Unit_hipMemcpy3DBatchAsync_ArrayMemCpyBatchOps, char,
                    int, float) {
   CHECK_IMAGE_SUPPORT
   constexpr auto kfloatval1 = -1.5f;
@@ -363,7 +363,7 @@ TEMPLATE_TEST_CASE("Unit_hipMemcpy3DBatchAsync_ArrayMemCpyBatchOps", "", char,
  * ------------------------
  *  - HIP_VERSION >= 7.1
  */
-TEST_CASE("Unit_hipMemcpy3DBatchAsync_NegativeTests") {
+TEST_CASE(Unit_hipMemcpy3DBatchAsync_NegativeTests) {
   CHECK_IMAGE_SUPPORT
   const int numOps = 2;
   hipStream_t stream = NULL;

--- a/projects/hip-tests/catch/unit/memory/hipMemcpy3DPeer.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemcpy3DPeer.cc
@@ -37,7 +37,7 @@
  * ------------------------
  *  - HIP_VERSION >= 7.1
  */
-TEST_CASE("Unit_hipMemcpy3DPeer_BasicFunctional") {
+TEST_CASE(Unit_hipMemcpy3DPeer_BasicFunctional) {
   CHECK_IMAGE_SUPPORT
   constexpr int numW = 16;
   constexpr int numH = 16;
@@ -140,7 +140,7 @@ TEST_CASE("Unit_hipMemcpy3DPeer_BasicFunctional") {
  * ------------------------
  *  - HIP_VERSION >= 7.1
  */
-TEST_CASE("Unit_hipMemcpy3DPeer_NegativeTsts") {
+TEST_CASE(Unit_hipMemcpy3DPeer_NegativeTsts) {
   CHECK_IMAGE_SUPPORT
   constexpr int numW = 16;
   constexpr int numH = 16;

--- a/projects/hip-tests/catch/unit/memory/hipMemcpy3DPeerAsync.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemcpy3DPeerAsync.cc
@@ -40,7 +40,7 @@
  * ------------------------
  *  - HIP_VERSION >= 7.1
  */
-TEST_CASE("Unit_hipMemcpy3DPeerAsync_BasicFunctional") {
+TEST_CASE(Unit_hipMemcpy3DPeerAsync_BasicFunctional) {
   CHECK_IMAGE_SUPPORT
   constexpr int numW = 16;
   constexpr int numH = 16;
@@ -147,7 +147,7 @@ TEST_CASE("Unit_hipMemcpy3DPeerAsync_BasicFunctional") {
  * ------------------------
  *  - HIP_VERSION >= 7.1
  */
-TEST_CASE("Unit_hipMemcpy3DPeerAsync_NegativeTsts") {
+TEST_CASE(Unit_hipMemcpy3DPeerAsync_NegativeTsts) {
   CHECK_IMAGE_SUPPORT
   hipStream_t stream = nullptr;
   HIP_CHECK(hipStreamCreate(&stream));

--- a/projects/hip-tests/catch/unit/memory/hipMemcpy3D_old.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemcpy3D_old.cc
@@ -527,7 +527,7 @@ template <typename T> void Memcpy3D<T>::simple_Memcpy3D() {
  *  - HIP_VERSION >= 5.2
  */
 
-TEST_CASE("Unit_hipMemcpy3D_multiDevice_Negative") {
+TEST_CASE(Unit_hipMemcpy3D_multiDevice_Negative) {
   CHECK_IMAGE_SUPPORT
   int numDevices = 0;
   HIP_CHECK(hipGetDeviceCount(&numDevices));

--- a/projects/hip-tests/catch/unit/memory/hipMemcpyAllApiNegative.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemcpyAllApiNegative.cc
@@ -34,7 +34,7 @@ static constexpr auto NUM_ELM{1024 * 1024};
 
 /*This testcase verifies the negative scenarios of hipMemcpy APIs
  */
-TEST_CASE("Unit_hipMemcpy_Negative") {
+TEST_CASE(Unit_hipMemcpy_Negative) {
   // Initialization of variables
   float *A_d{nullptr}, *B_d{nullptr}, *C_d{nullptr};
   float *A_h{nullptr}, *B_h{nullptr}, *C_h{nullptr};
@@ -107,7 +107,7 @@ TEST_CASE("Unit_hipMemcpy_Negative") {
 /*
 This testcase verifies the Nullcheck for all the 8 Memcpy APIs
 */
-TEST_CASE("Unit_hipMemcpy_NullCheck") {
+TEST_CASE(Unit_hipMemcpy_NullCheck) {
   // Initialization of variables
   float *A_d{nullptr}, *B_d{nullptr}, *C_d{nullptr};
   float *A_h{nullptr}, *B_h{nullptr}, *C_h{nullptr};
@@ -170,7 +170,7 @@ TEST_CASE("Unit_hipMemcpy_NullCheck") {
 This testcase verifies all the hipMemcpy APIs by
 copying half the memory.
 */
-TEST_CASE("Unit_hipMemcpy_HalfMemCopy") {
+TEST_CASE(Unit_hipMemcpy_HalfMemCopy) {
   // Initialization of variables
   float *A_d{nullptr}, *B_d{nullptr}, *C_d{nullptr};
   float *A_h{nullptr}, *B_h{nullptr}, *C_h{nullptr};

--- a/projects/hip-tests/catch/unit/memory/hipMemcpyAsync.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemcpyAsync.cc
@@ -25,7 +25,7 @@ THE SOFTWARE.
 #include <resource_guards.hh>
 #include <utils.hh>
 
-TEST_CASE("Unit_hipMemcpyAsync_Positive_Basic") {
+TEST_CASE(Unit_hipMemcpyAsync_Positive_Basic) {
   using namespace std::placeholders;
   const auto stream_type = GENERATE(Streams::nullstream, Streams::perThread, Streams::created);
   const StreamGuard stream_guard(stream_type);
@@ -34,7 +34,7 @@ TEST_CASE("Unit_hipMemcpyAsync_Positive_Basic") {
   MemcpyWithDirectionCommonTests<true>(std::bind(hipMemcpyAsync, _1, _2, _3, _4, stream), stream);
 }
 
-TEST_CASE("Unit_hipMemcpyAsync_Positive_Synchronization_Behavior") {
+TEST_CASE(Unit_hipMemcpyAsync_Positive_Synchronization_Behavior) {
   using namespace std::placeholders;
   HIP_CHECK(hipDeviceSynchronize());
 
@@ -78,7 +78,7 @@ TEST_CASE("Unit_hipMemcpyAsync_Positive_Synchronization_Behavior") {
   }
 }
 
-TEST_CASE("Unit_hipMemcpyAsync_Negative_Parameters") {
+TEST_CASE(Unit_hipMemcpyAsync_Negative_Parameters) {
   using namespace std::placeholders;
 
   SECTION("Host to device") {
@@ -139,7 +139,7 @@ TEST_CASE("Unit_hipMemcpyAsync_Negative_Parameters") {
   }
 }
 
-TEST_CASE("Unit_hipMemcpyAsync_Capture") {
+TEST_CASE(Unit_hipMemcpyAsync_Capture) {
   hipStream_t stream = nullptr;
   HIP_CHECK(hipStreamCreate(&stream));
 

--- a/projects/hip-tests/catch/unit/memory/hipMemcpyAsync_derivatives.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemcpyAsync_derivatives.cc
@@ -26,7 +26,7 @@ THE SOFTWARE.
 #include <utils.hh>
 #include <numeric>
 
-TEST_CASE("Unit_hipMemcpyDtoHAsync_Positive_Basic") {
+TEST_CASE(Unit_hipMemcpyDtoHAsync_Positive_Basic) {
   const auto stream_type = GENERATE(Streams::nullstream, Streams::perThread, Streams::created);
   const StreamGuard stream_guard(stream_type);
 
@@ -36,7 +36,7 @@ TEST_CASE("Unit_hipMemcpyDtoHAsync_Positive_Basic") {
   MemcpyDeviceToHostShell<true>(f, stream_guard.stream());
 }
 
-TEST_CASE("Unit_hipMemcpyDtoHAsync_Positive_Synchronization_Behavior") {
+TEST_CASE(Unit_hipMemcpyDtoHAsync_Positive_Synchronization_Behavior) {
   HIP_CHECK(hipDeviceSynchronize());
 
   SECTION("Device memory to pageable host memory") {
@@ -56,7 +56,7 @@ TEST_CASE("Unit_hipMemcpyDtoHAsync_Positive_Synchronization_Behavior") {
   }
 }
 
-TEST_CASE("Unit_hipMemcpyDtoHAsync_Negative_Parameters") {
+TEST_CASE(Unit_hipMemcpyDtoHAsync_Negative_Parameters) {
   using namespace std::placeholders;
   LinearAllocGuard<int> device_alloc(LinearAllocs::hipMalloc, kPageSize);
   LinearAllocGuard<int> host_alloc(LinearAllocs::hipHostMalloc, kPageSize);
@@ -68,7 +68,7 @@ TEST_CASE("Unit_hipMemcpyDtoHAsync_Negative_Parameters") {
       host_alloc.ptr(), device_alloc.ptr(), kPageSize);
 }
 
-TEST_CASE("Unit_hipMemcpyHtoDAsync_Positive_Basic") {
+TEST_CASE(Unit_hipMemcpyHtoDAsync_Positive_Basic) {
   const auto stream_type = GENERATE(Streams::nullstream, Streams::perThread, Streams::created);
   const StreamGuard stream_guard(stream_type);
 
@@ -78,7 +78,7 @@ TEST_CASE("Unit_hipMemcpyHtoDAsync_Positive_Basic") {
   MemcpyHostToDeviceShell<true>(f, stream_guard.stream());
 }
 
-TEST_CASE("Unit_hipMemcpyHtoDAsync_Positive_Synchronization_Behavior") {
+TEST_CASE(Unit_hipMemcpyHtoDAsync_Positive_Synchronization_Behavior) {
   // This behavior differs on NVIDIA and AMD, on AMD the hipMemcpy calls is synchronous with
   // respect to the host
 #if HT_AMD
@@ -94,7 +94,7 @@ TEST_CASE("Unit_hipMemcpyHtoDAsync_Positive_Synchronization_Behavior") {
       false);
 }
 
-TEST_CASE("Unit_hipMemcpyHtoDAsync_Negative_Parameters") {
+TEST_CASE(Unit_hipMemcpyHtoDAsync_Negative_Parameters) {
   using namespace std::placeholders;
   LinearAllocGuard<int> device_alloc(LinearAllocs::hipMalloc, kPageSize);
   LinearAllocGuard<int> host_alloc(LinearAllocs::hipHostMalloc, kPageSize);
@@ -106,7 +106,7 @@ TEST_CASE("Unit_hipMemcpyHtoDAsync_Negative_Parameters") {
       device_alloc.ptr(), host_alloc.ptr(), kPageSize);
 }
 
-TEST_CASE("Unit_hipMemcpyDtoDAsync_Positive_Basic") {
+TEST_CASE(Unit_hipMemcpyDtoDAsync_Positive_Basic) {
   const auto stream_type = GENERATE(Streams::nullstream, Streams::perThread, Streams::created);
   const StreamGuard stream_guard(stream_type);
 
@@ -130,7 +130,7 @@ TEST_CASE("Unit_hipMemcpyDtoDAsync_Positive_Basic") {
   }
 }
 
-TEST_CASE("Unit_hipMemcpyDtoDAsync_Positive_Synchronization_Behavior") {
+TEST_CASE(Unit_hipMemcpyDtoDAsync_Positive_Synchronization_Behavior) {
   MemcpyDtoDSyncBehavior(
       [](void* dst, void* src, size_t count) {
         return hipMemcpyDtoDAsync(reinterpret_cast<hipDeviceptr_t>(dst),
@@ -139,7 +139,7 @@ TEST_CASE("Unit_hipMemcpyDtoDAsync_Positive_Synchronization_Behavior") {
       false);
 }
 
-TEST_CASE("Unit_hipMemcpyDtoDAsync_Negative_Parameters") {
+TEST_CASE(Unit_hipMemcpyDtoDAsync_Negative_Parameters) {
   using namespace std::placeholders;
   LinearAllocGuard<int> src_alloc(LinearAllocs::hipMalloc, kPageSize);
   LinearAllocGuard<int> dst_alloc(LinearAllocs::hipMalloc, kPageSize);
@@ -164,7 +164,7 @@ TEST_CASE("Unit_hipMemcpyDtoDAsync_Negative_Parameters") {
  * ------------------------
  *  - HIP_VERSION >= 6.0
  */
-TEST_CASE("Unit_hipMemcpyDtoHAsync_Capture") {
+TEST_CASE(Unit_hipMemcpyDtoHAsync_Capture) {
   hipStream_t stream = nullptr;
   HIP_CHECK(hipStreamCreate(&stream));
 
@@ -202,7 +202,7 @@ TEST_CASE("Unit_hipMemcpyDtoHAsync_Capture") {
  * Test source
  * ------------------------
  */
-TEST_CASE("Unit_hipMemcpyHtoDAsync_Capture") {
+TEST_CASE(Unit_hipMemcpyHtoDAsync_Capture) {
   hipStream_t stream = nullptr;
   HIP_CHECK(hipStreamCreate(&stream));
 

--- a/projects/hip-tests/catch/unit/memory/hipMemcpyAsync_old.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemcpyAsync_old.cc
@@ -100,8 +100,7 @@ This testcase verifies the following scenarios
 4. Device context change
 5. H2D-D2D-D2H peer GPU
 */
-TEMPLATE_TEST_CASE("Unit_hipMemcpyAsync_H2H_H2D_D2H_H2PinMem", "[multigpu]",
-                   char, int, float, double) {
+TEMPLATE_TEST_CASE(Unit_hipMemcpyAsync_H2H_H2D_D2H_H2PinMem, char, int, float, double) {
   TestType *A_d{nullptr}, *B_d{nullptr};
   TestType *A_h{nullptr}, *B_h{nullptr};
   TestType *A_Ph{nullptr}, *B_Ph{nullptr};
@@ -202,7 +201,7 @@ TEMPLATE_TEST_CASE("Unit_hipMemcpyAsync_H2H_H2D_D2H_H2PinMem", "[multigpu]",
 // and also launch hipMemcpyAsync() api. This test case is simulate the scenario
 // reported in SWDEV-181598
 
-TEMPLATE_TEST_CASE("Unit_hipMemcpyAsync_hipMultiMemcpyMultiThread", "", int, float, double) {
+TEMPLATE_TEST_CASE(Unit_hipMemcpyAsync_hipMultiMemcpyMultiThread, int, float, double) {
   size_t Nbytes = N_ELMTS * sizeof(TestType);
 
   int Data_mismatch = 0;
@@ -242,7 +241,7 @@ TEMPLATE_TEST_CASE("Unit_hipMemcpyAsync_hipMultiMemcpyMultiThread", "", int, flo
   Thread_count.exchange(0);
 }
 
-TEMPLATE_TEST_CASE("Unit_hipMemcpyAsync_hipMultiMemcpyMultiThreadMultiStream", "", int, float,
+TEMPLATE_TEST_CASE(Unit_hipMemcpyAsync_hipMultiMemcpyMultiThreadMultiStream, int, float,
                    double) {
   std::thread T[NUM_THREADS];
   for (int i = 0; i < NUM_THREADS; i++) {
@@ -265,8 +264,7 @@ This testcase verifies hipMemcpy API with pinnedMemory and hostRegister
 along with kernel launches
 */
 
-TEMPLATE_TEST_CASE("Unit_hipMemcpyAsync_PinnedRegMemWithKernelLaunch",
-                   "[multigpu]", int, float, double) {
+TEMPLATE_TEST_CASE(Unit_hipMemcpyAsync_PinnedRegMemWithKernelLaunch, int, float, double) {
   int numDevices = 0;
   HIP_CHECK(hipGetDeviceCount(&numDevices));
   if (numDevices < 2) {

--- a/projects/hip-tests/catch/unit/memory/hipMemcpyAtoA.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemcpyAtoA.cc
@@ -44,7 +44,7 @@ THE SOFTWARE.
  *  - HIP_VERSION >= 6.2
  */
 
-TEST_CASE("Unit_hipMemcpyAtoA_Basic") {
+TEST_CASE(Unit_hipMemcpyAtoA_Basic) {
 #if HT_NVIDIA
   HipTest::HIP_SKIP_TEST("API currently unsupported on nvidia, skipping...");
   return;

--- a/projects/hip-tests/catch/unit/memory/hipMemcpyAtoD.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemcpyAtoD.cc
@@ -42,7 +42,7 @@ THE SOFTWARE.
  * ------------------------
  *  - HIP_VERSION >= 6.2
  */
-TEST_CASE("Unit_hipMemcpyAtoD_Basic") {
+TEST_CASE(Unit_hipMemcpyAtoD_Basic) {
 #if HT_NVIDIA
   HipTest::HIP_SKIP_TEST("API currently unsupported on nvidia, skipping...");
   return;

--- a/projects/hip-tests/catch/unit/memory/hipMemcpyAtoH.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemcpyAtoH.cc
@@ -24,7 +24,7 @@ THE SOFTWARE.
 #include <resource_guards.hh>
 #include <utils.hh>
 
-TEST_CASE("Unit_hipMemcpyAtoH_Positive_Default") {
+TEST_CASE(Unit_hipMemcpyAtoH_Positive_Default) {
   CHECK_IMAGE_SUPPORT
 
   using namespace std::placeholders;
@@ -35,7 +35,7 @@ TEST_CASE("Unit_hipMemcpyAtoH_Positive_Default") {
   MemcpyAtoHShell<false, int>(std::bind(hipMemcpyAtoH, _1, _2, 0, allocation_size), width);
 }
 
-TEST_CASE("Unit_hipMemcpyAtoH_Positive_Synchronization_Behavior") {
+TEST_CASE(Unit_hipMemcpyAtoH_Positive_Synchronization_Behavior) {
   CHECK_IMAGE_SUPPORT
 
   using namespace std::placeholders;
@@ -56,7 +56,7 @@ Excluded the testcase for amd,as there is already a bug raised
 SWDEV-274683
 */
 #if HT_NVIDIA
-TEST_CASE("Unit_hipMemcpyAtoH_Positive_ZeroCount") {
+TEST_CASE(Unit_hipMemcpyAtoH_Positive_ZeroCount) {
   CHECK_IMAGE_SUPPORT
 
   const auto width = 1024;
@@ -87,7 +87,7 @@ TEST_CASE("Unit_hipMemcpyAtoH_Positive_ZeroCount") {
 }
 #endif
 
-TEST_CASE("Unit_hipMemcpyAtoH_Negative_Parameters") {
+TEST_CASE(Unit_hipMemcpyAtoH_Negative_Parameters) {
   CHECK_IMAGE_SUPPORT
 
   using namespace std::placeholders;
@@ -130,7 +130,7 @@ TEST_CASE("Unit_hipMemcpyAtoH_Negative_Parameters") {
   }
 }
 
-TEST_CASE("Unit_hipMemcpyAtoH_Capture") {
+TEST_CASE(Unit_hipMemcpyAtoH_Capture) {
   CHECK_IMAGE_SUPPORT
 
   const auto width = 1024;

--- a/projects/hip-tests/catch/unit/memory/hipMemcpyAtoHAsync.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemcpyAtoHAsync.cc
@@ -42,7 +42,7 @@ THE SOFTWARE.
  * ------------------------
  *  - HIP_VERSION >= 6.2
  */
-TEST_CASE("Unit_hipMemcpyAtoHAsync_Basic") {
+TEST_CASE(Unit_hipMemcpyAtoHAsync_Basic) {
 #if HT_NVIDIA
   HipTest::HIP_SKIP_TEST("API currently unsupported on nvidia, skipping...");
   return;
@@ -73,7 +73,7 @@ TEST_CASE("Unit_hipMemcpyAtoHAsync_Basic") {
 #endif
 }
 
-TEST_CASE("Unit_hipMemcpyAtoHAsync_Capture") {
+TEST_CASE(Unit_hipMemcpyAtoHAsync_Capture) {
   CHECK_IMAGE_SUPPORT
 
   constexpr int kRows = 1;

--- a/projects/hip-tests/catch/unit/memory/hipMemcpyAtoH_old.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemcpyAtoH_old.cc
@@ -42,8 +42,7 @@ Output:"B_h" host variable output of hipMemcpyAtoH API
         is then validated with "hData"
 */
 #if HT_AMD
-TEMPLATE_TEST_CASE("Unit_hipMemcpyAtoH_multiDevice_PeerDeviceContext",
-                   "[hipMemcpyAtoH][multigpu]", char, int, float) {
+TEMPLATE_TEST_CASE(Unit_hipMemcpyAtoH_multiDevice_PeerDeviceContext, char, int, float) {
   CHECK_IMAGE_SUPPORT
 
   int numDevices = 0;

--- a/projects/hip-tests/catch/unit/memory/hipMemcpyBatchAsync.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemcpyBatchAsync.cc
@@ -44,7 +44,7 @@
  *  - HIP_VERSION >= 7.1
  */
 #if HT_AMD
-TEMPLATE_TEST_CASE("Unit_hipMemcpyBatchAsync_D2D_Functional", "", char, int,
+TEMPLATE_TEST_CASE(Unit_hipMemcpyBatchAsync_D2D_Functional, char, int,
                    float) {
   const size_t count = 2;
   size_t numAttrs = 0;
@@ -115,7 +115,7 @@ TEMPLATE_TEST_CASE("Unit_hipMemcpyBatchAsync_D2D_Functional", "", char, int,
  * ------------------------
  *  - HIP_VERSION >= 7.1
  */
-TEMPLATE_TEST_CASE("Unit_hipMemcpyBatchAsync_H2D_Functional", "", char, int,
+TEMPLATE_TEST_CASE(Unit_hipMemcpyBatchAsync_H2D_Functional, char, int,
                    float) {
   const size_t count = 2;
   size_t numAttrs = 0;
@@ -183,7 +183,7 @@ TEMPLATE_TEST_CASE("Unit_hipMemcpyBatchAsync_H2D_Functional", "", char, int,
  * ------------------------
  *  - HIP_VERSION >= 7.1
  */
-TEMPLATE_TEST_CASE("Unit_hipMemcpyBatchAsync_D2H_Functional", "", char, int,
+TEMPLATE_TEST_CASE(Unit_hipMemcpyBatchAsync_D2H_Functional, char, int,
                    float) {
   const size_t count = 2;
   size_t numAttrs = 0;
@@ -253,7 +253,7 @@ TEMPLATE_TEST_CASE("Unit_hipMemcpyBatchAsync_D2H_Functional", "", char, int,
  * ------------------------
  *  - HIP_VERSION >= 7.1
  */
-TEMPLATE_TEST_CASE("Unit_hipMemcpyBatchAsync_H2H_Functional", "", char, int,
+TEMPLATE_TEST_CASE(Unit_hipMemcpyBatchAsync_H2H_Functional, char, int,
                    float) {
   const size_t count = 2;
   size_t numAttrs = 0;
@@ -320,7 +320,7 @@ TEMPLATE_TEST_CASE("Unit_hipMemcpyBatchAsync_H2H_Functional", "", char, int,
  * ------------------------
  *  - HIP_VERSION >= 7.1
  */
-TEST_CASE("Unit_hipMemcpyBatchAsync_NegativeTsts") {
+TEST_CASE(Unit_hipMemcpyBatchAsync_NegativeTsts) {
   const size_t count = 2;
   size_t numAttrs = 0;
   size_t sizes[2];

--- a/projects/hip-tests/catch/unit/memory/hipMemcpyDeviceToDeviceNoCU.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemcpyDeviceToDeviceNoCU.cc
@@ -45,7 +45,7 @@ static void fillDataTransfer2Dev(int* hostBuf, size_t len) {
  * ------------------------
  *    - HIP_VERSION >= 6.1
  */
-TEST_CASE("Unit_hipMemcpyDeviceToDeviceNoCU_SingleStream") {
+TEST_CASE(Unit_hipMemcpyDeviceToDeviceNoCU_SingleStream) {
   auto testAsync = GENERATE(0, 1);
   auto isDefaultStrm = GENERATE(0, 1);
   constexpr int N = 1 << 18;
@@ -109,7 +109,7 @@ TEST_CASE("Unit_hipMemcpyDeviceToDeviceNoCU_SingleStream") {
  * ------------------------
  *    - HIP_VERSION >= 6.1
  */
-TEST_CASE("Unit_hipMemcpyDeviceToDeviceNoCU_WithCU_NoCU_Comb_SingleStrm") {
+TEST_CASE(Unit_hipMemcpyDeviceToDeviceNoCU_WithCU_NoCU_Comb_SingleStrm) {
   constexpr int N = 1 << 18;
   size_t buffer_size = N * sizeof(int);
   // Allocate device resources
@@ -170,7 +170,7 @@ TEST_CASE("Unit_hipMemcpyDeviceToDeviceNoCU_WithCU_NoCU_Comb_SingleStrm") {
  * ------------------------
  *    - HIP_VERSION >= 6.1
  */
-TEST_CASE("Unit_hipMemcpyDeviceToDeviceNoCU_NoCU_MulStrm") {
+TEST_CASE(Unit_hipMemcpyDeviceToDeviceNoCU_NoCU_MulStrm) {
   constexpr int N = 1 << 18;
   size_t buffer_size = N * sizeof(int);
   // Allocate device resources
@@ -229,7 +229,7 @@ TEST_CASE("Unit_hipMemcpyDeviceToDeviceNoCU_NoCU_MulStrm") {
  * ------------------------
  *    - HIP_VERSION >= 6.1
  */
-TEST_CASE("Unit_hipMemcpyDeviceToDeviceNoCU_Memcpy_Kernel_InParallel") {
+TEST_CASE(Unit_hipMemcpyDeviceToDeviceNoCU_Memcpy_Kernel_InParallel) {
   constexpr int N = 1 << 24;
   size_t buffer_size = N * sizeof(int);
   constexpr unsigned threadsPerBlock = 1024;

--- a/projects/hip-tests/catch/unit/memory/hipMemcpyDtoA.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemcpyDtoA.cc
@@ -23,7 +23,7 @@ THE SOFTWARE.
 
 #define N 32
 
-TEMPLATE_TEST_CASE("Unit_hipMemcpyDtoA_Basic", "", char, int, float) {
+TEMPLATE_TEST_CASE(Unit_hipMemcpyDtoA_Basic, char, int, float) {
   CHECK_IMAGE_SUPPORT
 
   hipArray_t dst_array = nullptr;
@@ -53,7 +53,7 @@ TEMPLATE_TEST_CASE("Unit_hipMemcpyDtoA_Basic", "", char, int, float) {
   HIP_CHECK(hipFree(reinterpret_cast<void*>(src_device)));
 }
 
-TEST_CASE("Unit_hipMemcpyDtoA_Negative") {
+TEST_CASE(Unit_hipMemcpyDtoA_Negative) {
   CHECK_IMAGE_SUPPORT
 
   hipArray_t dst_array = nullptr;
@@ -94,7 +94,7 @@ TEST_CASE("Unit_hipMemcpyDtoA_Negative") {
  * ------------------------
  *    - HIP_VERSION >= 6.2
  */
-TEST_CASE("Unit_hipMemcpyDtoA_BasicPositive") {
+TEST_CASE(Unit_hipMemcpyDtoA_BasicPositive) {
   CHECK_IMAGE_SUPPORT
 
   const size_t width = 1024;

--- a/projects/hip-tests/catch/unit/memory/hipMemcpyDtoD.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemcpyDtoD.cc
@@ -38,7 +38,7 @@ This testcase verifies hipMemcpyDtoD API
 6.Kernel Launch
 7.DtoH copy and validating the result
 */
-TEMPLATE_TEST_CASE("Unit_hipMemcpyDtoD_Basic", "[multigpu]", int, float,
+TEMPLATE_TEST_CASE(Unit_hipMemcpyDtoD_Basic, int, float,
                    double) {
   size_t Nbytes = NUM_ELM * sizeof(TestType);
   int numDevices = 0;

--- a/projects/hip-tests/catch/unit/memory/hipMemcpyDtoDAsync.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemcpyDtoDAsync.cc
@@ -40,7 +40,7 @@ This testcase verifies hipMemcpyDtoDAsync API
 7.DtoH copy and validating the result
 */
 
-TEMPLATE_TEST_CASE("Unit_hipMemcpyDtoDAsync_Basic", "[multigpu]", int, float,
+TEMPLATE_TEST_CASE(Unit_hipMemcpyDtoDAsync_Basic, int, float,
                    double) {
   size_t Nbytes = NUM_ELM * sizeof(TestType);
   int numDevices = 0;
@@ -110,7 +110,7 @@ TEMPLATE_TEST_CASE("Unit_hipMemcpyDtoDAsync_Basic", "[multigpu]", int, float,
  * ------------------------
  *  - HIP_VERSION >= 6.0
  */
-TEST_CASE("Unit_hipMemcpyDtoDAsync_Capture") {
+TEST_CASE(Unit_hipMemcpyDtoDAsync_Capture) {
   int device_count = 0;
   HIP_CHECK(hipGetDeviceCount(&device_count));
   if (device_count <= 1) {

--- a/projects/hip-tests/catch/unit/memory/hipMemcpyFromSymbol.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemcpyFromSymbol.cc
@@ -25,7 +25,7 @@ __constant__ int constSymbol[10];
 /* Test verifies hipMemcpy[From/To]Symbol[Async] API Negative scenarios.
  */
 
-TEST_CASE("Unit_hipMemcpyFromToSymbol_Negative") {
+TEST_CASE(Unit_hipMemcpyFromToSymbol_Negative) {
   SECTION("Invalid Src Ptr") {
     int result{0};
     HIP_CHECK_ERROR(
@@ -111,7 +111,7 @@ TEST_CASE("Unit_hipMemcpyFromToSymbol_Negative") {
  * For Array Values To and From Symbol
  * For Array Values with offset To and From Symbol
  * For Sync and Async Variants*/
-TEST_CASE("Unit_hipMemcpyToFromSymbol_SyncAndAsync") {
+TEST_CASE(Unit_hipMemcpyToFromSymbol_SyncAndAsync) {
   enum StreamTestType { NullStream = 0, StreamPerThread, CreatedStream, NoStream };
 
   /* Test type NoStream - Use Sync variants, else use async variants */
@@ -228,7 +228,7 @@ TEST_CASE("Unit_hipMemcpyToFromSymbol_SyncAndAsync") {
 * ------------------------
 *  - HIP_VERSION >= 6.0
 */
-TEST_CASE("Unit_hipMemcpyToFromSymbol_Capture") {
+TEST_CASE(Unit_hipMemcpyToFromSymbol_Capture) {
   hipStream_t stream = nullptr;
   HIP_CHECK(hipStreamCreate(&stream));
 

--- a/projects/hip-tests/catch/unit/memory/hipMemcpyHtoA.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemcpyHtoA.cc
@@ -34,7 +34,7 @@ hipMemcpyHtoA api when parameters are invalid
 #include <utils.hh>
 
 
-TEST_CASE("Unit_hipMemcpyHtoA_Positive_Default") {
+TEST_CASE(Unit_hipMemcpyHtoA_Positive_Default) {
   CHECK_IMAGE_SUPPORT
 
   using namespace std::placeholders;
@@ -45,7 +45,7 @@ TEST_CASE("Unit_hipMemcpyHtoA_Positive_Default") {
   MemcpyHtoAShell<false, int>(std::bind(hipMemcpyHtoA, _1, 0, _2, allocation_size), width);
 }
 
-TEST_CASE("Unit_hipMemcpyHtoA_Positive_Synchronization_Behavior") {
+TEST_CASE(Unit_hipMemcpyHtoA_Positive_Synchronization_Behavior) {
   CHECK_IMAGE_SUPPORT
 
   using namespace std::placeholders;
@@ -63,7 +63,7 @@ This is excluded for AMD as we have a bug already raised
 SWDEV-274683
 */
 #if HT_NVIDIA
-TEST_CASE("Unit_hipMemcpyHtoA_Positive_ZeroCount") {
+TEST_CASE(Unit_hipMemcpyHtoA_Positive_ZeroCount) {
   CHECK_IMAGE_SUPPORT
 
   const auto width = 1024;
@@ -97,7 +97,7 @@ TEST_CASE("Unit_hipMemcpyHtoA_Positive_ZeroCount") {
 }
 #endif
 
-TEST_CASE("Unit_hipMemcpyHtoA_Negative_Parameters") {
+TEST_CASE(Unit_hipMemcpyHtoA_Negative_Parameters) {
   CHECK_IMAGE_SUPPORT
 
   using namespace std::placeholders;
@@ -141,7 +141,7 @@ TEST_CASE("Unit_hipMemcpyHtoA_Negative_Parameters") {
   }
 }
 
-TEST_CASE("Unit_hipMemcpyHtoA_Capture") {
+TEST_CASE(Unit_hipMemcpyHtoA_Capture) {
   CHECK_IMAGE_SUPPORT
 
   const auto width = 512;

--- a/projects/hip-tests/catch/unit/memory/hipMemcpyHtoAAsync.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemcpyHtoAAsync.cc
@@ -24,7 +24,7 @@ THE SOFTWARE.
 
 #define N 32
 
-TEMPLATE_TEST_CASE("Unit_hipMemcpyHtoAAsync_Basic", "", char, int, float) {
+TEMPLATE_TEST_CASE(Unit_hipMemcpyHtoAAsync_Basic, char, int, float) {
   CHECK_IMAGE_SUPPORT
 
   hipArray_t dst_array = nullptr;
@@ -53,7 +53,7 @@ TEMPLATE_TEST_CASE("Unit_hipMemcpyHtoAAsync_Basic", "", char, int, float) {
   HIP_CHECK(hipFreeArray(dst_array));
 }
 
-TEST_CASE("Unit_hipMemcpyHtoAAsync_Negative") {
+TEST_CASE(Unit_hipMemcpyHtoAAsync_Negative) {
   CHECK_IMAGE_SUPPORT
 
   hipArray_t dst_array = nullptr;
@@ -104,7 +104,7 @@ TEST_CASE("Unit_hipMemcpyHtoAAsync_Negative") {
  * ------------------------
  *  - HIP_VERSION >= 6.2
  */
-TEST_CASE("Unit_hipMemcpyHtoAAsync_BasicTstsWithDiffStreams") {
+TEST_CASE(Unit_hipMemcpyHtoAAsync_BasicTstsWithDiffStreams) {
 #if HT_NVIDIA
   HipTest::HIP_SKIP_TEST("API currently unsupported on nvidia, skipping...");
   return;
@@ -166,7 +166,7 @@ TEST_CASE("Unit_hipMemcpyHtoAAsync_BasicTstsWithDiffStreams") {
  * ------------------------
  *  - HIP_VERSION >= 6.2
  */
-TEST_CASE("Unit_hipMemcpyHtoAAsync_MultiDevice", "[multigpu]") {
+TEST_CASE(Unit_hipMemcpyHtoAAsync_MultiDevice) {
 #if HT_NVIDIA
   HipTest::HIP_SKIP_TEST("API currently unsupported on nvidia, skipping...");
   return;
@@ -204,7 +204,7 @@ TEST_CASE("Unit_hipMemcpyHtoAAsync_MultiDevice", "[multigpu]") {
 #endif
 }
 
-TEST_CASE("UnitHipMemcpyHtoAAsync_Capture") {
+TEST_CASE(UnitHipMemcpyHtoAAsync_Capture) {
   CHECK_IMAGE_SUPPORT
 
   auto host_src = std::make_unique<std::vector<int>>(N);

--- a/projects/hip-tests/catch/unit/memory/hipMemcpyHtoA_old.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemcpyHtoA_old.cc
@@ -43,8 +43,7 @@ Output: "A_d" output of hipMemcpyHtoA is copied to "hData" host variable
         validated the result with "B_h"
 */
 #if HT_AMD
-TEMPLATE_TEST_CASE("Unit_hipMemcpyHtoA_multiDevice_PeerDeviceContext",
-                   "[hipMemcpyHtoA][multigpu]", char, int, float) {
+TEMPLATE_TEST_CASE(Unit_hipMemcpyHtoA_multiDevice_PeerDeviceContext, char, int, float) {
   CHECK_IMAGE_SUPPORT
   int numDevices = 0;
   HIP_CHECK(hipGetDeviceCount(&numDevices));

--- a/projects/hip-tests/catch/unit/memory/hipMemcpyParam2D.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemcpyParam2D.cc
@@ -27,7 +27,7 @@ THE SOFTWARE.
 #include <resource_guards.hh>
 #include <utils.hh>
 
-TEST_CASE("Unit_hipMemcpyParam2D_Positive_Basic", "[multigpu]") {
+TEST_CASE(Unit_hipMemcpyParam2D_Positive_Basic) {
   CHECK_IMAGE_SUPPORT
   constexpr bool async = false;
 
@@ -48,7 +48,7 @@ TEST_CASE("Unit_hipMemcpyParam2D_Positive_Basic", "[multigpu]") {
 #endif
 }
 
-TEST_CASE("Unit_hipMemcpyParam2D_Positive_Synchronization_Behavior") {
+TEST_CASE(Unit_hipMemcpyParam2D_Positive_Synchronization_Behavior) {
   HIP_CHECK(hipDeviceSynchronize());
 
   SECTION("Host to Device") { Memcpy2DHtoDSyncBehavior(MemcpyParam2DAdapter<>(), true); }
@@ -66,13 +66,13 @@ TEST_CASE("Unit_hipMemcpyParam2D_Positive_Synchronization_Behavior") {
   SECTION("Host to Host") { Memcpy2DHtoHSyncBehavior(MemcpyParam2DAdapter<>(), true); }
 }
 
-TEST_CASE("Unit_hipMemcpyParam2D_Positive_Parameters") {
+TEST_CASE(Unit_hipMemcpyParam2D_Positive_Parameters) {
   CHECK_IMAGE_SUPPORT
   constexpr bool async = false;
   Memcpy2DZeroWidthHeight<async>(MemcpyParam2DAdapter<async>());
 }
 
-TEST_CASE("Unit_hipMemcpyParam2D_Positive_Array") {
+TEST_CASE(Unit_hipMemcpyParam2D_Positive_Array) {
   CHECK_IMAGE_SUPPORT
   constexpr bool async = false;
   SECTION("Array from/to Host") {
@@ -83,7 +83,7 @@ TEST_CASE("Unit_hipMemcpyParam2D_Positive_Array") {
   }
 }
 
-TEST_CASE("Unit_hipMemcpyParam2D_Negative_Parameters") {
+TEST_CASE(Unit_hipMemcpyParam2D_Negative_Parameters) {
   CHECK_IMAGE_SUPPORT
   constexpr size_t cols = 128;
   constexpr size_t rows = 128;
@@ -185,7 +185,7 @@ TEST_CASE("Unit_hipMemcpyParam2D_Negative_Parameters") {
   }
 }
 
-TEST_CASE("Unit_hipMemcpyParam2D_Capture") {
+TEST_CASE(Unit_hipMemcpyParam2D_Capture) {
   CHECK_IMAGE_SUPPORT
 
   constexpr size_t cols = 128;

--- a/projects/hip-tests/catch/unit/memory/hipMemcpyParam2DAsync.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemcpyParam2DAsync.cc
@@ -27,7 +27,7 @@ THE SOFTWARE.
 #include <resource_guards.hh>
 #include <utils.hh>
 
-TEST_CASE("Unit_hipMemcpyParam2DAsync_Positive_Basic", "[multigpu]") {
+TEST_CASE(Unit_hipMemcpyParam2DAsync_Positive_Basic) {
   using namespace std::placeholders;
 
   constexpr bool async = true;
@@ -60,7 +60,7 @@ TEST_CASE("Unit_hipMemcpyParam2DAsync_Positive_Basic", "[multigpu]") {
   }
 }
 
-TEST_CASE("Unit_hipMemcpyParam2DAsync_Positive_Synchronization_Behavior") {
+TEST_CASE(Unit_hipMemcpyParam2DAsync_Positive_Synchronization_Behavior) {
   CHECK_IMAGE_SUPPORT
   using namespace std::placeholders;
 
@@ -96,13 +96,13 @@ TEST_CASE("Unit_hipMemcpyParam2DAsync_Positive_Synchronization_Behavior") {
 #endif
 }
 
-TEST_CASE("Unit_hipMemcpyParam2DAsync_Positive_Parameters") {
+TEST_CASE(Unit_hipMemcpyParam2DAsync_Positive_Parameters) {
   CHECK_IMAGE_SUPPORT
   constexpr bool async = true;
   Memcpy2DZeroWidthHeight<async>(MemcpyParam2DAdapter<async>());
 }
 
-TEST_CASE("Unit_hipMemcpyParam2DAsync_Positive_Array") {
+TEST_CASE(Unit_hipMemcpyParam2DAsync_Positive_Array) {
   CHECK_IMAGE_SUPPORT
   constexpr bool async = true;
   SECTION("Array from/to Host") {
@@ -113,7 +113,7 @@ TEST_CASE("Unit_hipMemcpyParam2DAsync_Positive_Array") {
   }
 }
 
-TEST_CASE("Unit_hipMemcpyParam2DAsync_Negative_Parameters") {
+TEST_CASE(Unit_hipMemcpyParam2DAsync_Negative_Parameters) {
   CHECK_IMAGE_SUPPORT
   constexpr bool async = true;
 
@@ -213,7 +213,7 @@ TEST_CASE("Unit_hipMemcpyParam2DAsync_Negative_Parameters") {
 static constexpr size_t NUM_W{10};
 static constexpr size_t NUM_H{10};
 
-TEST_CASE("Unit_hipMemcpyParam2DAsync_Capture") {
+TEST_CASE(Unit_hipMemcpyParam2DAsync_Capture) {
   void* device_a = nullptr;
   void* device_b = nullptr;
   size_t pitch_a = 0;

--- a/projects/hip-tests/catch/unit/memory/hipMemcpyParam2DAsync_old.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemcpyParam2DAsync_old.cc
@@ -43,8 +43,7 @@ static constexpr size_t NUM_H{10};
  * it with the initalized data "C_h".
  *
  */
-TEMPLATE_TEST_CASE("Unit_hipMemcpyParam2DAsync_multiDevice_StreamOnDiffDevice",
-                   "[hipMemcpyParam2DAsync][multigpu]", char, float, int,
+TEMPLATE_TEST_CASE(Unit_hipMemcpyParam2DAsync_multiDevice_StreamOnDiffDevice, char, float, int,
                    double, long double) {
   CHECK_IMAGE_SUPPORT
 

--- a/projects/hip-tests/catch/unit/memory/hipMemcpyPeer.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemcpyPeer.cc
@@ -45,7 +45,7 @@ THE SOFTWARE.
  *  - Multi-device
  *  - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_hipMemcpyPeer_Positive_Default", "[multigpu]") {
+TEST_CASE(Unit_hipMemcpyPeer_Positive_Default) {
   const auto device_count = HipTest::getDeviceCount();
   if (device_count < 2) {
     HipTest::HIP_SKIP_TEST("Skipping because devices < 2");
@@ -110,8 +110,7 @@ TEST_CASE("Unit_hipMemcpyPeer_Positive_Default", "[multigpu]") {
  *  - Multi-device
  *  - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_hipMemcpyPeer_Positive_Synchronization_Behavior",
-          "[multigpu]") {
+TEST_CASE(Unit_hipMemcpyPeer_Positive_Synchronization_Behavior) {
   HIP_CHECK(hipDeviceSynchronize());
 
   const auto device_count = HipTest::getDeviceCount();
@@ -159,7 +158,7 @@ TEST_CASE("Unit_hipMemcpyPeer_Positive_Synchronization_Behavior",
  *  - Multi-device
  *  - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_hipMemcpyPeer_Positive_ZeroSize", "[multigpu]") {
+TEST_CASE(Unit_hipMemcpyPeer_Positive_ZeroSize) {
   const auto device_count = HipTest::getDeviceCount();
   if (device_count < 2) {
     HipTest::HIP_SKIP_TEST("Skipping because devices < 2");
@@ -242,7 +241,7 @@ TEST_CASE("Unit_hipMemcpyPeer_Positive_ZeroSize", "[multigpu]") {
  *  - Multi-device
  *  - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_hipMemcpyPeer_Negative_Parameters", "[multigpu]") {
+TEST_CASE(Unit_hipMemcpyPeer_Negative_Parameters) {
   const auto device_count = HipTest::getDeviceCount();
   if (device_count < 2) {
     HipTest::HIP_SKIP_TEST("Skipping because devices < 2");

--- a/projects/hip-tests/catch/unit/memory/hipMemcpyPeerAsync.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemcpyPeerAsync.cc
@@ -45,7 +45,7 @@ THE SOFTWARE.
  *  - Multi-device
  *  - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_hipMemcpyPeerAsync_Positive_Default", "[multigpu]") {
+TEST_CASE(Unit_hipMemcpyPeerAsync_Positive_Default) {
   const auto device_count = HipTest::getDeviceCount();
   if (device_count < 2) {
     HipTest::HIP_SKIP_TEST("Skipping because devices < 2");
@@ -114,8 +114,7 @@ TEST_CASE("Unit_hipMemcpyPeerAsync_Positive_Default", "[multigpu]") {
  *  - Multi-device
  *  - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_hipMemcpyPeerAsync_Positive_Synchronization_Behavior",
-          "[multigpu]") {
+TEST_CASE(Unit_hipMemcpyPeerAsync_Positive_Synchronization_Behavior) {
   HIP_CHECK(hipDeviceSynchronize());
 
   const auto device_count = HipTest::getDeviceCount();
@@ -166,7 +165,7 @@ TEST_CASE("Unit_hipMemcpyPeerAsync_Positive_Synchronization_Behavior",
  *  - Multi-device
  *  - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_hipMemcpyPeerAsync_Positive_ZeroSize", "[multigpu]") {
+TEST_CASE(Unit_hipMemcpyPeerAsync_Positive_ZeroSize) {
   const auto device_count = HipTest::getDeviceCount();
   if (device_count < 2) {
     HipTest::HIP_SKIP_TEST("Skipping because devices < 2");
@@ -251,7 +250,7 @@ TEST_CASE("Unit_hipMemcpyPeerAsync_Positive_ZeroSize", "[multigpu]") {
  *  - Multi-device
  *  - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_hipMemcpyPeerAsync_Negative_Parameters", "[multigpu]") {
+TEST_CASE(Unit_hipMemcpyPeerAsync_Negative_Parameters) {
   const auto device_count = HipTest::getDeviceCount();
   if (device_count < 2) {
     HipTest::HIP_SKIP_TEST("Skipping because devices < 2");
@@ -311,7 +310,7 @@ TEST_CASE("Unit_hipMemcpyPeerAsync_Negative_Parameters", "[multigpu]") {
   }
 }
 
-TEST_CASE("Unit_hipMemcpyPeerAsync_Capture") {
+TEST_CASE(Unit_hipMemcpyPeerAsync_Capture) {
   const int device_count = HipTest::getDeviceCount();
   if (device_count < 2) {
     HipTest::HIP_SKIP_TEST("Skipping because devices < 2");

--- a/projects/hip-tests/catch/unit/memory/hipMemcpyPeerAsync_old.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemcpyPeerAsync_old.cc
@@ -41,7 +41,7 @@ This testfile verifies the following scenarios of hipMemcpyPeerAsync API
  * where stream is created in GPU-1
  * Then performs the addition and validates the sum
  */
-TEST_CASE("Unit_hipMemcpyPeerAsync_StreamOnDiffDevice", "[multigpu]") {
+TEST_CASE(Unit_hipMemcpyPeerAsync_StreamOnDiffDevice) {
   constexpr auto numElements{10};
   constexpr auto copy_bytes{numElements * sizeof(int)};
   int numDevices = 0;

--- a/projects/hip-tests/catch/unit/memory/hipMemcpySync.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemcpySync.cc
@@ -177,7 +177,7 @@ static void runMemcpyTests(hipStream_t stream, bool async, allocType type, memTy
 
 #if HT_AMD /* Disabled because frequency based wait is timing out on nvidia platforms */
 
-TEST_CASE("Unit_hipMemcpySync") {
+TEST_CASE(Unit_hipMemcpySync) {
 #if HT_AMD  // To be removed when EXSWCPHIPT-127 is fixed
   HipTest::HIP_SKIP_TEST("EXSWCPHIPT-127 - Sync behaviour differs on AMD and Nvidia");
   return;
@@ -191,7 +191,7 @@ TEST_CASE("Unit_hipMemcpySync") {
   doMemTest<char>(runMemcpyTests, type, memcpy_type, data);  // Uses long running kernel
 }
 
-TEST_CASE("Unit_hipMemcpy2DSync") {
+TEST_CASE(Unit_hipMemcpy2DSync) {
 #if HT_AMD
   HipTest::HIP_SKIP_TEST("EXSWCPHIPT-127 - Sync behaviour differs on AMD and Nvidia");
   return;
@@ -207,7 +207,7 @@ TEST_CASE("Unit_hipMemcpy2DSync") {
   doMemTest<char>(runMemcpyTests, mallocType, memcpy_type, data);
 }
 
-TEST_CASE("Unit_hipMemcpy3DSync") {
+TEST_CASE(Unit_hipMemcpy3DSync) {
 #if HT_AMD
   HipTest::HIP_SKIP_TEST("EXSWCPHIPT-127 - Sync behaviour differs on AMD and Nvidia");
   return;

--- a/projects/hip-tests/catch/unit/memory/hipMemcpyWithStream.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemcpyWithStream.cc
@@ -25,9 +25,9 @@ THE SOFTWARE.
 #include <resource_guards.hh>
 #include <utils.hh>
 
-TEST_CASE("Unit_hipMemcpy_Positive_Basic") { MemcpyWithDirectionCommonTests<false>(hipMemcpy); }
+TEST_CASE(Unit_hipMemcpy_Positive_Basic) { MemcpyWithDirectionCommonTests<false>(hipMemcpy); }
 
-TEST_CASE("Unit_hipMemcpy_Positive_Synchronization_Behavior") {
+TEST_CASE(Unit_hipMemcpy_Positive_Synchronization_Behavior) {
   using namespace std::placeholders;
   HIP_CHECK(hipDeviceSynchronize());
 
@@ -68,7 +68,7 @@ TEST_CASE("Unit_hipMemcpy_Positive_Synchronization_Behavior") {
   }
 }
 
-TEST_CASE("Unit_hipMemcpy_Negative_Parameters") {
+TEST_CASE(Unit_hipMemcpy_Negative_Parameters) {
   using namespace std::placeholders;
 
   SECTION("Host to device") {
@@ -100,7 +100,7 @@ TEST_CASE("Unit_hipMemcpy_Negative_Parameters") {
   }
 }
 
-TEST_CASE("Unit_hipMemcpyWithStream_Capture") {
+TEST_CASE(Unit_hipMemcpyWithStream_Capture) {
   constexpr size_t kNumElements = 1024;
 
   LinearAllocGuard<int> host_data(LinearAllocs::malloc, kNumElements * sizeof(int));

--- a/projects/hip-tests/catch/unit/memory/hipMemcpyWithStreamMultiThread.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemcpyWithStreamMultiThread.cc
@@ -580,7 +580,7 @@ void HipMemcpyWithStreamMultiThreadtests::TestkindHtoH(bool& val_res) {
   HIP_CHECK_THREAD(hipStreamDestroy(stream));
 }
 
-TEST_CASE("Unit_hipMemcpyWithStream_MultiThread", "[multigpu]") {
+TEST_CASE(Unit_hipMemcpyWithStream_MultiThread) {
   const auto Threadcount{10};
   bool ret_val[Threadcount];
   std::thread th[Threadcount];

--- a/projects/hip-tests/catch/unit/memory/hipMemcpyWithStream_old.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemcpyWithStream_old.cc
@@ -489,24 +489,23 @@ void TestkindHtoH(void) {
 
 TEST_CASE("Unit_hipMemcpyWithStream_TestwithTwoStream") { TestwithTwoStream(); }
 
-TEST_CASE("Unit_hipMemcpyWithStream_TestkindDtoH") { TestkindDtoH(); }
+TEST_CASE(Unit_hipMemcpyWithStream_TestkindDtoH) { TestkindDtoH(); }
 
-TEST_CASE("Unit_hipMemcpyWithStream_TestkindHtoH") { TestkindHtoH(); }
+TEST_CASE(Unit_hipMemcpyWithStream_TestkindHtoH) { TestkindHtoH(); }
 
-TEST_CASE("Unit_hipMemcpyWithStream_TestkindDtoD", "[multigpu]") {
+TEST_CASE(Unit_hipMemcpyWithStream_TestkindDtoD) {
   TestkindDtoD();
 }
 
-TEST_CASE("Unit_hipMemcpyWithStream_TestOnMultiGPUwithOneStream",
-          "[multigpu]") {
+TEST_CASE(Unit_hipMemcpyWithStream_TestOnMultiGPUwithOneStream) {
   TestOnMultiGPUwithOneStream();
 }
 
-TEST_CASE("Unit_hipMemcpyWithStream_TestkindDefault") { TestkindDefault(); }
+TEST_CASE(Unit_hipMemcpyWithStream_TestkindDefault) { TestkindDefault(); }
 #ifndef __HIP_PLATFORM_NVIDIA__
-TEST_CASE("Unit_hipMemcpyWithStream_TestkindDefaultForDtoD", "[multigpu]") {
+TEST_CASE(Unit_hipMemcpyWithStream_TestkindDefaultForDtoD) {
   TestkindDefaultForDtoD();
 }
 #endif
 
-TEST_CASE("Unit_hipMemcpyWithStream_TestDtoDonSameDevice") { TestDtoDonSameDevice(); }
+TEST_CASE(Unit_hipMemcpyWithStream_TestDtoDonSameDevice) { TestDtoDonSameDevice(); }

--- a/projects/hip-tests/catch/unit/memory/hipMemcpy_EdgeCases.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemcpy_EdgeCases.cc
@@ -372,7 +372,7 @@ Initializes device variables
 Launches kernel and performs the sum of device variables
 copies the result to host variable and validates the result.
 */
-TEMPLATE_TEST_CASE("Unit_hipMemcpy_KernelLaunch", "", int, float, double) {
+TEMPLATE_TEST_CASE(Unit_hipMemcpy_KernelLaunch, int, float, double) {
   size_t Nbytes = NUM_ELM * sizeof(TestType);
 
   TestType *A_d{nullptr}, *B_d{nullptr}, *C_d{nullptr};
@@ -404,8 +404,7 @@ This testcase verifies the following scenarios
 4. Device context change
 5. H2D-D2D-D2H peer GPU
 */
-TEMPLATE_TEST_CASE("Unit_hipMemcpy_H2H_H2D_D2H_H2PinMem", "[multigpu]", int,
-                   float, double) {
+TEMPLATE_TEST_CASE(Unit_hipMemcpy_H2H_H2D_D2H_H2PinMem, int, float, double) {
   TestType *A_d{nullptr}, *B_d{nullptr};
   TestType *A_h{nullptr}, *B_h{nullptr};
   TestType *A_Ph{nullptr}, *B_Ph{nullptr};
@@ -485,7 +484,7 @@ TEMPLATE_TEST_CASE("Unit_hipMemcpy_H2H_H2D_D2H_H2PinMem", "[multigpu]", int,
 /*
 This testcase verifies the multi thread scenario
 */
-TEST_CASE("Unit_hipMemcpy_MultiThreadWithSerialization") {
+TEST_CASE(Unit_hipMemcpy_MultiThreadWithSerialization) {
   HIP_CHECK(hipDeviceReset());
 
   // Simplest cases: serialize the threads, and also used pinned memory:
@@ -501,7 +500,7 @@ This testcase verifies hipMemcpy API with pinnedMemory and hostRegister
 along with kernel launches
 */
 
-TEMPLATE_TEST_CASE("Unit_hipMemcpy_PinnedRegMemWithKernelLaunch", "[multigpu]",
+TEMPLATE_TEST_CASE(Unit_hipMemcpy_PinnedRegMemWithKernelLaunch,
                    int, float, double) {
   int numDevices = 0;
   HIP_CHECK(hipGetDeviceCount(&numDevices));

--- a/projects/hip-tests/catch/unit/memory/hipMemcpy_MultiThread.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemcpy_MultiThread.cc
@@ -280,7 +280,7 @@ void Thread_func(bool& ret_val) {
 }
 
 
-TEST_CASE("Unit_hipMemcpy_MultiThread_AllAPIs", "[multigpu]") {
+TEST_CASE(Unit_hipMemcpy_MultiThread_AllAPIs) {
   std::thread Thrd[NUM_THREADS];
   bool ret_val[NUM_THREADS];
   for (int i = 0; i < NUM_THREADS; i++) Thrd[i] = std::thread(Thread_func, std::ref(ret_val[i]));

--- a/projects/hip-tests/catch/unit/memory/hipMemcpy_derivatives.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemcpy_derivatives.cc
@@ -26,13 +26,13 @@ THE SOFTWARE.
 #include <utils.hh>
 
 // hipMemcpyDtoH
-TEST_CASE("Unit_hipMemcpyDtoH_Positive_Basic") {
+TEST_CASE(Unit_hipMemcpyDtoH_Positive_Basic) {
   MemcpyDeviceToHostShell<false>([](void* dst, void* src, size_t count) {
     return hipMemcpyDtoH(dst, reinterpret_cast<hipDeviceptr_t>(src), count);
   });
 }
 
-TEST_CASE("Unit_hipMemcpyDtoH_Positive_Synchronization_Behavior") {
+TEST_CASE(Unit_hipMemcpyDtoH_Positive_Synchronization_Behavior) {
   const auto f = [](void* dst, void* src, size_t count) {
     return hipMemcpyDtoH(dst, reinterpret_cast<hipDeviceptr_t>(src), count);
   };
@@ -40,7 +40,7 @@ TEST_CASE("Unit_hipMemcpyDtoH_Positive_Synchronization_Behavior") {
   MemcpyDtoHPinnedSyncBehavior(f, true);
 }
 
-TEST_CASE("Unit_hipMemcpyDtoH_Negative_Parameters") {
+TEST_CASE(Unit_hipMemcpyDtoH_Negative_Parameters) {
   using namespace std::placeholders;
   LinearAllocGuard<int> device_alloc(LinearAllocs::hipMalloc, kPageSize);
   LinearAllocGuard<int> host_alloc(LinearAllocs::hipHostMalloc, kPageSize);
@@ -53,13 +53,13 @@ TEST_CASE("Unit_hipMemcpyDtoH_Negative_Parameters") {
 }
 
 // hipMemcpyHtoD
-TEST_CASE("Unit_hipMemcpyHtoD_Positive_Basic") {
+TEST_CASE(Unit_hipMemcpyHtoD_Positive_Basic) {
   MemcpyHostToDeviceShell<false>([](void* dst, void* src, size_t count) {
     return hipMemcpyHtoD(reinterpret_cast<hipDeviceptr_t>(dst), src, count);
   });
 }
 
-TEST_CASE("Unit_hipMemcpyHtoD_Positive_Synchronization_Behavior") {
+TEST_CASE(Unit_hipMemcpyHtoD_Positive_Synchronization_Behavior) {
   MemcpyHPageabletoDSyncBehavior(
       [](void* dst, void* src, size_t count) {
         return hipMemcpyHtoD(reinterpret_cast<hipDeviceptr_t>(dst), src, count);
@@ -67,7 +67,7 @@ TEST_CASE("Unit_hipMemcpyHtoD_Positive_Synchronization_Behavior") {
       true);
 }
 
-TEST_CASE("Unit_hipMemcpyHtoD_Negative_Parameters") {
+TEST_CASE(Unit_hipMemcpyHtoD_Negative_Parameters) {
   using namespace std::placeholders;
   LinearAllocGuard<int> device_alloc(LinearAllocs::hipMalloc, kPageSize);
   LinearAllocGuard<int> host_alloc(LinearAllocs::hipHostMalloc, kPageSize);
@@ -80,7 +80,7 @@ TEST_CASE("Unit_hipMemcpyHtoD_Negative_Parameters") {
 }
 
 // hipMemcpyDtoD
-TEST_CASE("Unit_hipMemcpyDtoD_Positive_Basic") {
+TEST_CASE(Unit_hipMemcpyDtoD_Positive_Basic) {
   const auto f = [](void* dst, void* src, size_t count) {
     return hipMemcpyDtoD(reinterpret_cast<hipDeviceptr_t>(dst),
                          reinterpret_cast<hipDeviceptr_t>(src), count);
@@ -89,7 +89,7 @@ TEST_CASE("Unit_hipMemcpyDtoD_Positive_Basic") {
   SECTION("Peer access disabled") { MemcpyDeviceToDeviceShell<false, false>(f); }
 }
 
-TEST_CASE("Unit_hipMemcpyDtoD_Positive_Synchronization_Behavior") {
+TEST_CASE(Unit_hipMemcpyDtoD_Positive_Synchronization_Behavior) {
   // This behavior differs on NVIDIA and AMD, on AMD the hipMemcpy calls is synchronous with
   // respect to the host
 #if HT_AMD
@@ -105,7 +105,7 @@ TEST_CASE("Unit_hipMemcpyDtoD_Positive_Synchronization_Behavior") {
       false);
 }
 
-TEST_CASE("Unit_hipMemcpyDtoD_Negative_Parameters") {
+TEST_CASE(Unit_hipMemcpyDtoD_Negative_Parameters) {
   using namespace std::placeholders;
   LinearAllocGuard<int> src_alloc(LinearAllocs::hipMalloc, kPageSize);
   LinearAllocGuard<int> dst_alloc(LinearAllocs::hipMalloc, kPageSize);

--- a/projects/hip-tests/catch/unit/memory/hipMemset.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemset.cc
@@ -133,7 +133,7 @@ template <typename T> static bool testhipMemsetAsync(T* A_h, T* A_d, T memsetval
  * Test hipMemset, hipMemsetD8, hipMemsetD16, hipMemsetD32 apis with unique
  * number of elements and memset values.
  */
-TEST_CASE("Unit_hipMemset_SetMemoryWithOffset") {
+TEST_CASE(Unit_hipMemset_SetMemoryWithOffset) {
   char memsetval;
   int memsetD32val;
   int16_t memsetD16val;
@@ -175,7 +175,7 @@ TEST_CASE("Unit_hipMemset_SetMemoryWithOffset") {
  * Test hipMemsetAsync, hipMemsetD8Async, hipMemsetD16Async, hipMemsetD32Async
  * apis with unique number of elements and memset values.
  */
-TEST_CASE("Unit_hipMemsetAsync_SetMemoryWithOffset") {
+TEST_CASE(Unit_hipMemsetAsync_SetMemoryWithOffset) {
   char memsetval;
   int memsetD32val;
   int16_t memsetD16val;
@@ -215,7 +215,7 @@ TEST_CASE("Unit_hipMemsetAsync_SetMemoryWithOffset") {
 /**
  * Test hipMemset small size buffers with unique memset values.
  */
-TEST_CASE("Unit_hipMemset_SmallBufferSizes") {
+TEST_CASE(Unit_hipMemset_SmallBufferSizes) {
   char *A_d, *A_h;
   constexpr int memsetval = 0x24;
 
@@ -243,7 +243,7 @@ TEST_CASE("Unit_hipMemset_SmallBufferSizes") {
 /**
  * Test two memset async operations at the same time.
  */
-TEST_CASE("Unit_hipMemset_2AsyncOperations") {
+TEST_CASE(Unit_hipMemset_2AsyncOperations) {
   std::vector<float> v;
   v.resize(2048);
   float *p2, *p3;

--- a/projects/hip-tests/catch/unit/memory/hipMemset2D.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemset2D.cc
@@ -43,7 +43,7 @@ static constexpr std::initializer_list<tupletype> tableItems{
 /**
  * Basic Functionality of hipMemset2D
  */
-TEST_CASE("Unit_hipMemset2D_BasicFunctional") {
+TEST_CASE(Unit_hipMemset2D_BasicFunctional) {
   CHECK_IMAGE_SUPPORT
 
   constexpr int memsetval = 0x24;
@@ -82,7 +82,7 @@ TEST_CASE("Unit_hipMemset2D_BasicFunctional") {
 /**
  * Basic Functionality of hipMemset2DAsync
  */
-TEST_CASE("Unit_hipMemset2DAsync_BasicFunctional") {
+TEST_CASE(Unit_hipMemset2DAsync_BasicFunctional) {
   CHECK_IMAGE_SUPPORT
 
   constexpr int memsetval = 0x26;
@@ -125,7 +125,7 @@ TEST_CASE("Unit_hipMemset2DAsync_BasicFunctional") {
 /**
  * Memset partial buffer with unique Width and Height
  */
-TEST_CASE("Unit_hipMemset2D_UniqueWidthHeight") {
+TEST_CASE(Unit_hipMemset2D_UniqueWidthHeight) {
   CHECK_IMAGE_SUPPORT
 
   int width2D, height2D;
@@ -180,7 +180,7 @@ TEST_CASE("Unit_hipMemset2D_UniqueWidthHeight") {
  * ------------------------
  *  - HIP_VERSION >= 6.0
  */
-TEST_CASE("Unit_hipMemset2DAsync_capturehipMemset2DAsync") {
+TEST_CASE(Unit_hipMemset2DAsync_capturehipMemset2DAsync) {
   char *A_h, *B_h, *A_d;
   hipGraph_t graph{nullptr};
   hipGraphExec_t graphExec{nullptr};

--- a/projects/hip-tests/catch/unit/memory/hipMemset2DAsyncMultiThreadAndKernel.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemset2DAsyncMultiThreadAndKernel.cc
@@ -48,7 +48,7 @@ void queueJobsForhipMemset2DAsync(char* A_d, char* A_h, size_t pitch, size_t wid
 /**
  * Order of execution of device kernel and hipMemset2DAsync api.
  */
-TEST_CASE("Unit_hipMemset2DAsync_WithKernel") {
+TEST_CASE(Unit_hipMemset2DAsync_WithKernel) {
   CHECK_IMAGE_SUPPORT
 
   constexpr auto N = 4 * 1024 * 1024;
@@ -127,7 +127,7 @@ TEST_CASE("Unit_hipMemset2DAsync_WithKernel") {
 /**
  * hipMemSet2DAsync execution in multiple threads.
  */
-TEST_CASE("Unit_hipMemset2DAsync_MultiThread") {
+TEST_CASE(Unit_hipMemset2DAsync_MultiThread) {
   CHECK_IMAGE_SUPPORT
 
   constexpr auto memPerThread = 200;

--- a/projects/hip-tests/catch/unit/memory/hipMemset3D.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemset3D.cc
@@ -31,7 +31,7 @@ THE SOFTWARE.
 /**
  * Basic Functional test of hipMemset3D
  */
-TEST_CASE("Unit_hipMemset3D_BasicFunctional") {
+TEST_CASE(Unit_hipMemset3D_BasicFunctional) {
   CHECK_IMAGE_SUPPORT
 
   constexpr int memsetval = 0x22;
@@ -81,7 +81,7 @@ TEST_CASE("Unit_hipMemset3D_BasicFunctional") {
 /**
  * Basic Functional test of hipMemset3DAsync
  */
-TEST_CASE("Unit_hipMemset3DAsync_BasicFunctional") {
+TEST_CASE(Unit_hipMemset3DAsync_BasicFunctional) {
   CHECK_IMAGE_SUPPORT
 
   constexpr int memsetval = 0x22;
@@ -143,7 +143,7 @@ TEST_CASE("Unit_hipMemset3DAsync_BasicFunctional") {
  * ------------------------
  *  - HIP_VERSION >= 6.0
  */
-TEST_CASE("Unit_hipMemset3DAsync_capturehipMemset3DAsync") {
+TEST_CASE(Unit_hipMemset3DAsync_capturehipMemset3DAsync) {
   char* A_h;
   hipPitchedPtr A_d;
   hipGraph_t graph{nullptr};

--- a/projects/hip-tests/catch/unit/memory/hipMemset3DFunctional.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemset3DFunctional.cc
@@ -400,7 +400,7 @@ static void seekAndSet3DArrayPortion(bool bAsync) {
  * Test Memset3D with different combinations of extent
  * taking zero and non-zero fields.
  */
-TEST_CASE("Unit_hipMemset3D_MemsetWithExtent") {
+TEST_CASE(Unit_hipMemset3D_MemsetWithExtent) {
   CHECK_IMAGE_SUPPORT
 
   hipExtent testExtent;
@@ -436,7 +436,7 @@ TEST_CASE("Unit_hipMemset3D_MemsetWithExtent") {
  * Test Memset3DAsync with different combinations of extent
  * taking zero and non-zero fields.
  */
-TEST_CASE("Unit_hipMemset3DAsync_MemsetWithExtent") {
+TEST_CASE(Unit_hipMemset3DAsync_MemsetWithExtent) {
   CHECK_IMAGE_SUPPORT
 
   hipExtent testExtent;
@@ -470,7 +470,7 @@ TEST_CASE("Unit_hipMemset3DAsync_MemsetWithExtent") {
 /**
  * Memset3D with max unsigned char and verify memset operation is success
  */
-TEST_CASE("Unit_hipMemset3D_MemsetMaxValue") {
+TEST_CASE(Unit_hipMemset3D_MemsetMaxValue) {
   CHECK_IMAGE_SUPPORT
 
   testMemsetMaxValue(0);
@@ -479,7 +479,7 @@ TEST_CASE("Unit_hipMemset3D_MemsetMaxValue") {
 /**
  * Memset3DAsync with max unsigned char and verify memset operation is success
  */
-TEST_CASE("Unit_hipMemset3DAsync_MemsetMaxValue") {
+TEST_CASE(Unit_hipMemset3DAsync_MemsetMaxValue) {
   CHECK_IMAGE_SUPPORT
 
   testMemsetMaxValue(1);
@@ -488,7 +488,7 @@ TEST_CASE("Unit_hipMemset3DAsync_MemsetMaxValue") {
 /**
  * Seek and set random slice of 3d array, verify memset is success
  */
-TEST_CASE("Unit_hipMemset3D_SeekSetSlice") {
+TEST_CASE(Unit_hipMemset3D_SeekSetSlice) {
   CHECK_IMAGE_SUPPORT
 
   seekAndSet3DArraySlice(0);
@@ -497,7 +497,7 @@ TEST_CASE("Unit_hipMemset3D_SeekSetSlice") {
 /**
  * Seek and set random slice of 3d array with async, verify memset is success
  */
-TEST_CASE("Unit_hipMemset3DAsync_SeekSetSlice") {
+TEST_CASE(Unit_hipMemset3DAsync_SeekSetSlice) {
   CHECK_IMAGE_SUPPORT
 
   seekAndSet3DArraySlice(1);
@@ -506,7 +506,7 @@ TEST_CASE("Unit_hipMemset3DAsync_SeekSetSlice") {
 /**
  * Memset3D selected portion of 3d array
  */
-TEST_CASE("Unit_hipMemset3D_SeekSetArrayPortion") {
+TEST_CASE(Unit_hipMemset3D_SeekSetArrayPortion) {
   CHECK_IMAGE_SUPPORT
 
   seekAndSet3DArrayPortion(0);
@@ -515,7 +515,7 @@ TEST_CASE("Unit_hipMemset3D_SeekSetArrayPortion") {
 /**
  * Memset3DAsync selected portion of 3d array
  */
-TEST_CASE("Unit_hipMemset3DAsync_SeekSetArrayPortion") {
+TEST_CASE(Unit_hipMemset3DAsync_SeekSetArrayPortion) {
   CHECK_IMAGE_SUPPORT
 
   seekAndSet3DArrayPortion(1);

--- a/projects/hip-tests/catch/unit/memory/hipMemset3DRegressMultiThread.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemset3DRegressMultiThread.cc
@@ -186,7 +186,7 @@ bool loopRegression(bool bAsync) {
  * Perform regression of hipMemset3D api with device memory allocated
  * on different gpus.
  */
-TEST_CASE("Unit_hipMemset3D_RegressInLoop", "[multigpu]") {
+TEST_CASE(Unit_hipMemset3D_RegressInLoop) {
   CHECK_IMAGE_SUPPORT
 
   bool TestPassed = false;
@@ -199,7 +199,7 @@ TEST_CASE("Unit_hipMemset3D_RegressInLoop", "[multigpu]") {
  * Perform regression of hipMemset3DAsync api with device memory allocated
  * on different gpus.
  */
-TEST_CASE("Unit_hipMemset3DAsync_RegressInLoop", "[multigpu]") {
+TEST_CASE(Unit_hipMemset3DAsync_RegressInLoop) {
   CHECK_IMAGE_SUPPORT
 
   bool TestPassed = false;
@@ -211,7 +211,7 @@ TEST_CASE("Unit_hipMemset3DAsync_RegressInLoop", "[multigpu]") {
 /**
  * Async commands queued concurrently and executed
  */
-TEST_CASE("Unit_hipMemset3DAsync_ConcurrencyMthread") {
+TEST_CASE(Unit_hipMemset3DAsync_ConcurrencyMthread) {
   CHECK_IMAGE_SUPPORT
 
   char* A_h;

--- a/projects/hip-tests/catch/unit/memory/hipMemsetAsync.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemsetAsync.cc
@@ -77,7 +77,7 @@ template <typename T> static void doMemsetTest(allocType mallocType, memType mem
  * test 2 async hipMemset's on the same memory at different offsets
  */
 
-TEST_CASE("Unit_hipMemsetASyncMulti") {
+TEST_CASE(Unit_hipMemsetASyncMulti) {
   allocType mallocType = GENERATE(allocType::hostMalloc, allocType::deviceMalloc,
                                   allocType::hostRegisted, allocType::devRegistered);
   memType mem_type = memType::hipMemsetD8;
@@ -94,7 +94,7 @@ TEST_CASE("Unit_hipMemsetASyncMulti") {
 /*
  * test 2 async hipMemsetD[8,16,32]'s on the same memory at different offsets
  */
-TEMPLATE_TEST_CASE("Unit_hipMemsetDASyncMulti", "", int8_t, int16_t, uint32_t) {
+TEMPLATE_TEST_CASE(Unit_hipMemsetDASyncMulti, int8_t, int16_t, uint32_t) {
   allocType mallocType = GENERATE(allocType::hostRegisted, allocType::deviceMalloc,
                                   allocType::hostMalloc, allocType::devRegistered);
   memType memset_type;
@@ -118,7 +118,7 @@ TEMPLATE_TEST_CASE("Unit_hipMemsetDASyncMulti", "", int8_t, int16_t, uint32_t) {
 /*
  * test 2 async hipMemset2D's on the same memory at different offsets
  */
-TEST_CASE("Unit_hipMemset2DASyncMulti") {
+TEST_CASE(Unit_hipMemset2DASyncMulti) {
 #if HT_AMD
   HipTest::HIP_SKIP_TEST("EXSWCPHIPT-127");
   return;
@@ -140,7 +140,7 @@ TEST_CASE("Unit_hipMemset2DASyncMulti") {
 /*
  * test 2 async hipMemset3D's on the same memory at different offsets
  */
-TEST_CASE("Unit_hipMemset3DASyncMulti") {
+TEST_CASE(Unit_hipMemset3DASyncMulti) {
 #if HT_AMD
   HipTest::HIP_SKIP_TEST("EXSWCPHIPT-127");
   return;

--- a/projects/hip-tests/catch/unit/memory/hipMemsetAsyncAndKernel.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemsetAsyncAndKernel.cc
@@ -168,7 +168,7 @@ static bool testhipMemsetD8AsyncWithKernel() {
  * Test for checking order of execution of device kernel and
  * hipMemsetAsync apis on all gpus
  */
-TEST_CASE("Unit_hipMemsetAsync_VerifyExecutionWithKernel") {
+TEST_CASE(Unit_hipMemsetAsync_VerifyExecutionWithKernel) {
   int numDevices = 0;
   bool ret, UseStrmPerThrd = false;
 

--- a/projects/hip-tests/catch/unit/memory/hipMemsetD16.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemsetD16.cc
@@ -105,7 +105,7 @@ static bool testMemset(allocator_fn_t allocator, deallocator_fn_t deallocator) {
  * ------------------------
  *  - HIP_VERSION >= 6.1
  */
-TEST_CASE("Unit_hipMemsetD16_ValidBuffer") {
+TEST_CASE(Unit_hipMemsetD16_ValidBuffer) {
   SECTION("Device Buffer") {
     bool result = testMemset(hipMalloc, hipFree);
 
@@ -133,7 +133,7 @@ TEST_CASE("Unit_hipMemsetD16_ValidBuffer") {
  * ------------------------
  *  - HIP_VERSION >= 6.1
  */
-TEST_CASE("Unit_hipMemsetD16_InvalidArg") {
+TEST_CASE(Unit_hipMemsetD16_InvalidArg) {
   constexpr size_t ptr_test_nelem = 4096;
   void* ptr = nullptr;
 
@@ -161,7 +161,7 @@ TEST_CASE("Unit_hipMemsetD16_InvalidArg") {
  * ------------------------
  *  - HIP_VERSION >= 6.1
  */
-TEST_CASE("Unit_hipMemsetD16_KernelBuffer") {
+TEST_CASE(Unit_hipMemsetD16_KernelBuffer) {
   constexpr size_t ptr_test_nelem = 4096;
   constexpr unsigned blocksPerCU = 6;
   constexpr unsigned threadsPerBlock = 256;

--- a/projects/hip-tests/catch/unit/memory/hipMemsetD16Async.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemsetD16Async.cc
@@ -113,7 +113,7 @@ static bool testMemset(allocator_fn_t allocator, deallocator_fn_t deallocator) {
  * ------------------------
  *  - HIP_VERSION >= 6.1
  */
-TEST_CASE("Unit_hipMemsetD16Async_ValidBuffer") {
+TEST_CASE(Unit_hipMemsetD16Async_ValidBuffer) {
   SECTION("Device Buffer") {
     bool result = testMemset(hipMalloc, hipFree);
 
@@ -141,7 +141,7 @@ TEST_CASE("Unit_hipMemsetD16Async_ValidBuffer") {
  * ------------------------
  *  - HIP_VERSION >= 6.1
  */
-TEST_CASE("Unit_hipMemsetD16Async_InvalidArg") {
+TEST_CASE(Unit_hipMemsetD16Async_InvalidArg) {
   constexpr size_t ptr_test_nelem = 4096;
   void* ptr = nullptr;
 
@@ -169,7 +169,7 @@ TEST_CASE("Unit_hipMemsetD16Async_InvalidArg") {
  * ------------------------
  *  - HIP_VERSION >= 6.1
  */
-TEST_CASE("Unit_hipMemsetD16Async_KernelBuffer") {
+TEST_CASE(Unit_hipMemsetD16Async_KernelBuffer) {
   constexpr size_t ptr_test_nelem = 4096;
   constexpr unsigned blocksPerCU = 6;
   constexpr unsigned threadsPerBlock = 256;

--- a/projects/hip-tests/catch/unit/memory/hipMemsetD2D16.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemsetD2D16.cc
@@ -42,7 +42,7 @@ THE SOFTWARE.
  * ------------------------
  *  - HIP_VERSION >= 7.1
  */
-TEST_CASE("Unit_hipMemsetD2D16_BasicFunctional") {
+TEST_CASE(Unit_hipMemsetD2D16_BasicFunctional) {
   constexpr uint16_t memsetval = static_cast<uint16_t>(0xDEADBEEF);
   constexpr size_t numH = 256;
   constexpr size_t numW = 256;
@@ -78,7 +78,7 @@ TEST_CASE("Unit_hipMemsetD2D16_BasicFunctional") {
  * ------------------------
  *  - HIP_VERSION >= 7.1
  */
-TEST_CASE("Unit_hipMemsetD2D16_UnEvenRowsCols") {
+TEST_CASE(Unit_hipMemsetD2D16_UnEvenRowsCols) {
   hipDeviceptr_t A_d;
   constexpr uint16_t memsetVal = 5;
   int rows, cols;
@@ -116,7 +116,7 @@ TEST_CASE("Unit_hipMemsetD2D16_UnEvenRowsCols") {
  * ------------------------
  * - HIP_VERSION >= 7.1
  */
-TEST_CASE("Unit_hipMemsetD2D16_NegTsts") {
+TEST_CASE(Unit_hipMemsetD2D16_NegTsts) {
   hipDeviceptr_t A_d;
   constexpr size_t numH = 256;
   constexpr size_t numW = 256;

--- a/projects/hip-tests/catch/unit/memory/hipMemsetD2D16Async.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemsetD2D16Async.cc
@@ -42,7 +42,7 @@ THE SOFTWARE.
  * ------------------------
  *  - HIP_VERSION >= 7.1
  */
-TEST_CASE("Unit_hipMemsetD2D16Async_BasicFunctional") {
+TEST_CASE(Unit_hipMemsetD2D16Async_BasicFunctional) {
   constexpr int memsetval = 0x24;
   constexpr size_t numH = 256;
   constexpr size_t numW = 256;
@@ -83,7 +83,7 @@ TEST_CASE("Unit_hipMemsetD2D16Async_BasicFunctional") {
  * ------------------------
  *  - HIP_VERSION >= 7.1
  */
-TEST_CASE("Unit_hipMemsetD2D16Async_UnEvenRowsCols") {
+TEST_CASE(Unit_hipMemsetD2D16Async_UnEvenRowsCols) {
   hipDeviceptr_t A_d;
   int rows, cols;
   constexpr int memsetval = 5;
@@ -123,7 +123,7 @@ TEST_CASE("Unit_hipMemsetD2D16Async_UnEvenRowsCols") {
  * ------------------------
  * - HIP_VERSION >= 7.1
  */
-TEST_CASE("Unit_hipMemsetD2D16Async_NegTsts") {
+TEST_CASE(Unit_hipMemsetD2D16Async_NegTsts) {
   hipDeviceptr_t A_d;
   constexpr size_t numH = 256;
   constexpr size_t numW = 256;

--- a/projects/hip-tests/catch/unit/memory/hipMemsetD2D32.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemsetD2D32.cc
@@ -42,7 +42,7 @@ THE SOFTWARE.
  * ------------------------
  *  - HIP_VERSION >= 7.1
  */
-TEST_CASE("Unit_hipMemsetD2D32_BasicFunctional") {
+TEST_CASE(Unit_hipMemsetD2D32_BasicFunctional) {
   constexpr int memsetval = 15;
   constexpr size_t numH = 256;
   constexpr size_t numW = 256;
@@ -77,7 +77,7 @@ TEST_CASE("Unit_hipMemsetD2D32_BasicFunctional") {
  * ------------------------
  *  - HIP_VERSION >= 7.1
  */
-TEST_CASE("Unit_hipMemsetD2D32_UnEvenRowsCols") {
+TEST_CASE(Unit_hipMemsetD2D32_UnEvenRowsCols) {
   constexpr int memsetval = 5;
   hipDeviceptr_t A_d;
   int rows, cols;
@@ -114,7 +114,7 @@ TEST_CASE("Unit_hipMemsetD2D32_UnEvenRowsCols") {
  * ------------------------
  * - HIP_VERSION >= 7.1
  */
-TEST_CASE("Unit_hipMemsetD2D32_NegTsts") {
+TEST_CASE(Unit_hipMemsetD2D32_NegTsts) {
   hipDeviceptr_t A_d;
   constexpr size_t numH = 256;
   constexpr size_t numW = 256;

--- a/projects/hip-tests/catch/unit/memory/hipMemsetD2D32Async.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemsetD2D32Async.cc
@@ -42,7 +42,7 @@ THE SOFTWARE.
  * ------------------------
  *  - HIP_VERSION >= 7.1
  */
-TEST_CASE("Unit_hipMemsetD2D32Async_BasicFunctional") {
+TEST_CASE(Unit_hipMemsetD2D32Async_BasicFunctional) {
   constexpr int memsetval = 0x24;
   constexpr size_t numH = 256;
   constexpr size_t numW = 256;
@@ -79,7 +79,7 @@ TEST_CASE("Unit_hipMemsetD2D32Async_BasicFunctional") {
  * ------------------------
  *  - HIP_VERSION >= 7.1
  */
-TEST_CASE("Unit_hipMemsetD2D32Async_UnEvenRowsCols") {
+TEST_CASE(Unit_hipMemsetD2D32Async_UnEvenRowsCols) {
   constexpr int memsetval = 5;
   hipDeviceptr_t A_d;
   int rows, cols;
@@ -120,7 +120,7 @@ TEST_CASE("Unit_hipMemsetD2D32Async_UnEvenRowsCols") {
  * ------------------------
  * - HIP_VERSION >= 7.1
  */
-TEST_CASE("Unit_hipMemsetD2D32Async_NegTsts") {
+TEST_CASE(Unit_hipMemsetD2D32Async_NegTsts) {
   hipDeviceptr_t A_d;
   constexpr size_t numH = 256;
   constexpr size_t numW = 256;

--- a/projects/hip-tests/catch/unit/memory/hipMemsetD2D8.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemsetD2D8.cc
@@ -41,7 +41,7 @@ THE SOFTWARE.
  * ------------------------
  *  - HIP_VERSION >= 7.1
  */
-TEST_CASE("Unit_hipMemsetD2D8_BasicFunctional") {
+TEST_CASE(Unit_hipMemsetD2D8_BasicFunctional) {
   constexpr char memsetval = 'c';
   constexpr size_t numH = 256;
   constexpr size_t numW = 256;
@@ -75,7 +75,7 @@ TEST_CASE("Unit_hipMemsetD2D8_BasicFunctional") {
  * ------------------------
  *  - HIP_VERSION >= 7.1
  */
-TEST_CASE("Unit_hipMemsetD2D8_UnEvenRowsCols") {
+TEST_CASE(Unit_hipMemsetD2D8_UnEvenRowsCols) {
   hipDeviceptr_t A_d;
   int rows, cols;
   rows = GENERATE(3, 4, 100);
@@ -115,7 +115,7 @@ TEST_CASE("Unit_hipMemsetD2D8_UnEvenRowsCols") {
  * ------------------------
  * - HIP_VERSION >= 7.1
  */
-TEST_CASE("Unit_hipMemsetD2D8_NegTsts") {
+TEST_CASE(Unit_hipMemsetD2D8_NegTsts) {
   hipDeviceptr_t A_d;
   constexpr size_t numH = 256;
   constexpr size_t numW = 256;

--- a/projects/hip-tests/catch/unit/memory/hipMemsetD2D8Async.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemsetD2D8Async.cc
@@ -43,7 +43,7 @@ THE SOFTWARE.
  * ------------------------
  *  - HIP_VERSION >= 7.1
  */
-TEST_CASE("Unit_hipMemsetD2D8Async_BasicFunctional") {
+TEST_CASE(Unit_hipMemsetD2D8Async_BasicFunctional) {
   constexpr char memsetval = 'c';
   constexpr size_t numH = 256;
   constexpr size_t numW = 256;
@@ -82,7 +82,7 @@ TEST_CASE("Unit_hipMemsetD2D8Async_BasicFunctional") {
  * ------------------------
  *  - HIP_VERSION >= 7.1
  */
-TEST_CASE("Unit_hipMemsetD2D8Async_UnEvenRowsCols") {
+TEST_CASE(Unit_hipMemsetD2D8Async_UnEvenRowsCols) {
   hipDeviceptr_t A_d;
   int rows, cols;
   rows = GENERATE(3, 4, 100);
@@ -125,7 +125,7 @@ TEST_CASE("Unit_hipMemsetD2D8Async_UnEvenRowsCols") {
  * ------------------------
  * - HIP_VERSION >= 7.1
  */
-TEST_CASE("Unit_hipMemsetD2D8Async_NegTsts") {
+TEST_CASE(Unit_hipMemsetD2D8Async_NegTsts) {
   hipDeviceptr_t A_d;
   constexpr size_t numH = 256;
   constexpr size_t numW = 256;

--- a/projects/hip-tests/catch/unit/memory/hipMemsetD32.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemsetD32.cc
@@ -105,7 +105,7 @@ static bool testMemset(allocator_fn_t allocator, deallocator_fn_t deallocator) {
  * ------------------------
  *  - HIP_VERSION >= 6.1
  */
-TEST_CASE("Unit_hipMemsetD32_ValidBuffer") {
+TEST_CASE(Unit_hipMemsetD32_ValidBuffer) {
   SECTION("Device Buffer") {
     bool result = testMemset(hipMalloc, hipFree);
 
@@ -133,7 +133,7 @@ TEST_CASE("Unit_hipMemsetD32_ValidBuffer") {
  * ------------------------
  *  - HIP_VERSION >= 6.1
  */
-TEST_CASE("Unit_hipMemsetD32_InvalidArg") {
+TEST_CASE(Unit_hipMemsetD32_InvalidArg) {
   constexpr size_t ptr_test_nelem = 4096;
   void* ptr = nullptr;
 
@@ -161,7 +161,7 @@ TEST_CASE("Unit_hipMemsetD32_InvalidArg") {
  * ------------------------
  *  - HIP_VERSION >= 6.1
  */
-TEST_CASE("Unit_hipMemsetD32_KernelBuffer") {
+TEST_CASE(Unit_hipMemsetD32_KernelBuffer) {
   constexpr size_t ptr_test_nelem = 4096;
   constexpr unsigned blocksPerCU = 6;
   constexpr unsigned threadsPerBlock = 256;

--- a/projects/hip-tests/catch/unit/memory/hipMemsetD32Async.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemsetD32Async.cc
@@ -113,7 +113,7 @@ static bool testMemset(allocator_fn_t allocator, deallocator_fn_t deallocator) {
  * ------------------------
  *  - HIP_VERSION >= 6.1
  */
-TEST_CASE("Unit_hipMemsetD32Async_ValidBuffer") {
+TEST_CASE(Unit_hipMemsetD32Async_ValidBuffer) {
   SECTION("Device Buffer") {
     bool result = testMemset(hipMalloc, hipFree);
 
@@ -141,7 +141,7 @@ TEST_CASE("Unit_hipMemsetD32Async_ValidBuffer") {
  * ------------------------
  *  - HIP_VERSION >= 6.1
  */
-TEST_CASE("Unit_hipMemsetD32Async_InvalidArg") {
+TEST_CASE(Unit_hipMemsetD32Async_InvalidArg) {
   constexpr size_t ptr_test_nelem = 4096;
   void* ptr = nullptr;
 
@@ -169,7 +169,7 @@ TEST_CASE("Unit_hipMemsetD32Async_InvalidArg") {
  * ------------------------
  *  - HIP_VERSION >= 6.1
  */
-TEST_CASE("Unit_hipMemsetD32Async_KernelBuffer") {
+TEST_CASE(Unit_hipMemsetD32Async_KernelBuffer) {
   constexpr size_t ptr_test_nelem = 4096;
   constexpr unsigned blocksPerCU = 6;
   constexpr unsigned threadsPerBlock = 256;

--- a/projects/hip-tests/catch/unit/memory/hipMemsetD8Async.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemsetD8Async.cc
@@ -113,7 +113,7 @@ static bool testMemset(allocator_fn_t allocator, deallocator_fn_t deallocator) {
  * ------------------------
  *  - HIP_VERSION >= 6.1
  */
-TEST_CASE("Unit_hipMemsetD8Async_ValidBuffer") {
+TEST_CASE(Unit_hipMemsetD8Async_ValidBuffer) {
   SECTION("Device Buffer") {
     bool result = testMemset(hipMalloc, hipFree);
 
@@ -141,7 +141,7 @@ TEST_CASE("Unit_hipMemsetD8Async_ValidBuffer") {
  * ------------------------
  *  - HIP_VERSION >= 6.1
  */
-TEST_CASE("Unit_hipMemsetD8Async_InvalidArg") {
+TEST_CASE(Unit_hipMemsetD8Async_InvalidArg) {
   constexpr size_t ptr_test_nelem = 4096;
   void* ptr = nullptr;
 
@@ -169,7 +169,7 @@ TEST_CASE("Unit_hipMemsetD8Async_InvalidArg") {
  * ------------------------
  *  - HIP_VERSION >= 6.1
  */
-TEST_CASE("Unit_hipMemsetD8Async_KernelBuffer") {
+TEST_CASE(Unit_hipMemsetD8Async_KernelBuffer) {
   constexpr size_t ptr_test_nelem = 4096;
   constexpr unsigned blocksPerCU = 6;
   constexpr unsigned threadsPerBlock = 256;

--- a/projects/hip-tests/catch/unit/memory/hipMemsetFunctional.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemsetFunctional.cc
@@ -149,8 +149,8 @@ void checkMemset(T value, size_t count, MemsetType memsetType, bool async = fals
 // Macro which defines a TEST_CASE which calls and then checks the result of the 1D memset macros
 // for all combinations of sync/async and hipMalloc/hipHostMalloc, given the value and memory range.
 #define DEFINE_1D_BASIC_TEST(suffix, memsetType, T, value, count)                                  \
-  TEST_CASE("Unit_hipMemsetFunctional_" + std::string(suffix)) {                                   \
-    const std::string memsetStr = std::string(suffix);                                             \
+  TEST_CASE(Unit_hipMemsetFunctional_##suffix) {                                                   \
+    const std::string memsetStr = std::string(#suffix);                                            \
     SECTION(memsetStr + " - Device Malloc") {                                                      \
       checkMemset(static_cast<T>(value), count, memsetType, false, hipDeviceMalloc_t);             \
     }                                                                                              \
@@ -165,20 +165,20 @@ void checkMemset(T value, size_t count, MemsetType memsetType, bool async = fals
     }                                                                                              \
   }
 
-DEFINE_1D_BASIC_TEST("ZeroValue_hipMemset", hipMemsetTypeDefault, float, 0, 1024)
-DEFINE_1D_BASIC_TEST("ZeroValue_hipMemsetD32", hipMemsetTypeD32, uint32_t, 0, 1024)
-DEFINE_1D_BASIC_TEST("ZeroValue_hipMemsetD16", hipMemsetTypeD16, int16_t, 0, 1024)
-DEFINE_1D_BASIC_TEST("ZeroValue_hipMemsetD8", hipMemsetTypeD8, int8_t, 0, 1024)
+DEFINE_1D_BASIC_TEST(ZeroValue_hipMemset, hipMemsetTypeDefault, float, 0, 1024)
+DEFINE_1D_BASIC_TEST(ZeroValue_hipMemsetD32, hipMemsetTypeD32, uint32_t, 0, 1024)
+DEFINE_1D_BASIC_TEST(ZeroValue_hipMemsetD16, hipMemsetTypeD16, int16_t, 0, 1024)
+DEFINE_1D_BASIC_TEST(ZeroValue_hipMemsetD8, hipMemsetTypeD8, int8_t, 0, 1024)
 
-DEFINE_1D_BASIC_TEST("SmallSize_hipMemset", hipMemsetTypeDefault, char, 0x42, 1)
-DEFINE_1D_BASIC_TEST("SmallSize_hipMemsetD32", hipMemsetTypeD32, uint32_t, 0x101, 1)
-DEFINE_1D_BASIC_TEST("SmallSize_hipMemsetD16", hipMemsetTypeD16, int16_t, 0x10, 1)
-DEFINE_1D_BASIC_TEST("SmallSize_hipMemsetD8", hipMemsetTypeD8, int8_t, 0x1, 1)
+DEFINE_1D_BASIC_TEST(SmallSize_hipMemset, hipMemsetTypeDefault, char, 0x42, 1)
+DEFINE_1D_BASIC_TEST(SmallSize_hipMemsetD32, hipMemsetTypeD32, uint32_t, 0x101, 1)
+DEFINE_1D_BASIC_TEST(SmallSize_hipMemsetD16, hipMemsetTypeD16, int16_t, 0x10, 1)
+DEFINE_1D_BASIC_TEST(SmallSize_hipMemsetD8, hipMemsetTypeD8, int8_t, 0x1, 1)
 
-DEFINE_1D_BASIC_TEST("ZeroSize_hipMemset", hipMemsetTypeDefault, char, 0x42, 0)
-DEFINE_1D_BASIC_TEST("ZeroSize_hipMemsetD32", hipMemsetTypeD32, uint32_t, 0x101, 0)
-DEFINE_1D_BASIC_TEST("ZeroSize_hipMemsetD16", hipMemsetTypeD16, int16_t, 0x10, 0)
-DEFINE_1D_BASIC_TEST("ZeroSize_hipMemsetD8", hipMemsetTypeD8, int8_t, 0x1, 0)
+DEFINE_1D_BASIC_TEST(ZeroSize_hipMemset, hipMemsetTypeDefault, char, 0x42, 0)
+DEFINE_1D_BASIC_TEST(ZeroSize_hipMemsetD32, hipMemsetTypeD32, uint32_t, 0x101, 0)
+DEFINE_1D_BASIC_TEST(ZeroSize_hipMemsetD16, hipMemsetTypeD16, int16_t, 0x10, 0)
+DEFINE_1D_BASIC_TEST(ZeroSize_hipMemsetD8, hipMemsetTypeD8, int8_t, 0x1, 0)
 
 // Helper function that sets a full region of memory with an initial value, sets a smaller subregion
 // with another value and check that the memset API do not write outside of the subregion of data.
@@ -201,7 +201,7 @@ template <typename T> void partialMemsetTest(T valA, T valB, size_t count, size_
   HIP_CHECK(hipFree(devPtr));
 }
 
-TEST_CASE("Unit_hipMemsetFunctional_PartialSet_1D") {
+TEST_CASE(Unit_hipMemsetFunctional_PartialSet_1D) {
   auto widthOffset = GENERATE(8, 16, 32, 64, 128, 256, 512, 1024);
   SECTION("hipMemset - Partial Set") {
     partialMemsetTest<char>(0x1, 0x42, 1024, widthOffset, hipMemsetTypeDefault, false);
@@ -278,7 +278,7 @@ template <typename T> void checkMemset2D(T value, size_t width, size_t height, b
   HIP_CHECK(hipStreamDestroy(stream));
 }
 
-TEST_CASE("Unit_hipMemsetFunctional_ZeroValue_2D") {
+TEST_CASE(Unit_hipMemsetFunctional_ZeroValue_2D) {
   CHECK_IMAGE_SUPPORT
 
   constexpr size_t width{128};
@@ -288,7 +288,7 @@ TEST_CASE("Unit_hipMemsetFunctional_ZeroValue_2D") {
   SECTION("hipMemset2DAsync - Zero Value") { checkMemset2D(memsetVal, width, height, true); }
 }
 
-TEST_CASE("Unit_hipMemsetFunctional_SmallSize_2D") {
+TEST_CASE(Unit_hipMemsetFunctional_SmallSize_2D) {
   CHECK_IMAGE_SUPPORT
 
   constexpr char memsetVal = 0x42;
@@ -296,7 +296,7 @@ TEST_CASE("Unit_hipMemsetFunctional_SmallSize_2D") {
   SECTION("hipMemset2DAsync - Small Size") { checkMemset2D(memsetVal, 1, 1, true); }
 }
 
-TEST_CASE("Unit_hipMemsetFunctional_ZeroSize_2D") {
+TEST_CASE(Unit_hipMemsetFunctional_ZeroSize_2D) {
   CHECK_IMAGE_SUPPORT
 
   size_t pitch{0};
@@ -378,7 +378,7 @@ template <typename T> void partialMemsetTest2D(T valA, T valB, size_t width, siz
   HIP_CHECK(hipFree(devPtr));
 }
 
-TEST_CASE("Unit_hipMemsetFunctional_PartialSet_2D") {
+TEST_CASE(Unit_hipMemsetFunctional_PartialSet_2D) {
   CHECK_IMAGE_SUPPORT
 
   for (auto widthOffset = 8; widthOffset <= 128; widthOffset *= 2) {
@@ -492,19 +492,19 @@ void check_memset_3D(std::string sectionStr, size_t width, size_t height, size_t
   }
 }
 
-TEST_CASE("Unit_hipMemsetFunctional_ZeroValue_3D") {
+TEST_CASE(Unit_hipMemsetFunctional_ZeroValue_3D) {
   CHECK_IMAGE_SUPPORT
 
   check_memset_3D("Zero Value", 128, 128, 10, 0);
 }
 
-TEST_CASE("Unit_hipMemsetFunctional_SmallSize_3D") {
+TEST_CASE(Unit_hipMemsetFunctional_SmallSize_3D) {
   CHECK_IMAGE_SUPPORT
 
   check_memset_3D("Small Size", 1, 1, 1, 0x42);
 }
 
-TEST_CASE("Unit_hipMemsetFunctional_ZeroSize_3D") {
+TEST_CASE(Unit_hipMemsetFunctional_ZeroSize_3D) {
   CHECK_IMAGE_SUPPORT
 
   constexpr size_t elementSize = sizeof(char);
@@ -560,7 +560,7 @@ void partialMemsetTest3D(T valA, T valB, size_t width, size_t height, size_t dep
   HIP_CHECK(hipFree(devPitchedPtr.ptr));
 }
 
-TEST_CASE("Unit_hipMemsetFunctional_PartialSet_3D") {
+TEST_CASE(Unit_hipMemsetFunctional_PartialSet_3D) {
   CHECK_IMAGE_SUPPORT
 
   for (auto widthOffset = 8; widthOffset <= 128; widthOffset *= 2) {

--- a/projects/hip-tests/catch/unit/memory/hipMemsetNegative.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemsetNegative.cc
@@ -54,7 +54,7 @@ inline void testHipMemset3DApis(hipPitchedPtr& pitchedDevPtr, int value, const h
   HIP_CHECK_ERROR(hipMemset3DAsync(pitchedDevPtr, value, extent, nullStream), expectedReturn);
 }
 
-TEST_CASE("Unit_hipMemset_Negative_InvalidPtr") {
+TEST_CASE(Unit_hipMemset_Negative_InvalidPtr) {
   void* dst;
 
   SECTION("Uninitialized Dst") {}
@@ -70,7 +70,7 @@ TEST_CASE("Unit_hipMemset_Negative_InvalidPtr") {
 }
 
 
-TEST_CASE("Unit_hipMemset_Negative_OutOfBoundsSize") {
+TEST_CASE(Unit_hipMemset_Negative_OutOfBoundsSize) {
 #if !HT_AMD
   void* dst;
   constexpr size_t outOfBoundsSize{width + 1};
@@ -81,7 +81,7 @@ TEST_CASE("Unit_hipMemset_Negative_OutOfBoundsSize") {
 #endif
 }
 
-TEST_CASE("Unit_hipMemset_Negative_OutOfBoundsPtr") {
+TEST_CASE(Unit_hipMemset_Negative_OutOfBoundsPtr) {
   void* dst;
   HIP_CHECK(hipMalloc(&dst, width));
   void* outOfBoundsPtr{reinterpret_cast<char*>(dst) + width + 1};
@@ -89,7 +89,7 @@ TEST_CASE("Unit_hipMemset_Negative_OutOfBoundsPtr") {
   HIP_CHECK(hipFree(dst));
 }
 
-TEST_CASE("Unit_hipMemset2D_Negative_InvalidPtr") {
+TEST_CASE(Unit_hipMemset2D_Negative_InvalidPtr) {
   CHECK_IMAGE_SUPPORT
 
   void* dst;
@@ -109,7 +109,7 @@ TEST_CASE("Unit_hipMemset2D_Negative_InvalidPtr") {
   HIP_CHECK(hipFree(A_d));
 }
 
-TEST_CASE("Unit_hipMemset2D_Negative_InvalidSizes") {
+TEST_CASE(Unit_hipMemset2D_Negative_InvalidSizes) {
   CHECK_IMAGE_SUPPORT
 
   void* dst;
@@ -135,7 +135,7 @@ TEST_CASE("Unit_hipMemset2D_Negative_InvalidSizes") {
   HIP_CHECK(hipFree(dst));
 }
 
-TEST_CASE("Unit_hipMemset2D_Negative_OutOfBoundsPtr") {
+TEST_CASE(Unit_hipMemset2D_Negative_OutOfBoundsPtr) {
   CHECK_IMAGE_SUPPORT
 
   void* dst;
@@ -148,7 +148,7 @@ TEST_CASE("Unit_hipMemset2D_Negative_OutOfBoundsPtr") {
 }
 
 
-TEST_CASE("Unit_hipMemset3D_Negative_InvalidPtr") {
+TEST_CASE(Unit_hipMemset3D_Negative_InvalidPtr) {
   CHECK_IMAGE_SUPPORT
 
   hipPitchedPtr pitchedDevPtr;
@@ -159,7 +159,7 @@ TEST_CASE("Unit_hipMemset3D_Negative_InvalidPtr") {
   testHipMemset3DApis(pitchedDevPtr, memsetVal, validExtent);
 }
 
-TEST_CASE("Unit_hipMemset3D_Negative_ModifiedPtr") {
+TEST_CASE(Unit_hipMemset3D_Negative_ModifiedPtr) {
   CHECK_IMAGE_SUPPORT
 
   hipPitchedPtr pitchedDevPtr;
@@ -182,7 +182,7 @@ TEST_CASE("Unit_hipMemset3D_Negative_ModifiedPtr") {
   HIP_CHECK(hipFree(allocatedMemory));
 }
 
-TEST_CASE("Unit_hipMemset3D_Negative_InvalidSizes") {
+TEST_CASE(Unit_hipMemset3D_Negative_InvalidSizes) {
   CHECK_IMAGE_SUPPORT
 
   hipPitchedPtr pitchedDevPtr;
@@ -210,7 +210,7 @@ TEST_CASE("Unit_hipMemset3D_Negative_InvalidSizes") {
   HIP_CHECK(hipFree(pitchedDevPtr.ptr));
 }
 
-TEST_CASE("Unit_hipMemset3D_Negative_OutOfBounds") {
+TEST_CASE(Unit_hipMemset3D_Negative_OutOfBounds) {
   CHECK_IMAGE_SUPPORT
 
   hipPitchedPtr pitchedDevPtr;

--- a/projects/hip-tests/catch/unit/memory/hipMemsetSync.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemsetSync.cc
@@ -439,7 +439,7 @@ static void doMemsetTest(allocType mallocType, memSetType memset_type, MultiDDat
   if (streamType == CREATEDSTR) HIP_CHECK(hipStreamDestroy(stream));
 }
 
-TEST_CASE("Unit_hipMemsetSync") {
+TEST_CASE(Unit_hipMemsetSync) {
   allocType type = GENERATE(allocType::deviceMalloc, allocType::hostMalloc, allocType::hostRegisted,
                             allocType::devRegistered);
   memSetType memset_type = memSetType::hipMemset;
@@ -448,7 +448,7 @@ TEST_CASE("Unit_hipMemsetSync") {
   doMemsetTest<char>(type, memset_type, data);
 }
 
-TEMPLATE_TEST_CASE("Unit_hipMemsetDSync", "", int8_t, int16_t, uint32_t) {
+TEMPLATE_TEST_CASE(Unit_hipMemsetDSync, int8_t, int16_t, uint32_t) {
   allocType mallocType = GENERATE(allocType::hostRegisted, allocType::deviceMalloc,
                                   allocType::hostMalloc, allocType::devRegistered);
   memSetType memset_type;
@@ -466,7 +466,7 @@ TEMPLATE_TEST_CASE("Unit_hipMemsetDSync", "", int8_t, int16_t, uint32_t) {
   doMemsetTest<TestType>(mallocType, memset_type, data);
 }
 
-TEST_CASE("Unit_hipMemset2DSync") {
+TEST_CASE(Unit_hipMemset2DSync) {
   allocType mallocType = GENERATE(allocType::deviceMalloc, allocType::hostMalloc,
                                   allocType::hostRegisted, allocType::devRegistered);
   memSetType memset_type = memSetType::hipMemset2D;
@@ -477,7 +477,7 @@ TEST_CASE("Unit_hipMemset2DSync") {
   doMemsetTest<char>(mallocType, memset_type, data);
 }
 
-TEST_CASE("Unit_hipMemset3DSync") {
+TEST_CASE(Unit_hipMemset3DSync) {
   allocType mallocType = GENERATE(allocType::deviceMalloc, allocType::hostMalloc,
                                   allocType::hostRegisted, allocType::devRegistered);
   memSetType memset_type = memSetType::hipMemset3D;

--- a/projects/hip-tests/catch/unit/memory/hipPointerGetAttribute.cc
+++ b/projects/hip-tests/catch/unit/memory/hipPointerGetAttribute.cc
@@ -69,7 +69,7 @@ static __global__ void var_update(int* data) {
 
 /* Allocate memory using different Allocation APIs and check whether
    correct memory type and device oridinal are returned */
-TEST_CASE("Unit_hipPointerGetAttribute_MemoryTypes") {
+TEST_CASE(Unit_hipPointerGetAttribute_MemoryTypes) {
   CHECK_IMAGE_SUPPORT
 
   HIP_CHECK(hipSetDevice(0));
@@ -121,7 +121,7 @@ TEST_CASE("Unit_hipPointerGetAttribute_MemoryTypes") {
  * Validates the device variable to check whether the
  * data is updated or not.
  */
-TEST_CASE("Unit_hipPointerGetAttribute_KernelUpdation") {
+TEST_CASE(Unit_hipPointerGetAttribute_KernelUpdation) {
   HIP_CHECK(hipSetDevice(0));
   size_t Nbytes = 0;
   Nbytes = N * sizeof(int);
@@ -150,7 +150,7 @@ TEST_CASE("Unit_hipPointerGetAttribute_KernelUpdation") {
  * from peer GPU device.It validates the memory type and
  * device ordinal in peer GPU
  */
-TEST_CASE("Unit_hipPointerGetAttribute_PeerGPU", "[multigpu]") {
+TEST_CASE(Unit_hipPointerGetAttribute_PeerGPU) {
   HIP_CHECK(hipSetDevice(0));
   size_t Nbytes = 0;
   Nbytes = N * sizeof(int);
@@ -185,7 +185,7 @@ TEST_CASE("Unit_hipPointerGetAttribute_PeerGPU", "[multigpu]") {
    hipPointerGetAttribute API with HIP_POINTER_ATTRIBUTE_BUFFER_ID,
    DeAllocate and Allocate the memory again and
    ensure that the buffer ID is unique */
-TEST_CASE("Unit_hipPointerGetAttribute_BufferID") {
+TEST_CASE(Unit_hipPointerGetAttribute_BufferID) {
   HIP_CHECK(hipSetDevice(0));
   size_t Nbytes = 0;
   Nbytes = N * sizeof(int);
@@ -207,7 +207,7 @@ TEST_CASE("Unit_hipPointerGetAttribute_BufferID") {
    and ensure that it matches with CUDA result
 */
 #if HT_AMD
-TEST_CASE("Unit_hipPointerGetAttribute_HostDeviceOrdinal") {
+TEST_CASE(Unit_hipPointerGetAttribute_HostDeviceOrdinal) {
   size_t Nbytes = 0;
   Nbytes = N * sizeof(int);
   int* A_h;
@@ -227,7 +227,7 @@ TEST_CASE("Unit_hipPointerGetAttribute_HostDeviceOrdinal") {
 /* Allocate managed memory with different flags and trigger
    hipPointerGetAttribute with the following flags HIP_POINTER_ATTRIBUTE_MAPPED
    and verify the behaviour */
-TEST_CASE("Unit_hipPointerGetAttribute_MappedMem") {
+TEST_CASE(Unit_hipPointerGetAttribute_MappedMem) {
   HIP_CHECK(hipSetDevice(0));
   size_t Nbytes = 0;
   Nbytes = N * sizeof(int);
@@ -256,7 +256,7 @@ TEST_CASE("Unit_hipPointerGetAttribute_MappedMem") {
 }
 
 /* This testcase verifies negative scenarios of hipPointerGetAttribute API */
-TEST_CASE("Unit_hipPointerGetAttribute_Negative") {
+TEST_CASE(Unit_hipPointerGetAttribute_Negative) {
   HIP_CHECK(hipSetDevice(0));
   size_t Nbytes = 0;
   constexpr size_t N{100};
@@ -334,7 +334,7 @@ TEST_CASE("Unit_hipPointerGetAttribute_Negative") {
 
 /* Allocate memory using different Allocation APIs and check whether
    IPC CAPABLE attribute returns correctly */
-TEST_CASE("Unit_hipPointerGetAttribute_ipc_capable") {
+TEST_CASE(Unit_hipPointerGetAttribute_ipc_capable) {
 
   HIP_CHECK(hipSetDevice(0));
   size_t Nbytes = N * sizeof(int);

--- a/projects/hip-tests/catch/unit/memory/hipPointerGetAttributes.cc
+++ b/projects/hip-tests/catch/unit/memory/hipPointerGetAttributes.cc
@@ -225,7 +225,7 @@ void clusterAllocs(int numAllocs, size_t minSize, size_t maxSize) {
  * ------------------------
  *  - HIP_VERSION >= 5.7
  */
-TEST_CASE("Unit_hipPointerGetAttributes_Basic") {
+TEST_CASE(Unit_hipPointerGetAttributes_Basic) {
   HIP_CHECK(hipSetDevice(0));
   Nbytes = N * sizeof(char);
   printf("\n");
@@ -310,7 +310,7 @@ TEST_CASE("Unit_hipPointerGetAttributes_Basic") {
  *  - HIP_VERSION >= 5.7
  */
 
-TEST_CASE("Unit_hipPointerGetAttributes_ClusterAlloc", "[multigpu]") {
+TEST_CASE(Unit_hipPointerGetAttributes_ClusterAlloc) {
   srand(0x100);
   printf("\n=============================================\n");
   clusterAllocs(100, 1024 * 1, 1024 * 1024);
@@ -327,7 +327,7 @@ TEST_CASE("Unit_hipPointerGetAttributes_ClusterAlloc", "[multigpu]") {
  *  - HIP_VERSION >= 5.7
  */
 
-TEST_CASE("Unit_hipPointerGetAttributes_TinyClusterAlloc", "[multigpu]") {
+TEST_CASE(Unit_hipPointerGetAttributes_TinyClusterAlloc) {
   srand(0x200);
   printf("\n=============================================\n");
   clusterAllocs(1000, 1, 10);  //  Many tiny allocations;
@@ -337,7 +337,7 @@ TEST_CASE("Unit_hipPointerGetAttributes_TinyClusterAlloc", "[multigpu]") {
 // IN : serialize will force the test to run in serial fashion.
 #if 0  // FIXME_jatinx These need to be ported to HIP_CHECK_THREAD.
 Disabling it for now
-TEST_CASE("Unit_hipPointerGetAttributes_MultiThread", "[multigpu]") {
+TEST_CASE(Unit_hipPointerGetAttributes_MultiThread) {
   srand(0x300);
   auto serialize = 1;
   printf("\n=============================================\n");
@@ -370,7 +370,7 @@ TEST_CASE("Unit_hipPointerGetAttributes_MultiThread", "[multigpu]") {
  *  - HIP_VERSION >= 5.7
  */
 
-TEST_CASE("Unit_hipPointerGetAttributes_Negative") {
+TEST_CASE(Unit_hipPointerGetAttributes_Negative) {
 #if HT_AMD  // Nvidia crashed in hipPointerGetAttributes on nullptr
   SECTION("Invalid Attributes Pointer") {
     int* dPtr{nullptr};
@@ -393,7 +393,7 @@ TEST_CASE("Unit_hipPointerGetAttributes_Negative") {
  * ------------------------
  *  - HIP_VERSION >= 6.0
  */
-TEST_CASE("Unit_hipPointerGetAttributes_GpuIter", "[multigpu]") {
+TEST_CASE(Unit_hipPointerGetAttributes_GpuIter) {
   int deviceCount{0};
   HIP_CHECK(hipGetDeviceCount(&deviceCount));
   REQUIRE(deviceCount != 0);
@@ -453,8 +453,7 @@ TEST_CASE("Unit_hipPointerGetAttributes_GpuIter", "[multigpu]") {
  * ------------------------
  *  - HIP_VERSION >= 6.0
  */
-TEST_CASE("Unit_hipPointerGetAttributes_GpuIter_Managed__Memory",
-          "[multigpu]") {
+TEST_CASE(Unit_hipPointerGetAttributes_GpuIter_Managed__Memory) {
   int deviceCount{0};
   HIP_CHECK(hipGetDeviceCount(&deviceCount));
   REQUIRE(deviceCount != 0);
@@ -491,8 +490,7 @@ TEST_CASE("Unit_hipPointerGetAttributes_GpuIter_Managed__Memory",
  * ------------------------
  *  - HIP_VERSION >= 6.0
  */
-TEST_CASE("Unit_hipPointerGetAttributes_GpuIter_Unregistered_Memory",
-          "[multigpu]") {
+TEST_CASE(Unit_hipPointerGetAttributes_GpuIter_Unregistered_Memory) {
   int deviceCount{0};
   HIP_CHECK(hipGetDeviceCount(&deviceCount));
   REQUIRE(deviceCount != 0);

--- a/projects/hip-tests/catch/unit/memory/hipPointerSetAttribute.cc
+++ b/projects/hip-tests/catch/unit/memory/hipPointerSetAttribute.cc
@@ -43,7 +43,7 @@ THE SOFTWARE.
  * ------------------------
  *  - HIP_VERSION >= 5.5
  */
-TEST_CASE("Unit_hipPointerSetAttribute_Positive_SyncMemops") {
+TEST_CASE(Unit_hipPointerSetAttribute_Positive_SyncMemops) {
   LinearAllocGuard<int> src(LinearAllocs::hipMalloc, 1024);
   LinearAllocGuard<int> dst(LinearAllocs::hipMalloc, 1024);
 
@@ -74,7 +74,7 @@ TEST_CASE("Unit_hipPointerSetAttribute_Positive_SyncMemops") {
  * ------------------------
  *  - HIP_VERSION >= 5.5
  */
-TEST_CASE("Unit_hipPointerSetAttribute_Negative_Parameters") {
+TEST_CASE(Unit_hipPointerSetAttribute_Negative_Parameters) {
   LinearAllocGuard<int> mem(LinearAllocs::hipMalloc, 4);
   int value = 0;
 

--- a/projects/hip-tests/catch/unit/memory/hipPtrGetAttribute.cc
+++ b/projects/hip-tests/catch/unit/memory/hipPtrGetAttribute.cc
@@ -29,7 +29,7 @@ THE SOFTWARE.
 #include <string>
 
 // Run few simple cases including  host pointer arithmetic:
-TEST_CASE("Unit_hipPtrGetAttribute_Simple", "[multigpu]") {
+TEST_CASE(Unit_hipPtrGetAttribute_Simple) {
   HIP_CHECK(hipSetDevice(0));
   size_t Nbytes = 0;
   constexpr size_t N{1000000};

--- a/projects/hip-tests/catch/unit/memory/hipSVMTestByteGranularity.cpp
+++ b/projects/hip-tests/catch/unit/memory/hipSVMTestByteGranularity.cpp
@@ -72,7 +72,7 @@ __global__ void sum_neighbor_locations(char* a, unsigned int num_devices,
 *  - Fine grain access and atomics supported on devices
 *  - HIP_VERSION >= 5.7
 */
-TEST_CASE("test_svm_byte_granularity", "[multigpu]") {
+TEST_CASE(test_svm_byte_granularity) {
   int pcieAtomic = 0;
   HIP_CHECK(hipDeviceGetAttribute(&pcieAtomic, hipDeviceAttributeHostNativeAtomicSupported, 0));
   if (!pcieAtomic) {

--- a/projects/hip-tests/catch/unit/memory/hipSVMTestFineGrainMemoryConsistency.cpp
+++ b/projects/hip-tests/catch/unit/memory/hipSVMTestFineGrainMemoryConsistency.cpp
@@ -227,7 +227,7 @@ void launch_kernels_and_verify(std::vector<hipStream_t>& streams, unsigned int n
 *  - Fine grain access and atomics supported on devices and host
 *  - HIP_VERSION >= 5.7
 */
-TEST_CASE("test_svm_fine_grain_memory_consistency", "[multigpu]") {
+TEST_CASE(test_svm_fine_grain_memory_consistency) {
   int num_devices = 0;
   HIP_CHECK(hipGetDeviceCount(&num_devices));
 

--- a/projects/hip-tests/catch/unit/memory/hipSVMTestFineGrainSyncBuffers.cpp
+++ b/projects/hip-tests/catch/unit/memory/hipSVMTestFineGrainSyncBuffers.cpp
@@ -71,7 +71,7 @@ void spawnAnalysisTask(int location) { printf("found target at location %d\n", l
 *  - Fine grain access and atomics supported on device and host
 *  - HIP_VERSION >= 5.7
 */
-TEST_CASE("test_svm_fine_grain_sync_buffers") {
+TEST_CASE(test_svm_fine_grain_sync_buffers) {
   int pcieAtomic = 0;
   HIP_CHECK(hipDeviceGetAttribute(&pcieAtomic, hipDeviceAttributeHostNativeAtomicSupported, 0));
   if (!pcieAtomic) {

--- a/projects/hip-tests/catch/unit/memory/hipSVMTestSharedAddressSpaceFineGrain.cpp
+++ b/projects/hip-tests/catch/unit/memory/hipSVMTestSharedAddressSpaceFineGrain.cpp
@@ -157,7 +157,7 @@ void verify_linked_lists_on_device(hipStream_t stream, Node* pNodes, unsigned in
 *  - Fine grain access supported on devices and host
 *  - HIP_VERSION >= 5.7
 */
-TEST_CASE("test_svm_shared_address_space_fine_grain_buffers", "[multigpu]") {
+TEST_CASE(test_svm_shared_address_space_fine_grain_buffers) {
   const unsigned int num_elements = 1024;
   int num_devices = 0;
   HIP_CHECK(hipGetDeviceCount(&num_devices));
@@ -247,7 +247,7 @@ TEST_CASE("test_svm_shared_address_space_fine_grain_buffers", "[multigpu]") {
 *  - System fine grain access supported on devices
 *  - HIP_VERSION >= 5.7
 */
-TEST_CASE("test_svm_shared_address_space_fine_grain_system", "[multigpu]") {
+TEST_CASE(test_svm_shared_address_space_fine_grain_system) {
   int num_devices = 0;
   HIP_CHECK(hipGetDeviceCount(&num_devices));
 

--- a/projects/hip-tests/catch/unit/memory/hipStreamAttachMemAsync.cc
+++ b/projects/hip-tests/catch/unit/memory/hipStreamAttachMemAsync.cc
@@ -26,7 +26,7 @@ THE SOFTWARE.
 #include <resource_guards.hh>
 #include <utils.hh>
 
-TEST_CASE("Unit_hipStreamAttachMemAsync_Positive_Basic") {
+TEST_CASE(Unit_hipStreamAttachMemAsync_Positive_Basic) {
   if (!DeviceAttributesSupport(0, hipDeviceAttributeManagedMemory)) {
     HipTest::HIP_SKIP_TEST("Managed memory is not supported");
     return;
@@ -40,7 +40,7 @@ TEST_CASE("Unit_hipStreamAttachMemAsync_Positive_Basic") {
   HIP_CHECK(hipStreamSynchronize(stream.stream()));
 }
 
-TEST_CASE("Unit_hipStreamAttachMemAsync_Positive_Pageable") {
+TEST_CASE(Unit_hipStreamAttachMemAsync_Positive_Pageable) {
   if (!DeviceAttributesSupport(0, hipDeviceAttributeManagedMemory)) {
     HipTest::HIP_SKIP_TEST("Managed memory is not supported");
     return;
@@ -61,7 +61,7 @@ TEST_CASE("Unit_hipStreamAttachMemAsync_Positive_Pageable") {
 // CUDA docs:
 // If the cudaMemAttachGlobal flag is specified, the memory can be accessed by any stream on any
 // device.
-TEST_CASE("Unit_hipStreamAttachMemAsync_Positive_AttachGlobal", "[multigpu]") {
+TEST_CASE(Unit_hipStreamAttachMemAsync_Positive_AttachGlobal) {
   if (!DeviceAttributesSupport(0, hipDeviceAttributeManagedMemory)) {
     HipTest::HIP_SKIP_TEST("Managed memory is not supported");
     return;
@@ -106,7 +106,7 @@ TEST_CASE("Unit_hipStreamAttachMemAsync_Positive_AttachGlobal", "[multigpu]") {
 // If the cudaMemAttachHost flag is specified, the program makes a guarantee that it won't access
 // the memory on the device from any stream on a device that has a zero value for the device
 // attribute cudaDevAttrConcurrentManagedAccess.
-TEST_CASE("Unit_hipStreamAttachMemAsync_Positive_AttachHost") {
+TEST_CASE(Unit_hipStreamAttachMemAsync_Positive_AttachHost) {
   if (!DeviceAttributesSupport(0, hipDeviceAttributeManagedMemory)) {
     HipTest::HIP_SKIP_TEST("Managed memory is not supported");
     return;
@@ -137,7 +137,7 @@ TEST_CASE("Unit_hipStreamAttachMemAsync_Positive_AttachHost") {
 // If the cudaMemAttachSingle flag is specified and stream is associated with a device that has a
 // zero value for the device attribute cudaDevAttrConcurrentManagedAccess, the program makes a
 // guarantee that it will only access the memory on the device from stream.
-TEST_CASE("Unit_hipStreamAttachMemAsync_Positive_AttachSingle") {
+TEST_CASE(Unit_hipStreamAttachMemAsync_Positive_AttachSingle) {
   if (!DeviceAttributesSupport(0, hipDeviceAttributeManagedMemory)) {
     HipTest::HIP_SKIP_TEST("Managed memory is not supported");
     return;
@@ -174,7 +174,7 @@ TEST_CASE("Unit_hipStreamAttachMemAsync_Positive_AttachSingle") {
   REQUIRE(*managed_single.ptr() == 128);
 }
 
-TEST_CASE("Unit_hipStreamAttachMemAsync_Negative_Parameters") {
+TEST_CASE(Unit_hipStreamAttachMemAsync_Negative_Parameters) {
   if (!DeviceAttributesSupport(0, hipDeviceAttributeManagedMemory)) {
     HipTest::HIP_SKIP_TEST("Managed memory is not supported");
     return;

--- a/projects/hip-tests/catch/unit/memory/inlineVar.cc
+++ b/projects/hip-tests/catch/unit/memory/inlineVar.cc
@@ -25,7 +25,7 @@ THE SOFTWARE.
 #include "memoryCommon.hh"
 using namespace mem_utils;
 
-TEST_CASE("Unit_hipMemcpyToFromSymbol_GlobalConstVar") {
+TEST_CASE(Unit_hipMemcpyToFromSymbol_GlobalConstVar) {
   int const initialValue = 10;
   set_value(initialValue);
   int const finalValue = get_value();


### PR DESCRIPTION
## Motivation

Since the number of unit test cases is constantly growing, the execution time is also increasing. Specific tests are suited for non standard testing and there is no need to run them in the regular PSDB. Add a mechanism to easily disable/enable tests and easily categorize them.

Part 4 covers test name changes for following groups:

- graph tests
- hip_specific tests
- kernel tests
- launchBounds tests
- library tests
- math tests
- memory tests

## Technical Details

Explained in the ticket in the document attached.

## JIRA ID

SWDEV-567112

## Test Plan

Ensure build passes. All enabled tests pass, all disabled tests are not run

## Test Result

Local build passed, local enabled tests pass, disabled are not run

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
