### PR TITLE
[rocprofiler-sdk] PCS exec mask skid

### DIFF
--- a/projects/rocprofiler-sdk/tests/bin/pc-sampling/exec-mask-manipulation/CMakeLists.txt
+++ b/projects/rocprofiler-sdk/tests/bin/pc-sampling/exec-mask-manipulation/CMakeLists.txt
@@ -35,7 +35,11 @@ set(CMAKE_HIP_STANDARD_REQUIRED ON)
 set_source_files_properties(exec_mask_manipulation.cpp PROPERTIES LANGUAGE HIP)
 add_executable(exec-mask-manipulation)
 target_sources(exec-mask-manipulation PRIVATE exec_mask_manipulation.cpp)
-# debug symbols required for PC sampling decoding validation
+# The test uses inline assembly with scalar instructions (s_mov_b32). In debug builds (no
+# optimization), the compiler may classify operands used in s_mov_b32 instructions as
+# vector rather than scalar, causing assembly errors. -O2 ensures the compiler correctly
+# resolves these operands as scalar registers. Debug symbols (-g) are still required for
+# PC sampling decoding validation.
 target_compile_options(exec-mask-manipulation PRIVATE -O2 -W -Wall -Wextra -Wpedantic
                                                       -Wshadow -Werror -g)
 

--- a/projects/rocprofiler-sdk/tests/bin/pc-sampling/exec-mask-manipulation/CMakeLists.txt
+++ b/projects/rocprofiler-sdk/tests/bin/pc-sampling/exec-mask-manipulation/CMakeLists.txt
@@ -36,7 +36,7 @@ set_source_files_properties(exec_mask_manipulation.cpp PROPERTIES LANGUAGE HIP)
 add_executable(exec-mask-manipulation)
 target_sources(exec-mask-manipulation PRIVATE exec_mask_manipulation.cpp)
 # debug symbols required for PC sampling decoding validation
-target_compile_options(exec-mask-manipulation PRIVATE -W -Wall -Wextra -Wpedantic
+target_compile_options(exec-mask-manipulation PRIVATE -O2 -W -Wall -Wextra -Wpedantic
                                                       -Wshadow -Werror -g)
 
 find_package(Threads REQUIRED)

--- a/projects/rocprofiler-sdk/tests/bin/pc-sampling/exec-mask-manipulation/exec_mask_manipulation.cpp
+++ b/projects/rocprofiler-sdk/tests/bin/pc-sampling/exec-mask-manipulation/exec_mask_manipulation.cpp
@@ -28,6 +28,14 @@ THE SOFTWARE.
 #define ITER_NUM   16 * 1024
 #define BLOCK_SIZE 1024
 
+// In some cases, there might be a skid between exec-mask and the PC.
+// Thus we inject some nops around branches in our testing kernels.
+#define EXEC_MASK_SKID                                                                             \
+    asm volatile("s_nop 1\n");                                                                     \
+    asm volatile("s_nop 1\n");                                                                     \
+    asm volatile("s_nop 1\n");                                                                     \
+    asm volatile("s_nop 1\n");
+
 #define HIP_API_CALL(CALL)                                                                         \
     {                                                                                              \
         hipError_t error_ = (CALL);                                                                \
@@ -60,6 +68,7 @@ kernel1(const int c, const int iter_num)
 #pragma nounroll
     for(int i = 0; i < iter_num; i++)
     {
+        EXEC_MASK_SKID;
         asm volatile("v_mov_b32 %0 %1\n" : "=v"(a) : "s"(c));
         asm volatile("v_mov_b32 %0 %1\n" : "=v"(a) : "s"(c));
         asm volatile("v_mov_b32 %0 %1\n" : "=v"(a) : "s"(c));
@@ -160,6 +169,7 @@ kernel1(const int c, const int iter_num)
         asm volatile("v_mov_b32 %0 %1\n" : "=v"(a) : "s"(c));
         asm volatile("v_mov_b32 %0 %1\n" : "=v"(a) : "s"(c));
         asm volatile("v_mov_b32 %0 %1\n" : "=v"(a) : "s"(c));
+        EXEC_MASK_SKID;
     }
 }
 
@@ -170,6 +180,7 @@ kernel2(const int c, const int iter_num)
 #pragma nounroll
     for(int i = 0; i < iter_num; i++)
     {
+        EXEC_MASK_SKID;
         asm volatile("s_mov_b32 %0 %1\n" : "=s"(a) : "s"(c));
         asm volatile("s_mov_b32 %0 %1\n" : "=s"(a) : "s"(c));
         asm volatile("s_mov_b32 %0 %1\n" : "=s"(a) : "s"(c));
@@ -270,6 +281,7 @@ kernel2(const int c, const int iter_num)
         asm volatile("s_mov_b32 %0 %1\n" : "=s"(a) : "s"(c));
         asm volatile("s_mov_b32 %0 %1\n" : "=s"(a) : "s"(c));
         asm volatile("s_mov_b32 %0 %1\n" : "=s"(a) : "s"(c));
+        EXEC_MASK_SKID;
     }
 }
 
