### PR TITLE
rocr/aie: Dev heap is not as large as the system's memory

### DIFF
--- a/projects/rocr-runtime/rocrtst/suites/functional/memory_basic.cc
+++ b/projects/rocr-runtime/rocrtst/suites/functional/memory_basic.cc
@@ -237,6 +237,12 @@ void MemoryTest::MaxSingleAllocationTest(hsa_agent_t ag,
   auto gran_sz = pool_i.alloc_granule;
   auto pool_sz = pool_i.aggregate_alloc_max / gran_sz;
 
+  // AIE agent's dev heap is advertized as HSA_HEAPTYPE_DEVICE_SVM, but
+  // is limited to the actual pool size.
+  if (ag_type == HSA_DEVICE_TYPE_AIE && pool_i.alloc_rec_granule == 0) {
+    pool_sz = pool_i.size / gran_sz;
+  }
+
   // Neg. test: Try to allocate more than the pool size
 #ifdef ROCRTST_ASAN
   // Under ASAN, hsa_amd_memory_pool_allocate is intercepted by the ASAN runtime.

--- a/projects/rocr-runtime/rocrtst/suites/functional/memory_basic.cc
+++ b/projects/rocr-runtime/rocrtst/suites/functional/memory_basic.cc
@@ -237,7 +237,7 @@ void MemoryTest::MaxSingleAllocationTest(hsa_agent_t ag,
   auto gran_sz = pool_i.alloc_granule;
   auto pool_sz = pool_i.aggregate_alloc_max / gran_sz;
 
-  // AIE agent's dev heap is advertized as HSA_HEAPTYPE_DEVICE_SVM, but
+  // AIE agent's dev heap is advertised as HSA_HEAPTYPE_DEVICE_SVM, but
   // is limited to the actual pool size.
   if (ag_type == HSA_DEVICE_TYPE_AIE && pool_i.alloc_rec_granule == 0) {
     pool_sz = pool_i.size / gran_sz;

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/driver/xdna/amd_xdna_driver.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/driver/xdna/amd_xdna_driver.cpp
@@ -336,6 +336,13 @@ XdnaDriver::AllocateMemory(const core::MemoryRegion &mem_region,
   if (use_bo_shmem) {
     create_bo_args.type = AMDXDNA_BO_SHMEM;
   } else {
+    // While this is already checked in MemoryRegion::AllocateImpl, the max size is
+    // MemoryRegion::max_sysmem_alloc_size_ for HSA_HEAPTYPE_DEVICE_SVM which is incorrect
+    // for dev heap.
+    if (size > dev_heap_size) {
+      return HSA_STATUS_ERROR_INVALID_ALLOCATION;
+    }
+
     create_bo_args.type = AMDXDNA_BO_DEV;
   }
 

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_aie_agent.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_aie_agent.cpp
@@ -3,7 +3,7 @@
 // The University of Illinois/NCSA
 // Open Source License (NCSA)
 //
-// Copyright (c) 2022-2025, Advanced Micro Devices, Inc. All rights reserved.
+// Copyright (c) 2022-2026, Advanced Micro Devices, Inc. All rights reserved.
 //
 // Developed by:
 //
@@ -298,28 +298,31 @@ hsa_status_t AieAgent::QueueCreate(size_t size, hsa_queue_type32_t queue_type, u
 }
 
 void AieAgent::InitRegionList() {
-  /// AIE itself currently has no memory regions of its own, all memory is just the system DRAM.
+  // AIE itself currently has no memory regions of its own, all memory is just the system DRAM.
   const uint64_t total_system_memory = os::HostTotalPhysicalMemory();
 
-  /// For allocating kernel arguments or other objects that only need
-  /// system memory.
+  // For allocating kernel arguments or other objects that only need system memory.
   HsaMemoryProperties sys_mem_props = {};
   sys_mem_props.HeapType = HSA_HEAPTYPE_SYSTEM;
   sys_mem_props.SizeInBytes = total_system_memory;
 
-  /// For any other allocation, e.g., buffers.
+  // For any other allocation, e.g., buffers.
   HsaMemoryProperties other_mem_props = {};
   other_mem_props.HeapType = HSA_HEAPTYPE_SYSTEM;
   other_mem_props.SizeInBytes = total_system_memory;
 
-  /// For allocating memory for programmable device image (PDI) files. These
-  /// need to be mapped to the device so the hardware can access the PDIs.
+  // For allocating memory for device instructions. These need to be mapped to the device so the
+  // hardware can access them.
+  // We use HSA_HEAPTYPE_DEVICE_SVM so that the recommended
+  // HSA_AMD_MEMORY_POOL_INFO_RUNTIME_ALLOC_GRANULE is 0. We can use that to determine if a pool is
+  // regular pool or dev heap.
+  // The system will report the max allocatable size as MemoryRegion::max_sysmem_alloc_size_, but
+  // this is incorrect. The pool is exactly XdnaDriver::GetDevHeapByteSize() bytes.
   HsaMemoryProperties dev_mem_props = {};
   dev_mem_props.HeapType = HSA_HEAPTYPE_DEVICE_SVM;
   dev_mem_props.SizeInBytes = XdnaDriver::GetDevHeapByteSize();
 
-  /// As of now the AIE devices support coarse-grain memory regions that require
-  /// explicit sync operations.
+  // AIE devices support only coarse-grain memory regions that require explicit sync operations.
   regions_.reserve(3);
   regions_.push_back(
     std::make_shared<MemoryRegion>(false, true, false, false, true, this, sys_mem_props));

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_aie_agent.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_aie_agent.cpp
@@ -314,8 +314,8 @@ void AieAgent::InitRegionList() {
   // For allocating memory for device instructions. These need to be mapped to the device so the
   // hardware can access them.
   // We use HSA_HEAPTYPE_DEVICE_SVM so that the recommended
-  // HSA_AMD_MEMORY_POOL_INFO_RUNTIME_ALLOC_GRANULE is 0. We can use that to determine if a pool is
-  // regular pool or dev heap.
+  // HSA_AMD_MEMORY_POOL_INFO_RUNTIME_ALLOC_REC_GRANULE is 0. We can use that to determine if a pool
+  // is regular pool or dev heap.
   // The system will report the max allocatable size as MemoryRegion::max_sysmem_alloc_size_, but
   // this is incorrect. The pool is exactly XdnaDriver::GetDevHeapByteSize() bytes.
   HsaMemoryProperties dev_mem_props = {};


### PR DESCRIPTION
## Motivation

XDNA dev heap is advertised as HSA_HEAPTYPE_DEVICE_SVM but it's only 64MB. This is creating issues in tests that assume that HSA_HEAPTYPE_DEVICE_SVM is as big as the system memory.

## Technical Details

This adds a work-around in tests so if a dev heap is detected, the actual size of the pool is considered rather than the total system memory.

Additional comments were added for posterity.

## JIRA ID

ROCM-8651

## Test Plan

./rocrtst64 --gtest_filter=rocrtstFunc.Memory_Max_Mem

## Test Result

Test passes on PHX.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
