### PR TITLE
[msvc 15/18] dbgapi/msvc: __cplusplus

### DIFF
--- a/projects/rocdbgapi/include/amd-dbgapi.h.in
+++ b/projects/rocdbgapi/include/amd-dbgapi.h.in
@@ -518,7 +518,20 @@
 #endif /* !defined (AMD_DBGAPI_EXPORTS) */
 #endif /* !defined (AMD_DBGAPI) */
 
-#if __cplusplus >= 201103L
+/* By default, MSVC reports 199711L (C++98) for the __cplusplus macro,
+   regardless of the actual language version you are using (like C++17
+   or C++20).  Instead, we need to look at _MSVC_LANG, which correctly
+   reports the C++ standard version being targeted by the
+   compiler.  */
+#if defined(__cplusplus)
+# if defined(_MSVC_LANG)
+#  define AMD_DBGAPI_CPLUSPLUS _MSVC_LANG
+# else
+#  define AMD_DBGAPI_CPLUSPLUS __cplusplus
+# endif
+#endif
+
+#if defined(__cplusplus) && AMD_DBGAPI_CPLUSPLUS >= 201103L
 /* c++11 allows extended initializer lists.  */
 #define AMD_DBGAPI_HANDLE_LITERAL(type, value) (type{ value })
 #elif __STDC_VERSION__ >= 199901L
@@ -528,7 +541,7 @@
 #define AMD_DBGAPI_HANDLE_LITERAL(type, value) {value}
 #endif /* !__STDC_VERSION__ >= 199901L */
 
-#if defined(__cplusplus) && __cplusplus >= 201402L
+#if defined(__cplusplus) && AMD_DBGAPI_CPLUSPLUS >= 201402L
 #define DEPRECATED [[deprecated]]
 #else
 #define DEPRECATED


### PR DESCRIPTION
MSVC currently shows this build error:

D:\therock\src\rocm-systems\projects\rocdbgapi\src\memory.h(146): error C2059: syntax error: '{'
D:\therock\src\rocm-systems\projects\rocdbgapi\src\memory.h(146): error C2334: unexpected token(s) preceding '{'; skipping apparent function body
D:\therock\src\rocm-systems\projects\rocdbgapi\src\memory.h(146): error C2059: syntax error: '.'
D:\therock\src\rocm-systems\projects\rocdbgapi\src\memory.h(149): error C2143: syntax error: missing ';' before '}'
D:\therock\src\rocm-systems\projects\rocdbgapi\src\memory.h(149): error C2238: unexpected token(s) preceding ';'
...

The problem is MSVC and __cplusplus.  By default, MSVC has a bit of a
historical quirk: it reports 199711L (C++98) for the __cplusplus
macro, regardless of the actual language version you are using (like
C++17 or C++20).

As far I understood, Microsoft did this to avoid breaking legacy code
that relied on the old behavior, but it creates a headache for modern
cross-platform development.

To solve this, we have two options:

1) _MSVC_LANG

This is a Microsoft-specific macro that correctly reports the C++
standard version currently being targeted by the compiler.

2) /Zc:__cplusplus

MSVC can be told to report the correct value for __cplusplus if you
pass the compiler flag /Zc:__cplusplus.

Approach #2 does not work for us here, since we need this in
amd-dbgapi.h.in, and we can't always guarantee that every user of
dbgapi will have that flag enabled in their build system.

So this patch fixes it using approach #1.

Change-Id: Icb7ca9176fe8b4d8c6e19903c7c05ca724e26945

---

**Stack**:
- #4316
- #4315
- #4314
- #4313 ⬅
- #4312
- #4311
- #4310
- #4309
- #4308
- #4307
- #4306
- #4305
- #4304
- #4303
- #4302
- #4301
- #4300
- #4299


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*