### PR TITLE
[SWDEV-567812] Add UBB power and power_limit fields to npm_info (#3262)

### DIFF
--- a/projects/amdsmi/CHANGELOG.md
+++ b/projects/amdsmi/CHANGELOG.md
@@ -13,6 +13,12 @@ Full documentation for amd_smi_lib is available at [https://rocm.docs.amd.com/pr
   - Selective display: Use `-p` for NPM only, `-b` for Baseboard only.
   - Default behavior (no flags): Shows both power management and baseboard temperatures.
 
+- **Added UBB (baseboard) power monitoring support**.
+  - Added `ubb_power` field to `amdsmi_power_info_t` for baseboard power in Watts.
+  - Added `ubb_power_threshold` field to `amdsmi_npm_info_t` for UBB node power threshold.
+  - `amd-smi metric --power` now displays `ubb_power` when available.
+  - `amd-smi node -p` now displays `THRESHOLD` when available.
+  
 - **Added Power Profile set/get/reset to amd-smi CLI**.  
   - New `amd-smi static --profile` command to display current and available power profiles.
   - New `amd-smi set --profile <PROFILE>` command to set the power profile.

--- a/projects/amdsmi/amdsmi_cli/amdsmi_commands.py
+++ b/projects/amdsmi/amdsmi_cli/amdsmi_commands.py
@@ -2584,7 +2584,8 @@ class AMDSMICommands():
                               'soc_voltage': "N/A",
                               'mem_voltage': "N/A",
                               'throttle_status': "N/A",
-                              'power_management': "N/A"}
+                              'power_management': "N/A",
+                              'ubb_power': "N/A"}
 
                 try:
                     voltage_unit = "mV"
@@ -2604,6 +2605,7 @@ class AMDSMICommands():
                     power_dict['gfx_voltage'] = power_info['gfx_voltage']
                     power_dict['soc_voltage'] = power_info['soc_voltage']
                     power_dict['mem_voltage'] = power_info['mem_voltage']
+                    power_dict['ubb_power'] = power_info.get('ubb_power', "N/A")
 
                 except amdsmi_exception.AmdSmiLibraryException as e:
                     logging.debug("Failed to get power info for gpu %s | %s", gpu_id, e.get_error_info())
@@ -8802,7 +8804,7 @@ class AMDSMICommands():
             self.group_check_printed = True
 
         # Initialize variables for both power management and base board temps
-        npm_dict = {"limit": "N/A", "status": "N/A"}
+        npm_dict = {"limit": "N/A", "status": "N/A", "threshold": "N/A"}
         power_unit = "W"
         limit = "N/A"
         base_board_temp_dict = {}
@@ -8822,11 +8824,15 @@ class AMDSMICommands():
             if isinstance(npm_info, dict):
                 limit = npm_info.get('limit', "N/A")
                 status = npm_info.get('status', npm_info.get('current', "N/A"))
+                ubb_power_threshold = npm_info.get('ubb_power_threshold', "N/A")
 
-                if limit !="N/A":
+                if limit != "N/A":
                     npm_dict['limit'] = limit
                 status = "DISABLED" if status == amdsmi_interface.amdsmi_wrapper.AMDSMI_NPM_STATUS_DISABLED else "ENABLED"
                 npm_dict.update({"status": status})
+                # Add UBB power threshold if available
+                if ubb_power_threshold != "N/A":
+                    npm_dict['threshold'] = ubb_power_threshold
 
         # Get base board temperatures using node_handle
         if args.base_board_temps:
@@ -8847,6 +8853,8 @@ class AMDSMICommands():
                 node_output.append("    POWER_MANAGEMENT:")
                 node_output.append(f"        LIMIT: {npm_dict.get('limit', 'N/A')} {power_unit}")
                 node_output.append(f"        STATUS: {npm_dict.get('status', 'N/A')}")
+                threshold = npm_dict.get('threshold', 'N/A')
+                node_output.append(f"        THRESHOLD: {threshold} {power_unit}")
             if args.base_board_temps and base_board_temp_dict:
                 node_output.append("    BASEBOARD:")
                 node_output.append("        TEMPERATURE:")
