### PR TITLE
ROCM-6497 - Restore global MemObjMap for device VAs if its not same as host registered ptr on Linux

### DIFF
--- a/projects/clr/hipamd/src/hip_memory.cpp
+++ b/projects/clr/hipamd/src/hip_memory.cpp
@@ -1312,7 +1312,13 @@ hipError_t ihipHostRegister(void* hostPtr, size_t sizeBytes, unsigned int flags)
       if (devMem != nullptr) {
         void* vAddr = reinterpret_cast<void*>(devMem->virtualAddress());
         if (hostPtr != vAddr) {
-          amdDevice->AddDevMemObj(vAddr, mem);
+          if (IS_WINDOWS) {
+            amdDevice->AddDevMemObj(vAddr, mem);
+          } else {
+            if (amd::MemObjMap::FindMemObj(vAddr) == nullptr) {
+              amd::MemObjMap::AddMemObj(vAddr, mem);
+            }
+          }
         }
       }
     }
@@ -1352,7 +1358,13 @@ hipError_t ihipHostUnregister(void* hostPtr) {
       if (devMem != nullptr) {
         void* vAddr = reinterpret_cast<void*>(devMem->virtualAddress());
         if (vAddr != hostPtr) {
-          amdDevice->RemoveDevMemObj(vAddr);
+          if (IS_WINDOWS) {
+            amdDevice->RemoveDevMemObj(vAddr);
+          } else {
+            if (amd::MemObjMap::FindMemObj(vAddr)) {
+              amd::MemObjMap::RemoveMemObj(vAddr);
+            }
+          }
         }
       }
     }


### PR DESCRIPTION
## Motivation

Some tests using host-registered ptrs are failing on Linux due to not finding them in the global memobj map.

## Technical Details

Fixes the issue by adding Vaddr to global memobj map instead of per device map on Linux.

## JIRA ID

Resolves ROCM-6497

## Test Plan

Verify with hipMemset* and hipStreamValue_Wait* tests.

## Test Result

Pass

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
