### PR TITLE
[clr] Reject VMM allocations in hipIpcGetMemHandle

### DIFF
--- a/projects/clr/rocclr/device/device.cpp
+++ b/projects/clr/rocclr/device/device.cpp
@@ -1053,7 +1053,7 @@ bool Device::IpcCreate(void* dev_ptr, size_t* mem_size, char* handle, size_t* me
   // VMM allocations must use hipMemExportToShareableHandle for IPC.
   if (amd_mem_obj->getMemFlags() & CL_MEM_VA_RANGE_AMD) {
     ClPrint(amd::LOG_DETAIL_DEBUG, amd::LOG_MEM,
-             "IPC is not supported for VMM allocations (dev_ptr: 0x%x)", dev_ptr);
+             "IPC is not supported for VMM allocations (dev_ptr: %p)", dev_ptr);
     return false;
   }
 

--- a/projects/clr/rocclr/device/device.cpp
+++ b/projects/clr/rocclr/device/device.cpp
@@ -1050,6 +1050,13 @@ bool Device::IpcCreate(void* dev_ptr, size_t* mem_size, char* handle, size_t* me
     return false;
   }
 
+  // VMM allocations must use hipMemExportToShareableHandle for IPC.
+  if (amd_mem_obj->getMemFlags() & CL_MEM_VA_RANGE_AMD) {
+    ClPrint(amd::LOG_DETAIL_DEBUG, amd::LOG_MEM,
+             "IPC is not supported for VMM allocations (dev_ptr: 0x%x)", dev_ptr);
+    return false;
+  }
+
   // Get the original pointer from the amd::Memory object
   void* orig_dev_ptr = nullptr;
   if (amd_mem_obj->getSvmPtr() != nullptr) {


### PR DESCRIPTION
Cloned from: https://github.com/ROCm/rocm-systems/pull/3882. CI could not run as PR was from a forked repo.

VMM allocations must use hipMemExportToShareableHandle for IPC, not hipIpcGetMemHandle. Add a check in Device::IpcCreate.