### PR TITLE
Update default net plugin

### DIFF
--- a/projects/rccl/src/plugin/net.cc
+++ b/projects/rccl/src/plugin/net.cc
@@ -233,7 +233,7 @@ static ncclResult_t ncclNetPluginDisableOtherExternal(int pluginIndex) {
 
 static void initPluginLibsOnceFunc() {
   char* netPluginName = nullptr;
-  const char* defaultNetPlugin = "libnccl-net.so";
+  const char* defaultNetPlugin = "librccl-net.so";
   const char* envNetPlugin = nullptr;
   char* envNetPluginList = nullptr;
   char* savePtr = nullptr;


### PR DESCRIPTION
Make librccl-net.so as default net plugin

## Motivation

RCCL in rocm7.2 looks for libnccl-net.so by default, updating it to librccl-net.so

## Technical Details

Update the default plug in to librccl.

## JIRA ID

Resolves ROCM-20014

## Test Plan

unit tests

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
