### PR TITLE
[RDC] Fix embedded profiler by loading librdc_rocp.so with RTLD_GLOBAL

### DIFF
--- a/projects/rdc/include/rdc_lib/RdcLibraryLoader.h
+++ b/projects/rdc/include/rdc_lib/RdcLibraryLoader.h
@@ -36,7 +36,7 @@ class RdcLibraryLoader {
   RdcLibraryLoader();
 
   // throws RdcException if lib not found
-  rdc_status_t load(const char* filename);
+  rdc_status_t load(const char* filename, int dlopen_flags = RTLD_LAZY);
 
   template <typename T>
   rdc_status_t load_symbol(T* func_handler, const char* func_name);

--- a/projects/rdc/rdc_libs/bootstrap/src/RdcLibraryLoader.cc
+++ b/projects/rdc/rdc_libs/bootstrap/src/RdcLibraryLoader.cc
@@ -29,7 +29,7 @@ namespace rdc {
 
 RdcLibraryLoader::RdcLibraryLoader() : libHandler_(nullptr) {}
 
-rdc_status_t RdcLibraryLoader::load(const char* filename) {
+rdc_status_t RdcLibraryLoader::load(const char* filename, int dlopen_flags) {
   if (filename == nullptr) {
     return RDC_ST_FAIL_LOAD_MODULE;
   }
@@ -38,7 +38,7 @@ rdc_status_t RdcLibraryLoader::load(const char* filename) {
   }
 
   std::lock_guard<std::mutex> guard(library_mutex_);
-  libHandler_ = dlopen(filename, RTLD_LAZY);
+  libHandler_ = dlopen(filename, dlopen_flags);
   if (!libHandler_) {
     char* error = dlerror();
     throw RdcException(

--- a/projects/rdc/rdc_libs/rdc/src/RdcRocpLib.cc
+++ b/projects/rdc/rdc_libs/rdc/src/RdcRocpLib.cc
@@ -21,6 +21,8 @@ THE SOFTWARE.
 */
 #include "rdc_lib/impl/RdcRocpLib.h"
 
+#include <dlfcn.h>
+
 #include <cstdint>
 #include <cstdlib>
 #include <cstring>
@@ -45,7 +47,12 @@ RdcRocpLib::RdcRocpLib()
   // must happen before library is loaded
   rdc_unset_hsa_tools_lib();
 
-  rdc_status_t status = lib_loader_.load("librdc_rocp.so");
+  // Load with RTLD_GLOBAL so that rocprofiler_configure (defined in librdc_rocp.so)
+  // is visible globally. This is required for rocprofiler-sdk tool registration:
+  // when hsa_init() is called later, rocprofiler searches for the rocprofiler_configure
+  // symbol in the global namespace. Without RTLD_GLOBAL, the symbol is only visible
+  // within the library and rocprofiler cannot discover the tool.
+  rdc_status_t status = lib_loader_.load("librdc_rocp.so", RTLD_LAZY | RTLD_GLOBAL);
   if (status != RDC_ST_OK) {
     RDC_LOG(RDC_ERROR, "Rocp related function will not work.");
     return;


### PR DESCRIPTION
rocprofiler-sdk discovers tools by searching for rocprofiler_configure in the global symbol namespace during hsa_init(). librdc_rocp.so was loaded with RTLD_LAZY (implicit RTLD_LOCAL), hiding the symbol and silently preventing profiler counter collection in embedded mode.