### PR TITLE
rocrtst: use non-fatal assertions in virtual memory cleanup paths

### DIFF
--- a/projects/rocr-runtime/rocrtst/common/helper_funcs.h
+++ b/projects/rocr-runtime/rocrtst/common/helper_funcs.h
@@ -156,6 +156,7 @@ static __forceinline ScopeGuard<lambda> MakeScopeGuard(lambda rel) {
                           __VA_ARGS__)
 
 #define ASSERT_SUCCESS(_val) ASSERT_EQ(HSA_STATUS_SUCCESS, (_val))
+#define EXPECT_SUCCESS(_val) EXPECT_EQ(HSA_STATUS_SUCCESS, (_val))
 
 #define ARRAY_SIZE(_x) (sizeof(_x) / sizeof(_x[0]))
 

--- a/projects/rocr-runtime/rocrtst/suites/functional/virtual_memory.cc
+++ b/projects/rocr-runtime/rocrtst/suites/functional/virtual_memory.cc
@@ -594,9 +594,10 @@ void VirtMemoryTestBasic::CPUAccessToGPUMemoryTest(hsa_agent_t cpuAgent, hsa_age
   }
   std::cout << "    CPU have read & write to GPU memory successfully" << std::endl;
 
-  ASSERT_SUCCESS(hsa_amd_vmem_unmap(dev_data, max_alloc_size));
-  ASSERT_SUCCESS(hsa_amd_vmem_handle_release(mem_handle_dev));
-  ASSERT_SUCCESS(hsa_amd_vmem_address_free(reinterpret_cast<void*>(dev_data), max_alloc_size));
+  // Cleanup
+  EXPECT_SUCCESS(hsa_amd_vmem_unmap(dev_data, max_alloc_size));
+  EXPECT_SUCCESS(hsa_amd_vmem_handle_release(mem_handle_dev));
+  EXPECT_SUCCESS(hsa_amd_vmem_address_free(reinterpret_cast<void*>(dev_data), max_alloc_size));
   free(host_data);
 }
 
@@ -821,11 +822,12 @@ void VirtMemoryTestBasic::GPUAccessToCPUMemoryTest(hsa_agent_t cpuAgent, hsa_age
     std::cout << "    GPU has written to system memory successfully" << std::endl;
   }
 
-  ASSERT_SUCCESS(hsa_amd_vmem_unmap(dev_data, sizeof(*dev_data)));
-  ASSERT_SUCCESS(hsa_amd_vmem_handle_release(mem_handle));
+  // Cleanup
+  EXPECT_SUCCESS(hsa_amd_vmem_unmap(dev_data, sizeof(*dev_data)));
+  EXPECT_SUCCESS(hsa_amd_vmem_handle_release(mem_handle));
 
   if (dev_data) {
-    ASSERT_SUCCESS(hsa_amd_vmem_address_free(dev_data, sizeof(*dev_data)));
+    EXPECT_SUCCESS(hsa_amd_vmem_address_free(dev_data, sizeof(*dev_data)));
   }
 
   if (host_data) hsa_memory_free(host_data);
@@ -1075,11 +1077,12 @@ void VirtMemoryTestBasic::GPUAccessToGPUMemoryTest(hsa_agent_t cpuAgent, hsa_age
     std::cout << "    GPU has written to system memory successfully" << std::endl;
   }
 
-  ASSERT_SUCCESS(hsa_amd_vmem_unmap(dev_data, sizeof(*dev_data)));
-  ASSERT_SUCCESS(hsa_amd_vmem_handle_release(mem_handle));
+  // Cleanup
+  EXPECT_SUCCESS(hsa_amd_vmem_unmap(dev_data, sizeof(*dev_data)));
+  EXPECT_SUCCESS(hsa_amd_vmem_handle_release(mem_handle));
 
   if (dev_data) {
-    ASSERT_SUCCESS(hsa_amd_vmem_address_free(dev_data, sizeof(*dev_data)));
+    EXPECT_SUCCESS(hsa_amd_vmem_address_free(dev_data, sizeof(*dev_data)));
   }
 
   if (host_data) hsa_memory_free(host_data);


### PR DESCRIPTION
ASSERT_SUCCESS in cleanup code causes an early return on failure, skipping subsequent resource frees and leaking memory. Switch cleanup sections of CPUAccessToGPUMemoryTest, GPUAccessToCPUMemoryTest, and GPUAccessToGPUMemoryTest to EXPECT_SUCCESS so all resources are freed even if a cleanup call fails.

Add EXPECT_SUCCESS macro to helper_funcs.h alongside the existing ASSERT_SUCCESS.

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
