### PR TITLE
Disable direct dispatch by default when CLR is compiled with ASAN

### DIFF
--- a/projects/clr/rocclr/device/device.cpp
+++ b/projects/clr/rocclr/device/device.cpp
@@ -697,8 +697,14 @@ bool Device::init() {
       }
       GPU_ENABLE_PAL = 1;
     } else {
-      // ROC initialization was successful, force direct dispatch
-      AMD_DIRECT_DISPATCH = true;
+      // ROC initialization successful, enable direct dispatch
+      if (flagIsDefault(AMD_DIRECT_DISPATCH)) {
+#if defined(__clang__) && __has_feature(address_sanitizer)
+        AMD_DIRECT_DISPATCH = false;
+#else
+        AMD_DIRECT_DISPATCH = true;
+#endif
+      }
       // Disable PAL path
       GPU_ENABLE_PAL = 0;
     }


### PR DESCRIPTION
## Motivation

CK kernels hang in MIOpen unit tests when the ROCm stack is built with ASAN (`TheRock -DTHEROCK_ASAN=ON`). This blocks ASAN CI for MIOpen, which currently skips all CK tests as a workaround (ROCm/TheRock#5073).

## Technical Details

Under ASAN, direct dispatch (`AMD_DIRECT_DISPATCH=1`) uses active polling on the caller thread, which prevents the ASAN hostcall listener from servicing device-side requests. This causes the `amdgcn.device.init` kernel to hang indefinitely when ASAN-instrumented code objects are loaded.

This PR disables direct dispatch by default when CLR is compiled with ASAN, using a compile-time check:

```cpp
#if defined(__clang__) && __has_feature(address_sanitizer)
  AMD_DIRECT_DISPATCH = false;
#else
  AMD_DIRECT_DISPATCH = true;
#endif
```

The `flagIsDefault()` guard is also added so users can still override via `AMD_DIRECT_DISPATCH=1` if needed.

## JIRA ID

N/A

## Test Plan

Tested on Sree's ASAN Docker image. Apply the fix to `projects/clr/rocclr/device/device.cpp`, then:

**Build:**

```bash
cd /TheRock/build/core/clr/build
ninja -j$(nproc) rocclr
ninja -j$(nproc) amdhip64
cp hipamd/lib/libamdhip64.so.7.12.60700-5ec3a0d0dc \
   /TheRock/build/math-libs/BLAS/rocBLAS/dist/lib/libamdhip64.so.7.12.60700-5ec3a0d0dc
```

**Run:**

```bash
cd /TheRock/build/ml-libs/MIOpen/build
HSA_XNACK=1 ASAN_OPTIONS=detect_leaks=0 HIP_VISIBLE_DEVICES=0 \
  ./bin/miopen_gtest \
  --gtest_filter="Smoke/GPU_BN_Spatial_FP32*:Smoke/GPU_ConvBiasActivInfer_FP16.ConvCKIgemmFwdBiasActivFused/1"
```

- Without the fix: hangs indefinitely on the CK test
- With the fix: all tests pass (no `AMD_DIRECT_DISPATCH=0` env var needed)

## Test Result

Tests that previously hung now complete successfully under ASAN.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
