### PR TITLE
Update test runner for single node multi GPU rccl tests

### DIFF
--- a/.github/workflows/therock-rccl-ci-linux.yml
+++ b/.github/workflows/therock-rccl-ci-linux.yml
@@ -135,5 +135,5 @@ jobs:
     with:
       amdgpu_families: ${{ inputs.amdgpu_families }}
       artifact_group: ${{ inputs.artifact_group }}
-      test_runs_on: linux-mi325-4gpu-ossci-rocm
+      test_runs_on: linux-mi325-8gpu-ossci-rocm
       artifact_run_id: ${{ github.run_id }}


### PR DESCRIPTION
This PR aims to update the single node test runner. We have been using "linux-mi325-4gpu-ossci-rocm" runner for the single node multi GPU tests which have been updated to "linux-mi325-8gpu-ossci-rocm" OSCII runner.