### PR TITLE
[msvc 3/12] dbgapi: Avoid unary minus operator applied to unsigned type

### DIFF
--- a/projects/rocdbgapi/CMakeLists.txt
+++ b/projects/rocdbgapi/CMakeLists.txt
@@ -461,8 +461,10 @@ target_include_directories(amd-dbgapi
     $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/include/amd-dbgapi>
     $<INSTALL_INTERFACE:include>)
 
-target_link_libraries(amd-dbgapi
-  PRIVATE -Wl,--version-script=${CMAKE_CURRENT_BINARY_DIR}/src/exportmap -Wl,--no-undefined)
+if(NOT WIN32)
+  target_link_libraries(amd-dbgapi
+    PRIVATE -Wl,--version-script=${CMAKE_CURRENT_BINARY_DIR}/src/exportmap -Wl,--no-undefined)
+endif()
 
 set(AMD_DBGAPI_CONFIG_NAME amd-dbgapi-config.cmake)
 set(AMD_DBGAPI_TARGETS_NAME amd-dbgapi-targets.cmake)

--- a/projects/rocdbgapi/CMakeLists.txt
+++ b/projects/rocdbgapi/CMakeLists.txt
@@ -285,19 +285,18 @@ elseif(CMAKE_SYSTEM_NAME STREQUAL "Windows")
 
   target_include_directories(amd-dbgapi PRIVATE
     src/windows/imported
-    ${D3DKMT_INCLUDE_PATH}
+    ${D3DKMT_INCLUDE_PATH})
+
+  # Including libdxg raises some warnings (unknown pragmas) as well as
+  # "X too small to hold all values of Y".  The latter warning cannot
+  # be silenced, so tell the compiler to treat the libdxg directory as
+  # a system headers include path, so that warnings are disabled for
+  # that directory's headers.
+  target_include_directories(amd-dbgapi SYSTEM PRIVATE
     third_party/libdxg/include)
 
   target_compile_definitions(amd-dbgapi
     PRIVATE D3DKMDT_SPECIAL_MULTIPLATFORM_TOOL)
-
-  # Including libdxg raises some warnings (unknown pargmas) as well us
-  # "X too small to hold all values of Y".  The latter warning cannot be
-  # silenced, se we need to disable -Werror for this file.
-  set_source_files_properties(
-    src/os_driver_kmd.cpp
-    PROPERTIES
-      COMPILE_OPTIONS "-Wno-error;-Wno-unknown-pragmas")
 else()
   message(FATAL_ERROR "Platform ${CMAKE_SYSTEM_NAME} is not supported")
 endif()

--- a/projects/rocdbgapi/CMakeLists.txt
+++ b/projects/rocdbgapi/CMakeLists.txt
@@ -167,7 +167,7 @@ set_target_properties(amd-dbgapi PROPERTIES
   SOVERSION ${PROJECT_VERSION_MAJOR})
 
 target_compile_options(amd-dbgapi PRIVATE
-  -fno-rtti -Werror -Wall -Wextra -Wshadow -Wno-attributes) #-pedantic)
+  -fno-rtti -Werror -Wall -Wextra -Wshadow -Wno-attributes -Wconversion) #-pedantic)
 
 target_compile_definitions(amd-dbgapi
   PRIVATE __STDC_LIMIT_MACROS __STDC_CONSTANT_MACROS __STDC_FORMAT_MACROS)

--- a/projects/rocdbgapi/include/amd-dbgapi.h.in
+++ b/projects/rocdbgapi/include/amd-dbgapi.h.in
@@ -492,19 +492,19 @@
 #endif /* !defined (AMD_DBGAPI_CALL) */
 
 #if !defined(AMD_DBGAPI_EXPORT_DECORATOR)
-#if defined(__GNUC__)
-#define AMD_DBGAPI_EXPORT_DECORATOR __attribute__ ((visibility ("default")))
-#elif defined(_MSC_VER)
-#define AMD_DBGAPI_EXPORT_DECORATOR __declspec(dllexport)
-#endif /* defined (_MSC_VER) */
+# if defined(_WIN32)
+#  define AMD_DBGAPI_EXPORT_DECORATOR __declspec(dllexport)
+# elif defined(__GNUC__)
+#  define AMD_DBGAPI_EXPORT_DECORATOR __attribute__ ((visibility ("default")))
+# endif
 #endif /* !defined (AMD_DBGAPI_EXPORT_DECORATOR) */
 
 #if !defined(AMD_DBGAPI_IMPORT_DECORATOR)
-#if defined(__GNUC__)
-#define AMD_DBGAPI_IMPORT_DECORATOR
-#elif defined(_MSC_VER)
-#define AMD_DBGAPI_IMPORT_DECORATOR __declspec(dllimport)
-#endif /* defined (_MSC_VER) */
+# if defined(_WIN32)
+#  define AMD_DBGAPI_IMPORT_DECORATOR __declspec(dllimport)
+# else
+#  define AMD_DBGAPI_IMPORT_DECORATOR
+# endif
 #endif /* !defined (AMD_DBGAPI_IMPORT_DECORATOR) */
 
 #define AMD_DBGAPI_EXPORT AMD_DBGAPI_EXPORT_DECORATOR AMD_DBGAPI_CALL

--- a/projects/rocdbgapi/src/agent.cpp
+++ b/projects/rocdbgapi/src/agent.cpp
@@ -260,7 +260,8 @@ agent_t::remove_watchpoint (const watchpoint_t &watchpoint)
   if (it == std::end (m_watchpoints))
     return;
 
-  os_watch_id_t os_watch_id = std::distance (begin (m_watchpoints), it);
+  auto os_watch_id
+    = utils::narrow<os_watch_id_t> (std::distance (begin (m_watchpoints), it));
 
   amd_dbgapi_status_t status = process ().os_driver ().clear_address_watch (
     os_agent_id (), os_watch_id);

--- a/projects/rocdbgapi/src/agent.cpp
+++ b/projects/rocdbgapi/src/agent.cpp
@@ -227,8 +227,8 @@ agent_t::insert_watchpoint (const watchpoint_t &watchpoint)
 
   os_watch_id_t os_watch_id;
   amd_dbgapi_status_t status = process ().os_driver ().set_address_watch (
-    os_agent_id (), watchpoint.address (), -watchpoint.size (), watch_mode,
-    &os_watch_id);
+    os_agent_id (), watchpoint.address (),
+    utils::alignment_to_mask (watchpoint.size ()), watch_mode, &os_watch_id);
 
   if (status == AMD_DBGAPI_STATUS_ERROR_NO_WATCHPOINT_AVAILABLE)
     throw api_error_t (AMD_DBGAPI_STATUS_ERROR_NO_WATCHPOINT_AVAILABLE);

--- a/projects/rocdbgapi/src/architecture.cpp
+++ b/projects/rocdbgapi/src/architecture.cpp
@@ -126,18 +126,19 @@ protected:
   static constexpr uint32_t sq_wave_status_cond_dbg_user_mask = 1 << 20;
   static constexpr uint32_t sq_wave_status_cond_dbg_sys_mask = 1 << 21;
 
-  static constexpr uint32_t ttmp11_wave_in_group_mask = utils::bit_mask (0, 5);
+  static constexpr auto ttmp11_wave_in_group_mask
+    = utils::bit_mask<uint32_t> (0, 5);
   static constexpr int ttmp11_wave_in_group_shift = 0;
-  static constexpr uint32_t ttmp6_spi_ttmps_setup_disabled_mask = 1 << 31;
+  static constexpr uint32_t ttmp6_spi_ttmps_setup_disabled_mask = 1u << 31;
   static constexpr uint32_t ttmp6_wave_stopped_mask = 1 << 30;
   static constexpr uint32_t ttmp6_saved_status_halt_mask = 1 << 29;
   static constexpr int ttmp6_saved_trap_id_shift = 25;
   static constexpr int ttmp6_saved_trap_id_size = 4;
