### PR TITLE
[rocprofiler-compute] Fix race condition in test_analyze_workloads when running with parallel pytest workers

### DIFF
--- a/projects/rocprofiler-compute/tests/test_analyze_workloads.py
+++ b/projects/rocprofiler-compute/tests/test_analyze_workloads.py
@@ -27,7 +27,12 @@
 ##          Generated tests                     ##
 ##################################################
 
+import os
+
 import test_utils
+
+config = {}
+config["cleanup"] = True if "PYTEST_XDIST_WORKER_COUNT" in os.environ else False
 
 
 def test_analyze_vcopy_MI100(binary_handler_analyze_rocprof_compute):
@@ -40,7 +45,7 @@ def test_analyze_vcopy_MI100(binary_handler_analyze_rocprof_compute):
     ])
     assert code == 0
 
-    test_utils.clean_output_dir(True, workload_dir)
+    test_utils.clean_output_dir(config["cleanup"], workload_dir)
 
 
 def test_analyze_vcopy_MI200(binary_handler_analyze_rocprof_compute):
@@ -53,7 +58,7 @@ def test_analyze_vcopy_MI200(binary_handler_analyze_rocprof_compute):
     ])
     assert code == 0
 
-    test_utils.clean_output_dir(True, workload_dir)
+    test_utils.clean_output_dir(config["cleanup"], workload_dir)
 
 
 def test_analyze_ipblocks_TCP_MI300X_A1(binary_handler_analyze_rocprof_compute):
@@ -68,7 +73,7 @@ def test_analyze_ipblocks_TCP_MI300X_A1(binary_handler_analyze_rocprof_compute):
     ])
     assert code == 0
 
-    test_utils.clean_output_dir(True, workload_dir)
+    test_utils.clean_output_dir(config["cleanup"], workload_dir)
 
 
 def test_analyze_ipblocks_TCP_MI100(binary_handler_analyze_rocprof_compute):
@@ -81,7 +86,7 @@ def test_analyze_ipblocks_TCP_MI100(binary_handler_analyze_rocprof_compute):
     ])
     assert code == 0
 
-    test_utils.clean_output_dir(True, workload_dir)
+    test_utils.clean_output_dir(config["cleanup"], workload_dir)
 
 
 def test_analyze_ipblocks_TCP_MI300A_A1(binary_handler_analyze_rocprof_compute):
@@ -96,7 +101,7 @@ def test_analyze_ipblocks_TCP_MI300A_A1(binary_handler_analyze_rocprof_compute):
     ])
     assert code == 0
 
-    test_utils.clean_output_dir(True, workload_dir)
+    test_utils.clean_output_dir(config["cleanup"], workload_dir)
 
 
 def test_analyze_ipblocks_TCP_MI200(binary_handler_analyze_rocprof_compute):
@@ -109,7 +114,7 @@ def test_analyze_ipblocks_TCP_MI200(binary_handler_analyze_rocprof_compute):
     ])
     assert code == 0
 
-    test_utils.clean_output_dir(True, workload_dir)
+    test_utils.clean_output_dir(config["cleanup"], workload_dir)
 
 
 def test_analyze_ipblocks_SQC_MI300X_A1(binary_handler_analyze_rocprof_compute):
@@ -124,7 +129,7 @@ def test_analyze_ipblocks_SQC_MI300X_A1(binary_handler_analyze_rocprof_compute):
     ])
     assert code == 0
 
-    test_utils.clean_output_dir(True, workload_dir)
+    test_utils.clean_output_dir(config["cleanup"], workload_dir)
 
 
 def test_analyze_ipblocks_SQC_MI100(binary_handler_analyze_rocprof_compute):
@@ -137,7 +142,7 @@ def test_analyze_ipblocks_SQC_MI100(binary_handler_analyze_rocprof_compute):
     ])
     assert code == 0
 
-    test_utils.clean_output_dir(True, workload_dir)
+    test_utils.clean_output_dir(config["cleanup"], workload_dir)
 
 
 def test_analyze_ipblocks_SQC_MI300A_A1(binary_handler_analyze_rocprof_compute):
@@ -152,7 +157,7 @@ def test_analyze_ipblocks_SQC_MI300A_A1(binary_handler_analyze_rocprof_compute):
     ])
     assert code == 0
 
-    test_utils.clean_output_dir(True, workload_dir)
+    test_utils.clean_output_dir(config["cleanup"], workload_dir)
 
 
 def test_analyze_ipblocks_SQC_MI200(binary_handler_analyze_rocprof_compute):
@@ -165,7 +170,7 @@ def test_analyze_ipblocks_SQC_MI200(binary_handler_analyze_rocprof_compute):
     ])
     assert code == 0
 
-    test_utils.clean_output_dir(True, workload_dir)
+    test_utils.clean_output_dir(config["cleanup"], workload_dir)
 
 
 def test_analyze_mem_levels_HBM_LDS_MI200(binary_handler_analyze_rocprof_compute):
@@ -180,7 +185,7 @@ def test_analyze_mem_levels_HBM_LDS_MI200(binary_handler_analyze_rocprof_compute
     ])
     assert code == 0
 
-    test_utils.clean_output_dir(True, workload_dir)
+    test_utils.clean_output_dir(config["cleanup"], workload_dir)
 
 
 def test_analyze_ipblocks_TCC_MI300X_A1(binary_handler_analyze_rocprof_compute):
@@ -195,7 +200,7 @@ def test_analyze_ipblocks_TCC_MI300X_A1(binary_handler_analyze_rocprof_compute):
     ])
     assert code == 0
 
-    test_utils.clean_output_dir(True, workload_dir)
+    test_utils.clean_output_dir(config["cleanup"], workload_dir)
 
 
 def test_analyze_ipblocks_TCC_MI100(binary_handler_analyze_rocprof_compute):
@@ -208,7 +213,7 @@ def test_analyze_ipblocks_TCC_MI100(binary_handler_analyze_rocprof_compute):
     ])
     assert code == 0
 
-    test_utils.clean_output_dir(True, workload_dir)
+    test_utils.clean_output_dir(config["cleanup"], workload_dir)
 
 
 def test_analyze_ipblocks_TCC_MI300A_A1(binary_handler_analyze_rocprof_compute):
@@ -223,7 +228,7 @@ def test_analyze_ipblocks_TCC_MI300A_A1(binary_handler_analyze_rocprof_compute):
     ])
     assert code == 0
 
-    test_utils.clean_output_dir(True, workload_dir)
+    test_utils.clean_output_dir(config["cleanup"], workload_dir)
 
 
 def test_analyze_ipblocks_TCC_MI200(binary_handler_analyze_rocprof_compute):
@@ -236,7 +241,7 @@ def test_analyze_ipblocks_TCC_MI200(binary_handler_analyze_rocprof_compute):
     ])
     assert code == 0
 
-    test_utils.clean_output_dir(True, workload_dir)
+    test_utils.clean_output_dir(config["cleanup"], workload_dir)
 
 
 def test_analyze_no_roof_MI350(binary_handler_analyze_rocprof_compute):
@@ -249,7 +254,7 @@ def test_analyze_no_roof_MI350(binary_handler_analyze_rocprof_compute):
     ])
     assert code == 0
 
-    test_utils.clean_output_dir(True, workload_dir)
+    test_utils.clean_output_dir(config["cleanup"], workload_dir)
 
 
 def test_analyze_no_roof_MI300X_A1(binary_handler_analyze_rocprof_compute):
@@ -262,7 +267,7 @@ def test_analyze_no_roof_MI300X_A1(binary_handler_analyze_rocprof_compute):
     ])
     assert code == 0
 
-    test_utils.clean_output_dir(True, workload_dir)
+    test_utils.clean_output_dir(config["cleanup"], workload_dir)
 
 
 def test_analyze_no_roof_MI100(binary_handler_analyze_rocprof_compute):
@@ -275,7 +280,7 @@ def test_analyze_no_roof_MI100(binary_handler_analyze_rocprof_compute):
     ])
     assert code == 0
 
-    test_utils.clean_output_dir(True, workload_dir)
+    test_utils.clean_output_dir(config["cleanup"], workload_dir)
 
 
 def test_analyze_no_roof_MI300A_A1(binary_handler_analyze_rocprof_compute):
@@ -288,7 +293,7 @@ def test_analyze_no_roof_MI300A_A1(binary_handler_analyze_rocprof_compute):
     ])
     assert code == 0
 
-    test_utils.clean_output_dir(True, workload_dir)
+    test_utils.clean_output_dir(config["cleanup"], workload_dir)
 
 
 def test_analyze_no_roof_MI200(binary_handler_analyze_rocprof_compute):
@@ -301,7 +306,7 @@ def test_analyze_no_roof_MI200(binary_handler_analyze_rocprof_compute):
     ])
     assert code == 0
 
-    test_utils.clean_output_dir(True, workload_dir)
+    test_utils.clean_output_dir(config["cleanup"], workload_dir)
 
 
 def test_analyze_ipblocks_SQ_CPC_MI300X_A1(binary_handler_analyze_rocprof_compute):
@@ -316,7 +321,7 @@ def test_analyze_ipblocks_SQ_CPC_MI300X_A1(binary_handler_analyze_rocprof_comput
     ])
     assert code == 0
 
-    test_utils.clean_output_dir(True, workload_dir)
+    test_utils.clean_output_dir(config["cleanup"], workload_dir)
 
 
 def test_analyze_ipblocks_SQ_CPC_MI100(binary_handler_analyze_rocprof_compute):
@@ -331,7 +336,7 @@ def test_analyze_ipblocks_SQ_CPC_MI100(binary_handler_analyze_rocprof_compute):
     ])
     assert code == 0
 
-    test_utils.clean_output_dir(True, workload_dir)
+    test_utils.clean_output_dir(config["cleanup"], workload_dir)
 
 
 def test_analyze_ipblocks_SQ_CPC_MI300A_A1(binary_handler_analyze_rocprof_compute):
@@ -346,7 +351,7 @@ def test_analyze_ipblocks_SQ_CPC_MI300A_A1(binary_handler_analyze_rocprof_comput
     ])
     assert code == 0
 
-    test_utils.clean_output_dir(True, workload_dir)
+    test_utils.clean_output_dir(config["cleanup"], workload_dir)
 
 
 def test_analyze_ipblocks_SQ_CPC_MI200(binary_handler_analyze_rocprof_compute):
@@ -361,7 +366,7 @@ def test_analyze_ipblocks_SQ_CPC_MI200(binary_handler_analyze_rocprof_compute):
     ])
     assert code == 0
 
-    test_utils.clean_output_dir(True, workload_dir)
+    test_utils.clean_output_dir(config["cleanup"], workload_dir)
 
 
 def test_analyze_dispatch_0_MI300X_A1(binary_handler_analyze_rocprof_compute):
@@ -374,7 +379,7 @@ def test_analyze_dispatch_0_MI300X_A1(binary_handler_analyze_rocprof_compute):
     ])
     assert code == 0
 
-    test_utils.clean_output_dir(True, workload_dir)
+    test_utils.clean_output_dir(config["cleanup"], workload_dir)
 
 
 def test_analyze_dispatch_0_MI100(binary_handler_analyze_rocprof_compute):
@@ -387,7 +392,7 @@ def test_analyze_dispatch_0_MI100(binary_handler_analyze_rocprof_compute):
     ])
     assert code == 0
 
-    test_utils.clean_output_dir(True, workload_dir)
+    test_utils.clean_output_dir(config["cleanup"], workload_dir)
 
 
 def test_analyze_dispatch_0_MI300A_A1(binary_handler_analyze_rocprof_compute):
@@ -400,7 +405,7 @@ def test_analyze_dispatch_0_MI300A_A1(binary_handler_analyze_rocprof_compute):
     ])
     assert code == 0
 
-    test_utils.clean_output_dir(True, workload_dir)
+    test_utils.clean_output_dir(config["cleanup"], workload_dir)
 
 
 def test_analyze_dispatch_0_MI200(binary_handler_analyze_rocprof_compute):
@@ -413,7 +418,7 @@ def test_analyze_dispatch_0_MI200(binary_handler_analyze_rocprof_compute):
     ])
     assert code == 0
 
-    test_utils.clean_output_dir(True, workload_dir)
+    test_utils.clean_output_dir(config["cleanup"], workload_dir)
 
 
 def test_analyze_join_type_grid_MI300X_A1(binary_handler_analyze_rocprof_compute):
@@ -428,7 +433,7 @@ def test_analyze_join_type_grid_MI300X_A1(binary_handler_analyze_rocprof_compute
     ])
     assert code == 0
 
-    test_utils.clean_output_dir(True, workload_dir)
+    test_utils.clean_output_dir(config["cleanup"], workload_dir)
 
 
 def test_analyze_join_type_grid_MI100(binary_handler_analyze_rocprof_compute):
@@ -441,7 +446,7 @@ def test_analyze_join_type_grid_MI100(binary_handler_analyze_rocprof_compute):
     ])
     assert code == 0
 
-    test_utils.clean_output_dir(True, workload_dir)
+    test_utils.clean_output_dir(config["cleanup"], workload_dir)
 
 
 def test_analyze_join_type_grid_MI300A_A1(binary_handler_analyze_rocprof_compute):
@@ -456,7 +461,7 @@ def test_analyze_join_type_grid_MI300A_A1(binary_handler_analyze_rocprof_compute
     ])
     assert code == 0
 
-    test_utils.clean_output_dir(True, workload_dir)
+    test_utils.clean_output_dir(config["cleanup"], workload_dir)
 
 
 def test_analyze_join_type_grid_MI200(binary_handler_analyze_rocprof_compute):
@@ -469,7 +474,7 @@ def test_analyze_join_type_grid_MI200(binary_handler_analyze_rocprof_compute):
     ])
     assert code == 0
 
-    test_utils.clean_output_dir(True, workload_dir)
+    test_utils.clean_output_dir(config["cleanup"], workload_dir)
 
 
 def test_analyze_kernel_MI300X_A1(binary_handler_analyze_rocprof_compute):
@@ -482,7 +487,7 @@ def test_analyze_kernel_MI300X_A1(binary_handler_analyze_rocprof_compute):
     ])
     assert code == 0
 
-    test_utils.clean_output_dir(True, workload_dir)
+    test_utils.clean_output_dir(config["cleanup"], workload_dir)
 
 
 def test_analyze_kernel_MI100(binary_handler_analyze_rocprof_compute):
@@ -495,7 +500,7 @@ def test_analyze_kernel_MI100(binary_handler_analyze_rocprof_compute):
     ])
     assert code == 0
 
-    test_utils.clean_output_dir(True, workload_dir)
+    test_utils.clean_output_dir(config["cleanup"], workload_dir)
 
 
 def test_analyze_kernel_MI300A_A1(binary_handler_analyze_rocprof_compute):
@@ -508,7 +513,7 @@ def test_analyze_kernel_MI300A_A1(binary_handler_analyze_rocprof_compute):
     ])
     assert code == 0
 
-    test_utils.clean_output_dir(True, workload_dir)
+    test_utils.clean_output_dir(config["cleanup"], workload_dir)
 
 
 def test_analyze_kernel_MI200(binary_handler_analyze_rocprof_compute):
@@ -521,7 +526,7 @@ def test_analyze_kernel_MI200(binary_handler_analyze_rocprof_compute):
     ])
     assert code == 0
 
-    test_utils.clean_output_dir(True, workload_dir)
+    test_utils.clean_output_dir(config["cleanup"], workload_dir)
 
 
 def test_analyze_kernel_substr_MI300X_A1(binary_handler_analyze_rocprof_compute):
@@ -536,7 +541,7 @@ def test_analyze_kernel_substr_MI300X_A1(binary_handler_analyze_rocprof_compute)
     ])
     assert code == 0
 
-    test_utils.clean_output_dir(True, workload_dir)
+    test_utils.clean_output_dir(config["cleanup"], workload_dir)
 
 
 def test_analyze_kernel_substr_MI100(binary_handler_analyze_rocprof_compute):
@@ -549,7 +554,7 @@ def test_analyze_kernel_substr_MI100(binary_handler_analyze_rocprof_compute):
     ])
     assert code == 0
 
-    test_utils.clean_output_dir(True, workload_dir)
+    test_utils.clean_output_dir(config["cleanup"], workload_dir)
 
 
 def test_analyze_kernel_substr_MI300A_A1(binary_handler_analyze_rocprof_compute):
