### PR TITLE
Jeonghyun/asan busywait hang

### DIFF
--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/default_signal.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/default_signal.cpp
@@ -42,7 +42,9 @@
 
 #include "core/inc/default_signal.h"
 
+#if defined(__SANITIZE_ADDRESS__) || (defined(__has_feature) && __has_feature(address_sanitizer))
 #include <sched.h>
+#endif
 
 #if defined(__i386__) || defined(__x86_64__)
 #include <mwaitxintrin.h>
@@ -108,9 +110,12 @@ hsa_signal_value_t BusyWaitSignal::WaitRelaxed(hsa_signal_condition_t condition,
 
     if (g_use_mwaitx) {
       timer::DoMwaitx(const_cast<int64_t*>(&signal_.value), 60000, true);
-    } else if (wait_hint != HSA_WAIT_STATE_ACTIVE) {
+    }
+#if defined(__SANITIZE_ADDRESS__) || (defined(__has_feature) && __has_feature(address_sanitizer))
+    else if (wait_hint != HSA_WAIT_STATE_ACTIVE) {
       sched_yield();
     }
+#endif
   }
 }
 

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/default_signal.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/default_signal.cpp
@@ -42,6 +42,8 @@
 
 #include "core/inc/default_signal.h"
 
+#include <sched.h>
+
 #if defined(__i386__) || defined(__x86_64__)
 #include <mwaitxintrin.h>
 #define MWAITX_ECX_TIMER_ENABLE 0x2  // BIT(1)
@@ -105,8 +107,9 @@ hsa_signal_value_t BusyWaitSignal::WaitRelaxed(hsa_signal_condition_t condition,
     timer::CheckAbortTimeout(start_time, signal_abort_timeout);
 
     if (g_use_mwaitx) {
-      // Use timer-enabled mwaitx for busy waiting
       timer::DoMwaitx(const_cast<int64_t*>(&signal_.value), 60000, true);
+    } else if (wait_hint != HSA_WAIT_STATE_ACTIVE) {
+      sched_yield();
     }
   }
 }


### PR DESCRIPTION

The g_use_mwaitx path uses a hardware instruction that briefly pauses the CPU. But when mwaitx is unavailable (which happens on some systems or when the flag is false), the loop spins with zero pause — pure busy-wait.
Under ASAN, every iteration of that tight loop triggers __asan_stack_malloc_0() (fake stack allocation), making each iteration ~100-1000x slower. This monopolizes the CPU core and starves the HostcallListener thread that processes device-side ASAN hostcall packets from the GPU. The GPU kernel can't drain its hostcall queue, so it stalls, and the signal never fires.
Our fix adds sched_yield() in the non-mwaitx case when the caller passed wait_hint != HSA_WAIT_STATE_ACTIVE (meaning the caller doesn't need ultra-low-latency polling). This gives the HostcallListener thread a chance to run.
The condition wait_hint != HSA_WAIT_STATE_ACTIVE is important — it preserves the original tight-spin behavior for callers that explicitly request active waiting (performance-critical paths), while adding the yield only for callers that are okay with slightly higher latency. In our hang case, the HIP event synchronize passes HSA_WAIT_STATE_ACTIVE, but the signal is a BusyWaitSignal which ignores wait_hint in the original code anyway. With our fix, the parameter actually gets respected.



The GDB backtrace captured during the hang proved this exact mechanism:
Main thread (burning CPU):
```
#0  FastPoisonShadow()              ← ASAN shadow memory poisoning
#1  PoisonShadow()                  ← ASAN
#2  SetShadow()                     ← ASAN fake stack
#3  OnMalloc()                      ← ASAN fake stack allocation
#4  __asan_stack_malloc_0()         ← ASAN stack frame setup (EVERY poll iteration)
#5  BusyWaitSignal::WaitRelaxed()   ← ROCr signal polling (default_signal.cpp:79)
    ...
#11 hipEventSynchronize()           ← HIP waiting for kernel
    ...
#19 GenericSearch()                 ← MIOpen benchmarking solver configs
```

HostcallListener (Thread 7, starved):
```
#0  std::atomic::exchange()
#1  HostcallBuffer::processPackets()  ← actively trying to process, but can't keep up
```


The Fix: 1 Line
File: rocr-runtime/.../core/runtime/default_signal.cpp

Before (deadlocks):
```
if (g_use_mwaitx) {
    timer::DoMwaitx(const_cast<int64_t*>(&signal_.value), 60000, true);
}
// else: NOTHING — tight spin continues, burns 100% CPU
```
After (fixed):
```
if (g_use_mwaitx) {
    timer::DoMwaitx(const_cast<int64_t*>(&signal_.value), 60000, true);
} else if (wait_hint != HSA_WAIT_STATE_ACTIVE) {
    sched_yield();  // <-- THE FIX: yield CPU to hostcall listener thread
}

```

sched_yield() tells the OS: "I have nothing useful to do right now — let another thread run." This gives the HostcallListener enough CPU time to process the GPU's ASAN hostcall requests, breaking the deadlock.


My Test result: 

| Metric | Before Fix | After Fix |
|--------|-----------|-----------|
| Filter | `*ImplicitGemm*:*group_conv*:*fused_conv*:...` | same |
| Total tests | 711 | 711 |
| Passed | ~hundreds, then **HANG** | **426** |
| Skipped | — | 285 (unsupported arch) |
| Failed | 0 | **0** |
| Hangs | Yes (after ~15 min) | **0** |
| Total time | Infinite (killed) | **45 minutes** |
| Exit code | killed | **0** |