### PR TITLE
[msvc 11/18] dbgapi/msvc: NOMINMAX

### DIFF
--- a/projects/rocdbgapi/src/os_driver_kmd.cpp
+++ b/projects/rocdbgapi/src/os_driver_kmd.cpp
@@ -23,6 +23,12 @@
 #include "os_driver.h"
 #include "utils_windows.h"
 
+/* Make sure windows.h doesn't define min/max, which conflicts with
+   our use of std::min.  */
+#ifndef NOMINMAX
+#define NOMINMAX
+#endif
+
 /* Make sure we use the STATUS_XXX constants from ntstatus.h.  Some of
    the constants we use (but not all) are defined in winnt.h too, but
    defined as DWORD (aka 'unsigned long'), while ntstatus.h defines


### PR DESCRIPTION
When compiling dbgapi standalone (i.e., outside TheRock) with MSVC, we
get this build error:

D:\therock\src\rocm-systems\projects\rocdbgapi\src\os_driver_kmd.cpp(1310): error C2589: '(': illegal token on right side of '::'
D:\therock\src\rocm-systems\projects\rocdbgapi\src\os_driver_kmd.cpp(1310): error C3878: syntax error: unexpected token '(' following 'expression'
D:\therock\src\rocm-systems\projects\rocdbgapi\src\os_driver_kmd.cpp(1310): error C2760: syntax error: ')' was unexpected here; expected ';'
D:\therock\src\rocm-systems\projects\rocdbgapi\src\os_driver_kmd.cpp(1310): error C3878: syntax error: unexpected token ')' following 'expression-statement'
D:\therock\src\rocm-systems\projects\rocdbgapi\src\os_driver_kmd.cpp(1310): error C2760: syntax error: ':' was unexpected here; expected ';'
D:\therock\src\rocm-systems\projects\rocdbgapi\src\os_driver_kmd.cpp(1310): error C3878: syntax error: unexpected token ':' following 'expression-statement'
D:\therock\src\rocm-systems\projects\rocdbgapi\src\os_driver_kmd.cpp(1384): error C2059: syntax error: ')'
D:\therock\src\rocm-systems\projects\rocdbgapi\src\os_driver_kmd.cpp(1384): error C2589: '(': illegal token on right side of '::'
D:\therock\src\rocm-systems\projects\rocdbgapi\src\os_driver_kmd.cpp(1384): error C2672: 'amd::dbgapi::tracer<AMD_DBGAPI_LOG_LEVEL_VERBOSE>::leave': no matching overloaded function found

The problem is that windows.h defines min/max macros, which conflict
with os_driver_kmd.cpp's use of std::min.

Fix this by defining NOMINMAX before including windows.h.

We hadn't seen the need for this before, because:

- MinGW always defines NOMINMAX.

- When compiling under TheRock with clang/msvc, TheRock defines
-DNOMINMAX on the command line.

Change-Id: If0b2bc4a77b3894628ed309501fe813235a372be

---

**Stack**:
- #4316
- #4315
- #4314
- #4313
- #4312
- #4311
- #4310
- #4309 ⬅
- #4308
- #4307
- #4306
- #4305
- #4304
- #4303
- #4302
- #4301
- #4300
- #4299


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*