### PR TITLE
[CI] Add choco cache server to prevent rate limiting

### DIFF
--- a/.github/workflows/therock-ci-windows.yml
+++ b/.github/workflows/therock-ci-windows.yml
@@ -57,6 +57,8 @@ jobs:
 
       - name: Install requirements
         run: |
+          choco source disable -n=chocolatey
+          choco source add -n=internal -s http://10.0.167.96:8081/repository/choco-group/ --priority=1
           choco install --no-progress -y ccache
           # ninja pinned due to a bug in the 1.13.0 release:
           # https://github.com/ninja-build/ninja/issues/2616


### PR DESCRIPTION
## Motivation
(associated with this PR in TheRock https://github.com/ROCm/TheRock/pull/4080)
Mitigates CI failures due to `choco install` rate limiting as observed in
https://github.com/ROCm/TheRock/issues/4060
Previously seen https://github.com/ROCm/TheRock/issues/1761

## Technical Details

Prioritizes the use of choco cache server local to the windows build cluster, Nexus as implemented previously here https://github.com/ROCm/TheRock/pull/1764, but propagate the change to remaining workflow files that use choco.

## Test Plan

Observe CI

## Test Result

TBD

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [X] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
