### PR TITLE
therock-ci-nightly: align testing with therock/ci_nightly.yml

### DIFF
--- a/.github/workflows/therock-ci-linux.yml
+++ b/.github/workflows/therock-ci-linux.yml
@@ -7,6 +7,15 @@ on:
         type: string
       projects_to_test:
         type: string
+      test_runs_on:
+        type: string
+        default: ""
+      run_functional_tests:
+        type: boolean
+        default: false
+      benchmark_runs_on:
+        type: string
+        default: ""
 
 
 permissions:
@@ -123,5 +132,23 @@ jobs:
       projects_to_test: ${{ inputs.projects_to_test }}
       amdgpu_families: "gfx94X-dcgpu"
       # Due to migrating MI325s, we have lost capacity as of 3/13/2026 11:41am PST
-      test_runs_on: ""
+      test_runs_on: ${{ inputs.test_runs_on }}
       platform: "linux"
+      run_functional_tests: ${{ inputs.run_functional_tests }}
+
+  therock-benchmark-linux:
+    name: "Benchmark"
+    needs: [therock-build-linux]
+    if: >-
+      ${{
+        !failure() &&
+        !cancelled() &&
+        inputs.benchmark_runs_on != ''
+      }}
+    uses: ./.github/workflows/therock-test-packages.yml
+    with:
+      projects_to_test: ${{ inputs.projects_to_test }}
+      amdgpu_families: "gfx94X-dcgpu"
+      test_runs_on: ${{ inputs.benchmark_runs_on }}
+      platform: "linux"
+      benchmark_mode: true

--- a/.github/workflows/therock-ci-nightly.yml
+++ b/.github/workflows/therock-ci-nightly.yml
@@ -99,6 +99,7 @@ jobs:
     with:
       cmake_options: ${{ matrix.projects.cmake_options }}
       projects_to_test: ${{ matrix.projects.projects_to_test }}
+      run_functional_tests: true
 
   therock-rccl-ci-linux:
     name: TheRock RCCL CI Linux
@@ -140,3 +141,4 @@ jobs:
     with:
       cmake_options: ${{ matrix.projects.cmake_options }}
       projects_to_test: ${{ matrix.projects.projects_to_test }}
+      run_functional_tests: true

--- a/.github/workflows/therock-ci-windows.yml
+++ b/.github/workflows/therock-ci-windows.yml
@@ -7,6 +7,15 @@ on:
         type: string
       projects_to_test:
         type: string
+      test_runs_on:
+        type: string
+        default: "windows-gfx1151-gpu-rocm"
+      run_functional_tests:
+        type: boolean
+        default: false
+      benchmark_runs_on:
+        type: string
+        default: ""
 
 permissions:
   contents: read
@@ -150,5 +159,23 @@ jobs:
     with:
       projects_to_test: ${{ inputs.projects_to_test }}
       amdgpu_families: ${{ needs.therock-build-windows.outputs.AMDGPU_FAMILIES }}
-      test_runs_on: "windows-gfx1151-gpu-rocm"
+      test_runs_on: ${{ inputs.test_runs_on }}
       platform: "windows"
+      run_functional_tests: ${{ inputs.run_functional_tests }}
+
+  therock-benchmark-windows:
+    name: "Benchmark"
+    needs: [therock-build-windows]
+    if: >-
+      ${{
+        !failure() &&
+        !cancelled() &&
+        inputs.benchmark_runs_on != ''
+      }}
+    uses: ./.github/workflows/therock-test-packages.yml
+    with:
+      projects_to_test: ${{ inputs.projects_to_test }}
+      amdgpu_families: ${{ needs.therock-build-windows.outputs.AMDGPU_FAMILIES }}
+      test_runs_on: ${{ inputs.benchmark_runs_on }}
+      platform: "windows"
+      benchmark_mode: true

--- a/.github/workflows/therock-test-packages.yml
+++ b/.github/workflows/therock-test-packages.yml
@@ -17,6 +17,12 @@ on:
       sanity_check_only_for_family:
         type: boolean
         default: false
+      run_functional_tests:
+        type: boolean
+        default: false
+      benchmark_mode:
+        type: boolean
+        default: false
 
 permissions:
   contents: read
@@ -61,6 +67,8 @@ jobs:
         env:
           PROJECTS_TO_TEST: ${{ inputs.projects_to_test }}
           AMDGPU_FAMILIES: ${{ inputs.amdgpu_families }}
+          RUN_FUNCTIONAL_TESTS: ${{ inputs.run_functional_tests }}
+          IS_BENCHMARK_WORKFLOW: ${{ inputs.benchmark_mode == true && 'true' || '' }}
         id: configure
         run: python ./build_tools/github_actions/fetch_test_configurations.py
 


### PR DESCRIPTION
Add functional tests and benchmark support to the nightly CI to match the test coverage in therock/.github/workflows/ci_nightly.yml.

- therock-test-packages.yml: add run_functional_tests and benchmark_mode inputs; pass RUN_FUNCTIONAL_TESTS and IS_BENCHMARK_WORKFLOW env vars to fetch_test_configurations.py
- therock-ci-linux.yml: add run_functional_tests, benchmark_runs_on, and test_runs_on inputs; forward run_functional_tests to test job; add therock-benchmark-linux job (runs when benchmark_runs_on is set)
- therock-ci-windows.yml: same additions as Linux; test_runs_on defaults to windows-gfx1151-gpu-rocm to preserve existing behavior
- therock-ci-nightly.yml: pass run_functional_tests: true to both Linux and Windows CI calls

## Motivation

public-rocm-sys/therock-ci-nightly.yml ran the same test suite as the regular CI — it had no nightly-specific testing.
  therock/ci_nightly.yml by contrast enables functional tests, benchmarks, and PyTorch builds on its nightly cadence.

## Technical Details

What this enables nightly (matching therock/ci_nightly.yml)
| Test Type | Before | After |
| ---------- | ------- | ------ |
| Regular component tests | Yes (Linux disabled due to MI325) | Yes + RUN_FUNCTIONAL_TESTS=true |
| Functional tests | No | Yes (nightly only) |
| Benchmarks | No | Yes, when benchmark_runs_on is set |
  
  Note: benchmark_runs_on defaults to "" so benchmark jobs are skipped until runner labels are configured in therock-ci-nightly.yml.
  Python/PyTorch wheel building was not added as there is no equivalent build infrastructure in public-rocm-sys.

## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
