### PR TITLE
[rocprofiler-compute] vendor pyyaml dependency in profile mode

### DIFF
--- a/.github/workflows/rocprofiler-compute-rhel-8.yml
+++ b/.github/workflows/rocprofiler-compute-rhel-8.yml
@@ -95,6 +95,9 @@ jobs:
           sparse-checkout: projects/rocprofiler-compute
           set-safe-directory: true
 
+      - name: Configure git safe directory
+        run: git config --global --add safe.directory '*'
+
       - name: Install Python prereqs
         working-directory: projects/rocprofiler-compute
         run: |

--- a/.github/workflows/rocprofiler-compute-rhel-8.yml
+++ b/.github/workflows/rocprofiler-compute-rhel-8.yml
@@ -88,11 +88,12 @@ jobs:
               yum install -y https://repo.radeon.com/amdgpu-install/${ROCM_MAJOR}.${ROCM_MINOR}/rhel/9.4/amdgpu-install-${ROCM_MAJOR}.${ROCM_MINOR}.${ROCM_VERSN}-1.el9.noarch.rpm
             fi
             yum install -y rocm-dev
-            
+
       - name: Checkout
         uses: actions/checkout@v5
         with:
           sparse-checkout: projects/rocprofiler-compute
+          set-safe-directory: true
 
       - name: Install Python prereqs
         working-directory: projects/rocprofiler-compute

--- a/.github/workflows/rocprofiler-compute-tarball.yml
+++ b/.github/workflows/rocprofiler-compute-tarball.yml
@@ -59,6 +59,7 @@ jobs:
         with:
           sparse-checkout: projects/rocprofiler-compute
           ref: ${{ steps.sha-mode.sha }}
+          set-safe-directory: true
       - name: Install ROCm Dependencies
         shell: bash
         run: |

--- a/.github/workflows/rocprofiler-compute-tarball.yml
+++ b/.github/workflows/rocprofiler-compute-tarball.yml
@@ -60,6 +60,10 @@ jobs:
           sparse-checkout: projects/rocprofiler-compute
           ref: ${{ steps.sha-mode.sha }}
           set-safe-directory: true
+
+      - name: Configure git safe directory
+        run: git config --global --add safe.directory '*'
+
       - name: Install ROCm Dependencies
         shell: bash
         run: |

--- a/.github/workflows/rocprofiler-compute-ubuntu-jammy.yml
+++ b/.github/workflows/rocprofiler-compute-ubuntu-jammy.yml
@@ -57,6 +57,9 @@ jobs:
           sparse-checkout: projects/rocprofiler-compute
           set-safe-directory: true
 
+      - name: Configure git safe directory
+        run: git config --global --add safe.directory '*'
+
       - name: Install Python prereqs
         working-directory: projects/rocprofiler-compute
         run: |

--- a/.github/workflows/rocprofiler-compute-ubuntu-jammy.yml
+++ b/.github/workflows/rocprofiler-compute-ubuntu-jammy.yml
@@ -55,6 +55,7 @@ jobs:
         uses: actions/checkout@v5
         with:
           sparse-checkout: projects/rocprofiler-compute
+          set-safe-directory: true
 
       - name: Install Python prereqs
         working-directory: projects/rocprofiler-compute

--- a/.gitmodules
+++ b/.gitmodules
@@ -109,3 +109,6 @@
 	path = projects/rccl/ext-src/rocSHMEM
 	url = https://github.com/ROCm/rocSHMEM.git
 	branch = develop
+[submodule "projects/rocprofiler-compute/src/vendored/pyyaml"]
+	path = projects/rocprofiler-compute/src/vendored/pyyaml
+	url = https://github.com/yaml/pyyaml.git

