### PR TITLE
rocr: Disable ASAN for dl_iterate_phdr callback function

### DIFF
--- a/projects/rocr-runtime/runtime/hsa-runtime/core/util/lnx/os_linux.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/util/lnx/os_linux.cpp
@@ -313,6 +313,13 @@ bool CloseLib(LibHandle lib) { return (dlclose(*(void**)&lib) == 0) ? true : fal
  * shared objects.
  */
 
+// Disable ASAN: dl_iterate_phdr pointers may reside outside ASAN's shadow
+// mapped range as ASLR makes this non-deterministic across nodes/runs
+#if defined(__has_attribute)
+#if __has_attribute(no_sanitize)
+__attribute__((no_sanitize("address")))
+#endif
+#endif
 static int callback(struct dl_phdr_info* info, size_t size, void* data) {
   std::vector<std::string>* loadedToolsLib = (std::vector<std::string>*)data;
   assert(loadedToolsLib != nullptr);
@@ -325,7 +332,7 @@ static int callback(struct dl_phdr_info* info, size_t size, void* data) {
    * will have a specific segment or section. Hence its skipped.
    */
 
-  if ((info) && (info->dlpi_name[0] != '\0')) {
+  if ((info) && (info->dlpi_name) && (info->dlpi_name[0] != '\0')) {
     if (std::string(info->dlpi_name).find("vdso.so") != std::string::npos) return 0;
 
     /*


### PR DESCRIPTION
Set `no_sanitize` for address as the `callback` function accesses kernel/linker provided structures that may reside outside the ASAN's shadow-mapped address space. Also, add a null check for `dlpi_name`.

## Technical Details
ASAN pre-maps its shadow memory for a fixed, expected range of user-space addresses. The `callback` function accesses kernel/linker-provided structures (_dlpi_name_, _dlpi_phdr_, string table, etc.) that may reside outside ASAN's shadow-mapped address space depending on ASLR layout, causing a SEGV on the shadow check itself.