### PR TITLE
[rocprofiler-compute] Add database indexes to analysis ORM for query optimization

### DIFF
--- a/projects/rocprofiler-compute/src/utils/analysis_orm.py
+++ b/projects/rocprofiler-compute/src/utils/analysis_orm.py
@@ -29,6 +29,7 @@ from sqlalchemy import (
     Column,
     Float,
     ForeignKey,
+    Index,
     Integer,
     String,
     Text,
@@ -98,6 +99,8 @@ class MetricDefinition(Base):
         "WorkloadMetricValue", back_populates="metric"
     )
 
+    __table_args__ = (Index("idx_metric_def_workload", "workload_id"),)
+
 
 class KernelRooflineData(Base):
     __tablename__ = f"{PREFIX}kernel_roofline_data"
@@ -114,6 +117,8 @@ class KernelRooflineData(Base):
     # Roofline data point can have one kernel
     kernel = relationship("Kernel", back_populates="roofline_data_points")
 
+    __table_args__ = (Index("idx_kernel_roofline_kernel", "kernel_uuid"),)
+
 
 class Dispatch(Base):
     __tablename__ = f"{PREFIX}dispatch"
@@ -129,6 +134,16 @@ class Dispatch(Base):
 
     # Dispatch can have one kernel
     kernel = relationship("Kernel", back_populates="dispatches")
+
+    __table_args__ = (
+        Index("idx_dispatch_kernel", "kernel_uuid"),
+        # Composite index for duration-based queries (median calculation)
+        Index(
+            "idx_dispatch_kernel_duration",
+            "kernel_uuid",
+            text("(end_timestamp - start_timestamp)"),
+        ),
+    )
 
 
 class Kernel(Base):
@@ -151,6 +166,8 @@ class Kernel(Base):
     # Kernel can have multiple pc_sampling values
     pc_sampling_values = relationship("PCsampling", back_populates="kernel")
 
+    __table_args__ = (Index("idx_kernel_workload", "workload_id"),)
+
 
 class PCsampling(Base):
     __tablename__ = f"{PREFIX}pcsampling"
@@ -169,6 +186,8 @@ class PCsampling(Base):
 
     # PCsampling can have one kernel
     kernel = relationship("Kernel", back_populates="pc_sampling_values")
+
+    __table_args__ = (Index("idx_pcsampling_kernel", "kernel_uuid"),)
 
 
 class KernelMetricValue(Base):
@@ -189,6 +208,11 @@ class KernelMetricValue(Base):
     # Value can have one kernel
     kernel = relationship("Kernel", back_populates="metric_values")
 
+    __table_args__ = (
+        Index("idx_kernel_metric_value_metric", "metric_uuid"),
+        Index("idx_kernel_metric_value_kernel", "kernel_uuid"),
+    )
+
 
 class WorkloadMetricValue(Base):
     __tablename__ = f"{PREFIX}workload_metric_value"
@@ -207,6 +231,11 @@ class WorkloadMetricValue(Base):
     metric = relationship("MetricDefinition", back_populates="workload_metric_values")
     workload = relationship("Workload", back_populates="workload_metric_values")
 
+    __table_args__ = (
+        Index("idx_workload_metric_value_metric", "metric_uuid"),
+        Index("idx_workload_metric_value_workload", "workload_id"),
+    )
+
 
 class WorkloadRooflineData(Base):
     __tablename__ = f"{PREFIX}workload_roofline_data"
@@ -222,6 +251,8 @@ class WorkloadRooflineData(Base):
 
     # Relationships
     workload = relationship("Workload", back_populates="workload_roofline_data_points")
+
+    __table_args__ = (Index("idx_workload_roofline_workload", "workload_id"),)
 
 
 class Metadata(Base):


### PR DESCRIPTION
## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

Adds SQLAlchemy indexes on all foreign key columns to improve query performance for database analysis mode. Indexes are created automatically during database initialization.

## Technical Details

Indexes added:
- idx_dispatch_kernel: Optimize Dispatch→Kernel joins
- idx_dispatch_kernel_duration: Optimize median/duration calculations
- idx_kernel_workload: Optimize Kernel→Workload joins
- idx_metric_def_workload: Optimize MetricDefinition→Workload joins
- idx_kernel_metric_value_metric: Optimize metric value lookups
- idx_kernel_metric_value_kernel: Optimize kernel metric queries
- idx_workload_metric_value_metric: Optimize workload metric queries
- idx_workload_metric_value_workload: Optimize workload filtering
- idx_kernel_roofline_kernel: Optimize roofline data retrieval
- idx_workload_roofline_workload: Optimize workload roofline queries
- idx_pcsampling_kernel: Optimize PC sampling queries

<!-- Explain the changes along with any relevant GitHub links. -->

## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan

Test creating analysis database

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

Tests pass

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
