### PR TITLE
[AMD-SMI] Hide libamd_smi.so internal symbols (#3777)

### DIFF
--- a/projects/amdsmi/CMakeLists.txt
+++ b/projects/amdsmi/CMakeLists.txt
@@ -128,6 +128,8 @@ cmake_dependent_option(BUILD_WRAPPER "Rebuild AMDSMI-wrapper" OFF "BUILD_SHARED_
 cmake_dependent_option(BUILD_CLI "Build AMDSMI-CLI and install" ON "BUILD_SHARED_LIBS" OFF)
 cmake_dependent_option(BUILD_RUST_WRAPPER "Build rust wrapper and install" OFF "BUILD_SHARED_LIBS" OFF)
 cmake_dependent_option(ENABLE_LDCONFIG "Set library links and caches using ldconfig." ON "BUILD_SHARED_LIBS" OFF)
+cmake_dependent_option(AUTO_BUILD_STATIC_LIBS "auto-build static library (tests/examples link to static)" ON "NOT BUILD_SHARED_LIBS OR BUILD_TESTS" OFF)
+cmake_dependent_option(BUILD_BOTH_LIBS "Build both shared and static library" ON "BUILD_SHARED_LIBS AND AUTO_BUILD_STATIC_LIBS" OFF)
 
 # Set share path here because project name != amd_smi
 set(SHARE_INSTALL_PREFIX "${CMAKE_INSTALL_DATAROOTDIR}/${AMD_SMI}" CACHE STRING "Tests and Example install directory")
@@ -358,7 +360,7 @@ install(
 
 # Create cmake target
 # Add all targets to the build-tree export set
-export(TARGETS ${AMD_SMI} FILE "${PROJECT_BINARY_DIR}/amd_smi_target.cmake")
+export(TARGETS ${AMD_SMI_EXPORT_TARGETS} FILE "${PROJECT_BINARY_DIR}/amd_smi_target.cmake")
 
 # Export the package for use from the build-tree
 # (this registers the build-tree with a global CMake-registry)

--- a/projects/amdsmi/example/CMakeLists.txt
+++ b/projects/amdsmi/example/CMakeLists.txt
@@ -40,6 +40,17 @@ list(APPEND CMAKE_PREFIX_PATH ../../../ ${ROCM_DIR})
 list(APPEND CMAKE_LIBRARY_PATH ${ROCM_DIR}/${CMAKE_INSTALL_LIBDIR})
 
 find_package(amd_smi CONFIG REQUIRED)
+find_package(Threads REQUIRED)
+
+#   --- When both shared and static are built (BUILD_BOTH_LIBS) ---
+#   link examples to static for full symbol access
+#
+if(TARGET amd_smi_static)
+    set(_AMDSMI_LINK_TARGET amd_smi_static)
+else()
+    set(_AMDSMI_LINK_TARGET amd_smi)
+endif()
+
 
 message("&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&")
 message("                    Finished Cmake Example                         ")
@@ -49,18 +60,18 @@ message("&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&")
 # this is only useful if running from build directory
 set(SMI_DRM_EXAMPLE_EXE "amd_smi_drm_ex")
 add_executable(${SMI_DRM_EXAMPLE_EXE} "amd_smi_drm_example.cc")
-target_link_libraries(${SMI_DRM_EXAMPLE_EXE} amd_smi)
+target_link_libraries(${SMI_DRM_EXAMPLE_EXE} ${_AMDSMI_LINK_TARGET})
 target_compile_definitions(${SMI_DRM_EXAMPLE_EXE} PUBLIC ENABLE_ESMI_LIB)
 
 set(SMI_NODRM_EXAMPLE_EXE "amd_smi_nodrm_ex")
 add_executable(${SMI_NODRM_EXAMPLE_EXE} "amd_smi_nodrm_example.cc")
-target_link_libraries(${SMI_NODRM_EXAMPLE_EXE} amd_smi)
+target_link_libraries(${SMI_NODRM_EXAMPLE_EXE} ${_AMDSMI_LINK_TARGET})
 target_compile_definitions(${SMI_NODRM_EXAMPLE_EXE} PUBLIC ENABLE_ESMI_LIB)
 
 if(ENABLE_ESMI_LIB)
     set(ESMI_SAMPLE_EXE "amd_smi_esmi_ex")
     add_executable(${ESMI_SAMPLE_EXE} "amdsmi_esmi_intg_example.cc")
-    target_link_libraries(${ESMI_SAMPLE_EXE} amd_smi)
+    target_link_libraries(${ESMI_SAMPLE_EXE} ${_AMDSMI_LINK_TARGET})
     target_compile_definitions(${ESMI_SAMPLE_EXE} PUBLIC ENABLE_ESMI_LIB)
 endif()
 
@@ -69,5 +80,5 @@ add_executable(ainic amd_smi_nic.cc)
 target_compile_definitions(ainic PRIVATE ENABLE_ESMI_LIB)
 target_include_directories(ainic PRIVATE /opt/rocm/include /opt/rocm/include/amd_smi/impl/nic)
 target_link_directories(ainic PRIVATE /opt/rocm/lib)
-target_link_libraries(ainic PRIVATE amd_smi)
+target_link_libraries(ainic PRIVATE ${_AMDSMI_LINK_TARGET})
 

--- a/projects/amdsmi/src/CMakeLists.txt
+++ b/projects/amdsmi/src/CMakeLists.txt
@@ -110,33 +110,82 @@ set(SO_VERSION_STRING "${MAJOR}.${MINOR}.${RELEASE}")
 message("SOVERSION: ${SO_VERSION_STRING}")
 
 add_subdirectory(nic/ai-nic/amdsmi_unified)
-add_library(${AMD_SMI} ${SRC_LIST} ${INC_LIST})
-target_link_libraries(${AMD_SMI} PRIVATE
-    rt
-    Threads::Threads
-    ${CMAKE_DL_LIBS}
-    amdsminic
-    ${FILESYSTEM_LIB}
-)
-target_link_directories(${AMD_SMI} PRIVATE
-    ${CMAKE_CURRENT_BINARY_DIR}/nic/ai-nic/amdsmi_unified/build/
-)
-target_include_directories(${AMD_SMI} PRIVATE
-    ${CMAKE_CURRENT_SOURCE_DIR}
-    ${CMAKE_CURRENT_SOURCE_DIR}/../
-    ${PROJECT_SOURCE_DIR}/rocm_smi/include
-    ${PROJECT_SOURCE_DIR}/common/shared_mutex
-    ${RAS_DECODE_INC_DIR}
-    ${DRM_INCLUDE_DIRS}
-    ${DRM_AMDGPU_INCLUDE_DIRS}
-    ${NIC_INCLUDE_DIRS}
-)
 
-# use the target_include_directories() command to specify the include directories for the target
-target_include_directories(${AMD_SMI} PUBLIC 
-    "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
-    "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/nic/ai-nic/amdsmi_unified/interface>"
-                                             "$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>")
+#
+#   --- When BUILD_BOTH_LIBS: build shared and static; tests/examples link to static ---
+#   Otherwise: build one library (BUILD_SHARED_LIBS).
+#
+if(BUILD_BOTH_LIBS)
+    add_library(${AMD_SMI} SHARED ${SRC_LIST} ${INC_LIST})
+    add_library(${AMD_SMI}_static STATIC ${SRC_LIST} ${INC_LIST})
+    set(AMD_SMI_TARGET ${AMD_SMI}_static PARENT_SCOPE)
+    set(AMD_SMI_EXPORT_TARGETS ${AMD_SMI} ${AMD_SMI}_static amdsminic PARENT_SCOPE)
+    set(_AMD_SMI_ALL_TARGETS ${AMD_SMI} ${AMD_SMI}_static)
+else()
+    add_library(${AMD_SMI} ${SRC_LIST} ${INC_LIST})
+    set(AMD_SMI_TARGET ${AMD_SMI} PARENT_SCOPE)
+    set(AMD_SMI_EXPORT_TARGETS ${AMD_SMI} amdsminic PARENT_SCOPE)
+    set(_AMD_SMI_ALL_TARGETS ${AMD_SMI})
+endif()
+
+foreach(_TARGET IN LISTS _AMD_SMI_ALL_TARGETS)
+    target_link_libraries(${_TARGET} PRIVATE
+        rt
+        Threads::Threads
+        ${CMAKE_DL_LIBS}
+        amdsminic
+        ${FILESYSTEM_LIB}
+    )
+    target_include_directories(${_TARGET} PRIVATE
+        ${CMAKE_CURRENT_SOURCE_DIR}
+        ${CMAKE_CURRENT_SOURCE_DIR}/../
+        ${PROJECT_SOURCE_DIR}/rocm_smi/include
+        ${PROJECT_SOURCE_DIR}/common/shared_mutex
+        ${RAS_DECODE_INC_DIR}
+        ${DRM_INCLUDE_DIRS}
+        ${DRM_AMDGPU_INCLUDE_DIRS}
+        ${NIC_INCLUDE_DIRS}
+    )
+    target_include_directories(${_TARGET} PUBLIC
+        "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
+        "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/nic/ai-nic/amdsmi_unified/interface>"
+        "$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>"
+    )
+    target_link_directories(${_TARGET} PRIVATE
+        ${CMAKE_CURRENT_BINARY_DIR}/nic/ai-nic/amdsmi_unified/build/
+    )
+endforeach()
+
+#
+#   --- When building the shared library ---
+#   Use a linker version script to export only the public C API (amdsmi_*).
+#   All other symbols (including internal C++ amd::smi::* and rsmi_*) are hidden
+#   by the version script's "local: *;" directive at link time.
+#   This prevents symbol collisions when libamd_smi.so and librocm_smi64.so
+#   are loaded in the same process (see TheRock#3487).
+#
+if(BUILD_BOTH_LIBS OR BUILD_SHARED_LIBS)
+    set(VERSION_SCRIPT "${CMAKE_CURRENT_BINARY_DIR}/libamd_smi.map")
+    file(WRITE ${VERSION_SCRIPT}
+        "# All public API functions MUST use the amdsmi_ prefix\n"
+        "# or be explicitly listed below to be exported.\n"
+        "AMDSMI_1 {\n"
+        "    global:\n"
+        "        amdsmi_*;\n"
+        "        # rsmi_init and rsmi_is_P2P_accessible are kept visible\n"
+        "        # for external libs that already depend on them\n"
+        "        # through libamd_smi.so (e.g. rocm_smi compatibility layer).\n"
+        "        rsmi_init;\n"
+        "        rsmi_is_P2P_accessible;\n"
+        "    local:\n"
+        "        *;\n"
+        "};\n"
+    )
+    target_link_options(${AMD_SMI} PRIVATE
+        "LINKER:--version-script=${VERSION_SCRIPT}")
+    set_property(TARGET ${AMD_SMI} APPEND PROPERTY LINK_DEPENDS "${VERSION_SCRIPT}")
+endif()
+
 
 ## Set the VERSION and SOVERSION values
 set_property(TARGET ${AMD_SMI} PROPERTY SOVERSION "${MAJOR}")
@@ -144,16 +193,24 @@ set_property(TARGET ${AMD_SMI} PROPERTY VERSION "${SO_VERSION_STRING}")
 
 ## If the library is a release, strip the target library
 if("${CMAKE_BUILD_TYPE}" STREQUAL Release)
-    if(${BUILD_SHARED_LIBS}) #stripping only for .so
-        add_custom_command(TARGET ${AMD_SMI} POST_BUILD COMMAND ${CMAKE_STRIP} lib${AMD_SMI}.so.${SO_VERSION_STRING})
+    if(BUILD_BOTH_LIBS OR BUILD_SHARED_LIBS)
+        if(TARGET ${AMD_SMI})
+            add_custom_command(TARGET ${AMD_SMI} POST_BUILD COMMAND ${CMAKE_STRIP} lib${AMD_SMI}.so.${SO_VERSION_STRING})
+        endif()
     endif()
 endif()
 
 ## Add the install directives for the runtime library.
+set(_INSTALL_TARGETS ${AMD_SMI} amdsminic)
+if(BUILD_BOTH_LIBS)
+    list(APPEND _INSTALL_TARGETS ${AMD_SMI}_static)
+endif()
+
 install(
-    TARGETS ${AMD_SMI}
+    TARGETS ${_INSTALL_TARGETS}
     EXPORT amd_smiTargets
-    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR} COMPONENT dev)
+    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR} COMPONENT dev
+    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR} COMPONENT dev)
 
 install(
     TARGETS ${AMD_SMI}
@@ -165,7 +222,7 @@ install(
     COMPONENT dev)
 
 install(
-    FILES ${IMPL_HEADERS} 
+    FILES ${IMPL_HEADERS}
     DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/amd_smi/impl/
     COMPONENT dev)
 
@@ -202,11 +259,6 @@ file(GLOB ESMI_HEADERS "${PROJECT_SOURCE_DIR}/esmi_ib_library/include/e_smi/*.h"
 install(
     FILES ${ESMI_HEADERS}
     DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/e_smi/
-    COMPONENT dev)
-
-install(
-    FILES "${PROJECT_SOURCE_DIR}/rocm_smi/include/rocm_smi/rocm_smi_logger.h"
-    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/rocm_smi/
     COMPONENT dev)
 
 install(

--- a/projects/amdsmi/src/nic/ai-nic/amdsmi_unified/CMakeLists.txt
+++ b/projects/amdsmi/src/nic/ai-nic/amdsmi_unified/CMakeLists.txt
@@ -39,4 +39,10 @@ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${NIC_DEFAULT_CXX_FLAGS}")
 file(GLOB CPP_SRCS "${NIC_SOURCE_DIR}/*.cpp")
 add_library(amdsminic STATIC ${CPP_SRCS})
 set_target_properties(amdsminic PROPERTIES ARCHIVE_OUTPUT_DIRECTORY ${NIC_BUILD_DIR})
-target_include_directories(amdsminic PUBLIC ${NIC_INCLUDE_DIR} ${NIC_INTERFACE_DIR})
+target_include_directories(amdsminic PUBLIC
+    "$<BUILD_INTERFACE:${PROJECT_ROOT}/inc>"
+    "$<BUILD_INTERFACE:${PROJECT_ROOT}/interface>"
+    "$<BUILD_INTERFACE:${NIC_INTERFACE_DIR}>"
+    "$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/amd_smi/impl/nic/amdsmi_unified/inc>"
+    "$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/amd_smi/impl/nic/amdsmi_unified/interface>"
+)

--- a/projects/amdsmi/tests/amd_smi_test/CMakeLists.txt
+++ b/projects/amdsmi/tests/amd_smi_test/CMakeLists.txt
@@ -56,14 +56,14 @@ set(TEST "amdsmitst")
 # Source files
 aux_source_directory(${CMAKE_CURRENT_SOURCE_DIR} tstSources)
 # Header file include path
-include_directories(${TEST} 
-${CMAKE_CURRENT_SOURCE_DIR}/.. 
-${ROCM_INC_DIR}/.. 
+include_directories(${TEST}
+    ${CMAKE_CURRENT_SOURCE_DIR}/..
+    ${ROCM_INC_DIR}/..
 )
 
 # Build rules
 add_executable(${TEST} ${tstSources} ${functionalSources})
-target_link_libraries(${TEST} ${AMD_SMI} GTest::gtest c stdc++ pthread ${AMDSMINIC_PATH} ${FILESYSTEM_LIB})
+target_link_libraries(${TEST} ${AMD_SMI_TARGET} GTest::gtest c stdc++ pthread ${AMDSMINIC_PATH} ${FILESYSTEM_LIB})
 
 # Install tests
 install(


### PR DESCRIPTION
## Motivation
Fixes VLLM crash issue with colliding symbols. Required cherry-pick to 7.12 release.

## Technical Details
* [AMD-SMI] Hide libamd_smi.so internal symbols

build: By default all APIs are 'hidden', and only set to 'visible' via linker script
       (--version-script) filtering by 'amdsmi_*' from libamd_smi.so.
       All other symbols — including internal 'amd::smi::*' and the embedded 'rsmi_*'
       functions — are hidden by the script's 'local: *' directive at link time.

       This way loading both 'libamd_smi.so' and 'librocm_smi64.so' in the same
       process should not cause symbol collisions.

       Issue related to this change: [ROCm/TheRock#3487](https://github.com/ROCm/TheRock/issues/3487)

Code changes related to the following:
  * Build files
* [AMD-SMI] Review fixes for symbol isolation PR

- Add version script comments: public API must use amdsmi_ prefix or be explicitly listed
- Document rsmi_init/rsmi_is_P2P_accessible exports as needed by external consumers
- Fix ${BUILD_SHARED_LIBS} -> BUILD_SHARED_LIBS in if() for idiomatic CMake
- Fix nodrm and ainic examples to use ${_AMDSMI_LINK_TARGET} instead of hardcoded amd_smi
- Remove commented-out export() line in root CMakeLists.txt
- Remove commented-out target_include_directories in amdsminic CMakeLists.txt

## JIRA ID

## Test Plan

## Test Result

## Submission Checklist

