### PR TITLE
[msvc 2/2] dbgapi: Avoid vprintf

### DIFF
--- a/projects/rocdbgapi/src/utils.cpp
+++ b/projects/rocdbgapi/src/utils.cpp
@@ -226,12 +226,13 @@ string_vprintf (const char *format, va_list va)
   va_list copy;
 
   va_copy (copy, va);
-  size_t size = vsnprintf (NULL, 0, format, copy);
+  int size = vsnprintf (NULL, 0, format, copy);
   va_end (copy);
 
-  std::string str (size, '\0');
-  vsprintf (&str[0], format, va);
+  dbgapi_assert (size >= 0);
 
+  std::string str (size, '\0');
+  vsnprintf (&str[0], str.size () + 1, format, va);
   return str;
 }
 


### PR DESCRIPTION
MSVC warns like so:

D:\therock\src\rocm-systems\projects\rocdbgapi\src\utils.cpp(233): warning C4996: 'vsprintf': This function or variable may be unsafe. Consider using vsprintf_s instead. To disable deprecation, use _CRT_SECURE

Fix it by using vsnprintf instead.

While at it, vsnprintf returns an int, and let's add an assert that it
didn't fail.

Change-Id: Iff7d3792a001fbc23b3fca7c01dad9c021c39107

---

**Stack**:
- #4298 ⬅
- #4297


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*