### PR TITLE
rocrtst: join threads in concurrent shutdown test

### DIFF
--- a/projects/rocr-runtime/rocrtst/suites/functional/concurrent_shutdown.cc
+++ b/projects/rocr-runtime/rocrtst/suites/functional/concurrent_shutdown.cc
@@ -152,5 +152,11 @@ void ConcurrentShutdownTest::TestConcurrentShutdown(void) {
       std::cout << Id << "Thread creation failed " << std::endl;
     }
   }
+
+  for (int Id = 0; Id < NumOfThreads; ++Id) {
+    pthread_join(ThreadId[Id], nullptr);
+  }
+
+  pthread_attr_destroy(&attr);
 }
 #undef RET_IF_HSA_ERR


### PR DESCRIPTION
The concurrent shutdown test spawns 1000 threads to call hsa_shut_down() but never joins them. Under ASAN, the detached threads continue accessing freed memory after the test function returns.

Join all threads before destroying the pthread attribute and returning.

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
