### PR TITLE
[rocprof-compute] Updated ruff version to 0.14.11 to match CI

### DIFF
--- a/projects/rocprofiler-compute/pyproject.toml
+++ b/projects/rocprofiler-compute/pyproject.toml
@@ -4,7 +4,7 @@ requires-python = ">=3.9"
 
 [project.optional-dependencies]
 developer = [
-    "ruff>=0.12.7",
+    "ruff>=0.14.11",
     "pre-commit",
 ]
 


### PR DESCRIPTION
## Motivation

Align the `ruff` version pin in `pyproject.toml` with what CI currently uses.

## Technical Details

Bumped `ruff` minimum version from `0.12.7` to `0.14.11` in `[project.optional-dependencies]`.

## JIRA ID

N/A

## Test Plan

- Verified `ruff check` and `ruff format` pass locally with `ruff 0.14.11`.

## Test Result

No new lint or format issues introduced since there is no functional changes

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