-  static constexpr uint32_t ttmp6_saved_trap_id_mask = utils::bit_mask (
+  static constexpr auto ttmp6_saved_trap_id_mask = utils::bit_mask<uint32_t> (
     ttmp6_saved_trap_id_shift,
     ttmp6_saved_trap_id_shift + ttmp6_saved_trap_id_size - 1);
-  static constexpr uint32_t ttmp6_queue_packet_id_mask
-    = utils::bit_mask (0, 24);
+  static constexpr auto ttmp6_queue_packet_id_mask
+    = utils::bit_mask<uint32_t> (0, 24);
   static constexpr int ttmp6_queue_packet_id_shift = 0;
 
   /* See https://llvm.org/docs/AMDGPUUsage.html#trap-handler-abi  */
@@ -155,7 +156,7 @@ protected:
      library only handles trap IDs between 1 and 14.  */
   static constexpr std::optional<trap_id_t> ttmp6_saved_trap_id (uint32_t x)
   {
-    if (uint8_t trap_id = utils::bit_extract (
+    if (auto trap_id = utils::bit_extract<uint8_t> (
           x, ttmp6_saved_trap_id_shift,
           ttmp6_saved_trap_id_shift + ttmp6_saved_trap_id_size - 1);
         trap_id != 0)
@@ -189,9 +190,10 @@ protected:
   static constexpr uint32_t sq_wave_trapsts_excp_hi_addr_watch3_mask = 1 << 14;
   static constexpr uint32_t sq_wave_trapsts_xnack_error_mask = 1 << 28;
 
-  static constexpr uint32_t sq_wave_trapsts_excp_mask = utils::bit_mask (0, 8);
-  static constexpr uint32_t sq_wave_trapsts_excp_hi_mask
-    = utils::bit_mask (12, 14);
+  static constexpr auto sq_wave_trapsts_excp_mask
+    = utils::bit_mask<uint32_t> (0, 8);
+  static constexpr auto sq_wave_trapsts_excp_hi_mask
+    = utils::bit_mask<uint32_t> (12, 14);
 
   static constexpr uint32_t compute_relaunch_is_event (uint32_t relaunch)
   {
@@ -877,7 +879,8 @@ amdgcn_architecture_t::branch_target (wave_t &wave, agent_address_t pc,
       uint32_t csp;
       wave.read_register (amdgpu_regnum_t::csp, &csp);
 
-      amdgpu_regnum_t regnum = amdgpu_regnum_t::s0 + --csp * 4;
+      amdgpu_regnum_t regnum
+        = amdgpu_regnum_t::s0 + static_cast<int> (--csp * 4);
 
       uint32_t pc_lo, pc_hi;
       wave.read_register (regnum + 2, &pc_lo);
@@ -1148,15 +1151,15 @@ amdgcn_architecture_t::simulate_instruction (
             = (taken ? pc + instruction.size ()
                      : branch_target (wave, pc, instruction));
 
-          uint32_t saved_exec_lo = taken ? mask_fail : mask_pass;
-          uint32_t saved_exec_hi = (taken ? mask_fail : mask_pass) >> 32;
-          uint32_t saved_pc_lo = saved_pc;
-          uint32_t saved_pc_hi = saved_pc >> 32;
+          auto saved_exec = taken ? mask_fail : mask_pass;
+          auto [saved_exec_lo, saved_exec_hi] = utils::split (saved_exec);
+          auto [saved_pc_lo, saved_pc_hi] = utils::split (saved_pc);
 
           uint32_t csp;
           wave.read_register (amdgpu_regnum_t::csp, &csp);
 
-          amdgpu_regnum_t regnum = amdgpu_regnum_t::s0 + csp++ * 4;
+          amdgpu_regnum_t regnum
+            = (amdgpu_regnum_t::s0 + static_cast<int> (csp++ * 4));
           wave.write_register (regnum + 0, saved_exec_lo);
           wave.write_register (regnum + 1, saved_exec_hi);
           wave.write_register (regnum + 2, saved_pc_lo);
@@ -1176,7 +1179,8 @@ amdgcn_architecture_t::simulate_instruction (
           uint32_t csp;
           wave.read_register (amdgpu_regnum_t::csp, &csp);
 
-          amdgpu_regnum_t regnum = amdgpu_regnum_t::s0 + --csp * 4;
+          amdgpu_regnum_t regnum
+            = amdgpu_regnum_t::s0 + static_cast<int> (--csp * 4);
 
           uint32_t exec_lo, exec_hi;
           wave.read_register (regnum + 0, &exec_lo);
@@ -1751,31 +1755,31 @@ amdgcn_architecture_t::wave_disable_traps (
 uint8_t
 amdgcn_architecture_t::ssrc0_operand (const instruction_t &instruction)
 {
-  return utils::bit_extract (instruction.word<0> (), 0, 7);
+  return utils::bit_extract<uint8_t> (instruction.word<0> (), 0, 7);
 }
 
 uint8_t
 amdgcn_architecture_t::ssrc1_operand (const instruction_t &instruction)
 {
-  return utils::bit_extract (instruction.word<0> (), 8, 15);
+  return utils::bit_extract<uint8_t> (instruction.word<0> (), 8, 15);
 }
 
 uint8_t
 amdgcn_architecture_t::sdst_operand (const instruction_t &instruction)
 {
-  return utils::bit_extract (instruction.word<0> (), 16, 22);
+  return utils::bit_extract<uint8_t> (instruction.word<0> (), 16, 22);
 }
 
 int16_t
 amdgcn_architecture_t::simm16_operand (const instruction_t &instruction)
 {
-  return utils::bit_extract (instruction.word<0> (), 0, 15);
+  return utils::bit_extract<int16_t> (instruction.word<0> (), 0, 15);
 }
 
 uint8_t
 amdgcn_architecture_t::encoding_op7 (const instruction_t &instruction)
 {
-  return utils::bit_extract (instruction.word<0> (), 16, 22);
+  return utils::bit_extract<uint8_t> (instruction.word<0> (), 16, 22);
 }
 
 template <int... op5>
@@ -1852,19 +1856,18 @@ amdgcn_architecture_t::register_name (amdgpu_regnum_t regnum) const
   if (regnum >= amdgpu_regnum_t::first_shadow_sgpr
       && regnum <= amdgpu_regnum_t::last_shadow_sgpr)
     {
-      return string_printf ("s%" PRId64,
+      return string_printf ("s%d",
                             regnum - amdgpu_regnum_t::first_shadow_sgpr);
     }
   if (regnum >= amdgpu_regnum_t::first_sgpr
       && regnum <= amdgpu_regnum_t::last_sgpr)
     {
-      return string_printf ("s%" PRId64, regnum - amdgpu_regnum_t::first_sgpr);
+      return string_printf ("s%d", regnum - amdgpu_regnum_t::first_sgpr);
     }
   if (regnum >= amdgpu_regnum_t::first_vgpr_64
       && regnum <= amdgpu_regnum_t::last_vgpr_64)
     {
-      return string_printf ("v%" PRId64,
-                            regnum - amdgpu_regnum_t::first_vgpr_64);
+      return string_printf ("v%d", regnum - amdgpu_regnum_t::first_vgpr_64);
     }
   if (regnum >= amdgpu_regnum_t::first_ttmp
       && regnum <= amdgpu_regnum_t::last_ttmp)
@@ -1880,7 +1883,7 @@ amdgcn_architecture_t::register_name (amdgpu_regnum_t regnum) const
         case amdgpu_regnum_t::ttmp10:
         case amdgpu_regnum_t::ttmp11:
         case amdgpu_regnum_t::ttmp13:
-          return string_printf ("ttmp%" PRId64,
+          return string_printf ("ttmp%d",
                                 regnum - amdgpu_regnum_t::first_ttmp);
         default:
           break;
@@ -1889,8 +1892,7 @@ amdgcn_architecture_t::register_name (amdgpu_regnum_t regnum) const
   if (regnum >= amdgpu_regnum_t::first_hwreg
       && regnum <= amdgpu_regnum_t::last_hwreg)
     {
-      return string_printf ("hwreg%" PRId64,
-                            regnum - amdgpu_regnum_t::first_hwreg);
+      return string_printf ("hwreg%d", regnum - amdgpu_regnum_t::first_hwreg);
     }
 
   if (regnum == amdgpu_regnum_t::exec_64
@@ -2087,32 +2089,35 @@ amdgcn_architecture_t::register_read_only_mask (amdgpu_regnum_t regnum) const
     case amdgpu_regnum_t::trapsts:
       {
         static uint32_t trapsts_read_only_bits
-          = utils::bit_mask (9, 9) /* 0  */ | utils::bit_mask (15, 15) /* 0  */
-            | utils::bit_mask (22, 27) /* 0  */;
+          = (utils::bit_mask<uint32_t> (9, 9)       /* 0 */
+             | utils::bit_mask<uint32_t> (15, 15)   /* 0 */
+             | utils::bit_mask<uint32_t> (22, 27)); /* 0 */
         return &trapsts_read_only_bits;
       }
 
     case amdgpu_regnum_t::mode:
       {
-        static uint32_t mode_read_only_bits = utils::bit_mask (21, 22); /* 0 */
+        static uint32_t mode_read_only_bits
+          = utils::bit_mask<uint32_t> (21, 22); /* 0 */
         return &mode_read_only_bits;
       }
 
     case amdgpu_regnum_t::pseudo_status:
       {
         static uint32_t status_read_only_bits
-          = utils::bit_mask (5, 7)      /* priv, trap_en, ttrace_en  */
-            | utils::bit_mask (9, 12)   /* execz, vccz, in_tg, in_barrier  */
-            | utils::bit_mask (14, 16)  /* trap, ttrace_cu_en, valid  */
-            | utils::bit_mask (18, 19)  /* skip_export, perf_en  */
-            | utils::bit_mask (22, 26)  /* allow_replay, fatal_halt, 0  */
-            | utils::bit_mask (28, 31); /* 0  */
+          = (utils::bit_mask<uint32_t> (5, 7)       /* priv, trap_en, ttrace_en */
+             | utils::bit_mask<uint32_t> (9, 12)    /* execz, vccz, in_tg, in_barrier */
+             | utils::bit_mask<uint32_t> (14,16)    /* trap, ttrace_cu_en, valid */
+             | utils::bit_mask<uint32_t> (18, 19)   /* skip_export, perf_en */
+             | utils::bit_mask<uint32_t> (22, 26)   /* allow_replay, fatal_halt, 0 */
+             | utils::bit_mask<uint32_t> (28, 31)); /* 0 */
         return &status_read_only_bits;
       }
 
     case amdgpu_regnum_t::pc:
       {
-        static uint64_t pc_read_only_bits = utils::bit_mask (0, 1); /* 0  */
+        static uint64_t pc_read_only_bits
+          = utils::bit_mask<uint32_t> (0, 1); /* 0  */
         return &pc_read_only_bits;
       }
 
@@ -2344,7 +2349,7 @@ amdgcn_architecture_t::write_pseudo_register (const wave_t &wave,
       memcpy (reinterpret_cast<std::byte *> (&csp) + offset, value,
               value_size);
 
-      mode = (mode & ~utils::bit_mask (29, 31)) | (csp << 29);
+      mode = (mode & ~utils::bit_mask<uint32_t> (29, 31)) | (csp << 29);
 
       wave.write_register (amdgpu_regnum_t::mode, mode);
       return;
@@ -2362,13 +2367,13 @@ amdgcn_architecture_t::save_pc_for_park (const wave_t &wave,
 
   uint32_t ttmp7, ttmp11;
   /* The trap handler saves PC[31:0] in ttmp7[31:0] ...  */
-  ttmp7 = utils::bit_extract (pc, 0, 31);
+  ttmp7 = utils::bit_extract<uint32_t> (pc, 0, 31);
   wave.write_register (amdgpu_regnum_t::ttmp7, ttmp7);
 
   /* ... and PC[47:32] in ttmp11[22:7].  */
   wave.read_register (amdgpu_regnum_t::ttmp11, &ttmp11);
-  ttmp11 &= ~utils::bit_mask (7, 22);
-  ttmp11 |= (utils::bit_extract (pc, 32, 47) << 7);
+  ttmp11 &= ~utils::bit_mask<uint32_t> (7, 22);
+  ttmp11 |= (utils::bit_extract<uint32_t> (pc, 32, 47) << 7);
   wave.write_register (amdgpu_regnum_t::ttmp11, ttmp11);
 }
 
@@ -2597,14 +2602,15 @@ gfx9_architecture_t::gfx9_architecture_t (elf_amdgpu_machine_t e_machine,
 
   /* Scalar registers: [s0-s102].  */
   auto &scalar_registers = create<register_class_t> (*this, "scalar");
-  scalar_registers.add_registers (
-    amdgpu_regnum_t::first_sgpr,
-    amdgpu_regnum_t::first_sgpr + gfx9_architecture_t::scalar_register_count ()
-      - 1);
-  scalar_registers.add_registers (
-    amdgpu_regnum_t::first_shadow_sgpr,
-    amdgpu_regnum_t::first_shadow_sgpr
-      + gfx9_architecture_t::scalar_register_count () - 1);
+  const auto scalar_register_count
+    = utils::narrow<int> (gfx9_architecture_t::scalar_register_count ());
+
+  scalar_registers.add_registers (amdgpu_regnum_t::first_sgpr,
+                                  (amdgpu_regnum_t::first_sgpr
+                                   + scalar_register_count - 1));
+  scalar_registers.add_registers (amdgpu_regnum_t::first_shadow_sgpr,
+                                  (amdgpu_regnum_t::first_shadow_sgpr
+                                   + scalar_register_count - 1));
 
   /* Vector registers: [v0-v255]  */
   auto &vector_registers = create<register_class_t> (*this, "vector");
@@ -2633,10 +2639,9 @@ gfx9_architecture_t::gfx9_architecture_t (elf_amdgpu_machine_t e_machine,
 
   /* General registers: [{scalar}, {vector}, pc, exec, vcc]  */
   auto &general_registers = create<register_class_t> (*this, "general");
-  general_registers.add_registers (
-    amdgpu_regnum_t::first_sgpr,
-    amdgpu_regnum_t::first_sgpr + gfx9_architecture_t::scalar_register_count ()
-      - 1);
+  general_registers.add_registers (amdgpu_regnum_t::first_sgpr,
+                                   amdgpu_regnum_t::first_sgpr
+                                     + scalar_register_count - 1);
   general_registers.add_registers (amdgpu_regnum_t::first_vgpr_64,
                                    amdgpu_regnum_t::last_vgpr_64);
   general_registers.add_registers (amdgpu_regnum_t::m0, amdgpu_regnum_t::m0);
@@ -3149,8 +3154,8 @@ gfx9_architecture_t::cwsr_record_t::register_address (
         return save_area_addr;
     }
 
-  size_t ttmp_size = sizeof (uint32_t);
-  size_t ttmp_count = 16;
+  int ttmp_size = sizeof (uint32_t);
+  int ttmp_count = 16;
   agent_address_t ttmps_addr = save_area_addr - ttmp_count * ttmp_size;
 
   if (regnum >= amdgpu_regnum_t::first_ttmp
@@ -3159,8 +3164,8 @@ gfx9_architecture_t::cwsr_record_t::register_address (
       return ttmps_addr + (regnum - amdgpu_regnum_t::first_ttmp) * ttmp_size;
     }
 
-  size_t hwreg_count = 16;
-  size_t hwreg_size = sizeof (uint32_t);
+  int hwreg_count = 16;
+  int hwreg_size = sizeof (uint32_t);
   agent_address_t hwregs_addr = ttmps_addr - hwreg_count * hwreg_size;
 
   /* Rename registers that map to the hwreg block.  */
@@ -3206,18 +3211,19 @@ gfx9_architecture_t::cwsr_record_t::register_address (
              + (regnum - amdgpu_regnum_t::first_hwreg) * hwreg_size;
     }
 
-  size_t sgpr_count = this->sgpr_count ();
-  size_t sgpr_size = sizeof (int32_t);
+  auto sgpr_count = utils::narrow<int> (this->sgpr_count ());
+  int sgpr_size = sizeof (int32_t);
   agent_address_t sgprs_addr = hwregs_addr - sgpr_count * sgpr_size;
 
+  auto arch_scalars_count
+    = utils::narrow<int> (architecture.scalar_register_count ()
+                          + architecture.scalar_alias_count ());
   amdgpu_regnum_t aliased_sgpr_end
-    = amdgpu_regnum_t::first_sgpr
-      + std::min (architecture.scalar_register_count ()
-                    + architecture.scalar_alias_count (),
-                  sgpr_count);
+    = amdgpu_regnum_t::first_sgpr + std::min (arch_scalars_count, sgpr_count);
 
   /* Exclude the aliased sgprs.  */
-  if (regnum >= (aliased_sgpr_end - architecture.scalar_alias_count ())
+  if (regnum >= (aliased_sgpr_end
+                 - utils::narrow<int> (architecture.scalar_alias_count ()))
       && regnum < aliased_sgpr_end)
     return std::nullopt;
 
@@ -3247,7 +3253,8 @@ gfx9_architecture_t::cwsr_record_t::register_address (
       + (amdgpu_regnum_t::first_shadow_sgpr - amdgpu_regnum_t::first_sgpr);
 
   /* Map the shadow sgprs onto the same slots as "regular" sgprs.  */
-  if (regnum >= (shadow_sgpr_end - architecture.scalar_alias_count ())
+  if (regnum >= (shadow_sgpr_end
+                 - utils::narrow<int> (architecture.scalar_alias_count ()))
       && regnum < shadow_sgpr_end)
     {
       /* The xnack_mask register (shadow_sgpr_end[-4:-3]) really is saved in
@@ -3264,8 +3271,8 @@ gfx9_architecture_t::cwsr_record_t::register_address (
       return sgprs_addr + (regnum - amdgpu_regnum_t::s0) * sgpr_size;
     }
 
-  size_t vgpr_count = this->vgpr_count ();
-  size_t vgpr_size = sizeof (int32_t) * 64;
+  auto vgpr_count = utils::narrow<int> (this->vgpr_count ());
+  int vgpr_size = sizeof (int32_t) * 64;
   agent_address_t vgprs_addr = sgprs_addr - vgpr_count * vgpr_size;
 
   if (regnum >= amdgpu_regnum_t::first_vgpr_64
@@ -3357,8 +3364,8 @@ gfx9_architecture_t::scratch_memory_region (
   amd_dbgapi_size_t wavesize
     = utils::bit_extract (compute_tmpring_size_register, 12, 24) * 1024;
 
-  uint32_t shader_engine_count
-    = agent.os_info ().shader_engine_count / agent.os_info ().xcc_count;
+  auto shader_engine_count = utils::narrow<uint32_t> (
+    agent.os_info ().shader_engine_count / agent.os_info ().xcc_count);
   dbgapi_assert (shader_engine_count != 0);
 
   amd_dbgapi_size_t offset
@@ -3491,8 +3498,7 @@ mi_architecture_t::register_name (amdgpu_regnum_t regnum) const
   if (regnum >= amdgpu_regnum_t::first_accvgpr_64
       && regnum <= amdgpu_regnum_t::last_accvgpr_64)
     {
-      return string_printf ("a%" PRId64,
-                            regnum - amdgpu_regnum_t::first_accvgpr_64);
+      return string_printf ("a%d", regnum - amdgpu_regnum_t::first_accvgpr_64);
     }
 
   return gfx9_architecture_t::register_name (regnum);
@@ -3537,8 +3543,8 @@ mi_architecture_t::cwsr_record_t::register_address (
 
   agent_address_t sgprs_addr = *first_sgpr_addr;
 
-  size_t accvgpr_count = this->acc_vgpr_count ();
-  size_t accvgpr_size = sizeof (int32_t) * 64;
+  auto accvgpr_count = utils::narrow<int> (this->acc_vgpr_count ());
+  int accvgpr_size = sizeof (int32_t) * 64;
   agent_address_t accvgprs_addr = sgprs_addr - accvgpr_count * accvgpr_size;
 
   if (regnum >= amdgpu_regnum_t::first_accvgpr_64
@@ -3548,8 +3554,8 @@ mi_architecture_t::cwsr_record_t::register_address (
       return accvgprs_addr + (regnum - amdgpu_regnum_t::a0_64) * accvgpr_size;
     }
 
-  size_t vgpr_count = this->vgpr_count ();
-  size_t vgpr_size = sizeof (int32_t) * 64;
+  auto vgpr_count = utils::narrow<int> (this->vgpr_count ());
+  int vgpr_size = sizeof (int32_t) * 64;
   agent_address_t vgprs_addr = accvgprs_addr - vgpr_count * vgpr_size;
 
   if (regnum >= amdgpu_regnum_t::first_vgpr_64
@@ -3716,10 +3722,10 @@ protected:
   static constexpr uint32_t sq_wave_trapsts_trap_after_inst_mask = 1 << 25;
   static constexpr uint32_t sq_wave_trapsts_perf_snapshot_mask = 1 << 26;
 
-  static constexpr uint32_t ttmp11_queue_packet_id_mask
-    = utils::bit_mask (6, 30);
+  static constexpr auto ttmp11_queue_packet_id_mask
+    = utils::bit_mask<uint32_t> (6, 30);
   static constexpr int ttmp11_queue_packet_id_shift = 6;
-  static constexpr uint32_t ttmp11_trap_hander_ttmps_setup_mask = 1 << 31;
+  static constexpr uint32_t ttmp11_trap_hander_ttmps_setup_mask = 1u << 31;
 
   class cwsr_record_t : public gfx90a_t::cwsr_record_t
   {
@@ -4109,22 +4115,24 @@ gfx9_4_architecture_t::register_read_only_mask (amdgpu_regnum_t regnum) const
     {
     case amdgpu_regnum_t::trapsts:
       static uint32_t trapsts_read_only_bits
-        = utils::bit_mask (9, 9) /* 0  */ | utils::bit_mask (15, 15) /* 0  */
-          | utils::bit_mask (27, 27) /* 0  */;
+        = (utils::bit_mask<uint32_t> (9, 9)       /* 0 */
+           | utils::bit_mask<uint32_t> (15, 15)   /* 0 */
+           | utils::bit_mask<uint32_t> (27, 27)); /* 0 */
       return &trapsts_read_only_bits;
 
     case amdgpu_regnum_t::mode:
-      static uint32_t mode_read_only_bits = utils::bit_mask (22, 22); /* 0 */
+      static uint32_t mode_read_only_bits
+        = utils::bit_mask<uint32_t> (22, 22); /* 0 */
       return &mode_read_only_bits;
 
     case amdgpu_regnum_t::pseudo_status:
       static uint32_t status_read_only_bits
-        = utils::bit_mask (5, 7)      /* priv, trap_en, ttrace_en  */
-          | utils::bit_mask (9, 12)   /* execz, vccz, in_tg, in_barrier  */
-          | utils::bit_mask (14, 16)  /* trap, ttrace_cu_en, valid  */
-          | utils::bit_mask (18, 19)  /* skip_export, perf_en  */
-          | utils::bit_mask (22, 26)  /* allow_replay, fatal_halt, 0  */
-          | utils::bit_mask (29, 30); /* 0  */
+        = (utils::bit_mask<uint32_t> (5, 7)       /* priv, trap_en, ttrace_en */
+           | utils::bit_mask<uint32_t> (9, 12)    /* execz, vccz, in_tg, in_barrier */
+           | utils::bit_mask<uint32_t> (14, 16)   /* trap, ttrace_cu_en, valid */
+           | utils::bit_mask<uint32_t> (18, 19)   /* skip_export, perf_en */
+           | utils::bit_mask<uint32_t> (22, 26)   /* allow_replay, fatal_halt, 0 */
+           | utils::bit_mask<uint32_t> (29, 30)); /* 0 */
       return &status_read_only_bits;
 
     default:
@@ -4394,17 +4402,18 @@ gfx10_architecture_t::gfx10_architecture_t (elf_amdgpu_machine_t e_machine,
                { return register_class.name () == "scalar"; });
   dbgapi_assert (scalar_registers != nullptr);
 
-  scalar_registers->add_registers (
-    amdgpu_regnum_t::first_sgpr
-      + gfx9_architecture_t::scalar_register_count (),
-    amdgpu_regnum_t::first_sgpr
-      + gfx10_architecture_t::scalar_register_count () - 1);
+  auto gfx9_scalar_register_count
+    = utils::narrow<int> (gfx9_architecture_t::scalar_register_count ());
+  auto gfx10_scalar_register_count
+    = utils::narrow<int> (gfx10_architecture_t::scalar_register_count ());
 
   scalar_registers->add_registers (
-    amdgpu_regnum_t::first_shadow_sgpr
-      + gfx9_architecture_t::scalar_register_count (),
-    amdgpu_regnum_t::first_shadow_sgpr
-      + gfx10_architecture_t::scalar_register_count () - 1);
+    amdgpu_regnum_t::first_sgpr + gfx9_scalar_register_count,
+    amdgpu_regnum_t::first_sgpr + gfx10_scalar_register_count - 1);
+
+  scalar_registers->add_registers (
+    amdgpu_regnum_t::first_shadow_sgpr + gfx9_scalar_register_count,
+    amdgpu_regnum_t::first_shadow_sgpr + gfx10_scalar_register_count - 1);
 
   /* Vector registers: [v0_32-v255_32]  */
   register_class_t *vector_registers
@@ -4438,10 +4447,8 @@ gfx10_architecture_t::gfx10_architecture_t (elf_amdgpu_machine_t e_machine,
   dbgapi_assert (general_registers != nullptr);
 
   general_registers->add_registers (
-    amdgpu_regnum_t::first_sgpr
-      + gfx9_architecture_t::scalar_register_count (),
-    amdgpu_regnum_t::first_sgpr
-      + gfx10_architecture_t::scalar_register_count () - 1);
+    amdgpu_regnum_t::first_sgpr + gfx9_scalar_register_count,
+    amdgpu_regnum_t::first_sgpr + gfx10_scalar_register_count - 1);
   general_registers->add_registers (amdgpu_regnum_t::first_vgpr_32,
                                     amdgpu_regnum_t::last_vgpr_32);
   general_registers->add_registers (amdgpu_regnum_t::pseudo_exec_32,
@@ -4456,8 +4463,7 @@ gfx10_architecture_t::register_name (amdgpu_regnum_t regnum) const
   if (regnum >= amdgpu_regnum_t::first_vgpr_32
       && regnum <= amdgpu_regnum_t::last_vgpr_32)
     {
-      return string_printf ("v%" PRId64,
-                            regnum - amdgpu_regnum_t::first_vgpr_32);
+      return string_printf ("v%d", regnum - amdgpu_regnum_t::first_vgpr_32);
     }
   if (regnum == amdgpu_regnum_t::exec_32
       || regnum == amdgpu_regnum_t::pseudo_exec_32)
@@ -4888,13 +4894,13 @@ gfx10_architecture_t::cwsr_record_t::register_address (
      of a wave64 on gfx10.  They are logically addressed right after the
      64-wide private vector registers.  Note: In wave32, although unsupported,
      they are still allocated.  */
-  size_t shared_vgpr_count = this->shared_vgpr_count ();
-  size_t shared_vgpr_size = sizeof (int32_t) * 32;
+  auto shared_vgpr_count = utils::narrow<int> (this->shared_vgpr_count ());
+  int shared_vgpr_size = sizeof (int32_t) * 32;
   agent_address_t shared_vgprs_addr
     = sgprs_addr - shared_vgpr_count * shared_vgpr_size;
 
-  size_t private_vgpr_count = this->vgpr_count ();
-  size_t private_vgpr_size = sizeof (int32_t) * lane_count;
+  auto private_vgpr_count = utils::narrow<int> (this->vgpr_count ());
+  auto private_vgpr_size = utils::narrow<int> (sizeof (int32_t) * lane_count);
   agent_address_t private_vgprs_addr
     = shared_vgprs_addr - private_vgpr_count * private_vgpr_size;
 
@@ -5750,23 +5756,25 @@ gfx11_architecture_t::register_read_only_mask (amdgpu_regnum_t regnum) const
     case amdgpu_regnum_t::trapsts:
       {
         static uint32_t trapsts_read_only_bits
-          = utils::bit_mask (9, 9) /* 0  */ | utils::bit_mask (21, 27) /* 0  */
-            | utils::bit_mask (29, 31) /* 0  */;
+          = (utils::bit_mask<uint32_t> (9, 9)       /* 0  */
+             | utils::bit_mask<uint32_t> (21, 27)   /* 0  */
+             | utils::bit_mask<uint32_t> (29, 31)); /* 0  */
         return &trapsts_read_only_bits;
       }
 
     case amdgpu_regnum_t::mode:
       {
         static uint32_t mode_read_only_bits
-          = utils::bit_mask (22, 22)   /* 0 */
-            | utils::bit_mask (24, 26) /* 0 */
-            | utils::bit_mask (28, 31) /* 0 */;
+          = (utils::bit_mask<uint32_t> (22, 22)     /* 0 */
+             | utils::bit_mask<uint32_t> (24, 26)   /* 0 */
+             | utils::bit_mask<uint32_t> (28, 31)); /* 0 */
         return &mode_read_only_bits;
       }
 
     case amdgpu_regnum_t::pseudo_status:
       {
-        static uint32_t status_read_only_bits = utils::bit_mask (0, 31);
+        static uint32_t status_read_only_bits
+          = utils::bit_mask<uint32_t> (0, 31);
         return &status_read_only_bits;
       }
 
@@ -5969,7 +5977,7 @@ gfx11_architecture_t::is_sendmsg (const instruction_t &instruction,
   if (message != nullptr)
     {
       /* Message type is in SIMM16[7:0] */
-      *message = simm16_operand (instruction) & 0xff;
+      utils::narrow_assign (*message, simm16_operand (instruction) & 0xff);
     }
 
   return true;
@@ -6020,8 +6028,8 @@ gfx11_architecture_t::scratch_memory_region (
                               + cwsr_record.scratch_scoreboard_id ())
                              * wavesize;
 
-  uint32_t shader_engine_count
-    = agent.os_info ().shader_engine_count / agent.os_info ().xcc_count;
+  auto shader_engine_count = utils::narrow<uint32_t> (
+    agent.os_info ().shader_engine_count / agent.os_info ().xcc_count);
 
   /* The scratch memory is evenly divided between all XCCs, so each XCC has its
      own scratch base.  */
@@ -6125,13 +6133,13 @@ protected:
   static constexpr uint32_t sq_wave_state_priv_barrier_complete_mask = 1 << 2;
   static constexpr uint32_t sq_wave_state_priv_named_barrier_complete_mask
     = 1 << 3;
-  static constexpr uint32_t sq_wave_state_priv_named_barrier_id_mask
-    = utils::bit_mask (4, 8);
+  static constexpr auto sq_wave_state_priv_named_barrier_id_mask
+    = utils::bit_mask<uint32_t> (4, 8);
   static constexpr uint32_t sq_wave_state_priv_scc_mask = 1 << 9;
-  static constexpr uint32_t sq_wave_state_priv_sys_prio_mask
-    = utils::bit_mask (10, 11);
-  static constexpr uint32_t sq_wave_state_priv_user_prio_mask
-    = utils::bit_mask (12, 13);
+  static constexpr auto sq_wave_state_priv_sys_prio_mask
+    = utils::bit_mask<uint32_t> (10, 11);
+  static constexpr auto sq_wave_state_priv_user_prio_mask
+    = utils::bit_mask<uint32_t> (12, 13);
   static constexpr uint32_t sq_wave_state_priv_halt_mask = 1 << 14;
   static constexpr uint32_t sq_wave_state_priv_poison_err_mask = 1 << 15;
   static constexpr uint32_t sq_wave_state_priv_cond_dbg_user_mask = 1 << 16;
@@ -6140,13 +6148,13 @@ protected:
   static constexpr uint32_t sq_wave_state_priv_perf_en_mask = 1 << 19;
   static constexpr uint32_t sq_wave_state_priv_ttrace_en_mask = 1 << 20;
 
-  static constexpr uint32_t ttmp8_queue_packet_id_mask
-    = utils::bit_mask (0, 24);
+  static constexpr auto ttmp8_queue_packet_id_mask
+    = utils::bit_mask<uint32_t> (0, 24);
   static constexpr uint32_t ttmp8_queue_packet_id_shift = 0;
-  static constexpr uint32_t ttmp8_wave_in_group_mask
-    = utils::bit_mask (25, 29);
+  static constexpr auto ttmp8_wave_in_group_mask
+    = utils::bit_mask<uint32_t> (25, 29);
   static constexpr uint32_t ttmp8_grid_yz_valid = 1 << 30;
-  static constexpr uint32_t ttmp8_debug_mark_mask = 1 << 31;
+  static constexpr uint32_t ttmp8_debug_mark_mask = 1u << 31;
 
   static constexpr uint32_t sq_wave_trap_ctrl_alu_invalid_mask = 1 << 0;
   static constexpr uint32_t sq_wave_trap_ctrl_alu_input_denorm_mask = 1 << 1;
@@ -6172,8 +6180,8 @@ protected:
   static constexpr uint32_t sq_wave_excp_priv_perf_snapshot_mask = 1 << 10;
   static constexpr uint32_t sq_wave_excp_priv_trap_after_inst_mask = 1 << 11;
   static constexpr uint32_t sq_wave_excp_priv_xnack_error_mask = 1 << 12;
-  static constexpr uint32_t sq_wave_excp_priv_first_memviol_source_watch
-    = utils::bit_mask (30, 31);
+  static constexpr auto sq_wave_excp_priv_first_memviol_source_watch
+    = utils::bit_mask<uint32_t> (30, 31);
 
   static constexpr uint32_t sq_wave_excp_user_alu_invalid_mask = 1 << 0;
   static constexpr uint32_t sq_wave_excp_user_alu_input_denorm_mask = 1 << 1;
@@ -6183,7 +6191,7 @@ protected:
   static constexpr uint32_t sq_wave_excp_user_alu_inexact_mask = 1 << 5;
   static constexpr uint32_t sq_wave_excp_user_alu_int_div0_mask = 1 << 6;
   static constexpr uint32_t sq_wave_excp_user_buffer_oob_mask = 1 << 30;
-  static constexpr uint32_t sq_wave_excp_user_lod_clamped_mask = 1 << 31;
+  static constexpr uint32_t sq_wave_excp_user_lod_clamped_mask = 1u << 31;
 
   class cwsr_record_t : public gfx11_architecture_t::cwsr_record_t
   {
@@ -6837,39 +6845,43 @@ gfx12_architecture_t::register_read_only_mask (amdgpu_regnum_t regnum) const
       {
         /* PRIV is RO, all unasigned bits are 0.  */
         static uint32_t status_ro_bits
-          = utils::bit_mask (0, 5) | utils::bit_mask (7, 7)
-            | utils::bit_mask (12, 13) | utils::bit_mask (17, 17)
-            | utils::bit_mask (19, 21);
+          = (utils::bit_mask<uint32_t> (0, 5)
+             | utils::bit_mask<uint32_t> (7, 7)
+             | utils::bit_mask<uint32_t> (12, 13)
+             | utils::bit_mask<uint32_t> (17, 17)
+             | utils::bit_mask<uint32_t> (19, 21));
         return &status_ro_bits;
       }
     case amdgpu_regnum_t::pseudo_state_priv:
       {
         static uint32_t state_priv_ro_bits
-          = utils::bit_mask (15, 17)
-            | utils::bit_mask (19, 20) /* PERF_EN and TTRACE_EN are RO.  */
-            | utils::bit_mask (21, 31);
+          = (utils::bit_mask<uint32_t> (15, 17)
+             | utils::bit_mask<uint32_t> (19, 20) /* PERF_EN and TTRACE_EN are RO.  */
+             | utils::bit_mask<uint32_t> (21, 31));
         return &state_priv_ro_bits;
       }
     case amdgpu_regnum_t::mode:
       {
-        static uint32_t mode_ro_bits = utils::bit_mask (8, 22)
-                                       | utils::bit_mask (25, 26)
-                                       | utils::bit_mask (28, 31);
+        static uint32_t mode_ro_bits = (utils::bit_mask<uint32_t> (8, 22)
+                                        | utils::bit_mask<uint32_t> (25, 26)
+                                        | utils::bit_mask<uint32_t> (28, 31));
         return &mode_ro_bits;
       }
     case amdgpu_regnum_t::trap_ctrl:
       {
-        static uint32_t trap_ctrl_ro_bits = utils::bit_mask (10, 31);
+        static uint32_t trap_ctrl_ro_bits = utils::bit_mask<uint32_t> (10, 31);
         return &trap_ctrl_ro_bits;
       }
     case amdgpu_regnum_t::excp_flag_priv:
       {
-        static uint32_t excp_flag_priv_ro_bits = utils::bit_mask (13, 29);
+        static uint32_t excp_flag_priv_ro_bits
+          = utils::bit_mask<uint32_t> (13, 29);
         return &excp_flag_priv_ro_bits;
       }
     case amdgpu_regnum_t::excp_flag_user:
       {
-        static uint32_t excp_flag_user_ro_bits = utils::bit_mask (7, 29);
+        static uint32_t excp_flag_user_ro_bits
+          = utils::bit_mask<uint32_t> (7, 29);
         return &excp_flag_user_ro_bits;
       }
 
@@ -7147,13 +7159,13 @@ gfx12_architecture_t::save_pc_for_park (const wave_t &wave,
 
   uint32_t ttmp10, ttmp11;
   /* The trap handler saves PC[31:0] in ttmp10[31:0] ...  */
-  ttmp10 = utils::bit_extract (pc, 0, 31);
+  ttmp10 = utils::bit_extract<uint32_t> (pc, 0, 31);
   wave.write_register (amdgpu_regnum_t::ttmp10, ttmp10);
 
   /* ... and PC[47:32] in ttmp11[22:7].  */
   wave.read_register (amdgpu_regnum_t::ttmp11, &ttmp11);
-  ttmp11 &= ~utils::bit_mask (7, 22);
-  ttmp11 |= (utils::bit_extract (pc, 32, 47) << 7);
+  ttmp11 &= ~utils::bit_mask<uint32_t> (7, 22);
+  ttmp11 |= (utils::bit_extract<uint32_t> (pc, 32, 47) << 7);
   wave.write_register (amdgpu_regnum_t::ttmp11, ttmp11);
 }
 
@@ -7300,8 +7312,8 @@ gfx12_architecture_t::cwsr_record_t::group_ids () const
   coordinates[0] = ttmp9;
   if (ttmp8 & ttmp8_grid_yz_valid)
     {
-      coordinates[1] = ttmp7 & utils::bit_mask (0, 15);
-      coordinates[2] = (ttmp7 & utils::bit_mask (16, 31)) >> 16;
+      coordinates[1] = ttmp7 & utils::bit_mask<uint32_t> (0, 15);
+      coordinates[2] = (ttmp7 & utils::bit_mask<uint32_t> (16, 31)) >> 16;
     }
 
   return coordinates;
@@ -7320,7 +7332,7 @@ gfx12_architecture_t::cwsr_record_t::position_in_group () const
 
   agent ().read_agent_memory (ttmp8_address, &ttmp8);
 
-  return (ttmp8 & utils::bit_mask (25, 29)) >> 25;
+  return utils::narrow<uint32_t> ((ttmp8 & utils::bit_mask (25, 29)) >> 25);
 }
 
 size_t
@@ -7467,8 +7479,8 @@ gfx12_architecture_t::scratch_memory_region (
                               + cwsr_record.scratch_scoreboard_id ())
                              * wavesize;
 
-  uint32_t shader_engine_count
-    = agent.os_info ().shader_engine_count / agent.os_info ().xcc_count;
+  auto shader_engine_count = utils::narrow<uint32_t> (
+    agent.os_info ().shader_engine_count / agent.os_info ().xcc_count);
 
   /* The scratch memory is evenly divided between all XCCs, so each XCC has its
      own scratch base.  */

--- a/projects/rocdbgapi/src/memory.h
+++ b/projects/rocdbgapi/src/memory.h
@@ -77,20 +77,20 @@ public:
 
   template <typename U> T operator+ (U increment) const
   {
-    return T{ m_address + increment };
+    return T{ m_address + static_cast<uint64_t> (increment) };
   }
   template <typename U> T operator- (U decrement) const
   {
-    return T{ m_address - decrement };
+    return T{ m_address - static_cast<uint64_t> (decrement) };
   }
   template <typename U> T &operator+= (U increment)
   {
-    m_address += increment;
+    m_address += static_cast<uint64_t> (increment);
     return static_cast<T &> (*this);
   }
   template <typename U> T &operator-= (U decrement)
   {
-    m_address -= decrement;
+    m_address -= static_cast<uint64_t> (decrement);
     return static_cast<T &> (*this);
   }
 };
@@ -123,6 +123,55 @@ public:
 template <> std::string to_string (agent_address_t address);
 template <> std::string to_string (host_address_t address);
 template <> std::string to_string (global_address_t address);
+
+namespace detail
+{
+
+/* Inherit from std::numeric_limits<uint64_t> and only override the
+   functions that return the type T.  */
+template <typename T>
+class numeric_limits_address_t : public std::numeric_limits<uint64_t>
+{
+public:
+  static constexpr bool is_specialized = true;
+
+  static constexpr T min () noexcept
+  {
+    return T (std::numeric_limits<uint64_t>::min ());
+  }
+  static constexpr T max () noexcept
+  {
+    return T (std::numeric_limits<uint64_t>::max ());
+  }
+  static constexpr T lowest () noexcept { return min (); }
+};
+
+} /* namespace amd::dbgapi::detail */
+} /* namespace amd::dbgapi */
+
+/* Specializations of std::numeric_limits for address_t types, using
+   the numeric_limits_address_t helper.  */
+namespace std
+{
+
+#define SPECIALIZE(ADDRESS)                                                   \
+  template <>                                                                 \
+  class numeric_limits<amd::dbgapi::ADDRESS>                                  \
+    : public amd::dbgapi::detail::numeric_limits_address_t<                   \
+        amd::dbgapi::ADDRESS>                                                 \
+  {                                                                           \
+  }
+
+SPECIALIZE (agent_address_t);
+SPECIALIZE (host_address_t);
+SPECIALIZE (global_address_t);
+
+#undef SPECIALIZE
+
+} /* namespace std */
+
+namespace amd::dbgapi
+{
 
 class address_class_t;
 
@@ -540,11 +589,13 @@ public:
   /* Discard all cache lines in the specified range.  If FORCE_DISCARD
      is true, dirty lines are silently dropped.  Otherwise it is an error to
      discarded dirty cache lines.  */
-  void discard (AddressType address = 0, amd_dbgapi_size_t size = -1,
+  void discard (AddressType address = 0,
+                amd_dbgapi_size_t size = amd_dbgapi_size_t (-1),
                 bool force_discard = false);
 
   /* Write dirty lines back to memory.  */
-  void write_back (AddressType address = 0, amd_dbgapi_size_t size = -1);
+  void write_back (AddressType address = 0,
+                   amd_dbgapi_size_t size = amd_dbgapi_size_t (-1));
 
   [[nodiscard]] size_t read_global_memory (AddressType address, void *buffer,
                                            size_t size)

--- a/projects/rocdbgapi/src/os_driver_kfd.cpp
+++ b/projects/rocdbgapi/src/os_driver_kfd.cpp
@@ -344,7 +344,7 @@ kfd_wave_launch_trap_mask (os_wave_launch_trap_mask_t wave_launch_trap)
       case os_wave_launch_trap_mask_t::wave_start:
         return KFD_DBG_TRAP_MASK_TRAP_ON_WAVE_START;
       case os_wave_launch_trap_mask_t::wave_end:
-        return KFD_DBG_TRAP_MASK_TRAP_ON_WAVE_END;
+        return (__u32)KFD_DBG_TRAP_MASK_TRAP_ON_WAVE_END;
       }
 
     dbgapi_assert_not_reached ();
@@ -387,7 +387,7 @@ os_wave_launch_trap_mask (__u32 wave_launch_trap)
     mask |= os_wave_launch_trap_mask_t::address_watch;
   if (!!(wave_launch_trap & KFD_DBG_TRAP_MASK_TRAP_ON_WAVE_START))
     mask |= os_wave_launch_trap_mask_t::wave_start;
-  if (!!(wave_launch_trap & KFD_DBG_TRAP_MASK_TRAP_ON_WAVE_END))
+  if (!!(wave_launch_trap & (__u32)KFD_DBG_TRAP_MASK_TRAP_ON_WAVE_END))
     mask |= os_wave_launch_trap_mask_t::wave_end;
 
   return mask;
@@ -420,7 +420,7 @@ decode_queue_id (__u32 queue_id)
   os_queue_state_t queue_state{};
   if (queue_id & KFD_DBG_QUEUE_ERROR_MASK)
     queue_state |= os_queue_state_t::error;
-  if (queue_id & KFD_DBG_QUEUE_INVALID_MASK)
+  if (queue_id & (__u32)KFD_DBG_QUEUE_INVALID_MASK)
     queue_state |= os_queue_state_t::invalid;
 
   return { queue_id & ~(KFD_DBG_QUEUE_ERROR_MASK | KFD_DBG_QUEUE_INVALID_MASK),
@@ -663,7 +663,7 @@ kfd_driver_base_t::agent_snapshot (
       agent_info.local_address_aperture_limit = entry.lds_limit;
       agent_info.private_address_aperture_base = entry.scratch_base;
       agent_info.private_address_aperture_limit = entry.scratch_limit;
-      agent_info.location_id = entry.location_id;
+      utils::narrow_assign (agent_info.location_id, entry.location_id);
       agent_info.simd_count = entry.simd_count;
       agent_info.max_waves_per_simd = entry.max_waves_per_simd;
       agent_info.vendor_id = entry.vendor_id;
@@ -1219,7 +1219,7 @@ kfd_driver_t::kfd_dbg_trap_ioctl (uint32_t action,
 {
   dbgapi_assert (m_os_pid);
 
-  args->pid = *m_os_pid;
+  utils::narrow_assign (args->pid, *m_os_pid);
   args->op = action;
 
   int ret = kfd_ioctl (AMDKFD_IOC_DBG_TRAP, args);
@@ -1272,7 +1272,7 @@ struct kfd_snapshots
 
     dbgapi_assert (n_ent == entries.size ());
 
-    n_entries = n_ent;
+    utils::narrow_assign (n_entries, n_ent);
     entry_size = sizeof (T);
 
     /* The rest of the code assumes that a T is 64-bit aligned.  */
@@ -1482,7 +1482,7 @@ kfd_driver_t::enable_debug (os_exception_mask_t exceptions_reported,
   args.enable.exception_mask = kfd_exception_mask (exceptions_reported);
   args.enable.rinfo_ptr = reinterpret_cast<uintptr_t> (&os_runtime_info);
   args.enable.rinfo_size = sizeof (kfd_runtime_info);
-  args.enable.dbg_fd = notifier;
+  utils::narrow_assign (args.enable.dbg_fd, notifier);
 
   int err = kfd_dbg_trap_ioctl (KFD_IOC_DBG_TRAP_ENABLE, &args);
   if (err == -ESRCH)
@@ -1566,8 +1566,10 @@ kfd_driver_t::send_exceptions (os_exception_mask_t exceptions,
 
   kfd_ioctl_dbg_trap_args args{};
   args.send_runtime_event.exception_mask = kfd_exception_mask (exceptions);
-  args.send_runtime_event.gpu_id = agent_id.has_value () ? *agent_id : -1;
-  args.send_runtime_event.queue_id = queue_id.has_value () ? *queue_id : -1;
+  args.send_runtime_event.gpu_id
+    = agent_id.has_value () ? *agent_id : os_agent_id_t (-1);
+  args.send_runtime_event.queue_id
+    = queue_id.has_value () ? *queue_id : os_agent_id_t (-1);
 
   int err = kfd_dbg_trap_ioctl (KFD_IOC_DBG_TRAP_SEND_RUNTIME_EVENT, &args);
   if (err == -ESRCH)
@@ -1700,7 +1702,7 @@ kfd_driver_t::suspend_queues (const os_queue_id_t *queues, size_t queue_count,
   else if (ret < 0)
     return AMD_DBGAPI_STATUS_ERROR;
 
-  *suspended_count = ret;
+  *suspended_count = static_cast<size_t> (ret);
   for (size_t i = 0; i < queue_count; i++)
     {
       auto [queue_id, queue_state] = decode_queue_id (kfd_queue_ids[i]);
@@ -1744,7 +1746,7 @@ kfd_driver_t::resume_queues (const os_queue_id_t *queues, size_t queue_count,
   else if (ret < 0)
     return AMD_DBGAPI_STATUS_ERROR;
 
-  *resumed_count = ret;
+  utils::narrow_assign (*resumed_count, ret);
   for (size_t i = 0; i < queue_count; i++)
     {
       auto [queue_id, queue_state] = decode_queue_id (kfd_queue_ids[i]);
@@ -1815,7 +1817,9 @@ kfd_driver_t::set_address_watch (os_agent_id_t os_agent_id,
   kfd_ioctl_dbg_trap_args args{};
   args.set_node_address_watch.address = address;
   args.set_node_address_watch.mode = kfd_watch_mode (os_watch_mode);
-  args.set_node_address_watch.mask = mask;
+  using mask_t = decltype (args.set_node_address_watch.mask);
+  utils::narrow_assign (args.set_node_address_watch.mask,
+                        mask & mask_t (-1));
   args.set_node_address_watch.gpu_id = os_agent_id;
 
   int err
@@ -1945,9 +1949,10 @@ kfd_driver_t::xfer_global_memory_partial (global_address_t address, void *read,
 
   ++(read != nullptr ? m_read_request_count : m_write_request_count);
 
+  auto offset = utils::narrow<off_t> (address);
   ssize_t ret = read != nullptr
-                  ? pread (*m_proc_mem_fd, read, *size, address)
-                  : pwrite (*m_proc_mem_fd, write, *size, address);
+                  ? pread (*m_proc_mem_fd, read, *size, offset)
+                  : pwrite (*m_proc_mem_fd, write, *size, offset);
 
   if (ret < 0 && errno != EIO && errno != EINVAL)
     warning ("kfd_driver_t::xfer_memory failed: %s", strerror (errno));
@@ -1957,9 +1962,10 @@ kfd_driver_t::xfer_global_memory_partial (global_address_t address, void *read,
   else if (ret < 0)
     return AMD_DBGAPI_STATUS_ERROR_MEMORY_ACCESS;
 
-  (read != nullptr ? m_bytes_read : m_bytes_written) += ret;
+  auto uret = static_cast<size_t> (ret);
+  (read != nullptr ? m_bytes_read : m_bytes_written) += uret;
 
-  *size = ret;
+  *size = uret;
   return AMD_DBGAPI_STATUS_SUCCESS;
 }
 

--- a/projects/rocdbgapi/src/os_driver_kmd.cpp
+++ b/projects/rocdbgapi/src/os_driver_kmd.cpp
@@ -21,6 +21,7 @@
 #include "debug.h"
 #include "logging.h"
 #include "os_driver.h"
+#include "utils_windows.h"
 
 /* Make sure we use the STATUS_XXX constants from ntstatus.h.  Some of
    the constants we use (but not all) are defined in winnt.h too, but
@@ -1279,28 +1280,17 @@ kmd_driver_t::get_adapter_name (D3DKMT_HANDLE adapter) const
   query_info.pPrivateDriverData = &adapter_reg_info;
   query_info.PrivateDriverDataSize = sizeof (D3DKMT_ADAPTERREGISTRYINFO);
 
-  if (m_d3d.api.query_adapter_info (&query_info) != STATUS_SUCCESS)
-    return "<unknown>";
+  if (m_d3d.api.query_adapter_info (&query_info) == STATUS_SUCCESS)
+    {
+      size_t wide_len = ::wcsnlen (adapter_reg_info.AdapterString,
+                                   std::size (adapter_reg_info.AdapterString));
+      std::wstring_view ws (adapter_reg_info.AdapterString, wide_len);
+      std::string name = utils::convert_to_string (ws);
+      if (!name.empty ())
+        return name;
+    }
 
-  size_t wide_len = ::wcsnlen (adapter_reg_info.AdapterString,
-                               std::size (adapter_reg_info.AdapterString));
-  if (wide_len == 0)
-    return "<unknown>";
-
-  int size_needed
-    = WideCharToMultiByte (CP_ACP, 0, adapter_reg_info.AdapterString,
-                           (int)wide_len, nullptr, 0,
-                           nullptr, nullptr);
-  if (size_needed <= 0)
-    return "<unknown>";
-
-  std::string result (size_needed, '\0');
-  int size
-    = WideCharToMultiByte (CP_ACP, 0, adapter_reg_info.AdapterString,
-                           (int)wide_len, &result[0], size_needed,
-                           "?", nullptr);
-  dbgapi_assert (size == size_needed);
-  return result;
+  return "<unknown>";
 }
 
 amd_dbgapi_status_t

--- a/projects/rocdbgapi/src/os_driver_kmd.cpp
+++ b/projects/rocdbgapi/src/os_driver_kmd.cpp
@@ -2129,77 +2129,77 @@ kmd_driver_t::xfer_agent_memory_partial (os_agent_id_t agent_id,
      aligned.  If so, use an intermediate guaranteed-aligned
      buffer.  */
   size_t misalign = (read != nullptr
-		     ? (uintptr_t) read % sizeof (DWORD)
-		     : (uintptr_t) write % sizeof (DWORD));
+                     ? (uintptr_t) read % sizeof (DWORD)
+                     : (uintptr_t) write % sizeof (DWORD));
   if (misalign != 0)
     {
       /* Large enough to fit most xfers in one escape call, and small
-	 enough to not cause stack overflow problems.  */
+         enough to not cause stack overflow problems.  */
       constexpr size_t aligned_buffer_size = 64;
       alignas(DWORD) std::byte aligned_buffer[aligned_buffer_size];
 
       /* If we need a second xfer, read/write enough bytes such that
-	 that xfer will be aligned.  */
+         that xfer will be aligned.  */
       size_t partial_size = (*size > sizeof (aligned_buffer)
-			     ? misalign
-			     : *size);
+                             ? misalign
+                             : *size);
 
       if (write != nullptr)
-	std::memcpy (aligned_buffer, write, partial_size);
+        std::memcpy (aligned_buffer, write, partial_size);
 
       /* Recurse to do the aligned partial xfer.  */
       size_t wanted_partial_size = partial_size;
       amd_dbgapi_status_t status
-	= xfer_agent_memory_partial (agent_id,
-				     address,
-				     (read != nullptr
-				      ? aligned_buffer
-				      : nullptr),
-				     (write != nullptr
-				      ? aligned_buffer
-				      : nullptr),
-				     &partial_size);
+        = xfer_agent_memory_partial (agent_id,
+                                     address,
+                                     (read != nullptr
+                                      ? aligned_buffer
+                                      : nullptr),
+                                     (write != nullptr
+                                      ? aligned_buffer
+                                      : nullptr),
+                                     &partial_size);
       if (status != AMD_DBGAPI_STATUS_SUCCESS)
-	return status;
+        return status;
       if (read != nullptr)
-	std::memcpy (read, aligned_buffer, partial_size);
+        std::memcpy (read, aligned_buffer, partial_size);
 
       /* If we got less than we wanted, then we're already done.  */
       if (wanted_partial_size != partial_size)
-	{
-	  *size = partial_size;
-	  return status;
-	}
+        {
+          *size = partial_size;
+          return status;
+        }
 
       /* Now xfer the remainder.  Several callers don't currently
-	 handle partial xfers, so if this fails, return failure for
-	 the whole xfer.  Once all such callers are fixed, this whole
-	 if block can be removed.  */
+         handle partial xfers, so if this fails, return failure for
+         the whole xfer.  Once all such callers are fixed, this whole
+         if block can be removed.  */
       size_t remaining_size = *size - partial_size;
       if (remaining_size != 0)
-	{
-	  if (read != nullptr)
-	    read = (char *) read + partial_size;
-	  else
-	    write = (char *) write + partial_size;
+        {
+          if (read != nullptr)
+            read = (char *) read + partial_size;
+          else
+            write = (char *) write + partial_size;
 
-	  /* This access is now guaranteed to be word-aligned.  */
-	  size_t new_misalign = (read != nullptr
-				 ? (uintptr_t) read % sizeof (DWORD)
-				 : (uintptr_t) write % sizeof (DWORD));
-	  dbgapi_assert (new_misalign == 0);
+          /* This access is now guaranteed to be word-aligned.  */
+          size_t new_misalign = (read != nullptr
+                                 ? (uintptr_t) read % sizeof (DWORD)
+                                 : (uintptr_t) write % sizeof (DWORD));
+          dbgapi_assert (new_misalign == 0);
 
-	  address += partial_size;
+          address += partial_size;
 
-	  /* Recurse.  */
-	  status
-	    = xfer_agent_memory_partial (agent_id, address,
-					 read, write, &remaining_size);
+          /* Recurse.  */
+          status
+            = xfer_agent_memory_partial (agent_id, address,
+                                         read, write, &remaining_size);
 
-	  /* Don't update SIZE unless we succeeded.  */
-	  if (status != AMD_DBGAPI_STATUS_SUCCESS)
-	    return status;
-	}
+          /* Don't update SIZE unless we succeeded.  */
+          if (status != AMD_DBGAPI_STATUS_SUCCESS)
+            return status;
+        }
 
       *size = partial_size + remaining_size;
       return status;

--- a/projects/rocdbgapi/src/os_driver_kmd.cpp
+++ b/projects/rocdbgapi/src/os_driver_kmd.cpp
@@ -2184,9 +2184,10 @@ kmd_driver_t::xfer_agent_memory_partial (os_agent_id_t agent_id,
             write = (char *) write + partial_size;
 
           /* This access is now guaranteed to be word-aligned.  */
-          size_t new_misalign = (read != nullptr
-                                 ? (uintptr_t) read % sizeof (DWORD)
-                                 : (uintptr_t) write % sizeof (DWORD));
+          [[maybe_unused]] size_t new_misalign
+            = (read != nullptr
+               ? (uintptr_t)read % sizeof (DWORD)
+               : (uintptr_t)write % sizeof (DWORD));
           dbgapi_assert (new_misalign == 0);
 
           address += partial_size;

--- a/projects/rocdbgapi/src/os_driver_kmd.cpp
+++ b/projects/rocdbgapi/src/os_driver_kmd.cpp
@@ -283,7 +283,7 @@ kmd_wave_launch_traps_mask (os_wave_launch_trap_mask_t mask)
   if (!!(mask & os_wave_launch_trap_mask_t::wave_start))
     kmd_mask |= 1 << 30;
   if (!!(mask & os_wave_launch_trap_mask_t::wave_end))
-    kmd_mask |= 1 << 31;
+    kmd_mask |= 1u << 31;
 
   return kmd_mask;
 }
@@ -1206,7 +1206,7 @@ kmd_driver_t::send_escape (const kmd::agent_handle_t &agent,
   static_assert (sizeof (payload)
                  == sizeof (PROXY_ESCAPE_INFO) + sizeof (KMDDBGRIF_DBGR_CMDS));
 
-  payload.proxy_header.gpuOrdinal = agent.chain_ordinal;
+  utils::narrow_assign (payload.proxy_header.gpuOrdinal, agent.chain_ordinal);
   payload.proxy_header.privateDataLengthBytes = sizeof (KMDDBGRIF_DBGR_CMDS);
   payload.proxy_header.version = PXDRV_HEADER_VERSION;
   payload.proxy_header.adapterDriverId = AdapterProxyDriver;
@@ -1329,13 +1329,14 @@ kmd_driver_t::agent_snapshot (os_agent_info_t *snapshots,
         return nt_status_to_dbgapi_status (status);
 
       KMDDBGR_DEVICE_INFO &kmd_snap = cmd.Output.getDeviceInfoOut.deviceInfo;
-      agent.os_agent_id = std::distance (&m_agents.front (), &agent_handle);
+      utils::narrow_assign (agent.os_agent_id,
+                            std::distance (&m_agents.front (), &agent_handle));
       agent.gfxip = { kmd_snap.gfxTargetVersion / 10000,
                       (kmd_snap.gfxTargetVersion / 100) % 100,
                       kmd_snap.gfxTargetVersion % 100 };
 
-      agent.domain = kmd_snap.pciSegment;
-      agent.location_id = kmd_snap.locationId;
+      utils::narrow_assign (agent.domain, kmd_snap.pciSegment);
+      utils::narrow_assign (agent.location_id, kmd_snap.locationId);
 
       agent.vendor_id = kmd_snap.vendorId;
       agent.device_id = kmd_snap.deviceId;
@@ -1578,8 +1579,8 @@ kmd_driver_t::query_debug_event (os_exception_mask_t *exceptions_present,
   /* TODO some fairness so we round-robin-ish across all the adapters?  */
   for (const auto &agent_handle : m_agents)
     {
-      os_agent_id_t agent_id
-        = std::distance (&m_agents.front (), &agent_handle);
+      auto distance = std::distance (&m_agents.front (), &agent_handle);
+      auto agent_id = utils::narrow<os_agent_id_t> (distance);
 
       KMDDBGRIF_DBGR_CMDS cmd{};
       cmd.Input.cmd = KMD_DBGR_CMD_OP_GET_EXCEPTIONS;
@@ -1718,7 +1719,8 @@ kmd_driver_t::suspend_queues (const os_queue_id_t *queues, size_t queue_count,
       cmd.Input.suspendQueueIn.exceptionMaskToClear
         = kmd_exception_mask (exceptions_cleared);
       cmd.Input.suspendQueueIn.gracePeriodIn100us = 500;
-      cmd.Input.suspendQueueIn.numQueues = agent_queue_ids.size ();
+      utils::narrow_assign (cmd.Input.suspendQueueIn.numQueues,
+                            agent_queue_ids.size ());
       std::transform (agent_queue_ids.begin (), agent_queue_ids.end (),
                       cmd.Input.suspendQueueIn.queueIds,
                       [this] (auto &&queue_id)
@@ -1769,7 +1771,8 @@ kmd_driver_t::resume_queues (const os_queue_id_t *queues, size_t queue_count,
     {
       KMDDBGRIF_DBGR_CMDS cmd{};
       cmd.Input.cmd = KMD_DBGR_CMD_OP_RESUME_QUEUE;
-      cmd.Input.resumeQueueIn.numQueues = agent_queue_ids.size ();
+      utils::narrow_assign (cmd.Input.resumeQueueIn.numQueues,
+                            agent_queue_ids.size ());
       std::transform (agent_queue_ids.begin (), agent_queue_ids.end (),
                       cmd.Input.resumeQueueIn.queueIds,
                       [this] (auto &&queue_id)
@@ -1923,7 +1926,7 @@ kmd_driver_t::set_address_watch (os_agent_id_t os_agent_id,
 
   /* TODO we should use the number of watchpoints from the agent info snapshot.
    */
-  int id = 0;
+  os_watch_id_t id = 0;
   for (; id < 4; id += 1)
     {
       KMDDBGRIF_DBGR_CMDS cmd{};
@@ -1932,7 +1935,9 @@ kmd_driver_t::set_address_watch (os_agent_id_t os_agent_id,
         = static_cast<KMDDBGRIF_ADDR_WATCH_ID> (id);
       cmd.Input.setAddrWatchIn.mode = kmd_addr_watch_mode (os_watch_mode);
       cmd.Input.setAddrWatchIn.watchAddr = address;
-      cmd.Input.setAddrWatchIn.watchAddrMask = mask;
+      using mask_t = decltype (cmd.Input.setAddrWatchIn.watchAddrMask);
+      utils::narrow_assign (cmd.Input.setAddrWatchIn.watchAddrMask,
+                            mask & mask_t (-1));
 
       NTSTATUS status = send_escape (m_agents[os_agent_id], cmd);
       if (status == STATUS_RESOURCE_IN_USE)
@@ -2212,14 +2217,14 @@ kmd_driver_t::xfer_agent_memory_partial (os_agent_id_t agent_id,
       cmd.Input.cmd = KMD_DBGR_CMD_OP_WRITE_BUFFER;
       cmd.Input.writeBufferIn.srcCpuVA = reinterpret_cast<uint64_t> (write);
       cmd.Input.writeBufferIn.dstGpuVA = static_cast<uint64_t> (address);
-      cmd.Input.writeBufferIn.size = *size;
+      utils::narrow_assign (cmd.Input.writeBufferIn.size, *size);
     }
   else
     {
       cmd.Input.cmd = KMD_DBGR_CMD_OP_READ_BUFFER;
       cmd.Input.readBufferIn.srcGpuVA = static_cast<uint64_t> (address);
       cmd.Input.readBufferIn.dstCpuVA = reinterpret_cast<uint64_t> (read);
-      cmd.Input.readBufferIn.size = *size;
+      utils::narrow_assign (cmd.Input.readBufferIn.size, *size);
     }
 
   auto status = send_escape (m_agents[agent_id], cmd);

--- a/projects/rocdbgapi/src/process.cpp
+++ b/projects/rocdbgapi/src/process.cpp
@@ -1296,7 +1296,7 @@ process_t::update_code_objects ()
                             &l_name_address);
 
           std::string uri;
-          read_string (l_name_address, &uri, -1);
+          read_string (l_name_address, &uri, size_t (-1));
 
           /* Check if the code object already exists.  */
           code_object_t *code_object = find_if (

--- a/projects/rocdbgapi/src/queue.cpp
+++ b/projects/rocdbgapi/src/queue.cpp
@@ -214,10 +214,13 @@ aql_queue_t::aql_dispatch_t::aql_dispatch_t (
 uint32_t
 aql_queue_t::aql_dispatch_t::grid_dimensions () const
 {
-  return static_cast<uint32_t> (utils::bit_extract (
-    m_packet.setup, HSA_KERNEL_DISPATCH_PACKET_SETUP_DIMENSIONS,
-    HSA_KERNEL_DISPATCH_PACKET_SETUP_DIMENSIONS
-      + HSA_KERNEL_DISPATCH_PACKET_SETUP_WIDTH_DIMENSIONS - 1));
+  /* Arithmetic between different enumeration types.  */
+  auto first = HSA_KERNEL_DISPATCH_PACKET_SETUP_DIMENSIONS;
+  auto last
+    = (utils::narrow<int> (HSA_KERNEL_DISPATCH_PACKET_SETUP_DIMENSIONS)
+       + utils::narrow<int> (HSA_KERNEL_DISPATCH_PACKET_SETUP_WIDTH_DIMENSIONS)
+       - 1);
+  return utils::bit_extract<uint32_t> (m_packet.setup, first, last);
 }
 
 std::array<uint32_t, 3>
@@ -283,8 +286,9 @@ aql_queue_t::aql_dispatch_t::get_info (amd_dbgapi_dispatch_info_t query,
         value_size, value,
         static_cast<amd_dbgapi_dispatch_fence_scope_t> (utils::bit_extract (
           m_packet.header, HSA_PACKET_HEADER_SCACQUIRE_FENCE_SCOPE,
-          HSA_PACKET_HEADER_SCACQUIRE_FENCE_SCOPE
-            + HSA_PACKET_HEADER_WIDTH_SCACQUIRE_FENCE_SCOPE - 1)));
+          (utils::narrow<int> (HSA_PACKET_HEADER_SCACQUIRE_FENCE_SCOPE)
+           + utils::narrow<int> (HSA_PACKET_HEADER_WIDTH_SCACQUIRE_FENCE_SCOPE)
+           - 1))));
       return;
 
     case AMD_DBGAPI_DISPATCH_INFO_RELEASE_FENCE:
@@ -292,8 +296,9 @@ aql_queue_t::aql_dispatch_t::get_info (amd_dbgapi_dispatch_info_t query,
         value_size, value,
         static_cast<amd_dbgapi_dispatch_fence_scope_t> (utils::bit_extract (
           m_packet.header, HSA_PACKET_HEADER_SCRELEASE_FENCE_SCOPE,
-          HSA_PACKET_HEADER_SCRELEASE_FENCE_SCOPE
-            + HSA_PACKET_HEADER_WIDTH_SCRELEASE_FENCE_SCOPE - 1)));
+          (utils::narrow<int> (HSA_PACKET_HEADER_SCRELEASE_FENCE_SCOPE)
+           + utils::narrow<int> (HSA_PACKET_HEADER_WIDTH_SCRELEASE_FENCE_SCOPE)
+           - 1))));
       return;
 
     case AMD_DBGAPI_DISPATCH_INFO_GRID_DIMENSIONS:
@@ -424,11 +429,7 @@ aql_queue_t::allocate_displaced_instruction (const instruction_t &instruction)
 
       /* Ensure that the number of chunks does not overflow the 16 bit index.
        */
-      if (chunk_count > std::numeric_limits<
-            decltype (m_debugger_memory_chunk_count)>::max ())
-        fatal_error ("Increase the width of m_debugger_memory_chunk_count");
-
-      m_debugger_memory_chunk_count = chunk_count;
+      utils::narrow_assign (m_debugger_memory_chunk_count, chunk_count);
 
       m_debugger_memory_free_chunks.reserve (m_debugger_memory_chunk_count);
     }

--- a/projects/rocdbgapi/src/register.cpp
+++ b/projects/rocdbgapi/src/register.cpp
@@ -195,8 +195,10 @@ amdgpu_regnum_to_dwarf_register (amdgpu_regnum_t regnum)
 }
 
 std::optional<amdgpu_regnum_t>
-dwarf_register_to_amdgpu_regnum (uint64_t dwarf_register)
+dwarf_register_to_amdgpu_regnum (uint64_t dwarf_register_)
 {
+  auto dwarf_register = utils::narrow<int> (dwarf_register_);
+
   /* See https://llvm.org/docs/AMDGPUUsage.html#register-mapping.  */
   if (dwarf_register == 1)
     {

--- a/projects/rocdbgapi/src/register.h
+++ b/projects/rocdbgapi/src/register.h
@@ -182,29 +182,30 @@ enum class amdgpu_regnum_t : uint32_t
   last_regnum = last_pseudo
 };
 
-constexpr size_t
+/* Distance between two regnums.  Returns int as that is the type that
+   operator+ and operator- take as rhs.  */
+constexpr int
 operator- (amdgpu_regnum_t lhs, amdgpu_regnum_t rhs)
 {
-  return static_cast<std::underlying_type_t<decltype (lhs)>> (lhs)
-         - static_cast<std::underlying_type_t<decltype (rhs)>> (rhs);
+  using underlying = std::underlying_type_t<decltype (lhs)>;
+  return utils::narrow<int> (static_cast<underlying> (lhs)
+                             - static_cast<underlying> (rhs));
 }
 
 constexpr amdgpu_regnum_t
 operator+ (amdgpu_regnum_t lhs, int rhs)
 {
-  return static_cast<amdgpu_regnum_t> (
-    static_cast<std::underlying_type_t<decltype (lhs)>> (lhs) + rhs);
+  return static_cast<amdgpu_regnum_t> (static_cast<int> (lhs) + rhs);
 }
 
 constexpr amdgpu_regnum_t
 operator- (amdgpu_regnum_t lhs, int rhs)
 {
-  return static_cast<amdgpu_regnum_t> (
-    static_cast<std::underlying_type_t<decltype (lhs)>> (lhs) - rhs);
+  return static_cast<amdgpu_regnum_t> (static_cast<int> (lhs) - rhs);
 }
 
 constexpr std::underlying_type_t<amdgpu_regnum_t>
-operator& (amdgpu_regnum_t lhs, int rhs)
+operator& (amdgpu_regnum_t lhs, std::underlying_type_t<amdgpu_regnum_t> rhs)
 {
   return static_cast<std::underlying_type_t<decltype (lhs)>> (lhs) & rhs;
 }

--- a/projects/rocdbgapi/src/utils.cpp
+++ b/projects/rocdbgapi/src/utils.cpp
@@ -226,12 +226,13 @@ string_vprintf (const char *format, va_list va)
   va_list copy;
 
   va_copy (copy, va);
-  size_t size = vsnprintf (NULL, 0, format, copy);
+  int size = vsnprintf (NULL, 0, format, copy);
   va_end (copy);
 
-  std::string str (size, '\0');
-  vsprintf (&str[0], format, va);
+  dbgapi_assert (size >= 0);
 
+  std::string str (size, '\0');
+  vsnprintf (&str[0], str.size () + 1, format, va);
   return str;
 }
 

--- a/projects/rocdbgapi/src/utils.cpp
+++ b/projects/rocdbgapi/src/utils.cpp
@@ -231,7 +231,7 @@ string_vprintf (const char *format, va_list va)
 
   dbgapi_assert (size >= 0);
 
-  std::string str (size, '\0');
+  std::string str (static_cast<size_t> (size), '\0');
   vsnprintf (&str[0], str.size () + 1, format, va);
   return str;
 }

--- a/projects/rocdbgapi/src/utils.h
+++ b/projects/rocdbgapi/src/utils.h
@@ -33,6 +33,7 @@
 #include <exception>
 #include <functional>
 #include <iterator>
+#include <limits>
 #include <memory>
 #include <optional>
 #include <string>
@@ -93,16 +94,78 @@ namespace utils
 /* Get the filename containing dbgapi's code.  */
 const char *get_self_name ();
 
+/* An explicit, checked, narrowing conversion.  Throws a fatal error
+   if the conversion would lose information.  */
+
+template <typename To, typename From>
+constexpr To
+narrow (From from)
+{
+  using ToLimits = std::numeric_limits<To>;
+  using FromLimits = std::numeric_limits<From>;
+
+  /* Check for negative values when converting to an unsigned
+     type.  */
+  if constexpr (std::is_unsigned_v<To> && std::is_signed_v<From>)
+    {
+      if (from < 0)
+        fatal_error ("narrowing error: negative value to unsigned");
+    }
+
+  /* For signed to signed, check for values smaller than the
+     destination can hold.  */
+  if constexpr (std::is_signed_v<To> && std::is_signed_v<From>)
+    {
+      if (from < ToLimits::min ())
+        fatal_error ("narrowing error: underflow");
+    }
+
+  /* Check for values larger than the destination can hold.  We cast
+     to From to ensure the comparison is performed in the
+     wider/original domain.  */
+  if constexpr (static_cast<std::uintmax_t> (FromLimits::max ())
+                > static_cast<std::uintmax_t> (ToLimits::max ()))
+    {
+      if (from > static_cast<From> (ToLimits::max ()))
+        fatal_error ("narrowing error: overflow");
+    }
+
+  return static_cast<To> (from);
+}
+
+/* Like narrow, but takes the destination as argument.  Useful for
+   assignments, to avoid spelling out the destination's type.  */
+
+template <typename To, typename From>
+void
+narrow_assign (To &to, From from)
+{
+  to = narrow<To> (from);
+}
+
 template <typename Integral = uint64_t>
 constexpr Integral
 bit_mask (int first, int last)
 {
   dbgapi_assert (last >= first && "invalid argument");
-  size_t num_bits = last - first + 1;
-  return ((num_bits >= sizeof (Integral) * 8)
-            ? ~Integral{ 0 } /* num_bits exceed the size of Integral */
-            : ((Integral{ 1 } << num_bits) - 1))
-         << first;
+  auto num_bits = static_cast<size_t> (last - first + 1);
+  auto mask = (((num_bits >= sizeof (Integral) * 8)
+                  ? ~Integral{ 0 } /* num_bits exceed the size of Integral */
+                  : ((Integral{ 1 } << num_bits) - 1))
+               << first);
+  /* If Integral is narrower than int, mask is now int.  Do an
+     explicit cast to avoid -Wconversion warnings.  */
+  return static_cast<Integral> (mask);
+}
+
+template <typename Integral = uint64_t, typename First,
+          typename Last>
+constexpr Integral
+bit_mask (First first, Last last)
+{
+  /* Defer to the int, int overload, with narrow checking.  */
+  return bit_mask<Integral> (narrow<int> (first),
+                             narrow<int> (last));
 }
 
 template <typename Integral>
@@ -118,7 +181,18 @@ bit_count (Integral x)
   x = x - ((x >> 1) & ~T{ 0 } / 3);
   x = (x & ~T{ 0 } / 15 * 3) + ((x >> 2) & ~T{ 0 } / 15 * 3);
   x = (x + (x >> 4)) & ~T{ 0 } / 255 * 15;
-  return (x * (~T{ 0 } / 255)) >> (sizeof (T) - 1) * 8;
+  auto count = (x * (~T{ 0 } / 255)) >> (sizeof (T) - 1) * 8;
+  return static_cast<int> (count);
+}
+
+/* Split an unsigned 64-bit value into a pair of unsigned 32-bit
+   values.  */
+inline std::pair<uint32_t, uint32_t>
+split (uint64_t val)
+{
+  auto lo = static_cast<uint32_t> (val);
+  auto hi = static_cast<uint32_t> (val >> 32);
+  return { lo, hi };
 }
 
 template <typename Integral>
@@ -163,27 +237,33 @@ trailing_zeroes_count<unsigned int> (unsigned int x)
 }
 #endif
 
-template <typename Integral>
-constexpr std::make_unsigned_t<Integral>
-zero_extend (Integral x, int width)
+template <typename Val, typename Width>
+constexpr auto
+zero_extend (Val x, Width width)
 {
-  return x & bit_mask (0, width - 1);
+  using UVal = std::make_unsigned_t<Val>;
+  return static_cast<UVal> (x) & bit_mask (0, width - 1);
 }
 
-template <typename Integral>
-constexpr std::make_signed_t<Integral>
-sign_extend (Integral x, int width)
+template <typename Val, typename Width>
+constexpr std::make_signed_t<Val>
+sign_extend (Val x, Width width)
 {
-  Integral sign_mask = bit_mask (width - 1, sizeof (Integral) * 8 - 1);
+  Val sign_mask = bit_mask (width - 1, sizeof (Val) * 8 - 1);
   return (zero_extend (x, width) ^ sign_mask) - sign_mask;
 }
 
-/* Extract bits [last:first] from t.  */
-template <typename Integral>
-constexpr Integral
-bit_extract (Integral x, int first, int last)
+/* Extract bits [last:first] from X.  */
+template <typename Res = void, typename From>
+constexpr auto
+bit_extract (From x, int first, int last)
 {
-  return (x >> first) & bit_mask<Integral> (0, last - first);
+  /* If Res is void, we use the type of From. If Res is specified, we
+     use that.  */
+  using ActualRes = std::conditional_t<std::is_void_v<Res>, From, Res>;
+
+  return static_cast<ActualRes> ((x >> first)
+                                 & bit_mask<From> (0, last - first));
 }
 
 template <typename Integral>
@@ -216,25 +296,27 @@ next_power_of_two (Integral x)
   return ++v;
 }
 
-template <typename Integral>
+template <typename Integral, typename Align>
 constexpr Integral
-align_down (Integral x, int alignment)
+align_down (Integral x, Align alignment)
 {
   dbgapi_assert (is_power_of_two (alignment));
-  return x & -alignment;
+  auto align = narrow<Integral> (alignment);
+  return x & -align;
 }
 
-template <typename Integral>
+template <typename Integral, typename Align>
 constexpr Integral
-align_up (Integral x, int alignment)
+align_up (Integral x, Align alignment)
 {
   dbgapi_assert (is_power_of_two (alignment));
-  return (x + alignment - 1) & -alignment;
+  auto align = narrow<Integral> (alignment);
+  return (x + align - 1) & -align;
 }
 
-template <typename Integral>
+template <typename Integral, typename Align>
 constexpr bool
-is_aligned (Integral x, int alignment)
+is_aligned (Integral x, Align alignment)
 {
   dbgapi_assert (is_power_of_two (alignment));
   return x == align_down (x, alignment);

--- a/projects/rocdbgapi/src/utils.h
+++ b/projects/rocdbgapi/src/utils.h
@@ -296,13 +296,45 @@ next_power_of_two (Integral x)
   return ++v;
 }
 
+/* Convert a power-of-two ALIGNMENT into an alignment mask.  The
+   result has the lower log2(ALIGNMENT) bits cleared and all higher
+   bits set.  For example, ALIGNMENT == 8 (0b00001000) yields a mask
+   of 0b1...11111000.
+
+   ALIGNMENT must be a non-zero power of two.  */
+
+template <typename Integral>
+constexpr Integral
+alignment_to_mask (Integral alignment)
+{
+  static_assert (!std::numeric_limits<Integral>::is_signed);
+  dbgapi_assert (is_power_of_two (alignment));
+  return ~(alignment - 1);
+}
+
+/* Convert an alignment MASK to a power-of-two alignment.  MASK has
+   some lower bits cleared and all higher bits set.  For example, a
+   mask of 0b1...11111000 yields ALIGNMENT == 8 (0b00001000).
+
+   The result is a non-zero power of two.  */
+
+template <typename Integral>
+constexpr Integral
+mask_to_alignment (Integral mask)
+{
+  static_assert (!std::numeric_limits<Integral>::is_signed);
+  auto alignment = ~(mask - 1);
+  dbgapi_assert (is_power_of_two (alignment));
+  return alignment;
+}
+
 template <typename Integral, typename Align>
 constexpr Integral
 align_down (Integral x, Align alignment)
 {
   dbgapi_assert (is_power_of_two (alignment));
   auto align = narrow<Integral> (alignment);
-  return x & -align;
+  return x & alignment_to_mask (align);
 }
 
 template <typename Integral, typename Align>
@@ -311,7 +343,7 @@ align_up (Integral x, Align alignment)
 {
   dbgapi_assert (is_power_of_two (alignment));
   auto align = narrow<Integral> (alignment);
-  return (x + align - 1) & -align;
+  return (x + align - 1) & alignment_to_mask (align);
 }
 
 template <typename Integral, typename Align>

--- a/projects/rocdbgapi/src/utils_linux.cpp
+++ b/projects/rocdbgapi/src/utils_linux.cpp
@@ -120,7 +120,7 @@ pipe_t::close ()
 int
 pipe_t::flush ()
 {
-  int ret;
+  ssize_t ret;
 
   do
     {
@@ -138,7 +138,7 @@ pipe_t::flush ()
 int
 pipe_t::mark ()
 {
-  int ret;
+  ssize_t ret;
 
   /* First, flush the pipe.  */
   flush ();

--- a/projects/rocdbgapi/src/utils_windows.cpp
+++ b/projects/rocdbgapi/src/utils_windows.cpp
@@ -41,7 +41,7 @@ convert_to_string (std::wstring_view ws)
   if (size_needed <= 0)
     return {};
 
-  std::string result (size_needed, '\0');
+  std::string result (static_cast<size_t> (size_needed), '\0');
 
   [[maybe_unused]] int size
     = ::WideCharToMultiByte (CP_ACP, 0, ws.data (), (int)ws.size (),

--- a/projects/rocdbgapi/src/utils_windows.cpp
+++ b/projects/rocdbgapi/src/utils_windows.cpp
@@ -18,6 +18,7 @@
  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  THE SOFTWARE. */
 
+#include "utils_windows.h"
 #include "utils.h"
 #include <io.h>
 #include <windows.h>
@@ -28,19 +29,65 @@ namespace amd::dbgapi
 namespace utils
 {
 
+std::string
+convert_to_string (std::wstring_view ws)
+{
+  if (ws.empty ())
+    return {};
+
+  int size_needed
+    = ::WideCharToMultiByte (CP_ACP, 0, ws.data (), (int)ws.size (),
+                             nullptr, 0, nullptr, nullptr);
+  if (size_needed <= 0)
+    return {};
+
+  std::string result (size_needed, '\0');
+
+  [[maybe_unused]] int size
+    = ::WideCharToMultiByte (CP_ACP, 0, ws.data (), (int)ws.size (),
+                             &result[0], size_needed, "?", nullptr);
+
+  dbgapi_assert (size == size_needed);
+
+  return result;
+}
+
 const char *
 get_self_name ()
 {
-  static char path[MAX_PATH];
-  HMODULE hmodule = nullptr;
+  static const auto self_name = [] () -> std::string
+  {
+    HMODULE h;
+    if (::GetModuleHandleExW (GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS
+                              | GET_MODULE_HANDLE_EX_FLAG_UNCHANGED_REFCOUNT,
+                              (LPCWSTR)&get_self_name, &h))
+      {
+        std::wstring wself_name;
+        DWORD size = MAX_PATH;
 
-  if (::GetModuleHandleEx (GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS
-                             | GET_MODULE_HANDLE_EX_FLAG_UNCHANGED_REFCOUNT,
-                           static_cast<const char *> (path), &hmodule)
-      && ::GetModuleFileName (hmodule, path, sizeof (path)))
-    return path;
+        /* Loop to find the true length, thus handling long paths.  */
+        while (true)
+          {
+            wself_name.resize (size);
+            DWORD len = ::GetModuleFileNameW (h, &wself_name[0], size);
+            if (len == 0)
+              break;
 
-  return "";
+            if (len < size)
+              {
+                wself_name.resize (len);
+                return convert_to_string (wself_name);
+              }
+
+            /* Buffer was too small; double it and try again.  */
+            size *= 2;
+          }
+      }
+
+    return {};
+  } ();
+
+  return self_name.c_str ();
 }
 
 } /* namespace amd::dbgapi::utils.  */

--- a/projects/rocdbgapi/src/utils_windows.h
+++ b/projects/rocdbgapi/src/utils_windows.h
@@ -1,0 +1,40 @@
+/* Copyright (c) 2026 Advanced Micro Devices, Inc.
+
+ Permission is hereby granted, free of charge, to any person obtaining a copy
+ of this software and associated documentation files (the "Software"), to deal
+ in the Software without restriction, including without limitation the rights
+ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ copies of the Software, and to permit persons to whom the Software is
+ furnished to do so, subject to the following conditions:
+
+ The above copyright notice and this permission notice shall be included in
+ all copies or substantial portions of the Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ THE SOFTWARE. */
+
+/* Utility routines only needed on Windows.  */
+
+#ifndef AMD_DBGAPI_UTILS_WINDOWS_H
+#define AMD_DBGAPI_UTILS_WINDOWS_H 1
+
+#include "amd-dbgapi.h"
+
+#include <string>
+#include <string_view>
+
+namespace amd::dbgapi::utils
+{
+
+/* Convert WS to a std::string, in the current code page.  If
+   conversion fails, returns an entry string.  */
+std::string convert_to_string (std::wstring_view ws);
+
+} /* namespace amd::dbgapi::utils */
+
+#endif /* AMD_DBGAPI_UTILS_WINDOWS_H */

--- a/projects/rocdbgapi/src/watchpoint.cpp
+++ b/projects/rocdbgapi/src/watchpoint.cpp
@@ -132,8 +132,11 @@ watchpoint_t::watchpoint_t (amd_dbgapi_watchpoint_id_t watchpoint_id,
       dbgapi_assert (stable_bits >= field_A);
     }
 
-  m_size = -(stable_bits & ~field_C);
-  m_address = requested_address & -m_size;
+  /* Mask out field_C.  */
+  uint64_t usable_bits = stable_bits & ~field_C;
+
+  m_size = utils::mask_to_alignment (usable_bits);
+  m_address = utils::align_down (requested_address, m_size);
 }
 
 void

--- a/projects/rocdbgapi/src/watchpoint.cpp
+++ b/projects/rocdbgapi/src/watchpoint.cpp
@@ -68,10 +68,16 @@ watchpoint_t::watchpoint_t (amd_dbgapi_watchpoint_id_t watchpoint_id,
      ones, e.g.:
 
              47       39        Y       23       15        X     0
-     First:  01111111 11111110 11100111 00000100 00000000 01000100
+     First:  01111111 11111110 11100111 00000100 00000000 01000000
      Last:   01111111 11111110 11100111 00000100 00000000 01001000
 
-     Stable := ~(next_power_of_2 (Start ^ End) - 1)
+     Start ^ End:
+             00000000 00000000 00000000 00000000 00000000 00001000
+
+     Stable := ~(next_power_of_2 (Start ^ End + 1) - 1)
+
+     Note: the +1 is required when (Start ^ End) is already a power of
+     two.
 
              47       39        Y       23       15        X     0
      Stable: 11111111 11111111 11111111 11111111 11111111 11110000
@@ -89,11 +95,15 @@ watchpoint_t::watchpoint_t (amd_dbgapi_watchpoint_id_t watchpoint_id,
      aAddr:  01111111 11111110 11100111 00000100 00000000 01000000
    */
 
+  auto get_stable_bits = [] (uint64_t first, uint64_t last)
+  {
+    return ~(utils::next_power_of_two ((first ^ last) + 1) - 1);
+  };
+
   uint64_t first_address = requested_address;
   uint64_t last_address = first_address + requested_size - 1;
 
-  uint64_t stable_bits
-    = -utils::next_power_of_two ((first_address ^ last_address) + 1);
+  uint64_t stable_bits = get_stable_bits (first_address, last_address);
 
   /* programmable_mask_bits is the intersection of all the process' agents
      capabilities.  architecture_t::watchpoint_mask_bits returns a mask
@@ -118,8 +128,7 @@ watchpoint_t::watchpoint_t (amd_dbgapi_watchpoint_id_t watchpoint_id,
          boundary and compute the stable_bits again.  This time the stable_bits
          mask must be in the agent capabilities.  */
       last_address = ((first_address + ~field_A) & field_A) - 1;
-      stable_bits
-        = -utils::next_power_of_two ((first_address ^ last_address) + 1);
+      stable_bits = get_stable_bits (first_address, last_address);
       dbgapi_assert (stable_bits >= field_A);
     }
 


### PR DESCRIPTION
Compiling dbgapi with MSVC currently shows a number of warnings like these:

 D:\therock\src\rocm-systems\projects\rocdbgapi\src\agent.cpp(230): warning C4146: unary minus operator applied to unsigned type, result still unsigned
 ...
 D:\therock\src\rocm-systems\projects\rocdbgapi\src\utils.h(313): warning C4146: unary minus operator applied to unsigned type, result still unsigned
 D:\therock\src\rocm-systems\projects\rocdbgapi\src\utils.h(305): warning C4146: unary minus operator applied to unsigned type, result still unsigned
 ...
 D:\therock\src\rocm-systems\projects\rocdbgapi\src\watchpoint.cpp(135): warning C4146: unary minus operator applied to unsigned type, result still unsigned
 D:\therock\src\rocm-systems\projects\rocdbgapi\src\watchpoint.cpp(136): warning C4146: unary minus operator applied to unsigned type, result still unsigned
 ...

See https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-2-c4146

Since, for unsigned integers:

 -X == ~(X - 1);

Tweak the codebase to use the right hand form, which MSVC does not
warn about, and is the more typical way to build a mask anyhow.

But instead of doing that change directly in several places, add a
utils::alignment_to_mask and utils::mask_alignment_to function that do
the bit manipulation in a single place, and that helps giving a
clearer meaning to intent at the caller sites.

In watchpoint.cpp, the code is a bit mysterious currently, I had to
stare at it for a bit to make sense of what it is doing.  Rewrite it
using mask_to_alignment and align_down, which IMHO make it a lot more
obvious.

Change-Id: Ia46d4cbd8fd3ad770025234276c6ac0e12dabad9
commit-id:c9c9b6ae

---

**Stack**:
- #4291
- #4290
- #4289
- #4288
- #4287
- #4286
- #4285
- #4284
- #4283
- #4282 ⬅
- #4281
- #4297


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*