### PR TITLE
[WIP] rocprofiler-sdk/rocr-runtime: fix HIP graph kernel-trace event loss

### DIFF
--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/context/correlation_id.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/context/correlation_id.cpp
@@ -30,6 +30,8 @@
 
 #include <rocprofiler-sdk/fwd.h>
 
+#include <vector>
+
 namespace rocprofiler
 {
 namespace context
@@ -47,7 +49,7 @@ get_correlation_id_map()
 auto&
 get_latest_correlation_id_impl()
 {
-    static thread_local auto _v = common::container::small_vector<correlation_id*, 16>{};
+    static thread_local auto _v = std::vector<correlation_id*>{};
     return _v;
 }
 

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/hsa/details/fmt.hpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/hsa/details/fmt.hpp
@@ -26,9 +26,250 @@
 #include <fmt/format.h>
 #include <fmt/ranges.h>
 #include <string>
+#include <type_traits>
 
 namespace fmt
 {
+namespace detail
+{
+constexpr auto hsa_amd_memory_copy_op_extended_layout_size = size_t{128};
+
+template <typename Tp>
+struct has_extended_memory_copy_op_layout
+: std::bool_constant<(sizeof(Tp) >= hsa_amd_memory_copy_op_extended_layout_size)>
+{};
+
+template <typename Tp>
+constexpr auto
+to_underlying(Tp value) -> std::underlying_type_t<Tp>
+{
+    return static_cast<std::underlying_type_t<Tp>>(value);
+}
+
+constexpr auto hsa_amd_memory_copy_op_linear_indirect_src_value    = 3;
+constexpr auto hsa_amd_memory_copy_op_linear_indirect_dst_value    = 4;
+constexpr auto hsa_amd_memory_copy_op_linear_indirect_srcdst_value = 5;
+
+template <typename CopyOpT, typename FormatContext>
+auto
+format_memory_copy_op(CopyOpT const& op, FormatContext& ctx, std::true_type)
+{
+    auto reserved = std::string{};
+    if(op.reserved1[0] != 0)
+    {
+        reserved = fmt::format(", reserved1=[{}]", op.reserved1[0]);
+    }
+
+    auto wait = std::string{};
+    if(op.wait.function != 0 || op.wait.scope != 0 || op.wait.reserved != 0 ||
+       op.wait.addr != nullptr || op.wait.value != 0 || op.wait.mask != 0)
+    {
+        wait = fmt::format(", wait={{function={}, scope={}, reserved={}, addr={}, value={}, "
+                           "mask={}}}",
+                           op.wait.function,
+                           op.wait.scope,
+                           op.wait.reserved,
+                           fmt::ptr(op.wait.addr),
+                           op.wait.value,
+                           op.wait.mask);
+    }
+
+    auto signal = std::string{};
+    if(op.signal.operation != 0 || op.signal.scope != 0 || op.signal.reserved != 0 ||
+       op.signal.addr != nullptr || op.signal.data != 0)
+    {
+        signal = fmt::format(", signal={{operation={}, scope={}, reserved={}, addr={}, data={}}}",
+                             op.signal.operation,
+                             op.signal.scope,
+                             op.signal.reserved,
+                             fmt::ptr(op.signal.addr),
+                             op.signal.data);
+    }
+
+    auto       type            = static_cast<hsa_amd_memory_copy_op_type_t>(op.type);
+    auto       type_value      = to_underlying(type);
+    const bool is_linear_multi =
+        (type_value == to_underlying(HSA_AMD_MEMORY_COPY_OP_LINEAR) && op.num_dsts > 0);
+    if(is_linear_multi && op.reserved0 != 0)
+    {
+        reserved += fmt::format(", reserved0={}", op.reserved0);
+    }
+
+    switch(type_value)
+    {
+        case detail::to_underlying(HSA_AMD_MEMORY_COPY_OP_LINEAR_BROADCAST):
+            return fmt::format_to(ctx.out(),
+                                  "[MEMORY_COPY_OP type={}, version={}, num_dsts={}, "
+                                  "traffic_class={}, completion_signal={}, src={}, "
+                                  "src_agent={}, dst_list={}, dst_agent_list={}, size={}{}{}{}]",
+                                  type,
+                                  op.version,
+                                  op.num_dsts,
+                                  op.traffic_class,
+                                  op.completion_signal.handle,
+                                  fmt::ptr(op.src),
+                                  op.src_agent.handle,
+                                  fmt::ptr(op.dst_list),
+                                  fmt::ptr(op.dst_agent_list),
+                                  op.size,
+                                  wait,
+                                  signal,
+                                  reserved);
+
+        case detail::to_underlying(HSA_AMD_MEMORY_COPY_OP_LINEAR_SWAP):
+            return fmt::format_to(ctx.out(),
+                                  "[MEMORY_COPY_OP type={}, version={}, num_dsts={}, "
+                                  "traffic_class={}, completion_signal={}, src={}, "
+                                  "src_agent={}, dst={}, dst_agent={}, src_size={}, "
+                                  "dst_size={}{}{}{}]",
+                                  type,
+                                  op.version,
+                                  op.num_dsts,
+                                  op.traffic_class,
+                                  op.completion_signal.handle,
+                                  fmt::ptr(op.src),
+                                  op.src_agent.handle,
+                                  fmt::ptr(op.dst),
+                                  op.dst_agent.handle,
+                                  op.src_size,
+                                  op.dst_size,
+                                  wait,
+                                  signal,
+                                  reserved);
+
+        case detail::to_underlying(HSA_AMD_MEMORY_COPY_OP_LINEAR):
+            if(is_linear_multi)
+            {
+                return fmt::format_to(
+                    ctx.out(),
+                    "[MEMORY_COPY_OP type={}, version={}, num_dsts={}, traffic_class={}, "
+                    "completion_signal={}, src_list={}, src_agent={}, dst_list={}, "
+                    "dst_agent_list={}, size_list={}{}{}{}]",
+                    type,
+                    op.version,
+                    op.num_dsts,
+                    op.traffic_class,
+                    op.completion_signal.handle,
+                    fmt::ptr(op.src_list),
+                    op.src_agent.handle,
+                    fmt::ptr(op.dst_list),
+                    fmt::ptr(op.dst_agent_list),
+                    fmt::ptr(op.size_list),
+                    wait,
+                    signal,
+                    reserved);
+            }
+            return fmt::format_to(ctx.out(),
+                                  "[MEMORY_COPY_OP type={}, version={}, num_dsts={}, "
+                                  "traffic_class={}, completion_signal={}, src={}, "
+                                  "src_agent={}, dst={}, dst_agent={}, size={}, "
+                                  "unused_size={}{}{}{}]",
+                                  type,
+                                  op.version,
+                                  op.num_dsts,
+                                  op.traffic_class,
+                                  op.completion_signal.handle,
+                                  fmt::ptr(op.src),
+                                  op.src_agent.handle,
+                                  fmt::ptr(op.dst),
+                                  op.dst_agent.handle,
+                                  op.size,
+                                  op.unused_size,
+                                  wait,
+                                  signal,
+                                  reserved);
+
+        case detail::hsa_amd_memory_copy_op_linear_indirect_src_value:
+        case detail::hsa_amd_memory_copy_op_linear_indirect_dst_value:
+        case detail::hsa_amd_memory_copy_op_linear_indirect_srcdst_value:
+            return fmt::format_to(ctx.out(),
+                                  "[MEMORY_COPY_OP type={}, version={}, num_dsts={}, "
+                                  "traffic_class={}, completion_signal={}, src={}, "
+                                  "src_agent={}, dst={}, dst_agent={}, size={}, "
+                                  "unused_size={}{}{}{}]",
+                                  type,
+                                  op.version,
+                                  op.num_dsts,
+                                  op.traffic_class,
+                                  op.completion_signal.handle,
+                                  fmt::ptr(op.src),
+                                  op.src_agent.handle,
+                                  fmt::ptr(op.dst),
+                                  op.dst_agent.handle,
+                                  op.size,
+                                  op.unused_size,
+                                  wait,
+                                  signal,
+                                  reserved);
+    }
+
+    ROCP_CI_LOG(INFO) << fmt::format("Unknown hsa_amd_memory_copy_op_type_t {}", type_value);
+    return fmt::format_to(
+        ctx.out(), "[MEMORY_COPY_OP type=hsa_amd_memory_copy_op_type_t({})]", type_value);
+}
+
+template <typename CopyOpT, typename FormatContext>
+auto
+format_memory_copy_op(CopyOpT const& op, FormatContext& ctx, std::false_type)
+{
+    auto out = fmt::format_to(ctx.out(),
+                              "[MEMORY_COPY_OP type={}, version={}, num_dsts={}, "
+                              "traffic_class={}, completion_signal={}",
+                              op.type,
+                              op.version,
+                              op.num_dsts,
+                              op.traffic_class,
+                              op.completion_signal.handle);
+
+    switch(op.type)
+    {
+        case HSA_AMD_MEMORY_COPY_OP_LINEAR_BROADCAST:
+            out = fmt::format_to(out,
+                                 ", src={}, src_agent={}, dst_list={}, dst_agent_list={}, "
+                                 "size={}",
+                                 fmt::ptr(op.src),
+                                 op.src_agent.handle,
+                                 fmt::ptr(op.dst_list),
+                                 fmt::ptr(op.dst_agent_list),
+                                 op.size);
+            break;
+
+        case HSA_AMD_MEMORY_COPY_OP_LINEAR_SWAP:
+            out = fmt::format_to(out,
+                                 ", src={}, src_agent={}, dst={}, dst_agent={}, "
+                                 "src_size={}, dst_size={}",
+                                 fmt::ptr(op.src),
+                                 op.src_agent.handle,
+                                 fmt::ptr(op.dst),
+                                 op.dst_agent.handle,
+                                 op.src_size,
+                                 op.dst_size);
+            break;
+
+        case HSA_AMD_MEMORY_COPY_OP_LINEAR:
+        default:
+            out = fmt::format_to(out,
+                                 ", src={}, src_agent={}, dst={}, dst_agent={}, size={}, "
+                                 "unused_size={}",
+                                 fmt::ptr(op.src),
+                                 op.src_agent.handle,
+                                 fmt::ptr(op.dst),
+                                 op.dst_agent.handle,
+                                 op.size,
+                                 op.unused_size);
+            break;
+    }
+
+    if(op.reserved[0] != 0 || op.reserved[1] != 0 || op.reserved[2] != 0)
+    {
+        out = fmt::format_to(
+            out, ", reserved=[{},{},{}]", op.reserved[0], op.reserved[1], op.reserved[2]);
+    }
+
+    return fmt::format_to(out, "]");
+}
+}  // namespace detail
+
 template <>
 struct formatter<hsa_ext_amd_aql_pm4_packet_t>
 {
@@ -203,23 +444,42 @@ struct formatter<hsa_amd_memory_copy_op_type_t>
     template <typename FormatContext>
     auto format(hsa_amd_memory_copy_op_type_t const& op, FormatContext& ctx) const
     {
-        switch(op)
+        auto value = detail::to_underlying(op);
+        switch(value)
         {
-            case HSA_AMD_MEMORY_COPY_OP_LINEAR:
+            case detail::to_underlying(HSA_AMD_MEMORY_COPY_OP_LINEAR):
                 return fmt::format_to(ctx.out(), "HSA_AMD_MEMORY_COPY_OP_LINEAR");
-            case HSA_AMD_MEMORY_COPY_OP_LINEAR_BROADCAST:
+            case detail::to_underlying(HSA_AMD_MEMORY_COPY_OP_LINEAR_BROADCAST):
                 return fmt::format_to(ctx.out(), "HSA_AMD_MEMORY_COPY_OP_LINEAR_BROADCAST");
-            case HSA_AMD_MEMORY_COPY_OP_LINEAR_SWAP:
+            case detail::to_underlying(HSA_AMD_MEMORY_COPY_OP_LINEAR_SWAP):
                 return fmt::format_to(ctx.out(), "HSA_AMD_MEMORY_COPY_OP_LINEAR_SWAP");
-            case HSA_AMD_MEMORY_COPY_OP_LINEAR_INDIRECT_SRC:
-                return fmt::format_to(ctx.out(), "HSA_AMD_MEMORY_COPY_OP_LINEAR_INDIRECT_SRC");
-            case HSA_AMD_MEMORY_COPY_OP_LINEAR_INDIRECT_DST:
-                return fmt::format_to(ctx.out(), "HSA_AMD_MEMORY_COPY_OP_LINEAR_INDIRECT_DST");
-            case HSA_AMD_MEMORY_COPY_OP_LINEAR_INDIRECT_SRCDST:
-                return fmt::format_to(ctx.out(), "HSA_AMD_MEMORY_COPY_OP_LINEAR_INDIRECT_SRCDST");
+            default:
+            {
+                if constexpr(detail::has_extended_memory_copy_op_layout<
+                                 hsa_amd_memory_copy_op_t>::value)
+                {
+                    switch(value)
+                    {
+                        case detail::hsa_amd_memory_copy_op_linear_indirect_src_value:
+                            return fmt::format_to(
+                                ctx.out(), "HSA_AMD_MEMORY_COPY_OP_LINEAR_INDIRECT_SRC");
+                        case detail::hsa_amd_memory_copy_op_linear_indirect_dst_value:
+                            return fmt::format_to(
+                                ctx.out(), "HSA_AMD_MEMORY_COPY_OP_LINEAR_INDIRECT_DST");
+                        case detail::hsa_amd_memory_copy_op_linear_indirect_srcdst_value:
+                            return fmt::format_to(
+                                ctx.out(), "HSA_AMD_MEMORY_COPY_OP_LINEAR_INDIRECT_SRCDST");
+                        default: break;
+                    }
+                }
+                else if(value == detail::hsa_amd_memory_copy_op_linear_indirect_src_value)
+                {
+                    return fmt::format_to(ctx.out(), "HSA_AMD_MEMORY_COPY_OP_LINEAR_INDIRECT");
+                }
+                break;
+            }
         }
 
-        auto value = static_cast<std::underlying_type_t<hsa_amd_memory_copy_op_type_t>>(op);
         ROCP_CI_LOG(INFO) << fmt::format("Unknown hsa_amd_memory_copy_op_type_t {}", value);
         return fmt::format_to(ctx.out(), "hsa_amd_memory_copy_op_type_t({})", value);
     }
@@ -237,158 +497,8 @@ struct formatter<hsa_amd_memory_copy_op_t>
     template <typename FormatContext>
     auto format(hsa_amd_memory_copy_op_t const& op, FormatContext& ctx) const
     {
-        auto reserved = std::string{};
-        if(op.reserved1[0] != 0)
-        {
-            reserved = fmt::format(", reserved1=[{}]", op.reserved1[0]);
-        }
-
-        auto wait = std::string{};
-        if(op.wait.function != 0 || op.wait.scope != 0 || op.wait.reserved != 0 ||
-           op.wait.addr != nullptr || op.wait.value != 0 || op.wait.mask != 0)
-        {
-            wait = fmt::format(
-                ", wait={{function={}, scope={}, reserved={}, addr={}, value={}, mask={}}}",
-                op.wait.function,
-                op.wait.scope,
-                op.wait.reserved,
-                fmt::ptr(op.wait.addr),
-                op.wait.value,
-                op.wait.mask);
-        }
-
-        auto signal = std::string{};
-        if(op.signal.operation != 0 || op.signal.scope != 0 || op.signal.reserved != 0 ||
-           op.signal.addr != nullptr || op.signal.data != 0)
-        {
-            signal =
-                fmt::format(", signal={{operation={}, scope={}, reserved={}, addr={}, data={}}}",
-                            op.signal.operation,
-                            op.signal.scope,
-                            op.signal.reserved,
-                            fmt::ptr(op.signal.addr),
-                            op.signal.data);
-        }
-
-        auto       type            = static_cast<hsa_amd_memory_copy_op_type_t>(op.type);
-        const bool is_linear_multi = (type == HSA_AMD_MEMORY_COPY_OP_LINEAR && op.num_dsts > 0);
-        if(is_linear_multi && op.reserved0 != 0)
-        {
-            reserved += fmt::format(", reserved0={}", op.reserved0);
-        }
-
-        switch(type)
-        {
-            case HSA_AMD_MEMORY_COPY_OP_LINEAR_BROADCAST:
-                return fmt::format_to(
-                    ctx.out(),
-                    "[MEMORY_COPY_OP type={}, version={}, num_dsts={}, traffic_class={}, "
-                    "completion_signal={}, src={}, src_agent={}, dst_list={}, "
-                    "dst_agent_list={}, size={}{}{}{}]",
-                    type,
-                    op.version,
-                    op.num_dsts,
-                    op.traffic_class,
-                    op.completion_signal.handle,
-                    fmt::ptr(op.src),
-                    op.src_agent.handle,
-                    fmt::ptr(op.dst_list),
-                    fmt::ptr(op.dst_agent_list),
-                    op.size,
-                    wait,
-                    signal,
-                    reserved);
-
-            case HSA_AMD_MEMORY_COPY_OP_LINEAR_SWAP:
-                return fmt::format_to(
-                    ctx.out(),
-                    "[MEMORY_COPY_OP type={}, version={}, num_dsts={}, traffic_class={}, "
-                    "completion_signal={}, src={}, src_agent={}, dst={}, dst_agent={}, "
-                    "src_size={}, dst_size={}{}{}{}]",
-                    type,
-                    op.version,
-                    op.num_dsts,
-                    op.traffic_class,
-                    op.completion_signal.handle,
-                    fmt::ptr(op.src),
-                    op.src_agent.handle,
-                    fmt::ptr(op.dst),
-                    op.dst_agent.handle,
-                    op.src_size,
-                    op.dst_size,
-                    wait,
-                    signal,
-                    reserved);
-
-            case HSA_AMD_MEMORY_COPY_OP_LINEAR:
-                if(is_linear_multi)
-                {
-                    return fmt::format_to(
-                        ctx.out(),
-                        "[MEMORY_COPY_OP type={}, version={}, num_dsts={}, traffic_class={}, "
-                        "completion_signal={}, src_list={}, src_agent={}, dst_list={}, "
-                        "dst_agent_list={}, size_list={}{}{}{}]",
-                        type,
-                        op.version,
-                        op.num_dsts,
-                        op.traffic_class,
-                        op.completion_signal.handle,
-                        fmt::ptr(op.src_list),
-                        op.src_agent.handle,
-                        fmt::ptr(op.dst_list),
-                        fmt::ptr(op.dst_agent_list),
-                        fmt::ptr(op.size_list),
-                        wait,
-                        signal,
-                        reserved);
-                }
-                return fmt::format_to(
-                    ctx.out(),
-                    "[MEMORY_COPY_OP type={}, version={}, num_dsts={}, traffic_class={}, "
-                    "completion_signal={}, src={}, src_agent={}, dst={}, dst_agent={}, "
-                    "size={}, unused_size={}{}{}{}]",
-                    type,
-                    op.version,
-                    op.num_dsts,
-                    op.traffic_class,
-                    op.completion_signal.handle,
-                    fmt::ptr(op.src),
-                    op.src_agent.handle,
-                    fmt::ptr(op.dst),
-                    op.dst_agent.handle,
-                    op.size,
-                    op.unused_size,
-                    wait,
-                    signal,
-                    reserved);
-            case HSA_AMD_MEMORY_COPY_OP_LINEAR_INDIRECT_SRC:
-            case HSA_AMD_MEMORY_COPY_OP_LINEAR_INDIRECT_DST:
-            case HSA_AMD_MEMORY_COPY_OP_LINEAR_INDIRECT_SRCDST:
-                return fmt::format_to(
-                    ctx.out(),
-                    "[MEMORY_COPY_OP type={}, version={}, num_dsts={}, traffic_class={}, "
-                    "completion_signal={}, src={}, src_agent={}, dst={}, dst_agent={}, "
-                    "size={}, unused_size={}{}{}{}]",
-                    type,
-                    op.version,
-                    op.num_dsts,
-                    op.traffic_class,
-                    op.completion_signal.handle,
-                    fmt::ptr(op.src),
-                    op.src_agent.handle,
-                    fmt::ptr(op.dst),
-                    op.dst_agent.handle,
-                    op.size,
-                    op.unused_size,
-                    wait,
-                    signal,
-                    reserved);
-        }
-
-        auto value = static_cast<std::underlying_type_t<hsa_amd_memory_copy_op_type_t>>(op.type);
-        ROCP_CI_LOG(INFO) << fmt::format("Unknown hsa_amd_memory_copy_op_type_t {}", value);
-        return fmt::format_to(
-            ctx.out(), "[MEMORY_COPY_OP type=hsa_amd_memory_copy_op_type_t({})]", value);
+        return detail::format_memory_copy_op(
+            op, ctx, detail::has_extended_memory_copy_op_layout<hsa_amd_memory_copy_op_t>{});
     }
 };
 #endif

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/hsa/queue.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/hsa/queue.cpp
@@ -44,8 +44,11 @@
 #include <hsa/hsa.h>
 #include <hsa/hsa_ext_amd.h>
 
+#include <algorithm>
 #include <atomic>
+#include <chrono>
 #include <memory>
+#include <thread>
 
 // static assert for rocprofiler_packet ABI compatibility
 static_assert(sizeof(hsa_ext_amd_aql_pm4_packet_t) == sizeof(hsa_kernel_dispatch_packet_t),
@@ -96,20 +99,70 @@ context_filter(const context::context* ctx)
             context_filter(ctx, ROCPROFILER_CALLBACK_TRACING_KERNEL_DISPATCH));
 }
 
-bool
-AsyncSignalHandler(hsa_signal_value_t /*signal_v*/, void* data)
+struct async_signal_handler_data
 {
-    if(!data) return true;
+    std::shared_ptr<Queue::queue_info_session_t> session = {};
+    Queue*                                       owner   = nullptr;
+    std::atomic<bool>                            handled = false;
+};
 
-    // if we have fully finalized, delete the data and return
-    if(registration::get_fini_status() > 0)
-    {
-        auto* _session = static_cast<Queue::queue_info_session_t**>(data);
-        delete _session;
-        return false;
-    }
+auto&
+get_async_signal_handler_data_map()
+{
+    static auto _v = common::Synchronized<
+        std::unordered_map<void*, std::shared_ptr<async_signal_handler_data>>>{};
+    return _v;
+}
 
-    auto& shared_ptr_info    = *static_cast<std::shared_ptr<Queue::queue_info_session_t>*>(data);
+void
+register_async_signal_handler_data(const std::shared_ptr<async_signal_handler_data>& data)
+{
+    get_async_signal_handler_data_map().wlock([&](auto& map) { map.emplace(data.get(), data); });
+}
+
+std::shared_ptr<async_signal_handler_data>
+acquire_async_signal_handler_data(void* data)
+{
+    return get_async_signal_handler_data_map().wlock([&](auto& map) {
+        auto itr = map.find(data);
+        if(itr == map.end()) return std::shared_ptr<async_signal_handler_data>{};
+
+        auto ret = itr->second;
+        if(!ret || ret->handled.exchange(true, std::memory_order_acq_rel))
+        {
+            return std::shared_ptr<async_signal_handler_data>{};
+        }
+
+        return ret;
+    });
+}
+
+void
+drain_async_signal_handler_data(const Queue& queue)
+{
+    get_async_signal_handler_data_map().wlock([&](auto& map) {
+        for(auto itr = map.begin(); itr != map.end();)
+        {
+            auto& entry = itr->second;
+            if(entry && entry->owner == &queue &&
+               entry->handled.load(std::memory_order_acquire))
+            {
+                itr = map.erase(itr);
+            }
+            else
+            {
+                ++itr;
+            }
+        }
+    });
+}
+
+void
+ProcessDispatchCompletion(std::shared_ptr<Queue::queue_info_session_t>& shared_ptr_info,
+                          bool                                          retire_signals)
+{
+    if(!shared_ptr_info) return;
+
     auto& queue_info_session = *shared_ptr_info;
 
     auto dispatch_time = kernel_dispatch::get_dispatch_time(queue_info_session);
@@ -142,17 +195,24 @@ AsyncSignalHandler(hsa_signal_value_t /*signal_v*/, void* data)
     if(queue_info_session.interrupt_signal.handle != 0u)
     {
 #if !defined(NDEBUG)
-        CHECK_NOTNULL(hsa::get_queue_controller())->_debug_signals.wlock([&](auto& signals) {
-            signals.erase(queue_info_session.interrupt_signal.handle);
-        });
+        if(retire_signals)
+        {
+            CHECK_NOTNULL(hsa::get_queue_controller())->_debug_signals.wlock([&](auto& signals) {
+                signals.erase(queue_info_session.interrupt_signal.handle);
+            });
+        }
 #endif
         hsa::get_core_table()->hsa_signal_store_screlease_fn(queue_info_session.interrupt_signal,
                                                              -1);
-        hsa::get_core_table()->hsa_signal_destroy_fn(queue_info_session.interrupt_signal);
+        if(retire_signals)
+        {
+            queue_info_session.queue.retire_signal(queue_info_session.interrupt_signal);
+        }
     }
-    if(queue_info_session.kernel_pkt.ext_amd_aql_pm4.completion_signal.handle != 0u)
+    if(retire_signals &&
+       queue_info_session.kernel_pkt.ext_amd_aql_pm4.completion_signal.handle != 0u)
     {
-        hsa::get_core_table()->hsa_signal_destroy_fn(
+        queue_info_session.queue.retire_signal(
             queue_info_session.kernel_pkt.ext_amd_aql_pm4.completion_signal);
     }
 
@@ -168,7 +228,25 @@ AsyncSignalHandler(hsa_signal_value_t /*signal_v*/, void* data)
     }
 
     queue_info_session.queue.async_complete();
-    delete &shared_ptr_info;
+    shared_ptr_info.reset();
+}
+
+bool
+AsyncSignalHandler(hsa_signal_value_t /*signal_v*/, void* data)
+{
+    if(!data) return true;
+
+    auto handler_data = acquire_async_signal_handler_data(data);
+    if(!handler_data) return false;
+
+    // if we have fully finalized, discard the retained session and return
+    if(registration::get_fini_status() > 0)
+    {
+        handler_data->session.reset();
+        return false;
+    }
+
+    ProcessDispatchCompletion(handler_data->session, true);
 
     return false;
 }
@@ -232,6 +310,23 @@ WriteInterceptor(const void* packets,
     ROCP_FATAL_IF(data == nullptr) << "WriteInterceptor was not passed a pointer to the queue";
 
     auto& queue = *static_cast<Queue*>(data);
+    // Graph replay can keep ROCr async-handler bookkeeping alive briefly after a dispatch
+    // completes. Retire completion signals in the callback and only reclaim them once the queue
+    // is fully idle.
+    if(queue.active_interceptors() == 0 && queue.active_async_packets() == 0)
+    {
+        drain_async_signal_handler_data(queue);
+        queue.drain_retired_signals();
+    }
+    queue.interceptor_started();
+    auto _interceptor_dtor =
+        common::scope_destructor{[&queue]() { queue.interceptor_complete(); }};
+
+    if(queue.get_state() != queue_state::normal)
+    {
+        writer(packets, pkt_count);
+        return;
+    }
 
     // We have no packets or no one who needs to be notified, do nothing.
     if(pkt_count == 0 ||
@@ -273,23 +368,17 @@ WriteInterceptor(const void* packets,
         auto*                    corr_id      = context::get_latest_correlation_id();
         context::correlation_id* _corr_id_pop = nullptr;
 
-        if(!corr_id)
+        // Graph replay and other queue writes can be intercepted on the HSA async event thread,
+        // outside any active host API scope. In that case we still want the dispatch trace, but
+        // synthesizing a fresh correlation ID per dispatch here adds allocator pressure on the
+        // async thread and is not required for kernel trace collection.
+        if(corr_id)
         {
-            constexpr auto ref_count = 1;
-            corr_id                  = context::correlation_tracing_service::construct(ref_count);
-            _corr_id_pop             = corr_id;
+            // increase the reference count to denote that this correlation id is being used in a
+            // kernel
+            corr_id->add_ref_count();
+            corr_id->add_kern_count();
         }
-
-        if(!corr_id)
-        {
-            // During finalization - just write packet through without tracing
-            transformed_packets.emplace_back(packets_arr[i]);
-            continue;
-        }
-
-        // increase the reference count to denote that this correlation id is being used in a kernel
-        corr_id->add_ref_count();
-        corr_id->add_kern_count();
 
         auto thr_id           = (corr_id) ? corr_id->thread_idx : common::get_tid();
         auto user_data        = rocprofiler_user_data_t{.value = 0};
@@ -321,10 +410,6 @@ WriteInterceptor(const void* packets,
 
         // Copy kernel pkt, copy is to allow for signal to be modified
         rocprofiler_packet kernel_pkt = packets_arr[i];
-        // create our own signal that we can get a callback on. if there is an original completion
-        // signal we will create a barrier packet, assign the original completion signal that that
-        // barrier packet, and add it right after the kernel packet
-        queue.create_signal(0, &kernel_pkt.kernel_dispatch.completion_signal);
 
         // computes the "size" based on the offset of reserved_padding field
         constexpr auto kernel_dispatch_info_rt_size =
@@ -417,6 +502,16 @@ WriteInterceptor(const void* packets,
             }
         }
 
+        const bool injected_end_pkt =
+            std::any_of(inst_pkt.begin(), inst_pkt.end(), [](const auto& pkt_injection) {
+                return !pkt_injection.first->after_krn_pkt.empty();
+            });
+
+        // create our own signal that we can get a callback on. if there is an original
+        // completion signal we will create a barrier packet, assign the original completion
+        // signal that that barrier packet, and add it right after the kernel packet
+        queue.create_signal(0, &kernel_pkt.kernel_dispatch.completion_signal);
+
 #if ROCPROFILER_SDK_HSA_PC_SAMPLING > 0
         if(pc_sampling::is_pc_sample_service_configured(queue.get_agent().get_rocp_agent()->id))
         {
@@ -441,13 +536,11 @@ WriteInterceptor(const void* packets,
             transformed_packets.emplace_back(barrier);
         }
 
-        bool injected_end_pkt = false;
         for(const auto& pkt_injection : inst_pkt)
         {
             for(const auto& pkt : pkt_injection.first->after_krn_pkt)
             {
                 transformed_packets.emplace_back(pkt);
-                injected_end_pkt = true;
             }
         }
 
@@ -487,9 +580,12 @@ WriteInterceptor(const void* packets,
                                                      .is_serialized    = bRequest_Serialize};
 
             auto shared = std::make_shared<Queue::queue_info_session_t>(std::move(info_session));
+            auto async_handler_data = std::make_shared<async_signal_handler_data>();
+            async_handler_data->session = shared;
+            async_handler_data->owner   = &queue;
+            register_async_signal_handler_data(async_handler_data);
 
-            queue.signal_async_handler(completion_signal,
-                                       new std::shared_ptr<Queue::queue_info_session_t>(shared));
+            queue.signal_async_handler(completion_signal, async_handler_data.get());
 
             auto tracer_data = callback_record;
             tracing::execute_phase_exit_callbacks(tracing_data_v.callback_contexts,
@@ -672,13 +768,60 @@ Queue::create_signal(uint32_t attribute, hsa_signal_t* signal) const
 }
 
 void
+Queue::retire_signal(hsa_signal_t signal) const
+{
+    if(signal.handle == 0u) return;
+    std::lock_guard<std::mutex> lk{_retired_signals_mutex};
+    _retired_signals.emplace_back(signal);
+}
+
+void
+Queue::drain_retired_signals() const
+{
+    auto pending = std::vector<hsa_signal_t>{};
+    {
+        std::lock_guard<std::mutex> lk{_retired_signals_mutex};
+        pending.swap(_retired_signals);
+    }
+
+    for(const auto& signal : pending)
+    {
+        _core_api.hsa_signal_destroy_fn(signal);
+    }
+}
+
+void
 Queue::sync() const
 {
-    if(_active_kernels.handle != 0u)
+    if(_active_kernels.handle == 0u) return;
+
+    constexpr auto wait_timeout =
+        std::chrono::duration_cast<std::chrono::nanoseconds>(std::chrono::milliseconds{1})
+            .count();
+
+    while(true)
     {
-        _core_api.hsa_signal_wait_relaxed_fn(
-            _active_kernels, HSA_SIGNAL_CONDITION_EQ, 0, UINT64_MAX, HSA_WAIT_STATE_ACTIVE);
+        const auto interceptors = active_interceptors();
+        const auto kernels      = _core_api.hsa_signal_load_scacquire_fn(_active_kernels);
+
+        if(interceptors == 0 && kernels == 0) break;
+
+        if(kernels != 0)
+        {
+            _core_api.hsa_signal_wait_relaxed_fn(_active_kernels,
+                                                 HSA_SIGNAL_CONDITION_EQ,
+                                                 0,
+                                                 wait_timeout,
+                                                 HSA_WAIT_STATE_ACTIVE);
+        }
+        else
+        {
+            std::this_thread::yield();
+        }
     }
+
+    drain_async_signal_handler_data(*this);
+    drain_retired_signals();
 }
 
 void
@@ -702,13 +845,13 @@ Queue::remove_callback(ClientID id)
 queue_state
 Queue::get_state() const
 {
-    return _state;
+    return _state.load(std::memory_order_acquire);
 }
 
 void
-Queue::set_state(queue_state state)
+Queue::set_state(queue_state state) const
 {
-    _state = state;
+    _state.store(state, std::memory_order_release);
 }
 }  // namespace hsa
 }  // namespace rocprofiler

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/hsa/queue.hpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/hsa/queue.hpp
@@ -43,10 +43,14 @@
 #include <hsa/hsa_ven_amd_loader.h>
 
 #include <atomic>
+#include <condition_variable>
 #include <cstdint>
 #include <functional>
 #include <memory>
+#include <mutex>
+#include <thread>
 #include <unordered_map>
+#include <vector>
 
 namespace rocprofiler
 {
@@ -128,6 +132,8 @@ public:
 
     void create_signal(uint32_t attribute, hsa_signal_t* signal) const;
     void signal_async_handler(const hsa_signal_t& signal, void* data) const;
+    void retire_signal(hsa_signal_t signal) const;
+    void drain_retired_signals() const;
 
     template <typename FuncT>
     void signal_callback(FuncT&& func) const;
@@ -143,8 +149,20 @@ public:
     // Tracks the number of in flight kernel executions we
     // are waiting on. We cannot destroy Queue until all kernels
     // have comleted.
-    void    async_started() { _core_api.hsa_signal_add_relaxed_fn(_active_kernels, 1); }
-    void    async_complete() { _core_api.hsa_signal_subtract_relaxed_fn(_active_kernels, 1); }
+    void    interceptor_started()
+    {
+        _active_async_packets.fetch_add(1, std::memory_order_acq_rel);
+    }
+    void interceptor_complete()
+    {
+        _active_async_packets.fetch_sub(1, std::memory_order_acq_rel);
+    }
+    int64_t active_interceptors() const
+    {
+        return _active_async_packets.load(std::memory_order_acquire);
+    }
+    void async_started() { _core_api.hsa_signal_add_relaxed_fn(_active_kernels, 1); }
+    void async_complete() { _core_api.hsa_signal_subtract_relaxed_fn(_active_kernels, 1); }
     int64_t active_async_packets() const
     {
         return _core_api.hsa_signal_load_scacquire_fn(_active_kernels);
@@ -161,7 +179,7 @@ public:
     hsa_signal_t                    block_signal;
     hsa_signal_t                    ready_signal;
     queue_state                     get_state() const;
-    void                            set_state(queue_state state);
+    void                            set_state(queue_state state) const;
 
 private:
     std::atomic<int>                     _notifiers            = {0};
@@ -171,7 +189,9 @@ private:
     const AgentCache&                    _agent;
     common::Synchronized<callback_map_t> _callbacks       = {};
     hsa_queue_t*                         _intercept_queue = nullptr;
-    queue_state                          _state           = queue_state::normal;
+    mutable std::atomic<queue_state>     _state           = queue_state::normal;
+    mutable std::mutex                   _retired_signals_mutex;
+    mutable std::vector<hsa_signal_t>    _retired_signals = {};
     std::mutex                           _lock_queue;
     hsa_signal_t                         _active_kernels = {.handle = 0};
 };

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/hsa/queue_controller.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/hsa/queue_controller.cpp
@@ -232,6 +232,7 @@ QueueController::destroy_queue(hsa_queue_t* id)
 
     ROCP_INFO << "destroying queue...";
 
+    queue->set_state(queue_state::to_destroy);
     queue->sync();
     if(queue->block_signal.handle != 0) get_core_table().hsa_signal_destroy_fn(queue->block_signal);
     _queues.wlock([&](auto& map) { map.erase(id); });

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/registration.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/registration.cpp
@@ -1059,16 +1059,24 @@ rocprofiler_force_configure(rocprofiler_configure_func_t configure_func)
     forced_config = configure_func;
     rocprofiler::registration::initialize();
 
-    // Trigger re-propagation of all registered API tables via rocprofiler-register.
-    // This enables late-start profiling where runtimes may have already initialized
-    // and registered their API tables before rocprofiler-sdk was loaded.
-    auto status = rocprofiler::registration::late::invoke_register_propagation();
-    if(status != ROCPROFILER_STATUS_SUCCESS)
+    // Late-start API-table re-propagation regressed kernel-trace stability for HIP-graph
+    // workloads in local validation. Keep it opt-in until the registration lifetime issue
+    // is resolved.
+    auto enable_late_register_propagation =
+        rocprofiler::common::get_env("ROCPROFILER_ENABLE_LATE_REGISTER_PROPAGATION", false);
+    if(enable_late_register_propagation)
     {
-        ROCP_WARNING << "Failed to invoke rocprofiler-register propagation. "
-                     << "This is normal if runtimes have not initialized yet, or if "
-                     << "rocprofiler-register is not loaded. Runtimes that initialize "
-                     << "after this call will be automatically profiled.";
+        // Trigger re-propagation of all registered API tables via rocprofiler-register.
+        // This enables late-start profiling where runtimes may have already initialized
+        // and registered their API tables before rocprofiler-sdk was loaded.
+        auto status = rocprofiler::registration::late::invoke_register_propagation();
+        if(status != ROCPROFILER_STATUS_SUCCESS)
+        {
+            ROCP_WARNING << "Failed to invoke rocprofiler-register propagation. "
+                         << "This is normal if runtimes have not initialized yet, or if "
+                         << "rocprofiler-register is not loaded. Runtimes that initialize "
+                         << "after this call will be automatically profiled.";
+        }
     }
 
     return ROCPROFILER_STATUS_SUCCESS;

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/inc/runtime.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/inc/runtime.h
@@ -50,6 +50,7 @@
 #include <memory>
 #include <tuple>
 #include <utility>
+#include <atomic>
 #include <thread>
 #include <shared_mutex>
 #if defined(__linux__)
@@ -583,6 +584,8 @@ class Runtime {
     AsyncEventsControl(AsyncEventsInfo *asyncInfo);
     void Start();
     void Shutdown();
+    bool RequestWake();
+    void ResetWake();
 
     hsa_signal_t wake;
     bool exit;
@@ -590,12 +593,14 @@ class Runtime {
     private:
     AsyncEventsInfo* info_;
     os::Thread thread_;
+    std::atomic<bool> wake_pending_;
  };
 
   struct AsyncEvents {
     void PushBack(hsa_signal_t signal, hsa_signal_condition_t cond,
                   hsa_signal_value_t value, hsa_amd_signal_handler handler,
                   void* arg);
+    void Reserve(size_t size);
 
     void CopyIndex(size_t dst, size_t src);
 

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/runtime.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/runtime.cpp
@@ -842,8 +842,9 @@ hsa_status_t Runtime::SetAsyncSignalHandler(hsa_signal_t signal,
   struct AsyncEventsInfo* asyncInfo = exception ? (*asyncExceptions_).get() : (*asyncSignals_).get();
 
   asyncInfo->new_events.PushBack(signal, cond, value, handler, arg);
-
-  hsa_signal_handle(asyncInfo->control.wake)->StoreRelease(1);
+  if (asyncInfo->control.RequestWake()) {
+    hsa_signal_handle(asyncInfo->control.wake)->StoreRelease(1);
+  }
 
   return HSA_STATUS_SUCCESS;
 }
@@ -1896,6 +1897,7 @@ void Runtime::AsyncEventsLoop(void* _eventsInfo) {
     // Reset the control signal
     if (index == 0) {
       hsa_signal_handle(async_events_control_.wake)->StoreRelaxed(0);
+      async_events_control_.ResetWake();
     } else if (index != -1) {
       if (wait_any) {
         processEvent(index, value[0], wait_any);
@@ -1930,6 +1932,7 @@ void Runtime::AsyncEventsLoop(void* _eventsInfo) {
           if (CheckSignalCondition(value[0], async_events_.cond_[i], async_events_.value_[i])) {
             if (i == 0) {
               hsa_signal_handle(async_events_control_.wake)->StoreRelaxed(0);
+              async_events_control_.ResetWake();
             } else {
               if (!processEvent(i, value[0], wait_any)) {
                 i--;
@@ -1974,6 +1977,9 @@ void Runtime::AsyncEventsLoop(void* _eventsInfo) {
     std::vector<func_arg_t> functions;
     std::vector<AsyncEventItem> new_events;
     new_async_events_.GetAllEvents(new_events);
+    if (!new_events.empty()) {
+      async_events_.Reserve(async_events_.Size() + new_events.size());
+    }
     for (const auto& event : new_events) {
       if (event.signal.handle == 0) {
         functions.push_back(func_arg_t((void (*)(void*))event.handler, event.arg));
@@ -2392,11 +2398,19 @@ Runtime::AsyncEventsInfo::~AsyncEventsInfo() {
 }
 
 Runtime::AsyncEventsControl::AsyncEventsControl(AsyncEventsInfo *asyncInfo)
-  : info_(asyncInfo), exit(false) {
+  : exit(false), info_(asyncInfo), wake_pending_(false) {
 
   auto err = HSA::hsa_signal_create(0, 0, NULL, &wake);
   if (err != HSA_STATUS_SUCCESS)
     throw AMD::hsa_exception(HSA_STATUS_ERROR, "Failed to allocate async handler signal");
+}
+
+bool Runtime::AsyncEventsControl::RequestWake() {
+  return !wake_pending_.exchange(true, std::memory_order_acq_rel);
+}
+
+void Runtime::AsyncEventsControl::ResetWake() {
+  wake_pending_.store(false, std::memory_order_release);
 }
 
 void Runtime::AsyncEventsControl::Start() {
@@ -2931,6 +2945,14 @@ void Runtime::AsyncEvents::PushBack(hsa_signal_t signal,
   value_.push_back(value);
   handler_.push_back(handler);
   arg_.push_back(arg);
+}
+
+void Runtime::AsyncEvents::Reserve(size_t size) {
+  signal_.reserve(size);
+  cond_.reserve(size);
+  value_.reserve(size);
+  handler_.reserve(size);
+  arg_.reserve(size);
 }
 
 void Runtime::AsyncEvents::CopyIndex(size_t dst, size_t src) {


### PR DESCRIPTION
## Summary

This PR contains the local HIP graph / rocprof kernel-trace investigation stack:

- ROCm 7.13 memory-copy-op formatter compatibility in `rocprofiler-sdk`
- late register propagation gated behind an env var
- queue signal retirement deferred until queue idle in `rocprofiler-sdk`
- ROCR async signal wake coalescing and wake reset fixes

## Validation

The strongest local HIP graph reproducer used for validation was:

- `hip_graph_bubble_repro`
- `NUM_KERNELS=2000`
- `NUM_ITERATIONS=200`
- `--kernel-trace`
- `--output-format csv`

I also uploaded a secret gist with the before/after analysis and screenshot artifact. I will add that gist link in a PR comment after creation.
