### PR TITLE
[ROCM-8647] Fix amdsmi frequencies_read test fail

### DIFF
--- a/projects/amdsmi/src/amd_smi/amd_smi.cc
+++ b/projects/amdsmi/src/amd_smi/amd_smi.cc
@@ -4051,6 +4051,9 @@ amdsmi_status_t amdsmi_set_gpu_pci_bandwidth(amdsmi_processor_handle processor_h
 
 amdsmi_status_t amdsmi_get_gpu_pci_bandwidth(amdsmi_processor_handle processor_handle,
                                              amdsmi_pcie_bandwidth_t* bandwidth) {
+  if (bandwidth == nullptr) {
+    return AMDSMI_STATUS_INVAL;
+  }
   return rsmi_wrapper(rsmi_dev_pci_bandwidth_get, processor_handle, 0,
                       reinterpret_cast<rsmi_pcie_bandwidth_t*>(bandwidth));
 }

--- a/projects/amdsmi/tests/amd_smi_test/functional/frequencies_read.cc
+++ b/projects/amdsmi/tests/amd_smi_test/functional/frequencies_read.cc
@@ -145,10 +145,14 @@ void TestFrequenciesRead::Run(void) {
       err = amdsmi_get_gpu_pci_bandwidth(processor_handles_[i], &b);
       if (err == AMDSMI_STATUS_NOT_SUPPORTED) {
         ASSERT_EQ(err, AMDSMI_STATUS_NOT_SUPPORTED);
-        std::cout << "\t**Get PCIE Bandwidth: Not supported on this machine" << std::endl;
+        IF_VERB(STANDARD) {
+          std::cout << "\t**Get PCIE Bandwidth: Not supported on this machine" << std::endl;
+        }
       } else if (err == AMDSMI_STATUS_NOT_YET_IMPLEMENTED) {
         ASSERT_EQ(err, AMDSMI_STATUS_NOT_YET_IMPLEMENTED);
-        std::cout << "\t**Get PCIE Bandwidth: Not implemented on this machine" << std::endl;
+        IF_VERB(STANDARD) {
+          std::cout << "\t**Get PCIE Bandwidth: Not implemented on this machine" << std::endl;
+        }
       } else {
         CHK_ERR_ASRT(err)
         IF_VERB(STANDARD) {

--- a/projects/amdsmi/tests/amd_smi_test/functional/frequencies_read.cc
+++ b/projects/amdsmi/tests/amd_smi_test/functional/frequencies_read.cc
@@ -139,31 +139,22 @@ void TestFrequenciesRead::Run(void) {
       freq_output(AMDSMI_CLK_TYPE_DCEF, "Display Controller Engine Clock");
       freq_output(AMDSMI_CLK_TYPE_SOC, "SOC Clock");
 
+      // Verify api support checking functionality is working
+      err = amdsmi_get_gpu_pci_bandwidth(processor_handles_[i], nullptr);
+      ASSERT_EQ(err, AMDSMI_STATUS_INVAL);
       err = amdsmi_get_gpu_pci_bandwidth(processor_handles_[i], &b);
       if (err == AMDSMI_STATUS_NOT_SUPPORTED) {
+        ASSERT_EQ(err, AMDSMI_STATUS_NOT_SUPPORTED);
         std::cout << "\t**Get PCIE Bandwidth: Not supported on this machine" << std::endl;
-        // Verify api support checking functionality is working
-        err = amdsmi_get_gpu_pci_bandwidth(processor_handles_[i], nullptr);
-        ASSERT_EQ(err, AMDSMI_STATUS_INVAL);
       } else if (err == AMDSMI_STATUS_NOT_YET_IMPLEMENTED) {
-        std::cout << "\t**Get PCIE Bandwidth "
-                  << ": Not implemented on this machine" << std::endl;
+        ASSERT_EQ(err, AMDSMI_STATUS_NOT_YET_IMPLEMENTED);
+        std::cout << "\t**Get PCIE Bandwidth: Not implemented on this machine" << std::endl;
       } else {
         CHK_ERR_ASRT(err)
         IF_VERB(STANDARD) {
           std::cout << "\t**Supported PCIe bandwidths: ";
           std::cout << b.transfer_rate.num_supported << std::endl;
           print_frequencies(&b.transfer_rate, b.lanes);
-          // Verify api support checking functionality is working
-          // NOTE:  We expect AMDSMI_STATUS_NOT_SUPPORTED, if rsmi_pcie_bandwidth_t* is NULL
-          err = amdsmi_get_gpu_pci_bandwidth(processor_handles_[i], nullptr);
-          if (err != amdsmi_status_t::AMDSMI_STATUS_NOT_SUPPORTED) {
-            ASSERT_EQ(err, AMDSMI_STATUS_INVAL);
-          } else {
-            auto status_string("");
-            amdsmi_status_code_to_string(err, &status_string);
-            std::cout << "\t\t** amdsmi_get_gpu_pci_bandwidth(): " << status_string << "\n";
-          }
         }
       }
     }


### PR DESCRIPTION

## Motivation

amdsmitstReadOnly.TestFrequenciesRead test failure

## Technical Details

The CHK_API_SUPPORT_ONLY from frequencies_read test can return either NOT_SUPPORTED or INVALID status depending on device support. Modified the test check accordingly.

## JIRA ID

ROCM-8647

## Test Plan

amdsmitstReadOnly.TestFrequenciesRead

## Test Result

<img width="291" height="256" alt="image" src="https://github.com/user-attachments/assets/e8b0aa7c-adb9-4c68-98ce-15f7a2d2aa21" />

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
