### PR TITLE
[rocprofiler-compute] add tests to guarantee only std lib during profiling and remove deps checking

### DIFF
--- a/projects/rocprofiler-compute/CMakeLists.txt
+++ b/projects/rocprofiler-compute/CMakeLists.txt
@@ -93,7 +93,10 @@ if(NOT STANDALONEBINARY)
     message(STATUS "Detecting Python interpreter...")
     find_package(Python3 3.8 COMPONENTS Interpreter REQUIRED)
     message(STATUS "Python ${Python3_VERSION} found")
-    message(STATUS "Note: Profile mode uses stdlib only. Analyze mode deps checked at runtime.")
+    message(
+        STATUS
+        "Note: Profile mode uses stdlib only. Analyze mode deps checked at runtime."
+    )
 endif()
 
 # ----------------------
@@ -256,9 +259,8 @@ if(NOT STANDALONEBINARY)
     add_test(
         NAME test_import_guard
         COMMAND
-            ${PYTHON_TEST_COMMAND} -m pytest
-            --junitxml=tests/test_import_guard.xml ${COV_OPTION}
-            tests/test_import_guard.py ${WORKING_DIR_OPTION}
+            ${PYTHON_TEST_COMMAND} -m pytest --junitxml=tests/test_import_guard.xml
+            ${COV_OPTION} tests/test_import_guard.py ${WORKING_DIR_OPTION}
     )
 endif()
 

