### PR TITLE
Added ROCPROF_USE_SYS_YAML_CPP option to allow system-provided yaml-cpp

### DIFF
--- a/projects/rocprofiler-sdk/cmake/rocprofiler_config_interfaces.cmake
+++ b/projects/rocprofiler-sdk/cmake/rocprofiler_config_interfaces.cmake
@@ -391,3 +391,21 @@ else()
                                INTERFACE ROCPROFILER_SDK_USE_SYSTEM_ROCJPEG=0)
 
 endif()
+
+# ----------------------------------------------------------------------------------------#
+#
+# yaml-cpp
+#
+# ----------------------------------------------------------------------------------------#
+if (NOT ROCPROFILER_BUILD_YAML_CPP)
+    find_package(yaml-cpp CONFIG REQUIRED)
+endif()
+
+target_link_libraries(rocprofiler-sdk-yaml-cpp
+                      INTERFACE yaml-cpp::yaml-cpp)
+
+if (ROCPROFILER_BUILD_YAML_CPP)
+    target_include_directories(
+        rocprofiler-sdk-yaml-cpp
+        INTERFACE $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/external/yaml-cpp/include>)
+endif()

--- a/projects/rocprofiler-sdk/cmake/rocprofiler_options.cmake
+++ b/projects/rocprofiler-sdk/cmake/rocprofiler_options.cmake
@@ -59,6 +59,8 @@ rocprofiler_add_option(
 rocprofiler_add_option(ROCPROFILER_BUILD_FMT "Enable building fmt library internally" ON)
 rocprofiler_add_option(ROCPROFILER_BUILD_GLOG
                        "Enable building glog (Google logging) library internally" ON)
+rocprofiler_add_option(ROCPROFILER_BUILD_YAML_CPP
+        "Enable building yaml-cpp library" ON)
 rocprofiler_add_option(ROCPROFILER_BUILD_SQLITE3
                        "Enable building sqlite3 library internally" OFF)
 rocprofiler_add_option(ROCPROFILER_BUILD_PYBIND11

--- a/projects/rocprofiler-sdk/external/CMakeLists.txt
+++ b/projects/rocprofiler-sdk/external/CMakeLists.txt
@@ -131,6 +131,7 @@ if(NOT TARGET PTL::ptl-static)
     add_subdirectory(ptl EXCLUDE_FROM_ALL)
 endif()
 
+# Prefer system-provided yaml-cpp over vendored one
 rocprofiler_checkout_git_submodule(
     RECURSIVE
     RELATIVE_PATH external/yaml-cpp
@@ -138,25 +139,8 @@ rocprofiler_checkout_git_submodule(
     REPO_URL https://github.com/jbeder/yaml-cpp.git
     REPO_BRANCH "master")
 
-
-# Prefer system-provided yaml-cpp over vendored one
-option(ROCPROF_USE_SYS_YAML_CPP
-        "Use system-provided yaml-cpp instead of vendored external/yaml-cpp" ON)
-
-    if (ROCPROF_USE_SYS_YAML_CPP)
-        find_package(yaml-cpp CONFIG REQUIRED)
-    else()
-        add_subdirectory(yaml-cpp EXCLUDE_FROM_ALL)
-    endif()
-
-
-target_link_libraries(rocprofiler-sdk-yaml-cpp
-                      INTERFACE yaml-cpp::yaml-cpp)
-
-if (NOT ROCPROF_USE_SYS_YAML_CPP)
-    target_include_directories(
-        rocprofiler-sdk-yaml-cpp
-        INTERFACE $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/external/yaml-cpp/include>)
+if(ROCPROFILER_BUILD_YAML_CPP)
+    add_subdirectory(yaml-cpp EXCLUDE_FROM_ALL)
 endif()
 
 # checkout submodule if not already checked out or clone repo if no .gitmodules file

--- a/projects/rocprofiler-sdk/external/CMakeLists.txt
+++ b/projects/rocprofiler-sdk/external/CMakeLists.txt
@@ -138,13 +138,29 @@ rocprofiler_checkout_git_submodule(
     REPO_URL https://github.com/jbeder/yaml-cpp.git
     REPO_BRANCH "master")
 
-add_subdirectory(yaml-cpp EXCLUDE_FROM_ALL)
+
+# Prefer system-provided yaml-cpp over vendored one
+option(ROCPROF_USE_SYS_YAML_CPP
+        "Use system-provided yaml-cpp instead of vendored external/yaml-cpp" ON)
+
+    if (ROCPROF_USE_SYS_YAML_CPP)
+        set(CMAKE_FIND_PACKAGE_PREFER_CONFIG ON)
+        find_package(yaml-cpp CONFIG REQUIRED)
+    else()
+        if (NOT TARGET yaml-cpp)
+            add_subdirectory(yaml-cpp EXCLUDE_FROM_ALL)
+        endif()
+    endif()
+
 
 target_link_libraries(rocprofiler-sdk-yaml-cpp
-                      INTERFACE $<BUILD_INTERFACE:yaml-cpp::yaml-cpp>)
+                      INTERFACE yaml-cpp::yaml-cpp)
+
+if (NOT ROCPROF_USE_SYS_YAML_CPP)
 target_include_directories(
     rocprofiler-sdk-yaml-cpp
     INTERFACE $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/external/yaml-cpp/include>)
+endif()
 
 # checkout submodule if not already checked out or clone repo if no .gitmodules file
 rocprofiler_checkout_git_submodule(

--- a/projects/rocprofiler-sdk/external/CMakeLists.txt
+++ b/projects/rocprofiler-sdk/external/CMakeLists.txt
@@ -144,12 +144,9 @@ option(ROCPROF_USE_SYS_YAML_CPP
         "Use system-provided yaml-cpp instead of vendored external/yaml-cpp" ON)
 
     if (ROCPROF_USE_SYS_YAML_CPP)
-        set(CMAKE_FIND_PACKAGE_PREFER_CONFIG ON)
         find_package(yaml-cpp CONFIG REQUIRED)
     else()
-        if (NOT TARGET yaml-cpp)
-            add_subdirectory(yaml-cpp EXCLUDE_FROM_ALL)
-        endif()
+        add_subdirectory(yaml-cpp EXCLUDE_FROM_ALL)
     endif()
 
 
@@ -157,9 +154,9 @@ target_link_libraries(rocprofiler-sdk-yaml-cpp
                       INTERFACE yaml-cpp::yaml-cpp)
 
 if (NOT ROCPROF_USE_SYS_YAML_CPP)
-target_include_directories(
-    rocprofiler-sdk-yaml-cpp
-    INTERFACE $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/external/yaml-cpp/include>)
+    target_include_directories(
+        rocprofiler-sdk-yaml-cpp
+        INTERFACE $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/external/yaml-cpp/include>)
 endif()
 
 # checkout submodule if not already checked out or clone repo if no .gitmodules file


### PR DESCRIPTION

## Motivation

Partially solves:: [#3517](https://github.com/ROCm/TheRock/issues/3517)

TheRock already provides yaml-cpp as sysdep (similar to sqlite3, zstd, etc.). Without this option, rocprofiler-sdk always builds its own vendored copy, which conflicts with TheRock's dependency management and prevents it from supplying its own yaml-cpp.

This option gives TheRock the ability to opt out of the vendored copy and supply yaml-cpp externaly.

## Technical Details

Added `ROCPROF_USE_SYS_YAML_CPP` option into `projects/rocprofiler-sdk/external/CMakeLists.txt`. When enabled the build finds system yaml-cpp instead of building the vendored copy.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.

## Related 
- Upstream issue: https://github.com/ROCm/TheRock/issues/3517