### PR TITLE
[msvc 4/6] dbgapi/win32: Fix src/os_driver_kmd.cpp warning in release mode

### DIFF
--- a/projects/rocdbgapi/src/os_driver_kmd.cpp
+++ b/projects/rocdbgapi/src/os_driver_kmd.cpp
@@ -2184,9 +2184,10 @@ kmd_driver_t::xfer_agent_memory_partial (os_agent_id_t agent_id,
             write = (char *) write + partial_size;
 
           /* This access is now guaranteed to be word-aligned.  */
-          size_t new_misalign = (read != nullptr
-                                 ? (uintptr_t) read % sizeof (DWORD)
-                                 : (uintptr_t) write % sizeof (DWORD));
+          [[maybe_unused]] size_t new_misalign
+            = (read != nullptr
+               ? (uintptr_t)read % sizeof (DWORD)
+               : (uintptr_t)write % sizeof (DWORD));
           dbgapi_assert (new_misalign == 0);
 
           address += partial_size;


### PR DESCRIPTION
When compiling in release mode, where dbgapi_assert is a no-op, we get:

/home/pedro/rocm/gdb/build-rocm-ci/rocm-dbgapi/src/os_driver_kmd.cpp: In lambda function:
/home/pedro/rocm/gdb/build-rocm-ci/rocm-dbgapi/src/os_driver_kmd.cpp:2198:18: error: unused variable 'new_misalign' [-Werror=unused-variable]
2198 |           size_t new_misalign = (read != nullptr
|                  ^~~~~~~~~~~~

Fix it with [[maybe_unused]].

Change-Id: Ia2bd17a6be31f5cd428573182e242014f253b704

---

**Stack**:
- #4296
- #4295
- #4294 ⬅
- #4293
- #4279
- #4243


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*