### PR TITLE
[msvc 14/18] dbgapi/msvc: case labels and initialization

### DIFF
--- a/projects/rocdbgapi/src/architecture.cpp
+++ b/projects/rocdbgapi/src/architecture.cpp
@@ -4131,26 +4131,32 @@ gfx9_4_architecture_t::register_read_only_mask (amdgpu_regnum_t regnum) const
   switch (regnum)
     {
     case amdgpu_regnum_t::trapsts:
-      static uint32_t trapsts_read_only_bits
-        = (utils::bit_mask<uint32_t> (9, 9)       /* 0 */
-           | utils::bit_mask<uint32_t> (15, 15)   /* 0 */
-           | utils::bit_mask<uint32_t> (27, 27)); /* 0 */
-      return &trapsts_read_only_bits;
+      {
+        static uint32_t trapsts_read_only_bits
+          = (utils::bit_mask<uint32_t> (9, 9)       /* 0 */
+             | utils::bit_mask<uint32_t> (15, 15)   /* 0 */
+             | utils::bit_mask<uint32_t> (27, 27)); /* 0 */
+        return &trapsts_read_only_bits;
+      }
 
     case amdgpu_regnum_t::mode:
-      static uint32_t mode_read_only_bits
-        = utils::bit_mask<uint32_t> (22, 22); /* 0 */
-      return &mode_read_only_bits;
+      {
+        static uint32_t mode_read_only_bits
+          = utils::bit_mask<uint32_t> (22, 22); /* 0 */
+        return &mode_read_only_bits;
+      }
 
     case amdgpu_regnum_t::pseudo_status:
-      static uint32_t status_read_only_bits
-        = (utils::bit_mask<uint32_t> (5, 7)       /* priv, trap_en, ttrace_en */
-           | utils::bit_mask<uint32_t> (9, 12)    /* execz, vccz, in_tg, in_barrier */
-           | utils::bit_mask<uint32_t> (14, 16)   /* trap, ttrace_cu_en, valid */
-           | utils::bit_mask<uint32_t> (18, 19)   /* skip_export, perf_en */
-           | utils::bit_mask<uint32_t> (22, 26)   /* allow_replay, fatal_halt, 0 */
-           | utils::bit_mask<uint32_t> (29, 30)); /* 0 */
-      return &status_read_only_bits;
+      {
+        static uint32_t status_read_only_bits
+          = (utils::bit_mask<uint32_t> (5, 7)       /* priv, trap_en, ttrace_en */
+             | utils::bit_mask<uint32_t> (9, 12)    /* execz, vccz, in_tg, in_barrier */
+             | utils::bit_mask<uint32_t> (14, 16)   /* trap, ttrace_cu_en, valid */
+             | utils::bit_mask<uint32_t> (18, 19)   /* skip_export, perf_en */
+             | utils::bit_mask<uint32_t> (22, 26)   /* allow_replay, fatal_halt, 0 */
+             | utils::bit_mask<uint32_t> (29, 30)); /* 0 */
+        return &status_read_only_bits;
+      }
 
     default:
       return gfx90a_t::register_read_only_mask (regnum);


### PR DESCRIPTION
MSVC gives the following warnings:

D: \therock\src\rocm-systems\projects\rocdbgapi\src\architecture.cpp(4116): error C2360: initialization of 'trapsts_read_only_bits' is skipped by 'case' label
D: \therock\src\rocm-systems\projects\rocdbgapi\src\architecture.cpp(4111): note: see declaration of 'trapsts_read_only_bits'
D: \therock\src\rocm-systems\projects\rocdbgapi\src\architecture.cpp(4120): error C2360: initialization of 'mode_read_only_bits' is skipped by 'case' label
D: \therock\src\rocm-systems\projects\rocdbgapi\src\architecture.cpp(4117): note: see declaration of 'mode_read_only_bits'
D: \therock\src\rocm-systems\projects\rocdbgapi\src\architecture.cpp(4120): error C2360: initialization of 'trapsts_read_only_bits' is skipped by 'case' label
D: \therock\src\rocm-systems\projects\rocdbgapi\src\architecture.cpp(4111): note: see declaration of 'trapsts_read_only_bits'
D: \therock\src\rocm-systems\projects\rocdbgapi\src\architecture.cpp(4130): error C2361: initialization of 'status_read_only_bits' is skipped by 'default' label
D: \therock\src\rocm-systems\projects\rocdbgapi\src\architecture.cpp(4121): note: see declaration of 'status_read_only_bits'
D: \therock\src\rocm-systems\projects\rocdbgapi\src\architecture.cpp(4130): error C2361: initialization of 'mode_read_only_bits' is skipped by 'default' label
D: \therock\src\rocm-systems\projects\rocdbgapi\src\architecture.cpp(4117): note: see declaration of 'mode_read_only_bits'
D: \therock\src\rocm-systems\projects\rocdbgapi\src\architecture.cpp(4130): error C2361: initialization of 'trapsts_read_only_bits' is skipped by 'default' label
D: \therock\src\rocm-systems\projects\rocdbgapi\src\architecture.cpp(4111): note: see declaration of 'trapsts_read_only_bits'

Fix that by adding a scope for the case labels that declare variables.

Change-Id: I744eb9d140839ab277a4a24ec70d9ed991d86d56

---

**Stack**:
- #4316
- #4315
- #4314
- #4313
- #4312 ⬅
- #4311
- #4310
- #4309
- #4308
- #4307
- #4306
- #4305
- #4304
- #4303
- #4302
- #4301
- #4300
- #4299


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*