### PR TITLE
[ROCM SMI] Fix fw pldm version not displayed in default amd-smi (#3594)

### DIFF
--- a/projects/amdsmi/amdsmi_cli/amdsmi_commands.py
+++ b/projects/amdsmi/amdsmi_cli/amdsmi_commands.py
@@ -8905,8 +8905,8 @@ class AMDSMICommands():
         try:
             fw_info = amdsmi_interface.amdsmi_get_fw_info(processors[0])
             for fw in fw_info['fw_list']:
-                if "pldm" in fw.keys():
-                    version_info['fw pldm version'] = fw['pldm']
+                if fw.get('fw_name') == amdsmi_interface.AmdSmiFwBlock.AMDSMI_FW_ID_PLDM_BUNDLE:
+                    version_info['fw pldm version'] = fw['fw_version']
                     # we only need to find one of them
                     break
         except amdsmi_exception.AmdSmiLibraryException as e:


### PR DESCRIPTION
## Motivation

amd-smi command was not showing PLDM version

## Technical Details

Corrected pldm version key lookup in fw_info output to get pldm version.

## JIRA ID

N/A

## Test Plan

amd-smi

## Test Result

<img width="787" height="178" alt="image" src="https://github.com/user-attachments/assets/789e754d-950a-4fbe-9aa4-71f0767b2442" />


## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
