### PR TITLE
[rocprofiler-systems] Update actions used in workflows

### DIFF
--- a/.github/workflows/rocprofiler-systems-containers.yml
+++ b/.github/workflows/rocprofiler-systems-containers.yml
@@ -40,6 +40,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
   GIT_DISCOVERY_ACROSS_FILESYSTEM: 1
 
 jobs:
@@ -50,7 +51,7 @@ jobs:
       matrix_data: ${{ steps.generate_matrix_ci.outputs.matrix_data }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           sparse-checkout: projects/rocprofiler-systems/docker
 
@@ -71,7 +72,7 @@ jobs:
         include: ${{ fromJSON(needs.prepare_matrix_ci.outputs.matrix_data) }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           sparse-checkout: projects/rocprofiler-systems/docker
           submodules: recursive
@@ -132,7 +133,7 @@ jobs:
       matrix_data: ${{ steps.generate_matrix_release.outputs.matrix_data }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           sparse-checkout: projects/rocprofiler-systems
 
@@ -153,7 +154,7 @@ jobs:
         include: ${{ fromJSON(needs.prepare_matrix_release.outputs.matrix_data) }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           sparse-checkout: projects/rocprofiler-systems
 

--- a/.github/workflows/rocprofiler-systems-containers.yml
+++ b/.github/workflows/rocprofiler-systems-containers.yml
@@ -40,7 +40,6 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
   GIT_DISCOVERY_ACROSS_FILESYSTEM: 1
 
 jobs:

--- a/.github/workflows/rocprofiler-systems-containers.yml
+++ b/.github/workflows/rocprofiler-systems-containers.yml
@@ -77,13 +77,13 @@ jobs:
           submodules: recursive
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
+        uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # v4.0.0
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
 
       - name: Login to DockerHub
-        uses: docker/login-action@v2
+        uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2 # v4.0.0
         with:
           username: ${{ secrets.ROCPROF_SYS_DOCKER_LOGIN }}
           password: ${{ secrets.ROCPROF_SYS_DOCKER_TOKEN }}
@@ -158,13 +158,13 @@ jobs:
           sparse-checkout: projects/rocprofiler-systems
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
+        uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # v4.0.0
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
 
       - name: Login to DockerHub
-        uses: docker/login-action@v2
+        uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2 # v4.0.0
         with:
           username: ${{ secrets.ROCPROF_SYS_DOCKER_LOGIN }}
           password: ${{ secrets.ROCPROF_SYS_DOCKER_TOKEN }}

--- a/.github/workflows/rocprofiler-systems-containers.yml
+++ b/.github/workflows/rocprofiler-systems-containers.yml
@@ -51,7 +51,7 @@ jobs:
       matrix_data: ${{ steps.generate_matrix_ci.outputs.matrix_data }}
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         with:
           sparse-checkout: projects/rocprofiler-systems/docker
 
@@ -72,7 +72,7 @@ jobs:
         include: ${{ fromJSON(needs.prepare_matrix_ci.outputs.matrix_data) }}
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         with:
           sparse-checkout: projects/rocprofiler-systems/docker
           submodules: recursive
@@ -133,7 +133,7 @@ jobs:
       matrix_data: ${{ steps.generate_matrix_release.outputs.matrix_data }}
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         with:
           sparse-checkout: projects/rocprofiler-systems
 
@@ -154,7 +154,7 @@ jobs:
         include: ${{ fromJSON(needs.prepare_matrix_release.outputs.matrix_data) }}
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         with:
           sparse-checkout: projects/rocprofiler-systems
 

--- a/.github/workflows/rocprofiler-systems-continuous-integration.yml
+++ b/.github/workflows/rocprofiler-systems-continuous-integration.yml
@@ -53,6 +53,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
   ROCPROFSYS_CI: ON
   ROCPROFSYS_TMPDIR: "%env{PWD}%/testing-tmp"
   ROCM_PATH: "/opt/rocm"

--- a/.github/workflows/rocprofiler-systems-continuous-integration.yml
+++ b/.github/workflows/rocprofiler-systems-continuous-integration.yml
@@ -53,7 +53,6 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
   ROCPROFSYS_CI: ON
   ROCPROFSYS_TMPDIR: "%env{PWD}%/testing-tmp"
   ROCM_PATH: "/opt/rocm"

--- a/.github/workflows/rocprofiler-systems-continuous-integration.yml
+++ b/.github/workflows/rocprofiler-systems-continuous-integration.yml
@@ -66,7 +66,7 @@ jobs:
       matrix: ${{ steps.generate_matrix.outputs.matrix }}
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         with:
           sparse-checkout: projects/rocprofiler-systems/.github
 
@@ -107,7 +107,7 @@ jobs:
         --cap-add CAP_SYS_ADMIN
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         with:
           sparse-checkout: projects/rocprofiler-systems/
 

--- a/.github/workflows/rocprofiler-systems-cpack.yml
+++ b/.github/workflows/rocprofiler-systems-cpack.yml
@@ -107,7 +107,7 @@ jobs:
             large-packages: false
             swap-storage: false
 
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         with:
           sparse-checkout: |
             projects/rocprofiler-systems
@@ -146,7 +146,7 @@ jobs:
 
       - name: STGZ Artifacts
         timeout-minutes: 10
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v7
         with:
           name: rocprofiler-systems-stgz-${{ matrix.os-distro }}-${{ matrix.os-version }}-rocm-${{ matrix.rocm-version }}-installer
           path: |

--- a/.github/workflows/rocprofiler-systems-cpack.yml
+++ b/.github/workflows/rocprofiler-systems-cpack.yml
@@ -39,7 +39,6 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
   GIT_DISCOVERY_ACROSS_FILESYSTEM: 1
 
 jobs:

--- a/.github/workflows/rocprofiler-systems-cpack.yml
+++ b/.github/workflows/rocprofiler-systems-cpack.yml
@@ -39,6 +39,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
   GIT_DISCOVERY_ACROSS_FILESYSTEM: 1
 
 jobs:
@@ -106,7 +107,7 @@ jobs:
             large-packages: false
             swap-storage: false
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           sparse-checkout: |
             projects/rocprofiler-systems
@@ -145,7 +146,7 @@ jobs:
 
       - name: STGZ Artifacts
         timeout-minutes: 10
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: rocprofiler-systems-stgz-${{ matrix.os-distro }}-${{ matrix.os-version }}-rocm-${{ matrix.rocm-version }}-installer
           path: |

--- a/.github/workflows/rocprofiler-systems-debian.yml
+++ b/.github/workflows/rocprofiler-systems-debian.yml
@@ -66,7 +66,7 @@ jobs:
       ROCPROFSYS_CI: 'ON'
 
     steps:
-    - uses: actions/checkout@v5
+    - uses: actions/checkout@v6
       with:
         sparse-checkout: projects/rocprofiler-systems/
 
@@ -198,7 +198,7 @@ jobs:
     - name: CTest Artifacts
       if: failure()
       continue-on-error: True
-      uses: actions/upload-artifact@v5
+      uses: actions/upload-artifact@v7
       with:
         name: ctest-${{ github.job }}-${{ strategy.job-index }}-log
         path: |
@@ -207,7 +207,7 @@ jobs:
     - name: Data Artifacts
       if: failure()
       continue-on-error: True
-      uses: actions/upload-artifact@v5
+      uses: actions/upload-artifact@v7
       with:
         name: data-${{ github.job }}-${{ strategy.job-index }}-files
         path: |

--- a/.github/workflows/rocprofiler-systems-debian.yml
+++ b/.github/workflows/rocprofiler-systems-debian.yml
@@ -42,7 +42,6 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
   ROCPROFSYS_CI: ON
   ROCPROFSYS_TMPDIR: "%env{PWD}%/testing-tmp"
 

--- a/.github/workflows/rocprofiler-systems-debian.yml
+++ b/.github/workflows/rocprofiler-systems-debian.yml
@@ -42,6 +42,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
   ROCPROFSYS_CI: ON
   ROCPROFSYS_TMPDIR: "%env{PWD}%/testing-tmp"
 
@@ -65,7 +66,7 @@ jobs:
       ROCPROFSYS_CI: 'ON'
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
       with:
         sparse-checkout: projects/rocprofiler-systems/
 
@@ -197,7 +198,7 @@ jobs:
     - name: CTest Artifacts
       if: failure()
       continue-on-error: True
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v5
       with:
         name: ctest-${{ github.job }}-${{ strategy.job-index }}-log
         path: |
@@ -206,7 +207,7 @@ jobs:
     - name: Data Artifacts
       if: failure()
       continue-on-error: True
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v5
       with:
         name: data-${{ github.job }}-${{ strategy.job-index }}-files
         path: |

--- a/.github/workflows/rocprofiler-systems-formatting.yml
+++ b/.github/workflows/rocprofiler-systems-formatting.yml
@@ -30,7 +30,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           sparse-checkout: projects/rocprofiler-systems
 
@@ -50,7 +50,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           sparse-checkout: projects/rocprofiler-systems
 
@@ -79,7 +79,7 @@ jobs:
         python-version: ['3.10']
 
     steps:
-    - uses: actions/checkout@v5
+    - uses: actions/checkout@v6
       with:
         sparse-checkout: projects/rocprofiler-systems
 
@@ -103,7 +103,7 @@ jobs:
     runs-on: ubuntu-24.04
 
     steps:
-    - uses: actions/checkout@v5
+    - uses: actions/checkout@v6
       with:
         sparse-checkout: projects/rocprofiler-systems
 
@@ -130,7 +130,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v5
+    - uses: actions/checkout@v6
       with:
         sparse-checkout: projects/rocprofiler-systems
 
@@ -157,7 +157,7 @@ jobs:
     runs-on: ubuntu-22.04
 
     steps:
-    - uses: actions/checkout@v5
+    - uses: actions/checkout@v6
       with:
         sparse-checkout: projects/rocprofiler-systems
     - name: check-includes

--- a/.github/workflows/rocprofiler-systems-formatting.yml
+++ b/.github/workflows/rocprofiler-systems-formatting.yml
@@ -20,9 +20,6 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
-env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
-
 jobs:
 
   lint-md:

--- a/.github/workflows/rocprofiler-systems-formatting.yml
+++ b/.github/workflows/rocprofiler-systems-formatting.yml
@@ -20,6 +20,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
 
   lint-md:
@@ -27,7 +30,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           sparse-checkout: projects/rocprofiler-systems
 
@@ -47,7 +50,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           sparse-checkout: projects/rocprofiler-systems
 
@@ -76,7 +79,7 @@ jobs:
         python-version: ['3.10']
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
       with:
         sparse-checkout: projects/rocprofiler-systems
 
@@ -100,7 +103,7 @@ jobs:
     runs-on: ubuntu-24.04
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
       with:
         sparse-checkout: projects/rocprofiler-systems
 
@@ -127,7 +130,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
       with:
         sparse-checkout: projects/rocprofiler-systems
 
@@ -154,7 +157,7 @@ jobs:
     runs-on: ubuntu-22.04
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
       with:
         sparse-checkout: projects/rocprofiler-systems
     - name: check-includes

--- a/.github/workflows/rocprofiler-systems-ghcr.yml
+++ b/.github/workflows/rocprofiler-systems-ghcr.yml
@@ -73,7 +73,7 @@ jobs:
           submodules: recursive
 
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@184bdaa0721073962dff0199f1fb9940f07167d1 # v3.5.0
+        uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2 # v4.0.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -116,14 +116,14 @@ jobs:
 
       - name: Extract metadata (tags, labels) for Docker
         id: meta
-        uses: docker/metadata-action@c1e51972afc2121e065aed6d45c65596fe445f3f # v5.7.9
+        uses: docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf # v6.0.0
         with:
           images: ghcr.io/ROCm/rocprofiler-${{ matrix.system.distro }}
 
       - name: Build CI GFX Container (Does not Push on PR)
         id: docker_build
         continue-on-error: true
-        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
+        uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294 # v7.0.0
         with:
           file: projects/rocprofiler-systems/docker/${{ steps.setup_vars_gfx.outputs.docker_file }}
           platforms: linux/amd64
@@ -144,7 +144,7 @@ jobs:
       # Retry a copy of docker_build if Docker build failed due to intermittent failure
       - name: Build CI GFX Container Retry (Does not Push on PR)
         if: steps.docker_build.outcome != 'success'
-        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
+        uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294 # v7.0.0
         with:
           file: projects/rocprofiler-systems/docker/${{ steps.setup_vars_gfx.outputs.docker_file }}
           platforms: linux/amd64

--- a/.github/workflows/rocprofiler-systems-ghcr.yml
+++ b/.github/workflows/rocprofiler-systems-ghcr.yml
@@ -33,6 +33,9 @@ on:
       - '!docs/**'
       - '!projects/*/docs/**'
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   prepare_matrix_ci:
     if: github.repository == 'ROCm/rocm-systems'
@@ -41,7 +44,7 @@ jobs:
       matrix_data: ${{ steps.generate_matrix_ci_base.outputs.matrix_data }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           sparse-checkout: projects/rocprofiler-systems/docker
 

--- a/.github/workflows/rocprofiler-systems-ghcr.yml
+++ b/.github/workflows/rocprofiler-systems-ghcr.yml
@@ -33,9 +33,6 @@ on:
       - '!docs/**'
       - '!projects/*/docs/**'
 
-env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
-
 jobs:
   prepare_matrix_ci:
     if: github.repository == 'ROCm/rocm-systems'

--- a/.github/workflows/rocprofiler-systems-ghcr.yml
+++ b/.github/workflows/rocprofiler-systems-ghcr.yml
@@ -44,7 +44,7 @@ jobs:
       matrix_data: ${{ steps.generate_matrix_ci_base.outputs.matrix_data }}
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         with:
           sparse-checkout: projects/rocprofiler-systems/docker
 
@@ -70,7 +70,7 @@ jobs:
 
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        uses: actions/checkout@v6
         with:
           sparse-checkout: projects/rocprofiler-systems
           submodules: recursive

--- a/.github/workflows/rocprofiler-systems-opensuse.yml
+++ b/.github/workflows/rocprofiler-systems-opensuse.yml
@@ -42,6 +42,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
   ROCPROFSYS_CI: ON
   ROCPROFSYS_TMPDIR: "%env{PWD}%/testing-tmp"
 
@@ -58,7 +59,7 @@ jobs:
         build-type: ['Release']
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
       with:
         sparse-checkout: projects/rocprofiler-systems/
 
@@ -161,7 +162,7 @@ jobs:
     - name: CTest Artifacts
       if: failure()
       continue-on-error: True
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v5
       with:
         name: ctest-${{ github.job }}-${{ strategy.job-index }}-log
         path: |
@@ -170,7 +171,7 @@ jobs:
     - name: Data Artifacts
       if: failure()
       continue-on-error: True
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v5
       with:
         name: data-${{ github.job }}-${{ strategy.job-index }}-files
         path: |

--- a/.github/workflows/rocprofiler-systems-opensuse.yml
+++ b/.github/workflows/rocprofiler-systems-opensuse.yml
@@ -59,7 +59,7 @@ jobs:
         build-type: ['Release']
 
     steps:
-    - uses: actions/checkout@v5
+    - uses: actions/checkout@v6
       with:
         sparse-checkout: projects/rocprofiler-systems/
 
@@ -162,7 +162,7 @@ jobs:
     - name: CTest Artifacts
       if: failure()
       continue-on-error: True
-      uses: actions/upload-artifact@v5
+      uses: actions/upload-artifact@v7
       with:
         name: ctest-${{ github.job }}-${{ strategy.job-index }}-log
         path: |
@@ -171,7 +171,7 @@ jobs:
     - name: Data Artifacts
       if: failure()
       continue-on-error: True
-      uses: actions/upload-artifact@v5
+      uses: actions/upload-artifact@v7
       with:
         name: data-${{ github.job }}-${{ strategy.job-index }}-files
         path: |

--- a/.github/workflows/rocprofiler-systems-opensuse.yml
+++ b/.github/workflows/rocprofiler-systems-opensuse.yml
@@ -42,7 +42,6 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
   ROCPROFSYS_CI: ON
   ROCPROFSYS_TMPDIR: "%env{PWD}%/testing-tmp"
 

--- a/.github/workflows/rocprofiler-systems-python.yml
+++ b/.github/workflows/rocprofiler-systems-python.yml
@@ -37,6 +37,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   linting:
     runs-on: ubuntu-latest
@@ -45,7 +48,7 @@ jobs:
         python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
       with:
         sparse-checkout: projects/rocprofiler-systems
     - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/rocprofiler-systems-python.yml
+++ b/.github/workflows/rocprofiler-systems-python.yml
@@ -37,9 +37,6 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
-env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
-
 jobs:
   linting:
     runs-on: ubuntu-latest

--- a/.github/workflows/rocprofiler-systems-python.yml
+++ b/.github/workflows/rocprofiler-systems-python.yml
@@ -48,7 +48,7 @@ jobs:
         python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
 
     steps:
-    - uses: actions/checkout@v5
+    - uses: actions/checkout@v6
       with:
         sparse-checkout: projects/rocprofiler-systems
     - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/rocprofiler-systems-redhat.yml
+++ b/.github/workflows/rocprofiler-systems-redhat.yml
@@ -62,7 +62,7 @@ jobs:
         build-type: ['Release']
 
     steps:
-    - uses: actions/checkout@v5
+    - uses: actions/checkout@v6
       with:
         sparse-checkout: projects/rocprofiler-systems/
 
@@ -199,7 +199,7 @@ jobs:
     - name: CTest Artifacts
       if: failure()
       continue-on-error: True
-      uses: actions/upload-artifact@v5
+      uses: actions/upload-artifact@v7
       with:
         name: ctest-${{ github.job }}-${{ strategy.job-index }}-log
         path: |
@@ -208,7 +208,7 @@ jobs:
     - name: Data Artifacts
       if: failure()
       continue-on-error: True
-      uses: actions/upload-artifact@v5
+      uses: actions/upload-artifact@v7
       with:
         name: data-${{ github.job }}-${{ strategy.job-index }}-files
         path: |

--- a/.github/workflows/rocprofiler-systems-redhat.yml
+++ b/.github/workflows/rocprofiler-systems-redhat.yml
@@ -42,6 +42,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
   ROCPROFSYS_CI: ON
   ROCPROFSYS_TMPDIR: "%env{PWD}%/testing-tmp"
 
@@ -61,7 +62,7 @@ jobs:
         build-type: ['Release']
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
       with:
         sparse-checkout: projects/rocprofiler-systems/
 
@@ -198,7 +199,7 @@ jobs:
     - name: CTest Artifacts
       if: failure()
       continue-on-error: True
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v5
       with:
         name: ctest-${{ github.job }}-${{ strategy.job-index }}-log
         path: |
@@ -207,7 +208,7 @@ jobs:
     - name: Data Artifacts
       if: failure()
       continue-on-error: True
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v5
       with:
         name: data-${{ github.job }}-${{ strategy.job-index }}-files
         path: |

--- a/.github/workflows/rocprofiler-systems-redhat.yml
+++ b/.github/workflows/rocprofiler-systems-redhat.yml
@@ -42,7 +42,6 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
   ROCPROFSYS_CI: ON
   ROCPROFSYS_TMPDIR: "%env{PWD}%/testing-tmp"
 

--- a/.github/workflows/rocprofiler-systems-release.yml
+++ b/.github/workflows/rocprofiler-systems-release.yml
@@ -34,7 +34,7 @@ jobs:
       packages: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           sparse-checkout: projects/rocprofiler-systems/
       - name: Generate generic installer script

--- a/.github/workflows/rocprofiler-systems-release.yml
+++ b/.github/workflows/rocprofiler-systems-release.yml
@@ -23,6 +23,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
   GIT_DISCOVERY_ACROSS_FILESYSTEM: 1
 
 jobs:
@@ -33,7 +34,7 @@ jobs:
       packages: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           sparse-checkout: projects/rocprofiler-systems/
       - name: Generate generic installer script

--- a/.github/workflows/rocprofiler-systems-release.yml
+++ b/.github/workflows/rocprofiler-systems-release.yml
@@ -23,7 +23,6 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
   GIT_DISCOVERY_ACROSS_FILESYSTEM: 1
 
 jobs:

--- a/.github/workflows/rocprofiler-systems-ubuntu-jammy.yml
+++ b/.github/workflows/rocprofiler-systems-ubuntu-jammy.yml
@@ -42,6 +42,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
   ROCPROFSYS_CI: ON
   ROCPROFSYS_TMPDIR: "%env{PWD}%/testing-tmp"
 
@@ -69,7 +70,7 @@ jobs:
       ROCPROFSYS_CI: 'ON'
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
       with:
         sparse-checkout: projects/rocprofiler-systems/
 
@@ -233,7 +234,7 @@ jobs:
     - name: CTest Artifacts
       if: failure()
       continue-on-error: True
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v5
       with:
         name: ctest-${{ github.job }}-${{ strategy.job-index }}-log
         path: |
@@ -242,7 +243,7 @@ jobs:
     - name: Data Artifacts
       if: failure()
       continue-on-error: True
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v5
       with:
         name: data-${{ github.job }}-${{ strategy.job-index }}-files
         path: |
@@ -263,7 +264,7 @@ jobs:
       ROCPROFSYS_CI: 'ON'
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
       with:
         sparse-checkout: projects/rocprofiler-systems/
 

--- a/.github/workflows/rocprofiler-systems-ubuntu-jammy.yml
+++ b/.github/workflows/rocprofiler-systems-ubuntu-jammy.yml
@@ -42,7 +42,6 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
   ROCPROFSYS_CI: ON
   ROCPROFSYS_TMPDIR: "%env{PWD}%/testing-tmp"
 

--- a/.github/workflows/rocprofiler-systems-ubuntu-jammy.yml
+++ b/.github/workflows/rocprofiler-systems-ubuntu-jammy.yml
@@ -70,7 +70,7 @@ jobs:
       ROCPROFSYS_CI: 'ON'
 
     steps:
-    - uses: actions/checkout@v5
+    - uses: actions/checkout@v6
       with:
         sparse-checkout: projects/rocprofiler-systems/
 
@@ -234,7 +234,7 @@ jobs:
     - name: CTest Artifacts
       if: failure()
       continue-on-error: True
-      uses: actions/upload-artifact@v5
+      uses: actions/upload-artifact@v7
       with:
         name: ctest-${{ github.job }}-${{ strategy.job-index }}-log
         path: |
@@ -243,7 +243,7 @@ jobs:
     - name: Data Artifacts
       if: failure()
       continue-on-error: True
-      uses: actions/upload-artifact@v5
+      uses: actions/upload-artifact@v7
       with:
         name: data-${{ github.job }}-${{ strategy.job-index }}-files
         path: |
@@ -264,7 +264,7 @@ jobs:
       ROCPROFSYS_CI: 'ON'
 
     steps:
-    - uses: actions/checkout@v5
+    - uses: actions/checkout@v6
       with:
         sparse-checkout: projects/rocprofiler-systems/
 

--- a/.github/workflows/rocprofiler-systems-ubuntu-noble.yml
+++ b/.github/workflows/rocprofiler-systems-ubuntu-noble.yml
@@ -65,7 +65,7 @@ jobs:
       ROCPROFSYS_CI: 'ON'
 
     steps:
-    - uses: actions/checkout@v5
+    - uses: actions/checkout@v6
       with:
         sparse-checkout: projects/rocprofiler-systems/
 
@@ -197,7 +197,7 @@ jobs:
     - name: CTest Artifacts
       if: failure()
       continue-on-error: True
-      uses: actions/upload-artifact@v5
+      uses: actions/upload-artifact@v7
       with:
         name: ctest-${{ github.job }}-${{ strategy.job-index }}-log
         path: |
@@ -206,7 +206,7 @@ jobs:
     - name: Data Artifacts
       if: failure()
       continue-on-error: True
-      uses: actions/upload-artifact@v5
+      uses: actions/upload-artifact@v7
       with:
         name: data-${{ github.job }}-${{ strategy.job-index }}-files
         path: |

--- a/.github/workflows/rocprofiler-systems-ubuntu-noble.yml
+++ b/.github/workflows/rocprofiler-systems-ubuntu-noble.yml
@@ -42,6 +42,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
   ROCPROFSYS_CI: ON
   ROCPROFSYS_TMPDIR: "%env{PWD}%/testing-tmp"
 
@@ -64,7 +65,7 @@ jobs:
       ROCPROFSYS_CI: 'ON'
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
       with:
         sparse-checkout: projects/rocprofiler-systems/
 
@@ -196,7 +197,7 @@ jobs:
     - name: CTest Artifacts
       if: failure()
       continue-on-error: True
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v5
       with:
         name: ctest-${{ github.job }}-${{ strategy.job-index }}-log
         path: |
@@ -205,7 +206,7 @@ jobs:
     - name: Data Artifacts
       if: failure()
       continue-on-error: True
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v5
       with:
         name: data-${{ github.job }}-${{ strategy.job-index }}-files
         path: |

--- a/.github/workflows/rocprofiler-systems-ubuntu-noble.yml
+++ b/.github/workflows/rocprofiler-systems-ubuntu-noble.yml
@@ -42,7 +42,6 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
   ROCPROFSYS_CI: ON
   ROCPROFSYS_TMPDIR: "%env{PWD}%/testing-tmp"
 


### PR DESCRIPTION
## Motivation
Address Node.js 20 deprecation warnings in GitHub Actions. Actions will run on Node.js 24 by default starting June 2, 2026.

https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/

## Technical Details

**GitHub Actions (12 rocprofiler-systems workflows):**
- **actions/checkout**: v4 → v6
- **actions/upload-artifact**: v4 → v7

**Docker actions** (`rocprofiler-systems-containers.yml`, `rocprofiler-systems-ghcr.yml`):
- **docker/setup-qemu-action**: v2 → v4.0.0 (`ce360397dd3f832beb865e1373c09c0e9f86d70a`)
- **docker/setup-buildx-action**: v2 → v4.0.0 (`4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd`)
- **docker/login-action**: v2/v3.5.0 → v4.0.0 (`b45d80f862d83dbcd57f89517bcf500b2ab88fb2`)
- **docker/metadata-action**: v5.7.9 → v6.0.0 (`030e881283bb7a6894de51c315a6bfe6a94e05cf`)
- **docker/build-push-action**: v6.18.0 → v7.0.0 (`d08e5c354a6adb9ed34480a06d141179aa583294`)

**Pinning:**
- Docker actions use commit-hash pinning with version comments (e.g. `@<sha> # v4.0.0`) for immutability, consistent with `rocprofiler-systems-ghcr.yml`.

**Misc Notes:**
- Actions Runner v2.327.1+ (GitHub-hosted runners meet this).
- `nick-fields/retry@v3` left unchanged; no Node 24 release yet, but it will run on Node 24 when that becomes the default.

## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->
AIPROFSYST-348

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->
Run all affected workflows

## Test Result

<!-- Briefly summarize test outcomes. -->
See Below

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
