### PR TITLE
AIRUNTIME-124 Add Unaligned Memset kernel

### DIFF
--- a/projects/clr/hipamd/src/hip_memory.cpp
+++ b/projects/clr/hipamd/src/hip_memory.cpp
@@ -3441,6 +3441,9 @@ hipError_t hipMemsetD8Async(hipDeviceptr_t dst, unsigned char value, size_t coun
 hipError_t hipMemsetD16(hipDeviceptr_t dst, unsigned short value, size_t count) {
   HIP_INIT_API(hipMemsetD16, dst, value, count);
   CHECK_STREAM_CAPTURING();
+  if (reinterpret_cast<uintptr_t>(dst) & 0x1) {
+    HIP_RETURN(hipErrorInvalidValue);
+  }
   HIP_RETURN(ihipMemset(dst, value, sizeof(int16_t), count * sizeof(int16_t), nullptr));
 }
 
@@ -3458,6 +3461,9 @@ hipError_t hipMemsetD16Async(hipDeviceptr_t dst, unsigned short value, size_t co
 hipError_t hipMemsetD32(hipDeviceptr_t dst, int value, size_t count) {
   HIP_INIT_API(hipMemsetD32, dst, value, count);
   CHECK_STREAM_CAPTURING();
+  if (reinterpret_cast<uintptr_t>(dst) & 0x3) {
+    HIP_RETURN(hipErrorInvalidValue);
+  }
   HIP_RETURN(ihipMemset(dst, value, sizeof(int32_t), count * sizeof(int32_t), nullptr));
 }
 

--- a/projects/clr/hipamd/src/hip_memory.cpp
+++ b/projects/clr/hipamd/src/hip_memory.cpp
@@ -3441,9 +3441,6 @@ hipError_t hipMemsetD8Async(hipDeviceptr_t dst, unsigned char value, size_t coun
 hipError_t hipMemsetD16(hipDeviceptr_t dst, unsigned short value, size_t count) {
   HIP_INIT_API(hipMemsetD16, dst, value, count);
   CHECK_STREAM_CAPTURING();
-  if (reinterpret_cast<uintptr_t>(dst) & 0x1) {
-    HIP_RETURN(hipErrorInvalidValue);
-  }
   HIP_RETURN(ihipMemset(dst, value, sizeof(int16_t), count * sizeof(int16_t), nullptr));
 }
 
@@ -3461,9 +3458,6 @@ hipError_t hipMemsetD16Async(hipDeviceptr_t dst, unsigned short value, size_t co
 hipError_t hipMemsetD32(hipDeviceptr_t dst, int value, size_t count) {
   HIP_INIT_API(hipMemsetD32, dst, value, count);
   CHECK_STREAM_CAPTURING();
-  if (reinterpret_cast<uintptr_t>(dst) & 0x3) {
-    HIP_RETURN(hipErrorInvalidValue);
-  }
   HIP_RETURN(ihipMemset(dst, value, sizeof(int32_t), count * sizeof(int32_t), nullptr));
 }
 

--- a/projects/clr/hipamd/src/hip_memory.cpp
+++ b/projects/clr/hipamd/src/hip_memory.cpp
@@ -3379,6 +3379,10 @@ hipError_t ihipMemset(void* dst, int64_t value, size_t valueSize, size_t sizeByt
   command->enqueue();
   if (!isAsync) {
     hip_stream->finish();
+    if (command->status() == CL_INVALID_OPERATION) {
+      command->release();
+      return hipErrorIllegalState;
+    }
   }
   command->release();
   return hip_error;

--- a/projects/clr/rocclr/device/blitcl.cpp
+++ b/projects/clr/rocclr/device/blitcl.cpp
@@ -36,14 +36,16 @@ const char* BlitLinearSourceCode = BLIT_KERNELS(
 
     extern void __amd_fillBufferUnAligned(
         __global void* __restrict buf, __constant uchar* __restrict pattern,
-        ulong2 body_tile_pattern, ulong body_tile_count, ulong body_tile_passes, ulong stride,
+        ulong2 body_tile_pattern, ulong body_pattern, ulong body_tail_pattern,
+        ulong body_tile_count, ulong body_tile_passes, ulong stride,
         ulong pattern_size, ulong tail_offset, __global uchar* __restrict body_ptr,
         __global uchar* __restrict body_tail_ptr, __global uchar* __restrict tail_ptr,
         __global ulong2* __restrict element_tiled, ushort4 counts);
 
     __kernel void __amd_rocclr_fillBufferUnAligned(
         __global void* __restrict buf, __constant uchar* __restrict pattern,
-        ulong2 body_tile_pattern, ulong body_tile_count, ulong body_tile_passes, ulong stride,
+        ulong2 body_tile_pattern, ulong body_pattern, ulong body_tail_pattern,
+        ulong body_tile_count, ulong body_tile_passes, ulong stride,
         ulong pattern_size, ulong tail_offset, __global uchar* __restrict body_ptr,
         __global uchar* __restrict body_tail_ptr, __global uchar* __restrict tail_ptr,
         __global ulong2* __restrict element_tiled, ushort4 counts) {
@@ -52,8 +54,8 @@ const char* BlitLinearSourceCode = BLIT_KERNELS(
       // Cleanup region: lanes 0..15 of group 0 wave 0 handle head/body/body_tail/tail.
       // Body and body_tail are always uint64 stores (always either 0 or 1 element).
       // Aligned-buffer case: counts are all zero, predicates fall through with no work.
-      // Under invariant addr % patternSize == 0, body_head/body_tail uint64 == body_tile_pattern.lo
-      // (no rotation needed); for patternSize=16 the cleanup region is unused entirely.
+      // body_pattern and body_tail_pattern are host-rotated u64 payloads (rotated by their
+      // byte-offset-from-fill-start mod patternSize), so the unaligned-base case is byte-correct.
       if (id < 16) {
         __global uchar* head_ptr = (__global uchar*)buf;
         const uint lane = (uint)id;
@@ -65,9 +67,9 @@ const char* BlitLinearSourceCode = BLIT_KERNELS(
         if (lane < head_end) {
           head_ptr[lane] = pattern[lane & (pattern_size - 1)];
         } else if (lane < body_end) {
-          *(__global ulong*)body_ptr = body_tile_pattern.lo;
+          *(__global ulong*)body_ptr = body_pattern;
         } else if (lane < body_tail_end) {
-          *(__global ulong*)body_tail_ptr = body_tile_pattern.lo;
+          *(__global ulong*)body_tail_ptr = body_tail_pattern;
         } else if (lane < tail_end) {
           const ulong tail_byte_idx = (ulong)(lane - body_tail_end);
           tail_ptr[tail_byte_idx] =

--- a/projects/clr/rocclr/device/blitcl.cpp
+++ b/projects/clr/rocclr/device/blitcl.cpp
@@ -10,9 +10,6 @@ namespace amd::device {
 
 const char* BlitLinearSourceCode = BLIT_KERNELS(
     // Extern
-    extern void __amd_fillBufferAligned(__global uchar*, __global ushort*, __global uint*,
-                                        __global ulong*, __constant uchar*, uint, ulong, ulong);
-
     extern void __amd_fillBufferAligned2D(__global uchar*, __global ushort*, __global uint*,
                                           __global ulong*, __constant uchar*, uint, ulong, ulong,
                                           ulong, ulong);
@@ -37,62 +34,65 @@ const char* BlitLinearSourceCode = BLIT_KERNELS(
 
     extern void __ockl_dm_init_v1(ulong, ulong, uint, uint);
 
-    __kernel void __amd_rocclr_fillBufferAligned(__global void* buf, __constant uchar* pattern,
-                                                 uint pattern_size, uint alignment, ulong end_ptr,
-                                                 uint next_chunk, uint workgroup_size) {
-      uint l = __builtin_amdgcn_workitem_id_x();
-      uint g = __builtin_amdgcn_workgroup_id_x();
-      ulong id = (g * workgroup_size + l);
-      long cur_id = id * pattern_size;
-      if (alignment == sizeof(ulong2)) {
-        __global ulong2* bufULong2 = (__global ulong2*)buf;
-        __global ulong2* element = &bufULong2[cur_id];
-        __constant ulong2* pt = (__constant ulong2*)pattern;
-        while ((ulong)element < end_ptr) {
-          for (uint i = 0; i < pattern_size; ++i) {
-            element[i] = pt[i];
+    extern void __amd_fillBufferUnAligned(
+        __global void* __restrict buf, __constant uchar* __restrict pattern, ulong2 body_pattern,
+        ulong2 body_tile_pattern, ulong body_tile_count, ulong body_tile_passes, ulong stride,
+        ulong pattern_size, ulong tail_offset, __global uchar* __restrict body_ptr,
+        __global uchar* __restrict body_tail_ptr, __global uchar* __restrict tail_ptr,
+        __global ulong2* __restrict element_tiled, ushort4 counts, uint body_elem_size,
+        int isAligned);
+
+    __kernel void __amd_rocclr_fillBufferUnAligned(
+        __global void* __restrict buf, __constant uchar* __restrict pattern, ulong2 body_pattern,
+        ulong2 body_tile_pattern, ulong body_tile_count, ulong body_tile_passes, ulong stride,
+        ulong pattern_size, ulong tail_offset, __global uchar* __restrict body_ptr,
+        __global uchar* __restrict body_tail_ptr, __global uchar* __restrict tail_ptr,
+        __global ulong2* __restrict element_tiled, ushort4 counts, uint body_elem_size,
+        int isAligned) {
+      ulong id = get_global_id(0);
+
+      // Handle head, body and tail in the first warp only.
+      // Combined cleanup work is constrained to fit in 32 lanes.
+      // Skip when buffer is 16-byte aligned (no head/body/body_tail/tail regions).
+      if (!isAligned && id < 32) {
+        __global uchar* head_ptr = (__global uchar*)buf;
+        const uint lane = (uint)id;
+        const uint head_end = (uint)counts.s0;
+        const uint body_end = head_end + (uint)counts.s1;
+        const uint body_tail_end = body_end + (uint)counts.s2;
+        const uint tail_end = body_tail_end + (uint)counts.s3;
+
+        if (lane < head_end) {
+          head_ptr[lane] = pattern[lane & (pattern_size - 1)];
+        } else if (lane < body_end) {
+          const uint body_idx = lane - head_end;
+          if (body_elem_size == 16) {
+            ((__global ulong2*)body_ptr)[body_idx] = body_pattern;
+          } else if (body_elem_size == 8) {
+            ((__global ulong*)body_ptr)[body_idx] = body_pattern.x;
+          } else {
+            ((__global uint*)body_ptr)[body_idx] = (uint)body_pattern.x;
           }
-          element += next_chunk;
-        }
-      } else if (alignment == sizeof(ulong)) {
-        __global ulong* bufULong = (__global ulong*)buf;
-        __global ulong* element = &bufULong[cur_id];
-        __constant ulong* pt = (__constant ulong*)pattern;
-        while ((ulong)element < end_ptr) {
-          for (uint i = 0; i < pattern_size; ++i) {
-            element[i] = pt[i];
+        } else if (lane < body_tail_end) {
+          const uint body_tail_idx = lane - body_end;
+          if (body_elem_size == 16) {
+            ((__global ulong2*)body_tail_ptr)[body_tail_idx] = body_pattern;
+          } else if (body_elem_size == 8) {
+            ((__global ulong*)body_tail_ptr)[body_tail_idx] = body_pattern.x;
+          } else {
+            ((__global uint*)body_tail_ptr)[body_tail_idx] = (uint)body_pattern.x;
           }
-          element += next_chunk;
+        } else if (lane < tail_end) {
+          const ulong tail_byte_idx = (ulong)(lane - body_tail_end);
+          tail_ptr[tail_byte_idx] =
+              pattern[(tail_offset + tail_byte_idx) & (pattern_size - 1)];
         }
-      } else if (alignment == sizeof(uint)) {
-        __global uint* bufUInt = (__global uint*)buf;
-        __global uint* element = &bufUInt[cur_id];
-        __constant uint* pt = (__constant uint*)pattern;
-        while ((ulong)element < end_ptr) {
-          for (uint i = 0; i < pattern_size; ++i) {
-            element[i] = pt[i];
-          }
-          element += next_chunk;
-        }
-      } else if (alignment == sizeof(ushort)) {
-        __global ushort* bufUShort = (__global ushort*)buf;
-        __global ushort* element = &bufUShort[cur_id];
-        __constant ushort* pt = (__constant ushort*)pattern;
-        while ((ulong)element < end_ptr) {
-          for (uint i = 0; i < pattern_size; ++i) {
-            element[i] = pt[i];
-          }
-          element += next_chunk;
-        }
-      } else {
-        __global uchar* bufUChar = (__global uchar*)buf;
-        __global uchar* element = &bufUChar[cur_id];
-        while ((ulong)element < end_ptr) {
-          for (uint i = 0; i < pattern_size; ++i) {
-            element[i] = pattern[i];
-          }
-          element += next_chunk;
-        }
+      }
+
+      // We pass in the number of passes from the CPU to get the best code-gen
+      // We use the number of passes and the size to get correct behiaviour
+      for (ulong j = 0; (j < body_tile_passes) && (j * stride + id < body_tile_count); ++j) {
+        element_tiled[j * stride + id] = body_tile_pattern;
       }
     }
 

--- a/projects/clr/rocclr/device/blitcl.cpp
+++ b/projects/clr/rocclr/device/blitcl.cpp
@@ -35,26 +35,26 @@ const char* BlitLinearSourceCode = BLIT_KERNELS(
     extern void __ockl_dm_init_v1(ulong, ulong, uint, uint);
 
     extern void __amd_fillBufferUnAligned(
-        __global void* __restrict buf, __constant uchar* __restrict pattern, ulong2 body_pattern,
+        __global void* __restrict buf, __constant uchar* __restrict pattern,
         ulong2 body_tile_pattern, ulong body_tile_count, ulong body_tile_passes, ulong stride,
         ulong pattern_size, ulong tail_offset, __global uchar* __restrict body_ptr,
         __global uchar* __restrict body_tail_ptr, __global uchar* __restrict tail_ptr,
-        __global ulong2* __restrict element_tiled, ushort4 counts, uint body_elem_size,
-        int isAligned);
+        __global ulong2* __restrict element_tiled, ushort4 counts);
 
     __kernel void __amd_rocclr_fillBufferUnAligned(
-        __global void* __restrict buf, __constant uchar* __restrict pattern, ulong2 body_pattern,
+        __global void* __restrict buf, __constant uchar* __restrict pattern,
         ulong2 body_tile_pattern, ulong body_tile_count, ulong body_tile_passes, ulong stride,
         ulong pattern_size, ulong tail_offset, __global uchar* __restrict body_ptr,
         __global uchar* __restrict body_tail_ptr, __global uchar* __restrict tail_ptr,
-        __global ulong2* __restrict element_tiled, ushort4 counts, uint body_elem_size,
-        int isAligned) {
+        __global ulong2* __restrict element_tiled, ushort4 counts) {
       ulong id = get_global_id(0);
 
-      // Handle head, body and tail in the first warp only.
-      // Combined cleanup work is constrained to fit in 32 lanes.
-      // Skip when buffer is 16-byte aligned (no head/body/body_tail/tail regions).
-      if (!isAligned && id < 32) {
+      // Cleanup region: lanes 0..15 of group 0 wave 0 handle head/body/body_tail/tail.
+      // Body and body_tail are always uint64 stores (always either 0 or 1 element).
+      // Aligned-buffer case: counts are all zero, predicates fall through with no work.
+      // Under invariant addr % patternSize == 0, body_head/body_tail uint64 == body_tile_pattern.lo
+      // (no rotation needed); for patternSize=16 the cleanup region is unused entirely.
+      if (id < 16) {
         __global uchar* head_ptr = (__global uchar*)buf;
         const uint lane = (uint)id;
         const uint head_end = (uint)counts.s0;
@@ -65,23 +65,9 @@ const char* BlitLinearSourceCode = BLIT_KERNELS(
         if (lane < head_end) {
           head_ptr[lane] = pattern[lane & (pattern_size - 1)];
         } else if (lane < body_end) {
-          const uint body_idx = lane - head_end;
-          if (body_elem_size == 16) {
-            ((__global ulong2*)body_ptr)[body_idx] = body_pattern;
-          } else if (body_elem_size == 8) {
-            ((__global ulong*)body_ptr)[body_idx] = body_pattern.x;
-          } else {
-            ((__global uint*)body_ptr)[body_idx] = (uint)body_pattern.x;
-          }
+          *(__global ulong*)body_ptr = body_tile_pattern.lo;
         } else if (lane < body_tail_end) {
-          const uint body_tail_idx = lane - body_end;
-          if (body_elem_size == 16) {
-            ((__global ulong2*)body_tail_ptr)[body_tail_idx] = body_pattern;
-          } else if (body_elem_size == 8) {
-            ((__global ulong*)body_tail_ptr)[body_tail_idx] = body_pattern.x;
-          } else {
-            ((__global uint*)body_tail_ptr)[body_tail_idx] = (uint)body_pattern.x;
-          }
+          *(__global ulong*)body_tail_ptr = body_tile_pattern.lo;
         } else if (lane < tail_end) {
           const ulong tail_byte_idx = (ulong)(lane - body_tail_end);
           tail_ptr[tail_byte_idx] =
@@ -89,10 +75,16 @@ const char* BlitLinearSourceCode = BLIT_KERNELS(
         }
       }
 
-      // We pass in the number of passes from the CPU to get the best code-gen
-      // We use the number of passes and the size to get correct behiaviour
-      for (ulong j = 0; (j < body_tile_passes) && (j * stride + id < body_tile_count); ++j) {
-        element_tiled[j * stride + id] = body_tile_pattern;
+      // Tile region: split-last-pass. Bulk passes have unconditional stores
+      // (host guarantees they are in-bounds); only the tail pass is per-lane guarded.
+      // body_tile_passes is a CPU-known bound for codegen.
+      ulong j = 0;
+      ulong idx = id;
+      for (; j + 1 < body_tile_passes; ++j, idx += stride) {
+        element_tiled[idx] = body_tile_pattern;
+      }
+      if (j < body_tile_passes && idx < body_tile_count) {
+        element_tiled[idx] = body_tile_pattern;
       }
     }
 

--- a/projects/clr/rocclr/device/pal/palblit.cpp
+++ b/projects/clr/rocclr/device/pal/palblit.cpp
@@ -2159,6 +2159,15 @@ bool KernelBlitManager::fillBuffer(device::Memory& memory, const void* pattern, 
   }
 
   const uintptr_t fill_buf_addr = memory.virtualAddress() + origin[0];
+
+  if ((fill_buf_addr % patternSize) != 0) {
+    LogPrintfError(
+        "fillBuffer: buffer VA 0x%lx with origin %zu is not aligned to pattern size %zu; "
+        "kernel path requires (VA + origin) %% patternSize == 0",
+        memory.virtualAddress(), origin[0], patternSize);
+    return false;
+  }
+
   constexpr uint32_t kFillType = FillBufferUnAligned;
 
   Memory* mem = &gpuMem(memory);
@@ -2176,7 +2185,7 @@ bool KernelBlitManager::fillBuffer(device::Memory& memory, const void* pattern, 
 
   // Calculate head, body, body-tail, tail, and tiled body counts
   // Head/tail are byte counts. Body/body-tail are element counts.
-  constexpr size_t tile_size = sizeof(ulong) * 2;
+  constexpr size_t tile_size = 2 * sizeof(uint64_t);
   uintptr_t end_addr = fill_buf_addr + size[0];
 
   uintptr_t body_aligned_start = alignUp(fill_buf_addr, bodyElemSize);
@@ -2214,13 +2223,21 @@ bool KernelBlitManager::fillBuffer(device::Memory& memory, const void* pattern, 
 
   assert(head_count <= (2 * bodyElemSize - 2) &&
          "head_count must fit cleanup region (small-buffer case may be up to 2*bodyElemSize-2)");
-  assert(body_count <= (tile_size / bodyElemSize) &&
-         "body_count should fit before first 16-byte tile");
-  assert(body_tail_count <= (tile_size / bodyElemSize) &&
-         "body_tail_count should fit after last 16-byte tile");
+  // body_aligned_start is 8-aligned, tile_start = alignUp(body_aligned_start, 16),
+  // so (tile_start - body_aligned_start) / bodyElemSize is structurally 0 or 1.
+  assert(body_count <= 1 && "body_count is structurally 0 or 1");
+  assert(body_tail_count <= 1 && "body_tail_count is structurally 0 or 1");
   assert(tail_count < bodyElemSize && "tail_count should be less than body element size");
-  assert((head_count + body_count + body_tail_count + tail_count) < 16 &&
-         "cleanup region must fit in the kernel's 16-lane cleanup gate");
+  const size_t cleanup_total = head_count + body_count + body_tail_count + tail_count;
+  assert(cleanup_total <= 16 && "cleanup region must fit in the kernel's 16-lane cleanup gate");
+  if (cleanup_total > 16) {
+    LogPrintfError(
+        "fillBuffer: cleanup region size %zu exceeds 16-lane kernel gate "
+        "(head=%zu body=%zu body_tail=%zu tail=%zu, fill_buf_addr=0x%lx, size=%zu, patternSize=%zu)",
+        cleanup_total, head_count, body_count, body_tail_count, tail_count,
+        fill_buf_addr, size[0], patternSize);
+    return false;
+  }
 
   const size_t tail_offset =
       head_count + body_count * bodyElemSize + body_tile_count * tile_size + body_tail_count * bodyElemSize;
@@ -2244,6 +2261,8 @@ bool KernelBlitManager::fillBuffer(device::Memory& memory, const void* pattern, 
     uint16_t s0, s1, s2, s3;
   } counts = {static_cast<uint16_t>(head_count), static_cast<uint16_t>(body_count),
               static_cast<uint16_t>(body_tail_count), static_cast<uint16_t>(tail_count)};
+  static_assert(sizeof(size_t) == sizeof(uint64_t),
+                "Kernel arg passing assumes 64-bit size_t");
   setArgument(kernels_[kFillType], 0, sizeof(cl_mem), &mem, origin[0]);
   setArgument(kernels_[kFillType], 1, sizeof(cl_mem), &pGpuCB);
   setArgument(kernels_[kFillType], 2, sizeof(tiled_pattern), &tiled_pattern);

--- a/projects/clr/rocclr/device/pal/palblit.cpp
+++ b/projects/clr/rocclr/device/pal/palblit.cpp
@@ -2129,17 +2129,23 @@ struct alignas(16) FillPatternPayload {
   uint64_t hi;
 };
 
+// startByte rotates the pattern so the payload is byte-correct for a region whose
+// byte-offset-from-fill-start is startByte % patternSize.  This works for all supported
+// patternSizes (1/2/4/8/16) since patternSize is always a power of two, making the
+// bitwise AND a valid modulo.
 static inline void tilePatternBytes(unsigned char* dst, size_t dstSize, const void* pattern,
-                                    size_t patternSize) {
+                                    size_t patternSize, size_t startByte) {
   const auto* src = static_cast<const unsigned char*>(pattern);
   for (size_t i = 0; i < dstSize; ++i) {
-    dst[i] = src[i & (patternSize - 1)];
+    dst[i] = src[(startByte + i) & (patternSize - 1)];
   }
 }
 
-static inline FillPatternPayload buildTilePattern(const void* pattern, size_t patternSize) {
+static inline FillPatternPayload buildTilePattern(const void* pattern, size_t patternSize,
+                                                  size_t startByte) {
   FillPatternPayload payload = {};
-  tilePatternBytes(reinterpret_cast<unsigned char*>(&payload), sizeof(payload), pattern, patternSize);
+  tilePatternBytes(reinterpret_cast<unsigned char*>(&payload), sizeof(payload), pattern,
+                   patternSize, startByte);
   return payload;
 }
 
@@ -2160,14 +2166,6 @@ bool KernelBlitManager::fillBuffer(device::Memory& memory, const void* pattern, 
 
   const uintptr_t fill_buf_addr = memory.virtualAddress() + origin[0];
 
-  if ((fill_buf_addr % patternSize) != 0) {
-    LogPrintfError(
-        "fillBuffer: buffer VA 0x%lx with origin %zu is not aligned to pattern size %zu; "
-        "kernel path requires (VA + origin) %% patternSize == 0",
-        memory.virtualAddress(), origin[0], patternSize);
-    return false;
-  }
-
   constexpr uint32_t kFillType = FillBufferUnAligned;
 
   Memory* mem = &gpuMem(memory);
@@ -2176,12 +2174,11 @@ bool KernelBlitManager::fillBuffer(device::Memory& memory, const void* pattern, 
           patternSize == 16) &&
          "fillBuffer supports pattern sizes of 1/2/4/8/16 bytes");
 
-  // Body region uses uint64 stores unconditionally. Tile region uses ulong2
-  // stores; head/body/body_tail uint64 patterns are derived from the tile
-  // pattern's low half (no rotation needed under invariant
-  // addr % patternSize == 0).
+  // Body region uses uint64 stores unconditionally. Tile region uses ulong2 stores.
+  // Payloads are built after region offsets are computed so they can be rotated
+  // by regionByteOffset % patternSize, making every region byte-correct even when
+  // the destination address is not aligned to patternSize.
   constexpr size_t bodyElemSize = sizeof(uint64_t);
-  const FillPatternPayload tiled_pattern = buildTilePattern(pattern, patternSize);
 
   // Calculate head, body, body-tail, tail, and tiled body counts
   // Head/tail are byte counts. Body/body-tail are element counts.
@@ -2245,6 +2242,16 @@ bool KernelBlitManager::fillBuffer(device::Memory& memory, const void* pattern, 
   const size_t body_tail_offset = head_count + body_count * bodyElemSize + body_tile_count * tile_size;
   const size_t tile_offset = static_cast<size_t>(tile_start - fill_buf_addr);
 
+  // Build rotated payloads: each region's payload is rotated by its byte-offset-from-fill-start
+  // modulo patternSize so that the stored bytes are correct regardless of destination alignment.
+  // When all offsets are 0 (aligned case), all three payloads agree with the unrotated pattern.
+  const FillPatternPayload tiled_pattern =
+      buildTilePattern(pattern, patternSize, tile_offset % patternSize);
+  const uint64_t body_pattern =
+      buildTilePattern(pattern, patternSize, body_offset % patternSize).lo;
+  const uint64_t body_tail_pattern =
+      buildTilePattern(pattern, patternSize, body_tail_offset % patternSize).lo;
+
   constexpr size_t localWorkSize = 256;
   const size_t work_items = std::max(alignUp(body_tile_count, localWorkSize), localWorkSize);
   size_t globalWorkSize = std::min(dev().settings().limit_blit_wg_ * localWorkSize, work_items);
@@ -2266,16 +2273,18 @@ bool KernelBlitManager::fillBuffer(device::Memory& memory, const void* pattern, 
   setArgument(kernels_[kFillType], 0, sizeof(cl_mem), &mem, origin[0]);
   setArgument(kernels_[kFillType], 1, sizeof(cl_mem), &pGpuCB);
   setArgument(kernels_[kFillType], 2, sizeof(tiled_pattern), &tiled_pattern);
-  setArgument(kernels_[kFillType], 3, sizeof(body_tile_count), &body_tile_count);
-  setArgument(kernels_[kFillType], 4, sizeof(body_tile_passes), &body_tile_passes);
-  setArgument(kernels_[kFillType], 5, sizeof(globalWorkSize), &globalWorkSize /* stride */);
-  setArgument(kernels_[kFillType], 6, sizeof(patternSize), &patternSize);
-  setArgument(kernels_[kFillType], 7, sizeof(tail_offset), &tail_offset);
-  setArgument(kernels_[kFillType], 8, sizeof(cl_mem), &mem, origin[0] + body_offset);
-  setArgument(kernels_[kFillType], 9, sizeof(cl_mem), &mem, origin[0] + body_tail_offset);
-  setArgument(kernels_[kFillType], 10, sizeof(cl_mem), &mem, origin[0] + tail_offset);
-  setArgument(kernels_[kFillType], 11, sizeof(cl_mem), &mem, origin[0] + tile_offset);
-  setArgument(kernels_[kFillType], 12, sizeof(counts), &counts);
+  setArgument(kernels_[kFillType], 3, sizeof(body_pattern), &body_pattern);
+  setArgument(kernels_[kFillType], 4, sizeof(body_tail_pattern), &body_tail_pattern);
+  setArgument(kernels_[kFillType], 5, sizeof(body_tile_count), &body_tile_count);
+  setArgument(kernels_[kFillType], 6, sizeof(body_tile_passes), &body_tile_passes);
+  setArgument(kernels_[kFillType], 7, sizeof(globalWorkSize), &globalWorkSize /* stride */);
+  setArgument(kernels_[kFillType], 8, sizeof(patternSize), &patternSize);
+  setArgument(kernels_[kFillType], 9, sizeof(tail_offset), &tail_offset);
+  setArgument(kernels_[kFillType], 10, sizeof(cl_mem), &mem, origin[0] + body_offset);
+  setArgument(kernels_[kFillType], 11, sizeof(cl_mem), &mem, origin[0] + body_tail_offset);
+  setArgument(kernels_[kFillType], 12, sizeof(cl_mem), &mem, origin[0] + tail_offset);
+  setArgument(kernels_[kFillType], 13, sizeof(cl_mem), &mem, origin[0] + tile_offset);
+  setArgument(kernels_[kFillType], 14, sizeof(counts), &counts);
 
   size_t globalWorkOffset[3] = {0, 0, 0};
   amd::NDRangeContainer ndrange(1, globalWorkOffset, &globalWorkSize, &localWorkSize);

--- a/projects/clr/rocclr/device/pal/palblit.cpp
+++ b/projects/clr/rocclr/device/pal/palblit.cpp
@@ -2124,6 +2124,25 @@ bool KernelBlitManager::writeBufferRect(const void* srcHost, device::Memory& dst
   return result;
 }
 
+struct alignas(16) FillPatternPayload {
+  uint64_t lo;
+  uint64_t hi;
+};
+
+static inline void tilePatternBytes(unsigned char* dst, size_t dstSize, const void* pattern,
+                                    size_t patternSize) {
+  const auto* src = static_cast<const unsigned char*>(pattern);
+  for (size_t i = 0; i < dstSize; ++i) {
+    dst[i] = src[i & (patternSize - 1)];
+  }
+}
+
+static inline FillPatternPayload buildTilePattern(const void* pattern, size_t patternSize) {
+  FillPatternPayload payload = {};
+  tilePatternBytes(reinterpret_cast<unsigned char*>(&payload), sizeof(payload), pattern, patternSize);
+  return payload;
+}
+
 bool KernelBlitManager::fillBuffer(device::Memory& memory, const void* pattern, size_t patternSize,
                                    const amd::Coord3D& surface, const amd::Coord3D& origin,
                                    const amd::Coord3D& size, bool entire, bool forceBlit) const {
@@ -2137,71 +2156,113 @@ bool KernelBlitManager::fillBuffer(device::Memory& memory, const void* pattern, 
     result = HostBlitManager::fillBuffer(memory, pattern, patternSize, size, origin, size, entire);
     synchronize();
     return result;
-  } else {
-    // Pack the fill buffer info, that handles unaligned memories.
-    std::vector<FillBufferInfo> packed_vector{};
-    FillBufferInfo::PackInfo(memory, size[0], origin[0], pattern, patternSize, packed_vector);
-
-    size_t overall_offset = origin[0];
-    for (auto& packed_obj : packed_vector) {
-      constexpr uint32_t kFillType = FillBufferAligned;
-      uint32_t kpattern_size = (packed_obj.pattern_expanded_)
-                                   ? HostBlitManager::FillBufferInfo::kExtendedSize
-                                   : patternSize;
-      size_t kfill_size = packed_obj.fill_size_ / kpattern_size;
-      uint64_t koffset = overall_offset;
-      overall_offset += packed_obj.fill_size_;
-
-      size_t globalWorkOffset[3] = {0, 0, 0};
-      uint32_t alignment = (kpattern_size & 0xf) == 0   ? 2 * sizeof(uint64_t)
-                           : (kpattern_size & 0x7) == 0 ? sizeof(uint64_t)
-                           : (kpattern_size & 0x3) == 0 ? sizeof(uint32_t)
-                           : (kpattern_size & 0x1) == 0 ? sizeof(uint16_t)
-                                                        : sizeof(uint8_t);
-
-      // Program kernels arguments for the fill operation
-      Memory* mem = &gpuMem(memory);
-      setArgument(kernels_[kFillType], 0, sizeof(cl_mem), &mem, koffset);
-      const size_t localWorkSize = 256;
-      size_t globalWorkSize = std::min(dev().settings().limit_blit_wg_ * localWorkSize, kfill_size);
-      globalWorkSize = amd::alignUp(globalWorkSize, localWorkSize);
-
-      Memory& gpuCB = gpu().xferWrite().Acquire(patternSize);
-      void* constBuf = gpuCB.map(&gpu(), Resource::NoWait);
-      // If pattern has been expanded, use the expanded pattern, otherwise use the default pattern
-      if (packed_obj.pattern_expanded_) {
-        memcpy(constBuf, &packed_obj.expanded_pattern_, kpattern_size);
-      } else {
-        memcpy(constBuf, pattern, kpattern_size);
-      }
-      gpuCB.unmap(&gpu());
-      Memory* pGpuCB = &gpuCB;
-      setArgument(kernels_[kFillType], 1, sizeof(cl_mem), &pGpuCB);
-      uint64_t offset = origin[0];
-
-      // Adjust the pattern size in the copy type size
-      kpattern_size /= alignment;
-      setArgument(kernels_[kFillType], 2, sizeof(uint32_t), &kpattern_size);
-      setArgument(kernels_[kFillType], 3, sizeof(alignment), &alignment);
-
-      // Calculate max id
-      uint64_t end_ptr = memory.virtualAddress() + koffset + kfill_size * kpattern_size * alignment;
-      setArgument(kernels_[kFillType], 4, sizeof(end_ptr), &end_ptr);
-      uint32_t next_chunk = globalWorkSize * kpattern_size;
-      setArgument(kernels_[kFillType], 5, sizeof(uint32_t), &next_chunk);
-      uint32_t lws = localWorkSize;
-      setArgument(kernels_[kFillType], 6, sizeof(lws), &lws);
-
-      // Create ND range object for the kernel's execution
-      amd::NDRangeContainer ndrange(1, globalWorkOffset, &globalWorkSize, &localWorkSize);
-
-      // Execute the blit
-      address parameters = kernels_[kFillType]->parameters().values();
-      result = gpu().submitKernelInternal(ndrange, *kernels_[kFillType], parameters);
-      gpu().xferWrite().Release(gpuCB);
-    }
   }
 
+  const uintptr_t fill_buf_addr = memory.virtualAddress() + origin[0];
+  constexpr uint32_t kFillType = FillBufferUnAligned;
+
+  Memory* mem = &gpuMem(memory);
+
+  assert((patternSize == 1 || patternSize == 2 || patternSize == 4 || patternSize == 8 ||
+          patternSize == 16) &&
+         "fillBuffer supports pattern sizes of 1/2/4/8/16 bytes");
+
+  // Body region uses uint64 stores unconditionally. Tile region uses ulong2
+  // stores; head/body/body_tail uint64 patterns are derived from the tile
+  // pattern's low half (no rotation needed under invariant
+  // addr % patternSize == 0).
+  constexpr size_t bodyElemSize = sizeof(uint64_t);
+  const FillPatternPayload tiled_pattern = buildTilePattern(pattern, patternSize);
+
+  // Calculate head, body, body-tail, tail, and tiled body counts
+  // Head/tail are byte counts. Body/body-tail are element counts.
+  constexpr size_t tile_size = sizeof(ulong) * 2;
+  uintptr_t end_addr = fill_buf_addr + size[0];
+
+  uintptr_t body_aligned_start = alignUp(fill_buf_addr, bodyElemSize);
+  uintptr_t body_aligned_end = alignDown(end_addr, bodyElemSize);
+
+  size_t head_count = 0;
+  size_t body_count = 0;
+  size_t body_tile_count = 0;
+  size_t body_tail_count = 0;
+  size_t tail_count = 0;
+  uintptr_t tile_start = fill_buf_addr;  // unused when body_tile_count == 0
+
+  if (body_aligned_end <= body_aligned_start) {
+    // Tiny or sufficiently misaligned buffer: no room for a body uint64 element.
+    // Route every byte through the head cleanup region. Head count is
+    // bounded by 2*bodyElemSize - 2 = 14 (e.g. patternSize=1, addr=1,
+    // size=14); still fits within the 16-lane cleanup region.
+    head_count = size[0];
+  } else {
+    tile_start = alignUp(body_aligned_start, tile_size);
+    uintptr_t tile_end = alignDown(body_aligned_end, tile_size);
+    head_count = body_aligned_start - fill_buf_addr;
+    body_tile_count =
+        (tile_end > tile_start) ? (tile_end - tile_start) / tile_size : 0;
+    body_count =
+        (tile_start > body_aligned_start)
+            ? static_cast<size_t>((tile_start - body_aligned_start) / bodyElemSize)
+            : static_cast<size_t>(0);
+    body_tail_count =
+        (body_aligned_end > tile_end)
+            ? static_cast<size_t>((body_aligned_end - tile_end) / bodyElemSize)
+            : static_cast<size_t>(0);
+    tail_count = static_cast<size_t>(end_addr - body_aligned_end);
+  }
+
+  assert(head_count <= (2 * bodyElemSize - 2) &&
+         "head_count must fit cleanup region (small-buffer case may be up to 2*bodyElemSize-2)");
+  assert(body_count <= (tile_size / bodyElemSize) &&
+         "body_count should fit before first 16-byte tile");
+  assert(body_tail_count <= (tile_size / bodyElemSize) &&
+         "body_tail_count should fit after last 16-byte tile");
+  assert(tail_count < bodyElemSize && "tail_count should be less than body element size");
+  assert((head_count + body_count + body_tail_count + tail_count) < 16 &&
+         "cleanup region must fit in the kernel's 16-lane cleanup gate");
+
+  const size_t tail_offset =
+      head_count + body_count * bodyElemSize + body_tile_count * tile_size + body_tail_count * bodyElemSize;
+  const size_t body_offset = head_count;
+  const size_t body_tail_offset = head_count + body_count * bodyElemSize + body_tile_count * tile_size;
+  const size_t tile_offset = static_cast<size_t>(tile_start - fill_buf_addr);
+
+  constexpr size_t localWorkSize = 256;
+  const size_t work_items = std::max(alignUp(body_tile_count, localWorkSize), localWorkSize);
+  size_t globalWorkSize = std::min(dev().settings().limit_blit_wg_ * localWorkSize, work_items);
+  const size_t body_tile_passes = (body_tile_count + globalWorkSize - 1) / globalWorkSize;
+
+  // Use xferWrite to acquire constant buffer for pattern (PAL-specific approach)
+  Memory& gpuCB = gpu().xferWrite().Acquire(patternSize);
+  void* constBuf = gpuCB.map(&gpu(), Resource::NoWait);
+  memcpy(constBuf, pattern, patternSize);
+  gpuCB.unmap(&gpu());
+  Memory* pGpuCB = &gpuCB;
+
+  struct Ushort4 {
+    uint16_t s0, s1, s2, s3;
+  } counts = {static_cast<uint16_t>(head_count), static_cast<uint16_t>(body_count),
+              static_cast<uint16_t>(body_tail_count), static_cast<uint16_t>(tail_count)};
+  setArgument(kernels_[kFillType], 0, sizeof(cl_mem), &mem, origin[0]);
+  setArgument(kernels_[kFillType], 1, sizeof(cl_mem), &pGpuCB);
+  setArgument(kernels_[kFillType], 2, sizeof(tiled_pattern), &tiled_pattern);
+  setArgument(kernels_[kFillType], 3, sizeof(body_tile_count), &body_tile_count);
+  setArgument(kernels_[kFillType], 4, sizeof(body_tile_passes), &body_tile_passes);
+  setArgument(kernels_[kFillType], 5, sizeof(globalWorkSize), &globalWorkSize /* stride */);
+  setArgument(kernels_[kFillType], 6, sizeof(patternSize), &patternSize);
+  setArgument(kernels_[kFillType], 7, sizeof(tail_offset), &tail_offset);
+  setArgument(kernels_[kFillType], 8, sizeof(cl_mem), &mem, origin[0] + body_offset);
+  setArgument(kernels_[kFillType], 9, sizeof(cl_mem), &mem, origin[0] + body_tail_offset);
+  setArgument(kernels_[kFillType], 10, sizeof(cl_mem), &mem, origin[0] + tail_offset);
+  setArgument(kernels_[kFillType], 11, sizeof(cl_mem), &mem, origin[0] + tile_offset);
+  setArgument(kernels_[kFillType], 12, sizeof(counts), &counts);
+
+  size_t globalWorkOffset[3] = {0, 0, 0};
+  amd::NDRangeContainer ndrange(1, globalWorkOffset, &globalWorkSize, &localWorkSize);
+  address parameters = kernels_[kFillType]->parameters().values();
+  result = gpu().submitKernelInternal(ndrange, *kernels_[kFillType], parameters);
+  gpu().xferWrite().Release(gpuCB);
   synchronize();
 
   return result;

--- a/projects/clr/rocclr/device/pal/palblit.hpp
+++ b/projects/clr/rocclr/device/pal/palblit.hpp
@@ -262,7 +262,7 @@ class KernelBlitManager : public DmaBlitManager {
     BlitCopyBufferRectAligned,
     BlitCopyBuffer,
     BlitCopyBufferAligned,
-    FillBufferAligned,
+    FillBufferUnAligned,
     FillImage,
     Scheduler,
     GwsInit,
@@ -536,14 +536,14 @@ class KernelBlitManager : public DmaBlitManager {
 };
 
 static const char* BlitName[KernelBlitManager::BlitTotal] = {
-    "__amd_rocclr_copyImage",         "__amd_rocclr_copyImage1DA",
-    "__amd_rocclr_copyImageToBuffer", "__amd_rocclr_copyBufferToImage",
-    "__amd_rocclr_copyBufferRect",    "__amd_rocclr_copyBufferRectAligned",
-    "__amd_rocclr_copyBuffer",        "__amd_rocclr_copyBufferAligned",
-    "__amd_rocclr_fillBufferAligned", "__amd_rocclr_fillImage",
-    "__amd_rocclr_scheduler",         "__amd_rocclr_gwsInit",
-    "__amd_rocclr_streamOpsWrite",    "__amd_rocclr_streamOpsWait",
-    "__amd_rocclr_initHeap",          "__amd_rocclr_streamOpsIncrement",
+    "__amd_rocclr_copyImage",           "__amd_rocclr_copyImage1DA",
+    "__amd_rocclr_copyImageToBuffer",   "__amd_rocclr_copyBufferToImage",
+    "__amd_rocclr_copyBufferRect",      "__amd_rocclr_copyBufferRectAligned",
+    "__amd_rocclr_copyBuffer",          "__amd_rocclr_copyBufferAligned",
+    "__amd_rocclr_fillBufferUnAligned", "__amd_rocclr_fillImage",
+    "__amd_rocclr_scheduler",           "__amd_rocclr_gwsInit",
+    "__amd_rocclr_streamOpsWrite",      "__amd_rocclr_streamOpsWait",
+    "__amd_rocclr_initHeap",            "__amd_rocclr_streamOpsIncrement",
     "__amd_rocclr_streamOpsDecrement"};
 
 /*@}*/  // namespace amd::pal

--- a/projects/clr/rocclr/device/rocm/rocblit.cpp
+++ b/projects/clr/rocclr/device/rocm/rocblit.cpp
@@ -2427,17 +2427,23 @@ struct alignas(16) FillPatternPayload {
   uint64_t hi;
 };
 
+// startByte rotates the pattern so the payload is byte-correct for a region whose
+// byte-offset-from-fill-start is startByte % patternSize.  This works for all supported
+// patternSizes (1/2/4/8/16) since patternSize is always a power of two, making the
+// bitwise AND a valid modulo.
 static inline void tilePatternBytes(unsigned char* dst, size_t dstSize, const void* pattern,
-                                    size_t patternSize) {
+                                    size_t patternSize, size_t startByte) {
   const auto* src = static_cast<const unsigned char*>(pattern);
   for (size_t i = 0; i < dstSize; ++i) {
-    dst[i] = src[i & (patternSize - 1)];
+    dst[i] = src[(startByte + i) & (patternSize - 1)];
   }
 }
 
-static inline FillPatternPayload buildTilePattern(const void* pattern, size_t patternSize) {
+static inline FillPatternPayload buildTilePattern(const void* pattern, size_t patternSize,
+                                                  size_t startByte) {
   FillPatternPayload payload = {};
-  tilePatternBytes(reinterpret_cast<unsigned char*>(&payload), sizeof(payload), pattern, patternSize);
+  tilePatternBytes(reinterpret_cast<unsigned char*>(&payload), sizeof(payload), pattern,
+                   patternSize, startByte);
   return payload;
 }
 
@@ -2460,14 +2466,6 @@ bool KernelBlitManager::fillBuffer1D(device::Memory& memory, const void* pattern
 
   const uintptr_t fill_buf_addr = memory.virtualAddress() + origin[0];
 
-  if ((fill_buf_addr % patternSize) != 0) {
-    LogPrintfError(
-        "fillBuffer1D: buffer VA 0x%lx with origin %zu is not aligned to pattern size %zu; "
-        "kernel path requires (VA + origin) %% patternSize == 0",
-        memory.virtualAddress(), origin[0], patternSize);
-    return false;
-  }
-
   constexpr uint32_t kFillType = FillBufferUnAligned;
 
   cl_mem mem = as_cl<amd::Memory>(memory.owner());
@@ -2481,12 +2479,11 @@ bool KernelBlitManager::fillBuffer1D(device::Memory& memory, const void* pattern
           patternSize == 16) &&
          "fillBuffer1D supports pattern sizes of 1/2/4/8/16 bytes");
 
-  // Body region uses uint64 stores unconditionally. Tile region uses ulong2
-  // stores; head/body/body_tail uint64 patterns are derived from the tile
-  // pattern's low half (no rotation needed under invariant
-  // addr % patternSize == 0).
+  // Body region uses uint64 stores unconditionally. Tile region uses ulong2 stores.
+  // Payloads are built after region offsets are computed so they can be rotated
+  // by regionByteOffset % patternSize, making every region byte-correct even when
+  // the destination address is not aligned to patternSize.
   constexpr size_t bodyElemSize = sizeof(uint64_t);
-  const FillPatternPayload tiled_pattern = buildTilePattern(pattern, patternSize);
 
   // Calculate head, body, body-tail, tail, and tiled body counts
   // Head/tail are byte counts. Body/body-tail are element counts.
@@ -2550,6 +2547,16 @@ bool KernelBlitManager::fillBuffer1D(device::Memory& memory, const void* pattern
   const size_t body_tail_offset = head_count + body_count * bodyElemSize + body_tile_count * tile_size;
   const size_t tile_offset = static_cast<size_t>(tile_start - fill_buf_addr);
 
+  // Build rotated payloads: each region's payload is rotated by its byte-offset-from-fill-start
+  // modulo patternSize so that the stored bytes are correct regardless of destination alignment.
+  // When all offsets are 0 (aligned case), all three payloads agree with the unrotated pattern.
+  const FillPatternPayload tiled_pattern =
+      buildTilePattern(pattern, patternSize, tile_offset % patternSize);
+  const uint64_t body_pattern =
+      buildTilePattern(pattern, patternSize, body_offset % patternSize).lo;
+  const uint64_t body_tail_pattern =
+      buildTilePattern(pattern, patternSize, body_tail_offset % patternSize).lo;
+
   constexpr size_t localWorkSize = 256;
   const size_t work_items = std::max(alignUp(body_tile_count, localWorkSize), localWorkSize);
   size_t globalWorkSize = std::min(dev().settings().limit_blit_wg_ * localWorkSize, work_items);
@@ -2566,16 +2573,18 @@ bool KernelBlitManager::fillBuffer1D(device::Memory& memory, const void* pattern
   setArgument(kernels_[kFillType], 0, sizeof(cl_mem), &mem, origin[0]);
   setArgument(kernels_[kFillType], 1, sizeof(cl_mem), kernArgBase, 0, nullptr, kDirectVa);
   setArgument(kernels_[kFillType], 2, sizeof(tiled_pattern), &tiled_pattern);
-  setArgument(kernels_[kFillType], 3, sizeof(body_tile_count), &body_tile_count);
-  setArgument(kernels_[kFillType], 4, sizeof(body_tile_passes), &body_tile_passes);
-  setArgument(kernels_[kFillType], 5, sizeof(globalWorkSize), &globalWorkSize /* stride */);
-  setArgument(kernels_[kFillType], 6, sizeof(patternSize), &patternSize);
-  setArgument(kernels_[kFillType], 7, sizeof(tail_offset), &tail_offset);
-  setArgument(kernels_[kFillType], 8, sizeof(cl_mem), &mem, origin[0] + body_offset);
-  setArgument(kernels_[kFillType], 9, sizeof(cl_mem), &mem, origin[0] + body_tail_offset);
-  setArgument(kernels_[kFillType], 10, sizeof(cl_mem), &mem, origin[0] + tail_offset);
-  setArgument(kernels_[kFillType], 11, sizeof(cl_mem), &mem, origin[0] + tile_offset);
-  setArgument(kernels_[kFillType], 12, sizeof(counts), &counts);
+  setArgument(kernels_[kFillType], 3, sizeof(body_pattern), &body_pattern);
+  setArgument(kernels_[kFillType], 4, sizeof(body_tail_pattern), &body_tail_pattern);
+  setArgument(kernels_[kFillType], 5, sizeof(body_tile_count), &body_tile_count);
+  setArgument(kernels_[kFillType], 6, sizeof(body_tile_passes), &body_tile_passes);
+  setArgument(kernels_[kFillType], 7, sizeof(globalWorkSize), &globalWorkSize /* stride */);
+  setArgument(kernels_[kFillType], 8, sizeof(patternSize), &patternSize);
+  setArgument(kernels_[kFillType], 9, sizeof(tail_offset), &tail_offset);
+  setArgument(kernels_[kFillType], 10, sizeof(cl_mem), &mem, origin[0] + body_offset);
+  setArgument(kernels_[kFillType], 11, sizeof(cl_mem), &mem, origin[0] + body_tail_offset);
+  setArgument(kernels_[kFillType], 12, sizeof(cl_mem), &mem, origin[0] + tail_offset);
+  setArgument(kernels_[kFillType], 13, sizeof(cl_mem), &mem, origin[0] + tile_offset);
+  setArgument(kernels_[kFillType], 14, sizeof(counts), &counts);
 
   size_t globalWorkOffset[3] = {0, 0, 0};
   amd::NDRangeContainer ndrange(1, globalWorkOffset, &globalWorkSize, &localWorkSize);

--- a/projects/clr/rocclr/device/rocm/rocblit.cpp
+++ b/projects/clr/rocclr/device/rocm/rocblit.cpp
@@ -2422,6 +2422,41 @@ bool KernelBlitManager::fillBuffer(device::Memory& memory, const void* pattern, 
   }
 }
 
+struct alignas(16) FillPatternPayload {
+  uint64_t lo;
+  uint64_t hi;
+};
+
+static inline void tilePatternBytes(unsigned char* dst, size_t dstSize, const void* pattern,
+                                    size_t patternSize) {
+  const auto* src = static_cast<const unsigned char*>(pattern);
+  for (size_t i = 0; i < dstSize; ++i) {
+    dst[i] = src[i & (patternSize - 1)];
+  }
+}
+
+static inline uint32_t getBodyElementSize(size_t patternSize) {
+  if (patternSize <= sizeof(uint32_t)) {
+    return sizeof(uint32_t);
+  } else if (patternSize <= sizeof(uint64_t)) {
+    return sizeof(uint64_t);
+  }
+  return 2 * sizeof(uint64_t);
+}
+
+static inline FillPatternPayload buildBodyPattern(const void* pattern, size_t patternSize,
+                                                  uint32_t bodyElemSize) {
+  FillPatternPayload payload = {};
+  tilePatternBytes(reinterpret_cast<unsigned char*>(&payload), bodyElemSize, pattern, patternSize);
+  return payload;
+}
+
+static inline FillPatternPayload buildTilePattern(const void* pattern, size_t patternSize) {
+  FillPatternPayload payload = {};
+  tilePatternBytes(reinterpret_cast<unsigned char*>(&payload), sizeof(payload), pattern, patternSize);
+  return payload;
+}
+
 // ================================================================================================
 bool KernelBlitManager::fillBuffer1D(device::Memory& memory, const void* pattern,
                                      size_t patternSize, const amd::Coord3D& surface,
@@ -2437,72 +2472,117 @@ bool KernelBlitManager::fillBuffer1D(device::Memory& memory, const void* pattern
     result = HostBlitManager::fillBuffer(memory, pattern, patternSize, size, origin, size, entire);
     synchronize();
     return result;
-  } else {
-    // Pack the fill buffer info, that handles unaligned memories.
-    std::vector<FillBufferInfo> packed_vector{};
-    FillBufferInfo::PackInfo(memory, size[0], origin[0], pattern, patternSize, packed_vector);
-
-    size_t overall_offset = origin[0];
-    for (auto& packed_obj : packed_vector) {
-      constexpr uint32_t kFillType = FillBufferAligned;
-      uint32_t kpattern_size = (packed_obj.pattern_expanded_)
-                                   ? HostBlitManager::FillBufferInfo::kExtendedSize
-                                   : patternSize;
-      size_t kfill_size = packed_obj.fill_size_ / kpattern_size;
-      size_t koffset = overall_offset;
-      overall_offset += packed_obj.fill_size_;
-
-      size_t globalWorkOffset[3] = {0, 0, 0};
-      uint32_t alignment = (kpattern_size & 0xf) == 0   ? 2 * sizeof(uint64_t)
-                           : (kpattern_size & 0x7) == 0 ? sizeof(uint64_t)
-                           : (kpattern_size & 0x3) == 0 ? sizeof(uint32_t)
-                           : (kpattern_size & 0x1) == 0 ? sizeof(uint16_t)
-                                                        : sizeof(uint8_t);
-      // Program kernels arguments for the fill operation
-      cl_mem mem = as_cl<amd::Memory>(memory.owner());
-      setArgument(kernels_[kFillType], 0, sizeof(cl_mem), &mem, koffset);
-      const size_t localWorkSize = 256;
-      size_t globalWorkSize = std::min(dev().settings().limit_blit_wg_ * localWorkSize, kfill_size);
-      globalWorkSize = amd::alignUp(globalWorkSize, localWorkSize);
-
-      bool isGraphPktCapturing =
-          gpu().command() != nullptr && gpu().command()->getPktCapturingState();
-      auto constBuf = isGraphPktCapturing
-                          ? gpu().command()->getGraphKernArg(kCBSize, kCBAlignment, dev().index())
-                          : gpu().allocKernArg(kCBSize, kCBAlignment);
-
-      // If pattern has been expanded, use the expanded pattern, otherwise use the default pattern.
-      if (packed_obj.pattern_expanded_) {
-        memcpy(constBuf, &packed_obj.expanded_pattern_, kpattern_size);
-      } else {
-        memcpy(constBuf, pattern, kpattern_size);
-      }
-      constexpr bool kDirectVa = true;
-      setArgument(kernels_[kFillType], 1, sizeof(cl_mem), constBuf, 0, nullptr, kDirectVa);
-
-      // Adjust the pattern size in the copy type size
-      kpattern_size /= alignment;
-      setArgument(kernels_[kFillType], 2, sizeof(uint32_t), &kpattern_size);
-      setArgument(kernels_[kFillType], 3, sizeof(alignment), &alignment);
-
-      // Calculate max id
-      kfill_size = memory.virtualAddress() + koffset + kfill_size * kpattern_size * alignment;
-      setArgument(kernels_[kFillType], 4, sizeof(kfill_size), &kfill_size);
-      uint32_t next_chunk = globalWorkSize * kpattern_size;
-      setArgument(kernels_[kFillType], 5, sizeof(uint32_t), &next_chunk);
-      uint32_t lws = localWorkSize;
-      setArgument(kernels_[kFillType], 6, sizeof(lws), &lws);
-
-      // Create ND range object for the kernel's execution
-      amd::NDRangeContainer ndrange(1, globalWorkOffset, &globalWorkSize, &localWorkSize);
-
-      // Execute the blit
-      address parameters = captureArguments(kernels_[kFillType]);
-      result = gpu().submitKernelInternal(ndrange, *kernels_[kFillType], parameters, nullptr);
-      releaseArguments(parameters);
-    }
   }
 
+  const uintptr_t fill_buf_addr = memory.virtualAddress() + origin[0];
+  constexpr uint32_t kFillType = FillBufferUnAligned;
+
+  cl_mem mem = as_cl<amd::Memory>(memory.owner());
+  bool isGraphPktCapturing = gpu().command() != nullptr && gpu().command()->getPktCapturingState();
+  unsigned char* kernArgBase =
+      isGraphPktCapturing
+          ? (unsigned char*)gpu().command()->getGraphKernArg(kCBSize, kCBAlignment, dev().index())
+          : (unsigned char*)gpu().allocKernArg(kCBSize, kCBAlignment);
+
+  assert((patternSize == 1 || patternSize == 2 || patternSize == 4 || patternSize == 8 ||
+          patternSize == 16) &&
+         "fillBuffer1D supports pattern sizes of 1/2/4/8/16 bytes");
+  const uint32_t bodyElemSize = getBodyElementSize(patternSize);
+  const FillPatternPayload body_pattern = buildBodyPattern(pattern, patternSize, bodyElemSize);
+
+  // Construct tiled body
+  const FillPatternPayload tiled_pattern = buildTilePattern(pattern, patternSize);
+
+  // Calculate head, body, body-tail, tail, and tiled body counts
+  // Head/tail are byte counts. Body/body-tail are element counts.
+  constexpr size_t tile_size = sizeof(ulong) * 2;
+  uintptr_t end_addr = fill_buf_addr + size[0];
+
+  uintptr_t body_aligned_start = alignUp(fill_buf_addr, static_cast<size_t>(bodyElemSize));
+  uintptr_t body_aligned_end = alignDown(end_addr, static_cast<size_t>(bodyElemSize));
+
+  size_t head_count = 0;
+  size_t body_count = 0;
+  size_t body_tile_count = 0;
+  size_t body_tail_count = 0;
+  size_t tail_count = 0;
+  uintptr_t tile_start = fill_buf_addr;  // unused when body_tile_count == 0
+
+  if (body_aligned_end <= body_aligned_start) {
+    // Tiny or sufficiently misaligned buffer: no room for a body element.
+    // Route every byte through the head cleanup region. Head count is
+    // bounded by 2*bodyElemSize - 2 (e.g. patternSize=1, bodyElemSize=4,
+    // addr=1, size=6 → head_count=6); the cleanup-fits-in-warp assert
+    // below still holds.
+    head_count = size[0];
+  } else {
+    tile_start = alignUp(body_aligned_start, tile_size);
+    uintptr_t tile_end = alignDown(body_aligned_end, tile_size);
+    head_count = body_aligned_start - fill_buf_addr;
+    body_tile_count =
+        (tile_end > tile_start) ? (tile_end - tile_start) / tile_size : 0;
+    body_count =
+        (tile_start > body_aligned_start)
+            ? static_cast<size_t>((tile_start - body_aligned_start) / bodyElemSize)
+            : static_cast<size_t>(0);
+    body_tail_count =
+        (body_aligned_end > tile_end)
+            ? static_cast<size_t>((body_aligned_end - tile_end) / bodyElemSize)
+            : static_cast<size_t>(0);
+    tail_count = static_cast<size_t>(end_addr - body_aligned_end);
+  }
+
+  assert(head_count <= (2 * bodyElemSize - 2) &&
+         "head_count must fit cleanup region (small-buffer case may be up to 2*bodyElemSize-2)");
+  assert(body_count <= (tile_size / bodyElemSize) &&
+         "body_count should fit before first 16-byte tile");
+  assert(body_tail_count <= (tile_size / bodyElemSize) &&
+         "body_tail_count should fit after last 16-byte tile");
+  assert(tail_count < bodyElemSize && "tail_count should be less than body element size");
+  assert((head_count + body_count + body_tail_count + tail_count) < 32 &&
+         "first-warp cleanup should fit in 32 lanes");
+
+  const size_t tail_offset =
+      head_count + body_count * bodyElemSize + body_tile_count * tile_size + body_tail_count * bodyElemSize;
+  const size_t body_offset = head_count;
+  const size_t body_tail_offset = head_count + body_count * bodyElemSize + body_tile_count * tile_size;
+  const size_t tile_offset = static_cast<size_t>(tile_start - fill_buf_addr);
+  const int isAligned =
+      (head_count == 0 && body_count == 0 && body_tail_count == 0 && tail_count == 0) ? 1 : 0;
+
+  constexpr size_t localWorkSize = 256;
+  const size_t work_items = std::max(alignUp(body_tile_count, localWorkSize), localWorkSize);
+  size_t globalWorkSize = std::min(dev().settings().limit_blit_wg_ * localWorkSize, work_items);
+  const size_t body_tile_passes = (body_tile_count + globalWorkSize - 1) / globalWorkSize;
+
+  memcpy(kernArgBase, pattern, patternSize);
+  constexpr bool kDirectVa = true;
+  struct Ushort4 {
+    uint16_t s0, s1, s2, s3;
+  } counts = {static_cast<uint16_t>(head_count), static_cast<uint16_t>(body_count),
+              static_cast<uint16_t>(body_tail_count), static_cast<uint16_t>(tail_count)};
+  setArgument(kernels_[kFillType], 0, sizeof(cl_mem), &mem, origin[0]);
+  setArgument(kernels_[kFillType], 1, sizeof(cl_mem), kernArgBase, 0, nullptr, kDirectVa);
+  setArgument(kernels_[kFillType], 2, sizeof(body_pattern), &body_pattern);
+  setArgument(kernels_[kFillType], 3, sizeof(tiled_pattern), &tiled_pattern);
+  setArgument(kernels_[kFillType], 4, sizeof(body_tile_count), &body_tile_count);
+  setArgument(kernels_[kFillType], 5, sizeof(body_tile_passes), &body_tile_passes);
+  setArgument(kernels_[kFillType], 6, sizeof(globalWorkSize), &globalWorkSize /* stride */);
+  setArgument(kernels_[kFillType], 7, sizeof(patternSize), &patternSize);
+  setArgument(kernels_[kFillType], 8, sizeof(tail_offset), &tail_offset);
+  setArgument(kernels_[kFillType], 9, sizeof(cl_mem), &mem, origin[0] + body_offset);
+  setArgument(kernels_[kFillType], 10, sizeof(cl_mem), &mem, origin[0] + body_tail_offset);
+  setArgument(kernels_[kFillType], 11, sizeof(cl_mem), &mem, origin[0] + tail_offset);
+  setArgument(kernels_[kFillType], 12, sizeof(cl_mem), &mem, origin[0] + tile_offset);
+  setArgument(kernels_[kFillType], 13, sizeof(counts), &counts);
+  setArgument(kernels_[kFillType], 14, sizeof(bodyElemSize), &bodyElemSize);
+  setArgument(kernels_[kFillType], 15, sizeof(isAligned), &isAligned);
+
+  size_t globalWorkOffset[3] = {0, 0, 0};
+  amd::NDRangeContainer ndrange(1, globalWorkOffset, &globalWorkSize, &localWorkSize);
+  address parameters = captureArguments(kernels_[kFillType]);
+  result = gpu().submitKernelInternal(ndrange, *kernels_[kFillType], parameters, nullptr);
+  releaseArguments(parameters);
   synchronize();
 
   return result;

--- a/projects/clr/rocclr/device/rocm/rocblit.cpp
+++ b/projects/clr/rocclr/device/rocm/rocblit.cpp
@@ -2435,22 +2435,6 @@ static inline void tilePatternBytes(unsigned char* dst, size_t dstSize, const vo
   }
 }
 
-static inline uint32_t getBodyElementSize(size_t patternSize) {
-  if (patternSize <= sizeof(uint32_t)) {
-    return sizeof(uint32_t);
-  } else if (patternSize <= sizeof(uint64_t)) {
-    return sizeof(uint64_t);
-  }
-  return 2 * sizeof(uint64_t);
-}
-
-static inline FillPatternPayload buildBodyPattern(const void* pattern, size_t patternSize,
-                                                  uint32_t bodyElemSize) {
-  FillPatternPayload payload = {};
-  tilePatternBytes(reinterpret_cast<unsigned char*>(&payload), bodyElemSize, pattern, patternSize);
-  return payload;
-}
-
 static inline FillPatternPayload buildTilePattern(const void* pattern, size_t patternSize) {
   FillPatternPayload payload = {};
   tilePatternBytes(reinterpret_cast<unsigned char*>(&payload), sizeof(payload), pattern, patternSize);
@@ -2487,10 +2471,12 @@ bool KernelBlitManager::fillBuffer1D(device::Memory& memory, const void* pattern
   assert((patternSize == 1 || patternSize == 2 || patternSize == 4 || patternSize == 8 ||
           patternSize == 16) &&
          "fillBuffer1D supports pattern sizes of 1/2/4/8/16 bytes");
-  const uint32_t bodyElemSize = getBodyElementSize(patternSize);
-  const FillPatternPayload body_pattern = buildBodyPattern(pattern, patternSize, bodyElemSize);
 
-  // Construct tiled body
+  // Body region uses uint64 stores unconditionally. Tile region uses ulong2
+  // stores; head/body/body_tail uint64 patterns are derived from the tile
+  // pattern's low half (no rotation needed under invariant
+  // addr % patternSize == 0).
+  constexpr size_t bodyElemSize = sizeof(uint64_t);
   const FillPatternPayload tiled_pattern = buildTilePattern(pattern, patternSize);
 
   // Calculate head, body, body-tail, tail, and tiled body counts
@@ -2498,8 +2484,8 @@ bool KernelBlitManager::fillBuffer1D(device::Memory& memory, const void* pattern
   constexpr size_t tile_size = sizeof(ulong) * 2;
   uintptr_t end_addr = fill_buf_addr + size[0];
 
-  uintptr_t body_aligned_start = alignUp(fill_buf_addr, static_cast<size_t>(bodyElemSize));
-  uintptr_t body_aligned_end = alignDown(end_addr, static_cast<size_t>(bodyElemSize));
+  uintptr_t body_aligned_start = alignUp(fill_buf_addr, bodyElemSize);
+  uintptr_t body_aligned_end = alignDown(end_addr, bodyElemSize);
 
   size_t head_count = 0;
   size_t body_count = 0;
@@ -2509,11 +2495,10 @@ bool KernelBlitManager::fillBuffer1D(device::Memory& memory, const void* pattern
   uintptr_t tile_start = fill_buf_addr;  // unused when body_tile_count == 0
 
   if (body_aligned_end <= body_aligned_start) {
-    // Tiny or sufficiently misaligned buffer: no room for a body element.
+    // Tiny or sufficiently misaligned buffer: no room for a body uint64 element.
     // Route every byte through the head cleanup region. Head count is
-    // bounded by 2*bodyElemSize - 2 (e.g. patternSize=1, bodyElemSize=4,
-    // addr=1, size=6 → head_count=6); the cleanup-fits-in-warp assert
-    // below still holds.
+    // bounded by 2*bodyElemSize - 2 = 14 (e.g. patternSize=1, addr=1,
+    // size=14); still fits within the 16-lane cleanup region.
     head_count = size[0];
   } else {
     tile_start = alignUp(body_aligned_start, tile_size);
@@ -2539,16 +2524,14 @@ bool KernelBlitManager::fillBuffer1D(device::Memory& memory, const void* pattern
   assert(body_tail_count <= (tile_size / bodyElemSize) &&
          "body_tail_count should fit after last 16-byte tile");
   assert(tail_count < bodyElemSize && "tail_count should be less than body element size");
-  assert((head_count + body_count + body_tail_count + tail_count) < 32 &&
-         "first-warp cleanup should fit in 32 lanes");
+  assert((head_count + body_count + body_tail_count + tail_count) < 16 &&
+         "cleanup region must fit in the kernel's 16-lane cleanup gate");
 
   const size_t tail_offset =
       head_count + body_count * bodyElemSize + body_tile_count * tile_size + body_tail_count * bodyElemSize;
   const size_t body_offset = head_count;
   const size_t body_tail_offset = head_count + body_count * bodyElemSize + body_tile_count * tile_size;
   const size_t tile_offset = static_cast<size_t>(tile_start - fill_buf_addr);
-  const int isAligned =
-      (head_count == 0 && body_count == 0 && body_tail_count == 0 && tail_count == 0) ? 1 : 0;
 
   constexpr size_t localWorkSize = 256;
   const size_t work_items = std::max(alignUp(body_tile_count, localWorkSize), localWorkSize);
@@ -2563,20 +2546,17 @@ bool KernelBlitManager::fillBuffer1D(device::Memory& memory, const void* pattern
               static_cast<uint16_t>(body_tail_count), static_cast<uint16_t>(tail_count)};
   setArgument(kernels_[kFillType], 0, sizeof(cl_mem), &mem, origin[0]);
   setArgument(kernels_[kFillType], 1, sizeof(cl_mem), kernArgBase, 0, nullptr, kDirectVa);
-  setArgument(kernels_[kFillType], 2, sizeof(body_pattern), &body_pattern);
-  setArgument(kernels_[kFillType], 3, sizeof(tiled_pattern), &tiled_pattern);
-  setArgument(kernels_[kFillType], 4, sizeof(body_tile_count), &body_tile_count);
-  setArgument(kernels_[kFillType], 5, sizeof(body_tile_passes), &body_tile_passes);
-  setArgument(kernels_[kFillType], 6, sizeof(globalWorkSize), &globalWorkSize /* stride */);
-  setArgument(kernels_[kFillType], 7, sizeof(patternSize), &patternSize);
-  setArgument(kernels_[kFillType], 8, sizeof(tail_offset), &tail_offset);
-  setArgument(kernels_[kFillType], 9, sizeof(cl_mem), &mem, origin[0] + body_offset);
-  setArgument(kernels_[kFillType], 10, sizeof(cl_mem), &mem, origin[0] + body_tail_offset);
-  setArgument(kernels_[kFillType], 11, sizeof(cl_mem), &mem, origin[0] + tail_offset);
-  setArgument(kernels_[kFillType], 12, sizeof(cl_mem), &mem, origin[0] + tile_offset);
-  setArgument(kernels_[kFillType], 13, sizeof(counts), &counts);
-  setArgument(kernels_[kFillType], 14, sizeof(bodyElemSize), &bodyElemSize);
-  setArgument(kernels_[kFillType], 15, sizeof(isAligned), &isAligned);
+  setArgument(kernels_[kFillType], 2, sizeof(tiled_pattern), &tiled_pattern);
+  setArgument(kernels_[kFillType], 3, sizeof(body_tile_count), &body_tile_count);
+  setArgument(kernels_[kFillType], 4, sizeof(body_tile_passes), &body_tile_passes);
+  setArgument(kernels_[kFillType], 5, sizeof(globalWorkSize), &globalWorkSize /* stride */);
+  setArgument(kernels_[kFillType], 6, sizeof(patternSize), &patternSize);
+  setArgument(kernels_[kFillType], 7, sizeof(tail_offset), &tail_offset);
+  setArgument(kernels_[kFillType], 8, sizeof(cl_mem), &mem, origin[0] + body_offset);
+  setArgument(kernels_[kFillType], 9, sizeof(cl_mem), &mem, origin[0] + body_tail_offset);
+  setArgument(kernels_[kFillType], 10, sizeof(cl_mem), &mem, origin[0] + tail_offset);
+  setArgument(kernels_[kFillType], 11, sizeof(cl_mem), &mem, origin[0] + tile_offset);
+  setArgument(kernels_[kFillType], 12, sizeof(counts), &counts);
 
   size_t globalWorkOffset[3] = {0, 0, 0};
   amd::NDRangeContainer ndrange(1, globalWorkOffset, &globalWorkSize, &localWorkSize);

--- a/projects/clr/rocclr/device/rocm/rocblit.cpp
+++ b/projects/clr/rocclr/device/rocm/rocblit.cpp
@@ -2459,6 +2459,15 @@ bool KernelBlitManager::fillBuffer1D(device::Memory& memory, const void* pattern
   }
 
   const uintptr_t fill_buf_addr = memory.virtualAddress() + origin[0];
+
+  if ((fill_buf_addr % patternSize) != 0) {
+    LogPrintfError(
+        "fillBuffer1D: buffer VA 0x%lx with origin %zu is not aligned to pattern size %zu; "
+        "kernel path requires (VA + origin) %% patternSize == 0",
+        memory.virtualAddress(), origin[0], patternSize);
+    return false;
+  }
+
   constexpr uint32_t kFillType = FillBufferUnAligned;
 
   cl_mem mem = as_cl<amd::Memory>(memory.owner());
@@ -2481,7 +2490,7 @@ bool KernelBlitManager::fillBuffer1D(device::Memory& memory, const void* pattern
 
   // Calculate head, body, body-tail, tail, and tiled body counts
   // Head/tail are byte counts. Body/body-tail are element counts.
-  constexpr size_t tile_size = sizeof(ulong) * 2;
+  constexpr size_t tile_size = 2 * sizeof(uint64_t);
   uintptr_t end_addr = fill_buf_addr + size[0];
 
   uintptr_t body_aligned_start = alignUp(fill_buf_addr, bodyElemSize);
@@ -2519,13 +2528,21 @@ bool KernelBlitManager::fillBuffer1D(device::Memory& memory, const void* pattern
 
   assert(head_count <= (2 * bodyElemSize - 2) &&
          "head_count must fit cleanup region (small-buffer case may be up to 2*bodyElemSize-2)");
-  assert(body_count <= (tile_size / bodyElemSize) &&
-         "body_count should fit before first 16-byte tile");
-  assert(body_tail_count <= (tile_size / bodyElemSize) &&
-         "body_tail_count should fit after last 16-byte tile");
+  // body_aligned_start is 8-aligned, tile_start = alignUp(body_aligned_start, 16),
+  // so (tile_start - body_aligned_start) / bodyElemSize is structurally 0 or 1.
+  assert(body_count <= 1 && "body_count is structurally 0 or 1");
+  assert(body_tail_count <= 1 && "body_tail_count is structurally 0 or 1");
   assert(tail_count < bodyElemSize && "tail_count should be less than body element size");
-  assert((head_count + body_count + body_tail_count + tail_count) < 16 &&
-         "cleanup region must fit in the kernel's 16-lane cleanup gate");
+  const size_t cleanup_total = head_count + body_count + body_tail_count + tail_count;
+  assert(cleanup_total <= 16 && "cleanup region must fit in the kernel's 16-lane cleanup gate");
+  if (cleanup_total > 16) {
+    LogPrintfError(
+        "fillBuffer1D: cleanup region size %zu exceeds 16-lane kernel gate "
+        "(head=%zu body=%zu body_tail=%zu tail=%zu, fill_buf_addr=0x%lx, size=%zu, patternSize=%zu)",
+        cleanup_total, head_count, body_count, body_tail_count, tail_count,
+        fill_buf_addr, size[0], patternSize);
+    return false;
+  }
 
   const size_t tail_offset =
       head_count + body_count * bodyElemSize + body_tile_count * tile_size + body_tail_count * bodyElemSize;
@@ -2544,6 +2561,8 @@ bool KernelBlitManager::fillBuffer1D(device::Memory& memory, const void* pattern
     uint16_t s0, s1, s2, s3;
   } counts = {static_cast<uint16_t>(head_count), static_cast<uint16_t>(body_count),
               static_cast<uint16_t>(body_tail_count), static_cast<uint16_t>(tail_count)};
+  static_assert(sizeof(size_t) == sizeof(uint64_t),
+                "Kernel arg passing assumes 64-bit size_t");
   setArgument(kernels_[kFillType], 0, sizeof(cl_mem), &mem, origin[0]);
   setArgument(kernels_[kFillType], 1, sizeof(cl_mem), kernArgBase, 0, nullptr, kDirectVa);
   setArgument(kernels_[kFillType], 2, sizeof(tiled_pattern), &tiled_pattern);

--- a/projects/clr/rocclr/device/rocm/rocblit.hpp
+++ b/projects/clr/rocclr/device/rocm/rocblit.hpp
@@ -294,7 +294,7 @@ class DmaBlitManager : public device::HostBlitManager {
 class KernelBlitManager : public DmaBlitManager {
  public:
   enum {
-    FillBufferAligned = 0,
+    FillBufferUnAligned = 0,
     FillBufferAligned2D,
     BlitCopyBuffer,
     BlitCopyBufferAligned,
@@ -629,7 +629,7 @@ class KernelBlitManager : public DmaBlitManager {
 };
 
 static const char* BlitName[KernelBlitManager::BlitTotal] = {
-    "__amd_rocclr_fillBufferAligned",  "__amd_rocclr_fillBufferAligned2D",
+    "__amd_rocclr_fillBufferUnAligned",  "__amd_rocclr_fillBufferAligned2D",
     "__amd_rocclr_copyBuffer",         "__amd_rocclr_copyBufferAligned",
     "__amd_rocclr_copyBufferRect",     "__amd_rocclr_copyBufferRectAligned",
     "__amd_rocclr_streamOpsWrite",     "__amd_rocclr_streamOpsWait",

--- a/projects/hip-tests/catch/config/configs/unit/memory.yaml
+++ b/projects/hip-tests/catch/config/configs/unit/memory.yaml
@@ -790,6 +790,18 @@ memory:
   Unit_hipMemsetD8Async_KernelBuffer:
     <<: *level_2
     tags: [memset]
+  Unit_hipMemsetD16_UnalignedPatternFill:
+    <<: *level_2
+    tags: [memset]
+  Unit_hipMemsetD32_UnalignedPatternFill:
+    <<: *level_2
+    tags: [memset]
+  Unit_hipMemsetD16Async_UnalignedPatternFill:
+    <<: *level_2
+    tags: [memset]
+  Unit_hipMemsetD32Async_UnalignedPatternFill:
+    <<: *level_2
+    tags: [memset]
   Unit_hipMemcpy2DArrayToArray_Negative:
     <<: *level_2
     tags: [transfer, image]

--- a/projects/hip-tests/catch/unit/memory/hipMemsetFunctional.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemsetFunctional.cc
@@ -639,59 +639,208 @@ TEST_CASE("Unit_hipMemset_UnalignedKernelCornerCases", "[fillBuffer][unaligned]"
 
     HIP_CHECK(hipFree(base));
   }
+}
 
-  SECTION("Sub-pattern-misaligned VA returns hipError") {
-    hipError_t err = hipSuccess;
-    void* base = nullptr;
-    HIP_CHECK(hipMalloc(&base, 256));
-    hipStream_t stream{nullptr};
-    HIP_CHECK(hipStreamCreate(&stream));
+// ---------------------------------------------------------------------------
+// Unaligned-base fill tests for D16 / D32 sync and async variants.
+// These exercise the head/body/tile/tail rotation paths of
+// __amd_rocclr_fillBufferUnAligned with sub-element-aligned destination
+// pointers.  The tests are deliberately RED until the source supports
+// unaligned bases.
+// ---------------------------------------------------------------------------
 
-    {
-      // Test hipMemsetD16 with odd-aligned pointer (not 2-byte aligned)
-      void* misaligned16 = static_cast<unsigned char*>(base) + 1;
-      err = hipMemsetD16(reinterpret_cast<hipDeviceptr_t>(misaligned16),
-                                    0xBEEF, /*count=*/16);
-      CAPTURE(err);
-      HIP_ASSERT(err == hipErrorInvalidValue);
-      // Test hipMemsetD16Async with odd-aligned pointer (not 2-byte aligned)
-      err = hipMemsetD16Async(reinterpret_cast<hipDeviceptr_t>(misaligned16),
-                              0xBEEF, /*count=*/16, stream);
-      CAPTURE(err);
-      HIP_ASSERT(err == hipErrorInvalidValue);
+TEST_CASE("Unit_hipMemsetD16_UnalignedPatternFill", "[fillBuffer][unaligned]") {
+  constexpr size_t kAllocBytes = 512;
+  constexpr unsigned char kSentinel = 0x5A;
+  constexpr unsigned short kPattern = 0xBEEF;
+  constexpr size_t kElemSize = sizeof(unsigned short);  // 2
+
+  void* base = nullptr;
+  HIP_CHECK(hipMalloc(&base, kAllocBytes));
+
+  for (size_t offset : {1U}) {
+    for (size_t count : {8U, 12U, 15U, 16U, 31U, 50U, 64U, 100U}) {
+      // Fill whole buffer with sentinel.
+      HIP_CHECK(hipMemset(base, kSentinel, kAllocBytes));
+      HIP_CHECK(hipDeviceSynchronize());
+
+      void* dst = static_cast<unsigned char*>(base) + offset;
+      HIP_CHECK(hipMemsetD16(reinterpret_cast<hipDeviceptr_t>(dst),
+                             kPattern, count));
+      HIP_CHECK(hipDeviceSynchronize());
+
+      std::vector<unsigned char> hostCopy(kAllocBytes, 0);
+      HIP_CHECK(hipMemcpy(hostCopy.data(), base, kAllocBytes,
+                          hipMemcpyDeviceToHost));
+
+      // Head sentinel region [0, offset) must be untouched.
+      for (size_t i = 0; i < offset; ++i) {
+        CAPTURE(offset, count, i);
+        HIP_ASSERT(hostCopy[i] == kSentinel);
+      }
+      // Fill region [offset, offset + count*kElemSize) must match pattern.
+      for (size_t j = 0; j < count * kElemSize; ++j) {
+        const unsigned char expected =
+            static_cast<unsigned char>(kPattern >> (8 * (j % kElemSize)));
+        CAPTURE(offset, count, j);
+        HIP_ASSERT(hostCopy[offset + j] == expected);
+      }
+      // Tail sentinel region must be untouched.
+      for (size_t i = offset + count * kElemSize; i < kAllocBytes; ++i) {
+        CAPTURE(offset, count, i);
+        HIP_ASSERT(hostCopy[i] == kSentinel);
+      }
     }
-
-    {
-      // Test hipMemsetD32 with misaligned pointer (not 4-byte aligned)
-      // Test +1 offset (misaligned by 1 byte)
-      void* misaligned32_1 = static_cast<unsigned char*>(base) + 1;
-      err = hipMemsetD32(reinterpret_cast<hipDeviceptr_t>(misaligned32_1),
-                         0xDEADBEEF, /*count=*/16);
-      CAPTURE(err);
-      HIP_ASSERT(err == hipErrorInvalidValue);
-
-      // Test +2 offset (misaligned by 2 bytes)
-      void* misaligned32_2 = static_cast<unsigned char*>(base) + 2;
-      err = hipMemsetD32(reinterpret_cast<hipDeviceptr_t>(misaligned32_2),
-                         0xDEADBEEF, /*count=*/16);
-      CAPTURE(err);
-      HIP_ASSERT(err == hipErrorInvalidValue);
-
-      // Test +3 offset (misaligned by 3 bytes)
-      void* misaligned32_3 = static_cast<unsigned char*>(base) + 3;
-      err = hipMemsetD32(reinterpret_cast<hipDeviceptr_t>(misaligned32_3),
-                         0xDEADBEEF, /*count=*/16);
-      CAPTURE(err);
-      HIP_ASSERT(err == hipErrorInvalidValue);
-
-      // Test hipMemsetD32Async with misaligned pointer (not 4-byte aligned)
-      err = hipMemsetD32Async(reinterpret_cast<hipDeviceptr_t>(misaligned32_1),
-                              0xDEADBEEF, /*count=*/16, stream);
-      CAPTURE(err);
-      HIP_ASSERT(err == hipErrorInvalidValue);
-    }
-
-    HIP_CHECK(hipStreamDestroy(stream));
-    HIP_CHECK(hipFree(base));
   }
+
+  HIP_CHECK(hipFree(base));
+}
+
+TEST_CASE("Unit_hipMemsetD32_UnalignedPatternFill", "[fillBuffer][unaligned]") {
+  constexpr size_t kAllocBytes = 512;
+  constexpr unsigned char kSentinel = 0x5A;
+  constexpr unsigned int kPattern = 0xDEADBEEFu;
+  constexpr size_t kElemSize = sizeof(unsigned int);  // 4
+
+  void* base = nullptr;
+  HIP_CHECK(hipMalloc(&base, kAllocBytes));
+
+  for (size_t offset : {1U, 2U, 3U}) {
+    for (size_t count : {4U, 6U, 7U, 8U, 15U, 25U, 32U, 50U}) {
+      // Fill whole buffer with sentinel.
+      HIP_CHECK(hipMemset(base, kSentinel, kAllocBytes));
+      HIP_CHECK(hipDeviceSynchronize());
+
+      void* dst = static_cast<unsigned char*>(base) + offset;
+      HIP_CHECK(hipMemsetD32(reinterpret_cast<hipDeviceptr_t>(dst),
+                             static_cast<int>(kPattern), count));
+      HIP_CHECK(hipDeviceSynchronize());
+
+      std::vector<unsigned char> hostCopy(kAllocBytes, 0);
+      HIP_CHECK(hipMemcpy(hostCopy.data(), base, kAllocBytes,
+                          hipMemcpyDeviceToHost));
+
+      // Head sentinel region [0, offset) must be untouched.
+      for (size_t i = 0; i < offset; ++i) {
+        CAPTURE(offset, count, i);
+        HIP_ASSERT(hostCopy[i] == kSentinel);
+      }
+      // Fill region [offset, offset + count*kElemSize) must match pattern.
+      for (size_t j = 0; j < count * kElemSize; ++j) {
+        const unsigned char expected =
+            static_cast<unsigned char>(kPattern >> (8 * (j % kElemSize)));
+        CAPTURE(offset, count, j);
+        HIP_ASSERT(hostCopy[offset + j] == expected);
+      }
+      // Tail sentinel region must be untouched.
+      for (size_t i = offset + count * kElemSize; i < kAllocBytes; ++i) {
+        CAPTURE(offset, count, i);
+        HIP_ASSERT(hostCopy[i] == kSentinel);
+      }
+    }
+  }
+
+  HIP_CHECK(hipFree(base));
+}
+
+TEST_CASE("Unit_hipMemsetD16Async_UnalignedPatternFill", "[fillBuffer][unaligned]") {
+  constexpr size_t kAllocBytes = 512;
+  constexpr unsigned char kSentinel = 0x5A;
+  constexpr unsigned short kPattern = 0xBEEF;
+  constexpr size_t kElemSize = sizeof(unsigned short);  // 2
+
+  void* base = nullptr;
+  HIP_CHECK(hipMalloc(&base, kAllocBytes));
+
+  hipStream_t stream{nullptr};
+  HIP_CHECK(hipStreamCreate(&stream));
+
+  for (size_t offset : {1U}) {
+    for (size_t count : {8U, 12U, 15U, 16U, 31U, 50U, 64U, 100U}) {
+      // Fill whole buffer with sentinel.
+      HIP_CHECK(hipMemset(base, kSentinel, kAllocBytes));
+      HIP_CHECK(hipDeviceSynchronize());
+
+      void* dst = static_cast<unsigned char*>(base) + offset;
+      HIP_CHECK(hipMemsetD16Async(reinterpret_cast<hipDeviceptr_t>(dst),
+                                  kPattern, count, stream));
+      HIP_CHECK(hipStreamSynchronize(stream));
+
+      std::vector<unsigned char> hostCopy(kAllocBytes, 0);
+      HIP_CHECK(hipMemcpy(hostCopy.data(), base, kAllocBytes,
+                          hipMemcpyDeviceToHost));
+
+      // Head sentinel region [0, offset) must be untouched.
+      for (size_t i = 0; i < offset; ++i) {
+        CAPTURE(offset, count, i);
+        HIP_ASSERT(hostCopy[i] == kSentinel);
+      }
+      // Fill region [offset, offset + count*kElemSize) must match pattern.
+      for (size_t j = 0; j < count * kElemSize; ++j) {
+        const unsigned char expected =
+            static_cast<unsigned char>(kPattern >> (8 * (j % kElemSize)));
+        CAPTURE(offset, count, j);
+        HIP_ASSERT(hostCopy[offset + j] == expected);
+      }
+      // Tail sentinel region must be untouched.
+      for (size_t i = offset + count * kElemSize; i < kAllocBytes; ++i) {
+        CAPTURE(offset, count, i);
+        HIP_ASSERT(hostCopy[i] == kSentinel);
+      }
+    }
+  }
+
+  HIP_CHECK(hipStreamDestroy(stream));
+  HIP_CHECK(hipFree(base));
+}
+
+TEST_CASE("Unit_hipMemsetD32Async_UnalignedPatternFill", "[fillBuffer][unaligned]") {
+  constexpr size_t kAllocBytes = 512;
+  constexpr unsigned char kSentinel = 0x5A;
+  constexpr unsigned int kPattern = 0xDEADBEEFu;
+  constexpr size_t kElemSize = sizeof(unsigned int);  // 4
+
+  void* base = nullptr;
+  HIP_CHECK(hipMalloc(&base, kAllocBytes));
+
+  hipStream_t stream{nullptr};
+  HIP_CHECK(hipStreamCreate(&stream));
+
+  for (size_t offset : {1U, 2U, 3U}) {
+    for (size_t count : {4U, 6U, 7U, 8U, 15U, 25U, 32U, 50U}) {
+      // Fill whole buffer with sentinel.
+      HIP_CHECK(hipMemset(base, kSentinel, kAllocBytes));
+      HIP_CHECK(hipDeviceSynchronize());
+
+      void* dst = static_cast<unsigned char*>(base) + offset;
+      HIP_CHECK(hipMemsetD32Async(reinterpret_cast<hipDeviceptr_t>(dst),
+                                  static_cast<int>(kPattern), count, stream));
+      HIP_CHECK(hipStreamSynchronize(stream));
+
+      std::vector<unsigned char> hostCopy(kAllocBytes, 0);
+      HIP_CHECK(hipMemcpy(hostCopy.data(), base, kAllocBytes,
+                          hipMemcpyDeviceToHost));
+
+      // Head sentinel region [0, offset) must be untouched.
+      for (size_t i = 0; i < offset; ++i) {
+        CAPTURE(offset, count, i);
+        HIP_ASSERT(hostCopy[i] == kSentinel);
+      }
+      // Fill region [offset, offset + count*kElemSize) must match pattern.
+      for (size_t j = 0; j < count * kElemSize; ++j) {
+        const unsigned char expected =
+            static_cast<unsigned char>(kPattern >> (8 * (j % kElemSize)));
+        CAPTURE(offset, count, j);
+        HIP_ASSERT(hostCopy[offset + j] == expected);
+      }
+      // Tail sentinel region must be untouched.
+      for (size_t i = offset + count * kElemSize; i < kAllocBytes; ++i) {
+        CAPTURE(offset, count, i);
+        HIP_ASSERT(hostCopy[i] == kSentinel);
+      }
+    }
+  }
+
+  HIP_CHECK(hipStreamDestroy(stream));
+  HIP_CHECK(hipFree(base));
 }

--- a/projects/hip-tests/catch/unit/memory/hipMemsetFunctional.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemsetFunctional.cc
@@ -548,3 +548,127 @@ HIP_TEST_CASE(Unit_hipMemsetFunctional_PartialSet_3D) {
     }
   }
 }
+
+// Corner-case coverage for the __amd_rocclr_fillBufferUnAligned kernel rewrite.
+// These exercise the head/body/body_tile/body_tail/tail cleanup-region paths
+// that the rewrite changed behavior on, and the precondition error propagation.
+TEST_CASE("Unit_hipMemset_UnalignedKernelCornerCases", "[fillBuffer][unaligned]") {
+  SECTION("Byte-misaligned hipHostRegister patternSize=1") {
+    // Register a host buffer at an odd offset to obtain a byte-misaligned
+    // device-visible pointer, then run hipMemset (D8, patternSize=1) at sizes
+    // including 30 — which is the exact case where the cleanup-region sum
+    // hits 16 (head=7, body=1, body_tail=1, tail=7) and exposed the original
+    // off-by-one in the host-side assertion.
+    constexpr size_t kSlack = 64;
+    constexpr size_t kMaxFill = 64;
+    std::vector<unsigned char> host(kSlack + kMaxFill + kSlack, 0);
+    void* registered = host.data() + 1;  // odd address inside the slack region
+    HIP_CHECK(hipHostRegister(registered, kMaxFill + 32, hipHostRegisterDefault));
+    void* devPtr = nullptr;
+    HIP_CHECK(hipHostGetDevicePointer(&devPtr, registered, 0));
+
+    for (size_t fillSize : {16U, 17U, 30U, 31U, 32U, 33U, 47U, 48U}) {
+      const unsigned char value = 0xA5;
+      // Reset the surrounding region so we can check no overrun occurred.
+      std::fill(host.begin(), host.end(), 0u);
+      HIP_CHECK(hipMemset(devPtr, value, fillSize));
+      HIP_CHECK(hipDeviceSynchronize());
+      const unsigned char* base = static_cast<const unsigned char*>(registered);
+      for (size_t i = 0; i < fillSize; ++i) {
+        CAPTURE(fillSize, i);
+        HIP_ASSERT(base[i] == value);
+      }
+      // First byte after the fill region should still be zero (no overrun).
+      CAPTURE(fillSize);
+      HIP_ASSERT(base[fillSize] == 0u);
+    }
+
+    HIP_CHECK(hipHostUnregister(registered));
+  }
+
+  SECTION("Body-cleanup path across pattern sizes 1/2/4 at varied sizes") {
+    // hipMalloc returns a base VA aligned to >= 256 bytes, so devPtr is
+    // 16-aligned. By offsetting the fill start by +8 we land on an address
+    // that is 8-aligned but not 16-aligned, which is the only configuration
+    // that produces body_count=1. Combined with sizes whose tail also lands
+    // 8-aligned-but-not-16-aligned, this exercises body_count=1 +
+    // body_tail_count=1 — the path that surfaces the Windows tile_size bug
+    // (sizeof(unsigned long)*2 == 8 on MSVC LLP64 instead of 16).
+    //
+    // HIP only exposes patternSize 1/2/4 via D8/D16/D32; patternSize 8 and 16
+    // are reachable from OpenCL clEnqueueFillBuffer (not tested here).
+    constexpr size_t kAllocBytes = 256;
+    void* base = nullptr;
+    HIP_CHECK(hipMalloc(&base, kAllocBytes));
+
+    auto runFill = [&](size_t patternSize, uint64_t patternValue,
+                       size_t fillBytes) {
+      // Reset whole buffer to a sentinel.
+      HIP_CHECK(hipMemset(base, 0u, kAllocBytes));
+      void* dst = static_cast<unsigned char*>(base) + 8;  // 8-aligned, not 16
+      switch (patternSize) {
+        case 1:
+          HIP_CHECK(hipMemsetD8(reinterpret_cast<hipDeviceptr_t>(dst),
+                                static_cast<unsigned char>(patternValue),
+                                fillBytes));
+          break;
+        case 2:
+          HIP_CHECK(hipMemsetD16(reinterpret_cast<hipDeviceptr_t>(dst),
+                                 static_cast<unsigned short>(patternValue),
+                                 fillBytes / 2));
+          break;
+        case 4:
+          HIP_CHECK(hipMemsetD32(reinterpret_cast<hipDeviceptr_t>(dst),
+                                 static_cast<int>(patternValue),
+                                 fillBytes / 4));
+          break;
+      }
+      HIP_CHECK(hipDeviceSynchronize());
+      std::vector<unsigned char> hostCopy(kAllocBytes, 0);
+      HIP_CHECK(hipMemcpy(hostCopy.data(), base, kAllocBytes,
+                          hipMemcpyDeviceToHost));
+      for (size_t i = 0; i < 8; ++i) {
+        CAPTURE(patternSize, fillBytes, i);
+        HIP_ASSERT(hostCopy[i] == 0u);  // head sentinel preserved
+      }
+      for (size_t i = 0; i < fillBytes; ++i) {
+        const size_t patternIdx = i % patternSize;
+        const unsigned char expected =
+            static_cast<unsigned char>(patternValue >> (8 * patternIdx));
+        CAPTURE(patternSize, fillBytes, i);
+        HIP_ASSERT(hostCopy[8 + i] == expected);
+      }
+      for (size_t i = 8 + fillBytes; i < kAllocBytes; ++i) {
+        CAPTURE(patternSize, fillBytes, i);
+        HIP_ASSERT(hostCopy[i] == 0u);  // tail sentinel preserved
+      }
+    };
+
+    for (size_t fillBytes : {16U, 24U, 32U, 40U, 48U, 56U, 64U, 72U}) {
+      runFill(1, 0xA5ULL, fillBytes);
+    }
+    for (size_t fillBytes : {16U, 24U, 32U, 40U, 48U, 56U, 64U, 72U}) {
+      runFill(2, 0xA53CULL, fillBytes);
+    }
+    for (size_t fillBytes : {16U, 24U, 32U, 40U, 48U, 56U, 64U, 72U}) {
+      runFill(4, 0xA53C7E91ULL, fillBytes);
+    }
+
+    HIP_CHECK(hipFree(base));
+  }
+
+  SECTION("Sub-pattern-misaligned VA returns hipError") {
+    // hipMalloc base is aligned >= 16. Offsetting by 1 gives an odd VA;
+    // calling hipMemsetD16 (patternSize=2) violates the precondition
+    // (VA + origin) % patternSize == 0 and must surface as a non-success
+    // hipError after the ihipMemset propagation fix in commit 1.
+    void* base = nullptr;
+    HIP_CHECK(hipMalloc(&base, 256));
+    void* misaligned = static_cast<unsigned char*>(base) + 1;
+    hipError_t err = hipMemsetD16(reinterpret_cast<hipDeviceptr_t>(misaligned),
+                                  0xBEEF, /*count=*/16);
+    CAPTURE(err);
+    HIP_ASSERT(err != hipSuccess);
+    HIP_CHECK(hipFree(base));
+  }
+}

--- a/projects/hip-tests/catch/unit/memory/hipMemsetFunctional.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemsetFunctional.cc
@@ -554,11 +554,6 @@ HIP_TEST_CASE(Unit_hipMemsetFunctional_PartialSet_3D) {
 // that the rewrite changed behavior on, and the precondition error propagation.
 TEST_CASE("Unit_hipMemset_UnalignedKernelCornerCases", "[fillBuffer][unaligned]") {
   SECTION("Byte-misaligned hipHostRegister patternSize=1") {
-    // Register a host buffer at an odd offset to obtain a byte-misaligned
-    // device-visible pointer, then run hipMemset (D8, patternSize=1) at sizes
-    // including 30 — which is the exact case where the cleanup-region sum
-    // hits 16 (head=7, body=1, body_tail=1, tail=7) and exposed the original
-    // off-by-one in the host-side assertion.
     constexpr size_t kSlack = 64;
     constexpr size_t kMaxFill = 64;
     std::vector<unsigned char> host(kSlack + kMaxFill + kSlack, 0);
@@ -587,16 +582,6 @@ TEST_CASE("Unit_hipMemset_UnalignedKernelCornerCases", "[fillBuffer][unaligned]"
   }
 
   SECTION("Body-cleanup path across pattern sizes 1/2/4 at varied sizes") {
-    // hipMalloc returns a base VA aligned to >= 256 bytes, so devPtr is
-    // 16-aligned. By offsetting the fill start by +8 we land on an address
-    // that is 8-aligned but not 16-aligned, which is the only configuration
-    // that produces body_count=1. Combined with sizes whose tail also lands
-    // 8-aligned-but-not-16-aligned, this exercises body_count=1 +
-    // body_tail_count=1 — the path that surfaces the Windows tile_size bug
-    // (sizeof(unsigned long)*2 == 8 on MSVC LLP64 instead of 16).
-    //
-    // HIP only exposes patternSize 1/2/4 via D8/D16/D32; patternSize 8 and 16
-    // are reachable from OpenCL clEnqueueFillBuffer (not tested here).
     constexpr size_t kAllocBytes = 256;
     void* base = nullptr;
     HIP_CHECK(hipMalloc(&base, kAllocBytes));
@@ -658,10 +643,6 @@ TEST_CASE("Unit_hipMemset_UnalignedKernelCornerCases", "[fillBuffer][unaligned]"
   }
 
   SECTION("Sub-pattern-misaligned VA returns hipError") {
-    // hipMalloc base is aligned >= 16. Offsetting by 1 gives an odd VA;
-    // calling hipMemsetD16 (patternSize=2) violates the precondition
-    // (VA + origin) % patternSize == 0 and must surface as a non-success
-    // hipError after the ihipMemset propagation fix in commit 1.
     void* base = nullptr;
     HIP_CHECK(hipMalloc(&base, 256));
     void* misaligned = static_cast<unsigned char*>(base) + 1;

--- a/projects/hip-tests/catch/unit/memory/hipMemsetFunctional.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemsetFunctional.cc
@@ -550,8 +550,6 @@ HIP_TEST_CASE(Unit_hipMemsetFunctional_PartialSet_3D) {
 }
 
 // Corner-case coverage for the __amd_rocclr_fillBufferUnAligned kernel rewrite.
-// These exercise the head/body/body_tile/body_tail/tail cleanup-region paths
-// that the rewrite changed behavior on, and the precondition error propagation.
 TEST_CASE("Unit_hipMemset_UnalignedKernelCornerCases", "[fillBuffer][unaligned]") {
   SECTION("Byte-misaligned hipHostRegister patternSize=1") {
     constexpr size_t kSlack = 64;
@@ -643,13 +641,57 @@ TEST_CASE("Unit_hipMemset_UnalignedKernelCornerCases", "[fillBuffer][unaligned]"
   }
 
   SECTION("Sub-pattern-misaligned VA returns hipError") {
+    hipError_t err = hipSuccess;
     void* base = nullptr;
     HIP_CHECK(hipMalloc(&base, 256));
-    void* misaligned = static_cast<unsigned char*>(base) + 1;
-    hipError_t err = hipMemsetD16(reinterpret_cast<hipDeviceptr_t>(misaligned),
-                                  0xBEEF, /*count=*/16);
-    CAPTURE(err);
-    HIP_ASSERT(err != hipSuccess);
+    hipStream_t stream{nullptr};
+    HIP_CHECK(hipStreamCreate(&stream));
+
+    {
+      // Test hipMemsetD16 with odd-aligned pointer (not 2-byte aligned)
+      void* misaligned16 = static_cast<unsigned char*>(base) + 1;
+      err = hipMemsetD16(reinterpret_cast<hipDeviceptr_t>(misaligned16),
+                                    0xBEEF, /*count=*/16);
+      CAPTURE(err);
+      HIP_ASSERT(err == hipErrorInvalidValue);
+      // Test hipMemsetD16Async with odd-aligned pointer (not 2-byte aligned)
+      err = hipMemsetD16Async(reinterpret_cast<hipDeviceptr_t>(misaligned16),
+                              0xBEEF, /*count=*/16, stream);
+      CAPTURE(err);
+      HIP_ASSERT(err == hipErrorInvalidValue);
+    }
+
+    {
+      // Test hipMemsetD32 with misaligned pointer (not 4-byte aligned)
+      // Test +1 offset (misaligned by 1 byte)
+      void* misaligned32_1 = static_cast<unsigned char*>(base) + 1;
+      err = hipMemsetD32(reinterpret_cast<hipDeviceptr_t>(misaligned32_1),
+                         0xDEADBEEF, /*count=*/16);
+      CAPTURE(err);
+      HIP_ASSERT(err == hipErrorInvalidValue);
+
+      // Test +2 offset (misaligned by 2 bytes)
+      void* misaligned32_2 = static_cast<unsigned char*>(base) + 2;
+      err = hipMemsetD32(reinterpret_cast<hipDeviceptr_t>(misaligned32_2),
+                         0xDEADBEEF, /*count=*/16);
+      CAPTURE(err);
+      HIP_ASSERT(err == hipErrorInvalidValue);
+
+      // Test +3 offset (misaligned by 3 bytes)
+      void* misaligned32_3 = static_cast<unsigned char*>(base) + 3;
+      err = hipMemsetD32(reinterpret_cast<hipDeviceptr_t>(misaligned32_3),
+                         0xDEADBEEF, /*count=*/16);
+      CAPTURE(err);
+      HIP_ASSERT(err == hipErrorInvalidValue);
+
+      // Test hipMemsetD32Async with misaligned pointer (not 4-byte aligned)
+      err = hipMemsetD32Async(reinterpret_cast<hipDeviceptr_t>(misaligned32_1),
+                              0xDEADBEEF, /*count=*/16, stream);
+      CAPTURE(err);
+      HIP_ASSERT(err == hipErrorInvalidValue);
+    }
+
+    HIP_CHECK(hipStreamDestroy(stream));
     HIP_CHECK(hipFree(base));
   }
 }


### PR DESCRIPTION
## Motivation

Currently we launch 3 kernels to handle unaligned memory set operations. This adds increased latency. 

## Technical Details

This PR moves us to use the new __amd_fillBufferUnAligned kernel added into deviceLibs [here](https://github.com/ROCm/llvm-project/pull/1780).  This provides improvements in hipMemset and hipMemsetAsync performance for unaligned kernels. Aligned kernel performance remains the same. rocSparse operations which use unaligned memset operations also achieve a speed up in performance. Results are below

**Unaligned results:**
<html xmlns:v="urn:schemas-microsoft-com:vml"
xmlns:o="urn:schemas-microsoft-com:office:office"
xmlns:x="urn:schemas-microsoft-com:office:excel"
xmlns="http://www.w3.org/TR/REC-html40">

<head>

<meta name=ProgId content=Excel.Sheet>
<meta name=Generator content="Microsoft Excel 15">
<link id=Main-File rel=Main-File
href="file:///C:/Users/abeltons/AppData/Local/Temp/msohtmlclip1/01/clip.htm">
<link rel=File-List
href="file:///C:/Users/abeltons/AppData/Local/Temp/msohtmlclip1/01/clip_filelist.xml">

<!--table
	{mso-displayed-decimal-separator:"\.";
	mso-displayed-thousand-separator:"\,";}
@page
	{mso-header-data:"&L&\0022Aptos\0022&10&K008000 \[Public\]&1\#\000D";
	margin:.75in .7in .75in .7in;
	mso-header-margin:.3in;
	mso-footer-margin:.3in;}
tr
	{mso-height-source:auto;}
col
	{mso-width-source:auto;}
br
	{mso-data-placement:same-cell;}
td
	{padding-top:1px;
	padding-right:1px;
	padding-left:1px;
	mso-ignore:padding;
	color:black;
	font-size:11.0pt;
	font-weight:400;
	font-style:normal;
	text-decoration:none;
	font-family:Arial, sans-serif;
	mso-font-charset:0;
	mso-number-format:General;
	text-align:general;
	vertical-align:bottom;
	border:none;
	mso-background-source:auto;
	mso-pattern:auto;
	mso-protection:locked visible;
	white-space:nowrap;
	mso-rotate:0;}
.xl65
	{font-weight:700;
	border:.5pt solid windowtext;}
.xl66
	{font-weight:700;
	border-top:.5pt solid windowtext;
	border-right:.5pt solid windowtext;
	border-bottom:none;
	border-left:.5pt solid windowtext;}
.xl67
	{font-weight:700;
	border-top:none;
	border-right:.5pt solid windowtext;
	border-bottom:none;
	border-left:.5pt solid windowtext;}
.xl68
	{border-top:.5pt solid windowtext;
	border-right:none;
	border-bottom:none;
	border-left:.5pt solid windowtext;}
.xl69
	{border-top:.5pt solid windowtext;
	border-right:.5pt solid windowtext;
	border-bottom:none;
	border-left:none;}
.xl70
	{border-top:none;
	border-right:none;
	border-bottom:none;
	border-left:.5pt solid windowtext;}
.xl71
	{border-top:none;
	border-right:.5pt solid windowtext;
	border-bottom:none;
	border-left:none;}
.xl72
	{font-weight:700;
	mso-number-format:0%;
	border-top:.5pt solid windowtext;
	border-right:none;
	border-bottom:none;
	border-left:.5pt solid windowtext;}
.xl73
	{font-weight:700;
	mso-number-format:0%;
	border-top:.5pt solid windowtext;
	border-right:.5pt solid windowtext;
	border-bottom:none;
	border-left:none;}
.xl74
	{font-weight:700;
	mso-number-format:0%;
	border-top:none;
	border-right:none;
	border-bottom:none;
	border-left:.5pt solid windowtext;}
.xl75
	{font-weight:700;
	mso-number-format:0%;
	border-top:none;
	border-right:.5pt solid windowtext;
	border-bottom:none;
	border-left:none;}
-->

</head>

<body link="#467886" vlink="#96607D">


  | Develop |   | UnalignedKernel |   | Percentage   Change |  
-- | -- | -- | -- | -- | -- | --
Size (fp32 elements) | Time (ns) | Throughput (GiB/s) | Time (ns) | Throughput (GiB/s) | Time (- is better) | Throughput (+ is   better)
512 | 7857 | 0.242758 | 4550 | 0.419198 | -42% | 73%
4096 | 8606 | 1.77304 | 4607 | 3.31209 | -46% | 87%
32768 | 8731 | 13.9813 | 4206 | 29.0229 | -52% | 108%
262144 | 8682 | 112.481 | 4159 | 234.807 | -52% | 109%
2097152 | 8587 | 909.806 | 4748 | 1645.43 | -45% | 81%
16777216 | 15882 | 3935.27 | 11998 | 5209.2 | -24% | 32%
134217728 | 115994 | 4310.57 | 112568 | 4441.76 | -3% | 3%
</body>
</html>

rocsparse improvements:
<html xmlns:v="urn:schemas-microsoft-com:vml"
xmlns:o="urn:schemas-microsoft-com:office:office"
xmlns:x="urn:schemas-microsoft-com:office:excel"
xmlns="http://www.w3.org/TR/REC-html40">

<head>

<meta name=ProgId content=Excel.Sheet>
<meta name=Generator content="Microsoft Excel 15">
<link id=Main-File rel=Main-File
href="file:///C:/Users/abeltons/AppData/Local/Temp/msohtmlclip1/01/clip.htm">
<link rel=File-List
href="file:///C:/Users/abeltons/AppData/Local/Temp/msohtmlclip1/01/clip_filelist.xml">

<!--table
	{mso-displayed-decimal-separator:"\.";
	mso-displayed-thousand-separator:"\,";}
@page
	{margin:.75in .7in .75in .7in;
	mso-header-margin:.3in;
	mso-footer-margin:.3in;}
tr
	{mso-height-source:auto;}
col
	{mso-width-source:auto;}
br
	{mso-data-placement:same-cell;}
td
	{padding-top:1px;
	padding-right:1px;
	padding-left:1px;
	mso-ignore:padding;
	color:black;
	font-size:11.0pt;
	font-weight:400;
	font-style:normal;
	text-decoration:none;
	font-family:Arial, sans-serif;
	mso-font-charset:0;
	mso-number-format:General;
	text-align:general;
	vertical-align:bottom;
	border:none;
	mso-background-source:auto;
	mso-pattern:auto;
	mso-protection:locked visible;
	white-space:nowrap;
	mso-rotate:0;}
.xl63
	{border:.5pt solid windowtext;}
.xl64
	{border-top:.5pt solid windowtext;
	border-right:none;
	border-bottom:none;
	border-left:.5pt solid windowtext;}
.xl65
	{border-top:.5pt solid windowtext;
	border-right:none;
	border-bottom:none;
	border-left:none;}
.xl66
	{mso-number-format:"0\.0%";
	border-top:.5pt solid windowtext;
	border-right:.5pt solid windowtext;
	border-bottom:none;
	border-left:none;}
.xl67
	{border-top:none;
	border-right:none;
	border-bottom:none;
	border-left:.5pt solid windowtext;}
.xl68
	{mso-number-format:"0\.0%";
	border-top:none;
	border-right:.5pt solid windowtext;
	border-bottom:none;
	border-left:none;}
.xl69
	{border-top:none;
	border-right:none;
	border-bottom:.5pt solid windowtext;
	border-left:.5pt solid windowtext;}
.xl70
	{border-top:none;
	border-right:none;
	border-bottom:.5pt solid windowtext;
	border-left:none;}
.xl71
	{mso-number-format:"0\.0%";
	border-top:none;
	border-right:.5pt solid windowtext;
	border-bottom:.5pt solid windowtext;
	border-left:none;}
-->

</head>

<body link="#467886" vlink="#96607D">


  | Develop | Unaligned Kernel |  
-- | -- | -- | --
  | Gflops/S | Gflops/S | % Change
webbase | 162.15 | 236.98 | 31.6%
mc2depi | 171.16 | 218.25 | 21.6%
scircuit | 170.06 | 211.27 | 19.5%
mac_econ | 168.85 | 204.85 | 17.6%
pwtk | 306.58 | 317.73 | 3.5%
shipsec | 299.55 | 309.86 | 3.3%
consph | 291.04 | 301.11 | 3.3%



</body>

</html>

Resolves -AIRUNTIME-124

## Test Result

Passes locally

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
