### PR TITLE
[hip-tests] Fix setFuncAttribute test setting more than max sharedMem

### DIFF
--- a/projects/hip-tests/catch/unit/kernel/hipDynamicShared2.cc
+++ b/projects/hip-tests/catch/unit/kernel/hipDynamicShared2.cc
@@ -8,16 +8,19 @@
 #include <hip_test_checkers.hh>
 #include <hip_test_common.hh>
 
-
-#define LEN (16 * 1024)
-#define SIZE (LEN * sizeof(float))
-
-__global__ void vectorAdd(float* Ad, float* Bd) {
+__global__ void vectorAdd(float* Ad, float* Bd, size_t num_elements) {
   extern __shared__ float sBd[];
   int tx = threadIdx.x;
-  for (int i = 0; i < LEN / 64; i++) {
-    sBd[tx + i * 64] = Ad[tx + i * 64] + 1.0f;
-    Bd[tx + i * 64] = sBd[tx + i * 64];
+  for (size_t i = 0; i < num_elements / blockDim.x; i++) {
+    sBd[tx + i * blockDim.x] = Ad[tx + i * blockDim.x] + 1.0f;
+    Bd[tx + i * blockDim.x] = sBd[tx + i * blockDim.x];
+  }
+
+  const int remainder = static_cast<int>(num_elements % blockDim.x);
+  if (tx < remainder) {
+    const int idx = (num_elements - remainder) + tx;
+    sBd[idx] = Ad[idx] + 1.0f;
+    Bd[idx] = sBd[idx];
   }
 }
 
@@ -44,18 +47,6 @@ __global__ void vectorAdd(float* Ad, float* Bd) {
  *    - HIP_VERSION >= 5.5
  */
 HIP_TEST_CASE(Unit_hipDynamicShared2) {
-  float *A, *B, *Ad, *Bd;
-  A = new float[LEN];
-  B = new float[LEN];
-  for (int i = 0; i < LEN; i++) {
-    A[i] = 1.0f;
-    B[i] = 1.0f;
-  }
-  HIP_CHECK(hipMalloc(&Ad, SIZE));
-  HIP_CHECK(hipMalloc(&Bd, SIZE));
-  HIP_CHECK(hipMemcpy(Ad, A, SIZE, hipMemcpyHostToDevice));
-  HIP_CHECK(hipMemcpy(Bd, B, SIZE, hipMemcpyHostToDevice));
-
   hipFuncAttributes func_attributes{};
   HIP_CHECK(hipFuncGetAttributes(&func_attributes, reinterpret_cast<const void*>(&vectorAdd)));
 
@@ -63,24 +54,42 @@ HIP_TEST_CASE(Unit_hipDynamicShared2) {
   HIP_CHECK(hipDeviceGetAttribute(&max_shared_memory_per_block,
                                   hipDeviceAttributeMaxSharedMemoryPerBlock, 0));
 
+  size_t threadPerBlock = 64;
+  const size_t dynamic_shared_bytes = max_shared_memory_per_block - func_attributes.sharedSizeBytes;
+
+  REQUIRE(dynamic_shared_bytes >= threadPerBlock * sizeof(float));
+  const size_t num_elements = dynamic_shared_bytes / sizeof(float);
+
+  std::vector<float> A(num_elements);
+  std::vector<float> B(num_elements);
+  for (int i = 0; i < num_elements; i++) {
+    A[i] = 1.0f;
+    B[i] = 1.0f;
+  }
+
+  float *Ad, *Bd;
+  HIP_CHECK(hipMalloc(&Ad, dynamic_shared_bytes));
+  HIP_CHECK(hipMalloc(&Bd, dynamic_shared_bytes));
+
+  HIP_CHECK(hipMemcpy(Ad, A.data(), dynamic_shared_bytes, hipMemcpyHostToDevice));
+  HIP_CHECK(hipMemcpy(Bd, B.data(), dynamic_shared_bytes, hipMemcpyHostToDevice));
+
   //  The sum of sharedSizeBytes (statically-allocated shared memory per block) and
   //  hipFuncAttributeMaxDynamicSharedMemorySize (dynamically-allocated shared memory per block)
   //  cannot exceed the size of hipDeviceAttributeMaxSharedMemoryPerBlock.
   HIP_CHECK(hipFuncSetAttribute(reinterpret_cast<const void*>(&vectorAdd),
-                                hipFuncAttributeMaxDynamicSharedMemorySize,
-                                max_shared_memory_per_block - func_attributes.sharedSizeBytes));
+                                hipFuncAttributeMaxDynamicSharedMemorySize, dynamic_shared_bytes));
 
-  hipLaunchKernelGGL(vectorAdd, dim3(1, 1, 1), dim3(64, 1, 1), SIZE, 0, Ad, Bd);
+  hipLaunchKernelGGL(vectorAdd, dim3(1, 1, 1), dim3(threadPerBlock, 1, 1), dynamic_shared_bytes, 0,
+                     Ad, Bd, num_elements);
   HIP_CHECK(hipGetLastError());
-  HIP_CHECK(hipMemcpy(B, Bd, SIZE, hipMemcpyDeviceToHost));
-  for (int i = 0; i < LEN; i++) {
-    assert(B[i] > 1.0f && B[i] < 3.0f);
+  HIP_CHECK(hipMemcpy(B.data(), Bd, dynamic_shared_bytes, hipMemcpyDeviceToHost));
+  for (int i = 0; i < num_elements; i++) {
+    REQUIRE(B[i] > 1.0f);
+    REQUIRE(B[i] < 3.0f);
   }
   HIP_CHECK(hipFree(Ad));
   HIP_CHECK(hipFree(Bd));
-
-  delete[] A;
-  delete[] B;
 }
 
 /**

--- a/projects/hip-tests/catch/unit/kernel/hipDynamicShared2.cc
+++ b/projects/hip-tests/catch/unit/kernel/hipDynamicShared2.cc
@@ -43,7 +43,6 @@ __global__ void vectorAdd(float* Ad, float* Bd) {
  * ------------------------
  *    - HIP_VERSION >= 5.5
  */
-
 HIP_TEST_CASE(Unit_hipDynamicShared2) {
   float *A, *B, *Ad, *Bd;
   A = new float[LEN];
@@ -57,10 +56,20 @@ HIP_TEST_CASE(Unit_hipDynamicShared2) {
   HIP_CHECK(hipMemcpy(Ad, A, SIZE, hipMemcpyHostToDevice));
   HIP_CHECK(hipMemcpy(Bd, B, SIZE, hipMemcpyHostToDevice));
 
-  hipError_t ret = hipFuncSetAttribute(reinterpret_cast<const void*>(&vectorAdd),
-                                       hipFuncAttributeMaxDynamicSharedMemorySize, SIZE);
+  hipFuncAttributes func_attributes{};
+  HIP_CHECK(hipFuncGetAttributes(&func_attributes, reinterpret_cast<const void*>(&vectorAdd)));
 
-  REQUIRE(ret == hipSuccess);
+  int max_shared_memory_per_block{};
+  HIP_CHECK(hipDeviceGetAttribute(&max_shared_memory_per_block,
+                                  hipDeviceAttributeMaxSharedMemoryPerBlock, 0));
+
+  //  The sum of sharedSizeBytes (statically-allocated shared memory per block) and
+  //  hipFuncAttributeMaxDynamicSharedMemorySize (dynamically-allocated shared memory per block)
+  //  cannot exceed the size of hipDeviceAttributeMaxSharedMemoryPerBlock.
+  HIP_CHECK(hipFuncSetAttribute(reinterpret_cast<const void*>(&vectorAdd),
+                                hipFuncAttributeMaxDynamicSharedMemorySize,
+                                max_shared_memory_per_block - func_attributes.sharedSizeBytes));
+
   hipLaunchKernelGGL(vectorAdd, dim3(1, 1, 1), dim3(64, 1, 1), SIZE, 0, Ad, Bd);
   HIP_CHECK(hipGetLastError());
   HIP_CHECK(hipMemcpy(B, Bd, SIZE, hipMemcpyDeviceToHost));


### PR DESCRIPTION
## Motivation

Test fails on MI325 when ASAN is enabled.

## Technical Details

The test was not respecting the maximum values for hipFuncAttributeMaxDynamicSharedMemorySize.

## JIRA ID

N/A

## Test Plan

Tested locally

## Test Result

Tested locally

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
