### PR TITLE
[ROCM-20039] Fix AttributeError for gpureset on VMs

### DIFF
--- a/projects/amdsmi/amdsmi_cli/amdsmi_commands.py
+++ b/projects/amdsmi/amdsmi_cli/amdsmi_commands.py
@@ -9588,6 +9588,9 @@ class AMDSMICommands:
             args.power_cap = power_cap
         if clean_local_data:
             args.clean_local_data = clean_local_data
+        # Normalize gpureset: not available on VMs
+        if not self.helpers.is_baremetal():
+            args.gpureset = False
 
         # Special GTT handling (system-wide, not per-GPU) — handle before device dispatch
         if hasattr(args, "gtt") and args.gtt:


### PR DESCRIPTION
## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

Argument gpureset is not registered by the parser on VMs, so accessing args.gpureset directly raises AttributeError. Normalize it to False when not available.

## JIRA ID

ROCM-20039

## Test Plan

amd-smi reset -l on VM

## Test Result

On VM:
<img width="370" height="71" alt="image" src="https://github.com/user-attachments/assets/6d4048bc-52c9-48f9-b643-a683dfa45d14" />


## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
