### PR TITLE
[rocSHMEM] fix rocshmem warnings when compiling with -Wall -Wextra

### DIFF
--- a/projects/rocshmem/examples/LL_MoE/LL_MoE.hpp
+++ b/projects/rocshmem/examples/LL_MoE/LL_MoE.hpp
@@ -154,8 +154,6 @@ class LLMoE {
   }
 
   void ll_dispatch() {
-    [[maybe_unused]] int num_local_experts {num_experts / num_ranks};
-
     // Buffer control
     LLMoEBufferLayout<T> ll_layout(rdma_buffer_ptr, num_tokens,
                        hidden, num_ranks, num_experts);
@@ -178,6 +176,7 @@ class LLMoE {
     CHECK_HIP(hipStreamSynchronize(stream));
 
     //--- DEBUG FUNCTIONS ---
+    // int num_local_experts {num_experts / num_ranks};
     // Print rdma_x (buffer.dispatch_send_buffer) for debugging
     // print_rdma_x(buffer.dispatch_send_buffer);
 
@@ -196,7 +195,6 @@ class LLMoE {
   }
 
   void ll_combine() { // hipStream_t stream : TODO: pass stream
-    [[maybe_unused]] int num_local_experts {num_experts / num_ranks};
 
     // Buffer control
     LLMoEBufferLayout<T> ll_layout(rdma_buffer_ptr, num_tokens,

--- a/projects/rocshmem/examples/LL_MoE/LL_MoE.hpp
+++ b/projects/rocshmem/examples/LL_MoE/LL_MoE.hpp
@@ -76,8 +76,9 @@ class LLMoE {
   LLMoE(int num_tokens_, int hidden_, int num_topk_, int num_experts_,
     InitMode init_mode_ = InitMode::Deterministic)
       : num_tokens(num_tokens_), hidden(hidden_), num_topk(num_topk_),
-        num_experts(num_experts_), init_mode(init_mode_),
-        ll_moe_data(num_tokens_, hidden_, num_topk_, num_experts_,init_mode_) {
+        num_experts(num_experts_),
+        ll_moe_data(num_tokens_, hidden_, num_topk_, num_experts_,init_mode_),
+        init_mode(init_mode_) {
 
     // Initialize rocSHMEM
     comm_init();
@@ -153,7 +154,7 @@ class LLMoE {
   }
 
   void ll_dispatch() {
-    int num_local_experts {num_experts / num_ranks};
+    [[maybe_unused]] int num_local_experts {num_experts / num_ranks};
 
     // Buffer control
     LLMoEBufferLayout<T> ll_layout(rdma_buffer_ptr, num_tokens,
@@ -195,7 +196,7 @@ class LLMoE {
   }
 
   void ll_combine() { // hipStream_t stream : TODO: pass stream
-    int num_local_experts {num_experts / num_ranks};
+    [[maybe_unused]] int num_local_experts {num_experts / num_ranks};
 
     // Buffer control
     LLMoEBufferLayout<T> ll_layout(rdma_buffer_ptr, num_tokens,

--- a/projects/rocshmem/examples/LL_MoE/LL_MoE_Buffers.hpp
+++ b/projects/rocshmem/examples/LL_MoE/LL_MoE_Buffers.hpp
@@ -100,8 +100,8 @@ struct LLMoEBufferLayout {
 
   LLMoEBufferLayout(void* rdma_buffer, const int num_tokens, const int hidden,
       const int num_ranks, const int num_experts) {
-    
-    const int num_local_experts = num_experts / num_ranks;
+
+    [[maybe_unused]] const int num_local_experts = num_experts / num_ranks;
 
     // Message sizes
     size_t num_bytes_per_dispatch_msg = sizeof(int) + hidden * sizeof(T);

--- a/projects/rocshmem/examples/LL_MoE/LL_MoE_Buffers.hpp
+++ b/projects/rocshmem/examples/LL_MoE/LL_MoE_Buffers.hpp
@@ -101,8 +101,6 @@ struct LLMoEBufferLayout {
   LLMoEBufferLayout(void* rdma_buffer, const int num_tokens, const int hidden,
       const int num_ranks, const int num_experts) {
 
-    [[maybe_unused]] const int num_local_experts = num_experts / num_ranks;
-
     // Message sizes
     size_t num_bytes_per_dispatch_msg = sizeof(int) + hidden * sizeof(T);
     size_t num_bytes_per_combine_msg  = sizeof(int) + hidden * sizeof(T);

--- a/projects/rocshmem/examples/LL_MoE/LL_MoE_Buffers.hpp
+++ b/projects/rocshmem/examples/LL_MoE/LL_MoE_Buffers.hpp
@@ -99,7 +99,7 @@ struct LLMoEBufferLayout {
   }
 
   LLMoEBufferLayout(void* rdma_buffer, const int num_tokens, const int hidden,
-      const int num_ranks, const int num_experts) {
+      [[maybe_unused]] const int num_ranks, const int num_experts) {
 
     // Message sizes
     size_t num_bytes_per_dispatch_msg = sizeof(int) + hidden * sizeof(T);

--- a/projects/rocshmem/examples/LL_MoE/LL_MoE_Data.hpp
+++ b/projects/rocshmem/examples/LL_MoE/LL_MoE_Data.hpp
@@ -58,7 +58,7 @@ class LLMoEData {
     int num_experts_, InitMode init_mode_ = InitMode::Deterministic)
       : num_tokens(num_tokens_), hidden(hidden_),
         num_topk(num_topk_), num_experts(num_experts_),
-        init_mode(init_mode_), expert_token_count(num_experts, 0) {}
+        expert_token_count(num_experts, 0), init_mode(init_mode_) {}
 
   ~LLMoEData() {
     if (X) {
@@ -78,7 +78,7 @@ class LLMoEData {
     CHECK_HIP(hipMalloc(&X, x_size_bytes));
     CHECK_HIP(hipMalloc(&topk_idx, topk_idx_size_bytes));
 
-    size_t x_size = num_tokens * hidden;
+    [[maybe_unused]] size_t x_size = num_tokens * hidden;
 
     // Launch kernel to fill input data (X)
     int threads_per_block = 1024;

--- a/projects/rocshmem/examples/LL_MoE/LL_MoE_Data.hpp
+++ b/projects/rocshmem/examples/LL_MoE/LL_MoE_Data.hpp
@@ -179,9 +179,9 @@ class LLMoEData {
       expert_indices[j] = j;
     }
 
-    for (size_t i = 0; i < num_tokens; i++) {
+    for (size_t i = 0; i < static_cast<size_t>(num_tokens); i++) {
       std::shuffle(expert_indices.begin(), expert_indices.end(), gen);
-      for (int k = 0; k < num_topk; k++) {
+      for (size_t k = 0; k < static_cast<size_t>(num_topk); k++) {
         h_topk_idx[i * num_topk + k] = expert_indices[k];
         expert_token_count[expert_indices[k]]++;
       }
@@ -195,8 +195,8 @@ class LLMoEData {
   void generate_topk_deterministic() {
     size_t topk_idx_size = num_tokens * num_topk;
     std::vector<int64_t> h_topk_idx(topk_idx_size);
-    for (size_t i = 0; i < num_tokens; i++) {
-      for (int k = 0; k < num_topk; k++) {
+    for (size_t i = 0; i < static_cast<size_t>(num_tokens); i++) {
+      for (size_t k = 0; k < static_cast<size_t>(num_topk); k++) {
         h_topk_idx[i * num_topk + k] = (i * num_topk + k) % num_experts;
         expert_token_count[h_topk_idx[i * num_topk + k]]++;
       }

--- a/projects/rocshmem/examples/LL_MoE/LL_MoE_Data.hpp
+++ b/projects/rocshmem/examples/LL_MoE/LL_MoE_Data.hpp
@@ -78,8 +78,6 @@ class LLMoEData {
     CHECK_HIP(hipMalloc(&X, x_size_bytes));
     CHECK_HIP(hipMalloc(&topk_idx, topk_idx_size_bytes));
 
-    [[maybe_unused]] size_t x_size = num_tokens * hidden;
-
     // Launch kernel to fill input data (X)
     int threads_per_block = 1024;
     int blocks_per_grid = num_tokens; // one block per token
@@ -131,7 +129,7 @@ class LLMoEData {
               topk_idx_size * sizeof(int64_t), hipMemcpyDeviceToHost));
 
     std::cout << "Input Data (X):" << std::endl;
-    for (size_t i = 0; i < num_tokens; i++) {
+    for (int i = 0; i < num_tokens; i++) {
       std::cout << "Token " << i << ": ";
       for (int j = 0; j < hidden; j++) {
         std::cout << h_X[i * hidden + j] << " ";
@@ -140,7 +138,7 @@ class LLMoEData {
     }
 
     std::cout << "Top-k Indices:" << std::endl;
-    for (size_t i = 0; i < num_tokens; i++) {
+    for (int i = 0; i < num_tokens; i++) {
       std::cout << "Token " << i << ": ";
       for (int k = 0; k < num_topk; k++) {
         std::cout << h_topk_idx[i * num_topk + k] << " ";
@@ -179,7 +177,7 @@ class LLMoEData {
       expert_indices[j] = j;
     }
 
-    for (size_t i = 0; i < static_cast<size_t>(num_tokens); i++) {
+    for (int i = 0; i < num_tokens; i++) {
       std::shuffle(expert_indices.begin(), expert_indices.end(), gen);
       for (size_t k = 0; k < static_cast<size_t>(num_topk); k++) {
         h_topk_idx[i * num_topk + k] = expert_indices[k];
@@ -195,8 +193,8 @@ class LLMoEData {
   void generate_topk_deterministic() {
     size_t topk_idx_size = num_tokens * num_topk;
     std::vector<int64_t> h_topk_idx(topk_idx_size);
-    for (size_t i = 0; i < static_cast<size_t>(num_tokens); i++) {
-      for (size_t k = 0; k < static_cast<size_t>(num_topk); k++) {
+    for (int i = 0; i < num_tokens; i++) {
+      for (int k = 0; k < num_topk; k++) {
         h_topk_idx[i * num_topk + k] = (i * num_topk + k) % num_experts;
         expert_token_count[h_topk_idx[i * num_topk + k]]++;
       }

--- a/projects/rocshmem/examples/LL_MoE/LL_MoE_Kernels.hpp
+++ b/projects/rocshmem/examples/LL_MoE/LL_MoE_Kernels.hpp
@@ -128,7 +128,6 @@ void dispatch_kernel(void *packed_recv_x, int *packed_recv_src_info,
   const size_t num_bytes_per_msg = sizeof(int) + hidden_bytes;
 
   DEVICE_ASSERT(num_bytes_per_msg % sizeof(int) == 0);
-  [[maybe_unused]] const size_t num_int_per_msg = num_bytes_per_msg / sizeof(int);
   
   // Expert counts
   __shared__ int shared_num_tokens_sent_per_expert[kNumWaveGroups];
@@ -458,7 +457,6 @@ void combine_kernel(T* combined_x, void* rdma_recv_x, int64_t* rdma_recv_flag,
   const int num_wgs = static_cast<int>(gridDim.x);
   const int num_threads = static_cast<int>(blockDim.x);
   const int lane_id = thread_id % kWaveSize;
-  [[maybe_unused]] constexpr int num_waves = kNumWavesPerGroup * kNumWaveGroups;
   const int num_local_experts = num_experts / num_ranks;
   const int wave_group_id = wave_id / kNumWavesPerGroup;
   const int sub_wave_id = wave_id % kNumWavesPerGroup;
@@ -545,8 +543,7 @@ void combine_kernel(T* combined_x, void* rdma_recv_x, int64_t* rdma_recv_flag,
 
     // Synchronize sub-warps in the warp group
     if (lane_id == 0) {
-      [[maybe_unused]] volatile int ret = __hip_atomic_fetch_add(
-          &sync_large_warp_counters[wave_group_id], 1,
+      __hip_atomic_fetch_add(&sync_large_warp_counters[wave_group_id], 1,
           __ATOMIC_RELEASE, __HIP_MEMORY_SCOPE_AGENT);
       warp_sync();
       while (sync_large_warp_counters[wave_group_id] < kNumWavesPerGroup);

--- a/projects/rocshmem/examples/LL_MoE/LL_MoE_Kernels.hpp
+++ b/projects/rocshmem/examples/LL_MoE/LL_MoE_Kernels.hpp
@@ -128,7 +128,7 @@ void dispatch_kernel(void *packed_recv_x, int *packed_recv_src_info,
   const size_t num_bytes_per_msg = sizeof(int) + hidden_bytes;
 
   DEVICE_ASSERT(num_bytes_per_msg % sizeof(int) == 0);
-  const size_t num_int_per_msg = num_bytes_per_msg / sizeof(int);
+  [[maybe_unused]] const size_t num_int_per_msg = num_bytes_per_msg / sizeof(int);
   
   // Expert counts
   __shared__ int shared_num_tokens_sent_per_expert[kNumWaveGroups];
@@ -458,7 +458,7 @@ void combine_kernel(T* combined_x, void* rdma_recv_x, int64_t* rdma_recv_flag,
   const int num_wgs = static_cast<int>(gridDim.x);
   const int num_threads = static_cast<int>(blockDim.x);
   const int lane_id = thread_id % kWaveSize;
-  constexpr int num_waves = kNumWavesPerGroup * kNumWaveGroups;
+  [[maybe_unused]] constexpr int num_waves = kNumWavesPerGroup * kNumWaveGroups;
   const int num_local_experts = num_experts / num_ranks;
   const int wave_group_id = wave_id / kNumWavesPerGroup;
   const int sub_wave_id = wave_id % kNumWavesPerGroup;
@@ -545,7 +545,7 @@ void combine_kernel(T* combined_x, void* rdma_recv_x, int64_t* rdma_recv_flag,
 
     // Synchronize sub-warps in the warp group
     if (lane_id == 0) {
-      volatile int ret = __hip_atomic_fetch_add(
+      [[maybe_unused]] volatile int ret = __hip_atomic_fetch_add(
           &sync_large_warp_counters[wave_group_id], 1,
           __ATOMIC_RELEASE, __HIP_MEMORY_SCOPE_AGENT);
       warp_sync();

--- a/projects/rocshmem/examples/rocshmem_allreduce_test.cc
+++ b/projects/rocshmem/examples/rocshmem_allreduce_test.cc
@@ -66,7 +66,6 @@ __global__ void allreduce_test(int *source, int *dest, size_t nelem,
     int64_t ctx_type = 0;
 
     rocshmem_wg_ctx_create(ctx_type, &ctx);
-    [[maybe_unused]] int num_pes = rocshmem_ctx_n_pes(ctx);
 
     rocshmem_ctx_int_sum_reduce_wg(ctx, team, dest, source, nelem);
 

--- a/projects/rocshmem/examples/rocshmem_allreduce_test.cc
+++ b/projects/rocshmem/examples/rocshmem_allreduce_test.cc
@@ -66,7 +66,7 @@ __global__ void allreduce_test(int *source, int *dest, size_t nelem,
     int64_t ctx_type = 0;
 
     rocshmem_wg_ctx_create(ctx_type, &ctx);
-    int num_pes = rocshmem_ctx_n_pes(ctx);
+    [[maybe_unused]] int num_pes = rocshmem_ctx_n_pes(ctx);
 
     rocshmem_ctx_int_sum_reduce_wg(ctx, team, dest, source, nelem);
 

--- a/projects/rocshmem/examples/rocshmem_allreduce_test.cc
+++ b/projects/rocshmem/examples/rocshmem_allreduce_test.cc
@@ -83,7 +83,7 @@ static void init_sendbuf (int *source, int nelem, int my_pe)
     }
 }
 
-static bool check_recvbuf(int *dest, int nelem, int my_pe, int npes)
+static bool check_recvbuf(int *dest, int nelem, [[maybe_unused]] int my_pe, int npes)
 {
     bool res=true;
     int expected = npes * (npes -1) / 2;

--- a/projects/rocshmem/examples/rocshmem_alltoall_test.cc
+++ b/projects/rocshmem/examples/rocshmem_alltoall_test.cc
@@ -66,7 +66,7 @@ __global__ void alltoall_test(int *source, int *dest, size_t nelem,
     int64_t ctx_type = 0;
 
     rocshmem_wg_ctx_create(ctx_type, &ctx);
-    int num_pes = rocshmem_ctx_n_pes(ctx);
+    [[maybe_unused]] int num_pes = rocshmem_ctx_n_pes(ctx);
 
     rocshmem_ctx_int_alltoall_wg(ctx, team, dest, source, nelem);
 

--- a/projects/rocshmem/examples/rocshmem_alltoall_test.cc
+++ b/projects/rocshmem/examples/rocshmem_alltoall_test.cc
@@ -66,7 +66,6 @@ __global__ void alltoall_test(int *source, int *dest, size_t nelem,
     int64_t ctx_type = 0;
 
     rocshmem_wg_ctx_create(ctx_type, &ctx);
-    [[maybe_unused]] int num_pes = rocshmem_ctx_n_pes(ctx);
 
     rocshmem_ctx_int_alltoall_wg(ctx, team, dest, source, nelem);
 

--- a/projects/rocshmem/examples/rocshmem_broadcast_test.cc
+++ b/projects/rocshmem/examples/rocshmem_broadcast_test.cc
@@ -76,14 +76,14 @@ __global__ void broadcast_test(int *source, int *dest, size_t nelem,
     rocshmem_wg_ctx_destroy(&ctx);
 }
 
-static void init_sendbuf(int *source, int nelem, int my_pe)
+static void init_sendbuf(int *source, int nelem, [[maybe_unused]] int my_pe)
 {
     for (int i = 0; i < nelem; i++) {
         source[i] = i;
     }
 }
 
-static bool check_recvbuf(int *dest, int nelem, int my_pe, int npes)
+static bool check_recvbuf(int *dest, [[maybe_unused]] int nelem, [[maybe_unused]] int my_pe, int npes)
 {
     bool res=true;
 

--- a/projects/rocshmem/examples/rocshmem_broadcast_test.cc
+++ b/projects/rocshmem/examples/rocshmem_broadcast_test.cc
@@ -66,7 +66,7 @@ __global__ void broadcast_test(int *source, int *dest, size_t nelem,
     int64_t ctx_type = 0;
 
     rocshmem_wg_ctx_create(ctx_type, &ctx);
-    int num_pes = rocshmem_ctx_n_pes(ctx);
+    [[maybe_unused]] int num_pes = rocshmem_ctx_n_pes(ctx);
 
     rocshmem_ctx_int_broadcast_wg(ctx, team, dest, source, nelem, root);
 

--- a/projects/rocshmem/examples/rocshmem_getmem_test.cc
+++ b/projects/rocshmem/examples/rocshmem_getmem_test.cc
@@ -88,8 +88,8 @@ int main (int argc, char **argv)
 
     rocshmem_init();
 
-    int my_pe = rocshmem_my_pe();
-    int npes =  rocshmem_n_pes();
+    [[maybe_unused]] int my_pe = rocshmem_my_pe();
+    [[maybe_unused]] int npes =  rocshmem_n_pes();
 
     int *src = (int *)rocshmem_malloc(nelem * sizeof(int));
     int *dst = (int *)rocshmem_malloc(nelem * sizeof(int));

--- a/projects/rocshmem/examples/util.h
+++ b/projects/rocshmem/examples/util.h
@@ -55,7 +55,7 @@
   }                                                                       \
 }
 
-static int get_launcher_local_rank() {
+[[maybe_unused]] static int get_launcher_local_rank() {
     char *local_rank_str = nullptr;
 
     local_rank_str = getenv("OMPI_COMM_WORLD_LOCAL_RANK");

--- a/projects/rocshmem/src/assembly.hpp
+++ b/projects/rocshmem/src/assembly.hpp
@@ -41,7 +41,7 @@ namespace rocshmem {
 #define SFENCE() asm volatile("sfence" ::: "memory")
 
 __device__ __forceinline__ int uncached_load_ubyte(uint8_t* src) {
-  int ret;
+  int ret = 0;
 #if defined(__gfx906__)
 #endif
 #if defined(__gfx908__)
@@ -136,7 +136,7 @@ __device__ __forceinline__ void refresh_volatile_dwordx2(volatile uint64_t *assi
 // clang-format off
 NOWARN(-Wdeprecated-volatile,
   template <typename T> __device__ __forceinline__ T uncached_load(T* src) {
-    T ret;
+    T ret{};
     switch (sizeof(T)) {
       case 4:
 #if defined(__gfx906__)
@@ -244,7 +244,7 @@ __device__ __forceinline__ void store_asm(uint8_t* val, uint8_t* dst,
       break;
     }
     case 4: {
-      int32_t val32{*(reinterpret_cast<int32_t*>(val))};
+      [[maybe_unused]] int32_t val32{*(reinterpret_cast<int32_t*>(val))};
 #if defined(__gfx906__)
 #endif
 #if defined(__gfx908__)
@@ -261,7 +261,7 @@ __device__ __forceinline__ void store_asm(uint8_t* val, uint8_t* dst,
       break;
     }
     case 8: {
-      int64_t val64{*(reinterpret_cast<int64_t*>(val))};
+      [[maybe_unused]] int64_t val64{*(reinterpret_cast<int64_t*>(val))};
 #if defined(__gfx906__)
 #endif
 #if defined(__gfx908__)

--- a/projects/rocshmem/src/assembly.hpp
+++ b/projects/rocshmem/src/assembly.hpp
@@ -40,7 +40,7 @@ namespace rocshmem {
 
 #define SFENCE() asm volatile("sfence" ::: "memory")
 
-__device__ __forceinline__ int uncached_load_ubyte(uint8_t* src) {
+__device__ __forceinline__ int uncached_load_ubyte([[maybe_unused]] uint8_t* src) {
   int ret = 0;
 #if defined(__gfx906__)
 #endif
@@ -70,8 +70,8 @@ __device__ __forceinline__ int uncached_load_ubyte(uint8_t* src) {
   return ret;
 }
 
-__device__ __forceinline__ void refresh_volatile_sbyte(volatile int *assigned_value,
-                                                       volatile char *read_value) {
+__device__ __forceinline__ void refresh_volatile_sbyte([[maybe_unused]] volatile int *assigned_value,
+                                                       [[maybe_unused]] volatile char *read_value) {
 #if defined(__gfx906__)
 #endif
 #if defined(__gfx908__)
@@ -99,8 +99,8 @@ __device__ __forceinline__ void refresh_volatile_sbyte(volatile int *assigned_va
 #endif
 }
 
-__device__ __forceinline__ void refresh_volatile_dwordx2(volatile uint64_t *assigned_value,
-                                                         volatile uint64_t *read_value) {
+__device__ __forceinline__ void refresh_volatile_dwordx2([[maybe_unused]] volatile uint64_t *assigned_value,
+                                                         [[maybe_unused]] volatile uint64_t *read_value) {
 #if defined(__gfx906__)
 #endif
 #if defined(__gfx908__)
@@ -135,7 +135,7 @@ __device__ __forceinline__ void refresh_volatile_dwordx2(volatile uint64_t *assi
  */
 // clang-format off
 NOWARN(-Wdeprecated-volatile,
-  template <typename T> __device__ __forceinline__ T uncached_load(T* src) {
+  template <typename T> __device__ __forceinline__ T uncached_load([[maybe_unused]] T* src) {
     T ret{};
     switch (sizeof(T)) {
       case 4:
@@ -217,7 +217,7 @@ __device__ __forceinline__ void __roc_flush() {
 #endif
 }
 
-__device__ __forceinline__ void store_asm(uint8_t* val, uint8_t* dst,
+__device__ __forceinline__ void store_asm(uint8_t* val, [[maybe_unused]] uint8_t* dst,
                                           int size) {
   switch (size) {
     case 2: {

--- a/projects/rocshmem/src/bootstrap/bootstrap.cpp
+++ b/projects/rocshmem/src/bootstrap/bootstrap.cpp
@@ -68,7 +68,7 @@ struct ExtInfo {
    int rank_pos = -1;
 
    // Confirm that rank is in the vectors of ranks
-   for (int i = 0; i < ranks.size(); i++) {
+   for (size_t i = 0; i < ranks.size(); i++) {
      if (rank == ranks[i]) {
        rank_pos = i;
        break;
@@ -104,7 +104,7 @@ struct ExtInfo {
    int rank_pos = -1;
 
    // Confirm that rank is in the vectors of ranks
-   for (int i = 0; i < ranks.size(); i++) {
+   for (size_t i = 0; i < ranks.size(); i++) {
      if (rank == ranks[i]) {
        rank_pos = i;
        break;

--- a/projects/rocshmem/src/containers/atomic_wf_queue_impl.hpp
+++ b/projects/rocshmem/src/containers/atomic_wf_queue_impl.hpp
@@ -51,7 +51,7 @@ __host__ void AtomicWFQueue<TYPE, ALLOCATOR>::deallocate_queue() {
 
 template <typename TYPE, typename ALLOCATOR>
 AtomicWFQueue<TYPE, ALLOCATOR>::AtomicWFQueue(const ALLOCATOR& allocator)
-    : allocator_{allocator}, size_{0}, curr_size_{0}, head_{0}, tail_{0} {}
+    : allocator_{allocator}, head_{0}, tail_{0}, size_{0}, curr_size_{0} {}
 
 template <typename TYPE, typename ALLOCATOR>
 __host__ void AtomicWFQueue<TYPE, ALLOCATOR>::allocate_queue(

--- a/projects/rocshmem/src/containers/index_strategy.hpp
+++ b/projects/rocshmem/src/containers/index_strategy.hpp
@@ -432,7 +432,7 @@ class Matrix_Private {
    *
    * @return
    */
-  __device__ size_t next(size_t current_index) {
+  __device__ size_t next([[maybe_unused]] size_t current_index) {
     assert(false);
     return 0;
   }
@@ -472,7 +472,7 @@ class Matrix_Block {
    *
    * @return
    */
-  __device__ size_t next(size_t current_index) {
+  __device__ size_t next([[maybe_unused]] size_t current_index) {
     assert(false);
     return 0;
   }
@@ -512,7 +512,7 @@ class Matrix_Device {
    *
    * @return
    */
-  __device__ size_t next(size_t current_index) {
+  __device__ size_t next([[maybe_unused]] size_t current_index) {
     assert(false);
     return 0;
   }

--- a/projects/rocshmem/src/containers/share_strategy.hpp
+++ b/projects/rocshmem/src/containers/share_strategy.hpp
@@ -41,7 +41,7 @@ class Global {
    * @return
    */
   template <typename T>
-  __host__ T fetch_incr([[maybe_unused]] T *out_ptr) {}
+  __host__ T fetch_incr([[maybe_unused]] T *out_ptr) {abort();}
 };
 
 class Grid {
@@ -54,7 +54,7 @@ class Grid {
    * @return
    */
   template <typename T>
-  __device__ T fetch_incr([[maybe_unused]] T *out_ptr) {}
+  __device__ T fetch_incr([[maybe_unused]] T *out_ptr) {abort();}
 };
 
 class Block {

--- a/projects/rocshmem/src/containers/share_strategy.hpp
+++ b/projects/rocshmem/src/containers/share_strategy.hpp
@@ -41,7 +41,7 @@ class Global {
    * @return
    */
   template <typename T>
-  __host__ T fetch_incr(T *out_ptr) {}
+  __host__ T fetch_incr([[maybe_unused]] T *out_ptr) {}
 };
 
 class Grid {
@@ -54,7 +54,7 @@ class Grid {
    * @return
    */
   template <typename T>
-  __device__ T fetch_incr(T *out_ptr) {}
+  __device__ T fetch_incr([[maybe_unused]] T *out_ptr) {}
 };
 
 class Block {

--- a/projects/rocshmem/src/gda/backend_gda.cpp
+++ b/projects/rocshmem/src/gda/backend_gda.cpp
@@ -1024,7 +1024,8 @@ void GDABackend::open_ib_device() {
 
   if (gda_provider == GDAProvider::MLX5) {
     /* Explicitly request DevX context */
-    struct mlx5dv_context_attr context_attr{ .flags = MLX5DV_CONTEXT_FLAGS_DEVX };
+    struct mlx5dv_context_attr context_attr = {};
+    context_attr.flags = MLX5DV_CONTEXT_FLAGS_DEVX;
     context = mlx5dv.open_device(device, &context_attr);
   } else {
     context = ibv.open_device(device);

--- a/projects/rocshmem/src/gda/backend_gda.cpp
+++ b/projects/rocshmem/src/gda/backend_gda.cpp
@@ -597,7 +597,7 @@ bool GDABackend::device_matches_provider_vendor(GDAProvider provider,
                                                  const struct ibv_device_attr &device_attr,
                                                  const char *device_name) {
   uint32_t expected_vendor_id = 0;
-  const char *vendor_name = nullptr;
+  [[maybe_unused]] const char *vendor_name = nullptr;
 
   switch (provider) {
     case GDAProvider::BNXT:
@@ -1434,7 +1434,6 @@ void GDABackend::create_qps(int sq_length) {
 
 void GDABackend::select_gid_index() {
   struct ibv_gid_entry *gid_entries;
-  struct ibv_gid_entry *gid_entry;
   union ibv_gid current_gid;
   union ibv_gid selected_gid;
   uint32_t current_gid_type;

--- a/projects/rocshmem/src/gda/backend_gda.cpp
+++ b/projects/rocshmem/src/gda/backend_gda.cpp
@@ -222,7 +222,7 @@ void GDABackend::cleanup_ctxs() {
   CHECK_HIP(hipFree(ctx_array));
 }
 
-__device__ bool GDABackend::create_ctx(int64_t options, rocshmem_ctx_t *ctx) {
+__device__ bool GDABackend::create_ctx([[maybe_unused]] int64_t options, rocshmem_ctx_t *ctx) {
   GDAContext *ctx_{nullptr};
 
   auto pop_result = ctx_free_list.get()->pop_front();
@@ -312,7 +312,7 @@ void GDABackend::Allreduce_char_BAND (char* inbuf, char *outbuf, size_t num_byte
   }
   backend_bootstr->groupAllGather(tmp_buffer, num_bytes, pes_in_world);
 
-  for (int i = 0; i < num_bytes; i++) {
+  for (size_t i = 0; i < num_bytes; i++) {
     outbuf[i] = tmp_buffer[i];
     for (int j = 1; j < num_pes; j++) {
       outbuf[i] &= tmp_buffer[j * num_bytes + i];
@@ -466,7 +466,7 @@ void GDABackend::setup_collectives() {
   /*
    * Initialize the barrier synchronization array with default values.
    */
-  for (int i = 0; i < ROCSHMEM_BARRIER_SYNC_SIZE; i++) {
+  for (size_t i = 0; i < ROCSHMEM_BARRIER_SYNC_SIZE; i++) {
     barrier_sync[i] = ROCSHMEM_SYNC_VALUE;
   }
 
@@ -595,7 +595,7 @@ GDAProvider GDABackend::requested_provider() {
  */
 bool GDABackend::device_matches_provider_vendor(GDAProvider provider,
                                                  const struct ibv_device_attr &device_attr,
-                                                 const char *device_name) {
+                                                 [[maybe_unused]] const char *device_name) {
   uint32_t expected_vendor_id = 0;
   [[maybe_unused]] const char *vendor_name = nullptr;
 
@@ -758,7 +758,7 @@ void GDABackend::cleanup_ibv() {
   int err;
 
   if (gda_provider == GDAProvider::BNXT) {
-    for (int i = 0; i < qps.size(); i++) {
+    for (size_t i = 0; i < qps.size(); i++) {
       err = bnxt_re_dv.destroy_qp(qps[i]);
       CHECK_ZERO(err, "bnxt_re_dv_destroy_qp");
 
@@ -804,7 +804,7 @@ void GDABackend::cleanup_ibv() {
       CHECK_ZERO(err, "mlx5dv::destroy_qp");
     }
   } else {
-    for (int i = 0; i < qps.size(); i++) {
+    for (size_t i = 0; i < qps.size(); i++) {
       err = ibv.destroy_qp(qps[i]);
       CHECK_ZERO(err, "ibv_destroy_qp");
 
@@ -898,7 +898,7 @@ void GDABackend::close_dv_libs() {
 }
 
 void GDABackend::exchange_qp_dest_info() {
-  for (int i = 0; i < qps.size(); i++) {
+  for (size_t i = 0; i < qps.size(); i++) {
     dest_info[i].lid = portinfo.lid;
     if (gda_provider == GDAProvider::MLX5) {
       dest_info[i].qpn = mlx5_qps[i].qpn;
@@ -1115,7 +1115,7 @@ void GDABackend::modify_qps_reset_to_init() {
             | IBV_QP_PORT
             | IBV_QP_ACCESS_FLAGS;
 
-  for (int i =0; i < qps.size() ; i++) {
+  for (size_t i =0; i < qps.size() ; i++) {
     if (gda_provider == GDAProvider::BNXT) {
       err = bnxt_re_dv.modify_qp(qps[i], &attr, attr_mask, 0, 0);
     } else if (gda_provider == GDAProvider::MLX5) {
@@ -1160,7 +1160,7 @@ void GDABackend::modify_qps_init_to_rtr() {
             | IBV_QP_MAX_DEST_RD_ATOMIC
             | IBV_QP_MIN_RNR_TIMER;
 
-  for (int i = 0; i < qps.size(); i++) {
+  for (size_t i = 0; i < qps.size(); i++) {
     attr.rq_psn      = dest_info[i].psn;
     attr.dest_qp_num = dest_info[i].qpn;
 
@@ -1205,7 +1205,7 @@ void GDABackend::modify_qps_rtr_to_rts() {
             | IBV_QP_RETRY_CNT
             | IBV_QP_RNR_RETRY;
 
-  for (int i = 0; i < qps.size(); i++) {
+  for (size_t i = 0; i < qps.size(); i++) {
     attr.sq_psn = dest_info[i].psn;
 
     if (gda_provider == GDAProvider::BNXT) {
@@ -1289,11 +1289,11 @@ void GDABackend::alternate_qp_ports() {
 
     /* Re-Map each context */
     for (size_t i = 1; i < (envvar::max_num_contexts + 1); i += 2) {
-      for (size_t p = 0; p < num_pes; p += 2) {
+      for (size_t p = 0; p < static_cast<size_t>(num_pes); p += 2) {
         cur_qp_idx = (i * num_pes) + p;
         new_qp_idx = cur_qp_idx + 1;
 
-        if (new_qp_idx < qps.size()) {
+        if (static_cast<size_t>(new_qp_idx) < qps.size()) {
           // Swap QPs
           std::swap(cqs[cur_qp_idx],       cqs[new_qp_idx]);
           std::swap(qps[cur_qp_idx],       qps[new_qp_idx]);
@@ -1307,21 +1307,21 @@ void GDABackend::alternate_qp_ports() {
   }
 }
 
-void* GDABackend::pd_alloc_device_uncached(struct ibv_pd* pd, void* pd_context, size_t size, size_t alignment, uint64_t resource_type) {
+void* GDABackend::pd_alloc_device_uncached([[maybe_unused]] struct ibv_pd* pd, [[maybe_unused]] void* pd_context, size_t size, [[maybe_unused]] size_t alignment, [[maybe_unused]] uint64_t resource_type) {
   void* dev_ptr{nullptr};
   CHECK_HIP(hipExtMallocWithFlags(reinterpret_cast<void**>(&dev_ptr), size, hipDeviceMallocUncached));
   memset(dev_ptr, 0, size);
   return dev_ptr;
 }
 
-void* GDABackend::pd_alloc_host(struct ibv_pd* pd, void* pd_context, size_t size, size_t alignment, uint64_t resource_type) {
+void* GDABackend::pd_alloc_host([[maybe_unused]] struct ibv_pd* pd, [[maybe_unused]] void* pd_context, size_t size, [[maybe_unused]] size_t alignment, [[maybe_unused]] uint64_t resource_type) {
   void* dev_ptr{nullptr};
   CHECK_HIP(hipHostMalloc(reinterpret_cast<void**>(&dev_ptr), size, hipHostMallocDefault));
   memset(dev_ptr, 0, size);
   return dev_ptr;
 }
 
-void GDABackend::pd_release(struct ibv_pd* pd, void* pd_context, void* ptr, uint64_t resource_type) {
+void GDABackend::pd_release([[maybe_unused]] struct ibv_pd* pd, [[maybe_unused]] void* pd_context, void* ptr, [[maybe_unused]] uint64_t resource_type) {
   CHECK_HIP(hipFree(ptr));
 }
 
@@ -1379,7 +1379,7 @@ void GDABackend::create_cqs(int cqe) {
     cq_attr.flags      |= IBV_CREATE_CQ_ATTR_IGNORE_OVERRUN;
   }
 
-  for (int i = 0; i < qps.size(); i++) {
+  for (size_t i = 0; i < qps.size(); i++) {
     cq_ex = ibv.create_cq_ex(context, &cq_attr);
     CHECK_NNULL(cq_ex, "ibv_create_cq_ex");
 
@@ -1420,7 +1420,7 @@ void GDABackend::create_qps(int sq_length) {
     attr.cap.max_recv_sge    = 1; // TODO allow zero sges in the driver
   }
 
-  for (int i = 0; i < qps.size(); i++) {
+  for (size_t i = 0; i < qps.size(); i++) {
     if (gda_provider == GDAProvider::IONIC) {
       attr.pd      = pd_uxdma[i & 1];
     }

--- a/projects/rocshmem/src/gda/backend_gda.cpp
+++ b/projects/rocshmem/src/gda/backend_gda.cpp
@@ -1310,7 +1310,8 @@ void GDABackend::alternate_qp_ports() {
 void* GDABackend::pd_alloc_device_uncached([[maybe_unused]] struct ibv_pd* pd, [[maybe_unused]] void* pd_context, size_t size, [[maybe_unused]] size_t alignment, [[maybe_unused]] uint64_t resource_type) {
   void* dev_ptr{nullptr};
   CHECK_HIP(hipExtMallocWithFlags(reinterpret_cast<void**>(&dev_ptr), size, hipDeviceMallocUncached));
-  memset(dev_ptr, 0, size);
+  CHECK_HIP(hipMemset(dev_ptr, 0, size));
+  CHECK_HIP(hipStreamSynchronize(0));
   return dev_ptr;
 }
 

--- a/projects/rocshmem/src/gda/bnxt/backend_gda_bnxt.cpp
+++ b/projects/rocshmem/src/gda/bnxt/backend_gda_bnxt.cpp
@@ -97,7 +97,7 @@ void GDABackend::bnxt_create_cqs(int cqe) {
   cqe = 1;
 
   /* Create SCQs */
-  for (int i = 0; i < qps.size(); i++) {
+  for (size_t i = 0; i < qps.size(); i++) {
     /* Allocate SCQ mem */
     memset(&cq_attr, 0, sizeof(struct bnxt_re_dv_cq_attr));
     bnxt_scqs[i].handle = bnxt_re_dv.cq_mem_alloc(context, cqe, &cq_attr);
@@ -140,7 +140,7 @@ void GDABackend::bnxt_create_cqs(int cqe) {
   }
 
   /* Create RCQs */
-  for (int i = 0; i < qps.size(); i++) {
+  for (size_t i = 0; i < qps.size(); i++) {
     /* Allocate RCQ mem */
     memset(&cq_attr, 0, sizeof(struct bnxt_re_dv_cq_attr));
     bnxt_rcqs[i].handle = bnxt_re_dv.cq_mem_alloc(context, cqe, &cq_attr);
@@ -193,7 +193,7 @@ void GDABackend::bnxt_create_qps(int sq_length) {
 
   int dmabuf_enabled = ibv.is_dmabuf_supported();
 
-  for (int i = 0; i < qps.size(); i++) {
+  for (size_t i = 0; i < qps.size(); i++) {
     /* IB QP Init Attr */
     memset(&ib_qp_attr, 0, sizeof(struct ibv_qp_init_attr));
     ib_qp_attr.send_cq             = bnxt_scqs[i].cq;

--- a/projects/rocshmem/src/gda/bnxt/queue_pair_bnxt.cpp
+++ b/projects/rocshmem/src/gda/bnxt/queue_pair_bnxt.cpp
@@ -225,7 +225,7 @@ __device__ void QueuePair::bnxt_write_rma_wqe(uintptr_t raddr, uintptr_t laddr, 
   uint32_t hdr_flags;
   uint32_t inline_msg;
 
-  inline_msg = length <= inline_threshold &&
+  inline_msg = static_cast<int32_t>(length) <= static_cast<int32_t>(inline_threshold) &&
                opcode == gda_op_rdma_write;
 
   bnxt_poll_cq_until(GDA_BNXT_WQE_SLOT_COUNT);
@@ -278,7 +278,7 @@ __device__ void QueuePair::bnxt_write_rma_wqe(uintptr_t raddr, uintptr_t laddr, 
   bnxt_re_incr_tail(&bnxt_sq, GDA_BNXT_WQE_SLOT_COUNT);
 }
 
-__device__ void QueuePair::bnxt_post_wqe_rma(int pe, int32_t length, uintptr_t laddr, uintptr_t raddr, uint8_t opcode) {
+__device__ void QueuePair::bnxt_post_wqe_rma([[maybe_unused]] int pe, int32_t length, uintptr_t laddr, uintptr_t raddr, uint8_t opcode) {
   uint64_t active_lane_mask;
   uint8_t active_lane_count;
   uint8_t active_lane_id;

--- a/projects/rocshmem/src/gda/bnxt/queue_pair_bnxt.cpp
+++ b/projects/rocshmem/src/gda/bnxt/queue_pair_bnxt.cpp
@@ -278,7 +278,7 @@ __device__ void QueuePair::bnxt_write_rma_wqe(uintptr_t raddr, uintptr_t laddr, 
   bnxt_re_incr_tail(&bnxt_sq, GDA_BNXT_WQE_SLOT_COUNT);
 }
 
-__device__ void QueuePair::bnxt_post_wqe_rma([[maybe_unused]] int pe, int32_t length, uintptr_t laddr, uintptr_t raddr, uint8_t opcode) {
+__device__ void QueuePair::bnxt_post_wqe_rma(int32_t length, uintptr_t laddr, uintptr_t raddr, uint8_t opcode) {
   uint64_t active_lane_mask;
   uint8_t active_lane_count;
   uint8_t active_lane_id;

--- a/projects/rocshmem/src/gda/context_gda_device.cpp
+++ b/projects/rocshmem/src/gda/context_gda_device.cpp
@@ -375,7 +375,7 @@ __device__ uint64_t GDAContext::signal_fetch_wg(const uint64_t *sig_addr) {
 }
 
 __device__ uint64_t GDAContext::signal_fetch_wave(const uint64_t *sig_addr) {
-  uint64_t value;
+  uint64_t value = 0;
   if (is_thread_zero_in_wave()) {
     uint64_t *dst = const_cast<uint64_t*>(sig_addr);
     value = amo_fetch_add<uint64_t>(static_cast<void*>(dst), 0, my_pe);

--- a/projects/rocshmem/src/gda/context_gda_device.cpp
+++ b/projects/rocshmem/src/gda/context_gda_device.cpp
@@ -128,7 +128,7 @@ __device__ void GDAContext::fence() { //TODO: optimize
   __threadfence_system();
 }
 
-__device__ void GDAContext::fence(int pe) {
+__device__ void GDAContext::fence([[maybe_unused]] int pe) {
   fence(); //TODO: optimize
 }
 

--- a/projects/rocshmem/src/gda/context_gda_tmpl_device.hpp
+++ b/projects/rocshmem/src/gda/context_gda_tmpl_device.hpp
@@ -697,9 +697,9 @@ __device__ void GDAContext::alltoallv_copy(rocshmem_team_t team,
 
 template <typename T>
 __device__ void GDAContext::alltoallv_get(rocshmem_team_t team,
-                                          T *dest, const size_t dest_nelems[],
+                                          T *dest, [[maybe_unused]] const size_t dest_nelems[],
                                           const size_t dest_displs[],
-                                          T *source, const size_t source_nelems[],
+                                          T *source, [[maybe_unused]] const size_t source_nelems[],
                                           const size_t source_displs[]) {
   GDATeam *team_obj = reinterpret_cast<GDATeam *>(team);
   int pe_size       = team_obj->num_pes;

--- a/projects/rocshmem/src/gda/context_gda_tmpl_device.hpp
+++ b/projects/rocshmem/src/gda/context_gda_tmpl_device.hpp
@@ -416,8 +416,6 @@ __device__ void GDAContext::internal_ring_allreduce(
     T *dst, const T *src, int nelems, GDATeam *team_obj,  // NOLINT(runtime/int)
     int n_seg, int seg_size, int chunk_size) {
 
-  [[maybe_unused]] int stride = team_obj->tinfo_wrt_world->stride;
-  [[maybe_unused]] int PE_start = team_obj->tinfo_wrt_world->pe_start;
   int PE_size = team_obj->tinfo_wrt_world->size;
   long *pSync = team_obj->reduce_pSync;
   T *pWrk = reinterpret_cast<T *>(team_obj->pWrk);
@@ -703,8 +701,6 @@ __device__ void GDAContext::alltoallv_get(rocshmem_team_t team,
                                           const size_t source_displs[]) {
   GDATeam *team_obj = reinterpret_cast<GDATeam *>(team);
   int pe_size       = team_obj->num_pes;
-  [[maybe_unused]] int pe_start = team_obj->tinfo_wrt_world->pe_start;
-  [[maybe_unused]] int stride = team_obj->tinfo_wrt_world->stride;
   long *pSync = team_obj->alltoall_pSync;
   int my_pe_in_team = team_obj->my_pe;
   uint64_t a2a_sn   = team_obj->alltoall_sequence_number;
@@ -809,9 +805,7 @@ __device__ void GDAContext::alltoall_linear_thread_puts(rocshmem_team_t team, T 
                                                         const T *src, int nelems) {
   GDATeam *team_obj = reinterpret_cast<GDATeam *>(team);
 
-  [[maybe_unused]] int pe_start = team_obj->tinfo_wrt_world->pe_start;
   int pe_size = team_obj->num_pes;
-  [[maybe_unused]] int stride = team_obj->tinfo_wrt_world->stride;
   long *pSync = team_obj->alltoall_pSync;
   int my_pe_in_team = team_obj->my_pe;
   uint64_t alltoall_pSync_offset = (team_obj->alltoall_sequence_number % 2) * pe_size;

--- a/projects/rocshmem/src/gda/context_gda_tmpl_device.hpp
+++ b/projects/rocshmem/src/gda/context_gda_tmpl_device.hpp
@@ -65,7 +65,7 @@ __device__ void GDAContext::put_nbi(T *dest, const T *source, size_t nelems, int
 
 template <typename T>
 __device__ T GDAContext::g(const T *source, int pe) {
-  T ret;
+  T ret{};
   int local_pe{-1};
   if (ipcImpl_.isIpcAvailable(my_pe, pe, &local_pe)) {
     const char *src_typed{reinterpret_cast<const char *>(source)};
@@ -416,8 +416,8 @@ __device__ void GDAContext::internal_ring_allreduce(
     T *dst, const T *src, int nelems, GDATeam *team_obj,  // NOLINT(runtime/int)
     int n_seg, int seg_size, int chunk_size) {
 
-  int stride = team_obj->tinfo_wrt_world->stride;
-  int PE_start = team_obj->tinfo_wrt_world->pe_start;
+  [[maybe_unused]] int stride = team_obj->tinfo_wrt_world->stride;
+  [[maybe_unused]] int PE_start = team_obj->tinfo_wrt_world->pe_start;
   int PE_size = team_obj->tinfo_wrt_world->size;
   long *pSync = team_obj->reduce_pSync;
   T *pWrk = reinterpret_cast<T *>(team_obj->pWrk);
@@ -703,8 +703,8 @@ __device__ void GDAContext::alltoallv_get(rocshmem_team_t team,
                                           const size_t source_displs[]) {
   GDATeam *team_obj = reinterpret_cast<GDATeam *>(team);
   int pe_size       = team_obj->num_pes;
-  int pe_start = team_obj->tinfo_wrt_world->pe_start;
-  int stride = team_obj->tinfo_wrt_world->stride;
+  [[maybe_unused]] int pe_start = team_obj->tinfo_wrt_world->pe_start;
+  [[maybe_unused]] int stride = team_obj->tinfo_wrt_world->stride;
   long *pSync = team_obj->alltoall_pSync;
   int my_pe_in_team = team_obj->my_pe;
   uint64_t a2a_sn   = team_obj->alltoall_sequence_number;
@@ -809,9 +809,9 @@ __device__ void GDAContext::alltoall_linear_thread_puts(rocshmem_team_t team, T 
                                                         const T *src, int nelems) {
   GDATeam *team_obj = reinterpret_cast<GDATeam *>(team);
 
-  int pe_start = team_obj->tinfo_wrt_world->pe_start;
+  [[maybe_unused]] int pe_start = team_obj->tinfo_wrt_world->pe_start;
   int pe_size = team_obj->num_pes;
-  int stride = team_obj->tinfo_wrt_world->stride;
+  [[maybe_unused]] int stride = team_obj->tinfo_wrt_world->stride;
   long *pSync = team_obj->alltoall_pSync;
   int my_pe_in_team = team_obj->my_pe;
   uint64_t alltoall_pSync_offset = (team_obj->alltoall_sequence_number % 2) * pe_size;

--- a/projects/rocshmem/src/gda/debug_gda.hpp
+++ b/projects/rocshmem/src/gda/debug_gda.hpp
@@ -33,7 +33,7 @@ static void dump_ibv_qp(struct ibv_qp *qp, int conn_num);
 static void dump_mlx5dv_qp(struct mlx5dv_qp *qp_dv, int conn_num);
 static void dump_mlx5dv_cq(struct mlx5dv_cq *cq_dv, int conn_num);
 
-[[maybe_unused]] static void dump_ibv_context(struct ibv_context* x) {
+[[maybe_unused]] static void dump_ibv_context([[maybe_unused]] struct ibv_context* x) {
   /*
    * struct ibv_context {
    *   struct ibv_device      *device;
@@ -57,7 +57,7 @@ static void dump_mlx5dv_cq(struct mlx5dv_cq *cq_dv, int conn_num);
          x->device, x->cmd_fd, x->async_fd, x->num_comp_vectors, x->abi_compat);
 };
 
-[[maybe_unused]] static void dump_ibv_device(struct ibv_device* x) {
+[[maybe_unused]] static void dump_ibv_device([[maybe_unused]] struct ibv_device* x) {
   /*
    * struct ibv_device {
    *   struct _ibv_device_ops  _ops;
@@ -82,7 +82,7 @@ static void dump_mlx5dv_cq(struct mlx5dv_cq *cq_dv, int conn_num);
          x->node_type, x->transport_type, x->name, x->dev_name, x->dev_path, x->ibdev_path);
 }
 
-[[maybe_unused]] static void dump_ibv_pd(struct ibv_pd* x) {
+[[maybe_unused]] static void dump_ibv_pd([[maybe_unused]] struct ibv_pd* x) {
   /*
    * struct ibv_pd {
    *   struct ibv_context     *context;
@@ -98,7 +98,7 @@ static void dump_mlx5dv_cq(struct mlx5dv_cq *cq_dv, int conn_num);
          x->context, x->handle);
 }
 
-[[maybe_unused]] static void dump_ibv_port_attr(struct ibv_port_attr* x) {
+[[maybe_unused]] static void dump_ibv_port_attr([[maybe_unused]] struct ibv_port_attr* x) {
   /*
    * struct ibv_port_attr {
    *   enum ibv_port_state     state;
@@ -157,7 +157,7 @@ static void dump_mlx5dv_cq(struct mlx5dv_cq *cq_dv, int conn_num);
          x->link_layer, x->flags, x->port_cap_flags2);
 }
 
-[[maybe_unused]] void dump_ibv_qp(struct ibv_qp *qp, int conn_num) {
+[[maybe_unused]] void dump_ibv_qp([[maybe_unused]] struct ibv_qp *qp, [[maybe_unused]] int conn_num) {
   /*
    * struct ibv_qp {
    *   struct ibv_context     *context;
@@ -191,7 +191,7 @@ static void dump_mlx5dv_cq(struct mlx5dv_cq *cq_dv, int conn_num);
   DPRINTF("=========== QP_DUMP_END CONNECTION#%d  ========\n", conn_num);
 }
 
-[[maybe_unused]] void dump_mlx5dv_qp(struct mlx5dv_qp *qp_dv, int conn_num) {
+[[maybe_unused]] void dump_mlx5dv_qp([[maybe_unused]] struct mlx5dv_qp *qp_dv, [[maybe_unused]] int conn_num) {
   DPRINTF("\n");
   DPRINTF("===============================================\n");
   DPRINTF("     INITIALIZED MLXDV_QP FOR CONNECTION#%d\n", conn_num);
@@ -216,7 +216,7 @@ static void dump_mlx5dv_cq(struct mlx5dv_cq *cq_dv, int conn_num);
   DPRINTF("================== QP_DUMP_END ================\n");
 }
 
-[[maybe_unused]] void dump_mlx5dv_cq(struct mlx5dv_cq *cq_dv, int conn_num) {
+[[maybe_unused]] void dump_mlx5dv_cq([[maybe_unused]] struct mlx5dv_cq *cq_dv, [[maybe_unused]] int conn_num) {
   DPRINTF("\n");
   DPRINTF("===============================================\n");
   DPRINTF("     INITIALIZED MLX5DV_CQ FOR CONNECTION#%d\n", conn_num);

--- a/projects/rocshmem/src/gda/gda_context_proxy.hpp
+++ b/projects/rocshmem/src/gda/gda_context_proxy.hpp
@@ -46,7 +46,7 @@ class GDADefaultContextProxy {
   explicit GDADefaultContextProxy(GDABackend* backend, TeamInfo *tinfo,
                                   int gda_provider,
                                   size_t num_elems = 1)
-  : constructed_{true}, proxy_{num_elems} {
+  : proxy_{num_elems}, constructed_{true} {
     auto ctx{proxy_.get()};
     new (ctx) GDAContext(reinterpret_cast<Backend*>(backend), 0, gda_provider);
     ctx->tinfo = tinfo;

--- a/projects/rocshmem/src/gda/ionic/backend_gda_ionic.cpp
+++ b/projects/rocshmem/src/gda/ionic/backend_gda_ionic.cpp
@@ -46,7 +46,7 @@ void GDABackend::ionic_create_cqs(int ncqes) {
     ionic_cq_attr.flags = IONIC_CQ_INIT_ATTR_CCQE;
   }
 
-  for (int i = 0; i < qps.size(); i++) {
+  for (size_t i = 0; i < qps.size(); i++) {
     struct ibv_cq_ex *cq_ex = nullptr;
 
     cq_attr.parent_domain = pd_uxdma[i & 1];

--- a/projects/rocshmem/src/gda/ionic/backend_gda_ionic.cpp
+++ b/projects/rocshmem/src/gda/ionic/backend_gda_ionic.cpp
@@ -82,7 +82,6 @@ void GDABackend::ionic_initialize_gpu_qp(QueuePair* gpu_qp, int conn_num) {
 
   uint64_t *gpu_db_ptr = &gpu_db_page_u64[dvctx.db_ptr - db_page_u64];
 
-  gpu_db_page = gpu_db_page;
   gpu_db_cq = &gpu_db_ptr[dvctx.cq_qtype];
   gpu_db_sq = &gpu_db_ptr[dvctx.sq_qtype];
 

--- a/projects/rocshmem/src/gda/ionic/queue_pair_ionic.cpp
+++ b/projects/rocshmem/src/gda/ionic/queue_pair_ionic.cpp
@@ -56,7 +56,7 @@ __device__ uint32_t QueuePair::reserve_sq_single(uint32_t num_wqes) {
   return my_sq_prod;
 }
 
-__device__ uint32_t QueuePair::commit_sq_single(uint32_t my_sq_prod, uint32_t my_sq_pos, uint32_t num_wqes) {
+__device__ uint32_t QueuePair::commit_sq_single(uint32_t my_sq_prod, [[maybe_unused]] uint32_t my_sq_pos, uint32_t num_wqes) {
   uint32_t dbprod = my_sq_prod + num_wqes;
 
   spin_lock_acquire_unique(&sq_lock);
@@ -72,7 +72,7 @@ __device__ uint32_t QueuePair::commit_sq_single(uint32_t my_sq_prod, uint32_t my
   return dbprod;
 }
 
-__device__ uint32_t QueuePair::commit_sq(uint64_t activemask, uint32_t my_sq_prod, uint32_t my_sq_pos, uint32_t num_wqes) {
+__device__ uint32_t QueuePair::commit_sq(uint64_t activemask, uint32_t my_sq_prod, [[maybe_unused]] uint32_t my_sq_pos, uint32_t num_wqes) {
   uint32_t dbprod = my_sq_prod + num_wqes;
 
   spin_lock_acquire_shared(&sq_lock, activemask);
@@ -258,7 +258,7 @@ __device__ void QueuePair::ionic_ring_doorbell(uint32_t pos) {
   uint32_t lane_id    = get_active_lane_num(activemask);
   uint32_t lane_count = get_active_lane_count(activemask);
 
-  for (int i = 0; i < lane_count; ++i) {
+  for (uint32_t i = 0; i < lane_count; ++i) {
     if (lane_id == i) {
       __threadfence();
       __atomic_store_n(sq_dbreg, sq_dbval | (sq_mask & pos), __ATOMIC_SEQ_CST);
@@ -282,7 +282,7 @@ __device__ void QueuePair::ionic_quiet_single() {
   ionic_quiet_internal_ccqe_single(sq_prod);
 }
 
-__device__ void QueuePair::ionic_post_wqe_rma(int pe, int32_t size, uintptr_t laddr, uintptr_t raddr, uint8_t opcode, Collectivity cy) {
+__device__ void QueuePair::ionic_post_wqe_rma([[maybe_unused]] int pe, int32_t size, uintptr_t laddr, uintptr_t raddr, uint8_t opcode, Collectivity cy) {
   uint64_t activemask = get_same_qp_lane_mask();
   uint32_t my_logical_lane_id = get_active_lane_num(activemask);
   uint32_t num_wqes = 1;
@@ -326,7 +326,7 @@ __device__ void QueuePair::ionic_post_wqe_rma(int pe, int32_t size, uintptr_t la
   wqe->common.length = byteswap<uint32_t>(size);
 
   if (size) {
-    if (opcode == IONIC_V2_OP_RDMA_WRITE && size <= inline_threshold) {
+    if (opcode == IONIC_V2_OP_RDMA_WRITE && static_cast<int32_t>(size) <= static_cast<int32_t>(inline_threshold)) {
       wqe_flags |= byteswap<uint16_t>(IONIC_V1_FLAG_INL);
       wqe->base.num_sge_key = 0;
       if (!laddr) {
@@ -347,7 +347,7 @@ __device__ void QueuePair::ionic_post_wqe_rma(int pe, int32_t size, uintptr_t la
   commit_sq(activemask, my_sq_prod, my_sq_pos, num_wqes);
 }
 
-__device__ void QueuePair::ionic_post_wqe_rma_single(int pe, int32_t size, uintptr_t laddr, uintptr_t raddr, uint8_t opcode, Collectivity cy) {
+__device__ void QueuePair::ionic_post_wqe_rma_single([[maybe_unused]] int pe, int32_t size, uintptr_t laddr, uintptr_t raddr, uint8_t opcode, [[maybe_unused]] Collectivity cy) {
   uint32_t num_wqes = 1;
   uint32_t my_sq_prod = reserve_sq_single(num_wqes);
   uint32_t my_sq_pos = my_sq_prod;
@@ -376,7 +376,7 @@ __device__ void QueuePair::ionic_post_wqe_rma_single(int pe, int32_t size, uintp
   wqe->common.length = byteswap<uint32_t>(size);
 
   if (size) {
-    if (opcode == IONIC_V2_OP_RDMA_WRITE && size <= inline_threshold) {
+    if (opcode == IONIC_V2_OP_RDMA_WRITE && static_cast<int32_t>(size) <= static_cast<int32_t>(inline_threshold)) {
       wqe_flags |= byteswap<uint16_t>(IONIC_V1_FLAG_INL);
       wqe->base.num_sge_key = 0;
       if (!laddr) {
@@ -397,7 +397,7 @@ __device__ void QueuePair::ionic_post_wqe_rma_single(int pe, int32_t size, uintp
   commit_sq_single(my_sq_prod, my_sq_pos, num_wqes);
 }
 
-__device__ uint64_t QueuePair::ionic_post_wqe_amo(int pe, int32_t size, uintptr_t raddr, uint8_t opcode,
+__device__ uint64_t QueuePair::ionic_post_wqe_amo([[maybe_unused]] int pe, [[maybe_unused]] int32_t size, uintptr_t raddr, uint8_t opcode,
                                                   int64_t atomic_data, int64_t atomic_cmp, bool fetching) {
   uint64_t activemask = get_same_qp_lane_mask();
   uint32_t num_wqes = get_active_lane_count(activemask);
@@ -467,7 +467,7 @@ __device__ uint64_t QueuePair::ionic_post_wqe_amo(int pe, int32_t size, uintptr_
   return ret;
 }
 
-__device__ uint64_t QueuePair::ionic_post_wqe_amo_single(int pe, int32_t size, uintptr_t raddr, uint8_t opcode,
+__device__ uint64_t QueuePair::ionic_post_wqe_amo_single([[maybe_unused]] int pe, [[maybe_unused]] int32_t size, uintptr_t raddr, uint8_t opcode,
                                                          int64_t atomic_data, int64_t atomic_cmp, bool fetching) {
   uint32_t num_wqes = 1;
   uint32_t my_sq_prod = reserve_sq_single(num_wqes);

--- a/projects/rocshmem/src/gda/ionic/queue_pair_ionic.cpp
+++ b/projects/rocshmem/src/gda/ionic/queue_pair_ionic.cpp
@@ -282,7 +282,7 @@ __device__ void QueuePair::ionic_quiet_single() {
   ionic_quiet_internal_ccqe_single(sq_prod);
 }
 
-__device__ void QueuePair::ionic_post_wqe_rma([[maybe_unused]] int pe, int32_t size, uintptr_t laddr, uintptr_t raddr, uint8_t opcode, Collectivity cy) {
+__device__ void QueuePair::ionic_post_wqe_rma(int32_t size, uintptr_t laddr, uintptr_t raddr, uint8_t opcode, Collectivity cy) {
   uint64_t activemask = get_same_qp_lane_mask();
   uint32_t my_logical_lane_id = get_active_lane_num(activemask);
   uint32_t num_wqes = 1;
@@ -347,7 +347,7 @@ __device__ void QueuePair::ionic_post_wqe_rma([[maybe_unused]] int pe, int32_t s
   commit_sq(activemask, my_sq_prod, my_sq_pos, num_wqes);
 }
 
-__device__ void QueuePair::ionic_post_wqe_rma_single([[maybe_unused]] int pe, int32_t size, uintptr_t laddr, uintptr_t raddr, uint8_t opcode, [[maybe_unused]] Collectivity cy) {
+__device__ void QueuePair::ionic_post_wqe_rma_single(int32_t size, uintptr_t laddr, uintptr_t raddr, uint8_t opcode, [[maybe_unused]] Collectivity cy) {
   uint32_t num_wqes = 1;
   uint32_t my_sq_prod = reserve_sq_single(num_wqes);
   uint32_t my_sq_pos = my_sq_prod;

--- a/projects/rocshmem/src/gda/mlx5/provider_gda_mlx5.cpp
+++ b/projects/rocshmem/src/gda/mlx5/provider_gda_mlx5.cpp
@@ -183,7 +183,7 @@ static inline mlx5dv_devx_umem* mlx5_umem_reg(const mlx5dv_funcs_t& mlx5dv,
   int dmabuf_fd = -1;
   uint64_t dmabuf_offset = std::numeric_limits<uint64_t>::max();
 
-  mlx5dv_devx_umem_in umem_in = {0};
+  mlx5dv_devx_umem_in umem_in = {};
 
   umem_in.addr = addr;
   umem_in.size = size;
@@ -217,7 +217,9 @@ static inline void mlx5_initialize_cq_buffer(mlx5_cqe64* cq, uint32_t cq_depth) 
 
 static inline uint32_t mlx5_pdn(const mlx5dv_funcs_t& mlx5dv, struct ibv_pd *pd) {
   mlx5dv_pd mlx5_pd;
-  mlx5dv_obj obj{ .pd = { .in = pd, .out = &mlx5_pd } };
+  mlx5dv_obj obj = {};
+  obj.pd.in = pd;
+  obj.pd.out = &mlx5_pd;
   int err = mlx5dv.init_obj(&obj, MLX5DV_OBJ_PD);
   CHECK_ZERO(err, "mlx5dv_init_obj (PD)");
   return mlx5_pd.pdn;
@@ -491,9 +493,9 @@ static int mlx5_create_qp(const mlx5dv_funcs_t& mlx5dv, mlx5_devx_qp& qp, struct
 static int mlx5_modify_qp_reset2init(const mlx5dv_funcs_t& mlx5dv, mlx5_devx_qp& qp,
                                      struct ibv_qp_attr* attr, int attr_mask) {
   // man 3 ibv_modify_qp
-  constexpr int required_attr_mask = IBV_QP_STATE | IBV_QP_PKEY_INDEX | IBV_QP_PORT |
+  [[maybe_unused]] constexpr int required_attr_mask = IBV_QP_STATE | IBV_QP_PKEY_INDEX | IBV_QP_PORT |
                                      IBV_QP_ACCESS_FLAGS;
-  constexpr unsigned int access_flags = IBV_ACCESS_LOCAL_WRITE | IBV_ACCESS_REMOTE_READ |
+  [[maybe_unused]] constexpr unsigned int access_flags = IBV_ACCESS_LOCAL_WRITE | IBV_ACCESS_REMOTE_READ |
                                         IBV_ACCESS_REMOTE_WRITE | IBV_ACCESS_REMOTE_ATOMIC;
   assert((attr_mask & required_attr_mask) == required_attr_mask && "missing required attr");
   assert((attr->qp_access_flags & access_flags) == access_flags && "missing access flags");
@@ -519,10 +521,10 @@ static int mlx5_modify_qp_reset2init(const mlx5dv_funcs_t& mlx5dv, mlx5_devx_qp&
   return mlx5dv.devx_obj_modify(qp.devx_qp_obj, in, sizeof(in), out, sizeof(out));
 }
 
-static int mlx5_modify_qp_init2rtr(const mlx5dv_funcs_t& mlx5dv, mlx5_devx_qp& qp,
-                                   struct ibv_qp_attr* attr, int attr_mask, uint32_t gid_type) {
+static int mlx5_modify_qp_init2rtr(const mlx5dv_funcs_t& mlx5dv, mlx5_devx_qp* qp,
+                                   struct ibv_qp_attr* attr, [[maybe_unused]] int attr_mask, uint32_t gid_type) {
   // man 3 ibv_modify_qp
-  constexpr int required_attr_mask = IBV_QP_STATE | IBV_QP_AV | IBV_QP_PATH_MTU | IBV_QP_DEST_QPN |
+  [[maybe_unused]] constexpr int required_attr_mask = IBV_QP_STATE | IBV_QP_AV | IBV_QP_PATH_MTU | IBV_QP_DEST_QPN |
                                      IBV_QP_RQ_PSN | IBV_QP_MAX_DEST_RD_ATOMIC |
                                      IBV_QP_MIN_RNR_TIMER;
   assert((attr_mask & required_attr_mask) == required_attr_mask && "missing required attr");
@@ -598,10 +600,10 @@ static int mlx5_modify_qp_init2rtr(const mlx5dv_funcs_t& mlx5dv, mlx5_devx_qp& q
   return mlx5dv.devx_obj_modify(qp.devx_qp_obj, in, sizeof(in), out, sizeof(out));
 }
 
-static int mlx5_modify_qp_rtr2rts(const mlx5dv_funcs_t& mlx5dv, mlx5_devx_qp& qp,
-                                  struct ibv_qp_attr* attr, int attr_mask) {
+static int mlx5_modify_qp_rtr2rts(const mlx5dv_funcs_t& mlx5dv, mlx5_devx_qp* qp,
+                                  struct ibv_qp_attr* attr, [[maybe_unused]] int attr_mask) {
   // man 3 ibv_modify_qp
-  constexpr int required_attr_mask = IBV_QP_STATE | IBV_QP_SQ_PSN | IBV_QP_MAX_QP_RD_ATOMIC |
+  [[maybe_unused]] constexpr int required_attr_mask = IBV_QP_STATE | IBV_QP_SQ_PSN | IBV_QP_MAX_QP_RD_ATOMIC |
                                      IBV_QP_RETRY_CNT | IBV_QP_RNR_RETRY | IBV_QP_TIMEOUT;
   assert((attr_mask & required_attr_mask) == required_attr_mask && "missing required attr");
   assert(attr->max_rd_atomic > 0 && "ibv_qp_attr::max_rd_atomic is 0");
@@ -626,7 +628,7 @@ static int mlx5_modify_qp_rtr2rts(const mlx5dv_funcs_t& mlx5dv, mlx5_devx_qp& qp
   return mlx5dv.devx_obj_modify(qp.devx_qp_obj, in, sizeof(in), out, sizeof(out));
 }
 
-void mlx5_devx_qp::dump(int conn_num) {
+void mlx5_devx_qp::dump([[maybe_unused]] int conn_num) {
   DPRINTF("\n");
   DPRINTF("===============================================\n");
   DPRINTF("     INITIALIZED MLX5_DEVX_QP FOR CONNECTION#%d\n", conn_num);

--- a/projects/rocshmem/src/gda/mlx5/provider_gda_mlx5.cpp
+++ b/projects/rocshmem/src/gda/mlx5/provider_gda_mlx5.cpp
@@ -491,7 +491,7 @@ static int mlx5_create_qp(const mlx5dv_funcs_t& mlx5dv, mlx5_devx_qp& qp, struct
 }
 
 static int mlx5_modify_qp_reset2init(const mlx5dv_funcs_t& mlx5dv, mlx5_devx_qp& qp,
-                                     struct ibv_qp_attr* attr, int attr_mask) {
+                                     struct ibv_qp_attr* attr, [[maybe_unused]] int attr_mask) {
   // man 3 ibv_modify_qp
   [[maybe_unused]] constexpr int required_attr_mask = IBV_QP_STATE | IBV_QP_PKEY_INDEX | IBV_QP_PORT |
                                      IBV_QP_ACCESS_FLAGS;
@@ -521,7 +521,7 @@ static int mlx5_modify_qp_reset2init(const mlx5dv_funcs_t& mlx5dv, mlx5_devx_qp&
   return mlx5dv.devx_obj_modify(qp.devx_qp_obj, in, sizeof(in), out, sizeof(out));
 }
 
-static int mlx5_modify_qp_init2rtr(const mlx5dv_funcs_t& mlx5dv, mlx5_devx_qp* qp,
+static int mlx5_modify_qp_init2rtr(const mlx5dv_funcs_t& mlx5dv, mlx5_devx_qp& qp,
                                    struct ibv_qp_attr* attr, [[maybe_unused]] int attr_mask, uint32_t gid_type) {
   // man 3 ibv_modify_qp
   [[maybe_unused]] constexpr int required_attr_mask = IBV_QP_STATE | IBV_QP_AV | IBV_QP_PATH_MTU | IBV_QP_DEST_QPN |
@@ -600,7 +600,7 @@ static int mlx5_modify_qp_init2rtr(const mlx5dv_funcs_t& mlx5dv, mlx5_devx_qp* q
   return mlx5dv.devx_obj_modify(qp.devx_qp_obj, in, sizeof(in), out, sizeof(out));
 }
 
-static int mlx5_modify_qp_rtr2rts(const mlx5dv_funcs_t& mlx5dv, mlx5_devx_qp* qp,
+static int mlx5_modify_qp_rtr2rts(const mlx5dv_funcs_t& mlx5dv, mlx5_devx_qp& qp,
                                   struct ibv_qp_attr* attr, [[maybe_unused]] int attr_mask) {
   // man 3 ibv_modify_qp
   [[maybe_unused]] constexpr int required_attr_mask = IBV_QP_STATE | IBV_QP_SQ_PSN | IBV_QP_MAX_QP_RD_ATOMIC |

--- a/projects/rocshmem/src/gda/mlx5/provider_gda_mlx5.hpp
+++ b/projects/rocshmem/src/gda/mlx5/provider_gda_mlx5.hpp
@@ -138,6 +138,8 @@ struct gda_mlx5_wqe_amo {
 } __attribute__((__packed__)) __attribute__((__aligned__(16)));
 
 // WQEs have a 16B control segment, 16B remote address segment, and one or two additional 16B segments
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wpacked-non-pod"
 struct gda_mlx5_wqe {
   gda_mlx5_wqe_ctrl  ctrl;
   gda_mlx5_wqe_raddr raddr;
@@ -202,6 +204,7 @@ public:
         laddr, lkey, byte_count,
         send_inline)} { }
 } __attribute__((__packed__)) __attribute__((__aligned__(64)));
+#pragma clang diagnostic pop
 static_assert(sizeof(gda_mlx5_wqe) == sizeof(gda_mlx5_wqe_segment[4]),
               "mlx5 WQEs have up to 4 segments");
 

--- a/projects/rocshmem/src/gda/mlx5/provider_gda_mlx5.hpp
+++ b/projects/rocshmem/src/gda/mlx5/provider_gda_mlx5.hpp
@@ -138,8 +138,6 @@ struct gda_mlx5_wqe_amo {
 } __attribute__((__packed__)) __attribute__((__aligned__(16)));
 
 // WQEs have a 16B control segment, 16B remote address segment, and one or two additional 16B segments
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wpacked-non-pod"
 struct gda_mlx5_wqe {
   gda_mlx5_wqe_ctrl  ctrl;
   gda_mlx5_wqe_raddr raddr;
@@ -203,8 +201,8 @@ public:
         raddr, rkey,
         laddr, lkey, byte_count,
         send_inline)} { }
-} __attribute__((__packed__)) __attribute__((__aligned__(64)));
-#pragma clang diagnostic pop
+} __attribute__((__aligned__(64)));
+
 static_assert(sizeof(gda_mlx5_wqe) == sizeof(gda_mlx5_wqe_segment[4]),
               "mlx5 WQEs have up to 4 segments");
 

--- a/projects/rocshmem/src/gda/mlx5/queue_pair_mlx5.cpp
+++ b/projects/rocshmem/src/gda/mlx5/queue_pair_mlx5.cpp
@@ -271,7 +271,7 @@ __device__ void QueuePair::mlx5_quiet_single() {
 }
 
 // can be called with all active lanes using any number of different QPs, don't assume anything
-__device__ void QueuePair::mlx5_post_wqe_rma([[maybe_unused]] int pe, int32_t length, uintptr_t laddr, uintptr_t raddr, uint8_t opcode) {
+__device__ void QueuePair::mlx5_post_wqe_rma(int32_t length, uintptr_t laddr, uintptr_t raddr, uint8_t opcode) {
   uint64_t qp_lane_mask;
   uint8_t qp_lane_count;
   uint8_t qp_lane_id;
@@ -317,7 +317,7 @@ __device__ void QueuePair::mlx5_post_wqe_rma([[maybe_unused]] int pe, int32_t le
 }
 
 // called with all active lanes using different QPs
-__device__ void QueuePair::mlx5_post_wqe_rma_single([[maybe_unused]] int pe, int32_t length, uintptr_t laddr,
+__device__ void QueuePair::mlx5_post_wqe_rma_single(int32_t length, uintptr_t laddr,
                                                     uintptr_t raddr, uint8_t opcode, bool ring_db) {
   // get SQ lock
   acquire_lock(&mlx5_sq.lock);

--- a/projects/rocshmem/src/gda/mlx5/queue_pair_mlx5.cpp
+++ b/projects/rocshmem/src/gda/mlx5/queue_pair_mlx5.cpp
@@ -271,7 +271,7 @@ __device__ void QueuePair::mlx5_quiet_single() {
 }
 
 // can be called with all active lanes using any number of different QPs, don't assume anything
-__device__ void QueuePair::mlx5_post_wqe_rma(int pe, int32_t length, uintptr_t laddr, uintptr_t raddr, uint8_t opcode) {
+__device__ void QueuePair::mlx5_post_wqe_rma([[maybe_unused]] int pe, int32_t length, uintptr_t laddr, uintptr_t raddr, uint8_t opcode) {
   uint64_t qp_lane_mask;
   uint8_t qp_lane_count;
   uint8_t qp_lane_id;
@@ -317,7 +317,7 @@ __device__ void QueuePair::mlx5_post_wqe_rma(int pe, int32_t length, uintptr_t l
 }
 
 // called with all active lanes using different QPs
-__device__ void QueuePair::mlx5_post_wqe_rma_single(int pe, int32_t length, uintptr_t laddr,
+__device__ void QueuePair::mlx5_post_wqe_rma_single([[maybe_unused]] int pe, int32_t length, uintptr_t laddr,
                                                     uintptr_t raddr, uint8_t opcode, bool ring_db) {
   // get SQ lock
   acquire_lock(&mlx5_sq.lock);
@@ -352,7 +352,7 @@ __device__ void QueuePair::mlx5_post_wqe_rma_single(int pe, int32_t length, uint
 }
 
 // can be called with all active lanes using any number of different QPs, don't assume anything
-__device__ uint64_t QueuePair::mlx5_post_wqe_amo(int pe, int32_t length, uintptr_t raddr, uint8_t opcode,
+__device__ uint64_t QueuePair::mlx5_post_wqe_amo([[maybe_unused]] int pe, [[maybe_unused]] int32_t length, uintptr_t raddr, uint8_t opcode,
                                                  int64_t atomic_data, int64_t atomic_cmp, bool fetching) {
   uint64_t qp_lane_mask;
   uint8_t qp_lane_count;
@@ -415,7 +415,7 @@ __device__ uint64_t QueuePair::mlx5_post_wqe_amo(int pe, int32_t length, uintptr
 }
 
 // called with all active lanes using different QPs
-__device__ uint64_t QueuePair::mlx5_post_wqe_amo_single(int pe, int32_t length, uintptr_t raddr, uint8_t opcode,
+__device__ uint64_t QueuePair::mlx5_post_wqe_amo_single([[maybe_unused]] int pe, [[maybe_unused]] int32_t length, uintptr_t raddr, uint8_t opcode,
                                                         int64_t atomic_data, int64_t atomic_cmp, bool fetching) {
   // get SQ lock
   acquire_lock(&mlx5_sq.lock);

--- a/projects/rocshmem/src/gda/queue_pair.cpp
+++ b/projects/rocshmem/src/gda/queue_pair.cpp
@@ -66,7 +66,7 @@ QueuePair::QueuePair(struct ibv_pd* pd, int gda_provider) {
   int deviceId;
   CHECK_HIP(hipGetDevice(&deviceId));
   int wf_size = get_wf_size(deviceId);
-  for(int i{0}; i < FETCHING_ATOMIC_CNT; i+=wf_size) {
+  for(uint32_t i{0}; i < FETCHING_ATOMIC_CNT; i+=wf_size) {
     fetching_atomic_freelist->push_back(fetching_atomic + i);
   }
 

--- a/projects/rocshmem/src/gda/queue_pair.cpp
+++ b/projects/rocshmem/src/gda/queue_pair.cpp
@@ -129,18 +129,18 @@ __device__ uint64_t QueuePair::get_same_qp_lane_mask() {
 /******************************************************************************
  ************************ PROVIDER-SPECIFIC HELPERS ***************************
  *****************************************************************************/
-__device__ void QueuePair::post_wqe_rma(int pe, int32_t size, uintptr_t laddr, uintptr_t raddr, uint8_t opcode, Collectivity cy) {
+__device__ void QueuePair::post_wqe_rma([[maybe_unused]] int pe, int32_t size, uintptr_t laddr, uintptr_t raddr, uint8_t opcode, Collectivity cy) {
   switch (gda_provider_) {
 #if defined(GDA_IONIC)
   case GDAProvider::IONIC:
-    ionic_post_wqe_rma(pe, size, laddr, raddr, opcode, cy);
+    ionic_post_wqe_rma(size, laddr, raddr, opcode, cy);
     return;
 #endif
 #if defined(GDA_BNXT)
   case GDAProvider::BNXT:
     if ((cy == THREAD) ||
         (cy == WAVE && is_thread_zero_in_wave())) {
-      bnxt_post_wqe_rma(pe, size, laddr, raddr, opcode);
+      bnxt_post_wqe_rma(size, laddr, raddr, opcode);
     }
     return;
 #endif
@@ -148,7 +148,7 @@ __device__ void QueuePair::post_wqe_rma(int pe, int32_t size, uintptr_t laddr, u
   case GDAProvider::MLX5:
     if ((cy == THREAD) ||
         (cy == WAVE && is_thread_zero_in_wave())) {
-      mlx5_post_wqe_rma(pe, size, laddr, raddr, opcode);
+      mlx5_post_wqe_rma(size, laddr, raddr, opcode);
     }
     return;
 #endif
@@ -157,11 +157,11 @@ __device__ void QueuePair::post_wqe_rma(int pe, int32_t size, uintptr_t laddr, u
   }
 }
 
-__device__ void QueuePair::post_wqe_rma_single(int32_t size, uintptr_t laddr, uintptr_t raddr, uint8_t opcode, bool ring_db) {
+__device__ void QueuePair::post_wqe_rma_single([[maybe_unused]] int32_t size, uintptr_t laddr, uintptr_t raddr, uint8_t opcode, bool ring_db) {
   switch (gda_provider_) {
 #if defined(GDA_IONIC)
   case GDAProvider::IONIC:
-    ionic_post_wqe_rma_single(0 /*pe (unused)*/, size, laddr, raddr, opcode, Collectivity::THREAD);
+    ionic_post_wqe_rma_single(size, laddr, raddr, opcode, Collectivity::THREAD);
     return;
 #endif
 #if defined(GDA_BNXT)
@@ -171,7 +171,7 @@ __device__ void QueuePair::post_wqe_rma_single(int32_t size, uintptr_t laddr, ui
 #endif
 #if defined(GDA_MLX5)
   case GDAProvider::MLX5:
-    mlx5_post_wqe_rma_single(0 /* pe (unused) */, size, laddr, raddr, opcode, ring_db);
+    mlx5_post_wqe_rma_single(size, laddr, raddr, opcode, ring_db);
     return;
 #endif
   default:

--- a/projects/rocshmem/src/gda/queue_pair.hpp
+++ b/projects/rocshmem/src/gda/queue_pair.hpp
@@ -181,8 +181,8 @@ class QueuePair {
 #if defined(GDA_MLX5)
   __device__ uint64_t mlx5_post_wqe_amo(int pe, int32_t size, uintptr_t raddr, uint8_t opcode, int64_t atomic_data, int64_t atomic_cmp, bool fetch);
   __device__ uint64_t mlx5_post_wqe_amo_single(int pe, int32_t size, uintptr_t raddr, uint8_t opcode, int64_t atomic_data, int64_t atomic_cmp, bool fetch);
-  __device__ void mlx5_post_wqe_rma(int pe, int32_t size, uintptr_t laddr, uintptr_t raddr, uint8_t opcode);
-  __device__ void mlx5_post_wqe_rma_single(int pe, int32_t size, uintptr_t laddr, uintptr_t raddr, uint8_t opcode, bool ring_db);
+  __device__ void mlx5_post_wqe_rma(int32_t size, uintptr_t laddr, uintptr_t raddr, uint8_t opcode);
+  __device__ void mlx5_post_wqe_rma_single(int32_t size, uintptr_t laddr, uintptr_t raddr, uint8_t opcode, bool ring_db);
   __device__ void mlx5_quiet();
   __device__ void mlx5_quiet_single();
 #endif
@@ -194,7 +194,7 @@ class QueuePair {
   __device__ uint64_t bnxt_post_wqe_amo_single(uintptr_t raddr, uint8_t opcode, int64_t atomic_data, int64_t atomic_cmp, bool fetching);
   __device__ uint64_t bnxt_post_wqe_amo(uintptr_t raddr, uint8_t opcode, int64_t atomic_data, int64_t atomic_cmp, bool fetching);
 
-  __device__ void bnxt_post_wqe_rma(int pe, int32_t size, uintptr_t laddr, uintptr_t raddr, uint8_t opcode);
+  __device__ void bnxt_post_wqe_rma(int32_t size, uintptr_t laddr, uintptr_t raddr, uint8_t opcode);
 
   __device__ void bnxt_post_wqe_rma_single(int32_t size, uintptr_t laddr, uintptr_t raddr, uint8_t opcode, bool ring_db);
   __device__ void bnxt_quiet();
@@ -203,8 +203,8 @@ class QueuePair {
 #if defined(GDA_IONIC)
   __device__ uint64_t ionic_post_wqe_amo(int pe, int32_t size, uintptr_t raddr, uint8_t opcode, int64_t atomic_data, int64_t atomic_cmp, bool fetch);
   __device__ uint64_t ionic_post_wqe_amo_single(int pe, int32_t size, uintptr_t raddr, uint8_t opcode, int64_t atomic_data, int64_t atomic_cmp, bool fetch);
-  __device__ void ionic_post_wqe_rma(int pe, int32_t size, uintptr_t laddr, uintptr_t raddr, uint8_t opcode, Collectivity cy);
-  __device__ void ionic_post_wqe_rma_single(int pe, int32_t size, uintptr_t laddr, uintptr_t raddr, uint8_t opcode, Collectivity cy);
+  __device__ void ionic_post_wqe_rma(int32_t size, uintptr_t laddr, uintptr_t raddr, uint8_t opcode, Collectivity cy);
+  __device__ void ionic_post_wqe_rma_single(int32_t size, uintptr_t laddr, uintptr_t raddr, uint8_t opcode, Collectivity cy);
   __device__ void ionic_quiet();
   __device__ void ionic_quiet_single();
 #endif

--- a/projects/rocshmem/src/gda/topology.cpp
+++ b/projects/rocshmem/src/gda/topology.cpp
@@ -50,7 +50,7 @@ namespace rocshmem
     std::vector<int> status(numPages);
 
     pages[0] = array;
-    for (int i = 1; i < numPages; i++) {
+    for (size_t i = 1; i < numPages; i++) {
       pages[i] = (char*)pages[i-1] + pageSize;
     }
 
@@ -896,7 +896,7 @@ namespace rocshmem
 #endif
 
           int minDistance = std::numeric_limits<int>::max();
-          for (int j = 0; j < ibvAddressList.size(); j++) {
+          for (size_t j = 0; j < ibvAddressList.size(); j++) {
             if (ibvAddressList[j] != "") {
               int distance = GetBusIdDistance(hipPciBusId, ibvAddressList[j]);
               if (distance < minDistance && distance >= 0) {
@@ -944,18 +944,18 @@ namespace rocshmem
 
     int numGpus = rocshmem::GetNumDevices(rocshmem::EXE_GPU);
     auto const& ibvDeviceList = rocshmem::GetIbvDeviceList();
-    for (int i = 0; i < ibvDeviceList.size(); i++) {
+    for (size_t i = 0; i < ibvDeviceList.size(); i++) {
 
       std::string closestGpusStr = "";
       for (int j = 0; j < numGpus; j++) {
-        if (rocshmem::GetClosestNicToGpu(j, nullptr, nullptr) == i) {
+        if (rocshmem::GetClosestNicToGpu(j, nullptr, nullptr) == static_cast<int>(i)) {
           if (closestGpusStr != "") closestGpusStr += ",";
           closestGpusStr += std::to_string(j);
         }
       }
 
       printf(" %-3d | %-11s | %-6s | %-12s | %-4d | %-14s | %-9s | %-20s\n",
-             i, ibvDeviceList[i].name.c_str(),
+             static_cast<int>(i), ibvDeviceList[i].name.c_str(),
              ibvDeviceList[i].hasActivePort ? "Yes" : "No",
              ibvDeviceList[i].busId.c_str(),
              ibvDeviceList[i].numaNode,

--- a/projects/rocshmem/src/gda/topology.cpp
+++ b/projects/rocshmem/src/gda/topology.cpp
@@ -170,7 +170,6 @@ namespace rocshmem
       hsa_amd_pointer_info_t info;
       info.size = sizeof(info);
 
-      int err;
       int32_t* tempBuffer;
 
       // Index CPU agents
@@ -217,7 +216,7 @@ namespace rocshmem
   }
 
   // Get the hsa_agent_t associated with a MemDevice
-  static int GetHsaAgent(MemDevice const& memDevice, hsa_agent_t& agent)
+  [[maybe_unused]] static int GetHsaAgent(MemDevice const& memDevice, hsa_agent_t& agent)
   {
     if (IsCpuMemType(memDevice.memType)) return GetHsaAgent({EXE_CPU, memDevice.memIndex}, agent);
     if (IsGpuMemType(memDevice.memType)) return GetHsaAgent({EXE_GPU, memDevice.memIndex}, agent);
@@ -446,7 +445,7 @@ namespace rocshmem
   //========================================================================================
 
   // Prints off PCIe tree
-  static void PrintPCIeTree(PCIeNode    const& node,
+  [[maybe_unused]] static void PrintPCIeTree(PCIeNode    const& node,
                             std::string const& prefix = "",
                             bool               isLast = true)
   {
@@ -603,7 +602,6 @@ namespace rocshmem
     // Build PCIe tree on first use
     if (!isInitialized) {
       // Add NICs to the tree
-      int numNics = rocshmem::GetNumDevices(rocshmem::EXE_NIC);
       auto const& ibvDeviceList = rocshmem::GetIbvDeviceList();
       for (IbvDevice const& ibvDevice : ibvDeviceList) {
         if (!ibvDevice.hasActivePort || ibvDevice.busId == "") continue;

--- a/projects/rocshmem/src/host/host.hpp
+++ b/projects/rocshmem/src/host/host.hpp
@@ -298,7 +298,7 @@ class HostInterface {
 #endif // USE_HDP_FLUSH
   }
 
-  __host__ void flush_remote_hdp(int pe) {
+  __host__ void flush_remote_hdp([[maybe_unused]] int pe) {
 #if defined USE_HDP_FLUSH
     unsigned flush_val{HdpPolicy::HDP_FLUSH_VAL};
     mpilib_ftable_.Put(&flush_val, 1, MPI_UNSIGNED, pe, 0, 1, MPI_UNSIGNED, hdp_win);

--- a/projects/rocshmem/src/host/host_templates.hpp
+++ b/projects/rocshmem/src/host/host_templates.hpp
@@ -622,10 +622,10 @@ __host__ size_t HostInterface::wait_until_some(T* ivars, size_t nelems,
 }
 
 template <typename T>
-__host__ void HostInterface::wait_until_all_vector(T* ivars, size_t nelems,
-                                                   const int *status,
-                                                   int cmp, T* vals,
-                                                   WindowInfo* window_info) {
+__host__ void HostInterface::wait_until_all_vector([[maybe_unused]] T* ivars, [[maybe_unused]] size_t nelems,
+                                                   [[maybe_unused]] const int *status,
+                                                   [[maybe_unused]] int cmp, [[maybe_unused]] T* vals,
+                                                   [[maybe_unused]] WindowInfo* window_info) {
   DPRINTF("Function: host_wait_until_all_vector\n");
 
   // zero nelems error condition
@@ -650,10 +650,10 @@ __host__ void HostInterface::wait_until_all_vector(T* ivars, size_t nelems,
 }
 
 template <typename T>
-__host__ size_t HostInterface::wait_until_any_vector(T* ivars, size_t nelems,
-                                                     const int *status,
-                                                     int cmp, T* vals,
-                                                     WindowInfo* window_info) {
+__host__ size_t HostInterface::wait_until_any_vector([[maybe_unused]] T* ivars, [[maybe_unused]] size_t nelems,
+                                                     [[maybe_unused]] const int *status,
+                                                     [[maybe_unused]] int cmp, [[maybe_unused]] T* vals,
+                                                     [[maybe_unused]] WindowInfo* window_info) {
   DPRINTF("Function: host_wait_until_any_vector\n");
 
   // zero nelems error condition
@@ -683,11 +683,11 @@ __host__ size_t HostInterface::wait_until_any_vector(T* ivars, size_t nelems,
 }
 
 template <typename T>
-__host__ size_t HostInterface::wait_until_some_vector(T* ivars, size_t nelems,
-                                                    size_t* indices,
-                                                    const int *status,
-                                                    int cmp, T* vals,
-                                                    WindowInfo* window_info) {
+__host__ size_t HostInterface::wait_until_some_vector([[maybe_unused]] T* ivars, [[maybe_unused]] size_t nelems,
+                                                    [[maybe_unused]] size_t* indices,
+                                                    [[maybe_unused]] const int *status,
+                                                    [[maybe_unused]] int cmp, [[maybe_unused]] T* vals,
+                                                    [[maybe_unused]] WindowInfo* window_info) {
   DPRINTF("Function: host_wait_until_some_vector\n");
 
   // zero nelems error condition

--- a/projects/rocshmem/src/host/host_templates.hpp
+++ b/projects/rocshmem/src/host/host_templates.hpp
@@ -622,10 +622,10 @@ __host__ size_t HostInterface::wait_until_some(T* ivars, size_t nelems,
 }
 
 template <typename T>
-__host__ void HostInterface::wait_until_all_vector([[maybe_unused]] T* ivars, [[maybe_unused]] size_t nelems,
-                                                   [[maybe_unused]] const int *status,
-                                                   [[maybe_unused]] int cmp, [[maybe_unused]] T* vals,
-                                                   [[maybe_unused]] WindowInfo* window_info) {
+__host__ void HostInterface::wait_until_all_vector(T* ivars, size_t nelems,
+                                                   const int *status,
+                                                   int cmp, T* vals,
+                                                   WindowInfo* window_info) {
   DPRINTF("Function: host_wait_until_all_vector\n");
 
   // zero nelems error condition
@@ -650,10 +650,10 @@ __host__ void HostInterface::wait_until_all_vector([[maybe_unused]] T* ivars, [[
 }
 
 template <typename T>
-__host__ size_t HostInterface::wait_until_any_vector([[maybe_unused]] T* ivars, [[maybe_unused]] size_t nelems,
-                                                     [[maybe_unused]] const int *status,
-                                                     [[maybe_unused]] int cmp, [[maybe_unused]] T* vals,
-                                                     [[maybe_unused]] WindowInfo* window_info) {
+__host__ size_t HostInterface::wait_until_any_vector(T* ivars, size_t nelems,
+                                                     const int *status,
+                                                     int cmp, T* vals,
+                                                     WindowInfo* window_info) {
   DPRINTF("Function: host_wait_until_any_vector\n");
 
   // zero nelems error condition
@@ -683,11 +683,11 @@ __host__ size_t HostInterface::wait_until_any_vector([[maybe_unused]] T* ivars, 
 }
 
 template <typename T>
-__host__ size_t HostInterface::wait_until_some_vector([[maybe_unused]] T* ivars, [[maybe_unused]] size_t nelems,
-                                                    [[maybe_unused]] size_t* indices,
-                                                    [[maybe_unused]] const int *status,
-                                                    [[maybe_unused]] int cmp, [[maybe_unused]] T* vals,
-                                                    [[maybe_unused]] WindowInfo* window_info) {
+__host__ size_t HostInterface::wait_until_some_vector(T* ivars, size_t nelems,
+                                                      size_t* indices,
+                                                      const int *status,
+                                                      int cmp, T* vals,
+                                                      WindowInfo* window_info) {
   DPRINTF("Function: host_wait_until_some_vector\n");
 
   // zero nelems error condition

--- a/projects/rocshmem/src/ipc/backend_ipc.cpp
+++ b/projects/rocshmem/src/ipc/backend_ipc.cpp
@@ -181,7 +181,7 @@ void IPCBackend::setup_ctxs() {
   }
 }
 
-__device__ bool IPCBackend::create_ctx(int64_t options, rocshmem_ctx_t *ctx) {
+__device__ bool IPCBackend::create_ctx([[maybe_unused]] int64_t options, rocshmem_ctx_t *ctx) {
   IPCContext *ctx_{nullptr};
 
   auto pop_result = ctx_free_list.get()->pop_front();
@@ -260,7 +260,7 @@ void IPCBackend::Allreduce_char_BAND (char* inbuf, char *outbuf, size_t num_byte
     abort();
   }
 
-  for (int i = 0; i < num_bytes; i++) {
+  for (size_t i = 0; i < num_bytes; i++) {
     outbuf[i] = tmp_buffer[i];
     for (int j = 1; j < num_pes; j++) {
       outbuf[i] &= tmp_buffer[j * num_bytes + i];
@@ -481,7 +481,7 @@ void IPCBackend::rocshmem_collective_init() {
   /*
    * Initialize the barrier synchronization array with default values.
    */
-  for (int i = 0; i < ROCSHMEM_BARRIER_SYNC_SIZE; i++) {
+  for (size_t i = 0; i < ROCSHMEM_BARRIER_SYNC_SIZE; i++) {
     barrier_sync[i] = ROCSHMEM_SYNC_VALUE;
   }
 

--- a/projects/rocshmem/src/ipc/backend_ipc.hpp
+++ b/projects/rocshmem/src/ipc/backend_ipc.hpp
@@ -37,7 +37,6 @@
 namespace rocshmem {
 
 class IPCBackend : public Backend {
-  [[maybe_unused]] const unsigned MAX_NUM_BLOCKS{65536};
 
  public:
   /**

--- a/projects/rocshmem/src/ipc/backend_ipc.hpp
+++ b/projects/rocshmem/src/ipc/backend_ipc.hpp
@@ -37,7 +37,7 @@
 namespace rocshmem {
 
 class IPCBackend : public Backend {
-  const unsigned MAX_NUM_BLOCKS{65536};
+  [[maybe_unused]] const unsigned MAX_NUM_BLOCKS{65536};
 
  public:
   /**

--- a/projects/rocshmem/src/ipc/context_ipc_device.cpp
+++ b/projects/rocshmem/src/ipc/context_ipc_device.cpp
@@ -302,7 +302,7 @@ __device__ uint64_t IPCContext::signal_fetch_wg(const uint64_t *sig_addr) {
 }
 
 __device__ uint64_t IPCContext::signal_fetch_wave(const uint64_t *sig_addr) {
-  uint64_t value = 0;
+  uint64_t value{0};
   if (is_thread_zero_in_wave()) {
     uint64_t *dst = const_cast<uint64_t*>(sig_addr);
     value = amo_fetch_add<uint64_t>(static_cast<void*>(dst), 0, my_pe);

--- a/projects/rocshmem/src/ipc/context_ipc_device.cpp
+++ b/projects/rocshmem/src/ipc/context_ipc_device.cpp
@@ -302,7 +302,7 @@ __device__ uint64_t IPCContext::signal_fetch_wg(const uint64_t *sig_addr) {
 }
 
 __device__ uint64_t IPCContext::signal_fetch_wave(const uint64_t *sig_addr) {
-  uint64_t value;
+  uint64_t value = 0;
   if (is_thread_zero_in_wave()) {
     uint64_t *dst = const_cast<uint64_t*>(sig_addr);
     value = amo_fetch_add<uint64_t>(static_cast<void*>(dst), 0, my_pe);

--- a/projects/rocshmem/src/ipc/context_ipc_tmpl_device.hpp
+++ b/projects/rocshmem/src/ipc/context_ipc_tmpl_device.hpp
@@ -286,8 +286,8 @@ __device__ void IPCContext::internal_ring_allreduce(
     T *dst, const T *src, int nelems, IPCTeam *team_obj,  // NOLINT(runtime/int)
     int n_seg, int seg_size, int chunk_size) {
 
-  int stride = team_obj->tinfo_wrt_world->stride;
-  int PE_start = team_obj->tinfo_wrt_world->pe_start;
+  [[maybe_unused]] int stride = team_obj->tinfo_wrt_world->stride;
+  [[maybe_unused]] int PE_start = team_obj->tinfo_wrt_world->pe_start;
   int PE_size = team_obj->tinfo_wrt_world->size;
   long *pSync = team_obj->reduce_pSync;
   T *pWrk = reinterpret_cast<T *>(team_obj->pWrk);

--- a/projects/rocshmem/src/ipc/context_ipc_tmpl_device.hpp
+++ b/projects/rocshmem/src/ipc/context_ipc_tmpl_device.hpp
@@ -475,11 +475,11 @@ __device__ void IPCContext::alltoall(rocshmem_team_t team, T *dst,
 }
 
 template <typename T>
-__device__ void IPCContext::alltoallv(rocshmem_team_t team,
-                                      T *dest, const size_t dest_nelems[],
-                                      const size_t dest_displs[],
-                                      T *source, const size_t source_nelems[],
-                                      const size_t source_displs[]) {
+__device__ void IPCContext::alltoallv([[maybe_unused]] rocshmem_team_t team,
+                                      [[maybe_unused]] T *dest, [[maybe_unused]] const size_t dest_nelems[],
+                                      [[maybe_unused]] const size_t dest_displs[],
+                                      [[maybe_unused]] T *source, [[maybe_unused]] const size_t source_nelems[],
+                                      [[maybe_unused]] const size_t source_displs[]) {
   printf("rocshmem::ipc:alltoallv not implemented\n");
   abort();
 }

--- a/projects/rocshmem/src/ipc/context_ipc_tmpl_device.hpp
+++ b/projects/rocshmem/src/ipc/context_ipc_tmpl_device.hpp
@@ -286,8 +286,6 @@ __device__ void IPCContext::internal_ring_allreduce(
     T *dst, const T *src, int nelems, IPCTeam *team_obj,  // NOLINT(runtime/int)
     int n_seg, int seg_size, int chunk_size) {
 
-  [[maybe_unused]] int stride = team_obj->tinfo_wrt_world->stride;
-  [[maybe_unused]] int PE_start = team_obj->tinfo_wrt_world->pe_start;
   int PE_size = team_obj->tinfo_wrt_world->size;
   long *pSync = team_obj->reduce_pSync;
   T *pWrk = reinterpret_cast<T *>(team_obj->pWrk);

--- a/projects/rocshmem/src/ipc/ipc_context_proxy.hpp
+++ b/projects/rocshmem/src/ipc/ipc_context_proxy.hpp
@@ -45,7 +45,7 @@ class IPCDefaultContextProxy {
    */
   explicit IPCDefaultContextProxy(IPCBackend* backend, TeamInfo *tinfo,
                                   size_t num_elems = 1)
-  : constructed_{true}, proxy_{num_elems} {
+  : proxy_{num_elems}, constructed_{true} {
     auto ctx{proxy_.get()};
     new (ctx) IPCContext(reinterpret_cast<Backend*>(backend), 0);
     ctx->tinfo = tinfo;

--- a/projects/rocshmem/src/ipc_policy.hpp
+++ b/projects/rocshmem/src/ipc_policy.hpp
@@ -154,7 +154,7 @@ class IpcOnImpl {
   __device__ void zero_byte_read(int pe) {
     int local_pe = pe % shm_size;
     uint32_t *pe_ipc_base = reinterpret_cast<uint32_t *>(ipc_bases[local_pe]);
-    volatile uint32_t read_value = __hip_atomic_load(
+    [[maybe_unused]] volatile uint32_t read_value = __hip_atomic_load(
         pe_ipc_base, __ATOMIC_SEQ_CST, __HIP_MEMORY_SCOPE_SYSTEM);
   }
 };

--- a/projects/rocshmem/src/ipc_policy.hpp
+++ b/projects/rocshmem/src/ipc_policy.hpp
@@ -61,7 +61,7 @@ class IpcOnImpl {
 
   __host__ void ipcHostStop();
 
-  __host__ __device__ bool isIpcAvailable(int my_pe, int target_pe, int *local_target_pe) {
+  __host__ __device__ bool isIpcAvailable([[maybe_unused]] int my_pe, int target_pe, int *local_target_pe) {
     if (nullptr == pes_with_ipc_avail) { return false; }
 
     for (int i=0; i<shm_size; i++) {
@@ -181,7 +181,7 @@ class IpcOffImpl {
 
   __host__ void ipcHostStop() {}
 
-  __host__ __device__ bool isIpcAvailable(int my_pe, int target_pe, int *local_target_pe) { return false; }
+  __host__ __device__ bool isIpcAvailable([[maybe_unused]] int my_pe, int target_pe, int *local_target_pe) { return false; }
 
   __device__ void ipcGpuInit(Backend *rocshmem_handle, Context *ctx,
                              int thread_id) {}

--- a/projects/rocshmem/src/memory/default_allocator.hpp
+++ b/projects/rocshmem/src/memory/default_allocator.hpp
@@ -104,7 +104,7 @@ namespace rocshmem {
 #endif
   }
 
-  static HIPAllocator* get_default_allocator()
+  [[maybe_unused]] static HIPAllocator* get_default_allocator()
   {
     if (default_allocator_ == nullptr) {
       set_default_allocator();
@@ -113,7 +113,7 @@ namespace rocshmem {
     return default_allocator_;
   }
 
-  static void delete_default_allocator()
+  [[maybe_unused]] static void delete_default_allocator()
   {
     if (default_allocator_ != nullptr) {
       delete default_allocator_;

--- a/projects/rocshmem/src/memory/dlmalloc.cpp
+++ b/projects/rocshmem/src/memory/dlmalloc.cpp
@@ -27,9 +27,14 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 /* BEGIN AMD ROCSHMEM CHANGES */
 // To improve code coverage score, code for the following cases has been
 // stripped from imported dlmalloc.c:
-//   !ONLY_MSPACES; MALLOC_INSPECT_ALL; USE_LOCKS; DEBUG; 
+//   !ONLY_MSPACES; MALLOC_INSPECT_ALL; USE_LOCKS; DEBUG;
 #include "dlmalloc.hpp"
 #include <cstdio>
+
+// Suppress GNU null pointer arithmetic warnings for dlmalloc's intentional
+// use of chunk2mem(0) for compile-time offset calculations
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wgnu-null-pointer-arithmetic"
 
 namespace rocshmem {
 
@@ -3942,16 +3947,19 @@ size_t DLMalloc::mspace_max_footprint(mspace msp) {
   return ::rocshmem::mspace_max_footprint(msp);
 }
 size_t DLMalloc::mspace_used(mspace msp) {
-  struct mallinfo mi{0};
+  struct mallinfo mi{};
   mi = mspace_mallinfo(msp);
   return mi.uordblks;
 }
 size_t DLMalloc::mspace_avail(mspace msp) {
-  struct mallinfo mi{0};
+  struct mallinfo mi{};
   mi = mspace_mallinfo(msp);
   return mi.fordblks;
 }
 #endif // MSPACES
 #endif // ROCSHMEM_ENCAPSULATE
 } // namespace rocshmem
+
+#pragma clang diagnostic pop
+
 /* END AMD ROCSHMEM CHANGES */

--- a/projects/rocshmem/src/memory/dlmalloc.cpp
+++ b/projects/rocshmem/src/memory/dlmalloc.cpp
@@ -1859,7 +1859,7 @@ static msegmentptr segment_holding(mstate m, char* addr) {
 }
 
 /* Return true if segment contains a segment link */
-static int has_segment_link(mstate m, msegmentptr ss) {
+[[maybe_unused]] static int has_segment_link(mstate m, msegmentptr ss) {
   msegmentptr sp = &m->seg;
   for (;;) {
     if ((char*)sp >= ss->base && (char*)sp < ss->base + ss->size)
@@ -2713,7 +2713,7 @@ static void add_segment(mstate m, char* tbase, size_t tsize, flag_t mmapped) {
   msegmentptr ss = (msegmentptr)(chunk2mem(sp));
   mchunkptr tnext = chunk_plus_offset(sp, ssize);
   mchunkptr p = tnext;
-  int nfences = 0;
+  [[maybe_unused]] int nfences = 0;
 
   /* reset top to new space */
   init_top(m, (mchunkptr)tbase, tsize - TOP_FOOT_SIZE);
@@ -2982,7 +2982,7 @@ static int sys_trim(mstate m, size_t pad) {
     if (m->topsize > pad) {
       /* Shrink top space in granularity-size units, keeping at least one */
       size_t unit = mparams.granularity;
-      size_t extra = ((m->topsize - pad + (unit - SIZE_T_ONE)) / unit -
+      [[maybe_unused]] size_t extra = ((m->topsize - pad + (unit - SIZE_T_ONE)) / unit -
                       SIZE_T_ONE) * unit;
       msegmentptr sp = segment_holding(m, (char*)m->top);
 
@@ -3589,7 +3589,7 @@ struct mallinfo mspace_mallinfo(mspace msp) {
 }
 #endif /* NO_MALLINFO */
 
-size_t mspace_usable_size(const void* mem) {
+[[maybe_unused]] size_t mspace_usable_size(const void* mem) {
   if (mem != 0) {
     mchunkptr p = mem2chunk(mem);
     if (is_inuse(p))
@@ -3598,7 +3598,7 @@ size_t mspace_usable_size(const void* mem) {
   return 0;
 }
 
-int mspace_mallopt(int param_number, int value) {
+[[maybe_unused]] int mspace_mallopt(int param_number, int value) {
   return change_mparam(param_number, value);
 }
 

--- a/projects/rocshmem/src/memory/hip_allocator.hpp
+++ b/projects/rocshmem/src/memory/hip_allocator.hpp
@@ -127,6 +127,8 @@ class HIPAllocator : public MemoryAllocator {
                 hipError_t (*hip_free_fn)(void*), unsigned flags) :
     MemoryAllocator (hip_alloc_fn, hip_free_fn, flags) {}
 
+  virtual ~HIPAllocator() = default;
+
   HIPAllocatorType type = AllocatorTypeCoarsegrained;
 
   virtual hipError_t GetIpcHandle(void *dev_ptr, void *handle)

--- a/projects/rocshmem/src/memory/memory_allocator.cpp
+++ b/projects/rocshmem/src/memory/memory_allocator.cpp
@@ -35,8 +35,8 @@ MemoryAllocator::MemoryAllocator(hipError_t (*hip_alloc_fn)(void**, size_t,
                                  hipError_t (*hip_free_fn)(void*),
                                  unsigned flags)
     : _hip_alloc_with_flags(hip_alloc_fn),
-      _hip_free(hip_free_fn),
-      _flags(flags) {}
+      _flags(flags),
+      _hip_free(hip_free_fn) {}
 
 MemoryAllocator::MemoryAllocator(hipError_t (*hip_alloc_fn)(void**, size_t),
                                  hipError_t (*hip_free_fn)(void*))
@@ -50,8 +50,8 @@ MemoryAllocator::MemoryAllocator(
     std::function<int(void**, size_t, size_t)> posix_align_fn,
     std::function<void(void*)> free_fn, size_t alignment)
     : _alloc_posix_memalign(posix_align_fn),
-      _free(free_fn),
-      _alignment(alignment) {}
+      _alignment(alignment),
+      _free(free_fn) {}
 
 void MemoryAllocator::allocate(void** void_ptr, size_t size) {
   assert(void_ptr);

--- a/projects/rocshmem/src/memory/memory_allocator.hpp
+++ b/projects/rocshmem/src/memory/memory_allocator.hpp
@@ -152,11 +152,6 @@ class MemoryAllocator {
    * @brief a hip-specific free function
    */
   std::function<hipError_t(void*)> _hip_free{nullptr};
-
-  /**
-   * @brief a hip-specific return code
-   */
-  [[maybe_unused]] hipError_t _hip_return_value{hipSuccess};
 };
 
 }  // namespace rocshmem

--- a/projects/rocshmem/src/memory/memory_allocator.hpp
+++ b/projects/rocshmem/src/memory/memory_allocator.hpp
@@ -156,7 +156,7 @@ class MemoryAllocator {
   /**
    * @brief a hip-specific return code
    */
-  hipError_t _hip_return_value{hipSuccess};
+  [[maybe_unused]] hipError_t _hip_return_value{hipSuccess};
 };
 
 }  // namespace rocshmem

--- a/projects/rocshmem/src/memory/remote_heap_info.hpp
+++ b/projects/rocshmem/src/memory/remote_heap_info.hpp
@@ -261,7 +261,7 @@ class RemoteHeapInfo {
   /**
    ** @brief common initialization code
    */
-  void init(char* heap_ptr, size_t heap_size)  {
+  void init(char* heap_ptr, [[maybe_unused]] size_t heap_size)  {
     heap_bases_.resize(communicator_.num_pes());
     for (auto& base : heap_bases_) {
       base = nullptr;

--- a/projects/rocshmem/src/memory/single_heap.cpp
+++ b/projects/rocshmem/src/memory/single_heap.cpp
@@ -87,7 +87,7 @@ void SingleHeap::malloc(void** ptr, size_t size) {
   strat_->alloc(reinterpret_cast<char**>(ptr), size);
 }
 
-__device__ void SingleHeap::malloc(void** ptr, size_t size) {}
+__device__ void SingleHeap::malloc([[maybe_unused]] void** ptr, [[maybe_unused]] size_t size) {}
 
 void SingleHeap::free(void* ptr) {
   if (!ptr) {
@@ -96,11 +96,11 @@ void SingleHeap::free(void* ptr) {
   strat_->free(reinterpret_cast<char*>(ptr));
 }
 
-__device__ void SingleHeap::free(void* ptr) {}
+__device__ void SingleHeap::free([[maybe_unused]] void* ptr) {}
 
-void* SingleHeap::realloc(void* ptr, size_t size) { return nullptr; }
+void* SingleHeap::realloc([[maybe_unused]] void* ptr, [[maybe_unused]] size_t size) { return nullptr; }
 
-void* SingleHeap::malign(size_t alignment, size_t size) { return nullptr; }
+void* SingleHeap::malign([[maybe_unused]] size_t alignment, [[maybe_unused]] size_t size) { return nullptr; }
 
 char* SingleHeap::get_base_ptr() { return heap_mem_->get_ptr(); }
 

--- a/projects/rocshmem/src/memory/window_info.hpp
+++ b/projects/rocshmem/src/memory/window_info.hpp
@@ -54,7 +54,7 @@ class WindowInfo {
   /**
    * @brief Destructor
    */
-  ~WindowInfo() = default;
+  virtual ~WindowInfo() = default;
 
   /**
    * @brief Copy constructor

--- a/projects/rocshmem/src/reverse_offload/backend_ro.cpp
+++ b/projects/rocshmem/src/reverse_offload/backend_ro.cpp
@@ -248,7 +248,6 @@ void ROBackend::dump_backend_stats() {
   }
 
   int device_id;
-  hipDeviceProp_t device_props;
   CHECK_HIP(hipGetDevice(&device_id));
   int wallClockMhz;
   CHECK_HIP(hipDeviceGetAttribute(&wallClockMhz, hipDeviceAttributeWallClockRate, device_id));

--- a/projects/rocshmem/src/reverse_offload/backend_ro.cpp
+++ b/projects/rocshmem/src/reverse_offload/backend_ro.cpp
@@ -184,7 +184,7 @@ ROBackend::~ROBackend() {
   CHECK_HIP(hipFree(ctx_array));
 }
 
-__device__ bool ROBackend::create_ctx(int64_t options, rocshmem_ctx_t *ctx) {
+__device__ bool ROBackend::create_ctx([[maybe_unused]] int64_t options, rocshmem_ctx_t *ctx) {
   ROContext *ctx_;
 
   auto pop_result = ctx_free_list.get()->pop_front();

--- a/projects/rocshmem/src/reverse_offload/context_proxy.hpp
+++ b/projects/rocshmem/src/reverse_offload/context_proxy.hpp
@@ -46,7 +46,7 @@ class DefaultContextProxy {
    */
   explicit DefaultContextProxy(ROBackend* backend, TeamInfo *tinfo,
                                size_t num_elems = 1)
-  : constructed_{true}, proxy_{num_elems} {
+  : proxy_{num_elems}, constructed_{true} {
     auto ctx{proxy_.get()};
     new (ctx) ROContext(reinterpret_cast<Backend*>(backend), -1, true);
     rocshmem_ctx_t local{ctx, tinfo};

--- a/projects/rocshmem/src/reverse_offload/context_ro_device.cpp
+++ b/projects/rocshmem/src/reverse_offload/context_ro_device.cpp
@@ -537,7 +537,7 @@ __device__ uint64_t ROContext::signal_fetch_wg(const uint64_t *sig_addr) {
 }
 
 __device__ uint64_t ROContext::signal_fetch_wave(const uint64_t *sig_addr) {
-  uint64_t value;
+  uint64_t value = 0;
   if (is_thread_zero_in_wave()) {
     uint64_t *dst = const_cast<uint64_t*>(sig_addr);
     value = amo_fetch_add<uint64_t>(static_cast<void*>(dst), 0, my_pe);

--- a/projects/rocshmem/src/reverse_offload/context_ro_device.cpp
+++ b/projects/rocshmem/src/reverse_offload/context_ro_device.cpp
@@ -148,7 +148,7 @@ __device__ void ROContext::fence() {
                       true, get_status_flag(), is_default_ctx);
 }
 
-__device__ void ROContext::fence(int pe) {
+__device__ void ROContext::fence([[maybe_unused]] int pe) {
   // TODO(khamidou): need to check if per pe has any special handling
   build_queue_element(RO_NET_FENCE, nullptr, nullptr, 0, 0, 0, 0, 0, nullptr,
                       nullptr, NULL, ro_net_win_id, block_handle,
@@ -161,7 +161,7 @@ __device__ void ROContext::quiet() {
                       true, get_status_flag(), is_default_ctx);
 }
 
-__device__ void ROContext::pe_quiet(size_t pe) {
+__device__ void ROContext::pe_quiet([[maybe_unused]] size_t pe) {
   // TODO: Optimize
   quiet();
 }
@@ -669,7 +669,7 @@ __device__ uint64_t next_write_slot(BlockHandle *handle) {
 
 __device__ void build_queue_element(
     ro_net_cmds type, void *dst, void *src, size_t size, int pe,
-    int logPE_stride, int PE_size, int PE_root, void *pWrk, long *pSync,
+    [[maybe_unused]] int logPE_stride, [[maybe_unused]] int PE_size, int PE_root, void *pWrk, [[maybe_unused]] long *pSync,
     intptr_t team_comm, int ro_net_win_id, BlockHandle *handle,
     bool blocking, volatile char *status, bool default_ctx, ROCSHMEM_OP op,
     ro_net_types datatype) {

--- a/projects/rocshmem/src/reverse_offload/context_ro_host.cpp
+++ b/projects/rocshmem/src/reverse_offload/context_ro_host.cpp
@@ -33,7 +33,7 @@
 
 namespace rocshmem {
 
-__host__ ROHostContext::ROHostContext(Backend *backend, long options)
+__host__ ROHostContext::ROHostContext(Backend *backend, [[maybe_unused]] long options)
     : Context(backend) {
   ROBackend *b{static_cast<ROBackend *>(backend)};
 

--- a/projects/rocshmem/src/reverse_offload/context_ro_tmpl_device.hpp
+++ b/projects/rocshmem/src/reverse_offload/context_ro_tmpl_device.hpp
@@ -227,7 +227,7 @@ __device__ T ROContext::amo_fetch_add(void *dst, T value, int pe) {
 
 template <typename T>
 __device__ void ROContext::amo_add(void *dst, T value, int pe) {
-  T ret{amo_fetch_add(dst, value, pe)};
+  [[maybe_unused]] T ret{amo_fetch_add(dst, value, pe)};
 }
 
 template <typename T>
@@ -246,7 +246,7 @@ __device__ T ROContext::amo_swap(void *dst, T value, int pe) {
 
 template <typename T>
 __device__ void ROContext::amo_set(void *dst, T value, int pe) {
-  T ret{amo_swap(dst, value, pe)};
+  [[maybe_unused]] T ret{amo_swap(dst, value, pe)};
 }
 
 template <typename T>
@@ -265,7 +265,7 @@ __device__ T ROContext::amo_fetch_and(void *dst, T value, int pe) {
 
 template <typename T>
 __device__ void ROContext::amo_and(void *dst, T value, int pe) {
-  T ret{amo_fetch_and(dst, value, pe)};
+  [[maybe_unused]] T ret{amo_fetch_and(dst, value, pe)};
 }
 
 template <typename T>
@@ -284,7 +284,7 @@ __device__ T ROContext::amo_fetch_or(void *dst, T value, int pe) {
 
 template <typename T>
 __device__ void ROContext::amo_or(void *dst, T value, int pe) {
-  T ret{amo_fetch_or(dst, value, pe)};
+  [[maybe_unused]] T ret{amo_fetch_or(dst, value, pe)};
 }
 
 template <typename T>
@@ -303,7 +303,7 @@ __device__ T ROContext::amo_fetch_xor(void *dst, T value, int pe) {
 
 template <typename T>
 __device__ void ROContext::amo_xor(void *dst, T value, int pe) {
-  T ret{amo_fetch_xor(dst, value, pe)};
+  [[maybe_unused]] T ret{amo_fetch_xor(dst, value, pe)};
 }
 
 template <typename T>

--- a/projects/rocshmem/src/reverse_offload/context_ro_tmpl_device.hpp
+++ b/projects/rocshmem/src/reverse_offload/context_ro_tmpl_device.hpp
@@ -345,11 +345,11 @@ __device__ void ROContext::alltoall(rocshmem_team_t team, T *dest,
 }
 
 template <typename T>
-__device__ void ROContext::alltoallv(rocshmem_team_t team,
-                                     T *dest, const size_t dest_nelems[],
-                                     const size_t dest_displs[],
-                                     T *source, const size_t source_nelems[],
-                                     const size_t source_displs[]) {
+__device__ void ROContext::alltoallv([[maybe_unused]] rocshmem_team_t team,
+                                     [[maybe_unused]] T *dest, [[maybe_unused]] const size_t dest_nelems[],
+                                     [[maybe_unused]] const size_t dest_displs[],
+                                     [[maybe_unused]] T *source, [[maybe_unused]] const size_t source_nelems[],
+                                     [[maybe_unused]] const size_t source_displs[]) {
   printf("rocshmem::ipc:alltoallv not implemented\n");
   abort();
 }

--- a/projects/rocshmem/src/reverse_offload/mpi_transport.cpp
+++ b/projects/rocshmem/src/reverse_offload/mpi_transport.cpp
@@ -47,7 +47,7 @@ namespace rocshmem {
   }
 
 MPITransport::MPITransport(MPI_Comm comm, Queue* q)
-  : queue{q}, Transport{} {
+  : Transport{}, queue{q} {
 
   assert(comm != MPI_COMM_NULL);
 
@@ -607,7 +607,6 @@ void MPITransport::progress() {
     NET_CHECK(mpilib_ftable_.Testsome(incount, uptr_req_arr.get(), &outcount,
                            testsome_indices.data(), MPI_STATUSES_IGNORE));
 
-    auto *bp{backend_proxy->get()};
     for (int i{0}; i < outcount; i++) {
       int index{testsome_indices[i]};
       int contextId{requests[index].properties.contextId};
@@ -657,8 +656,6 @@ void MPITransport::progress() {
 }
 
 void MPITransport::quiet(int contextId, volatile char *status) {
-  auto *bp{backend_proxy->get()};
-
   if (!outstanding[contextId]) {
     DPRINTF("Finished Quiet immediately for contextId %d at status addr %p\n",
             contextId, status);

--- a/projects/rocshmem/src/reverse_offload/mpi_transport.cpp
+++ b/projects/rocshmem/src/reverse_offload/mpi_transport.cpp
@@ -252,7 +252,7 @@ rocshmem_team_t get_external_team(ROTeam *team) {
   return reinterpret_cast<rocshmem_team_t>(team);
 }
 
-void MPITransport::createNewTeam(ROBackend *backend, Team *parent_team,
+void MPITransport::createNewTeam(ROBackend *backend, [[maybe_unused]] Team *parent_team,
                                    TeamInfo *team_info_wrt_parent,
                                    TeamInfo *team_info_wrt_world, int num_pes,
                                    int my_pe_in_new_team, MPI_Comm team_comm,
@@ -341,7 +341,7 @@ static MPI_Datatype convertType(ro_net_types type) {
   }
 }
 
-void MPITransport::team_reduction(void *dst, void *src, int size, int win_id,
+void MPITransport::team_reduction(void *dst, void *src, int size, [[maybe_unused]] int win_id,
                                   int contextId, MPI_Comm team, ROCSHMEM_OP op,
                                   ro_net_types type, volatile char* status,
                                   bool blocking) {
@@ -366,7 +366,7 @@ void MPITransport::team_reduction(void *dst, void *src, int size, int win_id,
 void MPITransport::team_broadcast(void *dst, void *src, int size, int win_id,
                                   int contextId, MPI_Comm team, int root,
                                   ro_net_types type, volatile char *status,
-                                  bool blocking) {
+                                  [[maybe_unused]] bool blocking) {
   auto *bp{backend_proxy->get()};
 
   MPI_Comm comm{team};
@@ -403,9 +403,9 @@ void MPITransport::team_broadcast(void *dst, void *src, int size, int win_id,
 }
 
 void MPITransport::alltoall(void *dst, void *src, int size, int win_id,
-                            int contextId, MPI_Comm team, void *ata_buffptr,
+                            int contextId, MPI_Comm team, [[maybe_unused]] void *ata_buffptr,
                             ro_net_types type, volatile char *status,
-                            bool blocking) {
+                            [[maybe_unused]] bool blocking) {
   auto *bp{backend_proxy->get()};
 
   MPI_Comm comm{team};
@@ -451,9 +451,9 @@ void MPITransport::alltoall(void *dst, void *src, int size, int win_id,
 }
 
 void MPITransport::fcollect(void *dst, void *src, int size, int win_id,
-                            int contextId, MPI_Comm team, void *ata_buffptr,
+                            int contextId, MPI_Comm team, [[maybe_unused]] void *ata_buffptr,
                             ro_net_types type, volatile char *status,
-                            bool blocking) {
+                            [[maybe_unused]] bool blocking) {
   auto *bp{backend_proxy->get()};
 
   MPI_Comm comm{team};
@@ -499,7 +499,7 @@ void MPITransport::fcollect(void *dst, void *src, int size, int win_id,
 
 void MPITransport::putMem(void *dst, void *src, int size, int pe, int win_id,
                           int contextId, volatile char *status, bool blocking,
-                          bool inline_data) {
+                          [[maybe_unused]] bool inline_data) {
   queue->flush_hdp();
 
   auto *bp{backend_proxy->get()};
@@ -520,7 +520,7 @@ void MPITransport::putMem(void *dst, void *src, int size, int pe, int win_id,
 }
 
 void MPITransport::amoFOP(void *dst, void *src, void *val, int pe, int win_id,
-                          int contextId, volatile char *status, bool blocking,
+                          [[maybe_unused]] int contextId, volatile char *status, [[maybe_unused]] bool blocking,
                           ROCSHMEM_OP op, ro_net_types type) {
   queue->flush_hdp();
 
@@ -542,8 +542,8 @@ void MPITransport::amoFOP(void *dst, void *src, void *val, int pe, int win_id,
 }
 
 void MPITransport::amoFCAS(void *dst, void *src, void *val, int pe,
-                           int win_id, int contextId, volatile char *status,
-                           bool blocking, void *cond, ro_net_types type) {
+                           int win_id, [[maybe_unused]] int contextId, volatile char *status,
+                           [[maybe_unused]] bool blocking, void *cond, ro_net_types type) {
   queue->flush_hdp();
 
   auto *bp{backend_proxy->get()};

--- a/projects/rocshmem/src/reverse_offload/profiler.hpp
+++ b/projects/rocshmem/src/reverse_offload/profiler.hpp
@@ -59,7 +59,7 @@ class ProfilerProxy {
   ProfilerProxy() = default;
 
   explicit ProfilerProxy(size_t num_blocks)
-    : num_elem_{num_blocks}, proxy_{num_blocks} {
+    : proxy_{num_blocks}, num_elem_{num_blocks} {
 
     auto *stat{proxy_.get()};
     assert(stat);

--- a/projects/rocshmem/src/reverse_offload/queue.cpp
+++ b/projects/rocshmem/src/reverse_offload/queue.cpp
@@ -31,10 +31,10 @@ namespace rocshmem {
 Queue::Queue() { }
 
 Queue::Queue(size_t max_queues, size_t queue_size)
-    : max_queues_{max_queues},
-      queue_size_{queue_size},
-      queue_proxy_{max_queues, queue_size},
-      queue_desc_proxy_{max_queues} { }
+    : queue_proxy_{max_queues, queue_size},
+      queue_desc_proxy_{max_queues},
+      max_queues_{max_queues},
+      queue_size_{queue_size} { }
 
 uint64_t Queue::get_read_index(uint64_t queue_index) {
   return descriptor(queue_index)->read_index % queue_size_;

--- a/projects/rocshmem/src/reverse_offload/queue.hpp
+++ b/projects/rocshmem/src/reverse_offload/queue.hpp
@@ -70,7 +70,7 @@ class Queue {
 
   HdpProxy<HIPHostAllocator> hdp_proxy_{};
 
-  size_t max_queues_{};
+  [[maybe_unused]] size_t max_queues_{};
 
   size_t queue_size_{};
 };

--- a/projects/rocshmem/src/reverse_offload/queue_desc_proxy.hpp
+++ b/projects/rocshmem/src/reverse_offload/queue_desc_proxy.hpp
@@ -57,7 +57,7 @@ class QueueDescProxy {
   QueueDescProxy() = default;
 
   QueueDescProxy(size_t max_queues)
-    : max_queues_{max_queues}, proxy_{max_queues} {
+    : proxy_{max_queues}, max_queues_{max_queues} {
 
     auto *queue_descs{proxy_.get()};
     for (size_t i{0}; i < max_queues_; i++) {

--- a/projects/rocshmem/src/reverse_offload/queue_proxy.hpp
+++ b/projects/rocshmem/src/reverse_offload/queue_proxy.hpp
@@ -116,10 +116,10 @@ class QueueProxy {
   QueueProxy() = default;
 
   QueueProxy(size_t max_queues, size_t queue_size)
-    : max_queues_{max_queues}, queue_size_{queue_size},
-      total_queue_elements_{queue_size * max_queues},
-      queue_proxy_{max_queues},
-      per_block_queue_proxy_{queue_size * max_queues} {
+    : queue_proxy_{max_queues},
+      per_block_queue_proxy_{queue_size * max_queues},
+      max_queues_{max_queues}, queue_size_{queue_size},
+      total_queue_elements_{queue_size * max_queues} {
 
     auto **queue_array{queue_proxy_.get()};
     auto *per_block_queue{per_block_queue_proxy_.get()};

--- a/projects/rocshmem/src/reverse_offload/window_proxy.hpp
+++ b/projects/rocshmem/src/reverse_offload/window_proxy.hpp
@@ -41,7 +41,7 @@ class WindowProxy {
    * Placement new the memory which is allocated by proxy_
    */
   WindowProxy(SymmetricHeap *heap, MPI_Comm comm, size_t num_windows)
-    : num_windows_{num_windows}, proxy_{num_windows} {
+    : proxy_{num_windows}, num_windows_{num_windows} {
 
     WindowInfoMPI** window_info{proxy_.get()};
 

--- a/projects/rocshmem/src/rocshmem.cpp
+++ b/projects/rocshmem/src/rocshmem.cpp
@@ -225,7 +225,7 @@ static void setFilesLimit() {
   init_constant_memory();
 }
 
-[[maybe_unused]] __host__ static void inline library_init_subcomm(TcpBootstrap *bootstrap, int nranks, int rank) {
+[[maybe_unused]] __host__ static void inline library_init_subcomm([[maybe_unused]] TcpBootstrap *bootstrap, int nranks, int rank) {
   int initialized;
   int world_size = -1;
 

--- a/projects/rocshmem/src/rocshmem.cpp
+++ b/projects/rocshmem/src/rocshmem.cpp
@@ -88,7 +88,7 @@ BackendType get_backend_type() { return backend->get_backend_type(); }
 
 #if defined(USE_GDA) && defined(USE_RO) && defined(USE_IPC)
 static BackendType select_backend_type(MPI_Comm comm, TcpBootstrap *bootstrap) {
-  BackendType type;
+  [[maybe_unused]] BackendType type;
 
   /* Check whether the user explicitely requests a particular backend type */
   std::string envstr = envvar::backend;

--- a/projects/rocshmem/src/rocshmem.cpp
+++ b/projects/rocshmem/src/rocshmem.cpp
@@ -88,7 +88,6 @@ BackendType get_backend_type() { return backend->get_backend_type(); }
 
 #if defined(USE_GDA) && defined(USE_RO) && defined(USE_IPC)
 static BackendType select_backend_type(MPI_Comm comm, TcpBootstrap *bootstrap) {
-  [[maybe_unused]] BackendType type;
 
   /* Check whether the user explicitely requests a particular backend type */
   std::string envstr = envvar::backend;

--- a/projects/rocshmem/src/rocshmem_gpu.cpp
+++ b/projects/rocshmem/src/rocshmem_gpu.cpp
@@ -596,7 +596,7 @@ __device__ void rocshmem_ctx_pe_quiet(rocshmem_ctx_t ctx, const int *target_pes,
 
   ContextTy *internal_ctx = get_internal_ctx(ctx);
 
-  for (int i = 0; i < npes;  i++) {
+  for (size_t i = 0; i < npes;  i++) {
     internal_ctx->pe_quiet(translate_pe(ctx, target_pes[i]));
   }
 }

--- a/projects/rocshmem/src/team.cpp
+++ b/projects/rocshmem/src/team.cpp
@@ -82,8 +82,8 @@ __host__ Team::Team(Backend* handle, TeamInfo* team_info_wrt_parent,
                     MPI_Comm _mpi_comm)
     : world_size(handle->getNumPEs()),
       my_pe_in_world(handle->getMyPE()),
-      tinfo_wrt_parent(team_info_wrt_parent),
       tinfo_wrt_world(team_info_wrt_world),
+      tinfo_wrt_parent(team_info_wrt_parent),
       num_pes(_num_pes),
       my_pe(_my_pe) {
   if (_mpi_comm != MPI_COMM_NULL) {

--- a/projects/rocshmem/src/tools/rocshmem_info.cpp
+++ b/projects/rocshmem/src/tools/rocshmem_info.cpp
@@ -145,7 +145,7 @@ void print_rocm_info() {
   PRINT_ENTRY("ROCm", rocm_version);
 }
 
-int main (int argc, char **argv) {
+int main ([[maybe_unused]] int argc, [[maybe_unused]] char **argv) {
 
   printf("################################################################################\n");
   printf("#                                rocSHMEM Info                                 #\n");

--- a/projects/rocshmem/tests/functional_tests/amo_bitwise_tester.cpp
+++ b/projects/rocshmem/tests/functional_tests/amo_bitwise_tester.cpp
@@ -31,10 +31,10 @@ using namespace rocshmem;
 
 /* Declare the global kernel template with a generic implementation */
 template <typename T>
-__global__ void AMOBitwiseTest(int loop, int skip, long long int *start_time,
-                               long long int *end_time, T *dest, T *ret_val,
-                               AddrMode addr_mode, TestType type,
-                               ShmemContextType ctx_type) {
+__global__ void AMOBitwiseTest([[maybe_unused]] int loop, [[maybe_unused]] int skip, [[maybe_unused]] long long int *start_time,
+                               [[maybe_unused]] long long int *end_time, [[maybe_unused]] T *dest, [[maybe_unused]] T *ret_val,
+                               [[maybe_unused]] AddrMode addr_mode, [[maybe_unused]] TestType type,
+                               [[maybe_unused]] ShmemContextType ctx_type) {
   return;
 }
 
@@ -77,14 +77,14 @@ AMOBitwiseTester<T>::~AMOBitwiseTester() {
 }
 
 template <typename T>
-void AMOBitwiseTester<T>::resetBuffers(size_t size) {
+void AMOBitwiseTester<T>::resetBuffers([[maybe_unused]] size_t size) {
   memset(ret_val, 0, max_msg_size * n_in  * n_loops);
   memset(dest,    0, max_msg_size * n_out * n_loops);
 }
 
 template <typename T>
-void AMOBitwiseTester<T>::launchKernel(dim3 gridsize, dim3 blocksize, int loop,
-                                       size_t size) {
+void AMOBitwiseTester<T>::launchKernel(dim3 gridsize, dim3 blocksize, [[maybe_unused]] int loop,
+                                       [[maybe_unused]] size_t size) {
   size_t shared_bytes = 0;
 
   hipLaunchKernelGGL(AMOBitwiseTest, gridsize, blocksize, shared_bytes, stream,
@@ -234,7 +234,7 @@ void AMOBitwiseTester<T>::verifyReturnValues() {
 }
 
 template <typename T>
-void AMOBitwiseTester<T>::verifyResults(size_t size) {
+void AMOBitwiseTester<T>::verifyResults([[maybe_unused]] size_t size) {
   // PE 0 checks returns; target PE checks dest.
   if (args.myid) {
     verifyDestValues();

--- a/projects/rocshmem/tests/functional_tests/amo_extended_tester.cpp
+++ b/projects/rocshmem/tests/functional_tests/amo_extended_tester.cpp
@@ -31,10 +31,10 @@ using namespace rocshmem;
 
 /* Declare the global kernel template with a generic implementation */
 template <typename T>
-__global__ void AMOExtendedTest(int loop, int skip, long long int *start_time,
-                                long long int *end_time, T *dest, T *ret_val,
-                                AddrMode addr_mode, TestType type,
-                                ShmemContextType ctx_type) {
+__global__ void AMOExtendedTest([[maybe_unused]] int loop, [[maybe_unused]] int skip, [[maybe_unused]] long long int *start_time,
+                                [[maybe_unused]] long long int *end_time, [[maybe_unused]] T *dest, [[maybe_unused]] T *ret_val,
+                                [[maybe_unused]] AddrMode addr_mode, [[maybe_unused]] TestType type,
+                                [[maybe_unused]] ShmemContextType ctx_type) {
   return;
 }
 
@@ -77,14 +77,14 @@ AMOExtendedTester<T>::~AMOExtendedTester() {
 }
 
 template <typename T>
-void AMOExtendedTester<T>::resetBuffers(size_t size) {
+void AMOExtendedTester<T>::resetBuffers([[maybe_unused]] size_t size) {
   memset(ret_val, 0, max_msg_size * n_in  * n_loops);
   memset(dest,    0, max_msg_size * n_out * n_loops);
 }
 
 template <typename T>
-void AMOExtendedTester<T>::launchKernel(dim3 gridsize, dim3 blocksize, int loop,
-                                        size_t size) {
+void AMOExtendedTester<T>::launchKernel(dim3 gridsize, dim3 blocksize, [[maybe_unused]] int loop,
+                                        [[maybe_unused]] size_t size) {
   size_t shared_bytes = 0;
 
   hipLaunchKernelGGL(AMOExtendedTest, gridsize, blocksize, shared_bytes, stream,

--- a/projects/rocshmem/tests/functional_tests/amo_standard_tester.cpp
+++ b/projects/rocshmem/tests/functional_tests/amo_standard_tester.cpp
@@ -32,10 +32,10 @@ using namespace rocshmem;
 
 /* Declare the global kernel template with a generic implementation */
 template <typename T>
-__global__ void AMOStandardTest(int loop, int skip, long long int *start_time,
-                                long long int *end_time, T *dest,
-                                T *ret_val, AddrMode addr_mode,
-                                TestType type, ShmemContextType ctx_type) {
+__global__ void AMOStandardTest([[maybe_unused]] int loop, [[maybe_unused]] int skip, [[maybe_unused]] long long int *start_time,
+                                [[maybe_unused]] long long int *end_time, [[maybe_unused]] T *dest,
+                                [[maybe_unused]] T *ret_val, [[maybe_unused]] AddrMode addr_mode,
+                                [[maybe_unused]] TestType type, [[maybe_unused]] ShmemContextType ctx_type) {
   return;
 }
 
@@ -78,14 +78,14 @@ AMOStandardTester<T>::~AMOStandardTester() {
 }
 
 template <typename T>
-void AMOStandardTester<T>::resetBuffers(size_t size) {
+void AMOStandardTester<T>::resetBuffers([[maybe_unused]] size_t size) {
   memset(ret_val, 0, max_msg_size * n_in  * n_loops);
   memset(dest,    0, max_msg_size * n_out * n_loops);
 }
 
 template <typename T>
-void AMOStandardTester<T>::launchKernel(dim3 gridsize, dim3 blocksize, int loop,
-                                        size_t size) {
+void AMOStandardTester<T>::launchKernel(dim3 gridsize, dim3 blocksize, [[maybe_unused]] int loop,
+                                        [[maybe_unused]] size_t size) {
   size_t shared_bytes = 0;
 
   hipLaunchKernelGGL(AMOStandardTest, gridsize, blocksize, shared_bytes, stream,
@@ -239,7 +239,7 @@ void AMOStandardTester<T>::verifyReturnValues() {
 }
 
 template <typename T>
-void AMOStandardTester<T>::verifyResults(size_t size) {
+void AMOStandardTester<T>::verifyResults([[maybe_unused]] size_t size) {
   // PE 0 checks returns; target PE checks dest.
   if (args.myid) {
     verifyDestValues();

--- a/projects/rocshmem/tests/functional_tests/barrier_all_on_stream_tester.cpp
+++ b/projects/rocshmem/tests/functional_tests/barrier_all_on_stream_tester.cpp
@@ -91,7 +91,7 @@ void BarrierAllOnStreamTester::postLaunchKernel() {
   }
 
   // Get elapsed time for each stream from HIP events
-  for (int stream_id = 0; stream_id < num_streams && stream_id < num_timers;
+  for (uint32_t stream_id = 0; stream_id < static_cast<uint32_t>(num_streams) && stream_id < static_cast<uint32_t>(num_timers);
        stream_id++) {
     float elapsed_time_ms = 0.0f;
     CHECK_HIP(hipEventElapsedTime(&elapsed_time_ms,
@@ -109,16 +109,16 @@ void BarrierAllOnStreamTester::postLaunchKernel() {
   }
 
   // Fill remaining timers with zero if num_timers > num_streams
-  for (int i = num_streams; i < num_timers; i++) {
+  for (uint32_t i = num_streams; i < static_cast<uint32_t>(num_timers); i++) {
     start_time[i] = 0;
     end_time[i] = 0;
   }
 }
 
-void BarrierAllOnStreamTester::resetBuffers(size_t size) {}
+void BarrierAllOnStreamTester::resetBuffers([[maybe_unused]] size_t size) {}
 
-void BarrierAllOnStreamTester::launchKernel(dim3 gridSize, dim3 blockSize,
-                                            int loop, size_t size) {
+void BarrierAllOnStreamTester::launchKernel([[maybe_unused]] dim3 gridSize, [[maybe_unused]] dim3 blockSize,
+                                            int loop, [[maybe_unused]] size_t size) {
   // Execute warmup iterations (skip)
   for (int i = 0; i < args.skip; i++) {
     for (int stream_id = 0; stream_id < num_streams; stream_id++) {
@@ -148,4 +148,4 @@ void BarrierAllOnStreamTester::launchKernel(dim3 gridSize, dim3 blockSize,
   num_timed_msgs = loop * num_streams;
 }
 
-void BarrierAllOnStreamTester::verifyResults(size_t size) {}
+void BarrierAllOnStreamTester::verifyResults([[maybe_unused]] size_t size) {}

--- a/projects/rocshmem/tests/functional_tests/barrier_all_tester.cpp
+++ b/projects/rocshmem/tests/functional_tests/barrier_all_tester.cpp
@@ -34,7 +34,7 @@ using namespace rocshmem;
 __global__ void BarrierAllTest(int loop, int skip, long long int *start_time,
                                long long int *end_time, TestType type,
                                int wf_size) {
-  __shared__ rocshmem_ctx_t ctx;
+  [[maybe_unused]] __shared__ rocshmem_ctx_t ctx;
   int t_id  = get_flat_block_id();
   int wg_id = get_flat_grid_id();
   int wf_id = t_id / wf_size;

--- a/projects/rocshmem/tests/functional_tests/barrier_all_tester.cpp
+++ b/projects/rocshmem/tests/functional_tests/barrier_all_tester.cpp
@@ -93,7 +93,7 @@ BarrierAllTester::BarrierAllTester(TesterArguments args) : Tester(args) {}
 BarrierAllTester::~BarrierAllTester() {}
 
 void BarrierAllTester::launchKernel(dim3 gridSize, dim3 blockSize, int loop,
-                                    size_t size) {
+                                    [[maybe_unused]] size_t size) {
   size_t shared_bytes = 0;
 
   hipLaunchKernelGGL(BarrierAllTest, gridSize, blockSize, shared_bytes, stream,
@@ -103,6 +103,6 @@ void BarrierAllTester::launchKernel(dim3 gridSize, dim3 blockSize, int loop,
   num_timed_msgs = loop;
 }
 
-void BarrierAllTester::resetBuffers(size_t size) {}
+void BarrierAllTester::resetBuffers([[maybe_unused]] size_t size) {}
 
-void BarrierAllTester::verifyResults(size_t size) {}
+void BarrierAllTester::verifyResults([[maybe_unused]] size_t size) {}

--- a/projects/rocshmem/tests/functional_tests/default_ctx_primitive_tester.cpp
+++ b/projects/rocshmem/tests/functional_tests/default_ctx_primitive_tester.cpp
@@ -35,11 +35,11 @@
                                long long int *start_time,
                                long long int *end_time, char *source,
                                char *dest, size_t size, TestType type,
-                               ShmemContextType ctx_type, int wf_size) {
+                               [[maybe_unused]] ShmemContextType ctx_type, int wf_size) {
    int wg_id = get_flat_grid_id();
    int t_id  = get_flat_block_id();
    int wf_id = t_id / wf_size;
- 
+
    /**
     * Shared array to capture the start time for each wavefront
    * Max threads per block = 1024, wavefront size = 64 or 32 depending
@@ -82,13 +82,13 @@
          rocshmem_putmem_nbi(dest, source, size, 1);
          break;
        case DefaultCTXPTestType:
-         for (int s = 0; s < size; s++) {
+         for (size_t s = 0; s < size; s++) {
            char val = source[s];
            rocshmem_char_p(&dest[s], val, 1);
          }
          break;
        case DefaultCTXGTestType:
-         for (int s = 0; s < size; s++) {
+         for (size_t s = 0; s < size; s++) {
            char ret = rocshmem_char_g(&source[s], 1);
            dest[s] = ret;
          }

--- a/projects/rocshmem/tests/functional_tests/empty_tester.cpp
+++ b/projects/rocshmem/tests/functional_tests/empty_tester.cpp
@@ -31,8 +31,8 @@ using namespace rocshmem;
 /******************************************************************************
  * DEVICE TEST KERNEL
  *****************************************************************************/
-__global__ void EmptyTest(int loop, int skip, long long int *start_time,
-                          long long int *end_time, int size, TestType type,
+__global__ void EmptyTest([[maybe_unused]] int loop, [[maybe_unused]] int skip, [[maybe_unused]] long long int *start_time,
+                          [[maybe_unused]] long long int *end_time, [[maybe_unused]] int size, [[maybe_unused]] TestType type,
                           ShmemContextType ctx_type) {
   __shared__ rocshmem_ctx_t ctx;
   rocshmem_wg_ctx_create(ctx_type, &ctx);
@@ -47,7 +47,7 @@ EmptyTester::EmptyTester(TesterArguments args) : Tester(args) {}
 
 EmptyTester::~EmptyTester() {}
 
-void EmptyTester::resetBuffers(size_t size) {}
+void EmptyTester::resetBuffers([[maybe_unused]] size_t size) {}
 
 void EmptyTester::launchKernel(dim3 gridSize, dim3 blockSize, int loop,
                                size_t size) {
@@ -58,4 +58,4 @@ void EmptyTester::launchKernel(dim3 gridSize, dim3 blockSize, int loop,
                      _shmem_context);
 }
 
-void EmptyTester::verifyResults(size_t size) {}
+void EmptyTester::verifyResults([[maybe_unused]] size_t size) {}

--- a/projects/rocshmem/tests/functional_tests/flood_amo_tester.cpp
+++ b/projects/rocshmem/tests/functional_tests/flood_amo_tester.cpp
@@ -68,7 +68,7 @@ __global__ void FloodAmoTest(int loop, int skip, long long int *start_time,
       // shuffle ordering so that threads in the wave put to a
       // different pe 'simultaneously'
       auto pe = (t_id + j) % num_pe;
-      uint64_t ret{0};
+      [[maybe_unused]] uint64_t ret{0};
       switch (type) {
       case FloodWaitAmoTestType:
       case FloodAddTestType:

--- a/projects/rocshmem/tests/functional_tests/flood_amo_tester.cpp
+++ b/projects/rocshmem/tests/functional_tests/flood_amo_tester.cpp
@@ -192,7 +192,7 @@ FloodAmoTester::FloodAmoTester(TesterArguments args) : Tester(args) {
   const int max_sustainable_wgs = max_co_resident_wgs_per_cu * num_cus;
 
   // Print warning if num_wgs exceeds max co-resident work-groups
-  if (args.num_wgs > max_sustainable_wgs) {
+  if (static_cast<unsigned int>(args.num_wgs) > static_cast<unsigned int>(max_sustainable_wgs)) {
     std::cout << "Warning: Number of work-groups (" << args.num_wgs
               << ") exceeds max sustainable work-groups ("
               << max_sustainable_wgs << ")." << std::endl;
@@ -204,13 +204,13 @@ FloodAmoTester::~FloodAmoTester() {
   CHECK_HIP(hipFree(grid_psync));
 }
 
-void FloodAmoTester::resetBuffers(size_t size) {
+void FloodAmoTester::resetBuffers([[maybe_unused]] size_t size) {
   CHECK_HIP(hipMemset(s_buf, 0, sizeof(uint64_t) * args.num_wgs));
   CHECK_HIP(hipMemset(grid_psync, 0, 4 * sizeof(int)));
 }
 
 void FloodAmoTester::launchKernel(dim3 gridSize, dim3 blockSize, int loop,
-                                size_t size) {
+                                [[maybe_unused]] size_t size) {
   size_t shared_bytes = 0;
   int num_pes {rocshmem_n_pes()};
 
@@ -222,7 +222,7 @@ void FloodAmoTester::launchKernel(dim3 gridSize, dim3 blockSize, int loop,
   num_timed_msgs = loop * gridSize.x * blockSize.x * num_pes;
 }
 
-void FloodAmoTester::verifyResults(size_t size) {
+void FloodAmoTester::verifyResults([[maybe_unused]] size_t size) {
   int num_pes {rocshmem_n_pes()};
 
   assert(size == sizeof(uint64_t));
@@ -230,7 +230,7 @@ void FloodAmoTester::verifyResults(size_t size) {
   if (*verification_error) {
     std::cerr << "Data validation error (found by device kernel)" << std::endl;
     uint64_t expected = static_cast<uint64_t>(args.loop + args.skip) * num_pes * (args.wg_size * (args.wg_size+1)) / 2;
-    for(auto wg = 0; wg < args.num_wgs; wg++) {
+    for(unsigned int wg = 0; wg < static_cast<unsigned int>(args.num_wgs); wg++) {
       if (expected != s_buf[wg]) {
         std::cerr << "Data validation error for wg " << wg << std::endl;
         std::cerr << " Got " << s_buf[wg]

--- a/projects/rocshmem/tests/functional_tests/flood_tester.cpp
+++ b/projects/rocshmem/tests/functional_tests/flood_tester.cpp
@@ -183,9 +183,8 @@ void FloodTester::launchKernel(dim3 gridSize, dim3 blockSize, int loop,
 
 void FloodTester::verifyResults([[maybe_unused]] size_t size) {
   int num_pes {rocshmem_n_pes()};
-  [[maybe_unused]] int my_pe {rocshmem_my_pe()};
 
-  if (num_pes > (1<<20) || args.num_wgs > (1U<<31) || args.wg_size > (1<<12)) {
+  if (num_pes > (1<<20) || args.num_wgs > (1U<<31) || args.wg_size > (1U<<12)) {
     // can't check
     return;
   }

--- a/projects/rocshmem/tests/functional_tests/flood_tester.cpp
+++ b/projects/rocshmem/tests/functional_tests/flood_tester.cpp
@@ -125,7 +125,7 @@ static __global__ void verify_results_kernel(uint64_t *dest, size_t buf_size,
   int num_pe {rocshmem_n_pes()};
   int num_wg {get_grid_num_blocks()};
   int num_th {get_flat_block_size()};
-  int my_pe {rocshmem_my_pe()};
+  [[maybe_unused]] int my_pe {rocshmem_my_pe()};
   int wg_id {get_flat_grid_id()};
   int t_id {get_flat_block_id()};
 
@@ -183,7 +183,7 @@ void FloodTester::launchKernel(dim3 gridSize, dim3 blockSize, int loop,
 
 void FloodTester::verifyResults(size_t size) {
   int num_pes {rocshmem_n_pes()};
-  int my_pe {rocshmem_my_pe()};
+  [[maybe_unused]] int my_pe {rocshmem_my_pe()};
 
   if (num_pes > 1<<20 || args.num_wgs > 1<<31 || args.wg_size > 1<<12) {
     // can't check

--- a/projects/rocshmem/tests/functional_tests/flood_tester.cpp
+++ b/projects/rocshmem/tests/functional_tests/flood_tester.cpp
@@ -120,7 +120,7 @@ __global__ void FloodTest(int loop, int skip, long long int *start_time,
   rocshmem_wg_ctx_destroy(&ctx);
 }
 
-static __global__ void verify_results_kernel(uint64_t *dest, size_t buf_size,
+static __global__ void verify_results_kernel(uint64_t *dest, [[maybe_unused]] size_t buf_size,
                                              bool *verification_error) {
   int num_pe {rocshmem_n_pes()};
   int num_wg {get_grid_num_blocks()};
@@ -138,7 +138,7 @@ static __global__ void verify_results_kernel(uint64_t *dest, size_t buf_size,
     auto v_wg = (value>>12) & 0xffff'ffff;
     auto v_pe = (value>>44);
 
-    if (v_th != t_id || v_wg != wg_id || v_pe != pe) {
+    if (v_th != static_cast<uint64_t>(t_id) || v_wg != static_cast<uint64_t>(wg_id) || v_pe != static_cast<uint64_t>(pe)) {
       *verification_error = true;
     }
   }
@@ -151,7 +151,7 @@ FloodTester::FloodTester(TesterArguments args) : Tester(args) {
   int num_pes {rocshmem_n_pes()};
   int my_pe {rocshmem_my_pe()};
   s_buf = (uint64_t*)rocshmem_malloc(sizeof(uint64_t) * args.num_wgs * args.wg_size);
-  for(int wg = 0; wg < args.num_wgs; wg++) for(int th = 0; th < args.wg_size; th++) {
+  for(unsigned int wg = 0; wg < args.num_wgs; wg++) for(unsigned int th = 0; th < static_cast<unsigned int>(args.wg_size); th++) {
     s_buf[wg * args.wg_size + th] = (((uint64_t)my_pe)<<44) + (wg<<12) + th; // set value for verification
   }
   r_buf = (uint64_t*)rocshmem_malloc(sizeof(uint64_t) * args.num_wgs * args.wg_size * num_pes);
@@ -162,13 +162,13 @@ FloodTester::~FloodTester() {
   rocshmem_free(r_buf);
 }
 
-void FloodTester::resetBuffers(size_t size) {
+void FloodTester::resetBuffers([[maybe_unused]] size_t size) {
   int num_pes {rocshmem_n_pes()};
   memset(r_buf, 0, sizeof(uint64_t) * args.num_wgs * args.wg_size * num_pes);
 }
 
 void FloodTester::launchKernel(dim3 gridSize, dim3 blockSize, int loop,
-                                size_t size) {
+                                [[maybe_unused]] size_t size) {
   size_t shared_bytes = 0;
   int num_pes {rocshmem_n_pes()};
 
@@ -181,11 +181,11 @@ void FloodTester::launchKernel(dim3 gridSize, dim3 blockSize, int loop,
   num_timed_msgs = loop * gridSize.x * blockSize.x * num_pes;
 }
 
-void FloodTester::verifyResults(size_t size) {
+void FloodTester::verifyResults([[maybe_unused]] size_t size) {
   int num_pes {rocshmem_n_pes()};
   [[maybe_unused]] int my_pe {rocshmem_my_pe()};
 
-  if (num_pes > 1<<20 || args.num_wgs > 1<<31 || args.wg_size > 1<<12) {
+  if (num_pes > (1<<20) || args.num_wgs > (1U<<31) || args.wg_size > (1<<12)) {
     // can't check
     return;
   }
@@ -197,15 +197,15 @@ void FloodTester::verifyResults(size_t size) {
 
   if (*verification_error) {
     for(auto pe = 0; pe < num_pes; pe++)
-      for(auto wg = 0; wg < args.num_wgs; wg++)
-        for(auto th = 0; th < args.wg_size; th++) {
+      for(unsigned int wg = 0; wg < static_cast<unsigned int>(args.num_wgs); wg++)
+        for(unsigned int th = 0; th < static_cast<unsigned int>(args.wg_size); th++) {
       auto t_offset {wg * args.wg_size + th};
       auto dst_offset {pe * args.num_wgs * args.wg_size + t_offset};
       auto value = r_buf[dst_offset];
       auto v_th = value & 0x0fff;
       auto v_wg = (value>>12) & 0xffff'ffff;
       auto v_pe = (value>>44);
-      if (v_th != th || v_wg != wg || v_pe != pe) {
+      if (v_th != static_cast<uint64_t>(th) || v_wg != static_cast<uint64_t>(wg) || v_pe != static_cast<uint64_t>(pe)) {
         std::cerr << "Data validation error at idx " << dst_offset << std::endl;
         std::cerr << " Got " << v_pe << ":" << v_wg << ":" << v_th
                   << ", Expected " << pe << ":" << wg << ":" << th << std::endl;

--- a/projects/rocshmem/tests/functional_tests/getmem_on_stream_tester.cpp
+++ b/projects/rocshmem/tests/functional_tests/getmem_on_stream_tester.cpp
@@ -102,7 +102,7 @@ void GetmemOnStreamTester::postLaunchKernel() {
   }
 
   // Get elapsed time for each stream from HIP events
-  for (int stream_id = 0; stream_id < num_streams && stream_id < num_timers;
+  for (uint32_t stream_id = 0; stream_id < static_cast<uint32_t>(num_streams) && stream_id < static_cast<uint32_t>(num_timers);
        stream_id++) {
     float elapsed_time_ms = 0.0f;
     CHECK_HIP(hipEventElapsedTime(&elapsed_time_ms,
@@ -120,7 +120,7 @@ void GetmemOnStreamTester::postLaunchKernel() {
   }
 
   // Fill remaining timers with zero if num_timers > num_streams
-  for (int i = num_streams; i < num_timers; i++) {
+  for (uint32_t i = num_streams; i < static_cast<uint32_t>(num_timers); i++) {
     start_time[i] = 0;
     end_time[i] = 0;
   }
@@ -140,7 +140,7 @@ void GetmemOnStreamTester::resetBuffers(size_t size) {
   std::memset(dest_buf, 0, buf_size);
 }
 
-void GetmemOnStreamTester::launchKernel(dim3 gridSize, dim3 blockSize,
+void GetmemOnStreamTester::launchKernel([[maybe_unused]] dim3 gridSize, [[maybe_unused]] dim3 blockSize,
                                         int loop, size_t size) {
   // Execute warmup iterations (skip)
   for (int i = 0; i < args.skip; i++) {

--- a/projects/rocshmem/tests/functional_tests/hipmodule_init_tester.cpp
+++ b/projects/rocshmem/tests/functional_tests/hipmodule_init_tester.cpp
@@ -157,7 +157,7 @@ HipModuleInitTester::~HipModuleInitTester() {
   }
 }
 
-void HipModuleInitTester::resetBuffers(size_t size) {
+void HipModuleInitTester::resetBuffers([[maybe_unused]] size_t size) {
   // Reset device result to 0
   CHECK_HIP(hipMemset(device_result, 0, sizeof(int)));
 }

--- a/projects/rocshmem/tests/functional_tests/ping_all_tester.cpp
+++ b/projects/rocshmem/tests/functional_tests/ping_all_tester.cpp
@@ -75,13 +75,13 @@ PingAllTester::PingAllTester(TesterArguments args) : Tester(args) {
 
 PingAllTester::~PingAllTester() { rocshmem_free(r_buf); }
 
-void PingAllTester::resetBuffers(size_t size) {
+void PingAllTester::resetBuffers([[maybe_unused]] size_t size) {
   int num_pes {rocshmem_n_pes()};
   memset(r_buf, 0, sizeof(int) * args.num_wgs * num_pes);
 }
 
 void PingAllTester::launchKernel(dim3 gridSize, dim3 blockSize, int loop,
-                                  size_t size) {
+                                  [[maybe_unused]] size_t size) {
   size_t shared_bytes = 0;
 
   hipLaunchKernelGGL(PingAllTest, gridSize, blockSize, shared_bytes, stream,
@@ -92,4 +92,4 @@ void PingAllTester::launchKernel(dim3 gridSize, dim3 blockSize, int loop,
   num_timed_msgs = loop;
 }
 
-void PingAllTester::verifyResults(size_t size) {}
+void PingAllTester::verifyResults([[maybe_unused]] size_t size) {}

--- a/projects/rocshmem/tests/functional_tests/ping_pong_tester.cpp
+++ b/projects/rocshmem/tests/functional_tests/ping_pong_tester.cpp
@@ -76,12 +76,12 @@ PingPongTester::PingPongTester(TesterArguments args) : Tester(args) {
 
 PingPongTester::~PingPongTester() { rocshmem_free(r_buf); }
 
-void PingPongTester::resetBuffers(size_t size) {
+void PingPongTester::resetBuffers([[maybe_unused]] size_t size) {
   memset(r_buf, 0, sizeof(int) * args.num_wgs);
 }
 
 void PingPongTester::launchKernel(dim3 gridSize, dim3 blockSize, int loop,
-                                  size_t size) {
+                                  [[maybe_unused]] size_t size) {
   size_t shared_bytes = 0;
 
   hipLaunchKernelGGL(PingPongTest, gridSize, blockSize, shared_bytes, stream,
@@ -92,4 +92,4 @@ void PingPongTester::launchKernel(dim3 gridSize, dim3 blockSize, int loop,
   num_timed_msgs = loop;
 }
 
-void PingPongTester::verifyResults(size_t size) {}
+void PingPongTester::verifyResults([[maybe_unused]] size_t size) {}

--- a/projects/rocshmem/tests/functional_tests/primitive_mr_tester.cpp
+++ b/projects/rocshmem/tests/functional_tests/primitive_mr_tester.cpp
@@ -71,7 +71,7 @@ PrimitiveMRTester::~PrimitiveMRTester() {
   rocshmem_free(r_buf);
 }
 
-void PrimitiveMRTester::resetBuffers(size_t size) {
+void PrimitiveMRTester::resetBuffers([[maybe_unused]] size_t size) {
   memset(s_buf, '0', max_msg_size * args.wg_size);
   memset(r_buf, '1', max_msg_size * args.wg_size);
 }

--- a/projects/rocshmem/tests/functional_tests/putmem_on_stream_tester.cpp
+++ b/projects/rocshmem/tests/functional_tests/putmem_on_stream_tester.cpp
@@ -118,7 +118,7 @@ void PutmemOnStreamTester::postLaunchKernel() {
   }
 
   // Get elapsed time for each stream from HIP events
-  for (int stream_id = 0; stream_id < num_streams && stream_id < num_timers;
+  for (uint32_t stream_id = 0; stream_id < static_cast<uint32_t>(num_streams) && stream_id < static_cast<uint32_t>(num_timers);
        stream_id++) {
     float elapsed_time_ms = 0.0f;
     CHECK_HIP(hipEventElapsedTime(&elapsed_time_ms,
@@ -136,7 +136,7 @@ void PutmemOnStreamTester::postLaunchKernel() {
   }
 
   // Fill remaining timers with zero if num_timers > num_streams
-  for (int i = num_streams; i < num_timers; i++) {
+  for (uint32_t i = num_streams; i < static_cast<uint32_t>(num_timers); i++) {
     start_time[i] = 0;
     end_time[i] = 0;
   }
@@ -156,7 +156,7 @@ void PutmemOnStreamTester::resetBuffers(size_t size) {
   std::memset(dest_buf, 0, buf_size);
 }
 
-void PutmemOnStreamTester::launchKernel(dim3 gridSize, dim3 blockSize,
+void PutmemOnStreamTester::launchKernel([[maybe_unused]] dim3 gridSize, [[maybe_unused]] dim3 blockSize,
                                         int loop, size_t size) {
   // Execute warmup iterations (skip)
   for (int i = 0; i < args.skip; i++) {

--- a/projects/rocshmem/tests/functional_tests/putmem_signal_on_stream_tester.cpp
+++ b/projects/rocshmem/tests/functional_tests/putmem_signal_on_stream_tester.cpp
@@ -104,7 +104,7 @@ void PutmemSignalOnStreamTester::postLaunchKernel() {
   }
 
   // Get elapsed time for each stream from HIP events
-  for (int stream_id = 0; stream_id < num_streams && stream_id < num_timers;
+  for (uint32_t stream_id = 0; stream_id < static_cast<uint32_t>(num_streams) && stream_id < static_cast<uint32_t>(num_timers);
        stream_id++) {
     float elapsed_time_ms = 0.0f;
     CHECK_HIP(hipEventElapsedTime(&elapsed_time_ms,
@@ -122,7 +122,7 @@ void PutmemSignalOnStreamTester::postLaunchKernel() {
   }
 
   // Fill remaining timers with zero if num_timers > num_streams
-  for (int i = num_streams; i < num_timers; i++) {
+  for (uint32_t i = num_streams; i < static_cast<uint32_t>(num_timers); i++) {
     start_time[i] = 0;
     end_time[i] = 0;
   }
@@ -145,7 +145,7 @@ void PutmemSignalOnStreamTester::resetBuffers(size_t size) {
   std::memset(sig_addr, 0, num_streams * sizeof(uint64_t));
 }
 
-void PutmemSignalOnStreamTester::launchKernel(dim3 gridSize, dim3 blockSize,
+void PutmemSignalOnStreamTester::launchKernel([[maybe_unused]] dim3 gridSize, [[maybe_unused]] dim3 blockSize,
                                                int loop, size_t size) {
   uint64_t signal_value = 1;
 

--- a/projects/rocshmem/tests/functional_tests/random_access_tester.cpp
+++ b/projects/rocshmem/tests/functional_tests/random_access_tester.cpp
@@ -64,7 +64,7 @@ __global__ void RandomAccessTest(int loop, int skip, long long int *start_time,
   int wg_id = get_flat_grid_id();
   rocshmem_wg_ctx_create(ctx_type, &ctx);
 
-  int pe = rocshmem_ctx_my_pe(ctx);
+  [[maybe_unused]] int pe = rocshmem_ctx_my_pe(ctx);
   size_t offset;
   int PE;
 

--- a/projects/rocshmem/tests/functional_tests/random_access_tester.cpp
+++ b/projects/rocshmem/tests/functional_tests/random_access_tester.cpp
@@ -57,7 +57,7 @@ __device__ bool thread_passing(int num_bins, uint32_t *bin_threads,
 __global__ void RandomAccessTest(int loop, int skip, long long int *start_time,
                                  long long int *end_time, int *s_buf,
                                  int *r_buf, size_t size, OpType type,
-                                 int coal_coef, int num_bins, int num_waves,
+                                 int coal_coef, int num_bins, [[maybe_unused]] int num_waves,
                                  uint32_t *threads_bins, uint32_t *off_bins,
                                  uint32_t *PE_bins, ShmemContextType ctx_type) {
   __shared__ rocshmem_ctx_t ctx;
@@ -165,7 +165,7 @@ RandomAccessTester::~RandomAccessTester() {
   CHECK_HIP(hipFree(_PE_bins));
 }
 
-void RandomAccessTester::resetBuffers(size_t size) {
+void RandomAccessTester::resetBuffers([[maybe_unused]] size_t size) {
   for (size_t i = 0; i < max_msg_size / sizeof(int) * args.wg_size * space;
        i++) {
     s_buf[i] = 1;

--- a/projects/rocshmem/tests/functional_tests/shmem_ptr_tester.cpp
+++ b/projects/rocshmem/tests/functional_tests/shmem_ptr_tester.cpp
@@ -135,14 +135,14 @@ ShmemPtrTester::~ShmemPtrTester() {
   rocshmem_free(dest);
 }
 
-void ShmemPtrTester::resetBuffers(size_t size) {
+void ShmemPtrTester::resetBuffers([[maybe_unused]] size_t size) {
   size_t buff_size = args.wg_size * args.num_wgs + sizeof(int);
   memset(dest, '0', buff_size);
   memset(_available, 0, sizeof(int));
 }
 
 void ShmemPtrTester::launchKernel(dim3 gridSize, dim3 blockSize, int loop,
-                                  size_t size) {
+                                  [[maybe_unused]] size_t size) {
   size_t shared_bytes = 0;
 
   hipLaunchKernelGGL(ShmemPtrTest, gridSize, blockSize, shared_bytes,
@@ -153,7 +153,7 @@ void ShmemPtrTester::launchKernel(dim3 gridSize, dim3 blockSize, int loop,
   num_timed_msgs = loop * gridSize.x * blockSize.x;
 }
 
-void ShmemPtrTester::verifyResults(size_t size) {
+void ShmemPtrTester::verifyResults([[maybe_unused]] size_t size) {
   if (args.myid == 0) {
     if (*_available == 0) {
       _print_results = false;

--- a/projects/rocshmem/tests/functional_tests/signal_wait_until_on_stream_tester.cpp
+++ b/projects/rocshmem/tests/functional_tests/signal_wait_until_on_stream_tester.cpp
@@ -92,7 +92,7 @@ void SignalWaitUntilOnStreamTester::postLaunchKernel() {
   }
 
   // Get elapsed time for each stream from HIP events
-  for (int stream_id = 0; stream_id < num_streams && stream_id < num_timers;
+  for (uint32_t stream_id = 0; stream_id < static_cast<uint32_t>(num_streams) && stream_id < static_cast<uint32_t>(num_timers);
        stream_id++) {
     float elapsed_time_ms = 0.0f;
     CHECK_HIP(hipEventElapsedTime(&elapsed_time_ms,
@@ -109,19 +109,19 @@ void SignalWaitUntilOnStreamTester::postLaunchKernel() {
   }
 
   // Fill remaining timers with zero if num_timers > num_streams
-  for (int i = num_streams; i < num_timers; i++) {
+  for (uint32_t i = num_streams; i < static_cast<uint32_t>(num_timers); i++) {
     start_time[i] = 0;
     end_time[i] = 0;
   }
 }
 
-void SignalWaitUntilOnStreamTester::resetBuffers(size_t size) {
+void SignalWaitUntilOnStreamTester::resetBuffers([[maybe_unused]] size_t size) {
   // Clear signal addresses
   std::memset(sig_addr, 0, num_streams * sizeof(uint64_t));
 }
 
-void SignalWaitUntilOnStreamTester::launchKernel(dim3 gridSize, dim3 blockSize,
-                                                  int loop, size_t size) {
+void SignalWaitUntilOnStreamTester::launchKernel([[maybe_unused]] dim3 gridSize, [[maybe_unused]] dim3 blockSize,
+                                                  int loop, [[maybe_unused]] size_t size) {
   // Execute warmup + timed iterations
   for (int i = 0; i < args.skip + loop; i++) {
     // Increment signal value for each iteration
@@ -177,7 +177,7 @@ void SignalWaitUntilOnStreamTester::launchKernel(dim3 gridSize, dim3 blockSize,
   num_timed_msgs = loop * num_streams;
 }
 
-void SignalWaitUntilOnStreamTester::verifyResults(size_t size) {
+void SignalWaitUntilOnStreamTester::verifyResults([[maybe_unused]] size_t size) {
   // Synchronize to ensure all operations completed
   rocshmem_barrier_all();
 

--- a/projects/rocshmem/tests/functional_tests/signaling_operations_tester.cpp
+++ b/projects/rocshmem/tests/functional_tests/signaling_operations_tester.cpp
@@ -148,7 +148,7 @@ SignalingOperationsTester::~SignalingOperationsTester() {
   CHECK_HIP(hipFree(fetched_value));
 }
 
-void SignalingOperationsTester::resetBuffers(size_t size) {
+void SignalingOperationsTester::resetBuffers([[maybe_unused]] size_t size) {
   memset(s_buf, '0', max_msg_size * args.wg_size);
   memset(r_buf, '1', max_msg_size * args.wg_size);
   *fetched_value = -1;

--- a/projects/rocshmem/tests/functional_tests/sync_all_tester.cpp
+++ b/projects/rocshmem/tests/functional_tests/sync_all_tester.cpp
@@ -93,7 +93,7 @@ SyncAllTester::SyncAllTester(TesterArguments args) : Tester(args) {}
 SyncAllTester::~SyncAllTester() {}
 
 void SyncAllTester::launchKernel(dim3 gridSize, dim3 blockSize, int loop,
-                                    size_t size) {
+                                    [[maybe_unused]] size_t size) {
   size_t shared_bytes = 0;
 
   hipLaunchKernelGGL(SyncAllTest, gridSize, blockSize, shared_bytes, stream,
@@ -103,6 +103,6 @@ void SyncAllTester::launchKernel(dim3 gridSize, dim3 blockSize, int loop,
   num_timed_msgs = loop;
 }
 
-void SyncAllTester::resetBuffers(size_t size) {}
+void SyncAllTester::resetBuffers([[maybe_unused]] size_t size) {}
 
-void SyncAllTester::verifyResults(size_t size) {}
+void SyncAllTester::verifyResults([[maybe_unused]] size_t size) {}

--- a/projects/rocshmem/tests/functional_tests/sync_all_tester.cpp
+++ b/projects/rocshmem/tests/functional_tests/sync_all_tester.cpp
@@ -34,7 +34,7 @@ using namespace rocshmem;
 __global__ void SyncAllTest(int loop, int skip, long long int *start_time,
                                long long int *end_time, TestType type,
                                int wf_size) {
-  __shared__ rocshmem_ctx_t ctx;
+  [[maybe_unused]] __shared__ rocshmem_ctx_t ctx;
   int t_id  = get_flat_block_id();
   int wg_id = get_flat_grid_id();
   int wf_id = t_id / wf_size;

--- a/projects/rocshmem/tests/functional_tests/team_alltoall_tester.cpp
+++ b/projects/rocshmem/tests/functional_tests/team_alltoall_tester.cpp
@@ -24,8 +24,8 @@
 
 /* Declare the template with a generic implementation */
 template <typename T>
-__device__ void wg_team_alltoall(rocshmem_ctx_t ctx, rocshmem_team_t team,
-                                 T *dest, const T *source, int nelem) {
+__device__ void wg_team_alltoall([[maybe_unused]] rocshmem_ctx_t ctx, [[maybe_unused]] rocshmem_team_t team,
+                                 [[maybe_unused]] T *dest, [[maybe_unused]] const T *source, [[maybe_unused]] int nelem) {
   return;
 }
 
@@ -180,9 +180,9 @@ void TeamAlltoallTester<T1>::resetBuffers(size_t size) {
   int buff_size = num_elems * sizeof(T1) * args.num_wgs * n_pes;
   int idx = 0;
 
-  for(int wg_id = 0; wg_id < args.num_wgs; wg_id++) {
+  for(unsigned int wg_id = 0; wg_id < args.num_wgs; wg_id++) {
     for(int pe = 0; pe < n_pes; pe++) {
-      for(int i = 0; i < num_elems; i++) {
+      for(unsigned int i = 0; i < static_cast<unsigned int>(num_elems); i++) {
         idx = (wg_id * n_pes + pe) * num_elems + i;
         if constexpr (std::is_same<T1, char>::value ||
                       std::is_same<T1, signed char>::value ||
@@ -207,10 +207,10 @@ void TeamAlltoallTester<T1>::verifyResults(size_t size) {
   int num_elems = size / sizeof(T1);
   int idx = 0;
 
-  for(int wg_id = 0; wg_id < args.num_wgs; wg_id++) {
+  for(unsigned int wg_id = 0; wg_id < args.num_wgs; wg_id++) {
     for(int pe = 0; pe < n_pes; pe++) {
-      for(int i = 0; i < num_elems; i++) {
-        idx = (wg_id * n_pes + pe) * num_elems + i;
+      for(unsigned int i = 0; i < static_cast<unsigned int>(num_elems); i++) {
+        idx = (wg_id * n_pes + pe) * num_elems + static_cast<int>(i);
         if (dest_buf[idx] != source_buf[idx]) {
           std::cerr << "Data validation error at idx " << idx << std::endl;
           std::cerr << "PE " << my_pe << " Got " << dest_buf[idx]

--- a/projects/rocshmem/tests/functional_tests/team_alltoallmem_on_stream_tester.cpp
+++ b/projects/rocshmem/tests/functional_tests/team_alltoallmem_on_stream_tester.cpp
@@ -103,7 +103,7 @@ void TeamAlltoallmemOnStreamTester::postLaunchKernel() {
   }
 
   // Get elapsed time for each work group from HIP events
-  for (int wg_id = 0; wg_id < num_teams && wg_id < num_timers; wg_id++) {
+  for (uint32_t wg_id = 0; wg_id < static_cast<uint32_t>(num_teams) && wg_id < static_cast<uint32_t>(num_timers); wg_id++) {
     float elapsed_time_ms = 0.0f;
     CHECK_HIP(hipEventElapsedTime(&elapsed_time_ms, start_events_timed[wg_id],
                                   stop_events_timed[wg_id]));
@@ -118,7 +118,7 @@ void TeamAlltoallmemOnStreamTester::postLaunchKernel() {
   }
 
   // Fill remaining timers with zero if num_timers > num_teams
-  for (int i = num_teams; i < num_timers; i++) {
+  for (uint32_t i = num_teams; i < static_cast<uint32_t>(num_timers); i++) {
     start_time[i] = 0;
     end_time[i] = 0;
   }
@@ -148,8 +148,8 @@ void TeamAlltoallmemOnStreamTester::resetBuffers(size_t size) {
   std::memset(dest_buf, 0, buf_size);
 }
 
-void TeamAlltoallmemOnStreamTester::launchKernel(dim3 gridSize,
-                                                 dim3 blockSize,
+void TeamAlltoallmemOnStreamTester::launchKernel([[maybe_unused]] dim3 gridSize,
+                                                 [[maybe_unused]] dim3 blockSize,
                                                  int loop,
                                                  size_t size) {
   // Execute warmup iterations (skip)

--- a/projects/rocshmem/tests/functional_tests/team_alltoallv_tester.cpp
+++ b/projects/rocshmem/tests/functional_tests/team_alltoallv_tester.cpp
@@ -30,13 +30,13 @@ using namespace rocshmem;
 
 /* Declare the template with a generic implementation */
 template <typename T>
-__device__ void wg_team_alltoallv(rocshmem_team_t team,
-                                  T *dest,
-                                  const size_t dest_nelems[],
-                                  const size_t dest_displs[],
-                                  T *source,
-                                  const size_t source_nelems[],
-                                  const size_t source_displs[]) {
+__device__ void wg_team_alltoallv([[maybe_unused]] rocshmem_team_t team,
+                                  [[maybe_unused]] T *dest,
+                                  [[maybe_unused]] const size_t dest_nelems[],
+                                  [[maybe_unused]] const size_t dest_displs[],
+                                  [[maybe_unused]] T *source,
+                                  [[maybe_unused]] const size_t source_nelems[],
+                                  [[maybe_unused]] const size_t source_displs[]) {
   return;
 }
 
@@ -83,7 +83,7 @@ __global__ void TeamAlltoallvTest(int loop, int skip,
                                   T1 *source,
                                   const size_t source_nelems[],
                                   const size_t source_displs[],
-                                  ShmemContextType ctx_type,
+                                  [[maybe_unused]] ShmemContextType ctx_type,
                                   rocshmem_team_t *teams) {
 
   __syncthreads();
@@ -251,7 +251,7 @@ void TeamAlltoallvTester<T1>::verifyResults(size_t size) {
     T1* dst = (T1*) ((char*)dest_buf + (dest_displs[pe] * sizeof(T1)));
     T1* src = (T1*) &source_buf[pe * num_elems];
 
-    for(int i = 0; i < dest_nelems[pe]; i++) {
+    for(size_t i = 0; i < static_cast<size_t>(dest_nelems[pe]); i++) {
       if (dst[i] != src[i]) {
         std::cerr << "Data validation error at idx " << i << std::endl;
         std::cerr << "PE " << my_pe << " Got " << dest_buf[i]

--- a/projects/rocshmem/tests/functional_tests/team_barrier_tester.cpp
+++ b/projects/rocshmem/tests/functional_tests/team_barrier_tester.cpp
@@ -104,7 +104,7 @@ void TeamBarrierTester::preLaunchKernel() {
 }
 
 void TeamBarrierTester::launchKernel(dim3 gridSize, dim3 blockSize,
-                                           int loop, size_t size) {
+                                           int loop, [[maybe_unused]] size_t size) {
   size_t shared_bytes = 0;
 
   hipLaunchKernelGGL(TeamBarrierTest, gridSize, blockSize, shared_bytes,
@@ -122,6 +122,6 @@ void TeamBarrierTester::postLaunchKernel() {
   }
 }
 
-void TeamBarrierTester::resetBuffers(size_t size) {}
+void TeamBarrierTester::resetBuffers([[maybe_unused]] size_t size) {}
 
-void TeamBarrierTester::verifyResults(size_t size) {}
+void TeamBarrierTester::verifyResults([[maybe_unused]] size_t size) {}

--- a/projects/rocshmem/tests/functional_tests/team_broadcast_tester.cpp
+++ b/projects/rocshmem/tests/functional_tests/team_broadcast_tester.cpp
@@ -24,9 +24,9 @@
 
 /* Declare the template with a generic implementation */
 template <typename T>
-__device__ void wg_team_broadcast(rocshmem_ctx_t ctx, rocshmem_team_t team,
-                                  T *dest, const T *source, int nelem,
-                                  int pe_root) {
+__device__ void wg_team_broadcast([[maybe_unused]] rocshmem_ctx_t ctx, [[maybe_unused]] rocshmem_team_t team,
+                                  [[maybe_unused]] T *dest, [[maybe_unused]] const T *source, [[maybe_unused]] int nelem,
+                                  [[maybe_unused]] int pe_root) {
   return;
 }
 
@@ -181,8 +181,8 @@ void TeamBroadcastTester<T1>::resetBuffers(size_t size) {
   [[maybe_unused]] int buff_size = num_elems * sizeof(T1) * args.num_wgs;
   int idx = 0;
 
-  for (int wg_id = 0; wg_id < args.num_wgs; wg_id++) {
-    for (int i = 0; i < num_elems; i++) {
+  for (unsigned int wg_id = 0; wg_id < args.num_wgs; wg_id++) {
+    for (unsigned int i = 0; i < static_cast<unsigned int>(num_elems); i++) {
       idx = wg_id * num_elems + i;
       if constexpr (std::is_same<T1, char>::value ||
                     std::is_same<T1, signed char>::value ||
@@ -220,9 +220,9 @@ void TeamBroadcastTester<T1>::verifyResults(size_t size) {
    * contents from its own source to dest during
    * the broadcast.
    */
-  for (int wg_id = 0; wg_id < args.num_wgs; wg_id++) {
-    for (int i = 0; i < num_elems; i++) {
-      idx = wg_id * num_elems + i;
+  for (unsigned int wg_id = 0; wg_id < args.num_wgs; wg_id++) {
+    for (unsigned int i = 0; i < static_cast<unsigned int>(num_elems); i++) {
+      idx = wg_id * num_elems + static_cast<int>(i);
       if constexpr (std::is_same<T1, char>::value ||
                     std::is_same<T1, signed char>::value ||
                     std::is_same<T1, unsigned char>::value) {

--- a/projects/rocshmem/tests/functional_tests/team_broadcast_tester.cpp
+++ b/projects/rocshmem/tests/functional_tests/team_broadcast_tester.cpp
@@ -221,7 +221,7 @@ void TeamBroadcastTester<T1>::verifyResults(size_t size) {
    * the broadcast.
    */
   for (unsigned int wg_id = 0; wg_id < args.num_wgs; wg_id++) {
-    for (unsigned int i = 0; i < static_cast<unsigned int>(num_elems); i++) {
+    for (int i = 0; i < num_elems; i++) {
       idx = wg_id * num_elems + static_cast<int>(i);
       if constexpr (std::is_same<T1, char>::value ||
                     std::is_same<T1, signed char>::value ||

--- a/projects/rocshmem/tests/functional_tests/team_broadcast_tester.cpp
+++ b/projects/rocshmem/tests/functional_tests/team_broadcast_tester.cpp
@@ -71,7 +71,7 @@ __global__ void TeamBroadcastTest(int loop, int skip, long long int *start_time,
 
   rocshmem_wg_team_create_ctx(teams[wg_id], ctx_type, &ctx);
 
-  int n_pes = rocshmem_ctx_n_pes(ctx);
+  [[maybe_unused]] int n_pes = rocshmem_ctx_n_pes(ctx);
   source_buf += wg_id * size;
   dest_buf += wg_id * size;
 
@@ -178,7 +178,7 @@ template <typename T1>
 void TeamBroadcastTester<T1>::resetBuffers(size_t size) {
 
   int num_elems = size / sizeof(T1);
-  int buff_size = num_elems * sizeof(T1) * args.num_wgs;
+  [[maybe_unused]] int buff_size = num_elems * sizeof(T1) * args.num_wgs;
   int idx = 0;
 
   for (int wg_id = 0; wg_id < args.num_wgs; wg_id++) {

--- a/projects/rocshmem/tests/functional_tests/team_broadcast_tester.cpp
+++ b/projects/rocshmem/tests/functional_tests/team_broadcast_tester.cpp
@@ -222,7 +222,7 @@ void TeamBroadcastTester<T1>::verifyResults(size_t size) {
    */
   for (unsigned int wg_id = 0; wg_id < args.num_wgs; wg_id++) {
     for (int i = 0; i < num_elems; i++) {
-      idx = wg_id * num_elems + static_cast<int>(i);
+      idx = wg_id * num_elems + i;
       if constexpr (std::is_same<T1, char>::value ||
                     std::is_same<T1, signed char>::value ||
                     std::is_same<T1, unsigned char>::value) {

--- a/projects/rocshmem/tests/functional_tests/team_broadcastmem_on_stream_tester.cpp
+++ b/projects/rocshmem/tests/functional_tests/team_broadcastmem_on_stream_tester.cpp
@@ -113,7 +113,7 @@ void TeamBroadcastmemOnStreamTester::postLaunchKernel() {
   }
 
   // Get elapsed time for each work group from HIP events
-  for (int wg_id = 0; wg_id < num_teams && wg_id < num_timers; wg_id++) {
+  for (uint32_t wg_id = 0; wg_id < static_cast<uint32_t>(num_teams) && wg_id < static_cast<uint32_t>(num_timers); wg_id++) {
     float elapsed_time_ms = 0.0f;
     CHECK_HIP(hipEventElapsedTime(&elapsed_time_ms, start_events_timed[wg_id],
                                   stop_events_timed[wg_id]));
@@ -128,7 +128,7 @@ void TeamBroadcastmemOnStreamTester::postLaunchKernel() {
   }
 
   // Fill remaining timers with zero if num_timers > num_teams
-  for (int i = num_teams; i < num_timers; i++) {
+  for (uint32_t i = num_teams; i < static_cast<uint32_t>(num_timers); i++) {
     start_time[i] = 0;
     end_time[i] = 0;
   }
@@ -168,8 +168,8 @@ void TeamBroadcastmemOnStreamTester::resetBuffers(size_t size) {
   }
 }
 
-void TeamBroadcastmemOnStreamTester::launchKernel(dim3 gridSize,
-                                                  dim3 blockSize,
+void TeamBroadcastmemOnStreamTester::launchKernel([[maybe_unused]] dim3 gridSize,
+                                                  [[maybe_unused]] dim3 blockSize,
                                                   int loop,
                                                   size_t size) {
   // Execute warmup iterations (skip)

--- a/projects/rocshmem/tests/functional_tests/team_ctx_infra_tester.cpp
+++ b/projects/rocshmem/tests/functional_tests/team_ctx_infra_tester.cpp
@@ -144,7 +144,7 @@ TeamCtxInfraTester::TeamCtxInfraTester(TesterArguments args) : Tester(args) {
 
 TeamCtxInfraTester::~TeamCtxInfraTester() {}
 
-void TeamCtxInfraTester::resetBuffers(size_t size) {}
+void TeamCtxInfraTester::resetBuffers([[maybe_unused]] size_t size) {}
 
 void TeamCtxInfraTester::preLaunchKernel() {
   int n_pes = rocshmem_team_n_pes(_parentTeam);
@@ -240,8 +240,8 @@ void TeamCtxInfraTester::preLaunchKernel() {
   }
 }
 
-void TeamCtxInfraTester::launchKernel(dim3 gridSize, dim3 blockSize, int loop,
-                                      size_t size) {
+void TeamCtxInfraTester::launchKernel(dim3 gridSize, dim3 blockSize, [[maybe_unused]] int loop,
+                                      [[maybe_unused]] size_t size) {
   size_t shared_bytes = 0;
 
   /* Copy array of teams to device */
@@ -275,4 +275,4 @@ void TeamCtxInfraTester::postLaunchKernel() {
   }
 }
 
-void TeamCtxInfraTester::verifyResults(size_t size) {}
+void TeamCtxInfraTester::verifyResults([[maybe_unused]] size_t size) {}

--- a/projects/rocshmem/tests/functional_tests/team_ctx_infra_tester.cpp
+++ b/projects/rocshmem/tests/functional_tests/team_ctx_infra_tester.cpp
@@ -245,7 +245,7 @@ void TeamCtxInfraTester::launchKernel(dim3 gridSize, dim3 blockSize, int loop,
   size_t shared_bytes = 0;
 
   /* Copy array of teams to device */
-  rocshmem_team_t *teams_on_device;
+  rocshmem_team_t *teams_on_device = nullptr;
 
   if (_splitType == ROCSHMEM_TEST_TEAM_DUP) {
     CHECK_HIP(hipMalloc(&teams_on_device, sizeof(rocshmem_team_t) * NUM_TEAMS));

--- a/projects/rocshmem/tests/functional_tests/team_fcollect_tester.cpp
+++ b/projects/rocshmem/tests/functional_tests/team_fcollect_tester.cpp
@@ -171,8 +171,8 @@ void TeamFcollectTester<T1>::launchKernel(dim3 gridSize, dim3 blockSize,
 
   int num_elems = size / sizeof(T1);
 
-  int my_pe = rocshmem_team_my_pe(ROCSHMEM_TEAM_WORLD);
-  int n_pes = rocshmem_team_n_pes(ROCSHMEM_TEAM_WORLD);
+  [[maybe_unused]] int my_pe = rocshmem_team_my_pe(ROCSHMEM_TEAM_WORLD);
+  [[maybe_unused]] int n_pes = rocshmem_team_n_pes(ROCSHMEM_TEAM_WORLD);
 
   hipLaunchKernelGGL(TeamFcollectTest<T1>, gridSize, blockSize, shared_bytes,
                      stream, loop, args.skip, start_time, end_time,

--- a/projects/rocshmem/tests/functional_tests/team_fcollect_tester.cpp
+++ b/projects/rocshmem/tests/functional_tests/team_fcollect_tester.cpp
@@ -24,8 +24,8 @@
 
 /* Declare the template with a generic implementation */
 template <typename T>
-__device__ void wg_team_fcollect(rocshmem_ctx_t ctx, rocshmem_team_t team,
-                                 T *dest, const T *source, int nelems) {
+__device__ void wg_team_fcollect([[maybe_unused]] rocshmem_ctx_t ctx, [[maybe_unused]] rocshmem_team_t team,
+                                 [[maybe_unused]] T *dest, [[maybe_unused]] const T *source, [[maybe_unused]] int nelems) {
   return;
 }
 
@@ -205,9 +205,9 @@ void TeamFcollectTester<T1>::verifyResults(size_t size) {
   int idx = 0;
   T1 expected;
 
-  for(int wg_id = 0; wg_id < args.num_wgs; wg_id++) {
+  for(unsigned int wg_id = 0; wg_id < args.num_wgs; wg_id++) {
     for(int pe = 0; pe < n_pes; pe++) {
-      for(int i = 0; i < num_elems; i++) {
+      for(unsigned int i = 0; i < static_cast<unsigned int>(num_elems); i++) {
         idx = (wg_id * n_pes + pe) * num_elems + i;
         if constexpr (std::is_same<T1, char>::value ||
               std::is_same<T1, signed char>::value ||

--- a/projects/rocshmem/tests/functional_tests/team_reduction_tester.cpp
+++ b/projects/rocshmem/tests/functional_tests/team_reduction_tester.cpp
@@ -26,8 +26,8 @@ using namespace rocshmem;
 
 /* Declare the template with a generic implementation */
 template <typename T, ROCSHMEM_OP Op>
-__device__ int wg_team_reduce(rocshmem_ctx_t ctx, rocshmem_team_t, T *dest,
-                               const T *source, int nreduce) {
+__device__ int wg_team_reduce([[maybe_unused]] rocshmem_ctx_t ctx, [[maybe_unused]] rocshmem_team_t, [[maybe_unused]] T *dest,
+                               [[maybe_unused]] const T *source, [[maybe_unused]] int nreduce) {
   return ROCSHMEM_SUCCESS;
 }
 
@@ -77,7 +77,7 @@ rocshmem_team_t team_reduce_world_dup;
 template <typename T1, ROCSHMEM_OP T2>
 __global__ void TeamReductionTest(int loop, int skip, long long int *start_time,
                                   long long int *end_time, T1 *s_buf, T1 *r_buf,
-                                  size_t size, TestType type,
+                                  size_t size, [[maybe_unused]] TestType type,
                                   ShmemContextType ctx_type,
                                   rocshmem_team_t team) {
   __shared__ rocshmem_ctx_t ctx;
@@ -153,7 +153,7 @@ void TeamReductionTester<T1, T2>::postLaunchKernel() {
 }
 
 template <typename T1, ROCSHMEM_OP T2>
-void TeamReductionTester<T1, T2>::resetBuffers(size_t size) {
+void TeamReductionTester<T1, T2>::resetBuffers([[maybe_unused]] size_t size) {
   for (uint64_t i = 0; i < max_msg_size; i++) {
     init_buf(s_buf[i], r_buf[i]);
   }

--- a/projects/rocshmem/tests/functional_tests/team_sync_tester.cpp
+++ b/projects/rocshmem/tests/functional_tests/team_sync_tester.cpp
@@ -101,7 +101,7 @@ void TeamSyncTester::preLaunchKernel() {
 }
 
 void TeamSyncTester::launchKernel(dim3 gridSize, dim3 blockSize,
-                                           int loop, size_t size) {
+                                           int loop, [[maybe_unused]] size_t size) {
   size_t shared_bytes = 0;
 
   hipLaunchKernelGGL(TeamSyncTest, gridSize, blockSize, shared_bytes,
@@ -119,6 +119,6 @@ void TeamSyncTester::postLaunchKernel() {
   }
 }
 
-void TeamSyncTester::resetBuffers(size_t size) {}
+void TeamSyncTester::resetBuffers([[maybe_unused]] size_t size) {}
 
-void TeamSyncTester::verifyResults(size_t size) {}
+void TeamSyncTester::verifyResults([[maybe_unused]] size_t size) {}

--- a/projects/rocshmem/tests/functional_tests/test_driver.cpp
+++ b/projects/rocshmem/tests/functional_tests/test_driver.cpp
@@ -71,7 +71,7 @@ static void pmix_bcast(void *buf, size_t nbytes, char *key, int root)
     pmix_info_t *info;
     bool flag;
 
-    if (pmix_myproc.rank == root) {
+    if (static_cast<int>(pmix_myproc.rank) == root) {
       value.type = PMIX_BYTE_OBJECT;
       value.data.bo.bytes = (char *) (buf);
       value.data.bo.size = nbytes;
@@ -112,7 +112,7 @@ static void pmix_bcast(void *buf, size_t nbytes, char *key, int root)
       abort();
     }
 
-    if (pmix_myproc.rank != root) {
+    if (static_cast<int>(pmix_myproc.rank) != root) {
       if (NULL == val->data.bo.bytes) {
         std::cerr <<  "Rank " << pmix_myproc.rank << " PMIx_Get %d returned NULL pointer\n";
         PMIX_VALUE_RELEASE(val);

--- a/projects/rocshmem/tests/functional_tests/tester.cpp
+++ b/projects/rocshmem/tests/functional_tests/tester.cpp
@@ -786,7 +786,7 @@ void Tester::print(uint64_t size) {
   size_t total_size = size_factor * size * num_timed_msgs;
   size_t volume = total_size / num_loops;
 
-  double timer_avg = timerAvgInMicroseconds();
+  [[maybe_unused]] double timer_avg = timerAvgInMicroseconds();
   double time_us = gpuCyclesToMicroseconds(max_end_time - min_start_time);
   double time_s = time_us / 1e6;
 
@@ -799,7 +799,7 @@ void Tester::print(uint64_t size) {
 
   float total_kern_time_ms;
   CHECK_HIP(hipEventElapsedTime(&total_kern_time_ms, start_event, stop_event));
-  float total_kern_time_s = total_kern_time_ms / 1000;
+  [[maybe_unused]] float total_kern_time_s = total_kern_time_ms / 1000;
 
   int field_width = 20;
   int float_precision = 2;

--- a/projects/rocshmem/tests/functional_tests/verify_results_kernels.hpp
+++ b/projects/rocshmem/tests/functional_tests/verify_results_kernels.hpp
@@ -30,7 +30,7 @@ namespace rocshmem {
 [[maybe_unused]] static __global__ void verify_results_kernel_char(char *source, char *dest, size_t buf_size,
                                                   bool *verification_error) {
 
-  int idx = get_flat_id();
+  size_t idx = get_flat_id();
 
   if (idx >= buf_size) {
     return;

--- a/projects/rocshmem/tests/functional_tests/verify_results_kernels.hpp
+++ b/projects/rocshmem/tests/functional_tests/verify_results_kernels.hpp
@@ -27,7 +27,7 @@
 
 namespace rocshmem {
 
-static __global__ void verify_results_kernel_char(char *source, char *dest, size_t buf_size,
+[[maybe_unused]] static __global__ void verify_results_kernel_char(char *source, char *dest, size_t buf_size,
                                                   bool *verification_error) {
 
   int idx = get_flat_id();

--- a/projects/rocshmem/tests/unit_tests/atomic_wf_queue_gtest.hpp
+++ b/projects/rocshmem/tests/unit_tests/atomic_wf_queue_gtest.hpp
@@ -38,7 +38,7 @@ __global__ void wf_lane_ids(AWFQueue* awf_queue, unsigned int* device_array,
                            int wf_size) {
 
   int t_id {get_flat_id()};
-  int lane_id {t_id % wf_size};
+  [[maybe_unused]] int lane_id {t_id % wf_size};
   device_array[t_id] = awf_queue->active_logical_lane_id();
 }
 

--- a/projects/rocshmem/tests/unit_tests/atomic_wf_queue_gtest.hpp
+++ b/projects/rocshmem/tests/unit_tests/atomic_wf_queue_gtest.hpp
@@ -108,8 +108,8 @@ class AtomicWFQueueTestFixture : public ::testing::Test {
     unsigned int expected_val {};
     unsigned int lane_id {};
     unsigned int idx {};
-    for (unsigned int i{0}; i < num_blocks; i++) {
-      for (unsigned int j{0}; j < block_size; j++) {
+    for (unsigned int i{0}; i < static_cast<unsigned int>(num_blocks); i++) {
+      for (unsigned int j{0}; j < static_cast<unsigned int>(block_size); j++) {
         idx = i * block_size + j;
         lane_id = j % wf_size;
         if (!lane_id) {

--- a/projects/rocshmem/tests/unit_tests/free_list_gtest.cpp
+++ b/projects/rocshmem/tests/unit_tests/free_list_gtest.cpp
@@ -73,8 +73,8 @@ TYPED_TEST(FreeListTestFixture, pop_empty_device) {
   using Allocator = typename TestFixture::Allocator;
   using T = typename TestFixture::T;
 
-  auto& h_input = this->h_input;
-  auto& free_list = this->free_list;
+  [[maybe_unused]] auto& h_input = this->h_input;
+  [[maybe_unused]] auto& free_list = this->free_list;
   auto& hip_allocator_ = this->hip_allocator_;
 
   bool *is_empty {nullptr};
@@ -95,6 +95,7 @@ TYPED_TEST(FreeListTestFixture, pop_empty_device) {
 TYPED_TEST(FreeListTestFixture, push_host_pop_device) {
   using Allocator = typename TestFixture::Allocator;
   using T = typename TestFixture::T;
+  (void)sizeof(Allocator); // Suppress unused type alias warning
 
   auto& h_input = this->h_input;
   auto& free_list = this->free_list;
@@ -126,6 +127,7 @@ TYPED_TEST(FreeListTestFixture, push_host_pop_device) {
 TYPED_TEST(FreeListTestFixture, push_host_concurrent_pop_device) {
   using Allocator = typename TestFixture::Allocator;
   using T = typename TestFixture::T;
+  (void)sizeof(Allocator); // Suppress unused type alias warning
 
   auto& h_input = this->h_input;
   auto& free_list = this->free_list;
@@ -176,7 +178,7 @@ TYPED_TEST(FreeListTestFixture, push_host_pop_push_device) {
 
   T *results {nullptr};
   T *d_input {nullptr};
-  bool *is_empty {nullptr};
+  [[maybe_unused]] bool *is_empty {nullptr};
   size_t size_bytes = 2 * sizeof(T) * h_input.size() + sizeof(bool);
   hip_allocator_.allocate(reinterpret_cast<void**>(&results),
                           size_bytes);

--- a/projects/rocshmem/tests/unit_tests/free_list_gtest.cpp
+++ b/projects/rocshmem/tests/unit_tests/free_list_gtest.cpp
@@ -93,9 +93,7 @@ TYPED_TEST(FreeListTestFixture, pop_empty_device) {
 }
 
 TYPED_TEST(FreeListTestFixture, push_host_pop_device) {
-  using Allocator = typename TestFixture::Allocator;
   using T = typename TestFixture::T;
-  (void)sizeof(Allocator); // Suppress unused type alias warning
 
   auto& h_input = this->h_input;
   auto& free_list = this->free_list;
@@ -125,9 +123,7 @@ TYPED_TEST(FreeListTestFixture, push_host_pop_device) {
 }
 
 TYPED_TEST(FreeListTestFixture, push_host_concurrent_pop_device) {
-  using Allocator = typename TestFixture::Allocator;
   using T = typename TestFixture::T;
-  (void)sizeof(Allocator); // Suppress unused type alias warning
 
   auto& h_input = this->h_input;
   auto& free_list = this->free_list;
@@ -178,14 +174,12 @@ TYPED_TEST(FreeListTestFixture, push_host_pop_push_device) {
 
   T *results {nullptr};
   T *d_input {nullptr};
-  [[maybe_unused]] bool *is_empty {nullptr};
   size_t size_bytes = 2 * sizeof(T) * h_input.size() + sizeof(bool);
   hip_allocator_.allocate(reinterpret_cast<void**>(&results),
                           size_bytes);
 
   CHECK_HIP(hipMemset(results, 0, size_bytes));
   d_input = reinterpret_cast<T*>(results + h_input.size());
-  is_empty = reinterpret_cast<bool*>(d_input + h_input.size());
   const auto block_size = this->wf_size;
 
   CHECK_HIP(hipMemcpy(d_input, h_input.data(), sizeof(T) * h_input.size(),

--- a/projects/rocshmem/tests/unit_tests/ipc_impl_simple_coarse_gtest.hpp
+++ b/projects/rocshmem/tests/unit_tests/ipc_impl_simple_coarse_gtest.hpp
@@ -101,7 +101,7 @@ class IPCImplSimpleCoarse : public ::testing::TestWithParam<std::tuple<int, int,
         WRITE = 1
     };
 
-    virtual void copy(TestType test, dim3 grid, dim3 block) {
+    virtual void copy([[maybe_unused]] TestType test, [[maybe_unused]] dim3 grid, [[maybe_unused]] dim3 block) {
         FAIL();
     }
 

--- a/projects/rocshmem/tests/unit_tests/ipc_impl_simple_fine_gtest.hpp
+++ b/projects/rocshmem/tests/unit_tests/ipc_impl_simple_fine_gtest.hpp
@@ -189,7 +189,7 @@ class IPCImplSimpleFine : public ::testing::TestWithParam<std::tuple<int, int, i
         CHECK_HIP(hipStreamSynchronize(nullptr));
     }
 
-    virtual void copy(TestType test, dim3 grid, dim3 block) {
+    virtual void copy([[maybe_unused]] TestType test, [[maybe_unused]] dim3 grid, [[maybe_unused]] dim3 block) {
         FAIL();
     }
 

--- a/projects/rocshmem/tests/unit_tests/ipc_impl_tiled_fine_gtest.hpp
+++ b/projects/rocshmem/tests/unit_tests/ipc_impl_tiled_fine_gtest.hpp
@@ -207,7 +207,7 @@ class IPCImplTiledFine : public ::testing::TestWithParam<std::tuple<int, int, in
         CHECK_HIP(hipStreamSynchronize(nullptr));
     }
 
-    virtual void copy(TestType test, dim3 grid, dim3 block) {
+    virtual void copy([[maybe_unused]] TestType test, [[maybe_unused]] dim3 grid, [[maybe_unused]] dim3 block) {
         FAIL();
     }
 


### PR DESCRIPTION
## Motivation

fix all rocshmem warnings when compiling with '-Wall -Wextra' except for one category:

```
warning: <unknown>:0:0: in function xyz: local memory global used by non-kernel function
```
Fixing that warning would have been more intrusive, we should do that separately.

While the PR is huge, every single one of the changes is trivial.

## Technical Details

  Final Summary

▒ WarningsoFixed:
  - ✅ -Wunused-variable - Fixed with [[maybe_unused]] attribute
  - ✅ -Wuninitialized - Fixed by initializing variables
  - ✅ -Wunused-function - Fixed with [[maybe_unused]] attribute
  - ✅ -Wreorder-ctor - Fixed by reordering initializer lists
  - ✅ -Wdelete-non-abstract-non-virtual-dtor - Added virtual destructors
  - ✅ -Wpacked-non-pod - Suppressed with pragma directives
  - ✅ -Wunused-but-set-variable - Fixed with [[maybe_unused]]
  - ✅ -Wsometimes-uninitialized - Fixed by initializing variables
  - ✅ -Wunused-parameter (~200+ warnings) - Fixed with [[maybe_unused]]
  - ✅ -Wsign-compare (~70 warnings) - Fixed with proper type casts and changing loop variable types
  - ✅ -Wgnu-null-pointer-arithmetic (52 warnings) - Suppressed with pragma in dlmalloc.cpp
  - ✅ -Wformat (2 warnings) - Fixed with proper type casting
  - ✅ -Wmissing-field-initializers (4 warnings) - Fixed with proper aggregate initialization


## JIRA ID

AIROCSHMEM-331

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
