### PR TITLE
ROCM-20280 - hipGraphAddMemcpyNode should validate the extents of srcArray and dstArray

### DIFF
--- a/projects/clr/hipamd/src/hip_memory.cpp
+++ b/projects/clr/hipamd/src/hip_memory.cpp
@@ -2621,9 +2621,17 @@ hipError_t ihipMemcpy3D_validate(const hipMemcpy3DParms* p) {
 
   // If the source and destination are both arrays, hipMemcpy3D() will return an error if they do
   // not have the same element size.
-  if (((p->srcArray != nullptr) && (p->dstArray != nullptr)) &&
-      (hip::getElementSize(p->srcArray) != hip::getElementSize(p->dstArray))) {
-    return hipErrorInvalidValue;
+  if ((p->srcArray != nullptr) && (p->dstArray != nullptr)) {
+    if (hip::getElementSize(p->srcArray) != hip::getElementSize(p->dstArray)) {
+         return hipErrorInvalidValue;
+      }
+
+    // If both src and dst are arrays, verify they have the same extents
+    if (p->srcArray->width != p->dstArray->width ||
+        p->srcArray->height != p->dstArray->height ||
+        p->srcArray->depth != p->dstArray->depth) {
+      return hipErrorInvalidValue;
+    }
   }
 
   // Pitch should not be less than width for both src and dst.


### PR DESCRIPTION
## Motivation

hipGraphAddMemcpyNode should validate if the extents (height, width and depth) of both srcArray and dstArray and should not succeed if they are different.

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

Adds a check to properly check the extents of srcArray and dstArray

## JIRA ID

Resolves ROCM-20280

## Test Plan

Check if the test case Unit_hipGraphAddMemcpyNode_Negative_Parameters works as expected.

## Test Result

Pass

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
