### PR TITLE
[msvc 17/18] dbgapi/msvc: Fix warning C4101: 'e': unreferenced local variable

### DIFF
--- a/projects/rocdbgapi/src/memory.cpp
+++ b/projects/rocdbgapi/src/memory.cpp
@@ -713,7 +713,7 @@ memory_cache_t<AddressType>::write_back (AddressType address,
         {
           /* The process has exited, simply discard the dirty cached bytes.  */
         }
-      catch (const memory_error_t &e)
+      catch (const memory_error_t &)
         {
           /* If we see memory errors, continue to try to write back all dirty
              lines.  The first exception seen will be rethrown at the end of


### PR DESCRIPTION
Building dbgapi with MSVC currently shows this warning:

[19/25] Building CXX object CMakeFiles\amd-dbgapi.dir\src\memory.cpp.obj
D:\therock\src\rocm-systems\projects\rocdbgapi\src\memory.cpp(706): warning C4101: 'e': unreferenced local variable
...

Fix it by simply removing 'e'.

Change-Id: I0de043824b61ed1674b29d314267a030261f0bca

---

**Stack**:
- #4316
- #4315 ⬅
- #4314
- #4313
- #4312
- #4311
- #4310
- #4309
- #4308
- #4307
- #4306
- #4305
- #4304
- #4303
- #4302
- #4301
- #4300
- #4299


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*