### PR TITLE
Enable PC sampling with attach/detach: add code_object tracking and dedicated background thread for attach/detach to prevent deadlocks

### DIFF
--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-attach/attach.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-attach/attach.cpp
@@ -114,18 +114,18 @@ get_background_thread()
 ROCPROFILER_EXTERN_C_INIT
 
 int
-rocprofiler_attach_set_api_table(const char*                                   name,
-                                 uint64_t                                      lib_version,
-                                 uint64_t                                      lib_instance,
+rocprofiler_attach_set_api_table(const char* name,
+                                 uint64_t /*lib_version*/,
+                                 uint64_t /*lib_instance*/,
                                  void**                                        tables,
                                  uint64_t                                      num_tables,
                                  rocprofiler_register_library_api_table_func_t register_functor)
     ROCPROFILER_PUBLIC_API;
 
 int
-rocprofiler_attach_set_api_table(const char*                                   name,
-                                 uint64_t                                      lib_version,
-                                 uint64_t                                      lib_instance,
+rocprofiler_attach_set_api_table(const char* name,
+                                 uint64_t /*lib_version*/,
+                                 uint64_t /*lib_instance*/,
                                  void**                                        tables,
                                  uint64_t                                      num_tables,
                                  rocprofiler_register_library_api_table_func_t register_functor)
@@ -135,8 +135,6 @@ rocprofiler_attach_set_api_table(const char*                                   n
     get_background_thread()->start();
 
     ROCP_TRACE << "rocprofiler_attach_set_api_table called for api " << name;
-    (void) lib_version;   // unused
-    (void) lib_instance;  // unused
 
     if(std::string_view{name} != "hsa")
     {

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-attach/attach.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-attach/attach.cpp
@@ -23,6 +23,7 @@
 #include "attach.h"
 #include "code_object_registration.hpp"
 #include "lib/common/defines.hpp"
+#include "lib/common/utility.hpp"
 #include "queue_registration.hpp"
 #include "table.hpp"
 
@@ -30,6 +31,12 @@
 
 #include <rocprofiler-register/rocprofiler-register.h>
 #include <rocprofiler-sdk/version.h>
+
+#include <condition_variable>
+#include <mutex>
+#include <signal.h>
+#include <thread>
+#include <unistd.h>
 
 #define ROCPROFILER_ATTACH_VERSION_MAJOR ROCPROFILER_VERSION_MAJOR
 #define ROCPROFILER_ATTACH_VERSION_MINOR ROCPROFILER_VERSION_MINOR
@@ -41,6 +48,49 @@
 
 using rocprofiler_register_library_api_table_func_t =
     decltype(::rocprofiler_register_library_api_table)*;
+
+namespace
+{
+struct BackgroundThread
+{
+    std::thread             thread;
+    std::mutex              mtx;
+    std::condition_variable cv;
+    bool                    should_stop = false;
+    pid_t                   tid         = 0;
+
+    void start()
+    {
+        if(thread.joinable()) return;
+
+        thread = std::thread([this]() {
+            pthread_setname_np(pthread_self(), "rocp-bg-attach");
+
+            sigset_t all_signals;
+            sigfillset(&all_signals);
+            pthread_sigmask(SIG_BLOCK, &all_signals, nullptr);
+
+            tid = static_cast<pid_t>(rocprofiler::common::get_tid());
+
+            ROCP_INFO << "[rocprofiler-sdk-attach] Background thread started, TID=" << tid
+                      << " PID=" << getpid();
+
+            std::unique_lock<std::mutex> lock(mtx);
+            cv.wait(lock, [this] { return should_stop; });
+        });
+    }
+
+    ~BackgroundThread()
+    {
+        {
+            std::lock_guard<std::mutex> lock(mtx);
+            should_stop = true;
+        }
+        cv.notify_one();
+        if(thread.joinable()) thread.join();
+    }
+};
+}  // namespace
 
 ROCPROFILER_EXTERN_C_INIT
 
@@ -62,6 +112,9 @@ rocprofiler_attach_set_api_table(const char*                                   n
                                  rocprofiler_register_library_api_table_func_t register_functor)
 {
     rocprofiler::common::init_logging("ROCPROFILER_ATTACH");
+
+    static BackgroundThread bg_thread;
+    bg_thread.start();
 
     ROCP_TRACE << "rocprofiler_attach_set_api_table called for api " << name;
     (void) lib_version;   // unused

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-attach/attach.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-attach/attach.cpp
@@ -23,6 +23,7 @@
 #include "attach.h"
 #include "code_object_registration.hpp"
 #include "lib/common/defines.hpp"
+#include "lib/common/static_object.hpp"
 #include "lib/common/utility.hpp"
 #include "queue_registration.hpp"
 #include "table.hpp"
@@ -32,11 +33,12 @@
 #include <rocprofiler-register/rocprofiler-register.h>
 #include <rocprofiler-sdk/version.h>
 
+#include <signal.h>
+#include <unistd.h>
+
 #include <condition_variable>
 #include <mutex>
-#include <signal.h>
 #include <thread>
-#include <unistd.h>
 
 #define ROCPROFILER_ATTACH_VERSION_MAJOR ROCPROFILER_VERSION_MAJOR
 #define ROCPROFILER_ATTACH_VERSION_MINOR ROCPROFILER_VERSION_MINOR
@@ -51,6 +53,14 @@ using rocprofiler_register_library_api_table_func_t =
 
 namespace
 {
+// Dedicated idle background thread used as a safe ptrace injection target during
+// attach/detach. Previously, ptrace-based code injection targeted the main
+// application thread, which could deadlock if that thread held internal mutexes.
+//
+// This thread names itself "rocp-bg-attach" via pthread_setname_np so the attacher
+// can locate it by scanning /proc/<pid>/task/*/comm. It blocks all signals, holds
+// no application-owned locks, and waits on a condition variable indefinitely until
+// shutdown.
 struct BackgroundThread
 {
     std::thread             thread;
@@ -66,6 +76,8 @@ struct BackgroundThread
         thread = std::thread([this]() {
             pthread_setname_np(pthread_self(), "rocp-bg-attach");
 
+            // Prevent signals from interrupting this thread -- it exists solely as a
+            // safe ptrace injection target and must never run application signal handlers.
             sigset_t all_signals;
             sigfillset(&all_signals);
             pthread_sigmask(SIG_BLOCK, &all_signals, nullptr);
@@ -90,6 +102,13 @@ struct BackgroundThread
         if(thread.joinable()) thread.join();
     }
 };
+
+BackgroundThread*
+get_background_thread()
+{
+    static auto*& _v = rocprofiler::common::static_object<BackgroundThread>::construct();
+    return _v;
+}
 }  // namespace
 
 ROCPROFILER_EXTERN_C_INIT
@@ -113,8 +132,7 @@ rocprofiler_attach_set_api_table(const char*                                   n
 {
     rocprofiler::common::init_logging("ROCPROFILER_ATTACH");
 
-    static BackgroundThread bg_thread;
-    bg_thread.start();
+    get_background_thread()->start();
 
     ROCP_TRACE << "rocprofiler_attach_set_api_table called for api " << name;
     (void) lib_version;   // unused

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-rocattach/rocattach.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-rocattach/rocattach.cpp
@@ -30,6 +30,8 @@
 #include <rocprofiler-sdk-rocattach/rocattach.h>
 #include <rocprofiler-sdk-rocattach/types.h>
 
+#include <filesystem>
+#include <fstream>
 #include <map>
 #include <mutex>
 #include <unordered_map>
@@ -186,6 +188,32 @@ build_environment_buffer()
     return environment_buffer;
 }
 
+pid_t
+resolve_attach_tid(pid_t pid)
+{
+    auto            task_dir = "/proc/" + std::to_string(pid) + "/task";
+    std::error_code ec;
+    for(const auto& entry : std::filesystem::directory_iterator(task_dir, ec))
+    {
+        if(!entry.is_directory()) continue;
+
+        auto          comm_path = entry.path() / "comm";
+        std::ifstream comm_file(comm_path);
+        std::string   name;
+        if(std::getline(comm_file, name) && name == "rocp-bg-attach")
+        {
+            pid_t tid = std::stoi(entry.path().filename().string());
+            ROCP_INFO << "[rocprofiler-sdk-rocattach] Found background thread TID " << tid
+                      << " for pid " << pid << " via /proc scan";
+            return tid;
+        }
+    }
+
+    ROCP_WARNING << "[rocprofiler-sdk-rocattach] Could not find 'rocp-bg-attach' thread in "
+                 << task_dir << ", falling back to pid " << pid;
+    return pid;
+}
+
 rocattach_status_t
 setup(int pid)
 {
@@ -206,7 +234,10 @@ setup(int pid)
             return ROCATTACH_STATUS_ERROR_INVALID_ARGUMENT;
         }
 
-        sessions->emplace(pid, pid);
+        auto target_tid = resolve_attach_tid(pid);
+        ROCP_INFO << "[rocprofiler-sdk-rocattach] Attaching to PID " << pid
+                  << " via background thread TID " << target_tid;
+        sessions->emplace(pid, target_tid);
         session = &(sessions->at(pid));
     }
     auto status = ROCATTACH_STATUS_SUCCESS;

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/pc_sampling/code_object.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/pc_sampling/code_object.cpp
@@ -169,7 +169,7 @@ chained_notify_new_code_object(hsa_executable_t executable, void* data)
     {
         get_prev_notify_callback()(executable, data);
     }
-   executable_freeze_internal(executable);
+    executable_freeze_internal(executable);
 }
 
 void

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/pc_sampling/code_object.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/pc_sampling/code_object.cpp
@@ -61,6 +61,20 @@ get_destroy_function()
     return _v;
 }
 
+RocAttachDispatchTable**
+get_attach_table()
+{
+    static auto* table = common::static_object<RocAttachDispatchTable*>::construct();
+    return table;
+}
+
+auto&
+get_prev_notify_callback()
+{
+    static rocprofiler_attach_notify_new_code_object_t _v = nullptr;
+    return _v;
+}
+
 /**
  * @brief Flush internal PC sampling buffers and generate a marker record
  * for the code object load/unload event.
@@ -91,13 +105,10 @@ flush_pc_sampling_buffers(const rocprofiler::code_object::hsa::code_object& code
     flush_internal_agent_buffers(agent_buffer_id);
 }
 
-hsa_status_t
-executable_freeze(hsa_executable_t executable, const char* options)
+// Internal implementation that can be called from both executable_freeze and attach mechanism
+void
+executable_freeze_internal(hsa_executable_t executable, bool flush = true)
 {
-    // Call underlying function
-    hsa_status_t status = CHECK_NOTNULL(get_freeze_function())(executable, options);
-    if(status != HSA_STATUS_SUCCESS) return status;
-
     rocprofiler::code_object::iterate_loaded_code_objects(
         [&](const rocprofiler::code_object::hsa::code_object& code_object) {
             if(code_object.hsa_executable == executable)
@@ -107,10 +118,19 @@ executable_freeze(hsa_executable_t executable, const char* options)
                     address_range_t{code_object_rocp.load_base,
                                     code_object_rocp.load_size,
                                     code_object_rocp.code_object_id});
-                flush_pc_sampling_buffers(code_object);
+                if(flush) flush_pc_sampling_buffers(code_object);
             }
         });
+}
 
+hsa_status_t
+executable_freeze(hsa_executable_t executable, const char* options)
+{
+    // Call underlying function
+    hsa_status_t status = CHECK_NOTNULL(get_freeze_function())(executable, options);
+    if(status != HSA_STATUS_SUCCESS) return status;
+
+    executable_freeze_internal(executable);
     return HSA_STATUS_SUCCESS;
 }
 
@@ -133,6 +153,33 @@ executable_destroy(hsa_executable_t executable)
     // Call underlying function
     return CHECK_NOTNULL(get_destroy_function())(executable);
 }
+
+void
+iterate_attach_code_object(hsa_executable_t executable, void*)
+{
+    // No need to flush when iterating over already loaded code objects during attach,
+    // as the PC sampling service might not be started yet, so there's nothing to flush.
+    executable_freeze_internal(executable, /*flush=*/false);
+}
+
+void
+chained_notify_new_code_object(hsa_executable_t executable, void* data)
+{
+    if(get_prev_notify_callback())
+    {
+        get_prev_notify_callback()(executable, data);
+    }
+   executable_freeze_internal(executable);
+}
+
+void
+load_attach_code_objects()
+{
+    auto* attach_table = CHECK_NOTNULL(*(get_attach_table()));
+    attach_table->rocprofiler_attach_iterate_all_code_objects(iterate_attach_code_object, nullptr);
+    get_prev_notify_callback() = attach_table->rocprofiler_attach_notify_new_code_object;
+    attach_table->rocprofiler_attach_notify_new_code_object = chained_notify_new_code_object;
+}
 }  // namespace
 
 void
@@ -141,14 +188,36 @@ initialize(HsaApiTable* table)
     (void) table;
     auto& core_table = *table->core_;
 
-    get_freeze_function()                = CHECK_NOTNULL(core_table.hsa_executable_freeze_fn);
-    get_destroy_function()               = CHECK_NOTNULL(core_table.hsa_executable_destroy_fn);
-    core_table.hsa_executable_freeze_fn  = executable_freeze;
-    core_table.hsa_executable_destroy_fn = executable_destroy;
-    LOG_IF(FATAL, get_freeze_function() == core_table.hsa_executable_freeze_fn)
-        << "infinite recursion";
-    LOG_IF(FATAL, get_destroy_function() == core_table.hsa_executable_destroy_fn)
-        << "infinite recursion";
+    if(*(get_attach_table()))
+    {
+        // If attach table is available, use it to iterate existing code objects
+        // and register for new ones instead of hooking freeze/destroy
+        load_attach_code_objects();
+    }
+    else
+    {
+        // No attach table, use traditional freeze/destroy hooks
+        get_freeze_function()                = CHECK_NOTNULL(core_table.hsa_executable_freeze_fn);
+        get_destroy_function()               = CHECK_NOTNULL(core_table.hsa_executable_destroy_fn);
+        core_table.hsa_executable_freeze_fn  = executable_freeze;
+        core_table.hsa_executable_destroy_fn = executable_destroy;
+        LOG_IF(FATAL, get_freeze_function() == core_table.hsa_executable_freeze_fn)
+            << "infinite recursion";
+        LOG_IF(FATAL, get_destroy_function() == core_table.hsa_executable_destroy_fn)
+            << "infinite recursion";
+    }
+}
+
+void
+initialize(RocAttachDispatchTable* attach_table)
+{
+    // We need to save the attach table for later, when the code object module receives the HSA
+    // table and is initialized. We must get the attach table before HSA for correct behavior. This
+    // is guaranteed by rocprofiler-register.
+    ROCP_ERROR_IF(get_freeze_function())
+        << "PC sampling code object module was initialized before attach table was provided. "
+           "Future HSA code objects may not be instrumented correctly.";
+    *(get_attach_table()) = attach_table;
 }
 
 void

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/pc_sampling/code_object.hpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/pc_sampling/code_object.hpp
@@ -23,8 +23,8 @@
 #pragma once
 
 #include "lib/common/static_object.hpp"
