### PR TITLE
[TheRock CI] Add sanity testing

### DIFF
--- a/.github/scripts/therock_matrix.py
+++ b/.github/scripts/therock_matrix.py
@@ -4,17 +4,16 @@ This dictionary is used to map specific file directory changes to the correspond
 subtree_to_project_map = {
     "projects/amdsmi": "core",
     "projects/aqlprofile": "profiler",
-    "projects/clr": "core",
+    "projects/clr": "runtimes",
     "projects/cuid": "rdc",
-    "projects/hip": "core",
-    "projects/hip-tests": "core",
-    "projects/hipother": "core",
+    "projects/hip": "runtimes",
+    "projects/hip-tests": "runtimes",
+    "projects/hipother": "runtimes",
     "projects/rdc": "dc_tools",
     "projects/rocdbgapi": "debug_tools",
     # "projects/rocdecode": "media-libs",
     # "projects/rocjpeg": "media-libs",
     "projects/rocm-core": "core",
-    "projects/rocm-smi-lib": "core",
     "projects/rocminfo": "core",
     "projects/rocm-smi-lib": "core",
     "projects/rocprofiler": "profiler",
@@ -24,15 +23,15 @@ subtree_to_project_map = {
     "projects/rocprofiler-systems": "profiler",
     "projects/rocprofiler": "profiler",
     "projects/rocr-debug-agent": "debug_tools",
-    "projects/rocr-runtime": "core",
+    "projects/rocr-runtime": "runtimes",
     "projects/rocshmem": "rocshmem",
     "projects/roctracer": "profiler",
 }
 
 project_map = {
     "core": {
-        "cmake_options": "-DTHEROCK_ENABLE_ALL=ON",
-        "projects_to_test": "hip-tests, rocrtst",
+        "cmake_options": "-DTHEROCK_ENABLE_CORE=ON -DTHEROCK_ENABLE_ALL=OFF",
+        "projects_to_test": "",  # will run sanity test to cover rocminfo and amdsmi
     },
     "dc_tools": {
         "cmake_options": "-DTHEROCK_ENABLE_DC_TOOLS=ON -DTHEROCK_ENABLE_ALL=OFF",
@@ -54,6 +53,10 @@ project_map = {
     "rocshmem": {
         "cmake_options": "-DTHEROCK_ENABLE_ROCSHMEM=ON -DTHEROCK_ENABLE_ALL=OFF",
         "projects_to_test": "",  # rocshmem testing to be enabled in a future PR
+    },
+    "runtimes": {
+        "cmake_options": "-DTHEROCK_ENABLE_ALL=ON",
+        "projects_to_test": "hip-tests, rocrtst",
     },
     "all": {
         "cmake_options": "-DTHEROCK_ENABLE_ALL=ON",

--- a/.github/workflows/therock-test-packages.yml
+++ b/.github/workflows/therock-test-packages.yml
@@ -11,6 +11,12 @@ on:
         type: string
       platform:
         type: string
+      artifact_run_id:
+        type: string
+        default: ""
+      sanity_check_only_for_family:
+        type: boolean
+        default: false
 
 permissions:
   contents: read
@@ -22,6 +28,8 @@ jobs:
     if: ${{ inputs.test_runs_on != '' }}
     outputs:
       components: ${{ steps.configure.outputs.components }}
+      platform: ${{ steps.configure.outputs.platform }}
+      sanity_component: ${{ steps.configure.outputs.sanity_component }}
     steps:
       - name: "Fetch 'build_tools' from repository"
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
@@ -59,11 +67,10 @@ jobs:
   test_sanity_check:
     name: 'Test Sanity Check'
     needs: configure_test_matrix
-    uses: './.github/workflows/test_component.yml'
+    uses: './.github/workflows/therock-test-component.yml'
     with:
       artifact_run_id: ${{ inputs.artifact_run_id }}
       amdgpu_families: ${{ inputs.amdgpu_families }}
-      amdgpu_targets: ${{ inputs.amdgpu_targets }}
       test_runs_on: ${{ inputs.test_runs_on }}
       platform: ${{ needs.configure_test_matrix.outputs.platform }}
       component: ${{ needs.configure_test_matrix.outputs.sanity_component }}
@@ -81,7 +88,6 @@ jobs:
     with:
       artifact_run_id: ${{ inputs.artifact_run_id }}
       amdgpu_families: ${{ inputs.amdgpu_families }}
-      amdgpu_targets: ${{ inputs.amdgpu_targets }}
       # If the test requires a multi GPU, use the multi GPU test runner
       # Otherwise, use the standard test runner
       test_runs_on: >-

--- a/.github/workflows/therock-test-packages.yml
+++ b/.github/workflows/therock-test-packages.yml
@@ -56,19 +56,39 @@ jobs:
         id: configure
         run: python ./build_tools/github_actions/fetch_test_configurations.py
 
+  test_sanity_check:
+    name: 'Test Sanity Check'
+    needs: configure_test_matrix
+    uses: './.github/workflows/test_component.yml'
+    with:
+      artifact_run_id: ${{ inputs.artifact_run_id }}
+      amdgpu_families: ${{ inputs.amdgpu_families }}
+      amdgpu_targets: ${{ inputs.amdgpu_targets }}
+      test_runs_on: ${{ inputs.test_runs_on }}
+      platform: ${{ needs.configure_test_matrix.outputs.platform }}
+      component: ${{ needs.configure_test_matrix.outputs.sanity_component }}
+
   test_components:
     name: 'Test ${{ matrix.components.job_name }}'
-    needs: [configure_test_matrix]
-    # skip tests if no test matrix to run
-    if: ${{ needs.configure_test_matrix.outputs.components != '[]' }}
+    needs: [test_sanity_check, configure_test_matrix]
+    # skip tests if no test matrix to run and sanity check only requested
+    if: ${{ needs.configure_test_matrix.outputs.components != '[]' && !inputs.sanity_check_only_for_family }}
     strategy:
       fail-fast: false
       matrix:
         components: ${{ fromJSON(needs.configure_test_matrix.outputs.components) }}
     uses: './.github/workflows/therock-test-component.yml'
     with:
-      artifact_run_id: ${{ github.run_id }}
+      artifact_run_id: ${{ inputs.artifact_run_id }}
       amdgpu_families: ${{ inputs.amdgpu_families }}
-      test_runs_on: ${{ inputs.test_runs_on }}
-      platform: ${{ inputs.platform }}
+      amdgpu_targets: ${{ inputs.amdgpu_targets }}
+      # If the test requires a multi GPU, use the multi GPU test runner
+      # Otherwise, use the standard test runner
+      test_runs_on: >-
+        ${{
+          matrix.components.multi_gpu_runner != '' &&
+            matrix.components.multi_gpu_runner ||
+            inputs.test_runs_on
+        }}
+      platform: ${{ needs.configure_test_matrix.outputs.platform }}
       component: ${{ toJSON(matrix.components) }}


### PR DESCRIPTION
- Run sanity test script from TheRock before proceeding with component-specific testing, similar to workflows on TheRock repo.
- Sanity tests execute rocminfo and amdsmi to verify basic functionality of the test system.
- Separate runtimes into a new build/test strategy, so other core projects do not need to go through the full build and a smaller test set.
