### PR TITLE
[msvc 12/18] dbgapi/msvc: Fix << shift

### DIFF
--- a/projects/rocdbgapi/src/os_driver_kmd.cpp
+++ b/projects/rocdbgapi/src/os_driver_kmd.cpp
@@ -1434,9 +1434,9 @@ kmd_driver_t::agent_snapshot (os_agent_info_t *snapshots,
       os_agent_info.address_watch_supported
         = kmd_snap.capability & KMD_DBGR_CAP_WATCH_POINTS_SUPPORTED;
       os_agent_info.address_watch_register_count
-        = 1 << ((kmd_snap.capability
-                 & KMD_DBGR_CAP_WATCH_POINTS_TOTALBITS_MASK)
-                >> KMD_DBGR_CAP_WATCH_POINTS_TOTALBITS_SHIFT);
+        = size_t (1) << ((kmd_snap.capability
+                          & KMD_DBGR_CAP_WATCH_POINTS_TOTALBITS_MASK)
+                         >> KMD_DBGR_CAP_WATCH_POINTS_TOTALBITS_SHIFT);
       os_agent_info.precise_memory_supported
         = kmd_snap.capability
           & KMD_DBGR_CAP_TRAP_DEBUG_PRECISE_MEMORY_OPERATIONS_SUPPORTED;


### PR DESCRIPTION
Fixes:

[23/25] Building CXX object CMakeFiles\amd-dbgapi.dir\src\os_driver_kmd.cpp.obj
D:\therock\src\rocm-systems\projects\rocdbgapi\src\os_driver_kmd.cpp(1370): warning C4334: '<<': result of 32-bit shift implicitly converted to 64 bits (was 64-bit shift intended?)

Change-Id: I36c1cce9fe749bafc20cc23b6b14f5c062080c91

---

**Stack**:
- #4316
- #4315
- #4314
- #4313
- #4312
- #4311
- #4310 ⬅
- #4309
- #4308
- #4307
- #4306
- #4305
- #4304
- #4303
- #4302
- #4301
- #4300
- #4299


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*