### PR TITLE
[AMD-SMI] CPU: Added support for family 1A Models 50h-57h (#3206)

### DIFF
--- a/projects/amdsmi/CHANGELOG.md
+++ b/projects/amdsmi/CHANGELOG.md
@@ -180,6 +180,390 @@ Full documentation for amd_smi_lib is available at [https://rocm.docs.amd.com/pr
 
 ## amd_smi_lib for ROCm 7.11.0
 
+### Updated
+
+- **Updated support for set and get option for the following APIs**.
+
+  - Users can now set the power efficiency mode using `amd-smi set --cpu-pwr-eff-mode MODE(0-5) UTIL(0-100) PPT_LIMIT(in mW)`
+  - UTIL and PPT_LIMIT are valid only if mode is 4 or 5 and Family 1Ah Models 50h-57h onwards.
+
+  ```console
+  amd-smi  set --cpu-pwr-eff-mode 4 100 3000
+  CPU: 0
+      PWR_EFF_MODE:
+          MODE: 4
+          UTIL: 100%
+          PPT_LIMIT: 3.000 Watts
+          RESPONSE: Set power efficiency mode operation successful
+
+  CPU: 1
+      PWR_EFF_MODE:
+          MODE: 4
+          UTIL: 100%
+          PPT_LIMIT: 3.000 Watts
+          RESPONSE: Set power efficiency mode operation successful
+  ```
+
+  - Users can now read the power efficiency mode using `amd-smi metric --cpu-pwr-eff-mode`
+
+  ```console
+  amd-smi  metric --cpu-pwr-eff-mode
+  CPU: 0
+      PWR_EFF_MODE:
+          MODE: 4
+          UTIL: 100%
+          PPT_LIMIT: 3.000 Watts
+
+  CPU: 1
+      PWR_EFF_MODE:
+          MODE: 4
+          UTIL: 100%
+          PPT_LIMIT: 3.000 Watts
+  ```
+
+  - Users can now set the XGMI Pstate range using `amd-smi set --cpu-xgmi-pstate-range MIN_PSTATE(0-1) MAX_PSTATE(0-1)`
+
+  ```console
+  amd-smi set --cpu-xgmi-pstate-range 1 1
+  CPU: 0
+      XGMI_PSTATE_RANGE:
+          RESPONSE: Set, MIN_PSTATE: 1, MAX_PSTATE: 1, successful
+
+  CPU: 1
+      XGMI_PSTATE_RANGE:
+          RESPONSE: Set, MIN_PSTATE: 1, MAX_PSTATE: 1, successful
+  ```
+
+  - Users can now read the XGMI Pstate range using `amd-smi metric --cpu-xgmi-pstate-range`
+
+  ```console
+  amd-smi metric --cpu-xgmi-pstate-range
+  CPU: 0
+      XGMI_PSTATE_RANGE:
+          MIN_PSTATE: 0
+          MAX_PSTATE: 0
+
+  CPU: 1
+      XGMI_PSTATE_RANGE:
+          MIN_PSTATE: 0
+          MAX_PSTATE: 0
+  ```
+
+  - Users can now set cpu rail isolated frequency policy using `amd-smi set --cpu-railisofreq-policy VALUE(0-1)`.
+
+  ```console
+  amd-smi set --cpu-railisofreq-policy 1
+  CPU: 0
+      RAILISOFREQ_POLICY:
+          RESPONSE: Set, VALUE: 1, successful
+
+  CPU: 1
+      RAILISOFREQ_POLICY:
+          RESPONSE: Set, VALUE: 1, successful
+  ```
+
+  - Users can now read the cpu rail isolated frequency policy  using `amd-smi metric --cpu-railisofreq-policy`.
+
+  ```console
+  amd-smi metric --cpu-railisofreq-policy
+  CPU: 0
+      RAILISOFREQ_POLICY:
+          VALUE: 1
+
+  CPU: 1
+      RAILISOFREQ_POLICY:
+          VALUE: 1
+  ```
+
+  - Users can now set the Data Fabric C-state control status using `amd-smi set --cpu-dfcstate-ctrl VALUE(0-1)`.
+
+  ```console
+  amd-smi set --cpu-dfcstate-ctrl 1
+  CPU: 0
+      DFCSTATE_CTRL:
+          RESPONSE: Set, VALUE: 1, successful
+
+  CPU: 1
+      DFCSTATE_CTRL:
+          RESPONSE: Set, VALUE: 1, successful
+  ```
+
+  - Users can now read the Data Fabric C-state control status  using `amd-smi metric --cpu-dfcstate-ctrl`.
+
+  ```console
+  amd-smi metric --cpu-dfcstate-ctrl
+  CPU: 0
+      DFCSTATE_CTRL:
+          VALUE: 1
+
+  CPU: 1
+      DFCSTATE_CTRL:
+          VALUE: 1
+  ```
+
+  - Users can now set the PC6 enabling control status using `amd-smi set --cpu-pc6-enable VALUE(0-1)`.
+
+  ```console
+  amd-smi set --cpu-pc6-enable 1
+  CPU: 0
+      PC6_ENABLE:
+          RESPONSE: Set, VALUE: 1, successful
+
+  CPU: 1
+      PC6_ENABLE:
+          RESPONSE: Set, VALUE: 1, successful
+  ```
+
+  - Users can now read the PC6 enabling control status using `amd-smi metric --cpu-pc6-enable`.
+
+  ```console
+  amd-smi metric --cpu-pc6-enable
+  CPU: 0
+      PC6_ENABLE:
+          VALUE: 1
+
+  CPU: 1
+      PC6_ENABLE:
+          VALUE: 1
+  ```
+
+  - Users can now set the CC6 enabling control status using `amd-smi set --cpu-cc6-enable VALUE(0-1)`.
+
+  ```console
+  amd-smi set --cpu-cc6-enable 1
+  CPU: 0
+      CC6_ENABLE:
+          RESPONSE: Set, VALUE: 1, successful
+
+  CPU: 1
+      CC6_ENABLE:
+          RESPONSE: Set, VALUE: 1, successful
+  ```
+
+  - Users can now read the CC6 enabling control status using `amd-smi metric --cpu-cc6-enable`.
+
+  ```console
+  amd-smi metric --cpu-cc6-enable
+  CPU: 0
+      CC6_ENABLE:
+          VALUE: 1
+
+  CPU: 1
+      CC6_ENABLE:
+          VALUE: 1
+  ```
+
+  - Users can now read 4 bytes data at a given register offset on the target DIMM address using `amd-smi metric --cpu-dimm-sb-reg`.
+
+  ```console
+  amd-smi metric --cpu-dimm-sb-reg 0x87 0xA 0 1
+  CPU: 0
+      DIMM_SB_REG:
+          DIMMADDRESS: 0x87
+          LID: 0x0A
+          OFFSET: 0x0000
+          REGSPACE: 1
+          DATA: 0x01121230
+  ```
+
+  - Users can now write 4 byte data at a given register offset on the target DIMM address using `amd-smi set --cpu-dimm-sb-reg`.
+
+  ```console
+  amd-smi set --cpu-dimm-sb-reg 0x87 0xA 0x2c0 1 0x11
+  CPU: 0
+      DIMM_SB_REG:
+          DIMMADDRESS: 0x87
+          LID: 0x0A
+          OFFSET: 0x02C0
+          REGSPACE: 1
+          DATA: 0x00000011
+          RESPONSE: Set DIMM sideband register write operation successful
+  ```
+
+  - Users can now read CCD power using `amd-smi metric --core-ccd-power`.
+
+  ```console
+  amd-smi metric --core-ccd-power -O 0 1 2
+  CORE: 0
+      CCD_POWER:
+          VALUE: 3.501 Watts
+
+  CORE: 1
+      CCD_POWER:
+          VALUE: 3.501 Watts
+
+  CORE: 2
+      CCD_POWER:
+          VALUE: 3.501 Watts
+  ```
+
+  - Users can now read Tdelta value using `amd-smi metric --cpu-tdelta`.
+
+  ```console
+  amd-smi metric --cpu-tdelta
+  CPU: 0
+      TDELTA:
+          VALUE: 0
+
+  CPU: 1
+      TDELTA:
+          VALUE: 0
+  ```
+
+  - Users can now read Temperature of SVI3 VR controller using `amd-smi metric --cpu-svi3-vr-controller-temp TYPE(0-1) RAIL_INDEX(0-4)`.
+  - RAIL_INDEX (0-4) is valid only when the TYPE is 1.
+
+  ```console
+  amd-smi metric --cpu-svi3-vr-controller-temp 1 1
+  CPU: 0
+      SVI3_VR_CONTROLLER_TEMP:
+          RAIL_SELECTION: 1
+          RAIL_INDEX: 1
+          TEMPERATURE: 30.0 Degree C
+
+  CPU: 1
+      SVI3_VR_CONTROLLER_TEMP:
+          RAIL_SELECTION: 1
+          RAIL_INDEX: 1
+          TEMPERATURE: 32.0 Degree C
+  ```
+
+  - Users can now read enabled HSMP command bit mask using `amd-smi metric --cpu-enabled-commands`.
+
+  ```console
+  amd-smi metric --cpu-enabled-commands
+  CPU: 0
+      ENABLED_COMMANDS:
+          READ_ENABLED_COMMANDS_BITMASK0: 0xFFFFFFFF
+          READ_ENABLED_COMMANDS_BITMASK1: 0xFFFFFFFF
+          READ_ENABLED_COMMANDS_BITMASK2: 0x7FFFFFFF
+          WRITE_ENABLED_COMMANDS_BITMASK0: 0xFFFFFFFF
+          WRITE_ENABLED_COMMANDS_BITMASK1: 0xFFFFFFFF
+          WRITE_ENABLED_COMMANDS_BITMASK2: 0x7FFFFFFF
+
+  CPU: 1
+      ENABLED_COMMANDS:
+          READ_ENABLED_COMMANDS_BITMASK0: 0xFFFFFFFF
+          READ_ENABLED_COMMANDS_BITMASK1: 0xFFFFFFFF
+          READ_ENABLED_COMMANDS_BITMASK2: 0x7FFFFFFF
+          WRITE_ENABLED_COMMANDS_BITMASK0: 0xFFFFFFFF
+          WRITE_ENABLED_COMMANDS_BITMASK1: 0xFFFFFFFF
+          WRITE_ENABLED_COMMANDS_BITMASK2: 0x7FFFFFFF
+  ```
+
+  - Users can now read core floor frequency limit using `amd-smi metric --core-floor-limit`.
+
+  ```console
+  amd-smi metric --core-floor-limit -O 0 1 2
+  CORE: 0
+      FLOOR_LIMIT:
+          VALUE: 600 MHz
+
+  CORE: 1
+      FLOOR_LIMIT:
+          VALUE: 600 MHz
+
+  CORE: 2
+      FLOOR_LIMIT:
+          VALUE: 600 MHz
+  ```
+
+  - Users can now read core effictive floor frequency limit using `amd-smi metric --core-eff-floor-limit`.
+
+  ```console
+  amd-smi metric --core-eff-floor-limit -O 0 1 2
+  CORE: 0
+      EFF_FLOOR_LIMIT:
+          VALUE: 600 MHz
+
+  CORE: 1
+      EFF_FLOOR_LIMIT:
+          VALUE: 600 MHz
+
+  CORE: 2
+      EFF_FLOOR_LIMIT:
+          VALUE: 600 MHz
+
+  ```
+
+  - Users can now set core floor frequency limit using `amd-smi set --core-floor-limit FLOOR_LIMIT(in MHz)`.
+  ```console
+  amd-smi set --core-floor-limit 1200 -O 0 1 2
+  CORE: 0
+      FLOOR_LIMIT:
+          RESPONSE: Set, VALUE: 1200 MHz, successful
+
+  CORE: 1
+      FLOOR_LIMIT:
+          RESPONSE: Set, VALUE: 1200 MHz, successful
+
+  CORE: 2
+      FLOOR_LIMIT:
+          RESPONSE: Set, VALUE: 1200 MHz, successful
+
+  ```
+
+  - Users can now set cpu floor frequency limit using `amd-smi set --cpu-floor-limit FLOOR_LIMIT (in MHz)`.
+
+  ```console
+  amd-smi set --cpu-floor-limit 1200
+  CPU: 0
+      FLOOR_LIMIT:
+          RESPONSE: Set, VALUE: 1200 MHz, successful
+
+  CPU: 1
+      FLOOR_LIMIT:
+          RESPONSE: Set, VALUE: 1200 MHz, successful
+  ```
+
+  - Users can now set core msr floor frequency limit using `amd-smi set --core-msr-floor-limit MSR_FLOOR_LIMIT (in MHz)`.
+
+  ```console
+  amd-smi set --core-msr-floor-limit 1200 -O 0 1 2
+  CORE: 0
+      MSR_FLOOR_LIMIT:
+          RESPONSE: Set, VALUE: 1200 MHz, successful
+
+  CORE: 1
+      MSR_FLOOR_LIMIT:
+          RESPONSE: Set, VALUE: 1200 MHz, successful
+
+  CORE: 2
+      MSR_FLOOR_LIMIT:
+          RESPONSE: Set, VALUE: 1200 MHz, successful
+  ```
+
+  - Users can now set cpu msr floor frequency limit using `amd-smi set --cpu-msr-floor-limit MSR_FLOOR_LIMIT (in MHz)`.
+
+  ```console
+  amd-smi set --cpu-msr-floor-limit 1200
+  CPU: 0
+      MSR_FLOOR_LIMIT:
+          RESPONSE: Set, VALUE: 1200 MHz, successful
+
+  CPU: 1
+      MSR_FLOOR_LIMIT:
+          RESPONSE: Set, VALUE: 1200 MHz, successful
+  ```
+
+  - Users can now set the socket + DIMM combined power (SDPS) limit using `amd-smi set --cpu-sdps-limit SDPS_LIMIT (in mW)`.
+
+  ```console
+  amd-smi set  --cpu-sdps-limit 300000
+  CPU: 0
+      SDPS_LIMIT:
+          RESPONSE: Set, VALUE: 300.000 Watts, successful
+  ```
+
+  - Users can now read set the socket + DIMM combined power (SDPS) limit using `amd-smi metric --cpu-sdps-limit`.
+
+  ```console
+  amd-smi metric --cpu-sdps-limit
+  CPU: 0
+      SDPS_LIMIT:
+          VALUE: 300.000 Watts
+  ```
+
 ### Added
 
 - **Added `--hex` flag to `amd-smi bad-pages` command**.  
@@ -341,49 +725,48 @@ Full documentation for amd_smi_lib is available at [https://rocm.docs.amd.com/pr
 ### Added
 
 - **Added support for get and set option for CPUISOFreqPolicy control API and DFCState Control API**.  
-  - Users can now able to set the  CPU ISO frequency policy  using `amd-smi set --cpu-railisofreq-policy (0-1)`.
-  - Users can now able to read the CPU ISO frequency policy  using `amd-smi metric --cpu-railisofreq-policy`.
-  - Users can now able to set the  Data Fabric C-state control status using `amd-smi set --cpu-dfcstate-ctrl (0-1)`.
-  - Users can now able to read the Data Fabric C-state control status  using `amd-smi metric --cpu-dfcstate-ctrl`.
+  - Users can now set the  CPU ISO frequency policy  using `amd-smi set --cpu-railisofreq-policy (0-1)`.
+  - Users can now read the CPU ISO frequency policy  using `amd-smi metric --cpu-railisofreq-policy`.
+  - Users can now set the  Data Fabric C-state control status using `amd-smi set --cpu-dfcstate-ctrl (0-1)`.
+  - Users can now read the Data Fabric C-state control status  using `amd-smi metric --cpu-dfcstate-ctrl`.
 
   ```console
   $amd-smi set --cpu-railisofreq-policy 0
   CPU: 0
-    CPURAILISO:
-        STATE: Set CPU ISO frequency policy operation successful
+      RAILISOFREQ_POLICY:
+          RESPONSE: Set, VALUE: 1, successful
 
   CPU: 1
-    CPURAILISO:
-        STATE: Set CPU ISO frequency policy operation successful
+      RAILISOFREQ_POLICY:
+          RESPONSE: Set, VALUE: 1, successful
 
   $amd-smi metric --cpu-railisofreq-policy
   CPU: 0
-    CPURAILISO:
-        CPURAILISOFREQ_POLICY: 0
+      RAILISOFREQ_POLICY:
+          VALUE: 1
 
   CPU: 1
-    CPURAILISO:
-        CPURAILISOFREQ_POLICY: 0
+      RAILISOFREQ_POLICY:
+          VALUE: 1
 
   $amd-smi set --cpu-dfcstate-ctrl 0
   CPU: 0
-    DFCSTATECTRL:
-        STATE: DFCState control operation successful
+      DFCSTATE_CTRL:
+          RESPONSE: Set, VALUE: 1, successful
 
   CPU: 1
-    DFCSTATECTRL:
-        STATE: DFCState control operation successful
+      DFCSTATE_CTRL:
+          RESPONSE: Set, VALUE: 1, successful
 
   $amd-smi metric --cpu-dfcstate-ctrl
   CPU: 0
-    DFCSTATE:
-        DFCSTATECTRL_STATUS: 0
+      DFCSTATE_CTRL:
+          VALUE: 1
 
   CPU: 1
-    DFCSTATE:
-        DFCSTATECTRL_STATUS: 0
-  ```
-
+      DFCSTATE_CTRL:
+          VALUE: 1
+ ```
 - **Added GPU and base board temperature `amd-smi monitor` CLI support**.  
   - Added `--gpu-board-temps` option to `amd-smi monitor` command for GPU board temperature sensors
   - Added `--base-board-temps` option to `amd-smi monitor` command for base board temperature sensors

--- a/projects/amdsmi/CMakeLists.txt
+++ b/projects/amdsmi/CMakeLists.txt
@@ -208,7 +208,7 @@ set(ROCM_INC_DIR "${PROJECT_SOURCE_DIR}/rocm_smi/include/rocm_smi")
 set(SHR_MUTEX_DIR "${PROJECT_SOURCE_DIR}/third_party/shared_mutex")
 if(ENABLE_ESMI_LIB)
     # Supported esmi library version tag
-    set(current_esmi_tag "esmi_pkg_ver-4.2")
+    set(current_esmi_tag "esmi_pkg_ver-5.1.1")
 
     if(NOT EXISTS ${PROJECT_SOURCE_DIR}/esmi_ib_library/src)
         # TODO: use ExternalProject_Add instead or a submodule

--- a/projects/amdsmi/amdsmi_cli/amdsmi_commands.py
+++ b/projects/amdsmi/amdsmi_cli/amdsmi_commands.py
@@ -36,6 +36,7 @@ from amdsmi_cli_exceptions import AmdSmiInvalidParameterException, AmdSmiRequire
 from amdsmi_helpers import AMDSMIHelpers
 from amdsmi_logger import AMDSMILogger
 from amdsmi import amdsmi_exception, amdsmi_interface
+from amdsmi.amdsmi_interface import AMDSMI_MAX_UTIL, AMDSMI_MAX_PPT_LIMIT, AMDSMI_MAX_RAIL_INDEX
 from pathlib import Path
 
 class AMDSMICommands():
@@ -3394,11 +3395,13 @@ class AMDSMICommands():
 
     def metric_cpu(self, args, multiple_devices=False, cpu=None, cpu_power_metrics=None, cpu_prochot=None,
                    cpu_freq_metrics=None, cpu_c0_res=None, cpu_lclk_dpm_level=None,
-                  cpu_pwr_svi_telemetry_rails=None, cpu_io_bandwidth=None, cpu_xgmi_bandwidth=None,
+                  cpu_pwr_svi_telemetry_rails=None, cpu_io_bandwidth=None, cpu_xgmi_bandwidth=None, cpu_pwr_eff_mode=None,
                    cpu_metrics_ver=None, cpu_metrics_table=None, cpu_socket_energy=None,
                    cpu_ddr_bandwidth=None, cpu_temp=None, cpu_dimm_temp_range_rate=None,
                    cpu_dimm_pow_consumption=None, cpu_dimm_thermal_sensor=None,
-                   cpu_dfcstate_ctrl=None, cpu_railisofreq_policy=None):
+                   cpu_xgmi_pstate_range=None, cpu_railisofreq_policy=None, cpu_dfcstate_ctrl=None,
+                   cpu_pc6_enable=None, cpu_cc6_enable=None, cpu_dimm_sb_reg=None, cpu_tdelta=None,
+                   cpu_svi3_vr_controller_temp=None, cpu_enabled_commands=None, cpu_sdps_limit=None):
         """Get Metric information for target cpu
 
         Args:
@@ -3413,6 +3416,7 @@ class AMDSMICommands():
             cpu_pwr_svi_telemetry_rails (list, optional): value override for args.cpu_pwr_svi_telemetry_rails. Defaults to None
             cpu_io_bandwidth (list, optional): value override for args.cpu_io_bandwidth. Defaults to None
             cpu_xgmi_bandwidth (list, optional): value override for args.cpu_xgmi_bandwidth. Defaults to None
+            cpu_pwr_eff_mode (bool, optional): Value override for args.cpu_pwr_eff_mode. Defaults to None
             cpu_metrics_ver (bool, optional): Value override for args.cpu_metrics_ver. Defaults to None
             cpu_metrics_table (bool, optional): Value override for args.cpu_metrics_table. Defaults to None
             cpu_socket_energy (bool, optional): Value override for args.cpu_socket_energy. Defaults to None
@@ -3421,8 +3425,16 @@ class AMDSMICommands():
             cpu_dimm_temp_range_rate (list, optional): Dimm address. Value override for args.cpu_dimm_temp_range_rate. Defaults to None
             cpu_dimm_pow_consumption (list, optional): Dimm address. Value override for args.cpu_dimm_pow_consumption. Defaults to None
             cpu_dimm_thermal_sensor (list, optional): Dimm address. Value override for args.cpu_dimm_thermal_sensor. Defaults to None
-            cpu_dfcstate_ctrl (bool, optional): Value override for args.cpu_dfcstate_ctrl. Defaults to None
+            cpu_xgmi_pstate_range (bool, optional): Value override for args.cpu_xgmi_pstate_range. Defaults to None
             cpu_railisofreq_policy (bool, optional): Value override for args.cpu_railisofreq_policy. Defaults to None
+            cpu_dfcstate_ctrl (bool, optional): Value override for args.cpu_dfcstate_ctrl. Defaults to None
+            cpu_pc6_enable (bool, optional): Value override for args.cpu_pc6_enable. Defaults to None
+            cpu_cc6_enable (bool, optional): Value override for args.cpu_cc6_enable. Defaults to None
+            cpu_dimm_sb_reg (list, optional): DIMM sideband register parameters [dimm_addr, lid, reg_offset, reg_space] for read. Value override for args.cpu_dimm_sb_reg. Defaults to None
+            cpu_tdelta (bool, optional): Value override for args.cpu_tdelta. Defaults to None
+            cpu_svi3_vr_controller_temp (list, optional): TYPE and optional RAIL_INDEX. Value override for args.cpu_svi3_vr_controller_temp. Defaults to None
+            cpu_enabled_commands (bool, optional): Value override for args.cpu_enabled_commands. Defaults to None
+            cpu_sdps_limit (bool, optional): Value override for args.cpu_sdps_limit. Defaults to None
 
         Returns:
             None: Print output via AMDSMILogger to destination
@@ -3446,6 +3458,8 @@ class AMDSMICommands():
             args.cpu_io_bandwidth = cpu_io_bandwidth
         if cpu_xgmi_bandwidth:
             args.cpu_xgmi_bandwidth = cpu_xgmi_bandwidth
+        if cpu_pwr_eff_mode:
+            args.cpu_pwr_eff_mode = cpu_pwr_eff_mode
         if cpu_metrics_ver:
             args.cpu_metrics_ver = cpu_metrics_ver
         if cpu_metrics_table:
@@ -3462,24 +3476,44 @@ class AMDSMICommands():
             args.cpu_dimm_pow_consumption = cpu_dimm_pow_consumption
         if cpu_dimm_thermal_sensor:
             args.cpu_dimm_thermal_sensor = cpu_dimm_thermal_sensor
-        if cpu_dfcstate_ctrl:
-            args.cpu_dfcstate_ctrl = cpu_dfcstate_ctrl
+        if cpu_xgmi_pstate_range:
+            args.cpu_xgmi_pstate_range = cpu_xgmi_pstate_range
         if cpu_railisofreq_policy:
             args.cpu_railisofreq_policy = cpu_railisofreq_policy
+        if cpu_dfcstate_ctrl:
+            args.cpu_dfcstate_ctrl = cpu_dfcstate_ctrl
+        if cpu_pc6_enable:
+            args.cpu_pc6_enable = cpu_pc6_enable
+        if cpu_cc6_enable:
+            args.cpu_cc6_enable = cpu_cc6_enable
+        if cpu_dimm_sb_reg:
+            args.cpu_dimm_sb_reg = cpu_dimm_sb_reg
+        if cpu_tdelta:
+            args.cpu_tdelta = cpu_tdelta
+        if cpu_svi3_vr_controller_temp:
+            args.cpu_svi3_vr_controller_temp = cpu_svi3_vr_controller_temp
+        if cpu_enabled_commands:
+            args.cpu_enabled_commands = cpu_enabled_commands
+        if cpu_sdps_limit:
+            args.cpu_sdps_limit = cpu_sdps_limit
 
         #store cpu args that are applicable to the current platform
         curr_platform_cpu_args = ["cpu_power_metrics", "cpu_prochot", "cpu_freq_metrics",
                                   "cpu_c0_res", "cpu_lclk_dpm_level", "cpu_pwr_svi_telemetry_rails",
-                                  "cpu_io_bandwidth", "cpu_xgmi_bandwidth", "cpu_metrics_ver",
+                                  "cpu_io_bandwidth", "cpu_xgmi_bandwidth", "cpu_pwr_eff_mode", "cpu_metrics_ver",
                                   "cpu_metrics_table", "cpu_socket_energy", "cpu_ddr_bandwidth",
                                   "cpu_temp", "cpu_dimm_temp_range_rate", "cpu_dimm_pow_consumption",
-                                  "cpu_dimm_thermal_sensor", "cpu_dfcstate_ctrl", "cpu_railisofreq_policy"]
+                                  "cpu_dimm_thermal_sensor", "cpu_xgmi_pstate_range", "cpu_railisofreq_policy",
+                                  "cpu_dfcstate_ctrl", "cpu_pc6_enable", "cpu_cc6_enable", "cpu_dimm_sb_reg",
+                                  "cpu_tdelta", "cpu_svi3_vr_controller_temp", "cpu_enabled_commands", "cpu_sdps_limit"]
         curr_platform_cpu_values = [args.cpu_power_metrics, args.cpu_prochot, args.cpu_freq_metrics,
                                     args.cpu_c0_res, args.cpu_lclk_dpm_level, args.cpu_pwr_svi_telemetry_rails,
-                                    args.cpu_io_bandwidth, args.cpu_xgmi_bandwidth, args.cpu_metrics_ver,
+                                    args.cpu_io_bandwidth, args.cpu_xgmi_bandwidth, args.cpu_pwr_eff_mode, args.cpu_metrics_ver,
                                     args.cpu_metrics_table, args.cpu_socket_energy, args.cpu_ddr_bandwidth,
                                     args.cpu_temp, args.cpu_dimm_temp_range_rate, args.cpu_dimm_pow_consumption,
-                                    args.cpu_dimm_thermal_sensor, args.cpu_dfcstate_ctrl, args.cpu_railisofreq_policy]
+                                    args.cpu_dimm_thermal_sensor, args.cpu_xgmi_pstate_range, args.cpu_railisofreq_policy,
+                                    args.cpu_dfcstate_ctrl, args.cpu_pc6_enable, args.cpu_cc6_enable, args.cpu_dimm_sb_reg,
+                                    args.cpu_tdelta, args.cpu_svi3_vr_controller_temp, args.cpu_enabled_commands, args.cpu_sdps_limit]
 
         # Handle No CPU passed (fall back as this should be defined in metric())
         if args.cpu == None:
@@ -3488,7 +3522,7 @@ class AMDSMICommands():
         if not any(curr_platform_cpu_values):
             for arg in curr_platform_cpu_args:
                 if arg not in("cpu_lclk_dpm_level", "cpu_io_bandwidth", "cpu_xgmi_bandwidth",
-                              "cpu_dimm_temp_range_rate", "cpu_dimm_pow_consumption", "cpu_dimm_thermal_sensor"):
+                              "cpu_dimm_temp_range_rate", "cpu_dimm_pow_consumption", "cpu_dimm_thermal_sensor", "cpu_dimm_sb_reg"):
                     setattr(args, arg, True)
 
         handled_multiple_cpus, device_handle = self.helpers.handle_cpus(args,
@@ -3608,6 +3642,27 @@ class AMDSMICommands():
             except amdsmi_exception.AmdSmiLibraryException as e:
                 static_dict["xgmi_bandwidth"]["band_width"] = "N/A"
                 logging.debug("Failed to get xgmi bandwidth for cpu %s | %s", cpu_id, e.get_error_info())
+        if args.cpu_pwr_eff_mode:
+            static_dict["pwr_eff_mode"] = {}
+            try:
+                mode, util, ppt_limit = amdsmi_interface.amdsmi_get_cpu_pwr_efficiency_mode(args.cpu)
+
+                # Always show mode
+                static_dict["pwr_eff_mode"]["mode"] = f"{mode}"
+
+                # Only show util and ppt_limit for modes 4 and 5
+                if mode in [4, 5]:
+                    static_dict["pwr_eff_mode"]["util"] = f"{util}%"
+                    static_dict["pwr_eff_mode"]["ppt_limit"] = f"{ppt_limit:.3f} Watts"
+                else:
+                    # For modes 0-3, util and ppt_limit are not displayed
+                    pass
+
+            except amdsmi_exception.AmdSmiLibraryException as e:
+                static_dict["pwr_eff_mode"]["mode"] = "N/A"
+                static_dict["pwr_eff_mode"]["util"] = "N/A"
+                static_dict["pwr_eff_mode"]["ppt_limit"] = "N/A"
+                logging.debug("Failed to get power efficiency mode for cpu %s | %s", cpu_id, e.get_error_info())
         if args.cpu_metrics_ver:
             static_dict["metric_version"] = {}
             try:
@@ -3684,22 +3739,117 @@ class AMDSMICommands():
             except amdsmi_exception.AmdSmiLibraryException as e:
                 static_dict["dimm_thermal_sensor"]["response"] = "N/A"
                 logging.debug("Failed to get dimm temperature range and refresh rate for cpu %s | %s", cpu_id, e.get_error_info())
-        if args.cpu_dfcstate_ctrl:
-            static_dict["dfcstate"] = {}
+        if args.cpu_xgmi_pstate_range:
+            static_dict["xgmi_pstate_range"] = {}
             try:
-                dfcstatectrl_status = amdsmi_interface.amdsmi_get_dfc_ctrl(args.cpu)
-                static_dict["dfcstate"]["dfcstatectrl_status"] = dfcstatectrl_status
+                pstate_range = amdsmi_interface.amdsmi_get_cpu_xgmi_pstate_range(args.cpu)
+                static_dict["xgmi_pstate_range"]["min_pstate"] = pstate_range["min_pstate"]
+                static_dict["xgmi_pstate_range"]["max_pstate"] = pstate_range["max_pstate"]
             except amdsmi_exception.AmdSmiLibraryException as e:
-                static_dict["dfcstate"]["dfcstatectrl_status"] = "N/A"
-                logging.debug("Failed to get dfcstate control status for cpu %s | %s", cpu_id, e.get_error_info())
+                static_dict["xgmi_pstate_range"]["min_pstate"] = "N/A"
+                static_dict["xgmi_pstate_range"]["max_pstate"] = "N/A"
+                logging.debug("Failed to get xgmi pstate range for cpu %s | %s", cpu_id, e.get_error_info())
         if args.cpu_railisofreq_policy:
-            static_dict["cpurailiso"] = {}
+            static_dict["railisofreq_policy"] = {}
             try:
                 cpurailisofreq_policy = amdsmi_interface.amdsmi_get_cpu_rail_isofreq_policy(args.cpu)
-                static_dict["cpurailiso"]["cpurailisofreq_policy"] = cpurailisofreq_policy
+                static_dict["railisofreq_policy"]["value"] = cpurailisofreq_policy
             except amdsmi_exception.AmdSmiLibraryException as e:
-                static_dict["cpurailiso"]["cpurailisofreq_policy"] = "N/A"
+                static_dict["railisofreq_policy"]["value"] = "N/A"
                 logging.debug("Failed to get cpurailiso frequency policy for cpu %s | %s", cpu_id, e.get_error_info())
+        if args.cpu_dfcstate_ctrl:
+            static_dict["dfcstate_ctrl"] = {}
+            try:
+                dfcstatectrl_status = amdsmi_interface.amdsmi_get_cpu_dfc_ctrl(args.cpu)
+                static_dict["dfcstate_ctrl"]["value"] = dfcstatectrl_status
+            except amdsmi_exception.AmdSmiLibraryException as e:
+                static_dict["dfcstate_ctrl"]["value"] = "N/A"
+                logging.debug("Failed to get dfcstate control status for cpu %s | %s", cpu_id, e.get_error_info())
+        if args.cpu_pc6_enable:
+            static_dict["pc6_enable"] = {}
+            try:
+                pc6_enable_status = amdsmi_interface.amdsmi_get_cpu_pc6_enable(args.cpu)
+                static_dict["pc6_enable"]["value"] = pc6_enable_status
+            except amdsmi_exception.AmdSmiLibraryException as e:
+                static_dict["pc6_enable"]["value"] = "N/A"
+                logging.debug("Failed to get PC6 enable status for cpu %s | %s", cpu_id, e.get_error_info())
+        if args.cpu_cc6_enable:
+            static_dict["cc6_enable"] = {}
+            try:
+                cc6_enable_status = amdsmi_interface.amdsmi_get_cpu_cc6_enable(args.cpu)
+                static_dict["cc6_enable"]["value"] = cc6_enable_status
+            except amdsmi_exception.AmdSmiLibraryException as e:
+                static_dict["cc6_enable"]["value"] = "N/A"
+                logging.debug("Failed to get CC6 enable status for cpu %s | %s", cpu_id, e.get_error_info())
+        if args.cpu_dimm_sb_reg:
+            static_dict["dimm_sb_reg"] = {}
+            try:
+                dimm_addr = args.cpu_dimm_sb_reg[0][0]
+                lid = args.cpu_dimm_sb_reg[0][1]
+                reg_offset = args.cpu_dimm_sb_reg[0][2]
+                reg_space = args.cpu_dimm_sb_reg[0][3]
+                dimm_sb_data = amdsmi_interface.amdsmi_get_cpu_dimm_sb_reg(args.cpu, dimm_addr, lid, reg_offset, reg_space)
+                static_dict["dimm_sb_reg"]["DimmAddress"] = f"0x{dimm_addr:02X}"
+                static_dict["dimm_sb_reg"]["Lid"] = f"0x{lid:02X}"
+                static_dict["dimm_sb_reg"]["Offset"] = f"0x{reg_offset:04X}"
+                static_dict["dimm_sb_reg"]["RegSpace"] = reg_space
+                static_dict["dimm_sb_reg"]["Data"] = f"0x{dimm_sb_data:08X}"
+            except amdsmi_exception.AmdSmiLibraryException as e:
+                static_dict["dimm_sb_reg"]["DimmAddress"] = f"0x{args.cpu_dimm_sb_reg[0][0]:02X}"
+                static_dict["dimm_sb_reg"]["Lid"] = f"0x{args.cpu_dimm_sb_reg[0][1]:02X}"
+                static_dict["dimm_sb_reg"]["Offset"] = f"0x{args.cpu_dimm_sb_reg[0][2]:04X}"
+                static_dict["dimm_sb_reg"]["RegSpace"] = args.cpu_dimm_sb_reg[0][3]
+                static_dict["dimm_sb_reg"]["Data"] = "N/A"
+                logging.debug("Failed to read DIMM sideband register for cpu %s | %s", cpu_id, e.get_error_info())
+        if args.cpu_tdelta:
+            static_dict["tdelta"] = {}
+            try:
+                tdelta_value = amdsmi_interface.amdsmi_get_cpu_tdelta(args.cpu)
+                static_dict["tdelta"]["value"] = tdelta_value
+            except amdsmi_exception.AmdSmiLibraryException as e:
+                static_dict["tdelta"]["value"] = "N/A"
+                logging.debug("Failed to get thermal delta (TDELTA) for cpu %s | %s", cpu_id, e.get_error_info())
+        if args.cpu_svi3_vr_controller_temp:
+            static_dict["svi3_vr_controller_temp"] = {}
+            try:
+                rail_type = args.cpu_svi3_vr_controller_temp[0][0]
+                rail_index = args.cpu_svi3_vr_controller_temp[0][1] if len(args.cpu_svi3_vr_controller_temp[0]) > 1 else AMDSMI_MAX_RAIL_INDEX
+                resp = amdsmi_interface.amdsmi_get_cpu_svi3_vr_controller_temp(args.cpu, rail_type, rail_index)
+                static_dict["svi3_vr_controller_temp"]["RAIL_SELECTION"] = resp["rail_selection"]
+                static_dict["svi3_vr_controller_temp"]["RAIL_INDEX"] = resp["rail_index"]
+                temp_celsius = resp["temperature"]
+                static_dict["svi3_vr_controller_temp"]["TEMPERATURE"] = f"{temp_celsius:.1f} Degree C"
+            except amdsmi_exception.AmdSmiLibraryException as e:
+                static_dict["svi3_vr_controller_temp"]["RAIL_SELECTION"] = "N/A"
+                static_dict["svi3_vr_controller_temp"]["RAIL_INDEX"] = "N/A"
+                static_dict["svi3_vr_controller_temp"]["TEMPERATURE"] = "N/A"
+                logging.debug("Failed to get SVI3 VR controller temperature for cpu %s | %s",cpu_id, e.get_error_info())
+        if args.cpu_enabled_commands:
+            static_dict["enabled_commands"] = {}
+            try:
+                enabled_cmds = amdsmi_interface.amdsmi_get_cpu_enabled_commands(args.cpu)
+                static_dict["enabled_commands"]["READ_ENABLED_COMMANDS_BITMASK0"] = f"0x{enabled_cmds['ReadEnabledCommandsBitMask0']:08X}"
+                static_dict["enabled_commands"]["READ_ENABLED_COMMANDS_BITMASK1"] = f"0x{enabled_cmds['ReadEnabledCommandsBitMask1']:08X}"
+                static_dict["enabled_commands"]["READ_ENABLED_COMMANDS_BITMASK2"] = f"0x{enabled_cmds['ReadEnabledCommandsBitMask2']:08X}"
+                static_dict["enabled_commands"]["WRITE_ENABLED_COMMANDS_BITMASK0"] = f"0x{enabled_cmds['WriteEnabledCommandsBitMask0']:08X}"
+                static_dict["enabled_commands"]["WRITE_ENABLED_COMMANDS_BITMASK1"] = f"0x{enabled_cmds['WriteEnabledCommandsBitMask1']:08X}"
+                static_dict["enabled_commands"]["WRITE_ENABLED_COMMANDS_BITMASK2"] = f"0x{enabled_cmds['WriteEnabledCommandsBitMask2']:08X}"
+            except amdsmi_exception.AmdSmiLibraryException as e:
+                static_dict["enabled_commands"]["READ_ENABLED_COMMANDS_BITMASK0"] = "N/A"
+                static_dict["enabled_commands"]["READ_ENABLED_COMMANDS_BITMASK1"] = "N/A"
+                static_dict["enabled_commands"]["READ_ENABLED_COMMANDS_BITMASK2"] = "N/A"
+                static_dict["enabled_commands"]["WRITE_ENABLED_COMMANDS_BITMASK0"] = "N/A"
+                static_dict["enabled_commands"]["WRITE_ENABLED_COMMANDS_BITMASK1"] = "N/A"
+                static_dict["enabled_commands"]["WRITE_ENABLED_COMMANDS_BITMASK2"] = "N/A"
+                logging.debug("Failed to get enabled commands for cpu %s | %s", cpu_id, e.get_error_info())
+        if args.cpu_sdps_limit:
+            static_dict["sdps_limit"] = {}
+            try:
+                sdps_limit = amdsmi_interface.amdsmi_get_cpu_sdps_limit(args.cpu)
+                static_dict["sdps_limit"]["value"] = sdps_limit
+            except amdsmi_exception.AmdSmiLibraryException as e:
+                static_dict["sdps_limit"]["value"] = "N/A"
+                logging.debug("Failed to get socket SDPS limit for cpu %s | %s", cpu_id, e.get_error_info())
 
         multiple_devices_csv_override = False
         if not self.logger.is_json_format():
@@ -3714,7 +3864,8 @@ class AMDSMICommands():
 
 
     def metric_core(self, args, multiple_devices=False, core=None, core_boost_limit=None,
-                    core_curr_active_freq_core_limit=None, core_energy=None):
+                    core_curr_active_freq_core_limit=None, core_energy=None, core_ccd_power=None,
+                    core_floor_limit=None, core_eff_floor_limit=None):
         """Get Static information for target core
 
         Args:
@@ -3724,6 +3875,9 @@ class AMDSMICommands():
             core_boost_limit (bool, optional): Value override for args.core_boost_limit. Defaults to None
             core_curr_active_freq_core_limit (bool, optional): Value override for args.core_curr_active_freq_core_limit. Defaults to None
             core_energy (bool, optional): Value override for args.core_energy. Defaults to None
+            core_ccd_power (bool, optional): Value override for args.core_ccd_power. Defaults to None
+            core_floor_limit (bool, optional): Value override for args.core_floor_limit. Defaults to None
+            core_eff_floor_limit (bool, optional): Value override for args.core_eff_floor_limit. Defaults to None
         Returns:
             None: Print output via AMDSMILogger to destination
         """
@@ -3735,10 +3889,16 @@ class AMDSMICommands():
             args.core_curr_active_freq_core_limit = core_curr_active_freq_core_limit
         if core_energy:
             args.core_energy = core_energy
+        if core_ccd_power:
+            args.core_ccd_power = core_ccd_power
+        if core_floor_limit:
+            args.core_floor_limit = core_floor_limit
+        if core_eff_floor_limit:
+            args.core_eff_floor_limit = core_eff_floor_limit
 
         #store core args that are applicable to the current platform
-        curr_platform_core_args = ["core_boost_limit", "core_curr_active_freq_core_limit", "core_energy"]
-        curr_platform_core_values = [args.core_boost_limit, args.core_curr_active_freq_core_limit, args.core_energy]
+        curr_platform_core_args = ["core_boost_limit", "core_curr_active_freq_core_limit", "core_energy", "core_ccd_power", "core_floor_limit", "core_eff_floor_limit"]
+        curr_platform_core_values = [args.core_boost_limit, args.core_curr_active_freq_core_limit, args.core_energy, args.core_ccd_power, args.core_floor_limit, args.core_eff_floor_limit]
 
         # Handle No cores passed
         if args.core == None:
@@ -3787,6 +3947,33 @@ class AMDSMICommands():
             except amdsmi_exception.AmdSmiLibraryException as e:
                 static_dict["core_energy"]["value"] = "N/A"
                 logging.debug("Failed to get core energy for core %s | %s", core_id, e.get_error_info())
+
+        if args.core_ccd_power:
+            static_dict["ccd_power"] = {}
+            try:
+                power = amdsmi_interface.amdsmi_get_cpu_core_ccd_power(args.core)
+                static_dict["ccd_power"]["value"] = f"{power:.3f} Watts"
+            except amdsmi_exception.AmdSmiLibraryException as e:
+                static_dict["ccd_power"]["value"] = "N/A"
+                logging.debug("Failed to get CCD power for core %s | %s", core_id, e.get_error_info())
+
+        if args.core_floor_limit:
+            static_dict["floor_limit"] = {}
+            try:
+                core_floor_limit = amdsmi_interface.amdsmi_get_cpu_core_floor_freq_limit(args.core)
+                static_dict["floor_limit"]["value"] = f"{core_floor_limit} MHz"
+            except amdsmi_exception.AmdSmiLibraryException as e:
+                static_dict["floor_limit"]["value"] = "N/A"
+                logging.debug("Failed to get core floor limit for core %s | %s", core_id, e.get_error_info())
+
+        if args.core_eff_floor_limit:
+            static_dict["eff_floor_limit"] = {}
+            try:
+                core_eff_floor_limit = amdsmi_interface.amdsmi_get_cpu_core_eff_floor_freq_limit(args.core)
+                static_dict["eff_floor_limit"]["value"] = f"{core_eff_floor_limit} MHz"
+            except amdsmi_exception.AmdSmiLibraryException as e:
+                static_dict["eff_floor_limit"]["value"] = "N/A"
+                logging.debug("Failed to get core effective floor limit for core %s | %s", core_id, e.get_error_info())
 
         multiple_devices_csv_override = False
         if not self.logger.is_json_format():
@@ -4154,12 +4341,15 @@ class AMDSMICommands():
                 guard=None, guest_data=None, fb_usage=None, xgmi=None,
                 cpu=None, cpu_power_metrics=None, cpu_prochot=None, cpu_freq_metrics=None,
                 cpu_c0_res=None, cpu_lclk_dpm_level=None, cpu_pwr_svi_telemetry_rails=None,
-                cpu_io_bandwidth=None, cpu_xgmi_bandwidth=None, cpu_metrics_ver=None,
+                cpu_io_bandwidth=None, cpu_xgmi_bandwidth=None, cpu_pwr_eff_mode=None, cpu_metrics_ver=None,
                 cpu_metrics_table=None, cpu_socket_energy=None, cpu_ddr_bandwidth=None,
                 cpu_temp=None, cpu_dimm_temp_range_rate=None, cpu_dimm_pow_consumption=None,
-                cpu_dimm_thermal_sensor=None, cpu_dfcstate_ctrl=None, cpu_railisofreq_policy=None,
+                cpu_dimm_thermal_sensor=None, cpu_xgmi_pstate_range=None, cpu_railisofreq_policy=None,
+                cpu_dfcstate_ctrl=None, cpu_pc6_enable=None, cpu_cc6_enable=None, cpu_dimm_sb_reg=None,
+                cpu_tdelta=None, cpu_svi3_vr_controller_temp=None, cpu_enabled_commands=None, cpu_sdps_limit=None,
                 core=None, core_boost_limit=None, core_curr_active_freq_core_limit=None,
-                core_energy=None, throttle=None, base_board=None, gpu_board=None):
+                core_energy=None, core_ccd_power=None, core_floor_limit=None, core_eff_floor_limit=None,
+                throttle=None, base_board=None, gpu_board=None):
         """Get Metric information for target gpu
 
         Args:
@@ -4200,6 +4390,7 @@ class AMDSMICommands():
             cpu_pwr_svi_telemetry_rails (list, optional): value override for args.cpu_pwr_svi_telemetry_rails. Defaults to None
             cpu_io_bandwidth (list, optional): value override for args.cpu_io_bandwidth. Defaults to None
             cpu_xgmi_bandwidth (list, optional): value override for args.cpu_xgmi_bandwidth. Defaults to None
+            cpu_pwr_eff_mode (bool, optional): Value override for args.cpu_pwr_eff_mode. Defaults to None
             cpu_metrics_ver (bool, optional): Value override for args.cpu_metrics_ver. Defaults to None
             cpu_metrics_table (bool, optional): Value override for args.cpu_metrics_table. Defaults to None
             cpu_socket_energy (bool, optional): Value override for args.cpu_socket_energy. Defaults to None
@@ -4208,13 +4399,24 @@ class AMDSMICommands():
             cpu_dimm_temp_range_rate (list, optional): Dimm address. Value override for args.cpu_dimm_temp_range_rate. Defaults to None
             cpu_dimm_pow_consumption (list, optional): Dimm address. Value override for args.cpu_dimm_pow_consumption. Defaults to None
             cpu_dimm_thermal_sensor (list, optional): Dimm address. Value override for args.cpu_dimm_thermal_sensor. Defaults to None
-            cpu_dfcstate_ctrl (bool, optional): Value override for args.cpu_dfcstate_ctrl. Defaults to None
+            cpu_xgmi_pstate_range (bool, optional): Value override for args.cpu_xgmi_pstate_range. Defaults to None
             cpu_railisofreq_policy (bool, optional): Value override for args.cpu_railisofreq_policy. Defaults to None
+            cpu_dfcstate_ctrl (bool, optional): Value override for args.cpu_dfcstate_ctrl. Defaults to None
+            cpu_pc6_enable (bool, optional): Value override for args.cpu_pc6_enable. Defaults to None
+            cpu_cc6_enable (bool, optional): Value override for args.cpu_cc6_enable. Defaults to None
+            cpu_dimm_sb_reg (list, optional): DIMM sideband register parameters [dimm_addr, lid, reg_offset, reg_space] for read. Value override for args.cpu_dimm_sb_reg. Defaults to None
+            cpu_tdelta (bool, optional): Value override for args.cpu_tdelta. Defaults to None
+            cpu_svi3_vr_controller_temp (list, optional): TYPE and optional RAIL_INDEX. Value override for args.cpu_svi3_vr_controller_temp. Defaults to None
+            cpu_enabled_commands (bool, optional): Value override for args.cpu_enabled_commands. Defaults to None
+            cpu_sdps_limit (bool, optional): Value override for args.cpu_sdps_limit. Defaults to None
 
             core (device_handle, optional): device_handle for target core. Defaults to None.
             core_boost_limit (bool, optional): Value override for args.core_boost_limit. Defaults to None
             core_curr_active_freq_core_limit (bool, optional): Value override for args.core_curr_active_freq_core_limit. Defaults to None
             core_energy (bool, optional): Value override for args.core_energy. Defaults to None
+            core_ccd_power (bool, optional): Value override for args.core_ccd_power. Defaults to None
+            core_floor_limit (bool, optional): Value override for args.core_floor_limit. Defaults to None
+            core_eff_floor_limit (bool, optional): Value override for args.core_eff_floor_limit. Defaults to None
 
             nic (nic_handle, optional): device_handle for target device. Defaults to None.
             nic_power (bool, optional): Value override for args.nic_power. Defaults to None.
@@ -4275,10 +4477,12 @@ class AMDSMICommands():
         cpu_args_enabled = False
         cpu_attributes = ["cpu_power_metrics", "cpu_prochot", "cpu_freq_metrics", "cpu_c0_res",
                           "cpu_lclk_dpm_level", "cpu_pwr_svi_telemetry_rails", "cpu_io_bandwidth",
-                          "cpu_xgmi_bandwidth", "cpu_metrics_ver", "cpu_metrics_table",
+                          "cpu_xgmi_bandwidth", "cpu_pwr_eff_mode", "cpu_metrics_ver", "cpu_metrics_table",
                           "cpu_socket_energy", "cpu_ddr_bandwidth", "cpu_temp", "cpu_dimm_temp_range_rate",
-                          "cpu_dimm_pow_consumption", "cpu_dimm_thermal_sensor",
-                          "cpu_dfcstate_ctrl", "cpu_railisofreq_policy"]
+                          "cpu_dimm_pow_consumption", "cpu_dimm_thermal_sensor", "cpu_xgmi_pstate_range",
+                          "cpu_railisofreq_policy", "cpu_dfcstate_ctrl", "cpu_pc6_enable", "cpu_cc6_enable",
+                          "cpu_dimm_sb_reg", "cpu_tdelta", "cpu_svi3_vr_controller_temp",
+                          "cpu_enabled_commands", "cpu_sdps_limit"]
         for attr in cpu_attributes:
             if hasattr(args, attr):
                 if getattr(args, attr):
@@ -4287,7 +4491,7 @@ class AMDSMICommands():
 
         # Check if a Core argument has been set
         core_args_enabled = False
-        core_attributes = ["core_boost_limit", "core_curr_active_freq_core_limit", "core_energy"]
+        core_attributes = ["core_boost_limit", "core_curr_active_freq_core_limit", "core_energy", "core_ccd_power", "core_floor_limit", "core_eff_floor_limit"]
         for attr in core_attributes:
             if hasattr(args, attr):
                 if getattr(args, attr):
@@ -4321,16 +4525,18 @@ class AMDSMICommands():
             if args.cpu:
                 self.metric_cpu(args, multiple_devices, cpu, cpu_power_metrics, cpu_prochot,
                                 cpu_freq_metrics, cpu_c0_res, cpu_lclk_dpm_level,
-                                cpu_pwr_svi_telemetry_rails, cpu_io_bandwidth, cpu_xgmi_bandwidth,
+                                cpu_pwr_svi_telemetry_rails, cpu_io_bandwidth, cpu_xgmi_bandwidth, cpu_pwr_eff_mode,
                                 cpu_metrics_ver, cpu_metrics_table, cpu_socket_energy,
                                 cpu_ddr_bandwidth, cpu_temp, cpu_dimm_temp_range_rate,
                                 cpu_dimm_pow_consumption, cpu_dimm_thermal_sensor,
-                                cpu_dfcstate_ctrl, cpu_railisofreq_policy)
+                                cpu_xgmi_pstate_range, cpu_railisofreq_policy, cpu_dfcstate_ctrl,
+                                cpu_pc6_enable, cpu_cc6_enable, cpu_dimm_sb_reg, cpu_tdelta,
+                                cpu_svi3_vr_controller_temp, cpu_enabled_commands, cpu_sdps_limit)
             if args.core:
                 self.logger.output = {}
                 self.logger.clear_multiple_devices_output()
                 self.metric_core(args, multiple_devices, core, core_boost_limit,
-                                     core_curr_active_freq_core_limit, core_energy)
+                                     core_curr_active_freq_core_limit, core_energy, core_ccd_power, core_floor_limit, core_eff_floor_limit)
             if args.gpu:
                 self.logger.output = {}
                 self.logger.clear_multiple_devices_output()
@@ -4356,16 +4562,18 @@ class AMDSMICommands():
             if args.cpu:
                 self.metric_cpu(args, multiple_devices, cpu, cpu_power_metrics, cpu_prochot,
                                 cpu_freq_metrics, cpu_c0_res, cpu_lclk_dpm_level,
-                                cpu_pwr_svi_telemetry_rails, cpu_io_bandwidth, cpu_xgmi_bandwidth,
+                                cpu_pwr_svi_telemetry_rails, cpu_io_bandwidth, cpu_xgmi_bandwidth, cpu_pwr_eff_mode,
                                 cpu_metrics_ver, cpu_metrics_table, cpu_socket_energy,
                                 cpu_ddr_bandwidth, cpu_temp, cpu_dimm_temp_range_rate,
                                 cpu_dimm_pow_consumption, cpu_dimm_thermal_sensor,
-                                cpu_dfcstate_ctrl, cpu_railisofreq_policy)
+                                cpu_xgmi_pstate_range, cpu_railisofreq_policy, cpu_dfcstate_ctrl,
+                                cpu_pc6_enable, cpu_cc6_enable, cpu_dimm_sb_reg, cpu_tdelta,
+                                cpu_svi3_vr_controller_temp, cpu_enabled_commands, cpu_sdps_limit)
             if args.core:
                 self.logger.output = {}
                 self.logger.clear_multiple_devices_output()
                 self.metric_core(args, multiple_devices, core, core_boost_limit,
-                                     core_curr_active_freq_core_limit, core_energy)
+                                     core_curr_active_freq_core_limit, core_energy, core_ccd_power, core_floor_limit, core_eff_floor_limit)
         elif self.helpers.is_amdgpu_initialized(): # Only GPU is initialized
             if args.gpu == None:
                 args.gpu = self.device_handles
@@ -5619,14 +5827,16 @@ class AMDSMICommands():
             self.logger.print_output(multiple_device_enabled=True)
 
 
-    def set_core(self, args, multiple_devices=False, core=None, core_boost_limit=None):
+    def set_core(self, args, multiple_devices=False, core=None, core_boost_limit=None, core_floor_limit=None, core_msr_floor_limit=None):
         """Issue set commands to target core(s)
 
         Args:
             args (Namespace): Namespace containing the parsed CLI args
             multiple_devices (bool, optional): True if checking for multiple devices. Defaults to False.
             core (device_handle, optional): device_handle for target device. Defaults to None.
-            core_boost_limit (list, optional): Value override for args.core_boost_limit. Defaults to None. Defaults to None.
+            core_boost_limit (list, optional): Value override for args.core_boost_limit. Defaults to None.
+            core_floor_limit (list, optional): Value override for args.core_floor_limit. Defaults to None.
+            core_msr_floor_limit (list, optional): Value override for args.core_msr_floor_limit. Defaults to None.
 
         Raises:
             ValueError: Value error if no core value is provided
@@ -5639,6 +5849,10 @@ class AMDSMICommands():
             args.core = core
         if core_boost_limit:
             args.core_boost_limit = core_boost_limit
+        if core_floor_limit:
+            args.core_floor_limit = core_floor_limit
+        if core_msr_floor_limit:
+            args.core_msr_floor_limit = core_msr_floor_limit
 
         if args.core == None:
             raise ValueError('No Core provided, specific Core targets(S) are needed')
@@ -5649,7 +5863,7 @@ class AMDSMICommands():
             return # This function is recursive
 
         # Error if no subcommand args are passed
-        if not any([args.core_boost_limit]):
+        if not any([args.core_boost_limit, args.core_floor_limit, args.core_msr_floor_limit]):
             command = " ".join(sys.argv[1:])
             raise AmdSmiRequiredCommandException(command, self.logger.format)
 
@@ -5684,6 +5898,65 @@ class AMDSMICommands():
                 static_dict["set_core_boost_limit"]["Response"] = f"Error occurred for Core {core_id} - {e.get_error_info()}"
                 logging.debug("Failed to set core boost limit for core %s | %s", core_id, e.get_error_info())
 
+        # Set core floor limit
+        if args.core_floor_limit:
+            static_dict["floor_limit"] = {}
+            try:
+                core_floor_limit = args.core_floor_limit[0][0]
+                amdsmi_interface.amdsmi_set_cpu_core_floor_freq_limit(args.core, core_floor_limit)
+
+                #Verify the core boost limit is set
+                flimit = amdsmi_interface.amdsmi_get_cpu_core_floor_freq_limit(args.core)
+                freq_range = amdsmi_interface.amdsmi_get_cpu_freq_range()
+                fmax = freq_range["fmax"]
+                fmin = freq_range["fmin"]
+
+                if flimit < core_floor_limit:
+                    if fmax and flimit != fmax:
+                        static_dict["floor_limit"]["Response"] = f"Set, VALUE: {flimit} MHz, successful"
+                    else:
+                        static_dict["floor_limit"]["Response"] = f"Set, VALUE: {flimit} MHz, successful. Max allowed cpu floor limit is {flimit} MHz"
+                elif flimit > core_floor_limit:
+                    if fmin and flimit != fmin:
+                        static_dict["floor_limit"]["Response"] = f"Set, VALUE: {flimit} MHz, successful"
+                    else:
+                        static_dict["floor_limit"]["Response"] = f"Set, VALUE: {flimit} MHz, successful. Min allowed cpu floor limit is {flimit} MHz"
+                else:
+                    static_dict["floor_limit"]["Response"] = f"Set, VALUE: {flimit} MHz, successful"
+            except amdsmi_exception.AmdSmiLibraryException as e:
+                static_dict["floor_limit"]["Response"] = f"Error occurred for Core {core_id} - {e.get_error_info()}"
+                logging.debug("Failed to set core floor limit for core %s | %s", core_id, e.get_error_info())
+
+        # Set core MSR floor limit
+        if args.core_msr_floor_limit:
+            static_dict["msr_floor_limit"] = {}
+            try:
+                msr_floor_limit = args.core_msr_floor_limit[0][0]
+                amdsmi_interface.amdsmi_set_cpu_core_msr_floor_freq_limit(args.core, msr_floor_limit)
+                #Verify the core msr floor limit is set
+                effflimit = amdsmi_interface.amdsmi_get_cpu_core_eff_floor_freq_limit(args.core)
+                if effflimit == 0:
+                    effflimit = msr_floor_limit
+                freq_range = amdsmi_interface.amdsmi_get_cpu_freq_range()
+                fmax = freq_range["fmax"]
+                fmin = freq_range["fmin"]
+
+                if effflimit < msr_floor_limit:
+                    if fmax and effflimit != fmax:
+                        static_dict["msr_floor_limit"]["Response"] = f"Set, VALUE: {effflimit} MHz, successful"
+                    else:
+                        static_dict["msr_floor_limit"]["Response"] = f"Set, VALUE: {effflimit} MHz, successful. Max allowed msr cpu floor limit is {effflimit} MHz"
+                elif effflimit > msr_floor_limit:
+                    if fmin and effflimit != fmin:
+                        static_dict["msr_floor_limit"]["Response"] = f"Set, VALUE: {effflimit} MHz, successful"
+                    else:
+                        static_dict["msr_floor_limit"]["Response"] = f"Set, VALUE: {effflimit} MHz, successful. Min allowed msr cpu floor limit is {effflimit} MHz"
+                else:
+                    static_dict["msr_floor_limit"]["Response"] = f"Set, VALUE: {effflimit} MHz, successful"
+            except amdsmi_exception.AmdSmiLibraryException as e:
+                static_dict["msr_floor_limit"]["Response"] = f"Error occurred for Core {core_id} - {e.get_error_info()}"
+                logging.debug("Failed to set core MSR floor limit for core %s | %s", core_id, e.get_error_info())
+
         multiple_devices_csv_override = False
         self.logger.store_core_output(args.core, 'values', static_dict)
         if multiple_devices:
@@ -5696,7 +5969,9 @@ class AMDSMICommands():
                 cpu_xgmi_link_width=None, cpu_lclk_dpm_level=None, cpu_pwr_eff_mode=None,
                 cpu_gmi3_link_width=None, cpu_pcie_link_rate=None, cpu_df_pstate_range=None,
                 cpu_enable_apb=None, cpu_disable_apb=None, soc_boost_limit=None,
-                cpu_dfcstate_ctrl=None, cpu_railisofreq_policy=None):
+                cpu_xgmi_pstate_range=None, cpu_railisofreq_policy=None, cpu_dfcstate_ctrl=None,
+                cpu_pc6_enable=None, cpu_cc6_enable=None, cpu_floor_limit=None,cpu_msr_floor_limit=None,
+                cpu_dimm_sb_reg=None, cpu_sdps_limit=None):
         """Issue set commands to target cpu(s)
 
         Args:
@@ -5706,15 +5981,22 @@ class AMDSMICommands():
             cpu_pwr_limit (int, optional): Value override for args.cpu_pwr_limit. Defaults to None.
             cpu_xgmi_link_width (List[int], optional): Value override for args.cpu_xgmi_link_width. Defaults to None.
             cpu_lclk_dpm_level (List[int], optional): Value override for args.cpu_lclk_dpm_level. Defaults to None.
-            cpu_pwr_eff_mode (int, optional): Value override for args.cpu_pwr_eff_mode. Defaults to None.
+            cpu_pwr_eff_mode (List[int], optional): Value override for args.cpu_pwr_eff_mode [mode, util, ppt_limit]. Defaults to None.
             cpu_gmi3_link_width (List[int], optional): Value override for args.cpu_gmi3_link_width. Defaults to None.
             cpu_pcie_link_rate (int, optional): Value override for args.cpu_pcie_link_rate. Defaults to None.
             cpu_df_pstate_range (List[int], optional): Value override for args.cpu_df_pstate_range. Defaults to None.
             cpu_enable_apb (bool, optional): Value override for args.cpu_enable_apb. Defaults to None.
             cpu_disable_apb (int, optional): Value override for args.cpu_disable_apb. Defaults to None.
             soc_boost_limit (int, optional): Value override for args.soc_boost_limit. Defaults to None.
-            cpu_dfcstate_ctrl (int, optional): Value override for args.cpu_dfcstate_ctrl. Defaults to None.
+            cpu_xgmi_pstate_range (List[int], optional): Value override for args.cpu_xgmi_pstate_range. Defaults to None.
             cpu_railisofreq_policy (int, optional): Value override for args.cpu_railisofreq_policy. Defaults to None.
+            cpu_dfcstate_ctrl (int, optional): Value override for args.cpu_dfcstate_ctrl. Defaults to None.
+            cpu_pc6_enable (int, optional): Value override for args.cpu_pc6_enable. Defaults to None.
+            cpu_cc6_enable (int, optional): Value override for args.cpu_cc6_enable. Defaults to None.
+            cpu_floor_limit (int, optional): Value override for args.cpu_floor_limit. Defaults to None.
+            cpu_msr_floor_limit (int, optional): Value override for args.cpu_msr_floor_limit. Defaults to None.
+            cpu_dimm_sb_reg (list, optional): DIMM sideband register write parameters [dimm_addr, lid, reg_offset, reg_space, write_data] for write operation. Value override for args.cpu_dimm_sb_reg. Defaults to None.
+            cpu_sdps_limit (int, optional): Value override for args.cpu_sdps_limit. Defaults to None.
 
         Raises:
             ValueError: Value error if no cpu value is provided
@@ -5745,10 +6027,24 @@ class AMDSMICommands():
             args.cpu_disable_apb = cpu_disable_apb
         if soc_boost_limit:
             args.soc_boost_limit = soc_boost_limit
-        if cpu_dfcstate_ctrl:
-            args.cpu_dfcstate_ctrl = cpu_dfcstate_ctrl
+        if cpu_xgmi_pstate_range:
+            args.cpu_xgmi_pstate_range = cpu_xgmi_pstate_range
         if cpu_railisofreq_policy:
             args.cpu_railisofreq_policy = cpu_railisofreq_policy
+        if cpu_dfcstate_ctrl:
+            args.cpu_dfcstate_ctrl = cpu_dfcstate_ctrl
+        if cpu_pc6_enable:
+            args.cpu_pc6_enable = cpu_pc6_enable
+        if cpu_cc6_enable:
+            args.cpu_cc6_enable = cpu_cc6_enable
+        if cpu_floor_limit:
+            args.cpu_floor_limit = cpu_floor_limit
+        if cpu_msr_floor_limit:
+            args.cpu_msr_floor_limit = cpu_msr_floor_limit
+        if cpu_dimm_sb_reg:
+            args.cpu_dimm_sb_reg = cpu_dimm_sb_reg
+        if cpu_sdps_limit:
+            args.cpu_sdps_limit = cpu_sdps_limit
 
         if args.cpu == None:
             raise ValueError('No CPU provided, specific CPU targets(S) are needed')
@@ -5763,7 +6059,10 @@ class AMDSMICommands():
         if not any([args.cpu_pwr_limit, args.cpu_xgmi_link_width, args.cpu_lclk_dpm_level,
                     args.cpu_pwr_eff_mode, args.cpu_gmi3_link_width, args.cpu_pcie_link_rate,
                     args.cpu_df_pstate_range, args.cpu_enable_apb, args.cpu_disable_apb,
-                    args.soc_boost_limit, args.cpu_dfcstate_ctrl, args.cpu_railisofreq_policy]):
+                    args.soc_boost_limit, args.cpu_xgmi_pstate_range, args.cpu_railisofreq_policy,
+                    args.cpu_dfcstate_ctrl, args.cpu_pc6_enable, args.cpu_cc6_enable,
+                    args.cpu_floor_limit, args.cpu_msr_floor_limit, args.cpu_dimm_sb_reg,
+                    args.cpu_sdps_limit]):
             command = " ".join(sys.argv[1:])
             raise AmdSmiRequiredCommandException(command, self.logger.format)
 
@@ -5812,12 +6111,27 @@ class AMDSMICommands():
                 logging.debug("Failed to set lclk dpm level for cpu %s | %s", cpu_id, e.get_error_info())
 
         if args.cpu_pwr_eff_mode:
-            static_dict["set_pwr_eff_mode"] = {}
+            static_dict["pwr_eff_mode"] = {}
             try:
-                amdsmi_interface.amdsmi_set_cpu_pwr_efficiency_mode(args.cpu, args.cpu_pwr_eff_mode[0][0])
-                static_dict["set_pwr_eff_mode"]["Response"] = f"{args.cpu_pwr_eff_mode[0][0]}"
+                mode = args.cpu_pwr_eff_mode[0][0]
+                util = args.cpu_pwr_eff_mode[0][1] if len(args.cpu_pwr_eff_mode[0]) > 1 else AMDSMI_MAX_UTIL
+                ppt_limit = args.cpu_pwr_eff_mode[0][2] if len(args.cpu_pwr_eff_mode[0]) > 2 else AMDSMI_MAX_PPT_LIMIT
+                updated_util, updated_ppt_limit = amdsmi_interface.amdsmi_set_cpu_pwr_efficiency_mode(args.cpu, mode, util, ppt_limit)
+
+                # Always show mode
+                static_dict["pwr_eff_mode"]["mode"] = f"{mode}"
+
+                # Only show util and ppt_limit for modes 4 and 5
+                if mode in [4, 5]:
+                    ppt_limit_watts = updated_ppt_limit/1000.0  # Convert milliwatts to watts
+                    static_dict["pwr_eff_mode"]["util"] = f"{updated_util}%"
+                    static_dict["pwr_eff_mode"]["ppt_limit"] = f"{ppt_limit_watts:.3f} Watts"
+                else:
+                    # For modes 0-3, util and ppt_limit are not displayed
+                    pass
+                static_dict["pwr_eff_mode"]["response"] = f"Set power efficiency mode operation successful"
             except amdsmi_exception.AmdSmiLibraryException as e:
-                static_dict["set_pwr_eff_mode"]["Response"] = f"Error occurred for CPU {cpu_id} - {e.get_error_info()}"
+                static_dict["pwr_eff_mode"]["response"] = f"Error occurred for CPU {cpu_id} - {e.get_error_info()}"
                 logging.debug("Failed to set power efficiency mode for cpu %s | %s", cpu_id, e.get_error_info())
 
         if args.cpu_gmi3_link_width:
@@ -5876,23 +6190,141 @@ class AMDSMICommands():
                 #static_dict["set_soc_boost_limit"]["Response"] = "N/A"
                 static_dict["set_soc_boost_limit"]["Response"] = f"Error occurred for CPU {cpu_id} - {e.get_error_info()}"
                 logging.debug("Failed to set socket boost limit for cpu %s | %s", cpu_id, e.get_error_info())
-        if args.cpu_dfcstate_ctrl:
-            static_dict["dfcstatectrl"] = {}
+
+        if args.cpu_xgmi_pstate_range:
+            static_dict["xgmi_pstate_range"] = {}
             try:
-                amdsmi_interface.amdsmi_set_dfc_ctrl(args.cpu, args.cpu_dfcstate_ctrl[0][0])
-                static_dict["dfcstatectrl"]["state"] = "DFCState control operation successful"
+                amdsmi_interface.amdsmi_set_cpu_xgmi_pstate_range(args.cpu, args.cpu_xgmi_pstate_range[0][0],
+                args.cpu_xgmi_pstate_range[0][1])
+                static_dict["xgmi_pstate_range"]["response"] = f"Set, MIN_PSTATE: {args.cpu_xgmi_pstate_range[0][0]}, MAX_PSTATE: {args.cpu_xgmi_pstate_range[0][1]}, successful"
             except amdsmi_exception.AmdSmiLibraryException as e:
-                static_dict["dfcstatectrl"]["state"] = f"Error occurred for CPU {cpu_id} - {e.get_error_info()}"
-                logging.debug("Failed to set dfcstate control for cpu %s | %s", cpu_id, e.get_error_info())
+                static_dict["xgmi_pstate_range"]["response"] = f"Error occurred for CPU {cpu_id} - {e.get_error_info()}"
+                logging.debug("Failed to set xgmi pstate range for cpu %s | %s", cpu_id, e.get_error_info())
 
         if args.cpu_railisofreq_policy:
-            static_dict["cpurailiso"] = {}
+            static_dict["railisofreq_policy"] = {}
             try:
-                amdsmi_interface.amdsmi_set_cpu_rail_isofreq_policy(args.cpu, args.cpu_railisofreq_policy[0][0])
-                static_dict["cpurailiso"]["state"] = "Set CPU ISO frequency policy operation successful"
+                resp = amdsmi_interface.amdsmi_set_cpu_rail_isofreq_policy(args.cpu, args.cpu_railisofreq_policy[0][0])
+                static_dict["railisofreq_policy"]["response"] = f"Set, VALUE: {resp}, successful"
             except amdsmi_exception.AmdSmiLibraryException as e:
-                static_dict["cpurailiso"]["state"] = f"Error occurred for CPU {cpu_id} - {e.get_error_info()}"
+                static_dict["railisofreq_policy"]["response"] = f"Error occurred for CPU {cpu_id} - {e.get_error_info()}"
                 logging.debug("Failed to set ISO frequency policy for cpu %s | %s", cpu_id, e.get_error_info())
+
+        if args.cpu_dfcstate_ctrl:
+            static_dict["dfcstate_ctrl"] = {}
+            try:
+                resp = amdsmi_interface.amdsmi_set_cpu_dfc_ctrl(args.cpu, args.cpu_dfcstate_ctrl[0][0])
+                static_dict["dfcstate_ctrl"]["response"] = f"Set, VALUE: {resp}, successful"
+            except amdsmi_exception.AmdSmiLibraryException as e:
+                static_dict["dfcstate_ctrl"]["response"] = f"Error occurred for CPU {cpu_id} - {e.get_error_info()}"
+                logging.debug("Failed to set dfcstate control for cpu %s | %s", cpu_id, e.get_error_info())
+
+        if args.cpu_pc6_enable:
+            static_dict["pc6_enable"] = {}
+            try:
+                amdsmi_interface.amdsmi_set_cpu_pc6_enable(args.cpu, args.cpu_pc6_enable[0][0])
+                static_dict["pc6_enable"]["response"] = f"Set, VALUE: {args.cpu_pc6_enable[0][0]}, successful"
+            except amdsmi_exception.AmdSmiLibraryException as e:
+                static_dict["pc6_enable"]["response"] = f"Error occurred for CPU {cpu_id} - {e.get_error_info()}"
+                logging.debug("Failed to set PC6 enable for cpu %s | %s", cpu_id, e.get_error_info())
+
+        if args.cpu_cc6_enable:
+            static_dict["cc6_enable"] = {}
+            try:
+                amdsmi_interface.amdsmi_set_cpu_cc6_enable(args.cpu, args.cpu_cc6_enable[0][0])
+                static_dict["cc6_enable"]["response"] = f"Set, VALUE: {args.cpu_cc6_enable[0][0]}, successful"
+            except amdsmi_exception.AmdSmiLibraryException as e:
+                static_dict["cc6_enable"]["response"] = f"Error occurred for CPU {cpu_id} - {e.get_error_info()}"
+                logging.debug("Failed to set CC6 enable for cpu %s | %s", cpu_id, e.get_error_info())
+
+        if args.cpu_floor_limit:
+            static_dict["floor_limit"] = {}
+            try:
+                cpu_floor_limit = args.cpu_floor_limit[0][0]
+                amdsmi_interface.amdsmi_set_cpu_floor_freq_limit(args.cpu, cpu_floor_limit)
+
+                #Verify the cpu floor limit is set
+                flimit= amdsmi_interface.amdsmi_get_cpu_floor_freq_limit(args.cpu)
+                freq_range = amdsmi_interface.amdsmi_get_cpu_freq_range()
+                fmax = freq_range["fmax"]
+                fmin = freq_range["fmin"]
+
+                if flimit < cpu_floor_limit:
+                    if fmax and flimit != fmax:
+                        static_dict["floor_limit"]["Response"] = f"Set, VALUE: {flimit} MHz, successful"
+                    else:
+                        static_dict["floor_limit"]["Response"] = f"Set, VALUE: {flimit} MHz, successful. Max allowed cpu floor limit is {flimit} MHz"
+                elif flimit > cpu_floor_limit:
+                    if fmin and flimit != fmin:
+                        static_dict["floor_limit"]["Response"] = f"Set, VALUE: {flimit} MHz, successful"
+                    else:
+                        static_dict["floor_limit"]["Response"] = f"Set, VALUE: {flimit} MHz, successful. Min allowed cpu floor limit is {flimit} MHz"
+                else:
+                    static_dict["floor_limit"]["Response"] = f"Set, VALUE: {flimit} MHz, successful"
+            except amdsmi_exception.AmdSmiLibraryException as e:
+                static_dict["floor_limit"]["Response"] = f"Error occurred for CPU {cpu_id} - {e.get_error_info()}"
+                logging.debug("Failed to set socket floor limit for cpu %s | %s", cpu_id, e.get_error_info())
+
+        if args.cpu_msr_floor_limit:
+            static_dict["msr_floor_limit"] = {}
+            try:
+                msr_floor_limit = args.cpu_msr_floor_limit[0][0]
+                amdsmi_interface.amdsmi_set_cpu_msr_floor_freq_limit(args.cpu, msr_floor_limit)
+
+                #Verify the cpu msr floor limit is set
+                effflimit = amdsmi_interface.amdsmi_get_cpu_eff_floor_freq_limit(args.cpu)
+                if effflimit == 0:
+                    effflimit = msr_floor_limit
+                freq_range = amdsmi_interface.amdsmi_get_cpu_freq_range()
+                fmax = freq_range["fmax"]
+                fmin = freq_range["fmin"]
+
+                if effflimit < msr_floor_limit:
+                    if fmax and effflimit != fmax:
+                        static_dict["msr_floor_limit"]["Response"] = f"Set, VALUE: {effflimit} MHz, successful"
+                    else:
+                        static_dict["msr_floor_limit"]["Response"] = f"Set, VALUE: {effflimit} MHz, successful. Max allowed msr cpu floor limit is {effflimit} MHz"
+                elif effflimit > msr_floor_limit:
+                    if fmin and effflimit != fmin:
+                        static_dict["msr_floor_limit"]["Response"] = f"Set, VALUE: {effflimit} MHz, successful"
+                    else:
+                        static_dict["msr_floor_limit"]["Response"] = f"Set, VALUE: {effflimit} MHz, successful. Min allowed msr cpu floor limit is {effflimit} MHz"
+                else:
+                    static_dict["msr_floor_limit"]["Response"] = f"Set, VALUE: {effflimit} MHz, successful"
+            except amdsmi_exception.AmdSmiLibraryException as e:
+                static_dict["msr_floor_limit"]["Response"] = f"Error occurred for CPU {cpu_id} - {e.get_error_info()}"
+                logging.debug("Failed to set CPU MSR floor limit for cpu %s | %s", cpu_id, e.get_error_info())
+
+        if args.cpu_dimm_sb_reg:
+            static_dict["dimm_sb_reg"] = {}
+            try:
+                dimm_addr = args.cpu_dimm_sb_reg[0][0]
+                lid = args.cpu_dimm_sb_reg[0][1]
+                reg_offset = args.cpu_dimm_sb_reg[0][2]
+                reg_space = args.cpu_dimm_sb_reg[0][3]
+                write_data = args.cpu_dimm_sb_reg[0][4]
+                amdsmi_interface.amdsmi_set_cpu_dimm_sb_reg(
+                    args.cpu, dimm_addr, lid, reg_offset, reg_space, write_data)
+                static_dict["dimm_sb_reg"]["DimmAddress"] = f"0x{dimm_addr:02X}"
+                static_dict["dimm_sb_reg"]["Lid"] = f"0x{lid:02X}"
+                static_dict["dimm_sb_reg"]["Offset"] = f"0x{reg_offset:04X}"
+                static_dict["dimm_sb_reg"]["RegSpace"] = reg_space
+                static_dict["dimm_sb_reg"]["Data"] = f"0x{write_data:08X}"
+                static_dict["dimm_sb_reg"]["Response"] = "Set DIMM sideband register write operation successful"
+            except amdsmi_exception.AmdSmiLibraryException as e:
+                static_dict["dimm_sb_reg"]["Response"] = f"Error occurred for CPU {cpu_id} - {e.get_error_info()}"
+                logging.debug("Failed to write DIMM sideband register for cpu %s | %s", cpu_id, e.get_error_info())
+
+        if args.cpu_sdps_limit:
+            static_dict["sdps_limit"] = {}
+            try:
+                amdsmi_interface.amdsmi_set_cpu_sdps_limit(args.cpu, args.cpu_sdps_limit[0][0])
+                sdps_limit_watts = float(args.cpu_sdps_limit[0][0]) / 1000
+                static_dict["sdps_limit"]["Response"] = f"Set, VALUE: {sdps_limit_watts:.3f} Watts, successful"
+            except amdsmi_exception.AmdSmiLibraryException as e:
+                static_dict["sdps_limit"]["Response"] = f"Error occurred for CPU {cpu_id} - {e.get_error_info()}"
+                logging.debug("Failed to set socket SDPS limit for cpu %s | %s", cpu_id, e.get_error_info())
+
 
         multiple_devices_csv_override = False
         self.logger.store_cpu_output(args.cpu, 'values', static_dict)
@@ -6552,8 +6984,10 @@ class AMDSMICommands():
                   cpu_pwr_eff_mode=None, cpu_gmi3_link_width=None, cpu_pcie_link_rate=None,
                   cpu_df_pstate_range=None, cpu_enable_apb=None, cpu_disable_apb=None,
                   soc_boost_limit=None, core=None, core_boost_limit=None, soc_pstate=None, xgmi_plpd=None,
-                  process_isolation=None, clk_limit=None, clk_level=None, cpu_dfcstate_ctrl=None,
-                  cpu_railisofreq_policy=None, ptl_status=None, ptl_format=None):
+                  process_isolation=None, clk_limit=None, clk_level=None, ptl_status=None, ptl_format=None,
+                  cpu_xgmi_pstate_range=None, cpu_railisofreq_policy=None, cpu_dfcstate_ctrl=None,
+                  cpu_pc6_enable=None, cpu_cc6_enable=None, cpu_floor_limit=None, cpu_msr_floor_limit=None,
+                  cpu_dimm_sb_reg=None, cpu_sdps_limit=None, core_floor_limit=None, core_msr_floor_limit=None):
         """Issue reset commands to target gpu(s)
 
         Args:
@@ -6572,7 +7006,7 @@ class AMDSMICommands():
             cpu_pwr_limit (int, optional): Value override for args.cpu_pwr_limit. Defaults to None.
             cpu_xgmi_link_width (List[int], optional): Value override for args.cpu_xgmi_link_width. Defaults to None.
             cpu_lclk_dpm_level (List[int], optional): Value override for args.cpu_lclk_dpm_level. Defaults to None.
-            cpu_pwr_eff_mode (int, optional): Value override for args.cpu_pwr_eff_mode. Defaults to None.
+            cpu_pwr_eff_mode (List[int], optional): Value override for args.cpu_pwr_eff_mode [mode, util, ppt_limit]. Defaults to None.
             cpu_gmi3_link_width (List[int], optional): Value override for args.cpu_gmi3_link_width. Defaults to None.
             cpu_pcie_link_rate (int, optional): Value override for args.cpu_pcie_link_rate. Defaults to None.
             cpu_df_pstate_range (List[int], optional): Value override for args.cpu_df_pstate_range. Defaults to None.
@@ -6581,9 +7015,18 @@ class AMDSMICommands():
             soc_boost_limit (int, optional): Value override for args.soc_boost_limit. Defaults to None.
             cpu_dfcstate_ctrl (int, optional): Value override for args.cpu_dfcstate_ctrl. Defaults to None.
             cpu_railisofreq_policy (int, optional): Value override for args.cpu_railisofreq_policy. Defaults to None.
+            cpu_xgmi_pstate_range (List[int], optional): Value override for args.cpu_xgmi_pstate_range. Defaults to None.
+            cpu_pc6_enable (int, optional): Value override for args.cpu_pc6_enable. Defaults to None.
+            cpu_cc6_enable (int, optional): Value override for args.cpu_cc6_enable. Defaults to None.
+            cpu_dimm_sb_reg (list, optional): DIMM sideband register write parameters [dimm_addr, lid, reg_offset, reg_space, write_data] for write operation. Value override for args.cpu_dimm_sb_reg. Defaults to None.
+            cpu_sdps_limit (int, optional): Value override for args.cpu_sdps_limit. Defaults to None.
+            cpu_floor_limit (int, optional): Value override for args.cpu_floor_limit. Defaults to None.
+            cpu_msr_floor_limit (int, optional): Value override for args.cpu_msr_floor_limit. Defaults to None.
 
             core (device_handle, optional): device_handle for target core. Defaults to None.
             core_boost_limit (int, optional): Value override for args.core_boost_limit. Defaults to None
+            core_floor_limit (int, optional): Value override for args.core_floor_limit. Defaults to None.
+            core_msr_floor_limit (int, optional): Value override for args.core_msr_floor_limit. Defaults to None.
             soc_pstate (int, optional): Value override for args.soc_pstate. Defaults to None.
             xgmi_plpd (int, optional): Value override for args.xgmi_plpd. Defaults to None.
             process_isolation (int, optional): Value override for args.process_isolation. Defaults to None.
@@ -6618,7 +7061,9 @@ class AMDSMICommands():
         cpu_attributes = ["cpu_pwr_limit", "cpu_xgmi_link_width", "cpu_lclk_dpm_level", "cpu_pwr_eff_mode",
                           "cpu_gmi3_link_width", "cpu_pcie_link_rate", "cpu_df_pstate_range",
                           "cpu_enable_apb", "cpu_disable_apb", "soc_boost_limit",
-                          "cpu_dfcstate_ctrl", "cpu_railisofreq_policy"]
+                          "cpu_xgmi_pstate_range", "cpu_railisofreq_policy", "cpu_dfcstate_ctrl",
+                          "cpu_pc6_enable", "cpu_cc6_enable", "cpu_floor_limit", "cpu_msr_floor_limit",
+                          "cpu_dimm_sb_reg", "cpu_sdps_limit"]
         for attr in cpu_attributes:
             if hasattr(args, attr):
                 if getattr(args, attr) not in [None, False]:
@@ -6627,7 +7072,7 @@ class AMDSMICommands():
 
         # Check if a Core argument has been set
         core_args_enabled = False
-        core_attributes = ["core_boost_limit"]
+        core_attributes = ["core_boost_limit", "core_floor_limit", "core_msr_floor_limit"]
         for attr in core_attributes:
             if hasattr(args, attr):
                 if getattr(args, attr) is not None:
@@ -6674,14 +7119,25 @@ class AMDSMICommands():
                             args.cpu_enable_apb,
                             args.cpu_disable_apb is not None,
                             args.soc_boost_limit is not None,
+                            args.cpu_xgmi_pstate_range is not None,
+                            args.cpu_railisofreq_policy is not None,
                             args.cpu_dfcstate_ctrl is not None,
-                            args.cpu_railisofreq_policy is not None
+                            args.cpu_pc6_enable is not None,
+                            args.cpu_cc6_enable is not None,
+                            args.cpu_floor_limit is not None,
+                            args.cpu_msr_floor_limit is not None,
+                            args.cpu_dimm_sb_reg is not None,
+                            args.cpu_sdps_limit is not None
                             ])
             except AttributeError:
                 # If attribute error for cpu, then we could be another subcommand
                 pass
             try:
                 if args.core_boost_limit:
+                    is_core_set = True
+                if args.core_floor_limit:
+                    is_core_set = True
+                if args.core_msr_floor_limit:
                     is_core_set = True
             except AttributeError:
                 # If attribute error for core, then we could be another subcommand
@@ -6729,11 +7185,13 @@ class AMDSMICommands():
                                 cpu_xgmi_link_width, cpu_lclk_dpm_level, cpu_pwr_eff_mode,
                                 cpu_gmi3_link_width, cpu_pcie_link_rate, cpu_df_pstate_range,
                                 cpu_enable_apb, cpu_disable_apb, soc_boost_limit,
-                                cpu_dfcstate_ctrl, cpu_railisofreq_policy)
+                                cpu_xgmi_pstate_range, cpu_railisofreq_policy, cpu_dfcstate_ctrl,
+                                cpu_pc6_enable, cpu_cc6_enable, cpu_floor_limit, cpu_msr_floor_limit,
+                                cpu_dimm_sb_reg, cpu_sdps_limit)
             if args.core:
                 self.logger.output = {}
                 self.logger.clear_multiple_devices_output()
-                self.set_core(args, multiple_devices, core, core_boost_limit)
+                self.set_core(args, multiple_devices, core, core_boost_limit, core_floor_limit, core_msr_floor_limit)
             if args.gpu:
                 self.logger.output = {}
                 self.logger.clear_multiple_devices_output()
@@ -6749,11 +7207,13 @@ class AMDSMICommands():
                                 cpu_xgmi_link_width, cpu_lclk_dpm_level, cpu_pwr_eff_mode,
                                 cpu_gmi3_link_width, cpu_pcie_link_rate, cpu_df_pstate_range,
                                 cpu_enable_apb, cpu_disable_apb, soc_boost_limit,
-                                cpu_dfcstate_ctrl, cpu_railisofreq_policy)
+                                cpu_xgmi_pstate_range, cpu_railisofreq_policy, cpu_dfcstate_ctrl,
+                                cpu_pc6_enable, cpu_cc6_enable, cpu_floor_limit, cpu_msr_floor_limit,
+                                cpu_dimm_sb_reg, cpu_sdps_limit)
             if args.core:
                 self.logger.output = {}
                 self.logger.clear_multiple_devices_output()
-                self.set_core(args, multiple_devices, core, core_boost_limit)
+                self.set_core(args, multiple_devices, core, core_boost_limit, core_floor_limit, core_msr_floor_limit)
         elif self.helpers.is_amdgpu_initialized(): # Only GPU is initialized
             if args.gpu == None:
                 args.gpu = self.device_handles

--- a/projects/amdsmi/amdsmi_cli/amdsmi_parser.py
+++ b/projects/amdsmi/amdsmi_cli/amdsmi_parser.py
@@ -341,6 +341,129 @@ class AMDSMIParser(argparse.ArgumentParser):
         return AMDSMIPowerCapArgs
 
 
+    def _cpu_power_eff_mode_options(self):
+        """Custom action for CPU power efficiency mode validation"""
+        output_format = self.helpers.get_output_format()
+
+        class CPUPowerEffModeArgs(argparse.Action):
+            def __call__(self, parser, namespace, values, option_string=None):
+                if len(values) < 1:
+                    raise amdsmi_cli_exceptions.AmdSmiInvalidParameterException(
+                            sys.argv[1], "Missing MODE argument", output_format)
+
+                mode = values[0]
+                if mode < 0 or mode > 5:
+                    raise amdsmi_cli_exceptions.AmdSmiInvalidParameterException(
+                            sys.argv[1], f"Invalid MODE {mode}, must be 0-5", output_format)
+                # Get CPU family and model for validation
+                try:
+                    cpu_family = amdsmi_interface.amdsmi_get_cpu_family()
+                    cpu_model = amdsmi_interface.amdsmi_get_cpu_model()
+                except Exception as e:
+                    # If we can't get CPU info, skip family/model validation
+                    cpu_family = None
+                    cpu_model = None
+
+                # Check if this is the specific family/model that requires UTIL and PPT_LIMIT for modes 4,5
+                requires_util_ppt = (cpu_family == 0x1A and cpu_model is not None and
+                                   0x50 <= cpu_model <= 0x5F)
+
+                # Mode-specific validation
+                if mode in [4, 5]:  # BalancedCore, BalancedCoreMemory
+                    if requires_util_ppt:
+                        # Family 0x1A, models 0x50-0x5F: REQUIRE UTIL and PPT_LIMIT
+                        if len(values) != 3:
+                            raise amdsmi_cli_exceptions.AmdSmiInvalidParameterException(
+                                    sys.argv[1],
+                                    f"Mode {mode} requires MODE UTIL PPT_LIMIT for CPU family 0x{cpu_family:X} model 0x{cpu_model:X} (got {len(values)} args)",
+                                    output_format)
+
+                        # Validate UTIL range
+                        util = values[1]
+                        if util < 0 or util > amdsmi_interface.AMDSMI_MAX_POWER_EFFICIENCY_UTIL:
+                            raise amdsmi_cli_exceptions.AmdSmiInvalidParameterException(
+                                 sys.argv[1],
+                                 f"UTIL must be 0-100, got {util}",
+                                 output_format)
+
+                        # Validate PPT_LIMIT range
+                        ppt_limit = values[2]
+                        if ppt_limit < 0 or ppt_limit > amdsmi_interface.AMDSMI_MAX_POWER_EFFICIENCY_PPTLIMIT:
+                            raise amdsmi_cli_exceptions.AmdSmiInvalidParameterException(
+                                sys.argv[1],
+                                "PPT_LIMIT Out of range",
+                                output_format)
+                    else:
+                        # Other family/models: modes 4,5 valid but should NOT accept UTIL and PPT_LIMIT
+                        if len(values) != 1:
+                            raise amdsmi_cli_exceptions.AmdSmiInvalidParameterException(
+                                sys.argv[1],
+                                f"Mode {mode} requires only MODE argument for this CPU (got {len(values)} args). UTIL and PPT_LIMIT not supported.",
+                                output_format)
+
+                else:  # HighPerformance, PowerEfficiency, IOPerformance, BalancedMemory
+                    if len(values) != 1:
+                        raise amdsmi_cli_exceptions.AmdSmiInvalidParameterException(
+                            sys.argv[1],
+                            f"Mode {mode} requires only MODE argument (got {len(values)} args)",
+                            output_format)
+
+                # Store values using 'append' behavior
+                if not hasattr(namespace, self.dest) or getattr(namespace, self.dest) is None:
+                    setattr(namespace, self.dest, [])
+                getattr(namespace, self.dest).append(values)
+
+        return CPUPowerEffModeArgs
+
+
+    def _cpu_svi3_vr_controller_temp_options(self):
+        """Custom action for CPU SVI3 VR controller temperature validation"""
+        output_format = self.helpers.get_output_format()
+
+        class CPUSvi3VrControllerTempArgs(argparse.Action):
+            def __call__(self, parser, namespace, values, option_string=None):
+                if len(values) < 1:
+                    raise amdsmi_cli_exceptions.AmdSmiInvalidParameterException(
+                        sys.argv[1], "Missing TYPE argument", output_format)
+
+                rail_type = values[0]
+
+                # Validate TYPE range
+                if rail_type not in [0, 1]:
+                    raise amdsmi_cli_exceptions.AmdSmiInvalidParameterException(
+                        sys.argv[1], f"Invalid TYPE {rail_type}, must be 0 (HottestRail) or 1 (IndividualRail)", output_format)
+
+                # Type-specific validation
+                if rail_type == 0:  # HottestRail
+                    if len(values) != 1:
+                        raise amdsmi_cli_exceptions.AmdSmiInvalidParameterException(
+                            sys.argv[1],
+                            f"TYPE 0 (HottestRail) requires exactly 1 argument (TYPE only), got {len(values)} arguments: {values}",
+                            output_format)
+
+                elif rail_type == 1:  # IndividualRail
+                    if len(values) != 2:
+                        raise amdsmi_cli_exceptions.AmdSmiInvalidParameterException(
+                            sys.argv[1],
+                            f"TYPE 1 (IndividualRail) requires exactly 2 arguments (TYPE RAIL_INDEX), got {len(values)} arguments: {values}",
+                            output_format)
+
+                    # Validate RAIL_INDEX range (0-4 based on help text)
+                    rail_index = values[1]
+                    if rail_index < 0 or rail_index > 4:
+                        raise amdsmi_cli_exceptions.AmdSmiInvalidParameterException(
+                            sys.argv[1],
+                            f"Invalid RAIL_INDEX {rail_index}, must be 0-4 (0=VDDCR_CPU0, 1=VDDCR_CPU1, 2=VDDCR_SOC, 3=VDDIO, 4=VDDIO_MEM_S3)",
+                            output_format)
+
+                # Store values using 'append' behavior
+                if not hasattr(namespace, self.dest) or getattr(namespace, self.dest) is None:
+                    setattr(namespace, self.dest, [])
+                getattr(namespace, self.dest).append(values)
+
+        return CPUSvi3VrControllerTempArgs
+
+
     def _check_folder_path(self):
         """ Argument action validator:
             Returns a path to folder from the folder path provided.
@@ -1202,6 +1325,8 @@ class AMDSMIParser(argparse.ArgumentParser):
         cpu_freq_help = "Displays currentFclkMemclk frequencies and cclk frequency limit"
         cpu_c0_res_help = "Displays C0 residency"
         cpu_lclk_dpm_help = "Displays lclk dpm level range. Requires socket ID and NBOID as inputs"
+        cpu_pwr_eff_mode_help = "Displays current power efficiency mode.\
+        \n For Family 1Ah Models 50h-57h onwards and MODE= 4 or 5, displays utilization percentage and PPT limit in Watts."
         cpu_pwr_svi_telemetry_rails_help = "Displays svi based telemetry for all rails"
         cpu_io_bandwidth_help = "Displays current IO bandwidth for the selected CPU.\
         \n input parameters are bandwidth type(1) and link ID encodings\
@@ -1218,13 +1343,26 @@ class AMDSMIParser(argparse.ArgumentParser):
         cpu_dimm_temp_range_rate_help = "Displays dimm temperature range and refresh rate"
         cpu_dimm_pow_consumption_help = "Displays dimm power consumption"
         cpu_dimm_thermal_sensor_help = "Displays dimm thermal sensor"
-        cpu_dfcstate_ctrl_help = "Displays DFCState control status"
+        cpu_xgmi_pstate_range_help = "Displays XGMI pstate range, min and max values for the selected CPU"
         cpu_railisofreq_policy_help = "Displays CPU ISO frequency policy"
+        cpu_dfcstate_ctrl_help = "Displays DFCState control status"
+        cpu_pc6_enable_help = "Displays PC6 enable control"
+        cpu_cc6_enable_help = "Displays CC6 enable control"
+        cpu_dimm_sb_reg_help = "Read DIMM sideband register.Requires DIMM_ADDR, LID(0x2->TS0,0x6->TS1,0x9->PMIC0,0xA->SPDHub)\
+        \n REG_OFFSET (hex), REG_SPACE (REGSPACE:0->Volatile,1->NVM)"
+        cpu_tdelta_help = "Displays CPU thermal delta (TDELTA) value for the selected CPU socket"
+        cpu_svi3_vr_controller_temp_help = "Get SVI3 VR controller temperature. TYPE: 0=HottestRail, 1=IndividualRail, RAIL_INDEX:\
+        \n (RAIL_INDEX:0->VDDCR_CPU0,1->VDDCR_CPU1,2->VDDCR_SOC,3->VDDIO,4->VDDIO_MEM_S3) must be, specified if TYPE is 1"
+        cpu_enabled_commands_help = "Displays HSMP enabled commands bit masks (Read/Write EnabledCommandsBitMask0-2)"
+        cpu_sdps_limit_help = "Displays CPU SDPS limit for the selected CPU socket in Watts"
 
         # Help text for core options
         core_energy_help = "Displays core energy for the selected core"
         core_boost_limit_help = "Get boost limit for the selected cores"
         core_curr_active_freq_core_limit_help = "Get Current CCLK limit set per Core"
+        core_ccd_power_help = "Displays ccd power consumption for the selected core"
+        core_floor_limit_help = "Displays floor limit frequency for the selected core in MHz"
+        core_eff_floor_limit_help = "Displays effective floor limit frequency for the selected core in MHz"
 
         # Create metric subparser
         metric_parser = subparsers.add_parser('metric', help=metric_help, description=metric_subcommand_help)
@@ -1289,6 +1427,7 @@ class AMDSMIParser(argparse.ArgumentParser):
                                     metavar=("IO_BW", "LINKID_NAME"), help=cpu_io_bandwidth_help)
             cpu_group.add_argument('--cpu-xgmi-bandwidth', action='append', required=False, nargs=2,
                                     metavar=("XGMI_BW", "LINKID_NAME"), help=cpu_xgmi_bandwidth_help)
+            cpu_group.add_argument('--cpu-pwr-eff-mode', action='store_true', required=False, help=cpu_pwr_eff_mode_help)
             cpu_group.add_argument('--cpu-metrics-ver', action='store_true', required=False, help=cpu_metrics_ver_help)
             cpu_group.add_argument('--cpu-metrics-table', action='store_true', required=False, help=cpu_metrics_table_help)
             cpu_group.add_argument('--cpu-socket-energy', action='store_true', required=False, help=cpu_socket_energy_help)
@@ -1300,8 +1439,18 @@ class AMDSMIParser(argparse.ArgumentParser):
                                     nargs=1, metavar=("DIMM_ADDR"), help=cpu_dimm_pow_consumption_help)
             cpu_group.add_argument('--cpu-dimm-thermal-sensor', action='append', required=False, type=lambda x: int(x, 0),
                                     nargs=1, metavar=("DIMM_ADDR"), help=cpu_dimm_thermal_sensor_help)
-            cpu_group.add_argument('--cpu-dfcstate-ctrl', action='store_true', required=False, help=cpu_dfcstate_ctrl_help)
+            cpu_group.add_argument('--cpu-xgmi-pstate-range', action='store_true', required=False, help=cpu_xgmi_pstate_range_help)
             cpu_group.add_argument('--cpu-railisofreq-policy', action='store_true', required=False, help=cpu_railisofreq_policy_help)
+            cpu_group.add_argument('--cpu-dfcstate-ctrl', action='store_true', required=False, help=cpu_dfcstate_ctrl_help)
+            cpu_group.add_argument('--cpu-pc6-enable', action='store_true', required=False, help=cpu_pc6_enable_help)
+            cpu_group.add_argument('--cpu-cc6-enable', action='store_true', required=False, help=cpu_cc6_enable_help)
+            cpu_group.add_argument('--cpu-dimm-sb-reg', action='append', required=False, type=lambda x: int(x, 0),
+                                    nargs=4, metavar=("DIMM_ADDR", "LID", "REG_OFFSET", "REG_SPACE"), help=cpu_dimm_sb_reg_help)
+            cpu_group.add_argument('--cpu-tdelta', action='store_true', required=False, help=cpu_tdelta_help)
+            cpu_group.add_argument('--cpu-svi3-vr-controller-temp', action=self._cpu_svi3_vr_controller_temp_options(), required=False, type=int,
+                                    nargs='+', metavar=("TYPE [RAIL_INDEX]"), help=cpu_svi3_vr_controller_temp_help)
+            cpu_group.add_argument("--cpu-enabled-commands", action="store_true", required=False, help=cpu_enabled_commands_help)
+            cpu_group.add_argument('--cpu-sdps-limit', action='store_true', required=False, help=cpu_sdps_limit_help)
 
             # Optional Args for CPU cores
             core_group = metric_parser.add_argument_group("CPU Core Arguments")
@@ -1309,6 +1458,9 @@ class AMDSMIParser(argparse.ArgumentParser):
             core_group.add_argument('--core-curr-active-freq-core-limit', action='store_true', required=False,
                                     help=core_curr_active_freq_core_limit_help)
             core_group.add_argument('--core-energy', action='store_true', required=False, help=core_energy_help)
+            core_group.add_argument('--core-ccd-power', action='store_true', required=False, help=core_ccd_power_help)
+            core_group.add_argument('--core-floor-limit', action='store_true', required=False, help=core_floor_limit_help)
+            core_group.add_argument('--core-eff-floor-limit', action='store_true', required=False, help=core_eff_floor_limit_help)
 
         # Add Universal Arguments & watch Args
         self._add_watch_arguments(metric_parser)
@@ -1493,21 +1645,32 @@ class AMDSMIParser(argparse.ArgumentParser):
 
         # Help text for CPU set options
         set_cpu_pwr_limit_help = "Set power limit for the given socket. Input parameter is power limit value."
-        set_cpu_xgmi_link_width_help = "Set max and Min linkwidth. Input parameters are min and max link width values"
-        set_cpu_lclk_dpm_level_help = "Sets the max and min dpm level on a given NBIO.\
-        \n Input parameters are die_index, min dpm, max dpm."
-        set_cpu_pwr_eff_mode_help = "Sets the power efficency mode policy. Input parameter is mode."
-        set_cpu_gmi3_link_width_help = "Sets max and min gmi3 link width range"
+        set_cpu_xgmi_link_width_help = "Set min and max linkwidth. Input parameters are min and max link width values (MAX >= MIN)"
+        set_cpu_lclk_dpm_level_help = "Sets the min and max dpm level on a given NBIO.\
+        \n Input parameters are die_index, min dpm, max dpm (MAX >= MIN)."
+        set_cpu_pwr_eff_mode_help = "Sets the power efficiency mode policy. Input parameters,\
+        \n MODE(0=HighPerformance, 1=PowerEfficiency, 2=IOPerformance, 3=BalancedMemory, 4=BalancedCore, 5=BalancedCoreMemory),\n For Family 1Ah Models 50h-57h onwards, UTIL(%%)(0-100) and PPT_limit (in mW) required if MODE= 4 or 5"
+        set_cpu_gmi3_link_width_help = "Sets min and max gmi3 link width range (MAX >= MIN)"
         set_cpu_pcie_link_rate_help = "Sets pcie link rate"
-        set_cpu_df_pstate_range_help = "Sets max and min df-pstates"
+        set_cpu_df_pstate_range_help = "Sets min and max df-pstates (MAX <= MIN)"
         set_cpu_enable_apb_help = "Enables the DF p-state performance boost algorithm"
         set_cpu_disable_apb_help = "Disables the DF p-state performance boost algorithm. Input parameter is DFPstate (0-3)"
         set_soc_boost_limit_help = "Sets the boost limit for the given socket. Input parameter is socket BOOST_LIMIT value"
-        set_cpu_dfcstate_ctrl_help = "Sets the DFCState control. Input parameter is value (0-1)"
+        set_cpu_xgmi_pstate_range_help = "Sets xgmi pstate range. Input parameters are min (0-1) and max (0-1), (MAX <= MIN)"
         set_cpu_railisofreq_policy_help = "Sets the CPU ISO frequency policy. Input parameter is value (0-1)"
+        set_cpu_dfcstate_ctrl_help = "Sets the DFCState control. Input parameter is value (0-1)"
+        set_cpu_pc6_enable_help = "Sets PC6 enable control. Input parameter is value (0-1)"
+        set_cpu_cc6_enable_help = "Sets CC6 enable control. Input parameter is value (0-1)"
+        set_cpu_floor_limit_help = "Sets the floor limit for the given CPU socket. Input parameter is CPU FLOOR_LIMIT value in MHz"
+        cpu_msr_floor_limit_help = "Sets the CPU MSR floor limit frequency for the given socket. Input parameter is MSR_FLOOR_LIMIT value in MHz"
+        cpu_dimm_sb_reg_write_help = "Write data to DIMM sideband register. Requires DIMM_ADDR, LID(0x2->TS0,0x6->TS1,0x9->PMIC0,0xA->SPDHub)\
+        \n REG_OFFSET (hex), REG_SPACE (REGSPACE:0->Volatile,1->NVM), WRITE_DATA (hex)"
+        set_cpu_sdps_limit_help = "Set CPU SDPS limit for the given socket. Input parameter is SDPS limit value in milliwatts (mW)."
 
         # Help text for CPU Core set options
         set_core_boost_limit_help = "Sets the boost limit for the given core. Input parameter is core BOOST_LIMIT value"
+        set_core_floor_limit_help = "Sets the floor limit for the given core. Input parameter is core FLOOR_LIMIT value in MHz"
+        set_core_msr_floor_limit_help = "Sets the MSR floor limit for the given core. Input parameter is core MSR_FLOOR_LIMIT value in MHz"
 
         # Create set_value subparser
         set_value_parser = subparsers.add_parser('set', help=set_value_help, description=set_value_subcommand_help)
@@ -1546,18 +1709,32 @@ class AMDSMIParser(argparse.ArgumentParser):
                 cpu_group.add_argument('--cpu-pwr-limit', action='append', required=False, type=self._positive_int, nargs=1, metavar=("PWR_LIMIT"), help=set_cpu_pwr_limit_help)
                 cpu_group.add_argument('--cpu-xgmi-link-width', action='append', required=False, type=self._not_negative_int, nargs=2, metavar=("MIN_WIDTH", "MAX_WIDTH"), help=set_cpu_xgmi_link_width_help)
                 cpu_group.add_argument('--cpu-lclk-dpm-level', action='append', required=False, type=self._not_negative_int, nargs=3, metavar=("NBIOID", "MIN_DPM", "MAX_DPM"), help=set_cpu_lclk_dpm_level_help)
-                cpu_group.add_argument('--cpu-pwr-eff-mode', action='append', required=False, type=self._not_negative_int, nargs=1, metavar=("MODE"), help=set_cpu_pwr_eff_mode_help)
+                cpu_group.add_argument('--cpu-pwr-eff-mode', action=self._cpu_power_eff_mode_options(), required=False, type=self._not_negative_int, nargs='+', metavar="MODE [UTIL PPT_LIMIT]", help=set_cpu_pwr_eff_mode_help)
                 cpu_group.add_argument('--cpu-gmi3-link-width', action='append', required=False, type=self._not_negative_int, nargs=2, metavar=("MIN_LW", "MAX_LW"), help=set_cpu_gmi3_link_width_help)
                 cpu_group.add_argument('--cpu-pcie-link-rate', action='append', required=False, type=self._not_negative_int, nargs=1, metavar=("LINK_RATE"), help=set_cpu_pcie_link_rate_help)
-                cpu_group.add_argument('--cpu-df-pstate-range', action='append', required=False, type=self._not_negative_int, nargs=2, metavar=("MAX_PSTATE", "MIN_PSTATE"), help=set_cpu_df_pstate_range_help)
+                cpu_group.add_argument('--cpu-df-pstate-range', action='append', required=False, type=self._not_negative_int, nargs=2, metavar=("MIN_PSTATE", "MAX_PSTATE"), help=set_cpu_df_pstate_range_help)
                 cpu_group.add_argument('--cpu-enable-apb', action='store_true', required=False, help=set_cpu_enable_apb_help)
                 cpu_group.add_argument('--cpu-disable-apb', action='append', required=False, type=self._not_negative_int, nargs=1, metavar=("DF_PSTATE"), help=set_cpu_disable_apb_help)
                 cpu_group.add_argument('--soc-boost-limit', action='append', required=False, type=self._positive_int, nargs=1, metavar=("BOOST_LIMIT"), help=set_soc_boost_limit_help)
+                cpu_group.add_argument('--cpu-xgmi-pstate-range', action='append', required=False, type=self._not_negative_int,
+                                       nargs=2, metavar=("MIN_PSTATE", "MAX_PSTATE"), help=set_cpu_xgmi_pstate_range_help)
+                cpu_group.add_argument('--cpu-railisofreq-policy', action='append', required=False, type=self._not_negative_int,
+                                       nargs=1, metavar=("VALUE"), help=set_cpu_railisofreq_policy_help)
                 cpu_group.add_argument('--cpu-dfcstate-ctrl', action='append', required=False, type=self._not_negative_int, nargs=1, metavar=("VALUE"), help=set_cpu_dfcstate_ctrl_help)
-                cpu_group.add_argument('--cpu-railisofreq-policy', action='append', required=False, type=self._not_negative_int, nargs=1, metavar=("VALUE"), help=set_cpu_railisofreq_policy_help)
+                cpu_group.add_argument('--cpu-pc6-enable', action='append', required=False, type=self._not_negative_int, nargs=1, metavar=("VALUE"), help=set_cpu_pc6_enable_help)
+                cpu_group.add_argument('--cpu-cc6-enable', action='append', required=False, type=self._not_negative_int, nargs=1, metavar=("VALUE"), help=set_cpu_cc6_enable_help)
+                cpu_group.add_argument('--cpu-floor-limit', action='append', required=False, type=self._positive_int, nargs=1, metavar=("FLOOR_LIMIT"), help=set_cpu_floor_limit_help)
+                cpu_group.add_argument('--cpu-msr-floor-limit', action='append', required=False, type=self._positive_int, nargs=1, metavar=("MSR_FLOOR_LIMIT"), help=cpu_msr_floor_limit_help)
+                cpu_group.add_argument('--cpu-dimm-sb-reg', action='append', required=False, type=lambda x: int(x, 0),
+                                       nargs=5, metavar=("DIMM_ADDR", "LID", "REG_OFFSET", "REG_SPACE", "WRITE_DATA"), help=cpu_dimm_sb_reg_write_help)
+                cpu_group.add_argument('--cpu-sdps-limit', action='append', required=False, type=self._positive_int,
+                                       nargs=1, metavar=('SDPS_LIMIT'), help=set_cpu_sdps_limit_help)
                 # Optional CPU Core Args
                 core_group = set_value_parser.add_argument_group("CPU Core Arguments")
                 core_group.add_argument('--core-boost-limit', action='append', required=False, type=self._positive_int, nargs=1, metavar=("BOOST_LIMIT"), help=set_core_boost_limit_help)
+                core_group.add_argument('--core-floor-limit', action='append', required=False, type=self._positive_int, nargs=1, metavar=("FLOOR_LIMIT"), help=set_core_floor_limit_help)
+                core_group.add_argument('--core-msr-floor-limit', action='append', required=False, type=self._positive_int,
+                                        nargs=1, metavar=("MSR_FLOOR_LIMIT"), help=set_core_msr_floor_limit_help)
 
         # Set accepts default devices of all
         self._add_device_arguments(set_value_parser, required=False)

--- a/projects/amdsmi/docs/how-to/amdsmi-cli-tool.md
+++ b/projects/amdsmi/docs/how-to/amdsmi-cli-tool.md
@@ -357,6 +357,8 @@ CPU Arguments:
   --cpu-xgmi-bandwidth XGMI_BW LINKID_NAME  Displays current XGMI bandwidth for the selected CPU
                                              input parameters are bandwidth type(1,2,4) and link ID encodings
                                              i.e. P2, P3, G0 - G7
+  --cpu-pwr-eff-mode                        Displays current power efficiency mode.
+                                             For Family 1Ah Models 50h-57h onwards and MODE= 4 or 5, displays utilization percentage and PPT limit in Watts.
   --cpu-metrics-ver                         Displays metrics table version
   --cpu-metrics-table                       Displays metric table
   --cpu-socket-energy                       Displays socket energy for the selected CPU socket
@@ -366,13 +368,27 @@ CPU Arguments:
   --cpu-dimm-temp-range-rate DIMM_ADDR      Displays dimm temperature range and refresh rate
   --cpu-dimm-pow-consumption DIMM_ADDR      Displays dimm power consumption
   --cpu-dimm-thermal-sensor DIMM_ADDR       Displays dimm thermal sensor
+  --cpu-xgmi-pstate-range                   Displays XGMI pstate range (min and max values) for the selected CPU
+  --cpu-railisofreq-policy                  Displays CPU rail isolated frequency policy
   --cpu-dfcstate-ctrl                       Displays DFCState control status
-  --cpu-railisofreq-policy                  Displays CPU ISO frequency policy
+  --cpu-pc6-enable                          Displays PC6 enable control
+  --cpu-cc6-enable                          Displays CC6 enable control
+  --cpu-dimm-sb-reg                         Read DIMM sideband register.Requires DIMM_ADDR, LID(0x2->TS0,0x6->TS1,0x9->PMIC0,0xA->SPDHub),
+                                             REG_OFFSET (hex), REG_SPACE (REGSPACE:0->Volatile,1->NVM)
+  --cpu-tdelta                              Displays CPU thermal delta (TDELTA) value for the selected CPU socket
+  --cpu-svi3-vr-controller-temp TYPE [RAIL_INDEX ...]
+                                            Get SVI3 VR controller temperature. TYPE: 0=HottestRail, 1=IndividualRail.
+                                             If TYPE=1, RAIL_INDEX: (RAIL_INDEX:0->VDDCR_CPU0,1->VDDCR_CPU1,2->VDDCR_SOC,3->VDDIO,4->VDDIO_MEM_S3) must be specified
+  --cpu-enabled-commands                    Displays HSMP enabled commands bit masks (Read/Write EnabledCommandsBitMask0-2)
+  --cpu-sdps-limit                          Displays CPU SDPS limit for the selected CPU socket (in Watts)
 
 CPU Core Arguments:
   --core-boost-limit                        Get boost limit for the selected cores
   --core-curr-active-freq-core-limit        Get Current CCLK limit set per Core
   --core-energy                             Displays core energy for the selected core
+  --core-ccd-power                          Displays CCD (Core Complex Die) power consumption for the selected core
+  --core-floor-limit                        Get floor limit frequency for the selected core (MHz)
+  --core-eff-floor-limit                    Get effective floor limit frequency for the selected core (MHz)
 
 Device Arguments:
   -g, --gpu GPU [GPU ...]      Select a GPU ID, BDF, or UUID from the possible choices:
@@ -556,12 +572,16 @@ usage: amd-smi set [-h] (-g GPU [GPU ...] | -U CPU [CPU ...] | -O CORE [CORE ...
                    [-l LEVEL] [-P SETPROFILE] [-d SCLKMAX] [-C PARTITION] [-M PARTITION]
                    [-o WATTS] [-p POLICY_ID] [-x POLICY_ID] [-R STATUS]
                    [--cpu-pwr-limit PWR_LIMIT] [--cpu-xgmi-link-width MIN_WIDTH MAX_WIDTH]
-                   [--cpu-lclk-dpm-level NBIOID MIN_DPM MAX_DPM] [--cpu-pwr-eff-mode MODE]
+                   [--cpu-lclk-dpm-level NBIOID MIN_DPM MAX_DPM] [--cpu-pwr-eff-mode MODE [UTIL PPT_LIMIT]]
                    [--cpu-gmi3-link-width MIN_LW MAX_LW] [--cpu-pcie-link-rate LINK_RATE]
                    [--cpu-df-pstate-range MAX_PSTATE MIN_PSTATE] [--cpu-enable-apb]
                    [--cpu-disable-apb DF_PSTATE] [--soc-boost-limit BOOST_LIMIT]
                    [--core-boost-limit BOOST_LIMIT] [--json | --csv] [--file FILE]
-                   [--loglevel LEVEL] [--cpu-dfcstate-ctrl VALUE] [--cpu-railisofreq-policy VALUE]
+                   [--loglevel LEVEL] [--cpu-xgmi-pstate-range MIN_PSTATE MAX_PSTATE] [--cpu-railisofreq-policy VALUE]
+                   [--cpu-dfcstate-ctrl VALUE] [--cpu-pc6-enable VALUE] [--cpu-cc6-enable VALUE]
+                   [--cpu-floor-limit FLOOR_LIMIT] [--cpu-msr-floor-limit MSR_FLOOR_LIMIT]
+                   [--core-floor-limit FLOOR_LIMIT] [--core-msr-floor-limit MSR_FLOOR_LIMIT]
+                   [--cpu-dimm-sb-reg DIMM_ADDR LID REG_OFFSET REG_SPACE WRITE_DATA] [--cpu-sdps-limit SDPS_LIMIT]
 
 If no GPU is specified, will select all GPUs on the system.
 A set argument must be provided; Multiple set arguments are accepted.
@@ -599,15 +619,27 @@ CPU Arguments:
   --cpu-xgmi-link-width MIN_WIDTH MAX_WIDTH                      Set max and Min linkwidth. Input parameters are min and max link width values
   --cpu-lclk-dpm-level NBIOID MIN_DPM MAX_DPM                    Sets the max and min dpm level on a given NBIO.
                                                                   Input parameters are die_index, min dpm, max dpm.
-  --cpu-pwr-eff-mode MODE                                        Sets the power efficency mode policy. Input parameter is mode.
+  --cpu-pwr-eff-mode MODE [UTIL PPT_LIMIT] [MODE [UTIL PPT_LIMIT] ...]
+                                                                 Sets the power efficiency mode policy. Input parameters,
+                                                                  MODE(0=HighPerformance, 1=PowerEfficiency, 2=IOPerformance, 3=BalancedMemory, 4=BalancedCore, 5=BalancedCoreMemory),
+                                                                  For Family 1Ah Models 50h-57h onwards, UTIL(%)(0-100) and PPT_limit (in mW) required if MODE= 4 or 5
   --cpu-gmi3-link-width MIN_LW MAX_LW                            Sets max and min gmi3 link width range
   --cpu-pcie-link-rate LINK_RATE                                 Sets pcie link rate
   --cpu-df-pstate-range MAX_PSTATE MIN_PSTATE                    Sets max and min df-pstates
   --cpu-enable-apb                                               Enables the DF p-state performance boost algorithm
   --cpu-disable-apb DF_PSTATE                                    Disables the DF p-state performance boost algorithm. Input parameter is DFPstate (0-3)
   --soc-boost-limit BOOST_LIMIT                                  Sets the boost limit for the given socket. Input parameter is socket BOOST_LIMIT value
+  --cpu-xgmi-pstate-range MIN_PSTATE MAX_PSTATE                  Sets min and max for xgmi pstate range (MAX <= MIN)
+  --cpu-railisofreq-policy VALUE                                 Sets the CPU rail isolated frequency policy. Input parameter is VALUE (0-1)
   --cpu-dfcstate-ctrl VALUE                                      Sets the DFCState control for the given socket. Input parameter is VALUE (0-1)
-  --cpu-railisofreq-policy VALUE                                 Sets the CPU ISO frequency policy. Input parameter is VALUE (0-1)
+  --cpu-pc6-enable VALUE                                         Sets PC6 enable control. Input parameter is value (0-1)
+  --cpu-cc6-enable VALUE                                         Sets CC6 enable control. Input parameter is value (0-1)
+  --cpu-floor-limit FLOOR_LIMIT                                  Sets the floor limit for the given CPU socket. Input parameter is CPU FLOOR_LIMIT value MHz
+  --cpu-msr-floor-limit MSR_FLOOR_LIMIT                          Sets the CPU MSR floor limit frequency for the given socket. Input parameter is MSR_FLOOR_LIMIT value in MHz
+  --cpu-dimm-sb-reg DIMM_ADDR LID REG_OFFSET REG_SPACE WRITE_DATA
+                                                                 Write data to DIMM sideband register. Requires DIMM_ADDR, LID(0x2->TS0,0x6->TS1,0x9->PMIC0,0xA->SPDHub)
+                                                                  REG_OFFSET (hex), REG_SPACE (REGSPACE:0->Volatile,1->NVM), WRITE_DATA (hex)
+  --cpu-sdps-limit SDPS_LIMIT                                    Set CPU SDPS limit for the given socket. Input parameter is SDPS limit value in milliwatts (mW).
 
 CPU Core Arguments:
   --core-boost-limit BOOST_LIMIT                                 Sets the boost limit for the given core. Input parameter is core BOOST_LIMIT value

--- a/projects/amdsmi/docs/reference/amdsmi-py-api.md
+++ b/projects/amdsmi/docs/reference/amdsmi-py-api.md
@@ -5860,7 +5860,17 @@ except AmdSmiException as e:
 
 Description: Set the power efficiency profile policy.
 
-Input: mode(0, 1, or 2)
+Input parameters:
+- `processor_handle` (amdsmi_processor_handle): CPU socket handle to configure
+- `power_efficiency_mode` (int): Power efficiency mode to be set (0-5):
+- `utilization` (int, optional): Utilization for balanced core modes (0-100)(%).
+                          Valid only if mode is 4 or 5 and Family 1Ah Models 50h-57h onwards
+- `ppt_limit` (int, optional): PPT limit in mW. Valid only if mode is 4 or 5 and Family 1Ah Models 50h-57h onwards
+
+Output: Dictionary containing the power efficiency mode information:
+- `power_efficiency_mode` (int): Mode value
+- `utilization` (int): Utilization point for balanced core modes (0-100)(%), if applicable
+- `ppt_limit` (float): PPT Limit value in Watts if applicable
 
 Exceptions that can be thrown by `amdsmi_set_cpu_pwr_efficiency_mode` function:
 
@@ -5868,19 +5878,100 @@ Exceptions that can be thrown by `amdsmi_set_cpu_pwr_efficiency_mode` function:
 
 #### Possible Library Exceptions
 
+- `AMDSMI_STATUS_NOT_SUPPORTED` - Feature not supported
+- `AMDSMI_STATUS_NOT_YET_IMPLEMENTED` - Feature not yet implemented
+- `AMDSMI_STATUS_NO_HSMP_MSG_SUP` - HSMP message/feature not supported
 - `AMDSMI_STATUS_INVAL` - Invalid parameters
 - `AMDSMI_STATUS_TIMEOUT` - Timeout in API call
 
 Example:
 
 ```python
+from amdsmi import *
 try:
+    ret = amdsmi_init(AmdSmiInitFlags.INIT_AMD_CPUS)
     processor_handles = amdsmi_get_cpusocket_handles()
     if len(processor_handles) == 0:
-        print("No CPU sockets on machine")
+        print("No CPUs on machine")
     else:
-        for processor in processor_handles:
-            policy = amdsmi_set_cpu_pwr_efficiency_mode(processor, 0)
+        for i, processor in enumerate(processor_handles):
+            try:
+                # This has been tested on CPU family 0x1A model 0x50, so with power efficiency mode 4 , utilization and ppt limit are valid
+                power_efficiency_mode = 4    # Use mode
+                utilization = 100      # Use Util 100%
+                ppt_limit = 1000  # Use PPT Limit 1000 mW
+                updated_util, updated_ppt_limit = amdsmi_set_cpu_pwr_efficiency_mode(processor, power_efficiency_mode, utilization, ppt_limit)
+                ppt_limit_watts = updated_ppt_limit/1000.0  # Convert milliwatts to watts
+                print(f"CPU: {i}")
+                print(f"    PWR_EFF_MODE:")
+                print(f"    	MODE: {power_efficiency_mode}")
+                # Only show utilization and ppt_limit for modes 4 and 5
+                if power_efficiency_mode in [4, 5]:
+                    print(f"        UTIL: {updated_util}%")
+                    print(f"        PPT_LIMIT: {ppt_limit_watts:.3f} Watts")
+                    print()
+                else:
+                    # For power efficiency mode 0-3, utilization and ppt_limit are not displayed
+                    pass
+                print(f"        RESPONSE: Set power efficiency mode operation successful")
+            except AmdSmiException as e:
+                print(f"Failed to set power efficiency mode for CPU {i}: {e}")
+except AmdSmiException as e:
+    print(e)
+```
+
+### amdsmi_get_cpu_pwr_efficiency_mode
+
+Description: Get the power efficiency profile policy. This function retrieves the CPU Power efficiency mode.
+
+Input parameters:
+- `processor_handle` (amdsmi_processor_handle): CPU socket handle to configure
+
+Output: Dictionary containing the power efficiency mode information:
+- `power_efficiency_mode` (int): Power efficiency mode (0-5):
+- `utilization` (int, optional): Utilization point for balanced core modes (0-100)(%).
+                          Valid only if mode is set as 4 or 5 and Family 1Ah Models 50h-57h onwards
+- `ppt_limit` (int, optional): PPT limit in Watts. Valid only if mode is set as 4 or 5 and Family 1Ah Models 50h-57h onwards
+
+Exceptions that can be thrown by `amdsmi_get_cpu_pwr_efficiency_mode` function:
+
+* `AmdSmiLibraryException`
+
+#### Possible Library Exceptions
+
+- `AMDSMI_STATUS_NOT_SUPPORTED` - Feature not supported
+- `AMDSMI_STATUS_NOT_YET_IMPLEMENTED` - Feature not yet implemented
+- `AMDSMI_STATUS_NO_HSMP_MSG_SUP` - HSMP message/feature not supported
+- `AMDSMI_STATUS_INVAL` - Invalid parameters
+- `AMDSMI_STATUS_TIMEOUT` - Timeout in API call
+
+Example:
+
+```python
+from amdsmi import *
+try:
+    ret = amdsmi_init(AmdSmiInitFlags.INIT_AMD_CPUS)
+    processor_handles = amdsmi_get_cpusocket_handles()
+    if len(processor_handles) == 0:
+        print("No CPUs on machine")
+    else:
+        for i, processor in enumerate(processor_handles):
+            try:
+                # This has been tested on CPU family 0x1A model 0x50, so with mode 4 , utilization and ppt limit are valid
+                power_efficiency_mode, utilization, ppt_limit = amdsmi_get_cpu_pwr_efficiency_mode(processor)
+                print(f"CPU: {i}")
+                print(f"    PWR_EFF_MODE:")
+                print(f"    	MODE: {power_efficiency_mode}")
+                # Only show utilization and ppt_limit for modes 4 and 5
+                if power_efficiency_mode in [4, 5]:
+                    print(f"    	UTIL: {utilization}%")
+                    print(f"    	PPT_LIMIT: {ppt_limit:.3f} Watts")
+                    print()
+                else:
+                    # For modes 0-3, utilization and ppt_limit are not displayed
+                    pass
+            except AmdSmiException as e:
+                print(f"Failed to get power efficiency mode for CPU {i}: {e}")
 except AmdSmiException as e:
     print(e)
 ```
@@ -6758,6 +6849,103 @@ except AmdSmiException as e:
     print(e)
 ```
 
+### amdsmi_set_cpu_xgmi_pstate_range
+
+Description: Set the Min and Max XGMI PState Range. This API configures the XGMI P-State frequency range for the specified processor socket.
+
+Input parameters:
+- `processor_handle` (amdsmi_processor_handle): CPU socket handle to configure
+- `min_pstate` (int): Minimum XGMI P-State value
+- `max_pstate` (int): Maximum XGMI P-State value
+
+Output: `None`
+
+Exceptions that can be thrown by `amdsmi_set_cpu_xgmi_pstate_range` function:
+
+* `AmdSmiLibraryException`
+
+#### Possible Library Exceptions
+
+- `AMDSMI_STATUS_NOT_SUPPORTED` - Feature not supported
+- `AMDSMI_STATUS_NOT_YET_IMPLEMENTED` - Feature not yet implemented
+- `AMDSMI_STATUS_NO_HSMP_MSG_SUP` - HSMP message/feature not supported
+- `AMDSMI_STATUS_INVAL` - Invalid parameters
+- `AMDSMI_STATUS_TIMEOUT` - Timeout in API call
+- 'AMDSMI_STATUS_NO_PERM' - Permission Denied
+
+Example:
+
+```python
+from amdsmi import *
+try:
+    ret = amdsmi_init(AmdSmiInitFlags.INIT_AMD_CPUS)
+    processor_handles = amdsmi_get_cpusocket_handles()
+    if len(processor_handles) == 0:
+        print("No CPUs on machine")
+    else:
+        for i, processor in enumerate(processor_handles):
+            try:
+                min_pstate = 1
+                max_pstate = 1
+                amdsmi_set_cpu_xgmi_pstate_range(processor, min_pstate, max_pstate)
+                print(f"CPU: {i}")
+                print(f"    XGMI_PSTATE_RANGE:")
+                print(f"        RESPONSE: Set, MIN_PSTATE: {min_pstate}, MAX_PSTATE: {max_pstate}, successful")
+                print()
+            except AmdSmiException as e:
+                print(f"Failed to set xgmi pstate range for cpu {i}: {e}")
+except AmdSmiException as e:
+    print(e)
+```
+
+### amdsmi_get_cpu_xgmi_pstate_range
+
+Description: Get the Min and Max XGMI PState Range. This API retrieves the current XGMI P-State range configuration for the specified processor socket.
+
+Input parameters:
+- `processor_handle` (amdsmi_processor_handle): CPU socket handle to query
+
+Output: Dictionary containing XGMI PState range values:
+    - `min_pstate`: Current minimum XGMI P-State setting
+    - `max_pstate`: Current maximum XGMI P-State setting
+
+Exceptions that can be thrown by `amdsmi_get_cpu_xgmi_pstate_range` function:
+
+* `AmdSmiLibraryException`
+
+#### Possible Library Exceptions
+
+- `AMDSMI_STATUS_NOT_SUPPORTED` - Feature not supported
+- `AMDSMI_STATUS_NOT_YET_IMPLEMENTED` - Feature not yet implemented
+- `AMDSMI_STATUS_NO_HSMP_MSG_SUP` - HSMP message/feature not supported
+- `AMDSMI_STATUS_INVAL` - Invalid parameters
+- `AMDSMI_STATUS_TIMEOUT` - Timeout in API call
+
+Example:
+
+```python
+from amdsmi import *
+try:
+    ret = amdsmi_init(AmdSmiInitFlags.INIT_AMD_CPUS)
+    processor_handles = amdsmi_get_cpusocket_handles()
+    if len(processor_handles) == 0:
+        print("No CPUs on machine")
+    else:
+        for i, processor in enumerate(processor_handles):
+            try:
+                pstate_range = amdsmi_get_cpu_xgmi_pstate_range(processor)
+
+                print(f"CPU: {i}")
+                print(f"    XGMI_PSTATE_RANGE:")
+                print(f"        MIN_PSTATE: {pstate_range['min_pstate']}")
+                print(f"        MAX_PSTATE: {pstate_range['max_pstate']}")
+                print()
+            except AmdSmiException as e:
+                print(f"Failed to get XGMI PState range for CPU {i}: {e}")
+except AmdSmiException as e:
+    print(e)
+```
+
 ### amdsmi_set_cpu_rail_isofreq_policy
 
 Description: Set the CPU Rail Isofrequency Policy. This function configures the frequency policy for CPU power rails.
@@ -6781,6 +6969,7 @@ Exceptions that can be thrown by `amdsmi_set_cpu_rail_isofreq_policy` function:
 - `AMDSMI_STATUS_NO_HSMP_MSG_SUP` - HSMP message/feature not supported
 - `AMDSMI_STATUS_INVAL` - Invalid parameters
 - `AMDSMI_STATUS_TIMEOUT` - Timeout in API call
+- 'AMDSMI_STATUS_NO_PERM' - Permission Denied
 
 Example:
 
@@ -6792,10 +6981,16 @@ try:
     if len(processor_handles) == 0:
         print("No CPUs on machine")
     else:
-        for processor in processor_handles:
-            # Set independent control mode (0)
-            amdsmi_set_cpu_rail_isofreq_policy(processor, 0)
-            print("CPU rail isofrequency policy: set to each rail has independent frequency limit")
+        for i, processor in enumerate(processor_handles):
+            try:
+                value = 1
+                amdsmi_set_cpu_rail_isofreq_policy(processor, value)
+                print(f"CPU: {i}")
+                print(f"    RAILISOFREQ_POLICY:")
+                print(f"        RESPONSE: Set, VALUE: {value}, successful")
+                print()
+            except AmdSmiException as e:
+                print(f"Failed to set cpurailiso frequency policy for cpu {i}: {e}")
 except AmdSmiException as e:
     print(e)
 ```
@@ -6833,19 +7028,20 @@ try:
     if len(processor_handles) == 0:
         print("No CPUs on machine")
     else:
-        for processor in processor_handles:
-            policy = amdsmi_get_cpu_rail_isofreq_policy(processor)
-            if policy == 0:
-                print("CPU rail isofrequency policy: Each rail has independent frequency limit")
-            elif policy == 1:
-                print("CPU rail isofrequency policy: Both rail have same frequency limit")
-            else:
-                print("CPU rail isofrequency policy: Unknown value {policy}")
+        for i, processor in enumerate(processor_handles):
+            try:
+                cpurailisofreq_policy = amdsmi_get_cpu_rail_isofreq_policy(processor)
+                print(f"CPU: {i}")
+                print(f"    RAILISOFREQ_POLICY:")
+                print(f"        VALUE: {cpurailisofreq_policy}")
+                print()
+            except AmdSmiException as e:
+                print(f"Failed to get cpurailiso frequency policy for cpu {i}: {e}")
 except AmdSmiException as e:
     print(e)
 ```
 
-### amdsmi_set_dfc_ctrl
+### amdsmi_set_cpu_dfc_ctrl
 
 Description: Set the DFCState enabling control. DFCState is a low power state used for I/O Die (IOD).
 
@@ -6857,7 +7053,7 @@ Input parameters:
 
 Output: `None`
 
-Exceptions that can be thrown by `amdsmi_set_dfc_ctrl` function:
+Exceptions that can be thrown by `amdsmi_set_cpu_dfc_ctrl` function:
 
 * `AmdSmiLibraryException`
 
@@ -6868,6 +7064,7 @@ Exceptions that can be thrown by `amdsmi_set_dfc_ctrl` function:
 - `AMDSMI_STATUS_NO_HSMP_MSG_SUP` - HSMP message/feature not supported
 - `AMDSMI_STATUS_INVAL` - Invalid parameters
 - `AMDSMI_STATUS_TIMEOUT` - Timeout in API call
+- 'AMDSMI_STATUS_NO_PERM' - Permission Denied
 
 Example:
 
@@ -6879,15 +7076,21 @@ try:
     if len(processor_handles) == 0:
         print("No CPUs on machine")
     else:
-        for processor in processor_handles:
-            # Enable DFCState control
-            amdsmi_set_dfc_ctrl(processor, 1)
-            print("DFCState control enabled")
+        for i, processor in enumerate(processor_handles):
+            try:
+                value = 1
+                amdsmi_set_cpu_dfc_ctrl(processor, value)
+                print(f"CPU: {i}")
+                print(f"    DFCSTATE_CTRL:")
+                print(f"        RESPONSE: Set, VALUE: {value}, successful")
+                print()
+            except AmdSmiException as e:
+                print(f"Failed to set dfcstate control status for cpu {i}: {e}")
 except AmdSmiException as e:
     print(e)
 ```
 
-### amdsmi_get_dfc_ctrl
+### amdsmi_get_cpu_dfc_ctrl
 
 Description: Get the current DFCState enabling control status. DFCState is a low power state used for I/O Die (IOD).
 
@@ -6898,7 +7101,7 @@ Output: Integer representing the DFCState control status:
     - 0: DFCState control is disabled
     - 1: DFCState control is enabled
 
-Exceptions that can be thrown by `amdsmi_get_dfc_ctrl` function:
+Exceptions that can be thrown by `amdsmi_get_cpu_dfc_ctrl` function:
 
 * `AmdSmiLibraryException`
 
@@ -6920,14 +7123,1006 @@ try:
     if len(processor_handles) == 0:
         print("No CPUs on machine")
     else:
-        for processor in processor_handles:
-            dfc_status = amdsmi_get_dfc_ctrl(processor)
-            if dfc_status == 0:
-                print("DFCState control is disabled")
-            elif dfc_status == 1:
-                print("DFCState control is enabled")
-            else:
-                print(f"DFCState control: Unknown status {dfc_status}")
+        for i, processor in enumerate(processor_handles):
+            try:
+                dfcstatectrl_status = amdsmi_get_cpu_dfc_ctrl(processor)
+
+                print(f"CPU: {i}")
+                print(f"    DFCSTATE_CTRL:")
+                print(f"        VALUE: {dfcstatectrl_status}")
+                print()
+            except AmdSmiException as e:
+                print(f"Failed to get dfcstate control status for cpu {i}: {e}")
+except AmdSmiException as e:
+    print(e)
+```
+
+### amdsmi_set_cpu_pc6_enable
+
+Description: Set the PC6 (Package C6) enable state. PC6 is a low power state used for package-level power management.
+
+Input parameters:
+- `processor_handle` (amdsmi_processor_handle): CPU socket handle to query
+- `value` (int): PC6 enable state value:
+  - 0: Disable PC6 state
+  - 1: Enable PC6 state
+
+Output: `None`
+
+Exceptions that can be thrown by `amdsmi_set_cpu_pc6_enable` function:
+
+* `AmdSmiLibraryException`
+
+#### Possible Library Exceptions
+
+- `AMDSMI_STATUS_NOT_SUPPORTED` - Feature not supported
+- `AMDSMI_STATUS_NOT_YET_IMPLEMENTED` - Feature not yet implemented
+- `AMDSMI_STATUS_NO_HSMP_MSG_SUP` - HSMP message/feature not supported
+- `AMDSMI_STATUS_INVAL` - Invalid parameters
+- `AMDSMI_STATUS_TIMEOUT` - Timeout in API call
+- 'AMDSMI_STATUS_NO_PERM' - Permission Denied
+
+Example:
+
+```python
+from amdsmi import *
+try:
+    ret = amdsmi_init(AmdSmiInitFlags.INIT_AMD_CPUS)
+    processor_handles = amdsmi_get_cpusocket_handles()
+    if len(processor_handles) == 0:
+        print("No CPUs on machine")
+    else:
+        for i, processor in enumerate(processor_handles):
+            try:
+                value = 1
+                amdsmi_set_cpu_pc6_enable(processor, value)
+                print(f"CPU: {i}")
+                print(f"    PC6_ENABLE:")
+                print(f"        RESPONSE: Set, VALUE: {value}, successful")
+                print()
+            except AmdSmiException as e:
+                print(f"Failed to set PC6 enable status for cpu {i}: {e}")
+except AmdSmiException as e:
+    print(e)
+```
+
+### amdsmi_get_cpu_pc6_enable
+
+Description: Get the current PC6 (Package C6) enable state. PC6 is a low power state used for package-level power management.
+
+Input parameters:
+- `processor_handle` (amdsmi_processor_handle): CPU socket handle to query
+
+Output: Integer representing the PC6 enable state:
+    - 0: PC6 state is disabled
+    - 1: PC6 state is enabled
+
+Exceptions that can be thrown by `amdsmi_get_cpu_pc6_enable` function:
+
+* `AmdSmiLibraryException`
+
+#### Possible Library Exceptions
+
+- `AMDSMI_STATUS_NOT_SUPPORTED` - Feature not supported
+- `AMDSMI_STATUS_NOT_YET_IMPLEMENTED` - Feature not yet implemented
+- `AMDSMI_STATUS_NO_HSMP_MSG_SUP` - HSMP message/feature not supported
+- `AMDSMI_STATUS_INVAL` - Invalid parameters
+- `AMDSMI_STATUS_TIMEOUT` - Timeout in API call
+
+Example:
+
+```python
+from amdsmi import *
+try:
+    ret = amdsmi_init(AmdSmiInitFlags.INIT_AMD_CPUS)
+    processor_handles = amdsmi_get_cpusocket_handles()
+    if len(processor_handles) == 0:
+        print("No CPUs on machine")
+    else:
+        for i, processor in enumerate(processor_handles):
+            try:
+                pc6_enable_status = amdsmi_get_cpu_pc6_enable(processor)
+
+                print(f"CPU: {i}")
+                print(f"    PC6_ENABLE:")
+                print(f"        VALUE: {pc6_enable_status}")
+                print()
+            except AmdSmiException as e:
+                print(f"Failed to get PC6 enable status for cpu {i}: {e}")
+except AmdSmiException as e:
+    print(e)
+```
+
+### amdsmi_set_cpu_cc6_enable
+
+Description: Set the CC6 (Core C6) enable state. CC6 is a low power state used for CPU core-level power management.
+
+Input parameters:
+- `processor_handle` (amdsmi_processor_handle): CPU socket handle to query
+- `value` (int): CC6 enable state value:
+  - 0: Disable CC6 state
+  - 1: Enable CC6 state
+
+Output: `None`
+
+Exceptions that can be thrown by `amdsmi_set_cpu_cc6_enable` function:
+
+* `AmdSmiLibraryException`
+
+#### Possible Library Exceptions
+
+- `AMDSMI_STATUS_NOT_SUPPORTED` - Feature not supported
+- `AMDSMI_STATUS_NOT_YET_IMPLEMENTED` - Feature not yet implemented
+- `AMDSMI_STATUS_NO_HSMP_MSG_SUP` - HSMP message/feature not supported
+- `AMDSMI_STATUS_INVAL` - Invalid parameters
+- `AMDSMI_STATUS_TIMEOUT` - Timeout in API call
+- 'AMDSMI_STATUS_NO_PERM' - Permission Denied
+
+Example:
+
+```python
+from amdsmi import *
+try:
+    ret = amdsmi_init(AmdSmiInitFlags.INIT_AMD_CPUS)
+    processor_handles = amdsmi_get_cpusocket_handles()
+    if len(processor_handles) == 0:
+        print("No CPUs on machine")
+    else:
+        for i, processor in enumerate(processor_handles):
+            try:
+                value = 1
+                amdsmi_set_cpu_cc6_enable(processor, value)
+                print(f"CPU: {i}")
+                print(f"    CC6_ENABLE:")
+                print(f"        RESPONSE: Set, VALUE: {value}, successful")
+                print()
+            except AmdSmiException as e:
+                print(f"Failed to set CC6 enable status for cpu {i}: {e}")
+except AmdSmiException as e:
+    print(e)
+```
+
+### amdsmi_get_cpu_cc6_enable
+
+Description: Get the current CC6 (Core C6) enable state. CC6 is a low power state used for CPU core-level power management.
+
+Input parameters:
+- `processor_handle` (amdsmi_processor_handle): CPU socket handle to query
+
+Output: Integer representing the CC6 enable state:
+    - 0: CC6 state is disabled
+    - 1: CC6 state is enabled
+
+Exceptions that can be thrown by `amdsmi_get_cpu_cc6_enable` function:
+
+* `AmdSmiLibraryException`
+
+#### Possible Library Exceptions
+
+- `AMDSMI_STATUS_NOT_SUPPORTED` - Feature not supported
+- `AMDSMI_STATUS_NOT_YET_IMPLEMENTED` - Feature not yet implemented
+- `AMDSMI_STATUS_NO_HSMP_MSG_SUP` - HSMP message/feature not supported
+- `AMDSMI_STATUS_INVAL` - Invalid parameters
+- `AMDSMI_STATUS_TIMEOUT` - Timeout in API call
+
+Example:
+
+```python
+from amdsmi import *
+try:
+    ret = amdsmi_init(AmdSmiInitFlags.INIT_AMD_CPUS)
+    processor_handles = amdsmi_get_cpusocket_handles()
+    if len(processor_handles) == 0:
+        print("No CPUs on machine")
+    else:
+        for i, processor in enumerate(processor_handles):
+            try:
+                cc6_enable_status = amdsmi_get_cpu_cc6_enable(processor)
+                print(f"CPU: {i}")
+                print(f"    CC6_ENABLE:")
+                print(f"        VALUE: {cc6_enable_status}")
+                print()
+            except AmdSmiException as e:
+                print(f"Failed to get CC6 enable status for cpu {i}: {e}")
+except AmdSmiException as e:
+    print(e)
+```
+
+### amdsmi_get_cpu_dimm_sb_reg
+
+Description: Read data from DIMM sideband register using JEDEC Sideband Bus protocol. This API executes a four-byte read transaction at a specified register offset in a designated device on the target DIMM.
+
+Input parameters:
+- `processor_handle` (amdsmi_processor_handle): CPU socket handle to query
+- `dimm_addr` (int): DIMM address identifier
+- `lid` (int): Local Identifier (LID) for the device on DIMM:
+  - 0x2: TS0 (Thermal Sensor 0)
+  - 0x6: TS1 (Thermal Sensor 1)
+  - 0xA: SPD Hub
+- `reg_offset` (int): Register offset within the specified register space (hexadecimal)
+- `reg_space` (int): Register space selector:
+  - 0: Volatile register space
+  - 1: Non-volatile memory (NVM) register space
+
+Output: Integer representing the 4-byte data read from the register
+
+Exceptions that can be thrown by `amdsmi_get_cpu_dimm_sb_reg` function:
+
+* `AmdSmiLibraryException`
+
+#### Possible Library Exceptions
+
+- `AMDSMI_STATUS_NOT_SUPPORTED` - Feature not supported
+- `AMDSMI_STATUS_NOT_YET_IMPLEMENTED` - Feature not yet implemented
+- `AMDSMI_STATUS_NO_HSMP_MSG_SUP` - HSMP message/feature not supported
+- `AMDSMI_STATUS_INVAL` - Invalid parameters
+- `AMDSMI_STATUS_TIMEOUT` - Timeout in API call
+
+Example:
+
+```python
+from amdsmi import *
+try:
+    ret = amdsmi_init(AmdSmiInitFlags.INIT_AMD_CPUS)
+    processor_handles = amdsmi_get_cpusocket_handles()
+    if len(processor_handles) == 0:
+        print("No CPUs on machine")
+    else:
+        for i, processor in enumerate(processor_handles):
+            try:
+                # Read from DIMM sideband register (SPD Hub, volatile space)
+                dimm_addr = 0x87  # Example DIMM address
+                lid = 0xA         # SPD Hub
+                reg_offset = 0x00 # Register offset
+                reg_space = 1     # Volatile register space
+                data = amdsmi_get_cpu_dimm_sb_reg(processor, dimm_addr, lid, reg_offset, reg_space)
+                print(f"CPU: {i}")
+                print(f"    DIMM_SB_REG:")
+                print(f"        DIMMADDRESS: 0x{dimm_addr:X}")
+                print(f"        LID: 0x{lid:X}")
+                print(f"        OFFSET: 0x{reg_offset:X}")
+                print(f"        REGSPACE: 0x{reg_space:X}")
+                print(f"        DATA: 0x{data:X}")
+                print()
+            except AmdSmiException as e:
+                print(f"Failed to read DIMM sideband register for cpu {i}: {e}")
+except AmdSmiException as e:
+    print(e)
+```
+
+### amdsmi_set_cpu_dimm_sb_reg
+
+Description: Write data to DIMM sideband register using JEDEC Sideband Bus protocol. This API executes a four-byte write transaction at a specified register offset in a designated device on the target DIMM.
+
+Input parameters:
+- `processor_handle` (amdsmi_processor_handle): CPU socket handle to query
+- `dimm_addr` (int): DIMM address identifier
+- `lid` (int): Local Identifier (LID) for the device on DIMM:
+  - 0x2: TS0 (Thermal Sensor 0)
+  - 0x6: TS1 (Thermal Sensor 1)
+  - 0xA: SPD Hub
+- `reg_offset` (int): Register offset within the specified register space (hexadecimal)
+- `reg_space` (int): Register space selector:
+  - 0: Volatile register space
+  - 1: Non-volatile memory (NVM) register space
+- `write_data` (int): 4-byte data value to write to the target register (hexadecimal)
+
+Output: `True` on successful write operation
+
+Exceptions that can be thrown by `amdsmi_set_cpu_dimm_sb_reg` function:
+
+* `AmdSmiLibraryException`
+
+#### Possible Library Exceptions
+
+- `AMDSMI_STATUS_NOT_SUPPORTED` - Feature not supported
+- `AMDSMI_STATUS_NOT_YET_IMPLEMENTED` - Feature not yet implemented
+- `AMDSMI_STATUS_NO_HSMP_MSG_SUP` - HSMP message/feature not supported
+- `AMDSMI_STATUS_INVAL` - Invalid parameters
+- `AMDSMI_STATUS_TIMEOUT` - Timeout in API call
+- 'AMDSMI_STATUS_NO_PERM' - Permission Denied
+
+Example:
+
+```python
+from amdsmi import *
+try:
+    ret = amdsmi_init(AmdSmiInitFlags.INIT_AMD_CPUS)
+    processor_handles = amdsmi_get_cpusocket_handles()
+    if len(processor_handles) == 0:
+        print("No CPUs on machine")
+    else:
+        for i, processor in enumerate(processor_handles):
+            try:
+                # Write to DIMM sideband register (SPD Hub, volatile space)
+                dimm_addr = 0x87  # Example DIMM address
+                lid = 0xA         # SPD Hub
+                reg_offset = 0x00 # Register offset
+                reg_space = 1     # Volatile register space
+                date = 0x12345678
+                amdsmi_set_cpu_dimm_sb_reg(processor, dimm_addr, lid, reg_offset, reg_space, data)
+                print(f"CPU: {i}")
+                print(f"    DIMM_SB_REG:")
+                print(f"        RESPONSE: Set, VALUE: 0x{data:X}, successful")
+                print()
+            except AmdSmiException as e:
+                print(f"Failed to write DIMM sideband register for cpu {i}: {e}")
+except AmdSmiException as e:
+    print(e)
+```
+
+### amdsmi_get_cpu_core_ccd_power
+
+Description: Get the power consumption of a specific CCD (Core Complex Die) within a CPU socket. This function reads the average power consumed by the specified CCD.
+
+Input parameters:
+- `processor_handle` (amdsmi_processor_handle): CPU socket handle to query
+- `core0` (int): Core 0 CCD power to query
+
+Output: Integer representing the CCD power consumption in watts (W)
+
+Exceptions that can be thrown by `amdsmi_get_cpu_core_ccd_power` function:
+
+* `AmdSmiLibraryException`
+
+#### Possible Library Exceptions
+
+- `AMDSMI_STATUS_NOT_SUPPORTED` - Feature not supported
+- `AMDSMI_STATUS_NOT_YET_IMPLEMENTED` - Feature not yet implemented
+- `AMDSMI_STATUS_NO_HSMP_MSG_SUP` - HSMP message/feature not supported
+- `AMDSMI_STATUS_INVAL` - Invalid parameters
+- `AMDSMI_STATUS_TIMEOUT` - Timeout in API call
+
+Example:
+
+```python
+from amdsmi import *
+try:
+    amdsmi_init(AmdSmiInitFlags.INIT_AMD_CPUS)
+    core_handles = amdsmi_get_cpucore_handles()
+    if len(core_handles) == 0:
+        print("No CPU cores on machine")
+    else:
+        core0 = core_handles[0]   # <-- pick core 0 explicitly
+        power = amdsmi_get_cpu_core_ccd_power(core0)
+        print("CPU: 0")
+        print("    CCD_POWER:")
+        print(f"        VALUE: {power:.3f} Watts")
+except AmdSmiException as e:
+    print(e)
+```
+
+### amdsmi_get_cpu_tdelta
+
+Description: Read the TDELTA value for a CPU socket.
+
+Input parameters:
+- `processor_handle` (amdsmi_processor_handle): CPU socket handle to query
+
+Output: Integer representing the TDELTA value
+
+Exceptions that can be thrown by `amdsmi_get_cpu_tdelta` function:
+
+* `AmdSmiLibraryException`
+
+#### Possible Library Exceptions
+
+- `AMDSMI_STATUS_NOT_SUPPORTED` - Feature not supported
+- `AMDSMI_STATUS_NOT_YET_IMPLEMENTED` - Feature not yet implemented
+- `AMDSMI_STATUS_NO_HSMP_MSG_SUP` - HSMP message/feature not supported
+- `AMDSMI_STATUS_INVAL` - Invalid parameters
+- `AMDSMI_STATUS_TIMEOUT` - Timeout in API call
+
+Example:
+
+```python
+from amdsmi import *
+try:
+    ret = amdsmi_init(AmdSmiInitFlags.INIT_AMD_CPUS)
+    processor_handles = amdsmi_get_cpusocket_handles()
+    if len(processor_handles) == 0:
+        print("No CPUs on machine")
+    else:
+        for i, processor in enumerate(processor_handles):
+            try:
+                # Read TDELTA value
+                tdelta_value = amdsmi_get_cpu_tdelta(processor)
+                print(f"CPU: {i}")
+                print(f"    TDELTA:")
+                print(f"        VALUE: {tdelta_value}")
+                print()
+            except AmdSmiException as e:
+                print(f"Failed to read TDELTA for CPU {i}: {e}")
+except AmdSmiException as e:
+    print(e)
+```
+
+### amdsmi_get_cpu_svi3_vr_controller_temp
+
+Description: Get the SVI3 VR temperature for a specific rail and index within a CPU socket. This function retrieves the SVI3 VR temperature for the CPU.
+
+Input parameters:
+- `processor_handle` (amdsmi_processor_handle): CPU socket handle to query
+- `rail_selection` (int): SVI3 Rail selection type:
+  - 0: HottestRail - Get temperature from the hottest rail
+  - 1: IndividualRail - Get temperature from a specific rail (requires rail_index)
+- `rail_index` (int, optional): Rail index (0-7) - Required only when rail_selection=1. Defaults to 0.
+
+Output: Dictionary containing the SVI3 VR controller temperature information:
+- `rail_selection` (int): SVI3 rail selection used
+- `rail_index` (int): SVI3 rail index used
+- `temperature` (float): Temperature value in degrees Celsius
+
+Exceptions that can be thrown by `amdsmi_get_cpu_svi3_vr_controller_temp` function:
+
+* `AmdSmiLibraryException`
+
+#### Possible Library Exceptions
+
+- `AMDSMI_STATUS_NOT_SUPPORTED` - Feature not supported
+- `AMDSMI_STATUS_NOT_YET_IMPLEMENTED` - Feature not yet implemented
+- `AMDSMI_STATUS_NO_HSMP_MSG_SUP` - HSMP message/feature not supported
+- `AMDSMI_STATUS_INVAL` - Invalid parameters
+- `AMDSMI_STATUS_TIMEOUT` - Timeout in API call
+
+Example:
+
+```python
+from amdsmi import *
+try:
+    ret = amdsmi_init(AmdSmiInitFlags.INIT_AMD_CPUS)
+    processor_handles = amdsmi_get_cpusocket_handles()
+    if len(processor_handles) == 0:
+        print("No CPUs on machine")
+    else:
+        for i, processor in enumerate(processor_handles):
+            try:
+                # Get SVI3 VR controller temperature with hardcoded values
+                rail_selection = 1  # Use rail selection 1
+                rail_index = 1      # Use rail index 1
+                vr_temp_info = amdsmi_get_cpu_svi3_vr_controller_temp(processor, rail_selection, rail_index)
+                print(f"CPU: {i}")
+                print(f"    SVI3_VR_CONTROLLER_TEMP:")
+                print(f"        RAIL_SELECTION: {vr_temp_info['rail_selection']}")
+                print(f"        RAIL_INDEX: {vr_temp_info['rail_index']}")
+                print(f"        TEMPERATURE: {vr_temp_info['temperature']:.1f} 'C")
+                print()
+            except AmdSmiException as e:
+                print(f"Failed to get SVI3 VR controller temperature for CPU {i}: {e}")
+except AmdSmiException as e:
+    print(e)
+```
+
+### amdsmi_get_cpu_enabled_commands
+
+Description: Get the enabled HSMP commands bitmasks for a specific CPU socket. This function retrieves both read and write HSMP enabled commands.
+
+Input parameters:
+- `processor_handle` (amdsmi_processor_handle): CPU socket handle to query
+
+Output: Dictionary containing the following keys:
+- `ReadEnabledCommandsBitMask0` (int): Bitmask of enabled read commands (bits 0-31)
+- `ReadEnabledCommandsBitMask1` (int): Bitmask of enabled read commands (bits 32-63)
+- `ReadEnabledCommandsBitMask2` (int): Bitmask of enabled read commands (bits 64-95)
+- `WriteEnabledCommandsBitMask0` (int): Bitmask of enabled write commands (bits 0-31)
+- `WriteEnabledCommandsBitMask1` (int): Bitmask of enabled write commands (bits 32-63)
+- `WriteEnabledCommandsBitMask2` (int): Bitmask of enabled write commands (bits 64-95)
+
+Exceptions that can be thrown by `amdsmi_get_cpu_enabled_commands` function:
+
+* `AmdSmiLibraryException`
+
+#### Possible Library Exceptions
+
+- `AMDSMI_STATUS_NOT_SUPPORTED` - Feature not supported
+- `AMDSMI_STATUS_NOT_YET_IMPLEMENTED` - Feature not yet implemented
+- `AMDSMI_STATUS_NO_HSMP_MSG_SUP` - HSMP message/feature not supported
+- `AMDSMI_STATUS_INVAL` - Invalid parameters
+- `AMDSMI_STATUS_TIMEOUT` - Timeout in API call
+
+Example:
+
+```python
+from amdsmi import *
+try:
+    ret = amdsmi_init(AmdSmiInitFlags.INIT_AMD_CPUS)
+    processor_handles = amdsmi_get_cpusocket_handles()
+    if len(processor_handles) == 0:
+        print("No CPUs on machine")
+    else:
+        for i, processor in enumerate(processor_handles):
+            try:
+                # Get enabled commands bitmasks
+                enabled_cmds = amdsmi_get_cpu_enabled_commands(processor)
+                print(f"CPU: {i}")
+                print(f"    ENABLED_COMMANDS:")
+                print(f"        READ_ENABLED_COMMANDS_BITMASK0: 0x{enabled_cmds['ReadEnabledCommandsBitMask0']:08X}")
+                print(f"        READ_ENABLED_COMMANDS_BITMASK1: 0x{enabled_cmds['ReadEnabledCommandsBitMask1']:08X}")
+                print(f"        READ_ENABLED_COMMANDS_BITMASK2: 0x{enabled_cmds['ReadEnabledCommandsBitMask2']:08X}")
+                print(f"        WRITE_ENABLED_COMMANDS_BITMASK0: 0x{enabled_cmds['WriteEnabledCommandsBitMask0']:08X}")
+                print(f"        WRITE_ENABLED_COMMANDS_BITMASK1: 0x{enabled_cmds['WriteEnabledCommandsBitMask1']:08X}")
+                print(f"        WRITE_ENABLED_COMMANDS_BITMASK2: 0x{enabled_cmds['WriteEnabledCommandsBitMask2']:08X}")
+                print()
+            except AmdSmiException as e:
+                print(f"Failed to get enabled commands for CPU {i}: {e}")
+except AmdSmiException as e:
+    print(e)
+```
+
+### amdsmi_get_cpu_core_floor_freq_limit
+
+Description: Get the floor limit frequency for CPU cores.
+
+Input parameters:
+- `core0` (int): Core 0 index to query
+
+Output: Integer representing the core floor limit frequency in MHz for core 0
+
+Exceptions that can be thrown by `amdsmi_get_cpu_core_floor_freq_limit` function:
+
+* `AmdSmiLibraryException`
+
+#### Possible Library Exceptions
+
+- `AMDSMI_STATUS_NOT_SUPPORTED` - Feature not supported
+- `AMDSMI_STATUS_NOT_YET_IMPLEMENTED` - Feature not yet implemented
+- `AMDSMI_STATUS_NO_HSMP_MSG_SUP` - HSMP message/feature not supported
+- `AMDSMI_STATUS_INVAL` - Invalid parameters
+- `AMDSMI_STATUS_TIMEOUT` - Timeout in API call
+
+Example:
+
+```python
+from amdsmi import *
+try:
+    ret = amdsmi_init(AmdSmiInitFlags.INIT_AMD_CPUS)
+    core_handles = amdsmi_get_cpucore_handles()
+    if len(core_handles) == 0:
+        print("No CPU Cores on machine")
+    else:
+        core0 = core_handles[0]   # <-- pick core 0 explicitly
+        # Get core floor limit for core 0
+        floor_limit = amdsmi_get_cpu_core_floor_freq_limit(core0)
+        print(f"CORE: 0")
+        print(f"    FLOOR_LIMIT:")
+        print(f"        VALUE: {floor_limit} MHz")
+        print()
+except AmdSmiException as e:
+    print(e)
+```
+
+### amdsmi_get_cpu_core_eff_floor_freq_limit
+
+Description: Get the effective floor limit frequency for CPU core.
+
+Input parameters:
+- `core0` (amdsmi_processor_handle): CPU core handle to query
+
+Output: Integer representing the effective core floor limit frequency in MHz for core 0
+
+Exceptions that can be thrown by `amdsmi_get_cpu_core_eff_floor_freq_limit` function:
+
+* `AmdSmiLibraryException`
+
+#### Possible Library Exceptions
+
+- `AMDSMI_STATUS_NOT_SUPPORTED` - Feature not supported
+- `AMDSMI_STATUS_NOT_YET_IMPLEMENTED` - Feature not yet implemented
+- `AMDSMI_STATUS_NO_HSMP_MSG_SUP` - HSMP message/feature not supported
+- `AMDSMI_STATUS_INVAL` - Invalid parameters
+- `AMDSMI_STATUS_TIMEOUT` - Timeout in API call
+
+Example:
+
+```python
+from amdsmi import *
+try:
+    ret = amdsmi_init(AmdSmiInitFlags.INIT_AMD_CPUS)
+    core_handles = amdsmi_get_cpucore_handles()
+    if len(core_handles) == 0:
+        print("No CPU cores on machine")
+    else:
+        core0 = core_handles[0]   # <-- pick core 0 explicitly
+        # Get core effective floor limit for core 0
+        eff_floor_limit = amdsmi_get_cpu_core_eff_floor_freq_limit(core0)
+        print(f"CORE: 0")
+        print(f"    EFF_FLOOR_LIMIT:")
+        print(f"        VALUE: {eff_floor_limit} MHz")
+        print()
+except AmdSmiException as e:
+    print(e)
+```
+
+### amdsmi_get_cpu_floor_freq_limit
+
+Description: Get the floor limit frequency for a CPU socket.
+
+Input parameters:
+- `processor_handle` (amdsmi_processor_handle): CPU socket handle to query
+
+Output: Integer representing the socket floor limit frequency in MHz
+
+Exceptions that can be thrown by `amdsmi_get_cpu_floor_freq_limit` function:
+
+* `AmdSmiLibraryException`
+
+#### Possible Library Exceptions
+
+- `AMDSMI_STATUS_NOT_SUPPORTED` - Feature not supported
+- `AMDSMI_STATUS_NOT_YET_IMPLEMENTED` - Feature not yet implemented
+- `AMDSMI_STATUS_NO_HSMP_MSG_SUP` - HSMP message/feature not supported
+- `AMDSMI_STATUS_INVAL` - Invalid parameters
+- `AMDSMI_STATUS_TIMEOUT` - Timeout in API call
+
+Example:
+
+```python
+from amdsmi import *
+try:
+    ret = amdsmi_init(AmdSmiInitFlags.INIT_AMD_CPUS)
+    processor_handles = amdsmi_get_cpusocket_handles()
+    if len(processor_handles) == 0:
+        print("No CPUs on machine")
+    else:
+        for i, processor in enumerate(processor_handles):
+            floor_limit = amdsmi_get_cpu_floor_freq_limit(processor)
+            print(f"CPU: {i}")
+            print(f"    FLOOR_LIMIT:")
+            print(f"        VALUE: {floor_limit} MHz")
+            print()
+except AmdSmiException as e:
+    print(e)
+```
+
+### amdsmi_get_cpu_eff_floor_freq_limit
+
+Description: Get the effective floor limit frequency for a CPU socket.
+
+Input parameters:
+- `processor_handle` (amdsmi_processor_handle): CPU socket handle to query
+
+Output: Integer representing the effective socket floor limit frequency in MHz
+
+Exceptions that can be thrown by `amdsmi_get_cpu_eff_floor_freq_limit` function:
+
+* `AmdSmiLibraryException`
+
+#### Possible Library Exceptions
+
+- `AMDSMI_STATUS_NOT_SUPPORTED` - Feature not supported
+- `AMDSMI_STATUS_NOT_YET_IMPLEMENTED` - Feature not yet implemented
+- `AMDSMI_STATUS_NO_HSMP_MSG_SUP` - HSMP message/feature not supported
+- `AMDSMI_STATUS_INVAL` - Invalid parameters
+- `AMDSMI_STATUS_TIMEOUT` - Timeout in API call
+
+Example:
+
+```python
+from amdsmi import *
+try:
+    ret = amdsmi_init(AmdSmiInitFlags.INIT_AMD_CPUS)
+    processor_handles = amdsmi_get_cpusocket_handles()
+    if len(processor_handles) == 0:
+        print("No CPUs on machine")
+    else:
+        for i, processor in enumerate(processor_handles):
+            eff_floor_limit = amdsmi_get_cpu_eff_floor_freq_limit(processor)
+            print(f"CPU: {i}")
+            print(f"    EFF_FLOOR_LIMIT:")
+            print(f"        VALUE: {eff_floor_limit} MHz")
+            print()
+except AmdSmiException as e:
+    print(e)
+```
+
+### amdsmi_get_cpu_freq_range
+
+Description: Get the CPU socket frequency range. Returns the minimum and maximum frequency limits for CPU socket 0.
+
+Input parameters: None
+
+Output: Dictionary containing frequency range values:
+- `fmax` (int): Maximum frequency in MHz
+- `fmin` (int): Minimum frequency in MHz
+
+Exceptions that can be thrown by `amdsmi_get_cpu_freq_range` function:
+
+* `AmdSmiLibraryException`
+
+#### Possible Library Exceptions
+
+- `AMDSMI_STATUS_NOT_SUPPORTED` - Feature not supported
+- `AMDSMI_STATUS_NOT_YET_IMPLEMENTED` - Feature not yet implemented
+- `AMDSMI_STATUS_NO_HSMP_MSG_SUP` - HSMP message/feature not supported
+- `AMDSMI_STATUS_INVAL` - Invalid parameters
+- `AMDSMI_STATUS_TIMEOUT` - Timeout in API call
+
+Example:
+
+```python
+from amdsmi import *
+try:
+    ret = amdsmi_init(AmdSmiInitFlags.INIT_AMD_CPUS)
+    freq_range = amdsmi_get_cpu_freq_range()
+    print(f"CPU Frequency Range:")
+    print(f"    FMAX: {freq_range['fmax']} MHz")
+    print(f"    FMIN: {freq_range['fmin']} MHz")
+except AmdSmiException as e:
+    print(e)
+```
+
+### amdsmi_set_cpu_core_floor_freq_limit
+
+Description: Set the floor limit frequency for a specific CPU core.
+
+Input parameters:
+- `core0` (int): Core index to configure
+- `floor_limit` (int): Floor limit frequency value in MHz
+
+Exceptions that can be thrown by `amdsmi_set_cpu_core_floor_freq_limit` function:
+
+* `AmdSmiLibraryException`
+
+#### Possible Library Exceptions
+
+- `AMDSMI_STATUS_NOT_SUPPORTED` - Feature not supported
+- `AMDSMI_STATUS_NOT_YET_IMPLEMENTED` - Feature not yet implemented
+- `AMDSMI_STATUS_NO_HSMP_MSG_SUP` - HSMP message/feature not supported
+- `AMDSMI_STATUS_INVAL` - Invalid parameters
+- `AMDSMI_STATUS_TIMEOUT` - Timeout in API call
+- 'AMDSMI_STATUS_NO_PERM' - Permission Denied
+
+Example:
+
+```python
+from amdsmi import *
+try:
+    ret = amdsmi_init(AmdSmiInitFlags.INIT_AMD_CPUS)
+    core_handles = amdsmi_get_cpucore_handles()
+    if len(core_handles) == 0:
+        print("No CPU cores on machine")
+    else:
+        core0 = core_handles[0]   # <-- pick core 0 explicitly
+        floor_limit_value = 1200  # Set floor limit to 1200 MHz
+        amdsmi_set_cpu_core_floor_freq_limit(core0, floor_limit_value)
+        print(f"CORE: 0")
+        print(f"    FLOOR_LIMIT:")
+        print(f"        RESPONSE: Set, VALUE: {floor_limit_value} MHz, successful")
+        print()
+except AmdSmiException as e:
+    print(e)
+```
+
+### amdsmi_set_cpu_floor_freq_limit
+
+Description: Set the CPU floor limit frequency for a CPU socket.
+
+Input parameters:
+- `processor_handle` (amdsmi_processor_handle): CPU socket handle to configure
+- `floor_limit_value` (int): Floor limit frequency value in MHz
+
+Output: `None`
+
+Exceptions that can be thrown by `amdsmi_set_cpu_floor_freq_limit` function:
+
+* `AmdSmiLibraryException`
+
+#### Possible Library Exceptions
+
+- `AMDSMI_STATUS_NOT_SUPPORTED` - Feature not supported
+- `AMDSMI_STATUS_NOT_YET_IMPLEMENTED` - Feature not yet implemented
+- `AMDSMI_STATUS_NO_HSMP_MSG_SUP` - HSMP message/feature not supported
+- `AMDSMI_STATUS_INVAL` - Invalid parameters
+- `AMDSMI_STATUS_TIMEOUT` - Timeout in API call
+- 'AMDSMI_STATUS_NO_PERM' - Permission Denied
+
+Example:
+
+```python
+from amdsmi import *
+try:
+    ret = amdsmi_init(AmdSmiInitFlags.INIT_AMD_CPUS)
+    processor_handles = amdsmi_get_cpusocket_handles()
+    if len(processor_handles) == 0:
+        print("No CPUs on machine")
+    else:
+        for i, processor in enumerate(processor_handles):
+            try:
+                # Set CPU floor limit from 600 MHz to  4000 MHz
+                floor_limit_value = 1200
+                amdsmi_set_cpu_floor_freq_limit(processor, floor_limit_value)
+                print(f"CPU: {i}")
+                print(f"    FLOOR_LIMIT:")
+                print(f"        RESPONSE: Set, VALUE: {floor_limit_value} MHz, successful")
+                print()
+            except AmdSmiException as e:
+                print(f"Failed to set CPU floor limit for CPU {i}: {e}")
+except AmdSmiException as e:
+    print(e)
+```
+
+### amdsmi_set_cpu_msr_floor_freq_limit
+
+Description: Set the CPU MSR floor limit frequency for a CPU socket.
+
+Input parameters:
+- `processor_handle` (amdsmi_processor_handle): CPU socket handle to configure
+- `floor_limit` (int): MSR floor limit frequency value in MHz
+
+Output: `None`
+
+Exceptions that can be thrown by `amdsmi_set_cpu_msr_floor_freq_limit` function:
+
+* `AmdSmiLibraryException`
+
+#### Possible Library Exceptions
+
+- `AMDSMI_STATUS_NOT_SUPPORTED` - Feature not supported
+- `AMDSMI_STATUS_NOT_YET_IMPLEMENTED` - Feature not yet implemented
+- `AMDSMI_STATUS_NO_HSMP_MSG_SUP` - HSMP message/feature not supported
+- `AMDSMI_STATUS_INVAL` - Invalid parameters
+- `AMDSMI_STATUS_TIMEOUT` - Timeout in API call
+- 'AMDSMI_STATUS_NO_PERM' - Permission Denied
+
+Example:
+
+```python
+from amdsmi import *
+try:
+    ret = amdsmi_init(AmdSmiInitFlags.INIT_AMD_CPUS)
+    processor_handles = amdsmi_get_cpusocket_handles()
+    if len(processor_handles) == 0:
+        print("No CPUs on machine")
+    else:
+        for i, processor in enumerate(processor_handles):
+            try:
+                # Set CPU MSR floor limit to 1200 MHz
+                msr_floor_limit_value = 1200
+                amdsmi_set_cpu_msr_floor_freq_limit(processor, msr_floor_limit_value)
+                print(f"CPU: {i}")
+                print(f"    MSR_FLOOR_LIMIT:")
+                print(f"        RESPONSE: Set, VALUE: {msr_floor_limit_value} MHz, successful")
+                print()
+            except AmdSmiException as e:
+                print(f"Failed to set CPU MSR floor limit for CPU {i}: {e}")
+except AmdSmiException as e:
+    print(e)
+```
+
+### amdsmi_set_cpu_core_msr_floor_freq_limit
+
+Description: Set the CPU core MSR floor limit frequency for a specific CPU core.
+
+Input parameters:
+- `core0` (int): Core 0 index to configure
+- `msr_floor_limit_value` (int): MSR floor limit frequency value in MHz
+
+Output: None
+
+Exceptions that can be thrown by `amdsmi_set_cpu_core_msr_floor_freq_limit` function:
+
+* `AmdSmiLibraryException`
+
+#### Possible Library Exceptions
+
+- `AMDSMI_STATUS_NOT_SUPPORTED` - Feature not supported
+- `AMDSMI_STATUS_NOT_YET_IMPLEMENTED` - Feature not yet implemented
+- `AMDSMI_STATUS_NO_HSMP_MSG_SUP` - HSMP message/feature not supported
+- `AMDSMI_STATUS_INVAL` - Invalid parameters
+- `AMDSMI_STATUS_TIMEOUT` - Timeout in API call
+- 'AMDSMI_STATUS_NO_PERM' - Permission Denied
+
+Example:
+
+```python
+from amdsmi import *
+try:
+    ret = amdsmi_init(AmdSmiInitFlags.INIT_AMD_CPUS)
+    core_handles = amdsmi_get_cpucore_handles()
+    if len(core_handles) == 0:
+        print("No CPU cores on machine")
+    else:
+        core0 = core_handles[0]   # <-- pick core 0 explicitly
+        # Set MSR floor limit for core 0 only
+        msr_floor_limit_value = 1200  # Set MSR floor limit to 1200 MHz
+        amdsmi_set_cpu_core_msr_floor_freq_limit(core0, msr_floor_limit_value)
+        print(f"CORE: 0")
+        print(f"    MSR_FLOOR_LIMIT:")
+        print(f"        RESPONSE: Set, VALUE: {msr_floor_limit_value} MHz, successful")
+        print()
+except AmdSmiException as e:
+    print(e)
+```
+
+### amdsmi_set_cpu_sdps_limit
+
+Description: Set the SDPS limit for a CPU socket. This function sets the socket SDPS power limit for the CPU socket.
+
+Input parameters:
+- `processor_handle` (amdsmi_processor_handle): CPU socket handle to configure
+- `sdps_limit` (int): SDPS limit value in Watts
+
+Output: `None`
+
+Exceptions that can be thrown by `amdsmi_set_cpu_sdps_limit` function:
+
+* `AmdSmiLibraryException`
+
+#### Possible Library Exceptions
+
+- `AMDSMI_STATUS_NOT_SUPPORTED` - Feature not supported
+- `AMDSMI_STATUS_NOT_YET_IMPLEMENTED` - Feature not yet implemented
+- `AMDSMI_STATUS_NO_HSMP_MSG_SUP` - HSMP message/feature not supported
+- `AMDSMI_STATUS_INVAL` - Invalid parameters
+- `AMDSMI_STATUS_TIMEOUT` - Timeout in API call
+
+Example:
+
+```python
+from amdsmi import *
+try:
+    ret = amdsmi_init(AmdSmiInitFlags.INIT_AMD_CPUS)
+    processor_handles = amdsmi_get_cpusocket_handles()
+    if len(processor_handles) == 0:
+        print("No CPUs on machine")
+    else:
+        for i, processor in enumerate(processor_handles):
+            try:
+                # Set CPU socket SDPS limit to 1000 mWatts
+                sdps_limit_value_mW = 1000
+                sdps_limit_watts = float(sdps_limit_value_mW) / 1000
+                amdsmi_set_cpu_sdps_limit(processor, sdps_limit_value_mW)
+                print(f"CPU: {i}")
+                print(f"    SDPS_LIMIT:")
+                print(f"        RESPONSE: Set, VALUE: {sdps_limit_watts} Watts, successful")
+                print()
+            except AmdSmiException as e:
+                print(f"Failed to set CPU socket SDPS limit for CPU {i}: {e}")
+except AmdSmiException as e:
+    print(e)
+```
+
+### amdsmi_get_cpu_sdps_limit
+
+Description: Get the SDPS limit for a CPU socket. This function retrieves the current socket SDPS power limit for the CPU socket.
+
+Input parameters:
+- `processor_handle` (amdsmi_processor_handle): CPU socket handle to query
+
+Output: Double representing the SDPS limit value in Watts
+
+Exceptions that can be thrown by `amdsmi_get_cpu_sdps_limit` function:
+
+* `AmdSmiLibraryException`
+
+#### Possible Library Exceptions
+
+- `AMDSMI_STATUS_NOT_SUPPORTED` - Feature not supported
+- `AMDSMI_STATUS_NOT_YET_IMPLEMENTED` - Feature not yet implemented
+- `AMDSMI_STATUS_NO_HSMP_MSG_SUP` - HSMP message/feature not supported
+- `AMDSMI_STATUS_INVAL` - Invalid parameters
+- `AMDSMI_STATUS_TIMEOUT` - Timeout in API call
+
+Example:
+
+```python
+from amdsmi import *
+try:
+    ret = amdsmi_init(AmdSmiInitFlags.INIT_AMD_CPUS)
+    processor_handles = amdsmi_get_cpusocket_handles()
+    if len(processor_handles) == 0:
+        print("No CPUs on machine")
+    else:
+        for i, processor in enumerate(processor_handles):
+            try:
+                # Get CPU socket SDPS limit
+                sdps_limit = amdsmi_get_cpu_sdps_limit(processor)
+                print(f"CPU: {i}")
+                print(f"    SDPS_LIMIT:")
+                print(f"        VALUE: {sdps_limit}")
+                print()
+            except AmdSmiException as e:
+                print(f"Failed to get CPU socket SDPS limit for CPU {i}: {e}")
 except AmdSmiException as e:
     print(e)
 ```

--- a/projects/amdsmi/goamdsmi_shim/smiwrapper/amdsmi_go_shim.c
+++ b/projects/amdsmi/goamdsmi_shim/smiwrapper/amdsmi_go_shim.c
@@ -348,21 +348,21 @@ uint32_t goamdsmi_cpu_prochot_status_get(uint32_t socket_index)
 uint32_t goamdsmi_cpu_socket_power_get(uint32_t socket_index)
 {
 	bool readSuccess = false;
-    uint32_t socket_power_temp = GOAMDSMI_UINT32_MAX;
-    if ((AMDSMI_STATUS_SUCCESS == amdsmi_get_cpu_socket_power(amdsmi_processor_handle_all_cpu_across_socket[socket_index], &socket_power_temp))) readSuccess = true;
-    if (enable_debug_level(GOAMDSMI_DEBUG_LEVEL_1)) {printf("AMDSMI, %s for Socket:%d, CpuSocketPower:%lu, CpuSocketPowerWatt:%.3f\n", readSuccess?"Success":"Failed", socket_index, (unsigned long)(socket_power_temp), ((double)(socket_power_temp))/1000);}
+    double socket_power_watts = 0;
+    if ((AMDSMI_STATUS_SUCCESS == amdsmi_get_cpu_socket_power(amdsmi_processor_handle_all_cpu_across_socket[socket_index], &socket_power_watts))) readSuccess = true;
+    if (enable_debug_level(GOAMDSMI_DEBUG_LEVEL_1)) {printf("AMDSMI, %s for Socket:%d, CpuSocketPowerWatt:%.3f\n", readSuccess?"Success":"Failed", socket_index, socket_power_watts);}
 
-    return socket_power_temp;
+    return readSuccess ? (uint32_t)(socket_power_watts * 1000) : GOAMDSMI_UINT32_MAX;
 }
 
 uint32_t goamdsmi_cpu_socket_power_cap_get(uint32_t socket_index)
 {
 	bool readSuccess = false;
-    uint32_t socket_power_cap_temp = GOAMDSMI_UINT32_MAX;
-    if ((AMDSMI_STATUS_SUCCESS == amdsmi_get_cpu_socket_power_cap(amdsmi_processor_handle_all_cpu_across_socket[socket_index], &socket_power_cap_temp))) readSuccess = true;
-    if (enable_debug_level(GOAMDSMI_DEBUG_LEVEL_1)) {printf("AMDSMI, %s for Socket:%d, CpuSocketPowerCap:%lu, CpuSocketPowerCapWatt:%.3f\n", readSuccess?"Success":"Failed", socket_index, (unsigned long)(socket_power_cap_temp), ((double)(socket_power_cap_temp))/1000);}
+    double socket_power_cap_watts = 0;
+    if ((AMDSMI_STATUS_SUCCESS == amdsmi_get_cpu_socket_power_cap(amdsmi_processor_handle_all_cpu_across_socket[socket_index], &socket_power_cap_watts))) readSuccess = true;
+    if (enable_debug_level(GOAMDSMI_DEBUG_LEVEL_1)) {printf("AMDSMI, %s for Socket:%d, CpuSocketPowerCapWatt:%.3f\n", readSuccess?"Success":"Failed", socket_index, socket_power_cap_watts);}
 
-    return socket_power_cap_temp;
+    return readSuccess ? (uint32_t)(socket_power_cap_watts * 1000) : GOAMDSMI_UINT32_MAX;
 }
 
 uint32_t goamdsmi_cpu_core_boostlimit_get(uint32_t thread_index)

--- a/projects/amdsmi/include/amd_smi/amdsmi.h
+++ b/projects/amdsmi/include/amd_smi/amdsmi.h
@@ -295,6 +295,23 @@ typedef struct {
     uint32_t minor;  //!< Minor version number
 } amdsmi_hsmp_driver_version_t;
 
+/**
+ * @brief SPD DIMM register validation limits
+ *
+ * @cond @tag{cpu_bm} @endcond
+ */
+#define AMDSMI_MAX_SPD_DIMM_ADDRESS           0xFF       //!< Maximum SPD DIMM address [7:0]
+#define AMDSMI_MAX_SPD_LID                    0xF        //!< Maximum SPD logical ID [11:8]
+#define AMDSMI_MAX_SPD_REG_OFFSET             0x7FF      //!< Maximum SPD register offset [22:12]
+#define AMDSMI_MAX_SPD_REG_SPACE              0x1        //!< Maximum SPD register space [23]
+#define AMDSMI_MAX_SPD_WRITE_DATA             0xFF       //!< Maximum SPD write data [31:24]
+#define MAX_SVI3_RAIL_INDEX                   4
+#define MAX_SVI3_RAIL_SELECTION               1
+#define POWER_EFFICIENCY_MODE_4               0x4
+#define POWER_EFFICIENCY_MODE_5               0x5
+#define AMDSMI_MAX_POWER_EFFICIENCY_UTIL      0x7F       //[9:3]=Utilization point for balanced core modes (%).
+#define AMDSMI_MAX_POWER_EFFICIENCY_PPTLIMIT  0x1FFFFF   //[30:10]=PPT limit for balanced core modes(mW).
+#define AMDSMI_RAIL_INDEX_NONE                0xFFFFFFFF //Rail Index value defined as maximun when not passed
 #endif
 
 /**
@@ -3669,7 +3686,7 @@ amdsmi_get_supported_power_cap(amdsmi_processor_handle processor_handle, uint32_
  *  @return ::amdsmi_status_t | ::AMDSMI_STATUS_SUCCESS on success, non-zero on fail
  */
 amdsmi_status_t amdsmi_get_cpu_socket_power(amdsmi_processor_handle processor_handle,
-                                            uint32_t *ppower);
+                                            double *ppower);
 
 /**
  *  @brief Get the socket power cap.
@@ -3685,7 +3702,7 @@ amdsmi_status_t amdsmi_get_cpu_socket_power(amdsmi_processor_handle processor_ha
  *  @return ::amdsmi_status_t | ::AMDSMI_STATUS_SUCCESS on success, non-zero on fail
  */
 amdsmi_status_t amdsmi_get_cpu_socket_power_cap(amdsmi_processor_handle processor_handle,
-                                                uint32_t *pcap);
+                                                double *pcap);
 
 /**
  *  @brief Get the maximum power cap value for a given socket.
@@ -3701,7 +3718,7 @@ amdsmi_status_t amdsmi_get_cpu_socket_power_cap(amdsmi_processor_handle processo
  *  @return ::amdsmi_status_t | ::AMDSMI_STATUS_SUCCESS on success, non-zero on fail
  */
 amdsmi_status_t amdsmi_get_cpu_socket_power_cap_max(amdsmi_processor_handle processor_handle,
-                                                    uint32_t *pmax);
+                                                    double *pmax);
 
 /**
  *  @brief Get the SVI based power telemetry for all rails.
@@ -3742,14 +3759,62 @@ amdsmi_status_t amdsmi_set_cpu_socket_power_cap(amdsmi_processor_handle processo
  *
  *  @platform{cpu_bm}
  *
- *  @param[in] processor_handle Cpu socket which to query
+ *  @param[in]  processor_handle Cpu socket which to configure
  *
- *  @param[in] mode - mode to be set
+ *  @param[in]  power_efficiency_mode - power efficiency mode to be set
+ *
+ *  @param[in,out]  utilization - pointer to store utilization for balanced core modes (%)
+ *
+ *  @param[in,out]  ppt_limit - pointer to PPT (Package Power Tracking) limit value
  *
  *  @return ::amdsmi_status_t | ::AMDSMI_STATUS_SUCCESS on success, non-zero on fail
  */
 amdsmi_status_t amdsmi_set_cpu_pwr_efficiency_mode(amdsmi_processor_handle processor_handle,
-                                                   uint8_t mode);
+                                                   uint8_t power_efficiency_mode,
+                                                   uint32_t *utilization,
+                                                   uint32_t *ppt_limit);
+
+/**
+ *  @brief Get the power efficiency profile policy
+ *
+ *  @details This function retrieves the current power efficiency mode, utility value,
+ *           and PPT (Package Power Tracking) limit for a given processor socket.
+ *
+ *  @ingroup tagPowerControl
+ *
+ *  @platform{cpu_bm}
+ *
+ *  @param[in]  processor_handle Cpu socket which to query
+ *
+ *  @param[out]  power_efficiency_mode - pointer to store current power efficiency mode
+ *
+ *  @param[out]  utilization - pointer to store utilization for balanced core modes (%)
+ *
+ *  @param[out]  ppt_limit - pointer to store PPT (Package Power Tracking) limit value in Watt
+ *
+ *  @return ::amdsmi_status_t | ::AMDSMI_STATUS_SUCCESS on success, non-zero on fail
+ */
+amdsmi_status_t amdsmi_get_cpu_pwr_efficiency_mode(amdsmi_processor_handle processor_handle,
+                                                   uint32_t *power_efficiency_mode,
+                                                   uint32_t *utilization,
+                                                   double *ppt_limit);
+/**
+ *  @brief Read CCD (Core Complex Die) power consumption
+ *
+ *  @details This function reads the power consumption of a specific CCD within a CPU socket.
+ *
+ *  @ingroup tagPowerControl
+ *
+ *  @platform{cpu_bm}
+ *
+ *  @param[in]  processor_handle Cpu core which to query
+ *  @param[out]  power - Input buffer to store power consumption in watts
+ *
+ *   @return ::amdsmi_status_t
+ *          ::AMDSMI_STATUS_SUCCESS on successful register read, non-zero on failure
+ */
+amdsmi_status_t amdsmi_get_cpu_core_ccd_power(amdsmi_processor_handle processor_handle,
+                                              double *power);
 
 /** @} End tagPowerControl */
 
@@ -7227,17 +7292,109 @@ amdsmi_status_t amdsmi_get_cpu_socket_freq_range(amdsmi_processor_handle process
 amdsmi_status_t amdsmi_get_cpu_core_current_freq_limit(amdsmi_processor_handle processor_handle,
                                                        uint32_t *freq);
 
+/**
+ *  @brief Set CPU rail isolated frequency policy for independent core clock control per power rail
+ *
+ *  This API configures the frequency policy for CPU power rails.
+ *  - If a socket-wide limit (e.g., PPT) is setting the core clock frequency, this setting has no effect.
+ *  - For other limiters specific to CPU power rails (e.g., TDC),
+ *    this policy enables or disables independent core clocks per rail (VDDCR_CPU0 or VDDCR_CPU1).
+ *
+ *  Policy values:
+ *  - 0: Disable independent control (all cores on both rails have the same frequency limit)
+ *  - 1: Enable independent control (each rail has an independent frequency limit)
+ *
+ *  @ingroup tagHSMPSystemStats
+ *
+ *  @platform{cpu_bm}
+ *
+ *  @param[in]	processor_handle Cpu socket which to query
+ *
+ *  @param[in,out]  rail_isofreq_policy - Input buffer to store policy value, indicating the CPU rail ISO frequency Policy setting:
+ *                        - 0: Disable independent control - each rail has its own independent frequency limit.
+ *                        - 1: Enable independent control - all cores on both rails share the same frequency limit.
+ *  @return ::amdsmi_status_t | ::AMDSMI_STATUS_SUCCESS on success, non-zero on fail
+ */
+amdsmi_status_t amdsmi_set_cpu_rail_isofreq_policy(amdsmi_processor_handle processor_handle,
+                                                   bool *rail_isofreq_policy);
+
+/**
+ *  @brief Get CPU rail isolated frequency policy status for independent core clock control per power rail.
+ *
+ * This API retrieves the current frequency policy configuration for CPU power rails.
+ *  - If a socket-wide limit (e.g., PPT) is setting the core clock frequency, the effective policy may be overridden.
+ *  - For other limiters specific to CPU power rails (e.g., TDC),
+ *    this policy indicates whether independent core clocks per rail (VDDCR_CPU0 or VDDCR_CPU1) are enabled or disabled.
+ *
+ *  Policy values returned:
+ *  - 0: Independent control disabled (all cores on both rails have the same frequency limit)
+ *  - 1: Independent control enabled (each rail has an independent frequency limit)
+ *
+ *  @ingroup tagHSMPSystemStats
+ *
+ *  @platform{cpu_bm}
+ *
+ *  @param[in]      processor_handle Cpu socket which to query
+ *
+ *  @param[in,out]  rail_isofreq_policy - Input buffer to receive the current cpu rail isolated frequency policy
+ *
+ *  @return ::amdsmi_status_t
+ *          ::AMDSMI_STATUS_SUCCESS on success, non-zero on failure
+ */
+amdsmi_status_t amdsmi_get_cpu_rail_isofreq_policy(amdsmi_processor_handle processor_handle,
+                                                   uint8_t *rail_isofreq_policy);
+
+/**
+ *  @brief Set the DFCState enabling control.
+ *
+ *  DFCState control values for setting:
+ *  - 0: Disable DFC control
+ *  - 1: Enable DFC control
+ *
+ *  @ingroup tagHSMPSystemStats
+ *
+ *  @platform{cpu_bm}
+ *
+ *  @param[in]	processor_handle Cpu socket handle to query
+ *
+ *  @param[in]  dfc_ctrl - Input buffer indicating whether to enable (1) or disable (0) DFCState control
+ *
+ *  @return ::amdsmi_status_t
+ *          ::AMDSMI_STATUS_SUCCESS on success, non-zero on failure
+ */
+amdsmi_status_t amdsmi_set_cpu_dfc_ctrl(amdsmi_processor_handle processor_handle, uint8_t *dfc_ctrl);
+
+/**
+ *  @brief Get the current DFCState enabling control status.
+ *
+ *  Returned DFCState control values:
+ *  - 0: DFC control is disabled
+ *  - 1: DFC control is enabled
+ *
+ *  @ingroup tagHSMPSystemStats
+ *
+ *  @platform{cpu_bm}
+ *
+ *  @param[in]      processor_handle Cpu socket handle to query
+ *
+ *  @param[in,out]  dfc_ctrl - Input buffer to receive the current DFCState control status
+ *
+ *  @return ::amdsmi_status_t
+ *          ::AMDSMI_STATUS_SUCCESS on success, non-zero on failure
+ */
+amdsmi_status_t amdsmi_get_cpu_dfc_ctrl(amdsmi_processor_handle processor_handle, uint8_t *dfc_ctrl);
+
 /** @} End tagHSMPSystemStats */
 
 /*****************************************************************************/
-/** @defgroup tagPerfBoostControl Performance (Boost limit) Control
+/** @defgroup tagPerfControl Performance (Boost limit) Control
  *  @{
  */
 
 /**
  *  @brief Get the core boost limit.
  *
- *  @ingroup tagPerfBoostControl
+ *  @ingroup tagPerfControl
  *
  *  @platform{cpu_bm}
  *
@@ -7253,7 +7410,7 @@ amdsmi_status_t amdsmi_get_cpu_core_boostlimit(amdsmi_processor_handle processor
 /**
  *  @brief Get the socket c0 residency.
  *
- *  @ingroup tagPerfBoostControl
+ *  @ingroup tagPerfControl
  *
  *  @platform{cpu_bm}
  *
@@ -7269,7 +7426,7 @@ amdsmi_status_t amdsmi_get_cpu_socket_c0_residency(amdsmi_processor_handle proce
 /**
  *  @brief Set the core boostlimit value.
  *
- *  @ingroup tagPerfBoostControl
+ *  @ingroup tagPerfControl
  *
  *  @platform{cpu_bm}
  *
@@ -7285,7 +7442,7 @@ amdsmi_status_t amdsmi_set_cpu_core_boostlimit(amdsmi_processor_handle processor
 /**
  *  @brief Set the socket boostlimit value.
  *
- *  @ingroup tagPerfBoostControl
+ *  @ingroup tagPerfControl
  *
  *  @platform{cpu_bm}
  *
@@ -7298,7 +7455,198 @@ amdsmi_status_t amdsmi_set_cpu_core_boostlimit(amdsmi_processor_handle processor
 amdsmi_status_t amdsmi_set_cpu_socket_boostlimit(amdsmi_processor_handle processor_handle,
                                                  uint32_t boostlimit);
 
-/** @} End tagPerfBoostControl */
+/**
+ *  @brief Get the CPU core floor limit frequency.
+ *
+ *  @details This function retrieves the floor frequency limit for the specified CPU core.
+ *
+ *  @ingroup tagPerfControl
+ *
+ *  @platform{cpu_bm}
+ *
+ *  @param[in]      processor_handle CPU core which to query
+ *
+ *  @param[in,out]  floor_freq - Input buffer to fill the floor limit frequency in MHz
+ *
+ *  @return ::amdsmi_status_t | ::AMDSMI_STATUS_SUCCESS on success, non-zero on fail
+ */
+amdsmi_status_t amdsmi_get_cpu_core_floor_freq_limit(amdsmi_processor_handle processor_handle,
+                                                     uint32_t *floor_freq);
+
+/**
+ *  @brief Get the CPU floor limit frequency.
+ *
+ *  @details This function retrieves the floor frequency limit for the specified CPU socket.
+ *
+ *  @ingroup tagPerfControl
+ *
+ *  @platform{cpu_bm}
+ *
+ *  @param[in]      processor_handle CPU socket which to query
+ *
+ *  @param[in,out]  floor_freq - Input buffer to fill the floor limit frequency in MHz
+ *
+ *  @return ::amdsmi_status_t | ::AMDSMI_STATUS_SUCCESS on success, non-zero on fail
+ */
+amdsmi_status_t amdsmi_get_cpu_floor_freq_limit(amdsmi_processor_handle processor_handle,
+                                                uint32_t *floor_freq);
+
+/**
+ *  @brief Get the CPU core effective floor limit frequency.
+ *
+ *  @details This function returns the effective floor frequency limit for the specified CPU core.
+ *
+ *  @ingroup tagPerfControl
+ *
+ *  @platform{cpu_bm}
+ *
+ *  @param[in]      processor_handle CPU core which to query
+ *
+ *  @param[in,out]  eff_floor_freq - Input buffer to fill the effective floor limit frequency in MHz
+ *
+ *  @return ::amdsmi_status_t | ::AMDSMI_STATUS_SUCCESS on success, non-zero on fail
+ */
+amdsmi_status_t amdsmi_get_cpu_core_eff_floor_freq_limit(amdsmi_processor_handle processor_handle,
+                                                         uint32_t *eff_floor_freq);
+
+/**
+ *  @brief Get the CPU effective floor limit frequency.
+ *
+ *  @details This function returns the effective floor frequency limit for the specified CPU socket.
+ *
+ *  @ingroup tagPerfControl
+ *
+ *  @platform{cpu_bm}
+ *
+ *  @param[in]      processor_handle CPU socket which to query
+ *
+ *  @param[in,out]  eff_floor_freq - Input buffer to fill the effective floor limit frequency in MHz
+ *
+ *  @return ::amdsmi_status_t | ::AMDSMI_STATUS_SUCCESS on success, non-zero on fail
+ */
+amdsmi_status_t amdsmi_get_cpu_eff_floor_freq_limit(amdsmi_processor_handle processor_handle,
+                                                    uint32_t *eff_floor_freq);
+
+/**
+ *  @brief Set the CPU core floor limit frequency.
+ *
+ *  @details This function sets the floor frequency limit for the specified CPU core.
+ *
+ *  @ingroup tagPerfControl
+ *
+ *  @platform{cpu_bm}
+ *
+ *  @param[in]  processor_handle CPU core which to set
+ *
+ *  @param[in]  floor_freq - floor limit frequency value to be set in MHz
+ *
+ *  @return ::amdsmi_status_t | ::AMDSMI_STATUS_SUCCESS on success, non-zero on fail
+ */
+amdsmi_status_t amdsmi_set_cpu_core_floor_freq_limit(amdsmi_processor_handle processor_handle,
+		                                     uint32_t floor_freq);
+
+/**
+ *  @brief Set the CPU socket floor limit frequency.
+ *
+ *  @details This function sets the floor frequency limit for the specified CPU socket.
+ *
+ *  @ingroup tagPerfControl
+ *
+ *  @platform{cpu_bm}
+ *
+ *  @param[in]  processor_handle CPU socket which to set
+ *
+ *  @param[in]  floor_freq - floor limit frequency value to be set in MHz
+ *
+ *  @return ::amdsmi_status_t | ::AMDSMI_STATUS_SUCCESS on success, non-zero on fail
+ */
+amdsmi_status_t amdsmi_set_cpu_floor_freq_limit(amdsmi_processor_handle processor_handle,
+                                                uint32_t floor_freq);
+
+/**
+ *  @brief Set CPU floor limit frequency via MSR(Model Specific Register).
+ *
+ *  @details This function sets the floor frequency limit via MSR(Model Specific Register) for the specified CPU socket.
+ *
+ *  @ingroup tagPerfControl
+ *
+ *  @platform{cpu_bm}
+ *
+ *  @param[in]  processor_handle CPU socket which to set
+ *
+ *  @param[in]  msr_floor_freq - MSR floor limit frequency value to be set in MHz
+ *
+ *  @return ::amdsmi_status_t | ::AMDSMI_STATUS_SUCCESS on success, non-zero on fail
+ */
+amdsmi_status_t amdsmi_set_cpu_msr_floor_freq_limit(amdsmi_processor_handle processor_handle,
+                                                    uint32_t msr_floor_freq);
+
+/**
+ *  @brief Set CPU core MSR floor limit frequency.
+ *
+ *  @details This function sets the MSR floor frequency limit for the specified CPU core.
+ *
+ *  @ingroup tagPerfControl
+ *
+ *  @platform{cpu_bm}
+ *
+ *  @param[in]  processor_handle CPU core which to set
+ *
+ *  @param[in]  msr_floor_freq - MSR floor limit frequency value to be set in MHz
+ *
+ *  @return ::amdsmi_status_t | ::AMDSMI_STATUS_SUCCESS on success, non-zero on fail
+ */
+amdsmi_status_t amdsmi_set_cpu_core_msr_floor_freq_limit(amdsmi_processor_handle processor_handle,
+                                                         uint32_t msr_floor_freq);
+
+/**
+ *  @brief Get the CPU socket frequency range.
+ *
+ *  @details This function retrieves frequency limit range for CPU socket 0.
+ *
+ *  @ingroup tagPerfControl
+ *
+ *  @platform{cpu_bm}
+ *
+ *  @param[out]  fmax - Output buffer to retrieve maximum frequency in MHz
+ *  @param[out]  fmin - Output buffer to retrieve minimum frequency in MHz
+ *
+ *  @return ::amdsmi_status_t | ::AMDSMI_STATUS_SUCCESS on success, non-zero on fail
+ */
+amdsmi_status_t amdsmi_get_cpu_freq_range(uint32_t *fmax, uint32_t *fmin);
+
+/**
+ *  @brief Set the SDPS(Socket DIMM Power Sloshing) limit for a given processor socket.
+ *
+ *  @ingroup tagPerfControl
+ *
+ *  @platform{cpu_bm}
+ *
+ *  @param[in]  processor_handle Processor handle for which to set the limit
+ *
+ *  @param[in]  sdps_limit - SDPS limit value in milliwatts
+ *
+ *  @return ::amdsmi_status_t | ::AMDSMI_STATUS_SUCCESS on success, non-zero on fail
+ */
+amdsmi_status_t amdsmi_set_cpu_sdps_limit(amdsmi_processor_handle processor_handle,
+                                          uint32_t sdps_limit);
+
+/**
+ *  @brief Get the current SDPS limit for a given processor socket.
+ *
+ *  @ingroup tagPerfControl
+ *
+ *  @platform{cpu_bm}
+ *
+ *  @param[in]  processor_handle Processor handle for which to query the limit
+ *  @param[out]  sdps_limit - Input buffer to receive the current SDPS limit value in watts
+ *
+ *  @return ::amdsmi_status_t | ::AMDSMI_STATUS_SUCCESS on success, non-zero on fail
+ */
+amdsmi_status_t amdsmi_get_cpu_sdps_limit(amdsmi_processor_handle processor_handle,
+                                          double *sdps_limit);
+
+/** @} End tagPerfControl */
 
 /*****************************************************************************/
 /** @defgroup tagDDRBandwidthMonitor DDR bandwidth monitor
@@ -7343,6 +7691,55 @@ amdsmi_status_t amdsmi_get_cpu_ddr_bw(amdsmi_processor_handle processor_handle,
  */
 amdsmi_status_t amdsmi_get_cpu_socket_temperature(amdsmi_processor_handle processor_handle,
                                                   uint32_t *ptmon);
+
+/**
+ *  @brief Read Thermal Delta (TDELTA) Behavior
+ *
+ *  This API retrieves the thermal solution behavior value from the CPU socket
+ *
+ *  Thermal Behavior values returned:
+ *  - 0: Thermal solution behavior is normal (operating within expected thermal range)
+ *  - 1 or any other value: Thermal solution is out of expected range (thermal stress detected)
+ *
+ *  @ingroup tagTempQuery
+ *
+ *  @platform{cpu_bm}
+ *
+ *  @param[in]  processor_handle CPU socket handle to query
+ *  @param[out]  tdelta - input buffer to store the thermal delta behavior value:
+ *  				- 0: Normal thermal solution behavior
+ *  				- Non-zero: Thermal solution out of expected range
+ *  @return ::amdsmi_status_t
+ *          ::AMDSMI_STATUS_SUCCESS on successful register read, non-zero on failure
+ */
+amdsmi_status_t amdsmi_get_cpu_tdelta(amdsmi_processor_handle processor_handle,
+                                      uint8_t *tdelta);
+
+/**
+ *  @brief Get Temperature of SVI3 VR(Voltage Rail)
+ *
+ *  This API retrieves the temperature of SVI3 voltage regulator
+ *
+ *  @ingroup tagTempQuery
+ *
+ *  @platform{cpu_bm}
+ *
+ *  @param[in]      processor_handle CPU socket handle to query
+ *
+ *  @param[in,out]  rail_selection - Input buffer to to store rail_selection, rail_selection: 0=HottestRail, 1=IndividualRail
+ *
+ *  @param[in,out]  rail_index - Input buffer to store rail_index, rail_index must be given when rail_selection = 1
+ *  					rail_index: 0->VDDCR_CPU0,1->VDDCR_CPU1,2->VDDCR_SOC,3->VDDIO,4->VDDIO_MEM_S3
+ *
+ *  @param[out]     temp - Output buffer to retrieve the temperature value
+ *
+ *  @return ::amdsmi_status_t
+ *          ::AMDSMI_STATUS_SUCCESS on successful temperature read, non-zero on failure
+ */
+amdsmi_status_t amdsmi_get_cpu_svi3_vr_controller_temp(amdsmi_processor_handle processor_handle,
+                                                       uint32_t *rail_selection,
+                                                       uint32_t *rail_index,
+                                                       uint32_t *temp);
 
 /** @} End tagTempQuery */
 
@@ -7405,6 +7802,67 @@ amdsmi_status_t amdsmi_get_cpu_dimm_power_consumption(amdsmi_processor_handle pr
 amdsmi_status_t amdsmi_get_cpu_dimm_thermal_sensor(amdsmi_processor_handle processor_handle,
                                                    uint8_t dimm_addr,
                                                    amdsmi_dimm_thermal_t *dimm_temp);
+
+/**
+ *  @brief Read DIMM sideband register data
+ *
+ *  @ingroup tagDimmStatistics
+ *
+ *  @platform{cpu_bm}
+ *
+ *  @param[in]  processor_handle Processor handle for the target socket
+ *
+ *  @param[in]  dimm_addr - DIMM address
+ *
+ *  @param[in]  lid - The local identifier of the device on DIMM
+ *
+ *  @param[in]  reg_offset - Register offset within the specified register space
+ *
+ *  @param[in]  reg_space - Register space selector:
+ *  				- 0: Volatile register space
+ *  				- 1: Non-volatile memory (NVM) register space
+ *
+ *  @param[out] data - Input buffer to store the 4-byte read data from the register
+ *
+ *  @return ::amdsmi_status_t
+ *          ::AMDSMI_STATUS_SUCCESS on successful register read, non-zero on failure
+ */
+amdsmi_status_t amdsmi_get_cpu_dimm_sb_reg(amdsmi_processor_handle processor_handle,
+                                           uint32_t dimm_addr,
+                                           uint32_t lid,
+                                           uint32_t reg_offset,
+                                           uint32_t reg_space,
+                                           uint32_t *data);
+/**
+ *  @brief Write Data to DIMM Sideband Register
+ *
+ *  @ingroup tagDimmStatistics
+ *
+ *  @platform{cpu_bm}
+ *
+ *  @param[in]  processor_handle Processor handle for the target socket
+ *
+ *  @param[in]  dimm_addr - DIMM address
+ *
+ *  @param[in]  lid - The local identifier of the device on DIMM
+ *
+ *  @param[in]  reg_offset - Register offset within the specified register space
+ *
+ *  @param[in]  reg_space - Register space selector:
+ *  				- 0: Volatile register space
+ *  				- 1: Non-volatile memory (NVM) register space
+ *
+ *  @param[in]  write_data - 4-byte data value to write to the target register
+ *
+ *  @return ::amdsmi_status_t
+ *          ::AMDSMI_STATUS_SUCCESS on successful register write, non-zero on failure
+ */
+amdsmi_status_t amdsmi_set_cpu_dimm_sb_reg(amdsmi_processor_handle processor_handle,
+                                           uint32_t dimm_addr,
+                                           uint32_t lid,
+                                           uint32_t reg_offset,
+                                           uint32_t reg_space,
+                                           uint32_t write_data);
 
 /** @} End tagDimmStatistics */
 
@@ -7556,14 +8014,155 @@ amdsmi_status_t amdsmi_set_cpu_pcie_link_rate(amdsmi_processor_handle processor_
  *
  *  @param[in]  processor_handle Cpu socket which to query
  *
- *  @param[in]  max_pstate - maximum pstate value to be set
- *
  *  @param[in]  min_pstate - minimum pstate value to be set
+ *
+ *  @param[in]  max_pstate - maximum pstate value to be set
  *
  *  @return ::amdsmi_status_t | ::AMDSMI_STATUS_SUCCESS on success, non-zero on fail
  */
 amdsmi_status_t amdsmi_set_cpu_df_pstate_range(amdsmi_processor_handle processor_handle,
-                                               uint8_t max_pstate, uint8_t min_pstate);
+                                               uint8_t min_pstate, uint8_t max_pstate);
+
+/**
+ *  @brief Set the Min and Max XGMI PState Range
+ *
+ *  This API configures the XGMI P-State range for the specified processor socket.
+ *
+ *  P-State range constraints:
+ *  - min_pstate: Minimum allowed XGMI P-State
+ *  - max_pstate: Maximum allowed XGMI P-State
+ *  - Constraint: max_pstate <= min_pstate
+ *
+ *  @ingroup tagPstateSelect
+ *
+ *  @platform{cpu_bm}
+ *
+ *  @param[in]  processor_handle Cpu socket which to configure
+ *
+ *  @param[in]  min_pstate - minimum XGMI P-State value
+ *
+ *  @param[in]  max_pstate - maximum XGMI P-State value
+ *
+ *  @return ::amdsmi_status_t | ::AMDSMI_STATUS_SUCCESS on success, non-zero on fail
+ */
+amdsmi_status_t amdsmi_set_cpu_xgmi_pstate_range(amdsmi_processor_handle processor_handle,
+                                                 uint8_t min_pstate, uint8_t max_pstate);
+
+/**
+ *  @brief Get the Max and Min XGMI PState Range
+ *
+ *  This API retrieves the current XGMI P-State range configuration for the specified processor socket.
+ *
+ *  P-State range values returned:
+ *  - min_pstate: Current minimum XGMI P-State setting
+ *  - max_pstate: Current maximum XGMI P-State setting
+ *  - Relationship: max_pstate <= min_pstate
+ *
+ *  @ingroup tagPstateSelect
+ *
+ *  @platform{cpu_bm}
+ *
+ *  @param[in]  processor_handle Cpu socket which to query
+ *
+ *  @param[out]  min_pstate - Input buffer to store current minimum XGMI P-State value
+ *
+ *  @param[out]  max_pstate - Input buffer to store current maximum XGMI P-State value
+ *
+ *  @return ::amdsmi_status_t | ::AMDSMI_STATUS_SUCCESS on success, non-zero on fail
+ */
+amdsmi_status_t amdsmi_get_cpu_xgmi_pstate_range(amdsmi_processor_handle processor_handle,
+                                                 uint8_t *min_pstate, uint8_t *max_pstate);
+
+/**
+ *  @brief Get the PC6 Enable State
+ *
+ *  This API retrieves the current PC6 (Package C-state 6) enable state for the specified processor socket.
+ *
+ *  PC6 enable state values returned:
+ *  - 0: PC6 disabled
+ *  - 1: PC6 enabled
+ *
+ *  @ingroup tagPstateSelect
+ *
+ *  @platform{cpu_bm}
+ *
+ *  @param[in]  processor_handle Cpu socket which to query
+ *
+ *  @param[out]  enabled - Input buffer to store the current PC6 enable state
+ *
+ *  @return ::amdsmi_status_t | ::AMDSMI_STATUS_SUCCESS on success, non-zero on fail
+ */
+amdsmi_status_t amdsmi_get_cpu_pc6_enable(amdsmi_processor_handle processor_handle,
+                                          uint8_t *enabled);
+
+/**
+ *  @brief Set the PC6 Enable State
+ *
+ *  This API configures the PC6 (Package C-state 6) enable state for the specified processor socket.
+ *
+ *  PC6 enable state values:
+ *  - 0: PC6 disabled
+ *  - 1: PC6 enabled
+ *
+ *  @ingroup tagPstateSelect
+ *
+ *  @platform{cpu_bm}
+ *
+ *  @param[in]  processor_handle Cpu socket which to configure
+ *
+ *  @param[in]  enable - PC6 enable state (0=disable, 1=enable)
+ *
+ *  @return ::amdsmi_status_t | ::AMDSMI_STATUS_SUCCESS on success, non-zero on fail
+ */
+amdsmi_status_t amdsmi_set_cpu_pc6_enable(amdsmi_processor_handle processor_handle,
+                                          uint8_t enable);
+
+/**
+ *  @brief Get the Core C6 Enable State.
+ *
+ *  This API retrieves the Core C6 (CC6) low-power state for the specified processor socket.
+ *
+ *  CC6 enable state values returned:
+ *  - 0: CC6 state disabled
+ *  - 1: CC6 state enabled
+ *
+ *  @ingroup tagPstateSelect
+ *
+ *  @platform{cpu_bm}
+ *
+ *  @param[in]      processor_handle Cpu socket which to query
+ *
+ *  @param[in,out]  enabled - Input buffer to store the current CC6 enable state
+ *
+ *  @return ::amdsmi_status_t
+ *          ::AMDSMI_STATUS_SUCCESS on success, non-zero on failure
+ */
+amdsmi_status_t amdsmi_get_cpu_cc6_enable(amdsmi_processor_handle processor_handle,
+                                          uint8_t *enabled);
+
+/**
+ *  @brief Set the Core C6 Enable State.
+ *
+ *  This API configures the Core C6 (CC6) low-power state for the specified processor socket.
+ *
+ *  CC6 enable state values:
+ *  - 0: Disable CC6 state
+ *  - 1: Enable CC6 state
+ *
+ *  @ingroup tagPstateSelect
+ *
+ *  @platform{cpu_bm}
+ *
+ *  @param[in]  processor_handle Cpu socket which to configure
+ *
+ *  @param[in]  enable - CC6 enable state value:
+ *  			- 0: Disable CC6 low-power state
+ *  			- 1: Enable CC6 low-power state
+ *
+ *  @return ::amdsmi_status_t | ::AMDSMI_STATUS_SUCCESS on success, non-zero on fail
+ */
+amdsmi_status_t amdsmi_set_cpu_cc6_enable(amdsmi_processor_handle processor_handle,
+                                          uint8_t enable);
 
 /** @} End tagPstateSelect */
 
@@ -7768,115 +8367,31 @@ amdsmi_status_t amdsmi_get_cpu_cores_per_socket(uint32_t sock_count, amdsmi_sock
  */
 amdsmi_status_t amdsmi_get_cpu_socket_count(uint32_t *sock_count);
 
-/** @} End tagCPUAuxillary */
-
 /**
- *  @brief Set the CPU Rail Isofrequency Policy
+ *  @brief Get HSMP Enabled Commands information for a given CPU socket.
  *
- *  This API configures the frequency policy for CPU power rails.
- *  - If a socket-wide limit (e.g., PPT) is setting the core clock frequency, this setting has no effect.
- *  - For other limiters specific to CPU power rails (e.g., TDC),
- *  this policy enables or disables independent core clocks per rail (VDDCR_CPU0 or VDDCR_CPU1).
+ *  @details This function retrieves enabled commands bit masks for both read and write commands
+ *  from the HSMP interface.
  *
- *  Policy values:
- *  - 0: Disable independent control (all cores on both rails have the same frequency limit)
- *  - 1: Enable independent control (each rail has an independent frequency limit)
- *
- *  @ingroup tagCpuISOFreqPolicy
+ *  @ingroup tagCPUAuxillary
  *
  *  @platform{cpu_bm}
  *
- *  @param[in]  processor_handle Cpu socket which to query
+ *  @param[in]  processor_handle CPU socket handle to query
+ *  @param[in]  r_mask - Input buffer to store read mask, indicating read or write enabled commands to query
+ *  @param[in,out]  mask0 - Input buffer to store read/write enabled hsmp command mask0
+ *  @param[in,out]  mask1 - Input buffer to store read/write enabled hsmp command mask1
+ *  @param[in,out]  mask2 - Input buffer to store read/write enabled hsmp command mask2
  *
- *  @param[in] input   Input policy value indicating the isofrequency setting:
- *                     - 0: Enable independent control - each rail has its own independent frequency limit.
- *                     - 1: Disable independent control - all cores on both rails share the same frequency limit.
  *  @return ::amdsmi_status_t | ::AMDSMI_STATUS_SUCCESS on success, non-zero on fail
  */
-amdsmi_status_t amdsmi_set_cpu_rail_isofreq_policy(amdsmi_processor_handle processor_handle,
-                                                   uint8_t input);
+amdsmi_status_t amdsmi_get_cpu_enabled_commands(amdsmi_processor_handle processor_handle,
+                                                bool  *r_mask,
+                                                uint32_t *mask0,
+                                                uint32_t *mask1,
+                                                uint32_t *mask2);
 
-/**
- *  @brief Get the CPU Rail Isofrequency Policy.
- *
- *  This API retrieves the current frequency policy configuration for CPU power rails.
- *  - If a socket-wide limit (e.g., PPT) is setting the core clock frequency, the effective policy may be overridden.
- *  - For other limiters specific to CPU power rails (e.g., TDC),
- *    this policy indicates whether independent core clocks per rail (VDDCR_CPU0 or VDDCR_CPU1) are enabled or disabled.
- *
- *  Cpu rail iso policy values returned:
- *  - 0: Independent control disabled (all cores on both rails have the same frequency limit)
- *  - 1: Independent control enabled (each rail has an independent frequency limit)
- *
- *  @ingroup tagCpuISOFreqPolicy
- *
- *  @platform{cpu_bm}
- *
- *  @param[in]      processor_handle Cpu socket which to query
- *
- *  @param[in,out]  cpurailiso to receive the current policy state
- *
- *  @return ::amdsmi_status_t
- *          ::AMDSMI_STATUS_SUCCESS on success, non-zero on failure
- */
-amdsmi_status_t amdsmi_get_cpu_rail_isofreq_policy(amdsmi_processor_handle processor_handle,
-                                                   uint8_t *cpurailiso);
-
-/** @} End tagCpuISOFreqPolicy */
-
-/**
- *  @brief Set the DFCState enabling control.
- *
- *  DFCState is a low power state used for I/O Die (IOD).
- *
- *  Note:
- *  - This feature cannot be enabled unless it was enabled by the BIOS during POST.
- *  - Use this API to enable or disable DFCState control.
- *
- *  DFCState control values for setting:
- *  - 0: Disable DFC control
- *  - 1: Enable DFC control
- *
- *  @ingroup tagDFCEnableControl
- *
- *  @platform{cpu_bm}
- *
- *  @param[in] processor_handle Cpu socket handle to query
- *
- *  @param[in] dfc_ctrl        indicating whether to enable (1) or disable (0) DFC control
- *
- *  @return ::amdsmi_status_t
- *          ::AMDSMI_STATUS_SUCCESS on success, non-zero on failure
- */
-amdsmi_status_t amdsmi_set_dfc_ctrl(amdsmi_processor_handle processor_handle, bool dfc_ctrl);
-
-/**
- *  @brief Get the current DFCState enabling control status.
- *
- *  DFCState is a low power state used for I/O Die (IOD).
- *
- *  Note:
- *  - This feature can only be enabled if it was enabled by the BIOS during POST.
- *  - This API retrieves whether DFC control is currently enabled or disabled.
- *
- *  Returned DFCState control values:
- *  - 0: DFC control is disabled
- *  - 1: DFC control is enabled
- *
- *  @ingroup tagDFCEnableControl
- *
- *  @platform{cpu_bm}
- *
- *  @param[in]      processor_handle Cpu socket handle to query
- *
- *  @param[in,out]  dfc_ctrl to receive the current DFCState control status
- *
- *  @return ::amdsmi_status_t
- *          ::AMDSMI_STATUS_SUCCESS on success, non-zero on failure
- */
-amdsmi_status_t amdsmi_get_dfc_ctrl(amdsmi_processor_handle processor_handle, uint8_t *dfc_ctrl);
-
-/** @} End tagDFCEnableControl */
+/** @} End tagCPUAuxillary */
 
 #endif
 

--- a/projects/amdsmi/include/amd_smi/impl/amd_hsmp.h
+++ b/projects/amdsmi/include/amd_smi/impl/amd_hsmp.h
@@ -13,80 +13,90 @@
  * HSMP Messages supported
  */
 enum hsmp_message_ids {
-    HSMP_TEST = 1,                  /* 01h Increments input value by 1 */
-    HSMP_GET_SMU_VER,               /* 02h SMU FW version */
-    HSMP_GET_PROTO_VER,             /* 03h HSMP interface version */
-    HSMP_GET_SOCKET_POWER,          /* 04h average package power consumption */
-    HSMP_SET_SOCKET_POWER_LIMIT,    /* 05h Set the socket power limit */
-    HSMP_GET_SOCKET_POWER_LIMIT,    /* 06h Get current socket power limit */
-    HSMP_GET_SOCKET_POWER_LIMIT_MAX,/* 07h Get maximum socket power value */
-    HSMP_SET_BOOST_LIMIT,           /* 08h Set a core maximum frequency limit */
-    HSMP_SET_BOOST_LIMIT_SOCKET,    /* 09h Set socket maximum frequency level */
-    HSMP_GET_BOOST_LIMIT,           /* 0Ah Get current frequency limit */
-    HSMP_GET_PROC_HOT,              /* 0Bh Get PROCHOT status */
-    HSMP_SET_XGMI_LINK_WIDTH,       /* 0Ch Set max and min width of xGMI Link */
-    HSMP_SET_DF_PSTATE,             /* 0Dh Alter APEnable/Disable messages behavior */
-    HSMP_SET_AUTO_DF_PSTATE,        /* 0Eh Enable DF P-State Performance Boost algorithm */
-    HSMP_GET_FCLK_MCLK,             /* 0Fh Get FCLK and MEMCLK for current socket */
-    HSMP_GET_CCLK_THROTTLE_LIMIT,   /* 10h Get CCLK frequency limit in socket */
-    HSMP_GET_C0_PERCENT,            /* 11h Get average C0 residency in socket */
-    HSMP_SET_NBIO_DPM_LEVEL,        /* 12h Set max/min LCLK DPM Level for a given NBIO */
-    HSMP_GET_NBIO_DPM_LEVEL,        /* 13h Get LCLK DPM level min and max for a given NBIO */
-    HSMP_GET_DDR_BANDWIDTH,         /* 14h Get theoretical maximum and current DDR Bandwidth */
-    HSMP_GET_TEMP_MONITOR,          /* 15h Get socket temperature */
-    HSMP_GET_DIMM_TEMP_RANGE,       /* 16h Get per-DIMM temperature range and refresh rate */
-    HSMP_GET_DIMM_POWER,            /* 17h Get per-DIMM power consumption */
-    HSMP_GET_DIMM_THERMAL,          /* 18h Get per-DIMM thermal sensors */
-    HSMP_GET_SOCKET_FREQ_LIMIT,     /* 19h Get current active frequency per socket */
-    HSMP_GET_CCLK_CORE_LIMIT,       /* 1Ah Get CCLK frequency limit per core */
-    HSMP_GET_RAILS_SVI,             /* 1Bh Get SVI-based Telemetry for all rails */
-    HSMP_GET_SOCKET_FMAX_FMIN,      /* 1Ch Get Fmax and Fmin per socket */
-    HSMP_GET_IOLINK_BANDWITH,       /* 1Dh Get current bandwidth on IO Link */
-    HSMP_GET_XGMI_BANDWITH,         /* 1Eh Get current bandwidth on xGMI Link */
-    HSMP_SET_GMI3_WIDTH,            /* 1Fh Set max and min GMI3 Link width */
-    HSMP_SET_PCI_RATE,              /* 20h Control link rate on PCIe devices */
-    HSMP_SET_POWER_MODE,            /* 21h Select power efficiency profile policy */
-    HSMP_SET_PSTATE_MAX_MIN,        /* 22h Set the max and min DF P-State  */
-    HSMP_GET_METRIC_TABLE_VER,      /* 23h Get metrics table version */
-    HSMP_GET_METRIC_TABLE,          /* 24h Get metrics table */
-    HSMP_GET_METRIC_TABLE_DRAM_ADDR,/* 25h Get metrics table dram address */
-    HSMP_SET_XGMI_PSTATE_RANGE,     /* 26h Set xGMI P-state range */
-    HSMP_CPU_RAIL_ISO_FREQ_POLICY,  /* 27h Get/Set Cpu Iso frequency policy */
-    HSMP_DFC_ENABLE_CTRL,           /* 28h Enable/Disable DF C-state */
-    HSMP_GET_RAPL_UNITS = 0x30,     /* 30h Get scaling factor for energy */
-    HSMP_GET_RAPL_CORE_COUNTER,     /* 31h Get core energy counter value */
-    HSMP_GET_RAPL_PACKAGE_COUNTER,  /* 32h Get package energy counter value */
-    HSMP_MSG_ID_MAX,
+	HSMP_TEST = 1,			/* 01h Increments input value by 1 */
+	HSMP_GET_SMU_VER,		/* 02h SMU FW version */
+	HSMP_GET_PROTO_VER,		/* 03h HSMP interface version */
+	HSMP_GET_SOCKET_POWER,		/* 04h average package power consumption */
+	HSMP_SET_SOCKET_POWER_LIMIT,	/* 05h Set the socket power limit */
+	HSMP_GET_SOCKET_POWER_LIMIT,	/* 06h Get current socket power limit */
+	HSMP_GET_SOCKET_POWER_LIMIT_MAX,/* 07h Get maximum socket power value */
+	HSMP_SET_BOOST_LIMIT,		/* 08h Set a core maximum frequency limit */
+	HSMP_SET_BOOST_LIMIT_SOCKET,	/* 09h Set socket maximum frequency level */
+	HSMP_GET_BOOST_LIMIT,		/* 0Ah Get current frequency limit */
+	HSMP_GET_PROC_HOT,		/* 0Bh Get PROCHOT status */
+	HSMP_SET_XGMI_LINK_WIDTH,	/* 0Ch Set max and min width of xGMI Link */
+	HSMP_SET_DF_PSTATE,		/* 0Dh Alter APEnable/Disable messages behavior */
+	HSMP_SET_AUTO_DF_PSTATE,	/* 0Eh Enable DF P-State Performance Boost algorithm */
+	HSMP_GET_FCLK_MCLK,		/* 0Fh Get FCLK and MEMCLK for current socket */
+	HSMP_GET_CCLK_THROTTLE_LIMIT,	/* 10h Get CCLK frequency limit in socket */
+	HSMP_GET_C0_PERCENT,		/* 11h Get average C0 residency in socket */
+	HSMP_SET_NBIO_DPM_LEVEL,	/* 12h Set max/min LCLK DPM Level for a given NBIO */
+	HSMP_GET_NBIO_DPM_LEVEL,	/* 13h Get LCLK DPM level min and max for a given NBIO */
+	HSMP_GET_DDR_BANDWIDTH,		/* 14h Get theoretical maximum and current DDR Bandwidth */
+	HSMP_GET_TEMP_MONITOR,		/* 15h Get socket temperature */
+	HSMP_GET_DIMM_TEMP_RANGE,	/* 16h Get per-DIMM temperature range and refresh rate */
+	HSMP_GET_DIMM_POWER,		/* 17h Get per-DIMM power consumption */
+	HSMP_GET_DIMM_THERMAL,		/* 18h Get per-DIMM thermal sensors */
+	HSMP_GET_SOCKET_FREQ_LIMIT,	/* 19h Get current active frequency per socket */
+	HSMP_GET_CCLK_CORE_LIMIT,	/* 1Ah Get CCLK frequency limit per core */
+	HSMP_GET_RAILS_SVI,		/* 1Bh Get SVI-based Telemetry for all rails */
+	HSMP_GET_SOCKET_FMAX_FMIN,	/* 1Ch Get Fmax and Fmin per socket */
+	HSMP_GET_IOLINK_BANDWITH,	/* 1Dh Get current bandwidth on IO Link */
+	HSMP_GET_XGMI_BANDWITH,		/* 1Eh Get current bandwidth on xGMI Link */
+	HSMP_SET_GMI3_WIDTH,		/* 1Fh Set max and min GMI3 Link width */
+	HSMP_SET_PCI_RATE,		/* 20h Control link rate on PCIe devices */
+	HSMP_SET_POWER_MODE,		/* 21h Select power efficiency profile policy */
+	HSMP_SET_PSTATE_MAX_MIN,	/* 22h Set the max and min DF P-State  */
+	HSMP_GET_METRIC_TABLE_VER,	/* 23h Get metrics table version */
+	HSMP_GET_METRIC_TABLE,		/* 24h Get metrics table */
+	HSMP_GET_METRIC_TABLE_DRAM_ADDR,/* 25h Get metrics table dram address */
+	HSMP_SET_XGMI_PSTATE_RANGE,	/* 26h Set xGMI P-state range */
+	HSMP_CPU_RAIL_ISO_FREQ_POLICY,	/* 27h Get/Set Cpu Iso frequency policy */
+	HSMP_DFC_ENABLE_CTRL,		/* 28h Enable/Disable DF C-state */
+	HSMP_PC6_ENABLE,		/* 29h Get/Set PC6 Enable/Disable Status */
+	HSMP_CC6_ENABLE,		/* 2Ah Get/Set CC6 Enable/Disable Status */
+	HSMP_GET_RAPL_UNITS = 0x30,	/* 30h Get scaling factor for energy */
+	HSMP_GET_RAPL_CORE_COUNTER,	/* 31h Get core energy counter value */
+	HSMP_GET_RAPL_PACKAGE_COUNTER,	/* 32h Get package energy counter value */
+	HSMP_DIMM_SB_RD,		/* 33h Get data from a specified device on the DIMM.*/
+	HSMP_READ_CCD_POWER,		/* 34h Get the average power consumed by CCD */
+	HSMP_READ_TDELTA,		/* 35h Get thermal solution behaviour */
+	HSMP_GET_SVI3_VR_CTRL_TEMP,	/* 36h Get temperature of SVI3 VR controlller rails */
+	HSMP_GET_ENABLED_HSMP_CMDS,	/* 37h Get/Set supported HSMP commands */
+	HSMP_SET_GET_FLOOR_LIMIT,       /* 38h Get/Set supported Floor Limit commands */
+	HSMP_DIMM_SB_WR,                /* 39h Set data to a specified device on the DIMM.*/
+	HSMP_SDPS_LIMIT,                /* 3Ah Get/Set SDPSLimit. */
+	HSMP_MSG_ID_MAX,
 };
 
 struct hsmp_message {
-    __u32    msg_id;                /* Message ID */
-    __u16    num_args;              /* Number of input argument words in message */
-    __u16    response_sz;           /* Number of expected output/response words */
-    __u32    args[HSMP_MAX_MSG_LEN];/* argument/response buffer */
-    __u16    sock_ind;              /* socket number */
+	__u32	msg_id;			/* Message ID */
+	__u16	num_args;		/* Number of input argument words in message */
+	__u16	response_sz;		/* Number of expected output/response words */
+	__u32	args[HSMP_MAX_MSG_LEN];	/* argument/response buffer */
+	__u16	sock_ind;		/* socket number */
 };
 
 enum hsmp_msg_type {
-    HSMP_RSVD    = -1,
-    HSMP_SET     = 0,
-    HSMP_GET     = 1,
-    HSMP_SET_GET = 2,
+	HSMP_RSVD	= -1,
+	HSMP_SET	= 0,
+	HSMP_GET	= 1,
+	HSMP_SET_GET 	= 2,
 };
 
 enum hsmp_proto_versions {
-    HSMP_PROTO_VER2 = 2,
-    HSMP_PROTO_VER3,
-    HSMP_PROTO_VER4,
-    HSMP_PROTO_VER5,
-    HSMP_PROTO_VER6,
-    HSMP_PROTO_VER7
+	HSMP_PROTO_VER2	= 2,
+	HSMP_PROTO_VER3,
+	HSMP_PROTO_VER4,
+	HSMP_PROTO_VER5,
+	HSMP_PROTO_VER6,
+	HSMP_PROTO_VER7
 };
 
 struct hsmp_msg_desc {
-    int num_args;
-    int response_sz;
-    enum hsmp_msg_type type;
+	int num_args;
+	int response_sz;
+	enum hsmp_msg_type type;
 };
 
 /*
@@ -97,380 +107,488 @@ struct hsmp_msg_desc {
  * Not supported messages would return -ENOMSG.
  */
 static const struct hsmp_msg_desc hsmp_msg_desc_table[] = {
-    /* RESERVED */
-    {0, 0, HSMP_RSVD},
+	/* RESERVED */
+	{0, 0, HSMP_RSVD},
 
-    /*
-     * HSMP_TEST, num_args = 1, response_sz = 1
-     * input:  args[0] = xx
-     * output: args[0] = xx + 1
-     */
-    {1, 1, HSMP_GET},
+	/*
+	 * HSMP_TEST, num_args = 1, response_sz = 1
+	 * input:  args[0] = xx
+	 * output: args[0] = xx + 1
+	 */
+	{1, 1, HSMP_GET},
 
-    /*
-     * HSMP_GET_SMU_VER, num_args = 0, response_sz = 1
-     * output: args[0] = smu fw ver
-     */
-    {0, 1, HSMP_GET},
+	/*
+	 * HSMP_GET_SMU_VER, num_args = 0, response_sz = 1
+	 * output: args[0] = smu fw ver
+	 */
+	{0, 1, HSMP_GET},
 
-    /*
-     * HSMP_GET_PROTO_VER, num_args = 0, response_sz = 1
-     * output: args[0] = proto version
-     */
-    {0, 1, HSMP_GET},
+	/*
+	 * HSMP_GET_PROTO_VER, num_args = 0, response_sz = 1
+	 * output: args[0] = proto version
+	 */
+	{0, 1, HSMP_GET},
 
-    /*
-     * HSMP_GET_SOCKET_POWER, num_args = 0, response_sz = 1
-     * output: args[0] = socket power in mWatts
-     */
-    {0, 1, HSMP_GET},
+	/*
+	 * HSMP_GET_SOCKET_POWER, num_args = 0, response_sz = 1
+	 * output: args[0] = socket power in mWatts
+	 */
+	{0, 1, HSMP_GET},
 
-    /*
-     * HSMP_SET_SOCKET_POWER_LIMIT, num_args = 1, response_sz = 0
-     * input: args[0] = power limit value in mWatts
-     */
-    {1, 0, HSMP_SET},
+	/*
+	 * HSMP_SET_SOCKET_POWER_LIMIT, num_args = 1, response_sz = 0
+	 * input: args[0] = power limit value in mWatts
+	 */
+	{1, 0, HSMP_SET},
 
-    /*
-     * HSMP_GET_SOCKET_POWER_LIMIT, num_args = 0, response_sz = 1
-     * output: args[0] = socket power limit value in mWatts
-     */
-    {0, 1, HSMP_GET},
+	/*
+	 * HSMP_GET_SOCKET_POWER_LIMIT, num_args = 0, response_sz = 1
+	 * output: args[0] = socket power limit value in mWatts
+	 */
+	{0, 1, HSMP_GET},
 
-    /*
-     * HSMP_GET_SOCKET_POWER_LIMIT_MAX, num_args = 0, response_sz = 1
-     * output: args[0] = maximuam socket power limit in mWatts
-     */
-    {0, 1, HSMP_GET},
+	/*
+	 * HSMP_GET_SOCKET_POWER_LIMIT_MAX, num_args = 0, response_sz = 1
+	 * output: args[0] = maximuam socket power limit in mWatts
+	 */
+	{0, 1, HSMP_GET},
 
-    /*
-     * HSMP_SET_BOOST_LIMIT, num_args = 1, response_sz = 0
-     * input: args[0] = apic id[31:16] + boost limit value in MHz[15:0]
-     */
-    {1, 0, HSMP_SET},
+	/*
+	 * HSMP_SET_BOOST_LIMIT, num_args = 1, response_sz = 0
+	 * input: args[0] = apic id[31:16] + boost limit value in MHz[15:0]
+	 */
+	{1, 0, HSMP_SET},
 
-    /*
-     * HSMP_SET_BOOST_LIMIT_SOCKET, num_args = 1, response_sz = 0
-     * input: args[0] = boost limit value in MHz
-     */
-    {1, 0, HSMP_SET},
+	/*
+	 * HSMP_SET_BOOST_LIMIT_SOCKET, num_args = 1, response_sz = 0
+	 * input: args[0] = boost limit value in MHz
+	 */
+	{1, 0, HSMP_SET},
 
-    /*
-     * HSMP_GET_BOOST_LIMIT, num_args = 1, response_sz = 1
-     * input: args[0] = apic id
-     * output: args[0] = boost limit value in MHz
-     */
-    {1, 1, HSMP_GET},
+	/*
+	 * HSMP_GET_BOOST_LIMIT, num_args = 1, response_sz = 1
+	 * input: args[0] = apic id
+	 * output: args[0] = boost limit value in MHz
+	 */
+	{1, 1, HSMP_GET},
 
-    /*
-     * HSMP_GET_PROC_HOT, num_args = 0, response_sz = 1
-     * output: args[0] = proc hot status
-     */
-    {0, 1, HSMP_GET},
+	/*
+	 * HSMP_GET_PROC_HOT, num_args = 0, response_sz = 1
+	 * output: args[0] = proc hot status
+	 */
+	{0, 1, HSMP_GET},
 
-    /*
-     * HSMP_SET_XGMI_LINK_WIDTH, num_args = 1, response_sz = 0
-     * input: args[0] = min link width[15:8] + max link width[7:0]
-     */
-    {1, 0, HSMP_SET},
+	/*
+	 * HSMP_SET_XGMI_LINK_WIDTH, num_args = 1, response_sz = 0/1
+	 * input: args[0] = set/get XGMI Link width[31] + min link width[15:8] + max link width[7:0]
+	 * output: args[0] = current min link width[15:8] + current max link width[7:0]
+	 */
+	{1, 1, HSMP_SET_GET},
 
-    /*
-     * HSMP_SET_DF_PSTATE, num_args = 1, response_sz = 0
-     * input: args[0] = df pstate[7:0]
-     */
-    {1, 0, HSMP_SET},
+	/*
+	 * HSMP_SET_DF_PSTATE, num_args = 1, response_sz = 0/1
+	 * input: args[0] = set/get df pstate[31] + df pstate[7:0]
+	* output: args[0] = APB Enabled/Disabled[8]+current df pstate[7:0]
+	 */
+	{1, 1, HSMP_SET_GET},
 
-    /* HSMP_SET_AUTO_DF_PSTATE, num_args = 0, response_sz = 0 */
-    {0, 0, HSMP_SET},
+	/* HSMP_SET_AUTO_DF_PSTATE, num_args = 0, response_sz = 0 */
+	{0, 0, HSMP_SET},
 
-    /*
-     * HSMP_GET_FCLK_MCLK, num_args = 0, response_sz = 2
-     * output: args[0] = fclk in MHz, args[1] = mclk in MHz
-     */
-    {0, 2, HSMP_GET},
+	/*
+	 * HSMP_GET_FCLK_MCLK, num_args = 0, response_sz = 2
+	 * output: args[0] = fclk in MHz, args[1] = mclk in MHz
+	 */
+	{0, 2, HSMP_GET},
 
-    /*
-     * HSMP_GET_CCLK_THROTTLE_LIMIT, num_args = 0, response_sz = 1
-     * output: args[0] = core clock in MHz
-     */
-    {0, 1, HSMP_GET},
+	/*
+	 * HSMP_GET_CCLK_THROTTLE_LIMIT, num_args = 0, response_sz = 1
+	 * output: args[0] = core clock in MHz
+	 */
+	{0, 1, HSMP_GET},
 
-    /*
-     * HSMP_GET_C0_PERCENT, num_args = 0, response_sz = 1
-     * output: args[0] = average c0 residency
-     */
-    {0, 1, HSMP_GET},
+	/*
+	 * HSMP_GET_C0_PERCENT, num_args = 0, response_sz = 1
+	 * output: args[0] = average c0 residency
+	 */
+	{0, 1, HSMP_GET},
 
-    /*
-     * HSMP_SET_NBIO_DPM_LEVEL, num_args = 1, response_sz = 0
-     * input: args[0] = nbioid[23:16] + max dpm level[15:8] + min dpm level[7:0]
-     */
-    {1, 0, HSMP_SET},
+	/*
+	 * HSMP_SET_NBIO_DPM_LEVEL, num_args = 1, response_sz = 0
+	 * input: args[0] = nbioid[23:16] + max dpm level[15:8] + min dpm level[7:0]
+	 */
+	{1, 0, HSMP_SET},
 
-    /*
-     * HSMP_GET_NBIO_DPM_LEVEL, num_args = 1, response_sz = 1
-     * input: args[0] = nbioid[23:16]
-     * output: args[0] = max dpm level[15:8] + min dpm level[7:0]
-     */
-    {1, 1, HSMP_GET},
+	/*
+	 * HSMP_GET_NBIO_DPM_LEVEL, num_args = 1, response_sz = 1
+	 * input: args[0] = nbioid[23:16]
+	 * output: args[0] = max dpm level[15:8] + min dpm level[7:0]
+	 */
+	{1, 1, HSMP_GET},
 
-    /*
-     * HSMP_GET_DDR_BANDWIDTH, num_args = 0, response_sz = 1
-     * output: args[0] = max bw in Gbps[31:20] + utilised bw in Gbps[19:8] +
-     * bw in percentage[7:0]
-     */
-    {0, 1, HSMP_GET},
+	/*
+	 * HSMP_GET_DDR_BANDWIDTH, num_args = 0, response_sz = 1
+	 * output: args[0] = max bw in Gbps[31:20] + utilised bw in Gbps[19:8] +
+	 * bw in percentage[7:0]
+	 */
+	{0, 1, HSMP_GET},
 
-    /*
-     * HSMP_GET_TEMP_MONITOR, num_args = 0, response_sz = 1
-     * output: args[0] = temperature in degree celsius. [15:8] integer part +
-     * [7:5] fractional part
-     */
-    {0, 1, HSMP_GET},
+	/*
+	 * HSMP_GET_TEMP_MONITOR, num_args = 0, response_sz = 1
+	 * output: args[0] = temperature in degree celsius. [15:8] integer part +
+	 * [7:5] fractional part
+	 */
+	{0, 1, HSMP_GET},
 
-    /*
-     * HSMP_GET_DIMM_TEMP_RANGE, num_args = 1, response_sz = 1
-     * input: args[0] = DIMM address[7:0]
-     * output: args[0] = refresh rate[3] + temperature range[2:0]
-     */
-    {1, 1, HSMP_GET},
+	/*
+	 * HSMP_GET_DIMM_TEMP_RANGE, num_args = 1, response_sz = 1
+	 * input: args[0] = DIMM address[7:0]
+	 * output: args[0] = refresh rate[3] + temperature range[2:0]
+	 */
+	{1, 1, HSMP_GET},
 
-    /*
-     * HSMP_GET_DIMM_POWER, num_args = 1, response_sz = 1
-     * input: args[0] = DIMM address[7:0]
-     * output: args[0] = DIMM power in mW[31:17] + update rate in ms[16:8] +
-     * DIMM address[7:0]
-     */
-    {1, 1, HSMP_GET},
+	/*
+	 * HSMP_GET_DIMM_POWER, num_args = 1, response_sz = 1
+	 * input: args[0] = DIMM address[7:0]
+	 * output: args[0] = DIMM power in mW[31:17] + update rate in ms[16:8] +
+	 * DIMM address[7:0]
+	 */
+	{1, 1, HSMP_GET},
 
-    /*
-     * HSMP_GET_DIMM_THERMAL, num_args = 1, response_sz = 1
-     * input: args[0] = DIMM address[7:0]
-     * output: args[0] = temperature in degree celsius[31:21] + update rate in ms[16:8] +
-     * DIMM address[7:0]
-     */
-    {1, 1, HSMP_GET},
+	/*
+	 * HSMP_GET_DIMM_THERMAL, num_args = 1, response_sz = 1
+	 * input: args[0] = DIMM address[7:0]
+	 * output: args[0] = temperature in degree celcius[31:21] + update rate in ms[16:8] +
+	 * DIMM address[7:0]
+	 */
+	{1, 1, HSMP_GET},
 
-    /*
-     * HSMP_GET_SOCKET_FREQ_LIMIT, num_args = 0, response_sz = 1
-     * output: args[0] = frequency in MHz[31:16] + frequency source[15:0]
-     */
-    {0, 1, HSMP_GET},
+	/*
+	 * HSMP_GET_SOCKET_FREQ_LIMIT, num_args = 0, response_sz = 1
+	 * output: args[0] = frequency in MHz[31:16] + frequency source[15:0]
+	 */
+	{0, 1, HSMP_GET},
 
-    /*
-     * HSMP_GET_CCLK_CORE_LIMIT, num_args = 1, response_sz = 1
-     * input: args[0] = apic id of the core[31:0]
-     * output: args[0] = frequency in MHz[31:0]
-     */
-    {1, 1, HSMP_GET},
+	/*
+	 * HSMP_GET_CCLK_CORE_LIMIT, num_args = 1, response_sz = 1
+	 * input: args[0] = apic id of the core[31:0]
+	 * output: args[0] = frequency in MHz[31:0]
+	 */
+	{1, 1, HSMP_GET},
 
-    /*
-     * HSMP_GET_RAILS_SVI, num_args = 0, response_sz = 1
-     * output: args[0] = power in mW[31:0]
-     */
-    {0, 1, HSMP_GET},
+	/*
+	 * HSMP_GET_RAILS_SVI, num_args = 0, response_sz = 1
+	 * output: args[0] = power in mW[31:0]
+	 */
+	{0, 1, HSMP_GET},
 
-    /*
-     * HSMP_GET_SOCKET_FMAX_FMIN, num_args = 0, response_sz = 1
-     * output: args[0] = fmax in MHz[31:16] + fmin in MHz[15:0]
-     */
-    {0, 1, HSMP_GET},
+	/*
+	 * HSMP_GET_SOCKET_FMAX_FMIN, num_args = 0, response_sz = 1
+	 * output: args[0] = fmax in MHz[31:16] + fmin in MHz[15:0]
+	 */
+	{0, 1, HSMP_GET},
 
-    /*
-     * HSMP_GET_IOLINK_BANDWITH, num_args = 1, response_sz = 1
-     * input: args[0] = link id[15:8] + bw type[2:0]
-     * output: args[0] = io bandwidth in Mbps[31:0]
-     */
-    {1, 1, HSMP_GET},
+	/*
+	 * HSMP_GET_IOLINK_BANDWITH, num_args = 1, response_sz = 1
+	 * input: args[0] = link id[15:8] + bw type[2:0]
+	 * output: args[0] = io bandwidth in Mbps[31:0]
+	 */
+	{1, 1, HSMP_GET},
 
-    /*
-     * HSMP_GET_XGMI_BANDWITH, num_args = 1, response_sz = 1
-     * input: args[0] = link id[15:8] + bw type[2:0]
-     * output: args[0] = xgmi bandwidth in Mbps[31:0]
-     */
-    {1, 1, HSMP_GET},
+	/*
+	 * HSMP_GET_XGMI_BANDWITH, num_args = 1, response_sz = 1
+	 * input: args[0] = link id[15:8] + bw type[2:0]
+	 * output: args[0] = xgmi bandwidth in Mbps[31:0]
+	 */
+	{1, 1, HSMP_GET},
 
-    /*
-     * HSMP_SET_GMI3_WIDTH, num_args = 1, response_sz = 0
-     * input: args[0] = min link width[15:8] + max link width[7:0]
-     */
-    {1, 0, HSMP_SET},
+	/*
+	 * HSMP_SET_GMI3_WIDTH, num_args = 1, response_sz = 0
+	 * input: args[0] = min link width[15:8] + max link width[7:0]
+	 */
+	{1, 0, HSMP_SET},
 
-    /*
-     * HSMP_SET_PCI_RATE, num_args = 1, response_sz = 1
-     * input: args[0] = link rate control value
-     * output: args[0] = previous link rate control value
-     */
-    {1, 1, HSMP_SET},
+	/*
+	 * HSMP_SET_PCI_RATE, num_args = 1, response_sz = 1
+	 * input: args[0] = link rate control value
+	 * output: args[0] = previous link rate control value
+	 */
+	{1, 1, HSMP_SET},
 
-    /*
-     * HSMP_SET_POWER_MODE, num_args = 1, response_sz = 0/1
-     * input: args[0] = set/get power mode[31] + power efficiency mode[2:0]
-     * output: args[0] = current power efficiency mode[2:0]
-     */
-    {1, 1, HSMP_SET_GET},
+	/*
+	 * HSMP_SET_POWER_MODE, num_args = 1, response_sz = 0/1
+	 * input: args[0] = set/get power mode[31] + power efficiency mode[2:0]
+	 * output: args[0] = current power efficiency mode[2:0]
+	 */
+	{1, 1, HSMP_SET_GET},
 
-    /*
-     * HSMP_SET_PSTATE_MAX_MIN, num_args = 1, response_sz = 0
-     * input: args[0] = min df pstate[15:8] + max df pstate[7:0]
-     */
-    {1, 0, HSMP_SET},
+	/*
+	 * HSMP_SET_PSTATE_MAX_MIN, num_args = 1, response_sz = 0/1
+	 * input: args[0] = set/get power mode[31] + min df pstate[15:8] + max df pstate[7:0]
+	* output: args[0] = min df pstate[15:8] + max df pstate[7:0]
+	 */
+	{1, 1, HSMP_SET_GET},
 
-    /*
-     * HSMP_GET_METRIC_TABLE_VER, num_args = 0, response_sz = 1
-     * output: args[0] = metrics table version
-     */
-    {0, 1, HSMP_GET},
+	/*
+	 * HSMP_GET_METRIC_TABLE_VER, num_args = 0, response_sz = 1
+	 * output: args[0] = metrics table version
+	 */
+	{0, 1, HSMP_GET},
 
-    /*
-     * HSMP_GET_METRIC_TABLE, num_args = 0, response_sz = 0
-     */
-    {0, 0, HSMP_GET},
+	/*
+	 * HSMP_GET_METRIC_TABLE, num_args = 0, response_sz = 0
+	 */
+	{0, 0, HSMP_GET},
 
-    /*
-     * HSMP_GET_METRIC_TABLE_DRAM_ADDR, num_args = 0, response_sz = 2
-     * output: args[0] = lower 32 bits of the address
-     * output: args[1] = upper 32 bits of the address
-     */
-    {0, 2, HSMP_GET},
+	/*
+	 * HSMP_GET_METRIC_TABLE_DRAM_ADDR, num_args = 0, response_sz = 2
+	 * output: args[0] = lower 32 bits of the address
+	 * output: args[1] = upper 32 bits of the address
+	 */
+	{0, 2, HSMP_GET},
 
-    /*
-     * HSMP_SET_XGMI_PSTATE_RANGE, num_args = 1, response_sz = 0
-     * input: args[0] = min xGMI p-state[15:8] + max xGMI state[7:0]
-     */
-    {1, 0, HSMP_SET},
+	/*
+	 * HSMP_SET_XGMI_PSTATE_RANGE, num_args = 1, response_sz = 0/1
+	 * input: args[0] = set/get XGMI pstate range[31] + min xGMI p-state[15:8] + max xGMI state[7:0]
+	* output: args[0] = min xGMI p-state[15:8] + max xGMI state[7:0]
+	 */
+	{1, 1, HSMP_SET_GET},
 
-    /*
-     * HSMP_CPU_RAIL_ISO_FREQ_POLICY, num_args = 1, response_sz = 1
-     * input: args[0] = set/get policy[31] +
-     * disable/enable independent control[0]
-     * output: args[0] = current policy[0]
-     */
-    {1, 1, HSMP_SET_GET},
+	/*
+	 * HSMP_CPU_RAIL_ISO_FREQ_POLICY, num_args = 1, response_sz = 1
+	 * input: args[0] = set/get policy[31] +
+	 * disable/enable independent control[0]
+	 * output: args[0] = current policy[0]
+	 */
+	{1, 1, HSMP_SET_GET},
 
-    /*
-     * HSMP_DFC_ENABLE_CTRL, num_args = 1, response_sz = 1
-     * input: args[0] = set/get policy[31] + enable/disable DFC[0]
-     * output: args[0] = current policy[0]
-     */
-    {1, 1, HSMP_SET_GET},
+	/*
+	 * HSMP_DFC_ENABLE_CTRL, num_args = 1, response_sz = 1
+	 * input: args[0] = set/get policy[31] + enable/disable DFC[0]
+	 * output: args[0] = current policy[0]
+	 */
+	{1, 1, HSMP_SET_GET},
 
-    /* RESERVED(0x29-0x2f) */
-    {0, 0, HSMP_RSVD},
-    {0, 0, HSMP_RSVD},
-    {0, 0, HSMP_RSVD},
-    {0, 0, HSMP_RSVD},
-    {0, 0, HSMP_RSVD},
-    {0, 0, HSMP_RSVD},
-    {0, 0, HSMP_RSVD},
+	/*
+	 * HSMP_PC6_REQUEST, num_args = 1, response_sz = 0/1
+	 * input: args[0] = set/get PC6 control[31] + disable/enable PC6[0]
+	 * output: args[0] = current PC6 control status[0]
+	 */
+	{1, 1, HSMP_SET_GET},
 
-    /*
-     * HSMP_GET_RAPL_UNITS, response_sz = 1
-     * output: args[0] = tu value[19:16] + esu value[12:8]
-     */
-    {0, 1, HSMP_GET},
+	/*
+	 * HSMP_CC6_REQUEST, num_args = 1, response_sz = 0/1
+	 * input: args[0] = set/get CC6 control[31] + disable/enable CC6[0]
+	 * output: args[0] = current CC6 control status[0]
+	 */
+	{1, 1, HSMP_SET_GET},
 
-    /*
-     * HSMP_GET_RAPL_CORE_COUNTER, num_args = 1, response_sz = 1
-     * input: args[0] = Apic id[15:0]
-     * output: args[0] = lower 32 bits of energy
-     * output: args[1] = upper 32 bits of energy
-     */
-    {1, 2, HSMP_GET},
+	/* RESERVED(0x2B-0x2F) */
+	{0, 0, HSMP_RSVD},
+	{0, 0, HSMP_RSVD},
+	{0, 0, HSMP_RSVD},
+	{0, 0, HSMP_RSVD},
+	{0, 0, HSMP_RSVD},
 
-    /*
-     * HSMP_GET_RAPL_PACKAGE_COUNTER, num_args = 0, response_sz = 1
-     * output: args[0] = lower 32 bits of energy
-     * output: args[1] = upper 32 bits of energy
-     */
-    {0, 2, HSMP_GET},
+	/*
+	 * HSMP_GET_RAPL_UNITS, response_sz = 1
+	 * output: args[0] = tu value[19:16] + esu value[12:8]
+	 */
+	{0, 1, HSMP_GET},
+
+	/*
+	 * HSMP_GET_RAPL_CORE_COUNTER, num_args = 1, response_sz = 1
+	 * input: args[0] = Apic id[15:0]
+	 * output: args[0] = lower 32 bits of energy
+	 * output: args[1] = upper 32 bits of energy
+	 */
+	{1, 2, HSMP_GET},
+
+	/*
+	 * HSMP_GET_RAPL_PACKAGE_COUNTER, num_args = 0, response_sz = 1
+	 * output: args[0] = lower 32 bits of energy
+	 * output: args[1] = upper 32 bits of energy
+	 */
+	{0, 2, HSMP_GET},
+
+	/*
+	 * HSMP_DIMM_SB_RD, num_args = 1, response_sz = 1
+	 * input: args[0] =
+	 * 		     [07:00] DIMM address
+	 * 		     [11:08] LID of device
+	 * 		     [22:12] Register offset in given reg space
+	 * 		     [23]    Register space
+	 * output: args[0] = [03:00] Read data byte
+	 */
+	{1, 1, HSMP_GET},
+
+	/*
+	 * HSMP_READ_CCD_POWER, num_args = 1, response_sz = 1
+	 * input: args[0] = [15:00] ApicId of core
+	 * output: args[0] = [31:00] CCD power(mWatts)
+	 */
+	{1, 1, HSMP_GET},
+
+	/*
+	 * HSMP_READ_TDELTA, num_args = 0, response_sz = 1
+	 * input: None
+	 * output: args[0] = [31:00] Thermal Behaviour
+	 */
+	{0, 1, HSMP_GET},
+
+	/*
+	 * HSMP_GET_SVI3_VR_CTRL_TEMP, num_args = 1, response_sz = 1
+	 * input: args[0] =
+	 * 		     [00] Read SVI3 temperature data
+	 * 		     [03:01] SVI3 rail index
+	 * output: args[0] =
+	 * 		     [30:28] SVI3 rail index
+	 * 		     [27:00] SVI3 rail temperature(degree C)
+	 */
+	{1, 1, HSMP_GET},
+
+	/*
+	 * HSMP_GET_ENABLED_HSMP_CMDS, num_args = 1, response_sz = 3
+	 * input: args[0] = [00] HSMP command mask
+	 * output: args[0], args[1], args[2] = status of HSMP command
+	 */
+	{1, 3, HSMP_GET},
+
+	/*
+	 * HSMP_SET_GET_FLOOR_LIMIT, num_args = 1, response_sz = 1
+	 * input: args[0] =
+	 *                  [31:30]=Set or Get:
+	 *                     00=Set the Floor frequency per core.
+	 *                     01=Set the Floor frequency for all cores.
+	 *                     10=Get the Floor frequency of a core.
+	 * 	               11=Get the Effective Floor frequency per core.
+	 *                  [29:28]=Reserved.
+	 *                  [27:16]=ApicId.
+	 *                 Note: DataIn[27:16] are Reserved if DataIn[31:30]==01.
+	 *
+	 *                 If DataIn[31]=0
+	 *                  [15:0]=Floor frequency limit.
+	 *                 Else
+	 *                  [15:0]=Reserved.
+	 *
+	 * output: args[0] =
+	 *                 If DataIn[31:30]=11
+	 *                  [15:0]=Effective Floor frequency limit(MHz).
+	 *                 Else
+	 *                  [15:0]=Floor frequency limit (MHz).
+	 *                 The output will be None if DataIn[31]=0.
+	 */
+	 {1, 1, HSMP_SET_GET},
+
+	/*
+	 * HSMP_DIMM_SB_WR, num_args = 1, response_sz = 0
+	 * input: args[0] =
+	 *                   [07:00] DIMM address
+	 *                   [11:08] LID of device
+	 *                   [22:12] Register offset in given reg space
+	 *                   [23]    Register space
+	 *                   [31:24] Write Data
+	 * output: None
+	 */
+	{1, 0, HSMP_SET},
+
+	/*
+	 * HSMP_SDPS_LIMIT, num_args = 1, response_sz = 1
+	 * input: args[0] =
+	 *                   [30:00] SDPS Limit
+	 *                   [31] Set/Get
+	 * output: args[0] =
+	 *                   [30:00] SDPS Limit
+	 */
+	{1, 1, HSMP_SET_GET},
 };
 
 /* Metrics table (supported only with proto version 6) */
 struct hsmp_metric_table {
-    __u32 accumulation_counter;
+	__u32 accumulation_counter;
 
-    /* TEMPERATURE */
-    __u32 max_socket_temperature;
-    __u32 max_vr_temperature;
-    __u32 max_hbm_temperature;
-    __u64 max_socket_temperature_acc;
-    __u64 max_vr_temperature_acc;
-    __u64 max_hbm_temperature_acc;
+	/* TEMPERATURE */
+	__u32 max_socket_temperature;
+	__u32 max_vr_temperature;
+	__u32 max_hbm_temperature;
+	__u64 max_socket_temperature_acc;
+	__u64 max_vr_temperature_acc;
+	__u64 max_hbm_temperature_acc;
 
-    /* POWER */
-    __u32 socket_power_limit;
-    __u32 max_socket_power_limit;
-    __u32 socket_power;
+	/* POWER */
+	__u32 socket_power_limit;
+	__u32 max_socket_power_limit;
+	__u32 socket_power;
 
-    /* ENERGY */
-    __u64 timestamp;
-    __u64 socket_energy_acc;
-    __u64 ccd_energy_acc;
-    __u64 xcd_energy_acc;
-    __u64 aid_energy_acc;
-    __u64 hbm_energy_acc;
+	/* ENERGY */
+	__u64 timestamp;
+	__u64 socket_energy_acc;
+	__u64 ccd_energy_acc;
+	__u64 xcd_energy_acc;
+	__u64 aid_energy_acc;
+	__u64 hbm_energy_acc;
 
-    /* FREQUENCY */
-    __u32 cclk_frequency_limit;
-    __u32 gfxclk_frequency_limit;
-    __u32 fclk_frequency;
-    __u32 uclk_frequency;
-    __u32 socclk_frequency[4];
-    __u32 vclk_frequency[4];
-    __u32 dclk_frequency[4];
-    __u32 lclk_frequency[4];
-    __u64 gfxclk_frequency_acc[8];
-    __u64 cclk_frequency_acc[96];
+	/* FREQUENCY */
+	__u32 cclk_frequency_limit;
+	__u32 gfxclk_frequency_limit;
+	__u32 fclk_frequency;
+	__u32 uclk_frequency;
+	__u32 socclk_frequency[4];
+	__u32 vclk_frequency[4];
+	__u32 dclk_frequency[4];
+	__u32 lclk_frequency[4];
+	__u64 gfxclk_frequency_acc[8];
+	__u64 cclk_frequency_acc[96];
 
-    /* FREQUENCY RANGE */
-    __u32 max_cclk_frequency;
-    __u32 min_cclk_frequency;
-    __u32 max_gfxclk_frequency;
-    __u32 min_gfxclk_frequency;
-    __u32 fclk_frequency_table[4];
-    __u32 uclk_frequency_table[4];
-    __u32 socclk_frequency_table[4];
-    __u32 vclk_frequency_table[4];
-    __u32 dclk_frequency_table[4];
-    __u32 lclk_frequency_table[4];
-    __u32 max_lclk_dpm_range;
-    __u32 min_lclk_dpm_range;
+	/* FREQUENCY RANGE */
+	__u32 max_cclk_frequency;
+	__u32 min_cclk_frequency;
+	__u32 max_gfxclk_frequency;
+	__u32 min_gfxclk_frequency;
+	__u32 fclk_frequency_table[4];
+	__u32 uclk_frequency_table[4];
+	__u32 socclk_frequency_table[4];
+	__u32 vclk_frequency_table[4];
+	__u32 dclk_frequency_table[4];
+	__u32 lclk_frequency_table[4];
+	__u32 max_lclk_dpm_range;
+	__u32 min_lclk_dpm_range;
 
-    /* XGMI */
-    __u32 xgmi_width;
-    __u32 xgmi_bitrate;
-    __u64 xgmi_read_bandwidth_acc[8];
-    __u64 xgmi_write_bandwidth_acc[8];
+	/* XGMI */
+	__u32 xgmi_width;
+	__u32 xgmi_bitrate;
+	__u64 xgmi_read_bandwidth_acc[8];
+	__u64 xgmi_write_bandwidth_acc[8];
 
-    /* ACTIVITY */
-    __u32 socket_c0_residency;
-    __u32 socket_gfx_busy;
-    __u32 dram_bandwidth_utilization;
-    __u64 socket_c0_residency_acc;
-    __u64 socket_gfx_busy_acc;
-    __u64 dram_bandwidth_acc;
-    __u32 max_dram_bandwidth;
-    __u64 dram_bandwidth_utilization_acc;
-    __u64 pcie_bandwidth_acc[4];
+	/* ACTIVITY */
+	__u32 socket_c0_residency;
+	__u32 socket_gfx_busy;
+	__u32 dram_bandwidth_utilization;
+	__u64 socket_c0_residency_acc;
+	__u64 socket_gfx_busy_acc;
+	__u64 dram_bandwidth_acc;
+	__u32 max_dram_bandwidth;
+	__u64 dram_bandwidth_utilization_acc;
+	__u64 pcie_bandwidth_acc[4];
 
-    /* THROTTLERS */
-    __u32 prochot_residency_acc;
-    __u32 ppt_residency_acc;
-    __u32 socket_thm_residency_acc;
-    __u32 vr_thm_residency_acc;
-    __u32 hbm_thm_residency_acc;
-    __u32 spare;
+	/* THROTTLERS */
+	__u32 prochot_residency_acc;
+	__u32 ppt_residency_acc;
+	__u32 socket_thm_residency_acc;
+	__u32 vr_thm_residency_acc;
+	__u32 hbm_thm_residency_acc;
+	__u32 spare;
 
-    /* New items at the end to maintain driver compatibility */
-    __u32 gfxclk_frequency[8];
+	/* New items at the end to maintain driver compatibility */
+	__u32 gfxclk_frequency[8];
 };
 
 /* Reset to default packing */
 #pragma pack()
 
 /* Define unique ioctl command for hsmp msgs using generic _IOWR */
-#define HSMP_BASE_IOCTL_NR    0xF8
-#define HSMP_IOCTL_CMD        _IOWR(HSMP_BASE_IOCTL_NR, 0, struct hsmp_message)
+#define HSMP_BASE_IOCTL_NR	0xF8
+#define HSMP_IOCTL_CMD		_IOWR(HSMP_BASE_IOCTL_NR, 0, struct hsmp_message)
+int hsmp_send_message(struct hsmp_message *msg);
 
 #endif /*_ASM_X86_AMD_HSMP_H_*/

--- a/projects/amdsmi/py-interface/__init__.py
+++ b/projects/amdsmi/py-interface/__init__.py
@@ -57,6 +57,7 @@ try:
     from .amdsmi_interface import amdsmi_get_cpu_pwr_svi_telemetry_all_rails
     from .amdsmi_interface import amdsmi_set_cpu_socket_power_cap
     from .amdsmi_interface import amdsmi_set_cpu_pwr_efficiency_mode
+    from .amdsmi_interface import amdsmi_get_cpu_pwr_efficiency_mode
     from .amdsmi_interface import amdsmi_get_cpu_core_boostlimit
     from .amdsmi_interface import amdsmi_get_cpu_socket_c0_residency
     from .amdsmi_interface import amdsmi_set_cpu_core_boostlimit
@@ -83,10 +84,33 @@ try:
     from .amdsmi_interface import amdsmi_get_cpu_model
     from .amdsmi_interface import amdsmi_get_cpu_model_name
     from .amdsmi_interface import amdsmi_get_cpu_handles
-    from .amdsmi_interface import amdsmi_get_dfc_ctrl
-    from .amdsmi_interface import amdsmi_set_dfc_ctrl
-    from .amdsmi_interface import amdsmi_get_cpu_rail_isofreq_policy
+    from .amdsmi_interface import amdsmi_set_cpu_xgmi_pstate_range
+    from .amdsmi_interface import amdsmi_get_cpu_xgmi_pstate_range
     from .amdsmi_interface import amdsmi_set_cpu_rail_isofreq_policy
+    from .amdsmi_interface import amdsmi_get_cpu_rail_isofreq_policy
+    from .amdsmi_interface import amdsmi_set_cpu_dfc_ctrl
+    from .amdsmi_interface import amdsmi_get_cpu_dfc_ctrl
+    from .amdsmi_interface import amdsmi_set_cpu_cc6_enable
+    from .amdsmi_interface import amdsmi_get_cpu_cc6_enable
+    from .amdsmi_interface import amdsmi_set_cpu_pc6_enable
+    from .amdsmi_interface import amdsmi_get_cpu_pc6_enable
+    from .amdsmi_interface import amdsmi_get_cpu_dimm_sb_reg
+    from .amdsmi_interface import amdsmi_set_cpu_dimm_sb_reg
+    from .amdsmi_interface import amdsmi_get_cpu_core_ccd_power
+    from .amdsmi_interface import amdsmi_get_cpu_tdelta
+    from .amdsmi_interface import amdsmi_get_cpu_svi3_vr_controller_temp
+    from .amdsmi_interface import amdsmi_get_cpu_enabled_commands
+    from .amdsmi_interface import amdsmi_get_cpu_core_floor_freq_limit
+    from .amdsmi_interface import amdsmi_get_cpu_floor_freq_limit
+    from .amdsmi_interface import amdsmi_get_cpu_core_eff_floor_freq_limit
+    from .amdsmi_interface import amdsmi_get_cpu_eff_floor_freq_limit
+    from .amdsmi_interface import amdsmi_set_cpu_core_floor_freq_limit
+    from .amdsmi_interface import amdsmi_set_cpu_floor_freq_limit
+    from .amdsmi_interface import amdsmi_set_cpu_core_msr_floor_freq_limit
+    from .amdsmi_interface import amdsmi_set_cpu_msr_floor_freq_limit
+    from .amdsmi_interface import amdsmi_get_cpu_freq_range
+    from .amdsmi_interface import amdsmi_set_cpu_sdps_limit
+    from .amdsmi_interface import amdsmi_get_cpu_sdps_limit
 except AttributeError:
     pass
 

--- a/projects/amdsmi/py-interface/amdsmi_interface.py
+++ b/projects/amdsmi/py-interface/amdsmi_interface.py
@@ -42,6 +42,12 @@ class MaxUIntegerTypes(IntEnum):
 NO_OF_32BITS = (sys.getsizeof(ctypes.c_uint32) * 8)
 NO_OF_64BITS = (sys.getsizeof(ctypes.c_uint64) * 8)
 KILO = math.pow(10, 3)
+AMDSMI_MAX_UTIL = 0xFFFFFFFF
+AMDSMI_MAX_PPT_LIMIT = 0xFFFFFFFF
+AMDSMI_MAX_RAIL_INDEX = 0xFFFFFFFF
+# Power efficiency mode constants
+AMDSMI_MAX_POWER_EFFICIENCY_UTIL = 0x7F       # Maximum UTIL value for balanced core modes (%)
+AMDSMI_MAX_POWER_EFFICIENCY_PPTLIMIT = 0x1FFFFF  # Maximum PPT limit for balanced core modes (mW)
 
 socket_handle_t = c_void_p
 processor_handle_t = c_void_p
@@ -1331,6 +1337,25 @@ def amdsmi_get_cpu_core_energy(
 
     return f"{float(penergy.value * pow(10, -6))} J"
 
+def amdsmi_get_cpu_core_ccd_power(
+    processor_handle: processor_handle_t,
+) -> float:
+    if not isinstance(processor_handle, amdsmi_wrapper.amdsmi_processor_handle):
+        raise AmdSmiParameterException(
+            processor_handle, amdsmi_wrapper.amdsmi_processor_handle
+        )
+
+    power = ctypes.c_double()
+
+    _check_res(
+        amdsmi_wrapper.amdsmi_get_cpu_core_ccd_power(
+            processor_handle, ctypes.byref(power)
+        )
+    )
+
+    #In Watt
+    return power.value
+
 def amdsmi_get_cpu_socket_energy(
     processor_handle: processor_handle_t
 ) -> str:
@@ -1487,32 +1512,31 @@ def amdsmi_get_cpu_socket_power(
             processor_handle, amdsmi_wrapper.amdsmi_processor_handle
         )
 
-    ppower = ctypes.c_uint32()
+    ppower = ctypes.c_double()
     _check_res(
         amdsmi_wrapper.amdsmi_get_cpu_socket_power(
             processor_handle, ctypes.byref(ppower)
         )
     )
 
-    return f"{ppower.value} mW"
+    return f"{ppower.value} Watts"
 
 def amdsmi_get_cpu_socket_power_cap(
     processor_handle: processor_handle_t
-) -> int:
+) -> str:
     if not isinstance(processor_handle, amdsmi_wrapper.amdsmi_processor_handle):
         raise AmdSmiParameterException(
             processor_handle, amdsmi_wrapper.amdsmi_processor_handle
         )
 
-    pcap = ctypes.c_uint32()
+    pcap = ctypes.c_double()
     _check_res(
         amdsmi_wrapper.amdsmi_get_cpu_socket_power_cap(
             processor_handle, ctypes.byref(pcap)
         )
     )
 
-    # in mW
-    return pcap.value
+    return f"{pcap.value} Watts"
 
 def amdsmi_get_cpu_socket_power_cap_max(
     processor_handle: processor_handle_t
@@ -1522,14 +1546,14 @@ def amdsmi_get_cpu_socket_power_cap_max(
             processor_handle, amdsmi_wrapper.amdsmi_processor_handle
         )
 
-    pmax = ctypes.c_uint32()
+    pmax = ctypes.c_double()
     _check_res(
         amdsmi_wrapper.amdsmi_get_cpu_socket_power_cap_max(
             processor_handle, ctypes.byref(pmax)
         )
     )
 
-    return f"{pmax.value} mW"
+    return f"{pmax.value} Watts"
 
 def amdsmi_get_cpu_pwr_svi_telemetry_all_rails(
     processor_handle: processor_handle_t
@@ -1566,20 +1590,51 @@ def amdsmi_set_cpu_socket_power_cap(
     )
 
 def amdsmi_set_cpu_pwr_efficiency_mode(
-    processor_handle: processor_handle_t, mode: int
-):
+    processor_handle: processor_handle_t,
+    mode: int,
+    util: int=AMDSMI_MAX_UTIL,
+    ppt_limit: int=AMDSMI_MAX_PPT_LIMIT
+) -> tuple:
     if not isinstance(processor_handle, amdsmi_wrapper.amdsmi_processor_handle):
         raise AmdSmiParameterException(
             processor_handle, amdsmi_wrapper.amdsmi_processor_handle
         )
     if not isinstance(mode, int):
         raise AmdSmiParameterException(mode, int)
+    if not isinstance(util, int):
+        raise AmdSmiParameterException(util, int)
+    if not isinstance(ppt_limit, int):
+        raise AmdSmiParameterException(ppt_limit, int)
+
     mode_8 = ctypes.c_uint8(mode)
+    util_32 = ctypes.c_uint32(util)
+    ppt_limit_32 = ctypes.c_uint32(ppt_limit)
 
     _check_res(
         amdsmi_wrapper.amdsmi_set_cpu_pwr_efficiency_mode(
-            processor_handle, mode_8)
+            processor_handle, mode_8, ctypes.byref(util_32), ctypes.byref(ppt_limit_32))
     )
+
+    return (util_32.value, ppt_limit_32.value)
+
+def amdsmi_get_cpu_pwr_efficiency_mode(
+    processor_handle: processor_handle_t
+) -> tuple:
+    if not isinstance(processor_handle, amdsmi_wrapper.amdsmi_processor_handle):
+        raise AmdSmiParameterException(
+            processor_handle, amdsmi_wrapper.amdsmi_processor_handle
+        )
+
+    mode = ctypes.c_uint32()
+    util = ctypes.c_uint32()
+    ppt_limit = ctypes.c_double()
+
+    _check_res(
+        amdsmi_wrapper.amdsmi_get_cpu_pwr_efficiency_mode(
+            processor_handle, ctypes.byref(mode), ctypes.byref(util), ctypes.byref(ppt_limit))
+    )
+
+    return (mode.value, util.value, ppt_limit.value)
 
 def amdsmi_get_cpu_core_boostlimit(
     processor_handle: processor_handle_t
@@ -1890,23 +1945,23 @@ def amdsmi_set_cpu_pcie_link_rate(
 
 def amdsmi_set_cpu_df_pstate_range(
     processor_handle: processor_handle_t,
-    max_pstate: int, min_pstate: int
+    min_pstate: int, max_pstate: int
 ):
     if not isinstance(processor_handle, amdsmi_wrapper.amdsmi_processor_handle):
         raise AmdSmiParameterException(
             processor_handle, amdsmi_wrapper.amdsmi_processor_handle
         )
-    if not isinstance(max_pstate, int):
-        raise AmdSmiParameterException(max_pstate, int)
     if not isinstance(min_pstate, int):
         raise AmdSmiParameterException(min_pstate, int)
+    if not isinstance(max_pstate, int):
+        raise AmdSmiParameterException(max_pstate, int)
 
-    max_pstate_8 = ctypes.c_uint8(max_pstate)
     min_pstate_8 = ctypes.c_uint8(min_pstate)
+    max_pstate_8 = ctypes.c_uint8(max_pstate)
 
     _check_res(
         amdsmi_wrapper.amdsmi_set_cpu_df_pstate_range(
-            processor_handle, max_pstate_8, min_pstate_8))
+            processor_handle, min_pstate_8, max_pstate_8))
 
 def amdsmi_get_cpu_current_io_bandwidth(
     processor_handle: processor_handle_t,
@@ -1977,17 +2032,69 @@ def amdsmi_get_hsmp_metrics_table_version(
 
     return metric_tbl_version.value
 
-def amdsmi_set_cpu_rail_isofreq_policy(
+def amdsmi_set_cpu_xgmi_pstate_range(
     processor_handle: processor_handle_t,
-    value: int):
+    min_pstate: int, max_pstate: int
+):
+    if not isinstance(processor_handle, amdsmi_wrapper.amdsmi_processor_handle):
+        raise AmdSmiParameterException(
+            processor_handle, amdsmi_wrapper.amdsmi_processor_handle
+        )
+    if not isinstance(min_pstate, int):
+        raise AmdSmiParameterException(min_pstate, int)
+    if not isinstance(max_pstate, int):
+        raise AmdSmiParameterException(max_pstate, int)
+
+    min_pstate_8 = ctypes.c_uint8(min_pstate)
+    max_pstate_8 = ctypes.c_uint8(max_pstate)
+
+    _check_res(
+        amdsmi_wrapper.amdsmi_set_cpu_xgmi_pstate_range(
+            processor_handle, min_pstate_8, max_pstate_8
+        )
+    )
+
+def amdsmi_get_cpu_xgmi_pstate_range(
+    processor_handle: processor_handle_t
+):
     if not isinstance(processor_handle, amdsmi_wrapper.amdsmi_processor_handle):
         raise AmdSmiParameterException(
             processor_handle, amdsmi_wrapper.amdsmi_processor_handle
         )
 
+    min_pstate = ctypes.c_uint8()
+    max_pstate = ctypes.c_uint8()
+
     _check_res(
-        amdsmi_wrapper.amdsmi_set_cpu_rail_isofreq_policy(processor_handle, value)
+        amdsmi_wrapper.amdsmi_get_cpu_xgmi_pstate_range(
+            processor_handle, ctypes.byref(min_pstate), ctypes.byref(max_pstate)
+        )
     )
+
+    return {
+        "min_pstate": min_pstate.value,
+        "max_pstate": max_pstate.value
+    }
+
+def amdsmi_set_cpu_rail_isofreq_policy(
+    processor_handle: processor_handle_t,
+    value: int
+) -> int:
+    if not isinstance(processor_handle, amdsmi_wrapper.amdsmi_processor_handle):
+        raise AmdSmiParameterException(
+            processor_handle, amdsmi_wrapper.amdsmi_processor_handle
+        )
+    if not isinstance(value, int):
+        raise AmdSmiParameterException(value, int)
+
+    value_bool = ctypes.c_bool(value)
+
+    _check_res(
+        amdsmi_wrapper.amdsmi_set_cpu_rail_isofreq_policy(processor_handle, ctypes.byref(value_bool))
+    )
+
+    value = int(value_bool.value)
+    return value
 
 def amdsmi_get_cpu_rail_isofreq_policy(
     processor_handle: processor_handle_t,
@@ -1998,15 +2105,38 @@ def amdsmi_get_cpu_rail_isofreq_policy(
         )
 
     cpurailiso = ctypes.c_uint8()
+
     _check_res(
         amdsmi_wrapper.amdsmi_get_cpu_rail_isofreq_policy(
             processor_handle, ctypes.byref(cpurailiso)
         )
     )
 
-    return cpurailiso.value
+    value = int(cpurailiso.value)
+    return value
 
-def amdsmi_get_dfc_ctrl(
+def amdsmi_set_cpu_dfc_ctrl(
+    processor_handle: processor_handle_t,
+    value: int
+) -> int:
+    if not isinstance(processor_handle, amdsmi_wrapper.amdsmi_processor_handle):
+        raise AmdSmiParameterException(
+            processor_handle, amdsmi_wrapper.amdsmi_processor_handle
+        )
+    if not isinstance(value, int):
+        raise AmdSmiParameterException(value, int)
+
+    value_8 = ctypes.c_uint8(value)
+
+    _check_res(
+        amdsmi_wrapper.amdsmi_set_cpu_dfc_ctrl(
+            processor_handle, ctypes.byref(value_8)
+        )
+    )
+
+    return value_8.value
+
+def amdsmi_get_cpu_dfc_ctrl(
     processor_handle: processor_handle_t,
 ) -> int:
     if not isinstance(processor_handle, amdsmi_wrapper.amdsmi_processor_handle):
@@ -2015,25 +2145,451 @@ def amdsmi_get_dfc_ctrl(
         )
 
     dfc_ctrl = ctypes.c_uint8()
+
     _check_res(
-        amdsmi_wrapper.amdsmi_get_dfc_ctrl(
+        amdsmi_wrapper.amdsmi_get_cpu_dfc_ctrl(
             processor_handle, ctypes.byref(dfc_ctrl)
         )
     )
 
     return dfc_ctrl.value
 
-def amdsmi_set_dfc_ctrl(
+def amdsmi_set_cpu_pc6_enable(
     processor_handle: processor_handle_t,
-    value: int):
+    value: int
+):
+    if not isinstance(processor_handle, amdsmi_wrapper.amdsmi_processor_handle):
+        raise AmdSmiParameterException(
+            processor_handle, amdsmi_wrapper.amdsmi_processor_handle
+        )
+    if not isinstance(value, int):
+        raise AmdSmiParameterException(value, int)
+
+    value_8 = ctypes.c_uint8(value)
+
+    _check_res(
+        amdsmi_wrapper.amdsmi_set_cpu_pc6_enable(
+            processor_handle, value_8
+        )
+    )
+
+def amdsmi_get_cpu_pc6_enable(
+    processor_handle: processor_handle_t,
+) -> int:
     if not isinstance(processor_handle, amdsmi_wrapper.amdsmi_processor_handle):
         raise AmdSmiParameterException(
             processor_handle, amdsmi_wrapper.amdsmi_processor_handle
         )
 
+    pc6_enable = ctypes.c_uint8()
+
     _check_res(
-        amdsmi_wrapper.amdsmi_set_dfc_ctrl(processor_handle, value)
+        amdsmi_wrapper.amdsmi_get_cpu_pc6_enable(
+            processor_handle, ctypes.byref(pc6_enable)
+        )
     )
+
+    return pc6_enable.value
+
+def amdsmi_set_cpu_cc6_enable(
+    processor_handle: processor_handle_t,
+    value: int
+):
+    if not isinstance(processor_handle, amdsmi_wrapper.amdsmi_processor_handle):
+        raise AmdSmiParameterException(
+            processor_handle, amdsmi_wrapper.amdsmi_processor_handle
+        )
+    if not isinstance(value, int):
+        raise AmdSmiParameterException(value, int)
+
+    value_8 = ctypes.c_uint8(value)
+
+    _check_res(
+        amdsmi_wrapper.amdsmi_set_cpu_cc6_enable(processor_handle, value_8)
+    )
+
+def amdsmi_get_cpu_cc6_enable(
+    processor_handle: processor_handle_t,
+) -> int:
+    if not isinstance(processor_handle, amdsmi_wrapper.amdsmi_processor_handle):
+        raise AmdSmiParameterException(
+            processor_handle, amdsmi_wrapper.amdsmi_processor_handle
+        )
+
+    cc6_enable = ctypes.c_uint8()
+
+    _check_res(
+        amdsmi_wrapper.amdsmi_get_cpu_cc6_enable(
+            processor_handle, ctypes.byref(cc6_enable)
+        )
+    )
+
+    return cc6_enable.value
+
+def amdsmi_get_cpu_dimm_sb_reg(
+    processor_handle: processor_handle_t,
+    dimm_addr: int,
+    lid: int,
+    reg_offset: int,
+    reg_space: int
+):
+    if not isinstance(processor_handle, amdsmi_wrapper.amdsmi_processor_handle):
+        raise AmdSmiParameterException(
+            processor_handle, amdsmi_wrapper.amdsmi_processor_handle
+        )
+    if not isinstance(dimm_addr, int):
+        raise AmdSmiParameterException(dimm_addr, int)
+    if not isinstance(lid, int):
+        raise AmdSmiParameterException(lid, int)
+    if not isinstance(reg_offset, int):
+        raise AmdSmiParameterException(reg_offset, int)
+    if not isinstance(reg_space, int):
+        raise AmdSmiParameterException(reg_space, int)
+
+    dimm_addr_32 = ctypes.c_uint32(dimm_addr)
+    lid_32 = ctypes.c_uint32(lid)
+    reg_offset_32 = ctypes.c_uint32(reg_offset)
+    reg_space_32 = ctypes.c_uint32(reg_space)
+    data = ctypes.c_uint32()
+
+    _check_res(
+        amdsmi_wrapper.amdsmi_get_cpu_dimm_sb_reg(
+            processor_handle, dimm_addr_32, lid_32,
+            reg_offset_32, reg_space_32,ctypes.byref(data)
+        )
+    )
+
+    return data.value
+
+def amdsmi_set_cpu_dimm_sb_reg(
+    processor_handle: processor_handle_t,
+    dimm_addr: int,
+    lid: int,
+    reg_offset: int,
+    reg_space: int,
+    write_data: int
+):
+    if not isinstance(processor_handle, amdsmi_wrapper.amdsmi_processor_handle):
+        raise AmdSmiParameterException(
+            processor_handle, amdsmi_wrapper.amdsmi_processor_handle
+        )
+    if not isinstance(dimm_addr, int):
+        raise AmdSmiParameterException(dimm_addr, int)
+    if not isinstance(lid, int):
+        raise AmdSmiParameterException(lid, int)
+    if not isinstance(reg_offset, int):
+        raise AmdSmiParameterException(reg_offset, int)
+    if not isinstance(reg_space, int):
+        raise AmdSmiParameterException(reg_space, int)
+    if not isinstance(write_data, int):
+        raise AmdSmiParameterException(write_data, int)
+
+    dimm_addr_32 = ctypes.c_uint32(dimm_addr)
+    lid_32 = ctypes.c_uint32(lid)
+    reg_offset_32 = ctypes.c_uint32(reg_offset)
+    reg_space_32 = ctypes.c_uint32(reg_space)
+    write_data_32 = ctypes.c_uint32(write_data)
+
+    _check_res(
+        amdsmi_wrapper.amdsmi_set_cpu_dimm_sb_reg(
+            processor_handle, dimm_addr_32, lid_32,
+            reg_offset_32, reg_space_32, write_data_32
+        )
+    )
+
+def amdsmi_get_cpu_tdelta(
+    processor_handle: processor_handle_t,
+) -> int:
+    if not isinstance(processor_handle, amdsmi_wrapper.amdsmi_processor_handle):
+        raise AmdSmiParameterException(
+            processor_handle, amdsmi_wrapper.amdsmi_processor_handle
+        )
+
+    tdelta = ctypes.c_uint8()
+
+    _check_res(
+        amdsmi_wrapper.amdsmi_get_cpu_tdelta(
+            processor_handle, ctypes.byref(tdelta)
+        )
+    )
+
+    return tdelta.value
+
+def amdsmi_get_cpu_svi3_vr_controller_temp(
+    processor_handle: processor_handle_t,
+    rail_selection: int,
+    rail_index: int=AMDSMI_MAX_RAIL_INDEX
+) -> dict:
+    if not isinstance(processor_handle, amdsmi_wrapper.amdsmi_processor_handle):
+        raise AmdSmiParameterException(
+            processor_handle, amdsmi_wrapper.amdsmi_processor_handle
+        )
+    if not isinstance(rail_selection, int):
+        raise AmdSmiParameterException(rail_selection, int)
+    if not isinstance(rail_index, int):
+        raise AmdSmiParameterException(rail_index, int)
+
+    rail_selection_32 = ctypes.c_uint32(rail_selection)
+    rail_index_32 = ctypes.c_uint32(rail_index)
+    temperature_32 = ctypes.c_uint32()
+
+    _check_res(
+        amdsmi_wrapper.amdsmi_get_cpu_svi3_vr_controller_temp(
+            processor_handle, ctypes.byref(rail_selection_32),
+            ctypes.byref(rail_index_32), ctypes.byref(temperature_32),
+        )
+    )
+
+    return {
+        "rail_selection": rail_selection_32.value,
+        "rail_index": rail_index_32.value,
+        "temperature": temperature_32.value
+    }
+
+def amdsmi_get_cpu_enabled_commands(
+    processor_handle: processor_handle_t
+):
+    if not isinstance(processor_handle, amdsmi_wrapper.amdsmi_processor_handle):
+        raise AmdSmiParameterException(
+            processor_handle, amdsmi_wrapper.amdsmi_processor_handle
+        )
+
+    # First call for read commands
+    mask = ctypes.c_bool(True)
+    read_mask0_u32 = ctypes.c_uint32()
+    read_mask1_u32 = ctypes.c_uint32()
+    read_mask2_u32 = ctypes.c_uint32()
+
+    _check_res(amdsmi_wrapper.amdsmi_get_cpu_enabled_commands(
+        processor_handle,
+        ctypes.byref(mask),
+        ctypes.byref(read_mask0_u32),
+        ctypes.byref(read_mask1_u32),
+        ctypes.byref(read_mask2_u32),
+        )
+    )
+
+    # Second call for write commands
+    mask = ctypes.c_bool(False)
+    write_mask0_u32 = ctypes.c_uint32()
+    write_mask1_u32 = ctypes.c_uint32()
+    write_mask2_u32 = ctypes.c_uint32()
+
+    _check_res(amdsmi_wrapper.amdsmi_get_cpu_enabled_commands(
+        processor_handle,
+        ctypes.byref(mask),
+        ctypes.byref(write_mask0_u32),
+        ctypes.byref(write_mask1_u32),
+        ctypes.byref(write_mask2_u32),
+        )
+    )
+
+    return {
+        "ReadEnabledCommandsBitMask0": read_mask0_u32.value,
+        "ReadEnabledCommandsBitMask1": read_mask1_u32.value,
+        "ReadEnabledCommandsBitMask2": read_mask2_u32.value,
+        "WriteEnabledCommandsBitMask0": write_mask0_u32.value,
+        "WriteEnabledCommandsBitMask1": write_mask1_u32.value,
+        "WriteEnabledCommandsBitMask2": write_mask2_u32.value,
+    }
+
+def amdsmi_get_cpu_core_floor_freq_limit(
+   processor_handle: processor_handle_t
+) -> int:
+    if not isinstance(processor_handle, amdsmi_wrapper.amdsmi_processor_handle):
+        raise AmdSmiParameterException(
+            processor_handle, amdsmi_wrapper.amdsmi_processor_handle
+        )
+
+    floorlimit = ctypes.c_uint32()
+
+    _check_res(
+        amdsmi_wrapper.amdsmi_get_cpu_core_floor_freq_limit(
+            processor_handle, ctypes.byref(floorlimit)
+        )
+    )
+
+    # In MHz
+    return floorlimit.value
+
+def amdsmi_get_cpu_floor_freq_limit(
+   processor_handle: processor_handle_t
+) -> int:
+    if not isinstance(processor_handle, amdsmi_wrapper.amdsmi_processor_handle):
+        raise AmdSmiParameterException(
+            processor_handle, amdsmi_wrapper.amdsmi_processor_handle
+        )
+
+    floorlimit = ctypes.c_uint32()
+
+    _check_res(
+        amdsmi_wrapper.amdsmi_get_cpu_floor_freq_limit(
+            processor_handle, ctypes.byref(floorlimit)
+        )
+    )
+
+    # In MHz
+    return floorlimit.value
+
+def amdsmi_get_cpu_core_eff_floor_freq_limit(
+    processor_handle: processor_handle_t
+) -> int:
+    if not isinstance(processor_handle, amdsmi_wrapper.amdsmi_processor_handle):
+        raise AmdSmiParameterException(
+            processor_handle, amdsmi_wrapper.amdsmi_processor_handle
+        )
+
+    eff_floor_freq_limit = ctypes.c_uint32()
+
+    _check_res(
+            amdsmi_wrapper.amdsmi_get_cpu_core_eff_floor_freq_limit(
+            processor_handle, ctypes.byref(eff_floor_freq_limit)
+        )
+    )
+
+    # In MHz
+    return eff_floor_freq_limit.value
+
+def amdsmi_get_cpu_eff_floor_freq_limit(
+    processor_handle: processor_handle_t
+) -> int:
+    if not isinstance(processor_handle, amdsmi_wrapper.amdsmi_processor_handle):
+        raise AmdSmiParameterException(
+            processor_handle, amdsmi_wrapper.amdsmi_processor_handle
+        )
+
+    eff_floor_freq_limit = ctypes.c_uint32()
+
+    _check_res(
+        amdsmi_wrapper.amdsmi_get_cpu_eff_floor_freq_limit(
+            processor_handle, ctypes.byref(eff_floor_freq_limit)
+        )
+    )
+
+    # In MHz
+    return eff_floor_freq_limit.value
+
+def amdsmi_set_cpu_core_floor_freq_limit(
+    processor_handle: processor_handle_t, floorlimit: int
+):
+    if not isinstance(processor_handle, amdsmi_wrapper.amdsmi_processor_handle):
+        raise AmdSmiParameterException(
+            processor_handle, amdsmi_wrapper.amdsmi_processor_handle
+        )
+    if not isinstance(floorlimit, int):
+        raise AmdSmiParameterException(floorlimit, int)
+
+    floorlimit_32 = ctypes.c_uint32(floorlimit)
+
+    _check_res(
+        amdsmi_wrapper.amdsmi_set_cpu_core_floor_freq_limit(
+            processor_handle, floorlimit_32)
+    )
+
+def amdsmi_set_cpu_floor_freq_limit(
+    processor_handle: processor_handle_t, floorlimit: int
+):
+    if not isinstance(processor_handle, amdsmi_wrapper.amdsmi_processor_handle):
+        raise AmdSmiParameterException(
+            processor_handle, amdsmi_wrapper.amdsmi_processor_handle
+        )
+    if not isinstance(floorlimit, int):
+        raise AmdSmiParameterException(floorlimit, int)
+
+    floorlimit_32 = ctypes.c_uint32(floorlimit)
+
+    _check_res(
+        amdsmi_wrapper.amdsmi_set_cpu_floor_freq_limit(
+            processor_handle, floorlimit_32)
+    )
+
+def amdsmi_set_cpu_msr_floor_freq_limit(
+    processor_handle: processor_handle_t, msrfloorlimit: int
+):
+    if not isinstance(processor_handle, amdsmi_wrapper.amdsmi_processor_handle):
+        raise AmdSmiParameterException(
+            processor_handle, amdsmi_wrapper.amdsmi_processor_handle
+        )
+    if not isinstance(msrfloorlimit, int):
+        raise AmdSmiParameterException(msrfloorlimit, int)
+
+    msrfloorlimit_32 = ctypes.c_uint32(msrfloorlimit)
+
+    _check_res(
+        amdsmi_wrapper.amdsmi_set_cpu_msr_floor_freq_limit(
+            processor_handle, msrfloorlimit_32)
+    )
+
+def amdsmi_set_cpu_core_msr_floor_freq_limit(
+    processor_handle: processor_handle_t, msrfloorlimit: int
+):
+    if not isinstance(processor_handle, amdsmi_wrapper.amdsmi_processor_handle):
+        raise AmdSmiParameterException(
+            processor_handle, amdsmi_wrapper.amdsmi_processor_handle
+        )
+    if not isinstance(msrfloorlimit, int):
+        raise AmdSmiParameterException(msrfloorlimit, int)
+
+    msrfloorlimit_32 = ctypes.c_uint32(msrfloorlimit)
+
+    _check_res(
+        amdsmi_wrapper.amdsmi_set_cpu_core_msr_floor_freq_limit(
+            processor_handle, msrfloorlimit_32)
+    )
+
+def amdsmi_get_cpu_freq_range(
+) -> Dict[str, int]:
+
+    fmax = ctypes.c_uint32()
+    fmin = ctypes.c_uint32()
+
+    _check_res(
+        amdsmi_wrapper.amdsmi_get_cpu_freq_range(
+            ctypes.byref(fmax),
+            ctypes.byref(fmin)
+        )
+    )
+
+    # In MHz
+    return {
+        "fmax": fmax.value,
+        "fmin": fmin.value
+    }
+
+def amdsmi_set_cpu_sdps_limit(
+    processor_handle: processor_handle_t, sdps_limit: int
+):
+    if not isinstance(processor_handle, amdsmi_wrapper.amdsmi_processor_handle):
+        raise AmdSmiParameterException(
+            processor_handle, amdsmi_wrapper.amdsmi_processor_handle
+        )
+    if not isinstance(sdps_limit, int):
+        raise AmdSmiParameterException(sdps_limit, int)
+
+    sdps_limit_32 = ctypes.c_uint32(sdps_limit)
+
+    _check_res(
+        amdsmi_wrapper.amdsmi_set_cpu_sdps_limit(
+            processor_handle, sdps_limit_32)
+    )
+
+def amdsmi_get_cpu_sdps_limit(
+    processor_handle: processor_handle_t
+) -> str:
+    if not isinstance(processor_handle, amdsmi_wrapper.amdsmi_processor_handle):
+        raise AmdSmiParameterException(
+            processor_handle, amdsmi_wrapper.amdsmi_processor_handle
+        )
+
+    sdps_limit = ctypes.c_double()
+    _check_res(
+        amdsmi_wrapper.amdsmi_get_cpu_sdps_limit(
+            processor_handle, ctypes.byref(sdps_limit)
+        )
+    )
+
+    #In Watt
+    return f"{sdps_limit.value} Watts"
 
 # Get 2's complement of 32 bit unsigned integer
 def check_msb_32(num):

--- a/projects/amdsmi/py-interface/amdsmi_wrapper.py
+++ b/projects/amdsmi/py-interface/amdsmi_wrapper.py
@@ -1417,6 +1417,16 @@ amdsmi_process_handle_t = ctypes.c_uint32
 class struct_amdsmi_proc_info_t(Structure):
     pass
 
+class struct_engine_usage_(Structure):
+    pass
+
+struct_engine_usage_._pack_ = 1 # source:False
+struct_engine_usage_._fields_ = [
+    ('gfx', ctypes.c_uint64),
+    ('enc', ctypes.c_uint64),
+    ('reserved', ctypes.c_uint32 * 12),
+]
+
 class struct_memory_usage_(Structure):
     pass
 
@@ -1426,16 +1436,6 @@ struct_memory_usage_._fields_ = [
     ('cpu_mem', ctypes.c_uint64),
     ('vram_mem', ctypes.c_uint64),
     ('reserved', ctypes.c_uint32 * 10),
-]
-
-class struct_engine_usage_(Structure):
-    pass
-
-struct_engine_usage_._pack_ = 1 # source:False
-struct_engine_usage_._fields_ = [
-    ('gfx', ctypes.c_uint64),
-    ('enc', ctypes.c_uint64),
-    ('reserved', ctypes.c_uint32 * 12),
 ]
 
 struct_amdsmi_proc_info_t._pack_ = 1 # source:False
@@ -2856,13 +2856,13 @@ amdsmi_get_supported_power_cap.restype = amdsmi_status_t
 amdsmi_get_supported_power_cap.argtypes = [amdsmi_processor_handle, ctypes.POINTER(ctypes.c_uint32), ctypes.POINTER(ctypes.c_uint32), ctypes.POINTER(amdsmi_power_cap_type_t)]
 amdsmi_get_cpu_socket_power = _libraries['libamd_smi.so'].amdsmi_get_cpu_socket_power
 amdsmi_get_cpu_socket_power.restype = amdsmi_status_t
-amdsmi_get_cpu_socket_power.argtypes = [amdsmi_processor_handle, ctypes.POINTER(ctypes.c_uint32)]
+amdsmi_get_cpu_socket_power.argtypes = [amdsmi_processor_handle, ctypes.POINTER(ctypes.c_double)]
 amdsmi_get_cpu_socket_power_cap = _libraries['libamd_smi.so'].amdsmi_get_cpu_socket_power_cap
 amdsmi_get_cpu_socket_power_cap.restype = amdsmi_status_t
-amdsmi_get_cpu_socket_power_cap.argtypes = [amdsmi_processor_handle, ctypes.POINTER(ctypes.c_uint32)]
+amdsmi_get_cpu_socket_power_cap.argtypes = [amdsmi_processor_handle, ctypes.POINTER(ctypes.c_double)]
 amdsmi_get_cpu_socket_power_cap_max = _libraries['libamd_smi.so'].amdsmi_get_cpu_socket_power_cap_max
 amdsmi_get_cpu_socket_power_cap_max.restype = amdsmi_status_t
-amdsmi_get_cpu_socket_power_cap_max.argtypes = [amdsmi_processor_handle, ctypes.POINTER(ctypes.c_uint32)]
+amdsmi_get_cpu_socket_power_cap_max.argtypes = [amdsmi_processor_handle, ctypes.POINTER(ctypes.c_double)]
 amdsmi_get_cpu_pwr_svi_telemetry_all_rails = _libraries['libamd_smi.so'].amdsmi_get_cpu_pwr_svi_telemetry_all_rails
 amdsmi_get_cpu_pwr_svi_telemetry_all_rails.restype = amdsmi_status_t
 amdsmi_get_cpu_pwr_svi_telemetry_all_rails.argtypes = [amdsmi_processor_handle, ctypes.POINTER(ctypes.c_uint32)]
@@ -2872,7 +2872,13 @@ amdsmi_set_cpu_socket_power_cap.argtypes = [amdsmi_processor_handle, uint32_t]
 uint8_t = ctypes.c_uint8
 amdsmi_set_cpu_pwr_efficiency_mode = _libraries['libamd_smi.so'].amdsmi_set_cpu_pwr_efficiency_mode
 amdsmi_set_cpu_pwr_efficiency_mode.restype = amdsmi_status_t
-amdsmi_set_cpu_pwr_efficiency_mode.argtypes = [amdsmi_processor_handle, uint8_t]
+amdsmi_set_cpu_pwr_efficiency_mode.argtypes = [amdsmi_processor_handle, uint8_t, ctypes.POINTER(ctypes.c_uint32), ctypes.POINTER(ctypes.c_uint32)]
+amdsmi_get_cpu_pwr_efficiency_mode = _libraries['libamd_smi.so'].amdsmi_get_cpu_pwr_efficiency_mode
+amdsmi_get_cpu_pwr_efficiency_mode.restype = amdsmi_status_t
+amdsmi_get_cpu_pwr_efficiency_mode.argtypes = [amdsmi_processor_handle, ctypes.POINTER(ctypes.c_uint32), ctypes.POINTER(ctypes.c_uint32), ctypes.POINTER(ctypes.c_double)]
+amdsmi_get_cpu_core_ccd_power = _libraries['libamd_smi.so'].amdsmi_get_cpu_core_ccd_power
+amdsmi_get_cpu_core_ccd_power.restype = amdsmi_status_t
+amdsmi_get_cpu_core_ccd_power.argtypes = [amdsmi_processor_handle, ctypes.POINTER(ctypes.c_double)]
 amdsmi_get_gpu_memory_total = _libraries['libamd_smi.so'].amdsmi_get_gpu_memory_total
 amdsmi_get_gpu_memory_total.restype = amdsmi_status_t
 amdsmi_get_gpu_memory_total.argtypes = [amdsmi_processor_handle, amdsmi_memory_type_t, ctypes.POINTER(ctypes.c_uint64)]
@@ -3312,6 +3318,18 @@ amdsmi_get_cpu_socket_freq_range.argtypes = [amdsmi_processor_handle, ctypes.POI
 amdsmi_get_cpu_core_current_freq_limit = _libraries['libamd_smi.so'].amdsmi_get_cpu_core_current_freq_limit
 amdsmi_get_cpu_core_current_freq_limit.restype = amdsmi_status_t
 amdsmi_get_cpu_core_current_freq_limit.argtypes = [amdsmi_processor_handle, ctypes.POINTER(ctypes.c_uint32)]
+amdsmi_set_cpu_rail_isofreq_policy = _libraries['libamd_smi.so'].amdsmi_set_cpu_rail_isofreq_policy
+amdsmi_set_cpu_rail_isofreq_policy.restype = amdsmi_status_t
+amdsmi_set_cpu_rail_isofreq_policy.argtypes = [amdsmi_processor_handle, ctypes.POINTER(ctypes.c_bool)]
+amdsmi_get_cpu_rail_isofreq_policy = _libraries['libamd_smi.so'].amdsmi_get_cpu_rail_isofreq_policy
+amdsmi_get_cpu_rail_isofreq_policy.restype = amdsmi_status_t
+amdsmi_get_cpu_rail_isofreq_policy.argtypes = [amdsmi_processor_handle, ctypes.POINTER(ctypes.c_ubyte)]
+amdsmi_set_cpu_dfc_ctrl = _libraries['libamd_smi.so'].amdsmi_set_cpu_dfc_ctrl
+amdsmi_set_cpu_dfc_ctrl.restype = amdsmi_status_t
+amdsmi_set_cpu_dfc_ctrl.argtypes = [amdsmi_processor_handle, ctypes.POINTER(ctypes.c_ubyte)]
+amdsmi_get_cpu_dfc_ctrl = _libraries['libamd_smi.so'].amdsmi_get_cpu_dfc_ctrl
+amdsmi_get_cpu_dfc_ctrl.restype = amdsmi_status_t
+amdsmi_get_cpu_dfc_ctrl.argtypes = [amdsmi_processor_handle, ctypes.POINTER(ctypes.c_ubyte)]
 amdsmi_get_cpu_core_boostlimit = _libraries['libamd_smi.so'].amdsmi_get_cpu_core_boostlimit
 amdsmi_get_cpu_core_boostlimit.restype = amdsmi_status_t
 amdsmi_get_cpu_core_boostlimit.argtypes = [amdsmi_processor_handle, ctypes.POINTER(ctypes.c_uint32)]
@@ -3324,12 +3342,51 @@ amdsmi_set_cpu_core_boostlimit.argtypes = [amdsmi_processor_handle, uint32_t]
 amdsmi_set_cpu_socket_boostlimit = _libraries['libamd_smi.so'].amdsmi_set_cpu_socket_boostlimit
 amdsmi_set_cpu_socket_boostlimit.restype = amdsmi_status_t
 amdsmi_set_cpu_socket_boostlimit.argtypes = [amdsmi_processor_handle, uint32_t]
+amdsmi_get_cpu_core_floor_freq_limit = _libraries['libamd_smi.so'].amdsmi_get_cpu_core_floor_freq_limit
+amdsmi_get_cpu_core_floor_freq_limit.restype = amdsmi_status_t
+amdsmi_get_cpu_core_floor_freq_limit.argtypes = [amdsmi_processor_handle, ctypes.POINTER(ctypes.c_uint32)]
+amdsmi_get_cpu_floor_freq_limit = _libraries['libamd_smi.so'].amdsmi_get_cpu_floor_freq_limit
+amdsmi_get_cpu_floor_freq_limit.restype = amdsmi_status_t
+amdsmi_get_cpu_floor_freq_limit.argtypes = [amdsmi_processor_handle, ctypes.POINTER(ctypes.c_uint32)]
+amdsmi_get_cpu_core_eff_floor_freq_limit = _libraries['libamd_smi.so'].amdsmi_get_cpu_core_eff_floor_freq_limit
+amdsmi_get_cpu_core_eff_floor_freq_limit.restype = amdsmi_status_t
+amdsmi_get_cpu_core_eff_floor_freq_limit.argtypes = [amdsmi_processor_handle, ctypes.POINTER(ctypes.c_uint32)]
+amdsmi_get_cpu_eff_floor_freq_limit = _libraries['libamd_smi.so'].amdsmi_get_cpu_eff_floor_freq_limit
+amdsmi_get_cpu_eff_floor_freq_limit.restype = amdsmi_status_t
+amdsmi_get_cpu_eff_floor_freq_limit.argtypes = [amdsmi_processor_handle, ctypes.POINTER(ctypes.c_uint32)]
+amdsmi_set_cpu_core_floor_freq_limit = _libraries['libamd_smi.so'].amdsmi_set_cpu_core_floor_freq_limit
+amdsmi_set_cpu_core_floor_freq_limit.restype = amdsmi_status_t
+amdsmi_set_cpu_core_floor_freq_limit.argtypes = [amdsmi_processor_handle, uint32_t]
+amdsmi_set_cpu_floor_freq_limit = _libraries['libamd_smi.so'].amdsmi_set_cpu_floor_freq_limit
+amdsmi_set_cpu_floor_freq_limit.restype = amdsmi_status_t
+amdsmi_set_cpu_floor_freq_limit.argtypes = [amdsmi_processor_handle, uint32_t]
+amdsmi_set_cpu_msr_floor_freq_limit = _libraries['libamd_smi.so'].amdsmi_set_cpu_msr_floor_freq_limit
+amdsmi_set_cpu_msr_floor_freq_limit.restype = amdsmi_status_t
+amdsmi_set_cpu_msr_floor_freq_limit.argtypes = [amdsmi_processor_handle, uint32_t]
+amdsmi_set_cpu_core_msr_floor_freq_limit = _libraries['libamd_smi.so'].amdsmi_set_cpu_core_msr_floor_freq_limit
+amdsmi_set_cpu_core_msr_floor_freq_limit.restype = amdsmi_status_t
+amdsmi_set_cpu_core_msr_floor_freq_limit.argtypes = [amdsmi_processor_handle, uint32_t]
+amdsmi_get_cpu_freq_range = _libraries['libamd_smi.so'].amdsmi_get_cpu_freq_range
+amdsmi_get_cpu_freq_range.restype = amdsmi_status_t
+amdsmi_get_cpu_freq_range.argtypes = [ctypes.POINTER(ctypes.c_uint32), ctypes.POINTER(ctypes.c_uint32)]
+amdsmi_set_cpu_sdps_limit = _libraries['libamd_smi.so'].amdsmi_set_cpu_sdps_limit
+amdsmi_set_cpu_sdps_limit.restype = amdsmi_status_t
+amdsmi_set_cpu_sdps_limit.argtypes = [amdsmi_processor_handle, uint32_t]
+amdsmi_get_cpu_sdps_limit = _libraries['libamd_smi.so'].amdsmi_get_cpu_sdps_limit
+amdsmi_get_cpu_sdps_limit.restype = amdsmi_status_t
+amdsmi_get_cpu_sdps_limit.argtypes = [amdsmi_processor_handle, ctypes.POINTER(ctypes.c_double)]
 amdsmi_get_cpu_ddr_bw = _libraries['libamd_smi.so'].amdsmi_get_cpu_ddr_bw
 amdsmi_get_cpu_ddr_bw.restype = amdsmi_status_t
 amdsmi_get_cpu_ddr_bw.argtypes = [amdsmi_processor_handle, ctypes.POINTER(struct_amdsmi_ddr_bw_metrics_t)]
 amdsmi_get_cpu_socket_temperature = _libraries['libamd_smi.so'].amdsmi_get_cpu_socket_temperature
 amdsmi_get_cpu_socket_temperature.restype = amdsmi_status_t
 amdsmi_get_cpu_socket_temperature.argtypes = [amdsmi_processor_handle, ctypes.POINTER(ctypes.c_uint32)]
+amdsmi_get_cpu_tdelta = _libraries['libamd_smi.so'].amdsmi_get_cpu_tdelta
+amdsmi_get_cpu_tdelta.restype = amdsmi_status_t
+amdsmi_get_cpu_tdelta.argtypes = [amdsmi_processor_handle, ctypes.POINTER(ctypes.c_ubyte)]
+amdsmi_get_cpu_svi3_vr_controller_temp = _libraries['libamd_smi.so'].amdsmi_get_cpu_svi3_vr_controller_temp
+amdsmi_get_cpu_svi3_vr_controller_temp.restype = amdsmi_status_t
+amdsmi_get_cpu_svi3_vr_controller_temp.argtypes = [amdsmi_processor_handle, ctypes.POINTER(ctypes.c_uint32), ctypes.POINTER(ctypes.c_uint32), ctypes.POINTER(ctypes.c_uint32)]
 amdsmi_get_cpu_dimm_temp_range_and_refresh_rate = _libraries['libamd_smi.so'].amdsmi_get_cpu_dimm_temp_range_and_refresh_rate
 amdsmi_get_cpu_dimm_temp_range_and_refresh_rate.restype = amdsmi_status_t
 amdsmi_get_cpu_dimm_temp_range_and_refresh_rate.argtypes = [amdsmi_processor_handle, uint8_t, ctypes.POINTER(struct_amdsmi_temp_range_refresh_rate_t)]
@@ -3339,6 +3396,12 @@ amdsmi_get_cpu_dimm_power_consumption.argtypes = [amdsmi_processor_handle, uint8
 amdsmi_get_cpu_dimm_thermal_sensor = _libraries['libamd_smi.so'].amdsmi_get_cpu_dimm_thermal_sensor
 amdsmi_get_cpu_dimm_thermal_sensor.restype = amdsmi_status_t
 amdsmi_get_cpu_dimm_thermal_sensor.argtypes = [amdsmi_processor_handle, uint8_t, ctypes.POINTER(struct_amdsmi_dimm_thermal_t)]
+amdsmi_get_cpu_dimm_sb_reg = _libraries['libamd_smi.so'].amdsmi_get_cpu_dimm_sb_reg
+amdsmi_get_cpu_dimm_sb_reg.restype = amdsmi_status_t
+amdsmi_get_cpu_dimm_sb_reg.argtypes = [amdsmi_processor_handle, uint32_t, uint32_t, uint32_t, uint32_t, ctypes.POINTER(ctypes.c_uint32)]
+amdsmi_set_cpu_dimm_sb_reg = _libraries['libamd_smi.so'].amdsmi_set_cpu_dimm_sb_reg
+amdsmi_set_cpu_dimm_sb_reg.restype = amdsmi_status_t
+amdsmi_set_cpu_dimm_sb_reg.argtypes = [amdsmi_processor_handle, uint32_t, uint32_t, uint32_t, uint32_t, uint32_t]
 amdsmi_set_cpu_xgmi_width = _libraries['libamd_smi.so'].amdsmi_set_cpu_xgmi_width
 amdsmi_set_cpu_xgmi_width.restype = amdsmi_status_t
 amdsmi_set_cpu_xgmi_width.argtypes = [amdsmi_processor_handle, uint8_t, uint8_t]
@@ -3363,6 +3426,24 @@ amdsmi_set_cpu_pcie_link_rate.argtypes = [amdsmi_processor_handle, uint8_t, ctyp
 amdsmi_set_cpu_df_pstate_range = _libraries['libamd_smi.so'].amdsmi_set_cpu_df_pstate_range
 amdsmi_set_cpu_df_pstate_range.restype = amdsmi_status_t
 amdsmi_set_cpu_df_pstate_range.argtypes = [amdsmi_processor_handle, uint8_t, uint8_t]
+amdsmi_set_cpu_xgmi_pstate_range = _libraries['libamd_smi.so'].amdsmi_set_cpu_xgmi_pstate_range
+amdsmi_set_cpu_xgmi_pstate_range.restype = amdsmi_status_t
+amdsmi_set_cpu_xgmi_pstate_range.argtypes = [amdsmi_processor_handle, uint8_t, uint8_t]
+amdsmi_get_cpu_xgmi_pstate_range = _libraries['libamd_smi.so'].amdsmi_get_cpu_xgmi_pstate_range
+amdsmi_get_cpu_xgmi_pstate_range.restype = amdsmi_status_t
+amdsmi_get_cpu_xgmi_pstate_range.argtypes = [amdsmi_processor_handle, ctypes.POINTER(ctypes.c_ubyte), ctypes.POINTER(ctypes.c_ubyte)]
+amdsmi_get_cpu_pc6_enable = _libraries['libamd_smi.so'].amdsmi_get_cpu_pc6_enable
+amdsmi_get_cpu_pc6_enable.restype = amdsmi_status_t
+amdsmi_get_cpu_pc6_enable.argtypes = [amdsmi_processor_handle, ctypes.POINTER(ctypes.c_ubyte)]
+amdsmi_set_cpu_pc6_enable = _libraries['libamd_smi.so'].amdsmi_set_cpu_pc6_enable
+amdsmi_set_cpu_pc6_enable.restype = amdsmi_status_t
+amdsmi_set_cpu_pc6_enable.argtypes = [amdsmi_processor_handle, uint8_t]
+amdsmi_get_cpu_cc6_enable = _libraries['libamd_smi.so'].amdsmi_get_cpu_cc6_enable
+amdsmi_get_cpu_cc6_enable.restype = amdsmi_status_t
+amdsmi_get_cpu_cc6_enable.argtypes = [amdsmi_processor_handle, ctypes.POINTER(ctypes.c_ubyte)]
+amdsmi_set_cpu_cc6_enable = _libraries['libamd_smi.so'].amdsmi_set_cpu_cc6_enable
+amdsmi_set_cpu_cc6_enable.restype = amdsmi_status_t
+amdsmi_set_cpu_cc6_enable.argtypes = [amdsmi_processor_handle, uint8_t]
 amdsmi_get_cpu_current_io_bandwidth = _libraries['libamd_smi.so'].amdsmi_get_cpu_current_io_bandwidth
 amdsmi_get_cpu_current_io_bandwidth.restype = amdsmi_status_t
 amdsmi_get_cpu_current_io_bandwidth.argtypes = [amdsmi_processor_handle, amdsmi_link_id_bw_type_t, ctypes.POINTER(ctypes.c_uint32)]
@@ -3396,18 +3477,9 @@ amdsmi_get_cpu_cores_per_socket.argtypes = [uint32_t, ctypes.POINTER(struct_amds
 amdsmi_get_cpu_socket_count = _libraries['libamd_smi.so'].amdsmi_get_cpu_socket_count
 amdsmi_get_cpu_socket_count.restype = amdsmi_status_t
 amdsmi_get_cpu_socket_count.argtypes = [ctypes.POINTER(ctypes.c_uint32)]
-amdsmi_set_cpu_rail_isofreq_policy = _libraries['libamd_smi.so'].amdsmi_set_cpu_rail_isofreq_policy
-amdsmi_set_cpu_rail_isofreq_policy.restype = amdsmi_status_t
-amdsmi_set_cpu_rail_isofreq_policy.argtypes = [amdsmi_processor_handle, uint8_t]
-amdsmi_get_cpu_rail_isofreq_policy = _libraries['libamd_smi.so'].amdsmi_get_cpu_rail_isofreq_policy
-amdsmi_get_cpu_rail_isofreq_policy.restype = amdsmi_status_t
-amdsmi_get_cpu_rail_isofreq_policy.argtypes = [amdsmi_processor_handle, ctypes.POINTER(ctypes.c_ubyte)]
-amdsmi_set_dfc_ctrl = _libraries['libamd_smi.so'].amdsmi_set_dfc_ctrl
-amdsmi_set_dfc_ctrl.restype = amdsmi_status_t
-amdsmi_set_dfc_ctrl.argtypes = [amdsmi_processor_handle, ctypes.c_bool]
-amdsmi_get_dfc_ctrl = _libraries['libamd_smi.so'].amdsmi_get_dfc_ctrl
-amdsmi_get_dfc_ctrl.restype = amdsmi_status_t
-amdsmi_get_dfc_ctrl.argtypes = [amdsmi_processor_handle, ctypes.POINTER(ctypes.c_ubyte)]
+amdsmi_get_cpu_enabled_commands = _libraries['libamd_smi.so'].amdsmi_get_cpu_enabled_commands
+amdsmi_get_cpu_enabled_commands.restype = amdsmi_status_t
+amdsmi_get_cpu_enabled_commands.argtypes = [amdsmi_processor_handle, ctypes.POINTER(ctypes.c_bool), ctypes.POINTER(ctypes.c_uint32), ctypes.POINTER(ctypes.c_uint32), ctypes.POINTER(ctypes.c_uint32)]
 amdsmi_get_nic_driver_info = _libraries['libamd_smi.so'].amdsmi_get_nic_driver_info
 amdsmi_get_nic_driver_info.restype = amdsmi_status_t
 amdsmi_get_nic_driver_info.argtypes = [amdsmi_processor_handle, ctypes.POINTER(struct_amdsmi_nic_driver_info_t)]
@@ -3748,21 +3820,32 @@ __all__ = \
     'amdsmi_frequency_range_t', 'amdsmi_fw_block_t',
     'amdsmi_fw_info_t', 'amdsmi_get_afids_from_cper',
     'amdsmi_get_clk_freq', 'amdsmi_get_clock_info',
-    'amdsmi_get_cpu_affinity_with_scope', 'amdsmi_get_cpu_cclk_limit',
-    'amdsmi_get_cpu_core_boostlimit',
+    'amdsmi_get_cpu_affinity_with_scope', 'amdsmi_get_cpu_cc6_enable',
+    'amdsmi_get_cpu_cclk_limit', 'amdsmi_get_cpu_core_boostlimit',
+    'amdsmi_get_cpu_core_ccd_power',
     'amdsmi_get_cpu_core_current_freq_limit',
-    'amdsmi_get_cpu_core_energy', 'amdsmi_get_cpu_cores_per_socket',
+    'amdsmi_get_cpu_core_eff_floor_freq_limit',
+    'amdsmi_get_cpu_core_energy',
+    'amdsmi_get_cpu_core_floor_freq_limit',
+    'amdsmi_get_cpu_cores_per_socket',
     'amdsmi_get_cpu_current_io_bandwidth',
     'amdsmi_get_cpu_current_xgmi_bw', 'amdsmi_get_cpu_ddr_bw',
+    'amdsmi_get_cpu_dfc_ctrl',
     'amdsmi_get_cpu_dimm_power_consumption',
+    'amdsmi_get_cpu_dimm_sb_reg',
     'amdsmi_get_cpu_dimm_temp_range_and_refresh_rate',
-    'amdsmi_get_cpu_dimm_thermal_sensor', 'amdsmi_get_cpu_family',
-    'amdsmi_get_cpu_fclk_mclk', 'amdsmi_get_cpu_handles',
+    'amdsmi_get_cpu_dimm_thermal_sensor',
+    'amdsmi_get_cpu_eff_floor_freq_limit',
+    'amdsmi_get_cpu_enabled_commands', 'amdsmi_get_cpu_family',
+    'amdsmi_get_cpu_fclk_mclk', 'amdsmi_get_cpu_floor_freq_limit',
+    'amdsmi_get_cpu_freq_range', 'amdsmi_get_cpu_handles',
     'amdsmi_get_cpu_hsmp_driver_version',
     'amdsmi_get_cpu_hsmp_proto_ver', 'amdsmi_get_cpu_model',
-    'amdsmi_get_cpu_model_name', 'amdsmi_get_cpu_prochot_status',
+    'amdsmi_get_cpu_model_name', 'amdsmi_get_cpu_pc6_enable',
+    'amdsmi_get_cpu_prochot_status',
+    'amdsmi_get_cpu_pwr_efficiency_mode',
     'amdsmi_get_cpu_pwr_svi_telemetry_all_rails',
-    'amdsmi_get_cpu_rail_isofreq_policy',
+    'amdsmi_get_cpu_rail_isofreq_policy', 'amdsmi_get_cpu_sdps_limit',
     'amdsmi_get_cpu_smu_fw_version',
     'amdsmi_get_cpu_socket_c0_residency',
     'amdsmi_get_cpu_socket_count',
@@ -3772,8 +3855,9 @@ __all__ = \
     'amdsmi_get_cpu_socket_lclk_dpm_level',
     'amdsmi_get_cpu_socket_power', 'amdsmi_get_cpu_socket_power_cap',
     'amdsmi_get_cpu_socket_power_cap_max',
-    'amdsmi_get_cpu_socket_temperature', 'amdsmi_get_cpucore_handles',
-    'amdsmi_get_cpusocket_handles', 'amdsmi_get_dfc_ctrl',
+    'amdsmi_get_cpu_socket_temperature',
+    'amdsmi_get_cpu_svi3_vr_controller_temp', 'amdsmi_get_cpu_tdelta',
+    'amdsmi_get_cpu_xgmi_pstate_range', 'amdsmi_get_cpucore_handles',
     'amdsmi_get_energy_count', 'amdsmi_get_esmi_err_msg',
     'amdsmi_get_fw_info',
     'amdsmi_get_gpu_accelerator_partition_profile',
@@ -3880,16 +3964,20 @@ __all__ = \
     'amdsmi_ras_feature_t', 'amdsmi_reg_type_t', 'amdsmi_reset_gpu',
     'amdsmi_reset_gpu_fan', 'amdsmi_reset_gpu_xgmi_error',
     'amdsmi_retired_page_record_t', 'amdsmi_set_clk_freq',
-    'amdsmi_set_cpu_core_boostlimit',
-    'amdsmi_set_cpu_df_pstate_range',
+    'amdsmi_set_cpu_cc6_enable', 'amdsmi_set_cpu_core_boostlimit',
+    'amdsmi_set_cpu_core_floor_freq_limit',
+    'amdsmi_set_cpu_core_msr_floor_freq_limit',
+    'amdsmi_set_cpu_df_pstate_range', 'amdsmi_set_cpu_dfc_ctrl',
+    'amdsmi_set_cpu_dimm_sb_reg', 'amdsmi_set_cpu_floor_freq_limit',
     'amdsmi_set_cpu_gmi3_link_width_range',
-    'amdsmi_set_cpu_pcie_link_rate',
+    'amdsmi_set_cpu_msr_floor_freq_limit',
+    'amdsmi_set_cpu_pc6_enable', 'amdsmi_set_cpu_pcie_link_rate',
     'amdsmi_set_cpu_pwr_efficiency_mode',
-    'amdsmi_set_cpu_rail_isofreq_policy',
+    'amdsmi_set_cpu_rail_isofreq_policy', 'amdsmi_set_cpu_sdps_limit',
     'amdsmi_set_cpu_socket_boostlimit',
     'amdsmi_set_cpu_socket_lclk_dpm_level',
-    'amdsmi_set_cpu_socket_power_cap', 'amdsmi_set_cpu_xgmi_width',
-    'amdsmi_set_dfc_ctrl',
+    'amdsmi_set_cpu_socket_power_cap',
+    'amdsmi_set_cpu_xgmi_pstate_range', 'amdsmi_set_cpu_xgmi_width',
     'amdsmi_set_gpu_accelerator_partition_profile',
     'amdsmi_set_gpu_clk_limit', 'amdsmi_set_gpu_clk_range',
     'amdsmi_set_gpu_compute_partition',

--- a/projects/amdsmi/src/amd_smi/amd_smi.cc
+++ b/projects/amdsmi/src/amd_smi/amd_smi.cc
@@ -6824,7 +6824,7 @@ amdsmi_status_t amdsmi_get_cpu_core_current_freq_limit(amdsmi_processor_handle p
 }
 
 amdsmi_status_t amdsmi_get_cpu_socket_power(amdsmi_processor_handle processor_handle,
-                                            uint32_t *ppower)
+                                            double *ppower)
 {
     amdsmi_status_t status;
     uint32_t avg_power;
@@ -6845,13 +6845,14 @@ amdsmi_status_t amdsmi_get_cpu_socket_power(amdsmi_processor_handle processor_ha
     if (status != AMDSMI_STATUS_SUCCESS)
         return amdsmi_errno_to_esmi_status(status);
 
-    *ppower = avg_power;
+    // Convert milliwatts to watts
+    *ppower = static_cast<double>(avg_power)/1000.0;
 
     return AMDSMI_STATUS_SUCCESS;
 }
 
 amdsmi_status_t amdsmi_get_cpu_socket_power_cap(amdsmi_processor_handle processor_handle,
-                                                uint32_t *pcap)
+                                                double *pcap)
 {
     amdsmi_status_t status;
     uint32_t p_cap;
@@ -6872,13 +6873,14 @@ amdsmi_status_t amdsmi_get_cpu_socket_power_cap(amdsmi_processor_handle processo
     if (status != AMDSMI_STATUS_SUCCESS)
         return amdsmi_errno_to_esmi_status(status);
 
-    *pcap = p_cap;
+    // Convert milliwatts to watts
+    *pcap = static_cast<double>(p_cap)/1000.0;
 
     return AMDSMI_STATUS_SUCCESS;
 }
 
 amdsmi_status_t amdsmi_get_cpu_socket_power_cap_max(amdsmi_processor_handle processor_handle,
-                                                    uint32_t *pmax)
+                                                    double *pmax)
 {
     amdsmi_status_t status;
     uint32_t p_max;
@@ -6899,7 +6901,8 @@ amdsmi_status_t amdsmi_get_cpu_socket_power_cap_max(amdsmi_processor_handle proc
     if (status != AMDSMI_STATUS_SUCCESS)
         return amdsmi_errno_to_esmi_status(status);
 
-    *pmax = p_max;
+    // Convert milliwatts to watts
+    *pmax = static_cast<double>(p_max)/1000.0;
 
     return AMDSMI_STATUS_SUCCESS;
 }
@@ -6957,26 +6960,101 @@ amdsmi_status_t amdsmi_set_cpu_socket_power_cap(amdsmi_processor_handle processo
 }
 
 amdsmi_status_t amdsmi_set_cpu_pwr_efficiency_mode(amdsmi_processor_handle processor_handle,
-                                                   uint8_t mode)
+                                                   uint8_t power_efficiency_mode,
+                                                   uint32_t *utilization,
+                                                   uint32_t *ppt_limit)
 {
     amdsmi_status_t status;
     uint8_t sock_ind;
+    uint32_t pwreffmode_util = 0;
+    uint32_t pwreffmode_pptlimit = 0;
+    amdsmi_status_t ret;
+
+    AMDSMI_CHECK_INIT();
+
+    if (processor_handle == nullptr || utilization == nullptr || ppt_limit == nullptr )
+        return AMDSMI_STATUS_INVAL;
+
+    pwreffmode_util = *utilization;
+    pwreffmode_pptlimit = *ppt_limit;
+
+    if ((power_efficiency_mode == POWER_EFFICIENCY_MODE_4) || (power_efficiency_mode == POWER_EFFICIENCY_MODE_5)) {
+        uint32_t cpu_family;
+        uint32_t cpu_model;
+        // cpu_family and cpu_model are only needed for mode 4/5 validation
+        ret = amdsmi_get_cpu_family(&cpu_family);
+        if (ret != AMDSMI_STATUS_SUCCESS)
+            return ret;
+
+        ret = amdsmi_get_cpu_model(&cpu_model);
+        if (ret != AMDSMI_STATUS_SUCCESS)
+            return ret;
+
+        // Check if utilization and ppt_limit are valid for this family/model/mode combination
+        if((0x1A == cpu_family) && ((cpu_model >= 0x50) && (cpu_model <= 0x5F))) {
+            //User has to provide utilization and ppt limit when power_efficiency_mode is 4 or 5 , for family 0x1A and model 0x50 onwards
+            if ((pwreffmode_util > AMDSMI_MAX_POWER_EFFICIENCY_UTIL) || (pwreffmode_pptlimit > AMDSMI_MAX_POWER_EFFICIENCY_PPTLIMIT))
+            {
+                return AMDSMI_STATUS_INVAL;
+            }
+	}
+	else{
+	    pwreffmode_util = 0;
+            pwreffmode_pptlimit = 0;
+	}
+    }
+    // utilization and ppt_limit is only considered if the power_efficiency_mode is 4 or 5
+    else
+    {
+        pwreffmode_util = 0;
+        pwreffmode_pptlimit = 0;
+    }
+
+    amdsmi_status_t r = amdsmi_get_processor_info(processor_handle, SIZE, proc_id);
+    if (r != AMDSMI_STATUS_SUCCESS)
+        return r;
+
+    sock_ind = static_cast<uint8_t>(std::stoi(proc_id, NULL, 0));
+
+    status = static_cast<amdsmi_status_t>(esmi_pwr_efficiency_mode_set(sock_ind, power_efficiency_mode, &pwreffmode_util, &pwreffmode_pptlimit));
+    if (status != AMDSMI_STATUS_SUCCESS)
+        return amdsmi_errno_to_esmi_status(status);
+
+    *utilization = pwreffmode_util;
+    *ppt_limit = pwreffmode_pptlimit;
+    return AMDSMI_STATUS_SUCCESS;
+}
+
+amdsmi_status_t amdsmi_get_cpu_pwr_efficiency_mode(amdsmi_processor_handle processor_handle,
+                                                   uint32_t *power_efficiency_mode,
+                                                   uint32_t *utilization,
+                                                   double *ppt_limit)
+{
+    amdsmi_status_t status;
+    uint8_t sock_ind;
+    uint8_t mode_uint8;
+    uint32_t pptlimit_uint32;
 
     AMDSMI_CHECK_INIT();
 
     if (processor_handle == nullptr)
         return AMDSMI_STATUS_INVAL;
 
+    if (power_efficiency_mode == nullptr || utilization == nullptr || ppt_limit == nullptr)
+        return AMDSMI_STATUS_INVAL;
+
     amdsmi_status_t r = amdsmi_get_processor_info(processor_handle, SIZE, proc_id);
     if (r != AMDSMI_STATUS_SUCCESS)
         return r;
 
-    sock_ind = (uint8_t)std::stoi(proc_id, NULL, 0);
+    sock_ind = static_cast<uint8_t>(std::stoi(proc_id, NULL, 0));
 
-    status = static_cast<amdsmi_status_t>(esmi_pwr_efficiency_mode_set(sock_ind, mode));
-
+    status = static_cast<amdsmi_status_t>(esmi_pwr_efficiency_mode_get(sock_ind, &mode_uint8, utilization, &pptlimit_uint32));
     if (status != AMDSMI_STATUS_SUCCESS)
         return amdsmi_errno_to_esmi_status(status);
+
+    *power_efficiency_mode = static_cast<uint32_t>(mode_uint8);
+    *ppt_limit = static_cast<double>(pptlimit_uint32)/1000.0;
 
     return AMDSMI_STATUS_SUCCESS;
 }
@@ -7235,13 +7313,20 @@ amdsmi_status_t amdsmi_set_cpu_xgmi_width(amdsmi_processor_handle processor_hand
         uint8_t min, uint8_t max)
 {
     amdsmi_status_t status;
+    uint8_t sock_ind;
 
     AMDSMI_CHECK_INIT();
 
     if (processor_handle == nullptr)
         return AMDSMI_STATUS_INVAL;
 
-    status = static_cast<amdsmi_status_t>(esmi_xgmi_width_set(min, max));
+    amdsmi_status_t r = amdsmi_get_processor_info(processor_handle, SIZE, proc_id);
+    if (r != AMDSMI_STATUS_SUCCESS)
+        return r;
+
+    sock_ind = (uint8_t)std::stoi(proc_id, NULL, 0);
+
+    status = static_cast<amdsmi_status_t>(esmi_xgmi_width_set(sock_ind, min, max));
     if (status != AMDSMI_STATUS_SUCCESS)
         return amdsmi_errno_to_esmi_status(status);
 
@@ -7402,7 +7487,7 @@ amdsmi_status_t amdsmi_set_cpu_pcie_link_rate(amdsmi_processor_handle processor_
 }
 
 amdsmi_status_t amdsmi_set_cpu_df_pstate_range(amdsmi_processor_handle processor_handle,
-        uint8_t max_pstate, uint8_t min_pstate)
+        uint8_t min_pstate, uint8_t max_pstate)
 {
     amdsmi_status_t status;
     uint8_t sock_ind;
@@ -7419,7 +7504,7 @@ amdsmi_status_t amdsmi_set_cpu_df_pstate_range(amdsmi_processor_handle processor
     sock_ind = (uint8_t)std::stoi(proc_id, NULL, 0);
 
     status = static_cast<amdsmi_status_t>(esmi_df_pstate_range_set(sock_ind,
-                                                                        max_pstate, min_pstate));
+                                                                        min_pstate, max_pstate));
     if (status != AMDSMI_STATUS_SUCCESS)
         return amdsmi_errno_to_esmi_status(status);
 
@@ -7777,60 +7862,8 @@ amdsmi_status_t amdsmi_get_esmi_err_msg(amdsmi_status_t status, const char **sta
     return AMDSMI_STATUS_SUCCESS;
 }
 
-amdsmi_status_t amdsmi_set_cpu_rail_isofreq_policy(amdsmi_processor_handle processor_handle,
-                                                   uint8_t input)
-{
-    amdsmi_status_t status;
-    uint8_t sock_ind;
-    bool val;
-
-    AMDSMI_CHECK_INIT();
-
-    if (processor_handle == nullptr )
-        return AMDSMI_STATUS_INVAL;
-
-    amdsmi_status_t r = amdsmi_get_processor_info(processor_handle, SIZE, proc_id);
-    if (r != AMDSMI_STATUS_SUCCESS)
-        return r;
-
-    sock_ind = (uint8_t)std::stoi(proc_id, NULL, 0);
-
-    val = (bool)input;
-    status = static_cast<amdsmi_status_t>(esmi_cpurail_isofreq_policy_set(sock_ind, &val));
-    if (status != AMDSMI_STATUS_SUCCESS)
-        return amdsmi_errno_to_esmi_status(status);
-
-    return AMDSMI_STATUS_SUCCESS;
-}
-
-amdsmi_status_t amdsmi_get_cpu_rail_isofreq_policy(amdsmi_processor_handle processor_handle,
-                                                   uint8_t *cpurailiso)
-{
-    amdsmi_status_t status;
-    uint8_t sock_ind;
-    bool cpurailisofreq;
-
-    AMDSMI_CHECK_INIT();
-
-    if (processor_handle == nullptr || cpurailiso == nullptr)
-        return AMDSMI_STATUS_INVAL;
-
-    amdsmi_status_t r = amdsmi_get_processor_info(processor_handle, SIZE, proc_id);
-    if (r != AMDSMI_STATUS_SUCCESS)
-        return r;
-
-    sock_ind = (uint8_t)std::stoi(proc_id, NULL, 0);
-
-    status = static_cast<amdsmi_status_t>(esmi_cpurail_isofreq_policy_get(sock_ind, &cpurailisofreq));
-    if (status != AMDSMI_STATUS_SUCCESS)
-        return amdsmi_errno_to_esmi_status(status);
-
-    *cpurailiso = (uint8_t) cpurailisofreq;
-    return AMDSMI_STATUS_SUCCESS;
-}
-
-amdsmi_status_t amdsmi_set_dfc_ctrl(amdsmi_processor_handle processor_handle,
-                                    bool dfc_ctrl)
+amdsmi_status_t amdsmi_set_cpu_xgmi_pstate_range(amdsmi_processor_handle processor_handle,
+                                                 uint8_t min_pstate, uint8_t max_pstate)
 {
     amdsmi_status_t status;
     uint8_t sock_ind;
@@ -7844,21 +7877,132 @@ amdsmi_status_t amdsmi_set_dfc_ctrl(amdsmi_processor_handle processor_handle,
     if (r != AMDSMI_STATUS_SUCCESS)
         return r;
 
-    sock_ind = (uint8_t)std::stoi(proc_id, NULL, 0);
+    sock_ind = static_cast<uint8_t>(std::stoi(proc_id, NULL, 0));
 
-    status = static_cast<amdsmi_status_t>(esmi_dfc_enable_set(sock_ind, &dfc_ctrl));
+    status = static_cast<amdsmi_status_t>(esmi_xgmi_pstate_range_set(sock_ind, min_pstate, max_pstate));
     if (status != AMDSMI_STATUS_SUCCESS)
         return amdsmi_errno_to_esmi_status(status);
 
     return AMDSMI_STATUS_SUCCESS;
 }
 
-amdsmi_status_t amdsmi_get_dfc_ctrl(amdsmi_processor_handle processor_handle,
-                                    uint8_t *dfc_ctrl)
+amdsmi_status_t amdsmi_get_cpu_xgmi_pstate_range(amdsmi_processor_handle processor_handle,
+                                                 uint8_t *min_pstate, uint8_t *max_pstate)
 {
     amdsmi_status_t status;
     uint8_t sock_ind;
-    bool dfcctrl;
+    char proc_id[SIZE];
+
+    AMDSMI_CHECK_INIT();
+
+    if (processor_handle == nullptr || min_pstate == nullptr || max_pstate == nullptr)
+        return AMDSMI_STATUS_INVAL;
+
+    amdsmi_status_t r = amdsmi_get_processor_info(processor_handle, SIZE, proc_id);
+    if (r != AMDSMI_STATUS_SUCCESS)
+        return r;
+
+    sock_ind = static_cast<uint8_t>(std::stoi(proc_id, NULL, 0));
+
+    status = static_cast<amdsmi_status_t>(esmi_xgmi_pstate_range_get(sock_ind, min_pstate, max_pstate));
+    if (status != AMDSMI_STATUS_SUCCESS)
+        return amdsmi_errno_to_esmi_status(status);
+
+    return AMDSMI_STATUS_SUCCESS;
+}
+
+amdsmi_status_t amdsmi_set_cpu_rail_isofreq_policy(amdsmi_processor_handle processor_handle,
+                                                   bool *rail_isofreq_policy)
+{
+    amdsmi_status_t status;
+    uint8_t sock_ind;
+    bool val;
+
+    AMDSMI_CHECK_INIT();
+
+    if (processor_handle == nullptr || rail_isofreq_policy == nullptr)
+        return AMDSMI_STATUS_INVAL;
+
+    amdsmi_status_t r = amdsmi_get_processor_info(processor_handle, SIZE, proc_id);
+    if (r != AMDSMI_STATUS_SUCCESS)
+        return r;
+
+    sock_ind = static_cast<uint8_t>(std::stoi(proc_id, NULL, 0));
+    val = *rail_isofreq_policy;
+
+    status = static_cast<amdsmi_status_t>(esmi_cpurail_isofreq_policy_set(sock_ind, &val));
+    if (status != AMDSMI_STATUS_SUCCESS)
+        return amdsmi_errno_to_esmi_status(status);
+
+    *rail_isofreq_policy = val;
+    return AMDSMI_STATUS_SUCCESS;
+}
+
+amdsmi_status_t amdsmi_get_cpu_rail_isofreq_policy(amdsmi_processor_handle processor_handle,
+                                                   uint8_t *rail_isofreq_policy)
+{
+    amdsmi_status_t status;
+    uint8_t sock_ind;
+    bool val;
+
+    AMDSMI_CHECK_INIT();
+
+    if (processor_handle == nullptr || rail_isofreq_policy == nullptr)
+        return AMDSMI_STATUS_INVAL;
+
+    amdsmi_status_t r = amdsmi_get_processor_info(processor_handle, SIZE, proc_id);
+    if (r != AMDSMI_STATUS_SUCCESS)
+        return r;
+
+    sock_ind = static_cast<uint8_t>(std::stoi(proc_id, NULL, 0));
+
+    status = static_cast<amdsmi_status_t>(esmi_cpurail_isofreq_policy_get(sock_ind, &val));
+    if (status != AMDSMI_STATUS_SUCCESS)
+        return amdsmi_errno_to_esmi_status(status);
+
+    *rail_isofreq_policy = static_cast<uint8_t>(val);
+    return AMDSMI_STATUS_SUCCESS;
+}
+
+amdsmi_status_t amdsmi_set_cpu_dfc_ctrl(amdsmi_processor_handle processor_handle,
+                                        uint8_t *dfc_ctrl)
+{
+    amdsmi_status_t status;
+    uint8_t sock_ind;
+    bool val;
+
+    AMDSMI_CHECK_INIT();
+
+    if (processor_handle == nullptr || dfc_ctrl == nullptr)
+        return AMDSMI_STATUS_INVAL;
+
+    //dfc_ctrl must be 0 or 1
+    if ((*dfc_ctrl) > 1) {
+	return AMDSMI_STATUS_INVAL;
+    }
+
+    amdsmi_status_t r = amdsmi_get_processor_info(processor_handle, SIZE, proc_id);
+    if (r != AMDSMI_STATUS_SUCCESS)
+        return r;
+
+    sock_ind = static_cast<uint8_t>(std::stoi(proc_id, NULL, 0));
+    val = static_cast<bool>(*dfc_ctrl);
+
+    status = static_cast<amdsmi_status_t>(esmi_dfc_enable_set(sock_ind, &val));
+    if (status != AMDSMI_STATUS_SUCCESS)
+        return amdsmi_errno_to_esmi_status(status);
+
+    *dfc_ctrl = static_cast<uint8_t>(val);
+
+    return AMDSMI_STATUS_SUCCESS;
+}
+
+amdsmi_status_t amdsmi_get_cpu_dfc_ctrl(amdsmi_processor_handle processor_handle,
+                                        uint8_t *dfc_ctrl)
+{
+    amdsmi_status_t status;
+    uint8_t sock_ind;
+    bool dfc_ctrl_status;
 
     AMDSMI_CHECK_INIT();
 
@@ -7869,13 +8013,655 @@ amdsmi_status_t amdsmi_get_dfc_ctrl(amdsmi_processor_handle processor_handle,
     if (r != AMDSMI_STATUS_SUCCESS)
         return r;
 
-    sock_ind = (uint8_t)std::stoi(proc_id, NULL, 0);
+    sock_ind = static_cast<uint8_t>(std::stoi(proc_id, NULL, 0));
 
-    status = static_cast<amdsmi_status_t>(esmi_dfc_ctrl_setting_get(sock_ind, &dfcctrl));
+    status = static_cast<amdsmi_status_t>(esmi_dfc_ctrl_setting_get(sock_ind, &dfc_ctrl_status));
     if (status != AMDSMI_STATUS_SUCCESS)
         return amdsmi_errno_to_esmi_status(status);
 
-    *dfc_ctrl = (uint8_t)dfcctrl;
+    *dfc_ctrl = static_cast<uint8_t>(dfc_ctrl_status);
+
+    return AMDSMI_STATUS_SUCCESS;
+}
+
+amdsmi_status_t amdsmi_set_cpu_pc6_enable(amdsmi_processor_handle processor_handle,
+                                          uint8_t enable)
+{
+    amdsmi_status_t status;
+    uint8_t sock_ind;
+
+    AMDSMI_CHECK_INIT();
+
+    if ((processor_handle == nullptr) || (enable > 1))
+        return AMDSMI_STATUS_INVAL;
+
+    amdsmi_status_t r = amdsmi_get_processor_info(processor_handle, SIZE, proc_id);
+    if (r != AMDSMI_STATUS_SUCCESS)
+        return r;
+
+    sock_ind = static_cast<uint8_t>(std::stoi(proc_id, NULL, 0));
+
+    status = static_cast<amdsmi_status_t>(esmi_pc6_enable_set(sock_ind, enable));
+    if (status != AMDSMI_STATUS_SUCCESS)
+        return amdsmi_errno_to_esmi_status(status);
+
+    return AMDSMI_STATUS_SUCCESS;
+}
+
+amdsmi_status_t amdsmi_get_cpu_pc6_enable(amdsmi_processor_handle processor_handle,
+                                          uint8_t *enabled)
+{
+    amdsmi_status_t status;
+    uint8_t sock_ind;
+    uint8_t pc6_enable;
+
+    AMDSMI_CHECK_INIT();
+
+    if (processor_handle == nullptr || enabled == nullptr)
+        return AMDSMI_STATUS_INVAL;
+
+    amdsmi_status_t r = amdsmi_get_processor_info(processor_handle, SIZE, proc_id);
+    if (r != AMDSMI_STATUS_SUCCESS)
+        return r;
+
+    sock_ind = static_cast<uint8_t>(std::stoi(proc_id, NULL, 0));
+
+    status = static_cast<amdsmi_status_t>(esmi_pc6_enable_get(sock_ind, &pc6_enable));
+    if (status != AMDSMI_STATUS_SUCCESS)
+        return amdsmi_errno_to_esmi_status(status);
+
+    *enabled = pc6_enable;
+
+    return AMDSMI_STATUS_SUCCESS;
+}
+
+amdsmi_status_t amdsmi_set_cpu_cc6_enable(amdsmi_processor_handle processor_handle,
+                                          uint8_t enable)
+{
+    amdsmi_status_t status;
+    uint8_t sock_ind;
+
+    AMDSMI_CHECK_INIT();
+
+    if ((processor_handle == nullptr) || (enable > 1))
+        return AMDSMI_STATUS_INVAL;
+
+    amdsmi_status_t r = amdsmi_get_processor_info(processor_handle, SIZE, proc_id);
+    if (r != AMDSMI_STATUS_SUCCESS)
+        return r;
+
+    sock_ind = static_cast<uint8_t>(std::stoi(proc_id, NULL, 0));
+
+    status = static_cast<amdsmi_status_t>(esmi_cc6_enable_set(sock_ind, enable));
+    if (status != AMDSMI_STATUS_SUCCESS)
+        return amdsmi_errno_to_esmi_status(status);
+
+    return AMDSMI_STATUS_SUCCESS;
+}
+
+amdsmi_status_t amdsmi_get_cpu_cc6_enable(amdsmi_processor_handle processor_handle,
+                                          uint8_t *enabled)
+{
+    amdsmi_status_t status;
+    uint8_t sock_ind;
+    uint8_t cc6_enable;
+
+    AMDSMI_CHECK_INIT();
+
+    if (processor_handle == nullptr || enabled == nullptr)
+        return AMDSMI_STATUS_INVAL;
+
+    amdsmi_status_t r = amdsmi_get_processor_info(processor_handle, SIZE, proc_id);
+    if (r != AMDSMI_STATUS_SUCCESS)
+        return r;
+
+    sock_ind = static_cast<uint8_t>(std::stoi(proc_id, NULL, 0));
+
+    status = static_cast<amdsmi_status_t>(esmi_cc6_enable_get(sock_ind, &cc6_enable));
+    if (status != AMDSMI_STATUS_SUCCESS)
+        return amdsmi_errno_to_esmi_status(status);
+
+    *enabled = cc6_enable;
+
+    return AMDSMI_STATUS_SUCCESS;
+}
+
+amdsmi_status_t amdsmi_get_cpu_dimm_sb_reg(amdsmi_processor_handle processor_handle,
+                                           uint32_t dimm_addr,
+                                           uint32_t lid,
+                                           uint32_t reg_offset,
+                                           uint32_t reg_space,
+                                           uint32_t *data)
+{
+    amdsmi_status_t status;
+    uint8_t sock_ind;
+    struct dimm_sb_info dimm_sb_info_;dimm_sb_info_.m_dimm_sb_info_inarg.reg_value = 0;
+    char proc_id[SIZE];
+
+    AMDSMI_CHECK_INIT();
+
+    if (processor_handle == nullptr || data == nullptr)
+        return AMDSMI_STATUS_INVAL;
+
+    // Validate input ranges based on dimm_sb_info structure
+    if ((dimm_addr > AMDSMI_MAX_SPD_DIMM_ADDRESS) || (lid > AMDSMI_MAX_SPD_LID) || (reg_offset > AMDSMI_MAX_SPD_REG_OFFSET) || (reg_space > AMDSMI_MAX_SPD_REG_SPACE))
+    {
+        return AMDSMI_STATUS_INVAL;
+    }
+
+    amdsmi_status_t r = amdsmi_get_processor_info(processor_handle, SIZE, proc_id);
+    if (r != AMDSMI_STATUS_SUCCESS)
+        return r;
+
+    sock_ind = static_cast<uint8_t>(std::stoi(proc_id, NULL, 0));
+
+    dimm_sb_info_.m_dimm_sb_info_inarg.info.dimm_addr = (dimm_addr & AMDSMI_MAX_SPD_DIMM_ADDRESS);
+    dimm_sb_info_.m_dimm_sb_info_inarg.info.lid = (lid & AMDSMI_MAX_SPD_LID);
+    dimm_sb_info_.m_dimm_sb_info_inarg.info.reg_offset = (reg_offset & AMDSMI_MAX_SPD_REG_OFFSET);
+    dimm_sb_info_.m_dimm_sb_info_inarg.info.reg_space = (reg_space & AMDSMI_MAX_SPD_REG_SPACE);
+    dimm_sb_info_.m_dimm_sb_info_inarg.info.write_data = 0;//Not Used for Read, so initialize to 0
+
+    status = static_cast<amdsmi_status_t>(esmi_dimm_sb_reg_read(sock_ind, &dimm_sb_info_));
+    if (status != AMDSMI_STATUS_SUCCESS)
+        return amdsmi_errno_to_esmi_status(status);
+
+    *data = dimm_sb_info_.read_data;
+    return AMDSMI_STATUS_SUCCESS;
+}
+
+amdsmi_status_t amdsmi_set_cpu_dimm_sb_reg(amdsmi_processor_handle processor_handle,
+                                           uint32_t dimm_addr,
+                                           uint32_t lid,
+                                           uint32_t reg_offset,
+                                           uint32_t reg_space,
+                                           uint32_t write_data)
+{
+    amdsmi_status_t status;
+    uint8_t sock_ind;
+    struct dimm_sb_info dimm_sb_info_;dimm_sb_info_.m_dimm_sb_info_inarg.reg_value = 0;
+    char proc_id[SIZE];
+
+    AMDSMI_CHECK_INIT();
+
+    if (processor_handle == nullptr)
+        return AMDSMI_STATUS_INVAL;
+
+    // Validate input ranges based on dimm_sb_info structure
+    if ((dimm_addr > AMDSMI_MAX_SPD_DIMM_ADDRESS) || (lid > AMDSMI_MAX_SPD_LID) || (reg_offset > AMDSMI_MAX_SPD_REG_OFFSET) || (reg_space > AMDSMI_MAX_SPD_REG_SPACE))
+    {
+        return AMDSMI_STATUS_INVAL;
+    }
+
+    if (write_data > AMDSMI_MAX_SPD_WRITE_DATA)  // 8 bit
+        return AMDSMI_STATUS_INVAL;
+
+    amdsmi_status_t r = amdsmi_get_processor_info(processor_handle, SIZE, proc_id);
+    if (r != AMDSMI_STATUS_SUCCESS)
+        return r;
+
+    sock_ind = static_cast<uint8_t>(std::stoi(proc_id, NULL, 0));
+
+    dimm_sb_info_.m_dimm_sb_info_inarg.info.dimm_addr = (dimm_addr & AMDSMI_MAX_SPD_DIMM_ADDRESS);
+    dimm_sb_info_.m_dimm_sb_info_inarg.info.lid = (lid & AMDSMI_MAX_SPD_LID);
+    dimm_sb_info_.m_dimm_sb_info_inarg.info.reg_offset = (reg_offset & AMDSMI_MAX_SPD_REG_OFFSET);
+    dimm_sb_info_.m_dimm_sb_info_inarg.info.reg_space = (reg_space & AMDSMI_MAX_SPD_REG_SPACE);
+    dimm_sb_info_.m_dimm_sb_info_inarg.info.write_data = (write_data & AMDSMI_MAX_SPD_WRITE_DATA);
+
+    status = static_cast<amdsmi_status_t>(esmi_dimm_sb_reg_write(sock_ind, &dimm_sb_info_));
+    if (status != AMDSMI_STATUS_SUCCESS)
+        return amdsmi_errno_to_esmi_status(status);
+
+    return AMDSMI_STATUS_SUCCESS;
+}
+
+amdsmi_status_t amdsmi_get_cpu_core_ccd_power(amdsmi_processor_handle processor_handle,
+                                              double *power)
+{
+    amdsmi_status_t status;
+    uint8_t core_ind;
+    char proc_id[SIZE];
+    uint32_t power_u32 = 0;
+
+    AMDSMI_CHECK_INIT();
+
+    if (processor_handle == nullptr || power == nullptr)
+        return AMDSMI_STATUS_INVAL;
+
+    amdsmi_status_t r = amdsmi_get_processor_info(processor_handle, SIZE, proc_id);
+    if (r != AMDSMI_STATUS_SUCCESS)
+        return r;
+
+    core_ind = static_cast<uint8_t>(std::stoi(proc_id, NULL, 0));
+
+    status = static_cast<amdsmi_status_t>(esmi_read_ccd_power(core_ind, &power_u32));
+    if (status != AMDSMI_STATUS_SUCCESS)
+        return amdsmi_errno_to_esmi_status(status);
+
+    *power = static_cast<double>(power_u32)/1000.0;
+     return AMDSMI_STATUS_SUCCESS;
+}
+
+amdsmi_status_t amdsmi_get_cpu_tdelta(amdsmi_processor_handle processor_handle,
+                                      uint8_t *tdelta)
+{
+    amdsmi_status_t status;
+    uint8_t sock_ind;
+    char proc_id[SIZE];
+
+    AMDSMI_CHECK_INIT();
+
+    if (processor_handle == nullptr || tdelta == nullptr)
+        return AMDSMI_STATUS_INVAL;
+
+    amdsmi_status_t r = amdsmi_get_processor_info(processor_handle, SIZE, proc_id);
+    if (r != AMDSMI_STATUS_SUCCESS)
+        return r;
+
+    sock_ind = static_cast<uint8_t>(std::stoi(proc_id, NULL, 0));
+
+    status = static_cast<amdsmi_status_t>(esmi_read_tdelta(sock_ind, tdelta));
+    if (status != AMDSMI_STATUS_SUCCESS)
+        return amdsmi_errno_to_esmi_status(status);
+
+    return AMDSMI_STATUS_SUCCESS;
+
+}
+
+amdsmi_status_t amdsmi_get_cpu_svi3_vr_controller_temp(amdsmi_processor_handle processor_handle,
+                                                       uint32_t *rail_selection,
+                                                       uint32_t *rail_index,
+                                                       uint32_t *temp)
+{
+    amdsmi_status_t status;
+    uint8_t sock_ind;
+    char proc_id[SIZE];
+    struct svi3_info svi3_info_;
+    svi3_info_.m_svi3_info_inarg.reg_value = 0;
+
+    AMDSMI_CHECK_INIT();
+
+    if (processor_handle == nullptr || rail_selection == nullptr || rail_index == nullptr || temp == nullptr)
+        return AMDSMI_STATUS_INVAL;
+
+    amdsmi_status_t r = amdsmi_get_processor_info(processor_handle, SIZE, proc_id);
+    if (r != AMDSMI_STATUS_SUCCESS)
+        return r;
+
+    sock_ind = static_cast<uint8_t>(std::stoi(proc_id, NULL, 0));
+
+    // Validate input parameters
+    if ((*rail_selection) > MAX_SVI3_RAIL_SELECTION) {
+        return AMDSMI_STATUS_INVAL;
+    }
+
+    // Prepare ESMI SVI3 structure with input parameters
+    svi3_info_.m_svi3_info_inarg.info.svi3_rail_selection = ((*rail_selection) & 0x1);
+    if ((*rail_selection) == MAX_SVI3_RAIL_SELECTION)
+    {
+        if((*rail_index) > MAX_SVI3_RAIL_INDEX){
+            return AMDSMI_STATUS_INVAL;
+	}
+        svi3_info_.m_svi3_info_inarg.info.svi3_rail_index = ((*rail_index) & 0x7);
+    }
+
+    svi3_info_.m_svi3_info_inarg.info.svi3_temperature = 0;//Initialize to 0
+
+    // Call ESMI function to get SVI3 VR controller temperature
+    status = static_cast<amdsmi_status_t>(esmi_get_svi3_vr_controller_temp(sock_ind, &svi3_info_));
+    if (status != AMDSMI_STATUS_SUCCESS)
+        return amdsmi_errno_to_esmi_status(status);
+
+    // Extract temperature from ESMI response
+    *temp = svi3_info_.m_svi3_info_inarg.info.svi3_temperature;
+    *rail_selection = svi3_info_.m_svi3_info_inarg.info.svi3_rail_selection;
+    *rail_index = svi3_info_.m_svi3_info_inarg.info.svi3_rail_index;
+
+    return AMDSMI_STATUS_SUCCESS;
+}
+
+amdsmi_status_t amdsmi_get_cpu_enabled_commands(amdsmi_processor_handle processor_handle,
+                                                bool  *r_mask,
+                                                uint32_t *mask0,
+                                                uint32_t *mask1,
+                                                uint32_t *mask2)
+{
+    amdsmi_status_t status;
+    struct hsmp_enabled_commands_info enabled_cmds_info;
+    uint8_t sock_ind;
+    char proc_id[SIZE] = {0};
+
+    AMDSMI_CHECK_INIT();
+
+    if (processor_handle == nullptr || r_mask == nullptr || mask0 == nullptr || mask1 == nullptr || mask2 == nullptr )
+        return AMDSMI_STATUS_INVAL;
+
+    amdsmi_status_t r = amdsmi_get_processor_info(processor_handle, SIZE, proc_id);
+    if (r != AMDSMI_STATUS_SUCCESS)
+        return r;
+
+    sock_ind = static_cast<uint8_t>(std::stoi(proc_id, NULL, 0));
+
+    // Use the read_mask from input to determine what to get
+    enabled_cmds_info.read_mask = *r_mask;
+    status = static_cast<amdsmi_status_t>(esmi_get_enabled_commands(sock_ind, &enabled_cmds_info));
+    if (status != AMDSMI_STATUS_SUCCESS)
+        return amdsmi_errno_to_esmi_status(status);
+
+    // Store commands in the output structure (keep the same read_mask)
+    *mask0 = static_cast<uint32_t>(enabled_cmds_info.arg0);
+    *mask1 = static_cast<uint32_t>(enabled_cmds_info.arg1);
+    *mask2 = static_cast<uint32_t>(enabled_cmds_info.arg2);
+
+    return AMDSMI_STATUS_SUCCESS;
+}
+
+amdsmi_status_t amdsmi_get_cpu_core_floor_freq_limit(amdsmi_processor_handle processor_handle,
+                                                     uint32_t *floor_freq)
+
+{
+    amdsmi_status_t status;
+    uint32_t floorlimit;
+    uint32_t core_ind;
+    char proc_id[SIZE];
+
+    AMDSMI_CHECK_INIT();
+
+    if (processor_handle == nullptr || floor_freq == nullptr)
+        return AMDSMI_STATUS_INVAL;
+
+    amdsmi_status_t r = amdsmi_get_processor_info(processor_handle, SIZE, proc_id);
+    if (r != AMDSMI_STATUS_SUCCESS)
+        return r;
+
+    core_ind = static_cast<uint8_t>(std::stoi(proc_id, NULL, 0));
+
+    status = static_cast<amdsmi_status_t>(esmi_floorlimit_set_get(core_ind, &floorlimit, GET_FLOOR_FREQUENCY_CORE));
+    if (status != AMDSMI_STATUS_SUCCESS)
+        return amdsmi_errno_to_esmi_status(status);
+
+    *floor_freq = floorlimit;
+
+    return AMDSMI_STATUS_SUCCESS;
+}
+
+amdsmi_status_t amdsmi_get_cpu_floor_freq_limit(amdsmi_processor_handle processor_handle,
+                                                uint32_t *floor_freq)
+{
+    amdsmi_status_t status;
+    uint32_t floorlimit;
+    uint8_t sock_ind;
+    char proc_id[SIZE];
+
+    AMDSMI_CHECK_INIT();
+
+    if (processor_handle == nullptr || floor_freq == nullptr)
+        return AMDSMI_STATUS_INVAL;
+
+    amdsmi_status_t r = amdsmi_get_processor_info(processor_handle, SIZE, proc_id);
+    if (r != AMDSMI_STATUS_SUCCESS)
+        return r;
+
+    sock_ind = static_cast<uint8_t>(std::stoi(proc_id, NULL, 0));
+
+    status = static_cast<amdsmi_status_t>(esmi_floorlimit_set_get(sock_ind, &floorlimit, GET_FLOOR_FREQUENCY_SOCKET));
+    if (status != AMDSMI_STATUS_SUCCESS)
+        return amdsmi_errno_to_esmi_status(status);
+
+    *floor_freq = floorlimit;
+
+    return AMDSMI_STATUS_SUCCESS;
+}
+
+amdsmi_status_t amdsmi_get_cpu_core_eff_floor_freq_limit(amdsmi_processor_handle processor_handle,
+                                                         uint32_t *eff_floor_freq)
+{
+    amdsmi_status_t status;
+    uint32_t efffloorlimit;
+    uint32_t core_ind;
+    char proc_id[SIZE];
+
+    AMDSMI_CHECK_INIT();
+
+    if (processor_handle == nullptr || eff_floor_freq == nullptr)
+        return AMDSMI_STATUS_INVAL;
+
+    amdsmi_status_t r = amdsmi_get_processor_info(processor_handle, SIZE, proc_id);
+    if (r != AMDSMI_STATUS_SUCCESS)
+        return r;
+
+    core_ind = static_cast<uint8_t>(std::stoi(proc_id, NULL, 0));
+
+    status = static_cast<amdsmi_status_t>(esmi_floorlimit_set_get(core_ind, &efffloorlimit, GET_EFF_FLOOR_FREQUENCY_CORE));
+    if (status != AMDSMI_STATUS_SUCCESS)
+        return amdsmi_errno_to_esmi_status(status);
+
+    *eff_floor_freq = efffloorlimit;
+
+    return AMDSMI_STATUS_SUCCESS;
+}
+
+amdsmi_status_t amdsmi_get_cpu_eff_floor_freq_limit(amdsmi_processor_handle processor_handle,
+                                                    uint32_t *eff_floor_freq)
+{
+    amdsmi_status_t status;
+    uint32_t efffloorlimit;
+    uint8_t sock_ind;
+    char proc_id[SIZE];
+
+    AMDSMI_CHECK_INIT();
+
+    if (processor_handle == nullptr || eff_floor_freq == nullptr)
+        return AMDSMI_STATUS_INVAL;
+
+    amdsmi_status_t r = amdsmi_get_processor_info(processor_handle, SIZE, proc_id);
+    if (r != AMDSMI_STATUS_SUCCESS)
+        return r;
+
+    sock_ind = static_cast<uint8_t>(std::stoi(proc_id, NULL, 0));
+
+    status = static_cast<amdsmi_status_t>(esmi_floorlimit_set_get(sock_ind, &efffloorlimit, GET_EFF_FLOOR_FREQUENCY_SOCKET));
+    if (status != AMDSMI_STATUS_SUCCESS)
+        return amdsmi_errno_to_esmi_status(status);
+
+    *eff_floor_freq = efffloorlimit;
+
+    return AMDSMI_STATUS_SUCCESS;
+}
+
+amdsmi_status_t amdsmi_set_cpu_core_floor_freq_limit(amdsmi_processor_handle processor_handle,
+                                                     uint32_t floor_freq)
+{
+    amdsmi_status_t status;
+    uint32_t core_ind;
+    char proc_id[SIZE];
+
+    AMDSMI_CHECK_INIT();
+
+    if (processor_handle == nullptr)
+        return AMDSMI_STATUS_INVAL;
+
+    amdsmi_status_t r = amdsmi_get_processor_info(processor_handle, SIZE, proc_id);
+    if (r != AMDSMI_STATUS_SUCCESS)
+        return r;
+
+    core_ind = static_cast<uint8_t>(std::stoi(proc_id, NULL, 0));
+
+    status = static_cast<amdsmi_status_t>(esmi_floorlimit_set_get(core_ind, &floor_freq, SET_FLOOR_FREQUENCY_CORE));
+    if (status != AMDSMI_STATUS_SUCCESS)
+        return amdsmi_errno_to_esmi_status(status);
+
+    return AMDSMI_STATUS_SUCCESS;
+}
+
+amdsmi_status_t amdsmi_set_cpu_floor_freq_limit(amdsmi_processor_handle processor_handle,
+                                                uint32_t floor_freq)
+{
+    amdsmi_status_t status;
+    uint8_t sock_ind;
+    char proc_id[SIZE];
+
+    AMDSMI_CHECK_INIT();
+
+    if (processor_handle == nullptr)
+        return AMDSMI_STATUS_INVAL;
+
+    amdsmi_status_t r = amdsmi_get_processor_info(processor_handle, SIZE, proc_id);
+    if (r != AMDSMI_STATUS_SUCCESS)
+        return r;
+
+    sock_ind = static_cast<uint8_t>(std::stoi(proc_id, NULL, 0));
+
+    status = static_cast<amdsmi_status_t>(esmi_floorlimit_set_get(sock_ind, &floor_freq, SET_FLOOR_FREQUENCY_SOCKET));
+    if (status != AMDSMI_STATUS_SUCCESS)
+        return amdsmi_errno_to_esmi_status(status);
+
+    return AMDSMI_STATUS_SUCCESS;
+}
+
+amdsmi_status_t amdsmi_set_cpu_core_msr_floor_freq_limit(amdsmi_processor_handle processor_handle,
+                                                         uint32_t msr_floor_freq)
+{
+    amdsmi_status_t status;
+    uint32_t core_ind;
+    char proc_id[SIZE];
+    uint16_t fmax, fmin;
+
+    AMDSMI_CHECK_INIT();
+
+    if (processor_handle == nullptr)
+        return AMDSMI_STATUS_INVAL;
+
+    amdsmi_status_t r = amdsmi_get_processor_info(processor_handle, SIZE, proc_id);
+    if (r != AMDSMI_STATUS_SUCCESS)
+        return r;
+
+    core_ind = static_cast<uint8_t>(std::stoi(proc_id, NULL, 0));
+
+    // Get socket frequency range to obtain fmax and fmin as per reference implementation
+    status = static_cast<amdsmi_status_t>(esmi_socket_freq_range_get(SOCKET_0, &fmax, &fmin));
+    if (status != AMDSMI_STATUS_SUCCESS)
+        return amdsmi_errno_to_esmi_status(status);
+
+    if ((status == AMDSMI_STATUS_SUCCESS) && fmax)
+    {
+        status = static_cast<amdsmi_status_t>(esmi_msr_floorlimit_set(core_ind, msr_floor_freq, SET_FLOOR_FREQUENCY_CORE, fmax));
+        if (status != AMDSMI_STATUS_SUCCESS)
+            return amdsmi_errno_to_esmi_status(status);
+    }
+
+    // wait 1000ms before reading again
+    system_wait(static_cast<int>(1000));
+    return AMDSMI_STATUS_SUCCESS;
+}
+
+amdsmi_status_t amdsmi_set_cpu_msr_floor_freq_limit(amdsmi_processor_handle processor_handle,
+                                                    uint32_t msr_floor_freq)
+{
+    amdsmi_status_t status;
+    uint32_t core_ind;
+    char proc_id[SIZE];
+    uint16_t fmax, fmin;
+
+    AMDSMI_CHECK_INIT();
+
+    if (processor_handle == nullptr)
+        return AMDSMI_STATUS_INVAL;
+
+    amdsmi_status_t r = amdsmi_get_processor_info(processor_handle, SIZE, proc_id);
+    if (r != AMDSMI_STATUS_SUCCESS)
+        return r;
+
+    core_ind = static_cast<uint32_t>(std::stoi(proc_id, NULL, 0));
+
+    status = static_cast<amdsmi_status_t>(esmi_socket_freq_range_get(SOCKET_0, &fmax, &fmin));
+    if (status != AMDSMI_STATUS_SUCCESS)
+        return amdsmi_errno_to_esmi_status(status);
+
+    if ((status == AMDSMI_STATUS_SUCCESS) && fmax)
+    {
+        status = static_cast<amdsmi_status_t>(esmi_msr_floorlimit_set(core_ind, msr_floor_freq, SET_FLOOR_FREQUENCY_CORE, fmax));
+        if (status != AMDSMI_STATUS_SUCCESS)
+            return amdsmi_errno_to_esmi_status(status);
+    }
+
+    // wait 1000ms before reading again
+    system_wait(static_cast<int>(1000));
+    return AMDSMI_STATUS_SUCCESS;
+}
+
+amdsmi_status_t amdsmi_get_cpu_freq_range(uint32_t *fmax, uint32_t *fmin)
+{
+    amdsmi_status_t status;
+    uint16_t maxfreq;
+    uint16_t minfreq;
+
+    AMDSMI_CHECK_INIT();
+
+    if ((fmax == nullptr) || (fmin == nullptr))
+        return AMDSMI_STATUS_INVAL;
+
+    status = static_cast<amdsmi_status_t>(esmi_socket_freq_range_get(SOCKET_0, &maxfreq, &minfreq));
+    if (status != AMDSMI_STATUS_SUCCESS)
+        return amdsmi_errno_to_esmi_status(status);
+
+    *fmax = static_cast<uint32_t>(maxfreq);
+    *fmin = static_cast<uint32_t>(minfreq);
+    return AMDSMI_STATUS_SUCCESS;
+}
+
+amdsmi_status_t amdsmi_set_cpu_sdps_limit(amdsmi_processor_handle processor_handle,
+                                          uint32_t sdps_limit)
+{
+    amdsmi_status_t status;
+    uint8_t sock_ind;
+    char proc_id[SIZE];
+    uint32_t sdps_limit_value = sdps_limit;
+
+    AMDSMI_CHECK_INIT();
+
+    if (processor_handle == nullptr)
+        return AMDSMI_STATUS_INVAL;
+
+    amdsmi_status_t r = amdsmi_get_processor_info(processor_handle, SIZE, proc_id);
+    if (r != AMDSMI_STATUS_SUCCESS)
+        return r;
+
+    sock_ind = static_cast<uint8_t>(std::stoi(proc_id, NULL, 0));
+
+    // Call ESMI function to set SDPS limit
+    status = static_cast<amdsmi_status_t>(esmi_sdps_limit_set(sock_ind, &sdps_limit_value));
+    if (status != AMDSMI_STATUS_SUCCESS)
+        return amdsmi_errno_to_esmi_status(status);
+
+    return AMDSMI_STATUS_SUCCESS;
+}
+
+amdsmi_status_t amdsmi_get_cpu_sdps_limit(amdsmi_processor_handle processor_handle,
+                                          double *sdps_limit)
+{
+    amdsmi_status_t status;
+    uint8_t sock_ind;
+    char proc_id[SIZE];
+    uint32_t sdpslimit_u32;
+
+    AMDSMI_CHECK_INIT();
+
+    if (processor_handle == nullptr || sdps_limit == nullptr)
+        return AMDSMI_STATUS_INVAL;
+
+    amdsmi_status_t r = amdsmi_get_processor_info(processor_handle, SIZE, proc_id);
+    if (r != AMDSMI_STATUS_SUCCESS)
+        return r;
+
+    sock_ind = static_cast<uint8_t>(std::stoi(proc_id, NULL, 0));
+
+    // Call ESMI function to get SDPS limit
+    status = static_cast<amdsmi_status_t>(esmi_sdps_limit_get(sock_ind, &sdpslimit_u32));
+    if (status != AMDSMI_STATUS_SUCCESS)
+        return amdsmi_errno_to_esmi_status(status);
+
+    // Convert milliwatts to watts
+    *sdps_limit = static_cast<double>(sdpslimit_u32)/1000.0;
 
     return AMDSMI_STATUS_SUCCESS;
 }


### PR DESCRIPTION
## Motivation
* AMDSMI CPU: Added support for family 1A Models 50h-57h. Cherry pick to 7.12 release.

## Technical Details
Added support for

* Get XGMI Width
* Get DF Pstate Range
* Get XGMI PState Range
* Get CCD Power
* Get TDelta
* Get DIMM SB Data
* Get SVI3 Temperature
* Get PC6 Enable
* Get CC6 Enable
* Get HSMP Enabled Commands
* Get Core FloorLimit
* Get Core EffectiveFloorLimit
* Get SDPS(SOC Dimm Power Sloshing) Limit
* Set Commands
* Set XGMI Width
* Set PC6 Enable Control
* Set CC6 Enable Control
* Set Core FloorLimit via HSMP
* Set Socket FloorLimit via HSMP
* Set DIMM SB Data
* Set SDPS(SOC Dimm Power Sloshing) Limit
* Set Socket MSR Floor Limit
* Set Core MSR Floor Limit
* Fixed goamdsmi_cpu_socket_power milliwat conversions & test failures
* Fixes for set core MSR floor frequency API, updated docs and description
* Added detailed description and fixed set core MSR floor frequency API

## JIRA ID
ROCM-2710

## Test Plan

## Test Result

## Submission Checklist
