### PR TITLE
[msvc 1/13] dbgapi: Fix comment vs code mismatch in watchpoint_t::watchpoint_t

### DIFF
--- a/projects/rocdbgapi/CMakeLists.txt
+++ b/projects/rocdbgapi/CMakeLists.txt
@@ -461,8 +461,10 @@ target_include_directories(amd-dbgapi
     $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/include/amd-dbgapi>
     $<INSTALL_INTERFACE:include>)
 
-target_link_libraries(amd-dbgapi
-  PRIVATE -Wl,--version-script=${CMAKE_CURRENT_BINARY_DIR}/src/exportmap -Wl,--no-undefined)
+if(NOT WIN32)
+  target_link_libraries(amd-dbgapi
+    PRIVATE -Wl,--version-script=${CMAKE_CURRENT_BINARY_DIR}/src/exportmap -Wl,--no-undefined)
+endif()
 
 set(AMD_DBGAPI_CONFIG_NAME amd-dbgapi-config.cmake)
 set(AMD_DBGAPI_TARGETS_NAME amd-dbgapi-targets.cmake)

--- a/projects/rocdbgapi/CMakeLists.txt
+++ b/projects/rocdbgapi/CMakeLists.txt
@@ -285,19 +285,18 @@ elseif(CMAKE_SYSTEM_NAME STREQUAL "Windows")
 
   target_include_directories(amd-dbgapi PRIVATE
     src/windows/imported
-    ${D3DKMT_INCLUDE_PATH}
+    ${D3DKMT_INCLUDE_PATH})
+
+  # Including libdxg raises some warnings (unknown pragmas) as well as
+  # "X too small to hold all values of Y".  The latter warning cannot
+  # be silenced, so tell the compiler to treat the libdxg directory as
+  # a system headers include path, so that warnings are disabled for
+  # that directory's headers.
+  target_include_directories(amd-dbgapi SYSTEM PRIVATE
     third_party/libdxg/include)
 
   target_compile_definitions(amd-dbgapi
     PRIVATE D3DKMDT_SPECIAL_MULTIPLATFORM_TOOL)
-
-  # Including libdxg raises some warnings (unknown pargmas) as well us
-  # "X too small to hold all values of Y".  The latter warning cannot be
-  # silenced, se we need to disable -Werror for this file.
-  set_source_files_properties(
-    src/os_driver_kmd.cpp
-    PROPERTIES
-      COMPILE_OPTIONS "-Wno-error;-Wno-unknown-pragmas")
 else()
   message(FATAL_ERROR "Platform ${CMAKE_SYSTEM_NAME} is not supported")
 endif()

--- a/projects/rocdbgapi/include/amd-dbgapi.h.in
+++ b/projects/rocdbgapi/include/amd-dbgapi.h.in
@@ -492,19 +492,19 @@
 #endif /* !defined (AMD_DBGAPI_CALL) */
 
 #if !defined(AMD_DBGAPI_EXPORT_DECORATOR)
-#if defined(__GNUC__)
-#define AMD_DBGAPI_EXPORT_DECORATOR __attribute__ ((visibility ("default")))
-#elif defined(_MSC_VER)
-#define AMD_DBGAPI_EXPORT_DECORATOR __declspec(dllexport)
-#endif /* defined (_MSC_VER) */
+# if defined(_WIN32)
+#  define AMD_DBGAPI_EXPORT_DECORATOR __declspec(dllexport)
+# elif defined(__GNUC__)
+#  define AMD_DBGAPI_EXPORT_DECORATOR __attribute__ ((visibility ("default")))
+# endif
 #endif /* !defined (AMD_DBGAPI_EXPORT_DECORATOR) */
 
 #if !defined(AMD_DBGAPI_IMPORT_DECORATOR)
-#if defined(__GNUC__)
-#define AMD_DBGAPI_IMPORT_DECORATOR
-#elif defined(_MSC_VER)
-#define AMD_DBGAPI_IMPORT_DECORATOR __declspec(dllimport)
-#endif /* defined (_MSC_VER) */
+# if defined(_WIN32)
+#  define AMD_DBGAPI_IMPORT_DECORATOR __declspec(dllimport)
+# else
+#  define AMD_DBGAPI_IMPORT_DECORATOR
+# endif
 #endif /* !defined (AMD_DBGAPI_IMPORT_DECORATOR) */
 
 #define AMD_DBGAPI_EXPORT AMD_DBGAPI_EXPORT_DECORATOR AMD_DBGAPI_CALL

