### PR TITLE
Add DEBUG_CLR_DISABLE_IMAGE and fix image support logic

### DIFF
--- a/projects/clr/rocclr/device/rocm/rocdevice.cpp
+++ b/projects/clr/rocclr/device/rocm/rocdevice.cpp
@@ -1616,7 +1616,8 @@ bool Device::populateOCLDeviceConstants() {
       : 0;
   std::string imageSupport;
   if (amd::device::getValueFromIsaMeta(isaName, "ImageSupport", imageSupport)) {
-    info_.imageSupport_ = atoi(imageSupport.c_str());
+    info_.imageSupport_ = 
+        (ROC_DISABLE_IMAGE_SUPPORT || !image_is_supported) ? 0 : std::atoi(imageSupport.c_str());
     ClPrint(amd::LOG_INFO, amd::LOG_INIT, "imageSupport=%u", info_.imageSupport_);
   } else {
     LogInfo("Can not get image support info from ISA meta");

--- a/projects/clr/rocclr/device/rocm/rocdevice.cpp
+++ b/projects/clr/rocclr/device/rocm/rocdevice.cpp
@@ -1616,8 +1616,8 @@ bool Device::populateOCLDeviceConstants() {
       : 0;
   std::string imageSupport;
   if (amd::device::getValueFromIsaMeta(isaName, "ImageSupport", imageSupport)) {
-    info_.imageSupport_ = 
-        (ROC_DISABLE_IMAGE_SUPPORT || !image_is_supported) ? 0 : std::atoi(imageSupport.c_str());
+    info_.imageSupport_ =
+        (DEBUG_CLR_DISABLE_IMAGE || !image_is_supported) ? 0 : std::atoi(imageSupport.c_str());
     ClPrint(amd::LOG_INFO, amd::LOG_INIT, "imageSupport=%u", info_.imageSupport_);
   } else {
     LogInfo("Can not get image support info from ISA meta");

--- a/projects/clr/rocclr/utils/flags.hpp
+++ b/projects/clr/rocclr/utils/flags.hpp
@@ -265,7 +265,9 @@ release(uint, HIP_SKIP_ABORT_ON_GPU_ERROR, true,                              \
 release(bool, HIP_FORCE_SPIRV_CODEOBJECT, false,                              \
         "Force use of SPIRV instead of device specific code object.")         \
 release(uint, DEBUG_CLR_BATCH_CPU_SYNC_SIZE, 8,                               \
-        "Forces the minimum batch size for CPU sync")  // clang-format on
+        "Forces the minimum batch size for CPU sync")                         \
+release(bool, ROC_DISABLE_IMAGE_SUPPORT, false,                               \
+        "1 = Disable Image support for ROC path")  // clang-format on
 
 namespace amd {
 

--- a/projects/clr/rocclr/utils/flags.hpp
+++ b/projects/clr/rocclr/utils/flags.hpp
@@ -266,7 +266,7 @@ release(bool, HIP_FORCE_SPIRV_CODEOBJECT, false,                              \
         "Force use of SPIRV instead of device specific code object.")         \
 release(uint, DEBUG_CLR_BATCH_CPU_SYNC_SIZE, 8,                               \
         "Forces the minimum batch size for CPU sync")                         \
-release(bool, ROC_DISABLE_IMAGE_SUPPORT, false,                               \
+release(bool, DEBUG_CLR_DISABLE_IMAGE, false,                               \
         "1 = Disable Image support for ROC path")  // clang-format on
 
 namespace amd {


### PR DESCRIPTION
## Motivation
Add a new flag DEBUG_CLR_DISABLE_IMAGE to disable 
fix image support logic
<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details
DEBUG_CLR_DISABLE_IMAGE is used to disable image support for ROC path, with default value false
Fix an issue that disabled image support can be re-enabled when ISA reports image support
<!-- Explain the changes along with any relevant GitHub links. -->

## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan
Image support can be disabled as expected
<!-- Explain any relevant testing done to verify this PR. -->

## Test Result
Image support can be disabled as expected
<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
