### PR TITLE
[CLR] Link pthread explicitly for ocltst when building with ASAN

### DIFF
--- a/projects/clr/opencl/tests/ocltst/env/CMakeLists.txt
+++ b/projects/clr/opencl/tests/ocltst/env/CMakeLists.txt
@@ -48,7 +48,7 @@ if (NOT WIN32)
   find_package(Threads REQUIRED)
   target_link_libraries(ocltst PRIVATE Threads::Threads ${CMAKE_DL_LIBS})
   # ASAN with -shared-libsan requires explicit pthread linkage
-  if(THEROCK_SANITIZER MATCHES "ASAN")
+  if(THEROCK_SANITIZER MATCHES "ASAN" OR ENABLE_ADDRESS_SANITIZER)
     target_link_options(ocltst PRIVATE -lpthread)
   endif()
 endif()

--- a/projects/clr/opencl/tests/ocltst/env/CMakeLists.txt
+++ b/projects/clr/opencl/tests/ocltst/env/CMakeLists.txt
@@ -47,6 +47,10 @@ if (NOT WIN32)
   set(THREADS_PREFER_PTHREAD_FLAG ON)
   find_package(Threads REQUIRED)
   target_link_libraries(ocltst PRIVATE Threads::Threads ${CMAKE_DL_LIBS})
+  # ASAN with -shared-libsan requires explicit pthread linkage
+  if(THEROCK_SANITIZER MATCHES "ASAN")
+    target_link_options(ocltst PRIVATE -lpthread)
+  endif()
 endif()
 
 set_target_properties(ocltst PROPERTIES INSTALL_RPATH "$ORIGIN")


### PR DESCRIPTION
ASAN with -shared-libsan requires explicit pthread linkage to avoid undefined symbol errors at runtime.

Ex: [ocl-clr] ld.lld: error: undefined symbol: pthread_mutex_trylock