@@ -285,6 +297,7 @@ kernel3(const float c, const int iter_num)
     {
         if(tid_even == 0)
         {
+            EXEC_MASK_SKID;
             asm volatile("v_rcp_f64 %0, %0\n" : "+v"(a), "=s"(i) : "s"(c));
             asm volatile("v_rcp_f64 %0, %0\n" : "+v"(a), "=s"(i) : "s"(c));
             asm volatile("v_rcp_f64 %0, %0\n" : "+v"(a), "=s"(i) : "s"(c));
@@ -385,9 +398,11 @@ kernel3(const float c, const int iter_num)
             asm volatile("v_rcp_f64 %0, %0\n" : "+v"(a), "=s"(i) : "s"(c));
             asm volatile("v_rcp_f64 %0, %0\n" : "+v"(a), "=s"(i) : "s"(c));
             asm volatile("v_rcp_f64 %0, %0\n" : "+v"(a), "=s"(i) : "s"(c));
+            EXEC_MASK_SKID;
         }
         else
         {
+            EXEC_MASK_SKID;
             asm volatile("v_rcp_f32 %0, %0\n" : "+v"(d), "=s"(e) : "s"(c));
             asm volatile("v_rcp_f32 %0, %0\n" : "+v"(d), "=s"(e) : "s"(c));
             asm volatile("v_rcp_f32 %0, %0\n" : "+v"(d), "=s"(e) : "s"(c));
@@ -488,6 +503,7 @@ kernel3(const float c, const int iter_num)
             asm volatile("v_rcp_f32 %0, %0\n" : "+v"(d), "=s"(e) : "s"(c));
             asm volatile("v_rcp_f32 %0, %0\n" : "+v"(d), "=s"(e) : "s"(c));
             asm volatile("v_rcp_f32 %0, %0\n" : "+v"(d), "=s"(e) : "s"(c));
+            EXEC_MASK_SKID;
         }
     }
 }

--- a/projects/rocprofiler-sdk/tests/pytest-packages/pc_sampling/exec_mask_manipulation/csv.py
+++ b/projects/rocprofiler-sdk/tests/pytest-packages/pc_sampling/exec_mask_manipulation/csv.py
@@ -27,22 +27,6 @@ import numpy as np
 import pandas as pd
 
 
-def stochastic_assert(df, df_condition_selection, max_failing_samples=30):
-    # TODO: When asserting certain conditions related to exec_masks for all samples,
-    # we observe some failures.
-    # This usually happens because some small number of samples (e.g., 1-30 out of 100k)
-    # do not satisfy the condition. This is either a regression in the ROCr 2nd level trap
-    # handler (as sometimes execution mask or correlation ID mismatches), or
-    # just stochastic nature of the sampling (meaning our checks are too strict).
-    # To relax checks, we introduce an assertion that will allow some small number
-    # of samples to disobey the condition.
-    # This is a temporary solution until we find the root cause of the issue.
-
-    # extract the failing samples
-    failing_samples = df[~df_condition_selection]
-    assert len(failing_samples) <= max_failing_samples, "Too many failing samples"
-
-
 # Keep this in case we decide to revert workgroup_id information
 def validate_workgoup_id_x_y_z(df, max_x, max_y, max_z):
     assert (df["Workgroup_Size_X"].astype(int) >= 0).all()
