### PR TITLE
[msvc 6/6] dbgapi: Fix comment vs code mismatch in watchpoint_t::watchpoint_t

### DIFF
--- a/projects/rocdbgapi/src/watchpoint.cpp
+++ b/projects/rocdbgapi/src/watchpoint.cpp
@@ -68,10 +68,16 @@ watchpoint_t::watchpoint_t (amd_dbgapi_watchpoint_id_t watchpoint_id,
      ones, e.g.:
 
              47       39        Y       23       15        X     0
-     First:  01111111 11111110 11100111 00000100 00000000 01000100
+     First:  01111111 11111110 11100111 00000100 00000000 01000000
      Last:   01111111 11111110 11100111 00000100 00000000 01001000
 
-     Stable := ~(next_power_of_2 (Start ^ End) - 1)
+     Start ^ End:
+             00000000 00000000 00000000 00000000 00000000 00001000
+
+     Stable := ~(next_power_of_2 (Start ^ End + 1) - 1)
+
+     Note: the +1 is required when (Start ^ End) is already a power of
+     two.
 
              47       39        Y       23       15        X     0
      Stable: 11111111 11111111 11111111 11111111 11111111 11110000
@@ -89,11 +95,15 @@ watchpoint_t::watchpoint_t (amd_dbgapi_watchpoint_id_t watchpoint_id,
      aAddr:  01111111 11111110 11100111 00000100 00000000 01000000
    */
 
+  auto get_stable_bits = [] (uint64_t first, uint64_t last)
+  {
+    return ~(utils::next_power_of_two ((first ^ last) + 1) - 1);
+  };
+
   uint64_t first_address = requested_address;
   uint64_t last_address = first_address + requested_size - 1;
 
-  uint64_t stable_bits
-    = -utils::next_power_of_two ((first_address ^ last_address) + 1);
+  uint64_t stable_bits = get_stable_bits (first_address, last_address);
 
   /* programmable_mask_bits is the intersection of all the process' agents
      capabilities.  architecture_t::watchpoint_mask_bits returns a mask
@@ -118,8 +128,7 @@ watchpoint_t::watchpoint_t (amd_dbgapi_watchpoint_id_t watchpoint_id,
          boundary and compute the stable_bits again.  This time the stable_bits
          mask must be in the agent capabilities.  */
       last_address = ((first_address + ~field_A) & field_A) - 1;
-      stable_bits
-        = -utils::next_power_of_two ((first_address ^ last_address) + 1);
+      stable_bits = get_stable_bits (first_address, last_address);
       dbgapi_assert (stable_bits >= field_A);
     }
 


### PR DESCRIPTION
The comment in watchpoint_t::watchpoint_t does not match the code.
Specifically, it says:

Stable := ~(next_power_of_2 (Start ^ End) - 1)

But the code does:

uint64_t stable_bits
= -utils::next_power_of_two ((first_address ^ last_address) + 1);

Which is the equivalent of:

Stable := ~(next_power_of_2 (Start ^ End + 1) - 1)
^^^^

So the "+ 1" is missing in the comment.  The code is correct, the
comment is wrong.  The "+ 1" is needed when "Start ^ End" is already a
power-of-two.

To illustrate, in the example given, The missing "+ 1" makes no
difference:

First: ...01000100  /* 0x44 */
Last:  ...01001000  /* 0x48 */

d = Start ^ End = 0x44 ^ 0x48 = 0x0C  /* 1100b */

Without +1:
next_power_of_2 (0x0C) = 0x10
With +1:
next_power_of_2 (0x0C + 1) = next_power_of_2 (0x0D) = 0x10

However, when 'd' is already a power of two:

next_power_of_two (d) == d

While what we actually want is:

smallest power-of-two strictly greater than d

So we need to compensate by doing:

next_power_of_two (d + 1)

Which effectively turns it into:

smallest power-of-two > d

I think we should tweak the example in the comment to be a case where
it the missing +1 matters, like:

First: ...01000000  /* 0x40 */
Last:  ...01001000  /* 0x48 */

d = Start ^ End = 0x40 ^ 0x48 = 0x08  /* 1000b */

Without +1:
next_power_of_2 (0x08) = 0x08
With +1:
next_power_of_2 (0x08 + 1) = next_power_of_2 (0x09) = 0x10

This commit does that too.

Also tweak the code to use "~(X - 1)" style instead of "-X" to match
the comment style, and also because this fixes a warning ("unary minus
operator applied to unsigned type, result still unsigned") when
compiled with MSVC, which is what made me look at this in the first
place.

Change-Id: I1ed0e22a90aee3c69de6c5954abc76e78b0e8189

---

**Stack**:
- #4296 ⬅
- #4295
- #4294
- #4293
- #4279
- #4243


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*