### PR TITLE
[RDC] Fix 'Fail to open librdc_rocp.so'

### DIFF
--- a/projects/rdc/rdc_libs/CMakeLists.txt
+++ b/projects/rdc/rdc_libs/CMakeLists.txt
@@ -115,7 +115,12 @@ if(RDC_LIB_MODULES)
         EXPORT rdcTargets
         LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}/${RDC} COMPONENT ${CLIENT_COMPONENT}
     )
-    set_target_properties(${RDC_LIB_MODULES} PROPERTIES INSTALL_RPATH "\$ORIGIN:\$ORIGIN/..")
+    set_target_properties(
+        ${RDC_LIB_MODULES}
+        PROPERTIES
+            INSTALL_RPATH "\$ORIGIN:\$ORIGIN/.."
+            THEROCK_INSTALL_RPATH_ORIGIN "${CMAKE_INSTALL_LIBDIR}/${RDC}"
+    )
 endif()
 
 install(

--- a/projects/rdc/rdc_libs/bootstrap/CMakeLists.txt
+++ b/projects/rdc/rdc_libs/bootstrap/CMakeLists.txt
@@ -48,7 +48,10 @@ target_include_directories(
 # Set the VERSION and SOVERSION values
 set_property(TARGET ${BOOTSTRAP_LIB} PROPERTY SOVERSION "${VERSION_MAJOR}")
 set_property(TARGET ${BOOTSTRAP_LIB} PROPERTY VERSION "${SO_VERSION_STRING}")
-set_target_properties(${BOOTSTRAP_LIB} PROPERTIES INSTALL_RPATH "\$ORIGIN:\$ORIGIN/rdc")
+set_target_properties(
+    ${BOOTSTRAP_LIB}
+    PROPERTIES INSTALL_RPATH "\$ORIGIN:\$ORIGIN/rdc" THEROCK_NO_INSTALL_RPATH TRUE
+)
 
 # If the library is a release, strip the target library
 if("${CMAKE_BUILD_TYPE}" STREQUAL Release)


### PR DESCRIPTION
## Temp workaround before this PR merges
If you have `/opt/rocm/core/lib/rdc/librdc_rocp.so` then do the following:
```
cd /opt/rocm/core
sudo patchelf --add-rpath '$ORIGIN/rdc' lib/librdc_bootstrap.so
for k in lib/rdc/*.so; do
    sudo patchelf --add-rpath '$ORIGIN/..:$ORIGIN/../rocm_sysdeps/lib:$ORIGIN/../llvm/lib' "$k"
done
```

## Issue 1.
RDC has libraries that get installed into `/opt/rocm/lib/rdc/` and need to have RPATH set correctly.
Something in TheRock changed breaking the rpath.
```
[lib]$ ldd rdc/librdc_rocp.so
	linux-vdso.so.1 (0x00007fcd81a8a000)
	libhsa-runtime64.so.1 => not found
	libpthread.so.0 => /lib64/libpthread.so.0 (0x00007fcd81a40000)
	libdl.so.2 => /lib64/libdl.so.2 (0x00007fcd81a3b000)
	libamd_smi.so.26 => not found
	librocprofiler-sdk.so.1 => not found
	libstdc++.so.6 => /lib64/libstdc++.so.6 (0x00007fcd81600000)
	libm.so.6 => /lib64/libm.so.6 (0x00007fcd8198b000)
	libgcc_s.so.1 => /lib64/libgcc_s.so.1 (0x00007fcd8195e000)
	libc.so.6 => /lib64/libc.so.6 (0x00007fcd81428000)
	/lib64/ld-linux-x86-64.so.2 (0x00007fcd81a8c000)
[lib]$ patchelf --print-rpath rdc/librdc_rocp.so
$ORIGIN:$ORIGIN/rocm_sysdeps/lib:$ORIGIN/llvm/lib:/home/runner/_work/rockrel/rockrel/output/build/core/amdsmi/dist/lib:/home/runner/_work/rockrel/rockrel/output/build/profiler/rocprofiler-sdk/dist/lib:/home/runner/_work/rockrel/rockrel/output/build/core/ROCR-Runtime/dist/lib
```

`$ORIGIN:$ORIGIN/rocm_sysdeps/lib:$ORIGIN/llvm/lib`
should say
`$ORIGIN/..:$ORIGIN/../rocm_sysdeps/lib:$ORIGIN/../llvm/lib`

## Issue 2.

Additionally, `librdc_bootstrap.so` installs to `lib/` and needs `$ORIGIN/rdc` in its RPATH to find the module libraries it dlopen's from `lib/rdc/`. TheRock's post-processing was overwriting its RPATH to just `$ORIGIN`, dropping the `$ORIGIN/rdc` entry. The fix sets `THEROCK_NO_INSTALL_RPATH` on the bootstrap target so TheRock preserves its manually-set RPATH.