### PR TITLE
kfdtest: Fix filter parsing logic

### DIFF
--- a/projects/rocr-runtime/libhsakmt/tests/kfdtest/scripts/run_kfdtest.sh
+++ b/projects/rocr-runtime/libhsakmt/tests/kfdtest/scripts/run_kfdtest.sh
@@ -141,19 +141,20 @@ getFilter() {
     # Check if the loaded driver is upstream (in-box) or DKMS
     rdma_get_pages_func=$(cat /proc/kallsyms | grep rdma_get_pages || true)
     if [ -z "$rdma_get_pages_func" ]; then
-        # If the first character of the filter is -, it's a blacklist
-	# So add the upstream tests to the blacklist. If it's not a -, it's a
-	# whitelist, so don't add anything
-	if [[ "$gtestFilter{0:1}" == "-" ]]; then
+        # If the filter is a blacklist (test list starts with -), we want to add to the list
+        # If the filter is a whitelist (test list starts with the test name), we don't want to add
+        # known-unsupported tests to the list, so don't add anything
+        if [[ "$gtestFilter" == --gtest_filter=-* ]]; then
             gtestFilter="$gtestFilter:${FILTER[upstream]}"
         fi
     fi
 
     if [ -n "$ADDITIONAL_EXCLUDE" ]; then
-        # If the first character of the filter is -, it's a blacklist
-	# So add the additional exclusions to the blacklist. If it's not a -, it's a
-	# whitelist, so don't add anything
-        if [[ "$gtestFilter{0:1}" == "-" ]]; then
+        # If the filter is a blacklist (test list starts with -), we want to add to the list
+	# If the filter is a whitelist (test list starts with the test name), we don't want to add
+	# excluded tests to the list, so don't add anything
+	# TODO: Add parsing so we can use --gtest_filter and -e together.
+        if [[ "$gtestFilter" == --gtest_filter=-* ]]; then
             gtestFilter="$gtestFilter:$ADDITIONAL_EXCLUDE"
         fi
     fi


### PR DESCRIPTION
gtest_filter will obviously start with -, since it's of the format --gtest_filter=.....
Fix the check to look for a --gtest_filter=- prefix, which denotes a blacklist