### PR TITLE
Fix gfx950 chunkSteps/sliceSteps mismatch in ncclAllReduceWithBias

### DIFF
--- a/projects/rccl/src/collectives.cc
+++ b/projects/rccl/src/collectives.cc
@@ -350,9 +350,15 @@ ncclResult_t ncclAllReduceWithBias_impl(const void* sendbuff, void* recvbuff, si
   }
 
   // RCCL update slice steps for AllReduce if single node
+  const bool isGfx950 = IsArchMatch(comm->archName, "gfx950");
+  int chunkSteps = (isGfx950 && comm->rcclUseOneSlice)? 1 : ALLREDUCE_CHUNKSTEPS;
+  int sliceSteps = comm->rcclUseOneSlice
+      ? (isGfx950 ? 1 : ALLREDUCE_SLICESTEPS_SINGLE_NODE)
+      : ALLREDUCE_SLICESTEPS;
+
   struct ncclInfo info = { ncclFuncAllReduce, "AllReduce",
     sendbuff, recvbuff, count, datatype, op, 0, comm, stream, /* Args */
-    ALLREDUCE_CHUNKSTEPS, comm -> rcclUseOneSlice ? ALLREDUCE_SLICESTEPS_SINGLE_NODE : ALLREDUCE_SLICESTEPS, acc };
+    chunkSteps, sliceSteps, acc };
 
   NCCLCHECK(Recorder::instance().record(rrAllReduceWithBias, info));
 


### PR DESCRIPTION
## Motivation

ncclAllReduceWithBias_impl was using hardcoded ALLREDUCE_CHUNKSTEPS and ALLREDUCE_SLICESTEPS_SINGLE_NODE values instead of applying the gfx950- specific override (chunkSteps=1, sliceSteps=1) that ncclAllReduce_impl already applies. On gfx950 single-node, the kernel selects ProtoSimple<1,1> via rcclUseOneSlice, but the host was configuring communication buffers for the default stepping. This mismatch caused data corruption at 1GB and illegal memory access crashes at 4GB+ message sizes.

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## JIRA ID

AICOMRCCL-723

## Test Plan

Tested on `smci355-ccs-aus-m03-17`.
`mpirun -x NCCL_DEBUG=INFO -x NCCL_DEBUG=SUBSYS=ALL -np 8 ./build/all_reduce_bias_perf -b 4 -e 16G -f 2 -g 1 -w 10`

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
