### PR TITLE
[msvc 13/18] dbgapi/msvc: Fix build error with missing typename

### DIFF
--- a/projects/rocdbgapi/src/architecture.cpp
+++ b/projects/rocdbgapi/src/architecture.cpp
@@ -7980,7 +7980,7 @@ amd_dbgapi_classify_instruction (
 
     if (instruction_information_p != nullptr)
       {
-        using information_type = decltype (information)::value_type;
+        using information_type = typename decltype (information)::value_type;
         size_t mem_size = information.size () * sizeof (information_type);
 
         if (!mem_size)


### PR DESCRIPTION
MSVC currently shows this build error:

D:\therock\src\rocm-systems\projects\rocdbgapi\src\architecture.cpp(7940): error C7510: 'value_type': use of dependent type name must be prefixed with 'typename'
... followed by cascading build errors...

Fix it by adding "typename".

Change-Id: Idb1743c43e70c63416a76acc9590765113ffa0eb

---

**Stack**:
- #4316
- #4315
- #4314
- #4313
- #4312
- #4311 ⬅
- #4310
- #4309
- #4308
- #4307
- #4306
- #4305
- #4304
- #4303
- #4302
- #4301
- #4300
- #4299


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*