--- a/projects/rocdbgapi/src/os_driver_kmd.cpp
+++ b/projects/rocdbgapi/src/os_driver_kmd.cpp
@@ -21,6 +21,7 @@
 #include "debug.h"
 #include "logging.h"
 #include "os_driver.h"
+#include "utils_windows.h"
 
 /* Make sure we use the STATUS_XXX constants from ntstatus.h.  Some of
    the constants we use (but not all) are defined in winnt.h too, but
@@ -1279,28 +1280,17 @@ kmd_driver_t::get_adapter_name (D3DKMT_HANDLE adapter) const
   query_info.pPrivateDriverData = &adapter_reg_info;
   query_info.PrivateDriverDataSize = sizeof (D3DKMT_ADAPTERREGISTRYINFO);
 
-  if (m_d3d.api.query_adapter_info (&query_info) != STATUS_SUCCESS)
-    return "<unknown>";
+  if (m_d3d.api.query_adapter_info (&query_info) == STATUS_SUCCESS)
+    {
+      size_t wide_len = ::wcsnlen (adapter_reg_info.AdapterString,
+                                   std::size (adapter_reg_info.AdapterString));
+      std::wstring_view ws (adapter_reg_info.AdapterString, wide_len);
+      std::string name = utils::convert_to_string (ws);
+      if (!name.empty ())
+        return name;
+    }
 
-  size_t wide_len = ::wcsnlen (adapter_reg_info.AdapterString,
-                               std::size (adapter_reg_info.AdapterString));
-  if (wide_len == 0)
-    return "<unknown>";
-
-  int size_needed
-    = WideCharToMultiByte (CP_ACP, 0, adapter_reg_info.AdapterString,
-                           (int)wide_len, nullptr, 0,
-                           nullptr, nullptr);
-  if (size_needed <= 0)
-    return "<unknown>";
-
-  std::string result (size_needed, '\0');
-  int size
-    = WideCharToMultiByte (CP_ACP, 0, adapter_reg_info.AdapterString,
-                           (int)wide_len, &result[0], size_needed,
-                           "?", nullptr);
-  dbgapi_assert (size == size_needed);
-  return result;
+  return "<unknown>";
 }
 
 amd_dbgapi_status_t

--- a/projects/rocdbgapi/src/os_driver_kmd.cpp
+++ b/projects/rocdbgapi/src/os_driver_kmd.cpp
@@ -2129,77 +2129,77 @@ kmd_driver_t::xfer_agent_memory_partial (os_agent_id_t agent_id,
      aligned.  If so, use an intermediate guaranteed-aligned
      buffer.  */
   size_t misalign = (read != nullptr
-		     ? (uintptr_t) read % sizeof (DWORD)
-		     : (uintptr_t) write % sizeof (DWORD));
+                     ? (uintptr_t) read % sizeof (DWORD)
+                     : (uintptr_t) write % sizeof (DWORD));
   if (misalign != 0)
     {
       /* Large enough to fit most xfers in one escape call, and small
-	 enough to not cause stack overflow problems.  */
+         enough to not cause stack overflow problems.  */
       constexpr size_t aligned_buffer_size = 64;
       alignas(DWORD) std::byte aligned_buffer[aligned_buffer_size];
 
       /* If we need a second xfer, read/write enough bytes such that
-	 that xfer will be aligned.  */
+         that xfer will be aligned.  */
       size_t partial_size = (*size > sizeof (aligned_buffer)
-			     ? misalign
-			     : *size);
+                             ? misalign
+                             : *size);
 
       if (write != nullptr)
-	std::memcpy (aligned_buffer, write, partial_size);
+        std::memcpy (aligned_buffer, write, partial_size);
 
       /* Recurse to do the aligned partial xfer.  */
       size_t wanted_partial_size = partial_size;
       amd_dbgapi_status_t status
