### PR TITLE
Updated PAPI to make net refresh latency configurable

### DIFF
--- a/projects/rocprofiler-systems/docs/how-to/nic-profiling.rst
+++ b/projects/rocprofiler-systems/docs/how-to/nic-profiling.rst
@@ -57,6 +57,7 @@ A sample configuration parameter settings looks like:
   ROCPROFSYS_TIMEMORY_COMPONENTS=wall_clock papi_array network_stats
   ROCPROFSYS_NETWORK_INTERFACE=enp7s0
   ROCPROFSYS_PAPI_EVENTS=net:::enp7s0:tx:byte net:::enp7s0:rx:byte net:::enp7s0:rx:packet net:::enp7s0:tx:packet
+  PAPI_NET_REFRESH_LATENCY=100000
 
 Details of the configuration parameter settings configured in the example are:
 
@@ -64,6 +65,7 @@ Details of the configuration parameter settings configured in the example are:
 * **TIMEMORY**:  Outputs the summaries for the ``wall_clock``, ``papi_array``, and ``network_stats`` components.
 * **Network Interface**: ``enp7s0`` is the predictable network interface device name.
 * **Events for the network device to be sampled**: Bytes transmitted, bytes received, packets transmitted, and packets received.
+* **PAPI_NET_REFRESH_LATENCY**: The shortest latency (in microseconds) with which PAPI updates network statistics. The default value is 1000000 (1s).
 
 The configuration parameter settings can be saved in a configuration file. Here is an example of a complete configuration file, ``rocprofsys.cfg``:
 
@@ -85,7 +87,8 @@ The configuration parameter settings can be saved in a configuration file. Here 
   ROCPROFSYS_USE_PID=OFF
   ROCPROFSYS_OUTPUT_PREFIX=foo/
   ROCPROFSYS_NETWORK_INTERFACE=enp7s0
-  ROCPROFSYS_PAPI_EVENTS = net:::enp7s0:tx:byte net:::enp7s0:rx:byte net:::enp7s0:rx:packet net:::enp7s0:tx:packet
+  ROCPROFSYS_PAPI_EVENTS=net:::enp7s0:tx:byte net:::enp7s0:rx:byte net:::enp7s0:rx:packet net:::enp7s0:tx:packet
+  PAPI_NET_REFRESH_LATENCY=100000
 
 To specify the configuration file, use the ``ROCPROFSYS_CONFIG_FILE`` setting:
 

--- a/projects/rocprofiler-systems/tests/rocprof-sys-nic-perf.cmake
+++ b/projects/rocprofiler-systems/tests/rocprof-sys-nic-perf.cmake
@@ -39,6 +39,7 @@ set(_nic_perf_environment
     "ROCPROFSYS_NETWORK_INTERFACE=${_network_interface}"
     "ROCPROFSYS_PAPI_EVENTS=${_event_list}"
     "ROCPROFSYS_SAMPLING_DELAY=0.05"
+    "PAPI_NET_REFRESH_LATENCY=100000"
 )
 
 # Set _download_url to a large file that will give rocprof-sys-sample time to collect NIC


### PR DESCRIPTION
## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->
This PR makes PAPI net refresh latency configurable. Until now, we were using a version of PAPI
with the net refresh latency hard-coded to 1s, which caused a test to fail sometimes because it ran for too short a time and PAPI hadn't had a chance to collect even a single sample.

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->
Now, net refresh latency is 1s by default, but it can be configured by environment variable PAPI_NET_REFRESH_LATENCY.

PAPI commit used: c27003e1642f1c151c9b18ef9e7610072b3c852d

## JIRA ID
AIPROFSYST-188

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->
Net performance test has to be done on a system with a fast network connection (because if the network connection is slow, the test was passing even before this change):

    ctest -R nic

## Test Result

<!-- Briefly summarize test outcomes. -->
Test passed on my development system.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
