### PR TITLE
hip-tests: remove EXSWCPHIPT-127 AMD skips from memcpy/memset tests

### DIFF
--- a/projects/hip-tests/catch/unit/memory/hipMemcpyAsync_derivatives.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemcpyAsync_derivatives.cc
@@ -64,14 +64,6 @@ HIP_TEST_CASE(Unit_hipMemcpyHtoDAsync_Positive_Basic) {
 }
 
 HIP_TEST_CASE(Unit_hipMemcpyHtoDAsync_Positive_Synchronization_Behavior) {
-  // This behavior differs on NVIDIA and AMD, on AMD the hipMemcpy calls is synchronous with
-  // respect to the host
-#if HT_AMD
-  HipTest::HIP_SKIP_TEST(
-      "EXSWCPHIPT-127 - MemcpyAsync from host to device memory behavior differs on AMD and "
-      "Nvidia");
-  return;
-#endif
   MemcpyHPinnedtoDSyncBehavior(
       [](void* dst, void* src, size_t count) {
         return hipMemcpyHtoDAsync(reinterpret_cast<hipDeviceptr_t>(dst), src, count, nullptr);

--- a/projects/hip-tests/catch/unit/memory/hipMemcpySync.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemcpySync.cc
@@ -162,10 +162,6 @@ static void runMemcpyTests(hipStream_t stream, bool async, allocType type, memTy
 #if HT_AMD /* Disabled because frequency based wait is timing out on nvidia platforms */
 
 HIP_TEST_CASE(Unit_hipMemcpySync) {
-#if HT_AMD  // To be removed when EXSWCPHIPT-127 is fixed
-  HipTest::HIP_SKIP_TEST("EXSWCPHIPT-127 - Sync behaviour differs on AMD and Nvidia");
-  return;
-#endif
   allocType type = GENERATE(allocType::deviceMalloc, allocType::hostMalloc, allocType::hostRegisted,
                             allocType::devRegistered);
   memType memcpy_type = memType::hipMem;
@@ -176,10 +172,6 @@ HIP_TEST_CASE(Unit_hipMemcpySync) {
 }
 
 HIP_TEST_CASE(Unit_hipMemcpy2DSync) {
-#if HT_AMD
-  HipTest::HIP_SKIP_TEST("EXSWCPHIPT-127 - Sync behaviour differs on AMD and Nvidia");
-  return;
-#endif
   allocType mallocType = GENERATE(allocType::deviceMalloc, allocType::hostMalloc,
                                   allocType::hostRegisted, allocType::devRegistered);
 
@@ -192,10 +184,6 @@ HIP_TEST_CASE(Unit_hipMemcpy2DSync) {
 }
 
 HIP_TEST_CASE(Unit_hipMemcpy3DSync) {
-#if HT_AMD
-  HipTest::HIP_SKIP_TEST("EXSWCPHIPT-127 - Sync behaviour differs on AMD and Nvidia");
-  return;
-#endif
   allocType mallocType = GENERATE(allocType::deviceMalloc, allocType::hostMalloc,
                                   allocType::hostRegisted, allocType::devRegistered);
 

--- a/projects/hip-tests/catch/unit/memory/hipMemcpyWithStream.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemcpyWithStream.cc
@@ -36,13 +36,6 @@ HIP_TEST_CASE(Unit_hipMemcpy_Positive_Synchronization_Behavior) {
 
   // For transfers from device memory to device memory, no host-side synchronization is performed.
   SECTION("Device memory to device memory") {
-    // This behavior differs on NVIDIA and AMD, on AMD the hipMemcpy calls is synchronous with
-    // respect to the host
-#if HT_AMD
-    HipTest::HIP_SKIP_TEST(
-        "EXSWCPHIPT-127 - Memcpy from device to device memory behavior differs on AMD and Nvidia");
-    return;
-#endif
     MemcpyDtoDSyncBehavior(std::bind(hipMemcpy, _1, _2, _3, hipMemcpyDeviceToDevice), false);
   }
 

--- a/projects/hip-tests/catch/unit/memory/hipMemcpy_derivatives.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemcpy_derivatives.cc
@@ -75,13 +75,6 @@ HIP_TEST_CASE(Unit_hipMemcpyDtoD_Positive_Basic) {
 }
 
 HIP_TEST_CASE(Unit_hipMemcpyDtoD_Positive_Synchronization_Behavior) {
-  // This behavior differs on NVIDIA and AMD, on AMD the hipMemcpy calls is synchronous with
-  // respect to the host
-#if HT_AMD
-  HipTest::HIP_SKIP_TEST(
-      "EXSWCPHIPT-127 - Memcpy from device to device memory behavior differs on AMD and Nvidia");
-  return;
-#endif
   MemcpyDtoDSyncBehavior(
       [](void* dst, void* src, size_t count) {
         return hipMemcpyDtoD(reinterpret_cast<hipDeviceptr_t>(dst),

--- a/projects/hip-tests/catch/unit/memory/hipMemsetAsync.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemsetAsync.cc
@@ -103,10 +103,6 @@ HIP_TEMPLATE_TEST_CASE(Unit_hipMemsetDASyncMulti, int8_t, int16_t, uint32_t) {
  * test 2 async hipMemset2D's on the same memory at different offsets
  */
 HIP_TEST_CASE(Unit_hipMemset2DASyncMulti) {
-#if HT_AMD
-  HipTest::HIP_SKIP_TEST("EXSWCPHIPT-127");
-  return;
-#endif
   allocType mallocType = GENERATE(allocType::deviceMalloc, allocType::hostMalloc,
                                   allocType::hostRegisted, allocType::devRegistered);
   memType memset_type = memType::hipMem2D;
@@ -125,10 +121,6 @@ HIP_TEST_CASE(Unit_hipMemset2DASyncMulti) {
  * test 2 async hipMemset3D's on the same memory at different offsets
  */
 HIP_TEST_CASE(Unit_hipMemset3DASyncMulti) {
-#if HT_AMD
-  HipTest::HIP_SKIP_TEST("EXSWCPHIPT-127");
-  return;
-#endif
   allocType mallocType = GENERATE(allocType::deviceMalloc, allocType::hostMalloc,
                                   allocType::hostRegisted, allocType::devRegistered);
   memType memset_type = memType::hipMem3D;


### PR DESCRIPTION
Re-enable synchronization and multi-memset tests on AMD now that behavior is aligned.

Made-with: Cursor

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
