### PR TITLE
[rocr-runtime]Remove metadata validation due to spurious IPC errors with vLLM

### DIFF
--- a/projects/rocr-runtime/libhsakmt/src/memory.c
+++ b/projects/rocr-runtime/libhsakmt/src/memory.c
@@ -975,11 +975,13 @@ HSAKMT_STATUS HSAKMTAPI hsaKmtHandleImport(const HsaExternalHandleDesc* import_d
     			buf_info.size_metadata = sizeof(HSAuint32);
     			buf_info.umd_metadata[0] = (uint32_t)import_desc->metadata;
     			amdgpu_bo_set_metadata(res.buf_handle, &buf_info);
+				import_res->metadata = import_desc->metadata;
 			}
-		} else if (import_desc->metadata != metadata) {
-			import_res->metadata = (HSAuint32)metadata;
-			return HSAKMT_STATUS_INVALID_PARAMETER;
 		}
+		// For client-side imports (UpdateMetadata==0), skip metadata validation entirely.
+		// Metadata is not reliably shared across dmabuf imports in different processes,
+		// so validation causes false failures. Return whatever metadata we find.
+		import_res->metadata = (HSAuint32)metadata;
 	}
 
 	import_res->buf_handle = (HsaMemoryObjectHandle)res.buf_handle;


### PR DESCRIPTION
## Motivation

Running rocprofiler-sdk with vLLM workloads results in spurious IPC errors and crashes. This change removes the metadata check causing these errors.

## Technical Details

A metadata validation check was added as part of this change (https://github.com/ROCm/rocm-systems/commit/324a864bc44267d167659b800e0305fa7ee06252). This PR removes this check to allow vLLM workloads to succeed when being profiled by the rocprofiler-sdk. I am not familiar with the code-base, so please feel free to rework this change in any way you see fit.

## JIRA ID

Resolves AILIROCR-184: [Migrated from SWDEV-578190][Alibaba][Mi308] rocprofv3 trace function did not work well and met coredump

## Test Plan

Run `rocprofv3 --output-format pftrace -r -- vllm bench throughput --model  /model/Qwen3-4B --num-prompts=100 --input-len 2000 --output-len 500 --tensor-parallel-size 2 --dtype float16 --distributed-executor-backend mp` and have run succeed.

## Test Result

After this change, the `rocprofv3` command listed above succeeded.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
