### PR TITLE
Fix ncclGroupSimulateEnd planner state leak and resource cleanup

### DIFF
--- a/projects/rccl/src/collectives.cc
+++ b/projects/rccl/src/collectives.cc
@@ -120,10 +120,10 @@ ncclResult_t ncclAllGather_impl(const void* sendbuff, void* recvbuff, size_t sen
       sendcount, datatype, 0, 0, ncclSum, mscclFuncAllGather, comm, stream);
   }
 
-  if (rcclUseAllGatherDirect(comm, msgSize)) {
+  if (rcclUseAllGatherDirect(comm, msgSize) && ncclGroupDepth == 0) {
      INFO(NCCL_INIT, "RCCL DIRECT ALLGATHER count = %zu, msgSize = %zu, comm = %p, stream = %p, rank = %d, sendbuff = %p, recvbuff = %p",
 		     sendcount, msgSize, comm, stream, rank, sendbuff, recvbuff);
-     // use direct allgather
+     // use direct allgather (only when not in a group; in-group use Ring so ncclGroupSimulateEnd gets estimatedTime)
      if (sendcount == 0) return ncclSuccess;
      size_t rankOffset = sendcount * ncclTypeSize(datatype);
      if (sendbuff == (((char*)recvbuff) + rank * rankOffset)) {

--- a/projects/rccl/src/group.cc
+++ b/projects/rccl/src/group.cc
@@ -365,49 +365,49 @@ static inline void groupLocalResetJobState() {
   return;
 }
 
+/* Reclaim planner state after ncclGroupSimulateEnd or on group failure.
+ * Runs collCleanupQueue (buffer unregister), reclaims planQueue, resets planner. */
+static void reclaimPlannerState(struct ncclComm* comm) {
+  while (!ncclIntruQueueEmpty(&comm->planner.collCleanupQueue)) {
+    struct ncclCommCallback* cb = ncclIntruQueueDequeue(&comm->planner.collCleanupQueue);
+    (void)cb->fn(comm, cb);
+  }
+  comm->preconnectNext = reinterpret_cast<struct ncclComm*>(0x1);
+  for (int i = 0; i < comm->nRanks; i++) {
+    for (int j = 0; j < MAXCHANNELS/64; j++) {
+      comm->connectSend[i].masks[j] = 0UL;
+      comm->connectRecv[i].masks[j] = 0UL;
+    }
+  }
+  while (!ncclIntruQueueEmpty(&comm->planner.planQueue)) {
+    struct ncclKernelPlan* plan = ncclIntruQueueDequeue(&comm->planner.planQueue);
+    if (!plan->persistent) {
+      while (!ncclIntruQueueEmpty(&plan->proxyOpQueue)) {
+        struct ncclProxyOp* pxop = ncclIntruQueueDequeue(&plan->proxyOpQueue);
+        ncclMemoryPoolFree(&comm->memPool_ncclProxyOp, pxop);
+      }
+      ncclMemoryPoolFree(&comm->memPool_ncclKernelPlan, plan);
+    }
+  }
+  {
+    ncclKernelPlanner::Peer* tmp = comm->planner.peers;
+    memset(&comm->planner, 0, sizeof(comm->planner));
+    comm->planner.peers = tmp;
+    if (comm->planner.peers != NULL) memset(comm->planner.peers, 0, comm->nRanks * sizeof(comm->planner.peers[0]));
+  }
+}
+
 static void groupCleanup(struct ncclComm** groupCommHeadPtr, struct ncclIntruQueue<struct ncclAsyncJob, &ncclAsyncJob::next>* asyncJobsPtr, ncclResult_t error) {
   struct ncclComm* comm;
   for (int type = 0; type < ncclGroupTaskTypeNum; ++type) {
     comm = groupCommHeadPtr[type];
-    // reset groupCommHeadPtr[type]
     groupCommHeadPtr[type] = nullptr;
     while (comm != nullptr) {
       struct ncclComm* next = comm->groupNext[type];
-      (void)ncclGroupCommLeave(comm, type); // overwrites comm->groupNext
-      // We don't know if preconnect succeeded or happened at all, so clear
-      // the flags that let `taskAppend()` skip over checking if preconnect
-      // is needed.
+      (void)ncclGroupCommLeave(comm, type);
       if (type == ncclGroupTaskTypeCollective) {
-        comm->preconnectNext = reinterpret_cast<struct ncclComm*>(0x1);
-        for (int i = 0; i < comm->nRanks; i++) {
-          for (int j = 0; j < MAXCHANNELS/64; j++) {
-            comm->connectSend[i].masks[j] = 0UL;
-            comm->connectRecv[i].masks[j] = 0UL;
-          }
-        }
-        // Reclaim abandoned kernel plan memory. Note ncclWork structs were already
-        // reclaimed by a `ncclMemoryStackPop(&comm->memScoped)` during `ncclGroupCommLeave()`.
-        while (!ncclIntruQueueEmpty(&comm->planner.planQueue)) {
-          struct ncclKernelPlan* plan = ncclIntruQueueDequeue(&comm->planner.planQueue);
-          // Persistent plans will be reclaimed via the callbackQueue when the
-          // graph drops its UserObject reference.
-          if (!plan->persistent) {
-            while (!ncclIntruQueueEmpty(&plan->proxyOpQueue)) {
-              struct ncclProxyOp* pxop = ncclIntruQueueDequeue(&plan->proxyOpQueue);
-              ncclMemoryPoolFree(&comm->memPool_ncclProxyOp, pxop);
-            }
-            ncclMemoryPoolFree(&comm->memPool_ncclKernelPlan, plan);
-          }
-        }
-
-        { // Reset comm->planner to empty.
-          ncclKernelPlanner::Peer* tmp = comm->planner.peers;
-          memset(&comm->planner, 0, sizeof(comm->planner));
-          comm->planner.peers = tmp;
-          if (comm->planner.peers != NULL) memset(comm->planner.peers, 0, comm->nRanks * sizeof(comm->planner.peers[0]));
-        }
+        reclaimPlannerState(comm);
       }
-
       if (!comm->config.blocking)
         (void)ncclCommSetAsyncError(comm, error);
       comm = next;
@@ -655,6 +655,9 @@ static ncclResult_t groupLaunch(struct ncclAsyncJob *job_, ncclSimInfo_t* simInf
         comm->reclaimSteps++;
       }
       (void)ncclGroupCommLeave(comm, type);
+      if (simInfo && type == ncclGroupTaskTypeCollective) {
+        reclaimPlannerState(comm);
+      }
       if (!comm->config.blocking) {
         (void)ncclCommSetAsyncError(comm, ret);
       }


### PR DESCRIPTION
## Motivation

Cleaned planner state, so subsequent collectives don't reuse stale state. 
All gather in-group use Ring so ncclGroupSimulateEnd gets estimatedTime

## Technical Details

- Ensure that planner state is reclaimed on the normal simulation exit path.
- When inside a group (e.g., `ncclGroupStart` / `ncclGroupSimulateEnd`), Ring path is used, it enables `ncclGroupSimulateEnd` to obtain `estimatedTime`.

## JIRA ID

ROCM-19878

## Test Plan

error reproducer was used to test.

## Test Result

<!-- Briefly summarize test outcomes. -->