--- a/projects/rocprofiler-compute/CMakeLists.txt
+++ b/projects/rocprofiler-compute/CMakeLists.txt
@@ -82,74 +82,18 @@ if(CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
 endif()
 message(STATUS "Installation path: ${CMAKE_INSTALL_PREFIX}")
 
-option(CHECK_PYTHON_DEPS "Verify necessary python dependencies" ON)
+# Profile mode requires only Python 3.8+ standard library (no external dependencies)
+# Analyze mode dependencies are checked at runtime via verify_deps()
+# Standalone binary handles its own dependencies via bundled venv
+
 option(STANDALONEBINARY "Whether to build standalone binary" OFF)
-if(CHECK_PYTHON_DEPS AND NOT STANDALONEBINARY)
-    # Python 3 is required
+
+# Only find Python interpreter - no dependency checking
+if(NOT STANDALONEBINARY)
     message(STATUS "Detecting Python interpreter...")
-    find_package(Python3 3.9 COMPONENTS Interpreter REQUIRED)
-
-    # Allow user-provided python search path
-    if(DEFINED PYTHON_DEPS)
-        set(ENV{PYTHONPATH} "${PYTHON_DEPS}")
-        message(STATUS "Optional PYTHON_DEPS provided:")
-        list(APPEND CMAKE_MESSAGE_INDENT "  ")
-        message(STATUS "including ${PYTHON_DEPS} in search path")
-        list(POP_BACK CMAKE_MESSAGE_INDENT)
-    endif()
-
-    # Check required Python packages
-    file(STRINGS "${CMAKE_CURRENT_SOURCE_DIR}/requirements.txt" pythonDeps)
-
-    message(STATUS "Checking for required Python package dependencies...")
-    set_property(GLOBAL PROPERTY pythonDepsFlag "groovy")
-
-    function(checkPythonPackage [package])
-        # mapping for non-default package names
-        set(PACKAGE ${ARGV0})
-        if(${ARGV0} STREQUAL "pyyaml")
-            set(PACKAGE "yaml")
-        endif()
-        execute_process(
-            COMMAND ${Python3_EXECUTABLE} -c "import ${PACKAGE}"
-            OUTPUT_QUIET
-            ERROR_QUIET
-            RESULT_VARIABLE EXIT_CODE
-        )
-        if(${EXIT_CODE} EQUAL 0)
-            message(STATUS "${ARGV0} = yes")
-        else()
-            message(STATUS "${ARGV0} = missing")
-            set_property(GLOBAL PROPERTY pythonDepsFlag "missing")
-        endif()
-    endfunction()
-
-    list(APPEND CMAKE_MESSAGE_INDENT "  ")
-    foreach(package IN LISTS pythonDeps)
-        # Filter out any version requirements from requirements.txt
-        string(REGEX REPLACE "[><=].*" "" package "${package}")
-        string(REPLACE "-" "_" package "${package}")
-        checkpythonpackage(${package})
-    endforeach()
-    list(POP_BACK CMAKE_MESSAGE_INDENT)
-
-    get_property(pythonDepsInstalled GLOBAL PROPERTY pythonDepsFlag)
-    if(${pythonDepsInstalled} STREQUAL "groovy")
-        message(STATUS "OK: Python dependencies available in current environment.")
-    else()
-        message(
-            FATAL_ERROR
-            "\nNecessary Python package dependencies not found. Please install required dependencies "
-            "above using your favorite package manager. If using pip, consider running:\n"
-            "python3 -m pip install -r requirements.txt\n"
-            "at the top-level of this repository. If preparing a shared installation for "
-            "multiple users, consider adding the -t <target-dir> option to install necessary dependencies "
-            "into a shared directory, e.g.\n"
-            "python3 -m pip install -t <shared-install-path> -r requirements.txt\n"
-            "Note that the -DPYTHON_DEPS=<shared-install-path> can be used to provide an "
-            "additional search path to cmake for python packages."
-        )
-    endif()
+    find_package(Python3 3.8 COMPONENTS Interpreter REQUIRED)
+    message(STATUS "Python ${Python3_VERSION} found")
+    message(STATUS "Note: Profile mode uses stdlib only. Analyze mode deps checked at runtime.")
 endif()
 
 # ----------------------
@@ -302,6 +246,21 @@ option(
     "Skip building native counter collection tool library (for runtime compilation)"
     OFF
 )
+
+# ---------------------------
+# Profile mode import guard
+# ---------------------------
+
+# Import guard only works when calling main() directly (not in binary subprocess mode)
+if(NOT STANDALONEBINARY)
+    add_test(
+        NAME test_import_guard
+        COMMAND
+            ${PYTHON_TEST_COMMAND} -m pytest
+            --junitxml=tests/test_import_guard.xml ${COV_OPTION}
+            tests/test_import_guard.py ${WORKING_DIR_OPTION}
+    )
+endif()
 
 # ---------------------------
 # profile mode tests

--- a/projects/rocprofiler-compute/CONTRIBUTING.md
+++ b/projects/rocprofiler-compute/CONTRIBUTING.md
@@ -231,8 +231,6 @@ These tests are automatically protected by guards in `tests/conftest.py` when te
 The guard intercepts ALL imports (direct, nested, dynamic) and fails tests immediately if
 non-stdlib packages are imported.
 
-NOTE: Tests
-
 ### What's Allowed
 
 **Python standard library** (Python 3.8+):

--- a/projects/rocprofiler-compute/CONTRIBUTING.md
+++ b/projects/rocprofiler-compute/CONTRIBUTING.md
@@ -205,3 +205,86 @@ For detailed vendoring workflow (adding/updating packages), see [`src/vendored/R
 This project uses AI coding assistants (Claude Code, Cursor, GitHub Copilot). All AI-specific guidelines live in [`AGENTS.md`](AGENTS.md), which serves as the single source of truth. Tool-specific adapter files (e.g., `CLAUDE.md`, `.github/copilot-instructions.md`) reference `AGENTS.md` without duplicating content.
 
 To add or update AI guidelines, edit the appropriate file under `.ai/` and add a reference in `AGENTS.md`.
+## Profile Mode Dependency Policy
+
+Profile mode code should not use non-standard Python libraries.
+
+### Why This Matters
+
+Profile mode uses only stdlib to:
+1. **Avoid dependency conflicts** - Users can profile without creating virtual environments or worrying about package version conflicts with their own projects
+2. **Work everywhere** - No `pip install` needed:
+   - HPC systems with locked-down Python environments
+   - Security-sensitive systems requiring minimal dependencies
+   - Any system with Python 3.8+ installed
+
+### Enforcement
+
+**Python Version Requirement:**
+- Import enforcement requires Python 3.10+ (uses `sys.stdlib_module_names`)
+- Python 3.8-3.9: Tests run but import enforcement is disabled (warning issued)
+- CI uses Python 3.10+ to ensure full enforcement coverage
+
+Enforcement is automatically done for tests which execute profile pipeline using main
+function instead of subprocess (unlike tests using --call-binary and multi mpi rank tests).
+These tests are automatically protected by guards in `tests/conftest.py` when testing with Python 3.10 and above.
+The guard intercepts ALL imports (direct, nested, dynamic) and fails tests immediately if
+non-stdlib packages are imported.
+
+NOTE: Tests
+
+### What's Allowed
+
+**Python standard library** (Python 3.8+):
+- `json`, `csv`, `sqlite3`, `subprocess`, `pathlib`, `logging`, `sys`, `os`, etc.
+
+**Project modules**:
+- `rocprof_compute`, `utils`, `vendored.*`, `roofline`, `config`, `argparser`
+
+**ROCm system libraries** (bundled with ROCm, not pip packages):
+- `amdsmi` - AMD System Management Interface
+- `hip` - HIP runtime Python bindings
+- `rocprofv3` - rocprofv3 Python bindings
+
+### What's NOT Allowed
+
+These are forbidden in profile mode
+
+**External packages**:
+- `pandas`, `yaml`, `numpy`, `plotly`, `dash`, `textual`, etc.
+- Anything from `requirements.txt`
+
+### Common Mistakes
+
+**Don't do this in profile code:**
+```python
+import pandas  # External package
+import yaml    # Use json or vendored.pyyaml instead
+import numpy   # Use stdlib math/statistics
+```
+
+**Do this instead:**
+```python
+import json              # Stdlib for config/data
+import csv               # Stdlib for CSV operations
+import sqlite3           # Stdlib for data manipulation
+from vendored.pyyaml import yaml  # Vendored package (if needed)
+```
+
+### If Your Test Fails
+
+**Error message:**
+```
+PROFILE MODE DEPENDENCY VIOLATION
+Forbidden package: pandas
+```
+
+**How to fix:**
+
+1. **Move import to analyze mode**
+   - Move the import and relevant code to analysis mode
+
+2. **Use stdlib alternative**
+   - `pandas` → `csv` module + `sqlite3` for dataframes
+   - `yaml` → `json` module (or `vendored.pyyaml` if YAML required)
+   - `numpy` → `math`/`statistics` modules

--- a/projects/rocprofiler-compute/src/rocprof-compute
+++ b/projects/rocprofiler-compute/src/rocprof-compute
@@ -58,20 +58,30 @@ def check_version(local_ver: str, desired_ver: str, operator: str) -> bool:
     return ops.get(operator, lambda loc, des: True)(local_ver, desired_ver)
 
 
-def verify_deps() -> None:
-    """Utility to read library dependencies from requirements.txt and endeavor
-    to load them within current execution environment.
-    Used in top-level rocprofiler-compute to provide error messages if necessary
-    dependencies are not available."""
+def check_python_version() -> None:
+    """Check that Python version meets minimum requirement for rocprofiler-compute.
 
+    Both profile and analyze modes require Python 3.8+.
+    """
+    min_python = (3, 8)
     # Check which version of python is being used
-    if sys.version_info < (3, 8):  # noqa: UP036
+    if sys.version_info < min_python:  # noqa: UP036
         print(
-            f"[ERROR] Python 3.8 or higher is required to run rocprofiler-compute. "
-            f"The current version is {sys.version_info[0]}.{sys.version_info[1]}."
+            f"[ERROR] Python {min_python[0]}.{min_python[1]} or higher "
+            f"is required for rocprofiler-compute. "
+            f"The current version is "
+            f"{sys.version_info[0]}.{sys.version_info[1]}."
         )
         sys.exit(1)
 
+
+def verify_deps() -> None:
+    """Verify that all required packages from requirements.txt are installed
+    with correct versions for analyze mode execution.
+
+    NOTE: Only called for analyze mode. Profile mode requires no external
+    dependencies (uses stdlib only).
+    """
     bindir = str(Path(__file__).resolve().parent)
     deps_locations = ["requirements.txt", "../requirements.txt"]
 
@@ -125,8 +135,8 @@ def verify_deps() -> None:
 def main() -> None:
     """Main function for rocprofiler-compute"""
 
-    # verify required python dependencies
-    verify_deps()
+    # Check Python version requirement applies to both profile and analyze modes
+    check_python_version()
 
     rocprof_compute = RocProfCompute()
     mode = rocprof_compute.get_mode()
@@ -135,6 +145,8 @@ def main() -> None:
     if mode == "profile":
         rocprof_compute.run_profiler()
     elif mode == "analyze":
+        # Analyze mode requires external dependencies - verify them
+        verify_deps()
         rocprof_compute.run_analysis()
     else:
         console_error("Unsupported execution mode")

--- a/projects/rocprofiler-compute/tests/conftest.py
+++ b/projects/rocprofiler-compute/tests/conftest.py
@@ -16,16 +16,129 @@ SRC = os.path.join(ROOT, "src")
 if SRC not in sys.path:
     sys.path.insert(0, SRC)
 
-try:
-    rocprof_compute = SourceFileLoader(
-        "rocprof-compute", "src/rocprof-compute"
-    ).load_module()
+# Determine script path
+if Path("src/rocprof-compute").exists():
     rocprof_compute_script_path = "src/rocprof-compute"
-except Exception:
-    rocprof_compute = SourceFileLoader(
-        "rocprof-compute", "rocprof-compute"
-    ).load_module()
+elif Path("rocprof-compute").exists():
     rocprof_compute_script_path = "rocprof-compute"
+else:
+    raise FileNotFoundError("Cannot find rocprof-compute script")
+
+
+class ProfileModeImportGuard:
+    """
+    Import guard using sys.meta_path to enforce stdlib-only imports in profile mode.
+
+    Python Version Compatibility:
+        - Python 3.10+: Full enforcement (uses sys.stdlib_module_names)
+        - Python 3.8-3.9: No-op mode (enforcement disabled, warning issued)
+
+    Usage:
+        with ProfileModeImportGuard():
+            # Python 3.10+: Import checking active, non-stdlib imports raise ImportError
+            # Python 3.8-3.9: No-op, all imports allowed (with warning)
+
+    Context Manager Protocol:
+        __enter__: Registers guard with Python's import system (sys.meta_path)
+        __exit__: Unregisters guard after code execution completes
+    """
+
+    # Project modules that are allowed (non-stdlib)
+    ALLOWED_PROJECT_MODULES = frozenset([
+        "rocprof_compute",
+        "rocprof_compute_profile",
+        "rocprof_compute_analyze",
+        "rocprof_compute_soc",
+        "rocprof_compute_tui",
+        "utils",
+        "vendored",
+        "roofline",
+        "config",
+        "argparser",  # src/argparser.py, not stdlib argparse
+        "rocprof_compute_base",
+    ])
+
+    # ROCm system libraries (not pip packages)
+    ALLOWED_ROCM_MODULES = frozenset([
+        "amdsmi",  # AMD System Management Interface
+        "hip",  # HIP runtime Python bindings
+        "rocprofv3",  # rocprofv3 python modules such as avail
+        "rocprofv3_avail_module",  # Alternative avail module for backward compatibility
+    ])
+
+    def __enter__(self):
+        """
+        Register import guard with Python's import system.
+
+        Called automatically when entering 'with' block.
+        Adds this object to sys.meta_path so Python calls our find_spec()
+        for every import during the with block.
+        """
+        if sys.version_info >= (3, 10):
+            sys.meta_path.insert(0, self)
+        else:
+            print(
+                "\n" + "=" * 70 + "\n"
+                "WARNING: ProfileModeImportGuard requires Python 3.10+\n"
+                "(sys.stdlib_module_names unavailable).\n"
+                "Import enforcement DISABLED for this test run.\n" + "=" * 70 + "\n",
+                file=sys.stderr,
+            )
+        return self
+
+    def __exit__(self, _exc_type, _exc_val, _exc_tb):
+        """
+        Unregister import guard from Python's import system.
+
+        Called automatically when exiting 'with' block.
+        Removes this object from sys.meta_path, disabling import checking.
+        """
+        if sys.version_info >= (3, 10) and self in sys.meta_path:
+            sys.meta_path.remove(self)
+
+    def find_spec(self, fullname, path, target=None):
+        """
+        PEP 451 import hook - called automatically by Python during imports.
+
+        Python's import system calls this method for every import statement.
+        We check if the module is allowed, and raise ImportError if not.
+        """
+        top_level = fullname.split(".")[0]
+
+        # Check stdlib
+        if top_level in sys.stdlib_module_names:
+            return None
+
+        # Check ROCm modules
+        if top_level in self.ALLOWED_ROCM_MODULES:
+            return None
+
+        # Check project modules (validate origin to prevent third-party modules
+        # with same name, e.g., "utils" from site-packages)
+        if top_level in self.ALLOWED_PROJECT_MODULES:
+            if self._is_from_project(top_level):
+                return None
+
+        # Forbidden module
+        raise ImportError(
+            f"\n{'=' * 70}\n"
+            "PROFILE MODE DEPENDENCY VIOLATION\n"
+            f"{'=' * 70}\n"
+            f"Forbidden package: {top_level}\n\n"
+            "Profile mode must use ONLY Python stdlib + ROCm libraries.\n"
+            "Fix: Move import to analyze mode or use stdlib alternative.\n"
+            "See CONTRIBUTING.md 'Profile Mode Dependency Policy'\n"
+            f"{'=' * 70}\n"
+        )
+
+    def _is_from_project(self, module_name):
+        """Check if module exists in project directory, not site-packages."""
+        project_root = Path(__file__).parent.parent
+        for base in [project_root / "src", project_root]:
+            for p in [base / f"{module_name}.py", base / module_name / "__init__.py"]:
+                if p.exists():
+                    return True
+        return False
 
 
 def inject_mpirun(command, num_ranks):
@@ -252,12 +365,17 @@ def binary_handler_profile_rocprof_compute(request):
                 return process.returncode
 
             # Default single-rank mode: patch sys.argv and call main() directly
+            # Guard imports during profile execution (test-time enforcement)
             with pytest.raises(SystemExit) as e:
                 with patch(
                     "sys.argv",
                     command_rocprof_compute,
                 ):
-                    rocprof_compute.main()
+                    with ProfileModeImportGuard():
+                        rocprof_compute = SourceFileLoader(
+                            "rocprof-compute", rocprof_compute_script_path
+                        ).load_module()
+                        rocprof_compute.main()
             # verify run status
             if check_success:
                 assert e.value.code == 0
@@ -297,6 +415,10 @@ def binary_handler_analyze_rocprof_compute(request):
                     "sys.argv",
                     ["rocprof-compute", *arguments],
                 ):
+                    # Load module (no guard needed for analyze mode)
+                    rocprof_compute = SourceFileLoader(
+                        "rocprof-compute", rocprof_compute_script_path
+                    ).load_module()
                     rocprof_compute.main()
             return e.value.code
 

--- a/projects/rocprofiler-compute/tests/conftest.py
+++ b/projects/rocprofiler-compute/tests/conftest.py
@@ -135,8 +135,14 @@ class ProfileModeImportGuard:
         """Check if module exists in project directory, not site-packages."""
         project_root = Path(__file__).parent.parent
         for base in [project_root / "src", project_root]:
-            for p in [base / f"{module_name}.py", base / module_name / "__init__.py"]:
-                if p.exists():
+            # Check for: module.py, module/__init__.py, or module/ (namespace pkg)
+            candidates = [
+                base / f"{module_name}.py",
+                base / module_name / "__init__.py",
+                base / module_name,  # namespace package (dir without __init__.py)
+            ]
+            for p in candidates:
+                if p.is_file() or (p.is_dir() and p.exists()):
                     return True
         return False
 

--- a/projects/rocprofiler-compute/tests/conftest.py
+++ b/projects/rocprofiler-compute/tests/conftest.py
@@ -17,12 +17,12 @@ if SRC not in sys.path:
     sys.path.insert(0, SRC)
 
 # Determine script path
-if Path("src/rocprof-compute").exists():
-    rocprof_compute_script_path = "src/rocprof-compute"
-elif Path("rocprof-compute").exists():
-    rocprof_compute_script_path = "rocprof-compute"
-else:
+rocprof_compute_script_path = Path(ROOT) / "src/rocprof-compute"
+if not rocprof_compute_script_path.exists():
+    rocprof_compute_script_path = Path(ROOT) / "rocprof-compute"
+if not rocprof_compute_script_path.exists():
     raise FileNotFoundError("Cannot find rocprof-compute script")
+rocprof_compute_script_path = str(rocprof_compute_script_path)
 
 
 class ProfileModeImportGuard:

--- a/projects/rocprofiler-compute/tests/test_import_guard.py
+++ b/projects/rocprofiler-compute/tests/test_import_guard.py
@@ -1,7 +1,7 @@
 ##############################################################################
 # MIT License
 #
-# Copyright (c) 2025 Advanced Micro Devices, Inc. All Rights Reserved.
+# Copyright (c) 2026 Advanced Micro Devices, Inc. All Rights Reserved.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal

--- a/projects/rocprofiler-compute/tests/test_import_guard.py
+++ b/projects/rocprofiler-compute/tests/test_import_guard.py
@@ -1,0 +1,114 @@
+##############################################################################
+# MIT License
+#
+# Copyright (c) 2025 Advanced Micro Devices, Inc. All Rights Reserved.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+##############################################################################
+
+"""Test the ProfileModeImportGuard to ensure it works correctly."""
+
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+
+def test_import_guard_allows_stdlib_and_project():
+    """Verify ProfileModeImportGuard allows stdlib and project imports."""
+    from conftest import ProfileModeImportGuard
+
+    with ProfileModeImportGuard():
+        # 1. Stdlib imports (must succeed - these are always available)
+        import argparse
+        import json
+        import pathlib
+
+        assert json is not None
+        assert argparse is not None
+        assert pathlib is not None
+
+        # 2. Project modules (must succeed - sys.path includes src/)
+        import config
+        import utils
+
+        assert utils is not None
+        assert config is not None
+
+
+def test_import_guard_allows_rocm_modules():
+    """Verify ProfileModeImportGuard allows ROCm system libraries."""
+    from conftest import ProfileModeImportGuard
+
+    # Add amdsmi to sys.path (same as profile code does)
+    amdsmi_path = Path(os.getenv("ROCM_PATH", "/opt/rocm")) / "share/amd_smi"
+    if not amdsmi_path.exists():
+        pytest.skip("ROCm not installed - skipping ROCm module import test")
+
+    sys.path.insert(0, str(amdsmi_path))
+
+    # Check if amdsmi module exists
+    try:
+        import amdsmi
+    except ImportError:
+        pytest.skip("amdsmi module not found - skipping ROCm module import test")
+
+    # Clear from cache to ensure guard is actually tested
+    if "amdsmi" in sys.modules:
+        del sys.modules["amdsmi"]
+
+    # Now test that the guard allows it
+    with ProfileModeImportGuard():
+        import amdsmi
+
+        assert amdsmi is not None
+
+
+def test_import_guard_blocks_non_stdlib():
+    """Verify ProfileModeImportGuard blocks non-stdlib imports."""
+    from conftest import ProfileModeImportGuard
+
+    if sys.version_info < (3, 10):
+        pytest.skip(
+            "ProfileModeImportGuard requires Python 3.10+ (sys.stdlib_module_names)"
+        )
+
+    # Test blocking non-stdlib imports
+    # Note: Must clear from sys.modules first since import hooks only
+    # run for uncached modules
+    test_packages = ["pandas", "yaml", "numpy"]
+
+    for package in test_packages:
+        # Clear from cache if present
+        if package in sys.modules:
+            del sys.modules[package]
+
+        # Should block the import
+        with pytest.raises(ImportError, match="PROFILE MODE DEPENDENCY VIOLATION"):
+            with ProfileModeImportGuard():
+                __import__(package)
+
+        # Verify error message mentions the forbidden package
+        if package in sys.modules:
+            del sys.modules[package]
+        with pytest.raises(ImportError, match=package):
+            with ProfileModeImportGuard():
+                __import__(package)


### PR DESCRIPTION
## Motivation

Implements test-time enforcement of the stdlib-only requirement for profile mode and removes dependency checking from build/profile startup.

Document this policy in CONTRIBUTING.md

This allows users can profile without venv setup, avoid dependency conflicts, and work on any Python 3.8+ system.


## Technical Details

**1. ProfileModeImportGuard** (`tests/conftest.py`)
- Uses `sys.meta_path` PEP 302 hooks to intercept imports
- Enforcement only works on >= Python 3.10 and no-op for < Python 3.10
- Fails fast on non-stdlib imports with clear error
- Allows project modules and ROCm libraries

**2. Guard Integration** (`tests/conftest.py:571`)
- Wraps `rocprof_compute.main()` in `binary_handler_profile_rocprof_compute` fixture

**3. Meta-Test** (`tests/test_import_guard.py`)
- Validates guard blocks non-stdlib packages
- Added to ctest (conditional on `NOT STANDALONEBINARY`)

**4. Move verify_deps()** (`src/rocprof-compute:143`)
- Removed from profile startup
- Only called in analyze mode

**5. Remove CMake Checks** (`CMakeLists.txt`)
- Deleted `CHECK_PYTHON_DEPS` option (~50 lines)
- Kept Python interpreter detection only

**6. Documentation** (`CONTRIBUTING.md`)
- Added "Profile Mode Dependency Policy" section
- Documents enforcement, allowed modules, and fix guidance

## JIRA ID

AIPROFCOMP-452
AIPROFCOMP-447

## Test Plan


## Test Result


## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
