### PR TITLE
Revert "rocr: Restore mmap flags back to MAP_PRIVATE (#2886)"

### DIFF
--- a/projects/rocr-runtime/libhsakmt/src/fmm.c
+++ b/projects/rocr-runtime/libhsakmt/src/fmm.c
@@ -2125,7 +2125,7 @@ static void *fmm_allocate_host_gpu(HsaKFDContext *ctx,
 
 		/* Map anonymous pages */
 		if (mmap(mem, MemorySizeInBytes, PROT_READ | PROT_WRITE,
-			 MAP_ANONYMOUS | MAP_PRIVATE | MAP_FIXED, -1, 0)
+			 MAP_ANONYMOUS | MAP_SHARED | MAP_FIXED, -1, 0)
 		    == MAP_FAILED)
 			goto out_release_area;
 


### PR DESCRIPTION
This reverts commit 00e8a671658b570d4db52e1cfa5c2e4b82c7a911.

It was a workaround to the slowness issue which has been root caused and the fix is implemented, thus reverting the aforementioned patch as it would be unnecessary.