### PR TITLE
[msvc 8/18] dbgapi: Add -Wconversion and fix whole dbgapi codebase

### DIFF
--- a/projects/rocdbgapi/CMakeLists.txt
+++ b/projects/rocdbgapi/CMakeLists.txt
@@ -166,7 +166,7 @@ set_target_properties(amd-dbgapi PROPERTIES
   SOVERSION ${PROJECT_VERSION_MAJOR})
 
 target_compile_options(amd-dbgapi PRIVATE
-  -fno-rtti -Werror -Wall -Wextra -Wshadow -Wno-attributes) #-pedantic)
+  -fno-rtti -Werror -Wall -Wextra -Wshadow -Wno-attributes -Wconversion) #-pedantic)
 
 target_compile_definitions(amd-dbgapi
   PRIVATE __STDC_LIMIT_MACROS __STDC_CONSTANT_MACROS __STDC_FORMAT_MACROS)

--- a/projects/rocdbgapi/src/agent.cpp
+++ b/projects/rocdbgapi/src/agent.cpp
@@ -266,7 +266,8 @@ agent_t::remove_watchpoint (const watchpoint_t &watchpoint)
   if (it == std::end (m_watchpoints))
     return;
 
-  os_watch_id_t os_watch_id = std::distance (begin (m_watchpoints), it);
+  auto os_watch_id
+    = utils::narrow<os_watch_id_t> (std::distance (begin (m_watchpoints), it));
 
   amd_dbgapi_status_t status = process ().os_driver ().clear_address_watch (
     os_agent_id (), os_watch_id);

--- a/projects/rocdbgapi/src/architecture.cpp
+++ b/projects/rocdbgapi/src/architecture.cpp
@@ -111,18 +111,19 @@ protected:
   static constexpr uint32_t sq_wave_status_cond_dbg_user_mask = 1 << 20;
   static constexpr uint32_t sq_wave_status_cond_dbg_sys_mask = 1 << 21;
 
-  static constexpr uint32_t ttmp11_wave_in_group_mask = utils::bit_mask (0, 5);
+  static constexpr auto ttmp11_wave_in_group_mask
+    = utils::bit_mask<uint32_t> (0, 5);
   static constexpr int ttmp11_wave_in_group_shift = 0;
-  static constexpr uint32_t ttmp6_spi_ttmps_setup_disabled_mask = 1 << 31;
+  static constexpr uint32_t ttmp6_spi_ttmps_setup_disabled_mask = 1u << 31;
   static constexpr uint32_t ttmp6_wave_stopped_mask = 1 << 30;
   static constexpr uint32_t ttmp6_saved_status_halt_mask = 1 << 29;
   static constexpr int ttmp6_saved_trap_id_shift = 25;
   static constexpr int ttmp6_saved_trap_id_size = 4;
