### PR TITLE
Fix rocm_smi64 exporting invalid absolute paths to consumers (#3717)

### DIFF
--- a/projects/rocm-smi-lib/rocm_smi/CMakeLists.txt
+++ b/projects/rocm-smi-lib/rocm_smi/CMakeLists.txt
@@ -94,8 +94,6 @@ target_include_directories(${ROCM_SMI_TARGET}
                            "$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>"
 )
 
-target_include_directories(${ROCM_SMI_TARGET} INTERFACE ${DRM_INCLUDE_DIRS})
-
 ## Set the VERSION and SOVERSION values
 set_property(TARGET ${ROCM_SMI_TARGET} PROPERTY
              SOVERSION "${VERSION_MAJOR}")


### PR DESCRIPTION
## Motivation
Cmake issue in nightly pytorch build: https://github.com/ROCm/TheRock/issues/3702. Requires cherry pick to 7.12 release.

## Technical Details
Fix rocm_smi64 exporting invalid absolute paths to consumers Remove redundant target_include_directories() that exported build-time absolute paths without BUILD_INTERFACE protection. Lines 91-92 already handle this correctly.

## JIRA ID
ROCM-4041

## Test Plan


## Test Result


## Submission Checklist
