### PR TITLE
[clr] Rework host-call buffer implementation

### DIFF
--- a/projects/clr/rocclr/device/rocm/rocdevice.cpp
+++ b/projects/clr/rocclr/device/rocm/rocdevice.cpp
@@ -125,7 +125,6 @@ Device::Device(hsa_agent_t bkendDevice)
       xferQueue_(nullptr),
       freeMem_(0),
       hsa_exclusive_gpu_access_(false),
-      coopHostcallBuffer_(nullptr),
       numOfVgpus_(0),
       preferred_numa_node_(0),
       maxSdmaReadMask_(0),
@@ -136,7 +135,6 @@ Device::Device(hsa_agent_t bkendDevice)
   // Initialize queue pools with proper comparators (requires 'this' pointer)
   for (uint i = 0; i < QueuePriority::Total; ++i) {
     queuePool_.emplace_back(QueueCompare(this));
-    queueWithCUMaskPool_.emplace_back(QueueCompare(this));
   }
 
   group_segment_.handle = 0;
@@ -191,11 +189,6 @@ void Device::checkAtomicSupport() {
 Device::~Device() {
   WaitForHsaAsyncHandlersIdle();
 
-  if (coopHostcallBuffer_) {
-    amd::disableHostcalls(coopHostcallBuffer_);
-    hostFree(coopHostcallBuffer_);
-    coopHostcallBuffer_ = nullptr;
-  }
   // Release cached map targets
   for (uint i = 0; mapCache_ != nullptr && i < mapCache_->size(); ++i) {
     if ((*mapCache_)[i] != nullptr) {
@@ -227,13 +220,6 @@ Device::~Device() {
     for (auto qIter = it.begin(); qIter != it.end();) {
       hsa_queue_t* queue = qIter->first;
       auto& qInfo = qIter->second;
-      if (qInfo.hostcallBuffer_) {
-        ClPrint(amd::LOG_DETAIL_DEBUG, amd::LOG_QUEUE,
-                "Deleting hostcall buffer %p for hardware queue %p", qInfo.hostcallBuffer_,
-                qIter->first->base_address);
-        amd::disableHostcalls(qInfo.hostcallBuffer_);
-        hostFree(qInfo.hostcallBuffer_);
-      }
       ClPrint(amd::LOG_DETAIL_DEBUG, amd::LOG_QUEUE, "Deleting hardware queue %p with refCount 0",
               queue->base_address);
       qIter = it.erase(qIter);
@@ -2139,7 +2125,7 @@ void* Device::hostAlloc(size_t size, size_t alignment, MemorySegment mem_seg,
   else {
     stat = Hsa::agents_allow_access(1, &bkendDevice_, nullptr, ptr);
   }
-  
+
   if (stat != HSA_STATUS_SUCCESS) {
     LogPrintfError("Fail hsa_amd_agents_allow_access with err %d", stat);
     hostFree(ptr, size);
@@ -3129,7 +3115,7 @@ hsa_queue_t* Device::acquireQueue(uint32_t queue_size_hint, bool coop_queue,
         }
       }
       ClPrint(amd::LOG_DETAIL_DEBUG, amd::LOG_QUEUE,
-               "Device::acquireQueue: hsa_queue_create failed!");
+              "Device::acquireQueue: hsa_queue_create failed!");
       return nullptr;
     }
   }
@@ -3139,7 +3125,7 @@ hsa_queue_t* Device::acquireQueue(uint32_t queue_size_hint, bool coop_queue,
     hsa_status_t st = Hsa::queue_set_priority(queue, queue_priority);
     if (st != HSA_STATUS_SUCCESS) {
       ClPrint(amd::LOG_DETAIL_DEBUG, amd::LOG_QUEUE,
-               "Device::acquireQueue: hsa_amd_queue_set_priority failed!");
+              "Device::acquireQueue: hsa_amd_queue_set_priority failed!");
       Hsa::queue_destroy(queue);
       return nullptr;
     }
@@ -3211,26 +3197,15 @@ hsa_queue_t* Device::acquireQueue(uint32_t queue_size_hint, bool coop_queue,
       final_mask = mask;
     }
 
-    hsa_status_t status =
-        Hsa::queue_cu_set_mask(queue, final_mask.size() * 32, final_mask.data());
+    hsa_status_t status = Hsa::queue_cu_set_mask(queue, final_mask.size() * 32, final_mask.data());
     if (status != HSA_STATUS_SUCCESS) {
       ClPrint(amd::LOG_DETAIL_DEBUG, amd::LOG_QUEUE,
-               "Device::acquireQueue: hsa_amd_queue_cu_set_mask failed!");
+              "Device::acquireQueue: hsa_amd_queue_cu_set_mask failed!");
       Hsa::queue_destroy(queue);
       return nullptr;
     }
-    if (cuMask.size() != 0) {
-      amd::ScopedLock l(active_queue_access_);
-      // add queues with custom CU mask into their special pool to keep track
-      // of mapping of these queues to their associated queueInfo (i.e., hostcall buffers)
-      auto result = queueWithCUMaskPool_[qIndex].emplace(std::make_pair(queue, QueueInfo()));
-      assert(result.second && "QueueInfo already exists");
-      auto& qInfo = result.first->second;
-      qInfo.refCount = 1;
-      qInfo.hasDedicatedQueue_ = dedicated_queue;  // Track if this is a dedicated queue
 
-      return queue;
-    }
+    return queue;
   }
 
   if (coop_queue) {
@@ -3284,14 +3259,10 @@ bool Device::ReleaseActiveQueue(hsa_queue_t* queue, amd::CommandQueue::Priority 
 void Device::releaseQueue(hsa_queue_t* queue, const std::vector<uint32_t>& cuMask, bool coop_queue,
                           bool managed) {
   // Defer cleanup operations outside the lock
-  void* hostcallBufferToFree = nullptr;
-  bool shouldDestroyQueue = false;
-
-  { // Lock
+  {  // Lock
     amd::ScopedLock l(active_queue_access_);
-    auto& pools = cuMask.size() == 0 ? queuePool_ : queueWithCUMaskPool_;
-    for (uint qIndex = 0; qIndex < pools.size(); ++qIndex) {
-      auto& it = pools[qIndex];
+    for (uint qIndex = 0; qIndex < queuePool_.size(); ++qIndex) {
+      auto& it = queuePool_[qIndex];
       auto qIter = it.find(queue);
       if (qIter != it.end()) {
         if (!managed && (cuMask.size() == 0)) {
@@ -3302,92 +3273,18 @@ void Device::releaseQueue(hsa_queue_t* queue, const std::vector<uint32_t>& cuMas
         qInfo.refCount--;
         ClPrint(amd::LOG_INFO, amd::LOG_QUEUE, "releaseQueue refCount:%p (%d)",
                 qIter->first->base_address, qIter->second.refCount);
-        // hsa queues with cumask set are not being reused. Hence, if the app uses multiple
-        // such queues it can cause memory leak and those must be destroyed here once the
-        // refcount reaches 0.
-        if ((!cuMask.empty()) && (qInfo.refCount == 0)) {
-          hostcallBufferToFree = qInfo.hostcallBuffer_;
-          shouldDestroyQueue = true;
-          ClPrint(amd::LOG_INFO, amd::LOG_QUEUE, "Deleting hardware queue %p with refCount 0",
-                  queue->base_address);
-          it.erase(qIter);
-        }
         break;  // Found and processed the queue
       }
     }
-  } // Lock release
+  }  // Lock release
 
-  // Perform expensive cleanup operations outside the lock
-  if (shouldDestroyQueue) {
-    if (hostcallBufferToFree) {
-      ClPrint(amd::LOG_INFO, amd::LOG_QUEUE,
-              "Deleting hostcall buffer %p for hardware queue %p", hostcallBufferToFree,
-              queue->base_address);
-      amd::disableHostcalls(hostcallBufferToFree);
-      hostFree(hostcallBufferToFree);
-    }
-    Hsa::queue_destroy(queue);
-  }
-
-  if (coop_queue) {  // cooperative queue
+  // hsa queues with cumask set and coop queues are not being reused. Hence, if the app uses such
+  // queues, we need to destroy them when the queue is released.
+  if (!cuMask.empty() || coop_queue) {
     ClPrint(amd::LOG_INFO, amd::LOG_QUEUE, "Deleting CG enabled hardware queue %p ",
             queue->base_address);
     Hsa::queue_destroy(queue);
   }
-}
-
-void* Device::getOrCreateHostcallBuffer(hsa_queue_t* queue, bool coop_queue,
-                                        const std::vector<uint32_t>& cuMask) {
-  decltype(queuePool_)::value_type::iterator qIter;
-  bool found = false;
-
-  amd::ScopedLock l(active_queue_access_);
-  if (!coop_queue) {
-    for (auto& it : cuMask.size() == 0 ? queuePool_ : queueWithCUMaskPool_) {
-      qIter = it.find(queue);
-      if (qIter != it.end()) {
-        found = true;
-        break;
-      }
-    }
-    assert(found && "Couldn't find queue");
-
-    if (qIter->second.hostcallBuffer_) {
-      return qIter->second.hostcallBuffer_;
-    }
-  } else {
-    if (coopHostcallBuffer_) {
-      return coopHostcallBuffer_;
-    }
-  }
-
-  // The number of packets required in each buffer is at least equal to the
-  // maximum number of waves supported by the device.
-  auto wavesPerCu = info().maxThreadsPerCU_ / info().wavefrontWidth_;
-  auto numPackets = info().maxComputeUnits_ * wavesPerCu;
-
-  auto size = amd::getHostcallBufferSize(numPackets);
-  auto align = amd::getHostcallBufferAlignment();
-
-  void* buffer = hostAlloc(size, align, kAtomics, cpu_agent_info_, false);
-  if (!buffer) {
-    ClPrint(amd::LOG_ERROR, amd::LOG_QUEUE,
-            "Failed to create hostcall buffer for hardware queue %p", queue->base_address);
-    return nullptr;
-  }
-  ClPrint(amd::LOG_INFO, amd::LOG_QUEUE, "Created hostcall buffer %p for hardware queue %p", buffer,
-          queue->base_address);
-  if (!coop_queue) {
-    qIter->second.hostcallBuffer_ = buffer;
-  } else {
-    coopHostcallBuffer_ = buffer;
-  }
-  if (!amd::enableHostcalls(*this, buffer, numPackets)) {
-    ClPrint(amd::LOG_ERROR, amd::LOG_QUEUE, "Failed to register hostcall buffer %p with listener",
-            buffer);
-    return nullptr;
-  }
-  return buffer;
 }
 
 bool Device::findLinkInfo(const amd::Device& other_device, std::vector<LinkAttrType>* link_attrs) {

--- a/projects/clr/rocclr/device/rocm/rocdevice.hpp
+++ b/projects/clr/rocclr/device/rocm/rocdevice.hpp
@@ -552,11 +552,6 @@ class Device : public NullDevice {
   hsa_queue_t* AcquireActiveQueue(amd::CommandQueue::Priority priority);
   bool ReleaseActiveQueue(hsa_queue_t* queue, amd::CommandQueue::Priority priority);
 
-  //! For the given HSA queue, return an existing hostcall buffer or create a
-  //! new one. queuePool_ keeps a mapping from HSA queue to hostcall buffer.
-  void* getOrCreateHostcallBuffer(hsa_queue_t* queue, bool coop_queue = false,
-                                  const std::vector<uint32_t>& cuMask = {});
-
   //! Return multi GPU grid launch sync buffer
   address MGSync() const { return mg_sync_; }
 
@@ -672,12 +667,11 @@ class Device : public NullDevice {
   static address mg_sync_;         //!< MGPU grid launch sync memory (SVM location)
 
   struct QueueInfo {
-    int refCount;           //! Reference counter. Shows how many time the queue was shared
-    void* hostcallBuffer_;  //! Host call buffer for the HSA queue
+    int refCount;             //! Reference counter. Shows how many time the queue was shared
     bool hasDedicatedQueue_;  //! True if this queue is a dedicated queue (e.g., null stream)
 
     // Constructor
-    QueueInfo() : refCount(0), hostcallBuffer_(nullptr), hasDedicatedQueue_(false) {}
+    QueueInfo() : refCount(0), hasDedicatedQueue_(false) {}
 
     //! Get the current hardware queue depth (wptr - rptr)
     static uint64_t GetHwQueueDepth(hsa_queue_t* queue) {
@@ -722,13 +716,10 @@ class Device : public NullDevice {
   //! Use dynamic queues mode to get a queue from pool
   hsa_queue_t* getQueueFromPool(const uint qIndex, bool force_reuse = false);
 
-  void* coopHostcallBuffer_;
   //! returns value for corresponding LinkAttrbutes in a vector given Memory pool.
   virtual bool findLinkInfo(const hsa_amd_memory_pool_t& pool,
                             std::vector<LinkAttrType>* link_attr);
 
-  //! Pool of HSA queues with custom CU masks
-  std::vector<std::map<hsa_queue_t*, QueueInfo, QueueCompare>> queueWithCUMaskPool_;
   hsa_amd_memory_pool_t getHostMemoryPool(MemorySegment mem_seg,
                                           const AgentInfo* agentInfo = nullptr) const;
   //! Read and Write mask for device<->host

--- a/projects/clr/rocclr/device/rocm/rocvirtual.cpp
+++ b/projects/clr/rocclr/device/rocm/rocvirtual.cpp
@@ -1719,7 +1719,8 @@ VirtualGPU::VirtualGPU(Device& device, bool profiling, bool cooperative,
       fence_state_(Device::CacheState::kCacheStateInvalid),
       fence_dirty_(false),
       dedicated_queue_(dedicated_queue),
-      schedulerQueueThreadRunning_(false) {
+      schedulerQueueThreadRunning_(false),
+      hostcallBuffer_(nullptr) {
   index_ = device.numOfVgpus_++;
   gpu_device_ = device.getBackendDevice();
   printfdbg_ = nullptr;
@@ -1843,6 +1844,12 @@ VirtualGPU::~VirtualGPU() {
 
   if (gpu_queue_ != nullptr) {
     roc_device_.releaseQueue(gpu_queue_, cuMask_, cooperative_);
+  }
+
+  if (hostcallBuffer_) {
+    ClPrint(amd::LOG_DETAIL_DEBUG, amd::LOG_QUEUE, "Deleting hostcall buffer %p", hostcallBuffer_);
+    amd::disableHostcalls(hostcallBuffer_);
+    roc_device_.svmFree(hostcallBuffer_);
   }
 }
 
@@ -3924,8 +3931,7 @@ bool VirtualGPU::submitKernelInternal(const amd::NDRangeContainer& sizes, const 
       case amd::KernelParameterDescriptor::HiddenHostcallBuffer: {
         if (amd::IS_HIP) {
           if (dev().info().pcie_atomics_) {
-            uintptr_t buffer = reinterpret_cast<uintptr_t>(
-                roc_device_.getOrCreateHostcallBuffer(gpu_queue_, coopGroups, cuMask_));
+            uintptr_t buffer = reinterpret_cast<uintptr_t>(getOrCreateHostcallBuffer());
             if (!buffer) {
               LogError("Kernel expects a hostcall buffer, but none found");
               return false;
@@ -4537,6 +4543,44 @@ void VirtualGPU::submitPerfCounter(amd::PerfCounterCommand& vcmd) {
     LogError("Unsupported performance counter state");
     vcmd.setStatus(CL_INVALID_OPERATION);
   }
+}
+
+// ================================================================================================
+void *VirtualGPU::getOrCreateHostcallBuffer() {
+  if (hostcallBuffer_ != nullptr) {
+    return hostcallBuffer_;
+  }
+
+  // The number of packets required in each buffer is at least equal to the
+  // maximum number of waves supported by the device.
+  auto wavesPerCu =
+      dev().info().maxThreadsPerCU_ / dev().info().wavefrontWidth_;
+  auto numPackets = dev().info().maxComputeUnits_ * wavesPerCu;
+
+  auto size = amd::getHostcallBufferSize(numPackets);
+  auto align = amd::getHostcallBufferAlignment();
+
+  hostcallBuffer_ = dev().hostAlloc(
+      size, align, Device::MemorySegment::kAtomics, nullptr, false);
+  if (!hostcallBuffer_) {
+    ClPrint(amd::LOG_ERROR, amd::LOG_QUEUE, "Failed to create hostcall buffer");
+    return nullptr;
+  }
+
+  ClPrint(amd::LOG_INFO, amd::LOG_QUEUE,
+          "Created hostcall buffer %p (numPackets == %d, size == %d, align == "
+          "%d) for virtual "
+          "queue %p\n",
+          hostcallBuffer_, numPackets, size, align, this);
+
+  if (!amd::enableHostcalls(dev(), hostcallBuffer_, numPackets)) {
+    ClPrint(amd::LOG_ERROR, amd::LOG_QUEUE,
+            "Failed to register hostcall buffer %p with listener",
+            hostcallBuffer_);
+    dev().svmFree(hostcallBuffer_);
+    return nullptr;
+  }
+  return hostcallBuffer_;
 }
 
 // ================================================================================================

--- a/projects/clr/rocclr/device/rocm/rocvirtual.hpp
+++ b/projects/clr/rocclr/device/rocm/rocvirtual.hpp
@@ -560,6 +560,8 @@ class VirtualGPU : public device::VirtualDevice {
     return assigned_sdma_engine_ != 0;
   }
 
+  void* getOrCreateHostcallBuffer();
+
  private:
   //! Dispatches a barrier with blocking HSA signals
   void dispatchBlockingWait(hsa_kernel_dispatch_packet_t* packet);
@@ -751,6 +753,8 @@ class VirtualGPU : public device::VirtualDevice {
 
   //! SDMA engine affinity tracking for this VirtualGPU/stream
   uint32_t assigned_sdma_engine_ = 0;           //!< Assigned SDMA engine mask for all operations
+
+  void* hostcallBuffer_;  //!< Hostcall buffer
 
   using KernelArgImpl = device::Settings::KernelArgImpl;
 };


### PR DESCRIPTION
## Motivation

The current Implementation of host-call buffers relies on a map of buffer
to hardware queue. To obtain a buffer, we need to rely on locks to avoid
concurrency problems. This works around the problem by using one buffer
per virtual  queue instead.

## Technical Details

Reworks the implementation of host-call buffers so that there is one buffer
per VirtualGPU instead of one buffer per hardware queue. This simplifies
the implementation since it avoids having to maintain a mapping of buffers
to hardware queue.

## JIRA ID

N/A

## Test Plan

Tested locally with an ASAN build.

## Test Result

Test passes. No new leaks introduced.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
