### PR TITLE
kfdtest: Fix logic error on whitelist/blacklist filter additions

### DIFF
--- a/projects/rocr-runtime/libhsakmt/tests/kfdtest/scripts/run_kfdtest.sh
+++ b/projects/rocr-runtime/libhsakmt/tests/kfdtest/scripts/run_kfdtest.sh
@@ -141,11 +141,21 @@ getFilter() {
     # Check if the loaded driver is upstream (in-box) or DKMS
     rdma_get_pages_func=$(cat /proc/kallsyms | grep rdma_get_pages || true)
     if [ -z "$rdma_get_pages_func" ]; then
-	    gtestFilter="$gtestFilter:${FILTER[upstream]}"
+        # If the first character of the filter is -, it's a blacklist
+	# So add the upstream tests to the blacklist. If it's not a -, it's a
+	# whitelist, so don't add anything
+	if [[ "$gtestFilter{0:1}" == "-" ]]; then
+            gtestFilter="$gtestFilter:${FILTER[upstream]}"
+        fi
     fi
 
     if [ -n "$ADDITIONAL_EXCLUDE" ]; then
-	    gtestFilter="$gtestFilter:$ADDITIONAL_EXCLUDE"
+        # If the first character of the filter is -, it's a blacklist
+	# So add the additional exclusions to the blacklist. If it's not a -, it's a
+	# whitelist, so don't add anything
+        if [[ "$gtestFilter{0:1}" == "-" ]]; then
+            gtestFilter="$gtestFilter:$ADDITIONAL_EXCLUDE"
+        fi
     fi
 }
 


### PR DESCRIPTION
The core_sws and core filters are whitelists, not blacklists. So if we're using the upstream filter, or additional exclusions, don't add them if it's core*, otherwise those subtests will actually be added.

This will fix anything using core/core_sws+upstream, or core/core_sws with the -e flag. There's a gap in core/core_sws with -e, but that's not a pressing issue currently