### PR TITLE
[rocprofiler-compute] Allow mpi testing from containers

### DIFF
--- a/projects/rocprofiler-compute/tests/conftest.py
+++ b/projects/rocprofiler-compute/tests/conftest.py
@@ -170,12 +170,15 @@ def binary_handler_profile_rocprof_compute(request):
 
             # Wrap with mpirun if num_ranks > 1
             if num_ranks > 1:
-                command_rocprof_compute = [
-                    "mpirun",
-                    "--allow-run-as-root",
-                    "-n",
-                    str(num_ranks),
-                ] + command_rocprof_compute
+                mpirun_cmd = ["mpirun"]
+                # Add --allow-run-as-root only when running as root
+                # (needed for OpenMPI in containers)
+                # This flag is OpenMPI-specific and would cause errors
+                # with other MPI implementations
+                if os.geteuid() == 0:
+                    mpirun_cmd.append("--allow-run-as-root")
+                mpirun_cmd.extend(["-n", str(num_ranks)])
+                command_rocprof_compute = mpirun_cmd + command_rocprof_compute
 
             process = subprocess.run(
                 command_rocprof_compute,
@@ -235,12 +238,15 @@ def binary_handler_profile_rocprof_compute(request):
             if num_ranks > 1:
                 # Use rocprof_compute_script_path instead of rocprof-compute
                 command_rocprof_compute[0] = rocprof_compute_script_path
-                command_rocprof_compute = [
-                    "mpirun",
-                    "--allow-run-as-root",
-                    "-n",
-                    str(num_ranks),
-                ] + command_rocprof_compute
+                mpirun_cmd = ["mpirun"]
+                # Add --allow-run-as-root only when running as root
+                # (needed for OpenMPI in containers)
+                # This flag is OpenMPI-specific and would cause errors
+                # with other MPI implementations
+                if os.geteuid() == 0:
+                    mpirun_cmd.append("--allow-run-as-root")
+                mpirun_cmd.extend(["-n", str(num_ranks)])
+                command_rocprof_compute = mpirun_cmd + command_rocprof_compute
 
             # For capture_output or multi-rank, run the command with subprocess
             if capture_output or num_ranks > 1:

--- a/projects/rocprofiler-compute/tests/conftest.py
+++ b/projects/rocprofiler-compute/tests/conftest.py
@@ -172,6 +172,7 @@ def binary_handler_profile_rocprof_compute(request):
             if num_ranks > 1:
                 command_rocprof_compute = [
                     "mpirun",
+                    "--allow-run-as-root",
                     "-n",
                     str(num_ranks),
                 ] + command_rocprof_compute
@@ -236,6 +237,7 @@ def binary_handler_profile_rocprof_compute(request):
                 command_rocprof_compute[0] = rocprof_compute_script_path
                 command_rocprof_compute = [
                     "mpirun",
+                    "--allow-run-as-root",
                     "-n",
                     str(num_ranks),
                 ] + command_rocprof_compute

--- a/projects/rocprofiler-compute/tests/conftest.py
+++ b/projects/rocprofiler-compute/tests/conftest.py
@@ -50,6 +50,21 @@ except Exception:
     rocprof_compute_script_path = "rocprof-compute"
 
 
+def inject_mpirun(command, num_ranks):
+    """
+    Wrap a command with mpirun for multi-rank execution.
+    """
+    mpirun_cmd = ["mpirun"]
+    # Add --allow-run-as-root only when running as root
+    # (needed for OpenMPI in containers)
+    # This flag is OpenMPI-specific and would cause errors
+    # with other MPI implementations
+    if os.geteuid() == 0:
+        mpirun_cmd.append("--allow-run-as-root")
+    mpirun_cmd.extend(["-n", str(num_ranks)])
+    return mpirun_cmd + command
+
+
 def pytest_addoption(parser):
     parser.addoption(
         "--call-binary",
@@ -170,15 +185,9 @@ def binary_handler_profile_rocprof_compute(request):
 
             # Wrap with mpirun if num_ranks > 1
             if num_ranks > 1:
-                mpirun_cmd = ["mpirun"]
-                # Add --allow-run-as-root only when running as root
-                # (needed for OpenMPI in containers)
-                # This flag is OpenMPI-specific and would cause errors
-                # with other MPI implementations
-                if os.geteuid() == 0:
-                    mpirun_cmd.append("--allow-run-as-root")
-                mpirun_cmd.extend(["-n", str(num_ranks)])
-                command_rocprof_compute = mpirun_cmd + command_rocprof_compute
+                command_rocprof_compute = inject_mpirun(
+                    command_rocprof_compute, num_ranks
+                )
 
             process = subprocess.run(
                 command_rocprof_compute,
@@ -238,15 +247,9 @@ def binary_handler_profile_rocprof_compute(request):
             if num_ranks > 1:
                 # Use rocprof_compute_script_path instead of rocprof-compute
                 command_rocprof_compute[0] = rocprof_compute_script_path
-                mpirun_cmd = ["mpirun"]
-                # Add --allow-run-as-root only when running as root
-                # (needed for OpenMPI in containers)
-                # This flag is OpenMPI-specific and would cause errors
-                # with other MPI implementations
-                if os.geteuid() == 0:
-                    mpirun_cmd.append("--allow-run-as-root")
-                mpirun_cmd.extend(["-n", str(num_ranks)])
-                command_rocprof_compute = mpirun_cmd + command_rocprof_compute
+                command_rocprof_compute = inject_mpirun(
+                    command_rocprof_compute, num_ranks
+                )
 
             # For capture_output or multi-rank, run the command with subprocess
             if capture_output or num_ranks > 1:


### PR DESCRIPTION
## Motivation

Allow mpi testing from containers

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

mpirun inside container requires --allow-run-as-root flag. This change allows mpi tests to be run from containers

<!-- Explain the changes along with any relevant GitHub links. -->

## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan

Run a mpi test from container
```
pytest -s --verbose -k test_multi_rank_profiling_no_mpi_comm -- tests/test_profile_general.py
```

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

Tests pass

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
