### PR TITLE
Fix stitch fail on illegal instruction

### DIFF
--- a/projects/rocprof-trace-decoder/source/gfx9/gfx9wave.cpp
+++ b/projects/rocprof-trace-decoder/source/gfx9/gfx9wave.cpp
@@ -53,7 +53,8 @@ constexpr std::array<std::string_view, 29> inst_type_dict = {
      "INST_SMEM_WR_REPLAY", "INST_VMEM_RD_REPLAY",
      "INST_VMEM_WR_REPLAY", "INST_FLAT_WR_REPLAY",
      "INST_FLAT_RD_REPLAY", "INST_FATAL_HALT",
-     "RESERVED0", "RESERVED1", "INST_VALU_MAI", }
+     "RESERVED0", "RESERVED1",
+     "INST_VALU_MAI", }
 };
 
 constexpr std::array<std::string_view, 16> token_name_dict = {

--- a/projects/rocprof-trace-decoder/source/stitch/stitch.cpp
+++ b/projects/rocprof-trace-decoder/source/stitch/stitch.cpp
@@ -30,11 +30,7 @@
 
 #define MAX_FAILED_STTICHES 1000
 
-inline bool skippable(InstCategory line)
-{
-    return line == InstCategory::VALU || line == InstCategory::VMEM || line == InstCategory::FLAT ||
-           line == InstCategory::IMMED || line == InstCategory::LDS;
-};
+inline bool skippable(InstCategory line) { return line != InstCategory::SALU && line <= InstCategory::IMMED; };
 
 inline bool is_trivial_match(int wave, InstCategory line)
 {


### PR DESCRIPTION
## Motivation

Some instructions on RDNA will report IMMED tokens when executed illegally. This will cause stitch.cpp to fail.
* Also fix a formatting issue in gfx9wave.cpp

## Technical Details

Allow SMEM to be a skippable instruction class as a workaround.

## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
