### PR TITLE
rocrtst: free agents_accessible between hsa_amd_pointer_info calls

### DIFF
--- a/projects/rocr-runtime/rocrtst/suites/functional/virtual_memory.cc
+++ b/projects/rocr-runtime/rocrtst/suites/functional/virtual_memory.cc
@@ -132,7 +132,7 @@ VirtMemoryTestBasic::VirtMemoryTestBasic(void) : TestBase() {
 VirtMemoryTestBasic::~VirtMemoryTestBasic(void) {}
 
 void VirtMemoryTestBasic::TestCreateDestroy(hsa_agent_t agent, hsa_amd_memory_pool_t pool) {
-  hsa_agent_t* agents_accessible;
+  hsa_agent_t* agents_accessible = nullptr;
   hsa_amd_pointer_info_t ptrInfo = {};
   uint32_t num_agents_accessible = 0;
   std::vector<hsa_agent_t> gpus;
@@ -171,6 +171,8 @@ void VirtMemoryTestBasic::TestCreateDestroy(hsa_agent_t agent, hsa_amd_memory_po
 
   /* Verify that pointer info for unmapped VA offset return expected values */
   ptrInfo.size = sizeof(ptrInfo);
+  num_agents_accessible = 0;
+  agents_accessible = nullptr;
   ASSERT_SUCCESS(hsa_amd_pointer_info(reinterpret_cast<uint8_t*>(addrRangeUnmapped) + 10, &ptrInfo, &malloc,
                                       &num_agents_accessible, &agents_accessible));
   ASSERT_EQ(ptrInfo.type, HSA_EXT_POINTER_TYPE_RESERVED_ADDR);

--- a/projects/rocr-runtime/rocrtst/suites/functional/virtual_memory.cc
+++ b/projects/rocr-runtime/rocrtst/suites/functional/virtual_memory.cc
@@ -166,6 +166,8 @@ void VirtMemoryTestBasic::TestCreateDestroy(hsa_agent_t agent, hsa_amd_memory_po
   /* For unmapped VA, then size is equal to size of address reservation */
   ASSERT_EQ(ptrInfo.sizeInBytes, sizeof_addrRangeUnmapped);
   ASSERT_EQ(num_agents_accessible, 0);
+  free(agents_accessible);
+  agents_accessible = nullptr;
 
   /* Verify that pointer info for unmapped VA offset return expected values */
   ptrInfo.size = sizeof(ptrInfo);
@@ -177,6 +179,8 @@ void VirtMemoryTestBasic::TestCreateDestroy(hsa_agent_t agent, hsa_amd_memory_po
   /* For unmapped VA, then size is equal to size of address reservation */
   ASSERT_EQ(ptrInfo.sizeInBytes, sizeof_addrRangeUnmapped);
   ASSERT_EQ(num_agents_accessible, 0);
+  free(agents_accessible);
+  agents_accessible = nullptr;
 
   hsa_amd_vmem_alloc_handle_t mem_handle;
   const size_t sizeof_mem_handle = 10 * granule_size;
@@ -210,6 +214,8 @@ void VirtMemoryTestBasic::TestCreateDestroy(hsa_agent_t agent, hsa_amd_memory_po
   ASSERT_EQ(ptrInfo.type, HSA_EXT_POINTER_TYPE_HSA_VMEM);
   ASSERT_EQ(ptrInfo.sizeInBytes, sizeof_mem_handle);  // size matches memory handle
   ASSERT_EQ(num_agents_accessible, 0);
+  free(agents_accessible);
+  agents_accessible = nullptr;
 
   // Access to each GPU should be None
   for (auto gpuIt = gpus.begin(); gpuIt != gpus.end(); ++gpuIt) {


### PR DESCRIPTION
TestCreateDestroy calls hsa_amd_pointer_info multiple times, each of which allocates a new agents_accessible array via the caller-supplied malloc callback. The previous allocation was not freed before the next call, leaking memory.

Free agents_accessible and reset the pointer to nullptr after each use.

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
