### PR TITLE
rocrtst: shut down HSA runtime in IPC child process before exit

### DIFF
--- a/projects/rocr-runtime/rocrtst/suites/functional/ipc.cc
+++ b/projects/rocr-runtime/rocrtst/suites/functional/ipc.cc
@@ -620,12 +620,13 @@ void IPCTest::Run(void) {
     PrintVerboseMesg();
   }
 
-  // Note: Close() (and hsa_shut_down()) will be called from main()
-  // processOne is true for parent process, false for child process
+  // Note: Close() (and hsa_shut_down()) will be called from main() for parent.
+  // Child process must shut down HSA runtime before exiting.
   if (parentProcess_) {
     ParentProcessImpl();
   } else {
     ChildProcessImpl();
+    hsa_shut_down();
     exit(0);
   }
 


### PR DESCRIPTION
The IPC test forks a child process that calls exit(0) without shutting down the HSA runtime. This leaks the runtime's internal allocations (e.g. AsyncEventsInfo signal, 144 bytes) which ASAN reports as leaks.

Call hsa_shut_down() before exit(0) in the child path. The parent process already shuts down via Close() in the test framework.

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
