### PR TITLE
ROCM-1667 - Check for OpenCL ICD loader presence when BUILD_ICD is not set explicitly

### DIFF
--- a/projects/clr/opencl/CMakeLists.txt
+++ b/projects/clr/opencl/CMakeLists.txt
@@ -40,11 +40,27 @@ set(OPENCL_ICD_LOADER_HEADERS_DIR "${CMAKE_CURRENT_LIST_DIR}/khronos/headers/ope
 if(BUILD_ICD)
   add_subdirectory(khronos/icd)
 endif()
+
+# Resolve OpenCL ICD link library once for tools and tests.
+# If OPENCL_ICD_LIB is empty, targets that need the ICD loader are skipped.
+if(TARGET OpenCL)
+  set(OPENCL_ICD_LIB OpenCL)
+else()
+  list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
+  find_package(AMD_ICD QUIET)
+  find_library(OPENCL_ICD_LIB OpenCL HINTS "${AMD_ICD_LIBRARY_DIR}")
+  if(NOT OPENCL_ICD_LIB)
+    message(WARNING "OpenCL ICD loader not found. clinfo and ocltst will not be built.")
+  endif()
+endif()
+
 add_subdirectory(amdocl)
-add_subdirectory(tools/clinfo)
 add_subdirectory(tools/cltrace)
-if(BUILD_TESTS)
-  add_subdirectory(tests/ocltst)
+if(OPENCL_ICD_LIB)
+  add_subdirectory(tools/clinfo)
+  if(BUILD_TESTS)
+    add_subdirectory(tests/ocltst)
+  endif()
 endif()
 
 ###--- Packaging ------------------------------------------------------------###

--- a/projects/clr/opencl/tests/ocltst/env/CMakeLists.txt
+++ b/projects/clr/opencl/tests/ocltst/env/CMakeLists.txt
@@ -38,14 +38,7 @@ target_include_directories(ocltst
     PRIVATE
         $<TARGET_PROPERTY:Common,INTERFACE_INCLUDE_DIRECTORIES>)
 
-if(TARGET OpenCL)
-  target_link_libraries(ocltst PRIVATE OpenCL)
-else()
-  list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/../../../cmake")
-  find_package(AMD_ICD)
-  find_library(AMD_ICD_LIBRARY OpenCL HINTS "${AMD_ICD_LIBRARY_DIR}")
-  target_link_libraries(ocltst PRIVATE ${AMD_ICD_LIBRARY})
-endif()
+target_link_libraries(ocltst PRIVATE ${OPENCL_ICD_LIB})
 
 if (NOT WIN32)
   set(THREADS_PREFER_PTHREAD_FLAG ON)
@@ -60,4 +53,3 @@ endif()
 set_target_properties(ocltst PROPERTIES INSTALL_RPATH "$ORIGIN")
 
 INSTALL(TARGETS ocltst DESTINATION ${OCLTST_INSTALL_DIR} COMPONENT ocltst)
-

--- a/projects/clr/opencl/tests/ocltst/module/gl/CMakeLists.txt
+++ b/projects/clr/opencl/tests/ocltst/module/gl/CMakeLists.txt
@@ -54,14 +54,7 @@ target_link_libraries(oclgl
         GLEW::GLEW
         ${OPENGL_LIBRARIES})
 
-if(TARGET OpenCL)
-  target_link_libraries(oclgl PRIVATE OpenCL)
-else()
-  list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/../../../../cmake")
-  find_package(AMD_ICD)
-  find_library(AMD_ICD_LIBRARY OpenCL HINTS "${AMD_ICD_LIBRARY_DIR}")
-  target_link_libraries(oclgl PRIVATE ${AMD_ICD_LIBRARY})
-endif()
+target_link_libraries(oclgl PRIVATE ${OPENCL_ICD_LIB})
 
 if (NOT WIN32)
   set(THREADS_PREFER_PTHREAD_FLAG ON)
@@ -99,4 +92,3 @@ endforeach()
 
 INSTALL(TARGETS oclgl DESTINATION ${OCLTST_INSTALL_DIR} COMPONENT ocltst)
 INSTALL(FILES oclgl.exclude DESTINATION ${OCLTST_INSTALL_DIR} COMPONENT ocltst)
-

--- a/projects/clr/opencl/tests/ocltst/module/perf/CMakeLists.txt
+++ b/projects/clr/opencl/tests/ocltst/module/perf/CMakeLists.txt
@@ -99,14 +99,7 @@ target_include_directories(oclperf
     PRIVATE
         $<TARGET_PROPERTY:Common,INTERFACE_INCLUDE_DIRECTORIES>)
 
-if(TARGET OpenCL)
-  target_link_libraries(oclperf PRIVATE OpenCL)
-else()
-  list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/../../../../cmake")
-  find_package(AMD_ICD)
-  find_library(AMD_ICD_LIBRARY OpenCL HINTS "${AMD_ICD_LIBRARY_DIR}")
-  target_link_libraries(oclperf PRIVATE ${AMD_ICD_LIBRARY})
-endif()
+target_link_libraries(oclperf PRIVATE ${OPENCL_ICD_LIB})
 if (NOT WIN32)
   set(THREADS_PREFER_PTHREAD_FLAG ON)
   find_package(Threads REQUIRED)
@@ -143,4 +136,3 @@ endforeach()
 
 INSTALL(TARGETS oclperf DESTINATION ${OCLTST_INSTALL_DIR} COMPONENT ocltst)
 INSTALL(FILES oclperf.exclude DESTINATION ${OCLTST_INSTALL_DIR} COMPONENT ocltst)
-

--- a/projects/clr/opencl/tests/ocltst/module/runtime/CMakeLists.txt
+++ b/projects/clr/opencl/tests/ocltst/module/runtime/CMakeLists.txt
@@ -73,15 +73,7 @@ target_include_directories(oclruntime
     PRIVATE
         $<TARGET_PROPERTY:Common,INTERFACE_INCLUDE_DIRECTORIES>)
 
-
-if(TARGET OpenCL)
-  target_link_libraries(oclruntime PRIVATE OpenCL)
-else()
-  list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/../../../../cmake")
-  find_package(AMD_ICD)
-  find_library(AMD_ICD_LIBRARY OpenCL HINTS "${AMD_ICD_LIBRARY_DIR}")
-  target_link_libraries(oclruntime PRIVATE ${AMD_ICD_LIBRARY})
-endif()
+target_link_libraries(oclruntime PRIVATE ${OPENCL_ICD_LIB})
 
 if (NOT WIN32)
   set(THREADS_PREFER_PTHREAD_FLAG ON)
@@ -119,4 +111,3 @@ endforeach()
 
 INSTALL(TARGETS oclruntime DESTINATION ${OCLTST_INSTALL_DIR} COMPONENT ocltst)
 INSTALL(FILES oclruntime.exclude DESTINATION ${OCLTST_INSTALL_DIR} COMPONENT ocltst)
-

--- a/projects/clr/opencl/tools/clinfo/CMakeLists.txt
+++ b/projects/clr/opencl/tools/clinfo/CMakeLists.txt
@@ -2,20 +2,6 @@
 #
 # SPDX-License-Identifier: MIT
 
-if(TARGET OpenCL)
-  set(CLINFO_OPENCL_LIB OpenCL)
-else()
-  list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/../../cmake")
-  find_package(AMD_ICD)
-  find_library(AMD_ICD_LIBRARY OpenCL HINTS "${AMD_ICD_LIBRARY_DIR}")
-  if(AMD_ICD_LIBRARY)
-    set(CLINFO_OPENCL_LIB ${AMD_ICD_LIBRARY})
-  else()
-    message(WARNING "OpenCL ICD loader not found, skipping clinfo build.")
-    return()
-  endif()
-endif()
-
 add_executable(clinfo clinfo.cpp)
 
 target_compile_definitions(clinfo PRIVATE CL_TARGET_OPENCL_VERSION=220 HAVE_CL2_HPP)
@@ -23,7 +9,7 @@ target_compile_definitions(clinfo PRIVATE CL_TARGET_OPENCL_VERSION=220 HAVE_CL2_
 #todo: to be updated to use header files from other repos
 target_include_directories(clinfo PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/../../khronos/headers/opencl2.2")
 
-target_link_libraries(clinfo PRIVATE ${CLINFO_OPENCL_LIB})
+target_link_libraries(clinfo PRIVATE ${OPENCL_ICD_LIB})
 
 INSTALL(TARGETS clinfo
   RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})


### PR DESCRIPTION
## Motivation

Enable CMake build for OpenCL

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

By default, BUILD_ICD is OFF, so OpenCL ICD Loader (OpenCL.dll) is not built.  So CMake should check for default path and if it is not found there as well, then don't build clinfo, ocltst etc. since they need ICD Loader to be linked with.

## Technical Details

CMake searches for OpenCL target and if not found, search in default path or if not skip building clinfo, ocltst.

## JIRA ID

ROCM-1667

## Test Plan

N/A

## Test Result

N/A

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
