### PR TITLE
rocrtst: shut down HSA runtime in virtual memory interprocess child

### DIFF
--- a/projects/rocr-runtime/rocrtst/suites/functional/virtual_memory.cc
+++ b/projects/rocr-runtime/rocrtst/suites/functional/virtual_memory.cc
@@ -1474,12 +1474,13 @@ void VirtMemoryTestInterProcess::Run(void) {
 
   TestBase::Run();
 
-  // Note: Close() (and hsa_shut_down()) will be called from main()
-  // processOne is true for parent process, false for child process
+  // Note: Close() (and hsa_shut_down()) will be called from main() for parent.
+  // Child process must shut down HSA runtime before exiting.
   if (parentProcess_) {
     ParentProcessImpl();
   } else {
     ChildProcessImpl();
+    hsa_shut_down();
     exit(0);
   }
 }


### PR DESCRIPTION
The VirtMemoryTestInterProcess child process calls exit(0) without hsa_shut_down(), leaking runtime allocations under ASAN.

Call hsa_shut_down() before exit(0) in the child path.

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
