### PR TITLE
[CLR][NFCI] Split argument capture optimization

### DIFF
--- a/projects/clr/rocclr/platform/command.cpp
+++ b/projects/clr/rocclr/platform/command.cpp
@@ -671,7 +671,11 @@ int32_t NDRangeKernelCommand::captureHIPArgsAndValidate(void** kernelParams, add
     return CL_OUT_OF_RESOURCES;
   }
 
-  if (!kernel().parameters().captureHIPArgs(kernelParams, kernArgs, kernArgsSize, parameters_)) {
+  // Pick the right capture method based on the kernel parameters layout.
+  bool captureSuccess =
+      kernelParams ? kernel().parameters().captureHIPArgs(kernelParams, parameters_)
+                   : kernel().parameters().captureHIPArgs(kernArgs, kernArgsSize, parameters_);
+  if (!captureSuccess) {
     LogError("Cannot capture and set the kernel parameters");
     return CL_OUT_OF_RESOURCES;
   }

--- a/projects/clr/rocclr/platform/kernel.cpp
+++ b/projects/clr/rocclr/platform/kernel.cpp
@@ -90,54 +90,69 @@ address KernelParameters::alloc(device::VirtualDevice& vDev) {
 }
 
 // =================================================================================================
-bool KernelParameters::captureHIPArgs(void** kernelParams, address kernArgs, size_t kernArgsSize,
-                                      address mem) {
-  amd::Memory** memories = reinterpret_cast<amd::Memory**>(mem + memoryObjOffset());
-  for (size_t idx = 0; idx < signature_.numParameters(); ++idx) {
-    KernelParameterDescriptor& desc = signature_.params()[idx];
-    void* value = kernelParams ? kernelParams[idx] : kernArgs + desc.offset_;
-    void* param = mem + desc.offset_;
-    uint32_t uint32_value = 0;
-    uint64_t uint64_value = 0;
-    // if using the 'extra' path and this parameter lies beyond supplied size, write zero
-    if (kernelParams == nullptr && ((desc.offset_ + desc.size_) > kernArgsSize)) {
-      value = &uint64_value;
-    }
-    if (desc.type_ == T_POINTER) {
-      LP64_SWITCH(uint32_value, uint64_value) = *(LP64_SWITCH(uint32_t*, uint64_t*))value;
-      Memory* memArg = nullptr;
-      if (!AMD_DIRECT_DISPATCH) {
-        memArg = amd::MemObjMap::FindMemObj(*reinterpret_cast<const void* const*>(value));
-        if (memArg != nullptr) {
-          memArg->retain();
-        }
-      }
-      memories[desc.info_.arrayIndex_] = memArg;
-    } else {
-      assert((desc.type_ != T_SAMPLER && desc.type_ != T_QUEUE) &&
-             "Unexpected argument type for a HIP kernel");
-      switch (desc.size_) {
-        case 4:
-          uint32_value = *(static_cast<const uint32_t*>(value));
-          break;
-        case 8:
-          uint64_value = *(static_cast<const uint64_t*>(value));
-          break;
-      }
-    }
+// Helper function for capturing and retaining memory objects for a kernel launch after the kernel
+// parameters have been set.
+static void captureMemObjs(address mem, const KernelSignature& signature, size_t memoryObjOffset) {
+  amd::Memory** memories = reinterpret_cast<amd::Memory**>(mem + memoryObjOffset);
+  for (const KernelParameterDescriptor& desc : signature.params()) {
+    if (desc.type_ != T_POINTER) continue;
 
+    Memory* memArg = nullptr;
+    if (!AMD_DIRECT_DISPATCH) {
+      memArg =
+          amd::MemObjMap::FindMemObj(*reinterpret_cast<const void* const*>(mem + desc.offset_));
+      if (memArg != nullptr) {
+        memArg->retain();
+      }
+    }
+    memories[desc.info_.arrayIndex_] = memArg;
+  }
+}
+
+bool KernelParameters::captureHIPArgs(address kernArgs, size_t kernArgsSize, address mem) {
+  assert(kernArgs && kernArgsSize && "kernArgs cannot be null when the size is non-zero");
+  assert(std::none_of(signature_.params().begin(), signature_.params().end(),
+                      [](const KernelParameterDescriptor& desc) {
+                        return desc.type_ != T_SAMPLER && desc.type_ != T_QUEUE;
+                      }) &&
+         "Unexpected argument type for a HIP kernel");
+
+  // Copy the arguments into the buffer allocated for the kernel parameters. Only copy as much as
+  // the signature defines, even if the user passed more, to avoid out-of-bounds access in the case
+  // where the user passed a size larger than what the kernel expects.
+  ::memcpy(mem, kernArgs, std::min(kernArgsSize, size_t{signature_.paramsSize()}));
+
+  // After the parameters have been registered, go through and capture the memory objects.
+  captureMemObjs(mem, signature_, memoryObjOffset());
+
+  return true;
+}
+
+bool KernelParameters::captureHIPArgs(void** kernelParams, address mem) {
+  assert(kernelParams && "kernelParams cannot be null");
+  for (size_t idx = 0; idx < signature_.numParameters(); ++idx) {
+    const KernelParameterDescriptor& desc = signature_.params()[idx];
+    void* value = kernelParams[idx];
+    void* param = mem + desc.offset_;
+
+    assert((desc.type_ != T_SAMPLER && desc.type_ != T_QUEUE) &&
+            "Unexpected argument type for a HIP kernel");
     switch (desc.size_) {
       case sizeof(uint32_t):
-        *static_cast<uint32_t*>(param) = uint32_value;
+        *static_cast<uint32_t*>(param) = *static_cast<const uint32_t*>(value);
         break;
       case sizeof(uint64_t):
-        *static_cast<uint64_t*>(param) = uint64_value;
+        *static_cast<uint64_t*>(param) = *static_cast<const uint64_t*>(value);
         break;
       default:
         ::memcpy(param, value, desc.size_);
         break;
     }
   }
+
+  // After the parameters have been registered, go through again and capture the memory objects.
+  captureMemObjs(mem, signature_, memoryObjOffset());
+
   return true;
 }
 

--- a/projects/clr/rocclr/platform/kernel.hpp
+++ b/projects/clr/rocclr/platform/kernel.hpp
@@ -79,6 +79,7 @@ class KernelSignature : public HeapObject {
   }
 
   std::vector<KernelParameterDescriptor>& params() { return params_; }
+  const std::vector<KernelParameterDescriptor>& params() const { return params_; }
 
   //! Return the size in bytes required for the arguments on the stack.
   uint32_t paramsSize() const { return paramsSize_; }
@@ -201,8 +202,11 @@ class KernelParameters : protected HeapObject {
   //! Capture the state of the parameters and return the stack base pointer.
   address captureOpenCLArgs(device::VirtualDevice& vDev, uint64_t lclMemSize, int32_t* error);
 
-  //! Capture the arguments from signature and set.
-  bool captureHIPArgs(void** kernelParams, address kernArgs, size_t kernArgsSize, address mem);
+  //! Capture the arguments in a list of pointers to arguments based on the signature and set.
+  bool captureHIPArgs(void** kernelParams, address mem);
+
+  //! Capture the arguments in pre-packed arguments based on the signature and set.
+  bool captureHIPArgs(address kernArgs, size_t kernArgsSize, address mem);
 
   //! Release the captured state of the parameters.
   void release(address parameters) const;


### PR DESCRIPTION
## Motivation

The argument capture optimization path in HIP does not currently fully utilize that pre-packed arguments in `extra` should have the same layout as the kernel should expect. Instead, the implementation could do a single memcpy of the pre-packed memory passed to it and process the memory objects arguments afterwards.

## Technical Details

This patch refactors the argument capture logic in the KernelParameters class to separate the copying of kernel arguments from the capturing of memory objects. This allows cases where pre-packed arguments are used to populate the kernel parameters with a single memcpy. It also allows the implementation of the capturing of the list of argument pointers to be simplified significantly.

## JIRA ID

N/A

## Test Plan

No functional changes are intended with this patch, so existing testing should cover it.

## Test Result

No functional changes are intended with this patch, so existing testing should cover it.

## Submission Checklist

- [X] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
