### PR TITLE
[rocprofiler-compute] Fix coverage calculation when testing from install

### DIFF
--- a/projects/rocprofiler-compute/CMakeLists.txt
+++ b/projects/rocprofiler-compute/CMakeLists.txt
@@ -279,7 +279,8 @@ if(TEST_FROM_INSTALL)
         "${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBEXECDIR}/${PACKAGE_NAME}/.coverage"
     )
 else()
-    # When testing from build, write coverage to build directory
+    # When testing from build, write coverage XML to build directory
+    # and coverage data to source directory
     set(COVERAGE_XML_PATH "${CMAKE_BINARY_DIR}/coverage.xml")
     set(COVERAGE_DATA_PATH "${PROJECT_SOURCE_DIR}/.coverage")
 endif()

--- a/projects/rocprofiler-compute/CMakeLists.txt
+++ b/projects/rocprofiler-compute/CMakeLists.txt
@@ -213,8 +213,15 @@ include(CTest)
 option(ENABLE_COVERAGE "Enable code coverage" OFF)
 set(COV_OPTION "")
 if(${ENABLE_COVERAGE})
+    # Set coverage source path based on test mode
+    if(TEST_FROM_INSTALL)
+        set(COV_SRC ".")
+    else()
+        set(COV_SRC "src")
+    endif()
+
     set(COV_OPTION
-        "--cov=src"
+        "--cov=${COV_SRC}"
         "--cov-append"
         "--cov-report=term-missing"
         "--cov-report=lcov:tests/coverage.info"
@@ -268,9 +275,13 @@ if(TEST_FROM_INSTALL)
     set(COVERAGE_XML_PATH
         "${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBEXECDIR}/${PACKAGE_NAME}/coverage.xml"
     )
+    set(COVERAGE_DATA_PATH
+        "${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBEXECDIR}/${PACKAGE_NAME}/.coverage"
+    )
 else()
     # When testing from build, write coverage to build directory
     set(COVERAGE_XML_PATH "${CMAKE_BINARY_DIR}/coverage.xml")
+    set(COVERAGE_DATA_PATH "${PROJECT_SOURCE_DIR}/.coverage")
 endif()
 
 set(STANDALONEBINARY_EXTRACT_DIR
@@ -639,7 +650,7 @@ if(${ENABLE_COVERAGE})
         PROPERTIES
             DEPENDS "${ALL_TESTS_STRING}"
             LABELS "coverage"
-            ENVIRONMENT "COVERAGE_FILE=${PROJECT_SOURCE_DIR}/.coverage"
+            ENVIRONMENT "COVERAGE_FILE=${COVERAGE_DATA_PATH}"
             TIMEOUT 600
     )
 endif()


### PR DESCRIPTION
## Motivation

Fix coverage calculation failing when testing from install

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

When TEST_FROM_INSTALL=ON cmake args. is provided and tests are run from within the installation. There is no top level src folder and the current directory has all the source code. This means we need to set --cov=. when TEST_FROM_INSTALL=ON to prevent coverage calculation failure

Also, we need to ensure that .coverage file from installation directory is used and not the source directory, which requires COVERAGE_DATA_PATH variable

<!-- Explain the changes along with any relevant GitHub links. -->

## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan

Create installation folder using TEST_FROM_INSTALL=ON
```
rm -rf build install && cmake -B build -D CMAKE_INSTALL_PREFIX=install -D TEST_FROM_INSTALL=ON -D ENABLE_TESTS=ON -D INSTALL_TESTS=ON -DENABLE_COVERAGE=ON -S . && cmake --build build --target install --parallel 8
```

```
cd install/libexec/rocprofiler-compute
```

Ensure utils and coverage tests pass
```
ctest -I 28
```

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

Tests pass

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