-	= xfer_agent_memory_partial (agent_id,
-				     address,
-				     (read != nullptr
-				      ? aligned_buffer
-				      : nullptr),
-				     (write != nullptr
-				      ? aligned_buffer
-				      : nullptr),
-				     &partial_size);
+        = xfer_agent_memory_partial (agent_id,
+                                     address,
+                                     (read != nullptr
+                                      ? aligned_buffer
+                                      : nullptr),
+                                     (write != nullptr
+                                      ? aligned_buffer
+                                      : nullptr),
+                                     &partial_size);
       if (status != AMD_DBGAPI_STATUS_SUCCESS)
-	return status;
+        return status;
       if (read != nullptr)
-	std::memcpy (read, aligned_buffer, partial_size);
+        std::memcpy (read, aligned_buffer, partial_size);
 
       /* If we got less than we wanted, then we're already done.  */
       if (wanted_partial_size != partial_size)
-	{
-	  *size = partial_size;
-	  return status;
-	}
+        {
+          *size = partial_size;
+          return status;
+        }
 
       /* Now xfer the remainder.  Several callers don't currently
-	 handle partial xfers, so if this fails, return failure for
-	 the whole xfer.  Once all such callers are fixed, this whole
-	 if block can be removed.  */
+         handle partial xfers, so if this fails, return failure for
+         the whole xfer.  Once all such callers are fixed, this whole
+         if block can be removed.  */
       size_t remaining_size = *size - partial_size;
       if (remaining_size != 0)
-	{
-	  if (read != nullptr)
-	    read = (char *) read + partial_size;
-	  else
-	    write = (char *) write + partial_size;
+        {
+          if (read != nullptr)
+            read = (char *) read + partial_size;
+          else
+            write = (char *) write + partial_size;
 
-	  /* This access is now guaranteed to be word-aligned.  */
-	  size_t new_misalign = (read != nullptr
-				 ? (uintptr_t) read % sizeof (DWORD)
-				 : (uintptr_t) write % sizeof (DWORD));
-	  dbgapi_assert (new_misalign == 0);
+          /* This access is now guaranteed to be word-aligned.  */
+          size_t new_misalign = (read != nullptr
+                                 ? (uintptr_t) read % sizeof (DWORD)
+                                 : (uintptr_t) write % sizeof (DWORD));
+          dbgapi_assert (new_misalign == 0);
 
-	  address += partial_size;
+          address += partial_size;
 
-	  /* Recurse.  */
-	  status
-	    = xfer_agent_memory_partial (agent_id, address,
-					 read, write, &remaining_size);
+          /* Recurse.  */
+          status
+            = xfer_agent_memory_partial (agent_id, address,
+                                         read, write, &remaining_size);
 
-	  /* Don't update SIZE unless we succeeded.  */
-	  if (status != AMD_DBGAPI_STATUS_SUCCESS)
-	    return status;
-	}
+          /* Don't update SIZE unless we succeeded.  */
+          if (status != AMD_DBGAPI_STATUS_SUCCESS)
+            return status;
+        }
 
       *size = partial_size + remaining_size;
       return status;