@@ -8859,6 +8867,7 @@ class AMDSMICommands():
                 if args.power_management:
                     csv_dict['limit'] = npm_dict.get('limit', "N/A")
                     csv_dict['status'] = npm_dict.get('status', "N/A")
+                    csv_dict['threshold'] = npm_dict.get('threshold', "N/A")
                 if args.base_board_temps and base_board_temp_dict:
                     csv_dict.update(base_board_temp_dict)
                 self.logger.output = csv_dict
@@ -8867,6 +8876,9 @@ class AMDSMICommands():
                 node_output = {}
                 if args.power_management:
                     npm_dict["limit"] = self.helpers.unit_format(self.logger, limit, power_unit)
+                    threshold = npm_dict.get('threshold', 'N/A')
+                    if threshold != 'N/A':
+                        npm_dict['threshold'] = self.helpers.unit_format(self.logger, threshold, power_unit)
                     node_output['power_management'] = npm_dict
                 if args.base_board_temps and base_board_temp_dict:
                     node_output['base_board'] = {'temperature': base_board_temp_dict}

--- a/projects/amdsmi/docs/reference/amdsmi-py-api.md
+++ b/projects/amdsmi/docs/reference/amdsmi-py-api.md
@@ -975,6 +975,7 @@ Field | Description | Units
 `soc_voltage` | voltage soc | mV
 `mem_voltage` | voltage mem | mV
 `power_limit` | power limit | W
+`ubb_power` | UBB (baseboard) node power | W
 
 Exceptions that can be thrown by `amdsmi_get_power_info` function:
 
@@ -1004,6 +1005,7 @@ try:
             print(power_info['soc_voltage'])
             print(power_info['mem_voltage'])
             print(power_info['power_limit'])
+            print(power_info['ubb_power'])
 except AmdSmiException as e:
     print(e)
 ```
@@ -2608,6 +2610,50 @@ try:
         for processor in devices:
             is_power_management_enabled = amdsmi_is_gpu_power_management_enabled(processor)
             print(is_power_management_enabled)
+except AmdSmiException as e:
+    print(e)
+```
+
+### amdsmi_get_npm_info
+
+Description: Returns Node Power Management (NPM) information including status,
+power limit, and UBB power threshold.
+
+Input parameters:
+
+* `node_handle` node handle obtained from `amdsmi_get_node_handle`
+
+Output: Dictionary with fields
+
+Field | Description | Units
+---|---|---
+`status` | NPM status (AMDSMI_NPM_STATUS_ENABLED or AMDSMI_NPM_STATUS_DISABLED) | -
+`limit` | Node-level power limit | W
+`ubb_power_threshold` | UBB node power threshold | W
+
+Exceptions that can be thrown by `amdsmi_get_npm_info` function:
+
+* `AmdSmiLibraryException`
+* `AmdSmiParameterException`
+
+#### Possible Library Exceptions
+
+- `AMDSMI_STATUS_NOT_SUPPORTED` - Feature not supported
+- `AMDSMI_STATUS_INVAL` - Invalid parameters
+
+Example:
+
+```python
+try:
+    devices = amdsmi_get_processor_handles()
+    if len(devices) == 0:
+        print("No GPUs on machine")
+    else:
+        node_handle = amdsmi_get_node_handle(devices[0])
+        npm_info = amdsmi_get_npm_info(node_handle)
+        print(npm_info['status'])
+        print(npm_info['limit'])
+        print(npm_info['ubb_power_threshold'])
 except AmdSmiException as e:
     print(e)
 ```

--- a/projects/amdsmi/include/amd_smi/amdsmi.h
+++ b/projects/amdsmi/include/amd_smi/amdsmi.h
@@ -1156,6 +1156,7 @@ typedef struct {
     uint64_t soc_voltage;           //!< SOC voltage measurement in mV {@linux_bm} or V {@host}
     uint64_t mem_voltage;           //!< MEM voltage measurement in mV {@linux_bm} or V {@host}
     uint32_t power_limit;           //!< The power limit in W {@linux_bm}, Linux only
+    uint32_t ubb_power;             //!< The UBB node power in W {@linux_bm}, MI350X+
     uint64_t reserved[18];
 } amdsmi_power_info_t;
 