--- a/projects/rocprofiler-compute/CMakeLists.txt
+++ b/projects/rocprofiler-compute/CMakeLists.txt
@@ -191,7 +191,7 @@ if(LOCALHOST MATCHES "TheraS01|.*\.thera\.amd\.com|thera-hn")
     file(READ ${PROJECT_SOURCE_DIR}/cmake/modfile.thera.mod mod_additions)
     file(
         APPEND
-        ${PROJECT_BINARY_DIR}/${MOD_INSTALL_PATH}/${ROCPROFCOMPUTE_FULL_VERSION}.lua
+            ${PROJECT_BINARY_DIR}/${MOD_INSTALL_PATH}/${ROCPROFCOMPUTE_FULL_VERSION}.lua
         ${mod_additions}
     )
     list(POP_BACK CMAKE_MESSAGE_INDENT)
@@ -685,8 +685,7 @@ install(
         src/config.py
         src/rocprof_compute_base.py
         src/roofline.py
-        VERSION
-        VERSION.sha
+        VERSION VERSION.sha
     DESTINATION ${CMAKE_INSTALL_LIBEXECDIR}/${PROJECT_NAME}
     COMPONENT main
 )
@@ -766,7 +765,8 @@ if(NOT EXISTS "${PROJECT_SOURCE_DIR}/src/vendored/pyyaml/lib/yaml")
     if(Git_FOUND)
         message(STATUS "Initializing vendored/pyyaml submodule...")
         execute_process(
-            COMMAND ${GIT_EXECUTABLE} submodule update --init --recursive src/vendored/pyyaml
+            COMMAND
+                ${GIT_EXECUTABLE} submodule update --init --recursive src/vendored/pyyaml
             WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
             RESULT_VARIABLE GIT_SUBMOD_RESULT
         )
@@ -783,7 +783,8 @@ install(
     DIRECTORY src/vendored/pyyaml/lib/yaml
     DESTINATION ${CMAKE_INSTALL_LIBEXECDIR}/${PROJECT_NAME}/vendored/pyyaml/lib
     COMPONENT main
-    FILES_MATCHING PATTERN "*.py"
+    FILES_MATCHING
+    PATTERN "*.py"
     PATTERN "__pycache__" EXCLUDE
     PATTERN "*.pyc" EXCLUDE
 )

--- a/projects/rocprofiler-compute/CMakeLists.txt
+++ b/projects/rocprofiler-compute/CMakeLists.txt
@@ -191,7 +191,7 @@ if(LOCALHOST MATCHES "TheraS01|.*\.thera\.amd\.com|thera-hn")
     file(READ ${PROJECT_SOURCE_DIR}/cmake/modfile.thera.mod mod_additions)
     file(
         APPEND
-            ${PROJECT_BINARY_DIR}/${MOD_INSTALL_PATH}/${ROCPROFCOMPUTE_FULL_VERSION}.lua
+        ${PROJECT_BINARY_DIR}/${MOD_INSTALL_PATH}/${ROCPROFCOMPUTE_FULL_VERSION}.lua
         ${mod_additions}
     )
     list(POP_BACK CMAKE_MESSAGE_INDENT)
@@ -685,7 +685,8 @@ install(
         src/config.py
         src/rocprof_compute_base.py
         src/roofline.py
-        VERSION VERSION.sha
+        VERSION
+        VERSION.sha
     DESTINATION ${CMAKE_INSTALL_LIBEXECDIR}/${PROJECT_NAME}
     COMPONENT main
 )

--- a/projects/rocprofiler-compute/CMakeLists.txt
+++ b/projects/rocprofiler-compute/CMakeLists.txt
@@ -744,6 +744,50 @@ install(
     COMPONENT main
     PATTERN "__pycache__" EXCLUDE
 )
