### PR TITLE
[rocprofiler-systems] Add python pause/resume integration

### DIFF
--- a/projects/rocprofiler-systems/source/lib/rocprof-sys-dl/dl.cpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys-dl/dl.cpp
@@ -294,6 +294,8 @@ struct ROCPROFSYS_INTERNAL_API indirect
         ROCPROFSYS_DLSYM(rocprofsys_progress_f, m_omnihandle, "rocprofsys_progress");
         ROCPROFSYS_DLSYM(rocprofsys_annotated_progress_f, m_omnihandle,
                          "rocprofsys_annotated_progress");
+        ROCPROFSYS_DLSYM(rocprofsys_register_pause_callbacks_f, m_omnihandle,
+                         "rocprofsys_external_register_pause_callbacks");
 
         ROCPROFSYS_DLSYM(kokkosp_print_help_f, m_omnihandle, "kokkosp_print_help");
         ROCPROFSYS_DLSYM(kokkosp_parse_args_f, m_omnihandle, "kokkosp_parse_args");
@@ -402,6 +404,7 @@ public:
     void (*rocprofsys_progress_f)(const char*)                                 = nullptr;
     void (*rocprofsys_annotated_progress_f)(const char*, rocprofsys_annotation_t*,
                                             size_t)                            = nullptr;
+    void (*rocprofsys_register_pause_callbacks_f)(void (*)(), void (*)())      = nullptr;
 
     // librocprof-sys-user functions
     int (*rocprofsys_user_configure_f)(int, user_cb_t, user_cb_t*) = nullptr;
@@ -876,6 +879,13 @@ extern "C"
     {
         return ROCPROFSYS_DL_INVOKE(get_indirect().rocprofsys_annotated_progress_f, _name,
                                     _annotations, _annotation_count);
+    }
+
+    void rocprofsys_external_register_pause_callbacks(void (*pause_fn)(),
+                                                      void (*resume_fn)())
+    {
+        ROCPROFSYS_DL_INVOKE(get_indirect().rocprofsys_register_pause_callbacks_f,
+                             pause_fn, resume_fn);
     }
 
     void rocprofsys_set_instrumented(int _mode)

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys-dl/dl/dl.hpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys-dl/dl/dl.hpp
@@ -92,6 +92,8 @@ extern "C"
     void rocprofsys_progress(const char*) ROCPROFSYS_PUBLIC_API;
     void rocprofsys_annotated_progress(const char*, rocprofsys_annotation_t*,
                                        size_t) ROCPROFSYS_PUBLIC_API;
+    void rocprofsys_external_register_pause_callbacks(void (*)(),
+                                                      void (*)()) ROCPROFSYS_PUBLIC_API;
 
 #if defined(ROCPROFSYS_DL_SOURCE) && (ROCPROFSYS_DL_SOURCE > 0)
     void rocprofsys_preinit_library(void) ROCPROFSYS_HIDDEN_API;

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/api.hpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/api.hpp
@@ -121,7 +121,6 @@ extern "C"
                                               size_t) ROCPROFSYS_HIDDEN_API;
 
     /// registers external pause/resume callbacks (e.g. from the Python profiler).
-    /// not part of the public user API — only resolvable via dlsym by internal libraries.
     void rocprofsys_external_register_pause_callbacks(void (*)(),
                                                       void (*)()) ROCPROFSYS_PUBLIC_API;
 }

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/api.hpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/api.hpp
@@ -119,4 +119,9 @@ extern "C"
     void rocprofsys_progress_hidden(const char*) ROCPROFSYS_HIDDEN_API;
     void rocprofsys_annotated_progress_hidden(const char*, rocprofsys_annotation_t*,
                                               size_t) ROCPROFSYS_HIDDEN_API;
+
+    /// registers external pause/resume callbacks (e.g. from the Python profiler).
+    /// not part of the public user API — only resolvable via dlsym by internal libraries.
+    void rocprofsys_external_register_pause_callbacks(void (*)(),
+                                                      void (*)()) ROCPROFSYS_PUBLIC_API;
 }

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library.cpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library.cpp
@@ -429,7 +429,44 @@ resume_gotcha_components()
     component::numa_gotcha::resume();
 }
 