-#include "lib/rocprofiler-sdk/pc_sampling/defines.hpp"
 #include "lib/rocprofiler-sdk-attach/table.h"
+#include "lib/rocprofiler-sdk/pc_sampling/defines.hpp"
 
 #include <hsa/hsa_api_trace.h>
 #include <rocprofiler-sdk/callback_tracing.h>

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/pc_sampling/code_object.hpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/pc_sampling/code_object.hpp
@@ -24,6 +24,7 @@
 
 #include "lib/common/static_object.hpp"
 #include "lib/rocprofiler-sdk/pc_sampling/defines.hpp"
+#include "lib/rocprofiler-sdk-attach/table.h"
 
 #include <hsa/hsa_api_trace.h>
 #include <rocprofiler-sdk/callback_tracing.h>
@@ -119,6 +120,9 @@ private:
 
 void
 initialize(HsaApiTable* table);
+
+void
+initialize(RocAttachDispatchTable* table);
 
 void
 finalize();

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/registration.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/registration.cpp
@@ -1427,6 +1427,9 @@ rocprofiler_set_api_table(const char* name,
         // forward the table to the relevant code sections, then move on
         rocprofiler::hsa::queue_controller_init(rocattach_api);
         rocprofiler::code_object::initialize(rocattach_api);
+#if ROCPROFILER_SDK_HSA_PC_SAMPLING > 0
+        rocprofiler::pc_sampling::code_object::initialize(rocattach_api);
+#endif
 
         rocprofiler::registration::get_attach_status()->has_attach_table = true;
     }


