### PR TITLE
[AMD-SMI] Display N/A for cu_occupancy when file is unavailable (#3589)

### DIFF
--- a/projects/amdsmi/rocm_smi/src/rocm_smi.cc
+++ b/projects/amdsmi/rocm_smi/src/rocm_smi.cc
@@ -5293,9 +5293,10 @@ rsmi_compute_process_info_get(rsmi_process_info_t *procs,
           procs[i].process_id, &procs[i], &gpu_set);
       // Non-fatal: if a process disappeared between enumeration
       // and info collection (ESRCH), zero-fill stats but keep process_id
+      // cu_occupancy uses KFD_STATS_INVALID to signal N/A.
       if (proc_err_code == ESRCH) {
         const auto pid = procs[i].process_id;
-        procs[i] = rsmi_process_info_t{pid, 0, 0, 0, 0};
+        procs[i] = rsmi_process_info_t{pid, 0, 0, KFD_STATS_INVALID, 0};
       } else if (proc_err_code) {
         return amd::smi::ErrnoToRsmiStatus(proc_err_code);
       }

--- a/projects/amdsmi/rocm_smi/src/rocm_smi_kfd.cc
+++ b/projects/amdsmi/rocm_smi/src/rocm_smi_kfd.cc
@@ -634,7 +634,8 @@ int GetProcessInfoForPID(uint32_t pid, rsmi_process_info_t *proc,
 
   proc->vram_usage = 0;
   proc->sdma_usage = 0;
-  proc->cu_occupancy = 0;
+  // Default to invalid to display N/A if cu_occupancy file is unavailable
+  proc->cu_occupancy = KFD_STATS_INVALID;
   proc->evicted_time = 0;
 
   // Collect all paths to read metrics from: primary process + secondary contexts
@@ -718,7 +719,8 @@ int GetProcessInfoForPID(uint32_t pid, rsmi_process_info_t *proc,
         }
       } else {
         // Aggregate cu_occupancy (use max value as it represents peak usage)
-        if (kfd_stat != KFD_STATS_INVALID && kfd_stat > proc->cu_occupancy) {
+        if (kfd_stat != KFD_STATS_INVALID &&
+            (proc->cu_occupancy == KFD_STATS_INVALID || kfd_stat > proc->cu_occupancy)) {
           proc->cu_occupancy = kfd_stat;
         }
       }

--- a/projects/amdsmi/tests/amd_smi_test/functional/process_info_read.cc
+++ b/projects/amdsmi/tests/amd_smi_test/functional/process_info_read.cc
@@ -183,7 +183,7 @@ void TestProcInfoRead::Run(void) {
                                    " SDMA Usage: " <<
                                    proc_info.sdma_usage <<
                                    " Compute Unit Usage: " <<
-                                   proc_info.cu_occupancy <<
+                                   (proc_info.cu_occupancy == UINT32_MAX ? "N/A" : std::to_string(proc_info.cu_occupancy)) <<
                                    " Evicted Time: " <<
                                    proc_info.evicted_time << std::endl <<
                                    std::endl;


### PR DESCRIPTION
## Motivation
CU_Occupancy metric displayed incorrect value when it was not valid which would lead to confusion. Needed for 7.12 release.

## Technical Details
Initialize process cu_occupancy to INVALID instead of zero to display N/A rather than misleading 0%.

## JIRA ID
ROCM-20260

## Test Plan

## Test Result

## Submission Checklist
