### PR TITLE
Fix passing CMake options to RCCL workflows

### DIFF
--- a/.github/workflows/therock-ci-nightly.yml
+++ b/.github/workflows/therock-ci-nightly.yml
@@ -116,7 +116,7 @@ jobs:
     with:
       amdgpu_families: ${{ matrix.amdgpu_family }}
       artifact_group: ${{ matrix.amdgpu_family }}
-      extra_cmake_options: >
+      cmake_options: >
         -DTHEROCK_ENABLE_ALL=OFF 
         -DTHEROCK_BUILD_TESTING=ON 
         -DTHEROCK_BUNDLE_SYSDEPS=ON 

--- a/.github/workflows/therock-ci.yml
+++ b/.github/workflows/therock-ci.yml
@@ -134,7 +134,7 @@ jobs:
     with:
       amdgpu_families: ${{ matrix.amdgpu_family }}
       artifact_group: ${{ matrix.amdgpu_family }}
-      extra_cmake_options: >
+      cmake_options: >
         -DTHEROCK_ENABLE_ALL=OFF 
         -DTHEROCK_BUILD_TESTING=ON 
         -DTHEROCK_BUNDLE_SYSDEPS=ON 

--- a/.github/workflows/therock-rccl-ci-linux.yml
+++ b/.github/workflows/therock-rccl-ci-linux.yml
@@ -7,7 +7,7 @@ on:
         type: string
       artifact_group:
         type: string
-      extra_cmake_options:
+      cmake_options:
         type: string
 
 permissions:

--- a/.github/workflows/therock-rccl-ci.yml
+++ b/.github/workflows/therock-rccl-ci.yml
@@ -67,7 +67,7 @@ jobs:
     with:
       amdgpu_families: ${{ matrix.amdgpu_family }}
       artifact_group: ${{ matrix.amdgpu_family }}
-      extra_cmake_options: >
+      cmake_options: >
         -DTHEROCK_ENABLE_ALL=OFF 
         -DTHEROCK_BUILD_TESTING=ON 
         -DTHEROCK_BUNDLE_SYSDEPS=ON 


### PR DESCRIPTION
`therock-rccl-ci-linux` expected `extra_cmake_options` as an input but was passing `inputs.cmake_options` in the 'Configure Projects' step. As a result the RCCL CI build _everything_ instead of just RCCL.

This harmonized the workflow inputs with the regular TheRock CI used in rocm-systems.