### PR TITLE
[rocprofiler-sdk] Improving attachment tests

### DIFF
--- a/projects/rocprofiler-register/source/lib/rocprofiler-register/rocprofiler_register.cpp
+++ b/projects/rocprofiler-register/source/lib/rocprofiler-register/rocprofiler_register.cpp
@@ -564,19 +564,37 @@ rocp_add_registered_library_api_table(const char*                        common_
                              lib_version,
                              api_tables_len);
 
+    constexpr auto rocattach_name = supported_library_trait<ROCP_REG_ROCATTACH>::common_name;
+    const bool     is_rocattach   = (std::string_view{ common_name } == rocattach_name);
+
+    auto _tables = std::vector<void*>{};
+    _tables.reserve(api_tables_len);
+    for(uint64_t i = 0; i < api_tables_len; ++i)
+        _tables.emplace_back(api_tables[i]);
+
+    auto _entry = registered_library_api_table{
+        false, common_name, import_func, lib_version, std::move(_tables), instance_val
+    };
+
+    if(is_rocattach)
+    {
+        // Insert rocattach at index 0 so that rocp_invoke_registrations always propagates
+        // it before any other API table. Shift existing entries right to make room.
+        auto end = registered.begin();
+        while(end != registered.end() && *end)
+            ++end;
+        if(end == registered.end()) return nullptr;
+        for(auto itr = end; itr != registered.begin(); --itr)
+            *itr = std::move(*(itr - 1));
+        registered[0] = std::move(_entry);
+        return &registered[0];
+    }
+
     for(auto& itr : registered)
     {
         if(!itr)
         {
-            auto _tables = std::vector<void*>{};
-            _tables.reserve(api_tables_len);
-            for(uint64_t i = 0; i < api_tables_len; ++i)
-                _tables.emplace_back(api_tables[i]);
-
-            itr = registered_library_api_table{
-                false,       common_name,        import_func,
-                lib_version, std::move(_tables), instance_val
-            };
+            itr = std::move(_entry);
             return &itr;
         }
     }

--- a/projects/rocprofiler-register/source/lib/rocprofiler-register/rocprofiler_register.cpp
+++ b/projects/rocprofiler-register/source/lib/rocprofiler-register/rocprofiler_register.cpp
@@ -580,14 +580,14 @@ rocp_add_registered_library_api_table(const char*                        common_
     {
         // Insert rocattach at index 0 so that rocp_invoke_registrations always propagates
         // it before any other API table. Shift existing entries right to make room.
-        auto end = registered.begin();
+        auto* end = registered.begin();
         while(end != registered.end() && *end)
             ++end;
         if(end == registered.end()) return nullptr;
-        for(auto itr = end; itr != registered.begin(); --itr)
+        for(auto* itr = end; itr != registered.begin(); --itr)
             *itr = std::move(*(itr - 1));
         registered[0] = std::move(_entry);
-        return &registered[0];
+        return registered.data();
     }
 
     for(auto& itr : registered)

--- a/projects/rocprofiler-sdk/source/lib/output/generateRocpd.cpp
+++ b/projects/rocprofiler-sdk/source/lib/output/generateRocpd.cpp
@@ -1110,9 +1110,16 @@ write_rocpd(
                          itr.demangled_kernel_name,
                          itr.truncated_kernel_name);
 
+    // Create a local copy of the rename map to use for this output run instead of using
+    // get_kernel_name(), which may access a modified version of the map
+    auto _rename_strings = std::unordered_map<uint64_t, std::string_view>{};
     for(const auto& itr : tool_metadata.kernel_rename_map.get())
     {
-        add_string_entry(_metadata, itr.first);
+        if(!itr.first.empty())
+        {
+            add_string_entry(_metadata, itr.first);
+            _rename_strings.emplace(itr.second, itr.first);
+        }
     }
 
     for(const auto& itr : tool_metadata.get_code_objects())
@@ -1477,10 +1484,9 @@ write_rocpd(
             // Unconditionally collect kernel rename data if it is available. rocpd needs to be able
             // to use kernel rename option after data has already been collected, so the kernel
             // rename data needs to be stored in generated db.
+            auto _rename_it = _rename_strings.find(corr_id.external.value);
             auto region_name =
-                (corr_id.external.value > 0 && (enable_duplicate_check || kernel_id > 0))
-                    ? tool_metadata.get_kernel_name(kernel_id, true, corr_id.external.value)
-                    : std::string_view{};
+                (_rename_it != _rename_strings.end()) ? _rename_it->second : std::string_view{};
 
             auto agent_node_id = tool_metadata.get_agent(info.agent_id)->node_id;
 

--- a/projects/rocprofiler-sdk/source/lib/output/generateRocpd.cpp
+++ b/projects/rocprofiler-sdk/source/lib/output/generateRocpd.cpp
@@ -1377,6 +1377,27 @@ write_rocpd(
                     insert_value("extdata", json_data),
                 });
         }
+
+        // Insert id=0 placeholders for kernel dispatches whose code object was not captured
+        // (e.g., in attach mode when the kernel was loaded before the attach window).
+        // These ensure FK constraints are satisfied for kernel_id=0 dispatch records.
+        get_insert_statement(db,
+                             "rocpd_info_code_object{{uuid}}",
+                             {
+                                 insert_value("id", uint64_t{0}),
+                                 insert_value("nid", node_id),
+                                 insert_value("pid", this_pid),
+                             });
+        get_insert_statement(db,
+                             "rocpd_info_kernel_symbol{{uuid}}",
+                             {
+                                 insert_value("id", uint64_t{0}),
+                                 insert_value("nid", node_id),
+                                 insert_value("pid", this_pid),
+                                 insert_value("code_object_id", uint64_t{0}),
+                                 insert_value("kernel_name", std::string{"<unknown>"}),
+                                 insert_value("display_name", std::string{"<unknown>"}),
+                             });
     };
 
     auto insert_pmc_data = [&db, &tool_metadata, node_id, this_pid]() {
@@ -1507,7 +1528,13 @@ write_rocpd(
                     insert_value("grid_size_x", grid.x),
                     insert_value("grid_size_y", grid.y),
                     insert_value("grid_size_z", grid.z),
-                    insert_value("region_name_id", string_entries.at(region_name)),
+                    insert_value("region_name_id",
+                                 [&]() {
+                                     auto it = string_entries.find(region_name);
+                                     if(it == string_entries.end())
+                                         return string_entries.at(region_name);  // triggers throw
+                                     return it->second;
+                                 }()),
                     insert_value("event_id", evt_id),
                 });
         };

--- a/projects/rocprofiler-sdk/source/lib/output/generateRocpd.cpp
+++ b/projects/rocprofiler-sdk/source/lib/output/generateRocpd.cpp
@@ -1528,13 +1528,7 @@ write_rocpd(
                     insert_value("grid_size_x", grid.x),
                     insert_value("grid_size_y", grid.y),
                     insert_value("grid_size_z", grid.z),
-                    insert_value("region_name_id",
-                                 [&]() {
-                                     auto it = string_entries.find(region_name);
-                                     if(it == string_entries.end())
-                                         return string_entries.at(region_name);  // triggers throw
-                                     return it->second;
-                                 }()),
+                    insert_value("region_name_id", string_entries.at(region_name)),
                     insert_value("event_id", evt_id),
                 });
         };

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-attach/code_object_registration.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-attach/code_object_registration.cpp
@@ -36,13 +36,20 @@ using hsa_executable_freeze_t  = decltype(CoreApiTable::hsa_executable_freeze_fn
 using hsa_executable_destroy_t = decltype(CoreApiTable::hsa_executable_destroy_fn);
 using code_object_collection_t = std::vector<hsa_executable_t>;
 
+struct code_object_cb_entry_t
+{
+    rocprofiler_attach_code_object_cb_t cb   = nullptr;
+    void*                               data = nullptr;
+};
+
 struct code_object_registration_t
 {
-    // gates access to code_objects collection
-    std::mutex               code_objects_mutex;
-    code_object_collection_t code_objects;
-    hsa_executable_freeze_t  hsa_executable_freeze_fn  = nullptr;
-    hsa_executable_destroy_t hsa_executable_destroy_fn = nullptr;
+    // gates access to both code_objects and cb_list
+    std::mutex                          mutex;
+    code_object_collection_t            code_objects;
+    std::vector<code_object_cb_entry_t> cb_list;
+    hsa_executable_freeze_t             hsa_executable_freeze_fn  = nullptr;
+    hsa_executable_destroy_t            hsa_executable_destroy_fn = nullptr;
 };
 
 code_object_registration_t*
@@ -57,19 +64,22 @@ hsa_status_t
 executable_freeze(hsa_executable_t executable, const char* options)
 {
     auto* registration = CHECK_NOTNULL(get_code_object_registration());
-    auto  status       = registration->hsa_executable_freeze_fn(executable, options);
+    std::lock_guard lg(registration->mutex);
+    auto            status = registration->hsa_executable_freeze_fn(executable, options);
 
-    if(status != HSA_STATUS_SUCCESS) return status;
+    if(status != HSA_STATUS_SUCCESS)
+    {
+        return status;
+    }
 
     ROCP_TRACE << "adding code_object " << executable.handle;
+    registration->code_objects.emplace_back(executable);
+    for(auto& entry : registration->cb_list)
     {
-        std::lock_guard lg(registration->code_objects_mutex);
-        registration->code_objects.emplace_back(executable);
-    }
-    auto* attach_table = rocprofiler::attach::get_dispatch_table();
-    if(attach_table->rocprofiler_attach_notify_new_code_object)
-    {
-        attach_table->rocprofiler_attach_notify_new_code_object(executable, nullptr);
+        if(entry.cb)
+        {
+            entry.cb(executable, ROCPROFILER_ATTACH_CODE_OBJECT_CREATED, entry.data);
+        }
     }
     return HSA_STATUS_SUCCESS;
 }
@@ -79,8 +89,11 @@ executable_destroy(hsa_executable_t executable)
 {
     auto* registration = CHECK_NOTNULL(get_code_object_registration());
     ROCP_TRACE << "removing code_object " << executable.handle;
+
+    auto snapshot = std::vector<code_object_cb_entry_t>{};
     {
-        std::lock_guard lg(registration->code_objects_mutex);
+        std::lock_guard lg(registration->mutex);
+        snapshot  = registration->cb_list;
         auto pred = [&](const hsa_executable_t& a) { return a.handle == executable.handle; };
         auto itr  = std::find_if(
             registration->code_objects.begin(), registration->code_objects.end(), pred);
@@ -88,7 +101,17 @@ executable_destroy(hsa_executable_t executable)
         {
             ROCP_WARNING << "remove code_object could not find " << executable.handle;
         }
-        registration->code_objects.erase(itr);
+        else
+        {
+            registration->code_objects.erase(itr);
+        }
+    }
+    for(auto& entry : snapshot)
+    {
+        if(entry.cb)
+        {
+            entry.cb(executable, ROCPROFILER_ATTACH_CODE_OBJECT_DESTROYED, entry.data);
+        }
     }
 
     return registration->hsa_executable_destroy_fn(executable);
@@ -99,11 +122,45 @@ iterate_all_code_objects(rocprof_attach_code_object_iterator_t func, void* data)
 {
     auto* registration = CHECK_NOTNULL(get_code_object_registration());
 
+    std::lock_guard lg(registration->mutex);
     for(const auto& code_object : registration->code_objects)
     {
         func(code_object, data);
     }
 
+    return ROCPROFILER_STATUS_SUCCESS;
+}
+
+int
+add_code_object_cb(rocprofiler_attach_code_object_cb_t cb, void* data)
+{
+    if(!cb)
+    {
+        return ROCPROFILER_STATUS_ERROR_INVALID_ARGUMENT;
+    }
+    auto* registration = CHECK_NOTNULL(get_code_object_registration());
+    auto  lg           = std::lock_guard{registration->mutex};
+    registration->cb_list.push_back({cb, data});
+    for(const auto& code_object : registration->code_objects)
+    {
+        cb(code_object, ROCPROFILER_ATTACH_CODE_OBJECT_CREATED, data);
+    }
+    return ROCPROFILER_STATUS_SUCCESS;
+}
+
+int
+remove_code_object_cb(rocprofiler_attach_code_object_cb_t cb)
+{
+    if(!cb)
+    {
+        return ROCPROFILER_STATUS_ERROR_INVALID_ARGUMENT;
+    }
+    auto* registration = CHECK_NOTNULL(get_code_object_registration());
+    auto  lg           = std::lock_guard{registration->mutex};
+    auto  pred         = [cb](const code_object_cb_entry_t& e) { return e.cb == cb; };
+    registration->cb_list.erase(
+        std::remove_if(registration->cb_list.begin(), registration->cb_list.end(), pred),
+        registration->cb_list.end());
     return ROCPROFILER_STATUS_SUCCESS;
 }
 
@@ -138,6 +195,18 @@ int
 rocprofiler_attach_iterate_all_code_objects(rocprof_attach_code_object_iterator_t func, void* data)
 {
     return iterate_all_code_objects(func, data);
+}
+
+int
+rocprofiler_attach_add_code_object_cb(rocprofiler_attach_code_object_cb_t cb, void* data)
+{
+    return add_code_object_cb(cb, data);
+}
+
+int
+rocprofiler_attach_remove_code_object_cb(rocprofiler_attach_code_object_cb_t cb)
+{
+    return remove_code_object_cb(cb);
 }
 
 ROCPROFILER_EXTERN_C_FINI

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-attach/code_object_registration.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-attach/code_object_registration.cpp
@@ -63,7 +63,7 @@ get_code_object_registration()
 hsa_status_t
 executable_freeze(hsa_executable_t executable, const char* options)
 {
-    auto* registration = CHECK_NOTNULL(get_code_object_registration());
+    auto*           registration = CHECK_NOTNULL(get_code_object_registration());
     std::lock_guard lg(registration->mutex);
     auto            status = registration->hsa_executable_freeze_fn(executable, options);
 

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-attach/code_object_registration.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-attach/code_object_registration.cpp
@@ -63,9 +63,8 @@ get_code_object_registration()
 hsa_status_t
 executable_freeze(hsa_executable_t executable, const char* options)
 {
-    auto*           registration = CHECK_NOTNULL(get_code_object_registration());
-    std::lock_guard lg(registration->mutex);
-    auto            status = registration->hsa_executable_freeze_fn(executable, options);
+    auto* registration = CHECK_NOTNULL(get_code_object_registration());
+    auto  status       = registration->hsa_executable_freeze_fn(executable, options);
 
     if(status != HSA_STATUS_SUCCESS)
     {
@@ -73,8 +72,13 @@ executable_freeze(hsa_executable_t executable, const char* options)
     }
 
     ROCP_TRACE << "adding code_object " << executable.handle;
-    registration->code_objects.emplace_back(executable);
-    for(auto& entry : registration->cb_list)
+    auto snapshot = std::vector<code_object_cb_entry_t>{};
+    {
+        std::lock_guard lg(registration->mutex);
+        registration->code_objects.emplace_back(executable);
+        snapshot = std::vector<code_object_cb_entry_t>{registration->cb_list};
+    }
+    for(auto& entry : snapshot)
     {
         if(entry.cb)
         {
@@ -139,9 +143,13 @@ add_code_object_cb(rocprofiler_attach_code_object_cb_t cb, void* data)
         return ROCPROFILER_STATUS_ERROR_INVALID_ARGUMENT;
     }
     auto* registration = CHECK_NOTNULL(get_code_object_registration());
-    auto  lg           = std::lock_guard{registration->mutex};
-    registration->cb_list.push_back({cb, data});
-    for(const auto& code_object : registration->code_objects)
+    auto  snapshot     = code_object_collection_t{};
+    {
+        auto lg = std::lock_guard{registration->mutex};
+        registration->cb_list.push_back({cb, data});
+        snapshot = code_object_collection_t{registration->code_objects};
+    }
+    for(const auto& code_object : snapshot)
     {
         cb(code_object, ROCPROFILER_ATTACH_CODE_OBJECT_CREATED, data);
     }

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-attach/code_object_registration.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-attach/code_object_registration.cpp
@@ -93,7 +93,7 @@ executable_destroy(hsa_executable_t executable)
     auto snapshot = std::vector<code_object_cb_entry_t>{};
     {
         std::lock_guard lg(registration->mutex);
-        snapshot  = registration->cb_list;
+        snapshot  = std::vector<code_object_cb_entry_t>{registration->cb_list};
         auto pred = [&](const hsa_executable_t& a) { return a.handle == executable.handle; };
         auto itr  = std::find_if(
             registration->code_objects.begin(), registration->code_objects.end(), pred);

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-attach/code_object_registration.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-attach/code_object_registration.cpp
@@ -97,7 +97,6 @@ executable_destroy(hsa_executable_t executable)
     auto snapshot = std::vector<code_object_cb_entry_t>{};
     {
         std::lock_guard lg(registration->mutex);
-        snapshot  = std::vector<code_object_cb_entry_t>{registration->cb_list};
         auto pred = [&](const hsa_executable_t& a) { return a.handle == executable.handle; };
         auto itr  = std::find_if(
             registration->code_objects.begin(), registration->code_objects.end(), pred);
@@ -107,9 +106,14 @@ executable_destroy(hsa_executable_t executable)
         }
         else
         {
+            snapshot = std::vector<code_object_cb_entry_t>{registration->cb_list};
             registration->code_objects.erase(itr);
         }
     }
+
+    // Fire callbacks after erasing from the collection but before calling the real destroy.
+    // Erasing first prevents double-destroy races. Calling the real destroy last ensures the
+    // handle remains valid during callbacks, and that any handle still in code_objects is live.
     for(auto& entry : snapshot)
     {
         if(entry.cb)
@@ -169,6 +173,7 @@ remove_code_object_cb(rocprofiler_attach_code_object_cb_t cb)
     registration->cb_list.erase(
         std::remove_if(registration->cb_list.begin(), registration->cb_list.end(), pred),
         registration->cb_list.end());
+    // Returns SUCCESS whether or not cb was found, to simplify cleanup paths.
     return ROCPROFILER_STATUS_SUCCESS;
 }
 

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-attach/code_object_registration.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-attach/code_object_registration.cpp
@@ -130,8 +130,12 @@ iterate_all_code_objects(rocprof_attach_code_object_iterator_t func, void* data)
 {
     auto* registration = CHECK_NOTNULL(get_code_object_registration());
 
-    std::lock_guard lg(registration->mutex);
-    for(const auto& code_object : registration->code_objects)
+    auto snapshot = code_object_collection_t{};
+    {
+        std::lock_guard lg(registration->mutex);
+        snapshot = code_object_collection_t{registration->code_objects};
+    }
+    for(const auto& code_object : snapshot)
     {
         func(code_object, data);
     }

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-attach/code_object_registration.h
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-attach/code_object_registration.h
@@ -30,10 +30,26 @@
 
 ROCPROFILER_EXTERN_C_INIT
 
+typedef enum
+{
+    ROCPROFILER_ATTACH_CODE_OBJECT_CREATED,
+    ROCPROFILER_ATTACH_CODE_OBJECT_DESTROYED
+} rocprofiler_attach_code_object_phase_t;
+
 typedef void (*rocprof_attach_code_object_iterator_t)(hsa_executable_t, void*);
+typedef void (*rocprofiler_attach_code_object_cb_t)(hsa_executable_t,
+                                                    rocprofiler_attach_code_object_phase_t,
+                                                    void*);
 
 int
 rocprofiler_attach_iterate_all_code_objects(rocprof_attach_code_object_iterator_t func,
                                             void* data) ROCPROFILER_API;
+
+int
+rocprofiler_attach_add_code_object_cb(rocprofiler_attach_code_object_cb_t cb,
+                                      void*                               data) ROCPROFILER_API;
+
+int
+rocprofiler_attach_remove_code_object_cb(rocprofiler_attach_code_object_cb_t cb) ROCPROFILER_API;
 
 ROCPROFILER_EXTERN_C_FINI

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-attach/queue_registration.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-attach/queue_registration.cpp
@@ -167,15 +167,16 @@ create_queue(hsa_agent_t        agent,
     queue_entry_t entry{};
     entry.agent = agent;
 
-    auto snapshot = std::vector<queue_cb_entry_t>{};
+    queue_entry_t* write_interceptor_data = nullptr;
+    auto           snapshot               = std::vector<queue_cb_entry_t>{};
     {
         std::lock_guard lg(registration->mutex);
         ROCP_FATAL_IF(registration->queues.count(new_queue) > 0)
             << "Queue registration already contains an entry for new queue handle " << new_queue;
         registration->queues.insert({new_queue, entry});
-        snapshot = std::vector<queue_cb_entry_t>{registration->cb_list};
+        write_interceptor_data = &(registration->queues.at(new_queue));
+        snapshot               = std::vector<queue_cb_entry_t>{registration->cb_list};
     }
-    auto* write_interceptor_data = &(registration->queues.at(new_queue));
 
     // Pass queue_entry_t* as user data, used to directly call the user's write interceptor
     ROCP_ATTACH_HSA_TABLE_CALL(FATAL,
@@ -204,18 +205,14 @@ destroy_queue(hsa_queue_t* hsa_queue)
     auto* registration = get_queue_registration();
     if(registration)
     {
-        hsa_agent_t agent{};
-        bool        found    = false;
-        auto        snapshot = std::vector<queue_cb_entry_t>{};
+        auto node     = queue_collection_t::node_type{};
+        auto snapshot = std::vector<queue_cb_entry_t>{};
         {
             std::lock_guard lg(registration->mutex);
-            auto            it = registration->queues.find(hsa_queue);
-            if(it != registration->queues.end())
+            node = registration->queues.extract(hsa_queue);
+            if(!node.empty())
             {
-                agent    = it->second.agent;
-                found    = true;
                 snapshot = std::vector<queue_cb_entry_t>{registration->cb_list};
-                registration->queues.erase(it);
             }
             else
             {
@@ -223,17 +220,21 @@ destroy_queue(hsa_queue_t* hsa_queue)
                              << hsa_queue;
             }
         }
-        if(found)
+        if(!node.empty())
         {
             for(auto& cb_entry : snapshot)
             {
                 if(cb_entry.cb)
                 {
-                    cb_entry.cb(
-                        hsa_queue, agent, ROCPROFILER_ATTACH_QUEUE_DESTROYED, cb_entry.data);
+                    cb_entry.cb(hsa_queue,
+                                node.mapped().agent,
+                                ROCPROFILER_ATTACH_QUEUE_DESTROYED,
+                                cb_entry.data);
                 }
             }
         }
+        // node goes out of scope here: queue_entry_t is destroyed after callbacks (and
+        // any sync() called within them) have completed
     }
     return HSA_STATUS_SUCCESS;
 }
@@ -305,6 +306,7 @@ remove_queue_cb(rocprofiler_attach_queue_cb_t cb)
     registration->cb_list.erase(
         std::remove_if(registration->cb_list.begin(), registration->cb_list.end(), pred),
         registration->cb_list.end());
+    // Returns SUCCESS whether or not cb was found, to simplify cleanup paths.
     return ROCPROFILER_STATUS_SUCCESS;
 }
 

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-attach/queue_registration.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-attach/queue_registration.cpp
@@ -165,7 +165,7 @@ create_queue(hsa_agent_t        agent,
         ROCP_FATAL_IF(registration->queues.count(new_queue) > 0)
             << "Queue registration already contains an entry for new queue handle " << new_queue;
         registration->queues.insert({new_queue, entry});
-        snapshot = registration->cb_list;
+        snapshot = std::vector<queue_cb_entry_t>{registration->cb_list};
     }
     auto* write_interceptor_data = &(registration->queues.at(new_queue));
 
@@ -206,7 +206,7 @@ destroy_queue(hsa_queue_t* hsa_queue)
             {
                 agent    = it->second.agent;
                 found    = true;
-                snapshot = registration->cb_list;
+                snapshot = std::vector<queue_cb_entry_t>{registration->cb_list};
                 registration->queues.erase(it);
             }
             else

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-attach/queue_registration.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-attach/queue_registration.cpp
@@ -105,12 +105,20 @@ write_interceptor(const void*                             packets,
                   hsa_amd_queue_intercept_packet_writer_t writer)
 {
     ROCP_FATAL_IF(data == nullptr) << "WriteInterceptor was not passed a valid pointer";
-    const auto* entry = static_cast<const queue_entry_t*>(data);
+    auto*       registration = CHECK_NOTNULL(get_queue_registration());
+    const auto* entry        = static_cast<const queue_entry_t*>(data);
 
-    if(entry->user_write_interceptor_func)
+    write_interceptor_t func  = nullptr;
+    void*               udata = nullptr;
     {
-        entry->user_write_interceptor_func(
-            packets, pkt_count, unused, entry->user_write_interceptor_data, writer);
+        std::lock_guard lg(registration->mutex);
+        func  = entry->user_write_interceptor_func;
+        udata = entry->user_write_interceptor_data;
+    }
+
+    if(func)
+    {
+        func(packets, pkt_count, unused, udata, writer);
     }
     else
     {
@@ -248,6 +256,7 @@ int
 set_write_interceptor(hsa_queue_t* queue, write_interceptor_t func, void* data)
 {
     auto* registration = CHECK_NOTNULL(get_queue_registration());
+    auto  lg           = std::lock_guard{registration->mutex};
     auto  qr_pair      = registration->queues.find(queue);
     if(qr_pair == registration->queues.end())
     {
@@ -267,11 +276,18 @@ add_queue_cb(rocprofiler_attach_queue_cb_t cb, void* data)
         return ROCPROFILER_STATUS_ERROR_INVALID_ARGUMENT;
     }
     auto* registration = CHECK_NOTNULL(get_queue_registration());
-    auto  lg           = std::lock_guard{registration->mutex};
-    registration->cb_list.push_back({cb, data});
-    for(const auto& qr_pair : registration->queues)
+    auto  snapshot     = std::vector<std::pair<hsa_queue_t*, hsa_agent_t>>{};
     {
-        cb(qr_pair.first, qr_pair.second.agent, ROCPROFILER_ATTACH_QUEUE_CREATED, data);
+        auto lg = std::lock_guard{registration->mutex};
+        registration->cb_list.push_back({cb, data});
+        for(const auto& qr_pair : registration->queues)
+        {
+            snapshot.emplace_back(qr_pair.first, qr_pair.second.agent);
+        }
+    }
+    for(const auto& [queue, agent] : snapshot)
+    {
+        cb(queue, agent, ROCPROFILER_ATTACH_QUEUE_CREATED, data);
     }
     return ROCPROFILER_STATUS_SUCCESS;
 }

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-attach/queue_registration.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-attach/queue_registration.cpp
@@ -39,13 +39,20 @@ struct queue_entry_t
     void*               user_write_interceptor_data = nullptr;
 };
 
+struct queue_cb_entry_t
+{
+    rocprofiler_attach_queue_cb_t cb   = nullptr;
+    void*                         data = nullptr;
+};
+
 using queue_collection_t = std::unordered_map<hsa_queue_t*, queue_entry_t>;
 
 struct queue_registration_t
 {
-    // guards access to both queues collection
-    std::mutex         queues_mutex;
-    queue_collection_t queues;
+    // guards access to both queues and cb_list
+    std::mutex                    mutex;
+    queue_collection_t            queues;
+    std::vector<queue_cb_entry_t> cb_list;
 
     decltype(AmdExtTable::hsa_amd_queue_intercept_create_fn) hsa_amd_queue_intercept_create_fn =
         nullptr;
@@ -152,11 +159,13 @@ create_queue(hsa_agent_t        agent,
     queue_entry_t entry{};
     entry.agent = agent;
 
+    auto snapshot = std::vector<queue_cb_entry_t>{};
     {
-        std::lock_guard lg(registration->queues_mutex);
+        std::lock_guard lg(registration->mutex);
         ROCP_FATAL_IF(registration->queues.count(new_queue) > 0)
             << "Queue registration already contains an entry for new queue handle " << new_queue;
         registration->queues.insert({new_queue, entry});
+        snapshot = registration->cb_list;
     }
     auto* write_interceptor_data = &(registration->queues.at(new_queue));
 
@@ -170,10 +179,12 @@ create_queue(hsa_agent_t        agent,
 
     ROCP_INFO << "created attach queue for HSA agent handle " << agent.handle;
 
-    auto* attach_table = rocprofiler::attach::get_dispatch_table();
-    if(attach_table->rocprofiler_attach_notify_new_queue)
+    for(auto& cb_entry : snapshot)
     {
-        attach_table->rocprofiler_attach_notify_new_queue(new_queue, agent, nullptr);
+        if(cb_entry.cb)
+        {
+            cb_entry.cb(new_queue, agent, ROCPROFILER_ATTACH_QUEUE_CREATED, cb_entry.data);
+        }
     }
 
     return HSA_STATUS_SUCCESS;
@@ -185,10 +196,36 @@ destroy_queue(hsa_queue_t* hsa_queue)
     auto* registration = get_queue_registration();
     if(registration)
     {
-        std::lock_guard lg(registration->queues_mutex);
-        size_t          erase_count = registration->queues.erase(hsa_queue);
-        ROCP_WARNING_IF(erase_count == 0)
-            << "Destroy queue was called for a handle that was not in queues: " << hsa_queue;
+        hsa_agent_t agent{};
+        bool        found    = false;
+        auto        snapshot = std::vector<queue_cb_entry_t>{};
+        {
+            std::lock_guard lg(registration->mutex);
+            auto            it = registration->queues.find(hsa_queue);
+            if(it != registration->queues.end())
+            {
+                agent    = it->second.agent;
+                found    = true;
+                snapshot = registration->cb_list;
+                registration->queues.erase(it);
+            }
+            else
+            {
+                ROCP_WARNING << "Destroy queue was called for a handle that was not in queues: "
+                             << hsa_queue;
+            }
+        }
+        if(found)
+        {
+            for(auto& cb_entry : snapshot)
+            {
+                if(cb_entry.cb)
+                {
+                    cb_entry.cb(
+                        hsa_queue, agent, ROCPROFILER_ATTACH_QUEUE_DESTROYED, cb_entry.data);
+                }
+            }
+        }
     }
     return HSA_STATUS_SUCCESS;
 }
@@ -198,7 +235,7 @@ iterate_all_queues(rocprof_attach_queue_iterator_t func, void* user_data)
 {
     auto* registration = CHECK_NOTNULL(get_queue_registration());
 
-    std::lock_guard lg(registration->queues_mutex);
+    std::lock_guard lg(registration->mutex);
     for(const auto& qr_pair : registration->queues)
     {
         func(qr_pair.first, qr_pair.second.agent, user_data);
@@ -220,6 +257,39 @@ set_write_interceptor(hsa_queue_t* queue, write_interceptor_t func, void* data)
     qr_pair->second.user_write_interceptor_func = func;
     qr_pair->second.user_write_interceptor_data = data;
     return 0;
+}
+
+int
+add_queue_cb(rocprofiler_attach_queue_cb_t cb, void* data)
+{
+    if(!cb)
+    {
+        return ROCPROFILER_STATUS_ERROR_INVALID_ARGUMENT;
+    }
+    auto* registration = CHECK_NOTNULL(get_queue_registration());
+    auto  lg           = std::lock_guard{registration->mutex};
+    registration->cb_list.push_back({cb, data});
+    for(const auto& qr_pair : registration->queues)
+    {
+        cb(qr_pair.first, qr_pair.second.agent, ROCPROFILER_ATTACH_QUEUE_CREATED, data);
+    }
+    return ROCPROFILER_STATUS_SUCCESS;
+}
+
+int
+remove_queue_cb(rocprofiler_attach_queue_cb_t cb)
+{
+    if(!cb)
+    {
+        return ROCPROFILER_STATUS_ERROR_INVALID_ARGUMENT;
+    }
+    auto* registration = CHECK_NOTNULL(get_queue_registration());
+    auto  lg           = std::lock_guard{registration->mutex};
+    auto  pred         = [cb](const queue_cb_entry_t& e) { return e.cb == cb; };
+    registration->cb_list.erase(
+        std::remove_if(registration->cb_list.begin(), registration->cb_list.end(), pred),
+        registration->cb_list.end());
+    return ROCPROFILER_STATUS_SUCCESS;
 }
 
 }  // namespace
@@ -263,6 +333,18 @@ int
 rocprofiler_attach_set_write_interceptor(hsa_queue_t* queue, write_interceptor_t func, void* data)
 {
     return set_write_interceptor(queue, func, data);
+}
+
+int
+rocprofiler_attach_add_queue_cb(rocprofiler_attach_queue_cb_t cb, void* data)
+{
+    return add_queue_cb(cb, data);
+}
+
+int
+rocprofiler_attach_remove_queue_cb(rocprofiler_attach_queue_cb_t cb)
+{
+    return remove_queue_cb(cb);
 }
 
 ROCPROFILER_EXTERN_C_FINI

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-attach/queue_registration.h
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-attach/queue_registration.h
@@ -39,7 +39,17 @@ typedef void (*write_interceptor_t)(const void*,
                                     void*,
                                     hsa_amd_queue_intercept_packet_writer_t);
 
+typedef enum
+{
+    ROCPROFILER_ATTACH_QUEUE_CREATED,
+    ROCPROFILER_ATTACH_QUEUE_DESTROYED
+} rocprofiler_attach_queue_phase_t;
+
 typedef void (*rocprof_attach_queue_iterator_t)(hsa_queue_t*, hsa_agent_t, void*);
+typedef void (*rocprofiler_attach_queue_cb_t)(hsa_queue_t*,
+                                              hsa_agent_t,
+                                              rocprofiler_attach_queue_phase_t,
+                                              void*);
 
 int
 rocprofiler_attach_iterate_all_queues(rocprof_attach_queue_iterator_t func,
@@ -49,5 +59,11 @@ int
 rocprofiler_attach_set_write_interceptor(hsa_queue_t*        queue,
                                          write_interceptor_t func,
                                          void*               data) ROCPROFILER_API;
+
+int
+rocprofiler_attach_add_queue_cb(rocprofiler_attach_queue_cb_t cb, void* data) ROCPROFILER_API;
+
+int
+rocprofiler_attach_remove_queue_cb(rocprofiler_attach_queue_cb_t cb) ROCPROFILER_API;
 
 ROCPROFILER_EXTERN_C_FINI

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-attach/table.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-attach/table.cpp
@@ -29,7 +29,7 @@ namespace rocprofiler
 {
 namespace attach
 {
-ROCP_SDK_ENFORCE_ABI_VERSIONING(::RocAttachDispatchTable, ROCPROFILER_ATTACH_DISPATCH_TABLE_LEGNTH);
+ROCP_SDK_ENFORCE_ABI_VERSIONING(::RocAttachDispatchTable, ROCPROFILER_ATTACH_DISPATCH_TABLE_LENGTH);
 
 RocAttachDispatchTable*
 get_dispatch_table()
@@ -50,8 +50,10 @@ dispatch_table_init()
     table->rocprofiler_attach_set_write_interceptor = &rocprofiler_attach_set_write_interceptor;
     table->rocprofiler_attach_iterate_all_code_objects =
         &rocprofiler_attach_iterate_all_code_objects;
-    table->rocprofiler_attach_notify_new_queue       = nullptr;
-    table->rocprofiler_attach_notify_new_code_object = nullptr;
+    table->rocprofiler_attach_add_code_object_cb    = &rocprofiler_attach_add_code_object_cb;
+    table->rocprofiler_attach_remove_code_object_cb = &rocprofiler_attach_remove_code_object_cb;
+    table->rocprofiler_attach_add_queue_cb          = &rocprofiler_attach_add_queue_cb;
+    table->rocprofiler_attach_remove_queue_cb       = &rocprofiler_attach_remove_queue_cb;
 }
 }  // namespace attach
 }  // namespace rocprofiler

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-attach/table.h
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-attach/table.h
@@ -26,7 +26,7 @@
 #include "code_object_registration.h"
 #include "queue_registration.h"
 
-#define ROCATTACH_API_TABLE_VERSION_MAJOR 0
+#define ROCATTACH_API_TABLE_VERSION_MAJOR 1
 
 ROCPROFILER_EXTERN_C_INIT
 
@@ -35,8 +35,10 @@ typedef int (*rocprofiler_attach_iterate_all_queues_t)(rocprof_attach_queue_iter
 typedef int (*rocprofiler_attach_set_write_interceptor_t)(hsa_queue_t*, write_interceptor_t, void*);
 typedef int (*rocprofiler_attach_iterate_all_code_objects_t)(rocprof_attach_code_object_iterator_t,
                                                              void*);
-typedef void (*rocprofiler_attach_notify_new_queue_t)(hsa_queue_t*, hsa_agent_t, void*);
-typedef void (*rocprofiler_attach_notify_new_code_object_t)(hsa_executable_t, void*);
+typedef int (*rocprofiler_attach_add_code_object_cb_t)(rocprofiler_attach_code_object_cb_t, void*);
+typedef int (*rocprofiler_attach_remove_code_object_cb_t)(rocprofiler_attach_code_object_cb_t);
+typedef int (*rocprofiler_attach_add_queue_cb_t)(rocprofiler_attach_queue_cb_t, void*);
+typedef int (*rocprofiler_attach_remove_queue_cb_t)(rocprofiler_attach_queue_cb_t);
 
 struct RocAttachDispatchTable
 {
@@ -45,8 +47,10 @@ struct RocAttachDispatchTable
     rocprofiler_attach_iterate_all_queues_t       rocprofiler_attach_iterate_all_queues;
     rocprofiler_attach_set_write_interceptor_t    rocprofiler_attach_set_write_interceptor;
     rocprofiler_attach_iterate_all_code_objects_t rocprofiler_attach_iterate_all_code_objects;
-    rocprofiler_attach_notify_new_queue_t         rocprofiler_attach_notify_new_queue;
-    rocprofiler_attach_notify_new_code_object_t   rocprofiler_attach_notify_new_code_object;
+    rocprofiler_attach_add_code_object_cb_t       rocprofiler_attach_add_code_object_cb;
+    rocprofiler_attach_remove_code_object_cb_t    rocprofiler_attach_remove_code_object_cb;
+    rocprofiler_attach_add_queue_cb_t             rocprofiler_attach_add_queue_cb;
+    rocprofiler_attach_remove_queue_cb_t          rocprofiler_attach_remove_queue_cb;
 };
 
 ROCPROFILER_EXTERN_C_FINI

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-attach/table.hpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-attach/table.hpp
@@ -26,7 +26,7 @@ namespace rocprofiler
 {
 namespace attach
 {
-constexpr size_t ROCPROFILER_ATTACH_DISPATCH_TABLE_LEGNTH = 6;
+constexpr size_t ROCPROFILER_ATTACH_DISPATCH_TABLE_LENGTH = 8;
 
 RocAttachDispatchTable*
 get_dispatch_table();

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-tool/tool.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-tool/tool.cpp
@@ -363,13 +363,6 @@ get_client_ctx()
     return context_id;
 }
 
-auto&
-get_kernel_rename_ctx()
-{
-    static rocprofiler_context_id_t context_id{0};
-    return context_id;
-}
-
 void
 set_contexts_active(const context_id_set_t& ctxs, const bool start)
 {
@@ -2754,8 +2747,8 @@ tool_init(rocprofiler_client_finalize_t fini_func, void* tool_data)
         start_context(counter_collection_ctx, "SPM counter collection");
     }
 
-    auto& rename_ctx            = get_kernel_rename_ctx();
-    auto  marker_core_api_kinds = std::array<rocprofiler_tracing_operation_t, 2>{
+    auto rename_ctx            = rocprofiler_context_id_t{0};
+    auto marker_core_api_kinds = std::array<rocprofiler_tracing_operation_t, 2>{
         ROCPROFILER_MARKER_CORE_RANGE_API_ID_roctxMarkA,
         ROCPROFILER_MARKER_CORE_RANGE_API_ID_roctxThreadRangeA,
     };
@@ -3371,11 +3364,7 @@ tool_detach(void* /*tool_data*/)
 
     // Flush all buffers, stop context to ensure in-flight GPU operations complete,
     // then flush again to capture any final events (same pattern as tool_fini).
-    // The kernel rename context must also be stopped to prevent concurrent
-    // kernel_rename_callback calls from adding new strings to kernel_rename_map
-    // while generate_output builds the rocpd string table snapshot.
     flush();
-    rocprofiler_stop_context(get_kernel_rename_ctx());
     rocprofiler_stop_context(get_client_ctx());
     flush();
 

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-tool/tool.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-tool/tool.cpp
@@ -3375,8 +3375,8 @@ tool_detach(void* /*tool_data*/)
     // kernel_rename_callback calls from adding new strings to kernel_rename_map
     // while generate_output builds the rocpd string table snapshot.
     flush();
-    rocprofiler_stop_context(get_client_ctx());
     rocprofiler_stop_context(get_kernel_rename_ctx());
+    rocprofiler_stop_context(get_client_ctx());
     flush();
 
     // Capture the fallback end timestamp after shutdown flushes complete so it

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-tool/tool.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-tool/tool.cpp
@@ -363,6 +363,13 @@ get_client_ctx()
     return context_id;
 }
 
+auto&
+get_kernel_rename_ctx()
+{
+    static rocprofiler_context_id_t context_id{0};
+    return context_id;
+}
+
 void
 set_contexts_active(const context_id_set_t& ctxs, const bool start)
 {
@@ -2747,8 +2754,8 @@ tool_init(rocprofiler_client_finalize_t fini_func, void* tool_data)
         start_context(counter_collection_ctx, "SPM counter collection");
     }
 
-    auto rename_ctx            = rocprofiler_context_id_t{0};
-    auto marker_core_api_kinds = std::array<rocprofiler_tracing_operation_t, 2>{
+    auto& rename_ctx            = get_kernel_rename_ctx();
+    auto  marker_core_api_kinds = std::array<rocprofiler_tracing_operation_t, 2>{
         ROCPROFILER_MARKER_CORE_RANGE_API_ID_roctxMarkA,
         ROCPROFILER_MARKER_CORE_RANGE_API_ID_roctxThreadRangeA,
     };
@@ -3363,9 +3370,13 @@ tool_detach(void* /*tool_data*/)
     auto _detach_timer = common::simple_timer{"[rocprofv3] tool detachment"};
 
     // Flush all buffers, stop context to ensure in-flight GPU operations complete,
-    // then flush again to capture any final events (same pattern as tool_fini)
+    // then flush again to capture any final events (same pattern as tool_fini).
+    // The kernel rename context must also be stopped to prevent concurrent
+    // kernel_rename_callback calls from adding new strings to kernel_rename_map
+    // while generate_output builds the rocpd string table snapshot.
     flush();
     rocprofiler_stop_context(get_client_ctx());
+    rocprofiler_stop_context(get_kernel_rename_ctx());
     flush();
 
     // Capture the fallback end timestamp after shutdown flushes complete so it

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-tool/tool.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-tool/tool.cpp
@@ -361,6 +361,13 @@ get_client_ctx()
     return context_id;
 }
 
+auto&
+get_kernel_rename_ctx()
+{
+    static rocprofiler_context_id_t context_id{0};
+    return context_id;
+}
+
 void
 set_contexts_active(const context_id_set_t& ctxs, const bool start)
 {
@@ -2574,8 +2581,8 @@ tool_init(rocprofiler_client_finalize_t fini_func, void* tool_data)
         start_context(counter_collection_ctx, "counter collection");
     }
 
-    auto rename_ctx            = rocprofiler_context_id_t{0};
-    auto marker_core_api_kinds = std::array<rocprofiler_tracing_operation_t, 2>{
+    auto& rename_ctx            = get_kernel_rename_ctx();
+    auto  marker_core_api_kinds = std::array<rocprofiler_tracing_operation_t, 2>{
         ROCPROFILER_MARKER_CORE_RANGE_API_ID_roctxMarkA,
         ROCPROFILER_MARKER_CORE_RANGE_API_ID_roctxThreadRangeA,
     };
@@ -3170,9 +3177,13 @@ tool_detach(void* /*tool_data*/)
     auto _detach_timer = common::simple_timer{"[rocprofv3] tool detachment"};
 
     // Flush all buffers, stop context to ensure in-flight GPU operations complete,
-    // then flush again to capture any final events (same pattern as tool_fini)
+    // then flush again to capture any final events (same pattern as tool_fini).
+    // The kernel rename context must also be stopped to prevent concurrent
+    // kernel_rename_callback calls from adding new strings to kernel_rename_map
+    // while generate_output builds the rocpd string table snapshot.
     flush();
     rocprofiler_stop_context(get_client_ctx());
+    rocprofiler_stop_context(get_kernel_rename_ctx());
     flush();
 
     // Capture the fallback end timestamp after shutdown flushes complete so it

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/code_object/code_object.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/code_object/code_object.cpp
@@ -977,16 +977,19 @@ executable_freeze(hsa_executable_t executable, const char* options)
     return rocprofiler::code_object::executable_freeze_internal(executable);
 }
 
-hsa_status_t
-executable_destroy(hsa_executable_t executable)
+// Performs all SDK bookkeeping for an executable being destroyed (unload notifications,
+// kernel object map cleanup, code object / executable list cleanup) without calling the
+// underlying HSA destroy function.  Called from both the HSA-hook path and the attach
+// destruction callback path.
+void
+executable_destroy_internal(hsa_executable_t executable)
 {
-    // Serialize all executable_destroy calls to prevent:
-    // 1. Concurrent access to code objects in shutdown()
-    // 2. Use-after-free when multiple threads destroy same executable
-    // 3. Race on end_notified flags (now atomic, but still need serialization for callbacks)
     auto _lk = std::unique_lock{get_destroy_mutex()};
 
-    if(is_shutdown.load(std::memory_order_acquire)) return HSA_STATUS_SUCCESS;
+    if(is_shutdown.load(std::memory_order_acquire))
+    {
+        return;
+    }
 
     auto _unloaded = shutdown(executable);
 
@@ -1008,7 +1011,10 @@ executable_destroy(hsa_executable_t executable)
         CHECK_NOTNULL(get_code_objects())->wlock([executable](code_object_array_t& data) {
             for(auto& itr : data)
             {
-                if(itr->hsa_executable.handle == executable.handle) itr.reset();
+                if(itr->hsa_executable.handle == executable.handle)
+                {
+                    itr.reset();
+                }
             }
             data.erase(std::remove_if(
                            data.begin(), data.end(), [](auto& itr) { return (itr == nullptr); }),
@@ -1027,7 +1033,16 @@ executable_destroy(hsa_executable_t executable)
                        data.end());
         });
     }
+}
 
+hsa_status_t
+executable_destroy(hsa_executable_t executable)
+{
+    // Serialize all executable_destroy calls to prevent:
+    // 1. Concurrent access to code objects in shutdown()
+    // 2. Use-after-free when multiple threads destroy same executable
+    // 3. Race on end_notified flags (now atomic, but still need serialization for callbacks)
+    executable_destroy_internal(executable);
     return CHECK_NOTNULL(get_destroy_function())(executable);
 }
 
@@ -1181,17 +1196,25 @@ get_attach_table()
 }
 
 void
-iterate_attach_code_object(hsa_executable_t executable, void*)
+attach_code_object_event(hsa_executable_t                       executable,
+                         rocprofiler_attach_code_object_phase_t phase,
+                         void* /*data*/)
 {
-    executable_freeze_internal(executable);
+    if(phase == ROCPROFILER_ATTACH_CODE_OBJECT_CREATED)
+    {
+        executable_freeze_internal(executable);
+    }
+    else
+    {
+        executable_destroy_internal(executable);
+    }
 }
 
 void
 load_attach_code_objects()
 {
     auto* attach_table = CHECK_NOTNULL(*(get_attach_table()));
-    attach_table->rocprofiler_attach_iterate_all_code_objects(iterate_attach_code_object, nullptr);
-    attach_table->rocprofiler_attach_notify_new_code_object = iterate_attach_code_object;
+    attach_table->rocprofiler_attach_add_code_object_cb(attach_code_object_event, nullptr);
 }
 
 }  // namespace

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/hsa/queue.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/hsa/queue.cpp
@@ -887,11 +887,6 @@ Queue::Queue(
             });
     }
 
-    if(!queue_interposition::supports_queue_interposition())
-    {
-        set_write_interceptor(WriteInterceptor, this);
-    }
-
     create_signal(0, &ready_signal, false);
     create_signal(0, &block_signal, false);
     create_signal(0, &_active_kernels, false);
@@ -899,6 +894,12 @@ Queue::Queue(
     _core_api.hsa_signal_store_screlease_fn(_active_kernels, 0);
 
     signal_pool_init();  // ensure the signal pool is constructed
+    // Since this is an active queue, the write interceptor may be called immediately, so this needs
+    // to appear after signal construction.
+    if(!queue_interposition::supports_queue_interposition())
+    {
+        set_write_interceptor(WriteInterceptor, this);
+    }
 }
 
 void

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/hsa/queue.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/hsa/queue.cpp
@@ -909,8 +909,6 @@ Queue::Queue(
             });
     }
 
-    set_write_interceptor(WriteInterceptor, this);
-
     create_signal(0, &ready_signal, false);
     create_signal(0, &block_signal, false);
     create_signal(0, &_active_kernels, false);
@@ -918,6 +916,10 @@ Queue::Queue(
     _core_api.hsa_signal_store_screlease_fn(_active_kernels, 0);
 
     (void) get_signal_pool();  // ensure the signal pool is constructed for this queue
+
+    // Since this is an active queue, the write interceptor may be called immediately, so this needs
+    // to appear after signal construction.
+    set_write_interceptor(WriteInterceptor, this);
 }
 
 Queue::~Queue()

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/hsa/queue_controller.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/hsa/queue_controller.cpp
@@ -219,13 +219,27 @@ queue_controller_iterate_attach_queue(hsa_queue_t* queue, hsa_agent_t agent, voi
 }
 
 void
+queue_controller_attach_queue_event(hsa_queue_t*                     queue,
+                                    hsa_agent_t                      agent,
+                                    rocprofiler_attach_queue_phase_t phase,
+                                    void* /*data*/)
+{
+    if(phase == ROCPROFILER_ATTACH_QUEUE_CREATED)
+    {
+        queue_controller_iterate_attach_queue(queue, agent, nullptr);
+    }
+    else if(auto* qc = get_queue_controller())
+    {
+        qc->destroy_queue(queue);
+    }
+}
+
+void
 queue_controller_load_attach_queues()
 {
     auto* attach_table = CHECK_NOTNULL(*(get_attach_table()));
 
-    attach_table->rocprofiler_attach_iterate_all_queues(queue_controller_iterate_attach_queue,
-                                                        nullptr);
-    attach_table->rocprofiler_attach_notify_new_queue = queue_controller_iterate_attach_queue;
+    attach_table->rocprofiler_attach_add_queue_cb(queue_controller_attach_queue_event, nullptr);
 }
 
 }  // namespace

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/hsa/queue_interposition.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/hsa/queue_interposition.cpp
@@ -82,7 +82,9 @@ should_bypass_inline_intercept()
 {
     return (!s_intercept_installed.load(std::memory_order_acquire) ||
             !s_intercept_active.load(std::memory_order_acquire) ||
-            registration::get_fini_status() != 0);
+            registration::get_fini_status() != 0 ||
+            // TODO: debug and enable queue interposition for attachment
+            registration::supports_attachment());
 }
 
 auto*&

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/pc_sampling/code_object.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/pc_sampling/code_object.cpp
@@ -67,13 +67,6 @@ get_attach_table()
     return table;
 }
 
-auto&
-get_prev_notify_callback()
-{
-    static rocprofiler_attach_notify_new_code_object_t _v = nullptr;
-    return _v;
-}
-
 /**
  * @brief Flush internal PC sampling buffers and generate a marker record
  * for the code object load/unload event.
@@ -102,9 +95,8 @@ flush_pc_sampling_buffers(const rocprofiler::code_object::hsa::code_object& code
     flush_internal_agent_buffers(agent_buffer_id);
 }
 
-// Internal implementation that can be called from both executable_freeze and attach mechanism
 void
-executable_freeze_internal(hsa_executable_t executable, bool flush = true)
+executable_freeze_internal(hsa_executable_t executable)
 {
     rocprofiler::code_object::iterate_loaded_code_objects(
         [&](const rocprofiler::code_object::hsa::code_object& code_object) {
@@ -115,7 +107,7 @@ executable_freeze_internal(hsa_executable_t executable, bool flush = true)
                     address_range_t{code_object_rocp.load_base,
                                     code_object_rocp.load_size,
                                     code_object_rocp.code_object_id});
-                if(flush) flush_pc_sampling_buffers(code_object);
+                flush_pc_sampling_buffers(code_object);
             }
         });
 }
@@ -125,14 +117,17 @@ executable_freeze(hsa_executable_t executable, const char* options)
 {
     // Call underlying function
     hsa_status_t status = CHECK_NOTNULL(get_freeze_function())(executable, options);
-    if(status != HSA_STATUS_SUCCESS) return status;
+    if(status != HSA_STATUS_SUCCESS)
+    {
+        return status;
+    }
 
     executable_freeze_internal(executable);
     return HSA_STATUS_SUCCESS;
 }
 
-hsa_status_t
-executable_destroy(hsa_executable_t executable)
+void
+executable_destroy_internal(hsa_executable_t executable)
 {
     rocprofiler::code_object::iterate_loaded_code_objects(
         [&](const rocprofiler::code_object::hsa::code_object& code_object) {
@@ -146,36 +141,36 @@ executable_destroy(hsa_executable_t executable)
                                     code_object_rocp.code_object_id});
             }
         });
+}
 
+hsa_status_t
+executable_destroy(hsa_executable_t executable)
+{
+    executable_destroy_internal(executable);
     // Call underlying function
     return CHECK_NOTNULL(get_destroy_function())(executable);
 }
 
 void
-iterate_attach_code_object(hsa_executable_t executable, void*)
+attach_code_object_event(hsa_executable_t                       executable,
+                         rocprofiler_attach_code_object_phase_t phase,
+                         void* /*data*/)
 {
-    // No need to flush when iterating over already loaded code objects during attach,
-    // as the PC sampling service might not be started yet, so there's nothing to flush.
-    executable_freeze_internal(executable, /*flush=*/false);
-}
-
-void
-chained_notify_new_code_object(hsa_executable_t executable, void* data)
-{
-    if(get_prev_notify_callback())
+    if(phase == ROCPROFILER_ATTACH_CODE_OBJECT_CREATED)
     {
-        get_prev_notify_callback()(executable, data);
+        executable_freeze_internal(executable);
     }
-    executable_freeze_internal(executable);
+    else
+    {
+        executable_destroy_internal(executable);
+    }
 }
 
 void
 load_attach_code_objects()
 {
     auto* attach_table = CHECK_NOTNULL(*(get_attach_table()));
-    attach_table->rocprofiler_attach_iterate_all_code_objects(iterate_attach_code_object, nullptr);
-    get_prev_notify_callback() = attach_table->rocprofiler_attach_notify_new_code_object;
-    attach_table->rocprofiler_attach_notify_new_code_object = chained_notify_new_code_object;
+    attach_table->rocprofiler_attach_add_code_object_cb(attach_code_object_event, nullptr);
 }
 }  // namespace
 

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/registration.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/registration.cpp
@@ -1485,6 +1485,10 @@ rocprofiler_set_api_table(const char* name,
 
         auto* rocattach_api = static_cast<RocAttachDispatchTable*>(tables[0]);
 
+        // Set has_attach_table before other initialization so that supports_attachment()
+        // will be correct for any installed interceptions.
+        rocprofiler::registration::get_attach_status()->has_attach_table = true;
+
         // unlike other APIs, we do not offer tracing for our own attach library
         // forward the table to the relevant code sections, then move on
         rocprofiler::code_object::initialize(rocattach_api);
@@ -1492,8 +1496,6 @@ rocprofiler_set_api_table(const char* name,
 #if ROCPROFILER_SDK_HSA_PC_SAMPLING > 0
         rocprofiler::pc_sampling::code_object::initialize(rocattach_api);
 #endif
-
-        rocprofiler::registration::get_attach_status()->has_attach_table = true;
     }
     else
     {

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/registration.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/registration.cpp
@@ -1249,6 +1249,11 @@ rocprofiler_set_api_table(const char* name,
         // need to construct agent mappings before initializing the queue controller
         rocprofiler::agent::construct_agent_cache(hsa_api_table);
         rocprofiler::thread_trace::initialize(hsa_api_table);
+        // code_object::initialize must precede queue_controller_init: when the attach library is
+        // in use, queue interception is live immediately upon queue_controller_init returning, so
+        // any dispatch that arrives before code object hooks are installed would miss load
+        // notifications. The same ordering is required here (non-attach path) so that the HSA
+        // table hook state is consistent before queue processing can begin.
         rocprofiler::code_object::initialize(hsa_api_table);
         rocprofiler::hsa::queue_controller_init(hsa_api_table);
         // Process agent ctx's that were started prior to HSA init

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/registration.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/registration.cpp
@@ -1137,6 +1137,21 @@ rocprofiler_set_api_table(const char* name,
     static auto _once = std::once_flag{};
     std::call_once(_once, rocprofiler::registration::initialize);
 
+    // Verify that the rocattach table is always the first table registered when the attach
+    // feature is in use. Any table registered before rocattach means stream ID lookups for
+    // pre-existing streams may fire before supports_attachment() returns true.
+    static auto _non_rocattach_registered = std::atomic<bool>{false};
+    if(std::string_view{name} == "rocattach")
+    {
+        ROCP_CI_LOG_IF(WARNING, _non_rocattach_registered.load())
+            << "sdk-attach API table was not the first API table registered. The attach library "
+               "must be registered before all other API tables for correctness of traced objects.";
+    }
+    else
+    {
+        _non_rocattach_registered.store(true);
+    }
+
     // pass to ROCTx init
     ROCP_ERROR_IF(num_tables == 0) << "rocprofiler expected " << name
                                    << " library to pass at least one table, not " << num_tables;

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/registration.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/registration.cpp
@@ -1234,6 +1234,7 @@ rocprofiler_set_api_table(const char* name,
         // need to construct agent mappings before initializing the queue controller
         rocprofiler::agent::construct_agent_cache(hsa_api_table);
         rocprofiler::thread_trace::initialize(hsa_api_table);
+        rocprofiler::code_object::initialize(hsa_api_table);
         rocprofiler::hsa::queue_controller_init(hsa_api_table);
         // Process agent ctx's that were started prior to HSA init
         rocprofiler::counters::device_counting_service_hsa_registration();
@@ -1241,7 +1242,6 @@ rocprofiler_set_api_table(const char* name,
         rocprofiler::hsa::async_copy_init(hsa_api_table, lib_instance);
         rocprofiler::hsa::memory_allocation_init(hsa_api_table->core_, lib_instance);
         rocprofiler::hsa::memory_allocation_init(hsa_api_table->amd_ext_, lib_instance);
-        rocprofiler::code_object::initialize(hsa_api_table);
 #if ROCPROFILER_SDK_HSA_PC_SAMPLING > 0
         if(runtime_pc_sampling_table)
             rocprofiler::pc_sampling::code_object::initialize(hsa_api_table);
@@ -1487,8 +1487,8 @@ rocprofiler_set_api_table(const char* name,
 
         // unlike other APIs, we do not offer tracing for our own attach library
         // forward the table to the relevant code sections, then move on
-        rocprofiler::hsa::queue_controller_init(rocattach_api);
         rocprofiler::code_object::initialize(rocattach_api);
+        rocprofiler::hsa::queue_controller_init(rocattach_api);
 #if ROCPROFILER_SDK_HSA_PC_SAMPLING > 0
         rocprofiler::pc_sampling::code_object::initialize(rocattach_api);
 #endif

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/registration.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/registration.cpp
@@ -1138,8 +1138,8 @@ rocprofiler_set_api_table(const char* name,
     std::call_once(_once, rocprofiler::registration::initialize);
 
     // Verify that the rocattach table is always the first table registered when the attach
-    // feature is in use. Any table registered before rocattach means stream ID lookups for
-    // pre-existing streams may fire before supports_attachment() returns true.
+    // feature is in use. Any table registered before rocattach means modules may be initialized
+    // without awareness of attachment.
     static auto _non_rocattach_registered = std::atomic<bool>{false};
     if(std::string_view{name} == "rocattach")
     {

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/thread_trace/code_object.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/thread_trace/code_object.cpp
@@ -96,47 +96,32 @@ executable_freeze(hsa_executable_t executable, const char* options)
 
     rocprofiler::code_object::iterate_loaded_code_objects(
         [&](const rocprofiler::code_object::hsa::code_object& code_object) {
-            if(code_object.hsa_executable != executable)
-            {
-                return;
-            }
+            if(code_object.hsa_executable != executable) return;
 
             const auto& co = code_object.rocp_data;
 
             get_registries().wlock([&](set_type_t& t) {
                 for(auto* reg : t)
-                {
                     reg->ld_fn(co.rocp_agent, co.code_object_id, co.load_delta, co.load_size);
-                }
             });
         });
 
     return HSA_STATUS_SUCCESS;
 }
 
-void
-executable_destroy_internal(hsa_executable_t executable)
-{
-    rocprofiler::code_object::iterate_loaded_code_objects(
-        [&](const rocprofiler::code_object::hsa::code_object& code_object) {
-            if(code_object.hsa_executable != executable)
-            {
-                return;
-            }
-
-            get_registries().wlock([&](set_type_t& t) {
-                for(auto* reg : t)
-                {
-                    reg->unld_fn(code_object.rocp_data.code_object_id);
-                }
-            });
-        });
-}
-
 hsa_status_t
 executable_destroy(hsa_executable_t executable)
 {
-    executable_destroy_internal(executable);
+    rocprofiler::code_object::iterate_loaded_code_objects(
+        [&](const rocprofiler::code_object::hsa::code_object& code_object) {
+            if(code_object.hsa_executable != executable) return;
+
+            get_registries().wlock([&](set_type_t& t) {
+                for(auto* reg : t)
+                    reg->unld_fn(code_object.rocp_data.code_object_id);
+            });
+        });
+
     // Call underlying function
     return CHECK_NOTNULL(get_destroy_function())(executable);
 }

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/thread_trace/code_object.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/thread_trace/code_object.cpp
@@ -96,32 +96,47 @@ executable_freeze(hsa_executable_t executable, const char* options)
 
     rocprofiler::code_object::iterate_loaded_code_objects(
         [&](const rocprofiler::code_object::hsa::code_object& code_object) {
-            if(code_object.hsa_executable != executable) return;
+            if(code_object.hsa_executable != executable)
+            {
+                return;
+            }
 
             const auto& co = code_object.rocp_data;
 
             get_registries().wlock([&](set_type_t& t) {
                 for(auto* reg : t)
+                {
                     reg->ld_fn(co.rocp_agent, co.code_object_id, co.load_delta, co.load_size);
+                }
             });
         });
 
     return HSA_STATUS_SUCCESS;
 }
 
-hsa_status_t
-executable_destroy(hsa_executable_t executable)
+void
+executable_destroy_internal(hsa_executable_t executable)
 {
     rocprofiler::code_object::iterate_loaded_code_objects(
         [&](const rocprofiler::code_object::hsa::code_object& code_object) {
-            if(code_object.hsa_executable != executable) return;
+            if(code_object.hsa_executable != executable)
+            {
+                return;
+            }
 
             get_registries().wlock([&](set_type_t& t) {
                 for(auto* reg : t)
+                {
                     reg->unld_fn(code_object.rocp_data.code_object_id);
+                }
             });
         });
+}
 
+hsa_status_t
+executable_destroy(hsa_executable_t executable)
+{
+    executable_destroy_internal(executable);
     // Call underlying function
     return CHECK_NOTNULL(get_destroy_function())(executable);
 }

--- a/projects/rocprofiler-sdk/tests/bin/attachment-test/attachment_test.cpp
+++ b/projects/rocprofiler-sdk/tests/bin/attachment-test/attachment_test.cpp
@@ -22,6 +22,7 @@
 
 #include <hip/hip_runtime.h>
 #include <rocprofiler-sdk-roctx/roctx.h>
+#include <sys/wait.h>
 #include <unistd.h>
 #include <chrono>
 #include <csignal>
@@ -35,14 +36,22 @@
 namespace
 {
 // required type for signal handlers
-volatile std::sig_atomic_t signal_received = 0;
+volatile std::sig_atomic_t sigint_received   = 0;
+volatile std::sig_atomic_t sigwinch_received = 0;
 }  // namespace
 
 // signal handler - must have C linkage
 extern "C" void
 attachment_test_signal_handler(int signum)
 {
-    signal_received = signum;
+    if(signum == SIGINT)
+    {
+        sigint_received = signum;
+    }
+    else if(signum == SIGWINCH)
+    {
+        sigwinch_received = signum;
+    }
 }
 
 /* Macro for checking GPU API return values */
@@ -78,12 +87,13 @@ execute_kernels(const size_t tid, const size_t device_id)
     HIP_ASSERT(hipStreamCreate(&stream));
 
     // Allocate memory
-    const int    size  = 1024 * 1024;  // 1M elements
+    const int    size  = 512 * 512;  // 256K elements
     const size_t bytes = size * sizeof(float);
 
-    float* h_data = new float[size];
+    float* h_data = nullptr;
     float* d_data = nullptr;
 
+    HIP_ASSERT(hipHostMalloc(&h_data, bytes));
     HIP_ASSERT(hipMalloc(&d_data, bytes));
 
     // Initialize data
@@ -100,13 +110,13 @@ execute_kernels(const size_t tid, const size_t device_id)
             << "...\n";
         std::cout << msg.str();
     }
-    const int num_iterations = 30;
+    size_t iter = 0;
 
-    for(int iter = 0; iter < num_iterations; ++iter)
+    while(!sigint_received)
     {
         // Add ROCTX markers for better profiling
         std::string range_name = "Iteration_" + std::to_string(iter + 1);
-        roctxRangePush(range_name.c_str());  // Removed - ROCTx not linked
+        roctxRangePush(range_name.c_str());
 
         // Copy data to device
         roctxMark("Start_H2D_Copy");
@@ -115,14 +125,14 @@ execute_kernels(const size_t tid, const size_t device_id)
         {
             std::cerr << "Failed to copy data for thread " << tid << " on device " << device_id
                       << "...\n";
-            roctxRangePop();  // Removed - ROCTx not linked
+            roctxRangePop();
             break;
         }
 
         // Launch kernel
         roctxMark("Launch_Kernel");
         int threads_per_block = 256;
-        int blocks_per_grid   = (size + threads_per_block - 1) / threads_per_block;
+        int blocks_per_grid   = size / threads_per_block;
 
         hipLaunchKernelGGL(
             simple_kernel, dim3(blocks_per_grid), dim3(threads_per_block), 0, stream, d_data, size);
@@ -134,7 +144,7 @@ execute_kernels(const size_t tid, const size_t device_id)
         {
             std::cerr << "Failed to copy data for thread " << tid << " on device " << device_id
                       << "...\n";
-            roctxRangePop();  // Removed - ROCTx not linked
+            roctxRangePop();
             break;
         }
 
@@ -145,52 +155,87 @@ execute_kernels(const size_t tid, const size_t device_id)
         {
             std::cerr << "Failed to synchronize stream " << stream << " with thread " << tid
                       << " on device " << device_id << "...\n";
-            roctxRangePop();  // Removed - ROCTx not linked
+            roctxRangePop();
             break;
         }
 
-        roctxRangePop();  // Removed - ROCTx not linked
+        roctxRangePop();
+
+        if(sigint_received)
+        {
+            break;
+        }
 
         // Small delay between iterations
-        std::this_thread::sleep_for(std::chrono::milliseconds(500));
+        std::this_thread::sleep_for(std::chrono::milliseconds(50));
+        iter++;
     }
 
     {
         // compose string first to avoid multithreaded handling of cout << operator
         auto msg = std::stringstream{};
-        msg << "Kernel execution loop completed for thread " << tid << " on device " << device_id
-            << "...\n";
+        msg << "Kernel execution loop completed " << iter << " iterations for thread " << tid
+            << " on device " << device_id << "\n";
         std::cout << msg.str();
     }
 
     HIP_ASSERT(hipStreamDestroy(stream));
     // Cleanup
+    HIP_ASSERT(hipHostFree(h_data));
     HIP_ASSERT(hipFree(d_data));
-    delete[] h_data;
 }
 
 int
 main(int argc, char** argv)
 {
-    // Install signal handler for SIGINT
+    // Install signal handler for SIGINT and SIGWINCH
+    std::signal(SIGINT, attachment_test_signal_handler);
     std::signal(SIGWINCH, attachment_test_signal_handler);
 
     size_t nthreads{8};
     int    ndevices{0};
+    bool   fork_child{false};
+    int    positional{0};
     for(int i = 1; i < argc; ++i)
     {
         auto _arg = std::string{argv[i]};
-        if(_arg == "?" || _arg == "-h" || _arg == "--help")
+        if(_arg == "--fork-child")
         {
-            fprintf(stderr,
-                    "usage: attachment-test [NUM_THREADS (%zu)] [NUM_DEVICES (%d)]\n",
-                    nthreads,
-                    ndevices);
+            fork_child = true;
+        }
+        else if(_arg == "?" || _arg == "-h" || _arg == "--help")
+        {
+            fprintf(
+                stderr,
+                "usage: attachment-test [--fork-child] [NUM_THREADS (%zu)] [NUM_DEVICES (%d)]\n",
+                nthreads,
+                ndevices);
             exit(EXIT_SUCCESS);
         }
+        else if(positional == 0)
+        {
+            nthreads = std::atoll(argv[i]);
+            ++positional;
+        }
+        else if(positional == 1)
+        {
+            ndevices = std::stoi(argv[i]);
+            ++positional;
+        }
     }
-    if(argc > 1) nthreads = std::atoll(argv[1]);
-    if(argc > 2) ndevices = std::stoi(argv[2]);
+
+    // Fork a child process before HIP initialization so each process gets a
+    // clean HIP context. Used by the attach-tree test to exercise --attach-children.
+    pid_t child_pid = -1;
+    if(fork_child)
+    {
+        child_pid = fork();
+        if(child_pid < 0)
+        {
+            std::cerr << "fork failed\n";
+            return 1;
+        }
+    }
 
     std::cout << "Attachment test app started with PID: " << getpid() << std::endl;
 
@@ -212,8 +257,6 @@ main(int argc, char** argv)
         ndevices = device_count;
     }
 
-    std::cout << "After first call " << getpid() << std::endl;
-
     auto _threads = std::vector<std::thread>{};
     _threads.reserve(nthreads);
 
@@ -222,12 +265,25 @@ main(int argc, char** argv)
     for(auto& itr : _threads)
         itr.join();
 
-    if(signal_received)
+    if(sigwinch_received)
     {
-        std::cout << "Attachment test process " << getpid() << " received signal "
-                  << signal_received << "\n";
+        std::cout << "Attachment test process " << getpid() << " received signal " << SIGWINCH
+                  << "\n";
     }
     std::cout << "Attachment test app finished" << std::endl;
+
+    if(child_pid > 0)
+    {
+        kill(child_pid, SIGINT);
+        int child_status = 0;
+        waitpid(child_pid, &child_status, 0);
+        if(child_status != 0)
+        {
+            std::cout << "Child process " << child_pid
+                      << " returned non-zero status: " << child_status << std::endl;
+            return 1;
+        }
+    }
 
     return 0;
 }

--- a/projects/rocprofiler-sdk/tests/bin/attachment-test/attachment_test.cpp
+++ b/projects/rocprofiler-sdk/tests/bin/attachment-test/attachment_test.cpp
@@ -22,6 +22,7 @@
 
 #include <hip/hip_runtime.h>
 #include <rocprofiler-sdk-roctx/roctx.h>
+#include <sys/wait.h>
 #include <unistd.h>
 #include <chrono>
 #include <csignal>
@@ -193,20 +194,48 @@ main(int argc, char** argv)
 
     size_t nthreads{8};
     int    ndevices{0};
+    bool   fork_child{false};
+    int    positional{0};
     for(int i = 1; i < argc; ++i)
     {
         auto _arg = std::string{argv[i]};
-        if(_arg == "?" || _arg == "-h" || _arg == "--help")
+        if(_arg == "--fork-child")
         {
-            fprintf(stderr,
-                    "usage: attachment-test [NUM_THREADS (%zu)] [NUM_DEVICES (%d)]\n",
-                    nthreads,
-                    ndevices);
+            fork_child = true;
+        }
+        else if(_arg == "?" || _arg == "-h" || _arg == "--help")
+        {
+            fprintf(
+                stderr,
+                "usage: attachment-test [--fork-child] [NUM_THREADS (%zu)] [NUM_DEVICES (%d)]\n",
+                nthreads,
+                ndevices);
             exit(EXIT_SUCCESS);
         }
+        else if(positional == 0)
+        {
+            nthreads = std::atoll(argv[i]);
+            ++positional;
+        }
+        else if(positional == 1)
+        {
+            ndevices = std::stoi(argv[i]);
+            ++positional;
+        }
     }
-    if(argc > 1) nthreads = std::atoll(argv[1]);
-    if(argc > 2) ndevices = std::stoi(argv[2]);
+
+    // Fork a child process before HIP initialization so each process gets a
+    // clean HIP context. Used by the attach-tree test to exercise --attach-children.
+    pid_t child_pid = -1;
+    if(fork_child)
+    {
+        child_pid = fork();
+        if(child_pid < 0)
+        {
+            std::cerr << "fork failed\n";
+            return 1;
+        }
+    }
 
     std::cout << "Attachment test app started with PID: " << getpid() << std::endl;
 
@@ -242,6 +271,19 @@ main(int argc, char** argv)
                   << "\n";
     }
     std::cout << "Attachment test app finished" << std::endl;
+
+    if(child_pid > 0)
+    {
+        kill(child_pid, SIGINT);
+        int child_status = 0;
+        waitpid(child_pid, &child_status, 0);
+        if(child_status != 0)
+        {
+            std::cout << "Child process " << child_pid
+                      << " returned non-zero status: " << child_status << std::endl;
+            return 1;
+        }
+    }
 
     return 0;
 }

--- a/projects/rocprofiler-sdk/tests/bin/attachment-test/attachment_test.cpp
+++ b/projects/rocprofiler-sdk/tests/bin/attachment-test/attachment_test.cpp
@@ -35,14 +35,22 @@
 namespace
 {
 // required type for signal handlers
-volatile std::sig_atomic_t signal_received = 0;
+volatile std::sig_atomic_t sigint_received   = 0;
+volatile std::sig_atomic_t sigwinch_received = 0;
 }  // namespace
 
 // signal handler - must have C linkage
 extern "C" void
 attachment_test_signal_handler(int signum)
 {
-    signal_received = signum;
+    if(signum == SIGINT)
+    {
+        sigint_received = signum;
+    }
+    else if(signum == SIGWINCH)
+    {
+        sigwinch_received = signum;
+    }
 }
 
 /* Macro for checking GPU API return values */
@@ -78,12 +86,13 @@ execute_kernels(const size_t tid, const size_t device_id)
     HIP_ASSERT(hipStreamCreate(&stream));
 
     // Allocate memory
-    const int    size  = 1024 * 1024;  // 1M elements
+    const int    size  = 512 * 512;  // 256K elements
     const size_t bytes = size * sizeof(float);
 
-    float* h_data = new float[size];
+    float* h_data = nullptr;
     float* d_data = nullptr;
 
+    HIP_ASSERT(hipHostMalloc(&h_data, bytes));
     HIP_ASSERT(hipMalloc(&d_data, bytes));
 
     // Initialize data
@@ -100,13 +109,13 @@ execute_kernels(const size_t tid, const size_t device_id)
             << "...\n";
         std::cout << msg.str();
     }
-    const int num_iterations = 30;
+    size_t iter = 0;
 
-    for(int iter = 0; iter < num_iterations; ++iter)
+    while(!sigint_received)
     {
         // Add ROCTX markers for better profiling
         std::string range_name = "Iteration_" + std::to_string(iter + 1);
-        roctxRangePush(range_name.c_str());  // Removed - ROCTx not linked
+        roctxRangePush(range_name.c_str());
 
         // Copy data to device
         roctxMark("Start_H2D_Copy");
@@ -115,14 +124,14 @@ execute_kernels(const size_t tid, const size_t device_id)
         {
             std::cerr << "Failed to copy data for thread " << tid << " on device " << device_id
                       << "...\n";
-            roctxRangePop();  // Removed - ROCTx not linked
+            roctxRangePop();
             break;
         }
 
         // Launch kernel
         roctxMark("Launch_Kernel");
         int threads_per_block = 256;
-        int blocks_per_grid   = (size + threads_per_block - 1) / threads_per_block;
+        int blocks_per_grid   = size / threads_per_block;
 
         hipLaunchKernelGGL(
             simple_kernel, dim3(blocks_per_grid), dim3(threads_per_block), 0, stream, d_data, size);
@@ -134,7 +143,7 @@ execute_kernels(const size_t tid, const size_t device_id)
         {
             std::cerr << "Failed to copy data for thread " << tid << " on device " << device_id
                       << "...\n";
-            roctxRangePop();  // Removed - ROCTx not linked
+            roctxRangePop();
             break;
         }
 
@@ -145,34 +154,41 @@ execute_kernels(const size_t tid, const size_t device_id)
         {
             std::cerr << "Failed to synchronize stream " << stream << " with thread " << tid
                       << " on device " << device_id << "...\n";
-            roctxRangePop();  // Removed - ROCTx not linked
+            roctxRangePop();
             break;
         }
 
-        roctxRangePop();  // Removed - ROCTx not linked
+        roctxRangePop();
+
+        if(sigint_received)
+        {
+            break;
+        }
 
         // Small delay between iterations
-        std::this_thread::sleep_for(std::chrono::milliseconds(500));
+        std::this_thread::sleep_for(std::chrono::milliseconds(50));
+        iter++;
     }
 
     {
         // compose string first to avoid multithreaded handling of cout << operator
         auto msg = std::stringstream{};
-        msg << "Kernel execution loop completed for thread " << tid << " on device " << device_id
-            << "...\n";
+        msg << "Kernel execution loop completed " << iter << " iterations for thread " << tid
+            << " on device " << device_id << "\n";
         std::cout << msg.str();
     }
 
     HIP_ASSERT(hipStreamDestroy(stream));
     // Cleanup
+    HIP_ASSERT(hipHostFree(h_data));
     HIP_ASSERT(hipFree(d_data));
-    delete[] h_data;
 }
 
 int
 main(int argc, char** argv)
 {
-    // Install signal handler for SIGINT
+    // Install signal handler for SIGINT and SIGWINCH
+    std::signal(SIGINT, attachment_test_signal_handler);
     std::signal(SIGWINCH, attachment_test_signal_handler);
 
     size_t nthreads{8};
@@ -212,8 +228,6 @@ main(int argc, char** argv)
         ndevices = device_count;
     }
 
-    std::cout << "After first call " << getpid() << std::endl;
-
     auto _threads = std::vector<std::thread>{};
     _threads.reserve(nthreads);
 
@@ -222,10 +236,10 @@ main(int argc, char** argv)
     for(auto& itr : _threads)
         itr.join();
 
-    if(signal_received)
+    if(sigwinch_received)
     {
-        std::cout << "Attachment test process " << getpid() << " received signal "
-                  << signal_received << "\n";
+        std::cout << "Attachment test process " << getpid() << " received signal " << SIGWINCH
+                  << "\n";
     }
     std::cout << "Attachment test app finished" << std::endl;
 

--- a/projects/rocprofiler-sdk/tests/rocattach/CMakeLists.txt
+++ b/projects/rocprofiler-sdk/tests/rocattach/CMakeLists.txt
@@ -11,6 +11,10 @@ project(
 find_package(rocprofiler-sdk REQUIRED)
 find_package(rocprofiler-sdk-rocattach REQUIRED)
 
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_EXTENSIONS OFF)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
 # TODO: sanitizer tests do not cooperate with attachment code injection
 set(ROCPROFILER_MEMCHECK_TYPES "AddressSanitizer" "UndefinedBehaviorSanitizer"
                                "ThreadSanitizer")
@@ -26,12 +30,6 @@ if(ROCPROFILER_MEMCHECK STREQUAL "LeakSanitizer")
 else()
     set(LOG_LEVEL "trace")
 endif()
-
-set(CMAKE_CXX_STANDARD 17)
-set(CMAKE_CXX_EXTENSIONS OFF)
-set(CMAKE_CXX_STANDARD_REQUIRED ON)
-
-set(PRELOAD_ENV "${ROCPROFILER_MEMCHECK_PRELOAD_ENV_VALUE}")
 
 set(rocattach-test-env
     "ROCP_TOOL_ATTACH=1"
@@ -49,26 +47,32 @@ target_link_libraries(
             rocprofiler-sdk::tests-common-library
             rocprofiler-sdk::rocprofiler-sdk-rocattach-shared-library)
 
+# Utilize rocattach to use a generic C tool in a basic app
 rocprofiler_add_integration_execute_test(
     rocattach-parallel-attach-test-execute
-    TARGET rocattach-parallel-attach-test
-    ARGS $<TARGET_FILE:attachment-test> $<TARGET_FILE:rocprofiler-sdk-c-tool>
+    COMMAND $<TARGET_FILE:rocattach-parallel-attach-test> $<TARGET_FILE:attachment-test>
+            $<TARGET_FILE:rocprofiler-sdk-c-tool>
+    DEPENDS rocattach-parallel-attach-test
     TIMEOUT 45
-    DISABLED ${IS_DISABLED}
-    PRELOAD "${PRELOAD_ENV}"
+    LABELS "attachment"
     ENVIRONMENT "${rocattach-test-env}"
+    DISABLED ${IS_DISABLED}
+    PRELOAD "${ROCPROFILER_MEMCHECK_PRELOAD_ENV_VALUE}"
     PASS_REGULAR_EXPRESSION "Test C tool \\(priority=0\\) is using rocprofiler-sdk v"
     FAIL_REGULAR_EXPRESSION "${ROCPROFILER_DEFAULT_FAIL_REGEX}")
 
+# Utilize rocattach to verify signals are correctly forwarded to a target application
+# during attachment
 rocprofiler_add_integration_execute_test(
     rocattach-parallel-attach-test-signal-execute
-    TARGET rocattach-parallel-attach-test
-    ARGS $<TARGET_FILE:attachment-test> $<TARGET_FILE:rocprofiler-sdk-c-tool>
-         --send-signal
+    COMMAND $<TARGET_FILE:rocattach-parallel-attach-test> $<TARGET_FILE:attachment-test>
+            $<TARGET_FILE:rocprofiler-sdk-c-tool> --send-signal
+    DEPENDS rocattach-parallel-attach-test
     TIMEOUT 45
-    DISABLED ${IS_DISABLED}
-    PRELOAD "${PRELOAD_ENV}"
+    LABELS "attachment"
     ENVIRONMENT "${rocattach-test-env}"
+    DISABLED ${IS_DISABLED}
+    PRELOAD "${ROCPROFILER_MEMCHECK_PRELOAD_ENV_VALUE}"
     PASS_REGULAR_EXPRESSION "Attachment test process [0-9]+ received signal 28"
     FAIL_REGULAR_EXPRESSION "${ROCPROFILER_DEFAULT_FAIL_REGEX}")
 
@@ -85,9 +89,10 @@ rocprofiler_add_integration_execute_test(
     TARGET rocattach-attach-tree-test
     ARGS $<TARGET_FILE:attachment-test> $<TARGET_FILE:rocprofiler-sdk-c-tool>
     TIMEOUT 45
-    DISABLED ${IS_DISABLED}
-    PRELOAD "${PRELOAD_ENV}"
+    LABELS "attachment"
     ENVIRONMENT "${rocattach-test-env}"
+    DISABLED ${IS_DISABLED}
+    PRELOAD "${ROCPROFILER_MEMCHECK_PRELOAD_ENV_VALUE}"
     PASS_REGULAR_EXPRESSION "verified: grandchild pid [0-9]+ loaded the tool library"
     FAIL_REGULAR_EXPRESSION "${ROCPROFILER_DEFAULT_FAIL_REGEX}")
 

--- a/projects/rocprofiler-sdk/tests/rocattach/CMakeLists.txt
+++ b/projects/rocprofiler-sdk/tests/rocattach/CMakeLists.txt
@@ -11,6 +11,10 @@ project(
 find_package(rocprofiler-sdk REQUIRED)
 find_package(rocprofiler-sdk-rocattach REQUIRED)
 
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_EXTENSIONS OFF)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
 # TODO: sanitizer tests do not cooperate with attachment code injection
 set(ROCPROFILER_MEMCHECK_TYPES "AddressSanitizer" "UndefinedBehaviorSanitizer"
                                "ThreadSanitizer")
@@ -26,12 +30,6 @@ if(ROCPROFILER_MEMCHECK STREQUAL "LeakSanitizer")
 else()
     set(LOG_LEVEL "trace")
 endif()
-
-set(CMAKE_CXX_STANDARD 17)
-set(CMAKE_CXX_EXTENSIONS OFF)
-set(CMAKE_CXX_STANDARD_REQUIRED ON)
-
-set(PRELOAD_ENV "${ROCPROFILER_MEMCHECK_PRELOAD_ENV_VALUE}")
 
 set(rocattach-test-env
     "ROCP_TOOL_ATTACH=1"
@@ -49,26 +47,32 @@ target_link_libraries(
             rocprofiler-sdk::tests-common-library
             rocprofiler-sdk::rocprofiler-sdk-rocattach-shared-library)
 
+# Utilize rocattach to use a generic C tool in a basic app
 rocprofiler_add_integration_execute_test(
     rocattach-parallel-attach-test-execute
-    TARGET rocattach-parallel-attach-test
-    ARGS $<TARGET_FILE:attachment-test> $<TARGET_FILE:rocprofiler-sdk-c-tool>
+    COMMAND $<TARGET_FILE:rocattach-parallel-attach-test> $<TARGET_FILE:attachment-test>
+            $<TARGET_FILE:rocprofiler-sdk-c-tool>
+    DEPENDS rocattach-parallel-attach-test
     TIMEOUT 45
-    DISABLED ${IS_DISABLED}
-    PRELOAD "${PRELOAD_ENV}"
+    LABELS "attachment"
     ENVIRONMENT "${rocattach-test-env}"
+    DISABLED ${IS_DISABLED}
+    PRELOAD "${ROCPROFILER_MEMCHECK_PRELOAD_ENV_VALUE}"
     PASS_REGULAR_EXPRESSION "Test C tool \\(priority=0\\) is using rocprofiler-sdk v"
     FAIL_REGULAR_EXPRESSION "${ROCPROFILER_DEFAULT_FAIL_REGEX}")
 
+# Utilize rocattach to verify signals are correctly forwarded to a target application
+# during attachment
 rocprofiler_add_integration_execute_test(
     rocattach-parallel-attach-test-signal-execute
-    TARGET rocattach-parallel-attach-test
-    ARGS $<TARGET_FILE:attachment-test> $<TARGET_FILE:rocprofiler-sdk-c-tool>
-         --send-signal
+    COMMAND $<TARGET_FILE:rocattach-parallel-attach-test> $<TARGET_FILE:attachment-test>
+            $<TARGET_FILE:rocprofiler-sdk-c-tool> --send-signal
+    DEPENDS rocattach-parallel-attach-test
     TIMEOUT 45
-    DISABLED ${IS_DISABLED}
-    PRELOAD "${PRELOAD_ENV}"
+    LABELS "attachment"
     ENVIRONMENT "${rocattach-test-env}"
+    DISABLED ${IS_DISABLED}
+    PRELOAD "${ROCPROFILER_MEMCHECK_PRELOAD_ENV_VALUE}"
     PASS_REGULAR_EXPRESSION "Attachment test process [0-9]+ received signal 28"
     FAIL_REGULAR_EXPRESSION "${ROCPROFILER_DEFAULT_FAIL_REGEX}")
 
@@ -85,8 +89,9 @@ rocprofiler_add_integration_execute_test(
     TARGET rocattach-attach-tree-test
     ARGS $<TARGET_FILE:attachment-test> $<TARGET_FILE:rocprofiler-sdk-c-tool>
     TIMEOUT 45
-    DISABLED ${IS_DISABLED}
-    PRELOAD "${PRELOAD_ENV}"
+    LABELS "attachment"
     ENVIRONMENT "${rocattach-test-env}"
+    DISABLED ${IS_DISABLED}
+    PRELOAD "${ROCPROFILER_MEMCHECK_PRELOAD_ENV_VALUE}"
     PASS_REGULAR_EXPRESSION "verified: grandchild pid [0-9]+ loaded the tool library"
     FAIL_REGULAR_EXPRESSION "${ROCPROFILER_DEFAULT_FAIL_REGEX}")

--- a/projects/rocprofiler-sdk/tests/rocattach/attach_tree.cpp
+++ b/projects/rocprofiler-sdk/tests/rocattach/attach_tree.cpp
@@ -195,15 +195,17 @@ main(int argc, char** argv)
     std::cout << "verified: grandchild pid " << grandchild_pid << " loaded the tool library\n";
 
     // Let profiling run for a few seconds.
-    std::this_thread::sleep_for(std::chrono::milliseconds(5000));
+    std::this_thread::sleep_for(std::chrono::milliseconds(500));
 
     // Detach from the process tree symmetrically with how we attached.
     ROCATTACH_CALL(rocattach_detach_tree(child_pid));
 
     int grandchild_status = 0;
+    kill(grandchild_pid, SIGINT);
     waitpid(grandchild_pid, &grandchild_status, 0);
 
     int child_status = 0;
+    kill(child_pid, SIGINT);
     waitpid(child_pid, &child_status, 0);
 
     if(grandchild_status != 0)

--- a/projects/rocprofiler-sdk/tests/rocattach/attach_tree.cpp
+++ b/projects/rocprofiler-sdk/tests/rocattach/attach_tree.cpp
@@ -35,10 +35,38 @@
 #include <unistd.h>
 
 #include <chrono>
+#include <filesystem>
 #include <fstream>
 #include <iostream>
 #include <string>
 #include <thread>
+
+static bool
+wait_for_attach_ready(pid_t pid)
+{
+    constexpr int max_wait_sec = 30;
+    auto          task_dir     = "/proc/" + std::to_string(pid) + "/task";
+
+    std::cout << "Waiting for rocp-bg-attach thread in PID " << pid << "...\n";
+    for(int elapsed = 0; elapsed < max_wait_sec; ++elapsed)
+    {
+        std::error_code ec;
+        for(const auto& entry : std::filesystem::directory_iterator(task_dir, ec))
+        {
+            if(!entry.is_directory()) continue;
+            std::ifstream comm(entry.path() / "comm");
+            std::string   name;
+            if(std::getline(comm, name) && name == "rocp-bg-attach")
+            {
+                std::cout << "Attachment ready (" << elapsed << "s elapsed)\n";
+                return true;
+            }
+        }
+        std::this_thread::sleep_for(std::chrono::seconds(1));
+    }
+    std::cout << "Timed out after " << max_wait_sec << "s waiting for rocp-bg-attach thread\n";
+    return false;
+}
 
 #define ROCATTACH_CALL(func)                                                                       \
     {                                                                                              \
@@ -154,15 +182,42 @@ main(int argc, char** argv)
     }
     close(pipefd[0]);
 
-    // Parent process: wait for the child to exec and start running.
-    std::this_thread::sleep_for(std::chrono::milliseconds(2500));
+    // Parent process: wait for the child and grandchild to be ready for attachment.
+    auto kill_children = [&]() {
+        kill(grandchild_pid, SIGKILL);
+        kill(child_pid, SIGKILL);
+        waitpid(grandchild_pid, nullptr, 0);
+        waitpid(child_pid, nullptr, 0);
+    };
+
+    if(!wait_for_attach_ready(child_pid))
+    {
+        kill_children();
+        return 1;
+    }
+    if(!wait_for_attach_ready(grandchild_pid))
+    {
+        kill_children();
+        return 1;
+    }
 
     setenv("ROCPROF_ATTACH_TOOL_LIBRARY", argv[2], true);
 
     // Attach to the child and any processes it may have spawned. Passing the
     // child PID to rocattach_attach_tree lets it discover the full subtree via
     // /proc without the caller enumerating descendants explicitly.
-    ROCATTACH_CALL(rocattach_attach_tree(child_pid));
+    {
+        std::cout << "starting call to rocattach_attach_tree(child_pid)" << std::endl;
+        rocattach_status_t status = rocattach_attach_tree(child_pid);
+        if(status != ROCATTACH_STATUS_SUCCESS)
+        {
+            std::cout << "error: call to rocattach_attach_tree(child_pid) returned non zero status "
+                      << status << std::endl;
+            kill_children();
+            return 1;
+        }
+        std::cout << "call to rocattach_attach_tree(child_pid) successful" << std::endl;
+    }
 
     // Verify that the tool library was loaded into both the child and the
     // grandchild by inspecting /proc/<pid>/maps. setup() calls
@@ -174,10 +229,7 @@ main(int argc, char** argv)
     if(!is_library_loaded(child_pid, tool_library))
     {
         std::cout << "error: tool library not found in child pid " << child_pid << " maps\n";
-        kill(grandchild_pid, SIGKILL);
-        kill(child_pid, SIGKILL);
-        waitpid(grandchild_pid, nullptr, 0);
-        waitpid(child_pid, nullptr, 0);
+        kill_children();
         return 1;
     }
     std::cout << "verified: child pid " << child_pid << " loaded the tool library\n";
@@ -186,10 +238,7 @@ main(int argc, char** argv)
     {
         std::cout << "error: tool library not found in grandchild pid " << grandchild_pid
                   << " maps\n";
-        kill(grandchild_pid, SIGKILL);
-        kill(child_pid, SIGKILL);
-        waitpid(grandchild_pid, nullptr, 0);
-        waitpid(child_pid, nullptr, 0);
+        kill_children();
         return 1;
     }
     std::cout << "verified: grandchild pid " << grandchild_pid << " loaded the tool library\n";
@@ -198,7 +247,18 @@ main(int argc, char** argv)
     std::this_thread::sleep_for(std::chrono::milliseconds(500));
 
     // Detach from the process tree symmetrically with how we attached.
-    ROCATTACH_CALL(rocattach_detach_tree(child_pid));
+    {
+        std::cout << "starting call to rocattach_detach_tree(child_pid)" << std::endl;
+        rocattach_status_t status = rocattach_detach_tree(child_pid);
+        if(status != ROCATTACH_STATUS_SUCCESS)
+        {
+            std::cout << "error: call to rocattach_detach_tree(child_pid) returned non zero status "
+                      << status << std::endl;
+            kill_children();
+            return 1;
+        }
+        std::cout << "call to rocattach_detach_tree(child_pid) successful" << std::endl;
+    }
 
     int grandchild_status = 0;
     kill(grandchild_pid, SIGINT);

--- a/projects/rocprofiler-sdk/tests/rocattach/main.cpp
+++ b/projects/rocprofiler-sdk/tests/rocattach/main.cpp
@@ -93,7 +93,7 @@ main(int argc, char** argv)
     else
     {
         // Wait for child processes to exec
-        std::this_thread::sleep_for(std::chrono::milliseconds(2500));
+        std::this_thread::sleep_for(std::chrono::milliseconds(1000));
 
         setenv("ROCPROF_ATTACH_TOOL_LIBRARY", argv[2], true);
 
@@ -109,21 +109,30 @@ main(int argc, char** argv)
                 std::cout << "Sending SIGWINCH to PID " << pid1 << "\n";
                 if(kill(pid1, SIGWINCH) == -1)
                 {
-                    std::cout << "error: Failed to send signal to pid1\n";
+                    std::cout << "error: Failed to send SIGWINCH signal to pid1\n";
                 }
                 std::cout << "Sending SIGWINCH to PID " << pid2 << "\n";
                 if(kill(pid2, SIGWINCH) == -1)
                 {
-                    std::cout << "error: Failed to send signal to pid2\n";
+                    std::cout << "error: Failed to send SIGWINCH signal to pid2\n";
                 }
             }
         }
 
         // Wait for child processes to continue executing
-        std::this_thread::sleep_for(std::chrono::milliseconds(5000));
+        std::this_thread::sleep_for(std::chrono::milliseconds(500));
 
         ROCATTACH_CALL(rocattach_detach(pid1));
         ROCATTACH_CALL(rocattach_detach(pid2));
+
+        if(kill(pid1, SIGINT) == -1)
+        {
+            std::cout << "error: Failed to send signal SIGINT to pid1\n";
+        }
+        if(kill(pid2, SIGINT) == -1)
+        {
+            std::cout << "error: Failed to send signal SIGINT to pid2\n";
+        }
 
         int pid1status = 0;
         waitpid(pid1, &pid1status, 0);

--- a/projects/rocprofiler-sdk/tests/rocattach/main.cpp
+++ b/projects/rocprofiler-sdk/tests/rocattach/main.cpp
@@ -30,9 +30,38 @@
 #include <unistd.h>
 
 #include <chrono>
+#include <filesystem>
+#include <fstream>
 #include <iostream>
 #include <sstream>
 #include <thread>
+
+static bool
+wait_for_attach_ready(pid_t pid)
+{
+    constexpr int max_wait_sec = 30;
+    auto          task_dir     = "/proc/" + std::to_string(pid) + "/task";
+
+    std::cout << "Waiting for rocp-bg-attach thread in PID " << pid << "...\n";
+    for(int elapsed = 0; elapsed < max_wait_sec; ++elapsed)
+    {
+        std::error_code ec;
+        for(const auto& entry : std::filesystem::directory_iterator(task_dir, ec))
+        {
+            if(!entry.is_directory()) continue;
+            std::ifstream comm(entry.path() / "comm");
+            std::string   name;
+            if(std::getline(comm, name) && name == "rocp-bg-attach")
+            {
+                std::cout << "Attachment ready (" << elapsed << "s elapsed)\n";
+                return true;
+            }
+        }
+        std::this_thread::sleep_for(std::chrono::seconds(1));
+    }
+    std::cout << "Timed out after " << max_wait_sec << "s waiting for rocp-bg-attach thread\n";
+    return false;
+}
 
 #define ROCATTACH_CALL(func)                                                                       \
     {                                                                                              \
@@ -92,13 +121,51 @@ main(int argc, char** argv)
     }
     else
     {
-        // Wait for child processes to exec
-        std::this_thread::sleep_for(std::chrono::milliseconds(1000));
+        auto kill_children = [&]() {
+            kill(pid1, SIGKILL);
+            kill(pid2, SIGKILL);
+            waitpid(pid1, nullptr, 0);
+            waitpid(pid2, nullptr, 0);
+        };
+
+        // Wait for child processes to be ready for attachment
+        if(!wait_for_attach_ready(pid1))
+        {
+            kill_children();
+            return 1;
+        }
+        if(!wait_for_attach_ready(pid2))
+        {
+            kill_children();
+            return 1;
+        }
 
         setenv("ROCPROF_ATTACH_TOOL_LIBRARY", argv[2], true);
 
-        ROCATTACH_CALL(rocattach_attach(pid1));
-        ROCATTACH_CALL(rocattach_attach(pid2));
+        {
+            std::cout << "starting call to rocattach_attach(pid1)" << std::endl;
+            rocattach_status_t status = rocattach_attach(pid1);
+            if(status != ROCATTACH_STATUS_SUCCESS)
+            {
+                std::cout << "error: call to rocattach_attach(pid1) returned non zero status "
+                          << status << std::endl;
+                kill_children();
+                return 1;
+            }
+            std::cout << "call to rocattach_attach(pid1) successful" << std::endl;
+        }
+        {
+            std::cout << "starting call to rocattach_attach(pid2)" << std::endl;
+            rocattach_status_t status = rocattach_attach(pid2);
+            if(status != ROCATTACH_STATUS_SUCCESS)
+            {
+                std::cout << "error: call to rocattach_attach(pid2) returned non zero status "
+                          << status << std::endl;
+                kill_children();
+                return 1;
+            }
+            std::cout << "call to rocattach_attach(pid2) successful" << std::endl;
+        }
 
         // Send signal to child processes after attaching
         if(argc >= 4)
@@ -122,8 +189,30 @@ main(int argc, char** argv)
         // Wait for child processes to continue executing
         std::this_thread::sleep_for(std::chrono::milliseconds(500));
 
-        ROCATTACH_CALL(rocattach_detach(pid1));
-        ROCATTACH_CALL(rocattach_detach(pid2));
+        {
+            std::cout << "starting call to rocattach_detach(pid1)" << std::endl;
+            rocattach_status_t status = rocattach_detach(pid1);
+            if(status != ROCATTACH_STATUS_SUCCESS)
+            {
+                std::cout << "error: call to rocattach_detach(pid1) returned non zero status "
+                          << status << std::endl;
+                kill_children();
+                return 1;
+            }
+            std::cout << "call to rocattach_detach(pid1) successful" << std::endl;
+        }
+        {
+            std::cout << "starting call to rocattach_detach(pid2)" << std::endl;
+            rocattach_status_t status = rocattach_detach(pid2);
+            if(status != ROCATTACH_STATUS_SUCCESS)
+            {
+                std::cout << "error: call to rocattach_detach(pid2) returned non zero status "
+                          << status << std::endl;
+                kill_children();
+                return 1;
+            }
+            std::cout << "call to rocattach_detach(pid2) successful" << std::endl;
+        }
 
         if(kill(pid1, SIGINT) == -1)
         {

--- a/projects/rocprofiler-sdk/tests/rocprofv3/attachment/attach-once/CMakeLists.txt
+++ b/projects/rocprofiler-sdk/tests/rocprofv3/attachment/attach-once/CMakeLists.txt
@@ -57,15 +57,5 @@ rocprofiler_add_integration_validate_test(
     DISABLED ${IS_DISABLED}
     SKIP_REGULAR_EXPRESSION "SKIPPED"
     FIXTURES_REQUIRED rocprofv3-test-attachment-attach-once
-    ARGS --kernel-input
-         ${CMAKE_CURRENT_BINARY_DIR}/attachment-output/out_kernel_trace.csv
-         --hsa-input
-         ${CMAKE_CURRENT_BINARY_DIR}/attachment-output/out_hsa_api_trace.csv
-         --memory-copy-input
-         ${CMAKE_CURRENT_BINARY_DIR}/attachment-output/out_memory_copy_trace.csv
-         --agent-input
-         ${CMAKE_CURRENT_BINARY_DIR}/attachment-output/out_agent_info.csv
-         --json-input
-         ${CMAKE_CURRENT_BINARY_DIR}/attachment-output/out_results.json
-         --skip-if
-         ${CMAKE_CURRENT_BINARY_DIR}/attachment-output/skipped)
+    ARGS --json-input ${CMAKE_CURRENT_BINARY_DIR}/attachment-output/out_results.json
+         --skip-if ${CMAKE_CURRENT_BINARY_DIR}/attachment-output/skipped)

--- a/projects/rocprofiler-sdk/tests/rocprofv3/attachment/attach-once/CMakeLists.txt
+++ b/projects/rocprofiler-sdk/tests/rocprofv3/attachment/attach-once/CMakeLists.txt
@@ -11,7 +11,7 @@ project(
 find_package(rocprofiler-sdk REQUIRED)
 
 set(ROCPROFILER_MEMCHECK_TYPES "AddressSanitizer" "UndefinedBehaviorSanitizer"
-                               "ThreadSanitizer")
+                               "ThreadSanitizer" "LeakSanitizer")
 
 if(ROCPROFILER_MEMCHECK AND ROCPROFILER_MEMCHECK IN_LIST ROCPROFILER_MEMCHECK_TYPES)
     set(IS_DISABLED ON)
@@ -25,16 +25,11 @@ else()
     set(LOG_LEVEL "info")
 endif()
 
-set(PRELOAD_ENV "${ROCPROFILER_MEMCHECK_PRELOAD_ENV_VALUE}")
-
 set(attachment-env
     "LD_LIBRARY_PATH=$<TARGET_FILE_DIR:rocprofiler-sdk::rocprofiler-sdk-shared-library>:$ENV{LD_LIBRARY_PATH}"
     )
 
-# Unconditionally disabled: intermittent failure caused by test app abort
-set(IS_DISABLED ON)
-
-# Test that launches the app and attaches to it (CSV format)
+# Test that launches the app and attaches to it
 rocprofiler_add_integration_execute_test(
     rocprofv3-test-attachment-attach-once
     COMMAND
@@ -43,22 +38,22 @@ rocprofiler_add_integration_execute_test(
         ${CMAKE_CURRENT_BINARY_DIR} ${LOG_LEVEL} out
     DEPENDS rocprofiler-sdk::rocprofv3
     TIMEOUT 60
-    LABELS "integration-tests;attachment"
+    LABELS "attachment"
     DISABLED ${IS_DISABLED}
-    PRELOAD "${PRELOAD_ENV}"
+    PRELOAD "${ROCPROFILER_MEMCHECK_PRELOAD_ENV_VALUE}"
     ENVIRONMENT "${attachment-env}"
+    FAIL_REGULAR_EXPRESSION "ERROR|FATAL|${ROCPROFILER_DEFAULT_FAIL_REGEX}"
     SKIP_REGULAR_EXPRESSION "This test is skipped."
-    FIXTURES_SETUP rocprofv3-test-attachment-attach-once
-    FAIL_REGULAR_EXPRESSION "ERROR|FATAL|${ROCPROFILER_DEFAULT_FAIL_REGEX}")
+    FIXTURES_SETUP rocprofv3-test-attachment-attach-once)
 
 # Validate the output from the attached profiling
 rocprofiler_add_integration_validate_test(
-    rocprofv3-test-attachment-attach-once-csv
+    rocprofv3-test-attachment-attach-once
     TEST_PATHS validate.py
     COPY conftest.py
     CONFIG pytest.ini
     TIMEOUT 30
-    LABELS "integration-tests;attachment"
+    LABELS "attachment"
     DISABLED ${IS_DISABLED}
     SKIP_REGULAR_EXPRESSION "SKIPPED"
     FIXTURES_REQUIRED rocprofv3-test-attachment-attach-once
@@ -70,26 +65,7 @@ rocprofiler_add_integration_validate_test(
          ${CMAKE_CURRENT_BINARY_DIR}/attachment-output/out_memory_copy_trace.csv
          --agent-input
          ${CMAKE_CURRENT_BINARY_DIR}/attachment-output/out_agent_info.csv
-         --skip-if
-         ${CMAKE_CURRENT_BINARY_DIR}/attachment-output/skipped)
-
-rocprofiler_add_integration_validate_test(
-    rocprofv3-test-attachment-attach-once-json
-    TEST_PATHS validate.py
-    COPY conftest.py
-    CONFIG pytest.ini
-    TIMEOUT 30
-    LABELS "integration-tests;attachment"
-    DISABLED ${IS_DISABLED}
-    SKIP_REGULAR_EXPRESSION "SKIPPED"
-    FIXTURES_REQUIRED rocprofv3-test-attachment-attach-once
-    ARGS --kernel-input
-         ${CMAKE_CURRENT_BINARY_DIR}/attachment-output/out_results.json
-         --hsa-input
-         ${CMAKE_CURRENT_BINARY_DIR}/attachment-output/out_results.json
-         --memory-copy-input
-         ${CMAKE_CURRENT_BINARY_DIR}/attachment-output/out_results.json
-         --agent-input
+         --json-input
          ${CMAKE_CURRENT_BINARY_DIR}/attachment-output/out_results.json
          --skip-if
          ${CMAKE_CURRENT_BINARY_DIR}/attachment-output/skipped)

--- a/projects/rocprofiler-sdk/tests/rocprofv3/attachment/attach-once/CMakeLists.txt
+++ b/projects/rocprofiler-sdk/tests/rocprofv3/attachment/attach-once/CMakeLists.txt
@@ -11,7 +11,7 @@ project(
 find_package(rocprofiler-sdk REQUIRED)
 
 set(ROCPROFILER_MEMCHECK_TYPES "AddressSanitizer" "UndefinedBehaviorSanitizer"
-                               "ThreadSanitizer")
+                               "ThreadSanitizer" "LeakSanitizer")
 
 if(ROCPROFILER_MEMCHECK AND ROCPROFILER_MEMCHECK IN_LIST ROCPROFILER_MEMCHECK_TYPES)
     set(IS_DISABLED ON)
@@ -25,16 +25,11 @@ else()
     set(LOG_LEVEL "info")
 endif()
 
-set(PRELOAD_ENV "${ROCPROFILER_MEMCHECK_PRELOAD_ENV_VALUE}")
-
 set(attachment-env
-    "LD_LIBRARY_PATH=$<TARGET_FILE_DIR:rocprofiler-sdk::rocprofiler-sdk-shared-library>:$ENV{LD_LIBRARY_PATH}"
+    "LD_LIBRARY_PATH=$<TARGET_FILE_DIR:rocprofiler-sdk::rocprofiler-sdk-shared-library>:$ENV{LD_LIBRARY_PATH} AMD_LOG_LEVEL=7"
     )
 
-# Unconditionally disabled: intermittent failure caused by test app abort
-set(IS_DISABLED ON)
-
-# Test that launches the app and attaches to it (CSV format)
+# Test that launches the app and attaches to it
 rocprofiler_add_integration_execute_test(
     rocprofv3-test-attachment-attach-once
     COMMAND
@@ -43,13 +38,13 @@ rocprofiler_add_integration_execute_test(
         ${CMAKE_CURRENT_BINARY_DIR} ${LOG_LEVEL} out
     DEPENDS rocprofiler-sdk::rocprofv3
     TIMEOUT 60
-    LABELS "integration-tests;attachment"
+    LABELS "attachment"
     DISABLED ${IS_DISABLED}
-    PRELOAD "${PRELOAD_ENV}"
+    PRELOAD "${ROCPROFILER_MEMCHECK_PRELOAD_ENV_VALUE}"
     ENVIRONMENT "${attachment-env}"
+    FAIL_REGULAR_EXPRESSION "ERROR|FATAL|${ROCPROFILER_DEFAULT_FAIL_REGEX}"
     SKIP_REGULAR_EXPRESSION "This test is skipped."
-    FIXTURES_SETUP rocprofv3-test-attachment-attach-once
-    FAIL_REGULAR_EXPRESSION "ERROR|FATAL|${ROCPROFILER_DEFAULT_FAIL_REGEX}")
+    FIXTURES_SETUP rocprofv3-test-attachment-attach-once)
 
 # Validate the output from the attached profiling
 rocprofiler_add_integration_validate_test(
@@ -58,7 +53,7 @@ rocprofiler_add_integration_validate_test(
     COPY conftest.py
     CONFIG pytest.ini
     TIMEOUT 30
-    LABELS "integration-tests;attachment"
+    LABELS "attachment"
     DISABLED ${IS_DISABLED}
     SKIP_REGULAR_EXPRESSION "SKIPPED"
     FIXTURES_REQUIRED rocprofv3-test-attachment-attach-once
@@ -79,7 +74,7 @@ rocprofiler_add_integration_validate_test(
     COPY conftest.py
     CONFIG pytest.ini
     TIMEOUT 30
-    LABELS "integration-tests;attachment"
+    LABELS "attachment"
     DISABLED ${IS_DISABLED}
     SKIP_REGULAR_EXPRESSION "SKIPPED"
     FIXTURES_REQUIRED rocprofv3-test-attachment-attach-once

--- a/projects/rocprofiler-sdk/tests/rocprofv3/attachment/attach-once/CMakeLists.txt
+++ b/projects/rocprofiler-sdk/tests/rocprofv3/attachment/attach-once/CMakeLists.txt
@@ -26,7 +26,7 @@ else()
 endif()
 
 set(attachment-env
-    "LD_LIBRARY_PATH=$<TARGET_FILE_DIR:rocprofiler-sdk::rocprofiler-sdk-shared-library>:$ENV{LD_LIBRARY_PATH} AMD_LOG_LEVEL=7"
+    "LD_LIBRARY_PATH=$<TARGET_FILE_DIR:rocprofiler-sdk::rocprofiler-sdk-shared-library>:$ENV{LD_LIBRARY_PATH}"
     )
 
 # Test that launches the app and attaches to it
@@ -48,7 +48,7 @@ rocprofiler_add_integration_execute_test(
 
 # Validate the output from the attached profiling
 rocprofiler_add_integration_validate_test(
-    rocprofv3-test-attachment-attach-once-csv
+    rocprofv3-test-attachment-attach-once
     TEST_PATHS validate.py
     COPY conftest.py
     CONFIG pytest.ini
@@ -65,26 +65,7 @@ rocprofiler_add_integration_validate_test(
          ${CMAKE_CURRENT_BINARY_DIR}/attachment-output/out_memory_copy_trace.csv
          --agent-input
          ${CMAKE_CURRENT_BINARY_DIR}/attachment-output/out_agent_info.csv
-         --skip-if
-         ${CMAKE_CURRENT_BINARY_DIR}/attachment-output/skipped)
-
-rocprofiler_add_integration_validate_test(
-    rocprofv3-test-attachment-attach-once-json
-    TEST_PATHS validate.py
-    COPY conftest.py
-    CONFIG pytest.ini
-    TIMEOUT 30
-    LABELS "attachment"
-    DISABLED ${IS_DISABLED}
-    SKIP_REGULAR_EXPRESSION "SKIPPED"
-    FIXTURES_REQUIRED rocprofv3-test-attachment-attach-once
-    ARGS --kernel-input
-         ${CMAKE_CURRENT_BINARY_DIR}/attachment-output/out_results.json
-         --hsa-input
-         ${CMAKE_CURRENT_BINARY_DIR}/attachment-output/out_results.json
-         --memory-copy-input
-         ${CMAKE_CURRENT_BINARY_DIR}/attachment-output/out_results.json
-         --agent-input
+         --json-input
          ${CMAKE_CURRENT_BINARY_DIR}/attachment-output/out_results.json
          --skip-if
          ${CMAKE_CURRENT_BINARY_DIR}/attachment-output/skipped)

--- a/projects/rocprofiler-sdk/tests/rocprofv3/attachment/attach-once/conftest.py
+++ b/projects/rocprofiler-sdk/tests/rocprofv3/attachment/attach-once/conftest.py
@@ -22,7 +22,6 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 
-import csv
 import json
 import pytest
 import os
@@ -32,61 +31,14 @@ from rocprofiler_sdk.pytest_utils import collapse_dict_list
 
 
 def pytest_addoption(parser):
-    parser.addoption("--kernel-input", action="store", help="Kernel trace CSV input")
-    parser.addoption(
-        "--memory-copy-input", action="store", help="Memory copy trace CSV input"
-    )
-    parser.addoption("--hsa-input", action="store", help="HSA API trace CSV input")
-    parser.addoption("--agent-input", action="store", help="Agent info CSV input")
     parser.addoption("--json-input", action="store", help="Path to JSON output file")
     parser.addoption("--skip-if", action="store", help="Skip test if file exists")
-
-
-def get_csv_data(file_path):
-    with open(file_path, "r") as inp:
-        return [row for row in csv.DictReader(inp)]
 
 
 def _skip_if(request):
     skip_file = request.config.getoption("--skip-if")
     if skip_file and os.path.exists(skip_file):
         pytest.skip("Attach tests unavailable due to insufficient ptrace permissions")
-
-
-@pytest.fixture
-def kernel_input_data(request):
-    _skip_if(request)
-    filename = request.config.getoption("--kernel-input")
-    if not filename:
-        pytest.skip("--kernel-input not provided")
-    return get_csv_data(filename)
-
-
-@pytest.fixture
-def memory_copy_input_data(request):
-    _skip_if(request)
-    filename = request.config.getoption("--memory-copy-input")
-    if not filename:
-        pytest.skip("--memory-copy-input not provided")
-    return get_csv_data(filename)
-
-
-@pytest.fixture
-def hsa_input_data(request):
-    _skip_if(request)
-    filename = request.config.getoption("--hsa-input")
-    if not filename:
-        pytest.skip("--hsa-input not provided")
-    return get_csv_data(filename)
-
-
-@pytest.fixture
-def agent_info_input_data(request):
-    _skip_if(request)
-    filename = request.config.getoption("--agent-input")
-    if not filename:
-        pytest.skip("--agent-input not provided")
-    return get_csv_data(filename)
 
 
 @pytest.fixture

--- a/projects/rocprofiler-sdk/tests/rocprofv3/attachment/attach-once/conftest.py
+++ b/projects/rocprofiler-sdk/tests/rocprofv3/attachment/attach-once/conftest.py
@@ -27,220 +27,73 @@ import json
 import pytest
 import os
 
+from rocprofiler_sdk.pytest_utils.dotdict import dotdict
+from rocprofiler_sdk.pytest_utils import collapse_dict_list
+
 
 def pytest_addoption(parser):
-    parser.addoption("--kernel-input", action="store", help="Kernel trace input")
+    parser.addoption("--kernel-input", action="store", help="Kernel trace CSV input")
     parser.addoption(
-        "--memory-copy-input", action="store", help="Memory copy trace input"
+        "--memory-copy-input", action="store", help="Memory copy trace CSV input"
     )
-    parser.addoption("--hsa-input", action="store", help="HSA API trace input")
-    parser.addoption("--agent-input", action="store", help="Agent info input")
+    parser.addoption("--hsa-input", action="store", help="HSA API trace CSV input")
+    parser.addoption("--agent-input", action="store", help="Agent info CSV input")
+    parser.addoption("--json-input", action="store", help="Path to JSON output file")
     parser.addoption("--skip-if", action="store", help="Skip test if file exists")
 
 
-def get_data(request, field, section_name):
-    """Load data from JSON or CSV file and extract specific section"""
-    inp_data = request.config.getoption(field)
-    if not inp_data:
-        return []
-
-    # Determine file format by extension
-    if inp_data.lower().endswith(".json"):
-        return get_json_data(inp_data, section_name)
-    else:
-        return get_csv_data(inp_data)
-
-
-def get_json_data(file_path, section_name):
-    """Load data from JSON file and extract specific section"""
-    try:
-        with open(file_path, "r") as inp:
-            data = json.load(inp)
-
-        # Navigate through the JSON structure to find buffer records
-        if "rocprofiler-sdk-tool" in data and len(data["rocprofiler-sdk-tool"]) > 0:
-            tool_data = data["rocprofiler-sdk-tool"][0]
-
-            # Handle buffer records (dictionary format)
-            if "buffer_records" in tool_data:
-                buffer_records = tool_data["buffer_records"]
-                if section_name in buffer_records:
-                    # buffer_records is a dict where keys are section names and values are lists of records
-                    records = buffer_records[section_name]
-                    if isinstance(records, list):
-                        # Pass additional data for kernel name lookup
-                        kernel_symbols = tool_data.get("kernel_symbols", [])
-                        return convert_json_records_to_csv_format(
-                            records, section_name, kernel_symbols
-                        )
-
-            # Handle agent data specially
-            if section_name == "agent_info" and "agents" in tool_data:
-                agents = tool_data["agents"]
-                return convert_agents_to_csv_format(agents)
-
-        return []
-
-    except (json.JSONDecodeError, KeyError, FileNotFoundError) as e:
-        print(f"Error loading JSON file {file_path}: {e}")
-        return []
-
-
-def convert_json_records_to_csv_format(records, section_name, kernel_symbols=None):
-    """Convert JSON records to CSV-like dictionary format"""
-    csv_records = []
-
-    # Create kernel symbol lookup
-    kernel_lookup = {}
-    if kernel_symbols:
-        for symbol in kernel_symbols:
-            kernel_lookup[symbol.get("kernel_id")] = symbol.get(
-                "truncated_kernel_name", ""
-            )
-
-    for record in records:
-        csv_record = {}
-
-        if section_name == "kernel_dispatch":
-            # Map JSON fields to CSV field names for kernel dispatch
-            csv_record["Kind"] = "KERNEL_DISPATCH"
-            # Extract kernel name from kernel symbols
-            dispatch_info = record.get("dispatch_info", {})
-            kernel_id = dispatch_info.get("kernel_id", 0)
-            csv_record["Kernel_Name"] = kernel_lookup.get(
-                kernel_id, f"kernel_{kernel_id}"
-            )
-
-            # Extract queue and kernel IDs with handle lookup
-            queue_info = dispatch_info.get("queue_id", {})
-            csv_record["Queue_Id"] = str(
-                queue_info.get("handle", 0)
-                if isinstance(queue_info, dict)
-                else queue_info
-            )
-            csv_record["Stream_Id"] = dispatch_info.get("stream_id", {}).get("handle", 0)
-            csv_record["Thread_Id"] = record.get("thread_id", 0)
-            csv_record["Kernel_Id"] = str(kernel_id)
-
-            # Correlation ID with internal/external handling
-            corr_id = record.get("correlation_id", {})
-            if isinstance(corr_id, dict):
-                csv_record["Correlation_Id"] = str(corr_id.get("internal", 0))
-            else:
-                csv_record["Correlation_Id"] = str(corr_id)
-
-            csv_record["Start_Timestamp"] = str(record.get("start_timestamp", 0))
-            csv_record["End_Timestamp"] = str(record.get("end_timestamp", 0))
-            csv_record["Workgroup_Size_X"] = str(
-                dispatch_info.get("workgroup_size", {}).get("x", 0)
-            )
-            csv_record["Workgroup_Size_Y"] = str(
-                dispatch_info.get("workgroup_size", {}).get("y", 0)
-            )
-            csv_record["Workgroup_Size_Z"] = str(
-                dispatch_info.get("workgroup_size", {}).get("z", 0)
-            )
-            csv_record["Grid_Size_X"] = str(
-                dispatch_info.get("grid_size", {}).get("x", 0)
-            )
-            csv_record["Grid_Size_Y"] = str(
-                dispatch_info.get("grid_size", {}).get("y", 0)
-            )
-            csv_record["Grid_Size_Z"] = str(
-                dispatch_info.get("grid_size", {}).get("z", 0)
-            )
-
-        elif section_name == "memory_copy":
-            # Map JSON fields to CSV field names for memory copy
-            csv_record["Kind"] = "MEMORY_COPY"
-            # Determine direction based on src and dst agent ids
-            src_agent = record.get("src_agent_id", {}).get("handle", 0)
-            dst_agent = record.get("dst_agent_id", {}).get("handle", 0)
-            if src_agent != dst_agent:
-                csv_record["Direction"] = "H2D" if src_agent < dst_agent else "D2H"
-            else:
-                csv_record["Direction"] = "D2D"
-            # Get stream ID
-            csv_record["Stream_Id"] = record.get("stream_id", {}).get("handle", 0)
-
-            # Correlation ID handling
-            corr_id = record.get("correlation_id", {})
-            if isinstance(corr_id, dict):
-                csv_record["Correlation_Id"] = str(corr_id.get("internal", 0))
-            else:
-                csv_record["Correlation_Id"] = str(corr_id)
-
-            csv_record["Start_Timestamp"] = str(record.get("start_timestamp", 0))
-            csv_record["End_Timestamp"] = str(record.get("end_timestamp", 0))
-
-        elif section_name == "hsa_api":
-            # Map JSON fields to CSV field names for HSA API
-            # Simplified domain assignment based on common patterns
-            csv_record["Domain"] = "HSA_CORE_API"  # Most common domain
-            csv_record["Function"] = "hsa_memory_copy"  # Common function for testing
-
-            # Extract process ID from metadata
-            csv_record["Process_Id"] = (
-                "154739"  # Use thread_id as fallback for process_id
-            )
-            csv_record["Thread_Id"] = str(record.get("thread_id", 154739))
-            csv_record["Start_Timestamp"] = str(record.get("start_timestamp", 0))
-            csv_record["End_Timestamp"] = str(record.get("end_timestamp", 0))
-
-        csv_records.append(csv_record)
-
-    return csv_records
-
-
-def convert_agents_to_csv_format(agents):
-    """Convert JSON agent data to CSV-like dictionary format"""
-    csv_records = []
-
-    for agent in agents:
-        csv_record = {}
-        csv_record["Agent_Type"] = "CPU" if agent.get("type") == 1 else "GPU"
-        csv_record["Cpu_Cores_Count"] = str(agent.get("cpu_cores_count", 0))
-        csv_record["Simd_Count"] = str(agent.get("simd_count", 0))
-        csv_record["Max_Waves_Per_Simd"] = str(agent.get("max_waves_per_simd", 0))
-        csv_records.append(csv_record)
-
-    return csv_records
-
-
 def get_csv_data(file_path):
-    """Load data from CSV file"""
-    try:
-        with open(file_path, "r") as inp:
-            csv_reader = csv.DictReader(inp)
-            return [row for row in csv_reader]
-    except FileNotFoundError as e:
-        print(f"Error loading CSV file {file_path}: {e}")
-        return []
+    with open(file_path, "r") as inp:
+        return [row for row in csv.DictReader(inp)]
+
+
+def _skip_if(request):
+    skip_file = request.config.getoption("--skip-if")
+    if skip_file and os.path.exists(skip_file):
+        pytest.skip("Attach tests unavailable due to insufficient ptrace permissions")
 
 
 @pytest.fixture
 def kernel_input_data(request):
-    if os.path.exists(request.config.getoption("--skip-if")):
-        pytest.skip("Attach tests unavailable due to insufficient ptrace permissions")
-    return get_data(request, "--kernel-input", "kernel_dispatch")
+    _skip_if(request)
+    filename = request.config.getoption("--kernel-input")
+    if not filename:
+        pytest.skip("--kernel-input not provided")
+    return get_csv_data(filename)
 
 
 @pytest.fixture
 def memory_copy_input_data(request):
-    if os.path.exists(request.config.getoption("--skip-if")):
-        pytest.skip("Attach tests unavailable due to insufficient ptrace permissions")
-    return get_data(request, "--memory-copy-input", "memory_copy")
+    _skip_if(request)
+    filename = request.config.getoption("--memory-copy-input")
+    if not filename:
+        pytest.skip("--memory-copy-input not provided")
+    return get_csv_data(filename)
 
 
 @pytest.fixture
 def hsa_input_data(request):
-    if os.path.exists(request.config.getoption("--skip-if")):
-        pytest.skip("Attach tests unavailable due to insufficient ptrace permissions")
-    return get_data(request, "--hsa-input", "hsa_api")
+    _skip_if(request)
+    filename = request.config.getoption("--hsa-input")
+    if not filename:
+        pytest.skip("--hsa-input not provided")
+    return get_csv_data(filename)
 
 
 @pytest.fixture
 def agent_info_input_data(request):
-    if os.path.exists(request.config.getoption("--skip-if")):
-        pytest.skip("Attach tests unavailable due to insufficient ptrace permissions")
-    return get_data(request, "--agent-input", "agent_info")
+    _skip_if(request)
+    filename = request.config.getoption("--agent-input")
+    if not filename:
+        pytest.skip("--agent-input not provided")
+    return get_csv_data(filename)
+
+
+@pytest.fixture
+def json_data(request):
+    _skip_if(request)
+    filename = request.config.getoption("--json-input")
+    if not filename:
+        pytest.skip("--json-input not provided")
+    with open(filename, "r") as inp:
+        return dotdict(collapse_dict_list(json.load(inp)))

--- a/projects/rocprofiler-sdk/tests/rocprofv3/attachment/attach-once/conftest.py
+++ b/projects/rocprofiler-sdk/tests/rocprofv3/attachment/attach-once/conftest.py
@@ -43,8 +43,12 @@ def pytest_addoption(parser):
 
 
 def get_csv_data(file_path):
-    with open(file_path, "r") as inp:
-        return [row for row in csv.DictReader(inp)]
+    try:
+        with open(file_path, "r") as inp:
+            return [row for row in csv.DictReader(inp)]
+    except FileNotFoundError as e:
+        print(f"Error loading CSV file {file_path}: {e}")
+        return []
 
 
 def _skip_if(request):
@@ -95,5 +99,9 @@ def json_data(request):
     filename = request.config.getoption("--json-input")
     if not filename:
         pytest.skip("--json-input not provided")
-    with open(filename, "r") as inp:
-        return dotdict(collapse_dict_list(json.load(inp)))
+    try:
+        with open(filename, "r") as inp:
+            return dotdict(collapse_dict_list(json.load(inp)))
+    except FileNotFoundError as e:
+        print(f"Error loading JSON file {filename}: {e}")
+        return None

--- a/projects/rocprofiler-sdk/tests/rocprofv3/attachment/attach-once/run_attachment_test_unified.sh
+++ b/projects/rocprofiler-sdk/tests/rocprofv3/attachment/attach-once/run_attachment_test_unified.sh
@@ -24,6 +24,23 @@
 
 set -e
 
+wait_for_attach_ready() {
+    local pid=$1
+    local max_wait=30
+    local elapsed=0
+    echo "Waiting for rocp-bg-attach thread in PID ${pid}..."
+    while [ $elapsed -lt $max_wait ]; do
+        if grep -ql "rocp-bg-attach" /proc/${pid}/task/*/comm 2>/dev/null; then
+            echo "Attachment ready (${elapsed}s elapsed)"
+            return 0
+        fi
+        sleep 1
+        elapsed=$((elapsed + 1))
+    done
+    echo "Timed out after ${max_wait}s waiting for rocp-bg-attach thread"
+    return 1
+}
+
 # Arguments
 TEST_APP=$1
 ROCPROFV3=$2
@@ -35,9 +52,6 @@ OUTPUT_FILENAME=${5:-out}
 export ROCP_TOOL_ATTACH=1
 
 OUTPUT_SUBDIR="attachment-output"
-# For CSV, we don't require specific files since different traces may or may not be generated
-# We'll just check if at least one CSV file was created
-EXPECTED_FILES=("${OUTPUT_FILENAME}_results.json" "${OUTPUT_FILENAME}_results.db")
 OUTPUT_FORMAT="csv json rocpd"
 
 # Clean up any existing output
@@ -59,15 +73,13 @@ if [ -e /proc/sys/kernel/yama/ptrace_scope ]                             \
     exit 0
 fi
 
-echo "Starting attachment test (${OUTPUT_FORMAT} format)..."
-
 # Start the test application in the background
 echo "Launching test application: ${TEST_APP}"
 LD_PRELOAD=${ROCPROF_PRELOAD} ${TEST_APP} &
 APP_PID=$!
 
-# Wait a moment for the application to start
-sleep 1
+# Wait for the application to be ready for attachment
+wait_for_attach_ready $APP_PID
 
 # Check if the application is still running
 if ! kill -0 $APP_PID 2>/dev/null; then
@@ -83,24 +95,30 @@ if [ ! -f "${ROCPROFV3}" ]; then
     exit 1
 fi
 
-echo "Attaching profiler to PID $APP_PID for 5 seconds (${OUTPUT_FORMAT} format)..."
+# Attachment
+echo "Attaching profiler to PID $APP_PID for 500 milliseconds..."
 
-# Output the command and environment for debugging
-echo "===== COMMAND TO EXECUTE ====="
-echo "${ROCPROFV3} --attach $APP_PID --attach-duration-msec 5000 -s -f ${OUTPUT_FORMAT} --stats --summary --group-by-queue --sync-output -d ${OUTPUT_DIR}/${OUTPUT_SUBDIR} --log-level ${LOG_LEVEL} -o ${OUTPUT_FILENAME:-out}"
-echo ""
-echo "===== ENVIRONMENT VARIABLES ====="
-env | grep "^ROCPROF" | sort
-echo "===== END ENVIRONMENT ====="
-echo ""
+# Run rocprofv3 with --attach option.
+# No -o flag: the process uses the default %hostname%/%pid% naming.
+LD_PRELOAD=${ROCPROF_PRELOAD} ${ROCPROFV3} --attach $APP_PID --attach-duration-msec 500 -s -f ${OUTPUT_FORMAT} --stats --summary --group-by-queue --attach-sync-output -d ${OUTPUT_DIR}/${OUTPUT_SUBDIR} --log-level ${LOG_LEVEL} &
+ROCPROF_PID=$!
+echo "rocprofv3 PID: $ROCPROF_PID"
 
-# Run rocprofv3 with --attach option
-LD_PRELOAD=${ROCPROF_PRELOAD} ${ROCPROFV3} --attach $APP_PID --attach-duration-msec 5000 -s -f ${OUTPUT_FORMAT} --stats --summary --group-by-queue --sync-output -d ${OUTPUT_DIR}/${OUTPUT_SUBDIR} --log-level ${LOG_LEVEL} -o ${OUTPUT_FILENAME:-out}
+# Wait for the attach process to complete
+wait $ROCPROF_PID
+ROCPROF_EXIT_CODE=$?
 
-echo "${OUTPUT_FORMAT} profiler detached successfully"
+if [ $ROCPROF_EXIT_CODE -ne 0 ]; then
+    echo "rocprofv3_attach test failed with exit code $ROCPROF_EXIT_CODE"
+    kill $APP_PID 2>/dev/null
+    exit 1
+fi
 
-# Wait for the application to finish
-echo "Waiting for application to complete..."
+echo "Profiler detached successfully"
+
+# End the running application
+echo "Sending SIGINT to application..."
+kill -2 $APP_PID 2>/dev/null
 wait $APP_PID
 APP_EXIT_CODE=$?
 
@@ -111,9 +129,8 @@ fi
 
 echo "Test application completed successfully"
 
-# Files should be created directly in the expected location with the specified output name
-echo "Checking for generated ${OUTPUT_FORMAT} output files..."
-ls -la ${OUTPUT_DIR}/${OUTPUT_SUBDIR}/
+echo "Checking for generated output files..."
+ls -laR ${OUTPUT_DIR}/${OUTPUT_SUBDIR}/
 
 # Check if expected output files were created
 # For CSV format, check if at least one CSV file was generated
@@ -125,13 +142,36 @@ else
     echo "Found $CSV_COUNT CSV file(s)"
 fi
 
-# For other formats, check specific expected files
-for expected_file in "${EXPECTED_FILES[@]}"; do
+# Locate the process's output files. With default naming the files are under a
+# subdirectory named after the hostname and contain the PID in the filename,
+# e.g. attachment-output/<hostname>/<pid>_results.json
+APP_JSON=$(find ${OUTPUT_DIR}/${OUTPUT_SUBDIR}/ -name "${APP_PID}_results.json" | head -1)
+if [ -z "$APP_JSON" ]; then
+    echo "Error: Could not find app (PID ${APP_PID}) JSON output in ${OUTPUT_DIR}/${OUTPUT_SUBDIR}/"
+    exit 1
+fi
+echo "Found app JSON output: $APP_JSON"
+
+APP_OUTPUT_DIR=$(dirname "$APP_JSON")
+
+# Rename output files to well-known names so CMakeLists.txt can reference them
+# without knowing the hostname or PID at configure time.
+for src in "${APP_OUTPUT_DIR}/${APP_PID}"_*.csv "${APP_OUTPUT_DIR}/${APP_PID}"_*.json "${APP_OUTPUT_DIR}/${APP_PID}"_*.db; do
+    [ -f "$src" ] || continue
+    dst_name=$(basename "$src" | sed "s/^${APP_PID}_/${OUTPUT_FILENAME}_/")
+    cp "$src" "${OUTPUT_DIR}/${OUTPUT_SUBDIR}/${dst_name}"
+    echo "Copied $(basename $src) -> ${dst_name}"
+done
+
+# Verify the well-known files exist
+for expected_file in "${OUTPUT_FILENAME}_results.json" "${OUTPUT_FILENAME}_results.db"; do
     if [ ! -f "${OUTPUT_DIR}/${OUTPUT_SUBDIR}/${expected_file}" ]; then
         echo "Error: Expected output file ${OUTPUT_DIR}/${OUTPUT_SUBDIR}/${expected_file} not found"
         exit 1
+    else
+        echo "Found ${expected_file}"
     fi
 done
 
-echo "Attachment ${OUTPUT_FORMAT} test completed successfully"
+echo "Attachment test completed successfully"
 exit 0

--- a/projects/rocprofiler-sdk/tests/rocprofv3/attachment/attach-once/run_attachment_test_unified.sh
+++ b/projects/rocprofiler-sdk/tests/rocprofv3/attachment/attach-once/run_attachment_test_unified.sh
@@ -52,7 +52,7 @@ OUTPUT_FILENAME=${5:-out}
 export ROCP_TOOL_ATTACH=1
 
 OUTPUT_SUBDIR="attachment-output"
-OUTPUT_FORMAT="csv json rocpd"
+OUTPUT_FORMAT="json rocpd"
 
 # Clean up any existing output
 rm -rf ${OUTPUT_DIR}/${OUTPUT_SUBDIR}
@@ -133,13 +133,12 @@ echo "Checking for generated output files..."
 ls -laR ${OUTPUT_DIR}/${OUTPUT_SUBDIR}/
 
 # Check if expected output files were created
-# For CSV format, check if at least one CSV file was generated
-CSV_COUNT=$(find ${OUTPUT_DIR}/${OUTPUT_SUBDIR}/ -name "*.csv" | wc -l)
-if [ $CSV_COUNT -eq 0 ]; then
-    echo "Error: No CSV files were generated"
+JSON_COUNT=$(find ${OUTPUT_DIR}/${OUTPUT_SUBDIR}/ -name "*.json" | wc -l)
+if [ $JSON_COUNT -eq 0 ]; then
+    echo "Error: No JSON files were generated"
     exit 1
 else
-    echo "Found $CSV_COUNT CSV file(s)"
+    echo "Found $JSON_COUNT JSON file(s)"
 fi
 
 # Locate the process's output files. With default naming the files are under a
@@ -156,7 +155,7 @@ APP_OUTPUT_DIR=$(dirname "$APP_JSON")
 
 # Rename output files to well-known names so CMakeLists.txt can reference them
 # without knowing the hostname or PID at configure time.
-for src in "${APP_OUTPUT_DIR}/${APP_PID}"_*.csv "${APP_OUTPUT_DIR}/${APP_PID}"_*.json "${APP_OUTPUT_DIR}/${APP_PID}"_*.db; do
+for src in "${APP_OUTPUT_DIR}/${APP_PID}"_*.json "${APP_OUTPUT_DIR}/${APP_PID}"_*.db; do
     [ -f "$src" ] || continue
     dst_name=$(basename "$src" | sed "s/^${APP_PID}_/${OUTPUT_FILENAME}_/")
     cp "$src" "${OUTPUT_DIR}/${OUTPUT_SUBDIR}/${dst_name}"

--- a/projects/rocprofiler-sdk/tests/rocprofv3/attachment/attach-once/run_attachment_test_unified.sh
+++ b/projects/rocprofiler-sdk/tests/rocprofv3/attachment/attach-once/run_attachment_test_unified.sh
@@ -35,8 +35,6 @@ OUTPUT_FILENAME=${5:-out}
 export ROCP_TOOL_ATTACH=1
 
 OUTPUT_SUBDIR="attachment-output"
-# For CSV, we don't require specific files since different traces may or may not be generated
-# We'll just check if at least one CSV file was created
 EXPECTED_FILES=("${OUTPUT_FILENAME}_results.json" "${OUTPUT_FILENAME}_results.db")
 OUTPUT_FORMAT="csv json rocpd"
 
@@ -58,8 +56,6 @@ if [ -e /proc/sys/kernel/yama/ptrace_scope ]                             \
     touch ${OUTPUT_DIR}/${OUTPUT_SUBDIR}/skipped
     exit 0
 fi
-
-echo "Starting attachment test (${OUTPUT_FORMAT} format)..."
 
 # Start the test application in the background
 echo "Launching test application: ${TEST_APP}"
@@ -83,24 +79,29 @@ if [ ! -f "${ROCPROFV3}" ]; then
     exit 1
 fi
 
-echo "Attaching profiler to PID $APP_PID for 5 seconds (${OUTPUT_FORMAT} format)..."
-
-# Output the command and environment for debugging
-echo "===== COMMAND TO EXECUTE ====="
-echo "${ROCPROFV3} --attach $APP_PID --attach-duration-msec 5000 -s -f ${OUTPUT_FORMAT} --stats --summary --group-by-queue --sync-output -d ${OUTPUT_DIR}/${OUTPUT_SUBDIR} --log-level ${LOG_LEVEL} -o ${OUTPUT_FILENAME:-out}"
-echo ""
-echo "===== ENVIRONMENT VARIABLES ====="
-env | grep "^ROCPROF" | sort
-echo "===== END ENVIRONMENT ====="
-echo ""
+# Attachment
+echo "Attaching profiler to PID $APP_PID for 500 milliseconds..."
 
 # Run rocprofv3 with --attach option
-LD_PRELOAD=${ROCPROF_PRELOAD} ${ROCPROFV3} --attach $APP_PID --attach-duration-msec 5000 -s -f ${OUTPUT_FORMAT} --stats --summary --group-by-queue --sync-output -d ${OUTPUT_DIR}/${OUTPUT_SUBDIR} --log-level ${LOG_LEVEL} -o ${OUTPUT_FILENAME:-out}
+LD_PRELOAD=${ROCPROF_PRELOAD} ${ROCPROFV3} --attach $APP_PID --attach-duration-msec 500 -s -f ${OUTPUT_FORMAT} --stats --summary --group-by-queue --attach-sync-output -d ${OUTPUT_DIR}/${OUTPUT_SUBDIR} --log-level ${LOG_LEVEL} -o ${OUTPUT_FILENAME:-out} &
+ROCPROF_PID=$!
+echo "rocprofv3 PID: $ROCPROF_PID"
 
-echo "${OUTPUT_FORMAT} profiler detached successfully"
+# Wait for the attach process to complete
+wait $ROCPROF_PID
+ROCPROF_EXIT_CODE=$?
 
-# Wait for the application to finish
-echo "Waiting for application to complete..."
+if [ $ROCPROF_EXIT_CODE -ne 0 ]; then
+    echo "rocprofv3_attach test failed with exit code $ROCPROF_EXIT_CODE"
+    kill $APP_PID 2>/dev/null
+    exit 1
+fi
+
+echo "Profiler detached successfully"
+
+# End the running application
+echo "Sending SIGINT to application..."
+kill -2 $APP_PID 2>/dev/null
 wait $APP_PID
 APP_EXIT_CODE=$?
 
@@ -130,8 +131,10 @@ for expected_file in "${EXPECTED_FILES[@]}"; do
     if [ ! -f "${OUTPUT_DIR}/${OUTPUT_SUBDIR}/${expected_file}" ]; then
         echo "Error: Expected output file ${OUTPUT_DIR}/${OUTPUT_SUBDIR}/${expected_file} not found"
         exit 1
+    else
+        echo "Found ${expected_file}"
     fi
 done
 
-echo "Attachment ${OUTPUT_FORMAT} test completed successfully"
+echo "Attachment test completed successfully"
 exit 0

--- a/projects/rocprofiler-sdk/tests/rocprofv3/attachment/attach-once/run_attachment_test_unified.sh
+++ b/projects/rocprofiler-sdk/tests/rocprofv3/attachment/attach-once/run_attachment_test_unified.sh
@@ -24,6 +24,23 @@
 
 set -e
 
+wait_for_attach_ready() {
+    local pid=$1
+    local max_wait=30
+    local elapsed=0
+    echo "Waiting for rocp-bg-attach thread in PID ${pid}..."
+    while [ $elapsed -lt $max_wait ]; do
+        if grep -ql "rocp-bg-attach" /proc/${pid}/task/*/comm 2>/dev/null; then
+            echo "Attachment ready (${elapsed}s elapsed)"
+            return 0
+        fi
+        sleep 1
+        elapsed=$((elapsed + 1))
+    done
+    echo "Timed out after ${max_wait}s waiting for rocp-bg-attach thread"
+    return 1
+}
+
 # Arguments
 TEST_APP=$1
 ROCPROFV3=$2
@@ -35,7 +52,6 @@ OUTPUT_FILENAME=${5:-out}
 export ROCP_TOOL_ATTACH=1
 
 OUTPUT_SUBDIR="attachment-output"
-EXPECTED_FILES=("${OUTPUT_FILENAME}_results.json" "${OUTPUT_FILENAME}_results.db")
 OUTPUT_FORMAT="csv json rocpd"
 
 # Clean up any existing output
@@ -62,8 +78,8 @@ echo "Launching test application: ${TEST_APP}"
 LD_PRELOAD=${ROCPROF_PRELOAD} ${TEST_APP} &
 APP_PID=$!
 
-# Wait a moment for the application to start
-sleep 1
+# Wait for the application to be ready for attachment
+wait_for_attach_ready $APP_PID
 
 # Check if the application is still running
 if ! kill -0 $APP_PID 2>/dev/null; then
@@ -82,8 +98,9 @@ fi
 # Attachment
 echo "Attaching profiler to PID $APP_PID for 500 milliseconds..."
 
-# Run rocprofv3 with --attach option
-LD_PRELOAD=${ROCPROF_PRELOAD} ${ROCPROFV3} --attach $APP_PID --attach-duration-msec 500 -s -f ${OUTPUT_FORMAT} --stats --summary --group-by-queue --attach-sync-output -d ${OUTPUT_DIR}/${OUTPUT_SUBDIR} --log-level ${LOG_LEVEL} -o ${OUTPUT_FILENAME:-out} &
+# Run rocprofv3 with --attach option.
+# No -o flag: the process uses the default %hostname%/%pid% naming.
+LD_PRELOAD=${ROCPROF_PRELOAD} ${ROCPROFV3} --attach $APP_PID --attach-duration-msec 500 -s -f ${OUTPUT_FORMAT} --stats --summary --group-by-queue --attach-sync-output -d ${OUTPUT_DIR}/${OUTPUT_SUBDIR} --log-level ${LOG_LEVEL} &
 ROCPROF_PID=$!
 echo "rocprofv3 PID: $ROCPROF_PID"
 
@@ -112,9 +129,8 @@ fi
 
 echo "Test application completed successfully"
 
-# Files should be created directly in the expected location with the specified output name
-echo "Checking for generated ${OUTPUT_FORMAT} output files..."
-ls -la ${OUTPUT_DIR}/${OUTPUT_SUBDIR}/
+echo "Checking for generated output files..."
+ls -laR ${OUTPUT_DIR}/${OUTPUT_SUBDIR}/
 
 # Check if expected output files were created
 # For CSV format, check if at least one CSV file was generated
@@ -126,8 +142,29 @@ else
     echo "Found $CSV_COUNT CSV file(s)"
 fi
 
-# For other formats, check specific expected files
-for expected_file in "${EXPECTED_FILES[@]}"; do
+# Locate the process's output files. With default naming the files are under a
+# subdirectory named after the hostname and contain the PID in the filename,
+# e.g. attachment-output/<hostname>/<pid>_results.json
+APP_JSON=$(find ${OUTPUT_DIR}/${OUTPUT_SUBDIR}/ -name "${APP_PID}_results.json" | head -1)
+if [ -z "$APP_JSON" ]; then
+    echo "Error: Could not find app (PID ${APP_PID}) JSON output in ${OUTPUT_DIR}/${OUTPUT_SUBDIR}/"
+    exit 1
+fi
+echo "Found app JSON output: $APP_JSON"
+
+APP_OUTPUT_DIR=$(dirname "$APP_JSON")
+
+# Rename output files to well-known names so CMakeLists.txt can reference them
+# without knowing the hostname or PID at configure time.
+for src in "${APP_OUTPUT_DIR}/${APP_PID}"_*.csv "${APP_OUTPUT_DIR}/${APP_PID}"_*.json "${APP_OUTPUT_DIR}/${APP_PID}"_*.db; do
+    [ -f "$src" ] || continue
+    dst_name=$(basename "$src" | sed "s/^${APP_PID}_/${OUTPUT_FILENAME}_/")
+    cp "$src" "${OUTPUT_DIR}/${OUTPUT_SUBDIR}/${dst_name}"
+    echo "Copied $(basename $src) -> ${dst_name}"
+done
+
+# Verify the well-known files exist
+for expected_file in "${OUTPUT_FILENAME}_results.json" "${OUTPUT_FILENAME}_results.db"; do
     if [ ! -f "${OUTPUT_DIR}/${OUTPUT_SUBDIR}/${expected_file}" ]; then
         echo "Error: Expected output file ${OUTPUT_DIR}/${OUTPUT_SUBDIR}/${expected_file} not found"
         exit 1

--- a/projects/rocprofiler-sdk/tests/rocprofv3/attachment/attach-once/validate.py
+++ b/projects/rocprofiler-sdk/tests/rocprofv3/attachment/attach-once/validate.py
@@ -26,124 +26,9 @@ import sys
 import pytest
 
 
-def test_attachment_kernel_trace(kernel_input_data):
-    """Verify that kernel traces were captured during attachment."""
-
-    # We should have captured some kernel dispatches
-    assert len(kernel_input_data) > 0, "No kernel dispatches captured during attachment"
-
-    # The test app launches a kernel called "simple_kernel"
-    kernel_names = [row["Kernel_Name"] for row in kernel_input_data]
-
-    # Check that we captured the simple_kernel
-    simple_kernel_found = any("simple_kernel" in name for name in kernel_names)
-    assert (
-        simple_kernel_found
-    ), f"Expected 'simple_kernel' not found in kernel names: {kernel_names}"
-
-    kernel_threads = set()
-    kernel_streams = set()
-    NUM_KERNEL_THREADS = 8
-    expected_stream_ids = set([i for i in range(1, 9)])
-
-    # Verify basic kernel properties
-    for row in kernel_input_data:
-        if "simple_kernel" in row["Kernel_Name"]:
-            assert "Stream_Id" in row
-            assert "Thread_Id" in row
-            assert row["Kind"] == "KERNEL_DISPATCH"
-            assert int(row["Queue_Id"]) > 0
-            assert int(row["Kernel_Id"]) > 0
-            assert int(row["Correlation_Id"]) > 0
-            assert int(row["End_Timestamp"]) >= int(row["Start_Timestamp"])
-
-            # Verify kernel dimensions (from the test app)
-            assert int(row["Workgroup_Size_X"]) == 256  # threads_per_block
-            assert int(row["Workgroup_Size_Y"]) == 1
-            assert int(row["Workgroup_Size_Z"]) == 1
-
-            assert int(row["Grid_Size_X"]) >= 1
-            assert int(row["Grid_Size_Y"]) >= 1
-            assert int(row["Grid_Size_Z"]) >= 1
-
-            thread_id = int(row["Thread_Id"])
-            stream_id = int(row["Stream_Id"])
-            kernel_threads.add(thread_id)
-            kernel_streams.add(stream_id)
-
-    # Exactly 8 streams and 8 threads
-    assert len(kernel_threads) == NUM_KERNEL_THREADS
-    # Readd when JSON conversion is redone
-    # assert kernel_streams == expected_stream_ids
-
-
-def test_attachment_memory_copy_trace(memory_copy_input_data):
-    """Verify that memory copy operations were captured during attachment."""
-
-    # We should have captured memory copies (HtoD and DtoH)
-    assert (
-        len(memory_copy_input_data) > 0
-    ), "No memory copy operations captured during attachment"
-
-    host_to_device_count = 0
-    device_to_host_count = 0
-    memory_copy_streams = set()
-    expected_stream_ids = set([i for i in range(1, 9)])
-
-    for row in memory_copy_input_data:
-        assert "Stream_Id" in row
-        assert row["Kind"] == "MEMORY_COPY"
-        assert int(row["Correlation_Id"]) > 0
-        assert int(row["End_Timestamp"]) >= int(row["Start_Timestamp"])
-
-        # Count the direction of memory copies
-        if "MEMORY_COPY_HOST_TO_DEVICE" in row["Direction"] or "H2D" in row["Direction"]:
-            host_to_device_count += 1
-        elif (
-            "MEMORY_COPY_DEVICE_TO_HOST" in row["Direction"] or "D2H" in row["Direction"]
-        ):
-            device_to_host_count += 1
-
-        stream_id = int(row["Stream_Id"])
-        memory_copy_streams.add(stream_id)
-
-    # We should have both H2D and D2H copies
-    assert host_to_device_count > 0, "No host-to-device memory copies captured"
-    assert device_to_host_count > 0, "No device-to-host memory copies captured"
-    # Exactly 8 streams
-    memory_copy_streams == expected_stream_ids
-
-
-def test_attachment_hsa_api_trace(hsa_input_data):
-    """Verify that HSA API calls were captured during attachment."""
-
-    # Should have some HSA API calls
-    assert len(hsa_input_data) > 0, "No HSA API calls captured during attachment"
-
-    functions = []
-    for row in hsa_input_data:
-        assert row["Domain"] in (
-            "HSA_CORE_API",
-            "HSA_AMD_EXT_API",
-            "HSA_IMAGE_EXT_API",
-            "HSA_FINALIZE_EXT_API",
-        )
-        assert int(row["Process_Id"]) > 0
-        assert int(row["Thread_Id"]) > 0
-        assert int(row["End_Timestamp"]) >= int(row["Start_Timestamp"])
-        functions.append(row["Function"])
-
-    assert any(
-        "memory" in func.lower() for func in functions
-    ), "No memory-related HSA functions captured"
-
-
 def test_agent_info(agent_info_input_data):
-    """Verify agent information is captured correctly."""
-
     assert len(agent_info_input_data) > 0, "No agent information captured"
 
-    cpu_count = 0
     gpu_count = 0
 
     for row in agent_info_input_data:
@@ -151,7 +36,6 @@ def test_agent_info(agent_info_input_data):
         assert agent_type in ("CPU", "GPU")
 
         if agent_type == "CPU":
-            cpu_count += 1
             assert int(row["Cpu_Cores_Count"]) > 0
             assert int(row["Simd_Count"]) == 0
             assert int(row["Max_Waves_Per_Simd"]) == 0
@@ -161,8 +45,213 @@ def test_agent_info(agent_info_input_data):
             assert int(row["Simd_Count"]) > 0
             assert int(row["Max_Waves_Per_Simd"]) > 0
 
-    # Should have at least one GPU for the test
     assert gpu_count > 0, "No GPU agents found"
+
+
+def test_attachment_kernel_trace(kernel_input_data):
+    assert len(kernel_input_data) > 0, "No kernel dispatches captured during attachment"
+
+    simple_kernel_found = False
+    kernel_threads = set()
+
+    for row in kernel_input_data:
+        assert row["Kind"] == "KERNEL_DISPATCH"
+        assert int(row["Queue_Id"]) > 0
+        assert int(row["Correlation_Id"]) > 0
+        assert int(row["End_Timestamp"]) >= int(row["Start_Timestamp"])
+
+        if "simple_kernel" in row["Kernel_Name"]:
+            simple_kernel_found = True
+            assert int(row["Kernel_Id"]) > 0
+            assert int(row["Workgroup_Size_X"]) == 256
+            assert int(row["Workgroup_Size_Y"]) == 1
+            assert int(row["Workgroup_Size_Z"]) == 1
+            assert int(row["Grid_Size_X"]) >= 1
+            assert int(row["Grid_Size_Y"]) >= 1
+            assert int(row["Grid_Size_Z"]) >= 1
+            kernel_threads.add(int(row["Thread_Id"]))
+
+    assert simple_kernel_found, "Expected 'simple_kernel' not found in kernel dispatches"
+    assert (
+        len(kernel_threads) == 8
+    ), f"Expected 8 unique threads, got {len(kernel_threads)}"
+
+
+def test_attachment_memory_copy_trace(memory_copy_input_data):
+    assert len(memory_copy_input_data) > 0, "No memory copy operations captured"
+
+    host_to_device_count = 0
+    device_to_host_count = 0
+
+    for row in memory_copy_input_data:
+        assert row["Kind"] == "MEMORY_COPY"
+        assert int(row["Correlation_Id"]) > 0
+        assert int(row["End_Timestamp"]) >= int(row["Start_Timestamp"])
+
+        direction = row["Direction"]
+        if "HOST_TO_DEVICE" in direction or "H2D" in direction:
+            host_to_device_count += 1
+        elif "DEVICE_TO_HOST" in direction or "D2H" in direction:
+            device_to_host_count += 1
+
+    assert host_to_device_count > 0, "No host-to-device memory copies captured"
+    assert device_to_host_count > 0, "No device-to-host memory copies captured"
+
+
+def test_attachment_hsa_api_trace(hsa_input_data):
+    assert len(hsa_input_data) > 0, "No HSA API calls captured during attachment"
+
+    valid_domains = (
+        "HSA_CORE_API",
+        "HSA_AMD_EXT_API",
+        "HSA_IMAGE_EXT_API",
+        "HSA_FINALIZE_EXT_API",
+    )
+    functions = []
+    for row in hsa_input_data:
+        assert row["Domain"] in valid_domains, f"Unexpected HSA domain: {row['Domain']}"
+        assert int(row["Process_Id"]) > 0
+        assert int(row["Thread_Id"]) > 0
+        assert int(row["End_Timestamp"]) >= int(row["Start_Timestamp"])
+        functions.append(row["Function"])
+
+    assert any(
+        "memory" in f.lower() for f in functions
+    ), "No memory-related HSA functions captured"
+
+
+def test_agent_info_json(json_data):
+    data = json_data["rocprofiler-sdk-tool"]
+
+    gpu_count = 0
+    for agent in data["agents"]:
+        # type 1 = CPU, type 2 = GPU
+        assert agent["type"] in (1, 2)
+        if agent["type"] == 1:
+            assert agent["cpu_cores_count"] > 0
+            assert agent["simd_count"] == 0
+            assert agent["max_waves_per_simd"] == 0
+        else:
+            gpu_count += 1
+            assert agent["cpu_cores_count"] == 0
+            assert agent["simd_count"] > 0
+            assert agent["max_waves_per_simd"] > 0
+
+    assert gpu_count > 0, "No GPU agents found"
+
+
+def test_kernel_dispatch(json_data):
+    data = json_data["rocprofiler-sdk-tool"]
+
+    def get_kind_name(kind_id):
+        return data["strings"]["buffer_records"][kind_id]["kind"]
+
+    def get_kernel_name(kernel_id):
+        return data["kernel_symbols"][kernel_id]["formatted_kernel_name"]
+
+    kernel_dispatch_data = data["buffer_records"]["kernel_dispatch"]
+    assert (
+        len(kernel_dispatch_data) > 0
+    ), "No kernel dispatches captured during attachment"
+
+    simple_kernel_found = False
+    kernel_threads = set()
+
+    for dispatch in kernel_dispatch_data:
+        dispatch_info = dispatch["dispatch_info"]
+        kernel_name = get_kernel_name(dispatch_info["kernel_id"])
+
+        assert get_kind_name(dispatch["kind"]) == "KERNEL_DISPATCH"
+        assert dispatch["correlation_id"]["internal"] > 0
+        assert dispatch["end_timestamp"] >= dispatch["start_timestamp"]
+        assert dispatch_info["queue_id"]["handle"] > 0
+
+        if "simple_kernel" in kernel_name:
+            simple_kernel_found = True
+            assert dispatch_info["workgroup_size"]["x"] == 256
+            assert dispatch_info["workgroup_size"]["y"] == 1
+            assert dispatch_info["workgroup_size"]["z"] == 1
+            assert dispatch_info["grid_size"]["x"] >= 1
+            assert dispatch_info["grid_size"]["y"] >= 1
+            assert dispatch_info["grid_size"]["z"] >= 1
+            kernel_threads.add(dispatch["thread_id"])
+
+    assert simple_kernel_found, "Expected 'simple_kernel' not found in kernel dispatches"
+    assert (
+        len(kernel_threads) == 8
+    ), f"Expected 8 unique threads, got {len(kernel_threads)}"
+
+
+def test_memory_copy(json_data):
+    data = json_data["rocprofiler-sdk-tool"]
+
+    def get_kind_name(kind_id):
+        return data["strings"]["buffer_records"][kind_id]["kind"]
+
+    def get_agent(agent_id):
+        for agent in data["agents"]:
+            if agent["id"]["handle"] == agent_id["handle"]:
+                return agent
+        return None
+
+    memory_copy_data = data["buffer_records"]["memory_copy"]
+    assert (
+        len(memory_copy_data) > 0
+    ), "No memory copy operations captured during attachment"
+
+    host_to_device_count = 0
+    device_to_host_count = 0
+
+    for record in memory_copy_data:
+        assert get_kind_name(record["kind"]) == "MEMORY_COPY"
+        assert record["correlation_id"]["internal"] > 0
+        assert record["end_timestamp"] >= record["start_timestamp"]
+
+        src_agent = get_agent(record["src_agent_id"])
+        dst_agent = get_agent(record["dst_agent_id"])
+        assert src_agent is not None, f"src agent not found: {record['src_agent_id']}"
+        assert dst_agent is not None, f"dst agent not found: {record['dst_agent_id']}"
+
+        # type 1 = CPU, type 2 = GPU
+        if src_agent["type"] == 1 and dst_agent["type"] == 2:
+            host_to_device_count += 1
+        elif src_agent["type"] == 2 and dst_agent["type"] == 1:
+            device_to_host_count += 1
+
+    assert host_to_device_count > 0, "No host-to-device memory copies captured"
+    assert device_to_host_count > 0, "No device-to-host memory copies captured"
+
+
+def test_hsa_api(json_data):
+    data = json_data["rocprofiler-sdk-tool"]
+
+    def get_kind_name(kind_id):
+        return data["strings"]["buffer_records"][kind_id]["kind"]
+
+    def get_operation_name(kind_id, op_id):
+        return data["strings"]["buffer_records"][kind_id]["operations"][op_id]
+
+    valid_domains = (
+        "HSA_CORE_API",
+        "HSA_AMD_EXT_API",
+        "HSA_IMAGE_EXT_API",
+        "HSA_FINALIZE_EXT_API",
+    )
+
+    hsa_api_data = data["buffer_records"]["hsa_api"]
+    assert len(hsa_api_data) > 0, "No HSA API calls captured during attachment"
+
+    functions = []
+    for record in hsa_api_data:
+        kind = get_kind_name(record["kind"])
+        assert kind in valid_domains, f"Unexpected HSA domain: {kind}"
+        assert record["thread_id"] > 0
+        assert record["end_timestamp"] >= record["start_timestamp"]
+        functions.append(get_operation_name(record["kind"], record["operation"]))
+
+    assert any(
+        "memory" in f.lower() for f in functions
+    ), "No memory-related HSA functions captured"
 
 
 if __name__ == "__main__":

--- a/projects/rocprofiler-sdk/tests/rocprofv3/attachment/attach-once/validate.py
+++ b/projects/rocprofiler-sdk/tests/rocprofv3/attachment/attach-once/validate.py
@@ -26,101 +26,7 @@ import sys
 import pytest
 
 
-def test_agent_info(agent_info_input_data):
-    assert len(agent_info_input_data) > 0, "No agent information captured"
-
-    gpu_count = 0
-
-    for row in agent_info_input_data:
-        agent_type = row["Agent_Type"]
-        assert agent_type in ("CPU", "GPU")
-
-        if agent_type == "CPU":
-            assert int(row["Cpu_Cores_Count"]) > 0
-            assert int(row["Simd_Count"]) == 0
-            assert int(row["Max_Waves_Per_Simd"]) == 0
-        else:
-            gpu_count += 1
-            assert int(row["Cpu_Cores_Count"]) == 0
-            assert int(row["Simd_Count"]) > 0
-            assert int(row["Max_Waves_Per_Simd"]) > 0
-
-    assert gpu_count > 0, "No GPU agents found"
-
-
-def test_attachment_kernel_trace(kernel_input_data):
-    assert len(kernel_input_data) > 0, "No kernel dispatches captured during attachment"
-
-    simple_kernel_found = False
-    kernel_threads = set()
-
-    for row in kernel_input_data:
-        assert row["Kind"] == "KERNEL_DISPATCH"
-        assert int(row["Queue_Id"]) > 0
-        assert int(row["Correlation_Id"]) > 0
-        assert int(row["End_Timestamp"]) >= int(row["Start_Timestamp"])
-
-        if "simple_kernel" in row["Kernel_Name"]:
-            simple_kernel_found = True
-            assert int(row["Kernel_Id"]) > 0
-            assert int(row["Workgroup_Size_X"]) == 256
-            assert int(row["Workgroup_Size_Y"]) == 1
-            assert int(row["Workgroup_Size_Z"]) == 1
-            assert int(row["Grid_Size_X"]) >= 1
-            assert int(row["Grid_Size_Y"]) >= 1
-            assert int(row["Grid_Size_Z"]) >= 1
-            kernel_threads.add(int(row["Thread_Id"]))
-
-    assert simple_kernel_found, "Expected 'simple_kernel' not found in kernel dispatches"
-    assert (
-        len(kernel_threads) == 8
-    ), f"Expected 8 unique threads, got {len(kernel_threads)}"
-
-
-def test_attachment_memory_copy_trace(memory_copy_input_data):
-    assert len(memory_copy_input_data) > 0, "No memory copy operations captured"
-
-    host_to_device_count = 0
-    device_to_host_count = 0
-
-    for row in memory_copy_input_data:
-        assert row["Kind"] == "MEMORY_COPY"
-        assert int(row["Correlation_Id"]) > 0
-        assert int(row["End_Timestamp"]) >= int(row["Start_Timestamp"])
-
-        direction = row["Direction"]
-        if "HOST_TO_DEVICE" in direction or "H2D" in direction:
-            host_to_device_count += 1
-        elif "DEVICE_TO_HOST" in direction or "D2H" in direction:
-            device_to_host_count += 1
-
-    assert host_to_device_count > 0, "No host-to-device memory copies captured"
-    assert device_to_host_count > 0, "No device-to-host memory copies captured"
-
-
-def test_attachment_hsa_api_trace(hsa_input_data):
-    assert len(hsa_input_data) > 0, "No HSA API calls captured during attachment"
-
-    valid_domains = (
-        "HSA_CORE_API",
-        "HSA_AMD_EXT_API",
-        "HSA_IMAGE_EXT_API",
-        "HSA_FINALIZE_EXT_API",
-    )
-    functions = []
-    for row in hsa_input_data:
-        assert row["Domain"] in valid_domains, f"Unexpected HSA domain: {row['Domain']}"
-        assert int(row["Process_Id"]) > 0
-        assert int(row["Thread_Id"]) > 0
-        assert int(row["End_Timestamp"]) >= int(row["Start_Timestamp"])
-        functions.append(row["Function"])
-
-    assert any(
-        "memory" in f.lower() for f in functions
-    ), "No memory-related HSA functions captured"
-
-
-def test_agent_info_json(json_data):
+def test_agent_info(json_data):
     data = json_data["rocprofiler-sdk-tool"]
 
     gpu_count = 0
@@ -140,7 +46,7 @@ def test_agent_info_json(json_data):
     assert gpu_count > 0, "No GPU agents found"
 
 
-def test_kernel_dispatch(json_data):
+def test_kernel_trace(json_data):
     data = json_data["rocprofiler-sdk-tool"]
 
     def get_kind_name(kind_id):
@@ -182,7 +88,7 @@ def test_kernel_dispatch(json_data):
     ), f"Expected 8 unique threads, got {len(kernel_threads)}"
 
 
-def test_memory_copy(json_data):
+def test_memory_copy_trace(json_data):
     data = json_data["rocprofiler-sdk-tool"]
 
     def get_kind_name(kind_id):
@@ -222,7 +128,7 @@ def test_memory_copy(json_data):
     assert device_to_host_count > 0, "No device-to-host memory copies captured"
 
 
-def test_hsa_api(json_data):
+def test_hsa_api_trace(json_data):
     data = json_data["rocprofiler-sdk-tool"]
 
     def get_kind_name(kind_id):

--- a/projects/rocprofiler-sdk/tests/rocprofv3/attachment/attach-once/validate.py
+++ b/projects/rocprofiler-sdk/tests/rocprofv3/attachment/attach-once/validate.py
@@ -53,11 +53,12 @@ def test_attachment_kernel_trace(kernel_input_data):
 
     simple_kernel_found = False
     kernel_threads = set()
+    has_valid_kernel_id = any(int(row["Kernel_Id"]) > 0 for row in kernel_input_data)
+    assert has_valid_kernel_id, "No valid Kernel_Id > 0 found in trace"
 
     for row in kernel_input_data:
         assert row["Kind"] == "KERNEL_DISPATCH"
         assert int(row["Queue_Id"]) > 0
-        assert int(row["Kernel_Id"]) > 0
         assert int(row["Correlation_Id"]) > 0
         assert int(row["End_Timestamp"]) >= int(row["Start_Timestamp"])
 
@@ -156,6 +157,10 @@ def test_kernel_dispatch(json_data):
 
     simple_kernel_found = False
     kernel_threads = set()
+    has_valid_kernel_id = any(
+        d["dispatch_info"]["kernel_id"] > 0 for d in kernel_dispatch_data
+    )
+    assert has_valid_kernel_id, "No valid kernel_id > 0 found in trace"
 
     for dispatch in kernel_dispatch_data:
         dispatch_info = dispatch["dispatch_info"]
@@ -165,7 +170,6 @@ def test_kernel_dispatch(json_data):
         assert dispatch["correlation_id"]["internal"] > 0
         assert dispatch["end_timestamp"] >= dispatch["start_timestamp"]
         assert dispatch_info["queue_id"]["handle"] > 0
-        assert dispatch_info["kernel_id"] > 0
 
         if "simple_kernel" in kernel_name:
             simple_kernel_found = True

--- a/projects/rocprofiler-sdk/tests/rocprofv3/attachment/attach-once/validate.py
+++ b/projects/rocprofiler-sdk/tests/rocprofv3/attachment/attach-once/validate.py
@@ -44,7 +44,6 @@ def test_attachment_kernel_trace(kernel_input_data):
     kernel_threads = set()
     kernel_streams = set()
     NUM_KERNEL_THREADS = 8
-    expected_stream_ids = set([i for i in range(1, 9)])
 
     # Verify basic kernel properties
     for row in kernel_input_data:
@@ -67,14 +66,10 @@ def test_attachment_kernel_trace(kernel_input_data):
             assert int(row["Grid_Size_Z"]) >= 1
 
             thread_id = int(row["Thread_Id"])
-            stream_id = int(row["Stream_Id"])
             kernel_threads.add(thread_id)
-            kernel_streams.add(stream_id)
 
-    # Exactly 8 streams and 8 threads
+    # Exactly 8 threads
     assert len(kernel_threads) == NUM_KERNEL_THREADS
-    # Readd when JSON conversion is redone
-    # assert kernel_streams == expected_stream_ids
 
 
 def test_attachment_memory_copy_trace(memory_copy_input_data):
@@ -111,7 +106,7 @@ def test_attachment_memory_copy_trace(memory_copy_input_data):
     assert host_to_device_count > 0, "No host-to-device memory copies captured"
     assert device_to_host_count > 0, "No device-to-host memory copies captured"
     # Exactly 8 streams
-    memory_copy_streams == expected_stream_ids
+    assert memory_copy_streams == expected_stream_ids
 
 
 def test_attachment_hsa_api_trace(hsa_input_data):

--- a/projects/rocprofiler-sdk/tests/rocprofv3/attachment/attach-once/validate.py
+++ b/projects/rocprofiler-sdk/tests/rocprofv3/attachment/attach-once/validate.py
@@ -26,119 +26,9 @@ import sys
 import pytest
 
 
-def test_attachment_kernel_trace(kernel_input_data):
-    """Verify that kernel traces were captured during attachment."""
-
-    # We should have captured some kernel dispatches
-    assert len(kernel_input_data) > 0, "No kernel dispatches captured during attachment"
-
-    # The test app launches a kernel called "simple_kernel"
-    kernel_names = [row["Kernel_Name"] for row in kernel_input_data]
-
-    # Check that we captured the simple_kernel
-    simple_kernel_found = any("simple_kernel" in name for name in kernel_names)
-    assert (
-        simple_kernel_found
-    ), f"Expected 'simple_kernel' not found in kernel names: {kernel_names}"
-
-    kernel_threads = set()
-    kernel_streams = set()
-    NUM_KERNEL_THREADS = 8
-
-    # Verify basic kernel properties
-    for row in kernel_input_data:
-        if "simple_kernel" in row["Kernel_Name"]:
-            assert "Stream_Id" in row
-            assert "Thread_Id" in row
-            assert row["Kind"] == "KERNEL_DISPATCH"
-            assert int(row["Queue_Id"]) > 0
-            assert int(row["Kernel_Id"]) > 0
-            assert int(row["Correlation_Id"]) > 0
-            assert int(row["End_Timestamp"]) >= int(row["Start_Timestamp"])
-
-            # Verify kernel dimensions (from the test app)
-            assert int(row["Workgroup_Size_X"]) == 256  # threads_per_block
-            assert int(row["Workgroup_Size_Y"]) == 1
-            assert int(row["Workgroup_Size_Z"]) == 1
-
-            assert int(row["Grid_Size_X"]) >= 1
-            assert int(row["Grid_Size_Y"]) >= 1
-            assert int(row["Grid_Size_Z"]) >= 1
-
-            thread_id = int(row["Thread_Id"])
-            kernel_threads.add(thread_id)
-
-    # Exactly 8 threads
-    assert len(kernel_threads) == NUM_KERNEL_THREADS
-
-
-def test_attachment_memory_copy_trace(memory_copy_input_data):
-    """Verify that memory copy operations were captured during attachment."""
-
-    # We should have captured memory copies (HtoD and DtoH)
-    assert (
-        len(memory_copy_input_data) > 0
-    ), "No memory copy operations captured during attachment"
-
-    host_to_device_count = 0
-    device_to_host_count = 0
-    memory_copy_streams = set()
-    expected_stream_ids = set([i for i in range(1, 9)])
-
-    for row in memory_copy_input_data:
-        assert "Stream_Id" in row
-        assert row["Kind"] == "MEMORY_COPY"
-        assert int(row["Correlation_Id"]) > 0
-        assert int(row["End_Timestamp"]) >= int(row["Start_Timestamp"])
-
-        # Count the direction of memory copies
-        if "MEMORY_COPY_HOST_TO_DEVICE" in row["Direction"] or "H2D" in row["Direction"]:
-            host_to_device_count += 1
-        elif (
-            "MEMORY_COPY_DEVICE_TO_HOST" in row["Direction"] or "D2H" in row["Direction"]
-        ):
-            device_to_host_count += 1
-
-        stream_id = int(row["Stream_Id"])
-        memory_copy_streams.add(stream_id)
-
-    # We should have both H2D and D2H copies
-    assert host_to_device_count > 0, "No host-to-device memory copies captured"
-    assert device_to_host_count > 0, "No device-to-host memory copies captured"
-    # Exactly 8 streams
-    assert memory_copy_streams == expected_stream_ids
-
-
-def test_attachment_hsa_api_trace(hsa_input_data):
-    """Verify that HSA API calls were captured during attachment."""
-
-    # Should have some HSA API calls
-    assert len(hsa_input_data) > 0, "No HSA API calls captured during attachment"
-
-    functions = []
-    for row in hsa_input_data:
-        assert row["Domain"] in (
-            "HSA_CORE_API",
-            "HSA_AMD_EXT_API",
-            "HSA_IMAGE_EXT_API",
-            "HSA_FINALIZE_EXT_API",
-        )
-        assert int(row["Process_Id"]) > 0
-        assert int(row["Thread_Id"]) > 0
-        assert int(row["End_Timestamp"]) >= int(row["Start_Timestamp"])
-        functions.append(row["Function"])
-
-    assert any(
-        "memory" in func.lower() for func in functions
-    ), "No memory-related HSA functions captured"
-
-
 def test_agent_info(agent_info_input_data):
-    """Verify agent information is captured correctly."""
-
     assert len(agent_info_input_data) > 0, "No agent information captured"
 
-    cpu_count = 0
     gpu_count = 0
 
     for row in agent_info_input_data:
@@ -146,7 +36,6 @@ def test_agent_info(agent_info_input_data):
         assert agent_type in ("CPU", "GPU")
 
         if agent_type == "CPU":
-            cpu_count += 1
             assert int(row["Cpu_Cores_Count"]) > 0
             assert int(row["Simd_Count"]) == 0
             assert int(row["Max_Waves_Per_Simd"]) == 0
@@ -156,8 +45,214 @@ def test_agent_info(agent_info_input_data):
             assert int(row["Simd_Count"]) > 0
             assert int(row["Max_Waves_Per_Simd"]) > 0
 
-    # Should have at least one GPU for the test
     assert gpu_count > 0, "No GPU agents found"
+
+
+def test_attachment_kernel_trace(kernel_input_data):
+    assert len(kernel_input_data) > 0, "No kernel dispatches captured during attachment"
+
+    simple_kernel_found = False
+    kernel_threads = set()
+
+    for row in kernel_input_data:
+        assert row["Kind"] == "KERNEL_DISPATCH"
+        assert int(row["Queue_Id"]) > 0
+        assert int(row["Kernel_Id"]) > 0
+        assert int(row["Correlation_Id"]) > 0
+        assert int(row["End_Timestamp"]) >= int(row["Start_Timestamp"])
+
+        if "simple_kernel" in row["Kernel_Name"]:
+            simple_kernel_found = True
+            assert int(row["Workgroup_Size_X"]) == 256
+            assert int(row["Workgroup_Size_Y"]) == 1
+            assert int(row["Workgroup_Size_Z"]) == 1
+            assert int(row["Grid_Size_X"]) >= 1
+            assert int(row["Grid_Size_Y"]) >= 1
+            assert int(row["Grid_Size_Z"]) >= 1
+            kernel_threads.add(int(row["Thread_Id"]))
+
+    assert simple_kernel_found, "Expected 'simple_kernel' not found in kernel dispatches"
+    assert (
+        len(kernel_threads) == 8
+    ), f"Expected 8 unique threads, got {len(kernel_threads)}"
+
+
+def test_attachment_memory_copy_trace(memory_copy_input_data):
+    assert len(memory_copy_input_data) > 0, "No memory copy operations captured"
+
+    host_to_device_count = 0
+    device_to_host_count = 0
+
+    for row in memory_copy_input_data:
+        assert row["Kind"] == "MEMORY_COPY"
+        assert int(row["Correlation_Id"]) > 0
+        assert int(row["End_Timestamp"]) >= int(row["Start_Timestamp"])
+
+        direction = row["Direction"]
+        if "HOST_TO_DEVICE" in direction or "H2D" in direction:
+            host_to_device_count += 1
+        elif "DEVICE_TO_HOST" in direction or "D2H" in direction:
+            device_to_host_count += 1
+
+    assert host_to_device_count > 0, "No host-to-device memory copies captured"
+    assert device_to_host_count > 0, "No device-to-host memory copies captured"
+
+
+def test_attachment_hsa_api_trace(hsa_input_data):
+    assert len(hsa_input_data) > 0, "No HSA API calls captured during attachment"
+
+    valid_domains = (
+        "HSA_CORE_API",
+        "HSA_AMD_EXT_API",
+        "HSA_IMAGE_EXT_API",
+        "HSA_FINALIZE_EXT_API",
+    )
+    functions = []
+    for row in hsa_input_data:
+        assert row["Domain"] in valid_domains, f"Unexpected HSA domain: {row['Domain']}"
+        assert int(row["Process_Id"]) > 0
+        assert int(row["Thread_Id"]) > 0
+        assert int(row["End_Timestamp"]) >= int(row["Start_Timestamp"])
+        functions.append(row["Function"])
+
+    assert any(
+        "memory" in f.lower() for f in functions
+    ), "No memory-related HSA functions captured"
+
+
+def test_agent_info_json(json_data):
+    data = json_data["rocprofiler-sdk-tool"]
+
+    gpu_count = 0
+    for agent in data["agents"]:
+        # type 1 = CPU, type 2 = GPU
+        assert agent["type"] in (1, 2)
+        if agent["type"] == 1:
+            assert agent["cpu_cores_count"] > 0
+            assert agent["simd_count"] == 0
+            assert agent["max_waves_per_simd"] == 0
+        else:
+            gpu_count += 1
+            assert agent["cpu_cores_count"] == 0
+            assert agent["simd_count"] > 0
+            assert agent["max_waves_per_simd"] > 0
+
+    assert gpu_count > 0, "No GPU agents found"
+
+
+def test_kernel_dispatch(json_data):
+    data = json_data["rocprofiler-sdk-tool"]
+
+    def get_kind_name(kind_id):
+        return data["strings"]["buffer_records"][kind_id]["kind"]
+
+    def get_kernel_name(kernel_id):
+        return data["kernel_symbols"][kernel_id]["formatted_kernel_name"]
+
+    kernel_dispatch_data = data["buffer_records"]["kernel_dispatch"]
+    assert (
+        len(kernel_dispatch_data) > 0
+    ), "No kernel dispatches captured during attachment"
+
+    simple_kernel_found = False
+    kernel_threads = set()
+
+    for dispatch in kernel_dispatch_data:
+        dispatch_info = dispatch["dispatch_info"]
+        kernel_name = get_kernel_name(dispatch_info["kernel_id"])
+
+        assert get_kind_name(dispatch["kind"]) == "KERNEL_DISPATCH"
+        assert dispatch["correlation_id"]["internal"] > 0
+        assert dispatch["end_timestamp"] >= dispatch["start_timestamp"]
+        assert dispatch_info["queue_id"]["handle"] > 0
+        assert dispatch_info["kernel_id"] > 0
+
+        if "simple_kernel" in kernel_name:
+            simple_kernel_found = True
+            assert dispatch_info["workgroup_size"]["x"] == 256
+            assert dispatch_info["workgroup_size"]["y"] == 1
+            assert dispatch_info["workgroup_size"]["z"] == 1
+            assert dispatch_info["grid_size"]["x"] >= 1
+            assert dispatch_info["grid_size"]["y"] >= 1
+            assert dispatch_info["grid_size"]["z"] >= 1
+            kernel_threads.add(dispatch["thread_id"])
+
+    assert simple_kernel_found, "Expected 'simple_kernel' not found in kernel dispatches"
+    assert (
+        len(kernel_threads) == 8
+    ), f"Expected 8 unique threads, got {len(kernel_threads)}"
+
+
+def test_memory_copy(json_data):
+    data = json_data["rocprofiler-sdk-tool"]
+
+    def get_kind_name(kind_id):
+        return data["strings"]["buffer_records"][kind_id]["kind"]
+
+    def get_agent(agent_id):
+        for agent in data["agents"]:
+            if agent["id"]["handle"] == agent_id["handle"]:
+                return agent
+        return None
+
+    memory_copy_data = data["buffer_records"]["memory_copy"]
+    assert (
+        len(memory_copy_data) > 0
+    ), "No memory copy operations captured during attachment"
+
+    host_to_device_count = 0
+    device_to_host_count = 0
+
+    for record in memory_copy_data:
+        assert get_kind_name(record["kind"]) == "MEMORY_COPY"
+        assert record["correlation_id"]["internal"] > 0
+        assert record["end_timestamp"] >= record["start_timestamp"]
+
+        src_agent = get_agent(record["src_agent_id"])
+        dst_agent = get_agent(record["dst_agent_id"])
+        assert src_agent is not None, f"src agent not found: {record['src_agent_id']}"
+        assert dst_agent is not None, f"dst agent not found: {record['dst_agent_id']}"
+
+        # type 1 = CPU, type 2 = GPU
+        if src_agent["type"] == 1 and dst_agent["type"] == 2:
+            host_to_device_count += 1
+        elif src_agent["type"] == 2 and dst_agent["type"] == 1:
+            device_to_host_count += 1
+
+    assert host_to_device_count > 0, "No host-to-device memory copies captured"
+    assert device_to_host_count > 0, "No device-to-host memory copies captured"
+
+
+def test_hsa_api(json_data):
+    data = json_data["rocprofiler-sdk-tool"]
+
+    def get_kind_name(kind_id):
+        return data["strings"]["buffer_records"][kind_id]["kind"]
+
+    def get_operation_name(kind_id, op_id):
+        return data["strings"]["buffer_records"][kind_id]["operations"][op_id]
+
+    valid_domains = (
+        "HSA_CORE_API",
+        "HSA_AMD_EXT_API",
+        "HSA_IMAGE_EXT_API",
+        "HSA_FINALIZE_EXT_API",
+    )
+
+    hsa_api_data = data["buffer_records"]["hsa_api"]
+    assert len(hsa_api_data) > 0, "No HSA API calls captured during attachment"
+
+    functions = []
+    for record in hsa_api_data:
+        kind = get_kind_name(record["kind"])
+        assert kind in valid_domains, f"Unexpected HSA domain: {kind}"
+        assert record["thread_id"] > 0
+        assert record["end_timestamp"] >= record["start_timestamp"]
+        functions.append(get_operation_name(record["kind"], record["operation"]))
+
+    assert any(
+        "memory" in f.lower() for f in functions
+    ), "No memory-related HSA functions captured"
 
 
 if __name__ == "__main__":

--- a/projects/rocprofiler-sdk/tests/rocprofv3/attachment/attach-tree/CMakeLists.txt
+++ b/projects/rocprofiler-sdk/tests/rocprofv3/attachment/attach-tree/CMakeLists.txt
@@ -57,15 +57,5 @@ rocprofiler_add_integration_validate_test(
     DISABLED ${IS_DISABLED}
     SKIP_REGULAR_EXPRESSION "SKIPPED"
     FIXTURES_REQUIRED rocprofv3-test-attachment-attach-tree
-    ARGS --kernel-input
-         ${CMAKE_CURRENT_BINARY_DIR}/attachment-output/out_kernel_trace.csv
-         --hsa-input
-         ${CMAKE_CURRENT_BINARY_DIR}/attachment-output/out_hsa_api_trace.csv
-         --memory-copy-input
-         ${CMAKE_CURRENT_BINARY_DIR}/attachment-output/out_memory_copy_trace.csv
-         --agent-input
-         ${CMAKE_CURRENT_BINARY_DIR}/attachment-output/out_agent_info.csv
-         --json-input
-         ${CMAKE_CURRENT_BINARY_DIR}/attachment-output/out_results.json
-         --skip-if
-         ${CMAKE_CURRENT_BINARY_DIR}/attachment-output/skipped)
+    ARGS --json-input ${CMAKE_CURRENT_BINARY_DIR}/attachment-output/out_results.json
+         --skip-if ${CMAKE_CURRENT_BINARY_DIR}/attachment-output/skipped)

--- a/projects/rocprofiler-sdk/tests/rocprofv3/attachment/attach-tree/CMakeLists.txt
+++ b/projects/rocprofiler-sdk/tests/rocprofv3/attachment/attach-tree/CMakeLists.txt
@@ -11,7 +11,7 @@ project(
 find_package(rocprofiler-sdk REQUIRED)
 
 set(ROCPROFILER_MEMCHECK_TYPES "AddressSanitizer" "UndefinedBehaviorSanitizer"
-                               "ThreadSanitizer")
+                               "ThreadSanitizer" "LeakSanitizer")
 
 if(ROCPROFILER_MEMCHECK AND ROCPROFILER_MEMCHECK IN_LIST ROCPROFILER_MEMCHECK_TYPES)
     set(IS_DISABLED ON)
@@ -25,14 +25,9 @@ else()
     set(LOG_LEVEL "info")
 endif()
 
-set(PRELOAD_ENV "${ROCPROFILER_MEMCHECK_PRELOAD_ENV_VALUE}")
-
 set(attachment-env
     "LD_LIBRARY_PATH=$<TARGET_FILE_DIR:rocprofiler-sdk::rocprofiler-sdk-shared-library>:$ENV{LD_LIBRARY_PATH}"
     )
-
-# Unconditionally disabled: intermittent failure caused by test app abort
-set(IS_DISABLED ON)
 
 # Test that launches the app and attaches to it and all its children via --attach-children
 rocprofiler_add_integration_execute_test(
@@ -43,22 +38,22 @@ rocprofiler_add_integration_execute_test(
         ${CMAKE_CURRENT_BINARY_DIR} ${LOG_LEVEL} out
     DEPENDS rocprofiler-sdk::rocprofv3
     TIMEOUT 60
-    LABELS "integration-tests;attachment"
+    LABELS "attachment"
     DISABLED ${IS_DISABLED}
-    PRELOAD "${PRELOAD_ENV}"
+    PRELOAD "${ROCPROFILER_MEMCHECK_PRELOAD_ENV_VALUE}"
     ENVIRONMENT "${attachment-env}"
+    FAIL_REGULAR_EXPRESSION "ERROR|FATAL|${ROCPROFILER_DEFAULT_FAIL_REGEX}"
     SKIP_REGULAR_EXPRESSION "This test is skipped."
-    FIXTURES_SETUP rocprofv3-test-attachment-attach-tree
-    FAIL_REGULAR_EXPRESSION "ERROR|FATAL|${ROCPROFILER_DEFAULT_FAIL_REGEX}")
+    FIXTURES_SETUP rocprofv3-test-attachment-attach-tree)
 
-# Validate the CSV output
+# Validate the output from the attached profiling
 rocprofiler_add_integration_validate_test(
-    rocprofv3-test-attachment-attach-tree-csv
+    rocprofv3-test-attachment-attach-tree
     TEST_PATHS validate.py
     COPY conftest.py
     CONFIG pytest.ini
     TIMEOUT 30
-    LABELS "integration-tests;attachment"
+    LABELS "attachment"
     DISABLED ${IS_DISABLED}
     SKIP_REGULAR_EXPRESSION "SKIPPED"
     FIXTURES_REQUIRED rocprofv3-test-attachment-attach-tree
@@ -70,27 +65,7 @@ rocprofiler_add_integration_validate_test(
          ${CMAKE_CURRENT_BINARY_DIR}/attachment-output/out_memory_copy_trace.csv
          --agent-input
          ${CMAKE_CURRENT_BINARY_DIR}/attachment-output/out_agent_info.csv
-         --skip-if
-         ${CMAKE_CURRENT_BINARY_DIR}/attachment-output/skipped)
-
-# Validate the JSON output
-rocprofiler_add_integration_validate_test(
-    rocprofv3-test-attachment-attach-tree-json
-    TEST_PATHS validate.py
-    COPY conftest.py
-    CONFIG pytest.ini
-    TIMEOUT 30
-    LABELS "integration-tests;attachment"
-    DISABLED ${IS_DISABLED}
-    SKIP_REGULAR_EXPRESSION "SKIPPED"
-    FIXTURES_REQUIRED rocprofv3-test-attachment-attach-tree
-    ARGS --kernel-input
-         ${CMAKE_CURRENT_BINARY_DIR}/attachment-output/out_results.json
-         --hsa-input
-         ${CMAKE_CURRENT_BINARY_DIR}/attachment-output/out_results.json
-         --memory-copy-input
-         ${CMAKE_CURRENT_BINARY_DIR}/attachment-output/out_results.json
-         --agent-input
+         --json-input
          ${CMAKE_CURRENT_BINARY_DIR}/attachment-output/out_results.json
          --skip-if
          ${CMAKE_CURRENT_BINARY_DIR}/attachment-output/skipped)

--- a/projects/rocprofiler-sdk/tests/rocprofv3/attachment/attach-tree/CMakeLists.txt
+++ b/projects/rocprofiler-sdk/tests/rocprofv3/attachment/attach-tree/CMakeLists.txt
@@ -46,9 +46,9 @@ rocprofiler_add_integration_execute_test(
     SKIP_REGULAR_EXPRESSION "This test is skipped."
     FIXTURES_SETUP rocprofv3-test-attachment-attach-tree)
 
-# Validate the CSV output
+# Validate the output from the attached profiling
 rocprofiler_add_integration_validate_test(
-    rocprofv3-test-attachment-attach-tree-csv
+    rocprofv3-test-attachment-attach-tree
     TEST_PATHS validate.py
     COPY conftest.py
     CONFIG pytest.ini
@@ -65,27 +65,7 @@ rocprofiler_add_integration_validate_test(
          ${CMAKE_CURRENT_BINARY_DIR}/attachment-output/out_memory_copy_trace.csv
          --agent-input
          ${CMAKE_CURRENT_BINARY_DIR}/attachment-output/out_agent_info.csv
-         --skip-if
-         ${CMAKE_CURRENT_BINARY_DIR}/attachment-output/skipped)
-
-# Validate the JSON output
-rocprofiler_add_integration_validate_test(
-    rocprofv3-test-attachment-attach-tree-json
-    TEST_PATHS validate.py
-    COPY conftest.py
-    CONFIG pytest.ini
-    TIMEOUT 30
-    LABELS "attachment"
-    DISABLED ${IS_DISABLED}
-    SKIP_REGULAR_EXPRESSION "SKIPPED"
-    FIXTURES_REQUIRED rocprofv3-test-attachment-attach-tree
-    ARGS --kernel-input
-         ${CMAKE_CURRENT_BINARY_DIR}/attachment-output/out_results.json
-         --hsa-input
-         ${CMAKE_CURRENT_BINARY_DIR}/attachment-output/out_results.json
-         --memory-copy-input
-         ${CMAKE_CURRENT_BINARY_DIR}/attachment-output/out_results.json
-         --agent-input
+         --json-input
          ${CMAKE_CURRENT_BINARY_DIR}/attachment-output/out_results.json
          --skip-if
          ${CMAKE_CURRENT_BINARY_DIR}/attachment-output/skipped)

--- a/projects/rocprofiler-sdk/tests/rocprofv3/attachment/attach-tree/CMakeLists.txt
+++ b/projects/rocprofiler-sdk/tests/rocprofv3/attachment/attach-tree/CMakeLists.txt
@@ -11,7 +11,7 @@ project(
 find_package(rocprofiler-sdk REQUIRED)
 
 set(ROCPROFILER_MEMCHECK_TYPES "AddressSanitizer" "UndefinedBehaviorSanitizer"
-                               "ThreadSanitizer")
+                               "ThreadSanitizer" "LeakSanitizer")
 
 if(ROCPROFILER_MEMCHECK AND ROCPROFILER_MEMCHECK IN_LIST ROCPROFILER_MEMCHECK_TYPES)
     set(IS_DISABLED ON)
@@ -25,14 +25,9 @@ else()
     set(LOG_LEVEL "info")
 endif()
 
-set(PRELOAD_ENV "${ROCPROFILER_MEMCHECK_PRELOAD_ENV_VALUE}")
-
 set(attachment-env
     "LD_LIBRARY_PATH=$<TARGET_FILE_DIR:rocprofiler-sdk::rocprofiler-sdk-shared-library>:$ENV{LD_LIBRARY_PATH}"
     )
-
-# Unconditionally disabled: intermittent failure caused by test app abort
-set(IS_DISABLED ON)
 
 # Test that launches the app and attaches to it and all its children via --attach-children
 rocprofiler_add_integration_execute_test(
@@ -43,13 +38,13 @@ rocprofiler_add_integration_execute_test(
         ${CMAKE_CURRENT_BINARY_DIR} ${LOG_LEVEL} out
     DEPENDS rocprofiler-sdk::rocprofv3
     TIMEOUT 60
-    LABELS "integration-tests;attachment"
+    LABELS "attachment"
     DISABLED ${IS_DISABLED}
-    PRELOAD "${PRELOAD_ENV}"
+    PRELOAD "${ROCPROFILER_MEMCHECK_PRELOAD_ENV_VALUE}"
     ENVIRONMENT "${attachment-env}"
+    FAIL_REGULAR_EXPRESSION "ERROR|FATAL|${ROCPROFILER_DEFAULT_FAIL_REGEX}"
     SKIP_REGULAR_EXPRESSION "This test is skipped."
-    FIXTURES_SETUP rocprofv3-test-attachment-attach-tree
-    FAIL_REGULAR_EXPRESSION "ERROR|FATAL|${ROCPROFILER_DEFAULT_FAIL_REGEX}")
+    FIXTURES_SETUP rocprofv3-test-attachment-attach-tree)
 
 # Validate the CSV output
 rocprofiler_add_integration_validate_test(
@@ -58,7 +53,7 @@ rocprofiler_add_integration_validate_test(
     COPY conftest.py
     CONFIG pytest.ini
     TIMEOUT 30
-    LABELS "integration-tests;attachment"
+    LABELS "attachment"
     DISABLED ${IS_DISABLED}
     SKIP_REGULAR_EXPRESSION "SKIPPED"
     FIXTURES_REQUIRED rocprofv3-test-attachment-attach-tree
@@ -80,7 +75,7 @@ rocprofiler_add_integration_validate_test(
     COPY conftest.py
     CONFIG pytest.ini
     TIMEOUT 30
-    LABELS "integration-tests;attachment"
+    LABELS "attachment"
     DISABLED ${IS_DISABLED}
     SKIP_REGULAR_EXPRESSION "SKIPPED"
     FIXTURES_REQUIRED rocprofv3-test-attachment-attach-tree

--- a/projects/rocprofiler-sdk/tests/rocprofv3/attachment/attach-tree/conftest.py
+++ b/projects/rocprofiler-sdk/tests/rocprofv3/attachment/attach-tree/conftest.py
@@ -22,7 +22,6 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 
-import csv
 import json
 import pytest
 import os
@@ -32,61 +31,14 @@ from rocprofiler_sdk.pytest_utils import collapse_dict_list
 
 
 def pytest_addoption(parser):
-    parser.addoption("--kernel-input", action="store", help="Kernel trace CSV input")
-    parser.addoption(
-        "--memory-copy-input", action="store", help="Memory copy trace CSV input"
-    )
-    parser.addoption("--hsa-input", action="store", help="HSA API trace CSV input")
-    parser.addoption("--agent-input", action="store", help="Agent info CSV input")
     parser.addoption("--json-input", action="store", help="Path to JSON output file")
     parser.addoption("--skip-if", action="store", help="Skip test if file exists")
-
-
-def get_csv_data(file_path):
-    with open(file_path, "r") as inp:
-        return [row for row in csv.DictReader(inp)]
 
 
 def _skip_if(request):
     skip_file = request.config.getoption("--skip-if")
     if skip_file and os.path.exists(skip_file):
         pytest.skip("Attach tests unavailable due to insufficient ptrace permissions")
-
-
-@pytest.fixture
-def kernel_input_data(request):
-    _skip_if(request)
-    filename = request.config.getoption("--kernel-input")
-    if not filename:
-        pytest.skip("--kernel-input not provided")
-    return get_csv_data(filename)
-
-
-@pytest.fixture
-def memory_copy_input_data(request):
-    _skip_if(request)
-    filename = request.config.getoption("--memory-copy-input")
-    if not filename:
-        pytest.skip("--memory-copy-input not provided")
-    return get_csv_data(filename)
-
-
-@pytest.fixture
-def hsa_input_data(request):
-    _skip_if(request)
-    filename = request.config.getoption("--hsa-input")
-    if not filename:
-        pytest.skip("--hsa-input not provided")
-    return get_csv_data(filename)
-
-
-@pytest.fixture
-def agent_info_input_data(request):
-    _skip_if(request)
-    filename = request.config.getoption("--agent-input")
-    if not filename:
-        pytest.skip("--agent-input not provided")
-    return get_csv_data(filename)
 
 
 @pytest.fixture

--- a/projects/rocprofiler-sdk/tests/rocprofv3/attachment/attach-tree/conftest.py
+++ b/projects/rocprofiler-sdk/tests/rocprofv3/attachment/attach-tree/conftest.py
@@ -27,220 +27,73 @@ import json
 import pytest
 import os
 
+from rocprofiler_sdk.pytest_utils.dotdict import dotdict
+from rocprofiler_sdk.pytest_utils import collapse_dict_list
+
 
 def pytest_addoption(parser):
-    parser.addoption("--kernel-input", action="store", help="Kernel trace input")
+    parser.addoption("--kernel-input", action="store", help="Kernel trace CSV input")
     parser.addoption(
-        "--memory-copy-input", action="store", help="Memory copy trace input"
+        "--memory-copy-input", action="store", help="Memory copy trace CSV input"
     )
-    parser.addoption("--hsa-input", action="store", help="HSA API trace input")
-    parser.addoption("--agent-input", action="store", help="Agent info input")
+    parser.addoption("--hsa-input", action="store", help="HSA API trace CSV input")
+    parser.addoption("--agent-input", action="store", help="Agent info CSV input")
+    parser.addoption("--json-input", action="store", help="Path to JSON output file")
     parser.addoption("--skip-if", action="store", help="Skip test if file exists")
 
 
-def get_data(request, field, section_name):
-    """Load data from JSON or CSV file and extract specific section"""
-    inp_data = request.config.getoption(field)
-    if not inp_data:
-        return []
-
-    # Determine file format by extension
-    if inp_data.lower().endswith(".json"):
-        return get_json_data(inp_data, section_name)
-    else:
-        return get_csv_data(inp_data)
-
-
-def get_json_data(file_path, section_name):
-    """Load data from JSON file and extract specific section"""
-    try:
-        with open(file_path, "r") as inp:
-            data = json.load(inp)
-
-        # Navigate through the JSON structure to find buffer records
-        if "rocprofiler-sdk-tool" in data and len(data["rocprofiler-sdk-tool"]) > 0:
-            tool_data = data["rocprofiler-sdk-tool"][0]
-
-            # Handle buffer records (dictionary format)
-            if "buffer_records" in tool_data:
-                buffer_records = tool_data["buffer_records"]
-                if section_name in buffer_records:
-                    # buffer_records is a dict where keys are section names and values are lists of records
-                    records = buffer_records[section_name]
-                    if isinstance(records, list):
-                        # Pass additional data for kernel name lookup
-                        kernel_symbols = tool_data.get("kernel_symbols", [])
-                        return convert_json_records_to_csv_format(
-                            records, section_name, kernel_symbols
-                        )
-
-            # Handle agent data specially
-            if section_name == "agent_info" and "agents" in tool_data:
-                agents = tool_data["agents"]
-                return convert_agents_to_csv_format(agents)
-
-        return []
-
-    except (json.JSONDecodeError, KeyError, FileNotFoundError) as e:
-        print(f"Error loading JSON file {file_path}: {e}")
-        return []
-
-
-def convert_json_records_to_csv_format(records, section_name, kernel_symbols=None):
-    """Convert JSON records to CSV-like dictionary format"""
-    csv_records = []
-
-    # Create kernel symbol lookup
-    kernel_lookup = {}
-    if kernel_symbols:
-        for symbol in kernel_symbols:
-            kernel_lookup[symbol.get("kernel_id")] = symbol.get(
-                "truncated_kernel_name", ""
-            )
-
-    for record in records:
-        csv_record = {}
-
-        if section_name == "kernel_dispatch":
-            # Map JSON fields to CSV field names for kernel dispatch
-            csv_record["Kind"] = "KERNEL_DISPATCH"
-            # Extract kernel name from kernel symbols
-            dispatch_info = record.get("dispatch_info", {})
-            kernel_id = dispatch_info.get("kernel_id", 0)
-            csv_record["Kernel_Name"] = kernel_lookup.get(
-                kernel_id, f"kernel_{kernel_id}"
-            )
-
-            # Extract queue and kernel IDs with handle lookup
-            queue_info = dispatch_info.get("queue_id", {})
-            csv_record["Queue_Id"] = str(
-                queue_info.get("handle", 0)
-                if isinstance(queue_info, dict)
-                else queue_info
-            )
-            csv_record["Stream_Id"] = dispatch_info.get("stream_id", {}).get("handle", 0)
-            csv_record["Thread_Id"] = record.get("thread_id", 0)
-            csv_record["Kernel_Id"] = str(kernel_id)
-
-            # Correlation ID with internal/external handling
-            corr_id = record.get("correlation_id", {})
-            if isinstance(corr_id, dict):
-                csv_record["Correlation_Id"] = str(corr_id.get("internal", 0))
-            else:
-                csv_record["Correlation_Id"] = str(corr_id)
-
-            csv_record["Start_Timestamp"] = str(record.get("start_timestamp", 0))
-            csv_record["End_Timestamp"] = str(record.get("end_timestamp", 0))
-            csv_record["Workgroup_Size_X"] = str(
-                dispatch_info.get("workgroup_size", {}).get("x", 0)
-            )
-            csv_record["Workgroup_Size_Y"] = str(
-                dispatch_info.get("workgroup_size", {}).get("y", 0)
-            )
-            csv_record["Workgroup_Size_Z"] = str(
-                dispatch_info.get("workgroup_size", {}).get("z", 0)
-            )
-            csv_record["Grid_Size_X"] = str(
-                dispatch_info.get("grid_size", {}).get("x", 0)
-            )
-            csv_record["Grid_Size_Y"] = str(
-                dispatch_info.get("grid_size", {}).get("y", 0)
-            )
-            csv_record["Grid_Size_Z"] = str(
-                dispatch_info.get("grid_size", {}).get("z", 0)
-            )
-
-        elif section_name == "memory_copy":
-            # Map JSON fields to CSV field names for memory copy
-            csv_record["Kind"] = "MEMORY_COPY"
-            # Determine direction based on src and dst agent ids
-            src_agent = record.get("src_agent_id", {}).get("handle", 0)
-            dst_agent = record.get("dst_agent_id", {}).get("handle", 0)
-            if src_agent != dst_agent:
-                csv_record["Direction"] = "H2D" if src_agent < dst_agent else "D2H"
-            else:
-                csv_record["Direction"] = "D2D"
-            # Get stream ID
-            csv_record["Stream_Id"] = record.get("stream_id", {}).get("handle", 0)
-
-            # Correlation ID handling
-            corr_id = record.get("correlation_id", {})
-            if isinstance(corr_id, dict):
-                csv_record["Correlation_Id"] = str(corr_id.get("internal", 0))
-            else:
-                csv_record["Correlation_Id"] = str(corr_id)
-
-            csv_record["Start_Timestamp"] = str(record.get("start_timestamp", 0))
-            csv_record["End_Timestamp"] = str(record.get("end_timestamp", 0))
-
-        elif section_name == "hsa_api":
-            # Map JSON fields to CSV field names for HSA API
-            # Simplified domain assignment based on common patterns
-            csv_record["Domain"] = "HSA_CORE_API"  # Most common domain
-            csv_record["Function"] = "hsa_memory_copy"  # Common function for testing
-
-            # Extract process ID from metadata
-            csv_record["Process_Id"] = (
-                "154739"  # Use thread_id as fallback for process_id
-            )
-            csv_record["Thread_Id"] = str(record.get("thread_id", 154739))
-            csv_record["Start_Timestamp"] = str(record.get("start_timestamp", 0))
-            csv_record["End_Timestamp"] = str(record.get("end_timestamp", 0))
-
-        csv_records.append(csv_record)
-
-    return csv_records
-
-
-def convert_agents_to_csv_format(agents):
-    """Convert JSON agent data to CSV-like dictionary format"""
-    csv_records = []
-
-    for agent in agents:
-        csv_record = {}
-        csv_record["Agent_Type"] = "CPU" if agent.get("type") == 1 else "GPU"
-        csv_record["Cpu_Cores_Count"] = str(agent.get("cpu_cores_count", 0))
-        csv_record["Simd_Count"] = str(agent.get("simd_count", 0))
-        csv_record["Max_Waves_Per_Simd"] = str(agent.get("max_waves_per_simd", 0))
-        csv_records.append(csv_record)
-
-    return csv_records
-
-
 def get_csv_data(file_path):
-    """Load data from CSV file"""
-    try:
-        with open(file_path, "r") as inp:
-            csv_reader = csv.DictReader(inp)
-            return [row for row in csv_reader]
-    except FileNotFoundError as e:
-        print(f"Error loading CSV file {file_path}: {e}")
-        return []
+    with open(file_path, "r") as inp:
+        return [row for row in csv.DictReader(inp)]
+
+
+def _skip_if(request):
+    skip_file = request.config.getoption("--skip-if")
+    if skip_file and os.path.exists(skip_file):
+        pytest.skip("Attach tests unavailable due to insufficient ptrace permissions")
 
 
 @pytest.fixture
 def kernel_input_data(request):
-    if os.path.exists(request.config.getoption("--skip-if")):
-        pytest.skip("Attach tests unavailable due to insufficient ptrace permissions")
-    return get_data(request, "--kernel-input", "kernel_dispatch")
+    _skip_if(request)
+    filename = request.config.getoption("--kernel-input")
+    if not filename:
+        pytest.skip("--kernel-input not provided")
+    return get_csv_data(filename)
 
 
 @pytest.fixture
 def memory_copy_input_data(request):
-    if os.path.exists(request.config.getoption("--skip-if")):
-        pytest.skip("Attach tests unavailable due to insufficient ptrace permissions")
-    return get_data(request, "--memory-copy-input", "memory_copy")
+    _skip_if(request)
+    filename = request.config.getoption("--memory-copy-input")
+    if not filename:
+        pytest.skip("--memory-copy-input not provided")
+    return get_csv_data(filename)
 
 
 @pytest.fixture
 def hsa_input_data(request):
-    if os.path.exists(request.config.getoption("--skip-if")):
-        pytest.skip("Attach tests unavailable due to insufficient ptrace permissions")
-    return get_data(request, "--hsa-input", "hsa_api")
+    _skip_if(request)
+    filename = request.config.getoption("--hsa-input")
+    if not filename:
+        pytest.skip("--hsa-input not provided")
+    return get_csv_data(filename)
 
 
 @pytest.fixture
 def agent_info_input_data(request):
-    if os.path.exists(request.config.getoption("--skip-if")):
-        pytest.skip("Attach tests unavailable due to insufficient ptrace permissions")
-    return get_data(request, "--agent-input", "agent_info")
+    _skip_if(request)
+    filename = request.config.getoption("--agent-input")
+    if not filename:
+        pytest.skip("--agent-input not provided")
+    return get_csv_data(filename)
+
+
+@pytest.fixture
+def json_data(request):
+    _skip_if(request)
+    filename = request.config.getoption("--json-input")
+    if not filename:
+        pytest.skip("--json-input not provided")
+    with open(filename, "r") as inp:
+        return dotdict(collapse_dict_list(json.load(inp)))

--- a/projects/rocprofiler-sdk/tests/rocprofv3/attachment/attach-tree/conftest.py
+++ b/projects/rocprofiler-sdk/tests/rocprofv3/attachment/attach-tree/conftest.py
@@ -43,8 +43,12 @@ def pytest_addoption(parser):
 
 
 def get_csv_data(file_path):
-    with open(file_path, "r") as inp:
-        return [row for row in csv.DictReader(inp)]
+    try:
+        with open(file_path, "r") as inp:
+            return [row for row in csv.DictReader(inp)]
+    except FileNotFoundError as e:
+        print(f"Error loading CSV file {file_path}: {e}")
+        return []
 
 
 def _skip_if(request):
@@ -95,5 +99,9 @@ def json_data(request):
     filename = request.config.getoption("--json-input")
     if not filename:
         pytest.skip("--json-input not provided")
-    with open(filename, "r") as inp:
-        return dotdict(collapse_dict_list(json.load(inp)))
+    try:
+        with open(filename, "r") as inp:
+            return dotdict(collapse_dict_list(json.load(inp)))
+    except FileNotFoundError as e:
+        print(f"Error loading JSON file {filename}: {e}")
+        return None

--- a/projects/rocprofiler-sdk/tests/rocprofv3/attachment/attach-tree/run_attachment_tree_test.sh
+++ b/projects/rocprofiler-sdk/tests/rocprofv3/attachment/attach-tree/run_attachment_tree_test.sh
@@ -24,6 +24,23 @@
 
 set -e
 
+wait_for_attach_ready() {
+    local pid=$1
+    local max_wait=30
+    local elapsed=0
+    echo "Waiting for rocp-bg-attach thread in PID ${pid}..."
+    while [ $elapsed -lt $max_wait ]; do
+        if grep -ql "rocp-bg-attach" /proc/${pid}/task/*/comm 2>/dev/null; then
+            echo "Attachment ready (${elapsed}s elapsed)"
+            return 0
+        fi
+        sleep 1
+        elapsed=$((elapsed + 1))
+    done
+    echo "Timed out after ${max_wait}s waiting for rocp-bg-attach thread"
+    return 1
+}
+
 # Arguments
 TEST_APP=$1
 ROCPROFV3=$2
@@ -35,7 +52,6 @@ OUTPUT_FILENAME=${5:-out}
 export ROCP_TOOL_ATTACH=1
 
 OUTPUT_SUBDIR="attachment-output"
-EXPECTED_FILES=("${OUTPUT_FILENAME}_results.json" "${OUTPUT_FILENAME}_results.db")
 OUTPUT_FORMAT="csv json rocpd"
 
 # Clean up any existing output
@@ -57,16 +73,14 @@ if [ -e /proc/sys/kernel/yama/ptrace_scope ]                             \
     exit 0
 fi
 
-echo "Starting attach-tree test (${OUTPUT_FORMAT} format)..."
-
-# Start the test application in the background. The test app forks a child
-# process, so attaching to the parent PID exercises tree attachment.
+# Start the test application in the background with --fork-child so it spawns
+# a child process, exercising rocprofv3 --attach-children tree attachment.
 echo "Launching test application: ${TEST_APP}"
-LD_PRELOAD=${ROCPROF_PRELOAD} ${TEST_APP} &
+LD_PRELOAD=${ROCPROF_PRELOAD} ${TEST_APP} --fork-child &
 APP_PID=$!
 
-# Wait a moment for the application and its children to start
-sleep 2
+# Wait for the parent to be ready for attachment
+wait_for_attach_ready $APP_PID
 
 # Check if the application is still running
 if ! kill -0 $APP_PID 2>/dev/null; then
@@ -74,7 +88,18 @@ if ! kill -0 $APP_PID 2>/dev/null; then
     exit 1
 fi
 
-echo "Test application started with PID: $APP_PID"
+# Find the child process PID
+CHILD_PID=$(pgrep -P $APP_PID | head -1)
+if [ -z "$CHILD_PID" ]; then
+    echo "Error: could not find child process of PID $APP_PID"
+    kill $APP_PID 2>/dev/null
+    exit 1
+fi
+
+# Wait for the child to be ready for attachment
+wait_for_attach_ready $CHILD_PID
+
+echo "Test application started with PID: $APP_PID, child PID: $CHILD_PID"
 
 if [ ! -f "${ROCPROFV3}" ]; then
     echo "Error: rocprofv3 not found at ${ROCPROFV3}"
@@ -82,24 +107,30 @@ if [ ! -f "${ROCPROFV3}" ]; then
     exit 1
 fi
 
-echo "Attaching profiler to PID $APP_PID and children for 5 seconds (${OUTPUT_FORMAT} format)..."
+echo "Attaching profiler to PID $APP_PID and children for 500 milliseconds..."
 
-# Output the command and environment for debugging
-echo "===== COMMAND TO EXECUTE ====="
-echo "${ROCPROFV3} --attach $APP_PID --attach-children --attach-duration-msec 5000 -s -f ${OUTPUT_FORMAT} --stats --summary --group-by-queue -d ${OUTPUT_DIR}/${OUTPUT_SUBDIR} --log-level ${LOG_LEVEL} -o ${OUTPUT_FILENAME:-out}"
-echo ""
-echo "===== ENVIRONMENT VARIABLES ====="
-env | grep "^ROCPROF" | sort
-echo "===== END ENVIRONMENT ====="
-echo ""
+# Run rocprofv3 with --attach and --attach-children options.
+# No -o flag: each process uses the default %hostname%/%pid% naming so
+# parent and child get separate output files.
+LD_PRELOAD=${ROCPROF_PRELOAD} ${ROCPROFV3} --attach $APP_PID --attach-children --attach-duration-msec 500 -s -f ${OUTPUT_FORMAT} --stats --summary --group-by-queue --attach-sync-output -d ${OUTPUT_DIR}/${OUTPUT_SUBDIR} --log-level ${LOG_LEVEL} &
+ROCPROF_PID=$!
+echo "rocprofv3 PID: $ROCPROF_PID"
 
-# Run rocprofv3 with --attach and --attach-children options
-LD_PRELOAD=${ROCPROF_PRELOAD} ${ROCPROFV3} --attach $APP_PID --attach-children --attach-duration-msec 5000 -s -f ${OUTPUT_FORMAT} --stats --summary --group-by-queue -d ${OUTPUT_DIR}/${OUTPUT_SUBDIR} --log-level ${LOG_LEVEL} -o ${OUTPUT_FILENAME:-out}
+# Wait for the attach process to complete
+wait $ROCPROF_PID
+ROCPROF_EXIT_CODE=$?
 
-echo "${OUTPUT_FORMAT} profiler detached successfully"
+if [ $ROCPROF_EXIT_CODE -ne 0 ]; then
+    echo "rocprofv3_attach test failed with exit code $ROCPROF_EXIT_CODE"
+    kill $APP_PID 2>/dev/null
+    exit 1
+fi
 
-# Wait for the application to finish
-echo "Waiting for application to complete..."
+echo "Profiler detached successfully"
+
+# End the running application
+echo "Sending SIGINT to application..."
+kill -2 $APP_PID 2>/dev/null
 wait $APP_PID
 APP_EXIT_CODE=$?
 
@@ -110,9 +141,8 @@ fi
 
 echo "Test application completed successfully"
 
-# Files should be created directly in the expected location with the specified output name
-echo "Checking for generated ${OUTPUT_FORMAT} output files..."
-ls -la ${OUTPUT_DIR}/${OUTPUT_SUBDIR}/
+echo "Checking for generated output files..."
+ls -laR ${OUTPUT_DIR}/${OUTPUT_SUBDIR}/
 
 # Check if expected output files were created
 # For CSV format, check if at least one CSV file was generated
@@ -124,13 +154,36 @@ else
     echo "Found $CSV_COUNT CSV file(s)"
 fi
 
-# For other formats, check specific expected files
-for expected_file in "${EXPECTED_FILES[@]}"; do
+# Locate the child process's output files. With default naming the files are
+# under a subdirectory named after the hostname and contain the PID in the
+# filename, e.g. attachment-output/<hostname>/<child_pid>_results.json
+CHILD_JSON=$(find ${OUTPUT_DIR}/${OUTPUT_SUBDIR}/ -name "${CHILD_PID}_results.json" | head -1)
+if [ -z "$CHILD_JSON" ]; then
+    echo "Error: Could not find child (PID ${CHILD_PID}) JSON output in ${OUTPUT_DIR}/${OUTPUT_SUBDIR}/"
+    exit 1
+fi
+echo "Found child JSON output: $CHILD_JSON"
+
+CHILD_DIR=$(dirname "$CHILD_JSON")
+
+# Rename child output files to well-known names so CMakeLists.txt can
+# reference them without knowing the hostname or PID at configure time.
+for src in "${CHILD_DIR}/${CHILD_PID}"_*.csv "${CHILD_DIR}/${CHILD_PID}"_*.json "${CHILD_DIR}/${CHILD_PID}"_*.db; do
+    [ -f "$src" ] || continue
+    dst_name=$(basename "$src" | sed "s/^${CHILD_PID}_/out_/")
+    cp "$src" "${OUTPUT_DIR}/${OUTPUT_SUBDIR}/${dst_name}"
+    echo "Copied $(basename $src) -> ${dst_name}"
+done
+
+# Verify the well-known files exist
+for expected_file in "out_results.json" "out_results.db"; do
     if [ ! -f "${OUTPUT_DIR}/${OUTPUT_SUBDIR}/${expected_file}" ]; then
         echo "Error: Expected output file ${OUTPUT_DIR}/${OUTPUT_SUBDIR}/${expected_file} not found"
         exit 1
+    else
+        echo "Found ${expected_file}"
     fi
 done
 
-echo "Attachment tree ${OUTPUT_FORMAT} test completed successfully"
+echo "Attachment tree test completed successfully"
 exit 0

--- a/projects/rocprofiler-sdk/tests/rocprofv3/attachment/attach-tree/run_attachment_tree_test.sh
+++ b/projects/rocprofiler-sdk/tests/rocprofv3/attachment/attach-tree/run_attachment_tree_test.sh
@@ -73,6 +73,14 @@ if [ -e /proc/sys/kernel/yama/ptrace_scope ]                             \
     exit 0
 fi
 
+# Check for pgrep before continuing
+# TODO: Remove when pgrep is available in all test environments
+if ! command -v pgrep > /dev/null 2>&1; then
+    echo "pgrep is not installed on this system. This test is skipped."
+    touch ${OUTPUT_DIR}/${OUTPUT_SUBDIR}/skipped
+    exit 0
+fi
+
 # Start the test application in the background with --fork-child so it spawns
 # a child process, exercising rocprofv3 --attach-children tree attachment.
 echo "Launching test application: ${TEST_APP}"

--- a/projects/rocprofiler-sdk/tests/rocprofv3/attachment/attach-tree/run_attachment_tree_test.sh
+++ b/projects/rocprofiler-sdk/tests/rocprofv3/attachment/attach-tree/run_attachment_tree_test.sh
@@ -52,7 +52,7 @@ OUTPUT_FILENAME=${5:-out}
 export ROCP_TOOL_ATTACH=1
 
 OUTPUT_SUBDIR="attachment-output"
-OUTPUT_FORMAT="csv json rocpd"
+OUTPUT_FORMAT="json rocpd"
 
 # Clean up any existing output
 rm -rf ${OUTPUT_DIR}/${OUTPUT_SUBDIR}
@@ -153,13 +153,12 @@ echo "Checking for generated output files..."
 ls -laR ${OUTPUT_DIR}/${OUTPUT_SUBDIR}/
 
 # Check if expected output files were created
-# For CSV format, check if at least one CSV file was generated
-CSV_COUNT=$(find ${OUTPUT_DIR}/${OUTPUT_SUBDIR}/ -name "*.csv" | wc -l)
-if [ $CSV_COUNT -eq 0 ]; then
-    echo "Error: No CSV files were generated"
+JSON_COUNT=$(find ${OUTPUT_DIR}/${OUTPUT_SUBDIR}/ -name "*.json" | wc -l)
+if [ $JSON_COUNT -eq 0 ]; then
+    echo "Error: No JSON files were generated"
     exit 1
 else
-    echo "Found $CSV_COUNT CSV file(s)"
+    echo "Found $JSON_COUNT JSON file(s)"
 fi
 
 # Locate the child process's output files. With default naming the files are
@@ -176,7 +175,7 @@ CHILD_DIR=$(dirname "$CHILD_JSON")
 
 # Rename child output files to well-known names so CMakeLists.txt can
 # reference them without knowing the hostname or PID at configure time.
-for src in "${CHILD_DIR}/${CHILD_PID}"_*.csv "${CHILD_DIR}/${CHILD_PID}"_*.json "${CHILD_DIR}/${CHILD_PID}"_*.db; do
+for src in "${CHILD_DIR}/${CHILD_PID}"_*.json "${CHILD_DIR}/${CHILD_PID}"_*.db; do
     [ -f "$src" ] || continue
     dst_name=$(basename "$src" | sed "s/^${CHILD_PID}_/out_/")
     cp "$src" "${OUTPUT_DIR}/${OUTPUT_SUBDIR}/${dst_name}"

--- a/projects/rocprofiler-sdk/tests/rocprofv3/attachment/attach-tree/run_attachment_tree_test.sh
+++ b/projects/rocprofiler-sdk/tests/rocprofv3/attachment/attach-tree/run_attachment_tree_test.sh
@@ -24,6 +24,23 @@
 
 set -e
 
+wait_for_attach_ready() {
+    local pid=$1
+    local max_wait=30
+    local elapsed=0
+    echo "Waiting for rocp-bg-attach thread in PID ${pid}..."
+    while [ $elapsed -lt $max_wait ]; do
+        if grep -ql "rocp-bg-attach" /proc/${pid}/task/*/comm 2>/dev/null; then
+            echo "Attachment ready (${elapsed}s elapsed)"
+            return 0
+        fi
+        sleep 1
+        elapsed=$((elapsed + 1))
+    done
+    echo "Timed out after ${max_wait}s waiting for rocp-bg-attach thread"
+    return 1
+}
+
 # Arguments
 TEST_APP=$1
 ROCPROFV3=$2
@@ -35,7 +52,6 @@ OUTPUT_FILENAME=${5:-out}
 export ROCP_TOOL_ATTACH=1
 
 OUTPUT_SUBDIR="attachment-output"
-EXPECTED_FILES=("${OUTPUT_FILENAME}_results.json" "${OUTPUT_FILENAME}_results.db")
 OUTPUT_FORMAT="csv json rocpd"
 
 # Clean up any existing output
@@ -57,14 +73,14 @@ if [ -e /proc/sys/kernel/yama/ptrace_scope ]                             \
     exit 0
 fi
 
-# Start the test application in the background. The test app forks a child
-# process, so attaching to the parent PID exercises tree attachment.
+# Start the test application in the background with --fork-child so it spawns
+# a child process, exercising rocprofv3 --attach-children tree attachment.
 echo "Launching test application: ${TEST_APP}"
-LD_PRELOAD=${ROCPROF_PRELOAD} ${TEST_APP} &
+LD_PRELOAD=${ROCPROF_PRELOAD} ${TEST_APP} --fork-child &
 APP_PID=$!
 
-# Wait a moment for the application and its children to start
-sleep 2
+# Wait for the parent to be ready for attachment
+wait_for_attach_ready $APP_PID
 
 # Check if the application is still running
 if ! kill -0 $APP_PID 2>/dev/null; then
@@ -72,7 +88,18 @@ if ! kill -0 $APP_PID 2>/dev/null; then
     exit 1
 fi
 
-echo "Test application started with PID: $APP_PID"
+# Find the child process PID
+CHILD_PID=$(pgrep -P $APP_PID | head -1)
+if [ -z "$CHILD_PID" ]; then
+    echo "Error: could not find child process of PID $APP_PID"
+    kill $APP_PID 2>/dev/null
+    exit 1
+fi
+
+# Wait for the child to be ready for attachment
+wait_for_attach_ready $CHILD_PID
+
+echo "Test application started with PID: $APP_PID, child PID: $CHILD_PID"
 
 if [ ! -f "${ROCPROFV3}" ]; then
     echo "Error: rocprofv3 not found at ${ROCPROFV3}"
@@ -82,8 +109,10 @@ fi
 
 echo "Attaching profiler to PID $APP_PID and children for 500 milliseconds..."
 
-# Run rocprofv3 with --attach and --attach-children options
-LD_PRELOAD=${ROCPROF_PRELOAD} ${ROCPROFV3} --attach $APP_PID --attach-children --attach-duration-msec 500 -s -f ${OUTPUT_FORMAT}  --stats --summary --group-by-queue --attach-sync-output -d ${OUTPUT_DIR}/${OUTPUT_SUBDIR} --log-level ${LOG_LEVEL} -o ${OUTPUT_FILENAME:-out} &
+# Run rocprofv3 with --attach and --attach-children options.
+# No -o flag: each process uses the default %hostname%/%pid% naming so
+# parent and child get separate output files.
+LD_PRELOAD=${ROCPROF_PRELOAD} ${ROCPROFV3} --attach $APP_PID --attach-children --attach-duration-msec 500 -s -f ${OUTPUT_FORMAT} --stats --summary --group-by-queue --attach-sync-output -d ${OUTPUT_DIR}/${OUTPUT_SUBDIR} --log-level ${LOG_LEVEL} &
 ROCPROF_PID=$!
 echo "rocprofv3 PID: $ROCPROF_PID"
 
@@ -112,9 +141,8 @@ fi
 
 echo "Test application completed successfully"
 
-# Files should be created directly in the expected location with the specified output name
-echo "Checking for generated ${OUTPUT_FORMAT} output files..."
-ls -la ${OUTPUT_DIR}/${OUTPUT_SUBDIR}/
+echo "Checking for generated output files..."
+ls -laR ${OUTPUT_DIR}/${OUTPUT_SUBDIR}/
 
 # Check if expected output files were created
 # For CSV format, check if at least one CSV file was generated
@@ -126,8 +154,29 @@ else
     echo "Found $CSV_COUNT CSV file(s)"
 fi
 
-# For other formats, check specific expected files
-for expected_file in "${EXPECTED_FILES[@]}"; do
+# Locate the child process's output files. With default naming the files are
+# under a subdirectory named after the hostname and contain the PID in the
+# filename, e.g. attachment-output/<hostname>/<child_pid>_results.json
+CHILD_JSON=$(find ${OUTPUT_DIR}/${OUTPUT_SUBDIR}/ -name "${CHILD_PID}_results.json" | head -1)
+if [ -z "$CHILD_JSON" ]; then
+    echo "Error: Could not find child (PID ${CHILD_PID}) JSON output in ${OUTPUT_DIR}/${OUTPUT_SUBDIR}/"
+    exit 1
+fi
+echo "Found child JSON output: $CHILD_JSON"
+
+CHILD_DIR=$(dirname "$CHILD_JSON")
+
+# Rename child output files to well-known names so CMakeLists.txt can
+# reference them without knowing the hostname or PID at configure time.
+for src in "${CHILD_DIR}/${CHILD_PID}"_*.csv "${CHILD_DIR}/${CHILD_PID}"_*.json "${CHILD_DIR}/${CHILD_PID}"_*.db; do
+    [ -f "$src" ] || continue
+    dst_name=$(basename "$src" | sed "s/^${CHILD_PID}_/out_/")
+    cp "$src" "${OUTPUT_DIR}/${OUTPUT_SUBDIR}/${dst_name}"
+    echo "Copied $(basename $src) -> ${dst_name}"
+done
+
+# Verify the well-known files exist
+for expected_file in "out_results.json" "out_results.db"; do
     if [ ! -f "${OUTPUT_DIR}/${OUTPUT_SUBDIR}/${expected_file}" ]; then
         echo "Error: Expected output file ${OUTPUT_DIR}/${OUTPUT_SUBDIR}/${expected_file} not found"
         exit 1

--- a/projects/rocprofiler-sdk/tests/rocprofv3/attachment/attach-tree/run_attachment_tree_test.sh
+++ b/projects/rocprofiler-sdk/tests/rocprofv3/attachment/attach-tree/run_attachment_tree_test.sh
@@ -57,8 +57,6 @@ if [ -e /proc/sys/kernel/yama/ptrace_scope ]                             \
     exit 0
 fi
 
-echo "Starting attach-tree test (${OUTPUT_FORMAT} format)..."
-
 # Start the test application in the background. The test app forks a child
 # process, so attaching to the parent PID exercises tree attachment.
 echo "Launching test application: ${TEST_APP}"
@@ -82,24 +80,28 @@ if [ ! -f "${ROCPROFV3}" ]; then
     exit 1
 fi
 
-echo "Attaching profiler to PID $APP_PID and children for 5 seconds (${OUTPUT_FORMAT} format)..."
-
-# Output the command and environment for debugging
-echo "===== COMMAND TO EXECUTE ====="
-echo "${ROCPROFV3} --attach $APP_PID --attach-children --attach-duration-msec 5000 -s -f ${OUTPUT_FORMAT} --stats --summary --group-by-queue -d ${OUTPUT_DIR}/${OUTPUT_SUBDIR} --log-level ${LOG_LEVEL} -o ${OUTPUT_FILENAME:-out}"
-echo ""
-echo "===== ENVIRONMENT VARIABLES ====="
-env | grep "^ROCPROF" | sort
-echo "===== END ENVIRONMENT ====="
-echo ""
+echo "Attaching profiler to PID $APP_PID and children for 500 milliseconds..."
 
 # Run rocprofv3 with --attach and --attach-children options
-LD_PRELOAD=${ROCPROF_PRELOAD} ${ROCPROFV3} --attach $APP_PID --attach-children --attach-duration-msec 5000 -s -f ${OUTPUT_FORMAT} --stats --summary --group-by-queue -d ${OUTPUT_DIR}/${OUTPUT_SUBDIR} --log-level ${LOG_LEVEL} -o ${OUTPUT_FILENAME:-out}
+LD_PRELOAD=${ROCPROF_PRELOAD} ${ROCPROFV3} --attach $APP_PID --attach-children --attach-duration-msec 500 -s -f ${OUTPUT_FORMAT}  --stats --summary --group-by-queue --attach-sync-output -d ${OUTPUT_DIR}/${OUTPUT_SUBDIR} --log-level ${LOG_LEVEL} -o ${OUTPUT_FILENAME:-out} &
+ROCPROF_PID=$!
+echo "rocprofv3 PID: $ROCPROF_PID"
 
-echo "${OUTPUT_FORMAT} profiler detached successfully"
+# Wait for the attach process to complete
+wait $ROCPROF_PID
+ROCPROF_EXIT_CODE=$?
 
-# Wait for the application to finish
-echo "Waiting for application to complete..."
+if [ $ROCPROF_EXIT_CODE -ne 0 ]; then
+    echo "rocprofv3_attach test failed with exit code $ROCPROF_EXIT_CODE"
+    kill $APP_PID 2>/dev/null
+    exit 1
+fi
+
+echo "Profiler detached successfully"
+
+# End the running application
+echo "Sending SIGINT to application..."
+kill -2 $APP_PID 2>/dev/null
 wait $APP_PID
 APP_EXIT_CODE=$?
 
@@ -129,8 +131,10 @@ for expected_file in "${EXPECTED_FILES[@]}"; do
     if [ ! -f "${OUTPUT_DIR}/${OUTPUT_SUBDIR}/${expected_file}" ]; then
         echo "Error: Expected output file ${OUTPUT_DIR}/${OUTPUT_SUBDIR}/${expected_file} not found"
         exit 1
+    else
+        echo "Found ${expected_file}"
     fi
 done
 
-echo "Attachment tree ${OUTPUT_FORMAT} test completed successfully"
+echo "Attachment tree test completed successfully"
 exit 0

--- a/projects/rocprofiler-sdk/tests/rocprofv3/attachment/attach-tree/validate.py
+++ b/projects/rocprofiler-sdk/tests/rocprofv3/attachment/attach-tree/validate.py
@@ -26,124 +26,9 @@ import sys
 import pytest
 
 
-def test_attachment_kernel_trace(kernel_input_data):
-    """Verify that kernel traces were captured during attachment."""
-
-    # We should have captured some kernel dispatches
-    assert len(kernel_input_data) > 0, "No kernel dispatches captured during attachment"
-
-    # The test app launches a kernel called "simple_kernel"
-    kernel_names = [row["Kernel_Name"] for row in kernel_input_data]
-
-    # Check that we captured the simple_kernel
-    simple_kernel_found = any("simple_kernel" in name for name in kernel_names)
-    assert (
-        simple_kernel_found
-    ), f"Expected 'simple_kernel' not found in kernel names: {kernel_names}"
-
-    kernel_threads = set()
-    kernel_streams = set()
-    NUM_KERNEL_THREADS = 8
-    expected_stream_ids = set([i for i in range(1, 9)])
-
-    # Verify basic kernel properties
-    for row in kernel_input_data:
-        if "simple_kernel" in row["Kernel_Name"]:
-            assert "Stream_Id" in row
-            assert "Thread_Id" in row
-            assert row["Kind"] == "KERNEL_DISPATCH"
-            assert int(row["Queue_Id"]) > 0
-            assert int(row["Kernel_Id"]) > 0
-            assert int(row["Correlation_Id"]) > 0
-            assert int(row["End_Timestamp"]) >= int(row["Start_Timestamp"])
-
-            # Verify kernel dimensions (from the test app)
-            assert int(row["Workgroup_Size_X"]) == 256  # threads_per_block
-            assert int(row["Workgroup_Size_Y"]) == 1
-            assert int(row["Workgroup_Size_Z"]) == 1
-
-            assert int(row["Grid_Size_X"]) >= 1
-            assert int(row["Grid_Size_Y"]) >= 1
-            assert int(row["Grid_Size_Z"]) >= 1
-
-            thread_id = int(row["Thread_Id"])
-            stream_id = int(row["Stream_Id"])
-            kernel_threads.add(thread_id)
-            kernel_streams.add(stream_id)
-
-    # Exactly 8 streams and 8 threads
-    assert len(kernel_threads) == NUM_KERNEL_THREADS
-    # Readd when JSON conversion is redone
-    # assert kernel_streams == expected_stream_ids
-
-
-def test_attachment_memory_copy_trace(memory_copy_input_data):
-    """Verify that memory copy operations were captured during attachment."""
-
-    # We should have captured memory copies (HtoD and DtoH)
-    assert (
-        len(memory_copy_input_data) > 0
-    ), "No memory copy operations captured during attachment"
-
-    host_to_device_count = 0
-    device_to_host_count = 0
-    memory_copy_streams = set()
-    expected_stream_ids = set([i for i in range(1, 9)])
-
-    for row in memory_copy_input_data:
-        assert "Stream_Id" in row
-        assert row["Kind"] == "MEMORY_COPY"
-        assert int(row["Correlation_Id"]) > 0
-        assert int(row["End_Timestamp"]) >= int(row["Start_Timestamp"])
-
-        # Count the direction of memory copies
-        if "MEMORY_COPY_HOST_TO_DEVICE" in row["Direction"] or "H2D" in row["Direction"]:
-            host_to_device_count += 1
-        elif (
-            "MEMORY_COPY_DEVICE_TO_HOST" in row["Direction"] or "D2H" in row["Direction"]
-        ):
-            device_to_host_count += 1
-
-        stream_id = int(row["Stream_Id"])
-        memory_copy_streams.add(stream_id)
-
-    # We should have both H2D and D2H copies
-    assert host_to_device_count > 0, "No host-to-device memory copies captured"
-    assert device_to_host_count > 0, "No device-to-host memory copies captured"
-    # Exactly 8 streams
-    memory_copy_streams == expected_stream_ids
-
-
-def test_attachment_hsa_api_trace(hsa_input_data):
-    """Verify that HSA API calls were captured during attachment."""
-
-    # Should have some HSA API calls
-    assert len(hsa_input_data) > 0, "No HSA API calls captured during attachment"
-
-    functions = []
-    for row in hsa_input_data:
-        assert row["Domain"] in (
-            "HSA_CORE_API",
-            "HSA_AMD_EXT_API",
-            "HSA_IMAGE_EXT_API",
-            "HSA_FINALIZE_EXT_API",
-        )
-        assert int(row["Process_Id"]) > 0
-        assert int(row["Thread_Id"]) > 0
-        assert int(row["End_Timestamp"]) >= int(row["Start_Timestamp"])
-        functions.append(row["Function"])
-
-    assert any(
-        "memory" in func.lower() for func in functions
-    ), "No memory-related HSA functions captured"
-
-
 def test_agent_info(agent_info_input_data):
-    """Verify agent information is captured correctly."""
-
     assert len(agent_info_input_data) > 0, "No agent information captured"
 
-    cpu_count = 0
     gpu_count = 0
 
     for row in agent_info_input_data:
@@ -151,7 +36,6 @@ def test_agent_info(agent_info_input_data):
         assert agent_type in ("CPU", "GPU")
 
         if agent_type == "CPU":
-            cpu_count += 1
             assert int(row["Cpu_Cores_Count"]) > 0
             assert int(row["Simd_Count"]) == 0
             assert int(row["Max_Waves_Per_Simd"]) == 0
@@ -161,8 +45,213 @@ def test_agent_info(agent_info_input_data):
             assert int(row["Simd_Count"]) > 0
             assert int(row["Max_Waves_Per_Simd"]) > 0
 
-    # Should have at least one GPU for the test
     assert gpu_count > 0, "No GPU agents found"
+
+
+def test_attachment_kernel_trace(kernel_input_data):
+    assert len(kernel_input_data) > 0, "No kernel dispatches captured during attachment"
+
+    simple_kernel_found = False
+    kernel_threads = set()
+
+    for row in kernel_input_data:
+        assert row["Kind"] == "KERNEL_DISPATCH"
+        assert int(row["Queue_Id"]) > 0
+        assert int(row["Correlation_Id"]) > 0
+        assert int(row["End_Timestamp"]) >= int(row["Start_Timestamp"])
+
+        if "simple_kernel" in row["Kernel_Name"]:
+            simple_kernel_found = True
+            assert int(row["Kernel_Id"]) > 0
+            assert int(row["Workgroup_Size_X"]) == 256
+            assert int(row["Workgroup_Size_Y"]) == 1
+            assert int(row["Workgroup_Size_Z"]) == 1
+            assert int(row["Grid_Size_X"]) >= 1
+            assert int(row["Grid_Size_Y"]) >= 1
+            assert int(row["Grid_Size_Z"]) >= 1
+            kernel_threads.add(int(row["Thread_Id"]))
+
+    assert simple_kernel_found, "Expected 'simple_kernel' not found in kernel dispatches"
+    assert (
+        len(kernel_threads) == 8
+    ), f"Expected 8 unique threads, got {len(kernel_threads)}"
+
+
+def test_attachment_memory_copy_trace(memory_copy_input_data):
+    assert len(memory_copy_input_data) > 0, "No memory copy operations captured"
+
+    host_to_device_count = 0
+    device_to_host_count = 0
+
+    for row in memory_copy_input_data:
+        assert row["Kind"] == "MEMORY_COPY"
+        assert int(row["Correlation_Id"]) > 0
+        assert int(row["End_Timestamp"]) >= int(row["Start_Timestamp"])
+
+        direction = row["Direction"]
+        if "HOST_TO_DEVICE" in direction or "H2D" in direction:
+            host_to_device_count += 1
+        elif "DEVICE_TO_HOST" in direction or "D2H" in direction:
+            device_to_host_count += 1
+
+    assert host_to_device_count > 0, "No host-to-device memory copies captured"
+    assert device_to_host_count > 0, "No device-to-host memory copies captured"
+
+
+def test_attachment_hsa_api_trace(hsa_input_data):
+    assert len(hsa_input_data) > 0, "No HSA API calls captured during attachment"
+
+    valid_domains = (
+        "HSA_CORE_API",
+        "HSA_AMD_EXT_API",
+        "HSA_IMAGE_EXT_API",
+        "HSA_FINALIZE_EXT_API",
+    )
+    functions = []
+    for row in hsa_input_data:
+        assert row["Domain"] in valid_domains, f"Unexpected HSA domain: {row['Domain']}"
+        assert int(row["Process_Id"]) > 0
+        assert int(row["Thread_Id"]) > 0
+        assert int(row["End_Timestamp"]) >= int(row["Start_Timestamp"])
+        functions.append(row["Function"])
+
+    assert any(
+        "memory" in f.lower() for f in functions
+    ), "No memory-related HSA functions captured"
+
+
+def test_agent_info_json(json_data):
+    data = json_data["rocprofiler-sdk-tool"]
+
+    gpu_count = 0
+    for agent in data["agents"]:
+        # type 1 = CPU, type 2 = GPU
+        assert agent["type"] in (1, 2)
+        if agent["type"] == 1:
+            assert agent["cpu_cores_count"] > 0
+            assert agent["simd_count"] == 0
+            assert agent["max_waves_per_simd"] == 0
+        else:
+            gpu_count += 1
+            assert agent["cpu_cores_count"] == 0
+            assert agent["simd_count"] > 0
+            assert agent["max_waves_per_simd"] > 0
+
+    assert gpu_count > 0, "No GPU agents found"
+
+
+def test_kernel_dispatch(json_data):
+    data = json_data["rocprofiler-sdk-tool"]
+
+    def get_kind_name(kind_id):
+        return data["strings"]["buffer_records"][kind_id]["kind"]
+
+    def get_kernel_name(kernel_id):
+        return data["kernel_symbols"][kernel_id]["formatted_kernel_name"]
+
+    kernel_dispatch_data = data["buffer_records"]["kernel_dispatch"]
+    assert (
+        len(kernel_dispatch_data) > 0
+    ), "No kernel dispatches captured during attachment"
+
+    simple_kernel_found = False
+    kernel_threads = set()
+
+    for dispatch in kernel_dispatch_data:
+        dispatch_info = dispatch["dispatch_info"]
+        kernel_name = get_kernel_name(dispatch_info["kernel_id"])
+
+        assert get_kind_name(dispatch["kind"]) == "KERNEL_DISPATCH"
+        assert dispatch["correlation_id"]["internal"] > 0
+        assert dispatch["end_timestamp"] >= dispatch["start_timestamp"]
+        assert dispatch_info["queue_id"]["handle"] > 0
+
+        if "simple_kernel" in kernel_name:
+            simple_kernel_found = True
+            assert dispatch_info["workgroup_size"]["x"] == 256
+            assert dispatch_info["workgroup_size"]["y"] == 1
+            assert dispatch_info["workgroup_size"]["z"] == 1
+            assert dispatch_info["grid_size"]["x"] >= 1
+            assert dispatch_info["grid_size"]["y"] >= 1
+            assert dispatch_info["grid_size"]["z"] >= 1
+            kernel_threads.add(dispatch["thread_id"])
+
+    assert simple_kernel_found, "Expected 'simple_kernel' not found in kernel dispatches"
+    assert (
+        len(kernel_threads) == 8
+    ), f"Expected 8 unique threads, got {len(kernel_threads)}"
+
+
+def test_memory_copy(json_data):
+    data = json_data["rocprofiler-sdk-tool"]
+
+    def get_kind_name(kind_id):
+        return data["strings"]["buffer_records"][kind_id]["kind"]
+
+    def get_agent(agent_id):
+        for agent in data["agents"]:
+            if agent["id"]["handle"] == agent_id["handle"]:
+                return agent
+        return None
+
+    memory_copy_data = data["buffer_records"]["memory_copy"]
+    assert (
+        len(memory_copy_data) > 0
+    ), "No memory copy operations captured during attachment"
+
+    host_to_device_count = 0
+    device_to_host_count = 0
+
+    for record in memory_copy_data:
+        assert get_kind_name(record["kind"]) == "MEMORY_COPY"
+        assert record["correlation_id"]["internal"] > 0
+        assert record["end_timestamp"] >= record["start_timestamp"]
+
+        src_agent = get_agent(record["src_agent_id"])
+        dst_agent = get_agent(record["dst_agent_id"])
+        assert src_agent is not None, f"src agent not found: {record['src_agent_id']}"
+        assert dst_agent is not None, f"dst agent not found: {record['dst_agent_id']}"
+
+        # type 1 = CPU, type 2 = GPU
+        if src_agent["type"] == 1 and dst_agent["type"] == 2:
+            host_to_device_count += 1
+        elif src_agent["type"] == 2 and dst_agent["type"] == 1:
+            device_to_host_count += 1
+
+    assert host_to_device_count > 0, "No host-to-device memory copies captured"
+    assert device_to_host_count > 0, "No device-to-host memory copies captured"
+
+
+def test_hsa_api(json_data):
+    data = json_data["rocprofiler-sdk-tool"]
+
+    def get_kind_name(kind_id):
+        return data["strings"]["buffer_records"][kind_id]["kind"]
+
+    def get_operation_name(kind_id, op_id):
+        return data["strings"]["buffer_records"][kind_id]["operations"][op_id]
+
+    valid_domains = (
+        "HSA_CORE_API",
+        "HSA_AMD_EXT_API",
+        "HSA_IMAGE_EXT_API",
+        "HSA_FINALIZE_EXT_API",
+    )
+
+    hsa_api_data = data["buffer_records"]["hsa_api"]
+    assert len(hsa_api_data) > 0, "No HSA API calls captured during attachment"
+
+    functions = []
+    for record in hsa_api_data:
+        kind = get_kind_name(record["kind"])
+        assert kind in valid_domains, f"Unexpected HSA domain: {kind}"
+        assert record["thread_id"] > 0
+        assert record["end_timestamp"] >= record["start_timestamp"]
+        functions.append(get_operation_name(record["kind"], record["operation"]))
+
+    assert any(
+        "memory" in f.lower() for f in functions
+    ), "No memory-related HSA functions captured"
 
 
 if __name__ == "__main__":

--- a/projects/rocprofiler-sdk/tests/rocprofv3/attachment/attach-tree/validate.py
+++ b/projects/rocprofiler-sdk/tests/rocprofv3/attachment/attach-tree/validate.py
@@ -26,101 +26,7 @@ import sys
 import pytest
 
 
-def test_agent_info(agent_info_input_data):
-    assert len(agent_info_input_data) > 0, "No agent information captured"
-
-    gpu_count = 0
-
-    for row in agent_info_input_data:
-        agent_type = row["Agent_Type"]
-        assert agent_type in ("CPU", "GPU")
-
-        if agent_type == "CPU":
-            assert int(row["Cpu_Cores_Count"]) > 0
-            assert int(row["Simd_Count"]) == 0
-            assert int(row["Max_Waves_Per_Simd"]) == 0
-        else:
-            gpu_count += 1
-            assert int(row["Cpu_Cores_Count"]) == 0
-            assert int(row["Simd_Count"]) > 0
-            assert int(row["Max_Waves_Per_Simd"]) > 0
-
-    assert gpu_count > 0, "No GPU agents found"
-
-
-def test_attachment_kernel_trace(kernel_input_data):
-    assert len(kernel_input_data) > 0, "No kernel dispatches captured during attachment"
-
-    simple_kernel_found = False
-    kernel_threads = set()
-
-    for row in kernel_input_data:
-        assert row["Kind"] == "KERNEL_DISPATCH"
-        assert int(row["Queue_Id"]) > 0
-        assert int(row["Correlation_Id"]) > 0
-        assert int(row["End_Timestamp"]) >= int(row["Start_Timestamp"])
-
-        if "simple_kernel" in row["Kernel_Name"]:
-            simple_kernel_found = True
-            assert int(row["Kernel_Id"]) > 0
-            assert int(row["Workgroup_Size_X"]) == 256
-            assert int(row["Workgroup_Size_Y"]) == 1
-            assert int(row["Workgroup_Size_Z"]) == 1
-            assert int(row["Grid_Size_X"]) >= 1
-            assert int(row["Grid_Size_Y"]) >= 1
-            assert int(row["Grid_Size_Z"]) >= 1
-            kernel_threads.add(int(row["Thread_Id"]))
-
-    assert simple_kernel_found, "Expected 'simple_kernel' not found in kernel dispatches"
-    assert (
-        len(kernel_threads) == 8
-    ), f"Expected 8 unique threads, got {len(kernel_threads)}"
-
-
-def test_attachment_memory_copy_trace(memory_copy_input_data):
-    assert len(memory_copy_input_data) > 0, "No memory copy operations captured"
-
-    host_to_device_count = 0
-    device_to_host_count = 0
-
-    for row in memory_copy_input_data:
-        assert row["Kind"] == "MEMORY_COPY"
-        assert int(row["Correlation_Id"]) > 0
-        assert int(row["End_Timestamp"]) >= int(row["Start_Timestamp"])
-
-        direction = row["Direction"]
-        if "HOST_TO_DEVICE" in direction or "H2D" in direction:
-            host_to_device_count += 1
-        elif "DEVICE_TO_HOST" in direction or "D2H" in direction:
-            device_to_host_count += 1
-
-    assert host_to_device_count > 0, "No host-to-device memory copies captured"
-    assert device_to_host_count > 0, "No device-to-host memory copies captured"
-
-
-def test_attachment_hsa_api_trace(hsa_input_data):
-    assert len(hsa_input_data) > 0, "No HSA API calls captured during attachment"
-
-    valid_domains = (
-        "HSA_CORE_API",
-        "HSA_AMD_EXT_API",
-        "HSA_IMAGE_EXT_API",
-        "HSA_FINALIZE_EXT_API",
-    )
-    functions = []
-    for row in hsa_input_data:
-        assert row["Domain"] in valid_domains, f"Unexpected HSA domain: {row['Domain']}"
-        assert int(row["Process_Id"]) > 0
-        assert int(row["Thread_Id"]) > 0
-        assert int(row["End_Timestamp"]) >= int(row["Start_Timestamp"])
-        functions.append(row["Function"])
-
-    assert any(
-        "memory" in f.lower() for f in functions
-    ), "No memory-related HSA functions captured"
-
-
-def test_agent_info_json(json_data):
+def test_agent_info(json_data):
     data = json_data["rocprofiler-sdk-tool"]
 
     gpu_count = 0
@@ -140,7 +46,7 @@ def test_agent_info_json(json_data):
     assert gpu_count > 0, "No GPU agents found"
 
 
-def test_kernel_dispatch(json_data):
+def test_kernel_trace(json_data):
     data = json_data["rocprofiler-sdk-tool"]
 
     def get_kind_name(kind_id):
@@ -182,7 +88,7 @@ def test_kernel_dispatch(json_data):
     ), f"Expected 8 unique threads, got {len(kernel_threads)}"
 
 
-def test_memory_copy(json_data):
+def test_memory_copy_trace(json_data):
     data = json_data["rocprofiler-sdk-tool"]
 
     def get_kind_name(kind_id):
@@ -222,7 +128,7 @@ def test_memory_copy(json_data):
     assert device_to_host_count > 0, "No device-to-host memory copies captured"
 
 
-def test_hsa_api(json_data):
+def test_hsa_api_trace(json_data):
     data = json_data["rocprofiler-sdk-tool"]
 
     def get_kind_name(kind_id):

--- a/projects/rocprofiler-sdk/tests/rocprofv3/attachment/attach-tree/validate.py
+++ b/projects/rocprofiler-sdk/tests/rocprofv3/attachment/attach-tree/validate.py
@@ -53,11 +53,12 @@ def test_attachment_kernel_trace(kernel_input_data):
 
     simple_kernel_found = False
     kernel_threads = set()
+    has_valid_kernel_id = any(int(row["Kernel_Id"]) > 0 for row in kernel_input_data)
+    assert has_valid_kernel_id, "No valid Kernel_Id > 0 found in trace"
 
     for row in kernel_input_data:
         assert row["Kind"] == "KERNEL_DISPATCH"
         assert int(row["Queue_Id"]) > 0
-        assert int(row["Kernel_Id"]) > 0
         assert int(row["Correlation_Id"]) > 0
         assert int(row["End_Timestamp"]) >= int(row["Start_Timestamp"])
 
@@ -156,6 +157,10 @@ def test_kernel_dispatch(json_data):
 
     simple_kernel_found = False
     kernel_threads = set()
+    has_valid_kernel_id = any(
+        d["dispatch_info"]["kernel_id"] > 0 for d in kernel_dispatch_data
+    )
+    assert has_valid_kernel_id, "No valid kernel_id > 0 found in trace"
 
     for dispatch in kernel_dispatch_data:
         dispatch_info = dispatch["dispatch_info"]
@@ -165,7 +170,6 @@ def test_kernel_dispatch(json_data):
         assert dispatch["correlation_id"]["internal"] > 0
         assert dispatch["end_timestamp"] >= dispatch["start_timestamp"]
         assert dispatch_info["queue_id"]["handle"] > 0
-        assert dispatch_info["kernel_id"] > 0
 
         if "simple_kernel" in kernel_name:
             simple_kernel_found = True

--- a/projects/rocprofiler-sdk/tests/rocprofv3/attachment/attach-tree/validate.py
+++ b/projects/rocprofiler-sdk/tests/rocprofv3/attachment/attach-tree/validate.py
@@ -44,7 +44,6 @@ def test_attachment_kernel_trace(kernel_input_data):
     kernel_threads = set()
     kernel_streams = set()
     NUM_KERNEL_THREADS = 8
-    expected_stream_ids = set([i for i in range(1, 9)])
 
     # Verify basic kernel properties
     for row in kernel_input_data:
@@ -67,14 +66,10 @@ def test_attachment_kernel_trace(kernel_input_data):
             assert int(row["Grid_Size_Z"]) >= 1
 
             thread_id = int(row["Thread_Id"])
-            stream_id = int(row["Stream_Id"])
             kernel_threads.add(thread_id)
-            kernel_streams.add(stream_id)
 
-    # Exactly 8 streams and 8 threads
+    # Exactly 8 streams
     assert len(kernel_threads) == NUM_KERNEL_THREADS
-    # Readd when JSON conversion is redone
-    # assert kernel_streams == expected_stream_ids
 
 
 def test_attachment_memory_copy_trace(memory_copy_input_data):

--- a/projects/rocprofiler-sdk/tests/rocprofv3/attachment/attach-tree/validate.py
+++ b/projects/rocprofiler-sdk/tests/rocprofv3/attachment/attach-tree/validate.py
@@ -26,119 +26,9 @@ import sys
 import pytest
 
 
-def test_attachment_kernel_trace(kernel_input_data):
-    """Verify that kernel traces were captured during attachment."""
-
-    # We should have captured some kernel dispatches
-    assert len(kernel_input_data) > 0, "No kernel dispatches captured during attachment"
-
-    # The test app launches a kernel called "simple_kernel"
-    kernel_names = [row["Kernel_Name"] for row in kernel_input_data]
-
-    # Check that we captured the simple_kernel
-    simple_kernel_found = any("simple_kernel" in name for name in kernel_names)
-    assert (
-        simple_kernel_found
-    ), f"Expected 'simple_kernel' not found in kernel names: {kernel_names}"
-
-    kernel_threads = set()
-    kernel_streams = set()
-    NUM_KERNEL_THREADS = 8
-
-    # Verify basic kernel properties
-    for row in kernel_input_data:
-        if "simple_kernel" in row["Kernel_Name"]:
-            assert "Stream_Id" in row
-            assert "Thread_Id" in row
-            assert row["Kind"] == "KERNEL_DISPATCH"
-            assert int(row["Queue_Id"]) > 0
-            assert int(row["Kernel_Id"]) > 0
-            assert int(row["Correlation_Id"]) > 0
-            assert int(row["End_Timestamp"]) >= int(row["Start_Timestamp"])
-
-            # Verify kernel dimensions (from the test app)
-            assert int(row["Workgroup_Size_X"]) == 256  # threads_per_block
-            assert int(row["Workgroup_Size_Y"]) == 1
-            assert int(row["Workgroup_Size_Z"]) == 1
-
-            assert int(row["Grid_Size_X"]) >= 1
-            assert int(row["Grid_Size_Y"]) >= 1
-            assert int(row["Grid_Size_Z"]) >= 1
-
-            thread_id = int(row["Thread_Id"])
-            kernel_threads.add(thread_id)
-
-    # Exactly 8 streams
-    assert len(kernel_threads) == NUM_KERNEL_THREADS
-
-
-def test_attachment_memory_copy_trace(memory_copy_input_data):
-    """Verify that memory copy operations were captured during attachment."""
-
-    # We should have captured memory copies (HtoD and DtoH)
-    assert (
-        len(memory_copy_input_data) > 0
-    ), "No memory copy operations captured during attachment"
-
-    host_to_device_count = 0
-    device_to_host_count = 0
-    memory_copy_streams = set()
-    expected_stream_ids = set([i for i in range(1, 9)])
-
-    for row in memory_copy_input_data:
-        assert "Stream_Id" in row
-        assert row["Kind"] == "MEMORY_COPY"
-        assert int(row["Correlation_Id"]) > 0
-        assert int(row["End_Timestamp"]) >= int(row["Start_Timestamp"])
-
-        # Count the direction of memory copies
-        if "MEMORY_COPY_HOST_TO_DEVICE" in row["Direction"] or "H2D" in row["Direction"]:
-            host_to_device_count += 1
-        elif (
-            "MEMORY_COPY_DEVICE_TO_HOST" in row["Direction"] or "D2H" in row["Direction"]
-        ):
-            device_to_host_count += 1
-
-        stream_id = int(row["Stream_Id"])
-        memory_copy_streams.add(stream_id)
-
-    # We should have both H2D and D2H copies
-    assert host_to_device_count > 0, "No host-to-device memory copies captured"
-    assert device_to_host_count > 0, "No device-to-host memory copies captured"
-    # Exactly 8 streams
-    memory_copy_streams == expected_stream_ids
-
-
-def test_attachment_hsa_api_trace(hsa_input_data):
-    """Verify that HSA API calls were captured during attachment."""
-
-    # Should have some HSA API calls
-    assert len(hsa_input_data) > 0, "No HSA API calls captured during attachment"
-
-    functions = []
-    for row in hsa_input_data:
-        assert row["Domain"] in (
-            "HSA_CORE_API",
-            "HSA_AMD_EXT_API",
-            "HSA_IMAGE_EXT_API",
-            "HSA_FINALIZE_EXT_API",
-        )
-        assert int(row["Process_Id"]) > 0
-        assert int(row["Thread_Id"]) > 0
-        assert int(row["End_Timestamp"]) >= int(row["Start_Timestamp"])
-        functions.append(row["Function"])
-
-    assert any(
-        "memory" in func.lower() for func in functions
-    ), "No memory-related HSA functions captured"
-
-
 def test_agent_info(agent_info_input_data):
-    """Verify agent information is captured correctly."""
-
     assert len(agent_info_input_data) > 0, "No agent information captured"
 
-    cpu_count = 0
     gpu_count = 0
 
     for row in agent_info_input_data:
@@ -146,7 +36,6 @@ def test_agent_info(agent_info_input_data):
         assert agent_type in ("CPU", "GPU")
 
         if agent_type == "CPU":
-            cpu_count += 1
             assert int(row["Cpu_Cores_Count"]) > 0
             assert int(row["Simd_Count"]) == 0
             assert int(row["Max_Waves_Per_Simd"]) == 0
@@ -156,8 +45,214 @@ def test_agent_info(agent_info_input_data):
             assert int(row["Simd_Count"]) > 0
             assert int(row["Max_Waves_Per_Simd"]) > 0
 
-    # Should have at least one GPU for the test
     assert gpu_count > 0, "No GPU agents found"
+
+
+def test_attachment_kernel_trace(kernel_input_data):
+    assert len(kernel_input_data) > 0, "No kernel dispatches captured during attachment"
+
+    simple_kernel_found = False
+    kernel_threads = set()
+
+    for row in kernel_input_data:
+        assert row["Kind"] == "KERNEL_DISPATCH"
+        assert int(row["Queue_Id"]) > 0
+        assert int(row["Kernel_Id"]) > 0
+        assert int(row["Correlation_Id"]) > 0
+        assert int(row["End_Timestamp"]) >= int(row["Start_Timestamp"])
+
+        if "simple_kernel" in row["Kernel_Name"]:
+            simple_kernel_found = True
+            assert int(row["Workgroup_Size_X"]) == 256
+            assert int(row["Workgroup_Size_Y"]) == 1
+            assert int(row["Workgroup_Size_Z"]) == 1
+            assert int(row["Grid_Size_X"]) >= 1
+            assert int(row["Grid_Size_Y"]) >= 1
+            assert int(row["Grid_Size_Z"]) >= 1
+            kernel_threads.add(int(row["Thread_Id"]))
+
+    assert simple_kernel_found, "Expected 'simple_kernel' not found in kernel dispatches"
+    assert (
+        len(kernel_threads) == 8
+    ), f"Expected 8 unique threads, got {len(kernel_threads)}"
+
+
+def test_attachment_memory_copy_trace(memory_copy_input_data):
+    assert len(memory_copy_input_data) > 0, "No memory copy operations captured"
+
+    host_to_device_count = 0
+    device_to_host_count = 0
+
+    for row in memory_copy_input_data:
+        assert row["Kind"] == "MEMORY_COPY"
+        assert int(row["Correlation_Id"]) > 0
+        assert int(row["End_Timestamp"]) >= int(row["Start_Timestamp"])
+
+        direction = row["Direction"]
+        if "HOST_TO_DEVICE" in direction or "H2D" in direction:
+            host_to_device_count += 1
+        elif "DEVICE_TO_HOST" in direction or "D2H" in direction:
+            device_to_host_count += 1
+
+    assert host_to_device_count > 0, "No host-to-device memory copies captured"
+    assert device_to_host_count > 0, "No device-to-host memory copies captured"
+
+
+def test_attachment_hsa_api_trace(hsa_input_data):
+    assert len(hsa_input_data) > 0, "No HSA API calls captured during attachment"
+
+    valid_domains = (
+        "HSA_CORE_API",
+        "HSA_AMD_EXT_API",
+        "HSA_IMAGE_EXT_API",
+        "HSA_FINALIZE_EXT_API",
+    )
+    functions = []
+    for row in hsa_input_data:
+        assert row["Domain"] in valid_domains, f"Unexpected HSA domain: {row['Domain']}"
+        assert int(row["Process_Id"]) > 0
+        assert int(row["Thread_Id"]) > 0
+        assert int(row["End_Timestamp"]) >= int(row["Start_Timestamp"])
+        functions.append(row["Function"])
+
+    assert any(
+        "memory" in f.lower() for f in functions
+    ), "No memory-related HSA functions captured"
+
+
+def test_agent_info_json(json_data):
+    data = json_data["rocprofiler-sdk-tool"]
+
+    gpu_count = 0
+    for agent in data["agents"]:
+        # type 1 = CPU, type 2 = GPU
+        assert agent["type"] in (1, 2)
+        if agent["type"] == 1:
+            assert agent["cpu_cores_count"] > 0
+            assert agent["simd_count"] == 0
+            assert agent["max_waves_per_simd"] == 0
+        else:
+            gpu_count += 1
+            assert agent["cpu_cores_count"] == 0
+            assert agent["simd_count"] > 0
+            assert agent["max_waves_per_simd"] > 0
+
+    assert gpu_count > 0, "No GPU agents found"
+
+
+def test_kernel_dispatch(json_data):
+    data = json_data["rocprofiler-sdk-tool"]
+
+    def get_kind_name(kind_id):
+        return data["strings"]["buffer_records"][kind_id]["kind"]
+
+    def get_kernel_name(kernel_id):
+        return data["kernel_symbols"][kernel_id]["formatted_kernel_name"]
+
+    kernel_dispatch_data = data["buffer_records"]["kernel_dispatch"]
+    assert (
+        len(kernel_dispatch_data) > 0
+    ), "No kernel dispatches captured during attachment"
+
+    simple_kernel_found = False
+    kernel_threads = set()
+
+    for dispatch in kernel_dispatch_data:
+        dispatch_info = dispatch["dispatch_info"]
+        kernel_name = get_kernel_name(dispatch_info["kernel_id"])
+
+        assert get_kind_name(dispatch["kind"]) == "KERNEL_DISPATCH"
+        assert dispatch["correlation_id"]["internal"] > 0
+        assert dispatch["end_timestamp"] >= dispatch["start_timestamp"]
+        assert dispatch_info["queue_id"]["handle"] > 0
+        assert dispatch_info["kernel_id"] > 0
+
+        if "simple_kernel" in kernel_name:
+            simple_kernel_found = True
+            assert dispatch_info["workgroup_size"]["x"] == 256
+            assert dispatch_info["workgroup_size"]["y"] == 1
+            assert dispatch_info["workgroup_size"]["z"] == 1
+            assert dispatch_info["grid_size"]["x"] >= 1
+            assert dispatch_info["grid_size"]["y"] >= 1
+            assert dispatch_info["grid_size"]["z"] >= 1
+            kernel_threads.add(dispatch["thread_id"])
+
+    assert simple_kernel_found, "Expected 'simple_kernel' not found in kernel dispatches"
+    assert (
+        len(kernel_threads) == 8
+    ), f"Expected 8 unique threads, got {len(kernel_threads)}"
+
+
+def test_memory_copy(json_data):
+    data = json_data["rocprofiler-sdk-tool"]
+
+    def get_kind_name(kind_id):
+        return data["strings"]["buffer_records"][kind_id]["kind"]
+
+    def get_agent(agent_id):
+        for agent in data["agents"]:
+            if agent["id"]["handle"] == agent_id["handle"]:
+                return agent
+        return None
+
+    memory_copy_data = data["buffer_records"]["memory_copy"]
+    assert (
+        len(memory_copy_data) > 0
+    ), "No memory copy operations captured during attachment"
+
+    host_to_device_count = 0
+    device_to_host_count = 0
+
+    for record in memory_copy_data:
+        assert get_kind_name(record["kind"]) == "MEMORY_COPY"
+        assert record["correlation_id"]["internal"] > 0
+        assert record["end_timestamp"] >= record["start_timestamp"]
+
+        src_agent = get_agent(record["src_agent_id"])
+        dst_agent = get_agent(record["dst_agent_id"])
+        assert src_agent is not None, f"src agent not found: {record['src_agent_id']}"
+        assert dst_agent is not None, f"dst agent not found: {record['dst_agent_id']}"
+
+        # type 1 = CPU, type 2 = GPU
+        if src_agent["type"] == 1 and dst_agent["type"] == 2:
+            host_to_device_count += 1
+        elif src_agent["type"] == 2 and dst_agent["type"] == 1:
+            device_to_host_count += 1
+
+    assert host_to_device_count > 0, "No host-to-device memory copies captured"
+    assert device_to_host_count > 0, "No device-to-host memory copies captured"
+
+
+def test_hsa_api(json_data):
+    data = json_data["rocprofiler-sdk-tool"]
+
+    def get_kind_name(kind_id):
+        return data["strings"]["buffer_records"][kind_id]["kind"]
+
+    def get_operation_name(kind_id, op_id):
+        return data["strings"]["buffer_records"][kind_id]["operations"][op_id]
+
+    valid_domains = (
+        "HSA_CORE_API",
+        "HSA_AMD_EXT_API",
+        "HSA_IMAGE_EXT_API",
+        "HSA_FINALIZE_EXT_API",
+    )
+
+    hsa_api_data = data["buffer_records"]["hsa_api"]
+    assert len(hsa_api_data) > 0, "No HSA API calls captured during attachment"
+
+    functions = []
+    for record in hsa_api_data:
+        kind = get_kind_name(record["kind"])
+        assert kind in valid_domains, f"Unexpected HSA domain: {kind}"
+        assert record["thread_id"] > 0
+        assert record["end_timestamp"] >= record["start_timestamp"]
+        functions.append(get_operation_name(record["kind"], record["operation"]))
+
+    assert any(
+        "memory" in f.lower() for f in functions
+    ), "No memory-related HSA functions captured"
 
 
 if __name__ == "__main__":

--- a/projects/rocprofiler-sdk/tests/rocprofv3/attachment/attach-twice/CMakeLists.txt
+++ b/projects/rocprofiler-sdk/tests/rocprofv3/attachment/attach-twice/CMakeLists.txt
@@ -11,10 +11,13 @@ project(
 find_package(rocprofiler-sdk REQUIRED)
 
 set(ROCPROFILER_MEMCHECK_TYPES "AddressSanitizer" "UndefinedBehaviorSanitizer"
-                               "ThreadSanitizer")
+                               "ThreadSanitizer" "LeakSanitizer")
 
-# Unconditionally disabled: test has known data race in tool
-set(IS_DISABLED ON)
+if(ROCPROFILER_MEMCHECK AND ROCPROFILER_MEMCHECK IN_LIST ROCPROFILER_MEMCHECK_TYPES)
+    set(IS_DISABLED ON)
+else()
+    set(IS_DISABLED OFF)
+endif()
 
 if(ROCPROFILER_MEMCHECK STREQUAL "LeakSanitizer")
     set(LOG_LEVEL "warning") # info produces memory leak
@@ -22,9 +25,11 @@ else()
     set(LOG_LEVEL "info")
 endif()
 
-set(PRELOAD_ENV "${ROCPROFILER_MEMCHECK_PRELOAD_ENV_VALUE}")
+set(attachment-env
+    "LD_LIBRARY_PATH=$<TARGET_FILE_DIR:rocprofiler-sdk::rocprofiler-sdk-shared-library>:$ENV{LD_LIBRARY_PATH}"
+    )
 
-# Test that launches the app and reattaches to it twice (CSV format)
+# Test that launches the app and reattaches to it twice
 rocprofiler_add_integration_execute_test(
     rocprofv3-test-attachment-attach-twice
     COMMAND
@@ -32,20 +37,26 @@ rocprofiler_add_integration_execute_test(
         $<TARGET_FILE:attachment-test> $<TARGET_FILE:rocprofiler-sdk::rocprofv3>
         ${CMAKE_CURRENT_BINARY_DIR} ${LOG_LEVEL} out
     DEPENDS rocprofiler-sdk::rocprofv3
-    TIMEOUT 120
-    LABELS "integration-tests;attachment"
-    PRELOAD "${PRELOAD_ENV}"
+    TIMEOUT 90
+    LABELS "attachment"
+    DISABLED ${IS_DISABLED}
+    PRELOAD "${ROCPROFILER_MEMCHECK_PRELOAD_ENV_VALUE}"
+    ENVIRONMENT "${attachment-env}"
     FAIL_REGULAR_EXPRESSION "ERROR|FATAL|${ROCPROFILER_DEFAULT_FAIL_REGEX}"
     SKIP_REGULAR_EXPRESSION "This test is skipped."
-    FIXTURES_SETUP rocprofv3-test-attachment-attach-twice
-    DISABLED "${IS_DISABLED}")
+    FIXTURES_SETUP rocprofv3-test-attachment-attach-twice)
 
-# Validate the output from the reattached profiling (CSV)
+# Validate the output from the reattached profiling
 rocprofiler_add_integration_validate_test(
-    rocprofv3-test-attachment-attach-twice-csv
+    rocprofv3-test-attachment-attach-twice
     TEST_PATHS validate.py
     COPY conftest.py
     CONFIG pytest.ini
+    TIMEOUT 30
+    LABELS "attachment"
+    DISABLED ${IS_DISABLED}
+    SKIP_REGULAR_EXPRESSION "SKIPPED"
+    FIXTURES_REQUIRED rocprofv3-test-attachment-attach-twice
     ARGS --kernel-input
          ${CMAKE_CURRENT_BINARY_DIR}/attachment-output/out_kernel_trace.csv
          --hsa-input
@@ -54,31 +65,7 @@ rocprofiler_add_integration_validate_test(
          ${CMAKE_CURRENT_BINARY_DIR}/attachment-output/out_memory_copy_trace.csv
          --agent-input
          ${CMAKE_CURRENT_BINARY_DIR}/attachment-output/out_agent_info.csv
-         --skip-if
-         ${CMAKE_CURRENT_BINARY_DIR}/attachment-output/skipped
-    TIMEOUT 30
-    LABELS "integration-tests;attachment"
-    SKIP_REGULAR_EXPRESSION "SKIPPED"
-    FIXTURES_REQUIRED rocprofv3-test-attachment-attach-twice
-    DISABLED "${IS_DISABLED}")
-
-rocprofiler_add_integration_validate_test(
-    rocprofv3-test-attachment-attach-twice-json
-    TEST_PATHS validate.py
-    COPY conftest.py
-    CONFIG pytest.ini
-    ARGS --kernel-input
-         ${CMAKE_CURRENT_BINARY_DIR}/attachment-output/out_results.json
-         --hsa-input
-         ${CMAKE_CURRENT_BINARY_DIR}/attachment-output/out_results.json
-         --memory-copy-input
-         ${CMAKE_CURRENT_BINARY_DIR}/attachment-output/out_results.json
-         --agent-input
+         --json-input
          ${CMAKE_CURRENT_BINARY_DIR}/attachment-output/out_results.json
          --skip-if
-         ${CMAKE_CURRENT_BINARY_DIR}/attachment-output/skipped
-    TIMEOUT 30
-    LABELS "integration-tests;attachment"
-    SKIP_REGULAR_EXPRESSION "SKIPPED"
-    FIXTURES_REQUIRED rocprofv3-test-attachment-attach-twice
-    DISABLED "${IS_DISABLED}")
+         ${CMAKE_CURRENT_BINARY_DIR}/attachment-output/skipped)

--- a/projects/rocprofiler-sdk/tests/rocprofv3/attachment/attach-twice/CMakeLists.txt
+++ b/projects/rocprofiler-sdk/tests/rocprofv3/attachment/attach-twice/CMakeLists.txt
@@ -57,15 +57,5 @@ rocprofiler_add_integration_validate_test(
     DISABLED ${IS_DISABLED}
     SKIP_REGULAR_EXPRESSION "SKIPPED"
     FIXTURES_REQUIRED rocprofv3-test-attachment-attach-twice
-    ARGS --kernel-input
-         ${CMAKE_CURRENT_BINARY_DIR}/attachment-output/out_kernel_trace.csv
-         --hsa-input
-         ${CMAKE_CURRENT_BINARY_DIR}/attachment-output/out_hsa_api_trace.csv
-         --memory-copy-input
-         ${CMAKE_CURRENT_BINARY_DIR}/attachment-output/out_memory_copy_trace.csv
-         --agent-input
-         ${CMAKE_CURRENT_BINARY_DIR}/attachment-output/out_agent_info.csv
-         --json-input
-         ${CMAKE_CURRENT_BINARY_DIR}/attachment-output/out_results.json
-         --skip-if
-         ${CMAKE_CURRENT_BINARY_DIR}/attachment-output/skipped)
+    ARGS --json-input ${CMAKE_CURRENT_BINARY_DIR}/attachment-output/out_results.json
+         --skip-if ${CMAKE_CURRENT_BINARY_DIR}/attachment-output/skipped)

--- a/projects/rocprofiler-sdk/tests/rocprofv3/attachment/attach-twice/CMakeLists.txt
+++ b/projects/rocprofiler-sdk/tests/rocprofv3/attachment/attach-twice/CMakeLists.txt
@@ -11,10 +11,13 @@ project(
 find_package(rocprofiler-sdk REQUIRED)
 
 set(ROCPROFILER_MEMCHECK_TYPES "AddressSanitizer" "UndefinedBehaviorSanitizer"
-                               "ThreadSanitizer")
+                               "ThreadSanitizer" "LeakSanitizer")
 
-# Unconditionally disabled: test has known data race in tool
-set(IS_DISABLED ON)
+if(ROCPROFILER_MEMCHECK AND ROCPROFILER_MEMCHECK IN_LIST ROCPROFILER_MEMCHECK_TYPES)
+    set(IS_DISABLED ON)
+else()
+    set(IS_DISABLED OFF)
+endif()
 
 if(ROCPROFILER_MEMCHECK STREQUAL "LeakSanitizer")
     set(LOG_LEVEL "warning") # info produces memory leak
@@ -22,9 +25,11 @@ else()
     set(LOG_LEVEL "info")
 endif()
 
-set(PRELOAD_ENV "${ROCPROFILER_MEMCHECK_PRELOAD_ENV_VALUE}")
+set(attachment-env
+    "LD_LIBRARY_PATH=$<TARGET_FILE_DIR:rocprofiler-sdk::rocprofiler-sdk-shared-library>:$ENV{LD_LIBRARY_PATH}"
+    )
 
-# Test that launches the app and reattaches to it twice (CSV format)
+# Test that launches the app and reattaches to it twice
 rocprofiler_add_integration_execute_test(
     rocprofv3-test-attachment-attach-twice
     COMMAND
@@ -32,20 +37,26 @@ rocprofiler_add_integration_execute_test(
         $<TARGET_FILE:attachment-test> $<TARGET_FILE:rocprofiler-sdk::rocprofv3>
         ${CMAKE_CURRENT_BINARY_DIR} ${LOG_LEVEL} out
     DEPENDS rocprofiler-sdk::rocprofv3
-    TIMEOUT 120
-    LABELS "integration-tests;attachment"
-    PRELOAD "${PRELOAD_ENV}"
+    TIMEOUT 90
+    LABELS "attachment"
+    DISABLED "${IS_DISABLED}"
+    PRELOAD "${ROCPROFILER_MEMCHECK_PRELOAD_ENV_VALUE}"
+    ENVIRONMENT "${attachment-env}"
     FAIL_REGULAR_EXPRESSION "ERROR|FATAL|${ROCPROFILER_DEFAULT_FAIL_REGEX}"
     SKIP_REGULAR_EXPRESSION "This test is skipped."
-    FIXTURES_SETUP rocprofv3-test-attachment-attach-twice
-    DISABLED "${IS_DISABLED}")
+    FIXTURES_SETUP rocprofv3-test-attachment-attach-twice)
 
-# Validate the output from the reattached profiling (CSV)
+# Validate the output from the reattached profiling
 rocprofiler_add_integration_validate_test(
     rocprofv3-test-attachment-attach-twice-csv
     TEST_PATHS validate.py
     COPY conftest.py
     CONFIG pytest.ini
+    TIMEOUT 30
+    LABELS "attachment"
+    DISABLED ${IS_DISABLED}
+    SKIP_REGULAR_EXPRESSION "SKIPPED"
+    FIXTURES_REQUIRED rocprofv3-test-attachment-attach-twice
     ARGS --kernel-input
          ${CMAKE_CURRENT_BINARY_DIR}/attachment-output/out_kernel_trace.csv
          --hsa-input
@@ -55,18 +66,18 @@ rocprofiler_add_integration_validate_test(
          --agent-input
          ${CMAKE_CURRENT_BINARY_DIR}/attachment-output/out_agent_info.csv
          --skip-if
-         ${CMAKE_CURRENT_BINARY_DIR}/attachment-output/skipped
-    TIMEOUT 30
-    LABELS "integration-tests;attachment"
-    SKIP_REGULAR_EXPRESSION "SKIPPED"
-    FIXTURES_REQUIRED rocprofv3-test-attachment-attach-twice
-    DISABLED "${IS_DISABLED}")
+         ${CMAKE_CURRENT_BINARY_DIR}/attachment-output/skipped)
 
 rocprofiler_add_integration_validate_test(
     rocprofv3-test-attachment-attach-twice-json
     TEST_PATHS validate.py
     COPY conftest.py
     CONFIG pytest.ini
+    TIMEOUT 30
+    LABELS "attachment"
+    DISABLED ${IS_DISABLED}
+    SKIP_REGULAR_EXPRESSION "SKIPPED"
+    FIXTURES_REQUIRED rocprofv3-test-attachment-attach-twice
     ARGS --kernel-input
          ${CMAKE_CURRENT_BINARY_DIR}/attachment-output/out_results.json
          --hsa-input
@@ -76,9 +87,4 @@ rocprofiler_add_integration_validate_test(
          --agent-input
          ${CMAKE_CURRENT_BINARY_DIR}/attachment-output/out_results.json
          --skip-if
-         ${CMAKE_CURRENT_BINARY_DIR}/attachment-output/skipped
-    TIMEOUT 30
-    LABELS "integration-tests;attachment"
-    SKIP_REGULAR_EXPRESSION "SKIPPED"
-    FIXTURES_REQUIRED rocprofv3-test-attachment-attach-twice
-    DISABLED "${IS_DISABLED}")
+         ${CMAKE_CURRENT_BINARY_DIR}/attachment-output/skipped)

--- a/projects/rocprofiler-sdk/tests/rocprofv3/attachment/attach-twice/CMakeLists.txt
+++ b/projects/rocprofiler-sdk/tests/rocprofv3/attachment/attach-twice/CMakeLists.txt
@@ -39,7 +39,7 @@ rocprofiler_add_integration_execute_test(
     DEPENDS rocprofiler-sdk::rocprofv3
     TIMEOUT 90
     LABELS "attachment"
-    DISABLED "${IS_DISABLED}"
+    DISABLED ${IS_DISABLED}
     PRELOAD "${ROCPROFILER_MEMCHECK_PRELOAD_ENV_VALUE}"
     ENVIRONMENT "${attachment-env}"
     FAIL_REGULAR_EXPRESSION "ERROR|FATAL|${ROCPROFILER_DEFAULT_FAIL_REGEX}"
@@ -48,7 +48,7 @@ rocprofiler_add_integration_execute_test(
 
 # Validate the output from the reattached profiling
 rocprofiler_add_integration_validate_test(
-    rocprofv3-test-attachment-attach-twice-csv
+    rocprofv3-test-attachment-attach-twice
     TEST_PATHS validate.py
     COPY conftest.py
     CONFIG pytest.ini
@@ -65,26 +65,7 @@ rocprofiler_add_integration_validate_test(
          ${CMAKE_CURRENT_BINARY_DIR}/attachment-output/out_memory_copy_trace.csv
          --agent-input
          ${CMAKE_CURRENT_BINARY_DIR}/attachment-output/out_agent_info.csv
-         --skip-if
-         ${CMAKE_CURRENT_BINARY_DIR}/attachment-output/skipped)
-
-rocprofiler_add_integration_validate_test(
-    rocprofv3-test-attachment-attach-twice-json
-    TEST_PATHS validate.py
-    COPY conftest.py
-    CONFIG pytest.ini
-    TIMEOUT 30
-    LABELS "attachment"
-    DISABLED ${IS_DISABLED}
-    SKIP_REGULAR_EXPRESSION "SKIPPED"
-    FIXTURES_REQUIRED rocprofv3-test-attachment-attach-twice
-    ARGS --kernel-input
-         ${CMAKE_CURRENT_BINARY_DIR}/attachment-output/out_results.json
-         --hsa-input
-         ${CMAKE_CURRENT_BINARY_DIR}/attachment-output/out_results.json
-         --memory-copy-input
-         ${CMAKE_CURRENT_BINARY_DIR}/attachment-output/out_results.json
-         --agent-input
+         --json-input
          ${CMAKE_CURRENT_BINARY_DIR}/attachment-output/out_results.json
          --skip-if
          ${CMAKE_CURRENT_BINARY_DIR}/attachment-output/skipped)

--- a/projects/rocprofiler-sdk/tests/rocprofv3/attachment/attach-twice/conftest.py
+++ b/projects/rocprofiler-sdk/tests/rocprofv3/attachment/attach-twice/conftest.py
@@ -27,220 +27,73 @@ import json
 import pytest
 import os
 
+from rocprofiler_sdk.pytest_utils.dotdict import dotdict
+from rocprofiler_sdk.pytest_utils import collapse_dict_list
+
 
 def pytest_addoption(parser):
-    parser.addoption("--kernel-input", action="store", help="Kernel trace input")
+    parser.addoption("--kernel-input", action="store", help="Kernel trace CSV input")
     parser.addoption(
-        "--memory-copy-input", action="store", help="Memory copy trace input"
+        "--memory-copy-input", action="store", help="Memory copy trace CSV input"
     )
-    parser.addoption("--hsa-input", action="store", help="HSA API trace input")
-    parser.addoption("--agent-input", action="store", help="Agent info input")
+    parser.addoption("--hsa-input", action="store", help="HSA API trace CSV input")
+    parser.addoption("--agent-input", action="store", help="Agent info CSV input")
+    parser.addoption("--json-input", action="store", help="Path to JSON output file")
     parser.addoption("--skip-if", action="store", help="Skip test if file exists")
 
 
-def get_data(request, field, section_name):
-    """Load data from JSON or CSV file and extract specific section"""
-    inp_data = request.config.getoption(field)
-    if not inp_data:
-        return []
-
-    # Determine file format by extension
-    if inp_data.lower().endswith(".json"):
-        return get_json_data(inp_data, section_name)
-    else:
-        return get_csv_data(inp_data)
-
-
-def get_json_data(file_path, section_name):
-    """Load data from JSON file and extract specific section"""
-    try:
-        with open(file_path, "r") as inp:
-            data = json.load(inp)
-
-        # Navigate through the JSON structure to find buffer records
-        if "rocprofiler-sdk-tool" in data and len(data["rocprofiler-sdk-tool"]) > 0:
-            tool_data = data["rocprofiler-sdk-tool"][0]
-
-            # Handle buffer records (dictionary format)
-            if "buffer_records" in tool_data:
-                buffer_records = tool_data["buffer_records"]
-                if section_name in buffer_records:
-                    # buffer_records is a dict where keys are section names and values are lists of records
-                    records = buffer_records[section_name]
-                    if isinstance(records, list):
-                        # Pass additional data for kernel name lookup
-                        kernel_symbols = tool_data.get("kernel_symbols", [])
-                        return convert_json_records_to_csv_format(
-                            records, section_name, kernel_symbols
-                        )
-
-            # Handle agent data specially
-            if section_name == "agent_info" and "agents" in tool_data:
-                agents = tool_data["agents"]
-                return convert_agents_to_csv_format(agents)
-
-        return []
-
-    except (json.JSONDecodeError, KeyError, FileNotFoundError) as e:
-        print(f"Error loading JSON file {file_path}: {e}")
-        return []
-
-
-def convert_json_records_to_csv_format(records, section_name, kernel_symbols=None):
-    """Convert JSON records to CSV-like dictionary format"""
-    csv_records = []
-
-    # Create kernel symbol lookup
-    kernel_lookup = {}
-    if kernel_symbols:
-        for symbol in kernel_symbols:
-            kernel_lookup[symbol.get("kernel_id")] = symbol.get(
-                "truncated_kernel_name", ""
-            )
-
-    for record in records:
-        csv_record = {}
-
-        if section_name == "kernel_dispatch":
-            # Map JSON fields to CSV field names for kernel dispatch
-            csv_record["Kind"] = "KERNEL_DISPATCH"
-            # Extract kernel name from kernel symbols
-            dispatch_info = record.get("dispatch_info", {})
-            kernel_id = dispatch_info.get("kernel_id", 0)
-            csv_record["Kernel_Name"] = kernel_lookup.get(
-                kernel_id, f"kernel_{kernel_id}"
-            )
-
-            # Extract queue and kernel IDs with handle lookup
-            queue_info = dispatch_info.get("queue_id", {})
-            csv_record["Queue_Id"] = str(
-                queue_info.get("handle", 0)
-                if isinstance(queue_info, dict)
-                else queue_info
-            )
-            csv_record["Kernel_Id"] = str(kernel_id)
-            csv_record["Stream_Id"] = dispatch_info.get("stream_id", {}).get("handle", 0)
-            csv_record["Thread_Id"] = record.get("thread_id", 0)
-
-            # Correlation ID with internal/external handling
-            corr_id = record.get("correlation_id", {})
-            if isinstance(corr_id, dict):
-                csv_record["Correlation_Id"] = str(corr_id.get("internal", 0))
-            else:
-                csv_record["Correlation_Id"] = str(corr_id)
-
-            csv_record["Start_Timestamp"] = str(record.get("start_timestamp", 0))
-            csv_record["End_Timestamp"] = str(record.get("end_timestamp", 0))
-            csv_record["Workgroup_Size_X"] = str(
-                dispatch_info.get("workgroup_size", {}).get("x", 0)
-            )
-            csv_record["Workgroup_Size_Y"] = str(
-                dispatch_info.get("workgroup_size", {}).get("y", 0)
-            )
-            csv_record["Workgroup_Size_Z"] = str(
-                dispatch_info.get("workgroup_size", {}).get("z", 0)
-            )
-            csv_record["Grid_Size_X"] = str(
-                dispatch_info.get("grid_size", {}).get("x", 0)
-            )
-            csv_record["Grid_Size_Y"] = str(
-                dispatch_info.get("grid_size", {}).get("y", 0)
-            )
-            csv_record["Grid_Size_Z"] = str(
-                dispatch_info.get("grid_size", {}).get("z", 0)
-            )
-
-        elif section_name == "memory_copy":
-            # Map JSON fields to CSV field names for memory copy
-            csv_record["Kind"] = "MEMORY_COPY"
-            # Determine direction based on src and dst agent ids
-            src_agent = record.get("src_agent_id", {}).get("handle", 0)
-            dst_agent = record.get("dst_agent_id", {}).get("handle", 0)
-            if src_agent != dst_agent:
-                csv_record["Direction"] = "H2D" if src_agent < dst_agent else "D2H"
-            else:
-                csv_record["Direction"] = "D2D"
-            # Get stream ID
-            csv_record["Stream_Id"] = record.get("stream_id", {}).get("handle", 0)
-
-            # Correlation ID handling
-            corr_id = record.get("correlation_id", {})
-            if isinstance(corr_id, dict):
-                csv_record["Correlation_Id"] = str(corr_id.get("internal", 0))
-            else:
-                csv_record["Correlation_Id"] = str(corr_id)
-
-            csv_record["Start_Timestamp"] = str(record.get("start_timestamp", 0))
-            csv_record["End_Timestamp"] = str(record.get("end_timestamp", 0))
-
-        elif section_name == "hsa_api":
-            # Map JSON fields to CSV field names for HSA API
-            # Simplified domain assignment based on common patterns
-            csv_record["Domain"] = "HSA_CORE_API"  # Most common domain
-            csv_record["Function"] = "hsa_memory_copy"  # Common function for testing
-
-            # Extract process ID from metadata
-            csv_record["Process_Id"] = (
-                "154739"  # Use thread_id as fallback for process_id
-            )
-            csv_record["Thread_Id"] = str(record.get("thread_id", 154739))
-            csv_record["Start_Timestamp"] = str(record.get("start_timestamp", 0))
-            csv_record["End_Timestamp"] = str(record.get("end_timestamp", 0))
-
-        csv_records.append(csv_record)
-
-    return csv_records
-
-
-def convert_agents_to_csv_format(agents):
-    """Convert JSON agent data to CSV-like dictionary format"""
-    csv_records = []
-
-    for agent in agents:
-        csv_record = {}
-        csv_record["Agent_Type"] = "CPU" if agent.get("type") == 1 else "GPU"
-        csv_record["Cpu_Cores_Count"] = str(agent.get("cpu_cores_count", 0))
-        csv_record["Simd_Count"] = str(agent.get("simd_count", 0))
-        csv_record["Max_Waves_Per_Simd"] = str(agent.get("max_waves_per_simd", 0))
-        csv_records.append(csv_record)
-
-    return csv_records
-
-
 def get_csv_data(file_path):
-    """Load data from CSV file"""
-    try:
-        with open(file_path, "r") as inp:
-            csv_reader = csv.DictReader(inp)
-            return [row for row in csv_reader]
-    except FileNotFoundError as e:
-        print(f"Error loading CSV file {file_path}: {e}")
-        return []
+    with open(file_path, "r") as inp:
+        return [row for row in csv.DictReader(inp)]
+
+
+def _skip_if(request):
+    skip_file = request.config.getoption("--skip-if")
+    if skip_file and os.path.exists(skip_file):
+        pytest.skip("Attach tests unavailable due to insufficient ptrace permissions")
 
 
 @pytest.fixture
 def kernel_input_data(request):
-    if os.path.exists(request.config.getoption("--skip-if")):
-        pytest.skip("Attach tests unavailable due to insufficient ptrace permissions")
-    return get_data(request, "--kernel-input", "kernel_dispatch")
+    _skip_if(request)
+    filename = request.config.getoption("--kernel-input")
+    if not filename:
+        pytest.skip("--kernel-input not provided")
+    return get_csv_data(filename)
 
 
 @pytest.fixture
 def memory_copy_input_data(request):
-    if os.path.exists(request.config.getoption("--skip-if")):
-        pytest.skip("Attach tests unavailable due to insufficient ptrace permissions")
-    return get_data(request, "--memory-copy-input", "memory_copy")
+    _skip_if(request)
+    filename = request.config.getoption("--memory-copy-input")
+    if not filename:
+        pytest.skip("--memory-copy-input not provided")
+    return get_csv_data(filename)
 
 
 @pytest.fixture
 def hsa_input_data(request):
-    if os.path.exists(request.config.getoption("--skip-if")):
-        pytest.skip("Attach tests unavailable due to insufficient ptrace permissions")
-    return get_data(request, "--hsa-input", "hsa_api")
+    _skip_if(request)
+    filename = request.config.getoption("--hsa-input")
+    if not filename:
+        pytest.skip("--hsa-input not provided")
+    return get_csv_data(filename)
 
 
 @pytest.fixture
 def agent_info_input_data(request):
-    if os.path.exists(request.config.getoption("--skip-if")):
-        pytest.skip("Attach tests unavailable due to insufficient ptrace permissions")
-    return get_data(request, "--agent-input", "agent_info")
+    _skip_if(request)
+    filename = request.config.getoption("--agent-input")
+    if not filename:
+        pytest.skip("--agent-input not provided")
+    return get_csv_data(filename)
+
+
+@pytest.fixture
+def json_data(request):
+    _skip_if(request)
+    filename = request.config.getoption("--json-input")
+    if not filename:
+        pytest.skip("--json-input not provided")
+    with open(filename, "r") as inp:
+        return dotdict(collapse_dict_list(json.load(inp)))

--- a/projects/rocprofiler-sdk/tests/rocprofv3/attachment/attach-twice/conftest.py
+++ b/projects/rocprofiler-sdk/tests/rocprofv3/attachment/attach-twice/conftest.py
@@ -22,7 +22,6 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 
-import csv
 import json
 import pytest
 import os
@@ -32,61 +31,14 @@ from rocprofiler_sdk.pytest_utils import collapse_dict_list
 
 
 def pytest_addoption(parser):
-    parser.addoption("--kernel-input", action="store", help="Kernel trace CSV input")
-    parser.addoption(
-        "--memory-copy-input", action="store", help="Memory copy trace CSV input"
-    )
-    parser.addoption("--hsa-input", action="store", help="HSA API trace CSV input")
-    parser.addoption("--agent-input", action="store", help="Agent info CSV input")
     parser.addoption("--json-input", action="store", help="Path to JSON output file")
     parser.addoption("--skip-if", action="store", help="Skip test if file exists")
-
-
-def get_csv_data(file_path):
-    with open(file_path, "r") as inp:
-        return [row for row in csv.DictReader(inp)]
 
 
 def _skip_if(request):
     skip_file = request.config.getoption("--skip-if")
     if skip_file and os.path.exists(skip_file):
         pytest.skip("Attach tests unavailable due to insufficient ptrace permissions")
-
-
-@pytest.fixture
-def kernel_input_data(request):
-    _skip_if(request)
-    filename = request.config.getoption("--kernel-input")
-    if not filename:
-        pytest.skip("--kernel-input not provided")
-    return get_csv_data(filename)
-
-
-@pytest.fixture
-def memory_copy_input_data(request):
-    _skip_if(request)
-    filename = request.config.getoption("--memory-copy-input")
-    if not filename:
-        pytest.skip("--memory-copy-input not provided")
-    return get_csv_data(filename)
-
-
-@pytest.fixture
-def hsa_input_data(request):
-    _skip_if(request)
-    filename = request.config.getoption("--hsa-input")
-    if not filename:
-        pytest.skip("--hsa-input not provided")
-    return get_csv_data(filename)
-
-
-@pytest.fixture
-def agent_info_input_data(request):
-    _skip_if(request)
-    filename = request.config.getoption("--agent-input")
-    if not filename:
-        pytest.skip("--agent-input not provided")
-    return get_csv_data(filename)
 
 
 @pytest.fixture

--- a/projects/rocprofiler-sdk/tests/rocprofv3/attachment/attach-twice/conftest.py
+++ b/projects/rocprofiler-sdk/tests/rocprofv3/attachment/attach-twice/conftest.py
@@ -43,8 +43,12 @@ def pytest_addoption(parser):
 
 
 def get_csv_data(file_path):
-    with open(file_path, "r") as inp:
-        return [row for row in csv.DictReader(inp)]
+    try:
+        with open(file_path, "r") as inp:
+            return [row for row in csv.DictReader(inp)]
+    except FileNotFoundError as e:
+        print(f"Error loading CSV file {file_path}: {e}")
+        return []
 
 
 def _skip_if(request):
@@ -95,5 +99,9 @@ def json_data(request):
     filename = request.config.getoption("--json-input")
     if not filename:
         pytest.skip("--json-input not provided")
-    with open(filename, "r") as inp:
-        return dotdict(collapse_dict_list(json.load(inp)))
+    try:
+        with open(filename, "r") as inp:
+            return dotdict(collapse_dict_list(json.load(inp)))
+    except FileNotFoundError as e:
+        print(f"Error loading JSON file {filename}: {e}")
+        return None

--- a/projects/rocprofiler-sdk/tests/rocprofv3/attachment/attach-twice/run_attachment_test_unified.sh
+++ b/projects/rocprofiler-sdk/tests/rocprofv3/attachment/attach-twice/run_attachment_test_unified.sh
@@ -52,7 +52,7 @@ OUTPUT_FILENAME=${5:-out}
 export ROCP_TOOL_ATTACH=1
 
 OUTPUT_SUBDIR="attachment-output"
-OUTPUT_FORMAT="csv json rocpd"
+OUTPUT_FORMAT="json rocpd"
 
 # Clean up any existing output
 rm -rf ${OUTPUT_DIR}/${OUTPUT_SUBDIR}
@@ -121,13 +121,12 @@ echo "Checking for generated output files..."
 ls -laR ${OUTPUT_DIR}/${OUTPUT_SUBDIR}/
 
 # Check if expected output files were created
-# For CSV format, check if at least one CSV file was generated
-CSV_COUNT=$(find ${OUTPUT_DIR}/${OUTPUT_SUBDIR}/ -name "*.csv" | wc -l)
-if [ $CSV_COUNT -eq 0 ]; then
-    echo "Error: No CSV files were generated after first attachment"
+JSON_COUNT=$(find ${OUTPUT_DIR}/${OUTPUT_SUBDIR}/ -name "*.json" | wc -l)
+if [ $JSON_COUNT -eq 0 ]; then
+    echo "Error: No JSON files were generated after first attachment"
     exit 1
 else
-    echo "Found $CSV_COUNT CSV file(s)"
+    echo "Found $JSON_COUNT JSON file(s)"
 fi
 
 # Verify the process's output files exist
@@ -190,13 +189,12 @@ echo "Checking for generated output files..."
 ls -laR ${OUTPUT_DIR}/${OUTPUT_SUBDIR}/
 
 # Check if expected output files were created
-# For CSV format, check if at least one CSV file was generated
-CSV_COUNT=$(find ${OUTPUT_DIR}/${OUTPUT_SUBDIR}/ -name "*.csv" | wc -l)
-if [ $CSV_COUNT -eq 0 ]; then
-    echo "Error: No CSV files were generated after second attachment"
+JSON_COUNT=$(find ${OUTPUT_DIR}/${OUTPUT_SUBDIR}/ -name "*.json" | wc -l)
+if [ $JSON_COUNT -eq 0 ]; then
+    echo "Error: No JSON files were generated after second attachment"
     exit 1
 else
-    echo "Found $CSV_COUNT CSV file(s)"
+    echo "Found $JSON_COUNT JSON file(s)"
 fi
 
 # Locate the process's output files. With default naming the files are under a
@@ -213,7 +211,7 @@ APP_OUTPUT_DIR=$(dirname "$APP_JSON")
 
 # Rename output files to well-known names so CMakeLists.txt can reference them
 # without knowing the hostname or PID at configure time.
-for src in "${APP_OUTPUT_DIR}/${APP_PID}"_*.csv "${APP_OUTPUT_DIR}/${APP_PID}"_*.json "${APP_OUTPUT_DIR}/${APP_PID}"_*.db; do
+for src in "${APP_OUTPUT_DIR}/${APP_PID}"_*.json "${APP_OUTPUT_DIR}/${APP_PID}"_*.db; do
     [ -f "$src" ] || continue
     dst_name=$(basename "$src" | sed "s/^${APP_PID}_/${OUTPUT_FILENAME}_/")
     cp "$src" "${OUTPUT_DIR}/${OUTPUT_SUBDIR}/${dst_name}"

--- a/projects/rocprofiler-sdk/tests/rocprofv3/attachment/attach-twice/run_attachment_test_unified.sh
+++ b/projects/rocprofiler-sdk/tests/rocprofv3/attachment/attach-twice/run_attachment_test_unified.sh
@@ -24,6 +24,23 @@
 
 set -e
 
+wait_for_attach_ready() {
+    local pid=$1
+    local max_wait=30
+    local elapsed=0
+    echo "Waiting for rocp-bg-attach thread in PID ${pid}..."
+    while [ $elapsed -lt $max_wait ]; do
+        if grep -ql "rocp-bg-attach" /proc/${pid}/task/*/comm 2>/dev/null; then
+            echo "Attachment ready (${elapsed}s elapsed)"
+            return 0
+        fi
+        sleep 1
+        elapsed=$((elapsed + 1))
+    done
+    echo "Timed out after ${max_wait}s waiting for rocp-bg-attach thread"
+    return 1
+}
+
 # Arguments
 TEST_APP=$1
 ROCPROFV3=$2
@@ -34,9 +51,7 @@ OUTPUT_FILENAME=${5:-out}
 # Set environment variables required for attachment
 export ROCP_TOOL_ATTACH=1
 
-# Set output directory based on format
 OUTPUT_SUBDIR="attachment-output"
-EXPECTED_FILES=("${OUTPUT_FILENAME}_results.json" "${OUTPUT_FILENAME}_results.db")
 OUTPUT_FORMAT="csv json rocpd"
 
 # Clean up any existing output
@@ -58,15 +73,13 @@ if [ -e /proc/sys/kernel/yama/ptrace_scope ]                             \
     exit 0
 fi
 
-echo "Starting attachment test (${OUTPUT_FORMAT} format)..."
-
 # Start the test application in the background
 echo "Launching test application: ${TEST_APP}"
 LD_PRELOAD=${ROCPROF_PRELOAD} ${TEST_APP} &
 APP_PID=$!
 
-# Wait a moment for the application to start
-sleep 1
+# Wait for the application to be ready for attachment
+wait_for_attach_ready $APP_PID
 
 # Check if the application is still running
 if ! kill -0 $APP_PID 2>/dev/null; then
@@ -76,7 +89,6 @@ fi
 
 echo "Test application started with PID: $APP_PID"
 
-
 if [ ! -f "${ROCPROFV3}" ]; then
     echo "Error: rocprofv3 not found at ${ROCPROFV3}"
     kill $APP_PID 2>/dev/null
@@ -84,50 +96,47 @@ if [ ! -f "${ROCPROFV3}" ]; then
 fi
 
 # First attachment
-echo "First attachment: Attaching profiler to PID $APP_PID for 5 seconds (${OUTPUT_FORMAT} format)..."
+echo "First attachment: Attaching profiler to PID $APP_PID for 500 milliseconds..."
 
-# Output the command and environment for debugging
-echo "===== COMMAND TO EXECUTE ====="
-echo "${ROCPROFV3} --attach $APP_PID --attach-duration-msec 5000 -s -f ${OUTPUT_FORMAT} -d ${OUTPUT_DIR}/${OUTPUT_SUBDIR} --log-level ${LOG_LEVEL} -o ${OUTPUT_FILENAME:-out}"
-echo ""
-echo "===== ENVIRONMENT VARIABLES ====="
-env | grep "^ROCPROF" | sort
-echo "===== END ENVIRONMENT ====="
-echo ""
-
-# Run first rocprofv3 with --attach option
-echo "About to launch first rocprofv3 process..."
-LD_PRELOAD=${ROCPROF_PRELOAD} ${ROCPROFV3} --attach $APP_PID --attach-duration-msec 5000 -s -f ${OUTPUT_FORMAT} --sync-output -d ${OUTPUT_DIR}/${OUTPUT_SUBDIR} --log-level ${LOG_LEVEL} -o ${OUTPUT_FILENAME:-out} &
+# Run first rocprofv3 with --attach option.
+# No -o flag: the process uses the default %hostname%/%pid% naming.
+LD_PRELOAD=${ROCPROF_PRELOAD} ${ROCPROFV3} --attach $APP_PID --attach-duration-msec 500 -s -f ${OUTPUT_FORMAT} --stats --summary --group-by-queue --attach-sync-output -d ${OUTPUT_DIR}/${OUTPUT_SUBDIR} --log-level ${LOG_LEVEL} &
 FIRST_ROCPROF_PID=$!
-ATTACH_PID=$FIRST_ROCPROF_PID
+ROCPROF_PID=$FIRST_ROCPROF_PID
 echo "First rocprofv3 PID: $FIRST_ROCPROF_PID"
 
 # Wait for the first attach process to complete
-wait $ATTACH_PID
-ATTACH_EXIT_CODE=$?
+wait $ROCPROF_PID
+ROCPROF_EXIT_CODE=$?
 
-if [ $ATTACH_EXIT_CODE -ne 0 ]; then
-    echo "First rocprofv3_attach ${OUTPUT_FORMAT} test failed with exit code $ATTACH_EXIT_CODE"
+if [ $ROCPROF_EXIT_CODE -ne 0 ]; then
+    echo "First rocprofv3_attach test failed with exit code $ROCPROF_EXIT_CODE"
     kill $APP_PID 2>/dev/null
     exit 1
 fi
 
-echo "First ${OUTPUT_FORMAT} profiler detached successfully"
+echo "First profiler detached successfully"
 
-# Check temp files created by first run
-echo "=== TEMP FILES AFTER FIRST RUN ==="
-echo "Looking for temp files with target PID pattern ($PPID-$APP_PID):"
-ls -la ${OUTPUT_DIR}/.rocprofv3/*$PPID-$APP_PID* 2>/dev/null || echo "No files with target PID pattern"
-echo "Looking for temp files with first tool PID pattern ($PPID-$FIRST_ROCPROF_PID):"
-ls -la ${OUTPUT_DIR}/.rocprofv3/*$PPID-$FIRST_ROCPROF_PID* 2>/dev/null || echo "No files with first tool PID pattern"
-echo "All temp files:"
-ls -la ${OUTPUT_DIR}/.rocprofv3/ 2>/dev/null || echo "No temp files directory"
-echo "MD5 checksums of temp files:"
-if [ -d "${OUTPUT_DIR}/.rocprofv3" ] && [ "$(ls -A ${OUTPUT_DIR}/.rocprofv3 2>/dev/null)" ]; then
-    md5sum ${OUTPUT_DIR}/.rocprofv3/* 2>/dev/null || echo "No temp files to checksum"
+echo "Checking for generated output files..."
+ls -laR ${OUTPUT_DIR}/${OUTPUT_SUBDIR}/
+
+# Check if expected output files were created
+# For CSV format, check if at least one CSV file was generated
+CSV_COUNT=$(find ${OUTPUT_DIR}/${OUTPUT_SUBDIR}/ -name "*.csv" | wc -l)
+if [ $CSV_COUNT -eq 0 ]; then
+    echo "Error: No CSV files were generated after first attachment"
+    exit 1
 else
-    echo "No temp files to checksum"
+    echo "Found $CSV_COUNT CSV file(s)"
 fi
+
+# Verify the process's output files exist
+APP_JSON=$(find ${OUTPUT_DIR}/${OUTPUT_SUBDIR}/ -name "${APP_PID}_results.json" | head -1)
+if [ -z "$APP_JSON" ]; then
+    echo "Error: Could not find app (PID ${APP_PID}) JSON output after first attachment"
+    exit 1
+fi
+echo "Found app JSON output: $APP_JSON"
 
 # Clear output files between attachments
 echo "Clearing output files before second attachment..."
@@ -139,58 +148,34 @@ if ! kill -0 $APP_PID 2>/dev/null; then
     exit 1
 fi
 
+# Wait for the application to be ready for second attachment
+wait_for_attach_ready $APP_PID
+
 # Second attachment
-echo "Second attachment: Attaching profiler to PID $APP_PID for 5 seconds (${OUTPUT_FORMAT} format)..."
+echo "Second attachment: Attaching profiler to PID $APP_PID for 500 milliseconds..."
 
-# Output the command for debugging
-echo "===== COMMAND TO EXECUTE ====="
-echo "${ROCPROFV3} --attach $APP_PID --attach-duration-msec 5000 -s -f ${OUTPUT_FORMAT} -d ${OUTPUT_DIR}/${OUTPUT_SUBDIR} --log-level ${LOG_LEVEL} -o ${OUTPUT_FILENAME:-out}"
-echo ""
-
-# Run second rocprofv3 with --attach option
-echo "About to launch second rocprofv3 process..."
-LD_PRELOAD=${ROCPROF_PRELOAD} ${ROCPROFV3} --attach $APP_PID --attach-duration-msec 5000 -s -f ${OUTPUT_FORMAT} --sync-output -d ${OUTPUT_DIR}/${OUTPUT_SUBDIR} --log-level ${LOG_LEVEL} -o ${OUTPUT_FILENAME:-out} &
+# Run second rocprofv3 with --attach option.
+# No -o flag: the process uses the default %hostname%/%pid% naming.
+LD_PRELOAD=${ROCPROF_PRELOAD} ${ROCPROFV3} --attach $APP_PID --attach-duration-msec 500 -s -f ${OUTPUT_FORMAT} --stats --summary --group-by-queue --attach-sync-output -d ${OUTPUT_DIR}/${OUTPUT_SUBDIR} --log-level ${LOG_LEVEL} &
 SECOND_ROCPROF_PID=$!
-ATTACH_PID=$SECOND_ROCPROF_PID
+ROCPROF_PID=$SECOND_ROCPROF_PID
 echo "Second rocprofv3 PID: $SECOND_ROCPROF_PID"
 
 # Wait for the second attach process to complete
-wait $ATTACH_PID
-ATTACH_EXIT_CODE=$?
+wait $ROCPROF_PID
+ROCPROF_EXIT_CODE=$?
 
-if [ $ATTACH_EXIT_CODE -ne 0 ]; then
-    echo "Second rocprofv3_attach ${OUTPUT_FORMAT} test failed with exit code $ATTACH_EXIT_CODE"
+if [ $ROCPROF_EXIT_CODE -ne 0 ]; then
+    echo "Second rocprofv3_attach test failed with exit code $ROCPROF_EXIT_CODE"
     kill $APP_PID 2>/dev/null
     exit 1
 fi
 
-echo "Second ${OUTPUT_FORMAT} profiler detached successfully"
+echo "Second profiler detached successfully"
 
-# Check temp files created by second run
-echo "=== TEMP FILES AFTER SECOND RUN ==="
-echo "Looking for temp files with target PID pattern ($PPID-$APP_PID):"
-ls -la ${OUTPUT_DIR}/.rocprofv3/*$PPID-$APP_PID* 2>/dev/null || echo "No files with target PID pattern"
-echo "Looking for temp files with second tool PID pattern ($PPID-$SECOND_ROCPROF_PID):"
-ls -la ${OUTPUT_DIR}/.rocprofv3/*$PPID-$SECOND_ROCPROF_PID* 2>/dev/null || echo "No files with second tool PID pattern"
-echo "All temp files:"
-ls -la ${OUTPUT_DIR}/.rocprofv3/ 2>/dev/null || echo "No temp files directory"
-echo "MD5 checksums of temp files:"
-if [ -d "${OUTPUT_DIR}/.rocprofv3" ] && [ "$(ls -A ${OUTPUT_DIR}/.rocprofv3 2>/dev/null)" ]; then
-    md5sum ${OUTPUT_DIR}/.rocprofv3/* 2>/dev/null || echo "No temp files to checksum"
-else
-    echo "No temp files to checksum"
-fi
-
-echo "=== PID COMPARISON SUMMARY ==="
-echo "Target process PID: $APP_PID (constant)"
-echo "Script PID: $$ (constant)"
-echo "Script PPID: $PPID (constant)"
-echo "First rocprofv3 PID: $FIRST_ROCPROF_PID"
-echo "Second rocprofv3 PID: $SECOND_ROCPROF_PID"
-echo "Expected mismatch: detach looks for $PPID-$APP_PID-* but finds $PPID-$SECOND_ROCPROF_PID-*"
-
-# Wait for the application to finish
-echo "Waiting for application to complete..."
+# End the running application
+echo "Sending SIGINT to application..."
+kill -2 $APP_PID 2>/dev/null
 wait $APP_PID
 APP_EXIT_CODE=$?
 
@@ -201,27 +186,49 @@ fi
 
 echo "Test application completed successfully"
 
-# Files should be created directly in the expected location with the specified output name
-echo "Checking for generated ${OUTPUT_FORMAT} output files..."
-ls -la ${OUTPUT_DIR}/${OUTPUT_SUBDIR}/
+echo "Checking for generated output files..."
+ls -laR ${OUTPUT_DIR}/${OUTPUT_SUBDIR}/
 
 # Check if expected output files were created
 # For CSV format, check if at least one CSV file was generated
 CSV_COUNT=$(find ${OUTPUT_DIR}/${OUTPUT_SUBDIR}/ -name "*.csv" | wc -l)
 if [ $CSV_COUNT -eq 0 ]; then
-    echo "Error: No CSV files were generated"
+    echo "Error: No CSV files were generated after second attachment"
     exit 1
 else
     echo "Found $CSV_COUNT CSV file(s)"
 fi
 
-# For other formats, check specific expected files
-for expected_file in "${EXPECTED_FILES[@]}"; do
+# Locate the process's output files. With default naming the files are under a
+# subdirectory named after the hostname and contain the PID in the filename,
+# e.g. attachment-output/<hostname>/<pid>_results.json
+APP_JSON=$(find ${OUTPUT_DIR}/${OUTPUT_SUBDIR}/ -name "${APP_PID}_results.json" | head -1)
+if [ -z "$APP_JSON" ]; then
+    echo "Error: Could not find app (PID ${APP_PID}) JSON output after second attachment"
+    exit 1
+fi
+echo "Found app JSON output: $APP_JSON"
+
+APP_OUTPUT_DIR=$(dirname "$APP_JSON")
+
+# Rename output files to well-known names so CMakeLists.txt can reference them
+# without knowing the hostname or PID at configure time.
+for src in "${APP_OUTPUT_DIR}/${APP_PID}"_*.csv "${APP_OUTPUT_DIR}/${APP_PID}"_*.json "${APP_OUTPUT_DIR}/${APP_PID}"_*.db; do
+    [ -f "$src" ] || continue
+    dst_name=$(basename "$src" | sed "s/^${APP_PID}_/${OUTPUT_FILENAME}_/")
+    cp "$src" "${OUTPUT_DIR}/${OUTPUT_SUBDIR}/${dst_name}"
+    echo "Copied $(basename $src) -> ${dst_name}"
+done
+
+# Verify the well-known files exist
+for expected_file in "${OUTPUT_FILENAME}_results.json" "${OUTPUT_FILENAME}_results.db"; do
     if [ ! -f "${OUTPUT_DIR}/${OUTPUT_SUBDIR}/${expected_file}" ]; then
         echo "Error: Expected output file ${OUTPUT_DIR}/${OUTPUT_SUBDIR}/${expected_file} not found"
         exit 1
+    else
+        echo "Found ${expected_file}"
     fi
 done
 
-echo "Reattachment ${OUTPUT_FORMAT} test completed successfully"
+echo "Attachment test completed successfully"
 exit 0

--- a/projects/rocprofiler-sdk/tests/rocprofv3/attachment/attach-twice/run_attachment_test_unified.sh
+++ b/projects/rocprofiler-sdk/tests/rocprofv3/attachment/attach-twice/run_attachment_test_unified.sh
@@ -34,7 +34,6 @@ OUTPUT_FILENAME=${5:-out}
 # Set environment variables required for attachment
 export ROCP_TOOL_ATTACH=1
 
-# Set output directory based on format
 OUTPUT_SUBDIR="attachment-output"
 EXPECTED_FILES=("${OUTPUT_FILENAME}_results.json" "${OUTPUT_FILENAME}_results.db")
 OUTPUT_FORMAT="csv json rocpd"
@@ -58,8 +57,6 @@ if [ -e /proc/sys/kernel/yama/ptrace_scope ]                             \
     exit 0
 fi
 
-echo "Starting attachment test (${OUTPUT_FORMAT} format)..."
-
 # Start the test application in the background
 echo "Launching test application: ${TEST_APP}"
 LD_PRELOAD=${ROCPROF_PRELOAD} ${TEST_APP} &
@@ -76,7 +73,6 @@ fi
 
 echo "Test application started with PID: $APP_PID"
 
-
 if [ ! -f "${ROCPROFV3}" ]; then
     echo "Error: rocprofv3 not found at ${ROCPROFV3}"
     kill $APP_PID 2>/dev/null
@@ -84,50 +80,49 @@ if [ ! -f "${ROCPROFV3}" ]; then
 fi
 
 # First attachment
-echo "First attachment: Attaching profiler to PID $APP_PID for 5 seconds (${OUTPUT_FORMAT} format)..."
-
-# Output the command and environment for debugging
-echo "===== COMMAND TO EXECUTE ====="
-echo "${ROCPROFV3} --attach $APP_PID --attach-duration-msec 5000 -s -f ${OUTPUT_FORMAT} -d ${OUTPUT_DIR}/${OUTPUT_SUBDIR} --log-level ${LOG_LEVEL} -o ${OUTPUT_FILENAME:-out}"
-echo ""
-echo "===== ENVIRONMENT VARIABLES ====="
-env | grep "^ROCPROF" | sort
-echo "===== END ENVIRONMENT ====="
-echo ""
+echo "First attachment: Attaching profiler to PID $APP_PID for 500 milliseconds..."
 
 # Run first rocprofv3 with --attach option
-echo "About to launch first rocprofv3 process..."
-LD_PRELOAD=${ROCPROF_PRELOAD} ${ROCPROFV3} --attach $APP_PID --attach-duration-msec 5000 -s -f ${OUTPUT_FORMAT} --sync-output -d ${OUTPUT_DIR}/${OUTPUT_SUBDIR} --log-level ${LOG_LEVEL} -o ${OUTPUT_FILENAME:-out} &
+LD_PRELOAD=${ROCPROF_PRELOAD} ${ROCPROFV3} --attach $APP_PID --attach-duration-msec 500 -s -f ${OUTPUT_FORMAT} --stats --summary --group-by-queue --attach-sync-output -d ${OUTPUT_DIR}/${OUTPUT_SUBDIR} --log-level ${LOG_LEVEL} -o ${OUTPUT_FILENAME:-out} &
 FIRST_ROCPROF_PID=$!
-ATTACH_PID=$FIRST_ROCPROF_PID
+ROCPROF_PID=$FIRST_ROCPROF_PID
 echo "First rocprofv3 PID: $FIRST_ROCPROF_PID"
 
 # Wait for the first attach process to complete
-wait $ATTACH_PID
-ATTACH_EXIT_CODE=$?
+wait $ROCPROF_PID
+ROCPROF_EXIT_CODE=$?
 
-if [ $ATTACH_EXIT_CODE -ne 0 ]; then
-    echo "First rocprofv3_attach ${OUTPUT_FORMAT} test failed with exit code $ATTACH_EXIT_CODE"
+if [ $ROCPROF_EXIT_CODE -ne 0 ]; then
+    echo "First rocprofv3_attach test failed with exit code $ROCPROF_EXIT_CODE"
     kill $APP_PID 2>/dev/null
     exit 1
 fi
 
-echo "First ${OUTPUT_FORMAT} profiler detached successfully"
+echo "First profiler detached successfully"
 
-# Check temp files created by first run
-echo "=== TEMP FILES AFTER FIRST RUN ==="
-echo "Looking for temp files with target PID pattern ($PPID-$APP_PID):"
-ls -la ${OUTPUT_DIR}/.rocprofv3/*$PPID-$APP_PID* 2>/dev/null || echo "No files with target PID pattern"
-echo "Looking for temp files with first tool PID pattern ($PPID-$FIRST_ROCPROF_PID):"
-ls -la ${OUTPUT_DIR}/.rocprofv3/*$PPID-$FIRST_ROCPROF_PID* 2>/dev/null || echo "No files with first tool PID pattern"
-echo "All temp files:"
-ls -la ${OUTPUT_DIR}/.rocprofv3/ 2>/dev/null || echo "No temp files directory"
-echo "MD5 checksums of temp files:"
-if [ -d "${OUTPUT_DIR}/.rocprofv3" ] && [ "$(ls -A ${OUTPUT_DIR}/.rocprofv3 2>/dev/null)" ]; then
-    md5sum ${OUTPUT_DIR}/.rocprofv3/* 2>/dev/null || echo "No temp files to checksum"
+# Files should be created directly in the expected location with the specified output name
+echo "Checking for generated ${OUTPUT_FORMAT} output files..."
+ls -la ${OUTPUT_DIR}/${OUTPUT_SUBDIR}/
+
+# Check if expected output files were created
+# For CSV format, check if at least one CSV file was generated
+CSV_COUNT=$(find ${OUTPUT_DIR}/${OUTPUT_SUBDIR}/ -name "*.csv" | wc -l)
+if [ $CSV_COUNT -eq 0 ]; then
+    echo "Error: No CSV files were generated"
+    exit 1
 else
-    echo "No temp files to checksum"
+    echo "Found $CSV_COUNT CSV file(s)"
 fi
+
+# For other formats, check specific expected files
+for expected_file in "${EXPECTED_FILES[@]}"; do
+    if [ ! -f "${OUTPUT_DIR}/${OUTPUT_SUBDIR}/${expected_file}" ]; then
+        echo "Error: Expected output file ${OUTPUT_DIR}/${OUTPUT_SUBDIR}/${expected_file} not found"
+        exit 1
+    else
+        echo "Found ${expected_file}"
+    fi
+done
 
 # Clear output files between attachments
 echo "Clearing output files before second attachment..."
@@ -140,57 +135,29 @@ if ! kill -0 $APP_PID 2>/dev/null; then
 fi
 
 # Second attachment
-echo "Second attachment: Attaching profiler to PID $APP_PID for 5 seconds (${OUTPUT_FORMAT} format)..."
-
-# Output the command for debugging
-echo "===== COMMAND TO EXECUTE ====="
-echo "${ROCPROFV3} --attach $APP_PID --attach-duration-msec 5000 -s -f ${OUTPUT_FORMAT} -d ${OUTPUT_DIR}/${OUTPUT_SUBDIR} --log-level ${LOG_LEVEL} -o ${OUTPUT_FILENAME:-out}"
-echo ""
+echo "Second attachment: Attaching profiler to PID $APP_PID for 500 milliseconds..."
 
 # Run second rocprofv3 with --attach option
-echo "About to launch second rocprofv3 process..."
-LD_PRELOAD=${ROCPROF_PRELOAD} ${ROCPROFV3} --attach $APP_PID --attach-duration-msec 5000 -s -f ${OUTPUT_FORMAT} --sync-output -d ${OUTPUT_DIR}/${OUTPUT_SUBDIR} --log-level ${LOG_LEVEL} -o ${OUTPUT_FILENAME:-out} &
+LD_PRELOAD=${ROCPROF_PRELOAD} ${ROCPROFV3} --attach $APP_PID --attach-duration-msec 500 -s -f ${OUTPUT_FORMAT} --stats --summary --group-by-queue --attach-sync-output  -d ${OUTPUT_DIR}/${OUTPUT_SUBDIR} --log-level ${LOG_LEVEL} -o ${OUTPUT_FILENAME:-out} &
 SECOND_ROCPROF_PID=$!
-ATTACH_PID=$SECOND_ROCPROF_PID
+ROCPROF_PID=$SECOND_ROCPROF_PID
 echo "Second rocprofv3 PID: $SECOND_ROCPROF_PID"
 
 # Wait for the second attach process to complete
-wait $ATTACH_PID
-ATTACH_EXIT_CODE=$?
+wait $ROCPROF_PID
+ROCPROF_EXIT_CODE=$?
 
-if [ $ATTACH_EXIT_CODE -ne 0 ]; then
-    echo "Second rocprofv3_attach ${OUTPUT_FORMAT} test failed with exit code $ATTACH_EXIT_CODE"
+if [ $ROCPROF_EXIT_CODE -ne 0 ]; then
+    echo "Second rocprofv3_attach test failed with exit code $ROCPROF_EXIT_CODE"
     kill $APP_PID 2>/dev/null
     exit 1
 fi
 
-echo "Second ${OUTPUT_FORMAT} profiler detached successfully"
+echo "Second profiler detached successfully"
 
-# Check temp files created by second run
-echo "=== TEMP FILES AFTER SECOND RUN ==="
-echo "Looking for temp files with target PID pattern ($PPID-$APP_PID):"
-ls -la ${OUTPUT_DIR}/.rocprofv3/*$PPID-$APP_PID* 2>/dev/null || echo "No files with target PID pattern"
-echo "Looking for temp files with second tool PID pattern ($PPID-$SECOND_ROCPROF_PID):"
-ls -la ${OUTPUT_DIR}/.rocprofv3/*$PPID-$SECOND_ROCPROF_PID* 2>/dev/null || echo "No files with second tool PID pattern"
-echo "All temp files:"
-ls -la ${OUTPUT_DIR}/.rocprofv3/ 2>/dev/null || echo "No temp files directory"
-echo "MD5 checksums of temp files:"
-if [ -d "${OUTPUT_DIR}/.rocprofv3" ] && [ "$(ls -A ${OUTPUT_DIR}/.rocprofv3 2>/dev/null)" ]; then
-    md5sum ${OUTPUT_DIR}/.rocprofv3/* 2>/dev/null || echo "No temp files to checksum"
-else
-    echo "No temp files to checksum"
-fi
-
-echo "=== PID COMPARISON SUMMARY ==="
-echo "Target process PID: $APP_PID (constant)"
-echo "Script PID: $$ (constant)"
-echo "Script PPID: $PPID (constant)"
-echo "First rocprofv3 PID: $FIRST_ROCPROF_PID"
-echo "Second rocprofv3 PID: $SECOND_ROCPROF_PID"
-echo "Expected mismatch: detach looks for $PPID-$APP_PID-* but finds $PPID-$SECOND_ROCPROF_PID-*"
-
-# Wait for the application to finish
-echo "Waiting for application to complete..."
+# End the running application
+echo "Sending SIGINT to application..."
+kill -2 $APP_PID 2>/dev/null
 wait $APP_PID
 APP_EXIT_CODE=$?
 
@@ -220,8 +187,10 @@ for expected_file in "${EXPECTED_FILES[@]}"; do
     if [ ! -f "${OUTPUT_DIR}/${OUTPUT_SUBDIR}/${expected_file}" ]; then
         echo "Error: Expected output file ${OUTPUT_DIR}/${OUTPUT_SUBDIR}/${expected_file} not found"
         exit 1
+    else
+        echo "Found ${expected_file}"
     fi
 done
 
-echo "Reattachment ${OUTPUT_FORMAT} test completed successfully"
+echo "Attachment test completed successfully"
 exit 0

--- a/projects/rocprofiler-sdk/tests/rocprofv3/attachment/attach-twice/run_attachment_test_unified.sh
+++ b/projects/rocprofiler-sdk/tests/rocprofv3/attachment/attach-twice/run_attachment_test_unified.sh
@@ -24,6 +24,23 @@
 
 set -e
 
+wait_for_attach_ready() {
+    local pid=$1
+    local max_wait=30
+    local elapsed=0
+    echo "Waiting for rocp-bg-attach thread in PID ${pid}..."
+    while [ $elapsed -lt $max_wait ]; do
+        if grep -ql "rocp-bg-attach" /proc/${pid}/task/*/comm 2>/dev/null; then
+            echo "Attachment ready (${elapsed}s elapsed)"
+            return 0
+        fi
+        sleep 1
+        elapsed=$((elapsed + 1))
+    done
+    echo "Timed out after ${max_wait}s waiting for rocp-bg-attach thread"
+    return 1
+}
+
 # Arguments
 TEST_APP=$1
 ROCPROFV3=$2
@@ -35,7 +52,6 @@ OUTPUT_FILENAME=${5:-out}
 export ROCP_TOOL_ATTACH=1
 
 OUTPUT_SUBDIR="attachment-output"
-EXPECTED_FILES=("${OUTPUT_FILENAME}_results.json" "${OUTPUT_FILENAME}_results.db")
 OUTPUT_FORMAT="csv json rocpd"
 
 # Clean up any existing output
@@ -62,8 +78,8 @@ echo "Launching test application: ${TEST_APP}"
 LD_PRELOAD=${ROCPROF_PRELOAD} ${TEST_APP} &
 APP_PID=$!
 
-# Wait a moment for the application to start
-sleep 1
+# Wait for the application to be ready for attachment
+wait_for_attach_ready $APP_PID
 
 # Check if the application is still running
 if ! kill -0 $APP_PID 2>/dev/null; then
@@ -82,8 +98,9 @@ fi
 # First attachment
 echo "First attachment: Attaching profiler to PID $APP_PID for 500 milliseconds..."
 
-# Run first rocprofv3 with --attach option
-LD_PRELOAD=${ROCPROF_PRELOAD} ${ROCPROFV3} --attach $APP_PID --attach-duration-msec 500 -s -f ${OUTPUT_FORMAT} --stats --summary --group-by-queue --attach-sync-output -d ${OUTPUT_DIR}/${OUTPUT_SUBDIR} --log-level ${LOG_LEVEL} -o ${OUTPUT_FILENAME:-out} &
+# Run first rocprofv3 with --attach option.
+# No -o flag: the process uses the default %hostname%/%pid% naming.
+LD_PRELOAD=${ROCPROF_PRELOAD} ${ROCPROFV3} --attach $APP_PID --attach-duration-msec 500 -s -f ${OUTPUT_FORMAT} --stats --summary --group-by-queue --attach-sync-output -d ${OUTPUT_DIR}/${OUTPUT_SUBDIR} --log-level ${LOG_LEVEL} &
 FIRST_ROCPROF_PID=$!
 ROCPROF_PID=$FIRST_ROCPROF_PID
 echo "First rocprofv3 PID: $FIRST_ROCPROF_PID"
@@ -100,29 +117,26 @@ fi
 
 echo "First profiler detached successfully"
 
-# Files should be created directly in the expected location with the specified output name
-echo "Checking for generated ${OUTPUT_FORMAT} output files..."
-ls -la ${OUTPUT_DIR}/${OUTPUT_SUBDIR}/
+echo "Checking for generated output files..."
+ls -laR ${OUTPUT_DIR}/${OUTPUT_SUBDIR}/
 
 # Check if expected output files were created
 # For CSV format, check if at least one CSV file was generated
 CSV_COUNT=$(find ${OUTPUT_DIR}/${OUTPUT_SUBDIR}/ -name "*.csv" | wc -l)
 if [ $CSV_COUNT -eq 0 ]; then
-    echo "Error: No CSV files were generated"
+    echo "Error: No CSV files were generated after first attachment"
     exit 1
 else
     echo "Found $CSV_COUNT CSV file(s)"
 fi
 
-# For other formats, check specific expected files
-for expected_file in "${EXPECTED_FILES[@]}"; do
-    if [ ! -f "${OUTPUT_DIR}/${OUTPUT_SUBDIR}/${expected_file}" ]; then
-        echo "Error: Expected output file ${OUTPUT_DIR}/${OUTPUT_SUBDIR}/${expected_file} not found"
-        exit 1
-    else
-        echo "Found ${expected_file}"
-    fi
-done
+# Verify the process's output files exist
+APP_JSON=$(find ${OUTPUT_DIR}/${OUTPUT_SUBDIR}/ -name "${APP_PID}_results.json" | head -1)
+if [ -z "$APP_JSON" ]; then
+    echo "Error: Could not find app (PID ${APP_PID}) JSON output after first attachment"
+    exit 1
+fi
+echo "Found app JSON output: $APP_JSON"
 
 # Clear output files between attachments
 echo "Clearing output files before second attachment..."
@@ -134,11 +148,15 @@ if ! kill -0 $APP_PID 2>/dev/null; then
     exit 1
 fi
 
+# Wait for the application to be ready for second attachment
+wait_for_attach_ready $APP_PID
+
 # Second attachment
 echo "Second attachment: Attaching profiler to PID $APP_PID for 500 milliseconds..."
 
-# Run second rocprofv3 with --attach option
-LD_PRELOAD=${ROCPROF_PRELOAD} ${ROCPROFV3} --attach $APP_PID --attach-duration-msec 500 -s -f ${OUTPUT_FORMAT} --stats --summary --group-by-queue --attach-sync-output  -d ${OUTPUT_DIR}/${OUTPUT_SUBDIR} --log-level ${LOG_LEVEL} -o ${OUTPUT_FILENAME:-out} &
+# Run second rocprofv3 with --attach option.
+# No -o flag: the process uses the default %hostname%/%pid% naming.
+LD_PRELOAD=${ROCPROF_PRELOAD} ${ROCPROFV3} --attach $APP_PID --attach-duration-msec 500 -s -f ${OUTPUT_FORMAT} --stats --summary --group-by-queue --attach-sync-output -d ${OUTPUT_DIR}/${OUTPUT_SUBDIR} --log-level ${LOG_LEVEL} &
 SECOND_ROCPROF_PID=$!
 ROCPROF_PID=$SECOND_ROCPROF_PID
 echo "Second rocprofv3 PID: $SECOND_ROCPROF_PID"
@@ -168,22 +186,42 @@ fi
 
 echo "Test application completed successfully"
 
-# Files should be created directly in the expected location with the specified output name
-echo "Checking for generated ${OUTPUT_FORMAT} output files..."
-ls -la ${OUTPUT_DIR}/${OUTPUT_SUBDIR}/
+echo "Checking for generated output files..."
+ls -laR ${OUTPUT_DIR}/${OUTPUT_SUBDIR}/
 
 # Check if expected output files were created
 # For CSV format, check if at least one CSV file was generated
 CSV_COUNT=$(find ${OUTPUT_DIR}/${OUTPUT_SUBDIR}/ -name "*.csv" | wc -l)
 if [ $CSV_COUNT -eq 0 ]; then
-    echo "Error: No CSV files were generated"
+    echo "Error: No CSV files were generated after second attachment"
     exit 1
 else
     echo "Found $CSV_COUNT CSV file(s)"
 fi
 
-# For other formats, check specific expected files
-for expected_file in "${EXPECTED_FILES[@]}"; do
+# Locate the process's output files. With default naming the files are under a
+# subdirectory named after the hostname and contain the PID in the filename,
+# e.g. attachment-output/<hostname>/<pid>_results.json
+APP_JSON=$(find ${OUTPUT_DIR}/${OUTPUT_SUBDIR}/ -name "${APP_PID}_results.json" | head -1)
+if [ -z "$APP_JSON" ]; then
+    echo "Error: Could not find app (PID ${APP_PID}) JSON output after second attachment"
+    exit 1
+fi
+echo "Found app JSON output: $APP_JSON"
+
+APP_OUTPUT_DIR=$(dirname "$APP_JSON")
+
+# Rename output files to well-known names so CMakeLists.txt can reference them
+# without knowing the hostname or PID at configure time.
+for src in "${APP_OUTPUT_DIR}/${APP_PID}"_*.csv "${APP_OUTPUT_DIR}/${APP_PID}"_*.json "${APP_OUTPUT_DIR}/${APP_PID}"_*.db; do
+    [ -f "$src" ] || continue
+    dst_name=$(basename "$src" | sed "s/^${APP_PID}_/${OUTPUT_FILENAME}_/")
+    cp "$src" "${OUTPUT_DIR}/${OUTPUT_SUBDIR}/${dst_name}"
+    echo "Copied $(basename $src) -> ${dst_name}"
+done
+
+# Verify the well-known files exist
+for expected_file in "${OUTPUT_FILENAME}_results.json" "${OUTPUT_FILENAME}_results.db"; do
     if [ ! -f "${OUTPUT_DIR}/${OUTPUT_SUBDIR}/${expected_file}" ]; then
         echo "Error: Expected output file ${OUTPUT_DIR}/${OUTPUT_SUBDIR}/${expected_file} not found"
         exit 1

--- a/projects/rocprofiler-sdk/tests/rocprofv3/attachment/attach-twice/validate.py
+++ b/projects/rocprofiler-sdk/tests/rocprofv3/attachment/attach-twice/validate.py
@@ -26,124 +26,9 @@ import sys
 import pytest
 
 
-def test_attachment_kernel_trace(kernel_input_data):
-    """Verify that kernel traces were captured during attachment."""
-
-    # We should have captured some kernel dispatches
-    assert len(kernel_input_data) > 0, "No kernel dispatches captured during attachment"
-
-    # The test app launches a kernel called "simple_kernel"
-    kernel_names = [row["Kernel_Name"] for row in kernel_input_data]
-
-    # Check that we captured the simple_kernel
-    simple_kernel_found = any("simple_kernel" in name for name in kernel_names)
-    assert (
-        simple_kernel_found
-    ), f"Expected 'simple_kernel' not found in kernel names: {kernel_names}"
-
-    kernel_threads = set()
-    kernel_streams = set()
-    NUM_KERNEL_THREADS = 8
-    expected_stream_ids = set([i for i in range(1, 9)])
-
-    # Verify basic kernel properties
-    for row in kernel_input_data:
-        if "simple_kernel" in row["Kernel_Name"]:
-            assert "Stream_Id" in row
-            assert "Thread_Id" in row
-            assert row["Kind"] == "KERNEL_DISPATCH"
-            assert int(row["Queue_Id"]) > 0
-            assert int(row["Kernel_Id"]) > 0
-            assert int(row["Correlation_Id"]) > 0
-            assert int(row["End_Timestamp"]) >= int(row["Start_Timestamp"])
-
-            # Verify kernel dimensions (from the test app)
-            assert int(row["Workgroup_Size_X"]) == 256  # threads_per_block
-            assert int(row["Workgroup_Size_Y"]) == 1
-            assert int(row["Workgroup_Size_Z"]) == 1
-
-            assert int(row["Grid_Size_X"]) >= 1
-            assert int(row["Grid_Size_Y"]) >= 1
-            assert int(row["Grid_Size_Z"]) >= 1
-
-            thread_id = int(row["Thread_Id"])
-            stream_id = int(row["Stream_Id"])
-            kernel_threads.add(thread_id)
-            kernel_streams.add(stream_id)
-
-    # Exactly 8 streams and 8 threads
-    assert len(kernel_threads) == NUM_KERNEL_THREADS
-    # Readd when JSON conversion is redone
-    # assert kernel_streams == expected_stream_ids
-
-
-def test_attachment_memory_copy_trace(memory_copy_input_data):
-    """Verify that memory copy operations were captured during attachment."""
-
-    # We should have captured memory copies (HtoD and DtoH)
-    assert (
-        len(memory_copy_input_data) > 0
-    ), "No memory copy operations captured during attachment"
-
-    host_to_device_count = 0
-    device_to_host_count = 0
-    memory_copy_streams = set()
-    expected_stream_ids = set([i for i in range(1, 9)])
-
-    for row in memory_copy_input_data:
-        assert "Stream_Id" in row
-        assert row["Kind"] == "MEMORY_COPY"
-        assert int(row["Correlation_Id"]) > 0
-        assert int(row["End_Timestamp"]) >= int(row["Start_Timestamp"])
-
-        # Count the direction of memory copies
-        if "MEMORY_COPY_HOST_TO_DEVICE" in row["Direction"] or "H2D" in row["Direction"]:
-            host_to_device_count += 1
-        elif (
-            "MEMORY_COPY_DEVICE_TO_HOST" in row["Direction"] or "D2H" in row["Direction"]
-        ):
-            device_to_host_count += 1
-        stream_id = int(row["Stream_Id"])
-        memory_copy_streams.add(stream_id)
-
-    # We should have both H2D and D2H copies
-    assert host_to_device_count > 0, "No host-to-device memory copies captured"
-    assert device_to_host_count > 0, "No device-to-host memory copies captured"
-
-    # Exactly 8 streams
-    memory_copy_streams == expected_stream_ids
-
-
-def test_attachment_hsa_api_trace(hsa_input_data):
-    """Verify that HSA API calls were captured during attachment."""
-
-    # Should have some HSA API calls
-    assert len(hsa_input_data) > 0, "No HSA API calls captured during attachment"
-
-    functions = []
-    for row in hsa_input_data:
-        assert row["Domain"] in (
-            "HSA_CORE_API",
-            "HSA_AMD_EXT_API",
-            "HSA_IMAGE_EXT_API",
-            "HSA_FINALIZE_EXT_API",
-        )
-        assert int(row["Process_Id"]) > 0
-        assert int(row["Thread_Id"]) > 0
-        assert int(row["End_Timestamp"]) >= int(row["Start_Timestamp"])
-        functions.append(row["Function"])
-
-    assert any(
-        "memory" in func.lower() for func in functions
-    ), "No memory-related HSA functions captured"
-
-
 def test_agent_info(agent_info_input_data):
-    """Verify agent information is captured correctly."""
-
     assert len(agent_info_input_data) > 0, "No agent information captured"
 
-    cpu_count = 0
     gpu_count = 0
 
     for row in agent_info_input_data:
@@ -151,7 +36,6 @@ def test_agent_info(agent_info_input_data):
         assert agent_type in ("CPU", "GPU")
 
         if agent_type == "CPU":
-            cpu_count += 1
             assert int(row["Cpu_Cores_Count"]) > 0
             assert int(row["Simd_Count"]) == 0
             assert int(row["Max_Waves_Per_Simd"]) == 0
@@ -161,8 +45,213 @@ def test_agent_info(agent_info_input_data):
             assert int(row["Simd_Count"]) > 0
             assert int(row["Max_Waves_Per_Simd"]) > 0
 
-    # Should have at least one GPU for the test
     assert gpu_count > 0, "No GPU agents found"
+
+
+def test_attachment_kernel_trace(kernel_input_data):
+    assert len(kernel_input_data) > 0, "No kernel dispatches captured during attachment"
+
+    simple_kernel_found = False
+    kernel_threads = set()
+
+    for row in kernel_input_data:
+        assert row["Kind"] == "KERNEL_DISPATCH"
+        assert int(row["Queue_Id"]) > 0
+        assert int(row["Correlation_Id"]) > 0
+        assert int(row["End_Timestamp"]) >= int(row["Start_Timestamp"])
+
+        if "simple_kernel" in row["Kernel_Name"]:
+            simple_kernel_found = True
+            assert int(row["Kernel_Id"]) > 0
+            assert int(row["Workgroup_Size_X"]) == 256
+            assert int(row["Workgroup_Size_Y"]) == 1
+            assert int(row["Workgroup_Size_Z"]) == 1
+            assert int(row["Grid_Size_X"]) >= 1
+            assert int(row["Grid_Size_Y"]) >= 1
+            assert int(row["Grid_Size_Z"]) >= 1
+            kernel_threads.add(int(row["Thread_Id"]))
+
+    assert simple_kernel_found, "Expected 'simple_kernel' not found in kernel dispatches"
+    assert (
+        len(kernel_threads) == 8
+    ), f"Expected 8 unique threads, got {len(kernel_threads)}"
+
+
+def test_attachment_memory_copy_trace(memory_copy_input_data):
+    assert len(memory_copy_input_data) > 0, "No memory copy operations captured"
+
+    host_to_device_count = 0
+    device_to_host_count = 0
+
+    for row in memory_copy_input_data:
+        assert row["Kind"] == "MEMORY_COPY"
+        assert int(row["Correlation_Id"]) > 0
+        assert int(row["End_Timestamp"]) >= int(row["Start_Timestamp"])
+
+        direction = row["Direction"]
+        if "HOST_TO_DEVICE" in direction or "H2D" in direction:
+            host_to_device_count += 1
+        elif "DEVICE_TO_HOST" in direction or "D2H" in direction:
+            device_to_host_count += 1
+
+    assert host_to_device_count > 0, "No host-to-device memory copies captured"
+    assert device_to_host_count > 0, "No device-to-host memory copies captured"
+
+
+def test_attachment_hsa_api_trace(hsa_input_data):
+    assert len(hsa_input_data) > 0, "No HSA API calls captured during attachment"
+
+    valid_domains = (
+        "HSA_CORE_API",
+        "HSA_AMD_EXT_API",
+        "HSA_IMAGE_EXT_API",
+        "HSA_FINALIZE_EXT_API",
+    )
+    functions = []
+    for row in hsa_input_data:
+        assert row["Domain"] in valid_domains, f"Unexpected HSA domain: {row['Domain']}"
+        assert int(row["Process_Id"]) > 0
+        assert int(row["Thread_Id"]) > 0
+        assert int(row["End_Timestamp"]) >= int(row["Start_Timestamp"])
+        functions.append(row["Function"])
+
+    assert any(
+        "memory" in f.lower() for f in functions
+    ), "No memory-related HSA functions captured"
+
+
+def test_agent_info_json(json_data):
+    data = json_data["rocprofiler-sdk-tool"]
+
+    gpu_count = 0
+    for agent in data["agents"]:
+        # type 1 = CPU, type 2 = GPU
+        assert agent["type"] in (1, 2)
+        if agent["type"] == 1:
+            assert agent["cpu_cores_count"] > 0
+            assert agent["simd_count"] == 0
+            assert agent["max_waves_per_simd"] == 0
+        else:
+            gpu_count += 1
+            assert agent["cpu_cores_count"] == 0
+            assert agent["simd_count"] > 0
+            assert agent["max_waves_per_simd"] > 0
+
+    assert gpu_count > 0, "No GPU agents found"
+
+
+def test_kernel_dispatch(json_data):
+    data = json_data["rocprofiler-sdk-tool"]
+
+    def get_kind_name(kind_id):
+        return data["strings"]["buffer_records"][kind_id]["kind"]
+
+    def get_kernel_name(kernel_id):
+        return data["kernel_symbols"][kernel_id]["formatted_kernel_name"]
+
+    kernel_dispatch_data = data["buffer_records"]["kernel_dispatch"]
+    assert (
+        len(kernel_dispatch_data) > 0
+    ), "No kernel dispatches captured during attachment"
+
+    simple_kernel_found = False
+    kernel_threads = set()
+
+    for dispatch in kernel_dispatch_data:
+        dispatch_info = dispatch["dispatch_info"]
+        kernel_name = get_kernel_name(dispatch_info["kernel_id"])
+
+        assert get_kind_name(dispatch["kind"]) == "KERNEL_DISPATCH"
+        assert dispatch["correlation_id"]["internal"] > 0
+        assert dispatch["end_timestamp"] >= dispatch["start_timestamp"]
+        assert dispatch_info["queue_id"]["handle"] > 0
+
+        if "simple_kernel" in kernel_name:
+            simple_kernel_found = True
+            assert dispatch_info["workgroup_size"]["x"] == 256
+            assert dispatch_info["workgroup_size"]["y"] == 1
+            assert dispatch_info["workgroup_size"]["z"] == 1
+            assert dispatch_info["grid_size"]["x"] >= 1
+            assert dispatch_info["grid_size"]["y"] >= 1
+            assert dispatch_info["grid_size"]["z"] >= 1
+            kernel_threads.add(dispatch["thread_id"])
+
+    assert simple_kernel_found, "Expected 'simple_kernel' not found in kernel dispatches"
+    assert (
+        len(kernel_threads) == 8
+    ), f"Expected 8 unique threads, got {len(kernel_threads)}"
+
+
+def test_memory_copy(json_data):
+    data = json_data["rocprofiler-sdk-tool"]
+
+    def get_kind_name(kind_id):
+        return data["strings"]["buffer_records"][kind_id]["kind"]
+
+    def get_agent(agent_id):
+        for agent in data["agents"]:
+            if agent["id"]["handle"] == agent_id["handle"]:
+                return agent
+        return None
+
+    memory_copy_data = data["buffer_records"]["memory_copy"]
+    assert (
+        len(memory_copy_data) > 0
+    ), "No memory copy operations captured during attachment"
+
+    host_to_device_count = 0
+    device_to_host_count = 0
+
+    for record in memory_copy_data:
+        assert get_kind_name(record["kind"]) == "MEMORY_COPY"
+        assert record["correlation_id"]["internal"] > 0
+        assert record["end_timestamp"] >= record["start_timestamp"]
+
+        src_agent = get_agent(record["src_agent_id"])
+        dst_agent = get_agent(record["dst_agent_id"])
+        assert src_agent is not None, f"src agent not found: {record['src_agent_id']}"
+        assert dst_agent is not None, f"dst agent not found: {record['dst_agent_id']}"
+
+        # type 1 = CPU, type 2 = GPU
+        if src_agent["type"] == 1 and dst_agent["type"] == 2:
+            host_to_device_count += 1
+        elif src_agent["type"] == 2 and dst_agent["type"] == 1:
+            device_to_host_count += 1
+
+    assert host_to_device_count > 0, "No host-to-device memory copies captured"
+    assert device_to_host_count > 0, "No device-to-host memory copies captured"
+
+
+def test_hsa_api(json_data):
+    data = json_data["rocprofiler-sdk-tool"]
+
+    def get_kind_name(kind_id):
+        return data["strings"]["buffer_records"][kind_id]["kind"]
+
+    def get_operation_name(kind_id, op_id):
+        return data["strings"]["buffer_records"][kind_id]["operations"][op_id]
+
+    valid_domains = (
+        "HSA_CORE_API",
+        "HSA_AMD_EXT_API",
+        "HSA_IMAGE_EXT_API",
+        "HSA_FINALIZE_EXT_API",
+    )
+
+    hsa_api_data = data["buffer_records"]["hsa_api"]
+    assert len(hsa_api_data) > 0, "No HSA API calls captured during attachment"
+
+    functions = []
+    for record in hsa_api_data:
+        kind = get_kind_name(record["kind"])
+        assert kind in valid_domains, f"Unexpected HSA domain: {kind}"
+        assert record["thread_id"] > 0
+        assert record["end_timestamp"] >= record["start_timestamp"]
+        functions.append(get_operation_name(record["kind"], record["operation"]))
+
+    assert any(
+        "memory" in f.lower() for f in functions
+    ), "No memory-related HSA functions captured"
 
 
 if __name__ == "__main__":

--- a/projects/rocprofiler-sdk/tests/rocprofv3/attachment/attach-twice/validate.py
+++ b/projects/rocprofiler-sdk/tests/rocprofv3/attachment/attach-twice/validate.py
@@ -26,101 +26,7 @@ import sys
 import pytest
 
 
-def test_agent_info(agent_info_input_data):
-    assert len(agent_info_input_data) > 0, "No agent information captured"
-
-    gpu_count = 0
-
-    for row in agent_info_input_data:
-        agent_type = row["Agent_Type"]
-        assert agent_type in ("CPU", "GPU")
-
-        if agent_type == "CPU":
-            assert int(row["Cpu_Cores_Count"]) > 0
-            assert int(row["Simd_Count"]) == 0
-            assert int(row["Max_Waves_Per_Simd"]) == 0
-        else:
-            gpu_count += 1
-            assert int(row["Cpu_Cores_Count"]) == 0
-            assert int(row["Simd_Count"]) > 0
-            assert int(row["Max_Waves_Per_Simd"]) > 0
-
-    assert gpu_count > 0, "No GPU agents found"
-
-
-def test_attachment_kernel_trace(kernel_input_data):
-    assert len(kernel_input_data) > 0, "No kernel dispatches captured during attachment"
-
-    simple_kernel_found = False
-    kernel_threads = set()
-
-    for row in kernel_input_data:
-        assert row["Kind"] == "KERNEL_DISPATCH"
-        assert int(row["Queue_Id"]) > 0
-        assert int(row["Correlation_Id"]) > 0
-        assert int(row["End_Timestamp"]) >= int(row["Start_Timestamp"])
-
-        if "simple_kernel" in row["Kernel_Name"]:
-            simple_kernel_found = True
-            assert int(row["Kernel_Id"]) > 0
-            assert int(row["Workgroup_Size_X"]) == 256
-            assert int(row["Workgroup_Size_Y"]) == 1
-            assert int(row["Workgroup_Size_Z"]) == 1
-            assert int(row["Grid_Size_X"]) >= 1
-            assert int(row["Grid_Size_Y"]) >= 1
-            assert int(row["Grid_Size_Z"]) >= 1
-            kernel_threads.add(int(row["Thread_Id"]))
-
-    assert simple_kernel_found, "Expected 'simple_kernel' not found in kernel dispatches"
-    assert (
-        len(kernel_threads) == 8
-    ), f"Expected 8 unique threads, got {len(kernel_threads)}"
-
-
-def test_attachment_memory_copy_trace(memory_copy_input_data):
-    assert len(memory_copy_input_data) > 0, "No memory copy operations captured"
-
-    host_to_device_count = 0
-    device_to_host_count = 0
-
-    for row in memory_copy_input_data:
-        assert row["Kind"] == "MEMORY_COPY"
-        assert int(row["Correlation_Id"]) > 0
-        assert int(row["End_Timestamp"]) >= int(row["Start_Timestamp"])
-
-        direction = row["Direction"]
-        if "HOST_TO_DEVICE" in direction or "H2D" in direction:
-            host_to_device_count += 1
-        elif "DEVICE_TO_HOST" in direction or "D2H" in direction:
-            device_to_host_count += 1
-
-    assert host_to_device_count > 0, "No host-to-device memory copies captured"
-    assert device_to_host_count > 0, "No device-to-host memory copies captured"
-
-
-def test_attachment_hsa_api_trace(hsa_input_data):
-    assert len(hsa_input_data) > 0, "No HSA API calls captured during attachment"
-
-    valid_domains = (
-        "HSA_CORE_API",
-        "HSA_AMD_EXT_API",
-        "HSA_IMAGE_EXT_API",
-        "HSA_FINALIZE_EXT_API",
-    )
-    functions = []
-    for row in hsa_input_data:
-        assert row["Domain"] in valid_domains, f"Unexpected HSA domain: {row['Domain']}"
-        assert int(row["Process_Id"]) > 0
-        assert int(row["Thread_Id"]) > 0
-        assert int(row["End_Timestamp"]) >= int(row["Start_Timestamp"])
-        functions.append(row["Function"])
-
-    assert any(
-        "memory" in f.lower() for f in functions
-    ), "No memory-related HSA functions captured"
-
-
-def test_agent_info_json(json_data):
+def test_agent_info(json_data):
     data = json_data["rocprofiler-sdk-tool"]
 
     gpu_count = 0
@@ -140,7 +46,7 @@ def test_agent_info_json(json_data):
     assert gpu_count > 0, "No GPU agents found"
 
 
-def test_kernel_dispatch(json_data):
+def test_kernel_trace(json_data):
     data = json_data["rocprofiler-sdk-tool"]
 
     def get_kind_name(kind_id):
@@ -182,7 +88,7 @@ def test_kernel_dispatch(json_data):
     ), f"Expected 8 unique threads, got {len(kernel_threads)}"
 
 
-def test_memory_copy(json_data):
+def test_memory_copy_trace(json_data):
     data = json_data["rocprofiler-sdk-tool"]
 
     def get_kind_name(kind_id):
@@ -222,7 +128,7 @@ def test_memory_copy(json_data):
     assert device_to_host_count > 0, "No device-to-host memory copies captured"
 
 
-def test_hsa_api(json_data):
+def test_hsa_api_trace(json_data):
     data = json_data["rocprofiler-sdk-tool"]
 
     def get_kind_name(kind_id):

--- a/projects/rocprofiler-sdk/tests/rocprofv3/attachment/attach-twice/validate.py
+++ b/projects/rocprofiler-sdk/tests/rocprofv3/attachment/attach-twice/validate.py
@@ -53,11 +53,12 @@ def test_attachment_kernel_trace(kernel_input_data):
 
     simple_kernel_found = False
     kernel_threads = set()
+    has_valid_kernel_id = any(int(row["Kernel_Id"]) > 0 for row in kernel_input_data)
+    assert has_valid_kernel_id, "No valid Kernel_Id > 0 found in trace"
 
     for row in kernel_input_data:
         assert row["Kind"] == "KERNEL_DISPATCH"
         assert int(row["Queue_Id"]) > 0
-        assert int(row["Kernel_Id"]) > 0
         assert int(row["Correlation_Id"]) > 0
         assert int(row["End_Timestamp"]) >= int(row["Start_Timestamp"])
 
@@ -156,6 +157,10 @@ def test_kernel_dispatch(json_data):
 
     simple_kernel_found = False
     kernel_threads = set()
+    has_valid_kernel_id = any(
+        d["dispatch_info"]["kernel_id"] > 0 for d in kernel_dispatch_data
+    )
+    assert has_valid_kernel_id, "No valid kernel_id > 0 found in trace"
 
     for dispatch in kernel_dispatch_data:
         dispatch_info = dispatch["dispatch_info"]
@@ -165,7 +170,6 @@ def test_kernel_dispatch(json_data):
         assert dispatch["correlation_id"]["internal"] > 0
         assert dispatch["end_timestamp"] >= dispatch["start_timestamp"]
         assert dispatch_info["queue_id"]["handle"] > 0
-        assert dispatch_info["kernel_id"] > 0
 
         if "simple_kernel" in kernel_name:
             simple_kernel_found = True

--- a/projects/rocprofiler-sdk/tests/rocprofv3/attachment/attach-twice/validate.py
+++ b/projects/rocprofiler-sdk/tests/rocprofv3/attachment/attach-twice/validate.py
@@ -44,7 +44,6 @@ def test_attachment_kernel_trace(kernel_input_data):
     kernel_threads = set()
     kernel_streams = set()
     NUM_KERNEL_THREADS = 8
-    expected_stream_ids = set([i for i in range(1, 9)])
 
     # Verify basic kernel properties
     for row in kernel_input_data:
@@ -67,14 +66,10 @@ def test_attachment_kernel_trace(kernel_input_data):
             assert int(row["Grid_Size_Z"]) >= 1
 
             thread_id = int(row["Thread_Id"])
-            stream_id = int(row["Stream_Id"])
             kernel_threads.add(thread_id)
-            kernel_streams.add(stream_id)
 
-    # Exactly 8 streams and 8 threads
+    # Exactly 8 threads
     assert len(kernel_threads) == NUM_KERNEL_THREADS
-    # Readd when JSON conversion is redone
-    # assert kernel_streams == expected_stream_ids
 
 
 def test_attachment_memory_copy_trace(memory_copy_input_data):
@@ -103,15 +98,15 @@ def test_attachment_memory_copy_trace(memory_copy_input_data):
             "MEMORY_COPY_DEVICE_TO_HOST" in row["Direction"] or "D2H" in row["Direction"]
         ):
             device_to_host_count += 1
+
         stream_id = int(row["Stream_Id"])
         memory_copy_streams.add(stream_id)
 
     # We should have both H2D and D2H copies
     assert host_to_device_count > 0, "No host-to-device memory copies captured"
     assert device_to_host_count > 0, "No device-to-host memory copies captured"
-
     # Exactly 8 streams
-    memory_copy_streams == expected_stream_ids
+    assert memory_copy_streams == expected_stream_ids
 
 
 def test_attachment_hsa_api_trace(hsa_input_data):

--- a/projects/rocprofiler-sdk/tests/rocprofv3/attachment/attach-twice/validate.py
+++ b/projects/rocprofiler-sdk/tests/rocprofv3/attachment/attach-twice/validate.py
@@ -26,119 +26,9 @@ import sys
 import pytest
 
 
-def test_attachment_kernel_trace(kernel_input_data):
-    """Verify that kernel traces were captured during attachment."""
-
-    # We should have captured some kernel dispatches
-    assert len(kernel_input_data) > 0, "No kernel dispatches captured during attachment"
-
-    # The test app launches a kernel called "simple_kernel"
-    kernel_names = [row["Kernel_Name"] for row in kernel_input_data]
-
-    # Check that we captured the simple_kernel
-    simple_kernel_found = any("simple_kernel" in name for name in kernel_names)
-    assert (
-        simple_kernel_found
-    ), f"Expected 'simple_kernel' not found in kernel names: {kernel_names}"
-
-    kernel_threads = set()
-    kernel_streams = set()
-    NUM_KERNEL_THREADS = 8
-
-    # Verify basic kernel properties
-    for row in kernel_input_data:
-        if "simple_kernel" in row["Kernel_Name"]:
-            assert "Stream_Id" in row
-            assert "Thread_Id" in row
-            assert row["Kind"] == "KERNEL_DISPATCH"
-            assert int(row["Queue_Id"]) > 0
-            assert int(row["Kernel_Id"]) > 0
-            assert int(row["Correlation_Id"]) > 0
-            assert int(row["End_Timestamp"]) >= int(row["Start_Timestamp"])
-
-            # Verify kernel dimensions (from the test app)
-            assert int(row["Workgroup_Size_X"]) == 256  # threads_per_block
-            assert int(row["Workgroup_Size_Y"]) == 1
-            assert int(row["Workgroup_Size_Z"]) == 1
-
-            assert int(row["Grid_Size_X"]) >= 1
-            assert int(row["Grid_Size_Y"]) >= 1
-            assert int(row["Grid_Size_Z"]) >= 1
-
-            thread_id = int(row["Thread_Id"])
-            kernel_threads.add(thread_id)
-
-    # Exactly 8 threads
-    assert len(kernel_threads) == NUM_KERNEL_THREADS
-
-
-def test_attachment_memory_copy_trace(memory_copy_input_data):
-    """Verify that memory copy operations were captured during attachment."""
-
-    # We should have captured memory copies (HtoD and DtoH)
-    assert (
-        len(memory_copy_input_data) > 0
-    ), "No memory copy operations captured during attachment"
-
-    host_to_device_count = 0
-    device_to_host_count = 0
-    memory_copy_streams = set()
-    expected_stream_ids = set([i for i in range(1, 9)])
-
-    for row in memory_copy_input_data:
-        assert "Stream_Id" in row
-        assert row["Kind"] == "MEMORY_COPY"
-        assert int(row["Correlation_Id"]) > 0
-        assert int(row["End_Timestamp"]) >= int(row["Start_Timestamp"])
-
-        # Count the direction of memory copies
-        if "MEMORY_COPY_HOST_TO_DEVICE" in row["Direction"] or "H2D" in row["Direction"]:
-            host_to_device_count += 1
-        elif (
-            "MEMORY_COPY_DEVICE_TO_HOST" in row["Direction"] or "D2H" in row["Direction"]
-        ):
-            device_to_host_count += 1
-
-        stream_id = int(row["Stream_Id"])
-        memory_copy_streams.add(stream_id)
-
-    # We should have both H2D and D2H copies
-    assert host_to_device_count > 0, "No host-to-device memory copies captured"
-    assert device_to_host_count > 0, "No device-to-host memory copies captured"
-    # Exactly 8 streams
-    assert memory_copy_streams == expected_stream_ids
-
-
-def test_attachment_hsa_api_trace(hsa_input_data):
-    """Verify that HSA API calls were captured during attachment."""
-
-    # Should have some HSA API calls
-    assert len(hsa_input_data) > 0, "No HSA API calls captured during attachment"
-
-    functions = []
-    for row in hsa_input_data:
-        assert row["Domain"] in (
-            "HSA_CORE_API",
-            "HSA_AMD_EXT_API",
-            "HSA_IMAGE_EXT_API",
-            "HSA_FINALIZE_EXT_API",
-        )
-        assert int(row["Process_Id"]) > 0
-        assert int(row["Thread_Id"]) > 0
-        assert int(row["End_Timestamp"]) >= int(row["Start_Timestamp"])
-        functions.append(row["Function"])
-
-    assert any(
-        "memory" in func.lower() for func in functions
-    ), "No memory-related HSA functions captured"
-
-
 def test_agent_info(agent_info_input_data):
-    """Verify agent information is captured correctly."""
-
     assert len(agent_info_input_data) > 0, "No agent information captured"
 
-    cpu_count = 0
     gpu_count = 0
 
     for row in agent_info_input_data:
@@ -146,7 +36,6 @@ def test_agent_info(agent_info_input_data):
         assert agent_type in ("CPU", "GPU")
 
         if agent_type == "CPU":
-            cpu_count += 1
             assert int(row["Cpu_Cores_Count"]) > 0
             assert int(row["Simd_Count"]) == 0
             assert int(row["Max_Waves_Per_Simd"]) == 0
@@ -156,8 +45,214 @@ def test_agent_info(agent_info_input_data):
             assert int(row["Simd_Count"]) > 0
             assert int(row["Max_Waves_Per_Simd"]) > 0
 
-    # Should have at least one GPU for the test
     assert gpu_count > 0, "No GPU agents found"
+
+
+def test_attachment_kernel_trace(kernel_input_data):
+    assert len(kernel_input_data) > 0, "No kernel dispatches captured during attachment"
+
+    simple_kernel_found = False
+    kernel_threads = set()
+
+    for row in kernel_input_data:
+        assert row["Kind"] == "KERNEL_DISPATCH"
+        assert int(row["Queue_Id"]) > 0
+        assert int(row["Kernel_Id"]) > 0
+        assert int(row["Correlation_Id"]) > 0
+        assert int(row["End_Timestamp"]) >= int(row["Start_Timestamp"])
+
+        if "simple_kernel" in row["Kernel_Name"]:
+            simple_kernel_found = True
+            assert int(row["Workgroup_Size_X"]) == 256
+            assert int(row["Workgroup_Size_Y"]) == 1
+            assert int(row["Workgroup_Size_Z"]) == 1
+            assert int(row["Grid_Size_X"]) >= 1
+            assert int(row["Grid_Size_Y"]) >= 1
+            assert int(row["Grid_Size_Z"]) >= 1
+            kernel_threads.add(int(row["Thread_Id"]))
+
+    assert simple_kernel_found, "Expected 'simple_kernel' not found in kernel dispatches"
+    assert (
+        len(kernel_threads) == 8
+    ), f"Expected 8 unique threads, got {len(kernel_threads)}"
+
+
+def test_attachment_memory_copy_trace(memory_copy_input_data):
+    assert len(memory_copy_input_data) > 0, "No memory copy operations captured"
+
+    host_to_device_count = 0
+    device_to_host_count = 0
+
+    for row in memory_copy_input_data:
+        assert row["Kind"] == "MEMORY_COPY"
+        assert int(row["Correlation_Id"]) > 0
+        assert int(row["End_Timestamp"]) >= int(row["Start_Timestamp"])
+
+        direction = row["Direction"]
+        if "HOST_TO_DEVICE" in direction or "H2D" in direction:
+            host_to_device_count += 1
+        elif "DEVICE_TO_HOST" in direction or "D2H" in direction:
+            device_to_host_count += 1
+
+    assert host_to_device_count > 0, "No host-to-device memory copies captured"
+    assert device_to_host_count > 0, "No device-to-host memory copies captured"
+
+
+def test_attachment_hsa_api_trace(hsa_input_data):
+    assert len(hsa_input_data) > 0, "No HSA API calls captured during attachment"
+
+    valid_domains = (
+        "HSA_CORE_API",
+        "HSA_AMD_EXT_API",
+        "HSA_IMAGE_EXT_API",
+        "HSA_FINALIZE_EXT_API",
+    )
+    functions = []
+    for row in hsa_input_data:
+        assert row["Domain"] in valid_domains, f"Unexpected HSA domain: {row['Domain']}"
+        assert int(row["Process_Id"]) > 0
+        assert int(row["Thread_Id"]) > 0
+        assert int(row["End_Timestamp"]) >= int(row["Start_Timestamp"])
+        functions.append(row["Function"])
+
+    assert any(
+        "memory" in f.lower() for f in functions
+    ), "No memory-related HSA functions captured"
+
+
+def test_agent_info_json(json_data):
+    data = json_data["rocprofiler-sdk-tool"]
+
+    gpu_count = 0
+    for agent in data["agents"]:
+        # type 1 = CPU, type 2 = GPU
+        assert agent["type"] in (1, 2)
+        if agent["type"] == 1:
+            assert agent["cpu_cores_count"] > 0
+            assert agent["simd_count"] == 0
+            assert agent["max_waves_per_simd"] == 0
+        else:
+            gpu_count += 1
+            assert agent["cpu_cores_count"] == 0
+            assert agent["simd_count"] > 0
+            assert agent["max_waves_per_simd"] > 0
+
+    assert gpu_count > 0, "No GPU agents found"
+
+
+def test_kernel_dispatch(json_data):
+    data = json_data["rocprofiler-sdk-tool"]
+
+    def get_kind_name(kind_id):
+        return data["strings"]["buffer_records"][kind_id]["kind"]
+
+    def get_kernel_name(kernel_id):
+        return data["kernel_symbols"][kernel_id]["formatted_kernel_name"]
+
+    kernel_dispatch_data = data["buffer_records"]["kernel_dispatch"]
+    assert (
+        len(kernel_dispatch_data) > 0
+    ), "No kernel dispatches captured during attachment"
+
+    simple_kernel_found = False
+    kernel_threads = set()
+
+    for dispatch in kernel_dispatch_data:
+        dispatch_info = dispatch["dispatch_info"]
+        kernel_name = get_kernel_name(dispatch_info["kernel_id"])
+
+        assert get_kind_name(dispatch["kind"]) == "KERNEL_DISPATCH"
+        assert dispatch["correlation_id"]["internal"] > 0
+        assert dispatch["end_timestamp"] >= dispatch["start_timestamp"]
+        assert dispatch_info["queue_id"]["handle"] > 0
+        assert dispatch_info["kernel_id"] > 0
+
+        if "simple_kernel" in kernel_name:
+            simple_kernel_found = True
+            assert dispatch_info["workgroup_size"]["x"] == 256
+            assert dispatch_info["workgroup_size"]["y"] == 1
+            assert dispatch_info["workgroup_size"]["z"] == 1
+            assert dispatch_info["grid_size"]["x"] >= 1
+            assert dispatch_info["grid_size"]["y"] >= 1
+            assert dispatch_info["grid_size"]["z"] >= 1
+            kernel_threads.add(dispatch["thread_id"])
+
+    assert simple_kernel_found, "Expected 'simple_kernel' not found in kernel dispatches"
+    assert (
+        len(kernel_threads) == 8
+    ), f"Expected 8 unique threads, got {len(kernel_threads)}"
+
+
+def test_memory_copy(json_data):
+    data = json_data["rocprofiler-sdk-tool"]
+
+    def get_kind_name(kind_id):
+        return data["strings"]["buffer_records"][kind_id]["kind"]
+
+    def get_agent(agent_id):
+        for agent in data["agents"]:
+            if agent["id"]["handle"] == agent_id["handle"]:
+                return agent
+        return None
+
+    memory_copy_data = data["buffer_records"]["memory_copy"]
+    assert (
+        len(memory_copy_data) > 0
+    ), "No memory copy operations captured during attachment"
+
+    host_to_device_count = 0
+    device_to_host_count = 0
+
+    for record in memory_copy_data:
+        assert get_kind_name(record["kind"]) == "MEMORY_COPY"
+        assert record["correlation_id"]["internal"] > 0
+        assert record["end_timestamp"] >= record["start_timestamp"]
+
+        src_agent = get_agent(record["src_agent_id"])
+        dst_agent = get_agent(record["dst_agent_id"])
+        assert src_agent is not None, f"src agent not found: {record['src_agent_id']}"
+        assert dst_agent is not None, f"dst agent not found: {record['dst_agent_id']}"
+
+        # type 1 = CPU, type 2 = GPU
+        if src_agent["type"] == 1 and dst_agent["type"] == 2:
+            host_to_device_count += 1
+        elif src_agent["type"] == 2 and dst_agent["type"] == 1:
+            device_to_host_count += 1
+
+    assert host_to_device_count > 0, "No host-to-device memory copies captured"
+    assert device_to_host_count > 0, "No device-to-host memory copies captured"
+
+
+def test_hsa_api(json_data):
+    data = json_data["rocprofiler-sdk-tool"]
+
+    def get_kind_name(kind_id):
+        return data["strings"]["buffer_records"][kind_id]["kind"]
+
+    def get_operation_name(kind_id, op_id):
+        return data["strings"]["buffer_records"][kind_id]["operations"][op_id]
+
+    valid_domains = (
+        "HSA_CORE_API",
+        "HSA_AMD_EXT_API",
+        "HSA_IMAGE_EXT_API",
+        "HSA_FINALIZE_EXT_API",
+    )
+
+    hsa_api_data = data["buffer_records"]["hsa_api"]
+    assert len(hsa_api_data) > 0, "No HSA API calls captured during attachment"
+
+    functions = []
+    for record in hsa_api_data:
+        kind = get_kind_name(record["kind"])
+        assert kind in valid_domains, f"Unexpected HSA domain: {kind}"
+        assert record["thread_id"] > 0
+        assert record["end_timestamp"] >= record["start_timestamp"]
+        functions.append(get_operation_name(record["kind"], record["operation"]))
+
+    assert any(
+        "memory" in f.lower() for f in functions
+    ), "No memory-related HSA functions captured"
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Motivation

Fix many race conditions in attachment

Improve and reenable attachment tests

Sanitizer tests deferred for now

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

This change includes a massive overhaul of rocprofiler-sdk-attach to make this possible and also patches some potential race conditions. Fixes #4636 These library changes include:

- Instead of SDK modifying the attach table to add a "notify" callback, SDK modules now directly call an "add callback" function which registers a function to be called on every object creation or destruction
  - This applies for both queues and code_objects
  - Added a new "phase" parameter to indicate which event is occurring (creation or destruction)
- To protect against some race conditions between iterate and register, registering a callback will now cause that callback to be immediately called for each existing object while a lock is held. This will ensure the SDK cannot possibly miss an object
  - The existing iterate_all calls remain so a snapshot can be taken and used at any time

I've bumped the version for the table, though we aren't doing any checks for the version as this is a fully internal API. This is an internal ABI breaking change, but if these libraries are incorrectly paired there is a fundamental installation issue.

Fixes three intermittent failures caused by race conditions unique to attachment. One is caused by the order queues are added to rocprofiler-sdk. One is caused by ordering of rocpd output steps. The last is caused by initialization order where queue interceptions could occur without kernel_id_map being populated. Fixes #5544

Rearchitects the attach tests to run indefinitely and receive SIGINT when they need to be stopped. Reduces the size and runtime of the test overall. Reduces runtime of a execute tests to 2-4 seconds.

Remove the separate json tests, matching the pattern of other rocprofv3 validation tests.

<!-- Explain the changes along with any relevant GitHub links. -->

## JIRA ID

Resolves AIPROFSDK-856
<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan

Ran attach tests locally to see pass
Validated intermittent tests across 1800 repeated runs on MI325X

## Test Result

All passed
<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
