### PR TITLE
[TheRock CI] Update therock_matrix.py to introduce new profiler mappings

### DIFF
--- a/.github/scripts/therock_matrix.py
+++ b/.github/scripts/therock_matrix.py
@@ -3,7 +3,7 @@ This dictionary is used to map specific file directory changes to the correspond
 """
 subtree_to_project_map = {
     "projects/amdsmi": "core",
-    "projects/aqlprofile": "profiler",
+    "projects/aqlprofile": "profiler-core",
     "projects/clr": "core",
     "projects/cuid": "rdc",
     "projects/hip": "core",
@@ -17,15 +17,14 @@ subtree_to_project_map = {
     "projects/rocm-smi-lib": "core",
     "projects/rocminfo": "core",
     "projects/rocm-smi-lib": "core",
-    "projects/rocprofiler": "profiler",
-    "projects/rocprofiler-compute": "profiler",
-    "projects/rocprofiler-register": "profiler",
-    "projects/rocprofiler-sdk": "profiler",
-    "projects/rocprofiler-systems": "profiler",
-    "projects/rocprofiler": "profiler",
+    "projects/rocprofiler": "profiler-core",
+    "projects/rocprofiler-compute": "profiler-compute",
+    "projects/rocprofiler-register": "profiler-core",
+    "projects/rocprofiler-sdk": "profiler-core",
+    "projects/rocprofiler-systems": "profiler-systems",
     "projects/rocr-debug-agent": "debug_tools",
     "projects/rocr-runtime": "core",
-    "projects/roctracer": "profiler",
+    "projects/roctracer": "profiler-core",
 }
 
 project_map = {
@@ -33,9 +32,17 @@ project_map = {
         "cmake_options": "-DTHEROCK_ENABLE_ALL=ON",
         "projects_to_test": "hip-tests, rocrtst",
     },
-    "profiler": {
+    "profiler-core": {
         "cmake_options": "-DTHEROCK_ENABLE_ALL=ON",
-        "projects_to_test": "aqlprofile, rocprofiler-compute, rocprofiler_systems",
+        "projects_to_test": "aqlprofile",
+    },
+    "profiler-compute": {
+        "cmake_options": "-DTHEROCK_ENABLE_ALL=ON",
+        "projects_to_test": "rocprofiler-compute",
+    },
+    "profiler-systems": {
+        "cmake_options": "-DTHEROCK_ENABLE_ALL=ON",
+        "projects_to_test": "rocprofiler_systems",
     },
     # media libs to be enabled in following PR
     # "media-libs": {


### PR DESCRIPTION
## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->
Currently, there is only a single `profiler` mapping that is used for changes to all profiler components.
We noticed that for rocprofiler-compute changes, it will run tests for all profiler components. However, changes to compute should not impact sdk/aqlprofile/rocprofiler-systems behaviour.

The plan would be to separate rocprofiler-systems and rocprofiler-compute from the core profiler dependencies. That way, when source code is changed for rocprofiler-systems or rocprofiler-compute, only tests for their own projects will be ran. Additionally, we want just the minimal build needed for both systems and compute tests to function.


## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->
- Updated `therock_matrix.py` to include new profiler mappings
  - Removed `profiler` mapping and replaced it with three different mappings
    - `profiler-core`
      - Runs tests for aqlprofile, rocprofiler-sdk (once added)
    - `profiler-compute`
      - Runs tests for rocprofiler-compute
    - `profiler-systems`
      - Runs tests for rocprofiler-systems
- Removed duplicate entry for `rocprofiler` in `therock_matrix.py`

## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->
Verify that TheRock CI handles the new mappings as expected, tests pass

## Test Result

<!-- Briefly summarize test outcomes. -->
TBA

## Submission Checklist

- [X] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
