### PR TITLE
dbgapi: Fix build with clang targeting x86_64-pc-windows-msvc

### DIFF
--- a/projects/rocdbgapi/include/amd-dbgapi.h.in
+++ b/projects/rocdbgapi/include/amd-dbgapi.h.in
@@ -543,7 +543,10 @@ extern "C" {
 #endif /* __linux__ */
 
 #if defined(_WIN32)
-#include <windef.h>
+/* Define these ourselves to avoid including windows.h in our public
+   header and polluting the namespace.  */
+typedef void *amd_dbgapi_HANDLE;
+typedef unsigned long amd_dbgapi_DWORD;
 #endif /* _WIN32 */
 
 #include <stddef.h>
@@ -692,7 +695,7 @@ typedef enum
 #if defined(__linux__)
 typedef pid_t amd_dbgapi_os_process_id_t;
 #elif defined(_WIN32)
-typedef DWORD amd_dbgapi_os_process_id_t;
+typedef amd_dbgapi_DWORD amd_dbgapi_os_process_id_t;
 #endif /* _WIN32 */
 
 /**
@@ -728,7 +731,7 @@ typedef DWORD amd_dbgapi_os_process_id_t;
 #if defined(__linux__)
 typedef int amd_dbgapi_notifier_t;
 #elif defined(_WIN32)
-typedef HANDLE amd_dbgapi_notifier_t;
+typedef amd_dbgapi_HANDLE amd_dbgapi_notifier_t;
 #endif /* _WIN32 */
 
 /**

--- a/projects/rocdbgapi/src/logging.h
+++ b/projects/rocdbgapi/src/logging.h
@@ -82,8 +82,19 @@ to_string (T v)
     if (v == nullptr)
       return "nullptr";
 
+  /* Handle function pointers explicitly to avoid
+
+       error: implicit conversion between pointer-to-function and
+       pointer-to-object is a Microsoft extension
+       [-Werror,-Wmicrosoft-cast]
+
+     with clang++.
+  */
   std::ostringstream ss;
-  ss << v;
+  if constexpr (std::is_function_v<std::remove_pointer_t<T>>)
+    ss << reinterpret_cast<const void *> (v);
+  else
+    ss << v;
   return ss.str ();
 }
 

--- a/projects/rocdbgapi/src/os_driver_kmd.cpp
+++ b/projects/rocdbgapi/src/os_driver_kmd.cpp
@@ -22,8 +22,16 @@
 #include "logging.h"
 #include "os_driver.h"
 
-#include <ntstatus.h>
+/* Make sure we use the STATUS_XXX constants from ntstatus.h.  Some of
+   the constants we use (but not all) are defined in winnt.h too, but
+   defined as DWORD (aka 'unsigned long'), while ntstatus.h defines
+   all STATUS constants as NTSTATUS (aka 'long').  */
+#define WIN32_NO_STATUS
 #include <windows.h>
+#undef WIN32_NO_STATUS
+#include <ntstatus.h>
+/* Needed for the NTSTATUS typedef.  */
+#include <winternl.h>
 
 #include <d3dkmthk.h>
 

--- a/projects/rocdbgapi/src/os_driver_kmd.cpp
+++ b/projects/rocdbgapi/src/os_driver_kmd.cpp
@@ -995,6 +995,9 @@ private:
      behind ADAPTER.  */
   amd_dbgapi_status_t init_adapter (D3DKMT_HANDLE adapter);
 
+  /* Get the adapter name.  */
+  std::string get_adapter_name (D3DKMT_HANDLE adapter) const;
+
   /* Build a queue_id we can return to the core from the agent_id and KMD
      queue_id.  */
   os_queue_id_t make_queue_id (os_agent_id_t agent_id,
@@ -1266,6 +1269,40 @@ kmd_driver_t::check_version () const
   return AMD_DBGAPI_STATUS_SUCCESS;
 }
 
