### PR TITLE
Fix broken graph dependency logic

### DIFF
--- a/projects/clr/rocclr/device/rocm/rocvirtual.cpp
+++ b/projects/clr/rocclr/device/rocm/rocvirtual.cpp
@@ -2129,14 +2129,13 @@ void VirtualGPU::profilingBegin(amd::Command& command, bool sdmaProfiling) {
         }
       }
     }
-
-    for (auto it = command.getDepHwEvents().begin(); it < command.getDepHwEvents().end(); ++it) {
-      ClPrint(amd::LOG_DEBUG, amd::LOG_SIG, "Adding dep hw event signal: 0x%lx",
-          reinterpret_cast<ProfilingSignal*>(*it)->signal_.handle);
-      Barriers().AddExternalSignal(reinterpret_cast<ProfilingSignal*>(*it));
-    }
-    command.clearDepHwEvents();
   }
+  for (auto it = command.getDepHwEvents().begin(); it < command.getDepHwEvents().end(); ++it) {
+    ClPrint(amd::LOG_DEBUG, amd::LOG_SIG, "Adding dep hw event signal: 0x%lx",
+            reinterpret_cast<ProfilingSignal*>(*it)->signal_.handle);
+    Barriers().AddExternalSignal(reinterpret_cast<ProfilingSignal*>(*it));
+  }
+  command.clearDepHwEvents();
 }
 
 // ================================================================================================


### PR DESCRIPTION
PR https://github.com/ROCm/rocm-systems/pull/3481 moved the DepHwEvents barrier logic inside the profilingBegin for-loop scope, causing external dependency signals to be skipped when the loop condition is not entered. This breaks graph node dependencies in the new scheduling path.

Move the DepHwEvents iteration and clearDepHwEvents() back outside the for-loop scope so dependency barriers are always applied.

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
