### PR TITLE
[AMD-SMI] Fix ASIC specific tests and CI workflow

### DIFF
--- a/.github/workflows/amdsmi-build.yml
+++ b/.github/workflows/amdsmi-build.yml
@@ -299,11 +299,13 @@ jobs:
           echo 'Running AMDSMI tests'
           cd /opt/rocm/share/amd_smi/tests
           source amdsmitst.exclude
+          source detect_asic_filter.sh
+          echo "GTEST_EXCLUDE=${GTEST_EXCLUDE}"
 
           AMDSMI_RETRIES=3
           for attempt in $(seq 1 $AMDSMI_RETRIES); do
             echo "AMDSMI test attempt $attempt for ${{ matrix.os }}..."
-            if ./amdsmitst --gtest_filter="-$(echo ${BLACKLIST_ALL_ASICS})" > /tmp/test-results-${{ matrix.os }}/amdsmi_tests.log 2>&1; then
+            if ./amdsmitst --gtest_filter="-${GTEST_EXCLUDE}" > /tmp/test-results-${{ matrix.os }}/amdsmi_tests.log 2>&1; then
               echo "AMDSMI tests passed on attempt $attempt"
               echo "=============== TEST OUTPUT ==============="
               cat /tmp/test-results-${{ matrix.os }}/amdsmi_tests.log | grep -E "\[==========\]|\[  PASSED  \]|\[  SKIPPED \]|\[  FAILED  \]"
@@ -824,11 +826,13 @@ jobs:
           echo 'Running AMDSMI tests'
           cd /opt/rocm/share/amd_smi/tests
           source amdsmitst.exclude
+          source detect_asic_filter.sh
+          echo "GTEST_EXCLUDE=${GTEST_EXCLUDE}"
 
           AMDSMI_RETRIES=3
           for attempt in $(seq 1 $AMDSMI_RETRIES); do
             echo "AMDSMI test attempt $attempt for ${{ matrix.os }}..."
-            if ./amdsmitst --gtest_filter="-$(echo ${BLACKLIST_ALL_ASICS})" > /tmp/test-results-${{ matrix.os }}/amdsmi_tests.log 2>&1; then
+            if ./amdsmitst --gtest_filter="-${GTEST_EXCLUDE}" > /tmp/test-results-${{ matrix.os }}/amdsmi_tests.log 2>&1; then
               echo "AMDSMI tests passed on attempt $attempt"
               echo "=============== TEST OUTPUT ==============="
               cat /tmp/test-results-${{ matrix.os }}/amdsmi_tests.log | grep -E "\[==========\]|\[  PASSED  \]|\[  SKIPPED \]|\[  FAILED  \]"

--- a/projects/amdsmi/.github/workflows/amdsmi-build.yml
+++ b/projects/amdsmi/.github/workflows/amdsmi-build.yml
@@ -256,11 +256,13 @@ jobs:
           echo 'Running AMDSMI tests'
           cd /opt/rocm/share/amd_smi/tests
           source amdsmitst.exclude
+          source detect_asic_filter.sh
+          echo "GTEST_EXCLUDE=${GTEST_EXCLUDE}"
 
           AMDSMI_RETRIES=3
           for attempt in $(seq 1 $AMDSMI_RETRIES); do
             echo "AMDSMI test attempt $attempt for ${{ matrix.os }}..."
-            if ./amdsmitst --gtest_filter="-$(echo ${BLACKLIST_ALL_ASICS})" > /tmp/test-results-${{ matrix.os }}/amdsmi_tests.log 2>&1; then
+            if ./amdsmitst --gtest_filter="-${GTEST_EXCLUDE}" > /tmp/test-results-${{ matrix.os }}/amdsmi_tests.log 2>&1; then
               echo "AMDSMI tests passed on attempt $attempt"
               echo "=============== TEST OUTPUT ==============="
               cat /tmp/test-results-${{ matrix.os }}/amdsmi_tests.log | grep -E "\[==========\]|\[  PASSED  \]|\[  SKIPPED \]|\[  FAILED  \]"
@@ -739,11 +741,13 @@ jobs:
           echo 'Running AMDSMI tests'
           cd /opt/rocm/share/amd_smi/tests
           source amdsmitst.exclude
