### PR TITLE
[Windows/HIP] Fix APU large BAR detection to enable >64GB unified memory allocation

### DIFF
--- a/projects/clr/rocclr/device/pal/paldevice.cpp
+++ b/projects/clr/rocclr/device/pal/paldevice.cpp
@@ -615,9 +615,10 @@ void NullDevice::fillDeviceInfo(const Pal::DeviceProperties& palProp,
     info_.aqlBarrierValue_ = true;
 
 #if defined(_WIN64)
-    if (amd::IS_HIP) {
-      info_.largeBar_ = false;
-    } else if (heaps[Pal::GpuHeapInvisible].logicalSize == 0) {
+    // For APU/integrated devices (no invisible/private VRAM heap), treat as large bar.
+    // This applies to both HIP and OpenCL: on UMA systems the entire system memory is
+    // GPU-local, so resizable BAR semantics apply.
+    if (heaps[Pal::GpuHeapInvisible].logicalSize == 0) {
       info_.largeBar_ = true;
       ClPrint(amd::LOG_INFO, amd::LOG_INIT, "Resizable bar enabled");
     }

--- a/projects/clr/rocclr/device/pal/palmemory.cpp
+++ b/projects/clr/rocclr/device/pal/palmemory.cpp
@@ -116,7 +116,10 @@ bool Memory::create(Resource::MemoryType memType, Resource::CreateParams* params
       memType = Persistent;
     }
 
-    if (amd::IS_HIP && dev().settings().apuSystem_) {
+    if (amd::IS_HIP && dev().settings().apuSystem_ && !dev().info().largeBar_) {
+      // For large-bar APU (UMA, no invisible heap), skip the premature redirect to
+      // RemoteUSWC: the retry loop below will naturally fall through Local ->
+      // Persistent -> RemoteUSWC, avoiding the Windows GART 50%-of-RAM cap.
       Pal::gpusize totalAlloc = dev().TotalAlloc();
       if (memType == Local && totalAlloc > dev().GetMaxFrameBuffer()) {
         memType = RemoteUSWC;


### PR DESCRIPTION
  Description:
  ## Problem

  On Windows, HIP unconditionally disables large BAR (`largeBar_ = false`) for all APU devices, regardless of their actual memory architecture.
   This causes unified memory architecture (UMA) APUs like AMD Strix Halo (gfx1151) to be artificially limited to ~64GB memory allocation, even
   when the system has 128GB+ RAM.

  **Root cause**: The premature redirect to `RemoteUSWC` heap in `palmemory.cpp` triggers the Windows GART allocator's 50%-of-RAM limit,
  preventing applications from utilizing the full unified memory capacity.

  ## Solution

  ### 1. `paldevice.cpp` — Proper large BAR detection

  Remove the HIP-specific hardcoded `largeBar_ = false`. Instead, detect UMA APUs by checking if `GpuHeapInvisible` (discrete VRAM) is absent.
  On UMA systems, the entire system memory is GPU-local, so resizable BAR semantics naturally apply.

  **Before:**
  ```cpp
  if (amd::IS_HIP) {
    info_.largeBar_ = false;  // hardcoded for all APUs
  } else if (heaps[Pal::GpuHeapInvisible].logicalSize == 0) {
    info_.largeBar_ = true;
  }

  After:
  // For APU/integrated devices (no invisible/private VRAM heap), treat as large bar.
  if (heaps[Pal::GpuHeapInvisible].logicalSize == 0) {
    info_.largeBar_ = true;
  }

  2. palmemory.cpp — Avoid premature RemoteUSWC redirect

  For large-bar APUs, skip the early redirect to RemoteUSWC. Let the natural retry loop handle heap selection (Local → Persistent →
  RemoteUSWC), avoiding the Windows GART 50% cap.

  Before:
  if (amd::IS_HIP && dev().settings().apuSystem_) {
      // always redirects, hits GART limit on large-bar APUs
      memType = RemoteUSWC;
  }

  After:
  if (amd::IS_HIP && dev().settings().apuSystem_ && !dev().info().largeBar_) {
      // only redirect for non-large-bar APUs
      memType = RemoteUSWC;
  }

  Testing

  Tested on AMD Strix Halo (gfx1151), 128GB unified memory, Windows 11:

  ┌─────────────────────────┬───────────────────┬──────────────────┐
  │       Allocation        │ Before (upstream) │ After (this fix) │
  ├─────────────────────────┼───────────────────┼──────────────────┤
  │ hipMallocManaged(64 GB) │ ❌ Out of memory  │ ✅ Success       │
  ├─────────────────────────┼───────────────────┼──────────────────┤
  │ hipMallocManaged(70 GB) │ ❌ Out of memory  │ ✅ Success       │
  ├─────────────────────────┼───────────────────┼──────────────────┤
  │ hipMallocManaged(80 GB) │ ❌ Out of memory  │ ✅ Success       │
  ├─────────────────────────┼───────────────────┼──────────────────┤
  │ Cumulative 2×40 GB      │ ❌ Out of memory  │ ✅ Success       │
  └─────────────────────────┴───────────────────┴──────────────────┘

  Compatibility

  - ✅ Discrete GPUs: No change — invisible heap exists, largeBar_ determined by hardware as before
  - ✅ Non-large-bar APUs: Behavior unchanged — early RemoteUSWC redirect still applies
  - ✅ Large-bar APUs: Now correctly utilize full unified memory
  - ✅ OpenCL: Benefits from the same fix — UMA detection is API-agnostic

  Impact

  This fix is critical for enabling large model inference (LLMs, AI workloads) on APU-based systems. Without it, users with 128GB unified
  memory systems cannot allocate more than ~64GB via HIP, making modern APUs unsuitable for AI workloads despite having sufficient RAM.