### PR TITLE
[clr] release queue after the marker has been enqueued

### DIFF
--- a/projects/clr/hipamd/src/hip_device.cpp
+++ b/projects/clr/hipamd/src/hip_device.cpp
@@ -157,6 +157,7 @@ void Device::Reset() {
 void Device::WaitActiveStreams(hip::Stream* blocking_stream, bool wait_null_stream) {
   amd::Command::EventWaitList eventWaitList(0);
   bool submitMarker = false;
+  std::vector<amd::CommandQueue*> activeQueues;
 
   auto waitForStream = [&submitMarker, &eventWaitList](hip::Stream* stream) {
     if (amd::Command* command = stream->getLastQueuedCommand(true)) {
@@ -183,7 +184,7 @@ void Device::WaitActiveStreams(hip::Stream* blocking_stream, bool wait_null_stre
       waitForStream(null_stream_);
     }
   } else {
-    const auto activeQueues = blocking_stream->device().getActiveQueues();
+    activeQueues = blocking_stream->device().getActiveQueues();
     for (const auto& queue : activeQueues) {
       auto* active_stream = static_cast<hip::Stream*>(queue);
       // Only wait on blocking (non-nonblocking) streams other than the current one
@@ -192,7 +193,6 @@ void Device::WaitActiveStreams(hip::Stream* blocking_stream, bool wait_null_stre
         ClPrint(amd::LOG_DETAIL_DEBUG, amd::LOG_WAIT, "Waiting on active stream %p", active_stream);
         waitForStream(active_stream);
       }
-      queue->release();
     }
   }
 
@@ -205,6 +205,12 @@ void Device::WaitActiveStreams(hip::Stream* blocking_stream, bool wait_null_stre
   // Release all active commands; safe after the marker was enqueued
   for (const auto& cmd : eventWaitList) {
     cmd->release();
+  }
+
+  // Release active queue references now that the marker has been fully enqueued
+  // and no longer needs to access the queues via eventWaitList commands
+  for (const auto& q : activeQueues) {
+    q->release();
   }
 }
 
@@ -801,8 +807,8 @@ hipError_t hipGetProcAddress_common(const char* symbol, void** pfn, int hipVersi
   }
   std::string symbolString = symbol;
 
-  if (flags != HIP_GET_PROC_ADDRESS_DEFAULT && flags != HIP_GET_PROC_ADDRESS_LEGACY_STREAM
-      && flags != HIP_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM) {
+  if (flags != HIP_GET_PROC_ADDRESS_DEFAULT && flags != HIP_GET_PROC_ADDRESS_LEGACY_STREAM &&
+      flags != HIP_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM) {
     return hipErrorInvalidValue;
   }
 
@@ -869,9 +875,10 @@ hipError_t hipGetProcAddress(const char* symbol, void** pfn, int hipVersion, uin
 
 // ================================================================================================
 hipError_t hipGetProcAddress_spt(const char* symbol, void** pfn, int hipVersion, uint64_t flags,
-                             hipDriverProcAddressQueryResult* symbolStatus) {
+                                 hipDriverProcAddressQueryResult* symbolStatus) {
   HIP_INIT_API(hipGetProcAddress, symbol, pfn, hipVersion, flags, symbolStatus);
-  flags = (flags == HIP_GET_PROC_ADDRESS_DEFAULT) ? HIP_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM : flags;
+  flags = (flags == HIP_GET_PROC_ADDRESS_DEFAULT) ? HIP_GET_PROC_ADDRESS_PER_THREAD_DEFAULT_STREAM
+                                                  : flags;
   HIP_RETURN(hipGetProcAddress_common(symbol, pfn, hipVersion, flags, symbolStatus));
 }
 

--- a/projects/hip-tests/catch/config/configs/unit/deviceLib.yaml
+++ b/projects/hip-tests/catch/config/configs/unit/deviceLib.yaml
@@ -591,3 +591,6 @@ deviceLib:
   Unit_hipTestHalfConstexpr_DeviceConstexpr:
     <<: *level_2
     tags: [types]
+  Unit_MemcpyToSymbolInParallelWithStreamLaunch:
+    <<: *level_3
+    tags: [misc]

--- a/projects/hip-tests/catch/unit/deviceLib/hipTestDeviceSymbol.cc
+++ b/projects/hip-tests/catch/unit/deviceLib/hipTestDeviceSymbol.cc
@@ -201,3 +201,66 @@ HIP_TEST_CASE(Unit_hipGetSymbolSize_Negative) {
     HIP_CHECK_ERROR(hipGetSymbolSize(&size, nullptr), hipErrorInvalidSymbol);
   }
 }
+
+static __device__ int d_symbol{};
+static __global__ void simple_kernel(float* data, int n) {
+  int idx = blockIdx.x * blockDim.x + threadIdx.x;
+  if (idx < n) {
+    data[idx] += 1.0f;
+  }
+}
+
+HIP_TEST_CASE(Unit_MemcpyToSymbolInParallelWithStreamLaunch) {
+  std::atomic_bool thread_errored{false};
+  std::atomic<bool> g_running{true};
+
+  // Simple thread function where we run MemcpyToSymbol in parallel
+  // While we create stream, enqueue work and destroy it
+  // This pattern is seen in rocDecode, where we found this issue.
+  // Creating this test so that we do not break this again.
+  auto thread_func = [&](int thread_id) {
+    int val = thread_id;
+    // We run it until we notify it or the previous threads have errored
+    while (g_running.load(std::memory_order_relaxed) &&
+           !thread_errored.load(std::memory_order_relaxed)) {
+      hipError_t err =
+          hipMemcpyToSymbol(HIP_SYMBOL(d_symbol), &val, sizeof(int), 0, hipMemcpyHostToDevice);
+      if (err != hipSuccess) {
+        thread_errored = true;
+      }
+    }
+  };
+
+  constexpr int N = 256;
+  constexpr int kNumWorkers = 4;
+  constexpr int kIterations = 50000;
+
+  float* d_data{nullptr};
+  HIP_CHECK(hipMalloc(&d_data, N * sizeof(float)));
+
+  std::vector<std::thread> workers;
+  workers.reserve(kNumWorkers);
+  for (int i = 0; i < kNumWorkers; ++i) {
+    workers.emplace_back(thread_func, i);
+  }
+
+  // Main thread: rapid stream create -> kernel launch -> destroy cycle.
+  for (int i = 0; i < kIterations; ++i) {
+    hipStream_t stream;
+    HIP_CHECK(hipStreamCreateWithFlags(&stream, hipStreamDefault));
+    simple_kernel<<<1, N, 0, stream>>>(d_data, N);
+    // Intentionally skip hipStreamSynchronize
+    HIP_CHECK(hipStreamDestroy(stream));
+  }
+
+  g_running.store(false, std::memory_order_relaxed);
+
+  for (auto& w : workers) {
+    w.join();
+  }
+
+  HIP_CHECK(hipFree(d_data));
+
+  INFO("Checking if threads have errored.");
+  REQUIRE(!thread_errored);
+}


### PR DESCRIPTION
## Motivation

There are memory leaks when user has a MemcpytToSymbol going on parallel with a stream launch.

## Technical Details

```cpp
// This function runs on a thread
auto function_on_thread() {
  hipMemcpyToSymbol(...);
}

// While we do this
for(...) {
  hipStreamCreate(stream);
  kernel<<<1, 32>>>(...);
  hipStreamDestroy(stream);
}
```
The key changes:

1. Move `activeQueues` declaration from inside the else block to function scope (so it's accessible after the if/else).
2. Remove queue's `release()` from inside the for loop (its named command which is a bit confusing)
3. Add a new loop at the end that releases all retained queue references after the `Marker` has been enqueued and the `eventWaitList` commands have been released. The queues are now safe to release.

## JIRA ID

NA

## Test Plan

There should be no leaks after the fix.

## Test Result

No leaks shown

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.

-----------------------------------

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>