### PR TITLE
[msvc 5/18] dbgapi/win32: Don't disable -Werror for src/os_driver_kmd.cpp

### DIFF
--- a/projects/rocdbgapi/CMakeLists.txt
+++ b/projects/rocdbgapi/CMakeLists.txt
@@ -284,19 +284,18 @@ elseif(CMAKE_SYSTEM_NAME STREQUAL "Windows")
 
   target_include_directories(amd-dbgapi PRIVATE
     src/windows/imported
-    ${D3DKMT_INCLUDE_PATH}
+    ${D3DKMT_INCLUDE_PATH})
+
+  # Including libdxg raises some warnings (unknown pragmas) as well as
+  # "X too small to hold all values of Y".  The latter warning cannot
+  # be silenced, so tell the compiler to treat the libdxg directory as
+  # a system headers include path, so that warnings are disabled for
+  # that directory's headers.
+  target_include_directories(amd-dbgapi SYSTEM PRIVATE
     third_party/libdxg/include)
 
   target_compile_definitions(amd-dbgapi
     PRIVATE D3DKMDT_SPECIAL_MULTIPLATFORM_TOOL)
-
-  # Including libdxg raises some warnings (unknown pargmas) as well us
-  # "X too small to hold all values of Y".  The latter warning cannot be
-  # silenced, se we need to disable -Werror for this file.
-  set_source_files_properties(
-    src/os_driver_kmd.cpp
-    PROPERTIES
-      COMPILE_OPTIONS "-Wno-error;-Wno-unknown-pragmas")
 else()
   message(FATAL_ERROR "Platform ${CMAKE_SYSTEM_NAME} is not supported")
 endif()


### PR DESCRIPTION
Instead of disabling -Werror for src/os_driver_kmd.cpp, make
libdxg/include/ a system includes path, which makes the compiler
disable warnings for headers in that path.

Change-Id: If8252d486523ce99666dfa12bb181d1126888e4b

---

**Stack**:
- #4316
- #4315
- #4314
- #4313
- #4312
- #4311
- #4310
- #4309
- #4308
- #4307
- #4306
- #4305
- #4304
- #4303 ⬅
- #4302
- #4301
- #4300
- #4299


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*