### PR TITLE
[hip-tests] Introduce new mechanism for tagging and disabling tests - Part 5

### DIFF
--- a/projects/hip-tests/catch/config/configs/unit/module.yaml
+++ b/projects/hip-tests/catch/config/configs/unit/module.yaml
@@ -39,10 +39,6 @@ module:
     <<: *level_2
     # Below tests tests fail in PSDB
     disabled: [nvidia_windows]
-  Unit_hipModuleLoadDataEx_Negative_Image_Is_An_Empty_String:
-    <<: *level_2
-    # Note: Following two tests disabled due to defect - EXSWHTEC-153
-    disabled: [amd_windows]
   Unit_hipGetFuncBySymbol_PositiveTest: *level_2
   Unit_hipGetFuncBySymbol_NegativeTests: *level_2
   Unit_hipGetFuncBySymbol_InChildProcess: *level_2
@@ -79,10 +75,6 @@ module:
     <<: *level_2
     # Below tests tests fail in PSDB
     disabled: [nvidia_windows]
-  Unit_hipModuleLoadData_Negative_Image_Is_An_Empty_String:
-    <<: *level_2
-    # Note: Following two tests disabled due to defect - EXSWHTEC-153
-    disabled: [amd_windows]
   Unit_hipModuleLoadData_Functional: *level_2
   Unit_hipModuleLoad_Positive_Basic:
     <<: *level_2

--- a/projects/hip-tests/catch/config/configs/unit/stream.yaml
+++ b/projects/hip-tests/catch/config/configs/unit/stream.yaml
@@ -58,94 +58,9 @@ stream:
     <<: *level_2
     # Below tests fail in stress test on 30/06/23
     disabled: [amd_wsl]
-  Unit_hipStreamValue_Wait32_Blocking_Mask_Gte:
-    <<: *level_2
-    # SWDEV-347670 - blocking tests have TDR, causing hangs
-    disabled: [amd_windows, amd_wsl]
-  Unit_hipStreamValue_Wait32_NonBlocking_Mask_Gte: *level_2
-  Unit_hipStreamValue_Wait32_Blocking_Mask_Eq_1:
-    <<: *level_2
-    # (amd_windows) SWDEV-347670 - blocking tests have TDR, causing hangs
-    # (amd_wsl) Below tests fail in stress test on 30/06/23
-    disabled: [amd_windows, amd_wsl]
-  Unit_hipStreamValue_Wait32_NonBlocking_Mask_Eq_1: *level_2
-  Unit_hipStreamValue_Wait32_Blocking_Mask_Eq_2:
-    <<: *level_2
-    # SWDEV-347670 - blocking tests have TDR, causing hangs
-    disabled: [amd_windows, amd_wsl]
-  Unit_hipStreamValue_Wait32_NonBlocking_Mask_Eq_2: *level_2
-  Unit_hipStreamValue_Wait32_Blocking_Mask_And:
-    <<: *level_2
-    # SWDEV-347670 - blocking tests have TDR, causing hangs
-    disabled: [amd_windows, amd_wsl]
-  Unit_hipStreamValue_Wait32_NonBlocking_Mask_And: *level_2
-  Unit_hipStreamValue_Wait32_Blocking_NoMask_Eq:
-    <<: *level_2
-    # SWDEV-347670 - blocking tests have TDR, causing hangs
-    disabled: [amd_windows, amd_wsl]
-  Unit_hipStreamValue_Wait32_NonBlocking_NoMask_Eq: *level_2
-  Unit_hipStreamValue_Wait32_Blocking_NoMask_Gte:
-    <<: *level_2
-    # SWDEV-347670 - blocking tests have TDR, causing hangs
-    disabled: [amd_windows, amd_wsl]
-  Unit_hipStreamValue_Wait32_NonBlocking_NoMask_Gte: *level_2
-  Unit_hipStreamValue_Wait32_Blocking_NoMask_And:
-    <<: *level_2
-    # SWDEV-347670 - blocking tests have TDR, causing hangs
-    disabled: [amd_windows, amd_wsl]
-  Unit_hipStreamValue_Wait32_NonBlocking_NoMask_And: *level_2
-  Unit_hipStreamValue_Wait32_Blocking_NoMask_Nor:
-    <<: *level_2
-    # SWDEV-347670 - blocking tests have TDR, causing hangs
-    disabled: [amd_windows, amd_wsl]
-  Unit_hipStreamValue_Wait32_NonBlocking_NoMask_Nor: *level_2
-  Unit_hipStreamValue_Wait64_Blocking_Mask_Gte_1:
-    <<: *level_2
-    # SWDEV-347670 - blocking tests have TDR, causing hangs
-    disabled: [amd_windows, amd_wsl]
-  Unit_hipStreamValue_Wait64_NonBlocking_Mask_Gte_1: *level_2
-  Unit_hipStreamValue_Wait64_Blocking_Mask_Gte_2:
-    <<: *level_2
-    # SWDEV-347670 - blocking tests have TDR, causing hangs
-    disabled: [amd_windows, amd_wsl]
-  Unit_hipStreamValue_Wait64_NonBlocking_Mask_Gte_2: *level_2
-  Unit_hipStreamValue_Wait64_Blocking_Mask_Eq_1:
-    <<: *level_2
-    # SWDEV-347670 - blocking tests have TDR, causing hangs
-    disabled: [amd_windows, amd_wsl]
-  Unit_hipStreamValue_Wait64_NonBlocking_Mask_Eq_1: *level_2
-  Unit_hipStreamValue_Wait64_Blocking_Mask_Eq_2:
-    <<: *level_2
-    # SWDEV-347670 - blocking tests have TDR, causing hangs
-    disabled: [amd_windows, amd_wsl]
-  Unit_hipStreamValue_Wait64_NonBlocking_Mask_Eq_2: *level_2
-  Unit_hipStreamValue_Wait64_Blocking_Mask_And:
-    <<: *level_2
-    # SWDEV-347670 - blocking tests have TDR, causing hangs
-    disabled: [amd_windows, amd_wsl]
-  Unit_hipStreamValue_Wait64_NonBlocking_Mask_And: *level_2
-  Unit_hipStreamValue_Wait64_Blocking_NoMask_Gte:
-    <<: *level_2
-    # SWDEV-347670 - blocking tests have TDR, causing hangs
-    disabled: [amd_windows, amd_wsl]
-  Unit_hipStreamValue_Wait64_NonBlocking_NoMask_Gte: *level_2
-  Unit_hipStreamValue_Wait64_Blocking_NoMask_Eq:
-    <<: *level_2
-    # SWDEV-347670 - blocking tests have TDR, causing hangs
-    disabled: [amd_windows, amd_wsl]
-  Unit_hipStreamValue_Wait64_NonBlocking_NoMask_Eq: *level_2
-  Unit_hipStreamValue_Wait64_Blocking_NoMask_And:
-    <<: *level_2
-    # SWDEV-347670 - blocking tests have TDR, causing hangs
-    disabled: [amd_windows, amd_wsl]
-  Unit_hipStreamValue_Wait64_NonBlocking_NoMask_And: *level_2
-  Unit_hipStreamValue_Wait64_Blocking_NoMask_Nor:
-    <<: *level_2
-    disabled: [amd_windows, amd_wsl]
-  Unit_hipStreamValue_Wait64_NonBlocking_NoMask_Nor: *level_2
+  Unit_hipStreamValue_Wait_Blocking: *level_2
   Unit_hipStreamValue_Negative_InvalidMemory: *level_2
-  Unit_hipStreamValue_Negative_UninitializedStream: *level_2
-  Unit_hipStreamValue_Negative_InvalidFlag: *level_2
+  Unit_hipStreamValue_Negative_StreamAndFlag: *level_2
   Unit_hipStreamWriteValue_Default: *level_2
   Unit_hipStreamWaitValue_Default: *level_2
   Unit_hipStreamSynchronize_EmptyStream: *level_2
@@ -302,5 +217,4 @@ stream:
   Unit_hipStreamCopyAttributes_Basic: *level_2
   Unit_hipStreamCopyAttributes_Negative: *level_2
   Unit_hipStreamCopyAttributes_WithAllSyncPolicyValues: *level_2
-  Unit_hipStreamValue_Negative_StreamAndFlag: *level_2
   Unit_hipStreamValue_Wait_Blocking: *level_2

--- a/projects/hip-tests/catch/unit/module/hipDrvLaunchKernelEx.cc
+++ b/projects/hip-tests/catch/unit/module/hipDrvLaunchKernelEx.cc
@@ -46,7 +46,7 @@ static constexpr auto kernel_name = "cooperativeKernelEx";
  * ------------------------
  *    - HIP_VERSION >= 6.5
  */
-TEST_CASE("Unit_hipDrvLaunchKernelEx_NegTsts") {
+TEST_CASE(Unit_hipDrvLaunchKernelEx_NegTsts) {
   if (!DeviceAttributesSupport(0, hipDeviceAttributeCooperativeLaunch)) {
     HipTest::HIP_SKIP_TEST("CooperativeLaunch not supported");
     return;
@@ -216,7 +216,7 @@ bool runTestDrvLaunch(const char* testName, std::string kernelFunc, int totalThr
  * ------------------------
  *    - HIP_VERSION >= 6.5
  */
-TEST_CASE("Unit_hipDrvLaunchKernelEx_Functional") {
+TEST_CASE(Unit_hipDrvLaunchKernelEx_Functional) {
   if (!DeviceAttributesSupport(0, hipDeviceAttributeCooperativeLaunch)) {
     HipTest::HIP_SKIP_TEST("CooperativeLaunch not supported");
     return;
@@ -239,7 +239,7 @@ TEST_CASE("Unit_hipDrvLaunchKernelEx_Functional") {
  * ------------------------
  *  - HIP_VERSION >= 6.5
  */
-TEST_CASE("Unit_hipDrvLaunchKernelEx_With_Different_Kernels") {
+TEST_CASE(Unit_hipDrvLaunchKernelEx_With_Different_Kernels) {
   CTX_CREATE();
   if (!DeviceAttributesSupport(0, hipDeviceAttributeCooperativeLaunch)) {
     HipTest::HIP_SKIP_TEST("CooperativeLaunch not supported");
@@ -319,7 +319,7 @@ TEST_CASE("Unit_hipDrvLaunchKernelEx_With_Different_Kernels") {
  * ------------------------
  *  - HIP_VERSION >= 6.5
  */
-TEST_CASE("Unit_hipDrvLaunchKernelEx_With_CooperativeKernelWithArgs") {
+TEST_CASE(Unit_hipDrvLaunchKernelEx_With_CooperativeKernelWithArgs) {
   CTX_CREATE();
   if (!DeviceAttributesSupport(0, hipDeviceAttributeCooperativeLaunch)) {
     HipTest::HIP_SKIP_TEST("CooperativeLaunch not supported");
@@ -395,7 +395,7 @@ TEST_CASE("Unit_hipDrvLaunchKernelEx_With_CooperativeKernelWithArgs") {
  * ------------------------
  *  - HIP_VERSION >= 6.5
  */
-TEST_CASE("Unit_hipDrvLaunchKernelEx_With_MaxBlockDims") {
+TEST_CASE(Unit_hipDrvLaunchKernelEx_With_MaxBlockDims) {
   CTX_CREATE();
   if (!DeviceAttributesSupport(0, hipDeviceAttributeCooperativeLaunch)) {
     HipTest::HIP_SKIP_TEST("CooperativeLaunch not supported");

--- a/projects/hip-tests/catch/unit/module/hipExtLaunchKernelGGL.cc
+++ b/projects/hip-tests/catch/unit/module/hipExtLaunchKernelGGL.cc
@@ -184,7 +184,7 @@ bool KernelTimeExecution() {
   return testStatus;
 }
 
-TEST_CASE("Unit_hipExtLaunchKernelGGL_Functional") {
+TEST_CASE(Unit_hipExtLaunchKernelGGL_Functional) {
   bool testStatus = true;
 // Disabled the concurency test as the firmware does not support concurrency
 //   in the same stream

--- a/projects/hip-tests/catch/unit/module/hipExtLaunchMultiKernelMultiDevFunctional.cc
+++ b/projects/hip-tests/catch/unit/module/hipExtLaunchMultiKernelMultiDevFunctional.cc
@@ -53,7 +53,7 @@ __global__ void vector_square(float* C_d, float* A_d, size_t N) {
   }
 }
 
-TEST_CASE("Unit_hipExtLaunchMultiKernelMultiDevice_Functional", "[multigpu]") {
+TEST_CASE(Unit_hipExtLaunchMultiKernelMultiDevice_Functional) {
   constexpr int MAX_GPUS = 8;
   float *A_d[MAX_GPUS], *C_d[MAX_GPUS];
   float *A_h, *C_h;

--- a/projects/hip-tests/catch/unit/module/hipExtModuleLaunchKernel.cc
+++ b/projects/hip-tests/catch/unit/module/hipExtModuleLaunchKernel.cc
@@ -94,7 +94,7 @@ static bool searchRegExpr(const std::regex& expr, const char* filename) {
  * ------------------------
  *    - HIP_VERSION >= 5.7
  */
-TEST_CASE("Unit_hipExtModuleLaunchKernel_CheckCodeObjAttr") {
+TEST_CASE(Unit_hipExtModuleLaunchKernel_CheckCodeObjAttr) {
   // Open copyKernel.s and read the file
   const std::regex regexp("uniform_work_group_size\\s*:\\s*[0-1]");
   REQUIRE(true == searchRegExpr(regexp, "copyKernel.s"));
@@ -115,7 +115,7 @@ TEST_CASE("Unit_hipExtModuleLaunchKernel_CheckCodeObjAttr") {
  * ------------------------
  *    - HIP_VERSION >= 5.7
  */
-TEST_CASE("Unit_hipExtModuleLaunchKernel_NonUniformWorkGroup") {
+TEST_CASE(Unit_hipExtModuleLaunchKernel_NonUniformWorkGroup) {
   // first check if uniform_work_group_size = 1.
   const std::regex regexp("uniform_work_group_size\\s*:\\s*1");
   if (false == searchRegExpr(regexp, "copyKernel.s")) {
@@ -185,7 +185,7 @@ TEST_CASE("Unit_hipExtModuleLaunchKernel_NonUniformWorkGroup") {
  * ------------------------
  *    - HIP_VERSION >= 5.7
  */
-TEST_CASE("Unit_hipExtModuleLaunchKernel_UniformWorkGroup") {
+TEST_CASE(Unit_hipExtModuleLaunchKernel_UniformWorkGroup) {
   size_t arraylength = totalWorkGroups * localWorkSize;
   size_t sizeBytes{arraylength * sizeof(int)};
   // Get module and function from module
@@ -251,7 +251,7 @@ TEST_CASE("Unit_hipExtModuleLaunchKernel_UniformWorkGroup") {
   HIP_CHECK(hipModuleUnload(Module));
 }
 
-TEST_CASE("Unit_hipExtModuleLaunchKernel_Positive_Parameters") {
+TEST_CASE(Unit_hipExtModuleLaunchKernel_Positive_Parameters) {
   ModuleLaunchKernelPositiveParameters<hipExtModuleLaunchKernel>();
   auto mg = ModuleGuard::InitModule("launch_kernel_module.code");
   SECTION("Pass only start event") {
@@ -277,7 +277,7 @@ TEST_CASE("Unit_hipExtModuleLaunchKernel_Positive_Parameters") {
   }
 }
 
-TEST_CASE("Unit_hipExtModuleLaunchKernel_Negative_Parameters", "[multigpu]") {
+TEST_CASE(Unit_hipExtModuleLaunchKernel_Negative_Parameters) {
   ModuleLaunchKernelNegativeParameters<hipExtModuleLaunchKernel>(true);
 }
 /**
@@ -744,7 +744,7 @@ bool ModuleLaunchKernel::Module_WorkGroup_Test() {
   return testStatus;
 }
 
-TEST_CASE("Unit_hipExtModuleLaunchKernel_Functional") {
+TEST_CASE(Unit_hipExtModuleLaunchKernel_Functional) {
   bool testStatus = true;
   ModuleLaunchKernel kernelLaunch;
   testStatus &= kernelLaunch.ExtModule_Negative_tests();

--- a/projects/hip-tests/catch/unit/module/hipFuncGetAttribute.cc
+++ b/projects/hip-tests/catch/unit/module/hipFuncGetAttribute.cc
@@ -32,7 +32,7 @@ static hipModule_t GetModule() {
   return mg.module();
 }
 
-TEST_CASE("Unit_hipFuncGetAttribute_Positive_Basic") {
+TEST_CASE(Unit_hipFuncGetAttribute_Positive_Basic) {
   hipFunction_t kernel = GetKernel(GetModule(), "GlobalKernel");
 
   int value;
@@ -70,7 +70,7 @@ TEST_CASE("Unit_hipFuncGetAttribute_Positive_Basic") {
   }
 }
 
-TEST_CASE("Unit_hipFuncGetAttribute_Negative_Parameters") {
+TEST_CASE(Unit_hipFuncGetAttribute_Negative_Parameters) {
   hipFunction_t kernel = GetKernel(GetModule(), "GlobalKernel");
 
   int value;

--- a/projects/hip-tests/catch/unit/module/hipFuncGetAttributes.cc
+++ b/projects/hip-tests/catch/unit/module/hipFuncGetAttributes.cc
@@ -45,7 +45,7 @@ __global__ void getAttrFn(float* px, float* py) {
   *py = *py + *px;
 }
 
-TEST_CASE("Unit_hipFuncGetAttributes_basic") {
+TEST_CASE(Unit_hipFuncGetAttributes_basic) {
   hipFuncAttributes attr{};
 
   auto r = hipFuncGetAttributes(&attr, reinterpret_cast<const void*>(&getAttrFn));

--- a/projects/hip-tests/catch/unit/module/hipFuncSetAttribute.cc
+++ b/projects/hip-tests/catch/unit/module/hipFuncSetAttribute.cc
@@ -45,7 +45,7 @@ __global__ void fn(float* px, float* py) {
   *py = *py + *px;
 }
 
-TEST_CASE("Unit_hipFuncSetAttribute_Basic") {
+TEST_CASE(Unit_hipFuncSetAttribute_Basic) {
   HIP_CHECK(hipFuncSetAttribute(reinterpret_cast<const void*>(&fn),
                                 hipFuncAttributeMaxDynamicSharedMemorySize, 0));
   HIP_CHECK(hipFuncSetAttribute(reinterpret_cast<const void*>(&fn),

--- a/projects/hip-tests/catch/unit/module/hipFuncSetSharedMemConfig.cc
+++ b/projects/hip-tests/catch/unit/module/hipFuncSetSharedMemConfig.cc
@@ -47,7 +47,7 @@ __global__ void ReverseSeq(int* A, int* B, int N) {
  * ------------------------
  * - HIP_VERSION >= 5.6
 */
-TEST_CASE("Unit_hipFuncSetSharedMemConfig_functional") {
+TEST_CASE(Unit_hipFuncSetSharedMemConfig_functional) {
   int *Ah = NULL, *RAh = NULL, NELMTS = 128;
   int *Ad = NULL, *RAd = NULL;
   Ah = reinterpret_cast<int*>(malloc(NELMTS * sizeof(int)));

--- a/projects/hip-tests/catch/unit/module/hipGetFuncBySymbol.cc
+++ b/projects/hip-tests/catch/unit/module/hipGetFuncBySymbol.cc
@@ -93,7 +93,7 @@ bool verifyResult(int* a, int* output_ref, int arrSize) {
  * - HIP_VERSION >= 6.2
  */
 
-TEST_CASE("Unit_hipGetFuncBySymbol_PositiveTest") {
+TEST_CASE(Unit_hipGetFuncBySymbol_PositiveTest) {
   uint32_t *A_d, *C_d;
   uint32_t *A_h, *C_h;
   size_t N = 1000000;
@@ -166,7 +166,7 @@ TEST_CASE("Unit_hipGetFuncBySymbol_PositiveTest") {
  *    - HIP_VERSION >= 6.2
  */
 
-TEST_CASE("Unit_hipGetFuncBySymbol_NegativeTests") {
+TEST_CASE(Unit_hipGetFuncBySymbol_NegativeTests) {
   hipFunction_t funcPointer;
 
   // Passing NULL as second parameter
@@ -189,7 +189,7 @@ TEST_CASE("Unit_hipGetFuncBySymbol_NegativeTests") {
  * ------------------------
  *    - HIP_VERSION >= 6.2
  */
-TEST_CASE("Unit_hipGetFuncBySymbol_InChildProcess") {
+TEST_CASE(Unit_hipGetFuncBySymbol_InChildProcess) {
   hip::SpawnProc proc("hipGetFuncBySymbol_exe", true);
   REQUIRE(proc.run() == 0);
 }
@@ -207,7 +207,7 @@ TEST_CASE("Unit_hipGetFuncBySymbol_InChildProcess") {
  * ------------------------
  *    - HIP_VERSION >= 6.2
  */
-TEST_CASE("Unit_hipGetFuncBySymbol_MultiDev", "[multigpu]") {
+TEST_CASE(Unit_hipGetFuncBySymbol_MultiDev) {
   int deviceCount = 0;
   HIP_CHECK(hipGetDeviceCount(&deviceCount));
   if (deviceCount < 2) {
@@ -323,7 +323,7 @@ void MultiThreadMultiDevFunc(int DevId) {
  * ------------------------
  *    - HIP_VERSION >= 6.2
  */
-TEST_CASE("Unit_hipGetFuncBySymbol_MultiDevMultiThread", "[multigpu]") {
+TEST_CASE(Unit_hipGetFuncBySymbol_MultiDevMultiThread) {
   int deviceCount = 0;
   HIP_CHECK(hipGetDeviceCount(&deviceCount));
   if (deviceCount < 2) {

--- a/projects/hip-tests/catch/unit/module/hipGetProcAddressModuleApis.cc
+++ b/projects/hip-tests/catch/unit/module/hipGetProcAddressModuleApis.cc
@@ -38,7 +38,7 @@ THE SOFTWARE.
  * ------------------------
  *  - HIP_VERSION >= 6.2
  */
-TEST_CASE("Unit_hipGetProcAddress_ModuleApis") {
+TEST_CASE(Unit_hipGetProcAddress_ModuleApis) {
   void* hipModuleLoad_ptr = nullptr;
   void* hipModuleUnload_ptr = nullptr;
   void* hipModuleGetFunction_ptr = nullptr;
@@ -262,7 +262,7 @@ TEST_CASE("Unit_hipGetProcAddress_ModuleApis") {
  * ------------------------
  *  - HIP_VERSION >= 6.2
  */
-TEST_CASE("Unit_hipGetProcAddress_ModuleApisLoadData") {
+TEST_CASE(Unit_hipGetProcAddress_ModuleApisLoadData) {
   void* hipModuleLoadData_ptr = nullptr;
   void* hipModuleLoadDataEx_ptr = nullptr;
 
@@ -328,7 +328,7 @@ TEST_CASE("Unit_hipGetProcAddress_ModuleApisLoadData") {
  * ------------------------
  *  - HIP_VERSION >= 6.2
  */
-TEST_CASE("Unit_hipGetProcAddress_ModuleApisCooperativeKernels", "[multigpu]") {
+TEST_CASE(Unit_hipGetProcAddress_ModuleApisCooperativeKernels) {
   if (!DeviceAttributesSupport(0, hipDeviceAttributeCooperativeLaunch)) {
     HipTest::HIP_SKIP_TEST("CooperativeLaunch not supported");
     return;
@@ -576,7 +576,7 @@ TEST_CASE("Unit_hipGetProcAddress_ModuleApisCooperativeKernels", "[multigpu]") {
  * ------------------------
  *  - HIP_VERSION >= 6.2
  */
-TEST_CASE("Unit_hipGetProcAddress_ModuleApisOccupancy") {
+TEST_CASE(Unit_hipGetProcAddress_ModuleApisOccupancy) {
   void* hipModuleOccupancyMaxPotentialBlockSize_ptr = nullptr;
   void* hipModuleOccupancyMaxPotentialBlockSizeWithFlags_ptr = nullptr;
   void* hipModuleOccupancyMaxActiveBlocksPerMultiprocessor_ptr = nullptr;

--- a/projects/hip-tests/catch/unit/module/hipHccModuleLaunchKernel.cc
+++ b/projects/hip-tests/catch/unit/module/hipHccModuleLaunchKernel.cc
@@ -57,7 +57,7 @@ THE SOFTWARE.
  * ------------------------
  *    - HIP_VERSION >= 5.7
  */
-TEST_CASE("Unit_hipHccModuleLaunchKernel_basic") {
+TEST_CASE(Unit_hipHccModuleLaunchKernel_basic) {
   size_t width = GENERATE(3, 4, 100);
   size_t widthInBytes = width * sizeof(int);
   int *A_d, *B_d;
@@ -99,7 +99,7 @@ TEST_CASE("Unit_hipHccModuleLaunchKernel_basic") {
  * ------------------------
  *    - HIP_VERSION >= 5.7
  */
-TEST_CASE("Unit_hipHccModuleLaunchKernel_NegTst") {
+TEST_CASE(Unit_hipHccModuleLaunchKernel_NegTst) {
   size_t width = GENERATE(3, 4, 100);
   size_t widthInBytes = width * sizeof(int);
   int *A_d, *B_d;

--- a/projects/hip-tests/catch/unit/module/hipKerArgOptimization.cc
+++ b/projects/hip-tests/catch/unit/module/hipKerArgOptimization.cc
@@ -48,7 +48,7 @@ static void verifyDevResult(int* hostBuf, int* devBuf, int coef1, int coef2, siz
   delete[] buf;
 }
 
-TEST_CASE("Unit_KerArgOptimization_Saxpy") {
+TEST_CASE(Unit_KerArgOptimization_Saxpy) {
   constexpr size_t arraylen = 1 << 16;
   constexpr size_t arraylenBytes = arraylen * sizeof(int);
   constexpr auto blocksize = 256;

--- a/projects/hip-tests/catch/unit/module/hipLinkCreate.cc
+++ b/projects/hip-tests/catch/unit/module/hipLinkCreate.cc
@@ -101,7 +101,7 @@ static inline void JitLink(hipModule_t *Module, hipFunction_t *Kernel, hipLinkSt
  * ------------------------
  *  - HIP_VERSION >= 6.4
  */
-TEST_CASE("Unit_hip_linker_spirv_input") {
+TEST_CASE(Unit_hip_linker_spirv_input) {
     size_t N = ARRAY_SIZE;
     size_t sizeBytes = N * sizeof(int);
     int *A_h = new int[sizeBytes];
@@ -165,7 +165,7 @@ TEST_CASE("Unit_hip_linker_spirv_input") {
  * ------------------------
  *  - HIP_VERSION >= 6.4
  */
-TEST_CASE("Unit_hipLinkCreate_Negative") {
+TEST_CASE(Unit_hipLinkCreate_Negative) {
 
     hipLinkState_t linkstate;
     hipJitOption options[4];
@@ -199,7 +199,7 @@ TEST_CASE("Unit_hipLinkCreate_Negative") {
  * ------------------------
  *  - HIP_VERSION >= 6.4
  */
-TEST_CASE("Unit_hipLinkCreate_AddLinker_CUDA_only_options") {
+TEST_CASE(Unit_hipLinkCreate_AddLinker_CUDA_only_options) {
   hipLinkState_t linkstate;
   // Random options so that it is not null
   const char* isaopts[] = {"-mllvm", "-inline-threshold=1", "-mllvm", "-inlinehint-threshold=1"};
@@ -254,7 +254,7 @@ TEST_CASE("Unit_hipLinkCreate_AddLinker_CUDA_only_options") {
  * ------------------------
  *  - HIP_VERSION >= 6.4
  */
-TEST_CASE("Unit_hipLinkAddFile_Negative") {
+TEST_CASE(Unit_hipLinkAddFile_Negative) {
     hipLinkState_t linkstate;
     HIP_CHECK(hipLinkCreate(0, nullptr, nullptr, &linkstate));
 

--- a/projects/hip-tests/catch/unit/module/hipManagedKeywordBasic.cc
+++ b/projects/hip-tests/catch/unit/module/hipManagedKeywordBasic.cc
@@ -43,7 +43,7 @@ constexpr auto fileName = "managed_kernel.code";
  * - HIP_VERSION >= 5.6
 */
 
-TEST_CASE("Unit_hipModuleGetGlobal_Functional", "[multigpu]") {
+TEST_CASE(Unit_hipModuleGetGlobal_Functional) {
   bool testStatus = true;
   int numDevices = 0;
   hipDeviceptr_t x;

--- a/projects/hip-tests/catch/unit/module/hipModule.cc
+++ b/projects/hip-tests/catch/unit/module/hipModule.cc
@@ -188,7 +188,7 @@ bool testMultiTargArchCodeObj() {
   return btestPassed;
 }
 
-TEST_CASE("Unit_hipModule_Functional") {
+TEST_CASE(Unit_hipModule_Functional) {
   bool TestPassed = true;
   SECTION("Code object file test on current GPU") {
     TestPassed &= testCodeObjFile(CODE_OBJ_SINGLEARCH);

--- a/projects/hip-tests/catch/unit/module/hipModuleGetFunction.cc
+++ b/projects/hip-tests/catch/unit/module/hipModuleGetFunction.cc
@@ -24,14 +24,14 @@ THE SOFTWARE.
 #include <hip_test_common.hh>
 #include <hip/hip_runtime_api.h>
 
-TEST_CASE("Unit_hipModuleGetFunction_Positive_Basic") {
+TEST_CASE(Unit_hipModuleGetFunction_Positive_Basic) {
   auto mg = ModuleGuard::InitModule("get_function_module.code");
   hipFunction_t kernel = nullptr;
   HIP_CHECK(hipModuleGetFunction(&kernel, mg.module(), "GlobalKernel"));
   REQUIRE(kernel != nullptr);
 }
 
-TEST_CASE("Unit_hipModuleGetFunction_Negative_Parameters") {
+TEST_CASE(Unit_hipModuleGetFunction_Negative_Parameters) {
   auto mg = ModuleGuard::InitModule("get_function_module.code");
   hipFunction_t kernel = nullptr;
 
@@ -71,7 +71,7 @@ TEST_CASE("Unit_hipModuleGetFunction_Negative_Parameters") {
 
 // Test description: Loading kernel function from different device than the one on which the module
 // is loaded
-TEST_CASE("Unit_hipModuleGetFunction_DiffDevice", "[multigpu]") {
+TEST_CASE(Unit_hipModuleGetFunction_DiffDevice) {
   int numDevices = 0;
   HIP_CHECK(hipGetDeviceCount(&numDevices));
   if (numDevices < 2) {

--- a/projects/hip-tests/catch/unit/module/hipModuleGetFunctionCount.cc
+++ b/projects/hip-tests/catch/unit/module/hipModuleGetFunctionCount.cc
@@ -47,7 +47,7 @@ THE SOFTWARE.
  * ------------------------
  * - HIP_VERSION >= 7.1
  */
-TEST_CASE("Unit_hipModuleGetFunctionCount_Functional") {
+TEST_CASE(Unit_hipModuleGetFunctionCount_Functional) {
   CTX_CREATE();
   hipModule_t moduleSingleArch, moduleEmpty, doubleKernelModule, rtcModule;
   unsigned int count = 0;
@@ -103,7 +103,7 @@ TEST_CASE("Unit_hipModuleGetFunctionCount_Functional") {
  * ------------------------
  * - HIP_VERSION >= 7.1
  */
-TEST_CASE("Unit_hipModuleGetFunctionCount_NegativeTsts") {
+TEST_CASE(Unit_hipModuleGetFunctionCount_NegativeTsts) {
   unsigned int count = 0;
   SECTION("Input module as nullptr") {
     HIP_CHECK_ERROR(hipModuleGetFunctionCount(&count, nullptr),

--- a/projects/hip-tests/catch/unit/module/hipModuleGetGlobal.cc
+++ b/projects/hip-tests/catch/unit/module/hipModuleGetGlobal.cc
@@ -82,7 +82,7 @@ static inline hipModule_t GetModule() {
   return mg.module();
 }
 
-TEST_CASE("Unit_hipModuleGetGlobal_Positive_Basic") {
+TEST_CASE(Unit_hipModuleGetGlobal_Positive_Basic) {
   hipModule_t module = GetModule();
 
   SECTION("int") { HIP_MODULE_GET_GLOBAL_TEST(int, module); }
@@ -94,7 +94,7 @@ TEST_CASE("Unit_hipModuleGetGlobal_Positive_Basic") {
   SECTION("double") { HIP_MODULE_GET_GLOBAL_TEST(double, module); }
 }
 
-TEST_CASE("Unit_hipModuleGetGlobal_Positive_Parameters") {
+TEST_CASE(Unit_hipModuleGetGlobal_Positive_Parameters) {
   hipModule_t module = GetModule();
   hipDeviceptr_t global = 0;
   size_t global_size = 0;
@@ -108,7 +108,7 @@ TEST_CASE("Unit_hipModuleGetGlobal_Positive_Parameters") {
   }
 }
 
-TEST_CASE("Unit_hipModuleGetGlobal_Negative_Parameters") {
+TEST_CASE(Unit_hipModuleGetGlobal_Negative_Parameters) {
   hipModule_t module = GetModule();
   hipDeviceptr_t global = 0;
   size_t global_size = 0;
@@ -123,7 +123,7 @@ TEST_CASE("Unit_hipModuleGetGlobal_Negative_Parameters") {
   }
 }
 
-TEST_CASE("Unit_hipModuleGetGlobal_Negative_Hmod_Is_Nullptr") {
+TEST_CASE(Unit_hipModuleGetGlobal_Negative_Hmod_Is_Nullptr) {
   hipDeviceptr_t global = 0;
   size_t global_size = 0;
 
@@ -133,7 +133,7 @@ TEST_CASE("Unit_hipModuleGetGlobal_Negative_Hmod_Is_Nullptr") {
   CTX_DESTROY();
 }
 
-TEST_CASE("Unit_hipModuleGetGlobal_Negative_Name_Is_Empty_String") {
+TEST_CASE(Unit_hipModuleGetGlobal_Negative_Name_Is_Empty_String) {
   hipModule_t module = GetModule();
   hipDeviceptr_t global = 0;
   size_t global_size = 0;
@@ -141,14 +141,14 @@ TEST_CASE("Unit_hipModuleGetGlobal_Negative_Name_Is_Empty_String") {
   HIP_CHECK_ERROR(hipModuleGetGlobal(&global, &global_size, module, ""), hipErrorInvalidValue);
 }
 
-TEST_CASE("Unit_hipModuleGetGlobal_Negative_Dptr_And_Bytes_Are_Nullptr") {
+TEST_CASE(Unit_hipModuleGetGlobal_Negative_Dptr_And_Bytes_Are_Nullptr) {
   hipModule_t module = GetModule();
   HIP_CHECK_ERROR(hipModuleGetGlobal(nullptr, nullptr, module, "int_var"), hipErrorInvalidValue);
 }
 
 // Test description: Loading device ptr from different device than the one on which the module
 // is loaded
-TEST_CASE("Unit_hipModuleGetGlobal_DiffDevice", "[multigpu]") {
+TEST_CASE(Unit_hipModuleGetGlobal_DiffDevice) {
   int numDevices = 0;
   HIP_CHECK(hipGetDeviceCount(&numDevices));
   if (numDevices < 2) {

--- a/projects/hip-tests/catch/unit/module/hipModuleGetTexRef.cc
+++ b/projects/hip-tests/catch/unit/module/hipModuleGetTexRef.cc
@@ -32,14 +32,14 @@ static hipModule_t GetModule() {
   return mg.module();
 }
 
-TEST_CASE("Unit_hipModuleGetTexRef_Positive_Basic") {
+TEST_CASE(Unit_hipModuleGetTexRef_Positive_Basic) {
   CHECK_IMAGE_SUPPORT
   hipTexRef tex_ref = nullptr;
   HIP_CHECK(hipModuleGetTexRef(&tex_ref, GetModule(), "tex"));
   REQUIRE(tex_ref != nullptr);
 }
 
-TEST_CASE("Unit_hipModuleGetTexRef_Negative_Parameters") {
+TEST_CASE(Unit_hipModuleGetTexRef_Negative_Parameters) {
   CHECK_IMAGE_SUPPORT
   hipModule_t module = GetModule();
   hipTexRef tex_ref = nullptr;
@@ -57,7 +57,7 @@ TEST_CASE("Unit_hipModuleGetTexRef_Negative_Parameters") {
   }
 }
 
-TEST_CASE("Unit_hipModuleGetTexRef_Negative_Hmod_Is_Nullptr") {
+TEST_CASE(Unit_hipModuleGetTexRef_Negative_Hmod_Is_Nullptr) {
   CHECK_IMAGE_SUPPORT
   hipTexRef tex_ref = nullptr;
 
@@ -66,7 +66,7 @@ TEST_CASE("Unit_hipModuleGetTexRef_Negative_Hmod_Is_Nullptr") {
   CTX_DESTROY();
 }
 
-TEST_CASE("Unit_hipModuleGetTexRef_Negative_Name_Is_Empty_String") {
+TEST_CASE(Unit_hipModuleGetTexRef_Negative_Name_Is_Empty_String) {
   CHECK_IMAGE_SUPPORT
   hipModule_t module = GetModule();
   hipTexRef tex_ref = nullptr;

--- a/projects/hip-tests/catch/unit/module/hipModuleLaunchCooperativeKernel.cc
+++ b/projects/hip-tests/catch/unit/module/hipModuleLaunchCooperativeKernel.cc
@@ -49,7 +49,7 @@ THE SOFTWARE.
  * ------------------------
  *  - HIP_VERSION >= 5.5
  */
-TEST_CASE("Unit_hipModuleLaunchCooperativeKernel_Positive_Basic") {
+TEST_CASE(Unit_hipModuleLaunchCooperativeKernel_Positive_Basic) {
   auto mg = ModuleGuard::InitModule("launch_kernel_module.code");
   if (!DeviceAttributesSupport(0, hipDeviceAttributeCooperativeLaunch)) {
     HipTest::HIP_SKIP_TEST("CooperativeLaunch not supported");
@@ -89,7 +89,7 @@ TEST_CASE("Unit_hipModuleLaunchCooperativeKernel_Positive_Basic") {
  * ------------------------
  *  - HIP_VERSION >= 5.5
  */
-TEST_CASE("Unit_hipModuleLaunchCooperativeKernel_Positive_Parameters") {
+TEST_CASE(Unit_hipModuleLaunchCooperativeKernel_Positive_Parameters) {
   auto mg = ModuleGuard::InitModule("launch_kernel_module.code");
   if (!DeviceAttributesSupport(0, hipDeviceAttributeCooperativeLaunch)) {
     HipTest::HIP_SKIP_TEST("CooperativeLaunch not supported");
@@ -125,7 +125,7 @@ TEST_CASE("Unit_hipModuleLaunchCooperativeKernel_Positive_Parameters") {
  * ------------------------
  *  - HIP_VERSION >= 5.5
  */
-TEST_CASE("Unit_hipModuleLaunchCooperativeKernel_Negative_Parameters") {
+TEST_CASE(Unit_hipModuleLaunchCooperativeKernel_Negative_Parameters) {
   auto mg = ModuleGuard::InitModule("launch_kernel_module.code");
   if (!DeviceAttributesSupport(0, hipDeviceAttributeCooperativeLaunch)) {
     HipTest::HIP_SKIP_TEST("CooperativeLaunch not supported");
@@ -224,7 +224,7 @@ TEST_CASE("Unit_hipModuleLaunchCooperativeKernel_Negative_Parameters") {
  * ------------------------
  *  - HIP_VERSION >= 5.5
  */
-TEST_CASE("Unit_hipModuleLaunchCooperativeKernel_Verify_Capture") {
+TEST_CASE(Unit_hipModuleLaunchCooperativeKernel_Verify_Capture) {
   if (!DeviceAttributesSupport(0, hipDeviceAttributeCooperativeLaunch)) {
     HipTest::HIP_SKIP_TEST("CooperativeLaunch not supported");
     return;

--- a/projects/hip-tests/catch/unit/module/hipModuleLaunchCooperativeKernelMultiDevice.cc
+++ b/projects/hip-tests/catch/unit/module/hipModuleLaunchCooperativeKernelMultiDevice.cc
@@ -48,8 +48,7 @@ THE SOFTWARE.
  * ------------------------
  *  - HIP_VERSION >= 5.5
  */
-TEST_CASE("Unit_hipModuleLaunchCooperativeKernelMultiDevice_Positive_Basic",
-          "[multigpu]") {
+TEST_CASE(Unit_hipModuleLaunchCooperativeKernelMultiDevice_Positive_Basic) {
   auto mg = ModuleGuard::InitModule("launch_kernel_module.code");
   if (!DeviceAttributesSupport(0, hipDeviceAttributeCooperativeLaunch)) {
     HipTest::HIP_SKIP_TEST("CooperativeLaunch not supported");
@@ -107,9 +106,7 @@ TEST_CASE("Unit_hipModuleLaunchCooperativeKernelMultiDevice_Positive_Basic",
  * ------------------------
  *  - HIP_VERSION >= 5.5
  */
-TEST_CASE(
-    "Unit_hipModuleLaunchCooperativeKernelMultiDevice_Negative_Parameters",
-    "[multigpu]") {
+TEST_CASE(Unit_hipModuleLaunchCooperativeKernelMultiDevice_Negative_Parameters) {
   auto mg = ModuleGuard::InitModule("launch_kernel_module.code");
   if (!DeviceAttributesSupport(0, hipDeviceAttributeCooperativeLaunch)) {
     HipTest::HIP_SKIP_TEST("CooperativeLaunch not supported");
@@ -227,8 +224,7 @@ TEST_CASE(
  * ------------------------
  *  - HIP_VERSION >= 5.5
  */
-TEST_CASE("Unit_hipModuleLaunchCooperativeKernelMultiDevice_Negative_MultiKernelSameDevice",
-          "[multigpu]") {
+TEST_CASE(Unit_hipModuleLaunchCooperativeKernelMultiDevice_Negative_MultiKernelSameDevice) {
   auto mg = ModuleGuard::InitModule("launch_kernel_module.code");
   if (!DeviceAttributesSupport(0, hipDeviceAttributeCooperativeLaunch)) {
     HipTest::HIP_SKIP_TEST("CooperativeLaunch not supported");

--- a/projects/hip-tests/catch/unit/module/hipModuleLaunchKernel.cc
+++ b/projects/hip-tests/catch/unit/module/hipModuleLaunchKernel.cc
@@ -32,17 +32,17 @@ static hipError_t hipModuleLaunchKernelWrapper(hipFunction_t f, uint32_t gridX, 
                                hStream, kernelParams, extra);
 }
 
-TEST_CASE("Unit_hipModuleLaunchKernel_Positive_Basic") {
+TEST_CASE(Unit_hipModuleLaunchKernel_Positive_Basic) {
   HIP_CHECK(hipFree(nullptr));
   ModuleLaunchKernelPositiveBasic<hipModuleLaunchKernelWrapper>();
 }
 
-TEST_CASE("Unit_hipModuleLaunchKernel_Positive_Parameters") {
+TEST_CASE(Unit_hipModuleLaunchKernel_Positive_Parameters) {
   HIP_CHECK(hipFree(nullptr));
   ModuleLaunchKernelPositiveParameters<hipModuleLaunchKernelWrapper>();
 }
 
-TEST_CASE("Unit_hipModuleLaunchKernel_Negative_Parameters", "[multigpu]") {
+TEST_CASE(Unit_hipModuleLaunchKernel_Negative_Parameters) {
   HIP_CHECK(hipFree(nullptr));
   ModuleLaunchKernelNegativeParameters<hipModuleLaunchKernelWrapper>();
 }
@@ -303,7 +303,7 @@ bool Module_WorkGroup_Test() {
   return testStatus;
 }
 
-TEST_CASE("Unit_hipModuleLaunchKernel_Fntl") {
+TEST_CASE(Unit_hipModuleLaunchKernel_Fntl) {
   bool testStatus = false;
   SECTION("Negative test scenarios") {
     testStatus = Module_Negative_tests();
@@ -319,7 +319,7 @@ TEST_CASE("Unit_hipModuleLaunchKernel_Fntl") {
   }
 }
 
-TEST_CASE("Unit_hipModuleLaunchKernel_Verify_Capture") {
+TEST_CASE(Unit_hipModuleLaunchKernel_Verify_Capture) {
   hipStream_t stream;
   HIP_CHECK(hipStreamCreate(&stream));
 

--- a/projects/hip-tests/catch/unit/module/hipModuleLoad.cc
+++ b/projects/hip-tests/catch/unit/module/hipModuleLoad.cc
@@ -22,7 +22,7 @@ THE SOFTWARE.
 #include <hip_test_common.hh>
 #include <hip/hip_runtime_api.h>
 
-TEST_CASE("Unit_hipModuleLoad_Positive_Basic") {
+TEST_CASE(Unit_hipModuleLoad_Positive_Basic) {
   HIP_CHECK(hipFree(nullptr));
   hipModule_t module = nullptr;
   HIP_CHECK(hipModuleLoad(&module, "empty_module.code"));
@@ -30,7 +30,7 @@ TEST_CASE("Unit_hipModuleLoad_Positive_Basic") {
   HIP_CHECK(hipModuleUnload(module));
 }
 
-TEST_CASE("Unit_hipModuleLoad_Negative_Parameters") {
+TEST_CASE(Unit_hipModuleLoad_Negative_Parameters) {
   HIP_CHECK(hipFree(nullptr));
   hipModule_t module;
 
@@ -51,7 +51,7 @@ TEST_CASE("Unit_hipModuleLoad_Negative_Parameters") {
   }
 }
 
-TEST_CASE("Unit_hipModuleLoad_Negative_Load_From_A_File_That_Is_Not_A_Module") {
+TEST_CASE(Unit_hipModuleLoad_Negative_Load_From_A_File_That_Is_Not_A_Module) {
   HIP_CHECK(hipFree(nullptr));
   hipModule_t module;
 

--- a/projects/hip-tests/catch/unit/module/hipModuleLoadData.cc
+++ b/projects/hip-tests/catch/unit/module/hipModuleLoadData.cc
@@ -25,7 +25,7 @@ THE SOFTWARE.
 #include <fstream>
 #include <vector>
 
-TEST_CASE("Unit_hipModuleLoadData_Positive_Basic") {
+TEST_CASE(Unit_hipModuleLoadData_Positive_Basic) {
   HIP_CHECK(hipFree(nullptr));
   hipModule_t module = nullptr;
 
@@ -84,7 +84,7 @@ TEST_CASE("Unit_hipModuleLoadData_Positive_Basic") {
   }
 }
 
-TEST_CASE("Unit_hipModuleLoadData_Negative_Parameters") {
+TEST_CASE(Unit_hipModuleLoadData_Negative_Parameters) {
   HIP_CHECK(hipFree(nullptr));
   hipModule_t module;
 
@@ -123,7 +123,7 @@ TEST_CASE("Unit_hipModuleLoadData_Negative_Parameters") {
 */
 #if HT_AMD
 // Below test disabled for NVIDIA due to the defect SWDEV-472385
-TEST_CASE("Unit_hipModuleLoadData_Functional") {
+TEST_CASE(Unit_hipModuleLoadData_Functional) {
   constexpr int LEN = 64;
   constexpr int SIZE = LEN << 2;
   constexpr auto FILENAME = "vcpy_kernel.code";

--- a/projects/hip-tests/catch/unit/module/hipModuleLoadDataEx.cc
+++ b/projects/hip-tests/catch/unit/module/hipModuleLoadDataEx.cc
@@ -25,7 +25,7 @@ THE SOFTWARE.
 #include <hip/hip_runtime_api.h>
 
 
-TEST_CASE("Unit_hipModuleLoadDataEx_Positive_Basic") {
+TEST_CASE(Unit_hipModuleLoadDataEx_Positive_Basic) {
   HIP_CHECK(hipFree(nullptr));
   hipModule_t module = nullptr;
 
@@ -44,7 +44,7 @@ TEST_CASE("Unit_hipModuleLoadDataEx_Positive_Basic") {
   }
 }
 
-TEST_CASE("Unit_hipModuleLoadDataEx_Negative_Parameters") {
+TEST_CASE(Unit_hipModuleLoadDataEx_Negative_Parameters) {
   HIP_CHECK(hipFree(nullptr));
   hipModule_t module = nullptr;
 

--- a/projects/hip-tests/catch/unit/module/hipModuleLoadFatBinary.cc
+++ b/projects/hip-tests/catch/unit/module/hipModuleLoadFatBinary.cc
@@ -39,7 +39,7 @@ THE SOFTWARE.
  * ------------------------
  * - HIP_VERSION >= 7.1
  */
-TEST_CASE("Unit_hipModuleLoadFatBinary_NegativeTsts") {
+TEST_CASE(Unit_hipModuleLoadFatBinary_NegativeTsts) {
   CTX_CREATE();
   hipModule_t Module;
   SECTION("fatCubin as nullptr") {
@@ -118,7 +118,7 @@ void loadKernelData(hipFunction_t kernel) {
  * ------------------------
  * - HIP_VERSION >= 7.1
  */
-TEST_CASE("Unit_hipModuleLoadFatBinary_PosiiveTsts") {
+TEST_CASE(Unit_hipModuleLoadFatBinary_PosiiveTsts) {
   hipModule_t Module;
   SECTION("Compiled module with regular target in compressed fatbin") {
     const auto loaded_module =

--- a/projects/hip-tests/catch/unit/module/hipModuleLoadMultProcessOnMultGPU.cc
+++ b/projects/hip-tests/catch/unit/module/hipModuleLoadMultProcessOnMultGPU.cc
@@ -44,7 +44,7 @@ THE SOFTWARE.
  * ------------------------
  * - HIP_VERSION >= 5.6
  */
-TEST_CASE("Unit_hipModuleLoad_MultProcess_MultGPU", "[multigpu]") {
+TEST_CASE(Unit_hipModuleLoad_MultProcess_MultGPU) {
   int deviceCount{0};
   HIP_CHECK(hipGetDeviceCount(&deviceCount));
   REQUIRE(deviceCount != 0);

--- a/projects/hip-tests/catch/unit/module/hipModuleUnload.cc
+++ b/projects/hip-tests/catch/unit/module/hipModuleUnload.cc
@@ -20,13 +20,13 @@ THE SOFTWARE.
 #include <hip_test_defgroups.hh>
 #include <hip/hip_runtime_api.h>
 
-TEST_CASE("Unit_hipModuleUnload_Negative_Module_Is_Nullptr") {
+TEST_CASE(Unit_hipModuleUnload_Negative_Module_Is_Nullptr) {
   HIP_CHECK(hipFree(nullptr));
 
   HIP_CHECK_ERROR(hipModuleUnload(nullptr), hipErrorInvalidResourceHandle);
 }
 
-TEST_CASE("Unit_hipModuleUnload_Negative_Double_Unload") {
+TEST_CASE(Unit_hipModuleUnload_Negative_Double_Unload) {
   HIP_CHECK(hipFree(nullptr));
 
   hipModule_t module = nullptr;

--- a/projects/hip-tests/catch/unit/multiThread/hipMemsetAsyncMultiThread.cc
+++ b/projects/hip-tests/catch/unit/multiThread/hipMemsetAsyncMultiThread.cc
@@ -143,7 +143,7 @@ template <typename Func, typename T> void launchThreads(Func f, TestType type) {
   }
 }
 
-TEST_CASE("Unit_hipMemsetAsync_QueueJobsMultithreaded") {
+TEST_CASE(Unit_hipMemsetAsync_QueueJobsMultithreaded) {
   using hipMemsetAsync_t = hipError_t (*)(void*, int, const size_t, hipStream_t);
   using hipMemsetAsyncD8_t =
       hipError_t (*)(hipDeviceptr_t, unsigned char, const size_t, hipStream_t);

--- a/projects/hip-tests/catch/unit/multiThread/hipMultiThreadDevice.cc
+++ b/projects/hip-tests/catch/unit/multiThread/hipMultiThreadDevice.cc
@@ -86,13 +86,13 @@ void multiThread_nearzero(bool serialize, int iters) {
   }
 }
 
-TEST_CASE("Unit_hipMultiThreadDevice_Streams") {
+TEST_CASE(Unit_hipMultiThreadDevice_Streams) {
   // Serial version, just call once:
   createThenDestroyStreams(10, 10);
 }
 
-TEST_CASE("Unit_hipMultiThreadDevice_SerialPyramid") { multiThread_pyramid(true, 3); }
+TEST_CASE(Unit_hipMultiThreadDevice_SerialPyramid) { multiThread_pyramid(true, 3); }
 
-TEST_CASE("Unit_hipMultiThreadDevice_ParallelPyramid") { multiThread_pyramid(false, 3); }
+TEST_CASE(Unit_hipMultiThreadDevice_ParallelPyramid) { multiThread_pyramid(false, 3); }
 
-TEST_CASE("Unit_hipMultiThreadDevice_NearZero") { multiThread_nearzero(false, 1000); }
+TEST_CASE(Unit_hipMultiThreadDevice_NearZero) { multiThread_nearzero(false, 1000); }

--- a/projects/hip-tests/catch/unit/multiThread/hipMultiThreadStreams1.cc
+++ b/projects/hip-tests/catch/unit/multiThread/hipMultiThreadStreams1.cc
@@ -103,7 +103,7 @@ void test_multiThread_1(hipStream_t stream0, hipStream_t stream1, bool serialize
   HIPCHECK(hipDeviceSynchronize());
 };
 
-TEST_CASE("Unit_hipMultiThreadStreams1_AsyncSync") {
+TEST_CASE(Unit_hipMultiThreadStreams1_AsyncSync) {
   hipStream_t stream;
   HIPCHECK(hipStreamCreate(&stream));
 
@@ -113,7 +113,7 @@ TEST_CASE("Unit_hipMultiThreadStreams1_AsyncSync") {
   HIPCHECK(hipStreamDestroy(stream));
 }
 
-TEST_CASE("Unit_hipMultiThreadStreams1_AsyncAsync") {
+TEST_CASE(Unit_hipMultiThreadStreams1_AsyncAsync) {
   hipStream_t stream0, stream1;
   HIPCHECK(hipStreamCreate(&stream0));
   HIPCHECK(hipStreamCreate(&stream1));
@@ -125,7 +125,7 @@ TEST_CASE("Unit_hipMultiThreadStreams1_AsyncAsync") {
   HIPCHECK(hipStreamDestroy(stream0));
   HIPCHECK(hipStreamDestroy(stream1));
 }
-TEST_CASE("Unit_hipMultiThreadStreams1_AsyncSame") {
+TEST_CASE(Unit_hipMultiThreadStreams1_AsyncSame) {
   hipStream_t stream;
   HIPCHECK(hipStreamCreate(&stream));
 

--- a/projects/hip-tests/catch/unit/multiThread/hipMultiThreadStreams2.cc
+++ b/projects/hip-tests/catch/unit/multiThread/hipMultiThreadStreams2.cc
@@ -121,7 +121,7 @@ void run(size_t size, hipStream_t stream1, hipStream_t stream2) {
   HIPCHECK(hipFree(Cdd));
   HIPCHECK(hipFree(Ddd));
 }
-TEST_CASE("Unit_hipMultiThreadStreams2") {
+TEST_CASE(Unit_hipMultiThreadStreams2) {
   int iterations = 100;
 
   hipStream_t stream[3];

--- a/projects/hip-tests/catch/unit/occupancy/hipModuleOccupancyMaxActiveBlocksPerMultiprocessor.cc
+++ b/projects/hip-tests/catch/unit/occupancy/hipModuleOccupancyMaxActiveBlocksPerMultiprocessor.cc
@@ -26,7 +26,7 @@ execution of hipModuleOccupancyMaxActiveBlocksPerMultiprocessor api when paramet
 #include <hip_test_kernels.hh>
 #include "occupancy_common.hh"
 
-TEST_CASE("Unit_hipModuleOccupancyMaxActiveBlocksPerMultiprocessor_Negative_Parameters") {
+TEST_CASE(Unit_hipModuleOccupancyMaxActiveBlocksPerMultiprocessor_Negative_Parameters) {
   hipModule_t module;
   hipFunction_t function;
   int blockSize = 0;
@@ -51,7 +51,7 @@ TEST_CASE("Unit_hipModuleOccupancyMaxActiveBlocksPerMultiprocessor_Negative_Para
   HIP_CHECK(hipModuleUnload(module));
 }
 
-TEST_CASE("Unit_hipModuleOccupancyMaxActiveBlocksPerMultiprocessor_Positive_RangeValidation") {
+TEST_CASE(Unit_hipModuleOccupancyMaxActiveBlocksPerMultiprocessor_Positive_RangeValidation) {
   hipDeviceProp_t devProp;
   hipModule_t module;
   hipFunction_t function;
@@ -101,7 +101,7 @@ TEST_CASE("Unit_hipModuleOccupancyMaxActiveBlocksPerMultiprocessor_Positive_Rang
  * ------------------------
  *  - unit/occupancy/hipModuleOccupancyMaxActiveBlocksPerMultiprocessor.cc
  */
-TEST_CASE("Unit_OccupancyAPIs_StreamCapture") {
+TEST_CASE(Unit_OccupancyAPIs_StreamCapture) {
   GENERATE_CAPTURE();
 
   hipStream_t stream;

--- a/projects/hip-tests/catch/unit/occupancy/hipModuleOccupancyMaxActiveBlocksPerMultiprocessorWithFlags.cc
+++ b/projects/hip-tests/catch/unit/occupancy/hipModuleOccupancyMaxActiveBlocksPerMultiprocessorWithFlags.cc
@@ -27,7 +27,7 @@ parameters are invalid
 */
 #include "occupancy_common.hh"
 
-TEST_CASE("Unit_hipModuleOccupancyMaxActiveBlocksPerMultiprocessorWithFlags_Negative_Parameters") {
+TEST_CASE(Unit_hipModuleOccupancyMaxActiveBlocksPerMultiprocessorWithFlags_Negative_Parameters) {
   hipModule_t module;
   hipFunction_t function;
   int numBlocks = 0;
@@ -60,8 +60,7 @@ TEST_CASE("Unit_hipModuleOccupancyMaxActiveBlocksPerMultiprocessorWithFlags_Nega
   HIP_CHECK(hipModuleUnload(module));
 }
 
-TEST_CASE(
-    "Unit_hipModuleOccupancyMaxActiveBlocksPerMultiprocessorWithFlags_Positive_RangeValidation") {
+TEST_CASE(Unit_hipModuleOccupancyMaxActiveBlocksPerMultiprocessorWithFlags_Positive_RangeValidation) {
   hipDeviceProp_t devProp;
   hipModule_t module;
   hipFunction_t function;

--- a/projects/hip-tests/catch/unit/occupancy/hipModuleOccupancyMaxPotentialBlockSize.cc
+++ b/projects/hip-tests/catch/unit/occupancy/hipModuleOccupancyMaxPotentialBlockSize.cc
@@ -25,7 +25,7 @@ hipModuleOccupancyMaxPotentialBlockSize api when parameters are invalid
 */
 #include "occupancy_common.hh"
 
-TEST_CASE("Unit_hipModuleOccupancyMaxPotentialBlockSize_Negative_Parameters") {
+TEST_CASE(Unit_hipModuleOccupancyMaxPotentialBlockSize_Negative_Parameters) {
   hipModule_t module;
   hipFunction_t function;
 
@@ -42,7 +42,7 @@ TEST_CASE("Unit_hipModuleOccupancyMaxPotentialBlockSize_Negative_Parameters") {
   HIP_CHECK(hipModuleUnload(module));
 }
 
-TEST_CASE("Unit_hipModuleOccupancyMaxPotentialBlockSize_Positive_RangeValidation") {
+TEST_CASE(Unit_hipModuleOccupancyMaxPotentialBlockSize_Positive_RangeValidation) {
   hipDeviceProp_t devProp;
   hipModule_t module;
   hipFunction_t function;

--- a/projects/hip-tests/catch/unit/occupancy/hipModuleOccupancyMaxPotentialBlockSizeWithFlags.cc
+++ b/projects/hip-tests/catch/unit/occupancy/hipModuleOccupancyMaxPotentialBlockSizeWithFlags.cc
@@ -25,7 +25,7 @@ execution of hipModuleOccupancyMaxPotentialBlockSizeWithFlags api when parameter
 */
 #include "occupancy_common.hh"
 
-TEST_CASE("Unit_hipModuleOccupancyMaxPotentialBlockSizeWithFlags_Negative_Parameters") {
+TEST_CASE(Unit_hipModuleOccupancyMaxPotentialBlockSizeWithFlags_Negative_Parameters) {
   hipModule_t module;
   hipFunction_t function;
   int blockSize = 0;
@@ -52,7 +52,7 @@ TEST_CASE("Unit_hipModuleOccupancyMaxPotentialBlockSizeWithFlags_Negative_Parame
   HIP_CHECK(hipModuleUnload(module));
 }
 
-TEST_CASE("Unit_hipModuleOccupancyMaxPotentialBlockSizeWithFlags_Positive_RangeValidation") {
+TEST_CASE(Unit_hipModuleOccupancyMaxPotentialBlockSizeWithFlags_Positive_RangeValidation) {
   hipDeviceProp_t devProp;
   hipModule_t module;
   hipFunction_t function;

--- a/projects/hip-tests/catch/unit/occupancy/hipOccupancyAvailableDynamicSMemPerBlock.cc
+++ b/projects/hip-tests/catch/unit/occupancy/hipOccupancyAvailableDynamicSMemPerBlock.cc
@@ -67,7 +67,7 @@ static __global__ void f1(float *a) { *a = 1.0; }
  * ------------------------
  * - HIP_VERSION >= 7.1
  */
-TEST_CASE("Unit_hipOccupancyAvailableDynamicSMemPerBlock_Negative") {
+TEST_CASE(Unit_hipOccupancyAvailableDynamicSMemPerBlock_Negative) {
   size_t dynamicSmemSize;
   int numBlocks = 1;
   SECTION("Number of blocks are zero") {
@@ -108,7 +108,7 @@ TEST_CASE("Unit_hipOccupancyAvailableDynamicSMemPerBlock_Negative") {
  * ------------------------
  * - HIP_VERSION >= 7.1
  */
-TEST_CASE("Unit_hipOccupancyAvailableDynamicSMemPerBlock_Positive") {
+TEST_CASE(Unit_hipOccupancyAvailableDynamicSMemPerBlock_Positive) {
   size_t dynamicSmemSize = 0;
   int numBlocks = 1;
   int inputArray[SIZE], expectedOutput[SIZE], actualOutput[SIZE];

--- a/projects/hip-tests/catch/unit/occupancy/hipOccupancyMaxActiveBlocksPerMultiprocessor.cc
+++ b/projects/hip-tests/catch/unit/occupancy/hipOccupancyMaxActiveBlocksPerMultiprocessor.cc
@@ -32,7 +32,7 @@ static __global__ void f1(float* a) { *a = 1.0; }
 
 template <typename T> static __global__ void f2(T* a) { *a = 1; }
 
-TEST_CASE("Unit_hipOccupancyMaxActiveBlocksPerMultiprocessor_Negative_Parameters") {
+TEST_CASE(Unit_hipOccupancyMaxActiveBlocksPerMultiprocessor_Negative_Parameters) {
   int numBlocks = 0;
   int blockSize = 0;
   int gridSize = 0;
@@ -60,7 +60,7 @@ TEST_CASE("Unit_hipOccupancyMaxActiveBlocksPerMultiprocessor_Negative_Parameters
   }
 }
 
-TEST_CASE("Unit_hipOccupancyMaxActiveBlocksPerMultiprocessor_Positive_RangeValidation") {
+TEST_CASE(Unit_hipOccupancyMaxActiveBlocksPerMultiprocessor_Positive_RangeValidation) {
   hipDeviceProp_t devProp;
   int blockSize = 0;
   int gridSize = 0;
@@ -91,7 +91,7 @@ TEST_CASE("Unit_hipOccupancyMaxActiveBlocksPerMultiprocessor_Positive_RangeValid
   }
 }
 
-TEST_CASE("Unit_hipOccupancyMaxActiveBlocksPerMultiprocessor_Positive_TemplateInvocation") {
+TEST_CASE(Unit_hipOccupancyMaxActiveBlocksPerMultiprocessor_Positive_TemplateInvocation) {
   hipDeviceProp_t devProp;
   int blockSize = 0;
   int gridSize = 0;

--- a/projects/hip-tests/catch/unit/occupancy/hipOccupancyMaxActiveBlocksPerMultiprocessorWithFlags.cc
+++ b/projects/hip-tests/catch/unit/occupancy/hipOccupancyMaxActiveBlocksPerMultiprocessorWithFlags.cc
@@ -47,7 +47,7 @@ static __global__ void kern1(int* t) { *t = 1; }
  * ------------------------
  *  - HIP_VERSION >= 6.1
  */
-TEST_CASE("Unit_hipOccupancyMaxActiveBlocksPerMultiprocessorWithFlags_ValidArgs") {
+TEST_CASE(Unit_hipOccupancyMaxActiveBlocksPerMultiprocessorWithFlags_ValidArgs) {
   hipError_t err;
 
   SECTION("hipOccupancyDefault no shared memory") {
@@ -98,7 +98,7 @@ TEST_CASE("Unit_hipOccupancyMaxActiveBlocksPerMultiprocessorWithFlags_ValidArgs"
  * ------------------------
  *  - HIP_VERSION >= 6.1
  */
-TEST_CASE("Unit_hipOccupancyMaxActiveBlocksPerMultiprocessorWithFlags_InvalidArgs") {
+TEST_CASE(Unit_hipOccupancyMaxActiveBlocksPerMultiprocessorWithFlags_InvalidArgs) {
   hipError_t err;
 
   SECTION("Zero block size") {

--- a/projects/hip-tests/catch/unit/occupancy/hipOccupancyMaxPotentialBlockSize.cc
+++ b/projects/hip-tests/catch/unit/occupancy/hipOccupancyMaxPotentialBlockSize.cc
@@ -31,7 +31,7 @@ static __global__ void f1(float* a) { *a = 1.0; }
 
 template <typename T> static __global__ void f2(T* a) { *a = 1; }
 
-TEST_CASE("Unit_hipOccupancyMaxPotentialBlockSize_Negative_Parameters") {
+TEST_CASE(Unit_hipOccupancyMaxPotentialBlockSize_Negative_Parameters) {
   // Common negative tests
   MaxPotentialBlockSizeNegative([](int* gridSize, int* blockSize) {
     return hipOccupancyMaxPotentialBlockSize(gridSize, blockSize, f1, 0, 0);
@@ -50,7 +50,7 @@ TEST_CASE("Unit_hipOccupancyMaxPotentialBlockSize_Negative_Parameters") {
 #endif
 }
 
-TEST_CASE("Unit_hipOccupancyMaxPotentialBlockSize_Positive_RangeValidation") {
+TEST_CASE(Unit_hipOccupancyMaxPotentialBlockSize_Positive_RangeValidation) {
   hipDeviceProp_t devProp;
 
   HIP_CHECK(hipGetDeviceProperties(&devProp, 0));
@@ -73,7 +73,7 @@ TEST_CASE("Unit_hipOccupancyMaxPotentialBlockSize_Positive_RangeValidation") {
   }
 }
 
-TEST_CASE("Unit_hipOccupancyMaxPotentialBlockSize_Positive_TemplateInvocation") {
+TEST_CASE(Unit_hipOccupancyMaxPotentialBlockSize_Positive_TemplateInvocation) {
   hipDeviceProp_t devProp;
 
   HIP_CHECK(hipGetDeviceProperties(&devProp, 0));

--- a/projects/hip-tests/catch/unit/occupancy/hipOccupancyMaxPotentialBlockSizeVariableSMemWithFlags.cc
+++ b/projects/hip-tests/catch/unit/occupancy/hipOccupancyMaxPotentialBlockSizeVariableSMemWithFlags.cc
@@ -81,7 +81,7 @@ void hipOccupancyMaxPotBlkSizeVariableSMemWithFlags_chkRange(int block_size_limi
   - for 0 < block_size_limit < attr.maxThreadsPerBlock
   - for block_size_limit > attr.maxThreadsPerBlock
 */
-TEST_CASE("Unit_hipOccupancyMaxPotBlkSizeVariableSMemWithFlags_chkRange") {
+TEST_CASE(Unit_hipOccupancyMaxPotBlkSizeVariableSMemWithFlags_chkRange) {
   hipDeviceProp_t devProp;
   // Get current device property
   HIP_CHECK(hipGetDeviceProperties(&devProp, 0));
@@ -108,8 +108,7 @@ TEST_CASE("Unit_hipOccupancyMaxPotBlkSizeVariableSMemWithFlags_chkRange") {
   - for 0 < block_size_limit < attr.maxThreadsPerBlock
   - for block_size_limit > attr.maxThreadsPerBlock
 */
-TEST_CASE("Unit_hipOccupancyMaxPotBlkSizeVariableSMemWithFlags_mgpu",
-          "[multigpu]") {
+TEST_CASE(Unit_hipOccupancyMaxPotBlkSizeVariableSMemWithFlags_mgpu) {
   int devcount = 0;
   HIP_CHECK(hipGetDeviceCount(&devcount));
   // If only single GPU is detected then return
@@ -135,7 +134,7 @@ TEST_CASE("Unit_hipOccupancyMaxPotBlkSizeVariableSMemWithFlags_mgpu",
   Check the basic functionality of hipOccupancyMaxPotentialBlockSizeVariableSMemWithFlags
   by passing a functor as 4th parameter.
 */
-TEST_CASE("Unit_hipOccupancyMaxPotBlkSizeVariableSMemWithFlags_Functor") {
+TEST_CASE(Unit_hipOccupancyMaxPotBlkSizeVariableSMemWithFlags_Functor) {
   hipDeviceProp_t devProp;
   HIP_CHECK(hipGetDeviceProperties(&devProp, 0));
   functorBlockSizeToDynamicSMemSize testFunc(SHARED_MEM_CONST);
@@ -155,7 +154,7 @@ TEST_CASE("Unit_hipOccupancyMaxPotBlkSizeVariableSMemWithFlags_Functor") {
   Check the basic functionality of hipOccupancyMaxPotentialBlockSizeVariableSMemWithFlags
   by passing a lambda function as 4th parameter.
 */
-TEST_CASE("Unit_hipOccupancyMaxPotBlkSizeVariableSMemWithFlags_Lambda") {
+TEST_CASE(Unit_hipOccupancyMaxPotBlkSizeVariableSMemWithFlags_Lambda) {
   hipDeviceProp_t devProp;
   HIP_CHECK(hipGetDeviceProperties(&devProp, 0));
   auto testFunc = [](const int blockSize) {
@@ -189,7 +188,7 @@ TEST_CASE("Unit_hipOccupancyMaxPotBlkSizeVariableSMemWithFlags_Lambda") {
   - null func
   - Invalid flag
 */
-TEST_CASE("Unit_hipOccupancyMaxPotBlkSizeVariableSMemWithFlags_NegTst") {
+TEST_CASE(Unit_hipOccupancyMaxPotBlkSizeVariableSMemWithFlags_NegTst) {
   hipError_t ret;
   int minGridSize = 0, blockSize = 0;
 
@@ -294,7 +293,7 @@ static size_t getMaxDynShMem(int blocksize) {
   Using the derived gridsize and blocksize launch the kernel and validate its
   output.
 */
-TEST_CASE("Unit_hipOccupancyMaxPotBlkSizeVariableSMemWithFlags_Functional") {
+TEST_CASE(Unit_hipOccupancyMaxPotBlkSizeVariableSMemWithFlags_Functional) {
   hipDeviceProp_t devProp;
   HIP_CHECK(hipGetDeviceProperties(&devProp, 0));
   SECTION("Non Dynamic Shared Kernel") {

--- a/projects/hip-tests/catch/unit/p2p/hipDeviceGetP2PAttribute.cc
+++ b/projects/hip-tests/catch/unit/p2p/hipDeviceGetP2PAttribute.cc
@@ -60,7 +60,7 @@ THE SOFTWARE.
  *    - HIP_VERSION >= 5.5
  */
 
-TEST_CASE("Unit_hipDeviceGetP2PAttribute_Basic") {
+TEST_CASE(Unit_hipDeviceGetP2PAttribute_Basic) {
 #if HT_AMD
   HipTest::HIP_SKIP_TEST("EXSWCPHIPT-119");
   return;
@@ -120,7 +120,7 @@ TEST_CASE("Unit_hipDeviceGetP2PAttribute_Basic") {
  *  - HIP_VERSION >= 5.2
  */
 
-TEST_CASE("Unit_hipDeviceGetP2PAttribute_Negative") {
+TEST_CASE(Unit_hipDeviceGetP2PAttribute_Negative) {
 #if HT_AMD
   HipTest::HIP_SKIP_TEST("EXSWCPHIPT-122");
   return;

--- a/projects/hip-tests/catch/unit/p2p/hipP2pLinkTypeAndHopFunc.cc
+++ b/projects/hip-tests/catch/unit/p2p/hipP2pLinkTypeAndHopFunc.cc
@@ -297,7 +297,7 @@ bool testhipLinkTypeHopcountDevice(int numDevices) {
  *    - HIP_VERSION >= 5.5
  */
 
-TEST_CASE("Unit_hipP2pLinkTypeAndHopFunc") {
+TEST_CASE(Unit_hipP2pLinkTypeAndHopFunc) {
   int numDevices = 0;
   bool TestPassed = true;
   HIP_CHECK(hipGetDeviceCount(&numDevices));

--- a/projects/hip-tests/catch/unit/printf/hipPrintfAltForms.cc
+++ b/projects/hip-tests/catch/unit/printf/hipPrintfAltForms.cc
@@ -55,7 +55,7 @@ __global__ void test_kernel() {
  * ------------------------
  * - HIP_VERSION >= 6.2
  */
-TEST_CASE("Unit_Printf_PrintfAltFormsTsts") {
+TEST_CASE(Unit_Printf_PrintfAltFormsTsts) {
   int pcieAtomic = 0;
   HIP_CHECK(hipDeviceGetAttribute(&pcieAtomic, hipDeviceAttributeHostNativeAtomicSupported, 0));
   if (!pcieAtomic) {

--- a/projects/hip-tests/catch/unit/printf/hipPrintfBasic.cc
+++ b/projects/hip-tests/catch/unit/printf/hipPrintfBasic.cc
@@ -190,7 +190,7 @@ static void test_series(int* retval, uint num_blocks, uint threads_per_block) {
  * ------------------------
  * - HIP_VERSION >= 6.2
  */
-TEST_CASE("Unit_Printf_PrintfBasicTsts") {
+TEST_CASE(Unit_Printf_PrintfBasicTsts) {
   int pcieAtomic = 0;
   HIP_CHECK(hipDeviceGetAttribute(&pcieAtomic, hipDeviceAttributeHostNativeAtomicSupported, 0));
   if (!pcieAtomic) {

--- a/projects/hip-tests/catch/unit/printf/hipPrintfManyDevices.cc
+++ b/projects/hip-tests/catch/unit/printf/hipPrintfManyDevices.cc
@@ -47,7 +47,7 @@ __global__ void print_things() {
  * ------------------------
  * - HIP_VERSION >= 6.2
  */
-TEST_CASE("Unit_Printf_ManyDevicesTest", "[multigpu]") {
+TEST_CASE(Unit_Printf_ManyDevicesTest) {
   int pcieAtomic = 0;
   HIP_CHECK(hipDeviceGetAttribute(&pcieAtomic, hipDeviceAttributeHostNativeAtomicSupported, 0));
   if (!pcieAtomic) {

--- a/projects/hip-tests/catch/unit/printf/hipPrintfManyWaves.cc
+++ b/projects/hip-tests/catch/unit/printf/hipPrintfManyWaves.cc
@@ -234,7 +234,7 @@ static void test_numbers(uint num_blocks, uint threads_per_block) {
  * ------------------------
  * - HIP_VERSION >= 6.2
  */
-TEST_CASE("Unit_Printf_PrintfManyWaves") {
+TEST_CASE(Unit_Printf_PrintfManyWaves) {
   int pcieAtomic = 0;
   HIP_CHECK(hipDeviceGetAttribute(&pcieAtomic, hipDeviceAttributeHostNativeAtomicSupported, 0));
   if (!pcieAtomic) {

--- a/projects/hip-tests/catch/unit/printf/hipPrintfStar.cc
+++ b/projects/hip-tests/catch/unit/printf/hipPrintfStar.cc
@@ -44,7 +44,7 @@ __global__ void test_kernel_star() {
  * ------------------------
  * - HIP_VERSION >= 6.2
  */
-TEST_CASE("Unit_Printf_PrintfStar") {
+TEST_CASE(Unit_Printf_PrintfStar) {
   int pcieAtomic = 0;
   HIP_CHECK(hipDeviceGetAttribute(&pcieAtomic, hipDeviceAttributeHostNativeAtomicSupported, 0));
   if (!pcieAtomic) {

--- a/projects/hip-tests/catch/unit/printf/hipPrintfWidthPrecision.cc
+++ b/projects/hip-tests/catch/unit/printf/hipPrintfWidthPrecision.cc
@@ -54,7 +54,7 @@ __global__ void test_kernel_width() {
  * ------------------------
  * - HIP_VERSION >= 6.2
  */
-TEST_CASE("Unit_Printf_PrintfWidthPrecision") {
+TEST_CASE(Unit_Printf_PrintfWidthPrecision) {
   int pcieAtomic = 0;
   HIP_CHECK(hipDeviceGetAttribute(&pcieAtomic, hipDeviceAttributeHostNativeAtomicSupported, 0));
   if (!pcieAtomic) {

--- a/projects/hip-tests/catch/unit/printf/printfFlags.cc
+++ b/projects/hip-tests/catch/unit/printf/printfFlags.cc
@@ -44,7 +44,7 @@ THE SOFTWARE.
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_Printf_flags_Sanity_Positive") {
+TEST_CASE(Unit_Printf_flags_Sanity_Positive) {
   int pcieAtomic = 0;
   HIP_CHECK(hipDeviceGetAttribute(&pcieAtomic, hipDeviceAttributeHostNativeAtomicSupported, 0));
   if (!pcieAtomic) {

--- a/projects/hip-tests/catch/unit/printf/printfFlagsNonHost.cc
+++ b/projects/hip-tests/catch/unit/printf/printfFlagsNonHost.cc
@@ -41,7 +41,7 @@ THE SOFTWARE.
  * - HIP_VERSION >= 5.7
  */
 
-TEST_CASE("Unit_Buffered_Printf_Flags") {
+TEST_CASE(Unit_Buffered_Printf_Flags) {
   int pcieAtomic = 0;
   HIP_CHECK(hipDeviceGetAttribute(&pcieAtomic, hipDeviceAttributeHostNativeAtomicSupported, 0));
   if (!pcieAtomic) {

--- a/projects/hip-tests/catch/unit/printf/printfHost.cc
+++ b/projects/hip-tests/catch/unit/printf/printfHost.cc
@@ -41,7 +41,7 @@ __global__ void run_printf(int* count) { *count = printf("Hello World"); }
  * ------------------------
  * - HIP_VERSION >= 5.7
  */
-TEST_CASE("Unit_Host_Printf") {
+TEST_CASE(Unit_Host_Printf) {
   int pcieAtomic = 0;
   HIP_CHECK(hipDeviceGetAttribute(&pcieAtomic, hipDeviceAttributeHostNativeAtomicSupported, 0));
   if (!pcieAtomic) {

--- a/projects/hip-tests/catch/unit/printf/printfLength.cc
+++ b/projects/hip-tests/catch/unit/printf/printfLength.cc
@@ -43,7 +43,7 @@ THE SOFTWARE.
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_Printf_length_Sanity_Positive") {
+TEST_CASE(Unit_Printf_length_Sanity_Positive) {
   int pcieAtomic = 0;
   HIP_CHECK(hipDeviceGetAttribute(&pcieAtomic, hipDeviceAttributeHostNativeAtomicSupported, 0));
   if (!pcieAtomic) {

--- a/projects/hip-tests/catch/unit/printf/printfNonHost.cc
+++ b/projects/hip-tests/catch/unit/printf/printfNonHost.cc
@@ -67,7 +67,7 @@ __global__ void kernel_printf_thread(int* count) {
  * - HIP_VERSION >= 5.7
  */
 
-TEST_CASE("Unit_NonHost_Printf_basic") {
+TEST_CASE(Unit_NonHost_Printf_basic) {
   int pcieAtomic = 0;
   HIP_CHECK(hipDeviceGetAttribute(&pcieAtomic, hipDeviceAttributeHostNativeAtomicSupported, 0));
   if (!pcieAtomic) {
@@ -102,7 +102,7 @@ TEST_CASE("Unit_NonHost_Printf_basic") {
  * - HIP_VERSION >= 5.7
  */
 
-TEST_CASE("Unit_NonHost_Printf_loop") {
+TEST_CASE(Unit_NonHost_Printf_loop) {
   int pcieAtomic = 0;
   HIP_CHECK(hipDeviceGetAttribute(&pcieAtomic, hipDeviceAttributeHostNativeAtomicSupported, 0));
   if (!pcieAtomic) {
@@ -144,7 +144,7 @@ TEST_CASE("Unit_NonHost_Printf_loop") {
  * - HIP_VERSION >= 5.7
  */
 
-TEST_CASE("Unit_NonHost_Printf_multiple_Threads") {
+TEST_CASE(Unit_NonHost_Printf_multiple_Threads) {
   int pcieAtomic = 0;
   HIP_CHECK(hipDeviceGetAttribute(&pcieAtomic, hipDeviceAttributeHostNativeAtomicSupported, 0));
   if (!pcieAtomic) {
@@ -189,7 +189,7 @@ TEST_CASE("Unit_NonHost_Printf_multiple_Threads") {
  * - HIP_VERSION >= 5.7
  */
 
-TEST_CASE("Unit_NonHost_Printf_BufferAvailability") {
+TEST_CASE(Unit_NonHost_Printf_BufferAvailability) {
   int pcieAtomic = 0;
   HIP_CHECK(hipDeviceGetAttribute(&pcieAtomic, hipDeviceAttributeHostNativeAtomicSupported, 0));
   if (!pcieAtomic) {

--- a/projects/hip-tests/catch/unit/printf/printfSpecifiers.cc
+++ b/projects/hip-tests/catch/unit/printf/printfSpecifiers.cc
@@ -46,7 +46,7 @@ THE SOFTWARE.
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_Printf_specifier_Sanity_Positive") {
+TEST_CASE(Unit_Printf_specifier_Sanity_Positive) {
   int pcieAtomic = 0;
   HIP_CHECK(hipDeviceGetAttribute(&pcieAtomic, hipDeviceAttributeHostNativeAtomicSupported, 0));
   if (!pcieAtomic) {
@@ -152,7 +152,7 @@ x
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_Printf_Negative_Parameters_RTC") {
+TEST_CASE(Unit_Printf_Negative_Parameters_RTC) {
   int pcieAtomic = 0;
   HIP_CHECK(hipDeviceGetAttribute(&pcieAtomic, hipDeviceAttributeHostNativeAtomicSupported, 0));
   if (!pcieAtomic) {

--- a/projects/hip-tests/catch/unit/printf/printfSpecifiersNonHost.cc
+++ b/projects/hip-tests/catch/unit/printf/printfSpecifiersNonHost.cc
@@ -45,7 +45,7 @@ THE SOFTWARE.
  * - HIP_VERSION >= 5.7
  */
 
-TEST_CASE("Unit_Buffered_Printf_Specifier") {
+TEST_CASE(Unit_Buffered_Printf_Specifier) {
   int pcieAtomic = 0;
   HIP_CHECK(hipDeviceGetAttribute(&pcieAtomic, hipDeviceAttributeHostNativeAtomicSupported, 0));
   if (!pcieAtomic) {

--- a/projects/hip-tests/catch/unit/rtc/customOptions.cc
+++ b/projects/hip-tests/catch/unit/rtc/customOptions.cc
@@ -24,7 +24,7 @@ __global__ void kernel(int* a) {
 }
 )"};
 
-TEST_CASE("Unit_hiprtc_cpp17") {
+TEST_CASE(Unit_hiprtc_cpp17) {
   using namespace std;
   hiprtcProgram prog;
   hiprtcCreateProgram(&prog,         // prog
@@ -93,7 +93,7 @@ template <typename T> __global__ void my_sqrt(T* input, int N) {
 }
 )"};
 
-TEST_CASE("Unit_hiprtc_namehandling") {
+TEST_CASE(Unit_hiprtc_namehandling) {
   using namespace std;
   hiprtcProgram prog;
   hiprtcCreateProgram(&prog,                 // prog
@@ -148,7 +148,7 @@ TEST_CASE("Unit_hiprtc_namehandling") {
   REQUIRE(compileResult == HIPRTC_SUCCESS);
 }
 
-TEST_CASE("Unit_hiprtc_getloweredname") {
+TEST_CASE(Unit_hiprtc_getloweredname) {
   using namespace std;
   hiprtcProgram prog;
   hiprtcCreateProgram(&prog,                 // prog

--- a/projects/hip-tests/catch/unit/rtc/hipRTCDeviceMalloc.cc
+++ b/projects/hip-tests/catch/unit/rtc/hipRTCDeviceMalloc.cc
@@ -36,7 +36,7 @@ void devicemalloc(float* x, float* y, float* out, float** px, float** py, size_t
 }
 )"};
 
-TEST_CASE("Unit_hiprtc_devicemalloc") {
+TEST_CASE(Unit_hiprtc_devicemalloc) {
   int pcieAtomic = 0;
   HIP_CHECK(hipDeviceGetAttribute(&pcieAtomic, hipDeviceAttributeHostNativeAtomicSupported, 0));
   if (!pcieAtomic) {

--- a/projects/hip-tests/catch/unit/rtc/hipRtcBfloat16.cc
+++ b/projects/hip-tests/catch/unit/rtc/hipRtcBfloat16.cc
@@ -52,7 +52,7 @@ void test_hip_bfloat16(float* f, bool* result)
 }
 )"};
 
-TEST_CASE("Unit_hiprtc_test_hip_bfloat16") {
+TEST_CASE(Unit_hiprtc_test_hip_bfloat16) {
   using namespace std;
   hiprtcProgram prog;
   HIPRTC_CHECK(hiprtcCreateProgram(&prog, code, "code.cu", 0, nullptr, nullptr));

--- a/projects/hip-tests/catch/unit/rtc/hipRtcComplexHeader.cc
+++ b/projects/hip-tests/catch/unit/rtc/hipRtcComplexHeader.cc
@@ -153,7 +153,7 @@ __global__ void hip_complex_corner_double_kernel(int *res) {
  * ------------------------
  *  - HIP_VERSION >= 6.1
  */
-TEST_CASE("Unit_Rtc_HipComplex_header") {
+TEST_CASE(Unit_Rtc_HipComplex_header) {
   int n = 0;
   hipDeviceProp_t prop;
   HIP_CHECK(hipGetDeviceProperties(&prop, 0));

--- a/projects/hip-tests/catch/unit/rtc/hipRtcFunctional.cc
+++ b/projects/hip-tests/catch/unit/rtc/hipRtcFunctional.cc
@@ -43,7 +43,7 @@ __global__ void testinline()
 }
 )"};
 
-TEST_CASE("Unit_hiprtc_functional") {
+TEST_CASE(Unit_hiprtc_functional) {
   using namespace std;
   hiprtcProgram prog;
   HIPRTC_CHECK(hiprtcCreateProgram(&prog, code, nullptr, 0, nullptr, nullptr));

--- a/projects/hip-tests/catch/unit/rtc/hipRtcPtrdiff_t.cc
+++ b/projects/hip-tests/catch/unit/rtc/hipRtcPtrdiff_t.cc
@@ -57,7 +57,7 @@ __global__ void ptrdiff_Kernel(unsigned int *res, int platformVar) {
  * ------------------------
  *  - HIP_VERSION >= 6.1
  */
-TEST_CASE("Unit_hipRTC_Ptrdiff_t_Check") {
+TEST_CASE(Unit_hipRTC_Ptrdiff_t_Check) {
   std::string kernel_name = "ptrdiff_Kernel";
   const char* kername = kernel_name.c_str();
   unsigned int* result_h;
@@ -134,7 +134,7 @@ TEST_CASE("Unit_hipRTC_Ptrdiff_t_Check") {
  * ------------------------
  *  - HIP_VERSION >= 6.1
  */
-TEST_CASE("Unit_hipRTC_Check_Ptrdiff_t_FrmChildProcess") {
+TEST_CASE(Unit_hipRTC_Check_Ptrdiff_t_FrmChildProcess) {
   // Spawn a process
   hip::SpawnProc proc("ChkPtrdiff_t_Exe", true);
   if ((proc.run("HIPRTC_PTRDIFF_T_IS_LONG_LONG 1") == 1) &&

--- a/projects/hip-tests/catch/unit/rtc/hipStreamCaptureRtc.cc
+++ b/projects/hip-tests/catch/unit/rtc/hipStreamCaptureRtc.cc
@@ -31,7 +31,7 @@ static constexpr auto kernel_src{
   )_KERN_EMBED_"};
 
 
-TEST_CASE("Unit_hipStreamCaptureRtc") {
+TEST_CASE(Unit_hipStreamCaptureRtc) {
   hipStream_t stream = nullptr;
   hipGraph_t graph = nullptr;
   hipGraphExec_t graph_exec = nullptr;

--- a/projects/hip-tests/catch/unit/rtc/hiprtcComplrOptnTesting.cc
+++ b/projects/hip-tests/catch/unit/rtc/hiprtcComplrOptnTesting.cc
@@ -36,177 +36,177 @@ HIPRTC supported compiler option idividually.
 */
 // SINGLE COMPILER OPTION TESTING
 const char** null = {};
-TEST_CASE("Unit_hiprtcGpuArchComplrOptnTst") {
+ TEST_CASE(Unit_hiprtcGpuArchComplrOptnTst) {
   INFO("Testing '--gpu-architecture=gfx906:sramecc+:xnack-' compiler opt");
   REQUIRE(check_architecture(null, -1, -1, -1));
 }
 
-TEST_CASE("Unit_hiprtcGpuRdcComplrOptnTst") {
+ TEST_CASE(Unit_hiprtcGpuRdcComplrOptnTst) {
   INFO("Testing '-fgpu-rdc' compiler option");
   REQUIRE(check_rdc(null, -1, -1, -1));
 }
 
-TEST_CASE("Unit_hiprtcEnabledDenormalsComplrOptnTst") {
+ TEST_CASE(Unit_hiprtcEnabledDenormalsComplrOptnTst) {
   INFO("Testing '-fgpu-flush-denormals-to-zero' compiler option");
   REQUIRE(check_denormals_enabled(null, -1, -1, -1));
 }
 
-TEST_CASE("Unit_hiprtcDisabledDenormalsComplrOptnTst") {
+ TEST_CASE(Unit_hiprtcDisabledDenormalsComplrOptnTst) {
   INFO("Testing '-fno-gpu-flush-denormals-to-zero' compiler option");
   REQUIRE(check_denormals_disabled(null, -1, -1, -1));
 }
 
-TEST_CASE("Unit_hiprtcOff_ffpContractComplrOptnTst") {
+ TEST_CASE(Unit_hiprtcOff_ffpContractComplrOptnTst) {
   INFO("Testing '-ffp-contract=off' compiler option");
   REQUIRE(check_ffp_contract_off(null, -1, -1, -1));
 }
 
-TEST_CASE("Unit_hiprtcOnffpContractComplrOptnTst") {
+ TEST_CASE(Unit_hiprtcOnffpContractComplrOptnTst) {
   INFO("Testing '-ffp-contract=on' compiler option");
   REQUIRE(check_ffp_contract_on(null, -1, -1, -1));
 }
 
-TEST_CASE("Unit_hiprtcFastffpContractComplrOptnTst") {
+ TEST_CASE(Unit_hiprtcFastffpContractComplrOptnTst) {
   INFO("Testing '-ffp-contract=fast' compiler option");
   REQUIRE(check_ffp_contract_fast(null, -1, -1, -1));
 }
 
-TEST_CASE("Unit_hiprtcEnabledFastMathComplrOptnTst") {
+ TEST_CASE(Unit_hiprtcEnabledFastMathComplrOptnTst) {
   INFO("Testing '-ffast-math' compiler option");
   REQUIRE(check_fast_math_enabled(null, -1, -1, -1));
 }
 
-TEST_CASE("Unit_hiprtcDisabledFastMathComplrOptnTst") {
+ TEST_CASE(Unit_hiprtcDisabledFastMathComplrOptnTst) {
   INFO("Testing '-fno-fast-math' compiler option");
   REQUIRE(check_fast_math_disabled(null, -1, -1, -1));
 }
 
-TEST_CASE("Unit_hiprtcEnabledSlpVectorizeComplrOptnTst") {
+ TEST_CASE(Unit_hiprtcEnabledSlpVectorizeComplrOptnTst) {
   INFO("Testing '-fslp-vectorize' compiler option");
   REQUIRE(check_slp_vectorize_enabled(null, -1, -1, -1));
 }
 
-TEST_CASE("Unit_hiprtcDisabledSlpVectorizeComplrOptnTst") {
+ TEST_CASE(Unit_hiprtcDisabledSlpVectorizeComplrOptnTst) {
   INFO("Testing '-fno-slp-vectorize' compiler option");
   REQUIRE(check_slp_vectorize_disabled(null, -1, -1, -1));
 }
 
-TEST_CASE("Unit_hiprtcDefineMacroComplrOptnTst") {
+ TEST_CASE(Unit_hiprtcDefineMacroComplrOptnTst) {
   INFO("Testing '-D' compiler option");
   REQUIRE(check_macro(null, -1, -1, -1));
 }
 
-TEST_CASE("Unit_hiprtcUndefMacroComplrOptnTst") {
+ TEST_CASE(Unit_hiprtcUndefMacroComplrOptnTst) {
   INFO("Testing '-U' compiler option");
   REQUIRE(check_undef_macro(null, -1, -1, -1));
 }
 
-TEST_CASE("Unit_hiprtcHeaderDirectoryComplrOptnTst") {
+ TEST_CASE(Unit_hiprtcHeaderDirectoryComplrOptnTst) {
   INFO("Testing '-I' compiler option");
   REQUIRE(check_header_dir(null, -1, -1, -1));
 }
 
-TEST_CASE("Unit_hiprtcWarningComplrOptnTst") {
+ TEST_CASE(Unit_hiprtcWarningComplrOptnTst) {
   INFO("Testing '-w' compiler option");
   REQUIRE(check_warning(null, -1, -1, -1));
 }
 
-TEST_CASE("Unit_hiprtcRpassInlineComplrOptnTst") {
+ TEST_CASE(Unit_hiprtcRpassInlineComplrOptnTst) {
   INFO("Testing '-Rpass=inline' compiler option");
   REQUIRE(check_Rpass_inline(null, -1, -1, -1));
 }
 
-TEST_CASE("Unit_hiprtcEnabledConversionErrComplrOptnTst") {
+ TEST_CASE(Unit_hiprtcEnabledConversionErrComplrOptnTst) {
   INFO("Testing '-Werror=conversion' compiler option");
   REQUIRE(check_conversionerror_enabled(null, -1, -1, -1));
 }
 
-TEST_CASE("Unit_hiprtcDisabledConversionErrComplrOptnTst") {
+ TEST_CASE(Unit_hiprtcDisabledConversionErrComplrOptnTst) {
   INFO("Testing '-Wno-error=conversion' compiler option");
   REQUIRE(check_conversionerror_disabled(null, -1, -1, -1));
 }
 
-TEST_CASE("Unit_hiprtcEnabledConversionWarningComplrOptnTst") {
+ TEST_CASE(Unit_hiprtcEnabledConversionWarningComplrOptnTst) {
   INFO("Testing '-Wconversion' compiler option");
   REQUIRE(check_conversionwarning_enabled(null, -1, -1, -1));
 }
 
-TEST_CASE("Unit_hiprtcDisabledConversionWarningComplrOptnTst") {
+ TEST_CASE(Unit_hiprtcDisabledConversionWarningComplrOptnTst) {
   INFO("Testing '-Wno-conversion' compiler option");
   REQUIRE(check_conversionwarning_disabled(null, -1, -1, -1));
 }
 
-TEST_CASE("Unit_hiprtcGpuMaxThreadPerBlockComplrOptnTst") {
+ TEST_CASE(Unit_hiprtcGpuMaxThreadPerBlockComplrOptnTst) {
   INFO("Testing '--gpu-max-threads-per-block=n' compiler option");
   REQUIRE(check_max_thread(null, -1, -1, -1));
 }
 
-TEST_CASE("Unit_hiprtcEnabledUnsafeAtomicComplrOptnTst") {
+ TEST_CASE(Unit_hiprtcEnabledUnsafeAtomicComplrOptnTst) {
   INFO("Testing '-munsafe-fp-atomics' compiler option");
   REQUIRE(check_unsafe_atomic_enabled(null, -1, -1, -1));
 }
 
-TEST_CASE("Unit_hiprtcDisabledUnsafeAtomicComplrOptnTst") {
+ TEST_CASE(Unit_hiprtcDisabledUnsafeAtomicComplrOptnTst) {
   INFO("Testing '-mno-unsafe-fp-atomics' compiler option");
   REQUIRE(check_unsafe_atomic_disabled(null, -1, -1, -1));
 }
 
-TEST_CASE("Unit_hiprtcEnabledInfiniteNumComplrOptnTst") {
+ TEST_CASE(Unit_hiprtcEnabledInfiniteNumComplrOptnTst) {
   INFO("Testing '-fhonor-infinities' compiler option");
   REQUIRE(check_infinite_num_enabled(null, -1, -1, -1));
 }
 
-TEST_CASE("Unit_hiprtcDisabledInfiniteNumComplrOptnTst") {
+ TEST_CASE(Unit_hiprtcDisabledInfiniteNumComplrOptnTst) {
   INFO("Testing '-fno-honor-infinities' compiler option");
   REQUIRE(check_infinite_num_disabled(null, -1, -1, -1));
 }
 
-TEST_CASE("Unit_hiprtcEnabledNANComplrOptnTst") {
+ TEST_CASE(Unit_hiprtcEnabledNANComplrOptnTst) {
   INFO("Testing '-fhonor-nans' compiler option");
   REQUIRE(check_NAN_num_enabled(null, -1, -1, -1));
 }
 
-TEST_CASE("Unit_hiprtcDisabledNANComplrOptnTst") {
+ TEST_CASE(Unit_hiprtcDisabledNANComplrOptnTst) {
   INFO("Testing '-fno-honor-nans' compiler option");
   REQUIRE(check_NAN_num_disabled(null, -1, -1, -1));
 }
 
-TEST_CASE("Unit_hiprtcEnabledFiniteMathComplrOptnTst") {
+ TEST_CASE(Unit_hiprtcEnabledFiniteMathComplrOptnTst) {
   INFO("Testing '-ffinite-math-only' compiler option");
   REQUIRE(check_finite_math_enabled(null, -1, -1, -1));
 }
 
-TEST_CASE("Unit_hiprtcDisabledFiniteMathComplrOptnTst") {
+ TEST_CASE(Unit_hiprtcDisabledFiniteMathComplrOptnTst) {
   INFO("Testing '-fno-finite-math-only' compiler option");
   REQUIRE(check_finite_math_disabled(null, -1, -1, -1));
 }
 
-TEST_CASE("Unit_hiprtcEnabledAssociativeMathComplrOptnTst") {
+ TEST_CASE(Unit_hiprtcEnabledAssociativeMathComplrOptnTst) {
   INFO("Testing '-fassociative-math' compiler option");
   REQUIRE(check_associative_math_enabled(null, -1, -1, -1));
 }
 
-TEST_CASE("Unit_hiprtcDisabledAssociativeMathComplrOptnTst") {
+ TEST_CASE(Unit_hiprtcDisabledAssociativeMathComplrOptnTst) {
   INFO("Testing '-fno-associative-math' compiler option");
   REQUIRE(check_associative_math_disabled(null, -1, -1, -1));
 }
 
-TEST_CASE("Unit_hiprtcEnabledSignedZerosComplrOptnTst") {
+ TEST_CASE(Unit_hiprtcEnabledSignedZerosComplrOptnTst) {
   INFO("Testing '-fsigned-zeros' compiler option");
   REQUIRE(check_signed_zeros_enabled(null, -1, -1, -1));
 }
 
-TEST_CASE("Unit_hiprtcDisabledSignedZerosComplrOptnTst") {
+ TEST_CASE(Unit_hiprtcDisabledSignedZerosComplrOptnTst) {
   INFO("Testing '-fno-signed-zeros' compiler option");
   REQUIRE(check_signed_zeros_disabled(null, -1, -1, -1));
 }
 
-TEST_CASE("Unit_hiprtcEnabledTrappingMathComplrOptnTst") {
+ TEST_CASE(Unit_hiprtcEnabledTrappingMathComplrOptnTst) {
   INFO("Testing '-ftrapping-math' compiler option");
   REQUIRE(check_trapping_math_enabled(null, -1, -1, -1));
 }
 
-TEST_CASE("Unit_hiprtcDisabledTrappingMathComplrOptnTst") {
+ TEST_CASE(Unit_hiprtcDisabledTrappingMathComplrOptnTst) {
   INFO("Testing '-fno-trapping-math' compiler option");
   REQUIRE(check_trapping_math_disabled(null, -1, -1, -1));
 }
@@ -217,7 +217,7 @@ a combination of HIPRTC supported compiler options which a retrieved from
 RtcConfig.jason file.
 */
 
-TEST_CASE("Unit_hiprtcCombiComplrOptnTst") {
+TEST_CASE(Unit_hiprtcCombiComplrOptnTst) {
   // COMBINATION COMPILER OPTIONS
   std::vector<std::string> CombiCompOptions = get_combi_string_vec();
   int TotalCombos = CombiCompOptions.size();

--- a/projects/hip-tests/catch/unit/rtc/hiprtcGetLoweredName.cc
+++ b/projects/hip-tests/catch/unit/rtc/hiprtcGetLoweredName.cc
@@ -157,7 +157,7 @@ bool Test(int CaseNum, const char* GpuProgram) {
 }
 
 
-TEST_CASE("Unit_hiprtcGetLoweredName_templateKrnls") {
+TEST_CASE(Unit_hiprtcGetLoweredName_templateKrnls) {
   REQUIRE(Test(1, gpuProgram1));
   REQUIRE(Test(2, gpuProgram2));
   REQUIRE(Test(3, gpuProgram3));

--- a/projects/hip-tests/catch/unit/rtc/hiprtc_Bitcode_UndefinedFn.cc
+++ b/projects/hip-tests/catch/unit/rtc/hiprtc_Bitcode_UndefinedFn.cc
@@ -32,7 +32,7 @@ THE SOFTWARE.
 // hiprtc kernel has an undefined function which will be linked in the later stages using hiprtc
 // linker APIs
 
-TEST_CASE("Unit_hiprtc_bitcode_undefined_function") {
+TEST_CASE(Unit_hiprtc_bitcode_undefined_function) {
   using namespace std;
 
   static constexpr auto kernel{

--- a/projects/hip-tests/catch/unit/rtc/hiprtc_MathConstants_HeaderTst.cc
+++ b/projects/hip-tests/catch/unit/rtc/hiprtc_MathConstants_HeaderTst.cc
@@ -145,7 +145,7 @@ __global__ void mathConstants(float *res) {
  * ------------------------
  *  - HIP_VERSION >= 6.0
  */
-TEST_CASE("Unit_Rtc_MathConstants_header") {
+TEST_CASE(Unit_Rtc_MathConstants_header) {
   std::string kernel_name = "mathConstants";
   const char* kername = kernel_name.c_str();
   float* result_h;

--- a/projects/hip-tests/catch/unit/rtc/hiprtc_MathFunctions_HeaderTst.cc
+++ b/projects/hip-tests/catch/unit/rtc/hiprtc_MathFunctions_HeaderTst.cc
@@ -59,7 +59,7 @@ __global__ void mathFuntn(float *res) {
  *  - HIP_VERSION >= 6.1
  */
 
-TEST_CASE("Unit_Rtc_MathFunctions_header") {
+TEST_CASE(Unit_Rtc_MathFunctions_header) {
   std::string kernel_name = "mathFuntn";
   const char* kername = kernel_name.c_str();
   float* result_h;

--- a/projects/hip-tests/catch/unit/rtc/hiprtc_TextureTypes_HeaderTst.cc
+++ b/projects/hip-tests/catch/unit/rtc/hiprtc_TextureTypes_HeaderTst.cc
@@ -67,7 +67,7 @@ __global__ void TextureTypes(float *res) {
  *  - HIP_VERSION >= 6.1
  */
 
-TEST_CASE("Unit_Rtc_TextureTypes_header") {
+TEST_CASE(Unit_Rtc_TextureTypes_header) {
   std::string kernel_name = "TextureTypes";
   const char* kername = kernel_name.c_str();
   float* result_h;

--- a/projects/hip-tests/catch/unit/rtc/hiprtc_VectorTypes_HeaderTst.cc
+++ b/projects/hip-tests/catch/unit/rtc/hiprtc_VectorTypes_HeaderTst.cc
@@ -1359,7 +1359,7 @@ __global__ void vectorTypes(int *res) {
  * ------------------------
  *  - HIP_VERSION >= 6.1
  */
-TEST_CASE("Unit_Rtc_VectorTypes_header") {
+TEST_CASE(Unit_Rtc_VectorTypes_header) {
   std::string kernel_name = "vectorTypes";
   const char* kername = kernel_name.c_str();
   int* result_h;

--- a/projects/hip-tests/catch/unit/rtc/hiprtc_bfloat16_HeaderTst.cc
+++ b/projects/hip-tests/catch/unit/rtc/hiprtc_bfloat16_HeaderTst.cc
@@ -81,7 +81,7 @@ __global__ void bfloat16(float *res) {
  *  - HIP_VERSION >= 6.1
  */
 
-TEST_CASE("Unit_Rtc_bfloat16_header") {
+TEST_CASE(Unit_Rtc_bfloat16_header) {
   std::string kernel_name = "bfloat16";
   const char* kername = kernel_name.c_str();
   float* result_h;

--- a/projects/hip-tests/catch/unit/rtc/hiprtc_fp16_HeaderTst.cc
+++ b/projects/hip-tests/catch/unit/rtc/hiprtc_fp16_HeaderTst.cc
@@ -289,7 +289,7 @@ __global__ void fp16(float *res) {
  *  - HIP_VERSION >= 5.7
  */
 
-TEST_CASE("Unit_Rtc_fp16_header") {
+TEST_CASE(Unit_Rtc_fp16_header) {
   std::string kernel_name = "fp16";
   const char* kername = kernel_name.c_str();
   float* result_h;

--- a/projects/hip-tests/catch/unit/rtc/includepath.cc
+++ b/projects/hip-tests/catch/unit/rtc/includepath.cc
@@ -17,7 +17,7 @@ static constexpr auto NUM_BLOCKS{32};
 // This test verifies hiprtc compilation by passing include path option using -I with spaces
 // before the path. eg: -I   ../ or -I /path/to/headers etc.
 
-TEST_CASE("Unit_hiprtc_includepath") {
+TEST_CASE(Unit_hiprtc_includepath) {
   using namespace std;
 
   string saxpy = "";

--- a/projects/hip-tests/catch/unit/rtc/linker.cc
+++ b/projects/hip-tests/catch/unit/rtc/linker.cc
@@ -28,7 +28,7 @@ void saxpy(float a, float* x, float* y, float* out, size_t n)
 }
 )"};
 
-TEST_CASE("Unit_RTC_LinkerAPI_Negative") {
+TEST_CASE(Unit_RTC_LinkerAPI_Negative) {
   SECTION("get bitcode - nullptr size and code") {
     hiprtcProgram program;
     REQUIRE(hiprtcGetBitcodeSize(program, nullptr) == HIPRTC_ERROR_INVALID_INPUT);
@@ -49,14 +49,14 @@ TEST_CASE("Unit_RTC_LinkerAPI_Negative") {
   }
 }
 
-TEST_CASE("Unit_RTC_LinkDestroy_Negative") {
+TEST_CASE(Unit_RTC_LinkDestroy_Negative) {
   SECTION("link destroy - incorrect hiprtcLinkState") {
     hiprtcLinkState linkstate;
     REQUIRE(hiprtcLinkDestroy(linkstate) == HIPRTC_ERROR_INVALID_INPUT);
   }
 }
 
-TEST_CASE("Unit_RTC_LinkDestroy_Default") {
+TEST_CASE(Unit_RTC_LinkDestroy_Default) {
   SECTION("link destroy - nullptr") {
     REQUIRE(hiprtcLinkDestroy(nullptr) == HIPRTC_ERROR_INVALID_INPUT);
   }
@@ -80,7 +80,7 @@ std::vector<char> createBitcodeFromSource(const char* src, const char* name, int
   return code;
 }
 
-TEST_CASE("Unit_RTC_LinkerAPI") {
+TEST_CASE(Unit_RTC_LinkerAPI) {
   const char* options[]{"-fgpu-rdc"};
   std::vector<char> code = createBitcodeFromSource(src, "saxpy", 1, options);
 
@@ -151,7 +151,7 @@ TEST_CASE("Unit_RTC_LinkerAPI") {
   }
 }
 
-TEST_CASE("Unit_RTC_LinkAddFile_Negative") {
+TEST_CASE(Unit_RTC_LinkAddFile_Negative) {
   static constexpr hiprtcJITInputType input_type = HIPRTC_JIT_INPUT_LLVM_BITCODE;
   static constexpr const char* file_name = "bitcode_file";
 
@@ -184,7 +184,7 @@ TEST_CASE("Unit_RTC_LinkAddFile_Negative") {
   }
 }
 
-TEST_CASE("Unit_RTC_LinkAddFile_Default") {
+TEST_CASE(Unit_RTC_LinkAddFile_Default) {
   // Create bitcode and save it to file
   const char* options[]{"-fgpu-rdc"};
   std::vector<char> code = createBitcodeFromSource(src, "saxpy", 1, options);

--- a/projects/hip-tests/catch/unit/rtc/rtc_reduce.cc
+++ b/projects/hip-tests/catch/unit/rtc/rtc_reduce.cc
@@ -172,7 +172,7 @@ void runAndCompileTest(const std::tuple<Types...> types) {
   HIPRTC_CHECK(hiprtcDestroyProgram(&prog));
 }
 
-TEST_CASE("Unit_Rtc_ReduceRandom") {
+TEST_CASE(Unit_Rtc_ReduceRandom) {
   const std::tuple<int, unsigned int, long long, unsigned long long, float, half, double> allTypes;
   const std::tuple<int, unsigned int, long long, unsigned long long> integralTypes;
 

--- a/projects/hip-tests/catch/unit/rtc/saxpy.cc
+++ b/projects/hip-tests/catch/unit/rtc/saxpy.cc
@@ -27,7 +27,7 @@ void saxpy(float a, float* x, float* y, float* out, size_t n)
 }
 )"};
 
-TEST_CASE("Unit_hiprtc_saxpy") {
+TEST_CASE(Unit_hiprtc_saxpy) {
   using namespace std;
   hiprtcProgram prog;
   hiprtcCreateProgram(&prog,       // prog

--- a/projects/hip-tests/catch/unit/rtc/shfl.cc
+++ b/projects/hip-tests/catch/unit/rtc/shfl.cc
@@ -153,7 +153,7 @@ template <typename T> void runTestShfl(int option) {
   HIPRTC_CHECK(hiprtcDestroyProgram(&prog));
 }
 
-TEST_CASE("Unit_hiprtc_half_shuffle") {
+TEST_CASE(Unit_hiprtc_half_shuffle) {
   runTestShfl<__half>(1);
   runTestShfl<__half>(2);
   runTestShfl<__half>(3);

--- a/projects/hip-tests/catch/unit/rtc/shfl_sync.cc
+++ b/projects/hip-tests/catch/unit/rtc/shfl_sync.cc
@@ -157,7 +157,7 @@ template <typename T> void runTestShflSync(int option) {
   HIPRTC_CHECK(hiprtcDestroyProgram(&prog));
 }
 
-TEST_CASE("Unit_hiprtc_half_shuffle_sync") {
+TEST_CASE(Unit_hiprtc_half_shuffle_sync) {
   runTestShflSync<__half>(1);
   runTestShflSync<__half>(2);
   runTestShflSync<__half>(3);

--- a/projects/hip-tests/catch/unit/rtc/stdheaders.cc
+++ b/projects/hip-tests/catch/unit/rtc/stdheaders.cc
@@ -76,7 +76,7 @@ template <typename T> __global__ void stdheader(T a, bool* passed) {
  * ------------------------
  *  - ROCM_VERSION >= 7.0
  */
-TEST_CASE("Unit_hiprtc_stdheaders") {
+TEST_CASE(Unit_hiprtc_stdheaders) {
   HipTest::HIP_SKIP_TEST("Test disabled due to incorrect ROCm version");
   return;
 

--- a/projects/hip-tests/catch/unit/rtc/warpsize.cc
+++ b/projects/hip-tests/catch/unit/rtc/warpsize.cc
@@ -43,7 +43,7 @@ void getWarpSize(int* warpSizePtr)
 }
 )"};
 
-TEST_CASE("Unit_hiprtc_warpsize") {
+TEST_CASE(Unit_hiprtc_warpsize) {
   using namespace std;
   hiprtcProgram prog;
   HIPRTC_CHECK(hiprtcCreateProgram(&prog, code, "code.cu", 0, nullptr, nullptr));

--- a/projects/hip-tests/catch/unit/stream/hipDeviceGetStreamPriorityRange.cc
+++ b/projects/hip-tests/catch/unit/stream/hipDeviceGetStreamPriorityRange.cc
@@ -26,7 +26,7 @@ Unit_hipDeviceGetStreamPriorityRange_Default - Check if device stream piority ra
 
 #include <hip_test_common.hh>
 
-TEST_CASE("Unit_hipDeviceGetStreamPriorityRange_Default") {
+TEST_CASE(Unit_hipDeviceGetStreamPriorityRange_Default) {
   int priority_low = 0;
   int priority_high = 0;
   int devID = GENERATE(range(0, HipTest::getDeviceCount()));

--- a/projects/hip-tests/catch/unit/stream/hipLaunchHostFunc.cc
+++ b/projects/hip-tests/catch/unit/stream/hipLaunchHostFunc.cc
@@ -97,7 +97,7 @@ static void Fn_ChkUserdataPtr(void* userData) {
   }
 }
 
-TEST_CASE("Unit_hipLaunchHostFunc_basic") {
+TEST_CASE(Unit_hipLaunchHostFunc_basic) {
   hipStream_t mystream;
   HIP_CHECK(hipStreamCreate(&mystream));
   gusrptr = ptr0xff;
@@ -109,7 +109,7 @@ TEST_CASE("Unit_hipLaunchHostFunc_basic") {
 }
 
 // Negative test scenario for hipLaunchHostFunc
-TEST_CASE("Unit_hipLaunchHostFunc_Negative") {
+TEST_CASE(Unit_hipLaunchHostFunc_Negative) {
   hipStream_t mystream;
   HIP_CHECK(hipStreamCreate(&mystream));
 
@@ -140,7 +140,7 @@ static void launchOperationOnStrm(usrDataS* usrDataptr, hipStream_t stream) {
 // Test scenario 2
 // scenario that validates the host launch function on 3 different streams,
 // created stream, default/null stream and hipStreamPerThread.
-TEST_CASE("Unit_hipLaunchHostFunc_streams") {
+TEST_CASE(Unit_hipLaunchHostFunc_streams) {
   hipStream_t stream[NUM_OF_STREAM];
   HIP_CHECK(hipStreamCreate(&stream[0]));
   stream[1] = 0;  // Null stream
@@ -178,7 +178,7 @@ static void Fn_validateMul_stream(void* userData) {
   ptrUsrData->isPassed = true;
 }
 
-TEST_CASE("Unit_hipLaunchHostFunc_multistreams") {
+TEST_CASE(Unit_hipLaunchHostFunc_multistreams) {
   hipStream_t mystream1, mystream2;
   HIP_CHECK(hipStreamCreateWithFlags(&mystream1, hipStreamNonBlocking));
   HIP_CHECK(hipStreamCreateWithFlags(&mystream2, hipStreamNonBlocking));
@@ -254,7 +254,7 @@ static void Fn_Completion_state(void* userData) {
   ptrUsrData->isOpCompleted = true;
 }
 
-TEST_CASE("Unit_hipLaunchHostFunc_KernelHost") {
+TEST_CASE(Unit_hipLaunchHostFunc_KernelHost) {
   hipStream_t stream1, stream2, stream3;
   HIP_CHECK(hipStreamCreate(&stream1));
   HIP_CHECK(hipStreamCreate(&stream2));
@@ -313,7 +313,7 @@ TEST_CASE("Unit_hipLaunchHostFunc_KernelHost") {
 // Test scenario 5
 // scenario that validates the host launch function on multi device
 // environment.
-TEST_CASE("Unit_hipLaunchHostFunc_multidevice", "[multigpu]") {
+TEST_CASE(Unit_hipLaunchHostFunc_multidevice) {
   int num_devices;
   HIP_CHECK(hipGetDeviceCount(&num_devices));
   if (num_devices < 2) {
@@ -344,7 +344,7 @@ TEST_CASE("Unit_hipLaunchHostFunc_multidevice", "[multigpu]") {
 // Test scenario 6
 // scenario that validates the host launch function on created
 // stream with same priority.
-TEST_CASE("Unit_hipLaunchHostFunc_Samepriority") {
+TEST_CASE(Unit_hipLaunchHostFunc_Samepriority) {
   int priority = 0;
   unsigned int flags = 0;
   usrDataS* usrDataptr = reinterpret_cast<usrDataS*>(malloc(sizeof(usrDataS)));
@@ -370,7 +370,7 @@ TEST_CASE("Unit_hipLaunchHostFunc_Samepriority") {
 // Test scenario 7
 // scenario that validates the host launch function on
 // created stream with different priority.
-TEST_CASE("Unit_hipLaunchHostFunc_Diffpriority") {
+TEST_CASE(Unit_hipLaunchHostFunc_Diffpriority) {
   int priority;
   int priority_low{};
   int priority_high{};
@@ -429,7 +429,7 @@ void myHostNodeCallback(void* data) {
   *result = 0.0;  // reset the result
 }
 
-TEST_CASE("Unit_hipLaunchHostFunc_Graph") {
+TEST_CASE(Unit_hipLaunchHostFunc_Graph) {
   size_t size = 1 << 12;
   size_t maxBlocks = 512;
   float *inputVec_d = NULL, *inputVec_h = NULL;

--- a/projects/hip-tests/catch/unit/stream/hipMultiStream.cc
+++ b/projects/hip-tests/catch/unit/stream/hipMultiStream.cc
@@ -36,7 +36,7 @@ __global__ void nKernel(float* y) {
   size_t tid{threadIdx.x};
   y[tid] = y[tid] + 1.0f;
 }
-TEST_CASE("Unit_hipMultiStream_sameDevice") {
+TEST_CASE(Unit_hipMultiStream_sameDevice) {
   constexpr int num_streams{8};
   hipStream_t streams[num_streams];
   float *data[num_streams], *yd, *xd;
@@ -62,7 +62,7 @@ TEST_CASE("Unit_hipMultiStream_sameDevice") {
   REQUIRE(x == Catch::Approx(y));
 }
 
-TEST_CASE("Unit_hipMultiStream_multimeDevice") {
+TEST_CASE(Unit_hipMultiStream_multimeDevice) {
   constexpr int nLoops = 50000;
   constexpr int nStreams = 2;
   std::vector<hipStream_t> streams(nStreams);

--- a/projects/hip-tests/catch/unit/stream/hipStreamACb_MultiThread.cc
+++ b/projects/hip-tests/catch/unit/stream/hipStreamACb_MultiThread.cc
@@ -86,7 +86,7 @@ void Thread2_func() { HIPCHECK(hipStreamAddCallback(mystream, Thread2_Callback, 
  Test multiple hipStreamAddCallback() called over
  multiple Threads.
  */
-TEST_CASE("Unit_hipStreamAddCallback_MultipleThreads") {
+TEST_CASE(Unit_hipStreamAddCallback_MultipleThreads) {
   float *A_d, *C_d;
   size_t Nbytes = (N) * sizeof(float);
   constexpr float Phi = 1.618f;

--- a/projects/hip-tests/catch/unit/stream/hipStreamACb_StrmSyncTiming.cc
+++ b/projects/hip-tests/catch/unit/stream/hipStreamACb_StrmSyncTiming.cc
@@ -80,7 +80,7 @@ static void HIPRT_CB Callback1(hipStream_t stream, hipError_t status, void* user
  Test multiple hipStreamAddCallback() called over
  multiple Threads.
  */
-TEST_CASE("Unit_hipStreamAddCallback_StrmSyncTiming") {
+TEST_CASE(Unit_hipStreamAddCallback_StrmSyncTiming) {
   float *A_d, *C_d;
   size_t Nbytes = N_elmts * sizeof(float);
 

--- a/projects/hip-tests/catch/unit/stream/hipStreamAddCallback.cc
+++ b/projects/hip-tests/catch/unit/stream/hipStreamAddCallback.cc
@@ -161,7 +161,7 @@ using hipStreaAddCallbackTest::testStreamCallbackFunctionality;
 /*
  * Validates parameter list of hipStreamAddCallback.
  */
-TEST_CASE("Unit_hipStreamAddCallback_ParamTst_Positive") {
+TEST_CASE(Unit_hipStreamAddCallback_ParamTst_Positive) {
   hipStream_t mystream;
   HIP_CHECK(hipStreamCreate(&mystream));
 
@@ -194,7 +194,7 @@ TEST_CASE("Unit_hipStreamAddCallback_ParamTst_Positive") {
 /*
  * Negative tests for validation of hipStreamAddCallback parameter list.
  */
-TEST_CASE("Unit_hipStreamAddCallback_ParamTst_Negative") {
+TEST_CASE(Unit_hipStreamAddCallback_ParamTst_Negative) {
   hipStream_t mystream;
   HIP_CHECK(hipStreamCreate(&mystream));
 
@@ -220,7 +220,7 @@ TEST_CASE("Unit_hipStreamAddCallback_ParamTst_Negative") {
 /*
  * Validates hipStreamAddCallback functionality with default stream.
  */
-TEST_CASE("Unit_hipStreamAddCallback_WithDefaultStream") {
+TEST_CASE(Unit_hipStreamAddCallback_WithDefaultStream) {
   bool TestPassed = true;
   TestPassed = testStreamCallbackFunctionality(true);
   REQUIRE(TestPassed);
@@ -229,7 +229,7 @@ TEST_CASE("Unit_hipStreamAddCallback_WithDefaultStream") {
 /*
  * Validates hipStreamAddCallback functionality with defined stream.
  */
-TEST_CASE("Unit_hipStreamAddCallback_WithCreatedStream") {
+TEST_CASE(Unit_hipStreamAddCallback_WithCreatedStream) {
   bool TestPassed = true;
   TestPassed = testStreamCallbackFunctionality(false);
   REQUIRE(TestPassed);

--- a/projects/hip-tests/catch/unit/stream/hipStreamAttachMemAsync.cc
+++ b/projects/hip-tests/catch/unit/stream/hipStreamAttachMemAsync.cc
@@ -26,7 +26,7 @@ __device__ __managed__ int var = 0;
 
 enum class StreamAttachTestType { NullStream = 0, StreamPerThread, CreatedStream };
 
-TEST_CASE("Unit_hipStreamAttachMemAsync_Negative") {
+TEST_CASE(Unit_hipStreamAttachMemAsync_Negative) {
   hipStream_t stream{nullptr};
 
   auto streamType =
@@ -81,7 +81,7 @@ __global__ void kernel(int* ptr, size_t size) {
 constexpr size_t size = 1024;
 __device__ __managed__ int m_memory[size];
 
-TEST_CASE("Unit_hipStreamAttachMemAsync_UseCase") {
+TEST_CASE(Unit_hipStreamAttachMemAsync_UseCase) {
   hipStream_t stream{nullptr};
 
   auto streamType =

--- a/projects/hip-tests/catch/unit/stream/hipStreamBatchMemOp.cc
+++ b/projects/hip-tests/catch/unit/stream/hipStreamBatchMemOp.cc
@@ -38,7 +38,7 @@ THE SOFTWARE.
  * ------------------------
  *    - HIP_VERSION >= 6.4
  */
-TEST_CASE("Unit_hipStreamBatchMemOp_Negative_Tests") {
+TEST_CASE(Unit_hipStreamBatchMemOp_Negative_Tests) {
   hipStream_t stream{nullptr};
   HIP_CHECK(hipStreamCreate(&stream));
   REQUIRE(stream != nullptr);

--- a/projects/hip-tests/catch/unit/stream/hipStreamCopyAttributes.cc
+++ b/projects/hip-tests/catch/unit/stream/hipStreamCopyAttributes.cc
@@ -38,7 +38,7 @@ THE SOFTWARE.
  *    - HIP_VERSION >= 7.2
  */
 
-TEST_CASE("Unit_hipStreamCopyAttributes_Basic") {
+TEST_CASE(Unit_hipStreamCopyAttributes_Basic) {
   hipStream_t stream1, stream2, stream3, stream4;
   hipStreamAttrValue val1, val2;
   HIP_CHECK(hipStreamCreate(&stream1));
@@ -116,7 +116,7 @@ TEST_CASE("Unit_hipStreamCopyAttributes_Basic") {
  * ------------------------
  *  - HIP_VERSION >= 7.2
  */
-TEST_CASE("Unit_hipStreamCopyAttributes_Negative") {
+TEST_CASE(Unit_hipStreamCopyAttributes_Negative) {
   hipStream_t srcStream = nullptr;
   HIP_CHECK(hipStreamCreate(&srcStream));
   hipStream_t dstStream = nullptr;
@@ -159,7 +159,7 @@ TEST_CASE("Unit_hipStreamCopyAttributes_Negative") {
  * ------------------------
  *  - HIP_VERSION >= 7.2
  */
-TEST_CASE("Unit_hipStreamCopyAttributes_WithAllSyncPolicyValues") {
+TEST_CASE(Unit_hipStreamCopyAttributes_WithAllSyncPolicyValues) {
   hipStream_t srcStream = nullptr;
   HIP_CHECK(hipStreamCreate(&srcStream));
   hipStream_t dstStream = nullptr;

--- a/projects/hip-tests/catch/unit/stream/hipStreamCreate.cc
+++ b/projects/hip-tests/catch/unit/stream/hipStreamCreate.cc
@@ -19,7 +19,7 @@ THE SOFTWARE.
 
 #include "streamCommon.hh"
 
-TEST_CASE("Unit_hipStreamCreate_default") {
+TEST_CASE(Unit_hipStreamCreate_default) {
   int id = GENERATE(range(0, HipTest::getDeviceCount()));
   HIP_CHECK(hipSetDevice(id));
 
@@ -30,6 +30,6 @@ TEST_CASE("Unit_hipStreamCreate_default") {
   HIP_CHECK(hipStreamDestroy(stream));
 }
 
-TEST_CASE("Unit_hipStreamCreate_Negative") {
+TEST_CASE(Unit_hipStreamCreate_Negative) {
   REQUIRE(hipErrorInvalidValue == hipStreamCreate(nullptr));
 }

--- a/projects/hip-tests/catch/unit/stream/hipStreamCreateWithFlags.cc
+++ b/projects/hip-tests/catch/unit/stream/hipStreamCreateWithFlags.cc
@@ -23,11 +23,11 @@ THE SOFTWARE.
 
 namespace hipStreamCreateWithFlagsTests {
 
-TEST_CASE("Unit_hipStreamCreateWithFlags_Negative_NullStream") {
+TEST_CASE(Unit_hipStreamCreateWithFlags_Negative_NullStream) {
   HIP_CHECK_ERROR(hipStreamCreateWithFlags(nullptr, hipStreamDefault), hipErrorInvalidValue);
 }
 
-TEST_CASE("Unit_hipStreamCreateWithFlags_Negative_InvalidFlag") {
+TEST_CASE(Unit_hipStreamCreateWithFlags_Negative_InvalidFlag) {
   hipStream_t stream{};
   unsigned int flag = 0xFF;
   REQUIRE(flag != hipStreamDefault);
@@ -36,7 +36,7 @@ TEST_CASE("Unit_hipStreamCreateWithFlags_Negative_InvalidFlag") {
 }
 
 // create a stream and check the properties are correctly set
-TEST_CASE("Unit_hipStreamCreateWithFlags_Default") {
+TEST_CASE(Unit_hipStreamCreateWithFlags_Default) {
   const unsigned int flagUnderTest = GENERATE(hipStreamDefault, hipStreamNonBlocking);
   hipStream_t stream{};
   HIP_CHECK(hipStreamCreateWithFlags(&stream, flagUnderTest));
@@ -56,7 +56,7 @@ TEST_CASE("Unit_hipStreamCreateWithFlags_Default") {
 // a stream will default to blocking the null stream, but will not block the null stream when
 // created with hipStreamNonBlocking
 #if HT_AMD /* Disabled because frequency based wait is timing out on nvidia platforms */
-TEST_CASE("Unit_hipStreamCreateWithFlags_DefaultStreamInteraction") {
+TEST_CASE(Unit_hipStreamCreateWithFlags_DefaultStreamInteraction) {
   const hipStream_t defaultStream = GENERATE(static_cast<hipStream_t>(nullptr), hipStreamPerThread);
   const unsigned int flagUnderTest = GENERATE(hipStreamDefault, hipStreamNonBlocking);
   CAPTURE(defaultStream, flagUnderTest);

--- a/projects/hip-tests/catch/unit/stream/hipStreamCreateWithPriority.cc
+++ b/projects/hip-tests/catch/unit/stream/hipStreamCreateWithPriority.cc
@@ -803,7 +803,7 @@ template <typename T> void TestForMultipleStreamWithPriority(void) {
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_hipStreamCreateWithPriority_FunctionalForAllPriorities") {
+TEST_CASE(Unit_hipStreamCreateWithPriority_FunctionalForAllPriorities) {
   SECTION("Default flag and device synchronize") {
     hipStreamCreateWithPriorityTest::funcTestsForAllPriorityLevelsWrtNullStrm(hipStreamDefault,
                                                                               true);
@@ -837,7 +837,7 @@ TEST_CASE("Unit_hipStreamCreateWithPriority_FunctionalForAllPriorities") {
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_hipStreamCreateWithPriority_MulthreadDefaultflag") {
+TEST_CASE(Unit_hipStreamCreateWithPriority_MulthreadDefaultflag) {
   bool TestPassed = true;
   TestPassed =
       hipStreamCreateWithPriorityTest::runFuncTestsForAllPriorityLevelsMultThread(hipStreamDefault);
@@ -856,7 +856,7 @@ TEST_CASE("Unit_hipStreamCreateWithPriority_MulthreadDefaultflag") {
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_hipStreamCreateWithPriority_MulthreadNonblockingflag") {
+TEST_CASE(Unit_hipStreamCreateWithPriority_MulthreadNonblockingflag) {
   bool TestPassed = true;
   TestPassed = hipStreamCreateWithPriorityTest::runFuncTestsForAllPriorityLevelsMultThread(
       hipStreamNonBlocking);
@@ -874,7 +874,7 @@ TEST_CASE("Unit_hipStreamCreateWithPriority_MulthreadNonblockingflag") {
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_hipStreamCreateWithPriority_NegTst") {
+TEST_CASE(Unit_hipStreamCreateWithPriority_NegTst) {
   hipStream_t stream{nullptr};
   int priority_low{0};
   int priority_high{0};
@@ -907,7 +907,7 @@ TEST_CASE("Unit_hipStreamCreateWithPriority_NegTst") {
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_hipStreamCreateWithPriority_CheckPriorityVal") {
+TEST_CASE(Unit_hipStreamCreateWithPriority_CheckPriorityVal) {
   int id = GENERATE(range(0, HipTest::getDeviceCount()));
 
   HIP_CHECK(hipSetDevice(id));
@@ -962,7 +962,7 @@ TEST_CASE("Unit_hipStreamCreateWithPriority_CheckPriorityVal") {
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_hipStreamCreateWithPriority_ValidateWithEvents") {
+TEST_CASE(Unit_hipStreamCreateWithPriority_ValidateWithEvents) {
   bool TestPassed = true;
   TestPassed = hipStreamCreateWithPriorityTest::validateStreamPrioritiesWithEvents<int>();
   REQUIRE(TestPassed);
@@ -979,7 +979,7 @@ TEST_CASE("Unit_hipStreamCreateWithPriority_ValidateWithEvents") {
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_hipStreamCreateWithPriority_TestMultipleStreamWithPriority") {
+TEST_CASE(Unit_hipStreamCreateWithPriority_TestMultipleStreamWithPriority) {
   hipStreamCreateWithPriorityTest::TestForMultipleStreamWithPriority<int>();
 }
 

--- a/projects/hip-tests/catch/unit/stream/hipStreamDestroy.cc
+++ b/projects/hip-tests/catch/unit/stream/hipStreamDestroy.cc
@@ -22,13 +22,13 @@ THE SOFTWARE.
 
 namespace hipStreamDestroyTests {
 
-TEST_CASE("Unit_hipStreamDestroy_Default") {
+TEST_CASE(Unit_hipStreamDestroy_Default) {
   hipStream_t stream{};
   HIP_CHECK(hipStreamCreate(&stream));
   HIP_CHECK(hipStreamDestroy(stream));
 }
 
-TEST_CASE("Unit_hipStreamDestroy_Negative_NullStream") {
+TEST_CASE(Unit_hipStreamDestroy_Negative_NullStream) {
   HIP_CHECK_ERROR(hipStreamDestroy(nullptr), hipErrorInvalidResourceHandle);
 }
 
@@ -47,7 +47,7 @@ __global__ void setToOne(int* x, size_t size) {
   }
 }
 
-TEST_CASE("Unit_hipStreamDestroy_WithFinishedWork") {
+TEST_CASE(Unit_hipStreamDestroy_WithFinishedWork) {
   hipStream_t stream{};
   HIP_CHECK(hipStreamCreate(&stream));
 
@@ -65,7 +65,7 @@ TEST_CASE("Unit_hipStreamDestroy_WithFinishedWork") {
 // hipStreamDestroy should return immediately then clean up the resources when the stream is empty
 // of work
 #if HT_AMD /* Disabled because frequency based wait is timing out on nvidia platforms */
-TEST_CASE("Unit_hipStreamDestroy_WithPendingWork") {
+TEST_CASE(Unit_hipStreamDestroy_WithPendingWork) {
   hipStream_t stream{};
   HIP_CHECK(hipStreamCreate(&stream));
   constexpr int numDataPoints = 10;

--- a/projects/hip-tests/catch/unit/stream/hipStreamGetCUMask.cc
+++ b/projects/hip-tests/catch/unit/stream/hipStreamGetCUMask.cc
@@ -34,7 +34,7 @@ Testcase Scenarios :
  * Scenario to verify hipExtStreamGetCUMask api returning default CU Mask or global CU Mask.
  * Scenario to verify hipExtStreamGetCUMask api returns custom mask set.
  */
-TEST_CASE("Unit_hipExtStreamGetCUMask_verifyDefaultAndCustomMask") {
+TEST_CASE(Unit_hipExtStreamGetCUMask_verifyDefaultAndCustomMask) {
   constexpr unsigned maxCUPerValue = 32;
   hipDeviceProp_t props;
   std::stringstream ss;
@@ -170,7 +170,7 @@ TEST_CASE("Unit_hipExtStreamGetCUMask_verifyDefaultAndCustomMask") {
 /**
  * Negative tests for hipExtStreamGetCUMask.
  */
-TEST_CASE("Unit_hipExtStreamGetCUMask_Negative") {
+TEST_CASE(Unit_hipExtStreamGetCUMask_Negative) {
   hipError_t ret;
   constexpr int maxNum = 6;
   std::vector<uint32_t> cuMask(maxNum);

--- a/projects/hip-tests/catch/unit/stream/hipStreamGetDevice.cc
+++ b/projects/hip-tests/catch/unit/stream/hipStreamGetDevice.cc
@@ -49,7 +49,7 @@ static bool thread_results[NUMBER_OF_THREADS];
  *    - HIP_VERSION >= 5.6
  */
 
-TEST_CASE("Unit_hipStreamGetDevice_Negative") {
+TEST_CASE(Unit_hipStreamGetDevice_Negative) {
   hipStream_t stream;
 
   HIP_CHECK(hipStreamCreate(&stream));
@@ -74,7 +74,7 @@ TEST_CASE("Unit_hipStreamGetDevice_Negative") {
  *    - HIP_VERSION >= 5.6
  */
 
-TEST_CASE("Unit_hipStreamGetDevice_Usecase", "[multigpu]") {
+TEST_CASE(Unit_hipStreamGetDevice_Usecase) {
   int device_count = 0;
   HIP_CHECK(hipGetDeviceCount(&device_count));
   REQUIRE(device_count != 0);
@@ -168,7 +168,7 @@ static bool test_hipStreamGetDevice_MThread() {
   return status;
 }
 
-TEST_CASE("Unit_hipStreamGetDevice_MThread") { REQUIRE(true == test_hipStreamGetDevice_MThread()); }
+TEST_CASE(Unit_hipStreamGetDevice_MThread) { REQUIRE(true == test_hipStreamGetDevice_MThread()); }
 
 /**
  * Test Description
@@ -186,7 +186,7 @@ TEST_CASE("Unit_hipStreamGetDevice_MThread") { REQUIRE(true == test_hipStreamGet
  *    - HIP_VERSION >= 5.6
  */
 
-TEST_CASE("Unit_hipStreamGetDevice_SetDiffDevice", "[multigpu]") {
+TEST_CASE(Unit_hipStreamGetDevice_SetDiffDevice) {
   hipDevice_t device_from_stream;
   int device_count = 0;
   HIP_CHECK(hipGetDeviceCount(&device_count));
@@ -225,7 +225,7 @@ TEST_CASE("Unit_hipStreamGetDevice_SetDiffDevice", "[multigpu]") {
  *      Test to be run only on AMD machine as it's failing in CUDA.
  */
 #if HT_AMD
-TEST_CASE("Unit_hipStreamGetDevice_NullStream", "[multigpu]") {
+TEST_CASE(Unit_hipStreamGetDevice_NullStream) {
   int device_count = 0;
   HIP_CHECK(hipGetDeviceCount(&device_count));
   REQUIRE(device_count != 0);

--- a/projects/hip-tests/catch/unit/stream/hipStreamGetFlags.cc
+++ b/projects/hip-tests/catch/unit/stream/hipStreamGetFlags.cc
@@ -30,7 +30,7 @@ Testcase Scenarios :
  * @brief Check that hipStreamGetFlags returns the same flags that were used to create the stream.
  *
  */
-TEST_CASE("Unit_hipStreamGetFlags_Basic") {
+TEST_CASE(Unit_hipStreamGetFlags_Basic) {
   unsigned int expectedFlag = GENERATE(hipStreamDefault, hipStreamNonBlocking);
   unsigned int returnedFlags;
   hipStream_t stream;
@@ -45,7 +45,7 @@ TEST_CASE("Unit_hipStreamGetFlags_Basic") {
  * @brief Negative scenarios for hipStreamGetFlags.
  *
  */
-TEST_CASE("Unit_hipStreamGetFlags_Negative") {
+TEST_CASE(Unit_hipStreamGetFlags_Negative) {
   hipStream_t validStream;
   unsigned int flags;
 
@@ -70,7 +70,7 @@ TEST_CASE("Unit_hipStreamGetFlags_Negative") {
 /**
  * Test flag value when streams created with CUMask.
  */
-TEST_CASE("Unit_hipStreamGetFlags_StreamsCreatedWithCUMask") {
+TEST_CASE(Unit_hipStreamGetFlags_StreamsCreatedWithCUMask) {
   hipStream_t stream;
   unsigned int flags;
   const uint32_t cuMask = 0xffffffff;

--- a/projects/hip-tests/catch/unit/stream/hipStreamGetFlags_spt.cc
+++ b/projects/hip-tests/catch/unit/stream/hipStreamGetFlags_spt.cc
@@ -38,7 +38,7 @@ THE SOFTWARE.
  * ------------------------
  *  - HIP_VERSION >= 6.2
  */
-TEST_CASE("Unit_hipStreamGetFlags_spt_Basic") {
+TEST_CASE(Unit_hipStreamGetFlags_spt_Basic) {
   unsigned int expectedFlag = GENERATE(hipStreamDefault, hipStreamNonBlocking);
   unsigned int returnedFlags;
   hipStream_t stream;
@@ -60,7 +60,7 @@ TEST_CASE("Unit_hipStreamGetFlags_spt_Basic") {
  *  - HIP_VERSION >= 6.2
  */
 
-TEST_CASE("Unit_hipStreamGetFlags_spt_Negative") {
+TEST_CASE(Unit_hipStreamGetFlags_spt_Negative) {
   hipStream_t validStream;
   unsigned int flags;
 
@@ -93,7 +93,7 @@ TEST_CASE("Unit_hipStreamGetFlags_spt_Negative") {
  */
 
 #if HT_AMD
-TEST_CASE("Unit_hipStreamGetFlags_spt_StreamsCreatedWithCUMask") {
+TEST_CASE(Unit_hipStreamGetFlags_spt_StreamsCreatedWithCUMask) {
   hipStream_t stream;
   unsigned int flags;
   const uint32_t cuMask = 0xffffffff;

--- a/projects/hip-tests/catch/unit/stream/hipStreamGetId.cc
+++ b/projects/hip-tests/catch/unit/stream/hipStreamGetId.cc
@@ -51,7 +51,7 @@ bool hasUniqueStreamIds(const std::vector<unsigned long long>& streamIds) {
 /**
  *  @brief Pass uninitialized stream and id as nullptr to check if the API behaves as expected.
  */
-TEST_CASE("Unit_hipStreamGetId_Negative") {
+TEST_CASE(Unit_hipStreamGetId_Negative) {
   hipStream_t stream;
   HIP_CHECK(hipStreamCreate(&stream));
   SECTION("Null Pointer") {
@@ -64,7 +64,7 @@ TEST_CASE("Unit_hipStreamGetId_Negative") {
  *  @brief Pass null stream, legacy stream and streamperthread, check the API behaves as expected.
  *  Also, check the stream id generated is not same for any two streams.
  */
-TEST_CASE("Unit_hipStreamGetId_Basic") {
+TEST_CASE(Unit_hipStreamGetId_Basic) {
   hipStream_t stream1, stream2;
   unsigned long long id1, id2, id3, id4, id5;
   SECTION("Unique Stream Id") {
@@ -99,7 +99,7 @@ TEST_CASE("Unit_hipStreamGetId_Basic") {
  * ------------------------
  *  - HIP_VERSION >= 7.1
  */
-TEST_CASE("Unit_hipStreamGetId_WithDifferentStreamCreateAPIs") {
+TEST_CASE(Unit_hipStreamGetId_WithDifferentStreamCreateAPIs) {
   hipStream_t stream_1 = nullptr, stream_2 = nullptr;
   unsigned long long streamId_1 = 0, streamId_2 = 0;
 
@@ -161,7 +161,7 @@ void launchFunction() {
  * ------------------------
  *  - HIP_VERSION >= 7.1
  */
-TEST_CASE("Unit_hipStreamGetId_MultipleThreads") {
+TEST_CASE(Unit_hipStreamGetId_MultipleThreads) {
   const unsigned int threadsSupported = std::thread::hardware_concurrency();
   INFO("Number of threads supported : " << threadsSupported);
 
@@ -192,7 +192,7 @@ TEST_CASE("Unit_hipStreamGetId_MultipleThreads") {
  * ------------------------
  *  - HIP_VERSION >= 7.1
  */
-TEST_CASE("Unit_hipStreamGetId_MultiDevice", "[multigpu]") {
+TEST_CASE(Unit_hipStreamGetId_MultiDevice) {
   int deviceCount = 0;
   HIP_CHECK(hipGetDeviceCount(&deviceCount));
   if (deviceCount < 2) {
@@ -231,7 +231,7 @@ TEST_CASE("Unit_hipStreamGetId_MultiDevice", "[multigpu]") {
  * ------------------------
  *  - HIP_VERSION >= 7.1
  */
-TEST_CASE("Unit_hipStreamGetId_MultiProcess") {
+TEST_CASE(Unit_hipStreamGetId_MultiProcess) {
   auto pid = fork();
   REQUIRE(pid >= 0);
 

--- a/projects/hip-tests/catch/unit/stream/hipStreamGetPriority.cc
+++ b/projects/hip-tests/catch/unit/stream/hipStreamGetPriority.cc
@@ -32,7 +32,7 @@ priority should be clamped to the priority range.
 /**
  * Create stream and check priority.
  */
-TEST_CASE("Unit_hipStreamGetPriority_happy") {
+TEST_CASE(Unit_hipStreamGetPriority_happy) {
   int priority_low = 0;
   int priority_high = 0;
   int devID = GENERATE(range(0, HipTest::getDeviceCount()));
@@ -82,7 +82,7 @@ TEST_CASE("Unit_hipStreamGetPriority_happy") {
 /**
  * both stream and priority passed as nullptr.
  */
-TEST_CASE("Unit_hipStreamGetPriority_nullptr_nullptr") {
+TEST_CASE(Unit_hipStreamGetPriority_nullptr_nullptr) {
   auto res = hipStreamGetPriority(nullptr, nullptr);
   REQUIRE(res == hipErrorInvalidValue);
 }
@@ -91,7 +91,7 @@ TEST_CASE("Unit_hipStreamGetPriority_nullptr_nullptr") {
 /**
  * valid stream and priority passed as nullptr.
  */
-TEST_CASE("Unit_hipStreamGetPriority_stream_nullptr") {
+TEST_CASE(Unit_hipStreamGetPriority_stream_nullptr) {
   hipStream_t stream = nullptr;
   HIP_CHECK(hipStreamCreate(&stream));
 
@@ -105,7 +105,7 @@ TEST_CASE("Unit_hipStreamGetPriority_stream_nullptr") {
 /**
  * nullptr stream and valid priority
  */
-TEST_CASE("Unit_hipStreamGetPriority_nullptr_priority") {
+TEST_CASE(Unit_hipStreamGetPriority_nullptr_priority) {
   int priority = -1;
   HIP_CHECK(hipStreamGetPriority(nullptr, &priority));
 }
@@ -113,7 +113,7 @@ TEST_CASE("Unit_hipStreamGetPriority_nullptr_priority") {
 /**
  * both stream and priority passed as valid.
  */
-TEST_CASE("Unit_hipStreamGetPriority_stream_priority") {
+TEST_CASE(Unit_hipStreamGetPriority_stream_priority) {
   int priority = -1;
   hipStream_t stream = nullptr;
   HIP_CHECK(hipStreamCreate(&stream));
@@ -127,7 +127,7 @@ TEST_CASE("Unit_hipStreamGetPriority_stream_priority") {
 /**
  * Create stream with CUMask and check priority is returned as expected.
  */
-TEST_CASE("Unit_hipStreamGetPriority_StreamsWithCUMask") {
+TEST_CASE(Unit_hipStreamGetPriority_StreamsWithCUMask) {
   hipStream_t stream{};
   int priority = 0;
   int priority_normal = 0;

--- a/projects/hip-tests/catch/unit/stream/hipStreamGetPriority_spt.cc
+++ b/projects/hip-tests/catch/unit/stream/hipStreamGetPriority_spt.cc
@@ -39,7 +39,7 @@ THE SOFTWARE.
  * ------------------------
  *  - HIP_VERSION >= 6.2
  */
-TEST_CASE("Unit_hipStreamGetPriority_spt_BasicTst") {
+TEST_CASE(Unit_hipStreamGetPriority_spt_BasicTst) {
   int priority_low = 0;
   int priority_high = 0;
   int devID = GENERATE(range(0, HipTest::getDeviceCount()));
@@ -98,7 +98,7 @@ TEST_CASE("Unit_hipStreamGetPriority_spt_BasicTst") {
  * ------------------------
  *  - HIP_VERSION >= 6.2
  */
-TEST_CASE("Unit_hipStreamGetPriority_spt_NegativeCases") {
+TEST_CASE(Unit_hipStreamGetPriority_spt_NegativeCases) {
   // stream as nullptr and priority as nullptr
   auto res = hipStreamGetPriority_spt(nullptr, nullptr);
   REQUIRE(res == hipErrorInvalidValue);
@@ -125,7 +125,7 @@ TEST_CASE("Unit_hipStreamGetPriority_spt_NegativeCases") {
  */
 
 #if HT_AMD
-TEST_CASE("Unit_hipStreamGetPriority_spt_StreamsWithCUMask") {
+TEST_CASE(Unit_hipStreamGetPriority_spt_StreamsWithCUMask) {
   hipStream_t stream{};
   int priority = 0;
   int priority_normal = 0;

--- a/projects/hip-tests/catch/unit/stream/hipStreamLegacy.cc
+++ b/projects/hip-tests/catch/unit/stream/hipStreamLegacy.cc
@@ -36,7 +36,7 @@ constexpr int blocks =
     (N % threadsPerBlock == 0) ? (N / threadsPerBlock) : ((N / threadsPerBlock) + 1);
 size_t Nbytes = N * sizeof(float);
 
-TEST_CASE("Unit_hipMemcpyAsync_hipStreamLegacy_H2H_H2D_D2H_H2PinMem") {
+TEST_CASE(Unit_hipMemcpyAsync_hipStreamLegacy_H2H_H2D_D2H_H2PinMem) {
   int *A_d{nullptr}, *B_d{nullptr};
   int *A_h{nullptr}, *B_h{nullptr};
   int *A_Ph{nullptr}, *B_Ph{nullptr};
@@ -68,7 +68,7 @@ TEST_CASE("Unit_hipMemcpyAsync_hipStreamLegacy_H2H_H2D_D2H_H2PinMem") {
   HipTest::freeArrays<int>(nullptr, nullptr, nullptr, A_Ph, B_Ph, nullptr, true);
 }
 
-TEST_CASE("Unit_hipStreamGetCaptureInfo_hipStreamLegacy_CaptureInfo") {
+TEST_CASE(Unit_hipStreamGetCaptureInfo_hipStreamLegacy_CaptureInfo) {
   hipStream_t stream{nullptr}, streamForGraph{nullptr};
   hipGraph_t graph{nullptr};
   hipError_t ret;
@@ -171,7 +171,7 @@ __global__ void MemPrefetchAsyncKernel(int* C_d, const int* A_d, size_t N) {
   }
 }
 
-TEST_CASE("Unit_hipMemPrefetchAsync_Basic") {
+TEST_CASE(Unit_hipMemPrefetchAsync_Basic) {
   LinearAllocGuard<int> alloc1(LinearAllocs::hipMallocManaged, kPageSize);
   const auto count = kPageSize / sizeof(*alloc1.ptr());
   constexpr auto fill_value = 42;
@@ -194,7 +194,7 @@ TEST_CASE("Unit_hipMemPrefetchAsync_Basic") {
   ArrayFindIfNot(alloc1.ptr(), fill_value, count);
 }
 
-TEST_CASE("Unit_hipMemPoolApi_hipStreamLegacy_Basic") {
+TEST_CASE(Unit_hipMemPoolApi_hipStreamLegacy_Basic) {
   int numElements = 64 * 1024 * 1024;
   float* A = nullptr;
 

--- a/projects/hip-tests/catch/unit/stream/hipStreamLegacy_Ext.cc
+++ b/projects/hip-tests/catch/unit/stream/hipStreamLegacy_Ext.cc
@@ -76,7 +76,7 @@ static __global__ void addOneKernel(int* a, int size) {
  * ------------------------
  *  - HIP_VERSION >= 6.3
  */
-TEST_CASE("Unit_hipStreamLegacy_WithBlockingStream") {
+TEST_CASE(Unit_hipStreamLegacy_WithBlockingStream) {
   int* hostArrSrc = new int[N];
   REQUIRE(hostArrSrc != nullptr);
   fillHostArray(hostArrSrc, N, 1);
@@ -158,7 +158,7 @@ void launchFunction(hipStream_t stream) {
  * ------------------------
  *  - HIP_VERSION >= 6.3
  */
-TEST_CASE("Unit_hipStreamLegacy_MultipleThreads") {
+TEST_CASE(Unit_hipStreamLegacy_MultipleThreads) {
   const unsigned int threadsSupported = std::thread::hardware_concurrency();
   const int numberOfThreads = (threadsSupported >= 10) ? 10 : threadsSupported;
 
@@ -184,7 +184,7 @@ TEST_CASE("Unit_hipStreamLegacy_MultipleThreads") {
  * ------------------------
  *  - HIP_VERSION >= 6.3
  */
-TEST_CASE("Unit_hipStreamLegacy_NegetiveCase") {
+TEST_CASE(Unit_hipStreamLegacy_NegetiveCase) {
   hipStream_t stream = hipStreamLegacy;
   REQUIRE(hipStreamBeginCapture(stream, hipStreamCaptureModeGlobal) ==
           hipErrorStreamCaptureUnsupported);
@@ -206,7 +206,7 @@ TEST_CASE("Unit_hipStreamLegacy_NegetiveCase") {
  * ------------------------
  *  - HIP_VERSION >= 6.3
  */
-TEST_CASE("Unit_hipStreamLegacy_WithNonBlockingStream") {
+TEST_CASE(Unit_hipStreamLegacy_WithNonBlockingStream) {
   int* hostArrSrc = new int[N];
   REQUIRE(hostArrSrc != nullptr);
   fillHostArray(hostArrSrc, N, 10);
@@ -253,7 +253,7 @@ TEST_CASE("Unit_hipStreamLegacy_WithNonBlockingStream") {
  * ------------------------
  *  - HIP_VERSION >= 6.3
  */
-TEST_CASE("Unit_hipStreamLegacy_WithStreamPerThread") {
+TEST_CASE(Unit_hipStreamLegacy_WithStreamPerThread) {
   int* hostArrSrc = new int[N];
   REQUIRE(hostArrSrc != nullptr);
   fillHostArray(hostArrSrc, N, 15);
@@ -295,7 +295,7 @@ TEST_CASE("Unit_hipStreamLegacy_WithStreamPerThread") {
  * ------------------------
  *  - HIP_VERSION >= 6.3
  */
-TEST_CASE("Unit_hipStreamLegacy_MultiDevice", "[multigpu]") {
+TEST_CASE(Unit_hipStreamLegacy_MultiDevice) {
   int deviceCount = 0;
   HIP_CHECK(hipGetDeviceCount(&deviceCount));
   if (deviceCount < 2) {
@@ -350,7 +350,7 @@ TEST_CASE("Unit_hipStreamLegacy_MultiDevice", "[multigpu]") {
  * ------------------------
  *  - HIP_VERSION >= 6.3
  */
-TEST_CASE("Unit_hipStreamLegacy_H2H_H2D_D2D_D2H_Default") {
+TEST_CASE(Unit_hipStreamLegacy_H2H_H2D_D2D_D2H_Default) {
   int* hostArr1 = new int[N];
   REQUIRE(hostArr1 != nullptr);
   fillHostArray(hostArr1, N, 30);
@@ -418,7 +418,7 @@ TEST_CASE("Unit_hipStreamLegacy_H2H_H2D_D2D_D2H_Default") {
  * ------------------------
  *  - HIP_VERSION >= 6.3
  */
-TEST_CASE("Unit_hipStreamLegacy_MultiDeviceMultiOperation", "[multigpu]") {
+TEST_CASE(Unit_hipStreamLegacy_MultiDeviceMultiOperation) {
   int deviceCount = 0;
   HIP_CHECK(hipGetDeviceCount(&deviceCount));
   if (deviceCount < 2) {
@@ -540,7 +540,7 @@ static void copyFromDeviceToHost(int* devArr, int* hostArr) {
  * ------------------------
  *  - HIP_VERSION >= 6.3
  */
-TEST_CASE("Unit_hipStreamLegacy_TwoThreadsEachOneDiffOperation") {
+TEST_CASE(Unit_hipStreamLegacy_TwoThreadsEachOneDiffOperation) {
   const unsigned int threadsSupported = std::thread::hardware_concurrency();
 
   if (threadsSupported < 2) {
@@ -594,7 +594,7 @@ TEST_CASE("Unit_hipStreamLegacy_TwoThreadsEachOneDiffOperation") {
  * ------------------------
  *  - HIP_VERSION >= 6.3
  */
-TEST_CASE("Unit_hipStreamLegacy_TwoDevicesEachOneDiffOperation", "[multigpu]") {
+TEST_CASE(Unit_hipStreamLegacy_TwoDevicesEachOneDiffOperation) {
   int deviceCount = 0;
   HIP_CHECK(hipGetDeviceCount(&deviceCount));
   if (deviceCount < 2) {
@@ -679,8 +679,7 @@ static void operationsInDev1(int* devArrDev1, int* hostArrDst) {
  * ------------------------
  *  - HIP_VERSION >= 6.3
  */
-TEST_CASE("Unit_hipStreamLegacy_TwoThreadsInTwoDevicesEachOneDiffOperation",
-          "[multigpu]") {
+TEST_CASE(Unit_hipStreamLegacy_TwoThreadsInTwoDevicesEachOneDiffOperation) {
   int deviceCount = 0;
   HIP_CHECK(hipGetDeviceCount(&deviceCount));
   if (deviceCount < 2) {
@@ -742,7 +741,7 @@ TEST_CASE("Unit_hipStreamLegacy_TwoThreadsInTwoDevicesEachOneDiffOperation",
  * ------------------------
  *  - HIP_VERSION >= 6.3
  */
-TEST_CASE("Unit_hipStreamLegacy_InChildProcess") {
+TEST_CASE(Unit_hipStreamLegacy_InChildProcess) {
   hip::SpawnProc proc("hipStreamLegacy_exe", true);
   REQUIRE(proc.run() == 0);
 }
@@ -759,7 +758,7 @@ TEST_CASE("Unit_hipStreamLegacy_InChildProcess") {
  * ------------------------
  *  - HIP_VERSION >= 6.3
  */
-TEST_CASE("Unit_hipStreamLegacy_WithKernel") {
+TEST_CASE(Unit_hipStreamLegacy_WithKernel) {
   int* hostArrSrc = new int[N];
   REQUIRE(hostArrSrc != nullptr);
   fillHostArray(hostArrSrc, N, 1);
@@ -801,7 +800,7 @@ TEST_CASE("Unit_hipStreamLegacy_WithKernel") {
  *  - HIP_VERSION >= 6.3
  */
 
-TEST_CASE("Unit_hipStreamLegacy_hipStreamSynchronize") {
+TEST_CASE(Unit_hipStreamLegacy_hipStreamSynchronize) {
   int* hostArrSrc = new int[N];
   REQUIRE(hostArrSrc != nullptr);
   fillHostArray(hostArrSrc, N, 1);

--- a/projects/hip-tests/catch/unit/stream/hipStreamLegacy_compiler_options.cc
+++ b/projects/hip-tests/catch/unit/stream/hipStreamLegacy_compiler_options.cc
@@ -49,7 +49,7 @@ static void fillArr(int* arr, unsigned int size, int value) {
  * ------------------------
  *  - HIP_VERSION >= 6.3
  */
-TEST_CASE("Unit_hipStreamLegacy_WithSptCompilerOption") {
+TEST_CASE(Unit_hipStreamLegacy_WithSptCompilerOption) {
   int* hostArrSrc = new int[N];
   REQUIRE(hostArrSrc != nullptr);
   fillArr(hostArrSrc, N, 1);
@@ -108,7 +108,7 @@ static void copyDeviceToHost(int* devArr, int* hostArr) {
  * ------------------------
  *  - HIP_VERSION >= 6.3
  */
-TEST_CASE("Unit_hipStreamLegacy_TwoThreadsDiffOperationWithSptCompOption") {
+TEST_CASE(Unit_hipStreamLegacy_TwoThreadsDiffOperationWithSptCompOption) {
   const unsigned int threadsSupported = std::thread::hardware_concurrency();
 
   if (threadsSupported < 2) {

--- a/projects/hip-tests/catch/unit/stream/hipStreamQuery.cc
+++ b/projects/hip-tests/catch/unit/stream/hipStreamQuery.cc
@@ -24,7 +24,7 @@ THE SOFTWARE.
  * @brief Check that querying a stream with no work returns hipSuccess
  *
  **/
-TEST_CASE("Unit_hipStreamQuery_WithNoWork") {
+TEST_CASE(Unit_hipStreamQuery_WithNoWork) {
   hipStream_t stream{nullptr};
 
   SECTION("Null Stream") { HIP_CHECK(hipStreamQuery(stream)); }
@@ -40,7 +40,7 @@ TEST_CASE("Unit_hipStreamQuery_WithNoWork") {
  * @brief Check that querying a stream with finished work returns hipSuccess
  *
  **/
-TEST_CASE("Unit_hipStreamQuery_WithFinishedWork") {
+TEST_CASE(Unit_hipStreamQuery_WithFinishedWork) {
   hipStream_t stream{nullptr};
 
   SECTION("Null Stream") {
@@ -67,7 +67,7 @@ TEST_CASE("Unit_hipStreamQuery_WithFinishedWork") {
  * hipErrorNotReady
  *
  */
-TEST_CASE("Unit_hipStreamQuery_SubmitWorkOnStreamAndQueryNullStream") {
+TEST_CASE(Unit_hipStreamQuery_SubmitWorkOnStreamAndQueryNullStream) {
   {
     hipStream_t stream;
     HIP_CHECK(hipStreamCreate(&stream));
@@ -86,7 +86,7 @@ TEST_CASE("Unit_hipStreamQuery_SubmitWorkOnStreamAndQueryNullStream") {
  * hipErrorNotReady.
  *
  */
-TEST_CASE("Unit_hipStreamQuery_NullStreamQuery") {
+TEST_CASE(Unit_hipStreamQuery_NullStreamQuery) {
   HIP_CHECK(hipStreamQuery(hip::nullStream));
   LaunchDelayKernel(std::chrono::milliseconds(500), hip::nullStream);
   HIP_CHECK_ERROR(hipStreamQuery(hip::nullStream), hipErrorNotReady);
@@ -98,7 +98,7 @@ TEST_CASE("Unit_hipStreamQuery_NullStreamQuery") {
  * @brief Check that querying a stream with pending work returns hipErrorNotReady
  *
  **/
-TEST_CASE("Unit_hipStreamQuery_WithPendingWork") {
+TEST_CASE(Unit_hipStreamQuery_WithPendingWork) {
   hipStream_t waitingStream{nullptr};
   HIP_CHECK(hipStreamCreate(&waitingStream));
 

--- a/projects/hip-tests/catch/unit/stream/hipStreamQuery_spt.cc
+++ b/projects/hip-tests/catch/unit/stream/hipStreamQuery_spt.cc
@@ -38,7 +38,7 @@ THE SOFTWARE.
  * ------------------------
  *  - HIP_VERSION >= 6.2
  */
-TEST_CASE("Unit_hipStreamQuery_spt_WithNoWork") {
+TEST_CASE(Unit_hipStreamQuery_spt_WithNoWork) {
   hipStream_t stream{nullptr};
 
   SECTION("Null Stream") { HIP_CHECK(hipStreamQuery_spt(stream)); }
@@ -60,7 +60,7 @@ TEST_CASE("Unit_hipStreamQuery_spt_WithNoWork") {
  * ------------------------
  *  - HIP_VERSION >= 6.2
  */
-TEST_CASE("Unit_hipStreamQuery_spt_WithFinishedWork") {
+TEST_CASE(Unit_hipStreamQuery_spt_WithFinishedWork) {
   hipStream_t stream{nullptr};
 
   SECTION("Null Stream") {
@@ -91,7 +91,7 @@ TEST_CASE("Unit_hipStreamQuery_spt_WithFinishedWork") {
  *  - HIP_VERSION >= 6.2
  */
 #if HT_AMD
-TEST_CASE("Unit_hipStreamQuery_spt_NegativeCases") {
+TEST_CASE(Unit_hipStreamQuery_spt_NegativeCases) {
   SECTION("Submit Work On Stream And Query Null Stream") {
     hipStream_t ValidStream;
     HIP_CHECK(hipStreamCreate(&ValidStream));
@@ -120,7 +120,7 @@ TEST_CASE("Unit_hipStreamQuery_spt_NegativeCases") {
  * ------------------------
  *  - HIP_VERSION >= 6.2
  */
-TEST_CASE("Unit_hipStreamQuery_spt_WithPendingWork") {
+TEST_CASE(Unit_hipStreamQuery_spt_WithPendingWork) {
   hipStream_t waitingStream{nullptr};
   HIP_CHECK(hipStreamCreate(&waitingStream));
   LaunchDelayKernel(std::chrono::milliseconds(500), waitingStream);

--- a/projects/hip-tests/catch/unit/stream/hipStreamSetGetAttributes.cc
+++ b/projects/hip-tests/catch/unit/stream/hipStreamSetGetAttributes.cc
@@ -43,7 +43,7 @@ static __global__ void doubleKernel(int *arr) {
  * ------------------------
  *  - HIP_VERSION >= 7.1
  */
-TEST_CASE("Unit_hipStreamSetAttribute_hipStreamGetAttribute_Basic") {
+TEST_CASE(Unit_hipStreamSetAttribute_hipStreamGetAttribute_Basic) {
   constexpr int N = 1024;
   int hostMem[N];
   for (int i = 0; i < N; i++) {
@@ -103,7 +103,7 @@ TEST_CASE("Unit_hipStreamSetAttribute_hipStreamGetAttribute_Basic") {
  * ------------------------
  *  - HIP_VERSION >= 7.1
  */
-TEST_CASE("Unit_hipStreamGetAttribute_Negative") {
+TEST_CASE(Unit_hipStreamGetAttribute_Negative) {
   hipStream_t stream = nullptr;
   HIP_CHECK(hipStreamCreate(&stream));
 
@@ -147,7 +147,7 @@ TEST_CASE("Unit_hipStreamGetAttribute_Negative") {
  * ------------------------
  *  - HIP_VERSION >= 7.1
  */
-TEST_CASE("Unit_hipStreamSetAttribute_Negative") {
+TEST_CASE(Unit_hipStreamSetAttribute_Negative) {
   hipStream_t stream = nullptr;
   HIP_CHECK(hipStreamCreate(&stream));
 

--- a/projects/hip-tests/catch/unit/stream/hipStreamSynchronize.cc
+++ b/projects/hip-tests/catch/unit/stream/hipStreamSynchronize.cc
@@ -26,7 +26,7 @@ namespace hipStreamSynchronizeTest {
  * @brief Check that hipStreamSynchronize handles empty streams properly.
  *
  */
-TEST_CASE("Unit_hipStreamSynchronize_EmptyStream") {
+TEST_CASE(Unit_hipStreamSynchronize_EmptyStream) {
   hipStream_t stream;
   HIP_CHECK(hipStreamCreate(&stream));
   HIP_CHECK(hipStreamSynchronize(stream));
@@ -40,7 +40,7 @@ TEST_CASE("Unit_hipStreamSynchronize_EmptyStream") {
  * hipStreamSynchronize.
  *
  */
-TEST_CASE("Unit_hipStreamSynchronize_FinishWork") {
+TEST_CASE(Unit_hipStreamSynchronize_FinishWork) {
   const hipStream_t explicitStream = reinterpret_cast<hipStream_t>(-1);
   hipStream_t stream = GENERATE_COPY(explicitStream, hip::nullStream, hip::streamPerThread);
 
@@ -61,7 +61,7 @@ TEST_CASE("Unit_hipStreamSynchronize_FinishWork") {
 /**
  * @brief Check that synchronizing the nullStream implicitly synchronizes all executing streams.
  */
-TEST_CASE("Unit_hipStreamSynchronize_NullStreamSynchronization") {
+TEST_CASE(Unit_hipStreamSynchronize_NullStreamSynchronization) {
   int totalStreams = 10;
 
   std::vector<hipStream_t> streams{};
@@ -99,7 +99,7 @@ TEST_CASE("Unit_hipStreamSynchronize_NullStreamSynchronization") {
  *        Check that submiting work to the nullStream does not affect synchronization of other
  * streams. Check that querying the nullStream does not affect synchronization of other streams.
  */
-TEST_CASE("Unit_hipStreamSynchronize_SynchronizeStreamAndQueryNullStream") {
+TEST_CASE(Unit_hipStreamSynchronize_SynchronizeStreamAndQueryNullStream) {
 #if HT_AMD
   HipTest::HIP_SKIP_TEST("EXSWCPHIPT-22");
 #else
@@ -143,7 +143,7 @@ TEST_CASE("Unit_hipStreamSynchronize_SynchronizeStreamAndQueryNullStream") {
  * special stream.
  *
  */
-TEST_CASE("Unit_hipStreamSynchronize_NullStreamAndStreamPerThread") {
+TEST_CASE(Unit_hipStreamSynchronize_NullStreamAndStreamPerThread) {
   LaunchDelayKernel(std::chrono::milliseconds(500), hip::streamPerThread);
   HIP_CHECK_ERROR(hipStreamQuery(hip::nullStream), hipErrorNotReady);
   HIP_CHECK_ERROR(hipStreamQuery(hip::streamPerThread), hipErrorNotReady);

--- a/projects/hip-tests/catch/unit/stream/hipStreamSynchronize_spt.cc
+++ b/projects/hip-tests/catch/unit/stream/hipStreamSynchronize_spt.cc
@@ -39,7 +39,7 @@ THE SOFTWARE.
  * ------------------------
  *  - HIP_VERSION >= 6.2
  */
-TEST_CASE("Unit_hipStreamSynchronize_spt_EmptyStream") {
+TEST_CASE(Unit_hipStreamSynchronize_spt_EmptyStream) {
   hipStream_t stream;
   HIP_CHECK(hipStreamCreate(&stream));
   HIP_CHECK(hipStreamSynchronize_spt(stream));
@@ -71,7 +71,7 @@ TEST_CASE("Unit_hipStreamSynchronize_spt_EmptyStream") {
  * ------------------------
  *  - HIP_VERSION >= 6.2
  */
-TEST_CASE("Unit_hipStreamSynchronize_spt_FinishWork") {
+TEST_CASE(Unit_hipStreamSynchronize_spt_FinishWork) {
   hipStream_t explicitStream = reinterpret_cast<hipStream_t>(-1);
   hipStream_t stream = GENERATE_COPY(explicitStream, hip::nullStream, hip::streamPerThread);
   if (explicitStream) {
@@ -101,7 +101,7 @@ TEST_CASE("Unit_hipStreamSynchronize_spt_FinishWork") {
  *  - HIP_VERSION >= 6.2
  */
 
-TEST_CASE("Unit_hipStreamSynchronize_spt_SynchronizeStreamAndQueryNullStream") {
+TEST_CASE(Unit_hipStreamSynchronize_spt_SynchronizeStreamAndQueryNullStream) {
   hipStream_t stream1;
   hipStream_t stream2;
 

--- a/projects/hip-tests/catch/unit/stream/hipStreamValue.cc
+++ b/projects/hip-tests/catch/unit/stream/hipStreamValue.cc
@@ -233,7 +233,7 @@ template <typename UIntT, PtrType ptrTypeValue> struct TestParams {
 };
 
 #if HT_AMD
-TEMPLATE_TEST_CASE("Unit_hipStreamValue_Write", "", (TestParams<uint32_t, PtrType::HostPtr>),
+TEMPLATE_TEST_CASE(Unit_hipStreamValue_Write, (TestParams<uint32_t, PtrType::HostPtr>),
                    (TestParams<uint32_t, PtrType::DevicePtr>),
                    (TestParams<uint32_t, PtrType::DevicePtrToHost>),
                    (TestParams<uint64_t, PtrType::HostPtr>),
@@ -241,7 +241,7 @@ TEMPLATE_TEST_CASE("Unit_hipStreamValue_Write", "", (TestParams<uint32_t, PtrTyp
                    (TestParams<uint64_t, PtrType::DevicePtrToHost>),
                    (TestParams<uint64_t, PtrType::Signal>)) {
 #else
-TEMPLATE_TEST_CASE("Unit_hipStreamValue_Write", "", (TestParams<uint32_t, PtrType::HostPtr>),
+TEMPLATE_TEST_CASE(Unit_hipStreamValue_Write, (TestParams<uint32_t, PtrType::HostPtr>),
                    (TestParams<uint32_t, PtrType::DevicePtr>),
                    (TestParams<uint32_t, PtrType::DevicePtrToHost>),
                    (TestParams<uint64_t, PtrType::HostPtr>),
@@ -355,7 +355,7 @@ void testWait(TEST_WAIT<typename TestType::UIntType> tc) {
 }
 
 // Combined blocking test case for both uint32_t and uint64_t
-TEMPLATE_TEST_CASE("Unit_hipStreamValue_Wait_Blocking", "", uint32_t, uint64_t) {
+TEMPLATE_TEST_CASE(Unit_hipStreamValue_Wait_Blocking, uint32_t, uint64_t) {
   if (!streamWaitValueSupported()) {
     HipTest::HIP_SKIP_TEST("hipStreamWaitValue not supported on this device.");
     return;
@@ -566,7 +566,7 @@ TEMPLATE_TEST_CASE("Unit_hipStreamValue_Wait_Blocking", "", uint32_t, uint64_t) 
 }
 
 // Negative Tests
-TEST_CASE("Unit_hipStreamValue_Negative_InvalidMemory") {
+TEST_CASE(Unit_hipStreamValue_Negative_InvalidMemory) {
   if (!streamWaitValueSupported()) {
     HipTest::HIP_SKIP_TEST("hipStreamWaitValue not supported on this device.");
     return;
@@ -598,7 +598,7 @@ TEST_CASE("Unit_hipStreamValue_Negative_InvalidMemory") {
 }
 
 // Merge the two similar negative tests
-TEMPLATE_TEST_CASE("Unit_hipStreamValue_Negative_StreamAndFlag", "", uint32_t, uint64_t) {
+TEMPLATE_TEST_CASE(Unit_hipStreamValue_Negative_StreamAndFlag, uint32_t, uint64_t) {
   if (!streamWaitValueSupported()) {
     HipTest::HIP_SKIP_TEST("hipStreamWaitValue not supported on this device.");
     return;
@@ -653,7 +653,7 @@ TEMPLATE_TEST_CASE("Unit_hipStreamValue_Negative_StreamAndFlag", "", uint32_t, u
   }
 }
 
-TEMPLATE_TEST_CASE("Unit_hipStreamWriteValue_Default", "", uint32_t, uint64_t) {
+TEMPLATE_TEST_CASE(Unit_hipStreamWriteValue_Default, uint32_t, uint64_t) {
   if (!streamWaitValueSupported()) {
     HipTest::HIP_SKIP_TEST("hipStreamWaitValue not supported on this device.");
     return;
@@ -684,7 +684,7 @@ template <typename T> __global__ void add(T* a, T* b, T* c, size_t size) {
   if (i < size) c[i] = a[i] + b[i];
 }
 
-TEMPLATE_TEST_CASE("Unit_hipStreamWaitValue_Default", "", uint32_t, uint64_t) {
+TEMPLATE_TEST_CASE(Unit_hipStreamWaitValue_Default, uint32_t, uint64_t) {
   if (!streamWaitValueSupported()) {
     HipTest::HIP_SKIP_TEST("hipStreamWaitValue not supported on this device.");
     return;

--- a/projects/hip-tests/catch/unit/stream/hipStreamWaitEvent.cc
+++ b/projects/hip-tests/catch/unit/stream/hipStreamWaitEvent.cc
@@ -26,7 +26,7 @@ different stream with hipStreamWaitEvent api
 
 #include <hip_test_common.hh>
 #include <utils.hh>
-TEST_CASE("Unit_hipStreamWaitEvent_Negative") {
+TEST_CASE(Unit_hipStreamWaitEvent_Negative) {
   enum class StreamTestType { NullStream = 0, StreamPerThread, CreatedStream };
 
   auto streamType = GENERATE(StreamTestType::NullStream, StreamTestType::StreamPerThread,
@@ -65,7 +65,7 @@ TEST_CASE("Unit_hipStreamWaitEvent_Negative") {
   }
 }
 
-TEST_CASE("Unit_hipStreamWaitEvent_Default") {
+TEST_CASE(Unit_hipStreamWaitEvent_Default) {
   hipStream_t stream{nullptr};
   hipEvent_t waitEvent{nullptr};
 
@@ -90,7 +90,7 @@ TEST_CASE("Unit_hipStreamWaitEvent_Default") {
   HIP_CHECK(hipEventDestroy(waitEvent));
 }
 
-TEST_CASE("Unit_hipStreamWaitEvent_DifferentStreams") {
+TEST_CASE(Unit_hipStreamWaitEvent_DifferentStreams) {
   hipStream_t blockedStreamA{nullptr}, streamBlockedOnStreamA{nullptr}, unblockingStream{nullptr};
   hipEvent_t waitEvent{nullptr};
 

--- a/projects/hip-tests/catch/unit/stream/hipStreamWithCUMask.cc
+++ b/projects/hip-tests/catch/unit/stream/hipStreamWithCUMask.cc
@@ -122,7 +122,7 @@ using hipExtStreamCreateWithCUMaskTest::N;
 /**
  * Scenario: Validates functionality of hipStreamAddCallback with created stream.
  */
-TEST_CASE("Unit_hipExtStreamCreateWithCUMask_ValidateCallbackFunc") {
+TEST_CASE(Unit_hipExtStreamCreateWithCUMask_ValidateCallbackFunc) {
   float *A_d, *C_d;
   size_t Nbytes = N * sizeof(float);
   cbDone = false;
@@ -169,7 +169,7 @@ TEST_CASE("Unit_hipExtStreamCreateWithCUMask_ValidateCallbackFunc") {
 /**
  * Scenario: Validates functionality of stream with cu mask.
  */
-TEST_CASE("Unit_hipExtStreamCreateWithCUMask_Functionality") {
+TEST_CASE(Unit_hipExtStreamCreateWithCUMask_Functionality) {
   const int KNumPartition = NUM_CU_PARTITIONS;
   float *dA[KNumPartition], *dC[KNumPartition];
   float *hA, *hC;
@@ -301,7 +301,7 @@ TEST_CASE("Unit_hipExtStreamCreateWithCUMask_Functionality") {
  * Scenario: Create a stream with all CU masks disabled (0x00000000).
  * Verify that default CU mask is set for the stream.
  */
-TEST_CASE("Unit_hipExtStreamCreateWithCUMask_AllCUsMasked") {
+TEST_CASE(Unit_hipExtStreamCreateWithCUMask_AllCUsMasked) {
   HIP_CHECK(hipSetDevice(0));
   hipDeviceProp_t props;
   HIP_CHECK(hipGetDeviceProperties(&props, 0));
@@ -325,7 +325,7 @@ TEST_CASE("Unit_hipExtStreamCreateWithCUMask_AllCUsMasked") {
 /**
  * Scenario: Negative Testing of hipExtStreamCreateWithCUMask.
  */
-TEST_CASE("Unit_hipExtStreamCreateWithCUMask_NegTst") {
+TEST_CASE(Unit_hipExtStreamCreateWithCUMask_NegTst) {
   std::vector<uint32_t> defaultCUMask;
   REQUIRE(hipSuccess == hipSetDevice(0));
   hipDeviceProp_t props;

--- a/projects/hip-tests/catch/unit/streamperthread/hipGetProcAddressSptApis.cc
+++ b/projects/hip-tests/catch/unit/streamperthread/hipGetProcAddressSptApis.cc
@@ -37,7 +37,7 @@ THE SOFTWARE.
  * ------------------------
  *  - HIP_VERSION >= 6.2
  */
-TEST_CASE("Unit_hipGetProcAddress_spt_MemCpy") {
+TEST_CASE(Unit_hipGetProcAddress_spt_MemCpy) {
   void* hipMemcpy_spt_ptr = nullptr;
   void* hipMemcpyAsync_spt_ptr = nullptr;
 
@@ -527,7 +527,7 @@ TEST_CASE("Unit_hipGetProcAddress_spt_MemCpy") {
  * ------------------------
  *  - HIP_VERSION >= 6.2
  */
-TEST_CASE("Unit_hipGetProcAddress_spt_Memset") {
+TEST_CASE(Unit_hipGetProcAddress_spt_Memset) {
   void* hipMemset_spt_ptr = nullptr;
   void* hipMemsetAsync_spt_ptr = nullptr;
 
@@ -617,7 +617,7 @@ TEST_CASE("Unit_hipGetProcAddress_spt_Memset") {
  * ------------------------
  *  - HIP_VERSION >= 6.2
  */
-TEST_CASE("Unit_hipGetProcAddress_spt_Memset2D3D") {
+TEST_CASE(Unit_hipGetProcAddress_spt_Memset2D3D) {
   CHECK_IMAGE_SUPPORT
 
   void* hipMemset2D_spt_ptr = nullptr;
@@ -793,7 +793,7 @@ TEST_CASE("Unit_hipGetProcAddress_spt_Memset2D3D") {
  * ------------------------
  *  - HIP_VERSION >= 6.2
  */
-TEST_CASE("Unit_hipGetProcAddress_spt_Memcpy2D") {
+TEST_CASE(Unit_hipGetProcAddress_spt_Memcpy2D) {
   CHECK_IMAGE_SUPPORT
 
   void* hipMemcpy2D_spt_ptr = nullptr;
@@ -1873,7 +1873,7 @@ TEST_CASE("Unit_hipGetProcAddress_spt_Memcpy2D") {
  * ------------------------
  *  - HIP_VERSION >= 6.2
  */
-TEST_CASE("Unit_hipGetProcAddress_spt_Memcpy3D") {
+TEST_CASE(Unit_hipGetProcAddress_spt_Memcpy3D) {
   CHECK_IMAGE_SUPPORT
 
   void* hipMemcpy3D_spt_ptr = nullptr;
@@ -2434,7 +2434,7 @@ TEST_CASE("Unit_hipGetProcAddress_spt_Memcpy3D") {
  * ------------------------
  *  - HIP_VERSION >= 6.2
  */
-TEST_CASE("Unit_hipGetProcAddress_spt_LaunchKernel") {
+TEST_CASE(Unit_hipGetProcAddress_spt_LaunchKernel) {
   void* hipLaunchKernel_spt_ptr = nullptr;
   void* hipLaunchHostFunc_spt_ptr = nullptr;
 
@@ -2517,7 +2517,7 @@ TEST_CASE("Unit_hipGetProcAddress_spt_LaunchKernel") {
  * ------------------------
  *  - HIP_VERSION >= 6.2
  */
-TEST_CASE("Unit_hipGetProcAddress_spt_LaunchCooperativeKernel") {
+TEST_CASE(Unit_hipGetProcAddress_spt_LaunchCooperativeKernel) {
   hipDeviceProp_t device_properties;
   HIP_CHECK(hipGetDeviceProperties(&device_properties, 0));
 
@@ -2587,7 +2587,7 @@ TEST_CASE("Unit_hipGetProcAddress_spt_LaunchCooperativeKernel") {
  * ------------------------
  *  - HIP_VERSION >= 6.2
  */
-TEST_CASE("Unit_hipGetProcAddress_spt_Stream") {
+TEST_CASE(Unit_hipGetProcAddress_spt_Stream) {
   void* hipStreamGetFlags_spt_ptr = nullptr;
   void* hipStreamGetPriority_spt_ptr = nullptr;
   void* hipStreamSynchronize_spt_ptr = nullptr;
@@ -2688,7 +2688,7 @@ TEST_CASE("Unit_hipGetProcAddress_spt_Stream") {
  * ------------------------
  *  - HIP_VERSION >= 6.2
  */
-TEST_CASE("Unit_hipGetProcAddress_spt_Graph") {
+TEST_CASE(Unit_hipGetProcAddress_spt_Graph) {
   void* hipStreamBeginCapture_spt_ptr = nullptr;
   void* hipStreamIsCapturing_spt_ptr = nullptr;
   void* hipStreamEndCapture_spt_ptr = nullptr;
@@ -2856,7 +2856,7 @@ TEST_CASE("Unit_hipGetProcAddress_spt_Graph") {
  * ------------------------
  *  - HIP_VERSION >= 6.2
  */
-TEST_CASE("Unit_hipGetProcAddress_spt_Event") {
+TEST_CASE(Unit_hipGetProcAddress_spt_Event) {
   void* hipEventRecord_spt_ptr = nullptr;
   void* hipStreamWaitEvent_spt_ptr = nullptr;
 

--- a/projects/hip-tests/catch/unit/streamperthread/hipStreamPerThrdCompilerOptn.cc
+++ b/projects/hip-tests/catch/unit/streamperthread/hipStreamPerThrdCompilerOptn.cc
@@ -709,7 +709,7 @@ void DefaultPT2_hipMemcpy3D() {
 }
 
 
-TEST_CASE("Unit_hipStrmPerThrdDefault") {
+TEST_CASE(Unit_hipStrmPerThrdDefault) {
   CHECK_IMAGE_SUPPORT
 
   SECTION("Testing hipMemset/Memcpy() and their async version") {

--- a/projects/hip-tests/catch/unit/streamperthread/hipStreamPerThrdTsts.cc
+++ b/projects/hip-tests/catch/unit/streamperthread/hipStreamPerThrdTsts.cc
@@ -253,7 +253,7 @@ static void EventSync() {
 
 /* Launch a kernel in hipStreamPerThread, while it is in flight check for
    hipStreamQuery(hipStreamPerThread) it should return hipErrorNotReady.*/
-TEST_CASE("Unit_hipStreamPerThreadTst_StrmQuery") {
+TEST_CASE(Unit_hipStreamPerThreadTst_StrmQuery) {
   int *Ad = nullptr, *Ah = nullptr, NumElms = 4096, CONST_NUM = 123;
   int blockSize = 32, peak_clk;
   hipError_t err;
@@ -302,7 +302,7 @@ TEST_CASE("Unit_hipStreamPerThreadTst_StrmQuery") {
 }
 
 /* Testing hipStreamPerThread stream object with hipMallocManaged() memory*/
-TEST_CASE("Unit_hipStreamPerThread_MangdMem") {
+TEST_CASE(Unit_hipStreamPerThread_MangdMem) {
   int managed = 0;
   HIP_CHECK(hipDeviceGetAttribute(&managed, hipDeviceAttributeManagedMemory, 0));
   if (managed == 1) {
@@ -353,7 +353,7 @@ TEST_CASE("Unit_hipStreamPerThread_MangdMem") {
 
 /*  To check the working of hipStreamPerThread in forked process*/
 #ifdef __linux__
-TEST_CASE("Unit_hipStreamPerThread_ChildProc") {
+TEST_CASE(Unit_hipStreamPerThread_ChildProc) {
   if (fork() == 0) {  //  child process
     int *Ad = nullptr, *Ah = nullptr, NumElms = 4096, CONST_NUM = 123;
     int blockSize = 32, peak_clk;
@@ -402,7 +402,7 @@ TEST_CASE("Unit_hipStreamPerThread_ChildProc") {
 
 /* The following test case tests the working of hipEventSynchronize in
    multiple threads which are launched in quick succession*/
-TEST_CASE("Unit_hipStreamPerThread_EvtRcrdMThrd") {
+TEST_CASE(Unit_hipStreamPerThread_EvtRcrdMThrd) {
   IfTestPassed = true;
   int MAX_THREAD_CNT = 20;
   std::vector<std::thread> threads(MAX_THREAD_CNT);
@@ -417,7 +417,7 @@ TEST_CASE("Unit_hipStreamPerThread_EvtRcrdMThrd") {
 
 /* The following test case checks the working of hipStreamWaitEvent() with
    hipStreamWaitEvent()*/
-TEST_CASE("Unit_hipStreamPerThread_StrmWaitEvt") {
+TEST_CASE(Unit_hipStreamPerThread_StrmWaitEvt) {
   IfTestPassed = true;
   int *Ad = nullptr, NumElms = 4096, CONST_NUM = 123, blockSize = 32, *Ah = nullptr;
   int *Ad1 = nullptr, *Ah1 = nullptr;
@@ -482,7 +482,7 @@ TEST_CASE("Unit_hipStreamPerThread_StrmWaitEvt") {
 
 
 /* Testing hipLaunchCooperativeKernel() api with hipStreamPerThread*/
-TEST_CASE("Unit_hipStreamPerThread_CoopLaunch") {
+TEST_CASE(Unit_hipStreamPerThread_CoopLaunch) {
   hipDeviceProp_t device_properties;
   HIPCHECK(hipGetDeviceProperties(&device_properties, 0));
   /* Test whether target device supports cooperative groups ****************/

--- a/projects/hip-tests/catch/unit/streamperthread/hipStreamPerThread_Basic.cc
+++ b/projects/hip-tests/catch/unit/streamperthread/hipStreamPerThread_Basic.cc
@@ -30,7 +30,7 @@ __global__ void copy_kernl(int* devPtr) {
   }
 }
 
-TEST_CASE("Unit_hipStreamPerThread_Basic") {
+TEST_CASE(Unit_hipStreamPerThread_Basic) {
   constexpr int size = sizeof(int) * MEM_SIZE;
   int* hostMem = nullptr;
   int* devMem = nullptr;
@@ -65,7 +65,7 @@ TEST_CASE("Unit_hipStreamPerThread_Basic") {
   HIP_CHECK(hipFree(devMem));
 }
 
-TEST_CASE("Unit_hipStreamPerThread_StreamQuery") {
+TEST_CASE(Unit_hipStreamPerThread_StreamQuery) {
   std::vector<std::thread> threads(MAX_THREAD_CNT);
 
   for (auto& th : threads) {
@@ -78,7 +78,7 @@ TEST_CASE("Unit_hipStreamPerThread_StreamQuery") {
   REQUIRE(true);
 }
 
-TEST_CASE("Unit_hipStreamPerThread_StreamSynchronize") {
+TEST_CASE(Unit_hipStreamPerThread_StreamSynchronize) {
   constexpr unsigned int MAX_THREAD_CNT = 10;
   std::vector<std::thread> threads(MAX_THREAD_CNT);
 
@@ -92,22 +92,22 @@ TEST_CASE("Unit_hipStreamPerThread_StreamSynchronize") {
   REQUIRE(true);
 }
 
-TEST_CASE("Unit_hipStreamPerThread_StreamGetPriority") {
+TEST_CASE(Unit_hipStreamPerThread_StreamGetPriority) {
   int priority = 0;
   HIP_CHECK(hipStreamGetPriority(hipStreamPerThread, &priority));
 }
 
-TEST_CASE("Unit_hipStreamPerThread_StreamGetFlags") {
+TEST_CASE(Unit_hipStreamPerThread_StreamGetFlags) {
   unsigned int flags = 0;
   HIP_CHECK(hipStreamGetFlags(hipStreamPerThread, &flags));
 }
 
-TEST_CASE("Unit_hipStreamPerThread_StreamDestroy") {
+TEST_CASE(Unit_hipStreamPerThread_StreamDestroy) {
   hipError_t status = hipStreamDestroy(hipStreamPerThread);
   REQUIRE(status != hipSuccess);
 }
 
-TEST_CASE("Unit_hipStreamPerThread_MemcpyAsync") {
+TEST_CASE(Unit_hipStreamPerThread_MemcpyAsync) {
   unsigned int ele_size = (16 * 1024);  // 16KB
   int* A_h = nullptr;
   int* A_d = nullptr;

--- a/projects/hip-tests/catch/unit/streamperthread/hipStreamPerThread_DeviceReset.cc
+++ b/projects/hip-tests/catch/unit/streamperthread/hipStreamPerThread_DeviceReset.cc
@@ -48,7 +48,7 @@ static void Copy_to_device() {
   HIP_CHECK(hipFree(A_d));
 }
 
-TEST_CASE("Unit_hipStreamPerThread_DeviceReset_1") {
+TEST_CASE(Unit_hipStreamPerThread_DeviceReset_1) {
   constexpr unsigned int MAX_THREAD_CNT = 10;
   std::vector<std::thread> threads(MAX_THREAD_CNT);
 
@@ -70,7 +70,7 @@ TEST_CASE("Unit_hipStreamPerThread_DeviceReset_1") {
  Watch out: Since hipStreamPerThread is an implicit stream hence even after device reset
             it should available to use.
  */
-TEST_CASE("Unit_hipStreamPerThread_DeviceReset_2") {
+TEST_CASE(Unit_hipStreamPerThread_DeviceReset_2) {
   unsigned int ele_size = (32 * 1024);  // 32KB
   int* A_h = nullptr;
   int* A_d = nullptr;

--- a/projects/hip-tests/catch/unit/streamperthread/hipStreamPerThread_Event.cc
+++ b/projects/hip-tests/catch/unit/streamperthread/hipStreamPerThread_Event.cc
@@ -19,7 +19,7 @@ THE SOFTWARE.
 
 #include <hip_test_common.hh>
 
-TEST_CASE("Unit_hipStreamPerThread_EventRecord") {
+TEST_CASE(Unit_hipStreamPerThread_EventRecord) {
   hipEvent_t event;
   HIP_CHECK(hipEventCreate(&event));
   HIP_CHECK(hipEventRecord(event, hipStreamPerThread));
@@ -36,7 +36,7 @@ __global__ void update_even_odd(unsigned int N, int* out) {
     }
   }
 }
-TEST_CASE("Unit_hipStreamPerThread_EventSynchronize") {
+TEST_CASE(Unit_hipStreamPerThread_EventSynchronize) {
   int* A_h = nullptr;
   int* A_d = nullptr;
   unsigned int size = 1000;

--- a/projects/hip-tests/catch/unit/streamperthread/hipStreamPerThread_MultiThread.cc
+++ b/projects/hip-tests/catch/unit/streamperthread/hipStreamPerThread_MultiThread.cc
@@ -44,7 +44,7 @@ hipStreamPerThread is an implicit stream which gets destroyed once thread is com
 Scenario : App pushes Async task(s) into hipStreamPerThread and did not wait for it to complete.
 Watch out : Incomplete task in hipStreamPerThread should not cause any crash due to thread exit.
  */
-TEST_CASE("Unit_hipStreamPerThread_MultiThread") {
+TEST_CASE(Unit_hipStreamPerThread_MultiThread) {
   constexpr unsigned int MAX_THREAD_CNT = 10;
   std::vector<std::thread> threads(MAX_THREAD_CNT);
 

--- a/projects/hip-tests/catch/unit/surface/hipCreateSurfaceObject.cc
+++ b/projects/hip-tests/catch/unit/surface/hipCreateSurfaceObject.cc
@@ -39,7 +39,7 @@ THE SOFTWARE.
  * ------------------------
  *    - HIP_VERSION >= 5.7
  */
-TEST_CASE("Unit_hipCreateSurfaceObject_Negative_Parameters") {
+TEST_CASE(Unit_hipCreateSurfaceObject_Negative_Parameters) {
   CHECK_IMAGE_SUPPORT
 
   hipArray_t array;

--- a/projects/hip-tests/catch/unit/surface/hipDestroySurfaceObject.cc
+++ b/projects/hip-tests/catch/unit/surface/hipDestroySurfaceObject.cc
@@ -39,7 +39,7 @@ THE SOFTWARE.
  * ------------------------
  *    - HIP_VERSION >= 5.7
  */
-TEST_CASE("Unit_hipDestroySurfaceObject_Negative_Parameters") {
+TEST_CASE(Unit_hipDestroySurfaceObject_Negative_Parameters) {
   CHECK_IMAGE_SUPPORT
 
   SECTION("surfObject is NULL") {

--- a/projects/hip-tests/catch/unit/surface/surf1D.cc
+++ b/projects/hip-tests/catch/unit/surface/surf1D.cc
@@ -242,8 +242,8 @@ template <typename T> static void runTestRW(const int width) {
  * ------------------------
  *    - HIP_VERSION >= 5.7
  */
-TEMPLATE_TEST_CASE("Unit_surf1Dread_Positive_Basic", "", char, unsigned char, short,
-                   unsigned short, int, unsigned int, float) {
+TEMPLATE_TEST_CASE(Unit_surf1Dread_Positive_Basic, char, unsigned char, short, unsigned short, int,
+                   unsigned int, float) {
   CHECK_IMAGE_SUPPORT;
 
   const int width = GENERATE(31, 67, 131, 263);
@@ -265,8 +265,8 @@ TEMPLATE_TEST_CASE("Unit_surf1Dread_Positive_Basic", "", char, unsigned char, sh
  * ------------------------
  *    - HIP_VERSION >= 5.7
  */
-TEMPLATE_TEST_CASE("Unit_surf1Dwrite_Positive_Basic", "", char, unsigned char, short,
-                   unsigned short, int, unsigned int, float) {
+TEMPLATE_TEST_CASE(Unit_surf1Dwrite_Positive_Basic, char, unsigned char, short, unsigned short, int,
+                   unsigned int, float) {
   CHECK_IMAGE_SUPPORT;
 
   const int width = GENERATE(31, 67, 131, 263);
@@ -288,8 +288,8 @@ TEMPLATE_TEST_CASE("Unit_surf1Dwrite_Positive_Basic", "", char, unsigned char, s
  * ------------------------
  *    - HIP_VERSION >= 5.7
  */
-TEMPLATE_TEST_CASE("Unit_surf1D_Positive_ReadWrite", "", char, unsigned char, short,
-                   unsigned short, int, unsigned int, float) {
+TEMPLATE_TEST_CASE(Unit_surf1D_Positive_ReadWrite, char, unsigned char, short, unsigned short, int,
+                   unsigned int, float) {
   CHECK_IMAGE_SUPPORT;
 
   const int width = GENERATE(31, 67, 131, 263);

--- a/projects/hip-tests/catch/unit/surface/surf1DLayered.cc
+++ b/projects/hip-tests/catch/unit/surface/surf1DLayered.cc
@@ -242,7 +242,7 @@ template <typename T> static void runTestRW(const int width) {
  * ------------------------
  *    - HIP_VERSION >= 5.7
  */
-TEMPLATE_TEST_CASE("Unit_surf1DLayeredread_Positive_Basic", "", char, unsigned char, short,
+TEMPLATE_TEST_CASE(Unit_surf1DLayeredread_Positive_Basic, char, unsigned char, short,
                    unsigned short, int, unsigned int, float) {
   CHECK_IMAGE_SUPPORT;
 
@@ -264,7 +264,7 @@ TEMPLATE_TEST_CASE("Unit_surf1DLayeredread_Positive_Basic", "", char, unsigned c
  * ------------------------
  *    - HIP_VERSION >= 5.7
  */
-TEMPLATE_TEST_CASE("Unit_surf1DLayeredwrite_Positive_Basic", "", char, unsigned char, short,
+TEMPLATE_TEST_CASE(Unit_surf1DLayeredwrite_Positive_Basic, char, unsigned char, short,
                    unsigned short, int, unsigned int, float) {
   CHECK_IMAGE_SUPPORT;
 
@@ -286,7 +286,7 @@ TEMPLATE_TEST_CASE("Unit_surf1DLayeredwrite_Positive_Basic", "", char, unsigned 
  * ------------------------
  *    - HIP_VERSION >= 5.7
  */
-TEMPLATE_TEST_CASE("Unit_surf1DLayered_Positive_ReadWrite", "", char, unsigned char, short,
+TEMPLATE_TEST_CASE(Unit_surf1DLayered_Positive_ReadWrite, char, unsigned char, short,
                    unsigned short, int, unsigned int, float) {
   CHECK_IMAGE_SUPPORT;
 

--- a/projects/hip-tests/catch/unit/surface/surf2D.cc
+++ b/projects/hip-tests/catch/unit/surface/surf2D.cc
@@ -281,8 +281,8 @@ template <typename T> static void runTestRW(const int width, const int height) {
  * ------------------------
  *    - HIP_VERSION >= 5.7
  */
-TEMPLATE_TEST_CASE("Unit_surf2Dread_Positive_Basic", "", char, unsigned char, short,
-                   unsigned short, int, unsigned int, float) {
+TEMPLATE_TEST_CASE(Unit_surf2Dread_Positive_Basic, char, unsigned char, short, unsigned short, int,
+                   unsigned int, float) {
   CHECK_IMAGE_SUPPORT;
 
   const int width = GENERATE(31, 67);
@@ -304,8 +304,8 @@ TEMPLATE_TEST_CASE("Unit_surf2Dread_Positive_Basic", "", char, unsigned char, sh
  * ------------------------
  *    - HIP_VERSION >= 5.7
  */
-TEMPLATE_TEST_CASE("Unit_surf2Dwrite_Positive_Basic", "", char, unsigned char, short,
-                   unsigned short, int, unsigned int, float) {
+TEMPLATE_TEST_CASE(Unit_surf2Dwrite_Positive_Basic, char, unsigned char, short, unsigned short, int,
+                   unsigned int, float) {
   CHECK_IMAGE_SUPPORT;
 
   const int width = GENERATE(31, 67);
@@ -327,8 +327,8 @@ TEMPLATE_TEST_CASE("Unit_surf2Dwrite_Positive_Basic", "", char, unsigned char, s
  * ------------------------
  *    - HIP_VERSION >= 5.7
  */
-TEMPLATE_TEST_CASE("Unit_surf2D_Positive_ReadWrite", "", char, unsigned char, short,
-                   unsigned short, int, unsigned int, float) {
+TEMPLATE_TEST_CASE(Unit_surf2D_Positive_ReadWrite, char, unsigned char, short, unsigned short, int,
+                   unsigned int, float) {
   CHECK_IMAGE_SUPPORT;
 
   const int width = GENERATE(31, 67);

--- a/projects/hip-tests/catch/unit/surface/surf2DLayered.cc
+++ b/projects/hip-tests/catch/unit/surface/surf2DLayered.cc
@@ -281,7 +281,7 @@ template <typename T> static void runTestRW(const int width, const int height) {
  * ------------------------
  *    - HIP_VERSION >= 5.7
  */
-TEMPLATE_TEST_CASE("Unit_surf2DLayeredread_Positive_Basic", "", char, unsigned char, short,
+TEMPLATE_TEST_CASE(Unit_surf2DLayeredread_Positive_Basic, char, unsigned char, short,
                    unsigned short, int, unsigned int, float) {
   CHECK_IMAGE_SUPPORT;
 
@@ -304,7 +304,7 @@ TEMPLATE_TEST_CASE("Unit_surf2DLayeredread_Positive_Basic", "", char, unsigned c
  * ------------------------
  *    - HIP_VERSION >= 5.7
  */
-TEMPLATE_TEST_CASE("Unit_surf2DLayeredwrite_Positive_Basic", "", char, unsigned char, short,
+TEMPLATE_TEST_CASE(Unit_surf2DLayeredwrite_Positive_Basic, char, unsigned char, short,
                    unsigned short, int, unsigned int, float) {
   CHECK_IMAGE_SUPPORT;
 
@@ -327,7 +327,7 @@ TEMPLATE_TEST_CASE("Unit_surf2DLayeredwrite_Positive_Basic", "", char, unsigned 
  * ------------------------
  *    - HIP_VERSION >= 5.7
  */
-TEMPLATE_TEST_CASE("Unit_surf2DLayered_Positive_ReadWrite", "", char, unsigned char, short,
+TEMPLATE_TEST_CASE(Unit_surf2DLayered_Positive_ReadWrite, char, unsigned char, short,
                    unsigned short, int, unsigned int, float) {
   CHECK_IMAGE_SUPPORT;
 

--- a/projects/hip-tests/catch/unit/surface/surf3D.cc
+++ b/projects/hip-tests/catch/unit/surface/surf3D.cc
@@ -327,8 +327,8 @@ template <typename T> static void runTestRW(const int width, const int height, c
  * ------------------------
  *    - HIP_VERSION >= 5.7
  */
-TEMPLATE_TEST_CASE("Unit_surf3Dread_Positive_Basic", "", char, unsigned char, short,
-                   unsigned short, int, unsigned int, float) {
+TEMPLATE_TEST_CASE(Unit_surf3Dread_Positive_Basic, char, unsigned char, short, unsigned short, int,
+                   unsigned int, float) {
   CHECK_IMAGE_SUPPORT;
 
   const int width = GENERATE(31, 67);
@@ -351,8 +351,8 @@ TEMPLATE_TEST_CASE("Unit_surf3Dread_Positive_Basic", "", char, unsigned char, sh
  * ------------------------
  *    - HIP_VERSION >= 5.7
  */
-TEMPLATE_TEST_CASE("Unit_surf3Dwrite_Positive_Basic", "", char, unsigned char, short,
-                   unsigned short, int, unsigned int, float) {
+TEMPLATE_TEST_CASE(Unit_surf3Dwrite_Positive_Basic, char, unsigned char, short, unsigned short, int,
+                   unsigned int, float) {
   CHECK_IMAGE_SUPPORT;
 
   const int width = GENERATE(31, 67);
@@ -375,8 +375,8 @@ TEMPLATE_TEST_CASE("Unit_surf3Dwrite_Positive_Basic", "", char, unsigned char, s
  * ------------------------
  *    - HIP_VERSION >= 5.7
  */
-TEMPLATE_TEST_CASE("Unit_surf3D_Positive_ReadWrite", "", char, unsigned char, short,
-                   unsigned short, int, unsigned int, float) {
+TEMPLATE_TEST_CASE(Unit_surf3D_Positive_ReadWrite, char, unsigned char, short, unsigned short, int,
+                   unsigned int, float) {
   CHECK_IMAGE_SUPPORT;
 
   const int width = GENERATE(31, 67);

--- a/projects/hip-tests/catch/unit/surface/surfCubemap.cc
+++ b/projects/hip-tests/catch/unit/surface/surfCubemap.cc
@@ -281,8 +281,8 @@ template <typename T> static void runTestRW(const int width, const int height) {
  * ------------------------
  *    - HIP_VERSION >= 5.7
  */
-TEMPLATE_TEST_CASE("Unit_surfCubemapread_Positive_Basic", "", char, unsigned char, short,
-                   unsigned short, int, unsigned int, float) {
+TEMPLATE_TEST_CASE(Unit_surfCubemapread_Positive_Basic, char, unsigned char, short, unsigned short,
+                   int, unsigned int, float) {
   CHECK_IMAGE_SUPPORT;
 
   const int width = GENERATE(31, 67);
@@ -304,8 +304,8 @@ TEMPLATE_TEST_CASE("Unit_surfCubemapread_Positive_Basic", "", char, unsigned cha
  * ------------------------
  *    - HIP_VERSION >= 5.7
  */
-TEMPLATE_TEST_CASE("Unit_surfCubemapwrite_Positive_Basic", "", char, unsigned char, short,
-                   unsigned short, int, unsigned int, float) {
+TEMPLATE_TEST_CASE(Unit_surfCubemapwrite_Positive_Basic, char, unsigned char, short, unsigned short,
+                   int, unsigned int, float) {
   CHECK_IMAGE_SUPPORT;
 
   const int width = GENERATE(31, 67);
@@ -327,8 +327,8 @@ TEMPLATE_TEST_CASE("Unit_surfCubemapwrite_Positive_Basic", "", char, unsigned ch
  * ------------------------
  *    - HIP_VERSION >= 5.7
  */
-TEMPLATE_TEST_CASE("Unit_surfCubemap_Positive_ReadWrite", "", char, unsigned char, short,
-                   unsigned short, int, unsigned int, float) {
+TEMPLATE_TEST_CASE(Unit_surfCubemap_Positive_ReadWrite, char, unsigned char, short, unsigned short,
+                   int, unsigned int, float) {
   CHECK_IMAGE_SUPPORT;
 
   const int width = GENERATE(31, 67);

--- a/projects/hip-tests/catch/unit/surface/surfCubemapLayered.cc
+++ b/projects/hip-tests/catch/unit/surface/surfCubemapLayered.cc
@@ -284,7 +284,7 @@ template <typename T> static void runTestRW(const int width, const int height) {
  * ------------------------
  *    - HIP_VERSION >= 5.7
  */
-TEMPLATE_TEST_CASE("Unit_surfCubemapLayeredread_Positive_Basic", "", char, unsigned char, short,
+TEMPLATE_TEST_CASE(Unit_surfCubemapLayeredread_Positive_Basic, char, unsigned char, short,
                    unsigned short, int, unsigned int, float) {
   CHECK_IMAGE_SUPPORT;
 
@@ -307,7 +307,7 @@ TEMPLATE_TEST_CASE("Unit_surfCubemapLayeredread_Positive_Basic", "", char, unsig
  * ------------------------
  *    - HIP_VERSION >= 5.7
  */
-TEMPLATE_TEST_CASE("Unit_surfCubemapLayeredwrite_Positive_Basic", "", char, unsigned char, short,
+TEMPLATE_TEST_CASE(Unit_surfCubemapLayeredwrite_Positive_Basic, char, unsigned char, short,
                    unsigned short, int, unsigned int, float) {
   CHECK_IMAGE_SUPPORT;
 
@@ -330,7 +330,7 @@ TEMPLATE_TEST_CASE("Unit_surfCubemapLayeredwrite_Positive_Basic", "", char, unsi
  * ------------------------
  *    - HIP_VERSION >= 5.7
  */
-TEMPLATE_TEST_CASE("Unit_surfCubemapLayered_Positive_ReadWrite", "", char, unsigned char, short,
+TEMPLATE_TEST_CASE(Unit_surfCubemapLayered_Positive_ReadWrite, char, unsigned char, short,
                    unsigned short, int, unsigned int, float) {
   CHECK_IMAGE_SUPPORT;
 

--- a/projects/hip-tests/catch/unit/synchronization/cache_coherency_cpu_gpu.cc
+++ b/projects/hip-tests/catch/unit/synchronization/cache_coherency_cpu_gpu.cc
@@ -254,7 +254,7 @@ static bool cpu_to_gpu_coherency() {
  *    - Test to be run only on AMD.
  */
 
-TEST_CASE("Unit_cache_coherency_cpu_gpu") {
+TEST_CASE(Unit_cache_coherency_cpu_gpu) {
   bool passed = true;
   // Coherency between CPU and GPU sharing host and device memory.
   REQUIRE(passed == cpu_to_gpu_coherency());

--- a/projects/hip-tests/catch/unit/synchronization/cache_coherency_gpu_gpu.cc
+++ b/projects/hip-tests/catch/unit/synchronization/cache_coherency_gpu_gpu.cc
@@ -284,7 +284,7 @@ static bool gpu_to_gpu_coherency() {
  *    - Test to be run only on AMD.
  */
 
-TEST_CASE("Unit_cache_coherency_gpu_gpu", "[multigpu]") {
+TEST_CASE(Unit_cache_coherency_gpu_gpu) {
   bool passed = true;
   // Coherency between GPUs accessing local or remote FB.
   REQUIRE(passed == gpu_to_gpu_coherency());

--- a/projects/hip-tests/catch/unit/synchronization/copy_coherency.cc
+++ b/projects/hip-tests/catch/unit/synchronization/copy_coherency.cc
@@ -327,7 +327,7 @@ void testWrapper(size_t numElements) {
  *    - HIP_VERSION >= 5.5
  */
 
-TEST_CASE("Unit_Copy_Coherency") {
+TEST_CASE(Unit_Copy_Coherency) {
   for (int index = 0; index < sizeof(g_elementSizes) / sizeof(int); index++) {
     size_t numElements = g_elementSizes[index];
     testWrapper(numElements);

--- a/projects/hip-tests/catch/unit/syncthreads/__syncthreads.cc
+++ b/projects/hip-tests/catch/unit/syncthreads/__syncthreads.cc
@@ -43,7 +43,7 @@ THE SOFTWARE.
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit___syncthreads_Positive_Basic") {
+TEST_CASE(Unit___syncthreads_Positive_Basic) {
   const auto kGridSize = 2;
   const auto kBlockSize = GENERATE(13, 32, 64, 513);
 

--- a/projects/hip-tests/catch/unit/syncthreads/__syncthreads_and.cc
+++ b/projects/hip-tests/catch/unit/syncthreads/__syncthreads_and.cc
@@ -44,7 +44,7 @@ THE SOFTWARE.
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit___syncthreads_and_Positive_Basic") {
+TEST_CASE(Unit___syncthreads_and_Positive_Basic) {
   const auto kGridSize = 2;
   const auto kBlockSize = GENERATE(13, 32, 64, 513);
 
@@ -71,7 +71,7 @@ TEST_CASE("Unit___syncthreads_and_Positive_Basic") {
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit___syncthreads_and_Positive_Predicate_Zero") {
+TEST_CASE(Unit___syncthreads_and_Positive_Predicate_Zero) {
   const auto kGridSize = 2;
   const auto kBlockSize = GENERATE(13, 32, 64, 513);
 
@@ -99,7 +99,7 @@ TEST_CASE("Unit___syncthreads_and_Positive_Predicate_Zero") {
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit___syncthreads_and_Positive_Predicate_One") {
+TEST_CASE(Unit___syncthreads_and_Positive_Predicate_One) {
   const auto kGridSize = 2;
   const auto kBlockSize = GENERATE(13, 32, 64, 513);
 
@@ -128,7 +128,7 @@ TEST_CASE("Unit___syncthreads_and_Positive_Predicate_One") {
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit___syncthreads_and_Positive_Predicate_OddEven") {
+TEST_CASE(Unit___syncthreads_and_Positive_Predicate_OddEven) {
   const auto kGridSize = 2;
   const auto kBlockSize = GENERATE(13, 32, 64, 513);
 
@@ -156,7 +156,7 @@ TEST_CASE("Unit___syncthreads_and_Positive_Predicate_OddEven") {
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit___syncthreads_and_Positive_Predicate_Negative") {
+TEST_CASE(Unit___syncthreads_and_Positive_Predicate_Negative) {
   const auto kGridSize = 2;
   const auto kBlockSize = GENERATE(13, 32, 64, 513);
 
@@ -184,7 +184,7 @@ TEST_CASE("Unit___syncthreads_and_Positive_Predicate_Negative") {
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit___syncthreads_and_Positive_Predicate_Id") {
+TEST_CASE(Unit___syncthreads_and_Positive_Predicate_Id) {
   const auto kGridSize = 2;
   const auto kBlockSize = GENERATE(13, 32, 64, 513);
 
@@ -212,7 +212,7 @@ TEST_CASE("Unit___syncthreads_and_Positive_Predicate_Id") {
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit___syncthreads_and_Negative_Parameters_RTC") {
+TEST_CASE(Unit___syncthreads_and_Negative_Parameters_RTC) {
   hiprtcProgram program{};
 
   HIPRTC_CHECK(hiprtcCreateProgram(&program, kSyncthreadsAndSource, "__syncthreads_and_negative.cc",

--- a/projects/hip-tests/catch/unit/syncthreads/__syncthreads_count.cc
+++ b/projects/hip-tests/catch/unit/syncthreads/__syncthreads_count.cc
@@ -44,7 +44,7 @@ THE SOFTWARE.
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit___syncthreads_count_Positive_Basic") {
+TEST_CASE(Unit___syncthreads_count_Positive_Basic) {
   const auto kGridSize = 2;
   const auto kBlockSize = GENERATE(13, 32, 64, 513);
 
@@ -71,7 +71,7 @@ TEST_CASE("Unit___syncthreads_count_Positive_Basic") {
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit___syncthreads_count_Positive_Predicate_Zero") {
+TEST_CASE(Unit___syncthreads_count_Positive_Predicate_Zero) {
   const auto kGridSize = 2;
   const auto kBlockSize = GENERATE(13, 32, 64, 513);
 
@@ -99,7 +99,7 @@ TEST_CASE("Unit___syncthreads_count_Positive_Predicate_Zero") {
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit___syncthreads_count_Positive_Predicate_One") {
+TEST_CASE(Unit___syncthreads_count_Positive_Predicate_One) {
   const auto kGridSize = 2;
   const auto kBlockSize = GENERATE(13, 32, 64, 513);
 
@@ -128,7 +128,7 @@ TEST_CASE("Unit___syncthreads_count_Positive_Predicate_One") {
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit___syncthreads_count_Positive_Predicate_OddEven") {
+TEST_CASE(Unit___syncthreads_count_Positive_Predicate_OddEven) {
   const auto kGridSize = 2;
   const auto kBlockSize = GENERATE(13, 32, 64, 513);
 
@@ -156,7 +156,7 @@ TEST_CASE("Unit___syncthreads_count_Positive_Predicate_OddEven") {
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit___syncthreads_count_Positive_Predicate_Negative") {
+TEST_CASE(Unit___syncthreads_count_Positive_Predicate_Negative) {
   const auto kGridSize = 2;
   const auto kBlockSize = GENERATE(13, 32, 64, 513);
 
@@ -184,7 +184,7 @@ TEST_CASE("Unit___syncthreads_count_Positive_Predicate_Negative") {
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit___syncthreads_count_Positive_Predicate_Id") {
+TEST_CASE(Unit___syncthreads_count_Positive_Predicate_Id) {
   const auto kGridSize = 2;
   const auto kBlockSize = GENERATE(13, 32, 64, 513);
 
@@ -212,7 +212,7 @@ TEST_CASE("Unit___syncthreads_count_Positive_Predicate_Id") {
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit___syncthreads_count_Negative_Parameters_RTC") {
+TEST_CASE(Unit___syncthreads_count_Negative_Parameters_RTC) {
   hiprtcProgram program{};
 
   HIPRTC_CHECK(hiprtcCreateProgram(&program, kSyncthreadsCountSource,

--- a/projects/hip-tests/catch/unit/syncthreads/__syncthreads_or.cc
+++ b/projects/hip-tests/catch/unit/syncthreads/__syncthreads_or.cc
@@ -44,7 +44,7 @@ THE SOFTWARE.
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit___syncthreads_or_Positive_Basic") {
+TEST_CASE(Unit___syncthreads_or_Positive_Basic) {
   const auto kGridSize = 2;
   const auto kBlockSize = GENERATE(13, 32, 64, 513);
 
@@ -71,7 +71,7 @@ TEST_CASE("Unit___syncthreads_or_Positive_Basic") {
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit___syncthreads_or_Positive_Predicate_Zero") {
+TEST_CASE(Unit___syncthreads_or_Positive_Predicate_Zero) {
   const auto kGridSize = 2;
   const auto kBlockSize = GENERATE(13, 32, 64, 513);
 
@@ -99,7 +99,7 @@ TEST_CASE("Unit___syncthreads_or_Positive_Predicate_Zero") {
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit___syncthreads_or_Positive_Predicate_One") {
+TEST_CASE(Unit___syncthreads_or_Positive_Predicate_One) {
   const auto kGridSize = 2;
   const auto kBlockSize = GENERATE(13, 32, 64, 513);
 
@@ -128,7 +128,7 @@ TEST_CASE("Unit___syncthreads_or_Positive_Predicate_One") {
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit___syncthreads_or_Positive_Predicate_OddEven") {
+TEST_CASE(Unit___syncthreads_or_Positive_Predicate_OddEven) {
   const auto kGridSize = 2;
   const auto kBlockSize = GENERATE(13, 32, 64, 513);
 
@@ -156,7 +156,7 @@ TEST_CASE("Unit___syncthreads_or_Positive_Predicate_OddEven") {
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit___syncthreads_or_Positive_Predicate_Negative") {
+TEST_CASE(Unit___syncthreads_or_Positive_Predicate_Negative) {
   const auto kGridSize = 2;
   const auto kBlockSize = GENERATE(13, 32, 64, 513);
 
@@ -184,7 +184,7 @@ TEST_CASE("Unit___syncthreads_or_Positive_Predicate_Negative") {
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit___syncthreads_or_Positive_Predicate_Id") {
+TEST_CASE(Unit___syncthreads_or_Positive_Predicate_Id) {
   const auto kGridSize = 2;
   const auto kBlockSize = GENERATE(13, 32, 64, 513);
 
@@ -212,7 +212,7 @@ TEST_CASE("Unit___syncthreads_or_Positive_Predicate_Id") {
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit___syncthreads_or_Negative_Parameters_RTC") {
+TEST_CASE(Unit___syncthreads_or_Negative_Parameters_RTC) {
   hiprtcProgram program{};
 
   HIPRTC_CHECK(hiprtcCreateProgram(&program, kSyncthreadsOrSource, "__syncthreads_or_negative.cc",

--- a/projects/hip-tests/catch/unit/texture/hipBindTexture.cc
+++ b/projects/hip-tests/catch/unit/texture/hipBindTexture.cc
@@ -35,7 +35,7 @@ static __global__ void kernel(float* out) {
 #endif
 }
 
-TEST_CASE("Unit_hipBindTexture_Positive") {
+TEST_CASE(Unit_hipBindTexture_Positive) {
   CHECK_IMAGE_SUPPORT
   size_t offset = 0;
   float* tex_buf;
@@ -58,7 +58,7 @@ TEST_CASE("Unit_hipBindTexture_Positive") {
   HIP_CHECK(hipFree(tex_buf));
 }
 
-TEST_CASE("Unit_hipBindTexture_1DfetchVerification") {
+TEST_CASE(Unit_hipBindTexture_1DfetchVerification) {
   CHECK_IMAGE_SUPPORT
 
   float* tex_buf;
@@ -103,7 +103,7 @@ TEST_CASE("Unit_hipBindTexture_1DfetchVerification") {
   HIP_CHECK(hipFree(dev_buf));
 }
 
-TEST_CASE("Unit_hipBindTexture_Negative") {
+TEST_CASE(Unit_hipBindTexture_Negative) {
   CHECK_IMAGE_SUPPORT
   size_t offset = 0;
   float* tex_buf;

--- a/projects/hip-tests/catch/unit/texture/hipBindTexture2D.cc
+++ b/projects/hip-tests/catch/unit/texture/hipBindTexture2D.cc
@@ -39,7 +39,7 @@ static __global__ void texture2dCopyKernel(float* dst) {
 #endif
 }
 
-TEST_CASE("Unit_hipBindTexture2D_Positive") {
+TEST_CASE(Unit_hipBindTexture2D_Positive) {
   CHECK_IMAGE_SUPPORT
   float* device_ptr;
   size_t device_pitch, texture_offset;
@@ -50,7 +50,7 @@ TEST_CASE("Unit_hipBindTexture2D_Positive") {
   HIP_CHECK(hipFree((void*)device_ptr));
 }
 
-TEST_CASE("Unit_hipBindTexture2D_Pitch") {
+TEST_CASE(Unit_hipBindTexture2D_Pitch) {
   CHECK_IMAGE_SUPPORT
   (void) hipGetLastError();  // Prevent negative tests affecting this
 
@@ -89,7 +89,7 @@ TEST_CASE("Unit_hipBindTexture2D_Pitch") {
   HIP_CHECK(hipUnbindTexture(tex));
 }
 
-TEST_CASE("Unit_hipBindTexture2D_Negative") {
+TEST_CASE(Unit_hipBindTexture2D_Negative) {
   CHECK_IMAGE_SUPPORT
   float* device_ptr;
   size_t device_pitch, texture_offset;

--- a/projects/hip-tests/catch/unit/texture/hipBindTextureToArray.cc
+++ b/projects/hip-tests/catch/unit/texture/hipBindTextureToArray.cc
@@ -77,7 +77,7 @@ bool compare_array_elements(int* array1, int* array2, int width, int height = 1,
   return true;
 }
 
-TEST_CASE("Unit_hipBindTextureToArray_Negative_Parameters") {
+TEST_CASE(Unit_hipBindTextureToArray_Negative_Parameters) {
   CHECK_IMAGE_SUPPORT
 
   constexpr unsigned int width = 16;
@@ -145,7 +145,7 @@ TEST_CASE("Unit_hipBindTextureToArray_Negative_Parameters") {
   free(data);
 }
 
-TEST_CASE("Unit_hipBindTextureToArray_Positive_1D") {
+TEST_CASE(Unit_hipBindTextureToArray_Positive_1D) {
   CHECK_IMAGE_SUPPORT
 
   constexpr unsigned int width = 1024;
@@ -190,7 +190,7 @@ TEST_CASE("Unit_hipBindTextureToArray_Positive_1D") {
   free(data);
 }
 
-TEST_CASE("Unit_hipBindTextureToArray_Positive_2D") {
+TEST_CASE(Unit_hipBindTextureToArray_Positive_2D) {
   CHECK_IMAGE_SUPPORT
 
   constexpr unsigned int width = 256;
@@ -239,7 +239,7 @@ TEST_CASE("Unit_hipBindTextureToArray_Positive_2D") {
   free(data);
 }
 
-TEST_CASE("Unit_hipBindTextureToArray_Positive_3D") {
+TEST_CASE(Unit_hipBindTextureToArray_Positive_3D) {
   CHECK_IMAGE_SUPPORT
 
   constexpr unsigned int width = 256;

--- a/projects/hip-tests/catch/unit/texture/hipBindTextureToMipmappedArray.cc
+++ b/projects/hip-tests/catch/unit/texture/hipBindTextureToMipmappedArray.cc
@@ -134,7 +134,7 @@ static void runMipMapTest(unsigned int width, unsigned int height, unsigned int 
  *  - Host specific (WINDOWS)
  *  - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_hipTextureMipmapRef2D_Positive_Check") {
+TEST_CASE(Unit_hipTextureMipmapRef2D_Positive_Check) {
   CHECK_IMAGE_SUPPORT
 
   // Height Width Vector
@@ -174,7 +174,7 @@ TEST_CASE("Unit_hipTextureMipmapRef2D_Positive_Check") {
  *  - Host specific (WINDOWS)
  *  - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_hipTextureMipmapRef2D_Negative_Parameters") {
+TEST_CASE(Unit_hipTextureMipmapRef2D_Negative_Parameters) {
   CHECK_IMAGE_SUPPORT
 
 #if defined(_WIN32)

--- a/projects/hip-tests/catch/unit/texture/hipCreateTextureObject_ArgValidation.cc
+++ b/projects/hip-tests/catch/unit/texture/hipCreateTextureObject_ArgValidation.cc
@@ -50,7 +50,7 @@ THE SOFTWARE.
  *  - Textures supported on device
  *  - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_hipCreateTextureObject_ArgValidation") {
+TEST_CASE(Unit_hipCreateTextureObject_ArgValidation) {
   CHECK_IMAGE_SUPPORT
 
   float* texBuf;

--- a/projects/hip-tests/catch/unit/texture/hipCreateTextureObject_Array.cc
+++ b/projects/hip-tests/catch/unit/texture/hipCreateTextureObject_Array.cc
@@ -38,7 +38,7 @@ THE SOFTWARE.
  *  - Textures supported on device
  *  - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_hipCreateTextureObject_ArrayResource") {
+TEST_CASE(Unit_hipCreateTextureObject_ArrayResource) {
   CHECK_IMAGE_SUPPORT
 
   hipError_t ret;
@@ -73,7 +73,7 @@ TEST_CASE("Unit_hipCreateTextureObject_ArrayResource") {
  *  - Textures supported on device
  *  - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_hipCreateTextureObject_MmArrayResource") {
+TEST_CASE(Unit_hipCreateTextureObject_MmArrayResource) {
   CHECK_IMAGE_SUPPORT
 
   hipError_t ret;

--- a/projects/hip-tests/catch/unit/texture/hipCreateTextureObject_Linear.cc
+++ b/projects/hip-tests/catch/unit/texture/hipCreateTextureObject_Linear.cc
@@ -51,7 +51,7 @@ THE SOFTWARE.
  *  - Textures supported on device
  *  - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_hipCreateTextureObject_LinearResource") {
+TEST_CASE(Unit_hipCreateTextureObject_LinearResource) {
   CHECK_IMAGE_SUPPORT
 
   float* texBuf;

--- a/projects/hip-tests/catch/unit/texture/hipCreateTextureObject_Pitch2D.cc
+++ b/projects/hip-tests/catch/unit/texture/hipCreateTextureObject_Pitch2D.cc
@@ -62,7 +62,7 @@ THE SOFTWARE.
  *  - Textures supported on device
  *  - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_hipCreateTextureObject_Pitch2DResource") {
+TEST_CASE(Unit_hipCreateTextureObject_Pitch2DResource) {
   CHECK_IMAGE_SUPPORT
 
   hipError_t ret;

--- a/projects/hip-tests/catch/unit/texture/hipDeviceGetTexture1DLinearMaxWidth.cc
+++ b/projects/hip-tests/catch/unit/texture/hipDeviceGetTexture1DLinearMaxWidth.cc
@@ -34,7 +34,7 @@ THE SOFTWARE.
  * ------------------------
  *    - HIP_VERSION >= 7.0
  */
-TEST_CASE("Unit_hipDeviceGetTexture1DLinearMaxWidth_Positive") {
+TEST_CASE(Unit_hipDeviceGetTexture1DLinearMaxWidth_Positive) {
   CHECK_IMAGE_SUPPORT
 
   int deviceCount = 0;
@@ -68,7 +68,7 @@ TEST_CASE("Unit_hipDeviceGetTexture1DLinearMaxWidth_Positive") {
  * ------------------------
  *    - HIP_VERSION >= 7.0
  */
-TEST_CASE("Unit_hipDeviceGetTexture1DLinearMaxWidth_Negative") {
+TEST_CASE(Unit_hipDeviceGetTexture1DLinearMaxWidth_Negative) {
   CHECK_IMAGE_SUPPORT
 
   int deviceCount = 0;

--- a/projects/hip-tests/catch/unit/texture/hipFreeMipmappedArray.cc
+++ b/projects/hip-tests/catch/unit/texture/hipFreeMipmappedArray.cc
@@ -39,7 +39,7 @@ THE SOFTWARE.
  * ------------------------
  *    - HIP_VERSION >= 5.7
  */
-TEST_CASE("Unit_hipFreeMipmappedArray_Negative_Parameters") {
+TEST_CASE(Unit_hipFreeMipmappedArray_Negative_Parameters) {
   CHECK_IMAGE_SUPPORT;
 
   SECTION("array is nullptr") {

--- a/projects/hip-tests/catch/unit/texture/hipGetChanDesc.cc
+++ b/projects/hip-tests/catch/unit/texture/hipGetChanDesc.cc
@@ -43,7 +43,7 @@ THE SOFTWARE.
  * ------------------------
  *  - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_hipGetChannelDesc_CreateAndGet") {
+TEST_CASE(Unit_hipGetChannelDesc_CreateAndGet) {
   CHECK_IMAGE_SUPPORT;
 
   hipChannelFormatDesc chan_test, chan_desc;
@@ -76,7 +76,7 @@ TEST_CASE("Unit_hipGetChannelDesc_CreateAndGet") {
  * ------------------------
  *  - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_hipGetChannelDesc_Negative_Parameters") {
+TEST_CASE(Unit_hipGetChannelDesc_Negative_Parameters) {
   CHECK_IMAGE_SUPPORT;
 
   hipChannelFormatDesc chan_test, chan_desc;

--- a/projects/hip-tests/catch/unit/texture/hipGetMipmappedArrayLevel.cc
+++ b/projects/hip-tests/catch/unit/texture/hipGetMipmappedArrayLevel.cc
@@ -39,7 +39,7 @@ THE SOFTWARE.
  * ------------------------
  *    - HIP_VERSION >= 5.7
  */
-TEST_CASE("Unit_hipGetMipmappedArrayLevel_Negative_Parameters") {
+TEST_CASE(Unit_hipGetMipmappedArrayLevel_Negative_Parameters) {
   CHECK_IMAGE_SUPPORT;
 
   hipMipmappedArray_t array;

--- a/projects/hip-tests/catch/unit/texture/hipGetTextureAlignmentOffset.cc
+++ b/projects/hip-tests/catch/unit/texture/hipGetTextureAlignmentOffset.cc
@@ -38,7 +38,7 @@ texture<float, 1, hipReadModeElementType> tex;
  * ------------------------
  *    - HIP_VERSION >= 5.7
  */
-TEST_CASE("Unit_hipGetTextureAlignmentOffset_Positive") {
+TEST_CASE(Unit_hipGetTextureAlignmentOffset_Positive) {
   CHECK_IMAGE_SUPPORT
 
   size_t offset = 0;
@@ -66,7 +66,7 @@ TEST_CASE("Unit_hipGetTextureAlignmentOffset_Positive") {
  * ------------------------
  *    - HIP_VERSION >= 5.7
  */
-TEST_CASE("Unit_hipGetTextureAlignmentOffset_Negative") {
+TEST_CASE(Unit_hipGetTextureAlignmentOffset_Negative) {
   CHECK_IMAGE_SUPPORT
   size_t offset = 0;
   size_t* tex_buf;

--- a/projects/hip-tests/catch/unit/texture/hipGetTextureReference.cc
+++ b/projects/hip-tests/catch/unit/texture/hipGetTextureReference.cc
@@ -26,7 +26,7 @@ THE SOFTWARE.
 
 texture<float, 2, hipReadModeElementType> tex;
 
-TEST_CASE("Unit_hipGetTextureReference_Positive") {
+TEST_CASE(Unit_hipGetTextureReference_Positive) {
   CHECK_IMAGE_SUPPORT
 
   const textureReference* tex_ref = nullptr;
@@ -34,7 +34,7 @@ TEST_CASE("Unit_hipGetTextureReference_Positive") {
   REQUIRE(tex_ref != nullptr);
 }
 
-TEST_CASE("Unit_hipGetTextureReference_Negative") {
+TEST_CASE(Unit_hipGetTextureReference_Negative) {
   CHECK_IMAGE_SUPPORT
 
   const textureReference* tex_ref = nullptr;

--- a/projects/hip-tests/catch/unit/texture/hipMallocMipmappedArray.cc
+++ b/projects/hip-tests/catch/unit/texture/hipMallocMipmappedArray.cc
@@ -39,7 +39,7 @@ THE SOFTWARE.
  * ------------------------
  *    - HIP_VERSION >= 5.7
  */
-TEST_CASE("Unit_hipMallocMipmappedArray_Negative_Parameters") {
+TEST_CASE(Unit_hipMallocMipmappedArray_Negative_Parameters) {
   CHECK_IMAGE_SUPPORT;
 
   hipMipmappedArray_t array;

--- a/projects/hip-tests/catch/unit/texture/hipMipmappedArrayCreate.cc
+++ b/projects/hip-tests/catch/unit/texture/hipMipmappedArrayCreate.cc
@@ -40,7 +40,7 @@ THE SOFTWARE.
  * ------------------------
  *    - HIP_VERSION >= 5.7
  */
-TEST_CASE("Unit_hipMipmappedArrayCreate_Negative_Parameters") {
+TEST_CASE(Unit_hipMipmappedArrayCreate_Negative_Parameters) {
   CHECK_IMAGE_SUPPORT;
 
   hipmipmappedArray array;

--- a/projects/hip-tests/catch/unit/texture/hipMipmappedArrayDestroy.cc
+++ b/projects/hip-tests/catch/unit/texture/hipMipmappedArrayDestroy.cc
@@ -40,7 +40,7 @@ THE SOFTWARE.
  * ------------------------
  *    - HIP_VERSION >= 5.7
  */
-TEST_CASE("Unit_hipMipmappedArrayDestroy_Negative_Parameters") {
+TEST_CASE(Unit_hipMipmappedArrayDestroy_Negative_Parameters) {
   CHECK_IMAGE_SUPPORT;
 
   SECTION("array is nullptr") {

--- a/projects/hip-tests/catch/unit/texture/hipMipmappedArrayGetLevel.cc
+++ b/projects/hip-tests/catch/unit/texture/hipMipmappedArrayGetLevel.cc
@@ -40,7 +40,7 @@ THE SOFTWARE.
  * ------------------------
  *    - HIP_VERSION >= 5.7
  */
-TEST_CASE("Unit_hipMipmappedArrayGetLevel_Negative_Parameters") {
+TEST_CASE(Unit_hipMipmappedArrayGetLevel_Negative_Parameters) {
   CHECK_IMAGE_SUPPORT;
 
   hipmipmappedArray array;

--- a/projects/hip-tests/catch/unit/texture/hipNormalizedFloatValueTex.cc
+++ b/projects/hip-tests/catch/unit/texture/hipNormalizedFloatValueTex.cc
@@ -135,7 +135,7 @@ static void runTest_hipTextureFilterMode() {
   textureTest<unsigned char, fMode>(&texuc);
 }
 
-TEST_CASE("Unit_hipNormalizedFloatValueTex_CheckModes") {
+TEST_CASE(Unit_hipNormalizedFloatValueTex_CheckModes) {
   CHECK_IMAGE_SUPPORT
 
 #if HT_AMD

--- a/projects/hip-tests/catch/unit/texture/hipSimpleTexture1DLayered.cc
+++ b/projects/hip-tests/catch/unit/texture/hipSimpleTexture1DLayered.cc
@@ -56,7 +56,7 @@ __global__ void simpleKernelLayered1DArray(hipTextureObject_t tex, TestType* out
  *  - Textures supported on device
  *  - HIP_VERSION >= 6.0
  */
-TEMPLATE_TEST_CASE("Unit_Layered1DTexture_Check_HostBufferToFromLayered1DArray", "", char,
+TEMPLATE_TEST_CASE(Unit_Layered1DTexture_Check_HostBufferToFromLayered1DArray, char,
                    unsigned char, short, ushort, int, uint, float, char1, uchar1, short1, ushort1,
                    int1, uint1, float1, char2, uchar2, short2, ushort2, int2, uint2, float2, char4,
                    uchar4, short4, ushort4, int4, uint4, float4) {
@@ -199,7 +199,7 @@ TEMPLATE_TEST_CASE("Unit_Layered1DTexture_Check_HostBufferToFromLayered1DArray",
  *  - Textures supported on device
  *  - HIP_VERSION >= 6.0
  */
-TEMPLATE_TEST_CASE("Unit_Layered1DTexture_Check_DeviceBufferToFromLayered1DArray", "", char,
+TEMPLATE_TEST_CASE(Unit_Layered1DTexture_Check_DeviceBufferToFromLayered1DArray, char,
                    unsigned char, short, ushort, int, uint, float, char1, uchar1, short1, ushort1,
                    int1, uint1, float1, char2, uchar2, short2, ushort2, int2, uint2, float2, char4,
                    uchar4, short4, ushort4, int4, uint4, float4) {

--- a/projects/hip-tests/catch/unit/texture/hipSimpleTexture2DLayered.cc
+++ b/projects/hip-tests/catch/unit/texture/hipSimpleTexture2DLayered.cc
@@ -58,7 +58,7 @@ __global__ void simpleKernelLayered2DArray(hipTextureObject_t tex, TestType* out
  *  - Textures supported on device
  *  - HIP_VERSION >= 6.0
  */
-TEMPLATE_TEST_CASE("Unit_Layered2DTexture_Check_HostBufferToFromLayered2DArray", "", char,
+TEMPLATE_TEST_CASE(Unit_Layered2DTexture_Check_HostBufferToFromLayered2DArray, char,
                    unsigned char, short, ushort, int, uint, float, char1, uchar1, short1, ushort1,
                    int1, uint1, float1, char2, uchar2, short2, ushort2, int2, uint2, float2, char4,
                    uchar4, short4, ushort4, int4, uint4, float4) {
@@ -204,7 +204,7 @@ TEMPLATE_TEST_CASE("Unit_Layered2DTexture_Check_HostBufferToFromLayered2DArray",
  *  - Textures supported on device
  *  - HIP_VERSION >= 6.0
  */
-TEMPLATE_TEST_CASE("Unit_Layered2DTexture_Check_DeviceBufferToFromLayered2DArray", "", char,
+TEMPLATE_TEST_CASE(Unit_Layered2DTexture_Check_DeviceBufferToFromLayered2DArray, char,
                    unsigned char, short, ushort, int, uint, float, char1, uchar1, short1, ushort1,
                    int1, uint1, float1, char2, uchar2, short2, ushort2, int2, uint2, float2, char4,
                    uchar4, short4, ushort4, int4, uint4, float4) {

--- a/projects/hip-tests/catch/unit/texture/hipSimpleTexture3D.cc
+++ b/projects/hip-tests/catch/unit/texture/hipSimpleTexture3D.cc
@@ -112,7 +112,7 @@ static void runSimpleTexture3D_Check(int width, int height, int depth,
   free(hOutputData);
 }
 
-TEST_CASE("Unit_hipSimpleTexture3D_Check_DataTypes") {
+TEST_CASE(Unit_hipSimpleTexture3D_Check_DataTypes) {
   CHECK_IMAGE_SUPPORT
 
 

--- a/projects/hip-tests/catch/unit/texture/hipTex1DFetchCheckModes.cc
+++ b/projects/hip-tests/catch/unit/texture/hipTex1DFetchCheckModes.cc
@@ -103,7 +103,7 @@ static void runTest(hipTextureAddressMode addressMode, hipTextureFilterMode filt
 }
 
 
-TEST_CASE("Unit_tex1Dfetch_CheckModes") {
+TEST_CASE(Unit_tex1Dfetch_CheckModes) {
   CHECK_IMAGE_SUPPORT
   (void) hipGetLastError();  // Prevent negative tests affecting this
 

--- a/projects/hip-tests/catch/unit/texture/hipTexObjPitch.cc
+++ b/projects/hip-tests/catch/unit/texture/hipTexObjPitch.cc
@@ -55,7 +55,7 @@ static __global__ void texture2dCopyKernel(hipTextureObject_t texObj, TYPE_t* ds
  *  - Textures supported on device
  *  - HIP_VERSION >= 5.2
  */
-TEMPLATE_TEST_CASE("Unit_hipTexObjPitch_texture2D", "", char, unsigned char, short, unsigned short,
+TEMPLATE_TEST_CASE(Unit_hipTexObjPitch_texture2D, char, unsigned char, short, unsigned short,
                    int, unsigned int, float) {
   CHECK_IMAGE_SUPPORT
   (void)hipGetLastError();  // Prevent negative tests affecting this

--- a/projects/hip-tests/catch/unit/texture/hipTexObjectCreate.cc
+++ b/projects/hip-tests/catch/unit/texture/hipTexObjectCreate.cc
@@ -21,7 +21,7 @@ THE SOFTWARE.
 
 #define N 256
 
-TEST_CASE("Unit_TexObjectCreate_NullptrParams") {
+TEST_CASE(Unit_TexObjectCreate_NullptrParams) {
   CHECK_IMAGE_SUPPORT
   CTX_CREATE();
 
@@ -48,7 +48,7 @@ TEST_CASE("Unit_TexObjectCreate_NullptrParams") {
   CTX_DESTROY();
 }
 
-TEST_CASE("Unit_TexObjectCreate_TypeLinear") {
+TEST_CASE(Unit_TexObjectCreate_TypeLinear) {
   CHECK_IMAGE_SUPPORT
   CTX_CREATE();
 
@@ -86,7 +86,7 @@ TEST_CASE("Unit_TexObjectCreate_TypeLinear") {
   CTX_DESTROY();
 }
 
-TEST_CASE("Unit_TexObjectCreate_TypeLinear_IncompleteInit") {
+TEST_CASE(Unit_TexObjectCreate_TypeLinear_IncompleteInit) {
   CHECK_IMAGE_SUPPORT
   CTX_CREATE();
 
@@ -159,7 +159,7 @@ TEST_CASE("Unit_TexObjectCreate_TypeLinear_IncompleteInit") {
   CTX_DESTROY();
 }
 
-TEST_CASE("Unit_TexObjectCreate_TypeLinear_EdgeCases") {
+TEST_CASE(Unit_TexObjectCreate_TypeLinear_EdgeCases) {
   CHECK_IMAGE_SUPPORT
   CTX_CREATE();
 
@@ -200,7 +200,7 @@ TEST_CASE("Unit_TexObjectCreate_TypeLinear_EdgeCases") {
   CTX_DESTROY();
 }
 
-TEST_CASE("Unit_TexObjectCreate_TypeArray") {
+TEST_CASE(Unit_TexObjectCreate_TypeArray) {
   CHECK_IMAGE_SUPPORT
   CTX_CREATE();
 
@@ -227,7 +227,7 @@ TEST_CASE("Unit_TexObjectCreate_TypeArray") {
   CTX_DESTROY();
 }
 
-TEST_CASE("Unit_TexObjectCreate_TypeArray_NullptrArray") {
+TEST_CASE(Unit_TexObjectCreate_TypeArray_NullptrArray) {
   CHECK_IMAGE_SUPPORT
   CTX_CREATE();
 
@@ -245,7 +245,7 @@ TEST_CASE("Unit_TexObjectCreate_TypeArray_NullptrArray") {
 }
 
 #if 0
-TEST_CASE("Unit_TexObjectCreate_TypeMipmapped") {
+TEST_CASE(Unit_TexObjectCreate_TypeMipmapped) {
   CHECK_IMAGE_SUPPORT
 
   hipMipmappedArray_t mipmapped_array;
@@ -272,7 +272,7 @@ TEST_CASE("Unit_TexObjectCreate_TypeMipmapped") {
   HIP_CHECK(hipFreeMipmappedArray(mipmapped_array));
 }
 
-TEST_CASE("Unit_TexObjectCreate_TypeMipmaped_IncompleteInit") {
+TEST_CASE(Unit_TexObjectCreate_TypeMipmaped_IncompleteInit) {
   CHECK_IMAGE_SUPPORT
   CTX_CREATE();
 
@@ -306,7 +306,7 @@ TEST_CASE("Unit_TexObjectCreate_TypeMipmaped_IncompleteInit") {
 }
 #endif
 
-TEST_CASE("Unit_TexObjectCreate_TypePitch2D") {
+TEST_CASE(Unit_TexObjectCreate_TypePitch2D) {
   CHECK_IMAGE_SUPPORT
   CTX_CREATE();
 
@@ -349,7 +349,7 @@ TEST_CASE("Unit_TexObjectCreate_TypePitch2D") {
   CTX_DESTROY();
 }
 
-TEST_CASE("Unit_TexObjectCreate_TypePitch2D_IncompleteInit") {
+TEST_CASE(Unit_TexObjectCreate_TypePitch2D_IncompleteInit) {
   CHECK_IMAGE_SUPPORT
   CTX_CREATE();
 
@@ -415,7 +415,7 @@ TEST_CASE("Unit_TexObjectCreate_TypePitch2D_IncompleteInit") {
   CTX_DESTROY();
 }
 
-TEST_CASE("Unit_TexObjectCreate_TypePitch2D_EdgeCases") {
+TEST_CASE(Unit_TexObjectCreate_TypePitch2D_EdgeCases) {
   CHECK_IMAGE_SUPPORT
   CTX_CREATE();
 

--- a/projects/hip-tests/catch/unit/texture/hipTexObjectTests.cc
+++ b/projects/hip-tests/catch/unit/texture/hipTexObjectTests.cc
@@ -115,7 +115,7 @@ class TexObjectTestWrapper {
  *  - Textures supported on device
  *  - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_hipGetTexObjectResourceDesc_positive") {
+TEST_CASE(Unit_hipGetTexObjectResourceDesc_positive) {
   CHECK_IMAGE_SUPPORT;
   CTX_CREATE();
 
@@ -148,7 +148,7 @@ TEST_CASE("Unit_hipGetTexObjectResourceDesc_positive") {
  *  - Textures supported on device
  *  - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_hipGetTexObjectResourceDesc_Negative_Parameters") {
+TEST_CASE(Unit_hipGetTexObjectResourceDesc_Negative_Parameters) {
   CHECK_IMAGE_SUPPORT;
   CTX_CREATE();
 
@@ -200,7 +200,7 @@ TEST_CASE("Unit_hipGetTexObjectResourceDesc_Negative_Parameters") {
  *  - Platform specific (AMD)
  *  - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_hipGetTexObjectResourceViewDesc_positive") {
+TEST_CASE(Unit_hipGetTexObjectResourceViewDesc_positive) {
   CHECK_IMAGE_SUPPORT;
   CTX_CREATE();
   TexObjectTestWrapper* tex_obj_wrapper = new TexObjectTestWrapper(true);
@@ -233,7 +233,7 @@ TEST_CASE("Unit_hipGetTexObjectResourceViewDesc_positive") {
  *  - Platform specific (AMD)
  *  - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_hipGetTexObjectResourceViewDesc_Negative_Parameters") {
+TEST_CASE(Unit_hipGetTexObjectResourceViewDesc_Negative_Parameters) {
   CHECK_IMAGE_SUPPORT;
   CTX_CREATE();
   TexObjectTestWrapper* tex_obj_wrapper = new TexObjectTestWrapper(true);
@@ -285,7 +285,7 @@ TEST_CASE("Unit_hipGetTexObjectResourceViewDesc_Negative_Parameters") {
  *  - Platform specific (AMD)
  *  - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_hipGetTexObjectTextureDesc_positive") {
+TEST_CASE(Unit_hipGetTexObjectTextureDesc_positive) {
   CHECK_IMAGE_SUPPORT;
   CTX_CREATE();
 
@@ -319,7 +319,7 @@ TEST_CASE("Unit_hipGetTexObjectTextureDesc_positive") {
  *  - Platform specific (AMD)
  *  - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_hipGetTexObjectTextureDesc_Negative_Parameters") {
+TEST_CASE(Unit_hipGetTexObjectTextureDesc_Negative_Parameters) {
   CHECK_IMAGE_SUPPORT;
   CTX_CREATE();
 
@@ -367,7 +367,7 @@ TEST_CASE("Unit_hipGetTexObjectTextureDesc_Negative_Parameters") {
  *  - Textures supported on device
  *  - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_hipTexObjectDestroy_positive") {
+TEST_CASE(Unit_hipTexObjectDestroy_positive) {
   CHECK_IMAGE_SUPPORT;
   CTX_CREATE();
 

--- a/projects/hip-tests/catch/unit/texture/hipTexRefGetAddress.cc
+++ b/projects/hip-tests/catch/unit/texture/hipTexRefGetAddress.cc
@@ -26,7 +26,7 @@ THE SOFTWARE.
 
 texture<float, 1, hipReadModeElementType> tex;
 
-TEST_CASE("Unit_hipTexRefGetAddress_Positive") {
+TEST_CASE(Unit_hipTexRefGetAddress_Positive) {
   CHECK_IMAGE_SUPPORT
   hipDeviceptr_t device_ptr;
   hipModule_t module = nullptr;
@@ -47,7 +47,7 @@ TEST_CASE("Unit_hipTexRefGetAddress_Positive") {
   HIP_CHECK(hipFree(tex_buffer));
 }
 
-TEST_CASE("Unit_hipTexRefGetAddress_Negative") {
+TEST_CASE(Unit_hipTexRefGetAddress_Negative) {
   CHECK_IMAGE_SUPPORT
   hipDeviceptr_t device_ptr;
   hipModule_t module = nullptr;
@@ -74,7 +74,7 @@ TEST_CASE("Unit_hipTexRefGetAddress_Negative") {
   HIP_CHECK(hipFree(tex_buffer));
 }
 
-TEST_CASE("Unit_hipTexRefGetAddress_AdressNotSet") {
+TEST_CASE(Unit_hipTexRefGetAddress_AdressNotSet) {
   CHECK_IMAGE_SUPPORT
   hipDeviceptr_t device_ptr;
   hipModule_t module = nullptr;

--- a/projects/hip-tests/catch/unit/texture/hipTexRefGetAddressMode.cc
+++ b/projects/hip-tests/catch/unit/texture/hipTexRefGetAddressMode.cc
@@ -23,7 +23,7 @@ THE SOFTWARE.
 
 #if defined(__HIP_PLATFORM_AMD__) || CUDA_VERSION < CUDA_12000
 
-TEST_CASE("Unit_hipTexRefGetAddressMode_Negative_Parameters") {
+TEST_CASE(Unit_hipTexRefGetAddressMode_Negative_Parameters) {
   CHECK_IMAGE_SUPPORT
 
   hipCtx_t ctx;
@@ -67,7 +67,7 @@ TEST_CASE("Unit_hipTexRefGetAddressMode_Negative_Parameters") {
   HIP_CHECK(hipCtxDestroy(ctx));
 }
 
-TEST_CASE("Unit_hipTexRefGetAddressMode_Positive") {
+TEST_CASE(Unit_hipTexRefGetAddressMode_Positive) {
   CHECK_IMAGE_SUPPORT
 
   hipCtx_t ctx;

--- a/projects/hip-tests/catch/unit/texture/hipTexRefGetArray.cc
+++ b/projects/hip-tests/catch/unit/texture/hipTexRefGetArray.cc
@@ -23,7 +23,7 @@ THE SOFTWARE.
 
 texture<float, 1, hipReadModeElementType> tex;
 
-TEST_CASE("Unit_hipTexRefGetArray_Positive") {
+TEST_CASE(Unit_hipTexRefGetArray_Positive) {
   CHECK_IMAGE_SUPPORT
   hipArray_t array_set = nullptr;
   hipArray_t array_get = nullptr;
@@ -47,7 +47,7 @@ TEST_CASE("Unit_hipTexRefGetArray_Positive") {
   HIP_CHECK(hipModuleUnload(module));
 }
 
-TEST_CASE("Unit_hipTexRefGetArray_Negative") {
+TEST_CASE(Unit_hipTexRefGetArray_Negative) {
   CHECK_IMAGE_SUPPORT
   hipArray_t array_set = nullptr;
   hipArray_t array_get = nullptr;

--- a/projects/hip-tests/catch/unit/texture/hipTexRefGetBorderColor.cc
+++ b/projects/hip-tests/catch/unit/texture/hipTexRefGetBorderColor.cc
@@ -26,7 +26,7 @@ texture<float, 1, hipReadModeElementType> tex;
 
 // It will be added for HIP in ROCm7.0
 #if HT_NVIDIA
-TEST_CASE("Unit_hipTexRefGetBorderColor_Positive") {
+TEST_CASE(Unit_hipTexRefGetBorderColor_Positive) {
   CHECK_IMAGE_SUPPORT
   float set_border_color[3] = {1, 2, 3};
   float get_border_color[3] = {0, 0, 0};
@@ -47,7 +47,7 @@ TEST_CASE("Unit_hipTexRefGetBorderColor_Positive") {
 }
 #endif
 
-TEST_CASE("Unit_hipTexRefGetBorderColor_Negative") {
+TEST_CASE(Unit_hipTexRefGetBorderColor_Negative) {
   CHECK_IMAGE_SUPPORT
   float border_color[3] = {0, 0, 0};
   hipModule_t module = nullptr;

--- a/projects/hip-tests/catch/unit/texture/hipTexRefGetFlags.cc
+++ b/projects/hip-tests/catch/unit/texture/hipTexRefGetFlags.cc
@@ -23,7 +23,7 @@ THE SOFTWARE.
 
 #if defined(__HIP_PLATFORM_AMD__) || CUDA_VERSION < CUDA_12000
 
-TEST_CASE("Unit_hipTexRefGetFlags_Negative_Parameters") {
+TEST_CASE(Unit_hipTexRefGetFlags_Negative_Parameters) {
   CHECK_IMAGE_SUPPORT
 
   hipCtx_t ctx;
@@ -55,7 +55,7 @@ TEST_CASE("Unit_hipTexRefGetFlags_Negative_Parameters") {
   HIP_CHECK(hipCtxDestroy(ctx));
 }
 
-TEST_CASE("Unit_hipTexRefGetFlags_Positive") {
+TEST_CASE(Unit_hipTexRefGetFlags_Positive) {
   CHECK_IMAGE_SUPPORT
 
   hipCtx_t ctx;

--- a/projects/hip-tests/catch/unit/texture/hipTexRefGetFormat.cc
+++ b/projects/hip-tests/catch/unit/texture/hipTexRefGetFormat.cc
@@ -23,7 +23,7 @@ THE SOFTWARE.
 
 texture<float, 2, hipReadModeElementType> tex;
 
-TEST_CASE("Unit_hipTexRefGetFormat_Basic") {
+TEST_CASE(Unit_hipTexRefGetFormat_Basic) {
   CHECK_IMAGE_SUPPORT
   hipModule_t module = nullptr;
   hipTexRef tex_ref = nullptr;
@@ -44,7 +44,7 @@ TEST_CASE("Unit_hipTexRefGetFormat_Basic") {
   HIP_CHECK(hipModuleUnload(module));
 }
 
-TEST_CASE("Unit_hipTexRefGetFormat_Positive") {
+TEST_CASE(Unit_hipTexRefGetFormat_Positive) {
   CHECK_IMAGE_SUPPORT
   hipModule_t module = nullptr;
   hipTexRef tex_ref = nullptr;
@@ -75,7 +75,7 @@ TEST_CASE("Unit_hipTexRefGetFormat_Positive") {
   HIP_CHECK(hipModuleUnload(module));
 }
 
-TEST_CASE("Unit_hipTexRefGetFormat_Negative") {
+TEST_CASE(Unit_hipTexRefGetFormat_Negative) {
   CHECK_IMAGE_SUPPORT
   hipModule_t module = nullptr;
   hipTexRef tex_ref = nullptr;

--- a/projects/hip-tests/catch/unit/texture/hipTexRefGetMaxAnisotropy.cc
+++ b/projects/hip-tests/catch/unit/texture/hipTexRefGetMaxAnisotropy.cc
@@ -23,7 +23,7 @@ THE SOFTWARE.
 
 #if defined(__HIP_PLATFORM_AMD__) || CUDA_VERSION < CUDA_12000
 
-TEST_CASE("Unit_hipTexRefGetMaxAnisotropy_Negative_Parameters") {
+TEST_CASE(Unit_hipTexRefGetMaxAnisotropy_Negative_Parameters) {
   CHECK_IMAGE_SUPPORT
 
   hipCtx_t ctx;
@@ -56,7 +56,7 @@ TEST_CASE("Unit_hipTexRefGetMaxAnisotropy_Negative_Parameters") {
   HIP_CHECK(hipCtxDestroy(ctx));
 }
 
-TEST_CASE("Unit_hipTexRefGetMaxAnisotropy_Positive") {
+TEST_CASE(Unit_hipTexRefGetMaxAnisotropy_Positive) {
   CHECK_IMAGE_SUPPORT
 
   hipCtx_t ctx;

--- a/projects/hip-tests/catch/unit/texture/hipTexRefSetAddress.cc
+++ b/projects/hip-tests/catch/unit/texture/hipTexRefSetAddress.cc
@@ -26,7 +26,7 @@ THE SOFTWARE.
 
 texture<float, 1, hipReadModeElementType> tex;
 
-TEST_CASE("Unit_hipTexRefSetAddress_Basic") {
+TEST_CASE(Unit_hipTexRefSetAddress_Basic) {
   CHECK_IMAGE_SUPPORT
   hipDeviceptr_t device_ptr;
   hipModule_t module = nullptr;
@@ -47,7 +47,7 @@ TEST_CASE("Unit_hipTexRefSetAddress_Basic") {
   HIP_CHECK(hipFree(tex_buffer));
 }
 
-TEST_CASE("Unit_hipTexRefSetAddress_Positive") {
+TEST_CASE(Unit_hipTexRefSetAddress_Positive) {
   CHECK_IMAGE_SUPPORT
   hipModule_t module = nullptr;
   hipTexRef tex_ref = nullptr;
@@ -73,7 +73,7 @@ TEST_CASE("Unit_hipTexRefSetAddress_Positive") {
   HIP_CHECK(hipFree(tex_buffer));
 }
 
-TEST_CASE("Unit_hipTexRefSetAddress_Negative") {
+TEST_CASE(Unit_hipTexRefSetAddress_Negative) {
   CHECK_IMAGE_SUPPORT
   hipModule_t module = nullptr;
   hipTexRef tex_ref = nullptr;

--- a/projects/hip-tests/catch/unit/texture/hipTexRefSetAddress2D.cc
+++ b/projects/hip-tests/catch/unit/texture/hipTexRefSetAddress2D.cc
@@ -23,7 +23,7 @@ THE SOFTWARE.
 
 #if defined(__HIP_PLATFORM_AMD__) || CUDA_VERSION < CUDA_12000
 
-TEST_CASE("Unit_hipTexRefSetAddress2D_Negative_Parameters") {
+TEST_CASE(Unit_hipTexRefSetAddress2D_Negative_Parameters) {
   CHECK_IMAGE_SUPPORT
 
   constexpr int width = 256;
@@ -79,7 +79,7 @@ TEST_CASE("Unit_hipTexRefSetAddress2D_Negative_Parameters") {
   HIP_CHECK(hipCtxDestroy(ctx));
 }
 
-TEST_CASE("Unit_hipTexRefSetAddress2D_Positive") {
+TEST_CASE(Unit_hipTexRefSetAddress2D_Positive) {
   CHECK_IMAGE_SUPPORT
 
   constexpr int width = 256;

--- a/projects/hip-tests/catch/unit/texture/hipTexRefSetAddressMode.cc
+++ b/projects/hip-tests/catch/unit/texture/hipTexRefSetAddressMode.cc
@@ -22,7 +22,7 @@ THE SOFTWARE.
 
 #if defined(__HIP_PLATFORM_AMD__) || CUDA_VERSION < CUDA_12000
 
-TEST_CASE("Unit_hipTexRefSetAddressMode_Negative_Parameters") {
+TEST_CASE(Unit_hipTexRefSetAddressMode_Negative_Parameters) {
   CHECK_IMAGE_SUPPORT
 
   hipCtx_t ctx;
@@ -60,7 +60,7 @@ TEST_CASE("Unit_hipTexRefSetAddressMode_Negative_Parameters") {
   HIP_CHECK(hipCtxDestroy(ctx));
 }
 
-TEST_CASE("Unit_hipTexRefSetAddressMode_Positive") {
+TEST_CASE(Unit_hipTexRefSetAddressMode_Positive) {
   CHECK_IMAGE_SUPPORT
 
   hipCtx_t ctx;

--- a/projects/hip-tests/catch/unit/texture/hipTexRefSetArray.cc
+++ b/projects/hip-tests/catch/unit/texture/hipTexRefSetArray.cc
@@ -23,7 +23,7 @@ THE SOFTWARE.
 
 texture<float, 1, hipReadModeElementType> tex;
 
-TEST_CASE("Unit_hipTexRefSetArray_Positive") {
+TEST_CASE(Unit_hipTexRefSetArray_Positive) {
   CHECK_IMAGE_SUPPORT
   hipArray_t array_set = nullptr;
   hipArray_t array_get = nullptr;
@@ -47,7 +47,7 @@ TEST_CASE("Unit_hipTexRefSetArray_Positive") {
   HIP_CHECK(hipModuleUnload(module));
 }
 
-TEST_CASE("Unit_hipTexRefSetArray_CheckData") {
+TEST_CASE(Unit_hipTexRefSetArray_CheckData) {
   CHECK_IMAGE_SUPPORT
   hipModule_t module = nullptr;
   hipTexRef tex_ref = nullptr;
@@ -76,7 +76,7 @@ TEST_CASE("Unit_hipTexRefSetArray_CheckData") {
   HIP_CHECK(hipModuleUnload(module));
 }
 
-TEST_CASE("Unit_hipTexRefSetArray_Negative") {
+TEST_CASE(Unit_hipTexRefSetArray_Negative) {
   CHECK_IMAGE_SUPPORT
   hipArray_t array_set = nullptr;
   hipModule_t module = nullptr;

--- a/projects/hip-tests/catch/unit/texture/hipTexRefSetBorderColor.cc
+++ b/projects/hip-tests/catch/unit/texture/hipTexRefSetBorderColor.cc
@@ -26,7 +26,7 @@ texture<float, 1, hipReadModeElementType> tex;
 
 // It will be added for HIP in ROCm7.0
 #if HT_NVIDIA
-TEST_CASE("Unit_hipTexRefSetBorderColor_Positive") {
+TEST_CASE(Unit_hipTexRefSetBorderColor_Positive) {
   float set_border_color[3] = {1, 2, 3};
   float get_border_color[3] = {0, 0, 0};
   hipModule_t module = nullptr;
@@ -46,7 +46,7 @@ TEST_CASE("Unit_hipTexRefSetBorderColor_Positive") {
 }
 #endif
 
-TEST_CASE("Unit_hipTexRefSetBorderColor_Negative") {
+TEST_CASE(Unit_hipTexRefSetBorderColor_Negative) {
   CHECK_IMAGE_SUPPORT
   float border_color[3] = {0, 0, 0};
   hipModule_t module = nullptr;

--- a/projects/hip-tests/catch/unit/texture/hipTexRefSetFlags.cc
+++ b/projects/hip-tests/catch/unit/texture/hipTexRefSetFlags.cc
@@ -23,7 +23,7 @@ THE SOFTWARE.
 
 #if defined(__HIP_PLATFORM_AMD__) || CUDA_VERSION < CUDA_12000
 
-TEST_CASE("Unit_hipTexRefSetFlags_Negative_Parameters") {
+TEST_CASE(Unit_hipTexRefSetFlags_Negative_Parameters) {
   CHECK_IMAGE_SUPPORT
 
   hipCtx_t ctx;
@@ -50,7 +50,7 @@ TEST_CASE("Unit_hipTexRefSetFlags_Negative_Parameters") {
   HIP_CHECK(hipCtxDestroy(ctx));
 }
 
-TEST_CASE("Unit_hipTexRefSetFlags_Positive") {
+TEST_CASE(Unit_hipTexRefSetFlags_Positive) {
   CHECK_IMAGE_SUPPORT
 
   hipCtx_t ctx;

--- a/projects/hip-tests/catch/unit/texture/hipTexRefSetFormat.cc
+++ b/projects/hip-tests/catch/unit/texture/hipTexRefSetFormat.cc
@@ -23,7 +23,7 @@ THE SOFTWARE.
 
 texture<float, 2, hipReadModeElementType> tex;
 
-TEST_CASE("Unit_hipTexRefSetFormat_Positive") {
+TEST_CASE(Unit_hipTexRefSetFormat_Positive) {
   CHECK_IMAGE_SUPPORT
   hipModule_t module = nullptr;
   hipTexRef tex_ref = nullptr;
@@ -44,7 +44,7 @@ TEST_CASE("Unit_hipTexRefSetFormat_Positive") {
   HIP_CHECK(hipModuleUnload(module));
 }
 
-TEST_CASE("Unit_hipTexRefSetFormat_Negative") {
+TEST_CASE(Unit_hipTexRefSetFormat_Negative) {
   CHECK_IMAGE_SUPPORT
   hipModule_t module = nullptr;
   hipTexRef tex_ref = nullptr;

--- a/projects/hip-tests/catch/unit/texture/hipTexRefSetGetFilterMode.cc
+++ b/projects/hip-tests/catch/unit/texture/hipTexRefSetGetFilterMode.cc
@@ -21,7 +21,7 @@ THE SOFTWARE.
 #if defined(__HIP_PLATFORM_AMD__) || CUDA_VERSION < CUDA_12000
 texture<float, 2, hipReadModeElementType> tex;
 // Test for hipTexRefSetFilterMode and hipTexRefGetFilterMode, including error handling
-TEST_CASE("Unit_hipTexRefSetGetFilterMode") {
+TEST_CASE(Unit_hipTexRefSetGetFilterMode) {
   CHECK_IMAGE_SUPPORT;
 
   // Retrieve the texture reference for our symbol

--- a/projects/hip-tests/catch/unit/texture/hipTexRefSetGetMipmapFilterMode.cc
+++ b/projects/hip-tests/catch/unit/texture/hipTexRefSetGetMipmapFilterMode.cc
@@ -21,7 +21,7 @@ THE SOFTWARE.
 #if defined(__HIP_PLATFORM_AMD__) || CUDA_VERSION < CUDA_12000
 texture<float, 2, hipReadModeElementType> tex;
 // Test for hipTexRefSetMipmapFilterMode and hipTexRefGetMipmapFilterMode, including error handling
-TEST_CASE("Unit_hipTexRefSetGetMipmapFilterMode") {
+TEST_CASE(Unit_hipTexRefSetGetMipmapFilterMode) {
   CHECK_IMAGE_SUPPORT;
 
   // Retrieve the texture reference for our symbol

--- a/projects/hip-tests/catch/unit/texture/hipTexRefSetGetMipmapLevelBias.cc
+++ b/projects/hip-tests/catch/unit/texture/hipTexRefSetGetMipmapLevelBias.cc
@@ -21,7 +21,7 @@ THE SOFTWARE.
 #if defined(__HIP_PLATFORM_AMD__) || CUDA_VERSION < CUDA_12000
 texture<float, 2, hipReadModeElementType> tex;
 // Test for hipTexRefSetMipmapLevelBias and hipTexRefGetMipmapLevelBias, including error handling
-TEST_CASE("Unit_hipTexRefSetGetMipmapLevelBias") {
+TEST_CASE(Unit_hipTexRefSetGetMipmapLevelBias) {
   CHECK_IMAGE_SUPPORT;
 
   // Retrieve the texture reference for our symbol

--- a/projects/hip-tests/catch/unit/texture/hipTexRefSetGetMipmapLevelClamp.cc
+++ b/projects/hip-tests/catch/unit/texture/hipTexRefSetGetMipmapLevelClamp.cc
@@ -22,7 +22,7 @@ THE SOFTWARE.
 #if defined(__HIP_PLATFORM_AMD__) || CUDA_VERSION < CUDA_12000
 texture<float, 2, hipReadModeElementType> tex;
 // Test for hipTexRefSetMipmapLevelClamp and hipTexRefGetMipmapLevelClamp, including error handling
-TEST_CASE("Unit_texRefSetGetMipmapLevelClamp") {
+TEST_CASE(Unit_texRefSetGetMipmapLevelClamp) {
   CHECK_IMAGE_SUPPORT;
 
   // Retrieve the texture reference for our symbol

--- a/projects/hip-tests/catch/unit/texture/hipTexRefSetGetMipmappedArray.cc
+++ b/projects/hip-tests/catch/unit/texture/hipTexRefSetGetMipmappedArray.cc
@@ -21,7 +21,7 @@ THE SOFTWARE.
 texture<float, 2, hipReadModeElementType> tex;
 
 // Test for hipTexRefSetMipmappedArray and hipTexRefGetMipmappedArray, including error handling
-TEST_CASE("Unit_hipTexRefSetGetMipmappedArray") {
+TEST_CASE(Unit_hipTexRefSetGetMipmappedArray) {
   CHECK_IMAGE_SUPPORT;
 
   // Retrieve the texture reference for our symbol

--- a/projects/hip-tests/catch/unit/texture/hipTexRefSetMaxAnisotropy.cc
+++ b/projects/hip-tests/catch/unit/texture/hipTexRefSetMaxAnisotropy.cc
@@ -23,7 +23,7 @@ THE SOFTWARE.
 
 #if defined(__HIP_PLATFORM_AMD__) || CUDA_VERSION < CUDA_12000
 
-TEST_CASE("Unit_hipTexRefSetMaxAnisotropy_Negative_Parameters") {
+TEST_CASE(Unit_hipTexRefSetMaxAnisotropy_Negative_Parameters) {
   CHECK_IMAGE_SUPPORT
 
   hipCtx_t ctx;
@@ -52,7 +52,7 @@ TEST_CASE("Unit_hipTexRefSetMaxAnisotropy_Negative_Parameters") {
   HIP_CHECK(hipCtxDestroy(ctx));
 }
 
-TEST_CASE("Unit_hipTexRefSetMaxAnisotropy_Positive") {
+TEST_CASE(Unit_hipTexRefSetMaxAnisotropy_Positive) {
   CHECK_IMAGE_SUPPORT
 
   hipCtx_t ctx;

--- a/projects/hip-tests/catch/unit/texture/hipTextureMipmapObj1D.cc
+++ b/projects/hip-tests/catch/unit/texture/hipTextureMipmapObj1D.cc
@@ -305,32 +305,32 @@ static void testMipmapTextureObj(size_t width, float offsetX = 0.) {
  *  - Textures supported on device
  *  - HIP_VERSION >= 5.7
  */
-TEMPLATE_TEST_CASE("Unit_hipTextureMipmapObj1D_Check_hipReadModeElementType", "", char, uchar,
-                   short, ushort, int, uint, float, char1, uchar1, short1, ushort1, int1, uint1,
-                   float1, char2, uchar2, short2, ushort2, int2, uint2, float2, char4, uchar4,
-                   short4, ushort4, int4, uint4, float4) {
+TEMPLATE_TEST_CASE(Unit_hipTextureMipmapObj1D_Check_hipReadModeElementType, char, uchar, short,
+                   ushort, int, uint, float, char1, uchar1, short1, ushort1, int1, uint1, float1,
+                   char2, uchar2, short2, ushort2, int2, uint2, float2, char4, uchar4, short4,
+                   ushort4, int4, uint4, float4) {
   CHECK_IMAGE_SUPPORT
 
   SECTION(
-      "Unit_hipTextureMipmapObj1D_Check - hipReadModeElementType, hipFilterModePoint, "
+      "hipTextureMipmapObj1D_Check - hipReadModeElementType, hipFilterModePoint, "
       "hipAddressModeClamp 23") {
     testMipmapTextureObj<TestType, hipReadModeElementType, hipFilterModePoint, hipAddressModeClamp>(
         23, 0.49);
   }
   SECTION(
-      "Unit_hipTextureMipmapObj1D_Check - hipReadModeElementType, hipFilterModePoint, "
+      "hipTextureMipmapObj1D_Check - hipReadModeElementType, hipFilterModePoint, "
       "hipAddressModeClamp 67") {
     testMipmapTextureObj<TestType, hipReadModeElementType, hipFilterModePoint, hipAddressModeClamp>(
         67, -0.3);
   }
   SECTION(
-      "Unit_hipTextureMipmapObj1D_Check - hipReadModeElementType, hipFilterModePoint, "
+      "hipTextureMipmapObj1D_Check - hipReadModeElementType, hipFilterModePoint, "
       "hipAddressModeBorder 131") {
     testMipmapTextureObj<TestType, hipReadModeElementType, hipFilterModePoint,
                          hipAddressModeBorder>(131, 0.15);
   }
   SECTION(
-      "Unit_hipTextureMipmapObj1D_Check - hipReadModeElementType, hipFilterModePoint, "
+      "hipTextureMipmapObj1D_Check - hipReadModeElementType, hipFilterModePoint, "
       "hipAddressModeBorder 263") {
     testMipmapTextureObj<TestType, hipReadModeElementType, hipFilterModePoint,
                          hipAddressModeBorder>(263, 0.96);
@@ -355,55 +355,55 @@ TEMPLATE_TEST_CASE("Unit_hipTextureMipmapObj1D_Check_hipReadModeElementType", ""
  *  - Textures supported on device
  *  - HIP_VERSION >= 5.7
  */
-TEMPLATE_TEST_CASE("Unit_hipTextureMipmapObj1D_Check_hipReadModeNormalizedFloat", "", char, uchar,
-                   short, ushort, char1, uchar1, short1, ushort1, char2, uchar2, short2, ushort2,
-                   char4, uchar4, short4, ushort4) {
+TEMPLATE_TEST_CASE(Unit_hipTextureMipmapObj1D_Check_hipReadModeNormalizedFloat, char, uchar, short,
+                   ushort, char1, uchar1, short1, ushort1, char2, uchar2, short2, ushort2, char4,
+                   uchar4, short4, ushort4) {
   CHECK_IMAGE_SUPPORT
 
   SECTION(
-      "Unit_hipTextureMipmapObj1D_Check - hipReadModeNormalizedFloat, hipFilterModePoint, "
+      "hipTextureMipmapObj1D_Check - hipReadModeNormalizedFloat, hipFilterModePoint, "
       "hipAddressModeClamp 23") {
     testMipmapTextureObj<TestType, hipReadModeNormalizedFloat, hipFilterModePoint,
                          hipAddressModeClamp>(23, -0.9);
   }
   SECTION(
-      "Unit_hipTextureMipmapObj1D_Check - hipReadModeNormalizedFloat, hipFilterModePoint, "
+      "hipTextureMipmapObj1D_Check - hipReadModeNormalizedFloat, hipFilterModePoint, "
       "hipAddressModeClamp 131") {
     testMipmapTextureObj<TestType, hipReadModeNormalizedFloat, hipFilterModePoint,
                          hipAddressModeClamp>(131, 0.15);
   }
   SECTION(
-      "Unit_hipTextureMipmapObj1D_Check - hipReadModeNormalizedFloat, hipFilterModeLinear, "
+      "hipTextureMipmapObj1D_Check - hipReadModeNormalizedFloat, hipFilterModeLinear, "
       "hipAddressModeClamp 67") {
     testMipmapTextureObj<TestType, hipReadModeNormalizedFloat, hipFilterModeLinear,
                          hipAddressModeClamp>(67, -0.3);
   }
   SECTION(
-      "Unit_hipTextureMipmapObj1D_Check - hipReadModeNormalizedFloat, hipFilterModeLinear, "
+      "hipTextureMipmapObj1D_Check - hipReadModeNormalizedFloat, hipFilterModeLinear, "
       "hipAddressModeClamp 263") {
     testMipmapTextureObj<TestType, hipReadModeNormalizedFloat, hipFilterModeLinear,
                          hipAddressModeClamp>(263, 0.13);
   }
   SECTION(
-      "Unit_hipTextureMipmapObj1D_Check - hipReadModeNormalizedFloat, hipFilterModePoint, "
+      "hipTextureMipmapObj1D_Check - hipReadModeNormalizedFloat, hipFilterModePoint, "
       "hipAddressModeBorder 131") {
     testMipmapTextureObj<TestType, hipReadModeNormalizedFloat, hipFilterModePoint,
                          hipAddressModeBorder>(131, -0.34);
   }
   SECTION(
-      "Unit_hipTextureMipmapObj1D_Check - hipReadModeNormalizedFloat, hipFilterModePoint, "
+      "hipTextureMipmapObj1D_Check - hipReadModeNormalizedFloat, hipFilterModePoint, "
       "hipAddressModeBorder 23") {
     testMipmapTextureObj<TestType, hipReadModeNormalizedFloat, hipFilterModePoint,
                          hipAddressModeBorder>(23, 0.4);
   }
   SECTION(
-      "Unit_hipTextureMipmapObj1D_Check - hipReadModeNormalizedFloat, hipFilterModeLinear, "
+      "hipTextureMipmapObj1D_Check - hipReadModeNormalizedFloat, hipFilterModeLinear, "
       "hipAddressModeBorder 263") {
     testMipmapTextureObj<TestType, hipReadModeNormalizedFloat, hipFilterModeLinear,
                          hipAddressModeBorder>(263, 0.96);
   }
   SECTION(
-      "Unit_hipTextureMipmapObj1D_Check - hipReadModeNormalizedFloat, hipFilterModeLinear, "
+      "hipTextureMipmapObj1D_Check - hipReadModeNormalizedFloat, hipFilterModeLinear, "
       "hipAddressModeBorder 67") {
     testMipmapTextureObj<TestType, hipReadModeNormalizedFloat, hipFilterModeLinear,
                          hipAddressModeBorder>(67, -0.67);
@@ -429,36 +429,36 @@ TEMPLATE_TEST_CASE("Unit_hipTextureMipmapObj1D_Check_hipReadModeNormalizedFloat"
  *  - Textures supported on device
  *  - HIP_VERSION >= 5.7
  */
-TEMPLATE_TEST_CASE("Unit_hipTextureMipmapObj1D_Check_hipReadModeElementType_float_only", "",
-                   float, float1, float2, float4) {
+TEMPLATE_TEST_CASE(Unit_hipTextureMipmapObj1D_Check_hipReadModeElementType_float_only, float,
+                   float1, float2, float4) {
   CHECK_IMAGE_SUPPORT
 
   SECTION(
-      "Unit_hipTextureMipmapObj1D_Check - hipReadModeElementType, hipFilterModeLinear, "
+      "hipTextureMipmapObj1D_Check - hipReadModeElementType, hipFilterModeLinear, "
       "hipAddressModeClamp 23, 0.") {
     testMipmapTextureObj<TestType, hipReadModeElementType, hipFilterModeLinear,
                          hipAddressModeClamp>(23, 0.7);
   }
   SECTION(
-      "Unit_hipTextureMipmapObj1D_Check - hipReadModeElementType, hipFilterModeLinear, "
+      "hipTextureMipmapObj1D_Check - hipReadModeElementType, hipFilterModeLinear, "
       "hipAddressModeClamp 23") {
     testMipmapTextureObj<TestType, hipReadModeElementType, hipFilterModeLinear,
                          hipAddressModeClamp>(23, -0.67);
   }
   SECTION(
-      "Unit_hipTextureMipmapObj1D_Check - hipReadModeElementType, hipFilterModeLinear, "
+      "hipTextureMipmapObj1D_Check - hipReadModeElementType, hipFilterModeLinear, "
       "hipAddressModeClamp 263") {
     testMipmapTextureObj<TestType, hipReadModeElementType, hipFilterModeLinear,
                          hipAddressModeClamp>(263, 0.13);
   }
   SECTION(
-      "Unit_hipTextureMipmapObj1D_Check - hipReadModeElementType, hipFilterModeLinear, "
+      "hipTextureMipmapObj1D_Check - hipReadModeElementType, hipFilterModeLinear, "
       "hipAddressModeBorder 131") {
     testMipmapTextureObj<TestType, hipReadModeElementType, hipFilterModeLinear,
                          hipAddressModeBorder>(131, 0.96);
   }
   SECTION(
-      "Unit_hipTextureMipmapObj1D_Check - hipReadModeElementType, hipFilterModeLinear, "
+      "hipTextureMipmapObj1D_Check - hipReadModeElementType, hipFilterModeLinear, "
       "hipAddressModeBorder 67") {
     testMipmapTextureObj<TestType, hipReadModeElementType, hipFilterModeLinear,
                          hipAddressModeBorder>(67, -0.97);

--- a/projects/hip-tests/catch/unit/texture/hipTextureMipmapObj2D.cc
+++ b/projects/hip-tests/catch/unit/texture/hipTextureMipmapObj2D.cc
@@ -338,32 +338,32 @@ static void testMipmapTextureObj(size_t width, size_t height, float offsetX = 0.
  *  - Textures supported on device
  *  - HIP_VERSION >= 5.7
  */
-TEMPLATE_TEST_CASE("Unit_hipTextureMipmapObj2D_Check_hipReadModeElementType", "", char, uchar,
-                   short, ushort, int, uint, float, char1, uchar1, short1, ushort1, int1, uint1,
-                   float1, char2, uchar2, short2, ushort2, int2, uint2, float2, char4, uchar4,
-                   short4, ushort4, int4, uint4, float4) {
+TEMPLATE_TEST_CASE(Unit_hipTextureMipmapObj2D_Check_hipReadModeElementType, char, uchar, short,
+                   ushort, int, uint, float, char1, uchar1, short1, ushort1, int1, uint1, float1,
+                   char2, uchar2, short2, ushort2, int2, uint2, float2, char4, uchar4, short4,
+                   ushort4, int4, uint4, float4) {
   CHECK_IMAGE_SUPPORT
 
   SECTION(
-      "Unit_hipTextureMipmapObj2D_Check - hipReadModeElementType, hipFilterModePoint, "
+      "hipTextureMipmapObj2D_Check - hipReadModeElementType, hipFilterModePoint, "
       "hipAddressModeClamp 23, 21") {
     testMipmapTextureObj<TestType, hipReadModeElementType, hipFilterModePoint, hipAddressModeClamp>(
         23, 21, 0.4, -0.9);
   }
   SECTION(
-      "Unit_hipTextureMipmapObj2D_Check - hipReadModeElementType, hipFilterModePoint, "
+      "hipTextureMipmapObj2D_Check - hipReadModeElementType, hipFilterModePoint, "
       "hipAddressModeClamp 67, 131") {
     testMipmapTextureObj<TestType, hipReadModeElementType, hipFilterModePoint, hipAddressModeClamp>(
         67, 131, -0.3, -0.67);
   }
   SECTION(
-      "Unit_hipTextureMipmapObj2D_Check - hipReadModeElementType, hipFilterModePoint, "
+      "hipTextureMipmapObj2D_Check - hipReadModeElementType, hipFilterModePoint, "
       "hipAddressModeBorder 131, 263") {
     testMipmapTextureObj<TestType, hipReadModeElementType, hipFilterModePoint,
                          hipAddressModeBorder>(131, 263, 0.15, -0.34);
   }
   SECTION(
-      "Unit_hipTextureMipmapObj2D_Check - hipReadModeElementType, hipFilterModePoint, "
+      "hipTextureMipmapObj2D_Check - hipReadModeElementType, hipFilterModePoint, "
       "hipAddressModeBorder 263, 67") {
     testMipmapTextureObj<TestType, hipReadModeElementType, hipFilterModePoint,
                          hipAddressModeBorder>(263, 67, 0.13, 0.96);
@@ -388,55 +388,55 @@ TEMPLATE_TEST_CASE("Unit_hipTextureMipmapObj2D_Check_hipReadModeElementType", ""
  *  - Textures supported on device
  *  - HIP_VERSION >= 5.7
  */
-TEMPLATE_TEST_CASE("Unit_hipTextureMipmapObj2D_Check_hipReadModeNormalizedFloat", "", char, uchar,
-                   short, ushort, char1, uchar1, short1, ushort1, char2, uchar2, short2, ushort2,
-                   char4, uchar4, short4, ushort4) {
+TEMPLATE_TEST_CASE(Unit_hipTextureMipmapObj2D_Check_hipReadModeNormalizedFloat, char, uchar, short,
+                   ushort, char1, uchar1, short1, ushort1, char2, uchar2, short2, ushort2, char4,
+                   uchar4, short4, ushort4) {
   CHECK_IMAGE_SUPPORT
 
   SECTION(
-      "Unit_hipTextureMipmapObj2D_Check - hipReadModeNormalizedFloat, hipFilterModePoint, "
+      "hipTextureMipmapObj2D_Check - hipReadModeNormalizedFloat, hipFilterModePoint, "
       "hipAddressModeClamp 23, 21") {
     testMipmapTextureObj<TestType, hipReadModeNormalizedFloat, hipFilterModePoint,
                          hipAddressModeClamp>(23, 21, 0.4, -0.9);
   }
   SECTION(
-      "Unit_hipTextureMipmapObj2D_Check - hipReadModeNormalizedFloat, hipFilterModePoint, "
+      "hipTextureMipmapObj2D_Check - hipReadModeNormalizedFloat, hipFilterModePoint, "
       "hipAddressModeClamp 131, 263") {
     testMipmapTextureObj<TestType, hipReadModeNormalizedFloat, hipFilterModePoint,
                          hipAddressModeClamp>(131, 263, 0.15, -0.34);
   }
   SECTION(
-      "Unit_hipTextureMipmapObj2D_Check - hipReadModeNormalizedFloat, hipFilterModeLinear, "
+      "hipTextureMipmapObj2D_Check - hipReadModeNormalizedFloat, hipFilterModeLinear, "
       "hipAddressModeClamp 67, 131") {
     testMipmapTextureObj<TestType, hipReadModeNormalizedFloat, hipFilterModeLinear,
                          hipAddressModeClamp>(23, 17, -0.3, -0.67);
   }
   SECTION(
-      "Unit_hipTextureMipmapObj2D_Check - hipReadModeNormalizedFloat, hipFilterModeLinear, "
+      "hipTextureMipmapObj2D_Check - hipReadModeNormalizedFloat, hipFilterModeLinear, "
       "hipAddressModeClamp 263, 67") {
     testMipmapTextureObj<TestType, hipReadModeNormalizedFloat, hipFilterModeLinear,
                          hipAddressModeClamp>(263, 67, 0.13, 0.96);
   }
   SECTION(
-      "Unit_hipTextureMipmapObj2D_Check - hipReadModeNormalizedFloat, hipFilterModePoint, "
+      "hipTextureMipmapObj2D_Check - hipReadModeNormalizedFloat, hipFilterModePoint, "
       "hipAddressModeBorder 131, 263") {
     testMipmapTextureObj<TestType, hipReadModeNormalizedFloat, hipFilterModePoint,
                          hipAddressModeBorder>(131, 263, 0.15, -0.34);
   }
   SECTION(
-      "Unit_hipTextureMipmapObj2D_Check - hipReadModeNormalizedFloat, hipFilterModePoint, "
+      "hipTextureMipmapObj2D_Check - hipReadModeNormalizedFloat, hipFilterModePoint, "
       "hipAddressModeBorder 23, 21") {
     testMipmapTextureObj<TestType, hipReadModeNormalizedFloat, hipFilterModePoint,
                          hipAddressModeBorder>(23, 21, 0.4, -0.9);
   }
   SECTION(
-      "Unit_hipTextureMipmapObj2D_Check - hipReadModeNormalizedFloat, hipFilterModeLinear, "
+      "hipTextureMipmapObj2D_Check - hipReadModeNormalizedFloat, hipFilterModeLinear, "
       "hipAddressModeBorder 263, 67") {
     testMipmapTextureObj<TestType, hipReadModeNormalizedFloat, hipFilterModeLinear,
                          hipAddressModeBorder>(263, 67, 0.13, 0.96);
   }
   SECTION(
-      "Unit_hipTextureMipmapObj2D_Check - hipReadModeNormalizedFloat, hipFilterModeLinear, "
+      "hipTextureMipmapObj2D_Check - hipReadModeNormalizedFloat, hipFilterModeLinear, "
       "hipAddressModeBorder 67, 131") {
     testMipmapTextureObj<TestType, hipReadModeNormalizedFloat, hipFilterModeLinear,
                          hipAddressModeBorder>(67, 131, -0.3, -0.67);
@@ -462,36 +462,36 @@ TEMPLATE_TEST_CASE("Unit_hipTextureMipmapObj2D_Check_hipReadModeNormalizedFloat"
  *  - Textures supported on device
  *  - HIP_VERSION >= 5.7
  */
-TEMPLATE_TEST_CASE("Unit_hipTextureMipmapObj2D_Check_hipReadModeElementType_float_only", "",
-                   float, float1, float2, float4) {
+TEMPLATE_TEST_CASE(Unit_hipTextureMipmapObj2D_Check_hipReadModeElementType_float_only, float,
+                   float1, float2, float4) {
   CHECK_IMAGE_SUPPORT
 
   SECTION(
-      "Unit_hipTextureMipmapObj2D_Check - hipReadModeElementType, hipFilterModeLinear, "
+      "hipTextureMipmapObj2D_Check - hipReadModeElementType, hipFilterModeLinear, "
       "hipAddressModeClamp 23, 17, 0., 0.") {
     testMipmapTextureObj<TestType, hipReadModeElementType, hipFilterModeLinear,
                          hipAddressModeClamp>(23, 17, 0.79, 0.37);
   }
   SECTION(
-      "Unit_hipTextureMipmapObj2D_Check - hipReadModeElementType, hipFilterModeLinear, "
+      "hipTextureMipmapObj2D_Check - hipReadModeElementType, hipFilterModeLinear, "
       "hipAddressModeClamp 23, 17") {
     testMipmapTextureObj<TestType, hipReadModeElementType, hipFilterModeLinear,
                          hipAddressModeClamp>(23, 17, -0.3, -0.67);
   }
   SECTION(
-      "Unit_hipTextureMipmapObj2D_Check - hipReadModeElementType, hipFilterModeLinear, "
+      "hipTextureMipmapObj2D_Check - hipReadModeElementType, hipFilterModeLinear, "
       "hipAddressModeClamp 263, 67") {
     testMipmapTextureObj<TestType, hipReadModeElementType, hipFilterModeLinear,
                          hipAddressModeClamp>(263, 67, 0.13, 0.96);
   }
   SECTION(
-      "Unit_hipTextureMipmapObj2D_Check - hipReadModeElementType, hipFilterModeLinear, "
+      "hipTextureMipmapObj2D_Check - hipReadModeElementType, hipFilterModeLinear, "
       "hipAddressModeBorder 263, 67") {
     testMipmapTextureObj<TestType, hipReadModeElementType, hipFilterModeLinear,
                          hipAddressModeBorder>(263, 67, 0.13, 0.96);
   }
   SECTION(
-      "Unit_hipTextureMipmapObj2D_Check - hipReadModeElementType, hipFilterModeLinear, "
+      "hipTextureMipmapObj2D_Check - hipReadModeElementType, hipFilterModeLinear, "
       "hipAddressModeBorder 67, 131") {
     testMipmapTextureObj<TestType, hipReadModeElementType, hipFilterModeLinear,
                          hipAddressModeBorder>(67, 131, -0.3, -0.67);

--- a/projects/hip-tests/catch/unit/texture/hipTextureMipmapObj3D.cc
+++ b/projects/hip-tests/catch/unit/texture/hipTextureMipmapObj3D.cc
@@ -360,32 +360,32 @@ static void testMipmapTextureObj(size_t width, size_t height, size_t depth, floa
  *  - Textures supported on device
  *  - HIP_VERSION >= 5.7
  */
-TEMPLATE_TEST_CASE("Unit_hipTextureMipmapObj3D_Check_hipReadModeElementType", "", char, uchar,
-                   short, ushort, int, uint, float, char1, uchar1, short1, ushort1, int1, uint1,
-                   float1, char2, uchar2, short2, ushort2, int2, uint2, float2, char4, uchar4,
-                   short4, ushort4, int4, uint4, float4) {
+TEMPLATE_TEST_CASE(Unit_hipTextureMipmapObj3D_Check_hipReadModeElementType, char, uchar, short,
+                   ushort, int, uint, float, char1, uchar1, short1, ushort1, int1, uint1, float1,
+                   char2, uchar2, short2, ushort2, int2, uint2, float2, char4, uchar4, short4,
+                   ushort4, int4, uint4, float4) {
   CHECK_IMAGE_SUPPORT
 
   SECTION(
-      "Unit_hipTextureMipmapObj3D_Check - hipReadModeElementType, hipFilterModePoint, "
+      "hipTextureMipmapObj3D_Check - hipReadModeElementType, hipFilterModePoint, "
       "hipAddressModeClamp 23, 21, 47") {
     testMipmapTextureObj<TestType, hipReadModeElementType, hipFilterModePoint, hipAddressModeClamp>(
         23, 21, 47, 0.4, -0.9, 0.77);
   }
   SECTION(
-      "Unit_hipTextureMipmapObj3D_Check - hipReadModeElementType, hipFilterModePoint, "
+      "hipTextureMipmapObj3D_Check - hipReadModeElementType, hipFilterModePoint, "
       "hipAddressModeClamp 67, 131, 99") {
     testMipmapTextureObj<TestType, hipReadModeElementType, hipFilterModePoint, hipAddressModeClamp>(
         67, 131, 99, -0.3, -0.67, 0.49);
   }
   SECTION(
-      "Unit_hipTextureMipmapObj3D_Check - hipReadModeElementType, hipFilterModePoint, "
+      "hipTextureMipmapObj3D_Check - hipReadModeElementType, hipFilterModePoint, "
       "hipAddressModeBorder 131, 263, 31") {
     testMipmapTextureObj<TestType, hipReadModeElementType, hipFilterModePoint,
                          hipAddressModeBorder>(131, 263, 31, 0.15, -0.34, 0.85);
   }
   SECTION(
-      "Unit_hipTextureMipmapObj3D_Check - hipReadModeElementType, hipFilterModePoint, "
+      "hipTextureMipmapObj3D_Check - hipReadModeElementType, hipFilterModePoint, "
       "hipAddressModeBorder 263, 67, 17") {
     testMipmapTextureObj<TestType, hipReadModeElementType, hipFilterModePoint,
                          hipAddressModeBorder>(263, 67, 17, 0.13, 0.96, -0.57);
@@ -410,55 +410,55 @@ TEMPLATE_TEST_CASE("Unit_hipTextureMipmapObj3D_Check_hipReadModeElementType", ""
  *  - Textures supported on device
  *  - HIP_VERSION >= 5.7
  */
-TEMPLATE_TEST_CASE("Unit_hipTextureMipmapObj3D_Check_hipReadModeNormalizedFloat", "", char, uchar,
-                   short, ushort, char1, uchar1, short1, ushort1, char2, uchar2, short2, ushort2,
-                   char4, uchar4, short4, ushort4) {
+TEMPLATE_TEST_CASE(Unit_hipTextureMipmapObj3D_Check_hipReadModeNormalizedFloat, char, uchar, short,
+                   ushort, char1, uchar1, short1, ushort1, char2, uchar2, short2, ushort2, char4,
+                   uchar4, short4, ushort4) {
   CHECK_IMAGE_SUPPORT
 
   SECTION(
-      "Unit_hipTextureMipmapObj3D_Check - hipReadModeNormalizedFloat, hipFilterModePoint, "
+      "hipTextureMipmapObj3D_Check - hipReadModeNormalizedFloat, hipFilterModePoint, "
       "hipAddressModeClamp 23, 21, 67") {
     testMipmapTextureObj<TestType, hipReadModeNormalizedFloat, hipFilterModePoint,
                          hipAddressModeClamp>(23, 21, 67, 0.4, -0.9, 0.37);
   }
   SECTION(
-      "Unit_hipTextureMipmapObj3D_Check - hipReadModeNormalizedFloat, hipFilterModePoint, "
+      "hipTextureMipmapObj3D_Check - hipReadModeNormalizedFloat, hipFilterModePoint, "
       "hipAddressModeClamp 131, 263, 11") {
     testMipmapTextureObj<TestType, hipReadModeNormalizedFloat, hipFilterModePoint,
                          hipAddressModeClamp>(131, 263, 11, 0.15, -0.34, 0.83);
   }
   SECTION(
-      "Unit_hipTextureMipmapObj3D_Check - hipReadModeNormalizedFloat, hipFilterModeLinear, "
+      "hipTextureMipmapObj3D_Check - hipReadModeNormalizedFloat, hipFilterModeLinear, "
       "hipAddressModeClamp 67, 131, 53") {
     testMipmapTextureObj<TestType, hipReadModeNormalizedFloat, hipFilterModeLinear,
                          hipAddressModeClamp>(23, 17, 53, -0.3, -0.67, 0.78);
   }
   SECTION(
-      "Unit_hipTextureMipmapObj3D_Check - hipReadModeNormalizedFloat, hipFilterModeLinear, "
+      "hipTextureMipmapObj3D_Check - hipReadModeNormalizedFloat, hipFilterModeLinear, "
       "hipAddressModeClamp 263, 67, 37") {
     testMipmapTextureObj<TestType, hipReadModeNormalizedFloat, hipFilterModeLinear,
                          hipAddressModeClamp>(263, 67, 37, 0.13, 0.96, -0.96);
   }
   SECTION(
-      "Unit_hipTextureMipmapObj3D_Check - hipReadModeNormalizedFloat, hipFilterModePoint, "
+      "hipTextureMipmapObj3D_Check - hipReadModeNormalizedFloat, hipFilterModePoint, "
       "hipAddressModeBorder 131, 263, 11") {
     testMipmapTextureObj<TestType, hipReadModeNormalizedFloat, hipFilterModePoint,
                          hipAddressModeBorder>(131, 263, 11, 0.15, -0.34, -0.11);
   }
   SECTION(
-      "Unit_hipTextureMipmapObj3D_Check - hipReadModeNormalizedFloat, hipFilterModePoint, "
+      "hipTextureMipmapObj3D_Check - hipReadModeNormalizedFloat, hipFilterModePoint, "
       "hipAddressModeBorder 23, 21, 201") {
     testMipmapTextureObj<TestType, hipReadModeNormalizedFloat, hipFilterModePoint,
                          hipAddressModeBorder>(23, 21, 201, 0.4, -0.9, 0.54);
   }
   SECTION(
-      "Unit_hipTextureMipmapObj3D_Check - hipReadModeNormalizedFloat, hipFilterModeLinear, "
+      "hipTextureMipmapObj3D_Check - hipReadModeNormalizedFloat, hipFilterModeLinear, "
       "hipAddressModeBorder 263, 67, 51") {
     testMipmapTextureObj<TestType, hipReadModeNormalizedFloat, hipFilterModeLinear,
                          hipAddressModeBorder>(263, 67, 51, 0.13, 0.96, 0.77);
   }
   SECTION(
-      "Unit_hipTextureMipmapObj3D_Check - hipReadModeNormalizedFloat, hipFilterModeLinear, "
+      "hipTextureMipmapObj3D_Check - hipReadModeNormalizedFloat, hipFilterModeLinear, "
       "hipAddressModeBorder 67, 131, 87") {
     testMipmapTextureObj<TestType, hipReadModeNormalizedFloat, hipFilterModeLinear,
                          hipAddressModeBorder>(67, 131, 87, -0.3, -0.67, -0.29);
@@ -484,36 +484,36 @@ TEMPLATE_TEST_CASE("Unit_hipTextureMipmapObj3D_Check_hipReadModeNormalizedFloat"
  *  - Textures supported on device
  *  - HIP_VERSION >= 5.7
  */
-TEMPLATE_TEST_CASE("Unit_hipTextureMipmapObj3D_Check_hipReadModeElementType_float_only", "",
-                   float, float1, float2, float4) {
+TEMPLATE_TEST_CASE(Unit_hipTextureMipmapObj3D_Check_hipReadModeElementType_float_only, float,
+                   float1, float2, float4) {
   CHECK_IMAGE_SUPPORT
 
   SECTION(
-      "Unit_hipTextureMipmapObj3D_Check - hipReadModeElementType, hipFilterModeLinear, "
+      "hipTextureMipmapObj3D_Check - hipReadModeElementType, hipFilterModeLinear, "
       "hipAddressModeClamp 23, 17, 301, 0., 0., 0.") {
     testMipmapTextureObj<TestType, hipReadModeElementType, hipFilterModeLinear,
                          hipAddressModeClamp>(23, 17, 301, 0.19, 0.46, -0.9);
   }
   SECTION(
-      "Unit_hipTextureMipmapObj3D_Check - hipReadModeElementType, hipFilterModeLinear, "
+      "hipTextureMipmapObj3D_Check - hipReadModeElementType, hipFilterModeLinear, "
       "hipAddressModeClamp 23, 17, 243") {
     testMipmapTextureObj<TestType, hipReadModeElementType, hipFilterModeLinear,
                          hipAddressModeClamp>(23, 17, 243, -0.3, -0.67, 0.65);
   }
   SECTION(
-      "Unit_hipTextureMipmapObj3D_Check - hipReadModeElementType, hipFilterModeLinear, "
+      "hipTextureMipmapObj3D_Check - hipReadModeElementType, hipFilterModeLinear, "
       "hipAddressModeClamp 263, 67, 39") {
     testMipmapTextureObj<TestType, hipReadModeElementType, hipFilterModeLinear,
                          hipAddressModeClamp>(263, 67, 39, 0.13, 0.96, 0.66);
   }
   SECTION(
-      "Unit_hipTextureMipmapObj3D_Check - hipReadModeElementType, hipFilterModeLinear, "
+      "hipTextureMipmapObj3D_Check - hipReadModeElementType, hipFilterModeLinear, "
       "hipAddressModeBorder 263, 67, 117") {
     testMipmapTextureObj<TestType, hipReadModeElementType, hipFilterModeLinear,
                          hipAddressModeBorder>(263, 67, 117, 0.13, 0.96, -0.93);
   }
   SECTION(
-      "Unit_hipTextureMipmapObj3D_Check - hipReadModeElementType, hipFilterModeLinear, "
+      "hipTextureMipmapObj3D_Check - hipReadModeElementType, hipFilterModeLinear, "
       "hipAddressModeBorder 67, 131, 67") {
     testMipmapTextureObj<TestType, hipReadModeElementType, hipFilterModeLinear,
                          hipAddressModeBorder>(67, 131, 67, -0.3, -0.67, 0.88);

--- a/projects/hip-tests/catch/unit/texture/hipTextureObj1DCheckModes.cc
+++ b/projects/hip-tests/catch/unit/texture/hipTextureObj1DCheckModes.cc
@@ -121,7 +121,7 @@ static void runTest(const int width, const float offsetX) {
  *  - Textures supported on device
  *  - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_hipTextureObj1DCheckModes") {
+TEST_CASE(Unit_hipTextureObj1DCheckModes) {
   CHECK_IMAGE_SUPPORT
 
   SECTION("hipAddressModeClamp, hipFilterModePoint, regularCoords") {

--- a/projects/hip-tests/catch/unit/texture/hipTextureObj1DCheckSRGBModes.cc
+++ b/projects/hip-tests/catch/unit/texture/hipTextureObj1DCheckSRGBModes.cc
@@ -171,7 +171,7 @@ line1:
   REQUIRE(result);
 }
 
-TEST_CASE("Unit_hipTextureObj1DCheckRGBAModes_array") {
+TEST_CASE(Unit_hipTextureObj1DCheckRGBAModes_array) {
   CHECK_IMAGE_SUPPORT
 
   SECTION("RGBA 1D hipAddressModeClamp, hipFilterModePoint, hipResourceTypeArray, regularCoords") {
@@ -227,7 +227,7 @@ TEST_CASE("Unit_hipTextureObj1DCheckRGBAModes_array") {
 }
 
 
-TEST_CASE("Unit_hipTextureObj1DCheckSRGBAModes_array") {
+TEST_CASE(Unit_hipTextureObj1DCheckSRGBAModes_array) {
   CHECK_IMAGE_SUPPORT
 
   SECTION("SRGBA 1D hipAddressModeClamp, hipFilterModePoint, hipResourceTypeArray, regularCoords") {
@@ -286,7 +286,7 @@ TEST_CASE("Unit_hipTextureObj1DCheckSRGBAModes_array") {
 #endif
 }
 
-TEST_CASE("Unit_hipTextureObj1DCheckRGBAModes_buffer") {
+TEST_CASE(Unit_hipTextureObj1DCheckRGBAModes_buffer) {
   CHECK_IMAGE_SUPPORT
 
   SECTION("RGBA 1D hipAddressModeClamp, hipFilterModePoint, hipResourceTypeLinear, regularCoords") {
@@ -299,7 +299,7 @@ TEST_CASE("Unit_hipTextureObj1DCheckRGBAModes_buffer") {
   }
 }
 
-TEST_CASE("Unit_hipTextureObj1DCheckSRGBAModes_buffer") {
+TEST_CASE(Unit_hipTextureObj1DCheckSRGBAModes_buffer) {
   CHECK_IMAGE_SUPPORT
 
   SECTION(

--- a/projects/hip-tests/catch/unit/texture/hipTextureObj1DFetch.cc
+++ b/projects/hip-tests/catch/unit/texture/hipTextureObj1DFetch.cc
@@ -32,7 +32,7 @@ static __global__ void tex1dKernel(float* val, hipTextureObject_t obj) {
 }
 
 
-TEST_CASE("Unit_hipCreateTextureObject_tex1DfetchVerification") {
+TEST_CASE(Unit_hipCreateTextureObject_tex1DfetchVerification) {
   CHECK_IMAGE_SUPPORT
   (void) hipGetLastError();  // Prevent negative tests affecting this
 

--- a/projects/hip-tests/catch/unit/texture/hipTextureObj2D.cc
+++ b/projects/hip-tests/catch/unit/texture/hipTextureObj2D.cc
@@ -46,7 +46,7 @@ __global__ void tex2DKernel(float* outputData, hipTextureObject_t textureObject,
  *  - Textures supported on device
  *  - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_hipTextureObj2D_Check") {
+TEST_CASE(Unit_hipTextureObj2D_Check) {
   CHECK_IMAGE_SUPPORT
 
   constexpr int SIZE = 256;

--- a/projects/hip-tests/catch/unit/texture/hipTextureObj2DCheckModes.cc
+++ b/projects/hip-tests/catch/unit/texture/hipTextureObj2DCheckModes.cc
@@ -131,7 +131,7 @@ line1:
  *  - Textures supported on device
  *  - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_hipTextureObj2DCheckModes") {
+TEST_CASE(Unit_hipTextureObj2DCheckModes) {
   CHECK_IMAGE_SUPPORT
 
   SECTION("hipAddressModeClamp, hipFilterModePoint, regularCoords") {

--- a/projects/hip-tests/catch/unit/texture/hipTextureObj2DCheckSRGBModes.cc
+++ b/projects/hip-tests/catch/unit/texture/hipTextureObj2DCheckSRGBModes.cc
@@ -152,7 +152,7 @@ line1:
   REQUIRE(result);
 }
 
-TEST_CASE("Unit_hipTextureObj2DCheckRGBAModes") {
+TEST_CASE(Unit_hipTextureObj2DCheckRGBAModes) {
   CHECK_IMAGE_SUPPORT
   (void) hipGetLastError();  // Prevent negative tests affecting this
 
@@ -198,7 +198,7 @@ TEST_CASE("Unit_hipTextureObj2DCheckRGBAModes") {
 }
 
 
-TEST_CASE("Unit_hipTextureObj2DCheckSRGBAModes") {
+TEST_CASE(Unit_hipTextureObj2DCheckSRGBAModes) {
   CHECK_IMAGE_SUPPORT
 
   SECTION("SRGBA 2D hipAddressModeClamp, hipFilterModePoint, regularCoords") {

--- a/projects/hip-tests/catch/unit/texture/hipTextureObj3DCheckModes.cc
+++ b/projects/hip-tests/catch/unit/texture/hipTextureObj3DCheckModes.cc
@@ -170,7 +170,7 @@ line1:
  *  - Textures supported on device
  *  - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_hipTextureObj3DCheckModes") {
+TEST_CASE(Unit_hipTextureObj3DCheckModes) {
   CHECK_IMAGE_SUPPORT
 
   int device = 0;

--- a/projects/hip-tests/catch/unit/texture/hipTextureObjFetchVector.cc
+++ b/projects/hip-tests/catch/unit/texture/hipTextureObjFetchVector.cc
@@ -128,7 +128,7 @@ template <typename T> bool runTest() {
   return testResult;
 }
 
-TEST_CASE("Unit_hipTextureFetch_vector") {
+TEST_CASE(Unit_hipTextureFetch_vector) {
   CHECK_IMAGE_SUPPORT
 
   // test for char

--- a/projects/hip-tests/catch/unit/texture/hipTextureObjectTests.cc
+++ b/projects/hip-tests/catch/unit/texture/hipTextureObjectTests.cc
@@ -112,7 +112,7 @@ class TextureObjectTestWrapper {
  *  - Textures supported on device
  *  - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_hipGetTextureObjectResourceDesc_positive") {
+TEST_CASE(Unit_hipGetTextureObjectResourceDesc_positive) {
   CHECK_IMAGE_SUPPORT;
 
   TextureObjectTestWrapper tex_obj_wrapper(false);
@@ -142,7 +142,7 @@ TEST_CASE("Unit_hipGetTextureObjectResourceDesc_positive") {
  *  - Textures supported on device
  *  - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_hipGetTextureObjectResourceDesc_Negative_Parameters") {
+TEST_CASE(Unit_hipGetTextureObjectResourceDesc_Negative_Parameters) {
   CHECK_IMAGE_SUPPORT;
 
   TextureObjectTestWrapper tex_obj_wrapper(false);
@@ -192,7 +192,7 @@ TEST_CASE("Unit_hipGetTextureObjectResourceDesc_Negative_Parameters") {
  *  - HIP_VERSION >= 5.2
  */
 #if HT_AMD
-TEST_CASE("Unit_hipGetTextureObjectResourceViewDesc_positive") {
+TEST_CASE(Unit_hipGetTextureObjectResourceViewDesc_positive) {
   CHECK_IMAGE_SUPPORT;
 
   TextureObjectTestWrapper tex_obj_wrapper(true);
@@ -225,7 +225,7 @@ TEST_CASE("Unit_hipGetTextureObjectResourceViewDesc_positive") {
  *  - HIP_VERSION >= 5.2
  */
 #if HT_AMD
-TEST_CASE("Unit_hipGetTextureObjectResourceViewDesc_Negative_Parameters") {
+TEST_CASE(Unit_hipGetTextureObjectResourceViewDesc_Negative_Parameters) {
   CHECK_IMAGE_SUPPORT;
 
   TextureObjectTestWrapper tex_obj_wrapper(true);
@@ -276,7 +276,7 @@ TEST_CASE("Unit_hipGetTextureObjectResourceViewDesc_Negative_Parameters") {
  *  - HIP_VERSION >= 5.2
  */
 #if HT_AMD
-TEST_CASE("Unit_hipGetTextureObjectTextureDesc_positive") {
+TEST_CASE(Unit_hipGetTextureObjectTextureDesc_positive) {
   CHECK_IMAGE_SUPPORT;
 
   TextureObjectTestWrapper tex_obj_wrapper(false);
@@ -311,7 +311,7 @@ TEST_CASE("Unit_hipGetTextureObjectTextureDesc_positive") {
  *  - HIP_VERSION >= 5.2
  */
 #if HT_AMD
-TEST_CASE("Unit_hipGetTextureObjectTextureDesc_Negative_Parameters") {
+TEST_CASE(Unit_hipGetTextureObjectTextureDesc_Negative_Parameters) {
   CHECK_IMAGE_SUPPORT;
 
   TextureObjectTestWrapper tex_obj_wrapper(false);
@@ -359,7 +359,7 @@ TEST_CASE("Unit_hipGetTextureObjectTextureDesc_Negative_Parameters") {
  *  - Textures supported on device
  *  - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_hipDestroyTextureObject_positive") {
+TEST_CASE(Unit_hipDestroyTextureObject_positive) {
   CHECK_IMAGE_SUPPORT;
 
   TextureObjectTestWrapper tex_obj_wrapper(false, true);

--- a/projects/hip-tests/catch/unit/texture/hipTextureRef2D.cc
+++ b/projects/hip-tests/catch/unit/texture/hipTextureRef2D.cc
@@ -33,7 +33,7 @@ __global__ void tex2DKernel(float* outputData, int width) {
 #endif
 }
 
-TEST_CASE("Unit_hipTextureRef2D_Check") {
+TEST_CASE(Unit_hipTextureRef2D_Check) {
   CHECK_IMAGE_SUPPORT
 
   constexpr int SIZE = 256;

--- a/projects/hip-tests/catch/unit/texture/hipUnbindTexture.cc
+++ b/projects/hip-tests/catch/unit/texture/hipUnbindTexture.cc
@@ -28,7 +28,7 @@ texture<float, hipTextureType1D, hipReadModeElementType> tex_1D;
 texture<float, hipTextureType2D, hipReadModeElementType> tex_2D;
 texture<float, hipTextureType3D, hipReadModeElementType> tex_3D;
 
-TEST_CASE("Unit_hipUnbindTexture_Null_Texture") {
+TEST_CASE(Unit_hipUnbindTexture_Null_Texture) {
 #if HT_AMD
   HIP_CHECK_ERROR(hipUnbindTexture(nullptr), hipErrorInvalidValue);
 #else
@@ -37,7 +37,7 @@ TEST_CASE("Unit_hipUnbindTexture_Null_Texture") {
 #endif
 }
 
-TEST_CASE("Unit_hipUnbindTexture_Positive_1D") {
+TEST_CASE(Unit_hipUnbindTexture_Positive_1D) {
   CHECK_IMAGE_SUPPORT
 
   constexpr int size = 1024;
@@ -63,7 +63,7 @@ TEST_CASE("Unit_hipUnbindTexture_Positive_1D") {
   HIP_CHECK(hipFree(tex_buffer));
 }
 
-TEST_CASE("Unit_hipUnbindTexture_Positive_2D") {
+TEST_CASE(Unit_hipUnbindTexture_Positive_2D) {
   CHECK_IMAGE_SUPPORT
 
   constexpr int width = 1024;
@@ -85,7 +85,7 @@ TEST_CASE("Unit_hipUnbindTexture_Positive_2D") {
   HIP_CHECK(hipFree(dev_ptr));
 }
 
-TEST_CASE("Unit_hipUnbindTexture_Positive_3D") {
+TEST_CASE(Unit_hipUnbindTexture_Positive_3D) {
   CHECK_IMAGE_SUPPORT
 
   constexpr unsigned int width = 256;

--- a/projects/hip-tests/catch/unit/texture/tex1D.cc
+++ b/projects/hip-tests/catch/unit/texture/tex1D.cc
@@ -48,7 +48,7 @@ THE SOFTWARE.
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEMPLATE_TEST_CASE("Unit_tex1D_Positive_ReadModeElementType", "", char, unsigned char, short,
+TEMPLATE_TEST_CASE(Unit_tex1D_Positive_ReadModeElementType, char, unsigned char, short,
                    unsigned short, int, unsigned int, float) {
   CHECK_IMAGE_SUPPORT;
 
@@ -98,7 +98,7 @@ TEMPLATE_TEST_CASE("Unit_tex1D_Positive_ReadModeElementType", "", char, unsigned
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEMPLATE_TEST_CASE("Unit_tex1D_Positive_ReadModeNormalizedFloat", "", char, unsigned char, short,
+TEMPLATE_TEST_CASE(Unit_tex1D_Positive_ReadModeNormalizedFloat, char, unsigned char, short,
                    unsigned short) {
   CHECK_IMAGE_SUPPORT;
 

--- a/projects/hip-tests/catch/unit/texture/tex1DGrad.cc
+++ b/projects/hip-tests/catch/unit/texture/tex1DGrad.cc
@@ -48,7 +48,7 @@ THE SOFTWARE.
  * ------------------------
  *    - HIP_VERSION >= 5.7
  */
-TEMPLATE_TEST_CASE("Unit_tex1DGrad_Positive_ReadModeElementType", "", char, unsigned char, short,
+TEMPLATE_TEST_CASE(Unit_tex1DGrad_Positive_ReadModeElementType, char, unsigned char, short,
                    unsigned short, int, unsigned int, float) {
   CHECK_IMAGE_SUPPORT;
 
@@ -98,7 +98,7 @@ TEMPLATE_TEST_CASE("Unit_tex1DGrad_Positive_ReadModeElementType", "", char, unsi
  * ------------------------
  *    - HIP_VERSION >= 5.7
  */
-TEMPLATE_TEST_CASE("Unit_tex1DGrad_Positive_ReadModeNormalizedFloat", "", char, unsigned char,
+TEMPLATE_TEST_CASE(Unit_tex1DGrad_Positive_ReadModeNormalizedFloat, char, unsigned char,
                    short, unsigned short) {
   CHECK_IMAGE_SUPPORT;
 

--- a/projects/hip-tests/catch/unit/texture/tex1DLayered.cc
+++ b/projects/hip-tests/catch/unit/texture/tex1DLayered.cc
@@ -48,7 +48,7 @@ THE SOFTWARE.
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEMPLATE_TEST_CASE("Unit_tex1DLayered_Positive_ReadModeElementType", "", char, unsigned char, short,
+TEMPLATE_TEST_CASE(Unit_tex1DLayered_Positive_ReadModeElementType, char, unsigned char, short,
                    unsigned short, int, unsigned int, float) {
   CHECK_IMAGE_SUPPORT;
 
@@ -103,7 +103,7 @@ TEMPLATE_TEST_CASE("Unit_tex1DLayered_Positive_ReadModeElementType", "", char, u
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEMPLATE_TEST_CASE("Unit_tex1DLayered_Positive_ReadModeNormalizedFloat", "", char, unsigned char,
+TEMPLATE_TEST_CASE(Unit_tex1DLayered_Positive_ReadModeNormalizedFloat, char, unsigned char,
                    short, unsigned short) {
   CHECK_IMAGE_SUPPORT;
 

--- a/projects/hip-tests/catch/unit/texture/tex1DLayeredGrad.cc
+++ b/projects/hip-tests/catch/unit/texture/tex1DLayeredGrad.cc
@@ -48,7 +48,7 @@ THE SOFTWARE.
  * ------------------------
  *    - HIP_VERSION >= 5.7
  */
-TEMPLATE_TEST_CASE("Unit_tex1DLayeredGrad_Positive_ReadModeElementType", "", char, unsigned char,
+TEMPLATE_TEST_CASE(Unit_tex1DLayeredGrad_Positive_ReadModeElementType, char, unsigned char,
                    short, unsigned short, int, unsigned int, float) {
   CHECK_IMAGE_SUPPORT;
 
@@ -103,7 +103,7 @@ TEMPLATE_TEST_CASE("Unit_tex1DLayeredGrad_Positive_ReadModeElementType", "", cha
  * ------------------------
  *    - HIP_VERSION >= 5.7
  */
-TEMPLATE_TEST_CASE("Unit_tex1DLayeredGrad_Positive_ReadModeNormalizedFloat", "", char,
+TEMPLATE_TEST_CASE(Unit_tex1DLayeredGrad_Positive_ReadModeNormalizedFloat, char,
                    unsigned char, short, unsigned short) {
   CHECK_IMAGE_SUPPORT;
 

--- a/projects/hip-tests/catch/unit/texture/tex1DLayeredLod.cc
+++ b/projects/hip-tests/catch/unit/texture/tex1DLayeredLod.cc
@@ -48,7 +48,7 @@ THE SOFTWARE.
  * ------------------------
  *    - HIP_VERSION >= 5.7
  */
-TEMPLATE_TEST_CASE("Unit_tex1DLayeredLod_Positive_ReadModeElementType", "", char, unsigned char,
+TEMPLATE_TEST_CASE(Unit_tex1DLayeredLod_Positive_ReadModeElementType, char, unsigned char,
                    short, unsigned short, int, unsigned int, float) {
   CHECK_IMAGE_SUPPORT;
 
@@ -103,7 +103,7 @@ TEMPLATE_TEST_CASE("Unit_tex1DLayeredLod_Positive_ReadModeElementType", "", char
  * ------------------------
  *    - HIP_VERSION >= 5.7
  */
-TEMPLATE_TEST_CASE("Unit_tex1DLayeredLod_Positive_ReadModeNormalizedFloat", "", char, unsigned char,
+TEMPLATE_TEST_CASE(Unit_tex1DLayeredLod_Positive_ReadModeNormalizedFloat, char, unsigned char,
                    short, unsigned short) {
   CHECK_IMAGE_SUPPORT;
 

--- a/projects/hip-tests/catch/unit/texture/tex1DLod.cc
+++ b/projects/hip-tests/catch/unit/texture/tex1DLod.cc
@@ -48,7 +48,7 @@ THE SOFTWARE.
  * ------------------------
  *    - HIP_VERSION >= 5.7
  */
-TEMPLATE_TEST_CASE("Unit_tex1DLod_Positive_ReadModeElementType", "", char, unsigned char, short,
+TEMPLATE_TEST_CASE(Unit_tex1DLod_Positive_ReadModeElementType, char, unsigned char, short,
                    unsigned short, int, unsigned int, float) {
   CHECK_IMAGE_SUPPORT;
 
@@ -98,7 +98,7 @@ TEMPLATE_TEST_CASE("Unit_tex1DLod_Positive_ReadModeElementType", "", char, unsig
  * ------------------------
  *    - HIP_VERSION >= 5.7
  */
-TEMPLATE_TEST_CASE("Unit_tex1DLod_Positive_ReadModeNormalizedFloat", "", char, unsigned char, short,
+TEMPLATE_TEST_CASE(Unit_tex1DLod_Positive_ReadModeNormalizedFloat, char, unsigned char, short,
                    unsigned short) {
   CHECK_IMAGE_SUPPORT;
 

--- a/projects/hip-tests/catch/unit/texture/tex1Dfetch.cc
+++ b/projects/hip-tests/catch/unit/texture/tex1Dfetch.cc
@@ -46,7 +46,7 @@ THE SOFTWARE.
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEMPLATE_TEST_CASE("Unit_tex1Dfetch_Positive_ReadModeElementType", "", char, unsigned char, short,
+TEMPLATE_TEST_CASE(Unit_tex1Dfetch_Positive_ReadModeElementType, char, unsigned char, short,
                    unsigned short, int, unsigned int, float) {
   CHECK_IMAGE_SUPPORT;
 
@@ -108,7 +108,7 @@ TEMPLATE_TEST_CASE("Unit_tex1Dfetch_Positive_ReadModeElementType", "", char, uns
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEMPLATE_TEST_CASE("Unit_tex1Dfetch_Positive_ReadModeNormalizedFloat", "", char, unsigned char,
+TEMPLATE_TEST_CASE(Unit_tex1Dfetch_Positive_ReadModeNormalizedFloat, char, unsigned char,
                    short, unsigned short) {
   CHECK_IMAGE_SUPPORT;
 

--- a/projects/hip-tests/catch/unit/texture/tex2D.cc
+++ b/projects/hip-tests/catch/unit/texture/tex2D.cc
@@ -48,7 +48,7 @@ THE SOFTWARE.
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEMPLATE_TEST_CASE("Unit_tex2D_Positive_ReadModeElementType", "", char, unsigned char, short,
+TEMPLATE_TEST_CASE(Unit_tex2D_Positive_ReadModeElementType, char, unsigned char, short,
                    unsigned short, int, unsigned int, float) {
   CHECK_IMAGE_SUPPORT;
   (void) hipGetLastError();  // Prevent negative tests affecting this
@@ -116,7 +116,7 @@ TEMPLATE_TEST_CASE("Unit_tex2D_Positive_ReadModeElementType", "", char, unsigned
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEMPLATE_TEST_CASE("Unit_tex2D_Positive_ReadModeNormalizedFloat", "", char, unsigned char, short,
+TEMPLATE_TEST_CASE(Unit_tex2D_Positive_ReadModeNormalizedFloat, char, unsigned char, short,
                    unsigned short) {
   CHECK_IMAGE_SUPPORT;
 

--- a/projects/hip-tests/catch/unit/texture/tex2DGrad.cc
+++ b/projects/hip-tests/catch/unit/texture/tex2DGrad.cc
@@ -48,7 +48,7 @@ THE SOFTWARE.
  * ------------------------
  *    - HIP_VERSION >= 5.7
  */
-TEMPLATE_TEST_CASE("Unit_tex2DGrad_Positive_ReadModeElementType", "", char, unsigned char, short,
+TEMPLATE_TEST_CASE(Unit_tex2DGrad_Positive_ReadModeElementType, char, unsigned char, short,
                    unsigned short, int, unsigned int, float) {
   CHECK_IMAGE_SUPPORT;
 
@@ -116,7 +116,7 @@ TEMPLATE_TEST_CASE("Unit_tex2DGrad_Positive_ReadModeElementType", "", char, unsi
  * ------------------------
  *    - HIP_VERSION >= 5.7
  */
-TEMPLATE_TEST_CASE("Unit_tex2DGrad_Positive_ReadModeNormalizedFloat", "", char, unsigned char,
+TEMPLATE_TEST_CASE(Unit_tex2DGrad_Positive_ReadModeNormalizedFloat, char, unsigned char,
                    short, unsigned short) {
   CHECK_IMAGE_SUPPORT;
 

--- a/projects/hip-tests/catch/unit/texture/tex2DLayered.cc
+++ b/projects/hip-tests/catch/unit/texture/tex2DLayered.cc
@@ -48,7 +48,7 @@ THE SOFTWARE.
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEMPLATE_TEST_CASE("Unit_tex2DLayered_Positive_ReadModeElementType", "", char, unsigned char, short,
+TEMPLATE_TEST_CASE(Unit_tex2DLayered_Positive_ReadModeElementType, char, unsigned char, short,
                    unsigned short, int, unsigned int, float) {
   CHECK_IMAGE_SUPPORT;
 
@@ -120,7 +120,7 @@ TEMPLATE_TEST_CASE("Unit_tex2DLayered_Positive_ReadModeElementType", "", char, u
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEMPLATE_TEST_CASE("Unit_tex2DLayered_Positive_ReadModeNormalizedFloat", "", char, unsigned char,
+TEMPLATE_TEST_CASE(Unit_tex2DLayered_Positive_ReadModeNormalizedFloat, char, unsigned char,
                    short, unsigned short) {
   CHECK_IMAGE_SUPPORT;
 

--- a/projects/hip-tests/catch/unit/texture/tex2DLayeredGrad.cc
+++ b/projects/hip-tests/catch/unit/texture/tex2DLayeredGrad.cc
@@ -48,7 +48,7 @@ THE SOFTWARE.
  * ------------------------
  *    - HIP_VERSION >= 5.7
  */
-TEMPLATE_TEST_CASE("Unit_tex2DLayeredGrad_Positive_ReadModeElementType", "", char, unsigned char,
+TEMPLATE_TEST_CASE(Unit_tex2DLayeredGrad_Positive_ReadModeElementType, char, unsigned char,
                    short, unsigned short, int, unsigned int, float) {
   CHECK_IMAGE_SUPPORT;
 
@@ -120,7 +120,7 @@ TEMPLATE_TEST_CASE("Unit_tex2DLayeredGrad_Positive_ReadModeElementType", "", cha
  * ------------------------
  *    - HIP_VERSION >= 5.7
  */
-TEMPLATE_TEST_CASE("Unit_tex2DLayeredGrad_Positive_ReadModeNormalizedFloat", "", char,
+TEMPLATE_TEST_CASE(Unit_tex2DLayeredGrad_Positive_ReadModeNormalizedFloat, char,
                    unsigned char, short, unsigned short) {
   CHECK_IMAGE_SUPPORT;
 

--- a/projects/hip-tests/catch/unit/texture/tex2DLayeredLod.cc
+++ b/projects/hip-tests/catch/unit/texture/tex2DLayeredLod.cc
@@ -48,7 +48,7 @@ THE SOFTWARE.
  * ------------------------
  *    - HIP_VERSION >= 5.7
  */
-TEMPLATE_TEST_CASE("Unit_tex2DLayeredLod_Positive_ReadModeElementType", "", char, unsigned char,
+TEMPLATE_TEST_CASE(Unit_tex2DLayeredLod_Positive_ReadModeElementType, char, unsigned char,
                    short, unsigned short, int, unsigned int, float) {
   CHECK_IMAGE_SUPPORT;
 
@@ -120,7 +120,7 @@ TEMPLATE_TEST_CASE("Unit_tex2DLayeredLod_Positive_ReadModeElementType", "", char
  * ------------------------
  *    - HIP_VERSION >= 5.7
  */
-TEMPLATE_TEST_CASE("Unit_tex2DLayeredLod_Positive_ReadModeNormalizedFloat", "", char, unsigned char,
+TEMPLATE_TEST_CASE(Unit_tex2DLayeredLod_Positive_ReadModeNormalizedFloat, char, unsigned char,
                    short, unsigned short) {
   CHECK_IMAGE_SUPPORT;
 

--- a/projects/hip-tests/catch/unit/texture/tex2DLod.cc
+++ b/projects/hip-tests/catch/unit/texture/tex2DLod.cc
@@ -48,7 +48,7 @@ THE SOFTWARE.
  * ------------------------
  *    - HIP_VERSION >= 5.7
  */
-TEMPLATE_TEST_CASE("Unit_tex2DLod_Positive_ReadModeElementType", "", char, unsigned char, short,
+TEMPLATE_TEST_CASE(Unit_tex2DLod_Positive_ReadModeElementType, char, unsigned char, short,
                    unsigned short, int, unsigned int, float) {
   CHECK_IMAGE_SUPPORT;
 
@@ -116,7 +116,7 @@ TEMPLATE_TEST_CASE("Unit_tex2DLod_Positive_ReadModeElementType", "", char, unsig
  * ------------------------
  *    - HIP_VERSION >= 5.7
  */
-TEMPLATE_TEST_CASE("Unit_tex2DLod_Positive_ReadModeNormalizedFloat", "", char, unsigned char, short,
+TEMPLATE_TEST_CASE(Unit_tex2DLod_Positive_ReadModeNormalizedFloat, char, unsigned char, short,
                    unsigned short) {
   CHECK_IMAGE_SUPPORT;
 

--- a/projects/hip-tests/catch/unit/texture/tex2Dgather.cc
+++ b/projects/hip-tests/catch/unit/texture/tex2Dgather.cc
@@ -48,7 +48,7 @@ THE SOFTWARE.
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEMPLATE_TEST_CASE("Unit_tex2Dgather_Positive_ReadModeElementType", "", char, unsigned char, short,
+TEMPLATE_TEST_CASE(Unit_tex2Dgather_Positive_ReadModeElementType, char, unsigned char, short,
                    unsigned short, int, unsigned int, float) {
   CHECK_IMAGE_SUPPORT;
 

--- a/projects/hip-tests/catch/unit/texture/tex3D.cc
+++ b/projects/hip-tests/catch/unit/texture/tex3D.cc
@@ -48,7 +48,7 @@ THE SOFTWARE.
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEMPLATE_TEST_CASE("Unit_tex3D_Positive_ReadModeElementType", "", char, unsigned char, short,
+TEMPLATE_TEST_CASE(Unit_tex3D_Positive_ReadModeElementType, char, unsigned char, short,
                    unsigned short, int, unsigned int, float) {
   CHECK_IMAGE_SUPPORT;
 #if HT_NVIDIA
@@ -127,7 +127,7 @@ TEMPLATE_TEST_CASE("Unit_tex3D_Positive_ReadModeElementType", "", char, unsigned
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEMPLATE_TEST_CASE("Unit_tex3D_Positive_ReadModeNormalizedFloat", "", char, unsigned char, short,
+TEMPLATE_TEST_CASE(Unit_tex3D_Positive_ReadModeNormalizedFloat, char, unsigned char, short,
                    unsigned short) {
   CHECK_IMAGE_SUPPORT;
 

--- a/projects/hip-tests/catch/unit/texture/tex3DGrad.cc
+++ b/projects/hip-tests/catch/unit/texture/tex3DGrad.cc
@@ -48,7 +48,7 @@ THE SOFTWARE.
  * ------------------------
  *    - HIP_VERSION >= 5.7
  */
-TEMPLATE_TEST_CASE("Unit_tex3DGrad_Positive_ReadModeElementType", "", char, unsigned char, short,
+TEMPLATE_TEST_CASE(Unit_tex3DGrad_Positive_ReadModeElementType, char, unsigned char, short,
                    unsigned short, int, unsigned int, float) {
   CHECK_IMAGE_SUPPORT;
 
@@ -125,7 +125,7 @@ TEMPLATE_TEST_CASE("Unit_tex3DGrad_Positive_ReadModeElementType", "", char, unsi
  * ------------------------
  *    - HIP_VERSION >= 5.7
  */
-TEMPLATE_TEST_CASE("Unit_tex3DGrad_Positive_ReadModeNormalizedFloat", "", char, unsigned char,
+TEMPLATE_TEST_CASE(Unit_tex3DGrad_Positive_ReadModeNormalizedFloat, char, unsigned char,
                    short, unsigned short) {
   CHECK_IMAGE_SUPPORT;
 

--- a/projects/hip-tests/catch/unit/texture/tex3DLod.cc
+++ b/projects/hip-tests/catch/unit/texture/tex3DLod.cc
@@ -48,7 +48,7 @@ THE SOFTWARE.
  * ------------------------
  *    - HIP_VERSION >= 5.7
  */
-TEMPLATE_TEST_CASE("Unit_tex3DLod_Positive_ReadModeElementType", "", char, unsigned char, short,
+TEMPLATE_TEST_CASE(Unit_tex3DLod_Positive_ReadModeElementType, char, unsigned char, short,
                    unsigned short, int, unsigned int, float) {
   CHECK_IMAGE_SUPPORT;
 
@@ -125,7 +125,7 @@ TEMPLATE_TEST_CASE("Unit_tex3DLod_Positive_ReadModeElementType", "", char, unsig
  * ------------------------
  *    - HIP_VERSION >= 5.7
  */
-TEMPLATE_TEST_CASE("Unit_tex3DLod_Positive_ReadModeNormalizedFloat", "", char, unsigned char, short,
+TEMPLATE_TEST_CASE(Unit_tex3DLod_Positive_ReadModeNormalizedFloat, char, unsigned char, short,
                    unsigned short) {
   CHECK_IMAGE_SUPPORT;
 

--- a/projects/hip-tests/catch/unit/texture/texCubemap.cc
+++ b/projects/hip-tests/catch/unit/texture/texCubemap.cc
@@ -48,7 +48,7 @@ THE SOFTWARE.
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEMPLATE_TEST_CASE("Unit_texCubemap_Positive_ReadModeElementType", "", char, unsigned char, short,
+TEMPLATE_TEST_CASE(Unit_texCubemap_Positive_ReadModeElementType, char, unsigned char, short,
                    unsigned short, int, unsigned int, float) {
   CHECK_IMAGE_SUPPORT;
   INFO("texCubemap isn't supported. Skipped.");
@@ -130,7 +130,7 @@ TEMPLATE_TEST_CASE("Unit_texCubemap_Positive_ReadModeElementType", "", char, uns
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEMPLATE_TEST_CASE("Unit_texCubemap_Positive_ReadModeNormalizedFloat", "", char, unsigned char,
+TEMPLATE_TEST_CASE(Unit_texCubemap_Positive_ReadModeNormalizedFloat, char, unsigned char,
                    short, unsigned short) {
   CHECK_IMAGE_SUPPORT;
   INFO("texCubemap isn't supported. Skipped.");

--- a/projects/hip-tests/catch/unit/texture/texCubemapGrad.cc
+++ b/projects/hip-tests/catch/unit/texture/texCubemapGrad.cc
@@ -48,7 +48,7 @@ THE SOFTWARE.
  * ------------------------
  *    - HIP_VERSION >= 5.7
  */
-TEMPLATE_TEST_CASE("Unit_texCubemapGrad_Positive_ReadModeElementType", "", char, unsigned char,
+TEMPLATE_TEST_CASE(Unit_texCubemapGrad_Positive_ReadModeElementType, char, unsigned char,
                    short, unsigned short, int, unsigned int, float) {
   CHECK_IMAGE_SUPPORT;
   INFO("texCubemap isn't supported. Skipped.");
@@ -130,7 +130,7 @@ TEMPLATE_TEST_CASE("Unit_texCubemapGrad_Positive_ReadModeElementType", "", char,
  * ------------------------
  *    - HIP_VERSION >= 5.7
  */
-TEMPLATE_TEST_CASE("Unit_texCubemapGrad_Positive_ReadModeNormalizedFloat", "", char, unsigned char,
+TEMPLATE_TEST_CASE(Unit_texCubemapGrad_Positive_ReadModeNormalizedFloat, char, unsigned char,
                    short, unsigned short) {
   CHECK_IMAGE_SUPPORT;
   INFO("texCubemap isn't supported. Skipped.");

--- a/projects/hip-tests/catch/unit/texture/texCubemapLayered.cc
+++ b/projects/hip-tests/catch/unit/texture/texCubemapLayered.cc
@@ -48,7 +48,7 @@ THE SOFTWARE.
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEMPLATE_TEST_CASE("Unit_texCubemapLayered_Positive_ReadModeElementType", "", char, unsigned char,
+TEMPLATE_TEST_CASE(Unit_texCubemapLayered_Positive_ReadModeElementType, char, unsigned char,
                    short, unsigned short, int, unsigned int, float) {
   CHECK_IMAGE_SUPPORT;
   INFO("texCubemap isn't supported. Skipped.");
@@ -133,7 +133,7 @@ TEMPLATE_TEST_CASE("Unit_texCubemapLayered_Positive_ReadModeElementType", "", ch
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEMPLATE_TEST_CASE("Unit_texCubemapLayered_Positive_ReadModeNormalizedFloat", "", char,
+TEMPLATE_TEST_CASE(Unit_texCubemapLayered_Positive_ReadModeNormalizedFloat, char,
                    unsigned char, short, unsigned short) {
   CHECK_IMAGE_SUPPORT;
   INFO("texCubemap isn't supported. Skipped.");

--- a/projects/hip-tests/catch/unit/texture/texCubemapLayeredGrad.cc
+++ b/projects/hip-tests/catch/unit/texture/texCubemapLayeredGrad.cc
@@ -48,7 +48,7 @@ THE SOFTWARE.
  * ------------------------
  *    - HIP_VERSION >= 5.7
  */
-TEMPLATE_TEST_CASE("Unit_texCubemapLayeredGrad_Positive_ReadModeElementType", "", char,
+TEMPLATE_TEST_CASE(Unit_texCubemapLayeredGrad_Positive_ReadModeElementType, char,
                    unsigned char, short, unsigned short, int, unsigned int, float) {
   CHECK_IMAGE_SUPPORT;
   INFO("texCubemap isn't supported. Skipped.");
@@ -134,7 +134,7 @@ TEMPLATE_TEST_CASE("Unit_texCubemapLayeredGrad_Positive_ReadModeElementType", ""
  * ------------------------
  *    - HIP_VERSION >= 5.7
  */
-TEMPLATE_TEST_CASE("Unit_texCubemapLayeredGrad_Positive_ReadModeNormalizedFloat", "", char,
+TEMPLATE_TEST_CASE(Unit_texCubemapLayeredGrad_Positive_ReadModeNormalizedFloat, char,
                    unsigned char, short, unsigned short) {
   CHECK_IMAGE_SUPPORT;
   INFO("texCubemap isn't supported. Skipped.");

--- a/projects/hip-tests/catch/unit/texture/texCubemapLayeredLod.cc
+++ b/projects/hip-tests/catch/unit/texture/texCubemapLayeredLod.cc
@@ -48,7 +48,7 @@ THE SOFTWARE.
  * ------------------------
  *    - HIP_VERSION >= 5.7
  */
-TEMPLATE_TEST_CASE("Unit_texCubemapLayeredLod_Positive_ReadModeElementType", "", char,
+TEMPLATE_TEST_CASE(Unit_texCubemapLayeredLod_Positive_ReadModeElementType, char,
                    unsigned char, short, unsigned short, int, unsigned int, float) {
   CHECK_IMAGE_SUPPORT;
   INFO("texCubemap isn't supported. Skipped.");
@@ -134,7 +134,7 @@ TEMPLATE_TEST_CASE("Unit_texCubemapLayeredLod_Positive_ReadModeElementType", "",
  * ------------------------
  *    - HIP_VERSION >= 5.7
  */
-TEMPLATE_TEST_CASE("Unit_texCubemapLayeredLod_Positive_ReadModeNormalizedFloat", "", char,
+TEMPLATE_TEST_CASE(Unit_texCubemapLayeredLod_Positive_ReadModeNormalizedFloat, char,
                    unsigned char, short, unsigned short) {
   CHECK_IMAGE_SUPPORT;
   INFO("texCubemap isn't supported. Skipped.");

--- a/projects/hip-tests/catch/unit/texture/texCubemapLod.cc
+++ b/projects/hip-tests/catch/unit/texture/texCubemapLod.cc
@@ -48,7 +48,7 @@ THE SOFTWARE.
  * ------------------------
  *    - HIP_VERSION >= 5.7
  */
-TEMPLATE_TEST_CASE("Unit_texCubemapLod_Positive_ReadModeElementType", "", char, unsigned char,
+TEMPLATE_TEST_CASE(Unit_texCubemapLod_Positive_ReadModeElementType, char, unsigned char,
                    short, unsigned short, int, unsigned int, float) {
   CHECK_IMAGE_SUPPORT;
   INFO("texCubemap isn't supported. Skipped.");
@@ -130,7 +130,7 @@ TEMPLATE_TEST_CASE("Unit_texCubemapLod_Positive_ReadModeElementType", "", char, 
  * ------------------------
  *    - HIP_VERSION >= 5.7
  */
-TEMPLATE_TEST_CASE("Unit_texCubemapLod_Positive_ReadModeNormalizedFloat", "", char, unsigned char,
+TEMPLATE_TEST_CASE(Unit_texCubemapLod_Positive_ReadModeNormalizedFloat, char, unsigned char,
                    short, unsigned short) {
   CHECK_IMAGE_SUPPORT;
   INFO("texCubemap isn't supported. Skipped.");

--- a/projects/hip-tests/catch/unit/threadfence/__threadfence.cc
+++ b/projects/hip-tests/catch/unit/threadfence/__threadfence.cc
@@ -44,7 +44,7 @@ THE SOFTWARE.
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit___threadfence_Positive_Basic_Shared") {
+TEST_CASE(Unit___threadfence_Positive_Basic_Shared) {
   LinearAllocGuard<int> in_dev(LinearAllocs::hipMalloc, 2 * sizeof(int));
   LinearAllocGuard<int> out_dev(LinearAllocs::hipMalloc, 2 * sizeof(int));
 
@@ -76,7 +76,7 @@ TEST_CASE("Unit___threadfence_Positive_Basic_Shared") {
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit___threadfence_Positive_Basic_Global") {
+TEST_CASE(Unit___threadfence_Positive_Basic_Global) {
   LinearAllocGuard<int> in_dev(LinearAllocs::hipMalloc, 2 * sizeof(int));
   LinearAllocGuard<int> out_dev(LinearAllocs::hipMalloc, 2 * sizeof(int));
 
@@ -108,7 +108,7 @@ TEST_CASE("Unit___threadfence_Positive_Basic_Global") {
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit___threadfence_Positive_Basic_Pinned") {
+TEST_CASE(Unit___threadfence_Positive_Basic_Pinned) {
   LinearAllocGuard<int> in_host(LinearAllocs::hipHostMalloc, 2 * sizeof(int));
   LinearAllocGuard<int> out_host(LinearAllocs::hipHostMalloc, 2 * sizeof(int));
 
@@ -136,7 +136,7 @@ TEST_CASE("Unit___threadfence_Positive_Basic_Pinned") {
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit___threadfence_Positive_Basic_Managed") {
+TEST_CASE(Unit___threadfence_Positive_Basic_Managed) {
   LinearAllocGuard<int> in_host(LinearAllocs::hipMallocManaged, 2 * sizeof(int));
   LinearAllocGuard<int> out_host(LinearAllocs::hipMallocManaged, 2 * sizeof(int));
 
@@ -164,7 +164,7 @@ TEST_CASE("Unit___threadfence_Positive_Basic_Managed") {
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit___threadfence_Positive_Basic_Peer", "[multigpu]") {
+TEST_CASE(Unit___threadfence_Positive_Basic_Peer) {
   const auto device_count = HipTest::getDeviceCount();
   if (device_count < 2) {
     HipTest::HIP_SKIP_TEST("At least 2 devices are required");

--- a/projects/hip-tests/catch/unit/threadfence/__threadfence_block.cc
+++ b/projects/hip-tests/catch/unit/threadfence/__threadfence_block.cc
@@ -44,7 +44,7 @@ THE SOFTWARE.
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit___threadfence_block_Positive_Basic_Shared") {
+TEST_CASE(Unit___threadfence_block_Positive_Basic_Shared) {
   LinearAllocGuard<int> in_dev(LinearAllocs::hipMalloc, 2 * sizeof(int));
   LinearAllocGuard<int> out_dev(LinearAllocs::hipMalloc, 2 * sizeof(int));
 
@@ -76,7 +76,7 @@ TEST_CASE("Unit___threadfence_block_Positive_Basic_Shared") {
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit___threadfence_block_Positive_Basic_Global") {
+TEST_CASE(Unit___threadfence_block_Positive_Basic_Global) {
   LinearAllocGuard<int> in_dev(LinearAllocs::hipMalloc, 2 * sizeof(int));
   LinearAllocGuard<int> out_dev(LinearAllocs::hipMalloc, 2 * sizeof(int));
 
@@ -108,7 +108,7 @@ TEST_CASE("Unit___threadfence_block_Positive_Basic_Global") {
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit___threadfence_block_Positive_Basic_Pinned") {
+TEST_CASE(Unit___threadfence_block_Positive_Basic_Pinned) {
   LinearAllocGuard<int> in_host(LinearAllocs::hipHostMalloc, 2 * sizeof(int));
   LinearAllocGuard<int> out_host(LinearAllocs::hipHostMalloc, 2 * sizeof(int));
 
@@ -136,7 +136,7 @@ TEST_CASE("Unit___threadfence_block_Positive_Basic_Pinned") {
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit___threadfence_block_Positive_Basic_Managed") {
+TEST_CASE(Unit___threadfence_block_Positive_Basic_Managed) {
   LinearAllocGuard<int> in_host(LinearAllocs::hipMallocManaged, 2 * sizeof(int));
   LinearAllocGuard<int> out_host(LinearAllocs::hipMallocManaged, 2 * sizeof(int));
 
@@ -164,7 +164,7 @@ TEST_CASE("Unit___threadfence_block_Positive_Basic_Managed") {
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit___threadfence_block_Positive_Basic_Peer", "[multigpu]") {
+TEST_CASE(Unit___threadfence_block_Positive_Basic_Peer) {
   const auto device_count = HipTest::getDeviceCount();
   if (device_count < 2) {
     HipTest::HIP_SKIP_TEST("At least 2 devices are required");

--- a/projects/hip-tests/catch/unit/threadfence/__threadfence_system.cc
+++ b/projects/hip-tests/catch/unit/threadfence/__threadfence_system.cc
@@ -60,7 +60,7 @@ __global__ void ReadKernel(int* out, int* in) {
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit___threadfence_system_Positive_Basic_Peer", "[multigpu]") {
+TEST_CASE(Unit___threadfence_system_Positive_Basic_Peer) {
   const auto device_count = HipTest::getDeviceCount();
   if (device_count < 2) {
     HipTest::HIP_SKIP_TEST("At least 2 devices are required");
@@ -114,7 +114,7 @@ TEST_CASE("Unit___threadfence_system_Positive_Basic_Peer", "[multigpu]") {
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit___threadfence_system_Positive_Basic_Host") {
+TEST_CASE(Unit___threadfence_system_Positive_Basic_Host) {
   LinearAllocGuard<int> in_host(LinearAllocs::hipHostMalloc, 2 * sizeof(int));
   LinearAllocGuard<int> out_host(LinearAllocs::hipHostMalloc, 2 * sizeof(int));
 

--- a/projects/hip-tests/catch/unit/vector_types/dim3.cc
+++ b/projects/hip-tests/catch/unit/vector_types/dim3.cc
@@ -48,7 +48,7 @@ __global__ void Dim3VectorKernel(dim3* vector, const uint32_t x, const uint32_t 
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_dim3_Empty_Positive_Device") {
+TEST_CASE(Unit_dim3_Empty_Positive_Device) {
   dim3 vector_h{0, 0, 0};
   dim3* vector_d;
   HIP_CHECK(hipMalloc(&vector_d, sizeof(dim3)));
@@ -75,7 +75,7 @@ TEST_CASE("Unit_dim3_Empty_Positive_Device") {
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_dim3_X_Positive_Device") {
+TEST_CASE(Unit_dim3_X_Positive_Device) {
   dim3 vector_h{0, 0, 0};
   dim3* vector_d;
   HIP_CHECK(hipMalloc(&vector_d, sizeof(dim3)));
@@ -105,7 +105,7 @@ TEST_CASE("Unit_dim3_X_Positive_Device") {
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_dim3_XY_Positive_Device") {
+TEST_CASE(Unit_dim3_XY_Positive_Device) {
   dim3 vector_h{0, 0, 0};
   dim3* vector_d;
   HIP_CHECK(hipMalloc(&vector_d, sizeof(dim3)));
@@ -138,7 +138,7 @@ TEST_CASE("Unit_dim3_XY_Positive_Device") {
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_dim3_XYZ_Positive_Device") {
+TEST_CASE(Unit_dim3_XYZ_Positive_Device) {
   dim3 vector_h{0, 0, 0};
   dim3* vector_d;
   HIP_CHECK(hipMalloc(&vector_d, sizeof(dim3)));
@@ -175,7 +175,7 @@ TEST_CASE("Unit_dim3_XYZ_Positive_Device") {
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_dim3_Empty_Positive_Host") {
+TEST_CASE(Unit_dim3_Empty_Positive_Host) {
   dim3 vector = dim3();
   REQUIRE(vector.x == 1);
   REQUIRE(vector.y == 1);
@@ -195,7 +195,7 @@ TEST_CASE("Unit_dim3_Empty_Positive_Host") {
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_dim3_X_Positive_Host") {
+TEST_CASE(Unit_dim3_X_Positive_Host) {
   uint32_t value_x =
       GENERATE(std::numeric_limits<uint32_t>::min(), std::numeric_limits<uint32_t>::max() / 2,
                std::numeric_limits<uint32_t>::max());
@@ -218,7 +218,7 @@ TEST_CASE("Unit_dim3_X_Positive_Host") {
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_dim3_XY_Positive_Host") {
+TEST_CASE(Unit_dim3_XY_Positive_Host) {
   uint32_t value_x =
       GENERATE(std::numeric_limits<uint32_t>::min(), std::numeric_limits<uint32_t>::max() / 2,
                std::numeric_limits<uint32_t>::max());
@@ -244,7 +244,7 @@ TEST_CASE("Unit_dim3_XY_Positive_Host") {
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_dim3_XYZ_Positive_Host") {
+TEST_CASE(Unit_dim3_XYZ_Positive_Host) {
   uint32_t value_x =
       GENERATE(std::numeric_limits<uint32_t>::min(), std::numeric_limits<uint32_t>::max() / 2,
                std::numeric_limits<uint32_t>::max());

--- a/projects/hip-tests/catch/unit/vector_types/vector_types.cc
+++ b/projects/hip-tests/catch/unit/vector_types/vector_types.cc
@@ -55,7 +55,7 @@ THE SOFTWARE.
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEMPLATE_TEST_CASE("Unit_make_vector_SanityCheck_Basic_Host", "", char, unsigned char, short,
+TEMPLATE_TEST_CASE(Unit_make_vector_SanityCheck_Basic_Host, char, unsigned char, short,
                    unsigned short, int, unsigned int, long, unsigned long, long long,
                    unsigned long long, float, double) {
   {
@@ -109,7 +109,7 @@ TEMPLATE_TEST_CASE("Unit_make_vector_SanityCheck_Basic_Host", "", char, unsigned
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEMPLATE_TEST_CASE("Unit_make_vector_SanityCheck_Basic_Device", "", char, unsigned char, short,
+TEMPLATE_TEST_CASE(Unit_make_vector_SanityCheck_Basic_Device, char, unsigned char, short,
                    unsigned short, int, unsigned int, long, unsigned long, long long,
                    unsigned long long, float, double) {
   {
@@ -153,9 +153,9 @@ TEMPLATE_TEST_CASE("Unit_make_vector_SanityCheck_Basic_Device", "", char, unsign
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEMPLATE_TEST_CASE("Unit_VectorAndVectorOperations_SanityCheck_Basic_Host", "", char,
-                   unsigned char, short, unsigned short, int, unsigned int, long, unsigned long,
-                   long long, unsigned long long, float, double) {
+TEMPLATE_TEST_CASE(Unit_VectorAndVectorOperations_SanityCheck_Basic_Host, char, unsigned char,
+                   short, unsigned short, int, unsigned int, long, unsigned long, long long,
+                   unsigned long long, float, double) {
   const VectorOperation operations[] = {
       VectorOperation::kIncrementPrefix,  VectorOperation::kIncrementPostfix,
       VectorOperation::kDecrementPrefix, VectorOperation::kDecrementPostfix,
@@ -232,9 +232,9 @@ TEMPLATE_TEST_CASE("Unit_VectorAndVectorOperations_SanityCheck_Basic_Host", "", 
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEMPLATE_TEST_CASE("Unit_VectorAndValueTypeOperations_SanityCheck_Basic_Host", "", char,
-                   unsigned char, short, unsigned short, int, unsigned int, long, unsigned long,
-                   long long, unsigned long long, float, double) {
+TEMPLATE_TEST_CASE(Unit_VectorAndValueTypeOperations_SanityCheck_Basic_Host, char, unsigned char,
+                   short, unsigned short, int, unsigned int, long, unsigned long, long long,
+                   unsigned long long, float, double) {
   const VectorOperation operations[] = {
       VectorOperation::kAddAssign,      VectorOperation::kSubtractAssign,
       VectorOperation::kMultiplyAssign, VectorOperation::kDivideAssign,
@@ -305,9 +305,9 @@ TEMPLATE_TEST_CASE("Unit_VectorAndValueTypeOperations_SanityCheck_Basic_Host", "
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEMPLATE_TEST_CASE("Unit_VectorAndVectorOperations_SanityCheck_Basic_Device", "", char,
-                   unsigned char, short, unsigned short, int, unsigned int, long, unsigned long,
-                   long long, unsigned long long, float, double) {
+TEMPLATE_TEST_CASE(Unit_VectorAndVectorOperations_SanityCheck_Basic_Device, char, unsigned char,
+                   short, unsigned short, int, unsigned int, long, unsigned long, long long,
+                   unsigned long long, float, double) {
   const VectorOperation operations[] = {
       VectorOperation::kIncrementPrefix,  VectorOperation::kIncrementPostfix,
       VectorOperation::kDecrementPrefix, VectorOperation::kDecrementPostfix,
@@ -384,9 +384,9 @@ TEMPLATE_TEST_CASE("Unit_VectorAndVectorOperations_SanityCheck_Basic_Device", ""
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEMPLATE_TEST_CASE("Unit_VectorAndValueTypeOperations_SanityCheck_Basic_Device", "", char,
-                   unsigned char, short, unsigned short, int, unsigned int, long, unsigned long,
-                   long long, unsigned long long, float, double) {
+TEMPLATE_TEST_CASE(Unit_VectorAndValueTypeOperations_SanityCheck_Basic_Device, char, unsigned char,
+                   short, unsigned short, int, unsigned int, long, unsigned long, long long,
+                   unsigned long long, float, double) {
   const VectorOperation operations[] = {
       VectorOperation::kAddAssign,      VectorOperation::kSubtractAssign,
       VectorOperation::kMultiplyAssign,  VectorOperation::kDivideAssign,
@@ -455,7 +455,7 @@ TEMPLATE_TEST_CASE("Unit_VectorAndValueTypeOperations_SanityCheck_Basic_Device",
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEMPLATE_TEST_CASE("Unit_VectorStructuredBindings_SanityCheck_Basic_host", "", float3, double3) {
+TEMPLATE_TEST_CASE(Unit_VectorStructuredBindings_SanityCheck_Basic_host, float3, double3) {
   auto value = GetTestValue<decltype(TestType().x)>(0);
 
   TestType vec3 = {value, value, value};
@@ -485,7 +485,7 @@ __global__ void generate_my_kernel() { static_assert(func()); }
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_VectorConstexpr_SanityCheck_Basic_host_device", "") {
+TEST_CASE(Unit_VectorConstexpr_SanityCheck_Basic_host_device) {
   generate_my_kernel<<<1, 1>>>();
   static_assert(func());
 }
@@ -577,7 +577,7 @@ __global__ void check_alignment_device() { check_alignment(); }
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_Vector_alignment_check", "") {
+TEST_CASE(Unit_Vector_alignment_check) {
   check_alignment_device<<<1, 1>>>();
   check_alignment();
 }
@@ -670,7 +670,7 @@ __global__ void check_size_device() { check_size(); }
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_Vector_size_check", "") {
+TEST_CASE(Unit_Vector_size_check) {
   check_size_device<<<1, 1>>>();
   check_size();
 }

--- a/projects/hip-tests/catch/unit/virtualMemoryManagement/hipGetProcAddressVmmApis.cc
+++ b/projects/hip-tests/catch/unit/virtualMemoryManagement/hipGetProcAddressVmmApis.cc
@@ -37,7 +37,7 @@ THE SOFTWARE.
  * ------------------------
  *  - HIP_VERSION >= 6.2
  */
-TEST_CASE("Unit_hipGetProcAddress_VMM") {
+TEST_CASE(Unit_hipGetProcAddress_VMM) {
   int value = 0;
   HIP_CHECK(hipDeviceGetAttribute(&value, hipDeviceAttributeVirtualMemoryManagementSupported, 0));
   if (value == 0) {

--- a/projects/hip-tests/catch/unit/virtualMemoryManagement/hipMemAddressFree.cc
+++ b/projects/hip-tests/catch/unit/virtualMemoryManagement/hipMemAddressFree.cc
@@ -44,7 +44,7 @@ THE SOFTWARE.
  * ------------------------
  *    - HIP_VERSION >= 6.1
  */
-TEST_CASE("Unit_hipMemAddressFree_negative") {
+TEST_CASE(Unit_hipMemAddressFree_negative) {
   size_t granularity = 0;
   constexpr int N = DATA_SIZE;
   size_t buffer_size = N * sizeof(int);
@@ -75,7 +75,7 @@ TEST_CASE("Unit_hipMemAddressFree_negative") {
   CTX_DESTROY();
 }
 
-TEST_CASE("Unit_hipMemAddressFree_Capture") {
+TEST_CASE(Unit_hipMemAddressFree_Capture) {
   CTX_CREATE();
   size_t granularity = 0;
   size_t buffer_size = DATA_SIZE * sizeof(int);

--- a/projects/hip-tests/catch/unit/virtualMemoryManagement/hipMemAddressReserve.cc
+++ b/projects/hip-tests/catch/unit/virtualMemoryManagement/hipMemAddressReserve.cc
@@ -49,7 +49,7 @@ THE SOFTWARE.
  * ------------------------
  *    - HIP_VERSION >= 6.1
  */
-TEST_CASE("Unit_hipMemAddressReserve_AlignmentTest") {
+TEST_CASE(Unit_hipMemAddressReserve_AlignmentTest) {
   size_t granularity = 0;
   constexpr int N = DATA_SIZE;
   size_t buffer_size = N * sizeof(int);
@@ -113,7 +113,7 @@ TEST_CASE("Unit_hipMemAddressReserve_AlignmentTest") {
  * ------------------------
  *    - HIP_VERSION >= 6.1
  */
-TEST_CASE("Unit_hipMemAddressReserve_Negative") {
+TEST_CASE(Unit_hipMemAddressReserve_Negative) {
   size_t granularity = 0;
   constexpr int N = DATA_SIZE;
   size_t buffer_size = N * sizeof(int);
@@ -152,7 +152,7 @@ TEST_CASE("Unit_hipMemAddressReserve_Negative") {
   CTX_DESTROY();
 }
 
-TEST_CASE("Unit_hipMemAddressReserve_Capture") {
+TEST_CASE(Unit_hipMemAddressReserve_Capture) {
   hipMemGenericAllocationHandle_t allocation_handle;
   size_t granularity = 0;
   constexpr size_t kAlignment = 2;

--- a/projects/hip-tests/catch/unit/virtualMemoryManagement/hipMemCreate.cc
+++ b/projects/hip-tests/catch/unit/virtualMemoryManagement/hipMemCreate.cc
@@ -60,7 +60,7 @@ static __global__ void square_kernel(int* Buff) {
  * ------------------------
  *    - HIP_VERSION >= 7.0
  */
-TEST_CASE("Unit_hipMemCreate_BasicAllocateDeAlloc_MultGranularity") {
+TEST_CASE(Unit_hipMemCreate_BasicAllocateDeAlloc_MultGranularity) {
   size_t granularity = 0;
   int deviceId = 0;
   CTX_CREATE();
@@ -107,7 +107,7 @@ TEST_CASE("Unit_hipMemCreate_BasicAllocateDeAlloc_MultGranularity") {
  * ------------------------
  *    - HIP_VERSION >= 7.0
  */
-TEST_CASE("Unit_hipMemCreate_ChkDev2HstMemcpy_ReleaseHdlPostUnmap") {
+TEST_CASE(Unit_hipMemCreate_ChkDev2HstMemcpy_ReleaseHdlPostUnmap) {
   size_t granularity = 0;
   constexpr int N = DATA_SIZE;
   size_t buffer_size = N * sizeof(int);
@@ -176,7 +176,7 @@ TEST_CASE("Unit_hipMemCreate_ChkDev2HstMemcpy_ReleaseHdlPostUnmap") {
  * ------------------------
  *    - HIP_VERSION >= 7.0
  */
-TEST_CASE("Unit_hipMemCreate_ChkDev2HstMemcpy_ReleaseHdlPreUse") {
+TEST_CASE(Unit_hipMemCreate_ChkDev2HstMemcpy_ReleaseHdlPreUse) {
   size_t granularity = 0;
   constexpr int N = DATA_SIZE;
   size_t buffer_size = N * sizeof(int);
@@ -245,7 +245,7 @@ TEST_CASE("Unit_hipMemCreate_ChkDev2HstMemcpy_ReleaseHdlPreUse") {
  * ------------------------
  *    - HIP_VERSION >= 7.0
  */
-TEST_CASE("Unit_hipMemCreate_ChkWithKerLaunch") {
+TEST_CASE(Unit_hipMemCreate_ChkWithKerLaunch) {
   size_t granularity = 0;
   constexpr int N = DATA_SIZE;
   size_t buffer_size = N * sizeof(int);
@@ -318,7 +318,7 @@ TEST_CASE("Unit_hipMemCreate_ChkWithKerLaunch") {
  * ------------------------
  *    - HIP_VERSION >= 7.0
  */
-TEST_CASE("Unit_hipMemCreate_MapNonContiguousChunks") {
+TEST_CASE(Unit_hipMemCreate_MapNonContiguousChunks) {
   size_t granularity = 0;
   constexpr int numOfBuffers = NUM_OF_BUFFERS;
   constexpr int N = DATA_SIZE;
@@ -404,7 +404,7 @@ TEST_CASE("Unit_hipMemCreate_MapNonContiguousChunks") {
  * ------------------------
  *    - HIP_VERSION >= 7.0
  */
-TEST_CASE("Unit_hipMemCreate_ChkWithMemset") {
+TEST_CASE(Unit_hipMemCreate_ChkWithMemset) {
   size_t granularity = 0;
   constexpr int N = DATA_SIZE;
   size_t buffer_size = N * sizeof(int);
@@ -468,7 +468,7 @@ TEST_CASE("Unit_hipMemCreate_ChkWithMemset") {
  * ------------------------
  *    - HIP_VERSION >= 6.1
  */
-TEST_CASE("Unit_hipMemCreate_Negative") {
+TEST_CASE(Unit_hipMemCreate_Negative) {
   size_t granularity = 0;
   int deviceId = 0;
   hipDevice_t device;
@@ -522,7 +522,7 @@ TEST_CASE("Unit_hipMemCreate_Negative") {
   CTX_DESTROY();
 }
 
-TEST_CASE("Unit_hipMemCreate_Capture") {
+TEST_CASE(Unit_hipMemCreate_Capture) {
   CTX_CREATE();
 
   hipMemGenericAllocationHandle_t allocation_handle;

--- a/projects/hip-tests/catch/unit/virtualMemoryManagement/hipMemExportToShareableHandle.cc
+++ b/projects/hip-tests/catch/unit/virtualMemoryManagement/hipMemExportToShareableHandle.cc
@@ -45,7 +45,7 @@ THE SOFTWARE.
  *    - Host specific (LINUX)
  *    - HIP_VERSION >= 6.1
  */
-TEST_CASE("Unit_hipMemExportToShareableHandle_Positive_Basic") {
+TEST_CASE(Unit_hipMemExportToShareableHandle_Positive_Basic) {
   HIP_CHECK(hipFree(0));
 
   hipDevice_t device;
@@ -84,7 +84,7 @@ TEST_CASE("Unit_hipMemExportToShareableHandle_Positive_Basic") {
  *    - Host specific (LINUX)
  *    - HIP_VERSION >= 6.1
  */
-TEST_CASE("Unit_hipMemExportToShareableHandle_Negative_Parameters") {
+TEST_CASE(Unit_hipMemExportToShareableHandle_Negative_Parameters) {
   HIP_CHECK(hipFree(0));
 
   hipDevice_t device;
@@ -133,7 +133,7 @@ TEST_CASE("Unit_hipMemExportToShareableHandle_Negative_Parameters") {
   HIP_CHECK(hipMemRelease(handle));
 }
 
-TEST_CASE("Unit_hipMemExportToShareableHandle_Capture") {
+TEST_CASE(Unit_hipMemExportToShareableHandle_Capture) {
   CTX_CREATE();
 
   hipDevice_t device;

--- a/projects/hip-tests/catch/unit/virtualMemoryManagement/hipMemGetAllocationGranularity.cc
+++ b/projects/hip-tests/catch/unit/virtualMemoryManagement/hipMemGetAllocationGranularity.cc
@@ -58,7 +58,7 @@ void getGranularity(size_t* granularity, hipMemAllocationGranularity_flags optio
  * ------------------------
  *    - HIP_VERSION >= 6.1
  */
-TEST_CASE("Unit_hipMemGetAllocationGranularity_AllGPUs") {
+TEST_CASE(Unit_hipMemGetAllocationGranularity_AllGPUs) {
   HIP_CHECK(hipFree(0));
   int numDevices = 0;
   HIP_CHECK(hipGetDeviceCount(&numDevices));
@@ -91,7 +91,7 @@ TEST_CASE("Unit_hipMemGetAllocationGranularity_AllGPUs") {
  * ------------------------
  *    - HIP_VERSION >= 6.1
  */
-TEST_CASE("Unit_hipMemGetAllocationGranularity_NegativeTests") {
+TEST_CASE(Unit_hipMemGetAllocationGranularity_NegativeTests) {
   HIP_CHECK(hipFree(0));
   size_t granularity = 0;
   hipDevice_t device;
@@ -143,7 +143,7 @@ TEST_CASE("Unit_hipMemGetAllocationGranularity_NegativeTests") {
 #endif
 }
 
-TEST_CASE("Unit_hipMemGetAllocationGranularity_Capture") {
+TEST_CASE(Unit_hipMemGetAllocationGranularity_Capture) {
   CTX_CREATE();
 
   size_t granularity = 0;

--- a/projects/hip-tests/catch/unit/virtualMemoryManagement/hipMemGetAllocationPropertiesFromHandle.cc
+++ b/projects/hip-tests/catch/unit/virtualMemoryManagement/hipMemGetAllocationPropertiesFromHandle.cc
@@ -45,7 +45,7 @@ THE SOFTWARE.
  * ------------------------
  *    - HIP_VERSION >= 6.1
  */
-TEST_CASE("Unit_hipMemGetAllocationPropertiesFromHandle_functional") {
+TEST_CASE(Unit_hipMemGetAllocationPropertiesFromHandle_functional) {
   hipDevice_t device;
   CTX_CREATE();
   HIP_CHECK(hipDeviceGet(&device, 0));
@@ -85,7 +85,7 @@ TEST_CASE("Unit_hipMemGetAllocationPropertiesFromHandle_functional") {
  * ------------------------
  *    - HIP_VERSION >= 6.1
  */
-TEST_CASE("Unit_hipMemGetAllocationPropertiesFromHandle_Negative") {
+TEST_CASE(Unit_hipMemGetAllocationPropertiesFromHandle_Negative) {
   CTX_CREATE();
   hipDevice_t device;
   HIP_CHECK(hipDeviceGet(&device, 0));
@@ -121,7 +121,7 @@ TEST_CASE("Unit_hipMemGetAllocationPropertiesFromHandle_Negative") {
   CTX_DESTROY();
 }
 
-TEST_CASE("Unit_hipMemGetAllocationPropertiesFromHandle_Capture") {
+TEST_CASE(Unit_hipMemGetAllocationPropertiesFromHandle_Capture) {
   CTX_CREATE();
   hipDevice_t device;
   HIP_CHECK(hipDeviceGet(&device, 0));

--- a/projects/hip-tests/catch/unit/virtualMemoryManagement/hipMemGetHandleForAddressRange.cc
+++ b/projects/hip-tests/catch/unit/virtualMemoryManagement/hipMemGetHandleForAddressRange.cc
@@ -105,7 +105,7 @@ hipMemGenericAllocationHandle_t GetPhysicalMemory(hipDevice_t device, size_t siz
  * ------------------------
  *  - HIP_VERSION >= 7.0
  */
-TEST_CASE("Unit_hipMemGetHandleForAddressRange_Negative") {
+TEST_CASE(Unit_hipMemGetHandleForAddressRange_Negative) {
   int handle = -1;
   int* dptr = nullptr;
   constexpr int size = 10;
@@ -384,7 +384,7 @@ bool validateHandle(int handle, int size, int device = 0) {
  * ------------------------
  *  - HIP_VERSION >= 7.0
  */
-TEST_CASE("Unit_hipMemGetHandleForAddressRange_DeviceMemory") {
+TEST_CASE(Unit_hipMemGetHandleForAddressRange_DeviceMemory) {
   constexpr int size = 1024;
   constexpr int sizeBytes = size * sizeof(int);
   CTX_CREATE();
@@ -423,7 +423,7 @@ TEST_CASE("Unit_hipMemGetHandleForAddressRange_DeviceMemory") {
  * ------------------------
  *  - HIP_VERSION >= 7.0
  */
-TEST_CASE("Unit_hipMemGetHandleForAddressRange_VM") {
+TEST_CASE(Unit_hipMemGetHandleForAddressRange_VM) {
   CTX_CREATE();
   hipDevice_t device;
   constexpr int kDeviceId = 0;
@@ -466,8 +466,7 @@ TEST_CASE("Unit_hipMemGetHandleForAddressRange_VM") {
  * ------------------------
  *  - HIP_VERSION >= 7.0
  */
-TEST_CASE("Unit_hipMemGetHandleForAddressRange_DeviceMemory_InAnotherDevice",
-          "[multigpu]") {
+TEST_CASE(Unit_hipMemGetHandleForAddressRange_DeviceMemory_InAnotherDevice) {
   CTX_CREATE();
   int deviceCount = 0;
   HIP_CHECK(hipGetDeviceCount(&deviceCount));
@@ -522,8 +521,7 @@ TEST_CASE("Unit_hipMemGetHandleForAddressRange_DeviceMemory_InAnotherDevice",
  * ------------------------
  *  - HIP_VERSION >= 7.0
  */
-TEST_CASE("Unit_hipMemGetHandleForAddressRange_VM_InAnotherDevice",
-          "[multigpu]") {
+TEST_CASE(Unit_hipMemGetHandleForAddressRange_VM_InAnotherDevice) {
   CTX_CREATE();
   int deviceCount = 0;
   HIP_CHECK(hipGetDeviceCount(&deviceCount));
@@ -586,7 +584,7 @@ TEST_CASE("Unit_hipMemGetHandleForAddressRange_VM_InAnotherDevice",
  * ------------------------
  *  - HIP_VERSION >= 7.0
  */
-TEST_CASE("Unit_hipMemGetHandleForAddressRange_MulProc_Socket_DeviceMem") {
+TEST_CASE(Unit_hipMemGetHandleForAddressRange_MulProc_Socket_DeviceMem) {
   int fd[2], fdSig[2];
   REQUIRE(pipe(fd) == 0);
   REQUIRE(pipe(fdSig) == 0);
@@ -690,7 +688,7 @@ TEST_CASE("Unit_hipMemGetHandleForAddressRange_MulProc_Socket_DeviceMem") {
  * ------------------------
  *  - HIP_VERSION >= 7.0
  */
-TEST_CASE("Unit_hipMemGetHandleForAddressRange_MulProc_Socket_VM") {
+TEST_CASE(Unit_hipMemGetHandleForAddressRange_MulProc_Socket_VM) {
   int fd[2], fdSig[2];
   REQUIRE(pipe(fd) == 0);
   REQUIRE(pipe(fdSig) == 0);
@@ -833,7 +831,7 @@ void launchForVM() {
  * ------------------------
  *  - HIP_VERSION >= 7.0
  */
-TEST_CASE("Unit_hipMemGetHandleForAddressRange_MultipleThreads") {
+TEST_CASE(Unit_hipMemGetHandleForAddressRange_MultipleThreads) {
   hipDevice_t device;
   constexpr int kDeviceId = 0;
   HIP_CHECK(hipDeviceGet(&device, kDeviceId));
@@ -880,7 +878,7 @@ TEST_CASE("Unit_hipMemGetHandleForAddressRange_MultipleThreads") {
  * ------------------------
  *  - HIP_VERSION >= 7.0
  */
-TEST_CASE("Unit_hipMemGetHandleForAddressRange_DifferentOffsets") {
+TEST_CASE(Unit_hipMemGetHandleForAddressRange_DifferentOffsets) {
   hipDevice_t device;
   constexpr int kDeviceId = 0;
   HIP_CHECK(hipDeviceGet(&device, kDeviceId));

--- a/projects/hip-tests/catch/unit/virtualMemoryManagement/hipMemImportFromShareableHandle.cc
+++ b/projects/hip-tests/catch/unit/virtualMemoryManagement/hipMemImportFromShareableHandle.cc
@@ -57,7 +57,7 @@ static __global__ void square_kernel(int* Buff) {
  *    - Host specific (LINUX)
  *    - HIP_VERSION >= 6.1
  */
-TEST_CASE("Unit_hipMemImportFromShareableHandle_Positive_Basic") {
+TEST_CASE(Unit_hipMemImportFromShareableHandle_Positive_Basic) {
   CTX_CREATE();
 
   hipDevice_t device;
@@ -100,7 +100,7 @@ TEST_CASE("Unit_hipMemImportFromShareableHandle_Positive_Basic") {
  *    - Host specific (LINUX)
  *    - HIP_VERSION >= 6.1
  */
-TEST_CASE("Unit_hipMemImportFromShareableHandle_Negative_Parameters") {
+TEST_CASE(Unit_hipMemImportFromShareableHandle_Negative_Parameters) {
   CTX_CREATE();
 
   hipDevice_t device;
@@ -156,7 +156,7 @@ TEST_CASE("Unit_hipMemImportFromShareableHandle_Negative_Parameters") {
  *    - Host specific (LINUX)
  *    - HIP_VERSION >= 6.2
  */
-TEST_CASE("Unit_hipMemImportFromShareableHandle_MulProc_ChldUseHdl") {
+TEST_CASE(Unit_hipMemImportFromShareableHandle_MulProc_ChldUseHdl) {
   constexpr int N = DATA_SIZE;
   size_t buffer_size = N * sizeof(int);
   int fd[2], fdSig[2];
@@ -281,7 +281,7 @@ TEST_CASE("Unit_hipMemImportFromShareableHandle_MulProc_ChldUseHdl") {
  *    - Host specific (LINUX)
  *    - HIP_VERSION >= 6.2
  */
-TEST_CASE("Unit_hipMemImportFromShareableHandle_MulProc_ParntChldUseHdl") {
+TEST_CASE(Unit_hipMemImportFromShareableHandle_MulProc_ParntChldUseHdl) {
   constexpr int N = DATA_SIZE;
   size_t buffer_size = N * sizeof(int);
   int fd[2], fdSig[2];
@@ -429,7 +429,7 @@ TEST_CASE("Unit_hipMemImportFromShareableHandle_MulProc_ParntChldUseHdl") {
  *    - Host specific (LINUX)
  *    - HIP_VERSION >= 6.2
  */
-TEST_CASE("Unit_hipMemImportFromShareableHandle_MulProc_GrndChldUseHdl") {
+TEST_CASE(Unit_hipMemImportFromShareableHandle_MulProc_GrndChldUseHdl) {
   constexpr int N = DATA_SIZE;
   size_t buffer_size = N * sizeof(int);
   int fd[2], fdSig[2], fdpid[2];
@@ -560,7 +560,7 @@ TEST_CASE("Unit_hipMemImportFromShareableHandle_MulProc_GrndChldUseHdl") {
   }
 }
 
-TEST_CASE("Unit_hipMemImportFromShareableHandle_Capture") {
+TEST_CASE(Unit_hipMemImportFromShareableHandle_Capture) {
   CTX_CREATE();
 
   hipDevice_t device;

--- a/projects/hip-tests/catch/unit/virtualMemoryManagement/hipMemMap.cc
+++ b/projects/hip-tests/catch/unit/virtualMemoryManagement/hipMemMap.cc
@@ -61,7 +61,7 @@ static __global__ void square_kernel(int* Buff) {
  * ------------------------
  *    - HIP_VERSION >= 7.0
  */
-TEST_CASE("Unit_hipMemMap_SameMemoryReuse") {
+TEST_CASE(Unit_hipMemMap_SameMemoryReuse) {
   constexpr int iterations = 20;
   size_t granularity = 0;
   size_t buffer_size = N * sizeof(int);
@@ -138,7 +138,7 @@ TEST_CASE("Unit_hipMemMap_SameMemoryReuse") {
  * ------------------------
  *    - HIP_VERSION >= 7.0
  */
-TEST_CASE("Unit_hipMemMap_PhysicalMemoryReuse_SingleGPU") {
+TEST_CASE(Unit_hipMemMap_PhysicalMemoryReuse_SingleGPU) {
   size_t granularity = 0;
   size_t buffer_size = N * sizeof(int);
   CTX_CREATE();
@@ -219,7 +219,7 @@ TEST_CASE("Unit_hipMemMap_PhysicalMemoryReuse_SingleGPU") {
  * ------------------------
  *    - HIP_VERSION >= 7.0
  */
-TEST_CASE("Unit_hipMemMap_PhysicalMemory_Map2MultVMMs") {
+TEST_CASE(Unit_hipMemMap_PhysicalMemory_Map2MultVMMs) {
   size_t granularity = 0;
   size_t buffer_size = N * sizeof(int);
   CTX_CREATE();
@@ -364,7 +364,7 @@ void physicalMemoryReuse_MultiDev (hipMemAllocationProp prop) {
  * ------------------------
  *    - HIP_VERSION >= 7.0
  */
-TEST_CASE("Unit_hipMemMap_PhysicalMemoryReuse_MultiDev", "[multigpu]") {
+TEST_CASE(Unit_hipMemMap_PhysicalMemoryReuse_MultiDev) {
   CHECK_P2P_SUPPORT
   SECTION("Memory Allocation Type as hipMemAllocationTypePinned") {
     hipMemAllocationProp prop{};
@@ -394,7 +394,7 @@ TEST_CASE("Unit_hipMemMap_PhysicalMemoryReuse_MultiDev", "[multigpu]") {
  * ------------------------
  *    - HIP_VERSION >= 7.0
  */
-TEST_CASE("Unit_hipMemMap_VMMMemoryReuse_SingleGPU") {
+TEST_CASE(Unit_hipMemMap_VMMMemoryReuse_SingleGPU) {
   size_t granularity = 0;
   size_t buffer_size = N * sizeof(int);
   CTX_CREATE();
@@ -554,7 +554,7 @@ void vMMMemoryReuse_MultiGPU (hipMemAllocationProp prop) {
  * ------------------------
  *    - HIP_VERSION >= 7.0
  */
-TEST_CASE("Unit_hipMemMap_VMMMemoryReuse_MultiGPU", "[multigpu]") {
+TEST_CASE(Unit_hipMemMap_VMMMemoryReuse_MultiGPU) {
   CHECK_P2P_SUPPORT
   SECTION("Memory Allocation Type as hipMemAllocationTypePinned") {
     hipMemAllocationProp prop{};
@@ -583,7 +583,7 @@ TEST_CASE("Unit_hipMemMap_VMMMemoryReuse_MultiGPU", "[multigpu]") {
  * ------------------------
  *    - HIP_VERSION >= 7.0
  */
-TEST_CASE("Unit_hipMemMap_MapPartialVMMMem") {
+TEST_CASE(Unit_hipMemMap_MapPartialVMMMem) {
   int deviceId = 0;
   size_t granularity = 0;
   size_t buffer_size = N * sizeof(int);
@@ -648,7 +648,7 @@ TEST_CASE("Unit_hipMemMap_MapPartialVMMMem") {
  * ------------------------
  *    - HIP_VERSION >= 6.1
  */
-TEST_CASE("Unit_hipMemMap_negative") {
+TEST_CASE(Unit_hipMemMap_negative) {
   size_t granularity = 0;
   size_t buffer_size = N * sizeof(int);
   CTX_CREATE();
@@ -684,7 +684,7 @@ TEST_CASE("Unit_hipMemMap_negative") {
   CTX_DESTROY();
 }
 
-TEST_CASE("Unit_hipMemMap_Capture") {
+TEST_CASE(Unit_hipMemMap_Capture) {
   hipMemGenericAllocationHandle_t handle;
   size_t granularity = 0;
   constexpr size_t kAlignment = 2;

--- a/projects/hip-tests/catch/unit/virtualMemoryManagement/hipMemMapArrayAsync.cc
+++ b/projects/hip-tests/catch/unit/virtualMemoryManagement/hipMemMapArrayAsync.cc
@@ -46,7 +46,7 @@ THE SOFTWARE.
  * ------------------------
  *    - HIP_VERSION >= 6.1
  */
-TEST_CASE("Unit_hipMemMapArrayAsync_Positive_Basic") {
+TEST_CASE(Unit_hipMemMapArrayAsync_Positive_Basic) {
   HIP_CHECK(hipFree(0));
 
   hipDevice_t device;

--- a/projects/hip-tests/catch/unit/virtualMemoryManagement/hipMemRelease.cc
+++ b/projects/hip-tests/catch/unit/virtualMemoryManagement/hipMemRelease.cc
@@ -41,7 +41,7 @@ THE SOFTWARE.
  * ------------------------
  *    - HIP_VERSION >= 6.1
  */
-TEST_CASE("Unit_hipMemRelease_negative") {
+TEST_CASE(Unit_hipMemRelease_negative) {
   CTX_CREATE();
   SECTION("Nullptr to handle") {
     REQUIRE(hipMemRelease((hipMemGenericAllocationHandle_t) nullptr) == hipErrorInvalidValue);
@@ -49,7 +49,7 @@ TEST_CASE("Unit_hipMemRelease_negative") {
   CTX_DESTROY();
 }
 
-TEST_CASE("Unit_hipMemRelease_Capture") {
+TEST_CASE(Unit_hipMemRelease_Capture) {
   CTX_CREATE();
 
   hipMemGenericAllocationHandle_t allocation_handle;

--- a/projects/hip-tests/catch/unit/virtualMemoryManagement/hipMemRetainAllocationHandle.cc
+++ b/projects/hip-tests/catch/unit/virtualMemoryManagement/hipMemRetainAllocationHandle.cc
@@ -47,7 +47,7 @@ THE SOFTWARE.
  * ------------------------
  *    - HIP_VERSION >= 6.1
  */
-TEST_CASE("Unit_hipMemRetainAllocationHandle_SetGet") {
+TEST_CASE(Unit_hipMemRetainAllocationHandle_SetGet) {
   HIP_CHECK(hipFree(0));
   size_t granularity = 0;
   constexpr int N = DATA_SIZE;
@@ -92,7 +92,7 @@ TEST_CASE("Unit_hipMemRetainAllocationHandle_SetGet") {
  * ------------------------
  *    - HIP_VERSION >= 6.1
  */
-TEST_CASE("Unit_hipMemRetainAllocationHandle_NegTst") {
+TEST_CASE(Unit_hipMemRetainAllocationHandle_NegTst) {
   HIP_CHECK(hipFree(0));
   size_t granularity = 0;
   constexpr int N = DATA_SIZE;
@@ -141,7 +141,7 @@ TEST_CASE("Unit_hipMemRetainAllocationHandle_NegTst") {
   HIP_CHECK(hipMemAddressFree(ptrA, size_mem));
 }
 
-TEST_CASE("Unit_hipMemRetainAllocationHandle_Capture") {
+TEST_CASE(Unit_hipMemRetainAllocationHandle_Capture) {
   CTX_CREATE();
   size_t granularity = 0;
   size_t buffer_size = DATA_SIZE * sizeof(int);

--- a/projects/hip-tests/catch/unit/virtualMemoryManagement/hipMemSetGetAccess.cc
+++ b/projects/hip-tests/catch/unit/virtualMemoryManagement/hipMemSetGetAccess.cc
@@ -79,7 +79,7 @@ __global__ void copyFromHostMem(const int* hostMem, int* devOut, int N) {
  * ------------------------
  *    - HIP_VERSION >= 6.1
  */
-TEST_CASE("Unit_hipMemSetAccess_SetGet") {
+TEST_CASE(Unit_hipMemSetAccess_SetGet) {
   size_t granularity = 0;
   constexpr int N = DATA_SIZE;
   size_t buffer_size = N * sizeof(int);
@@ -148,7 +148,7 @@ TEST_CASE("Unit_hipMemSetAccess_SetGet") {
  * ------------------------
  *    - HIP_VERSION >= 6.1
  */
-TEST_CASE("Unit_hipMemSetAccess_MultDevSetGet") {
+TEST_CASE(Unit_hipMemSetAccess_MultDevSetGet) {
   size_t granularity = 0;
   constexpr int N = DATA_SIZE;
   size_t buffer_size = N * sizeof(int);
@@ -218,7 +218,7 @@ TEST_CASE("Unit_hipMemSetAccess_MultDevSetGet") {
  * ------------------------
  *    - HIP_VERSION >= 6.1
  */
-TEST_CASE("Unit_hipMemSetAccess_EntireVMMRangeSetGet") {
+TEST_CASE(Unit_hipMemSetAccess_EntireVMMRangeSetGet) {
   size_t granularity = 0;
   constexpr int N = DATA_SIZE;
   size_t buffer_size = N * sizeof(int);
@@ -276,7 +276,7 @@ TEST_CASE("Unit_hipMemSetAccess_EntireVMMRangeSetGet") {
  * ------------------------
  *    - HIP_VERSION >= 6.1
  */
-TEST_CASE("Unit_hipMemGetAccess_NegTst") {
+TEST_CASE(Unit_hipMemGetAccess_NegTst) {
   size_t granularity = 0;
   constexpr int N = DATA_SIZE;
   size_t buffer_size = N * sizeof(int);
@@ -340,7 +340,7 @@ TEST_CASE("Unit_hipMemGetAccess_NegTst") {
  * ------------------------
  *    - HIP_VERSION >= 6.1
  */
-TEST_CASE("Unit_hipMemSetAccess_FuncTstOnMultDev", "[multigpu]") {
+TEST_CASE(Unit_hipMemSetAccess_FuncTstOnMultDev) {
   size_t granularity = 0;
   constexpr int N = DATA_SIZE;
   size_t buffer_size = N * sizeof(int);
@@ -412,7 +412,7 @@ TEST_CASE("Unit_hipMemSetAccess_FuncTstOnMultDev", "[multigpu]") {
  * ------------------------
  *    - HIP_VERSION >= 6.1
  */
-TEST_CASE("Unit_hipMemSetAccess_ChangeAccessProp") {
+TEST_CASE(Unit_hipMemSetAccess_ChangeAccessProp) {
   size_t granularity = 0;
   constexpr int N = DATA_SIZE;
   size_t buffer_size = N * sizeof(int);
@@ -626,7 +626,7 @@ TEST_CASE("Unit_hipMemSetAccess_SegmentsAccess") {
  * ------------------------
  *    - HIP_VERSION >= 6.1
  */
-TEST_CASE("Unit_hipMemSetAccess_Vmm2UnifiedMemCpy") {
+TEST_CASE(Unit_hipMemSetAccess_Vmm2UnifiedMemCpy) {
   CTX_CREATE();
   auto managed = HmmAttrPrint();
   if (managed != 1) {
@@ -702,7 +702,7 @@ TEST_CASE("Unit_hipMemSetAccess_Vmm2UnifiedMemCpy") {
  * ------------------------
  *    - HIP_VERSION >= 6.1
  */
-TEST_CASE("Unit_hipMemSetAccess_Vmm2DevMemCpy") {
+TEST_CASE(Unit_hipMemSetAccess_Vmm2DevMemCpy) {
   size_t granularity = 0;
   constexpr int N = DATA_SIZE;
   size_t buffer_size = N * sizeof(int);
@@ -762,7 +762,7 @@ TEST_CASE("Unit_hipMemSetAccess_Vmm2DevMemCpy") {
  * ------------------------
  *    - HIP_VERSION >= 6.1
  */
-TEST_CASE("Unit_hipMemSetAccess_Vmm2PeerDevMemCpy", "[multigpu]") {
+TEST_CASE(Unit_hipMemSetAccess_Vmm2PeerDevMemCpy) {
   size_t granularity = 0;
   constexpr int N = DATA_SIZE;
   size_t buffer_size = N * sizeof(int);
@@ -853,7 +853,7 @@ TEST_CASE("Unit_hipMemSetAccess_Vmm2PeerDevMemCpy", "[multigpu]") {
  * ------------------------
  *    - HIP_VERSION >= 6.1
  */
-TEST_CASE("Unit_hipMemSetAccess_Vmm2PeerPeerMemCpy", "[multigpu]") {
+TEST_CASE(Unit_hipMemSetAccess_Vmm2PeerPeerMemCpy) {
   size_t granularity = 0;
   constexpr int N = DATA_SIZE;
   size_t buffer_size = N * sizeof(int);
@@ -949,7 +949,7 @@ TEST_CASE("Unit_hipMemSetAccess_Vmm2PeerPeerMemCpy", "[multigpu]") {
  * ------------------------
  *    - HIP_VERSION >= 6.1
  */
-TEST_CASE("Unit_hipMemSetAccess_Vmm2VMMMemCpy") {
+TEST_CASE(Unit_hipMemSetAccess_Vmm2VMMMemCpy) {
   size_t granularity = 0;
   constexpr int N = DATA_SIZE;
   size_t buffer_size = N * sizeof(int);
@@ -1015,7 +1015,7 @@ TEST_CASE("Unit_hipMemSetAccess_Vmm2VMMMemCpy") {
  * ------------------------
  *    - HIP_VERSION >= 6.1
  */
-TEST_CASE("Unit_hipMemSetAccess_Vmm2VMMInterDevMemCpy", "[multigpu]") {
+TEST_CASE(Unit_hipMemSetAccess_Vmm2VMMInterDevMemCpy) {
   size_t granularity = 0;
   constexpr int N = DATA_SIZE;
   size_t buffer_size = N * sizeof(int);
@@ -1229,7 +1229,7 @@ class vmm_resize_class {
  * ------------------------
  *    - HIP_VERSION >= 6.1
  */
-TEST_CASE("Unit_hipMemSetAccess_GrowVMM") {
+TEST_CASE(Unit_hipMemSetAccess_GrowVMM) {
   hipDeviceptr_t ptr;
   constexpr int N = DATA_SIZE;
   size_t buffer_size = N * sizeof(int);
@@ -1332,7 +1332,7 @@ void test_thread(hipDevice_t device) {
  * ------------------------
  *    - HIP_VERSION >= 6.1
  */
-TEST_CASE("Unit_hipMemSetAccess_Multithreaded") {
+TEST_CASE(Unit_hipMemSetAccess_Multithreaded) {
   CTX_CREATE();
   int deviceId = 0;
   hipDevice_t device;
@@ -1360,7 +1360,7 @@ TEST_CASE("Unit_hipMemSetAccess_Multithreaded") {
  * ------------------------
  *    - HIP_VERSION >= 6.1
  */
-TEST_CASE("Unit_hipMemSetAccess_negative") {
+TEST_CASE(Unit_hipMemSetAccess_negative) {
   size_t granularity = 0;
   constexpr int N = DATA_SIZE;
   size_t buffer_size = N * sizeof(int);
@@ -1453,7 +1453,7 @@ TEST_CASE("Unit_hipMemSetAccess_negative") {
   CTX_DESTROY();
 }
 
-TEST_CASE("Unit_hipMemSetGetAccess_Capture") {
+TEST_CASE(Unit_hipMemSetGetAccess_Capture) {
   CTX_CREATE();
 
   const size_t kBufferBytes = DATA_SIZE * sizeof(int);
@@ -1512,7 +1512,7 @@ TEST_CASE("Unit_hipMemSetGetAccess_Capture") {
   CTX_DESTROY();
 }
 
-TEST_CASE("Unit_hipMemSetAccessHostDevice_hostalloc") {
+TEST_CASE(Unit_hipMemSetAccessHostDevice_hostalloc) {
   // Ensure device 0 is selected
   REQUIRE(hipSetDevice(0) == hipSuccess);
 
@@ -1584,7 +1584,7 @@ TEST_CASE("Unit_hipMemSetAccessHostDevice_hostalloc") {
   HIP_CHECK(hipMemRelease(handle));
 }
 
-TEST_CASE("Unit_hipMemSetAccessHost_devicealloc") {
+TEST_CASE(Unit_hipMemSetAccessHost_devicealloc) {
   // Ensure device 0 is selected
   REQUIRE(hipSetDevice(0) == hipSuccess);
 

--- a/projects/hip-tests/catch/unit/virtualMemoryManagement/hipMemUnmap.cc
+++ b/projects/hip-tests/catch/unit/virtualMemoryManagement/hipMemUnmap.cc
@@ -45,7 +45,7 @@ constexpr int N = (1 << 13);
  * ------------------------
  *    - HIP_VERSION >= 6.1
  */
-TEST_CASE("Unit_hipMemUnmap_negative") {
+TEST_CASE(Unit_hipMemUnmap_negative) {
   size_t granularity = 0;
   size_t buffer_size = N * sizeof(int);
   int deviceId = 0;
@@ -87,7 +87,7 @@ TEST_CASE("Unit_hipMemUnmap_negative") {
   CTX_DESTROY();
 }
 
-TEST_CASE("Unit_hipMemUnmap_Capture") {
+TEST_CASE(Unit_hipMemUnmap_Capture) {
   CTX_CREATE();
   size_t granularity = 0;
   constexpr size_t kBufferSize = N * sizeof(int);

--- a/projects/hip-tests/catch/unit/vulkan_interop/hipDestroyExternalMemory.cc
+++ b/projects/hip-tests/catch/unit/vulkan_interop/hipDestroyExternalMemory.cc
@@ -25,7 +25,7 @@ THE SOFTWARE.
 constexpr bool enable_validation = false;
 #endif
 
-TEST_CASE("Unit_hipDestroyExternalMemory_Vulkan_Negative_Parameters") {
+TEST_CASE(Unit_hipDestroyExternalMemory_Vulkan_Negative_Parameters) {
   SECTION("extMem == nullptr") {
     HIP_CHECK_ERROR(hipDestroyExternalMemory(nullptr), hipErrorInvalidValue);
   }
@@ -57,7 +57,7 @@ TEST_CASE("Unit_hipDestroyExternalMemory_Vulkan_Negative_Parameters") {
  * ------------------------
  *    - HIP_VERSION >= 6.0
  */
-TEST_CASE("Unit_hipDestroyExternalMemory_Vulkan_Capture") {
+TEST_CASE(Unit_hipDestroyExternalMemory_Vulkan_Capture) {
 // Segfaults in CUDA
 // Disabled on AMD due to defect - EXSWHTEC-187
 #if HT_AMD && 0

--- a/projects/hip-tests/catch/unit/vulkan_interop/hipDestroyExternalSemaphore.cc
+++ b/projects/hip-tests/catch/unit/vulkan_interop/hipDestroyExternalSemaphore.cc
@@ -23,7 +23,7 @@ THE SOFTWARE.
 
 constexpr bool enable_validation = false;
 
-TEST_CASE("Unit_hipDestroyExternalSemaphore_Vulkan_Negative_Parameters") {
+TEST_CASE(Unit_hipDestroyExternalSemaphore_Vulkan_Negative_Parameters) {
   SECTION("extSem == nullptr") {
     HIP_CHECK_ERROR(hipDestroyExternalSemaphore(nullptr), hipErrorInvalidValue);
   }
@@ -50,7 +50,7 @@ TEST_CASE("Unit_hipDestroyExternalSemaphore_Vulkan_Negative_Parameters") {
  * ------------------------
  *    - HIP_VERSION >= 6.0
  */
-TEST_CASE("Unit_hipDestroyExternalSemaphore_Vulkan_Capture") {
+TEST_CASE(Unit_hipDestroyExternalSemaphore_Vulkan_Capture) {
   VulkanTest vkt(enable_validation);
   const auto semaphore = vkt.CreateExternalSemaphore(VK_SEMAPHORE_TYPE_BINARY);
   auto handle_desc = vkt.BuildSemaphoreDescriptor(semaphore, VK_SEMAPHORE_TYPE_BINARY);

--- a/projects/hip-tests/catch/unit/vulkan_interop/hipExternalMemoryGetMappedBuffer.cc
+++ b/projects/hip-tests/catch/unit/vulkan_interop/hipExternalMemoryGetMappedBuffer.cc
@@ -25,7 +25,7 @@ constexpr bool enable_validation = false;
 
 template <typename T> __global__ void Set(T* ptr, const T val) { ptr[threadIdx.x] = val; }
 
-TEST_CASE("Unit_hipExternalMemoryGetMappedBuffer_Vulkan_Positive_Read_Write") {
+TEST_CASE(Unit_hipExternalMemoryGetMappedBuffer_Vulkan_Positive_Read_Write) {
   VulkanTest vkt(enable_validation);
   using type = uint8_t;
   constexpr uint32_t count = 3;
@@ -69,7 +69,7 @@ TEST_CASE("Unit_hipExternalMemoryGetMappedBuffer_Vulkan_Positive_Read_Write") {
 }
 
 // Disabled on AMD due to defect - EXSWHTEC-175
-TEST_CASE("Unit_hipExternalMemoryGetMappedBuffer_Vulkan_Positive_Read_Write_With_Offset") {
+TEST_CASE(Unit_hipExternalMemoryGetMappedBuffer_Vulkan_Positive_Read_Write_With_Offset) {
   VulkanTest vkt(enable_validation);
   using type = uint8_t;
   constexpr uint32_t count = 2;
@@ -104,7 +104,7 @@ TEST_CASE("Unit_hipExternalMemoryGetMappedBuffer_Vulkan_Positive_Read_Write_With
   HIP_CHECK(hipDestroyExternalMemory(hip_ext_memory));
 }
 
-TEST_CASE("Unit_hipExternalMemoryGetMappedBuffer_Vulkan_Negative_Parameters") {
+TEST_CASE(Unit_hipExternalMemoryGetMappedBuffer_Vulkan_Negative_Parameters) {
   VulkanTest vkt(enable_validation);
   const auto vk_storage = vkt.CreateMappedStorage<int>(1, VK_BUFFER_USAGE_TRANSFER_DST_BIT, true);
   if (vk_storage.memory == nullptr) {
@@ -169,7 +169,7 @@ TEST_CASE("Unit_hipExternalMemoryGetMappedBuffer_Vulkan_Negative_Parameters") {
  * ------------------------
  *    - HIP_VERSION >= 6.0
  */
-TEST_CASE("Unit_hipExternalMemoryGetMappedBuffer_Vulkan_Capture") {
+TEST_CASE(Unit_hipExternalMemoryGetMappedBuffer_Vulkan_Capture) {
   VulkanTest vkt(enable_validation);
   using type = uint8_t;
   constexpr uint32_t count = 3;
@@ -196,7 +196,7 @@ TEST_CASE("Unit_hipExternalMemoryGetMappedBuffer_Vulkan_Capture") {
   REQUIRE(nullptr != hip_dev_ptr);
 }
 
-TEST_CASE("Unit_hipExternalMemoryGetMappedBuffer_Vulkan_Positive_Read_Write_Device_Memory") {
+TEST_CASE(Unit_hipExternalMemoryGetMappedBuffer_Vulkan_Positive_Read_Write_Device_Memory) {
   VulkanTest vkt(enable_validation);
   using type = uint8_t;
   constexpr uint32_t count = 3;
@@ -281,7 +281,7 @@ TEST_CASE("Unit_hipExternalMemoryGetMappedBuffer_Vulkan_Positive_Read_Write_Devi
   vkFreeMemory(vkt.GetDevice(), dst_staging_memory, nullptr);
 }
 
-TEST_CASE("Unit_hipExternalMemoryGetMappedBuffer_Vulkan_Positive_Read_Write_With_Offset_Device_Memory") {
+TEST_CASE(Unit_hipExternalMemoryGetMappedBuffer_Vulkan_Positive_Read_Write_With_Offset_Device_Memory) {
   VulkanTest vkt(enable_validation);
   using type = uint8_t;
   constexpr uint32_t count = 2;

--- a/projects/hip-tests/catch/unit/vulkan_interop/hipExternalMemoryGetMappedMipmappedArray.cc
+++ b/projects/hip-tests/catch/unit/vulkan_interop/hipExternalMemoryGetMappedMipmappedArray.cc
@@ -48,7 +48,7 @@ template <typename T> bool WriteAndValidateData(hipArray_t& array, size_t array_
   return is_valid;
 }
 
-TEST_CASE("Unit_hipExternalMemoryGetMappedMipmappedArray_Vulkan_Positive_Read_Write") {
+TEST_CASE(Unit_hipExternalMemoryGetMappedMipmappedArray_Vulkan_Positive_Read_Write) {
   VulkanTest vkt(enable_validation);
   using type = uint8_t;
   constexpr uint32_t count = 16384;
@@ -90,7 +90,7 @@ TEST_CASE("Unit_hipExternalMemoryGetMappedMipmappedArray_Vulkan_Positive_Read_Wr
   HIP_CHECK(hipDestroyExternalMemory(ext_memory));
 }
 
-TEST_CASE("Unit_hipExternalMemoryGetMappedMipmappedArray_Vulkan_Array_Layered") {
+TEST_CASE(Unit_hipExternalMemoryGetMappedMipmappedArray_Vulkan_Array_Layered) {
   VulkanTest vkt(enable_validation);
   using type = uint8_t;
   constexpr uint32_t count = 16384;
@@ -123,7 +123,7 @@ TEST_CASE("Unit_hipExternalMemoryGetMappedMipmappedArray_Vulkan_Array_Layered") 
   HIP_CHECK(hipDestroyExternalMemory(ext_memory));
 }
 
-TEST_CASE("Unit_hipExternalMemoryGetMappedMipmappedArray_Vulkan_Array_Cubemap") {
+TEST_CASE(Unit_hipExternalMemoryGetMappedMipmappedArray_Vulkan_Array_Cubemap) {
   VulkanTest vkt(enable_validation);
   using type = uint8_t;
   //  cubemap HIP array is allocated if all three extents are non-zero and the hipArrayCubemap
@@ -160,7 +160,7 @@ TEST_CASE("Unit_hipExternalMemoryGetMappedMipmappedArray_Vulkan_Array_Cubemap") 
   HIP_CHECK(hipDestroyExternalMemory(ext_memory));
 }
 
-TEST_CASE("Unit_hipExternalMemoryGetMappedMipmappedArray_Vulkan_Negative_Parameters") {
+TEST_CASE(Unit_hipExternalMemoryGetMappedMipmappedArray_Vulkan_Negative_Parameters) {
   CHECK_IMAGE_SUPPORT
 
   VulkanTest vkt(enable_validation);
@@ -224,7 +224,7 @@ TEST_CASE("Unit_hipExternalMemoryGetMappedMipmappedArray_Vulkan_Negative_Paramet
  * ------------------------
  *    - HIP_VERSION >= 6.0
  */
-TEST_CASE("Unit_hipExternalMemoryGetMappedMipmappedArray_Vulkan_Capture") {
+TEST_CASE(Unit_hipExternalMemoryGetMappedMipmappedArray_Vulkan_Capture) {
   VulkanTest vkt(enable_validation);
   using type = uint8_t;
   //  cubemap HIP array is allocated if all three extents are non-zero and the hipArrayCubemap

--- a/projects/hip-tests/catch/unit/vulkan_interop/hipGraphAddExternalSemaphoresSignalNode.cc
+++ b/projects/hip-tests/catch/unit/vulkan_interop/hipGraphAddExternalSemaphoresSignalNode.cc
@@ -54,7 +54,7 @@ THE SOFTWARE.
  * ------------------------
  *  - HIP_VERSION >= 6.0
  */
-TEST_CASE("Unit_hipGraphAddExternalSemaphoresSignalNode_Positive_Basic") {
+TEST_CASE(Unit_hipGraphAddExternalSemaphoresSignalNode_Positive_Basic) {
   SignalExternalSemaphoreCommon(GraphExtSemaphoreSignalWrapper<>);
 }
 
@@ -74,7 +74,7 @@ TEST_CASE("Unit_hipGraphAddExternalSemaphoresSignalNode_Positive_Basic") {
  * ------------------------
  *  - HIP_VERSION >= 6.0
  */
-TEST_CASE("Unit_hipGraphAddExternalSemaphoresSignalNode_Vulkan_Positive_Timeline_Semaphore") {
+TEST_CASE(Unit_hipGraphAddExternalSemaphoresSignalNode_Vulkan_Positive_Timeline_Semaphore) {
   SignalExternalTimelineSemaphoreCommon(GraphExtSemaphoreSignalWrapper<>);
 }
 
@@ -93,7 +93,7 @@ TEST_CASE("Unit_hipGraphAddExternalSemaphoresSignalNode_Vulkan_Positive_Timeline
  * ------------------------
  *  - HIP_VERSION >= 6.0
  */
-TEST_CASE("Unit_hipGraphAddExternalSemaphoresSignalNode_Vulkan_Positive_Multiple_Semaphores") {
+TEST_CASE(Unit_hipGraphAddExternalSemaphoresSignalNode_Vulkan_Positive_Multiple_Semaphores) {
   SignalExternalMultipleSemaphoresCommon(GraphExtSemaphoreSignalWrapper<>);
 }
 #endif
@@ -116,7 +116,7 @@ TEST_CASE("Unit_hipGraphAddExternalSemaphoresSignalNode_Vulkan_Positive_Multiple
  * ------------------------
  *  - HIP_VERSION >= 6.0
  */
-TEST_CASE("Unit_hipGraphAddExternalSemaphoresSignalNode_Vulkan_Negative_Parameters") {
+TEST_CASE(Unit_hipGraphAddExternalSemaphoresSignalNode_Vulkan_Negative_Parameters) {
   using namespace std::placeholders;
   hipGraph_t graph = nullptr;
   HIP_CHECK(hipGraphCreate(&graph, 0));

--- a/projects/hip-tests/catch/unit/vulkan_interop/hipGraphAddExternalSemaphoresWaitNode.cc
+++ b/projects/hip-tests/catch/unit/vulkan_interop/hipGraphAddExternalSemaphoresWaitNode.cc
@@ -54,7 +54,7 @@ THE SOFTWARE.
  *  - HIP_VERSION >= 6.0
  */
 
-TEST_CASE("Unit_hipGraphAddExternalSemaphoresWaitNode_Positive_Basic") {
+TEST_CASE(Unit_hipGraphAddExternalSemaphoresWaitNode_Positive_Basic) {
   WaitExternalSemaphoreCommon(GraphExtSemaphoreWaitWrapper<>);
 }
 
@@ -74,7 +74,7 @@ TEST_CASE("Unit_hipGraphAddExternalSemaphoresWaitNode_Positive_Basic") {
  * ------------------------
  *  - HIP_VERSION >= 6.0
  */
-TEST_CASE("Unit_hipGraphAddExternalSemaphoresWaitNode_Vulkan_Positive_Timeline_Semaphore") {
+TEST_CASE(Unit_hipGraphAddExternalSemaphoresWaitNode_Vulkan_Positive_Timeline_Semaphore) {
   WaitExternalTimelineSemaphoreCommon(GraphExtSemaphoreWaitWrapper<>);
 }
 #endif
@@ -94,7 +94,7 @@ TEST_CASE("Unit_hipGraphAddExternalSemaphoresWaitNode_Vulkan_Positive_Timeline_S
  * ------------------------
  *  - HIP_VERSION >= 6.0
  */
-TEST_CASE("Unit_hipGraphAddExternalSemaphoresWaitNode_Vulkan_Positive_Multiple_Semaphores") {
+TEST_CASE(Unit_hipGraphAddExternalSemaphoresWaitNode_Vulkan_Positive_Multiple_Semaphores) {
   WaitExternalMultipleSemaphoresCommon(GraphExtSemaphoreWaitWrapper<>);
 }
 
@@ -115,7 +115,7 @@ TEST_CASE("Unit_hipGraphAddExternalSemaphoresWaitNode_Vulkan_Positive_Multiple_S
  * ------------------------
  *  - HIP_VERSION >= 6.0
  */
-TEST_CASE("Unit_hipGraphAddExternalSemaphoresWaitNode_Vulkan_Negative_Parameters") {
+TEST_CASE(Unit_hipGraphAddExternalSemaphoresWaitNode_Vulkan_Negative_Parameters) {
   using namespace std::placeholders;
   hipGraph_t graph = nullptr;
   HIP_CHECK(hipGraphCreate(&graph, 0));

--- a/projects/hip-tests/catch/unit/vulkan_interop/hipGraphExecExternalSemaphoresSignalNodeSetParams.cc
+++ b/projects/hip-tests/catch/unit/vulkan_interop/hipGraphExecExternalSemaphoresSignalNodeSetParams.cc
@@ -91,7 +91,7 @@ static hipError_t GraphExecSemaphoreSetParamsSignalWrapper(
  * ------------------------
  *    - HIP_VERSION >= 6.0
  */
-TEST_CASE("Unit_hipGraphExecExternalSemaphoresSignalNodeSetParams_Positive_Basic") {
+TEST_CASE(Unit_hipGraphExecExternalSemaphoresSignalNodeSetParams_Positive_Basic) {
   SignalExternalSemaphoreCommon(GraphExecSemaphoreSetParamsSignalWrapper);
 }
 
@@ -112,8 +112,7 @@ TEST_CASE("Unit_hipGraphExecExternalSemaphoresSignalNodeSetParams_Positive_Basic
  * ------------------------
  *    - HIP_VERSION >= 6.0
  */
-TEST_CASE(
-    "Unit_hipGraphExecExternalSemaphoresSignalNodeSetParams_Vulkan_Positive_Timeline_Semaphore") {
+TEST_CASE(Unit_hipGraphExecExternalSemaphoresSignalNodeSetParams_Vulkan_Positive_Timeline_Semaphore) {
   SignalExternalTimelineSemaphoreCommon(GraphExecSemaphoreSetParamsSignalWrapper);
 }
 
@@ -131,8 +130,7 @@ TEST_CASE(
  * ------------------------
  *    - HIP_VERSION >= 6.0
  */
-TEST_CASE(
-    "Unit_hipGraphExecExternalSemaphoresSignalNodeSetParams_Vulkan_Positive_Multiple_Semaphores") {
+TEST_CASE(Unit_hipGraphExecExternalSemaphoresSignalNodeSetParams_Vulkan_Positive_Multiple_Semaphores) {
   SignalExternalMultipleSemaphoresCommon(GraphExecSemaphoreSetParamsSignalWrapper);
 }
 #endif
@@ -152,7 +150,7 @@ TEST_CASE(
  * ------------------------
  *  - HIP_VERSION >= 6.0
  */
-TEST_CASE("Unit_hipGraphExecExternalSemaphoresSignalNodeSetParams_Vulkan_Negative_Parameters") {
+TEST_CASE(Unit_hipGraphExecExternalSemaphoresSignalNodeSetParams_Vulkan_Negative_Parameters) {
   hipGraph_t graph = nullptr;
   HIP_CHECK(hipGraphCreate(&graph, 0));
 

--- a/projects/hip-tests/catch/unit/vulkan_interop/hipGraphExecExternalSemaphoresWaitNodeSetParams.cc
+++ b/projects/hip-tests/catch/unit/vulkan_interop/hipGraphExecExternalSemaphoresWaitNodeSetParams.cc
@@ -91,7 +91,7 @@ static hipError_t GraphExecSemaphoreSetParamsWaitWrapper(
  * ------------------------
  *    - HIP_VERSION >= 6.0
  */
-TEST_CASE("Unit_hipGraphExecExternalSemaphoresWaitNodeSetParams_Positive_Basic") {
+TEST_CASE(Unit_hipGraphExecExternalSemaphoresWaitNodeSetParams_Positive_Basic) {
   WaitExternalSemaphoreCommon(GraphExecSemaphoreSetParamsWaitWrapper);
 }
 
@@ -112,8 +112,7 @@ TEST_CASE("Unit_hipGraphExecExternalSemaphoresWaitNodeSetParams_Positive_Basic")
  * ------------------------
  *    - HIP_VERSION >= 6.0
  */
-TEST_CASE(
-    "Unit_hipGraphExecExternalSemaphoresWaitNodeSetParams_Vulkan_Positive_Timeline_Semaphore") {
+TEST_CASE(Unit_hipGraphExecExternalSemaphoresWaitNodeSetParams_Vulkan_Positive_Timeline_Semaphore) {
   WaitExternalTimelineSemaphoreCommon(GraphExecSemaphoreSetParamsWaitWrapper);
 }
 #endif
@@ -132,8 +131,7 @@ TEST_CASE(
  * ------------------------
  *    - HIP_VERSION >= 6.0
  */
-TEST_CASE(
-    "Unit_hipGraphExecExternalSemaphoresWaitNodeSetParams_Vulkan_Positive_Multiple_Semaphores") {
+TEST_CASE(Unit_hipGraphExecExternalSemaphoresWaitNodeSetParams_Vulkan_Positive_Multiple_Semaphores) {
   WaitExternalMultipleSemaphoresCommon(GraphExecSemaphoreSetParamsWaitWrapper);
 }
 
@@ -152,7 +150,7 @@ TEST_CASE(
  * ------------------------
  *  - HIP_VERSION >= 6.0
  */
-TEST_CASE("Unit_hipGraphExecExternalSemaphoresWaitNodeSetParams_Vulkan_Negative_Parameters") {
+TEST_CASE(Unit_hipGraphExecExternalSemaphoresWaitNodeSetParams_Vulkan_Negative_Parameters) {
   hipGraph_t graph = nullptr;
   HIP_CHECK(hipGraphCreate(&graph, 0));
 

--- a/projects/hip-tests/catch/unit/vulkan_interop/hipGraphExternalSemaphoresSignalNodeGetParams.cc
+++ b/projects/hip-tests/catch/unit/vulkan_interop/hipGraphExternalSemaphoresSignalNodeGetParams.cc
@@ -52,7 +52,7 @@ THE SOFTWARE.
  * ------------------------
  *  - HIP_VERSION >= 6.0
  */
-TEST_CASE("Unit_hipGraphExternalSemaphoresSignalNodeGetParams_Negative_Parameters") {
+TEST_CASE(Unit_hipGraphExternalSemaphoresSignalNodeGetParams_Negative_Parameters) {
   hipGraph_t graph = nullptr;
   HIP_CHECK(hipGraphCreate(&graph, 0));
 

--- a/projects/hip-tests/catch/unit/vulkan_interop/hipGraphExternalSemaphoresSignalNodeSetParams.cc
+++ b/projects/hip-tests/catch/unit/vulkan_interop/hipGraphExternalSemaphoresSignalNodeSetParams.cc
@@ -46,7 +46,7 @@ THE SOFTWARE.
  * ------------------------
  *    - HIP_VERSION >= 6.0
  */
-TEST_CASE("Unit_hipGraphExternalSemaphoresSignalNodeSetParams_Positive_Basic") {
+TEST_CASE(Unit_hipGraphExternalSemaphoresSignalNodeSetParams_Positive_Basic) {
   SignalExternalSemaphoreCommon(GraphExtSemaphoreSignalWrapper<true>);
 }
 
@@ -67,7 +67,7 @@ TEST_CASE("Unit_hipGraphExternalSemaphoresSignalNodeSetParams_Positive_Basic") {
  * ------------------------
  *    - HIP_VERSION >= 6.0
  */
-TEST_CASE("Unit_hipGraphExternalSemaphoresSignalNodeSetParams_Vulkan_Positive_Timeline_Semaphore") {
+TEST_CASE(Unit_hipGraphExternalSemaphoresSignalNodeSetParams_Vulkan_Positive_Timeline_Semaphore) {
   SignalExternalTimelineSemaphoreCommon(GraphExtSemaphoreSignalWrapper<true>);
 }
 
@@ -85,8 +85,7 @@ TEST_CASE("Unit_hipGraphExternalSemaphoresSignalNodeSetParams_Vulkan_Positive_Ti
  * ------------------------
  *    - HIP_VERSION >= 6.0
  */
-TEST_CASE(
-    "Unit_hipGraphExternalSemaphoresSignalNodeSetParams_Vulkan_Positive_Multiple_Semaphores") {
+TEST_CASE(Unit_hipGraphExternalSemaphoresSignalNodeSetParams_Vulkan_Positive_Multiple_Semaphores) {
   SignalExternalMultipleSemaphoresCommon(GraphExtSemaphoreSignalWrapper<true>);
 }
 #endif
@@ -105,7 +104,7 @@ TEST_CASE(
  * ------------------------
  *  - HIP_VERSION >= 6.0
  */
-TEST_CASE("Unit_hipGraphExternalSemaphoresSignalNodeSetParams_Vulkan_Negative_Parameters") {
+TEST_CASE(Unit_hipGraphExternalSemaphoresSignalNodeSetParams_Vulkan_Negative_Parameters) {
   hipGraph_t graph = nullptr;
   HIP_CHECK(hipGraphCreate(&graph, 0));
 

--- a/projects/hip-tests/catch/unit/vulkan_interop/hipGraphExternalSemaphoresWaitNodeGetParams.cc
+++ b/projects/hip-tests/catch/unit/vulkan_interop/hipGraphExternalSemaphoresWaitNodeGetParams.cc
@@ -52,7 +52,7 @@ THE SOFTWARE.
  * ------------------------
  *  - HIP_VERSION >= 6.0
  */
-TEST_CASE("Unit_hipGraphExternalSemaphoresWaitNodeGetParams_Negative_Parameters") {
+TEST_CASE(Unit_hipGraphExternalSemaphoresWaitNodeGetParams_Negative_Parameters) {
   hipGraph_t graph = nullptr;
   HIP_CHECK(hipGraphCreate(&graph, 0));
 

--- a/projects/hip-tests/catch/unit/vulkan_interop/hipGraphExternalSemaphoresWaitNodeSetParams.cc
+++ b/projects/hip-tests/catch/unit/vulkan_interop/hipGraphExternalSemaphoresWaitNodeSetParams.cc
@@ -46,7 +46,7 @@ THE SOFTWARE.
  * ------------------------
  *    - HIP_VERSION >= 6.0
  */
-TEST_CASE("Unit_hipGraphExternalSemaphoresWaitNodeSetParams_Positive_Basic") {
+TEST_CASE(Unit_hipGraphExternalSemaphoresWaitNodeSetParams_Positive_Basic) {
   WaitExternalSemaphoreCommon(GraphExtSemaphoreWaitWrapper<true>);
 }
 
@@ -67,7 +67,7 @@ TEST_CASE("Unit_hipGraphExternalSemaphoresWaitNodeSetParams_Positive_Basic") {
  * ------------------------
  *    - HIP_VERSION >= 6.0
  */
-TEST_CASE("Unit_hipGraphExternalSemaphoresWaitNodeSetParams_Vulkan_Positive_Timeline_Semaphore") {
+TEST_CASE(Unit_hipGraphExternalSemaphoresWaitNodeSetParams_Vulkan_Positive_Timeline_Semaphore) {
   WaitExternalTimelineSemaphoreCommon(GraphExtSemaphoreWaitWrapper<true>);
 }
 #endif
@@ -86,7 +86,7 @@ TEST_CASE("Unit_hipGraphExternalSemaphoresWaitNodeSetParams_Vulkan_Positive_Time
  * ------------------------
  *    - HIP_VERSION >= 6.0
  */
-TEST_CASE("Unit_hipGraphExternalSemaphoresWaitNodeSetParams_Vulkan_Positive_Multiple_Semaphores") {
+TEST_CASE(Unit_hipGraphExternalSemaphoresWaitNodeSetParams_Vulkan_Positive_Multiple_Semaphores) {
   WaitExternalMultipleSemaphoresCommon(GraphExtSemaphoreWaitWrapper<true>);
 }
 
@@ -104,7 +104,7 @@ TEST_CASE("Unit_hipGraphExternalSemaphoresWaitNodeSetParams_Vulkan_Positive_Mult
  * ------------------------
  *  - HIP_VERSION >= 6.0
  */
-TEST_CASE("Unit_hipGraphExternalSemaphoresWaitNodeSetParams_Vulkan_Negative_Parameters") {
+TEST_CASE(Unit_hipGraphExternalSemaphoresWaitNodeSetParams_Vulkan_Negative_Parameters) {
   hipGraph_t graph = nullptr;
   HIP_CHECK(hipGraphCreate(&graph, 0));
 

--- a/projects/hip-tests/catch/unit/vulkan_interop/hipImportExternalMemory.cc
+++ b/projects/hip-tests/catch/unit/vulkan_interop/hipImportExternalMemory.cc
@@ -23,7 +23,7 @@ THE SOFTWARE.
 
 constexpr bool enable_validation = false;
 
-TEST_CASE("Unit_hipImportExternalMemory_Vulkan_Negative_Parameters") {
+TEST_CASE(Unit_hipImportExternalMemory_Vulkan_Negative_Parameters) {
   VulkanTest vkt(enable_validation);
 #if HT_NVIDIA
   const auto storage = vkt.CreateMappedStorage<int>(1, VK_BUFFER_USAGE_TRANSFER_DST_BIT, true);
@@ -90,7 +90,7 @@ TEST_CASE("Unit_hipImportExternalMemory_Vulkan_Negative_Parameters") {
  * ------------------------
  *    - HIP_VERSION >= 6.0
  */
-TEST_CASE("Unit_hipImportExternalMemory_Vulkan_Capture") {
+TEST_CASE(Unit_hipImportExternalMemory_Vulkan_Capture) {
   VulkanTest vkt(enable_validation);
   using type = uint8_t;
   constexpr uint32_t count = 2;

--- a/projects/hip-tests/catch/unit/vulkan_interop/hipImportExternalSemaphore.cc
+++ b/projects/hip-tests/catch/unit/vulkan_interop/hipImportExternalSemaphore.cc
@@ -23,7 +23,7 @@ THE SOFTWARE.
 
 constexpr bool enable_validation = false;
 
-TEST_CASE("Unit_hipImportExternalSemaphore_Vulkan_Negative_Parameters") {
+TEST_CASE(Unit_hipImportExternalSemaphore_Vulkan_Negative_Parameters) {
   VulkanTest vkt(enable_validation);
   const auto semaphore = vkt.CreateExternalSemaphore(VK_SEMAPHORE_TYPE_BINARY);
   auto handle_desc = vkt.BuildSemaphoreDescriptor(semaphore, VK_SEMAPHORE_TYPE_BINARY);
@@ -68,7 +68,7 @@ TEST_CASE("Unit_hipImportExternalSemaphore_Vulkan_Negative_Parameters") {
  * ------------------------
  *    - HIP_VERSION >= 6.0
  */
-TEST_CASE("Unit_hipImportExternalSemaphore_Vulkan_Capture") {
+TEST_CASE(Unit_hipImportExternalSemaphore_Vulkan_Capture) {
   VulkanTest vkt(enable_validation);
   const auto semaphore = vkt.CreateExternalSemaphore(VK_SEMAPHORE_TYPE_BINARY);
   auto handle_desc = vkt.BuildSemaphoreDescriptor(semaphore, VK_SEMAPHORE_TYPE_BINARY);

--- a/projects/hip-tests/catch/unit/vulkan_interop/hipSignalExternalSemaphoresAsync.cc
+++ b/projects/hip-tests/catch/unit/vulkan_interop/hipSignalExternalSemaphoresAsync.cc
@@ -22,22 +22,22 @@ THE SOFTWARE.
 #include "vulkan_test.hh"
 #include "signal_semaphore_common.hh"
 
-TEST_CASE("Unit_hipSignalExternalSemaphoresAsync_Vulkan_Positive_Binary_Semaphore") {
+TEST_CASE(Unit_hipSignalExternalSemaphoresAsync_Vulkan_Positive_Binary_Semaphore) {
   SignalExternalSemaphoreCommon(hipSignalExternalSemaphoresAsync);
 }
 
 // Timeline semaphores unsupported on AMD
 #if HT_NVIDIA
-TEST_CASE("Unit_hipSignalExternalSemaphoresAsync_Vulkan_Positive_Timeline_Semaphore") {
+TEST_CASE(Unit_hipSignalExternalSemaphoresAsync_Vulkan_Positive_Timeline_Semaphore) {
   SignalExternalTimelineSemaphoreCommon(hipSignalExternalSemaphoresAsync);
 }
 
-TEST_CASE("Unit_hipSignalExternalSemaphoresAsync_Vulkan_Positive_Multiple_Semaphores") {
+TEST_CASE(Unit_hipSignalExternalSemaphoresAsync_Vulkan_Positive_Multiple_Semaphores) {
   SignalExternalMultipleSemaphoresCommon(hipSignalExternalSemaphoresAsync);
 }
 #endif
 
-TEST_CASE("Unit_hipSignalExternalSemaphoresAsync_Vulkan_Negative_Parameters") {
+TEST_CASE(Unit_hipSignalExternalSemaphoresAsync_Vulkan_Negative_Parameters) {
   VulkanTest vkt(enable_validation);
   hipExternalSemaphoreSignalParams signal_params = {};
   signal_params.params.fence.value = 1;

--- a/projects/hip-tests/catch/unit/vulkan_interop/hipWaitExternalSemaphoresAsync.cc
+++ b/projects/hip-tests/catch/unit/vulkan_interop/hipWaitExternalSemaphoresAsync.cc
@@ -22,22 +22,22 @@ THE SOFTWARE.
 #include "vulkan_test.hh"
 #include "wait_semaphore_common.hh"
 
-TEST_CASE("Unit_hipWaitExternalSemaphoresAsync_Vulkan_Positive_Binary_Semaphore") {
+TEST_CASE(Unit_hipWaitExternalSemaphoresAsync_Vulkan_Positive_Binary_Semaphore) {
   WaitExternalSemaphoreCommon(hipWaitExternalSemaphoresAsync);
 }
 
 // Timeline semaphores unsupported on AMD
 #if HT_NVIDIA
-TEST_CASE("Unit_hipWaitExternalSemaphoresAsync_Vulkan_Positive_Timeline_Semaphore") {
+TEST_CASE(Unit_hipWaitExternalSemaphoresAsync_Vulkan_Positive_Timeline_Semaphore) {
   WaitExternalTimelineSemaphoreCommon(hipWaitExternalSemaphoresAsync);
 }
 #endif
 
-TEST_CASE("Unit_hipWaitExternalSemaphoresAsync_Vulkan_Positive_Multiple_Semaphores") {
+TEST_CASE(Unit_hipWaitExternalSemaphoresAsync_Vulkan_Positive_Multiple_Semaphores) {
   WaitExternalMultipleSemaphoresCommon(hipWaitExternalSemaphoresAsync);
 }
 
-TEST_CASE("Unit_hipWaitExternalSemaphoresAsync_Vulkan_Negative_Parameters") {
+TEST_CASE(Unit_hipWaitExternalSemaphoresAsync_Vulkan_Negative_Parameters) {
   VulkanTest vkt(enable_validation);
   hipExternalSemaphoreWaitParams wait_params = {};
   wait_params.params.fence.value = 1;

--- a/projects/hip-tests/catch/unit/warp/hipMatchSyncAllTests.cc
+++ b/projects/hip-tests/catch/unit/warp/hipMatchSyncAllTests.cc
@@ -330,7 +330,7 @@ static void runTestMatchAll_4() {
  *    - HIP_VERSION >= 5.6
  */
 
-TEST_CASE("Unit_hipMatchSync_All") {
+TEST_CASE(Unit_hipMatchSync_All) {
   CHECK_WARP_MATCH_FUNCTIONS_SUPPORT
 
   SECTION("run test for int") {

--- a/projects/hip-tests/catch/unit/warp/hipMatchSyncAnyTests.cc
+++ b/projects/hip-tests/catch/unit/warp/hipMatchSyncAnyTests.cc
@@ -205,7 +205,7 @@ static void runTestMatchAny_3() {
  *    - HIP_VERSION >= 5.6
  */
 
-TEST_CASE("Unit_hipMatchSync_Any") {
+TEST_CASE(Unit_hipMatchSync_Any) {
   CHECK_WARP_MATCH_FUNCTIONS_SUPPORT
 
   SECTION("run test for int") {

--- a/projects/hip-tests/catch/unit/warp/hipShflSyncDownTests.cc
+++ b/projects/hip-tests/catch/unit/warp/hipShflSyncDownTests.cc
@@ -229,7 +229,7 @@ static void runTestShflDown_4() {
  *    - HIP_VERSION >= 5.6
  */
 
-TEST_CASE("Unit_hipShflSync_Down") {
+TEST_CASE(Unit_hipShflSync_Down) {
   CHECK_WARP_MATCH_FUNCTIONS_SUPPORT
 
   SECTION("run test for short") {

--- a/projects/hip-tests/catch/unit/warp/hipShflSyncTests.cc
+++ b/projects/hip-tests/catch/unit/warp/hipShflSyncTests.cc
@@ -171,7 +171,7 @@ static void runTestShfl_3() {
  *    - HIP_VERSION >= 5.6
  */
 
-TEST_CASE("Unit_hipShflSync") {
+TEST_CASE(Unit_hipShflSync) {
   CHECK_WARP_MATCH_FUNCTIONS_SUPPORT
 
   SECTION("run test for short") {

--- a/projects/hip-tests/catch/unit/warp/hipShflSyncUpTests.cc
+++ b/projects/hip-tests/catch/unit/warp/hipShflSyncUpTests.cc
@@ -211,7 +211,7 @@ static void runTestShflUp_4() {
  *    - HIP_VERSION >= 5.6
  */
 
-TEST_CASE("Unit_hipShflSync_Up") {
+TEST_CASE(Unit_hipShflSync_Up) {
   CHECK_WARP_MATCH_FUNCTIONS_SUPPORT
 
   SECTION("run test for short") {

--- a/projects/hip-tests/catch/unit/warp/hipShflSyncXorTests.cc
+++ b/projects/hip-tests/catch/unit/warp/hipShflSyncXorTests.cc
@@ -288,7 +288,7 @@ static void runTestShflXor_4() {
  *    - HIP_VERSION >= 5.6
  */
 
-TEST_CASE("Unit_hipShflSync_Xor") {
+TEST_CASE(Unit_hipShflSync_Xor) {
   CHECK_WARP_MATCH_FUNCTIONS_SUPPORT
 
   SECTION("run test for short") {

--- a/projects/hip-tests/catch/unit/warp/hipShflTests.cc
+++ b/projects/hip-tests/catch/unit/warp/hipShflTests.cc
@@ -165,7 +165,7 @@ template <typename T> static void runTest() {
  *    - HIP_VERSION >= 5.6
  */
 
-TEST_CASE("Unit_hipShflTests") {
+TEST_CASE(Unit_hipShflTests) {
   SECTION("run test for int") { runTest<int>(); }
   SECTION("run test for float") { runTest<float>(); }
   SECTION("run test for double") { runTest<double>(); }
@@ -211,7 +211,7 @@ __global__ void testShflWithUndefArgs(unsigned long total_out_strings, unsigned 
     out[lane]++;
   }
 }
-TEST_CASE("Unit_hipShflUndefArgs") {
+TEST_CASE(Unit_hipShflUndefArgs) {
   hipDeviceProp_t prop;
   int device;
   HIP_CHECK(hipGetDevice(&device));

--- a/projects/hip-tests/catch/unit/warp/hipShflUpDownTest.cc
+++ b/projects/hip-tests/catch/unit/warp/hipShflUpDownTest.cc
@@ -152,7 +152,7 @@ template <typename T> static void runTestShflXor() {
  * ticket SWDEV-379177
  */
 
-TEST_CASE("Unit_runTestShfl_up") {
+TEST_CASE(Unit_runTestShfl_up) {
   SECTION("runTestShflUp for int") { runTestShflUp<int>(); }
   SECTION("runTestShflUp for float") { runTestShflUp<float>(); }
   SECTION("runTestShflUp for double") { runTestShflUp<double>(); }
@@ -189,7 +189,7 @@ TEST_CASE("Unit_runTestShfl_up") {
  * ticket SWDEV-379177
  */
 
-TEST_CASE("Unit_runTestShfl_Down") {
+TEST_CASE(Unit_runTestShfl_Down) {
   SECTION("runTestShflDown for int") { runTestShflDown<int>(); }
   SECTION("runTestShflDown for float") { runTestShflDown<float>(); }
   SECTION("runTestShflDown for double") { runTestShflDown<double>(); }
@@ -226,7 +226,7 @@ TEST_CASE("Unit_runTestShfl_Down") {
  * ticket SWDEV-379177
  */
 
-TEST_CASE("Unit_runTestShfl_Xor") {
+TEST_CASE(Unit_runTestShfl_Xor) {
   SECTION("runTestShflXor for int") { runTestShflXor<int>(); }
   SECTION("runTestShflXor for float") { runTestShflXor<float>(); }
   SECTION("runTestShflXor for double") { runTestShflXor<double>(); }

--- a/projects/hip-tests/catch/unit/warp/hipVoteSyncTests.cc
+++ b/projects/hip-tests/catch/unit/warp/hipVoteSyncTests.cc
@@ -567,7 +567,7 @@ static void runTestBallot_3() {
  *    - HIP_VERSION >= 5.6
  */
 
-TEST_CASE("Unit_hipVoteSync_Any") {
+TEST_CASE(Unit_hipVoteSync_Any) {
   CHECK_WARP_MATCH_FUNCTIONS_SUPPORT
 
   runTestAny_1();
@@ -577,7 +577,7 @@ TEST_CASE("Unit_hipVoteSync_Any") {
   runTestAny_4();
 }
 
-TEST_CASE("Unit_hipVoteSync_All") {
+TEST_CASE(Unit_hipVoteSync_All) {
   CHECK_WARP_MATCH_FUNCTIONS_SUPPORT
 
   runTestAll_1_w64();
@@ -587,7 +587,7 @@ TEST_CASE("Unit_hipVoteSync_All") {
   runTestAll_4();
 }
 
-TEST_CASE("Unit_hipVoteSync_Ballot") {
+TEST_CASE(Unit_hipVoteSync_Ballot) {
   CHECK_WARP_MATCH_FUNCTIONS_SUPPORT
 
   runTestBallot_1();

--- a/projects/hip-tests/catch/unit/warp/warp_all.cc
+++ b/projects/hip-tests/catch/unit/warp/warp_all.cc
@@ -114,7 +114,7 @@ class WarpAll : public WarpVoteTest<WarpAll, uint64_t> {
  *  - HIP_VERSION >= 5.2
  *  - Device supports warp vote
  */
-TEST_CASE("Unit_Warp_Vote_All_Positive_Basic") {
+TEST_CASE(Unit_Warp_Vote_All_Positive_Basic) {
   int device;
   hipDeviceProp_t device_properties;
   HIP_CHECK(hipGetDevice(&device));

--- a/projects/hip-tests/catch/unit/warp/warp_any.cc
+++ b/projects/hip-tests/catch/unit/warp/warp_any.cc
@@ -105,7 +105,7 @@ class WarpAny : public WarpVoteTest<WarpAny, uint64_t> {
  *  - HIP_VERSION >= 5.2
  *  - Device supports warp vote
  */
-TEST_CASE("Unit_Warp_Vote_Any_Positive_Basic") {
+TEST_CASE(Unit_Warp_Vote_Any_Positive_Basic) {
   int device;
   hipDeviceProp_t device_properties;
   HIP_CHECK(hipGetDevice(&device));

--- a/projects/hip-tests/catch/unit/warp/warp_ballot.cc
+++ b/projects/hip-tests/catch/unit/warp/warp_ballot.cc
@@ -104,7 +104,7 @@ class WarpBallot : public WarpVoteTest<WarpBallot, uint64_t> {
  *  - HIP_VERSION >= 5.2
  *  - Device supports warp ballot
  */
-TEST_CASE("Unit_Warp_Ballot_Positive_Basic") {
+TEST_CASE(Unit_Warp_Ballot_Positive_Basic) {
   int device;
   hipDeviceProp_t device_properties;
   HIP_CHECK(hipGetDevice(&device));

--- a/projects/hip-tests/catch/unit/warp/warp_reduce.cc
+++ b/projects/hip-tests/catch/unit/warp/warp_reduce.cc
@@ -131,7 +131,7 @@ template <class T> void runTestMultipleMasks(unsigned long long masks[], int num
   }
 }
 
-TEMPLATE_TEST_CASE("Unit_hipReduceSingleMasks", "", int, unsigned int, long long,
+TEMPLATE_TEST_CASE(Unit_hipReduceSingleMasks, int, unsigned int, long long,
                    unsigned long long, float, half, double) {
   unsigned long long fullMask = getWarpSize() == 64 ? ~0ul : 0xFFFFFFFF;
   unsigned long long oneBitMasks[] = {0b1 & fullMask};
@@ -145,7 +145,7 @@ TEMPLATE_TEST_CASE("Unit_hipReduceSingleMasks", "", int, unsigned int, long long
   runTestMultipleMasks<TestType>(everyFifthButNinethMasks, NELEMS(everyFifthButNinethMasks));
 }
 
-TEMPLATE_TEST_CASE("Unit_hipReduceMultipleMasks", "", int, unsigned int, long long,
+TEMPLATE_TEST_CASE(Unit_hipReduceMultipleMasks, int, unsigned int, long long,
                    unsigned long long, float, half, double) {
   if (getWarpSize() == 64) {
     unsigned long long masks[] = {0b0110011, 0x0F0F0F0F00000000, 0xF0F0F0F000000000,
@@ -198,7 +198,7 @@ void runTestReduceForTypes(const std::tuple<T, Types...>) {
   runTestReduceForTypes<Op>(remainingTypes);
 }
 
-TEST_CASE("Unit_hipReduceRandom") {
+TEST_CASE(Unit_hipReduceRandom) {
   const std::tuple<int, unsigned int, long long, unsigned long long, float, half, double> allTypes;
   const std::tuple<int, unsigned int, long long, unsigned long long> integralTypes;
 

--- a/projects/hip-tests/catch/unit/warp/warp_shfl.cc
+++ b/projects/hip-tests/catch/unit/warp/warp_shfl.cc
@@ -99,7 +99,7 @@ template <typename T> class WarpShfl : public WarpShflTest<WarpShfl<T>, T> {
  *  - HIP_VERSION >= 5.2
  *  - Device supports warp shuffle
  */
-TEMPLATE_TEST_CASE("Unit_Warp_Shfl_Positive_Basic", "", int, unsigned int, long, unsigned long,
+TEMPLATE_TEST_CASE(Unit_Warp_Shfl_Positive_Basic, int, unsigned int, long, unsigned long,
                    long long, unsigned long long, float, double, __half, __half2) {
   int device;
   hipDeviceProp_t device_properties;

--- a/projects/hip-tests/catch/unit/warp/warp_shfl_down.cc
+++ b/projects/hip-tests/catch/unit/warp/warp_shfl_down.cc
@@ -99,7 +99,7 @@ template <typename T> class WarpShflDown : public WarpShflTest<WarpShflDown<T>, 
  *  - HIP_VERSION >= 5.2
  *  - Device supports warp shuffle
  */
-TEMPLATE_TEST_CASE("Unit_Warp_Shfl_Down_Positive_Basic", "", int, unsigned int, long, unsigned long,
+TEMPLATE_TEST_CASE(Unit_Warp_Shfl_Down_Positive_Basic, int, unsigned int, long, unsigned long,
                    long long, unsigned long long, float, double, __half, __half2) {
   int device;
   hipDeviceProp_t device_properties;

--- a/projects/hip-tests/catch/unit/warp/warp_shfl_up.cc
+++ b/projects/hip-tests/catch/unit/warp/warp_shfl_up.cc
@@ -98,7 +98,7 @@ template <typename T> class WarpShflUp : public WarpShflTest<WarpShflUp<T>, T> {
  *  - HIP_VERSION >= 5.2
  *  - Device supports warp shuffle
  */
-TEMPLATE_TEST_CASE("Unit_Warp_Shfl_Up_Positive_Basic", "", int, unsigned int, long, unsigned long,
+TEMPLATE_TEST_CASE(Unit_Warp_Shfl_Up_Positive_Basic, int, unsigned int, long, unsigned long,
                    long long, unsigned long long, float, double, __half, __half2) {
   int device;
   hipDeviceProp_t device_properties;

--- a/projects/hip-tests/catch/unit/warp/warp_shfl_xor.cc
+++ b/projects/hip-tests/catch/unit/warp/warp_shfl_xor.cc
@@ -105,7 +105,7 @@ template <typename T> class WarpShflXOR : public WarpShflTest<WarpShflXOR<T>, T>
  *  - HIP_VERSION >= 5.2
  *  - Device supports warp shuffle
  */
-TEMPLATE_TEST_CASE("Unit_Warp_Shfl_XOR_Positive_Basic", "", int, unsigned int, long, unsigned long,
+TEMPLATE_TEST_CASE(Unit_Warp_Shfl_XOR_Positive_Basic, int, unsigned int, long, unsigned long,
                    long long, unsigned long long, float, double, __half, __half2) {
   int device;
   hipDeviceProp_t device_properties;


### PR DESCRIPTION
## Motivation

Since the number of unit test cases is constantly growing, the execution time is also increasing. Specific tests are suited for non standard testing and there is no need to run them in the regular PSDB. Add a mechanism to easily disable/enable tests and easily categorize them.

Part 5 covers test name changes for following groups:
- module tests
- multiThread tests
- occupancy tests
- p2p tests
- printf tests
- rtc tests
- stream tests
- streamperthread tests
- surface tests
- synchronization tests
- texture tests
- threadfence tests
- vector_types tests
- virtualMemoryManagement tests
- vulkan_interop tests
- warp tests

## Technical Details

Explained in the ticket in the document attached.

## JIRA ID

SWDEV-567112

## Test Plan

Ensure build passes. All enabled tests pass, all disabled tests are not run

## Test Result

Local build passed, local enabled tests pass, disabled are not run

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
