### PR TITLE
rocr: Fix dlopen handle leak in hsa_system_get_major_extension_table

### DIFF
--- a/projects/rocr-runtime/runtime/hsa-runtime/core/inc/runtime.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/inc/runtime.h
@@ -514,6 +514,7 @@ class Runtime {
   bool XnackEnabled() const { return xnack_enabled_; }
   void XnackEnabled(bool enable) { xnack_enabled_ = enable; }
   bool AqlProfileAvailable() const { return (aqlprofile_lib_ != nullptr); }
+  os::LibHandle AqlProfileLib() const { return aqlprofile_lib_; }
 
   Driver &AgentDriver(DriverType drv_type) {
     auto is_drv_type = [&](const std::unique_ptr<Driver> &d) {

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/hsa.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/hsa.cpp
@@ -503,7 +503,7 @@ hsa_status_t hsa_system_get_major_extension_table(uint16_t extension, uint16_t v
     // and closed in Runtime::Unload(), avoiding a dlopen handle leak.
     os::LibHandle lib = core::Runtime::runtime_singleton_->AqlProfileLib();
     if (lib == NULL) {
-      debug_print("Loading '%s' failed\n", kAqlProfileLib);
+      debug_print("AQL profile library '%s' is unavailable.\n", kAqlProfileLib);
       return HSA_STATUS_ERROR;
     }
 

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/hsa.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/hsa.cpp
@@ -498,7 +498,10 @@ hsa_status_t hsa_system_get_major_extension_table(uint16_t extension, uint16_t v
       return HSA_STATUS_ERROR;
     }
 
-    os::LibHandle lib = os::LoadLib(kAqlProfileLib);
+    // Use the cached aqlprofile library handle from Runtime instead of
+    // opening a new one.  The handle is loaded once during Runtime::Load()
+    // and closed in Runtime::Unload(), avoiding a dlopen handle leak.
+    os::LibHandle lib = core::Runtime::runtime_singleton_->AqlProfileLib();
     if (lib == NULL) {
       debug_print("Loading '%s' failed\n", kAqlProfileLib);
       return HSA_STATUS_ERROR;


### PR DESCRIPTION
hsa_system_get_major_extension_table() called os::LoadLib(kAqlProfileLib) to dlopen the aqlprofile library every time the extension table was queried, but never called os::CloseLib() on the returned handle. The local variable went out of scope, leaking the dlopen handle.

Use the cached aqlprofile_lib_ handle that Runtime::Load() already opens at startup and Runtime::Unload() properly closes at shutdown. Add an AqlProfileLib() accessor to Runtime to expose the cached handle.

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
