### PR TITLE
rocrtst: ASAN Fixes: Fix MemoryAllocateContiguousTest size assertion …

### DIFF
--- a/projects/rocr-runtime/rocrtst/suites/functional/memory_allocation.cc
+++ b/projects/rocr-runtime/rocrtst/suites/functional/memory_allocation.cc
@@ -540,7 +540,10 @@ void MemoryAllocationTest::MemoryAllocateContiguousTest(hsa_agent_t agent,
                                                    &importedPtr, 0, NULL));
 
   ASSERT_NE(importedPtr, nullptr);
-  ASSERT_EQ(importedSz, alloc_size);
+  // When there's an offset in the DMA buffer export, the imported size includes
+  // the offset, so importedSz >= alloc_size + offset. The actual memory region
+  // starts at (reinterpret_cast<char*>(importedPtr) + offset) with size alloc_size.
+  ASSERT_GE(importedSz, alloc_size + offset);
 
   close(dmabuf);
 


### PR DESCRIPTION
…for DMA offset

Change ASSERT_EQ(importedSz, alloc_size) to ASSERT_GE(importedSz, alloc_size) in MemoryAllocateContiguousTest.

When hsa_amd_portable_export_dmabuf returns a non-zero offset, the DMA buffer includes additional memory at the beginning. The imported buffer size via hsa_amd_interop_map_buffer will be (alloc_size + offset), not just alloc_size. The actual memory region the caller requested starts at (importedPtr + offset) with size alloc_size.

ASAN Error Fixed:
  memory_allocation.cc:543: Failure
  Value of: alloc_size
    Actual: 4194304
  Expected: importedSz
  Which is: 4206592

Test: rocrtstFunc.MemoryAllocateContiguousTest now passes under ASAN

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
