### PR TITLE
Enable additional tests to rocprof-trace-decoder

### DIFF
--- a/projects/rocprof-trace-decoder/test/CMakeLists.txt
+++ b/projects/rocprof-trace-decoder/test/CMakeLists.txt
@@ -149,15 +149,7 @@ if(BUILD_INTEGRATION_TESTS)
                        FIXTURES_REQUIRED
                        unpack_data)
 
-        set(USES_VCMPX FALSE)
-        if(${DATA} STREQUAL "mi300_pcs"
-           OR ${DATA} STREQUAL "mi300_gemmv2"
-           OR ${DATA} STREQUAL "mi300_sgemm"
-           OR ${DATA} STREQUAL "mi300_perf")
-            set(USES_VCMPX TRUE)
-        endif()
-
-        if(NOT APPLE AND NOT USES_VCMPX)
+        if(NOT APPLE)
             add_test(NAME ${DATA}_execute COMMAND $<TARGET_FILE:tool> ${TEST_BIN_DIR}/${DATA}/1_results.json)
             set_tests_properties(
                 ${DATA}_execute


### PR DESCRIPTION
## Motivation

A few of the tests were disabled due to v_cmpx* instructions failing to disassemble: https://github.com/llvm/llvm-project/pull/163825 
The latest therock should have it fixed and so we can enable them.

Note: Rocm 7.2.x and therock <7.11 will fail these tests.

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
