### PR TITLE
[rocprofiler-compute] Fix LD_PRELOAD overwrite bug in rocprofiler-compute profiler

### DIFF
--- a/projects/rocprofiler-compute/src/rocprof_compute_profile/profiler_rocprofiler_sdk.py
+++ b/projects/rocprofiler-compute/src/rocprof_compute_profile/profiler_rocprofiler_sdk.py
@@ -24,6 +24,7 @@
 ##############################################################################
 
 import argparse
+import os
 import shlex
 from pathlib import Path
 from typing import Optional, Union
@@ -54,10 +55,18 @@ class rocprofiler_sdk_profiler(RocProfCompute_Base):
         args = self.get_args()
         app_cmd = shlex.split(args.remaining)
 
-        ld_preload = [args.rocprofiler_sdk_tool_path]
+        # Build LD_PRELOAD: preserve user's existing, then append our libs
+        # Order: [user's existing LD_PRELOAD] : [our profiler libs]
+        ld_preload_parts = [
+            os.environ.get("LD_PRELOAD"),  # User's existing LD_PRELOAD (if any)
+            args.rocprofiler_sdk_tool_path,  # Our rocprofiler-sdk tool
+            native_tool_path,  # Native tool (if provided)
+        ]
+        # Filter out None values and join with ':'
+        ld_preload_value = ":".join(part for part in ld_preload_parts if part)
+
         if native_tool_path:
             # Use native tool to collect counters
