### PR TITLE
[hipamd] Fix wrong hipChannelFormatKind when regarding char as unsinged

### DIFF
--- a/projects/clr/hipamd/include/hip/amd_detail/amd_channel_descriptor.h
+++ b/projects/clr/hipamd/include/hip/amd_detail/amd_channel_descriptor.h
@@ -43,8 +43,13 @@ template <typename T> static inline hipChannelFormatDesc hipCreateChannelDesc() 
 }
 
 template <> inline hipChannelFormatDesc hipCreateChannelDesc<char>() {
-  int e = (int)sizeof(char) * 8;
+#ifdef __CHAR_UNSIGNED__
+  int e = (int)sizeof(unsigned char) * 8;
+  return hipCreateChannelDesc(e, 0, 0, 0, hipChannelFormatKindUnsigned);
+#else
+  int e = (int)sizeof(signed char) * 8;
   return hipCreateChannelDesc(e, 0, 0, 0, hipChannelFormatKindSigned);
+#endif
 }
 
 template <> inline hipChannelFormatDesc hipCreateChannelDesc<signed char>() {
@@ -63,8 +68,13 @@ template <> inline hipChannelFormatDesc hipCreateChannelDesc<uchar1>() {
 }
 
 template <> inline hipChannelFormatDesc hipCreateChannelDesc<char1>() {
+#ifdef __CHAR_UNSIGNED__
+  int e = (int)sizeof(unsigned char) * 8;
+  return hipCreateChannelDesc(e, 0, 0, 0, hipChannelFormatKindUnsigned);
+#else
   int e = (int)sizeof(signed char) * 8;
   return hipCreateChannelDesc(e, 0, 0, 0, hipChannelFormatKindSigned);
+#endif
 }
 
 template <> inline hipChannelFormatDesc hipCreateChannelDesc<uchar2>() {
@@ -73,8 +83,13 @@ template <> inline hipChannelFormatDesc hipCreateChannelDesc<uchar2>() {
 }
 
 template <> inline hipChannelFormatDesc hipCreateChannelDesc<char2>() {
+#ifdef __CHAR_UNSIGNED__
+  int e = (int)sizeof(unsigned char) * 8;
+  return hipCreateChannelDesc(e, e, 0, 0, hipChannelFormatKindUnsigned);
+#else
   int e = (int)sizeof(signed char) * 8;
   return hipCreateChannelDesc(e, e, 0, 0, hipChannelFormatKindSigned);
+#endif
 }
 
 #ifndef __GNUC__  // vector3 is the same as vector4
@@ -84,8 +99,13 @@ template <> inline hipChannelFormatDesc hipCreateChannelDesc<uchar3>() {
 }
 
 template <> inline hipChannelFormatDesc hipCreateChannelDesc<char3>() {
+#ifdef __CHAR_UNSIGNED__
+  int e = (int)sizeof(unsigned char) * 8;
+  return hipCreateChannelDesc(e, e, e, 0, hipChannelFormatKindUnsigned);
+#else
   int e = (int)sizeof(signed char) * 8;
   return hipCreateChannelDesc(e, e, e, 0, hipChannelFormatKindSigned);
+#endif
 }
 #endif
 
@@ -95,8 +115,13 @@ template <> inline hipChannelFormatDesc hipCreateChannelDesc<uchar4>() {
 }
 
 template <> inline hipChannelFormatDesc hipCreateChannelDesc<char4>() {
+#ifdef __CHAR_UNSIGNED__
+  int e = (int)sizeof(unsigned char) * 8;
+  return hipCreateChannelDesc(e, e, e, e, hipChannelFormatKindUnsigned);
+#else
   int e = (int)sizeof(signed char) * 8;
   return hipCreateChannelDesc(e, e, e, e, hipChannelFormatKindSigned);
+#endif
 }
 
 template <> inline hipChannelFormatDesc hipCreateChannelDesc<unsigned short>() {


### PR DESCRIPTION
## Motivation

 Fix wrong hipChannelFormatKind when regarding char as unsinged char

## Technical Details

The API in amd_channel_descriptor below always hardcode the hipChannelFormatKind as signed
    hipCreateChannelDesc<char>()
    hipCreateChannelDesc<char1>()
    hipCreateChannelDesc<char2>()
    hipCreateChannelDesc<char3>()
    hipCreateChannelDesc<char4>()
On arm platform, char will be defaultly regarded as unsinged char ,or when use -fno-singed-char for hipcc/clang to take char as unsinged char, This will cause issue, like the testcase for hipSurfaceObj1D.cc, when char regarding as unsinged
  use  __ockl_image_store_1D to store a char (value > 127)
  then use __ockl_image_load_1D the value, data will be inconsistent

## JIRA ID

NA

## Test Plan

Already did test for case hipSurfaceObj1D.cc

## Test Result

Now the stored data and load data is consistent

## Submission Checklist
NA