+std::string
+kmd_driver_t::get_adapter_name (D3DKMT_HANDLE adapter) const
+{
+  D3DKMT_QUERYADAPTERINFO query_info{};
+  D3DKMT_ADAPTERREGISTRYINFO adapter_reg_info{};
+  query_info.Type = KMTQAITYPE_ADAPTERREGISTRYINFO;
+  query_info.hAdapter = adapter;
+  query_info.pPrivateDriverData = &adapter_reg_info;
+  query_info.PrivateDriverDataSize = sizeof (D3DKMT_ADAPTERREGISTRYINFO);
+
+  if (m_d3d.api.query_adapter_info (&query_info) != STATUS_SUCCESS)
+    return "<unknown>";
+
+  size_t wide_len = ::wcsnlen (adapter_reg_info.AdapterString,
+                               std::size (adapter_reg_info.AdapterString));
+  if (wide_len == 0)
+    return "<unknown>";
+
+  int size_needed
+    = WideCharToMultiByte (CP_ACP, 0, adapter_reg_info.AdapterString,
+                           (int)wide_len, nullptr, 0,
+                           nullptr, nullptr);
+  if (size_needed <= 0)
+    return "<unknown>";
+
+  std::string result (size_needed, '\0');
+  int size
+    = WideCharToMultiByte (CP_ACP, 0, adapter_reg_info.AdapterString,
+                           (int)wide_len, &result[0], size_needed,
+                           "?", nullptr);
+  dbgapi_assert (size == size_needed);
+  return result;
+}
+
 amd_dbgapi_status_t
 kmd_driver_t::agent_snapshot (os_agent_info_t *snapshots,
                               size_t snapshot_count, size_t *agent_count,
@@ -1289,32 +1326,7 @@ kmd_driver_t::agent_snapshot (os_agent_info_t *snapshots,
       agent = {};
 
       /* Query the agent name from the OS.  */
-      D3DKMT_QUERYADAPTERINFO query_info{};
-      D3DKMT_ADAPTERREGISTRYINFO adapter_reg_info{};
-      query_info.Type = KMTQAITYPE_ADAPTERREGISTRYINFO;
-      query_info.hAdapter = agent_handle.adapter;
-      query_info.pPrivateDriverData = &adapter_reg_info;
-      query_info.PrivateDriverDataSize = sizeof (D3DKMT_ADAPTERREGISTRYINFO);
-
-      if (m_d3d.api.query_adapter_info (&query_info) == STATUS_SUCCESS)
-        {
-          /* We need to convert from wchar string to std::string.  */
-          char tmp[MAX_PATH * MB_CUR_MAX] = {};
-          size_t tmp_i = 0;
-          for (size_t i = 0;
-               i < MAX_PATH && adapter_reg_info.AdapterString[i] != 0; i++)
-            {
-              int r
-                = ::wctomb (&tmp[tmp_i], adapter_reg_info.AdapterString[i]);
-              if (r == -1)
-                tmp[tmp_i++] = '?';
-              else
-                tmp_i += r;
-            }
-          agent.name = tmp;
-        }
-      else
-        agent.name = "<unknown>";
+      agent.name = get_adapter_name (agent_handle.adapter);
 
       /* Query the rest of the information to MKD.  */
       KMDDBGRIF_DBGR_CMDS cmd{};

--- a/projects/rocdbgapi/third_party/libdxg/include/d3dkmdt.h
+++ b/projects/rocdbgapi/third_party/libdxg/include/d3dkmdt.h
@@ -24,7 +24,7 @@
 
 #include "d3dukmdt.h"
 
-#if !defined(__MINGW32__)
+#if defined(__linux__)
 #define NTSTATUS                int32_t
 
 /*
@@ -75,7 +75,7 @@ typedef enum _DEVICE_POWER_STATE {
     PowerDeviceMaximum
 } DEVICE_POWER_STATE, *PDEVICE_POWER_STATE;
 
-#endif // !defined(__MINGW32__)
+#endif // __linux__
 
 #pragma region Desktop Family
 #if WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_DESKTOP)

--- a/projects/rocdbgapi/third_party/libdxg/include/d3dkmthk.h
+++ b/projects/rocdbgapi/third_party/libdxg/include/d3dkmthk.h
@@ -5632,9 +5632,9 @@ typedef _Check_return_ NTSTATUS (APIENTRY *PFND3DKMT_ENUMADAPTERS3)(_Inout_ D3DK
 
 typedef _Check_return_ NTSTATUS (APIENTRY *PFND3DKMT_PINRESOURCES)(_Inout_ D3DKMT_PINRESOURCES*);
 typedef _Check_return_ NTSTATUS (APIENTRY *PFND3DKMT_UNPINRESOURCES)(_In_ CONST D3DKMT_UNPINRESOURCES*);
-#if defined(WIN32) && !defined(__MINGW32__)
+#if defined(__linux__)
 typedef _Check_return_ NTSTATUS (APIENTRY *PFND3DKMT_DISPLAYPORT_OPERATION)(_Inout_ D3DKMT_DISPLAYPORT_OPERATION_HEADER*);
-#endif // _WIN32 && !__MINGW32__
+#endif // __linux__
 
 #endif
 


### PR DESCRIPTION
This series of patches fixes the dbgapi build with clang targeting x86_64-pc-windows-msvc.

Pedro Alves (5):
  dbgapi/win32: Fix libdxg and MSVC
  dbgapi/win32: Fix NTSTATUS constants
  dbgapi/win32: No windef.h in amd-dbgapi.h.in
  dbgapi: Handle function pointers explicitly in to_string
  dbgapi/win32: Fix for MB_CUR_MAX not constant

 projects/rocdbgapi/include/amd-dbgapi.h.in    |  9 ++-
 projects/rocdbgapi/src/logging.h              | 13 +++-
 projects/rocdbgapi/src/os_driver_kmd.cpp      | 70 ++++++++++++-------
 .../third_party/libdxg/include/d3dkmdt.h      |  4 +-
 .../third_party/libdxg/include/d3dkmthk.h     |  4 +-
 5 files changed, 65 insertions(+), 35 deletions(-)
