### PR TITLE
[rocshmem] Fix alltoallv_get deadlock after 65536 calls

### DIFF
--- a/projects/rocshmem/src/gda/context_gda_tmpl_device.hpp
+++ b/projects/rocshmem/src/gda/context_gda_tmpl_device.hpp
@@ -747,7 +747,7 @@ __device__ void GDAContext::alltoallv_get(rocshmem_team_t team,
       ctrl_value = uncached_load(vol_ctrl);
       seq_bits = (ctrl_value >> seq_shift) & seq_mask;
       displ_bits = ctrl_value & displs_mask;
-    } while (seq_bits != (a2a_sn + 1));
+    } while (seq_bits != ((a2a_sn + 1) & seq_mask));
 
     /* Get data */
     size_t nelems = dest_nelems[dest_pe] * sizeof(T);


### PR DESCRIPTION
## Motivation

Fix hang that occurs with rccl+rocshmem alltoallv GDA at high iteration counts.

## Technical Details

The GDA alltoallv_get rendezvous protocol packs a 16-bit sequence number into each control message. The sender correctly masks to 16 bits when packing, and the receiver correctly extracts 16 bits from the message, but the receiver's comparison used the full 64-bit alltoall_sequence_number counter:

`    } while (seq_bits != (a2a_sn + 1));`

After 65535 calls, a2a_sn + 1 = 0x10000, but seq_bits can never exceed 0xFFFF. Every PE spins forever, causing a system-wide deadlock.

The fix is to mask the comparison value to the same 16-bit domain:

 `   } while (seq_bits != ((a2a_sn + 1) & seq_mask));`

## JIRA ID

Resolves AICOMRCCL-744

## Testing Performed

Verified on 2 nodes / 16 MI300X GPUs with rccl-tests alltoallv_perf, with RCCL_ROCSHMEM_ENABLE=1 which utilizes rocshmem gda a2av, (-n 1000 -w 20 -N 5), completing 5 full cycles across all message sizes (1K-512MB) with zero errors."

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