+using callback_t = void (*)();
+std::mutex              external_pause_resume_callbacks_mutex;
+std::vector<callback_t> external_pause_callbacks;
+std::vector<callback_t> external_resume_callbacks;
+
+void
+invoke_external_pause_callbacks()
+{
+    std::lock_guard<std::mutex> _lk{ external_pause_resume_callbacks_mutex };
+    for(auto* _fn : external_pause_callbacks)
+        _fn();
+}
+
+void
+invoke_external_resume_callbacks()
+{
+    std::lock_guard<std::mutex> _lk{ external_pause_resume_callbacks_mutex };
+    for(auto* _fn : external_resume_callbacks)
+        _fn();
+}
+
 }  // namespace
+
+extern "C" void
+rocprofsys_external_register_pause_callbacks(void (*pause_fn)(), void (*resume_fn)())
+{
+    std::lock_guard<std::mutex> _lk{ external_pause_resume_callbacks_mutex };
+
+    if(pause_fn)
+    {
+        external_pause_callbacks.emplace_back(pause_fn);
+    }
+
+    if(resume_fn)
+    {
+        external_resume_callbacks.emplace_back(resume_fn);
+    }
+}
 
 extern "C" void
 rocprofsys_set_mpi_hidden(bool use, bool attached)
@@ -685,6 +722,7 @@ rocprofsys_init_tooling_hidden(void)
                 sampling::resume();
                 resume_gotcha_components();
                 rocprofsys::kokkosp::resume();
+                invoke_external_resume_callbacks();
             };
             auto stop_callback = []() {
                 rocprofiler_sdk::stop_main_contexts();
@@ -692,6 +730,7 @@ rocprofsys_init_tooling_hidden(void)
                 sampling::pause();
                 pause_gotcha_components();
                 rocprofsys::kokkosp::pause();
+                invoke_external_pause_callbacks();
             };
             g_trace_controller->register_region_start_callback(start_callback);
             g_trace_controller->register_region_stop_callback(stop_callback);

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library/control.cpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library/control.cpp
@@ -11,7 +11,6 @@
 
 #include <timemory/utility/delimit.hpp>
 
-#include "library/components/category_region.hpp"
 #include "logger/debug.hpp"
 
 namespace rocprofsys
@@ -34,25 +33,20 @@ marker_watch_start_callback(rocprofiler_callback_tracing_record_t record,
                             rocprofiler_user_data_t* /*user_data*/, void* callback_data)
 {
     if(!callback_data) return;
-    if(record.phase != ROCPROFILER_CALLBACK_PHASE_ENTER) return;
     auto* controller = static_cast<trace_controller*>(callback_data);
     auto* data =
         static_cast<rocprofiler_callback_tracing_marker_api_data_t*>(record.payload);
 
-    if(record.operation == ROCPROFILER_MARKER_CORE_API_ID_roctxRangeStartA)
+    if(record.operation == ROCPROFILER_MARKER_CORE_API_ID_roctxRangeStartA &&
+       record.phase == ROCPROFILER_CALLBACK_PHASE_EXIT)
     {
-        LOG_CRITICAL("MARKER WATCH START {}", record.operation);
         controller->handle_range_start(data->retval.roctx_range_id_t_retval,
                                        data->args.roctxRangeStartA.message);
-        component::category_region<tim::category::rocm_marker_api>::start(
-            data->args.roctxRangeStartA.message);
     }
-    else if(record.operation == ROCPROFILER_MARKER_CORE_API_ID_roctxRangeStop)
+    else if(record.operation == ROCPROFILER_MARKER_CORE_API_ID_roctxRangeStop &&
+            record.phase == ROCPROFILER_CALLBACK_PHASE_EXIT)
     {
-        LOG_CRITICAL("MARKER WATCH STOP {}", record.operation);
         controller->handle_range_stop(data->args.roctxRangeStop.id);
-        component::category_region<tim::category::rocm_marker_api>::stop(
-            data->args.roctxRangeStartA.message);
     }
 }
 

