### PR TITLE
[rocprofiler-systems] Update CMake presets and create symbolic link for compile_commands.json

### DIFF
--- a/projects/rocprofiler-systems/CMakeLists.txt
+++ b/projects/rocprofiler-systems/CMakeLists.txt
@@ -393,6 +393,14 @@ set(CMAKE_VISIBILITY_INLINES_HIDDEN
 )
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
+# symlink compile_commands.json to source root for clangd and clang-tidy
+file(
+    CREATE_LINK
+        "${CMAKE_BINARY_DIR}/compile_commands.json"
+        "${CMAKE_SOURCE_DIR}/compile_commands.json"
+    SYMBOLIC
+)
+
 include(Formatting) # format target
 include(Packages) # finds third-party libraries
 

--- a/projects/rocprofiler-systems/CMakePresets.json
+++ b/projects/rocprofiler-systems/CMakePresets.json
@@ -1,89 +1,73 @@
 {
+    "cmakeMinimumRequired": {
+        "major": 3,
+        "minor": 16,
+        "patch": 0
+    },
     "configurePresets": [
+        {
+            "cacheVariables": {
+                "CMAKE_CXX_COMPILER": "g++",
+                "CMAKE_C_COMPILER": "gcc",
+                "CMAKE_EXPORT_COMPILE_COMMANDS": "ON",
+                "CMAKE_INSTALL_PREFIX": "/opt/rocprofiler-systems",
+                "ROCPROFSYS_BUILD_BOOST": "ON",
+                "ROCPROFSYS_BUILD_DYNINST": "ON",
+                "ROCPROFSYS_BUILD_ELFUTILS": "ON",
+                "ROCPROFSYS_BUILD_LIBIBERTY": "ON",
+                "ROCPROFSYS_BUILD_TBB": "ON",
+                "ROCPROFSYS_STRIP_LIBRARIES": "OFF",
+                "ROCPROFSYS_USE_PYTHON": "ON"
+            },
+            "generator": "Ninja",
+            "hidden": true,
+            "name": "default"
+        },
         {
             "binaryDir": "${sourceDir}/build/ci",
             "cacheVariables": {
                 "CMAKE_BUILD_TYPE": "Release",
-                "CMAKE_CXX_COMPILER": "g++",
-                "CMAKE_C_COMPILER": "gcc",
-                "CMAKE_INSTALL_PREFIX": "/opt/rocprofiler-systems",
-                "ROCPROFSYS_BUILD_BOOST": "ON",
                 "ROCPROFSYS_BUILD_CI": "ON",
-                "ROCPROFSYS_BUILD_DYNINST": "ON",
-                "ROCPROFSYS_BUILD_ELFUTILS": "ON",
                 "ROCPROFSYS_BUILD_GTEST": "ON",
-                "ROCPROFSYS_BUILD_LIBIBERTY": "ON",
-                "ROCPROFSYS_BUILD_TBB": "ON",
                 "ROCPROFSYS_BUILD_TESTING": "ON",
-                "ROCPROFSYS_MAX_THREADS": "64",
-                "ROCPROFSYS_STRIP_LIBRARIES": "OFF",
-                "ROCPROFSYS_USE_PYTHON": "ON"
+                "ROCPROFSYS_MAX_THREADS": "64"
             },
             "description": "Official CI build parameters",
-            "displayName": "official CI build",
-            "generator": "Ninja",
+            "displayName": "Official CI build",
+            "inherits": "default",
             "name": "ci"
         },
         {
             "binaryDir": "${sourceDir}/build/debug",
             "cacheVariables": {
                 "CMAKE_BUILD_TYPE": "Debug",
-                "CMAKE_CXX_COMPILER": "g++",
-                "CMAKE_C_COMPILER": "gcc",
-                "CMAKE_INSTALL_PREFIX": "/opt/rocprofiler-systems",
-                "ROCPROFSYS_BUILD_BOOST": "ON",
                 "ROCPROFSYS_BUILD_DEBUG": "ON",
-                "ROCPROFSYS_BUILD_DYNINST": "ON",
-                "ROCPROFSYS_BUILD_ELFUTILS": "ON",
-                "ROCPROFSYS_BUILD_LIBIBERTY": "ON",
-                "ROCPROFSYS_BUILD_TBB": "ON",
-                "ROCPROFSYS_BUILD_TESTING": "ON",
-                "ROCPROFSYS_STRIP_LIBRARIES": "OFF",
-                "ROCPROFSYS_USE_PYTHON": "ON"
+                "ROCPROFSYS_BUILD_TESTING": "ON"
             },
             "description": "Debug build parameters with tests",
-            "displayName": "official debug build",
-            "generator": "Ninja",
+            "displayName": "Official debug build",
+            "inherits": "default",
             "name": "debug"
         },
         {
             "binaryDir": "${sourceDir}/build/debug-optimized",
             "cacheVariables": {
                 "CMAKE_BUILD_TYPE": "RelWithDebInfo",
-                "CMAKE_CXX_COMPILER": "g++",
-                "CMAKE_C_COMPILER": "gcc",
-                "CMAKE_INSTALL_PREFIX": "/opt/rocprofiler-systems",
-                "ROCPROFSYS_BUILD_BOOST": "ON",
-                "ROCPROFSYS_BUILD_DYNINST": "ON",
-                "ROCPROFSYS_BUILD_ELFUTILS": "ON",
-                "ROCPROFSYS_BUILD_LIBIBERTY": "ON",
-                "ROCPROFSYS_BUILD_TBB": "ON",
-                "ROCPROFSYS_BUILD_TESTING": "ON",
-                "ROCPROFSYS_STRIP_LIBRARIES": "OFF",
-                "ROCPROFSYS_USE_PYTHON": "ON"
+                "ROCPROFSYS_BUILD_TESTING": "ON"
             },
             "description": "Release build with debug info with tests",
-            "displayName": "release build with debug info",
-            "generator": "Ninja",
+            "displayName": "Release build with debug info",
+            "inherits": "default",
             "name": "debug-optimized"
         },
         {
             "binaryDir": "${sourceDir}/build/release",
             "cacheVariables": {
-                "CMAKE_BUILD_TYPE": "Release",
-                "CMAKE_CXX_COMPILER": "g++",
-                "CMAKE_C_COMPILER": "gcc",
-                "CMAKE_INSTALL_PREFIX": "/opt/rocprofiler-systems",
-                "ROCPROFSYS_BUILD_BOOST": "ON",
-                "ROCPROFSYS_BUILD_DYNINST": "ON",
-                "ROCPROFSYS_BUILD_ELFUTILS": "ON",
-                "ROCPROFSYS_BUILD_LIBIBERTY": "ON",
-                "ROCPROFSYS_BUILD_TBB": "ON",
-                "ROCPROFSYS_USE_PYTHON": "ON"
+                "CMAKE_BUILD_TYPE": "Release"
             },
             "description": "Official release build",
-            "displayName": "official release build",
-            "generator": "Ninja",
+            "displayName": "Official release build",
+            "inherits": "default",
             "name": "release"
         }
     ],

--- a/projects/rocprofiler-systems/CMakePresets.json
+++ b/projects/rocprofiler-systems/CMakePresets.json
@@ -9,7 +9,6 @@
             "cacheVariables": {
                 "CMAKE_CXX_COMPILER": "g++",
                 "CMAKE_C_COMPILER": "gcc",
-                "CMAKE_EXPORT_COMPILE_COMMANDS": "ON",
                 "CMAKE_INSTALL_PREFIX": "/opt/rocprofiler-systems",
                 "ROCPROFSYS_BUILD_BOOST": "ON",
                 "ROCPROFSYS_BUILD_DYNINST": "ON",


### PR DESCRIPTION
Update/cleanup `CMakePresets.json`

## Motivation

Refactor CMakePresets.json to reduce duplication and improve maintainability:

- Add hidden "default" base preset with common configuration
- Use preset inheritance to eliminate repeated settings
- Enable CMAKE_EXPORT_COMPILE_COMMANDS for all presets (IDE integration)
- Add cmakeMinimumRequired specification (CMake 3.16+)
- Reduce file size

Each preset now only defines its unique settings (build type, test flags) while inheriting compiler, install path, and dependency build options from the base preset. This makes it easier to update shared configuration in one place.

No functional changes - all presets maintain their original behavior.

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
