### PR TITLE
Specify THEROCK_ROCM_SYSTEMS_SOURCE_DIR

### DIFF
--- a/.github/workflows/therock-rccl-ci-linux.yml
+++ b/.github/workflows/therock-rccl-ci-linux.yml
@@ -69,7 +69,7 @@ jobs:
         env:
           amdgpu_families: ${{ env.AMDGPU_FAMILIES }}
           package_version: ADHOCBUILD
-          extra_cmake_options: ${{ inputs.extra_cmake_options }}
+          extra_cmake_options: "-DTHEROCK_ROCM_SYSTEMS_SOURCE_DIR=../ ${{ inputs.cmake_options }}"
           BUILD_DIR: build
         run: |
           python3 ./TheRock/build_tools/github_actions/build_configure.py

--- a/.github/workflows/therock-rccl-ci-linux.yml
+++ b/.github/workflows/therock-rccl-ci-linux.yml
@@ -63,7 +63,7 @@ jobs:
 
       - name: Fetch sources
         run: |
-          ./TheRock/build_tools/fetch_sources.py --jobs 12
+          ./TheRock/build_tools/fetch_sources.py --jobs 12 --no-include-rocm-systems
 
       - name: Configure Projects
         env:


### PR DESCRIPTION
THEROCK_ROCM_SYSTEMS_SOURCE_DIR needs to be set to test the checked out rocm-systems repo instead of the rocm-systems submodule pulled via TheRock.