### PR TITLE
libhsakmt: add src/dxg/wkmi include path in CMakeLists_wsl.txt

### DIFF
--- a/projects/rocr-runtime/libhsakmt/CMakeLists_wsl.txt
+++ b/projects/rocr-runtime/libhsakmt/CMakeLists_wsl.txt
@@ -145,6 +145,7 @@ target_include_directories( ${ROCDXG_TARGET}
   PRIVATE
   ${WIN_SDK}
   ${CMAKE_CURRENT_SOURCE_DIR}/src/dxg
+  ${CMAKE_CURRENT_SOURCE_DIR}/src/dxg/wkmi
   ${CMAKE_CURRENT_SOURCE_DIR}/../runtime
   ${CMAKE_CURRENT_SOURCE_DIR}/../runtime/hsa-runtime/core
   ${CMAKE_CURRENT_SOURCE_DIR}/../runtime/hsa-runtime


### PR DESCRIPTION
Align WSL build with PR #3891's Windows change so #include "wkmi.h" resolves. Fixes ROCR Runtime WSL Test (wkmi.h: No such file or directory).

## Motivation

PR #3891 changed `device.h` and `gpu_memory.h` to use `#include "wkmi.h"` and added the include path only in the Windows branch of `libhsakmt/CMakeLists.txt`. The WSL build uses `CMakeLists_wsl.txt`, which was not updated, so the ROCR Runtime WSL Test fails with `wkmi.h: No such file or directory`. This PR adds the same include path to the WSL build so the job passes.

## Technical Details

- Add `${CMAKE_CURRENT_SOURCE_DIR}/src/dxg/wkmi` to `target_include_directories` for the rocdxg target in `projects/rocr-runtime/libhsakmt/CMakeLists_wsl.txt` (PRIVATE section).
- Mirrors the Windows-side change in [PR #3891](https://github.com/ROCm/rocm-systems/pull/3891) ([commit 9060966](https://github.com/ROCm/rocm-systems/commit/9060966715cbfd86c8d1ef85fbfd7290845f1450)).
- Unblocks downstream PRs (e.g. #4066) that hit the same WSL failure after #3891 was merged.

## JIRA ID

N/A

## Test Plan

Push the branch and run the "ROCR Runtime WSL Test" workflow (or open a PR and rely on CI). The "Build libhsakmt with Windows SDK" step should complete without `wkmi.h: No such file or directory`.

## Test Result

ROCR Runtime WSL Test passes (or pending CI run).

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.