### PR TITLE
Copy TheRock CI test scripts to `test/therock/`

### DIFF
--- a/test/therock/test_amdsmi.py
+++ b/test/therock/test_amdsmi.py
@@ -52,11 +52,11 @@ env["GTEST_TOTAL_SHARDS"] = str(TOTAL_SHARDS)
 # -----------------------------
 # Test filtering
 # -----------------------------
-# If smoke mode is enabled, run minimal suite (only dynamic metric tests)
+# If quick mode is enabled, run minimal suite (only dynamic metric tests)
 test_type = os.getenv("TEST_TYPE", "full")
 
-if test_type == "smoke":
-    logging.info("Running smoke tests only for amdsmitst")
+if test_type == "quick":
+    logging.info("Running quick tests only for amdsmitst")
     test_filter = ["--gtest_filter=AmdSmiDynamicMetricTest.*"]
 else:
     # Full test mode: run whitelist and explicitly exclude known failing tests

--- a/test/therock/test_amdsmi.py
+++ b/test/therock/test_amdsmi.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python3
+# Copyright Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+"""
+===============================================================================
+AMDSMI Test Runner (Manual Execution Only)
+
+This script is NOT part of automated CI runs.
+
+`amdsmitst` requires GPU device access (/dev/kfd, /dev/dri), elevated
+permissions, and execution on a ROCm-enabled system. GitHub-hosted CI
+environments do not expose these capabilities, so this script must be run
+manually by developers inside a privileged ROCm environment or container.
+
+Usage:
+    python test_amdsmi.py
+
+===============================================================================
+"""
+
+import pytest
+
+pytestmark = pytest.mark.skip("Manual execution only — requires GPU device access")
+import logging
+import os
+import shlex
+import subprocess
+from pathlib import Path
+import sys
+
+logging.basicConfig(level=logging.INFO)
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+THEROCK_DIR = SCRIPT_DIR.parent.parent.parent
+
+AMDSMITST_BIN = (
+    THEROCK_DIR / "build" / "share" / "amd_smi" / "tests" / "amdsmitst"
+).resolve()
+
+# -----------------------------
+# GTest sharding
+# -----------------------------
+SHARD_INDEX = os.getenv("SHARD_INDEX", "1")
+TOTAL_SHARDS = os.getenv("TOTAL_SHARDS", "1")
+env = os.environ.copy()
+
+# Convert to 0-based index for GTest
+env["GTEST_SHARD_INDEX"] = str(int(SHARD_INDEX) - 1)
+env["GTEST_TOTAL_SHARDS"] = str(TOTAL_SHARDS)
+
+# -----------------------------
+# Test filtering
+# -----------------------------
+# If smoke mode is enabled, run minimal suite (only dynamic metric tests)
+test_type = os.getenv("TEST_TYPE", "full")
+
+if test_type == "smoke":
+    logging.info("Running smoke tests only for amdsmitst")
+    test_filter = ["--gtest_filter=AmdSmiDynamicMetricTest.*"]
+else:
+    # Full test mode: run whitelist and explicitly exclude known failing tests
+    logging.info("Running full amdsmitst test suite (include + exclude filter)")
+
+    include_tests = [
+        "amdsmitstReadOnly.*",
+        "amdsmitstReadWrite.FanReadWrite",
+        "amdsmitstReadWrite.TestOverdriveReadWrite",
+        "amdsmitstReadWrite.TestPciReadWrite",
+        "amdsmitstReadWrite.TestPowerReadWrite",
+        "amdsmitstReadWrite.TestPerfCntrReadWrite",
+        "amdsmitstReadWrite.TestEvtNotifReadWrite",
+        "AmdSmiDynamicMetricTest.*",
+    ]
+
+    exclude_tests = [
+        "amdsmitstReadOnly.TempRead",
+        "amdsmitstReadOnly.TestFrequenciesRead",
+        "amdsmitstReadWrite.TestPowerReadWrite",
+    ]
+
+    gtest_filter = f"{':'.join(include_tests)}:-{':'.join(exclude_tests)}"
+    test_filter = [f"--gtest_filter={gtest_filter}"]
+
+# -----------------------------
+# Build command
+# -----------------------------
+cmd = [str(AMDSMITST_BIN)] + test_filter
+
+logging.info(f"++ Exec [{THEROCK_DIR}]$ {shlex.join(cmd)}")
+
+# -----------------------------
+# Run tests
+# -----------------------------
+subprocess.run(
+    cmd,
+    cwd=THEROCK_DIR,
+    env=env,
+    check=True,
+)

--- a/test/therock/test_aqlprofile.py
+++ b/test/therock/test_aqlprofile.py
@@ -1,0 +1,27 @@
+#!/usr/bin/env python3
+# Copyright Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+import logging
+import os
+import subprocess
+from pathlib import Path
+
+logging.basicConfig(level=logging.INFO, format="%(message)s")
+
+# repo + dirs
+SCRIPT_DIR = Path(__file__).resolve().parent
+THEROCK_DIR = Path(os.getenv("OUTPUT_ARTIFACTS_DIR")).resolve()
+env = os.environ.copy()
+
+env["LD_LIBRARY_PATH"] = THEROCK_DIR / "lib"
+cmd = THEROCK_DIR / "share" / "hsa-amd-aqlprofile" / "run_tests.sh"
+
+logging.info(f"++ Exec {cmd}")
+
+subprocess.run(
+    cmd,
+    cwd=THEROCK_DIR,
+    check=True,
+    env=env,
+)

--- a/test/therock/test_hiptests.py
+++ b/test/therock/test_hiptests.py
@@ -23,9 +23,9 @@ AMDGPU_FAMILIES = os.getenv("AMDGPU_FAMILIES")
 os_type = platform.system().lower()
 CATCH_TESTS_PATH = str(Path(THEROCK_BIN_DIR).parent / "share" / "hip" / "catch_tests")
 
-# Importing is_asan from github_actions_utils.py
+# Importing is_asan from github_actions_api.py
 sys.path.append(str(THEROCK_DIR / "build_tools" / "github_actions"))
-from github_actions_utils import is_asan
+from github_actions_api import is_asan
 
 env = os.environ.copy()
 
@@ -41,15 +41,31 @@ if not os.path.isdir(CATCH_TESTS_PATH):
 
 # TODO(#3204): Re-enable tests once issues are resolved
 TEST_TO_IGNORE = {
-    "gfx94X-dcgpu": {
-        "linux": [
-            "Unit_hipGetProcAddress_spt_Stream",
-        ]
-    },
     "gfx950-dcgpu": {
         "linux": [
+            "Unit_hipHostRegister_AsyncApis",
+            "Unit_hipMemsetDSync - uint32_t",
+            "Unit_hipMemsetDASyncMulti - int8_t",
+            "Unit_hipStreamValue_Wait_Blocking - uint32_t",
+            "Unit_atomicExch_Positive_Same_Address_Compile_Time",
+            "Unit_hipHostRegister_ReferenceFromKernelandhipMemset - int",
+            "Unit_hipHostRegister_Graphs",
             "Unit_hipManagedKeyword_SingleGpu",
-            "Unit_hipGetProcAddress_spt_Stream",
+            "Unit_hipMemsetSync",
+            "Unit_hipMemset2DSync",
+            "Unit_hipMemsetDASyncMulti - int16_t",
+            "Unit_hipStreamValue_Wait_Blocking - uint64_t",
+            "Unit_hipHostRegister_ReferenceFromKernelandhipMemset - float",
+            "Unit_hipMemsetDSync - int8_t",
+            "Unit_hipMemset3DSync",
+            "Unit_hipMemsetDASyncMulti - uint32_t",
+            "Unit_hipStreamValue_Write - TestParams<uint64_t, PtrType::DevicePtrToHost>",
+            "Unit_hipHostRegister_ReferenceFromKernelandhipMemset - double",
+            "Unit_hipGetProcAddress_MemoryApisRegisterUnReg",
+            "Unit_hipMemsetDSync - int16_t",
+            "Unit_hipMemsetASyncMulti",
+            "Unit_hipHostAlloc_AllocateMoreThanAvailGPUMemory",
+            "Unit_hipStreamValue_Write - TestParams<uint32_t, PtrType::DevicePtrToHost>",
         ]
     },
     "gfx110X-all": {

--- a/test/therock/test_hiptests.py
+++ b/test/therock/test_hiptests.py
@@ -1,0 +1,149 @@
+# Copyright Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+import logging
+import os
+import shlex
+import subprocess
+from pathlib import Path
+import platform
+import shutil
+import json
+import sys
+import platform
+
+logging.basicConfig(level=logging.INFO)
+THEROCK_BIN_DIR_STR = os.getenv("THEROCK_BIN_DIR")
+THEROCK_BIN_DIR = Path(THEROCK_BIN_DIR_STR)
+SCRIPT_DIR = Path(__file__).resolve().parent
+THEROCK_DIR = SCRIPT_DIR.parent.parent.parent
+SHARD_INDEX = int(os.getenv("SHARD_INDEX", 1)) - 1
+TOTAL_SHARDS = int(os.getenv("TOTAL_SHARDS", 1))
+AMDGPU_FAMILIES = os.getenv("AMDGPU_FAMILIES")
+os_type = platform.system().lower()
+CATCH_TESTS_PATH = str(Path(THEROCK_BIN_DIR).parent / "share" / "hip" / "catch_tests")
+
+# Importing is_asan from github_actions_utils.py
+sys.path.append(str(THEROCK_DIR / "build_tools" / "github_actions"))
+from github_actions_utils import is_asan
+
+env = os.environ.copy()
+
+if THEROCK_BIN_DIR_STR is None:
+    logging.info(
+        "++ Error: env(THEROCK_BIN_DIR) is not set. Please set it before executing tests."
+    )
+    sys.exit(1)
+
+if not os.path.isdir(CATCH_TESTS_PATH):
+    logging.info(f"++ Error: catch tests not found in {CATCH_TESTS_PATH}")
+    sys.exit(1)
+
+# TODO(#3204): Re-enable tests once issues are resolved
+TEST_TO_IGNORE = {
+    "gfx94X-dcgpu": {
+        "linux": [
+            "Unit_hipGetProcAddress_spt_Stream",
+        ]
+    },
+    "gfx950-dcgpu": {
+        "linux": [
+            "Unit_hipManagedKeyword_SingleGpu",
+            "Unit_hipGetProcAddress_spt_Stream",
+        ]
+    },
+    "gfx110X-all": {
+        "windows": [
+            "Unit_hipStreamValue_Wait_Blocking - uint64_t",
+            "Unit_hipStreamValue_Wait_Blocking - uint32_t",
+        ]
+    },
+}
+
+
+def get_asan_lib_path():
+    arch = platform.machine()
+    CLANG_PATH = str(Path(THEROCK_BIN_DIR).parent / "lib" / "llvm" / "bin" / "clang++")
+    cmd = [f"{CLANG_PATH}", f"--print-file-name=libclang_rt.asan-{arch}.so"]
+    logging.info(f"++ Exec [{CLANG_PATH}]$ {shlex.join(cmd)}")
+    result = subprocess.run(
+        cmd,
+        check=True,
+        text=True,
+        capture_output=True,
+    )
+    return result.stdout.strip()
+
+
+def copy_dlls_exe_path():
+    if platform.system() == "Windows":
+        # hip and comgr dlls need to be copied to the same folder as exectuable
+        dlls_pattern = [
+            "amdhip64*.dll",
+            "amd_comgr*.dll",
+            "hiprtc*.dll",
+            "rocm_kpack*.dll",
+        ]
+        dlls_to_copy = []
+        for pattern in dlls_pattern:
+            dlls_to_copy.extend(THEROCK_BIN_DIR.glob(pattern))
+        for dll in dlls_to_copy:
+            try:
+                shutil.copy(dll, CATCH_TESTS_PATH)
+                logging.info(f"++ Copied: {dll} to {CATCH_TESTS_PATH}")
+            except Exception as e:
+                logging.info(f"++ Error copying {dll}: {e}")
+
+
+def setup_env(env):
+    # catch/ctest framework
+    # Linux
+    #   LD_LIBRARY_PATH needs to be used
+    #   tests are hardcoded to look at THEROCK_BIN_DIR or /opt/rocm/lib path
+    # Windows
+    #   tests load the dlls present in the local exe folder
+    # Set ROCM Path, to find rocm_agent_enum etc
+    ROCM_PATH = Path(THEROCK_BIN_DIR).resolve().parent
+    env["ROCM_PATH"] = str(ROCM_PATH)
+    if platform.system() == "Linux":
+        HIP_LIB_PATH = Path(THEROCK_BIN_DIR).parent / "lib"
+        logging.info(f"++ Setting LD_LIBRARY_PATH={HIP_LIB_PATH}")
+        if "LD_LIBRARY_PATH" in env:
+            env["LD_LIBRARY_PATH"] = f"{HIP_LIB_PATH}:{env['LD_LIBRARY_PATH']}"
+        else:
+            env["LD_LIBRARY_PATH"] = HIP_LIB_PATH
+        # For ASAN mode, we preload it for test count query and test running
+        if is_asan():
+            env["LD_PRELOAD"] = get_asan_lib_path()
+            env["HSA_XNACK"] = "1"
+            # TODO: enable this when we have symbolizer patch in
+            # env["ASAN_SYMBOLIZER_PATH"] = str(Path(THEROCK_BIN_DIR).parent / "lib" / "llvm" / "bin" / "llvm-symbolizer")
+    else:
+        copy_dlls_exe_path()
+
+
+def execute_tests(env):
+    # Allow for more time in ASAN mode to run the tests.
+    timeout = 1500 if is_asan() else 600
+    cmd = [
+        "ctest",
+        "--tests-information",
+        f"{SHARD_INDEX},,{TOTAL_SHARDS}",
+        "--test-dir",
+        CATCH_TESTS_PATH,
+        "--output-on-failure",
+        "--timeout",
+        f"{timeout}",
+    ]
+
+    if AMDGPU_FAMILIES in TEST_TO_IGNORE and os_type in TEST_TO_IGNORE[AMDGPU_FAMILIES]:
+        ignored_tests = TEST_TO_IGNORE[AMDGPU_FAMILIES][os_type]
+        cmd.extend(["--exclude-regex", "|".join(ignored_tests)])
+
+    logging.info(f"++ Exec [{THEROCK_DIR}]$ {shlex.join(cmd)}")
+    subprocess.run(cmd, cwd=THEROCK_DIR, check=True, env=env)
+
+
+if __name__ == "__main__":
+    setup_env(env)
+    execute_tests(env)

--- a/test/therock/test_rccl.py
+++ b/test/therock/test_rccl.py
@@ -10,7 +10,7 @@ from pathlib import Path
 import pytest
 
 sys.path.insert(0, os.fspath(Path(__file__).parent.parent))
-from github_actions_utils import get_visible_gpu_count
+from github_actions_api import get_visible_gpu_count
 
 THEROCK_BIN_DIR = os.getenv("THEROCK_BIN_DIR")
 SCRIPT_DIR = Path(__file__).resolve().parent

--- a/test/therock/test_rccl.py
+++ b/test/therock/test_rccl.py
@@ -1,0 +1,68 @@
+# Copyright Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+import logging
+import os
+import shlex
+import subprocess
+import sys
+from pathlib import Path
+import pytest
+
+sys.path.insert(0, os.fspath(Path(__file__).parent.parent))
+from github_actions_utils import get_visible_gpu_count
+
+THEROCK_BIN_DIR = os.getenv("THEROCK_BIN_DIR")
+SCRIPT_DIR = Path(__file__).resolve().parent
+THEROCK_DIR = SCRIPT_DIR.parent.parent.parent
+logging.basicConfig(level=logging.INFO)
+
+
+class TestRCCL:
+    def test_rccl_unittests(self):
+        # Executing rccl gtest from rccl repo
+        environ_vars = os.environ.copy()
+        # Expect at least 2 GPUs for RCCL collectives
+        gpu_count = get_visible_gpu_count(
+            env=environ_vars, therock_bin_dir=THEROCK_BIN_DIR
+        )
+        logging.info(f"Visible GPU count: {gpu_count}")
+
+        if gpu_count < 2:
+            pytest.skip("Skipping RCCL unit tests: <2 GPUs visible")
+        environ_vars["HIP_VISIBLE_DEVICES"] = "2,3"
+        environ_vars["UT_MIN_GPUS"] = "2"
+        environ_vars["UT_MAX_GPUS"] = "2"
+        environ_vars["UT_POW2_GPUS"] = "1"
+        environ_vars["UT_PROCESS_MASK"] = "1"
+        cmd = [f"{THEROCK_BIN_DIR}/rccl-UnitTests"]
+        logging.info(f"++ Exec [{THEROCK_DIR}]$ {shlex.join(cmd)}")
+        result = subprocess.run(cmd, cwd=THEROCK_DIR, check=False, env=environ_vars)
+        assert result.returncode == 0
+
+    # Executing rccl performance and correctness tests from rccl-tests repo
+    @pytest.mark.parametrize(
+        "executable",
+        [
+            "all_gather_perf",
+            "alltoallv_perf",
+            "broadcast_perf",
+            "alltoall_perf",
+            "all_reduce_perf",
+            "reduce_perf",
+            "hypercube_perf",
+            "gather_perf",
+            "scatter_perf",
+            "sendrecv_perf",
+            "reduce_scatter_perf",
+        ],
+    )
+    def test_rccl_correctness_tests(self, executable):
+        cmd = [f"{THEROCK_BIN_DIR}/{executable}"]
+        logging.info(f"++ Exec [{THEROCK_DIR}]$ {shlex.join(cmd)}")
+        result = subprocess.run(
+            cmd,
+            cwd=THEROCK_DIR,
+            check=False,
+        )
+        assert result.returncode == 0

--- a/test/therock/test_rocprofiler_compute.py
+++ b/test/therock/test_rocprofiler_compute.py
@@ -19,8 +19,8 @@ EXCLUDED_TESTS = [
     "test_profile_live_attach_detach",
 ]
 
-# Smoke Tests
-SMOKE_TESTS = [
+# quick Tests
+QUICK_TESTS = [
     "test_autogen_config",
     "test_utils",
     "test_num_xcds_cli_output",
@@ -76,12 +76,12 @@ def execute_tests():
         f"{shard_index},,{total_shards}",
     ]
 
-    # If smoke tests are enabled, we run smoke tests only.
+    # If quick tests are enabled, we run quick tests only.
     # Otherwise, we run the normal test suite
     test_type = os.getenv("TEST_TYPE", "full")
-    if test_type == "smoke":
+    if test_type == "quick":
         cmd.append("--tests-regex")
-        cmd.append("|".join(SMOKE_TESTS))
+        cmd.append("|".join(QUICK_TESTS))
 
     logging.info(f"++ Exec [{THEROCK_PATH}]$ {shlex.join(cmd)}")
     subprocess.run(

--- a/test/therock/test_rocprofiler_compute.py
+++ b/test/therock/test_rocprofiler_compute.py
@@ -1,0 +1,97 @@
+# Copyright Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+import logging
+import os
+import shlex
+import subprocess
+from pathlib import Path
+
+# Resolve paths
+THEROCK_BIN_DIR = os.getenv("THEROCK_BIN_DIR")
+THEROCK_BIN_PATH = Path(THEROCK_BIN_DIR).resolve()
+THEROCK_PATH = THEROCK_BIN_PATH.parent
+THEROCK_LIB_PATH = str(THEROCK_PATH / "lib")
+ROCPROFILER_COMPUTE_DIRECTORY = THEROCK_PATH / "libexec" / "rocprofiler-compute"
+
+# Set up excluded tests
+EXCLUDED_TESTS = [
+    "test_profile_live_attach_detach",
+]
+
+# Smoke Tests
+SMOKE_TESTS = [
+    "test_autogen_config",
+    "test_utils",
+    "test_num_xcds_cli_output",
+    "test_num_xcds_spec_class",
+    "test_L1_cache_counters",
+    "test_analyze_workloads",
+    "test_analyze_commands",
+    "test_metric_validation",
+    "test_profile_iteration_multiplexing_1",
+]
+
+environ_vars = os.environ.copy()
+
+
+def setup_env():
+    # Set up ROCM_PATH
+    environ_vars["ROCM_PATH"] = str(THEROCK_PATH)
+
+    # Set up PATH
+    old_path = os.getenv("PATH", "")
+    rocm_bin = str(THEROCK_BIN_PATH)
+    if old_path:
+        environ_vars["PATH"] = f"{rocm_bin}:{old_path}"
+    else:
+        environ_vars["PATH"] = rocm_bin
+
+    # Set up LD_LIBRARY_PATH
+    old_ld_lib_path = os.getenv("LD_LIBRARY_PATH", "")
+    sysdeps_path = f"{THEROCK_LIB_PATH}/rocm_sysdeps/lib"
+    if old_ld_lib_path:
+        environ_vars[
+            "LD_LIBRARY_PATH"
+        ] = f"{THEROCK_LIB_PATH}:{sysdeps_path}:{old_ld_lib_path}"
+    else:
+        environ_vars["LD_LIBRARY_PATH"] = f"{THEROCK_LIB_PATH}:{sysdeps_path}"
+
+
+def execute_tests():
+    # Sharding
+    shard_index = int(os.getenv("SHARD_INDEX", "1")) - 1
+    total_shards = int(os.getenv("TOTAL_SHARDS", "1"))
+
+    # Run tests
+    cmd = [
+        "ctest",
+        "--test-dir",
+        f"{ROCPROFILER_COMPUTE_DIRECTORY}",
+        "--output-on-failure",
+        "--verbose",
+        "--exclude-regex",
+        f"{" | ".join(EXCLUDED_TESTS)}",
+        "--tests-information",
+        f"{shard_index},,{total_shards}",
+    ]
+
+    # If smoke tests are enabled, we run smoke tests only.
+    # Otherwise, we run the normal test suite
+    test_type = os.getenv("TEST_TYPE", "full")
+    if test_type == "smoke":
+        cmd.append("--tests-regex")
+        cmd.append("|".join(SMOKE_TESTS))
+
+    logging.info(f"++ Exec [{THEROCK_PATH}]$ {shlex.join(cmd)}")
+    subprocess.run(
+        cmd,
+        cwd=THEROCK_PATH,
+        check=True,
+        env=environ_vars,
+    )
+
+
+if __name__ == "__main__":
+    setup_env()
+    execute_tests()

--- a/test/therock/test_rocprofiler_systems.py
+++ b/test/therock/test_rocprofiler_systems.py
@@ -1,0 +1,59 @@
+# Copyright Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+import logging
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+THEROCK_BIN_DIR = os.getenv("THEROCK_BIN_DIR")
+SCRIPT_DIR = Path(__file__).resolve().parent
+THEROCK_DIR = SCRIPT_DIR.parent.parent.parent
+
+logging.basicConfig(level=logging.INFO)
+rocm_base = Path(THEROCK_BIN_DIR).resolve().parent
+
+# Environment variables
+environ_vars = os.environ.copy()
+ld_paths = [
+    # Libraries used by examples
+    rocm_base
+    / "share"
+    / "rocprofiler-systems"
+    / "examples"
+    / "lib",
+]
+ld_paths_str = ":".join(str(p) for p in ld_paths)
+
+existing_ld_path = os.environ.get("LD_LIBRARY_PATH", "")
+existing_path = os.environ.get("PATH", "")
+
+environ_vars["PATH"] = (
+    f"{THEROCK_BIN_DIR}:{existing_path}" if existing_path else THEROCK_BIN_DIR
+)
+environ_vars["ROCM_PATH"] = str(rocm_base)
+environ_vars["LD_LIBRARY_PATH"] = (
+    f"{ld_paths_str}:{existing_ld_path}" if existing_ld_path else ld_paths_str
+)
+# Required to force the pytest package to use install mode
+environ_vars["ROCPROFSYS_INSTALL_DIR"] = str(rocm_base)
+
+# Execute tests
+pytest_package_exec = (
+    rocm_base / "share" / "rocprofiler-systems" / "tests" / "rocprofsys-tests.pyz"
+)
+
+cmd = [
+    sys.executable,
+    str(pytest_package_exec),
+    # TODO: Once the corresponding tests are fixed, remove the lines below
+    "-k",
+    "not TestOpenMPTarget and not (TestTranspose and runtime_instrument) and not TestGPUConnect",
+    "--junit-xml=junit.xml",
+    "--ci-mode",
+    "--log-cli-level=info",
+]
+
+logging.info(f"++ Exec: {' '.join(cmd)}")
+subprocess.run(cmd, cwd=THEROCK_DIR, check=True, env=environ_vars)

--- a/test/therock/test_rocr-debug-agent.py
+++ b/test/therock/test_rocr-debug-agent.py
@@ -1,0 +1,346 @@
+# Copyright Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+import argparse
+import logging
+import os
+import resource
+import shlex
+import subprocess
+import sys
+import time
+from pathlib import Path
+from typing import Dict, Optional
+
+logging.basicConfig(
+    level=logging.INFO, format="%(asctime)s - %(levelname)s: %(message)s"
+)
+logger = logging.getLogger(__name__)
+
+
+def parse_arguments() -> argparse.Namespace:
+    """
+    Parse command-line arguments with all-or-nothing logic.
+    """
+    parser = argparse.ArgumentParser(
+        description="Run ROCm Debug Agent tests with configurable paths.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""
+Environment Variables (used when CLI args are not provided):
+  THEROCK_BIN_DIR          Directory containing rocm-debug-agent-test
+  OUTPUT_ARTIFACTS_DIR     Directory containing run-test.py script
+        """,
+    )
+    parser.add_argument(
+        "--test-bin",
+        type=Path,
+        help="Path to rocm-debug-agent-test binary.",
+    )
+    parser.add_argument(
+        "--test-script",
+        type=Path,
+        help="Path to run-test.py script.",
+    )
+    parser.add_argument(
+        "--max-retries",
+        type=int,
+        default=3,
+        help="Maximum number of test retry attempts (default: 3).",
+    )
+    parser.add_argument(
+        "--retry-delay",
+        type=int,
+        default=5,
+        help="Base delay in seconds between retries (default: 5).",
+    )
+
+    args = parser.parse_args()
+
+    # Check if any arguments are provided.
+    args_provided = [args.test_bin, args.test_script]
+    args_count = sum(arg is not None for arg in args_provided)
+
+    # Either all arguments or none.
+    if args_count not in (0, 2):
+        parser.error(
+            "Error: Either provide both arguments (--test-bin, --test-script) or none."
+        )
+
+    return args
+
+
+def set_core_dump_limit() -> None:
+    """
+    Set core dump size limit to 0 (equivalent to ulimit -c 0).
+    """
+    try:
+        resource.setrlimit(resource.RLIMIT_CORE, (0, 0))
+        logger.info("[✓] Core dump limit set to 0.")
+    except (ValueError, OSError) as e:
+        logger.warning(f"[!] Failed to set core dump limit: {e}")
+        logger.warning("Core files may be generated and consume disk space.")
+
+
+def validate_path(path: Path, path_type: str, must_exist: bool = True) -> Path:
+    """
+    Validate and resolve a path.
+
+    Args:
+        path: Path to validate.
+        path_type: Description of the path (for error messages).
+        must_exist: Whether the path must exist.
+
+    Returns:
+        Resolved path.
+
+    Raises:
+        SystemExit: If path validation fails.
+    """
+    try:
+        resolved = path.resolve(strict=must_exist)
+        if must_exist and not resolved.exists():
+            logger.error(f"[X] Error: {path_type} does not exist: {resolved}")
+            sys.exit(1)
+        return resolved
+    except (OSError, RuntimeError) as e:
+        logger.error(f"[X] Error: Could not resolve {path_type} '{path}': {e}")
+        sys.exit(1)
+
+
+def get_default_paths() -> Dict[str, Path]:
+    """
+    Get default paths from environment variables.
+
+    Returns:
+        Dictionary containing 'test_bin' and 'test_script' paths.
+
+    Raises:
+        SystemExit: If environment variables are not defined or paths cannot be resolved.
+    """
+    therock_bin_dir_str = os.getenv("THEROCK_BIN_DIR")
+    artifacts_dir_str = os.getenv("OUTPUT_ARTIFACTS_DIR")
+
+    # Check if environment variables are defined.
+    if therock_bin_dir_str is None:
+        logger.error("[X] Error: THEROCK_BIN_DIR environment variable is not defined.")
+        sys.exit(1)
+
+    if artifacts_dir_str is None:
+        logger.error(
+            "[X] Error: OUTPUT_ARTIFACTS_DIR environment variable is not defined."
+        )
+        sys.exit(1)
+
+    # Resolve and validate paths.
+    therock_bin_dir = validate_path(Path(therock_bin_dir_str), "THEROCK_BIN_DIR")
+    artifacts_dir = validate_path(Path(artifacts_dir_str), "OUTPUT_ARTIFACTS_DIR")
+
+    return {
+        "test_bin": therock_bin_dir / "rocm-debug-agent-test",
+        "test_script": artifacts_dir / "src" / "rocm-debug-agent-test" / "run-test.py",
+    }
+
+
+def get_python_executable() -> str:
+    """
+    Validates and returns the Python executable path.
+
+    Returns:
+        Path to Python executable.
+
+    Raises:
+        SystemExit: If valid Python executable cannot be found.
+    """
+    if not sys.executable or not os.path.exists(sys.executable):
+        logger.error("[X] Error: Could not identify a valid Python executable path.")
+        sys.exit(1)
+    return sys.executable
+
+
+def print_section(
+    title: str,
+    border_char: str = "=",
+    width: int = 80,
+    center: bool = True,
+    inline: bool = False,
+    color: Optional[str] = None,
+) -> None:
+    """
+    Print a visually distinct section header for console output.
+
+    Supports two modes:
+    1. Full multi-line section:
+        ==============================
+              Section Title
+        ==============================
+    2. Inline single-line section:
+        -------- Section Title --------
+
+    Args:
+        title (str):
+            The text to display inside the section header.
+        border_char (str, optional):
+            Character used for the border line (default: "=").
+        width (int, optional):
+            Total width of the header including borders (default: 80).
+        center (bool, optional):
+            Whether to center the title text for multi-line sections (default: True).
+        inline (bool, optional):
+            If True, print a single-line header with title inline (default: False).
+        color (str, optional):
+            ANSI color escape code applied to both title and borders (default: None, no color).
+
+            Examples:
+                "\033[92m" → Green
+                "\033[93m" → Yellow
+                "\033[94m" → Blue
+                "\033[91m" → Red
+                "\033[0m" resets color
+
+    Example:
+        print_section("EXCLUSIVE FAILING TESTS COMPARISON")
+        print_section("Clang/Clang++", border_char="-", inline=True)
+        print_section("WARNING", border_char="!", width=50, color="\033[93m")
+
+    Notes:
+        - Works in standard terminals and logs.
+    """
+    reset = "\033[0m"
+    apply_color = (
+        (lambda text: f"{color}{text}{reset}") if color else (lambda text: text)
+    )
+
+    # Always add a newline to the beginning of the section.
+    logger.info("")
+
+    if inline:
+        # Prepare inline title.
+        title_str = f" {title} "
+        remaining = width - len(title_str)
+        if remaining < 0:
+            remaining = 0
+        left = border_char * (remaining // 2)
+        right = border_char * (remaining - len(left))
+        logger.info(apply_color(f"{left}{title_str}{right}"))
+    else:
+        # Multi-line section style.
+        border = border_char * width
+        title_line = f"{title:^{width}}" if center else title
+        logger.info(apply_color(border))
+        logger.info(apply_color(title_line))
+        logger.info(apply_color(border))
+
+
+def run_tests(
+    python_executable: str,
+    test_script: Path,
+    working_dir: Path,
+    test_bin_dir: Path,
+    env_vars: Optional[Dict[str, str]] = None,
+    max_retries: int = 3,
+    retry_delay: int = 5,
+) -> None:
+    """
+    Runs the testsuite with a retry mechanism.
+
+    Args:
+        python_executable: Path to Python interpreter.
+        test_script: Path to test script.
+        working_dir: Working directory for test execution.
+        test_bin_dir: Directory containing test binaries.
+        env_vars: Environment variables for test execution.
+        max_retries: Maximum number of retry attempts.
+        retry_delay: Base delay in seconds between retries.
+
+    Raises:
+        SystemExit: If all retry attempts fail.
+    """
+    if env_vars is None:
+        env_vars = os.environ.copy()
+
+    cmd = [python_executable, str(test_script), str(test_bin_dir)]
+
+    for attempt in range(1, max_retries + 1):
+        print_section(f"Running tests (Attempt {attempt}/{max_retries})")
+
+        logger.info(f"Exec [{working_dir}]$ {shlex.join(cmd)}")
+
+        start_time = time.perf_counter()
+        try:
+            subprocess.run(cmd, cwd=str(working_dir), check=True, env=env_vars)
+
+            duration = time.perf_counter() - start_time
+
+            print_section(
+                f"[✓] Tests succeeded on attempt {attempt}. Duration: {duration:.2f}s"
+            )
+            return
+
+        except subprocess.CalledProcessError as e:
+            duration = time.perf_counter() - start_time
+            logger.error(
+                f"[X] Attempt {attempt}/{max_retries} failed with exit code {e.returncode} "
+                f"after {duration:.2f}s"
+            )
+
+            if attempt < max_retries:
+                # Exponential-ish backoff: multiply base delay by attempt number
+                wait_time = attempt * retry_delay
+                logger.info(f"Retrying in {wait_time}s...")
+                time.sleep(wait_time)
+            else:
+                # We failed all the attempts.
+                print_section(f"[X] All {max_retries} attempts failed.")
+                sys.exit(1)
+
+
+def main() -> None:
+    """
+    Main entry point for the script.
+    """
+    # Parse command-line arguments.
+    args = parse_arguments()
+
+    print_section("Path discovery")
+    # Determine paths to use.
+    if args.test_bin is not None:
+        logger.info("Using paths from command-line arguments.")
+        rocr_debug_agent_test_bin = validate_path(args.test_bin, "--test-bin")
+        rocr_debug_agent_test_script = validate_path(args.test_script, "--test-script")
+    else:
+        # Use default logic.
+        logger.info("Using default paths from environment variables.")
+        defaults = get_default_paths()
+        rocr_debug_agent_test_bin = defaults["test_bin"]
+        rocr_debug_agent_test_script = defaults["test_script"]
+
+    # Derive the test binary directory.
+    test_bin_dir = rocr_debug_agent_test_bin.parent
+
+    logger.info(f"Test Binary: {rocr_debug_agent_test_bin}")
+    logger.info(f"Test Script: {rocr_debug_agent_test_script}")
+    logger.info(f"Test Bin Dir: {test_bin_dir}")
+
+    # Setup Python executable.
+    python_executable = get_python_executable()
+
+    logger.info(f"Located python executable: {python_executable}")
+
+    print_section("Disabling core file generation")
+
+    # Set core dump limit to 0 (ulimit -c 0).
+    set_core_dump_limit()
+
+    # Run tests.
+    run_tests(
+        python_executable=python_executable,
+        test_script=rocr_debug_agent_test_script,
+        working_dir=test_bin_dir,
+        test_bin_dir=test_bin_dir,
+        max_retries=args.max_retries,
+        retry_delay=args.retry_delay,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/test/therock/test_rocrtst.py
+++ b/test/therock/test_rocrtst.py
@@ -1,0 +1,62 @@
+# Copyright Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+import logging
+import os
+import shlex
+import subprocess
+import sys
+from pathlib import Path
+
+sys.path.insert(0, os.fspath(Path(__file__).resolve().parent.parent))
+from github_actions_utils import get_first_gpu_architecture
+
+THEROCK_BIN_DIR = os.getenv("THEROCK_BIN_DIR")
+
+logging.basicConfig(level=logging.INFO)
+
+# GTest sharding
+SHARD_INDEX = os.getenv("SHARD_INDEX", 1)
+TOTAL_SHARDS = os.getenv("TOTAL_SHARDS", 1)
+environ_vars = os.environ.copy()
+# For display purposes in the GitHub Action UI, the shard array is 1th indexed.
+# For shard indexes, we convert to 0th index.
+environ_vars["GTEST_SHARD_INDEX"] = str(int(SHARD_INDEX) - 1)
+environ_vars["GTEST_TOTAL_SHARDS"] = str(TOTAL_SHARDS)
+
+cwd_dir = Path(THEROCK_BIN_DIR)
+cmd = ["./rocrtst64"]
+
+# Excluded tests (flaky or disabled in CI).
+EXCLUDED_TESTS = [
+    "-rocrtstFunc.Memory_Max_Mem",
+]
+
+# If smoke tests are enabled, run smoke tests only. Otherwise, run the full suite.
+SMOKE_TESTS = [
+    "rocrtst.Test_Example",
+    "rocrtstFunc.MemoryAccessTests",
+    "rocrtstFunc.GroupMemoryAllocationTest",
+    "rocrtstFunc.MemoryAllocateAndFreeTest",
+    "rocrtstFunc.Memory_Alignment_Test",
+    "rocrtstFunc.Concurrent_Init_Test",
+    "rocrtstFunc.Concurrent_Init_Shutdown_Test",
+    "rocrtstFunc.Reference_Count",
+    "rocrtstFunc.Signal_Create_Concurrently",
+    "rocrtstFunc.Signal_Destroy_Concurrently",
+    "rocrtstFunc.IPC",
+    "rocrtstFunc.AgentProp_UUID",
+    "rocrtstFunc.Deallocation_Notifier_Test",
+    "rocrtstFunc.Memory_Atomic_Add_Test",
+    "rocrtstFunc.Memory_Atomic_Xchg_Test",
+]
+test_type = os.getenv("TEST_TYPE", "full")
+exclude_filter = ":".join(EXCLUDED_TESTS)
+
+if test_type == "smoke":
+    environ_vars["GTEST_FILTER"] = ":".join(SMOKE_TESTS) + ":" + exclude_filter
+else:
+    environ_vars["GTEST_FILTER"] = exclude_filter
+
+logging.info(f"++ Exec [{cwd_dir}]$ {shlex.join(cmd)}")
+subprocess.run(cmd, cwd=cwd_dir, check=True, env=environ_vars)

--- a/test/therock/test_rocrtst.py
+++ b/test/therock/test_rocrtst.py
@@ -5,13 +5,12 @@ import logging
 import os
 import shlex
 import subprocess
-import sys
 from pathlib import Path
-
-sys.path.insert(0, os.fspath(Path(__file__).resolve().parent.parent))
-from github_actions_utils import get_first_gpu_architecture
+import platform
 
 THEROCK_BIN_DIR = os.getenv("THEROCK_BIN_DIR")
+AMDGPU_FAMILIES = os.getenv("AMDGPU_FAMILIES")
+os_type = platform.system().lower()
 
 logging.basicConfig(level=logging.INFO)
 
@@ -27,13 +26,33 @@ environ_vars["GTEST_TOTAL_SHARDS"] = str(TOTAL_SHARDS)
 cwd_dir = Path(THEROCK_BIN_DIR)
 cmd = ["./rocrtst64"]
 
-# Excluded tests (flaky or disabled in CI).
-EXCLUDED_TESTS = [
-    "-rocrtstFunc.Memory_Max_Mem",
-]
+# TODO(#3851): Excluded tests (flaky or disabled in CI).
+TEST_TO_IGNORE = {
+    "gfx94X-dcgpu": {
+        "linux": [
+            "rocrtstFunc.Memory_Max_Mem",
+        ]
+    },
+    "gfx950-dcgpu": {
+        "linux": [
+            "rocrtstFunc.GpuCoreDump_DefaultPattern",
+            "rocrtstFunc.Memory_Max_Mem",
+        ]
+    },
+    "gfx110X-all": {
+        "windows": [
+            "rocrtstFunc.Memory_Max_Mem",
+        ]
+    },
+    "gfx1151": {
+        "windows": [
+            "rocrtstFunc.Memory_Max_Mem",
+        ]
+    },
+}
 
-# If smoke tests are enabled, run smoke tests only. Otherwise, run the full suite.
-SMOKE_TESTS = [
+# If quick tests are enabled, run quick tests only. Otherwise, run the full suite.
+QUICK_TESTS = [
     "rocrtst.Test_Example",
     "rocrtstFunc.MemoryAccessTests",
     "rocrtstFunc.GroupMemoryAllocationTest",
@@ -50,11 +69,15 @@ SMOKE_TESTS = [
     "rocrtstFunc.Memory_Atomic_Add_Test",
     "rocrtstFunc.Memory_Atomic_Xchg_Test",
 ]
-test_type = os.getenv("TEST_TYPE", "full")
-exclude_filter = ":".join(EXCLUDED_TESTS)
 
-if test_type == "smoke":
-    environ_vars["GTEST_FILTER"] = ":".join(SMOKE_TESTS) + ":" + exclude_filter
+if AMDGPU_FAMILIES in TEST_TO_IGNORE and os_type in TEST_TO_IGNORE[AMDGPU_FAMILIES]:
+    ignored_tests = TEST_TO_IGNORE[AMDGPU_FAMILIES][os_type]
+    exclude_filter = "-" + ":".join(ignored_tests)
+
+test_type = os.getenv("TEST_TYPE", "full")
+
+if test_type == "quick":
+    environ_vars["GTEST_FILTER"] = ":".join(QUICK_TESTS) + ":" + exclude_filter
 else:
     environ_vars["GTEST_FILTER"] = exclude_filter
 


### PR DESCRIPTION
## Summary

- Seeds `test/therock/` with 8 CI test scripts copied verbatim from
  ROCm/TheRock@fc47892f as the initial step of the TheRock test script
  migration ([RFC0010](https://github.com/ROCm/TheRock/blob/main/docs/rfcs/RFC0010-Test-Scripts-Migration.md))
- Scripts are not yet usable from this location — path assumptions
  (`THEROCK_DIR`) and `github_actions_utils` imports still point to
  TheRock-relative paths and will be fixed in a follow-on PR

## Scripts added

`test_amdsmi.py`, `test_aqlprofile.py`, `test_hiptests.py`,
`test_rccl.py`, `test_rocprofiler_compute.py`,
`test_rocprofiler_systems.py`, `test_rocr-debug-agent.py`,
`test_rocrtst.py`