### PR TITLE
clrDebug: Add DEBUG_HIP_DUMP_ACTIVITY_RECORDS 

### DIFF
--- a/projects/clr/rocclr/platform/activity.cpp
+++ b/projects/clr/rocclr/platform/activity.cpp
@@ -8,12 +8,81 @@
 #include "platform/command.hpp"
 #include "platform/commandqueue.hpp"
 #include "platform/command_utils.hpp"
+#include "os/os.hpp"
+#include "utils/flags.hpp"
 
 #include <atomic>
+#include <cstdio>
+#include <mutex>
+#include <string>
 
 namespace amd::activity_prof {
 
 decltype(report_activity) report_activity{nullptr};
+
+static FILE* activityDumpFile = nullptr;
+static std::once_flag activityDumpFileInitFlag;
+
+static const char* opIdToString(activity_op_t op) {
+  switch (op) {
+    case OP_ID_DISPATCH: return "DISPATCH";
+    case OP_ID_COPY:     return "COPY";
+    case OP_ID_BARRIER:  return "BARRIER";
+    default:             return "UNKNOWN";
+  }
+}
+
+static void DumpActivityRecord(const activity_record_t& record) {
+  std::call_once(activityDumpFileInitFlag, []() { InitActivityDumpFile(); });
+  if (activityDumpFile == nullptr) return;
+
+  const char* kindStr = getOclCommandKindString(static_cast<cl_command_type>(record.kind));
+  if (record.op == OP_ID_DISPATCH) {
+    fprintf(activityDumpFile,
+            "domain=%u kind=%s op=%s corr_id=%lu begin_ns=%lu end_ns=%lu "
+            "duration_ns=%lu device_id=%d queue_id=%lu kernel_name=%s\n",
+            record.domain, kindStr, opIdToString(record.op),
+            static_cast<unsigned long>(record.correlation_id),
+            static_cast<unsigned long>(record.begin_ns),
+            static_cast<unsigned long>(record.end_ns),
+            static_cast<unsigned long>(record.end_ns - record.begin_ns),
+            record.device_id,
+            static_cast<unsigned long>(record.queue_id),
+            record.kernel_name ? record.kernel_name : "(null)");
+  } else {
+    fprintf(activityDumpFile,
+            "domain=%u kind=%s op=%s corr_id=%lu begin_ns=%lu end_ns=%lu "
+            "duration_ns=%lu device_id=%d queue_id=%lu bytes=%zu\n",
+            record.domain, kindStr, opIdToString(record.op),
+            static_cast<unsigned long>(record.correlation_id),
+            static_cast<unsigned long>(record.begin_ns),
+            static_cast<unsigned long>(record.end_ns),
+            static_cast<unsigned long>(record.end_ns - record.begin_ns),
+            record.device_id,
+            static_cast<unsigned long>(record.queue_id),
+            record.bytes);
+  }
+  fflush(activityDumpFile);
+}
+
+void InitActivityDumpFile() {
+  if (flagIsDefault(DEBUG_HIP_DUMP_ACTIVITY_RECORDS)) return;
+  std::string fileName = DEBUG_HIP_DUMP_ACTIVITY_RECORDS;
+  if (fileName.empty()) return;
+  std::string pid = std::to_string(amd::Os::getProcessId());
+  fileName = fileName + "_" + pid;
+  activityDumpFile = fopen(fileName.c_str(), "a");
+  if (activityDumpFile == nullptr) {
+    activityDumpFile = fopen(("activity_records_" + pid + ".txt").c_str(), "a");
+  }
+}
+
+void TearDownActivityDumpFile() {
+  if (activityDumpFile != nullptr) {
+    fclose(activityDumpFile);
+    activityDumpFile = nullptr;
+  }
+}
 
 #if defined(__linux__)
 __thread activity_correlation_id_t correlation_id __attribute__((tls_model("initial-exec"))) = 0;
@@ -96,11 +165,13 @@ void ReportActivity(const amd::Command& command) {
       record.begin_ns = it.first;
       record.end_ns = it.second;
       record.kernel_name = kernel_names[i] != nullptr ? kernel_names[i]->c_str() : "";
+      DumpActivityRecord(record);
       function(ACTIVITY_DOMAIN_HIP_OPS, operation_id, &record);
     }
   } else {
     record.begin_ns = command.profilingInfo().start_;
     record.end_ns = command.profilingInfo().end_;
+    DumpActivityRecord(record);
     function(ACTIVITY_DOMAIN_HIP_OPS, operation_id, &record);
   }
 }

--- a/projects/clr/rocclr/platform/activity.hpp
+++ b/projects/clr/rocclr/platform/activity.hpp
@@ -62,6 +62,8 @@ constexpr OpId OperationId(cl_command_type commandType) {
 bool IsEnabled(OpId operation_id);
 void ReportActivity(const amd::Command& command);
 
+void InitActivityDumpFile();
+void TearDownActivityDumpFile();
 
 const char* getOclCommandKindString(cl_command_type kind);
 }  // namespace amd::activity_prof

--- a/projects/clr/rocclr/platform/runtime.cpp
+++ b/projects/clr/rocclr/platform/runtime.cpp
@@ -5,6 +5,7 @@
  */
 
 #include "platform/runtime.hpp"
+#include "platform/activity.hpp"
 #include "os/os.hpp"
 #include "thread/thread.hpp"
 #include "device/device.hpp"
@@ -83,6 +84,7 @@ void Runtime::tearDown() {
   Device::tearDown();
   option::teardown();
   Flag::tearDown();
+  amd::activity_prof::TearDownActivityDumpFile();
   if (outFile != stderr && outFile != nullptr) {
     fclose(outFile);
   }

--- a/projects/clr/rocclr/utils/flags.hpp
+++ b/projects/clr/rocclr/utils/flags.hpp
@@ -266,8 +266,10 @@ release(bool, HIP_FORCE_SPIRV_CODEOBJECT, false,                              \
         "Force use of SPIRV instead of device specific code object.")         \
 release(uint, DEBUG_CLR_BATCH_CPU_SYNC_SIZE, 8,                               \
         "Forces the minimum batch size for CPU sync")                         \
-release(bool, DEBUG_CLR_DISABLE_IMAGE, false,                               \
-        "1 = Disable Image support for ROC path")  // clang-format on
+release(bool, DEBUG_CLR_DISABLE_IMAGE, false,                                 \
+        "1 = Disable Image support for ROC path")                             \
+release(cstring, DEBUG_HIP_DUMP_ACTIVITY_RECORDS, "",                         \
+        "Dump activity records to file (per-process, PID appended)")  // clang-format on
 
 namespace amd {
 


### PR DESCRIPTION
Add env var to dump profiling activity. DEBUG_HIP_DUMP_ACTIVITY_RECORDS=records would generate records_pidxx 

Debug-only flag that writes each HIP activity record (dispatches, copies, barriers) as one line to a per-process file (<filename>_<pid>), following the same pattern as AMD_LOG_LEVEL_FILE.

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