@@ -564,7 +569,7 @@ def test_analyze_kernel_substr_MI300A_A1(binary_handler_analyze_rocprof_compute)
     ])
     assert code == 0
 
-    test_utils.clean_output_dir(True, workload_dir)
+    test_utils.clean_output_dir(config["cleanup"], workload_dir)
 
 
 def test_analyze_kernel_substr_MI200(binary_handler_analyze_rocprof_compute):
@@ -577,7 +582,7 @@ def test_analyze_kernel_substr_MI200(binary_handler_analyze_rocprof_compute):
     ])
     assert code == 0
 
-    test_utils.clean_output_dir(True, workload_dir)
+    test_utils.clean_output_dir(config["cleanup"], workload_dir)
 
 
 def test_analyze_dispatch_7_MI300X_A1(binary_handler_analyze_rocprof_compute):
@@ -590,7 +595,7 @@ def test_analyze_dispatch_7_MI300X_A1(binary_handler_analyze_rocprof_compute):
     ])
     assert code == 0
 
-    test_utils.clean_output_dir(True, workload_dir)
+    test_utils.clean_output_dir(config["cleanup"], workload_dir)
 
 
 def test_analyze_dispatch_7_MI100(binary_handler_analyze_rocprof_compute):
@@ -603,7 +608,7 @@ def test_analyze_dispatch_7_MI100(binary_handler_analyze_rocprof_compute):
     ])
     assert code == 1
 
-    test_utils.clean_output_dir(True, workload_dir)
+    test_utils.clean_output_dir(config["cleanup"], workload_dir)
 
 
 def test_analyze_dispatch_7_MI300A_A1(binary_handler_analyze_rocprof_compute):
@@ -616,7 +621,7 @@ def test_analyze_dispatch_7_MI300A_A1(binary_handler_analyze_rocprof_compute):
     ])
     assert code == 0
 
-    test_utils.clean_output_dir(True, workload_dir)
+    test_utils.clean_output_dir(config["cleanup"], workload_dir)
 
 
 def test_analyze_dispatch_7_MI200(binary_handler_analyze_rocprof_compute):
@@ -629,7 +634,7 @@ def test_analyze_dispatch_7_MI200(binary_handler_analyze_rocprof_compute):
     ])
     assert code == 1
 
-    test_utils.clean_output_dir(True, workload_dir)
+    test_utils.clean_output_dir(config["cleanup"], workload_dir)
 
 
 def test_analyze_kernel_inv_int_MI300X_A1(binary_handler_analyze_rocprof_compute):
@@ -644,7 +649,7 @@ def test_analyze_kernel_inv_int_MI300X_A1(binary_handler_analyze_rocprof_compute
     ])
     assert code == 0
 
-    test_utils.clean_output_dir(True, workload_dir)
+    test_utils.clean_output_dir(config["cleanup"], workload_dir)
 
 
 def test_analyze_kernel_inv_int_MI100(binary_handler_analyze_rocprof_compute):
@@ -657,7 +662,7 @@ def test_analyze_kernel_inv_int_MI100(binary_handler_analyze_rocprof_compute):
     ])
     assert code == 1
 
-    test_utils.clean_output_dir(True, workload_dir)
+    test_utils.clean_output_dir(config["cleanup"], workload_dir)
 
 
 def test_analyze_kernel_inv_int_MI300A_A1(binary_handler_analyze_rocprof_compute):
@@ -672,7 +677,7 @@ def test_analyze_kernel_inv_int_MI300A_A1(binary_handler_analyze_rocprof_compute
     ])
     assert code == 0
 
-    test_utils.clean_output_dir(True, workload_dir)
+    test_utils.clean_output_dir(config["cleanup"], workload_dir)
 
 
 def test_analyze_kernel_inv_int_MI200(binary_handler_analyze_rocprof_compute):
@@ -685,7 +690,7 @@ def test_analyze_kernel_inv_int_MI200(binary_handler_analyze_rocprof_compute):
     ])
     assert code == 1
 
-    test_utils.clean_output_dir(True, workload_dir)
+    test_utils.clean_output_dir(config["cleanup"], workload_dir)
 
 
 def test_analyze_mem_levels_vL1D_MI200(binary_handler_analyze_rocprof_compute):
@@ -700,7 +705,7 @@ def test_analyze_mem_levels_vL1D_MI200(binary_handler_analyze_rocprof_compute):
     ])
     assert code == 0
 
-    test_utils.clean_output_dir(True, workload_dir)
+    test_utils.clean_output_dir(config["cleanup"], workload_dir)
 
 
 def test_analyze_sort_kernels_MI200(binary_handler_analyze_rocprof_compute):
@@ -713,7 +718,7 @@ def test_analyze_sort_kernels_MI200(binary_handler_analyze_rocprof_compute):
     ])
     assert code == 0
 
-    test_utils.clean_output_dir(True, workload_dir)
+    test_utils.clean_output_dir(config["cleanup"], workload_dir)
 
 
 def test_analyze_kernel_inv_str_MI300X_A1(binary_handler_analyze_rocprof_compute):
@@ -728,7 +733,7 @@ def test_analyze_kernel_inv_str_MI300X_A1(binary_handler_analyze_rocprof_compute
     ])
     assert code == 0
 
-    test_utils.clean_output_dir(True, workload_dir)
+    test_utils.clean_output_dir(config["cleanup"], workload_dir)
 
 
 def test_analyze_kernel_inv_str_MI100(binary_handler_analyze_rocprof_compute):
@@ -741,7 +746,7 @@ def test_analyze_kernel_inv_str_MI100(binary_handler_analyze_rocprof_compute):
     ])
     assert code == 1
 
-    test_utils.clean_output_dir(True, workload_dir)
+    test_utils.clean_output_dir(config["cleanup"], workload_dir)
 
 
 def test_analyze_kernel_inv_str_MI300A_A1(binary_handler_analyze_rocprof_compute):
@@ -756,7 +761,7 @@ def test_analyze_kernel_inv_str_MI300A_A1(binary_handler_analyze_rocprof_compute
     ])
     assert code == 0
 
-    test_utils.clean_output_dir(True, workload_dir)
+    test_utils.clean_output_dir(config["cleanup"], workload_dir)
 
 
 def test_analyze_kernel_inv_str_MI200(binary_handler_analyze_rocprof_compute):
@@ -769,7 +774,7 @@ def test_analyze_kernel_inv_str_MI200(binary_handler_analyze_rocprof_compute):
     ])
     assert code == 1
 
-    test_utils.clean_output_dir(True, workload_dir)
+    test_utils.clean_output_dir(config["cleanup"], workload_dir)
 
 
 def test_analyze_ipblocks_SQ_SPI_MI300X_A1(binary_handler_analyze_rocprof_compute):
@@ -784,7 +789,7 @@ def test_analyze_ipblocks_SQ_SPI_MI300X_A1(binary_handler_analyze_rocprof_comput
     ])
     assert code == 0
 
-    test_utils.clean_output_dir(True, workload_dir)
+    test_utils.clean_output_dir(config["cleanup"], workload_dir)
 
 
 def test_analyze_ipblocks_SQ_SPI_MI100(binary_handler_analyze_rocprof_compute):
@@ -799,7 +804,7 @@ def test_analyze_ipblocks_SQ_SPI_MI100(binary_handler_analyze_rocprof_compute):
     ])
     assert code == 0
 
-    test_utils.clean_output_dir(True, workload_dir)
+    test_utils.clean_output_dir(config["cleanup"], workload_dir)
 
 
 def test_analyze_ipblocks_SQ_SPI_MI300A_A1(binary_handler_analyze_rocprof_compute):
@@ -814,7 +819,7 @@ def test_analyze_ipblocks_SQ_SPI_MI300A_A1(binary_handler_analyze_rocprof_comput
     ])
     assert code == 0
 
-    test_utils.clean_output_dir(True, workload_dir)
+    test_utils.clean_output_dir(config["cleanup"], workload_dir)
 
 
 def test_analyze_ipblocks_SQ_SPI_MI200(binary_handler_analyze_rocprof_compute):
@@ -829,7 +834,7 @@ def test_analyze_ipblocks_SQ_SPI_MI200(binary_handler_analyze_rocprof_compute):
     ])
     assert code == 0
 
-    test_utils.clean_output_dir(True, workload_dir)
+    test_utils.clean_output_dir(config["cleanup"], workload_dir)
 
 
 def test_analyze_dispatch_2_MI300X_A1(binary_handler_analyze_rocprof_compute):
@@ -842,7 +847,7 @@ def test_analyze_dispatch_2_MI300X_A1(binary_handler_analyze_rocprof_compute):
     ])
     assert code == 0
 
-    test_utils.clean_output_dir(True, workload_dir)
+    test_utils.clean_output_dir(config["cleanup"], workload_dir)
 
 
 def test_analyze_dispatch_2_MI100(binary_handler_analyze_rocprof_compute):
@@ -855,7 +860,7 @@ def test_analyze_dispatch_2_MI100(binary_handler_analyze_rocprof_compute):
     ])
     assert code == 0
 
-    test_utils.clean_output_dir(True, workload_dir)
+    test_utils.clean_output_dir(config["cleanup"], workload_dir)
 
 
 def test_analyze_dispatch_2_MI300A_A1(binary_handler_analyze_rocprof_compute):
@@ -868,7 +873,7 @@ def test_analyze_dispatch_2_MI300A_A1(binary_handler_analyze_rocprof_compute):
     ])
     assert code == 0
 
-    test_utils.clean_output_dir(True, workload_dir)
+    test_utils.clean_output_dir(config["cleanup"], workload_dir)
 
 
 def test_analyze_dispatch_2_MI200(binary_handler_analyze_rocprof_compute):
@@ -881,7 +886,7 @@ def test_analyze_dispatch_2_MI200(binary_handler_analyze_rocprof_compute):
     ])
     assert code == 0
 
-    test_utils.clean_output_dir(True, workload_dir)
+    test_utils.clean_output_dir(config["cleanup"], workload_dir)
 
 
 def test_analyze_dispatch_0_1_MI300X_A1(binary_handler_analyze_rocprof_compute):
@@ -896,7 +901,7 @@ def test_analyze_dispatch_0_1_MI300X_A1(binary_handler_analyze_rocprof_compute):
     ])
     assert code == 0
 
-    test_utils.clean_output_dir(True, workload_dir)
+    test_utils.clean_output_dir(config["cleanup"], workload_dir)
 
 
 def test_analyze_dispatch_0_1_MI100(binary_handler_analyze_rocprof_compute):
@@ -909,7 +914,7 @@ def test_analyze_dispatch_0_1_MI100(binary_handler_analyze_rocprof_compute):
     ])
     assert code == 0
 
-    test_utils.clean_output_dir(True, workload_dir)
+    test_utils.clean_output_dir(config["cleanup"], workload_dir)
 
 
 def test_analyze_dispatch_0_1_MI300A_A1(binary_handler_analyze_rocprof_compute):
@@ -924,7 +929,7 @@ def test_analyze_dispatch_0_1_MI300A_A1(binary_handler_analyze_rocprof_compute):
     ])
     assert code == 0
 
-    test_utils.clean_output_dir(True, workload_dir)
+    test_utils.clean_output_dir(config["cleanup"], workload_dir)
 
 
 def test_analyze_dispatch_0_1_MI200(binary_handler_analyze_rocprof_compute):
@@ -937,7 +942,7 @@ def test_analyze_dispatch_0_1_MI200(binary_handler_analyze_rocprof_compute):
     ])
     assert code == 0
 
-    test_utils.clean_output_dir(True, workload_dir)
+    test_utils.clean_output_dir(config["cleanup"], workload_dir)
 
 
 def test_analyze_mem_levels_LDS_MI200(binary_handler_analyze_rocprof_compute):
@@ -950,7 +955,7 @@ def test_analyze_mem_levels_LDS_MI200(binary_handler_analyze_rocprof_compute):
     ])
     assert code == 0
 
-    test_utils.clean_output_dir(True, workload_dir)
+    test_utils.clean_output_dir(config["cleanup"], workload_dir)
 
 
 def test_analyze_ipblocks_TA_MI300X_A1(binary_handler_analyze_rocprof_compute):
@@ -965,7 +970,7 @@ def test_analyze_ipblocks_TA_MI300X_A1(binary_handler_analyze_rocprof_compute):
     ])
     assert code == 0
 
-    test_utils.clean_output_dir(True, workload_dir)
+    test_utils.clean_output_dir(config["cleanup"], workload_dir)
 
 
 def test_analyze_ipblocks_TA_MI100(binary_handler_analyze_rocprof_compute):
@@ -978,7 +983,7 @@ def test_analyze_ipblocks_TA_MI100(binary_handler_analyze_rocprof_compute):
     ])
     assert code == 0
 
-    test_utils.clean_output_dir(True, workload_dir)
+    test_utils.clean_output_dir(config["cleanup"], workload_dir)
 
 
 def test_analyze_ipblocks_TA_MI300A_A1(binary_handler_analyze_rocprof_compute):
@@ -993,7 +998,7 @@ def test_analyze_ipblocks_TA_MI300A_A1(binary_handler_analyze_rocprof_compute):
     ])
     assert code == 0
 
-    test_utils.clean_output_dir(True, workload_dir)
+    test_utils.clean_output_dir(config["cleanup"], workload_dir)
 
 
 def test_analyze_ipblocks_TA_MI200(binary_handler_analyze_rocprof_compute):
@@ -1006,7 +1011,7 @@ def test_analyze_ipblocks_TA_MI200(binary_handler_analyze_rocprof_compute):
     ])
     assert code == 0
 
-    test_utils.clean_output_dir(True, workload_dir)
+    test_utils.clean_output_dir(config["cleanup"], workload_dir)
 
 
 def test_analyze_dispatch_6_8_MI300X_A1(binary_handler_analyze_rocprof_compute):
@@ -1021,7 +1026,7 @@ def test_analyze_dispatch_6_8_MI300X_A1(binary_handler_analyze_rocprof_compute):
     ])
     assert code == 0
 
-    test_utils.clean_output_dir(True, workload_dir)
+    test_utils.clean_output_dir(config["cleanup"], workload_dir)
 
 
 def test_analyze_dispatch_6_8_MI100(binary_handler_analyze_rocprof_compute):
@@ -1034,7 +1039,7 @@ def test_analyze_dispatch_6_8_MI100(binary_handler_analyze_rocprof_compute):
     ])
     assert code == 1
 
-    test_utils.clean_output_dir(True, workload_dir)
+    test_utils.clean_output_dir(config["cleanup"], workload_dir)
 
 
 def test_analyze_dispatch_6_8_MI300A_A1(binary_handler_analyze_rocprof_compute):
@@ -1049,7 +1054,7 @@ def test_analyze_dispatch_6_8_MI300A_A1(binary_handler_analyze_rocprof_compute):
     ])
     assert code == 0
 
-    test_utils.clean_output_dir(True, workload_dir)
+    test_utils.clean_output_dir(config["cleanup"], workload_dir)
 
 
 def test_analyze_dispatch_6_8_MI200(binary_handler_analyze_rocprof_compute):
@@ -1062,7 +1067,7 @@ def test_analyze_dispatch_6_8_MI200(binary_handler_analyze_rocprof_compute):
     ])
     assert code == 1
 
-    test_utils.clean_output_dir(True, workload_dir)
+    test_utils.clean_output_dir(config["cleanup"], workload_dir)
 
 
 def test_analyze_device_inv_int_MI300X_A1(binary_handler_analyze_rocprof_compute):
@@ -1077,7 +1082,7 @@ def test_analyze_device_inv_int_MI300X_A1(binary_handler_analyze_rocprof_compute
     ])
     assert code == 0
 
-    test_utils.clean_output_dir(True, workload_dir)
+    test_utils.clean_output_dir(config["cleanup"], workload_dir)
 
 
 def test_analyze_device_inv_int_MI100(binary_handler_analyze_rocprof_compute):
@@ -1090,7 +1095,7 @@ def test_analyze_device_inv_int_MI100(binary_handler_analyze_rocprof_compute):
     ])
     assert code == 0
 
-    test_utils.clean_output_dir(True, workload_dir)
+    test_utils.clean_output_dir(config["cleanup"], workload_dir)
 
 
 def test_analyze_device_inv_int_MI300A_A1(binary_handler_analyze_rocprof_compute):
@@ -1105,7 +1110,7 @@ def test_analyze_device_inv_int_MI300A_A1(binary_handler_analyze_rocprof_compute
     ])
     assert code == 0
 
