### PR TITLE
Fix occupancy calculation

### DIFF
--- a/projects/clr/hipamd/src/hip_platform.cpp
+++ b/projects/clr/hipamd/src/hip_platform.cpp
@@ -91,9 +91,9 @@ hipError_t ihipOccupancyMaxActiveBlocksPerMultiprocessor(
   const int alu_limited_threads = static_cast<int>(alu_occupancy * wavefrontSize);
 
   const size_t total_used_lds = wrkGrpInfo->usedLDSSize_ + dynamicSMemSize;
-  const int lds_occupancy_wgs = total_used_lds != 0
-      ? static_cast<int>(device.info().localMemSize_ / total_used_lds)
-      : INT_MAX;
+  const int lds_occupancy_wgs =
+      total_used_lds != 0 ? static_cast<int>(device.info().localMemSizePerCU_ / total_used_lds)
+                          : INT_MAX;
   // Calculate how many blocks of inputBlockSize we can fit per CU
   // Need to align with hardware wavefront size. If they want 65 threads, but
   // waves are 64, then we need 128 threads per block.


### PR DESCRIPTION
## Motivation

The LDS occupancy formula in ihipOccupancyMaxActiveBlocksPerMultiprocessor calculates how many workgroups can fit on a CU by dividing the total LDS budget by the LDS each workgroup consumes. The issue is that it uses localMemSize_ as the numerator, which is the max LDS a single workgroup can allocate, not the total physical LDS on the CU.

## Technical Details

Changed the formula to use localMemSizePerCU_ instead.

## JIRA ID

AIRUNTIME-262

## Test Plan

Occupancy tests

## Test Result

Passed.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
