### PR TITLE
[msvc 16/18] dbgapi/msvc: dbgapi_assert_not_reached

### DIFF
--- a/projects/rocdbgapi/src/debug.h
+++ b/projects/rocdbgapi/src/debug.h
@@ -31,7 +31,13 @@
 #if defined(NDEBUG)
 
 #define dbgapi_assert(expr) ((void)0)
-#define dbgapi_assert_not_reached(message) __builtin_trap ()
+
+#if defined(_MSC_VER)
+# define dbgapi_assert_not_reached(message) \
+  do { __debugbreak (); abort (); } while (0)
+#else
+# define dbgapi_assert_not_reached(message) __builtin_trap ()
+#endif /* defined (_MSC_VER) */
 
 #else /* !defined (NDEBUG) */
 


### PR DESCRIPTION
MSVC does not have __builtin_trap, resulting in:

D:\therock\src\rocm-systems\projects\rocdbgapi\src\queue.h(187): error C3861: '__builtin_trap': identifier not found

... and many more of the same.

Reimplement dbgapi_assert_not_reached using __debugbreak + abort.  Add
the abort to match better the semantics of __builtin_trap, which is
noreturn.  I.e., to avoid someone catching the __debugbreak in a
debugger and then continuing after the trap.

Change-Id: Ic3e0fa5dfd686150a7b9f61564371e521e28d095

---

**Stack**:
- #4316
- #4315
- #4314 ⬅
- #4313
- #4312
- #4311
- #4310
- #4309
- #4308
- #4307
- #4306
- #4305
- #4304
- #4303
- #4302
- #4301
- #4300
- #4299


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*