### PR TITLE
hip-tests: Fix ComplrOptn test failure in CI

### DIFF
--- a/projects/hip-tests/catch/unit/rtc/CMakeLists.txt
+++ b/projects/hip-tests/catch/unit/rtc/CMakeLists.txt
@@ -37,9 +37,15 @@ add_custom_target(copyRtcHeaders ALL
   ${CMAKE_CURRENT_SOURCE_DIR}/headers
   ${CMAKE_CURRENT_BINARY_DIR}/headers)
 
+add_custom_target(copyTstJson ALL
+  COMMAND ${CMAKE_COMMAND} -E copy
+  ${CMAKE_CURRENT_SOURCE_DIR}/RtcConfig.json
+  ${CMAKE_CURRENT_BINARY_DIR}/RtcConfig.json)
+
 file(GLOB INSTALL_HEADER_FILES "./headers/*")
 set_property(GLOBAL APPEND PROPERTY G_INSTALL_HEADER_FILES ${INSTALL_HEADER_FILES})
 set_property(GLOBAL APPEND PROPERTY G_INSTALL_CUSTOM_TARGETS ${CMAKE_CURRENT_BINARY_DIR}/saxpy.h)
+set_property(GLOBAL APPEND PROPERTY G_INSTALL_CUSTOM_TARGETS ${CMAKE_CURRENT_BINARY_DIR}/RtcConfig.json)
 
 if(UNIX)
   set(AMD_TEST_SRC ${AMD_TEST_SRC}
@@ -72,4 +78,4 @@ elseif(HIP_PLATFORM MATCHES "amd")
   target_link_libraries(ChkPtrdiff_t_Exe hiprtc::hiprtc hip::host hip::device)
 endif()
 
-add_dependencies(RTC copyRtcHeaders ChkPtrdiff_t_Exe)
+add_dependencies(RTC copyRtcHeaders copyTstJson ChkPtrdiff_t_Exe)

--- a/projects/hip-tests/catch/unit/rtc/RtcUtility.cpp
+++ b/projects/hip-tests/catch/unit/rtc/RtcUtility.cpp
@@ -108,9 +108,8 @@ int calling_combination_function(std::vector<std::string> combi_vec_list) {
     } else if (combi_vec_list[i] == "header_dir") {
       std::string retrived_CO = get_string_parameters("compiler_option", "header_dir");
       std::string wor_dir = std::filesystem::current_path().string();
-      std::string break_dir = wor_dir.substr(0, wor_dir.find("build"));
-      std::string append_str = "catch/unit/rtc/headers";
-      std::string CO = retrived_CO + " " + break_dir + append_str;
+      std::string append_str = "/headers";
+      std::string CO = retrived_CO + " " + wor_dir + append_str;
       hold_CO[i] = CO;
     } else if (combi_vec_list[i] == "architecture") {
       std::string retrived_CO = get_string_parameters("compiler_option", "architecture");
@@ -324,9 +323,7 @@ picojson::array getblock_fromconfig() {
   static bool initialized = false;
   if (!initialized) {
     std::string wor_dir = std::filesystem::current_path().string();
-    std::string break_dir = wor_dir.substr(0, wor_dir.find("build"));
-    std::string append_str = "catch/unit/rtc/RtcConfig.json";
-    std::string config_path = break_dir + append_str;
+    std::string config_path = wor_dir + "/RtcConfig.json";
     std::ifstream json_file(config_path.c_str());
     if (!json_file.is_open()) {
       FAIL("Error loading config.json");


### PR DESCRIPTION
## Motivation

- search path for config.json and headers is incorrect for rock CI builds
- modify cmake to copy these files to target directory

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
