### PR TITLE
Add WSL ABI compatibility check for DXG thunk

### DIFF
--- a/projects/rocr-runtime/libhsakmt/include/hsakmt/hsakmttypes.h
+++ b/projects/rocr-runtime/libhsakmt/include/hsakmt/hsakmttypes.h
@@ -1573,6 +1573,12 @@ typedef struct _HsaHandleImportFlags {
     } ui32;
 } HsaHandleImportFlags;
 
+typedef struct _HsaStructureSizes {
+  HSAuint16 StructureSizes;           // sizeof(HsaStructureSizes) used for check overflow
+  HSAuint16 SizeOfHsaNodeProperties;  // sizeof(HsaNodeProperties)
+  HSAuint16 Reserved[6];
+} HsaStructureSizes;
+
 #ifdef __cplusplus
 }   //extern "C"
 #endif

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/inc/thunk_loader.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/inc/thunk_loader.h
@@ -54,6 +54,7 @@
 class DtifPlatform;
 typedef DtifPlatform* (DtifCreateFunc)(const char*);
 typedef void (DtifDestroyFunc)();
+typedef HSAKMT_STATUS (DxgAbiCheckFunc)(HsaStructureSizes*);
 
 namespace rocr {
 namespace core {
@@ -408,6 +409,7 @@ class ThunkLoader {
     void LoadThunkApiTable();
     bool CreateThunkInstance();
     bool DestroyThunkInstance();
+    bool CheckThunkAbi();
     bool IsDXG() const { return is_dxg_; }
     bool IsDTIF() const { return is_dtif_; }
     bool IsSharedLibraryLoaded() const { return is_loaded_; }

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/runtime.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/runtime.cpp
@@ -2403,6 +2403,12 @@ hsa_status_t Runtime::Load() {
     return HSA_STATUS_ERROR_NOT_INITIALIZED;
   }
 
+#if defined(__linux__)
+  if (!thunkLoader_->CheckThunkAbi()) {
+    return HSA_STATUS_ERROR_INVALID_ARGUMENT;
+  }
+#endif
+
   g_use_interrupt_wait = flag_.enable_interrupt();
   g_use_mwaitx = flag_.check_mwaitx(cpuinfo.mwaitx);
 

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/thunk_loader.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/thunk_loader.cpp
@@ -608,5 +608,29 @@ ERROR:
     }
     return false;
   }
+
+  bool ThunkLoader::CheckThunkAbi() {
+    if (!IsDXG()) return true;
+
+    if (thunk_handle == nullptr) return false;
+
+    DxgAbiCheckFunc* pfnDxgAbiCheck =
+        (DxgAbiCheckFunc*)rocr::os::GetExportAddress(thunk_handle, "DxgAbiCheck");
+    if (pfnDxgAbiCheck == nullptr) {
+      // Old librocdxg without DxgAbiCheck — assume compatible.
+      debug_print("DxgAbiCheck not exported, skipping ABI check.\n");
+      return true;
+    }
+
+    HsaStructureSizes sizes = {};
+    sizes.StructureSizes = (HSAuint16)sizeof(HsaStructureSizes);
+    sizes.SizeOfHsaNodeProperties = (HSAuint16)sizeof(HsaNodeProperties);
+
+    if (pfnDxgAbiCheck(&sizes) != HSAKMT_STATUS_SUCCESS) {
+      debug_print("DxgAbiCheck failed!\n");
+      return false;
+    }
+    return true;
+  }
 }   //  namespace core
 }   //  namespace rocr


### PR DESCRIPTION
Adds a structure size ABI check in the DXG thunk loader for WSL, calling optional DxgAbiCheck and failing initialization on mismatch while remaining compatible with older libraries.