### PR TITLE
[RCCL] Support building rocSHMEM from the mono-repo via git worktree

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .cline_storage
 /projects/hip/_build
+/.rocshmem-worktree

--- a/.gitmodules
+++ b/.gitmodules
@@ -102,10 +102,6 @@
 [submodule "projects/rocprofiler-systems/external/json"]
 	path = projects/rocprofiler-systems/external/json
 	url = https://github.com/nlohmann/json.git
-[submodule "projects/rccl/ext-src/rocSHMEM"]
-	path = projects/rccl/ext-src/rocSHMEM
-	url = https://github.com/ROCm/rocSHMEM.git
-	branch = develop
 [submodule "projects/rocprofiler-compute/src/vendored/pyyaml"]
 	path = projects/rocprofiler-compute/src/vendored/pyyaml
 	url = https://github.com/yaml/pyyaml.git

--- a/projects/rccl/.gitmodules
+++ b/projects/rccl/.gitmodules
@@ -8,7 +8,3 @@
 	url = https://github.com/nlohmann/json.git
 	ignore = dirty
 	shallow = true
-[submodule "ext-src/rocSHMEM"]
-	path = ext-src/rocSHMEM
-	url = https://github.com/ROCm/rocSHMEM.git
-	branch = develop

--- a/projects/rccl/README.md
+++ b/projects/rccl/README.md
@@ -81,7 +81,7 @@ $ cd build
 $ cmake ..
 $ make -j 16      # Or some other suitable number of parallel jobs
 ```
-If you have already cloned, you can checkout the external submodules manually.
+If you have already cloned, you can check out the remaining git submodules manually (for example MSCCL++ and nlohmann/json under `ext-src/`). rocSHMEM is **not** a submodule; to build RCCL with rocSHMEM from CMake, set `ROCSHMEM_INSTALL_DIR` or `ROCSHMEM_SOURCE_DIR` as described under [rocSHMEM support](#rocshmem-support) below.
 ```shell
 $ git submodule update --init --recursive --depth=1
 ```
@@ -139,13 +139,20 @@ Please consult the [rocSHMEM documentation](https://rocm.docs.amd.com/projects/r
   ```shell
   ./install.sh --rocshmem
   ```
-  If the rocSHMEM submodule is present (`ext-src/rocSHMEM`), it will be built and linked automatically. To use a pre-built rocSHMEM installation instead, set `ROCSHMEM_INSTALL_DIR` to the install prefix before running the script.
-- Using CMake:
+  By default (without `ROCSHMEM_INSTALL_DIR`), the script creates a sparse git worktree of the mono-repo at a pinned commit and passes that rocSHMEM tree to CMake as `ROCSHMEM_SOURCE_DIR`, so RCCL builds rocSHMEM via CMake `ExternalProject`. To use an already-built rocSHMEM instead, set `ROCSHMEM_INSTALL_DIR` to its install prefix before running the script.
+
+- **Manual CMake (without `install.sh`)**  
+  You need InfiniBand Verbs development libraries on the system (`libibverbs`; e.g. `rdma-core` / `libibverbs-dev` on Debian/Ubuntu). Then enable rocSHMEM and supply **either** a pre-built install prefix **or** a path to the rocSHMEM CMake source tree (the directory that contains rocSHMEM’s top-level `CMakeLists.txt`, e.g. `projects/rocshmem` in the rocm-systems mono-repo):
+
   ```shell
