### PR TITLE
libhsakmt: Add kfdtest support for secondary KFD context testing

### DIFF
--- a/projects/rocr-runtime/libhsakmt/tests/kfdtest/CMakeLists.txt
+++ b/projects/rocr-runtime/libhsakmt/tests/kfdtest/CMakeLists.txt
@@ -247,6 +247,15 @@ link_directories(${HSAKMT_LIBRARY_DIRS})
 
 add_executable(kfdtest ${SRC_FILES})
 
+# Context-version test support
+if( ${HSAKMT_CTX} )
+    target_compile_definitions(kfdtest PRIVATE -DHSAKMT_CTX=1)
+    # Secondary context test support
+    if( ${HSAKMT_SECONDARY_CTX} )
+        target_compile_definitions(kfdtest PRIVATE -DHSAKMT_SECONDARY_CTX=1)
+    endif()
+endif()
+
 target_link_libraries(kfdtest ${HSAKMT_LIBRARIES} ${DRM_LDFLAGS} ${DRM_AMDGPU_LDFLAGS} ${llvm_libs} pthread m stdc++ rt numa)
 
 configure_file ( scripts/kfdtest.exclude kfdtest.exclude COPYONLY )

--- a/projects/rocr-runtime/libhsakmt/tests/kfdtest/src/BaseQueue.cpp
+++ b/projects/rocr-runtime/libhsakmt/tests/kfdtest/src/BaseQueue.cpp
@@ -30,7 +30,8 @@
 
 BaseQueue::BaseQueue()
     :m_QueueBuf(NULL),