-    test_utils.clean_output_dir(True, workload_dir)
+    test_utils.clean_output_dir(config["cleanup"], workload_dir)
 
 
 def test_analyze_device_inv_int_MI200(binary_handler_analyze_rocprof_compute):
@@ -1118,7 +1123,7 @@ def test_analyze_device_inv_int_MI200(binary_handler_analyze_rocprof_compute):
     ])
     assert code == 0
 
-    test_utils.clean_output_dir(True, workload_dir)
+    test_utils.clean_output_dir(config["cleanup"], workload_dir)
 
 
 def test_analyze_ipblocks_SQ_TA_MI300X_A1(binary_handler_analyze_rocprof_compute):
@@ -1133,7 +1138,7 @@ def test_analyze_ipblocks_SQ_TA_MI300X_A1(binary_handler_analyze_rocprof_compute
     ])
     assert code == 0
 
-    test_utils.clean_output_dir(True, workload_dir)
+    test_utils.clean_output_dir(config["cleanup"], workload_dir)
 
 
 def test_analyze_ipblocks_SQ_TA_MI100(binary_handler_analyze_rocprof_compute):
@@ -1146,7 +1151,7 @@ def test_analyze_ipblocks_SQ_TA_MI100(binary_handler_analyze_rocprof_compute):
     ])
     assert code == 0
 
-    test_utils.clean_output_dir(True, workload_dir)
+    test_utils.clean_output_dir(config["cleanup"], workload_dir)
 
 
 def test_analyze_ipblocks_SQ_TA_MI300A_A1(binary_handler_analyze_rocprof_compute):
@@ -1161,7 +1166,7 @@ def test_analyze_ipblocks_SQ_TA_MI300A_A1(binary_handler_analyze_rocprof_compute
     ])
     assert code == 0
 
-    test_utils.clean_output_dir(True, workload_dir)
+    test_utils.clean_output_dir(config["cleanup"], workload_dir)
 
 
 def test_analyze_ipblocks_SQ_TA_MI200(binary_handler_analyze_rocprof_compute):
@@ -1174,7 +1179,7 @@ def test_analyze_ipblocks_SQ_TA_MI200(binary_handler_analyze_rocprof_compute):
     ])
     assert code == 0
 
-    test_utils.clean_output_dir(True, workload_dir)
+    test_utils.clean_output_dir(config["cleanup"], workload_dir)
 
 
 def test_analyze_ipblocks_TD_MI300X_A1(binary_handler_analyze_rocprof_compute):
@@ -1189,7 +1194,7 @@ def test_analyze_ipblocks_TD_MI300X_A1(binary_handler_analyze_rocprof_compute):
     ])
     assert code == 0
 
-    test_utils.clean_output_dir(True, workload_dir)
+    test_utils.clean_output_dir(config["cleanup"], workload_dir)
 
 
 def test_analyze_ipblocks_TD_MI100(binary_handler_analyze_rocprof_compute):
@@ -1202,7 +1207,7 @@ def test_analyze_ipblocks_TD_MI100(binary_handler_analyze_rocprof_compute):
     ])
     assert code == 0
 
-    test_utils.clean_output_dir(True, workload_dir)
+    test_utils.clean_output_dir(config["cleanup"], workload_dir)
 
 
 def test_analyze_ipblocks_TD_MI300A_A1(binary_handler_analyze_rocprof_compute):
@@ -1217,7 +1222,7 @@ def test_analyze_ipblocks_TD_MI300A_A1(binary_handler_analyze_rocprof_compute):
     ])
     assert code == 0
 
-    test_utils.clean_output_dir(True, workload_dir)
+    test_utils.clean_output_dir(config["cleanup"], workload_dir)
 
 
 def test_analyze_ipblocks_TD_MI200(binary_handler_analyze_rocprof_compute):
@@ -1230,7 +1235,7 @@ def test_analyze_ipblocks_TD_MI200(binary_handler_analyze_rocprof_compute):
     ])
     assert code == 0
 
-    test_utils.clean_output_dir(True, workload_dir)
+    test_utils.clean_output_dir(config["cleanup"], workload_dir)
 
 
 def test_analyze_device_filter_MI300X_A1(binary_handler_analyze_rocprof_compute):
@@ -1245,7 +1250,7 @@ def test_analyze_device_filter_MI300X_A1(binary_handler_analyze_rocprof_compute)
     ])
     assert code == 0
 
-    test_utils.clean_output_dir(True, workload_dir)
+    test_utils.clean_output_dir(config["cleanup"], workload_dir)
 
 
 def test_analyze_device_filter_MI100(binary_handler_analyze_rocprof_compute):
@@ -1258,7 +1263,7 @@ def test_analyze_device_filter_MI100(binary_handler_analyze_rocprof_compute):
     ])
     assert code == 0
 
-    test_utils.clean_output_dir(True, workload_dir)
+    test_utils.clean_output_dir(config["cleanup"], workload_dir)
 
 
 def test_analyze_device_filter_MI300A_A1(binary_handler_analyze_rocprof_compute):
@@ -1273,7 +1278,7 @@ def test_analyze_device_filter_MI300A_A1(binary_handler_analyze_rocprof_compute)
     ])
     assert code == 0
 
-    test_utils.clean_output_dir(True, workload_dir)
+    test_utils.clean_output_dir(config["cleanup"], workload_dir)
 
 
 def test_analyze_device_filter_MI200(binary_handler_analyze_rocprof_compute):
@@ -1286,7 +1291,7 @@ def test_analyze_device_filter_MI200(binary_handler_analyze_rocprof_compute):
     ])
     assert code == 0
 
-    test_utils.clean_output_dir(True, workload_dir)
+    test_utils.clean_output_dir(config["cleanup"], workload_dir)
 
 
 def test_analyze_join_type_kernel_MI300X_A1(binary_handler_analyze_rocprof_compute):
@@ -1301,7 +1306,7 @@ def test_analyze_join_type_kernel_MI300X_A1(binary_handler_analyze_rocprof_compu
     ])
     assert code == 0
 
-    test_utils.clean_output_dir(True, workload_dir)
+    test_utils.clean_output_dir(config["cleanup"], workload_dir)
 
 
 def test_analyze_join_type_kernel_MI100(binary_handler_analyze_rocprof_compute):
@@ -1316,7 +1321,7 @@ def test_analyze_join_type_kernel_MI100(binary_handler_analyze_rocprof_compute):
     ])
     assert code == 0
 
-    test_utils.clean_output_dir(True, workload_dir)
+    test_utils.clean_output_dir(config["cleanup"], workload_dir)
 
 
 def test_analyze_join_type_kernel_MI300A_A1(binary_handler_analyze_rocprof_compute):
@@ -1331,7 +1336,7 @@ def test_analyze_join_type_kernel_MI300A_A1(binary_handler_analyze_rocprof_compu
     ])
     assert code == 0
 
-    test_utils.clean_output_dir(True, workload_dir)
+    test_utils.clean_output_dir(config["cleanup"], workload_dir)
 
 
 def test_analyze_join_type_kernel_MI200(binary_handler_analyze_rocprof_compute):
@@ -1346,7 +1351,7 @@ def test_analyze_join_type_kernel_MI200(binary_handler_analyze_rocprof_compute):
     ])
     assert code == 0
 
-    test_utils.clean_output_dir(True, workload_dir)
+    test_utils.clean_output_dir(config["cleanup"], workload_dir)
 
 
 def test_analyze_ipblocks_SQ_SQC_TCP_CPC_MI300X_A1(
@@ -1363,7 +1368,7 @@ def test_analyze_ipblocks_SQ_SQC_TCP_CPC_MI300X_A1(
     ])
     assert code == 0
 
-    test_utils.clean_output_dir(True, workload_dir)
+    test_utils.clean_output_dir(config["cleanup"], workload_dir)
 
 
 def test_analyze_ipblocks_SQ_SQC_TCP_CPC_MI100(binary_handler_analyze_rocprof_compute):
@@ -1378,7 +1383,7 @@ def test_analyze_ipblocks_SQ_SQC_TCP_CPC_MI100(binary_handler_analyze_rocprof_co
     ])
     assert code == 0
 
-    test_utils.clean_output_dir(True, workload_dir)
+    test_utils.clean_output_dir(config["cleanup"], workload_dir)
 
 
 def test_analyze_ipblocks_SQ_SQC_TCP_CPC_MI300A_A1(
@@ -1395,7 +1400,7 @@ def test_analyze_ipblocks_SQ_SQC_TCP_CPC_MI300A_A1(
     ])
     assert code == 0
 
-    test_utils.clean_output_dir(True, workload_dir)
+    test_utils.clean_output_dir(config["cleanup"], workload_dir)
 
 
 def test_analyze_ipblocks_SQ_SQC_TCP_CPC_MI200(binary_handler_analyze_rocprof_compute):
@@ -1410,7 +1415,7 @@ def test_analyze_ipblocks_SQ_SQC_TCP_CPC_MI200(binary_handler_analyze_rocprof_co
     ])
     assert code == 0
 
-    test_utils.clean_output_dir(True, workload_dir)
+    test_utils.clean_output_dir(config["cleanup"], workload_dir)
 
 
 def test_analyze_mem_levels_L2_vL1d_LDS_MI200(binary_handler_analyze_rocprof_compute):
@@ -1425,7 +1430,7 @@ def test_analyze_mem_levels_L2_vL1d_LDS_MI200(binary_handler_analyze_rocprof_com
     ])
     assert code == 0
 
-    test_utils.clean_output_dir(True, workload_dir)
+    test_utils.clean_output_dir(config["cleanup"], workload_dir)
 
 
 def test_analyze_ipblocks_CPF_MI300X_A1(binary_handler_analyze_rocprof_compute):
@@ -1440,7 +1445,7 @@ def test_analyze_ipblocks_CPF_MI300X_A1(binary_handler_analyze_rocprof_compute):
     ])
     assert code == 0
 
-    test_utils.clean_output_dir(True, workload_dir)
+    test_utils.clean_output_dir(config["cleanup"], workload_dir)
 
 
 def test_analyze_ipblocks_CPF_MI100(binary_handler_analyze_rocprof_compute):
@@ -1453,7 +1458,7 @@ def test_analyze_ipblocks_CPF_MI100(binary_handler_analyze_rocprof_compute):
     ])
     assert code == 0
 
-    test_utils.clean_output_dir(True, workload_dir)
+    test_utils.clean_output_dir(config["cleanup"], workload_dir)
 
 
 def test_analyze_ipblocks_CPF_MI300A_A1(binary_handler_analyze_rocprof_compute):
@@ -1468,7 +1473,7 @@ def test_analyze_ipblocks_CPF_MI300A_A1(binary_handler_analyze_rocprof_compute):
     ])
     assert code == 0
 
-    test_utils.clean_output_dir(True, workload_dir)
+    test_utils.clean_output_dir(config["cleanup"], workload_dir)
 
 
 def test_analyze_ipblocks_CPF_MI200(binary_handler_analyze_rocprof_compute):
@@ -1481,7 +1486,7 @@ def test_analyze_ipblocks_CPF_MI200(binary_handler_analyze_rocprof_compute):
     ])
     assert code == 0
 
-    test_utils.clean_output_dir(True, workload_dir)
+    test_utils.clean_output_dir(config["cleanup"], workload_dir)
 
 
 def test_analyze_sort_dispatches_MI200(binary_handler_analyze_rocprof_compute):
@@ -1496,7 +1501,7 @@ def test_analyze_sort_dispatches_MI200(binary_handler_analyze_rocprof_compute):
     ])
     assert code == 0
 
-    test_utils.clean_output_dir(True, workload_dir)
+    test_utils.clean_output_dir(config["cleanup"], workload_dir)
 
 
 def test_analyze_kernel_names_MI200(binary_handler_analyze_rocprof_compute):
@@ -1509,7 +1514,7 @@ def test_analyze_kernel_names_MI200(binary_handler_analyze_rocprof_compute):
     ])
     assert code == 0
 
-    test_utils.clean_output_dir(True, workload_dir)
+    test_utils.clean_output_dir(config["cleanup"], workload_dir)
 
 
 def test_analyze_mem_levels_vL1d_LDS_MI200(binary_handler_analyze_rocprof_compute):
@@ -1524,7 +1529,7 @@ def test_analyze_mem_levels_vL1d_LDS_MI200(binary_handler_analyze_rocprof_comput
     ])
     assert code == 0
 
-    test_utils.clean_output_dir(True, workload_dir)
+    test_utils.clean_output_dir(config["cleanup"], workload_dir)
 
 
 def test_analyze_ipblocks_SQ_MI300X_A1(binary_handler_analyze_rocprof_compute):
@@ -1539,7 +1544,7 @@ def test_analyze_ipblocks_SQ_MI300X_A1(binary_handler_analyze_rocprof_compute):
     ])
     assert code == 0
 
-    test_utils.clean_output_dir(True, workload_dir)
+    test_utils.clean_output_dir(config["cleanup"], workload_dir)
 
 
 def test_analyze_ipblocks_SQ_MI100(binary_handler_analyze_rocprof_compute):
@@ -1552,7 +1557,7 @@ def test_analyze_ipblocks_SQ_MI100(binary_handler_analyze_rocprof_compute):
     ])
     assert code == 0
 
-    test_utils.clean_output_dir(True, workload_dir)
+    test_utils.clean_output_dir(config["cleanup"], workload_dir)
 
 
 def test_analyze_ipblocks_SQ_MI300A_A1(binary_handler_analyze_rocprof_compute):
@@ -1567,7 +1572,7 @@ def test_analyze_ipblocks_SQ_MI300A_A1(binary_handler_analyze_rocprof_compute):
     ])
     assert code == 0
 
-    test_utils.clean_output_dir(True, workload_dir)
+    test_utils.clean_output_dir(config["cleanup"], workload_dir)
 
 
 def test_analyze_ipblocks_SQ_MI200(binary_handler_analyze_rocprof_compute):
@@ -1580,7 +1585,7 @@ def test_analyze_ipblocks_SQ_MI200(binary_handler_analyze_rocprof_compute):
     ])
     assert code == 0
 
-    test_utils.clean_output_dir(True, workload_dir)
+    test_utils.clean_output_dir(config["cleanup"], workload_dir)
 
 
 def test_analyze_mem_levels_L2_MI200(binary_handler_analyze_rocprof_compute):
@@ -1593,7 +1598,7 @@ def test_analyze_mem_levels_L2_MI200(binary_handler_analyze_rocprof_compute):
     ])
     assert code == 0
 
-    test_utils.clean_output_dir(True, workload_dir)
+    test_utils.clean_output_dir(config["cleanup"], workload_dir)
 
 
 def test_analyze_dispatch_inv_MI300X_A1(binary_handler_analyze_rocprof_compute):
@@ -1608,7 +1613,7 @@ def test_analyze_dispatch_inv_MI300X_A1(binary_handler_analyze_rocprof_compute):
     ])
     assert code == 0
 
-    test_utils.clean_output_dir(True, workload_dir)
+    test_utils.clean_output_dir(config["cleanup"], workload_dir)
 
 
 def test_analyze_dispatch_inv_MI100(binary_handler_analyze_rocprof_compute):
@@ -1621,7 +1626,7 @@ def test_analyze_dispatch_inv_MI100(binary_handler_analyze_rocprof_compute):
     ])
     assert code == 0
 
-    test_utils.clean_output_dir(True, workload_dir)
+    test_utils.clean_output_dir(config["cleanup"], workload_dir)
 
 
 def test_analyze_dispatch_inv_MI300A_A1(binary_handler_analyze_rocprof_compute):
@@ -1636,7 +1641,7 @@ def test_analyze_dispatch_inv_MI300A_A1(binary_handler_analyze_rocprof_compute):
     ])
     assert code == 0
 
-    test_utils.clean_output_dir(True, workload_dir)
+    test_utils.clean_output_dir(config["cleanup"], workload_dir)
 
 
 def test_analyze_dispatch_inv_MI200(binary_handler_analyze_rocprof_compute):
@@ -1649,7 +1654,7 @@ def test_analyze_dispatch_inv_MI200(binary_handler_analyze_rocprof_compute):
     ])
     assert code == 0
 
-    test_utils.clean_output_dir(True, workload_dir)
+    test_utils.clean_output_dir(config["cleanup"], workload_dir)
 
 
 def test_analyze_path_MI300X_A1(binary_handler_analyze_rocprof_compute):
@@ -1662,7 +1667,7 @@ def test_analyze_path_MI300X_A1(binary_handler_analyze_rocprof_compute):
     ])
     assert code == 0
 
