### PR TITLE
[rocprofiler-compute] Roofline: Use gfx950 builtins for MFMA

### DIFF
--- a/projects/rocprofiler-compute/CHANGELOG.md
+++ b/projects/rocprofiler-compute/CHANGELOG.md
@@ -55,6 +55,8 @@ Full documentation for ROCm Compute Profiler is available at [https://rocm.docs.
     * Processes attempting to benchmark on the same GPU will wait with user-visible feedback and execute sequentially.
     * Lock applies specifically to the roofline.csv file generated during benchmarking, not other files generated in profile mode.
 
+* Added proper support for `gfx950` in roofline benchmark.
+
 * Missing metric descriptions for gfx950 and gfx942 architecture.
 
 * Added `--membw-analysis` under experimental features to allow memory bandwidth specific profiling and analysis with metric block 30.

--- a/projects/rocprofiler-compute/CHANGELOG.md
+++ b/projects/rocprofiler-compute/CHANGELOG.md
@@ -16,6 +16,8 @@ Full documentation for ROCm Compute Profiler is available at [https://rocm.docs.
 
 ### Resolved issues
 
+* Fixed roofline benchmark MFMA FP16/BF16/INT8 peaks for MI 350
+
 ### Upcoming changes
 
 ## ROCm Compute Profiler 3.5.0 for ROCm 7.12.0
@@ -54,8 +56,6 @@ Full documentation for ROCm Compute Profiler is available at [https://rocm.docs.
     * Multiple `rocprof-compute` processes can safely profile on different GPUs in parallel.
     * Processes attempting to benchmark on the same GPU will wait with user-visible feedback and execute sequentially.
     * Lock applies specifically to the roofline.csv file generated during benchmarking, not other files generated in profile mode.
-
-* Added proper support for `gfx950` in roofline benchmark.
 
 * Missing metric descriptions for gfx950 and gfx942 architecture.
 

--- a/projects/rocprofiler-compute/src/utils/benchmark.py
+++ b/projects/rocprofiler-compute/src/utils/benchmark.py
@@ -1,7 +1,7 @@
 ##############################################################################
 # MIT License
 #
-# Copyright (c) 2025 Advanced Micro Devices, Inc. All Rights Reserved.
+# Copyright (c) 2026 Advanced Micro Devices, Inc. All Rights Reserved.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal

--- a/projects/rocprofiler-compute/src/utils/benchmark.py
+++ b/projects/rocprofiler-compute/src/utils/benchmark.py
@@ -147,8 +147,8 @@ mfma_ops = {
     "F32": dict.fromkeys(
         ["gfx908", "gfx90a", "gfx940", "gfx941", "gfx942", "gfx950"], 4096
     ),
-    "BF16": dict.fromkeys(["gfx940", "gfx941", "gfx942", "gfx950"], 16384)
-    | dict.fromkeys(["gfx90a"], 8192),
+    "BF16": dict.fromkeys(["gfx940", "gfx941", "gfx942"], 16384)
+    | dict.fromkeys(["gfx90a"], 8192) | dict.fromkeys(["gfx950"], 32768),
     "I8": dict.fromkeys(["gfx940", "gfx941", "gfx942", "gfx950"], 32768)
     | dict.fromkeys(["gfx90a"], 16384),
     "F64": dict.fromkeys(["gfx90a", "gfx940", "gfx941", "gfx942", "gfx950"], 2048),
@@ -785,7 +785,7 @@ extern "C" __global__ void mfma_bf16(int iter, float *dummy)
     vec16<float> result = {0};
 
 // MI100/MI200
-#if defined(__gfx908__) or defined(__gfx90a__)
+#if defined(__gfx908__) || defined(__gfx90a__)
     vec2<short> a;
     a[1] = a[0]= threadIdx.x;
 
@@ -794,7 +794,7 @@ extern "C" __global__ void mfma_bf16(int iter, float *dummy)
         result = __builtin_amdgcn_mfma_f32_32x32x4bf16(a, a, result, 0, 0, 0);
     }
 //MI300 series
-#else
+#elif defined(__gfx940__) || defined(__gfx941__) || defined(__gfx942__)
     vec4<short> a;
     a[3] = a[2] = a[1] = a[0] = threadIdx.x;
 
@@ -802,6 +802,16 @@ extern "C" __global__ void mfma_bf16(int iter, float *dummy)
     {
         result = __builtin_amdgcn_mfma_f32_32x32x8bf16_1k(a, a, result, 0, 0, 0);
     }
+#elif defined(__gfx950__)
+    vec8<short> a;
+    a[3] = a[2] = a[1] = a[0] = threadIdx.x;
+
+    for(int i = 0; i < iter; ++i)
+    {
+        result = __builtin_amdgcn_mfma_f32_32x32x16_bf16(a, a, result, 0, 0, 0);
+    }
+#else
+#error "Unsupported gfx arch"
 #endif
 
     if (result[0] != 2*result[0])
@@ -844,7 +854,7 @@ extern "C" __global__ void mfma_i8(int iter, float *dummy)
     vec16<int> result = {0};
 
 // MI100/MI200
-#if defined(__gfx908__) or defined(__gfx90a__)
+#if defined(__gfx908__) || defined(__gfx90a__)
     int a = threadIdx.x;
 
     for(int i = 0; i < iter; ++i)

--- a/projects/rocprofiler-compute/src/utils/benchmark.py
+++ b/projects/rocprofiler-compute/src/utils/benchmark.py
@@ -756,7 +756,7 @@ extern "C" __global__ void mfma_f16(int iter, float *dummy)
 #if defined(__gfx908__) || defined(__gfx90a__) || defined(__gfx940__) || \
     defined(__gfx941__) || defined(__gfx942__)
     vec4<__fp16> a;
-    a[1] = a[0] = threadIdx.x;
+    a[3] = a[2] = a[1] = a[0] = threadIdx.x;
     for(int i = 0; i < iter; ++i)
     {
         result = __builtin_amdgcn_mfma_f32_32x32x8f16(a, a, result, 0, 0, 0);

--- a/projects/rocprofiler-compute/src/utils/benchmark.py
+++ b/projects/rocprofiler-compute/src/utils/benchmark.py
@@ -726,7 +726,7 @@ mfma_f32_src = (
 
 extern "C" __global__ void mfma_f32(int iter, float *dummy)
 {
-    float a =  threadIdx.x;
+    float a = threadIdx.x;
     vec16<float> result = {0};
 
     for(int i = 0; i < iter; ++i)
@@ -750,7 +750,6 @@ mfma_f16_src = (
 extern "C" __global__ void mfma_f16(int iter, float *dummy)
 {
     vec16<float> result = {0};
-
 #if defined(__gfx908__) || defined(__gfx90a__) || defined(__gfx940__) || defined(__gfx941__) || defined(__gfx942___)
     vec4<__fp16> a;
     a[1] = a[0] = threadIdx.x;
@@ -794,7 +793,7 @@ extern "C" __global__ void mfma_bf16(int iter, float *dummy)
     {
         result = __builtin_amdgcn_mfma_f32_32x32x4bf16(a, a, result, 0, 0, 0);
     }
-//MI300 series
+// MI300 series
 #elif defined(__gfx940__) || defined(__gfx941__) || defined(__gfx942__)
     vec4<short> a;
     a[3] = a[2] = a[1] = a[0] = threadIdx.x;
@@ -803,6 +802,7 @@ extern "C" __global__ void mfma_bf16(int iter, float *dummy)
     {
         result = __builtin_amdgcn_mfma_f32_32x32x8bf16_1k(a, a, result, 0, 0, 0);
     }
+// MI350
 #elif defined(__gfx950__)
     vec8<short> a;
     a[7] = a[6] = a[5] = a[4] = a[3] = a[2] = a[1] = a[0] = threadIdx.x;
@@ -870,6 +870,7 @@ extern "C" __global__ void mfma_i8(int iter, float *dummy)
     {
         result = __builtin_amdgcn_mfma_i32_32x32x16_i8(a, a, result, 0, 0, 0);
     }
+// MI350 series
 #elif defined(__gfx950__)
     vec2<long> a;
     a[1] = a[0] = threadIdx.x;

--- a/projects/rocprofiler-compute/src/utils/benchmark.py
+++ b/projects/rocprofiler-compute/src/utils/benchmark.py
@@ -149,8 +149,8 @@ mfma_ops = {
     ),
     "BF16": dict.fromkeys(["gfx940", "gfx941", "gfx942"], 16384)
     | dict.fromkeys(["gfx90a"], 8192) | dict.fromkeys(["gfx950"], 32768),
-    "I8": dict.fromkeys(["gfx940", "gfx941", "gfx942", "gfx950"], 32768)
-    | dict.fromkeys(["gfx90a"], 16384),
+    "I8": dict.fromkeys(["gfx940", "gfx941", "gfx942"], 32768)
+    | dict.fromkeys(["gfx90a"], 16384) | dict.fromkeys(["gfx950"], 65536),
     "F64": dict.fromkeys(["gfx90a", "gfx940", "gfx941", "gfx942", "gfx950"], 2048),
 }
 
@@ -760,6 +760,7 @@ extern "C" __global__ void mfma_f16(int iter, float *dummy)
     }
 #elif defined(__gfx950__)
     vec8<__fp16> a;
+    a[7] = a[6] = a[5] = a[4] = a[3] = a[2] = a[1] = a[0] = threadIdx.x;
     for(int i = 0; i < iter; ++i)
     {
         result = __builtin_amdgcn_mfma_f32_32x32x16_f16(a, a, result, 0, 0, 0);
@@ -804,7 +805,7 @@ extern "C" __global__ void mfma_bf16(int iter, float *dummy)
     }
 #elif defined(__gfx950__)
     vec8<short> a;
-    a[3] = a[2] = a[1] = a[0] = threadIdx.x;
+    a[7] = a[6] = a[5] = a[4] = a[3] = a[2] = a[1] = a[0] = threadIdx.x;
 
     for(int i = 0; i < iter; ++i)
     {
@@ -862,13 +863,23 @@ extern "C" __global__ void mfma_i8(int iter, float *dummy)
         result = __builtin_amdgcn_mfma_i32_32x32x8i8(a, a, result, 0, 0, 0);
     }
 // MI300 series
-#else
+#elif defined(__gfx940__) || defined(__gfx941__) || defined(__gfx942__)
     long a =  threadIdx.x;
 
     for(int i = 0; i < iter; ++i)
     {
         result = __builtin_amdgcn_mfma_i32_32x32x16_i8(a, a, result, 0, 0, 0);
     }
+#elif defined(__gfx950__)
+    vec2<long> a;
+    a[1] = a[0] = threadIdx.x;
+
+    for(int i = 0; i < iter; ++i)
+    {
+        result = __builtin_amdgcn_mfma_i32_32x32x32_i8(a, a, result, 0, 0, 0);
+    }
+#else
+#error "Unsupported gfx arch"
 #endif
 
     if (result[0] != 2*result[0])

--- a/projects/rocprofiler-compute/src/utils/benchmark.py
+++ b/projects/rocprofiler-compute/src/utils/benchmark.py
@@ -143,7 +143,7 @@ mfma_ops = {
     "F6": {"gfx950": 131072},
     "F6F4": {"gfx950": 131072},  # Mixed precision F6 x F4
     "F8": dict.fromkeys(["gfx90a", "gfx940", "gfx941", "gfx942", "gfx950"], 32768),
-    "F16": dict.fromkeys(["gfx90a", "gfx940", "gfx941", "gfx942", "gfx950"], 16384),
+    "F16": dict.fromkeys(["gfx90a", "gfx940", "gfx941", "gfx942"], 16384) | dict.fromkeys(["gfx950"], 32768),
     "F32": dict.fromkeys(
         ["gfx908", "gfx90a", "gfx940", "gfx941", "gfx942", "gfx950"], 4096
     ),
@@ -749,15 +749,24 @@ mfma_f16_src = (
 
 extern "C" __global__ void mfma_f16(int iter, float *dummy)
 {
-    vec4<__fp16> a;
-    a[1] = a[0] = threadIdx.x;
-    
     vec16<float> result = {0};
 
+#if defined(__gfx908__) || defined(__gfx90a__) || defined(__gfx940__) || defined(__gfx941__) || defined(__gfx942___)
+    vec4<__fp16> a;
+    a[1] = a[0] = threadIdx.x;
     for(int i = 0; i < iter; ++i)
     {
         result = __builtin_amdgcn_mfma_f32_32x32x8f16(a, a, result, 0, 0, 0);
     }
+#elif defined(__gfx950__)
+    vec8<__fp16> a;
+    for(int i = 0; i < iter; ++i)
+    {
+        result = __builtin_amdgcn_mfma_f32_32x32x16_f16(a, a, result, 0, 0, 0);
+    }
+#else
+#error "Unsupported gfx arch"
+#endif
 
     if (result[0] != 2*result[0])
     {

--- a/projects/rocprofiler-compute/src/utils/benchmark.py
+++ b/projects/rocprofiler-compute/src/utils/benchmark.py
@@ -1,7 +1,7 @@
 ##############################################################################
 # MIT License
 #
-# Copyright (c) 2026 Advanced Micro Devices, Inc. All Rights Reserved.
+# Copyright (c) 2025 - 2026 Advanced Micro Devices, Inc. All Rights Reserved.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -753,7 +753,8 @@ mfma_f16_src = (
 extern "C" __global__ void mfma_f16(int iter, float *dummy)
 {
     vec16<float> result = {0};
-#if defined(__gfx908__) || defined(__gfx90a__) || defined(__gfx940__) || defined(__gfx941__) || defined(__gfx942___)
+#if defined(__gfx908__) || defined(__gfx90a__) || defined(__gfx940__) || \
+    defined(__gfx941__) || defined(__gfx942__)
     vec4<__fp16> a;
     a[1] = a[0] = threadIdx.x;
     for(int i = 0; i < iter; ++i)

--- a/projects/rocprofiler-compute/src/utils/benchmark.py
+++ b/projects/rocprofiler-compute/src/utils/benchmark.py
@@ -143,14 +143,17 @@ mfma_ops = {
     "F6": {"gfx950": 131072},
     "F6F4": {"gfx950": 131072},  # Mixed precision F6 x F4
     "F8": dict.fromkeys(["gfx90a", "gfx940", "gfx941", "gfx942", "gfx950"], 32768),
-    "F16": dict.fromkeys(["gfx90a", "gfx940", "gfx941", "gfx942"], 16384) | dict.fromkeys(["gfx950"], 32768),
+    "F16": dict.fromkeys(["gfx90a", "gfx940", "gfx941", "gfx942"], 16384)
+    | dict.fromkeys(["gfx950"], 32768),
     "F32": dict.fromkeys(
         ["gfx908", "gfx90a", "gfx940", "gfx941", "gfx942", "gfx950"], 4096
     ),
     "BF16": dict.fromkeys(["gfx940", "gfx941", "gfx942"], 16384)
-    | dict.fromkeys(["gfx90a"], 8192) | dict.fromkeys(["gfx950"], 32768),
+    | dict.fromkeys(["gfx90a"], 8192)
+    | dict.fromkeys(["gfx950"], 32768),
     "I8": dict.fromkeys(["gfx940", "gfx941", "gfx942"], 32768)
-    | dict.fromkeys(["gfx90a"], 16384) | dict.fromkeys(["gfx950"], 65536),
+    | dict.fromkeys(["gfx90a"], 16384)
+    | dict.fromkeys(["gfx950"], 65536),
     "F64": dict.fromkeys(["gfx90a", "gfx940", "gfx941", "gfx942", "gfx950"], 2048),
 }
 


### PR DESCRIPTION
## Motivation

Resolves https://github.com/ROCm/rocm-systems/issues/3506

MFMA tests for F16, BF16, and I8 were far below spec on gfx950.

Copy of https://github.com/ROCm/rocm-systems/pull/3837 to remove unintended rccl changes being merged.
Original author @benrichard-amd 

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

* `gfx950` introduced new MFMA instructions with higher throughput for F16, BF16 and I8. Use the builtins for these on `gfx950`.

|type|peak|actual|
|---|---|---|
|FP16|2.3 PFLOPS|1.8 PFLOPS|
|BF16|2.3 PFLOPS|2.0 PFLOPS|
|I8|4.6 POPS|4.2POPS|

<!-- Explain the changes along with any relevant GitHub links. -->

## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan

* Run roofline on MI350. Verify expected performance improvement.
* Verify reported MI350 TFLOPs using rocprof-compute.
* Run roofline on MI100/MI250/MI300. Verify works as expected.

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
