### PR TITLE
Fix nvidia build with explicitly set arch

### DIFF
--- a/projects/hip-tests/catch/unit/deviceLib/CMakeLists.txt
+++ b/projects/hip-tests/catch/unit/deviceLib/CMakeLists.txt
@@ -131,25 +131,25 @@ if (HIP_PLATFORM MATCHES "amd")
                   -I${CMAKE_CURRENT_SOURCE_DIR}/../../include)
 else()
   add_custom_target(kerDevAllocMultCO.code
-                  COMMAND ${CMAKE_HIP_COMPILER} --fatbin ${OFFLOAD_ARCH_LIST}
+                  COMMAND ${CMAKE_HIP_COMPILER} --fatbin
                   -x cu ${CMAKE_CURRENT_SOURCE_DIR}/kerDevAllocMultCO.cc
                   -o ${CMAKE_CURRENT_BINARY_DIR}/../../unit/deviceLib/kerDevAllocMultCO.code
                   -I${HIP_INCLUDE_DIR}
                   -I${CMAKE_CURRENT_SOURCE_DIR}/../../include)
   add_custom_target(kerDevWriteMultCO.code
-                  COMMAND ${CMAKE_HIP_COMPILER} --fatbin ${OFFLOAD_ARCH_LIST}
+                  COMMAND ${CMAKE_HIP_COMPILER} --fatbin
                   -x cu ${CMAKE_CURRENT_SOURCE_DIR}/kerDevWriteMultCO.cc
                   -o ${CMAKE_CURRENT_BINARY_DIR}/../../unit/deviceLib/kerDevWriteMultCO.code
                   -I${HIP_INCLUDE_DIR}
                   -I${CMAKE_CURRENT_SOURCE_DIR}/../../include)
   add_custom_target(kerDevFreeMultCO.code
-                  COMMAND ${CMAKE_HIP_COMPILER} --fatbin ${OFFLOAD_ARCH_LIST}
+                  COMMAND ${CMAKE_HIP_COMPILER} --fatbin
                   -x cu ${CMAKE_CURRENT_SOURCE_DIR}/kerDevFreeMultCO.cc
                   -o ${CMAKE_CURRENT_BINARY_DIR}/../../unit/deviceLib/kerDevFreeMultCO.code
                   -I${HIP_INCLUDE_DIR}
                   -I${CMAKE_CURRENT_SOURCE_DIR}/../../include)
   add_custom_target(kerDevAllocSingleKer.code
-                  COMMAND ${CMAKE_HIP_COMPILER} --fatbin ${OFFLOAD_ARCH_LIST}
+                  COMMAND ${CMAKE_HIP_COMPILER} --fatbin
                   -x cu ${CMAKE_CURRENT_SOURCE_DIR}/kerDevAllocSingleKer.cc
                   -o ${CMAKE_CURRENT_BINARY_DIR}/../../unit/deviceLib/kerDevAllocSingleKer.code
                   -I${HIP_INCLUDE_DIR}

--- a/projects/hip-tests/catch/unit/dynamicLoading/CMakeLists.txt
+++ b/projects/hip-tests/catch/unit/dynamicLoading/CMakeLists.txt
@@ -32,7 +32,7 @@ if(UNIX AND BUILD_SHARED_LIBS)
     -I${Catch2_SOURCE_DIR}/src -I${Catch2_BINARY_DIR}/generated-includes -I${HIP_PATH}/include/ -o libLazyLoad.so)
     add_custom_target(bit_extract_kernel.code COMMAND ${CMAKE_HIP_COMPILER} --fatbin
       -x cu ${CMAKE_CURRENT_SOURCE_DIR}/bit_extract_kernel.cpp -I${HIP_PATH}/include/
-      ${OFFLOAD_ARCH_LIST} -o ${CMAKE_CURRENT_BINARY_DIR}/../dynamicLoading/bit_extract_kernel.code
+      -o ${CMAKE_CURRENT_BINARY_DIR}/../dynamicLoading/bit_extract_kernel.code
       -I${CMAKE_CURRENT_SOURCE_DIR}/../../include)
   endif()
 