+          source detect_asic_filter.sh
+          echo "GTEST_EXCLUDE=${GTEST_EXCLUDE}"
 
           AMDSMI_RETRIES=3
           for attempt in $(seq 1 $AMDSMI_RETRIES); do
             echo "AMDSMI test attempt $attempt for ${{ matrix.os }}..."
-            if ./amdsmitst --gtest_filter="-$(echo ${BLACKLIST_ALL_ASICS})" > /tmp/test-results-${{ matrix.os }}/amdsmi_tests.log 2>&1; then
+            if ./amdsmitst --gtest_filter="-${GTEST_EXCLUDE}" > /tmp/test-results-${{ matrix.os }}/amdsmi_tests.log 2>&1; then
               echo "AMDSMI tests passed on attempt $attempt"
               echo "=============== TEST OUTPUT ==============="
               cat /tmp/test-results-${{ matrix.os }}/amdsmi_tests.log | grep -E "\[==========\]|\[  PASSED  \]|\[  SKIPPED \]|\[  FAILED  \]"

--- a/projects/amdsmi/tests/README.md
+++ b/projects/amdsmi/tests/README.md
@@ -12,8 +12,27 @@ sudo integration_test.py -v > _integration_test.log 2> _integration_test_err.log
 ```
 
 <u>The C++ test is in the directory /opt/rocm/share/amd_smi/tests</u>
+
+To run with ASIC-specific test exclusions (recommended):
 ```
