### PR TITLE
Add std::filesystem restriction presubmit

### DIFF
--- a/.github/workflows/rocr-runtime-restrictions.yml
+++ b/.github/workflows/rocr-runtime-restrictions.yml
@@ -31,6 +31,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
+      with:
+        sparse-checkout: 'projects/rocr-runtime'
 
     - name: Apply restriction
       run: |

--- a/.github/workflows/rocr-runtime-restrictions.yml
+++ b/.github/workflows/rocr-runtime-restrictions.yml
@@ -1,0 +1,46 @@
+
+name: rocr-runtime Code Restrictions
+permissions:
+    contents: read
+
+# This workflow ensures that certain code restrictions are applied.
+
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - 'projects/rocr-runtime/runtime/**'
+      - '!**/*.md'
+      - '!**/*.rtf'
+      - '!**/*.rst'
+      - '!**/*.txt'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+
+# rocr-runtime cannot use std::filesystem because of C++ ABI issues when
+# loaded into applications that ship their own C++ standard library (e.g.
+# DaVinci Resolve). See https://github.com/ROCm/rocm-systems/pull/2586 
+# for details.
+
+  no-std-filesystem:
+    runs-on: ubuntu-22.04
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Apply restriction
+      run: |
+        set +e
+        FILES="$(find projects/rocr-runtime/runtime -type f \( -name '*.cpp' -o -name '*.hpp' -o -name '*.h' -o -name '*.cc' \))"
+        GREP="$(grep -E -n 'std::filesystem|<filesystem>' ${FILES})"
+        if [ "${GREP}" != "" ]; then
+          echo -e "\nError! std::filesystem detected in rocr-runtime library sources."
+          echo -e "This is not permitted due to C++ ABI compatibility issues (https://github.com/ROCm/rocm-systems/pull/2586).\n"
+          echo -e "Results:\n"
+          echo "${GREP}"
+          exit 1
+        fi

--- a/.github/workflows/rocr-runtime-restrictions.yml
+++ b/.github/workflows/rocr-runtime-restrictions.yml
@@ -36,9 +36,13 @@ jobs:
 
     - name: Apply restriction
       run: |
-        set +e
-        FILES="$(find projects/rocr-runtime/runtime -type f \( -name '*.cpp' -o -name '*.hpp' -o -name '*.h' -o -name '*.cc' \))"
-        GREP="$(grep -E -n 'std::filesystem|<filesystem>' ${FILES})"
+        GREP="$(grep -R -n \
+          --include='*.cpp' \
+          --include='*.hpp' \
+          --include='*.h' \
+          --include='*.cc' \
+          -E 'std::filesystem|<filesystem>' \
+          projects/rocr-runtime/runtime || true)"
         if [ "${GREP}" != "" ]; then
           echo -e "\nError! std::filesystem detected in rocr-runtime library sources."
           echo -e "This is not permitted due to C++ ABI compatibility issues (https://github.com/ROCm/rocm-systems/pull/2586).\n"


### PR DESCRIPTION
## Motivation

With https://github.com/ROCm/rocm-systems/pull/2586, we're removing the usage of `std::filesystem` to prevent ABI conflicts with applications that ship with their own C++ standard library. Adding presubmit to prevent reintroducing this library usage.

## Technical Details

Following the code restrictions standards set in existing presubmit (https://github.com/ROCm/rocm-systems/blob/develop/.github/workflows/rocprofiler-sdk-restrictions.yml)

- Presubmit will check for the existence of `std::filesystem` or `filesystem` in `projects/rocr-runtime/runtime/` and fail if found. 
- Presubmit will ignore this check in .md, .rtf, .rst and .txt files.

## Test Plan

Tested using [act](https://github.com/nektos/act) tool to run worfklows locally.

## Test Result

PR with `std::filesystem` usage fails with
```
| 
| Error! std::filesystem detected in rocr-runtime library sources.
| This is not permitted due to C++ ABI compatibility issues (https://github.com/ROCm/rocm-systems/pull/2586).
| 
| Results:
| 
| projects/rocr-runtime/runtime/hsa-runtime/core/driver/xdna/amd_xdna_driver.cpp:1107:#include <filesystem>
```
PR without `std::filesystem`
```
[rocr-runtime Code Restrictions/no-std-filesystem]   ✅  Success - Main Apply restriction [58.208143ms]
```

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
