### PR TITLE
Do timed submit only if queue timing is active

### DIFF
--- a/projects/clr/rocclr/device/pal/palubercapturemgr.cpp
+++ b/projects/clr/rocclr/device/pal/palubercapturemgr.cpp
@@ -330,11 +330,10 @@ Pal::Result UberTraceCaptureMgr::TimedQueueSubmit(Pal::IQueue* queue, uint64_t c
   timedSubmitInfo.pSqttCmdBufIds = &sqttCmdBufIds;
   timedSubmitInfo.frameIndex = 0;
 
-  // Do a timed submit of all the command buffers
-  Pal::Result result = queue_timings_trace_source_->TimedSubmit(queue, submitInfo, timedSubmitInfo);
-
-  // Punt to non-timed submit if a timed submit fails (or is not supported)
-  if (result != Pal::Result::Success) {
+  Pal::Result result = Pal::Result::Success;
+  if (IsQueueTimingActive()) {
+    result = queue_timings_trace_source_->TimedSubmit(queue, submitInfo, timedSubmitInfo);
+  } else {
     result = queue->Submit(submitInfo);
   }
 


### PR DESCRIPTION
## Motivation

Blender crashes when capturing the trace using RDP with backtrace:
```
amdhip64_6!GpuUtil::GpaSession::RecycleGartGpuMem+0x184
amdhip64_6!GpuUtil::GpaSession::Reset+0x27d
amdhip64_6!GpuUtil::QueueTimingsTraceSource::OnTraceFinished+0x2ba
amdhip64_6!GpuUtil::TraceSession::FinishTrace+0x1f8
amdhip64_6!GpuUtil::RenderOpTraceController::FinishTrace+0x18
amdhip64_6!GpuUtil::RenderOpTraceController::OnRenderOpUpdated+0x6b3
amdhip64_6!GpuUtil::RenderOpTraceController::RecordRenderOps+0xe0
amdhip64_6!amd::pal::UberTraceCaptureMgr::PreDispatch+0xc1
amdhip64_6!amd::pal::VirtualGPU::submitKernelInternal+0x2fb
amdhip64_6!amd::pal::VirtualGPU::submitKernel+0x3f2
...
```

## Technical Details

Avoid using timed submit when queue timing isn't active. Timed submit is also fixed on the PAL side to avoid accepting timed submits when session is not active.

## JIRA ID

ROCM-19854

## Test Plan

Trace capture using RDP

## Test Result

Blender runs successfully when capturing trace using RDP

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