-    m_SkipWaitConsumption(true) {
+    m_SkipWaitConsumption(true),
+    m_KFDContext(NULL) {
 }
 
 BaseQueue::~BaseQueue(void) {
@@ -45,7 +46,7 @@ HSAKMT_STATUS BaseQueue::Create(unsigned int NodeId, unsigned int size, HSAuint6
         // Queue already exists, one queue per object
         Destroy();
     }
-
+    m_KFDContext = g_baseTest->m_hsakmt_current_ctx;
     memset(&m_Resources, 0, sizeof(m_Resources));
 
     m_QueueBuf = new HsaMemoryBuffer(size, NodeId, true/*zero*/, false/*local*/, true/*exec*/,
@@ -57,24 +58,26 @@ HSAKMT_STATUS BaseQueue::Create(unsigned int NodeId, unsigned int size, HSAuint6
     }
 
     if (type == HSA_QUEUE_SDMA_BY_ENG_ID)
-        status = hsaKmtCreateQueueExt(NodeId,
-                                      type,
-                                      DEFAULT_QUEUE_PERCENTAGE,
-                                      DEFAULT_PRIORITY,
-                                      m_SdmaEngineId,
-                                      m_QueueBuf->As<unsigned int*>(),
-                                      m_QueueBuf->Size(),
-                                      NULL,
-                                      &m_Resources);
+        status = HSAKMT_CALL(hsaKmtCreateQueueExt, m_KFDContext,
+                             NodeId,
+                             type,
+                             DEFAULT_QUEUE_PERCENTAGE,
+                             DEFAULT_PRIORITY,
+                             m_SdmaEngineId,
+                             m_QueueBuf->As<unsigned int*>(),
+                             m_QueueBuf->Size(),
+                             NULL,
+                             &m_Resources);
     else
-        status = hsaKmtCreateQueue(NodeId,
-                                   type,
-                                   DEFAULT_QUEUE_PERCENTAGE,
-                                   DEFAULT_PRIORITY,
-                                   m_QueueBuf->As<unsigned int*>(),
-                                   m_QueueBuf->Size(),
-                                   NULL,
-                                   &m_Resources);
+        status = HSAKMT_CALL(hsaKmtCreateQueue, m_KFDContext,
+                             NodeId,
+                             type,
+                             DEFAULT_QUEUE_PERCENTAGE,
+                             DEFAULT_PRIORITY,
+                             m_QueueBuf->As<unsigned int*>(),
+                             m_QueueBuf->Size(),
+                             NULL,
+                             &m_Resources);
 
     if (status != HSAKMT_STATUS_SUCCESS) {
         return status;
@@ -102,18 +105,20 @@ HSAKMT_STATUS BaseQueue::Update(unsigned int percent, HSA_QUEUE_PRIORITY priorit
     void* pNewBuffer = (nullifyBuffer ? NULL : m_QueueBuf->As<void*>());
     HSAuint64 newSize = (nullifyBuffer ? 0 : m_QueueBuf->Size());
 
-    return hsaKmtUpdateQueue(m_Resources.QueueId, percent, priority, pNewBuffer, newSize, NULL);
+    return HSAKMT_CALL(hsaKmtUpdateQueue, m_KFDContext,
+                      m_Resources.QueueId, percent, priority, pNewBuffer, newSize, NULL);
 }
 
 HSAKMT_STATUS BaseQueue::SetCUMask(unsigned int *mask, unsigned int mask_count) {
-    return hsaKmtSetQueueCUMask(m_Resources.QueueId, mask_count, mask);
+    return HSAKMT_CALL(hsaKmtSetQueueCUMask, m_KFDContext,
+                      m_Resources.QueueId, mask_count, mask);
 }
 
 HSAKMT_STATUS BaseQueue::Destroy() {
     HSAKMT_STATUS status =  HSAKMT_STATUS_SUCCESS;
 
     if (m_QueueBuf != NULL) {
-        status = hsaKmtDestroyQueue(m_Resources.QueueId);
+        status = HSAKMT_CALL(hsaKmtDestroyQueue, m_KFDContext, m_Resources.QueueId);
 
         if (status == HSAKMT_STATUS_SUCCESS) {
             delete m_QueueBuf;

--- a/projects/rocr-runtime/libhsakmt/tests/kfdtest/src/BaseQueue.hpp
+++ b/projects/rocr-runtime/libhsakmt/tests/kfdtest/src/BaseQueue.hpp
@@ -102,6 +102,8 @@ class BaseQueue {
     unsigned int m_Node;
     unsigned int m_FamilyId;
     int m_SdmaEngineId;
+    // KFD Context this queue belongs to
+    HsaKFDContext *m_KFDContext;
 
     // @return Write pointer modulo queue size in dwords
     virtual unsigned int Wptr() = 0;

--- a/projects/rocr-runtime/libhsakmt/tests/kfdtest/src/Dispatch.cpp
+++ b/projects/rocr-runtime/libhsakmt/tests/kfdtest/src/Dispatch.cpp
@@ -42,7 +42,7 @@ Dispatch::Dispatch(const HsaMemoryBuffer& isaBuf, const bool eventAutoReset)
     eventDesc.SyncVar.SyncVar.UserData = NULL;
     eventDesc.SyncVar.SyncVarSize = 0;
 
-    hsaKmtCreateEvent(&eventDesc, !eventAutoReset, false, &m_pEop);
+    HSAKMT_CALL(hsaKmtCreateEvent, g_baseTest->m_hsakmt_current_ctx, &eventDesc, !eventAutoReset, false, &m_pEop);
 
     m_FamilyId  = g_baseTest->GetFamilyIdFromNodeId(isaBuf.Node());
     m_NeedCwsrWA = g_baseTest->NeedCwsrWA(isaBuf.Node());
@@ -50,7 +50,7 @@ Dispatch::Dispatch(const HsaMemoryBuffer& isaBuf, const bool eventAutoReset)
 
 Dispatch::~Dispatch() {
     if (m_pEop != NULL)
-        hsaKmtDestroyEvent(m_pEop);
+        HSAKMT_CALL(hsaKmtDestroyEvent, g_baseTest->m_hsakmt_current_ctx, m_pEop);
 }
 
 void Dispatch::SetArgs(void* pArg1, void* pArg2) {
@@ -99,14 +99,14 @@ void Dispatch::Submit(BaseQueue& queue) {
 }
 
 void Dispatch::Sync(unsigned int timeout) {
-    ASSERT_SUCCESS(hsaKmtWaitOnEvent(m_pEop, timeout));
+    ASSERT_SUCCESS(HSAKMT_CALL(hsaKmtWaitOnEvent, g_baseTest->m_hsakmt_current_ctx, m_pEop, timeout));
 }
 
 // Returning with status in order to allow actions to be performed before process termination
 int Dispatch::SyncWithStatus(unsigned int timeout) {
     int stat;
 
-    return ((stat = hsaKmtWaitOnEvent(m_pEop, timeout)) != HSAKMT_STATUS_SUCCESS);
+    return ((stat = HSAKMT_CALL(hsaKmtWaitOnEvent, g_baseTest->m_hsakmt_current_ctx, m_pEop, timeout)) != HSAKMT_STATUS_SUCCESS);
 }
 
 void Dispatch::BuildIb() {

--- a/projects/rocr-runtime/libhsakmt/tests/kfdtest/src/KFDBaseComponentTest.cpp
+++ b/projects/rocr-runtime/libhsakmt/tests/kfdtest/src/KFDBaseComponentTest.cpp
@@ -60,6 +60,7 @@ void KFDBaseComponentTest::SetUp() {
 
     EXPECT_SUCCESS(hsaKmtGetVersion(&m_VersionInfo));
 
+    g_baseTest = this;
     /** In order to be correctly testing the KFD interfaces and ensure
      *  that the KFD acknowledges relevant node parameters
      *  for the rest of the tests and used for more specific topology tests,
@@ -93,7 +94,6 @@ void KFDBaseComponentTest::SetUp() {
     GetHwQueueInfo(nodeProperties, &m_numCpQueues, &m_numSdmaEngines,
                     &m_numSdmaXgmiEngines, &m_numSdmaQueuesPerEngine);
 
-    g_baseTest = this;
 
     /* m_pAsm is default gpu assembler, keep it to support old test method */
     m_pAsm = new Assembler(GetGfxVersion(nodeProperties));

--- a/projects/rocr-runtime/libhsakmt/tests/kfdtest/src/KFDBaseComponentTest.cpp
+++ b/projects/rocr-runtime/libhsakmt/tests/kfdtest/src/KFDBaseComponentTest.cpp
@@ -40,17 +40,31 @@ void KFDBaseComponentTest::TearDownTestCase() {
 void KFDBaseComponentTest::SetUp() {
     ROUTINE_START
 
-    ASSERT_SUCCESS(hsaKmtOpenKFD());
-    EXPECT_SUCCESS(hsaKmtGetVersion(&m_VersionInfo));
-    memset( &m_SystemProperties, 0, sizeof(m_SystemProperties) );
+    memset(&m_SystemProperties, 0, sizeof(m_SystemProperties));
     memset(m_RenderNodes, 0, sizeof(m_RenderNodes));
+
+#ifdef HSAKMT_CTX
+    ASSERT_SUCCESS(hsaKmtOpenKFDCtx(&m_hsakmt_primary_ctx));
+    ASSERT_SUCCESS(HSAKMT_CALL(hsaKmtAcquireSystemProperties, m_hsakmt_primary_ctx, &m_SystemProperties));
+    m_hsakmt_current_ctx = m_hsakmt_primary_ctx;
+
+    #ifdef HSAKMT_SECONDARY_CTX
+        ASSERT_SUCCESS(hsaKmtOpenSecondaryKFDCtx(&m_hsakmt_secondary_ctx));
+        ASSERT_SUCCESS(HSAKMT_CALL(hsaKmtAcquireSystemProperties, m_hsakmt_secondary_ctx, &m_SystemProperties));
+        m_hsakmt_current_ctx = m_hsakmt_secondary_ctx;
+    #endif
+#else
+    ASSERT_SUCCESS(hsaKmtOpenKFD());
+    ASSERT_SUCCESS(hsaKmtAcquireSystemProperties(&m_SystemProperties));
+#endif
+
+    EXPECT_SUCCESS(hsaKmtGetVersion(&m_VersionInfo));
 
     /** In order to be correctly testing the KFD interfaces and ensure
      *  that the KFD acknowledges relevant node parameters
      *  for the rest of the tests and used for more specific topology tests,
      *  call to GetSystemProperties for a system snapshot of the topology here
      */
-    ASSERT_SUCCESS(hsaKmtAcquireSystemProperties(&m_SystemProperties));
     ASSERT_GT(m_SystemProperties.NumNodes, HSAuint32(0)) << "HSA has no nodes.";
 
     m_NodeInfo.Init(m_SystemProperties.NumNodes);
@@ -165,8 +179,17 @@ void KFDBaseComponentTest::TearDown() {
         drmClose(m_RenderNodes[i].fd);
     }
 
-    EXPECT_SUCCESS(hsaKmtReleaseSystemProperties());
+#ifdef HSAKMT_CTX
+    #ifdef HSAKMT_SECONDARY_CTX
+        EXPECT_SUCCESS(HSAKMT_CALL(hsaKmtReleaseSystemProperties, m_hsakmt_secondary_ctx));
+        EXPECT_SUCCESS(hsaKmtCloseSecondaryKFDCtx(m_hsakmt_secondary_ctx));
+    #endif
+    EXPECT_SUCCESS(HSAKMT_CALL(hsaKmtReleaseSystemProperties, m_hsakmt_primary_ctx));
+    EXPECT_SUCCESS(hsaKmtCloseKFDCtx());
+#else
+    EXPECT_SUCCESS(HSAKMT_CALL(hsaKmtReleaseSystemProperties, m_hsakmt_current_ctx));
     EXPECT_SUCCESS(hsaKmtCloseKFD());
+#endif
     g_baseTest = NULL;
 
     if (m_pAsm)
@@ -229,7 +252,7 @@ HSAuint64 KFDBaseComponentTest::GetSysMemSize() {
              * Compute total system memory size. KFD driver also computes
              * the system memory (si_meminfo) similarly
              */
-            EXPECT_SUCCESS(hsaKmtGetNodeMemoryProperties(node, 1, &cpuMemoryProps));
+            EXPECT_SUCCESS(HSAKMT_CALL(hsaKmtGetNodeMemoryProperties, m_hsakmt_current_ctx, node, 1, &cpuMemoryProps));
             systemMemSize += cpuMemoryProps.SizeInBytes;
         }
     }
@@ -245,7 +268,7 @@ HSAuint64 KFDBaseComponentTest::GetVramSize(int gpuNode) {
     EXPECT_NE((const HsaNodeProperties *)NULL, nodeProps);
     HSAuint32 numBanks = nodeProps->NumMemoryBanks;
     HsaMemoryProperties memoryProps[numBanks];
-    EXPECT_SUCCESS(hsaKmtGetNodeMemoryProperties(gpuNode, numBanks, memoryProps));
+    EXPECT_SUCCESS(HSAKMT_CALL(hsaKmtGetNodeMemoryProperties, m_hsakmt_current_ctx, gpuNode, numBanks, memoryProps));
     unsigned bank;
     for (bank = 0; bank < numBanks; bank++) {
         if (memoryProps[bank].HeapType == HSA_HEAPTYPE_FRAME_BUFFER_PRIVATE
@@ -312,7 +335,7 @@ int KFDBaseComponentTest::FindDRMRenderNode(int gpuNode) {
 
     nodeProperties = new HsaNodeProperties();
 
-    status = hsaKmtGetNodeProperties(gpuNode, nodeProperties);
+    status = HSAKMT_CALL(hsaKmtGetNodeProperties, m_hsakmt_current_ctx, gpuNode, nodeProperties);
     EXPECT_SUCCESS(status) << "Node index: " << gpuNode << "hsaKmtGetNodeProperties returned status " << status;
 
     if (status != HSAKMT_STATUS_SUCCESS) {

--- a/projects/rocr-runtime/libhsakmt/tests/kfdtest/src/KFDBaseComponentTest.hpp
+++ b/projects/rocr-runtime/libhsakmt/tests/kfdtest/src/KFDBaseComponentTest.hpp
@@ -36,6 +36,7 @@
 #include <algorithm>
 #include <future>
 #include "hsakmt/hsakmt.h"
+#include "hsakmt/hsakmtctx.h"
 #include "OSWrapper.hpp"
 #include "KFDTestUtil.hpp"
 #include "Assemble.hpp"
@@ -60,7 +61,7 @@ typedef struct _KFDTESTGPU_PARAMETERS
 //  @class KFDBaseComponentTest
 class KFDBaseComponentTest : public testing::Test {
  public:
-    KFDBaseComponentTest(void) { m_MemoryFlags.Value = 0; }
+    KFDBaseComponentTest(void) { m_MemoryFlags.Value = 0; m_hsakmt_current_ctx = NULL; }
     ~KFDBaseComponentTest(void) {}
 
     HSAuint64 GetSysMemSize();
@@ -116,7 +117,12 @@ class KFDBaseComponentTest : public testing::Test {
 
     HSAKMT_STATUS KFDTestLaunch(std::function<void(int)> test_func);
 
+    HsaKFDContext *m_hsakmt_current_ctx;
+
  protected:
+    HsaKFDContext *m_hsakmt_primary_ctx;
+    HsaKFDContext *m_hsakmt_secondary_ctx;
+
     HsaVersionInfo  m_VersionInfo;
     HsaSystemProperties m_SystemProperties;
     unsigned int m_FamilyId;

--- a/projects/rocr-runtime/libhsakmt/tests/kfdtest/src/KFDBaseComponentTest.hpp
+++ b/projects/rocr-runtime/libhsakmt/tests/kfdtest/src/KFDBaseComponentTest.hpp
@@ -166,7 +166,7 @@ class KFDBaseComponentTest : public testing::Test {
             return;
         }
         m_xnack = -1;
-        HSAKMT_STATUS ret = hsaKmtGetXNACKMode(&m_xnack);
+        HSAKMT_STATUS ret = HSAKMT_CALL(hsaKmtGetXNACKMode, m_hsakmt_current_ctx, &m_xnack);
         if (ret != HSAKMT_STATUS_SUCCESS) {
             LOG() << "Failed " << ret << " to get XNACK mode" << std::endl;
             return;
@@ -187,7 +187,7 @@ class KFDBaseComponentTest : public testing::Test {
         if (xnack_on == m_xnack)
             return;
 
-        ret = hsaKmtSetXNACKMode(xnack_on);
+        ret = HSAKMT_CALL(hsaKmtSetXNACKMode, m_hsakmt_current_ctx, xnack_on);
         if (ret != HSAKMT_STATUS_SUCCESS)
             LOG() << "Failed " << ret << " to set XNACK mode " << xnack_on << std::endl;
         else
@@ -201,7 +201,7 @@ class KFDBaseComponentTest : public testing::Test {
         if (m_xnack == -1)
             return;
 
-        hsaKmtSetXNACKMode(m_xnack);
+        HSAKMT_CALL(hsaKmtSetXNACKMode, m_hsakmt_current_ctx, m_xnack);
     }
 };
 

--- a/projects/rocr-runtime/libhsakmt/tests/kfdtest/src/KFDEventTest.cpp
+++ b/projects/rocr-runtime/libhsakmt/tests/kfdtest/src/KFDEventTest.cpp
@@ -47,7 +47,7 @@ void KFDEventTest::TearDown() {
     for (int i = 0; i < MAX_GPU; i++) {
         if (m_pHsaEventGPU[i] != NULL) {
             // hsaKmtDestroyEvent moved to TearDown to make sure it is being called
-            EXPECT_SUCCESS(hsaKmtDestroyEvent(m_pHsaEventGPU[i]));
+            EXPECT_SUCCESS(HSAKMT_CALL(hsaKmtDestroyEvent, m_hsakmt_current_ctx, m_pHsaEventGPU[i]));
         }
     }
 
@@ -92,7 +92,7 @@ void KFDEventTest::CreateMaxEvents(int gpuNode) {
     }
 
     for (i = 0; i < MAX_EVENT_NUMBER; i++) {
-        EXPECT_SUCCESS_GPU(hsaKmtDestroyEvent(pHsaEvent[i]), gpuNode);
+        EXPECT_SUCCESS_GPU(HSAKMT_CALL(hsaKmtDestroyEvent, m_hsakmt_current_ctx, pHsaEvent[i]), gpuNode);
     }
 }
 
@@ -131,9 +131,9 @@ void KFDEventTest::SignalEvent(int gpuNode) {
 
     queue.Wait4PacketConsumption();
 
-    EXPECT_SUCCESS_GPU(hsaKmtWaitOnEvent(m_pHsaEvent, g_TestTimeOut), gpuNode);
+    EXPECT_SUCCESS_GPU(HSAKMT_CALL(hsaKmtWaitOnEvent, m_hsakmt_current_ctx, m_pHsaEvent, g_TestTimeOut), gpuNode);
 
-    EXPECT_SUCCESS_GPU(hsaKmtDestroyEvent(tmp_event), gpuNode);
+    EXPECT_SUCCESS_GPU(HSAKMT_CALL(hsaKmtDestroyEvent, m_hsakmt_current_ctx, tmp_event), gpuNode);
 
     EXPECT_SUCCESS_GPU(queue.Destroy(), gpuNode);
 }
@@ -177,36 +177,36 @@ void KFDEventTest::SignalEventExt(int gpuNode) {
     event_age = 1;
     queue.PlaceAndSubmitPacket(PM4ReleaseMemoryPacket(m_FamilyId, false,
                     m_pHsaEvent->EventData.HWData2, m_pHsaEvent->EventId));
-    EXPECT_SUCCESS_GPU(hsaKmtWaitOnEvent_Ext(m_pHsaEvent, g_TestTimeOut, &event_age), gpuNode);
+    EXPECT_SUCCESS_GPU(HSAKMT_CALL(hsaKmtWaitOnEvent_Ext, m_hsakmt_current_ctx, m_pHsaEvent, g_TestTimeOut, &event_age), gpuNode);
     ASSERT_EQ_GPU(event_age, 2, gpuNode);
     queue.PlaceAndSubmitPacket(PM4ReleaseMemoryPacket(m_FamilyId, false,
                     m_pHsaEvent->EventData.HWData2, m_pHsaEvent->EventId));
-    EXPECT_SUCCESS_GPU(hsaKmtWaitOnEvent_Ext(m_pHsaEvent, g_TestTimeOut, &event_age), gpuNode);
+    EXPECT_SUCCESS_GPU(HSAKMT_CALL(hsaKmtWaitOnEvent_Ext, m_hsakmt_current_ctx, m_pHsaEvent, g_TestTimeOut, &event_age), gpuNode);
     ASSERT_EQ_GPU(event_age, 3, gpuNode);
 
     /* 2. event wait return without sleep after the event signals */
     queue.PlaceAndSubmitPacket(PM4ReleaseMemoryPacket(m_FamilyId, false,
                     m_pHsaEvent->EventData.HWData2, m_pHsaEvent->EventId));
     sleep(1); /* wait for event signaling */
-    EXPECT_SUCCESS_GPU(hsaKmtWaitOnEvent_Ext(m_pHsaEvent, g_TestTimeOut, &event_age), gpuNode);
+    EXPECT_SUCCESS_GPU(HSAKMT_CALL(hsaKmtWaitOnEvent_Ext, m_hsakmt_current_ctx, m_pHsaEvent, g_TestTimeOut, &event_age), gpuNode);
     ASSERT_EQ_GPU(event_age, 4, gpuNode);
 
     /* 3. signaling from CPU */
-    hsaKmtSetEvent(m_pHsaEvent);
-    EXPECT_SUCCESS_GPU(hsaKmtWaitOnEvent_Ext(m_pHsaEvent, g_TestTimeOut, &event_age), gpuNode);
+    HSAKMT_CALL(hsaKmtSetEvent, m_hsakmt_current_ctx, m_pHsaEvent);
+    EXPECT_SUCCESS_GPU(HSAKMT_CALL(hsaKmtWaitOnEvent_Ext, m_hsakmt_current_ctx, m_pHsaEvent, g_TestTimeOut, &event_age), gpuNode);
     ASSERT_EQ_GPU(event_age, 5, gpuNode);
 
     /* 4. when event_age is 0, hsaKmtWaitOnEvent_Ext always sleeps */
     event_age = 0;
-    ASSERT_EQ_GPU(HSAKMT_STATUS_WAIT_TIMEOUT, hsaKmtWaitOnEvent_Ext(m_pHsaEvent, g_TestTimeOut, &event_age), gpuNode);
+    ASSERT_EQ_GPU(HSAKMT_STATUS_WAIT_TIMEOUT, HSAKMT_CALL(hsaKmtWaitOnEvent_Ext, m_hsakmt_current_ctx, m_pHsaEvent, g_TestTimeOut, &event_age), gpuNode);
 
     /* 5. when event_age is 0, it always stays 0 after the event signals */
     queue.PlaceAndSubmitPacket(PM4ReleaseMemoryPacket(m_FamilyId, false,
                     m_pHsaEvent->EventData.HWData2, m_pHsaEvent->EventId));
-    EXPECT_SUCCESS(hsaKmtWaitOnEvent_Ext(m_pHsaEvent, g_TestTimeOut, &event_age));
+    EXPECT_SUCCESS(HSAKMT_CALL(hsaKmtWaitOnEvent_Ext, m_hsakmt_current_ctx, m_pHsaEvent, g_TestTimeOut, &event_age));
     ASSERT_EQ(event_age, 0);
 
-    EXPECT_SUCCESS(hsaKmtDestroyEvent(tmp_event));
+    EXPECT_SUCCESS(HSAKMT_CALL(hsaKmtDestroyEvent, m_hsakmt_current_ctx, tmp_event));
 
     EXPECT_SUCCESS(queue.Destroy());
 
@@ -274,7 +274,7 @@ class QueueAndSignalBenchmark {
         startTime = gettime();
         queue.SubmitPacket();
         for (int i = 0; i < eventCount; i++) {
-            r = hsaKmtWaitOnEvent(pHsaEvent[i], g_TestTimeOut);
+            r = HSAKMT_CALL(hsaKmtWaitOnEvent, g_baseTest->m_hsakmt_current_ctx, pHsaEvent[i], g_TestTimeOut);
 
             if (r != HSAKMT_STATUS_SUCCESS)
                 goto exit;
@@ -287,7 +287,7 @@ class QueueAndSignalBenchmark {
 exit:
         for (int i = 0; i < eventCount; i++) {
             if (pHsaEvent[i])
-                hsaKmtDestroyEvent(pHsaEvent[i]);
+                HSAKMT_CALL(hsaKmtDestroyEvent, g_baseTest->m_hsakmt_current_ctx, pHsaEvent[i]);
         }
         queue.Destroy();
 
@@ -397,12 +397,12 @@ void KFDEventTest::SignalMultipleEventsWaitForAll(int gpuNode) {
         Delay(WAIT_BETWEEN_SUBMISSIONS_MS);
     }
 
-    EXPECT_SUCCESS_GPU(hsaKmtWaitOnMultipleEvents(pHsaEvent, EVENT_NUMBER, true, g_TestTimeOut), gpuNode);
+    EXPECT_SUCCESS_GPU(HSAKMT_CALL(hsaKmtWaitOnMultipleEvents, m_hsakmt_current_ctx, pHsaEvent, EVENT_NUMBER, true, g_TestTimeOut), gpuNode);
 
     EXPECT_SUCCESS_GPU(queue.Destroy(), gpuNode);
 
     for (i = 0; i < EVENT_NUMBER; i++)
-        EXPECT_SUCCESS_GPU(hsaKmtDestroyEvent(pHsaEvent[i]), gpuNode);
+        EXPECT_SUCCESS_GPU(HSAKMT_CALL(hsaKmtDestroyEvent, m_hsakmt_current_ctx, pHsaEvent[i]), gpuNode);
 }
 
 TEST_F(KFDEventTest, SignalMultipleEventsWaitForAll) {
@@ -453,7 +453,7 @@ void KFDEventTest::SignalInvalidEvent(int gpuNode) {
         HSAuint64 startTime = GetSystemTickCountInMicroSec();
         queue.SubmitPacket();
 
-        EXPECT_SUCCESS_GPU(hsaKmtWaitOnEvent(m_pHsaEvent, g_TestTimeOut), gpuNode);
+        EXPECT_SUCCESS_GPU(HSAKMT_CALL(hsaKmtWaitOnEvent, m_hsakmt_current_ctx, m_pHsaEvent, g_TestTimeOut), gpuNode);
 
         duration[i] = GetSystemTickCountInMicroSec() - startTime;
         total += duration[i];
@@ -492,7 +492,7 @@ void KFDEventTest::SignalInvalidEvent(int gpuNode) {
     EXPECT_SUCCESS_GPU(queue.Destroy(), gpuNode);
 
     for (int i = 0; i < EVENT_NUMBER; i++)
-        EXPECT_SUCCESS_GPU(hsaKmtDestroyEvent(pHsaEvent[i]), gpuNode);
+        EXPECT_SUCCESS_GPU(HSAKMT_CALL(hsaKmtDestroyEvent, m_hsakmt_current_ctx, pHsaEvent[i]), gpuNode);
 
 }
 

--- a/projects/rocr-runtime/libhsakmt/tests/kfdtest/src/KFDEvictTest.cpp
+++ b/projects/rocr-runtime/libhsakmt/tests/kfdtest/src/KFDEvictTest.cpp
@@ -73,12 +73,12 @@ void KFDEvictTest::AllocBuffers(bool m_IsParent, HSAuint32 defaultGPUNode, HSAui
     m_Flags.ui32.NonPaged = 1;
 
     for (HSAuint32 i = 0; i < count; ) {
-        ret = hsaKmtAllocMemory(defaultGPUNode, vramBufSize, m_Flags, &m_pBuf);
+        ret = HSAKMT_CALL(hsaKmtAllocMemory, m_hsakmt_current_ctx, defaultGPUNode, vramBufSize, m_Flags, &m_pBuf);
         if (ret == HSAKMT_STATUS_SUCCESS) {
             if (hsakmt_is_dgpu()) {
-                if (hsaKmtMapMemoryToGPUNodes(m_pBuf, vramBufSize, NULL,
+                if (HSAKMT_CALL(hsaKmtMapMemoryToGPUNodes, m_hsakmt_current_ctx, m_pBuf, vramBufSize, NULL,
                        mapFlags, 1, reinterpret_cast<HSAuint32 *>(&defaultGPUNode)) == HSAKMT_STATUS_ERROR) {
-                    EXPECT_SUCCESS(hsaKmtFreeMemory(m_pBuf, vramBufSize));
+                    EXPECT_SUCCESS(HSAKMT_CALL(hsaKmtFreeMemory, m_hsakmt_current_ctx, m_pBuf, vramBufSize));
                     LOG() << "Map failed for " << i << "/" << count << " buffer. Retrying allocation" << std::endl;
                     goto retry;
                 }
@@ -104,8 +104,8 @@ void KFDEvictTest::FreeBuffers(std::vector<void *> &pBuffers, HSAuint64 vramBufS
         m_pBuf = pBuffers[i];
         if (m_pBuf != NULL) {
             if (hsakmt_is_dgpu())
-                EXPECT_SUCCESS(hsaKmtUnmapMemoryToGPU(m_pBuf));
-            EXPECT_SUCCESS(hsaKmtFreeMemory(m_pBuf, vramBufSize));
+                EXPECT_SUCCESS(HSAKMT_CALL(hsaKmtUnmapMemoryToGPU, m_hsakmt_current_ctx, m_pBuf));
+            EXPECT_SUCCESS(HSAKMT_CALL(hsaKmtFreeMemory, m_hsakmt_current_ctx, m_pBuf, vramBufSize));
         }
     }
 }

--- a/projects/rocr-runtime/libhsakmt/tests/kfdtest/src/KFDExceptionTest.cpp
+++ b/projects/rocr-runtime/libhsakmt/tests/kfdtest/src/KFDExceptionTest.cpp
@@ -81,7 +81,7 @@ void KFDExceptionTest::TestMemoryException(int gpuNode, HSAuint64 pSrc,
         WARN() << "Queue create failed, on gpuNode: " << gpuNode << std::endl;
         return;
     }
-    m_ChildStatus = hsaKmtCreateEvent(&eventDesc, true, false, &vmFaultEvent);
+    m_ChildStatus = HSAKMT_CALL(hsaKmtCreateEvent, m_hsakmt_current_ctx, &eventDesc, true, false, &vmFaultEvent);
     if (m_ChildStatus != HSAKMT_STATUS_SUCCESS) {
         WARN() << "Event create failed on gpuNode: " << gpuNode << std::endl;
         goto queuefail;
@@ -91,7 +91,7 @@ void KFDExceptionTest::TestMemoryException(int gpuNode, HSAuint64 pSrc,
     dispatch.SetArgs(reinterpret_cast<void *>(pSrc), reinterpret_cast<void *>(pDst));
     dispatch.Submit(queue);
 
-    m_ChildStatus = hsaKmtWaitOnEvent(vmFaultEvent, g_TestTimeOut);
+    m_ChildStatus = HSAKMT_CALL(hsaKmtWaitOnEvent, m_hsakmt_current_ctx, vmFaultEvent, g_TestTimeOut);
     if (m_ChildStatus != HSAKMT_STATUS_SUCCESS) {
         WARN() << "Wait failed. No Exception triggered on gpuNode: " << gpuNode << std::endl;
         goto eventfail;
@@ -113,7 +113,7 @@ void KFDExceptionTest::TestMemoryException(int gpuNode, HSAuint64 pSrc,
     }
 
 eventfail:
-    hsaKmtDestroyEvent(vmFaultEvent);
+    HSAKMT_CALL(hsaKmtDestroyEvent, m_hsakmt_current_ctx, vmFaultEvent);
 queuefail:
     queue.Destroy();
 }
@@ -136,7 +136,7 @@ void KFDExceptionTest::TestSdmaException(int gpuNode, void *pDst) {
         return;
     }
 
-    m_ChildStatus = hsaKmtCreateEvent(&eventDesc, true, false, &vmFaultEvent);
+    m_ChildStatus = HSAKMT_CALL(hsaKmtCreateEvent, m_hsakmt_current_ctx, &eventDesc, true, false, &vmFaultEvent);
     if (m_ChildStatus != HSAKMT_STATUS_SUCCESS) {
         WARN() << "Event create failed on gpuNode: " << gpuNode << std::endl;
         goto queuefail;
@@ -146,7 +146,7 @@ void KFDExceptionTest::TestSdmaException(int gpuNode, void *pDst) {
                                                    reinterpret_cast<void *>(pDst),
                                                    0x02020202));
 
-    m_ChildStatus = hsaKmtWaitOnEvent(vmFaultEvent, g_TestTimeOut);
+    m_ChildStatus = HSAKMT_CALL(hsaKmtWaitOnEvent, m_hsakmt_current_ctx, vmFaultEvent, g_TestTimeOut);
     if (m_ChildStatus != HSAKMT_STATUS_SUCCESS) {
         WARN() << "Wait failed. No Exception triggered on gpuNode: " << gpuNode << std::endl;
         goto eventfail;
@@ -166,7 +166,7 @@ void KFDExceptionTest::TestSdmaException(int gpuNode, void *pDst) {
     }
 
 eventfail:
-    hsaKmtDestroyEvent(vmFaultEvent);
+    HSAKMT_CALL(hsaKmtDestroyEvent, m_hsakmt_current_ctx, vmFaultEvent);
 queuefail:
     queue.Destroy();
 }
@@ -289,8 +289,8 @@ void KFDExceptionTest::PermissionFaultUserPointer(int gpuNode) {
          void *pBuf = mmap(NULL, PAGE_SIZE, PROT_READ,
                       MAP_ANONYMOUS | MAP_PRIVATE, -1, 0);
          ASSERT_NE(pBuf, MAP_FAILED);
-         EXPECT_SUCCESS(hsaKmtRegisterMemory(pBuf, PAGE_SIZE));
-         EXPECT_SUCCESS(hsaKmtMapMemoryToGPU(pBuf, PAGE_SIZE, NULL));
+         EXPECT_SUCCESS(HSAKMT_CALL(hsaKmtRegisterMemory, m_hsakmt_current_ctx, pBuf, PAGE_SIZE));
+         EXPECT_SUCCESS(HSAKMT_CALL(hsaKmtMapMemoryToGPU, m_hsakmt_current_ctx, pBuf, PAGE_SIZE, NULL));
          HsaMemoryBuffer srcSysBuffer(PAGE_SIZE, gpuNode, false);
 
          srcSysBuffer.Fill(0xAA55AA55);
@@ -397,15 +397,15 @@ void KFDExceptionTest::SdmaQueueException(int gpuNode) {
        // setting memory flags with default values , can be modified according to needs
         m_MemoryFlags.ui32.NonPaged = 1;                         // Paged
         m_MemoryFlags.ui32.HostAccess = 0;                       // Host accessible
-        ASSERT_SUCCESS_GPU(hsaKmtAllocMemory(gpuNode, PAGE_SIZE, m_MemoryFlags,
+        ASSERT_SUCCESS_GPU(HSAKMT_CALL(hsaKmtAllocMemory, m_hsakmt_current_ctx, gpuNode, PAGE_SIZE, m_MemoryFlags,
                                   reinterpret_cast<void**>(&pDb)), gpuNode);
         // verify that pDb is not null before it's being used
         ASSERT_NE_GPU(nullPtr, pDb, gpuNode) << "hsaKmtAllocMemory returned a null pointer";
-        ASSERT_SUCCESS_GPU(hsaKmtMapMemoryToGPU(pDb, PAGE_SIZE, NULL), gpuNode);
-        EXPECT_SUCCESS_GPU(hsaKmtUnmapMemoryToGPU(pDb), gpuNode);
+        ASSERT_SUCCESS_GPU(HSAKMT_CALL(hsaKmtMapMemoryToGPU, m_hsakmt_current_ctx, pDb, PAGE_SIZE, NULL), gpuNode);
+        EXPECT_SUCCESS_GPU(HSAKMT_CALL(hsaKmtUnmapMemoryToGPU, m_hsakmt_current_ctx, pDb), gpuNode);
 
         TestSdmaException(gpuNode, pDb);
-        EXPECT_SUCCESS_GPU(hsaKmtFreeMemory(pDb, PAGE_SIZE), gpuNode);
+        EXPECT_SUCCESS_GPU(HSAKMT_CALL(hsaKmtFreeMemory, m_hsakmt_current_ctx, pDb, PAGE_SIZE), gpuNode);
 
         exit(0);
     } else {

--- a/projects/rocr-runtime/libhsakmt/tests/kfdtest/src/KFDGWSTest.cpp
+++ b/projects/rocr-runtime/libhsakmt/tests/kfdtest/src/KFDGWSTest.cpp
@@ -55,7 +55,7 @@ void KFDGWSTest::Allocate(int gpuNode) {
     }
 
     ASSERT_SUCCESS_GPU(queue.Create(gpuNode), gpuNode);
-    ASSERT_SUCCESS_GPU(hsaKmtAllocQueueGWS(queue.GetResource()->QueueId,
+    ASSERT_SUCCESS_GPU(HSAKMT_CALL(hsaKmtAllocQueueGWS, m_hsakmt_current_ctx, queue.GetResource()->QueueId,
                        pNodeProperties->NumGws,&firstGWS), gpuNode);
     EXPECT_EQ_GPU(0, firstGWS, gpuNode);
     EXPECT_SUCCESS_GPU(queue.Destroy(), gpuNode);
@@ -88,7 +88,7 @@ void KFDGWSTest::Semaphore(int gpuNode) {
     HsaMemoryBuffer isaBuffer(PAGE_SIZE, gpuNode, true/*zero*/, false/*local*/, true/*exec*/);
     HsaMemoryBuffer buffer(PAGE_SIZE, gpuNode, true, false, false);
     ASSERT_SUCCESS(queue.Create(gpuNode));
-    ASSERT_SUCCESS_GPU(hsaKmtAllocQueueGWS(queue.GetResource()->QueueId,
+    ASSERT_SUCCESS_GPU(HSAKMT_CALL(hsaKmtAllocQueueGWS, m_hsakmt_current_ctx, queue.GetResource()->QueueId,
                        pNodeProperties->NumGws,&firstGWS), gpuNode);
     EXPECT_EQ_GPU(0, firstGWS, gpuNode);
 

--- a/projects/rocr-runtime/libhsakmt/tests/kfdtest/src/KFDGraphicsInterop.cpp
+++ b/projects/rocr-runtime/libhsakmt/tests/kfdtest/src/KFDGraphicsInterop.cpp
@@ -77,7 +77,7 @@ void KFDGraphicsInterop::RegisterGraphicsHandle(int gpuNode) {
 
     // Register it with HSA
     HsaGraphicsResourceInfo info;
-    ASSERT_SUCCESS_GPU(hsaKmtRegisterGraphicsHandleToNodes(dmabufFd, &info,
+    ASSERT_SUCCESS_GPU(HSAKMT_CALL(hsaKmtRegisterGraphicsHandleToNodes, m_hsakmt_current_ctx, dmabufFd, &info,
                                                        1, nodes), gpuNode);
 
     /* DMA buffer handle and GEM handle are no longer needed, KFD
@@ -92,7 +92,7 @@ void KFDGraphicsInterop::RegisterGraphicsHandle(int gpuNode) {
     EXPECT_EQ_GPU(0, strcmp(metadata, (const char *)info.Metadata), gpuNode);
 
     // Map the buffer
-    ASSERT_SUCCESS_GPU(hsaKmtMapMemoryToGPU(info.MemoryAddress,
+    ASSERT_SUCCESS_GPU(HSAKMT_CALL(hsaKmtMapMemoryToGPU, m_hsakmt_current_ctx, info.MemoryAddress,
                                         info.SizeInBytes,
                                         NULL), gpuNode);
 
@@ -121,7 +121,7 @@ void KFDGraphicsInterop::RegisterGraphicsHandle(int gpuNode) {
 
     // Test QueryMem before the cleanup
     HsaPointerInfo ptrInfo;
-    EXPECT_SUCCESS_GPU(hsaKmtQueryPointerInfo((const void *)info.MemoryAddress, &ptrInfo), gpuNode);
+    EXPECT_SUCCESS_GPU(HSAKMT_CALL(hsaKmtQueryPointerInfo, m_hsakmt_current_ctx, (const void *)info.MemoryAddress, &ptrInfo), gpuNode);
     EXPECT_EQ_GPU(ptrInfo.Type, HSA_POINTER_REGISTERED_GRAPHICS, gpuNode);
     EXPECT_EQ_GPU(ptrInfo.Node, (HSAuint32)gpuNode, gpuNode);
     EXPECT_EQ_GPU(ptrInfo.GPUAddress, (HSAuint64)info.MemoryAddress, gpuNode);
@@ -129,8 +129,8 @@ void KFDGraphicsInterop::RegisterGraphicsHandle(int gpuNode) {
     EXPECT_EQ_GPU(ptrInfo.MemFlags.ui32.CoarseGrain, 1, gpuNode);
 
     // Cleanup
-    EXPECT_SUCCESS_GPU(hsaKmtUnmapMemoryToGPU(info.MemoryAddress), gpuNode);
-    EXPECT_SUCCESS_GPU(hsaKmtDeregisterMemory(info.MemoryAddress), gpuNode);
+    EXPECT_SUCCESS_GPU(HSAKMT_CALL(hsaKmtUnmapMemoryToGPU, m_hsakmt_current_ctx, info.MemoryAddress), gpuNode);
+    EXPECT_SUCCESS_GPU(HSAKMT_CALL(hsaKmtDeregisterMemory, m_hsakmt_current_ctx, info.MemoryAddress), gpuNode);
 
 }
 

--- a/projects/rocr-runtime/libhsakmt/tests/kfdtest/src/KFDIPCTest.cpp
+++ b/projects/rocr-runtime/libhsakmt/tests/kfdtest/src/KFDIPCTest.cpp
@@ -83,9 +83,9 @@ void KFDIPCTest::BasicTestChildProcess(int defaultGPUNode, int *pipefd, HsaMemFl
     /* Read from Pipe the shared Handle. Import shared Local Memory */
     ASSERT_GE(read(pipefd[0], reinterpret_cast<void*>(&sharedHandleLM), sizeof(sharedHandleLM)), 0);
 
-    ASSERT_SUCCESS(hsaKmtRegisterSharedHandle(&sharedHandleLM,
+    ASSERT_SUCCESS(HSAKMT_CALL(hsaKmtRegisterSharedHandle, m_hsakmt_current_ctx, &sharedHandleLM,
                   reinterpret_cast<void**>(&sharedLocalBuffer), &sharedSize));
-    ASSERT_SUCCESS(hsaKmtMapMemoryToGPUNodes(sharedLocalBuffer, sharedSize, NULL,
+    ASSERT_SUCCESS(HSAKMT_CALL(hsaKmtMapMemoryToGPUNodes, m_hsakmt_current_ctx, sharedLocalBuffer, sharedSize, NULL,
                   mapFlags, 1, reinterpret_cast<HSAuint32 *>(&defaultGPUNode)));
 
     /* Check for pattern in the shared Local Memory */
@@ -101,7 +101,7 @@ void KFDIPCTest::BasicTestChildProcess(int defaultGPUNode, int *pipefd, HsaMemFl
     sdmaQueue.Wait4PacketConsumption();
 
     HsaPointerInfo ptrInfo;
-    EXPECT_SUCCESS(hsaKmtQueryPointerInfo(sharedLocalBuffer, &ptrInfo));
+    EXPECT_SUCCESS(HSAKMT_CALL(hsaKmtQueryPointerInfo, m_hsakmt_current_ctx, sharedLocalBuffer, &ptrInfo));
     EXPECT_EQ(ptrInfo.Type, HSA_POINTER_REGISTERED_SHARED);
     EXPECT_EQ(ptrInfo.Node, (HSAuint32)defaultGPUNode);
     EXPECT_EQ(ptrInfo.GPUAddress, (HSAuint64)sharedLocalBuffer);
@@ -110,8 +110,8 @@ void KFDIPCTest::BasicTestChildProcess(int defaultGPUNode, int *pipefd, HsaMemFl
 
     /* Clean up */
     EXPECT_SUCCESS(sdmaQueue.Destroy());
-    EXPECT_SUCCESS(hsaKmtUnmapMemoryToGPU(sharedLocalBuffer));
-    EXPECT_SUCCESS(hsaKmtDeregisterMemory(sharedLocalBuffer));
+    EXPECT_SUCCESS(HSAKMT_CALL(hsaKmtUnmapMemoryToGPU, m_hsakmt_current_ctx, sharedLocalBuffer));
+    EXPECT_SUCCESS(HSAKMT_CALL(hsaKmtDeregisterMemory, m_hsakmt_current_ctx, sharedLocalBuffer));
 }
 
 /* Fill a pattern into Local Memory and share with the child process.
@@ -129,9 +129,9 @@ void KFDIPCTest::BasicTestParentProcess(int defaultGPUNode, pid_t cpid, int *pip
     HsaSharedMemoryHandle sharedHandleLM;
     HsaMemMapFlags mapFlags = {0};
 
-    ASSERT_SUCCESS(hsaKmtAllocMemory(defaultGPUNode, size, mflags, &toShareLocalBuffer));
+    ASSERT_SUCCESS(HSAKMT_CALL(hsaKmtAllocMemory, m_hsakmt_current_ctx, defaultGPUNode, size, mflags, &toShareLocalBuffer));
     /* Fill a Local Buffer with a pattern */
-    ASSERT_SUCCESS(hsaKmtMapMemoryToGPUNodes(toShareLocalBuffer, size, &AlternateVAGPU,
+    ASSERT_SUCCESS(HSAKMT_CALL(hsaKmtMapMemoryToGPUNodes, m_hsakmt_current_ctx, toShareLocalBuffer, size, &AlternateVAGPU,
                        mapFlags, 1, reinterpret_cast<HSAuint32 *>(&defaultGPUNode)));
     tempSysBuffer.Fill(0xAAAAAAAA);
 
@@ -142,7 +142,7 @@ void KFDIPCTest::BasicTestParentProcess(int defaultGPUNode, pid_t cpid, int *pip
     sdmaQueue.Wait4PacketConsumption();
 
     /* Share it with the child process */
-    ASSERT_SUCCESS(hsaKmtShareMemory(toShareLocalBuffer, size, &sharedHandleLM));
+    ASSERT_SUCCESS(HSAKMT_CALL(hsaKmtShareMemory, m_hsakmt_current_ctx, toShareLocalBuffer, size, &sharedHandleLM));
 
     ASSERT_GE(write(pipefd[1], reinterpret_cast<void*>(&sharedHandleLM), sizeof(sharedHandleLM)), 0);
 
@@ -159,7 +159,7 @@ void KFDIPCTest::BasicTestParentProcess(int defaultGPUNode, pid_t cpid, int *pip
     EXPECT_TRUE(WaitOnValue(tempSysBuffer.As<HSAuint32*>(), 0xBBBBBBBB));
 
     /* Clean up */
-    EXPECT_SUCCESS(hsaKmtUnmapMemoryToGPU(toShareLocalBuffer));
+    EXPECT_SUCCESS(HSAKMT_CALL(hsaKmtUnmapMemoryToGPU, m_hsakmt_current_ctx, toShareLocalBuffer));
     EXPECT_SUCCESS(sdmaQueue.Destroy());
 }
 

--- a/projects/rocr-runtime/libhsakmt/tests/kfdtest/src/KFDLocalMemoryTest.cpp
+++ b/projects/rocr-runtime/libhsakmt/tests/kfdtest/src/KFDLocalMemoryTest.cpp
@@ -101,9 +101,9 @@ void KFDLocalMemoryTest::BasicTest(int gpuNode) {
 
     ASSERT_SUCCESS_GPU(m_pAsm->RunAssembleBuf(CopyDwordIsa, isaBuffer.As<char*>()), gpuNode);
 
-    ASSERT_SUCCESS_GPU(hsaKmtMapMemoryToGPUNodes(srcLocalBuffer.As<void*>(), srcLocalBuffer.Size(), &AlternateVAGPU,
+    ASSERT_SUCCESS_GPU(HSAKMT_CALL(hsaKmtMapMemoryToGPUNodes, m_hsakmt_current_ctx, srcLocalBuffer.As<void*>(), srcLocalBuffer.Size(), &AlternateVAGPU,
                        mapFlags, 1, reinterpret_cast<HSAuint32 *>(&gpuNode)), gpuNode);
-    ASSERT_SUCCESS_GPU(hsaKmtMapMemoryToGPUNodes(dstLocalBuffer.As<void*>(), dstLocalBuffer.Size(), &AlternateVAGPU,
+    ASSERT_SUCCESS_GPU(HSAKMT_CALL(hsaKmtMapMemoryToGPUNodes, m_hsakmt_current_ctx, dstLocalBuffer.As<void*>(), dstLocalBuffer.Size(), &AlternateVAGPU,
                        mapFlags, 1, reinterpret_cast<HSAuint32 *>(&gpuNode)), gpuNode);
 
     ASSERT_SUCCESS_GPU(queue.Create(gpuNode), gpuNode);
@@ -125,8 +125,8 @@ void KFDLocalMemoryTest::BasicTest(int gpuNode) {
 
     EXPECT_SUCCESS_GPU(queue.Destroy(), gpuNode);
 
-    ASSERT_SUCCESS_GPU(hsaKmtUnmapMemoryToGPU(srcLocalBuffer.As<void*>()), gpuNode);
-    ASSERT_SUCCESS_GPU(hsaKmtUnmapMemoryToGPU(dstLocalBuffer.As<void*>()), gpuNode);
+    ASSERT_SUCCESS_GPU(HSAKMT_CALL(hsaKmtUnmapMemoryToGPU, m_hsakmt_current_ctx, srcLocalBuffer.As<void*>()), gpuNode);
+    ASSERT_SUCCESS_GPU(HSAKMT_CALL(hsaKmtUnmapMemoryToGPU, m_hsakmt_current_ctx, dstLocalBuffer.As<void*>()), gpuNode);
     EXPECT_EQ_GPU(destSysBuffer.As<unsigned int*>()[0], 0x01010101, gpuNode);
 
 }
@@ -166,7 +166,7 @@ void KFDLocalMemoryTest::VerifyContentsAfterUnmapAndMap(int gpuNode)
     queue.SetSkipWaitConsump(0);
 
     if (!hsakmt_is_dgpu())
-        ASSERT_SUCCESS_GPU(hsaKmtMapMemoryToGPUNodes(LocalBuffer.As<void*>(), LocalBuffer.Size(), &AlternateVAGPU,
+        ASSERT_SUCCESS_GPU(HSAKMT_CALL(hsaKmtMapMemoryToGPUNodes, m_hsakmt_current_ctx, LocalBuffer.As<void*>(), LocalBuffer.Size(), &AlternateVAGPU,
                            mapFlags, 1, reinterpret_cast<HSAuint32 *>(&gpuNode)), gpuNode);
 
     Dispatch dispatch(isaBuffer);
@@ -175,8 +175,8 @@ void KFDLocalMemoryTest::VerifyContentsAfterUnmapAndMap(int gpuNode)
     dispatch.Submit(queue);
     dispatch.Sync(g_TestTimeOut);
 
-    EXPECT_SUCCESS_GPU(hsaKmtUnmapMemoryToGPU(LocalBuffer.As<void*>()), gpuNode);
-    EXPECT_SUCCESS_GPU(hsaKmtMapMemoryToGPUNodes(LocalBuffer.As<void*>(), LocalBuffer.Size(), &AlternateVAGPU,
+    EXPECT_SUCCESS_GPU(HSAKMT_CALL(hsaKmtUnmapMemoryToGPU, m_hsakmt_current_ctx, LocalBuffer.As<void*>()), gpuNode);
+    EXPECT_SUCCESS_GPU(HSAKMT_CALL(hsaKmtMapMemoryToGPUNodes, m_hsakmt_current_ctx, LocalBuffer.As<void*>(), LocalBuffer.Size(), &AlternateVAGPU,
                        mapFlags, 1, reinterpret_cast<HSAuint32 *>(&gpuNode)), gpuNode);
 
     dispatch.SetArgs(LocalBuffer.As<void*>(), SysBufferB.As<void*>());
@@ -186,7 +186,7 @@ void KFDLocalMemoryTest::VerifyContentsAfterUnmapAndMap(int gpuNode)
     EXPECT_SUCCESS_GPU(queue.Destroy(), gpuNode);
     EXPECT_EQ_GPU(SysBufferB.As<unsigned int*>()[0], 0x01010101, gpuNode);
     if (!hsakmt_is_dgpu())
-        EXPECT_SUCCESS_GPU(hsaKmtUnmapMemoryToGPU(LocalBuffer.As<void*>()), gpuNode);
+        EXPECT_SUCCESS_GPU(HSAKMT_CALL(hsaKmtUnmapMemoryToGPU, m_hsakmt_current_ctx, LocalBuffer.As<void*>()), gpuNode);
 }
 
 TEST_F(KFDLocalMemoryTest, VerifyContentsAfterUnmapAndMap) {
@@ -355,7 +355,7 @@ void KFDLocalMemoryTest::Fragmentation(int gpuNode){
         LOG() << std::dec << "Trying to allocate " << pages[order].nPages
               << " order " << order << " blocks " << std::endl;
         for (p = 0; p < pages[order].nPages; p++) {
-            status = hsaKmtAllocMemory(gpuNode, size,
+            status = HSAKMT_CALL(hsaKmtAllocMemory, m_hsakmt_current_ctx, gpuNode, size,
                                        memFlags, &pages[order].pointers[p]);
             if (status != HSAKMT_STATUS_SUCCESS) {
                 EXPECT_EQ_GPU(HSAKMT_STATUS_NO_MEMORY, status, gpuNode);
@@ -367,10 +367,10 @@ void KFDLocalMemoryTest::Fragmentation(int gpuNode){
                                        + size - sizeof(unsigned));
             sysBuffer.As<unsigned *>()[0] = ++value;
 
-            status = hsaKmtMapMemoryToGPUNodes(pages[order].pointers[p], size, NULL,
+            status = HSAKMT_CALL(hsaKmtMapMemoryToGPUNodes, m_hsakmt_current_ctx, pages[order].pointers[p], size, NULL,
                                mapFlags, 1, reinterpret_cast<HSAuint32 *>(&gpuNode));
             if (status != HSAKMT_STATUS_SUCCESS) {
-                ASSERT_SUCCESS_GPU(hsaKmtFreeMemory(pages[order].pointers[p],
+                ASSERT_SUCCESS_GPU(HSAKMT_CALL(hsaKmtFreeMemory, m_hsakmt_current_ctx, pages[order].pointers[p],
                                                 size), gpuNode);
                 pages[order].nPages = p;
                 break;
@@ -392,7 +392,7 @@ void KFDLocalMemoryTest::Fragmentation(int gpuNode){
             dispatch3.Sync(g_TestTimeOut);
             EXPECT_EQ_GPU(value, sysBuffer.As<unsigned *>()[1], gpuNode);
 
-            EXPECT_SUCCESS_GPU(hsaKmtUnmapMemoryToGPU(pages[order].pointers[p]), gpuNode);
+            EXPECT_SUCCESS_GPU(HSAKMT_CALL(hsaKmtUnmapMemoryToGPU, m_hsakmt_current_ctx, pages[order].pointers[p]), gpuNode);
         }
         LOG() << "  Got " << pages[order].nPages
               << ", end of last block addr: "
@@ -408,7 +408,7 @@ void KFDLocalMemoryTest::Fragmentation(int gpuNode){
                   << o << " block starting with " << offset << std::endl;
             for (p = offset; p < pages[o].nPages; p += step) {
                 ASSERT_NE_GPU((void **)NULL, pages[o].pointers[p], gpuNode);
-                EXPECT_SUCCESS_GPU(hsaKmtFreeMemory(pages[o].pointers[p], size), gpuNode);
+                EXPECT_SUCCESS_GPU(HSAKMT_CALL(hsaKmtFreeMemory, m_hsakmt_current_ctx, pages[o].pointers[p], size), gpuNode);
                 pages[o].pointers[p] = NULL;
             }
         }
@@ -422,7 +422,7 @@ void KFDLocalMemoryTest::Fragmentation(int gpuNode){
         size = (HSAuint64)(1 << order) * pageSize;
         for (p = 0; p < pages[order].nPages; p++)
             if (pages[order].pointers[p] != NULL)
-                EXPECT_SUCCESS_GPU(hsaKmtFreeMemory(pages[order].pointers[p], size), gpuNode);
+                EXPECT_SUCCESS_GPU(HSAKMT_CALL(hsaKmtFreeMemory, m_hsakmt_current_ctx, pages[order].pointers[p], size), gpuNode);
 
         delete[] pages[order].pointers;
     }
@@ -557,32 +557,32 @@ TEST_F(KFDLocalMemoryTest, MapVramToGPUNodesTest) {
 
     HsaMemMapFlags mapFlags = {0};
 
-    EXPECT_SUCCESS(hsaKmtAllocMemory(nodes[1], PAGE_SIZE, memFlags, &shared_addr));
-    EXPECT_SUCCESS(hsaKmtMapMemoryToGPUNodes(shared_addr, PAGE_SIZE, NULL, mapFlags, 2, nodes));
-    EXPECT_SUCCESS(hsaKmtQueryPointerInfo(shared_addr, &info));
+    EXPECT_SUCCESS(HSAKMT_CALL(hsaKmtAllocMemory, g_baseTest->m_hsakmt_current_ctx, nodes[1], PAGE_SIZE, memFlags, &shared_addr));
+    EXPECT_SUCCESS(HSAKMT_CALL(hsaKmtMapMemoryToGPUNodes, g_baseTest->m_hsakmt_current_ctx, shared_addr, PAGE_SIZE, NULL, mapFlags, 2, nodes));
+    EXPECT_SUCCESS(HSAKMT_CALL(hsaKmtQueryPointerInfo, g_baseTest->m_hsakmt_current_ctx, shared_addr, &info));
     EXPECT_EQ(info.NMappedNodes, 2);
 
-    EXPECT_SUCCESS(hsaKmtMapMemoryToGPUNodes(shared_addr, PAGE_SIZE, NULL, mapFlags, 1, &nodes[0]));
-    EXPECT_SUCCESS(hsaKmtQueryPointerInfo(shared_addr, &info));
+    EXPECT_SUCCESS(HSAKMT_CALL(hsaKmtMapMemoryToGPUNodes, g_baseTest->m_hsakmt_current_ctx, shared_addr, PAGE_SIZE, NULL, mapFlags, 1, &nodes[0]));
+    EXPECT_SUCCESS(HSAKMT_CALL(hsaKmtQueryPointerInfo, g_baseTest->m_hsakmt_current_ctx, shared_addr, &info));
     EXPECT_EQ(info.NMappedNodes, 1);
     EXPECT_EQ(info.MappedNodes[0], nodes[0]);
 
-    EXPECT_SUCCESS(hsaKmtMapMemoryToGPUNodes(shared_addr, PAGE_SIZE, NULL, mapFlags, 1, &nodes[1]));
-    EXPECT_SUCCESS(hsaKmtQueryPointerInfo(shared_addr, &info));
+    EXPECT_SUCCESS(HSAKMT_CALL(hsaKmtMapMemoryToGPUNodes, g_baseTest->m_hsakmt_current_ctx, shared_addr, PAGE_SIZE, NULL, mapFlags, 1, &nodes[1]));
+    EXPECT_SUCCESS(HSAKMT_CALL(hsaKmtQueryPointerInfo, g_baseTest->m_hsakmt_current_ctx, shared_addr, &info));
     EXPECT_EQ(info.NMappedNodes, 1);
     EXPECT_EQ(info.MappedNodes[0], nodes[1]);
 
-    EXPECT_SUCCESS(hsaKmtUnmapMemoryToGPU(shared_addr));
-    EXPECT_SUCCESS(hsaKmtQueryPointerInfo(shared_addr, &info));
+    EXPECT_SUCCESS(HSAKMT_CALL(hsaKmtUnmapMemoryToGPU, g_baseTest->m_hsakmt_current_ctx, shared_addr));
+    EXPECT_SUCCESS(HSAKMT_CALL(hsaKmtQueryPointerInfo, g_baseTest->m_hsakmt_current_ctx, shared_addr, &info));
     EXPECT_EQ(info.NMappedNodes, 0);
 
-    EXPECT_SUCCESS(hsaKmtMapMemoryToGPUNodes(shared_addr, PAGE_SIZE, NULL, mapFlags, 1, &nodes[0]));
-    EXPECT_SUCCESS(hsaKmtQueryPointerInfo(shared_addr, &info));
+    EXPECT_SUCCESS(HSAKMT_CALL(hsaKmtMapMemoryToGPUNodes, g_baseTest->m_hsakmt_current_ctx, shared_addr, PAGE_SIZE, NULL, mapFlags, 1, &nodes[0]));
+    EXPECT_SUCCESS(HSAKMT_CALL(hsaKmtQueryPointerInfo, g_baseTest->m_hsakmt_current_ctx, shared_addr, &info));
     EXPECT_EQ(info.NMappedNodes, 1);
     EXPECT_EQ(info.MappedNodes[0], nodes[0]);
 
-    EXPECT_SUCCESS(hsaKmtUnmapMemoryToGPU(shared_addr));
-    EXPECT_SUCCESS(hsaKmtFreeMemory(shared_addr, PAGE_SIZE));
+    EXPECT_SUCCESS(HSAKMT_CALL(hsaKmtUnmapMemoryToGPU, g_baseTest->m_hsakmt_current_ctx, shared_addr));
+    EXPECT_SUCCESS(HSAKMT_CALL(hsaKmtFreeMemory, g_baseTest->m_hsakmt_current_ctx, shared_addr, PAGE_SIZE));
 
     TEST_END
 }

--- a/projects/rocr-runtime/libhsakmt/tests/kfdtest/src/KFDMemoryTest.cpp
+++ b/projects/rocr-runtime/libhsakmt/tests/kfdtest/src/KFDMemoryTest.cpp
@@ -103,11 +103,11 @@ void KFDMemoryTest::MMapLarge(int gpuNode) {
             }
         }
 
-        if (hsaKmtRegisterMemory(addr + i, s - i))
+        if (HSAKMT_CALL(hsaKmtRegisterMemory, m_hsakmt_current_ctx, addr + i, s - i))
             break;
-        if (hsaKmtMapMemoryToGPUNodes(addr + i, s - i,
+        if (HSAKMT_CALL(hsaKmtMapMemoryToGPUNodes, m_hsakmt_current_ctx, addr + i, s - i,
                     &AlternateVAGPU[i], mapFlags, 1, reinterpret_cast<HSAuint32 *>(&gpuNode))) {
-            hsaKmtDeregisterMemory(addr + i);
+            HSAKMT_CALL(hsaKmtDeregisterMemory, m_hsakmt_current_ctx, addr + i);
             break;
         }
     }
@@ -118,8 +118,8 @@ void KFDMemoryTest::MMapLarge(int gpuNode) {
     RECORD(i * s >> 30) << "Mmap-SysMem-Size";
 
     while (i--) {
-        EXPECT_SUCCESS_GPU(hsaKmtUnmapMemoryToGPU(reinterpret_cast<void*>(AlternateVAGPU[i])), gpuNode);
-        EXPECT_SUCCESS_GPU(hsaKmtDeregisterMemory(reinterpret_cast<void*>(AlternateVAGPU[i])), gpuNode);
+        EXPECT_SUCCESS_GPU(HSAKMT_CALL(hsaKmtUnmapMemoryToGPU, m_hsakmt_current_ctx, reinterpret_cast<void*>(AlternateVAGPU[i])), gpuNode);
+        EXPECT_SUCCESS_GPU(HSAKMT_CALL(hsaKmtDeregisterMemory, m_hsakmt_current_ctx, reinterpret_cast<void*>(AlternateVAGPU[i])), gpuNode);
     }
 
     munmap(addr, s);
@@ -201,7 +201,7 @@ void KFDMemoryTest::MapUnmapToNodes(int gpuNode) {
     memFlags.ui32.HostAccess = 1;
 
     for (unsigned i = 0; i < 1<<14; i ++) {
-        hsaKmtMapMemoryToGPUNodes(srcBuffer.As<void*>(), PAGE_SIZE, NULL, memFlags, (i>>5)&1+1, mapNodes);
+        HSAKMT_CALL(hsaKmtMapMemoryToGPUNodes, m_hsakmt_current_ctx, srcBuffer.As<void*>(), PAGE_SIZE, NULL, memFlags, (i>>5)&1+1, mapNodes);
     }
 
     /* Fill src buffer so shader quits */
@@ -227,14 +227,14 @@ void KFDMemoryTest::MapMemoryToGPU(int gpuNode) {
     unsigned int *nullPtr = NULL;
     unsigned int* pDb = NULL;
 
-    ASSERT_SUCCESS_GPU(hsaKmtAllocMemory(gpuNode /* system */, PAGE_SIZE, GetHsaMemFlags(),
+    ASSERT_SUCCESS_GPU(HSAKMT_CALL(hsaKmtAllocMemory, m_hsakmt_current_ctx, gpuNode /* system */, PAGE_SIZE, GetHsaMemFlags(),
                    reinterpret_cast<void**>(&pDb)), gpuNode);
     // verify that pDb is not null before it's being used
     ASSERT_NE_GPU(nullPtr, pDb, gpuNode) << "hsaKmtAllocMemory returned a null pointer";
-    ASSERT_SUCCESS_GPU(hsaKmtMapMemoryToGPU(pDb, PAGE_SIZE, NULL), gpuNode);
-    EXPECT_SUCCESS_GPU(hsaKmtUnmapMemoryToGPU(pDb), gpuNode);
+    ASSERT_SUCCESS_GPU(HSAKMT_CALL(hsaKmtMapMemoryToGPU, m_hsakmt_current_ctx, pDb, PAGE_SIZE, NULL), gpuNode);
+    EXPECT_SUCCESS_GPU(HSAKMT_CALL(hsaKmtUnmapMemoryToGPU, m_hsakmt_current_ctx, pDb), gpuNode);
     // Release the buffers
-    EXPECT_SUCCESS_GPU(hsaKmtFreeMemory(pDb, PAGE_SIZE), gpuNode);
+    EXPECT_SUCCESS_GPU(HSAKMT_CALL(hsaKmtFreeMemory, m_hsakmt_current_ctx, pDb, PAGE_SIZE), gpuNode);
 }
 
 TEST_F(KFDMemoryTest, MapMemoryToGPU) {
@@ -253,7 +253,7 @@ TEST_F(KFDMemoryTest, InvalidMemoryPointerAlloc) {
     TEST_START(TESTPROFILE_RUNALL)
 
     m_MemoryFlags.ui32.NoNUMABind = 1;
-    EXPECT_EQ(HSAKMT_STATUS_INVALID_PARAMETER, hsaKmtAllocMemory(0 /* system */, PAGE_SIZE, m_MemoryFlags, NULL));
+    EXPECT_EQ(HSAKMT_STATUS_INVALID_PARAMETER, HSAKMT_CALL(hsaKmtAllocMemory, g_baseTest->m_hsakmt_current_ctx, 0 /* system */, PAGE_SIZE, m_MemoryFlags, NULL));
 
     TEST_END
 }
@@ -262,7 +262,7 @@ TEST_F(KFDMemoryTest, ZeroMemorySizeAlloc) {
     TEST_START(TESTPROFILE_RUNALL)
 
     unsigned int* pDb = NULL;
-    EXPECT_EQ(HSAKMT_STATUS_INVALID_PARAMETER, hsaKmtAllocMemory(0 /* system */, 0, m_MemoryFlags,
+    EXPECT_EQ(HSAKMT_STATUS_INVALID_PARAMETER, HSAKMT_CALL(hsaKmtAllocMemory, g_baseTest->m_hsakmt_current_ctx, 0 /* system */, 0, m_MemoryFlags,
               reinterpret_cast<void**>(&pDb)));
 
     TEST_END
@@ -274,7 +274,7 @@ TEST_F(KFDMemoryTest, MemoryAlloc) {
 
     unsigned int* pDb = NULL;
     m_MemoryFlags.ui32.NoNUMABind = 1;
-    EXPECT_SUCCESS(hsaKmtAllocMemory(0 /* system */, PAGE_SIZE, m_MemoryFlags, reinterpret_cast<void**>(&pDb)));
+    EXPECT_SUCCESS(HSAKMT_CALL(hsaKmtAllocMemory, g_baseTest->m_hsakmt_current_ctx, 0 /* system */, PAGE_SIZE, m_MemoryFlags, reinterpret_cast<void**>(&pDb)));
 
     TEST_END
 }
@@ -293,12 +293,12 @@ void KFDMemoryTest::MemoryAllocAll(int gpuNode) {
 
     void *object = NULL;
     int shrink = 21, success = HSAKMT_STATUS_NO_MEMORY;
-    EXPECT_SUCCESS_GPU(hsaKmtAvailableMemory(gpuNode, &available), gpuNode);
+    EXPECT_SUCCESS_GPU(HSAKMT_CALL(hsaKmtAvailableMemory, m_hsakmt_current_ctx, gpuNode, &available), gpuNode);
     LOG() << "Available: " << available << " bytes" << std::endl;
     HSAuint64 leeway = (10 << shrink), size = available + leeway;
     for (int i = 0; i < available >> shrink; i++) {
-        if (hsaKmtAllocMemory(gpuNode, size, memFlags, &object) == HSAKMT_STATUS_SUCCESS) {
-            success = hsaKmtFreeMemory(object, available);
+        if (HSAKMT_CALL(hsaKmtAllocMemory, m_hsakmt_current_ctx, gpuNode, size, memFlags, &object) == HSAKMT_STATUS_SUCCESS) {
+            success = HSAKMT_CALL(hsaKmtFreeMemory, m_hsakmt_current_ctx, object, available);
             break;
         }
         size -= (1 << shrink);
@@ -350,7 +350,7 @@ void KFDMemoryTest::AccessPPRMem(int gpuNode) {
     WaitOnValue(destBuf, 0xABCDEF09);
     WaitOnValue(destBuf + 1, 0x12345678);
 
-    hsaKmtDestroyEvent(event);
+    HSAKMT_CALL(hsaKmtDestroyEvent, m_hsakmt_current_ctx, event);
     EXPECT_SUCCESS_GPU(queue.Destroy(), gpuNode);
 
     /* This sleep hides the dmesg PPR message storm on Raven, which happens
@@ -504,16 +504,16 @@ void KFDMemoryTest::MemoryRegisterSamePtr(int gpuNode) {
     HSAuint64 gpuva1, gpuva2;
 
     /* Same address, different size */
-    EXPECT_SUCCESS(hsaKmtRegisterMemory((void *)&mem[0], sizeof(HSAuint32)*2));
-    EXPECT_SUCCESS(hsaKmtMapMemoryToGPU((void *)&mem[0], sizeof(HSAuint32)*2,
+    EXPECT_SUCCESS(HSAKMT_CALL(hsaKmtRegisterMemory, m_hsakmt_current_ctx, (void *)&mem[0], sizeof(HSAuint32)*2));
+    EXPECT_SUCCESS(HSAKMT_CALL(hsaKmtMapMemoryToGPU, m_hsakmt_current_ctx, (void *)&mem[0], sizeof(HSAuint32)*2,
                                         &gpuva1));
-    EXPECT_SUCCESS(hsaKmtRegisterMemory((void *)&mem[0], sizeof(HSAuint32)));
-    EXPECT_SUCCESS(hsaKmtMapMemoryToGPU((void *)&mem[0], sizeof(HSAuint32),
+    EXPECT_SUCCESS(HSAKMT_CALL(hsaKmtRegisterMemory, m_hsakmt_current_ctx, (void *)&mem[0], sizeof(HSAuint32)));
+    EXPECT_SUCCESS(HSAKMT_CALL(hsaKmtMapMemoryToGPU, m_hsakmt_current_ctx, (void *)&mem[0], sizeof(HSAuint32),
                                         &gpuva2));
-    EXPECT_SUCCESS(hsaKmtUnmapMemoryToGPU(reinterpret_cast<void *>(gpuva1)));
-    EXPECT_SUCCESS(hsaKmtDeregisterMemory(reinterpret_cast<void *>(gpuva1)));
-    EXPECT_SUCCESS(hsaKmtUnmapMemoryToGPU(reinterpret_cast<void *>(gpuva2)));
-    EXPECT_SUCCESS(hsaKmtDeregisterMemory(reinterpret_cast<void *>(gpuva2)));
+    EXPECT_SUCCESS(HSAKMT_CALL(hsaKmtUnmapMemoryToGPU, m_hsakmt_current_ctx, reinterpret_cast<void *>(gpuva1)));
+    EXPECT_SUCCESS(HSAKMT_CALL(hsaKmtDeregisterMemory, m_hsakmt_current_ctx, reinterpret_cast<void *>(gpuva1)));
+    EXPECT_SUCCESS(HSAKMT_CALL(hsaKmtUnmapMemoryToGPU, m_hsakmt_current_ctx, reinterpret_cast<void *>(gpuva2)));
+    EXPECT_SUCCESS(HSAKMT_CALL(hsaKmtDeregisterMemory, m_hsakmt_current_ctx, reinterpret_cast<void *>(gpuva2)));
 
     /* Same address, same size */
     HsaMemMapFlags memFlags = {0};
@@ -523,19 +523,19 @@ void KFDMemoryTest::MemoryRegisterSamePtr(int gpuNode) {
     HSAuint32 nodes[nGPU];
     for (unsigned int i = 0; i < nGPU; i++)
         nodes[i] = gpuNodes.at(i);
-    EXPECT_SUCCESS(hsaKmtRegisterMemoryToNodes((void *)&mem[2],
+    EXPECT_SUCCESS(HSAKMT_CALL(hsaKmtRegisterMemoryToNodes, m_hsakmt_current_ctx, (void *)&mem[2],
                             sizeof(HSAuint32)*2, nGPU, nodes));
-    EXPECT_SUCCESS(hsaKmtMapMemoryToGPUNodes((void *)&mem[2],
+    EXPECT_SUCCESS(HSAKMT_CALL(hsaKmtMapMemoryToGPUNodes, m_hsakmt_current_ctx, (void *)&mem[2],
                                         sizeof(HSAuint32) * 2,
                                         &gpuva1, memFlags, nGPU, nodes));
-    EXPECT_SUCCESS(hsaKmtRegisterMemoryToNodes((void *)&mem[2],
+    EXPECT_SUCCESS(HSAKMT_CALL(hsaKmtRegisterMemoryToNodes, m_hsakmt_current_ctx, (void *)&mem[2],
                                         sizeof(HSAuint32) * 2, nGPU, nodes));
-    EXPECT_SUCCESS(hsaKmtMapMemoryToGPUNodes((void *)&mem[2],
+    EXPECT_SUCCESS(HSAKMT_CALL(hsaKmtMapMemoryToGPUNodes, m_hsakmt_current_ctx, (void *)&mem[2],
                                         sizeof(HSAuint32) * 2,
                                         &gpuva2, memFlags, nGPU, nodes));
     EXPECT_EQ(gpuva1, gpuva2);
-    EXPECT_SUCCESS(hsaKmtUnmapMemoryToGPU(reinterpret_cast<void *>(gpuva1)));
-    EXPECT_SUCCESS(hsaKmtDeregisterMemory(reinterpret_cast<void *>(gpuva1)));
+    EXPECT_SUCCESS(HSAKMT_CALL(hsaKmtUnmapMemoryToGPU, m_hsakmt_current_ctx, reinterpret_cast<void *>(gpuva1)));
+    EXPECT_SUCCESS(HSAKMT_CALL(hsaKmtDeregisterMemory, m_hsakmt_current_ctx, reinterpret_cast<void *>(gpuva1)));
     /* Confirm that we still have access to the memory, mem[2] */
     PM4Queue queue;
     ASSERT_SUCCESS(queue.Create(gpuNode));
@@ -546,8 +546,8 @@ void KFDMemoryTest::MemoryRegisterSamePtr(int gpuNode) {
     queue.Wait4PacketConsumption();
     EXPECT_EQ(true, WaitOnValue((unsigned int *)(&mem[2]), 0xdeadbeef));
     EXPECT_SUCCESS(queue.Destroy());
-    EXPECT_SUCCESS(hsaKmtUnmapMemoryToGPU(reinterpret_cast<void *>(gpuva2)));
-    EXPECT_SUCCESS(hsaKmtDeregisterMemory(reinterpret_cast<void *>(gpuva2)));
+    EXPECT_SUCCESS(HSAKMT_CALL(hsaKmtUnmapMemoryToGPU, m_hsakmt_current_ctx, reinterpret_cast<void *>(gpuva2)));
+    EXPECT_SUCCESS(HSAKMT_CALL(hsaKmtDeregisterMemory, m_hsakmt_current_ctx, reinterpret_cast<void *>(gpuva2)));
 }
 
 TEST_F(KFDMemoryTest, MemoryRegisterSamePtr) {
@@ -585,25 +585,25 @@ void KFDMemoryTest::FlatScratchAccess(int gpuNode) {
 
     HsaMemoryBuffer isaBuffer(PAGE_SIZE, gpuNode, true/*zero*/, false/*local*/, true/*exec*/);
     HsaMemoryBuffer scratchBuffer(SCRATCH_SIZE, gpuNode, false/*zero*/, false/*local*/,
-                                  false/*exec*/, true /*scratch*/);
+                                  false/*exec*/, true/*scratch*/);
 
     // Unmap scratch for sub-allocation mapping tests
-    ASSERT_SUCCESS_GPU(hsaKmtUnmapMemoryToGPU(scratchBuffer.As<void*>()), gpuNode);
+    ASSERT_SUCCESS_GPU(HSAKMT_CALL(hsaKmtUnmapMemoryToGPU, m_hsakmt_current_ctx, scratchBuffer.As<void*>()), gpuNode);
 
     // Map and unmap a few slices in different order: 2-0-1, 0-2-1
-    ASSERT_SUCCESS_GPU(hsaKmtMapMemoryToGPU(scratchBuffer.As<char*>() + SCRATCH_SLICE_OFFSET(2),
+    ASSERT_SUCCESS_GPU(HSAKMT_CALL(hsaKmtMapMemoryToGPU, m_hsakmt_current_ctx, scratchBuffer.As<char*>() + SCRATCH_SLICE_OFFSET(2),
                                         SCRATCH_SLICE_SIZE, NULL), gpuNode);
-    ASSERT_SUCCESS_GPU(hsaKmtMapMemoryToGPU(scratchBuffer.As<char*>() + SCRATCH_SLICE_OFFSET(0),
+    ASSERT_SUCCESS_GPU(HSAKMT_CALL(hsaKmtMapMemoryToGPU, m_hsakmt_current_ctx, scratchBuffer.As<char*>() + SCRATCH_SLICE_OFFSET(0),
                                         SCRATCH_SLICE_SIZE, NULL), gpuNode);
-    ASSERT_SUCCESS_GPU(hsaKmtMapMemoryToGPU(scratchBuffer.As<char*>() + SCRATCH_SLICE_OFFSET(1),
+    ASSERT_SUCCESS_GPU(HSAKMT_CALL(hsaKmtMapMemoryToGPU, m_hsakmt_current_ctx, scratchBuffer.As<char*>() + SCRATCH_SLICE_OFFSET(1),
                                         SCRATCH_SLICE_SIZE, NULL), gpuNode);
 
-    EXPECT_SUCCESS_GPU(hsaKmtUnmapMemoryToGPU(scratchBuffer.As<char*>() + SCRATCH_SLICE_OFFSET(1)), gpuNode);
-    EXPECT_SUCCESS_GPU(hsaKmtUnmapMemoryToGPU(scratchBuffer.As<char*>() + SCRATCH_SLICE_OFFSET(2)), gpuNode);
-    EXPECT_SUCCESS_GPU(hsaKmtUnmapMemoryToGPU(scratchBuffer.As<char*>() + SCRATCH_SLICE_OFFSET(0)), gpuNode);
+    EXPECT_SUCCESS_GPU(HSAKMT_CALL(hsaKmtUnmapMemoryToGPU, m_hsakmt_current_ctx, scratchBuffer.As<char*>() + SCRATCH_SLICE_OFFSET(1)), gpuNode);
+    EXPECT_SUCCESS_GPU(HSAKMT_CALL(hsaKmtUnmapMemoryToGPU, m_hsakmt_current_ctx, scratchBuffer.As<char*>() + SCRATCH_SLICE_OFFSET(2)), gpuNode);
+    EXPECT_SUCCESS_GPU(HSAKMT_CALL(hsaKmtUnmapMemoryToGPU, m_hsakmt_current_ctx, scratchBuffer.As<char*>() + SCRATCH_SLICE_OFFSET(0)), gpuNode);
 
     // Map everything for test below
-    ASSERT_SUCCESS_GPU(hsaKmtMapMemoryToGPU(scratchBuffer.As<char*>(), SCRATCH_SIZE, NULL), gpuNode);
+    ASSERT_SUCCESS_GPU(HSAKMT_CALL(hsaKmtMapMemoryToGPU, m_hsakmt_current_ctx, scratchBuffer.As<char*>(), SCRATCH_SIZE, NULL), gpuNode);
 
     HsaMemoryBuffer srcMemBuffer(PAGE_SIZE, gpuNode);
     HsaMemoryBuffer dstMemBuffer(PAGE_SIZE, gpuNode);
@@ -623,7 +623,7 @@ void KFDMemoryTest::FlatScratchAccess(int gpuNode) {
     if (pNodeProperties != NULL) {
         // Get the aperture of the scratch buffer
         HsaMemoryProperties *memoryProperties = new HsaMemoryProperties[pNodeProperties->NumMemoryBanks];
-        EXPECT_SUCCESS_GPU(hsaKmtGetNodeMemoryProperties(gpuNode, pNodeProperties->NumMemoryBanks,
+        EXPECT_SUCCESS_GPU(HSAKMT_CALL(hsaKmtGetNodeMemoryProperties, m_hsakmt_current_ctx, gpuNode, pNodeProperties->NumMemoryBanks,
                        memoryProperties), gpuNode);
 
         for (unsigned int bank = 0; bank < pNodeProperties->NumMemoryBanks; bank++) {
@@ -691,7 +691,7 @@ void KFDMemoryTest::GetTileConfigTest(int gpuNode) {
     config.NumTileConfigs = 32;
     config.NumMacroTileConfigs = 16;
 
-    ASSERT_SUCCESS(hsaKmtGetTileConfig(gpuNode, &config));
+    ASSERT_SUCCESS(HSAKMT_CALL(hsaKmtGetTileConfig, g_baseTest->m_hsakmt_current_ctx, gpuNode, &config));
 
     LOG() << "tile_config:" << std::endl;
     for (i = 0; i < config.NumTileConfigs; i++)
@@ -738,7 +738,7 @@ void KFDMemoryTest::SearchLargestBuffer(int allocNode, const HsaMemFlags &memFla
     while (highMB > granularityMB) {
         sizeMB = highMB - granularityMB;
         size = sizeMB * 1024 * 1024;
-        ret = hsaKmtAllocMemory(allocNode, size, memFlags,
+        ret = HSAKMT_CALL(hsaKmtAllocMemory, m_hsakmt_current_ctx, allocNode, size, memFlags,
                                 reinterpret_cast<void**>(&pDb));
         if (ret) {
             highMB = sizeMB;
@@ -751,15 +751,15 @@ void KFDMemoryTest::SearchLargestBuffer(int allocNode, const HsaMemFlags &memFla
             sleep(g_SleepTime);
         }
 
-        ret = hsaKmtMapMemoryToGPUNodes(pDb, size, NULL,
+        ret = HSAKMT_CALL(hsaKmtMapMemoryToGPUNodes, m_hsakmt_current_ctx, pDb, size, NULL,
                         mapFlags, 1, reinterpret_cast<HSAuint32 *>(&nodeToMap));
         if (ret) {
-            EXPECT_SUCCESS_GPU(hsaKmtFreeMemory(pDb, size), nodeToMap);
+            EXPECT_SUCCESS_GPU(HSAKMT_CALL(hsaKmtFreeMemory, m_hsakmt_current_ctx, pDb, size), nodeToMap);
             highMB = sizeMB;
             continue;
         }
-        EXPECT_SUCCESS_GPU(hsaKmtUnmapMemoryToGPU(pDb), nodeToMap);
-        EXPECT_SUCCESS_GPU(hsaKmtFreeMemory(pDb, size), nodeToMap);
+        EXPECT_SUCCESS_GPU(HSAKMT_CALL(hsaKmtUnmapMemoryToGPU, m_hsakmt_current_ctx, pDb), nodeToMap);
+        EXPECT_SUCCESS_GPU(HSAKMT_CALL(hsaKmtFreeMemory, m_hsakmt_current_ctx, pDb, size), nodeToMap);
 
         if (lastSizeMB)
            *lastSizeMB = sizeMB;
@@ -896,15 +896,15 @@ void KFDMemoryTest::BigSysBufferStressTest(int gpuNode) {
     for (int repeat = 1; repeat < 5; repeat++) {
 
         for (i = 0; i < ARRAY_ENTRIES; i++) {
-            ret = hsaKmtAllocMemory(0 /* system */, block_size, GetHsaMemFlags(),
+            ret = HSAKMT_CALL(hsaKmtAllocMemory, m_hsakmt_current_ctx, 0 /* system */, block_size, GetHsaMemFlags(),
                     reinterpret_cast<void**>(&pDb_array[i]));
             if (ret)
                 break;
 
-            ret = hsaKmtMapMemoryToGPUNodes(pDb_array[i], block_size,
+            ret = HSAKMT_CALL(hsaKmtMapMemoryToGPUNodes, m_hsakmt_current_ctx, pDb_array[i], block_size,
                     &AlternateVAGPU, mapFlags, 1, reinterpret_cast<HSAuint32 *>(&gpuNode));
             if (ret) {
-                EXPECT_SUCCESS_GPU(hsaKmtFreeMemory(pDb_array[i], block_size), gpuNode);
+                EXPECT_SUCCESS_GPU(HSAKMT_CALL(hsaKmtFreeMemory, m_hsakmt_current_ctx, pDb_array[i], block_size), gpuNode);
                 break;
             }
         }
@@ -917,8 +917,8 @@ void KFDMemoryTest::BigSysBufferStressTest(int gpuNode) {
         EXPECT_GE_GPU(i, allocationCount, gpuNode) << "There might be memory leak!" << std::endl;
 
         for (int j = 0; j < i; j++) {
-            EXPECT_SUCCESS_GPU(hsaKmtUnmapMemoryToGPU(pDb_array[j]), gpuNode);
-            EXPECT_SUCCESS_GPU(hsaKmtFreeMemory(pDb_array[j], block_size), gpuNode);
+            EXPECT_SUCCESS_GPU(HSAKMT_CALL(hsaKmtUnmapMemoryToGPU, m_hsakmt_current_ctx, pDb_array[j]), gpuNode);
+            EXPECT_SUCCESS_GPU(HSAKMT_CALL(hsaKmtFreeMemory, m_hsakmt_current_ctx, pDb_array[j], block_size), gpuNode);
         }
     }
 }
@@ -1068,7 +1068,7 @@ void KFDMemoryTest::MMBench(int gpuNode) {
         /* Allocation */
         start = GetSystemTickCountInMicroSec();
         for (i = 0; i < nBufs; i++) {
-            ASSERT_SUCCESS_GPU(hsaKmtAllocMemory(allocNode, bufSize, memFlags,
+            ASSERT_SUCCESS_GPU(HSAKMT_CALL(hsaKmtAllocMemory, m_hsakmt_current_ctx, allocNode, bufSize, memFlags,
                                              &bufs[i]), gpuNode);
             INTERLEAVE_SDMA();
         }
@@ -1078,7 +1078,7 @@ void KFDMemoryTest::MMBench(int gpuNode) {
         /* Map to one GPU */
         start = GetSystemTickCountInMicroSec();
         for (i = 0; i < nBufs; i++) {
-            ASSERT_SUCCESS_GPU(hsaKmtMapMemoryToGPUNodes(bufs[i], bufSize,
+            ASSERT_SUCCESS_GPU(HSAKMT_CALL(hsaKmtMapMemoryToGPUNodes, m_hsakmt_current_ctx, bufs[i], bufSize,
                                                      &altVa, mapFlags, 1,
                                                      (HSAuint32*)&gpuNode),  gpuNode);
             INTERLEAVE_SDMA();
@@ -1089,7 +1089,7 @@ void KFDMemoryTest::MMBench(int gpuNode) {
         /* Unmap from GPU */
         start = GetSystemTickCountInMicroSec();
         for (i = 0; i < nBufs; i++) {
-            EXPECT_SUCCESS_GPU(hsaKmtUnmapMemoryToGPU(bufs[i]), gpuNode);
+            EXPECT_SUCCESS_GPU(HSAKMT_CALL(hsaKmtUnmapMemoryToGPU, m_hsakmt_current_ctx, bufs[i]), gpuNode);
             INTERLEAVE_SDMA();
         }
         unmap1Time = GetSystemTickCountInMicroSec() - start;
@@ -1099,7 +1099,7 @@ void KFDMemoryTest::MMBench(int gpuNode) {
         if (is_all_large_bar) {
             start = GetSystemTickCountInMicroSec();
             for (i = 0; i < nBufs; i++) {
-                ASSERT_SUCCESS_GPU(hsaKmtMapMemoryToGPU(bufs[i], bufSize, &altVa), gpuNode);
+                ASSERT_SUCCESS_GPU(HSAKMT_CALL(hsaKmtMapMemoryToGPU, m_hsakmt_current_ctx, bufs[i], bufSize, &altVa), gpuNode);
                 INTERLEAVE_SDMA();
             }
             mapAllTime = GetSystemTickCountInMicroSec() - start;
@@ -1108,7 +1108,7 @@ void KFDMemoryTest::MMBench(int gpuNode) {
             /* Unmap from all GPUs */
             start = GetSystemTickCountInMicroSec();
             for (i = 0; i < nBufs; i++) {
-                EXPECT_SUCCESS(hsaKmtUnmapMemoryToGPU(bufs[i]));
+                EXPECT_SUCCESS(HSAKMT_CALL(hsaKmtUnmapMemoryToGPU, m_hsakmt_current_ctx, bufs[i]));
                 INTERLEAVE_SDMA();
             }
             unmapAllTime = GetSystemTickCountInMicroSec() - start;
@@ -1118,7 +1118,7 @@ void KFDMemoryTest::MMBench(int gpuNode) {
         /* Free */
         start = GetSystemTickCountInMicroSec();
         for (i = 0; i < nBufs; i++) {
-            EXPECT_SUCCESS_GPU(hsaKmtFreeMemory(bufs[i], bufSize), gpuNode);
+            EXPECT_SUCCESS_GPU(HSAKMT_CALL(hsaKmtFreeMemory, m_hsakmt_current_ctx, bufs[i], bufSize), gpuNode);
             INTERLEAVE_SDMA();
         }
         freeTime = GetSystemTickCountInMicroSec() - start;
@@ -1189,7 +1189,7 @@ void KFDMemoryTest::QueryPointerInfo(int gpuNode) {
 
     /*** Memory allocated on CPU node ***/
     HsaMemoryBuffer hostBuffer(bufSize, 0/*node*/, false, false/*local*/);
-    EXPECT_SUCCESS_GPU(hsaKmtQueryPointerInfo(hostBuffer.As<void*>(), &ptrInfo), gpuNode);
+    EXPECT_SUCCESS_GPU(HSAKMT_CALL(hsaKmtQueryPointerInfo, m_hsakmt_current_ctx, hostBuffer.As<void*>(), &ptrInfo), gpuNode);
     EXPECT_EQ_GPU(ptrInfo.Type, HSA_POINTER_ALLOCATED, gpuNode);
     EXPECT_EQ_GPU(ptrInfo.Node, 0, gpuNode);
     EXPECT_EQ_GPU(ptrInfo.MemFlags.Value, hostBuffer.Flags().Value, gpuNode);
@@ -1200,15 +1200,15 @@ void KFDMemoryTest::QueryPointerInfo(int gpuNode) {
     if (hsakmt_is_dgpu()) {
         EXPECT_EQ_GPU((HSAuint64)ptrInfo.NMappedNodes, nGPU, gpuNode);
         // Check NMappedNodes again after unmapping the memory
-        hsaKmtUnmapMemoryToGPU(hostBuffer.As<void*>());
-        hsaKmtQueryPointerInfo(hostBuffer.As<void*>(), &ptrInfo);
+        HSAKMT_CALL(hsaKmtUnmapMemoryToGPU, m_hsakmt_current_ctx, hostBuffer.As<void*>());
+        HSAKMT_CALL(hsaKmtQueryPointerInfo, m_hsakmt_current_ctx, hostBuffer.As<void*>(), &ptrInfo);
     }
     EXPECT_EQ_GPU((HSAuint64)ptrInfo.NMappedNodes, 0, gpuNode);
 
     /* Skip testing local memory if the platform does not have it */
     if (GetVramSize(gpuNode)) {
         HsaMemoryBuffer localBuffer(bufSize, gpuNode, false, true);
-        EXPECT_SUCCESS_GPU(hsaKmtQueryPointerInfo(localBuffer.As<void*>(), &ptrInfo), gpuNode);
+        EXPECT_SUCCESS_GPU(HSAKMT_CALL(hsaKmtQueryPointerInfo, m_hsakmt_current_ctx, localBuffer.As<void*>(), &ptrInfo), gpuNode);
         EXPECT_EQ_GPU(ptrInfo.Type, HSA_POINTER_ALLOCATED, gpuNode);
         EXPECT_EQ_GPU(ptrInfo.Node, gpuNode, gpuNode);
         EXPECT_EQ_GPU(ptrInfo.MemFlags.Value, localBuffer.Flags().Value, gpuNode);
@@ -1218,7 +1218,7 @@ void KFDMemoryTest::QueryPointerInfo(int gpuNode) {
         EXPECT_EQ_GPU(ptrInfo.MemFlags.ui32.CoarseGrain, 1, gpuNode);
 
         HSAuint32 *addr = localBuffer.As<HSAuint32 *>() + 4;
-        EXPECT_SUCCESS_GPU(hsaKmtQueryPointerInfo(reinterpret_cast<void *>(addr), &ptrInfo), gpuNode);
+        EXPECT_SUCCESS_GPU(HSAKMT_CALL(hsaKmtQueryPointerInfo, m_hsakmt_current_ctx, reinterpret_cast<void *>(addr), &ptrInfo), gpuNode);
         EXPECT_EQ_GPU(ptrInfo.GPUAddress, (HSAuint64)localBuffer.As<void*>(), gpuNode);
     }
 
@@ -1232,7 +1232,7 @@ void KFDMemoryTest::QueryPointerInfo(int gpuNode) {
      * Therefore, pointer info can not be queried.
      */
     if (hsakmt_is_dgpu() && mem != hsaBuffer.As<void*>()) {
-        EXPECT_SUCCESS_GPU(hsaKmtQueryPointerInfo((void *)(&mem[0]), &ptrInfo), gpuNode);
+        EXPECT_SUCCESS_GPU(HSAKMT_CALL(hsaKmtQueryPointerInfo, m_hsakmt_current_ctx, (void *)(&mem[0]), &ptrInfo), gpuNode);
         EXPECT_EQ_GPU(ptrInfo.Type, HSA_POINTER_REGISTERED_USER, gpuNode);
         EXPECT_EQ_GPU(ptrInfo.CPUAddress, &mem[0], gpuNode);
         EXPECT_EQ_GPU(ptrInfo.GPUAddress, (HSAuint64)hsaBuffer.As<void*>(), gpuNode);
@@ -1244,30 +1244,30 @@ void KFDMemoryTest::QueryPointerInfo(int gpuNode) {
         HSAuint32 nodes[nGPU];
         for (unsigned int i = 0; i < nGPU; i++)
             nodes[i] = gpuNodes.at(i);
-        EXPECT_SUCCESS_GPU(hsaKmtRegisterMemoryToNodes((void *)(&mem[2]),
+        EXPECT_SUCCESS_GPU(HSAKMT_CALL(hsaKmtRegisterMemoryToNodes, m_hsakmt_current_ctx, (void *)(&mem[2]),
                                 sizeof(HSAuint32)*2, nGPU, nodes), gpuNode);
-        EXPECT_SUCCESS_GPU(hsaKmtQueryPointerInfo((void *)(&mem[2]), &ptrInfo), gpuNode);
+        EXPECT_SUCCESS_GPU(HSAKMT_CALL(hsaKmtQueryPointerInfo, m_hsakmt_current_ctx, (void *)(&mem[2]), &ptrInfo), gpuNode);
         EXPECT_EQ_GPU(ptrInfo.NRegisteredNodes, nGPU, gpuNode);
-        EXPECT_SUCCESS_GPU(hsaKmtDeregisterMemory((void *)(&mem[2])), gpuNode);
+        EXPECT_SUCCESS_GPU(HSAKMT_CALL(hsaKmtDeregisterMemory, m_hsakmt_current_ctx, (void *)(&mem[2])), gpuNode);
     }
 
     /* Not a starting address, but an address inside the memory range
      * should also get the memory information
      */
     HSAuint32 *address = hostBuffer.As<HSAuint32 *>() + 1;
-    EXPECT_SUCCESS_GPU(hsaKmtQueryPointerInfo(reinterpret_cast<void *>(address), &ptrInfo), gpuNode);
+    EXPECT_SUCCESS_GPU(HSAKMT_CALL(hsaKmtQueryPointerInfo, m_hsakmt_current_ctx, reinterpret_cast<void *>(address), &ptrInfo), gpuNode);
     EXPECT_EQ_GPU(ptrInfo.Type, HSA_POINTER_ALLOCATED, gpuNode);
     EXPECT_EQ_GPU(ptrInfo.CPUAddress, hostBuffer.As<void*>(), gpuNode);
     if (hsakmt_is_dgpu() && &mem[1] != hsaBuffer.As<HSAuint32 *>() + 1) {
-        EXPECT_SUCCESS_GPU(hsaKmtQueryPointerInfo((void *)(&mem[1]), &ptrInfo), gpuNode);
+        EXPECT_SUCCESS_GPU(HSAKMT_CALL(hsaKmtQueryPointerInfo, m_hsakmt_current_ctx, (void *)(&mem[1]), &ptrInfo), gpuNode);
         EXPECT_EQ_GPU(ptrInfo.Type, HSA_POINTER_REGISTERED_USER, gpuNode);
         EXPECT_EQ_GPU(ptrInfo.CPUAddress, &mem[0], gpuNode);
     }
 
     /*** Set user data ***/
     char userData[16] = "This is a test.";
-    EXPECT_SUCCESS_GPU(hsaKmtSetMemoryUserData(hostBuffer.As<HSAuint32 *>(), reinterpret_cast<void *>(userData)), gpuNode);
-    EXPECT_SUCCESS_GPU(hsaKmtQueryPointerInfo(hostBuffer.As<void*>(), &ptrInfo), gpuNode);
+    EXPECT_SUCCESS_GPU(HSAKMT_CALL(hsaKmtSetMemoryUserData, m_hsakmt_current_ctx, hostBuffer.As<HSAuint32 *>(), reinterpret_cast<void *>(userData)), gpuNode);
+    EXPECT_SUCCESS_GPU(HSAKMT_CALL(hsaKmtQueryPointerInfo, m_hsakmt_current_ctx, hostBuffer.As<void*>(), &ptrInfo), gpuNode);
     EXPECT_EQ_GPU(ptrInfo.UserData, (void *)userData, gpuNode);
 }
 
@@ -1311,7 +1311,7 @@ void KFDMemoryTest::PtraceAccess(int gpuNode) {
     // Alloc system memory from node 0 and initialize it
     memFlags.ui32.NonPaged = 0;
     memFlags.ui32.NoNUMABind = 1;
-    ASSERT_SUCCESS_GPU(hsaKmtAllocMemory(0, PAGE_SIZE*2, memFlags, &mem[0]), gpuNode);
+    ASSERT_SUCCESS_GPU(HSAKMT_CALL(hsaKmtAllocMemory, m_hsakmt_current_ctx, 0, PAGE_SIZE*2, memFlags, &mem[0]), gpuNode);
     for (i = 0; i < 4*sizeof(HSAint64) + 4; i++) {
         (reinterpret_cast<HSAuint8 *>(mem[0]))[i] = i;            // source
         (reinterpret_cast<HSAuint8 *>(mem[0]))[PAGE_SIZE+i] = 0;  // destination
@@ -1320,8 +1320,7 @@ void KFDMemoryTest::PtraceAccess(int gpuNode) {
     // Try to alloc local memory from GPU node
     memFlags.ui32.NonPaged = 1;
     if (Get_NodeInfo()->IsGPUNodeLargeBar(gpuNode)) {
-        EXPECT_SUCCESS_GPU(hsaKmtAllocMemory(gpuNode, PAGE_SIZE*2 + (4 << 20),
-                                            memFlags, &mem[1]), gpuNode);
+        EXPECT_SUCCESS_GPU(HSAKMT_CALL(hsaKmtAllocMemory, m_hsakmt_current_ctx, gpuNode, PAGE_SIZE*2 + (4 << 20), memFlags, &mem[1]), gpuNode);
         mem[1] = reinterpret_cast<void *>(reinterpret_cast<HSAuint8 *>(mem[1]) + VRAM_OFFSET);
         for (i = 0; i < 4*sizeof(HSAint64) + 4; i++) {
             (reinterpret_cast<HSAuint8 *>(mem[1]))[i] = i;
@@ -1413,7 +1412,7 @@ void KFDMemoryTest::PtraceAccess(int gpuNode) {
     EXPECT_EQ_GPU(0, memcmp(mem[0], reinterpret_cast<HSAuint8 *>(mem[0]) + PAGE_SIZE,
                         sizeof(long)*4 + 4), gpuNode);
     // Free memory
-    EXPECT_SUCCESS_GPU(hsaKmtFreeMemory(mem[0], PAGE_SIZE*2), gpuNode);
+    EXPECT_SUCCESS_GPU(HSAKMT_CALL(hsaKmtFreeMemory, m_hsakmt_current_ctx, mem[0], PAGE_SIZE*2), gpuNode);
 
     if (mem[1]) {
         (reinterpret_cast<uint8_t*>(mem[1]))[  sizeof(HSAint64)    ] = 0;
@@ -1423,7 +1422,7 @@ void KFDMemoryTest::PtraceAccess(int gpuNode) {
         EXPECT_EQ_GPU(0, memcmp(mem[1], reinterpret_cast<HSAuint8 *>(mem[1]) + PAGE_SIZE,
                             sizeof(HSAint64)*4 + 4), gpuNode);
         mem[1] = reinterpret_cast<void *>(reinterpret_cast<HSAuint8 *>(mem[1]) - VRAM_OFFSET);
-        EXPECT_SUCCESS_GPU(hsaKmtFreeMemory(mem[1], PAGE_SIZE*2), gpuNode);
+        EXPECT_SUCCESS_GPU(HSAKMT_CALL(hsaKmtFreeMemory, m_hsakmt_current_ctx, mem[1], PAGE_SIZE*2), gpuNode);
     }
 }
 
@@ -1472,8 +1471,8 @@ void KFDMemoryTest::PtraceAccessInvisibleVram(int gpuNode) {
 
     const HSAuint64 VRAM_OFFSET = (4 << 20) - sizeof(HSAuint64);
 
-    ASSERT_SUCCESS_GPU(hsaKmtAllocMemory(gpuNode, size, memFlags, &mem), gpuNode);
-    ASSERT_SUCCESS_GPU(hsaKmtMapMemoryToGPUNodes(mem, size, NULL,
+    ASSERT_SUCCESS_GPU(HSAKMT_CALL(hsaKmtAllocMemory, m_hsakmt_current_ctx, gpuNode, size, memFlags, &mem), gpuNode);
+    ASSERT_SUCCESS_GPU(HSAKMT_CALL(hsaKmtMapMemoryToGPUNodes, m_hsakmt_current_ctx, mem, size, NULL,
                                 mapFlags, 1, reinterpret_cast<HSAuint32 *>(&gpuNode)), gpuNode);
     /* Set the word before 4M boundary to 0xdeadbeefdeadbeef
      * and the word after 4M boundary to 0xcafebabecafebabe
@@ -1578,8 +1577,8 @@ void KFDMemoryTest::PtraceAccessInvisibleVram(int gpuNode) {
     EXPECT_EQ_GPU(data0[0], dstBuffer.As<unsigned int*>()[0], gpuNode);
 
     // Clean up
-    EXPECT_SUCCESS_GPU(hsaKmtUnmapMemoryToGPU(mem), gpuNode);
-    EXPECT_SUCCESS_GPU(hsaKmtFreeMemory(mem, size), gpuNode);
+    EXPECT_SUCCESS_GPU(HSAKMT_CALL(hsaKmtUnmapMemoryToGPU, m_hsakmt_current_ctx, mem), gpuNode);
+    EXPECT_SUCCESS_GPU(HSAKMT_CALL(hsaKmtFreeMemory, m_hsakmt_current_ctx, mem, size), gpuNode);
     EXPECT_SUCCESS_GPU(queue.Destroy(), gpuNode);
 }
 
@@ -1632,7 +1631,7 @@ void KFDMemoryTest::SignalHandling(int gpuNode) {
     size = size > (3ULL << 30) ? (3ULL << 30) : size;
 
     GetHsaMemFlags().ui32.NoNUMABind = 1;
-    ASSERT_SUCCESS_GPU(hsaKmtAllocMemory(0 /* system */, size, GetHsaMemFlags(), reinterpret_cast<void**>(&pDb)), gpuNode);
+    ASSERT_SUCCESS_GPU(HSAKMT_CALL(hsaKmtAllocMemory, m_hsakmt_current_ctx, 0 /* system */, size, GetHsaMemFlags(), reinterpret_cast<void**>(&pDb)), gpuNode);
     // Verify that pDb is not null before it's being used
     EXPECT_NE_GPU(nullPtr, pDb, gpuNode) << "hsaKmtAllocMemory returned a null pointer";
 
@@ -1643,7 +1642,7 @@ void KFDMemoryTest::SignalHandling(int gpuNode) {
         exit(0);
     } else {
         LOG() << "Start Memory Mapping..." << std::endl;
-        ASSERT_SUCCESS_GPU(hsaKmtMapMemoryToGPU(pDb, size, NULL), gpuNode);
+        ASSERT_SUCCESS_GPU(HSAKMT_CALL(hsaKmtMapMemoryToGPU, m_hsakmt_current_ctx, pDb, size, NULL), gpuNode);
         LOG() << "Mapping finished" << std::endl;
         int childStatus;
         pid_t pid;
@@ -1669,9 +1668,9 @@ void KFDMemoryTest::SignalHandling(int gpuNode) {
     EXPECT_TRUE_GPU(WaitOnValue(pDb, 0x01010101), gpuNode);
     EXPECT_SUCCESS_GPU(queue.Destroy(), gpuNode);
 
-    EXPECT_SUCCESS_GPU(hsaKmtUnmapMemoryToGPU(pDb), gpuNode);
+    EXPECT_SUCCESS_GPU(HSAKMT_CALL(hsaKmtUnmapMemoryToGPU, m_hsakmt_current_ctx, pDb), gpuNode);
     // Release the buffers
-    EXPECT_SUCCESS_GPU(hsaKmtFreeMemory(pDb, size), gpuNode);
+    EXPECT_SUCCESS_GPU(HSAKMT_CALL(hsaKmtFreeMemory, m_hsakmt_current_ctx, pDb, size), gpuNode);
 }
 
 TEST_F(KFDMemoryTest, SignalHandling) {
@@ -1717,7 +1716,7 @@ void KFDMemoryTest::CheckZeroInitializationSysMem(int gpuNode) {
     GetHsaMemFlags().ui32.NoNUMABind = 1;
 
     while (count--) {
-        ret = hsaKmtAllocMemory(0 /* system */, sysBufSizePerGPU, GetHsaMemFlags(),
+        ret = HSAKMT_CALL(hsaKmtAllocMemory, m_hsakmt_current_ctx, 0 /* system */, sysBufSizePerGPU, GetHsaMemFlags(),
                                 reinterpret_cast<void**>(&pDb));
         if (ret) {
             LOG() << "Failed to allocate system buffer of" << std::dec << sysBufSizeMB
@@ -1740,7 +1739,7 @@ void KFDMemoryTest::CheckZeroInitializationSysMem(int gpuNode) {
         EXPECT_EQ_GPU(0, pDb[size-1], gpuNode);
         pDb[size-1] = size;
 
-        EXPECT_SUCCESS_GPU(hsaKmtFreeMemory(pDb, sysBufSizePerGPU), gpuNode);
+        EXPECT_SUCCESS_GPU(HSAKMT_CALL(hsaKmtFreeMemory, m_hsakmt_current_ctx, pDb, sysBufSizePerGPU), gpuNode);
     }
 }
 
@@ -1774,7 +1773,6 @@ static inline void access(volatile void *sd, int size, int rw) {
  * KFD is not allowed to alloc visible vram on non-largebar system.
  */
 void KFDMemoryTest::MMBandWidth(int gpuNode) {
-
     unsigned nBufs = 1000; /* measure us, report ns */
     unsigned testIndex, sizeIndex, memType;
     const unsigned nMemTypes = 2;
@@ -1847,8 +1845,8 @@ void KFDMemoryTest::MMBandWidth(int gpuNode) {
         }
 
         for (i = 0; i < nBufs; i++)
-            ASSERT_SUCCESS_GPU(hsaKmtAllocMemory(allocNode, bufSize, memFlags,
-                        &bufs[i]), gpuNode);
+            ASSERT_SUCCESS_GPU(HSAKMT_CALL(hsaKmtAllocMemory, m_hsakmt_current_ctx, allocNode, bufSize, memFlags,
+                                             &bufs[i]), gpuNode);
 
         start = GetSystemTickCountInMicroSec();
         for (i = 0; i < nBufs; i++) {
@@ -1875,7 +1873,7 @@ void KFDMemoryTest::MMBandWidth(int gpuNode) {
         accessRTime = GetSystemTickCountInMicroSec() - start;
 
         for (i = 0; i < nBufs; i++)
-            EXPECT_SUCCESS_GPU(hsaKmtFreeMemory(bufs[i], bufSize), gpuNode);
+            EXPECT_SUCCESS_GPU(HSAKMT_CALL(hsaKmtFreeMemory, m_hsakmt_current_ctx, bufs[i], bufSize), gpuNode);
 
         LOG() << std::dec
             << std::right << std::setw(3) << (bufSize >> 10) << "K-"
@@ -1954,8 +1952,10 @@ void KFDMemoryTest::HostHdpFlush(int gpuNode) {
     }
 
     HsaMemoryProperties *memoryProperties = new HsaMemoryProperties[pNodeProperties->NumMemoryBanks];
-    EXPECT_SUCCESS_GPU(hsaKmtGetNodeMemoryProperties(gpuNode, pNodeProperties->NumMemoryBanks,
-                   memoryProperties), gpuNode);
+    EXPECT_SUCCESS_GPU(HSAKMT_CALL(hsaKmtGetNodeMemoryProperties,
+                                    m_hsakmt_current_ctx,
+                                    gpuNode, pNodeProperties->NumMemoryBanks,
+                                    memoryProperties), gpuNode);
     for (unsigned int bank = 0; bank < pNodeProperties->NumMemoryBanks; bank++) {
         if (memoryProperties[bank].HeapType == HSA_HEAPTYPE_MMIO_REMAP) {
             mmioBase = (unsigned int *)memoryProperties[bank].VirtualBaseAddress;
@@ -1970,9 +1970,9 @@ void KFDMemoryTest::HostHdpFlush(int gpuNode) {
 
     memoryFlags.ui32.NonPaged = 1;
     memoryFlags.ui32.CoarseGrain = 0;
-    ASSERT_SUCCESS_GPU(hsaKmtAllocMemory(gpuNode, PAGE_SIZE, memoryFlags,
+    ASSERT_SUCCESS_GPU(HSAKMT_CALL(hsaKmtAllocMemory, m_hsakmt_current_ctx, gpuNode, PAGE_SIZE, memoryFlags,
                    reinterpret_cast<void**>(&buffer)), gpuNode);
-    ASSERT_SUCCESS_GPU(hsaKmtMapMemoryToGPU(buffer, PAGE_SIZE, NULL), gpuNode);
+    ASSERT_SUCCESS_GPU(HSAKMT_CALL(hsaKmtMapMemoryToGPU, m_hsakmt_current_ctx, buffer, PAGE_SIZE, NULL), gpuNode);
 
     /* Signal is dead from the beginning*/
     buffer[0] = 0xdead;
@@ -2002,8 +2002,8 @@ void KFDMemoryTest::HostHdpFlush(int gpuNode) {
     // Clean up
     EXPECT_SUCCESS_GPU(queue.Destroy(), gpuNode);
     delete [] memoryProperties;
-    EXPECT_SUCCESS_GPU(hsaKmtUnmapMemoryToGPU(buffer), gpuNode);
-    EXPECT_SUCCESS_GPU(hsaKmtFreeMemory(buffer, PAGE_SIZE), gpuNode);
+    EXPECT_SUCCESS_GPU(HSAKMT_CALL(hsaKmtUnmapMemoryToGPU, m_hsakmt_current_ctx, buffer), gpuNode);
+    EXPECT_SUCCESS_GPU(HSAKMT_CALL(hsaKmtFreeMemory, m_hsakmt_current_ctx, buffer, PAGE_SIZE), gpuNode);
 }
 
 TEST_F(KFDMemoryTest, HostHdpFlush) {
@@ -2103,8 +2103,8 @@ void KFDMemoryTest::DeviceHdpFlush(int gpuNode) {
     }
 
     HsaMemoryProperties *memoryProperties = new HsaMemoryProperties[pNodeProperties->NumMemoryBanks];
-    EXPECT_SUCCESS_GPU(hsaKmtGetNodeMemoryProperties(nodes[0], pNodeProperties->NumMemoryBanks,
-                   memoryProperties), gpuNode);
+    EXPECT_SUCCESS_GPU(HSAKMT_CALL(hsaKmtGetNodeMemoryProperties, m_hsakmt_current_ctx,
+                   nodes[0], pNodeProperties->NumMemoryBanks, memoryProperties), gpuNode);
     for (unsigned int bank = 0; bank < pNodeProperties->NumMemoryBanks; bank++) {
         if (memoryProperties[bank].HeapType == HSA_HEAPTYPE_MMIO_REMAP) {
             mmioBase = (unsigned int *)memoryProperties[bank].VirtualBaseAddress;
@@ -2119,9 +2119,9 @@ void KFDMemoryTest::DeviceHdpFlush(int gpuNode) {
 
     memoryFlags.ui32.NonPaged = 1;
     memoryFlags.ui32.CoarseGrain = 0;
-    ASSERT_SUCCESS_GPU(hsaKmtAllocMemory(nodes[0], PAGE_SIZE, memoryFlags,
+    ASSERT_SUCCESS_GPU(HSAKMT_CALL(hsaKmtAllocMemory, m_hsakmt_current_ctx, 0, PAGE_SIZE, memoryFlags,
                    reinterpret_cast<void**>(&buffer)), gpuNode);
-    ASSERT_SUCCESS_GPU(hsaKmtMapMemoryToGPU(buffer, PAGE_SIZE, NULL), gpuNode);
+    ASSERT_SUCCESS_GPU(HSAKMT_CALL(hsaKmtMapMemoryToGPU, m_hsakmt_current_ctx, buffer, PAGE_SIZE, NULL), gpuNode);
 
     /* Signal is dead from the beginning*/
     buffer[0] = 0xdead;
@@ -2159,8 +2159,8 @@ void KFDMemoryTest::DeviceHdpFlush(int gpuNode) {
     EXPECT_SUCCESS_GPU(queue.Destroy(), gpuNode);
     EXPECT_SUCCESS_GPU(queue0.Destroy(), gpuNode);
     delete [] memoryProperties;
-    EXPECT_SUCCESS_GPU(hsaKmtUnmapMemoryToGPU(buffer), gpuNode);
-    EXPECT_SUCCESS_GPU(hsaKmtFreeMemory(buffer, PAGE_SIZE), gpuNode);
+    EXPECT_SUCCESS_GPU(HSAKMT_CALL(hsaKmtUnmapMemoryToGPU, m_hsakmt_current_ctx, buffer), gpuNode);
+    EXPECT_SUCCESS_GPU(HSAKMT_CALL(hsaKmtFreeMemory, m_hsakmt_current_ctx, buffer, PAGE_SIZE), gpuNode);
 }
 
 TEST_F(KFDMemoryTest, DeviceHdpFlush) {
@@ -2267,8 +2267,9 @@ void KFDMemoryTest::CacheInvalidateOnCPUWrite(int gpuNode) {
     memFlags.ui32.HostAccess = 1;
     memFlags.ui32.NonPaged = 1;
     memFlags.ui32.CoarseGrain = 1;
-    ASSERT_SUCCESS_GPU(hsaKmtAllocMemory(gpuNode, PAGE_SIZE, memFlags, reinterpret_cast<void**>(&buffer)), gpuNode);
-    ASSERT_SUCCESS_GPU(hsaKmtMapMemoryToGPU(buffer, PAGE_SIZE, NULL), gpuNode);
+    ASSERT_SUCCESS_GPU(HSAKMT_CALL(hsaKmtAllocMemory, m_hsakmt_current_ctx,
+                                    gpuNode, PAGE_SIZE, memFlags, reinterpret_cast<void**>(&buffer)), gpuNode);
+    ASSERT_SUCCESS_GPU(HSAKMT_CALL(hsaKmtMapMemoryToGPU, m_hsakmt_current_ctx, buffer, PAGE_SIZE, NULL), gpuNode);
     *buffer = 0;
 
     /* Read buffer from shader to fill cache */
@@ -2293,8 +2294,8 @@ void KFDMemoryTest::CacheInvalidateOnCPUWrite(int gpuNode) {
     EXPECT_EQ_GPU(buffer[100], 0x5678, gpuNode);
 
     // Clean up
-    EXPECT_SUCCESS_GPU(hsaKmtUnmapMemoryToGPU(buffer), gpuNode);
-    EXPECT_SUCCESS_GPU(hsaKmtFreeMemory(buffer, PAGE_SIZE), gpuNode);
+    EXPECT_SUCCESS_GPU(HSAKMT_CALL(hsaKmtUnmapMemoryToGPU, m_hsakmt_current_ctx, buffer), gpuNode);
+    EXPECT_SUCCESS_GPU(HSAKMT_CALL(hsaKmtFreeMemory, m_hsakmt_current_ctx, buffer, PAGE_SIZE), gpuNode);
     EXPECT_SUCCESS_GPU(queue.Destroy(), gpuNode);
 }
 
@@ -2523,9 +2524,9 @@ void KFDMemoryTest::VramCacheCoherenceWithCPU(int gpuNode) {
     /* Allocate a fine grain local FB accessed by CPU */
     memFlags.ui32.HostAccess = 1;
     memFlags.ui32.NonPaged = 1;
-    ASSERT_SUCCESS_GPU(hsaKmtAllocMemory(gpuNode, PAGE_SIZE, memFlags,
+    ASSERT_SUCCESS_GPU(HSAKMT_CALL(hsaKmtAllocMemory, m_hsakmt_current_ctx, gpuNode, PAGE_SIZE, memFlags,
             reinterpret_cast<void**>(&buffer)), gpuNode);
-    ASSERT_SUCCESS_GPU(hsaKmtMapMemoryToGPU(buffer, PAGE_SIZE, NULL), gpuNode);
+    ASSERT_SUCCESS_GPU(HSAKMT_CALL(hsaKmtMapMemoryToGPU, m_hsakmt_current_ctx, buffer, PAGE_SIZE, NULL), gpuNode);
     buffer[0] = 0;
     buffer[dwLocation] = 0;
 
@@ -2554,8 +2555,8 @@ void KFDMemoryTest::VramCacheCoherenceWithCPU(int gpuNode) {
     EXPECT_EQ_GPU(buffer[dwLocation], 0x5678, gpuNode);
 
     // Clean up
-    EXPECT_SUCCESS_GPU(hsaKmtUnmapMemoryToGPU(buffer), gpuNode);
-    EXPECT_SUCCESS_GPU(hsaKmtFreeMemory(buffer, PAGE_SIZE), gpuNode);
+    EXPECT_SUCCESS_GPU(HSAKMT_CALL(hsaKmtUnmapMemoryToGPU, m_hsakmt_current_ctx, buffer), gpuNode);
+    EXPECT_SUCCESS_GPU(HSAKMT_CALL(hsaKmtFreeMemory, m_hsakmt_current_ctx, buffer, PAGE_SIZE), gpuNode);
     EXPECT_SUCCESS_GPU(queue.Destroy(), gpuNode);
 }
 
@@ -2597,9 +2598,11 @@ void KFDMemoryTest::SramCacheCoherenceWithGPU(int gpuNode) {
     unsigned int *fineBuffer = NULL;
     unsigned int tmp;
 
-    ASSERT_SUCCESS_GPU(hsaKmtAllocMemory(gpuNode /* system */, PAGE_SIZE, GetHsaMemFlags(),
+    ASSERT_SUCCESS_GPU(HSAKMT_CALL(hsaKmtAllocMemory,
+                       m_hsakmt_current_ctx, gpuNode,
+                       PAGE_SIZE, GetHsaMemFlags(),
                        reinterpret_cast<void**>(&fineBuffer)), gpuNode);
-    ASSERT_SUCCESS_GPU(hsaKmtMapMemoryToGPU(fineBuffer, PAGE_SIZE, NULL), gpuNode);
+    ASSERT_SUCCESS_GPU(HSAKMT_CALL(hsaKmtMapMemoryToGPU, m_hsakmt_current_ctx, fineBuffer, PAGE_SIZE, NULL), gpuNode);
     fineBuffer[0] = 0;
     fineBuffer[1] = 0;
     /* Read buffer from CPU to fill cache */
@@ -2633,8 +2636,8 @@ void KFDMemoryTest::SramCacheCoherenceWithGPU(int gpuNode) {
     EXPECT_EQ_GPU(fineBuffer[dwLocation], 0x5678, gpuNode);
 
     // Clean up
-    EXPECT_SUCCESS_GPU(hsaKmtUnmapMemoryToGPU(fineBuffer), gpuNode);
-    EXPECT_SUCCESS_GPU(hsaKmtFreeMemory(fineBuffer, PAGE_SIZE), gpuNode);
+    EXPECT_SUCCESS_GPU(HSAKMT_CALL(hsaKmtUnmapMemoryToGPU, m_hsakmt_current_ctx, fineBuffer), gpuNode);
+    EXPECT_SUCCESS_GPU(HSAKMT_CALL(hsaKmtFreeMemory, m_hsakmt_current_ctx, fineBuffer, PAGE_SIZE), gpuNode);
     EXPECT_SUCCESS_GPU(queue.Destroy(), gpuNode);
 }
 
@@ -2991,17 +2994,17 @@ static unsigned int RegisterThread(void* p) {
     struct ThreadParams* pArgs = reinterpret_cast<struct ThreadParams*>(p);
 
     pthread_barrier_wait(pArgs->barrier);
-    EXPECT_SUCCESS(hsaKmtRegisterMemory(pArgs->pBuf, pArgs->BufferSize));
-    EXPECT_SUCCESS(hsaKmtMapMemoryToGPU(pArgs->pBuf, pArgs->BufferSize, &pArgs->VAGPU));
+    EXPECT_SUCCESS(HSAKMT_CALL(hsaKmtRegisterMemory, g_baseTest->m_hsakmt_current_ctx, pArgs->pBuf, pArgs->BufferSize));
+    EXPECT_SUCCESS(HSAKMT_CALL(hsaKmtMapMemoryToGPU, g_baseTest->m_hsakmt_current_ctx, pArgs->pBuf, pArgs->BufferSize, &pArgs->VAGPU));
 
     return 0;
 }
 static unsigned int UnregisterThread(void* p) {
     struct ThreadParams* pArgs = reinterpret_cast<struct ThreadParams*>(p);
 
-    EXPECT_SUCCESS(hsaKmtUnmapMemoryToGPU(reinterpret_cast<void *>(pArgs->VAGPU)));
+    EXPECT_SUCCESS(HSAKMT_CALL(hsaKmtUnmapMemoryToGPU, g_baseTest->m_hsakmt_current_ctx, reinterpret_cast<void *>(pArgs->VAGPU)));
     pthread_barrier_wait(pArgs->barrier);
-    EXPECT_SUCCESS(hsaKmtDeregisterMemory(reinterpret_cast<void *>(pArgs->VAGPU)));
+    EXPECT_SUCCESS(HSAKMT_CALL(hsaKmtDeregisterMemory, g_baseTest->m_hsakmt_current_ctx, reinterpret_cast<void *>(pArgs->VAGPU)));
 
     return 0;
 }
@@ -3074,9 +3077,11 @@ void KFDMemoryTest::ExportDMABufTest(int gpuNode) {
     memFlags.ui32.NonPaged = 1;
 
     HSAuint32 *buf;
-    ASSERT_SUCCESS_GPU(hsaKmtAllocMemory(0, PAGE_SIZE, memFlags,
-                                          reinterpret_cast<void**>(&buf)), gpuNode);
-    ASSERT_SUCCESS_GPU(hsaKmtMapMemoryToGPU(buf, PAGE_SIZE, NULL), gpuNode);
+    ASSERT_SUCCESS_GPU(HSAKMT_CALL(hsaKmtAllocMemory,
+                                m_hsakmt_current_ctx,
+                                gpuNode, PAGE_SIZE, memFlags,
+                                reinterpret_cast<void**>(&buf)), gpuNode);
+    ASSERT_SUCCESS_GPU(HSAKMT_CALL(hsaKmtMapMemoryToGPU, m_hsakmt_current_ctx, buf, PAGE_SIZE, NULL), gpuNode);
 
     for (int i = 0; i < PAGE_SIZE/4; i++)
         buf[i] = i;
@@ -3087,30 +3092,32 @@ void KFDMemoryTest::ExportDMABufTest(int gpuNode) {
 
     // Expected error: address out of range (not a BO)
     ASSERT_EQ_GPU(HSAKMT_STATUS_INVALID_PARAMETER,
-            hsaKmtExportDMABufHandle(buf + PAGE_SIZE/4, SIZE*4, &fd, &offset), gpuNode);
+            HSAKMT_CALL(hsaKmtExportDMABufHandle, m_hsakmt_current_ctx, buf + PAGE_SIZE/4, SIZE*4, &fd, &offset), gpuNode);
     // Expected error: size out of range
     ASSERT_EQ_GPU(HSAKMT_STATUS_INVALID_PARAMETER,
-            hsaKmtExportDMABufHandle(buf + INDEX, PAGE_SIZE, &fd, &offset), gpuNode);
+            HSAKMT_CALL(hsaKmtExportDMABufHandle, m_hsakmt_current_ctx, buf + INDEX, PAGE_SIZE, &fd, &offset), gpuNode);
 
     // For real this time. Check that the offset matches
-    ASSERT_SUCCESS_GPU(hsaKmtExportDMABufHandle(buf + INDEX, SIZE*4, &fd, &offset), gpuNode);
+    ASSERT_SUCCESS_GPU(HSAKMT_CALL(hsaKmtExportDMABufHandle, m_hsakmt_current_ctx, buf + INDEX, SIZE*4, &fd, &offset), gpuNode);
     ASSERT_EQ_GPU(INDEX*4, offset, gpuNode);
 
     // Free the original BO. The memory should persist as long as the DMA buf
     // handle exists.
-    ASSERT_SUCCESS_GPU(hsaKmtUnmapMemoryToGPU(buf), gpuNode);
-    ASSERT_SUCCESS_GPU(hsaKmtFreeMemory(buf, PAGE_SIZE), gpuNode);
+    ASSERT_SUCCESS_GPU(HSAKMT_CALL(hsaKmtUnmapMemoryToGPU, m_hsakmt_current_ctx, buf), gpuNode);
+    ASSERT_SUCCESS_GPU(HSAKMT_CALL(hsaKmtFreeMemory, m_hsakmt_current_ctx, buf, PAGE_SIZE), gpuNode);
 
     // Import the BO using the Interop API and check the contents. It doesn't
     // map the import for CPU access, which gives us an excuse to test GPU
     // mapping of the imported BO as well.
     HsaGraphicsResourceInfo info;
-    ASSERT_SUCCESS_GPU(hsaKmtRegisterGraphicsHandleToNodes(fd, &info, 1, (HSAuint32 *)&gpuNode), gpuNode);
+    ASSERT_SUCCESS_GPU(HSAKMT_CALL(hsaKmtRegisterGraphicsHandleToNodes, m_hsakmt_current_ctx,
+                                 fd, &info, 1, (HSAuint32 *)&gpuNode), gpuNode);
     buf = reinterpret_cast<HSAuint32 *>(info.MemoryAddress);
     ASSERT_EQ_GPU(info.SizeInBytes, PAGE_SIZE, gpuNode);
 
     HsaMemMapFlags mapFlags = {0};
-    ASSERT_SUCCESS_GPU(hsaKmtMapMemoryToGPUNodes(buf, PAGE_SIZE, NULL, mapFlags, 1,
+    ASSERT_SUCCESS_GPU(HSAKMT_CALL(hsaKmtMapMemoryToGPUNodes, m_hsakmt_current_ctx,
+                                             buf, PAGE_SIZE, NULL, mapFlags, 1,
                                              (HSAuint32 *)&gpuNode), gpuNode);
 
     PM4Queue pm4Queue;
@@ -3127,8 +3134,8 @@ void KFDMemoryTest::ExportDMABufTest(int gpuNode) {
     }
     ASSERT_SUCCESS_GPU(pm4Queue.Destroy(), gpuNode);
 
-    ASSERT_SUCCESS_GPU(hsaKmtUnmapMemoryToGPU(buf), gpuNode);
-    ASSERT_SUCCESS_GPU(hsaKmtDeregisterMemory(buf), gpuNode);
+    ASSERT_SUCCESS_GPU(HSAKMT_CALL(hsaKmtUnmapMemoryToGPU, m_hsakmt_current_ctx, buf), gpuNode);
+    ASSERT_SUCCESS_GPU(HSAKMT_CALL(hsaKmtDeregisterMemory, m_hsakmt_current_ctx, buf), gpuNode);
 
     ASSERT_EQ_GPU(0, close(fd), gpuNode);
 }
@@ -3165,28 +3172,28 @@ void KFDMemoryTest::VA_VRAM_Only_AllocTest(int gpuNode) {
 
     /*alloc va without vram alloc*/
     memFlags.ui32.OnlyAddress = 1;
-    ASSERT_SUCCESS(hsaKmtAllocMemory(gpuNode, PAGE_SIZE, memFlags,
+    ASSERT_SUCCESS(HSAKMT_CALL(hsaKmtAllocMemory, m_hsakmt_current_ctx, gpuNode, PAGE_SIZE, memFlags,
                                           reinterpret_cast<void**>(&buf)));
 
     /*mapping VA allocated by kfd api would fail*/
-    ASSERT_EQ(HSAKMT_STATUS_INVALID_PARAMETER, hsaKmtMapMemoryToGPU(buf, PAGE_SIZE, NULL));
-    ASSERT_EQ(HSAKMT_STATUS_INVALID_PARAMETER, hsaKmtMapMemoryToGPUNodes(buf, PAGE_SIZE, NULL,
+    ASSERT_EQ(HSAKMT_STATUS_INVALID_PARAMETER, HSAKMT_CALL(hsaKmtMapMemoryToGPU, m_hsakmt_current_ctx, buf, PAGE_SIZE, NULL));
+    ASSERT_EQ(HSAKMT_STATUS_INVALID_PARAMETER, HSAKMT_CALL(hsaKmtMapMemoryToGPUNodes, m_hsakmt_current_ctx, buf, PAGE_SIZE, NULL,
                                mapFlags, 1, reinterpret_cast<HSAuint32 *>(&gpuNode)));
 
-    ASSERT_SUCCESS(hsaKmtFreeMemory(buf, PAGE_SIZE));
+    ASSERT_SUCCESS(HSAKMT_CALL(hsaKmtFreeMemory, m_hsakmt_current_ctx, buf, PAGE_SIZE));
 
     /*alloc vram without va assigned*/
     memFlags.ui32.OnlyAddress = 0;
     memFlags.ui32.NoAddress = 1;
-    ASSERT_SUCCESS(hsaKmtAllocMemory(gpuNode, PAGE_SIZE, memFlags,
+    ASSERT_SUCCESS(HSAKMT_CALL(hsaKmtAllocMemory, m_hsakmt_current_ctx, gpuNode, PAGE_SIZE, memFlags,
                                       reinterpret_cast<void**>(&buf)));
 
     /*mapping handle allocated by kfd API would fail*/
-    ASSERT_EQ(HSAKMT_STATUS_INVALID_PARAMETER, hsaKmtMapMemoryToGPU(buf, PAGE_SIZE, NULL));
-    ASSERT_EQ(HSAKMT_STATUS_INVALID_PARAMETER, hsaKmtMapMemoryToGPUNodes(buf, PAGE_SIZE, NULL,
+    ASSERT_EQ(HSAKMT_STATUS_INVALID_PARAMETER, HSAKMT_CALL(hsaKmtMapMemoryToGPU, m_hsakmt_current_ctx, buf, PAGE_SIZE, NULL));
+    ASSERT_EQ(HSAKMT_STATUS_INVALID_PARAMETER, HSAKMT_CALL(hsaKmtMapMemoryToGPUNodes, m_hsakmt_current_ctx, buf, PAGE_SIZE, NULL,
                                mapFlags, 1, reinterpret_cast<HSAuint32 *>(&gpuNode)));
 
-    ASSERT_SUCCESS(hsaKmtFreeMemory(buf, PAGE_SIZE));
+    ASSERT_SUCCESS(HSAKMT_CALL(hsaKmtFreeMemory, m_hsakmt_current_ctx, buf, PAGE_SIZE));
 }
 
 TEST_F(KFDMemoryTest, VA_VRAM_Only_AllocTest) {

--- a/projects/rocr-runtime/libhsakmt/tests/kfdtest/src/KFDNegativeTest.cpp
+++ b/projects/rocr-runtime/libhsakmt/tests/kfdtest/src/KFDNegativeTest.cpp
@@ -91,7 +91,7 @@ TEST_F(KFDNegativeTest, BasicPipeReset) {
             queue.Destroy();
 
             // child expects hw exception event
-            EXPECT_SUCCESS(hsaKmtWaitOnEvent(resetEvent, g_TestTimeOut));
+            EXPECT_SUCCESS(HSAKMT_CALL(hsaKmtWaitOnEvent, g_baseTest->m_hsakmt_current_ctx, resetEvent, g_TestTimeOut));
             EXPECT_EQ(resetEvent->EventData.EventType, HSA_EVENTTYPE_HW_EXCEPTION);
 
             LOG() << "Child ==> Complete" << std::endl;
@@ -110,7 +110,7 @@ TEST_F(KFDNegativeTest, BasicPipeReset) {
             waitpid(childPid, &childStatus, 0);
 
             // parent process should not intercept reset event on child queue reset
-            EXPECT_NE(HSAKMT_STATUS_SUCCESS, hsaKmtWaitOnEvent(resetEvent, 100));
+            EXPECT_NE(HSAKMT_STATUS_SUCCESS, HSAKMT_CALL(hsaKmtWaitOnEvent, g_baseTest->m_hsakmt_current_ctx, resetEvent, 100));
 
             HsaMemoryBuffer destBuf(PAGE_SIZE, defaultGPUNode, false);
             destBuf.Fill(0xFF);
@@ -125,8 +125,8 @@ TEST_F(KFDNegativeTest, BasicPipeReset) {
             queue.Wait4PacketConsumption(event);
             EXPECT_TRUE(WaitOnValue(destBuf.As<unsigned int*>(), 0));
 
-            hsaKmtDestroyEvent(event);
-            hsaKmtDestroyEvent(resetEvent);
+            HSAKMT_CALL(hsaKmtDestroyEvent, g_baseTest->m_hsakmt_current_ctx, event);
+            HSAKMT_CALL(hsaKmtDestroyEvent, g_baseTest->m_hsakmt_current_ctx, resetEvent);
             EXPECT_SUCCESS(queue.Destroy());
 
             LOG() << "Parent ==> Complete" << std::endl;
@@ -208,9 +208,9 @@ TEST_F(KFDNegativeTest, BasicSDMAReset) {
                 queue.Destroy();
 
                 // child expects hw exception event
-                EXPECT_SUCCESS(hsaKmtWaitOnEvent(resetEvent, g_TestTimeOut));
+                EXPECT_SUCCESS(HSAKMT_CALL(hsaKmtWaitOnEvent, g_baseTest->m_hsakmt_current_ctx, resetEvent, g_TestTimeOut));
                 EXPECT_EQ(resetEvent->EventData.EventType, HSA_EVENTTYPE_HW_EXCEPTION);
-                hsaKmtDestroyEvent(resetEvent);
+                HSAKMT_CALL(hsaKmtDestroyEvent, g_baseTest->m_hsakmt_current_ctx, resetEvent);
 
                 // ack reset to parent and wait for parent to check healthy queue
                 write(pipe2[1], &buf2, 1);
@@ -257,12 +257,12 @@ TEST_F(KFDNegativeTest, BasicSDMAReset) {
                ASSERT_EQ(buf1, buf2);
 
                // expect no reset event, then update poll to trigger write completion check
-               EXPECT_NE(HSAKMT_STATUS_SUCCESS, hsaKmtWaitOnEvent(resetEvent, 100));
+               EXPECT_NE(HSAKMT_STATUS_SUCCESS, HSAKMT_CALL(hsaKmtWaitOnEvent, g_baseTest->m_hsakmt_current_ctx, resetEvent, 100));
                poll[0] = 1;
                queue.Wait4PacketConsumption();
                EXPECT_TRUE(WaitOnValue(&dest[0], targetDestValue));
-               hsaKmtDestroyEvent(event);
-               hsaKmtDestroyEvent(resetEvent);
+               HSAKMT_CALL(hsaKmtDestroyEvent, g_baseTest->m_hsakmt_current_ctx, event);
+               HSAKMT_CALL(hsaKmtDestroyEvent, g_baseTest->m_hsakmt_current_ctx, resetEvent);
                EXPECT_SUCCESS(queue.Destroy());
                write(pipe1[1], &buf1, 1);
             }

--- a/projects/rocr-runtime/libhsakmt/tests/kfdtest/src/KFDPMTest.cpp
+++ b/projects/rocr-runtime/libhsakmt/tests/kfdtest/src/KFDPMTest.cpp
@@ -99,7 +99,7 @@ TEST_F(KFDPMTest, SuspendWithIdleQueueAfterWork) {
     WaitOnValue(&(destBuffer.As<unsigned int*>()[2]), 0x3);
     WaitOnValue(&(destBuffer.As<unsigned int*>()[3]), 0x4);
 
-    hsaKmtDestroyEvent(event);
+    HSAKMT_CALL(hsaKmtDestroyEvent, g_baseTest->m_hsakmt_current_ctx, event);
     EXPECT_SUCCESS(queue.Destroy());
 
     TEST_END

--- a/projects/rocr-runtime/libhsakmt/tests/kfdtest/src/KFDPerformanceTest.cpp
+++ b/projects/rocr-runtime/libhsakmt/tests/kfdtest/src/KFDPerformanceTest.cpp
@@ -80,13 +80,13 @@ testNodeToNodes(HSAuint32 n1, const HSAuint32 *const n2Array, int n, P2PDirectio
     std::vector<SDMACopyParams> copyArray;
     int i;
 
-    ASSERT_SUCCESS(hsaKmtAllocMemory(n1, alloc_size, memFlags, &n1Mem));
-    ASSERT_SUCCESS(hsaKmtMapMemoryToGPU(n1Mem, alloc_size, NULL));
+    ASSERT_SUCCESS(HSAKMT_CALL(hsaKmtAllocMemory, g_baseTest->m_hsakmt_current_ctx, n1, alloc_size, memFlags, &n1Mem));
+    ASSERT_SUCCESS(HSAKMT_CALL(hsaKmtMapMemoryToGPU, g_baseTest->m_hsakmt_current_ctx, n1Mem, alloc_size, NULL));
 
     for (i = 0; i < n; i++) {
         n2[i] = n2Array[i];
-        ASSERT_SUCCESS(hsaKmtAllocMemory(n2[i], alloc_size, memFlags, &n2Mem[i]));
-        ASSERT_SUCCESS(hsaKmtMapMemoryToGPU(n2Mem[i], alloc_size, NULL));
+        ASSERT_SUCCESS(HSAKMT_CALL(hsaKmtAllocMemory, g_baseTest->m_hsakmt_current_ctx, n2[i], alloc_size, memFlags, &n2Mem[i]));
+        ASSERT_SUCCESS(HSAKMT_CALL(hsaKmtMapMemoryToGPU, g_baseTest->m_hsakmt_current_ctx, n2Mem[i], alloc_size, NULL));
     }
 
     for (i = 0; i < n; i++) {
@@ -127,12 +127,12 @@ testNodeToNodes(HSAuint32 n1, const HSAuint32 *const n2Array, int n, P2PDirectio
         /* It did not respect the group id we set above.*/
         sdma_multicopy(array, array_count, speed, speed2, msg);
 
-    EXPECT_SUCCESS(hsaKmtUnmapMemoryToGPU(n1Mem));
-    EXPECT_SUCCESS(hsaKmtFreeMemory(n1Mem, alloc_size));
+    EXPECT_SUCCESS(HSAKMT_CALL(hsaKmtUnmapMemoryToGPU, g_baseTest->m_hsakmt_current_ctx, n1Mem));
+    EXPECT_SUCCESS(HSAKMT_CALL(hsaKmtFreeMemory, g_baseTest->m_hsakmt_current_ctx, n1Mem, alloc_size));
 
     for (i = 0; i < n; i++) {
-        EXPECT_SUCCESS(hsaKmtUnmapMemoryToGPU(n2Mem[i]));
-        EXPECT_SUCCESS(hsaKmtFreeMemory(n2Mem[i], alloc_size));
+        EXPECT_SUCCESS(HSAKMT_CALL(hsaKmtUnmapMemoryToGPU, g_baseTest->m_hsakmt_current_ctx, n2Mem[i]));
+        EXPECT_SUCCESS(HSAKMT_CALL(hsaKmtFreeMemory, g_baseTest->m_hsakmt_current_ctx, n2Mem[i], alloc_size));
     }
 }
 

--- a/projects/rocr-runtime/libhsakmt/tests/kfdtest/src/KFDQMTest.cpp
+++ b/projects/rocr-runtime/libhsakmt/tests/kfdtest/src/KFDQMTest.cpp
@@ -87,7 +87,7 @@ void KFDQMTest::SubmitNopCpQueue(int gpuNode) {
 
     queue.Wait4PacketConsumption(event);
 
-    hsaKmtDestroyEvent(event);
+    HSAKMT_CALL(hsaKmtDestroyEvent, m_hsakmt_current_ctx, event);
     EXPECT_SUCCESS_GPU(queue.Destroy(), gpuNode);
 
 }
@@ -119,7 +119,7 @@ void KFDQMTest::SubmitPacketCpQueue(int gpuNode) {
 
     EXPECT_TRUE_GPU(WaitOnValue(destBuf.As<unsigned int*>(), 0), gpuNode);
 
-    hsaKmtDestroyEvent(event);
+    HSAKMT_CALL(hsaKmtDestroyEvent, m_hsakmt_current_ctx, event);
     EXPECT_SUCCESS_GPU(queue.Destroy(), gpuNode);
 }
 
@@ -559,7 +559,7 @@ void KFDQMTest::DisableCpQueueByUpdateWithNullAddress(int gpuNode) {
 
     WaitOnValue(destBuf.As<unsigned int*>(), 1);
 
-    hsaKmtDestroyEvent(event);
+    HSAKMT_CALL(hsaKmtDestroyEvent, m_hsakmt_current_ctx, event);
     EXPECT_SUCCESS_GPU(queue.Destroy(), gpuNode);
 
 }
@@ -658,7 +658,7 @@ void KFDQMTest::DisableCpQueueByUpdateWithZeroPercentage(int gpuNode) {
     queue.Wait4PacketConsumption(event);
 
     WaitOnValue(destBuf.As<unsigned int*>(), 1);
-    hsaKmtDestroyEvent(event);
+    HSAKMT_CALL(hsaKmtDestroyEvent, m_hsakmt_current_ctx, event);
 
     EXPECT_SUCCESS_GPU(queue.Destroy(), gpuNode);
 
@@ -1664,7 +1664,7 @@ void KFDQMTest::testQueuePriority(int gpuNode, bool isSamePipe)
         dispatch[i].Submit(queue[i]);
 
     while (activeTaskBitmap > 0) {
-        hsaKmtWaitOnMultipleEvents(pHsaEvent, numEvent, false, g_TestTimeOut);
+        HSAKMT_CALL(hsaKmtWaitOnMultipleEvents, m_hsakmt_current_ctx, pHsaEvent, numEvent, false, g_TestTimeOut);
         for (i = 0; i < 2; i++) {
             if ((activeTaskBitmap & (1 << i)) && (syncBuffer[i] == pHsaEvent[i]->EventId)) {
                 endTime[i] = GetSystemTickCountInMicroSec();
@@ -1949,7 +1949,7 @@ void KFDQMTest::CpuWriteCoherence(int gpuNode) {
 
     WaitOnValue(destBuf.As<unsigned int*>(), 0x42);
 
-    hsaKmtDestroyEvent(event);
+    HSAKMT_CALL(hsaKmtDestroyEvent, m_hsakmt_current_ctx, event);
 }
 
 TEST_F(KFDQMTest, CpuWriteCoherence) {
@@ -1966,7 +1966,7 @@ void KFDQMTest::CreateAqlCpQueue(int gpuNode) {
 
     AqlQueue queue;
 
-    HsaMemoryBuffer pointers(PAGE_SIZE, gpuNode, /*zero*/true, /*local*/false, /*exec*/false, /*isScratch */false, /* isReadOnly */false, /* isUncached */false, /* NonPaged */g_baseTest->NeedNonPagedWptr(gpuNode));
+    HsaMemoryBuffer pointers(PAGE_SIZE, gpuNode, /*zero*/true, /*local*/false, /*exec*/false, /*isScratch */false, /* isReadOnly */false, /* isUncached */false, /* NonPaged */NeedNonPagedWptr(gpuNode));
 
     ASSERT_SUCCESS_GPU(queue.Create(gpuNode, PAGE_SIZE, pointers.As<HSAuint64 *>()), gpuNode);
 
@@ -2071,7 +2071,7 @@ void KFDQMTest::QueueLatency(int gpuNode) {
     queue.SubmitPacket();
     queue.Wait4PacketConsumption(event);
 
-    hsaKmtDestroyEvent(event);
+    HSAKMT_CALL(hsaKmtDestroyEvent, m_hsakmt_current_ctx, event);
     /* qts[i] records the timestamp of the end of packet[i] which is
      * approximate that of the beginging of packet[i+1].
      * The workload total is [0, skip], [skip+1, slots-1].
@@ -2146,7 +2146,7 @@ void KFDQMTest::CpQueueWraparound(int gpuNode) {
         WaitOnValue(destBuf.As<unsigned int*>(), pktIdx);
     }
 
-    hsaKmtDestroyEvent(event);
+    HSAKMT_CALL(hsaKmtDestroyEvent, m_hsakmt_current_ctx, event);
     EXPECT_SUCCESS_GPU(queue.Destroy(), gpuNode);
 
 }
@@ -2247,7 +2247,7 @@ void KFDQMTest::Atomics(int gpuNode) {
     dispatch.SetArgs(destBuf.As<void*>(), NULL);
     dispatch.SetDim(1024, 1, 1);
 
-    hsaKmtSetMemoryPolicy(gpuNode, HSA_CACHING_CACHED, HSA_CACHING_CACHED, NULL, 0);
+    HSAKMT_CALL(hsaKmtSetMemoryPolicy, m_hsakmt_current_ctx, gpuNode, HSA_CACHING_CACHED, HSA_CACHING_CACHED, NULL, 0);
 
     ASSERT_SUCCESS_GPU(queue.Create(gpuNode), gpuNode);
 
@@ -2338,7 +2338,7 @@ sdma_copy(HSAuint32 node, void *src, void *const dst[], int n, HSAuint64 size) {
     sdmaQueue.PlaceAndSubmitPacket(SDMACopyDataPacket(sdmaQueue.GetFamilyId(), dst, src, n, size));
     sdmaQueue.Wait4PacketConsumption(event);
     EXPECT_SUCCESS(sdmaQueue.Destroy());
-    hsaKmtDestroyEvent(event);
+    HSAKMT_CALL(hsaKmtDestroyEvent, g_baseTest->m_hsakmt_current_ctx, event);
 }
 
 static void
@@ -2350,7 +2350,7 @@ sdma_fill(HSAint32 node, void *dst, unsigned int data, HSAuint64 size) {
     sdmaQueue.PlaceAndSubmitPacket(SDMAFillDataPacket(sdmaQueue.GetFamilyId(), dst, data, size));
     sdmaQueue.Wait4PacketConsumption(event);
     EXPECT_SUCCESS(sdmaQueue.Destroy());
-    hsaKmtDestroyEvent(event);
+    HSAKMT_CALL(hsaKmtDestroyEvent, g_baseTest->m_hsakmt_current_ctx, event);
 }
 
 TEST_F(KFDQMTest, P2PTest) {
@@ -2415,17 +2415,17 @@ TEST_F(KFDQMTest, P2PTest) {
     unsigned int end = size / sizeof(HSAuint32) - 1;
 
     /* 1. Allocate a system buffer and allow the access to GPUs */
-    EXPECT_SUCCESS(hsaKmtAllocMemory(0, size, m_MemoryFlags,
+    EXPECT_SUCCESS(HSAKMT_CALL(hsaKmtAllocMemory, g_baseTest->m_hsakmt_current_ctx, 0, size, m_MemoryFlags,
                                      reinterpret_cast<void **>(&sysBuf)));
-    EXPECT_SUCCESS(hsaKmtMapMemoryToGPUNodes(sysBuf, size, NULL,
+    EXPECT_SUCCESS(HSAKMT_CALL(hsaKmtMapMemoryToGPUNodes, g_baseTest->m_hsakmt_current_ctx, sysBuf, size, NULL,
                                              mapFlags, nodes.size(), (HSAuint32 *)&nodes[0]));
 #define MAGIC_NUM 0xdeadbeaf
 
     /* First GPU fills mem with MAGIC_NUM */
     void *src, *dst;
     HSAuint32 cur = nodes[0], next;
-    ASSERT_SUCCESS(hsaKmtAllocMemory(cur, size, memFlags, reinterpret_cast<void**>(&src)));
-    ASSERT_SUCCESS(hsaKmtMapMemoryToGPU(src, size, NULL));
+    ASSERT_SUCCESS(HSAKMT_CALL(hsaKmtAllocMemory, g_baseTest->m_hsakmt_current_ctx, cur, size, memFlags, reinterpret_cast<void**>(&src)));
+    ASSERT_SUCCESS(HSAKMT_CALL(hsaKmtMapMemoryToGPU, g_baseTest->m_hsakmt_current_ctx, src, size, NULL));
     sdma_fill(cur, src, MAGIC_NUM, size);
 
     for (unsigned i = 1; i <= nodes.size(); i++) {
@@ -2445,8 +2445,8 @@ TEST_F(KFDQMTest, P2PTest) {
             if (!m_NodeInfo.IsPeerAccessibleByNode(next, cur))
                 continue;
 
-            ASSERT_SUCCESS(hsaKmtAllocMemory(next, size, memFlags, reinterpret_cast<void**>(&dst)));
-            ASSERT_SUCCESS(hsaKmtMapMemoryToGPU(dst, size, NULL));
+            ASSERT_SUCCESS(HSAKMT_CALL(hsaKmtAllocMemory, g_baseTest->m_hsakmt_current_ctx, next, size, memFlags, reinterpret_cast<void**>(&dst)));
+            ASSERT_SUCCESS(HSAKMT_CALL(hsaKmtMapMemoryToGPU, g_baseTest->m_hsakmt_current_ctx, dst, size, NULL));
         }
 
         LOG() << "Test " << cur << " -> " << next << std::endl;
@@ -2460,15 +2460,15 @@ TEST_F(KFDQMTest, P2PTest) {
 
         LOG() << "PASS " << cur << " -> " << next << std::endl;
 
-        EXPECT_SUCCESS(hsaKmtUnmapMemoryToGPU(src));
-        EXPECT_SUCCESS(hsaKmtFreeMemory(src, size));
+    EXPECT_SUCCESS(HSAKMT_CALL(hsaKmtUnmapMemoryToGPU, g_baseTest->m_hsakmt_current_ctx, src));
+    EXPECT_SUCCESS(HSAKMT_CALL(hsaKmtFreeMemory, g_baseTest->m_hsakmt_current_ctx, src, size));
 
         cur = next;
         src = dst;
     }
 
-    EXPECT_SUCCESS(hsaKmtUnmapMemoryToGPU(sysBuf));
-    EXPECT_SUCCESS(hsaKmtFreeMemory(sysBuf, size));
+    EXPECT_SUCCESS(HSAKMT_CALL(hsaKmtUnmapMemoryToGPU, g_baseTest->m_hsakmt_current_ctx, sysBuf));
+    EXPECT_SUCCESS(HSAKMT_CALL(hsaKmtFreeMemory, g_baseTest->m_hsakmt_current_ctx, sysBuf, size));
 
     TEST_END
 }
@@ -2519,7 +2519,7 @@ void KFDQMTest::PM4EventInterrupt(int gpuNode) {
             queue[i].SubmitPacket();
 
         for (int i = 0; i < numPM4Queue; i++) {
-            EXPECT_SUCCESS_GPU(hsaKmtWaitOnEvent(event[i], g_TestTimeOut), gpuNode);
+            EXPECT_SUCCESS_GPU(HSAKMT_CALL(hsaKmtWaitOnEvent, m_hsakmt_current_ctx, event[i], g_TestTimeOut), gpuNode);
             EXPECT_EQ_GPU(buf[i][0], 0xdeadbeaf, gpuNode);
             EXPECT_EQ_GPU(buf[i][packetCount - 1], 0xdeadbeaf, gpuNode);
             memset(buf[i], 0, bufSize);
@@ -2527,7 +2527,7 @@ void KFDQMTest::PM4EventInterrupt(int gpuNode) {
 
         for (int i = 0; i < numPM4Queue; i++) {
             EXPECT_SUCCESS_GPU(queue[i].Destroy(), gpuNode);
-            EXPECT_SUCCESS_GPU(hsaKmtDestroyEvent(event[i]), gpuNode);
+            EXPECT_SUCCESS_GPU(HSAKMT_CALL(hsaKmtDestroyEvent, m_hsakmt_current_ctx, event[i]), gpuNode);
         }
     }
 
@@ -2603,7 +2603,7 @@ void KFDQMTest::SdmaEventInterrupt(int gpuNode) {
 
             for (int i = 0; i < testSDMAQueue; i++) {
                 TimeStamp *ts = tsbuf + i * 32;
-                HSAKMT_STATUS ret = hsaKmtWaitOnEvent(event[i], g_TestTimeOut);
+                HSAKMT_STATUS ret = HSAKMT_CALL(hsaKmtWaitOnEvent, m_hsakmt_current_ctx, event[i], g_TestTimeOut);
 
                 if (dst[i][0] != src[0])
                     WARN() << "SDMACopyData FAIL! " << std::dec
@@ -2620,7 +2620,7 @@ void KFDQMTest::SdmaEventInterrupt(int gpuNode) {
 
                     queue[i].SubmitPacket();
 
-                    if (hsaKmtWaitOnEvent(event[i], g_TestTimeOut) == HSAKMT_STATUS_SUCCESS)
+                    if (HSAKMT_CALL(hsaKmtWaitOnEvent, m_hsakmt_current_ctx, event[i], g_TestTimeOut) == HSAKMT_STATUS_SUCCESS)
                         WARN() << "The timeout event is signaled!" << std::endl;
                     else
                         WARN() << "The timeout event is lost after resubmit!" << std::endl;
@@ -2636,7 +2636,7 @@ void KFDQMTest::SdmaEventInterrupt(int gpuNode) {
 
             for (int i = 0; i < testSDMAQueue; i++) {
                 EXPECT_SUCCESS_GPU(queue[i].Destroy(), gpuNode);
-                EXPECT_SUCCESS_GPU(hsaKmtDestroyEvent(event[i]), gpuNode);
+                EXPECT_SUCCESS_GPU(HSAKMT_CALL(hsaKmtDestroyEvent, m_hsakmt_current_ctx, event[i]), gpuNode);
             }
         }
 
@@ -2765,7 +2765,8 @@ TEST_F(KFDQMTest, UserQueueBufValidation) {
     // System memory mapping on GPU
     QueueBuf = new HsaMemoryBuffer(PAGE_SIZE, defaultGPUNode);
 
-    EXPECT_SUCCESS(hsaKmtCreateQueue(defaultGPUNode,
+    EXPECT_SUCCESS(HSAKMT_CALL(hsaKmtCreateQueue, g_baseTest->m_hsakmt_current_ctx,
+                               defaultGPUNode,
                                HSA_QUEUE_COMPUTE,
                                100,
                                HSA_QUEUE_PRIORITY_NORMAL,
@@ -2773,10 +2774,11 @@ TEST_F(KFDQMTest, UserQueueBufValidation) {
                                PAGE_SIZE,
                                NULL,
                                &QueueResources));
-    EXPECT_SUCCESS(hsaKmtDestroyQueue(QueueResources.QueueId));
+    EXPECT_SUCCESS(HSAKMT_CALL(hsaKmtDestroyQueue, g_baseTest->m_hsakmt_current_ctx, QueueResources.QueueId));
 
     // CP Queue creation should fail using wrong ring buffer size
-    EXPECT_SUCCESS(!hsaKmtCreateQueue(defaultGPUNode,
+    EXPECT_SUCCESS(!HSAKMT_CALL(hsaKmtCreateQueue, g_baseTest->m_hsakmt_current_ctx,
+                               defaultGPUNode,
                                HSA_QUEUE_COMPUTE,
                                100,
                                HSA_QUEUE_PRIORITY_NORMAL,
@@ -2786,7 +2788,8 @@ TEST_F(KFDQMTest, UserQueueBufValidation) {
                                &QueueResources));
 
     // SDMA queue create should fail using wrong ring buffer size
-    EXPECT_SUCCESS(!hsaKmtCreateQueue(defaultGPUNode,
+    EXPECT_SUCCESS(!HSAKMT_CALL(hsaKmtCreateQueue, g_baseTest->m_hsakmt_current_ctx,
+                               defaultGPUNode,
                                HSA_QUEUE_SDMA,
                                100,
                                HSA_QUEUE_PRIORITY_NORMAL,
@@ -2796,7 +2799,8 @@ TEST_F(KFDQMTest, UserQueueBufValidation) {
                                &QueueResources));
 
     // CP queue create should fail using NULL ring buffer
-    EXPECT_SUCCESS(!hsaKmtCreateQueue(defaultGPUNode,
+    EXPECT_SUCCESS(!HSAKMT_CALL(hsaKmtCreateQueue, g_baseTest->m_hsakmt_current_ctx,
+                               defaultGPUNode,
                                HSA_QUEUE_COMPUTE,
                                100,
                                HSA_QUEUE_PRIORITY_NORMAL,
@@ -2806,7 +2810,8 @@ TEST_F(KFDQMTest, UserQueueBufValidation) {
                                &QueueResources));
 
     // SDMA queue create should fail using NULL ring buffer
-    EXPECT_SUCCESS(!hsaKmtCreateQueue(defaultGPUNode,
+    EXPECT_SUCCESS(!HSAKMT_CALL(hsaKmtCreateQueue, g_baseTest->m_hsakmt_current_ctx,
+                               defaultGPUNode,
                                HSA_QUEUE_SDMA,
                                100,
                                HSA_QUEUE_PRIORITY_NORMAL,
@@ -2815,8 +2820,8 @@ TEST_F(KFDQMTest, UserQueueBufValidation) {
                                NULL,
                                &QueueResources));
 
-    EXPECT_SUCCESS(hsaKmtUnmapMemoryToGPU(QueueBuf->As<unsigned int*>()));
-    EXPECT_SUCCESS(hsaKmtFreeMemory(QueueBuf->As<unsigned int*>(), PAGE_SIZE));
+    EXPECT_SUCCESS(HSAKMT_CALL(hsaKmtUnmapMemoryToGPU, g_baseTest->m_hsakmt_current_ctx, QueueBuf->As<unsigned int*>()));
+    EXPECT_SUCCESS(HSAKMT_CALL(hsaKmtFreeMemory, g_baseTest->m_hsakmt_current_ctx, QueueBuf->As<unsigned int*>(), PAGE_SIZE));
 
     //
     // This following negative test will evict user queues, must execute in child process,
@@ -2835,7 +2840,8 @@ TEST_F(KFDQMTest, UserQueueBufValidation) {
         QueueBuf = new HsaMemoryBuffer(PAGE_SIZE, defaultGPUNode);
         memset(&QueueResources, 0, sizeof(QueueResources));
 
-        status = hsaKmtCreateQueue(defaultGPUNode,
+        status = HSAKMT_CALL(hsaKmtCreateQueue, g_baseTest->m_hsakmt_current_ctx,
+                               defaultGPUNode,
                                HSA_QUEUE_COMPUTE,
                                100,
                                HSA_QUEUE_PRIORITY_NORMAL,
@@ -2849,7 +2855,7 @@ TEST_F(KFDQMTest, UserQueueBufValidation) {
         }
 
         // Update queue percentage 0 to set queue inactive in order to get queue info CWSR area
-        status = hsaKmtUpdateQueue(QueueResources.QueueId, 0, HSA_QUEUE_PRIORITY_NORMAL,
+        status = HSAKMT_CALL(hsaKmtUpdateQueue, g_baseTest->m_hsakmt_current_ctx, QueueResources.QueueId, 0, HSA_QUEUE_PRIORITY_NORMAL,
                                      QueueBuf->As<unsigned int*>(), PAGE_SIZE, NULL);
         if (status != HSAKMT_STATUS_SUCCESS) {
             LOG() << "update queue failed." << std::endl;
@@ -2857,7 +2863,7 @@ TEST_F(KFDQMTest, UserQueueBufValidation) {
         }
 
         HsaQueueInfo QueueInfo;
-        status = hsaKmtGetQueueInfo(QueueResources.QueueId, &QueueInfo);
+        status = HSAKMT_CALL(hsaKmtGetQueueInfo, g_baseTest->m_hsakmt_current_ctx, QueueResources.QueueId, &QueueInfo);
         if (status != HSAKMT_STATUS_SUCCESS) {
             LOG() << "get queue info failed." << std::endl;
             goto err_exit;
@@ -2868,13 +2874,13 @@ TEST_F(KFDQMTest, UserQueueBufValidation) {
         munmap(cwsr_addr, PAGE_SIZE);
 
         // unmap and free queue ring buffer should fail before the queue is destroyed
-        status = hsaKmtFreeMemory(QueueBuf->As<unsigned int*>(), PAGE_SIZE);
+        status = HSAKMT_CALL(hsaKmtFreeMemory, g_baseTest->m_hsakmt_current_ctx, QueueBuf->As<unsigned int*>(), PAGE_SIZE);
         if (status == HSAKMT_STATUS_SUCCESS) {
             LOG() << "free queue buf should fail." << std::endl;
             goto err_exit;
         }
 
-        status = hsaKmtUnmapMemoryToGPU(QueueBuf->As<unsigned int*>());
+        status = HSAKMT_CALL(hsaKmtUnmapMemoryToGPU, g_baseTest->m_hsakmt_current_ctx, QueueBuf->As<unsigned int*>());
         if (status == HSAKMT_STATUS_SUCCESS) {
             LOG() << "unmap queue buf should fail." << std::endl;
             goto err_exit;
@@ -2883,19 +2889,19 @@ TEST_F(KFDQMTest, UserQueueBufValidation) {
         exit_code = 0;
 
 err_exit:
-        status = hsaKmtDestroyQueue(QueueResources.QueueId);
+        status = HSAKMT_CALL(hsaKmtDestroyQueue, g_baseTest->m_hsakmt_current_ctx, QueueResources.QueueId);
         if (status != HSAKMT_STATUS_SUCCESS) {
             LOG() << "destroy queue failed." << std::endl;
             exit_code = 1;
         }
 free_exit:
-        status = hsaKmtUnmapMemoryToGPU(QueueBuf->As<unsigned int*>());
+        status = HSAKMT_CALL(hsaKmtUnmapMemoryToGPU, g_baseTest->m_hsakmt_current_ctx, QueueBuf->As<unsigned int*>());
         if (status != HSAKMT_STATUS_SUCCESS) {
             LOG() << "unmap queue buf failed." << std::endl;
             exit_code = 1;
         }
 
-        status = hsaKmtFreeMemory(QueueBuf->As<unsigned int*>(), PAGE_SIZE);
+        status = HSAKMT_CALL(hsaKmtFreeMemory, g_baseTest->m_hsakmt_current_ctx, QueueBuf->As<unsigned int*>(), PAGE_SIZE);
         if (status != HSAKMT_STATUS_SUCCESS) {
             LOG() << "free queue buf failed." << std::endl;
             exit_code = 1;

--- a/projects/rocr-runtime/libhsakmt/tests/kfdtest/src/KFDRASTest.cpp
+++ b/projects/rocr-runtime/libhsakmt/tests/kfdtest/src/KFDRASTest.cpp
@@ -110,7 +110,7 @@ void KFDRASTest::SetUp() {
     eventDesc.SyncVar.SyncVar.UserData = NULL;
     eventDesc.SyncVar.SyncVarSize = 0;
 
-    ASSERT_SUCCESS(hsaKmtCreateEvent(&eventDesc, true, false, &m_pRasEvent));
+    ASSERT_SUCCESS(HSAKMT_CALL(hsaKmtCreateEvent, m_hsakmt_current_ctx, &eventDesc, true, false, &m_pRasEvent));
 
     m_setupStatus = true;
 
@@ -121,7 +121,7 @@ void KFDRASTest::TearDown() {
     ROUTINE_START
 
     if (m_pRasEvent != NULL) {
-        EXPECT_SUCCESS(hsaKmtDestroyEvent(m_pRasEvent));
+        EXPECT_SUCCESS(HSAKMT_CALL(hsaKmtDestroyEvent, m_hsakmt_current_ctx, m_pRasEvent));
     }
 
     fclose(m_pFile);
@@ -142,7 +142,7 @@ TEST_F(KFDRASTest, DISABLED_BasicTest) {
     fwrite("inject umc ue 0 0", sizeof(char), 17, m_pFile);
     fflush(m_pFile);
 
-    EXPECT_SUCCESS(hsaKmtWaitOnEvent(m_pRasEvent, g_TestTimeOut));
+    EXPECT_SUCCESS(HSAKMT_CALL(hsaKmtWaitOnEvent, g_baseTest->m_hsakmt_current_ctx, m_pRasEvent, g_TestTimeOut));
 
     EXPECT_EQ(1, m_pRasEvent->EventData.EventData.MemoryAccessFault.Failure.ErrorType);
 
@@ -169,17 +169,17 @@ TEST_F(KFDRASTest, DISABLED_MixEventsTest) {
 
     queue.Wait4PacketConsumption();
 
-    EXPECT_SUCCESS(hsaKmtWaitOnEvent(pHsaEvent, g_TestTimeOut));
+    EXPECT_SUCCESS(HSAKMT_CALL(hsaKmtWaitOnEvent, g_baseTest->m_hsakmt_current_ctx, pHsaEvent, g_TestTimeOut));
 
     fwrite("inject umc ue 0 0", sizeof(char), 17, m_pFile);
     fflush(m_pFile);
 
-    EXPECT_SUCCESS(hsaKmtWaitOnEvent(m_pRasEvent, g_TestTimeOut));
+    EXPECT_SUCCESS(HSAKMT_CALL(hsaKmtWaitOnEvent, g_baseTest->m_hsakmt_current_ctx, m_pRasEvent, g_TestTimeOut));
 
     EXPECT_EQ(1, m_pRasEvent->EventData.EventData.MemoryAccessFault.Failure.ErrorType);
 
     EXPECT_SUCCESS(queue.Destroy());
-    EXPECT_SUCCESS(hsaKmtDestroyEvent(pHsaEvent));
+    EXPECT_SUCCESS(HSAKMT_CALL(hsaKmtDestroyEvent, g_baseTest->m_hsakmt_current_ctx, pHsaEvent));
 
     TEST_END;
 }

--- a/projects/rocr-runtime/libhsakmt/tests/kfdtest/src/KFDSVMEvictTest.cpp
+++ b/projects/rocr-runtime/libhsakmt/tests/kfdtest/src/KFDSVMEvictTest.cpp
@@ -74,7 +74,7 @@ HSAint32 KFDSVMEvictTest::GetBufferCounter(HSAuint64 vramSize, HSAuint64 vramBuf
      * KFD system memory limit is 15/16.
      */
     HSAint32 xnack_enable = 0;
-    EXPECT_SUCCESS(hsaKmtGetXNACKMode(&xnack_enable));
+    EXPECT_SUCCESS(HSAKMT_CALL(hsaKmtGetXNACKMode, m_hsakmt_current_ctx, &xnack_enable));
     if (!xnack_enable && size > (sysMemSize - (sysMemSize >> 4)))
         return 0;
 
@@ -236,10 +236,10 @@ TEST_P(KFDSVMEvictTest, BasicTest) {
         return;
     if (m_is_xnack_supported) {
         HSAint32 xnack_enable = 0;
-        EXPECT_SUCCESS(hsaKmtGetXNACKMode(&xnack_enable));
+        EXPECT_SUCCESS(HSAKMT_CALL(hsaKmtGetXNACKMode, g_baseTest->m_hsakmt_current_ctx, &xnack_enable));
         if (!xnack_enable) {
-	    LOG() << std::hex << "Test is skipped with xnack off" << std::endl;
-            return;
+	        LOG() << std::hex << "Test is skipped with xnack off" << std::endl;
+                return;
         }
     }
 
@@ -311,7 +311,7 @@ TEST_P(KFDSVMEvictTest, QueueTest) {
         return;
     HSAint32 xnack_enable = 0;
     if (m_is_xnack_supported) {
-        EXPECT_SUCCESS(hsaKmtGetXNACKMode(&xnack_enable));
+        EXPECT_SUCCESS(HSAKMT_CALL(hsaKmtGetXNACKMode, g_baseTest->m_hsakmt_current_ctx, &xnack_enable));
         if (!xnack_enable) {
             LOG() << std::hex << "Test is skipped with xnack off" << std::endl;
             return;

--- a/projects/rocr-runtime/libhsakmt/tests/kfdtest/src/KFDSVMRangeTest.cpp
+++ b/projects/rocr-runtime/libhsakmt/tests/kfdtest/src/KFDSVMRangeTest.cpp
@@ -135,14 +135,14 @@ void KFDSVMRangeTest::SetGetAttributesTest(int gpuNode) {
                                              0,
                                          };
     HSAint32 enable = -1;
-    EXPECT_SUCCESS_GPU(hsaKmtGetXNACKMode(&enable), gpuNode);
+    EXPECT_SUCCESS_GPU(HSAKMT_CALL(hsaKmtGetXNACKMode, m_hsakmt_current_ctx, &enable), gpuNode);
     expectedDefaultResults[4] = (enable) ?
                                  HSA_SVM_ATTR_ACCESS : HSA_SVM_ATTR_NO_ACCESS;
     char *pBuf = sysBuffer->As<char *>();
 
     LOG() << "Get default atrributes" << std::endl;
     memcpy(outputAttributes, inputAttributes, nAttributes * sizeof(HSA_SVM_ATTRIBUTE));
-    EXPECT_SUCCESS_GPU(hsaKmtSVMGetAttr(pBuf, BufSize,
+    EXPECT_SUCCESS_GPU(HSAKMT_CALL(hsaKmtSVMGetAttr, m_hsakmt_current_ctx, pBuf, BufSize,
                                     nAttributes, outputAttributes), gpuNode);
 
     for (i = 0; i < nAttributes; i++) {
@@ -161,9 +161,9 @@ void KFDSVMRangeTest::SetGetAttributesTest(int gpuNode) {
     }
     LOG() << "Setting/Getting atrributes" << std::endl;
     memcpy(outputAttributes, inputAttributes, nAttributes * sizeof(HSA_SVM_ATTRIBUTE));
-    EXPECT_SUCCESS_GPU(hsaKmtSVMSetAttr(pBuf, BufSize,
+    EXPECT_SUCCESS_GPU(HSAKMT_CALL(hsaKmtSVMSetAttr, m_hsakmt_current_ctx, pBuf, BufSize,
                                     nAttributes, inputAttributes), gpuNode);
-    EXPECT_SUCCESS_GPU(hsaKmtSVMGetAttr(pBuf, BufSize,
+    EXPECT_SUCCESS_GPU(HSAKMT_CALL(hsaKmtSVMGetAttr, m_hsakmt_current_ctx, pBuf, BufSize,
                                     nAttributes, outputAttributes), gpuNode);
     for (i = 0; i < nAttributes; i++) {
         if (outputAttributes[i].type == HSA_SVM_ATTR_ACCESS ||
@@ -203,10 +203,10 @@ TEST_P(KFDSVMRangeTest, XNACKModeTest) {
     HSAint32 enable = 0;
     const std::vector<int> gpuNodes = m_NodeInfo.GetNodesWithGPU();
 
-    EXPECT_SUCCESS(hsaKmtGetXNACKMode(&enable));
+    EXPECT_SUCCESS(HSAKMT_CALL(hsaKmtGetXNACKMode, g_baseTest->m_hsakmt_current_ctx, &enable));
     for (i = 0; i < 2; i++) {
         enable = !enable;
-        r = hsaKmtSetXNACKMode(enable);
+        r = HSAKMT_CALL(hsaKmtSetXNACKMode, g_baseTest->m_hsakmt_current_ctx, enable);
         if (r == HSAKMT_STATUS_SUCCESS) {
             LOG() << "XNACK mode: " << std::boolalpha << enable <<
                      " supported" << std::endl;
@@ -216,7 +216,7 @@ TEST_P(KFDSVMRangeTest, XNACKModeTest) {
                       << gpuNodes.at(j) << std::endl;
                 ASSERT_SUCCESS(queue.Create(gpuNodes.at(j)));
                 EXPECT_EQ(HSAKMT_STATUS_ERROR,
-                        hsaKmtSetXNACKMode(enable));
+                        HSAKMT_CALL(hsaKmtSetXNACKMode, g_baseTest->m_hsakmt_current_ctx, enable));
                 EXPECT_SUCCESS(queue.Destroy());
             }
         } else if (r == HSAKMT_STATUS_NOT_SUPPORTED) {
@@ -634,7 +634,7 @@ void KFDSVMRangeTest::PrefetchTest(int gpuNode) {
     /* hsaKmtSVMGetAttr for HSA_SVM_ATTR_ACCESS is either fail or
      * returned attr.value not equal gpuNode
      */
-    if (hsaKmtSVMGetAttr(pBuf, BufSize, 1, &attr) == HSAKMT_STATUS_SUCCESS)
+    if (HSAKMT_CALL(hsaKmtSVMGetAttr, m_hsakmt_current_ctx, pBuf, BufSize, 1, &attr) == HSAKMT_STATUS_SUCCESS)
         EXPECT_NE_GPU(attr.value, gpuNode, gpuNode);
 
     sysBuffer = new HsaSVMRange(BufSize, gpuNode);
@@ -1480,7 +1480,7 @@ TEST_P(KFDSVMRangeTest, ReadOnlyRangeTest) {
     eventDesc.SyncVar.SyncVar.UserData = NULL;
     eventDesc.SyncVar.SyncVarSize = 0;
 
-    ret = hsaKmtCreateEvent(&eventDesc, true, false, &vmFaultEvent);
+    ret = HSAKMT_CALL(hsaKmtCreateEvent, g_baseTest->m_hsakmt_current_ctx, &eventDesc, true, false, &vmFaultEvent);
     if (ret != HSAKMT_STATUS_SUCCESS) {
         WARN() << "Event create failed" << std::endl;
         exit(ret);
@@ -1510,7 +1510,7 @@ TEST_P(KFDSVMRangeTest, ReadOnlyRangeTest) {
     sdmaQueue.PlaceAndSubmitPacket(SDMACopyDataPacket(sdmaQueue.GetFamilyId(),
                     pinBuf, reinterpret_cast<void *>(pBuf), PAGE_SIZE));
 
-    ret = hsaKmtWaitOnEvent(vmFaultEvent, g_TestTimeOut);
+    ret = HSAKMT_CALL(hsaKmtWaitOnEvent, g_baseTest->m_hsakmt_current_ctx, vmFaultEvent, g_TestTimeOut);
     if (ret != HSAKMT_STATUS_SUCCESS) {
         WARN() << "Wait failed. No Exception triggered" << std::endl;
         goto event_fail;
@@ -1530,7 +1530,7 @@ TEST_P(KFDSVMRangeTest, ReadOnlyRangeTest) {
 event_fail:
     EXPECT_SUCCESS(sdmaQueue.Destroy());
 queue_fail:
-    hsaKmtDestroyEvent(vmFaultEvent);
+    HSAKMT_CALL(hsaKmtDestroyEvent, g_baseTest->m_hsakmt_current_ctx, vmFaultEvent);
     /* Child process exit, otherwise it will continue to run remaining tests */
     exit(ret);
 
@@ -1555,7 +1555,7 @@ unsigned int ReadSMIEventThread(void* p) {
     HSAuint64 events;
     int fd;
 
-    EXPECT_SUCCESS_GPU(hsaKmtOpenSMI(pArgs->nodeid, &fd), pArgs->nodeid);
+    EXPECT_SUCCESS_GPU(HSAKMT_CALL(hsaKmtOpenSMI, g_baseTest->m_hsakmt_current_ctx, pArgs->nodeid, &fd), pArgs->nodeid);
 
     events = HSA_SMI_EVENT_MASK_FROM_INDEX(HSA_SMI_EVENT_INDEX_MAX) - 1;
     EXPECT_EQ_GPU(write(fd, &events, sizeof(events)), sizeof(events), pArgs->nodeid);

--- a/projects/rocr-runtime/libhsakmt/tests/kfdtest/src/KFDTestUtil.cpp
+++ b/projects/rocr-runtime/libhsakmt/tests/kfdtest/src/KFDTestUtil.cpp
@@ -32,6 +32,7 @@
 #include "SDMAQueue.hpp"
 #include "Dispatch.hpp"
 #include "SDMAPacket.hpp"
+#include "KFDBaseComponentTest.hpp"
 
 void WaitUntilInput() {
     char dummy;
@@ -129,7 +130,7 @@ HSAKMT_STATUS CreateQueueTypeEvent(
     Descriptor.SyncVar.SyncVar.UserData = (void*)0xABCDABCD;
     Descriptor.NodeId = NodeId;
 
-    return hsaKmtCreateEvent(&Descriptor, ManualReset, IsSignaled, Event);
+    return HSAKMT_CALL(hsaKmtCreateEvent, g_baseTest->m_hsakmt_current_ctx, &Descriptor, ManualReset, IsSignaled, Event);
 }
 
 HSAKMT_STATUS CreateHWExceptionEvent(
@@ -144,7 +145,7 @@ HSAKMT_STATUS CreateHWExceptionEvent(
     Descriptor.SyncVar.SyncVar.UserData = (void*)0xABCDABCD;
     Descriptor.NodeId = NodeId;
 
-    return hsaKmtCreateEvent(&Descriptor, ManualReset, IsSignaled, Event);
+    return HSAKMT_CALL(hsaKmtCreateEvent, g_baseTest->m_hsakmt_current_ctx, &Descriptor, ManualReset, IsSignaled, Event);
 }
 
 static bool hsakmt_is_dgpu_dev = false;
@@ -156,7 +157,7 @@ bool hsakmt_is_dgpu() {
 bool hasPciAtomicsSupport(int node) {
     /* If we can't get Node Properties, assume a lack of Atomics support */
     HsaNodeProperties *pNodeProperties = new HsaNodeProperties();
-    if (hsaKmtGetNodeProperties(node, pNodeProperties)) {
+    if (HSAKMT_CALL(hsaKmtGetNodeProperties, g_baseTest->m_hsakmt_current_ctx, node, pNodeProperties)) {
         LOG() << "Unable to get Node Properties for node " << node << std::endl;
         return false;
     }
@@ -166,7 +167,7 @@ bool hasPciAtomicsSupport(int node) {
         return true;
 
     HsaIoLinkProperties *IolinkProperties = new HsaIoLinkProperties[pNodeProperties->NumIOLinks];
-    if (hsaKmtGetNodeIoLinkProperties(node, pNodeProperties->NumIOLinks, IolinkProperties)) {
+    if (HSAKMT_CALL(hsaKmtGetNodeIoLinkProperties, g_baseTest->m_hsakmt_current_ctx, node, pNodeProperties->NumIOLinks, IolinkProperties)) {
         LOG() << "Unable to get Node IO Link Information for node " << node << std::endl;
         return false;
     }
@@ -175,7 +176,7 @@ bool hasPciAtomicsSupport(int node) {
     for (int linkId = 0; linkId < pNodeProperties->NumIOLinks; linkId++) {
         /* Make sure it's a CPU */
         HsaNodeProperties *linkProps = new HsaNodeProperties();
-        if (hsaKmtGetNodeProperties(IolinkProperties[linkId].NodeTo, linkProps)) {
+        if (HSAKMT_CALL(hsaKmtGetNodeProperties, g_baseTest->m_hsakmt_current_ctx, IolinkProperties[linkId].NodeTo, linkProps)) {
             LOG() << "Unable to get connected device's IO Link information" << std::endl;
             return false;
         }
@@ -291,7 +292,7 @@ bool GPUMemCopy(void* dst, void* src, size_t size, unsigned int node, bool useSd
             return false;
 
         HsaNodeProperties nodeProperties;
-        if (hsaKmtGetNodeProperties(node, &nodeProperties) != HSAKMT_STATUS_SUCCESS)
+        if (HSAKMT_CALL(hsaKmtGetNodeProperties, g_baseTest->m_hsakmt_current_ctx, node, &nodeProperties) != HSAKMT_STATUS_SUCCESS)
             return false;
         Assembler pAsm(GetGfxVersion(&nodeProperties));
 
@@ -360,12 +361,12 @@ HsaMemoryBuffer::HsaMemoryBuffer(HSAuint64 size, unsigned int node, bool zero, b
     if (zero)
         EXPECT_EQ(m_Flags.ui32.HostAccess, 1);
 
-    EXPECT_SUCCESS(hsaKmtAllocMemory(m_Node, m_Size, m_Flags, &m_pBuf));
+    EXPECT_SUCCESS(HSAKMT_CALL(hsaKmtAllocMemory, g_baseTest->m_hsakmt_current_ctx, m_Node, m_Size, m_Flags, &m_pBuf));
     if (hsakmt_is_dgpu()) {
         if (map_specific_gpu)
-            EXPECT_SUCCESS(hsaKmtMapMemoryToGPUNodes(m_pBuf, m_Size, NULL, mapFlags, 1, &m_Node));
+            EXPECT_SUCCESS(HSAKMT_CALL(hsaKmtMapMemoryToGPUNodes, g_baseTest->m_hsakmt_current_ctx, m_pBuf, m_Size, NULL, mapFlags, 1, &m_Node));
         else
-            EXPECT_SUCCESS(hsaKmtMapMemoryToGPU(m_pBuf, m_Size, NULL));
+            EXPECT_SUCCESS(HSAKMT_CALL(hsaKmtMapMemoryToGPU, g_baseTest->m_hsakmt_current_ctx, m_pBuf, m_Size, NULL));
         m_MappedNodes = 1 << m_Node;
     }
 
@@ -380,8 +381,8 @@ HsaMemoryBuffer::HsaMemoryBuffer(void *addr, HSAuint64 size):
     m_Local(false),
     m_Node(0) {
     HSAuint64 gpuva = 0;
-    EXPECT_SUCCESS(hsaKmtRegisterMemory(m_pUser, m_Size));
-    EXPECT_SUCCESS(hsaKmtMapMemoryToGPU(m_pUser, m_Size, &gpuva));
+    EXPECT_SUCCESS(HSAKMT_CALL(hsaKmtRegisterMemory, g_baseTest->m_hsakmt_current_ctx, m_pUser, m_Size));
+    EXPECT_SUCCESS(HSAKMT_CALL(hsaKmtMapMemoryToGPU, g_baseTest->m_hsakmt_current_ctx, m_pUser, m_Size, &gpuva));
     m_pBuf = gpuva ? (void *)gpuva : m_pUser;
 }
 
@@ -444,9 +445,9 @@ void HsaMemoryBuffer::Fill(HSAuint32 value, BaseQueue& baseQueue, HSAuint64 offs
     baseQueue.PlacePacket(SDMAFencePacket(baseQueue.GetFamilyId(),
                                 reinterpret_cast<void*>(event->EventData.HWData2), event->EventId));
     baseQueue.PlaceAndSubmitPacket(SDMATrapPacket(event->EventId));
-    EXPECT_SUCCESS(hsaKmtWaitOnEvent(event, g_TestTimeOut));
+    EXPECT_SUCCESS(HSAKMT_CALL(hsaKmtWaitOnEvent, g_baseTest->m_hsakmt_current_ctx, event, g_TestTimeOut));
 
-    hsaKmtDestroyEvent(event);
+    HSAKMT_CALL(hsaKmtDestroyEvent, g_baseTest->m_hsakmt_current_ctx, event);
 }
 
 /* Check if HsaMemoryBuffer[location] has the pattern specified.
@@ -502,8 +503,8 @@ bool HsaMemoryBuffer::IsPattern(HSAuint64 location, HSAuint32 pattern, BaseQueue
             event->EventId));
     baseQueue.PlaceAndSubmitPacket(SDMATrapPacket(event->EventId));
 
-    ret = hsaKmtWaitOnEvent(event, g_TestTimeOut);
-    hsaKmtDestroyEvent(event);
+    ret = HSAKMT_CALL(hsaKmtWaitOnEvent, g_baseTest->m_hsakmt_current_ctx, event, g_TestTimeOut);
+    HSAKMT_CALL(hsaKmtDestroyEvent, g_baseTest->m_hsakmt_current_ctx, event);
     if (ret)
         return false;
 
@@ -526,7 +527,7 @@ int HsaMemoryBuffer::MapMemToNodes(unsigned int *nodes, unsigned int nodes_num) 
     HsaMemMapFlags mapFlags = {0};
     int ret, bit;
 
-    ret = hsaKmtMapMemoryToGPUNodes(m_pBuf, m_Size, NULL, mapFlags, nodes_num, nodes);
+    ret = HSAKMT_CALL(hsaKmtMapMemoryToGPUNodes, g_baseTest->m_hsakmt_current_ctx, m_pBuf, m_Size, NULL, mapFlags, nodes_num, nodes);
     if (ret != 0) {
         return ret;
     }
@@ -542,7 +543,7 @@ int HsaMemoryBuffer::MapMemToNodes(unsigned int *nodes, unsigned int nodes_num) 
 int HsaMemoryBuffer::UnmapMemToNodes(unsigned int *nodes, unsigned int nodes_num) {
     int ret, bit;
 
-    ret = hsaKmtUnmapMemoryToGPU(m_pBuf);
+    ret = HSAKMT_CALL(hsaKmtUnmapMemoryToGPU, g_baseTest->m_hsakmt_current_ctx, m_pBuf);
     if (ret)
         return ret;
 
@@ -578,7 +579,7 @@ void HsaMemoryBuffer::UnmapAllNodes() {
     /*
      * TODO: When thunk is updated, use hsaKmtRegisterToNodes. Then nodes will be used
      */
-    hsaKmtUnmapMemoryToGPU(m_pBuf);
+    HSAKMT_CALL(hsaKmtUnmapMemoryToGPU, g_baseTest->m_hsakmt_current_ctx, m_pBuf);
 
     m_MappedNodes = 0;
 
@@ -587,15 +588,15 @@ void HsaMemoryBuffer::UnmapAllNodes() {
 
 HsaMemoryBuffer::~HsaMemoryBuffer() {
     if (m_pUser != NULL) {
-        hsaKmtUnmapMemoryToGPU(m_pUser);
-        hsaKmtDeregisterMemory(m_pUser);
+        HSAKMT_CALL(hsaKmtUnmapMemoryToGPU, g_baseTest->m_hsakmt_current_ctx, m_pUser);
+        HSAKMT_CALL(hsaKmtDeregisterMemory, g_baseTest->m_hsakmt_current_ctx, m_pUser);
     } else if (m_pBuf != NULL) {
         if (hsakmt_is_dgpu()) {
             if (m_MappedNodes) {
-                hsaKmtUnmapMemoryToGPU(m_pBuf);
+                HSAKMT_CALL(hsaKmtUnmapMemoryToGPU, g_baseTest->m_hsakmt_current_ctx, m_pBuf);
             }
         }
-        hsaKmtFreeMemory(m_pBuf, m_Size);
+        HSAKMT_CALL(hsaKmtFreeMemory, g_baseTest->m_hsakmt_current_ctx, m_pBuf, m_Size);
     }
     m_pBuf = NULL;
 }
@@ -612,7 +613,7 @@ HsaInteropMemoryBuffer::HsaInteropMemoryBuffer(HSAuint64 device_handle, HSAuint6
 }
 
 HsaInteropMemoryBuffer::~HsaInteropMemoryBuffer() {
-    hsaKmtUnmapGraphicHandle(m_Node, (HSAuint64)m_pBuf, m_Size);
+    HSAKMT_CALL(hsaKmtUnmapGraphicHandle, g_baseTest->m_hsakmt_current_ctx, m_Node, (HSAuint64)m_pBuf, m_Size);
 }
 
 
@@ -631,7 +632,7 @@ bool HsaNodeInfo::Init(int NumOfNodes) {
     for (int i = 0; i < NumOfNodes; i++) {
         nodeProperties = new HsaNodeProperties();
 
-        status = hsaKmtGetNodeProperties(i, nodeProperties);
+        status = HSAKMT_CALL(hsaKmtGetNodeProperties, g_baseTest->m_hsakmt_current_ctx, i, nodeProperties);
         /* This is not a fatal test (not using assert), since even when it fails for one node
          * we want to get information regarding others.
          */
@@ -736,8 +737,8 @@ const bool HsaNodeInfo::IsGPUNodeLargeBar(int node) const {
     if (pNodeProperties) {
         HsaMemoryProperties *memoryProperties =
                 new HsaMemoryProperties[pNodeProperties->NumMemoryBanks];
-        EXPECT_SUCCESS(hsaKmtGetNodeMemoryProperties(node,
-                       pNodeProperties->NumMemoryBanks, memoryProperties));
+        EXPECT_SUCCESS(HSAKMT_CALL(hsaKmtGetNodeMemoryProperties, g_baseTest->m_hsakmt_current_ctx,
+                                        node, pNodeProperties->NumMemoryBanks, memoryProperties));
         for (unsigned bank = 0; bank < pNodeProperties->NumMemoryBanks; bank++)
             if (memoryProperties[bank].HeapType ==
                                 HSA_HEAPTYPE_FRAME_BUFFER_PUBLIC) {
@@ -758,7 +759,7 @@ const bool HsaNodeInfo::IsAppAPU(int node) const {
         return false;
 
     HsaIoLinkProperties *IolinkProperties = new HsaIoLinkProperties[pNodeProperties->NumIOLinks];
-    if (hsaKmtGetNodeIoLinkProperties(node, pNodeProperties->NumIOLinks, IolinkProperties)) {
+    if (HSAKMT_CALL(hsaKmtGetNodeIoLinkProperties, g_baseTest->m_hsakmt_current_ctx, node, pNodeProperties->NumIOLinks, IolinkProperties)) {
         LOG() << "Unable to get Node IO Link Information for node " << node << std::endl;
         delete [] IolinkProperties;
         return false;
@@ -768,7 +769,7 @@ const bool HsaNodeInfo::IsAppAPU(int node) const {
     for (int linkId = 0; linkId < pNodeProperties->NumIOLinks; linkId++) {
         HsaNodeProperties linkProps;
 
-        if (hsaKmtGetNodeProperties(IolinkProperties[linkId].NodeTo, &linkProps)) {
+        if (HSAKMT_CALL(hsaKmtGetNodeProperties, g_baseTest->m_hsakmt_current_ctx, IolinkProperties[linkId].NodeTo, &linkProps)) {
             LOG() << "Unable to get connected device's IO Link information" << std::endl;
             break;
         }
@@ -789,8 +790,8 @@ const bool HsaNodeInfo::IsPeerAccessibleByNode(int peer, int node) const {
     pNodeProperties = GetNodeProperties(node);
     if (pNodeProperties) {
         HsaIoLinkProperties p2pLinksProperties[pNodeProperties->NumIOLinks];
-        EXPECT_SUCCESS(hsaKmtGetNodeIoLinkProperties(node,
-					pNodeProperties->NumIOLinks, p2pLinksProperties));
+        EXPECT_SUCCESS(HSAKMT_CALL(hsaKmtGetNodeIoLinkProperties, g_baseTest->m_hsakmt_current_ctx,
+                                        node, pNodeProperties->NumIOLinks, p2pLinksProperties));
 
         for (unsigned link = 0; link < pNodeProperties->NumIOLinks; link++)
             if (p2pLinksProperties[link].NodeTo == peer)
@@ -842,7 +843,8 @@ const bool HsaNodeInfo::IsNodeXGMItoCPU(int node) const {
     pNodeProperties = GetNodeProperties(node);
     if (pNodeProperties && pNodeProperties->NumIOLinks) {
         HsaIoLinkProperties  *IolinkProperties =  new HsaIoLinkProperties[pNodeProperties->NumIOLinks];
-        EXPECT_SUCCESS(hsaKmtGetNodeIoLinkProperties(node, pNodeProperties->NumIOLinks, IolinkProperties));
+        EXPECT_SUCCESS(HSAKMT_CALL(hsaKmtGetNodeIoLinkProperties, g_baseTest->m_hsakmt_current_ctx,
+                                        node, pNodeProperties->NumIOLinks, IolinkProperties));
 
         for (int linkId = 0; linkId < pNodeProperties->NumIOLinks; linkId++) {
             EXPECT_EQ(node, IolinkProperties[linkId].NodeFrom);
@@ -879,7 +881,7 @@ HSAKMT_STATUS RegisterSVMRange(HSAuint32 GPUNode, void *MemoryAddress,
     attrs[3].type = HSA_SVM_ATTR_ACCESS;
     attrs[3].value = GPUNode;
 
-    r = hsaKmtSVMSetAttr(MemoryAddress, SizeInBytes, nattr, attrs);
+    r = HSAKMT_CALL(hsaKmtSVMSetAttr, g_baseTest->m_hsakmt_current_ctx, MemoryAddress, SizeInBytes, nattr, attrs);
     if (r)
         return HSAKMT_STATUS_ERROR;
 
@@ -894,7 +896,7 @@ HSAKMT_STATUS SVMRangeGetPrefetchNode(void *MemoryAddress, HSAuint64 SizeInBytes
     attr.type = HSA_SVM_ATTR_PREFETCH_LOC;
     attr.value = 0;
 
-    r = hsaKmtSVMGetAttr(MemoryAddress, SizeInBytes, 1, &attr);
+    r = HSAKMT_CALL(hsaKmtSVMGetAttr, g_baseTest->m_hsakmt_current_ctx, MemoryAddress, SizeInBytes, 1, &attr);
     if (r)
         return HSAKMT_STATUS_ERROR;
 
@@ -911,7 +913,7 @@ HSAKMT_STATUS SVMRangePrefetchToNode(void *MemoryAddress, HSAuint64 SizeInBytes,
     attr.type = HSA_SVM_ATTR_PREFETCH_LOC;
     attr.value = PrefetchNode;
 
-    r = hsaKmtSVMSetAttr(MemoryAddress, SizeInBytes, 1, &attr);
+    r = HSAKMT_CALL(hsaKmtSVMSetAttr, g_baseTest->m_hsakmt_current_ctx, MemoryAddress, SizeInBytes, 1, &attr);
     if (r)
         return HSAKMT_STATUS_ERROR;
 
@@ -926,7 +928,7 @@ HSAKMT_STATUS SVMRangeMapToNode(void *MemoryAddress, HSAuint64 SizeInBytes,
     attr.type = HSA_SVM_ATTR_ACCESS;
     attr.value = NodeID;
 
-    r = hsaKmtSVMSetAttr(MemoryAddress, SizeInBytes, 1, &attr);
+    r = HSAKMT_CALL(hsaKmtSVMSetAttr, g_baseTest->m_hsakmt_current_ctx, MemoryAddress, SizeInBytes, 1, &attr);
     if (r)
         return HSAKMT_STATUS_ERROR;
 
@@ -941,7 +943,7 @@ HSAKMT_STATUS SVMRangeMapInPlaceToNode(void *MemoryAddress, HSAuint64 SizeInByte
     attr.type = HSA_SVM_ATTR_ACCESS_IN_PLACE;
     attr.value = NodeID;
 
-    r = hsaKmtSVMSetAttr(MemoryAddress, SizeInBytes, 1, &attr);
+    r = HSAKMT_CALL(hsaKmtSVMSetAttr, g_baseTest->m_hsakmt_current_ctx, MemoryAddress, SizeInBytes, 1, &attr);
     if (r)
         return HSAKMT_STATUS_ERROR;
 
@@ -956,7 +958,7 @@ HSAKMT_STATUS SVMRangSetGranularity(void *MemoryAddress, HSAuint64 SizeInBytes,
     attr.type = HSA_SVM_ATTR_GRANULARITY;
     attr.value = Granularity;
 
-    r = hsaKmtSVMSetAttr(MemoryAddress, SizeInBytes, 1, &attr);
+    r = HSAKMT_CALL(hsaKmtSVMSetAttr, g_baseTest->m_hsakmt_current_ctx, MemoryAddress, SizeInBytes, 1, &attr);
     if (r)
         return HSAKMT_STATUS_ERROR;
 

--- a/projects/rocr-runtime/libhsakmt/tests/kfdtest/src/KFDTestUtil.hpp
+++ b/projects/rocr-runtime/libhsakmt/tests/kfdtest/src/KFDTestUtil.hpp
@@ -29,6 +29,7 @@
 #include "OSWrapper.hpp"
 #include "GoogleTestExtension.hpp"
 #include "hsakmt/hsakmt.h"
+#include "hsakmt/hsakmtctx.h"
 #include "Assemble.hpp"
 #include "ShaderStore.hpp"
 

--- a/projects/rocr-runtime/libhsakmt/tests/kfdtest/src/KFDTestUtil.hpp
+++ b/projects/rocr-runtime/libhsakmt/tests/kfdtest/src/KFDTestUtil.hpp
@@ -37,6 +37,12 @@ class BaseQueue;
 #define ALIGN_UP(x, align) (((uint64_t)(x) + (align) - 1) & ~(uint64_t)((align)-1))
 #define CounterToNanoSec(x) ((x) * 1000 / (hsakmt_is_dgpu() ? 27 : 100))
 
+#ifdef HSAKMT_CTX
+#define HSAKMT_CALL(func, ctx, ...) func##Ctx(ctx, ##__VA_ARGS__)
+#else
+#define HSAKMT_CALL(func, ctx, ...) func(__VA_ARGS__)
+#endif
+
 void WaitUntilInput();
 HSAKMT_STATUS fscanf_dec(const char *file, uint32_t *num);
 uint64_t RoundToPowerOf2(uint64_t val);

--- a/projects/rocr-runtime/libhsakmt/tests/kfdtest/src/KFDTestUtilQueue.cpp
+++ b/projects/rocr-runtime/libhsakmt/tests/kfdtest/src/KFDTestUtilQueue.cpp
@@ -147,7 +147,7 @@ void AsyncMPSQ::Destroy(void) {
         delete m_buf;
 
     if (m_event)
-        hsaKmtDestroyEvent(m_event);
+        HSAKMT_CALL(hsaKmtDestroyEvent, g_baseTest->m_hsakmt_current_ctx, m_event);
 }
 
 void AsyncMPSQ::AllocTimeStampBuf(int packetCount) {

--- a/projects/rocr-runtime/libhsakmt/tests/kfdtest/src/KFDTopologyTest.cpp
+++ b/projects/rocr-runtime/libhsakmt/tests/kfdtest/src/KFDTopologyTest.cpp
@@ -79,7 +79,7 @@ TEST_F(KFDTopologyTest , BasicTest) {
 TEST_F(KFDTopologyTest, GetNodePropertiesInvalidParams) {
     TEST_START(TESTPROFILE_RUNALL)
 
-    EXPECT_EQ(HSAKMT_STATUS_INVALID_PARAMETER, hsaKmtGetNodeProperties(0, NULL));
+    EXPECT_EQ(HSAKMT_STATUS_INVALID_PARAMETER, HSAKMT_CALL(hsaKmtGetNodeProperties, g_baseTest->m_hsakmt_current_ctx, 0, NULL));
 
     TEST_END
 }
@@ -90,7 +90,7 @@ TEST_F(KFDTopologyTest, GetNodePropertiesInvalidNodeNum) {
 
     HsaNodeProperties nodeProperties;
     memset(&nodeProperties, 0, sizeof(nodeProperties));
-    EXPECT_EQ(HSAKMT_STATUS_INVALID_NODE_UNIT, hsaKmtGetNodeProperties(m_SystemProperties.NumNodes, &nodeProperties));
+    EXPECT_EQ(HSAKMT_STATUS_INVALID_NODE_UNIT, HSAKMT_CALL(hsaKmtGetNodeProperties, g_baseTest->m_hsakmt_current_ctx, m_SystemProperties.NumNodes, &nodeProperties));
 
     TEST_END
 }
@@ -106,7 +106,7 @@ TEST_F(KFDTopologyTest, GetNodeMemoryProperties) {
 
         if (pNodeProperties != NULL) {
             HsaMemoryProperties *memoryProperties = new HsaMemoryProperties[pNodeProperties->NumMemoryBanks];
-            EXPECT_SUCCESS(hsaKmtGetNodeMemoryProperties(node, pNodeProperties->NumMemoryBanks, memoryProperties));
+            EXPECT_SUCCESS(HSAKMT_CALL(hsaKmtGetNodeMemoryProperties, g_baseTest->m_hsakmt_current_ctx, node, pNodeProperties->NumMemoryBanks, memoryProperties));
             delete [] memoryProperties;
         }
     }
@@ -131,7 +131,7 @@ TEST_F(KFDTopologyTest, GpuvmApertureValidate) {
                 return;
             }
             HsaMemoryProperties *memoryProperties =  new HsaMemoryProperties[pNodeProperties->NumMemoryBanks];
-            EXPECT_SUCCESS(hsaKmtGetNodeMemoryProperties(GpuNodes.at(i), pNodeProperties->NumMemoryBanks,
+            EXPECT_SUCCESS(HSAKMT_CALL(hsaKmtGetNodeMemoryProperties, g_baseTest->m_hsakmt_current_ctx, GpuNodes.at(i), pNodeProperties->NumMemoryBanks,
                                                          memoryProperties));
             bool GpuVMHeapFound = false;
             for (unsigned int bank = 0 ; bank  < pNodeProperties->NumMemoryBanks ; bank++) {
@@ -159,7 +159,8 @@ TEST_F(KFDTopologyTest, GetNodeCacheProperties) {
         pNodeProperties = m_NodeInfo.GetNodeProperties(node);
         if (pNodeProperties != NULL) {
             HsaCacheProperties *cacheProperties = new HsaCacheProperties[pNodeProperties->NumCaches];
-            EXPECT_SUCCESS(hsaKmtGetNodeCacheProperties(node, pNodeProperties->CComputeIdLo,
+            EXPECT_SUCCESS(HSAKMT_CALL(hsaKmtGetNodeCacheProperties, g_baseTest->m_hsakmt_current_ctx,
+                           node, pNodeProperties->CComputeIdLo,
                            pNodeProperties->NumCaches, cacheProperties));
             if (pNodeProperties->NumCPUCores > 0) {  // this is a CPU node
                 LOG() << "CPU Node " << std::dec << node << ": " << pNodeProperties->NumCaches << " caches"
@@ -227,7 +228,8 @@ TEST_F(KFDTopologyTest, GetNodeIoLinkProperties) {
 
         if (pNodeProperties != NULL) {
             HsaIoLinkProperties  *IolinkProperties =  new HsaIoLinkProperties[pNodeProperties->NumIOLinks];
-            EXPECT_SUCCESS(hsaKmtGetNodeIoLinkProperties(node, pNodeProperties->NumIOLinks, IolinkProperties));
+            EXPECT_SUCCESS(HSAKMT_CALL(hsaKmtGetNodeIoLinkProperties, g_baseTest->m_hsakmt_current_ctx,
+                           node, pNodeProperties->NumIOLinks, IolinkProperties));
             if (pNodeProperties->NumIOLinks == 0) {
                 // No io_links. Just print the node
                 LOG() << "[" << node << "]" << std::endl;

--- a/projects/rocr-runtime/libhsakmt/tests/kfdtest/src/PM4Queue.cpp
+++ b/projects/rocr-runtime/libhsakmt/tests/kfdtest/src/PM4Queue.cpp
@@ -78,7 +78,7 @@ void PM4Queue::Wait4PacketConsumption(HsaEvent *event, unsigned int timeOut) {
                     event->EventId,
                     true));
 
-        EXPECT_SUCCESS(hsaKmtWaitOnEvent(event, timeOut));
+        EXPECT_SUCCESS(HSAKMT_CALL(hsaKmtWaitOnEvent, m_KFDContext, event, timeOut));
     } else {
         BaseQueue::Wait4PacketConsumption(NULL, timeOut);
     }

--- a/projects/rocr-runtime/libhsakmt/tests/kfdtest/src/RDMATest.cpp
+++ b/projects/rocr-runtime/libhsakmt/tests/kfdtest/src/RDMATest.cpp
@@ -61,12 +61,8 @@ TEST_F(RDMATest, GPUDirect) {
     HsaMemoryBuffer srcSysBuffer(BufferSize, defaultGPUNode, false);
     HsaMemoryBuffer srcLocalBuffer(BufferSize, defaultGPUNode, false, true);
 
-    ASSERT_SUCCESS(hsaKmtMapMemoryToGPU(srcSysBuffer.As<void*>(),
-                                        srcSysBuffer.Size(),
-                                        &AlternateVAGPU));
-    ASSERT_SUCCESS(hsaKmtMapMemoryToGPU(srcLocalBuffer.As<void*>(),
-                                        srcLocalBuffer.Size(),
-                                        &AlternateVAGPU));
+    ASSERT_SUCCESS(HSAKMT_CALL(hsaKmtMapMemoryToGPU, g_baseTest->m_hsakmt_current_ctx, srcSysBuffer.As<void*>(), srcSysBuffer.Size(), &AlternateVAGPU));
+    ASSERT_SUCCESS(HSAKMT_CALL(hsaKmtMapMemoryToGPU, g_baseTest->m_hsakmt_current_ctx, srcLocalBuffer.As<void*>(), srcLocalBuffer.Size(), &AlternateVAGPU));
 
     /* Fill up srcSysBuffer */
     srcSysBuffer.Fill(0xfe);
@@ -138,16 +134,14 @@ TEST_F(RDMATest, ContiguousVRAMAllocation) {
 
     memFlags.ui32.NonPaged = 1;
     memFlags.ui32.Contiguous = 1;
-    ret = hsaKmtAllocMemory(defaultGPUNode, BufferSize, memFlags, &LocalBuffer);
+    ret = HSAKMT_CALL(hsaKmtAllocMemory, g_baseTest->m_hsakmt_current_ctx, defaultGPUNode, BufferSize, memFlags, &LocalBuffer);
     if (ret == HSAKMT_STATUS_NOT_SUPPORTED) {
         LOG() << "KFD does not support contiguous memory, skipping the test" << std::endl;
         return;
     }
 
-    ASSERT_SUCCESS(hsaKmtMapMemoryToGPU(srcSysBuffer.As<void*>(),
-                                        srcSysBuffer.Size(),
-                                        &AlternateVAGPU));
-    ASSERT_SUCCESS(hsaKmtMapMemoryToGPU(LocalBuffer, BufferSize, &AlternateVAGPU));
+    ASSERT_SUCCESS(HSAKMT_CALL(hsaKmtMapMemoryToGPU, g_baseTest->m_hsakmt_current_ctx, srcSysBuffer.As<void*>(), srcSysBuffer.Size(), &AlternateVAGPU));
+    ASSERT_SUCCESS(HSAKMT_CALL(hsaKmtMapMemoryToGPU, g_baseTest->m_hsakmt_current_ctx, LocalBuffer, BufferSize, &AlternateVAGPU));
 
     /* Fill up srcSysBuffer */
     srcSysBuffer.Fill(0xfe);
@@ -200,9 +194,9 @@ TEST_F(RDMATest, ContiguousVRAMAllocation) {
     Rdma.Close();
 
 exit:
-    EXPECT_SUCCESS(hsaKmtUnmapMemoryToGPU(srcSysBuffer.As<void*>()));
-    EXPECT_SUCCESS(hsaKmtUnmapMemoryToGPU(LocalBuffer));
-    EXPECT_SUCCESS(hsaKmtFreeMemory(LocalBuffer, BufferSize));
+    EXPECT_SUCCESS(HSAKMT_CALL(hsaKmtUnmapMemoryToGPU, g_baseTest->m_hsakmt_current_ctx, srcSysBuffer.As<void*>()));
+    EXPECT_SUCCESS(HSAKMT_CALL(hsaKmtUnmapMemoryToGPU, g_baseTest->m_hsakmt_current_ctx, LocalBuffer));
+    EXPECT_SUCCESS(HSAKMT_CALL(hsaKmtFreeMemory, g_baseTest->m_hsakmt_current_ctx, LocalBuffer, BufferSize));
 
     TEST_END
 }

--- a/projects/rocr-runtime/libhsakmt/tests/kfdtest/src/SDMAQueue.cpp
+++ b/projects/rocr-runtime/libhsakmt/tests/kfdtest/src/SDMAQueue.cpp
@@ -86,7 +86,7 @@ void SDMAQueue::Wait4PacketConsumption(HsaEvent *event, unsigned int timeOut) {
 
         PlaceAndSubmitPacket(SDMATrapPacket(event->EventId));
 
-        EXPECT_SUCCESS(hsaKmtWaitOnEvent(event, timeOut));
+        EXPECT_SUCCESS(HSAKMT_CALL(hsaKmtWaitOnEvent, m_KFDContext, event, timeOut));
     } else {
         BaseQueue::Wait4PacketConsumption(NULL, timeOut);
     }


### PR DESCRIPTION
## Summary

This PR adds kfdtest test framework support for the secondary KFD context feature introduced in [#1705](https://github.com/ROCm/rocm-systems/pull/1705). It enables the existing kfdtest suite to validate both the original `hsaKmt*` APIs and the new context-aware `hsaKmt*Ctx` APIs, including the secondary context path, through a unified macro-based dispatch mechanism.
 - The functionality of the secondary context requires synchronous support from the [AMD KFD driver](https://lore.kernel.org/amd-gfx/20251106060739.2281-1-lingshan.zhu@amd.com/) in the Linux kernel. It has already been merged into the upstream linux - 7.0.

## Motivation
PR [#1705](https://github.com/ROCm/rocm-systems/pull/1705) introduced secondary KFD context creation support (`hsaKmtOpenSecondaryKFDCtx` / `hsaKmtCloseSecondaryKFDCtx`) in libhsakmt, enabling true multi-context operation within a single process. However, the kfdtest test suite was not updated to exercise these new context-aware interfaces.

This PR bridges that gap by:
1. Building the test infrastructure to create and manage primary/secondary KFD contexts in kfdtest.
2. Refactoring all `hsaKmt*` API calls in kfdtest to use a unified `HSAKMT_CALL` macro, ensuring consistent coverage for both original and context-based APIs.

## Technical Details

### Commit 1: `libhsakmt: Add multi-context test framework support in kfdtest`

Introduces the foundational test framework for multi-context testing:

- **CMakeLists.txt**: Add `HSAKMT_CTX` and `HSAKMT_SECONDARY_CTX` compile definitions to control which API version is tested.
- **KFDTestUtil.hpp**: Define the `HSAKMT_CALL` macro:
  ```cpp
  #ifdef HSAKMT_CTX
  #define HSAKMT_CALL(func, ctx, ...) func##Ctx(ctx, ##__VA_ARGS__)
  #else
  #define HSAKMT_CALL(func, ctx, ...) func(__VA_ARGS__)
  #endif
  ```
  When `HSAKMT_CTX` is defined, `HSAKMT_CALL(hsaKmtAllocMemory, ctx, ...)` expands to `hsaKmtAllocMemoryCtx(ctx, ...)`; otherwise it expands to `hsaKmtAllocMemory(...)`. This allows a single codebase to test both API variants.
- **KFDBaseComponentTest.hpp/cpp**: Add `HsaKFDContext*` member variables (`m_hsakmt_primary_ctx`, `m_hsakmt_secondary_ctx`, `m_hsakmt_current_ctx`). Modify `SetUp()` and `TearDown()` to handle context lifecycle:
  - Default (no macros): Original `hsaKmtOpenKFD()` / `hsaKmtCloseKFD()` path
  - `HSAKMT_CTX`: Primary context via `hsaKmtOpenKFDCtx()` / `hsaKmtCloseKFDCtx()`
  - `HSAKMT_CTX` + `HSAKMT_SECONDARY_CTX`: Additionally opens secondary context via `hsaKmtOpenSecondaryKFDCtx()` and sets it as the current context for testing

### Commit 2: `libhsakmt: Refactor kfdtest: unify hsaKmt* API calls using HSAKMT_CALL macro`

Systematically wraps all `hsaKmt*` interface calls across the entire kfdtest suite with the `HSAKMT_CALL` macro:

| Component | Files Modified |
|-----------|---------------|
| **Queue Infrastructure** | `BaseQueue.cpp/hpp`, `PM4Queue.cpp`, `SDMAQueue.cpp` |
| **Dispatch** | `Dispatch.cpp` |
| **Test Base** | `KFDBaseComponentTest.cpp/hpp` |
| **Test Utilities** | `KFDTestUtil.cpp/hpp`, `KFDTestUtilQueue.cpp` |
| **Test Suites** | `KFDEventTest`, `KFDEvictTest`, `KFDExceptionTest`, `KFDGWSTest`, `KFDGraphicsInterop`, `KFDIPCTest`, `KFDLocalMemoryTest`, `KFDMemoryTest`, `KFDNegativeTest`, `KFDPMTest`, `KFDPerformanceTest`, `KFDQMTest`, `KFDRASTest`, `KFDSVMEvictTest`, `KFDSVMRangeTest`, `KFDTopologyTest`, `RDMATest` |

Key changes beyond the macro wrapping:
- `BaseQueue` now stores a `HsaKFDContext*` (`m_KFDContext`) to track which context created the queue, ensuring queue operations use the correct context.
- `g_baseTest` assignment is moved earlier in `SetUp()` so that `HSAKMT_CALL` is usable during initialization by other components (e.g., `HsaMemoryBuffer` constructors).
### Build Configuration Matrix

| Macro Configuration | API Tested | Context Type |
|---------------------|-----------|--------------|
| Neither defined | Original `hsaKmt*()` | N/A (legacy) |
| `HSAKMT_CTX=1` | Context-aware `hsaKmt*Ctx()` | Primary |
| `HSAKMT_CTX=1` + `HSAKMT_SECONDARY_CTX=1` | Context-aware `hsaKmt*Ctx()` | Secondary |

## JIRA ID

## Test Plan
kfdtest

## Test Result

kfdtest suite passes under all three build configurations:
- ✅ Original API (no macros)
- ✅ Context-aware API with primary context (`HSAKMT_CTX=1`)
- ✅ Context-aware API with secondary context (`HSAKMT_CTX=1`, `HSAKMT_SECONDARY_CTX=1`)
