### PR TITLE
[rocprofiler-systems] Add amd_smi_data_parse.py to ROCPROFSYS_PYTHON_VALIDATION_FILES and fix Jacobi-USM test

### DIFF
--- a/projects/rocprofiler-systems/tests/CMakeLists.txt
+++ b/projects/rocprofiler-systems/tests/CMakeLists.txt
@@ -93,6 +93,7 @@ endif()
 # ------------------------------------------------------------------------------#
 
 set(ROCPROFSYS_PYTHON_VALIDATION_FILES
+    ${CMAKE_CURRENT_LIST_DIR}/amd_smi_data_parse.py
     ${CMAKE_CURRENT_LIST_DIR}/validate-causal-json.py
     ${CMAKE_CURRENT_LIST_DIR}/validate-perfetto-proto.py
     ${CMAKE_CURRENT_LIST_DIR}/validate-rocpd.py

--- a/projects/rocprofiler-systems/tests/pytest/test_hpc.py
+++ b/projects/rocprofiler-systems/tests/pytest/test_hpc.py
@@ -86,6 +86,7 @@ class TestJacobi(RocprofsysTest):
             "kfd_event_page_fault,kfd_event_page_migrate,"
             "kfd_event_queue,kfd_event_unmap_from_gpu,kfd_event_dropped_events"
         )
+        env["ROCPROFSYS_TRACE_LEGACY"] = "ON"
         env["HSA_XNACK"] = "1"
         if "apu" not in gpu_info.categories:
             # Forces zero-copy behavior on non-APU GPUs
@@ -101,21 +102,21 @@ class TestJacobi(RocprofsysTest):
         )
 
         if "apu" in gpu_info.categories:
-            # We expect no ompt_target_data_op_emi (CPU and GPU share the same memory)
+            # We expect no omp_target_data_op_emi (CPU and GPU share the same memory)
             self.assert_regex(
                 result,
                 subtest_name="USM Zero-Copy Validation (APU)",
-                fail_regex=["ompt_target_data_op_emi"],
+                fail_regex=["omp_target_data_op_emi"],
             )
 
             self.assert_perfetto(
                 result,
                 subtest_name="Perfetto USM Zero-Copy Validation (APU)",
-                fail_regex=["ompt_target_data_op_emi"],
+                fail_regex=["omp_target_data_op_emi"],
             )
 
         else:
-            # We expect to see only one ompt_target_data_op_emi
+            # We expect to see only one omp_target_data_op_emi
             # Corresponds to the Fortran array descriptor being transferred
             #   at the start of the program
             self.assert_regex(
@@ -128,7 +129,7 @@ class TestJacobi(RocprofsysTest):
                 result,
                 subtest_name="Perfetto USM Zero-Copy validation (Non-APU)",
                 categories=["rocm_ompt_api"],
-                labels=["ompt_target_data_op_emi"],
+                labels=["omp_target_data_op_emi"],
                 counts=[1],
                 depths=[1],
             )


### PR DESCRIPTION
## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

Validation PyTests are failing as `amd_smi_data_parse.py` was never copied to build folder.
This will also fix potential failure on TheRock.

Furthermore, Jacobi-USM test was flawed and would fail because:
1. ROCPROFSYS_TRACE_LEGACY was not set to ON
2. The regexes would search for `ompt_target_data_emi` instead of `omp_target_data_emi`.

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

Add amd_smi_data_parse.py to ROCPROFSYS_PYTHON_VALIDATION_FILES
Added both fixes mentioned above for Jacobi-USM

## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

Validation tests fail before change

## Test Result

<!-- Briefly summarize test outcomes. -->

With change, validation tests pass

**The Jacobi-USM tests also pass**
test_hpc.py::TestJacobi::test_usm[sys_run] SUBPASSED[USM Zero-Copy validation (Non-APU)] [100%]
test_hpc.py::TestJacobi::test_usm[sys_run] SUBPASSED[Perfetto USM Zero-Copy validation (Non-APU)] [100%]
test_hpc.py::TestJacobi::test_usm[sys_run] PASSED [100%]


## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
