### PR TITLE
rocr: ASAN Fixes : Remove incorrect offset assertion in ExportDMABuf

### DIFF
--- a/projects/rocr-runtime/runtime/hsa-runtime/core/driver/kfd/amd_kfd_driver.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/driver/kfd/amd_kfd_driver.cpp
@@ -176,8 +176,11 @@ hsa_status_t KfdDriver::Close() {
 }
 
 hsa_status_t KfdDriver::GetSystemProperties(HsaSystemProperties& sys_props) const {
-  if (HSAKMT_CALL(hsaKmtReleaseSystemProperties()) != HSAKMT_STATUS_SUCCESS) return HSA_STATUS_ERROR;
-
+  // Note: We intentionally do NOT call hsaKmtReleaseSystemProperties() here.
+  // hsaKmtRuntimeEnable (called from Init) already acquired system properties.
+  // Releasing and re-acquiring would tear down FMM apertures and fail to
+  // re-acquire the VM because the kernel-side VM binding persists.
+  // hsaKmtAcquireSystemProperties handles the cached-snapshot case internally.
   if (HSAKMT_CALL(hsaKmtAcquireSystemProperties(&sys_props)) != HSAKMT_STATUS_SUCCESS) return HSA_STATUS_ERROR;
 
   return HSA_STATUS_SUCCESS;
@@ -448,8 +451,6 @@ hsa_status_t KfdDriver::ExportDMABuf(void *mem, size_t size, int *dmabuf_fd,
     }
     return HSA_STATUS_ERROR_OUT_OF_RESOURCES;
   }
-
-  assert(offset_res == 0);
 
   *dmabuf_fd = dmabuf_fd_res;
   *offset = offset_res;


### PR DESCRIPTION
Remove the assert(offset_res == 0) check in KfdDriver::ExportDMABuf() which incorrectly assumed the DMA buffer offset would always be zero.

The DMA buffer offset can be non-zero for contiguous allocations (HSA_AMD_MEMORY_POOL_CONTIGUOUS_FLAG). This matches the behavior in KfdVirtioDriver::ExportDMABuf which does not have this assertion.

Modify KfdDriver::GetSystemProperties() behavior to avoid calling hsaKmtReleaseSystemProperties() before acquiring system properties, with added explanatory comments.

ASAN Error Fixed:
    rocrtst64: amd_kfd_driver.cpp:455: virtual hsa_status_t
    rocr::AMD::KfdDriver::ExportDMABuf(void *, size_t, int *, size_t *):
    Assertion `offset_res == 0' failed.
    Aborted

Test: rocrtstFunc.MemoryAllocateContiguousTest now passes under ASAN

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
