### PR TITLE
aqlprofile ASAN build linking error fix for tests

### DIFF
--- a/projects/aqlprofile/test/integration/CMakeLists.txt
+++ b/projects/aqlprofile/test/integration/CMakeLists.txt
@@ -63,6 +63,12 @@ add_executable(testv2)
 target_sources(testv2 PRIVATE main.cpp workload.cpp counter.cpp agent.cpp)
 target_include_directories(testv2 PRIVATE ${CMAKE_CURRENT_SOURCE_DIR} ${CMAKE_SOURCE_DIR}/src/core/include/ ${HSA_RUNTIME_INC_PATH} /opt/rocm/include)
 target_link_libraries(testv2 PRIVATE hsa-runtime64::hsa-runtime64 ${AQLPROFILE_TARGET})
+if ( ENABLE_ASAN_PACKAGING )
+    message(STATUS "aqlprofile/test/integration ENABLE_ASAN_PACKAGING")
+    set ( CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-omit-frame-pointer -fsanitize=address" )
+    set ( CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -fsanitize=address" )
+    set ( CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -fsanitize=address" )
+endif()
 target_compile_definitions(testv2 PUBLIC AMD_INTERNAL_BUILD)
 
 # Add a PRELOAD environment with libintercept


### PR DESCRIPTION
Fixes linking errors on tests when doing an ASAN build.

46.5	ld.lld: error: undefined symbol: __asan_unregister_elf_globals 46.5	>>> referenced by workload.cpp
46.5	>>>               test/integration/CMakeFiles/testv2.dir/workload.cpp.o:(asan.module_dtor)
46.5
46.5	ld.lld: error: undefined symbol: __asan_stack_free_7
46.5	>>> referenced by agent.cpp:162
46.5	>>>(/therock/rocm-systems/projects/aqlprofile/test/integration/agent.cpp:162)
46.5	>>>               test/integration/CMakeFiles/testv2.dir/agent.cpp.o:
46.5	>>> (AgentInfo::get_agent_handle_cb(hsa_agent_s, void*))
46.5	>>> referenced by agent.cpp:162
46.5	>>> (/therock/rocm-systems/projects/aqlprofile/test/integration/agent.cpp:162)
46.5	>>>               test/integration/CMakeFiles/testv2.dir/agent.cpp.o:
46.5	>>>(AgentInfo::get_agent_handle_cb(hsa_agent_s, void*))

fix: https://github.com/ROCm/TheRock/issues/3902
