### PR TITLE
[rocprofiler-systems] Fix `transpose` runtime-instrument crash

### DIFF
--- a/projects/rocprofiler-systems/source/bin/rocprof-sys-instrument/internal_libs.cpp
+++ b/projects/rocprofiler-systems/source/bin/rocprof-sys-instrument/internal_libs.cpp
@@ -335,21 +335,16 @@ get_internal_basic_libs_impl()
                                                    "libamd_smi.so",
                                                    "libamd_comgr.so" };
 
-    // shared libraries potentially used by timemory
-    const auto _3rdparty_libs = strview_init_t{ "libcaliper.so",
-                                                "liblikwid.so",
-                                                "libprofiler.so",
-                                                "libtcmalloc.so",
-                                                "libtcmalloc_and_profiler.so",
-                                                "libtcmalloc_debug.so",
-                                                "libtcmalloc_minimal.so",
-                                                "libtcmalloc_minimal_debug.so" };
+    const auto _3rdparty_libs = strview_init_t{
+        // shared libs potentially used by timemory
+        "libcaliper.so", "liblikwid.so", "libprofiler.so", "libtcmalloc.so",
+        "libtcmalloc_and_profiler.so", "libtcmalloc_debug.so", "libtcmalloc_minimal.so",
+        "libtcmalloc_minimal_debug.so",
+        // shared libs that Dyninst will fail to instrument correctly
+        "libclang-cpp.so", "libLLVM.so"
+    };
 
-    // libraries that Dyninst will fail to instrument correctly
-    const auto _dyninst_unstable_libs = strview_init_t{ "libclang-cpp.so", "libLLVM.so" };
-
-    for(const auto& gitr : { _gnu_libs, _dyn_libs, _rocprof_sys_libs, _3rdparty_libs,
-                             _dyninst_unstable_libs })
+    for(const auto& gitr : { _gnu_libs, _dyn_libs, _rocprof_sys_libs, _3rdparty_libs })
     {
         for(auto itr : gitr)
         {

--- a/projects/rocprofiler-systems/source/bin/rocprof-sys-instrument/internal_libs.cpp
+++ b/projects/rocprofiler-systems/source/bin/rocprof-sys-instrument/internal_libs.cpp
@@ -345,7 +345,11 @@ get_internal_basic_libs_impl()
                                                 "libtcmalloc_minimal.so",
                                                 "libtcmalloc_minimal_debug.so" };
 
-    for(const auto& gitr : { _gnu_libs, _dyn_libs, _rocprof_sys_libs, _3rdparty_libs })
+    // libraries that Dyninst will fail to instrument correctly
+    const auto _dyninst_unstable_libs = strview_init_t{ "libclang-cpp.so", "libLLVM.so" };
+
+    for(const auto& gitr : { _gnu_libs, _dyn_libs, _rocprof_sys_libs, _3rdparty_libs,
+                             _dyninst_unstable_libs })
     {
         for(auto itr : gitr)
         {


### PR DESCRIPTION
## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

Test fails on TheRock and it was disabled (see https://github.com/ROCm/TheRock/pull/3884). 
Per my investigation:
```
I noticed that transpose → libamdhip64.so.7 → libamd_comgr.so → libLLVM.so + libclang-cpp.so
The last two shared libraries are huge and Dyninst fails to parse them, causing failure after ~450 seconds.
Even if you exclude both libraries, the test will still take ~370 seconds, which is far too long for now.
```

The reason that `rocprof-sys-instrument` takes so long to instrument them even when you exclude them is that we fetch all instrumentation functions via `std::vector<procedure_t*>* app_functions = app_image->getProcedures(include_uninstr);`
Then we proceed to loop over them in different places. We need proper module level checks, but for now, we just want runtime-instrument to not fail.

**I have ideas on how to fix this to reduce instrumentation time, but I will handle that in a different PR.** 

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

Add `libclang-cpp.so` and `libLLVM.so` to libraries that are not instrumented.
They are put in a new category called `dyninst_unstable_libs` because they do not fit in any of the existing three categories.

## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

AIPROFSYST-333 (Half of it)

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

Tested on TheRock (LOCALLY)

## Test Result

<!-- Briefly summarize test outcomes. -->

Test passes on TheRock (but it takes ~370 seconds)

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
