### PR TITLE
[msvc 2/18] dbgapi/win32: __declspec(dllexport) instead of --version-script

### DIFF
--- a/projects/rocdbgapi/CMakeLists.txt
+++ b/projects/rocdbgapi/CMakeLists.txt
@@ -434,8 +434,10 @@ target_include_directories(amd-dbgapi
     $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/include/amd-dbgapi>
     $<INSTALL_INTERFACE:include>)
 
-target_link_libraries(amd-dbgapi
-  PRIVATE -Wl,--version-script=${CMAKE_CURRENT_BINARY_DIR}/src/exportmap -Wl,--no-undefined)
+if(NOT WIN32)
+  target_link_libraries(amd-dbgapi
+    PRIVATE -Wl,--version-script=${CMAKE_CURRENT_BINARY_DIR}/src/exportmap -Wl,--no-undefined)
+endif()
 
 set(AMD_DBGAPI_CONFIG_NAME amd-dbgapi-config.cmake)
 set(AMD_DBGAPI_TARGETS_NAME amd-dbgapi-targets.cmake)

--- a/projects/rocdbgapi/include/amd-dbgapi.h.in
+++ b/projects/rocdbgapi/include/amd-dbgapi.h.in
@@ -492,19 +492,19 @@
 #endif /* !defined (AMD_DBGAPI_CALL) */
 
 #if !defined(AMD_DBGAPI_EXPORT_DECORATOR)
-#if defined(__GNUC__)
-#define AMD_DBGAPI_EXPORT_DECORATOR __attribute__ ((visibility ("default")))
-#elif defined(_MSC_VER)
-#define AMD_DBGAPI_EXPORT_DECORATOR __declspec(dllexport)
-#endif /* defined (_MSC_VER) */
+# if defined(_WIN32)
+#  define AMD_DBGAPI_EXPORT_DECORATOR __declspec(dllexport)
+# elif defined(__GNUC__)
+#  define AMD_DBGAPI_EXPORT_DECORATOR __attribute__ ((visibility ("default")))
+# endif
 #endif /* !defined (AMD_DBGAPI_EXPORT_DECORATOR) */
 
 #if !defined(AMD_DBGAPI_IMPORT_DECORATOR)
-#if defined(__GNUC__)
-#define AMD_DBGAPI_IMPORT_DECORATOR
-#elif defined(_MSC_VER)
-#define AMD_DBGAPI_IMPORT_DECORATOR __declspec(dllimport)
-#endif /* defined (_MSC_VER) */
+# if defined(_WIN32)
+#  define AMD_DBGAPI_IMPORT_DECORATOR __declspec(dllimport)
+# else
+#  define AMD_DBGAPI_IMPORT_DECORATOR
+# endif
 #endif /* !defined (AMD_DBGAPI_IMPORT_DECORATOR) */
 
 #define AMD_DBGAPI_EXPORT AMD_DBGAPI_EXPORT_DECORATOR AMD_DBGAPI_CALL


### PR DESCRIPTION
Don't pass --version-script to the linker on Windows.  GNU ld accepts
it, which has the effect to exporting all symbols marked with default
visibility (instead of all symbols), but it does not work with MSVC's
linker, nor with LLVM's lld-link:

[amd-dbgapi] [25/25] Linking CXX shared library rocm-dbgapi.dll
[amd-dbgapi] lld-link: warning: ignoring unknown argument '--version-script=D:/therock/build/debug-tools/amd-dbgapi/build/src/exportmap'
[amd-dbgapi] lld-link: warning: ignoring unknown argument '--no-undefined'

Instead, tweak the AMD_DBGAPI_EXPORT_DECORATOR definition to use
__declspec(dllexport) on all Windows toolchains, including MinGW with
GNU ld.  If GNU ld sees any symbol with __declspec(dllexport), then it
switches to only exporting those symbols.

If/when we need more control over the exported symbols, we should look
into a .def file instead, which works on all Windows toolchains.

Change-Id: I01b586c8fa0d64b103174d3082677d200131b17a

---

**Stack**:
- #4316
- #4315
- #4314
- #4313
- #4312
- #4311
- #4310
- #4309
- #4308
- #4307
- #4306
- #4305
- #4304
- #4303
- #4302
- #4301
- #4300 ⬅
- #4299


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*