### PR TITLE
Add missing hipFree in test and hide check of mem allocate behind ASAN

### DIFF
--- a/projects/hip-tests/catch/unit/graph/hipGraphInstantiateWithFlags.cc
+++ b/projects/hip-tests/catch/unit/graph/hipGraphInstantiateWithFlags.cc
@@ -394,6 +394,7 @@ TEST_CASE("Unit_hipGraphInstantiateWithFlags_FlagAutoFreeOnLaunch_check") {
   HIP_CHECK(hipGraphDestroy(graph));
   HIP_CHECK(hipGraphExecDestroy(graphExec));
   HIP_CHECK(hipStreamDestroy(stream));
+  HIP_CHECK(hipFree(A_d));
 }
 
 /**

--- a/projects/hip-tests/catch/unit/library/hipKernelGetAttribute.cc
+++ b/projects/hip-tests/catch/unit/library/hipKernelGetAttribute.cc
@@ -66,12 +66,14 @@ TEST_CASE("Unit_hipKernelGetAttribute_Positive_Basic") {
     REQUIRE(pi > 0);
   }
 
+#if !defined(ENABLE_ADDRESS_SANITIZER)
   SECTION("sharedSizeBytes") {
     hipKernel_t kernel;
     HIP_CHECK(hipLibraryGetKernel(&kernel, library, "reverse"));
     HIP_CHECK(hipKernelGetAttribute(&pi, HIP_FUNC_ATTRIBUTE_SHARED_SIZE_BYTES, kernel, device_id));
     REQUIRE(pi == 256);
   }
+#endif
 
   SECTION("dynamicSharedSizeBytes") {
     hipKernel_t addKernel;


### PR DESCRIPTION
## Motivation

Add a missing hipFree and hide memory check behind ASAN

## Technical Details

The test was missing a hipfree and memory check fails with ASAN due to it allocating more memory.

## JIRA ID

NA

## Test Plan

Existing test should pass with ASAN

## Test Result

Tests pass with ASAN

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
