### PR TITLE
Cherry-pick [RCCL] handle net ib request failures

### DIFF
--- a/projects/rccl/ext-src/rocm_netib.patch
+++ b/projects/rccl/ext-src/rocm_netib.patch
@@ -1,5 +1,4 @@
 diff --git a/src/transport/net_ib.cc b/src/transport/net_ib.cc
-index 9bfd8dcf..4d3f0a08 100644
 --- a/src/transport/net_ib.cc
 +++ b/src/transport/net_ib.cc
 @@ -29,6 +29,7 @@
@@ -10,7 +9,7 @@ index 9bfd8dcf..4d3f0a08 100644
  #include "graph/xml.h"
  
  #define MAXSUFFIXSIZE 16
-@@ -110,16 +111,38 @@ struct ncclIbMergedDev ncclIbMergedDevs[MAX_IB_VDEVS];
+@@ -110,6 +111,26 @@ struct ncclIbMergedDev ncclIbMergedDevs[
  struct ncclIbDev ncclIbDevs[MAX_IB_DEVS];
  static std::mutex ncclIbMutex;
  static int ncclIbRelaxedOrderingEnabled = 0;
@@ -37,10 +36,7 @@ index 9bfd8dcf..4d3f0a08 100644
  
  // With ncclNet_v11_t the NCCL core initializes the network plugin per-communicator
  // rather than once for all communicators. However, the internal plugin implementation
- // still assumes the plugin is initialized only once across all communicators. The ref
- // counter makes sure the plugin internally initializes only once. When per communicator
- // context support is added to the plugin the ref counter can be removed.
- static int netRefCount;
+@@ -120,6 +141,8 @@ static int netRefCount;
  
  #define NCCL_IB_LLSTR(ll) (((ll) == IBV_LINK_LAYER_INFINIBAND) ? "IB" : (((ll) == IBV_LINK_LAYER_ETHERNET) ? "RoCE" : "UNSPECIFIED"))
  
@@ -49,7 +45,7 @@ index 9bfd8dcf..4d3f0a08 100644
  #define NCCL_IB_SL_DEFAULT 0
  #define NCCL_IB_TC_DEFAULT 0
  
-@@ -141,6 +164,13 @@ NCCL_PARAM(IbEceEnable,"IB_ECE_ENABLE",1);
+@@ -141,6 +164,13 @@ NCCL_PARAM(IbEceEnable,"IB_ECE_ENABLE",1
  NCCL_PARAM(IbDataDirect,"IB_DATA_DIRECT",1);
  NCCL_PARAM(IbQpsPerConn, "IB_QPS_PER_CONNECTION", 1);
  RCCL_PARAM(IbQpsPerP2p, "IB_QPS_PER_P2P", 0);
@@ -63,7 +59,7 @@ index 9bfd8dcf..4d3f0a08 100644
  
  static ncclResult_t ncclIbStatsInit(struct ncclIbStats* stat) {
    __atomic_store_n(&stat->fatalErrorCount, 0, __ATOMIC_RELAXED);
-@@ -779,6 +809,10 @@ ncclResult_t ncclIbInit(void** ctx, uint64_t commId, ncclNetCommConfig_t* config
+@@ -779,6 +809,10 @@ ncclResult_t ncclIbInit(void** ctx, uint
    static int shownIbHcaEnv = 0;
    if(wrap_ibv_symbols() != ncclSuccess) { return ncclInternalError; }
    if(wrap_mlx5dv_symbols() != ncclSuccess) { INFO(NCCL_NET, "NET/IB : Failed to open mlx5dv symbols. Advance features like CX-8 Direct-NIC will be disabled."); }
@@ -74,7 +70,7 @@ index 9bfd8dcf..4d3f0a08 100644
  
    // Detect IB cards
    int nIbDevs = 0;
-@@ -944,6 +978,37 @@ ncclResult_t ncclIbInit(void** ctx, uint64_t commId, ncclNetCommConfig_t* config
+@@ -944,6 +978,37 @@ ncclResult_t ncclIbInit(void** ctx, uint
      INFO(NCCL_INIT|NCCL_NET, "NET/IB : Using%s %s; OOB %s:%s", line, ncclIbRelaxedOrderingEnabled ? "[RO]" : "",
            ncclIbIfName, ncclSocketToString(&ncclIbIfAddr, addrline));
  
@@ -112,7 +108,7 @@ index 9bfd8dcf..4d3f0a08 100644
    }
  exit:
    ibContext.trafficClass = config->trafficClass;
-@@ -1271,6 +1336,8 @@ struct ncclIbListenComm {
+@@ -1280,6 +1345,8 @@ struct ncclIbListenComm {
    struct ncclIbCommStage stage;
  };
  
@@ -121,7 +117,7 @@ index 9bfd8dcf..4d3f0a08 100644
  struct alignas(64) ncclIbSendFifo {
    uint64_t addr;
    uint64_t size;
-@@ -1281,10 +1348,21 @@ struct alignas(64) ncclIbSendFifo {
+@@ -1290,10 +1357,21 @@ struct alignas(64) ncclIbSendFifo {
    char padding[16];
  };
  
@@ -143,7 +139,7 @@ index 9bfd8dcf..4d3f0a08 100644
  };
  
  struct ncclIbRemSizesFifo {
-@@ -1331,6 +1409,7 @@ struct ncclIbSendComm {
+@@ -1340,6 +1418,7 @@ struct ncclIbSendComm {
    struct ncclIbNetCommBase base;
    // Start with fifo and ibv structs as they have alignment restrictions
    struct ncclIbSendFifo fifo[MAX_REQUESTS][NCCL_NET_IB_MAX_RECVS];
@@ -151,7 +147,7 @@ index 9bfd8dcf..4d3f0a08 100644
    struct ibv_sge sges[NCCL_NET_IB_MAX_RECVS];
    struct ibv_send_wr wrs[NCCL_NET_IB_MAX_RECVS + 1];
    // Each dev correlates to a mergedIbDev
-@@ -1346,6 +1425,7 @@ struct ncclIbSendComm {
+@@ -1355,6 +1434,7 @@ struct ncclIbSendComm {
  static_assert((sizeof(struct ncclIbNetCommBase) % 32) == 0, "ncclIbNetCommBase size must be 32-byte multiple to ensure fifo is at proper offset");
  static_assert((offsetof(struct ncclIbSendComm, fifo) % 32) == 0, "ncclIbSendComm fifo must be 32-byte aligned");
  static_assert((sizeof(struct ncclIbSendFifo) % 32) == 0, "ncclIbSendFifo element size must be 32-byte multiples");
@@ -159,7 +155,7 @@ index 9bfd8dcf..4d3f0a08 100644
  static_assert((offsetof(struct ncclIbSendComm, sges) % 32) == 0, "sges must be 32-byte aligned");
  static_assert((offsetof(struct ncclIbSendComm, wrs) % 32) == 0, "wrs must be 32-byte aligned");
  
-@@ -1360,6 +1440,7 @@ struct ncclIbGpuFlush {
+@@ -1369,6 +1449,7 @@ struct ncclIbGpuFlush {
  
  struct ncclIbRemFifo {
    struct ncclIbSendFifo elems[MAX_REQUESTS][NCCL_NET_IB_MAX_RECVS];
@@ -167,7 +163,7 @@ index 9bfd8dcf..4d3f0a08 100644
    uint64_t fifoTail;
    uint64_t addr;
    uint32_t flags;
-@@ -1415,20 +1496,59 @@ ncclResult_t ncclIbDestroyBase(struct ncclIbNetCommDevBase* base) {
+@@ -1424,20 +1505,59 @@ ncclResult_t ncclIbDestroyBase(struct nc
    return ncclSuccess;
  }
  
@@ -229,7 +225,7 @@ index 9bfd8dcf..4d3f0a08 100644
    struct ibv_qp_attr qpAttr;
    memset(&qpAttr, 0, sizeof(struct ibv_qp_attr));
    qpAttr.qp_state = IBV_QPS_INIT;
-@@ -1438,6 +1558,9 @@ ncclResult_t ncclIbCreateQp(uint8_t ib_port, struct ncclIbNetCommDevBase* base,
+@@ -1447,6 +1567,9 @@ ncclResult_t ncclIbCreateQp(uint8_t ib_p
    NCCLCHECK(wrap_ibv_modify_qp(qp->qp, &qpAttr, IBV_QP_STATE | IBV_QP_PKEY_INDEX | IBV_QP_PORT | IBV_QP_ACCESS_FLAGS));
    TRACE(NCCL_NET, "NET/IB : ncclIbCreateQp port=%d dev=%d devName=%s ndevs=%d nmdevs=%d qpn=%u pkey=%u pd=%p",
      ib_port, base->ibDevN, ncclIbDevs[base->ibDevN].devName, ncclNIbDevs, ncclNMergedIbDevs, qp->qp->qp_num, qpAttr.pkey_index, base->pd);
@@ -239,7 +235,7 @@ index 9bfd8dcf..4d3f0a08 100644
    return ncclSuccess;
  }
  
-@@ -1521,7 +1644,7 @@ fail:
+@@ -1530,16 +1653,21 @@ fail:
    goto exit;
  }
  
@@ -248,10 +244,11 @@ index 9bfd8dcf..4d3f0a08 100644
    ncclResult_t ret = ncclSuccess;
    struct ncclIbHandle* handle = (struct ncclIbHandle*) opaqueHandle;
    struct ncclIbCommStage* stage = &handle->stage;
-@@ -1529,8 +1652,13 @@ ncclResult_t ncclIbConnect(void* ctx, int dev, void* opaqueHandle, void** sendCo
+   struct ncclIbSendComm* comm = (struct ncclIbSendComm*)stage->comm;
    int ready;
    uint8_t link_layer = IBV_LINK_LAYER_UNSPECIFIED;
-   int isP2p = 0; 
+-  int isP2p = 0; 
++  int isP2p = 0;
 +  int channel_id = 0;
    *sendComm = NULL;
  
@@ -262,7 +259,7 @@ index 9bfd8dcf..4d3f0a08 100644
    if (stage->state == ncclIbCommStateConnect)      goto ib_connect_check;
    if (stage->state == ncclIbCommStateSendDevList)  goto ib_send_dev_list;
    if (stage->state == ncclIbCommStateRecvDevList)  goto ib_recv_dev_list;
-@@ -1612,7 +1740,7 @@ ib_recv_dev_list:
+@@ -1621,7 +1749,7 @@ ib_recv_dev_list:
    for (int q = 0; q < comm->base.nqps; q++) {
      ncclIbSendCommDev* commDev = comm->devs + devIndex;
      ncclIbDev* ibDev = ncclIbDevs + commDev->base.ibDevN;
@@ -271,7 +268,7 @@ index 9bfd8dcf..4d3f0a08 100644
      comm->base.qps[q].devIndex = devIndex;
      meta.qpInfo[q].qpn      = comm->base.qps[q].qp->qp_num;
      meta.qpInfo[q].devIndex = comm->base.qps[q].devIndex;
-@@ -1637,7 +1765,11 @@ ib_recv_dev_list:
+@@ -1646,7 +1774,11 @@ ib_recv_dev_list:
      devInfo->lid           = ibDev->portAttr.lid;
      devInfo->ibv_dev_index = commDev->base.ibDevN;
      // Prepare my fifo
@@ -284,7 +281,7 @@ index 9bfd8dcf..4d3f0a08 100644
      devInfo->fifoRkey = commDev->fifoMr->rkey;
  
      // Pack local GID info
-@@ -1680,7 +1812,11 @@ ib_recv_dev_list:
+@@ -1689,7 +1821,11 @@ ib_recv_dev_list:
      }
    }
    config = (ncclNetCommConfig_t*)ctx;
@@ -297,7 +294,7 @@ index 9bfd8dcf..4d3f0a08 100644
    meta.sl = (ncclParamIbSl() != -1) ? ncclParamIbSl() : (config && config->trafficClass != NCCL_NET_TRAFFIC_CLASS_UNDEF) ? config->trafficClass : NCCL_IB_SL_DEFAULT;
    meta.tc = (ncclParamIbTc() != -1) ? ncclParamIbTc() : (config && config->trafficClass != NCCL_NET_TRAFFIC_CLASS_UNDEF) ? config->trafficClass : NCCL_IB_TC_DEFAULT;
    strncpy(meta.devName, mergedDev->devName, MAX_MERGED_DEV_NAME);
-@@ -1825,18 +1961,22 @@ ncclResult_t ncclIbCheckVProps(ncclNetVDeviceProps_t* vProps1, ncclNetVDevicePro
+@@ -1834,18 +1970,22 @@ ncclResult_t ncclIbCheckVProps(ncclNetVD
    return ncclSuccess;
  }
  
@@ -322,7 +319,29 @@ index 9bfd8dcf..4d3f0a08 100644
    if (stage->state == ncclIbCommStateAccept)   goto ib_accept_check;
    if (stage->state == ncclIbCommStateRecvDevList) goto ib_recv_dev_list;
    if (stage->state == ncclIbCommStateSendDevList) goto ib_send_dev_list;
-@@ -1966,7 +2106,7 @@ ib_recv:
+@@ -1894,7 +2040,6 @@ ib_accept:
+   }
+
+   // Reduce the physical device list and store in the connection base
+-  struct ncclIbMergedDev* mergedDev;
+   mergedDev = ncclIbMergedDevs + lComm->dev;
+   NCCLCHECK(ncclIbCheckVProps(&mergedDev->vProps, &remoteVProps));
+   rComm->base.vProps = mergedDev->vProps;
+@@ -1918,13 +2063,6 @@ ib_recv_dev_list:
+   memcpy(&remMeta, stage->buffer, sizeof(struct ncclIbConnectionMetadata));
+
+   // IB setup
+-  // Pre-declare variables because of goto
+-  struct ncclIbDev* ibDev;
+-  int ibDevN;
+-  struct ncclIbRecvCommDev* rCommDev;
+-  struct ncclIbDevInfo* remDevInfo;
+-  struct ncclIbQp* qp;
+-
+   mergedDev = ncclIbMergedDevs + lComm->dev;
+   rComm->base.nRemDevs = remMeta.ndevs;
+   rComm->base.nqps = ncclIbCalculateNqps(remMeta.isP2p, rComm->base.vProps.ndevs,
+@@ -1981,7 +2119,7 @@ ib_recv:
      // Local ibDevN
      ibDevN = rComm->devs[devIndex].base.ibDevN;
      ibDev = ncclIbDevs + ibDevN;
@@ -331,16 +350,14 @@ index 9bfd8dcf..4d3f0a08 100644
      qp->devIndex = devIndex;
      devIndex = (devIndex + 1) % rComm->base.vProps.ndevs;
  
-@@ -1992,16 +2132,22 @@ ib_recv:
- 
-   useDmaBuf  = (ncclIbDmaBufSupport(lComm->dev) == ncclSuccess);
-   rComm->flushEnabled = ((ncclIbGdrSupport() == ncclSuccess || useDmaBuf)
+@@ -2036,14 +2176,20 @@ ib_recv:
+   rComm->flushEnabled = ((peermemAvailable || useDmaBuf)
 -                            && (ncclParamIbGdrFlushDisable() == 0)) ? 1 : 0;              
 +                            && (ncclIbGdrFlushDisable == 0)) ? 1 : 0;
    for (int i = 0; i < rComm->base.vProps.ndevs; i++) {
      rCommDev = rComm->devs + i;
      ibDev = ncclIbDevs + rCommDev->base.ibDevN;
- 
+
      // Retain remote fifo info and prepare my RDMA ops
      rComm->remFifo.addr = remMeta.fifoAddr;
 -    NCCLCHECKGOTO(wrap_ibv_reg_mr(&rCommDev->fifoMr, rCommDev->base.pd, &rComm->remFifo.elems, sizeof(struct ncclIbSendFifo)*MAX_REQUESTS*NCCL_NET_IB_MAX_RECVS, IBV_ACCESS_REMOTE_WRITE|IBV_ACCESS_LOCAL_WRITE|IBV_ACCESS_REMOTE_READ), ret, fail);
@@ -354,10 +371,10 @@ index 9bfd8dcf..4d3f0a08 100644
      rCommDev->fifoSge.lkey = rCommDev->fifoMr->lkey;
 -    if (ncclParamIbUseInline()) rComm->remFifo.flags = IBV_SEND_INLINE;
 +    if (ncclIbUseInline) rComm->remFifo.flags = IBV_SEND_INLINE;
- 
+
      // Allocate Flush dummy buffer for GPU Direct RDMA
      if (rComm->flushEnabled) {
-@@ -2039,7 +2185,7 @@ ib_recv:
+@@ -2048,7 +2194,7 @@ ib_recv:
        rCommDev->gpuFlush.sge.addr = (uint64_t)&rComm->gpuFlushHostMem;
        rCommDev->gpuFlush.sge.length = 1;
        rCommDev->gpuFlush.sge.lkey = rCommDev->gpuFlush.hostMr->lkey;
@@ -366,7 +383,7 @@ index 9bfd8dcf..4d3f0a08 100644
        struct ncclIbDevInfo devInfo;
        devInfo.lid         = ibDev->portAttr.lid;
        devInfo.link_layer  = ibDev->portAttr.link_layer;
-@@ -2257,10 +2403,15 @@ ncclResult_t ncclIbDeregMr(void* comm, void* mhandle) {
+@@ -2270,11 +2416,16 @@ ncclResult_t ncclIbDeregMr(void* comm, v
  
  NCCL_PARAM(IbSplitDataOnQps, "IB_SPLIT_DATA_ON_QPS", 0);
  
@@ -374,6 +391,7 @@ index 9bfd8dcf..4d3f0a08 100644
 +ncclResult_t ncclIbMultiSend(struct ncclIbSendComm* comm, int slot, bool use_write_op) {
    struct ncclIbRequest** reqs = comm->fifoReqs[slot];
    volatile struct ncclIbSendFifo* slots = comm->fifo[slot];
+   ncclResult_t ret = ncclSuccess;
 -  int nreqs = slots[0].nreqs;
 +  int nreqs;
 +  if (rcclCtsOffloadEnabled) {
@@ -384,7 +402,7 @@ index 9bfd8dcf..4d3f0a08 100644
    if (nreqs > NCCL_NET_IB_MAX_RECVS) return ncclInternalError;
  
    uint64_t wr_id = 0ULL;
-@@ -2272,7 +2423,11 @@ ncclResult_t ncclIbMultiSend(struct ncclIbSendComm* comm, int slot) {
+@@ -2286,7 +2437,11 @@ ncclResult_t ncclIbMultiSend(struct nccl
      sge->addr=(uintptr_t)reqs[r]->send.data;
      wr->opcode = IBV_WR_RDMA_WRITE;
      wr->send_flags = 0;
@@ -397,7 +415,7 @@ index 9bfd8dcf..4d3f0a08 100644
      wr->next = wr + 1;
      wr_id += (reqs[r] - comm->base.reqs) << (r*8);
  #ifdef NCCL_ENABLE_NET_PROFILING
-@@ -2283,7 +2438,7 @@ ncclResult_t ncclIbMultiSend(struct ncclIbSendComm* comm, int slot) {
+@@ -2297,7 +2452,7 @@ ncclResult_t ncclIbMultiSend(struct nccl
    // Write size as immediate data. In the case of multi-send, only write
    // 0 or 1 as size to indicate whether there was data sent or received.
    uint32_t immData = 0;
@@ -406,7 +424,7 @@ index 9bfd8dcf..4d3f0a08 100644
      immData = reqs[0]->send.size;
    } else {
      int* sizes = comm->remSizesFifo.elems[slot];
-@@ -2293,22 +2448,24 @@ ncclResult_t ncclIbMultiSend(struct ncclIbSendComm* comm, int slot) {
+@@ -2307,22 +2462,24 @@ ncclResult_t ncclIbMultiSend(struct nccl
    }
  
    struct ibv_send_wr* lastWr = comm->wrs+nreqs-1;
@@ -444,7 +462,7 @@ index 9bfd8dcf..4d3f0a08 100644
    lastWr->next = NULL;
    lastWr->send_flags = IBV_SEND_SIGNALED;
  
-@@ -2324,7 +2481,11 @@ ncclResult_t ncclIbMultiSend(struct ncclIbSendComm* comm, int slot) {
+@@ -2338,7 +2495,11 @@ ncclResult_t ncclIbMultiSend(struct nccl
        //ncclIbAddEvent(reqs[r], devIndex, &comm->devs[devIndex].base);
  
        // Select proper rkey (needed even for 0-size send)
@@ -457,7 +475,7 @@ index 9bfd8dcf..4d3f0a08 100644
  
        int chunkSize = DIVUP(DIVUP(reqs[r]->send.size, nqps), align) * align;
        int length = std::min(reqs[r]->send.size-reqs[r]->send.offset, chunkSize);
-@@ -2340,7 +2501,7 @@ ncclResult_t ncclIbMultiSend(struct ncclIbSendComm* comm, int slot) {
+@@ -2354,7 +2515,7 @@ ncclResult_t ncclIbMultiSend(struct nccl
        }
      }
  
@@ -466,35 +484,37 @@ index 9bfd8dcf..4d3f0a08 100644
        // Also make sure lastWr writes remote sizes using the right lkey
        comm->remSizesFifo.sge.lkey = comm->remSizesFifo.mrs[devIndex]->lkey;
        lastWr->wr.rdma.rkey = comm->remSizesFifo.rkeys[devIndex];
-@@ -2398,32 +2559,46 @@ ncclResult_t ncclIbIsend(void* sendComm, void* data, size_t size, int tag, void*
-   NCCLCHECK(ncclIbStatsCheckFatalCount(&comm->base.stats,__func__));
- 
+@@ -2414,6 +2575,11 @@ ncclResult_t ncclIbIsend(void* sendComm,
+   ncclResult_t ret = ncclSuccess;
+   struct ncclIbRequest* req = NULL;
    struct ncclIbMrHandle* mhandleWrapper = (struct ncclIbMrHandle*) mhandle;
 +  bool use_write_op = false;
 +  if (rcclAinicRoce) {
 +      use_write_op = (*request == (void *)NCCL_NET_OPTIONAL_RECV_COMPLETION) ? true : false;
 +  }
- 
-   // Wait for the receiver to have posted the corresponding receive
++
    int nreqs = 0;
-   volatile struct ncclIbSendFifo* slots;
+   volatile struct ncclIbSendFifo* slots = NULL;
+   int slot = (comm->fifoHead) % MAX_REQUESTS;
+@@ -2427,26 +2593,36 @@ ncclResult_t ncclIbIsend(void* sendComm,
+   }
+   NCCLCHECKGOTO(ncclIbStatsCheckFatalCount(&comm->base.stats,__func__), ret, fail);
  
 +  if (rcclCtsOffloadEnabled) {
 +      nreqs = 1;
 +  }
 +
-   int slot = (comm->fifoHead) % MAX_REQUESTS;
-   struct ncclIbRequest** reqs = comm->fifoReqs[slot];
+   // Wait for the receiver to have posted the corresponding receive
 -  slots = comm->fifo[slot];
--  uint64_t idx = comm->fifoHead+1;
+-  idx = comm->fifoHead+1;
 -  if (slots[0].idx != idx) { *request = NULL; return ncclSuccess; }
 -  nreqs = slots[0].nreqs;
 -  // Wait until all data has arrived
 -  for (int r=1; r<nreqs; r++) while(slots[r].idx != idx);
 -  __sync_synchronize(); // order the nreqsPtr load against tag/rkey/addr loads below
 +  if (!rcclCtsOffloadEnabled) {
-+    slots = comm->fifo[slot];
-+    uint64_t idx = comm->fifoHead+1;
++      slots = comm->fifo[slot];
++    idx = comm->fifoHead+1;
 +    if (slots[0].idx != idx) { *request = NULL; return ncclSuccess; }
 +    nreqs = slots[0].nreqs;
 +    // Wait until all data has arrived
@@ -526,17 +546,17 @@ index 9bfd8dcf..4d3f0a08 100644
 +             r, nreqs, tag, ncclSocketToString(&addr, line), slots[r].size, slots[r].addr, slots[r].rkeys[0]);
 +        return ncclInternalError;
 +      }
-+    } else{
++    } else {
 +      if (reqs[r] != NULL) continue;
      }
  
-     struct ncclIbRequest* req;
-@@ -2467,10 +2642,12 @@ ncclResult_t ncclIbIsend(void* sendComm, void* data, size_t size, int tag, void*
+     NCCLCHECKGOTO(ncclIbGetRequest(&comm->base, &req), ret, fail);
+@@ -2489,10 +2665,12 @@ ncclResult_t ncclIbIsend(void* sendComm,
      }
  
      TIME_START(0);
--    NCCLCHECK(ncclIbMultiSend(comm, slot));
-+    NCCLCHECK(ncclIbMultiSend(comm, slot, use_write_op));
+-    NCCLCHECKGOTO(ncclIbMultiSend(comm, slot), ret, fail);
++    NCCLCHECKGOTO(ncclIbMultiSend(comm, slot, use_write_op), ret, fail);
  
      // Clear slots[0]->nreqs, as well as other fields to help debugging and sanity checks
 -    memset((void*)slots, 0, sizeof(struct ncclIbSendFifo));
@@ -546,7 +566,7 @@ index 9bfd8dcf..4d3f0a08 100644
      memset(reqs, 0, NCCL_NET_IB_MAX_RECVS*sizeof(struct ncclIbRequest*));
      comm->fifoHead++;
      TIME_STOP(0);
-@@ -2483,30 +2660,60 @@ ncclResult_t ncclIbIsend(void* sendComm, void* data, size_t size, int tag, void*
+@@ -2527,30 +2705,60 @@ fail:
  
  ncclResult_t ncclIbPostFifo(struct ncclIbRecvComm* comm, int n, void** data, size_t* sizes, int* tags, void** mhandles, struct ncclIbRequest* req) {
    struct ibv_send_wr wr;
@@ -620,7 +640,7 @@ index 9bfd8dcf..4d3f0a08 100644
    }
    wr.wr.rdma.remote_addr = comm->remFifo.addr + slot*NCCL_NET_IB_MAX_RECVS*sizeof(struct ncclIbSendFifo);
  
-@@ -2514,8 +2721,12 @@ ncclResult_t ncclIbPostFifo(struct ncclIbRecvComm* comm, int n, void** data, siz
+@@ -2558,8 +2766,12 @@ ncclResult_t ncclIbPostFifo(struct ncclI
    wr.wr.rdma.rkey = comm->base.remDevs[ctsQp->remDevIdx].fifoRkey;
  
    // Set the correct sge properties
@@ -635,7 +655,7 @@ index 9bfd8dcf..4d3f0a08 100644
    wr.sg_list = &comm->devs[ctsQp->devIndex].fifoSge;
    wr.num_sge = 1;
  
-@@ -2545,7 +2756,13 @@ ncclResult_t ncclIbPostFifo(struct ncclIbRecvComm* comm, int n, void** data, siz
+@@ -2589,7 +2801,13 @@ ncclResult_t ncclIbPostFifo(struct ncclI
    //
    // slot == devIndex - When writing to fifo slot N, and this QP lives on device index N, it should send signalled.
    // This works out that each fifo posting QP gets drained
@@ -650,7 +670,7 @@ index 9bfd8dcf..4d3f0a08 100644
      wr.send_flags |= IBV_SEND_SIGNALED;
      wr.wr_id = req - comm->base.reqs;
      ncclIbAddEvent(req, ctsQp->devIndex, &comm->devs[ctsQp->devIndex].base);
-@@ -2560,10 +2777,16 @@ ncclResult_t ncclIbPostFifo(struct ncclIbRecvComm* comm, int n, void** data, siz
+@@ -2610,10 +2828,16 @@ ncclResult_t ncclIbPostFifo(struct ncclI
  
    comm->remFifo.fifoTail++;
  
@@ -665,31 +685,33 @@ index 9bfd8dcf..4d3f0a08 100644
 +  ncclResult_t res = ncclSuccess;
 +  bool netOptRecvCompletionEnabled = false;
    struct ncclIbRecvComm* comm = (struct ncclIbRecvComm*)recvComm;
-   if (comm->base.ready == 0) {
-     WARN("NET/IB: ncclIbIrecv() called when comm->base.ready == 0");
-@@ -2573,6 +2796,11 @@ ncclResult_t ncclIbIrecv(void* recvComm, int n, void** data, size_t* sizes, int*
+   ncclResult_t ret = ncclSuccess;
+   struct ncclIbRequest* req = NULL;
+@@ -2629,6 +2853,11 @@ ncclResult_t ncclIbIrecv(void* recvComm,
    if (n > NCCL_NET_IB_MAX_RECVS) return ncclInternalError;
-   NCCLCHECK(ncclIbStatsCheckFatalCount(&comm->base.stats,__func__));
+   NCCLCHECKGOTO(ncclIbStatsCheckFatalCount(&comm->base.stats,__func__), ret, fail);
  
 +  if (rcclAinicRoce) {
 +    if (*request == (void *) NCCL_NET_OPTIONAL_RECV_COMPLETION) {
 +        netOptRecvCompletionEnabled = true;
 +    }
 +  }
-   struct ncclIbRequest* req;
-   NCCLCHECK(ncclIbGetRequest(&comm->base, &req));
+   NCCLCHECKGOTO(ncclIbGetRequest(&comm->base, &req), ret, fail);
    req->type = NCCL_NET_IB_REQ_RECV;
-@@ -2586,50 +2814,65 @@ ncclResult_t ncclIbIrecv(void* recvComm, int n, void** data, size_t* sizes, int*
+   req->sock = &comm->base.sock;
+@@ -2641,44 +2870,54 @@ ncclResult_t ncclIbIrecv(void* recvComm,
      req->devBases[i] = &comm->devs[i].base;
    }
  
--  struct ibv_recv_wr wr;
 -  memset(&wr, 0, sizeof(wr));
 -  wr.wr_id = req - comm->base.reqs;
 -  wr.sg_list = NULL;
 -  wr.num_sge = 0;
+-
+-  TIME_START(1);
+-  // Select either all QPs, or one qp per-device
+-  nqps = ncclParamIbSplitDataOnQps() ? comm->base.nqps : comm->base.nDataQps;
 +  if (!netOptRecvCompletionEnabled) {
-+    struct ibv_recv_wr wr;
 +    memset(&wr, 0, sizeof(wr));
 +    wr.wr_id = req - comm->base.reqs;
 +    wr.sg_list = NULL;
@@ -703,12 +725,14 @@ index 9bfd8dcf..4d3f0a08 100644
 +    const int nqps = ncclParamIbSplitDataOnQps() ? comm->base.nqps : comm->base.nDataQps;
  
 -  // Post recvs
--  struct ibv_recv_wr* bad_wr;
 -  for (int i = 0; i < nqps; i++) {
 -    struct ncclIbQp* qp = comm->base.qps + comm->base.qpIndex;
 -    ncclIbAddEvent(req, qp->devIndex, &comm->devs[qp->devIndex].base);
++    TIME_START(1);
++    // Select either all QPs, or one qp per-device
++    nqps = ncclParamIbSplitDataOnQps() ? comm->base.nqps : comm->base.nDataQps;
++
 +    // Post recvs
-+    struct ibv_recv_wr* bad_wr;
 +    int qpIndex = comm->base.qpIndex;
 +    for (int i = 0; i < nqps; i++) {
 +      int curQpIndex = rcclAinicRoce ? qpIndex : comm->base.qpIndex;
@@ -744,10 +768,10 @@ index 9bfd8dcf..4d3f0a08 100644
 +        req->pInfo[r].nEventHandles++;
 +      }
  #endif
--    NCCLCHECK(wrap_ibv_post_recv(qp->qp, &wr, &bad_wr));
+-    NCCLCHECKGOTO(wrap_ibv_post_recv(qp->qp, &wr, &bad_wr), ret, fail);
 -    comm->base.qpIndex = (comm->base.qpIndex+1)%comm->base.nqps;
 -  }
-+      NCCLCHECKGOTO(wrap_ibv_post_recv(qp->qp, &wr, &bad_wr), res, err);
++      NCCLCHECKGOTO(wrap_ibv_post_recv(qp->qp, &wr, &bad_wr), ret, fail);
 +      // Don't update comm->base.qpIndex yet, we need to run through this same set of QPs
 +      // inside ncclIbPostFifo()
 +      if (rcclAinicRoce) {
@@ -763,21 +787,7 @@ index 9bfd8dcf..4d3f0a08 100644
  
    // Post to FIFO to notify sender
    TIME_START(2);
--  NCCLCHECK(ncclIbPostFifo(comm, n, data, sizes, tags, mhandles, req));
-+  NCCLCHECKGOTO(ncclIbPostFifo(comm, n, data, sizes, tags, mhandles, req), res, err);
-   TIME_STOP(2);
- 
-   *request = req;
-   return ncclSuccess;
-+err:
-+  if (req) {
-+      ncclIbFreeRequest(req);
-+  }
-+  return res;
- }
- 
- ncclResult_t ncclIbIflush(void* recvComm, int n, void** data, int* sizes, void** mhandles, void** request) {
-@@ -2698,6 +2941,8 @@ static int getReqQpIndex(struct ncclIbRequest* req, int request, int qpNumber) {
+@@ -2798,6 +3037,8 @@ static int getReqQpIndex(struct ncclIbRe
  }
  #endif
  
@@ -785,8 +795,8 @@ index 9bfd8dcf..4d3f0a08 100644
 +
  ncclResult_t ncclIbTest(void* request, int* done, int* sizes) {
    struct ncclIbRequest *r = (struct ncclIbRequest*)request;
-   *done = 0;
-@@ -2731,13 +2976,18 @@ ncclResult_t ncclIbTest(void* request, int* done, int* sizes) {
+   ncclResult_t ret = ncclSuccess;
+@@ -2841,13 +3082,17 @@ ncclResult_t ncclIbTest(void* request, i
  
      int totalWrDone = 0;
      int wrDone = 0;
@@ -801,13 +811,12 @@ index 9bfd8dcf..4d3f0a08 100644
        TIME_START(3);
        // If we expect any completions from this device's CQ
        if (r->events[i]) {
--        NCCLCHECK(wrap_ibv_poll_cq(r->devBases[i]->cq, 4, wcs, &wrDone));
-+        NCCLCHECK(wrap_ibv_poll_cq(r->devBases[i]->cq, cqMaxPollEvent,
-+                                   wcs, &wrDone));
-         totalWrDone += wrDone;
-         if (wrDone == 0) { TIME_CANCEL(3); } else { TIME_STOP(3); }
-         if (wrDone == 0) continue;
-@@ -2889,7 +3139,7 @@ ncclResult_t rcclNetP2pPolicy(void* handle, int isP2p) {
+-        ret = wrap_ibv_poll_cq(r->devBases[i]->cq, 4, wcs, &wrDone);
++        ret = wrap_ibv_poll_cq(r->devBases[i]->cq, cqMaxPollEvent, wcs, &wrDone);
+         if (ret != ncclSuccess) {
+           failDevIdx = i;
+           goto fail;
+@@ -3024,7 +3269,7 @@ ncclResult_t rcclNetP2pPolicy(void* hand
  }
  
  ncclNet_t ncclNetIb = {

--- a/projects/rccl/ext-src/rocm_netib.patch
+++ b/projects/rccl/ext-src/rocm_netib.patch
@@ -1,4 +1,5 @@
 diff --git a/src/transport/net_ib.cc b/src/transport/net_ib.cc
+index 17ab50e8f2..661e9eaf68 100644
 --- a/src/transport/net_ib.cc
 +++ b/src/transport/net_ib.cc
 @@ -29,6 +29,7 @@
@@ -9,7 +10,7 @@ diff --git a/src/transport/net_ib.cc b/src/transport/net_ib.cc
  #include "graph/xml.h"
  
  #define MAXSUFFIXSIZE 16
-@@ -110,6 +111,26 @@ struct ncclIbMergedDev ncclIbMergedDevs[
+@@ -110,6 +111,26 @@ struct ncclIbMergedDev ncclIbMergedDevs[MAX_IB_VDEVS];
  struct ncclIbDev ncclIbDevs[MAX_IB_DEVS];
  static std::mutex ncclIbMutex;
  static int ncclIbRelaxedOrderingEnabled = 0;
@@ -45,21 +46,20 @@ diff --git a/src/transport/net_ib.cc b/src/transport/net_ib.cc
  #define NCCL_IB_SL_DEFAULT 0
  #define NCCL_IB_TC_DEFAULT 0
  
-@@ -141,6 +164,13 @@ NCCL_PARAM(IbEceEnable,"IB_ECE_ENABLE",1
- NCCL_PARAM(IbDataDirect,"IB_DATA_DIRECT",1);
+@@ -142,6 +165,12 @@ NCCL_PARAM(IbDataDirect,"IB_DATA_DIRECT",1);
  NCCL_PARAM(IbQpsPerConn, "IB_QPS_PER_CONNECTION", 1);
  RCCL_PARAM(IbQpsPerP2p, "IB_QPS_PER_P2P", 0);
-+NCCL_PARAM(IbGdrFlushDisable, "GDR_FLUSH_DISABLE", 0);
-+
+ 
 +// AMD AINIC
 +RCCL_PARAM(CtsInlineData, "CTS_INLINE_DATA", -1);
 +RCCL_PARAM(CtsOffloadEnabled, "CTS_OFFLOAD_ENABLED", -1);
 +
 +extern int64_t rcclParamAinicRoce();
- 
++
  static ncclResult_t ncclIbStatsInit(struct ncclIbStats* stat) {
    __atomic_store_n(&stat->fatalErrorCount, 0, __ATOMIC_RELAXED);
-@@ -779,6 +809,10 @@ ncclResult_t ncclIbInit(void** ctx, uint
+   return ncclSuccess;
+@@ -779,6 +808,10 @@ ncclResult_t ncclIbInit(void** ctx, uint64_t commId, ncclNetCommConfig_t* config
    static int shownIbHcaEnv = 0;
    if(wrap_ibv_symbols() != ncclSuccess) { return ncclInternalError; }
    if(wrap_mlx5dv_symbols() != ncclSuccess) { INFO(NCCL_NET, "NET/IB : Failed to open mlx5dv symbols. Advance features like CX-8 Direct-NIC will be disabled."); }
@@ -70,14 +70,14 @@ diff --git a/src/transport/net_ib.cc b/src/transport/net_ib.cc
  
    // Detect IB cards
    int nIbDevs = 0;
-@@ -944,6 +978,37 @@ ncclResult_t ncclIbInit(void** ctx, uint
+@@ -944,6 +977,37 @@ ncclResult_t ncclIbInit(void** ctx, uint64_t commId, ncclNetCommConfig_t* config
      INFO(NCCL_INIT|NCCL_NET, "NET/IB : Using%s %s; OOB %s:%s", line, ncclIbRelaxedOrderingEnabled ? "[RO]" : "",
            ncclIbIfName, ncclSocketToString(&ncclIbIfAddr, addrline));
  
 +    ncclIbUseInline = ncclParamIbUseInline();
 +    ncclIbGdrFlushDisable = ncclParamIbGdrFlushDisable();
 +
-+    rcclAinicRoce = ((rcclParamAinicRoce() == 1) ? true : false);
++    rcclAinicRoce = (rcclUseAinic() ? true : false);
 +    if (rcclAinicRoce) {
 +      // for AINIC, these params are defaulted to enabled unless user forces it to disable(0).
 +      rcclCtsInlineData = ((rcclParamCtsInlineData() == 0) ? false : true);
@@ -108,7 +108,7 @@ diff --git a/src/transport/net_ib.cc b/src/transport/net_ib.cc
    }
  exit:
    ibContext.trafficClass = config->trafficClass;
-@@ -1280,6 +1345,8 @@ struct ncclIbListenComm {
+@@ -1280,6 +1344,8 @@ struct ncclIbListenComm {
    struct ncclIbCommStage stage;
  };
  
@@ -117,7 +117,7 @@ diff --git a/src/transport/net_ib.cc b/src/transport/net_ib.cc
  struct alignas(64) ncclIbSendFifo {
    uint64_t addr;
    uint64_t size;
-@@ -1290,10 +1357,21 @@ struct alignas(64) ncclIbSendFifo {
+@@ -1290,10 +1356,21 @@ struct alignas(64) ncclIbSendFifo {
    char padding[16];
  };
  
@@ -139,7 +139,7 @@ diff --git a/src/transport/net_ib.cc b/src/transport/net_ib.cc
  };
  
  struct ncclIbRemSizesFifo {
-@@ -1340,6 +1418,7 @@ struct ncclIbSendComm {
+@@ -1340,6 +1417,7 @@ struct ncclIbSendComm {
    struct ncclIbNetCommBase base;
    // Start with fifo and ibv structs as they have alignment restrictions
    struct ncclIbSendFifo fifo[MAX_REQUESTS][NCCL_NET_IB_MAX_RECVS];
@@ -147,7 +147,7 @@ diff --git a/src/transport/net_ib.cc b/src/transport/net_ib.cc
    struct ibv_sge sges[NCCL_NET_IB_MAX_RECVS];
    struct ibv_send_wr wrs[NCCL_NET_IB_MAX_RECVS + 1];
    // Each dev correlates to a mergedIbDev
-@@ -1355,6 +1434,7 @@ struct ncclIbSendComm {
+@@ -1355,6 +1433,7 @@ struct ncclIbSendComm {
  static_assert((sizeof(struct ncclIbNetCommBase) % 32) == 0, "ncclIbNetCommBase size must be 32-byte multiple to ensure fifo is at proper offset");
  static_assert((offsetof(struct ncclIbSendComm, fifo) % 32) == 0, "ncclIbSendComm fifo must be 32-byte aligned");
  static_assert((sizeof(struct ncclIbSendFifo) % 32) == 0, "ncclIbSendFifo element size must be 32-byte multiples");
@@ -155,7 +155,7 @@ diff --git a/src/transport/net_ib.cc b/src/transport/net_ib.cc
  static_assert((offsetof(struct ncclIbSendComm, sges) % 32) == 0, "sges must be 32-byte aligned");
  static_assert((offsetof(struct ncclIbSendComm, wrs) % 32) == 0, "wrs must be 32-byte aligned");
  
-@@ -1369,6 +1449,7 @@ struct ncclIbGpuFlush {
+@@ -1369,6 +1448,7 @@ struct ncclIbGpuFlush {
  
  struct ncclIbRemFifo {
    struct ncclIbSendFifo elems[MAX_REQUESTS][NCCL_NET_IB_MAX_RECVS];
@@ -163,7 +163,7 @@ diff --git a/src/transport/net_ib.cc b/src/transport/net_ib.cc
    uint64_t fifoTail;
    uint64_t addr;
    uint32_t flags;
-@@ -1424,20 +1505,59 @@ ncclResult_t ncclIbDestroyBase(struct nc
+@@ -1424,20 +1504,59 @@ ncclResult_t ncclIbDestroyBase(struct ncclIbNetCommDevBase* base) {
    return ncclSuccess;
  }
  
@@ -225,7 +225,7 @@ diff --git a/src/transport/net_ib.cc b/src/transport/net_ib.cc
    struct ibv_qp_attr qpAttr;
    memset(&qpAttr, 0, sizeof(struct ibv_qp_attr));
    qpAttr.qp_state = IBV_QPS_INIT;
-@@ -1447,6 +1567,9 @@ ncclResult_t ncclIbCreateQp(uint8_t ib_p
+@@ -1447,6 +1566,9 @@ ncclResult_t ncclIbCreateQp(uint8_t ib_port, struct ncclIbNetCommDevBase* base,
    NCCLCHECK(wrap_ibv_modify_qp(qp->qp, &qpAttr, IBV_QP_STATE | IBV_QP_PKEY_INDEX | IBV_QP_PORT | IBV_QP_ACCESS_FLAGS));
    TRACE(NCCL_NET, "NET/IB : ncclIbCreateQp port=%d dev=%d devName=%s ndevs=%d nmdevs=%d qpn=%u pkey=%u pd=%p",
      ib_port, base->ibDevN, ncclIbDevs[base->ibDevN].devName, ncclNIbDevs, ncclNMergedIbDevs, qp->qp->qp_num, qpAttr.pkey_index, base->pd);
@@ -235,7 +235,7 @@ diff --git a/src/transport/net_ib.cc b/src/transport/net_ib.cc
    return ncclSuccess;
  }
  
-@@ -1530,16 +1653,21 @@ fail:
+@@ -1530,16 +1652,21 @@ fail:
    goto exit;
  }
  
@@ -259,7 +259,7 @@ diff --git a/src/transport/net_ib.cc b/src/transport/net_ib.cc
    if (stage->state == ncclIbCommStateConnect)      goto ib_connect_check;
    if (stage->state == ncclIbCommStateSendDevList)  goto ib_send_dev_list;
    if (stage->state == ncclIbCommStateRecvDevList)  goto ib_recv_dev_list;
-@@ -1621,7 +1749,7 @@ ib_recv_dev_list:
+@@ -1621,7 +1748,7 @@ ib_recv_dev_list:
    for (int q = 0; q < comm->base.nqps; q++) {
      ncclIbSendCommDev* commDev = comm->devs + devIndex;
      ncclIbDev* ibDev = ncclIbDevs + commDev->base.ibDevN;
@@ -268,7 +268,7 @@ diff --git a/src/transport/net_ib.cc b/src/transport/net_ib.cc
      comm->base.qps[q].devIndex = devIndex;
      meta.qpInfo[q].qpn      = comm->base.qps[q].qp->qp_num;
      meta.qpInfo[q].devIndex = comm->base.qps[q].devIndex;
-@@ -1646,7 +1774,11 @@ ib_recv_dev_list:
+@@ -1646,7 +1773,11 @@ ib_recv_dev_list:
      devInfo->lid           = ibDev->portAttr.lid;
      devInfo->ibv_dev_index = commDev->base.ibDevN;
      // Prepare my fifo
@@ -281,7 +281,7 @@ diff --git a/src/transport/net_ib.cc b/src/transport/net_ib.cc
      devInfo->fifoRkey = commDev->fifoMr->rkey;
  
      // Pack local GID info
-@@ -1689,7 +1821,11 @@ ib_recv_dev_list:
+@@ -1689,7 +1820,11 @@ ib_recv_dev_list:
      }
    }
    config = (ncclNetCommConfig_t*)ctx;
@@ -294,11 +294,8 @@ diff --git a/src/transport/net_ib.cc b/src/transport/net_ib.cc
    meta.sl = (ncclParamIbSl() != -1) ? ncclParamIbSl() : (config && config->trafficClass != NCCL_NET_TRAFFIC_CLASS_UNDEF) ? config->trafficClass : NCCL_IB_SL_DEFAULT;
    meta.tc = (ncclParamIbTc() != -1) ? ncclParamIbTc() : (config && config->trafficClass != NCCL_NET_TRAFFIC_CLASS_UNDEF) ? config->trafficClass : NCCL_IB_TC_DEFAULT;
    strncpy(meta.devName, mergedDev->devName, MAX_MERGED_DEV_NAME);
-@@ -1834,18 +1970,22 @@ ncclResult_t ncclIbCheckVProps(ncclNetVD
-   return ncclSuccess;
- }
- 
--NCCL_PARAM(IbGdrFlushDisable, "GDR_FLUSH_DISABLE", 0);
+@@ -1837,15 +1972,27 @@ ncclResult_t ncclIbCheckVProps(ncclNetVDeviceProps_t* vProps1, ncclNetVDevicePro
+ NCCL_PARAM(IbGdrFlushDisable, "GDR_FLUSH_DISABLE", 0);
  RCCL_PARAM(IbGdrFlushGpuMemNoRelaxedOrdering, "GDR_FLUSH_GPU_MEM_NO_RELAXED_ORDERING", 1);
  
 -ncclResult_t ncclIbAccept(void* listenComm, void** recvComm, ncclNetDeviceHandle_t** /*recvDevComm*/) {
@@ -310,6 +307,13 @@ diff --git a/src/transport/net_ib.cc b/src/transport/net_ib.cc
    int ready;
    int link_layer = IBV_LINK_LAYER_UNSPECIFIED;
 +  int channel_id = 0;
++  // Pre-declare variables because of goto
++  struct ncclIbDev* ibDev;
++  int ibDevN;
++  struct ncclIbRecvCommDev* rCommDev;
++  struct ncclIbDevInfo* remDevInfo;
++  struct ncclIbQp* qp;
++  struct ncclIbMergedDev* mergedDev;
    *recvComm = NULL;
  
 +  if (rcclAinicRoce) {
@@ -319,17 +323,17 @@ diff --git a/src/transport/net_ib.cc b/src/transport/net_ib.cc
    if (stage->state == ncclIbCommStateAccept)   goto ib_accept_check;
    if (stage->state == ncclIbCommStateRecvDevList) goto ib_recv_dev_list;
    if (stage->state == ncclIbCommStateSendDevList) goto ib_send_dev_list;
-@@ -1894,7 +2040,6 @@ ib_accept:
+@@ -1887,7 +2034,6 @@ ib_recv_dev_list:
    }
-
+ 
    // Reduce the physical device list and store in the connection base
 -  struct ncclIbMergedDev* mergedDev;
    mergedDev = ncclIbMergedDevs + lComm->dev;
    NCCLCHECK(ncclIbCheckVProps(&mergedDev->vProps, &remoteVProps));
    rComm->base.vProps = mergedDev->vProps;
-@@ -1918,13 +2063,6 @@ ib_recv_dev_list:
+@@ -1911,12 +2057,6 @@ ib_recv:
    memcpy(&remMeta, stage->buffer, sizeof(struct ncclIbConnectionMetadata));
-
+ 
    // IB setup
 -  // Pre-declare variables because of goto
 -  struct ncclIbDev* ibDev;
@@ -337,11 +341,10 @@ diff --git a/src/transport/net_ib.cc b/src/transport/net_ib.cc
 -  struct ncclIbRecvCommDev* rCommDev;
 -  struct ncclIbDevInfo* remDevInfo;
 -  struct ncclIbQp* qp;
--
+   bool useDmaBuf;
+ 
    mergedDev = ncclIbMergedDevs + lComm->dev;
-   rComm->base.nRemDevs = remMeta.ndevs;
-   rComm->base.nqps = ncclIbCalculateNqps(remMeta.isP2p, rComm->base.vProps.ndevs,
-@@ -1981,7 +2119,7 @@ ib_recv:
+@@ -1975,7 +2115,7 @@ ib_recv:
      // Local ibDevN
      ibDevN = rComm->devs[devIndex].base.ibDevN;
      ibDev = ncclIbDevs + ibDevN;
@@ -350,14 +353,16 @@ diff --git a/src/transport/net_ib.cc b/src/transport/net_ib.cc
      qp->devIndex = devIndex;
      devIndex = (devIndex + 1) % rComm->base.vProps.ndevs;
  
-@@ -2036,14 +2176,20 @@ ib_recv:
-   rComm->flushEnabled = ((peermemAvailable || useDmaBuf)
+@@ -2001,16 +2141,22 @@ ib_recv:
+ 
+   useDmaBuf  = (ncclIbDmaBufSupport(lComm->dev) == ncclSuccess && ncclParamDmaBufEnable());
+   rComm->flushEnabled = ((ncclIbGdrSupport() == ncclSuccess || useDmaBuf)
 -                            && (ncclParamIbGdrFlushDisable() == 0)) ? 1 : 0;              
 +                            && (ncclIbGdrFlushDisable == 0)) ? 1 : 0;
    for (int i = 0; i < rComm->base.vProps.ndevs; i++) {
      rCommDev = rComm->devs + i;
      ibDev = ncclIbDevs + rCommDev->base.ibDevN;
-
+ 
      // Retain remote fifo info and prepare my RDMA ops
      rComm->remFifo.addr = remMeta.fifoAddr;
 -    NCCLCHECKGOTO(wrap_ibv_reg_mr(&rCommDev->fifoMr, rCommDev->base.pd, &rComm->remFifo.elems, sizeof(struct ncclIbSendFifo)*MAX_REQUESTS*NCCL_NET_IB_MAX_RECVS, IBV_ACCESS_REMOTE_WRITE|IBV_ACCESS_LOCAL_WRITE|IBV_ACCESS_REMOTE_READ), ret, fail);
@@ -371,7 +376,7 @@ diff --git a/src/transport/net_ib.cc b/src/transport/net_ib.cc
      rCommDev->fifoSge.lkey = rCommDev->fifoMr->lkey;
 -    if (ncclParamIbUseInline()) rComm->remFifo.flags = IBV_SEND_INLINE;
 +    if (ncclIbUseInline) rComm->remFifo.flags = IBV_SEND_INLINE;
-
+ 
      // Allocate Flush dummy buffer for GPU Direct RDMA
      if (rComm->flushEnabled) {
 @@ -2048,7 +2194,7 @@ ib_recv:
@@ -383,7 +388,7 @@ diff --git a/src/transport/net_ib.cc b/src/transport/net_ib.cc
        struct ncclIbDevInfo devInfo;
        devInfo.lid         = ibDev->portAttr.lid;
        devInfo.link_layer  = ibDev->portAttr.link_layer;
-@@ -2270,11 +2416,16 @@ ncclResult_t ncclIbDeregMr(void* comm, v
+@@ -2270,11 +2416,16 @@ ncclResult_t ncclIbDeregMr(void* comm, void* mhandle) {
  
  NCCL_PARAM(IbSplitDataOnQps, "IB_SPLIT_DATA_ON_QPS", 0);
  
@@ -402,7 +407,7 @@ diff --git a/src/transport/net_ib.cc b/src/transport/net_ib.cc
    if (nreqs > NCCL_NET_IB_MAX_RECVS) return ncclInternalError;
  
    uint64_t wr_id = 0ULL;
-@@ -2286,7 +2437,11 @@ ncclResult_t ncclIbMultiSend(struct nccl
+@@ -2286,7 +2437,11 @@ ncclResult_t ncclIbMultiSend(struct ncclIbSendComm* comm, int slot) {
      sge->addr=(uintptr_t)reqs[r]->send.data;
      wr->opcode = IBV_WR_RDMA_WRITE;
      wr->send_flags = 0;
@@ -415,7 +420,7 @@ diff --git a/src/transport/net_ib.cc b/src/transport/net_ib.cc
      wr->next = wr + 1;
      wr_id += (reqs[r] - comm->base.reqs) << (r*8);
  #ifdef NCCL_ENABLE_NET_PROFILING
-@@ -2297,7 +2452,7 @@ ncclResult_t ncclIbMultiSend(struct nccl
+@@ -2297,7 +2452,7 @@ ncclResult_t ncclIbMultiSend(struct ncclIbSendComm* comm, int slot) {
    // Write size as immediate data. In the case of multi-send, only write
    // 0 or 1 as size to indicate whether there was data sent or received.
    uint32_t immData = 0;
@@ -424,7 +429,7 @@ diff --git a/src/transport/net_ib.cc b/src/transport/net_ib.cc
      immData = reqs[0]->send.size;
    } else {
      int* sizes = comm->remSizesFifo.elems[slot];
-@@ -2307,22 +2462,24 @@ ncclResult_t ncclIbMultiSend(struct nccl
+@@ -2307,22 +2462,24 @@ ncclResult_t ncclIbMultiSend(struct ncclIbSendComm* comm, int slot) {
    }
  
    struct ibv_send_wr* lastWr = comm->wrs+nreqs-1;
@@ -462,7 +467,7 @@ diff --git a/src/transport/net_ib.cc b/src/transport/net_ib.cc
    lastWr->next = NULL;
    lastWr->send_flags = IBV_SEND_SIGNALED;
  
-@@ -2338,7 +2495,11 @@ ncclResult_t ncclIbMultiSend(struct nccl
+@@ -2338,7 +2495,11 @@ ncclResult_t ncclIbMultiSend(struct ncclIbSendComm* comm, int slot) {
        //ncclIbAddEvent(reqs[r], devIndex, &comm->devs[devIndex].base);
  
        // Select proper rkey (needed even for 0-size send)
@@ -475,7 +480,7 @@ diff --git a/src/transport/net_ib.cc b/src/transport/net_ib.cc
  
        int chunkSize = DIVUP(DIVUP(reqs[r]->send.size, nqps), align) * align;
        int length = std::min(reqs[r]->send.size-reqs[r]->send.offset, chunkSize);
-@@ -2354,7 +2515,7 @@ ncclResult_t ncclIbMultiSend(struct nccl
+@@ -2354,7 +2515,7 @@ ncclResult_t ncclIbMultiSend(struct ncclIbSendComm* comm, int slot) {
        }
      }
  
@@ -484,7 +489,7 @@ diff --git a/src/transport/net_ib.cc b/src/transport/net_ib.cc
        // Also make sure lastWr writes remote sizes using the right lkey
        comm->remSizesFifo.sge.lkey = comm->remSizesFifo.mrs[devIndex]->lkey;
        lastWr->wr.rdma.rkey = comm->remSizesFifo.rkeys[devIndex];
-@@ -2414,6 +2575,11 @@ ncclResult_t ncclIbIsend(void* sendComm,
+@@ -2414,6 +2575,11 @@ ncclResult_t ncclIbIsend(void* sendComm, void* data, size_t size, int tag, void*
    ncclResult_t ret = ncclSuccess;
    struct ncclIbRequest* req = NULL;
    struct ncclIbMrHandle* mhandleWrapper = (struct ncclIbMrHandle*) mhandle;
@@ -496,7 +501,7 @@ diff --git a/src/transport/net_ib.cc b/src/transport/net_ib.cc
    int nreqs = 0;
    volatile struct ncclIbSendFifo* slots = NULL;
    int slot = (comm->fifoHead) % MAX_REQUESTS;
-@@ -2427,26 +2593,36 @@ ncclResult_t ncclIbIsend(void* sendComm,
+@@ -2427,26 +2593,36 @@ ncclResult_t ncclIbIsend(void* sendComm, void* data, size_t size, int tag, void*
    }
    NCCLCHECKGOTO(ncclIbStatsCheckFatalCount(&comm->base.stats,__func__), ret, fail);
  
@@ -551,7 +556,7 @@ diff --git a/src/transport/net_ib.cc b/src/transport/net_ib.cc
      }
  
      NCCLCHECKGOTO(ncclIbGetRequest(&comm->base, &req), ret, fail);
-@@ -2489,10 +2665,12 @@ ncclResult_t ncclIbIsend(void* sendComm,
+@@ -2489,10 +2665,12 @@ ncclResult_t ncclIbIsend(void* sendComm, void* data, size_t size, int tag, void*
      }
  
      TIME_START(0);
@@ -616,13 +621,13 @@ diff --git a/src/transport/net_ib.cc b/src/transport/net_ib.cc
 +      localElemCtsInline[i].tag = tags[i];
 +      localElemCtsInline[i].idx = comm->remFifo.fifoTail+1;
 +      localElemRef = (uint64_t)localElemCtsInline;
-+
-+    } else {
-+      localElem[i].addr = (uint64_t)data[i];
  
 -    // Send all applicable rkeys
 -    for (int j = 0; j < comm->base.vProps.ndevs; j++)
 -      localElem[i].rkeys[j] = mhandleWrapper->mrs[j]->rkey;
++    } else {
++      localElem[i].addr = (uint64_t)data[i];
++
 +      // Send all applicable rkeys
 +      for (int j = 0; j < comm->base.vProps.ndevs; j++)
 +        localElem[i].rkeys[j] = mhandleWrapper->mrs[j]->rkey;
@@ -640,7 +645,7 @@ diff --git a/src/transport/net_ib.cc b/src/transport/net_ib.cc
    }
    wr.wr.rdma.remote_addr = comm->remFifo.addr + slot*NCCL_NET_IB_MAX_RECVS*sizeof(struct ncclIbSendFifo);
  
-@@ -2558,8 +2766,12 @@ ncclResult_t ncclIbPostFifo(struct ncclI
+@@ -2558,8 +2766,12 @@ ncclResult_t ncclIbPostFifo(struct ncclIbRecvComm* comm, int n, void** data, siz
    wr.wr.rdma.rkey = comm->base.remDevs[ctsQp->remDevIdx].fifoRkey;
  
    // Set the correct sge properties
@@ -655,7 +660,7 @@ diff --git a/src/transport/net_ib.cc b/src/transport/net_ib.cc
    wr.sg_list = &comm->devs[ctsQp->devIndex].fifoSge;
    wr.num_sge = 1;
  
-@@ -2589,7 +2801,13 @@ ncclResult_t ncclIbPostFifo(struct ncclI
+@@ -2589,7 +2801,13 @@ ncclResult_t ncclIbPostFifo(struct ncclIbRecvComm* comm, int n, void** data, siz
    //
    // slot == devIndex - When writing to fifo slot N, and this QP lives on device index N, it should send signalled.
    // This works out that each fifo posting QP gets drained
@@ -670,7 +675,7 @@ diff --git a/src/transport/net_ib.cc b/src/transport/net_ib.cc
      wr.send_flags |= IBV_SEND_SIGNALED;
      wr.wr_id = req - comm->base.reqs;
      ncclIbAddEvent(req, ctsQp->devIndex, &comm->devs[ctsQp->devIndex].base);
-@@ -2610,10 +2828,16 @@ ncclResult_t ncclIbPostFifo(struct ncclI
+@@ -2610,10 +2828,16 @@ ncclResult_t ncclIbPostFifo(struct ncclIbRecvComm* comm, int n, void** data, siz
  
    comm->remFifo.fifoTail++;
  
@@ -687,7 +692,7 @@ diff --git a/src/transport/net_ib.cc b/src/transport/net_ib.cc
    struct ncclIbRecvComm* comm = (struct ncclIbRecvComm*)recvComm;
    ncclResult_t ret = ncclSuccess;
    struct ncclIbRequest* req = NULL;
-@@ -2629,6 +2853,11 @@ ncclResult_t ncclIbIrecv(void* recvComm,
+@@ -2629,6 +2853,11 @@ ncclResult_t ncclIbIrecv(void* recvComm, int n, void** data, size_t* sizes, int*
    if (n > NCCL_NET_IB_MAX_RECVS) return ncclInternalError;
    NCCLCHECKGOTO(ncclIbStatsCheckFatalCount(&comm->base.stats,__func__), ret, fail);
  
@@ -699,7 +704,7 @@ diff --git a/src/transport/net_ib.cc b/src/transport/net_ib.cc
    NCCLCHECKGOTO(ncclIbGetRequest(&comm->base, &req), ret, fail);
    req->type = NCCL_NET_IB_REQ_RECV;
    req->sock = &comm->base.sock;
-@@ -2641,44 +2870,54 @@ ncclResult_t ncclIbIrecv(void* recvComm,
+@@ -2641,40 +2870,50 @@ ncclResult_t ncclIbIrecv(void* recvComm, int n, void** data, size_t* sizes, int*
      req->devBases[i] = &comm->devs[i].base;
    }
  
@@ -707,10 +712,6 @@ diff --git a/src/transport/net_ib.cc b/src/transport/net_ib.cc
 -  wr.wr_id = req - comm->base.reqs;
 -  wr.sg_list = NULL;
 -  wr.num_sge = 0;
--
--  TIME_START(1);
--  // Select either all QPs, or one qp per-device
--  nqps = ncclParamIbSplitDataOnQps() ? comm->base.nqps : comm->base.nDataQps;
 +  if (!netOptRecvCompletionEnabled) {
 +    memset(&wr, 0, sizeof(wr));
 +    wr.wr_id = req - comm->base.reqs;
@@ -719,19 +720,15 @@ diff --git a/src/transport/net_ib.cc b/src/transport/net_ib.cc
  
 -  TIME_START(1);
 -  // Select either all QPs, or one qp per-device
--  const int nqps = ncclParamIbSplitDataOnQps() ? comm->base.nqps : comm->base.nDataQps;
+-  nqps = ncclParamIbSplitDataOnQps() ? comm->base.nqps : comm->base.nDataQps;
 +    TIME_START(1);
 +    // Select either all QPs, or one qp per-device
-+    const int nqps = ncclParamIbSplitDataOnQps() ? comm->base.nqps : comm->base.nDataQps;
++    nqps = ncclParamIbSplitDataOnQps() ? comm->base.nqps : comm->base.nDataQps;
  
 -  // Post recvs
 -  for (int i = 0; i < nqps; i++) {
 -    struct ncclIbQp* qp = comm->base.qps + comm->base.qpIndex;
 -    ncclIbAddEvent(req, qp->devIndex, &comm->devs[qp->devIndex].base);
-+    TIME_START(1);
-+    // Select either all QPs, or one qp per-device
-+    nqps = ncclParamIbSplitDataOnQps() ? comm->base.nqps : comm->base.nDataQps;
-+
 +    // Post recvs
 +    int qpIndex = comm->base.qpIndex;
 +    for (int i = 0; i < nqps; i++) {
@@ -787,7 +784,7 @@ diff --git a/src/transport/net_ib.cc b/src/transport/net_ib.cc
  
    // Post to FIFO to notify sender
    TIME_START(2);
-@@ -2798,6 +3037,8 @@ static int getReqQpIndex(struct ncclIbRe
+@@ -2798,6 +3037,8 @@ static int getReqQpIndex(struct ncclIbRequest* req, int request, int qpNumber) {
  }
  #endif
  
@@ -796,7 +793,7 @@ diff --git a/src/transport/net_ib.cc b/src/transport/net_ib.cc
  ncclResult_t ncclIbTest(void* request, int* done, int* sizes) {
    struct ncclIbRequest *r = (struct ncclIbRequest*)request;
    ncclResult_t ret = ncclSuccess;
-@@ -2841,13 +3082,17 @@ ncclResult_t ncclIbTest(void* request, i
+@@ -2841,13 +3082,17 @@ ncclResult_t ncclIbTest(void* request, int* done, int* sizes) {
  
      int totalWrDone = 0;
      int wrDone = 0;
@@ -816,7 +813,7 @@ diff --git a/src/transport/net_ib.cc b/src/transport/net_ib.cc
          if (ret != ncclSuccess) {
            failDevIdx = i;
            goto fail;
-@@ -3024,7 +3269,7 @@ ncclResult_t rcclNetP2pPolicy(void* hand
+@@ -3024,7 +3269,7 @@ ncclResult_t rcclNetP2pPolicy(void* handle, int isP2p) {
  }
  
  ncclNet_t ncclNetIb = {

--- a/projects/rccl/ext-src/rocm_netib.patch
+++ b/projects/rccl/ext-src/rocm_netib.patch
@@ -1,5 +1,5 @@
 diff --git a/src/transport/net_ib.cc b/src/transport/net_ib.cc
-index 17ab50e8f2..661e9eaf68 100644
+index 17ab50e8f2..c6051c4729 100644
 --- a/src/transport/net_ib.cc
 +++ b/src/transport/net_ib.cc
 @@ -29,6 +29,7 @@
@@ -46,20 +46,21 @@ index 17ab50e8f2..661e9eaf68 100644
  #define NCCL_IB_SL_DEFAULT 0
  #define NCCL_IB_TC_DEFAULT 0
  
-@@ -142,6 +165,12 @@ NCCL_PARAM(IbDataDirect,"IB_DATA_DIRECT",1);
+@@ -141,6 +164,13 @@ NCCL_PARAM(IbEceEnable,"IB_ECE_ENABLE",1);
+ NCCL_PARAM(IbDataDirect,"IB_DATA_DIRECT",1);
  NCCL_PARAM(IbQpsPerConn, "IB_QPS_PER_CONNECTION", 1);
  RCCL_PARAM(IbQpsPerP2p, "IB_QPS_PER_P2P", 0);
- 
++NCCL_PARAM(IbGdrFlushDisable, "GDR_FLUSH_DISABLE", 0);
++
 +// AMD AINIC
 +RCCL_PARAM(CtsInlineData, "CTS_INLINE_DATA", -1);
 +RCCL_PARAM(CtsOffloadEnabled, "CTS_OFFLOAD_ENABLED", -1);
 +
 +extern int64_t rcclParamAinicRoce();
-+
+ 
  static ncclResult_t ncclIbStatsInit(struct ncclIbStats* stat) {
    __atomic_store_n(&stat->fatalErrorCount, 0, __ATOMIC_RELAXED);
-   return ncclSuccess;
-@@ -779,6 +808,10 @@ ncclResult_t ncclIbInit(void** ctx, uint64_t commId, ncclNetCommConfig_t* config
+@@ -779,6 +809,10 @@ ncclResult_t ncclIbInit(void** ctx, uint64_t commId, ncclNetCommConfig_t* config
    static int shownIbHcaEnv = 0;
    if(wrap_ibv_symbols() != ncclSuccess) { return ncclInternalError; }
    if(wrap_mlx5dv_symbols() != ncclSuccess) { INFO(NCCL_NET, "NET/IB : Failed to open mlx5dv symbols. Advance features like CX-8 Direct-NIC will be disabled."); }
@@ -70,14 +71,14 @@ index 17ab50e8f2..661e9eaf68 100644
  
    // Detect IB cards
    int nIbDevs = 0;
-@@ -944,6 +977,37 @@ ncclResult_t ncclIbInit(void** ctx, uint64_t commId, ncclNetCommConfig_t* config
+@@ -944,6 +978,37 @@ ncclResult_t ncclIbInit(void** ctx, uint64_t commId, ncclNetCommConfig_t* config
      INFO(NCCL_INIT|NCCL_NET, "NET/IB : Using%s %s; OOB %s:%s", line, ncclIbRelaxedOrderingEnabled ? "[RO]" : "",
            ncclIbIfName, ncclSocketToString(&ncclIbIfAddr, addrline));
  
 +    ncclIbUseInline = ncclParamIbUseInline();
 +    ncclIbGdrFlushDisable = ncclParamIbGdrFlushDisable();
 +
-+    rcclAinicRoce = (rcclUseAinic() ? true : false);
++    rcclAinicRoce = (rcclParamAinicRoce() ? true : false);
 +    if (rcclAinicRoce) {
 +      // for AINIC, these params are defaulted to enabled unless user forces it to disable(0).
 +      rcclCtsInlineData = ((rcclParamCtsInlineData() == 0) ? false : true);
@@ -108,7 +109,7 @@ index 17ab50e8f2..661e9eaf68 100644
    }
  exit:
    ibContext.trafficClass = config->trafficClass;
-@@ -1280,6 +1344,8 @@ struct ncclIbListenComm {
+@@ -1280,6 +1345,8 @@ struct ncclIbListenComm {
    struct ncclIbCommStage stage;
  };
  
@@ -117,7 +118,7 @@ index 17ab50e8f2..661e9eaf68 100644
  struct alignas(64) ncclIbSendFifo {
    uint64_t addr;
    uint64_t size;
-@@ -1290,10 +1356,21 @@ struct alignas(64) ncclIbSendFifo {
+@@ -1290,10 +1357,21 @@ struct alignas(64) ncclIbSendFifo {
    char padding[16];
  };
  
@@ -139,7 +140,7 @@ index 17ab50e8f2..661e9eaf68 100644
  };
  
  struct ncclIbRemSizesFifo {
-@@ -1340,6 +1417,7 @@ struct ncclIbSendComm {
+@@ -1340,6 +1418,7 @@ struct ncclIbSendComm {
    struct ncclIbNetCommBase base;
    // Start with fifo and ibv structs as they have alignment restrictions
    struct ncclIbSendFifo fifo[MAX_REQUESTS][NCCL_NET_IB_MAX_RECVS];
@@ -147,7 +148,7 @@ index 17ab50e8f2..661e9eaf68 100644
    struct ibv_sge sges[NCCL_NET_IB_MAX_RECVS];
    struct ibv_send_wr wrs[NCCL_NET_IB_MAX_RECVS + 1];
    // Each dev correlates to a mergedIbDev
-@@ -1355,6 +1433,7 @@ struct ncclIbSendComm {
+@@ -1355,6 +1434,7 @@ struct ncclIbSendComm {
  static_assert((sizeof(struct ncclIbNetCommBase) % 32) == 0, "ncclIbNetCommBase size must be 32-byte multiple to ensure fifo is at proper offset");
  static_assert((offsetof(struct ncclIbSendComm, fifo) % 32) == 0, "ncclIbSendComm fifo must be 32-byte aligned");
  static_assert((sizeof(struct ncclIbSendFifo) % 32) == 0, "ncclIbSendFifo element size must be 32-byte multiples");
@@ -155,7 +156,7 @@ index 17ab50e8f2..661e9eaf68 100644
  static_assert((offsetof(struct ncclIbSendComm, sges) % 32) == 0, "sges must be 32-byte aligned");
  static_assert((offsetof(struct ncclIbSendComm, wrs) % 32) == 0, "wrs must be 32-byte aligned");
  
-@@ -1369,6 +1448,7 @@ struct ncclIbGpuFlush {
+@@ -1369,6 +1449,7 @@ struct ncclIbGpuFlush {
  
  struct ncclIbRemFifo {
    struct ncclIbSendFifo elems[MAX_REQUESTS][NCCL_NET_IB_MAX_RECVS];
@@ -163,7 +164,7 @@ index 17ab50e8f2..661e9eaf68 100644
    uint64_t fifoTail;
    uint64_t addr;
    uint32_t flags;
-@@ -1424,20 +1504,59 @@ ncclResult_t ncclIbDestroyBase(struct ncclIbNetCommDevBase* base) {
+@@ -1424,20 +1505,59 @@ ncclResult_t ncclIbDestroyBase(struct ncclIbNetCommDevBase* base) {
    return ncclSuccess;
  }
  
@@ -225,7 +226,7 @@ index 17ab50e8f2..661e9eaf68 100644
    struct ibv_qp_attr qpAttr;
    memset(&qpAttr, 0, sizeof(struct ibv_qp_attr));
    qpAttr.qp_state = IBV_QPS_INIT;
-@@ -1447,6 +1566,9 @@ ncclResult_t ncclIbCreateQp(uint8_t ib_port, struct ncclIbNetCommDevBase* base,
+@@ -1447,6 +1567,9 @@ ncclResult_t ncclIbCreateQp(uint8_t ib_port, struct ncclIbNetCommDevBase* base,
    NCCLCHECK(wrap_ibv_modify_qp(qp->qp, &qpAttr, IBV_QP_STATE | IBV_QP_PKEY_INDEX | IBV_QP_PORT | IBV_QP_ACCESS_FLAGS));
    TRACE(NCCL_NET, "NET/IB : ncclIbCreateQp port=%d dev=%d devName=%s ndevs=%d nmdevs=%d qpn=%u pkey=%u pd=%p",
      ib_port, base->ibDevN, ncclIbDevs[base->ibDevN].devName, ncclNIbDevs, ncclNMergedIbDevs, qp->qp->qp_num, qpAttr.pkey_index, base->pd);
@@ -235,7 +236,7 @@ index 17ab50e8f2..661e9eaf68 100644
    return ncclSuccess;
  }
  
-@@ -1530,16 +1652,21 @@ fail:
+@@ -1530,16 +1653,21 @@ fail:
    goto exit;
  }
  
@@ -259,7 +260,7 @@ index 17ab50e8f2..661e9eaf68 100644
    if (stage->state == ncclIbCommStateConnect)      goto ib_connect_check;
    if (stage->state == ncclIbCommStateSendDevList)  goto ib_send_dev_list;
    if (stage->state == ncclIbCommStateRecvDevList)  goto ib_recv_dev_list;
-@@ -1621,7 +1748,7 @@ ib_recv_dev_list:
+@@ -1621,7 +1749,7 @@ ib_recv_dev_list:
    for (int q = 0; q < comm->base.nqps; q++) {
      ncclIbSendCommDev* commDev = comm->devs + devIndex;
      ncclIbDev* ibDev = ncclIbDevs + commDev->base.ibDevN;
@@ -268,7 +269,7 @@ index 17ab50e8f2..661e9eaf68 100644
      comm->base.qps[q].devIndex = devIndex;
      meta.qpInfo[q].qpn      = comm->base.qps[q].qp->qp_num;
      meta.qpInfo[q].devIndex = comm->base.qps[q].devIndex;
-@@ -1646,7 +1773,11 @@ ib_recv_dev_list:
+@@ -1646,7 +1774,11 @@ ib_recv_dev_list:
      devInfo->lid           = ibDev->portAttr.lid;
      devInfo->ibv_dev_index = commDev->base.ibDevN;
      // Prepare my fifo
@@ -281,7 +282,7 @@ index 17ab50e8f2..661e9eaf68 100644
      devInfo->fifoRkey = commDev->fifoMr->rkey;
  
      // Pack local GID info
-@@ -1689,7 +1820,11 @@ ib_recv_dev_list:
+@@ -1689,7 +1821,11 @@ ib_recv_dev_list:
      }
    }
    config = (ncclNetCommConfig_t*)ctx;
@@ -294,8 +295,11 @@ index 17ab50e8f2..661e9eaf68 100644
    meta.sl = (ncclParamIbSl() != -1) ? ncclParamIbSl() : (config && config->trafficClass != NCCL_NET_TRAFFIC_CLASS_UNDEF) ? config->trafficClass : NCCL_IB_SL_DEFAULT;
    meta.tc = (ncclParamIbTc() != -1) ? ncclParamIbTc() : (config && config->trafficClass != NCCL_NET_TRAFFIC_CLASS_UNDEF) ? config->trafficClass : NCCL_IB_TC_DEFAULT;
    strncpy(meta.devName, mergedDev->devName, MAX_MERGED_DEV_NAME);
-@@ -1837,15 +1972,27 @@ ncclResult_t ncclIbCheckVProps(ncclNetVDeviceProps_t* vProps1, ncclNetVDevicePro
- NCCL_PARAM(IbGdrFlushDisable, "GDR_FLUSH_DISABLE", 0);
+@@ -1834,18 +1970,29 @@ ncclResult_t ncclIbCheckVProps(ncclNetVDeviceProps_t* vProps1, ncclNetVDevicePro
+   return ncclSuccess;
+ }
+ 
+-NCCL_PARAM(IbGdrFlushDisable, "GDR_FLUSH_DISABLE", 0);
  RCCL_PARAM(IbGdrFlushGpuMemNoRelaxedOrdering, "GDR_FLUSH_GPU_MEM_NO_RELAXED_ORDERING", 1);
  
 -ncclResult_t ncclIbAccept(void* listenComm, void** recvComm, ncclNetDeviceHandle_t** /*recvDevComm*/) {
@@ -615,27 +619,27 @@ index 17ab50e8f2..661e9eaf68 100644
 +      // Send all applicable rkeys
 +      for (int j = 0; j < comm->base.vProps.ndevs; j++)
 +        localElemCtsInline[i].rkeys[j] = mhandleWrapper->mrs[j]->rkey;
-+
+ 
+-    // Send all applicable rkeys
+-    for (int j = 0; j < comm->base.vProps.ndevs; j++)
+-      localElem[i].rkeys[j] = mhandleWrapper->mrs[j]->rkey;
 +      localElemCtsInline[i].nreqs = n;
 +      localElemCtsInline[i].size = sizes[i]; // Sanity/Debugging
 +      localElemCtsInline[i].tag = tags[i];
 +      localElemCtsInline[i].idx = comm->remFifo.fifoTail+1;
 +      localElemRef = (uint64_t)localElemCtsInline;
  
--    // Send all applicable rkeys
--    for (int j = 0; j < comm->base.vProps.ndevs; j++)
--      localElem[i].rkeys[j] = mhandleWrapper->mrs[j]->rkey;
+-    localElem[i].nreqs = n;
+-    localElem[i].size = sizes[i]; // Sanity/Debugging
+-    localElem[i].tag = tags[i];
+-    localElem[i].idx = comm->remFifo.fifoTail+1;
 +    } else {
 +      localElem[i].addr = (uint64_t)data[i];
 +
 +      // Send all applicable rkeys
 +      for (int j = 0; j < comm->base.vProps.ndevs; j++)
 +        localElem[i].rkeys[j] = mhandleWrapper->mrs[j]->rkey;
- 
--    localElem[i].nreqs = n;
--    localElem[i].size = sizes[i]; // Sanity/Debugging
--    localElem[i].tag = tags[i];
--    localElem[i].idx = comm->remFifo.fifoTail+1;
++
 +      localElem[i].nreqs = n;
 +      localElem[i].size = sizes[i]; // Sanity/Debugging
 +      localElem[i].tag = tags[i];

--- a/projects/rccl/src/transport/net_ib.cc
+++ b/projects/rccl/src/transport/net_ib.cc
@@ -1223,7 +1223,8 @@ struct ncclIbGidInfo {
 #define NCCL_NET_IB_REQ_SEND 1
 #define NCCL_NET_IB_REQ_RECV 2
 #define NCCL_NET_IB_REQ_FLUSH 3
-const char* reqTypeStr[] = { "Unused", "Send", "Recv", "Flush" };
+#define NCCL_NET_IB_REQ_FAILED 4
+const char* reqTypeStr[] = { "Unused", "Send", "Recv", "Flush", "Failed" };
 
 #define MAX_QPS_PER_REQ 8
 struct ncclProfilerInfo {
@@ -1256,6 +1257,14 @@ struct ncclIbRequest {
     } recv;
   };
 };
+
+// Check if request has any pending events (IBV operations in flight)
+static inline bool ncclIbRequestHasEvents(struct ncclIbRequest* r) {
+  for (int i = 0; i < NCCL_IB_MAX_DEVS_PER_NIC; i++) {
+    if (r->events[i] != 0) return true;
+  }
+  return false;
+}
 
 struct ncclIbNetCommDevBase {
   int ibDevN;
@@ -2264,6 +2273,7 @@ NCCL_PARAM(IbSplitDataOnQps, "IB_SPLIT_DATA_ON_QPS", 0);
 ncclResult_t ncclIbMultiSend(struct ncclIbSendComm* comm, int slot) {
   struct ncclIbRequest** reqs = comm->fifoReqs[slot];
   volatile struct ncclIbSendFifo* slots = comm->fifo[slot];
+  ncclResult_t ret = ncclSuccess;
   int nreqs = slots[0].nreqs;
   if (nreqs > NCCL_NET_IB_MAX_RECVS) return ncclInternalError;
 
@@ -2371,7 +2381,14 @@ ncclResult_t ncclIbMultiSend(struct ncclIbSendComm* comm, int slot) {
       reqs[r]->pInfo[0].nEventHandles++;
     }
 #endif
-    NCCLCHECK(wrap_ibv_post_send(qp->qp, comm->wrs, &bad_wr));
+    ret = wrap_ibv_post_send(qp->qp, comm->wrs, &bad_wr);
+    if (ret != ncclSuccess) {
+      // Mark connection as fatal. DO NOT free requests here - the caller
+      // (ncclIbIsend) owns the requests and will handle cleanup.
+      // Some requests may have events from earlier QP iterations.
+      ncclIbStatsFatalError(&comm->base.stats);
+      return ret;
+    }
 
     for (int r=0; r<nreqs; r++) {
       int chunkSize = DIVUP(DIVUP(reqs[r]->send.size, nqps), align) * align;
@@ -2394,23 +2411,25 @@ ncclResult_t ncclIbMultiSend(struct ncclIbSendComm* comm, int slot) {
 
 ncclResult_t ncclIbIsend(void* sendComm, void* data, size_t size, int tag, void* mhandle, void* phandle, void** request) {
   struct ncclIbSendComm* comm = (struct ncclIbSendComm*)sendComm;
+  ncclResult_t ret = ncclSuccess;
+  struct ncclIbRequest* req = NULL;
+  struct ncclIbMrHandle* mhandleWrapper = (struct ncclIbMrHandle*) mhandle;
+  int nreqs = 0;
+  volatile struct ncclIbSendFifo* slots = NULL;
+  int slot = (comm->fifoHead) % MAX_REQUESTS;
+  struct ncclIbRequest** reqs = comm->fifoReqs[slot];
+  uint64_t idx = 0;
+
   if (comm->base.ready == 0) {
     WARN("NET/IB: ncclIbIsend() called when comm->base.ready == 0");
     *request = NULL;
     return ncclInternalError;
   }
-  NCCLCHECK(ncclIbStatsCheckFatalCount(&comm->base.stats,__func__));
-
-  struct ncclIbMrHandle* mhandleWrapper = (struct ncclIbMrHandle*) mhandle;
+  NCCLCHECKGOTO(ncclIbStatsCheckFatalCount(&comm->base.stats,__func__), ret, fail);
 
   // Wait for the receiver to have posted the corresponding receive
-  int nreqs = 0;
-  volatile struct ncclIbSendFifo* slots;
-
-  int slot = (comm->fifoHead) % MAX_REQUESTS;
-  struct ncclIbRequest** reqs = comm->fifoReqs[slot];
   slots = comm->fifo[slot];
-  uint64_t idx = comm->fifoHead+1;
+  idx = comm->fifoHead+1;
   if (slots[0].idx != idx) { *request = NULL; return ncclSuccess; }
   nreqs = slots[0].nreqs;
   // Wait until all data has arrived
@@ -2430,8 +2449,7 @@ ncclResult_t ncclIbIsend(void* sendComm, void* data, size_t size, int tag, void*
       return ncclInternalError;
     }
 
-    struct ncclIbRequest* req;
-    NCCLCHECK(ncclIbGetRequest(&comm->base, &req));
+    NCCLCHECKGOTO(ncclIbGetRequest(&comm->base, &req), ret, fail);
     req->type = NCCL_NET_IB_REQ_SEND;
     req->sock = &comm->base.sock;
     req->base = &comm->base;
@@ -2471,7 +2489,7 @@ ncclResult_t ncclIbIsend(void* sendComm, void* data, size_t size, int tag, void*
     }
 
     TIME_START(0);
-    NCCLCHECK(ncclIbMultiSend(comm, slot));
+    NCCLCHECKGOTO(ncclIbMultiSend(comm, slot), ret, fail);
 
     // Clear slots[0]->nreqs, as well as other fields to help debugging and sanity checks
     memset((void*)slots, 0, sizeof(struct ncclIbSendFifo));
@@ -2483,6 +2501,28 @@ ncclResult_t ncclIbIsend(void* sendComm, void* data, size_t size, int tag, void*
 
   *request = NULL;
   return ncclSuccess;
+
+fail:
+  ncclIbStatsFatalError(&comm->base.stats);
+  if (req) {
+    // If events were added (IBV ops posted), we can't free immediately -
+    // completions may still arrive. Mark as failed and return it so
+    // caller can call Test to drain completions.
+    if (ncclIbRequestHasEvents(req)) {
+      req->type = NCCL_NET_IB_REQ_FAILED;
+      *request = req;
+      // Return success so caller proceeds to call Test() which will drain
+      // completions. The fatal error is recorded in stats and will be
+      // caught on the next operation.
+      return ncclSuccess;
+    } else {
+      ncclIbFreeRequest(req);
+      *request = NULL;
+    }
+  } else {
+    *request = NULL;
+  }
+  return ret;
 }
 
 ncclResult_t ncclIbPostFifo(struct ncclIbRecvComm* comm, int n, void** data, size_t* sizes, int* tags, void** mhandles, struct ncclIbRequest* req) {
@@ -2556,7 +2596,13 @@ ncclResult_t ncclIbPostFifo(struct ncclIbRecvComm* comm, int n, void** data, siz
   }
 
   struct ibv_send_wr* bad_wr;
-  NCCLCHECK(wrap_ibv_post_send(ctsQp->qp, &wr, &bad_wr));
+  ncclResult_t ret = wrap_ibv_post_send(ctsQp->qp, &wr, &bad_wr);
+  if (ret != ncclSuccess) {
+    // Mark connection as fatal. Don't free request here - caller owns it
+    // and will handle cleanup based on whether events were posted.
+    ncclIbStatsFatalError(&comm->base.stats);
+    return ret;
+  }
 
   TRACE(NCCL_VERBS, "Posted send wr_id=%lu, wr_indx=%d, qp_num=%d, src_nic=%d, dst_nic=%d, dlid=%lu, opcode=%d, send_flags=%d, imm_data=%d, remote_addr=%lx, rkey=%x, length=%d, lkey=%x",
         wr.wr_id, 0, ctsQp->qp->qp_num, comm->devs[ctsQp->devIndex].base.ibDevN, comm->base.remDevs[ctsQp->remDevIdx].ibv_dev_index, comm->base.remDevs[ctsQp->remDevIdx].lid,
@@ -2569,16 +2615,21 @@ ncclResult_t ncclIbPostFifo(struct ncclIbRecvComm* comm, int n, void** data, siz
 
 ncclResult_t ncclIbIrecv(void* recvComm, int n, void** data, size_t* sizes, int* tags, void** mhandles, void** phandles, void** request) {
   struct ncclIbRecvComm* comm = (struct ncclIbRecvComm*)recvComm;
+  ncclResult_t ret = ncclSuccess;
+  struct ncclIbRequest* req = NULL;
+  struct ibv_recv_wr wr;
+  struct ibv_recv_wr* bad_wr = NULL;
+  int nqps = 0;
+
   if (comm->base.ready == 0) {
     WARN("NET/IB: ncclIbIrecv() called when comm->base.ready == 0");
     *request = NULL;
     return ncclInternalError;
   }
   if (n > NCCL_NET_IB_MAX_RECVS) return ncclInternalError;
-  NCCLCHECK(ncclIbStatsCheckFatalCount(&comm->base.stats,__func__));
+  NCCLCHECKGOTO(ncclIbStatsCheckFatalCount(&comm->base.stats,__func__), ret, fail);
 
-  struct ncclIbRequest* req;
-  NCCLCHECK(ncclIbGetRequest(&comm->base, &req));
+  NCCLCHECKGOTO(ncclIbGetRequest(&comm->base, &req), ret, fail);
   req->type = NCCL_NET_IB_REQ_RECV;
   req->sock = &comm->base.sock;
   req->nreqs = n;
@@ -2590,7 +2641,6 @@ ncclResult_t ncclIbIrecv(void* recvComm, int n, void** data, size_t* sizes, int*
     req->devBases[i] = &comm->devs[i].base;
   }
 
-  struct ibv_recv_wr wr;
   memset(&wr, 0, sizeof(wr));
   wr.wr_id = req - comm->base.reqs;
   wr.sg_list = NULL;
@@ -2598,10 +2648,9 @@ ncclResult_t ncclIbIrecv(void* recvComm, int n, void** data, size_t* sizes, int*
 
   TIME_START(1);
   // Select either all QPs, or one qp per-device
-  const int nqps = ncclParamIbSplitDataOnQps() ? comm->base.nqps : comm->base.nDataQps;
+  nqps = ncclParamIbSplitDataOnQps() ? comm->base.nqps : comm->base.nDataQps;
 
   // Post recvs
-  struct ibv_recv_wr* bad_wr;
   for (int i = 0; i < nqps; i++) {
     struct ncclIbQp* qp = comm->base.qps + comm->base.qpIndex;
     ncclIbAddEvent(req, qp->devIndex, &comm->devs[qp->devIndex].base);
@@ -2621,7 +2670,7 @@ ncclResult_t ncclIbIrecv(void* recvComm, int n, void** data, size_t* sizes, int*
       req->pInfo[r].nEventHandles++;
     }
 #endif
-    NCCLCHECK(wrap_ibv_post_recv(qp->qp, &wr, &bad_wr));
+    NCCLCHECKGOTO(wrap_ibv_post_recv(qp->qp, &wr, &bad_wr), ret, fail);
     comm->base.qpIndex = (comm->base.qpIndex+1)%comm->base.nqps;
   }
 
@@ -2629,25 +2678,50 @@ ncclResult_t ncclIbIrecv(void* recvComm, int n, void** data, size_t* sizes, int*
 
   // Post to FIFO to notify sender
   TIME_START(2);
-  NCCLCHECK(ncclIbPostFifo(comm, n, data, sizes, tags, mhandles, req));
+  NCCLCHECKGOTO(ncclIbPostFifo(comm, n, data, sizes, tags, mhandles, req), ret, fail);
   TIME_STOP(2);
 
   *request = req;
   return ncclSuccess;
+
+fail:
+  ncclIbStatsFatalError(&comm->base.stats);
+  if (req) {
+    // If events were added (IBV ops posted), we can't free immediately -
+    // completions may still arrive. Mark as failed and return it so
+    // caller can call Test to drain completions.
+    if (ncclIbRequestHasEvents(req)) {
+      req->type = NCCL_NET_IB_REQ_FAILED;
+      *request = req;
+      // Return success so caller proceeds to call Test() which will drain
+      // completions. The fatal error is recorded in stats and will be
+      // caught on the next operation.
+      return ncclSuccess;
+    } else {
+      ncclIbFreeRequest(req);
+      *request = NULL;
+    }
+  } else {
+    *request = NULL;
+  }
+  return ret;
 }
 
 ncclResult_t ncclIbIflush(void* recvComm, int n, void** data, int* sizes, void** mhandles, void** request) {
   struct ncclIbRecvComm* comm = (struct ncclIbRecvComm*)recvComm;
+  ncclResult_t ret = ncclSuccess;
+  struct ncclIbRequest* req = NULL;
+  struct ncclIbMrHandle* mhandle = NULL;
   int last = -1;
+
   for (int i=0; i<n; i++) if (sizes[i]) last = i;
   if (comm->flushEnabled == 0 || last == -1) return ncclSuccess;
 
   // Only flush once using the last non-zero receive
-  struct ncclIbRequest* req;
-  NCCLCHECK(ncclIbGetRequest(&comm->base, &req));
+  mhandle = (struct ncclIbMrHandle*) mhandles[last];
+  NCCLCHECKGOTO(ncclIbGetRequest(&comm->base, &req), ret, fail);
   req->type = NCCL_NET_IB_REQ_FLUSH;
   req->sock = &comm->base.sock;
-  struct ncclIbMrHandle* mhandle = (struct ncclIbMrHandle*) mhandles[last];
 
   // We don't know which devIndex the recv was on, so we flush on all devices
   for (int i = 0; i < comm->base.vProps.ndevs; i++) {
@@ -2662,7 +2736,7 @@ ncclResult_t ncclIbIflush(void* recvComm, int n, void** data, int* sizes, void**
       wr.opcode = IBV_WR_RDMA_WRITE;
       wr.send_flags = 0;
       struct ibv_send_wr* bad_wr;
-      NCCLCHECK(wrap_ibv_post_send(comm->devs[i].gpuFlush.qp.qp, &wr, &bad_wr));
+      NCCLCHECKGOTO(wrap_ibv_post_send(comm->devs[i].gpuFlush.qp.qp, &wr, &bad_wr), ret, fail);
     }
     memset(&wr, 0, sizeof(wr));
     wr.wr_id = req - comm->base.reqs;
@@ -2680,7 +2754,7 @@ ncclResult_t ncclIbIflush(void* recvComm, int n, void** data, int* sizes, void**
 
     TIME_START(4);
     struct ibv_send_wr* bad_wr;
-    NCCLCHECK(wrap_ibv_post_send(comm->devs[i].gpuFlush.qp.qp, &wr, &bad_wr));
+    NCCLCHECKGOTO(wrap_ibv_post_send(comm->devs[i].gpuFlush.qp.qp, &wr, &bad_wr), ret, fail);
     TIME_STOP(4);
 
     ncclIbAddEvent(req, i, &comm->devs[i].base);
@@ -2688,6 +2762,28 @@ ncclResult_t ncclIbIflush(void* recvComm, int n, void** data, int* sizes, void**
 
   *request = req;
   return ncclSuccess;
+
+fail:
+  ncclIbStatsFatalError(&comm->base.stats);
+  if (req) {
+    // If events were added (IBV ops posted), we can't free immediately -
+    // completions may still arrive. Mark as failed and return it so
+    // caller can call Test to drain completions.
+    if (ncclIbRequestHasEvents(req)) {
+      req->type = NCCL_NET_IB_REQ_FAILED;
+      *request = req;
+      // Return success so caller proceeds to call Test() which will drain
+      // completions. The fatal error is recorded in stats and will be
+      // caught on the next operation.
+      return ncclSuccess;
+    } else {
+      ncclIbFreeRequest(req);
+      *request = NULL;
+    }
+  } else {
+    *request = NULL;
+  }
+  return ret;
 }
 
 #define HCA_NAME(req, index) ((req)->devBases[(index)]->pd->context->device->name)
@@ -2704,12 +2800,22 @@ static int getReqQpIndex(struct ncclIbRequest* req, int request, int qpNumber) {
 
 ncclResult_t ncclIbTest(void* request, int* done, int* sizes) {
   struct ncclIbRequest *r = (struct ncclIbRequest*)request;
+  ncclResult_t ret = ncclSuccess;
+  int failDevIdx = -1;
   *done = 0;
   while (1) {
-    NCCLCHECK(ncclIbStatsCheckFatalCount(&r->base->stats,__func__));
+    NCCLCHECKGOTO(ncclIbStatsCheckFatalCount(&r->base->stats,__func__), ret, fail);
     if (r->events[0] == 0 && r->events[1] == 0 && r->events[2] == 0 && r->events[3] == 0) {
       TRACE(NCCL_NET, "r=%p done", r);
       *done = 1;
+      // If this was a failed request, we were just draining completions.
+      // Now that all events are done, free and return success.
+      if (r->type == NCCL_NET_IB_REQ_FAILED) {
+        NCCLCHECK(ncclIbFreeRequest(r));
+        // Return success since we successfully drained. The fatal error
+        // is already recorded in stats and will be caught on next operation.
+        return ncclSuccess;
+      }
       if (sizes && r->type == NCCL_NET_IB_REQ_RECV) {
         for (int i=0; i<r->nreqs; i++) {
           sizes[i] = r->recv.sizes[i];
@@ -2741,7 +2847,11 @@ ncclResult_t ncclIbTest(void* request, int* done, int* sizes) {
       TIME_START(3);
       // If we expect any completions from this device's CQ
       if (r->events[i]) {
-        NCCLCHECK(wrap_ibv_poll_cq(r->devBases[i]->cq, 4, wcs, &wrDone));
+        ret = wrap_ibv_poll_cq(r->devBases[i]->cq, 4, wcs, &wrDone);
+        if (ret != ncclSuccess) {
+          failDevIdx = i;
+          goto fail;
+        }
         totalWrDone += wrDone;
         if (wrDone == 0) { TIME_CANCEL(3); } else { TIME_STOP(3); }
         if (wrDone == 0) continue;
@@ -2763,7 +2873,9 @@ ncclResult_t ncclIbTest(void* request, int* done, int* sizes) {
             WARN("NET/IB: Got completion from peer %s with status=%d opcode=%d len=%u vendor err %u (%s)%s%s%s%s hca %s",
                 ncclSocketToString(&addr, line), wc->status, wc->opcode, wc->byte_len, wc->vendor_err, reqTypeStr[r->type],
                 localGidStr ?  " localGid ":"", localGidString, remoteGidStr ? " remoteGids":"", remoteGidString, hcaName);
-            return ncclRemoteError;
+            ret = ncclRemoteError;
+            failDevIdx = i;
+            goto fail;
           }
 
           union ncclSocketAddress addr;
@@ -2780,7 +2892,9 @@ ncclResult_t ncclIbTest(void* request, int* done, int* sizes) {
               struct ncclIbRequest* sendReq = r->base->reqs+((wc->wr_id >> (j*8)) & 0xff);
               if ((sendReq->events[i] <= 0)) {
                 WARN("NET/IB: sendReq(%p)->events={%d,%d,%d,%d}, i=%d, j=%d <= 0", sendReq, sendReq->events[0], sendReq->events[1], sendReq->events[2], sendReq->events[3], i, j);
-                return ncclInternalError;
+                ret = ncclInternalError;
+                failDevIdx = i;
+                goto fail;
               }
               sendReq->events[i]--;
 #ifdef NCCL_ENABLE_NET_PROFILING
@@ -2793,7 +2907,9 @@ ncclResult_t ncclIbTest(void* request, int* done, int* sizes) {
             if (req && wc->opcode == IBV_WC_RECV_RDMA_WITH_IMM) {
               if (req->type != NCCL_NET_IB_REQ_RECV) {
                 WARN("NET/IB: wc->opcode == IBV_WC_RECV_RDMA_WITH_IMM and req->type=%d", req->type);
-                return ncclInternalError;
+                ret = ncclInternalError;
+                failDevIdx = i;
+                goto fail;
               }
               if (req->nreqs == 1) {
                 req->recv.sizes[0] = wc->imm_data;
@@ -2811,13 +2927,28 @@ ncclResult_t ncclIbTest(void* request, int* done, int* sizes) {
         }
         // Once the IB fatal event is reported in the async thread, we want to propagate this error
         // to communicator and prevent further polling to reduce error pollution.
-        NCCLCHECK(ncclIbStatsCheckFatalCount(&ncclIbDevs[r->devBases[i]->ibDevN].stats,__func__));
+        ret = ncclIbStatsCheckFatalCount(&ncclIbDevs[r->devBases[i]->ibDevN].stats,__func__);
+        if (ret != ncclSuccess) {
+          failDevIdx = i;
+          goto fail;
+        }
       }
     }
 
     // If no CQEs found on any device, return and come back later
     if (totalWrDone == 0) return ncclSuccess;
   }
+
+fail:
+  // Mark connection and device as fatal
+  ncclIbStatsFatalError(&r->base->stats);
+  if (failDevIdx >= 0 && r->devBases[failDevIdx] != NULL) {
+    ncclIbStatsFatalError(&ncclIbDevs[r->devBases[failDevIdx]->ibDevN].stats);
+  }
+  // Mark request as failed so subsequent Test calls drain completions
+  r->type = NCCL_NET_IB_REQ_FAILED;
+  *done = 1;
+  return ret;
 }
 
 ncclResult_t ncclIbCloseSend(void* sendComm) {

--- a/projects/rccl/src/transport/net_ib.cc
+++ b/projects/rccl/src/transport/net_ib.cc
@@ -2943,7 +2943,11 @@ fail:
   // Mark connection and device as fatal
   ncclIbStatsFatalError(&r->base->stats);
   if (failDevIdx >= 0 && r->devBases[failDevIdx] != NULL) {
+    int ibDevN = r->devBases[failDevIdx]->ibDevN;
+    struct ncclIbDev* failedDev = ncclIbDevs + ibDevN;
     ncclIbStatsFatalError(&ncclIbDevs[r->devBases[failDevIdx]->ibDevN].stats);
+    WARN("NET/IB: Device failure - name: %s, port: %d, PCI: %s, ibDevN: %d",
+         failedDev->devName, failedDev->portNum, failedDev->pciPath ? failedDev->pciPath : "N/A", ibDevN);
   }
   // Mark request as failed so subsequent Test calls drain completions
   r->type = NCCL_NET_IB_REQ_FAILED;


### PR DESCRIPTION
ROCM-2357 handle net ib request failures

When an IBV operation fails after some completions have been posted, the request cannot be freed immediately because completions may still arrive. The solution is to mark the request as "failed" and have ncclIbTest() drain all pending completions before freeing the request. This prevents memory corruption and ensures clean shutdown on IB errors.

This commit adds robust error handling for InfiniBand (IB) network request failures in RCCL. Previously, failures during IBV operations could leave the system in an inconsistent state. This change ensures proper cleanup and completion draining when errors occur. Key Changes
. New request type NCCL_NET_IB_REQ_FAILED (#define = 4) .. Added a new request state to track failed requests that still have in-flight IBV operations
.. Updated reqTypeStr[] array to include "Failed"

. New helper function ncclIbRequestHasEvents()
.. Checks if a request has any pending events (IBV operations in flight) .. Used to determine if a request can be freed immediately or needs completion draining

. Error handling pattern changes (NCCLCHECK → NCCLCHECKGOTO) .. Converted direct NCCLCHECK calls to NCCLCHECKGOTO pattern with fail: blocks
.. Enables proper cleanup on error paths

. ncclIbMultiSend() changes
.. Added ncclResult_t ret variable
.. Wrapped wrap_ibv_post_send() with error checking .. On failure: marks connection as fatal via ncclIbStatsFatalError()

. ncclIbIsend() changes
.. Moved variable declarations to function start for goto compatibility .. Added fail: block that:
.. Marks connection as fatal
.. If request has events: marks as NCCL_NET_IB_REQ_FAILED and returns success (so caller calls Test() to drain)
.. If no events: frees request immediately

. ncclIbPostFifo() changes
.. Added error handling for wrap_ibv_post_send()
.. Marks connection as fatal on failure

. ncclIbIrecv() changes
.. Similar refactoring with NCCLCHECKGOTO pattern
.. Added fail: block with same logic as ncclIbIsend()

. ncclIbTest() changes
.. Added ret and failDevIdx variables
.. All error returns converted to goto fail
.. Handles NCCL_NET_IB_REQ_FAILED requests: drains completions then frees
.. fail: block marks both connection and device stats as fatal

ROCM-2357

Run UT
Run 4-node rccl tests

Unit test passes
4-node rccl tests pass 800+ iterations without any segfaults reported earlier

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.


