### PR TITLE
ROCM-20222 Hip Init in Hip Storage

### DIFF
--- a/projects/clr/hipamd/src/hip_storage.cpp
+++ b/projects/clr/hipamd/src/hip_storage.cpp
@@ -11,15 +11,25 @@
 
 hipError_t hipAmdFileRead(hipAmdFileHandle_t handle, void* devicePtr, uint64_t size, int64_t file_offset,
                        uint64_t* size_copied, int32_t* status) {
+  HIP_INIT_VOID();
+
   if (size == 0) {
     // Skip if nothing needs reading.
     return hipSuccess;
   }
-  amd::Device* device = hip::getCurrentDevice()->devices()[0];
-  if (device == nullptr) {
+
+  auto* currentContext = hip::getCurrentDevice();
+  amd::Device* device = nullptr;
+
+  if (currentContext && !currentContext->devices().empty()) {
+    device = currentContext->devices()[0];
+  }
+
+  if (!device) {
     LogError("Failed to get current device");
     return hipErrorInvalidDevice;
   }
+
 #if defined(_WIN32)
   amd::Os::FileDesc opaque = handle.handle;
 #else
@@ -34,15 +44,25 @@ hipError_t hipAmdFileRead(hipAmdFileHandle_t handle, void* devicePtr, uint64_t s
 
 hipError_t hipAmdFileWrite(hipAmdFileHandle_t handle, void* devicePtr, uint64_t size, int64_t file_offset,
                        uint64_t* size_copied, int32_t* status) {
+  HIP_INIT_VOID();
+
   if (size == 0) {
     // Skip if nothing needs writing.
     return hipSuccess;
   }
-  amd::Device* device = hip::getCurrentDevice()->devices()[0];
-  if (device == nullptr) {
+  
+  auto* currentContext = hip::getCurrentDevice();
+  amd::Device* device = nullptr;
+
+  if (currentContext && !currentContext->devices().empty()) {
+    device = currentContext->devices()[0];
+  }
+
+  if (!device) {
     LogError("Failed to get current device");
     return hipErrorInvalidDevice;
   }
+
 #if defined(_WIN32)
   amd::Os::FileDesc opaque = handle.handle;
 #else


### PR DESCRIPTION

## Motivation

Bug found when running at high token length that we lose context.

This fixes the bug by ensuring we have called hip init.

## Technical Details

The problem is the functions use a "hidden" API and not the standard API path. The API path has the hip init macros baked into them which led this them not being included originally.

This is a simple fix of calling the hip init marco and also improving the edge case of calling the function and not getting a device.

ROCM-20222

## Test Plan

Another developer was able to reproduce the bug and was able to confirm this change fixed the issue.

## Test Result

A work around is being used by the customer with no additional concerns so far. 

The fix works for internal reproductions.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
