### PR TITLE
[rocprofiler-sdk] Fix segfault in glog fatal logging when querying metrics

### DIFF
--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/aql/helpers.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/aql/helpers.cpp
@@ -31,6 +31,7 @@
 #include <rocprofiler-sdk/fwd.h>
 
 #include <fmt/core.h>
+#include <iostream>
 
 namespace rocprofiler
 {
@@ -44,7 +45,7 @@ get_query_info(rocprofiler_agent_id_t agent, const counters::Metric& metric)
     hsa_ven_amd_aqlprofile_id_query_t query = {metric.block().c_str(), 0, 0};
     if(aqlprofile_get_pmc_info(&profile, AQLPROFILE_INFO_BLOCK_ID, &query) != HSA_STATUS_SUCCESS)
     {
-        ROCP_DFATAL << fmt::format("AQL failed to query info for counter {}", metric);
+        std::cerr << fmt::format("[rocprofiler-sdk]: AQL failed to query info for counter {}", metric);
         throw std::runtime_error(fmt::format("AQL failed to query info for counter {}", metric));
     }
     return query;

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/aql/helpers.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/aql/helpers.cpp
@@ -45,7 +45,7 @@ get_query_info(rocprofiler_agent_id_t agent, const counters::Metric& metric)
     hsa_ven_amd_aqlprofile_id_query_t query = {metric.block().c_str(), 0, 0};
     if(aqlprofile_get_pmc_info(&profile, AQLPROFILE_INFO_BLOCK_ID, &query) != HSA_STATUS_SUCCESS)
     {
-        std::cerr << fmt::format("[rocprofiler-sdk]: AQL failed to query info for counter {}", metric);
+        ROCP_ERROR << fmt::format("[rocprofiler-sdk]: AQL failed to query info for counter {}", metric);
         throw std::runtime_error(fmt::format("AQL failed to query info for counter {}", metric));
     }
     return query;


### PR DESCRIPTION
## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->
Use `ROCP_ERROR` for logging to prevent a crash in glog. 

## Technical Details

When querying metrics in `get_query_info`, if `aqlprofile_get_pmc_info` internally throws (as can often happen experimenting with new metrics), glog seems to be in a state where it is unable to log, causing a SIGSEV without any logs printed. 

Under such cases, the backtrace is unhelpful and therefore becomes hard to find the root cause. To overcome this, use `ROCP_ERROR`. This is in a draft while I track down the root cause. 

Not 100% sure yet, but took a quick look .... in `external/glog/src/logging.cc:64`, `stream_->self_` is `null` when this happens, causing a SIGSEV. Will update after a more in-depth reproducer. 

<!-- Explain the changes along with any relevant GitHub links. -->

## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
