### PR TITLE
support clinfo in rocm-ci without adding the env variable

### DIFF
--- a/projects/clr/opencl/CMakeLists.txt
+++ b/projects/clr/opencl/CMakeLists.txt
@@ -110,6 +110,13 @@ configure_file(
   ${CMAKE_BINARY_DIR}/opencl/packages/opencl/${OPENCL_AMD_ICD_FILE}
   COPYONLY
 )
+# support legacy rocm-ci
+install(
+  FILES ${CMAKE_BINARY_DIR}/opencl/packages/opencl/${OPENCL_AMD_ICD_FILE}
+  DESTINATION /${CMAKE_INSTALL_SYSCONFDIR}/OpenCL/vendors
+  COMPONENT binary
+  EXCLUDE_FROM_ALL
+)
 
 configure_file(
   packaging/rocm-opencl.conf
@@ -117,6 +124,13 @@ configure_file(
   COPYONLY
 )
 
+# support legacy rocm-ci
+install(
+  FILES ${CMAKE_BINARY_DIR}/opencl/packages/opencl/10-rocm-opencl.conf
+  DESTINATION /${CMAKE_INSTALL_SYSCONFDIR}/ld.so.conf.d
+  COMPONENT binary
+  EXCLUDE_FROM_ALL
+)
 
 #Package: rocm-opencl,rocm-opencl-dev/devel,rocm-ocl-icd
 


### PR DESCRIPTION
support clinfo in rocm-ci without adding the env variable
env["OCL_ICD_VENDORS"]

## Motivation
ocltst and clinfo are still not enabled on Rock. 
This PR renables the installation of /etc/OpenCL/ files so that rocm-ci can continue to run clinfo and ocltsts

## Technical Details
Rock cannot install to system folder /etc/OpenCL so workaround is to install to stage/etc/OpenCL, then use env["OCL_ICD_VENDORS"] to point to the icd file. Since ocltest and clinfo are not enabled on Rock, we need to continue supporting rocm-ci testing
This PR renables the installation of /etc/OpenCL/ files so that rocm-ci can continue to run clinfo and ocltsts

## JIRA ID

ROCM-20510

## Test Plan
rocm-ci clinfo and ocltst working fine

## Test Result
rocm-ci clinfo and ocltst working fine

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