@@ -78,9 +62,9 @@ def validate_instruction_decoding(
     assert not df_inst.empty
     # assert the exec mask if requested
     if exec_mask_uint64 is not None:
-        stochastic_assert(
-            df_inst, df_inst["Exec_Mask"].astype(np.uint64) == exec_mask_uint64
-        )
+        assert (
+            df_inst["Exec_Mask"].astype(np.uint64) == exec_mask_uint64
+        ).all(), "Exec_Mask mismatch: not all samples have the expected exec mask value"
 
     # assert whether the samples source code lines belongs to the provided range
     if source_code_lines_range is not None:
@@ -141,7 +125,9 @@ def validate_exec_mask_based_on_correlation_id(df):
     df["active_SIMD_threads"] = df["Exec_Mask"].apply(
         lambda exec_mask: bin(exec_mask).count("1")
     )
-    stochastic_assert(df, df["active_SIMD_threads"] == df["Correlation_Id"])
+    assert (
+        df["active_SIMD_threads"] == df["Correlation_Id"]
+    ).all(), "Active SIMD thread count does not match Correlation_Id for all samples"
 
     # TODO: Comment out the following code if it causes spurious fails.
     # The more conservative constraint based on the experience follows.
@@ -158,9 +144,9 @@ def validate_exec_mask_based_on_correlation_id(df):
     )
 
     # TODO: exec should be in hex and that will ease the comparison
-    stochastic_assert(
-        df, df["Exec_Mask"].astype(np.uint64) == df["Exec_Mask2"].astype(np.uint64)
-    )
+    assert (
+        df["Exec_Mask"].astype(np.uint64) == df["Exec_Mask2"].astype(np.uint64)
+    ).all(), "Exec_Mask does not match expected mask derived from Correlation_Id for all samples"
 
 
 def exec_mask_manipulation_validate_csv(df, all_sampled=False):
@@ -215,7 +201,7 @@ def exec_mask_manipulation_validate_csv(df, all_sampled=False):
         last_kernel,
         "v_rcp_f64",
         exec_mask_uint64=np.uint64(even_simd_threads_active_exec_mask),
-        source_code_lines_range=(288, 387),
+        source_code_lines_range=(301, 400),
         all_source_lines_samples=all_sampled,
     )
 
@@ -225,6 +211,6 @@ def exec_mask_manipulation_validate_csv(df, all_sampled=False):
         last_kernel,
         "v_rcp_f32",
         exec_mask_uint64=np.uint64(odd_simd_threads_active_exec_mask),
-        source_code_lines_range=(391, 490),
+        source_code_lines_range=(406, 505),
         all_source_lines_samples=all_sampled,
     )

