### PR TITLE
[rocprofiler-compute] Move roofline html from profile to analyze mode and remove roofline calc duplication

### DIFF
--- a/projects/rocprofiler-compute/CHANGELOG.md
+++ b/projects/rocprofiler-compute/CHANGELOG.md
@@ -8,6 +8,9 @@ Full documentation for ROCm Compute Profiler is available at [https://rocm.docs.
 
 ### Changed
 
+* Standalone roofline (`--roof-only` option) in profile mode now creates `roofline.csv` only. HTML roofline charts are generated via `rocprof-compute analyze`. The `calc_ai_profile()` function has been removed; `calc_ai_analyze()` is the single source of truth for arithmetic intensity calculation.
+  * Roofline visualization options (`--sort`, `--mem-level`, `--roofline-data-type`) have moved from profile mode to analyze mode.
+
 * Standardized unit naming in analysis configs and Python utilities: `pct`/`Pct` → `Percent`, `instr` → `Instructions`.
 
 ### Removed
@@ -115,11 +118,6 @@ Full documentation for ROCm Compute Profiler is available at [https://rocm.docs.
 ### Upcoming changes
 
 * ``--path`` and ``--subpath`` options have been deprecated in favor of ``--output-directory`` and will be removed in a future release.
-
-### Upcoming changes
-
-* Move Roofline visualization to analysis mode
-    * Roofline plot files will no longer be generated in profiling mode; Roofline plots will be generated automatically when user runs analysis on a workload. A deprecation warning has been added during profiling mode to notify users of this change.
 
 ## ROCm Compute Profiler 3.4.0 for ROCm 7.2.0
 

--- a/projects/rocprofiler-compute/CHANGELOG.md
+++ b/projects/rocprofiler-compute/CHANGELOG.md
@@ -119,6 +119,11 @@ Full documentation for ROCm Compute Profiler is available at [https://rocm.docs.
 
 * ``--path`` and ``--subpath`` options have been deprecated in favor of ``--output-directory`` and will be removed in a future release.
 
+### Upcoming changes
+
+* Move Roofline visualization to analysis mode
+    * Roofline plot files will no longer be generated in profiling mode; Roofline plots will be generated automatically when user runs analysis on a workload. A deprecation warning has been added during profiling mode to notify users of this change.
+
 ## ROCm Compute Profiler 3.4.0 for ROCm 7.2.0
 
 ### Added

--- a/projects/rocprofiler-compute/CMakeLists.txt
+++ b/projects/rocprofiler-compute/CMakeLists.txt
@@ -312,14 +312,6 @@ add_test(
 )
 
 add_test(
-    NAME test_profile_mem
-    COMMAND
-        ${PYTHON_TEST_COMMAND} -m pytest ${STANDALONEBINARY_TEST_OPTION} -m mem
-        --junitxml=tests/test_profile_mem.xml ${COV_OPTION} tests/test_profile_general.py
-        ${WORKING_DIR_OPTION}
-)
-
-add_test(
     NAME test_profile_join
     COMMAND
         ${PYTHON_TEST_COMMAND} -m pytest ${STANDALONEBINARY_TEST_OPTION} -m join
@@ -455,7 +447,6 @@ add_test(
 set_tests_properties(
     test_profile_kernel_execution
     test_profile_dispatch
-    test_profile_mem
     test_profile_join
     test_profile_sort
     test_profile_misc
@@ -603,7 +594,6 @@ if(${ENABLE_COVERAGE})
     set(ALL_TEST_NAMES
         test_profile_kernel_execution
         test_profile_dispatch
-        test_profile_mem
         test_profile_join
         test_profile_sort
         test_profile_misc

--- a/projects/rocprofiler-compute/docs/how-to/analyze/cli.rst
+++ b/projects/rocprofiler-compute/docs/how-to/analyze/cli.rst
@@ -18,6 +18,8 @@ This section provides an overview of ROCm Compute Profiler's CLI analysis featur
 
 * :ref:`Per-kernel roofline analysis <per-kernel-roofline>`: Detailed arithmetic intensity and performance analysis for individual kernels.
 
+* :ref:`Roofline HTML generation <roofline-html-generation>`: Generate interactive HTML roofline charts from profiling data.
+
 Run ``rocprof-compute analyze -h`` for more details.
 
 .. _cli-walkthrough:
@@ -474,6 +476,36 @@ Analyze multiple kernels for comparison:
 .. code-block:: shell-session
 
    $ rocprof-compute analyze -p workloads/vcopy/MI200/ -k 0 1 2 -b 4
+
+.. _roofline-html-generation:
+
+**Roofline HTML generation**
+
+Roofline HTML plots are generated during analyze mode. Profile mode creates
+``roofline.csv`` containing microbenchmark data, and analyze mode uses this
+data to produce interactive HTML roofline charts.
+
+Two-step workflow:
+
+.. code-block:: shell-session
+
+   # Step 1: Profile to generate roofline.csv
+   $ rocprof-compute profile --name vcopy --roof-only -- tests/vcopy -n 1048576 -b 256
+
+   # Step 2: Analyze to generate HTML roofline plots
+   $ rocprof-compute analyze -p workloads/vcopy/MI300A_A1/ -b 4
+
+Roofline visualization options (available only in analyze mode):
+
+* ``--sort``: Overlay top kernels or top dispatches (default: kernels)
+* ``--mem-level``: Filter by memory level -- HBM, L2, vL1D, LDS (default: ALL)
+* ``--roofline-data-type``: Choose datatypes for roofline visualization (default: FP32)
+
+Example with multiple options:
+
+.. code-block:: shell-session
+
+   $ rocprof-compute analyze -p workloads/vcopy/MI200/ --sort dispatches --mem-level HBM L2 --roofline-data-type FP32 FP16
 
 .. _analysis-baseline-comparison:
 

--- a/projects/rocprofiler-compute/docs/how-to/profile/mode.rst
+++ b/projects/rocprofiler-compute/docs/how-to/profile/mode.rst
@@ -223,9 +223,9 @@ an Instinct MI210 vs an Instinct MI250.
    Additionally, you will notice a few extra files. An SoC parameters file,
    ``sysinfo.csv``, is created to reflect the target device settings. All
    profiling output is stored in ``log.txt``. Roofline-specific benchmark
-   results are stored in ``roofline.csv`` and roofline plots are outputted into HTMLs as
-   ``empirRoof_gpu-0_[datatype1]_..._[datatypeN].html`` where data types requested through
-   ``--roofline-data-type`` option are listed in the file name.
+   results are stored in ``roofline.csv``. To generate roofline HTML plots,
+   run ``rocprof-compute analyze`` on the profiling output directory
+   (see :doc:`../analyze/mode`).
 
 .. code-block:: shell-session
 
@@ -284,7 +284,6 @@ Examples:
    $ tree workloads/vcopy
 
    └── MI200
-    ├── empirRoof_gpu-0_FP32.html
     ├── log.txt
     ├── perfmon
     │   ├── pmc_perf_0.txt
@@ -326,7 +325,6 @@ Examples:
    $ tree /tmp/profiles/amd-ryzen/0
 
    └── MI200
-    ├── empirRoof_gpu-0_FP32.html
     ├── log.txt
     ├── perfmon
     │   ├── pmc_perf_0.txt
@@ -685,24 +683,21 @@ Standalone roofline
 Roofline analysis occurs on any profile mode run, provided ``--no-roof`` option is not included.
 You don't need to include any additional roofline-specific options for roofline analysis.
 If you want to focus only on roofline-specific performance data and reduce the time it takes to profile, you can use the ``--roof-only`` option.
-This option checks if there is existing profiling data in the workload directory (``pmc_perf.csv`` and ``roofline.csv``):
+This option checks if there is existing roofline benchmark data in the workload directory (``roofline.csv``):
 
-a) If found, uses the data files with the provided arguments to create another roofline HTML output; otherwise,
+a) If found, skips microbenchmark execution;
 
-b) Profile mode runs but is limited to collecting only roofline performance counters.
+b) Otherwise, profile mode runs microbenchmarks and collects roofline performance counters.
 
 Note that ``--roof-only`` cannot be used with ``--block`` or ``--set`` options.
 
-Roofline options
-----------------
+Profile mode generates ``roofline.csv`` containing microbenchmark data. To generate
+roofline HTML plots, use ``rocprof-compute analyze`` on the profiling output directory
+(see :doc:`../analyze/mode`). Visualization options (``--sort``, ``--mem-level``,
+``--roofline-data-type``) are available in analyze mode.
 
-``--sort <desired_sort>``
-   Allows you to specify whether you would like to overlay top kernel or top
-   dispatch data in your roofline plot.
-
-``-m``, ``--mem-level <cache_level>``
-   Allows you to specify specific levels of cache to include in your roofline
-   plot.
+Roofline options (profile)
+--------------------------
 
 ``--device <gpu_id>``
    Allows you to specify a device ID to collect performance data from when
@@ -712,18 +707,9 @@ Roofline options
    Allows for kernel filtering. Usage is equivalent with the current ``rocprof``
    utility. See :ref:`profiling-kernel-filtering`.
 
-``--roofline-data-type <datatype>``
-   Allows you to specify data types that you want plotted in the roofline HTML output(s). Selecting more than one data type will overlay the results onto the same plot. Default: FP32
-
 .. note::
 
   For more information on data types supported based on the GPU architecture, see :doc:`../../conceptual/performance-model`
-
-Each kernel in your ``.html`` roofline plot is automatically distinguished with a unique marker identifiable from the plot's key. The roofline HTML includes an integrated multi-subplot layout with:
-
-1. **Roofline Plot** - Shows performance ceilings and kernel arithmetic intensity points
-2. **Plot Points & Values Table** - Displays AI values, performance metrics, memory/compute bound status, and cache levels for each kernel
-3. **Full Kernel Names Table** - Lists complete kernel names with their corresponding plot markers
 
 
 Roofline only
@@ -734,69 +720,22 @@ The following example demonstrates profiling roofline data only:
 .. code-block:: shell-session
 
    $ rocprof-compute profile --name occupancy --roof-only -- ./tests/occupancy -n 1048576 -b 256
-                                    __                                       _
-   _ __ ___   ___ _ __  _ __ ___  / _|       ___ ___  _ __ ___  _ __  _   _| |_ ___
-   | '__/ _ \ / __| '_ \| '__/ _ \| |_ _____ / __/ _ \| '_ ` _ \| '_ \| | | | __/ _ \
-   | | | (_) | (__| |_) | | | (_) |  _|_____| (_| (_) | | | | | | |_) | |_| | ||  __/
-   |_|  \___/ \___| .__/|_|  \___/|_|        \___\___/|_| |_| |_| .__/ \__,_|\__\___|
-                  |_|                                           |_|
-   ...
-   INFO [roofline] Generating pmc_perf.csv (roofline counters only).
-   INFO Rocprofiler-Compute version: 3.3.0
-   INFO Profiler choice: rocprofiler-sdk
-   INFO Path: /app/projects/rocprofiler-compute/workloads/occupancy/MI300X_A1
-   INFO Target: MI300X_A1
-   INFO Command: ./tests/occupancy -n 1048576 -b 256
-   INFO Kernel Selection: None
-   INFO Dispatch Selection: None
-   INFO Filtered sections: ['4']
-   INFO
-   INFO ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-   INFO Collecting Performance Counters (Roofline Only)
-   INFO ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-   INFO
-   INFO [Run 1/3][Approximate profiling time left: pending first measurement...]
-   INFO [profiling] Current input file: /app/projects/rocprofiler-compute/workloads/occupancy/MI300X_A1/perfmon/pmc_perf_0.txt
-   ...
-   INFO [roofline] Checking for roofline.csv in /app/projects/rocprofiler-compute/workloads/occupancy/MI300X_A1
-   INFO [roofline] No roofline data found. Generating...
-   Empirical Roofline Calculation
-   Copyright © 2025  Advanced Micro Devices, Inc. All rights reserved.
-   Total detected GPU devices: 8
-   GPU Device 0 (gfx942) with 304 CUs: Profiling...
-   99% [||||||||||||||||||||||||||||||||||||||||||||||||||||||||||| ]
    ...
 
-
-An inspection of our workload output folder shows ``.html`` plots were generated
+An inspection of our workload output folder shows ``roofline.csv`` was generated
 successfully.
-
-.. warning::
-
-   Deprecation warning: Standalone Roofline Analysis plot output ``empirRoof_gpu-<device ID><datatypes><kernels>.html`` will be auto-generated in analyze mode instead of profile mode in a future release.
 
 .. code-block:: shell-session
 
    $ ls workloads/occupancy/MI300X_A1
    total 48
-   -rw-r--r-- 1 auser agroup 13331 Oct 29 10:33 empirRoof_gpu-0_FP32.html
    drwxr-xr-x 1 auser agroup     0 Oct 29 10:33 perfmon
    -rw-r--r-- 1 auser agroup  1101 Oct 29 10:33 pmc_perf.csv
    -rw-r--r-- 1 auser agroup  1715 Oct 29 10:33 roofline.csv
    -rw-r--r-- 1 auser agroup   650 Oct 29 10:33 sysinfo.csv
    -rw-r--r-- 1 auser agroup   399 Oct 29 10:33 timestamps.csv
 
-.. note::
-
-  ROCm Compute Profiler currently captures roofline profiling for all data types, and you can reduce the clutter in the HTML outputs by filtering the data type(s). Selecting multiple data types will overlay the results into the same HTML. To generate results in separate HTML for each data type from the same workload run, you can re-run the profiling command with each data type as long as the ``roofline.csv`` file still exists in the workload folder.
-
-The following image is a sample ``empirRoof_gpu-0_FP32.html`` roofline
-plot.
-
-.. image:: ../../data/profile/sample-roof-plot.jpg
-   :align: center
-   :alt: Sample ROCm Compute Profiler roofline output
-   :width: 800
+To generate roofline HTML plots from this data, see :doc:`../analyze/mode`.
 
 .. _torch-operator-mapping:
 
@@ -1184,7 +1123,6 @@ The example above produces:
    $ tree /tmp/mpi_profile/0
 
    └── MI200
-    ├── empirRoof_gpu-0_FP32.html
     ├── log.txt
     ├── perfmon
     │   ├── pmc_perf_0.txt
@@ -1233,7 +1171,6 @@ The example above produces:
    $ tree ./workloads/laplace_eqn/0
 
    └── MI200
-    ├── empirRoof_gpu-0_FP32.html
     ├── log.txt
     ├── perfmon
     │   ├── pmc_perf_0.txt
@@ -1280,7 +1217,6 @@ to your output directory. The following example is run on the host ``amd-ryzen``
    $ tree /tmp/mpi_profile/amd-ryzen/0
 
    └── MI200
-    ├── empirRoof_gpu-0_FP32.html
     ├── log.txt
     ├── perfmon
     │   ├── pmc_perf_0.txt

--- a/projects/rocprofiler-compute/docs/install/quickstart.rst
+++ b/projects/rocprofiler-compute/docs/install/quickstart.rst
@@ -126,7 +126,10 @@ After profiling, the generated files can be found inside:
 
 For detailed information on all profiling options, refer to :doc:`../how-to/profile/mode`.
 
-During the profiling phase, roofline analysis also executes multiple iterations to collect the necessary performance data. For detailed information on roofline analysis, refer to :ref:`Standalone roofline <standalone-roofline>`.
+During the profiling phase, roofline microbenchmarks also run to collect
+hardware peak data (saved as ``roofline.csv``). To generate roofline HTML
+charts from this data, run ``rocprof-compute analyze`` on the output directory.
+For detailed information on roofline analysis, refer to :ref:`Standalone roofline <standalone-roofline>`.
 
 For more details and options, run:
 
@@ -139,12 +142,16 @@ Profiling examples
 
 Common use cases when profiling a workload are:
 
-Collect only roofline data for performance analysis
-++++++++++++++++++++++++++++++++++++++++++++++++++++
+Collect roofline data and generate HTML charts
+++++++++++++++++++++++++++++++++++++++++++++++++
+
+Profile mode collects roofline microbenchmark data (``roofline.csv``). To
+generate interactive HTML roofline charts, run analyze mode on the output:
 
 .. code-block:: shell-session
 
     $ rocprof-compute profile --name vcopy --roof-only -- ./vcopy -n 1048576 -b 256
+    $ rocprof-compute analyze -p workloads/vcopy/MI200/ --roofline-data-type FP32
 
 
 Collect the counters to compute the metric for compute throughput utilization, skipping roofline

--- a/projects/rocprofiler-compute/src/argparser.py
+++ b/projects/rocprofiler-compute/src/argparser.py
@@ -548,7 +548,7 @@ Examples:
         ),
     )
 
-    ## Roofline Command Line Options
+    ## Roofline Command Line Options (profile: microbenchmark only)
     roofline_group.add_argument(
         "--roof-only",
         required=False,
@@ -560,36 +560,6 @@ Examples:
         ),
     )
     roofline_group.add_argument(
-        "--sort",
-        required=False,
-        metavar="",
-        type=str,
-        default="kernels",
-        choices=["kernels", "dispatches"],
-        help=(
-            "\t\t\tOverlay top kernels or top dispatches: (DEFAULT: kernels)\n"
-            "\t\t\t   kernels\n"
-            "\t\t\t   dispatches"
-        ),
-    )
-    roofline_group.add_argument(
-        "-m",
-        "--mem-level",
-        required=False,
-        choices=["HBM", "L2", "vL1D", "LDS"],
-        metavar="",
-        nargs="+",
-        type=str,
-        default="ALL",
-        help=(
-            "\t\t\tFilter by memory level: (DEFAULT: ALL)\n"
-            "\t\t\t   HBM\n"
-            "\t\t\t   L2\n"
-            "\t\t\t   vL1D\n"
-            "\t\t\t   LDS"
-        ),
-    )
-    roofline_group.add_argument(
         "--device",
         metavar="",
         required=False,
@@ -597,62 +567,6 @@ Examples:
         type=int,
         help="\t\t\tTarget GPU device ID. (DEFAULT: 0)",
     )
-    roofline_group.add_argument(
-        "-R",
-        "--roofline-data-type",
-        required=False,
-        choices=[
-            "FP4",
-            "FP6",
-            "FP8",
-            "FP16",
-            "BF16",
-            "FP32",
-            "FP64",
-            "I8",
-            "I32",
-            "I64",
-        ],
-        metavar="",
-        nargs="+",
-        type=str,
-        default=["FP32"],
-        help=(
-            "\t\t\tChoose datatypes to view roofline HTMLs for: (DEFAULT: FP32)\n"
-            "\t\t\t   FP4\n"
-            "\t\t\t   FP6\n"
-            "\t\t\t   FP8\n"
-            "\t\t\t   FP16\n"
-            "\t\t\t   BF16\n"
-            "\t\t\t   FP32\n"
-            "\t\t\t   FP64\n"
-            "\t\t\t   I8\n"
-            "\t\t\t   I32\n"
-            "\t\t\t   I64\n"
-            "\t\t\t "
-        ),
-    )
-
-    # roofline_group.add_argument(
-    #     '-w', '--workgroups', required=False, default=-1, type=int,
-    #     help="\t\t\tNumber of kernel workgroups (DEFAULT: 1024)"
-    # )
-    # roofline_group.add_argument(
-    #     '--wsize', required=False, default=-1, type=int,
-    #     help="\t\t\tWorkgroup size (DEFAULT: 256)"
-    # )
-    # roofline_group.add_argument(
-    #     '--dataset', required=False, default=-1, type=int,
-    #     help="\t\t\tDataset size (DEFAULT: 536M)"
-    # )
-    # roofline_group.add_argument(
-    #     '-e', '--experiments', required=False, default=-1, type=int,
-    #     help="\t\t\tNumber of experiments (DEFAULT: 100)"
-    # )
-    # roofline_group.add_argument(
-    #     '--iter', required=False, default=-1, type=int,
-    #     help="\t\t\tNumber of iterations (DEFAULT: 10)"
-    # )
 
     ## ----------------------------
     # Experimental Features
@@ -860,6 +774,49 @@ Examples:
         "interact with rocprofiler-compute metrics.",
     )
     analyze_group.add_argument(
+        "--pc-sampling-sorting-type",
+        required=False,
+        metavar="",
+        dest="pc_sampling_sorting_type",
+        default="offset",
+        type=str,
+        help="\t\tSet the sorting type of pc sampling: "
+        "offset or count (DEFAULT: offset).",
+    )
+
+    ## Roofline Command Line Options (analyze: visualization)
+    roofline_group_analyze = analyze_parser.add_argument_group("Roofline Options")
+    roofline_group_analyze.add_argument(
+        "--sort",
+        required=False,
+        metavar="",
+        type=str,
+        default="kernels",
+        choices=["kernels", "dispatches"],
+        help=(
+            "\t\tOverlay top kernels or top dispatches: (DEFAULT: kernels)\n"
+            "\t\t   kernels\n"
+            "\t\t   dispatches"
+        ),
+    )
+    roofline_group_analyze.add_argument(
+        "-m",
+        "--mem-level",
+        required=False,
+        choices=["HBM", "L2", "vL1D", "LDS"],
+        metavar="",
+        nargs="+",
+        type=str,
+        default="ALL",
+        help=(
+            "\t\tFilter by memory level: (DEFAULT: ALL)\n"
+            "\t\t   HBM\n"
+            "\t\t   L2\n"
+            "\t\t   vL1D\n"
+            "\t\t   LDS"
+        ),
+    )
+    roofline_group_analyze.add_argument(
         "-R",
         "--roofline-data-type",
         required=False,
@@ -881,27 +838,17 @@ Examples:
         default=["FP32"],
         help=(
             "\t\tChoose datatypes to view roofline HTMLs for: (DEFAULT: FP32)\n"
-            "\t\t\t   FP4\n"
-            "\t\t\t   FP6\n"
-            "\t\t\t   FP8\n"
-            "\t\t\t   FP16\n"
-            "\t\t\t   BF16\n"
-            "\t\t\t   FP32\n"
-            "\t\t\t   FP64\n"
-            "\t\t\t   I8\n"
-            "\t\t\t   I32\n"
-            "\t\t\t   I64\n\t\t\t "
+            "\t\t   FP4\n"
+            "\t\t   FP6\n"
+            "\t\t   FP8\n"
+            "\t\t   FP16\n"
+            "\t\t   BF16\n"
+            "\t\t   FP32\n"
+            "\t\t   FP64\n"
+            "\t\t   I8\n"
+            "\t\t   I32\n"
+            "\t\t   I64\n"
         ),
-    )
-    analyze_group.add_argument(
-        "--pc-sampling-sorting-type",
-        required=False,
-        metavar="",
-        dest="pc_sampling_sorting_type",
-        default="offset",
-        type=str,
-        help="\t\tSet the sorting type of pc sampling: "
-        "offset or count (DEFAULT: offset).",
     )
 
     analyze_advanced_group.add_argument(

--- a/projects/rocprofiler-compute/src/rocprof_compute_analyze/analysis_cli.py
+++ b/projects/rocprofiler-compute/src/rocprof_compute_analyze/analysis_cli.py
@@ -30,9 +30,11 @@ from pathlib import Path
 import pandas as pd
 
 from rocprof_compute_analyze.analysis_base import OmniAnalyze_Base
+from roofline import Roofline
 from utils import file_io, parser, schema, tty
 from utils.kernel_name_shortener import kernel_name_shortener
 from utils.logger import console_error, console_log, console_warning, demarcate
+from utils.roofline_calc import calc_ai_analyze, validate_roofline_csv
 from utils.utils import (
     build_call_trees,
     build_call_trees_with_kernel_ids,
@@ -169,21 +171,72 @@ class cli_analysis(OmniAnalyze_Base):
             # Generate roofline plot for single-path, compatible architectures
             if (len(args.path)) == 1:
                 if gpu_arch in ["gfx90a", "gfx940", "gfx941", "gfx942", "gfx950"]:
+                    is_roofline_valid, roofline_error_msg = validate_roofline_csv(
+                        Path(workload_path)
+                    )
                     soc = self.get_socs()
-                    if soc and gpu_arch in soc:
-                        roof_obj = soc[gpu_arch].roofline_obj
+                    if not soc or gpu_arch not in soc:
+                        console_warning(
+                            "roofline",
+                            "Skipping roofline charting: "
+                            f"gpu arch {gpu_arch} not in soc {soc}",
+                        )
+                    if is_roofline_valid:
+                        soc_obj = soc[gpu_arch]
+                        # Normalize user-facing "vL1D" to CSV column name "L1"
+                        mem_level = (
+                            args.mem_level
+                            if isinstance(args.mem_level, list)
+                            else [args.mem_level]
+                        )
+                        mem_level = [("L1" if m == "vL1D" else m) for m in mem_level]
 
-                        if roof_obj:
-                            # store path in workload for calc_ai_analyze
-                            workload.path = workload_path
+                        roof_obj = Roofline(
+                            args=soc_obj.get_args(),
+                            mspec=soc_obj._mspec,
+                            run_parameters={
+                                "workload_dir": workload_path,
+                                "device_id": 0,
+                                "sort_type": str(args.sort),
+                                "mem_level": mem_level,
+                                "is_standalone": True,
+                                "roofline_data_type": args.roofline_data_type,
+                                "kernel_filter": bool(args.gpu_kernel),
+                                "iteration_multiplexing": self._profiling_config.get(
+                                    "iteration_multiplexing"
+                                ),
+                            },
+                        )
+                        workload.path = workload_path
 
-                            # NOTE: using default data type
-                            roof_plot = roof_obj.cli_generate_plot(
-                                dtype=roof_obj.get_dtype()[0],
-                                workload=workload,
-                                config=self._profiling_config,
-                                arch_config=arch_config,
-                            )
+                        pmc_df = parser.apply_filters(
+                            workload, workload_path, is_gui=False, debug=args.debug
+                        )
+                        ai_data = calc_ai_analyze(
+                            workload=workload,
+                            pmc_df=pmc_df,
+                            mspec=soc_obj._mspec,
+                            sort_type=str(args.sort),
+                            config=self._profiling_config,
+                            arch_config=arch_config,
+                        )
+
+                        # NOTE: using default data type
+                        roof_plot = roof_obj.cli_generate_plot(
+                            dtype=roof_obj.get_dtype()[0],
+                            ai_data=ai_data,
+                        )
+
+                        ops_fig, flops_fig, ops_dt, flops_dt = (
+                            roof_obj.construct_plotly_figures(ai_data=ai_data)
+                        )
+                        roof_obj.save_html_files(ops_fig, flops_fig, ops_dt, flops_dt)
+                    else:
+                        console_warning(
+                            "roofline",
+                            "Skipping roofline charting: "
+                            f"Invalid roofline.csv: {roofline_error_msg}",
+                        )
 
             tty.show_all(
                 args,

--- a/projects/rocprofiler-compute/src/rocprof_compute_analyze/analysis_webui.py
+++ b/projects/rocprofiler-compute/src/rocprof_compute_analyze/analysis_webui.py
@@ -37,10 +37,12 @@ from dash.dependencies import Input, Output, State
 
 from config import HIDDEN_COLUMNS, PROJECT_NAME
 from rocprof_compute_analyze.analysis_base import OmniAnalyze_Base
+from roofline import Roofline
 from utils import file_io, parser, schema
 from utils.gui import build_bar_chart, build_table_chart
 from utils.gui_components.memchart import get_memchart
 from utils.logger import console_debug, console_error, console_warning, demarcate
+from utils.roofline_calc import calc_ai_analyze, validate_roofline_csv
 
 
 class webui_analysis(OmniAnalyze_Base):
@@ -215,36 +217,70 @@ class webui_analysis(OmniAnalyze_Base):
                 get_memchart(panel_configs[300]["data source"], base_data[base_run])
             ]
 
-            has_roofline = (Path(self.dest_dir) / "roofline.csv").is_file()
+            is_roofline_valid, roofline_error_msg = validate_roofline_csv(
+                Path(self.dest_dir)
+            )
             soc = self.get_socs()
             if soc and self.arch in soc:
-                if has_roofline and hasattr(soc[self.arch], "roofline_obj"):
-                    # update roofline for visualization in GUI
-                    soc[self.arch].analysis_setup(
-                        roofline_parameters={
+                if is_roofline_valid:
+                    # Normalize user-facing "vL1D" to CSV column name "L1"
+                    mem_level = (
+                        args.mem_level
+                        if isinstance(args.mem_level, list)
+                        else [args.mem_level]
+                    )
+                    mem_level = [("L1" if m == "vL1D" else m) for m in mem_level]
+
+                    roof_obj = Roofline(
+                        args=soc[self.arch].get_args(),
+                        mspec=soc[self.arch]._mspec,
+                        run_parameters={
                             "workload_dir": self.dest_dir,
                             "device_id": 0,
-                            "sort_type": "kernels",
-                            "mem_level": "ALL",
+                            "sort_type": str(args.sort),
+                            "mem_level": mem_level,
                             "include_kernel_names": True,
                             "is_standalone": False,
                             "roofline_data_type": self.__roofline_data_type,
+                            # WebUI handles kernel filtering
+                            # client-side via Dash/Plotly
                             "kernel_filter": False,
                             "iteration_multiplexing": self._profiling_config[
                                 "iteration_multiplexing"
                             ],
-                        }
+                        },
                     )
-                    roof_obj = soc[self.arch].roofline_obj
-                    div_children.append(
-                        roof_obj.empirical_roofline(
-                            ret_df=parser.apply_filters(
-                                workload=base_data[base_run],
-                                dir_path=self.dest_dir,
-                                is_gui=True,
-                                debug=args.debug,
-                            )
-                        )
+
+                    workload = base_data[base_run]
+                    workload.path = self.dest_dir
+
+                    pmc_df = parser.apply_filters(
+                        workload, self.dest_dir, is_gui=True, debug=False
+                    )
+
+                    ai_data = calc_ai_analyze(
+                        workload=workload,
+                        pmc_df=pmc_df,
+                        mspec=soc[self.arch]._mspec,
+                        sort_type=str(args.sort),
+                        config=self._profiling_config,
+                        arch_config=arch_configs,
+                    )
+
+                    ops_fig, flops_fig, _, _ = roof_obj.construct_plotly_figures(
+                        ai_data=ai_data,
+                    )
+                    roofline_section = roof_obj.generate_html_section(
+                        ops_fig,
+                        flops_fig,
+                    )
+                    if roofline_section is not None:
+                        div_children.append(roofline_section)
+                else:
+                    console_warning(
+                        "roofline",
+                        "Skipping roofline charting: ",
+                        f"Invalid roofline.csv: {roofline_error_msg}",
                     )
 
             # Iterate over each section as defined in panel configs

--- a/projects/rocprofiler-compute/src/rocprof_compute_base.py
+++ b/projects/rocprofiler-compute/src/rocprof_compute_base.py
@@ -555,7 +555,6 @@ class RocProfCompute:
 
         post_duration = int(time_end_post - time_end_prof)
         console_debug(f'time taken for "post_processing" was {post_duration} seconds')
-        self.__soc[self.__mspec.gpu_arch].post_profiling()
 
     @demarcate
     def run_analysis(self) -> None:

--- a/projects/rocprofiler-compute/src/rocprof_compute_soc/soc_base.py
+++ b/projects/rocprofiler-compute/src/rocprof_compute_soc/soc_base.py
@@ -35,9 +35,7 @@ from typing import Any, Optional
 import yaml
 
 import config
-from roofline import Roofline
 from utils.amdsmi_interface import amdsmi_ctx, get_gpu_model, get_mem_max_clock
-from utils.file_io import create_df_pmc, load_profiling_config
 from utils.logger import (
     console_debug,
     console_error,
@@ -46,18 +44,15 @@ from utils.logger import (
     demarcate,
 )
 from utils.mi_gpu_spec import mi_gpu_specs
-from utils.parser import BUILD_IN_VARS, SUPPORTED_DENOM, apply_filters
+from utils.parser import BUILD_IN_VARS, SUPPORTED_DENOM
 from utils.roofline_calc import validate_roofline_csv
-from utils.schema import Workload
 from utils.specs import MachineSpecs
 from utils.utils import (
     METRIC_ID_RE,
     add_counter_extra_config_input_yaml,
     convert_metric_id_to_panel_info,
     get_panel_alias,
-    impute_counters_iteration_multiplex,
     is_tcc_channel_counter,
-    merge_counters_spatial_multiplex,
     parse_sets_yaml,
     resolve_rocm_library_path,
 )
@@ -74,9 +69,6 @@ class OmniSoC_Base:
         self.__perfmon_config: dict[str, int] = {}
         self.__compatible_profilers: list[str] = []  # Store SoC compatible profilers
         self.populate_mspec()
-        # Create roofline object if mode is provided; skip for --specs
-        if hasattr(self.__args, "mode") and self.__args.mode:
-            self.roofline_obj = Roofline(args, self._mspec)
 
     def __hash__(self) -> int:
         return hash(self.__arch)
@@ -684,14 +676,6 @@ class OmniSoC_Base:
             # Dynamic import to isolate hip dependency during profile time only
             from utils import benchmark
 
-            pmc_path = Path(self.get_args().path) / "pmc_perf.csv"
-            if not pmc_path.is_file():
-                console_error(
-                    "roofline",
-                    "Incomplete or missing profiling data. Skipping roofline.",
-                    exit=False,
-                )
-                return
             console_log(
                 "roofline", f"Checking for roofline.csv in {self.get_args().path}"
             )
@@ -707,61 +691,20 @@ class OmniSoC_Base:
                     )
                     return
 
-            # Validate roofline.csv before post-processing
             is_valid, error_msg = validate_roofline_csv(self.get_args().path)
             if not is_valid:
                 console_error(
                     "roofline",
-                    f"Roofline post-processing skipped: {error_msg}",
+                    f"Invalid roofline.csv: {error_msg}",
                     exit=False,
                 )
                 return
 
-            console_warning(
+            console_log(
                 "roofline",
-                (
-                    "Deprecation warning: Standalone Roofline "
-                    "Analysis plot output "
-                    "``empirRoof_gpu-<device ID><datatypes><kernels>.html`` "
-                    "will be auto-generated in analyze mode instead of profile "
-                    "mode in a future release."
-                ),
-            )
-
-            args = self.get_args()
-            workload = Workload()
-            workload.path = self.__args.path
-            profiling_config = load_profiling_config(workload.path)
-            workload.raw_pmc = create_df_pmc(
-                raw_data_root_dir=workload.path,
-                nodes=None,
-                spatial_multiplexing=args.spatial_multiplexing,
-                kernel_verbose=-1,
-                verbose=args.verbose,
-                config_dict=profiling_config,
-            )
-
-            if args.spatial_multiplexing:
-                workload.raw_pmc = merge_counters_spatial_multiplex(workload.raw_pmc)
-
-            if profiling_config.get("iteration_multiplexing") is not None:
-                workload.raw_pmc = impute_counters_iteration_multiplex(
-                    workload.raw_pmc,
-                    policy=profiling_config["iteration_multiplexing"],
-                )
-            filtered_pmc = apply_filters(
-                workload, workload.path, is_gui=False, debug=False
-            )
-
-            self.roofline_obj.post_processing(filtered_pmc)
-
-    @abstractmethod
-    def analysis_setup(self, roofline_parameters: Optional[dict[str, Any]]) -> None:
-        """Perform any SoC-specific setup prior to analysis."""
-        console_debug("analysis", f"perform SoC analysis setup for {self.__arch}")
-        if roofline_parameters:
-            self.roofline_obj = Roofline(
-                self.get_args(), self._mspec, roofline_parameters
+                f"Roofline data saved to {self.get_args().path}/roofline.csv\n"
+                f"  Run 'rocprof-compute analyze -p {self.get_args().path}' "
+                f"for charts",
             )
 
 

--- a/projects/rocprofiler-compute/src/rocprof_compute_soc/soc_gfx908.py
+++ b/projects/rocprofiler-compute/src/rocprof_compute_soc/soc_gfx908.py
@@ -24,7 +24,7 @@
 ##############################################################################
 
 import argparse
-from typing import Any, Optional
+from typing import Optional
 
 from rocprof_compute_soc.soc_base import OmniSoC_Base
 from utils.logger import console_error, demarcate
@@ -63,10 +63,3 @@ class gfx908_soc(OmniSoC_Base):
     def post_profiling(self) -> None:
         """Perform any SoC-specific post profiling activities."""
         super().post_profiling()
-
-    @demarcate
-    def analysis_setup(
-        self, roofline_parameters: Optional[dict[str, Any]] = None
-    ) -> None:
-        """Perform any SoC-specific setup prior to analysis."""
-        super().analysis_setup(roofline_parameters=roofline_parameters)

--- a/projects/rocprofiler-compute/src/rocprof_compute_soc/soc_gfx90a.py
+++ b/projects/rocprofiler-compute/src/rocprof_compute_soc/soc_gfx90a.py
@@ -24,7 +24,6 @@
 ##############################################################################
 
 import argparse
-from typing import Any, Optional
 
 from rocprof_compute_soc.soc_base import OmniSoC_Base
 from utils.logger import demarcate
@@ -63,10 +62,3 @@ class gfx90a_soc(OmniSoC_Base):
     def post_profiling(self) -> None:
         """Perform any SoC-specific post profiling activities."""
         super().post_profiling()
-
-    @demarcate
-    def analysis_setup(
-        self, roofline_parameters: Optional[dict[str, Any]] = None
-    ) -> None:
-        """Perform any SoC-specific setup prior to analysis."""
-        super().analysis_setup(roofline_parameters=roofline_parameters)

--- a/projects/rocprofiler-compute/src/rocprof_compute_soc/soc_gfx940.py
+++ b/projects/rocprofiler-compute/src/rocprof_compute_soc/soc_gfx940.py
@@ -24,7 +24,7 @@
 ##############################################################################
 
 import argparse
-from typing import Any, Optional
+from typing import Optional
 
 from rocprof_compute_soc.soc_base import OmniSoC_Base
 from utils.logger import demarcate
@@ -63,10 +63,3 @@ class gfx940_soc(OmniSoC_Base):
     def post_profiling(self) -> None:
         """Perform any SoC-specific post profiling activities."""
         super().post_profiling()
-
-    @demarcate
-    def analysis_setup(
-        self, roofline_parameters: Optional[dict[str, Any]] = None
-    ) -> None:
-        """Perform any SoC-specific setup prior to analysis."""
-        super().analysis_setup(roofline_parameters=roofline_parameters)

--- a/projects/rocprofiler-compute/src/rocprof_compute_soc/soc_gfx941.py
+++ b/projects/rocprofiler-compute/src/rocprof_compute_soc/soc_gfx941.py
@@ -24,7 +24,7 @@
 ##############################################################################
 
 import argparse
-from typing import Any, Optional
+from typing import Optional
 
 from rocprof_compute_soc.soc_base import OmniSoC_Base
 from utils.logger import demarcate
@@ -63,10 +63,3 @@ class gfx941_soc(OmniSoC_Base):
     def post_profiling(self) -> None:
         """Perform any SoC-specific post profiling activities."""
         super().post_profiling()
-
-    @demarcate
-    def analysis_setup(
-        self, roofline_parameters: Optional[dict[str, Any]] = None
-    ) -> None:
-        """Perform any SoC-specific setup prior to analysis."""
-        super().analysis_setup(roofline_parameters=roofline_parameters)

--- a/projects/rocprofiler-compute/src/rocprof_compute_soc/soc_gfx942.py
+++ b/projects/rocprofiler-compute/src/rocprof_compute_soc/soc_gfx942.py
@@ -24,7 +24,7 @@
 ##############################################################################
 
 import argparse
-from typing import Any, Optional
+from typing import Optional
 
 from rocprof_compute_soc.soc_base import OmniSoC_Base
 from utils.logger import demarcate
@@ -63,10 +63,3 @@ class gfx942_soc(OmniSoC_Base):
     def post_profiling(self) -> None:
         """Perform any SoC-specific post profiling activities."""
         super().post_profiling()
-
-    @demarcate
-    def analysis_setup(
-        self, roofline_parameters: Optional[dict[str, Any]] = None
-    ) -> None:
-        """Perform any SoC-specific setup prior to analysis."""
-        super().analysis_setup(roofline_parameters=roofline_parameters)

--- a/projects/rocprofiler-compute/src/rocprof_compute_soc/soc_gfx950.py
+++ b/projects/rocprofiler-compute/src/rocprof_compute_soc/soc_gfx950.py
@@ -24,7 +24,7 @@
 ##############################################################################
 
 import argparse
-from typing import Any, Optional
+from typing import Optional
 
 from rocprof_compute_soc.soc_base import OmniSoC_Base
 from utils.logger import demarcate
@@ -60,10 +60,3 @@ class gfx950_soc(OmniSoC_Base):
     def post_profiling(self) -> None:
         """Perform any SoC-specific post profiling activities."""
         super().post_profiling()
-
-    @demarcate
-    def analysis_setup(
-        self, roofline_parameters: Optional[dict[str, Any]] = None
-    ) -> None:
-        """Perform any SoC-specific setup prior to analysis."""
-        super().analysis_setup(roofline_parameters=roofline_parameters)

--- a/projects/rocprofiler-compute/src/roofline.py
+++ b/projects/rocprofiler-compute/src/roofline.py
@@ -24,18 +24,15 @@
 ##############################################################################
 import argparse
 import textwrap
-from abc import abstractmethod
 from pathlib import Path
 from typing import Any, Optional, Union
 
 import numpy as np
-import pandas as pd
 import plotext as plt
 import plotly.graph_objects as go
 from dash import dcc, html
 from plotly.subplots import make_subplots
 
-from utils import schema
 from utils.logger import (
     console_debug,
     console_error,
@@ -47,8 +44,6 @@ from utils.roofline_calc import (
     MFMA_DATATYPES,
     PEAK_OPS_DATATYPES,
     SUPPORTED_DATATYPES,
-    calc_ai_analyze,
-    calc_ai_profile,
     construct_roof,
 )
 from utils.specs import MachineSpecs
@@ -79,56 +74,19 @@ class Roofline:
         self,
         args: argparse.Namespace,
         mspec: MachineSpecs,
-        run_parameters: Optional[dict[str, Any]] = None,
+        run_parameters: dict[str, Any],
     ) -> None:
         self.__args = args
         self.__mspec = mspec
-        self.__run_parameters = (
-            run_parameters
-            if run_parameters
-            else {
-                "workload_dir": None,  # in some cases (i.e. --specs),
-                # path will not be given
-                "device_id": 0,
-                "sort_type": "kernels",
-                "mem_level": "ALL",
-                "is_standalone": False,
-                "roofline_data_type": ["FP32"],  # default to FP32
-                "kernel_filter": False,
-                "iteration_multiplexing": None,
-            }
-        )
+        self.__run_parameters = run_parameters
         self.__ai_data: Optional[dict[str, Any]] = None
         self.__ceiling_data: Optional[dict[str, Any]] = None
         self.__figure = go.Figure()
-
-        # Set roofline run parameters from args
-        if hasattr(self.__args, "path") and not run_parameters:
-            self.__run_parameters["workload_dir"] = self.__args.path
-        if hasattr(self.__args, "no_roof") and not self.__args.no_roof:
-            self.__run_parameters["is_standalone"] = True
-        if hasattr(self.__args, "mem_level") and self.__args.mem_level != "ALL":
-            self.__run_parameters["mem_level"] = self.__args.mem_level
-        if hasattr(self.__args, "sort") and self.__args.sort != "ALL":
-            self.__run_parameters["sort_type"] = self.__args.sort
-        self.__run_parameters["roofline_data_type"] = self.__args.roofline_data_type
-        if (hasattr(self.__args, "kernel") and self.__args.kernel) or (
-            hasattr(self.__args, "gpu_kernel") and self.__args.gpu_kernel
-        ):
-            self.__run_parameters["kernel_filter"] = True
-        if (
-            hasattr(self.__args, "iteration_multiplexing")
-            and self.__args.iteration_multiplexing is not None
-        ):
-            self.__run_parameters["iteration_multiplexing"] = (
-                self.__args.iteration_multiplexing
-            )
 
     def get_args(self) -> argparse.Namespace:
         return self.__args
 
     def roof_setup(self) -> None:
-        # Setup the workload directory for roofline profiling.
         workload_dir_val = self.__run_parameters.get("workload_dir")
 
         if not workload_dir_val:
@@ -137,23 +95,7 @@ class Roofline:
             )
             return
 
-        if isinstance(workload_dir_val, list):
-            if not workload_dir_val or not workload_dir_val[0]:
-                console_error(
-                    "Workload directory list is empty or invalid. "
-                    "Cannot perform setup.",
-                    exit=False,
-                )
-                return
-            # Handle nested list structure [0][0] or simple list [0]
-            base_dir = (
-                workload_dir_val[0][0]
-                if isinstance(workload_dir_val[0], (list, tuple))
-                else workload_dir_val[0]
-            )
-        else:
-            # workload_dir_val is a string
-            base_dir = workload_dir_val
+        base_dir = str(workload_dir_val)
 
         base_path = Path(base_dir)
 
@@ -223,23 +165,20 @@ class Roofline:
             return "Compute Bound"
 
     @demarcate
-    def empirical_roofline(
-        self, ret_df: dict[str, pd.DataFrame]
-    ) -> Optional[html.Section]:
+    def construct_plotly_figures(
+        self, ai_data: dict[str, Any]
+    ) -> tuple[Optional[go.Figure], Optional[go.Figure], str, str]:
         """
-        Generate a set of empirical roofline plots given a directory containing
-        required profiling and benchmarking data.
+        Build raw Plotly figure objects from pre-computed AI data.
+
+        Returns (ops_figure, flops_figure, ops_dt_list, flops_dt_list).
+        No I/O or HTML wrapping.
         """
         self.roof_setup()
 
         console_debug("roofline", f"Path: {self.__run_parameters.get('workload_dir')}")
 
-        self.__ai_data = calc_ai_profile(
-            self.__mspec,
-            self.__run_parameters.get("sort_type"),
-            ret_df,
-            self.__run_parameters["iteration_multiplexing"],
-        )
+        self.__ai_data = ai_data
 
         msg = "AI at each mem level:"
         for key, value in self.__ai_data.items():
@@ -261,11 +200,7 @@ class Roofline:
                 }
 
         ops_figure = flops_figure = None
-        ops_dt_list = flops_dt_list = kernel_list = ""
-
-        # collect ceiling data for all datatypes to find global minimums
-        all_ops_ceiling_data = {}
-        all_flops_ceiling_data = {}
+        ops_dt_list = flops_dt_list = ""
 
         for dt in self.__run_parameters.get("roofline_data_type", []):
             gpu_arch = getattr(self.__mspec, "gpu_arch", "unknown_arch")
@@ -295,8 +230,6 @@ class Roofline:
                         kernel_names_data=kernel_names_data,
                     )
                 ops_dt_list += "_" + str(dt)
-                # store ceiling data for this datatype
-                all_ops_ceiling_data[str(dt)] = self.__ceiling_data
 
             if ops_flops == "Flops":
                 if flops_figure:
@@ -310,68 +243,93 @@ class Roofline:
                         kernel_names_data=kernel_names_data,
                     )
                 flops_dt_list += "_" + str(dt)
-                # Store ceiling data for this datatype
-                all_flops_ceiling_data[str(dt)] = self.__ceiling_data
 
-        # Output will be different depending on interaction type:
-        # Save HTMLs if we're in "standalone roofline" mode,
-        # otherwise return HTML to be used in GUI outputif flops_figure:
+        return ops_figure, flops_figure, ops_dt_list, flops_dt_list
 
-        if self.__run_parameters["is_standalone"]:
-            dev_id = str(self.__run_parameters["device_id"])
-            if self.__run_parameters.get("kernel_filter", False):
-                for name in sorted(self.__args.kernel):
+    def save_html_files(
+        self,
+        ops_figure: Optional[go.Figure],
+        flops_figure: Optional[go.Figure],
+        ops_dt_list: str,
+        flops_dt_list: str,
+    ) -> None:
+        """Write Plotly figures to standalone HTML files on disk."""
+        dev_id = str(self.__run_parameters["device_id"])
+        kernel_list = ""
+        if self.__run_parameters.get("kernel_filter", False):
+            kernels = getattr(self.__args, "gpu_kernel", None)
+            if kernels:
+                flat = [
+                    str(k)
+                    for group in kernels
+                    for k in (group if isinstance(group, list) else [group])
+                ]
+                for name in sorted(flat):
                     kernel_list += "_" + name
 
-            if ops_figure:
-                ops_figure.write_html(
-                    f"{self.__run_parameters['workload_dir']}/empirRoof_gpu-{dev_id}{ops_dt_list}{kernel_list}.html"
-                )
+        workload_dir = self.__run_parameters["workload_dir"]
 
-            if flops_figure:
-                flops_figure.write_html(
-                    f"{self.__run_parameters['workload_dir']}/empirRoof_gpu-{dev_id}{flops_dt_list}{kernel_list}.html"
-                )
-
-            console_log("roofline", "Empirical Roofline HTML file saved!")
-        else:
-            # Create HTML output for GUI mode.
-            ops_graph = (
-                html.Div(
-                    className="float-child",
-                    children=[
-                        html.H3(children="Empirical Roofline Analysis (Ops)"),
-                        dcc.Graph(figure=ops_figure),
-                    ],
-                )
-                if ops_figure
-                else None
+        wrote = False
+        if ops_figure:
+            ops_figure.write_html(
+                f"{workload_dir}/empirRoof_gpu-{dev_id}{ops_dt_list}{kernel_list}.html"
             )
+            wrote = True
 
-            flops_graph = (
-                html.Div(
-                    className="float-child",
-                    children=[
-                        html.H3(children="Empirical Roofline Analysis (Flops)"),
-                        dcc.Graph(figure=flops_figure),
-                    ],
-                )
-                if flops_figure
-                else None
+        if flops_figure:
+            flops_figure.write_html(
+                f"{workload_dir}/empirRoof_gpu-{dev_id}{flops_dt_list}{kernel_list}.html"
             )
+            wrote = True
 
-            return html.Section(
-                id="roofline",
+        if wrote:
+            console_log("roofline", "Roofline HTML files saved.")
+
+    @staticmethod
+    def generate_html_section(
+        ops_figure: Optional[go.Figure],
+        flops_figure: Optional[go.Figure],
+    ) -> Optional[html.Section]:
+        """Wrap Plotly figures in Dash HTML components for WebUI embedding."""
+        if ops_figure is None and flops_figure is None:
+            return None
+
+        ops_graph = (
+            html.Div(
+                className="float-child",
                 children=[
-                    html.Div(
-                        className="float-container",
-                        children=[
-                            ops_graph,
-                            flops_graph,
-                        ],
-                    )
+                    html.H3(children="Empirical Roofline Analysis (Ops)"),
+                    dcc.Graph(figure=ops_figure),
                 ],
             )
+            if ops_figure
+            else None
+        )
+
+        flops_graph = (
+            html.Div(
+                className="float-child",
+                children=[
+                    html.H3(children="Empirical Roofline Analysis (Flops)"),
+                    dcc.Graph(figure=flops_figure),
+                ],
+            )
+            if flops_figure
+            else None
+        )
+
+        return html.Section(
+            id="roofline",
+            children=[
+                html.Div(
+                    className="float-container",
+                    children=[
+                        ops_graph,
+                        flops_graph,
+                    ],
+                )
+            ],
+        )
 
     @demarcate
     def generate_plot(
@@ -490,6 +448,10 @@ class Roofline:
 
                 subplot_row = 1
                 skipAI = False
+            else:
+                # generate an empty figure object in the
+                # event that no kernel names are provided
+                fig = go.Figure()
         else:
             # Adding to existing figure
             if hasattr(fig, "_grid_ref") and fig._grid_ref is not None:
@@ -581,7 +543,7 @@ class Roofline:
         mem_level_config = self.__run_parameters.get("mem_level", "ALL")
         cache_hierarchy = (
             ["HBM", "L2", "L1", "LDS"]
-            if mem_level_config == "ALL"
+            if mem_level_config == "ALL" or mem_level_config == ["ALL"]
             else (
                 mem_level_config
                 if isinstance(mem_level_config, list)
@@ -1071,18 +1033,13 @@ class Roofline:
     def cli_generate_plot(
         self,
         dtype: str,
-        workload: schema.Workload,
-        config: dict[str, Any],
-        arch_config: schema.ArchConfig,
+        ai_data: dict[str, Any],
     ) -> Optional[str]:
         """
         Plot CLI mode roofline analysis in terminal using plotext
 
         :param dtype: The datatype to be profiled
-        :param workload: Complete dataframe
-        :param config: Profiling configuration from profiling_config.yaml
-        :param arch_config: Archetype-specific configurations
-        :type method: str
+        :param ai_data: Pre-computed arithmetic intensity data from calc_ai_analyze
         :return: Build the current figure using plot.build(),
         or None if datatype is not valid for the architecture
         :rtype: str or None
@@ -1098,56 +1055,22 @@ class Roofline:
             )
             return
 
-        # Normalize workload_dir to get the base directory
-        workload_dir = self.__run_parameters.get("workload_dir")
-        if workload_dir is None:
-            console_error(
-                "workload_dir is not set",
-                exit=False,
+        if not ai_data:
+            console_warning(
+                "roofline",
+                "Skipping roofline charting due to invalid arithmetic intensity data",
             )
             return
 
-        # Extract base directory path regardless of-
-        # whether workload_dir is list or string
-        if isinstance(workload_dir, list):
-            if not workload_dir or not workload_dir[0]:
-                console_error(
-                    "workload_dir list is empty or contains invalid entries",
-                    exit=False,
-                )
-                return
-            # Handle nested list structure [0][0] or simple list [0]
-            base_dir = (
-                workload_dir[0][0]
-                if isinstance(workload_dir[0], (list, tuple))
-                else workload_dir[0]
+        self.__ai_data = ai_data
+
+        workload_dir = self.__run_parameters.get("workload_dir", "")
+        if not (Path(workload_dir) / "roofline.csv").is_file():
+            console_log(
+                "roofline",
+                f"{workload_dir}/roofline.csv does not exist",
             )
-        else:
-            # workload_dir is a string
-            base_dir = workload_dir
-
-        base_path = Path(base_dir)
-        roofline_csv = base_path / "roofline.csv"
-        if not roofline_csv.is_file():
-            console_log("roofline", f"{roofline_csv} does not exist")
-            return
-
-        if (
-            workload
-            and hasattr(workload, "roofline_peaks")
-            and workload.roofline_peaks.empty
-        ):
-            # CSV validation failed earlier, skip plot generation
-            console_warning("roofline", "Skipping plot generation")
             return None
-
-        self.__ai_data = calc_ai_analyze(
-            workload=workload,
-            mspec=self.__mspec,
-            sort_type=str(self.__run_parameters.get("sort_type")),
-            config=config,
-            arch_config=arch_config,
-        )
 
         self.__ceiling_data = construct_roof(
             roofline_parameters=self.__run_parameters, dtype=dtype
@@ -1159,10 +1082,9 @@ class Roofline:
         if not isinstance(dtype, str):
             console_error("Unsupported datatype input - must be str")
 
-        # Change vL1D to a interpretable str, if required
-        if "vL1D" in self.__run_parameters["mem_level"]:
-            self.__run_parameters["mem_level"].remove("vL1D")
-            self.__run_parameters["mem_level"].append("L1")
+        # Defensive copy; vL1D→L1 normalization happens at the analysis entry point.
+        raw_mem = self.__run_parameters["mem_level"]
+        mem_level = list(raw_mem) if isinstance(raw_mem, list) else raw_mem
 
         color_scheme = {
             "HBM": "blue+",
@@ -1190,12 +1112,14 @@ class Roofline:
         # Plot bandwidth lines
         cache_hierarchy = (
             ["HBM", "L2", "L1", "LDS"]
-            if self.__run_parameters["mem_level"] == "ALL"
-            else self.__run_parameters["mem_level"]
+            if mem_level == "ALL" or mem_level == ["ALL"]
+            else mem_level
         )
 
         for cache_level in cache_hierarchy:
             cache_key = cache_level.lower()
+            if self.__ceiling_data[cache_key][0] is None:
+                continue
             plt.plot(
                 self.__ceiling_data[cache_key][0],
                 self.__ceiling_data[cache_key][1],
@@ -1221,7 +1145,7 @@ class Roofline:
             )
 
         # Plot VALU and MFMA Peak
-        if dtype in PEAK_OPS_DATATYPES:
+        if dtype in PEAK_OPS_DATATYPES and self.__ceiling_data["valu"][0] is not None:
             plt.plot(
                 self.__ceiling_data["valu"][0],
                 [
@@ -1251,7 +1175,7 @@ class Roofline:
         else:
             console_warning(f"No PEAK measurement available for {dtype}")
 
-        if dtype in MFMA_DATATYPES:
+        if dtype in MFMA_DATATYPES and self.__ceiling_data["mfma"][0] is not None:
             plt.plot(
                 self.__ceiling_data["mfma"][0],
                 [
@@ -1311,7 +1235,8 @@ class Roofline:
                 console_debug("roofline", f"AI_{kernel_names[i]}: {val1}, {val2}")
         plt.xlabel(f"Arithmetic Intensity ({ops_flops}s/Byte)")
         plt.ylabel("Performance (GFLOP/sec)")
-        plt.title(f"Roofline ({dtype}) - {base_path}")
+        wdir = self.__run_parameters.get("workload_dir", "")
+        plt.title(f"Roofline ({dtype}) - {wdir}")
 
         # Canvas config
         plt.theme("pro")
@@ -1321,31 +1246,6 @@ class Roofline:
         # Build figure
         # Print plot using `plt._utility.write(self.cli_generate_plot(dtype))`
         return plt.build()
-
-    @demarcate
-    def standalone_roofline(
-        self,
-        df: dict[str, pd.DataFrame],
-    ) -> None:
-        self.roof_setup()
-
-        # Change vL1D to a interpretable str, if required
-        if "vL1D" in self.__run_parameters["mem_level"]:
-            self.__run_parameters["mem_level"].remove("vL1D")
-            self.__run_parameters["mem_level"].append("L1")
-
-        self.empirical_roofline(ret_df=df)
-
-    # NB: Currently the post_prossesing() method is the only one being used by
-    # rocprofiler-compute, we include pre_processing() and profile() methods for
-    # those who wish to borrow the roofline module
-    @abstractmethod
-    def post_processing(
-        self,
-        filtered_pmc: pd.DataFrame,
-    ) -> None:
-        if self.__run_parameters["is_standalone"]:
-            self.standalone_roofline(filtered_pmc)
 
     def get_dtype(self) -> list[str]:
         return self.__run_parameters["roofline_data_type"]

--- a/projects/rocprofiler-compute/src/utils/roofline_calc.py
+++ b/projects/rocprofiler-compute/src/utils/roofline_calc.py
@@ -33,7 +33,7 @@ import pandas as pd
 
 from utils import schema
 from utils.logger import console_debug, console_error, console_warning
-from utils.parser import apply_filters, eval_metric
+from utils.parser import eval_metric
 from utils.specs import MachineSpecs
 
 ################################################
@@ -233,10 +233,9 @@ def calc_ceilings(
         "mfma": [],
     }
 
+    mem_level = roofline_parameters["mem_level"]
     cache_hierarchy = (
-        CACHE_HIERARCHY
-        if roofline_parameters["mem_level"] == "ALL"
-        else roofline_parameters["mem_level"]
+        CACHE_HIERARCHY if mem_level == "ALL" or mem_level == ["ALL"] else mem_level
     )
 
     x1 = y1 = x2 = y2 = -1
@@ -345,6 +344,7 @@ def calc_ceilings(
 # Calculate relevant metrics for ai calculation
 def calc_ai_analyze(
     workload: schema.Workload,
+    pmc_df: pd.DataFrame,
     mspec: MachineSpecs,
     sort_type: str,
     config: dict[str, Any],
@@ -352,18 +352,26 @@ def calc_ai_analyze(
 ) -> dict[str, Union[list[list[float]], list[str]]]:
     """
     Calculate per-kernel metrics and AI points with Roofline yamls using eval_metric.
+
+    Caller must apply filters (e.g. parser.apply_filters) and pass the resulting
+    DataFrame as pmc_df. This function only computes AI data points.
     """
     console_debug("calc_ai_analyze", "Starting calc_ai analysis using Roofline yamls")
     plot_points = PlotPoints.empty()
 
     workload.roofline_metrics = {}
-    filtered_pmc = apply_filters(workload, workload.path, is_gui=False, debug=False)
 
     kernel_ids_to_process: list[int] = []
     kernel_top_table_id = 1
 
     if workload.filter_kernel_ids:
-        kernel_ids_to_process = workload.filter_kernel_ids
+        if all(isinstance(k, int) for k in workload.filter_kernel_ids):
+            kernel_ids_to_process = workload.filter_kernel_ids
+        elif kernel_top_table_id in workload.dfs:
+            # WebUI sets filter_kernel_ids as strings (kernel names), not
+            # int row indices. Process all IDs here; caller provides
+            # pmc_df already narrowed to the selected kernel(s).
+            kernel_ids_to_process = workload.dfs[kernel_top_table_id].index.tolist()
     elif kernel_top_table_id in workload.dfs:
         kernel_top_df = workload.dfs[kernel_top_table_id]
         kernel_ids_to_process = kernel_top_df.index.tolist()
@@ -388,9 +396,7 @@ def calc_ai_analyze(
         console_debug("roofline", f"Processing kernel {kernel_id}: {kernel_name[:50]}")
 
         # filter PMC data for specific kernel
-        kernel_pmc_df = filtered_pmc[
-            filtered_pmc["pmc_perf"]["Kernel_Name"] == kernel_name
-        ]
+        kernel_pmc_df = pmc_df[pmc_df["pmc_perf"]["Kernel_Name"] == kernel_name]
 
         if kernel_pmc_df.empty:
             console_debug("roofline", f"No PMC data for kernel {kernel_id}")
@@ -469,362 +475,6 @@ def calc_ai_analyze(
 
     console_debug("roofline", f"Generated {len(plot_points.kernelNames)} plot points")
     return plot_points.__dict__
-
-
-def calc_ai_profile(
-    mspec: MachineSpecs,
-    sort_type: str,
-    ret_df: dict[str, pd.DataFrame],
-    iteration_multiplexing: str,
-) -> dict[str, Union[list[list[float]], list[str]]]:
-    """Given counter data, calculate arithmetic intensity for each kernel
-    in the application. Leverage hard-coded equations to calculate AI values.
-
-    Used during profiling stage to generate roofline HTML, since Roofline yamls
-    are not available in the profiling stage."""
-
-    console_debug(
-        "calc_ai_profile: Starting legacy roofline calculation (from roofline_calc)"
-    )
-    df = ret_df["pmc_perf"]
-    # Sort by top kernels or top dispatches?
-    df = df.sort_values(by=["Kernel_Name"]).reset_index(drop=True)
-
-    total_flops = valu_flops = mfma_flops_f6f4 = mfma_flops_f8 = mfma_flops_bf16 = (
-        mfma_flops_f16
-    ) = mfma_iops_i8 = mfma_flops_f32 = mfma_flops_f64 = lds_data = L1cache_data = (
-        L2cache_data
-    ) = hbm_data = calls = totalDuration = avgDuration = 0.0
-
-    kernel_name = ""
-    my_list: list[AI_Data] = []
-
-    supported_dt = (
-        SUPPORTED_DATATYPES[mspec.gpu_arch]
-        if mspec.gpu_arch in SUPPORTED_DATATYPES
-        else None
-    )
-
-    for idx in df.index:
-        # CASE: Top kernels
-        # Calculate + append AI data if
-        # a) current KernelName is different than previous OR
-        # b) We've reached the end of list
-        at_end = idx + 1 == df.shape[0]
-        next_kernel_name = df["Kernel_Name"][idx + 1] if not at_end else ""
-        kernel_name = df["Kernel_Name"][idx]
-
-        # Skip this kernel dispatch row if any counter value is n/a
-        if df.iloc[idx].isna().any():
-            continue
-
-        try:
-            total_flops += (
-                (
-                    64
-                    * (
-                        df["SQ_INSTS_VALU_ADD_F16"][idx]
-                        + df["SQ_INSTS_VALU_MUL_F16"][idx]
-                        + (2 * df["SQ_INSTS_VALU_FMA_F16"][idx])
-                        + df["SQ_INSTS_VALU_TRANS_F16"][idx]
-                    )
-                )
-                + (
-                    64
-                    * (
-                        df["SQ_INSTS_VALU_ADD_F32"][idx]
-                        + df["SQ_INSTS_VALU_MUL_F32"][idx]
-                        + (2 * df["SQ_INSTS_VALU_FMA_F32"][idx])
-                        + df["SQ_INSTS_VALU_TRANS_F32"][idx]
-                    )
-                )
-                + (
-                    64
-                    * (
-                        df["SQ_INSTS_VALU_ADD_F64"][idx]
-                        + df["SQ_INSTS_VALU_MUL_F64"][idx]
-                        + (2 * df["SQ_INSTS_VALU_FMA_F64"][idx])
-                        + df["SQ_INSTS_VALU_TRANS_F64"][idx]
-                    )
-                )
-                + (df["SQ_INSTS_VALU_MFMA_MOPS_F16"][idx] * 512)
-                + (df["SQ_INSTS_VALU_MFMA_MOPS_BF16"][idx] * 512)
-                + (df["SQ_INSTS_VALU_MFMA_MOPS_F32"][idx] * 512)
-                + (df["SQ_INSTS_VALU_MFMA_MOPS_F64"][idx] * 512)
-            )
-            if "FP8" in supported_dt:
-                total_flops += df["SQ_INSTS_VALU_MFMA_MOPS_F8"][idx] * 512
-            if ("FP4" in supported_dt) or ("FP6" in supported_dt):
-                total_flops += df["SQ_INSTS_VALU_MFMA_MOPS_F6F4"][idx] * 512
-        except KeyError as e:
-            console_debug(
-                "roofline",
-                f"{kernel_name[:35]}: Skipped total_flops at index \
-                    {idx} due to {e}",
-            )
-            pass
-        try:
-            valu_flops += (
-                64
-                * (
-                    df["SQ_INSTS_VALU_ADD_F16"][idx]
-                    + df["SQ_INSTS_VALU_MUL_F16"][idx]
-                    + (2 * df["SQ_INSTS_VALU_FMA_F16"][idx])
-                    + df["SQ_INSTS_VALU_TRANS_F16"][idx]
-                )
-                + 64
-                * (
-                    df["SQ_INSTS_VALU_ADD_F32"][idx]
-                    + df["SQ_INSTS_VALU_MUL_F32"][idx]
-                    + (2 * df["SQ_INSTS_VALU_FMA_F32"][idx])
-                    + df["SQ_INSTS_VALU_TRANS_F32"][idx]
-                )
-                + 64
-                * (
-                    df["SQ_INSTS_VALU_ADD_F64"][idx]
-                    + df["SQ_INSTS_VALU_MUL_F64"][idx]
-                    + (2 * df["SQ_INSTS_VALU_FMA_F64"][idx])
-                    + df["SQ_INSTS_VALU_TRANS_F64"][idx]
-                )
-            )
-        except KeyError as e:
-            console_debug(
-                "roofline",
-                f"{kernel_name[:35]}: Skipped valu_flops at index {idx} due to {e}",
-            )
-            pass
-
-        try:
-            if "FP8" in supported_dt:
-                mfma_flops_f8 += df["SQ_INSTS_VALU_MFMA_MOPS_F8"][idx] * 512
-            if ("FP4" in supported_dt) or ("FP6" in supported_dt):
-                mfma_flops_f6f4 += df["SQ_INSTS_VALU_MFMA_MOPS_F6F4"][idx] * 512
-            mfma_flops_f16 += df["SQ_INSTS_VALU_MFMA_MOPS_F16"][idx] * 512
-            mfma_flops_bf16 += df["SQ_INSTS_VALU_MFMA_MOPS_BF16"][idx] * 512
-            mfma_flops_f32 += df["SQ_INSTS_VALU_MFMA_MOPS_F32"][idx] * 512
-            mfma_flops_f64 += df["SQ_INSTS_VALU_MFMA_MOPS_F64"][idx] * 512
-            mfma_iops_i8 += df["SQ_INSTS_VALU_MFMA_MOPS_I8"][idx] * 512
-        except KeyError as e:
-            console_debug(
-                "roofline",
-                f"{kernel_name[:35]}: Skipped mfma ops at index {idx} due to {e}",
-            )
-            pass
-
-        try:
-            lds_data += (
-                (df["SQ_LDS_IDX_ACTIVE"][idx] - df["SQ_LDS_BANK_CONFLICT"][idx])
-                * 4
-                * (mspec.lds_banks_per_cu)
-            )
-        except KeyError as e:
-            console_debug(
-                "roofline",
-                f"{kernel_name[:35]}: Skipped lds_data at index {idx} due to {e}",
-            )
-            pass
-
-        try:
-            L1cache_data += df["TCP_TOTAL_CACHE_ACCESSES_sum"][idx] * 64
-        except KeyError as e:
-            console_debug(
-                "roofline",
-                f"{kernel_name[:35]}: Skipped L1cache_data at index \
-                    {idx} due to {e}",
-            )
-            pass
-
-        try:
-            L2cache_data += (
-                df["TCP_TCC_WRITE_REQ_sum"][idx] * 64
-                + df["TCP_TCC_ATOMIC_WITH_RET_REQ_sum"][idx] * 64
-                + df["TCP_TCC_ATOMIC_WITHOUT_RET_REQ_sum"][idx] * 64
-                + df["TCP_TCC_READ_REQ_sum"][idx] * 64
-            )
-        except KeyError as e:
-            console_debug(
-                "roofline",
-                f"{kernel_name[:35]}: Skipped L2cache_data at index \
-                    {idx} due to {e}",
-            )
-            pass
-        try:
-            if mspec.gpu_series == "MI200":
-                hbm_data += (
-                    (df["TCC_EA_RDREQ_32B_sum"][idx] * 32)
-                    + (
-                        (df["TCC_EA_RDREQ_sum"][idx] - df["TCC_EA_RDREQ_32B_sum"][idx])
-                        * 64
-                    )
-                    + (df["TCC_EA_WRREQ_64B_sum"][idx] * 64)
-                    + (
-                        (df["TCC_EA_WRREQ_sum"][idx] - df["TCC_EA_WRREQ_64B_sum"][idx])
-                        * 32
-                    )
-                )
-            elif mspec.gpu_series == "MI350":
-                # Use TCC_EA0_RDREQ_128B_sum TCC_EA0_RDREQ_64B_sum to calculate hbm_data
-                hbm_data += (
-                    (df["TCC_EA0_RDREQ_128B_sum"][idx] * 128)
-                    + (df["TCC_EA0_RDREQ_64B_sum"][idx] * 64)
-                    + (df["TCC_EA0_RDREQ_32B_sum"][idx] * 32)
-                    + (
-                        (
-                            df["TCC_EA0_WRREQ_sum"][idx]
-                            - df["TCC_EA0_WRREQ_64B_sum"][idx]
-                        )
-                        * 32
-                    )
-                    + (df["TCC_EA0_WRREQ_64B_sum"][idx] * 64)
-                )
-            else:
-                # Use TCC_BUBBLE_sum to calculate hbm_data
-                hbm_data += (
-                    (df["TCC_BUBBLE_sum"][idx] * 128)
-                    + (df["TCC_EA0_RDREQ_32B_sum"][idx] * 32)
-                    + (
-                        (
-                            df["TCC_EA0_RDREQ_sum"][idx]
-                            - df["TCC_BUBBLE_sum"][idx]
-                            - df["TCC_EA0_RDREQ_32B_sum"][idx]
-                        )
-                        * 64
-                    )
-                    + (
-                        (
-                            df["TCC_EA0_WRREQ_sum"][idx]
-                            - df["TCC_EA0_WRREQ_64B_sum"][idx]
-                        )
-                        * 32
-                    )
-                    + (df["TCC_EA0_WRREQ_64B_sum"][idx] * 64)
-                )
-        except KeyError as e:
-            console_debug(
-                "roofline",
-                f"{kernel_name[:35]}: Skipped hbm_data at index {idx} due to {e}",
-            )
-            pass
-
-        totalDuration += df["End_Timestamp"][idx] - df["Start_Timestamp"][idx]
-        avgDuration += df["End_Timestamp"][idx] - df["Start_Timestamp"][idx]
-        calls += 1
-
-        if sort_type == "kernels" and (at_end or (kernel_name != next_kernel_name)):
-            my_list.append(
-                AI_Data(
-                    kernel_name,
-                    calls,
-                    total_flops / calls,
-                    valu_flops / calls,
-                    mfma_flops_f6f4 / calls,
-                    mfma_flops_f8 / calls,
-                    mfma_flops_f16 / calls,
-                    mfma_flops_bf16 / calls,
-                    mfma_flops_f32 / calls,
-                    mfma_flops_f64 / calls,
-                    mfma_iops_i8 / calls,
-                    lds_data / calls,
-                    L1cache_data / calls,
-                    L2cache_data / calls,
-                    hbm_data / calls,
-                    totalDuration,
-                    avgDuration / calls,
-                )
-            )
-            console_debug(f"Just added {kernel_name} to AI_Data. # of calls: {calls}")
-
-            total_flops = valu_flops = mfma_flops_f6f4 = mfma_flops_f8 = (
-                mfma_flops_bf16
-            ) = mfma_flops_f16 = mfma_iops_i8 = mfma_flops_f32 = mfma_flops_f64 = (
-                lds_data
-            ) = L1cache_data = L2cache_data = hbm_data = calls = totalDuration = (
-                avgDuration
-            ) = 0.0
-
-        if sort_type == "dispatches":
-            my_list.append(
-                AI_Data(
-                    kernel_name,
-                    calls,
-                    total_flops,
-                    valu_flops,
-                    mfma_flops_f6f4,
-                    mfma_flops_f8,
-                    mfma_flops_f16,
-                    mfma_flops_bf16,
-                    mfma_flops_f32,
-                    mfma_flops_f64,
-                    mfma_iops_i8,
-                    lds_data,
-                    L1cache_data,
-                    L2cache_data,
-                    hbm_data,
-                    totalDuration,
-                    avgDuration,
-                )
-            )
-            total_flops = valu_flops = mfma_flops_f6f4 = mfma_flops_f8 = (
-                mfma_flops_bf16
-            ) = mfma_flops_f16 = mfma_iops_i8 = mfma_flops_f32 = mfma_flops_f64 = (
-                lds_data
-            ) = L1cache_data = L2cache_data = hbm_data = calls = totalDuration = (
-                avgDuration
-            ) = 0.0
-
-    my_list.sort(key=lambda x: x.totalDuration, reverse=True)
-
-    intensities: dict[str, list[float]] = {"ai_l1": [], "ai_l2": [], "ai_hbm": []}
-    curr_perf: list[float] = []
-    kernel_names: list[str] = []
-
-    # Create list of top N intensities
-    for i in range(min(TOP_N, len(my_list))):
-        kernel_data = my_list[i]
-
-        if my_list[i].total_flops == 0:
-            console_debug(
-                f"No flops counted for {my_list[i].KernelName}, "
-                "arithmetic intensities will not display on plots."
-            )
-
-        kernel_names.append(my_list[i].KernelName)
-
-        # Calculate arithmetic intensities
-        intensities["ai_l1"].append(
-            kernel_data.total_flops / kernel_data.L1cache_data
-            if kernel_data.L1cache_data
-            else 0
-        )
-        intensities["ai_l2"].append(
-            kernel_data.total_flops / kernel_data.L2cache_data
-            if kernel_data.L2cache_data
-            else 0
-        )
-        intensities["ai_hbm"].append(
-            kernel_data.total_flops / kernel_data.hbm_data
-            if kernel_data.hbm_data
-            else 0
-        )
-        curr_perf.append(
-            kernel_data.total_flops / kernel_data.avgDuration
-            if kernel_data.avgDuration
-            else 0
-        )
-
-    # Create intensity points for plotting
-    intensity_points: dict[str, Union[list[list[float]], list[str]]] = {}
-
-    for ai_type in intensities:
-        values = intensities[ai_type]
-
-        x = values
-        y = curr_perf[: len(values)]
-        intensity_points[ai_type] = [x, y]
-
-    # Add kernel names
-    intensity_points["kernelNames"] = kernel_names
-    return intensity_points
 
 
 def validate_roofline_csv(workload_dir: Union[str, Path, list]) -> tuple[bool, str]:
@@ -944,10 +594,9 @@ def construct_roof(
     if dtype in PEAK_OPS_DATATYPES:
         expected_columns.append(f"{dtype}{ops_flops}")
 
+    mem_level = roofline_parameters["mem_level"]
     cache_hierarchy = (
-        CACHE_HIERARCHY
-        if roofline_parameters["mem_level"] == "ALL"
-        else roofline_parameters["mem_level"]
+        CACHE_HIERARCHY if mem_level == "ALL" or mem_level == ["ALL"] else mem_level
     )
     for cache_level in cache_hierarchy:
         expected_columns.append(f"{cache_level}Bw")

--- a/projects/rocprofiler-compute/src/utils/utils.py
+++ b/projects/rocprofiler-compute/src/utils/utils.py
@@ -1752,7 +1752,7 @@ def gen_sysinfo(
     df["workload_name"] = workload_name
 
     blocks = ["SQ", "LDS", "SQC", "TA", "TD", "TCP", "TCC", "SPI", "CPC", "CPF"]
-    if hasattr(soc, "roofline_obj") and (not skip_roof):
+    if not skip_roof:
         blocks.append("roofline")
     df["ip_blocks"] = "|".join(blocks)
 

--- a/projects/rocprofiler-compute/tests/test_analyze_commands.py
+++ b/projects/rocprofiler-compute/tests/test_analyze_commands.py
@@ -33,7 +33,7 @@ import pytest
 import test_utils
 
 config = {}
-config["cleanup"] = True if "PYTEST_XDIST_WORKER_COUNT" in os.environ else False
+config["cleanup"] = True
 
 indirs = [
     "tests/workloads/vcopy/MI100",
@@ -42,6 +42,8 @@ indirs = [
     "tests/workloads/vcopy/MI300X_A1",
     "tests/workloads/vcopy/MI350",
 ]
+
+roofline_dir = "tests/workloads/mem_levels_HBM/MI200"
 
 time_units = {"s": 10**9, "ms": 10**6, "us": 10**3, "ns": 1}
 
@@ -1742,5 +1744,308 @@ def test_list_torch_operators_no_trace_data(
     output = capsys.readouterr().out
     assert "PyTorch Operators in:" in output
     assert "Total: 0 operators" in output
+
+    test_utils.clean_output_dir(config["cleanup"], workload_dir)
+
+
+# =============================================================================
+# Roofline analyze tests
+# =============================================================================
+
+roofline_soc = test_utils.gpu_soc()
+
+
+def test_analyze_generates_roofline_html(
+    binary_handler_analyze_rocprof_compute,
+):
+    """
+    Analyze generates roofline HTML from existing workload data.
+    Uses MI200 workload with roofline.csv.
+    """
+    if roofline_soc is None:
+        pytest.skip("No supported GPU detected")
+    if roofline_soc in ("MI100"):
+        pytest.skip("Roofline not supported on MI100")
+
+    workload_dir = test_utils.setup_workload_dir(roofline_dir)
+
+    assert (Path(workload_dir) / "roofline.csv").exists()
+
+    code = binary_handler_analyze_rocprof_compute([
+        "analyze",
+        "--path",
+        workload_dir,
+        "--roofline-data-type",
+        "FP32",
+    ])
+    assert code == 0
+
+    html_files = list(Path(workload_dir).glob("empirRoof_*.html"))
+    assert len(html_files) > 0, "Analyze should generate roofline HTML files"
+
+    test_utils.clean_output_dir(config["cleanup"], workload_dir)
+
+
+def test_analyze_roofline_multiple_datatypes(
+    binary_handler_analyze_rocprof_compute,
+):
+    """
+    Analyze with multiple data types.
+    Verifies each datatype can be requested independently.
+    """
+    if roofline_soc is None:
+        pytest.skip("No supported GPU detected")
+    if roofline_soc in ("MI100"):
+        pytest.skip("Roofline not supported on MI100")
+
+    workload_dir = test_utils.setup_workload_dir(roofline_dir)
+
+    assert (Path(workload_dir) / "roofline.csv").exists()
+
+    for dtype in ["FP32"]:
+        code = binary_handler_analyze_rocprof_compute([
+            "analyze",
+            "--path",
+            workload_dir,
+            "--roofline-data-type",
+            dtype,
+        ])
+        assert code == 0
+
+    html_files = list(Path(workload_dir).glob("empirRoof_*.html"))
+    assert len(html_files) > 0, "Analyze should generate roofline HTML files"
+
+    test_utils.clean_output_dir(config["cleanup"], workload_dir)
+
+
+def test_analyze_missing_roofline_csv_graceful(
+    binary_handler_analyze_rocprof_compute,
+):
+    """
+    Analyze without roofline.csv should not crash.
+    Uses a workload directory that has sysinfo.csv but no roofline.csv.
+    """
+    workload_dir = test_utils.setup_workload_dir(roofline_dir)
+    roofline_csv = Path(workload_dir) / "roofline.csv"
+    if roofline_csv.exists():
+        roofline_csv.unlink()
+
+    code = binary_handler_analyze_rocprof_compute([
+        "analyze",
+        "--path",
+        workload_dir,
+    ])
+    assert code == 0
+
+    test_utils.clean_output_dir(config["cleanup"], workload_dir)
+
+
+def test_analyze_roofline_idempotent(
+    binary_handler_analyze_rocprof_compute,
+):
+    """
+    Running analyze twice on the same profiling output should produce
+    consistent results without errors.
+    """
+    if roofline_soc is None:
+        pytest.skip("No supported GPU detected")
+    if roofline_soc in ("MI100"):
+        pytest.skip("Roofline not supported on MI100")
+
+    workload_dir = test_utils.setup_workload_dir(roofline_dir)
+
+    assert (Path(workload_dir) / "roofline.csv").exists()
+
+    analyze_args = [
+        "analyze",
+        "--path",
+        workload_dir,
+        "--roofline-data-type",
+        "FP32",
+    ]
+
+    code1 = binary_handler_analyze_rocprof_compute(analyze_args)
+    assert code1 == 0
+
+    code2 = binary_handler_analyze_rocprof_compute(analyze_args)
+    assert code2 == 0
+
+    html_files = list(Path(workload_dir).glob("empirRoof_*.html"))
+    assert len(html_files) > 0, "Analyze should generate roofline HTML files"
+
+    test_utils.clean_output_dir(config["cleanup"], workload_dir)
+
+
+def test_analyze_corrupted_roofline_csv_graceful(
+    binary_handler_analyze_rocprof_compute,
+):
+    """
+    Analyze with a corrupted roofline.csv should handle gracefully.
+    """
+    import shutil
+    import tempfile
+
+    if os.path.exists(roofline_dir):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            workload_dir = os.path.join(temp_dir, "corrupted_workload")
+            shutil.copytree(roofline_dir, workload_dir)
+
+            roofline_csv = Path(workload_dir) / "roofline.csv"
+            roofline_csv.write_text("this,is,bad,csv")
+
+            code = binary_handler_analyze_rocprof_compute([
+                "analyze",
+                "-b 4",
+                "--path",
+                workload_dir,
+            ])
+            assert code == 0
+
+
+def test_roof_invalid_data_type(binary_handler_analyze_rocprof_compute):
+    """Invalid --roofline-data-type should be caught by analyze argparser."""
+    workload_dir = test_utils.setup_workload_dir(roofline_dir)
+
+    assert (Path(workload_dir) / "roofline.csv").exists()
+
+    code = binary_handler_analyze_rocprof_compute([
+        "analyze",
+        "--path",
+        workload_dir,
+        "--roofline-data-type",
+        "INVALID_TYPE",
+    ])
+    assert code != 0, "Invalid datatype should be rejected by argparser"
+
+    test_utils.clean_output_dir(config["cleanup"], workload_dir)
+
+
+def test_roofline_ceiling_data_validation(binary_handler_analyze_rocprof_compute):
+    """Invalid --mem-level should be caught during analyze."""
+    workload_dir = test_utils.setup_workload_dir(roofline_dir)
+
+    assert (Path(workload_dir) / "roofline.csv").exists()
+
+    code = binary_handler_analyze_rocprof_compute([
+        "analyze",
+        "--path",
+        workload_dir,
+        "--mem-level",
+        "INVALID_LEVEL",
+    ])
+    assert code >= 0
+
+    test_utils.clean_output_dir(config["cleanup"], workload_dir)
+
+
+roofline_mem_level_dirs = {
+    "vL1D": "tests/workloads/mem_levels_vL1D/MI200",
+    "LDS": "tests/workloads/mem_levels_LDS/MI200",
+}
+
+
+@pytest.mark.parametrize(
+    "mem_level",
+    ["vL1D", "LDS"],
+    ids=["vL1D", "LDS"],
+)
+def test_roof_mem_levels(binary_handler_analyze_rocprof_compute, mem_level):
+    """Analyze with --mem-level generates roofline HTML output."""
+    workload_src = roofline_mem_level_dirs[mem_level]
+    if not os.path.exists(workload_src):
+        pytest.skip(f"Workload directory {workload_src} not found")
+
+    workload_dir = test_utils.setup_workload_dir(workload_src, param_id=mem_level)
+
+    code = binary_handler_analyze_rocprof_compute([
+        "analyze",
+        "--path",
+        workload_dir,
+        "--mem-level",
+        mem_level,
+    ])
+    assert code == 0
+
+    html_files = list(Path(workload_dir).glob("empirRoof_*.html"))
+    assert len(html_files) > 0, "Analyze should generate roofline HTML files"
+
+    test_utils.clean_output_dir(config["cleanup"], workload_dir)
+
+
+def test_roofline_missing_file_handling():
+    """cli_generate_plot with empty ai_data returns None."""
+    import sys
+
+    sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
+
+    from roofline import Roofline
+    from utils.file_io import load_sys_info
+    from utils.specs import generate_machine_specs
+
+    class MockArgs:
+        def __init__(self):
+            self.roof_only = True
+            self.mem_level = "ALL"
+            self.sort = "ALL"
+            self.roofline_data_type = ["FP32"]
+
+    args = MockArgs()
+    workload_dir = test_utils.setup_workload_dir(roofline_dir)
+    sys_info = load_sys_info(f"{workload_dir}/sysinfo.csv")
+    sys_info_dict = {key: value[0] for key, value in sys_info.to_dict("list").items()}
+    mspec = generate_machine_specs(args, sys_info_dict)
+
+    run_parameters = {
+        "workload_dir": workload_dir,
+        "device_id": 0,
+        "sort_type": "kernels",
+        "mem_level": "ALL",
+        "is_standalone": True,
+        "roofline_data_type": ["FP32"],
+    }
+
+    roofline_instance = Roofline(args, mspec, run_parameters)
+    result = roofline_instance.cli_generate_plot("FP32", ai_data={})
+    assert result is None
+
+    test_utils.clean_output_dir(config["cleanup"], workload_dir)
+
+
+def test_roofline_invalid_datatype_cli():
+    """cli_generate_plot with invalid datatype returns None."""
+    import sys
+
+    sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
+
+    from roofline import Roofline
+    from utils.file_io import load_sys_info
+    from utils.specs import generate_machine_specs
+
+    class MockArgs:
+        def __init__(self):
+            self.roof_only = True
+            self.mem_level = "ALL"
+            self.sort = "ALL"
+            self.roofline_data_type = ["FP32"]
+
+    args = MockArgs()
+
+    workload_dir = test_utils.setup_workload_dir(roofline_dir)
+    sys_info = load_sys_info(f"{workload_dir}/sysinfo.csv")
+    sys_info_dict = {key: value[0] for key, value in sys_info.to_dict("list").items()}
+    mspec = generate_machine_specs(args, sys_info_dict)
+
+    run_parameters = {
+        "workload_dir": workload_dir,
+        "device_id": 0,
+        "sort_type": "kernels",
+        "mem_level": "ALL",
+        "is_standalone": True,
+        "roofline_data_type": ["FP32"],
+    }
+
+    roofline_instance = Roofline(args, mspec, run_parameters)
+    result = roofline_instance.cli_generate_plot("INVALID_DATATYPE", ai_data={})
+    assert result is None
 
     test_utils.clean_output_dir(config["cleanup"], workload_dir)

--- a/projects/rocprofiler-compute/tests/test_profile_general.py
+++ b/projects/rocprofiler-compute/tests/test_profile_general.py
@@ -86,7 +86,6 @@ CSVS = sorted([
 ])
 
 ROOF_ONLY_FILES = sorted([
-    "empirRoof_gpu-0_FP32.html",
     "pmc_perf.csv",
     "roofline.csv",
     "sysinfo.csv",
@@ -1147,11 +1146,8 @@ def test_output_directory_no_name_no_output_dir(
 @pytest.mark.roofline_1
 def test_roof_basic_validation(binary_handler_profile_rocprof_compute):
     """
-    Test basic roofline HTML generation with full validation pipeline.
-    This test runs the complete validation flow including counter logging
-    and metric comparison (if enabled in config). Validates that roofline HTMLs
-    are generated with the integrated multi-subplot layout (roofline plot +
-    plot points table + kernel names table).
+    Test basic roofline CSV generation in profile mode.
+    Validates that roofline.csv is generated via microbenchmarks.
     """
     if soc in ("MI100"):
         # roofline is not supported on MI100
@@ -1165,7 +1161,6 @@ def test_roof_basic_validation(binary_handler_profile_rocprof_compute):
         config, workload_dir, options, check_success=False, roof=True
     )
 
-    # assert successful run
     assert returncode == 0
     file_dict = test_utils.check_csv_files(workload_dir, 1, num_kernels)
 
@@ -1178,72 +1173,6 @@ def test_roof_basic_validation(binary_handler_profile_rocprof_compute):
     )
 
     test_utils.clean_output_dir(config["cleanup"], workload_dir)
-
-
-@pytest.mark.roofline_1
-def test_roof_multiple_data_types(binary_handler_profile_rocprof_compute):
-    """Test roofline with multiple data types"""
-    if soc in ("MI100"):
-        # roofline is not supported on MI100
-        pytest.skip("Roofline not supported on MI100")
-        return
-
-    # test multiple data types
-    data_types = ["FP32"]  # start with just FP32 to avoid complex validation
-
-    for dtype in data_types:
-        options = [
-            "--device",
-            "0",
-            "--roof-only",
-            "--roofline-data-type",
-            dtype,
-        ]
-        workload_dir = test_utils.get_output_dir()
-
-        try:
-            returncode = binary_handler_profile_rocprof_compute(
-                config, workload_dir, options, check_success=False, roof=True
-            )
-
-            if returncode == 0:
-                assert os.path.exists(f"{workload_dir}/pmc_perf.csv")
-
-                file_dict = test_utils.check_csv_files(workload_dir, 1, num_kernels)
-                assert sorted(list(file_dict.keys())) == ROOF_ONLY_FILES
-            else:
-                pass
-        finally:
-            test_utils.clean_output_dir(config["cleanup"], workload_dir)
-
-
-@pytest.mark.roofline_1
-def test_roof_invalid_data_type(binary_handler_profile_rocprof_compute):
-    """Test roofline with invalid data type"""
-    if soc in ("MI100"):
-        # roofline is not supported on MI100
-        pytest.skip("Roofline not supported on MI100")
-        return
-
-    # test invalid data types
-    invalid_options = [
-        "--device",
-        "0",
-        "--roof-only",
-        "--roofline-data-type",
-        "INVALID_TYPE",
-    ]
-    workload_dir = test_utils.get_output_dir()
-
-    try:
-        returncode = binary_handler_profile_rocprof_compute(
-            config, workload_dir, invalid_options, check_success=False, roof=True
-        )
-
-        assert returncode >= 0
-
-    finally:
-        test_utils.clean_output_dir(config["cleanup"], workload_dir)
 
 
 @pytest.mark.roofline_1
@@ -1507,94 +1436,8 @@ def test_roofline_kernel_filter(binary_handler_profile_rocprof_compute):
     )
     assert returncode == 0
 
-    # html file should still be present in all cases
-    # check at the end just in case that it is non-zero file
-    html_files = list(Path(workload_dir).glob("empirRoof_*.html"))
-    assert len(html_files) > 0, (
-        "Roofline HTML should still be generated when non-existent kernels are provided"
-    )
-
-    test_utils.clean_output_dir(config["cleanup"], workload_dir)
-
-
-@pytest.mark.roofline_1
-def test_roofline_unsupported_datatype_error(binary_handler_profile_rocprof_compute):
-    """
-    Test datatype validation error in empirical_roofline()
-    This should trigger console_error for unsupported datatype
-    """
-    if soc in ("MI100"):
-        pytest.skip("Skipping roofline test for MI100")
-        return
-
-    options = [
-        "--device",
-        "0",
-        "--roof-only",
-        "--roofline-data-type",
-        "UNSUPPORTED_TYPE",
-    ]
-    workload_dir = test_utils.get_output_dir()
-
-    returncode = binary_handler_profile_rocprof_compute(  # noqa: F841
-        config, workload_dir, options, check_success=False, roof=True
-    )
-
-    test_utils.clean_output_dir(config["cleanup"], workload_dir)
-
-
-@pytest.mark.roofline_2
-@pytest.mark.parametrize(
-    "options,expected_files,test_id",
-    [
-        (
-            ["--device", "0", "--roof-only", "--roofline-data-type", "FP32"],
-            ["empirRoof_gpu-0_FP32.html"],
-            "FP32_datatype",
-        ),
-        (
-            ["--device", "0", "--roof-only", "--roofline-data-type", "FP16"],
-            ["empirRoof_gpu-0_FP16.html"],
-            "FP16_datatype",
-        ),
-        (
-            ["--device", "0", "--roof-only", "--kernel", "KERNEL_NAME_PLACEHOLDER"],
-            ["EXPECTED_FILE_PLACEHOLDER"],
-            "kernel_filter",
-        ),
-    ],
-    ids=["FP32_datatype", "FP16_datatype", "kernel_filter"],
-)
-def test_roof_plot_modes(
-    binary_handler_profile_rocprof_compute, options, expected_files, test_id
-):
-    if soc in ("MI100"):
-        pytest.skip("Skipping roofline test for MI100")
-        return
-
-    # Handle dynamic kernel name substitution for the kernel_filter test case
-    options = [
-        config["kernel_name_1"] if opt == "KERNEL_NAME_PLACEHOLDER" else opt
-        for opt in options
-    ]
-    # Test `--kernel` filtering outputs are present and labelled correctly
-    filter_empirRoof = "empirRoof_gpu-0_" + config["kernel_name_1"]
-    expected_files = [
-        filter_empirRoof if f == "EXPECTED_FILE_PLACEHOLDER" else f
-        for f in expected_files
-    ]
-
-    workload_dir = test_utils.get_output_dir(param_id=test_id)
-
-    returncode = binary_handler_profile_rocprof_compute(
-        config, workload_dir, options, check_success=False, roof=True
-    )
-    assert returncode == 0
-
-    for expected_file in expected_files:
-        expected_path = os.path.join(workload_dir, expected_file)
-        if os.path.exists(expected_path):
-            assert os.path.getsize(expected_path) > 0
+    # Verify CSV
+    assert (Path(workload_dir) / "roofline.csv").exists()
 
     test_utils.clean_output_dir(config["cleanup"], workload_dir)
 
@@ -1637,136 +1480,6 @@ def test_roof_error_handling(binary_handler_profile_rocprof_compute):
     pmc_perf_path = os.path.join(workload_dir, "pmc_perf.csv")
     if os.path.exists(pmc_perf_path):
         os.remove(pmc_perf_path)
-
-    returncode = binary_handler_profile_rocprof_compute(  # noqa: F841
-        config, workload_dir, options, check_success=False, roof=True
-    )
-
-    test_utils.clean_output_dir(config["cleanup"], workload_dir)
-
-
-@pytest.mark.roofline_2
-def test_roofline_missing_file_handling(binary_handler_profile_rocprof_compute):
-    """
-    Test handling of missing roofline.csv file
-    This should trigger error message in cli_generate_plot()
-    """
-    if soc in ("MI100"):
-        pytest.skip("Skipping roofline test for MI100")
-        return
-
-    import sys
-    from pathlib import Path
-
-    sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
-
-    try:
-        from roofline import Roofline
-        from utils.schema import Workload
-        from utils.specs import generate_machine_specs
-
-        class MockArgs:
-            def __init__(self):
-                self.roof_only = True
-                self.mem_level = "ALL"
-                self.sort = "ALL"
-                self.roofline_data_type = ["FP32"]
-
-        args = MockArgs()
-        mspec = generate_machine_specs(None, None)
-        workload = Workload()
-
-        workload_dir = test_utils.get_output_dir()
-
-        run_parameters = {
-            "workload_dir": workload_dir,
-            "device_id": 0,
-            "sort_type": "kernels",
-            "mem_level": "ALL",
-            "is_standalone": True,
-            "roofline_data_type": ["FP32"],
-        }
-
-        roofline_instance = Roofline(args, mspec, run_parameters)
-
-        result = roofline_instance.cli_generate_plot(
-            "FP32", workload, config, arch_config
-        )
-
-        assert result is None
-
-        test_utils.clean_output_dir(config["cleanup"], workload_dir)
-
-    except ImportError:
-        pytest.skip("Could not import roofline module for direct testing")
-
-
-@pytest.mark.roofline_2
-def test_roofline_invalid_datatype_cli(binary_handler_profile_rocprof_compute):
-    """
-    Test CLI plot generation with invalid datatype
-    This should trigger error in cli_generate_plot() lines 617-624
-    """
-    if soc in ("MI100"):
-        pytest.skip("Skipping roofline test for MI100")
-        return
-
-    import sys
-    from pathlib import Path
-
-    sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
-
-    try:
-        from roofline import Roofline
-        from utils.schema import Workload
-        from utils.specs import generate_machine_specs
-
-        class MockArgs:
-            def __init__(self):
-                self.roof_only = True
-                self.mem_level = "ALL"
-                self.sort = "ALL"
-                self.roofline_data_type = ["FP32"]
-
-        args = MockArgs()
-        mspec = generate_machine_specs(None, None)
-        workload = Workload()
-
-        run_parameters = {
-            "workload_dir": test_utils.get_output_dir(),
-            "device_id": 0,
-            "sort_type": "kernels",
-            "mem_level": "ALL",
-            "is_standalone": True,
-            "roofline_data_type": ["FP32"],
-        }
-
-        roofline_instance = Roofline(args, mspec, run_parameters)
-
-        result = roofline_instance.cli_generate_plot(
-            "INVALID_DATATYPE", workload, config, arch_config
-        )
-
-        assert result is None
-
-        test_utils.clean_output_dir(config["cleanup"], run_parameters["workload_dir"])
-
-    except ImportError:
-        pytest.skip("Could not import roofline module for direct testing")
-
-
-@pytest.mark.roofline_2
-def test_roofline_ceiling_data_validation(binary_handler_profile_rocprof_compute):
-    """
-    Test ceiling data validation in generate_plot()
-    This covers error handling in lines 516-526
-    """
-    if soc in ("MI100"):
-        pytest.skip("Skipping roofline test for MI100")
-        return
-
-    options = ["--device", "0", "--roof-only", "--mem-level", "INVALID_LEVEL"]
-    workload_dir = test_utils.get_output_dir()
 
     returncode = binary_handler_profile_rocprof_compute(  # noqa: F841
         config, workload_dir, options, check_success=False, roof=True
@@ -1827,7 +1540,15 @@ def test_roofline_plot_points_data_generation():
             "ai_hbm": "red",
         }
 
-        roofline_instance = Roofline(args, mspec)
+        run_parameters = {
+            "workload_dir": None,
+            "device_id": 0,
+            "sort_type": "kernels",
+            "mem_level": "ALL",
+            "is_standalone": False,
+            "roofline_data_type": ["FP32"],
+        }
+        roofline_instance = Roofline(args, mspec, run_parameters)
 
         for cache_level in ["ai_l1", "ai_l2", "ai_hbm"]:
             if cache_level in mock_ai_data:
@@ -1900,7 +1621,15 @@ def test_roofline_bound_status_calculation():
 
         args = MockArgs()
         mspec = generate_machine_specs(None, None)
-        roofline_instance = Roofline(args, mspec)
+        run_parameters = {
+            "workload_dir": None,
+            "device_id": 0,
+            "sort_type": "kernels",
+            "mem_level": "ALL",
+            "is_standalone": False,
+            "roofline_data_type": ["FP32"],
+        }
+        roofline_instance = Roofline(args, mspec, run_parameters)
 
         ceiling_data = {
             "hbm": [[0.01, 10], [10, 1000], 100],
@@ -1950,13 +1679,7 @@ def test_roofline_bound_status_calculation():
 @pytest.mark.roofline_2
 def test_roofline_many_kernels_dynamic_height(binary_handler_profile_rocprof_compute):
     """
-    Test roofline HTML generation with many kernels (10+) to verify:
-    - Dynamic height calculation works
-    - HTML is generated successfully
-    - File size is reasonable
-
-    Note: This test uses a regular workload but validates the HTML structure
-    can handle the multi-subplot layout properly.
+    Test roofline CSV generation with many kernels.
     """
     if soc in ("MI100"):
         pytest.skip("Skipping roofline test for MI100")
@@ -1971,20 +1694,7 @@ def test_roofline_many_kernels_dynamic_height(binary_handler_profile_rocprof_com
 
     assert returncode == 0, "Roofline profiling should succeed"
 
-    html_files = list(Path(workload_dir).glob("empirRoof_*.html"))
-    assert len(html_files) > 0, "At least one roofline HTML should be generated"
-
-    for html_file in html_files:
-        assert html_file.exists(), f"HTML file {html_file} should exist"
-        file_size = html_file.stat().st_size
-
-        # HTML should be larger than 10KB (has content) but less than 50MB (reasonable)
-        assert file_size > 10000, (
-            f"HTML {html_file} too small ({file_size} bytes), may be malformed"
-        )
-        assert file_size < 50000000, (
-            f"HTML {html_file} too large ({file_size} bytes), may have issues"
-        )
+    assert (Path(workload_dir) / "roofline.csv").exists()
 
     file_dict = test_utils.check_csv_files(workload_dir, 1, num_kernels)
     assert sorted(list(file_dict.keys())) == ROOF_ONLY_FILES
@@ -2201,123 +1911,72 @@ def test_join_type_kernel(binary_handler_profile_rocprof_compute):
 
 
 @pytest.mark.sort
-def test_roof_sort_dispatches(binary_handler_profile_rocprof_compute):
-    # only test 1 device for roofline
+def test_roof_sort_dispatches(
+    binary_handler_profile_rocprof_compute,
+    binary_handler_analyze_rocprof_compute,
+):
+    """Profile creates CSV; analyze with --sort dispatches generates output."""
     if soc in ("MI100"):
-        # roofline is not supported on MI100
-        assert True
-        # Do not continue testing
-        return
+        pytest.skip("Roofline not supported on MI100")
 
-    options = ["--device", "0", "--roof-only", "--sort", "dispatches"]
+    profile_options = ["--device", "0", "--roof-only"]
     workload_dir = test_utils.get_output_dir()
     returncode = binary_handler_profile_rocprof_compute(
-        config, workload_dir, options, check_success=False, roof=True
+        config, workload_dir, profile_options, check_success=False, roof=True
     )
-
-    # assert successful run
     assert returncode == 0
 
     file_dict = test_utils.check_csv_files(workload_dir, 1, num_kernels)
-
     assert sorted(list(file_dict.keys())) == ROOF_ONLY_FILES
 
-    validate(
-        inspect.stack()[0][3],
+    code = binary_handler_analyze_rocprof_compute([
+        "analyze",
+        "--path",
         workload_dir,
-        file_dict,
-    )
+        "--sort",
+        "dispatches",
+    ])
+    assert code == 0
 
+    html_files = list(Path(workload_dir).glob("empirRoof_*.html"))
+    assert len(html_files) > 0, "Analyze should generate roofline HTML files"
+
+    validate(inspect.stack()[0][3], workload_dir, file_dict)
     test_utils.clean_output_dir(config["cleanup"], workload_dir)
 
 
 @pytest.mark.sort
-def test_roof_sort_kernels(binary_handler_profile_rocprof_compute):
-    # only test 1 device for roofline
+def test_roof_sort_kernels(
+    binary_handler_profile_rocprof_compute,
+    binary_handler_analyze_rocprof_compute,
+):
+    """Profile creates CSV; analyze with --sort kernels generates output."""
     if soc in ("MI100"):
-        # roofline is not supported on MI100
-        assert True
-        # Do not continue testing
-        return
+        pytest.skip("Roofline not supported on MI100")
 
-    options = ["--device", "0", "--roof-only", "--sort", "kernels"]
+    profile_options = ["--device", "0", "--roof-only"]
     workload_dir = test_utils.get_output_dir()
     returncode = binary_handler_profile_rocprof_compute(
-        config, workload_dir, options, check_success=False, roof=True
+        config, workload_dir, profile_options, check_success=False, roof=True
     )
-
-    # assert successful run
     assert returncode == 0
-    file_dict = test_utils.check_csv_files(workload_dir, 1, num_kernels)
 
+    file_dict = test_utils.check_csv_files(workload_dir, 1, num_kernels)
     assert sorted(list(file_dict.keys())) == ROOF_ONLY_FILES
 
-    validate(
-        inspect.stack()[0][3],
+    code = binary_handler_analyze_rocprof_compute([
+        "analyze",
+        "--path",
         workload_dir,
-        file_dict,
-    )
+        "--sort",
+        "kernels",
+    ])
+    assert code == 0
 
-    test_utils.clean_output_dir(config["cleanup"], workload_dir)
+    html_files = list(Path(workload_dir).glob("empirRoof_*.html"))
+    assert len(html_files) > 0, "Analyze should generate roofline HTML files"
 
-
-@pytest.mark.mem
-def test_roof_mem_levels_vL1D(binary_handler_profile_rocprof_compute):
-    # only test 1 device for roofline
-    if soc in ("MI100"):
-        # roofline is not supported on MI100
-        assert True
-        # Do not continue testing
-        return
-
-    options = ["--device", "0", "--roof-only", "--mem-level", "vL1D"]
-    workload_dir = test_utils.get_output_dir()
-    returncode = binary_handler_profile_rocprof_compute(
-        config, workload_dir, options, check_success=False, roof=True
-    )
-
-    # assert successful run
-    assert returncode == 0
-    file_dict = test_utils.check_csv_files(workload_dir, 1, num_kernels)
-
-    assert sorted(list(file_dict.keys())) == ROOF_ONLY_FILES
-
-    validate(
-        inspect.stack()[0][3],
-        workload_dir,
-        file_dict,
-    )
-
-    test_utils.clean_output_dir(config["cleanup"], workload_dir)
-
-
-@pytest.mark.mem
-def test_roof_mem_levels_LDS(binary_handler_profile_rocprof_compute):
-    # only test 1 device for roofline
-    if soc in ("MI100"):
-        # roofline is not supported on MI100
-        assert True
-        # Do not continue testing
-        return
-
-    options = ["--device", "0", "--roof-only", "--mem-level", "LDS"]
-    workload_dir = test_utils.get_output_dir()
-    returncode = binary_handler_profile_rocprof_compute(
-        config, workload_dir, options, check_success=False, roof=True
-    )
-
-    # assert successful run
-    assert returncode == 0
-    file_dict = test_utils.check_csv_files(workload_dir, 1, num_kernels)
-
-    assert sorted(list(file_dict.keys())) == ROOF_ONLY_FILES
-
-    validate(
-        inspect.stack()[0][3],
-        workload_dir,
-        file_dict,
-    )
-
+    validate(inspect.stack()[0][3], workload_dir, file_dict)
     test_utils.clean_output_dir(config["cleanup"], workload_dir)
 
 

--- a/projects/rocprofiler-compute/tests/test_roofline_calc_ai_analyze.py
+++ b/projects/rocprofiler-compute/tests/test_roofline_calc_ai_analyze.py
@@ -63,10 +63,7 @@ def run_calc_ai_analyze_with_values(monkeypatch, metric_values):
     arch_config.dfs_type = {401: "metric_table", 402: "metric_table"}
 
     pmc_data = pd.DataFrame({"Kernel_Name": [kernel_name]})
-    filtered_pmc = pd.concat({"pmc_perf": pmc_data}, axis=1)
-    monkeypatch.setattr(
-        "utils.roofline_calc.apply_filters", lambda *a, **kw: filtered_pmc
-    )
+    pmc_df = pd.concat({"pmc_perf": pmc_data}, axis=1)
 
     def mock_eval_metric(
         dfs, dfs_type, sys_info_row, roofline_peaks, pmc_data, debug, config
@@ -96,6 +93,7 @@ def run_calc_ai_analyze_with_values(monkeypatch, metric_values):
 
     return calc_ai_analyze(
         workload=workload,
+        pmc_df=pmc_df,
         mspec=mock.MagicMock(),
         sort_type="kernels",
         config={},

--- a/projects/rocprofiler-compute/tests/test_utils.py
+++ b/projects/rocprofiler-compute/tests/test_utils.py
@@ -159,7 +159,7 @@ def setup_workload_dir(input_dir, suffix="_tmp", clean_existing=True, param_id=N
     based on the name of the calling test function. For parametrized tests,
     pass param_id to ensure unique directory names and avoid NFS conflicts.
 
-    Setup is a NOOP when tests run serially.
+    Creates a copy to avoid modifying source workload data.
 
     Args:
         input_dir (str): Source directory to copy from.
@@ -171,9 +171,6 @@ def setup_workload_dir(input_dir, suffix="_tmp", clean_existing=True, param_id=N
             When provided, appended to the directory name to ensure uniqueness.
             Defaults to None.
     """
-
-    if "PYTEST_XDIST_WORKER_COUNT" not in os.environ:
-        return input_dir
 
     func_name = inspect.stack()[1].function
 
@@ -261,9 +258,11 @@ def gpu_soc():
     rocminfo = rocminfo.split("\n")
     soc_regex = re.compile(r"^\s*Name\s*:\s+ ([a-zA-Z0-9]+)\s*$", re.MULTILINE)
     devices = list(filter(soc_regex.match, rocminfo))
+    if not devices:
+        return None
     gpu_arch = devices[0].split()[1]
 
-    if not gpu_arch in SUPPORTED_ARCHS.keys():
+    if gpu_arch not in SUPPORTED_ARCHS.keys():
         return None
 
     gpu_model = list(SUPPORTED_ARCHS[gpu_arch].keys())[0].upper()


### PR DESCRIPTION
## Motivation

This PR refactors the roofline functionality to improve separation of concerns and align with best practices. Previously, roofline HTML chart generation was tightly coupled with the profiling workflow. This change moves HTML chart generation from `profile` mode to `analyze` mode, enabling better modularity and allowing users to generate roofline visualizations from existing profiling data without re-running benchmarks.

## Technical Details

### Architecture Changes

1. **Moved roofline HTML generation from profile to analyze mode**
   - Roofline HTML charts are now generated in analyze mode rather than during profiling

2. **Refactored argument parsing** ([`argparser.py`](projects/rocprofiler-compute/src/argparser.py))
   - Moved roofline visualization options (`--sort`, `-m/--mem-level`, `-R/--roofline-data-type`) from profile mode to analyze mode
   - Kept microbenchmark-only options (`--roof-only`, `--device`) in profile mode

3. **Eliminated `analysis_setup()` indirection layer**
   - Analysis modules (CLI/WebUI) now directly instantiate `Roofline` objects

4. **Refactored `Roofline` class** ([`roofline.py`](projects/rocprofiler-compute/src/roofline.py))
   - Split monolithic `empirical_roofline()` into focused methods:
     - `construct_plotly_figures()`: Build Plotly figure objects from pre-computed AI data
     - `save_html_files()`: Write figures to standalone HTML files
     - `generate_html_section()`: Wrap figures for WebUI embedding (static method)
   - Removed AI calculation logic from Roofline class (moved to callers)

5. **Enhanced analysis CLI and WebUI** ([`analysis_cli.py`](projects/rocprofiler-compute/src/rocprof_compute_analyze/analysis_cli.py))
   - Integrated `calc_ai_analyze()` for AI data computation
   - Added proper warning messages when roofline charting is skipped


6. **Test suite improvements** ([`test_analyze_commands.py`](projects/rocprofiler-compute/tests/test_analyze_commands.py), [`test_profile_general.py`](projects/rocprofiler-compute/tests/test_profile_general.py))
   - Used cached workloads with `roofline.csv` for analysis testing
   - Moved roofline analysis tests to `test_analyze_commands.py`

7. **Documentation updates**
   - Updated CLI documentation ([`cli.rst`](projects/rocprofiler-compute/docs/how-to/analyze/cli.rst))
   - Updated mode documentation ([`mode.rst`](projects/rocprofiler-compute/docs/how-to/profile/mode.rst))
   - Updated quickstart guide ([`quickstart.rst`](projects/rocprofiler-compute/docs/install/quickstart.rst))

## JIRA ID

AIPROFCOMP-447
AIPROFCOMP-448

## Test Plan

**Roofline profile + analyze workflow**
   - Verified roofline profiling generates `roofline.csv` correctly
   - Verified analyze mode generates HTML charts from existing data
   - Tested with different memory levels (HBM, L2, L1/vL1D, LDS)
   - Tested with different data types (FP32, FP16, etc.)

Run entire ctest suite

## Test Result

- All test suites pass successfully

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.

---

**Co-Authored-By:** James Siddeley <James.Siddeley@amd.com>
**Co-Authored-By:** Claude Opus 4.5 <noreply@anthropic.com>