### PR TITLE
Do not check for image for 2D/3D tests that don't involve an array

### DIFF
--- a/projects/hip-tests/catch/unit/memory/hipDrvMemcpy3D.cc
+++ b/projects/hip-tests/catch/unit/memory/hipDrvMemcpy3D.cc
@@ -13,8 +13,6 @@
 #include <utils.hh>
 
 HIP_TEST_CASE(Unit_hipDrvMemcpy3D_Positive_Basic) {
-  CHECK_IMAGE_SUPPORT
-
   constexpr bool async = false;
 
 #if HT_NVIDIA  // Disabled on AMD due to defect - EXSWHTEC-236
@@ -38,8 +36,6 @@ HIP_TEST_CASE(Unit_hipDrvMemcpy3D_Positive_Basic) {
 }
 
 HIP_TEST_CASE(Unit_hipDrvMemcpy3D_Positive_Synchronization_Behavior) {
-  CHECK_IMAGE_SUPPORT
-
   HIP_CHECK(hipDeviceSynchronize());
 
   SECTION("Host to Device") { Memcpy3DHtoDSyncBehavior(DrvMemcpy3DWrapper<>, true); }
@@ -56,8 +52,6 @@ HIP_TEST_CASE(Unit_hipDrvMemcpy3D_Positive_Synchronization_Behavior) {
 }
 
 HIP_TEST_CASE(Unit_hipDrvMemcpy3D_Positive_Parameters) {
-  CHECK_IMAGE_SUPPORT
-
   constexpr bool async = false;
   Memcpy3DZeroWidthHeightDepth<async>(DrvMemcpy3DWrapper<>);
 }
@@ -72,8 +66,6 @@ HIP_TEST_CASE(Unit_hipDrvMemcpy3D_Positive_Array) {
 }
 
 HIP_TEST_CASE(Unit_hipDrvMemcpy3D_Negative_Parameters) {
-  CHECK_IMAGE_SUPPORT
-
   constexpr hipExtent extent{128 * sizeof(int), 128, 8};
 
   constexpr auto NegativeTests = [](hipPitchedPtr dst_ptr, hipPos dst_pos, hipPitchedPtr src_ptr,
@@ -211,8 +203,6 @@ HIP_TEST_CASE(Unit_hipDrvMemcpy3D_Negative_Parameters) {
 }
 
 HIP_TEST_CASE(Unit_hipDrvMemcpy3D_Capture) {
-  CHECK_IMAGE_SUPPORT
-
   constexpr hipExtent extent{128 * sizeof(int), 128, 8};
   LinearAllocGuard3D<int> device_alloc(extent);
   LinearAllocGuard<int> host_alloc(

--- a/projects/hip-tests/catch/unit/memory/hipGetProcAddressMemoryApis.cc
+++ b/projects/hip-tests/catch/unit/memory/hipGetProcAddressMemoryApis.cc
@@ -2473,8 +2473,6 @@ HIP_TEST_CASE(Unit_hipGetProcAddress_MemoryApisMemset) {
  *  - HIP_VERSION >= 6.2
  */
 HIP_TEST_CASE(Unit_hipGetProcAddress_MemoryApisMemset2D3D) {
-  CHECK_IMAGE_SUPPORT
-
   void* hipMemset2D_ptr = nullptr;
   void* hipMemset2DAsync_ptr = nullptr;
   void* hipMemset3D_ptr = nullptr;
@@ -2703,7 +2701,6 @@ HIP_TEST_CASE(Unit_hipGetProcAddress_MemoryApisGetMemInfoRelated) {
  */
 HIP_TEST_CASE(Unit_hipGetProcAddress_MemoryApisMemcpy2DRelated) {
   CHECK_IMAGE_SUPPORT
-
   void* hipMemcpy2D_ptr = nullptr;
   void* hipMemcpy2DAsync_ptr = nullptr;
   void* hipMemcpyParam2D_ptr = nullptr;
@@ -4479,8 +4476,6 @@ HIP_TEST_CASE(Unit_hipGetProcAddress_MemoryApisMemcpy2DRelated) {
  *  - HIP_VERSION >= 6.2
  */
 HIP_TEST_CASE(Unit_hipGetProcAddress_MemoryApisMemcpy3DRelated) {
-  CHECK_IMAGE_SUPPORT
-
   void* hipMemcpy3D_ptr = nullptr;
   void* hipMemcpy3DAsync_ptr = nullptr;
   void* hipDrvMemcpy3D_ptr = nullptr;

--- a/projects/hip-tests/catch/unit/memory/hipMalloc3D.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMalloc3D.cc
@@ -55,7 +55,6 @@ static void Malloc3DThreadFunc(int gpu) { MemoryAlloc3DDiffSizes(gpu); }
  * hipMemGetInfo() should indicate the memory went down after we hipFree() all of them
  */
 HIP_TEST_CASE(Unit_hipMalloc3D_Basic) {
-  CHECK_IMAGE_SUPPORT
 
   static constexpr int ChunkSize = 64;  // (in megabytes)
   static constexpr int NumAllocations = 3;
@@ -104,7 +103,6 @@ This testcase verifies the hipMalloc3D API by allocating
 smaller and big chunk data.
 */
 HIP_TEST_CASE(Unit_hipMalloc3D_SmallandBigChunks) {
-  CHECK_IMAGE_SUPPORT
 
   MemoryAlloc3DDiffSizes(0);
 }
@@ -115,7 +113,6 @@ scenario by launching threads in parallel on multiple GPUs
 and verifies the hipMalloc3D API with small and big chunks data
 */
 HIP_TEST_CASE(Unit_hipMalloc3D_MultiThread) {
-  CHECK_IMAGE_SUPPORT
 
   std::vector<std::thread> threadlist;
   int devCnt = 0;

--- a/projects/hip-tests/catch/unit/memory/hipMallocPitch.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMallocPitch.cc
@@ -116,7 +116,6 @@ hipExtent generateExtent(AllocationApi api) {
 
 
 HIP_TEST_CASE(Unit_hipMalloc3D_ValidatePitch) {
-  CHECK_IMAGE_SUPPORT
 
   hipPitchedPtr hipPitchedPtr;
   hipExtent validExtent{generateExtent(AllocationApi::hipMalloc3D)};
@@ -127,7 +126,6 @@ HIP_TEST_CASE(Unit_hipMalloc3D_ValidatePitch) {
 }
 
 HIP_TEST_CASE(Unit_hipMemAllocPitch_ValidatePitch) {
-  CHECK_IMAGE_SUPPORT
 
   size_t pitch = 0;
   hipDeviceptr_t ptr;
@@ -148,7 +146,6 @@ HIP_TEST_CASE(Unit_hipMemAllocPitch_ValidatePitch) {
 }
 
 HIP_TEST_CASE(Unit_hipMallocPitch_ValidatePitch) {
-  CHECK_IMAGE_SUPPORT
 
   size_t pitch = 0;
   void* ptr;
@@ -159,7 +156,6 @@ HIP_TEST_CASE(Unit_hipMallocPitch_ValidatePitch) {
 }
 
 HIP_TEST_CASE(Unit_hipMalloc3D_Negative) {
-  CHECK_IMAGE_SUPPORT
 
   SECTION("Invalid ptr") {
     hipExtent validExtent{1, 1, 1};
@@ -197,7 +193,6 @@ HIP_TEST_CASE(Unit_hipMalloc3D_Negative) {
 }
 
 HIP_TEST_CASE(Unit_hipMallocPitch_Negative) {
-  CHECK_IMAGE_SUPPORT
 
   size_t pitch = 0;
   void* ptr;
@@ -224,7 +219,6 @@ HIP_TEST_CASE(Unit_hipMallocPitch_Negative) {
 }
 
 HIP_TEST_CASE(Unit_hipMallocPitch_Zero_Dims) {
-  CHECK_IMAGE_SUPPORT
 
   void* ptr = nullptr;
   size_t pitch = 0;
@@ -241,7 +235,6 @@ HIP_TEST_CASE(Unit_hipMallocPitch_Zero_Dims) {
 }
 
 HIP_TEST_CASE(Unit_hipMemAllocPitch_Negative) {
-  CHECK_IMAGE_SUPPORT
 
   size_t pitch = 0;
   hipDeviceptr_t ptr{};
@@ -374,7 +367,6 @@ static void threadFunc(int gpu) { MemoryAllocDiffSizes<float>(gpu); }
  *
  */
 HIP_TEMPLATE_TEST_CASE(Unit_hipMallocPitch_Basic, int, unsigned int, float) {
-  CHECK_IMAGE_SUPPORT
 
   TestType* A_d;
   size_t pitch_A = 0;
@@ -390,7 +382,6 @@ HIP_TEMPLATE_TEST_CASE(Unit_hipMallocPitch_Basic, int, unsigned int, float) {
  */
 HIP_TEMPLATE_TEST_CASE(Unit_hipMallocPitch_SmallandBigChunks, int, unsigned int,
                    float) {
-  CHECK_IMAGE_SUPPORT
 
   MemoryAllocDiffSizes<TestType>(0);
 }
@@ -400,7 +391,6 @@ HIP_TEMPLATE_TEST_CASE(Unit_hipMallocPitch_SmallandBigChunks, int, unsigned int,
  * by performing Memcpy2D on the allocated memory.
  */
 HIP_TEMPLATE_TEST_CASE(Unit_hipMallocPitch_Memcpy2D, int, float, double) {
-  CHECK_IMAGE_SUPPORT
 
   HIP_CHECK(hipSetDevice(0));
   TestType *A_h{nullptr}, *B_h{nullptr}, *C_h{nullptr}, *A_d{nullptr}, *B_d{nullptr};
@@ -445,7 +435,6 @@ and verifies the hipMallocPitch API with small and big chunks data
 */
 
 HIP_TEST_CASE(Unit_hipMallocPitch_MultiThread) {
-  CHECK_IMAGE_SUPPORT
 
   std::vector<std::thread> threadlist;
   int devCnt = 0;
@@ -468,7 +457,6 @@ HIP_TEST_CASE(Unit_hipMallocPitch_MultiThread) {
  *  3. Validating the result
  */
 HIP_TEMPLATE_TEST_CASE(Unit_hipMallocPitch_KernelLaunch, int, float, double) {
-  CHECK_IMAGE_SUPPORT
 
   HIP_CHECK(hipSetDevice(0));
   TestType *A_h{nullptr}, *B_h{nullptr}, *C_h{nullptr}, *A_d{nullptr}, *B_d{nullptr};

--- a/projects/hip-tests/catch/unit/memory/hipMemPoolSetGetAccess.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemPoolSetGetAccess.cc
@@ -231,7 +231,6 @@ HIP_TEST_CASE(Unit_hipMemPoolSetGetAccess_Positive_P2P) {
  *  - HIP_VERSION >= 6.2
  */
 HIP_TEST_CASE(Unit_hipMemPoolSetAccess_Negative_Parameters) {
-  CHECK_IMAGE_SUPPORT
   int device_id = 0;
   HIP_CHECK(hipSetDevice(device_id));
   checkMempoolSupported(device_id) MemPoolGuard mempool(MemPools::dev_default, device_id);

--- a/projects/hip-tests/catch/unit/memory/hipMemcpy2D.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemcpy2D.cc
@@ -12,7 +12,6 @@
 #include <utils.hh>
 
 HIP_TEST_CASE(Unit_hipMemcpy2D_Positive_Basic) {
-  CHECK_IMAGE_SUPPORT
   constexpr bool async = false;
 
   SECTION("Device to Host") { Memcpy2DDeviceToHostShell<async>(hipMemcpy2D); }
@@ -50,13 +49,11 @@ HIP_TEST_CASE(Unit_hipMemcpy2D_Positive_Synchronization_Behavior) {
 }
 
 HIP_TEST_CASE(Unit_hipMemcpy2D_Positive_Parameters) {
-  CHECK_IMAGE_SUPPORT
   constexpr bool async = false;
   Memcpy2DZeroWidthHeight<async>(hipMemcpy2D);
 }
 
 HIP_TEST_CASE(Unit_hipMemcpy2D_Negative_Parameters) {
-  CHECK_IMAGE_SUPPORT
   constexpr size_t cols = 128;
   constexpr size_t rows = 128;
 
@@ -137,7 +134,6 @@ HIP_TEST_CASE(Unit_hipMemcpy2D_Negative_Parameters) {
 }
 
 HIP_TEST_CASE(Unit_hipMemcpy2D_Capture) {
-  CHECK_IMAGE_SUPPORT
 
   constexpr size_t width = 16;
   constexpr size_t height = 16;

--- a/projects/hip-tests/catch/unit/memory/hipMemcpy2DAsync.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemcpy2DAsync.cc
@@ -48,7 +48,6 @@ HIP_TEST_CASE(Unit_hipMemcpy2DAsync_Positive_Basic) {
 }
 
 HIP_TEST_CASE(Unit_hipMemcpy2DAsync_Positive_Synchronization_Behavior) {
-  CHECK_IMAGE_SUPPORT
   using namespace std::placeholders;
 
   HIP_CHECK(hipDeviceSynchronize());
@@ -84,14 +83,12 @@ HIP_TEST_CASE(Unit_hipMemcpy2DAsync_Positive_Synchronization_Behavior) {
 }
 
 HIP_TEST_CASE(Unit_hipMemcpy2DAsync_Positive_Parameters) {
-  CHECK_IMAGE_SUPPORT
   using namespace std::placeholders;
   constexpr bool async = true;
   Memcpy2DZeroWidthHeight<async>(std::bind(hipMemcpy2DAsync, _1, _2, _3, _4, _5, _6, _7, nullptr));
 }
 
 HIP_TEST_CASE(Unit_hipMemcpy2DAsync_Negative_Parameters) {
-  CHECK_IMAGE_SUPPORT
   constexpr size_t cols = 128;
   constexpr size_t rows = 128;
 

--- a/projects/hip-tests/catch/unit/memory/hipMemcpy2DAsync_old.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemcpy2DAsync_old.cc
@@ -45,7 +45,6 @@ static constexpr auto ROWS{6};
  */
 
 HIP_TEMPLATE_TEST_CASE(Unit_hipMemcpy2DAsync_Host_N_PinnedMem, int, float, double) {
-  CHECK_IMAGE_SUPPORT
   // 1 refers to pinned host memory
   auto mem_type = GENERATE(0, 1);
   auto memcpy_d2d_type = GENERATE(0, 1);
@@ -121,7 +120,6 @@ HIP_TEMPLATE_TEST_CASE(Unit_hipMemcpy2DAsync_Host_N_PinnedMem, int, float, doubl
 }
 
 HIP_TEMPLATE_TEST_CASE(Unit_hipMemcpy2DAsync_multiDevice_StreamOnDiffDevice, int, float, double) {
-  CHECK_IMAGE_SUPPORT
   auto mem_type = GENERATE(0, 1);
   int numDevices = 0;
   int canAccessPeer = 0;
@@ -253,7 +251,6 @@ static void hipMemcpy2DAsync_Basic_Size_Test(size_t inc) {
  */
 
 HIP_TEST_CASE(Unit_hipMemcpy2DAsync_multiDevice_Basic_Size_Test) {
-  CHECK_IMAGE_SUPPORT
   size_t input = 1 << 20;
   int numDevices = 0;
   HIP_CHECK(hipGetDeviceCount(&numDevices));

--- a/projects/hip-tests/catch/unit/memory/hipMemcpy2D_old.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemcpy2D_old.cc
@@ -45,7 +45,6 @@ static constexpr auto ROWS{8};
  */
 
 HIP_TEMPLATE_TEST_CASE(Unit_hipMemcpy2D_H2D_D2D_D2H, int, float, double) {
-  CHECK_IMAGE_SUPPORT
   // 1 refers to pinned host memory
   auto mem_type = GENERATE(0, 1);
   auto memcpy_d2d_type = GENERATE(0, 1);
@@ -121,7 +120,6 @@ HIP_TEMPLATE_TEST_CASE(Unit_hipMemcpy2D_H2D_D2D_D2H, int, float, double) {
  */
 
 HIP_TEMPLATE_TEST_CASE(Unit_hipMemcpy2D_H2D_D2D_D2H_WithOffset, int, float, double) {
-  CHECK_IMAGE_SUPPORT
   // 1 refers to pinned host memory
   auto mem_type = GENERATE(0, 1);
   auto memcpy_d2d_type = GENERATE(0, 1);
@@ -201,7 +199,6 @@ HIP_TEMPLATE_TEST_CASE(Unit_hipMemcpy2D_H2D_D2D_D2H_WithOffset, int, float, doub
  *  - HIP_VERSION >= 6.0
  */
 HIP_TEMPLATE_TEST_CASE(Unit_hipMemcpy2D_H2D_D2D_D2H_Managed_WithOffset, int, float, double) {
-  CHECK_IMAGE_SUPPORT
   // 1 refers to pinned host memory
   auto mem_type = GENERATE(0, 1);
   auto memcpy_default = GENERATE(0, 1);
@@ -314,7 +311,6 @@ static void hipMemcpy2D_Basic_Size_Test(size_t inc) {
  */
 
 HIP_TEST_CASE(Unit_hipMemcpy2D_multiDevice_Basic_Size_Test) {
-  CHECK_IMAGE_SUPPORT
   size_t input = 1 << 20;
   int numDevices = 0;
   HIP_CHECK(hipGetDeviceCount(&numDevices));

--- a/projects/hip-tests/catch/unit/memory/hipMemcpy3D.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemcpy3D.cc
@@ -15,8 +15,6 @@
 #pragma clang diagnostic ignored "-Wunused-variable"
 
 HIP_TEST_CASE(Unit_hipMemcpy3D_Positive_Basic) {
-  CHECK_IMAGE_SUPPORT
-
   constexpr bool async = false;
 
   SECTION("Device to Host") { Memcpy3DDeviceToHostShell<async>(Memcpy3DWrapper<>); }
@@ -34,8 +32,6 @@ HIP_TEST_CASE(Unit_hipMemcpy3D_Positive_Basic) {
 }
 
 HIP_TEST_CASE(Unit_hipMemcpy3D_Positive_Synchronization_Behavior) {
-  CHECK_IMAGE_SUPPORT
-
   HIP_CHECK(hipDeviceSynchronize());
 
   SECTION("Host to Device") { Memcpy3DHtoDSyncBehavior(Memcpy3DWrapper<>, true); }
@@ -48,8 +44,6 @@ HIP_TEST_CASE(Unit_hipMemcpy3D_Positive_Synchronization_Behavior) {
 }
 
 HIP_TEST_CASE(Unit_hipMemcpy3D_Positive_DeviceToDevice_Synchronization_Behavior) {
-  CHECK_IMAGE_SUPPORT
-
   LinearAllocGuard3D<int> src_alloc(make_hipExtent(32 * sizeof(int), 32, 8));
   LinearAllocGuard3D<int> dst_alloc(make_hipExtent(32 * sizeof(int), 32, 8));
   HipTest::BlockingContext b_context{nullptr};
@@ -74,8 +68,6 @@ HIP_TEST_CASE(Unit_hipMemcpy3D_Positive_DeviceToDevice_Synchronization_Behavior)
 }
 
 HIP_TEST_CASE(Unit_hipMemcpy3D_Positive_Parameters) {
-  CHECK_IMAGE_SUPPORT
-
   constexpr bool async = false;
   Memcpy3DZeroWidthHeightDepth<async>(Memcpy3DWrapper<>);
 }
@@ -91,8 +83,6 @@ HIP_TEST_CASE(Unit_hipMemcpy3D_Positive_Array) {
 }
 
 HIP_TEST_CASE(Unit_hipMemcpy3D_Negative_Parameters) {
-  CHECK_IMAGE_SUPPORT
-
   constexpr hipExtent extent{128 * sizeof(int), 128, 8};
 
   constexpr auto NegativeTests = [](hipPitchedPtr dst_ptr, hipPos dst_pos, hipPitchedPtr src_ptr,
@@ -240,8 +230,6 @@ HIP_TEST_CASE(Unit_hipMemcpy3D_Negative_Parameters) {
 }
 
 HIP_TEST_CASE(Unit_hipMemcpy3D_Capture) {
-  CHECK_IMAGE_SUPPORT
-
   constexpr hipExtent extent{16 * sizeof(int), 16, 16};
   LinearAllocGuard3D<int> dev_alloc(extent);
   LinearAllocGuard<int> host_alloc(LinearAllocs::hipHostMalloc,

--- a/projects/hip-tests/catch/unit/memory/hipMemcpy3DAsync.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemcpy3DAsync.cc
@@ -15,8 +15,6 @@
 #pragma clang diagnostic ignored "-Wunused-variable"
 
 HIP_TEST_CASE(Unit_hipMemcpy3DAsync_Positive_Basic) {
-  CHECK_IMAGE_SUPPORT
-
   constexpr bool async = true;
 
   const auto stream_type = GENERATE(Streams::nullstream, Streams::perThread, Streams::created);
@@ -40,8 +38,6 @@ HIP_TEST_CASE(Unit_hipMemcpy3DAsync_Positive_Basic) {
 }
 
 HIP_TEST_CASE(Unit_hipMemcpy3DAsync_Positive_Synchronization_Behavior) {
-  CHECK_IMAGE_SUPPORT
-
   constexpr bool async = true;
 
   HIP_CHECK(hipDeviceSynchronize());
@@ -62,8 +58,6 @@ HIP_TEST_CASE(Unit_hipMemcpy3DAsync_Positive_Synchronization_Behavior) {
 }
 
 HIP_TEST_CASE(Unit_hipMemcpy3DAsync_Positive_Parameters) {
-  CHECK_IMAGE_SUPPORT
-
   constexpr bool async = true;
   Memcpy3DZeroWidthHeightDepth<async>(Memcpy3DWrapper<async>);
 }
@@ -79,8 +73,6 @@ HIP_TEST_CASE(Unit_hipMemcpy3DAsync_Positive_Array) {
 }
 
 HIP_TEST_CASE(Unit_hipMemcpy3DAsync_Negative_Parameters) {
-  CHECK_IMAGE_SUPPORT
-
   constexpr bool async = true;
   constexpr hipExtent extent{128 * sizeof(int), 128, 8};
 
@@ -229,8 +221,6 @@ HIP_TEST_CASE(Unit_hipMemcpy3DAsync_Negative_Parameters) {
 }
 
 HIP_TEST_CASE(Unit_hipMemcpy3DAsync_Capture) {
-  CHECK_IMAGE_SUPPORT
-
   constexpr hipExtent kExtent{128 * sizeof(int), 128, 8};
 
   LinearAllocGuard3D<int> src_alloc(kExtent);

--- a/projects/hip-tests/catch/unit/memory/hipMemcpy3DAsync_old.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemcpy3DAsync_old.cc
@@ -624,7 +624,6 @@ template <typename T> void Memcpy3DAsync<T>::simple_Memcpy3DAsync() {
  */
 
 HIP_TEST_CASE(Unit_hipMemcpy3DAsync_multiDevice_Negative) {
-  CHECK_IMAGE_SUPPORT
   int numDevices = 0;
   HIP_CHECK(hipGetDeviceCount(&numDevices));
   if (numDevices > 1) {
@@ -649,7 +648,6 @@ HIP_TEST_CASE(Unit_hipMemcpy3DAsync_multiDevice_Negative) {
  */
 
 HIP_TEST_CASE(Unit_hipMemcpy3DAsync_multiDevice_DiffStream) {
-  CHECK_IMAGE_SUPPORT
   int numDevices = 0;
   HIP_CHECK(hipGetDeviceCount(&numDevices));
   if (numDevices > 1) {

--- a/projects/hip-tests/catch/unit/memory/hipMemcpy3DBatchAsync.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemcpy3DBatchAsync.cc
@@ -352,7 +352,6 @@ HIP_TEMPLATE_TEST_CASE(Unit_hipMemcpy3DBatchAsync_ArrayMemCpyBatchOps, char,
  *  - HIP_VERSION >= 7.1
  */
 HIP_TEST_CASE(Unit_hipMemcpy3DBatchAsync_NegativeTests) {
-  CHECK_IMAGE_SUPPORT
   const int numOps = 2;
   hipStream_t stream = NULL;
   HIP_CHECK(hipStreamCreate(&stream));

--- a/projects/hip-tests/catch/unit/memory/hipMemcpy3D_old.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemcpy3D_old.cc
@@ -515,7 +515,6 @@ template <typename T> void Memcpy3D<T>::simple_Memcpy3D() {
  */
 
 HIP_TEST_CASE(Unit_hipMemcpy3D_multiDevice_Negative) {
-  CHECK_IMAGE_SUPPORT
   int numDevices = 0;
   HIP_CHECK(hipGetDeviceCount(&numDevices));
   if (numDevices > 1) {

--- a/projects/hip-tests/catch/unit/memory/hipMemcpyParam2D.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemcpyParam2D.cc
@@ -12,7 +12,6 @@
 #include <utils.hh>
 
 HIP_TEST_CASE(Unit_hipMemcpyParam2D_Positive_Basic) {
-  CHECK_IMAGE_SUPPORT
   constexpr bool async = false;
 
 #if HT_NVIDIA  // Disabled on AMD due to defect - EXSWHTEC-236
@@ -51,7 +50,6 @@ HIP_TEST_CASE(Unit_hipMemcpyParam2D_Positive_Synchronization_Behavior) {
 }
 
 HIP_TEST_CASE(Unit_hipMemcpyParam2D_Positive_Parameters) {
-  CHECK_IMAGE_SUPPORT
   constexpr bool async = false;
   Memcpy2DZeroWidthHeight<async>(MemcpyParam2DAdapter<async>());
 }
@@ -68,7 +66,6 @@ HIP_TEST_CASE(Unit_hipMemcpyParam2D_Positive_Array) {
 }
 
 HIP_TEST_CASE(Unit_hipMemcpyParam2D_Negative_Parameters) {
-  CHECK_IMAGE_SUPPORT
   constexpr size_t cols = 128;
   constexpr size_t rows = 128;
 
@@ -170,8 +167,6 @@ HIP_TEST_CASE(Unit_hipMemcpyParam2D_Negative_Parameters) {
 }
 
 HIP_TEST_CASE(Unit_hipMemcpyParam2D_Capture) {
-  CHECK_IMAGE_SUPPORT
-
   constexpr size_t cols = 128;
   constexpr size_t rows = 128;
 

--- a/projects/hip-tests/catch/unit/memory/hipMemcpyParam2DAsync.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemcpyParam2DAsync.cc
@@ -45,7 +45,6 @@ HIP_TEST_CASE(Unit_hipMemcpyParam2DAsync_Positive_Basic) {
 }
 
 HIP_TEST_CASE(Unit_hipMemcpyParam2DAsync_Positive_Synchronization_Behavior) {
-  CHECK_IMAGE_SUPPORT
   using namespace std::placeholders;
 
   constexpr bool async = true;
@@ -81,7 +80,6 @@ HIP_TEST_CASE(Unit_hipMemcpyParam2DAsync_Positive_Synchronization_Behavior) {
 }
 
 HIP_TEST_CASE(Unit_hipMemcpyParam2DAsync_Positive_Parameters) {
-  CHECK_IMAGE_SUPPORT
   constexpr bool async = true;
   Memcpy2DZeroWidthHeight<async>(MemcpyParam2DAdapter<async>());
 }
@@ -98,7 +96,6 @@ HIP_TEST_CASE(Unit_hipMemcpyParam2DAsync_Positive_Array) {
 }
 
 HIP_TEST_CASE(Unit_hipMemcpyParam2DAsync_Negative_Parameters) {
-  CHECK_IMAGE_SUPPORT
   constexpr bool async = true;
 
   constexpr size_t cols = 128;

--- a/projects/hip-tests/catch/unit/memory/hipMemcpyParam2DAsync_old.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemcpyParam2DAsync_old.cc
@@ -32,8 +32,6 @@ static constexpr size_t NUM_H{10};
  */
 HIP_TEMPLATE_TEST_CASE(Unit_hipMemcpyParam2DAsync_multiDevice_StreamOnDiffDevice, char, float, int,
                    double, long double) {
-  CHECK_IMAGE_SUPPORT
-
   int numDevices = 0;
   HIP_CHECK(hipGetDeviceCount(&numDevices));
   if (numDevices > 1) {

--- a/projects/hip-tests/catch/unit/memory/hipMemset2D.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemset2D.cc
@@ -31,7 +31,6 @@ static constexpr std::initializer_list<tupletype> tableItems{
  * Basic Functionality of hipMemset2D
  */
 HIP_TEST_CASE(Unit_hipMemset2D_BasicFunctional) {
-  CHECK_IMAGE_SUPPORT
 
   constexpr int memsetval = 0x24;
   constexpr size_t numH = 256;
@@ -70,7 +69,6 @@ HIP_TEST_CASE(Unit_hipMemset2D_BasicFunctional) {
  * Basic Functionality of hipMemset2DAsync
  */
 HIP_TEST_CASE(Unit_hipMemset2DAsync_BasicFunctional) {
-  CHECK_IMAGE_SUPPORT
 
   constexpr int memsetval = 0x26;
   constexpr size_t numH = 256;
@@ -113,7 +111,6 @@ HIP_TEST_CASE(Unit_hipMemset2DAsync_BasicFunctional) {
  * Memset partial buffer with unique Width and Height
  */
 HIP_TEST_CASE(Unit_hipMemset2D_UniqueWidthHeight) {
-  CHECK_IMAGE_SUPPORT
 
   int width2D, height2D;
   int memsetWidth, memsetHeight;
@@ -227,7 +224,6 @@ HIP_TEST_CASE(Unit_hipMemset2DAsync_capturehipMemset2DAsync) {
  *    - HIP_VERSION >= 6.0
  */
 HIP_TEST_CASE(Unit_hipMemset2D_Capture) {
-  CHECK_IMAGE_SUPPORT
 
   constexpr int memsetval = 0x24;
   constexpr size_t numH = 256;

--- a/projects/hip-tests/catch/unit/memory/hipMemset2DAsyncMultiThreadAndKernel.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemset2DAsyncMultiThreadAndKernel.cc
@@ -36,7 +36,6 @@ void queueJobsForhipMemset2DAsync(char* A_d, char* A_h, size_t pitch, size_t wid
  * Order of execution of device kernel and hipMemset2DAsync api.
  */
 HIP_TEST_CASE(Unit_hipMemset2DAsync_WithKernel) {
-  CHECK_IMAGE_SUPPORT
 
   constexpr auto N = 4 * 1024 * 1024;
   constexpr auto blocksPerCU = 6;  // to hide latency
@@ -115,7 +114,6 @@ HIP_TEST_CASE(Unit_hipMemset2DAsync_WithKernel) {
  * hipMemSet2DAsync execution in multiple threads.
  */
 HIP_TEST_CASE(Unit_hipMemset2DAsync_MultiThread) {
-  CHECK_IMAGE_SUPPORT
 
   constexpr auto memPerThread = 200;
   constexpr int memsetval = 0x22;

--- a/projects/hip-tests/catch/unit/memory/hipMemset3D.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemset3D.cc
@@ -16,7 +16,6 @@
  * Basic Functional test of hipMemset3D
  */
 HIP_TEST_CASE(Unit_hipMemset3D_BasicFunctional) {
-  CHECK_IMAGE_SUPPORT
 
   constexpr int memsetval = 0x22;
   constexpr size_t numH = 256;
@@ -66,7 +65,6 @@ HIP_TEST_CASE(Unit_hipMemset3D_BasicFunctional) {
  * Basic Functional test of hipMemset3DAsync
  */
 HIP_TEST_CASE(Unit_hipMemset3DAsync_BasicFunctional) {
-  CHECK_IMAGE_SUPPORT
 
   constexpr int memsetval = 0x22;
   constexpr size_t numH = 256;
@@ -181,7 +179,6 @@ HIP_TEST_CASE(Unit_hipMemset3DAsync_capturehipMemset3DAsync) {
  *    - HIP_VERSION >= 6.0
  */
 HIP_TEST_CASE(Unit_hipMemset3D_Capture) {
-  CHECK_IMAGE_SUPPORT
 
   constexpr int memsetval = 0x22;
   constexpr size_t numH = 256;

--- a/projects/hip-tests/catch/unit/memory/hipMemset3DFunctional.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemset3DFunctional.cc
@@ -388,7 +388,6 @@ static void seekAndSet3DArrayPortion(bool bAsync) {
  * taking zero and non-zero fields.
  */
 HIP_TEST_CASE(Unit_hipMemset3D_MemsetWithExtent) {
-  CHECK_IMAGE_SUPPORT
 
   hipExtent testExtent;
   size_t numH = NUMH_EXT, numW = NUMW_EXT, depth = DEPTH_EXT;
@@ -424,7 +423,6 @@ HIP_TEST_CASE(Unit_hipMemset3D_MemsetWithExtent) {
  * taking zero and non-zero fields.
  */
 HIP_TEST_CASE(Unit_hipMemset3DAsync_MemsetWithExtent) {
-  CHECK_IMAGE_SUPPORT
 
   hipExtent testExtent;
   size_t numH = NUMH_EXT, numW = NUMW_EXT, depth = DEPTH_EXT;
@@ -458,7 +456,6 @@ HIP_TEST_CASE(Unit_hipMemset3DAsync_MemsetWithExtent) {
  * Memset3D with max unsigned char and verify memset operation is success
  */
 HIP_TEST_CASE(Unit_hipMemset3D_MemsetMaxValue) {
-  CHECK_IMAGE_SUPPORT
 
   testMemsetMaxValue(0);
 }
@@ -467,7 +464,6 @@ HIP_TEST_CASE(Unit_hipMemset3D_MemsetMaxValue) {
  * Memset3DAsync with max unsigned char and verify memset operation is success
  */
 HIP_TEST_CASE(Unit_hipMemset3DAsync_MemsetMaxValue) {
-  CHECK_IMAGE_SUPPORT
 
   testMemsetMaxValue(1);
 }
@@ -476,7 +472,6 @@ HIP_TEST_CASE(Unit_hipMemset3DAsync_MemsetMaxValue) {
  * Seek and set random slice of 3d array, verify memset is success
  */
 HIP_TEST_CASE(Unit_hipMemset3D_SeekSetSlice) {
-  CHECK_IMAGE_SUPPORT
 
   seekAndSet3DArraySlice(0);
 }
@@ -485,7 +480,6 @@ HIP_TEST_CASE(Unit_hipMemset3D_SeekSetSlice) {
  * Seek and set random slice of 3d array with async, verify memset is success
  */
 HIP_TEST_CASE(Unit_hipMemset3DAsync_SeekSetSlice) {
-  CHECK_IMAGE_SUPPORT
 
   seekAndSet3DArraySlice(1);
 }
@@ -494,7 +488,6 @@ HIP_TEST_CASE(Unit_hipMemset3DAsync_SeekSetSlice) {
  * Memset3D selected portion of 3d array
  */
 HIP_TEST_CASE(Unit_hipMemset3D_SeekSetArrayPortion) {
-  CHECK_IMAGE_SUPPORT
 
   seekAndSet3DArrayPortion(0);
 }
@@ -503,7 +496,6 @@ HIP_TEST_CASE(Unit_hipMemset3D_SeekSetArrayPortion) {
  * Memset3DAsync selected portion of 3d array
  */
 HIP_TEST_CASE(Unit_hipMemset3DAsync_SeekSetArrayPortion) {
-  CHECK_IMAGE_SUPPORT
 
   seekAndSet3DArrayPortion(1);
 }

--- a/projects/hip-tests/catch/unit/memory/hipMemset3DRegressMultiThread.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemset3DRegressMultiThread.cc
@@ -174,7 +174,6 @@ bool loopRegression(bool bAsync) {
  * on different gpus.
  */
 HIP_TEST_CASE(Unit_hipMemset3D_RegressInLoop) {
-  CHECK_IMAGE_SUPPORT
 
   bool TestPassed = false;
 
@@ -187,7 +186,6 @@ HIP_TEST_CASE(Unit_hipMemset3D_RegressInLoop) {
  * on different gpus.
  */
 HIP_TEST_CASE(Unit_hipMemset3DAsync_RegressInLoop) {
-  CHECK_IMAGE_SUPPORT
 
   bool TestPassed = false;
 
@@ -199,7 +197,6 @@ HIP_TEST_CASE(Unit_hipMemset3DAsync_RegressInLoop) {
  * Async commands queued concurrently and executed
  */
 HIP_TEST_CASE(Unit_hipMemset3DAsync_ConcurrencyMthread) {
-  CHECK_IMAGE_SUPPORT
 
   char* A_h;
   constexpr int memsetval = 1, testval = 2;

--- a/projects/hip-tests/catch/unit/memory/hipMemsetFunctional.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemsetFunctional.cc
@@ -266,7 +266,6 @@ template <typename T> void checkMemset2D(T value, size_t width, size_t height, b
 }
 
 HIP_TEST_CASE(Unit_hipMemsetFunctional_ZeroValue_2D) {
-  CHECK_IMAGE_SUPPORT
 
   constexpr size_t width{128};
   constexpr size_t height{128};
@@ -276,7 +275,6 @@ HIP_TEST_CASE(Unit_hipMemsetFunctional_ZeroValue_2D) {
 }
 
 HIP_TEST_CASE(Unit_hipMemsetFunctional_SmallSize_2D) {
-  CHECK_IMAGE_SUPPORT
 
   constexpr char memsetVal = 0x42;
   SECTION("hipMemset2D - Small Size") { checkMemset2D(memsetVal, 1, 1, false); }
@@ -284,7 +282,6 @@ HIP_TEST_CASE(Unit_hipMemsetFunctional_SmallSize_2D) {
 }
 
 HIP_TEST_CASE(Unit_hipMemsetFunctional_ZeroSize_2D) {
-  CHECK_IMAGE_SUPPORT
 
   size_t pitch{0};
   size_t width{10};
@@ -366,7 +363,6 @@ template <typename T> void partialMemsetTest2D(T valA, T valB, size_t width, siz
 }
 
 HIP_TEST_CASE(Unit_hipMemsetFunctional_PartialSet_2D) {
-  CHECK_IMAGE_SUPPORT
 
   for (auto widthOffset = 8; widthOffset <= 128; widthOffset *= 2) {
     for (auto heightOffset = 8; heightOffset <= 128; heightOffset *= 2) {
@@ -480,19 +476,16 @@ void check_memset_3D(std::string sectionStr, size_t width, size_t height, size_t
 }
 
 HIP_TEST_CASE(Unit_hipMemsetFunctional_ZeroValue_3D) {
-  CHECK_IMAGE_SUPPORT
 
   check_memset_3D("Zero Value", 128, 128, 10, 0);
 }
 
 HIP_TEST_CASE(Unit_hipMemsetFunctional_SmallSize_3D) {
-  CHECK_IMAGE_SUPPORT
 
   check_memset_3D("Small Size", 1, 1, 1, 0x42);
 }
 
 HIP_TEST_CASE(Unit_hipMemsetFunctional_ZeroSize_3D) {
-  CHECK_IMAGE_SUPPORT
 
   constexpr size_t elementSize = sizeof(char);
   check_memset_3D("Zero Width", 0, FULL_DIM, FULL_DIM, 0x23);
@@ -548,7 +541,6 @@ void partialMemsetTest3D(T valA, T valB, size_t width, size_t height, size_t dep
 }
 
 HIP_TEST_CASE(Unit_hipMemsetFunctional_PartialSet_3D) {
-  CHECK_IMAGE_SUPPORT
 
   for (auto widthOffset = 8; widthOffset <= 128; widthOffset *= 2) {
     for (auto heightOffset = 8; heightOffset <= 128; heightOffset *= 2) {

--- a/projects/hip-tests/catch/unit/memory/hipMemsetNegative.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemsetNegative.cc
@@ -77,8 +77,6 @@ HIP_TEST_CASE(Unit_hipMemset_Negative_OutOfBoundsPtr) {
 }
 
 HIP_TEST_CASE(Unit_hipMemset2D_Negative_InvalidPtr) {
-  CHECK_IMAGE_SUPPORT
-
   void* dst;
   SECTION("Uninitialized Dst") {}
   SECTION("Nullptr as Dst") { dst = nullptr; }
@@ -97,8 +95,6 @@ HIP_TEST_CASE(Unit_hipMemset2D_Negative_InvalidPtr) {
 }
 
 HIP_TEST_CASE(Unit_hipMemset2D_Negative_InvalidSizes) {
-  CHECK_IMAGE_SUPPORT
-
   void* dst;
   size_t realPitch;
   HIP_CHECK(hipMallocPitch(&dst, &realPitch, width, height));
@@ -123,8 +119,6 @@ HIP_TEST_CASE(Unit_hipMemset2D_Negative_InvalidSizes) {
 }
 
 HIP_TEST_CASE(Unit_hipMemset2D_Negative_OutOfBoundsPtr) {
-  CHECK_IMAGE_SUPPORT
-
   void* dst;
   size_t realPitch;
 
@@ -136,8 +130,6 @@ HIP_TEST_CASE(Unit_hipMemset2D_Negative_OutOfBoundsPtr) {
 
 
 HIP_TEST_CASE(Unit_hipMemset3D_Negative_InvalidPtr) {
-  CHECK_IMAGE_SUPPORT
-
   hipPitchedPtr pitchedDevPtr;
 
   SECTION("Uninitialized PitchedDevPtr") {}
@@ -147,8 +139,6 @@ HIP_TEST_CASE(Unit_hipMemset3D_Negative_InvalidPtr) {
 }
 
 HIP_TEST_CASE(Unit_hipMemset3D_Negative_ModifiedPtr) {
-  CHECK_IMAGE_SUPPORT
-
   hipPitchedPtr pitchedDevPtr;
 
   HIP_CHECK(hipMalloc3D(&pitchedDevPtr, validExtent));
@@ -170,8 +160,6 @@ HIP_TEST_CASE(Unit_hipMemset3D_Negative_ModifiedPtr) {
 }
 
 HIP_TEST_CASE(Unit_hipMemset3D_Negative_InvalidSizes) {
-  CHECK_IMAGE_SUPPORT
-
   hipPitchedPtr pitchedDevPtr;
   HIP_CHECK(hipMalloc3D(&pitchedDevPtr, validExtent));
   hipExtent invalidExtent{validExtent};
@@ -198,8 +186,6 @@ HIP_TEST_CASE(Unit_hipMemset3D_Negative_InvalidSizes) {
 }
 
 HIP_TEST_CASE(Unit_hipMemset3D_Negative_OutOfBounds) {
-  CHECK_IMAGE_SUPPORT
-
   hipPitchedPtr pitchedDevPtr;
 
   HIP_CHECK(hipMalloc3D(&pitchedDevPtr, validExtent));

--- a/projects/hip-tests/catch/unit/memory/hipPointerGetAttribute.cc
+++ b/projects/hip-tests/catch/unit/memory/hipPointerGetAttribute.cc
@@ -59,7 +59,6 @@ static __global__ void var_update(int* data) {
    correct memory type and device oridinal are returned */
 HIP_TEST_CASE(Unit_hipPointerGetAttribute_MemoryTypes) {
   CHECK_IMAGE_SUPPORT
-
   HIP_CHECK(hipSetDevice(0));
   size_t pitch_A;
   size_t width{NUM_W * sizeof(char)};
@@ -323,7 +322,6 @@ HIP_TEST_CASE(Unit_hipPointerGetAttribute_Negative) {
 /* Allocate memory using different Allocation APIs and check whether
    IPC CAPABLE attribute returns correctly */
 HIP_TEST_CASE(Unit_hipPointerGetAttribute_ipc_capable) {
-
   HIP_CHECK(hipSetDevice(0));
   size_t Nbytes = N * sizeof(int);
   unsigned int datatype;
@@ -340,7 +338,6 @@ HIP_TEST_CASE(Unit_hipPointerGetAttribute_ipc_capable) {
   size_t pitch_A;
   size_t width{NUM_W * sizeof(char)};
   SECTION("Malloc Pitch Allocation") {
-    CHECK_IMAGE_SUPPORT
     char* A_d;
     HIP_CHECK(hipMallocPitch(reinterpret_cast<void**>(&A_d), &pitch_A, width, NUM_H));
     HIP_CHECK(hipPointerGetAttribute(&datatype, HIP_POINTER_ATTRIBUTE_IS_LEGACY_HIP_IPC_CAPABLE,


### PR DESCRIPTION
## Motivation
This PR removes CHECK_IMAGE_SUPPORT gating from a broad set of HIP memory tests (memcpy/memset/malloc pitch/3D, etc.) so that 2D/3D pitched-memory test coverage is not skipped on devices lacking image/texture support.
<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
