### PR TITLE
[ci] disabling mi325 test runners

### DIFF
--- a/.github/workflows/therock-ci-linux.yml
+++ b/.github/workflows/therock-ci-linux.yml
@@ -122,5 +122,6 @@ jobs:
     with:
       projects_to_test: ${{ inputs.projects_to_test }}
       amdgpu_families: "gfx94X-dcgpu"
-      test_runs_on: "linux-mi325-1gpu-ossci-rocm"
+      # Due to migrating MI325s, we have lost capacity as of 3/13/2026 11:41am PST
+      test_runs_on: ""
       platform: "linux"

--- a/.github/workflows/therock-rccl-ci-linux.yml
+++ b/.github/workflows/therock-rccl-ci-linux.yml
@@ -134,7 +134,9 @@ jobs:
 
   therock-test-linux-single-node:
     name: "Test single-node"
-    if: ${{ inputs.amdgpu_families == 'gfx94X-dcgpu' }}
+    # TODO(TheRock#3288): Re-enable gfx950-dcgpu runners once we get more capacity
+    # Due to migrating MI325s, we have lost capacity as of 3/13/2026 11:41am PST
+    if: ${{ inputs.amdgpu_families != 'gfx94X-dcgpu' && inputs.amdgpu_families != 'gfx950-dcgpu' }}
     needs: [therock-build-linux]
     uses: ./.github/workflows/therock-rccl-test-packages-single-node.yml
     with:


### PR DESCRIPTION
As DigitalOcean MI325 machines are being migrated, we have lost capacity. this PR will disable them until we get capacity (so we can continue to get signal and no infinite hangs)