### PR TITLE
[rocprofiler-systems] Deprecate rocprof-sys user API

### DIFF
--- a/projects/rocprofiler-systems/docs/conceptual/data-collection-modes.rst
+++ b/projects/rocprofiler-systems/docs/conceptual/data-collection-modes.rst
@@ -30,7 +30,7 @@ ROCm Systems Profiler supports several modes of recording trace and profiling da
 |                             | dynamic library/executable, like ``pthread_mutex_lock`` |
 |                             | in ``libpthread.so`` or ``MPI_Init`` in the MPI library |
 +-----------------------------+---------------------------------------------------------+
-| User API                    | User-defined regions and controls for User API ROCm     |
+| User API (deprecated)       | User-defined regions and controls for User API ROCm     |
 |                             | Systems Profiler                                        |
 +-----------------------------+---------------------------------------------------------+
 

--- a/projects/rocprofiler-systems/docs/how-to/using-rocprof-sys-api.rst
+++ b/projects/rocprofiler-systems/docs/how-to/using-rocprof-sys-api.rst
@@ -8,7 +8,7 @@ Using the ROCm Systems Profiler API
 
 .. deprecated::
    The ROCm Systems Profiler user API is deprecated and will be removed in a future release.
-   Use the `ROCTx Markers <https://rocm.docs.amd.com/projects/rocprofiler-sdk/en/latest/_doxygen/roctx/html/group__marker__group.html>`_
+   Use the `ROCTx Markers <https://rocm.docs.amd.com/projects/rocprofiler-sdk/en/latest/how-to/using-rocprofiler-sdk-roctx.html>`_
    instrumentation instead for runtime profiling and tracing.
 
 The following example shows how a program can use the ROCm Systems Profiler API

--- a/projects/rocprofiler-systems/docs/how-to/using-rocprof-sys-api.rst
+++ b/projects/rocprofiler-systems/docs/how-to/using-rocprof-sys-api.rst
@@ -6,6 +6,11 @@
 Using the ROCm Systems Profiler API
 ****************************************************
 
+.. deprecated::
+   The ROCm Systems Profiler user API is deprecated and will be removed in a future release.
+   Use the `ROCTx Markers <https://rocm.docs.amd.com/projects/rocprofiler-sdk/en/latest/_doxygen/roctx/html/group__marker__group.html>`_
+   instrumentation instead for runtime profiling and tracing.
+
 The following example shows how a program can use the ROCm Systems Profiler API
 for run-time analysis.
 

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys-user/user.cpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys-user/user.cpp
@@ -111,7 +111,7 @@ extern "C"
     {
         fprintf(stderr,
                 "[rocprof-sys][warning] The rocprof-sys-user library is deprecated and "
-                "will be removed in a future release. Use rocprofiler-sdk instead.\n");
+                "will be removed in a future release. Use rocprofiler-sdk-roctx instead.\n");
         auto _former = _callbacks;
 
         switch(mode)

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys-user/user.cpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys-user/user.cpp
@@ -111,7 +111,8 @@ extern "C"
     {
         fprintf(stderr,
                 "[rocprof-sys][warning] The rocprof-sys-user library is deprecated and "
-                "will be removed in a future release. Use rocprofiler-sdk-roctx instead.\n");
+                "will be removed in a future release. Use rocprofiler-sdk-roctx "
+                "instead.\n");
         auto _former = _callbacks;
 
         switch(mode)

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys-user/user.cpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys-user/user.cpp
@@ -109,6 +109,9 @@ extern "C"
                                   rocprofsys_user_callbacks_t      inp,
                                   rocprofsys_user_callbacks_t*     out)
     {
+        fprintf(stderr,
+                "[rocprof-sys][warning] The rocprof-sys-user library is deprecated and "
+                "will be removed in a future release. Use rocprofiler-sdk instead.\n");
         auto _former = _callbacks;
 
         switch(mode)


### PR DESCRIPTION
## Motivation

The rocprof-sys user API is superseded by ROCTx Markers from rocprofiler-sdk. This PR marks the user API as deprecated across documentation and runtime to guide users toward the modern replacement before eventual removal.

## Technical Details

- Adds a `.. deprecated::` directive to `using-rocprof-sys-api.rst` pointing users to ROCTx Markers from rocprofiler-sdk.
- Marks "User API" as "(deprecated)" in the data-collection-modes.rst feature table.
- Emits a deprecation warning to stderr via `fprintf` when `rocprofsys_user_configure` is called at runtime in `user.cpp`.

## JIRA ID

AIPROFSYST-325

## Test Plan

- Build the project and verify the documentation renders the deprecation notice correctly in the RST output.
- Write and run a small program that calls `rocprofsys_user_configure` and verify the deprecation warning is printed to stderr.
- Confirm existing tests still pass (the warning is informational and does not change behavior).

## Test Result

- Documentation pages should show the deprecation notice and link to ROCTx Markers.
- Any program invoking `rocprofsys_user_configure` should print: `[rocprof-sys][warning] The rocprof-sys-user library is deprecated and will be removed in a future release. Use rocprofiler-sdk instead.`
- All existing tests should continue to pass with no functional regressions.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