### PR DESCRIPTION
## Summary

### PC Sampling: Code Object Tracking in Attach/Detach Mode

- PC sampling relies on `CodeobjTableTranslatorSynchronized` to map sampled PC addresses to code object IDs. In non-attach mode, this is populated via `hsa_executable_freeze`  / `hsa_executable_destroy` hooks. In attach/detach mode, these hooks are not available as the profiler attaches after HSA initialization, so `hsa_executable_freeze` has already been called for all loaded executables. Without the attach table path, the translation table remains empty and PC samples cannot be correlated to code objects.
- Added a new initialization path in `pc_sampling/code_object` that uses the attach dispatch table to enumerate already‑loaded code objects and register a chained notify callback for newly loaded ones.
- Ensures `CodeobjTableTranslatorSynchronized` is correctly populated, enabling PC address → code object correlation when attaching mid‑execution.
- Skip buffer flushing for pre‑existing code objects during attach initialization, since the PC sampling service may not yet be active.
- Introduced `pc_sampling::code_object::initialize(rocattach_api)` and integrated it into `registration.cpp` so the PC sampling code object module initializes when rocattach registers.

### Background Thread to avoid deadlocks during Attach/Detach

- Previously, ptrace‑based code injection targeted the main application thread, which could deadlock if that thread held internal mutexes.
- Added a dedicated idle background thread in `librocprofiler-sdk-attach` that:
  - Names itself `"rocp-bg-attach"` via `pthread_setname_np`
  - Blocks all signals
  - Waits on a condition variable indefinitely
  - Avoids taking any application‑owned locks
