### PR TITLE
[rocshmem] Revert C++20 to C++17 as the std support

### DIFF
--- a/projects/rocshmem/cmake/DeviceBitcode.cmake
+++ b/projects/rocshmem/cmake/DeviceBitcode.cmake
@@ -47,7 +47,7 @@ set(BITCODE_GPU_ARCHS "${_BITCODE_DEFAULT_ARCHS}" CACHE STRING "GPU architecture
 set(BITCODE_COMPILE_FLAGS_BASE
     -x hip
     --cuda-device-only
-    -std=c++20
+    -std=c++17
     -emit-llvm
     -fvisibility=default
     -I${CMAKE_CURRENT_SOURCE_DIR}/include/rocshmem
@@ -56,6 +56,11 @@ set(BITCODE_COMPILE_FLAGS_BASE
     -I${CMAKE_BINARY_DIR}/include
     -I${CMAKE_BINARY_DIR}/include/rocshmem
 )
+
+if(${ROCM_MAJOR_VERSION} LESS 7)
+  # ROCm 6.x requires us to explicitly enable warp sync builtins
+  list(APPEND BITCODE_COMPILE_FLAGS_BASE -DHIP_ENABLE_WARP_SYNC_BUILTINS=1)
+endif()
 
 # Add MPI include directories — rocshmem_config.h defines HAVE_EXTERNAL_MPI
 # when MPI is found, causing rocshmem_mpi.hpp to #include <mpi.h> transitively.

--- a/projects/rocshmem/cmake/setup_project.cmake
+++ b/projects/rocshmem/cmake/setup_project.cmake
@@ -76,7 +76,7 @@ endif()
 # GLOBAL COMPILE FLAGS
 ###############################################################################
 set(CMAKE_CXX_EXTENSIONS OFF)
-set(CMAKE_CXX_STANDARD 20)
+set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_FLAGS_DEBUG "-Og -ggdb")
 

--- a/projects/rocshmem/src/envvar.hpp
+++ b/projects/rocshmem/src/envvar.hpp
@@ -149,7 +149,9 @@ namespace envvar {
         template <> struct _is_narrow_character<char>          : std::true_type  { };
         template <> struct _is_narrow_character<signed char>   : std::true_type  { };
         template <> struct _is_narrow_character<unsigned char> : std::true_type  { };
-        //template <> struct _is_narrow_character<char8_t>       : std::true_type  { }; //C++20 required
+#if defined(__cpp_char8_t) || (defined(__cplusplus) && __cplusplus >= 202002L)
+        template <> struct _is_narrow_character<char8_t>       : std::true_type  { };
+#endif  // char8_t narrow character specialization
 
         template <typename T>
         struct is_narrow_character

--- a/projects/rocshmem/src/envvar.hpp
+++ b/projects/rocshmem/src/envvar.hpp
@@ -149,7 +149,7 @@ namespace envvar {
         template <> struct _is_narrow_character<char>          : std::true_type  { };
         template <> struct _is_narrow_character<signed char>   : std::true_type  { };
         template <> struct _is_narrow_character<unsigned char> : std::true_type  { };
-        template <> struct _is_narrow_character<char8_t>       : std::true_type  { };
+        //template <> struct _is_narrow_character<char8_t>       : std::true_type  { }; //C++20 required
 
         template <typename T>
         struct is_narrow_character

--- a/projects/rocshmem/tests/functional_tests/CMakeDeviceBitcodeTester.cmake
+++ b/projects/rocshmem/tests/functional_tests/CMakeDeviceBitcodeTester.cmake
@@ -48,7 +48,7 @@ foreach(GPU_ARCH ${BITCODE_GPU_ARCHS})
   add_custom_command(
     OUTPUT ${KERNEL_BC}
     COMMAND ${LLVM_CLANG}
-      -x hip --cuda-device-only -std=c++20 -emit-llvm
+      -x hip --cuda-device-only -std=c++17 -emit-llvm
       --offload-arch=${GPU_ARCH}
       -fvisibility=default
       -c ${CMAKE_CURRENT_SOURCE_DIR}/device_bitcode_tester_kernel.hip

--- a/projects/rocshmem/tests/unit_tests/envvar_gtest.cpp
+++ b/projects/rocshmem/tests/unit_tests/envvar_gtest.cpp
@@ -101,7 +101,7 @@ TEST_F(EnvVarTestFixture, parse_integer_negative) {
   const envvar::var<int64_t> var_{this->var_name_, this->var_doc_};
   EXPECT_FALSE(var_.is_default());
   EXPECT_EQ(var_.get_default(), 0);
-  EXPECT_EQ(var_.get_value(), -1L << 30);
+  EXPECT_EQ(var_.get_value(), -(1L << 30));
 }
 
 TEST_F(EnvVarTestFixture, parse_integer_negative_large) {
@@ -149,7 +149,7 @@ TEST_F(EnvVarTestFixture, parse_integer_hex_negative) {
   const envvar::var<int64_t> var_{this->var_name_, this->var_doc_};
   EXPECT_FALSE(var_.is_default());
   EXPECT_EQ(var_.get_default(), 0);
-  EXPECT_EQ(var_.get_value(), -1L << 30);
+  EXPECT_EQ(var_.get_value(), -(1L << 30));
 }
 
 TEST_F(EnvVarTestFixture, parse_integer_hex_negative_large) {


### PR DESCRIPTION
## Motivation

C++20 is causing issues atm, revert to C++17

## Technical Details

Removed C++20 code, set compilation target to C++17. Usage of C++20 will error out.

## JIRA ID

AIROCSHMEM-326

## Test Plan

* envvar unit-tests passed
* compiled without errors with C++17
* CI run

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