-    test_utils.clean_output_dir(True, workload_dir)
+    test_utils.clean_output_dir(config["cleanup"], workload_dir)
 
 
 def test_analyze_path_MI100(binary_handler_analyze_rocprof_compute):
@@ -1675,7 +1680,7 @@ def test_analyze_path_MI100(binary_handler_analyze_rocprof_compute):
     ])
     assert code == 0
 
-    test_utils.clean_output_dir(True, workload_dir)
+    test_utils.clean_output_dir(config["cleanup"], workload_dir)
 
 
 def test_analyze_path_MI300A_A1(binary_handler_analyze_rocprof_compute):
@@ -1688,7 +1693,7 @@ def test_analyze_path_MI300A_A1(binary_handler_analyze_rocprof_compute):
     ])
     assert code == 0
 
-    test_utils.clean_output_dir(True, workload_dir)
+    test_utils.clean_output_dir(config["cleanup"], workload_dir)
 
 
 def test_analyze_path_MI200(binary_handler_analyze_rocprof_compute):
@@ -1701,7 +1706,7 @@ def test_analyze_path_MI200(binary_handler_analyze_rocprof_compute):
     ])
     assert code == 0
 
-    test_utils.clean_output_dir(True, workload_dir)
+    test_utils.clean_output_dir(config["cleanup"], workload_dir)
 
 
 def test_analyze_ipblocks_CPC_MI300X_A1(binary_handler_analyze_rocprof_compute):
@@ -1716,7 +1721,7 @@ def test_analyze_ipblocks_CPC_MI300X_A1(binary_handler_analyze_rocprof_compute):
     ])
     assert code == 0
 
-    test_utils.clean_output_dir(True, workload_dir)
+    test_utils.clean_output_dir(config["cleanup"], workload_dir)
 
 
 def test_analyze_ipblocks_CPC_MI100(binary_handler_analyze_rocprof_compute):
@@ -1729,7 +1734,7 @@ def test_analyze_ipblocks_CPC_MI100(binary_handler_analyze_rocprof_compute):
     ])
     assert code == 0
 
-    test_utils.clean_output_dir(True, workload_dir)
+    test_utils.clean_output_dir(config["cleanup"], workload_dir)
 
 
 def test_analyze_ipblocks_CPC_MI300A_A1(binary_handler_analyze_rocprof_compute):
@@ -1744,7 +1749,7 @@ def test_analyze_ipblocks_CPC_MI300A_A1(binary_handler_analyze_rocprof_compute):
     ])
     assert code == 0
 
-    test_utils.clean_output_dir(True, workload_dir)
+    test_utils.clean_output_dir(config["cleanup"], workload_dir)
 
 
 def test_analyze_ipblocks_CPC_MI200(binary_handler_analyze_rocprof_compute):
@@ -1757,7 +1762,7 @@ def test_analyze_ipblocks_CPC_MI200(binary_handler_analyze_rocprof_compute):
     ])
     assert code == 0
 
-    test_utils.clean_output_dir(True, workload_dir)
+    test_utils.clean_output_dir(config["cleanup"], workload_dir)
 
 
 def test_analyze_ipblocks_SQ_SPI_TA_TCC_CPF_MI300X_A1(
@@ -1774,7 +1779,7 @@ def test_analyze_ipblocks_SQ_SPI_TA_TCC_CPF_MI300X_A1(
     ])
     assert code == 0
 
-    test_utils.clean_output_dir(True, workload_dir)
+    test_utils.clean_output_dir(config["cleanup"], workload_dir)
 
 
 def test_analyze_ipblocks_SQ_SPI_TA_TCC_CPF_MI100(
@@ -1791,7 +1796,7 @@ def test_analyze_ipblocks_SQ_SPI_TA_TCC_CPF_MI100(
     ])
     assert code == 0
 
-    test_utils.clean_output_dir(True, workload_dir)
+    test_utils.clean_output_dir(config["cleanup"], workload_dir)
 
 
 def test_analyze_ipblocks_SQ_SPI_TA_TCC_CPF_MI300A_A1(
@@ -1808,7 +1813,7 @@ def test_analyze_ipblocks_SQ_SPI_TA_TCC_CPF_MI300A_A1(
     ])
     assert code == 0
 
-    test_utils.clean_output_dir(True, workload_dir)
+    test_utils.clean_output_dir(config["cleanup"], workload_dir)
 
 
 def test_analyze_ipblocks_SQ_SPI_TA_TCC_CPF_MI200(
@@ -1825,7 +1830,7 @@ def test_analyze_ipblocks_SQ_SPI_TA_TCC_CPF_MI200(
     ])
     assert code == 0
 
-    test_utils.clean_output_dir(True, workload_dir)
+    test_utils.clean_output_dir(config["cleanup"], workload_dir)
 
 
 def test_analyze_mem_levels_HBM_MI200(binary_handler_analyze_rocprof_compute):
@@ -1838,7 +1843,7 @@ def test_analyze_mem_levels_HBM_MI200(binary_handler_analyze_rocprof_compute):
     ])
     assert code == 0
 
-    test_utils.clean_output_dir(True, workload_dir)
+    test_utils.clean_output_dir(config["cleanup"], workload_dir)
 
 
 def test_analyze_ipblocks_SPI_MI300X_A1(binary_handler_analyze_rocprof_compute):
@@ -1853,7 +1858,7 @@ def test_analyze_ipblocks_SPI_MI300X_A1(binary_handler_analyze_rocprof_compute):
     ])
     assert code == 0
 
-    test_utils.clean_output_dir(True, workload_dir)
+    test_utils.clean_output_dir(config["cleanup"], workload_dir)
 
 
 def test_analyze_ipblocks_SPI_MI100(binary_handler_analyze_rocprof_compute):
@@ -1866,7 +1871,7 @@ def test_analyze_ipblocks_SPI_MI100(binary_handler_analyze_rocprof_compute):
     ])
     assert code == 0
 
-    test_utils.clean_output_dir(True, workload_dir)
+    test_utils.clean_output_dir(config["cleanup"], workload_dir)
 
 
 def test_analyze_ipblocks_SPI_MI300A_A1(binary_handler_analyze_rocprof_compute):
@@ -1881,7 +1886,7 @@ def test_analyze_ipblocks_SPI_MI300A_A1(binary_handler_analyze_rocprof_compute):
     ])
     assert code == 0
 
-    test_utils.clean_output_dir(True, workload_dir)
+    test_utils.clean_output_dir(config["cleanup"], workload_dir)
 
 
 def test_analyze_ipblocks_SPI_MI200(binary_handler_analyze_rocprof_compute):
@@ -1894,7 +1899,7 @@ def test_analyze_ipblocks_SPI_MI200(binary_handler_analyze_rocprof_compute):
     ])
     assert code == 0
 
-    test_utils.clean_output_dir(True, workload_dir)
+    test_utils.clean_output_dir(config["cleanup"], workload_dir)
 
 
 ##################################################