@@ -2238,7 +2239,8 @@ typedef enum  {
 typedef struct {
     amdsmi_npm_status_t status; //!< NPM status (enabled/disabled).
     uint64_t            limit;  //!< Node-level power limit in Watts.
-    uint64_t            reserved[6];
+    uint32_t            ubb_power_threshold;  //!< The UBB node power threshold in Watts.
+    uint64_t            reserved[5];
 } amdsmi_npm_info_t;
 
 /**

--- a/projects/amdsmi/py-interface/amdsmi_interface.py
+++ b/projects/amdsmi/py-interface/amdsmi_interface.py
@@ -3688,6 +3688,7 @@ def amdsmi_get_power_info(
         "soc_voltage": power_info.soc_voltage,
         "mem_voltage": power_info.mem_voltage,
         "power_limit" : power_info.power_limit,
+        "ubb_power" : power_info.ubb_power,
     }
 
     for key, value in power_info_dict.items():
@@ -5281,9 +5282,11 @@ def amdsmi_get_npm_info(node_handle: processor_handle_t) -> Dict[str, Any]:
     )
 
     dict_ret = {
-        "limit": npm_info.limit,
+        "limit": _validate_if_max_uint(npm_info.limit, MaxUIntegerTypes.UINT64_T),
         "status": npm_info.status,
+        "ubb_power_threshold": _validate_if_max_uint(npm_info.ubb_power_threshold, MaxUIntegerTypes.UINT32_T),
     }
+
     return dict_ret
 
 

--- a/projects/amdsmi/py-interface/amdsmi_wrapper.py
+++ b/projects/amdsmi/py-interface/amdsmi_wrapper.py
@@ -1381,7 +1381,7 @@ struct_amdsmi_power_info_t._fields_ = [
     ('soc_voltage', ctypes.c_uint64),
     ('mem_voltage', ctypes.c_uint64),
     ('power_limit', ctypes.c_uint32),
-    ('PADDING_0', ctypes.c_ubyte * 4),
+    ('ubb_power', ctypes.c_uint32),
     ('reserved', ctypes.c_uint64 * 18),
 ]
 
@@ -2351,7 +2351,9 @@ struct_amdsmi_npm_info_t._fields_ = [
     ('status', amdsmi_npm_status_t),
     ('PADDING_0', ctypes.c_ubyte * 4),
     ('limit', ctypes.c_uint64),
-    ('reserved', ctypes.c_uint64 * 6),
+    ('ubb_power_threshold', ctypes.c_uint32),
+    ('PADDING_1', ctypes.c_ubyte * 4),
+    ('reserved', ctypes.c_uint64 * 5),
 ]
 
 amdsmi_npm_info_t = struct_amdsmi_npm_info_t

--- a/projects/amdsmi/rocm_smi/include/rocm_smi/rocm_smi.h
+++ b/projects/amdsmi/rocm_smi/include/rocm_smi/rocm_smi.h
@@ -615,7 +615,8 @@ typedef struct
 {
   rsmi_npm_status_t status; //!< NPM status (enabled/disabled).
   uint64_t limit;  //!< Node-level power limit in Watts.
-  uint64_t reserved[6];
+  uint32_t ubb_power_threshold;  //!< The UBB node power threshold in Watts.
+  uint64_t reserved[5];
 } rsmi_npm_info_t;
 
 /**
@@ -2964,6 +2965,8 @@ rsmi_status_t rsmi_dev_fan_speed_max_get(uint32_t dv_ind,
 
 rsmi_status_t rsmi_dev_npm_info_get(uint32_t dv_ind,
                               uintptr_t node_handle, rsmi_npm_info_t *npm_info);
+
+rsmi_status_t rsmi_dev_baseboard_power_get(uint32_t dv_ind, uint64_t *power);
 
 /**
  *  @brief Get the temperature metric value for the specified metric, from the

--- a/projects/amdsmi/rocm_smi/include/rocm_smi/rocm_smi_device.h
+++ b/projects/amdsmi/rocm_smi/include/rocm_smi/rocm_smi_device.h
@@ -162,6 +162,8 @@ enum DevInfoTypes {
   kDevBaseBoardTempMetrics,
   kDevGpuBoardTempMetrics,
   kDevGpuReset,
+  kDevBaseBoardPower,
+  kDevBaseBoardPowerLimit,
   kDevAvailableComputePartition,
   kDevComputePartition,
   kDevMemoryPartition,

--- a/projects/amdsmi/rocm_smi/include/rocm_smi/rocm_smi_npm.h
+++ b/projects/amdsmi/rocm_smi/include/rocm_smi/rocm_smi_npm.h
@@ -1,23 +1,6 @@
 /*
  * Copyright (c) Advanced Micro Devices, Inc. All rights reserved.
- *
- * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the "Software"), to deal
- * in the Software without restriction, including without limitation the rights
- * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the Software is
- * furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
- * THE SOFTWARE.
+ * See LICENSE file for full license text.
  */
 
 #ifndef ROCM_SMI_INCLUDE_ROCM_SMI_ROCM_SMI_NPM_H_
@@ -26,14 +9,14 @@
 #include "rocm_smi/rocm_smi.h"
 #include <string>
 
-
 namespace amd::smi {
 
-rsmi_status_t get_npm_board_status(const std::string &board_path,
-                                        bool *enabled);
+// NPM board status and limit queries
+rsmi_status_t get_npm_board_status(const std::string &board_path, bool *enabled);
+rsmi_status_t get_npm_board_limit(const std::string &board_path, uint64_t *limit);
 
-rsmi_status_t get_npm_board_limit(const std::string &board_path,
-                                                uint64_t *limit);
+// UBB (baseboard) power limit query
+rsmi_status_t get_ubb_power_limit(const std::string &board_path, uint64_t *limit);
 
-}
+}  // namespace amd::smi
 #endif  // ROCM_SMI_INCLUDE_ROCM_SMI_ROCM_SMI_NPM_H_

