### PR TITLE
roctracer ASAN build linking error fix for tests

### DIFF
--- a/projects/roctracer/test/CMakeLists.txt
+++ b/projects/roctracer/test/CMakeLists.txt
@@ -22,6 +22,13 @@
 
 get_property(HSA_RUNTIME_INCLUDE_DIRECTORIES TARGET hsa-runtime64::hsa-runtime64 PROPERTY INTERFACE_INCLUDE_DIRECTORIES)
 
+if ( ENABLE_ASAN_PACKAGING )
+    message(STATUS "roctracer/test ENABLE_ASAN_PACKAGING")
+    set ( CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-omit-frame-pointer -fsanitize=address" )
+    set ( CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -fsanitize=address" )
+    set ( CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -fsanitize=address" )
+endif()
+
 # Set the HIP language runtime link flags as FindHIP does not set them.
 set(CMAKE_EXECUTABLE_RUNTIME_HIP_FLAG ${CMAKE_SHARED_LIBRARY_RUNTIME_CXX_FLAG})
 set(CMAKE_EXECUTABLE_RUNTIME_HIP_FLAG_SEP ${CMAKE_SHARED_LIBRARY_RUNTIME_CXX_FLAG_SEP})


### PR DESCRIPTION
Fixes linking errors on tests when doing an ASAN build.

33.2    [40/42] Linking HIP executable test/MatrixTranspose_ctest
33.2    FAILED: test/MatrixTranspose_ctest
...
33.2    ld.lld: error: undefined symbol: __asan_option_detect_stack_use_after_return
33.2    >>> referenced by MatrixTranspose.c:46 (test/MatrixTranspose.c:46)
33.2    >>>               test/CMakeFiles/MatrixTranspose_ctest.dir/MatrixTranspose.c.o:(SPRINT)
33.2    >>> referenced by MatrixTranspose.c:322 (test/MatrixTranspose.c:322)
33.2    >>>               test/CMakeFiles/MatrixTranspose_ctest.dir/MatrixTranspose.c.o:(activity_callback)
33.2    >>> referenced by MatrixTranspose.c:353 (test/MatrixTranspose.c:353)
33.2    >>>               test/CMakeFiles/MatrixTranspose_ctest.dir/MatrixTranspose.c.o:(init_tracing)
33.2
33.2    ld.lld: error: undefined symbol: __asan_stack_malloc_1
33.2    >>> referenced by MatrixTranspose.c:46 (test/MatrixTranspose.c:46)
33.2    >>>               test/CMakeFiles/MatrixTranspose_ctest.dir/MatrixTranspose.c.o:(SPRINT)
33.2    >>> referenced by MatrixTranspose.c:353 (test/MatrixTranspose.c:353)
33.2    >>>               test/CMakeFiles/MatrixTranspose_ctest.dir/MatrixTranspose.c.o:(init_tracing)

Fixes: https://github.com/ROCm/TheRock/issues/3902