@@ -1926,7 +1931,7 @@ def test_analyze_torch_trace_list_operators_MI350(
     assert "kernel_launches:" in output
     assert "total_duration:" in output
 
-    test_utils.clean_output_dir(True, workload_dir)
+    test_utils.clean_output_dir(config["cleanup"], workload_dir)
 
 
 def test_analyze_torch_trace_filter_operator_MI350(
@@ -1951,7 +1956,7 @@ def test_analyze_torch_trace_filter_operator_MI350(
     assert "kernel_launches:" in output
     assert "total_duration:" in output
 
-    test_utils.clean_output_dir(True, workload_dir)
+    test_utils.clean_output_dir(config["cleanup"], workload_dir)
 
 
 def test_analyze_torch_trace_multi_operator_MI350(
@@ -1976,7 +1981,7 @@ def test_analyze_torch_trace_multi_operator_MI350(
     assert "relu" in output
     assert "ones_like" in output
 
-    test_utils.clean_output_dir(True, workload_dir)
+    test_utils.clean_output_dir(config["cleanup"], workload_dir)
 
 
 def test_analyze_torch_trace_invalid_operator_MI350(
@@ -1997,7 +2002,7 @@ def test_analyze_torch_trace_invalid_operator_MI350(
     output = capsys.readouterr().out
     assert "No operators matched" in output
 
-    test_utils.clean_output_dir(True, workload_dir)
+    test_utils.clean_output_dir(config["cleanup"], workload_dir)
 
 
 def test_analyze_torch_trace_hierarchy_path_MI350(
@@ -2022,7 +2027,7 @@ def test_analyze_torch_trace_hierarchy_path_MI350(
     assert "torch.relu" in output
     assert "kernel_launches:" in output
 
-    test_utils.clean_output_dir(True, workload_dir)
+    test_utils.clean_output_dir(config["cleanup"], workload_dir)
 
 
 def test_analyze_torch_trace_torch_prefix_MI350(
@@ -2046,4 +2051,4 @@ def test_analyze_torch_trace_torch_prefix_MI350(
     assert "torch.relu" in output
     assert "kernel_launches:" in output
 
-    test_utils.clean_output_dir(True, workload_dir)
+    test_utils.clean_output_dir(config["cleanup"], workload_dir)

--- a/projects/rocprofiler-compute/tests/test_analyze_workloads.py
+++ b/projects/rocprofiler-compute/tests/test_analyze_workloads.py
@@ -27,1214 +27,1874 @@
 ##          Generated tests                     ##
 ##################################################
 
+import test_utils
+
 
 def test_analyze_vcopy_MI100(binary_handler_analyze_rocprof_compute):
+    workload_dir = test_utils.setup_workload_dir("tests/workloads/vcopy/MI100")
+
     code = binary_handler_analyze_rocprof_compute([
         "analyze",
         "--path",
-        "tests/workloads/vcopy/MI100",
+        workload_dir,
     ])
     assert code == 0
+
+    test_utils.clean_output_dir(True, workload_dir)
 
 
 def test_analyze_vcopy_MI200(binary_handler_analyze_rocprof_compute):
+    workload_dir = test_utils.setup_workload_dir("tests/workloads/vcopy/MI200")
+
     code = binary_handler_analyze_rocprof_compute([
         "analyze",
         "--path",
-        "tests/workloads/vcopy/MI200",
+        workload_dir,
     ])
     assert code == 0
+
+    test_utils.clean_output_dir(True, workload_dir)
 
 
 def test_analyze_ipblocks_TCP_MI300X_A1(binary_handler_analyze_rocprof_compute):
+    workload_dir = test_utils.setup_workload_dir(
+        "tests/workloads/ipblocks_TCP/MI300X_A1"
+    )
+
     code = binary_handler_analyze_rocprof_compute([
         "analyze",
         "--path",
-        "tests/workloads/ipblocks_TCP/MI300X_A1",
+        workload_dir,
     ])
     assert code == 0
+
+    test_utils.clean_output_dir(True, workload_dir)
 
 
 def test_analyze_ipblocks_TCP_MI100(binary_handler_analyze_rocprof_compute):
+    workload_dir = test_utils.setup_workload_dir("tests/workloads/ipblocks_TCP/MI100")
+
     code = binary_handler_analyze_rocprof_compute([
         "analyze",
         "--path",
-        "tests/workloads/ipblocks_TCP/MI100",
+        workload_dir,
     ])
     assert code == 0
+
+    test_utils.clean_output_dir(True, workload_dir)
 
 
 def test_analyze_ipblocks_TCP_MI300A_A1(binary_handler_analyze_rocprof_compute):
+    workload_dir = test_utils.setup_workload_dir(
+        "tests/workloads/ipblocks_TCP/MI300A_A1"
+    )
+
     code = binary_handler_analyze_rocprof_compute([
         "analyze",
         "--path",
-        "tests/workloads/ipblocks_TCP/MI300A_A1",
+        workload_dir,
     ])
     assert code == 0
+
+    test_utils.clean_output_dir(True, workload_dir)
 
 
 def test_analyze_ipblocks_TCP_MI200(binary_handler_analyze_rocprof_compute):
+    workload_dir = test_utils.setup_workload_dir("tests/workloads/ipblocks_TCP/MI200")
+
     code = binary_handler_analyze_rocprof_compute([
         "analyze",
         "--path",
-        "tests/workloads/ipblocks_TCP/MI200",
+        workload_dir,
     ])
     assert code == 0
+
+    test_utils.clean_output_dir(True, workload_dir)
 
 
 def test_analyze_ipblocks_SQC_MI300X_A1(binary_handler_analyze_rocprof_compute):
+    workload_dir = test_utils.setup_workload_dir(
+        "tests/workloads/ipblocks_SQC/MI300X_A1"
+    )
+
     code = binary_handler_analyze_rocprof_compute([
         "analyze",
         "--path",
-        "tests/workloads/ipblocks_SQC/MI300X_A1",
+        workload_dir,
     ])
     assert code == 0
+
+    test_utils.clean_output_dir(True, workload_dir)
 
 
 def test_analyze_ipblocks_SQC_MI100(binary_handler_analyze_rocprof_compute):
+    workload_dir = test_utils.setup_workload_dir("tests/workloads/ipblocks_SQC/MI100")
+
     code = binary_handler_analyze_rocprof_compute([
         "analyze",
         "--path",
-        "tests/workloads/ipblocks_SQC/MI100",
+        workload_dir,
     ])
     assert code == 0
+
+    test_utils.clean_output_dir(True, workload_dir)
 
 
 def test_analyze_ipblocks_SQC_MI300A_A1(binary_handler_analyze_rocprof_compute):
+    workload_dir = test_utils.setup_workload_dir(
+        "tests/workloads/ipblocks_SQC/MI300A_A1"
+    )
+
     code = binary_handler_analyze_rocprof_compute([
         "analyze",
         "--path",
-        "tests/workloads/ipblocks_SQC/MI300A_A1",
+        workload_dir,
     ])
     assert code == 0
+
+    test_utils.clean_output_dir(True, workload_dir)
 
 
 def test_analyze_ipblocks_SQC_MI200(binary_handler_analyze_rocprof_compute):
+    workload_dir = test_utils.setup_workload_dir("tests/workloads/ipblocks_SQC/MI200")
+
     code = binary_handler_analyze_rocprof_compute([
         "analyze",
         "--path",
-        "tests/workloads/ipblocks_SQC/MI200",
+        workload_dir,
     ])
     assert code == 0
+
+    test_utils.clean_output_dir(True, workload_dir)
 
 
 def test_analyze_mem_levels_HBM_LDS_MI200(binary_handler_analyze_rocprof_compute):
+    workload_dir = test_utils.setup_workload_dir(
+        "tests/workloads/mem_levels_HBM_LDS/MI200"
+    )
+
     code = binary_handler_analyze_rocprof_compute([
         "analyze",
         "--path",
-        "tests/workloads/mem_levels_HBM_LDS/MI200",
+        workload_dir,
     ])
     assert code == 0
+
+    test_utils.clean_output_dir(True, workload_dir)
 
 
 def test_analyze_ipblocks_TCC_MI300X_A1(binary_handler_analyze_rocprof_compute):
+    workload_dir = test_utils.setup_workload_dir(
+        "tests/workloads/ipblocks_TCC/MI300X_A1"
+    )
+
     code = binary_handler_analyze_rocprof_compute([
         "analyze",
         "--path",
-        "tests/workloads/ipblocks_TCC/MI300X_A1",
+        workload_dir,
     ])
     assert code == 0
+
+    test_utils.clean_output_dir(True, workload_dir)
 
 
 def test_analyze_ipblocks_TCC_MI100(binary_handler_analyze_rocprof_compute):
+    workload_dir = test_utils.setup_workload_dir("tests/workloads/ipblocks_TCC/MI100")
+
     code = binary_handler_analyze_rocprof_compute([
         "analyze",
         "--path",
-        "tests/workloads/ipblocks_TCC/MI100",
+        workload_dir,
     ])
     assert code == 0
+
+    test_utils.clean_output_dir(True, workload_dir)
 
 
 def test_analyze_ipblocks_TCC_MI300A_A1(binary_handler_analyze_rocprof_compute):
+    workload_dir = test_utils.setup_workload_dir(
+        "tests/workloads/ipblocks_TCC/MI300A_A1"
+    )
+
     code = binary_handler_analyze_rocprof_compute([
         "analyze",
         "--path",
-        "tests/workloads/ipblocks_TCC/MI300A_A1",
+        workload_dir,
     ])
     assert code == 0
+
+    test_utils.clean_output_dir(True, workload_dir)
 
 
 def test_analyze_ipblocks_TCC_MI200(binary_handler_analyze_rocprof_compute):
+    workload_dir = test_utils.setup_workload_dir("tests/workloads/ipblocks_TCC/MI200")
+
     code = binary_handler_analyze_rocprof_compute([
         "analyze",
         "--path",
-        "tests/workloads/ipblocks_TCC/MI200",
+        workload_dir,
     ])
     assert code == 0
+
+    test_utils.clean_output_dir(True, workload_dir)
 
 
 def test_analyze_no_roof_MI350(binary_handler_analyze_rocprof_compute):
+    workload_dir = test_utils.setup_workload_dir("tests/workloads/no_roof/MI350")
+
     code = binary_handler_analyze_rocprof_compute([
         "analyze",
         "--path",
-        "tests/workloads/no_roof/MI350",
+        workload_dir,
     ])
     assert code == 0
+
+    test_utils.clean_output_dir(True, workload_dir)
 
 
 def test_analyze_no_roof_MI300X_A1(binary_handler_analyze_rocprof_compute):
+    workload_dir = test_utils.setup_workload_dir("tests/workloads/no_roof/MI300X_A1")
+
     code = binary_handler_analyze_rocprof_compute([
         "analyze",
         "--path",
-        "tests/workloads/no_roof/MI300X_A1",
+        workload_dir,
     ])
     assert code == 0
+
+    test_utils.clean_output_dir(True, workload_dir)
 
 
 def test_analyze_no_roof_MI100(binary_handler_analyze_rocprof_compute):
+    workload_dir = test_utils.setup_workload_dir("tests/workloads/no_roof/MI100")
+
     code = binary_handler_analyze_rocprof_compute([
         "analyze",
         "--path",
-        "tests/workloads/no_roof/MI100",
+        workload_dir,
     ])
     assert code == 0
+
+    test_utils.clean_output_dir(True, workload_dir)
 
 
 def test_analyze_no_roof_MI300A_A1(binary_handler_analyze_rocprof_compute):
+    workload_dir = test_utils.setup_workload_dir("tests/workloads/no_roof/MI300A_A1")
+
     code = binary_handler_analyze_rocprof_compute([
         "analyze",
         "--path",
-        "tests/workloads/no_roof/MI300A_A1",
+        workload_dir,
     ])
     assert code == 0
+
+    test_utils.clean_output_dir(True, workload_dir)
 
 
 def test_analyze_no_roof_MI200(binary_handler_analyze_rocprof_compute):
+    workload_dir = test_utils.setup_workload_dir("tests/workloads/no_roof/MI200")
+
     code = binary_handler_analyze_rocprof_compute([
         "analyze",
         "--path",
-        "tests/workloads/no_roof/MI200",
+        workload_dir,
     ])
     assert code == 0
+
+    test_utils.clean_output_dir(True, workload_dir)
 
 
 def test_analyze_ipblocks_SQ_CPC_MI300X_A1(binary_handler_analyze_rocprof_compute):
+    workload_dir = test_utils.setup_workload_dir(
+        "tests/workloads/ipblocks_SQ_CPC/MI300X_A1"
+    )
+
     code = binary_handler_analyze_rocprof_compute([
         "analyze",
         "--path",
-        "tests/workloads/ipblocks_SQ_CPC/MI300X_A1",
+        workload_dir,
     ])
     assert code == 0
+
+    test_utils.clean_output_dir(True, workload_dir)
 
 
 def test_analyze_ipblocks_SQ_CPC_MI100(binary_handler_analyze_rocprof_compute):
+    workload_dir = test_utils.setup_workload_dir(
+        "tests/workloads/ipblocks_SQ_CPC/MI100"
+    )
+
     code = binary_handler_analyze_rocprof_compute([
         "analyze",
         "--path",
-        "tests/workloads/ipblocks_SQ_CPC/MI100",
+        workload_dir,
     ])
     assert code == 0
+
+    test_utils.clean_output_dir(True, workload_dir)
 
 
 def test_analyze_ipblocks_SQ_CPC_MI300A_A1(binary_handler_analyze_rocprof_compute):
+    workload_dir = test_utils.setup_workload_dir(
+        "tests/workloads/ipblocks_SQ_CPC/MI300A_A1"
+    )
+
     code = binary_handler_analyze_rocprof_compute([
         "analyze",
         "--path",
-        "tests/workloads/ipblocks_SQ_CPC/MI300A_A1",
+        workload_dir,
     ])
     assert code == 0
+
+    test_utils.clean_output_dir(True, workload_dir)
 
 
 def test_analyze_ipblocks_SQ_CPC_MI200(binary_handler_analyze_rocprof_compute):
+    workload_dir = test_utils.setup_workload_dir(
+        "tests/workloads/ipblocks_SQ_CPC/MI200"
+    )
+
     code = binary_handler_analyze_rocprof_compute([
         "analyze",
         "--path",
-        "tests/workloads/ipblocks_SQ_CPC/MI200",
+        workload_dir,
     ])
     assert code == 0
+
+    test_utils.clean_output_dir(True, workload_dir)
 
 
 def test_analyze_dispatch_0_MI300X_A1(binary_handler_analyze_rocprof_compute):
+    workload_dir = test_utils.setup_workload_dir("tests/workloads/dispatch_0/MI300X_A1")
+
     code = binary_handler_analyze_rocprof_compute([
         "analyze",
         "--path",
-        "tests/workloads/dispatch_0/MI300X_A1",
+        workload_dir,
     ])
     assert code == 0
+
+    test_utils.clean_output_dir(True, workload_dir)
 
 
 def test_analyze_dispatch_0_MI100(binary_handler_analyze_rocprof_compute):
+    workload_dir = test_utils.setup_workload_dir("tests/workloads/dispatch_0/MI100")
+
     code = binary_handler_analyze_rocprof_compute([
         "analyze",
         "--path",
-        "tests/workloads/dispatch_0/MI100",
+        workload_dir,
     ])
     assert code == 0
+
+    test_utils.clean_output_dir(True, workload_dir)
 
 
 def test_analyze_dispatch_0_MI300A_A1(binary_handler_analyze_rocprof_compute):
+    workload_dir = test_utils.setup_workload_dir("tests/workloads/dispatch_0/MI300A_A1")
+
     code = binary_handler_analyze_rocprof_compute([
         "analyze",
         "--path",
-        "tests/workloads/dispatch_0/MI300A_A1",
+        workload_dir,
     ])
     assert code == 0
+
+    test_utils.clean_output_dir(True, workload_dir)
 
 
 def test_analyze_dispatch_0_MI200(binary_handler_analyze_rocprof_compute):
+    workload_dir = test_utils.setup_workload_dir("tests/workloads/dispatch_0/MI200")
+
     code = binary_handler_analyze_rocprof_compute([
         "analyze",
         "--path",
-        "tests/workloads/dispatch_0/MI200",
+        workload_dir,
     ])
     assert code == 0
+
+    test_utils.clean_output_dir(True, workload_dir)
 
 
 def test_analyze_join_type_grid_MI300X_A1(binary_handler_analyze_rocprof_compute):
+    workload_dir = test_utils.setup_workload_dir(
+        "tests/workloads/join_type_grid/MI300X_A1"
+    )
+
     code = binary_handler_analyze_rocprof_compute([
         "analyze",
         "--path",
-        "tests/workloads/join_type_grid/MI300X_A1",
+        workload_dir,
     ])
     assert code == 0
+
+    test_utils.clean_output_dir(True, workload_dir)
 
 
 def test_analyze_join_type_grid_MI100(binary_handler_analyze_rocprof_compute):
+    workload_dir = test_utils.setup_workload_dir("tests/workloads/join_type_grid/MI100")
+
     code = binary_handler_analyze_rocprof_compute([
         "analyze",
         "--path",
-        "tests/workloads/join_type_grid/MI100",
+        workload_dir,
     ])
     assert code == 0
+
+    test_utils.clean_output_dir(True, workload_dir)
 
 
 def test_analyze_join_type_grid_MI300A_A1(binary_handler_analyze_rocprof_compute):
+    workload_dir = test_utils.setup_workload_dir(
+        "tests/workloads/join_type_grid/MI300A_A1"
+    )
+
     code = binary_handler_analyze_rocprof_compute([
         "analyze",
         "--path",
-        "tests/workloads/join_type_grid/MI300A_A1",
+        workload_dir,
     ])
     assert code == 0
+
+    test_utils.clean_output_dir(True, workload_dir)
 
 
 def test_analyze_join_type_grid_MI200(binary_handler_analyze_rocprof_compute):
+    workload_dir = test_utils.setup_workload_dir("tests/workloads/join_type_grid/MI200")
+
     code = binary_handler_analyze_rocprof_compute([
         "analyze",
         "--path",
-        "tests/workloads/join_type_grid/MI200",
+        workload_dir,
     ])
     assert code == 0
+
+    test_utils.clean_output_dir(True, workload_dir)
 
 
 def test_analyze_kernel_MI300X_A1(binary_handler_analyze_rocprof_compute):
+    workload_dir = test_utils.setup_workload_dir("tests/workloads/kernel/MI300X_A1")
+
     code = binary_handler_analyze_rocprof_compute([
         "analyze",
         "--path",
-        "tests/workloads/kernel/MI300X_A1",
+        workload_dir,
     ])
     assert code == 0
+
+    test_utils.clean_output_dir(True, workload_dir)
 
 
 def test_analyze_kernel_MI100(binary_handler_analyze_rocprof_compute):
+    workload_dir = test_utils.setup_workload_dir("tests/workloads/kernel/MI100")
+
     code = binary_handler_analyze_rocprof_compute([
         "analyze",
         "--path",
-        "tests/workloads/kernel/MI100",
+        workload_dir,
     ])
     assert code == 0
+
+    test_utils.clean_output_dir(True, workload_dir)
 
 
 def test_analyze_kernel_MI300A_A1(binary_handler_analyze_rocprof_compute):
+    workload_dir = test_utils.setup_workload_dir("tests/workloads/kernel/MI300A_A1")
+
     code = binary_handler_analyze_rocprof_compute([
         "analyze",
         "--path",
-        "tests/workloads/kernel/MI300A_A1",
+        workload_dir,
     ])
     assert code == 0
+
+    test_utils.clean_output_dir(True, workload_dir)
 
 
 def test_analyze_kernel_MI200(binary_handler_analyze_rocprof_compute):
+    workload_dir = test_utils.setup_workload_dir("tests/workloads/kernel/MI200")
+
     code = binary_handler_analyze_rocprof_compute([
         "analyze",
         "--path",
-        "tests/workloads/kernel/MI200",
+        workload_dir,
     ])
     assert code == 0
+
+    test_utils.clean_output_dir(True, workload_dir)
 
 
 def test_analyze_kernel_substr_MI300X_A1(binary_handler_analyze_rocprof_compute):
+    workload_dir = test_utils.setup_workload_dir(
+        "tests/workloads/kernel_substr/MI300X_A1"
+    )
+
     code = binary_handler_analyze_rocprof_compute([
         "analyze",
         "--path",
-        "tests/workloads/kernel_substr/MI300X_A1",
+        workload_dir,
     ])
     assert code == 0
+
+    test_utils.clean_output_dir(True, workload_dir)
 
 
 def test_analyze_kernel_substr_MI100(binary_handler_analyze_rocprof_compute):
+    workload_dir = test_utils.setup_workload_dir("tests/workloads/kernel_substr/MI100")
+
     code = binary_handler_analyze_rocprof_compute([
         "analyze",
         "--path",
-        "tests/workloads/kernel_substr/MI100",
+        workload_dir,
     ])
     assert code == 0
+
+    test_utils.clean_output_dir(True, workload_dir)
 
 
 def test_analyze_kernel_substr_MI300A_A1(binary_handler_analyze_rocprof_compute):
+    workload_dir = test_utils.setup_workload_dir(
+        "tests/workloads/kernel_substr/MI300A_A1"
+    )
+
     code = binary_handler_analyze_rocprof_compute([
         "analyze",
         "--path",
-        "tests/workloads/kernel_substr/MI300A_A1",
+        workload_dir,
     ])
     assert code == 0
+
+    test_utils.clean_output_dir(True, workload_dir)
 
 
 def test_analyze_kernel_substr_MI200(binary_handler_analyze_rocprof_compute):
+    workload_dir = test_utils.setup_workload_dir("tests/workloads/kernel_substr/MI200")
+
     code = binary_handler_analyze_rocprof_compute([
         "analyze",
         "--path",
-        "tests/workloads/kernel_substr/MI200",
+        workload_dir,
     ])
     assert code == 0
+
+    test_utils.clean_output_dir(True, workload_dir)
 
 
 def test_analyze_dispatch_7_MI300X_A1(binary_handler_analyze_rocprof_compute):
+    workload_dir = test_utils.setup_workload_dir("tests/workloads/dispatch_7/MI300X_A1")
+
     code = binary_handler_analyze_rocprof_compute([
         "analyze",
         "--path",
-        "tests/workloads/dispatch_7/MI300X_A1",
+        workload_dir,
     ])
     assert code == 0
+
+    test_utils.clean_output_dir(True, workload_dir)
 
 
 def test_analyze_dispatch_7_MI100(binary_handler_analyze_rocprof_compute):
+    workload_dir = test_utils.setup_workload_dir("tests/workloads/dispatch_7/MI100")
+
     code = binary_handler_analyze_rocprof_compute([
         "analyze",
         "--path",
-        "tests/workloads/dispatch_7/MI100",
+        workload_dir,
     ])
     assert code == 1
+
+    test_utils.clean_output_dir(True, workload_dir)
 
 
 def test_analyze_dispatch_7_MI300A_A1(binary_handler_analyze_rocprof_compute):
+    workload_dir = test_utils.setup_workload_dir("tests/workloads/dispatch_7/MI300A_A1")
+
     code = binary_handler_analyze_rocprof_compute([
         "analyze",
         "--path",
-        "tests/workloads/dispatch_7/MI300A_A1",
+        workload_dir,
     ])
     assert code == 0
+
+    test_utils.clean_output_dir(True, workload_dir)
 
 
 def test_analyze_dispatch_7_MI200(binary_handler_analyze_rocprof_compute):
+    workload_dir = test_utils.setup_workload_dir("tests/workloads/dispatch_7/MI200")
+
     code = binary_handler_analyze_rocprof_compute([
         "analyze",
         "--path",
-        "tests/workloads/dispatch_7/MI200",
+        workload_dir,
     ])
     assert code == 1
+
+    test_utils.clean_output_dir(True, workload_dir)
 
 
 def test_analyze_kernel_inv_int_MI300X_A1(binary_handler_analyze_rocprof_compute):
+    workload_dir = test_utils.setup_workload_dir(
+        "tests/workloads/kernel_inv_int/MI300X_A1"
+    )
+
     code = binary_handler_analyze_rocprof_compute([
         "analyze",
         "--path",
-        "tests/workloads/kernel_inv_int/MI300X_A1",
+        workload_dir,
     ])
     assert code == 0
+
+    test_utils.clean_output_dir(True, workload_dir)
 
 
 def test_analyze_kernel_inv_int_MI100(binary_handler_analyze_rocprof_compute):
+    workload_dir = test_utils.setup_workload_dir("tests/workloads/kernel_inv_int/MI100")
+
     code = binary_handler_analyze_rocprof_compute([
         "analyze",
         "--path",
-        "tests/workloads/kernel_inv_int/MI100",
+        workload_dir,
     ])
     assert code == 1
+
+    test_utils.clean_output_dir(True, workload_dir)
 
 
 def test_analyze_kernel_inv_int_MI300A_A1(binary_handler_analyze_rocprof_compute):
+    workload_dir = test_utils.setup_workload_dir(
+        "tests/workloads/kernel_inv_int/MI300A_A1"
+    )
+
     code = binary_handler_analyze_rocprof_compute([
         "analyze",
         "--path",
-        "tests/workloads/kernel_inv_int/MI300A_A1",
+        workload_dir,
     ])
     assert code == 0
+
+    test_utils.clean_output_dir(True, workload_dir)
 
 
 def test_analyze_kernel_inv_int_MI200(binary_handler_analyze_rocprof_compute):
+    workload_dir = test_utils.setup_workload_dir("tests/workloads/kernel_inv_int/MI200")
+
     code = binary_handler_analyze_rocprof_compute([
         "analyze",
         "--path",
-        "tests/workloads/kernel_inv_int/MI200",
+        workload_dir,
     ])
     assert code == 1
+
+    test_utils.clean_output_dir(True, workload_dir)
 
 
 def test_analyze_mem_levels_vL1D_MI200(binary_handler_analyze_rocprof_compute):
+    workload_dir = test_utils.setup_workload_dir(
+        "tests/workloads/mem_levels_vL1D/MI200"
+    )
+
     code = binary_handler_analyze_rocprof_compute([
         "analyze",
         "--path",
-        "tests/workloads/mem_levels_vL1D/MI200",
+        workload_dir,
     ])
     assert code == 0
+
+    test_utils.clean_output_dir(True, workload_dir)
 
 
 def test_analyze_sort_kernels_MI200(binary_handler_analyze_rocprof_compute):
+    workload_dir = test_utils.setup_workload_dir("tests/workloads/sort_kernels/MI200")
+
     code = binary_handler_analyze_rocprof_compute([
         "analyze",
         "--path",
-        "tests/workloads/sort_kernels/MI200",
+        workload_dir,
     ])
     assert code == 0
+
+    test_utils.clean_output_dir(True, workload_dir)
 
 
 def test_analyze_kernel_inv_str_MI300X_A1(binary_handler_analyze_rocprof_compute):
+    workload_dir = test_utils.setup_workload_dir(
+        "tests/workloads/kernel_inv_str/MI300X_A1"
+    )
+
     code = binary_handler_analyze_rocprof_compute([
         "analyze",
         "--path",
-        "tests/workloads/kernel_inv_str/MI300X_A1",
+        workload_dir,
     ])
     assert code == 0
+
+    test_utils.clean_output_dir(True, workload_dir)
 
 
 def test_analyze_kernel_inv_str_MI100(binary_handler_analyze_rocprof_compute):
+    workload_dir = test_utils.setup_workload_dir("tests/workloads/kernel_inv_str/MI100")
+
     code = binary_handler_analyze_rocprof_compute([
         "analyze",
         "--path",
-        "tests/workloads/kernel_inv_str/MI100",
+        workload_dir,
     ])
     assert code == 1
+
+    test_utils.clean_output_dir(True, workload_dir)
 
 
 def test_analyze_kernel_inv_str_MI300A_A1(binary_handler_analyze_rocprof_compute):
+    workload_dir = test_utils.setup_workload_dir(
+        "tests/workloads/kernel_inv_str/MI300A_A1"
+    )
+
     code = binary_handler_analyze_rocprof_compute([
         "analyze",
         "--path",
-        "tests/workloads/kernel_inv_str/MI300A_A1",
+        workload_dir,
     ])
     assert code == 0
+
+    test_utils.clean_output_dir(True, workload_dir)
 
 
 def test_analyze_kernel_inv_str_MI200(binary_handler_analyze_rocprof_compute):
+    workload_dir = test_utils.setup_workload_dir("tests/workloads/kernel_inv_str/MI200")
+
     code = binary_handler_analyze_rocprof_compute([
         "analyze",
         "--path",
-        "tests/workloads/kernel_inv_str/MI200",
+        workload_dir,
     ])
     assert code == 1
+
+    test_utils.clean_output_dir(True, workload_dir)
 
 
 def test_analyze_ipblocks_SQ_SPI_MI300X_A1(binary_handler_analyze_rocprof_compute):
+    workload_dir = test_utils.setup_workload_dir(
+        "tests/workloads/ipblocks_SQ_SPI/MI300X_A1"
+    )
+
     code = binary_handler_analyze_rocprof_compute([
         "analyze",
         "--path",
-        "tests/workloads/ipblocks_SQ_SPI/MI300X_A1",
+        workload_dir,
     ])
     assert code == 0
+
+    test_utils.clean_output_dir(True, workload_dir)
 
 
 def test_analyze_ipblocks_SQ_SPI_MI100(binary_handler_analyze_rocprof_compute):
+    workload_dir = test_utils.setup_workload_dir(
+        "tests/workloads/ipblocks_SQ_SPI/MI100"
+    )
+
     code = binary_handler_analyze_rocprof_compute([
         "analyze",
         "--path",
-        "tests/workloads/ipblocks_SQ_SPI/MI100",
+        workload_dir,
     ])
     assert code == 0
+
+    test_utils.clean_output_dir(True, workload_dir)
 
 
 def test_analyze_ipblocks_SQ_SPI_MI300A_A1(binary_handler_analyze_rocprof_compute):
+    workload_dir = test_utils.setup_workload_dir(
+        "tests/workloads/ipblocks_SQ_SPI/MI300A_A1"
+    )
+
     code = binary_handler_analyze_rocprof_compute([
         "analyze",
         "--path",
-        "tests/workloads/ipblocks_SQ_SPI/MI300A_A1",
+        workload_dir,
     ])
     assert code == 0
+
+    test_utils.clean_output_dir(True, workload_dir)
 
 
 def test_analyze_ipblocks_SQ_SPI_MI200(binary_handler_analyze_rocprof_compute):
+    workload_dir = test_utils.setup_workload_dir(
+        "tests/workloads/ipblocks_SQ_SPI/MI200"
+    )
+
     code = binary_handler_analyze_rocprof_compute([
         "analyze",
         "--path",
-        "tests/workloads/ipblocks_SQ_SPI/MI200",
+        workload_dir,
     ])
     assert code == 0
+
+    test_utils.clean_output_dir(True, workload_dir)
 
 
 def test_analyze_dispatch_2_MI300X_A1(binary_handler_analyze_rocprof_compute):
+    workload_dir = test_utils.setup_workload_dir("tests/workloads/dispatch_2/MI300X_A1")
+
     code = binary_handler_analyze_rocprof_compute([
         "analyze",
         "--path",
-        "tests/workloads/dispatch_2/MI300X_A1",
+        workload_dir,
     ])
     assert code == 0
+
+    test_utils.clean_output_dir(True, workload_dir)
 
 
 def test_analyze_dispatch_2_MI100(binary_handler_analyze_rocprof_compute):
+    workload_dir = test_utils.setup_workload_dir("tests/workloads/dispatch_2/MI100")
+
     code = binary_handler_analyze_rocprof_compute([
         "analyze",
         "--path",
-        "tests/workloads/dispatch_2/MI100",
+        workload_dir,
     ])
     assert code == 0
+
+    test_utils.clean_output_dir(True, workload_dir)
 
 
 def test_analyze_dispatch_2_MI300A_A1(binary_handler_analyze_rocprof_compute):
+    workload_dir = test_utils.setup_workload_dir("tests/workloads/dispatch_2/MI300A_A1")
+
     code = binary_handler_analyze_rocprof_compute([
         "analyze",
         "--path",
-        "tests/workloads/dispatch_2/MI300A_A1",
+        workload_dir,
     ])
     assert code == 0
+
+    test_utils.clean_output_dir(True, workload_dir)
 
 
 def test_analyze_dispatch_2_MI200(binary_handler_analyze_rocprof_compute):
+    workload_dir = test_utils.setup_workload_dir("tests/workloads/dispatch_2/MI200")
+
     code = binary_handler_analyze_rocprof_compute([
         "analyze",
         "--path",
-        "tests/workloads/dispatch_2/MI200",
+        workload_dir,
     ])
     assert code == 0
+
+    test_utils.clean_output_dir(True, workload_dir)
 
 
 def test_analyze_dispatch_0_1_MI300X_A1(binary_handler_analyze_rocprof_compute):
+    workload_dir = test_utils.setup_workload_dir(
+        "tests/workloads/dispatch_0_1/MI300X_A1"
+    )
+
     code = binary_handler_analyze_rocprof_compute([
         "analyze",
         "--path",
-        "tests/workloads/dispatch_0_1/MI300X_A1",
+        workload_dir,
     ])
     assert code == 0
+
+    test_utils.clean_output_dir(True, workload_dir)
 
 
 def test_analyze_dispatch_0_1_MI100(binary_handler_analyze_rocprof_compute):
+    workload_dir = test_utils.setup_workload_dir("tests/workloads/dispatch_0_1/MI100")
+
     code = binary_handler_analyze_rocprof_compute([
         "analyze",
         "--path",
-        "tests/workloads/dispatch_0_1/MI100",
+        workload_dir,
     ])
     assert code == 0
+
+    test_utils.clean_output_dir(True, workload_dir)
 
 
 def test_analyze_dispatch_0_1_MI300A_A1(binary_handler_analyze_rocprof_compute):
+    workload_dir = test_utils.setup_workload_dir(
+        "tests/workloads/dispatch_0_1/MI300A_A1"
+    )
+
     code = binary_handler_analyze_rocprof_compute([
         "analyze",
         "--path",
-        "tests/workloads/dispatch_0_1/MI300A_A1",
+        workload_dir,
     ])
     assert code == 0
+
+    test_utils.clean_output_dir(True, workload_dir)
 
 
 def test_analyze_dispatch_0_1_MI200(binary_handler_analyze_rocprof_compute):
+    workload_dir = test_utils.setup_workload_dir("tests/workloads/dispatch_0_1/MI200")
+
     code = binary_handler_analyze_rocprof_compute([
         "analyze",
         "--path",
-        "tests/workloads/dispatch_0_1/MI200",
+        workload_dir,
     ])
     assert code == 0
+
+    test_utils.clean_output_dir(True, workload_dir)
 
 
 def test_analyze_mem_levels_LDS_MI200(binary_handler_analyze_rocprof_compute):
+    workload_dir = test_utils.setup_workload_dir("tests/workloads/mem_levels_LDS/MI200")
+
     code = binary_handler_analyze_rocprof_compute([
         "analyze",
         "--path",
-        "tests/workloads/mem_levels_LDS/MI200",
+        workload_dir,
     ])
     assert code == 0
+
+    test_utils.clean_output_dir(True, workload_dir)
 
 
 def test_analyze_ipblocks_TA_MI300X_A1(binary_handler_analyze_rocprof_compute):
+    workload_dir = test_utils.setup_workload_dir(
+        "tests/workloads/ipblocks_TA/MI300X_A1"
+    )
+
     code = binary_handler_analyze_rocprof_compute([
         "analyze",
         "--path",
-        "tests/workloads/ipblocks_TA/MI300X_A1",
+        workload_dir,
     ])
     assert code == 0
+
+    test_utils.clean_output_dir(True, workload_dir)
 
 
 def test_analyze_ipblocks_TA_MI100(binary_handler_analyze_rocprof_compute):
+    workload_dir = test_utils.setup_workload_dir("tests/workloads/ipblocks_TA/MI100")
+
     code = binary_handler_analyze_rocprof_compute([
         "analyze",
         "--path",
-        "tests/workloads/ipblocks_TA/MI100",
+        workload_dir,
     ])
     assert code == 0
+
+    test_utils.clean_output_dir(True, workload_dir)
 
 
 def test_analyze_ipblocks_TA_MI300A_A1(binary_handler_analyze_rocprof_compute):
+    workload_dir = test_utils.setup_workload_dir(
+        "tests/workloads/ipblocks_TA/MI300A_A1"
+    )
+
     code = binary_handler_analyze_rocprof_compute([
         "analyze",
         "--path",
-        "tests/workloads/ipblocks_TA/MI300A_A1",
+        workload_dir,
     ])
     assert code == 0
+
+    test_utils.clean_output_dir(True, workload_dir)
 
 
 def test_analyze_ipblocks_TA_MI200(binary_handler_analyze_rocprof_compute):
+    workload_dir = test_utils.setup_workload_dir("tests/workloads/ipblocks_TA/MI200")
+
     code = binary_handler_analyze_rocprof_compute([
         "analyze",
         "--path",
-        "tests/workloads/ipblocks_TA/MI200",
+        workload_dir,
     ])
     assert code == 0
+
+    test_utils.clean_output_dir(True, workload_dir)
 
 
 def test_analyze_dispatch_6_8_MI300X_A1(binary_handler_analyze_rocprof_compute):
+    workload_dir = test_utils.setup_workload_dir(
+        "tests/workloads/dispatch_6_8/MI300X_A1"
+    )
+
     code = binary_handler_analyze_rocprof_compute([
         "analyze",
         "--path",
-        "tests/workloads/dispatch_6_8/MI300X_A1",
+        workload_dir,
     ])
     assert code == 0
+
+    test_utils.clean_output_dir(True, workload_dir)
 
 
 def test_analyze_dispatch_6_8_MI100(binary_handler_analyze_rocprof_compute):
+    workload_dir = test_utils.setup_workload_dir("tests/workloads/dispatch_6_8/MI100")
+
     code = binary_handler_analyze_rocprof_compute([
         "analyze",
         "--path",
-        "tests/workloads/dispatch_6_8/MI100",
+        workload_dir,
     ])
     assert code == 1
+
+    test_utils.clean_output_dir(True, workload_dir)
 
 
 def test_analyze_dispatch_6_8_MI300A_A1(binary_handler_analyze_rocprof_compute):
+    workload_dir = test_utils.setup_workload_dir(
+        "tests/workloads/dispatch_6_8/MI300A_A1"
+    )
+
     code = binary_handler_analyze_rocprof_compute([
         "analyze",
         "--path",
-        "tests/workloads/dispatch_6_8/MI300A_A1",
+        workload_dir,
     ])
     assert code == 0
+
+    test_utils.clean_output_dir(True, workload_dir)
 
 
 def test_analyze_dispatch_6_8_MI200(binary_handler_analyze_rocprof_compute):
+    workload_dir = test_utils.setup_workload_dir("tests/workloads/dispatch_6_8/MI200")
+
     code = binary_handler_analyze_rocprof_compute([
         "analyze",
         "--path",
-        "tests/workloads/dispatch_6_8/MI200",
+        workload_dir,
     ])
     assert code == 1
 
+    test_utils.clean_output_dir(True, workload_dir)
+
 
 def test_analyze_device_inv_int_MI300X_A1(binary_handler_analyze_rocprof_compute):
+    workload_dir = test_utils.setup_workload_dir(
+        "tests/workloads/device_inv_int/MI300X_A1"
+    )
+
     code = binary_handler_analyze_rocprof_compute([
         "analyze",
         "--path",
-        "tests/workloads/device_inv_int/MI300X_A1",
+        workload_dir,
     ])
     assert code == 0
+
+    test_utils.clean_output_dir(True, workload_dir)
 
 
 def test_analyze_device_inv_int_MI100(binary_handler_analyze_rocprof_compute):
+    workload_dir = test_utils.setup_workload_dir("tests/workloads/device_inv_int/MI100")
+
     code = binary_handler_analyze_rocprof_compute([
         "analyze",
         "--path",
-        "tests/workloads/device_inv_int/MI100",
+        workload_dir,
     ])
     assert code == 0
+
+    test_utils.clean_output_dir(True, workload_dir)
 
 
 def test_analyze_device_inv_int_MI300A_A1(binary_handler_analyze_rocprof_compute):
+    workload_dir = test_utils.setup_workload_dir(
+        "tests/workloads/device_inv_int/MI300A_A1"
+    )
+
     code = binary_handler_analyze_rocprof_compute([
         "analyze",
         "--path",
-        "tests/workloads/device_inv_int/MI300A_A1",
+        workload_dir,
     ])
     assert code == 0
+
+    test_utils.clean_output_dir(True, workload_dir)
 
 
 def test_analyze_device_inv_int_MI200(binary_handler_analyze_rocprof_compute):
+    workload_dir = test_utils.setup_workload_dir("tests/workloads/device_inv_int/MI200")
+
     code = binary_handler_analyze_rocprof_compute([
         "analyze",
         "--path",
-        "tests/workloads/device_inv_int/MI200",
+        workload_dir,
     ])
     assert code == 0
+
+    test_utils.clean_output_dir(True, workload_dir)
 
 
 def test_analyze_ipblocks_SQ_TA_MI300X_A1(binary_handler_analyze_rocprof_compute):
+    workload_dir = test_utils.setup_workload_dir(
+        "tests/workloads/ipblocks_SQ_TA/MI300X_A1"
+    )
+
     code = binary_handler_analyze_rocprof_compute([
         "analyze",
         "--path",
-        "tests/workloads/ipblocks_SQ_TA/MI300X_A1",
+        workload_dir,
     ])
     assert code == 0
+
+    test_utils.clean_output_dir(True, workload_dir)
 
 
 def test_analyze_ipblocks_SQ_TA_MI100(binary_handler_analyze_rocprof_compute):
+    workload_dir = test_utils.setup_workload_dir("tests/workloads/ipblocks_SQ_TA/MI100")
+
     code = binary_handler_analyze_rocprof_compute([
         "analyze",
         "--path",
-        "tests/workloads/ipblocks_SQ_TA/MI100",
+        workload_dir,
     ])
     assert code == 0
+
+    test_utils.clean_output_dir(True, workload_dir)
 
 
 def test_analyze_ipblocks_SQ_TA_MI300A_A1(binary_handler_analyze_rocprof_compute):
+    workload_dir = test_utils.setup_workload_dir(
+        "tests/workloads/ipblocks_SQ_TA/MI300A_A1"
+    )
+
     code = binary_handler_analyze_rocprof_compute([
         "analyze",
         "--path",
-        "tests/workloads/ipblocks_SQ_TA/MI300A_A1",
+        workload_dir,
     ])
     assert code == 0
+
+    test_utils.clean_output_dir(True, workload_dir)
 
 
 def test_analyze_ipblocks_SQ_TA_MI200(binary_handler_analyze_rocprof_compute):
+    workload_dir = test_utils.setup_workload_dir("tests/workloads/ipblocks_SQ_TA/MI200")
+
     code = binary_handler_analyze_rocprof_compute([
         "analyze",
         "--path",
-        "tests/workloads/ipblocks_SQ_TA/MI200",
+        workload_dir,
     ])
     assert code == 0
+
+    test_utils.clean_output_dir(True, workload_dir)
 
 
 def test_analyze_ipblocks_TD_MI300X_A1(binary_handler_analyze_rocprof_compute):
+    workload_dir = test_utils.setup_workload_dir(
+        "tests/workloads/ipblocks_TD/MI300X_A1"
+    )
+
     code = binary_handler_analyze_rocprof_compute([
         "analyze",
         "--path",
-        "tests/workloads/ipblocks_TD/MI300X_A1",
+        workload_dir,
     ])
     assert code == 0
+
+    test_utils.clean_output_dir(True, workload_dir)
 
 
 def test_analyze_ipblocks_TD_MI100(binary_handler_analyze_rocprof_compute):
+    workload_dir = test_utils.setup_workload_dir("tests/workloads/ipblocks_TD/MI100")
+
     code = binary_handler_analyze_rocprof_compute([
         "analyze",
         "--path",
-        "tests/workloads/ipblocks_TD/MI100",
+        workload_dir,
     ])
     assert code == 0
+
+    test_utils.clean_output_dir(True, workload_dir)
 
 
 def test_analyze_ipblocks_TD_MI300A_A1(binary_handler_analyze_rocprof_compute):
+    workload_dir = test_utils.setup_workload_dir(
+        "tests/workloads/ipblocks_TD/MI300A_A1"
+    )
+
     code = binary_handler_analyze_rocprof_compute([
         "analyze",
         "--path",
-        "tests/workloads/ipblocks_TD/MI300A_A1",
+        workload_dir,
     ])
     assert code == 0
+
+    test_utils.clean_output_dir(True, workload_dir)
 
 
 def test_analyze_ipblocks_TD_MI200(binary_handler_analyze_rocprof_compute):
+    workload_dir = test_utils.setup_workload_dir("tests/workloads/ipblocks_TD/MI200")
+
     code = binary_handler_analyze_rocprof_compute([
         "analyze",
         "--path",
-        "tests/workloads/ipblocks_TD/MI200",
+        workload_dir,
     ])
     assert code == 0
+
+    test_utils.clean_output_dir(True, workload_dir)
 
 
 def test_analyze_device_filter_MI300X_A1(binary_handler_analyze_rocprof_compute):
+    workload_dir = test_utils.setup_workload_dir(
+        "tests/workloads/device_filter/MI300X_A1"
+    )
+
     code = binary_handler_analyze_rocprof_compute([
         "analyze",
         "--path",
-        "tests/workloads/device_filter/MI300X_A1",
+        workload_dir,
     ])
     assert code == 0
+
+    test_utils.clean_output_dir(True, workload_dir)
 
 
 def test_analyze_device_filter_MI100(binary_handler_analyze_rocprof_compute):
+    workload_dir = test_utils.setup_workload_dir("tests/workloads/device_filter/MI100")
+
     code = binary_handler_analyze_rocprof_compute([
         "analyze",
         "--path",
-        "tests/workloads/device_filter/MI100",
+        workload_dir,
     ])
     assert code == 0
+
+    test_utils.clean_output_dir(True, workload_dir)
 
 
 def test_analyze_device_filter_MI300A_A1(binary_handler_analyze_rocprof_compute):
+    workload_dir = test_utils.setup_workload_dir(
+        "tests/workloads/device_filter/MI300A_A1"
+    )
+
     code = binary_handler_analyze_rocprof_compute([
         "analyze",
         "--path",
-        "tests/workloads/device_filter/MI300A_A1",
+        workload_dir,
     ])
     assert code == 0
+
+    test_utils.clean_output_dir(True, workload_dir)
 
 
 def test_analyze_device_filter_MI200(binary_handler_analyze_rocprof_compute):
+    workload_dir = test_utils.setup_workload_dir("tests/workloads/device_filter/MI200")
+
     code = binary_handler_analyze_rocprof_compute([
         "analyze",
         "--path",
-        "tests/workloads/device_filter/MI200",
+        workload_dir,
     ])
     assert code == 0
+
+    test_utils.clean_output_dir(True, workload_dir)
 
 
 def test_analyze_join_type_kernel_MI300X_A1(binary_handler_analyze_rocprof_compute):
+    workload_dir = test_utils.setup_workload_dir(
+        "tests/workloads/join_type_kernel/MI300X_A1"
+    )
+
     code = binary_handler_analyze_rocprof_compute([
         "analyze",
         "--path",
-        "tests/workloads/join_type_kernel/MI300X_A1",
+        workload_dir,
     ])
     assert code == 0
+
+    test_utils.clean_output_dir(True, workload_dir)
 
 
 def test_analyze_join_type_kernel_MI100(binary_handler_analyze_rocprof_compute):
+    workload_dir = test_utils.setup_workload_dir(
+        "tests/workloads/join_type_kernel/MI100"
+    )
+
     code = binary_handler_analyze_rocprof_compute([
         "analyze",
         "--path",
-        "tests/workloads/join_type_kernel/MI100",
+        workload_dir,
     ])
     assert code == 0
+
+    test_utils.clean_output_dir(True, workload_dir)
 
 
 def test_analyze_join_type_kernel_MI300A_A1(binary_handler_analyze_rocprof_compute):
+    workload_dir = test_utils.setup_workload_dir(
+        "tests/workloads/join_type_kernel/MI300A_A1"
+    )
+
     code = binary_handler_analyze_rocprof_compute([
         "analyze",
         "--path",
-        "tests/workloads/join_type_kernel/MI300A_A1",
+        workload_dir,
     ])
     assert code == 0
+
+    test_utils.clean_output_dir(True, workload_dir)
 
 
 def test_analyze_join_type_kernel_MI200(binary_handler_analyze_rocprof_compute):
+    workload_dir = test_utils.setup_workload_dir(
+        "tests/workloads/join_type_kernel/MI200"
+    )
+
     code = binary_handler_analyze_rocprof_compute([
         "analyze",
         "--path",
-        "tests/workloads/join_type_kernel/MI200",
+        workload_dir,
     ])
     assert code == 0
+
+    test_utils.clean_output_dir(True, workload_dir)
 
 
 def test_analyze_ipblocks_SQ_SQC_TCP_CPC_MI300X_A1(
     binary_handler_analyze_rocprof_compute,
 ):
+    workload_dir = test_utils.setup_workload_dir(
+        "tests/workloads/ipblocks_SQ_SQC_TCP_CPC/MI300X_A1"
+    )
+
     code = binary_handler_analyze_rocprof_compute([
         "analyze",
         "--path",
-        "tests/workloads/ipblocks_SQ_SQC_TCP_CPC/MI300X_A1",
+        workload_dir,
     ])
     assert code == 0
+
+    test_utils.clean_output_dir(True, workload_dir)
 
 
 def test_analyze_ipblocks_SQ_SQC_TCP_CPC_MI100(binary_handler_analyze_rocprof_compute):
+    workload_dir = test_utils.setup_workload_dir(
+        "tests/workloads/ipblocks_SQ_SQC_TCP_CPC/MI100"
+    )
+
     code = binary_handler_analyze_rocprof_compute([
         "analyze",
         "--path",
-        "tests/workloads/ipblocks_SQ_SQC_TCP_CPC/MI100",
+        workload_dir,
     ])
     assert code == 0
+
+    test_utils.clean_output_dir(True, workload_dir)
 
 
 def test_analyze_ipblocks_SQ_SQC_TCP_CPC_MI300A_A1(
     binary_handler_analyze_rocprof_compute,
 ):
+    workload_dir = test_utils.setup_workload_dir(
+        "tests/workloads/ipblocks_SQ_SQC_TCP_CPC/MI300A_A1"
+    )
+
     code = binary_handler_analyze_rocprof_compute([
         "analyze",
         "--path",
-        "tests/workloads/ipblocks_SQ_SQC_TCP_CPC/MI300A_A1",
+        workload_dir,
     ])
     assert code == 0
+
+    test_utils.clean_output_dir(True, workload_dir)
 
 
 def test_analyze_ipblocks_SQ_SQC_TCP_CPC_MI200(binary_handler_analyze_rocprof_compute):
+    workload_dir = test_utils.setup_workload_dir(
+        "tests/workloads/ipblocks_SQ_SQC_TCP_CPC/MI200"
+    )
+
     code = binary_handler_analyze_rocprof_compute([
         "analyze",
         "--path",
-        "tests/workloads/ipblocks_SQ_SQC_TCP_CPC/MI200",
+        workload_dir,
     ])
     assert code == 0
+
+    test_utils.clean_output_dir(True, workload_dir)
 
 
 def test_analyze_mem_levels_L2_vL1d_LDS_MI200(binary_handler_analyze_rocprof_compute):
+    workload_dir = test_utils.setup_workload_dir(
+        "tests/workloads/mem_levels_L2_vL1d_LDS/MI200"
+    )
+
     code = binary_handler_analyze_rocprof_compute([
         "analyze",
         "--path",
-        "tests/workloads/mem_levels_L2_vL1d_LDS/MI200",
+        workload_dir,
     ])
     assert code == 0
+
+    test_utils.clean_output_dir(True, workload_dir)
 
 
 def test_analyze_ipblocks_CPF_MI300X_A1(binary_handler_analyze_rocprof_compute):
+    workload_dir = test_utils.setup_workload_dir(
+        "tests/workloads/ipblocks_CPF/MI300X_A1"
+    )
+
     code = binary_handler_analyze_rocprof_compute([
         "analyze",
         "--path",
-        "tests/workloads/ipblocks_CPF/MI300X_A1",
+        workload_dir,
     ])
     assert code == 0
+
+    test_utils.clean_output_dir(True, workload_dir)
 
 
 def test_analyze_ipblocks_CPF_MI100(binary_handler_analyze_rocprof_compute):
+    workload_dir = test_utils.setup_workload_dir("tests/workloads/ipblocks_CPF/MI100")
+
     code = binary_handler_analyze_rocprof_compute([
         "analyze",
         "--path",
-        "tests/workloads/ipblocks_CPF/MI100",
+        workload_dir,
     ])
     assert code == 0
+
+    test_utils.clean_output_dir(True, workload_dir)
 
 
 def test_analyze_ipblocks_CPF_MI300A_A1(binary_handler_analyze_rocprof_compute):
+    workload_dir = test_utils.setup_workload_dir(
+        "tests/workloads/ipblocks_CPF/MI300A_A1"
+    )
+
     code = binary_handler_analyze_rocprof_compute([
         "analyze",
         "--path",
-        "tests/workloads/ipblocks_CPF/MI300A_A1",
+        workload_dir,
     ])
     assert code == 0
+
+    test_utils.clean_output_dir(True, workload_dir)
 
 
 def test_analyze_ipblocks_CPF_MI200(binary_handler_analyze_rocprof_compute):
+    workload_dir = test_utils.setup_workload_dir("tests/workloads/ipblocks_CPF/MI200")
+
     code = binary_handler_analyze_rocprof_compute([
         "analyze",
         "--path",
-        "tests/workloads/ipblocks_CPF/MI200",
+        workload_dir,
     ])
     assert code == 0
+
+    test_utils.clean_output_dir(True, workload_dir)
 
 
 def test_analyze_sort_dispatches_MI200(binary_handler_analyze_rocprof_compute):
+    workload_dir = test_utils.setup_workload_dir(
+        "tests/workloads/sort_dispatches/MI200"
+    )
+
     code = binary_handler_analyze_rocprof_compute([
         "analyze",
         "--path",
-        "tests/workloads/sort_dispatches/MI200",
+        workload_dir,
     ])
     assert code == 0
+
+    test_utils.clean_output_dir(True, workload_dir)
 
 
 def test_analyze_kernel_names_MI200(binary_handler_analyze_rocprof_compute):
+    workload_dir = test_utils.setup_workload_dir("tests/workloads/kernel_names/MI200")
+
     code = binary_handler_analyze_rocprof_compute([
         "analyze",
         "--path",
-        "tests/workloads/kernel_names/MI200",
+        workload_dir,
     ])
     assert code == 0
+
+    test_utils.clean_output_dir(True, workload_dir)
 
 
 def test_analyze_mem_levels_vL1d_LDS_MI200(binary_handler_analyze_rocprof_compute):
+    workload_dir = test_utils.setup_workload_dir(
+        "tests/workloads/mem_levels_vL1d_LDS/MI200"
+    )
+
     code = binary_handler_analyze_rocprof_compute([
         "analyze",
         "--path",
-        "tests/workloads/mem_levels_vL1d_LDS/MI200",
+        workload_dir,
     ])
     assert code == 0
+
+    test_utils.clean_output_dir(True, workload_dir)
 
 
 def test_analyze_ipblocks_SQ_MI300X_A1(binary_handler_analyze_rocprof_compute):
+    workload_dir = test_utils.setup_workload_dir(
+        "tests/workloads/ipblocks_SQ/MI300X_A1"
+    )
+
     code = binary_handler_analyze_rocprof_compute([
         "analyze",
         "--path",
-        "tests/workloads/ipblocks_SQ/MI300X_A1",
+        workload_dir,
     ])
     assert code == 0
+
+    test_utils.clean_output_dir(True, workload_dir)
 
 
 def test_analyze_ipblocks_SQ_MI100(binary_handler_analyze_rocprof_compute):
+    workload_dir = test_utils.setup_workload_dir("tests/workloads/ipblocks_SQ/MI100")
+
     code = binary_handler_analyze_rocprof_compute([
         "analyze",
         "--path",
-        "tests/workloads/ipblocks_SQ/MI100",
+        workload_dir,
     ])
     assert code == 0
+
+    test_utils.clean_output_dir(True, workload_dir)
 
 
 def test_analyze_ipblocks_SQ_MI300A_A1(binary_handler_analyze_rocprof_compute):
+    workload_dir = test_utils.setup_workload_dir(
+        "tests/workloads/ipblocks_SQ/MI300A_A1"
+    )
+
     code = binary_handler_analyze_rocprof_compute([
         "analyze",
         "--path",
-        "tests/workloads/ipblocks_SQ/MI300A_A1",
+        workload_dir,
     ])
     assert code == 0
+
+    test_utils.clean_output_dir(True, workload_dir)
 
 
 def test_analyze_ipblocks_SQ_MI200(binary_handler_analyze_rocprof_compute):
+    workload_dir = test_utils.setup_workload_dir("tests/workloads/ipblocks_SQ/MI200")
+
     code = binary_handler_analyze_rocprof_compute([
         "analyze",
         "--path",
-        "tests/workloads/ipblocks_SQ/MI200",
+        workload_dir,
     ])
     assert code == 0
+
+    test_utils.clean_output_dir(True, workload_dir)
 
 
 def test_analyze_mem_levels_L2_MI200(binary_handler_analyze_rocprof_compute):
+    workload_dir = test_utils.setup_workload_dir("tests/workloads/mem_levels_L2/MI200")
+
     code = binary_handler_analyze_rocprof_compute([
         "analyze",
         "--path",
-        "tests/workloads/mem_levels_L2/MI200",
+        workload_dir,
     ])
     assert code == 0
+
+    test_utils.clean_output_dir(True, workload_dir)
 
 
 def test_analyze_dispatch_inv_MI300X_A1(binary_handler_analyze_rocprof_compute):
+    workload_dir = test_utils.setup_workload_dir(
+        "tests/workloads/dispatch_inv/MI300X_A1"
+    )
+
     code = binary_handler_analyze_rocprof_compute([
         "analyze",
         "--path",
-        "tests/workloads/dispatch_inv/MI300X_A1",
+        workload_dir,
     ])
     assert code == 0
+
+    test_utils.clean_output_dir(True, workload_dir)
 
 
 def test_analyze_dispatch_inv_MI100(binary_handler_analyze_rocprof_compute):
+    workload_dir = test_utils.setup_workload_dir("tests/workloads/dispatch_inv/MI100")
+
     code = binary_handler_analyze_rocprof_compute([
         "analyze",
         "--path",
-        "tests/workloads/dispatch_inv/MI100",
+        workload_dir,
     ])
     assert code == 0
+
+    test_utils.clean_output_dir(True, workload_dir)
 
 
 def test_analyze_dispatch_inv_MI300A_A1(binary_handler_analyze_rocprof_compute):
+    workload_dir = test_utils.setup_workload_dir(
+        "tests/workloads/dispatch_inv/MI300A_A1"
+    )
+
     code = binary_handler_analyze_rocprof_compute([
         "analyze",
         "--path",
-        "tests/workloads/dispatch_inv/MI300A_A1",
+        workload_dir,
     ])
     assert code == 0
+
+    test_utils.clean_output_dir(True, workload_dir)
 
 
 def test_analyze_dispatch_inv_MI200(binary_handler_analyze_rocprof_compute):
+    workload_dir = test_utils.setup_workload_dir("tests/workloads/dispatch_inv/MI200")
+
     code = binary_handler_analyze_rocprof_compute([
         "analyze",
         "--path",
-        "tests/workloads/dispatch_inv/MI200",
+        workload_dir,
     ])
     assert code == 0
+
+    test_utils.clean_output_dir(True, workload_dir)
 
 
 def test_analyze_path_MI300X_A1(binary_handler_analyze_rocprof_compute):
+    workload_dir = test_utils.setup_workload_dir("tests/workloads/path/MI300X_A1")
+
     code = binary_handler_analyze_rocprof_compute([
         "analyze",
         "--path",
-        "tests/workloads/path/MI300X_A1",
+        workload_dir,
     ])
     assert code == 0
+
+    test_utils.clean_output_dir(True, workload_dir)
 
 
 def test_analyze_path_MI100(binary_handler_analyze_rocprof_compute):
+    workload_dir = test_utils.setup_workload_dir("tests/workloads/path/MI100")
+
     code = binary_handler_analyze_rocprof_compute([
         "analyze",
         "--path",
-        "tests/workloads/path/MI100",
+        workload_dir,
     ])
     assert code == 0
+
+    test_utils.clean_output_dir(True, workload_dir)
 
 
 def test_analyze_path_MI300A_A1(binary_handler_analyze_rocprof_compute):
+    workload_dir = test_utils.setup_workload_dir("tests/workloads/path/MI300A_A1")
+
     code = binary_handler_analyze_rocprof_compute([
         "analyze",
         "--path",
-        "tests/workloads/path/MI300A_A1",
+        workload_dir,
     ])
     assert code == 0
+
+    test_utils.clean_output_dir(True, workload_dir)
 
 
 def test_analyze_path_MI200(binary_handler_analyze_rocprof_compute):
+    workload_dir = test_utils.setup_workload_dir("tests/workloads/path/MI200")
+
     code = binary_handler_analyze_rocprof_compute([
         "analyze",
         "--path",
-        "tests/workloads/path/MI200",
+        workload_dir,
     ])
     assert code == 0
+
+    test_utils.clean_output_dir(True, workload_dir)
 
 
 def test_analyze_ipblocks_CPC_MI300X_A1(binary_handler_analyze_rocprof_compute):
+    workload_dir = test_utils.setup_workload_dir(
+        "tests/workloads/ipblocks_CPC/MI300X_A1"
+    )
+
     code = binary_handler_analyze_rocprof_compute([
         "analyze",
         "--path",
-        "tests/workloads/ipblocks_CPC/MI300X_A1",
+        workload_dir,
     ])
     assert code == 0
+
+    test_utils.clean_output_dir(True, workload_dir)
 
 
 def test_analyze_ipblocks_CPC_MI100(binary_handler_analyze_rocprof_compute):
+    workload_dir = test_utils.setup_workload_dir("tests/workloads/ipblocks_CPC/MI100")
+
     code = binary_handler_analyze_rocprof_compute([
         "analyze",
         "--path",
-        "tests/workloads/ipblocks_CPC/MI100",
+        workload_dir,
     ])
     assert code == 0
+
+    test_utils.clean_output_dir(True, workload_dir)
 
 
 def test_analyze_ipblocks_CPC_MI300A_A1(binary_handler_analyze_rocprof_compute):
+    workload_dir = test_utils.setup_workload_dir(
+        "tests/workloads/ipblocks_CPC/MI300A_A1"
+    )
+
     code = binary_handler_analyze_rocprof_compute([
         "analyze",
         "--path",
-        "tests/workloads/ipblocks_CPC/MI300A_A1",
+        workload_dir,
     ])
     assert code == 0
+
+    test_utils.clean_output_dir(True, workload_dir)
 
 
 def test_analyze_ipblocks_CPC_MI200(binary_handler_analyze_rocprof_compute):
+    workload_dir = test_utils.setup_workload_dir("tests/workloads/ipblocks_CPC/MI200")
+
     code = binary_handler_analyze_rocprof_compute([
         "analyze",
         "--path",
-        "tests/workloads/ipblocks_CPC/MI200",
+        workload_dir,
     ])
     assert code == 0
+
+    test_utils.clean_output_dir(True, workload_dir)
 
 
 def test_analyze_ipblocks_SQ_SPI_TA_TCC_CPF_MI300X_A1(
     binary_handler_analyze_rocprof_compute,
 ):
+    workload_dir = test_utils.setup_workload_dir(
+        "tests/workloads/ipblocks_SQ_SPI_TA_TCC_CPF/MI300X_A1"
+    )
+
     code = binary_handler_analyze_rocprof_compute([
         "analyze",
         "--path",
-        "tests/workloads/ipblocks_SQ_SPI_TA_TCC_CPF/MI300X_A1",
+        workload_dir,
     ])
     assert code == 0
+
+    test_utils.clean_output_dir(True, workload_dir)
 
 
 def test_analyze_ipblocks_SQ_SPI_TA_TCC_CPF_MI100(
     binary_handler_analyze_rocprof_compute,
 ):
+    workload_dir = test_utils.setup_workload_dir(
+        "tests/workloads/ipblocks_SQ_SPI_TA_TCC_CPF/MI100"
+    )
+
     code = binary_handler_analyze_rocprof_compute([
         "analyze",
         "--path",
-        "tests/workloads/ipblocks_SQ_SPI_TA_TCC_CPF/MI100",
+        workload_dir,
     ])
     assert code == 0
+
+    test_utils.clean_output_dir(True, workload_dir)
 
 
 def test_analyze_ipblocks_SQ_SPI_TA_TCC_CPF_MI300A_A1(
     binary_handler_analyze_rocprof_compute,
 ):
+    workload_dir = test_utils.setup_workload_dir(
+        "tests/workloads/ipblocks_SQ_SPI_TA_TCC_CPF/MI300A_A1"
+    )
+
     code = binary_handler_analyze_rocprof_compute([
         "analyze",
         "--path",
-        "tests/workloads/ipblocks_SQ_SPI_TA_TCC_CPF/MI300A_A1",
+        workload_dir,
     ])
     assert code == 0
+
+    test_utils.clean_output_dir(True, workload_dir)
 
 
 def test_analyze_ipblocks_SQ_SPI_TA_TCC_CPF_MI200(
     binary_handler_analyze_rocprof_compute,
 ):
+    workload_dir = test_utils.setup_workload_dir(
+        "tests/workloads/ipblocks_SQ_SPI_TA_TCC_CPF/MI200"
+    )
+
     code = binary_handler_analyze_rocprof_compute([
         "analyze",
         "--path",
-        "tests/workloads/ipblocks_SQ_SPI_TA_TCC_CPF/MI200",
+        workload_dir,
     ])
     assert code == 0
+
+    test_utils.clean_output_dir(True, workload_dir)
 
 
 def test_analyze_mem_levels_HBM_MI200(binary_handler_analyze_rocprof_compute):
+    workload_dir = test_utils.setup_workload_dir("tests/workloads/mem_levels_HBM/MI200")
+
     code = binary_handler_analyze_rocprof_compute([
         "analyze",
         "--path",
-        "tests/workloads/mem_levels_HBM/MI200",
+        workload_dir,
     ])
     assert code == 0
+
+    test_utils.clean_output_dir(True, workload_dir)
 
 
 def test_analyze_ipblocks_SPI_MI300X_A1(binary_handler_analyze_rocprof_compute):
+    workload_dir = test_utils.setup_workload_dir(
+        "tests/workloads/ipblocks_SPI/MI300X_A1"
+    )
+
     code = binary_handler_analyze_rocprof_compute([
         "analyze",
         "--path",
-        "tests/workloads/ipblocks_SPI/MI300X_A1",
+        workload_dir,
     ])
     assert code == 0
+
+    test_utils.clean_output_dir(True, workload_dir)
 
 
 def test_analyze_ipblocks_SPI_MI100(binary_handler_analyze_rocprof_compute):
+    workload_dir = test_utils.setup_workload_dir("tests/workloads/ipblocks_SPI/MI100")
+
     code = binary_handler_analyze_rocprof_compute([
         "analyze",
         "--path",
-        "tests/workloads/ipblocks_SPI/MI100",
+        workload_dir,
     ])
     assert code == 0
+
+    test_utils.clean_output_dir(True, workload_dir)
 
 
 def test_analyze_ipblocks_SPI_MI300A_A1(binary_handler_analyze_rocprof_compute):
+    workload_dir = test_utils.setup_workload_dir(
+        "tests/workloads/ipblocks_SPI/MI300A_A1"
+    )
+
     code = binary_handler_analyze_rocprof_compute([
         "analyze",
         "--path",
-        "tests/workloads/ipblocks_SPI/MI300A_A1",
+        workload_dir,
     ])
     assert code == 0
+
+    test_utils.clean_output_dir(True, workload_dir)
 
 
 def test_analyze_ipblocks_SPI_MI200(binary_handler_analyze_rocprof_compute):
+    workload_dir = test_utils.setup_workload_dir("tests/workloads/ipblocks_SPI/MI200")
+
     code = binary_handler_analyze_rocprof_compute([
         "analyze",
         "--path",
-        "tests/workloads/ipblocks_SPI/MI200",
+        workload_dir,
     ])
     assert code == 0
+
+    test_utils.clean_output_dir(True, workload_dir)
 
 
 ##################################################
@@ -1245,11 +1905,13 @@ def test_analyze_ipblocks_SPI_MI200(binary_handler_analyze_rocprof_compute):
 def test_analyze_torch_trace_list_operators_MI350(
     binary_handler_analyze_rocprof_compute, capsys
 ):
+    workload_dir = test_utils.setup_workload_dir("tests/workloads/torch_trace/MI350")
+
     code = binary_handler_analyze_rocprof_compute([
         "--experimental",
         "analyze",
         "--path",
-        "tests/workloads/torch_trace/MI350",
+        workload_dir,
         "--list-torch-operators",
     ])
     assert code == 0
@@ -1264,15 +1926,19 @@ def test_analyze_torch_trace_list_operators_MI350(
     assert "kernel_launches:" in output
     assert "total_duration:" in output
 
+    test_utils.clean_output_dir(True, workload_dir)
+
 
 def test_analyze_torch_trace_filter_operator_MI350(
     binary_handler_analyze_rocprof_compute, capsys
 ):
+    workload_dir = test_utils.setup_workload_dir("tests/workloads/torch_trace/MI350")
+
     code = binary_handler_analyze_rocprof_compute([
         "--experimental",
         "analyze",
         "--path",
-        "tests/workloads/torch_trace/MI350",
+        workload_dir,
         "--torch-operator",
         "*relu",
     ])
@@ -1285,15 +1951,19 @@ def test_analyze_torch_trace_filter_operator_MI350(
     assert "kernel_launches:" in output
     assert "total_duration:" in output
 
+    test_utils.clean_output_dir(True, workload_dir)
+
 
 def test_analyze_torch_trace_multi_operator_MI350(
     binary_handler_analyze_rocprof_compute, capsys
 ):
+    workload_dir = test_utils.setup_workload_dir("tests/workloads/torch_trace/MI350")
+
     code = binary_handler_analyze_rocprof_compute([
         "--experimental",
         "analyze",
         "--path",
-        "tests/workloads/torch_trace/MI350",
+        workload_dir,
         "--torch-operator",
         "*relu",
         "*ones_like",
@@ -1306,15 +1976,19 @@ def test_analyze_torch_trace_multi_operator_MI350(
     assert "relu" in output
     assert "ones_like" in output
 
+    test_utils.clean_output_dir(True, workload_dir)
+
 
 def test_analyze_torch_trace_invalid_operator_MI350(
     binary_handler_analyze_rocprof_compute, capsys
 ):
+    workload_dir = test_utils.setup_workload_dir("tests/workloads/torch_trace/MI350")
+
     code = binary_handler_analyze_rocprof_compute([
         "--experimental",
         "analyze",
         "--path",
-        "tests/workloads/torch_trace/MI350",
+        workload_dir,
         "--torch-operator",
         "nonexistent_op",
     ])
@@ -1323,16 +1997,20 @@ def test_analyze_torch_trace_invalid_operator_MI350(
     output = capsys.readouterr().out
     assert "No operators matched" in output
 
+    test_utils.clean_output_dir(True, workload_dir)
+
 
 def test_analyze_torch_trace_hierarchy_path_MI350(
     binary_handler_analyze_rocprof_compute, capsys
 ):
+    workload_dir = test_utils.setup_workload_dir("tests/workloads/torch_trace/MI350")
+
     hierarchy = "nn.Module.SimpleNet.forward/torch.nn.functional.relu/torch.relu"
     code = binary_handler_analyze_rocprof_compute([
         "--experimental",
         "analyze",
         "--path",
-        "tests/workloads/torch_trace/MI350",
+        workload_dir,
         "--torch-operator",
         hierarchy,
     ])
@@ -1344,15 +2022,19 @@ def test_analyze_torch_trace_hierarchy_path_MI350(
     assert "torch.relu" in output
     assert "kernel_launches:" in output
 
+    test_utils.clean_output_dir(True, workload_dir)
+
 
 def test_analyze_torch_trace_torch_prefix_MI350(
     binary_handler_analyze_rocprof_compute, capsys
 ):
+    workload_dir = test_utils.setup_workload_dir("tests/workloads/torch_trace/MI350")
+
     code = binary_handler_analyze_rocprof_compute([
         "--experimental",
         "analyze",
         "--path",
-        "tests/workloads/torch_trace/MI350",
+        workload_dir,
         "--torch-operator",
         "torch.relu",
     ])
@@ -1363,3 +2045,5 @@ def test_analyze_torch_trace_torch_prefix_MI350(
     assert "Matched PyTorch Operators:" in output
     assert "torch.relu" in output
     assert "kernel_launches:" in output
+
+    test_utils.clean_output_dir(True, workload_dir)


### PR DESCRIPTION
## Motivation

When running tests with `PYTEST_NUMPROCS > 1` on CI, the `test_analyze_workloads.py` tests were failing with `FileNotFoundError` due to race conditions. Multiple tests were attempting to access and modify the same workload directories simultaneously, particularly the `torch_trace/` subdirectory created during analysis.

## Technical Details

Updated all 139 test functions in `tests/test_analyze_workloads.py` to use the existing `test_utils.setup_workload_dir()` utility function, which:

- When running serially (`PYTEST_NUMPROCS=1`): Returns the original workload path (no overhead)
- When running in parallel (`PYTEST_NUMPROCS>1`): Creates a unique copy of the workload directory for each test (e.g., `test_analyze_torch_trace_filter_operator_MI350_tmp/`)

This follows the same pattern already used in `tests/test_analyze_commands.py`.

## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->

## Test Plan

Run test_analyze_workloads serially and parallely (using PYTEST_NUMPROCS=4 cmake args. during build time)

## Test Result

All tests pass with serial and parallel execution
- Code formatting: Passed ruff linting and formatting checks
- Expected CI outcome: Tests should now pass with parallel execution without `FileNotFoundError`

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.