### PR TITLE
Add conflict to rocmmod.in to prevent loading multiple rocm versions using module

### DIFF
--- a/projects/rocm-core/rocmmod.in
+++ b/projects/rocm-core/rocmmod.in
@@ -12,6 +12,8 @@ proc ModulesHelp { } {
     puts stderr "\tThe ROCM Module."
 }
 
+conflict rocm
+
 set ROOT [file normalize [file dirname [file normalize ${ModulesCurrentModulefile}/__]]/../..]
 
 prepend-path PATH "${ROOT}/@CMAKE_INSTALL_BINDIR@:${ROOT}/lib/llvm/bin"


### PR DESCRIPTION
Add a conflict statement, to prevent having multiple rocm versions loaded using module, as that doesn't make sense.

## Motivation
Stop allowing loading multiple rocm versions using module command. This gives unclear behavior as both modulefiles edit the same environment variables.

## Technical Details

Using conflict statement as provided by the modulefile language: https://modules.readthedocs.io/en/latest/modulefile.html#mfcmd-conflict

This assumes that the modulefile is always linked to `/usr/share/modules/modulefiles/rocm/<version>`.

## JIRA ID
-

## Test Plan

Added this single line change to the modulefiles on a machine with multiple ROCm versions installed.

## Test Result

Module prevents a user from loading a second ROCm module. Users are now forced to first unload the first one and then load the new version, or use the switch command to do this in one command. This ensures that it isn't possible to have two ROCm modules loaded at the same time. This is the intended flow of the 'module' command.

```
hacc-box-02[0]:~# module avail
----------------------------------------------------------------------------------------------------------------------------------------------------------- /usr/share/modules/modulefiles -----------------------------------------------------------------------------------------------------------------------------------------------------------
rocm/6.3.3  rocm/7.0.2  rocm/7.1.1  rocm/7.2.0  use.own  vivado/2024.2

Key:
loaded  modulepath
hacc-box-02[1]:~# module list
Currently Loaded Modulefiles:
 1) vivado/2024.2
hacc-box-02[0]:~# module load rocm/6.3.3
hacc-box-02[0]:~# module list
Currently Loaded Modulefiles:
 1) vivado/2024.2   2) rocm/6.3.3
hacc-box-02[0]:~# module load rocm/7.0.2
Loading rocm/7.0.2
  ERROR: Module cannot be loaded due to a conflict.
    HINT: Might try "module unload rocm" first.
hacc-box-02[1]:~# module list
Currently Loaded Modulefiles:
 1) vivado/2024.2   2) rocm/6.3.3
hacc-box-02[0]:~# module switch rocm/6.3.3 rocm/7.0.2
hacc-box-02[0]:~# module list
Currently Loaded Modulefiles:
 1) vivado/2024.2   2) rocm/7.0.2
```

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
