### PR TITLE
[AMD-SMI] Fix Python wrapper FIXME_STUB by upgrading ctypeslib2 to 2.4.0

### DIFF
--- a/projects/amdsmi/amdsmi_cli/BDF.py
+++ b/projects/amdsmi/amdsmi_cli/BDF.py
@@ -46,9 +46,11 @@ class BDF:
             #   - BB: 2 hex digits (bus)
             #   - DD: 2 hex digits (device)
             #   - F: 1 hex digit 0-7 (function) - MUST be single digit
-            bdf_format_regex = r'^(?:[0-9a-fA-F]{4}:)?[0-9a-fA-F]{2}:[0-9a-fA-F]{2}\.[0-7]$'
+            bdf_format_regex = r"^(?:[0-9a-fA-F]{4}:)?[0-9a-fA-F]{2}:[0-9a-fA-F]{2}\.[0-7]$"
             if not re.match(bdf_format_regex, bdf):
-                raise self.BDFError(f"Invalid BDF format: '{bdf}'. Expected format: [SSSS:]BB:DD.F (where F is 0-7)")
+                raise self.BDFError(
+                    f"Invalid BDF format: '{bdf}'. Expected format: [SSSS:]BB:DD.F (where F is 0-7)"
+                )
 
             try:
                 bdf_components = [int(x, 16) for x in re.split("[:.]", bdf)]

--- a/projects/amdsmi/amdsmi_cli/amdsmi_cli.py
+++ b/projects/amdsmi/amdsmi_cli/amdsmi_cli.py
@@ -230,27 +230,37 @@ if __name__ == "__main__":
 
     try:
         if len(sys.argv) == 1:
-            args = amd_smi_parser.parse_args(args=['default'])
-        elif sys.tracebacklimit == 10 and (sys.argv[1] == '--loglevel'):
-            args = amd_smi_parser.parse_args(args=['default', '--loglevel'] + sys.argv[2:])
+            args = amd_smi_parser.parse_args(args=["default"])
+        elif sys.tracebacklimit == 10 and (sys.argv[1] == "--loglevel"):
+            args = amd_smi_parser.parse_args(args=["default", "--loglevel"] + sys.argv[2:])
         elif sys.argv[1] in valid_commands:
             args = amd_smi_parser.parse_args(args=None)
         else:
-            raise amdsmi_cli_exceptions.AmdSmiInvalidSubcommandException(sys.argv[1],amd_smi_commands.logger.destination)
+            raise amdsmi_cli_exceptions.AmdSmiInvalidSubcommandException(
+                sys.argv[1], amd_smi_commands.logger.destination
+            )
 
         # Handle command modifiers before subcommand execution
         # human readable is the default output format
-        if hasattr(args, 'json') and args.json:
+        if hasattr(args, "json") and args.json:
             amd_smi_commands.logger.format = amd_smi_commands.logger.LoggerFormat.json.value
-        if hasattr(args, 'csv') and args.csv:
+        if hasattr(args, "csv") and args.csv:
             amd_smi_commands.logger.format = amd_smi_commands.logger.LoggerFormat.csv.value
-        if hasattr(args, 'file') and args.file:
+        if hasattr(args, "file") and args.file:
             amd_smi_commands.logger.destination = args.file
         configure_logging_and_execute(args, amd_smi_commands)
     except amdsmi_cli_exceptions.AmdSmiException as e:
-        _print_error(f"{type(e).__module__}.{type(e).__name__}: {str(e)}", amd_smi_commands.logger.destination)
+        _print_error(
+            f"{type(e).__module__}.{type(e).__name__}: {str(e)}",
+            amd_smi_commands.logger.destination,
+        )
         sys.exit(abs(e.value))
     except amdsmi_exception.AmdSmiLibraryException as e:
-        exc = amdsmi_cli_exceptions.AmdSmiLibraryErrorException(amd_smi_commands.logger.format, e.get_error_code())
-        _print_error(f"{type(exc).__module__}.{type(exc).__name__}: {str(exc)}", amd_smi_commands.logger.destination)
+        exc = amdsmi_cli_exceptions.AmdSmiLibraryErrorException(
+            amd_smi_commands.logger.format, e.get_error_code()
+        )
+        _print_error(
+            f"{type(exc).__module__}.{type(exc).__name__}: {str(exc)}",
+            amd_smi_commands.logger.destination,
+        )
         sys.exit(abs(exc.value))

--- a/projects/amdsmi/amdsmi_cli/amdsmi_parser.py
+++ b/projects/amdsmi/amdsmi_cli/amdsmi_parser.py
@@ -739,7 +739,10 @@ class AMDSMIParser(argparse.ArgumentParser):
             # Checks the values
             def __call__(self, parser, args, values, option_string=None):
                 if args.watch is None:
-                    raise argparse.ArgumentError(self, f"invalid argument: '{self.dest}' needs to be paired with -w/--watch. Error code: -2")
+                    raise argparse.ArgumentError(
+                        self,
+                        f"invalid argument: '{self.dest}' needs to be paired with -w/--watch. Error code: -2",
+                    )
                 else:
                     setattr(args, self.dest, values)
 

--- a/projects/amdsmi/py-interface/CMakeLists.txt
+++ b/projects/amdsmi/py-interface/CMakeLists.txt
@@ -5,7 +5,7 @@
 # this is normally done in a docker container with a controlled clang and python-clang versions
 set(clang_ver 16.0)
 set(clang_ver_py 16.0.1)
-set(ctypeslib_ver_py 2.3.4)
+set(ctypeslib_ver_py 2.4.0)
 
 set(PY_BUILD_DIR "python_package")
 # amdsmi part of this string is the directory containing all python files

--- a/projects/amdsmi/py-interface/Dockerfile
+++ b/projects/amdsmi/py-interface/Dockerfile
@@ -32,7 +32,7 @@ RUN TEMPDIR=$(mktemp -d) \
         && wget https://apt.llvm.org/llvm.sh && chmod +x llvm.sh \
         && ./llvm.sh 16 \
         && update-alternatives --install /usr/bin/clang clang $(which clang-16) 91 --slave /usr/bin/clang++ clang++ $(which clang++-16) \
-        && python3 -m pip install --no-cache-dir clang==16.0.1 ctypeslib2==2.3.4 -U \
+        && python3 -m pip install --no-cache-dir clang==16.0.1 ctypeslib2==2.4.0 -U \
         && rm -rf $TEMPDIR
 
 # install cmake

--- a/projects/amdsmi/py-interface/amdsmi_interface.py
+++ b/projects/amdsmi/py-interface/amdsmi_interface.py
@@ -821,9 +821,7 @@ def _format_bad_page_info(bad_page_info, bad_page_count: ctypes.c_uint32) -> Lis
     return table_records
 
 
-def _format_bdf(
-    amdsmi_bdf: Union[amdsmi_wrapper.amdsmi_bdf_t, amdsmi_wrapper.struct_amdsmi_bdf_t],
-) -> str:
+def _format_bdf(amdsmi_bdf: Union[amdsmi_wrapper.amdsmi_bdf_t, amdsmi_wrapper.struct_bdf_]) -> str:
     """
     Format BDF struct to readable data.
 
@@ -835,7 +833,7 @@ def _format_bdf(
         `str`: String containing BDF data in a readable format.
     """
     try:
-        struct = amdsmi_bdf.struct_amdsmi_bdf_t
+        struct = amdsmi_bdf.bdf
     except AttributeError:
         struct = amdsmi_bdf
 
@@ -893,10 +891,10 @@ def _make_amdsmi_bdf_from_list(bdf):
     if len(bdf) != 4:
         return None
     amdsmi_bdf = amdsmi_wrapper.amdsmi_bdf_t()
-    amdsmi_bdf.struct_amdsmi_bdf_t.function_number = bdf[3]
-    amdsmi_bdf.struct_amdsmi_bdf_t.device_number = bdf[2]
-    amdsmi_bdf.struct_amdsmi_bdf_t.bus_number = bdf[1]
-    amdsmi_bdf.struct_amdsmi_bdf_t.domain_number = bdf[0]
+    amdsmi_bdf.bdf.function_number = bdf[3]
+    amdsmi_bdf.bdf.device_number = bdf[2]
+    amdsmi_bdf.bdf.bus_number = bdf[1]
+    amdsmi_bdf.bdf.domain_number = bdf[0]
     return amdsmi_bdf
 
 
@@ -2537,7 +2535,7 @@ def amdsmi_get_gpu_device_bdf(processor_handle: processor_handle_t) -> str:
     bdf_info = amdsmi_wrapper.amdsmi_bdf_t()
     _check_res(amdsmi_wrapper.amdsmi_get_gpu_device_bdf(processor_handle, ctypes.byref(bdf_info)))
 
