### PR TITLE
[ROCM-20039] Fix AttributeError for gpureset on VMs. Cherry-pick #3925

### DIFF
--- a/projects/amdsmi/amdsmi_cli/amdsmi_commands.py
+++ b/projects/amdsmi/amdsmi_cli/amdsmi_commands.py
@@ -6808,6 +6808,9 @@ class AMDSMICommands():
             args.power_cap = power_cap
         if clean_local_data:
             args.clean_local_data = clean_local_data
+        # Normalize gpureset: not available on VMs
+        if not self.helpers.is_baremetal():
+            args.gpureset = False
 
         # Handle No GPU passed
         if args.gpu == None:


### PR DESCRIPTION

## Motivation

Fix amd-smi reset -l failure on VMs.

## Technical Details

Argument gpureset is not registered by the parser on VMs, so accessing args.gpureset directly raises AttributeError. Normalize it to False when not available.

## JIRA ID

ROCM-20039

## Test Plan

amd-smi reset -l on VM

## Test Result

Passed on VM:
<img width="739" height="142" alt="image" src="https://github.com/user-attachments/assets/12bc4522-9bd9-49d4-b6ec-f0d535354dca" />


## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
