### PR TITLE
Update to use ENOTTY to align with kernel ioctl result

### DIFF
--- a/projects/rocr-runtime/libhsakmt/src/pc_sampling.c
+++ b/projects/rocr-runtime/libhsakmt/src/pc_sampling.c
@@ -74,6 +74,7 @@ HSAKMT_STATUS HSAKMTAPI hsaKmtPcSamplingQueryCapabilities(HSAuint32 NodeId, void
         case EINVAL:
                 return HSAKMT_STATUS_INVALID_PARAMETER;
         case EOPNOTSUPP:
+        case ENOTTY:
                 return HSAKMT_STATUS_NOT_SUPPORTED;
         case EBUSY:
                 return HSAKMT_STATUS_UNAVAILABLE;


### PR DESCRIPTION
The kernel now reports -ENOTTY when an IOCTL is not supported. Note that the kernel module has never returned `EOPNOTSUPP` but instead `EINVAL`, as such no fallback is required here.

Link: https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=57af162bfc8c05332a28c4d458d246cc46d2746d