+
+# ==============================================================================
+# Vendored Dependencies Installation
+# ==============================================================================
+# Vendored packages are included as git submodules and installed as pure Python.
+# Each package has: conditional submodule init + unconditional install.
+# See src/vendored/README.md and CONTRIBUTING.md for vendoring guidelines.
+
+find_package(Git QUIET)
+
+# Vendored package wrapper
+install(
+    FILES src/vendored/__init__.py
+    DESTINATION ${CMAKE_INSTALL_LIBEXECDIR}/${PROJECT_NAME}/vendored
+    COMPONENT main
+)
+
+# PyYAML
+if(NOT EXISTS "${PROJECT_SOURCE_DIR}/src/vendored/pyyaml/lib/yaml")
+    if(Git_FOUND)
+        message(STATUS "Initializing vendored/pyyaml submodule...")
+        execute_process(
+            COMMAND ${GIT_EXECUTABLE} submodule update --init --recursive src/vendored/pyyaml
+            WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+            RESULT_VARIABLE GIT_SUBMOD_RESULT
+        )
+        if(NOT GIT_SUBMOD_RESULT EQUAL "0")
+            message(FATAL_ERROR "git submodule update failed for src/vendored/pyyaml")
+        endif()
+    else()
+        message(FATAL_ERROR "vendored/pyyaml not found and git not available")
+    endif()
+else()
+    message(STATUS "Vendored/pyyaml: OK")
+endif()
+install(
+    DIRECTORY src/vendored/pyyaml/lib/yaml
+    DESTINATION ${CMAKE_INSTALL_LIBEXECDIR}/${PROJECT_NAME}/vendored/pyyaml/lib
+    COMPONENT main
+    FILES_MATCHING PATTERN "*.py"
+    PATTERN "__pycache__" EXCLUDE
+    PATTERN "*.pyc" EXCLUDE
+)
+
 # samples
 install(
     DIRECTORY sample

--- a/projects/rocprofiler-compute/CONTRIBUTING.md
+++ b/projects/rocprofiler-compute/CONTRIBUTING.md
@@ -251,3 +251,13 @@ If your PR modifies **metric configurations** — panel YAMLs under `src/rocprof
 3. Verify that hashes are updated and CI tests pass.
 
 For full details, see the [metric config management README](./tools/config_management/README.md).
+
+## Vendoring External Dependencies
+
+rocprofiler-compute vendors certain Python dependencies (via git submodules) to eliminate external dependencies in profile mode. This improves portability and reliability on HPC systems.
+
+**We vendor:**
+- Pure Python packages used in profile code path
+- Stable packages with permissive licenses
+
+For detailed vendoring workflow (adding/updating packages), see [`src/vendored/README.md`](./src/vendored/README.md).

--- a/projects/rocprofiler-compute/README.md
+++ b/projects/rocprofiler-compute/README.md
@@ -33,8 +33,14 @@ git sparse-checkout set projects/rocprofiler-compute
 git checkout develop
 
 cd projects/rocprofiler-compute
+
+# Initialize vendored dependencies
+git submodule update --init --recursive -- src/vendored/
+
 python3 -m pip install -r requirements.txt
 ```
+
+**Note**: When working from source, vendored dependencies (like PyYAML) are included as git submodules. If you see import errors about missing vendored modules, run `git submodule update --init --recursive -- src/vendored/`.
 
 ## Testing
 

--- a/projects/rocprofiler-compute/src/rocprof_compute_profile/profiler_base.py
+++ b/projects/rocprofiler-compute/src/rocprof_compute_profile/profiler_base.py
@@ -32,6 +32,7 @@ import time
 from abc import abstractmethod
 from pathlib import Path
 from typing import Any, Optional, Union
+
 from rocprof_compute_soc.soc_base import OmniSoC_Base
 from utils.logger import (
     console_debug,

--- a/projects/rocprofiler-compute/src/rocprof_compute_profile/profiler_base.py
+++ b/projects/rocprofiler-compute/src/rocprof_compute_profile/profiler_base.py
@@ -32,9 +32,6 @@ import time
 from abc import abstractmethod
 from pathlib import Path
 from typing import Any, Optional, Union
-
-import yaml
-
 from rocprof_compute_soc.soc_base import OmniSoC_Base
 from utils.logger import (
     console_debug,
@@ -53,6 +50,7 @@ from utils.utils import (
     print_status,
     run_prof,
 )
+from vendored import yaml
 
 
 class RocProfCompute_Base:

--- a/projects/rocprofiler-compute/src/rocprof_compute_soc/soc_base.py
+++ b/projects/rocprofiler-compute/src/rocprof_compute_soc/soc_base.py
@@ -32,8 +32,6 @@ from abc import abstractmethod
 from pathlib import Path
 from typing import Any, Optional
 
-import yaml
-
 import config
 from utils.amdsmi_interface import amdsmi_ctx, get_gpu_model, get_mem_max_clock
 from utils.logger import (
@@ -57,6 +55,7 @@ from utils.utils import (
     parse_sets_yaml,
     resolve_rocm_library_path,
 )
+from vendored import yaml
 
 
 class OmniSoC_Base:

--- a/projects/rocprofiler-compute/src/utils/mi_gpu_spec.py
+++ b/projects/rocprofiler-compute/src/utils/mi_gpu_spec.py
@@ -26,9 +26,8 @@
 from pathlib import Path
 from typing import Any, Optional
 
-import yaml
-
 from utils.logger import console_debug, console_error, console_warning
+from vendored import yaml
 
 # ----------------------------
 # Data Class handling to preserve the hierarchical gpu information

--- a/projects/rocprofiler-compute/src/vendored/README.md
+++ b/projects/rocprofiler-compute/src/vendored/README.md
@@ -1,0 +1,149 @@
+# Vendored Dependencies
+
+This directory contains external Python packages that are vendored (included directly) in the rocprofiler-compute source tree.
+
+## Current Vendored Packages
+
+| Package | Version | License | Source | Vendored |
+|---------|---------|---------|--------|----------|
+| PyYAML  | 6.0.3   | MIT     | https://github.com/yaml/pyyaml | 2024-03-14 |
+
+## Usage
+
+```python
+# Recommended: Use convenience wrapper
+from vendored import yaml
+
+# Alternative: Direct import
+from vendored.pyyaml.lib import yaml
+```
+
+## Why Vendor?
+
+To eliminate external dependencies in profile mode, improving:
+- **Portability**: Works without pip/internet access on HPC systems
+- **Reliability**: No version conflicts with user environments
+- **Installation**: Simpler deployment, no separate pip install step
+
+---
+
+## Vendoring Workflow
+
+### What We Vendor
+
+**Criteria for vendoring:**
+- Pure Python packages only (no C extensions)
+- Critical dependencies used in profile code path
+- Stable, mature packages with permissive licenses (MIT, BSD, Apache 2.0)
+
+**Do NOT vendor:**
+- Test-only dependencies (use `requirements-test.txt` instead)
+- Analyze-mode only dependencies (use `requirements.txt` instead)
+- Packages with C extensions (portability issues)
+
+### Adding a New Vendored Package
+
+Follow these steps to vendor a new package (example: hypothetical future package):
+
+#### 1. Add as Git Submodule
+
+```bash
+cd /path/to/rocprofiler-compute
+
+# Add the package as a submodule under src/vendored/
+git submodule add https://github.com/org/package.git src/vendored/package
+
+# Pin to a specific version
+cd src/vendored/package
+git checkout v1.2.3  # Use appropriate version tag
+cd ../../..
+
+git add .gitmodules src/vendored/package
+git commit -m "Vendor package v1.2.3"
+```
+
+#### 2. Update `src/vendored/__init__.py`
+
+Add a convenience import for the new package:
+
+```python
+# Package v1.2.3
+# Source: https://github.com/org/package (License)
+# Vendored: YYYY-MM-DD
+from .package.lib import module
+
+__all__ = ['yaml', 'module']  # Add to __all__
+```
+
+#### 3. Add CMake Install Block
+
+In `CMakeLists.txt`, add a new install block in the "Vendored Dependencies Installation" section:
+
+```cmake
+# Package v1.2.3 (pure Python only, no C extensions)
+install(
+    DIRECTORY src/vendored/package/lib/module
+    DESTINATION ${CMAKE_INSTALL_LIBEXECDIR}/${PROJECT_NAME}/vendored/package/lib
+    COMPONENT main
+    FILES_MATCHING PATTERN "*.py"
+    PATTERN "__pycache__" EXCLUDE
+    PATTERN "*.pyc" EXCLUDE
+    PATTERN "*.so" EXCLUDE      # Exclude any C extensions
+    PATTERN "*.pyd" EXCLUDE     # Exclude Windows extensions
+)
+```
+
+**Important**: Each vendored package has unique structure. Adjust the `DIRECTORY` path and patterns based on the package's layout. Only install pure Python files (`.py`).
+
+#### 4. Add Submodule Auto-Init to CMake
+
+In the "Git Submodule Auto-Initialization" section of `CMakeLists.txt`, add a check for the new submodule:
+
+```cmake
+# Package submodule
+if(NOT EXISTS "${PROJECT_SOURCE_DIR}/src/vendored/package/.git")
+    message(STATUS "  Initializing vendored/package submodule...")
+    execute_process(
+        COMMAND ${GIT_EXECUTABLE} submodule update --init src/vendored/package
+        WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+        RESULT_VARIABLE GIT_SUBMOD_RESULT
+    )
+    if(NOT GIT_SUBMOD_RESULT EQUAL "0")
+        message(FATAL_ERROR "git submodule update failed for src/vendored/package")
+    endif()
+else()
+    message(STATUS "  vendored/package: OK")
+endif()
+```
+
+#### 5. Update Documentation
+
+- Update the table above with package details (name, version, license, source URL, date)
+
+### Updating a Vendored Package
+
+```bash
+# Example: Update PyYAML from 6.0.3 to 6.0.4
+cd src/vendored/pyyaml
+git fetch origin
+git checkout 6.0.4  # New version tag
+cd ../../..
+
+# Update version in src/vendored/README.md table
+# Version update might require changes in how CMake installs that vendored package
+
+git add src/vendored/pyyaml src/vendored/README.md
+git commit -m "Update vendored PyYAML to 6.0.4"
+```
+
+### Using Vendored Packages in Code
+
+```python
+# Recommended: Use convenience wrapper
+from vendored import yaml
+
+# Alternative: Direct import
+from vendored.pyyaml.lib import yaml
+```
+
+The convenience wrapper (`from vendored import yaml`) is preferred as it provides a stable import interface even if the underlying package structure changes.

--- a/projects/rocprofiler-compute/src/vendored/__init__.py
+++ b/projects/rocprofiler-compute/src/vendored/__init__.py
@@ -1,0 +1,40 @@
+##############################################################################
+# MIT License
+#
+# Copyright (c) 2026 Advanced Micro Devices, Inc. All Rights Reserved.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+##############################################################################
+
+"""Vendored dependencies for rocprofiler-compute.
+
+This package contains external dependencies vendored (included directly) into
+the source tree to eliminate external dependencies in profile mode.
+
+Only the pure-Python portions should be installed/used for vendored
+packages (no C extensions) for maximum portability.
+For vendoring guidelines and adding new packages, see CONTRIBUTING.md.
+"""
+
+try:
+    from .pyyaml.lib import yaml
+except ImportError as e:
+    raise ImportError("Vendored dependencies not found.") from e
+
+__all__ = ["yaml"]


### PR DESCRIPTION
## Motivation

By vendoring PyYAML as a git submodule, we eliminate the external dependency for profile mode.
This phase builds the vendoring infrastructure for future packages while maintaining full backward compatibility.

## Technical Details

### Changes Overview

**1. Git Submodule Setup**
- Added PyYAML 6.0.3 as git submodule at `src/vendored/pyyaml/`

**2. Vendored Package Infrastructure**
- Created `src/vendored/__init__.py` with fail-fast import wrapper
- Created `src/vendored/README.md` with complete vendoring workflow documentation

**3. Import Updates**
Changed from `import yaml` to `from vendored import yaml` in:

**4. CMake Integration**
- Git submodule auto-initialization block
- Vendored dependencies installation blocks

**5. Documentation**
- Updated `README.md` with submodule initialization instructions
- Updated `CONTRIBUTING.md` to link to `src/vendored/README.md` which explains vendoring guidelines

**6. Workflow updates**
- Add manual git config step after checkout to ensure git submodule
   commands run by CMake can access the repository without ownership
   errors.

## JIRA ID

AIPROFCOMP-450
AIPROFCOMP-447

## Test Plan

* Run profiling pytest from source
* Build and run profiling ctest


## Test Result

* Tests pass
* No regressions detected in profiling using vendored pyyaml

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.