### PR TITLE
[msvc 10/18] dbgapi/msvc: Fix __has_builtin

### DIFF
--- a/projects/rocdbgapi/src/utils.h
+++ b/projects/rocdbgapi/src/utils.h
@@ -210,7 +210,8 @@ trailing_zeroes_count (Integral x)
   return bit_count (v);
 }
 
-#if defined __has_builtin && __has_builtin(__builtin_ctzll)
+#if defined(__has_builtin)
+#if __has_builtin(__builtin_ctzll)
 template <>
 constexpr int
 trailing_zeroes_count<unsigned long long> (unsigned long long x)
@@ -219,7 +220,7 @@ trailing_zeroes_count<unsigned long long> (unsigned long long x)
 }
 #endif
 
-#if defined __has_builtin && __has_builtin(__builtin_ctzl)
+#if __has_builtin(__builtin_ctzl)
 template <>
 constexpr int
 trailing_zeroes_count<unsigned long> (unsigned long x)
@@ -228,7 +229,7 @@ trailing_zeroes_count<unsigned long> (unsigned long x)
 }
 #endif
 
-#if defined __has_builtin && __has_builtin(__builtin_ctz)
+#if __has_builtin(__builtin_ctz)
 template <>
 constexpr int
 trailing_zeroes_count<unsigned int> (unsigned int x)
@@ -236,6 +237,7 @@ trailing_zeroes_count<unsigned int> (unsigned int x)
   return __builtin_ctz (x);
 }
 #endif
+#endif /* defined(__has_builtin) */
 
 template <typename Val, typename Width>
 constexpr auto


### PR DESCRIPTION
Compiling dbgapi with MSVC 2022 results in:

[1/25] Building CXX object CMakeFiles\amd-dbgapi.dir\src\debug.cpp.obj
D:\therock\src\rocm-systems\projects\rocdbgapi\src\utils.h(139): warning C4067: unexpected tokens following preprocessor directive - expected a newline
D:\therock\src\rocm-systems\projects\rocdbgapi\src\utils.h(148): warning C4067: unexpected tokens following preprocessor directive - expected a newline
D:\therock\src\rocm-systems\projects\rocdbgapi\src\utils.h(157): warning C4067: unexpected tokens following preprocessor directive - expected a newline
... many more of the same ...

This patch fixes it.

Change-Id: I659df294e9ba39f3568125948fd7341f520dfd20

---

**Stack**:
- #4316
- #4315
- #4314
- #4313
- #4312
- #4311
- #4310
- #4309
- #4308 ⬅
- #4307
- #4306
- #4305
- #4304
- #4303
- #4302
- #4301
- #4300
- #4299


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*