-    return _format_bdf(bdf_info.struct_amdsmi_bdf_t)
+    return _format_bdf(bdf_info)
 
 
 def amdsmi_get_gpu_device_bdf_bdf(
@@ -2560,7 +2558,7 @@ def amdsmi_get_nic_info(processor_handle: amdsmi_wrapper.amdsmi_processor_handle
 
 def amdsmi_get_ainic_info_summary(nic_info):
     return {
-        "bdf": _format_bdf(nic_info.bus.bdf.struct_amdsmi_bdf_t),
+        "bdf": _format_bdf(nic_info.bus.bdf),
         "UUID": nic_info.asic.permanent_address.decode("utf-8"),
         "Permanent Address": nic_info.asic.permanent_address.decode("utf-8"),
         # "Device Name": nic_info.asic.product_name.decode('utf-8'),
@@ -2587,7 +2585,7 @@ def amdsmi_get_ainic_info_detail(ainic_info_struct):
             "VENDOR_NAME": ainic_info_struct.asic.vendor_name.decode("utf-8"),
         },
         "BUS": {
-            "bdf": _format_bdf(ainic_info_struct.bus.bdf.struct_amdsmi_bdf_t),
+            "bdf": _format_bdf(ainic_info_struct.bus.bdf),
             "MAX_PCIE_WIDTH": int(ainic_info_struct.bus.max_pcie_width),
             "MAX_PCIE_SPEED": ainic_info_struct.bus.max_pcie_speed,
             "PCIE_INTERFACE_VERSION": ainic_info_struct.bus.pcie_interface_version.decode("utf-8"),
@@ -2720,7 +2718,7 @@ def amdsmi_get_switch_device_bdf(processor_handle: amdsmi_wrapper.amdsmi_process
         amdsmi_wrapper.amdsmi_get_switch_device_bdf(processor_handle, ctypes.byref(bdf_info))
     )
 
-    return _format_bdf(bdf_info.struct_amdsmi_bdf_t)
+    return _format_bdf(bdf_info)
 
 
 def amdsmi_get_nic_temp_info(
@@ -2803,7 +2801,7 @@ def amdsmi_get_root_switch(amdsmi_bdf: amdsmi_wrapper.amdsmi_bdf_t) -> str:
 
     _check_res(amdsmi_wrapper.amdsmi_get_root_switch(amdsmi_bdf, ctypes.byref(switch_bdf_info)))
 
-    return _format_bdf(switch_bdf_info.struct_amdsmi_bdf_t)
+    return _format_bdf(switch_bdf_info)
 
 
 def amdsmi_get_gpu_device_uuid(processor_handle: processor_handle_t) -> str:

--- a/projects/amdsmi/py-interface/amdsmi_wrapper.py
+++ b/projects/amdsmi/py-interface/amdsmi_wrapper.py
@@ -55,11 +55,11 @@ class AsDictMixin:
             type_ = type(value)
             if hasattr(value, "_length_") and hasattr(value, "_type_"):
                 # array
-                if not hasattr(type_, "as_dict"):
-                    value = [v for v in value]
-                else:
-                    type_ = type_._type_
+                type_ = type_._type_
+                if hasattr(type_, 'as_dict'):
                     value = [type_.as_dict(v) for v in value]
+                else:
+                    value = [i for i in value]
             elif hasattr(value, "contents") and hasattr(value, "_type_"):
                 # pointer
                 try:
@@ -939,11 +939,11 @@ struct_bdf_._fields_ = [
     ('domain_number', ctypes.c_uint64, 48),
 ]
 
-class struct_amdsmi_bdf_t(Structure):
+class struct_amdsmi_bdf_t_1(Structure):
     pass
 
-struct_amdsmi_bdf_t._pack_ = 1 # source:False
-struct_amdsmi_bdf_t._fields_ = [
+struct_amdsmi_bdf_t_1._pack_ = 1 # source:False
+struct_amdsmi_bdf_t_1._fields_ = [
     ('function_number', ctypes.c_uint64, 3),
     ('device_number', ctypes.c_uint64, 5),
     ('bus_number', ctypes.c_uint64, 8),
@@ -954,7 +954,7 @@ union_amdsmi_bdf_t._pack_ = 1 # source:False
 
 union_amdsmi_bdf_t._fields_ = [
     ('bdf', struct_bdf_),
-    ('struct_amdsmi_bdf_t', struct_amdsmi_bdf_t),
+    ('_0', struct_amdsmi_bdf_t_1),
     ('as_uint', ctypes.c_uint64),
 ]
 
@@ -988,6 +988,21 @@ amdsmi_card_form_factor_t = ctypes.c_uint32 # enum
 class struct_amdsmi_pcie_info_t(Structure):
     pass
 
+class struct_pcie_static_(Structure):
+    pass
+
+struct_pcie_static_._pack_ = 1 # source:False
+struct_pcie_static_._fields_ = [
+    ('max_pcie_width', ctypes.c_uint16),
+    ('PADDING_0', ctypes.c_ubyte * 2),
+    ('max_pcie_speed', ctypes.c_uint32),
+    ('pcie_interface_version', ctypes.c_uint32),
+    ('slot_type', amdsmi_card_form_factor_t),
+    ('max_pcie_interface_version', ctypes.c_uint32),
+    ('PADDING_1', ctypes.c_ubyte * 4),
+    ('reserved', ctypes.c_uint64 * 9),
+]
+
 class struct_pcie_metric_(Structure):
     pass
 
@@ -1006,21 +1021,6 @@ struct_pcie_metric_._fields_ = [
     ('pcie_lc_perf_other_end_recovery_count', ctypes.c_uint32),
     ('PADDING_2', ctypes.c_ubyte * 4),
     ('reserved', ctypes.c_uint64 * 12),
-]
-
-class struct_pcie_static_(Structure):
-    pass
-
-struct_pcie_static_._pack_ = 1 # source:False
-struct_pcie_static_._fields_ = [
-    ('max_pcie_width', ctypes.c_uint16),
-    ('PADDING_0', ctypes.c_ubyte * 2),
-    ('max_pcie_speed', ctypes.c_uint32),
-    ('pcie_interface_version', ctypes.c_uint32),
-    ('slot_type', amdsmi_card_form_factor_t),
-    ('max_pcie_interface_version', ctypes.c_uint32),
-    ('PADDING_1', ctypes.c_ubyte * 4),
-    ('reserved', ctypes.c_uint64 * 9),
 ]
 
 struct_amdsmi_pcie_info_t._pack_ = 1 # source:False
@@ -1417,6 +1417,16 @@ amdsmi_process_handle_t = ctypes.c_uint32
 class struct_amdsmi_proc_info_t(Structure):
     pass
 
+class struct_engine_usage_(Structure):
+    pass
+
+struct_engine_usage_._pack_ = 1 # source:False
+struct_engine_usage_._fields_ = [
+    ('gfx', ctypes.c_uint64),
+    ('enc', ctypes.c_uint64),
+    ('reserved', ctypes.c_uint32 * 12),
+]
+
 class struct_memory_usage_(Structure):
     pass
 
@@ -1426,16 +1436,6 @@ struct_memory_usage_._fields_ = [
     ('cpu_mem', ctypes.c_uint64),
     ('vram_mem', ctypes.c_uint64),
     ('reserved', ctypes.c_uint32 * 10),
-]
-
-class struct_engine_usage_(Structure):
-    pass
-
-struct_engine_usage_._pack_ = 1 # source:False
-struct_engine_usage_._fields_ = [
-    ('gfx', ctypes.c_uint64),
-    ('enc', ctypes.c_uint64),
-    ('reserved', ctypes.c_uint32 * 12),
 ]
 
 struct_amdsmi_proc_info_t._pack_ = 1 # source:False
@@ -2752,279 +2752,549 @@ struct_amdsmi_nic_rdma_devices_info_t._fields_ = [
 
 amdsmi_nic_rdma_devices_info_t = struct_amdsmi_nic_rdma_devices_info_t
 uint64_t = ctypes.c_uint64
-amdsmi_init = _libraries['libamd_smi.so'].amdsmi_init
-amdsmi_init.restype = amdsmi_status_t
-amdsmi_init.argtypes = [uint64_t]
-amdsmi_shut_down = _libraries['libamd_smi.so'].amdsmi_shut_down
-amdsmi_shut_down.restype = amdsmi_status_t
-amdsmi_shut_down.argtypes = []
-amdsmi_get_socket_handles = _libraries['libamd_smi.so'].amdsmi_get_socket_handles
-amdsmi_get_socket_handles.restype = amdsmi_status_t
-amdsmi_get_socket_handles.argtypes = [ctypes.POINTER(ctypes.c_uint32), ctypes.POINTER(ctypes.POINTER(None))]
-amdsmi_get_cpu_handles = _libraries['libamd_smi.so'].amdsmi_get_cpu_handles
-amdsmi_get_cpu_handles.restype = amdsmi_status_t
-amdsmi_get_cpu_handles.argtypes = [ctypes.POINTER(ctypes.c_uint32), ctypes.POINTER(ctypes.POINTER(None))]
+try:
+    amdsmi_init = _libraries['libamd_smi.so'].amdsmi_init
+    amdsmi_init.restype = amdsmi_status_t
+    amdsmi_init.argtypes = [uint64_t]
+except AttributeError:
+    pass
+try:
+    amdsmi_shut_down = _libraries['libamd_smi.so'].amdsmi_shut_down
+    amdsmi_shut_down.restype = amdsmi_status_t
+    amdsmi_shut_down.argtypes = []
+except AttributeError:
+    pass
+try:
+    amdsmi_get_socket_handles = _libraries['libamd_smi.so'].amdsmi_get_socket_handles
+    amdsmi_get_socket_handles.restype = amdsmi_status_t
+    amdsmi_get_socket_handles.argtypes = [ctypes.POINTER(ctypes.c_uint32), ctypes.POINTER(ctypes.POINTER(None))]
+except AttributeError:
+    pass
+try:
+    amdsmi_get_cpu_handles = _libraries['libamd_smi.so'].amdsmi_get_cpu_handles
+    amdsmi_get_cpu_handles.restype = amdsmi_status_t
+    amdsmi_get_cpu_handles.argtypes = [ctypes.POINTER(ctypes.c_uint32), ctypes.POINTER(ctypes.POINTER(None))]
+except AttributeError:
+    pass
 size_t = ctypes.c_uint64
-amdsmi_get_socket_info = _libraries['libamd_smi.so'].amdsmi_get_socket_info
-amdsmi_get_socket_info.restype = amdsmi_status_t
-amdsmi_get_socket_info.argtypes = [amdsmi_socket_handle, size_t, ctypes.POINTER(ctypes.c_char)]
-amdsmi_get_processor_info = _libraries['libamd_smi.so'].amdsmi_get_processor_info
-amdsmi_get_processor_info.restype = amdsmi_status_t
-amdsmi_get_processor_info.argtypes = [amdsmi_processor_handle, size_t, ctypes.POINTER(ctypes.c_char)]
-amdsmi_get_processor_count_from_handles = _libraries['libamd_smi.so'].amdsmi_get_processor_count_from_handles
-amdsmi_get_processor_count_from_handles.restype = amdsmi_status_t
-amdsmi_get_processor_count_from_handles.argtypes = [ctypes.POINTER(ctypes.POINTER(None)), ctypes.POINTER(ctypes.c_uint32), ctypes.POINTER(ctypes.c_uint32), ctypes.POINTER(ctypes.c_uint32), ctypes.POINTER(ctypes.c_uint32)]
-amdsmi_get_processor_handles_by_type = _libraries['libamd_smi.so'].amdsmi_get_processor_handles_by_type
-amdsmi_get_processor_handles_by_type.restype = amdsmi_status_t
-amdsmi_get_processor_handles_by_type.argtypes = [amdsmi_socket_handle, processor_type_t, ctypes.POINTER(ctypes.POINTER(None)), ctypes.POINTER(ctypes.c_uint32)]
-amdsmi_get_processor_handles = _libraries['libamd_smi.so'].amdsmi_get_processor_handles
-amdsmi_get_processor_handles.restype = amdsmi_status_t
-amdsmi_get_processor_handles.argtypes = [amdsmi_socket_handle, ctypes.POINTER(ctypes.c_uint32), ctypes.POINTER(ctypes.POINTER(None))]
-amdsmi_get_node_handle = _libraries['libamd_smi.so'].amdsmi_get_node_handle
-amdsmi_get_node_handle.restype = amdsmi_status_t
-amdsmi_get_node_handle.argtypes = [amdsmi_processor_handle, ctypes.POINTER(ctypes.POINTER(None))]
-amdsmi_get_cpucore_handles = _libraries['libamd_smi.so'].amdsmi_get_cpucore_handles
-amdsmi_get_cpucore_handles.restype = amdsmi_status_t
-amdsmi_get_cpucore_handles.argtypes = [ctypes.POINTER(ctypes.c_uint32), ctypes.POINTER(ctypes.POINTER(None))]
-amdsmi_get_processor_type = _libraries['libamd_smi.so'].amdsmi_get_processor_type
-amdsmi_get_processor_type.restype = amdsmi_status_t
-amdsmi_get_processor_type.argtypes = [amdsmi_processor_handle, ctypes.POINTER(processor_type_t)]
-amdsmi_get_processor_handle_from_bdf = _libraries['libamd_smi.so'].amdsmi_get_processor_handle_from_bdf
-amdsmi_get_processor_handle_from_bdf.restype = amdsmi_status_t
-amdsmi_get_processor_handle_from_bdf.argtypes = [amdsmi_bdf_t, ctypes.POINTER(ctypes.POINTER(None))]
-amdsmi_get_gpu_device_bdf = _libraries['libamd_smi.so'].amdsmi_get_gpu_device_bdf
-amdsmi_get_gpu_device_bdf.restype = amdsmi_status_t
-amdsmi_get_gpu_device_bdf.argtypes = [amdsmi_processor_handle, ctypes.POINTER(union_amdsmi_bdf_t)]
-amdsmi_get_gpu_device_uuid = _libraries['libamd_smi.so'].amdsmi_get_gpu_device_uuid
-amdsmi_get_gpu_device_uuid.restype = amdsmi_status_t
-amdsmi_get_gpu_device_uuid.argtypes = [amdsmi_processor_handle, ctypes.POINTER(ctypes.c_uint32), ctypes.POINTER(ctypes.c_char)]
-amdsmi_get_gpu_enumeration_info = _libraries['libamd_smi.so'].amdsmi_get_gpu_enumeration_info
-amdsmi_get_gpu_enumeration_info.restype = amdsmi_status_t
-amdsmi_get_gpu_enumeration_info.argtypes = [amdsmi_processor_handle, ctypes.POINTER(struct_amdsmi_enumeration_info_t)]
+try:
+    amdsmi_get_socket_info = _libraries['libamd_smi.so'].amdsmi_get_socket_info
+    amdsmi_get_socket_info.restype = amdsmi_status_t
+    amdsmi_get_socket_info.argtypes = [amdsmi_socket_handle, size_t, ctypes.POINTER(ctypes.c_char)]
+except AttributeError:
+    pass
+try:
+    amdsmi_get_processor_info = _libraries['libamd_smi.so'].amdsmi_get_processor_info
+    amdsmi_get_processor_info.restype = amdsmi_status_t
+    amdsmi_get_processor_info.argtypes = [amdsmi_processor_handle, size_t, ctypes.POINTER(ctypes.c_char)]
+except AttributeError:
+    pass
+try:
+    amdsmi_get_processor_count_from_handles = _libraries['libamd_smi.so'].amdsmi_get_processor_count_from_handles
+    amdsmi_get_processor_count_from_handles.restype = amdsmi_status_t
+    amdsmi_get_processor_count_from_handles.argtypes = [ctypes.POINTER(ctypes.POINTER(None)), ctypes.POINTER(ctypes.c_uint32), ctypes.POINTER(ctypes.c_uint32), ctypes.POINTER(ctypes.c_uint32), ctypes.POINTER(ctypes.c_uint32)]
+except AttributeError:
+    pass
+try:
+    amdsmi_get_processor_handles_by_type = _libraries['libamd_smi.so'].amdsmi_get_processor_handles_by_type
+    amdsmi_get_processor_handles_by_type.restype = amdsmi_status_t
+    amdsmi_get_processor_handles_by_type.argtypes = [amdsmi_socket_handle, processor_type_t, ctypes.POINTER(ctypes.POINTER(None)), ctypes.POINTER(ctypes.c_uint32)]
+except AttributeError:
+    pass
+try:
+    amdsmi_get_processor_handles = _libraries['libamd_smi.so'].amdsmi_get_processor_handles
+    amdsmi_get_processor_handles.restype = amdsmi_status_t
+    amdsmi_get_processor_handles.argtypes = [amdsmi_socket_handle, ctypes.POINTER(ctypes.c_uint32), ctypes.POINTER(ctypes.POINTER(None))]
+except AttributeError:
+    pass
+try:
+    amdsmi_get_node_handle = _libraries['libamd_smi.so'].amdsmi_get_node_handle
+    amdsmi_get_node_handle.restype = amdsmi_status_t
+    amdsmi_get_node_handle.argtypes = [amdsmi_processor_handle, ctypes.POINTER(ctypes.POINTER(None))]
+except AttributeError:
+    pass
+try:
+    amdsmi_get_cpucore_handles = _libraries['libamd_smi.so'].amdsmi_get_cpucore_handles
+    amdsmi_get_cpucore_handles.restype = amdsmi_status_t
+    amdsmi_get_cpucore_handles.argtypes = [ctypes.POINTER(ctypes.c_uint32), ctypes.POINTER(ctypes.POINTER(None))]
+except AttributeError:
+    pass
+try:
+    amdsmi_get_processor_type = _libraries['libamd_smi.so'].amdsmi_get_processor_type
+    amdsmi_get_processor_type.restype = amdsmi_status_t
+    amdsmi_get_processor_type.argtypes = [amdsmi_processor_handle, ctypes.POINTER(processor_type_t)]
+except AttributeError:
+    pass
+try:
+    amdsmi_get_processor_handle_from_bdf = _libraries['libamd_smi.so'].amdsmi_get_processor_handle_from_bdf
+    amdsmi_get_processor_handle_from_bdf.restype = amdsmi_status_t
+    amdsmi_get_processor_handle_from_bdf.argtypes = [amdsmi_bdf_t, ctypes.POINTER(ctypes.POINTER(None))]
+except AttributeError:
+    pass
+try:
+    amdsmi_get_gpu_device_bdf = _libraries['libamd_smi.so'].amdsmi_get_gpu_device_bdf
+    amdsmi_get_gpu_device_bdf.restype = amdsmi_status_t
+    amdsmi_get_gpu_device_bdf.argtypes = [amdsmi_processor_handle, ctypes.POINTER(union_amdsmi_bdf_t)]
+except AttributeError:
+    pass
+try:
+    amdsmi_get_gpu_device_uuid = _libraries['libamd_smi.so'].amdsmi_get_gpu_device_uuid
+    amdsmi_get_gpu_device_uuid.restype = amdsmi_status_t
+    amdsmi_get_gpu_device_uuid.argtypes = [amdsmi_processor_handle, ctypes.POINTER(ctypes.c_uint32), ctypes.POINTER(ctypes.c_char)]
+except AttributeError:
+    pass
+try:
+    amdsmi_get_gpu_enumeration_info = _libraries['libamd_smi.so'].amdsmi_get_gpu_enumeration_info
+    amdsmi_get_gpu_enumeration_info.restype = amdsmi_status_t
+    amdsmi_get_gpu_enumeration_info.argtypes = [amdsmi_processor_handle, ctypes.POINTER(struct_amdsmi_enumeration_info_t)]
+except AttributeError:
+    pass
 uint32_t = ctypes.c_uint32
-amdsmi_get_cpu_affinity_with_scope = _libraries['libamd_smi.so'].amdsmi_get_cpu_affinity_with_scope
-amdsmi_get_cpu_affinity_with_scope.restype = amdsmi_status_t
-amdsmi_get_cpu_affinity_with_scope.argtypes = [amdsmi_processor_handle, uint32_t, ctypes.POINTER(ctypes.c_uint64), amdsmi_affinity_scope_t]
-amdsmi_get_gpu_virtualization_mode = _libraries['libamd_smi.so'].amdsmi_get_gpu_virtualization_mode
-amdsmi_get_gpu_virtualization_mode.restype = amdsmi_status_t
-amdsmi_get_gpu_virtualization_mode.argtypes = [amdsmi_processor_handle, ctypes.POINTER(amdsmi_virtualization_mode_t)]
-amdsmi_get_gpu_id = _libraries['libamd_smi.so'].amdsmi_get_gpu_id
-amdsmi_get_gpu_id.restype = amdsmi_status_t
-amdsmi_get_gpu_id.argtypes = [amdsmi_processor_handle, ctypes.POINTER(ctypes.c_uint16)]
-amdsmi_get_gpu_revision = _libraries['libamd_smi.so'].amdsmi_get_gpu_revision
-amdsmi_get_gpu_revision.restype = amdsmi_status_t
-amdsmi_get_gpu_revision.argtypes = [amdsmi_processor_handle, ctypes.POINTER(ctypes.c_uint16)]
-amdsmi_get_gpu_vendor_name = _libraries['libamd_smi.so'].amdsmi_get_gpu_vendor_name
-amdsmi_get_gpu_vendor_name.restype = amdsmi_status_t
-amdsmi_get_gpu_vendor_name.argtypes = [amdsmi_processor_handle, ctypes.POINTER(ctypes.c_char), size_t]
-amdsmi_get_gpu_vram_vendor = _libraries['libamd_smi.so'].amdsmi_get_gpu_vram_vendor
-amdsmi_get_gpu_vram_vendor.restype = amdsmi_status_t
-amdsmi_get_gpu_vram_vendor.argtypes = [amdsmi_processor_handle, ctypes.POINTER(ctypes.c_char), uint32_t]
-amdsmi_get_gpu_subsystem_id = _libraries['libamd_smi.so'].amdsmi_get_gpu_subsystem_id
-amdsmi_get_gpu_subsystem_id.restype = amdsmi_status_t
-amdsmi_get_gpu_subsystem_id.argtypes = [amdsmi_processor_handle, ctypes.POINTER(ctypes.c_uint16)]
-amdsmi_get_gpu_subsystem_name = _libraries['libamd_smi.so'].amdsmi_get_gpu_subsystem_name
-amdsmi_get_gpu_subsystem_name.restype = amdsmi_status_t
-amdsmi_get_gpu_subsystem_name.argtypes = [amdsmi_processor_handle, ctypes.POINTER(ctypes.c_char), size_t]
-amdsmi_get_gpu_pci_bandwidth = _libraries['libamd_smi.so'].amdsmi_get_gpu_pci_bandwidth
-amdsmi_get_gpu_pci_bandwidth.restype = amdsmi_status_t
-amdsmi_get_gpu_pci_bandwidth.argtypes = [amdsmi_processor_handle, ctypes.POINTER(struct_amdsmi_pcie_bandwidth_t)]
-amdsmi_get_gpu_bdf_id = _libraries['libamd_smi.so'].amdsmi_get_gpu_bdf_id
-amdsmi_get_gpu_bdf_id.restype = amdsmi_status_t
-amdsmi_get_gpu_bdf_id.argtypes = [amdsmi_processor_handle, ctypes.POINTER(ctypes.c_uint64)]
-amdsmi_get_gpu_topo_numa_affinity = _libraries['libamd_smi.so'].amdsmi_get_gpu_topo_numa_affinity
-amdsmi_get_gpu_topo_numa_affinity.restype = amdsmi_status_t
-amdsmi_get_gpu_topo_numa_affinity.argtypes = [amdsmi_processor_handle, ctypes.POINTER(ctypes.c_int32)]
-amdsmi_get_gpu_pci_throughput = _libraries['libamd_smi.so'].amdsmi_get_gpu_pci_throughput
-amdsmi_get_gpu_pci_throughput.restype = amdsmi_status_t
-amdsmi_get_gpu_pci_throughput.argtypes = [amdsmi_processor_handle, ctypes.POINTER(ctypes.c_uint64), ctypes.POINTER(ctypes.c_uint64), ctypes.POINTER(ctypes.c_uint64)]
-amdsmi_get_gpu_pci_replay_counter = _libraries['libamd_smi.so'].amdsmi_get_gpu_pci_replay_counter
-amdsmi_get_gpu_pci_replay_counter.restype = amdsmi_status_t
-amdsmi_get_gpu_pci_replay_counter.argtypes = [amdsmi_processor_handle, ctypes.POINTER(ctypes.c_uint64)]
-amdsmi_set_gpu_pci_bandwidth = _libraries['libamd_smi.so'].amdsmi_set_gpu_pci_bandwidth
-amdsmi_set_gpu_pci_bandwidth.restype = amdsmi_status_t
-amdsmi_set_gpu_pci_bandwidth.argtypes = [amdsmi_processor_handle, uint64_t]
-amdsmi_get_energy_count = _libraries['libamd_smi.so'].amdsmi_get_energy_count
-amdsmi_get_energy_count.restype = amdsmi_status_t
-amdsmi_get_energy_count.argtypes = [amdsmi_processor_handle, ctypes.POINTER(ctypes.c_uint64), ctypes.POINTER(ctypes.c_float), ctypes.POINTER(ctypes.c_uint64)]
-amdsmi_set_power_cap = _libraries['libamd_smi.so'].amdsmi_set_power_cap
-amdsmi_set_power_cap.restype = amdsmi_status_t
-amdsmi_set_power_cap.argtypes = [amdsmi_processor_handle, uint32_t, uint64_t]
-amdsmi_set_gpu_power_profile = _libraries['libamd_smi.so'].amdsmi_set_gpu_power_profile
-amdsmi_set_gpu_power_profile.restype = amdsmi_status_t
-amdsmi_set_gpu_power_profile.argtypes = [amdsmi_processor_handle, uint32_t, amdsmi_power_profile_preset_masks_t]
-amdsmi_get_supported_power_cap = _libraries['libamd_smi.so'].amdsmi_get_supported_power_cap
-amdsmi_get_supported_power_cap.restype = amdsmi_status_t
-amdsmi_get_supported_power_cap.argtypes = [amdsmi_processor_handle, ctypes.POINTER(ctypes.c_uint32), ctypes.POINTER(ctypes.c_uint32), ctypes.POINTER(amdsmi_power_cap_type_t)]
-amdsmi_get_cpu_socket_power = _libraries['libamd_smi.so'].amdsmi_get_cpu_socket_power
-amdsmi_get_cpu_socket_power.restype = amdsmi_status_t
-amdsmi_get_cpu_socket_power.argtypes = [amdsmi_processor_handle, ctypes.POINTER(ctypes.c_double)]
-amdsmi_get_cpu_socket_power_cap = _libraries['libamd_smi.so'].amdsmi_get_cpu_socket_power_cap
-amdsmi_get_cpu_socket_power_cap.restype = amdsmi_status_t
-amdsmi_get_cpu_socket_power_cap.argtypes = [amdsmi_processor_handle, ctypes.POINTER(ctypes.c_double)]
-amdsmi_get_cpu_socket_power_cap_max = _libraries['libamd_smi.so'].amdsmi_get_cpu_socket_power_cap_max
-amdsmi_get_cpu_socket_power_cap_max.restype = amdsmi_status_t
-amdsmi_get_cpu_socket_power_cap_max.argtypes = [amdsmi_processor_handle, ctypes.POINTER(ctypes.c_double)]
-amdsmi_get_cpu_pwr_svi_telemetry_all_rails = _libraries['libamd_smi.so'].amdsmi_get_cpu_pwr_svi_telemetry_all_rails
-amdsmi_get_cpu_pwr_svi_telemetry_all_rails.restype = amdsmi_status_t
-amdsmi_get_cpu_pwr_svi_telemetry_all_rails.argtypes = [amdsmi_processor_handle, ctypes.POINTER(ctypes.c_uint32)]
-amdsmi_set_cpu_socket_power_cap = _libraries['libamd_smi.so'].amdsmi_set_cpu_socket_power_cap
-amdsmi_set_cpu_socket_power_cap.restype = amdsmi_status_t
-amdsmi_set_cpu_socket_power_cap.argtypes = [amdsmi_processor_handle, uint32_t]
+try:
+    amdsmi_get_cpu_affinity_with_scope = _libraries['libamd_smi.so'].amdsmi_get_cpu_affinity_with_scope
+    amdsmi_get_cpu_affinity_with_scope.restype = amdsmi_status_t
+    amdsmi_get_cpu_affinity_with_scope.argtypes = [amdsmi_processor_handle, uint32_t, ctypes.POINTER(ctypes.c_uint64), amdsmi_affinity_scope_t]
+except AttributeError:
+    pass
+try:
+    amdsmi_get_gpu_virtualization_mode = _libraries['libamd_smi.so'].amdsmi_get_gpu_virtualization_mode
+    amdsmi_get_gpu_virtualization_mode.restype = amdsmi_status_t
+    amdsmi_get_gpu_virtualization_mode.argtypes = [amdsmi_processor_handle, ctypes.POINTER(amdsmi_virtualization_mode_t)]
+except AttributeError:
+    pass
+try:
+    amdsmi_get_gpu_id = _libraries['libamd_smi.so'].amdsmi_get_gpu_id
+    amdsmi_get_gpu_id.restype = amdsmi_status_t
+    amdsmi_get_gpu_id.argtypes = [amdsmi_processor_handle, ctypes.POINTER(ctypes.c_uint16)]
+except AttributeError:
+    pass
+try:
+    amdsmi_get_gpu_revision = _libraries['libamd_smi.so'].amdsmi_get_gpu_revision
+    amdsmi_get_gpu_revision.restype = amdsmi_status_t
+    amdsmi_get_gpu_revision.argtypes = [amdsmi_processor_handle, ctypes.POINTER(ctypes.c_uint16)]
+except AttributeError:
+    pass
+try:
+    amdsmi_get_gpu_vendor_name = _libraries['libamd_smi.so'].amdsmi_get_gpu_vendor_name
+    amdsmi_get_gpu_vendor_name.restype = amdsmi_status_t
+    amdsmi_get_gpu_vendor_name.argtypes = [amdsmi_processor_handle, ctypes.POINTER(ctypes.c_char), size_t]
+except AttributeError:
+    pass
+try:
+    amdsmi_get_gpu_vram_vendor = _libraries['libamd_smi.so'].amdsmi_get_gpu_vram_vendor
+    amdsmi_get_gpu_vram_vendor.restype = amdsmi_status_t
+    amdsmi_get_gpu_vram_vendor.argtypes = [amdsmi_processor_handle, ctypes.POINTER(ctypes.c_char), uint32_t]
+except AttributeError:
+    pass
+try:
+    amdsmi_get_gpu_subsystem_id = _libraries['libamd_smi.so'].amdsmi_get_gpu_subsystem_id
+    amdsmi_get_gpu_subsystem_id.restype = amdsmi_status_t
+    amdsmi_get_gpu_subsystem_id.argtypes = [amdsmi_processor_handle, ctypes.POINTER(ctypes.c_uint16)]
+except AttributeError:
+    pass
+try:
+    amdsmi_get_gpu_subsystem_name = _libraries['libamd_smi.so'].amdsmi_get_gpu_subsystem_name
+    amdsmi_get_gpu_subsystem_name.restype = amdsmi_status_t
+    amdsmi_get_gpu_subsystem_name.argtypes = [amdsmi_processor_handle, ctypes.POINTER(ctypes.c_char), size_t]
+except AttributeError:
+    pass
+try:
+    amdsmi_get_gpu_pci_bandwidth = _libraries['libamd_smi.so'].amdsmi_get_gpu_pci_bandwidth
+    amdsmi_get_gpu_pci_bandwidth.restype = amdsmi_status_t
+    amdsmi_get_gpu_pci_bandwidth.argtypes = [amdsmi_processor_handle, ctypes.POINTER(struct_amdsmi_pcie_bandwidth_t)]
+except AttributeError:
+    pass
+try:
+    amdsmi_get_gpu_bdf_id = _libraries['libamd_smi.so'].amdsmi_get_gpu_bdf_id
+    amdsmi_get_gpu_bdf_id.restype = amdsmi_status_t
+    amdsmi_get_gpu_bdf_id.argtypes = [amdsmi_processor_handle, ctypes.POINTER(ctypes.c_uint64)]
+except AttributeError:
+    pass
+try:
+    amdsmi_get_gpu_topo_numa_affinity = _libraries['libamd_smi.so'].amdsmi_get_gpu_topo_numa_affinity
+    amdsmi_get_gpu_topo_numa_affinity.restype = amdsmi_status_t
+    amdsmi_get_gpu_topo_numa_affinity.argtypes = [amdsmi_processor_handle, ctypes.POINTER(ctypes.c_int32)]
+except AttributeError:
+    pass
+try:
+    amdsmi_get_gpu_pci_throughput = _libraries['libamd_smi.so'].amdsmi_get_gpu_pci_throughput
+    amdsmi_get_gpu_pci_throughput.restype = amdsmi_status_t
+    amdsmi_get_gpu_pci_throughput.argtypes = [amdsmi_processor_handle, ctypes.POINTER(ctypes.c_uint64), ctypes.POINTER(ctypes.c_uint64), ctypes.POINTER(ctypes.c_uint64)]
+except AttributeError:
+    pass
+try:
+    amdsmi_get_gpu_pci_replay_counter = _libraries['libamd_smi.so'].amdsmi_get_gpu_pci_replay_counter
+    amdsmi_get_gpu_pci_replay_counter.restype = amdsmi_status_t
+    amdsmi_get_gpu_pci_replay_counter.argtypes = [amdsmi_processor_handle, ctypes.POINTER(ctypes.c_uint64)]
+except AttributeError:
+    pass
+try:
+    amdsmi_set_gpu_pci_bandwidth = _libraries['libamd_smi.so'].amdsmi_set_gpu_pci_bandwidth
+    amdsmi_set_gpu_pci_bandwidth.restype = amdsmi_status_t
+    amdsmi_set_gpu_pci_bandwidth.argtypes = [amdsmi_processor_handle, uint64_t]
+except AttributeError:
+    pass
+try:
+    amdsmi_get_energy_count = _libraries['libamd_smi.so'].amdsmi_get_energy_count
+    amdsmi_get_energy_count.restype = amdsmi_status_t
+    amdsmi_get_energy_count.argtypes = [amdsmi_processor_handle, ctypes.POINTER(ctypes.c_uint64), ctypes.POINTER(ctypes.c_float), ctypes.POINTER(ctypes.c_uint64)]
+except AttributeError:
+    pass
+try:
+    amdsmi_set_power_cap = _libraries['libamd_smi.so'].amdsmi_set_power_cap
+    amdsmi_set_power_cap.restype = amdsmi_status_t
+    amdsmi_set_power_cap.argtypes = [amdsmi_processor_handle, uint32_t, uint64_t]
+except AttributeError:
+    pass
+try:
+    amdsmi_set_gpu_power_profile = _libraries['libamd_smi.so'].amdsmi_set_gpu_power_profile
+    amdsmi_set_gpu_power_profile.restype = amdsmi_status_t
+    amdsmi_set_gpu_power_profile.argtypes = [amdsmi_processor_handle, uint32_t, amdsmi_power_profile_preset_masks_t]
+except AttributeError:
+    pass
+try:
+    amdsmi_get_supported_power_cap = _libraries['libamd_smi.so'].amdsmi_get_supported_power_cap
+    amdsmi_get_supported_power_cap.restype = amdsmi_status_t
+    amdsmi_get_supported_power_cap.argtypes = [amdsmi_processor_handle, ctypes.POINTER(ctypes.c_uint32), ctypes.POINTER(ctypes.c_uint32), ctypes.POINTER(amdsmi_power_cap_type_t)]
+except AttributeError:
+    pass
+try:
+    amdsmi_get_cpu_socket_power = _libraries['libamd_smi.so'].amdsmi_get_cpu_socket_power
+    amdsmi_get_cpu_socket_power.restype = amdsmi_status_t
+    amdsmi_get_cpu_socket_power.argtypes = [amdsmi_processor_handle, ctypes.POINTER(ctypes.c_double)]
+except AttributeError:
+    pass
+try:
+    amdsmi_get_cpu_socket_power_cap = _libraries['libamd_smi.so'].amdsmi_get_cpu_socket_power_cap
+    amdsmi_get_cpu_socket_power_cap.restype = amdsmi_status_t
+    amdsmi_get_cpu_socket_power_cap.argtypes = [amdsmi_processor_handle, ctypes.POINTER(ctypes.c_double)]
+except AttributeError:
+    pass
+try:
+    amdsmi_get_cpu_socket_power_cap_max = _libraries['libamd_smi.so'].amdsmi_get_cpu_socket_power_cap_max
+    amdsmi_get_cpu_socket_power_cap_max.restype = amdsmi_status_t
+    amdsmi_get_cpu_socket_power_cap_max.argtypes = [amdsmi_processor_handle, ctypes.POINTER(ctypes.c_double)]
+except AttributeError:
+    pass
+try:
+    amdsmi_get_cpu_pwr_svi_telemetry_all_rails = _libraries['libamd_smi.so'].amdsmi_get_cpu_pwr_svi_telemetry_all_rails
+    amdsmi_get_cpu_pwr_svi_telemetry_all_rails.restype = amdsmi_status_t
+    amdsmi_get_cpu_pwr_svi_telemetry_all_rails.argtypes = [amdsmi_processor_handle, ctypes.POINTER(ctypes.c_uint32)]
+except AttributeError:
+    pass
+try:
+    amdsmi_set_cpu_socket_power_cap = _libraries['libamd_smi.so'].amdsmi_set_cpu_socket_power_cap
+    amdsmi_set_cpu_socket_power_cap.restype = amdsmi_status_t
+    amdsmi_set_cpu_socket_power_cap.argtypes = [amdsmi_processor_handle, uint32_t]
+except AttributeError:
+    pass
 uint8_t = ctypes.c_uint8
-amdsmi_set_cpu_pwr_efficiency_mode = _libraries['libamd_smi.so'].amdsmi_set_cpu_pwr_efficiency_mode
-amdsmi_set_cpu_pwr_efficiency_mode.restype = amdsmi_status_t
-amdsmi_set_cpu_pwr_efficiency_mode.argtypes = [amdsmi_processor_handle, uint8_t, ctypes.POINTER(ctypes.c_uint32), ctypes.POINTER(ctypes.c_uint32)]
-amdsmi_get_cpu_pwr_efficiency_mode = _libraries['libamd_smi.so'].amdsmi_get_cpu_pwr_efficiency_mode
-amdsmi_get_cpu_pwr_efficiency_mode.restype = amdsmi_status_t
-amdsmi_get_cpu_pwr_efficiency_mode.argtypes = [amdsmi_processor_handle, ctypes.POINTER(ctypes.c_uint32), ctypes.POINTER(ctypes.c_uint32), ctypes.POINTER(ctypes.c_double)]
-amdsmi_get_cpu_core_ccd_power = _libraries['libamd_smi.so'].amdsmi_get_cpu_core_ccd_power
-amdsmi_get_cpu_core_ccd_power.restype = amdsmi_status_t
-amdsmi_get_cpu_core_ccd_power.argtypes = [amdsmi_processor_handle, ctypes.POINTER(ctypes.c_double)]
-amdsmi_get_gpu_memory_total = _libraries['libamd_smi.so'].amdsmi_get_gpu_memory_total
-amdsmi_get_gpu_memory_total.restype = amdsmi_status_t
-amdsmi_get_gpu_memory_total.argtypes = [amdsmi_processor_handle, amdsmi_memory_type_t, ctypes.POINTER(ctypes.c_uint64)]
-amdsmi_get_gpu_memory_usage = _libraries['libamd_smi.so'].amdsmi_get_gpu_memory_usage
-amdsmi_get_gpu_memory_usage.restype = amdsmi_status_t
-amdsmi_get_gpu_memory_usage.argtypes = [amdsmi_processor_handle, amdsmi_memory_type_t, ctypes.POINTER(ctypes.c_uint64)]
-amdsmi_get_gpu_bad_page_info = _libraries['libamd_smi.so'].amdsmi_get_gpu_bad_page_info
-amdsmi_get_gpu_bad_page_info.restype = amdsmi_status_t
-amdsmi_get_gpu_bad_page_info.argtypes = [amdsmi_processor_handle, ctypes.POINTER(ctypes.c_uint32), ctypes.POINTER(struct_amdsmi_retired_page_record_t)]
-amdsmi_get_gpu_bad_page_threshold = _libraries['libamd_smi.so'].amdsmi_get_gpu_bad_page_threshold
-amdsmi_get_gpu_bad_page_threshold.restype = amdsmi_status_t
-amdsmi_get_gpu_bad_page_threshold.argtypes = [amdsmi_processor_handle, ctypes.POINTER(ctypes.c_uint32)]
-amdsmi_gpu_validate_ras_eeprom = _libraries['libamd_smi.so'].amdsmi_gpu_validate_ras_eeprom
-amdsmi_gpu_validate_ras_eeprom.restype = amdsmi_status_t
-amdsmi_gpu_validate_ras_eeprom.argtypes = [amdsmi_processor_handle]
-amdsmi_get_gpu_ras_block_features_enabled = _libraries['libamd_smi.so'].amdsmi_get_gpu_ras_block_features_enabled
-amdsmi_get_gpu_ras_block_features_enabled.restype = amdsmi_status_t
-amdsmi_get_gpu_ras_block_features_enabled.argtypes = [amdsmi_processor_handle, amdsmi_gpu_block_t, ctypes.POINTER(amdsmi_ras_err_state_t)]
-amdsmi_get_gpu_memory_reserved_pages = _libraries['libamd_smi.so'].amdsmi_get_gpu_memory_reserved_pages
-amdsmi_get_gpu_memory_reserved_pages.restype = amdsmi_status_t
-amdsmi_get_gpu_memory_reserved_pages.argtypes = [amdsmi_processor_handle, ctypes.POINTER(ctypes.c_uint32), ctypes.POINTER(struct_amdsmi_retired_page_record_t)]
-amdsmi_get_gpu_fan_rpms = _libraries['libamd_smi.so'].amdsmi_get_gpu_fan_rpms
-amdsmi_get_gpu_fan_rpms.restype = amdsmi_status_t
-amdsmi_get_gpu_fan_rpms.argtypes = [amdsmi_processor_handle, uint32_t, ctypes.POINTER(ctypes.c_int64)]
-amdsmi_get_gpu_fan_speed = _libraries['libamd_smi.so'].amdsmi_get_gpu_fan_speed
-amdsmi_get_gpu_fan_speed.restype = amdsmi_status_t
-amdsmi_get_gpu_fan_speed.argtypes = [amdsmi_processor_handle, uint32_t, ctypes.POINTER(ctypes.c_int64)]
-amdsmi_get_gpu_fan_speed_max = _libraries['libamd_smi.so'].amdsmi_get_gpu_fan_speed_max
-amdsmi_get_gpu_fan_speed_max.restype = amdsmi_status_t
-amdsmi_get_gpu_fan_speed_max.argtypes = [amdsmi_processor_handle, uint32_t, ctypes.POINTER(ctypes.c_uint64)]
-amdsmi_get_gpu_cache_info = _libraries['libamd_smi.so'].amdsmi_get_gpu_cache_info
-amdsmi_get_gpu_cache_info.restype = amdsmi_status_t
-amdsmi_get_gpu_cache_info.argtypes = [amdsmi_processor_handle, ctypes.POINTER(struct_amdsmi_gpu_cache_info_t)]
-amdsmi_get_gpu_volt_metric = _libraries['libamd_smi.so'].amdsmi_get_gpu_volt_metric
-amdsmi_get_gpu_volt_metric.restype = amdsmi_status_t
-amdsmi_get_gpu_volt_metric.argtypes = [amdsmi_processor_handle, amdsmi_voltage_type_t, amdsmi_voltage_metric_t, ctypes.POINTER(ctypes.c_int64)]
-amdsmi_reset_gpu_fan = _libraries['libamd_smi.so'].amdsmi_reset_gpu_fan
-amdsmi_reset_gpu_fan.restype = amdsmi_status_t
-amdsmi_reset_gpu_fan.argtypes = [amdsmi_processor_handle, uint32_t]
-amdsmi_set_gpu_fan_speed = _libraries['libamd_smi.so'].amdsmi_set_gpu_fan_speed
-amdsmi_set_gpu_fan_speed.restype = amdsmi_status_t
-amdsmi_set_gpu_fan_speed.argtypes = [amdsmi_processor_handle, uint32_t, uint64_t]
-amdsmi_get_gpu_busy_percent = _libraries['libamd_smi.so'].amdsmi_get_gpu_busy_percent
-amdsmi_get_gpu_busy_percent.restype = amdsmi_status_t
-amdsmi_get_gpu_busy_percent.argtypes = [amdsmi_processor_handle, ctypes.POINTER(ctypes.c_uint32)]
-amdsmi_get_utilization_count = _libraries['libamd_smi.so'].amdsmi_get_utilization_count
-amdsmi_get_utilization_count.restype = amdsmi_status_t
-amdsmi_get_utilization_count.argtypes = [amdsmi_processor_handle, ctypes.POINTER(struct_amdsmi_utilization_counter_t), uint32_t, ctypes.POINTER(ctypes.c_uint64)]
-amdsmi_get_gpu_perf_level = _libraries['libamd_smi.so'].amdsmi_get_gpu_perf_level
-amdsmi_get_gpu_perf_level.restype = amdsmi_status_t
-amdsmi_get_gpu_perf_level.argtypes = [amdsmi_processor_handle, ctypes.POINTER(amdsmi_dev_perf_level_t)]
-amdsmi_set_gpu_perf_determinism_mode = _libraries['libamd_smi.so'].amdsmi_set_gpu_perf_determinism_mode
-amdsmi_set_gpu_perf_determinism_mode.restype = amdsmi_status_t
-amdsmi_set_gpu_perf_determinism_mode.argtypes = [amdsmi_processor_handle, uint64_t]
-amdsmi_get_gpu_overdrive_level = _libraries['libamd_smi.so'].amdsmi_get_gpu_overdrive_level
-amdsmi_get_gpu_overdrive_level.restype = amdsmi_status_t
-amdsmi_get_gpu_overdrive_level.argtypes = [amdsmi_processor_handle, ctypes.POINTER(ctypes.c_uint32)]
-amdsmi_get_gpu_mem_overdrive_level = _libraries['libamd_smi.so'].amdsmi_get_gpu_mem_overdrive_level
-amdsmi_get_gpu_mem_overdrive_level.restype = amdsmi_status_t
-amdsmi_get_gpu_mem_overdrive_level.argtypes = [amdsmi_processor_handle, ctypes.POINTER(ctypes.c_uint32)]
-amdsmi_get_clk_freq = _libraries['libamd_smi.so'].amdsmi_get_clk_freq
-amdsmi_get_clk_freq.restype = amdsmi_status_t
-amdsmi_get_clk_freq.argtypes = [amdsmi_processor_handle, amdsmi_clk_type_t, ctypes.POINTER(struct_amdsmi_frequencies_t)]
-amdsmi_reset_gpu = _libraries['libamd_smi.so'].amdsmi_reset_gpu
-amdsmi_reset_gpu.restype = amdsmi_status_t
-amdsmi_reset_gpu.argtypes = [amdsmi_processor_handle]
-amdsmi_get_gpu_od_volt_info = _libraries['libamd_smi.so'].amdsmi_get_gpu_od_volt_info
-amdsmi_get_gpu_od_volt_info.restype = amdsmi_status_t
-amdsmi_get_gpu_od_volt_info.argtypes = [amdsmi_processor_handle, ctypes.POINTER(struct_amdsmi_od_volt_freq_data_t)]
-amdsmi_get_gpu_metrics_header_info = _libraries['libamd_smi.so'].amdsmi_get_gpu_metrics_header_info
-amdsmi_get_gpu_metrics_header_info.restype = amdsmi_status_t
-amdsmi_get_gpu_metrics_header_info.argtypes = [amdsmi_processor_handle, ctypes.POINTER(struct_amd_metrics_table_header_t)]
-amdsmi_get_gpu_metrics_info = _libraries['libamd_smi.so'].amdsmi_get_gpu_metrics_info
-amdsmi_get_gpu_metrics_info.restype = amdsmi_status_t
-amdsmi_get_gpu_metrics_info.argtypes = [amdsmi_processor_handle, ctypes.POINTER(struct_amdsmi_gpu_metrics_t)]
-amdsmi_get_gpu_partition_metrics_info = _libraries['libamd_smi.so'].amdsmi_get_gpu_partition_metrics_info
-amdsmi_get_gpu_partition_metrics_info.restype = amdsmi_status_t
-amdsmi_get_gpu_partition_metrics_info.argtypes = [amdsmi_processor_handle, ctypes.POINTER(struct_amdsmi_gpu_metrics_t)]
-amdsmi_get_gpu_pm_metrics_info = _libraries['libamd_smi.so'].amdsmi_get_gpu_pm_metrics_info
-amdsmi_get_gpu_pm_metrics_info.restype = amdsmi_status_t
-amdsmi_get_gpu_pm_metrics_info.argtypes = [amdsmi_processor_handle, ctypes.POINTER(ctypes.POINTER(struct_amdsmi_name_value_t)), ctypes.POINTER(ctypes.c_uint32)]
-amdsmi_get_gpu_reg_table_info = _libraries['libamd_smi.so'].amdsmi_get_gpu_reg_table_info
-amdsmi_get_gpu_reg_table_info.restype = amdsmi_status_t
-amdsmi_get_gpu_reg_table_info.argtypes = [amdsmi_processor_handle, amdsmi_reg_type_t, ctypes.POINTER(ctypes.POINTER(struct_amdsmi_name_value_t)), ctypes.POINTER(ctypes.c_uint32)]
-amdsmi_set_gpu_clk_range = _libraries['libamd_smi.so'].amdsmi_set_gpu_clk_range
-amdsmi_set_gpu_clk_range.restype = amdsmi_status_t
-amdsmi_set_gpu_clk_range.argtypes = [amdsmi_processor_handle, uint64_t, uint64_t, amdsmi_clk_type_t]
-amdsmi_set_gpu_clk_limit = _libraries['libamd_smi.so'].amdsmi_set_gpu_clk_limit
-amdsmi_set_gpu_clk_limit.restype = amdsmi_status_t
-amdsmi_set_gpu_clk_limit.argtypes = [amdsmi_processor_handle, amdsmi_clk_type_t, amdsmi_clk_limit_type_t, uint64_t]
-amdsmi_set_gpu_od_clk_info = _libraries['libamd_smi.so'].amdsmi_set_gpu_od_clk_info
-amdsmi_set_gpu_od_clk_info.restype = amdsmi_status_t
-amdsmi_set_gpu_od_clk_info.argtypes = [amdsmi_processor_handle, amdsmi_freq_ind_t, uint64_t, amdsmi_clk_type_t]
-amdsmi_set_gpu_od_volt_info = _libraries['libamd_smi.so'].amdsmi_set_gpu_od_volt_info
-amdsmi_set_gpu_od_volt_info.restype = amdsmi_status_t
-amdsmi_set_gpu_od_volt_info.argtypes = [amdsmi_processor_handle, uint32_t, uint64_t, uint64_t]
-amdsmi_get_gpu_od_volt_curve_regions = _libraries['libamd_smi.so'].amdsmi_get_gpu_od_volt_curve_regions
-amdsmi_get_gpu_od_volt_curve_regions.restype = amdsmi_status_t
-amdsmi_get_gpu_od_volt_curve_regions.argtypes = [amdsmi_processor_handle, ctypes.POINTER(ctypes.c_uint32), ctypes.POINTER(struct_amdsmi_freq_volt_region_t)]
-amdsmi_get_gpu_power_profile_presets = _libraries['libamd_smi.so'].amdsmi_get_gpu_power_profile_presets
-amdsmi_get_gpu_power_profile_presets.restype = amdsmi_status_t
-amdsmi_get_gpu_power_profile_presets.argtypes = [amdsmi_processor_handle, uint32_t, ctypes.POINTER(struct_amdsmi_power_profile_status_t)]
-amdsmi_set_gpu_perf_level = _libraries['libamd_smi.so'].amdsmi_set_gpu_perf_level
-amdsmi_set_gpu_perf_level.restype = amdsmi_status_t
-amdsmi_set_gpu_perf_level.argtypes = [amdsmi_processor_handle, amdsmi_dev_perf_level_t]
-amdsmi_set_gpu_overdrive_level = _libraries['libamd_smi.so'].amdsmi_set_gpu_overdrive_level
-amdsmi_set_gpu_overdrive_level.restype = amdsmi_status_t
-amdsmi_set_gpu_overdrive_level.argtypes = [amdsmi_processor_handle, uint32_t]
-amdsmi_set_clk_freq = _libraries['libamd_smi.so'].amdsmi_set_clk_freq
-amdsmi_set_clk_freq.restype = amdsmi_status_t
-amdsmi_set_clk_freq.argtypes = [amdsmi_processor_handle, amdsmi_clk_type_t, uint64_t]
-amdsmi_get_soc_pstate = _libraries['libamd_smi.so'].amdsmi_get_soc_pstate
-amdsmi_get_soc_pstate.restype = amdsmi_status_t
-amdsmi_get_soc_pstate.argtypes = [amdsmi_processor_handle, ctypes.POINTER(struct_amdsmi_dpm_policy_t)]
-amdsmi_set_soc_pstate = _libraries['libamd_smi.so'].amdsmi_set_soc_pstate
-amdsmi_set_soc_pstate.restype = amdsmi_status_t
-amdsmi_set_soc_pstate.argtypes = [amdsmi_processor_handle, uint32_t]
-amdsmi_get_xgmi_plpd = _libraries['libamd_smi.so'].amdsmi_get_xgmi_plpd
-amdsmi_get_xgmi_plpd.restype = amdsmi_status_t
-amdsmi_get_xgmi_plpd.argtypes = [amdsmi_processor_handle, ctypes.POINTER(struct_amdsmi_dpm_policy_t)]
-amdsmi_set_xgmi_plpd = _libraries['libamd_smi.so'].amdsmi_set_xgmi_plpd
-amdsmi_set_xgmi_plpd.restype = amdsmi_status_t
-amdsmi_set_xgmi_plpd.argtypes = [amdsmi_processor_handle, uint32_t]
-amdsmi_get_gpu_process_isolation = _libraries['libamd_smi.so'].amdsmi_get_gpu_process_isolation
-amdsmi_get_gpu_process_isolation.restype = amdsmi_status_t
-amdsmi_get_gpu_process_isolation.argtypes = [amdsmi_processor_handle, ctypes.POINTER(ctypes.c_uint32)]
-amdsmi_set_gpu_process_isolation = _libraries['libamd_smi.so'].amdsmi_set_gpu_process_isolation
-amdsmi_set_gpu_process_isolation.restype = amdsmi_status_t
-amdsmi_set_gpu_process_isolation.argtypes = [amdsmi_processor_handle, uint32_t]
-amdsmi_clean_gpu_local_data = _libraries['libamd_smi.so'].amdsmi_clean_gpu_local_data
-amdsmi_clean_gpu_local_data.restype = amdsmi_status_t
-amdsmi_clean_gpu_local_data.argtypes = [amdsmi_processor_handle]
-amdsmi_get_lib_version = _libraries['libamd_smi.so'].amdsmi_get_lib_version
-amdsmi_get_lib_version.restype = amdsmi_status_t
-amdsmi_get_lib_version.argtypes = [ctypes.POINTER(struct_amdsmi_version_t)]
-amdsmi_get_gpu_ecc_count = _libraries['libamd_smi.so'].amdsmi_get_gpu_ecc_count
-amdsmi_get_gpu_ecc_count.restype = amdsmi_status_t
-amdsmi_get_gpu_ecc_count.argtypes = [amdsmi_processor_handle, amdsmi_gpu_block_t, ctypes.POINTER(struct_amdsmi_error_count_t)]
-amdsmi_get_gpu_ecc_enabled = _libraries['libamd_smi.so'].amdsmi_get_gpu_ecc_enabled
-amdsmi_get_gpu_ecc_enabled.restype = amdsmi_status_t
-amdsmi_get_gpu_ecc_enabled.argtypes = [amdsmi_processor_handle, ctypes.POINTER(ctypes.c_uint64)]
-amdsmi_get_gpu_total_ecc_count = _libraries['libamd_smi.so'].amdsmi_get_gpu_total_ecc_count
-amdsmi_get_gpu_total_ecc_count.restype = amdsmi_status_t
-amdsmi_get_gpu_total_ecc_count.argtypes = [amdsmi_processor_handle, ctypes.POINTER(struct_amdsmi_error_count_t)]
+try:
+    amdsmi_set_cpu_pwr_efficiency_mode = _libraries['libamd_smi.so'].amdsmi_set_cpu_pwr_efficiency_mode
+    amdsmi_set_cpu_pwr_efficiency_mode.restype = amdsmi_status_t
+    amdsmi_set_cpu_pwr_efficiency_mode.argtypes = [amdsmi_processor_handle, uint8_t, ctypes.POINTER(ctypes.c_uint32), ctypes.POINTER(ctypes.c_uint32)]
+except AttributeError:
+    pass
+try:
+    amdsmi_get_cpu_pwr_efficiency_mode = _libraries['libamd_smi.so'].amdsmi_get_cpu_pwr_efficiency_mode
+    amdsmi_get_cpu_pwr_efficiency_mode.restype = amdsmi_status_t
+    amdsmi_get_cpu_pwr_efficiency_mode.argtypes = [amdsmi_processor_handle, ctypes.POINTER(ctypes.c_uint32), ctypes.POINTER(ctypes.c_uint32), ctypes.POINTER(ctypes.c_double)]
+except AttributeError:
+    pass
+try:
+    amdsmi_get_cpu_core_ccd_power = _libraries['libamd_smi.so'].amdsmi_get_cpu_core_ccd_power
+    amdsmi_get_cpu_core_ccd_power.restype = amdsmi_status_t
+    amdsmi_get_cpu_core_ccd_power.argtypes = [amdsmi_processor_handle, ctypes.POINTER(ctypes.c_double)]
+except AttributeError:
+    pass
+try:
+    amdsmi_get_gpu_memory_total = _libraries['libamd_smi.so'].amdsmi_get_gpu_memory_total
+    amdsmi_get_gpu_memory_total.restype = amdsmi_status_t
+    amdsmi_get_gpu_memory_total.argtypes = [amdsmi_processor_handle, amdsmi_memory_type_t, ctypes.POINTER(ctypes.c_uint64)]
+except AttributeError:
+    pass
+try:
+    amdsmi_get_gpu_memory_usage = _libraries['libamd_smi.so'].amdsmi_get_gpu_memory_usage
+    amdsmi_get_gpu_memory_usage.restype = amdsmi_status_t
+    amdsmi_get_gpu_memory_usage.argtypes = [amdsmi_processor_handle, amdsmi_memory_type_t, ctypes.POINTER(ctypes.c_uint64)]
+except AttributeError:
+    pass
+try:
+    amdsmi_get_gpu_bad_page_info = _libraries['libamd_smi.so'].amdsmi_get_gpu_bad_page_info
+    amdsmi_get_gpu_bad_page_info.restype = amdsmi_status_t
+    amdsmi_get_gpu_bad_page_info.argtypes = [amdsmi_processor_handle, ctypes.POINTER(ctypes.c_uint32), ctypes.POINTER(struct_amdsmi_retired_page_record_t)]
+except AttributeError:
+    pass
+try:
+    amdsmi_get_gpu_bad_page_threshold = _libraries['libamd_smi.so'].amdsmi_get_gpu_bad_page_threshold
+    amdsmi_get_gpu_bad_page_threshold.restype = amdsmi_status_t
+    amdsmi_get_gpu_bad_page_threshold.argtypes = [amdsmi_processor_handle, ctypes.POINTER(ctypes.c_uint32)]
+except AttributeError:
+    pass
+try:
+    amdsmi_gpu_validate_ras_eeprom = _libraries['libamd_smi.so'].amdsmi_gpu_validate_ras_eeprom
+    amdsmi_gpu_validate_ras_eeprom.restype = amdsmi_status_t
+    amdsmi_gpu_validate_ras_eeprom.argtypes = [amdsmi_processor_handle]
+except AttributeError:
+    pass
+try:
+    amdsmi_get_gpu_ras_block_features_enabled = _libraries['libamd_smi.so'].amdsmi_get_gpu_ras_block_features_enabled
+    amdsmi_get_gpu_ras_block_features_enabled.restype = amdsmi_status_t
+    amdsmi_get_gpu_ras_block_features_enabled.argtypes = [amdsmi_processor_handle, amdsmi_gpu_block_t, ctypes.POINTER(amdsmi_ras_err_state_t)]
+except AttributeError:
+    pass
+try:
+    amdsmi_get_gpu_memory_reserved_pages = _libraries['libamd_smi.so'].amdsmi_get_gpu_memory_reserved_pages
+    amdsmi_get_gpu_memory_reserved_pages.restype = amdsmi_status_t
+    amdsmi_get_gpu_memory_reserved_pages.argtypes = [amdsmi_processor_handle, ctypes.POINTER(ctypes.c_uint32), ctypes.POINTER(struct_amdsmi_retired_page_record_t)]
+except AttributeError:
+    pass
+try:
+    amdsmi_get_gpu_fan_rpms = _libraries['libamd_smi.so'].amdsmi_get_gpu_fan_rpms
+    amdsmi_get_gpu_fan_rpms.restype = amdsmi_status_t
+    amdsmi_get_gpu_fan_rpms.argtypes = [amdsmi_processor_handle, uint32_t, ctypes.POINTER(ctypes.c_int64)]
+except AttributeError:
+    pass
+try:
+    amdsmi_get_gpu_fan_speed = _libraries['libamd_smi.so'].amdsmi_get_gpu_fan_speed
+    amdsmi_get_gpu_fan_speed.restype = amdsmi_status_t
+    amdsmi_get_gpu_fan_speed.argtypes = [amdsmi_processor_handle, uint32_t, ctypes.POINTER(ctypes.c_int64)]
+except AttributeError:
+    pass
+try:
+    amdsmi_get_gpu_fan_speed_max = _libraries['libamd_smi.so'].amdsmi_get_gpu_fan_speed_max
+    amdsmi_get_gpu_fan_speed_max.restype = amdsmi_status_t
+    amdsmi_get_gpu_fan_speed_max.argtypes = [amdsmi_processor_handle, uint32_t, ctypes.POINTER(ctypes.c_uint64)]
+except AttributeError:
+    pass
+try:
+    amdsmi_get_gpu_cache_info = _libraries['libamd_smi.so'].amdsmi_get_gpu_cache_info
+    amdsmi_get_gpu_cache_info.restype = amdsmi_status_t
+    amdsmi_get_gpu_cache_info.argtypes = [amdsmi_processor_handle, ctypes.POINTER(struct_amdsmi_gpu_cache_info_t)]
+except AttributeError:
+    pass
+try:
+    amdsmi_get_gpu_volt_metric = _libraries['libamd_smi.so'].amdsmi_get_gpu_volt_metric
+    amdsmi_get_gpu_volt_metric.restype = amdsmi_status_t
+    amdsmi_get_gpu_volt_metric.argtypes = [amdsmi_processor_handle, amdsmi_voltage_type_t, amdsmi_voltage_metric_t, ctypes.POINTER(ctypes.c_int64)]
+except AttributeError:
+    pass
+try:
+    amdsmi_reset_gpu_fan = _libraries['libamd_smi.so'].amdsmi_reset_gpu_fan
+    amdsmi_reset_gpu_fan.restype = amdsmi_status_t
+    amdsmi_reset_gpu_fan.argtypes = [amdsmi_processor_handle, uint32_t]
+except AttributeError:
+    pass
+try:
+    amdsmi_set_gpu_fan_speed = _libraries['libamd_smi.so'].amdsmi_set_gpu_fan_speed
+    amdsmi_set_gpu_fan_speed.restype = amdsmi_status_t
+    amdsmi_set_gpu_fan_speed.argtypes = [amdsmi_processor_handle, uint32_t, uint64_t]
+except AttributeError:
+    pass
+try:
+    amdsmi_get_gpu_busy_percent = _libraries['libamd_smi.so'].amdsmi_get_gpu_busy_percent
+    amdsmi_get_gpu_busy_percent.restype = amdsmi_status_t
+    amdsmi_get_gpu_busy_percent.argtypes = [amdsmi_processor_handle, ctypes.POINTER(ctypes.c_uint32)]
+except AttributeError:
+    pass
+try:
+    amdsmi_get_utilization_count = _libraries['libamd_smi.so'].amdsmi_get_utilization_count
+    amdsmi_get_utilization_count.restype = amdsmi_status_t
+    amdsmi_get_utilization_count.argtypes = [amdsmi_processor_handle, ctypes.POINTER(struct_amdsmi_utilization_counter_t), uint32_t, ctypes.POINTER(ctypes.c_uint64)]
+except AttributeError:
+    pass
+try:
+    amdsmi_get_gpu_perf_level = _libraries['libamd_smi.so'].amdsmi_get_gpu_perf_level
+    amdsmi_get_gpu_perf_level.restype = amdsmi_status_t
+    amdsmi_get_gpu_perf_level.argtypes = [amdsmi_processor_handle, ctypes.POINTER(amdsmi_dev_perf_level_t)]
+except AttributeError:
+    pass
+try:
+    amdsmi_set_gpu_perf_determinism_mode = _libraries['libamd_smi.so'].amdsmi_set_gpu_perf_determinism_mode
+    amdsmi_set_gpu_perf_determinism_mode.restype = amdsmi_status_t
+    amdsmi_set_gpu_perf_determinism_mode.argtypes = [amdsmi_processor_handle, uint64_t]
+except AttributeError:
+    pass
+try:
+    amdsmi_get_gpu_overdrive_level = _libraries['libamd_smi.so'].amdsmi_get_gpu_overdrive_level
+    amdsmi_get_gpu_overdrive_level.restype = amdsmi_status_t
+    amdsmi_get_gpu_overdrive_level.argtypes = [amdsmi_processor_handle, ctypes.POINTER(ctypes.c_uint32)]
+except AttributeError:
+    pass
+try:
+    amdsmi_get_gpu_mem_overdrive_level = _libraries['libamd_smi.so'].amdsmi_get_gpu_mem_overdrive_level
+    amdsmi_get_gpu_mem_overdrive_level.restype = amdsmi_status_t
+    amdsmi_get_gpu_mem_overdrive_level.argtypes = [amdsmi_processor_handle, ctypes.POINTER(ctypes.c_uint32)]
+except AttributeError:
+    pass
+try:
+    amdsmi_get_clk_freq = _libraries['libamd_smi.so'].amdsmi_get_clk_freq
+    amdsmi_get_clk_freq.restype = amdsmi_status_t
+    amdsmi_get_clk_freq.argtypes = [amdsmi_processor_handle, amdsmi_clk_type_t, ctypes.POINTER(struct_amdsmi_frequencies_t)]
+except AttributeError:
+    pass
+try:
+    amdsmi_reset_gpu = _libraries['libamd_smi.so'].amdsmi_reset_gpu
+    amdsmi_reset_gpu.restype = amdsmi_status_t
+    amdsmi_reset_gpu.argtypes = [amdsmi_processor_handle]
+except AttributeError:
+    pass
+try:
+    amdsmi_get_gpu_od_volt_info = _libraries['libamd_smi.so'].amdsmi_get_gpu_od_volt_info
+    amdsmi_get_gpu_od_volt_info.restype = amdsmi_status_t
+    amdsmi_get_gpu_od_volt_info.argtypes = [amdsmi_processor_handle, ctypes.POINTER(struct_amdsmi_od_volt_freq_data_t)]
+except AttributeError:
+    pass
+try:
+    amdsmi_get_gpu_metrics_header_info = _libraries['libamd_smi.so'].amdsmi_get_gpu_metrics_header_info
+    amdsmi_get_gpu_metrics_header_info.restype = amdsmi_status_t
+    amdsmi_get_gpu_metrics_header_info.argtypes = [amdsmi_processor_handle, ctypes.POINTER(struct_amd_metrics_table_header_t)]
+except AttributeError:
+    pass
+try:
+    amdsmi_get_gpu_metrics_info = _libraries['libamd_smi.so'].amdsmi_get_gpu_metrics_info
+    amdsmi_get_gpu_metrics_info.restype = amdsmi_status_t
+    amdsmi_get_gpu_metrics_info.argtypes = [amdsmi_processor_handle, ctypes.POINTER(struct_amdsmi_gpu_metrics_t)]
+except AttributeError:
+    pass
+try:
+    amdsmi_get_gpu_partition_metrics_info = _libraries['libamd_smi.so'].amdsmi_get_gpu_partition_metrics_info
+    amdsmi_get_gpu_partition_metrics_info.restype = amdsmi_status_t
+    amdsmi_get_gpu_partition_metrics_info.argtypes = [amdsmi_processor_handle, ctypes.POINTER(struct_amdsmi_gpu_metrics_t)]
+except AttributeError:
+    pass
+try:
+    amdsmi_get_gpu_pm_metrics_info = _libraries['libamd_smi.so'].amdsmi_get_gpu_pm_metrics_info
+    amdsmi_get_gpu_pm_metrics_info.restype = amdsmi_status_t
+    amdsmi_get_gpu_pm_metrics_info.argtypes = [amdsmi_processor_handle, ctypes.POINTER(ctypes.POINTER(struct_amdsmi_name_value_t)), ctypes.POINTER(ctypes.c_uint32)]
+except AttributeError:
+    pass
+try:
+    amdsmi_get_gpu_reg_table_info = _libraries['libamd_smi.so'].amdsmi_get_gpu_reg_table_info
+    amdsmi_get_gpu_reg_table_info.restype = amdsmi_status_t
+    amdsmi_get_gpu_reg_table_info.argtypes = [amdsmi_processor_handle, amdsmi_reg_type_t, ctypes.POINTER(ctypes.POINTER(struct_amdsmi_name_value_t)), ctypes.POINTER(ctypes.c_uint32)]
+except AttributeError:
+    pass
+try:
+    amdsmi_set_gpu_clk_range = _libraries['libamd_smi.so'].amdsmi_set_gpu_clk_range
+    amdsmi_set_gpu_clk_range.restype = amdsmi_status_t
+    amdsmi_set_gpu_clk_range.argtypes = [amdsmi_processor_handle, uint64_t, uint64_t, amdsmi_clk_type_t]
+except AttributeError:
+    pass
+try:
+    amdsmi_set_gpu_clk_limit = _libraries['libamd_smi.so'].amdsmi_set_gpu_clk_limit
+    amdsmi_set_gpu_clk_limit.restype = amdsmi_status_t
+    amdsmi_set_gpu_clk_limit.argtypes = [amdsmi_processor_handle, amdsmi_clk_type_t, amdsmi_clk_limit_type_t, uint64_t]
+except AttributeError:
+    pass
+try:
+    amdsmi_set_gpu_od_clk_info = _libraries['libamd_smi.so'].amdsmi_set_gpu_od_clk_info
+    amdsmi_set_gpu_od_clk_info.restype = amdsmi_status_t
+    amdsmi_set_gpu_od_clk_info.argtypes = [amdsmi_processor_handle, amdsmi_freq_ind_t, uint64_t, amdsmi_clk_type_t]
+except AttributeError:
+    pass
+try:
+    amdsmi_set_gpu_od_volt_info = _libraries['libamd_smi.so'].amdsmi_set_gpu_od_volt_info
+    amdsmi_set_gpu_od_volt_info.restype = amdsmi_status_t
+    amdsmi_set_gpu_od_volt_info.argtypes = [amdsmi_processor_handle, uint32_t, uint64_t, uint64_t]
+except AttributeError:
+    pass
+try:
+    amdsmi_get_gpu_od_volt_curve_regions = _libraries['libamd_smi.so'].amdsmi_get_gpu_od_volt_curve_regions
+    amdsmi_get_gpu_od_volt_curve_regions.restype = amdsmi_status_t
+    amdsmi_get_gpu_od_volt_curve_regions.argtypes = [amdsmi_processor_handle, ctypes.POINTER(ctypes.c_uint32), ctypes.POINTER(struct_amdsmi_freq_volt_region_t)]
+except AttributeError:
+    pass
+try:
+    amdsmi_get_gpu_power_profile_presets = _libraries['libamd_smi.so'].amdsmi_get_gpu_power_profile_presets
+    amdsmi_get_gpu_power_profile_presets.restype = amdsmi_status_t
+    amdsmi_get_gpu_power_profile_presets.argtypes = [amdsmi_processor_handle, uint32_t, ctypes.POINTER(struct_amdsmi_power_profile_status_t)]
+except AttributeError:
+    pass
+try:
+    amdsmi_set_gpu_perf_level = _libraries['libamd_smi.so'].amdsmi_set_gpu_perf_level
+    amdsmi_set_gpu_perf_level.restype = amdsmi_status_t
+    amdsmi_set_gpu_perf_level.argtypes = [amdsmi_processor_handle, amdsmi_dev_perf_level_t]
+except AttributeError:
+    pass
+try:
+    amdsmi_set_gpu_overdrive_level = _libraries['libamd_smi.so'].amdsmi_set_gpu_overdrive_level
+    amdsmi_set_gpu_overdrive_level.restype = amdsmi_status_t
+    amdsmi_set_gpu_overdrive_level.argtypes = [amdsmi_processor_handle, uint32_t]
+except AttributeError:
+    pass
+try:
+    amdsmi_set_clk_freq = _libraries['libamd_smi.so'].amdsmi_set_clk_freq
+    amdsmi_set_clk_freq.restype = amdsmi_status_t
+    amdsmi_set_clk_freq.argtypes = [amdsmi_processor_handle, amdsmi_clk_type_t, uint64_t]
+except AttributeError:
+    pass
+try:
+    amdsmi_get_soc_pstate = _libraries['libamd_smi.so'].amdsmi_get_soc_pstate
+    amdsmi_get_soc_pstate.restype = amdsmi_status_t
+    amdsmi_get_soc_pstate.argtypes = [amdsmi_processor_handle, ctypes.POINTER(struct_amdsmi_dpm_policy_t)]
+except AttributeError:
+    pass
+try:
+    amdsmi_set_soc_pstate = _libraries['libamd_smi.so'].amdsmi_set_soc_pstate
+    amdsmi_set_soc_pstate.restype = amdsmi_status_t
+    amdsmi_set_soc_pstate.argtypes = [amdsmi_processor_handle, uint32_t]
+except AttributeError:
+    pass
+try:
+    amdsmi_get_xgmi_plpd = _libraries['libamd_smi.so'].amdsmi_get_xgmi_plpd
+    amdsmi_get_xgmi_plpd.restype = amdsmi_status_t
+    amdsmi_get_xgmi_plpd.argtypes = [amdsmi_processor_handle, ctypes.POINTER(struct_amdsmi_dpm_policy_t)]
+except AttributeError:
+    pass
+try:
+    amdsmi_set_xgmi_plpd = _libraries['libamd_smi.so'].amdsmi_set_xgmi_plpd
+    amdsmi_set_xgmi_plpd.restype = amdsmi_status_t
+    amdsmi_set_xgmi_plpd.argtypes = [amdsmi_processor_handle, uint32_t]
+except AttributeError:
+    pass
+try:
+    amdsmi_get_gpu_process_isolation = _libraries['libamd_smi.so'].amdsmi_get_gpu_process_isolation
+    amdsmi_get_gpu_process_isolation.restype = amdsmi_status_t
+    amdsmi_get_gpu_process_isolation.argtypes = [amdsmi_processor_handle, ctypes.POINTER(ctypes.c_uint32)]
+except AttributeError:
+    pass
+try:
+    amdsmi_set_gpu_process_isolation = _libraries['libamd_smi.so'].amdsmi_set_gpu_process_isolation
+    amdsmi_set_gpu_process_isolation.restype = amdsmi_status_t
+    amdsmi_set_gpu_process_isolation.argtypes = [amdsmi_processor_handle, uint32_t]
+except AttributeError:
+    pass
+try:
+    amdsmi_clean_gpu_local_data = _libraries['libamd_smi.so'].amdsmi_clean_gpu_local_data
+    amdsmi_clean_gpu_local_data.restype = amdsmi_status_t
+    amdsmi_clean_gpu_local_data.argtypes = [amdsmi_processor_handle]
+except AttributeError:
+    pass
+try:
+    amdsmi_get_lib_version = _libraries['libamd_smi.so'].amdsmi_get_lib_version
+    amdsmi_get_lib_version.restype = amdsmi_status_t
+    amdsmi_get_lib_version.argtypes = [ctypes.POINTER(struct_amdsmi_version_t)]
+except AttributeError:
+    pass
+try:
+    amdsmi_get_gpu_ecc_count = _libraries['libamd_smi.so'].amdsmi_get_gpu_ecc_count
+    amdsmi_get_gpu_ecc_count.restype = amdsmi_status_t
+    amdsmi_get_gpu_ecc_count.argtypes = [amdsmi_processor_handle, amdsmi_gpu_block_t, ctypes.POINTER(struct_amdsmi_error_count_t)]
+except AttributeError:
+    pass
+try:
+    amdsmi_get_gpu_ecc_enabled = _libraries['libamd_smi.so'].amdsmi_get_gpu_ecc_enabled
+    amdsmi_get_gpu_ecc_enabled.restype = amdsmi_status_t
+    amdsmi_get_gpu_ecc_enabled.argtypes = [amdsmi_processor_handle, ctypes.POINTER(ctypes.c_uint64)]
+except AttributeError:
+    pass
+try:
+    amdsmi_get_gpu_total_ecc_count = _libraries['libamd_smi.so'].amdsmi_get_gpu_total_ecc_count
+    amdsmi_get_gpu_total_ecc_count.restype = amdsmi_status_t
+    amdsmi_get_gpu_total_ecc_count.argtypes = [amdsmi_processor_handle, ctypes.POINTER(struct_amdsmi_error_count_t)]
+except AttributeError:
+    pass
 class struct_amdsmi_cper_guid_t(Structure):
     pass
 
@@ -3095,414 +3365,822 @@ struct_amdsmi_cper_hdr_t._fields_ = [
 ]
 
 amdsmi_cper_hdr_t = struct_amdsmi_cper_hdr_t
-amdsmi_get_afids_from_cper = _libraries['libamd_smi.so'].amdsmi_get_afids_from_cper
-amdsmi_get_afids_from_cper.restype = amdsmi_status_t
-amdsmi_get_afids_from_cper.argtypes = [ctypes.POINTER(ctypes.c_char), uint32_t, ctypes.POINTER(ctypes.c_uint64), ctypes.POINTER(ctypes.c_uint32)]
-amdsmi_get_gpu_ras_feature_info = _libraries['libamd_smi.so'].amdsmi_get_gpu_ras_feature_info
-amdsmi_get_gpu_ras_feature_info.restype = amdsmi_status_t
-amdsmi_get_gpu_ras_feature_info.argtypes = [amdsmi_processor_handle, ctypes.POINTER(struct_amdsmi_ras_feature_t)]
-amdsmi_get_gpu_cper_entries = _libraries['libamd_smi.so'].amdsmi_get_gpu_cper_entries
-amdsmi_get_gpu_cper_entries.restype = amdsmi_status_t
-amdsmi_get_gpu_cper_entries.argtypes = [amdsmi_processor_handle, uint32_t, ctypes.POINTER(ctypes.c_char), ctypes.POINTER(ctypes.c_uint64), ctypes.POINTER(ctypes.POINTER(struct_amdsmi_cper_hdr_t)), ctypes.POINTER(ctypes.c_uint64), ctypes.POINTER(ctypes.c_uint64)]
-amdsmi_get_gpu_ecc_status = _libraries['libamd_smi.so'].amdsmi_get_gpu_ecc_status
-amdsmi_get_gpu_ecc_status.restype = amdsmi_status_t
-amdsmi_get_gpu_ecc_status.argtypes = [amdsmi_processor_handle, amdsmi_gpu_block_t, ctypes.POINTER(amdsmi_ras_err_state_t)]
-amdsmi_status_code_to_string = _libraries['libamd_smi.so'].amdsmi_status_code_to_string
-amdsmi_status_code_to_string.restype = amdsmi_status_t
-amdsmi_status_code_to_string.argtypes = [amdsmi_status_t, ctypes.POINTER(ctypes.POINTER(ctypes.c_char))]
-amdsmi_gpu_counter_group_supported = _libraries['libamd_smi.so'].amdsmi_gpu_counter_group_supported
-amdsmi_gpu_counter_group_supported.restype = amdsmi_status_t
-amdsmi_gpu_counter_group_supported.argtypes = [amdsmi_processor_handle, amdsmi_event_group_t]
-amdsmi_gpu_create_counter = _libraries['libamd_smi.so'].amdsmi_gpu_create_counter
-amdsmi_gpu_create_counter.restype = amdsmi_status_t
-amdsmi_gpu_create_counter.argtypes = [amdsmi_processor_handle, amdsmi_event_type_t, ctypes.POINTER(ctypes.c_uint64)]
-amdsmi_gpu_destroy_counter = _libraries['libamd_smi.so'].amdsmi_gpu_destroy_counter
-amdsmi_gpu_destroy_counter.restype = amdsmi_status_t
-amdsmi_gpu_destroy_counter.argtypes = [amdsmi_event_handle_t]
-amdsmi_gpu_control_counter = _libraries['libamd_smi.so'].amdsmi_gpu_control_counter
-amdsmi_gpu_control_counter.restype = amdsmi_status_t
-amdsmi_gpu_control_counter.argtypes = [amdsmi_event_handle_t, amdsmi_counter_command_t, ctypes.POINTER(None)]
-amdsmi_gpu_read_counter = _libraries['libamd_smi.so'].amdsmi_gpu_read_counter
-amdsmi_gpu_read_counter.restype = amdsmi_status_t
-amdsmi_gpu_read_counter.argtypes = [amdsmi_event_handle_t, ctypes.POINTER(struct_amdsmi_counter_value_t)]
-amdsmi_get_gpu_available_counters = _libraries['libamd_smi.so'].amdsmi_get_gpu_available_counters
-amdsmi_get_gpu_available_counters.restype = amdsmi_status_t
-amdsmi_get_gpu_available_counters.argtypes = [amdsmi_processor_handle, amdsmi_event_group_t, ctypes.POINTER(ctypes.c_uint32)]
-amdsmi_get_gpu_compute_process_info = _libraries['libamd_smi.so'].amdsmi_get_gpu_compute_process_info
-amdsmi_get_gpu_compute_process_info.restype = amdsmi_status_t
-amdsmi_get_gpu_compute_process_info.argtypes = [ctypes.POINTER(struct_amdsmi_process_info_t), ctypes.POINTER(ctypes.c_uint32)]
-amdsmi_get_gpu_compute_process_info_by_pid = _libraries['libamd_smi.so'].amdsmi_get_gpu_compute_process_info_by_pid
-amdsmi_get_gpu_compute_process_info_by_pid.restype = amdsmi_status_t
-amdsmi_get_gpu_compute_process_info_by_pid.argtypes = [uint32_t, ctypes.POINTER(struct_amdsmi_process_info_t)]
-amdsmi_get_gpu_compute_process_gpus = _libraries['libamd_smi.so'].amdsmi_get_gpu_compute_process_gpus
-amdsmi_get_gpu_compute_process_gpus.restype = amdsmi_status_t
-amdsmi_get_gpu_compute_process_gpus.argtypes = [uint32_t, ctypes.POINTER(ctypes.c_uint32), ctypes.POINTER(ctypes.c_uint32)]
-amdsmi_gpu_xgmi_error_status = _libraries['libamd_smi.so'].amdsmi_gpu_xgmi_error_status
-amdsmi_gpu_xgmi_error_status.restype = amdsmi_status_t
-amdsmi_gpu_xgmi_error_status.argtypes = [amdsmi_processor_handle, ctypes.POINTER(amdsmi_xgmi_status_t)]
-amdsmi_reset_gpu_xgmi_error = _libraries['libamd_smi.so'].amdsmi_reset_gpu_xgmi_error
-amdsmi_reset_gpu_xgmi_error.restype = amdsmi_status_t
-amdsmi_reset_gpu_xgmi_error.argtypes = [amdsmi_processor_handle]
-amdsmi_get_xgmi_info = _libraries['libamd_smi.so'].amdsmi_get_xgmi_info
-amdsmi_get_xgmi_info.restype = amdsmi_status_t
-amdsmi_get_xgmi_info.argtypes = [amdsmi_processor_handle, ctypes.POINTER(struct_amdsmi_xgmi_info_t)]
-amdsmi_get_gpu_xgmi_link_status = _libraries['libamd_smi.so'].amdsmi_get_gpu_xgmi_link_status
-amdsmi_get_gpu_xgmi_link_status.restype = amdsmi_status_t
-amdsmi_get_gpu_xgmi_link_status.argtypes = [amdsmi_processor_handle, ctypes.POINTER(struct_amdsmi_xgmi_link_status_t)]
-amdsmi_get_link_metrics = _libraries['libamd_smi.so'].amdsmi_get_link_metrics
-amdsmi_get_link_metrics.restype = amdsmi_status_t
-amdsmi_get_link_metrics.argtypes = [amdsmi_processor_handle, ctypes.POINTER(struct_amdsmi_link_metrics_t)]
-amdsmi_topo_get_numa_node_number = _libraries['libamd_smi.so'].amdsmi_topo_get_numa_node_number
-amdsmi_topo_get_numa_node_number.restype = amdsmi_status_t
-amdsmi_topo_get_numa_node_number.argtypes = [amdsmi_processor_handle, ctypes.POINTER(ctypes.c_uint32)]
-amdsmi_topo_get_link_weight = _libraries['libamd_smi.so'].amdsmi_topo_get_link_weight
-amdsmi_topo_get_link_weight.restype = amdsmi_status_t
-amdsmi_topo_get_link_weight.argtypes = [amdsmi_processor_handle, amdsmi_processor_handle, ctypes.POINTER(ctypes.c_uint64)]
-amdsmi_get_minmax_bandwidth_between_processors = _libraries['libamd_smi.so'].amdsmi_get_minmax_bandwidth_between_processors
-amdsmi_get_minmax_bandwidth_between_processors.restype = amdsmi_status_t
-amdsmi_get_minmax_bandwidth_between_processors.argtypes = [amdsmi_processor_handle, amdsmi_processor_handle, ctypes.POINTER(ctypes.c_uint64), ctypes.POINTER(ctypes.c_uint64)]
-amdsmi_topo_get_link_type = _libraries['libamd_smi.so'].amdsmi_topo_get_link_type
-amdsmi_topo_get_link_type.restype = amdsmi_status_t
-amdsmi_topo_get_link_type.argtypes = [amdsmi_processor_handle, amdsmi_processor_handle, ctypes.POINTER(ctypes.c_uint64), ctypes.POINTER(amdsmi_link_type_t)]
-amdsmi_get_link_topology_nearest = _libraries['libamd_smi.so'].amdsmi_get_link_topology_nearest
-amdsmi_get_link_topology_nearest.restype = amdsmi_status_t
-amdsmi_get_link_topology_nearest.argtypes = [amdsmi_processor_handle, amdsmi_link_type_t, ctypes.POINTER(struct_amdsmi_topology_nearest_t)]
-amdsmi_is_P2P_accessible = _libraries['libamd_smi.so'].amdsmi_is_P2P_accessible
-amdsmi_is_P2P_accessible.restype = amdsmi_status_t
-amdsmi_is_P2P_accessible.argtypes = [amdsmi_processor_handle, amdsmi_processor_handle, ctypes.POINTER(ctypes.c_bool)]
-amdsmi_topo_get_p2p_status = _libraries['libamd_smi.so'].amdsmi_topo_get_p2p_status
-amdsmi_topo_get_p2p_status.restype = amdsmi_status_t
-amdsmi_topo_get_p2p_status.argtypes = [amdsmi_processor_handle, amdsmi_processor_handle, ctypes.POINTER(amdsmi_link_type_t), ctypes.POINTER(struct_amdsmi_p2p_capability_t)]
-amdsmi_get_gpu_compute_partition = _libraries['libamd_smi.so'].amdsmi_get_gpu_compute_partition
-amdsmi_get_gpu_compute_partition.restype = amdsmi_status_t
-amdsmi_get_gpu_compute_partition.argtypes = [amdsmi_processor_handle, ctypes.POINTER(ctypes.c_char), uint32_t]
-amdsmi_set_gpu_compute_partition = _libraries['libamd_smi.so'].amdsmi_set_gpu_compute_partition
-amdsmi_set_gpu_compute_partition.restype = amdsmi_status_t
-amdsmi_set_gpu_compute_partition.argtypes = [amdsmi_processor_handle, amdsmi_compute_partition_type_t]
-amdsmi_get_gpu_memory_partition = _libraries['libamd_smi.so'].amdsmi_get_gpu_memory_partition
-amdsmi_get_gpu_memory_partition.restype = amdsmi_status_t
-amdsmi_get_gpu_memory_partition.argtypes = [amdsmi_processor_handle, ctypes.POINTER(ctypes.c_char), uint32_t]
-amdsmi_set_gpu_memory_partition = _libraries['libamd_smi.so'].amdsmi_set_gpu_memory_partition
-amdsmi_set_gpu_memory_partition.restype = amdsmi_status_t
-amdsmi_set_gpu_memory_partition.argtypes = [amdsmi_processor_handle, amdsmi_memory_partition_type_t]
-amdsmi_get_gpu_memory_partition_config = _libraries['libamd_smi.so'].amdsmi_get_gpu_memory_partition_config
-amdsmi_get_gpu_memory_partition_config.restype = amdsmi_status_t
-amdsmi_get_gpu_memory_partition_config.argtypes = [amdsmi_processor_handle, ctypes.POINTER(struct_amdsmi_memory_partition_config_t)]
-amdsmi_set_gpu_memory_partition_mode = _libraries['libamd_smi.so'].amdsmi_set_gpu_memory_partition_mode
-amdsmi_set_gpu_memory_partition_mode.restype = amdsmi_status_t
-amdsmi_set_gpu_memory_partition_mode.argtypes = [amdsmi_processor_handle, amdsmi_memory_partition_type_t]
-amdsmi_get_gpu_accelerator_partition_profile_config = _libraries['libamd_smi.so'].amdsmi_get_gpu_accelerator_partition_profile_config
-amdsmi_get_gpu_accelerator_partition_profile_config.restype = amdsmi_status_t
-amdsmi_get_gpu_accelerator_partition_profile_config.argtypes = [amdsmi_processor_handle, ctypes.POINTER(struct_amdsmi_accelerator_partition_profile_config_t)]
-amdsmi_get_gpu_accelerator_partition_profile = _libraries['libamd_smi.so'].amdsmi_get_gpu_accelerator_partition_profile
-amdsmi_get_gpu_accelerator_partition_profile.restype = amdsmi_status_t
-amdsmi_get_gpu_accelerator_partition_profile.argtypes = [amdsmi_processor_handle, ctypes.POINTER(struct_amdsmi_accelerator_partition_profile_t), ctypes.POINTER(ctypes.c_uint32)]
-amdsmi_set_gpu_accelerator_partition_profile = _libraries['libamd_smi.so'].amdsmi_set_gpu_accelerator_partition_profile
-amdsmi_set_gpu_accelerator_partition_profile.restype = amdsmi_status_t
-amdsmi_set_gpu_accelerator_partition_profile.argtypes = [amdsmi_processor_handle, uint32_t]
-amdsmi_init_gpu_event_notification = _libraries['libamd_smi.so'].amdsmi_init_gpu_event_notification
-amdsmi_init_gpu_event_notification.restype = amdsmi_status_t
-amdsmi_init_gpu_event_notification.argtypes = [amdsmi_processor_handle]
-amdsmi_set_gpu_event_notification_mask = _libraries['libamd_smi.so'].amdsmi_set_gpu_event_notification_mask
-amdsmi_set_gpu_event_notification_mask.restype = amdsmi_status_t
-amdsmi_set_gpu_event_notification_mask.argtypes = [amdsmi_processor_handle, uint64_t]
-amdsmi_get_gpu_event_notification = _libraries['libamd_smi.so'].amdsmi_get_gpu_event_notification
-amdsmi_get_gpu_event_notification.restype = amdsmi_status_t
-amdsmi_get_gpu_event_notification.argtypes = [ctypes.c_int32, ctypes.POINTER(ctypes.c_uint32), ctypes.POINTER(struct_amdsmi_evt_notification_data_t)]
-amdsmi_stop_gpu_event_notification = _libraries['libamd_smi.so'].amdsmi_stop_gpu_event_notification
-amdsmi_stop_gpu_event_notification.restype = amdsmi_status_t
-amdsmi_stop_gpu_event_notification.argtypes = [amdsmi_processor_handle]
-amdsmi_get_gpu_driver_info = _libraries['libamd_smi.so'].amdsmi_get_gpu_driver_info
-amdsmi_get_gpu_driver_info.restype = amdsmi_status_t
-amdsmi_get_gpu_driver_info.argtypes = [amdsmi_processor_handle, ctypes.POINTER(struct_amdsmi_driver_info_t)]
-amdsmi_get_gpu_asic_info = _libraries['libamd_smi.so'].amdsmi_get_gpu_asic_info
-amdsmi_get_gpu_asic_info.restype = amdsmi_status_t
-amdsmi_get_gpu_asic_info.argtypes = [amdsmi_processor_handle, ctypes.POINTER(struct_amdsmi_asic_info_t)]
-amdsmi_get_gpu_kfd_info = _libraries['libamd_smi.so'].amdsmi_get_gpu_kfd_info
-amdsmi_get_gpu_kfd_info.restype = amdsmi_status_t
-amdsmi_get_gpu_kfd_info.argtypes = [amdsmi_processor_handle, ctypes.POINTER(struct_amdsmi_kfd_info_t)]
-amdsmi_get_gpu_vram_info = _libraries['libamd_smi.so'].amdsmi_get_gpu_vram_info
-amdsmi_get_gpu_vram_info.restype = amdsmi_status_t
-amdsmi_get_gpu_vram_info.argtypes = [amdsmi_processor_handle, ctypes.POINTER(struct_amdsmi_vram_info_t)]
-amdsmi_get_gpu_board_info = _libraries['libamd_smi.so'].amdsmi_get_gpu_board_info
-amdsmi_get_gpu_board_info.restype = amdsmi_status_t
-amdsmi_get_gpu_board_info.argtypes = [amdsmi_processor_handle, ctypes.POINTER(struct_amdsmi_board_info_t)]
-amdsmi_get_power_cap_info = _libraries['libamd_smi.so'].amdsmi_get_power_cap_info
-amdsmi_get_power_cap_info.restype = amdsmi_status_t
-amdsmi_get_power_cap_info.argtypes = [amdsmi_processor_handle, uint32_t, ctypes.POINTER(struct_amdsmi_power_cap_info_t)]
-amdsmi_get_pcie_info = _libraries['libamd_smi.so'].amdsmi_get_pcie_info
-amdsmi_get_pcie_info.restype = amdsmi_status_t
-amdsmi_get_pcie_info.argtypes = [amdsmi_processor_handle, ctypes.POINTER(struct_amdsmi_pcie_info_t)]
-amdsmi_get_gpu_xcd_counter = _libraries['libamd_smi.so'].amdsmi_get_gpu_xcd_counter
-amdsmi_get_gpu_xcd_counter.restype = amdsmi_status_t
-amdsmi_get_gpu_xcd_counter.argtypes = [amdsmi_processor_handle, ctypes.POINTER(ctypes.c_uint16)]
-amdsmi_get_npm_info = _libraries['libamd_smi.so'].amdsmi_get_npm_info
-amdsmi_get_npm_info.restype = amdsmi_status_t
-amdsmi_get_npm_info.argtypes = [amdsmi_node_handle, ctypes.POINTER(struct_amdsmi_npm_info_t)]
-amdsmi_get_fw_info = _libraries['libamd_smi.so'].amdsmi_get_fw_info
-amdsmi_get_fw_info.restype = amdsmi_status_t
-amdsmi_get_fw_info.argtypes = [amdsmi_processor_handle, ctypes.POINTER(struct_amdsmi_fw_info_t)]
-amdsmi_get_gpu_vbios_info = _libraries['libamd_smi.so'].amdsmi_get_gpu_vbios_info
-amdsmi_get_gpu_vbios_info.restype = amdsmi_status_t
-amdsmi_get_gpu_vbios_info.argtypes = [amdsmi_processor_handle, ctypes.POINTER(struct_amdsmi_vbios_info_t)]
-amdsmi_get_temp_metric = _libraries['libamd_smi.so'].amdsmi_get_temp_metric
-amdsmi_get_temp_metric.restype = amdsmi_status_t
-amdsmi_get_temp_metric.argtypes = [amdsmi_processor_handle, amdsmi_temperature_type_t, amdsmi_temperature_metric_t, ctypes.POINTER(ctypes.c_int64)]
-amdsmi_get_gpu_activity = _libraries['libamd_smi.so'].amdsmi_get_gpu_activity
-amdsmi_get_gpu_activity.restype = amdsmi_status_t
-amdsmi_get_gpu_activity.argtypes = [amdsmi_processor_handle, ctypes.POINTER(struct_amdsmi_engine_usage_t)]
-amdsmi_get_power_info = _libraries['libamd_smi.so'].amdsmi_get_power_info
-amdsmi_get_power_info.restype = amdsmi_status_t
-amdsmi_get_power_info.argtypes = [amdsmi_processor_handle, ctypes.POINTER(struct_amdsmi_power_info_t)]
-amdsmi_is_gpu_power_management_enabled = _libraries['libamd_smi.so'].amdsmi_is_gpu_power_management_enabled
-amdsmi_is_gpu_power_management_enabled.restype = amdsmi_status_t
-amdsmi_is_gpu_power_management_enabled.argtypes = [amdsmi_processor_handle, ctypes.POINTER(ctypes.c_bool)]
-amdsmi_get_clock_info = _libraries['libamd_smi.so'].amdsmi_get_clock_info
-amdsmi_get_clock_info.restype = amdsmi_status_t
-amdsmi_get_clock_info.argtypes = [amdsmi_processor_handle, amdsmi_clk_type_t, ctypes.POINTER(struct_amdsmi_clk_info_t)]
-amdsmi_get_gpu_vram_usage = _libraries['libamd_smi.so'].amdsmi_get_gpu_vram_usage
-amdsmi_get_gpu_vram_usage.restype = amdsmi_status_t
-amdsmi_get_gpu_vram_usage.argtypes = [amdsmi_processor_handle, ctypes.POINTER(struct_amdsmi_vram_usage_t)]
-amdsmi_get_violation_status = _libraries['libamd_smi.so'].amdsmi_get_violation_status
-amdsmi_get_violation_status.restype = amdsmi_status_t
-amdsmi_get_violation_status.argtypes = [amdsmi_processor_handle, ctypes.POINTER(struct_amdsmi_violation_status_t)]
-amdsmi_get_gpu_process_list = _libraries['libamd_smi.so'].amdsmi_get_gpu_process_list
-amdsmi_get_gpu_process_list.restype = amdsmi_status_t
-amdsmi_get_gpu_process_list.argtypes = [amdsmi_processor_handle, ctypes.POINTER(ctypes.c_uint32), ctypes.POINTER(struct_amdsmi_proc_info_t)]
-amdsmi_gpu_driver_reload = _libraries['libamd_smi.so'].amdsmi_gpu_driver_reload
-amdsmi_gpu_driver_reload.restype = amdsmi_status_t
-amdsmi_gpu_driver_reload.argtypes = []
-amdsmi_get_gpu_ptl_state = _libraries['libamd_smi.so'].amdsmi_get_gpu_ptl_state
-amdsmi_get_gpu_ptl_state.restype = amdsmi_status_t
-amdsmi_get_gpu_ptl_state.argtypes = [amdsmi_processor_handle, ctypes.POINTER(ctypes.c_bool)]
-amdsmi_set_gpu_ptl_state = _libraries['libamd_smi.so'].amdsmi_set_gpu_ptl_state
-amdsmi_set_gpu_ptl_state.restype = amdsmi_status_t
-amdsmi_set_gpu_ptl_state.argtypes = [amdsmi_processor_handle, ctypes.c_bool]
-amdsmi_get_gpu_ptl_formats = _libraries['libamd_smi.so'].amdsmi_get_gpu_ptl_formats
-amdsmi_get_gpu_ptl_formats.restype = amdsmi_status_t
-amdsmi_get_gpu_ptl_formats.argtypes = [amdsmi_processor_handle, ctypes.POINTER(amdsmi_ptl_data_format_t), ctypes.POINTER(amdsmi_ptl_data_format_t)]
-amdsmi_set_gpu_ptl_formats = _libraries['libamd_smi.so'].amdsmi_set_gpu_ptl_formats
-amdsmi_set_gpu_ptl_formats.restype = amdsmi_status_t
-amdsmi_set_gpu_ptl_formats.argtypes = [amdsmi_processor_handle, amdsmi_ptl_data_format_t, amdsmi_ptl_data_format_t]
-amdsmi_get_cpu_core_energy = _libraries['libamd_smi.so'].amdsmi_get_cpu_core_energy
-amdsmi_get_cpu_core_energy.restype = amdsmi_status_t
-amdsmi_get_cpu_core_energy.argtypes = [amdsmi_processor_handle, ctypes.POINTER(ctypes.c_uint64)]
-amdsmi_get_cpu_socket_energy = _libraries['libamd_smi.so'].amdsmi_get_cpu_socket_energy
-amdsmi_get_cpu_socket_energy.restype = amdsmi_status_t
-amdsmi_get_cpu_socket_energy.argtypes = [amdsmi_processor_handle, ctypes.POINTER(ctypes.c_uint64)]
-amdsmi_get_threads_per_core = _libraries['libamd_smi.so'].amdsmi_get_threads_per_core
-amdsmi_get_threads_per_core.restype = amdsmi_status_t
-amdsmi_get_threads_per_core.argtypes = [ctypes.POINTER(ctypes.c_uint32)]
-amdsmi_get_cpu_hsmp_driver_version = _libraries['libamd_smi.so'].amdsmi_get_cpu_hsmp_driver_version
-amdsmi_get_cpu_hsmp_driver_version.restype = amdsmi_status_t
-amdsmi_get_cpu_hsmp_driver_version.argtypes = [amdsmi_processor_handle, ctypes.POINTER(struct_amdsmi_hsmp_driver_version_t)]
-amdsmi_get_cpu_smu_fw_version = _libraries['libamd_smi.so'].amdsmi_get_cpu_smu_fw_version
-amdsmi_get_cpu_smu_fw_version.restype = amdsmi_status_t
-amdsmi_get_cpu_smu_fw_version.argtypes = [amdsmi_processor_handle, ctypes.POINTER(struct_amdsmi_smu_fw_version_t)]
-amdsmi_get_cpu_hsmp_proto_ver = _libraries['libamd_smi.so'].amdsmi_get_cpu_hsmp_proto_ver
-amdsmi_get_cpu_hsmp_proto_ver.restype = amdsmi_status_t
-amdsmi_get_cpu_hsmp_proto_ver.argtypes = [amdsmi_processor_handle, ctypes.POINTER(ctypes.c_uint32)]
-amdsmi_get_cpu_prochot_status = _libraries['libamd_smi.so'].amdsmi_get_cpu_prochot_status
-amdsmi_get_cpu_prochot_status.restype = amdsmi_status_t
-amdsmi_get_cpu_prochot_status.argtypes = [amdsmi_processor_handle, ctypes.POINTER(ctypes.c_uint32)]
-amdsmi_get_cpu_fclk_mclk = _libraries['libamd_smi.so'].amdsmi_get_cpu_fclk_mclk
-amdsmi_get_cpu_fclk_mclk.restype = amdsmi_status_t
-amdsmi_get_cpu_fclk_mclk.argtypes = [amdsmi_processor_handle, ctypes.POINTER(ctypes.c_uint32), ctypes.POINTER(ctypes.c_uint32)]
-amdsmi_get_cpu_cclk_limit = _libraries['libamd_smi.so'].amdsmi_get_cpu_cclk_limit
-amdsmi_get_cpu_cclk_limit.restype = amdsmi_status_t
-amdsmi_get_cpu_cclk_limit.argtypes = [amdsmi_processor_handle, ctypes.POINTER(ctypes.c_uint32)]
-amdsmi_get_cpu_socket_current_active_freq_limit = _libraries['libamd_smi.so'].amdsmi_get_cpu_socket_current_active_freq_limit
-amdsmi_get_cpu_socket_current_active_freq_limit.restype = amdsmi_status_t
-amdsmi_get_cpu_socket_current_active_freq_limit.argtypes = [amdsmi_processor_handle, ctypes.POINTER(ctypes.c_uint16), ctypes.POINTER(ctypes.POINTER(ctypes.c_char))]
-amdsmi_get_cpu_socket_freq_range = _libraries['libamd_smi.so'].amdsmi_get_cpu_socket_freq_range
-amdsmi_get_cpu_socket_freq_range.restype = amdsmi_status_t
-amdsmi_get_cpu_socket_freq_range.argtypes = [amdsmi_processor_handle, ctypes.POINTER(ctypes.c_uint16), ctypes.POINTER(ctypes.c_uint16)]
-amdsmi_get_cpu_core_current_freq_limit = _libraries['libamd_smi.so'].amdsmi_get_cpu_core_current_freq_limit
-amdsmi_get_cpu_core_current_freq_limit.restype = amdsmi_status_t
-amdsmi_get_cpu_core_current_freq_limit.argtypes = [amdsmi_processor_handle, ctypes.POINTER(ctypes.c_uint32)]
-amdsmi_set_cpu_rail_isofreq_policy = _libraries['libamd_smi.so'].amdsmi_set_cpu_rail_isofreq_policy
-amdsmi_set_cpu_rail_isofreq_policy.restype = amdsmi_status_t
-amdsmi_set_cpu_rail_isofreq_policy.argtypes = [amdsmi_processor_handle, ctypes.POINTER(ctypes.c_bool)]
-amdsmi_get_cpu_rail_isofreq_policy = _libraries['libamd_smi.so'].amdsmi_get_cpu_rail_isofreq_policy
-amdsmi_get_cpu_rail_isofreq_policy.restype = amdsmi_status_t
-amdsmi_get_cpu_rail_isofreq_policy.argtypes = [amdsmi_processor_handle, ctypes.POINTER(ctypes.c_ubyte)]
-amdsmi_set_cpu_dfc_ctrl = _libraries['libamd_smi.so'].amdsmi_set_cpu_dfc_ctrl
-amdsmi_set_cpu_dfc_ctrl.restype = amdsmi_status_t
-amdsmi_set_cpu_dfc_ctrl.argtypes = [amdsmi_processor_handle, ctypes.POINTER(ctypes.c_ubyte)]
-amdsmi_get_cpu_dfc_ctrl = _libraries['libamd_smi.so'].amdsmi_get_cpu_dfc_ctrl
-amdsmi_get_cpu_dfc_ctrl.restype = amdsmi_status_t
-amdsmi_get_cpu_dfc_ctrl.argtypes = [amdsmi_processor_handle, ctypes.POINTER(ctypes.c_ubyte)]
-amdsmi_get_cpu_core_boostlimit = _libraries['libamd_smi.so'].amdsmi_get_cpu_core_boostlimit
-amdsmi_get_cpu_core_boostlimit.restype = amdsmi_status_t
-amdsmi_get_cpu_core_boostlimit.argtypes = [amdsmi_processor_handle, ctypes.POINTER(ctypes.c_uint32)]
-amdsmi_get_cpu_socket_c0_residency = _libraries['libamd_smi.so'].amdsmi_get_cpu_socket_c0_residency
-amdsmi_get_cpu_socket_c0_residency.restype = amdsmi_status_t
-amdsmi_get_cpu_socket_c0_residency.argtypes = [amdsmi_processor_handle, ctypes.POINTER(ctypes.c_uint32)]
-amdsmi_set_cpu_core_boostlimit = _libraries['libamd_smi.so'].amdsmi_set_cpu_core_boostlimit
-amdsmi_set_cpu_core_boostlimit.restype = amdsmi_status_t
-amdsmi_set_cpu_core_boostlimit.argtypes = [amdsmi_processor_handle, uint32_t]
-amdsmi_set_cpu_socket_boostlimit = _libraries['libamd_smi.so'].amdsmi_set_cpu_socket_boostlimit
-amdsmi_set_cpu_socket_boostlimit.restype = amdsmi_status_t
-amdsmi_set_cpu_socket_boostlimit.argtypes = [amdsmi_processor_handle, uint32_t]
-amdsmi_get_cpu_core_floor_freq_limit = _libraries['libamd_smi.so'].amdsmi_get_cpu_core_floor_freq_limit
-amdsmi_get_cpu_core_floor_freq_limit.restype = amdsmi_status_t
-amdsmi_get_cpu_core_floor_freq_limit.argtypes = [amdsmi_processor_handle, ctypes.POINTER(ctypes.c_uint32)]
-amdsmi_get_cpu_floor_freq_limit = _libraries['libamd_smi.so'].amdsmi_get_cpu_floor_freq_limit
-amdsmi_get_cpu_floor_freq_limit.restype = amdsmi_status_t
-amdsmi_get_cpu_floor_freq_limit.argtypes = [amdsmi_processor_handle, ctypes.POINTER(ctypes.c_uint32)]
-amdsmi_get_cpu_core_eff_floor_freq_limit = _libraries['libamd_smi.so'].amdsmi_get_cpu_core_eff_floor_freq_limit
-amdsmi_get_cpu_core_eff_floor_freq_limit.restype = amdsmi_status_t
-amdsmi_get_cpu_core_eff_floor_freq_limit.argtypes = [amdsmi_processor_handle, ctypes.POINTER(ctypes.c_uint32)]
-amdsmi_get_cpu_eff_floor_freq_limit = _libraries['libamd_smi.so'].amdsmi_get_cpu_eff_floor_freq_limit
-amdsmi_get_cpu_eff_floor_freq_limit.restype = amdsmi_status_t
-amdsmi_get_cpu_eff_floor_freq_limit.argtypes = [amdsmi_processor_handle, ctypes.POINTER(ctypes.c_uint32)]
-amdsmi_set_cpu_core_floor_freq_limit = _libraries['libamd_smi.so'].amdsmi_set_cpu_core_floor_freq_limit
-amdsmi_set_cpu_core_floor_freq_limit.restype = amdsmi_status_t
-amdsmi_set_cpu_core_floor_freq_limit.argtypes = [amdsmi_processor_handle, uint32_t]
-amdsmi_set_cpu_floor_freq_limit = _libraries['libamd_smi.so'].amdsmi_set_cpu_floor_freq_limit
-amdsmi_set_cpu_floor_freq_limit.restype = amdsmi_status_t
-amdsmi_set_cpu_floor_freq_limit.argtypes = [amdsmi_processor_handle, uint32_t]
-amdsmi_set_cpu_msr_floor_freq_limit = _libraries['libamd_smi.so'].amdsmi_set_cpu_msr_floor_freq_limit
-amdsmi_set_cpu_msr_floor_freq_limit.restype = amdsmi_status_t
-amdsmi_set_cpu_msr_floor_freq_limit.argtypes = [amdsmi_processor_handle, uint32_t]
-amdsmi_set_cpu_core_msr_floor_freq_limit = _libraries['libamd_smi.so'].amdsmi_set_cpu_core_msr_floor_freq_limit
-amdsmi_set_cpu_core_msr_floor_freq_limit.restype = amdsmi_status_t
-amdsmi_set_cpu_core_msr_floor_freq_limit.argtypes = [amdsmi_processor_handle, uint32_t]
-amdsmi_get_cpu_freq_range = _libraries['libamd_smi.so'].amdsmi_get_cpu_freq_range
-amdsmi_get_cpu_freq_range.restype = amdsmi_status_t
-amdsmi_get_cpu_freq_range.argtypes = [ctypes.POINTER(ctypes.c_uint32), ctypes.POINTER(ctypes.c_uint32)]
-amdsmi_set_cpu_sdps_limit = _libraries['libamd_smi.so'].amdsmi_set_cpu_sdps_limit
-amdsmi_set_cpu_sdps_limit.restype = amdsmi_status_t
-amdsmi_set_cpu_sdps_limit.argtypes = [amdsmi_processor_handle, uint32_t]
-amdsmi_get_cpu_sdps_limit = _libraries['libamd_smi.so'].amdsmi_get_cpu_sdps_limit
-amdsmi_get_cpu_sdps_limit.restype = amdsmi_status_t
-amdsmi_get_cpu_sdps_limit.argtypes = [amdsmi_processor_handle, ctypes.POINTER(ctypes.c_double)]
-amdsmi_get_cpu_ddr_bw = _libraries['libamd_smi.so'].amdsmi_get_cpu_ddr_bw
-amdsmi_get_cpu_ddr_bw.restype = amdsmi_status_t
-amdsmi_get_cpu_ddr_bw.argtypes = [amdsmi_processor_handle, ctypes.POINTER(struct_amdsmi_ddr_bw_metrics_t)]
-amdsmi_get_cpu_socket_temperature = _libraries['libamd_smi.so'].amdsmi_get_cpu_socket_temperature
-amdsmi_get_cpu_socket_temperature.restype = amdsmi_status_t
-amdsmi_get_cpu_socket_temperature.argtypes = [amdsmi_processor_handle, ctypes.POINTER(ctypes.c_uint32)]
-amdsmi_get_cpu_tdelta = _libraries['libamd_smi.so'].amdsmi_get_cpu_tdelta
-amdsmi_get_cpu_tdelta.restype = amdsmi_status_t
-amdsmi_get_cpu_tdelta.argtypes = [amdsmi_processor_handle, ctypes.POINTER(ctypes.c_ubyte)]
-amdsmi_get_cpu_svi3_vr_controller_temp = _libraries['libamd_smi.so'].amdsmi_get_cpu_svi3_vr_controller_temp
-amdsmi_get_cpu_svi3_vr_controller_temp.restype = amdsmi_status_t
-amdsmi_get_cpu_svi3_vr_controller_temp.argtypes = [amdsmi_processor_handle, ctypes.POINTER(ctypes.c_uint32), ctypes.POINTER(ctypes.c_uint32), ctypes.POINTER(ctypes.c_uint32)]
-amdsmi_get_cpu_dimm_temp_range_and_refresh_rate = _libraries['libamd_smi.so'].amdsmi_get_cpu_dimm_temp_range_and_refresh_rate
-amdsmi_get_cpu_dimm_temp_range_and_refresh_rate.restype = amdsmi_status_t
-amdsmi_get_cpu_dimm_temp_range_and_refresh_rate.argtypes = [amdsmi_processor_handle, uint8_t, ctypes.POINTER(struct_amdsmi_temp_range_refresh_rate_t)]
-amdsmi_get_cpu_dimm_power_consumption = _libraries['libamd_smi.so'].amdsmi_get_cpu_dimm_power_consumption
-amdsmi_get_cpu_dimm_power_consumption.restype = amdsmi_status_t
-amdsmi_get_cpu_dimm_power_consumption.argtypes = [amdsmi_processor_handle, uint8_t, ctypes.POINTER(struct_amdsmi_dimm_power_t)]
-amdsmi_get_cpu_dimm_thermal_sensor = _libraries['libamd_smi.so'].amdsmi_get_cpu_dimm_thermal_sensor
-amdsmi_get_cpu_dimm_thermal_sensor.restype = amdsmi_status_t
-amdsmi_get_cpu_dimm_thermal_sensor.argtypes = [amdsmi_processor_handle, uint8_t, ctypes.POINTER(struct_amdsmi_dimm_thermal_t)]
-amdsmi_get_cpu_dimm_sb_reg = _libraries['libamd_smi.so'].amdsmi_get_cpu_dimm_sb_reg
-amdsmi_get_cpu_dimm_sb_reg.restype = amdsmi_status_t
-amdsmi_get_cpu_dimm_sb_reg.argtypes = [amdsmi_processor_handle, uint32_t, uint32_t, uint32_t, uint32_t, ctypes.POINTER(ctypes.c_uint32)]
-amdsmi_set_cpu_dimm_sb_reg = _libraries['libamd_smi.so'].amdsmi_set_cpu_dimm_sb_reg
-amdsmi_set_cpu_dimm_sb_reg.restype = amdsmi_status_t
-amdsmi_set_cpu_dimm_sb_reg.argtypes = [amdsmi_processor_handle, uint32_t, uint32_t, uint32_t, uint32_t, uint32_t]
-amdsmi_set_cpu_xgmi_width = _libraries['libamd_smi.so'].amdsmi_set_cpu_xgmi_width
-amdsmi_set_cpu_xgmi_width.restype = amdsmi_status_t
-amdsmi_set_cpu_xgmi_width.argtypes = [amdsmi_processor_handle, uint8_t, uint8_t]
-amdsmi_set_cpu_gmi3_link_width_range = _libraries['libamd_smi.so'].amdsmi_set_cpu_gmi3_link_width_range
-amdsmi_set_cpu_gmi3_link_width_range.restype = amdsmi_status_t
-amdsmi_set_cpu_gmi3_link_width_range.argtypes = [amdsmi_processor_handle, uint8_t, uint8_t]
-amdsmi_cpu_apb_enable = _libraries['libamd_smi.so'].amdsmi_cpu_apb_enable
-amdsmi_cpu_apb_enable.restype = amdsmi_status_t
-amdsmi_cpu_apb_enable.argtypes = [amdsmi_processor_handle]
-amdsmi_cpu_apb_disable = _libraries['libamd_smi.so'].amdsmi_cpu_apb_disable
-amdsmi_cpu_apb_disable.restype = amdsmi_status_t
-amdsmi_cpu_apb_disable.argtypes = [amdsmi_processor_handle, uint8_t]
-amdsmi_set_cpu_socket_lclk_dpm_level = _libraries['libamd_smi.so'].amdsmi_set_cpu_socket_lclk_dpm_level
-amdsmi_set_cpu_socket_lclk_dpm_level.restype = amdsmi_status_t
-amdsmi_set_cpu_socket_lclk_dpm_level.argtypes = [amdsmi_processor_handle, uint8_t, uint8_t, uint8_t]
-amdsmi_get_cpu_socket_lclk_dpm_level = _libraries['libamd_smi.so'].amdsmi_get_cpu_socket_lclk_dpm_level
-amdsmi_get_cpu_socket_lclk_dpm_level.restype = amdsmi_status_t
-amdsmi_get_cpu_socket_lclk_dpm_level.argtypes = [amdsmi_processor_handle, uint8_t, ctypes.POINTER(struct_amdsmi_dpm_level_t)]
-amdsmi_set_cpu_pcie_link_rate = _libraries['libamd_smi.so'].amdsmi_set_cpu_pcie_link_rate
-amdsmi_set_cpu_pcie_link_rate.restype = amdsmi_status_t
-amdsmi_set_cpu_pcie_link_rate.argtypes = [amdsmi_processor_handle, uint8_t, ctypes.POINTER(ctypes.c_ubyte)]
-amdsmi_set_cpu_df_pstate_range = _libraries['libamd_smi.so'].amdsmi_set_cpu_df_pstate_range
-amdsmi_set_cpu_df_pstate_range.restype = amdsmi_status_t
-amdsmi_set_cpu_df_pstate_range.argtypes = [amdsmi_processor_handle, uint8_t, uint8_t]
-amdsmi_set_cpu_xgmi_pstate_range = _libraries['libamd_smi.so'].amdsmi_set_cpu_xgmi_pstate_range
-amdsmi_set_cpu_xgmi_pstate_range.restype = amdsmi_status_t
-amdsmi_set_cpu_xgmi_pstate_range.argtypes = [amdsmi_processor_handle, uint8_t, uint8_t]
-amdsmi_get_cpu_xgmi_pstate_range = _libraries['libamd_smi.so'].amdsmi_get_cpu_xgmi_pstate_range
-amdsmi_get_cpu_xgmi_pstate_range.restype = amdsmi_status_t
-amdsmi_get_cpu_xgmi_pstate_range.argtypes = [amdsmi_processor_handle, ctypes.POINTER(ctypes.c_ubyte), ctypes.POINTER(ctypes.c_ubyte)]
-amdsmi_get_cpu_pc6_enable = _libraries['libamd_smi.so'].amdsmi_get_cpu_pc6_enable
-amdsmi_get_cpu_pc6_enable.restype = amdsmi_status_t
-amdsmi_get_cpu_pc6_enable.argtypes = [amdsmi_processor_handle, ctypes.POINTER(ctypes.c_ubyte)]
-amdsmi_set_cpu_pc6_enable = _libraries['libamd_smi.so'].amdsmi_set_cpu_pc6_enable
-amdsmi_set_cpu_pc6_enable.restype = amdsmi_status_t
-amdsmi_set_cpu_pc6_enable.argtypes = [amdsmi_processor_handle, uint8_t]
-amdsmi_get_cpu_cc6_enable = _libraries['libamd_smi.so'].amdsmi_get_cpu_cc6_enable
-amdsmi_get_cpu_cc6_enable.restype = amdsmi_status_t
-amdsmi_get_cpu_cc6_enable.argtypes = [amdsmi_processor_handle, ctypes.POINTER(ctypes.c_ubyte)]
-amdsmi_set_cpu_cc6_enable = _libraries['libamd_smi.so'].amdsmi_set_cpu_cc6_enable
-amdsmi_set_cpu_cc6_enable.restype = amdsmi_status_t
-amdsmi_set_cpu_cc6_enable.argtypes = [amdsmi_processor_handle, uint8_t]
-amdsmi_get_cpu_current_io_bandwidth = _libraries['libamd_smi.so'].amdsmi_get_cpu_current_io_bandwidth
-amdsmi_get_cpu_current_io_bandwidth.restype = amdsmi_status_t
-amdsmi_get_cpu_current_io_bandwidth.argtypes = [amdsmi_processor_handle, amdsmi_link_id_bw_type_t, ctypes.POINTER(ctypes.c_uint32)]
-amdsmi_get_cpu_current_xgmi_bw = _libraries['libamd_smi.so'].amdsmi_get_cpu_current_xgmi_bw
-amdsmi_get_cpu_current_xgmi_bw.restype = amdsmi_status_t
-amdsmi_get_cpu_current_xgmi_bw.argtypes = [amdsmi_processor_handle, amdsmi_link_id_bw_type_t, ctypes.POINTER(ctypes.c_uint32)]
-amdsmi_get_hsmp_metrics_table_version = _libraries['libamd_smi.so'].amdsmi_get_hsmp_metrics_table_version
-amdsmi_get_hsmp_metrics_table_version.restype = amdsmi_status_t
-amdsmi_get_hsmp_metrics_table_version.argtypes = [amdsmi_processor_handle, ctypes.POINTER(ctypes.c_uint32)]
-amdsmi_get_hsmp_metrics_table = _libraries['libamd_smi.so'].amdsmi_get_hsmp_metrics_table
-amdsmi_get_hsmp_metrics_table.restype = amdsmi_status_t
-amdsmi_get_hsmp_metrics_table.argtypes = [amdsmi_processor_handle, ctypes.POINTER(struct_amdsmi_hsmp_metrics_table_t)]
-amdsmi_first_online_core_on_cpu_socket = _libraries['libamd_smi.so'].amdsmi_first_online_core_on_cpu_socket
-amdsmi_first_online_core_on_cpu_socket.restype = amdsmi_status_t
-amdsmi_first_online_core_on_cpu_socket.argtypes = [amdsmi_processor_handle, ctypes.POINTER(ctypes.c_uint32)]
-amdsmi_get_cpu_family = _libraries['libamd_smi.so'].amdsmi_get_cpu_family
-amdsmi_get_cpu_family.restype = amdsmi_status_t
-amdsmi_get_cpu_family.argtypes = [ctypes.POINTER(ctypes.c_uint32)]
-amdsmi_get_cpu_model = _libraries['libamd_smi.so'].amdsmi_get_cpu_model
-amdsmi_get_cpu_model.restype = amdsmi_status_t
-amdsmi_get_cpu_model.argtypes = [ctypes.POINTER(ctypes.c_uint32)]
-amdsmi_get_cpu_model_name = _libraries['libamd_smi.so'].amdsmi_get_cpu_model_name
-amdsmi_get_cpu_model_name.restype = amdsmi_status_t
-amdsmi_get_cpu_model_name.argtypes = [amdsmi_processor_handle, ctypes.POINTER(struct_amdsmi_cpu_info_t)]
-amdsmi_get_esmi_err_msg = _libraries['libamd_smi.so'].amdsmi_get_esmi_err_msg
-amdsmi_get_esmi_err_msg.restype = amdsmi_status_t
-amdsmi_get_esmi_err_msg.argtypes = [amdsmi_status_t, ctypes.POINTER(ctypes.POINTER(ctypes.c_char))]
-amdsmi_get_cpu_cores_per_socket = _libraries['libamd_smi.so'].amdsmi_get_cpu_cores_per_socket
-amdsmi_get_cpu_cores_per_socket.restype = amdsmi_status_t
-amdsmi_get_cpu_cores_per_socket.argtypes = [uint32_t, ctypes.POINTER(struct_amdsmi_sock_info_t)]
-amdsmi_get_cpu_socket_count = _libraries['libamd_smi.so'].amdsmi_get_cpu_socket_count
-amdsmi_get_cpu_socket_count.restype = amdsmi_status_t
-amdsmi_get_cpu_socket_count.argtypes = [ctypes.POINTER(ctypes.c_uint32)]
-amdsmi_get_cpu_enabled_commands = _libraries['libamd_smi.so'].amdsmi_get_cpu_enabled_commands
-amdsmi_get_cpu_enabled_commands.restype = amdsmi_status_t
-amdsmi_get_cpu_enabled_commands.argtypes = [amdsmi_processor_handle, ctypes.POINTER(ctypes.c_bool), ctypes.POINTER(ctypes.c_uint32), ctypes.POINTER(ctypes.c_uint32), ctypes.POINTER(ctypes.c_uint32)]
-amdsmi_get_nic_driver_info = _libraries['libamd_smi.so'].amdsmi_get_nic_driver_info
-amdsmi_get_nic_driver_info.restype = amdsmi_status_t
-amdsmi_get_nic_driver_info.argtypes = [amdsmi_processor_handle, ctypes.POINTER(struct_amdsmi_nic_driver_info_t)]
-amdsmi_get_nic_asic_info = _libraries['libamd_smi.so'].amdsmi_get_nic_asic_info
-amdsmi_get_nic_asic_info.restype = amdsmi_status_t
-amdsmi_get_nic_asic_info.argtypes = [amdsmi_processor_handle, ctypes.POINTER(struct_amdsmi_nic_asic_info_t)]
-amdsmi_get_nic_bus_info = _libraries['libamd_smi.so'].amdsmi_get_nic_bus_info
-amdsmi_get_nic_bus_info.restype = amdsmi_status_t
-amdsmi_get_nic_bus_info.argtypes = [amdsmi_processor_handle, ctypes.POINTER(struct_amdsmi_nic_bus_info_t)]
-amdsmi_get_nic_numa_info = _libraries['libamd_smi.so'].amdsmi_get_nic_numa_info
-amdsmi_get_nic_numa_info.restype = amdsmi_status_t
-amdsmi_get_nic_numa_info.argtypes = [amdsmi_processor_handle, ctypes.POINTER(struct_amdsmi_nic_numa_info_t)]
-amdsmi_get_nic_port_info = _libraries['libamd_smi.so'].amdsmi_get_nic_port_info
-amdsmi_get_nic_port_info.restype = amdsmi_status_t
-amdsmi_get_nic_port_info.argtypes = [amdsmi_processor_handle, ctypes.POINTER(struct_amdsmi_nic_port_info_t)]
-amdsmi_get_nic_rdma_dev_info = _libraries['libamd_smi.so'].amdsmi_get_nic_rdma_dev_info
-amdsmi_get_nic_rdma_dev_info.restype = amdsmi_status_t
-amdsmi_get_nic_rdma_dev_info.argtypes = [amdsmi_processor_handle, ctypes.POINTER(struct_amdsmi_nic_rdma_devices_info_t)]
-amdsmi_get_nic_rdma_port_statistics = _libraries['libamd_smi.so'].amdsmi_get_nic_rdma_port_statistics
-amdsmi_get_nic_rdma_port_statistics.restype = amdsmi_status_t
-amdsmi_get_nic_rdma_port_statistics.argtypes = [amdsmi_processor_handle, uint32_t, ctypes.POINTER(ctypes.c_uint32), ctypes.POINTER(struct_amdsmi_nic_stat_t)]
+try:
+    amdsmi_get_afids_from_cper = _libraries['libamd_smi.so'].amdsmi_get_afids_from_cper
+    amdsmi_get_afids_from_cper.restype = amdsmi_status_t
+    amdsmi_get_afids_from_cper.argtypes = [ctypes.POINTER(ctypes.c_char), uint32_t, ctypes.POINTER(ctypes.c_uint64), ctypes.POINTER(ctypes.c_uint32)]
+except AttributeError:
+    pass
+try:
+    amdsmi_get_gpu_ras_feature_info = _libraries['libamd_smi.so'].amdsmi_get_gpu_ras_feature_info
+    amdsmi_get_gpu_ras_feature_info.restype = amdsmi_status_t
+    amdsmi_get_gpu_ras_feature_info.argtypes = [amdsmi_processor_handle, ctypes.POINTER(struct_amdsmi_ras_feature_t)]
+except AttributeError:
+    pass
+try:
+    amdsmi_get_gpu_cper_entries = _libraries['libamd_smi.so'].amdsmi_get_gpu_cper_entries
+    amdsmi_get_gpu_cper_entries.restype = amdsmi_status_t
+    amdsmi_get_gpu_cper_entries.argtypes = [amdsmi_processor_handle, uint32_t, ctypes.POINTER(ctypes.c_char), ctypes.POINTER(ctypes.c_uint64), ctypes.POINTER(ctypes.POINTER(struct_amdsmi_cper_hdr_t)), ctypes.POINTER(ctypes.c_uint64), ctypes.POINTER(ctypes.c_uint64)]
+except AttributeError:
+    pass
+try:
+    amdsmi_get_gpu_ecc_status = _libraries['libamd_smi.so'].amdsmi_get_gpu_ecc_status
+    amdsmi_get_gpu_ecc_status.restype = amdsmi_status_t
+    amdsmi_get_gpu_ecc_status.argtypes = [amdsmi_processor_handle, amdsmi_gpu_block_t, ctypes.POINTER(amdsmi_ras_err_state_t)]
+except AttributeError:
+    pass
+try:
+    amdsmi_status_code_to_string = _libraries['libamd_smi.so'].amdsmi_status_code_to_string
+    amdsmi_status_code_to_string.restype = amdsmi_status_t
+    amdsmi_status_code_to_string.argtypes = [amdsmi_status_t, ctypes.POINTER(ctypes.POINTER(ctypes.c_char))]
+except AttributeError:
+    pass
+try:
+    amdsmi_gpu_counter_group_supported = _libraries['libamd_smi.so'].amdsmi_gpu_counter_group_supported
+    amdsmi_gpu_counter_group_supported.restype = amdsmi_status_t
+    amdsmi_gpu_counter_group_supported.argtypes = [amdsmi_processor_handle, amdsmi_event_group_t]
+except AttributeError:
+    pass
+try:
+    amdsmi_gpu_create_counter = _libraries['libamd_smi.so'].amdsmi_gpu_create_counter
+    amdsmi_gpu_create_counter.restype = amdsmi_status_t
+    amdsmi_gpu_create_counter.argtypes = [amdsmi_processor_handle, amdsmi_event_type_t, ctypes.POINTER(ctypes.c_uint64)]
+except AttributeError:
+    pass
+try:
+    amdsmi_gpu_destroy_counter = _libraries['libamd_smi.so'].amdsmi_gpu_destroy_counter
+    amdsmi_gpu_destroy_counter.restype = amdsmi_status_t
+    amdsmi_gpu_destroy_counter.argtypes = [amdsmi_event_handle_t]
+except AttributeError:
+    pass
+try:
+    amdsmi_gpu_control_counter = _libraries['libamd_smi.so'].amdsmi_gpu_control_counter
+    amdsmi_gpu_control_counter.restype = amdsmi_status_t
+    amdsmi_gpu_control_counter.argtypes = [amdsmi_event_handle_t, amdsmi_counter_command_t, ctypes.POINTER(None)]
+except AttributeError:
+    pass
+try:
+    amdsmi_gpu_read_counter = _libraries['libamd_smi.so'].amdsmi_gpu_read_counter
+    amdsmi_gpu_read_counter.restype = amdsmi_status_t
+    amdsmi_gpu_read_counter.argtypes = [amdsmi_event_handle_t, ctypes.POINTER(struct_amdsmi_counter_value_t)]
+except AttributeError:
+    pass
+try:
+    amdsmi_get_gpu_available_counters = _libraries['libamd_smi.so'].amdsmi_get_gpu_available_counters
+    amdsmi_get_gpu_available_counters.restype = amdsmi_status_t
+    amdsmi_get_gpu_available_counters.argtypes = [amdsmi_processor_handle, amdsmi_event_group_t, ctypes.POINTER(ctypes.c_uint32)]
+except AttributeError:
+    pass
+try:
+    amdsmi_get_gpu_compute_process_info = _libraries['libamd_smi.so'].amdsmi_get_gpu_compute_process_info
+    amdsmi_get_gpu_compute_process_info.restype = amdsmi_status_t
+    amdsmi_get_gpu_compute_process_info.argtypes = [ctypes.POINTER(struct_amdsmi_process_info_t), ctypes.POINTER(ctypes.c_uint32)]
+except AttributeError:
+    pass
+try:
+    amdsmi_get_gpu_compute_process_info_by_pid = _libraries['libamd_smi.so'].amdsmi_get_gpu_compute_process_info_by_pid
+    amdsmi_get_gpu_compute_process_info_by_pid.restype = amdsmi_status_t
+    amdsmi_get_gpu_compute_process_info_by_pid.argtypes = [uint32_t, ctypes.POINTER(struct_amdsmi_process_info_t)]
+except AttributeError:
+    pass
+try:
+    amdsmi_get_gpu_compute_process_gpus = _libraries['libamd_smi.so'].amdsmi_get_gpu_compute_process_gpus
+    amdsmi_get_gpu_compute_process_gpus.restype = amdsmi_status_t
+    amdsmi_get_gpu_compute_process_gpus.argtypes = [uint32_t, ctypes.POINTER(ctypes.c_uint32), ctypes.POINTER(ctypes.c_uint32)]
+except AttributeError:
+    pass
+try:
+    amdsmi_gpu_xgmi_error_status = _libraries['libamd_smi.so'].amdsmi_gpu_xgmi_error_status
+    amdsmi_gpu_xgmi_error_status.restype = amdsmi_status_t
+    amdsmi_gpu_xgmi_error_status.argtypes = [amdsmi_processor_handle, ctypes.POINTER(amdsmi_xgmi_status_t)]
+except AttributeError:
+    pass
+try:
+    amdsmi_reset_gpu_xgmi_error = _libraries['libamd_smi.so'].amdsmi_reset_gpu_xgmi_error
+    amdsmi_reset_gpu_xgmi_error.restype = amdsmi_status_t
+    amdsmi_reset_gpu_xgmi_error.argtypes = [amdsmi_processor_handle]
+except AttributeError:
+    pass
+try:
+    amdsmi_get_xgmi_info = _libraries['libamd_smi.so'].amdsmi_get_xgmi_info
+    amdsmi_get_xgmi_info.restype = amdsmi_status_t
+    amdsmi_get_xgmi_info.argtypes = [amdsmi_processor_handle, ctypes.POINTER(struct_amdsmi_xgmi_info_t)]
+except AttributeError:
+    pass
+try:
+    amdsmi_get_gpu_xgmi_link_status = _libraries['libamd_smi.so'].amdsmi_get_gpu_xgmi_link_status
+    amdsmi_get_gpu_xgmi_link_status.restype = amdsmi_status_t
+    amdsmi_get_gpu_xgmi_link_status.argtypes = [amdsmi_processor_handle, ctypes.POINTER(struct_amdsmi_xgmi_link_status_t)]
+except AttributeError:
+    pass
+try:
+    amdsmi_get_link_metrics = _libraries['libamd_smi.so'].amdsmi_get_link_metrics
+    amdsmi_get_link_metrics.restype = amdsmi_status_t
+    amdsmi_get_link_metrics.argtypes = [amdsmi_processor_handle, ctypes.POINTER(struct_amdsmi_link_metrics_t)]
+except AttributeError:
+    pass
+try:
+    amdsmi_topo_get_numa_node_number = _libraries['libamd_smi.so'].amdsmi_topo_get_numa_node_number
+    amdsmi_topo_get_numa_node_number.restype = amdsmi_status_t
+    amdsmi_topo_get_numa_node_number.argtypes = [amdsmi_processor_handle, ctypes.POINTER(ctypes.c_uint32)]
+except AttributeError:
+    pass
+try:
+    amdsmi_topo_get_link_weight = _libraries['libamd_smi.so'].amdsmi_topo_get_link_weight
+    amdsmi_topo_get_link_weight.restype = amdsmi_status_t
+    amdsmi_topo_get_link_weight.argtypes = [amdsmi_processor_handle, amdsmi_processor_handle, ctypes.POINTER(ctypes.c_uint64)]
+except AttributeError:
+    pass
+try:
+    amdsmi_get_minmax_bandwidth_between_processors = _libraries['libamd_smi.so'].amdsmi_get_minmax_bandwidth_between_processors
+    amdsmi_get_minmax_bandwidth_between_processors.restype = amdsmi_status_t
+    amdsmi_get_minmax_bandwidth_between_processors.argtypes = [amdsmi_processor_handle, amdsmi_processor_handle, ctypes.POINTER(ctypes.c_uint64), ctypes.POINTER(ctypes.c_uint64)]
+except AttributeError:
+    pass
+try:
+    amdsmi_topo_get_link_type = _libraries['libamd_smi.so'].amdsmi_topo_get_link_type
+    amdsmi_topo_get_link_type.restype = amdsmi_status_t
+    amdsmi_topo_get_link_type.argtypes = [amdsmi_processor_handle, amdsmi_processor_handle, ctypes.POINTER(ctypes.c_uint64), ctypes.POINTER(amdsmi_link_type_t)]
+except AttributeError:
+    pass
+try:
+    amdsmi_get_link_topology_nearest = _libraries['libamd_smi.so'].amdsmi_get_link_topology_nearest
+    amdsmi_get_link_topology_nearest.restype = amdsmi_status_t
+    amdsmi_get_link_topology_nearest.argtypes = [amdsmi_processor_handle, amdsmi_link_type_t, ctypes.POINTER(struct_amdsmi_topology_nearest_t)]
+except AttributeError:
+    pass
+try:
+    amdsmi_is_P2P_accessible = _libraries['libamd_smi.so'].amdsmi_is_P2P_accessible
+    amdsmi_is_P2P_accessible.restype = amdsmi_status_t
+    amdsmi_is_P2P_accessible.argtypes = [amdsmi_processor_handle, amdsmi_processor_handle, ctypes.POINTER(ctypes.c_bool)]
+except AttributeError:
+    pass
+try:
+    amdsmi_topo_get_p2p_status = _libraries['libamd_smi.so'].amdsmi_topo_get_p2p_status
+    amdsmi_topo_get_p2p_status.restype = amdsmi_status_t
+    amdsmi_topo_get_p2p_status.argtypes = [amdsmi_processor_handle, amdsmi_processor_handle, ctypes.POINTER(amdsmi_link_type_t), ctypes.POINTER(struct_amdsmi_p2p_capability_t)]
+except AttributeError:
+    pass
+try:
+    amdsmi_get_gpu_compute_partition = _libraries['libamd_smi.so'].amdsmi_get_gpu_compute_partition
+    amdsmi_get_gpu_compute_partition.restype = amdsmi_status_t
+    amdsmi_get_gpu_compute_partition.argtypes = [amdsmi_processor_handle, ctypes.POINTER(ctypes.c_char), uint32_t]
+except AttributeError:
+    pass
+try:
+    amdsmi_set_gpu_compute_partition = _libraries['libamd_smi.so'].amdsmi_set_gpu_compute_partition
+    amdsmi_set_gpu_compute_partition.restype = amdsmi_status_t
+    amdsmi_set_gpu_compute_partition.argtypes = [amdsmi_processor_handle, amdsmi_compute_partition_type_t]
+except AttributeError:
+    pass
+try:
+    amdsmi_get_gpu_memory_partition = _libraries['libamd_smi.so'].amdsmi_get_gpu_memory_partition
+    amdsmi_get_gpu_memory_partition.restype = amdsmi_status_t
+    amdsmi_get_gpu_memory_partition.argtypes = [amdsmi_processor_handle, ctypes.POINTER(ctypes.c_char), uint32_t]
+except AttributeError:
+    pass
+try:
+    amdsmi_set_gpu_memory_partition = _libraries['libamd_smi.so'].amdsmi_set_gpu_memory_partition
+    amdsmi_set_gpu_memory_partition.restype = amdsmi_status_t
+    amdsmi_set_gpu_memory_partition.argtypes = [amdsmi_processor_handle, amdsmi_memory_partition_type_t]
+except AttributeError:
+    pass
+try:
+    amdsmi_get_gpu_memory_partition_config = _libraries['libamd_smi.so'].amdsmi_get_gpu_memory_partition_config
+    amdsmi_get_gpu_memory_partition_config.restype = amdsmi_status_t
+    amdsmi_get_gpu_memory_partition_config.argtypes = [amdsmi_processor_handle, ctypes.POINTER(struct_amdsmi_memory_partition_config_t)]
+except AttributeError:
+    pass
+try:
+    amdsmi_set_gpu_memory_partition_mode = _libraries['libamd_smi.so'].amdsmi_set_gpu_memory_partition_mode
+    amdsmi_set_gpu_memory_partition_mode.restype = amdsmi_status_t
+    amdsmi_set_gpu_memory_partition_mode.argtypes = [amdsmi_processor_handle, amdsmi_memory_partition_type_t]
+except AttributeError:
+    pass
+try:
+    amdsmi_get_gpu_accelerator_partition_profile_config = _libraries['libamd_smi.so'].amdsmi_get_gpu_accelerator_partition_profile_config
+    amdsmi_get_gpu_accelerator_partition_profile_config.restype = amdsmi_status_t
+    amdsmi_get_gpu_accelerator_partition_profile_config.argtypes = [amdsmi_processor_handle, ctypes.POINTER(struct_amdsmi_accelerator_partition_profile_config_t)]
+except AttributeError:
+    pass
+try:
+    amdsmi_get_gpu_accelerator_partition_profile = _libraries['libamd_smi.so'].amdsmi_get_gpu_accelerator_partition_profile
+    amdsmi_get_gpu_accelerator_partition_profile.restype = amdsmi_status_t
+    amdsmi_get_gpu_accelerator_partition_profile.argtypes = [amdsmi_processor_handle, ctypes.POINTER(struct_amdsmi_accelerator_partition_profile_t), ctypes.POINTER(ctypes.c_uint32)]
+except AttributeError:
+    pass
+try:
+    amdsmi_set_gpu_accelerator_partition_profile = _libraries['libamd_smi.so'].amdsmi_set_gpu_accelerator_partition_profile
+    amdsmi_set_gpu_accelerator_partition_profile.restype = amdsmi_status_t
+    amdsmi_set_gpu_accelerator_partition_profile.argtypes = [amdsmi_processor_handle, uint32_t]
+except AttributeError:
+    pass
+try:
+    amdsmi_init_gpu_event_notification = _libraries['libamd_smi.so'].amdsmi_init_gpu_event_notification
+    amdsmi_init_gpu_event_notification.restype = amdsmi_status_t
+    amdsmi_init_gpu_event_notification.argtypes = [amdsmi_processor_handle]
+except AttributeError:
+    pass
+try:
+    amdsmi_set_gpu_event_notification_mask = _libraries['libamd_smi.so'].amdsmi_set_gpu_event_notification_mask
+    amdsmi_set_gpu_event_notification_mask.restype = amdsmi_status_t
+    amdsmi_set_gpu_event_notification_mask.argtypes = [amdsmi_processor_handle, uint64_t]
+except AttributeError:
+    pass
+try:
+    amdsmi_get_gpu_event_notification = _libraries['libamd_smi.so'].amdsmi_get_gpu_event_notification
+    amdsmi_get_gpu_event_notification.restype = amdsmi_status_t
+    amdsmi_get_gpu_event_notification.argtypes = [ctypes.c_int32, ctypes.POINTER(ctypes.c_uint32), ctypes.POINTER(struct_amdsmi_evt_notification_data_t)]
+except AttributeError:
+    pass
+try:
+    amdsmi_stop_gpu_event_notification = _libraries['libamd_smi.so'].amdsmi_stop_gpu_event_notification
+    amdsmi_stop_gpu_event_notification.restype = amdsmi_status_t
+    amdsmi_stop_gpu_event_notification.argtypes = [amdsmi_processor_handle]
+except AttributeError:
+    pass
+try:
+    amdsmi_get_gpu_driver_info = _libraries['libamd_smi.so'].amdsmi_get_gpu_driver_info
+    amdsmi_get_gpu_driver_info.restype = amdsmi_status_t
+    amdsmi_get_gpu_driver_info.argtypes = [amdsmi_processor_handle, ctypes.POINTER(struct_amdsmi_driver_info_t)]
+except AttributeError:
+    pass
+try:
+    amdsmi_get_gpu_asic_info = _libraries['libamd_smi.so'].amdsmi_get_gpu_asic_info
+    amdsmi_get_gpu_asic_info.restype = amdsmi_status_t
+    amdsmi_get_gpu_asic_info.argtypes = [amdsmi_processor_handle, ctypes.POINTER(struct_amdsmi_asic_info_t)]
+except AttributeError:
+    pass
+try:
+    amdsmi_get_gpu_kfd_info = _libraries['libamd_smi.so'].amdsmi_get_gpu_kfd_info
+    amdsmi_get_gpu_kfd_info.restype = amdsmi_status_t
+    amdsmi_get_gpu_kfd_info.argtypes = [amdsmi_processor_handle, ctypes.POINTER(struct_amdsmi_kfd_info_t)]
+except AttributeError:
+    pass
+try:
+    amdsmi_get_gpu_vram_info = _libraries['libamd_smi.so'].amdsmi_get_gpu_vram_info
+    amdsmi_get_gpu_vram_info.restype = amdsmi_status_t
+    amdsmi_get_gpu_vram_info.argtypes = [amdsmi_processor_handle, ctypes.POINTER(struct_amdsmi_vram_info_t)]
+except AttributeError:
+    pass
+try:
+    amdsmi_get_gpu_board_info = _libraries['libamd_smi.so'].amdsmi_get_gpu_board_info
+    amdsmi_get_gpu_board_info.restype = amdsmi_status_t
+    amdsmi_get_gpu_board_info.argtypes = [amdsmi_processor_handle, ctypes.POINTER(struct_amdsmi_board_info_t)]
+except AttributeError:
+    pass
+try:
+    amdsmi_get_power_cap_info = _libraries['libamd_smi.so'].amdsmi_get_power_cap_info
+    amdsmi_get_power_cap_info.restype = amdsmi_status_t
+    amdsmi_get_power_cap_info.argtypes = [amdsmi_processor_handle, uint32_t, ctypes.POINTER(struct_amdsmi_power_cap_info_t)]
+except AttributeError:
+    pass
+try:
+    amdsmi_get_pcie_info = _libraries['libamd_smi.so'].amdsmi_get_pcie_info
+    amdsmi_get_pcie_info.restype = amdsmi_status_t
+    amdsmi_get_pcie_info.argtypes = [amdsmi_processor_handle, ctypes.POINTER(struct_amdsmi_pcie_info_t)]
+except AttributeError:
+    pass
+try:
+    amdsmi_get_gpu_xcd_counter = _libraries['libamd_smi.so'].amdsmi_get_gpu_xcd_counter
+    amdsmi_get_gpu_xcd_counter.restype = amdsmi_status_t
+    amdsmi_get_gpu_xcd_counter.argtypes = [amdsmi_processor_handle, ctypes.POINTER(ctypes.c_uint16)]
+except AttributeError:
+    pass
+try:
+    amdsmi_get_npm_info = _libraries['libamd_smi.so'].amdsmi_get_npm_info
+    amdsmi_get_npm_info.restype = amdsmi_status_t
+    amdsmi_get_npm_info.argtypes = [amdsmi_node_handle, ctypes.POINTER(struct_amdsmi_npm_info_t)]
+except AttributeError:
+    pass
+try:
+    amdsmi_get_fw_info = _libraries['libamd_smi.so'].amdsmi_get_fw_info
+    amdsmi_get_fw_info.restype = amdsmi_status_t
+    amdsmi_get_fw_info.argtypes = [amdsmi_processor_handle, ctypes.POINTER(struct_amdsmi_fw_info_t)]
+except AttributeError:
+    pass
+try:
+    amdsmi_get_gpu_vbios_info = _libraries['libamd_smi.so'].amdsmi_get_gpu_vbios_info
+    amdsmi_get_gpu_vbios_info.restype = amdsmi_status_t
+    amdsmi_get_gpu_vbios_info.argtypes = [amdsmi_processor_handle, ctypes.POINTER(struct_amdsmi_vbios_info_t)]
+except AttributeError:
+    pass
+try:
+    amdsmi_get_temp_metric = _libraries['libamd_smi.so'].amdsmi_get_temp_metric
+    amdsmi_get_temp_metric.restype = amdsmi_status_t
+    amdsmi_get_temp_metric.argtypes = [amdsmi_processor_handle, amdsmi_temperature_type_t, amdsmi_temperature_metric_t, ctypes.POINTER(ctypes.c_int64)]
+except AttributeError:
+    pass
+try:
+    amdsmi_get_gpu_activity = _libraries['libamd_smi.so'].amdsmi_get_gpu_activity
+    amdsmi_get_gpu_activity.restype = amdsmi_status_t
+    amdsmi_get_gpu_activity.argtypes = [amdsmi_processor_handle, ctypes.POINTER(struct_amdsmi_engine_usage_t)]
+except AttributeError:
+    pass
+try:
+    amdsmi_get_power_info = _libraries['libamd_smi.so'].amdsmi_get_power_info
+    amdsmi_get_power_info.restype = amdsmi_status_t
+    amdsmi_get_power_info.argtypes = [amdsmi_processor_handle, ctypes.POINTER(struct_amdsmi_power_info_t)]
+except AttributeError:
+    pass
+try:
+    amdsmi_is_gpu_power_management_enabled = _libraries['libamd_smi.so'].amdsmi_is_gpu_power_management_enabled
+    amdsmi_is_gpu_power_management_enabled.restype = amdsmi_status_t
+    amdsmi_is_gpu_power_management_enabled.argtypes = [amdsmi_processor_handle, ctypes.POINTER(ctypes.c_bool)]
+except AttributeError:
+    pass
+try:
+    amdsmi_get_clock_info = _libraries['libamd_smi.so'].amdsmi_get_clock_info
+    amdsmi_get_clock_info.restype = amdsmi_status_t
+    amdsmi_get_clock_info.argtypes = [amdsmi_processor_handle, amdsmi_clk_type_t, ctypes.POINTER(struct_amdsmi_clk_info_t)]
+except AttributeError:
+    pass
+try:
+    amdsmi_get_gpu_vram_usage = _libraries['libamd_smi.so'].amdsmi_get_gpu_vram_usage
+    amdsmi_get_gpu_vram_usage.restype = amdsmi_status_t
+    amdsmi_get_gpu_vram_usage.argtypes = [amdsmi_processor_handle, ctypes.POINTER(struct_amdsmi_vram_usage_t)]
+except AttributeError:
+    pass
+try:
+    amdsmi_get_violation_status = _libraries['libamd_smi.so'].amdsmi_get_violation_status
+    amdsmi_get_violation_status.restype = amdsmi_status_t
+    amdsmi_get_violation_status.argtypes = [amdsmi_processor_handle, ctypes.POINTER(struct_amdsmi_violation_status_t)]
+except AttributeError:
+    pass
+try:
+    amdsmi_get_gpu_process_list = _libraries['libamd_smi.so'].amdsmi_get_gpu_process_list
+    amdsmi_get_gpu_process_list.restype = amdsmi_status_t
+    amdsmi_get_gpu_process_list.argtypes = [amdsmi_processor_handle, ctypes.POINTER(ctypes.c_uint32), ctypes.POINTER(struct_amdsmi_proc_info_t)]
+except AttributeError:
+    pass
+try:
+    amdsmi_gpu_driver_reload = _libraries['libamd_smi.so'].amdsmi_gpu_driver_reload
+    amdsmi_gpu_driver_reload.restype = amdsmi_status_t
+    amdsmi_gpu_driver_reload.argtypes = []
+except AttributeError:
+    pass
+try:
+    amdsmi_get_gpu_ptl_state = _libraries['libamd_smi.so'].amdsmi_get_gpu_ptl_state
+    amdsmi_get_gpu_ptl_state.restype = amdsmi_status_t
+    amdsmi_get_gpu_ptl_state.argtypes = [amdsmi_processor_handle, ctypes.POINTER(ctypes.c_bool)]
+except AttributeError:
+    pass
+try:
+    amdsmi_set_gpu_ptl_state = _libraries['libamd_smi.so'].amdsmi_set_gpu_ptl_state
+    amdsmi_set_gpu_ptl_state.restype = amdsmi_status_t
+    amdsmi_set_gpu_ptl_state.argtypes = [amdsmi_processor_handle, ctypes.c_bool]
+except AttributeError:
+    pass
+try:
+    amdsmi_get_gpu_ptl_formats = _libraries['libamd_smi.so'].amdsmi_get_gpu_ptl_formats
+    amdsmi_get_gpu_ptl_formats.restype = amdsmi_status_t
+    amdsmi_get_gpu_ptl_formats.argtypes = [amdsmi_processor_handle, ctypes.POINTER(amdsmi_ptl_data_format_t), ctypes.POINTER(amdsmi_ptl_data_format_t)]
+except AttributeError:
+    pass
+try:
+    amdsmi_set_gpu_ptl_formats = _libraries['libamd_smi.so'].amdsmi_set_gpu_ptl_formats
+    amdsmi_set_gpu_ptl_formats.restype = amdsmi_status_t
+    amdsmi_set_gpu_ptl_formats.argtypes = [amdsmi_processor_handle, amdsmi_ptl_data_format_t, amdsmi_ptl_data_format_t]
+except AttributeError:
+    pass
+try:
+    amdsmi_get_cpu_core_energy = _libraries['libamd_smi.so'].amdsmi_get_cpu_core_energy
+    amdsmi_get_cpu_core_energy.restype = amdsmi_status_t
+    amdsmi_get_cpu_core_energy.argtypes = [amdsmi_processor_handle, ctypes.POINTER(ctypes.c_uint64)]
+except AttributeError:
+    pass
+try:
+    amdsmi_get_cpu_socket_energy = _libraries['libamd_smi.so'].amdsmi_get_cpu_socket_energy
+    amdsmi_get_cpu_socket_energy.restype = amdsmi_status_t
+    amdsmi_get_cpu_socket_energy.argtypes = [amdsmi_processor_handle, ctypes.POINTER(ctypes.c_uint64)]
+except AttributeError:
+    pass
+try:
+    amdsmi_get_threads_per_core = _libraries['libamd_smi.so'].amdsmi_get_threads_per_core
+    amdsmi_get_threads_per_core.restype = amdsmi_status_t
+    amdsmi_get_threads_per_core.argtypes = [ctypes.POINTER(ctypes.c_uint32)]
+except AttributeError:
+    pass
+try:
+    amdsmi_get_cpu_hsmp_driver_version = _libraries['libamd_smi.so'].amdsmi_get_cpu_hsmp_driver_version
+    amdsmi_get_cpu_hsmp_driver_version.restype = amdsmi_status_t
+    amdsmi_get_cpu_hsmp_driver_version.argtypes = [amdsmi_processor_handle, ctypes.POINTER(struct_amdsmi_hsmp_driver_version_t)]
+except AttributeError:
+    pass
+try:
+    amdsmi_get_cpu_smu_fw_version = _libraries['libamd_smi.so'].amdsmi_get_cpu_smu_fw_version
+    amdsmi_get_cpu_smu_fw_version.restype = amdsmi_status_t
+    amdsmi_get_cpu_smu_fw_version.argtypes = [amdsmi_processor_handle, ctypes.POINTER(struct_amdsmi_smu_fw_version_t)]
+except AttributeError:
+    pass
+try:
+    amdsmi_get_cpu_hsmp_proto_ver = _libraries['libamd_smi.so'].amdsmi_get_cpu_hsmp_proto_ver
+    amdsmi_get_cpu_hsmp_proto_ver.restype = amdsmi_status_t
+    amdsmi_get_cpu_hsmp_proto_ver.argtypes = [amdsmi_processor_handle, ctypes.POINTER(ctypes.c_uint32)]
+except AttributeError:
+    pass
+try:
+    amdsmi_get_cpu_prochot_status = _libraries['libamd_smi.so'].amdsmi_get_cpu_prochot_status
+    amdsmi_get_cpu_prochot_status.restype = amdsmi_status_t
+    amdsmi_get_cpu_prochot_status.argtypes = [amdsmi_processor_handle, ctypes.POINTER(ctypes.c_uint32)]
+except AttributeError:
+    pass
+try:
+    amdsmi_get_cpu_fclk_mclk = _libraries['libamd_smi.so'].amdsmi_get_cpu_fclk_mclk
+    amdsmi_get_cpu_fclk_mclk.restype = amdsmi_status_t
+    amdsmi_get_cpu_fclk_mclk.argtypes = [amdsmi_processor_handle, ctypes.POINTER(ctypes.c_uint32), ctypes.POINTER(ctypes.c_uint32)]
+except AttributeError:
+    pass
+try:
+    amdsmi_get_cpu_cclk_limit = _libraries['libamd_smi.so'].amdsmi_get_cpu_cclk_limit
+    amdsmi_get_cpu_cclk_limit.restype = amdsmi_status_t
+    amdsmi_get_cpu_cclk_limit.argtypes = [amdsmi_processor_handle, ctypes.POINTER(ctypes.c_uint32)]
+except AttributeError:
+    pass
+try:
+    amdsmi_get_cpu_socket_current_active_freq_limit = _libraries['libamd_smi.so'].amdsmi_get_cpu_socket_current_active_freq_limit
+    amdsmi_get_cpu_socket_current_active_freq_limit.restype = amdsmi_status_t
+    amdsmi_get_cpu_socket_current_active_freq_limit.argtypes = [amdsmi_processor_handle, ctypes.POINTER(ctypes.c_uint16), ctypes.POINTER(ctypes.POINTER(ctypes.c_char))]
+except AttributeError:
+    pass
+try:
+    amdsmi_get_cpu_socket_freq_range = _libraries['libamd_smi.so'].amdsmi_get_cpu_socket_freq_range
+    amdsmi_get_cpu_socket_freq_range.restype = amdsmi_status_t
+    amdsmi_get_cpu_socket_freq_range.argtypes = [amdsmi_processor_handle, ctypes.POINTER(ctypes.c_uint16), ctypes.POINTER(ctypes.c_uint16)]
+except AttributeError:
+    pass
+try:
+    amdsmi_get_cpu_core_current_freq_limit = _libraries['libamd_smi.so'].amdsmi_get_cpu_core_current_freq_limit
+    amdsmi_get_cpu_core_current_freq_limit.restype = amdsmi_status_t
+    amdsmi_get_cpu_core_current_freq_limit.argtypes = [amdsmi_processor_handle, ctypes.POINTER(ctypes.c_uint32)]
+except AttributeError:
+    pass
+try:
+    amdsmi_set_cpu_rail_isofreq_policy = _libraries['libamd_smi.so'].amdsmi_set_cpu_rail_isofreq_policy
+    amdsmi_set_cpu_rail_isofreq_policy.restype = amdsmi_status_t
+    amdsmi_set_cpu_rail_isofreq_policy.argtypes = [amdsmi_processor_handle, ctypes.POINTER(ctypes.c_bool)]
+except AttributeError:
+    pass
+try:
+    amdsmi_get_cpu_rail_isofreq_policy = _libraries['libamd_smi.so'].amdsmi_get_cpu_rail_isofreq_policy
+    amdsmi_get_cpu_rail_isofreq_policy.restype = amdsmi_status_t
+    amdsmi_get_cpu_rail_isofreq_policy.argtypes = [amdsmi_processor_handle, ctypes.POINTER(ctypes.c_ubyte)]
+except AttributeError:
+    pass
+try:
+    amdsmi_set_cpu_dfc_ctrl = _libraries['libamd_smi.so'].amdsmi_set_cpu_dfc_ctrl
+    amdsmi_set_cpu_dfc_ctrl.restype = amdsmi_status_t
+    amdsmi_set_cpu_dfc_ctrl.argtypes = [amdsmi_processor_handle, ctypes.POINTER(ctypes.c_ubyte)]
+except AttributeError:
+    pass
+try:
+    amdsmi_get_cpu_dfc_ctrl = _libraries['libamd_smi.so'].amdsmi_get_cpu_dfc_ctrl
+    amdsmi_get_cpu_dfc_ctrl.restype = amdsmi_status_t
+    amdsmi_get_cpu_dfc_ctrl.argtypes = [amdsmi_processor_handle, ctypes.POINTER(ctypes.c_ubyte)]
+except AttributeError:
+    pass
+try:
+    amdsmi_get_cpu_core_boostlimit = _libraries['libamd_smi.so'].amdsmi_get_cpu_core_boostlimit
+    amdsmi_get_cpu_core_boostlimit.restype = amdsmi_status_t
+    amdsmi_get_cpu_core_boostlimit.argtypes = [amdsmi_processor_handle, ctypes.POINTER(ctypes.c_uint32)]
+except AttributeError:
+    pass
+try:
+    amdsmi_get_cpu_socket_c0_residency = _libraries['libamd_smi.so'].amdsmi_get_cpu_socket_c0_residency
+    amdsmi_get_cpu_socket_c0_residency.restype = amdsmi_status_t
+    amdsmi_get_cpu_socket_c0_residency.argtypes = [amdsmi_processor_handle, ctypes.POINTER(ctypes.c_uint32)]
+except AttributeError:
+    pass
+try:
+    amdsmi_set_cpu_core_boostlimit = _libraries['libamd_smi.so'].amdsmi_set_cpu_core_boostlimit
+    amdsmi_set_cpu_core_boostlimit.restype = amdsmi_status_t
+    amdsmi_set_cpu_core_boostlimit.argtypes = [amdsmi_processor_handle, uint32_t]
+except AttributeError:
+    pass
+try:
+    amdsmi_set_cpu_socket_boostlimit = _libraries['libamd_smi.so'].amdsmi_set_cpu_socket_boostlimit
+    amdsmi_set_cpu_socket_boostlimit.restype = amdsmi_status_t
+    amdsmi_set_cpu_socket_boostlimit.argtypes = [amdsmi_processor_handle, uint32_t]
+except AttributeError:
+    pass
+try:
+    amdsmi_get_cpu_core_floor_freq_limit = _libraries['libamd_smi.so'].amdsmi_get_cpu_core_floor_freq_limit
+    amdsmi_get_cpu_core_floor_freq_limit.restype = amdsmi_status_t
+    amdsmi_get_cpu_core_floor_freq_limit.argtypes = [amdsmi_processor_handle, ctypes.POINTER(ctypes.c_uint32)]
+except AttributeError:
+    pass
+try:
+    amdsmi_get_cpu_floor_freq_limit = _libraries['libamd_smi.so'].amdsmi_get_cpu_floor_freq_limit
+    amdsmi_get_cpu_floor_freq_limit.restype = amdsmi_status_t
+    amdsmi_get_cpu_floor_freq_limit.argtypes = [amdsmi_processor_handle, ctypes.POINTER(ctypes.c_uint32)]
+except AttributeError:
+    pass
+try:
+    amdsmi_get_cpu_core_eff_floor_freq_limit = _libraries['libamd_smi.so'].amdsmi_get_cpu_core_eff_floor_freq_limit
+    amdsmi_get_cpu_core_eff_floor_freq_limit.restype = amdsmi_status_t
+    amdsmi_get_cpu_core_eff_floor_freq_limit.argtypes = [amdsmi_processor_handle, ctypes.POINTER(ctypes.c_uint32)]
+except AttributeError:
+    pass
+try:
+    amdsmi_get_cpu_eff_floor_freq_limit = _libraries['libamd_smi.so'].amdsmi_get_cpu_eff_floor_freq_limit
+    amdsmi_get_cpu_eff_floor_freq_limit.restype = amdsmi_status_t
+    amdsmi_get_cpu_eff_floor_freq_limit.argtypes = [amdsmi_processor_handle, ctypes.POINTER(ctypes.c_uint32)]
+except AttributeError:
+    pass
+try:
+    amdsmi_set_cpu_core_floor_freq_limit = _libraries['libamd_smi.so'].amdsmi_set_cpu_core_floor_freq_limit
+    amdsmi_set_cpu_core_floor_freq_limit.restype = amdsmi_status_t
+    amdsmi_set_cpu_core_floor_freq_limit.argtypes = [amdsmi_processor_handle, uint32_t]
+except AttributeError:
+    pass
+try:
+    amdsmi_set_cpu_floor_freq_limit = _libraries['libamd_smi.so'].amdsmi_set_cpu_floor_freq_limit
+    amdsmi_set_cpu_floor_freq_limit.restype = amdsmi_status_t
+    amdsmi_set_cpu_floor_freq_limit.argtypes = [amdsmi_processor_handle, uint32_t]
+except AttributeError:
+    pass
+try:
+    amdsmi_set_cpu_msr_floor_freq_limit = _libraries['libamd_smi.so'].amdsmi_set_cpu_msr_floor_freq_limit
+    amdsmi_set_cpu_msr_floor_freq_limit.restype = amdsmi_status_t
+    amdsmi_set_cpu_msr_floor_freq_limit.argtypes = [amdsmi_processor_handle, uint32_t]
+except AttributeError:
+    pass
+try:
+    amdsmi_set_cpu_core_msr_floor_freq_limit = _libraries['libamd_smi.so'].amdsmi_set_cpu_core_msr_floor_freq_limit
+    amdsmi_set_cpu_core_msr_floor_freq_limit.restype = amdsmi_status_t
+    amdsmi_set_cpu_core_msr_floor_freq_limit.argtypes = [amdsmi_processor_handle, uint32_t]
+except AttributeError:
+    pass
+try:
+    amdsmi_get_cpu_freq_range = _libraries['libamd_smi.so'].amdsmi_get_cpu_freq_range
+    amdsmi_get_cpu_freq_range.restype = amdsmi_status_t
+    amdsmi_get_cpu_freq_range.argtypes = [ctypes.POINTER(ctypes.c_uint32), ctypes.POINTER(ctypes.c_uint32)]
+except AttributeError:
+    pass
+try:
+    amdsmi_set_cpu_sdps_limit = _libraries['libamd_smi.so'].amdsmi_set_cpu_sdps_limit
+    amdsmi_set_cpu_sdps_limit.restype = amdsmi_status_t
+    amdsmi_set_cpu_sdps_limit.argtypes = [amdsmi_processor_handle, uint32_t]
+except AttributeError:
+    pass
+try:
+    amdsmi_get_cpu_sdps_limit = _libraries['libamd_smi.so'].amdsmi_get_cpu_sdps_limit
+    amdsmi_get_cpu_sdps_limit.restype = amdsmi_status_t
+    amdsmi_get_cpu_sdps_limit.argtypes = [amdsmi_processor_handle, ctypes.POINTER(ctypes.c_double)]
+except AttributeError:
+    pass
+try:
+    amdsmi_get_cpu_ddr_bw = _libraries['libamd_smi.so'].amdsmi_get_cpu_ddr_bw
+    amdsmi_get_cpu_ddr_bw.restype = amdsmi_status_t
+    amdsmi_get_cpu_ddr_bw.argtypes = [amdsmi_processor_handle, ctypes.POINTER(struct_amdsmi_ddr_bw_metrics_t)]
+except AttributeError:
+    pass
+try:
+    amdsmi_get_cpu_socket_temperature = _libraries['libamd_smi.so'].amdsmi_get_cpu_socket_temperature
+    amdsmi_get_cpu_socket_temperature.restype = amdsmi_status_t
+    amdsmi_get_cpu_socket_temperature.argtypes = [amdsmi_processor_handle, ctypes.POINTER(ctypes.c_uint32)]
+except AttributeError:
+    pass
+try:
+    amdsmi_get_cpu_tdelta = _libraries['libamd_smi.so'].amdsmi_get_cpu_tdelta
+    amdsmi_get_cpu_tdelta.restype = amdsmi_status_t
+    amdsmi_get_cpu_tdelta.argtypes = [amdsmi_processor_handle, ctypes.POINTER(ctypes.c_ubyte)]
+except AttributeError:
+    pass
+try:
+    amdsmi_get_cpu_svi3_vr_controller_temp = _libraries['libamd_smi.so'].amdsmi_get_cpu_svi3_vr_controller_temp
+    amdsmi_get_cpu_svi3_vr_controller_temp.restype = amdsmi_status_t
+    amdsmi_get_cpu_svi3_vr_controller_temp.argtypes = [amdsmi_processor_handle, ctypes.POINTER(ctypes.c_uint32), ctypes.POINTER(ctypes.c_uint32), ctypes.POINTER(ctypes.c_uint32)]
+except AttributeError:
+    pass
+try:
+    amdsmi_get_cpu_dimm_temp_range_and_refresh_rate = _libraries['libamd_smi.so'].amdsmi_get_cpu_dimm_temp_range_and_refresh_rate
+    amdsmi_get_cpu_dimm_temp_range_and_refresh_rate.restype = amdsmi_status_t
+    amdsmi_get_cpu_dimm_temp_range_and_refresh_rate.argtypes = [amdsmi_processor_handle, uint8_t, ctypes.POINTER(struct_amdsmi_temp_range_refresh_rate_t)]
+except AttributeError:
+    pass
+try:
+    amdsmi_get_cpu_dimm_power_consumption = _libraries['libamd_smi.so'].amdsmi_get_cpu_dimm_power_consumption
+    amdsmi_get_cpu_dimm_power_consumption.restype = amdsmi_status_t
+    amdsmi_get_cpu_dimm_power_consumption.argtypes = [amdsmi_processor_handle, uint8_t, ctypes.POINTER(struct_amdsmi_dimm_power_t)]
+except AttributeError:
+    pass
+try:
+    amdsmi_get_cpu_dimm_thermal_sensor = _libraries['libamd_smi.so'].amdsmi_get_cpu_dimm_thermal_sensor
+    amdsmi_get_cpu_dimm_thermal_sensor.restype = amdsmi_status_t
+    amdsmi_get_cpu_dimm_thermal_sensor.argtypes = [amdsmi_processor_handle, uint8_t, ctypes.POINTER(struct_amdsmi_dimm_thermal_t)]
+except AttributeError:
+    pass
+try:
+    amdsmi_get_cpu_dimm_sb_reg = _libraries['libamd_smi.so'].amdsmi_get_cpu_dimm_sb_reg
+    amdsmi_get_cpu_dimm_sb_reg.restype = amdsmi_status_t
+    amdsmi_get_cpu_dimm_sb_reg.argtypes = [amdsmi_processor_handle, uint32_t, uint32_t, uint32_t, uint32_t, ctypes.POINTER(ctypes.c_uint32)]
+except AttributeError:
+    pass
+try:
+    amdsmi_set_cpu_dimm_sb_reg = _libraries['libamd_smi.so'].amdsmi_set_cpu_dimm_sb_reg
+    amdsmi_set_cpu_dimm_sb_reg.restype = amdsmi_status_t
+    amdsmi_set_cpu_dimm_sb_reg.argtypes = [amdsmi_processor_handle, uint32_t, uint32_t, uint32_t, uint32_t, uint32_t]
+except AttributeError:
+    pass
+try:
+    amdsmi_set_cpu_xgmi_width = _libraries['libamd_smi.so'].amdsmi_set_cpu_xgmi_width
+    amdsmi_set_cpu_xgmi_width.restype = amdsmi_status_t
+    amdsmi_set_cpu_xgmi_width.argtypes = [amdsmi_processor_handle, uint8_t, uint8_t]
+except AttributeError:
+    pass
+try:
+    amdsmi_set_cpu_gmi3_link_width_range = _libraries['libamd_smi.so'].amdsmi_set_cpu_gmi3_link_width_range
+    amdsmi_set_cpu_gmi3_link_width_range.restype = amdsmi_status_t
+    amdsmi_set_cpu_gmi3_link_width_range.argtypes = [amdsmi_processor_handle, uint8_t, uint8_t]
+except AttributeError:
+    pass
+try:
+    amdsmi_cpu_apb_enable = _libraries['libamd_smi.so'].amdsmi_cpu_apb_enable
+    amdsmi_cpu_apb_enable.restype = amdsmi_status_t
+    amdsmi_cpu_apb_enable.argtypes = [amdsmi_processor_handle]
+except AttributeError:
+    pass
+try:
+    amdsmi_cpu_apb_disable = _libraries['libamd_smi.so'].amdsmi_cpu_apb_disable
+    amdsmi_cpu_apb_disable.restype = amdsmi_status_t
+    amdsmi_cpu_apb_disable.argtypes = [amdsmi_processor_handle, uint8_t]
+except AttributeError:
+    pass
+try:
+    amdsmi_set_cpu_socket_lclk_dpm_level = _libraries['libamd_smi.so'].amdsmi_set_cpu_socket_lclk_dpm_level
+    amdsmi_set_cpu_socket_lclk_dpm_level.restype = amdsmi_status_t
+    amdsmi_set_cpu_socket_lclk_dpm_level.argtypes = [amdsmi_processor_handle, uint8_t, uint8_t, uint8_t]
+except AttributeError:
+    pass
+try:
+    amdsmi_get_cpu_socket_lclk_dpm_level = _libraries['libamd_smi.so'].amdsmi_get_cpu_socket_lclk_dpm_level
+    amdsmi_get_cpu_socket_lclk_dpm_level.restype = amdsmi_status_t
+    amdsmi_get_cpu_socket_lclk_dpm_level.argtypes = [amdsmi_processor_handle, uint8_t, ctypes.POINTER(struct_amdsmi_dpm_level_t)]
+except AttributeError:
+    pass
+try:
+    amdsmi_set_cpu_pcie_link_rate = _libraries['libamd_smi.so'].amdsmi_set_cpu_pcie_link_rate
+    amdsmi_set_cpu_pcie_link_rate.restype = amdsmi_status_t
+    amdsmi_set_cpu_pcie_link_rate.argtypes = [amdsmi_processor_handle, uint8_t, ctypes.POINTER(ctypes.c_ubyte)]
+except AttributeError:
+    pass
+try:
+    amdsmi_set_cpu_df_pstate_range = _libraries['libamd_smi.so'].amdsmi_set_cpu_df_pstate_range
+    amdsmi_set_cpu_df_pstate_range.restype = amdsmi_status_t
+    amdsmi_set_cpu_df_pstate_range.argtypes = [amdsmi_processor_handle, uint8_t, uint8_t]
+except AttributeError:
+    pass
+try:
+    amdsmi_set_cpu_xgmi_pstate_range = _libraries['libamd_smi.so'].amdsmi_set_cpu_xgmi_pstate_range
+    amdsmi_set_cpu_xgmi_pstate_range.restype = amdsmi_status_t
+    amdsmi_set_cpu_xgmi_pstate_range.argtypes = [amdsmi_processor_handle, uint8_t, uint8_t]
+except AttributeError:
+    pass
+try:
+    amdsmi_get_cpu_xgmi_pstate_range = _libraries['libamd_smi.so'].amdsmi_get_cpu_xgmi_pstate_range
+    amdsmi_get_cpu_xgmi_pstate_range.restype = amdsmi_status_t
+    amdsmi_get_cpu_xgmi_pstate_range.argtypes = [amdsmi_processor_handle, ctypes.POINTER(ctypes.c_ubyte), ctypes.POINTER(ctypes.c_ubyte)]
+except AttributeError:
+    pass
+try:
+    amdsmi_get_cpu_pc6_enable = _libraries['libamd_smi.so'].amdsmi_get_cpu_pc6_enable
+    amdsmi_get_cpu_pc6_enable.restype = amdsmi_status_t
+    amdsmi_get_cpu_pc6_enable.argtypes = [amdsmi_processor_handle, ctypes.POINTER(ctypes.c_ubyte)]
+except AttributeError:
+    pass
+try:
+    amdsmi_set_cpu_pc6_enable = _libraries['libamd_smi.so'].amdsmi_set_cpu_pc6_enable
+    amdsmi_set_cpu_pc6_enable.restype = amdsmi_status_t
+    amdsmi_set_cpu_pc6_enable.argtypes = [amdsmi_processor_handle, uint8_t]
+except AttributeError:
+    pass
+try:
+    amdsmi_get_cpu_cc6_enable = _libraries['libamd_smi.so'].amdsmi_get_cpu_cc6_enable
+    amdsmi_get_cpu_cc6_enable.restype = amdsmi_status_t
+    amdsmi_get_cpu_cc6_enable.argtypes = [amdsmi_processor_handle, ctypes.POINTER(ctypes.c_ubyte)]
+except AttributeError:
+    pass
+try:
+    amdsmi_set_cpu_cc6_enable = _libraries['libamd_smi.so'].amdsmi_set_cpu_cc6_enable
+    amdsmi_set_cpu_cc6_enable.restype = amdsmi_status_t
+    amdsmi_set_cpu_cc6_enable.argtypes = [amdsmi_processor_handle, uint8_t]
+except AttributeError:
+    pass
+try:
+    amdsmi_get_cpu_current_io_bandwidth = _libraries['libamd_smi.so'].amdsmi_get_cpu_current_io_bandwidth
+    amdsmi_get_cpu_current_io_bandwidth.restype = amdsmi_status_t
+    amdsmi_get_cpu_current_io_bandwidth.argtypes = [amdsmi_processor_handle, amdsmi_link_id_bw_type_t, ctypes.POINTER(ctypes.c_uint32)]
+except AttributeError:
+    pass
+try:
+    amdsmi_get_cpu_current_xgmi_bw = _libraries['libamd_smi.so'].amdsmi_get_cpu_current_xgmi_bw
+    amdsmi_get_cpu_current_xgmi_bw.restype = amdsmi_status_t
+    amdsmi_get_cpu_current_xgmi_bw.argtypes = [amdsmi_processor_handle, amdsmi_link_id_bw_type_t, ctypes.POINTER(ctypes.c_uint32)]
+except AttributeError:
+    pass
+try:
+    amdsmi_get_hsmp_metrics_table_version = _libraries['libamd_smi.so'].amdsmi_get_hsmp_metrics_table_version
+    amdsmi_get_hsmp_metrics_table_version.restype = amdsmi_status_t
+    amdsmi_get_hsmp_metrics_table_version.argtypes = [amdsmi_processor_handle, ctypes.POINTER(ctypes.c_uint32)]
+except AttributeError:
+    pass
+try:
+    amdsmi_get_hsmp_metrics_table = _libraries['libamd_smi.so'].amdsmi_get_hsmp_metrics_table
+    amdsmi_get_hsmp_metrics_table.restype = amdsmi_status_t
+    amdsmi_get_hsmp_metrics_table.argtypes = [amdsmi_processor_handle, ctypes.POINTER(struct_amdsmi_hsmp_metrics_table_t)]
+except AttributeError:
+    pass
+try:
+    amdsmi_first_online_core_on_cpu_socket = _libraries['libamd_smi.so'].amdsmi_first_online_core_on_cpu_socket
+    amdsmi_first_online_core_on_cpu_socket.restype = amdsmi_status_t
+    amdsmi_first_online_core_on_cpu_socket.argtypes = [amdsmi_processor_handle, ctypes.POINTER(ctypes.c_uint32)]
+except AttributeError:
+    pass
+try:
+    amdsmi_get_cpu_family = _libraries['libamd_smi.so'].amdsmi_get_cpu_family
+    amdsmi_get_cpu_family.restype = amdsmi_status_t
+    amdsmi_get_cpu_family.argtypes = [ctypes.POINTER(ctypes.c_uint32)]
+except AttributeError:
+    pass
+try:
+    amdsmi_get_cpu_model = _libraries['libamd_smi.so'].amdsmi_get_cpu_model
+    amdsmi_get_cpu_model.restype = amdsmi_status_t
+    amdsmi_get_cpu_model.argtypes = [ctypes.POINTER(ctypes.c_uint32)]
+except AttributeError:
+    pass
+try:
+    amdsmi_get_cpu_model_name = _libraries['libamd_smi.so'].amdsmi_get_cpu_model_name
+    amdsmi_get_cpu_model_name.restype = amdsmi_status_t
+    amdsmi_get_cpu_model_name.argtypes = [amdsmi_processor_handle, ctypes.POINTER(struct_amdsmi_cpu_info_t)]
+except AttributeError:
+    pass
+try:
+    amdsmi_get_esmi_err_msg = _libraries['libamd_smi.so'].amdsmi_get_esmi_err_msg
+    amdsmi_get_esmi_err_msg.restype = amdsmi_status_t
+    amdsmi_get_esmi_err_msg.argtypes = [amdsmi_status_t, ctypes.POINTER(ctypes.POINTER(ctypes.c_char))]
+except AttributeError:
+    pass
+try:
+    amdsmi_get_cpu_cores_per_socket = _libraries['libamd_smi.so'].amdsmi_get_cpu_cores_per_socket
+    amdsmi_get_cpu_cores_per_socket.restype = amdsmi_status_t
+    amdsmi_get_cpu_cores_per_socket.argtypes = [uint32_t, ctypes.POINTER(struct_amdsmi_sock_info_t)]
+except AttributeError:
+    pass
+try:
+    amdsmi_get_cpu_socket_count = _libraries['libamd_smi.so'].amdsmi_get_cpu_socket_count
+    amdsmi_get_cpu_socket_count.restype = amdsmi_status_t
+    amdsmi_get_cpu_socket_count.argtypes = [ctypes.POINTER(ctypes.c_uint32)]
+except AttributeError:
+    pass
+try:
+    amdsmi_get_cpu_enabled_commands = _libraries['libamd_smi.so'].amdsmi_get_cpu_enabled_commands
+    amdsmi_get_cpu_enabled_commands.restype = amdsmi_status_t
+    amdsmi_get_cpu_enabled_commands.argtypes = [amdsmi_processor_handle, ctypes.POINTER(ctypes.c_bool), ctypes.POINTER(ctypes.c_uint32), ctypes.POINTER(ctypes.c_uint32), ctypes.POINTER(ctypes.c_uint32)]
+except AttributeError:
+    pass
+try:
+    amdsmi_get_nic_driver_info = _libraries['libamd_smi.so'].amdsmi_get_nic_driver_info
+    amdsmi_get_nic_driver_info.restype = amdsmi_status_t
+    amdsmi_get_nic_driver_info.argtypes = [amdsmi_processor_handle, ctypes.POINTER(struct_amdsmi_nic_driver_info_t)]
+except AttributeError:
+    pass
+try:
+    amdsmi_get_nic_asic_info = _libraries['libamd_smi.so'].amdsmi_get_nic_asic_info
+    amdsmi_get_nic_asic_info.restype = amdsmi_status_t
+    amdsmi_get_nic_asic_info.argtypes = [amdsmi_processor_handle, ctypes.POINTER(struct_amdsmi_nic_asic_info_t)]
+except AttributeError:
+    pass
+try:
+    amdsmi_get_nic_bus_info = _libraries['libamd_smi.so'].amdsmi_get_nic_bus_info
+    amdsmi_get_nic_bus_info.restype = amdsmi_status_t
+    amdsmi_get_nic_bus_info.argtypes = [amdsmi_processor_handle, ctypes.POINTER(struct_amdsmi_nic_bus_info_t)]
+except AttributeError:
+    pass
+try:
+    amdsmi_get_nic_numa_info = _libraries['libamd_smi.so'].amdsmi_get_nic_numa_info
+    amdsmi_get_nic_numa_info.restype = amdsmi_status_t
+    amdsmi_get_nic_numa_info.argtypes = [amdsmi_processor_handle, ctypes.POINTER(struct_amdsmi_nic_numa_info_t)]
+except AttributeError:
+    pass
+try:
+    amdsmi_get_nic_port_info = _libraries['libamd_smi.so'].amdsmi_get_nic_port_info
+    amdsmi_get_nic_port_info.restype = amdsmi_status_t
+    amdsmi_get_nic_port_info.argtypes = [amdsmi_processor_handle, ctypes.POINTER(struct_amdsmi_nic_port_info_t)]
+except AttributeError:
+    pass
+try:
+    amdsmi_get_nic_rdma_dev_info = _libraries['libamd_smi.so'].amdsmi_get_nic_rdma_dev_info
+    amdsmi_get_nic_rdma_dev_info.restype = amdsmi_status_t
+    amdsmi_get_nic_rdma_dev_info.argtypes = [amdsmi_processor_handle, ctypes.POINTER(struct_amdsmi_nic_rdma_devices_info_t)]
+except AttributeError:
+    pass
+try:
+    amdsmi_get_nic_rdma_port_statistics = _libraries['libamd_smi.so'].amdsmi_get_nic_rdma_port_statistics
+    amdsmi_get_nic_rdma_port_statistics.restype = amdsmi_status_t
+    amdsmi_get_nic_rdma_port_statistics.argtypes = [amdsmi_processor_handle, uint32_t, ctypes.POINTER(ctypes.c_uint32), ctypes.POINTER(struct_amdsmi_nic_stat_t)]
+except AttributeError:
+    pass
 class struct_amdsmi_uma_carveout_option_t(Structure):
     pass
 
@@ -3533,21 +4211,36 @@ struct_amdsmi_ttm_info_t._fields_ = [
 ]
 
 amdsmi_ttm_info_t = struct_amdsmi_ttm_info_t
-amdsmi_get_gpu_uma_carveout_info = _libraries['libamd_smi.so'].amdsmi_get_gpu_uma_carveout_info
-amdsmi_get_gpu_uma_carveout_info.restype = amdsmi_status_t
-amdsmi_get_gpu_uma_carveout_info.argtypes = [amdsmi_processor_handle, ctypes.POINTER(struct_amdsmi_uma_carveout_info_t)]
-amdsmi_set_gpu_uma_carveout = _libraries['libamd_smi.so'].amdsmi_set_gpu_uma_carveout
-amdsmi_set_gpu_uma_carveout.restype = amdsmi_status_t
-amdsmi_set_gpu_uma_carveout.argtypes = [amdsmi_processor_handle, uint32_t]
-amdsmi_get_ttm_info = _libraries['libamd_smi.so'].amdsmi_get_ttm_info
-amdsmi_get_ttm_info.restype = amdsmi_status_t
-amdsmi_get_ttm_info.argtypes = [ctypes.POINTER(struct_amdsmi_ttm_info_t)]
-amdsmi_set_ttm_pages_limit = _libraries['libamd_smi.so'].amdsmi_set_ttm_pages_limit
-amdsmi_set_ttm_pages_limit.restype = amdsmi_status_t
-amdsmi_set_ttm_pages_limit.argtypes = [uint64_t]
-amdsmi_reset_ttm_pages_limit = _libraries['libamd_smi.so'].amdsmi_reset_ttm_pages_limit
-amdsmi_reset_ttm_pages_limit.restype = amdsmi_status_t
-amdsmi_reset_ttm_pages_limit.argtypes = []
+try:
+    amdsmi_get_gpu_uma_carveout_info = _libraries['libamd_smi.so'].amdsmi_get_gpu_uma_carveout_info
+    amdsmi_get_gpu_uma_carveout_info.restype = amdsmi_status_t
+    amdsmi_get_gpu_uma_carveout_info.argtypes = [amdsmi_processor_handle, ctypes.POINTER(struct_amdsmi_uma_carveout_info_t)]
+except AttributeError:
+    pass
+try:
+    amdsmi_set_gpu_uma_carveout = _libraries['libamd_smi.so'].amdsmi_set_gpu_uma_carveout
+    amdsmi_set_gpu_uma_carveout.restype = amdsmi_status_t
+    amdsmi_set_gpu_uma_carveout.argtypes = [amdsmi_processor_handle, uint32_t]
+except AttributeError:
+    pass
+try:
+    amdsmi_get_ttm_info = _libraries['libamd_smi.so'].amdsmi_get_ttm_info
+    amdsmi_get_ttm_info.restype = amdsmi_status_t
+    amdsmi_get_ttm_info.argtypes = [ctypes.POINTER(struct_amdsmi_ttm_info_t)]
+except AttributeError:
+    pass
+try:
+    amdsmi_set_ttm_pages_limit = _libraries['libamd_smi.so'].amdsmi_set_ttm_pages_limit
+    amdsmi_set_ttm_pages_limit.restype = amdsmi_status_t
+    amdsmi_set_ttm_pages_limit.argtypes = [uint64_t]
+except AttributeError:
+    pass
+try:
+    amdsmi_reset_ttm_pages_limit = _libraries['libamd_smi.so'].amdsmi_reset_ttm_pages_limit
+    amdsmi_reset_ttm_pages_limit.restype = amdsmi_status_t
+    amdsmi_reset_ttm_pages_limit.argtypes = []
+except AttributeError:
+    pass
 __all__ = \
     ['AGG_BW0', 'AMDSMI_ACCELERATOR_DECODER',
     'AMDSMI_ACCELERATOR_DMA', 'AMDSMI_ACCELERATOR_ENCODER',
@@ -4062,15 +4755,15 @@ __all__ = \
     'struct_amdsmi_accelerator_partition_profile_config_t',
     'struct_amdsmi_accelerator_partition_profile_t',
     'struct_amdsmi_accelerator_partition_resource_profile_t',
-    'struct_amdsmi_asic_info_t', 'struct_amdsmi_board_info_t',
-    'struct_amdsmi_clk_info_t', 'struct_amdsmi_counter_value_t',
-    'struct_amdsmi_cper_guid_t', 'struct_amdsmi_cper_hdr_t',
-    'struct_amdsmi_cper_timestamp_t', 'struct_amdsmi_cpu_info_t',
-    'struct_amdsmi_cpu_util_t', 'struct_amdsmi_ddr_bw_metrics_t',
-    'struct_amdsmi_dimm_power_t', 'struct_amdsmi_dimm_thermal_t',
-    'struct_amdsmi_dpm_level_t', 'struct_amdsmi_dpm_policy_entry_t',
-    'struct_amdsmi_dpm_policy_t', 'struct_amdsmi_driver_info_t',
-    'struct_amdsmi_engine_usage_t',
+    'struct_amdsmi_asic_info_t', 'struct_amdsmi_bdf_t_1',
+    'struct_amdsmi_board_info_t', 'struct_amdsmi_clk_info_t',
+    'struct_amdsmi_counter_value_t', 'struct_amdsmi_cper_guid_t',
+    'struct_amdsmi_cper_hdr_t', 'struct_amdsmi_cper_timestamp_t',
+    'struct_amdsmi_cpu_info_t', 'struct_amdsmi_cpu_util_t',
+    'struct_amdsmi_ddr_bw_metrics_t', 'struct_amdsmi_dimm_power_t',
+    'struct_amdsmi_dimm_thermal_t', 'struct_amdsmi_dpm_level_t',
+    'struct_amdsmi_dpm_policy_entry_t', 'struct_amdsmi_dpm_policy_t',
+    'struct_amdsmi_driver_info_t', 'struct_amdsmi_engine_usage_t',
     'struct_amdsmi_enumeration_info_t', 'struct_amdsmi_error_count_t',
     'struct_amdsmi_evt_notification_data_t',
     'struct_amdsmi_freq_volt_region_t', 'struct_amdsmi_frequencies_t',
@@ -4113,7 +4806,6 @@ __all__ = \
     'struct_cache_', 'struct_engine_usage_', 'struct_fw_info_list_',
     'struct_memory_usage_', 'struct_nps_flags_', 'struct_numa_range_',
     'struct_pcie_metric_', 'struct_pcie_static_', 'struct_ras_info_',
-    'struct_amdsmi_bdf_t',
     'struct_valid_bits_', 'uint32_t', 'uint64_t', 'uint8_t',
     'union_amdsmi_bdf_t', 'union_amdsmi_cper_valid_bits_t',
     'union_amdsmi_nps_caps_t', 'union_policy_data_']


### PR DESCRIPTION
ctypeslib2 2.3.4 uses `nm --dynamic` to discover symbols but cannot
parse versioned ELF symbol names (e.g. `amdsmi_init@@AMDSMI_1`)
produced by the linker version script added in #3777. This caused
every function binding to fall back to FIXME_STUB.

ctypeslib2 2.4.0 strips the `@@VERSION` suffix from nm output
(upstream fix: trolldbois/ctypeslib#128), resolving the issue.

Closes #4026
