### PR TITLE
[CLR][NFCI] Reduce amount of kernel name copies

### DIFF
--- a/projects/clr/opencl/amdocl/cl_program.cpp
+++ b/projects/clr/opencl/amdocl/cl_program.cpp
@@ -1402,7 +1402,7 @@ RUNTIME_ENTRY(cl_int, clCreateKernelsInProgram,
   cl_kernel* result = kernels;
 
   for (const auto& it : symbols) {
-    amd::Kernel* kernel = new amd::Kernel(*amd_program, it.second, it.first);
+    amd::Kernel* kernel = new amd::Kernel(*amd_program, it.second, std::string(it.first));
     if (kernel == NULL) {
       while (--result >= kernels) {
         as_amd(*result)->release();

--- a/projects/clr/rocclr/device/devprogram.hpp
+++ b/projects/clr/rocclr/device/devprogram.hpp
@@ -53,7 +53,7 @@ class Program : public amd::HeapObject {
  public:
   typedef std::pair<const void* /* binary_image */, size_t /* binary size */> binary_t;
   typedef std::pair<amd::Os::FileDesc /* file_desc */, size_t /* file_offset */> finfo_t;
-  typedef std::unordered_map<std::string, Kernel*> kernels_t;
+  typedef std::unordered_map<std::string_view, Kernel*> kernels_t;
   // type of the program
   typedef enum {
     TYPE_NONE = 0,     // uncompiled

--- a/projects/clr/rocclr/platform/program.cpp
+++ b/projects/clr/rocclr/platform/program.cpp
@@ -350,7 +350,7 @@ int32_t Program::link(const std::vector<Device*>& devices, size_t numInputs,
 
     const device::Program::kernels_t& kernels = program.kernels();
     for (const auto& it : kernels) {
-      const std::string& name = it.first;
+      const std::string_view name = it.first;
       const device::Kernel* devKernel = it.second;
 
       Symbol& symbol = (*symbolTable_)[name];
@@ -494,7 +494,7 @@ int32_t Program::build(const std::vector<Device*>& devices, const char* options,
 
       const device::Program::kernels_t& kernels = program.kernels();
       for (const auto& kit : kernels) {
-        const std::string& name = kit.first;
+        const std::string_view name = kit.first;
         const device::Kernel* devKernel = kit.second;
 
         Symbol& symbol = (*symbolTable_)[name];
@@ -555,7 +555,7 @@ const std::string& Program::kernelNames() {
       if (it != symbols().cbegin()) {
         kernelNames_.append(1, ';');
       }
-      kernelNames_.append(it->first.c_str());
+      kernelNames_.append(it->first);
     }
   }
   return kernelNames_;

--- a/projects/clr/rocclr/platform/program.hpp
+++ b/projects/clr/rocclr/platform/program.hpp
@@ -72,7 +72,7 @@ class Program : public RuntimeObject {
   typedef std::set<Device const*> devicelist_t;
   typedef std::unordered_map<Device const*, binary_t> devicebinary_t;
   typedef std::unordered_map<Device const*, device::Program*> deviceprograms_t;
-  typedef std::unordered_map<std::string, Symbol> symbols_t;
+  typedef std::unordered_map<std::string_view, Symbol> symbols_t;
 
   enum Language { Binary = 0, OpenCL_C, SPIRV, Assembly, HIP };
 


### PR DESCRIPTION
## Motivation

General performance optimizations of the HIP RT.

## Technical Details

Kernel names are owned by kernel objects, so instead of storing copies of those names we can store references to already stored values.

## JIRA ID

N/A

## Test Plan

N/A, this is intended to be a non-functional change

## Test Result

N/A, this is intended to be a non-functional change

## Submission Checklist

- [X] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