-sudo amdsmitst -v 1 > _amdsmitst.log 2> _amdsmitst_err.log
+cd /opt/rocm/share/amd_smi/tests
+source amdsmitst.exclude
+source detect_asic_filter.sh
+sudo ./amdsmitst --gtest_filter="-${GTEST_EXCLUDE}" -v 1 > _amdsmitst.log 2> _amdsmitst_err.log
+```
+
+`detect_asic_filter.sh` reads the KFD topology to detect the installed ASIC
+(e.g. `aldebaran`, `sienna_cichlid`) or falls back to `gfx_target_version` for
+`ip discovery` nodes (e.g. `90400`, `90402`). It also detects SR-IOV
+virtualization. The script sets `GTEST_EXCLUDE` by combining the global
+blacklist (`BLACKLIST_ALL_ASICS`) with the device-specific filter from
+`amdsmitst.exclude`.
+
+To run without ASIC-specific exclusions (uses only the global blacklist):
+```
+cd /opt/rocm/share/amd_smi/tests
+source amdsmitst.exclude
+sudo ./amdsmitst --gtest_filter="-${BLACKLIST_ALL_ASICS}" -v 1 > _amdsmitst.log 2> _amdsmitst_err.log
 ```
 
 ## How to Run Summary Report

--- a/projects/amdsmi/tests/amd_smi_test/CMakeLists.txt
+++ b/projects/amdsmi/tests/amd_smi_test/CMakeLists.txt
@@ -72,6 +72,6 @@ install(
     COMPONENT ${TESTS_COMPONENT})
 
 install(
-    FILES amdsmitst.exclude
+    FILES amdsmitst.exclude detect_asic_filter.sh
     DESTINATION ${SHARE_INSTALL_PREFIX}/tests
     COMPONENT ${TESTS_COMPONENT})

--- a/projects/amdsmi/tests/amd_smi_test/amdsmitst.exclude
+++ b/projects/amdsmi/tests/amd_smi_test/amdsmitst.exclude
@@ -79,7 +79,7 @@ $BLACKLIST_ALL_ASICS\
 # /sys/class/kfd/kfd/topology/nodes/*/properties
 FILTER[90400]=\
 $BLACKLIST_ALL_ASICS\
-"rsmitstReadOnly.TestVoltCurvRead"
+"amdsmitstReadOnly.TestVoltCurvRead:"
 FILTER[90401]=${FILTER[90400]}
 FILTER[90402]=${FILTER[90400]}
 

--- a/projects/amdsmi/tests/amd_smi_test/detect_asic_filter.sh
+++ b/projects/amdsmi/tests/amd_smi_test/detect_asic_filter.sh
@@ -1,0 +1,102 @@
+#!/bin/bash
+# detect_asic_filter.sh — Detect the GPU ASIC and build the appropriate
+# gtest negative filter from amdsmitst.exclude.
+#
+# Usage:
+#   source amdsmitst.exclude        # loads FILTER[] and BLACKLIST_ALL_ASICS
+#   source detect_asic_filter.sh    # sets GTEST_EXCLUDE
+#   ./amdsmitst --gtest_filter="-${GTEST_EXCLUDE}"
+#
+# Requires: FILTER (associative array) and BLACKLIST_ALL_ASICS from
+#           amdsmitst.exclude to already be sourced.
+
+# ---------- gfx string to ASIC name mapping ----------
+# Maps TARGET_GRAPHICS_VERSION strings from amd-smi to the ASIC name or
+# gfx_target_version used as FILTER keys in amdsmitst.exclude.
+declare -A GFX_TO_ASIC=(
+    [gfx900]=vega10
+    [gfx906]=vega20
+    [gfx908]=arcturus
+    [gfx90a]=aldebaran
+    [gfx940]=90400
+    [gfx941]=90401
+    [gfx942]=90402
+    [gfx1030]=sienna_cichlid
+    [gfx1100]=strix_point
+    [gfx1150]=gfx1150
+    [gfx1151]=gfx1151
+    [gfx1152]=gfx1152
+    [gfx1153]=gfx1153
+)
+
+# ---------- ASIC detection ----------
+# Method 1: KFD topology nodes expose the ASIC name.  Newer GPUs
+# ("ip discovery") require gfx_target_version from the node properties.
+ASIC_NAME=""
+for node_dir in /sys/class/kfd/kfd/topology/nodes/*/; do
+    if [ -f "${node_dir}name" ]; then
+        node_name=$(cat "${node_dir}name" 2>/dev/null | tr -d '[:space:]')
+        if [ -n "$node_name" ] && [ "$node_name" != "ip_discovery" ] && \
+           [ "$node_name" != "ipdiscovery" ]; then
+            ASIC_NAME="$node_name"
+            break
+        fi
+        # For ip discovery nodes, fall back to gfx_target_version
+        if [ "$node_name" = "ip_discovery" ] || [ "$node_name" = "ipdiscovery" ]; then
+            if [ -f "${node_dir}properties" ]; then
+                gfx_ver=$(grep 'gfx_target_version' "${node_dir}properties" 2>/dev/null | awk '{print $2}')
+                if [ -n "$gfx_ver" ] && [ "$gfx_ver" != "0" ]; then
+                    ASIC_NAME="$gfx_ver"
+                    break
+                fi
+            fi
+        fi
+    fi
+done
+
+# Method 2: If KFD topology didn't yield an ASIC, try amd-smi.
+# This is more reliable inside Docker containers where sysfs may be
+# partially mounted.
+if [ -z "$ASIC_NAME" ] && command -v amd-smi >/dev/null 2>&1; then
+    gfx_str=$(amd-smi static --asic 2>/dev/null \
+              | grep 'TARGET_GRAPHICS_VERSION' \
+              | head -1 \
+              | awk '{print $NF}')
+    if [ -n "$gfx_str" ]; then
+        # Map gfx string to FILTER key via lookup table
+        if [ -n "${GFX_TO_ASIC[$gfx_str]+x}" ]; then
+            ASIC_NAME="${GFX_TO_ASIC[$gfx_str]}"
+            echo "KFD detection failed — amd-smi detected $gfx_str → $ASIC_NAME"
+        else
+            echo "KFD detection failed — amd-smi detected $gfx_str (no FILTER mapping)"
+        fi
+    fi
+fi
+
+# ---------- Virtualization detection ----------
+VIRT_MODE=""
+virt_file=$(find /sys/class/drm/card*/device/ -name 'current_virtualization_mode' 2>/dev/null | head -1)
+if [ -n "$virt_file" ]; then
+    virt_val=$(cat "$virt_file" 2>/dev/null | tr -d '[:space:]')
+    if [ "$virt_val" = "SRIOV" ] || [ "$virt_val" = "VF" ]; then
+        VIRT_MODE="virtualization"
+    fi
+fi
+
+# ---------- Build combined gtest exclude filter ----------
+# Start with the ASIC-specific blacklist, or fall back to the global one.
+if [ -n "$ASIC_NAME" ] && [ -n "${FILTER[$ASIC_NAME]+x}" ]; then
+    GTEST_EXCLUDE="${FILTER[$ASIC_NAME]}"
+    echo "Detected ASIC: $ASIC_NAME — using device-specific blacklist"
+else
+    GTEST_EXCLUDE="${BLACKLIST_ALL_ASICS}"
+    echo "ASIC '${ASIC_NAME:-unknown}' has no specific filter — using global blacklist"
+fi
+
+# Layer on virtualization exclusions if running in a VM/VF.
+if [ -n "$VIRT_MODE" ] && [ -n "${FILTER[$VIRT_MODE]+x}" ]; then
+    GTEST_EXCLUDE="${GTEST_EXCLUDE}${FILTER[$VIRT_MODE]}"
+    echo "Virtualization detected — appending virtualization blacklist"
+fi
+
+echo "Final gtest negative filter: -${GTEST_EXCLUDE}"

--- a/projects/amdsmi/tests/python_unittest/integration_test.py
+++ b/projects/amdsmi/tests/python_unittest/integration_test.py
@@ -28,6 +28,16 @@ import unittest
 import common
 
 
+# ---------------------------------------------------------------------------
+# Per-ASIC test exclusions (mirrors amdsmitst.exclude for GTest)
+# Maps gfx target version -> set of test method names to skip.
+# ---------------------------------------------------------------------------
+GFX_FILTER = {
+    # SWDEV-306889 — aldebaran: TestFrequenciesRead / TestFrequenciesReadWrite
+    "gfx90a": {"test_clock_frequency"},
+}
+
+
 amdsmi_path = os.environ.get("AMDSMI_PATH", "/opt/rocm/share/amd_smi")
 if not os.path.exists(amdsmi_path):
     raise FileNotFoundError(f"AMDSMI_PATH '{amdsmi_path}' does not exist. Please set the correct path in your environment.")
@@ -1434,6 +1444,23 @@ if __name__ == '__main__':
         print("Warning: Some tests may require elevated privileges (sudo/root) to run completely.\n")
         print("Please relaunch with elevated privileges.\n")
         sys.exit(1)
+
+    # Apply per-ASIC test exclusions
+    try:
+        amdsmi.amdsmi_init()
+        gpu = amdsmi.amdsmi_get_processor_handles()[0]
+        gfx = amdsmi.amdsmi_get_gpu_asic_info(gpu)["target_graphics_version"]
+        amdsmi.amdsmi_shut_down()
+        skip_set = GFX_FILTER.get(gfx, set())
+        if skip_set:
+            print(f"ASIC filter: {gfx} — skipping {len(skip_set)} test(s): {', '.join(sorted(skip_set))}")
+            for name in skip_set:
+                method = getattr(TestAmdSmiPythonInterface, name, None)
+                if method is not None:
+                    setattr(TestAmdSmiPythonInterface, name,
+                            unittest.skip(f"Excluded for {gfx} (see amdsmitst.exclude)")(method))
+    except Exception as e:
+        print(f"ASIC filter: could not detect GPU ({e}), running all tests")
 
     runner = unittest.TextTestRunner(verbosity=verbose)
     unittest.main(testRunner=runner)


### PR DESCRIPTION
## Motivation
The CI workflows were only applying BLACKLIST_ALL_ASICS (CperEntriesTest) when running amdsmitst, ignoring device-specific exclusions defined in amdsmitst.exclude (e.g. aldebaran skips TestPowerReadWrite).

## Technical Details
Add detect_asic_filter.sh that reads the KFD topology to identify the GPU ASIC (or gfx_target_version for ip_discovery nodes), looks up the matching FILTER[] entry, and also checks for virtualization mode.  Both the debian and rpm test jobs now source this script and use GTEST_EXCLUDE instead of BLACKLIST_ALL_ASICS.

Additionally:
- Add detect_asic_filter.sh for per-ASIC GTest blacklists via KFD topology
- Add amd-smi CLI fallback for ASIC detection in Docker containers
- Update CI workflow to source ASIC filter and apply GTEST_EXCLUDE
- Add per-ASIC test exclusions for Python integration tests
- Install detect_asic_filter.sh with test package
- Update tests/README.md with ASIC filter documentation

## JIRA ID
ROCM-20259
ROCM-3771

## Test Plan

## Test Result

## Submission Checklist