--- a/projects/rocprofiler-sdk/tests/pytest-packages/pc_sampling/exec_mask_manipulation/json.py
+++ b/projects/rocprofiler-sdk/tests/pytest-packages/pc_sampling/exec_mask_manipulation/json.py
@@ -80,12 +80,12 @@ def validate_json_exec_mask_manipulation(
     # correspond to the v_rcp_f64 instructions of the last kernel
     even_simds_active_exec_mask = np.uint64(int("5" * exec_mask_hex_digit_width, 16))
     # start and end source code lines of the v_rcp_f64 instructions of the last kernel
-    v_rcp_f64_start_line_num, v_rcp_f64_end_line_num = 288, 387
+    v_rcp_f64_start_line_num, v_rcp_f64_end_line_num = 301, 400
     # execution mask where even SIMD lanes are active
     # correspond to the v_rcp_f64 instructions of the last kernel
     odd_simds_active_exec_mask = np.uint64(int("A" * exec_mask_hex_digit_width, 16))
     # start and end source code lines of the v_rcp_f32 0 instructions of the last kernel
-    v_rcp_f32_start_line_num, v_rcp_f32_end_line_num = 391, 490
+    v_rcp_f32_start_line_num, v_rcp_f32_end_line_num = 406, 505
 
     # sampled wave_ids of the last kernel
     last_kernel_sampled_wave_in_grp = set()
@@ -101,24 +101,6 @@ def validate_json_exec_mask_manipulation(
     sampled_chiplets = set()
     # sample VMIDs
     sampled_vmids = set()
-    # TODO: Similar reason for introducing stochastic_assert inside the csv.py.
-    # When asserting certain conditions related to exec_masks for all samples,
-    # we observe some failures.
-    # This usually happens because some small number of samples (e.g., 1-10 out of 100k)
-    # do not satisfy the condition. This is either a regression in the ROCr 2nd level trap
-    # handler (as sometimes execution mask or correlation ID mismatches), or
-    # just stochastic nature of the sampling (meaning our checks are too strict).
-    # To relax checks, we introduce an assertion that will allow some small number
-    # of samples to disobey the condition.
-    # This is a temporary solution until we find the root cause of the issue.
-
-    failing_exec_mask_checks_samples_num = 0
-    # We noticed failing samples in:
-    # 1. kernels 1-64
-    # 2. kernel 65 even SIMD lanes
-    # 3. kernel 64 odd SIMD lanes
-    # The number of failing samples is less than 10 per category.
-    max_number_of_failing_records = 60
 
     for sample in data_json["buffer_records"][f"pc_sample_{pc_sampling_method}"]:
         record = sample["record"]
@@ -175,9 +157,9 @@ def validate_json_exec_mask_manipulation(
                 # Each block contains number of threads that matches correlation ID of the kernel.
                 # The exec mask of a sample should contain number of ones equal to
                 # the correlation ID of the kernel during which execution the sample was generated.
-                # assert bin(exec_mask).count("1") == cid
-                if bin(exec_mask).count("1") != cid:
-                    failing_exec_mask_checks_samples_num += 1
+                assert (
+                    bin(exec_mask).count("1") == cid
+                ), "Active SIMD thread count does not match Correlation_Id"
 
                 # TODO: Comment out the following code if it causes spurious fails.
                 # The more conservative constraint based on the experience follows.
@@ -189,9 +171,9 @@ def validate_json_exec_mask_manipulation(
                 # ...
                 # 64 -> 0xffffffffffffffff
                 exec_mask_str = "0b" + "1" * cid
-                # assert np.uint64(exec_mask) == np.uint64(int(exec_mask_str, 2))
-                if np.uint64(exec_mask) != np.uint64(int(exec_mask_str, 2)):
-                    failing_exec_mask_checks_samples_num += 1
+                assert np.uint64(exec_mask) == np.uint64(
+                    int(exec_mask_str, 2)
+                ), "Exec_Mask does not match expected mask derived from Correlation_Id"
             else:
                 # No more than `unique_kernels_num`` cids
                 assert cid == unique_kernels_num
@@ -208,9 +190,9 @@ def validate_json_exec_mask_manipulation(
                 line_num = int(comm.split(":")[-1])
                 if inst.startswith("v_rcp_f64"):
                     # even SIMD lanes active
-                    # assert np.uint64(exec_mask) == even_simds_active_exec_mask
-                    if np.uint64(exec_mask) != even_simds_active_exec_mask:
-                        failing_exec_mask_checks_samples_num += 1
+                    assert (
+                        np.uint64(exec_mask) == even_simds_active_exec_mask
+                    ), "Exec_Mask mismatch for v_rcp_f64: expected even SIMD lanes active"
 
                     assert (
                         line_num >= v_rcp_f64_start_line_num
@@ -219,9 +201,9 @@ def validate_json_exec_mask_manipulation(
                     last_kernel_v_rcp_64_sampled_source_line_set.add(line_num)
                 elif inst.startswith("v_rcp_f32"):
                     # odd SIMD lanes active
-                    # assert np.uint64(exec_mask) == odd_simds_active_exec_mask
-                    if np.uint64(exec_mask) != odd_simds_active_exec_mask:
-                        failing_exec_mask_checks_samples_num += 1
+                    assert (
+                        np.uint64(exec_mask) == odd_simds_active_exec_mask
+                    ), "Exec_Mask mismatch for v_rcp_f32: expected odd SIMD lanes active"
 
                     assert (
                         line_num >= v_rcp_f32_start_line_num
@@ -265,8 +247,3 @@ def validate_json_exec_mask_manipulation(
     # so I'm temporarily disabling the following check.
     # # all samples should belong to the same VMID
     # assert len(sampled_vmids) == 1
-
-    # assert that the number of failing samples is acceptable
-    assert (
-        failing_exec_mask_checks_samples_num <= max_number_of_failing_records
-    ), "Number of failing samples failing exec_mask check is too high"


### PR DESCRIPTION
1. Cover exec mask skid that might happen when using stochastic PC sampling
2. Always compile the example with -02 to surpress compilation issues on s_mov instructions that always use scalar registers

## Motivation

Instead of randomly relaxing checks in our tests, we introduce a few s_nops arounds the instructions for which we check exec-mask. This way, asserted instructions should have correct exec-masks.

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
