### PR TITLE
[rocprofiler-sdk][clr] Fix iterator invalidation crash in `hipDeviceReset`

### DIFF
--- a/projects/clr/hipamd/src/hip_device.cpp
+++ b/projects/clr/hipamd/src/hip_device.cpp
@@ -137,11 +137,11 @@ void Device::AddSafeStream(Stream* event_stream, Stream* wait_stream) {
 void Device::Reset() {
   {
     std::scoped_lock lock(lock_);
-    for (auto* pool : mem_pools_) {
+    auto pools_to_delete = std::exchange(mem_pools_, {});
+    for (auto* pool : pools_to_delete) {
       pool->ReleaseAllMemory();
       delete pool;
     }
-    mem_pools_.clear();
   }
   flags_ = hipDeviceScheduleSpin;
   destroyAllStreams();


### PR DESCRIPTION
## Motivation

`rocprofiler-sdk` PSDB stability fixes. 

Fix a segfault in some of the tests. 

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

`Device::Reset` iterates `mem_pools_` (`std::set<MemoryPool*>`) with a range-for loop and deletes each pool. The `~MemoryPool` destructor calls `Device::RemoveMemoryPool(this)`, which erases the element from `mem_pools_` while the range-for iterator is still live, causing a segfault.

Since lock_ is a recursive_mutex, the re-entrant lock acquisition succeeds.

<!-- Explain the changes along with any relevant GitHub links. -->

## JIRA ID

N/A

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

Tested with rocprofiler-sdk ctest test suite, crash not observed

## Test Result

<!-- Briefly summarize test outcomes. -->

fewer ctest failures

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