--- a/projects/hip-tests/catch/unit/graph/CMakeLists.txt
+++ b/projects/hip-tests/catch/unit/graph/CMakeLists.txt
@@ -171,7 +171,7 @@ if(HIP_PLATFORM MATCHES "amd")
                G_INSTALL_CUSTOM_TARGETS ${CMAKE_CURRENT_BINARY_DIR}/hipMatMul.code)
 else()
   add_custom_target(add_Kernel.code COMMAND ${CMAKE_HIP_COMPILER}
-  --fatbin ${OFFLOAD_ARCH_LIST} -x cu ${CMAKE_CURRENT_SOURCE_DIR}/add_Kernel.cpp
+  --fatbin -x cu ${CMAKE_CURRENT_SOURCE_DIR}/add_Kernel.cpp
   -o ${CMAKE_CURRENT_BINARY_DIR}/../graph/add_Kernel.code
   -I${HIP_INCLUDE_DIR}
   -I${CMAKE_CURRENT_SOURCE_DIR}/../../include)

--- a/projects/hip-tests/catch/unit/library/CMakeLists.txt
+++ b/projects/hip-tests/catch/unit/library/CMakeLists.txt
@@ -24,12 +24,12 @@ add_custom_target(reverse_kernel.code
 else()
   add_custom_target(library_code_load.code
     COMMAND ${CMAKE_HIP_COMPILER} --fatbin -x cu ${CMAKE_CURRENT_SOURCE_DIR}/library_code_load.cc
-            -o ${CMAKE_CURRENT_BINARY_DIR}/../library/library_code_load.code ${OFFLOAD_ARCH_LIST}
+            -o ${CMAKE_CURRENT_BINARY_DIR}/../library/library_code_load.code
             -I${CMAKE_CURRENT_SOURCE_DIR}/../../include
             -I${HIP_INCLUDE_DIR})
 add_custom_target(reverse_kernel.code
     COMMAND ${CMAKE_HIP_COMPILER} --fatbin -x cu ${CMAKE_CURRENT_SOURCE_DIR}/reverse_kernel.cc
-            -o ${CMAKE_CURRENT_BINARY_DIR}/../library/reverse_kernel.code ${OFFLOAD_ARCH_LIST}
+            -o ${CMAKE_CURRENT_BINARY_DIR}/../library/reverse_kernel.code
             -I${CMAKE_CURRENT_SOURCE_DIR}/../../include
             -I${HIP_INCLUDE_DIR} )
 endif()

--- a/projects/hip-tests/catch/unit/module/CMakeLists.txt
+++ b/projects/hip-tests/catch/unit/module/CMakeLists.txt
@@ -31,7 +31,7 @@ if (HIP_PLATFORM MATCHES "amd")
                    DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/get_function_module.cc)
 else()
   add_custom_command(OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/get_function_module.code
-                   COMMAND ${CMAKE_HIP_COMPILER} --fatbin ${OFFLOAD_ARCH_LIST}
+                   COMMAND ${CMAKE_HIP_COMPILER} --fatbin
                    -x cu ${CMAKE_CURRENT_SOURCE_DIR}/get_function_module.cc
                     -I${HIP_INCLUDE_DIR}
                    -o get_function_module.code
@@ -59,7 +59,7 @@ if (NOT WIN32)
     #target_link_libraries(coopKernel.code hip::host hip::device)
   else()
     add_custom_command(OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/launch_kernel_module.code
-                     COMMAND ${CMAKE_HIP_COMPILER} --fatbin ${OFFLOAD_ARCH_LIST}
+                     COMMAND ${CMAKE_HIP_COMPILER} --fatbin
                      -x cu ${CMAKE_CURRENT_SOURCE_DIR}/launch_kernel_module.cc
                      -I${HIP_INCLUDE_DIR}
                      -o launch_kernel_module.code
@@ -68,7 +68,7 @@ if (NOT WIN32)
     add_custom_target(launch_kernel_module ALL DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/launch_kernel_module.code)
 
     add_custom_target(coopKernel.code
-                    COMMAND ${CMAKE_HIP_COMPILER} --fatbin ${OFFLOAD_ARCH_LIST}
+                    COMMAND ${CMAKE_HIP_COMPILER} --fatbin
                     -x cu ${CMAKE_CURRENT_SOURCE_DIR}/coopKernel.cpp
                     -o ${CMAKE_CURRENT_BINARY_DIR}/../../unit/module/coopKernel.code
                     -I${HIP_INCLUDE_DIR}
@@ -117,7 +117,7 @@ if (HIP_PLATFORM MATCHES "amd")
                   -I${CMAKE_CURRENT_SOURCE_DIR}/../../include ${HIP_PATH_OPT})
 else()
   add_custom_command(OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/get_global_test_module.code
-                   COMMAND ${CMAKE_HIP_COMPILER} --fatbin ${OFFLOAD_ARCH_LIST}
+                   COMMAND ${CMAKE_HIP_COMPILER} --fatbin
                    -x cu ${CMAKE_CURRENT_SOURCE_DIR}/get_global_test_module.cc
                    -I${HIP_INCLUDE_DIR}
                    -o get_global_test_module.code
@@ -125,7 +125,7 @@ else()
   add_custom_target(get_global_test_module ALL DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/get_global_test_module.code)
 
   add_custom_command(OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/get_tex_ref_module.code
-                   COMMAND ${CMAKE_HIP_COMPILER} --fatbin ${OFFLOAD_ARCH_LIST}
+                   COMMAND ${CMAKE_HIP_COMPILER} --fatbin
                    -x cu ${CMAKE_CURRENT_SOURCE_DIR}/get_tex_ref_module.cc
                    -I${HIP_INCLUDE_DIR}
                    -o get_tex_ref_module.code
@@ -146,7 +146,7 @@ else()
   add_custom_target(empty_file ALL DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/empty_file.txt)
 
   add_custom_target(empty_module
-                  COMMAND ${CMAKE_HIP_COMPILER} --fatbin ${OFFLOAD_ARCH_LIST}
+                  COMMAND ${CMAKE_HIP_COMPILER} --fatbin
                   -x cu ${CMAKE_CURRENT_SOURCE_DIR}/empty_module.cc
                   -o ${CMAKE_CURRENT_BINARY_DIR}/empty_module.code
                   -I${CMAKE_CURRENT_SOURCE_DIR}/../../include)
@@ -436,31 +436,31 @@ if (HIP_PLATFORM MATCHES "amd")
   #target_link_libraries(emptyModuleCount.code hip::host hip::device)
 else()
   add_custom_target(managed_kernel.code COMMAND ${CMAKE_HIP_COMPILER} --fatbin
-  ${OFFLOAD_ARCH_LIST} -x cu ${CMAKE_CURRENT_SOURCE_DIR}/managed_kernel.cpp
+  -x cu ${CMAKE_CURRENT_SOURCE_DIR}/managed_kernel.cpp
   -o ${CMAKE_CURRENT_BINARY_DIR}/../module/managed_kernel.code
   -I${CMAKE_CURRENT_SOURCE_DIR}/../../include -I${HIP_INCLUDE_DIR})
   #target_link_libraries(managed_kernel.code hip::host hip::device)
 
   add_custom_target(vcpy_kernel.code COMMAND ${CMAKE_HIP_COMPILER} --fatbin
-  ${OFFLOAD_ARCH_LIST} -x cu ${CMAKE_CURRENT_SOURCE_DIR}/vcpy_kernel.cpp
+  -x cu ${CMAKE_CURRENT_SOURCE_DIR}/vcpy_kernel.cpp
   -o ${CMAKE_CURRENT_BINARY_DIR}/../module/vcpy_kernel.code
   -I${CMAKE_CURRENT_SOURCE_DIR}/../../include -I${HIP_INCLUDE_DIR})
   #target_link_libraries(vcpy_kernel.code hip::host hip::device)
 
   add_custom_target(matmul.code COMMAND ${CMAKE_HIP_COMPILER} --fatbin
-  -x cu ${OFFLOAD_ARCH_LIST} ${CMAKE_CURRENT_SOURCE_DIR}/matmul.cpp -o
+  -x cu ${CMAKE_CURRENT_SOURCE_DIR}/matmul.cpp -o
   ${CMAKE_CURRENT_BINARY_DIR}/../module/matmul.code
   -I${CMAKE_CURRENT_SOURCE_DIR}/../../include -I${HIP_INCLUDE_DIR})
   #target_link_libraries(matmul.code hip::host hip::device)
 
   add_custom_target(kernel_count.code COMMAND ${CMAKE_HIP_COMPILER} --fatbin
-  ${OFFLOAD_ARCH_LIST} -x cu ${CMAKE_CURRENT_SOURCE_DIR}/kernel_count.cpp -o
+  -x cu ${CMAKE_CURRENT_SOURCE_DIR}/kernel_count.cpp -o
   ${CMAKE_CURRENT_BINARY_DIR}/../module/kernel_count.code
   -I${CMAKE_CURRENT_SOURCE_DIR}/../../include -I${HIP_INCLUDE_DIR})
   #target_link_libraries(kernel_count.code hip::host hip::device)
 
   add_custom_target(emptyModuleCount.code COMMAND ${CMAKE_HIP_COMPILER} --fatbin
-  ${OFFLOAD_ARCH_LIST} -x cu ${CMAKE_CURRENT_SOURCE_DIR}/emptyModuleCount.cpp -o
+  -x cu ${CMAKE_CURRENT_SOURCE_DIR}/emptyModuleCount.cpp -o
   ${CMAKE_CURRENT_BINARY_DIR}/../module/emptyModuleCount.code
   -I${CMAKE_CURRENT_SOURCE_DIR}/../../include -I${HIP_INCLUDE_DIR})
 endif()
@@ -478,7 +478,7 @@ if (HIP_PLATFORM MATCHES "amd")
   -I${CMAKE_CURRENT_SOURCE_DIR}/../../include ${HIP_PATH_OPT})
 else()
   add_custom_target(kernel_composite_test.code COMMAND ${CMAKE_HIP_COMPILER} --fatbin
-  ${OFFLOAD_ARCH_LIST} -x cu ${CMAKE_CURRENT_SOURCE_DIR}/kernel_composite_test.cpp -o
+  -x cu ${CMAKE_CURRENT_SOURCE_DIR}/kernel_composite_test.cpp -o
   ${CMAKE_CURRENT_BINARY_DIR}/../module/kernel_composite_test.code
   -I${CMAKE_CURRENT_SOURCE_DIR}/../../include -I${HIP_INCLUDE_DIR})
 endif()

--- a/projects/hip-tests/catch/unit/occupancy/CMakeLists.txt
+++ b/projects/hip-tests/catch/unit/occupancy/CMakeLists.txt
@@ -24,7 +24,7 @@ if (HIP_PLATFORM MATCHES "amd")
                    DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/simple_kernel.cc)
 else()
   add_custom_command(OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/simple_kernel.code
-                   COMMAND ${CMAKE_HIP_COMPILER} --fatbin ${OFFLOAD_ARCH_LIST}
+                   COMMAND ${CMAKE_HIP_COMPILER} --fatbin
                    -x cu ${CMAKE_CURRENT_SOURCE_DIR}/simple_kernel.cc
                    -o simple_kernel.code
                    -I${HIP_INCLUDE_DIR}

--- a/projects/hip-tests/catch/unit/stream/hipStreamAttachMemAsync.cc
+++ b/projects/hip-tests/catch/unit/stream/hipStreamAttachMemAsync.cc
@@ -29,10 +29,10 @@ HIP_TEST_CASE(Unit_hipStreamAttachMemAsync_Negative) {
 
   SECTION("Invalid Resource Handle") {
     int definitelyNotAManagedVariable = 0;
-    HIP_CHECK_ERROR(
-        hipStreamAttachMemAsync(stream, reinterpret_cast<void*>(&definitelyNotAManagedVariable),
-                                sizeof(int), hipMemAttachSingle),
-        hipErrorInvalidValue);
+    HIP_CHECK_ERROR(hipStreamAttachMemAsync(
+                        stream, reinterpret_cast<hipDeviceptr_t*>(&definitelyNotAManagedVariable),
+                        sizeof(int), hipMemAttachSingle),
+                    hipErrorInvalidValue);
   }
 
   SECTION("Invalid devptr") {
@@ -41,14 +41,14 @@ HIP_TEST_CASE(Unit_hipStreamAttachMemAsync_Negative) {
   }
 
   SECTION("Invalid Resource Size") {
-    HIP_CHECK_ERROR(hipStreamAttachMemAsync(stream, reinterpret_cast<void*>(&var), sizeof(int) - 1,
-                                            hipMemAttachSingle),
+    HIP_CHECK_ERROR(hipStreamAttachMemAsync(stream, reinterpret_cast<hipDeviceptr_t*>(&var),
+                                            sizeof(int) - 1, hipMemAttachSingle),
                     hipErrorInvalidValue);
   }
 
   SECTION("Invalid Flags") {
     HIP_CHECK_ERROR(
-        hipStreamAttachMemAsync(stream, reinterpret_cast<void*>(&var), sizeof(int) - 1,
+        hipStreamAttachMemAsync(stream, reinterpret_cast<hipDeviceptr_t*>(&var), sizeof(int) - 1,
                                 hipMemAttachSingle | hipMemAttachHost | hipMemAttachGlobal),
         hipErrorInvalidValue);
   }
@@ -83,8 +83,8 @@ HIP_TEST_CASE(Unit_hipStreamAttachMemAsync_UseCase) {
   SECTION("Size zero is valid") {
     int* d_memory{nullptr};
     HIP_CHECK(hipMallocManaged(&d_memory, sizeof(int) * size, hipMemAttachHost));
-    HIP_CHECK(
-        hipStreamAttachMemAsync(stream, reinterpret_cast<void*>(d_memory), 0, hipMemAttachHost));
+    HIP_CHECK(hipStreamAttachMemAsync(stream, reinterpret_cast<hipDeviceptr_t*>(d_memory), 0,
+                                      hipMemAttachHost));
     HIP_CHECK(hipStreamSynchronize(stream));  // Wait for command to complete
     HIP_CHECK(hipFree(d_memory));
   }
@@ -94,8 +94,8 @@ HIP_TEST_CASE(Unit_hipStreamAttachMemAsync_UseCase) {
 
     HIP_CHECK(hipMallocManaged(&d_memory, sizeof(int) * size, hipMemAttachHost));
     HIP_CHECK(hipMemset(d_memory, 0, sizeof(int) * size));
-    HIP_CHECK(
-        hipStreamAttachMemAsync(stream, reinterpret_cast<void*>(d_memory), 0, hipMemAttachHost));
+    HIP_CHECK(hipStreamAttachMemAsync(stream, reinterpret_cast<hipDeviceptr_t*>(d_memory), 0,
+                                      hipMemAttachHost));
     HIP_CHECK(hipStreamSynchronize(stream));  // Wait for the command to complete
 
     kernel<<<1, size, 0, stream>>>(d_memory, size);
@@ -111,8 +111,8 @@ HIP_TEST_CASE(Unit_hipStreamAttachMemAsync_UseCase) {
 
   SECTION("Access ManagedMemory") {
     HIP_CHECK(hipMemset(m_memory, 0, sizeof(int) * size));
-    HIP_CHECK(
-        hipStreamAttachMemAsync(stream, reinterpret_cast<void*>(m_memory), 0, hipMemAttachHost));
+    HIP_CHECK(hipStreamAttachMemAsync(stream, reinterpret_cast<hipDeviceptr_t*>(m_memory), 0,
+                                      hipMemAttachHost));
     HIP_CHECK(hipStreamSynchronize(stream));  // Wait for the command to complete
 
     kernel<<<1, size, 0, stream>>>(m_memory, size);

--- a/projects/hip-tests/catch/unit/synchronization/CMakeLists.txt
+++ b/projects/hip-tests/catch/unit/synchronization/CMakeLists.txt
@@ -13,7 +13,7 @@ if (HIP_PLATFORM MATCHES "amd")
                   -I${HIP_INCLUDE_DIR} ${HIP_PATH_OPT}
                   -I${CMAKE_CURRENT_SOURCE_DIR}/../../include)
 else()
-  add_custom_target(memcpyInt.hsaco COMMAND ${CMAKE_HIP_COMPILER} --fatbin ${OFFLOAD_ARCH_LIST}
+  add_custom_target(memcpyInt.hsaco COMMAND ${CMAKE_HIP_COMPILER} --fatbin
                   -x cu ${CMAKE_CURRENT_SOURCE_DIR}/memcpyIntDevice.cpp -o
                   ${CMAKE_CURRENT_BINARY_DIR}/../synchronization/memcpyInt.hsaco
                   -I${HIP_INCLUDE_DIR}

--- a/projects/hip-tests/catch/unit/texture/CMakeLists.txt
+++ b/projects/hip-tests/catch/unit/texture/CMakeLists.txt
@@ -115,7 +115,7 @@ if (HIP_PLATFORM MATCHES "amd")
                    DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/tex_ref_get_module.cc)
 else()
   add_custom_command(OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/tex_ref_get_module.code
-                   COMMAND ${CMAKE_HIP_COMPILER} --fatbin ${OFFLOAD_ARCH_LIST}
+                   COMMAND ${CMAKE_HIP_COMPILER} --fatbin
                    -x cu ${CMAKE_CURRENT_SOURCE_DIR}/tex_ref_get_module.cc
                    -I${HIP_INCLUDE_DIR}
                    -o tex_ref_get_module.code

--- a/projects/hip-tests/catch/unit/texture/hipMipmappedArrayGetMemoryRequirements.cc
+++ b/projects/hip-tests/catch/unit/texture/hipMipmappedArrayGetMemoryRequirements.cc
@@ -28,10 +28,13 @@ HIP_TEST_CASE(Unit_hipMipmappedArrayGetMemoryRequirements_Negative_Parameters) {
   HIP_CHECK(hipMipmappedArrayCreate(&array, &desc, levels));
 
   SECTION("memoryRequirements is nullptr") {
-    HIP_CHECK_ERROR(hipMipmappedArrayGetMemoryRequirements(nullptr, array, device_id), hipErrorInvalidValue);
+    HIP_CHECK_ERROR(hipMipmappedArrayGetMemoryRequirements(
+                        nullptr, reinterpret_cast<hipMipmappedArray_t>(array), device_id),
+                    hipErrorInvalidValue);
   }
 
   SECTION("mipmap is nullptr") {
-    HIP_CHECK_ERROR(hipMipmappedArrayGetMemoryRequirements(&memoryRequirements, nullptr, device_id), hipErrorInvalidHandle);
+    HIP_CHECK_ERROR(hipMipmappedArrayGetMemoryRequirements(&memoryRequirements, nullptr, device_id),
+                    hipErrorInvalidHandle);
   }
 }


### PR DESCRIPTION
## Motivation
The latest version of hip-tests includes the auto-generated headers, created in build-time via python script. Script relies on offload_arch variable, which was not presented on nightly nvidia tests schedule. This PR fixes the offload arch usage on the Nvidia pipelines
<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details
Removes redundant offload arch argument in the custom targets, fixing the configure and compile steps for this target.
<!-- Explain the changes along with any relevant GitHub links. -->

## JIRA ID
NA
<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan
Nvidia nightly schedule workflow should be able to compile and start tests.
AMD platform should not be impacted 
<!-- Explain any relevant testing done to verify this PR. -->

## Test Result
No AMD impact locally, waiting for PSDB completion.
NVidia pipeline results will be attached later.
<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