-  cmake -DENABLE_ROCSHMEM=ON ..
-  # Optional: use an existing rocSHMEM install
-  cmake -DENABLE_ROCSHMEM=ON -DROCSHMEM_INSTALL_DIR=/path/to/rocshmem ..
+  # Option A — link against an existing rocSHMEM installation
+  cmake -DENABLE_ROCSHMEM=ON -DROCSHMEM_INSTALL_DIR=/path/to/rocshmem/prefix ..
+
+  # Option B — build rocSHMEM from source as part of the RCCL build
+  cmake -DENABLE_ROCSHMEM=ON -DROCSHMEM_SOURCE_DIR=/path/to/rocshmem/source ..
   ```
+
+  If neither `ROCSHMEM_INSTALL_DIR` (with a successful `find_package(rocshmem_static)`) nor `ROCSHMEM_SOURCE_DIR` is set, configuration fails with an error directing you to set `ROCSHMEM_SOURCE_DIR` (or use `install.sh --rocshmem`).
 
 **Runtime behavior**
 

--- a/projects/rccl/cmake/ROCSHMEM.cmake
+++ b/projects/rccl/cmake/ROCSHMEM.cmake
@@ -24,90 +24,66 @@ include(ExternalProject)
 
 function(add_rocshmem_targets)
 
-    # Check for an existing installation via the user-provided prefix ROCSHMEM_INSTALL DIR
+    # Common dependency: libibverbs is required for all rocSHMEM paths
+    find_library(_IBVERBS ibverbs)
+    if(NOT _IBVERBS)
+        message(FATAL_ERROR "libibverbs not found (install rdma-core/libibverbs-dev)")
+    endif()
+    set(IBVERBS ${_IBVERBS} PARENT_SCOPE)
+
+    # -----------------------------------------------------------------
+    # Path 1: Pre-built rocSHMEM installation (ROCSHMEM_INSTALL_DIR)
+    # -----------------------------------------------------------------
     if(ROCSHMEM_INSTALL_DIR)
         list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
         find_package(rocshmem_static)
-        if(NOT IBVERBS)
-            find_library(IBVERBS ibverbs)
-            if(IBVERBS)
-                set(IBVERBS ${IBVERBS} PARENT_SCOPE)
-            endif()
+        if(rocshmem_static_FOUND)
+            set(ROCSHMEM_INCLUDE_DIR "${ROCSHMEM_INCLUDE_DIR}" PARENT_SCOPE)
+            set(ROCSHMEM_LIBRARY     "${ROCSHMEM_LIBRARY}"      PARENT_SCOPE)
+            return()
         endif()
     endif()
 
-    # If no pre-existing installation, build from submodule into ext/rocshmem
-    if(NOT rocshmem_static_FOUND)
-        set(_rccl_root            "${CMAKE_SOURCE_DIR}")
-        set(ROCSHMEM_SOURCE       "${_rccl_root}/ext-src/rocSHMEM")
-        set(ROCSHMEM_INSTALL_DIR  "${_rccl_root}/ext/rocshmem")
-
-        # Make sure submodule exists (same style as MSCCL++: custom rule + target)
-        add_custom_command(
-            OUTPUT "${ROCSHMEM_SOURCE}/CMakeLists.txt"
-            COMMAND git submodule update --init --recursive ext-src/rocSHMEM
-            WORKING_DIRECTORY "${_rccl_root}"
-            COMMENT "Checking out submodule: ext-src/rocSHMEM"
-            VERBATIM
-        )
-
-        add_custom_target(rocshmem_checkout_submodule
-            DEPENDS "${ROCSHMEM_SOURCE}/CMakeLists.txt")
-
-        # Where our patch files live (like MSCCL++)
-        set(EXT_SOURCE "${_rccl_root}/ext-src")
-
-            # Build and install rocSHMEM. We run `../build_scripts/gdx_bxnt`
-        # from a 'build' dir just like the README shows.
-        ExternalProject_Add(rocshmem_ext
-            SOURCE_DIR          "${ROCSHMEM_SOURCE}"
-            INSTALL_DIR         "${ROCSHMEM_INSTALL_DIR}"
-            UPDATE_DISCONNECTED TRUE
-            LOG_DOWNLOAD        FALSE
-            LOG_CONFIGURE       FALSE
-            LOG_BUILD           FALSE
-            LOG_INSTALL         FALSE
-            BUILD_IN_SOURCE     TRUE
-            DOWNLOAD_COMMAND    ""   # using the submodule checkout above
-            TEST_COMMAND        ""
-            DEPENDS             rocshmem_checkout_submodule   
-
-            # Rocshmem submodule commit hash -> commit f273bc0 "Add alltoallv"
-            # The project has its own scripts; we replicate the README sequence:
-            CONFIGURE_COMMAND   ""
-            BUILD_COMMAND
-                ${CMAKE_COMMAND} -E make_directory build
-		&& ${CMAKE_COMMAND} -E chdir build bash -lc "../scripts/build_configs/gda_bnxt -DUSE_EXTERNAL_MPI=OFF -DUSE_IPC=ON -DBUILD_EXAMPLES=OFF "
-                && ${CMAKE_COMMAND} -E chdir build ${CMAKE_COMMAND}
-                    -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
-                    -DCMAKE_INSTALL_PREFIX=<INSTALL_DIR>
-                    -DBUILD_EXAMPLES=OFF ..
-                && ${CMAKE_COMMAND} -E chdir build ${CMAKE_MAKE_PROGRAM} -j
-            INSTALL_COMMAND
-                ${CMAKE_COMMAND} -E chdir build ${CMAKE_MAKE_PROGRAM} install
-        )
-
-         # After build, define the variables RCCL expects
-        set(ROCSHMEM_INCLUDE_DIR "${ROCSHMEM_INSTALL_DIR}/include" PARENT_SCOPE)
-        set(ROCSHMEM_LIBRARY      "${ROCSHMEM_INSTALL_DIR}/lib/librocshmem.a" PARENT_SCOPE)
-        find_library(_IBVERBS ibverbs)
-        if(NOT _IBVERBS)
-            message(FATAL_ERROR "libibverbs not found (install rdma-core/libibverbs-dev)")
-        endif()
-        set(IBVERBS ${_IBVERBS} PARENT_SCOPE)
-
-        # Provide a dummy target other code can depend on
-        add_custom_target(rocshmem_static ALL DEPENDS rocshmem_ext)
-    else()
-    # We found a prebuilt rocSHMEM; export variables upward as-is
-    set(ROCSHMEM_INCLUDE_DIR  "${ROCSHMEM_INCLUDE_DIR}" PARENT_SCOPE)
-    set(ROCSHMEM_LIBRARY      "${ROCSHMEM_LIBRARY}"      PARENT_SCOPE)
-
-    find_library(_IBVERBS ibverbs)
-    if(NOT _IBVERBS)
-        message(FATAL_ERROR "libibverbs not found")
+    # -----------------------------------------------------------------
+    # Path 2: Build from mono-repo worktree source (ROCSHMEM_SOURCE_DIR)
+    # -----------------------------------------------------------------
+    if(NOT ROCSHMEM_SOURCE_DIR)
+        message(FATAL_ERROR "ROCSHMEM_SOURCE_DIR is not set. "
+            "Use --rocshmem with install.sh or pass -DROCSHMEM_SOURCE_DIR=<path>.")
     endif()
-    set(IBVERBS ${_IBVERBS} PARENT_SCOPE)
-    endif()
+
+    set(_rccl_root           "${CMAKE_SOURCE_DIR}")
+    set(ROCSHMEM_INSTALL_DIR "${_rccl_root}/ext/rocshmem")
+    message(STATUS "rocSHMEM: building from ${ROCSHMEM_SOURCE_DIR}")
+
+    ExternalProject_Add(rocshmem_ext
+        SOURCE_DIR          "${ROCSHMEM_SOURCE_DIR}"
+        INSTALL_DIR         "${ROCSHMEM_INSTALL_DIR}"
+        UPDATE_DISCONNECTED TRUE
+        LOG_DOWNLOAD        FALSE
+        LOG_CONFIGURE       FALSE
+        LOG_BUILD           FALSE
+        LOG_INSTALL         FALSE
+        BUILD_IN_SOURCE     TRUE
+        DOWNLOAD_COMMAND    ""
+        TEST_COMMAND        ""
+
+        CONFIGURE_COMMAND   ""
+        BUILD_COMMAND
+            ${CMAKE_COMMAND} -E make_directory build
+            && ${CMAKE_COMMAND} -E chdir build bash -lc "../scripts/build_configs/gda_bnxt -DUSE_EXTERNAL_MPI=OFF -DUSE_IPC=ON -DBUILD_EXAMPLES=OFF "
+            && ${CMAKE_COMMAND} -E chdir build ${CMAKE_COMMAND}
+                -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
+                -DCMAKE_INSTALL_PREFIX=<INSTALL_DIR>
+                -DBUILD_EXAMPLES=OFF ..
+            && ${CMAKE_COMMAND} -E chdir build ${CMAKE_MAKE_PROGRAM} -j
+        INSTALL_COMMAND
+            ${CMAKE_COMMAND} -E chdir build ${CMAKE_MAKE_PROGRAM} install
+    )
+
+    set(ROCSHMEM_INCLUDE_DIR "${ROCSHMEM_INSTALL_DIR}/include" PARENT_SCOPE)
+    set(ROCSHMEM_LIBRARY     "${ROCSHMEM_INSTALL_DIR}/lib/librocshmem.a" PARENT_SCOPE)
+
+    add_custom_target(rocshmem_static ALL DEPENDS rocshmem_ext)
 
 endfunction()

--- a/projects/rccl/install.sh
+++ b/projects/rccl/install.sh
@@ -44,6 +44,7 @@ generate_sym_kernels=false
 warp_speed_enabled=true # note that this flag will be overridden to false for non MI350/MI300 platforms
 quiet_warnings=false
 build_rocshmem_support=false
+rocshmem_mono_hash="0e2998b11f99e8302c72f1ac2ce9f2b8c1816587"
 custom_cmake_options=""
 
 # #################################################
@@ -105,6 +106,7 @@ function display_help()
     echo "    -DRCCL_ROCPROFILER_REGISTER=OFF       Disable rocprofiler-register support (default: ON)"
     echo ""
     echo "  Environment variables:"
+    echo "    ROCSHMEM_INSTALL_DIR       Path to a pre-built rocSHMEM installation (skips building from source)"
     echo "    ONLY_FUNCS                 Build only specified collective functions (debug builds only)."
     echo "                               Restricts GPU kernel generation to the listed collectives, significantly"
     echo "                               reducing build time during development. Use '|' to separate multiple functions."
@@ -214,6 +216,58 @@ check_exit_code( )
     fi
 }
 
+# Set up a git worktree of the rocm-systems mono-repo so that
+# projects/rocshmem is checked out at a pinned commit hash while the
+# main working tree (which contains rccl at HEAD) stays untouched.
+setup_rocshmem_worktree()
+{
+    local mono_root
+    mono_root=$(git rev-parse --show-toplevel 2>/dev/null)
+    if [[ -z "$mono_root" ]]; then
+        echo "ERROR: Not inside a git repository. Cannot set up rocSHMEM worktree."
+        echo "       Use ROCSHMEM_INSTALL_DIR to point to a pre-built rocSHMEM instead."
+        exit 1
+    fi
+
+    local pinned_hash="${rocshmem_mono_hash}"
+    local worktree_dir="${mono_root}/.rocshmem-worktree"
+
+    echo "=== Setting up rocSHMEM from mono-repo worktree ==="
+    echo "  Pinned hash  : ${pinned_hash:0:12}"
+    echo "  Worktree dir : ${worktree_dir}"
+
+    if [[ -d "$worktree_dir" ]]; then
+        local current_hash
+        current_hash=$(git -C "$worktree_dir" rev-parse HEAD 2>/dev/null)
+        if [[ "${current_hash}" == "${pinned_hash}"* ]] || [[ "${pinned_hash}" == "${current_hash}"* ]]; then
+            echo "  Worktree already at the correct hash — reusing."
+            rocshmem_source_dir="${worktree_dir}/projects/rocshmem"
+            return 0
+        fi
+        echo "  Removing stale worktree..."
+        git -C "$mono_root" worktree remove "$worktree_dir" --force 2>/dev/null || rm -rf "$worktree_dir"
+    fi
+
+    git -C "$mono_root" worktree add --no-checkout "$worktree_dir" "$pinned_hash"
+    check_exit_code "$?"
+
+    git -C "$worktree_dir" sparse-checkout init --cone
+    git -C "$worktree_dir" sparse-checkout set projects/rocshmem
+    check_exit_code "$?"
+
+    git -C "$worktree_dir" checkout
+    check_exit_code "$?"
+
+    if [[ ! -d "${worktree_dir}/projects/rocshmem" ]]; then
+        echo "ERROR: projects/rocshmem not found in worktree."
+        exit 1
+    fi
+
+    rocshmem_source_dir="${worktree_dir}/projects/rocshmem"
+    echo "  rocSHMEM source ready at: ${rocshmem_source_dir}"
+    echo "=================================================="
+}
+
 # set RCCL-UnitTests path
 if [[ "${build_release}" == true ]]; then
     unit_test_path="./build/release/test/rccl-UnitTests"
@@ -225,6 +279,14 @@ if [[ "${run_tests}" == true ]] && [[ -f "${unit_test_path}" ]]; then
     if [[ "${build_tests}" == false ]]; then
         clean_build=false
     fi
+fi
+
+# #################################################
+# rocSHMEM worktree setup (must run before cd-ing into the build directory)
+# #################################################
+rocshmem_source_dir=""
+if [[ "${build_rocshmem_support}" == true ]] && [[ -z "${ROCSHMEM_INSTALL_DIR}" ]]; then
+    setup_rocshmem_worktree
 fi
 
 # #################################################
@@ -380,7 +442,11 @@ fi
 # Enable rocSHMEM support
 if [[ "${build_rocshmem_support}" == true ]]; then
     cmake_common_options="${cmake_common_options} -DENABLE_ROCSHMEM=ON"
-    cmake_common_options="${cmake_common_options} -DROCSHMEM_INSTALL_DIR=${ROCSHMEM_INSTALL_DIR}"
+    if [[ -n "${ROCSHMEM_INSTALL_DIR}" ]]; then
+        cmake_common_options="${cmake_common_options} -DROCSHMEM_INSTALL_DIR=${ROCSHMEM_INSTALL_DIR}"
+    elif [[ -n "${rocshmem_source_dir}" ]]; then
+        cmake_common_options="${cmake_common_options} -DROCSHMEM_SOURCE_DIR=${rocshmem_source_dir}"
+    fi
 else
     cmake_common_options="${cmake_common_options} -DENABLE_ROCSHMEM=OFF"
 fi


### PR DESCRIPTION
## Motivation

Now that RCCL and rocSHMEM coexist in the rocm-systems mono-repo, the
old approach of cloning rocSHMEM from a standalone submodule is no longer
the preferred path. However, pinning a specific rocSHMEM version remains
critical for reproducibility -- and a naive `git checkout <hash>` would
roll back RCCL sources too, since both projects share one repository.

## Technical Details

Introduces a git-worktree + sparse-checkout strategy that lets RCCL
build against an exact, pinned revision of rocSHMEM without disturbing
its own working tree:

- `install.sh --rocshmem` now calls `setup_rocshmem_worktree()`, which
  creates a lightweight worktree at `<mono-root>/.rocshmem-worktree`
  with sparse-checkout scoped to `projects/rocshmem`. The worktree is
  reused when the hash matches and automatically replaced when it changes.

- `cmake/ROCSHMEM.cmake` gains a new `ROCSHMEM_SOURCE_DIR` code path
  (Path 2) that builds directly from the worktree source, alongside the
  existing pre-built (Path 1 / `ROCSHMEM_INSTALL_DIR`) and legacy
  submodule (Path 3) paths.

 `ROCSHMEM_INSTALL_DIR` continues to work for
pre-built installations.

## JIRA ID

Closes AICOMRCCL-676
In conjunction with https://github.com/ROCm/rocm-systems/pull/4191, fixes AICOMRCCL-744

## Test Plan

- Build RCCL with `--rocshmem` using both the submodule (original) and
  mono-repo worktree (new) approaches, pinned to the same rocSHMEM
  source.
- Run alltoall_perf and alltoallv_perf at 2-node (16 GPU) and 4-node
  (32 GPU) scales on MI300X with bfloat16, 100 iters, 20 warmup,
  5 cycles averaged.
- Compare OOP latency with RCCL_ROCSHMEM_ENABLE=1 (GDA path) and
  RCCL_ROCSHMEM_ENABLE=0 (fallback path).

## Test Result

Zero performance degradation: OOP latency deltas within +/-3%
run-to-run noise across all message sizes (1K-8M) for both GDA-enabled
and GDA-disabled paths. Fallback (non-GDA) performance confirmed intact.