--- a/projects/rocprofiler-systems/source/python/libpyrocprofsys.cpp
+++ b/projects/rocprofiler-systems/source/python/libpyrocprofsys.cpp
@@ -44,6 +44,7 @@
 #include <pybind11/pybind11.h>
 #include <pyerrors.h>
 
+#include <atomic>
 #include <cctype>
 #include <cstdint>
 #include <exception>
@@ -56,6 +57,23 @@
 #define ROCPROFSYS_PYTHON_VERSION                                                        \
     ((10000 * PY_MAJOR_VERSION) + (100 * PY_MINOR_VERSION) + PY_MICRO_VERSION)
 
+namespace
+{
+std::atomic<bool> g_library_paused{ false };
+}  // namespace
+
+extern "C"
+{
+    void pyrocprofsys_pause_callback()
+    {
+        g_library_paused.store(true, std::memory_order_relaxed);
+    }
+
+    void pyrocprofsys_resume_callback()
+    {
+        g_library_paused.store(false, std::memory_order_relaxed);
+    }
+}
 namespace pyrocprofsys
 {
 namespace pyprofile
@@ -99,6 +117,8 @@ PYBIND11_MODULE(libpyrocprofsys, omni)
         }
         return _use_mpi;
     };
+    rocprofsys_external_register_pause_callbacks(&pyrocprofsys_pause_callback,
+                                                 &pyrocprofsys_resume_callback);
 
     omni.def("is_initialized", []() { return _is_initialized; }, "Initialization state");
 
@@ -296,7 +316,7 @@ get_frame_code(PyFrameObject* frame)
 void
 profiler_function(py::object pframe, const char* swhat, py::object arg)
 {
-    if(get_paused() > 0) return;
+    if(get_paused() > 0 || g_library_paused.load(std::memory_order_relaxed)) return;
 
     static thread_local auto& _config  = get_config();
     static thread_local auto  _disable = false;
@@ -564,6 +584,10 @@ generate(py::module& _pymod)
             std::cerr << "[profiler_init]> " << e.what() << std::endl;
         }
         if(get_config().is_running) return;
+        // force tooling init before sys.setprofile is installed so that
+        // the trace_controller's stop_callback sets g_library_paused
+        // before any profiler events can fire
+        rocprofsys_init_tooling();
         get_config().records.clear();
         get_config().base_stack_depth = -1;
         get_config().is_running       = true;
@@ -591,7 +615,8 @@ generate(py::module& _pymod)
     _prof.def(
         "profiler_resume",
         [_setprofile]() {
-            if(--get_paused() == 0) _setprofile(py::cpp_function{ profiler_function });
+            if(--get_paused() == 0 && !g_library_paused.load(std::memory_order_relaxed))
+                _setprofile(py::cpp_function{ profiler_function });
         },
         "Resume the profiler");
 

--- a/projects/rocprofiler-systems/source/python/libpyrocprofsys.cpp
+++ b/projects/rocprofiler-systems/source/python/libpyrocprofsys.cpp
@@ -584,9 +584,6 @@ generate(py::module& _pymod)
             std::cerr << "[profiler_init]> " << e.what() << std::endl;
         }
         if(get_config().is_running) return;
-        // force tooling init before sys.setprofile is installed so that
-        // the trace_controller's stop_callback sets g_library_paused
-        // before any profiler events can fire
         rocprofsys_init_tooling();
         get_config().records.clear();
         get_config().base_stack_depth = -1;


### PR DESCRIPTION
## Motivation

This PR bridges the gap by propagating the trace controller's pause/resume state into the Python profiler, so that Python  profiling events are suppressed while the library is paused.

## Technical Details
- Exposed API for external pause/resume callbacks
- Registered callbacks in python module to control global pause resume
- Connected external pause/resume callbacks to trace controller

## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan
- Python workloads get's paused-resumed

## Test Result

- Clear gap is visible

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