-  static constexpr uint32_t ttmp6_saved_trap_id_mask = utils::bit_mask (
+  static constexpr auto ttmp6_saved_trap_id_mask = utils::bit_mask<uint32_t> (
     ttmp6_saved_trap_id_shift,
     ttmp6_saved_trap_id_shift + ttmp6_saved_trap_id_size - 1);
-  static constexpr uint32_t ttmp6_queue_packet_id_mask
-    = utils::bit_mask (0, 24);
+  static constexpr auto ttmp6_queue_packet_id_mask
+    = utils::bit_mask<uint32_t> (0, 24);
   static constexpr int ttmp6_queue_packet_id_shift = 0;
 
   /* See https://llvm.org/docs/AMDGPUUsage.html#trap-handler-abi  */
@@ -140,7 +141,7 @@ protected:
      library only handles trap IDs between 1 and 14.  */
   static constexpr std::optional<trap_id_t> ttmp6_saved_trap_id (uint32_t x)
   {
-    if (uint8_t trap_id = utils::bit_extract (
+    if (auto trap_id = utils::bit_extract<uint8_t> (
           x, ttmp6_saved_trap_id_shift,
           ttmp6_saved_trap_id_shift + ttmp6_saved_trap_id_size - 1);
         trap_id != 0)
@@ -174,9 +175,10 @@ protected:
   static constexpr uint32_t sq_wave_trapsts_excp_hi_addr_watch3_mask = 1 << 14;
   static constexpr uint32_t sq_wave_trapsts_xnack_error_mask = 1 << 28;
 
-  static constexpr uint32_t sq_wave_trapsts_excp_mask = utils::bit_mask (0, 8);
-  static constexpr uint32_t sq_wave_trapsts_excp_hi_mask
-    = utils::bit_mask (12, 14);
+  static constexpr auto sq_wave_trapsts_excp_mask
+    = utils::bit_mask<uint32_t> (0, 8);
+  static constexpr auto sq_wave_trapsts_excp_hi_mask
+    = utils::bit_mask<uint32_t> (12, 14);
 
   static constexpr uint32_t compute_relaunch_is_event (uint32_t relaunch)
   {
@@ -862,7 +864,8 @@ amdgcn_architecture_t::branch_target (wave_t &wave, agent_address_t pc,
       uint32_t csp;
       wave.read_register (amdgpu_regnum_t::csp, &csp);
 
-      amdgpu_regnum_t regnum = amdgpu_regnum_t::s0 + --csp * 4;
+      amdgpu_regnum_t regnum = (amdgpu_regnum_t::s0
+                                + utils::narrow<amdgpu_regdiff_t> (--csp * 4));
 
       uint32_t pc_lo, pc_hi;
       wave.read_register (regnum + 2, &pc_lo);
@@ -1133,15 +1136,16 @@ amdgcn_architecture_t::simulate_instruction (
             = (taken ? pc + instruction.size ()
                      : branch_target (wave, pc, instruction));
 
-          uint32_t saved_exec_lo = taken ? mask_fail : mask_pass;
-          uint32_t saved_exec_hi = (taken ? mask_fail : mask_pass) >> 32;
-          uint32_t saved_pc_lo = saved_pc;
-          uint32_t saved_pc_hi = saved_pc >> 32;
+          auto saved_exec = taken ? mask_fail : mask_pass;
+          auto [saved_exec_lo, saved_exec_hi] = utils::split (saved_exec);
+          auto [saved_pc_lo, saved_pc_hi] = utils::split (saved_pc);
 
           uint32_t csp;
           wave.read_register (amdgpu_regnum_t::csp, &csp);
 
-          amdgpu_regnum_t regnum = amdgpu_regnum_t::s0 + csp++ * 4;
+          amdgpu_regnum_t regnum
+            = (amdgpu_regnum_t::s0
+               + utils::narrow<amdgpu_regdiff_t> (--csp * 4));
           wave.write_register (regnum + 0, saved_exec_lo);
           wave.write_register (regnum + 1, saved_exec_hi);
           wave.write_register (regnum + 2, saved_pc_lo);
@@ -1161,7 +1165,9 @@ amdgcn_architecture_t::simulate_instruction (
           uint32_t csp;
           wave.read_register (amdgpu_regnum_t::csp, &csp);
 
-          amdgpu_regnum_t regnum = amdgpu_regnum_t::s0 + --csp * 4;
+          amdgpu_regnum_t regnum
+            = (amdgpu_regnum_t::s0
+               + utils::narrow<amdgpu_regdiff_t> (--csp * 4));
 
           uint32_t exec_lo, exec_hi;
           wave.read_register (regnum + 0, &exec_lo);
@@ -1736,31 +1742,31 @@ amdgcn_architecture_t::wave_disable_traps (
 uint8_t
 amdgcn_architecture_t::ssrc0_operand (const instruction_t &instruction)
 {
-  return utils::bit_extract (instruction.word<0> (), 0, 7);
+  return utils::bit_extract<uint8_t> (instruction.word<0> (), 0, 7);
 }
 
 uint8_t
 amdgcn_architecture_t::ssrc1_operand (const instruction_t &instruction)
 {
-  return utils::bit_extract (instruction.word<0> (), 8, 15);
+  return utils::bit_extract<uint8_t> (instruction.word<0> (), 8, 15);
 }
 
 uint8_t
 amdgcn_architecture_t::sdst_operand (const instruction_t &instruction)
 {
-  return utils::bit_extract (instruction.word<0> (), 16, 22);
+  return utils::bit_extract<uint8_t> (instruction.word<0> (), 16, 22);
 }
 
 int16_t
 amdgcn_architecture_t::simm16_operand (const instruction_t &instruction)
 {
-  return utils::bit_extract (instruction.word<0> (), 0, 15);
+  return utils::bit_extract<int16_t> (instruction.word<0> (), 0, 15);
 }
 
 uint8_t
 amdgcn_architecture_t::encoding_op7 (const instruction_t &instruction)
 {
-  return utils::bit_extract (instruction.word<0> (), 16, 22);
+  return utils::bit_extract<uint8_t> (instruction.word<0> (), 16, 22);
 }
 
 template <int... op5>
@@ -1837,19 +1843,23 @@ amdgcn_architecture_t::register_name (amdgpu_regnum_t regnum) const
   if (regnum >= amdgpu_regnum_t::first_shadow_sgpr
       && regnum <= amdgpu_regnum_t::last_shadow_sgpr)
     {
-      return string_printf ("s%" PRId64,
-                            regnum - amdgpu_regnum_t::first_shadow_sgpr);
+      auto print_num
+        = utils::narrow<int> (regnum - amdgpu_regnum_t::first_shadow_sgpr);
+      return string_printf ("s%d", print_num);
     }
   if (regnum >= amdgpu_regnum_t::first_sgpr
       && regnum <= amdgpu_regnum_t::last_sgpr)
     {
-      return string_printf ("s%" PRId64, regnum - amdgpu_regnum_t::first_sgpr);
+      auto print_num
+        = utils::narrow<int> (regnum - amdgpu_regnum_t::first_sgpr);
+      return string_printf ("s%d", print_num);
     }
   if (regnum >= amdgpu_regnum_t::first_vgpr_64
       && regnum <= amdgpu_regnum_t::last_vgpr_64)
     {
-      return string_printf ("v%" PRId64,
-                            regnum - amdgpu_regnum_t::first_vgpr_64);
+      auto print_num
+        = utils::narrow<int> (regnum - amdgpu_regnum_t::first_vgpr_64);
+      return string_printf ("v%d", print_num);
     }
   if (regnum >= amdgpu_regnum_t::first_ttmp
       && regnum <= amdgpu_regnum_t::last_ttmp)
@@ -1865,8 +1875,11 @@ amdgcn_architecture_t::register_name (amdgpu_regnum_t regnum) const
         case amdgpu_regnum_t::ttmp10:
         case amdgpu_regnum_t::ttmp11:
         case amdgpu_regnum_t::ttmp13:
-          return string_printf ("ttmp%" PRId64,
-                                regnum - amdgpu_regnum_t::first_ttmp);
+          {
+            auto print_num
+              = utils::narrow<int> (regnum - amdgpu_regnum_t::first_ttmp);
+            return string_printf ("ttmp%d", print_num);
+          }
         default:
           break;
         }
@@ -1874,8 +1887,9 @@ amdgcn_architecture_t::register_name (amdgpu_regnum_t regnum) const
   if (regnum >= amdgpu_regnum_t::first_hwreg
       && regnum <= amdgpu_regnum_t::last_hwreg)
     {
-      return string_printf ("hwreg%" PRId64,
-                            regnum - amdgpu_regnum_t::first_hwreg);
+      auto print_num
+        = utils::narrow<int> (regnum - amdgpu_regnum_t::first_hwreg);
+      return string_printf ("hwreg%d", print_num);
     }
 
   if (regnum == amdgpu_regnum_t::exec_64
@@ -2072,26 +2086,28 @@ amdgcn_architecture_t::register_read_only_mask (amdgpu_regnum_t regnum) const
     case amdgpu_regnum_t::trapsts:
       {
         static uint32_t trapsts_read_only_bits
-          = utils::bit_mask (9, 9) /* 0  */ | utils::bit_mask (15, 15) /* 0  */
-            | utils::bit_mask (22, 27) /* 0  */;
+          = (utils::bit_mask<uint32_t> (9, 9)       /* 0 */
+             | utils::bit_mask<uint32_t> (15, 15)   /* 0 */
+             | utils::bit_mask<uint32_t> (22, 27)); /* 0 */
         return &trapsts_read_only_bits;
       }
 
     case amdgpu_regnum_t::mode:
       {
-        static uint32_t mode_read_only_bits = utils::bit_mask (21, 22); /* 0 */
+        static uint32_t mode_read_only_bits
+          = utils::bit_mask<uint32_t> (21, 22); /* 0 */
         return &mode_read_only_bits;
       }
 
     case amdgpu_regnum_t::pseudo_status:
       {
         static uint32_t status_read_only_bits
-          = utils::bit_mask (5, 7)      /* priv, trap_en, ttrace_en  */
-            | utils::bit_mask (9, 12)   /* execz, vccz, in_tg, in_barrier  */
-            | utils::bit_mask (14, 16)  /* trap, ttrace_cu_en, valid  */
-            | utils::bit_mask (18, 19)  /* skip_export, perf_en  */
-            | utils::bit_mask (22, 26)  /* allow_replay, fatal_halt, 0  */
-            | utils::bit_mask (28, 31); /* 0  */
+          = (utils::bit_mask<uint32_t> (5, 7)       /* priv, trap_en, ttrace_en */
+             | utils::bit_mask<uint32_t> (9, 12)    /* execz, vccz, in_tg, in_barrier */
+             | utils::bit_mask<uint32_t> (14,16)    /* trap, ttrace_cu_en, valid */
+             | utils::bit_mask<uint32_t> (18, 19)   /* skip_export, perf_en */
+             | utils::bit_mask<uint32_t> (22, 26)   /* allow_replay, fatal_halt, 0 */
+             | utils::bit_mask<uint32_t> (28, 31)); /* 0 */
         return &status_read_only_bits;
       }
 
@@ -2329,7 +2345,7 @@ amdgcn_architecture_t::write_pseudo_register (const wave_t &wave,
       memcpy (reinterpret_cast<std::byte *> (&csp) + offset, value,
               value_size);
 
-      mode = (mode & ~utils::bit_mask (29, 31)) | (csp << 29);
+      mode = (mode & ~utils::bit_mask<uint32_t> (29, 31)) | (csp << 29);
 
       wave.write_register (amdgpu_regnum_t::mode, mode);
       return;
@@ -2347,13 +2363,13 @@ amdgcn_architecture_t::save_pc_for_park (const wave_t &wave,
 
   uint32_t ttmp7, ttmp11;
   /* The trap handler saves PC[31:0] in ttmp7[31:0] ...  */
-  ttmp7 = utils::bit_extract (pc, 0, 31);
+  ttmp7 = utils::bit_extract<uint32_t> (pc, 0, 31);
   wave.write_register (amdgpu_regnum_t::ttmp7, ttmp7);
 
   /* ... and PC[47:32] in ttmp11[22:7].  */
   wave.read_register (amdgpu_regnum_t::ttmp11, &ttmp11);
-  ttmp11 &= ~utils::bit_mask (7, 22);
-  ttmp11 |= (utils::bit_extract (pc, 32, 47) << 7);
+  ttmp11 &= ~utils::bit_mask<uint32_t> (7, 22);
+  ttmp11 |= (utils::bit_extract<uint32_t> (pc, 32, 47) << 7);
   wave.write_register (amdgpu_regnum_t::ttmp11, ttmp11);
 }
 
@@ -2576,14 +2592,19 @@ gfx9_architecture_t::gfx9_architecture_t (elf_amdgpu_machine_t e_machine,
 
   /* Scalar registers: [s0-s102].  */
   auto &scalar_registers = create<register_class_t> (*this, "scalar");
-  scalar_registers.add_registers (
-    amdgpu_regnum_t::first_sgpr,
-    amdgpu_regnum_t::first_sgpr + gfx9_architecture_t::scalar_register_count ()
-      - 1);
-  scalar_registers.add_registers (
-    amdgpu_regnum_t::first_shadow_sgpr,
-    amdgpu_regnum_t::first_shadow_sgpr
-      + gfx9_architecture_t::scalar_register_count () - 1);
+  const auto scalar_register_count
+    = gfx9_architecture_t::scalar_register_count ();
+
+  scalar_registers.add_registers
+    (amdgpu_regnum_t::first_sgpr,
+     (amdgpu_regnum_t::first_sgpr
+      + utils::narrow<amdgpu_regdiff_t> (scalar_register_count)
+      - 1));
+  scalar_registers.add_registers
+    (amdgpu_regnum_t::first_shadow_sgpr,
+     (amdgpu_regnum_t::first_shadow_sgpr
+      + utils::narrow<amdgpu_regdiff_t> (scalar_register_count)
+      - 1));
 
   /* Vector registers: [v0-v255]  */
   auto &vector_registers = create<register_class_t> (*this, "vector");
@@ -2612,10 +2633,11 @@ gfx9_architecture_t::gfx9_architecture_t (elf_amdgpu_machine_t e_machine,
 
   /* General registers: [{scalar}, {vector}, pc, exec, vcc]  */
   auto &general_registers = create<register_class_t> (*this, "general");
-  general_registers.add_registers (
-    amdgpu_regnum_t::first_sgpr,
-    amdgpu_regnum_t::first_sgpr + gfx9_architecture_t::scalar_register_count ()
-      - 1);
+  general_registers.add_registers
+    (amdgpu_regnum_t::first_sgpr,
+     amdgpu_regnum_t::first_sgpr
+     + utils::narrow<amdgpu_regdiff_t> (scalar_register_count)
+     - 1);
   general_registers.add_registers (amdgpu_regnum_t::first_vgpr_64,
                                    amdgpu_regnum_t::last_vgpr_64);
   general_registers.add_registers (amdgpu_regnum_t::m0, amdgpu_regnum_t::m0);
@@ -3135,7 +3157,9 @@ gfx9_architecture_t::cwsr_record_t::register_address (
   if (regnum >= amdgpu_regnum_t::first_ttmp
       && regnum <= amdgpu_regnum_t::last_ttmp)
     {
-      return ttmps_addr + (regnum - amdgpu_regnum_t::first_ttmp) * ttmp_size;
+      return (ttmps_addr
+              + (utils::narrow<size_t> (regnum - amdgpu_regnum_t::first_ttmp)
+                 * ttmp_size));
     }
 
   size_t hwreg_count = 16;
@@ -3181,22 +3205,27 @@ gfx9_architecture_t::cwsr_record_t::register_address (
   if (regnum >= amdgpu_regnum_t::first_hwreg
       && regnum <= amdgpu_regnum_t::last_hwreg)
     {
-      return hwregs_addr
-             + (regnum - amdgpu_regnum_t::first_hwreg) * hwreg_size;
+      return (hwregs_addr
+              + utils::narrow<size_t> (regnum - amdgpu_regnum_t::first_hwreg)
+              * hwreg_size);
     }
 
   size_t sgpr_count = this->sgpr_count ();
   size_t sgpr_size = sizeof (int32_t);
   agent_address_t sgprs_addr = hwregs_addr - sgpr_count * sgpr_size;
 
+  auto arch_scalars_count = (architecture.scalar_register_count ()
+                             + architecture.scalar_alias_count ());
   amdgpu_regnum_t aliased_sgpr_end
-    = amdgpu_regnum_t::first_sgpr
-      + std::min (architecture.scalar_register_count ()
-                    + architecture.scalar_alias_count (),
-                  sgpr_count);
+    = (amdgpu_regnum_t::first_sgpr
+       + utils::narrow<amdgpu_regdiff_t> (std::min (arch_scalars_count,
+                                                    sgpr_count)));
+
+  auto scalar_alias_count = architecture.scalar_alias_count ();
 
   /* Exclude the aliased sgprs.  */
-  if (regnum >= (aliased_sgpr_end - architecture.scalar_alias_count ())
+  if (regnum >= (aliased_sgpr_end
+                 - utils::narrow<amdgpu_regdiff_t> (scalar_alias_count))
       && regnum < aliased_sgpr_end)
     return std::nullopt;
 
@@ -3226,13 +3255,16 @@ gfx9_architecture_t::cwsr_record_t::register_address (
       + (amdgpu_regnum_t::first_shadow_sgpr - amdgpu_regnum_t::first_sgpr);
 
   /* Map the shadow sgprs onto the same slots as "regular" sgprs.  */
-  if (regnum >= (shadow_sgpr_end - architecture.scalar_alias_count ())
+  if (regnum >= (shadow_sgpr_end
+                 - utils::narrow<amdgpu_regdiff_t> (scalar_alias_count))
       && regnum < shadow_sgpr_end)
     {
       /* The xnack_mask register (shadow_sgpr_end[-4:-3]) really is saved in
          the hwreg block (hwreg[7:8]) by the CWSR handler.  */
       if (regnum == (shadow_sgpr_end - 4) || regnum == (shadow_sgpr_end - 3))
-        return hwregs_addr + (11 - (shadow_sgpr_end - regnum)) * hwreg_size;
+        return (hwregs_addr
+                + (utils::narrow<size_t> (11 - (shadow_sgpr_end - regnum))
+                   * hwreg_size));
 
       regnum = amdgpu_regnum_t::first_sgpr
                + (regnum - amdgpu_regnum_t::first_shadow_sgpr);
@@ -3240,7 +3272,9 @@ gfx9_architecture_t::cwsr_record_t::register_address (
 
   if (regnum >= amdgpu_regnum_t::first_sgpr && regnum < aliased_sgpr_end)
     {
-      return sgprs_addr + (regnum - amdgpu_regnum_t::s0) * sgpr_size;
+      return (sgprs_addr
+              + (utils::narrow<size_t> (regnum - amdgpu_regnum_t::s0)
+                 * sgpr_size));
     }
 
   size_t vgpr_count = this->vgpr_count ();
@@ -3249,9 +3283,12 @@ gfx9_architecture_t::cwsr_record_t::register_address (
 
   if (regnum >= amdgpu_regnum_t::first_vgpr_64
       && regnum <= amdgpu_regnum_t::last_vgpr_64
-      && ((regnum - amdgpu_regnum_t::v0_64) < vgpr_count))
+      && ((regnum - amdgpu_regnum_t::v0_64)
+          < utils::narrow<amdgpu_regdiff_t> (vgpr_count)))
     {
-      return vgprs_addr + (regnum - amdgpu_regnum_t::v0_64) * vgpr_size;
+      return (vgprs_addr
+              + (utils::narrow<size_t> (regnum - amdgpu_regnum_t::v0_64)
+                 * vgpr_size));
     }
 
   return std::nullopt;
@@ -3336,8 +3373,8 @@ gfx9_architecture_t::scratch_memory_region (
   amd_dbgapi_size_t wavesize
     = utils::bit_extract (compute_tmpring_size_register, 12, 24) * 1024;
 
-  uint32_t shader_engine_count
-    = agent.os_info ().shader_engine_count / agent.os_info ().xcc_count;
+  auto shader_engine_count = utils::narrow<uint32_t> (
+    agent.os_info ().shader_engine_count / agent.os_info ().xcc_count);
   dbgapi_assert (shader_engine_count != 0);
 
   amd_dbgapi_size_t offset
@@ -3470,8 +3507,9 @@ mi_architecture_t::register_name (amdgpu_regnum_t regnum) const
   if (regnum >= amdgpu_regnum_t::first_accvgpr_64
       && regnum <= amdgpu_regnum_t::last_accvgpr_64)
     {
-      return string_printf ("a%" PRId64,
-                            regnum - amdgpu_regnum_t::first_accvgpr_64);
+      int print_num
+        = utils::narrow<int> (regnum - amdgpu_regnum_t::first_accvgpr_64);
+      return string_printf ("a%d", print_num);
     }
 
   return gfx9_architecture_t::register_name (regnum);
@@ -3522,9 +3560,12 @@ mi_architecture_t::cwsr_record_t::register_address (
 
   if (regnum >= amdgpu_regnum_t::first_accvgpr_64
       && regnum <= amdgpu_regnum_t::last_accvgpr_64
-      && ((regnum - amdgpu_regnum_t::a0_64) < accvgpr_count))
+      && ((regnum - amdgpu_regnum_t::a0_64)
+          < utils::narrow<amdgpu_regdiff_t> (accvgpr_count)))
     {
-      return accvgprs_addr + (regnum - amdgpu_regnum_t::a0_64) * accvgpr_size;
+      return (accvgprs_addr
+              + (utils::narrow<size_t> (regnum - amdgpu_regnum_t::a0_64)
+                 * accvgpr_size));
     }
 
   size_t vgpr_count = this->vgpr_count ();
@@ -3533,9 +3574,12 @@ mi_architecture_t::cwsr_record_t::register_address (
 
   if (regnum >= amdgpu_regnum_t::first_vgpr_64
       && regnum <= amdgpu_regnum_t::last_vgpr_64
-      && ((regnum - amdgpu_regnum_t::v0_64) < vgpr_count))
+      && ((regnum - amdgpu_regnum_t::v0_64)
+          < utils::narrow<amdgpu_regdiff_t> (vgpr_count)))
     {
-      return vgprs_addr + (regnum - amdgpu_regnum_t::v0_64) * vgpr_size;
+      return (vgprs_addr
+              + (utils::narrow<size_t> (regnum - amdgpu_regnum_t::v0_64)
+                 * vgpr_size));
     }
 
   return std::nullopt;
@@ -3695,10 +3739,10 @@ protected:
   static constexpr uint32_t sq_wave_trapsts_trap_after_inst_mask = 1 << 25;
   static constexpr uint32_t sq_wave_trapsts_perf_snapshot_mask = 1 << 26;
 
-  static constexpr uint32_t ttmp11_queue_packet_id_mask
-    = utils::bit_mask (6, 30);
+  static constexpr auto ttmp11_queue_packet_id_mask
+    = utils::bit_mask<uint32_t> (6, 30);
   static constexpr int ttmp11_queue_packet_id_shift = 6;
-  static constexpr uint32_t ttmp11_trap_hander_ttmps_setup_mask = 1 << 31;
+  static constexpr uint32_t ttmp11_trap_hander_ttmps_setup_mask = 1u << 31;
 
   class cwsr_record_t : public gfx90a_t::cwsr_record_t
   {
@@ -4088,22 +4132,24 @@ gfx9_4_architecture_t::register_read_only_mask (amdgpu_regnum_t regnum) const
     {
     case amdgpu_regnum_t::trapsts:
       static uint32_t trapsts_read_only_bits
-        = utils::bit_mask (9, 9) /* 0  */ | utils::bit_mask (15, 15) /* 0  */
-          | utils::bit_mask (27, 27) /* 0  */;
+        = (utils::bit_mask<uint32_t> (9, 9)       /* 0 */
+           | utils::bit_mask<uint32_t> (15, 15)   /* 0 */
+           | utils::bit_mask<uint32_t> (27, 27)); /* 0 */
       return &trapsts_read_only_bits;
 
     case amdgpu_regnum_t::mode:
-      static uint32_t mode_read_only_bits = utils::bit_mask (22, 22); /* 0 */
+      static uint32_t mode_read_only_bits
+        = utils::bit_mask<uint32_t> (22, 22); /* 0 */
       return &mode_read_only_bits;
 
     case amdgpu_regnum_t::pseudo_status:
       static uint32_t status_read_only_bits
-        = utils::bit_mask (5, 7)      /* priv, trap_en, ttrace_en  */
-          | utils::bit_mask (9, 12)   /* execz, vccz, in_tg, in_barrier  */
-          | utils::bit_mask (14, 16)  /* trap, ttrace_cu_en, valid  */
-          | utils::bit_mask (18, 19)  /* skip_export, perf_en  */
-          | utils::bit_mask (22, 26)  /* allow_replay, fatal_halt, 0  */
-          | utils::bit_mask (29, 30); /* 0  */
+        = (utils::bit_mask<uint32_t> (5, 7)       /* priv, trap_en, ttrace_en */
+           | utils::bit_mask<uint32_t> (9, 12)    /* execz, vccz, in_tg, in_barrier */
+           | utils::bit_mask<uint32_t> (14, 16)   /* trap, ttrace_cu_en, valid */
+           | utils::bit_mask<uint32_t> (18, 19)   /* skip_export, perf_en */
+           | utils::bit_mask<uint32_t> (22, 26)   /* allow_replay, fatal_halt, 0 */
+           | utils::bit_mask<uint32_t> (29, 30)); /* 0 */
       return &status_read_only_bits;
 
     default:
@@ -4373,17 +4419,24 @@ gfx10_architecture_t::gfx10_architecture_t (elf_amdgpu_machine_t e_machine,
                { return register_class.name () == "scalar"; });
   dbgapi_assert (scalar_registers != nullptr);
 
-  scalar_registers->add_registers (
-    amdgpu_regnum_t::first_sgpr
-      + gfx9_architecture_t::scalar_register_count (),
-    amdgpu_regnum_t::first_sgpr
-      + gfx10_architecture_t::scalar_register_count () - 1);
+  auto gfx9_scalar_register_count
+    = gfx9_architecture_t::scalar_register_count ();
+  auto gfx10_scalar_register_count
+    = gfx10_architecture_t::scalar_register_count ();
 
-  scalar_registers->add_registers (
-    amdgpu_regnum_t::first_shadow_sgpr
-      + gfx9_architecture_t::scalar_register_count (),
-    amdgpu_regnum_t::first_shadow_sgpr
-      + gfx10_architecture_t::scalar_register_count () - 1);
+  scalar_registers->add_registers
+    ((amdgpu_regnum_t::first_sgpr
+      + utils::narrow<amdgpu_regdiff_t> (gfx9_scalar_register_count)),
+     (amdgpu_regnum_t::first_sgpr
+      + utils::narrow<amdgpu_regdiff_t> (gfx10_scalar_register_count)
+      - 1));
+
+  scalar_registers->add_registers
+    ((amdgpu_regnum_t::first_shadow_sgpr
+      + utils::narrow<amdgpu_regdiff_t> (gfx9_scalar_register_count)),
+     (amdgpu_regnum_t::first_shadow_sgpr
+      + utils::narrow<amdgpu_regdiff_t> (gfx10_scalar_register_count)
+      - 1));
 
   /* Vector registers: [v0_32-v255_32]  */
   register_class_t *vector_registers
@@ -4416,11 +4469,12 @@ gfx10_architecture_t::gfx10_architecture_t (elf_amdgpu_machine_t e_machine,
                { return register_class.name () == "general"; });
   dbgapi_assert (general_registers != nullptr);
 
-  general_registers->add_registers (
-    amdgpu_regnum_t::first_sgpr
-      + gfx9_architecture_t::scalar_register_count (),
-    amdgpu_regnum_t::first_sgpr
-      + gfx10_architecture_t::scalar_register_count () - 1);
+  general_registers->add_registers
+    ((amdgpu_regnum_t::first_sgpr
+      + utils::narrow<amdgpu_regdiff_t> (gfx9_scalar_register_count)),
+     (amdgpu_regnum_t::first_sgpr
+      + utils::narrow<amdgpu_regdiff_t> (gfx10_scalar_register_count)
+      - 1));
   general_registers->add_registers (amdgpu_regnum_t::first_vgpr_32,
                                     amdgpu_regnum_t::last_vgpr_32);
   general_registers->add_registers (amdgpu_regnum_t::pseudo_exec_32,
@@ -4435,8 +4489,9 @@ gfx10_architecture_t::register_name (amdgpu_regnum_t regnum) const
   if (regnum >= amdgpu_regnum_t::first_vgpr_32
       && regnum <= amdgpu_regnum_t::last_vgpr_32)
     {
-      return string_printf ("v%" PRId64,
-                            regnum - amdgpu_regnum_t::first_vgpr_32);
+      auto print_num
+        = utils::narrow<int> (regnum - amdgpu_regnum_t::first_vgpr_32);
+      return string_printf ("v%d", print_num);
     }
   if (regnum == amdgpu_regnum_t::exec_32
       || regnum == amdgpu_regnum_t::pseudo_exec_32)
@@ -4877,30 +4932,39 @@ gfx10_architecture_t::cwsr_record_t::register_address (
   agent_address_t private_vgprs_addr
     = shared_vgprs_addr - private_vgpr_count * private_vgpr_size;
 
-  if (regnum >= (amdgpu_regnum_t::v0_32 + private_vgpr_count)
+  if (regnum >= (amdgpu_regnum_t::v0_32
+                 + utils::narrow<amdgpu_regdiff_t> (private_vgpr_count))
       && regnum <= amdgpu_regnum_t::last_vgpr_32
       && ((regnum - amdgpu_regnum_t::v0_32)
-          < (private_vgpr_count + shared_vgpr_count)))
+          < utils::narrow<amdgpu_regdiff_t> (private_vgpr_count
+                                             + shared_vgpr_count)))
     {
-      return shared_vgprs_addr
-             + (regnum - (amdgpu_regnum_t::v0_32 + private_vgpr_count))
-                 * shared_vgpr_size;
+      return (shared_vgprs_addr
+              + (utils::narrow<size_t>
+                 (regnum
+                  - (amdgpu_regnum_t::v0_32
+                     + utils::narrow<amdgpu_regdiff_t> (private_vgpr_count)))
+                 * shared_vgpr_size));
     }
 
   if (lane_count == 32 && regnum >= amdgpu_regnum_t::first_vgpr_32
       && regnum <= amdgpu_regnum_t::last_vgpr_32
-      && ((regnum - amdgpu_regnum_t::v0_32) < private_vgpr_count))
+      && ((regnum - amdgpu_regnum_t::v0_32)
+          < utils::narrow<amdgpu_regdiff_t> (private_vgpr_count)))
     {
-      return private_vgprs_addr
-             + (regnum - amdgpu_regnum_t::v0_32) * private_vgpr_size;
+      return (private_vgprs_addr
+              + (utils::narrow<size_t> (regnum - amdgpu_regnum_t::v0_32)
+                 * private_vgpr_size));
     }
 
   if (lane_count == 64 && regnum >= amdgpu_regnum_t::first_vgpr_64
       && regnum <= amdgpu_regnum_t::last_vgpr_64
-      && ((regnum - amdgpu_regnum_t::v0_64) < private_vgpr_count))
+      && ((regnum - amdgpu_regnum_t::v0_64)
+          < utils::narrow<amdgpu_regdiff_t> (private_vgpr_count)))
     {
-      return private_vgprs_addr
-             + (regnum - amdgpu_regnum_t::v0_64) * private_vgpr_size;
+      return (private_vgprs_addr
+              + (utils::narrow<size_t> (regnum - amdgpu_regnum_t::v0_64)
+                 * private_vgpr_size));
     }
 
   return std::nullopt;
@@ -5729,23 +5793,25 @@ gfx11_architecture_t::register_read_only_mask (amdgpu_regnum_t regnum) const
     case amdgpu_regnum_t::trapsts:
       {
         static uint32_t trapsts_read_only_bits
-          = utils::bit_mask (9, 9) /* 0  */ | utils::bit_mask (21, 27) /* 0  */
-            | utils::bit_mask (29, 31) /* 0  */;
+          = (utils::bit_mask<uint32_t> (9, 9)       /* 0  */
+             | utils::bit_mask<uint32_t> (21, 27)   /* 0  */
+             | utils::bit_mask<uint32_t> (29, 31)); /* 0  */
         return &trapsts_read_only_bits;
       }
 
     case amdgpu_regnum_t::mode:
       {
         static uint32_t mode_read_only_bits
-          = utils::bit_mask (22, 22)   /* 0 */
-            | utils::bit_mask (24, 26) /* 0 */
-            | utils::bit_mask (28, 31) /* 0 */;
+          = (utils::bit_mask<uint32_t> (22, 22)     /* 0 */
+             | utils::bit_mask<uint32_t> (24, 26)   /* 0 */
+             | utils::bit_mask<uint32_t> (28, 31)); /* 0 */
         return &mode_read_only_bits;
       }
 
     case amdgpu_regnum_t::pseudo_status:
       {
-        static uint32_t status_read_only_bits = utils::bit_mask (0, 31);
+        static uint32_t status_read_only_bits
+          = utils::bit_mask<uint32_t> (0, 31);
         return &status_read_only_bits;
       }
 
@@ -5948,7 +6014,7 @@ gfx11_architecture_t::is_sendmsg (const instruction_t &instruction,
   if (message != nullptr)
     {
       /* Message type is in SIMM16[7:0] */
-      *message = simm16_operand (instruction) & 0xff;
+      utils::narrow_assign (*message, simm16_operand (instruction) & 0xff);
     }
 
   return true;
@@ -5999,8 +6065,8 @@ gfx11_architecture_t::scratch_memory_region (
                               + cwsr_record.scratch_scoreboard_id ())
                              * wavesize;
 
-  uint32_t shader_engine_count
-    = agent.os_info ().shader_engine_count / agent.os_info ().xcc_count;
+  auto shader_engine_count = utils::narrow<uint32_t> (
+    agent.os_info ().shader_engine_count / agent.os_info ().xcc_count);
 
   /* The scratch memory is evenly divided between all XCCs, so each XCC has its
      own scratch base.  */
@@ -6104,13 +6170,13 @@ protected:
   static constexpr uint32_t sq_wave_state_priv_barrier_complete_mask = 1 << 2;
   static constexpr uint32_t sq_wave_state_priv_named_barrier_complete_mask
     = 1 << 3;
-  static constexpr uint32_t sq_wave_state_priv_named_barrier_id_mask
-    = utils::bit_mask (4, 8);
+  static constexpr auto sq_wave_state_priv_named_barrier_id_mask
+    = utils::bit_mask<uint32_t> (4, 8);
   static constexpr uint32_t sq_wave_state_priv_scc_mask = 1 << 9;
-  static constexpr uint32_t sq_wave_state_priv_sys_prio_mask
-    = utils::bit_mask (10, 11);
-  static constexpr uint32_t sq_wave_state_priv_user_prio_mask
-    = utils::bit_mask (12, 13);
+  static constexpr auto sq_wave_state_priv_sys_prio_mask
+    = utils::bit_mask<uint32_t> (10, 11);
+  static constexpr auto sq_wave_state_priv_user_prio_mask
+    = utils::bit_mask<uint32_t> (12, 13);
   static constexpr uint32_t sq_wave_state_priv_halt_mask = 1 << 14;
   static constexpr uint32_t sq_wave_state_priv_poison_err_mask = 1 << 15;
   static constexpr uint32_t sq_wave_state_priv_cond_dbg_user_mask = 1 << 16;
@@ -6119,13 +6185,13 @@ protected:
   static constexpr uint32_t sq_wave_state_priv_perf_en_mask = 1 << 19;
   static constexpr uint32_t sq_wave_state_priv_ttrace_en_mask = 1 << 20;
 
-  static constexpr uint32_t ttmp8_queue_packet_id_mask
-    = utils::bit_mask (0, 24);
+  static constexpr auto ttmp8_queue_packet_id_mask
+    = utils::bit_mask<uint32_t> (0, 24);
   static constexpr uint32_t ttmp8_queue_packet_id_shift = 0;
-  static constexpr uint32_t ttmp8_wave_in_group_mask
-    = utils::bit_mask (25, 29);
+  static constexpr auto ttmp8_wave_in_group_mask
+    = utils::bit_mask<uint32_t> (25, 29);
   static constexpr uint32_t ttmp8_grid_yz_valid = 1 << 30;
-  static constexpr uint32_t ttmp8_debug_mark_mask = 1 << 31;
+  static constexpr uint32_t ttmp8_debug_mark_mask = 1u << 31;
 
   static constexpr uint32_t sq_wave_trap_ctrl_alu_invalid_mask = 1 << 0;
   static constexpr uint32_t sq_wave_trap_ctrl_alu_input_denorm_mask = 1 << 1;
@@ -6151,8 +6217,8 @@ protected:
   static constexpr uint32_t sq_wave_excp_priv_perf_snapshot_mask = 1 << 10;
   static constexpr uint32_t sq_wave_excp_priv_trap_after_inst_mask = 1 << 11;
   static constexpr uint32_t sq_wave_excp_priv_xnack_error_mask = 1 << 12;
-  static constexpr uint32_t sq_wave_excp_priv_first_memviol_source_watch
-    = utils::bit_mask (30, 31);
+  static constexpr auto sq_wave_excp_priv_first_memviol_source_watch
+    = utils::bit_mask<uint32_t> (30, 31);
 
   static constexpr uint32_t sq_wave_excp_user_alu_invalid_mask = 1 << 0;
   static constexpr uint32_t sq_wave_excp_user_alu_input_denorm_mask = 1 << 1;
@@ -6162,7 +6228,7 @@ protected:
   static constexpr uint32_t sq_wave_excp_user_alu_inexact_mask = 1 << 5;
   static constexpr uint32_t sq_wave_excp_user_alu_int_div0_mask = 1 << 6;
   static constexpr uint32_t sq_wave_excp_user_buffer_oob_mask = 1 << 30;
-  static constexpr uint32_t sq_wave_excp_user_lod_clamped_mask = 1 << 31;
+  static constexpr uint32_t sq_wave_excp_user_lod_clamped_mask = 1u << 31;
 
   class cwsr_record_t : public gfx11_architecture_t::cwsr_record_t
   {
@@ -6816,39 +6882,43 @@ gfx12_architecture_t::register_read_only_mask (amdgpu_regnum_t regnum) const
       {
         /* PRIV is RO, all unasigned bits are 0.  */
         static uint32_t status_ro_bits
-          = utils::bit_mask (0, 5) | utils::bit_mask (7, 7)
-            | utils::bit_mask (12, 13) | utils::bit_mask (17, 17)
-            | utils::bit_mask (19, 21);
+          = (utils::bit_mask<uint32_t> (0, 5)
+             | utils::bit_mask<uint32_t> (7, 7)
+             | utils::bit_mask<uint32_t> (12, 13)
+             | utils::bit_mask<uint32_t> (17, 17)
+             | utils::bit_mask<uint32_t> (19, 21));
         return &status_ro_bits;
       }
     case amdgpu_regnum_t::pseudo_state_priv:
       {
         static uint32_t state_priv_ro_bits
-          = utils::bit_mask (15, 17)
-            | utils::bit_mask (19, 20) /* PERF_EN and TTRACE_EN are RO.  */
-            | utils::bit_mask (21, 31);
+          = (utils::bit_mask<uint32_t> (15, 17)
+             | utils::bit_mask<uint32_t> (19, 20) /* PERF_EN and TTRACE_EN are RO.  */
+             | utils::bit_mask<uint32_t> (21, 31));
         return &state_priv_ro_bits;
       }
     case amdgpu_regnum_t::mode:
       {
-        static uint32_t mode_ro_bits = utils::bit_mask (8, 22)
-                                       | utils::bit_mask (25, 26)
-                                       | utils::bit_mask (28, 31);
+        static uint32_t mode_ro_bits = (utils::bit_mask<uint32_t> (8, 22)
+                                        | utils::bit_mask<uint32_t> (25, 26)
+                                        | utils::bit_mask<uint32_t> (28, 31));
         return &mode_ro_bits;
       }
     case amdgpu_regnum_t::trap_ctrl:
       {
-        static uint32_t trap_ctrl_ro_bits = utils::bit_mask (10, 31);
+        static uint32_t trap_ctrl_ro_bits = utils::bit_mask<uint32_t> (10, 31);
         return &trap_ctrl_ro_bits;
       }
     case amdgpu_regnum_t::excp_flag_priv:
       {
-        static uint32_t excp_flag_priv_ro_bits = utils::bit_mask (13, 29);
+        static uint32_t excp_flag_priv_ro_bits
+          = utils::bit_mask<uint32_t> (13, 29);
         return &excp_flag_priv_ro_bits;
       }
     case amdgpu_regnum_t::excp_flag_user:
       {
-        static uint32_t excp_flag_user_ro_bits = utils::bit_mask (7, 29);
+        static uint32_t excp_flag_user_ro_bits
+          = utils::bit_mask<uint32_t> (7, 29);
         return &excp_flag_user_ro_bits;
       }
 
@@ -7126,13 +7196,13 @@ gfx12_architecture_t::save_pc_for_park (const wave_t &wave,
 
   uint32_t ttmp10, ttmp11;
   /* The trap handler saves PC[31:0] in ttmp10[31:0] ...  */
-  ttmp10 = utils::bit_extract (pc, 0, 31);
+  ttmp10 = utils::bit_extract<uint32_t> (pc, 0, 31);
   wave.write_register (amdgpu_regnum_t::ttmp10, ttmp10);
 
   /* ... and PC[47:32] in ttmp11[22:7].  */
   wave.read_register (amdgpu_regnum_t::ttmp11, &ttmp11);
-  ttmp11 &= ~utils::bit_mask (7, 22);
-  ttmp11 |= (utils::bit_extract (pc, 32, 47) << 7);
+  ttmp11 &= ~utils::bit_mask<uint32_t> (7, 22);
+  ttmp11 |= (utils::bit_extract<uint32_t> (pc, 32, 47) << 7);
   wave.write_register (amdgpu_regnum_t::ttmp11, ttmp11);
 }
 
@@ -7279,8 +7349,8 @@ gfx12_architecture_t::cwsr_record_t::group_ids () const
   coordinates[0] = ttmp9;
   if (ttmp8 & ttmp8_grid_yz_valid)
     {
-      coordinates[1] = ttmp7 & utils::bit_mask (0, 15);
-      coordinates[2] = (ttmp7 & utils::bit_mask (16, 31)) >> 16;
+      coordinates[1] = ttmp7 & utils::bit_mask<uint32_t> (0, 15);
+      coordinates[2] = (ttmp7 & utils::bit_mask<uint32_t> (16, 31)) >> 16;
     }
 
   return coordinates;
@@ -7299,7 +7369,7 @@ gfx12_architecture_t::cwsr_record_t::position_in_group () const
 
   agent ().read_agent_memory (ttmp8_address, &ttmp8);
 
-  return (ttmp8 & utils::bit_mask (25, 29)) >> 25;
+  return utils::narrow<uint32_t> ((ttmp8 & utils::bit_mask (25, 29)) >> 25);
 }
 
 size_t
@@ -7446,8 +7516,8 @@ gfx12_architecture_t::scratch_memory_region (
                               + cwsr_record.scratch_scoreboard_id ())
                              * wavesize;
 
-  uint32_t shader_engine_count
-    = agent.os_info ().shader_engine_count / agent.os_info ().xcc_count;
+  auto shader_engine_count = utils::narrow<uint32_t> (
+    agent.os_info ().shader_engine_count / agent.os_info ().xcc_count);
 
   /* The scratch memory is evenly divided between all XCCs, so each XCC has its
      own scratch base.  */

--- a/projects/rocdbgapi/src/memory.h
+++ b/projects/rocdbgapi/src/memory.h
@@ -81,20 +81,20 @@ public:
 
   template <typename U> T operator+ (U increment) const
   {
-    return T{ m_address + increment };
+    return T{ m_address + static_cast<uint64_t> (increment) };
   }
   template <typename U> T operator- (U decrement) const
   {
-    return T{ m_address - decrement };
+    return T{ m_address - static_cast<uint64_t> (decrement) };
   }
   template <typename U> T &operator+= (U increment)
   {
-    m_address += increment;
+    m_address += static_cast<uint64_t> (increment);
     return static_cast<T &> (*this);
   }
   template <typename U> T &operator-= (U decrement)
   {
-    m_address -= decrement;
+    m_address -= static_cast<uint64_t> (decrement);
     return static_cast<T &> (*this);
   }
 };
@@ -127,6 +127,55 @@ public:
 template <> std::string to_string (agent_address_t address);
 template <> std::string to_string (host_address_t address);
 template <> std::string to_string (global_address_t address);
+
+namespace detail
+{
+
+/* Inherit from std::numeric_limits<uint64_t> and only override the
+   functions that return the type T.  */
+template <typename T>
+class numeric_limits_address_t : public std::numeric_limits<uint64_t>
+{
+public:
+  static constexpr bool is_specialized = true;
+
+  static constexpr T min () noexcept
+  {
+    return T (std::numeric_limits<uint64_t>::min ());
+  }
+  static constexpr T max () noexcept
+  {
+    return T (std::numeric_limits<uint64_t>::max ());
+  }
+  static constexpr T lowest () noexcept { return min (); }
+};
+
+} /* namespace amd::dbgapi::detail */
+} /* namespace amd::dbgapi */
+
+/* Specializations of std::numeric_limits for address_t types, using
+   the numeric_limits_address_t helper.  */
+namespace std
+{
+
+#define SPECIALIZE(ADDRESS)                                                   \
+  template <>                                                                 \
+  class numeric_limits<amd::dbgapi::ADDRESS>                                  \
+    : public amd::dbgapi::detail::numeric_limits_address_t<                   \
+        amd::dbgapi::ADDRESS>                                                 \
+  {                                                                           \
+  }
+
+SPECIALIZE (agent_address_t);
+SPECIALIZE (host_address_t);
+SPECIALIZE (global_address_t);
+
+#undef SPECIALIZE
+
+} /* namespace std */
+
+namespace amd::dbgapi
+{
 
 class address_class_t;
 
@@ -536,11 +585,13 @@ public:
   /* Discard all cache lines in the specified range.  If FORCE_DISCARD
      is true, dirty lines are silently dropped.  Otherwise it is an error to
      discarded dirty cache lines.  */
-  void discard (AddressType address = 0, amd_dbgapi_size_t size = -1,
+  void discard (AddressType address = 0,
+                amd_dbgapi_size_t size = amd_dbgapi_size_t (-1),
                 bool force_discard = false);
 
   /* Write dirty lines back to memory.  */
-  void write_back (AddressType address = 0, amd_dbgapi_size_t size = -1);
+  void write_back (AddressType address = 0,
+                   amd_dbgapi_size_t size = amd_dbgapi_size_t (-1));
 
   [[nodiscard]] size_t read_global_memory (AddressType address, void *buffer,
                                            size_t size)

--- a/projects/rocdbgapi/src/os_driver_kfd.cpp
+++ b/projects/rocdbgapi/src/os_driver_kfd.cpp
@@ -344,7 +344,7 @@ kfd_wave_launch_trap_mask (os_wave_launch_trap_mask_t wave_launch_trap)
       case os_wave_launch_trap_mask_t::wave_start:
         return KFD_DBG_TRAP_MASK_TRAP_ON_WAVE_START;
       case os_wave_launch_trap_mask_t::wave_end:
-        return KFD_DBG_TRAP_MASK_TRAP_ON_WAVE_END;
+        return (__u32)KFD_DBG_TRAP_MASK_TRAP_ON_WAVE_END;
       }
 
     dbgapi_assert_not_reached ();
@@ -387,7 +387,7 @@ os_wave_launch_trap_mask (__u32 wave_launch_trap)
     mask |= os_wave_launch_trap_mask_t::address_watch;
   if (!!(wave_launch_trap & KFD_DBG_TRAP_MASK_TRAP_ON_WAVE_START))
     mask |= os_wave_launch_trap_mask_t::wave_start;
-  if (!!(wave_launch_trap & KFD_DBG_TRAP_MASK_TRAP_ON_WAVE_END))
+  if (!!(wave_launch_trap & (__u32)KFD_DBG_TRAP_MASK_TRAP_ON_WAVE_END))
     mask |= os_wave_launch_trap_mask_t::wave_end;
 
   return mask;
@@ -420,7 +420,7 @@ decode_queue_id (__u32 queue_id)
   os_queue_state_t queue_state{};
   if (queue_id & KFD_DBG_QUEUE_ERROR_MASK)
     queue_state |= os_queue_state_t::error;
-  if (queue_id & KFD_DBG_QUEUE_INVALID_MASK)
+  if (queue_id & (__u32)KFD_DBG_QUEUE_INVALID_MASK)
     queue_state |= os_queue_state_t::invalid;
 
   return { queue_id & ~(KFD_DBG_QUEUE_ERROR_MASK | KFD_DBG_QUEUE_INVALID_MASK),
@@ -663,7 +663,7 @@ kfd_driver_base_t::agent_snapshot (
       agent_info.local_address_aperture_limit = entry.lds_limit;
       agent_info.private_address_aperture_base = entry.scratch_base;
       agent_info.private_address_aperture_limit = entry.scratch_limit;
-      agent_info.location_id = entry.location_id;
+      utils::narrow_assign (agent_info.location_id, entry.location_id);
       agent_info.simd_count = entry.simd_count;
       agent_info.max_waves_per_simd = entry.max_waves_per_simd;
       agent_info.vendor_id = entry.vendor_id;
@@ -1219,7 +1219,7 @@ kfd_driver_t::kfd_dbg_trap_ioctl (uint32_t action,
 {
   dbgapi_assert (m_os_pid);
 
-  args->pid = *m_os_pid;
+  utils::narrow_assign (args->pid, *m_os_pid);
   args->op = action;
 
   int ret = kfd_ioctl (AMDKFD_IOC_DBG_TRAP, args);
@@ -1272,7 +1272,7 @@ struct kfd_snapshots
 
     dbgapi_assert (n_ent == entries.size ());
 
-    n_entries = n_ent;
+    utils::narrow_assign (n_entries, n_ent);
     entry_size = sizeof (T);
 
     /* The rest of the code assumes that a T is 64-bit aligned.  */
@@ -1482,7 +1482,7 @@ kfd_driver_t::enable_debug (os_exception_mask_t exceptions_reported,
   args.enable.exception_mask = kfd_exception_mask (exceptions_reported);
   args.enable.rinfo_ptr = reinterpret_cast<uintptr_t> (&os_runtime_info);
   args.enable.rinfo_size = sizeof (kfd_runtime_info);
-  args.enable.dbg_fd = notifier;
+  utils::narrow_assign (args.enable.dbg_fd, notifier);
 
   int err = kfd_dbg_trap_ioctl (KFD_IOC_DBG_TRAP_ENABLE, &args);
   if (err == -ESRCH)
@@ -1566,8 +1566,10 @@ kfd_driver_t::send_exceptions (os_exception_mask_t exceptions,
 
   kfd_ioctl_dbg_trap_args args{};
   args.send_runtime_event.exception_mask = kfd_exception_mask (exceptions);
-  args.send_runtime_event.gpu_id = agent_id.has_value () ? *agent_id : -1;
-  args.send_runtime_event.queue_id = queue_id.has_value () ? *queue_id : -1;
+  args.send_runtime_event.gpu_id
+    = agent_id.has_value () ? *agent_id : os_agent_id_t (-1);
+  args.send_runtime_event.queue_id
+    = queue_id.has_value () ? *queue_id : os_agent_id_t (-1);
 
   int err = kfd_dbg_trap_ioctl (KFD_IOC_DBG_TRAP_SEND_RUNTIME_EVENT, &args);
   if (err == -ESRCH)
@@ -1700,7 +1702,7 @@ kfd_driver_t::suspend_queues (const os_queue_id_t *queues, size_t queue_count,
   else if (ret < 0)
     return AMD_DBGAPI_STATUS_ERROR;
 
-  *suspended_count = ret;
+  utils::narrow_assign (*suspended_count, ret);
   for (size_t i = 0; i < queue_count; i++)
     {
       auto [queue_id, queue_state] = decode_queue_id (kfd_queue_ids[i]);
@@ -1744,7 +1746,7 @@ kfd_driver_t::resume_queues (const os_queue_id_t *queues, size_t queue_count,
   else if (ret < 0)
     return AMD_DBGAPI_STATUS_ERROR;
 
-  *resumed_count = ret;
+  utils::narrow_assign (*resumed_count, ret);
   for (size_t i = 0; i < queue_count; i++)
     {
       auto [queue_id, queue_state] = decode_queue_id (kfd_queue_ids[i]);
@@ -1815,7 +1817,9 @@ kfd_driver_t::set_address_watch (os_agent_id_t os_agent_id,
   kfd_ioctl_dbg_trap_args args{};
   args.set_node_address_watch.address = address;
   args.set_node_address_watch.mode = kfd_watch_mode (os_watch_mode);
-  args.set_node_address_watch.mask = mask;
+  using mask_t = decltype (args.set_node_address_watch.mask);
+  utils::narrow_assign (args.set_node_address_watch.mask,
+                        mask & mask_t (-1));
   args.set_node_address_watch.gpu_id = os_agent_id;
 
   int err
@@ -1945,9 +1949,10 @@ kfd_driver_t::xfer_global_memory_partial (global_address_t address, void *read,
 
   ++(read != nullptr ? m_read_request_count : m_write_request_count);
 
+  auto offset = utils::narrow<off_t> (address);
   ssize_t ret = read != nullptr
-                  ? pread (*m_proc_mem_fd, read, *size, address)
-                  : pwrite (*m_proc_mem_fd, write, *size, address);
+                  ? pread (*m_proc_mem_fd, read, *size, offset)
+                  : pwrite (*m_proc_mem_fd, write, *size, offset);
 
   if (ret < 0 && errno != EIO && errno != EINVAL)
     warning ("kfd_driver_t::xfer_memory failed: %s", strerror (errno));
@@ -1957,9 +1962,10 @@ kfd_driver_t::xfer_global_memory_partial (global_address_t address, void *read,
   else if (ret < 0)
     return AMD_DBGAPI_STATUS_ERROR_MEMORY_ACCESS;
 
-  (read != nullptr ? m_bytes_read : m_bytes_written) += ret;
+  auto uret = static_cast<size_t> (ret);
+  (read != nullptr ? m_bytes_read : m_bytes_written) += uret;
 
-  *size = ret;
+  *size = uret;
   return AMD_DBGAPI_STATUS_SUCCESS;
 }
 

--- a/projects/rocdbgapi/src/os_driver_kmd.cpp
+++ b/projects/rocdbgapi/src/os_driver_kmd.cpp
@@ -283,7 +283,7 @@ kmd_wave_launch_traps_mask (os_wave_launch_trap_mask_t mask)
   if (!!(mask & os_wave_launch_trap_mask_t::wave_start))
     kmd_mask |= 1 << 30;
   if (!!(mask & os_wave_launch_trap_mask_t::wave_end))
-    kmd_mask |= 1 << 31;
+    kmd_mask |= 1u << 31;
 
   return kmd_mask;
 }
@@ -1279,7 +1279,8 @@ kmd_driver_t::send_escape (const kmd::agent_t &agent, KMDDBGRIF_DBGR_CMDS &arg,
   static_assert (sizeof (payload)
                  == sizeof (PROXY_ESCAPE_INFO) + sizeof (KMDDBGRIF_DBGR_CMDS));
 
-  payload.proxy_header.gpuOrdinal = agent.handle.chain_ordinal;
+  utils::narrow_assign (payload.proxy_header.gpuOrdinal,
+                        agent.handle.chain_ordinal);
   payload.proxy_header.privateDataLengthBytes = sizeof (KMDDBGRIF_DBGR_CMDS);
   payload.proxy_header.version = PXDRV_HEADER_VERSION;
   payload.proxy_header.adapterDriverId = AdapterProxyDriver;
@@ -1393,13 +1394,14 @@ kmd_driver_t::agent_snapshot (os_agent_info_t *snapshots,
         return nt_status_to_dbgapi_status (status);
 
       KMDDBGR_DEVICE_INFO &kmd_snap = cmd.Output.getDeviceInfoOut.deviceInfo;
-      os_agent_info.os_agent_id = std::distance (&m_agents.front (), &agent);
+      utils::narrow_assign (os_agent_info.os_agent_id,
+                            std::distance (&m_agents.front (), &agent));
       os_agent_info.gfxip = { kmd_snap.gfxTargetVersion / 10000,
                               (kmd_snap.gfxTargetVersion / 100) % 100,
                               kmd_snap.gfxTargetVersion % 100 };
 
-      os_agent_info.domain = kmd_snap.pciSegment;
-      os_agent_info.location_id = kmd_snap.locationId;
+      utils::narrow_assign (os_agent_info.domain, kmd_snap.pciSegment);
+      utils::narrow_assign (os_agent_info.location_id, kmd_snap.locationId);
 
       os_agent_info.vendor_id = kmd_snap.vendorId;
       os_agent_info.device_id = kmd_snap.deviceId;
@@ -1626,7 +1628,8 @@ kmd_driver_t::query_debug_event (os_exception_mask_t *exceptions_present,
   /* TODO some fairness so we round-robin-ish across all the adapters?  */
   for (const auto &agent : m_agents)
     {
-      os_agent_id_t agent_id = std::distance (&m_agents.front (), &agent);
+      auto distance = std::distance (&m_agents.front (), &agent);
+      auto agent_id = utils::narrow<os_agent_id_t> (distance);
 
       KMDDBGRIF_DBGR_CMDS cmd{};
       cmd.Input.cmd = KMD_DBGR_CMD_OP_GET_EXCEPTIONS;
@@ -1760,7 +1763,8 @@ kmd_driver_t::suspend_queues (const os_queue_id_t *queues, size_t queue_count,
       cmd.Input.suspendQueueIn.exceptionMaskToClear
         = kmd_exception_mask (exceptions_cleared);
       cmd.Input.suspendQueueIn.gracePeriodIn100us = 500;
-      cmd.Input.suspendQueueIn.numQueues = agent_queue_ids.size ();
+      utils::narrow_assign (cmd.Input.suspendQueueIn.numQueues,
+                            agent_queue_ids.size ());
       std::transform (agent_queue_ids.begin (), agent_queue_ids.end (),
                       cmd.Input.suspendQueueIn.queueIds,
                       [this] (auto &&queue_id)
@@ -1811,7 +1815,8 @@ kmd_driver_t::resume_queues (const os_queue_id_t *queues, size_t queue_count,
     {
       KMDDBGRIF_DBGR_CMDS cmd{};
       cmd.Input.cmd = KMD_DBGR_CMD_OP_RESUME_QUEUE;
-      cmd.Input.resumeQueueIn.numQueues = agent_queue_ids.size ();
+      utils::narrow_assign (cmd.Input.resumeQueueIn.numQueues,
+                            agent_queue_ids.size ());
       std::transform (agent_queue_ids.begin (), agent_queue_ids.end (),
                       cmd.Input.resumeQueueIn.queueIds,
                       [this] (auto &&queue_id)
@@ -1965,7 +1970,7 @@ kmd_driver_t::set_address_watch (os_agent_id_t os_agent_id,
 
   /* TODO we should use the number of watchpoints from the agent info snapshot.
    */
-  int id = 0;
+  os_watch_id_t id = 0;
   for (; id < 4; id += 1)
     {
       KMDDBGRIF_DBGR_CMDS cmd{};
@@ -1974,7 +1979,9 @@ kmd_driver_t::set_address_watch (os_agent_id_t os_agent_id,
         = static_cast<KMDDBGRIF_ADDR_WATCH_ID> (id);
       cmd.Input.setAddrWatchIn.mode = kmd_addr_watch_mode (os_watch_mode);
       cmd.Input.setAddrWatchIn.watchAddr = address;
-      cmd.Input.setAddrWatchIn.watchAddrMask = mask;
+      using mask_t = decltype (cmd.Input.setAddrWatchIn.watchAddrMask);
+      utils::narrow_assign (cmd.Input.setAddrWatchIn.watchAddrMask,
+                            mask & mask_t (-1));
 
       NTSTATUS status = send_escape (m_agents[os_agent_id], cmd);
       if (status == STATUS_RESOURCE_IN_USE)
@@ -2254,14 +2261,14 @@ kmd_driver_t::xfer_agent_memory_partial (os_agent_id_t agent_id,
       cmd.Input.cmd = KMD_DBGR_CMD_OP_WRITE_BUFFER;
       cmd.Input.writeBufferIn.srcCpuVA = reinterpret_cast<uint64_t> (write);
       cmd.Input.writeBufferIn.dstGpuVA = static_cast<uint64_t> (address);
-      cmd.Input.writeBufferIn.size = *size;
+      utils::narrow_assign (cmd.Input.writeBufferIn.size, *size);
     }
   else
     {
       cmd.Input.cmd = KMD_DBGR_CMD_OP_READ_BUFFER;
       cmd.Input.readBufferIn.srcGpuVA = static_cast<uint64_t> (address);
       cmd.Input.readBufferIn.dstCpuVA = reinterpret_cast<uint64_t> (read);
-      cmd.Input.readBufferIn.size = *size;
+      utils::narrow_assign (cmd.Input.readBufferIn.size, *size);
     }
 
   const auto &agent = m_agents[agent_id];

--- a/projects/rocdbgapi/src/process.cpp
+++ b/projects/rocdbgapi/src/process.cpp
@@ -1288,7 +1288,8 @@ process_t::update_code_objects ()
           read_host_memory (link_map_address, &entry);
 
           std::string uri;
-          read_string (reinterpret_cast<uintptr_t> (entry.l_name), &uri, -1);
+          read_string (reinterpret_cast<uintptr_t> (entry.l_name), &uri,
+                       size_t (-1));
 
           code_object_t *code_object = nullptr;
           if (auto found = m_code_objects_index.find (entry.l_addr);

--- a/projects/rocdbgapi/src/queue.cpp
+++ b/projects/rocdbgapi/src/queue.cpp
@@ -214,10 +214,13 @@ aql_queue_t::aql_dispatch_t::aql_dispatch_t (
 uint32_t
 aql_queue_t::aql_dispatch_t::grid_dimensions () const
 {
-  return static_cast<uint32_t> (utils::bit_extract (
-    m_packet.setup, HSA_KERNEL_DISPATCH_PACKET_SETUP_DIMENSIONS,
-    HSA_KERNEL_DISPATCH_PACKET_SETUP_DIMENSIONS
-      + HSA_KERNEL_DISPATCH_PACKET_SETUP_WIDTH_DIMENSIONS - 1));
+  /* Arithmetic between different enumeration types.  */
+  auto first = HSA_KERNEL_DISPATCH_PACKET_SETUP_DIMENSIONS;
+  auto last
+    = (utils::narrow<int> (HSA_KERNEL_DISPATCH_PACKET_SETUP_DIMENSIONS)
+       + utils::narrow<int> (HSA_KERNEL_DISPATCH_PACKET_SETUP_WIDTH_DIMENSIONS)
+       - 1);
+  return utils::bit_extract<uint32_t> (m_packet.setup, first, last);
 }
 
 std::array<uint32_t, 3>
@@ -283,8 +286,9 @@ aql_queue_t::aql_dispatch_t::get_info (amd_dbgapi_dispatch_info_t query,
         value_size, value,
         static_cast<amd_dbgapi_dispatch_fence_scope_t> (utils::bit_extract (
           m_packet.header, HSA_PACKET_HEADER_SCACQUIRE_FENCE_SCOPE,
-          HSA_PACKET_HEADER_SCACQUIRE_FENCE_SCOPE
-            + HSA_PACKET_HEADER_WIDTH_SCACQUIRE_FENCE_SCOPE - 1)));
+          (utils::narrow<int> (HSA_PACKET_HEADER_SCACQUIRE_FENCE_SCOPE)
+           + utils::narrow<int> (HSA_PACKET_HEADER_WIDTH_SCACQUIRE_FENCE_SCOPE)
+           - 1))));
       return;
 
     case AMD_DBGAPI_DISPATCH_INFO_RELEASE_FENCE:
@@ -292,8 +296,9 @@ aql_queue_t::aql_dispatch_t::get_info (amd_dbgapi_dispatch_info_t query,
         value_size, value,
         static_cast<amd_dbgapi_dispatch_fence_scope_t> (utils::bit_extract (
           m_packet.header, HSA_PACKET_HEADER_SCRELEASE_FENCE_SCOPE,
-          HSA_PACKET_HEADER_SCRELEASE_FENCE_SCOPE
-            + HSA_PACKET_HEADER_WIDTH_SCRELEASE_FENCE_SCOPE - 1)));
+          (utils::narrow<int> (HSA_PACKET_HEADER_SCRELEASE_FENCE_SCOPE)
+           + utils::narrow<int> (HSA_PACKET_HEADER_WIDTH_SCRELEASE_FENCE_SCOPE)
+           - 1))));
       return;
 
     case AMD_DBGAPI_DISPATCH_INFO_GRID_DIMENSIONS:
@@ -424,11 +429,7 @@ aql_queue_t::allocate_displaced_instruction (const instruction_t &instruction)
 
       /* Ensure that the number of chunks does not overflow the 16 bit index.
        */
-      if (chunk_count > std::numeric_limits<
-            decltype (m_debugger_memory_chunk_count)>::max ())
-        fatal_error ("Increase the width of m_debugger_memory_chunk_count");
-
-      m_debugger_memory_chunk_count = chunk_count;
+      utils::narrow_assign (m_debugger_memory_chunk_count, chunk_count);
 
       m_debugger_memory_free_chunks.reserve (m_debugger_memory_chunk_count);
     }

--- a/projects/rocdbgapi/src/register.cpp
+++ b/projects/rocdbgapi/src/register.cpp
@@ -195,8 +195,10 @@ amdgpu_regnum_to_dwarf_register (amdgpu_regnum_t regnum)
 }
 
 std::optional<amdgpu_regnum_t>
-dwarf_register_to_amdgpu_regnum (uint64_t dwarf_register)
+dwarf_register_to_amdgpu_regnum (uint64_t dwarf_register_)
 {
+  auto dwarf_register = utils::narrow<int> (dwarf_register_);
+
   /* See https://llvm.org/docs/AMDGPUUsage.html#register-mapping.  */
   if (dwarf_register == 1)
     {

--- a/projects/rocdbgapi/src/register.h
+++ b/projects/rocdbgapi/src/register.h
@@ -182,29 +182,40 @@ enum class amdgpu_regnum_t : uint32_t
   last_regnum = last_pseudo
 };
 
-constexpr size_t
+/* Distance between two amdgpu_regnum_t.  A difference between two
+   enumerators is not an enumerator, it's the distance between them.
+   This is signed following the std::distance /
+   iterator_traits<It>::difference_type / ptrdiff_t model: distance
+   can be negative if rhs > lhs.  */
+using amdgpu_regdiff_t
+  = std::make_signed_t<std::underlying_type_t<amdgpu_regnum_t>>;
+
+constexpr amdgpu_regdiff_t
 operator- (amdgpu_regnum_t lhs, amdgpu_regnum_t rhs)
 {
-  return static_cast<std::underlying_type_t<decltype (lhs)>> (lhs)
-         - static_cast<std::underlying_type_t<decltype (rhs)>> (rhs);
+  using u = std::underlying_type_t<decltype (lhs)>;
+  /* Use static_cast, not utils::narrow, so 'u(0) - u(1) = u(-1)'
+     becomes -1 instead of an error.  */
+  return static_cast<amdgpu_regdiff_t> (static_cast<u> (lhs)
+                                        - static_cast<u> (rhs));
 }
 
 constexpr amdgpu_regnum_t
-operator+ (amdgpu_regnum_t lhs, int rhs)
+operator+ (amdgpu_regnum_t lhs, amdgpu_regdiff_t rhs)
 {
-  return static_cast<amdgpu_regnum_t> (
-    static_cast<std::underlying_type_t<decltype (lhs)>> (lhs) + rhs);
+  return static_cast<amdgpu_regnum_t> (static_cast<amdgpu_regdiff_t> (lhs)
+                                       + rhs);
 }
 
 constexpr amdgpu_regnum_t
-operator- (amdgpu_regnum_t lhs, int rhs)
+operator- (amdgpu_regnum_t lhs, amdgpu_regdiff_t rhs)
 {
-  return static_cast<amdgpu_regnum_t> (
-    static_cast<std::underlying_type_t<decltype (lhs)>> (lhs) - rhs);
+  return static_cast<amdgpu_regnum_t> (static_cast<amdgpu_regdiff_t> (lhs)
+                                       - rhs);
 }
 
 constexpr std::underlying_type_t<amdgpu_regnum_t>
-operator& (amdgpu_regnum_t lhs, int rhs)
+operator& (amdgpu_regnum_t lhs, std::underlying_type_t<amdgpu_regnum_t> rhs)
 {
   return static_cast<std::underlying_type_t<decltype (lhs)>> (lhs) & rhs;
 }

--- a/projects/rocdbgapi/src/utils.cpp
+++ b/projects/rocdbgapi/src/utils.cpp
@@ -231,7 +231,7 @@ string_vprintf (const char *format, va_list va)
 
   dbgapi_assert (size >= 0);
 
-  std::string str (size, '\0');
+  std::string str (static_cast<size_t> (size), '\0');
   vsnprintf (&str[0], str.size () + 1, format, va);
   return str;
 }

--- a/projects/rocdbgapi/src/utils.h
+++ b/projects/rocdbgapi/src/utils.h
@@ -33,6 +33,7 @@
 #include <exception>
 #include <functional>
 #include <iterator>
+#include <limits>
 #include <memory>
 #include <optional>
 #include <string>
@@ -93,16 +94,78 @@ namespace utils
 /* Get the filename containing dbgapi's code.  */
 const char *get_self_name ();
 
+/* An explicit, checked, narrowing conversion.  Throws a fatal error
+   if the conversion would lose information.  */
+
+template <typename To, typename From>
+constexpr To
+narrow (From from)
+{
+  using ToLimits = std::numeric_limits<To>;
+  using FromLimits = std::numeric_limits<From>;
+
+  /* Check for negative values when converting to an unsigned
+     type.  */
+  if constexpr (std::is_unsigned_v<To> && std::is_signed_v<From>)
+    {
+      if (from < 0)
+        fatal_error ("narrowing error: negative value to unsigned");
+    }
+
+  /* For signed to signed, check for values smaller than the
+     destination can hold.  */
+  if constexpr (std::is_signed_v<To> && std::is_signed_v<From>)
+    {
+      if (from < ToLimits::min ())
+        fatal_error ("narrowing error: underflow");
+    }
+
+  /* Check for values larger than the destination can hold.  We cast
+     to From to ensure the comparison is performed in the
+     wider/original domain.  */
+  if constexpr (static_cast<std::uintmax_t> (FromLimits::max ())
+                > static_cast<std::uintmax_t> (ToLimits::max ()))
+    {
+      if (from > static_cast<From> (ToLimits::max ()))
+        fatal_error ("narrowing error: overflow");
+    }
+
+  return static_cast<To> (from);
+}
+
+/* Like narrow, but takes the destination as argument.  Useful for
+   assignments, to avoid spelling out the destination's type.  */
+
+template <typename To, typename From>
+void
+narrow_assign (To &to, From from)
+{
+  to = narrow<To> (from);
+}
+
 template <typename Integral = uint64_t>
 constexpr Integral
 bit_mask (int first, int last)
 {
   dbgapi_assert (last >= first && "invalid argument");
-  size_t num_bits = last - first + 1;
-  return ((num_bits >= sizeof (Integral) * 8)
-            ? ~Integral{ 0 } /* num_bits exceed the size of Integral */
-            : ((Integral{ 1 } << num_bits) - 1))
-         << first;
+  auto num_bits = static_cast<size_t> (last - first + 1);
+  auto mask = (((num_bits >= sizeof (Integral) * 8)
+                  ? ~Integral{ 0 } /* num_bits exceed the size of Integral */
+                  : ((Integral{ 1 } << num_bits) - 1))
+               << first);
+  /* If Integral is narrower than int, mask is now int.  Do an
+     explicit cast to avoid -Wconversion warnings.  */
+  return static_cast<Integral> (mask);
+}
+
+template <typename Integral = uint64_t, typename First,
+          typename Last>
+constexpr Integral
+bit_mask (First first, Last last)
+{
+  /* Defer to the int, int overload, with narrow checking.  */
+  return bit_mask<Integral> (narrow<int> (first),
+                             narrow<int> (last));
 }
 
 template <typename Integral>
@@ -118,7 +181,18 @@ bit_count (Integral x)
   x = x - ((x >> 1) & ~T{ 0 } / 3);
   x = (x & ~T{ 0 } / 15 * 3) + ((x >> 2) & ~T{ 0 } / 15 * 3);
   x = (x + (x >> 4)) & ~T{ 0 } / 255 * 15;
-  return (x * (~T{ 0 } / 255)) >> (sizeof (T) - 1) * 8;
+  auto count = (x * (~T{ 0 } / 255)) >> (sizeof (T) - 1) * 8;
+  return static_cast<int> (count);
+}
+
+/* Split an unsigned 64-bit value into a pair of unsigned 32-bit
+   values.  */
+inline std::pair<uint32_t, uint32_t>
+split (uint64_t val)
+{
+  auto lo = static_cast<uint32_t> (val);
+  auto hi = static_cast<uint32_t> (val >> 32);
+  return { lo, hi };
 }
 
 template <typename Integral>
@@ -163,27 +237,33 @@ trailing_zeroes_count<unsigned int> (unsigned int x)
 }
 #endif
 
-template <typename Integral>
-constexpr std::make_unsigned_t<Integral>
-zero_extend (Integral x, int width)
+template <typename Val, typename Width>
+constexpr auto
+zero_extend (Val x, Width width)
 {
-  return x & bit_mask (0, width - 1);
+  using UVal = std::make_unsigned_t<Val>;
+  return static_cast<UVal> (x) & bit_mask (0, width - 1);
 }
 
-template <typename Integral>
-constexpr std::make_signed_t<Integral>
-sign_extend (Integral x, int width)
+template <typename Val, typename Width>
+constexpr std::make_signed_t<Val>
+sign_extend (Val x, Width width)
 {
-  Integral sign_mask = bit_mask (width - 1, sizeof (Integral) * 8 - 1);
+  Val sign_mask = bit_mask (width - 1, sizeof (Val) * 8 - 1);
   return (zero_extend (x, width) ^ sign_mask) - sign_mask;
 }
 
-/* Extract bits [last:first] from t.  */
-template <typename Integral>
-constexpr Integral
-bit_extract (Integral x, int first, int last)
+/* Extract bits [last:first] from X.  */
+template <typename Res = void, typename From>
+constexpr auto
+bit_extract (From x, int first, int last)
 {
-  return (x >> first) & bit_mask<Integral> (0, last - first);
+  /* If Res is void, we use the type of From. If Res is specified, we
+     use that.  */
+  using ActualRes = std::conditional_t<std::is_void_v<Res>, From, Res>;
+
+  return static_cast<ActualRes> ((x >> first)
+                                 & bit_mask<From> (0, last - first));
 }
 
 template <typename Integral>
@@ -216,25 +296,27 @@ next_power_of_two (Integral x)
   return ++v;
 }
 
-template <typename Integral>
+template <typename Integral, typename Align>
 constexpr Integral
-align_down (Integral x, int alignment)
+align_down (Integral x, Align alignment)
 {
   dbgapi_assert (is_power_of_two (alignment));
-  return x & -alignment;
+  auto align = narrow<Integral> (alignment);
+  return x & -align;
 }
 
-template <typename Integral>
+template <typename Integral, typename Align>
 constexpr Integral
-align_up (Integral x, int alignment)
+align_up (Integral x, Align alignment)
 {
   dbgapi_assert (is_power_of_two (alignment));
-  return (x + alignment - 1) & -alignment;
+  auto align = narrow<Integral> (alignment);
+  return (x + align - 1) & -align;
 }
 
-template <typename Integral>
+template <typename Integral, typename Align>
 constexpr bool
-is_aligned (Integral x, int alignment)
+is_aligned (Integral x, Align alignment)
 {
   dbgapi_assert (is_power_of_two (alignment));
   return x == align_down (x, alignment);

--- a/projects/rocdbgapi/src/utils_linux.cpp
+++ b/projects/rocdbgapi/src/utils_linux.cpp
@@ -120,7 +120,7 @@ pipe_t::close ()
 int
 pipe_t::flush ()
 {
-  int ret;
+  ssize_t ret;
 
   do
     {
@@ -138,7 +138,7 @@ pipe_t::flush ()
 int
 pipe_t::mark ()
 {
-  int ret;
+  ssize_t ret;
 
   /* First, flush the pipe.  */
   flush ();

--- a/projects/rocdbgapi/src/utils_windows.cpp
+++ b/projects/rocdbgapi/src/utils_windows.cpp
@@ -41,7 +41,7 @@ convert_to_string (std::wstring_view ws)
   if (size_needed <= 0)
     return {};
 
-  std::string result (size_needed, '\0');
+  std::string result (static_cast<size_t> (size_needed), '\0');
 
   [[maybe_unused]] int size
     = ::WideCharToMultiByte (CP_ACP, 0, ws.data (), (int)ws.size (),


### PR DESCRIPTION
I tried to compile dbgapi with MSVC, and by default, MSVC issues a
large number of warnings around conversions, like:

D:\therock\src\rocm-systems\projects\rocdbgapi\src\memory.h(191): warning C4244: 'argument': conversion from 'amd_dbgapi_size_t' to 'int', possible loss of data
D:\therock\src\rocm-systems\projects\rocdbgapi\src\architecture.cpp(129): warning C4244: 'initializing': conversion from 'Integral' to 'const uint32_t', possible loss of data

... and many more.

I think that it's actually good to warn/error on implicit narrowing
conversions, which indeed can lose data unintentially.  Particularly
so since our codebase does a lot of bit manipulation.

So I went ahead and fixed all of the warning MSVC threw.  More
specifically, all warnings under /wd4244 and /wd4267:

# warning C4244: '=': conversion from '...' to '...', possible loss of data
# warning C4267: '=': conversion from '...' to '...', possible loss of data

I then went back to GCC, added -Wconversion, which warns for the same
things more or less, and fixed the remaining warnings, both on Linux
and mingw.

Then I did the same with Clang, both Linux and Windows.

This patch is the result.

Notes:

Instead of just static_cast, I added a new utils::narrow template function:

template <typename To, typename From> To narrow (From from);

This is a safer version than static_cast -- it checks if we'd lose
data, before doing a static_cast.

The typical style is to use it like so when initializing a new
variable:

auto foo = utils::narrow<uint32_t> (wider_type_value);

When assigning to a pre-existing variable, to avoid having to type the
type of the lhs variable, we have:

template <typename To, typename From> void narrow_assign (To &to, From from);

Used like so:

utils::narrow_assign (dest, src);

utils::narrow depends on std::numeric_limits to do its checking, and
because utils::narrow is passed {agent,global,host}_address_t, we need
to specialize std::numeric_limits for those types.

I added a new utils::split function that makes it convenient to split
a 64-bit value in two 32-bit parts, like so:

auto [lo32, hi32] = utils::split (val64);

Many utils.h template functions hardcode parameters as int type.  I
made them template parameters too, which avoids having to cast at the
caller site.

bit_extract is tweaked to allow different source type and return type.

The following operators currently take an int as rhs, as that is a
distance type:

constexpr amdgpu_regnum_t operator+ (amdgpu_regnum_t lhs, int rhs);
constexpr amdgpu_regnum_t operator- (amdgpu_regnum_t lhs, int rhs);

Replace the "int" with a new amdgpu_regdiff_t typedef instead (which
is the signed counterpart of the underlying type of amdgpu_regnum_t
(which is uint32_t), which in practice means it's int32_t, so no real
type change.

However, the "operator-(amdgpu_regnum_t lhs, amdgpu_regnum_t rhs)"
function now returns amdgpu_regdiff_t, a signed integer, instead of
size_t, so that the result can naturally be passed directly as rhs to:

constexpr amdgpu_regnum_t operator+ (amdgpu_regnum_t lhs, amdgpu_regdiff_t rhs);
constexpr amdgpu_regnum_t operator- (amdgpu_regnum_t lhs, amdgpu_regdiff_t rhs);

Some local variables in architecture.cpp have amdgpu_regdiff_t though
at first look you'd think they should be size_t.  That's because if
you look closer to the code that actually uses them, you'll notice
that those variables exist only to be used as distances/offsets from
another register.

That's it.  Most of the patch is then passing explicit type to
utils::bit_mask, and utils::bit_extract, and using utils::narrow and
utils::narrow_assign.

Change-Id: I08d0f66ae3ad8dfe48ce3af710ad838de8a27a4c

---

**Stack**:
- #4316
- #4315
- #4314
- #4313
- #4312
- #4311
- #4310
- #4309
- #4308
- #4307
- #4306 ⬅
- #4305
- #4304
- #4303
- #4302
- #4301
- #4300
- #4299


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*