### PR TITLE
[CLR][NFCI] Reduce number of times a kernel name is copied

### DIFF
--- a/projects/clr/hipamd/src/hip_global.cpp
+++ b/projects/clr/hipamd/src/hip_global.cpp
@@ -107,15 +107,6 @@ DeviceFunc::DeviceFunc(const std::string &name, hipModule_t hmod) : kernel_(null
   const amd::Symbol* symbol = program->findSymbol(name.c_str());
   guarantee(symbol != nullptr, "Cannot find Symbol with name: %s", name.c_str());
 
-  // TODO: consider storing amd::Symbol* instead of amd::Kernel*
-  // Symbols hold device kernels for every device a program was built for and
-  // they are themselves stored within a program.
-  // Moreover, when a program is built, we automatically create kernel objects
-  // for every kernel, so this new object is just extra unnecessary allocation.
-  // The only concern I have is that symbols may be re-built if a program is
-  // re-built. However, that (presumably) shouldn't happen for implicitly
-  // created programs. Need to check modules which are explicitly managed by
-  // users.
   kernel_ = new amd::Kernel(*program, *symbol, name);
 }
 

--- a/projects/clr/hipamd/src/hip_global.cpp
+++ b/projects/clr/hipamd/src/hip_global.cpp
@@ -101,12 +101,21 @@ DeviceVar::~DeviceVar() {
 }
 
 // Device Functions
-DeviceFunc::DeviceFunc(std::string name, hipModule_t hmod) : name_(name), kernel_(nullptr) {
+DeviceFunc::DeviceFunc(const std::string &name, hipModule_t hmod) : kernel_(nullptr) {
   amd::Program* program = as_amd(reinterpret_cast<cl_program>(hmod));
 
   const amd::Symbol* symbol = program->findSymbol(name.c_str());
   guarantee(symbol != nullptr, "Cannot find Symbol with name: %s", name.c_str());
 
+  // TODO: consider storing amd::Symbol* instead of amd::Kernel*
+  // Symbols hold device kernels for every device a program was built for and
+  // they are themselves stored within a program.
+  // Moreover, when a program is built, we automatically create kernel objects
+  // for every kernel, so this new object is just extra unnecessary allocation.
+  // The only concern I have is that symbols may be re-built if a program is
+  // re-built. However, that (presumably) shouldn't happen for implicitly
+  // created programs. Need to check modules which are explicitly managed by
+  // users.
   kernel_ = new amd::Kernel(*program, *symbol, name);
 }
 

--- a/projects/clr/hipamd/src/hip_global.hpp
+++ b/projects/clr/hipamd/src/hip_global.hpp
@@ -42,7 +42,7 @@ class DeviceVar {
 
 class DeviceFunc {
  public:
-  DeviceFunc(std::string name, hipModule_t hmod);
+  DeviceFunc(const std::string &name, hipModule_t hmod);
   ~DeviceFunc();
 
   std::recursive_mutex dflock_;
@@ -53,11 +53,10 @@ class DeviceFunc {
   static DeviceFunc* asFunction(hipKernel_t k) { return reinterpret_cast<DeviceFunc*>(k); }
 
   // Accessor for kernel_ and name_ populated during constructor.
-  std::string name() const { return name_; }
+  const std::string &name() const { return kernel_->name(); }
   amd::Kernel* kernel() const { return kernel_; }
 
  private:
-  std::string name_;     // name of the func(not unique identifier)
   amd::Kernel* kernel_;  // Kernel ptr referencing to ROCclr Symbol
 };
 


### PR DESCRIPTION
## Motivation

Reduce memory footprint of the ROCm runtime and time to launch a kernel for the first time.

## Technical Details

`DeviceFunc` holds a pointer to an `amd::Kernel` object which already knows its name, so storing it (moreover a copy!) seems wasteful.

## JIRA ID

N/A

## Test Plan

N/A, this is intended to be a non-functional change

## Test Result

N/A, this is intended to be a non-functional change

## Submission Checklist

- [X] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
