### PR TITLE
[rocprofiler-sdk] Fix --selected-regions not registering pause/resume callbacks

### DIFF
--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-tool/tool.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-tool/tool.cpp
@@ -2189,7 +2189,12 @@ tool_init(rocprofiler_client_finalize_t fini_func, void* tool_data)
                              callbacks.callback_tracing,
                              nullptr),
                          "callback tracing service failed to configure");
+    }
 
+    // Register pause/resume control callbacks when using selected_regions or marker tracing
+    if(tool::get_config().marker_api_trace || tool::get_config().selected_regions ||
+       tool::get_config().selected_regions_ref_count)
+    {
         auto pause_resume_ctx = null_context_id;
         ROCPROFILER_CALL(rocprofiler_create_context(&pause_resume_ctx), "failed to create context");
 

--- a/projects/rocprofiler-sdk/tests/rocprofv3/roctx-pause-resume/nested-pause-resume/CMakeLists.txt
+++ b/projects/rocprofiler-sdk/tests/rocprofv3/roctx-pause-resume/nested-pause-resume/CMakeLists.txt
@@ -62,8 +62,8 @@ rocprofiler_add_integration_validate_test(
     FIXTURES_REQUIRED rocprofv3-test-roctx-pause-resume-nested-tracing
     FAIL_REGULAR_EXPRESSION "AssertionError")
 
-# Test --selected-regions with --kernel-trace WITHOUT --marker-trace
-# This verifies that marker control callbacks are registered even without --marker-trace
+# Test --selected-regions with --kernel-trace WITHOUT --marker-trace This verifies that
+# marker control callbacks are registered even without --marker-trace
 rocprofiler_add_integration_execute_test(
     rocprofv3-test-selected-regions-kernel-only
     COMMAND

--- a/projects/rocprofiler-sdk/tests/rocprofv3/roctx-pause-resume/nested-pause-resume/CMakeLists.txt
+++ b/projects/rocprofiler-sdk/tests/rocprofv3/roctx-pause-resume/nested-pause-resume/CMakeLists.txt
@@ -81,7 +81,8 @@ rocprofiler_add_integration_validate_test(
     TEST_PATHS validate.py
     COPY conftest.py
     CONFIG pytest.ini
-    ARGS --json-input ${CMAKE_CURRENT_BINARY_DIR}/selected-kernel/out_results.json
+    ARGS --json-input
+         ${CMAKE_CURRENT_BINARY_DIR}/roctx-pause-resume-nested-trace/out_results.json
     TIMEOUT 45
     LABELS "integration-tests;pause-resume;selected-regions"
     FIXTURES_REQUIRED rocprofv3-test-selected-regions-kernel-only

--- a/projects/rocprofiler-sdk/tests/rocprofv3/roctx-pause-resume/nested-pause-resume/CMakeLists.txt
+++ b/projects/rocprofiler-sdk/tests/rocprofv3/roctx-pause-resume/nested-pause-resume/CMakeLists.txt
@@ -61,3 +61,28 @@ rocprofiler_add_integration_validate_test(
     LABELS "integration-tests;pause-resume"
     FIXTURES_REQUIRED rocprofv3-test-roctx-pause-resume-nested-tracing
     FAIL_REGULAR_EXPRESSION "AssertionError")
+
+# Test --selected-regions with --kernel-trace WITHOUT --marker-trace
+# This verifies that marker control callbacks are registered even without --marker-trace
+rocprofiler_add_integration_execute_test(
+    rocprofv3-test-selected-regions-kernel-only
+    COMMAND
+        $<TARGET_FILE:rocprofiler-sdk::rocprofv3> --selected-regions --kernel-trace -d
+        ${CMAKE_CURRENT_BINARY_DIR}/%tag%-selected-kernel -o out --output-format json
+        --log-level info -- $<TARGET_FILE:roctx-pause-resume>
+    DEPENDS roctx-pause-resume
+    TIMEOUT 45
+    LABELS "integration-tests;pause-resume;selected-regions"
+    ENVIRONMENT "${roctx-pause-resume-nested-env}"
+    FIXTURES_SETUP rocprofv3-test-selected-regions-kernel-only)
+
+rocprofiler_add_integration_validate_test(
+    rocprofv3-test-selected-regions-kernel-only
+    TEST_PATHS validate.py
+    COPY conftest.py
+    CONFIG pytest.ini
+    ARGS --json-input ${CMAKE_CURRENT_BINARY_DIR}/selected-kernel/out_results.json
+    TIMEOUT 45
+    LABELS "integration-tests;pause-resume;selected-regions"
+    FIXTURES_REQUIRED rocprofv3-test-selected-regions-kernel-only
+    FAIL_REGULAR_EXPRESSION "AssertionError")


### PR DESCRIPTION
The --selected-regions option was not working because the marker control API callbacks (roctxProfilerPause/Resume) were only registered when --marker-trace was enabled. This meant that when using --selected-regions alone, the pause/resume calls in user code were never intercepted by the profiler, resulting in no trace data being collected.

Changes:
- Register ROCPROFILER_CALLBACK_TRACING_MARKER_CONTROL_API callbacks when either marker_api_trace OR selected_regions is enabled

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