- The attacher now locates this safe injection thread by scanning `/proc/<pid>/task/*/comm` for `"rocp-bg-attach"` and uses its TID for all ptrace operations.

## Changes

- **pc_sampling/code_object.cpp**
  - Added `executable_freeze_internal()` shared logic for HSA hook path and the attach path
  - Added `chained_notify_new_code_object()` for callback chaining
  - Added `load_attach_code_objects()` for attach‑time initialization
  - Added `initialize(RocAttachDispatchTable*)` overload

- **pc_sampling/code_object.hpp**
  - Included `"lib/rocprofiler-sdk-attach/table.h"`
  - Declared `initialize(RocAttachDispatchTable*)` overload

- **registration.cpp**
  - Initialize PC sampling code_object module when rocattach registers  
    (guarded by `ROCPROFILER_SDK_HSA_PC_SAMPLING`)

- **rocprofiler-sdk-attach/attach.cpp**
  - Added `BackgroundThread` with thread naming, signal blocking, and idle wait

- **rocprofiler-sdk-rocattach/rocattach.cpp**
  - Added `resolve_attach_tid()` to scan `/proc/<pid>/task/*/comm`
  - Updated `setup()` to use the background thread’s TID

## Testing

- Verified PC sampling with attach/detach on the transpose application — no deadlocks across multiple runs.
- Confirmed background thread TID discovery via `/proc/<pid>/task/*/comm`.
- The generated PC sampling CSV output contains:
  - Instruction addresses
  - Dispatch IDs
  - Correlation IDs
-  Verified PC sampling with attach/detach on the exec-mask manipulation application — no deadlocks across multiple runs and the csv output was generated.
- In Progress: Developing a dedicated testing strategy for attach/detach scenarios with PC sampling.

## To Do
- **Automated testing:**
  - Identify and use an application that runs long enough to support attachment and produce sufficient PC samples.
  - Update the existing PC sampling validation scripts to accurately verify the collected samples.
- **Code object unload/destroy hook:** Add unload/destroy handling for attach mode in the attach dispatch table. See #4636.
