### PR TITLE
[RCCL] NIC fusion test coverage

### DIFF
--- a/projects/rccl/test/common/DeviceBufferHelpers.hpp
+++ b/projects/rccl/test/common/DeviceBufferHelpers.hpp
@@ -6,8 +6,6 @@
 
 #ifndef DEVICE_BUFFER_HELPERS_HPP
 #define DEVICE_BUFFER_HELPERS_HPP
-#ifndef DEVICE_BUFFER_HELPERS_HPP
-#define DEVICE_BUFFER_HELPERS_HPP
 
 #include "nccl.h"
 #include <cmath>

--- a/projects/rccl/test/common/DeviceBufferHelpers.hpp
+++ b/projects/rccl/test/common/DeviceBufferHelpers.hpp
@@ -6,6 +6,8 @@
 
 #ifndef DEVICE_BUFFER_HELPERS_HPP
 #define DEVICE_BUFFER_HELPERS_HPP
+#ifndef DEVICE_BUFFER_HELPERS_HPP
+#define DEVICE_BUFFER_HELPERS_HPP
 
 #include "nccl.h"
 #include <cmath>
@@ -401,4 +403,3 @@ std::pair<hipError_t, std::vector<T>> downloadBuffer(const void* device_buffer, 
 } // namespace RCCLTestHelpers
 
 #endif // DEVICE_BUFFER_HELPERS_HPP
-

--- a/projects/rccl/test/common/HostBufferHelpers.hpp
+++ b/projects/rccl/test/common/HostBufferHelpers.hpp
@@ -1,0 +1,148 @@
+/*************************************************************************
+ * Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * See LICENSE.txt for license information
+ ************************************************************************/
+
+#pragma once
+
+#include <cmath>
+#include <cstddef>
+#include <cstdint>
+#include <cstring>
+#include <type_traits>
+
+/**
+ * @file HostBufferHelpers.hpp
+ * @brief Template-based host buffer utilities for RCCL tests
+ *
+ * Provides type-safe, reusable functions for host buffer operations:
+ * - Initialization with test patterns
+ * - Data verification with error reporting
+ *
+ * NOTE: All functions expect HOST memory pointers allocated with malloc/new.
+ *       For device memory operations, use DeviceBufferHelpers.hpp instead.
+ */
+
+namespace RCCLTestHelpers
+{
+
+// ============================================================================
+// Host Buffer Initialization
+// ============================================================================
+
+/**
+ * @brief Fill host buffer with pattern function
+ *
+ * @tparam T Element type (uint8_t, float, etc.)
+ * @tparam PatternFunc Callable: T pattern_func(size_t index)
+ * @param buffer Host memory pointer
+ * @param num_elements Number of elements
+ * @param pattern_func Function that generates value for each index
+ */
+template<typename T, typename PatternFunc>
+void fillHostBufferWithPattern(void* buffer, size_t num_elements, PatternFunc pattern_func)
+{
+    if(!buffer || num_elements == 0)
+    {
+        return;
+    }
+
+    T* typed = static_cast<T*>(buffer);
+    for(size_t i = 0; i < num_elements; i++)
+    {
+        typed[i] = pattern_func(i);
+    }
+}
+
+/**
+ * @brief Zero-initialize host buffer
+ *
+ * @param buffer Host memory pointer
+ * @param num_bytes Number of bytes to zero
+ */
+inline void zeroHostBuffer(void* buffer, size_t num_bytes)
+{
+    if(buffer && num_bytes > 0)
+    {
+        memset(buffer, 0, num_bytes);
+    }
+}
+
+// ============================================================================
+// Host Buffer Verification
+// ============================================================================
+
+/**
+ * @brief Verify host buffer data against a pattern function
+ *
+ * @tparam T Element type
+ * @tparam PatternFunc Callable: T pattern_func(size_t index)
+ * @param buffer Host memory pointer
+ * @param num_elements Total number of elements in buffer
+ * @param pattern_func Function that generates expected value for each index
+ * @param num_samples Number of elements to verify (0 = all)
+ * @param tolerance Tolerance for floating-point comparison (ignored for integer types)
+ * @param[out] first_error_index If verification fails, set to index of first mismatch
+ * @param[out] expected_value If verification fails, set to expected value
+ * @param[out] actual_value If verification fails, set to actual value
+ * @return true if all samples match, false otherwise
+ */
+template<typename T, typename PatternFunc>
+bool verifyHostBufferData(const void* buffer,
+                          size_t      num_elements,
+                          PatternFunc pattern_func,
+                          size_t      num_samples       = 0,
+                          double      tolerance         = 1e-5,
+                          size_t*     first_error_index = nullptr,
+                          T*          expected_value    = nullptr,
+                          T*          actual_value      = nullptr)
+{
+    if(!buffer || num_elements == 0)
+    {
+        return false;
+    }
+
+    if(num_samples == 0)
+    {
+        num_samples = num_elements;
+    }
+    else
+    {
+        num_samples = std::min(num_samples, num_elements);
+    }
+
+    const T* typed = static_cast<const T*>(buffer);
+
+    for(size_t i = 0; i < num_samples; i++)
+    {
+        T expected = pattern_func(i);
+        T actual   = typed[i];
+
+        bool matches = false;
+
+        if constexpr(std::is_floating_point_v<T>)
+        {
+            matches = (std::abs(actual - expected) <= tolerance);
+        }
+        else
+        {
+            matches = (actual == expected);
+        }
+
+        if(!matches)
+        {
+            if(first_error_index)
+                *first_error_index = i;
+            if(expected_value)
+                *expected_value = expected;
+            if(actual_value)
+                *actual_value = actual;
+            return false;
+        }
+    }
+
+    return true;
+}
+
+} // namespace RCCLTestHelpers

--- a/projects/rccl/test/common/HostBufferHelpers.hpp
+++ b/projects/rccl/test/common/HostBufferHelpers.hpp
@@ -4,7 +4,8 @@
  * See LICENSE.txt for license information
  ************************************************************************/
 
-#pragma once
+#ifndef HOST_BUFFER_HELPERS_HPP
+#define HOST_BUFFER_HELPERS_HPP
 
 #include <cmath>
 #include <cstddef>
@@ -146,3 +147,5 @@ bool verifyHostBufferData(const void* buffer,
 }
 
 } // namespace RCCLTestHelpers
+
+#endif // HOST_BUFFER_HELPERS_HPP

