### PR TITLE
[rocprofiler-compute] Pin gersemi version in github workflow to match that of pre commit

### DIFF
--- a/.github/workflows/rocprofiler-compute-formatting.yml
+++ b/.github/workflows/rocprofiler-compute-formatting.yml
@@ -74,7 +74,7 @@ jobs:
       run: |
         sudo apt-get update
         sudo apt-get install -y python3-pip
-        python3 -m pip install gersemi
+        python3 -m pip install gersemi==0.22.1
     - name: gersemi
       working-directory: projects/rocprofiler-compute
       run: |

--- a/projects/rocprofiler-compute/CMakeLists.txt
+++ b/projects/rocprofiler-compute/CMakeLists.txt
@@ -24,7 +24,8 @@ file(READ "${CMAKE_CURRENT_SOURCE_DIR}/VERSION" FULL_VERSION_STRING LIMIT_COUNT 
 string(REGEX REPLACE "(\n|\r)" "" FULL_VERSION_STRING "${FULL_VERSION_STRING}")
 set(ROCPROFCOMPUTE_FULL_VERSION "${FULL_VERSION_STRING}")
 string(
-    REGEX REPLACE "([0-9]+)\.([0-9]+)\.([0-9]+)(.*)"
+    REGEX REPLACE
+    "([0-9]+)\.([0-9]+)\.([0-9]+)(.*)"
     "\\1.\\2.\\3"
     ROCPROFCOMPUTE_VERSION
     "${FULL_VERSION_STRING}"
@@ -190,7 +191,7 @@ if(LOCALHOST MATCHES "TheraS01|.*\.thera\.amd\.com|thera-hn")
     file(READ ${PROJECT_SOURCE_DIR}/cmake/modfile.thera.mod mod_additions)
     file(
         APPEND
-            ${PROJECT_BINARY_DIR}/${MOD_INSTALL_PATH}/${ROCPROFCOMPUTE_FULL_VERSION}.lua
+        ${PROJECT_BINARY_DIR}/${MOD_INSTALL_PATH}/${ROCPROFCOMPUTE_FULL_VERSION}.lua
         ${mod_additions}
     )
     list(POP_BACK CMAKE_MESSAGE_INDENT)
@@ -627,7 +628,8 @@ install(
         src/config.py
         src/rocprof_compute_base.py
         src/roofline.py
-        VERSION VERSION.sha
+        VERSION
+        VERSION.sha
     DESTINATION ${CMAKE_INSTALL_LIBEXECDIR}/${PROJECT_NAME}
     COMPONENT main
 )


### PR DESCRIPTION
## Motivation

Pin gersemi version in github workflow to match that of pre commit

We want to use gersemi 0.22.1 for rocprofiler-compute formatting checks

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

Pin gersemi version in github workflow to match that of pre commit, that is 0.22.0

<!-- Explain the changes along with any relevant GitHub links. -->

## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan

Ensure gersemi pass

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

Ensure gersemi pass

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