--- a/projects/amdsmi/rocm_smi/src/rocm_smi.cc
+++ b/projects/amdsmi/rocm_smi/src/rocm_smi.cc
@@ -3374,15 +3374,44 @@ rsmi_dev_npm_info_get(uint32_t dv_ind, uintptr_t node_handle,
     npm_limit = UINT64_MAX;
   }
 
+  // Get UBB power threshold (optional - don't fail if not available)
+  uint64_t ubb_power_threshold_raw = UINT64_MAX;
+  rsmi_status_t ubb_status = amd::smi::get_ubb_power_limit(*board_path_str, &ubb_power_threshold_raw);
+
   // fill output
   std::memset(npm_info, 0, sizeof(*npm_info));
   npm_info->status = npm_status ? RSMI_NPM_STATUS_ENABLED : RSMI_NPM_STATUS_DISABLED;
   npm_info->limit = npm_limit;
+  constexpr auto kU32Max = static_cast<uint64_t>(std::numeric_limits<uint32_t>::max());
+  npm_info->ubb_power_threshold = (ubb_status == RSMI_STATUS_SUCCESS && ubb_power_threshold_raw <= kU32Max)
+      ? static_cast<uint32_t>(ubb_power_threshold_raw) : std::numeric_limits<uint32_t>::max();
 
   ss << __PRETTY_FUNCTION__ << " | ======= end ======= | returning "
      << getRSMIStatusString(RSMI_STATUS_SUCCESS);
   LOG_TRACE(ss);
   return RSMI_STATUS_SUCCESS;
+  CATCH
+}
+
+rsmi_status_t
+rsmi_dev_baseboard_power_get(uint32_t dv_ind, uint64_t *power) {
+  TRY
+  std::ostringstream ss;
+  ss << __PRETTY_FUNCTION__ << "| ======= start =======";
+  LOG_TRACE(ss);
+
+  CHK_SUPPORT_NAME_ONLY(power)
+
+  DEVICE_MUTEX
+  rsmi_status_t ret = get_dev_value_int(amd::smi::kDevBaseBoardPower,
+                                        dv_ind, power);
+
+  ss << __PRETTY_FUNCTION__
+     << " | Device #: " << std::to_string(dv_ind)
+     << " | Data: baseboard_power = " << std::to_string(*power)
+     << " | ret = " << getRSMIStatusString(ret, false);
+  LOG_DEBUG(ss);
+  return ret;
   CATCH
 }
 

