### PR TITLE
[CLR][HIP][NFCI] Simplify variable usage in hipLaunchKernelGGL

### DIFF
--- a/projects/clr/hipamd/include/hip/amd_detail/amd_hip_runtime.h
+++ b/projects/clr/hipamd/include/hip/amd_detail/amd_hip_runtime.h
@@ -204,7 +204,7 @@ void hipLaunchKernelGGL(F kernel, const dim3& numBlocks, const dim3& dimBlocks,
   auto k = reinterpret_cast<void*>(kernel);
 
   if constexpr (std::is_same_v<F, void (*)(Args...)>) {
-    auto ptrArgsArr = std::array<void*, sizeof...(Args)>{static_cast<void*>(&args)...};
+    std::array<void*, sizeof...(Args)> ptrArgsArr{static_cast<void*>(&args)...};
     hipExtLaunchKernel(k, numBlocks, dimBlocks, ptrArgsArr.data(), sharedMemBytes, stream,
                        nullptr, nullptr, 0);
   } else {

--- a/projects/clr/hipamd/include/hip/amd_detail/amd_hip_runtime.h
+++ b/projects/clr/hipamd/include/hip/amd_detail/amd_hip_runtime.h
@@ -165,15 +165,14 @@ __host__ inline void* __get_dynamicgroupbaseptr() { return nullptr; }
 
 typedef int hipLaunchParm;
 
-template <std::size_t n, typename... Ts,
-          typename std::enable_if<n == sizeof...(Ts)>::type* = nullptr>
-void pArgs(const std::tuple<Ts...>&, void*) {}
+template <typename... Formals, typename... Actuals>
+std::tuple<Formals...> validateArgsCountType(void (*kernel)(Formals...),
+                                             Actuals... actuals) {
+  static_assert(sizeof...(Formals) == sizeof...(Actuals), "Argument Count Mismatch");
+  return {std::move(actuals)...};
+}
 
-template <std::size_t n, typename... Ts,
-          typename std::enable_if<n != sizeof...(Ts)>::type* = nullptr>
-void pArgs(const std::tuple<Ts...>& formals, void** _vargs) {
-  using T = typename std::tuple_element<n, std::tuple<Ts...>>::type;
-
+template <typename T> constexpr void validateArgType() {
   static_assert(!std::is_reference<T>{},
                 "A __global__ function cannot have a reference as one of its "
                 "arguments.");
@@ -182,30 +181,42 @@ void pArgs(const std::tuple<Ts...>& formals, void** _vargs) {
                 "Only TriviallyCopyable types can be arguments to a __global__ "
                 "function");
 #endif
-  _vargs[n] = const_cast<void*>(reinterpret_cast<const void*>(&std::get<n>(formals)));
-  return pArgs<n + 1>(formals, _vargs);
 }
 
-template <typename... Formals, typename... Actuals>
-std::tuple<Formals...> validateArgsCountType(void (*kernel)(Formals...),
-                                             std::tuple<Actuals...>(actuals)) {
-  static_assert(sizeof...(Formals) == sizeof...(Actuals), "Argument Count Mismatch");
-  std::tuple<Formals...> to_formals{std::move(actuals)};
-  return to_formals;
+template <typename... Ts> constexpr void validateArgs(void (*)(Ts...)) {
+  (validateArgType<Ts>(), ...);
+}
+
+template <typename... Ts> std::array<void*, sizeof...(Ts)> pArgs(Ts... formals) {
+  return {static_cast<void*>(&formals)...};
+}
+
+template <typename... Ts, size_t... Is>
+std::array<void*, sizeof...(Ts)> pArgs(std::tuple<Ts...>& formals, std::index_sequence<Is...>) {
+  return {(static_cast<void*>(&std::get<Is>(formals)))...};
+}
+
+template <typename... Ts> std::array<void*, sizeof...(Ts)> pArgs(std::tuple<Ts...>& formals) {
+  return pArgs(formals, std::make_index_sequence<sizeof...(Ts)>());
 }
 
 #if defined(HIP_TEMPLATE_KERNEL_LAUNCH)
 template <typename... Args, typename F = void (*)(Args...)>
 void hipLaunchKernelGGL(F kernel, const dim3& numBlocks, const dim3& dimBlocks,
                         std::uint32_t sharedMemBytes, hipStream_t stream, Args... args) {
-  constexpr size_t count = sizeof...(Args);
-  auto tup_ = std::tuple<Args...>{args...};
-  auto tup = validateArgsCountType(kernel, tup_);
-  void* _Args[count];
-  pArgs<0>(tup, _Args);
-
+  validateArgs(kernel);
   auto k = reinterpret_cast<void*>(kernel);
-  hipLaunchKernel(k, numBlocks, dimBlocks, _Args, sharedMemBytes, stream);
+
+  if constexpr (std::is_same_v<F, void (*)(Args...)>) {
+    auto ptrArgsArr = pArgs(args...);
+    hipExtLaunchKernel(k, numBlocks, dimBlocks, ptrArgsArr.data(), sharedMemBytes, stream,
+                       nullptr, nullptr, 0);
+  } else {
+    auto formals = validateArgsCountType(kernel, args...);
+    auto ptrArgsArr = pArgs(formals);
+    hipExtLaunchKernel(k, numBlocks, dimBlocks, ptrArgsArr.data(), sharedMemBytes, stream,
+                       nullptr, nullptr, 0);
+  }
 }
 #else
 #define hipLaunchKernelGGLInternal(kernelName, numBlocks, numThreads, memPerBlock, streamId, ...)  \

--- a/projects/clr/hipamd/include/hip/amd_detail/amd_hip_runtime.h
+++ b/projects/clr/hipamd/include/hip/amd_detail/amd_hip_runtime.h
@@ -187,10 +187,6 @@ template <typename... Ts> constexpr void validateArgs(void (*)(Ts...)) {
   (validateArgType<Ts>(), ...);
 }
 
-template <typename... Ts> std::array<void*, sizeof...(Ts)> pArgs(Ts... formals) {
-  return {static_cast<void*>(&formals)...};
-}
-
 template <typename... Ts, size_t... Is>
 std::array<void*, sizeof...(Ts)> pArgs(std::tuple<Ts...>& formals, std::index_sequence<Is...>) {
   return {(static_cast<void*>(&std::get<Is>(formals)))...};
@@ -208,7 +204,7 @@ void hipLaunchKernelGGL(F kernel, const dim3& numBlocks, const dim3& dimBlocks,
   auto k = reinterpret_cast<void*>(kernel);
 
   if constexpr (std::is_same_v<F, void (*)(Args...)>) {
-    auto ptrArgsArr = pArgs(args...);
+    auto ptrArgsArr = std::array<void*, sizeof...(Args)>{static_cast<void*>(&args)...};
     hipExtLaunchKernel(k, numBlocks, dimBlocks, ptrArgsArr.data(), sharedMemBytes, stream,
                        nullptr, nullptr, 0);
   } else {

--- a/projects/clr/hipamd/include/hip/amd_detail/amd_hip_runtime.h
+++ b/projects/clr/hipamd/include/hip/amd_detail/amd_hip_runtime.h
@@ -205,13 +205,11 @@ void hipLaunchKernelGGL(F kernel, const dim3& numBlocks, const dim3& dimBlocks,
 
   if constexpr (std::is_same_v<F, void (*)(Args...)>) {
     std::array<void*, sizeof...(Args)> ptrArgsArr{static_cast<void*>(&args)...};
-    hipExtLaunchKernel(k, numBlocks, dimBlocks, ptrArgsArr.data(), sharedMemBytes, stream,
-                       nullptr, nullptr, 0);
+    hipLaunchKernel(k, numBlocks, dimBlocks, ptrArgsArr.data(), sharedMemBytes, stream);
   } else {
     auto formals = validateArgsCountType(kernel, args...);
     auto ptrArgsArr = pArgs(formals);
-    hipExtLaunchKernel(k, numBlocks, dimBlocks, ptrArgsArr.data(), sharedMemBytes, stream,
-                       nullptr, nullptr, 0);
+    hipLaunchKernel(k, numBlocks, dimBlocks, ptrArgsArr.data(), sharedMemBytes, stream);
   }
 }
 #else

--- a/projects/hip/include/hip/hip_ext.h
+++ b/projects/hip/include/hip/hip_ext.h
@@ -130,7 +130,7 @@ inline void hipExtLaunchKernelGGL(F kernel, const dim3& numBlocks, const dim3& d
   auto k = reinterpret_cast<void*>(kernel);
 
   if constexpr (std::is_same_v<F, void (*)(Args...)>) {
-    auto ptrArgsArr = std::array<void*, sizeof...(Args)>{static_cast<void*>(&args)...};
+    std::array<void*, sizeof...(Args)> ptrArgsArr{static_cast<void*>(&args)...};
     hipExtLaunchKernel(k, numBlocks, dimBlocks, ptrArgsArr.data(), sharedMemBytes, stream,
                        startEvent, stopEvent, (int)flags);
   } else {

--- a/projects/hip/include/hip/hip_ext.h
+++ b/projects/hip/include/hip/hip_ext.h
@@ -126,15 +126,19 @@ inline void hipExtLaunchKernelGGL(F kernel, const dim3& numBlocks, const dim3& d
                                   std::uint32_t sharedMemBytes, hipStream_t stream,
                                   hipEvent_t startEvent, hipEvent_t stopEvent, std::uint32_t flags,
                                   Args... args) {
-  constexpr size_t count = sizeof...(Args);
-  auto tup_ = std::tuple<Args...>{args...};
-  auto tup = validateArgsCountType(kernel, tup_);
-  void* _Args[count];
-  pArgs<0>(tup, _Args);
-
+  validateArgs(kernel);
   auto k = reinterpret_cast<void*>(kernel);
-  hipExtLaunchKernel(k, numBlocks, dimBlocks, _Args, sharedMemBytes, stream, startEvent, stopEvent,
-                     (int)flags);
+
+  if constexpr (std::is_same_v<F, void (*)(Args...)>) {
+    auto ptrArgsArr = pArgs(args...);
+    hipExtLaunchKernel(k, numBlocks, dimBlocks, ptrArgsArr.data(), sharedMemBytes, stream,
+                       startEvent, stopEvent, (int)flags);
+  } else {
+    auto formals = validateArgsCountType(kernel, args...);
+    auto ptrArgsArr = pArgs(formals);
+    hipExtLaunchKernel(k, numBlocks, dimBlocks, ptrArgsArr.data(), sharedMemBytes, stream,
+                       startEvent, stopEvent, (int)flags);
+  }
 }
 
 #endif  // defined(__cplusplus)

--- a/projects/hip/include/hip/hip_ext.h
+++ b/projects/hip/include/hip/hip_ext.h
@@ -130,7 +130,7 @@ inline void hipExtLaunchKernelGGL(F kernel, const dim3& numBlocks, const dim3& d
   auto k = reinterpret_cast<void*>(kernel);
 
   if constexpr (std::is_same_v<F, void (*)(Args...)>) {
-    auto ptrArgsArr = pArgs(args...);
+    auto ptrArgsArr = std::array<void*, sizeof...(Args)>{static_cast<void*>(&args)...};
     hipExtLaunchKernel(k, numBlocks, dimBlocks, ptrArgsArr.data(), sharedMemBytes, stream,
                        startEvent, stopEvent, (int)flags);
   } else {


### PR DESCRIPTION
## Motivation

The current template-based implementation of `hipLaunchKernelGGL` uses multiple tuples to ensure arguments are in the proper form to be used by the corresponding kernel. However, some of these tuple objects could be avoided by using some additional template magic and compile-time available information to potentially reduce the runtime overhead and memory footprint of calls to this funtion.

## Technical Details

This patch changes the structure of `hipLaunchKernelGGL` and constituents to simplify the use of temporary local variables. This is done by:

1. Removing the need for a temporary tuple containing copies of the arguments prior to conversion to the formal arguments of the kernel function.
2. Directly initializing the array of pointers to the arguments instead of first creating the array and then populating it in a separate recursive function.
3. Short-cutting the case where the input arguments and the formal arguments of the kernel function are already in the correct form, thus avoiding unnecessary copying, conversions and storage.

## JIRA ID

N/A

## Test Plan

No additional testing as these are intended to be non-functional and should be covered by exisinting testing.

## Test Result

No additional testing as these are intended to be non-functional and should be covered by exisinting testing.

## Submission Checklist

- [X] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