--- a/projects/rccl/test/common/MPITestRunner.md
+++ b/projects/rccl/test/common/MPITestRunner.md
@@ -8,7 +8,6 @@ A simple C++ testing framework for multi-process RCCL tests using MPI (Message P
 - [Overview](#overview)
 - [Why Use MPI Testing?](#why-use-mpi-testing)
 - [Quick Start](#quick-start)
-- [System-Specific Configuration (`--system`)](#system-specific-configuration---system)
 - [Core Concepts](#core-concepts)
 - [Per-Rank Logging](#per-rank-logging)
 - [API Reference](#api-reference)
@@ -233,6 +232,18 @@ python3 test_runner.py -c config.json --system <profile_name>
 - When `--system <name>` is passed, `mpi_args[name]` is used for MPI launch args and `system_env_variables[name]` is merged on top of the global `env_variables`.
 - Without `--system`, the runner falls back to a default set of MCA parameters.
 - All three fields are optional. Configs that omit them continue to work unchanged.
+
+### MPICH Support (`--mpich`)
+
+By default the test runner uses OpenMPI syntax (`-x KEY=VALUE`) to pass environment variables to `mpirun`. Pass `--mpich` to switch to MPICH syntax (`-env KEY VALUE`).
+
+```bash
+# OpenMPI (default)
+python3 test_runner.py -c config.json --system <profile_name>
+
+# MPICH
+python3 test_runner.py -c config.json --system <profile_name> --mpich
+```
 
 **Important: Node Validation**
 

--- a/projects/rccl/test/common/MPITestRunner.md
+++ b/projects/rccl/test/common/MPITestRunner.md
@@ -8,6 +8,7 @@ A simple C++ testing framework for multi-process RCCL tests using MPI (Message P
 - [Overview](#overview)
 - [Why Use MPI Testing?](#why-use-mpi-testing)
 - [Quick Start](#quick-start)
+- [System-Specific Configuration (`--system`)](#system-specific-configuration---system)
 - [Core Concepts](#core-concepts)
 - [Per-Rank Logging](#per-rank-logging)
 - [API Reference](#api-reference)
@@ -194,6 +195,44 @@ salloc -N 2 -n 16 --time=01:00:00
 - **CPU binding disabled**: Tests run with `--bind-to none` to avoid "more processes than CPUs" errors
 - **GPU assignment**: Each node independently assigns GPUs 0-N to local ranks 0-N
 - **Multi-node**: Script auto-generates hostfiles with proper slot counts from SLURM allocations
+
+### System-Specific Configuration (`--system`)
+
+The test runner supports per-system profiles for MPI arguments and environment variables via the `--system` flag. This allows a single JSON config to target multiple clusters with different network interfaces and MPI settings.
+
+```bash
+# Select a system profile at runtime
+python3 test_runner.py -c config.json --system <profile_name>
+```
+
+**JSON config fields used by `--system`:**
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `mpi_args` | dict of strings | Maps profile names to MPI arguments (MCA params, binding, etc.) |
+| `system_env_variables` | dict of dicts | Maps profile names to environment variable overrides |
+| `auto_detect_hosts` | bool (optional) | If `true`, auto-detect hosts from SLURM via `scontrol show hostnames` |
+
+```json
+{
+  "auto_detect_hosts": true,
+  "mpi_args": {
+    "system_a": "--mca oob_tcp_if_include <iface1> --mca btl_tcp_if_include <iface1> --bind-to none",
+    "system_b": "--mca oob_tcp_if_include <iface2> --mca btl_tcp_if_include <iface2> --bind-to none"
+  },
+  "env_variables": {
+    "NCCL_DEBUG": "INFO"
+  },
+  "system_env_variables": {
+    "system_a": { "NCCL_SOCKET_IFNAME": "<iface1>" },
+    "system_b": { "NCCL_SOCKET_IFNAME": "<iface2>" }
+  }
+}
+```
+
+- When `--system <name>` is passed, `mpi_args[name]` is used for MPI launch args and `system_env_variables[name]` is merged on top of the global `env_variables`.
+- Without `--system`, the runner falls back to a default set of MCA parameters.
+- All three fields are optional. Configs that omit them continue to work unchanged.
 
 **Important: Node Validation**
 

--- a/projects/rccl/test/transport/NetIbMPITests.cpp
+++ b/projects/rccl/test/transport/NetIbMPITests.cpp
@@ -10,6 +10,7 @@
 #include "ResourceGuards.hpp"
 #include "TestChecks.hpp"
 #include "DeviceBufferHelpers.hpp"
+#include "HostBufferHelpers.hpp"
 #include "nccl.h"
 #include "net.h"
 #include <vector>
@@ -292,6 +293,22 @@ protected:
             [pattern](size_t i) {
                 return static_cast<uint8_t>((pattern + i) % kBytePatternModulo);
             }
+        );
+    }
+
+    // Helper: Fill host buffer with pattern using HostBufferHelpers
+    void FillHostBuffer(void* buffer, size_t size, int seed) {
+        fillHostBufferWithPattern<uint8_t>(
+            buffer, size,
+            [seed](size_t i) { return static_cast<uint8_t>((seed + i) % kBytePatternModulo); }
+        );
+    }
+
+    // Helper: Verify host buffer pattern using HostBufferHelpers
+    bool VerifyHostBuffer(const void* buffer, size_t size, int seed) {
+        return verifyHostBufferData<uint8_t>(
+            buffer, size,
+            [seed](size_t i) { return static_cast<uint8_t>((seed + i) % kBytePatternModulo); }
         );
     }
 
@@ -673,11 +690,8 @@ TEST_F(NetIbMPITest, SimpleSendRecv) {
         ASSERT_EQ(PostRecv(pair.recvComm, 1, recvBuffers, recvSizes, recvTags,
                           recvHandles, &request), ncclSuccess);
     } else {
-        // Sender - initialize host buffer directly
-        uint8_t* hostBuffer = static_cast<uint8_t*>(buffer);
-        for (size_t i = 0; i < bufferSize; i++) {
-            hostBuffer[i] = static_cast<uint8_t>((rank + i) % kBytePatternModulo);
-        }
+        // Sender
+        FillHostBuffer(buffer, bufferSize, rank);
 
         PostSendWithRetry(pair.sendComm, buffer, bufferSize, tag, mhandle, &request);
     }
@@ -693,16 +707,8 @@ TEST_F(NetIbMPITest, SimpleSendRecv) {
         EXPECT_EQ(sizes[0], bufferSize) << "Received size mismatch";
 
         // Verify received data
-        uint8_t* hostBuffer = static_cast<uint8_t*>(buffer);
-        bool dataValid = true;
         int senderRank = 1;  // Data was sent by rank 1
-        for (size_t i = 0; i < bufferSize && dataValid; i++) {
-            uint8_t expected = static_cast<uint8_t>((senderRank + i) % kBytePatternModulo);
-            if (hostBuffer[i] != expected) {
-                dataValid = false;
-            }
-        }
-        EXPECT_TRUE(dataValid) << "Data validation failed";
+        EXPECT_TRUE(VerifyHostBuffer(buffer, bufferSize, senderRank)) << "Data validation failed";
     }
 
     // NetMHandleGuard will automatically deregister memory when test scope ends
@@ -768,11 +774,7 @@ TEST_F(NetIbMPITest, SendRecvMultipleSizes) {
                               recvHandles, &request), ncclSuccess);
             ASSERT_NE(request, nullptr) << "Recv request should never be NULL";
         } else {
-            // Initialize host buffer directly (not using InitializeBuffer which expects device memory)
-            uint8_t* hostBuffer = static_cast<uint8_t*>(buffer);
-            for (size_t i = 0; i < size; i++) {
-                hostBuffer[i] = static_cast<uint8_t>((seed + i) % kBytePatternModulo);
-            }
+            FillHostBuffer(buffer, size, seed);
 
             PostSendWithRetry(pair.sendComm, buffer, size, tag, mhandle, &request);
         }
@@ -792,16 +794,7 @@ TEST_F(NetIbMPITest, SendRecvMultipleSizes) {
         if (rank == 0) {
             EXPECT_EQ(sizes[0], size) << "Size mismatch for transfer of " << size << " bytes";
 
-            // Validate received data matches expected pattern (host buffer verification)
-            uint8_t* hostBuffer = static_cast<uint8_t*>(buffer);
-            bool dataValid = true;
-            for (size_t j = 0; j < size && dataValid; j++) {
-                uint8_t expected = static_cast<uint8_t>((seed + j) % kBytePatternModulo);
-                if (hostBuffer[j] != expected) {
-                    dataValid = false;
-                }
-            }
-            EXPECT_TRUE(dataValid) << "Data validation failed for size " << size;
+            EXPECT_TRUE(VerifyHostBuffer(buffer, size, seed)) << "Data validation failed for size " << size;
         }
 
         // NetMHandleGuard will automatically deregister at end of loop iteration
@@ -935,16 +928,7 @@ TEST_F(NetIbMPITest, FlushAfterRecv) {
                           recvHandles, &request), ncclSuccess);
     } else {
         // Sender
-        void* hostBuffer = malloc(bufferSize);
-        ASSERT_NE(hostBuffer, nullptr);
-        auto hostBufferGuard = makeHostBufferAutoGuard(hostBuffer);
-
-        // Initialize host buffer directly (not using InitializeBuffer which expects device memory)
-        uint8_t* hostBuf = static_cast<uint8_t*>(hostBuffer);
-        for (size_t i = 0; i < bufferSize; i++) {
-            hostBuf[i] = static_cast<uint8_t>((rank + i) % kBytePatternModulo);
-        }
-        HIP_TEST_CHECK_GTEST_FAIL(hipMemcpy(buffer, hostBuffer, bufferSize, hipMemcpyHostToDevice));
+        ASSERT_EQ(InitializeBuffer(buffer, bufferSize, rank), hipSuccess);
 
         PostSendWithRetry(pair.sendComm, buffer, bufferSize, tag, mhandle, &request);
     }
@@ -1119,11 +1103,7 @@ TEST_F(NetIbMPITest, MultipleSequentialTransfers) {
                               recvHandles, &request), ncclSuccess);
             ASSERT_NE(request, nullptr) << "Recv request should never be NULL";
         } else {
-            // Initialize host buffer directly (not using InitializeBuffer which expects device memory)
-            uint8_t* hostBuffer = static_cast<uint8_t*>(sendBuffer);
-            for (size_t j = 0; j < bufferSize; j++) {
-                hostBuffer[j] = static_cast<uint8_t>((seed + j) % kBytePatternModulo);
-            }
+            FillHostBuffer(sendBuffer, bufferSize, seed);
 
             PostSendWithRetry(pair.sendComm, sendBuffer, bufferSize, tag, mhandle, &request);
         }
@@ -1143,27 +1123,7 @@ TEST_F(NetIbMPITest, MultipleSequentialTransfers) {
         if (rank == 0) {
             EXPECT_EQ(sizes[0], bufferSize) << "Transfer " << i << " size mismatch";
 
-            // Validate received data matches expected pattern (host buffer verification)
-            uint8_t* hostBuffer = static_cast<uint8_t*>(recvBuffer);
-            bool dataValid = true;
-            for (size_t j = 0; j < bufferSize && dataValid; j++) {
-                uint8_t expected = static_cast<uint8_t>((seed + j) % kBytePatternModulo);
-                if (hostBuffer[j] != expected) {
-                    dataValid = false;
-                }
-            }
-            EXPECT_TRUE(dataValid) << "Transfer " << i << " data validation failed (seed=" << seed << ")";
-
-            if (!dataValid) {
-                // Print first few mismatched values for debugging
-                TEST_WARN("Rank %d: Transfer %d data mismatch. First %d values:", rank, i, kNumDebugSamples);
-                for (size_t j = 0; j < kNumDebugSamples && j < bufferSize; j++) {
-                    uint8_t expected = static_cast<uint8_t>((seed + j) % kBytePatternModulo);
-                    TEST_WARN("  [%zu] expected=%u, got=%u %s",
-                           j, expected, hostBuffer[j],
-                           (hostBuffer[j] == expected) ? "PASS" : "FAIL");
-                }
-            }
+            EXPECT_TRUE(VerifyHostBuffer(recvBuffer, bufferSize, seed)) << "Transfer " << i << " data validation failed (seed=" << seed << ")";
 
             // NOTE: Flush is NOT called for host memory transfers
             // Flush (iflush) is only needed for GPU Direct RDMA to ensure data visibility on GPU.
@@ -1226,11 +1186,8 @@ TEST_F(NetIbMPITest, LargeTransfer) {
         ASSERT_EQ(PostRecv(pair.recvComm, 1, recvBuffers, recvSizes, recvTags,
                           recvHandles, &request), ncclSuccess);
     } else {
-        // Sender - Initialize host buffer directly (not using InitializeBuffer which expects device memory)
-        uint8_t* hostBuffer = static_cast<uint8_t*>(buffer);
-        for (size_t i = 0; i < bufferSize; i++) {
-            hostBuffer[i] = static_cast<uint8_t>((rank + i) % kBytePatternModulo);
-        }
+        // Sender
+        FillHostBuffer(buffer, bufferSize, rank);
 
         PostSendWithRetry(pair.sendComm, buffer, bufferSize, tag, mhandle, &request);
     }
@@ -1246,29 +1203,8 @@ TEST_F(NetIbMPITest, LargeTransfer) {
         EXPECT_EQ(sizes[0], bufferSize) << "Large transfer size mismatch";
 
         // Verify received data
-        uint8_t* hostBuffer = static_cast<uint8_t*>(buffer);
-        bool dataValid = true;
         int senderRank = 1;  // Data was sent by rank 1
-        size_t errorsFound = 0;
-        const size_t maxErrorsToReport = 10;
-
-        for (size_t i = 0; i < bufferSize && errorsFound < maxErrorsToReport; i++) {
-            uint8_t expected = static_cast<uint8_t>((senderRank + i) % kBytePatternModulo);
-            if (hostBuffer[i] != expected) {
-                if (errorsFound == 0) {
-                    TEST_WARN("Rank %d: Data validation errors found in large transfer:", rank);
-                }
-                TEST_WARN("  Index %zu: expected=%u, got=%u", i, expected, hostBuffer[i]);
-                dataValid = false;
-                errorsFound++;
-            }
-        }
-
-        if (!dataValid && errorsFound >= maxErrorsToReport) {
-            TEST_WARN("  ... (showing first %zu errors only)", maxErrorsToReport);
-        }
-
-        EXPECT_TRUE(dataValid) << "Large transfer data validation failed";
+        EXPECT_TRUE(VerifyHostBuffer(buffer, bufferSize, senderRank)) << "Large transfer data validation failed";
     }
 
     // NetMHandleGuard will automatically deregister at scope end
@@ -1368,10 +1304,7 @@ TEST_F(NetIbMPITest, ConnectAndTransfer_VNic) {
         ASSERT_EQ(PostRecv(pair.recvComm, 1, recvBuffers, recvSizes, recvTags,
                           recvHandles, &request), ncclSuccess);
     } else {
-        uint8_t* hostBuffer = static_cast<uint8_t*>(buffer);
-        for (size_t i = 0; i < bufferSize; i++) {
-            hostBuffer[i] = static_cast<uint8_t>((seed + i) % kBytePatternModulo);
-        }
+        FillHostBuffer(buffer, bufferSize, seed);
 
         PostSendWithRetry(pair.sendComm, buffer, bufferSize, tag, mhandle, &request);
     }
@@ -1385,17 +1318,7 @@ TEST_F(NetIbMPITest, ConnectAndTransfer_VNic) {
     if (rank == 0) {
         EXPECT_EQ(sizes[0], bufferSize) << "Received size mismatch";
 
-        uint8_t* hostBuffer = static_cast<uint8_t*>(buffer);
-        bool dataValid = true;
-        for (size_t i = 0; i < bufferSize && dataValid; i++) {
-            uint8_t expected = static_cast<uint8_t>((seed + i) % kBytePatternModulo);
-            if (hostBuffer[i] != expected) {
-                dataValid = false;
-                TEST_WARN("Rank %d: Data mismatch at index %zu: expected=%u, got=%u",
-                         rank, i, expected, hostBuffer[i]);
-            }
-        }
-        EXPECT_TRUE(dataValid) << "Data validation failed on vNIC transfer";
+        EXPECT_TRUE(VerifyHostBuffer(buffer, bufferSize, seed)) << "Data validation failed on vNIC transfer";
     }
 
 }
@@ -1495,10 +1418,7 @@ TEST_F(NetIbMPITest, AsymmetricMerge_VNic) {
         ASSERT_EQ(PostRecv(pair.recvComm, 1, recvBuffers, recvSizes, recvTags,
                           recvHandles, &request), ncclSuccess);
     } else {
-        uint8_t* hostBuffer = static_cast<uint8_t*>(buffer);
-        for (size_t i = 0; i < bufferSize; i++) {
-            hostBuffer[i] = static_cast<uint8_t>((seed + i) % kBytePatternModulo);
-        }
+        FillHostBuffer(buffer, bufferSize, seed);
 
         PostSendWithRetry(pair.sendComm, buffer, bufferSize, tag, mhandle, &request);
     }
@@ -1512,17 +1432,7 @@ TEST_F(NetIbMPITest, AsymmetricMerge_VNic) {
     if (rank == 0) {
         EXPECT_EQ(sizes[0], bufferSize) << "Received size mismatch";
 
-        uint8_t* hostBuffer = static_cast<uint8_t*>(buffer);
-        bool dataValid = true;
-        for (size_t i = 0; i < bufferSize && dataValid; i++) {
-            uint8_t expected = static_cast<uint8_t>((seed + i) % kBytePatternModulo);
-            if (hostBuffer[i] != expected) {
-                dataValid = false;
-                TEST_WARN("Rank %d: Data mismatch at index %zu: expected=%u, got=%u",
-                         rank, i, expected, hostBuffer[i]);
-            }
-        }
-        EXPECT_TRUE(dataValid) << "Data validation failed on asymmetric vNIC transfer";
+        EXPECT_TRUE(VerifyHostBuffer(buffer, bufferSize, seed)) << "Data validation failed on asymmetric vNIC transfer";
     }
 }
 
@@ -1611,10 +1521,7 @@ TEST_F(NetIbMPITest, CloseWithoutTransfer_VNic) {
         ASSERT_EQ(PostRecv(pair2.recvComm, 1, recvBuffers, recvSizes, recvTags,
                           recvHandles, &request), ncclSuccess);
     } else {
-        uint8_t* hostBuffer = static_cast<uint8_t*>(buffer);
-        for (size_t i = 0; i < bufferSize; i++) {
-            hostBuffer[i] = static_cast<uint8_t>((seed + i) % kBytePatternModulo);
-        }
+        FillHostBuffer(buffer, bufferSize, seed);
 
         PostSendWithRetry(pair2.sendComm, buffer, bufferSize, tag, mhandle, &request);
     }
@@ -1628,17 +1535,7 @@ TEST_F(NetIbMPITest, CloseWithoutTransfer_VNic) {
     if (rank == 0) {
         EXPECT_EQ(sizes[0], bufferSize) << "Received size mismatch";
 
-        uint8_t* hostBuffer = static_cast<uint8_t*>(buffer);
-        bool dataValid = true;
-        for (size_t i = 0; i < bufferSize && dataValid; i++) {
-            uint8_t expected = static_cast<uint8_t>((seed + i) % kBytePatternModulo);
-            if (hostBuffer[i] != expected) {
-                dataValid = false;
-                TEST_WARN("Rank %d: Data mismatch at index %zu: expected=%u, got=%u",
-                         rank, i, expected, hostBuffer[i]);
-            }
-        }
-        EXPECT_TRUE(dataValid) << "Data validation failed after no-transfer teardown reconnect";
+        EXPECT_TRUE(VerifyHostBuffer(buffer, bufferSize, seed)) << "Data validation failed after no-transfer teardown reconnect";
     }
 }
 
@@ -1722,10 +1619,7 @@ TEST_F(NetIbMPITest, RegDeregCycling_VNic) {
         ASSERT_EQ(PostRecv(pair.recvComm, 1, recvBuffers, recvSizes, recvTags,
                           recvHandles, &request), ncclSuccess);
     } else {
-        uint8_t* hostBuffer = static_cast<uint8_t*>(buffer);
-        for (size_t i = 0; i < bufferSize; i++) {
-            hostBuffer[i] = static_cast<uint8_t>((seed + i) % kBytePatternModulo);
-        }
+        FillHostBuffer(buffer, bufferSize, seed);
 
         PostSendWithRetry(pair.sendComm, buffer, bufferSize, tag, mhandle, &request);
     }
@@ -1739,17 +1633,7 @@ TEST_F(NetIbMPITest, RegDeregCycling_VNic) {
     if (rank == 0) {
         EXPECT_EQ(sizes[0], bufferSize) << "Received size mismatch";
 
-        uint8_t* hostBuffer = static_cast<uint8_t*>(buffer);
-        bool dataValid = true;
-        for (size_t i = 0; i < bufferSize && dataValid; i++) {
-            uint8_t expected = static_cast<uint8_t>((seed + i) % kBytePatternModulo);
-            if (hostBuffer[i] != expected) {
-                dataValid = false;
-                TEST_WARN("Rank %d: Data mismatch at index %zu: expected=%u, got=%u",
-                         rank, i, expected, hostBuffer[i]);
-            }
-        }
-        EXPECT_TRUE(dataValid) << "Data validation failed after reg/dereg cycling";
+        EXPECT_TRUE(VerifyHostBuffer(buffer, bufferSize, seed)) << "Data validation failed after reg/dereg cycling";
     }
 }
 
@@ -1819,10 +1703,7 @@ TEST_F(NetIbMPITest, LargeTransfer_VNic) {
         ASSERT_EQ(PostRecv(pair.recvComm, 1, recvBuffers, recvSizes, recvTags,
                           recvHandles, &request), ncclSuccess);
     } else {
-        uint8_t* hostBuffer = static_cast<uint8_t*>(buffer);
-        for (size_t i = 0; i < bufferSize; i++) {
-            hostBuffer[i] = static_cast<uint8_t>((seed + i) % kBytePatternModulo);
-        }
+        FillHostBuffer(buffer, bufferSize, seed);
 
         PostSendWithRetry(pair.sendComm, buffer, bufferSize, tag, mhandle, &request);
     }
@@ -1838,28 +1719,7 @@ TEST_F(NetIbMPITest, LargeTransfer_VNic) {
     if (rank == 0) {
         EXPECT_EQ(sizes[0], bufferSize) << "Large transfer size mismatch";
 
-        uint8_t* hostBuffer = static_cast<uint8_t*>(buffer);
-        bool dataValid = true;
-        size_t errorsFound = 0;
-        const size_t maxErrorsToReport = 10;
-
-        for (size_t i = 0; i < bufferSize && errorsFound < maxErrorsToReport; i++) {
-            uint8_t expected = static_cast<uint8_t>((seed + i) % kBytePatternModulo);
-            if (hostBuffer[i] != expected) {
-                if (errorsFound == 0) {
-                    TEST_WARN("Rank %d: Data validation errors in large vNIC transfer:", rank);
-                }
-                TEST_WARN("  Index %zu: expected=%u, got=%u", i, expected, hostBuffer[i]);
-                dataValid = false;
-                errorsFound++;
-            }
-        }
-
-        if (!dataValid && errorsFound >= maxErrorsToReport) {
-            TEST_WARN("  ... (showing first %zu errors only)", maxErrorsToReport);
-        }
-
-        EXPECT_TRUE(dataValid) << "Large vNIC transfer data validation failed";
+        EXPECT_TRUE(VerifyHostBuffer(buffer, bufferSize, seed)) << "Large vNIC transfer data validation failed";
     }
 }
 
@@ -1938,10 +1798,7 @@ TEST_F(NetIbMPITest, MixedSizes_VNic) {
             ASSERT_EQ(PostRecv(pair.recvComm, 1, recvBuffers, recvSizes, recvTags,
                               recvHandles, &request), ncclSuccess);
         } else {
-            uint8_t* hostBuffer = static_cast<uint8_t*>(buffer);
-            for (size_t i = 0; i < size; i++) {
-                hostBuffer[i] = static_cast<uint8_t>((seed + i) % kBytePatternModulo);
-            }
+            FillHostBuffer(buffer, size, seed);
 
             PostSendWithRetry(pair.sendComm, buffer, size, tag, mhandle, &request);
         }
@@ -1958,17 +1815,7 @@ TEST_F(NetIbMPITest, MixedSizes_VNic) {
         if (rank == 0) {
             EXPECT_EQ(sizes[0], size) << "Size mismatch for transfer of " << size << " bytes";
 
-            uint8_t* hostBuffer = static_cast<uint8_t*>(buffer);
-            bool dataValid = true;
-            for (size_t j = 0; j < size && dataValid; j++) {
-                uint8_t expected = static_cast<uint8_t>((seed + j) % kBytePatternModulo);
-                if (hostBuffer[j] != expected) {
-                    dataValid = false;
-                    TEST_WARN("Rank %d: Mismatch at index %zu for size %zu: expected=%u, got=%u",
-                             rank, j, size, expected, hostBuffer[j]);
-                }
-            }
-            EXPECT_TRUE(dataValid) << "Data validation failed for size " << size;
+            EXPECT_TRUE(VerifyHostBuffer(buffer, size, seed)) << "Data validation failed for size " << size;
         }
     }
 }
@@ -2047,10 +1894,7 @@ TEST_F(NetIbMPITest, UnalignedSizeTransfer_VNic) {
             ASSERT_EQ(PostRecv(pair.recvComm, 1, recvBuffers, recvSizes, recvTags,
                               recvHandles, &request), ncclSuccess);
         } else {
-            uint8_t* hostBuffer = static_cast<uint8_t*>(buffer);
-            for (size_t i = 0; i < size; i++) {
-                hostBuffer[i] = static_cast<uint8_t>((seed + i) % kBytePatternModulo);
-            }
+            FillHostBuffer(buffer, size, seed);
 
             PostSendWithRetry(pair.sendComm, buffer, size, tag, mhandle, &request);
         }
@@ -2067,17 +1911,7 @@ TEST_F(NetIbMPITest, UnalignedSizeTransfer_VNic) {
         if (rank == 0) {
             EXPECT_EQ(sizes[0], size) << "Size mismatch for transfer of " << size << " bytes";
 
-            uint8_t* hostBuffer = static_cast<uint8_t*>(buffer);
-            bool dataValid = true;
-            for (size_t j = 0; j < size && dataValid; j++) {
-                uint8_t expected = static_cast<uint8_t>((seed + j) % kBytePatternModulo);
-                if (hostBuffer[j] != expected) {
-                    dataValid = false;
-                    TEST_WARN("Rank %d: Mismatch at index %zu for size %zu: expected=%u, got=%u",
-                             rank, j, size, expected, hostBuffer[j]);
-                }
-            }
-            EXPECT_TRUE(dataValid) << "Data validation failed for size " << size;
+            EXPECT_TRUE(VerifyHostBuffer(buffer, size, seed)) << "Data validation failed for size " << size;
         }
     }
 }
@@ -2193,10 +2027,7 @@ TEST_F(NetIbMPITest, Bidirectional_VNic) {
     const int sendSeed = 5700 + rank;
 
     // Fill send buffer with rank-specific pattern.
-    uint8_t* hostSendBuf = static_cast<uint8_t*>(sendBuf);
-    for (size_t i = 0; i < bufferSize; i++) {
-        hostSendBuf[i] = static_cast<uint8_t>((sendSeed + i) % kBytePatternModulo);
-    }
+    FillHostBuffer(sendBuf, bufferSize, sendSeed);
 
     // Post recv and send simultaneously on both connections.
     void* recvRequest = nullptr;
@@ -2227,17 +2058,7 @@ TEST_F(NetIbMPITest, Bidirectional_VNic) {
     int peerSeed = 5700 + peerRank;
     EXPECT_EQ(recvSizesOut[0], bufferSize) << "Received size mismatch";
 
-    uint8_t* hostRecvBuf = static_cast<uint8_t*>(recvBuf);
-    bool dataValid = true;
-    for (size_t i = 0; i < bufferSize && dataValid; i++) {
-        uint8_t expected = static_cast<uint8_t>((peerSeed + i) % kBytePatternModulo);
-        if (hostRecvBuf[i] != expected) {
-            dataValid = false;
-            TEST_WARN("Rank %d: Bidirectional mismatch at index %zu: expected=%u, got=%u",
-                     rank, i, expected, hostRecvBuf[i]);
-        }
-    }
-    EXPECT_TRUE(dataValid) << "Bidirectional vNIC transfer data validation failed";
+    EXPECT_TRUE(VerifyHostBuffer(recvBuf, bufferSize, peerSeed)) << "Bidirectional vNIC transfer data validation failed";
 }
 
 TEST_F(NetIbMPITest, FlushRepeated_VNic) {
@@ -2299,22 +2120,13 @@ TEST_F(NetIbMPITest, FlushRepeated_VNic) {
     ASSERT_EQ(RegisterMemory(comm, gpuBuffer, bufferSize, NCCL_PTR_CUDA, &mhandle), ncclSuccess);
     NetMHandleGuard mhandleGuard(mhandle, NetMHandleDeleter(net_, comm));
 
-    // Host staging buffer for fill and verify.
-    void* hostBuf = malloc(bufferSize);
-    ASSERT_NE(hostBuf, nullptr);
-    auto hostGuard = makeHostBufferAutoGuard(hostBuf);
-
     for (int iter = 0; iter < numIterations; iter++) {
         const int seed = 6000 + iter;
         void* request = nullptr;
 
         if (rank == 1) {
-            // Fill host staging buffer, copy to GPU, then send.
-            uint8_t* h = static_cast<uint8_t*>(hostBuf);
-            for (size_t i = 0; i < bufferSize; i++) {
-                h[i] = static_cast<uint8_t>((seed + i) % kBytePatternModulo);
-            }
-            HIP_TEST_CHECK_GTEST_FAIL(hipMemcpy(gpuBuffer, hostBuf, bufferSize, hipMemcpyHostToDevice));
+            // Fill GPU buffer via DeviceBufferHelpers (host vector → hipMemcpy in one call).
+            ASSERT_EQ(InitializeBuffer(gpuBuffer, bufferSize, seed), hipSuccess);
 
             PostSendWithRetry(pair.sendComm, gpuBuffer, bufferSize, tag, mhandle, &request);
         } else {
@@ -2348,21 +2160,9 @@ TEST_F(NetIbMPITest, FlushRepeated_VNic) {
                 ASSERT_EQ(WaitForCompletion(flushRequest, nullptr), ncclSuccess);
             }
 
-            // Copy GPU buffer to host and verify data.
-            memset(hostBuf, 0, bufferSize);
-            HIP_TEST_CHECK_GTEST_FAIL(hipMemcpy(hostBuf, gpuBuffer, bufferSize, hipMemcpyDeviceToHost));
-
-            uint8_t* h = static_cast<uint8_t*>(hostBuf);
-            bool dataValid = true;
-            for (size_t i = 0; i < bufferSize && dataValid; i++) {
-                uint8_t expected = static_cast<uint8_t>((seed + i) % kBytePatternModulo);
-                if (h[i] != expected) {
-                    dataValid = false;
-                    TEST_WARN("Iter %d: flush mismatch at index %zu: expected=%u, got=%u",
-                             iter, i, expected, h[i]);
-                }
-            }
-            ASSERT_TRUE(dataValid) << "Iter " << iter << ": data verification failed after flush";
+            // Verify GPU buffer via DeviceBufferHelpers (hipMemcpy + compare in one call).
+            ASSERT_TRUE(VerifyBuffer(gpuBuffer, bufferSize, seed))
+                << "Iter " << iter << ": data verification failed after flush";
         }
 
         MPI_Barrier(MPI_COMM_WORLD);
@@ -2429,10 +2229,7 @@ TEST_F(NetIbMPITest, SequentialTransfers_VNic) {
 
         if (rank == 1) {
             // Fill buffer with per-iteration pattern.
-            uint8_t* h = static_cast<uint8_t*>(buffer);
-            for (size_t i = 0; i < bufferSize; i++) {
-                h[i] = static_cast<uint8_t>((seed + i) % kBytePatternModulo);
-            }
+            FillHostBuffer(buffer, bufferSize, seed);
 
             PostSendWithRetry(pair.sendComm, buffer, bufferSize, tag, mhandle, &request);
         } else {
@@ -2458,17 +2255,7 @@ TEST_F(NetIbMPITest, SequentialTransfers_VNic) {
         if (rank == 0) {
             ASSERT_EQ(sizes[0], bufferSize) << "Iter " << iter << ": received size mismatch";
 
-            uint8_t* h = static_cast<uint8_t*>(buffer);
-            bool dataValid = true;
-            for (size_t i = 0; i < bufferSize && dataValid; i++) {
-                uint8_t expected = static_cast<uint8_t>((seed + i) % kBytePatternModulo);
-                if (h[i] != expected) {
-                    dataValid = false;
-                    TEST_WARN("Iter %d: mismatch at index %zu: expected=%u, got=%u",
-                             iter, i, expected, h[i]);
-                }
-            }
-            ASSERT_TRUE(dataValid) << "Iter " << iter << ": data verification failed";
+            ASSERT_TRUE(VerifyHostBuffer(buffer, bufferSize, seed)) << "Iter " << iter << ": data verification failed";
         }
 
         // Sync before next iteration to prevent request reuse races.
@@ -2528,10 +2315,7 @@ TEST_F(NetIbMPITest, Reconnect_VNic) {
 
         if (rank == 1) {
             // Fill with cycle-specific pattern.
-            uint8_t* h = static_cast<uint8_t*>(buffer);
-            for (size_t i = 0; i < bufferSize; i++) {
-                h[i] = static_cast<uint8_t>((seed + i) % kBytePatternModulo);
-            }
+            FillHostBuffer(buffer, bufferSize, seed);
 
             PostSendWithRetry(pair.sendComm, buffer, bufferSize, tag, mhandle, &request);
         } else {
@@ -2555,17 +2339,7 @@ TEST_F(NetIbMPITest, Reconnect_VNic) {
         if (rank == 0) {
             ASSERT_EQ(sizes[0], bufferSize) << "Cycle " << cycle << ": received size mismatch";
 
-            uint8_t* h = static_cast<uint8_t*>(buffer);
-            bool dataValid = true;
-            for (size_t i = 0; i < bufferSize && dataValid; i++) {
-                uint8_t expected = static_cast<uint8_t>((seed + i) % kBytePatternModulo);
-                if (h[i] != expected) {
-                    dataValid = false;
-                    TEST_WARN("Cycle %d: mismatch at index %zu: expected=%u, got=%u",
-                             cycle, i, expected, h[i]);
-                }
-            }
-            ASSERT_TRUE(dataValid) << "Cycle " << cycle << ": data verification failed";
+            ASSERT_TRUE(VerifyHostBuffer(buffer, bufferSize, seed)) << "Cycle " << cycle << ": data verification failed";
         }
 
         MPI_Barrier(MPI_COMM_WORLD);

--- a/projects/rccl/test/transport/NetIbMPITests.cpp
+++ b/projects/rccl/test/transport/NetIbMPITests.cpp
@@ -1356,4 +1356,1400 @@ TEST_F(NetIbMPITest, CloseWithoutWaitingForCompletion) {
     }
 }
 
+TEST_F(NetIbMPITest, ConnectAndTransfer_VNic) {
+    ASSERT_TRUE(validateTestPrerequisites(kExactTwoProcesses, kExactTwoProcesses,
+                                         false, kMinGpusPerNode, kNoNodeLimit))
+        << "Test requires exactly " << kExactTwoProcesses << " processes";
+
+    ASSERT_EQ(InitNetIb(), ncclSuccess);
+
+    int ndev = 0;
+    ASSERT_EQ(GetDeviceCount(&ndev), ncclSuccess);
+
+    if (ndev < 2) {
+        GTEST_SKIP() << "Need at least 2 IB devices for NIC fusion tests";
+    }
+
+    // Create a fused vNIC from physical devices 0 and 1.
+    ncclNetVDeviceProps_t vProps;
+    vProps.ndevs = 2;
+    vProps.devs[0] = 0;
+    vProps.devs[1] = 1;
+
+    int vdev = -1;
+    ASSERT_EQ(MakeVirtualDevice(&vdev, &vProps), ncclSuccess)
+        << "Failed to create fused vNIC from devices 0 and 1";
+    ASSERT_GE(vdev, 0);
+
+    int rank = MPIEnvironment::world_rank;
+    int peerRank = (rank + 1) % 2;
+
+    // Connect through the vNIC
+    ConnectionPair pair;
+    ASSERT_EQ(SetupConnection(vdev, pair, rank, peerRank), ncclSuccess);
+
+    NetConnectionGuard connGuard(net_);
+    if (rank == 0) {
+        connGuard.setRecvComm(pair.recvComm);
+        connGuard.setListenComm(pair.listenComm);
+    } else {
+        connGuard.setSendComm(pair.sendComm);
+    }
+
+    const size_t bufferSize = kSmallBufferSize;
+    const int tag = 500;
+    const int seed = 5000;
+
+    void* buffer = malloc(bufferSize);
+    ASSERT_NE(buffer, nullptr);
+    auto bufferGuard = makeHostBufferAutoGuard(buffer);
+
+    // Register the buffer on each sub-device's PD.
+    void* mhandle = nullptr;
+    void* comm = (rank == 0) ? pair.recvComm : pair.sendComm;
+    ASSERT_EQ(RegisterMemory(comm, buffer, bufferSize, NCCL_PTR_HOST, &mhandle), ncclSuccess);
+    NetMHandleGuard mhandleGuard(mhandle, NetMHandleDeleter(net_, comm));
+
+    void* request = nullptr;
+
+    if (rank == 0) {
+        memset(buffer, 0, bufferSize);
+
+        void* recvBuffers[1] = {buffer};
+        size_t recvSizes[1] = {bufferSize};
+        int recvTags[1] = {tag};
+        void* recvHandles[1] = {mhandle};
+
+        ASSERT_EQ(PostRecv(pair.recvComm, 1, recvBuffers, recvSizes, recvTags,
+                          recvHandles, &request), ncclSuccess);
+    } else {
+        uint8_t* hostBuffer = static_cast<uint8_t*>(buffer);
+        for (size_t i = 0; i < bufferSize; i++) {
+            hostBuffer[i] = static_cast<uint8_t>((seed + i) % kBytePatternModulo);
+        }
+
+        // Retry until the receiver's FIFO is ready.
+        int attempts = 0;
+        do {
+            ncclResult_t result = PostSend(pair.sendComm, buffer, bufferSize, tag, mhandle, &request);
+            ASSERT_EQ(result, ncclSuccess);
+            if (request != nullptr) break;
+            if (++attempts >= kMaxRetryAttempts) {
+                FAIL() << "PostSend returned NULL request after " << kMaxRetryAttempts << " attempts";
+            }
+            usleep(kPollIntervalUs);
+        } while (request == nullptr);
+    }
+
+    MPI_Barrier(MPI_COMM_WORLD);
+
+    int sizes[1] = {0};
+    ASSERT_EQ(WaitForCompletion(request, sizes), ncclSuccess);
+
+    // Verify data integrity.
+    if (rank == 0) {
+        EXPECT_EQ(sizes[0], bufferSize) << "Received size mismatch";
+
+        uint8_t* hostBuffer = static_cast<uint8_t*>(buffer);
+        bool dataValid = true;
+        for (size_t i = 0; i < bufferSize && dataValid; i++) {
+            uint8_t expected = static_cast<uint8_t>((seed + i) % kBytePatternModulo);
+            if (hostBuffer[i] != expected) {
+                dataValid = false;
+                TEST_WARN("Rank %d: Data mismatch at index %zu: expected=%u, got=%u",
+                         rank, i, expected, hostBuffer[i]);
+            }
+        }
+        EXPECT_TRUE(dataValid) << "Data validation failed on vNIC transfer";
+    }
+
+}
+
+TEST_F(NetIbMPITest, AsymmetricMerge_VNic) {
+    ASSERT_TRUE(validateTestPrerequisites(kExactTwoProcesses, kExactTwoProcesses,
+                                         false, kMinGpusPerNode, kNoNodeLimit))
+        << "Test requires exactly " << kExactTwoProcesses << " processes";
+
+    ASSERT_EQ(InitNetIb(), ncclSuccess);
+
+    int ndev = 0;
+    ASSERT_EQ(GetDeviceCount(&ndev), ncclSuccess);
+
+    if (ndev < 2) {
+        GTEST_SKIP() << "Need at least 2 IB devices for NIC fusion tests";
+    }
+
+    int rank = MPIEnvironment::world_rank;
+    int peerRank = (rank + 1) % 2;
+
+    // Rank 0: create a fused vNIC (ndevs=2). Rank 1: use physical device 0 (ndevs=1).
+    int vdev = -1;
+    if (rank == 0) {
+        ncclNetVDeviceProps_t vProps;
+        vProps.ndevs = 2;
+        vProps.devs[0] = 0;
+        vProps.devs[1] = 1;
+        ASSERT_EQ(MakeVirtualDevice(&vdev, &vProps), ncclSuccess)
+            << "Failed to create fused vNIC from devices 0 and 1";
+        ASSERT_GE(vdev, 0);
+    }
+
+    // Inline connection setup: each rank uses a different device ID.
+    // Rank 0 (receiver): listen on vdev (ndevs=2, 2 PDs, doubled QPs)
+    // Rank 1 (sender):   connect on physical dev 0 (ndevs=1, 1 PD)
+    // ncclIbCalculateNqps uses max(local, remote) so both sides get the same QP count.
+    ConnectionPair pair;
+    if (rank == 0) {
+        ASSERT_EQ(CreateListenComm(vdev, &pair.handle, &pair.listenComm), ncclSuccess);
+        MPI_Send(&pair.handle, sizeof(ncclNetHandle_t), MPI_BYTE, peerRank, 0, MPI_COMM_WORLD);
+
+        int done = 0;
+        while (!done) {
+            ncclResult_t result = AcceptConnection(pair.listenComm, &pair.recvComm);
+            if (result == ncclSuccess && pair.recvComm != nullptr) {
+                done = 1;
+            }
+        }
+    } else {
+        MPI_Recv(&pair.handle, sizeof(ncclNetHandle_t), MPI_BYTE, peerRank, 0, MPI_COMM_WORLD, MPI_STATUS_IGNORE);
+
+        // Connect using physical device 0 (ndevs=1)
+        int done = 0;
+        while (!done) {
+            ncclResult_t result = ConnectToRemote(0, &pair.handle, &pair.sendComm);
+            if (result == ncclSuccess && pair.sendComm != nullptr) {
+                done = 1;
+            }
+        }
+    }
+
+    MPI_Barrier(MPI_COMM_WORLD);
+
+    NetConnectionGuard connGuard(net_);
+    if (rank == 0) {
+        connGuard.setRecvComm(pair.recvComm);
+        connGuard.setListenComm(pair.listenComm);
+    } else {
+        connGuard.setSendComm(pair.sendComm);
+    }
+
+    const size_t bufferSize = kSmallBufferSize;
+    const int tag = 510;
+    const int seed = 5100;
+
+    void* buffer = malloc(bufferSize);
+    ASSERT_NE(buffer, nullptr);
+    auto bufferGuard = makeHostBufferAutoGuard(buffer);
+
+    // Rank 0 registers on 2 PDs (vNIC), rank 1 registers on 1 PD (physical dev).
+    void* mhandle = nullptr;
+    void* comm = (rank == 0) ? pair.recvComm : pair.sendComm;
+    ASSERT_EQ(RegisterMemory(comm, buffer, bufferSize, NCCL_PTR_HOST, &mhandle), ncclSuccess);
+    NetMHandleGuard mhandleGuard(mhandle, NetMHandleDeleter(net_, comm));
+
+    void* request = nullptr;
+
+    if (rank == 0) {
+        memset(buffer, 0, bufferSize);
+
+        void* recvBuffers[1] = {buffer};
+        size_t recvSizes[1] = {bufferSize};
+        int recvTags[1] = {tag};
+        void* recvHandles[1] = {mhandle};
+
+        ASSERT_EQ(PostRecv(pair.recvComm, 1, recvBuffers, recvSizes, recvTags,
+                          recvHandles, &request), ncclSuccess);
+    } else {
+        uint8_t* hostBuffer = static_cast<uint8_t*>(buffer);
+        for (size_t i = 0; i < bufferSize; i++) {
+            hostBuffer[i] = static_cast<uint8_t>((seed + i) % kBytePatternModulo);
+        }
+
+        // Retry until the receiver's FIFO is ready.
+        int attempts = 0;
+        do {
+            ncclResult_t result = PostSend(pair.sendComm, buffer, bufferSize, tag, mhandle, &request);
+            ASSERT_EQ(result, ncclSuccess);
+            if (request != nullptr) break;
+            if (++attempts >= kMaxRetryAttempts) {
+                FAIL() << "PostSend returned NULL request after " << kMaxRetryAttempts << " attempts";
+            }
+            usleep(kPollIntervalUs);
+        } while (request == nullptr);
+    }
+
+    MPI_Barrier(MPI_COMM_WORLD);
+
+    int sizes[1] = {0};
+    ASSERT_EQ(WaitForCompletion(request, sizes), ncclSuccess);
+
+    // Verify data integrity across the asymmetric connection.
+    if (rank == 0) {
+        EXPECT_EQ(sizes[0], bufferSize) << "Received size mismatch";
+
+        uint8_t* hostBuffer = static_cast<uint8_t*>(buffer);
+        bool dataValid = true;
+        for (size_t i = 0; i < bufferSize && dataValid; i++) {
+            uint8_t expected = static_cast<uint8_t>((seed + i) % kBytePatternModulo);
+            if (hostBuffer[i] != expected) {
+                dataValid = false;
+                TEST_WARN("Rank %d: Data mismatch at index %zu: expected=%u, got=%u",
+                         rank, i, expected, hostBuffer[i]);
+            }
+        }
+        EXPECT_TRUE(dataValid) << "Data validation failed on asymmetric vNIC transfer";
+    }
+}
+
+TEST_F(NetIbMPITest, CloseWithoutTransfer_VNic) {
+    ASSERT_TRUE(validateTestPrerequisites(kExactTwoProcesses, kExactTwoProcesses,
+                                         false, kMinGpusPerNode, kNoNodeLimit))
+        << "Test requires exactly " << kExactTwoProcesses << " processes";
+
+    ASSERT_EQ(InitNetIb(), ncclSuccess);
+
+    int ndev = 0;
+    ASSERT_EQ(GetDeviceCount(&ndev), ncclSuccess);
+
+    if (ndev < 2) {
+        GTEST_SKIP() << "Need at least 2 IB devices for NIC fusion tests";
+    }
+
+    int rank = MPIEnvironment::world_rank;
+    int peerRank = (rank + 1) % 2;
+
+    // Create a fused vNIC from physical devices 0 and 1.
+    ncclNetVDeviceProps_t vProps;
+    vProps.ndevs = 2;
+    vProps.devs[0] = 0;
+    vProps.devs[1] = 1;
+
+    int vdev = -1;
+    ASSERT_EQ(MakeVirtualDevice(&vdev, &vProps), ncclSuccess)
+        << "Failed to create fused vNIC from devices 0 and 1";
+    ASSERT_GE(vdev, 0);
+
+    // Phase 1: connect through the vNIC, then close immediately without any transfer.
+    // Scoped block ensures RAII teardown happens before phase 2.
+    {
+        ConnectionPair pair;
+        ASSERT_EQ(SetupConnection(vdev, pair, rank, peerRank), ncclSuccess);
+
+        // Guard triggers closeSend/closeRecv/closeListen on a connection that
+        // never had regMr, isend, or irecv called.
+        NetConnectionGuard connGuard(net_);
+        if (rank == 0) {
+            connGuard.setRecvComm(pair.recvComm);
+            connGuard.setListenComm(pair.listenComm);
+        } else {
+            connGuard.setSendComm(pair.sendComm);
+        }
+    }
+
+    MPI_Barrier(MPI_COMM_WORLD);
+
+    // Phase 2: reconnect on the same vdev and do a transfer to verify no corruption.
+    ConnectionPair pair2;
+    ASSERT_EQ(SetupConnection(vdev, pair2, rank, peerRank), ncclSuccess);
+
+    NetConnectionGuard connGuard2(net_);
+    if (rank == 0) {
+        connGuard2.setRecvComm(pair2.recvComm);
+        connGuard2.setListenComm(pair2.listenComm);
+    } else {
+        connGuard2.setSendComm(pair2.sendComm);
+    }
+
+    const size_t bufferSize = kSmallBufferSize;
+    const int tag = 520;
+    const int seed = 5200;
+
+    void* buffer = malloc(bufferSize);
+    ASSERT_NE(buffer, nullptr);
+    auto bufferGuard = makeHostBufferAutoGuard(buffer);
+
+    void* mhandle = nullptr;
+    void* comm = (rank == 0) ? pair2.recvComm : pair2.sendComm;
+    ASSERT_EQ(RegisterMemory(comm, buffer, bufferSize, NCCL_PTR_HOST, &mhandle), ncclSuccess);
+    NetMHandleGuard mhandleGuard(mhandle, NetMHandleDeleter(net_, comm));
+
+    void* request = nullptr;
+
+    if (rank == 0) {
+        memset(buffer, 0, bufferSize);
+
+        void* recvBuffers[1] = {buffer};
+        size_t recvSizes[1] = {bufferSize};
+        int recvTags[1] = {tag};
+        void* recvHandles[1] = {mhandle};
+
+        ASSERT_EQ(PostRecv(pair2.recvComm, 1, recvBuffers, recvSizes, recvTags,
+                          recvHandles, &request), ncclSuccess);
+    } else {
+        uint8_t* hostBuffer = static_cast<uint8_t*>(buffer);
+        for (size_t i = 0; i < bufferSize; i++) {
+            hostBuffer[i] = static_cast<uint8_t>((seed + i) % kBytePatternModulo);
+        }
+
+        int attempts = 0;
+        do {
+            ncclResult_t result = PostSend(pair2.sendComm, buffer, bufferSize, tag, mhandle, &request);
+            ASSERT_EQ(result, ncclSuccess);
+            if (request != nullptr) break;
+            if (++attempts >= kMaxRetryAttempts) {
+                FAIL() << "PostSend returned NULL request after " << kMaxRetryAttempts << " attempts";
+            }
+            usleep(kPollIntervalUs);
+        } while (request == nullptr);
+    }
+
+    MPI_Barrier(MPI_COMM_WORLD);
+
+    int sizes[1] = {0};
+    ASSERT_EQ(WaitForCompletion(request, sizes), ncclSuccess);
+
+    // Verify the vNIC is still functional after the no-transfer teardown.
+    if (rank == 0) {
+        EXPECT_EQ(sizes[0], bufferSize) << "Received size mismatch";
+
+        uint8_t* hostBuffer = static_cast<uint8_t*>(buffer);
+        bool dataValid = true;
+        for (size_t i = 0; i < bufferSize && dataValid; i++) {
+            uint8_t expected = static_cast<uint8_t>((seed + i) % kBytePatternModulo);
+            if (hostBuffer[i] != expected) {
+                dataValid = false;
+                TEST_WARN("Rank %d: Data mismatch at index %zu: expected=%u, got=%u",
+                         rank, i, expected, hostBuffer[i]);
+            }
+        }
+        EXPECT_TRUE(dataValid) << "Data validation failed after no-transfer teardown reconnect";
+    }
+}
+
+TEST_F(NetIbMPITest, RegDeregCycling_VNic) {
+    ASSERT_TRUE(validateTestPrerequisites(kExactTwoProcesses, kExactTwoProcesses,
+                                         false, kMinGpusPerNode, kNoNodeLimit))
+        << "Test requires exactly " << kExactTwoProcesses << " processes";
+
+    ASSERT_EQ(InitNetIb(), ncclSuccess);
+
+    int ndev = 0;
+    ASSERT_EQ(GetDeviceCount(&ndev), ncclSuccess);
+
+    if (ndev < 2) {
+        GTEST_SKIP() << "Need at least 2 IB devices for NIC fusion tests";
+    }
+
+    int rank = MPIEnvironment::world_rank;
+    int peerRank = (rank + 1) % 2;
+
+    // Create a fused vNIC from physical devices 0 and 1.
+    ncclNetVDeviceProps_t vProps;
+    vProps.ndevs = 2;
+    vProps.devs[0] = 0;
+    vProps.devs[1] = 1;
+
+    int vdev = -1;
+    ASSERT_EQ(MakeVirtualDevice(&vdev, &vProps), ncclSuccess)
+        << "Failed to create fused vNIC from devices 0 and 1";
+    ASSERT_GE(vdev, 0);
+
+    ConnectionPair pair;
+    ASSERT_EQ(SetupConnection(vdev, pair, rank, peerRank), ncclSuccess);
+
+    NetConnectionGuard connGuard(net_);
+    if (rank == 0) {
+        connGuard.setRecvComm(pair.recvComm);
+        connGuard.setListenComm(pair.listenComm);
+    } else {
+        connGuard.setSendComm(pair.sendComm);
+    }
+
+    const size_t bufferSize = kSmallBufferSize;
+    void* buffer = malloc(bufferSize);
+    ASSERT_NE(buffer, nullptr);
+    auto bufferGuard = makeHostBufferAutoGuard(buffer);
+
+    void* comm = (rank == 0) ? pair.recvComm : pair.sendComm;
+
+    // Cycle 50× regMr→deregMr on the same buffer to stress multi-PD MR cache.
+    const int kCycles = 50;
+    for (int i = 0; i < kCycles; i++) {
+        void* mhandle = nullptr;
+        ASSERT_EQ(RegisterMemory(comm, buffer, bufferSize, NCCL_PTR_HOST, &mhandle), ncclSuccess)
+            << "regMr failed on cycle " << i;
+        ASSERT_NE(mhandle, nullptr);
+        ASSERT_EQ(DeregisterMemory(comm, mhandle), ncclSuccess)
+            << "deregMr failed on cycle " << i;
+    }
+
+    MPI_Barrier(MPI_COMM_WORLD);
+
+    // Verify the connection is still functional after 50 reg/dereg cycles.
+    void* mhandle = nullptr;
+    ASSERT_EQ(RegisterMemory(comm, buffer, bufferSize, NCCL_PTR_HOST, &mhandle), ncclSuccess);
+    NetMHandleGuard mhandleGuard(mhandle, NetMHandleDeleter(net_, comm));
+
+    const int tag = 530;
+    const int seed = 5300;
+    void* request = nullptr;
+
+    // Send/recv to verify the connection works after MR cache stress.
+    if (rank == 0) {
+        memset(buffer, 0, bufferSize);
+
+        void* recvBuffers[1] = {buffer};
+        size_t recvSizes[1] = {bufferSize};
+        int recvTags[1] = {tag};
+        void* recvHandles[1] = {mhandle};
+
+        ASSERT_EQ(PostRecv(pair.recvComm, 1, recvBuffers, recvSizes, recvTags,
+                          recvHandles, &request), ncclSuccess);
+    } else {
+        uint8_t* hostBuffer = static_cast<uint8_t*>(buffer);
+        for (size_t i = 0; i < bufferSize; i++) {
+            hostBuffer[i] = static_cast<uint8_t>((seed + i) % kBytePatternModulo);
+        }
+
+        // Retry until the receiver's FIFO is ready.
+        int attempts = 0;
+        do {
+            ncclResult_t result = PostSend(pair.sendComm, buffer, bufferSize, tag, mhandle, &request);
+            ASSERT_EQ(result, ncclSuccess);
+            if (request != nullptr) break;
+            if (++attempts >= kMaxRetryAttempts) {
+                FAIL() << "PostSend returned NULL request after " << kMaxRetryAttempts << " attempts";
+            }
+            usleep(kPollIntervalUs);
+        } while (request == nullptr);
+    }
+
+    MPI_Barrier(MPI_COMM_WORLD);
+
+    int sizes[1] = {0};
+    ASSERT_EQ(WaitForCompletion(request, sizes), ncclSuccess);
+
+    // Data integrity check after MR cache cycling.
+    if (rank == 0) {
+        EXPECT_EQ(sizes[0], bufferSize) << "Received size mismatch";
+
+        uint8_t* hostBuffer = static_cast<uint8_t*>(buffer);
+        bool dataValid = true;
+        for (size_t i = 0; i < bufferSize && dataValid; i++) {
+            uint8_t expected = static_cast<uint8_t>((seed + i) % kBytePatternModulo);
+            if (hostBuffer[i] != expected) {
+                dataValid = false;
+                TEST_WARN("Rank %d: Data mismatch at index %zu: expected=%u, got=%u",
+                         rank, i, expected, hostBuffer[i]);
+            }
+        }
+        EXPECT_TRUE(dataValid) << "Data validation failed after reg/dereg cycling";
+    }
+}
+
+TEST_F(NetIbMPITest, LargeTransfer_VNic) {
+    ASSERT_TRUE(validateTestPrerequisites(kExactTwoProcesses, kExactTwoProcesses,
+                                         false, kMinGpusPerNode, kNoNodeLimit))
+        << "Test requires exactly " << kExactTwoProcesses << " processes";
+
+    ASSERT_EQ(InitNetIb(), ncclSuccess);
+
+    int ndev = 0;
+    ASSERT_EQ(GetDeviceCount(&ndev), ncclSuccess);
+
+    if (ndev < 2) {
+        GTEST_SKIP() << "Need at least 2 IB devices for NIC fusion tests";
+    }
+
+    int rank = MPIEnvironment::world_rank;
+    int peerRank = (rank + 1) % 2;
+
+    // Create a fused vNIC from physical devices 0 and 1.
+    ncclNetVDeviceProps_t vProps;
+    vProps.ndevs = 2;
+    vProps.devs[0] = 0;
+    vProps.devs[1] = 1;
+
+    int vdev = -1;
+    ASSERT_EQ(MakeVirtualDevice(&vdev, &vProps), ncclSuccess)
+        << "Failed to create fused vNIC from devices 0 and 1";
+    ASSERT_GE(vdev, 0);
+
+    ConnectionPair pair;
+    ASSERT_EQ(SetupConnection(vdev, pair, rank, peerRank), ncclSuccess);
+
+    NetConnectionGuard connGuard(net_);
+    if (rank == 0) {
+        connGuard.setRecvComm(pair.recvComm);
+        connGuard.setListenComm(pair.listenComm);
+    } else {
+        connGuard.setSendComm(pair.sendComm);
+    }
+
+    // 64MB buffer — ncclIbMultiSend stripes this across the doubled QPs.
+    const size_t bufferSize = 64 * 1024 * 1024;
+    const int tag = 540;
+    const int seed = 5400;
+
+    void* buffer = malloc(bufferSize);
+    ASSERT_NE(buffer, nullptr);
+    auto bufferGuard = makeHostBufferAutoGuard(buffer);
+
+    void* mhandle = nullptr;
+    void* comm = (rank == 0) ? pair.recvComm : pair.sendComm;
+    ASSERT_EQ(RegisterMemory(comm, buffer, bufferSize, NCCL_PTR_HOST, &mhandle), ncclSuccess);
+    NetMHandleGuard mhandleGuard(mhandle, NetMHandleDeleter(net_, comm));
+
+    void* request = nullptr;
+
+    if (rank == 0) {
+        memset(buffer, 0, bufferSize);
+
+        void* recvBuffers[1] = {buffer};
+        size_t recvSizes[1] = {bufferSize};
+        int recvTags[1] = {tag};
+        void* recvHandles[1] = {mhandle};
+
+        ASSERT_EQ(PostRecv(pair.recvComm, 1, recvBuffers, recvSizes, recvTags,
+                          recvHandles, &request), ncclSuccess);
+    } else {
+        uint8_t* hostBuffer = static_cast<uint8_t*>(buffer);
+        for (size_t i = 0; i < bufferSize; i++) {
+            hostBuffer[i] = static_cast<uint8_t>((seed + i) % kBytePatternModulo);
+        }
+
+        // Retry until the receiver's FIFO is ready.
+        int attempts = 0;
+        do {
+            ncclResult_t result = PostSend(pair.sendComm, buffer, bufferSize, tag, mhandle, &request);
+            ASSERT_EQ(result, ncclSuccess);
+            if (request != nullptr) break;
+            if (++attempts >= kMaxRetryAttempts) {
+                FAIL() << "PostSend returned NULL request after " << kMaxRetryAttempts << " attempts";
+            }
+            usleep(kPollIntervalUs);
+        } while (request == nullptr);
+    }
+
+    MPI_Barrier(MPI_COMM_WORLD);
+
+    // Extended timeout for 16MB transfer across doubled QPs.
+    int sizes[1] = {0};
+    ASSERT_EQ(WaitForCompletion(request, sizes, kLargeTransferTimeout), ncclSuccess);
+
+    // Full 64MB byte-by-byte verification
+    // ncclIbMultiSend would corrupt data at QP split points.
+    if (rank == 0) {
+        EXPECT_EQ(sizes[0], bufferSize) << "Large transfer size mismatch";
+
+        uint8_t* hostBuffer = static_cast<uint8_t*>(buffer);
+        bool dataValid = true;
+        size_t errorsFound = 0;
+        const size_t maxErrorsToReport = 10;
+
+        for (size_t i = 0; i < bufferSize && errorsFound < maxErrorsToReport; i++) {
+            uint8_t expected = static_cast<uint8_t>((seed + i) % kBytePatternModulo);
+            if (hostBuffer[i] != expected) {
+                if (errorsFound == 0) {
+                    TEST_WARN("Rank %d: Data validation errors in large vNIC transfer:", rank);
+                }
+                TEST_WARN("  Index %zu: expected=%u, got=%u", i, expected, hostBuffer[i]);
+                dataValid = false;
+                errorsFound++;
+            }
+        }
+
+        if (!dataValid && errorsFound >= maxErrorsToReport) {
+            TEST_WARN("  ... (showing first %zu errors only)", maxErrorsToReport);
+        }
+
+        EXPECT_TRUE(dataValid) << "Large vNIC transfer data validation failed";
+    }
+}
+
+TEST_F(NetIbMPITest, MixedSizes_VNic) {
+    ASSERT_TRUE(validateTestPrerequisites(kExactTwoProcesses, kExactTwoProcesses,
+                                         false, kMinGpusPerNode, kNoNodeLimit))
+        << "Test requires exactly " << kExactTwoProcesses << " processes";
+
+    ASSERT_EQ(InitNetIb(), ncclSuccess);
+
+    int ndev = 0;
+    ASSERT_EQ(GetDeviceCount(&ndev), ncclSuccess);
+
+    if (ndev < 2) {
+        GTEST_SKIP() << "Need at least 2 IB devices for NIC fusion tests";
+    }
+
+    int rank = MPIEnvironment::world_rank;
+    int peerRank = (rank + 1) % 2;
+
+    // Create a fused vNIC from physical devices 0 and 1.
+    ncclNetVDeviceProps_t vProps;
+    vProps.ndevs = 2;
+    vProps.devs[0] = 0;
+    vProps.devs[1] = 1;
+
+    int vdev = -1;
+    ASSERT_EQ(MakeVirtualDevice(&vdev, &vProps), ncclSuccess)
+        << "Failed to create fused vNIC from devices 0 and 1";
+    ASSERT_GE(vdev, 0);
+
+    ConnectionPair pair;
+    ASSERT_EQ(SetupConnection(vdev, pair, rank, peerRank), ncclSuccess);
+
+    NetConnectionGuard connGuard(net_);
+    if (rank == 0) {
+        connGuard.setRecvComm(pair.recvComm);
+        connGuard.setListenComm(pair.listenComm);
+    } else {
+        connGuard.setSendComm(pair.sendComm);
+    }
+
+    // Sizes: 1B, 3MB, 3B, 5MB, 7B, 7MB, 64B, 16MB, 1B, 11MB, 4MB, 1B.
+    // Tiny sizes may use only one QP, large ones stripe across both.
+    // Odd MB sizes (3, 5, 7, 11) produce uneven QP splits.
+    std::vector<size_t> testSizes = {
+        1, 3*1024*1024, 3, 5*1024*1024, 7, 7*1024*1024,
+        64, 16*1024*1024, 1, 11*1024*1024, 4*1024*1024, 1
+    };
+
+    for (size_t idx = 0; idx < testSizes.size(); idx++) {
+        size_t size = testSizes[idx];
+        const int tag = 550;
+        const int seed = 5500 + static_cast<int>(idx);
+
+        void* buffer = malloc(size);
+        ASSERT_NE(buffer, nullptr) << "malloc failed for size " << size;
+        auto bufferGuard = makeHostBufferAutoGuard(buffer);
+
+        void* mhandle = nullptr;
+        void* comm = (rank == 0) ? pair.recvComm : pair.sendComm;
+        ASSERT_EQ(RegisterMemory(comm, buffer, size, NCCL_PTR_HOST, &mhandle), ncclSuccess)
+            << "regMr failed for size " << size;
+        NetMHandleGuard mhandleGuard(mhandle, NetMHandleDeleter(net_, comm));
+
+        void* request = nullptr;
+
+        if (rank == 0) {
+            memset(buffer, 0, size);
+
+            void* recvBuffers[1] = {buffer};
+            size_t recvSizes[1] = {size};
+            int recvTags[1] = {tag};
+            void* recvHandles[1] = {mhandle};
+
+            ASSERT_EQ(PostRecv(pair.recvComm, 1, recvBuffers, recvSizes, recvTags,
+                              recvHandles, &request), ncclSuccess);
+        } else {
+            uint8_t* hostBuffer = static_cast<uint8_t*>(buffer);
+            for (size_t i = 0; i < size; i++) {
+                hostBuffer[i] = static_cast<uint8_t>((seed + i) % kBytePatternModulo);
+            }
+
+            int attempts = 0;
+            do {
+                ncclResult_t result = PostSend(pair.sendComm, buffer, size, tag, mhandle, &request);
+                ASSERT_EQ(result, ncclSuccess);
+                if (request != nullptr) break;
+                if (++attempts >= kMaxRetryAttempts) {
+                    FAIL() << "PostSend returned NULL request after " << kMaxRetryAttempts
+                           << " attempts for size " << size;
+                }
+                usleep(kPollIntervalUs);
+            } while (request == nullptr);
+        }
+
+        MPI_Barrier(MPI_COMM_WORLD);
+
+        int sizes[1] = {0};
+        int timeout = (size > 1024 * 1024) ? kLargeTransferTimeout : kDefaultTimeoutMs;
+        ASSERT_EQ(WaitForCompletion(request, sizes, timeout), ncclSuccess);
+
+        // Prevent request reuse race between iterations.
+        MPI_Barrier(MPI_COMM_WORLD);
+
+        if (rank == 0) {
+            EXPECT_EQ(sizes[0], size) << "Size mismatch for transfer of " << size << " bytes";
+
+            uint8_t* hostBuffer = static_cast<uint8_t*>(buffer);
+            bool dataValid = true;
+            for (size_t j = 0; j < size && dataValid; j++) {
+                uint8_t expected = static_cast<uint8_t>((seed + j) % kBytePatternModulo);
+                if (hostBuffer[j] != expected) {
+                    dataValid = false;
+                    TEST_WARN("Rank %d: Mismatch at index %zu for size %zu: expected=%u, got=%u",
+                             rank, j, size, expected, hostBuffer[j]);
+                }
+            }
+            EXPECT_TRUE(dataValid) << "Data validation failed for size " << size;
+        }
+    }
+}
+
+TEST_F(NetIbMPITest, UnalignedSizeTransfer_VNic) {
+    ASSERT_TRUE(validateTestPrerequisites(kExactTwoProcesses, kExactTwoProcesses,
+                                         false, kMinGpusPerNode, kNoNodeLimit))
+        << "Test requires exactly " << kExactTwoProcesses << " processes";
+
+    ASSERT_EQ(InitNetIb(), ncclSuccess);
+
+    int ndev = 0;
+    ASSERT_EQ(GetDeviceCount(&ndev), ncclSuccess);
+
+    if (ndev < 2) {
+        GTEST_SKIP() << "Need at least 2 IB devices for NIC fusion tests";
+    }
+
+    int rank = MPIEnvironment::world_rank;
+    int peerRank = (rank + 1) % 2;
+
+    ncclNetVDeviceProps_t vProps;
+    vProps.ndevs = 2;
+    vProps.devs[0] = 0;
+    vProps.devs[1] = 1;
+
+    int vdev = -1;
+    ASSERT_EQ(MakeVirtualDevice(&vdev, &vProps), ncclSuccess)
+        << "Failed to create fused vNIC from devices 0 and 1";
+    ASSERT_GE(vdev, 0);
+
+    ConnectionPair pair;
+    ASSERT_EQ(SetupConnection(vdev, pair, rank, peerRank), ncclSuccess);
+
+    NetConnectionGuard connGuard(net_);
+    if (rank == 0) {
+        connGuard.setRecvComm(pair.recvComm);
+        connGuard.setListenComm(pair.listenComm);
+    } else {
+        connGuard.setSendComm(pair.sendComm);
+    }
+
+    // Sizes around 128-byte QP striping alignment boundaries.
+    // ncclIbMultiSend computes chunkSize = DIVUP(DIVUP(size, nqps), 128) * 128.
+    // These sizes produce uneven QP splits where one QP gets more data than the other.
+    // 127: all on QP 0, QP 1 posts zero-sge. 129: 128B on QP 0, 1B on QP 1.
+    // 255: 128B each, QP 1 gets 127B. 257: 256B on QP 0, 1B remainder on QP 1.
+    std::vector<size_t> testSizes = {127, 129, 255, 257, 511, 513};
+
+    for (size_t idx = 0; idx < testSizes.size(); idx++) {
+        size_t size = testSizes[idx];
+        const int tag = 560;
+        const int seed = 5600 + static_cast<int>(idx);
+
+        // Per-iteration buffer and MR registration on 2 PDs.
+        void* buffer = malloc(size);
+        ASSERT_NE(buffer, nullptr) << "malloc failed for size " << size;
+        auto bufferGuard = makeHostBufferAutoGuard(buffer);
+
+        void* mhandle = nullptr;
+        void* comm = (rank == 0) ? pair.recvComm : pair.sendComm;
+        ASSERT_EQ(RegisterMemory(comm, buffer, size, NCCL_PTR_HOST, &mhandle), ncclSuccess)
+            << "regMr failed for size " << size;
+        NetMHandleGuard mhandleGuard(mhandle, NetMHandleDeleter(net_, comm));
+
+        void* request = nullptr;
+
+        if (rank == 0) {
+            memset(buffer, 0, size);
+
+            void* recvBuffers[1] = {buffer};
+            size_t recvSizes[1] = {size};
+            int recvTags[1] = {tag};
+            void* recvHandles[1] = {mhandle};
+
+            ASSERT_EQ(PostRecv(pair.recvComm, 1, recvBuffers, recvSizes, recvTags,
+                              recvHandles, &request), ncclSuccess);
+        } else {
+            uint8_t* hostBuffer = static_cast<uint8_t*>(buffer);
+            for (size_t i = 0; i < size; i++) {
+                hostBuffer[i] = static_cast<uint8_t>((seed + i) % kBytePatternModulo);
+            }
+
+            // Retry until the receiver's FIFO is ready.
+            int attempts = 0;
+            do {
+                ncclResult_t result = PostSend(pair.sendComm, buffer, size, tag, mhandle, &request);
+                ASSERT_EQ(result, ncclSuccess);
+                if (request != nullptr) break;
+                if (++attempts >= kMaxRetryAttempts) {
+                    FAIL() << "PostSend returned NULL request after " << kMaxRetryAttempts
+                           << " attempts for size " << size;
+                }
+                usleep(kPollIntervalUs);
+            } while (request == nullptr);
+        }
+
+        MPI_Barrier(MPI_COMM_WORLD);
+
+        int sizes[1] = {0};
+        ASSERT_EQ(WaitForCompletion(request, sizes), ncclSuccess);
+
+        // Prevent request reuse race between iterations.
+        MPI_Barrier(MPI_COMM_WORLD);
+
+        // Byte level verification at the striping boundary.
+        if (rank == 0) {
+            EXPECT_EQ(sizes[0], size) << "Size mismatch for transfer of " << size << " bytes";
+
+            uint8_t* hostBuffer = static_cast<uint8_t*>(buffer);
+            bool dataValid = true;
+            for (size_t j = 0; j < size && dataValid; j++) {
+                uint8_t expected = static_cast<uint8_t>((seed + j) % kBytePatternModulo);
+                if (hostBuffer[j] != expected) {
+                    dataValid = false;
+                    TEST_WARN("Rank %d: Mismatch at index %zu for size %zu: expected=%u, got=%u",
+                             rank, j, size, expected, hostBuffer[j]);
+                }
+            }
+            EXPECT_TRUE(dataValid) << "Data validation failed for size " << size;
+        }
+    }
+}
+
+TEST_F(NetIbMPITest, Bidirectional_VNic) {
+    ASSERT_TRUE(validateTestPrerequisites(kExactTwoProcesses, kExactTwoProcesses,
+                                         false, kMinGpusPerNode, kNoNodeLimit))
+        << "Test requires exactly " << kExactTwoProcesses << " processes";
+
+    ASSERT_EQ(InitNetIb(), ncclSuccess);
+
+    int ndev = 0;
+    ASSERT_EQ(GetDeviceCount(&ndev), ncclSuccess);
+
+    if (ndev < 2) {
+        GTEST_SKIP() << "Need at least 2 IB devices for NIC fusion tests";
+    }
+
+    int rank = MPIEnvironment::world_rank;
+    int peerRank = (rank + 1) % 2;
+
+    // Both ranks create a fused vNIC.
+    ncclNetVDeviceProps_t vProps;
+    vProps.ndevs = 2;
+    vProps.devs[0] = 0;
+    vProps.devs[1] = 1;
+
+    int vdev = -1;
+    ASSERT_EQ(MakeVirtualDevice(&vdev, &vProps), ncclSuccess)
+        << "Failed to create fused vNIC from devices 0 and 1";
+    ASSERT_GE(vdev, 0);
+
+    // Two connections through the same vNIC with reversed roles.
+    // ConnA: rank 0 receives, rank 1 sends (tag 0 for MPI handle exchange).
+    // ConnB: rank 1 receives, rank 0 sends (tag 1 for MPI handle exchange).
+    ConnectionPair connA, connB;
+
+    // Phase 1: Both ranks create their listener, then exchange handles via MPI.
+    // Rank 0 receives on ConnA, rank 1 receives on ConnB.
+    if (rank == 0) {
+        ASSERT_EQ(CreateListenComm(vdev, &connA.handle, &connA.listenComm), ncclSuccess);
+    } else {
+        ASSERT_EQ(CreateListenComm(vdev, &connB.handle, &connB.listenComm), ncclSuccess);
+    }
+
+    // Exchange: rank 0 sends connA handle, rank 1 sends connB handle.
+    if (rank == 0) {
+        MPI_Send(&connA.handle, sizeof(ncclNetHandle_t), MPI_BYTE, peerRank, 0, MPI_COMM_WORLD);
+        MPI_Recv(&connB.handle, sizeof(ncclNetHandle_t), MPI_BYTE, peerRank, 1, MPI_COMM_WORLD, MPI_STATUS_IGNORE);
+    } else {
+        MPI_Recv(&connA.handle, sizeof(ncclNetHandle_t), MPI_BYTE, peerRank, 0, MPI_COMM_WORLD, MPI_STATUS_IGNORE);
+        MPI_Send(&connB.handle, sizeof(ncclNetHandle_t), MPI_BYTE, peerRank, 1, MPI_COMM_WORLD);
+    }
+
+    // Phase 2: Connect and accept interleaved to avoid deadlock.
+    // Rank 0: connect on ConnB (sender), accept on ConnA (receiver).
+    // Rank 1: connect on ConnA (sender), accept on ConnB (receiver).
+    ncclNetHandle_t* connectHandle = (rank == 0) ? &connB.handle : &connA.handle;
+    void** connectSendComm = (rank == 0) ? &connB.sendComm : &connA.sendComm;
+    void*  myListenComm    = (rank == 0) ? connA.listenComm : connB.listenComm;
+    void** acceptRecvComm  = (rank == 0) ? &connA.recvComm : &connB.recvComm;
+
+    while (*connectSendComm == nullptr || *acceptRecvComm == nullptr) {
+        if (*connectSendComm == nullptr) {
+            ConnectToRemote(vdev, connectHandle, connectSendComm);
+        }
+        if (*acceptRecvComm == nullptr) {
+            AcceptConnection(myListenComm, acceptRecvComm);
+        }
+    }
+
+    MPI_Barrier(MPI_COMM_WORLD);
+
+    // RAII guards for both connections.
+    NetConnectionGuard guardA(net_);
+    NetConnectionGuard guardB(net_);
+    if (rank == 0) {
+        guardA.setRecvComm(connA.recvComm);
+        guardA.setListenComm(connA.listenComm);
+        guardB.setSendComm(connB.sendComm);
+    } else {
+        guardA.setSendComm(connA.sendComm);
+        guardB.setRecvComm(connB.recvComm);
+        guardB.setListenComm(connB.listenComm);
+    }
+
+    const size_t bufferSize = kSmallBufferSize;
+
+    // Each rank has a send buffer and a recv buffer.
+    void* sendBuf = malloc(bufferSize);
+    ASSERT_NE(sendBuf, nullptr);
+    auto sendGuard = makeHostBufferAutoGuard(sendBuf);
+
+    void* recvBuf = malloc(bufferSize);
+    ASSERT_NE(recvBuf, nullptr);
+    auto recvGuard = makeHostBufferAutoGuard(recvBuf);
+    memset(recvBuf, 0, bufferSize);
+
+    // Register send buffer on the send comm, recv buffer on the recv comm.
+    void* sendComm = (rank == 0) ? connB.sendComm : connA.sendComm;
+    void* recvComm = (rank == 0) ? connA.recvComm : connB.recvComm;
+
+    void* sendMhandle = nullptr;
+    ASSERT_EQ(RegisterMemory(sendComm, sendBuf, bufferSize, NCCL_PTR_HOST, &sendMhandle), ncclSuccess);
+    NetMHandleGuard sendMhGuard(sendMhandle, NetMHandleDeleter(net_, sendComm));
+
+    void* recvMhandle = nullptr;
+    ASSERT_EQ(RegisterMemory(recvComm, recvBuf, bufferSize, NCCL_PTR_HOST, &recvMhandle), ncclSuccess);
+    NetMHandleGuard recvMhGuard(recvMhandle, NetMHandleDeleter(net_, recvComm));
+
+    const int sendTag = 570;
+    const int recvTag = 570;
+    const int sendSeed = 5700 + rank;
+
+    // Fill send buffer with rank-specific pattern.
+    uint8_t* hostSendBuf = static_cast<uint8_t*>(sendBuf);
+    for (size_t i = 0; i < bufferSize; i++) {
+        hostSendBuf[i] = static_cast<uint8_t>((sendSeed + i) % kBytePatternModulo);
+    }
+
+    // Post recv and send simultaneously on both connections.
+    void* recvRequest = nullptr;
+    void* sendRequest = nullptr;
+
+    void* recvBuffers[1] = {recvBuf};
+    size_t recvSizes[1] = {bufferSize};
+    int recvTags[1] = {recvTag};
+    void* recvHandles[1] = {recvMhandle};
+
+    ASSERT_EQ(PostRecv(recvComm, 1, recvBuffers, recvSizes, recvTags,
+                      recvHandles, &recvRequest), ncclSuccess);
+
+    int attempts = 0;
+    do {
+        ncclResult_t result = PostSend(sendComm, sendBuf, bufferSize, sendTag, sendMhandle, &sendRequest);
+        ASSERT_EQ(result, ncclSuccess);
+        if (sendRequest != nullptr) break;
+        if (++attempts >= kMaxRetryAttempts) {
+            FAIL() << "PostSend returned NULL request after " << kMaxRetryAttempts << " attempts";
+        }
+        usleep(kPollIntervalUs);
+    } while (sendRequest == nullptr);
+
+    MPI_Barrier(MPI_COMM_WORLD);
+
+    // Wait for both completions.
+    int recvSizesOut[1] = {0};
+    ASSERT_EQ(WaitForCompletion(recvRequest, recvSizesOut), ncclSuccess);
+
+    int sendSizesOut[1] = {0};
+    ASSERT_EQ(WaitForCompletion(sendRequest, sendSizesOut), ncclSuccess);
+
+    MPI_Barrier(MPI_COMM_WORLD);
+
+    // Verify received data matches the peer's send pattern.
+    int peerSeed = 5700 + peerRank;
+    EXPECT_EQ(recvSizesOut[0], bufferSize) << "Received size mismatch";
+
+    uint8_t* hostRecvBuf = static_cast<uint8_t*>(recvBuf);
+    bool dataValid = true;
+    for (size_t i = 0; i < bufferSize && dataValid; i++) {
+        uint8_t expected = static_cast<uint8_t>((peerSeed + i) % kBytePatternModulo);
+        if (hostRecvBuf[i] != expected) {
+            dataValid = false;
+            TEST_WARN("Rank %d: Bidirectional mismatch at index %zu: expected=%u, got=%u",
+                     rank, i, expected, hostRecvBuf[i]);
+        }
+    }
+    EXPECT_TRUE(dataValid) << "Bidirectional vNIC transfer data validation failed";
+}
+
+TEST_F(NetIbMPITest, FlushRepeated_VNic) {
+    ASSERT_TRUE(validateTestPrerequisites(kExactTwoProcesses, kExactTwoProcesses,
+                                         false, kMinGpusPerNode, kNoNodeLimit))
+        << "Test requires exactly " << kExactTwoProcesses << " processes";
+
+    ASSERT_EQ(InitNetIb(), ncclSuccess);
+
+    int ndev = 0;
+    ASSERT_EQ(GetDeviceCount(&ndev), ncclSuccess);
+
+    if (ndev < 2) {
+        GTEST_SKIP() << "Need at least 2 IB devices for NIC fusion tests";
+    }
+
+    // Check GDR support on device 0 before creating the vNIC.
+    ncclNetProperties_t props;
+    ASSERT_EQ(GetDeviceProperties(0, &props), ncclSuccess);
+    if (!(props.ptrSupport & NCCL_PTR_CUDA)) {
+        GTEST_SKIP() << "GDR not supported, skipping flush test";
+    }
+
+    // Create a fused vNIC from physical devices 0 and 1.
+    ncclNetVDeviceProps_t vProps;
+    vProps.ndevs = 2;
+    vProps.devs[0] = 0;
+    vProps.devs[1] = 1;
+
+    int vdev = -1;
+    ASSERT_EQ(MakeVirtualDevice(&vdev, &vProps), ncclSuccess);
+    ASSERT_GE(vdev, 0);
+
+    int rank = MPIEnvironment::world_rank;
+    int peerRank = (rank + 1) % 2;
+
+    ConnectionPair pair;
+    ASSERT_EQ(SetupConnection(vdev, pair, rank, peerRank), ncclSuccess);
+
+    NetConnectionGuard connGuard(net_);
+    if (rank == 0) {
+        connGuard.setRecvComm(pair.recvComm);
+        connGuard.setListenComm(pair.listenComm);
+    } else {
+        connGuard.setSendComm(pair.sendComm);
+    }
+
+    const size_t bufferSize = kSmallBufferSize;
+    const int tag = 600;
+    const int numIterations = 50;
+
+    // Allocate GPU buffer and register with NCCL_PTR_CUDA on the vNIC connection.
+    void* gpuBuffer = nullptr;
+    HIP_TEST_CHECK_GTEST_FAIL(hipMalloc(&gpuBuffer, bufferSize));
+    auto gpuGuard = makeDeviceBufferAutoGuard(gpuBuffer);
+
+    void* comm = (rank == 0) ? pair.recvComm : pair.sendComm;
+    void* mhandle = nullptr;
+    ASSERT_EQ(RegisterMemory(comm, gpuBuffer, bufferSize, NCCL_PTR_CUDA, &mhandle), ncclSuccess);
+    NetMHandleGuard mhandleGuard(mhandle, NetMHandleDeleter(net_, comm));
+
+    // Host staging buffer for fill and verify.
+    void* hostBuf = malloc(bufferSize);
+    ASSERT_NE(hostBuf, nullptr);
+    auto hostGuard = makeHostBufferAutoGuard(hostBuf);
+
+    for (int iter = 0; iter < numIterations; iter++) {
+        const int seed = 6000 + iter;
+        void* request = nullptr;
+
+        if (rank == 1) {
+            // Fill host staging buffer, copy to GPU, then send.
+            uint8_t* h = static_cast<uint8_t*>(hostBuf);
+            for (size_t i = 0; i < bufferSize; i++) {
+                h[i] = static_cast<uint8_t>((seed + i) % kBytePatternModulo);
+            }
+            HIP_TEST_CHECK_GTEST_FAIL(hipMemcpy(gpuBuffer, hostBuf, bufferSize, hipMemcpyHostToDevice));
+
+            int attempts = 0;
+            do {
+                ncclResult_t result = PostSend(pair.sendComm, gpuBuffer, bufferSize, tag, mhandle, &request);
+                ASSERT_EQ(result, ncclSuccess);
+                if (request != nullptr) break;
+                if (++attempts >= kMaxRetryAttempts) {
+                    FAIL() << "Iter " << iter << ": PostSend returned NULL after " << kMaxRetryAttempts << " attempts";
+                }
+                usleep(kPollIntervalUs);
+            } while (request == nullptr);
+        } else {
+            // Rank 0: post recv on GPU buffer.
+            void* recvBuffers[1] = {gpuBuffer};
+            size_t recvSizes[1] = {bufferSize};
+            int recvTags[1] = {tag};
+            void* recvHandles[1] = {mhandle};
+
+            ASSERT_EQ(PostRecv(pair.recvComm, 1, recvBuffers, recvSizes, recvTags,
+                              recvHandles, &request), ncclSuccess);
+        }
+
+        MPI_Barrier(MPI_COMM_WORLD);
+
+        int sizes[1] = {0};
+        ASSERT_EQ(WaitForCompletion(request, sizes), ncclSuccess);
+
+        if (rank == 0) {
+            ASSERT_EQ(sizes[0], bufferSize) << "Iter " << iter << ": received size mismatch";
+
+            // Flush GPU memory to ensure RDMA write is visible on GPU.
+            void* flushBuffers[1] = {gpuBuffer};
+            int flushSizes[1] = {static_cast<int>(bufferSize)};
+            void* flushHandles[1] = {mhandle};
+            void* flushRequest = nullptr;
+
+            ncclResult_t flushResult = FlushRecv(pair.recvComm, 1, flushBuffers, flushSizes,
+                                                 flushHandles, &flushRequest);
+            if (flushResult == ncclSuccess && flushRequest != nullptr) {
+                ASSERT_EQ(WaitForCompletion(flushRequest, nullptr), ncclSuccess);
+            }
+
+            // Copy GPU buffer to host and verify data.
+            memset(hostBuf, 0, bufferSize);
+            HIP_TEST_CHECK_GTEST_FAIL(hipMemcpy(hostBuf, gpuBuffer, bufferSize, hipMemcpyDeviceToHost));
+
+            uint8_t* h = static_cast<uint8_t*>(hostBuf);
+            bool dataValid = true;
+            for (size_t i = 0; i < bufferSize && dataValid; i++) {
+                uint8_t expected = static_cast<uint8_t>((seed + i) % kBytePatternModulo);
+                if (h[i] != expected) {
+                    dataValid = false;
+                    TEST_WARN("Iter %d: flush mismatch at index %zu: expected=%u, got=%u",
+                             iter, i, expected, h[i]);
+                }
+            }
+            ASSERT_TRUE(dataValid) << "Iter " << iter << ": data verification failed after flush";
+        }
+
+        MPI_Barrier(MPI_COMM_WORLD);
+    }
+}
+
+TEST_F(NetIbMPITest, SequentialTransfers_VNic) {
+    ASSERT_TRUE(validateTestPrerequisites(kExactTwoProcesses, kExactTwoProcesses,
+                                         false, kMinGpusPerNode, kNoNodeLimit))
+        << "Test requires exactly " << kExactTwoProcesses << " processes";
+
+    ASSERT_EQ(InitNetIb(), ncclSuccess);
+
+    int ndev = 0;
+    ASSERT_EQ(GetDeviceCount(&ndev), ncclSuccess);
+
+    if (ndev < 2) {
+        GTEST_SKIP() << "Need at least 2 IB devices for NIC fusion tests";
+    }
+
+    // Create a fused vNIC from physical devices 0 and 1.
+    ncclNetVDeviceProps_t vProps;
+    vProps.ndevs = 2;
+    vProps.devs[0] = 0;
+    vProps.devs[1] = 1;
+
+    int vdev = -1;
+    ASSERT_EQ(MakeVirtualDevice(&vdev, &vProps), ncclSuccess);
+    ASSERT_GE(vdev, 0);
+
+    int rank = MPIEnvironment::world_rank;
+    int peerRank = (rank + 1) % 2;
+
+    // Single connection through the vNIC, reused across all 100 iterations.
+    ConnectionPair pair;
+    ASSERT_EQ(SetupConnection(vdev, pair, rank, peerRank), ncclSuccess);
+
+    NetConnectionGuard connGuard(net_);
+    if (rank == 0) {
+        connGuard.setRecvComm(pair.recvComm);
+        connGuard.setListenComm(pair.listenComm);
+    } else {
+        connGuard.setSendComm(pair.sendComm);
+    }
+
+    const size_t bufferSize = kSmallBufferSize;
+    const int tag = 700;
+    const int numIterations = 100;
+
+    // Single buffer registered once on both sub-device PDs, reused every iteration.
+    void* buffer = malloc(bufferSize);
+    ASSERT_NE(buffer, nullptr);
+    auto bufferGuard = makeHostBufferAutoGuard(buffer);
+
+    void* comm = (rank == 0) ? pair.recvComm : pair.sendComm;
+    void* mhandle = nullptr;
+    ASSERT_EQ(RegisterMemory(comm, buffer, bufferSize, NCCL_PTR_HOST, &mhandle), ncclSuccess);
+    NetMHandleGuard mhandleGuard(mhandle, NetMHandleDeleter(net_, comm));
+
+    for (int iter = 0; iter < numIterations; iter++) {
+        // Unique seed per iteration to detect stale data from prior rounds.
+        const int seed = 7000 + iter;
+        void* request = nullptr;
+
+        if (rank == 1) {
+            // Fill buffer with per-iteration pattern.
+            uint8_t* h = static_cast<uint8_t*>(buffer);
+            for (size_t i = 0; i < bufferSize; i++) {
+                h[i] = static_cast<uint8_t>((seed + i) % kBytePatternModulo);
+            }
+
+            // Retry until the receiver's FIFO slot is ready.
+            int attempts = 0;
+            do {
+                ncclResult_t result = PostSend(pair.sendComm, buffer, bufferSize, tag, mhandle, &request);
+                ASSERT_EQ(result, ncclSuccess);
+                if (request != nullptr) break;
+                if (++attempts >= kMaxRetryAttempts) {
+                    FAIL() << "Iter " << iter << ": PostSend returned NULL after " << kMaxRetryAttempts << " attempts";
+                }
+                usleep(kPollIntervalUs);
+            } while (request == nullptr);
+        } else {
+            // Zero buffer before recv to ensure verification catches stale data.
+            memset(buffer, 0, bufferSize);
+
+            void* recvBuffers[1] = {buffer};
+            size_t recvSizes[1] = {bufferSize};
+            int recvTags[1] = {tag};
+            void* recvHandles[1] = {mhandle};
+
+            ASSERT_EQ(PostRecv(pair.recvComm, 1, recvBuffers, recvSizes, recvTags,
+                              recvHandles, &request), ncclSuccess);
+        }
+
+        // Sync both ranks before polling for completion.
+        MPI_Barrier(MPI_COMM_WORLD);
+
+        int sizes[1] = {0};
+        ASSERT_EQ(WaitForCompletion(request, sizes), ncclSuccess);
+
+        // Verify received data matches the iteration-specific pattern.
+        if (rank == 0) {
+            ASSERT_EQ(sizes[0], bufferSize) << "Iter " << iter << ": received size mismatch";
+
+            uint8_t* h = static_cast<uint8_t*>(buffer);
+            bool dataValid = true;
+            for (size_t i = 0; i < bufferSize && dataValid; i++) {
+                uint8_t expected = static_cast<uint8_t>((seed + i) % kBytePatternModulo);
+                if (h[i] != expected) {
+                    dataValid = false;
+                    TEST_WARN("Iter %d: mismatch at index %zu: expected=%u, got=%u",
+                             iter, i, expected, h[i]);
+                }
+            }
+            ASSERT_TRUE(dataValid) << "Iter " << iter << ": data verification failed";
+        }
+
+        // Sync before next iteration to prevent request reuse races.
+        MPI_Barrier(MPI_COMM_WORLD);
+    }
+}
+
+TEST_F(NetIbMPITest, Reconnect_VNic) {
+    ASSERT_TRUE(validateTestPrerequisites(kExactTwoProcesses, kExactTwoProcesses,
+                                         false, kMinGpusPerNode, kNoNodeLimit))
+        << "Test requires exactly " << kExactTwoProcesses << " processes";
+
+    ASSERT_EQ(InitNetIb(), ncclSuccess);
+
+    int ndev = 0;
+    ASSERT_EQ(GetDeviceCount(&ndev), ncclSuccess);
+
+    if (ndev < 2) {
+        GTEST_SKIP() << "Need at least 2 IB devices for NIC fusion tests";
+    }
+
+    // Create a fused vNIC once, reuse across all reconnect cycles.
+    ncclNetVDeviceProps_t vProps;
+    vProps.ndevs = 2;
+    vProps.devs[0] = 0;
+    vProps.devs[1] = 1;
+
+    int vdev = -1;
+    ASSERT_EQ(MakeVirtualDevice(&vdev, &vProps), ncclSuccess);
+    ASSERT_GE(vdev, 0);
+
+    int rank = MPIEnvironment::world_rank;
+    int peerRank = (rank + 1) % 2;
+
+    const size_t bufferSize = kSmallBufferSize;
+    const int tag = 800;
+    const int numCycles = 10;
+
+    for (int cycle = 0; cycle < numCycles; cycle++) {
+        const int seed = 8000 + cycle;
+
+        // Each cycle creates a fresh connection through the same vNIC.
+        ConnectionPair pair;
+        ASSERT_EQ(SetupConnection(vdev, pair, rank, peerRank), ncclSuccess)
+            << "Cycle " << cycle << ": SetupConnection failed";
+
+        // Allocate and register a fresh buffer per cycle.
+        void* buffer = malloc(bufferSize);
+        ASSERT_NE(buffer, nullptr);
+
+        void* comm = (rank == 0) ? pair.recvComm : pair.sendComm;
+        void* mhandle = nullptr;
+        ASSERT_EQ(RegisterMemory(comm, buffer, bufferSize, NCCL_PTR_HOST, &mhandle), ncclSuccess)
+            << "Cycle " << cycle << ": regMr failed";
+
+        void* request = nullptr;
+
+        if (rank == 1) {
+            // Fill with cycle-specific pattern.
+            uint8_t* h = static_cast<uint8_t*>(buffer);
+            for (size_t i = 0; i < bufferSize; i++) {
+                h[i] = static_cast<uint8_t>((seed + i) % kBytePatternModulo);
+            }
+
+            int attempts = 0;
+            do {
+                ncclResult_t result = PostSend(pair.sendComm, buffer, bufferSize, tag, mhandle, &request);
+                ASSERT_EQ(result, ncclSuccess);
+                if (request != nullptr) break;
+                if (++attempts >= kMaxRetryAttempts) {
+                    FAIL() << "Cycle " << cycle << ": PostSend returned NULL after " << kMaxRetryAttempts << " attempts";
+                }
+                usleep(kPollIntervalUs);
+            } while (request == nullptr);
+        } else {
+            memset(buffer, 0, bufferSize);
+
+            void* recvBuffers[1] = {buffer};
+            size_t recvSizes[1] = {bufferSize};
+            int recvTags[1] = {tag};
+            void* recvHandles[1] = {mhandle};
+
+            ASSERT_EQ(PostRecv(pair.recvComm, 1, recvBuffers, recvSizes, recvTags,
+                              recvHandles, &request), ncclSuccess);
+        }
+
+        MPI_Barrier(MPI_COMM_WORLD);
+
+        int sizes[1] = {0};
+        ASSERT_EQ(WaitForCompletion(request, sizes), ncclSuccess);
+
+        // Verify received data matches the cycle-specific pattern.
+        if (rank == 0) {
+            ASSERT_EQ(sizes[0], bufferSize) << "Cycle " << cycle << ": received size mismatch";
+
+            uint8_t* h = static_cast<uint8_t*>(buffer);
+            bool dataValid = true;
+            for (size_t i = 0; i < bufferSize && dataValid; i++) {
+                uint8_t expected = static_cast<uint8_t>((seed + i) % kBytePatternModulo);
+                if (h[i] != expected) {
+                    dataValid = false;
+                    TEST_WARN("Cycle %d: mismatch at index %zu: expected=%u, got=%u",
+                             cycle, i, expected, h[i]);
+                }
+            }
+            ASSERT_TRUE(dataValid) << "Cycle " << cycle << ": data verification failed";
+        }
+
+        MPI_Barrier(MPI_COMM_WORLD);
+
+        // Manually deregister and close all resources for this cycle.
+        // deregMr iterates ndevs=2, removing MR cache entries for each sub-device.
+        ASSERT_EQ(DeregisterMemory(comm, mhandle), ncclSuccess)
+            << "Cycle " << cycle << ": deregMr failed";
+
+        // closeSend/closeRecv destroy per-sub-device QPs, PDs, FIFO MRs, and sockets.
+        if (rank == 0) {
+            ASSERT_EQ(CloseRecvComm(pair.recvComm), ncclSuccess);
+            ASSERT_EQ(CloseListenComm(pair.listenComm), ncclSuccess);
+        } else {
+            ASSERT_EQ(CloseSendComm(pair.sendComm), ncclSuccess);
+        }
+
+        free(buffer);
+
+        // Sync before next cycle to ensure both ranks have fully torn down.
+        MPI_Barrier(MPI_COMM_WORLD);
+    }
+}
+
 #endif // MPI_TESTS_ENABLED

--- a/projects/rccl/test/transport/NetIbMPITests.cpp
+++ b/projects/rccl/test/transport/NetIbMPITests.cpp
@@ -295,6 +295,21 @@ protected:
         );
     }
 
+    // Helper: Retry until the receiver's FIFO slot is ready.
+    void PostSendWithRetry(void* sendComm, void* data, size_t size, int tag,
+                           void* mhandle, void** request) {
+        int attempts = 0;
+        do {
+            ncclResult_t result = PostSend(sendComm, data, size, tag, mhandle, request);
+            ASSERT_EQ(result, ncclSuccess);
+            if (*request != nullptr) break;
+            if (++attempts >= kMaxRetryAttempts) {
+                FAIL() << "PostSend returned NULL request after " << kMaxRetryAttempts << " attempts";
+            }
+            usleep(kPollIntervalUs);
+        } while (*request == nullptr);
+    }
+
     // Helper: Wait for request completion with timeout
     ncclResult_t WaitForCompletion(void* request, int* sizes, int timeoutMs = kDefaultTimeoutMs) {
         if (!request) return ncclInternalError;
@@ -664,18 +679,7 @@ TEST_F(NetIbMPITest, SimpleSendRecv) {
             hostBuffer[i] = static_cast<uint8_t>((rank + i) % kBytePatternModulo);
         }
 
-        // NET IB isend can return success with NULL request if FIFO isn't ready
-        // (receiver's irecv RDMA write hasn't reached sender yet) — retry until ready
-        int attempts = 0;
-        do {
-            ncclResult_t result = PostSend(pair.sendComm, buffer, bufferSize, tag, mhandle, &request);
-            ASSERT_EQ(result, ncclSuccess);
-            if (request != nullptr) break;
-            if (++attempts >= kMaxRetryAttempts) {
-                FAIL() << "PostSend returned NULL request after " << kMaxRetryAttempts << " attempts";
-            }
-            usleep(kPollIntervalUs);
-        } while (request == nullptr);
+        PostSendWithRetry(pair.sendComm, buffer, bufferSize, tag, mhandle, &request);
     }
 
     MPI_Barrier(MPI_COMM_WORLD);
@@ -770,23 +774,7 @@ TEST_F(NetIbMPITest, SendRecvMultipleSizes) {
                 hostBuffer[i] = static_cast<uint8_t>((seed + i) % kBytePatternModulo);
             }
 
-            // NET IB isend can return success with NULL request if FIFO isn't ready
-            // This means the receiver hasn't posted recv yet - retry until ready
-            int attempts = 0;
-            do {
-                ncclResult_t result = PostSend(pair.sendComm, buffer, size, tag, mhandle, &request);
-                ASSERT_EQ(result, ncclSuccess);
-
-                if (request != nullptr) {
-                    break;
-                }
-
-                // NULL request means "not ready yet", wait and retry
-                if (++attempts >= kMaxRetryAttempts) {
-                    FAIL() << "PostSend returned NULL request after " << kMaxRetryAttempts << " attempts";
-                }
-                usleep(kPollIntervalUs);
-            } while (request == nullptr);
+            PostSendWithRetry(pair.sendComm, buffer, size, tag, mhandle, &request);
         }
 
         // Barrier 1: Ensure both ranks have posted their operations before waiting
@@ -870,17 +858,8 @@ TEST_F(NetIbMPITest, SendRecvZeroSize) {
         ASSERT_EQ(PostRecv(pair.recvComm, 1, recvBuffers, recvSizes, recvTags,
                           recvHandles, &request), ncclSuccess);
     } else {
-        // Sender - send zero bytes (retry on NULL request — FIFO may not be ready)
-        int attempts = 0;
-        do {
-            ncclResult_t result = PostSend(pair.sendComm, buffer, 0, tag, mhandle, &request);
-            ASSERT_EQ(result, ncclSuccess);
-            if (request != nullptr) break;
-            if (++attempts >= kMaxRetryAttempts) {
-                FAIL() << "PostSend returned NULL request after " << kMaxRetryAttempts << " attempts";
-            }
-            usleep(kPollIntervalUs);
-        } while (request == nullptr);
+        // Sender - send zero bytes
+        PostSendWithRetry(pair.sendComm, buffer, 0, tag, mhandle, &request);
     }
 
     MPI_Barrier(MPI_COMM_WORLD);
@@ -967,16 +946,7 @@ TEST_F(NetIbMPITest, FlushAfterRecv) {
         }
         HIP_TEST_CHECK_GTEST_FAIL(hipMemcpy(buffer, hostBuffer, bufferSize, hipMemcpyHostToDevice));
 
-        int attempts = 0;
-        do {
-            ncclResult_t result = PostSend(pair.sendComm, buffer, bufferSize, tag, mhandle, &request);
-            ASSERT_EQ(result, ncclSuccess);
-            if (request != nullptr) break;
-            if (++attempts >= kMaxRetryAttempts) {
-                FAIL() << "PostSend returned NULL request after " << kMaxRetryAttempts << " attempts";
-            }
-            usleep(kPollIntervalUs);
-        } while (request == nullptr);
+        PostSendWithRetry(pair.sendComm, buffer, bufferSize, tag, mhandle, &request);
     }
 
     MPI_Barrier(MPI_COMM_WORLD);
@@ -1155,23 +1125,7 @@ TEST_F(NetIbMPITest, MultipleSequentialTransfers) {
                 hostBuffer[j] = static_cast<uint8_t>((seed + j) % kBytePatternModulo);
             }
 
-            // NET IB isend can return success with NULL request if FIFO isn't ready
-            // This means the receiver hasn't posted recv yet - retry until ready
-            int attempts = 0;
-            do {
-                ncclResult_t result = PostSend(pair.sendComm, sendBuffer, bufferSize, tag, mhandle, &request);
-                ASSERT_EQ(result, ncclSuccess);
-
-                if (request != nullptr) {
-                    break;
-                }
-
-                // NULL request means "not ready yet", wait and retry
-                if (++attempts >= kMaxRetryAttempts) {
-                    FAIL() << "PostSend returned NULL request after " << kMaxRetryAttempts << " attempts";
-                }
-                usleep(kPollIntervalUs);
-            } while (request == nullptr);
+            PostSendWithRetry(pair.sendComm, sendBuffer, bufferSize, tag, mhandle, &request);
         }
 
         // Barrier 1: Ensure both ranks have posted their operations before waiting
@@ -1278,16 +1232,7 @@ TEST_F(NetIbMPITest, LargeTransfer) {
             hostBuffer[i] = static_cast<uint8_t>((rank + i) % kBytePatternModulo);
         }
 
-        int attempts = 0;
-        do {
-            ncclResult_t result = PostSend(pair.sendComm, buffer, bufferSize, tag, mhandle, &request);
-            ASSERT_EQ(result, ncclSuccess);
-            if (request != nullptr) break;
-            if (++attempts >= kMaxRetryAttempts) {
-                FAIL() << "PostSend returned NULL request after " << kMaxRetryAttempts << " attempts";
-            }
-            usleep(kPollIntervalUs);
-        } while (request == nullptr);
+        PostSendWithRetry(pair.sendComm, buffer, bufferSize, tag, mhandle, &request);
     }
 
     MPI_Barrier(MPI_COMM_WORLD);
@@ -1428,17 +1373,7 @@ TEST_F(NetIbMPITest, ConnectAndTransfer_VNic) {
             hostBuffer[i] = static_cast<uint8_t>((seed + i) % kBytePatternModulo);
         }
 
-        // Retry until the receiver's FIFO is ready.
-        int attempts = 0;
-        do {
-            ncclResult_t result = PostSend(pair.sendComm, buffer, bufferSize, tag, mhandle, &request);
-            ASSERT_EQ(result, ncclSuccess);
-            if (request != nullptr) break;
-            if (++attempts >= kMaxRetryAttempts) {
-                FAIL() << "PostSend returned NULL request after " << kMaxRetryAttempts << " attempts";
-            }
-            usleep(kPollIntervalUs);
-        } while (request == nullptr);
+        PostSendWithRetry(pair.sendComm, buffer, bufferSize, tag, mhandle, &request);
     }
 
     MPI_Barrier(MPI_COMM_WORLD);
@@ -1565,17 +1500,7 @@ TEST_F(NetIbMPITest, AsymmetricMerge_VNic) {
             hostBuffer[i] = static_cast<uint8_t>((seed + i) % kBytePatternModulo);
         }
 
-        // Retry until the receiver's FIFO is ready.
-        int attempts = 0;
-        do {
-            ncclResult_t result = PostSend(pair.sendComm, buffer, bufferSize, tag, mhandle, &request);
-            ASSERT_EQ(result, ncclSuccess);
-            if (request != nullptr) break;
-            if (++attempts >= kMaxRetryAttempts) {
-                FAIL() << "PostSend returned NULL request after " << kMaxRetryAttempts << " attempts";
-            }
-            usleep(kPollIntervalUs);
-        } while (request == nullptr);
+        PostSendWithRetry(pair.sendComm, buffer, bufferSize, tag, mhandle, &request);
     }
 
     MPI_Barrier(MPI_COMM_WORLD);
@@ -1691,16 +1616,7 @@ TEST_F(NetIbMPITest, CloseWithoutTransfer_VNic) {
             hostBuffer[i] = static_cast<uint8_t>((seed + i) % kBytePatternModulo);
         }
 
-        int attempts = 0;
-        do {
-            ncclResult_t result = PostSend(pair2.sendComm, buffer, bufferSize, tag, mhandle, &request);
-            ASSERT_EQ(result, ncclSuccess);
-            if (request != nullptr) break;
-            if (++attempts >= kMaxRetryAttempts) {
-                FAIL() << "PostSend returned NULL request after " << kMaxRetryAttempts << " attempts";
-            }
-            usleep(kPollIntervalUs);
-        } while (request == nullptr);
+        PostSendWithRetry(pair2.sendComm, buffer, bufferSize, tag, mhandle, &request);
     }
 
     MPI_Barrier(MPI_COMM_WORLD);
@@ -1811,17 +1727,7 @@ TEST_F(NetIbMPITest, RegDeregCycling_VNic) {
             hostBuffer[i] = static_cast<uint8_t>((seed + i) % kBytePatternModulo);
         }
 
-        // Retry until the receiver's FIFO is ready.
-        int attempts = 0;
-        do {
-            ncclResult_t result = PostSend(pair.sendComm, buffer, bufferSize, tag, mhandle, &request);
-            ASSERT_EQ(result, ncclSuccess);
-            if (request != nullptr) break;
-            if (++attempts >= kMaxRetryAttempts) {
-                FAIL() << "PostSend returned NULL request after " << kMaxRetryAttempts << " attempts";
-            }
-            usleep(kPollIntervalUs);
-        } while (request == nullptr);
+        PostSendWithRetry(pair.sendComm, buffer, bufferSize, tag, mhandle, &request);
     }
 
     MPI_Barrier(MPI_COMM_WORLD);
@@ -1918,17 +1824,7 @@ TEST_F(NetIbMPITest, LargeTransfer_VNic) {
             hostBuffer[i] = static_cast<uint8_t>((seed + i) % kBytePatternModulo);
         }
 
-        // Retry until the receiver's FIFO is ready.
-        int attempts = 0;
-        do {
-            ncclResult_t result = PostSend(pair.sendComm, buffer, bufferSize, tag, mhandle, &request);
-            ASSERT_EQ(result, ncclSuccess);
-            if (request != nullptr) break;
-            if (++attempts >= kMaxRetryAttempts) {
-                FAIL() << "PostSend returned NULL request after " << kMaxRetryAttempts << " attempts";
-            }
-            usleep(kPollIntervalUs);
-        } while (request == nullptr);
+        PostSendWithRetry(pair.sendComm, buffer, bufferSize, tag, mhandle, &request);
     }
 
     MPI_Barrier(MPI_COMM_WORLD);
@@ -2047,17 +1943,7 @@ TEST_F(NetIbMPITest, MixedSizes_VNic) {
                 hostBuffer[i] = static_cast<uint8_t>((seed + i) % kBytePatternModulo);
             }
 
-            int attempts = 0;
-            do {
-                ncclResult_t result = PostSend(pair.sendComm, buffer, size, tag, mhandle, &request);
-                ASSERT_EQ(result, ncclSuccess);
-                if (request != nullptr) break;
-                if (++attempts >= kMaxRetryAttempts) {
-                    FAIL() << "PostSend returned NULL request after " << kMaxRetryAttempts
-                           << " attempts for size " << size;
-                }
-                usleep(kPollIntervalUs);
-            } while (request == nullptr);
+            PostSendWithRetry(pair.sendComm, buffer, size, tag, mhandle, &request);
         }
 
         MPI_Barrier(MPI_COMM_WORLD);
@@ -2166,18 +2052,7 @@ TEST_F(NetIbMPITest, UnalignedSizeTransfer_VNic) {
                 hostBuffer[i] = static_cast<uint8_t>((seed + i) % kBytePatternModulo);
             }
 
-            // Retry until the receiver's FIFO is ready.
-            int attempts = 0;
-            do {
-                ncclResult_t result = PostSend(pair.sendComm, buffer, size, tag, mhandle, &request);
-                ASSERT_EQ(result, ncclSuccess);
-                if (request != nullptr) break;
-                if (++attempts >= kMaxRetryAttempts) {
-                    FAIL() << "PostSend returned NULL request after " << kMaxRetryAttempts
-                           << " attempts for size " << size;
-                }
-                usleep(kPollIntervalUs);
-            } while (request == nullptr);
+            PostSendWithRetry(pair.sendComm, buffer, size, tag, mhandle, &request);
         }
 
         MPI_Barrier(MPI_COMM_WORLD);
@@ -2335,16 +2210,7 @@ TEST_F(NetIbMPITest, Bidirectional_VNic) {
     ASSERT_EQ(PostRecv(recvComm, 1, recvBuffers, recvSizes, recvTags,
                       recvHandles, &recvRequest), ncclSuccess);
 
-    int attempts = 0;
-    do {
-        ncclResult_t result = PostSend(sendComm, sendBuf, bufferSize, sendTag, sendMhandle, &sendRequest);
-        ASSERT_EQ(result, ncclSuccess);
-        if (sendRequest != nullptr) break;
-        if (++attempts >= kMaxRetryAttempts) {
-            FAIL() << "PostSend returned NULL request after " << kMaxRetryAttempts << " attempts";
-        }
-        usleep(kPollIntervalUs);
-    } while (sendRequest == nullptr);
+    PostSendWithRetry(sendComm, sendBuf, bufferSize, sendTag, sendMhandle, &sendRequest);
 
     MPI_Barrier(MPI_COMM_WORLD);
 
@@ -2450,16 +2316,7 @@ TEST_F(NetIbMPITest, FlushRepeated_VNic) {
             }
             HIP_TEST_CHECK_GTEST_FAIL(hipMemcpy(gpuBuffer, hostBuf, bufferSize, hipMemcpyHostToDevice));
 
-            int attempts = 0;
-            do {
-                ncclResult_t result = PostSend(pair.sendComm, gpuBuffer, bufferSize, tag, mhandle, &request);
-                ASSERT_EQ(result, ncclSuccess);
-                if (request != nullptr) break;
-                if (++attempts >= kMaxRetryAttempts) {
-                    FAIL() << "Iter " << iter << ": PostSend returned NULL after " << kMaxRetryAttempts << " attempts";
-                }
-                usleep(kPollIntervalUs);
-            } while (request == nullptr);
+            PostSendWithRetry(pair.sendComm, gpuBuffer, bufferSize, tag, mhandle, &request);
         } else {
             // Rank 0: post recv on GPU buffer.
             void* recvBuffers[1] = {gpuBuffer};
@@ -2577,17 +2434,7 @@ TEST_F(NetIbMPITest, SequentialTransfers_VNic) {
                 h[i] = static_cast<uint8_t>((seed + i) % kBytePatternModulo);
             }
 
-            // Retry until the receiver's FIFO slot is ready.
-            int attempts = 0;
-            do {
-                ncclResult_t result = PostSend(pair.sendComm, buffer, bufferSize, tag, mhandle, &request);
-                ASSERT_EQ(result, ncclSuccess);
-                if (request != nullptr) break;
-                if (++attempts >= kMaxRetryAttempts) {
-                    FAIL() << "Iter " << iter << ": PostSend returned NULL after " << kMaxRetryAttempts << " attempts";
-                }
-                usleep(kPollIntervalUs);
-            } while (request == nullptr);
+            PostSendWithRetry(pair.sendComm, buffer, bufferSize, tag, mhandle, &request);
         } else {
             // Zero buffer before recv to ensure verification catches stale data.
             memset(buffer, 0, bufferSize);
@@ -2686,16 +2533,7 @@ TEST_F(NetIbMPITest, Reconnect_VNic) {
                 h[i] = static_cast<uint8_t>((seed + i) % kBytePatternModulo);
             }
 
-            int attempts = 0;
-            do {
-                ncclResult_t result = PostSend(pair.sendComm, buffer, bufferSize, tag, mhandle, &request);
-                ASSERT_EQ(result, ncclSuccess);
-                if (request != nullptr) break;
-                if (++attempts >= kMaxRetryAttempts) {
-                    FAIL() << "Cycle " << cycle << ": PostSend returned NULL after " << kMaxRetryAttempts << " attempts";
-                }
-                usleep(kPollIntervalUs);
-            } while (request == nullptr);
+            PostSendWithRetry(pair.sendComm, buffer, bufferSize, tag, mhandle, &request);
         } else {
             memset(buffer, 0, bufferSize);
 

--- a/projects/rccl/tools/scripts/test_runner/configs/net_ib_transport.json
+++ b/projects/rccl/tools/scripts/test_runner/configs/net_ib_transport.json
@@ -10,7 +10,7 @@
   },
   "auto_detect_hosts": true,
   "mpi_args": {
-    "alola": "--mca oob_tcp_if_include eth1 --mca btl_tcp_if_include eth1 --mca btl ^vader,openib --bind-to none",
+    "mellanox": "--mca oob_tcp_if_include eth1 --mca btl_tcp_if_include eth1 --mca btl ^vader,openib --bind-to none",
     "ainic": "--mca oob_tcp_if_include eno0 --mca btl_tcp_if_include eno0 --mca btl ^vader,openib --bind-to none",
     "thor2": "--oversubscribe --mca plm_rsh_agent srun --mca oob_tcp_if_include eno8303 --mca btl_tcp_if_include eno8303 --mca btl ^openib --bind-to none"
   },
@@ -18,7 +18,7 @@
     "NCCL_DEBUG": "INFO"
   },
   "system_env_variables": {
-    "alola": {
+    "mellanox": {
       "HSA_NO_SCRATCH_RECLAIM": "1",
       "NCCL_SOCKET_IFNAME": "eth0,eth1",
       "NCCL_IB_HCA": "mlx_5_5,mlx_5_7,mlx5_2,mlx_5_1,mlx_5_7",

--- a/projects/rccl/tools/scripts/test_runner/configs/net_ib_transport.json
+++ b/projects/rccl/tools/scripts/test_runner/configs/net_ib_transport.json
@@ -20,13 +20,19 @@
   "system_env_variables": {
     "alola": {
       "HSA_NO_SCRATCH_RECLAIM": "1",
-      "NCCL_SOCKET_IFNAME": "eth0,eth1"
+      "NCCL_SOCKET_IFNAME": "eth0,eth1",
+      "NCCL_IB_HCA": "mlx_5_5,mlx_5_7,mlx5_2,mlx_5_1,mlx_5_7",
+      "NCCL_NET_FORCE_MERGE": "mlx5_0,mlx5_1;mlx5_5,mlx5_6"
     },
     "ainic": {
-      "NCCL_SOCKET_IFNAME": "eno0"
+      "NCCL_SOCKET_IFNAME": "eno0",
+      "NCCL_IB_HCA": "rdma0,rdma1,rdma2,rdma3",
+      "NCCL_NET_FORCE_MERGE": "rdma0,rdma1;rdma2,rdma3"
     },
     "thor2": {
-      "NCCL_SOCKET_IFNAME": "eno8303"
+      "NCCL_SOCKET_IFNAME": "eno8303",
+      "NCCL_IB_HCA": "bnxt_re0,bnxt_re1,bnxt_re5,bnxt_re6",
+      "NCCL_NET_FORCE_MERGE": "bnxt_re0,bnxt_re1;bnxt_re5,bnxt_re6"
     }
   },
   "build_configuration": {
@@ -50,6 +56,7 @@
       "num_gpus": 1,
       "env_variables": {
         "NCCL_IB_MERGE_NICS": "1",
+        "NCCL_IB_MERGE_VFS": "1",
         "NCCL_DMABUF_ENABLE": "1"
       }
     },

--- a/projects/rccl/tools/scripts/test_runner/configs/net_ib_transport.json
+++ b/projects/rccl/tools/scripts/test_runner/configs/net_ib_transport.json
@@ -8,6 +8,7 @@
     "rocm_path": "${ROCM_PATH:-/opt/rocm}",
     "mpi_path": "${MPI_PATH}"
   },
+  "auto_detect_hosts": true,
   "mpi_args": {
     "alola": "--mca oob_tcp_if_include eth1 --mca btl_tcp_if_include eth1 --mca btl ^vader,openib --bind-to none",
     "ainic": "--mca oob_tcp_if_include eno0 --mca btl_tcp_if_include eno0 --mca btl ^vader,openib --bind-to none",

--- a/projects/rccl/tools/scripts/test_runner/configs/net_ib_transport.json
+++ b/projects/rccl/tools/scripts/test_runner/configs/net_ib_transport.json
@@ -8,11 +8,22 @@
     "rocm_path": "${ROCM_PATH:-/opt/rocm}",
     "mpi_path": "${MPI_PATH}"
   },
-  "mpi_args": "--mca oob_tcp_if_include eno0 --mca btl_tcp_if_include eno0 --bind-to none",
+  "mpi_args": {
+    "ainic": "--oversubscribe --mca oob_tcp_if_include eno0 --mca btl_tcp_if_include eno0 --mca btl ^openib --bind-to none",
+    "thor2": "--oversubscribe --mca plm_rsh_agent srun --mca oob_tcp_if_include eno8303 --mca btl_tcp_if_include eno8303 --mca btl ^openib --bind-to none"
+  },
   "env_variables": {
     "HSA_NO_SCRATCH_RECLAIM": "1",
-    "NCCL_SOCKET_IFNAME": "eno0",
+    "NCCL_SOCKET_IFNAME": "eth0,eth1",
     "NCCL_DEBUG": "INFO"
+  },
+  "system_env_variables": {
+    "ainic": {
+      "NCCL_SOCKET_IFNAME": "eno0"
+    },
+    "thor2": {
+      "NCCL_SOCKET_IFNAME": "eno8303"
+    }
   },
   "build_configuration": {
     "cmake_options": {

--- a/projects/rccl/tools/scripts/test_runner/configs/net_ib_transport.json
+++ b/projects/rccl/tools/scripts/test_runner/configs/net_ib_transport.json
@@ -30,19 +30,12 @@
     }
   },
   "build_configuration": {
-    "cmake_options": {
-      "CMAKE_BUILD_TYPE": "Debug",
-      "ENABLE_CODE_COVERAGE": "ON",
-      "BUILD_TESTS": "ON",
-      "BUILD_LOCAL_GPU_TARGET_ONLY": "ON",
-      "TRACE": "ON",
-      "COLLTRACE": "ON"
-    },
+    "install_flags": ["--debug", "-c", "-t", "-l", "--log-trace", "--enable-mpi-tests", "--no_clean"],
+    "cmake_options": "-DCMAKE_EXPORT_COMPILE_COMMANDS=ON",
     "env_variables": {
       "HIPCC_COMPILE_FLAGS_APPEND": "-g -Wno-format-nonliteral -Xarch_host -fprofile-instr-generate -Xarch_host -fcoverage-mapping -parallel-jobs=16"
     },
-    "parallel_jobs": 64,
-    "generator": "Unix Makefiles"
+    "parallel_jobs": 64
   },
   "test_configurations": {
     "default": {
@@ -224,7 +217,18 @@
           "name": "NetIB_VNic_ConnectAndTransfer",
           "description": "End-to-end data transfer through fused vNIC (ndevs=2)",
           "test_filter": "NetIbMPITest.ConnectAndTransfer_VNic"
-        },
+        }
+      ]
+    },
+
+    "net_ib_vnic_edge": {
+      "extends": "net_ib_base",
+      "timeout": 120,
+      "env_variables": {
+        "NCCL_DEBUG": "INFO",
+        "NCCL_DEBUG_SUBSYS": "NET,INIT"
+      },
+      "tests": [
         {
           "name": "NetIB_VNic_AsymmetricMerge",
           "description": "Connection with mismatched ndevs (vNIC ndevs=2 vs physical ndevs=1)",
@@ -287,22 +291,6 @@
           "test_filter": "NetIbMPITest.RegDeregCycling_VNic"
         }
       ]
-    },
-
-    "net_ib_vnic_all": {
-      "extends": "net_ib_base",
-      "timeout": 300,
-      "env_variables": {
-        "NCCL_DEBUG": "INFO",
-        "NCCL_DEBUG_SUBSYS": "NET,INIT"
-      },
-      "tests": [
-        {
-          "name": "NetIB_VNic_AllTests",
-          "description": "All vNIC tests in a single run",
-          "test_filter": "NetIbMPITest.*_VNic"
-        }
-      ]
     }
   },
   "test_suites": [
@@ -350,20 +338,20 @@
     },
     {
       "name": "NET IB - vNIC Functional",
-      "description": "Virtual NIC functional and edge case tests",
+      "description": "Virtual NIC functional validation",
       "config": "net_ib_vnic_functional",
+      "enabled": true
+    },
+    {
+      "name": "NET IB - vNIC Edge",
+      "description": "Virtual NIC edge case and boundary condition tests",
+      "config": "net_ib_vnic_edge",
       "enabled": true
     },
     {
       "name": "NET IB - vNIC Stress",
       "description": "Virtual NIC stress, reconnect, and repeated-operation tests",
       "config": "net_ib_vnic_stress",
-      "enabled": true
-    },
-    {
-      "name": "NET IB - All vNIC Tests (Single Run)",
-      "description": "All vNIC tests via wildcard filter",
-      "config": "net_ib_vnic_all",
       "enabled": true
     }
   ]

--- a/projects/rccl/tools/scripts/test_runner/configs/net_ib_transport.json
+++ b/projects/rccl/tools/scripts/test_runner/configs/net_ib_transport.json
@@ -30,11 +30,8 @@
     }
   },
   "build_configuration": {
-    "install_flags": ["--debug", "-c", "-t", "-l", "--log-trace", "--enable-mpi-tests", "--no_clean"],
+    "install_flags": ["--debug", "-t", "-l", "--log-trace", "--enable-code-coverage", "--enable-mpi-tests", "--no_clean"],
     "cmake_options": "-DCMAKE_EXPORT_COMPILE_COMMANDS=ON",
-    "env_variables": {
-      "HIPCC_COMPILE_FLAGS_APPEND": "-g -Wno-format-nonliteral -Xarch_host -fprofile-instr-generate -Xarch_host -fcoverage-mapping -parallel-jobs=16"
-    },
     "parallel_jobs": 64
   },
   "test_configurations": {

--- a/projects/rccl/tools/scripts/test_runner/configs/net_ib_transport.json
+++ b/projects/rccl/tools/scripts/test_runner/configs/net_ib_transport.json
@@ -1,0 +1,355 @@
+{
+  "system_configurations": {
+    "name": "RCCL-Tests-NET-IB-Transport",
+    "description": "Comprehensive InfiniBand transport test config. Runs all NetIbMPITest tests including plugin API, physical device, and virtual device (vNIC) tests."
+  },
+  "paths": {
+    "workdir": "${WORKDIR:-$PWD}",
+    "rocm_path": "${ROCM_PATH:-/opt/rocm}",
+    "mpi_path": "${MPI_PATH}"
+  },
+  "mpi_args": "--mca oob_tcp_if_include eno0 --mca btl_tcp_if_include eno0 --bind-to none",
+  "env_variables": {
+    "HSA_NO_SCRATCH_RECLAIM": "1",
+    "NCCL_SOCKET_IFNAME": "eno0",
+    "NCCL_DEBUG": "INFO"
+  },
+  "build_configuration": {
+    "cmake_options": {
+      "CMAKE_BUILD_TYPE": "Debug",
+      "ENABLE_CODE_COVERAGE": "ON",
+      "BUILD_TESTS": "ON",
+      "BUILD_LOCAL_GPU_TARGET_ONLY": "ON",
+      "TRACE": "ON",
+      "COLLTRACE": "ON"
+    },
+    "env_variables": {
+      "HIPCC_COMPILE_FLAGS_APPEND": "-g -Wno-format-nonliteral -Xarch_host -fprofile-instr-generate -Xarch_host -fcoverage-mapping -parallel-jobs=16"
+    },
+    "parallel_jobs": 64,
+    "generator": "Unix Makefiles"
+  },
+  "test_configurations": {
+    "default": {
+      "env_variables": {
+        "NCCL_LAUNCH_MODE": "GROUP"
+      }
+    },
+
+    "net_ib_base": {
+      "extends": "default",
+      "is_gtest": true,
+      "binary": "rccl-UnitTestsMPI",
+      "num_ranks": 2,
+      "num_nodes": 2,
+      "num_gpus": 1,
+      "env_variables": {
+        "NCCL_IB_MERGE_NICS": "1",
+        "NCCL_DMABUF_ENABLE": "1"
+      }
+    },
+
+    "net_ib_initialization": {
+      "extends": "net_ib_base",
+      "timeout": 60,
+      "tests": [
+        {
+          "name": "NetIB_Init_Plugin",
+          "description": "Initialize InfiniBand network plugin and verify basic setup",
+          "test_filter": "NetIbMPITest.InitializePlugin"
+        },
+        {
+          "name": "NetIB_Init_GetDeviceCount",
+          "description": "Query and validate InfiniBand device count",
+          "test_filter": "NetIbMPITest.GetDeviceCount"
+        }
+      ]
+    },
+
+    "net_ib_properties": {
+      "extends": "net_ib_base",
+      "timeout": 60,
+      "tests": [
+        {
+          "name": "NetIB_Props_GetProperties",
+          "description": "Query InfiniBand device properties and capabilities",
+          "test_filter": "NetIbMPITest.GetDeviceProperties"
+        },
+        {
+          "name": "NetIB_Props_InvalidDevice",
+          "description": "Error handling when querying properties of invalid InfiniBand device",
+          "test_filter": "NetIbMPITest.GetDevicePropertiesInvalidDevice"
+        }
+      ]
+    },
+
+    "net_ib_connection": {
+      "extends": "net_ib_base",
+      "timeout": 120,
+      "tests": [
+        {
+          "name": "NetIB_Conn_ListenAndConnect",
+          "description": "Basic listen/connect/accept handshake over IB",
+          "test_filter": "NetIbMPITest.ListenAndConnect"
+        },
+        {
+          "name": "NetIB_Conn_InvalidHandle",
+          "description": "Connect with invalid handle error handling",
+          "test_filter": "NetIbMPITest.ConnectWithInvalidHandle"
+        },
+        {
+          "name": "NetIB_Conn_CloseWithoutWaiting",
+          "description": "Close connection without waiting for transfer completion",
+          "test_filter": "NetIbMPITest.CloseWithoutWaitingForCompletion"
+        }
+      ]
+    },
+
+    "net_ib_memory": {
+      "extends": "net_ib_base",
+      "timeout": 120,
+      "tests": [
+        {
+          "name": "NetIB_Mem_RegisterHost",
+          "description": "Register host memory buffers for IB RDMA",
+          "test_filter": "NetIbMPITest.RegisterHostMemory"
+        },
+        {
+          "name": "NetIB_Mem_RegisterGpu",
+          "description": "Register GPU device memory buffers for IB RDMA",
+          "test_filter": "NetIbMPITest.RegisterGpuMemory"
+        },
+        {
+          "name": "NetIB_Mem_RegisterNull",
+          "description": "Register NULL pointer error handling",
+          "test_filter": "NetIbMPITest.RegisterMemoryNullPointer"
+        },
+        {
+          "name": "NetIB_Mem_DeregisterNull",
+          "description": "Deregister NULL handle error handling",
+          "test_filter": "NetIbMPITest.DeregisterNullHandle"
+        }
+      ]
+    },
+
+    "net_ib_transfer": {
+      "extends": "net_ib_base",
+      "timeout": 300,
+      "env_variables": {
+        "NCCL_DEBUG": "INFO",
+        "NCCL_DEBUG_SUBSYS": "NET,INIT"
+      },
+      "tests": [
+        {
+          "name": "NetIB_Xfer_SimpleSendRecv",
+          "description": "Basic IB send/receive data transfer",
+          "test_filter": "NetIbMPITest.SimpleSendRecv"
+        },
+        {
+          "name": "NetIB_Xfer_MultipleSizes",
+          "description": "IB data transfer with multiple buffer sizes",
+          "test_filter": "NetIbMPITest.SendRecvMultipleSizes"
+        },
+        {
+          "name": "NetIB_Xfer_ZeroSize",
+          "description": "IB zero-byte send/receive",
+          "test_filter": "NetIbMPITest.SendRecvZeroSize"
+        },
+        {
+          "name": "NetIB_Xfer_LargeTransfer",
+          "description": "IB large buffer data transfer",
+          "test_filter": "NetIbMPITest.LargeTransfer"
+        },
+        {
+          "name": "NetIB_Xfer_MultipleSequential",
+          "description": "Multiple sequential send/recv on the same connection",
+          "test_filter": "NetIbMPITest.MultipleSequentialTransfers"
+        }
+      ]
+    },
+
+    "net_ib_flush": {
+      "extends": "net_ib_base",
+      "timeout": 120,
+      "tests": [
+        {
+          "name": "NetIB_Flush_AfterRecv",
+          "description": "GPU flush (iflush) after receive with GDR",
+          "test_filter": "NetIbMPITest.FlushAfterRecv"
+        }
+      ]
+    },
+
+    "net_ib_vdevice": {
+      "extends": "net_ib_base",
+      "timeout": 60,
+      "tests": [
+        {
+          "name": "NetIB_VDev_MakeVirtualDevice",
+          "description": "Create virtual device from 2 physical IB NICs via makeVDevice(ndevs=2)",
+          "test_filter": "NetIbMPITest.MakeVirtualDevice"
+        },
+        {
+          "name": "NetIB_VDev_InvalidProps",
+          "description": "Reject makeVDevice with ndevs=0 (ncclInvalidUsage)",
+          "test_filter": "NetIbMPITest.MakeVirtualDeviceInvalidProps"
+        }
+      ]
+    },
+
+    "net_ib_vnic_functional": {
+      "extends": "net_ib_base",
+      "timeout": 120,
+      "env_variables": {
+        "NCCL_DEBUG": "INFO",
+        "NCCL_DEBUG_SUBSYS": "NET,INIT"
+      },
+      "tests": [
+        {
+          "name": "NetIB_VNic_ConnectAndTransfer",
+          "description": "End-to-end data transfer through fused vNIC (ndevs=2)",
+          "test_filter": "NetIbMPITest.ConnectAndTransfer_VNic"
+        },
+        {
+          "name": "NetIB_VNic_AsymmetricMerge",
+          "description": "Connection with mismatched ndevs (vNIC ndevs=2 vs physical ndevs=1)",
+          "test_filter": "NetIbMPITest.AsymmetricMerge_VNic"
+        },
+        {
+          "name": "NetIB_VNic_CloseWithoutTransfer",
+          "description": "Clean teardown of never-used multi-PD/QP vNIC connection",
+          "test_filter": "NetIbMPITest.CloseWithoutTransfer_VNic"
+        },
+        {
+          "name": "NetIB_VNic_UnalignedSizeTransfer",
+          "description": "Data integrity at 128-byte QP striping alignment boundaries",
+          "test_filter": "NetIbMPITest.UnalignedSizeTransfer_VNic"
+        }
+      ]
+    },
+
+    "net_ib_vnic_stress": {
+      "extends": "net_ib_base",
+      "timeout": 300,
+      "env_variables": {
+        "NCCL_DEBUG": "INFO",
+        "NCCL_DEBUG_SUBSYS": "NET,INIT"
+      },
+      "tests": [
+        {
+          "name": "NetIB_VNic_LargeTransfer",
+          "description": "64MB payload striped across doubled QPs on vNIC",
+          "test_filter": "NetIbMPITest.LargeTransfer_VNic"
+        },
+        {
+          "name": "NetIB_VNic_MixedSizes",
+          "description": "Rapid tiny/large size transitions on multi-QP vNIC path",
+          "test_filter": "NetIbMPITest.MixedSizes_VNic"
+        },
+        {
+          "name": "NetIB_VNic_Bidirectional",
+          "description": "Full-duplex concurrent send+recv through same fused device",
+          "test_filter": "NetIbMPITest.Bidirectional_VNic"
+        },
+        {
+          "name": "NetIB_VNic_FlushRepeated",
+          "description": "50x GPU flush QP stability under repeated invocation (requires GDR)",
+          "test_filter": "NetIbMPITest.FlushRepeated_VNic"
+        },
+        {
+          "name": "NetIB_VNic_SequentialTransfers",
+          "description": "100x send/recv reuse on same doubled QP pool",
+          "test_filter": "NetIbMPITest.SequentialTransfers_VNic"
+        },
+        {
+          "name": "NetIB_VNic_Reconnect",
+          "description": "10x connect/transfer/close cycles for resource leak detection",
+          "test_filter": "NetIbMPITest.Reconnect_VNic"
+        },
+        {
+          "name": "NetIB_VNic_RegDeregCycling",
+          "description": "50x regMr/deregMr cycles on multi-PD MR cache",
+          "test_filter": "NetIbMPITest.RegDeregCycling_VNic"
+        }
+      ]
+    },
+
+    "net_ib_vnic_all": {
+      "extends": "net_ib_base",
+      "timeout": 300,
+      "env_variables": {
+        "NCCL_DEBUG": "INFO",
+        "NCCL_DEBUG_SUBSYS": "NET,INIT"
+      },
+      "tests": [
+        {
+          "name": "NetIB_VNic_AllTests",
+          "description": "All vNIC tests in a single run",
+          "test_filter": "NetIbMPITest.*_VNic"
+        }
+      ]
+    }
+  },
+  "test_suites": [
+    {
+      "name": "NET IB - Initialization",
+      "description": "InfiniBand plugin initialization and device enumeration",
+      "config": "net_ib_initialization",
+      "enabled": true
+    },
+    {
+      "name": "NET IB - Device Properties",
+      "description": "InfiniBand device property queries",
+      "config": "net_ib_properties",
+      "enabled": true
+    },
+    {
+      "name": "NET IB - Connection Setup",
+      "description": "InfiniBand listen/connect/accept and error handling",
+      "config": "net_ib_connection",
+      "enabled": true
+    },
+    {
+      "name": "NET IB - Memory Registration",
+      "description": "InfiniBand memory registration and deregistration",
+      "config": "net_ib_memory",
+      "enabled": true
+    },
+    {
+      "name": "NET IB - Data Transfer",
+      "description": "InfiniBand send/recv with various sizes",
+      "config": "net_ib_transfer",
+      "enabled": true
+    },
+    {
+      "name": "NET IB - Flush",
+      "description": "InfiniBand GPU flush (iflush) with GDR",
+      "config": "net_ib_flush",
+      "enabled": true
+    },
+    {
+      "name": "NET IB - Virtual Device API",
+      "description": "makeVDevice creation and error paths",
+      "config": "net_ib_vdevice",
+      "enabled": true
+    },
+    {
+      "name": "NET IB - vNIC Functional",
+      "description": "Virtual NIC functional and edge case tests",
+      "config": "net_ib_vnic_functional",
+      "enabled": true
+    },
+    {
+      "name": "NET IB - vNIC Stress",
+      "description": "Virtual NIC stress, reconnect, and repeated-operation tests",
+      "config": "net_ib_vnic_stress",
+      "enabled": true
+    },
+    {
+      "name": "NET IB - All vNIC Tests (Single Run)",
+      "description": "All vNIC tests via wildcard filter",
+      "config": "net_ib_vnic_all",
+      "enabled": true
+    }
+  ]
+}

--- a/projects/rccl/tools/scripts/test_runner/configs/net_ib_transport.json
+++ b/projects/rccl/tools/scripts/test_runner/configs/net_ib_transport.json
@@ -9,15 +9,18 @@
     "mpi_path": "${MPI_PATH}"
   },
   "mpi_args": {
-    "ainic": "--oversubscribe --mca oob_tcp_if_include eno0 --mca btl_tcp_if_include eno0 --mca btl ^openib --bind-to none",
+    "alola": "--mca oob_tcp_if_include eth1 --mca btl_tcp_if_include eth1 --mca btl ^vader,openib --bind-to none",
+    "ainic": "--mca oob_tcp_if_include eno0 --mca btl_tcp_if_include eno0 --mca btl ^vader,openib --bind-to none",
     "thor2": "--oversubscribe --mca plm_rsh_agent srun --mca oob_tcp_if_include eno8303 --mca btl_tcp_if_include eno8303 --mca btl ^openib --bind-to none"
   },
   "env_variables": {
-    "HSA_NO_SCRATCH_RECLAIM": "1",
-    "NCCL_SOCKET_IFNAME": "eth0,eth1",
     "NCCL_DEBUG": "INFO"
   },
   "system_env_variables": {
+    "alola": {
+      "HSA_NO_SCRATCH_RECLAIM": "1",
+      "NCCL_SOCKET_IFNAME": "eth0,eth1"
+    },
     "ainic": {
       "NCCL_SOCKET_IFNAME": "eno0"
     },

--- a/projects/rccl/tools/scripts/test_runner/lib/test_executor.py
+++ b/projects/rccl/tools/scripts/test_runner/lib/test_executor.py
@@ -68,7 +68,11 @@ class TestExecutor:
         # Setup directories
         self.setup_directories()
 
-        # Detect MPI hosts: prefer SLURM, fall back to hostfile
+        # MPI hostfile is detected lazily on first MPI test
+        self._mpi_hostfile = None
+        self._mpi_hostfile_detected = False
+
+        # Detect MPI hosts: auto-detect from SLURM if "auto_detect_hosts" is true in config, otherwise use hostfile
         self.mpi_hosts = self._detect_mpi_hosts()
 
         # Test tracking
@@ -139,16 +143,51 @@ class TestExecutor:
             print(f"Log directory:    {self.log_dir}")
             print(f"Report directory: {self.report_dir}")
 
+    @property
+    def mpi_hostfile(self):
+        """Lazy MPI hostfile detection -- only runs on first access."""
+        if not self._mpi_hostfile_detected:
+            self._mpi_hostfile = self._detect_mpi_hostfile()
+            self._mpi_hostfile_detected = True
+        return self._mpi_hostfile
+
+    def _detect_mpi_hostfile(self):
+        """
+        Detect MPI hostfile.
+        Checks RCCL_TEST_MPI_HOSTFILE env var, then ~/.mpi_hostfile default.
+
+        Returns:
+            str: Path to hostfile, or None if not found
+        """
+        hostfile = os.environ.get('RCCL_TEST_MPI_HOSTFILE')
+        if hostfile and os.path.isfile(hostfile):
+            print(f"Using MPI hostfile from RCCL_TEST_MPI_HOSTFILE: {hostfile}")
+            return hostfile
+
+        default_hostfile = os.path.expanduser('~/.mpi_hostfile')
+        if os.path.isfile(default_hostfile):
+            print(f"Using default MPI hostfile: {default_hostfile}")
+            return default_hostfile
+
+        if self.args.verbose:
+            print("No MPI hostfile found (checked RCCL_TEST_MPI_HOSTFILE env var and ~/.mpi_hostfile)")
+        return None
+
     def _detect_mpi_hosts(self):
         """
         Detect MPI host list once during initialization.
-        Priority: SLURM allocation (scontrol) > RCCL_TEST_MPI_HOSTFILE env > ~/.mpi_hostfile
+
+        If "auto_detect_hosts" is true in the system profile (or top-level config)
+        and a SLURM allocation is active, uses scontrol to get the host list.
+        Otherwise falls back to the hostfile detected by mpi_hostfile property.
 
         Returns:
-            dict with either 'host_list' (comma-separated hosts) or 'hostfile' (path), or empty dict
+            dict with 'host_list', 'hostfile', or empty dict
         """
-        # Check for SLURM allocation first
-        if os.environ.get('SLURM_JOB_ID'):
+        system = getattr(self.args, 'system', '') or ''
+        auto_detect = self.config_processor.config.get("auto_detect_hosts", False)
+
+        if auto_detect and os.environ.get('SLURM_JOB_ID'):
             try:
                 result = subprocess.run(
                     ['scontrol', 'show', 'hostnames'],
@@ -161,20 +200,11 @@ class TestExecutor:
             except (subprocess.TimeoutExpired, FileNotFoundError):
                 pass
 
-        # Fall back to hostfile
-        hostfile = os.environ.get('RCCL_TEST_MPI_HOSTFILE')
-        if hostfile and os.path.isfile(hostfile):
-            print(f"Using MPI hostfile from RCCL_TEST_MPI_HOSTFILE: {hostfile}")
+        hostfile = self.mpi_hostfile
+        if hostfile:
             return {'hostfile': hostfile}
 
-        default_hostfile = os.path.expanduser('~/.mpi_hostfile')
-        if os.path.isfile(default_hostfile):
-            print(f"Using default MPI hostfile: {default_hostfile}")
-            return {'hostfile': default_hostfile}
-
-        if self.args.verbose:
-            print("No MPI hostfile found (checked RCCL_TEST_MPI_HOSTFILE env var and ~/.mpi_hostfile)")
-        return None
+        return {}
 
     def check_environment(self):
         """

--- a/projects/rccl/tools/scripts/test_runner/lib/test_executor.py
+++ b/projects/rccl/tools/scripts/test_runner/lib/test_executor.py
@@ -40,6 +40,17 @@ class TestExecutor:
     Executes tests and manages build/test workflows
     """
 
+    MPI_IMPL_CONFIG = {
+        "openmpi": {
+            "env_format": "-x {key}='{value}'",
+            "default_args": "--mca btl ^vader,openib --mca pml ucx --bind-to none",
+        },
+        "mpich": {
+            "env_format": "-env {key} '{value}'",
+            "default_args": "-bind-to none",
+        },
+    }
+
     def __init__(self, config_processor, args):
         """
         Initialize TestExecutor
@@ -74,6 +85,7 @@ class TestExecutor:
 
         # MPI implementation: openmpi (default) or mpich (via --mpich flag)
         self.mpi_impl = "mpich" if getattr(args, 'mpich', False) else "openmpi"
+        self.mpi_config = self.MPI_IMPL_CONFIG[self.mpi_impl]
 
         # Detect MPI hosts: auto-detect from SLURM if "auto_detect_hosts" is true in config, otherwise use hostfile
         self.mpi_hosts = self._detect_mpi_hosts()
@@ -549,13 +561,8 @@ class TestExecutor:
                 host_arg = ""
                 map_by_arg = ""
 
-            # Default MCA params per MPI implementation
-            if self.mpi_impl == "mpich":
-                default_mca = "-bind-to none"
-            else:
-                default_mca = "--mca btl ^vader,openib --mca pml ucx --bind-to none"
-
             # MCA params priority: --system profile lookup > test-level "mpi_args" string > default
+            default_mca = self.mpi_config["default_args"]
             system = getattr(self.args, 'system', '') or ''
             mpi_args_config = self.config_processor.config.get("mpi_args", {})
 
@@ -578,17 +585,12 @@ class TestExecutor:
             )
 
             # Add environment variables for MPI (quote values to handle shell metacharacters like ;)
+            env_fmt = self.mpi_config["env_format"]
             for key, value in merged_env.items():
-                if self.mpi_impl == "mpich":
-                    mpi_args += f" -env {key} '{value}'"
-                else:
-                    mpi_args += f" -x {key}='{value}'"
+                mpi_args += " " + env_fmt.format(key=key, value=value)
 
-            # Pass the LD_LIBRARY_PATH
-            if self.mpi_impl == "mpich":
-                mpi_args += f" -env LD_LIBRARY_PATH {env['LD_LIBRARY_PATH']}"
-            else:
-                mpi_args += f" -x LD_LIBRARY_PATH={env['LD_LIBRARY_PATH']}"
+            mpi_args += " " + env_fmt.format(key="LD_LIBRARY_PATH", value=env['LD_LIBRARY_PATH'])
+            mpi_args += " " + env_fmt.format(key="LLVM_PROFILE_FILE", value="rccl_tests_%p_%m.profraw")
 
             # Forward LD_PRELOAD so UCX core libraries are preloaded with
             # global visibility on remote ranks (required for UCX PML)

--- a/projects/rccl/tools/scripts/test_runner/lib/test_executor.py
+++ b/projects/rccl/tools/scripts/test_runner/lib/test_executor.py
@@ -52,12 +52,24 @@ class TestExecutor:
         self.args = args
         self.system_config = config_processor.get_system_config()
         self.paths = config_processor.get_paths()
-        self.global_env = config_processor.get_env_variables()
+        self.global_env = dict(config_processor.get_env_variables())
+
+        # Merge system-specific env overrides if --system is specified
+        system = getattr(args, 'system', '') or ''
+        if system:
+            system_env = config_processor.config.get("system_env_variables", {})
+            if isinstance(system_env, dict) and system in system_env:
+                self.global_env.update(system_env[system])
+            elif system_env and system not in system_env:
+                available = list(system_env.keys()) if isinstance(system_env, dict) else []
+                print(f"WARNING: No system_env_variables for '{system}'. Available: {available}")
         self.build_config = config_processor.get_build_config()
 
         # Setup directories
         self.setup_directories()
 
+        # Detect MPI hosts: prefer SLURM, fall back to hostfile
+        self.mpi_hosts = self._detect_mpi_hosts()
         # MPI hostfile is detected lazily on first MPI test
         self._mpi_hostfile = None
         self._mpi_hostfile_detected = False
@@ -138,24 +150,40 @@ class TestExecutor:
             self._mpi_hostfile_detected = True
         return self._mpi_hostfile
 
-    def _detect_mpi_hostfile(self):
+    def _detect_mpi_hosts(self):
         """
+        Detect MPI host list once during initialization.
+        Priority: SLURM allocation (scontrol) > RCCL_TEST_MPI_HOSTFILE env > ~/.mpi_hostfile
         Detect MPI hostfile.
         Checks RCCL_TEST_MPI_HOSTFILE env var, then ~/.mpi_hostfile default.
 
         Returns:
-            str: Path to hostfile, or None if not found
+            dict with either 'host_list' (comma-separated hosts) or 'hostfile' (path), or empty dict
         """
+        # Check for SLURM allocation first
+        if os.environ.get('SLURM_JOB_ID'):
+            try:
+                result = subprocess.run(
+                    ['scontrol', 'show', 'hostnames'],
+                    capture_output=True, text=True, timeout=5
+                )
+                if result.returncode == 0 and result.stdout.strip():
+                    hosts = ','.join(result.stdout.strip().split('\n'))
+                    print(f"Using SLURM hosts: {hosts}")
+                    return {'host_list': hosts}
+            except (subprocess.TimeoutExpired, FileNotFoundError):
+                pass
+
+        # Fall back to hostfile
         hostfile = os.environ.get('RCCL_TEST_MPI_HOSTFILE')
         if hostfile and os.path.isfile(hostfile):
             print(f"Using MPI hostfile from RCCL_TEST_MPI_HOSTFILE: {hostfile}")
-            return hostfile
+            return {'hostfile': hostfile}
 
-        # Check default hostfile
         default_hostfile = os.path.expanduser('~/.mpi_hostfile')
         if os.path.isfile(default_hostfile):
             print(f"Using default MPI hostfile: {default_hostfile}")
-            return default_hostfile
+            return {'hostfile': default_hostfile}
 
         if self.args.verbose:
             print("No MPI hostfile found (checked RCCL_TEST_MPI_HOSTFILE env var and ~/.mpi_hostfile)")
@@ -482,33 +510,45 @@ class TestExecutor:
             if os.getuid() == 0:
                 mpi_cmd += " --allow-run-as-root"
 
-            # Use cached hostfile detected during initialization
-            hostfile = self.mpi_hostfile
-
-            # Warn if multi-node test without hostfile
-            if hostfile is None and num_nodes > 1:
-                print("WARNING: Multi-node test without hostfile")
-
-            hostfile_arg = f"--hostfile {hostfile} " if hostfile else ""
-
-            # Determine mapping strategy based on num_gpus and num_nodes
-            # Use PPR (processes per resource) to place num_gpus ranks per node
-            # This ignores the slots specification in the hostfile
-            if num_nodes > 1:
-                # Multi-node test: use ppr to control ranks per node
-                map_by_arg = f"--map-by ppr:{num_gpus}:node "
+            # Use cached host detection from initialization
+            if 'host_list' in self.mpi_hosts:
+                # SLURM mode: use --host with slot counts instead of --map-by ppr
+                # Repeat each host num_gpus times to place that many ranks per node
+                hosts = self.mpi_hosts['host_list'].split(',')
+                expanded = ','.join(f"{h}:{num_gpus}" for h in hosts)
+                host_arg = f"--host {expanded} "
+                map_by_arg = ""
+            elif 'hostfile' in self.mpi_hosts:
+                host_arg = f"--hostfile {self.mpi_hosts['hostfile']} "
+                # Use PPR to control ranks per node with hostfile
+                map_by_arg = f"--map-by ppr:{num_gpus}:node " if num_nodes > 1 else ""
             else:
-                # Single node: use default mapping (no need for ppr)
+                if num_nodes > 1:
+                    print("WARNING: Multi-node test without hostfile or SLURM allocation")
+                host_arg = ""
                 map_by_arg = ""
 
-            # MCA params: use config-level "mpi_args" if provided, otherwise defaults
-            default_mca = "--mca btl ^vader,openib --mca pml ucx --bind-to none"
-            extra_mpi_args = test_config.get("mpi_args", "") or self.config_processor.config.get("mpi_args", "")
-            mca_params = extra_mpi_args if extra_mpi_args else default_mca
+            # MCA params priority: --system profile lookup > test-level "mpi_args" string > default
+            default_mca = "--mca btl ^openib --mca pml ucx --bind-to none"
+            system = getattr(self.args, 'system', '') or ''
+            mpi_args_config = self.config_processor.config.get("mpi_args", {})
+
+            if system:
+                if isinstance(mpi_args_config, dict) and system in mpi_args_config:
+                    mca_params = mpi_args_config[system]
+                else:
+                    available = list(mpi_args_config.keys()) if isinstance(mpi_args_config, dict) else []
+                    print(f"ERROR: Unknown system profile '{system}'. Available: {available}")
+                    mca_params = default_mca
+            elif isinstance(mpi_args_config, str) and mpi_args_config:
+                mca_params = mpi_args_config
+            else:
+                config_mpi_args = test_config.get("mpi_args", "")
+                mca_params = config_mpi_args if config_mpi_args else default_mca
 
             mpi_args = (
                 f"-np {num_ranks} "
-                f"{hostfile_arg}"
+                f"{host_arg}"
                 f"{map_by_arg}"
                 f"{mca_params}"
             )

--- a/projects/rccl/tools/scripts/test_runner/lib/test_executor.py
+++ b/projects/rccl/tools/scripts/test_runner/lib/test_executor.py
@@ -72,6 +72,9 @@ class TestExecutor:
         self._mpi_hostfile = None
         self._mpi_hostfile_detected = False
 
+        # MPI implementation: openmpi (default) or mpich (via --mpich flag)
+        self.mpi_impl = "mpich" if getattr(args, 'mpich', False) else "openmpi"
+
         # Detect MPI hosts: auto-detect from SLURM if "auto_detect_hosts" is true in config, otherwise use hostfile
         self.mpi_hosts = self._detect_mpi_hosts()
 
@@ -569,12 +572,18 @@ class TestExecutor:
                 f"{mca_params}"
             )
 
-            # Add environment variables for MPI
+            # Add environment variables for MPI (quote values to handle shell metacharacters like ;)
             for key, value in merged_env.items():
-                mpi_args += f" -x {key}={value}"
+                if self.mpi_impl == "mpich":
+                    mpi_args += f" -env {key} '{value}'"
+                else:
+                    mpi_args += f" -x {key}='{value}'"
 
             # Pass the LD_LIBRARY_PATH
-            mpi_args += f" -x LD_LIBRARY_PATH={env['LD_LIBRARY_PATH']}"
+            if self.mpi_impl == "mpich":
+                mpi_args += f" -env LD_LIBRARY_PATH {env['LD_LIBRARY_PATH']}"
+            else:
+                mpi_args += f" -x LD_LIBRARY_PATH={env['LD_LIBRARY_PATH']}"
 
             # Forward LD_PRELOAD so UCX core libraries are preloaded with
             # global visibility on remote ranks (required for UCX PML)
@@ -583,7 +592,10 @@ class TestExecutor:
                 mpi_args += f" -x LD_PRELOAD={ld_preload}"
 
             # Pass LLVM_PROFILE_FILE to MPI ranks for code coverage (prevents default.profraw collision)
-            mpi_args += f" -x LLVM_PROFILE_FILE=rccl_tests_%p_%m.profraw"
+            if self.mpi_impl == "mpich":
+                mpi_args += f" -env LLVM_PROFILE_FILE rccl_tests_%p_%m.profraw"
+            else:
+                mpi_args += f" -x LLVM_PROFILE_FILE=rccl_tests_%p_%m.profraw"
 
             # Build test command based on type
             if is_gtest:

--- a/projects/rccl/tools/scripts/test_runner/lib/test_executor.py
+++ b/projects/rccl/tools/scripts/test_runner/lib/test_executor.py
@@ -164,6 +164,7 @@ class TestExecutor:
             print(f"Using MPI hostfile from RCCL_TEST_MPI_HOSTFILE: {hostfile}")
             return hostfile
 
+        # Check default hostfile
         default_hostfile = os.path.expanduser('~/.mpi_hostfile')
         if os.path.isfile(default_hostfile):
             print(f"Using default MPI hostfile: {default_hostfile}")

--- a/projects/rccl/tools/scripts/test_runner/lib/test_executor.py
+++ b/projects/rccl/tools/scripts/test_runner/lib/test_executor.py
@@ -565,11 +565,24 @@ class TestExecutor:
                 config_mpi_args = test_config.get("mpi_args", "")
                 mca_params = config_mpi_args if config_mpi_args else default_mca
 
+            MPI_ARGS = {
+                "openmpi": "--mca pml ucx --mca btl ^vader,openib",
+                "mpich": "",
+            }
+            BIND_ARGS = {
+                "openmpi": "--bind-to none",
+                "mpich": "-bind-to none",
+            }
+
+            mca_params = MPI_ARGS.get(self.mpi_impl, "")
+            bind_params = BIND_ARGS.get(self.mpi_impl, "")
+
             mpi_args = (
                 f"-np {num_ranks} "
                 f"{host_arg}"
                 f"{map_by_arg}"
-                f"{mca_params}"
+                f"{mca_params} "
+                f"{bind_params} "
             )
 
             # Add environment variables for MPI (quote values to handle shell metacharacters like ;)

--- a/projects/rccl/tools/scripts/test_runner/lib/test_executor.py
+++ b/projects/rccl/tools/scripts/test_runner/lib/test_executor.py
@@ -501,13 +501,16 @@ class TestExecutor:
                 # Single node: use default mapping (no need for ppr)
                 map_by_arg = ""
 
+            # MCA params: use config-level "mpi_args" if provided, otherwise defaults
+            default_mca = "--mca btl ^vader,openib --mca pml ucx --bind-to none"
+            extra_mpi_args = test_config.get("mpi_args", "") or self.config_processor.config.get("mpi_args", "")
+            mca_params = extra_mpi_args if extra_mpi_args else default_mca
+
             mpi_args = (
                 f"-np {num_ranks} "
                 f"{hostfile_arg}"
                 f"{map_by_arg}"
-                f"--mca btl ^vader,openib "
-                f"--mca pml ucx "
-                f"--bind-to none"
+                f"{mca_params}"
             )
 
             # Add environment variables for MPI

--- a/projects/rccl/tools/scripts/test_runner/lib/test_executor.py
+++ b/projects/rccl/tools/scripts/test_runner/lib/test_executor.py
@@ -549,8 +549,13 @@ class TestExecutor:
                 host_arg = ""
                 map_by_arg = ""
 
+            # Default MCA params per MPI implementation
+            if self.mpi_impl == "mpich":
+                default_mca = "-bind-to none"
+            else:
+                default_mca = "--mca btl ^vader,openib --mca pml ucx --bind-to none"
+
             # MCA params priority: --system profile lookup > test-level "mpi_args" string > default
-            default_mca = "--mca btl ^vader,openib --mca pml ucx --bind-to none"
             system = getattr(self.args, 'system', '') or ''
             mpi_args_config = self.config_processor.config.get("mpi_args", {})
 
@@ -565,24 +570,11 @@ class TestExecutor:
                 config_mpi_args = test_config.get("mpi_args", "")
                 mca_params = config_mpi_args if config_mpi_args else default_mca
 
-            MPI_ARGS = {
-                "openmpi": "--mca pml ucx --mca btl ^vader,openib",
-                "mpich": "",
-            }
-            BIND_ARGS = {
-                "openmpi": "--bind-to none",
-                "mpich": "-bind-to none",
-            }
-
-            mca_params = MPI_ARGS.get(self.mpi_impl, "")
-            bind_params = BIND_ARGS.get(self.mpi_impl, "")
-
             mpi_args = (
                 f"-np {num_ranks} "
                 f"{host_arg}"
                 f"{map_by_arg}"
-                f"{mca_params} "
-                f"{bind_params} "
+                f"{mca_params}"
             )
 
             # Add environment variables for MPI (quote values to handle shell metacharacters like ;)

--- a/projects/rccl/tools/scripts/test_runner/lib/test_executor.py
+++ b/projects/rccl/tools/scripts/test_runner/lib/test_executor.py
@@ -70,9 +70,6 @@ class TestExecutor:
 
         # Detect MPI hosts: prefer SLURM, fall back to hostfile
         self.mpi_hosts = self._detect_mpi_hosts()
-        # MPI hostfile is detected lazily on first MPI test
-        self._mpi_hostfile = None
-        self._mpi_hostfile_detected = False
 
         # Test tracking
         self.test_results = []
@@ -142,20 +139,10 @@ class TestExecutor:
             print(f"Log directory:    {self.log_dir}")
             print(f"Report directory: {self.report_dir}")
 
-    @property
-    def mpi_hostfile(self):
-        """Lazy MPI hostfile detection -- only runs on first access."""
-        if not self._mpi_hostfile_detected:
-            self._mpi_hostfile = self._detect_mpi_hostfile()
-            self._mpi_hostfile_detected = True
-        return self._mpi_hostfile
-
     def _detect_mpi_hosts(self):
         """
         Detect MPI host list once during initialization.
         Priority: SLURM allocation (scontrol) > RCCL_TEST_MPI_HOSTFILE env > ~/.mpi_hostfile
-        Detect MPI hostfile.
-        Checks RCCL_TEST_MPI_HOSTFILE env var, then ~/.mpi_hostfile default.
 
         Returns:
             dict with either 'host_list' (comma-separated hosts) or 'hostfile' (path), or empty dict

--- a/projects/rccl/tools/scripts/test_runner/lib/test_executor.py
+++ b/projects/rccl/tools/scripts/test_runner/lib/test_executor.py
@@ -529,7 +529,7 @@ class TestExecutor:
                 map_by_arg = ""
 
             # MCA params priority: --system profile lookup > test-level "mpi_args" string > default
-            default_mca = "--mca btl ^openib --mca pml ucx --bind-to none"
+            default_mca = "--mca btl ^vader,openib --mca pml ucx --bind-to none"
             system = getattr(self.args, 'system', '') or ''
             mpi_args_config = self.config_processor.config.get("mpi_args", {})
 
@@ -537,8 +537,6 @@ class TestExecutor:
                 if isinstance(mpi_args_config, dict) and system in mpi_args_config:
                     mca_params = mpi_args_config[system]
                 else:
-                    available = list(mpi_args_config.keys()) if isinstance(mpi_args_config, dict) else []
-                    print(f"ERROR: Unknown system profile '{system}'. Available: {available}")
                     mca_params = default_mca
             elif isinstance(mpi_args_config, str) and mpi_args_config:
                 mca_params = mpi_args_config

--- a/projects/rccl/tools/scripts/test_runner/lib/test_executor.py
+++ b/projects/rccl/tools/scripts/test_runner/lib/test_executor.py
@@ -596,13 +596,7 @@ class TestExecutor:
             # global visibility on remote ranks (required for UCX PML)
             ld_preload = os.environ.get("LD_PRELOAD", "")
             if ld_preload:
-                mpi_args += f" -x LD_PRELOAD={ld_preload}"
-
-            # Pass LLVM_PROFILE_FILE to MPI ranks for code coverage (prevents default.profraw collision)
-            if self.mpi_impl == "mpich":
-                mpi_args += f" -env LLVM_PROFILE_FILE rccl_tests_%p_%m.profraw"
-            else:
-                mpi_args += f" -x LLVM_PROFILE_FILE=rccl_tests_%p_%m.profraw"
+                mpi_args += " " + env_fmt.format(key="LD_PRELOAD", value=ld_preload)
 
             # Build test command based on type
             if is_gtest:

--- a/projects/rccl/tools/scripts/test_runner/lib/test_parser.py
+++ b/projects/rccl/tools/scripts/test_runner/lib/test_parser.py
@@ -113,6 +113,12 @@ Examples:
             default='',
             help="Select system-specific MPI args profile from config (e.g. 'ainic', 'thor2')"
         )
+        self.parser.add_argument(
+            '--mpich',
+            action='store_true',
+            default=False,
+            help="Use MPICH syntax (-env) instead of OpenMPI (-x) for passing env vars to mpirun"
+        )
 
     def parse_arguments(self):
         """Parse command-line arguments"""
@@ -144,6 +150,7 @@ Examples:
             print(f"Skip MPI check:    {args.skip_mpi_check}")
             print(f"Stop on rerun fail: {args.stop_on_rerun_failure}")
             print(f"System profile:    {args.system if args.system else 'none (use default MPI args)'}")
+            print(f"MPI implementation: {'mpich' if args.mpich else 'openmpi (default)'}")
             print("="*80)
             print()
 

--- a/projects/rccl/tools/scripts/test_runner/lib/test_parser.py
+++ b/projects/rccl/tools/scripts/test_runner/lib/test_parser.py
@@ -37,6 +37,9 @@ Examples:
 
   # Generate coverage report from existing data
   %(prog)s -c test_config.json --no-build --skip-tests --coverage-report
+
+  # Run on thor2 system (uses thor2 MPI args from config)
+  %(prog)s -c test_config.json --no-build --system thor2
             """
         )
 
@@ -104,6 +107,12 @@ Examples:
             action='store_true',
             help="Stop testing immediately if a rerun also fails (requires --rerun-failed)"
         )
+        self.parser.add_argument(
+            '--system',
+            type=str,
+            default='',
+            help="Select system-specific MPI args profile from config (e.g. 'ainic', 'thor2')"
+        )
 
     def parse_arguments(self):
         """Parse command-line arguments"""
@@ -134,6 +143,7 @@ Examples:
             print(f"Rerun failed:      {args.rerun_failed}")
             print(f"Skip MPI check:    {args.skip_mpi_check}")
             print(f"Stop on rerun fail: {args.stop_on_rerun_failure}")
+            print(f"System profile:    {args.system if args.system else 'none (use default MPI args)'}")
             print("="*80)
             print()
 


### PR DESCRIPTION
## Motivation

Extend `NetIbMPITest` with transport-level test coverage for the NIC fusion (virtual device) feature

## Technical Details

`NetIbMPITests.cpp`

Added 11 vNIC tests covering:
- Functional: `ConnectAndTransfer_VNic`
- Stress: `LargeTransfer_VNic` (64MB), `MixedSizes_VNic`, `SequentialTransfers_VNic` (100 iterations), `Reconnect_VNic` (10 connect/teardown cycles), `RegDeregCycling_VNic`, `Bidirectional_VNic`, `FlushRepeated_VNic`
- Edge case: `CloseWithoutTransfer_VNic`, `AsymmetricMerge_VNic`, `UnalignedSizeTransfer_VNic`

`test_executor.py`

- Made MPI MCA parameters configurable via the JSON config. Supports per-system profiles with --system flag, falling back to the default when a system has no custom MCA args.
- Added `auto_detect_hosts` support to automatically detect MPI hosts from SLURM allocations
- Added `--mpich` flag to support MPICH alongside default OpenMPI

`configs/net_ib_transport.json`

- New test runner config for all NetIbMPITest tests with per-system MPI args and environment overrides (ainic, thor2, mellanox).

## JIRA ID

AICOMRCCL-601

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