-            ld_preload.append(native_tool_path)
             options = {"ROCPROF_COUNTER_COLLECTION": "0"}
             console_log(
                 f"Using native counter collection tool: {str(native_tool_path)}"
@@ -66,7 +75,7 @@ class rocprofiler_sdk_profiler(RocProfCompute_Base):
             options = {"ROCPROF_COUNTER_COLLECTION": "1"}
 
         options.update({
-            "LD_PRELOAD": ":".join(ld_preload),
+            "LD_PRELOAD": ld_preload_value,
             "ROCPROF_KERNEL_TRACE": "1",
             "ROCPROF_OUTPUT_FORMAT": args.format_rocprof_output,
             "ROCPROF_OUTPUT_PATH": f"{args.path}/out/pmc_1",
@@ -85,8 +94,12 @@ class rocprofiler_sdk_profiler(RocProfCompute_Base):
         if args.attach_pid:
             # In attach mode, tools are provided using ROCPROF_ATTACH_TOOL_LIBRARY
             # instead of LD_PRELOAD.
+            # Build attach tool list (only our tools, not user's LD_PRELOAD)
+            attach_tools = [args.rocprofiler_sdk_tool_path]
+            if native_tool_path:
+                attach_tools.append(native_tool_path)
             options.update({
-                "ROCPROF_ATTACH_TOOL_LIBRARY": ":".join(ld_preload),
+                "ROCPROF_ATTACH_TOOL_LIBRARY": ":".join(attach_tools),
             })
             options.pop("LD_PRELOAD", None)
 

--- a/projects/rocprofiler-compute/src/rocprof_compute_profile/profiler_rocprofiler_sdk.py
+++ b/projects/rocprofiler-compute/src/rocprof_compute_profile/profiler_rocprofiler_sdk.py
@@ -62,7 +62,7 @@ class rocprofiler_sdk_profiler(RocProfCompute_Base):
             args.rocprofiler_sdk_tool_path,  # Our rocprofiler-sdk tool
             native_tool_path,  # Native tool (if provided)
         ]
-        # Filter out None values and join with ':'
+        # Filter out None and empty string values and join with ':'
         ld_preload_value = ":".join(part for part in ld_preload_parts if part)
 
         if native_tool_path:

--- a/projects/rocprofiler-compute/tests/test_utils.py
+++ b/projects/rocprofiler-compute/tests/test_utils.py
@@ -3022,6 +3022,7 @@ def test_run_prof_sdk_creates_new_env_copy(tmp_path, monkeypatch):
         soc=MockSoc(),
     )
 
+    # Test 1: LD_PRELOAD is already set - should be preserved
     # Since we check all env. vars. in test,
     # empty them out while calling profiling function
     with mock.patch.dict(os.environ, {}, clear=True):
@@ -3066,6 +3067,35 @@ def test_run_prof_sdk_creates_new_env_copy(tmp_path, monkeypatch):
     assert capture_subprocess_called_with_env["LD_PRELOAD"] == expected_ld_preload, (
         f"LD_PRELOAD should be '{expected_ld_preload}' but got "
         f"'{capture_subprocess_called_with_env['LD_PRELOAD']}'"
+    )
+
+    # Test 2: LD_PRELOAD is unset - should only contain profiler tools
+    capture_subprocess_called_with_env = None
+    with mock.patch.dict(os.environ, {}, clear=True):
+        assert len(os.environ) == 0
+        monkeypatch.setenv("EXISTING_VAR", original_env_var)
+        monkeypatch.setenv("LD_LIBRARY_PATH", original_env_var)
+        # Intentionally not setting LD_PRELOAD to test the unset case
+        profiler_options = profiler.get_profiler_options(native_tool_path="native_tool")
+
+        utils.run_prof(
+            fname_str,
+            profiler_options,
+            workload_dir_str,
+            mspec,
+            loglevel,
+            format_rocprof_output,
+        )
+
+    assert capture_subprocess_called_with_env is not None, (
+        "new_env should have been created"
+    )
+    # When LD_PRELOAD is unset, should only contain our profiler tools
+    expected_ld_preload_unset = "sdk_tool:native_tool"
+    actual_ld_preload = capture_subprocess_called_with_env["LD_PRELOAD"]
+    assert actual_ld_preload == expected_ld_preload_unset, (
+        f"LD_PRELOAD should be '{expected_ld_preload_unset}' when unset, "
+        f"but got '{actual_ld_preload}'"
     )
     assert (
         capture_subprocess_called_with_env["ROCPROFILER_METRICS_PATH"] == "dummy_path"

--- a/projects/rocprofiler-compute/tests/test_utils.py
+++ b/projects/rocprofiler-compute/tests/test_utils.py
@@ -3029,6 +3029,7 @@ def test_run_prof_sdk_creates_new_env_copy(tmp_path, monkeypatch):
         original_env_var = "original_value"
         monkeypatch.setenv("EXISTING_VAR", original_env_var)
         monkeypatch.setenv("LD_LIBRARY_PATH", original_env_var)
+        monkeypatch.setenv("LD_PRELOAD", original_env_var)
         profiler_options = profiler.get_profiler_options(native_tool_path="native_tool")
 
         utils.run_prof(
@@ -3050,11 +3051,26 @@ def test_run_prof_sdk_creates_new_env_copy(tmp_path, monkeypatch):
     assert capture_subprocess_called_with_env["EXISTING_VAR"] == original_env_var
     # Ensure LD_LIBRARY_PATH is not touched
     assert capture_subprocess_called_with_env["LD_LIBRARY_PATH"] == original_env_var
+    # Ensure LD_PRELOAD is preserved and our tools are appended
+    assert original_env_var in capture_subprocess_called_with_env["LD_PRELOAD"], (
+        f"User's LD_PRELOAD '{original_env_var}' should be preserved"
+    )
+    assert "sdk_tool" in capture_subprocess_called_with_env["LD_PRELOAD"], (
+        "Profiler sdk_tool should be in LD_PRELOAD"
+    )
+    assert "native_tool" in capture_subprocess_called_with_env["LD_PRELOAD"], (
+        "Native tool should be in LD_PRELOAD"
+    )
+    # Verify the order: user's LD_PRELOAD comes first, then our tools appended
+    expected_ld_preload = f"{original_env_var}:sdk_tool:native_tool"
+    assert capture_subprocess_called_with_env["LD_PRELOAD"] == expected_ld_preload, (
+        f"LD_PRELOAD should be '{expected_ld_preload}' but got "
+        f"'{capture_subprocess_called_with_env['LD_PRELOAD']}'"
+    )
     assert (
         capture_subprocess_called_with_env["ROCPROFILER_METRICS_PATH"] == "dummy_path"
     )
     assert capture_subprocess_called_with_env["ROCPROF_COUNTER_COLLECTION"] == "0"
-    assert capture_subprocess_called_with_env["LD_PRELOAD"] == "sdk_tool:native_tool"
     assert capture_subprocess_called_with_env["ROCPROF_KERNEL_TRACE"] == "1"
     assert capture_subprocess_called_with_env["ROCPROF_OUTPUT_FORMAT"] == "format"
     assert capture_subprocess_called_with_env["ROCPROF_OUTPUT_PATH"] == "path/out/pmc_1"


### PR DESCRIPTION
## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

Preserve user's existing LD_PRELOAD environment variable by prepending it to profiler libraries instead of overwriting. This ensures compatibility with sanitizer libraries and other user tools that rely on LD_PRELOAD.

## Technical Details

  **File: `src/rocprof_compute_profile/profiler_rocprofiler_sdk.py`**
  - Modified `get_profiler_options()` method to build LD_PRELOAD list preserving user's existing value
  - Order: `[user's existing LD_PRELOAD] : [rocprofiler-sdk tool] : [native tool]`
  - Filter out None values before joining with ':'
  - In attach mode, correctly uses `ROCPROF_ATTACH_TOOL_LIBRARY` (profiler tools only) instead of `LD_PRELOAD`

  **File: `tests/test_utils.py`**
  - Enhanced existing test `test_run_prof_sdk_creates_new_env_copy` to verify LD_PRELOAD preservation
  - Added assertions to check that user's LD_PRELOAD is preserved and profiler tools are appended in correct order
  - Validates expected format: `original_value:sdk_tool:native_tool`

Fixes https://github.com/ROCm/rocm-systems/issues/3989

<!-- Explain the changes along with any relevant GitHub links. -->

## JIRA ID

Resolves AIPROFCOMP-464

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan

1. Enhanced unit test `test_run_prof_sdk_creates_new_env_copy` in `tests/test_utils.py`:
     - Sets user's LD_PRELOAD to a custom value
     - Verifies the user's value is preserved in subprocess environment
     - Verifies profiler tools (sdk_tool and native_tool) are appended
     - Validates correct ordering of all components

 2. Manual verification with sanitizer libraries:
     - Set `LD_PRELOAD=/usr/lib/libasan.so` before running rocprof-compute
     - Confirmed user's LD_PRELOAD is preserved in profiled workload

  3. Verified attach mode behavior matches rocprofv3 (uses ROCPROF_ATTACH_TOOL_LIBRARY, not LD_PRELOAD)

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

  - All unit tests pass including the enhanced LD_PRELOAD preservation test
  - Pre-commit hooks (ruff check, ruff format, hash consistency) pass
  - Manual testing confirms user's LD_PRELOAD is preserved correctly

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
