### PR TITLE
[hip-tests] Fix memory leak on single device systems

### DIFF
--- a/projects/hip-tests/catch/unit/memory/hipMallocManaged_MultiScenario.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMallocManaged_MultiScenario.cc
@@ -341,14 +341,15 @@ HIP_TEMPLATE_TEST_CASE(Unit_hipMallocManaged_DeviceContextChange,
     return;
   }
 
-  std::atomic<unsigned int> DataMismatch;
-  TestType *Ah1 = new TestType[N], *Ah2 = new TestType[N], *Ad = nullptr, *Hmm = nullptr;
   int NumDevices = 0;
   HIP_CHECK(hipGetDeviceCount(&NumDevices));
   if (NumDevices < 2) {
     HipTest::HIP_SKIP_TEST("Skipping test because more than one device was not found.");
     return;
   }
+
+  std::atomic<unsigned int> DataMismatch;
+  TestType *Ah1 = new TestType[N], *Ah2 = new TestType[N], *Ad = nullptr, *Hmm = nullptr;
 
   for (size_t i = 0; i < N; ++i) {
     Ah1[i] = INIT_VAL;


### PR DESCRIPTION
## Motivation

Memory leak is detected when run with ASAN

## Technical Details

When the test is skipped due to lack to devices, the memory allocated is never freed.

## JIRA ID

N/A

## Test Plan

N/A

## Test Result

N/A

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