--- a/projects/amdsmi/rocm_smi/src/rocm_smi_device.cc
+++ b/projects/amdsmi/rocm_smi/src/rocm_smi_device.cc
@@ -119,6 +119,8 @@ static const char *kDevPmMetricsFName = "pm_metrics";   // PM log
 static const char *kDevRegMetricsFName = "reg_state";   // register table
 static const char *kDevBaseBoardTempMetricsFName = "board/baseboard_temp";
 static const char *kDevGpuBoardTempMetricsFName = "board/gpuboard_temp";
+static const char *kDevBaseBoardPowerFName = "board/baseboard_power";
+static const char *kDevBaseBoardPowerLimitFName = "board/baseboard_power_limit";
 static const char *kDevPtlSupportedFName = "ptl/ptl_supported_formats"; // Only used internally for verification
 static const char *kDevPtlStatusFName = "ptl/ptl_enable";
 static const char *kDevPtlFormatFName = "ptl/ptl_format";
@@ -334,6 +336,8 @@ static const std::map<DevInfoTypes, const char *> kDevAttribNameMap = {
     {kDevRegMetrics, kDevRegMetricsFName},
     {kDevBaseBoardTempMetrics, kDevBaseBoardTempMetricsFName},
     {kDevGpuBoardTempMetrics, kDevGpuBoardTempMetricsFName},
+    {kDevBaseBoardPower, kDevBaseBoardPowerFName},
+    {kDevBaseBoardPowerLimit, kDevBaseBoardPowerLimitFName},
     {kDevPtlSupported, kDevPtlSupportedFName},
     {kDevPtlStatus, kDevPtlStatusFName},
     {kDevPtlFormat, kDevPtlFormatFName},
@@ -511,6 +515,8 @@ Device::devInfoTypesStrings = {
   {kDevRegMetrics, "kDevRegMetrics"},
   {kDevBaseBoardTempMetrics, "kDevBaseBoardTempMetrics"},
   {kDevGpuBoardTempMetrics, "kDevGpuBoardTempMetrics"},
+  {kDevBaseBoardPower, "kDevBaseBoardPower"},
+  {kDevBaseBoardPowerLimit, "kDevBaseBoardPowerLimit"},
   {kDevGpuReset, "kDevGpuReset"},
   {kDevAvailableComputePartition, "kDevAvailableComputePartition"},
   {kDevComputePartition, "kDevComputePartition"},
@@ -1361,6 +1367,8 @@ int Device::readDevInfo(DevInfoTypes type, uint64_t *val) {
     case kDevDFCountersAvailable:
     case kDevMemBusyPercent:
     case kDevXGMIError:
+    case kDevBaseBoardPower:
+    case kDevBaseBoardPowerLimit:
       ret = readDevInfoStr(type, &tempStr);
       RET_IF_NONZERO(ret);
       if (tempStr.empty()) {

--- a/projects/amdsmi/rocm_smi/src/rocm_smi_npm.cc
+++ b/projects/amdsmi/rocm_smi/src/rocm_smi_npm.cc
@@ -1,23 +1,6 @@
 /*
  * Copyright (c) Advanced Micro Devices, Inc. All rights reserved.
- *
- * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the "Software"), to deal
- * in the Software without restriction, including without limitation the rights
- * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the Software is
- * furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
- * THE SOFTWARE.
+ * See LICENSE file for full license text.
  */
 
 #include "rocm_smi/rocm_smi_npm.h"
@@ -72,14 +55,15 @@ rsmi_status_t get_npm_board_status(const std::string &board_path, bool *enabled)
   return RSMI_STATUS_UNEXPECTED_DATA;
 }
 
-rsmi_status_t get_npm_board_limit(const std::string &board_path, uint64_t *limit) {
-  if (limit == nullptr) return RSMI_STATUS_INVALID_ARGS;
+static rsmi_status_t read_board_uint64(const std::string &board_path,
+                                       const char *filename, uint64_t *value) {
+  if (value == nullptr) return RSMI_STATUS_INVALID_ARGS;
   if (board_path.empty()) return RSMI_STATUS_INVALID_ARGS;
 
   fs::path bd(board_path);
   if (!fs::exists(bd) || !fs::is_directory(bd)) return RSMI_STATUS_NOT_SUPPORTED;
 
-  fs::path p = bd / "cur_node_power_limit";
+  fs::path p = bd / filename;
   if (!fs::exists(p) || !fs::is_regular_file(p)) return RSMI_STATUS_NOT_SUPPORTED;
 
   std::string s;
@@ -90,11 +74,22 @@ rsmi_status_t get_npm_board_limit(const std::string &board_path, uint64_t *limit
     size_t idx = 0;
     unsigned long long v = std::stoull(s, &idx, 10);
     if (idx != s.size()) return RSMI_STATUS_UNEXPECTED_DATA;
-    *limit = static_cast<uint64_t>(v);
+    *value = static_cast<uint64_t>(v);
     return RSMI_STATUS_SUCCESS;
-  } catch (...) {
+  } catch (const std::invalid_argument&) {
+    return RSMI_STATUS_UNEXPECTED_DATA;
+  } catch (const std::out_of_range&) {
     return RSMI_STATUS_UNEXPECTED_DATA;
   }
+}
+
+rsmi_status_t get_npm_board_limit(const std::string &board_path, uint64_t *limit) {
+  return read_board_uint64(board_path, "cur_node_power_limit", limit);
+}
+
+
+rsmi_status_t get_ubb_power_limit(const std::string &board_path, uint64_t *limit) {
+  return read_board_uint64(board_path, "baseboard_power_limit", limit);
 }
 
 }  // end namespace

--- a/projects/amdsmi/src/amd_smi/amd_smi.cc
+++ b/projects/amdsmi/src/amd_smi/amd_smi.cc
@@ -35,6 +35,8 @@
 #include <sstream>
 #include <iomanip>
 #include <iostream>
+#include <fstream>
+#include <filesystem>
 #include <queue>
 #include <vector>
 #include <set>
@@ -5481,6 +5483,7 @@ amdsmi_get_power_info(amdsmi_processor_handle processor_handle, amdsmi_power_inf
     info->soc_voltage = get_std_num_limit<decltype(info->soc_voltage)>();
     info->mem_voltage = get_std_num_limit<decltype(info->mem_voltage)>();
     info->power_limit = get_std_num_limit<decltype(info->power_limit)>();
+    info->ubb_power = get_std_num_limit<decltype(info->ubb_power)>();
 
     amdsmi_gpu_metrics_t metrics = {};
     status = amdsmi_get_gpu_metrics_info(processor_handle, &metrics);
@@ -5510,6 +5513,20 @@ amdsmi_get_power_info(amdsmi_processor_handle processor_handle, amdsmi_power_inf
         info->power_limit = power_limit;
     } else if (status2 == AMDSMI_STATUS_NOT_SUPPORTED) {
         status = AMDSMI_STATUS_SUCCESS;
+    }
+
+    // Read UBB (baseboard) power through the Device object's kDevBaseBoardPower
+    // sysfs attribute.  XCP platform devices have no board/ directory so the
+    // read silently fails and the sentinel value is kept.
+    {
+        uint64_t ubb_power_raw = 0;
+        if (rsmi_wrapper(rsmi_dev_baseboard_power_get, processor_handle, 0,
+                         &ubb_power_raw) == AMDSMI_STATUS_SUCCESS) {
+            constexpr auto kU32Max = static_cast<uint64_t>(std::numeric_limits<uint32_t>::max());
+            info->ubb_power = (ubb_power_raw <= kU32Max)
+                ? static_cast<uint32_t>(ubb_power_raw)
+                : std::numeric_limits<uint32_t>::max();
+        }
     }
 
     // Returning status from amdsmi_get_gpu_metrics_info() which should return SUCCESS


### PR DESCRIPTION
## Motivation
Adding support for UBB power metrics. Needed for 7.12 release.

## Technical Details
* Add UBB power and power_limit fields to npm_info for MIXXX baseboard power monitoring (SWDEV-567812)
* Extracted helper function and use MaxUIntegerTypes constant
* Add ubb_power and ubb_power_limit defaults to npm_dict
* Fixes to align to convention + Added rsmi callback

## JIRA ID
ROCM-668
SWDEV-567812

## Test Plan

## Test Result

## Submission Checklist

