### PR TITLE
rocrtst: ASAN Fixes: Use hsa_amd_memory_pool_free under ASAN in TestAllocate

### DIFF
--- a/projects/rocr-runtime/rocrtst/suites/functional/memory_basic.cc
+++ b/projects/rocr-runtime/rocrtst/suites/functional/memory_basic.cc
@@ -137,7 +137,15 @@ hsa_status_t MemoryTest::TestAllocate(hsa_amd_memory_pool_t pool, size_t sz) {
   err = hsa_amd_memory_pool_allocate(pool, sz, 0, &ptr);
 
   if (err == HSA_STATUS_SUCCESS) {
+#ifdef ROCRTST_ASAN
+    // Under ASAN, hsa_amd_memory_pool_allocate returns base+PAGE_SIZE (ASAN header offset).
+    // hsa_memory_free is not intercepted by the ASAN runtime, so it receives the offset pointer
+    // and fails to find it in allocation_map_. Use hsa_amd_memory_pool_free which IS intercepted
+    // and correctly strips the PAGE_SIZE offset before calling into ROCr.
+    err = hsa_amd_memory_pool_free(ptr);
+#else
     err = hsa_memory_free(ptr);
+#endif
   }
 
   return err;


### PR DESCRIPTION
Under ASAN, hsa_amd_memory_pool_allocate returns (base + PAGE_SIZE) due to the ASAN header offset. The hsa_memory_free function is not intercepted by the ASAN runtime, so it receives the offset pointer and fails to find it in the runtime's allocation_map_.

Use hsa_amd_memory_pool_free instead, which IS intercepted by ASAN and correctly strips the PAGE_SIZE offset before calling into ROCr.

This is consistent with the existing ASAN handling in MemAvailableTest

ASAN Error Fixed:
  Warning: (false && "Can't find address in allocation map") in
  hsa_status_t rocr::core::Runtime::FreeMemory(void *),
  runtime.cpp:350
  (repeated hundreds of times during Memory_Max_Mem test)

Test: rocrtstFunc.Memory_Max_Mem and rocrtstFunc.Memory_Available
      now pass without warnings under ASAN

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
