### PR TITLE
Avoid graph stream queue collision: UpdateStreams + getQueueId hints

### DIFF
--- a/projects/clr/hipamd/src/hip_graph_internal.cpp
+++ b/projects/clr/hipamd/src/hip_graph_internal.cpp
@@ -831,8 +831,8 @@ hipError_t GraphExec::CreateStreams(uint32_t num_streams, int devId) {
     max_streams, devId);
   parallel_streams_[devId].reserve(max_streams);
   for (uint32_t i = 0; i < max_streams; ++i) {
-    auto stream = new hip::Stream(g_devices[devId], hip::Stream::Priority::Normal,
-                                  hipStreamNonBlocking);
+    auto stream =
+        new hip::Stream(g_devices[devId], hip::Stream::Priority::Normal, hipStreamNonBlocking);
 
     if (!stream->Create()) {
       ClPrint(amd::LOG_ERROR, amd::LOG_CODE, "[hipGraph] Failed to create stream %u for device %d",
@@ -1734,31 +1734,27 @@ hipError_t GraphExec::EnqueueSegment(const Segment& segment, hip::Stream* stream
 // ================================================================================================
 void GraphExec::UpdateStreams(hip::Stream* launch_stream) {
   int devId = launch_stream->vdev()->device().index();
-  // Clear any previous stream assignments
   streams_.clear();
-  // Current stream is the default in the assignment
   streams_.push_back(launch_stream);
   if (parallel_streams_.find(devId) == parallel_streams_.end()) {
     LogPrintfError("UpdateStreams failed for device id:%d", devId);
     return;
   }
   auto parallel_streams = parallel_streams_[devId];
-  std::unordered_map<int, int> unique_stream_ids;
-  unique_stream_ids[launch_stream->getQueueID()] = 1;
-  std::vector<hip::Stream*> collided_streams;
-  // Assign streams that are unique in parallel_streams and doesnt collide with launch stream
-  for (uint32_t i = 0; i < parallel_streams.size(); i++) {
-    auto qid = parallel_streams[i]->getQueueID();
-    if (unique_stream_ids[qid] == 0) {
-      streams_.push_back(parallel_streams[i]);
-    } else {
-      collided_streams.push_back(parallel_streams[i]);
-    }
-    unique_stream_ids[qid]++;
+  std::vector<uint32_t> exclude_list;
+  uint64_t launch_qid = launch_stream->getQueueID();
+  if (launch_qid != static_cast<uint64_t>(-1)) {
+    exclude_list.push_back(static_cast<uint32_t>(launch_qid));
   }
-  // Assign the remaining streams for execution.
-  for (int i = streams_.size(), j = 0; i < max_streams_ && j < collided_streams.size(); i++, j++) {
-    streams_.push_back(collided_streams[j]);
+  const std::vector<uint32_t>* hint = exclude_list.empty() ? nullptr : &exclude_list;
+  for (uint32_t i = 0; i < parallel_streams.size() && streams_.size() < static_cast<size_t>(max_streams_);
+       i++) {
+    hip::Stream* s = parallel_streams[i];
+    uint64_t qid = s->getQueueID(hint, true);
+    if (qid != static_cast<uint64_t>(-1)) {
+      exclude_list.push_back(static_cast<uint32_t>(qid));
+    }
+    streams_.push_back(s);
   }
 }
 
@@ -1996,8 +1992,8 @@ hipError_t GraphExec::Run(hip::Stream* launch_stream) {
       launch_stream->vdev()->HiddenHeapInit();
       initialized = true;
     }
-    // Update streams for the graph execution only if launch stream changed
-    if (lastLaunchStream_ != launch_stream) {
+    // Update streams only when launch stream changed and its HW queue is not assigned yet
+    if (lastLaunchStream_ != launch_stream || !launch_stream->hasAssignedQueue()) {
       UpdateStreams(launch_stream);
       lastLaunchStream_ = launch_stream;
     }
@@ -2021,8 +2017,8 @@ hipError_t GraphExec::Run(hip::Stream* launch_stream) {
       topoOrder_[i]->EnqueueCommands(launch_stream);
     }
   } else {
-    // Update streams for the graph execution only if launch stream changed
-    if (lastLaunchStream_ != launch_stream) {
+    // Update streams only when launch stream changed and its HW queue is not assigned yet
+    if (lastLaunchStream_ != launch_stream || !launch_stream->hasAssignedQueue()) {
       UpdateStreams(launch_stream);
       lastLaunchStream_ = launch_stream;
     }

--- a/projects/clr/hipamd/src/hip_stream.cpp
+++ b/projects/clr/hipamd/src/hip_stream.cpp
@@ -404,7 +404,7 @@ hipError_t hipStreamDestroy(hipStream_t stream) {
     if (s->GetParentStream() != nullptr) {
       reinterpret_cast<hip::Stream*>(s->GetParentStream())->EraseParallelCaptureStream(stream);
     }
-    s->EndCapture();
+    [[maybe_unused]] const auto err = s->EndCapture();
   }
   s->GetDevice()->RemoveStreamFromPools(s);
 

--- a/projects/clr/rocclr/device/device.hpp
+++ b/projects/clr/rocclr/device/device.hpp
@@ -1253,7 +1253,10 @@ class VirtualDevice : public amd::ReferenceCountedObject {
 
   //! Return the physical device for this virtual device.
   const amd::Device& device() const { return device_(); }
-  virtual uint64_t getQueueID() = 0;
+  virtual uint64_t getQueueID(const std::vector<uint32_t>* exclusionHint = nullptr,
+                              bool forceAcquire = false) = 0;
+  //! True if this virtual device already has an HW queue assigned (no lazy assign on read).
+  virtual bool hasAssignedQueue() const { return true; }
   virtual void submitReadMemory(amd::ReadMemoryCommand& cmd) = 0;
   virtual void submitWriteMemory(amd::WriteMemoryCommand& cmd) = 0;
   virtual void submitCopyMemory(amd::CopyMemoryCommand& cmd) = 0;

--- a/projects/clr/rocclr/device/pal/palvirtual.hpp
+++ b/projects/clr/rocclr/device/pal/palvirtual.hpp
@@ -302,7 +302,12 @@ class VirtualGPU : public device::VirtualDevice {
               amd::CommandQueue::Priority priority = amd::CommandQueue::Priority::Normal);
   ~VirtualGPU();
 
-  uint64_t getQueueID() { return hwRing_; }
+  uint64_t getQueueID(const std::vector<uint32_t>* exclusionHint = nullptr,
+                      bool forceAcquire = false) override {
+    (void)exclusionHint;
+    (void)forceAcquire;
+    return hwRing_;
+  }
   void submitReadMemory(amd::ReadMemoryCommand& vcmd);
   void submitWriteMemory(amd::WriteMemoryCommand& vcmd);
   void submitCopyMemory(amd::CopyMemoryCommand& vcmd);

--- a/projects/clr/rocclr/device/rocm/rocdevice.cpp
+++ b/projects/clr/rocclr/device/rocm/rocdevice.cpp
@@ -2865,7 +2865,8 @@ void Device::getHwEventTime(const amd::Event& event, uint64_t* start, uint64_t* 
 }
 
 // ================================================================================================
-hsa_queue_t* Device::getQueueFromPool(const uint qIndex, bool force_reuse) {
+hsa_queue_t* Device::getQueueFromPool(const uint qIndex, bool force_reuse,
+                                      const std::vector<uint32_t>* excludedHwQueueIds) {
   // Only reuse queues when we've reached the maximum limit, unless forced
   // Below the limit, return nullptr to allow creating new queues
   if (!force_reuse && queuePool_[qIndex].size() < settings().max_hw_queues_) {
@@ -2876,32 +2877,38 @@ hsa_queue_t* Device::getQueueFromPool(const uint qIndex, bool force_reuse) {
   if (qIndex < QueuePriority::Total && queuePool_[qIndex].size() > 0) {
     typedef decltype(queuePool_)::value_type::const_reference PoolRef;
 
-    // Select queue based on dynamic_queues_ mode
+    // Select queue based on dynamic_queues_ mode; prefer queues not in excludedHwQueueIds
     decltype(queuePool_[qIndex].begin()) lowest;
     uint32_t mode = settings().dynamic_queues_;
 
-    // gfx9XX pipe distribution: queues map to pipes via queue_id % num_pipes
     const bool pipe_dist = settings().queue_pipe_dist_;
     const uint32_t num_pipes = numHwPipes_;
 
+    auto isExcluded = [excludedHwQueueIds](uint64_t queue_id) -> bool {
+      if (excludedHwQueueIds == nullptr || excludedHwQueueIds->empty()) return false;
+      const uint32_t id = static_cast<uint32_t>(queue_id);
+      return std::find(excludedHwQueueIds->begin(), excludedHwQueueIds->end(), id) !=
+             excludedHwQueueIds->end();
+    };
+
     lowest = std::min_element(
         queuePool_[qIndex].begin(), queuePool_[qIndex].end(),
-        [mode, pipe_dist, num_pipes](PoolRef A, PoolRef B) {
+        [mode, pipe_dist, num_pipes, isExcluded](PoolRef A, PoolRef B) {
+          const bool aExcl = isExcluded(A.first->id);
+          const bool bExcl = isExcluded(B.first->id);
+          if (aExcl != bExcl) return !aExcl;
+
           if (mode >= 1) {
-            // Mode 1+: Advanced weighted metric with dedicated queue penalty
-            // Metric = dedicated_queue_penalty + (depth << 4) + refCount
             uint64_t metricA = A.second.GetLoadMetric(A.first, mode);
             uint64_t metricB = B.second.GetLoadMetric(B.first, mode);
 
             if (metricA == metricB && pipe_dist) {
-              // gfx9XX pipe distribution: prefer lower pipe IDs for consistent distribution
               uint64_t pipeA = A.first->id % num_pipes;
               uint64_t pipeB = B.first->id % num_pipes;
               return pipeA < pipeB;
             }
             return metricA < metricB;
           } else {
-            // Mode 0: Simple refCount-based selection
             return A.second.refCount < B.second.refCount;
           }
         });
@@ -2920,10 +2927,11 @@ hsa_queue_t* Device::getQueueFromPool(const uint qIndex, bool force_reuse) {
 }
 
 // ================================================================================================
-hsa_queue_t* Device::AcquireActiveQueue(amd::CommandQueue::Priority priority) {
+hsa_queue_t* Device::AcquireActiveQueue(amd::CommandQueue::Priority priority,
+                                        const std::vector<uint32_t>& excludedHwQueueIds) {
   uint32_t queue_size = ROC_AQL_QUEUE_SIZE;
   auto queue = acquireQueue(queue_size, false, std::vector<uint32_t>{},
-                            priority, true, false);
+                            priority, true, false, excludedHwQueueIds);
   return queue;
 }
 
@@ -2931,7 +2939,8 @@ hsa_queue_t* Device::AcquireActiveQueue(amd::CommandQueue::Priority priority) {
 hsa_queue_t* Device::acquireQueue(uint32_t queue_size_hint, bool coop_queue,
                                   const std::vector<uint32_t>& cuMask,
                                   amd::CommandQueue::Priority priority, bool managed,
-                                  bool dedicated_queue) {
+                                  bool dedicated_queue,
+                                  const std::vector<uint32_t>& excludedHwQueueIds) {
   hsa_amd_queue_priority_t queue_priority;
   uint qIndex;
   switch (priority) {
@@ -2983,7 +2992,9 @@ hsa_queue_t* Device::acquireQueue(uint32_t queue_size_hint, bool coop_queue,
     // decide when to start reclaiming queues.
     if (!coop_queue && (cuMask.size() == 0) &&
         (queuePool_[qIndex].size() >= settings().max_hw_queues_)) {
-      hsa_queue_t* queue = getQueueFromPool(qIndex, false);
+      const std::vector<uint32_t>* pExcluded =
+          excludedHwQueueIds.empty() ? nullptr : &excludedHwQueueIds;
+      hsa_queue_t* queue = getQueueFromPool(qIndex, false, pExcluded);
       if (queue != nullptr) {
         if (!managed) {
           num_queues_[qIndex]++;
@@ -3021,7 +3032,9 @@ hsa_queue_t* Device::acquireQueue(uint32_t queue_size_hint, bool coop_queue,
         amd::ScopedLock l(active_queue_access_);
         if (queuePool_[qIndex].size() > 0) {
           bool kForceReuse = true;
-          return getQueueFromPool(qIndex, kForceReuse);
+          const std::vector<uint32_t>* pExcluded =
+              excludedHwQueueIds.empty() ? nullptr : &excludedHwQueueIds;
+          return getQueueFromPool(qIndex, kForceReuse, pExcluded);
         }
       }
       ClPrint(amd::LOG_DETAIL_DEBUG, amd::LOG_QUEUE,

--- a/projects/clr/rocclr/device/rocm/rocdevice.hpp
+++ b/projects/clr/rocclr/device/rocm/rocdevice.hpp
@@ -538,13 +538,15 @@ class Device : public NullDevice {
   hsa_queue_t* acquireQueue(
       uint32_t queue_size_hint, bool coop_queue = false, const std::vector<uint32_t>& cuMask = {},
       amd::CommandQueue::Priority priority = amd::CommandQueue::Priority::Normal,
-      bool managed = false, bool dedicated_queue = false);
+      bool managed = false, bool dedicated_queue = false,
+      const std::vector<uint32_t>& excludedHwQueueIds = {});
 
   //! Release HSA queue
   void releaseQueue(hsa_queue_t*, const std::vector<uint32_t>& cuMask = {}, bool coop_queue = false,
                     bool managed = false);
 
-  hsa_queue_t* AcquireActiveQueue(amd::CommandQueue::Priority priority);
+  hsa_queue_t* AcquireActiveQueue(amd::CommandQueue::Priority priority,
+                                  const std::vector<uint32_t>& excludedHwQueueIds = {});
   bool ReleaseActiveQueue(hsa_queue_t* queue, amd::CommandQueue::Priority priority);
 
   //! For the given HSA queue, return an existing hostcall buffer or create a
@@ -712,7 +714,8 @@ class Device : public NullDevice {
   std::atomic<uint32_t> num_queues_[QueuePriority::Total] = {};  //!< Per-priority queue counters
 
   //! Use dynamic queues mode to get a queue from pool
-  hsa_queue_t* getQueueFromPool(const uint qIndex, bool force_reuse = false);
+  hsa_queue_t* getQueueFromPool(const uint qIndex, bool force_reuse = false,
+                                const std::vector<uint32_t>* excludedHwQueueIds = nullptr);
 
   void* coopHostcallBuffer_;
   //! returns value for corresponding LinkAttrbutes in a vector given Memory pool.

--- a/projects/clr/rocclr/device/rocm/rocvirtual.cpp
+++ b/projects/clr/rocclr/device/rocm/rocvirtual.cpp
@@ -26,6 +26,7 @@
 #include <memory>
 #include <string>
 #include <thread>
+#include <algorithm>
 #include <vector>
 #include <atomic>
 #include <cinttypes>
@@ -962,13 +963,31 @@ bool VirtualGPU::processMemObjects(const amd::Kernel& kernel, const_address para
 }
 
 // ================================================================================================
-uint64_t VirtualGPU::getQueueID() {
+uint64_t VirtualGPU::getQueueID(const std::vector<uint32_t>* exclusionHint, bool forceAcquire) {
   std::scoped_lock lock(execution());
-  // Dedicated queues keep their HW queue, never acquire from pool
-  if (!dedicated_queue_ && gpu_queue_ == nullptr) {
-    gpu_queue_ = roc_device_.AcquireActiveQueue(priority_);
+  if (dedicated_queue_) {
+    return (gpu_queue_ != nullptr) ? gpu_queue_->id : UINT64_MAX;
   }
-  return gpu_queue_->id;
+  if (forceAcquire && gpu_queue_ != nullptr && exclusionHint != nullptr && !exclusionHint->empty()) {
+    const uint32_t current_id = static_cast<uint32_t>(gpu_queue_->id);
+    bool collision =
+        (std::find(exclusionHint->begin(), exclusionHint->end(), current_id) != exclusionHint->end());
+    if (collision) {
+      if (roc_device_.ReleaseActiveQueue(gpu_queue_, priority_)) {
+        gpu_queue_ = nullptr;
+      }
+      gpu_queue_ = roc_device_.AcquireActiveQueue(priority_, *exclusionHint);
+    }
+    return (gpu_queue_ != nullptr) ? gpu_queue_->id : UINT64_MAX;
+  }
+  if (gpu_queue_ == nullptr) {
+    if (exclusionHint != nullptr && !exclusionHint->empty()) {
+      gpu_queue_ = roc_device_.AcquireActiveQueue(priority_, *exclusionHint);
+    } else {
+      gpu_queue_ = roc_device_.AcquireActiveQueue(priority_);
+    }
+  }
+  return (gpu_queue_ != nullptr) ? gpu_queue_->id : UINT64_MAX;
 }
 
 // ================================================================================================
@@ -1832,10 +1851,9 @@ VirtualGPU::~VirtualGPU() {
 
 // ================================================================================================
 bool VirtualGPU::create() {
-  // Pick a reasonable queue size
   uint32_t queue_size = ROC_AQL_QUEUE_SIZE;
   gpu_queue_ = roc_device_.acquireQueue(queue_size, cooperative_, cuMask_, priority_, false,
-                                         dedicated_queue_);
+                                        dedicated_queue_, {});
   if (!gpu_queue_) return false;
 
   if (!managed_kernarg_buffer_.Create(Device::MemorySegment::kKernArg)) {
@@ -3755,7 +3773,9 @@ static inline void nontemporalMemcpy(void* __restrict dst, const void* __restric
 }
 #endif
 
-void VirtualGPU::HiddenHeapInit() { const_cast<Device&>(dev()).HiddenHeapInit(*this); }
+void VirtualGPU::HiddenHeapInit() { 
+  getQueueID();
+  const_cast<Device&>(dev()).HiddenHeapInit(*this); }
 
 // ================================================================================================
 bool VirtualGPU::submitKernelInternal(const amd::NDRangeContainer& sizes, const amd::Kernel& kernel,

--- a/projects/clr/rocclr/device/rocm/rocvirtual.hpp
+++ b/projects/clr/rocclr/device/rocm/rocvirtual.hpp
@@ -400,6 +400,7 @@ class VirtualGPU : public device::VirtualDevice {
 
   hsa_agent_t gpu_device() const { return gpu_device_; }
   hsa_queue_t* gpu_queue() { return gpu_queue_; }
+  bool hasAssignedQueue() const final { return gpu_queue_ != nullptr; }
   void set_gpu_queue(hsa_queue_t* gpu_queue) { gpu_queue_ = gpu_queue; }
 
   // Return pointer to PrintfDbg
@@ -444,8 +445,8 @@ class VirtualGPU : public device::VirtualDevice {
   void WaitCompleteSignal(hsa_signal_t signal);
 
   void HiddenHeapInit();
-  uint64_t getQueueID();
-
+  uint64_t getQueueID(const std::vector<uint32_t>* exclusionHint = nullptr,
+                      bool forceAcquire = false) final;
   //! Add completion signal to the scheduler queue thread's event list.
   //! Wakes the scheduler queue thread if it's sleeping.
   void addSchedulerEvent(hsa_signal_t signal) {

--- a/projects/clr/rocclr/platform/commandqueue.hpp
+++ b/projects/clr/rocclr/platform/commandqueue.hpp
@@ -113,8 +113,7 @@ class CommandQueue : public RuntimeObject {
                uint rtCUs = RealTimeDisabled,            //!< Avaialble real time compute units
                Priority priority = Priority::Normal,     //!< Queue priority
                const std::vector<uint32_t>& cuMask = {}, //!< CU mask
-               bool dedicated_queue = false              //!< TRUE if requires dedicated HW queue
-               )
+               bool dedicated_queue = false)             //!< TRUE if requires dedicated HW queue
       : properties_(propMask, properties),
         rtCUs_(rtCUs),
         priority_(priority),
@@ -301,8 +300,13 @@ class HostQueue : public CommandQueue {
   //! Set the force destory to terminate queue without checking last command
   void SetForceDestroy(bool forceDestroy) { forceDestroy_ = forceDestroy; }
 
-  uint64_t getQueueID() { return thread_.vdev()->getQueueID(); }
-
+  uint64_t getQueueID(const std::vector<uint32_t>* exclusionHint = nullptr,
+                      bool forceAcquire = false) {
+    return thread_.vdev()->getQueueID(exclusionHint, forceAcquire);
+  }
+  bool hasAssignedQueue() const {
+    return (thread_.vdev() != nullptr) && thread_.vdev()->hasAssignedQueue();
+  }
   //! Returns Synchronization Policy for the current stream
   amd::SyncPolicy GetSyncPolicy() const { return sync_policy_; }
   //! Set Synchronization Policy used by Queue


### PR DESCRIPTION
- use getQueueID(exclusionHint, true) in UpdateStreams
- Queue separation for graph launch done at Run() via UpdateStreams exclusion list only

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
