### PR TITLE
Fix overhead that occurs when rocshmem gda a2a falls back to rccl a2a

### DIFF
--- a/projects/rccl/src/include/proxy.h
+++ b/projects/rccl/src/include/proxy.h
@@ -380,6 +380,12 @@ struct ncclProxyState {
   // Profiler plugin
   void* profilerContext;
 
+#ifdef ENABLE_ROCSHMEM
+  // When ROCshmem GDA is active, the proxy must busy-poll instead of sleeping
+  // to avoid OS scheduling delays at GDA-to-RCCL transitions.
+  bool rocshmemEnabled;
+#endif
+
   // Queue of expected responses from the proxy
   struct ncclExpectedProxyResponse* expectedResponses;
 

--- a/projects/rccl/src/init.cc
+++ b/projects/rccl/src/init.cc
@@ -2321,6 +2321,7 @@ static ncclResult_t ncclCommInitRankFunc(struct ncclAsyncJob* job_) {
 
     comm->enableRocshmem = rcclParamRocshmemEnabled();
     comm->rocshmemThreshold = rcclParamRocshmemThreshold();
+    if (comm->proxyState) comm->proxyState->rocshmemEnabled = true;
     comm->numSymBuf = NUM_SYM_BUF;
     comm->symId = 0;
     comm->bufThreshold = rocshmemHeapSize/2;

--- a/projects/rccl/src/init.cc
+++ b/projects/rccl/src/init.cc
@@ -2321,7 +2321,8 @@ static ncclResult_t ncclCommInitRankFunc(struct ncclAsyncJob* job_) {
 
     comm->enableRocshmem = rcclParamRocshmemEnabled();
     comm->rocshmemThreshold = rcclParamRocshmemThreshold();
-    if (comm->proxyState) comm->proxyState->rocshmemEnabled = true;
+    if (comm->proxyState && comm->nNodes > 1 && (comm->nRanks / comm->nNodes == 8))
+      comm->proxyState->rocshmemEnabled = true;
     comm->numSymBuf = NUM_SYM_BUF;
     comm->symId = 0;
     comm->bufThreshold = rocshmemHeapSize/2;

--- a/projects/rccl/src/proxy.cc
+++ b/projects/rccl/src/proxy.cc
@@ -830,11 +830,22 @@ static ncclResult_t ncclProxyGetPostedOps(struct ncclProxyState* proxyState, int
   if (state->active == NULL) {
     pthread_mutex_lock(&pool->mutex);
     if (pool->nextOps == -1 && !state->stop) {
-      ncclProfilerStartProxyCtrlEvent(proxyState->profilerContext, &eHandle);
-      ncclProfilerRecordProxyCtrlEventState(eHandle, 0, ncclProfilerProxyCtrlSleep);
-      pthread_cond_wait(&pool->cond, &pool->mutex);
-      ncclProfilerRecordProxyCtrlEventState(eHandle, 0, ncclProfilerProxyCtrlWakeup);
-      ncclProfilerStopProxyCtrlEvent(eHandle);
+#ifdef ENABLE_ROCSHMEM
+      if (proxyState->rocshmemEnabled) {
+        while (pool->nextOps == -1 && !state->stop) {
+          pthread_mutex_unlock(&pool->mutex);
+          sched_yield();
+          pthread_mutex_lock(&pool->mutex);
+        }
+      } else
+#endif
+      {
+        ncclProfilerStartProxyCtrlEvent(proxyState->profilerContext, &eHandle);
+        ncclProfilerRecordProxyCtrlEventState(eHandle, 0, ncclProfilerProxyCtrlSleep);
+        pthread_cond_wait(&pool->cond, &pool->mutex);
+        ncclProfilerRecordProxyCtrlEventState(eHandle, 0, ncclProfilerProxyCtrlWakeup);
+        ncclProfilerStopProxyCtrlEvent(eHandle);
+      }
     }
   }
   state->nextOps = pool->nextOps;

--- a/projects/rccl/src/proxy.cc
+++ b/projects/rccl/src/proxy.cc
@@ -1925,6 +1925,9 @@ ncclResult_t ncclProxyInit(struct ncclComm* comm, struct ncclSocket* sock, union
   assert(comm->sharedRes->proxyState == NULL);
   NCCLCHECK(ncclCalloc(&comm->sharedRes->proxyState, 1));
   comm->proxyState = comm->sharedRes->proxyState;
+#ifdef ENABLE_ROCSHMEM
+  comm->proxyState->rocshmemEnabled = false;
+#endif
   comm->proxyState->refCount = 1;
   comm->proxyState->listenSock = sock;
   comm->proxyState->peerAddresses = peerAddresses;

--- a/projects/rccl/src/proxy.cc
+++ b/projects/rccl/src/proxy.cc
@@ -834,7 +834,11 @@ static ncclResult_t ncclProxyGetPostedOps(struct ncclProxyState* proxyState, int
       if (proxyState->rocshmemEnabled) {
         while (pool->nextOps == -1 && !state->stop) {
           pthread_mutex_unlock(&pool->mutex);
-          sched_yield();
+#if defined(__x86_64__)
+          __builtin_ia32_pause();
+#elif defined(__aarch64__)
+          __asm__ __volatile__("yield");
+#endif
           pthread_mutex_lock(&pool->mutex);
         }
       } else


### PR DESCRIPTION
## Motivation

When ROCshmem GDA handles small AlltoAll messages, the RCCL proxy thread sleeps via `pthread_cond_wait`. Upon crossing the GDA threshold, RCCL must wake the proxy, but OS scheduling latency causes sporadic 5-22ms kernel stalls — averaging up to +63us overhead at 8MB on 2 nodes (16x MI300X). This PR eliminates that overhead by keeping the proxy thread runnable when GDA is active.

## Technical Details

The proxy thread in `ncclProxyGetPostedOps` sleeps when no ops are queued. During GDA execution the proxy is idle, and when RCCL takes over it suffers OS reschedule latency from SLEEPING→RUNNABLE.

Fix: conditionally replace `pthread_cond_wait` with a `sched_yield()` busy-spin loop when ROCshmem is enabled. Three changes:
- `src/include/proxy.h`: add `bool rocshmemEnabled` to `ncclProxyState`
- `src/init.cc`: set flag when ROCshmem is initialized
- `src/proxy.cc`: if flag set, busy-spin; otherwise original `pthread_cond_wait` with profiler instrumentation

All guarded by `#ifdef ENABLE_ROCSHMEM` — non-ROCshmem builds are unaffected (no extra branches, no struct change).

## JIRA ID

Resolves AICOMRCCL-332

## Test Plan

Ran `alltoall_perf` (bfloat16, 1K-8M, n=100, 5 cycles, validation ON) across three configurations:
1. Baseline: `RCCL_ROCSHMEM_ENABLE=0`
2. Before fix: `RCCL_ROCSHMEM_ENABLE=1` (original proxy sleep)
3. After fix: `RCCL_ROCSHMEM_ENABLE=1` (proxy busy-spin)

Tested on 2 nodes (16 GPUs) and 4 nodes (32 GPUs), MI300X. All runs passed data validation (0 out-of-bounds).

## Test Result

2-node RCCL-range overhead vs baseline (cycles 3-5 avg, OOP):

| Size | Before Fix | After Fix |
|------|-----------|-----------|
| 512K | +5.50 us | +0.65 us |
| 1M | +17.94 us | +0.23 us |
| 2M | +21.24 us | -0.11 us |
| 4M | +44.23 us | +0.65 us |
| 8M | +63.04 us | -0.04 us |

GDA range (≤256KB) unaffected — proxy is not involved in GDA operations.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