--- a/projects/rocdbgapi/src/os_driver_kmd.cpp
+++ b/projects/rocdbgapi/src/os_driver_kmd.cpp
@@ -2184,9 +2184,10 @@ kmd_driver_t::xfer_agent_memory_partial (os_agent_id_t agent_id,
             write = (char *) write + partial_size;
 
           /* This access is now guaranteed to be word-aligned.  */
-          size_t new_misalign = (read != nullptr
-                                 ? (uintptr_t) read % sizeof (DWORD)
-                                 : (uintptr_t) write % sizeof (DWORD));
+          [[maybe_unused]] size_t new_misalign
+            = (read != nullptr
+               ? (uintptr_t)read % sizeof (DWORD)
+               : (uintptr_t)write % sizeof (DWORD));
           dbgapi_assert (new_misalign == 0);
 
           address += partial_size;

--- a/projects/rocdbgapi/src/utils_windows.cpp
+++ b/projects/rocdbgapi/src/utils_windows.cpp
@@ -18,6 +18,7 @@
  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  THE SOFTWARE. */
 
+#include "utils_windows.h"
 #include "utils.h"
 #include <io.h>
 #include <windows.h>
@@ -28,19 +29,65 @@ namespace amd::dbgapi
 namespace utils
 {
 
+std::string
+convert_to_string (std::wstring_view ws)
+{
+  if (ws.empty ())
+    return {};
+
+  int size_needed
+    = ::WideCharToMultiByte (CP_ACP, 0, ws.data (), (int)ws.size (),
+                             nullptr, 0, nullptr, nullptr);
+  if (size_needed <= 0)
+    return {};
+
+  std::string result (size_needed, '\0');
+
+  [[maybe_unused]] int size
+    = ::WideCharToMultiByte (CP_ACP, 0, ws.data (), (int)ws.size (),
+                             &result[0], size_needed, "?", nullptr);
+
+  dbgapi_assert (size == size_needed);
+
+  return result;
+}
+
 const char *
 get_self_name ()
 {
-  static char path[MAX_PATH];
-  HMODULE hmodule = nullptr;
+  static const auto self_name = [] () -> std::string
+  {
+    HMODULE h;
+    if (::GetModuleHandleExW (GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS
+                              | GET_MODULE_HANDLE_EX_FLAG_UNCHANGED_REFCOUNT,
+                              (LPCWSTR)&get_self_name, &h))
+      {
+        std::wstring wself_name;
+        DWORD size = MAX_PATH;
 
-  if (::GetModuleHandleEx (GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS
-                             | GET_MODULE_HANDLE_EX_FLAG_UNCHANGED_REFCOUNT,
-                           static_cast<const char *> (path), &hmodule)
-      && ::GetModuleFileName (hmodule, path, sizeof (path)))
-    return path;
+        /* Loop to find the true length, thus handling long paths.  */
+        while (true)
+          {
+            wself_name.resize (size);
+            DWORD len = ::GetModuleFileNameW (h, &wself_name[0], size);
+            if (len == 0)
+              break;
 
-  return "";
+            if (len < size)
+              {
+                wself_name.resize (len);
+                return convert_to_string (wself_name);
+              }
+
+            /* Buffer was too small; double it and try again.  */
+            size *= 2;
+          }
+      }
+
+    return {};
+  } ();
+
+  return self_name.c_str ();
 }
 
 } /* namespace amd::dbgapi::utils.  */

--- a/projects/rocdbgapi/src/utils_windows.h
+++ b/projects/rocdbgapi/src/utils_windows.h
@@ -1,0 +1,40 @@
+/* Copyright (c) 2026 Advanced Micro Devices, Inc.
+
+ Permission is hereby granted, free of charge, to any person obtaining a copy
+ of this software and associated documentation files (the "Software"), to deal
+ in the Software without restriction, including without limitation the rights
+ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ copies of the Software, and to permit persons to whom the Software is
+ furnished to do so, subject to the following conditions:
+
+ The above copyright notice and this permission notice shall be included in
+ all copies or substantial portions of the Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ THE SOFTWARE. */
+
+/* Utility routines only needed on Windows.  */
+
+#ifndef AMD_DBGAPI_UTILS_WINDOWS_H
+#define AMD_DBGAPI_UTILS_WINDOWS_H 1
+
+#include "amd-dbgapi.h"
+
+#include <string>
+#include <string_view>
+
+namespace amd::dbgapi::utils
+{
+
+/* Convert WS to a std::string, in the current code page.  If
+   conversion fails, returns an entry string.  */
+std::string convert_to_string (std::wstring_view ws);
+
+} /* namespace amd::dbgapi::utils */
+
+#endif /* AMD_DBGAPI_UTILS_WINDOWS_H */

--- a/projects/rocdbgapi/src/watchpoint.cpp
+++ b/projects/rocdbgapi/src/watchpoint.cpp
@@ -68,10 +68,16 @@ watchpoint_t::watchpoint_t (amd_dbgapi_watchpoint_id_t watchpoint_id,
      ones, e.g.:
 
              47       39        Y       23       15        X     0
-     First:  01111111 11111110 11100111 00000100 00000000 01000100
+     First:  01111111 11111110 11100111 00000100 00000000 01000000
      Last:   01111111 11111110 11100111 00000100 00000000 01001000
 
-     Stable := ~(next_power_of_2 (Start ^ End) - 1)
+     Start ^ End:
+             00000000 00000000 00000000 00000000 00000000 00001000
+
+     Stable := ~(next_power_of_2 (Start ^ End + 1) - 1)
+
+     Note: the +1 is required when (Start ^ End) is already a power of
+     two.
 
              47       39        Y       23       15        X     0
      Stable: 11111111 11111111 11111111 11111111 11111111 11110000
@@ -89,11 +95,15 @@ watchpoint_t::watchpoint_t (amd_dbgapi_watchpoint_id_t watchpoint_id,
      aAddr:  01111111 11111110 11100111 00000100 00000000 01000000
    */
 
+  auto get_stable_bits = [] (uint64_t first, uint64_t last)
+  {
+    return ~(utils::next_power_of_two ((first ^ last) + 1) - 1);
+  };
+
   uint64_t first_address = requested_address;
   uint64_t last_address = first_address + requested_size - 1;
 
-  uint64_t stable_bits
-    = -utils::next_power_of_two ((first_address ^ last_address) + 1);
+  uint64_t stable_bits = get_stable_bits (first_address, last_address);
 
   /* programmable_mask_bits is the intersection of all the process' agents
      capabilities.  architecture_t::watchpoint_mask_bits returns a mask
@@ -118,8 +128,7 @@ watchpoint_t::watchpoint_t (amd_dbgapi_watchpoint_id_t watchpoint_id,
          boundary and compute the stable_bits again.  This time the stable_bits
          mask must be in the agent capabilities.  */
       last_address = ((first_address + ~field_A) & field_A) - 1;
-      stable_bits
-        = -utils::next_power_of_two ((first_address ^ last_address) + 1);
+      stable_bits = get_stable_bits (first_address, last_address);
       dbgapi_assert (stable_bits >= field_A);
     }
 


### PR DESCRIPTION
The comment in watchpoint_t::watchpoint_t does not match the code.
Specifically, it says:

Stable := ~(next_power_of_2 (Start ^ End) - 1)

But the code does:

uint64_t stable_bits
= -utils::next_power_of_two ((first_address ^ last_address) + 1);

Which is the equivalent of:

Stable := ~(next_power_of_2 (Start ^ End + 1) - 1)
^^^^

So the "+ 1" is missing in the comment.  The code is correct, the
comment is wrong.  The "+ 1" is needed when "Start ^ End" is already a
power-of-two.

To illustrate, in the example given, The missing "+ 1" makes no
difference:

First: ...01000100  /* 0x44 */
Last:  ...01001000  /* 0x48 */

d = Start ^ End = 0x44 ^ 0x48 = 0x0C  /* 1100b */

Without +1:
next_power_of_2 (0x0C) = 0x10
With +1:
next_power_of_2 (0x0C + 1) = next_power_of_2 (0x0D) = 0x10

However, when 'd' is already a power of two:

next_power_of_two (d) == d

While what we actually want is:

smallest power-of-two strictly greater than d

So we need to compensate by doing:

next_power_of_two (d + 1)

Which effectively turns it into:

smallest power-of-two > d

I think we should tweak the example in the comment to be a case where
it the missing +1 matters, like:

First: ...01000000  /* 0x40 */
Last:  ...01001000  /* 0x48 */

d = Start ^ End = 0x40 ^ 0x48 = 0x08  /* 1000b */

Without +1:
next_power_of_2 (0x08) = 0x08
With +1:
next_power_of_2 (0x08 + 1) = next_power_of_2 (0x09) = 0x10

This commit does that too.

Also tweak the code to use "~(X - 1)" style instead of "-X" to match
the comment style, and also because this fixes a warning ("unary minus
operator applied to unsigned type, result still unsigned") when
compiled with MSVC, which is what made me look at this in the first
place.

Change-Id: Ib15e6b1bc2799ed25a8d6f277f8b7aa4bf7868f6

---

**Stack**:
- #4291
- #4290
- #4289
- #4288
- #4287
- #4286
- #4285
- #4284
- #4283
- #4282
- #4281
- #4280
- #4245 ⬅


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*