### PR TITLE
[rocr-runtime] Fix heap overflow in InterceptQueue staging buffer

### DIFF
--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/intercept_queue.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/intercept_queue.cpp
@@ -128,7 +128,7 @@ InterceptQueue::InterceptQueue(std::unique_ptr<Queue> queue)
   amd_queue_.hsa_queue.base_address = reinterpret_cast<void*>(&buffer_[0]);
 
   // Pre-allocate staging buffer with queue size
-  staging_buffer_.resize(256);
+  staging_buffer_.resize(wrapped->amd_queue_.hsa_queue.size);
 
   // Fill the ring buffer with invalid packet headers.
   // Leave packet content uninitialized to help trigger application errors.


### PR DESCRIPTION
## Motivation

Multi-GPU JAX/XLA training with RCCL collectives crashes with SIGSEGV on ROCm 7.2.1.

## Technical Details

The staging_buffer_ in InterceptQueue was hardcoded to 256 entries, but the ring buffer can hold up to queue_size entries (typically 4096+). When pending packets wrap around the ring buffer boundary and exceed 256, StoreRelaxed writes AQL packets past the vector allocation into adjacent heap memory.

This caused non-deterministic SIGSEGV in multi-GPU training workloads (e.g. Llama-2-70B FP8 on 8x MI355X) where high kernel dispatch rates from RCCL AllReduce + FP8 quantization kernels could accumulate >256 pending packets.  FP8 workloads are disproportionately affected because each matmul requires additional quantize/dequantize/scaling kernels that multiply the packet submission rate compared to BF16.

The environment variable workaround ROC_AQL_QUEUE_SIZE=256 (capping queue to staging buffer size) was tested but causes hangs during RCCL initialization.  

Fix: size the staging buffer to match the ring buffer (queue_size), which is what the original comment intended.

## JIRA ID

The details are in AIMA-53.  

## Test Plan

- Run Llama-2-70B FP8 training — this workload previously crashed with SIGSEGV
- CI/CD

## Test Result

- Built patched libhsa-runtime64.so and installed in the ROCm 7.2.1 container. Passed on the above Llama-2-70B FP8 model.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
