### PR TITLE
ROCM-1580 - Remove dflock_

### DIFF
--- a/projects/clr/hipamd/src/hip_global.hpp
+++ b/projects/clr/hipamd/src/hip_global.hpp
@@ -45,8 +45,6 @@ class DeviceFunc {
   DeviceFunc(const std::string &name, hipModule_t hmod);
   ~DeviceFunc();
 
-  std::recursive_mutex dflock_;
-
   // Converts DeviceFunc to hipFunction_t(used by app) and vice versa.
   hipFunction_t asHipFunction() { return reinterpret_cast<hipFunction_t>(this); }
   static DeviceFunc* asFunction(hipFunction_t f) { return reinterpret_cast<DeviceFunc*>(f); }

--- a/projects/clr/hipamd/src/hip_graph_internal.hpp
+++ b/projects/clr/hipamd/src/hip_graph_internal.hpp
@@ -1215,8 +1215,6 @@ class GraphKernelNode : public GraphNode {
     }
     for (auto& command : commands_) {
       hipFunction_t func = getFunc(kernelParams_, dev_id_);
-      hip::DeviceFunc* function = hip::DeviceFunc::asFunction(func);
-      std::scoped_lock lock(function->dflock_);
       command->enqueue();
       command->release();
     }
@@ -1474,8 +1472,6 @@ class GraphKernelNode : public GraphNode {
     if (!func) {
       return hipErrorInvalidDeviceFunction;
     }
-    hip::DeviceFunc* function = hip::DeviceFunc::asFunction(func);
-    std::scoped_lock lock(function->dflock_);
     status = validateKernelParams(&kernelParams_, func, dev_id_);
     if (hipSuccess != status) {
       return status;

--- a/projects/clr/hipamd/src/hip_graph_internal.hpp
+++ b/projects/clr/hipamd/src/hip_graph_internal.hpp
@@ -1214,7 +1214,6 @@ class GraphKernelNode : public GraphNode {
       return;
     }
     for (auto& command : commands_) {
-      hipFunction_t func = getFunc(kernelParams_, dev_id_);
       command->enqueue();
       command->release();
     }

--- a/projects/clr/hipamd/src/hip_module.cpp
+++ b/projects/clr/hipamd/src/hip_module.cpp
@@ -399,7 +399,7 @@ hipError_t ihipLaunchKernelCommand(amd::Command*& command, hipFunction_t f,
     }
   }
 
-  if (CL_SUCCESS != kernelCommand->AllocCaptureSetValidate(kernelParams, kernargs, kernargs_size)) {
+  if (CL_SUCCESS != kernelCommand->captureHIPArgsAndValidate(kernelParams, kernargs, kernargs_size)) {
     kernelCommand->release();
     return hipErrorOutOfMemory;
   }

--- a/projects/clr/hipamd/src/hip_module.cpp
+++ b/projects/clr/hipamd/src/hip_module.cpp
@@ -399,34 +399,9 @@ hipError_t ihipLaunchKernelCommand(amd::Command*& command, hipFunction_t f,
     }
   }
 
-  if (DEBUG_HIP_KERNARG_COPY_OPT) {
-    if (CL_SUCCESS !=
-        kernelCommand->captureHIPArgsAndValidate(kernelParams, kernargs, kernargs_size)) {
-      kernelCommand->release();
-      return hipErrorOutOfMemory;
-    }
-
-  } else {
-    for (size_t i = 0; i < kernel->signature().numParameters(); ++i) {
-      const amd::KernelParameterDescriptor& desc = kernel->signature().at(i);
-      if (kernelParams == nullptr) {
-        assert(kernargs != nullptr);
-        // only copy if this parameter lies fully inside the passed buffer
-        if (desc.offset_ + desc.size_ <= kernargs_size) {
-          kernel->parameters().set(i, desc.size_, kernargs + desc.offset_,
-                                   desc.type_ == T_POINTER /*svmBound*/);
-        }
-      } else {
-        kernel->parameters().set(i, desc.size_, kernelParams[i],
-                                 desc.type_ == T_POINTER /*svmBound*/);
-      }
-    }
-
-    // Capture the kernel arguments
-    if (CL_SUCCESS != kernelCommand->captureOpenCLArgsAndValidate()) {
-      kernelCommand->release();
-      return hipErrorOutOfMemory;
-    }
+  if (CL_SUCCESS != kernelCommand->AllocCaptureSetValidate(kernelParams, kernargs, kernargs_size)) {
+    kernelCommand->release();
+    return hipErrorOutOfMemory;
   }
 
   command = kernelCommand;
@@ -454,12 +429,7 @@ hipError_t ihipModuleLaunchKernel(hipFunction_t f, amd::LaunchParams& launch_par
     LogPrintfError("%s", "Function passed is null");
     return hipErrorInvalidResourceHandle;
   }
-  hip::DeviceFunc* function = hip::DeviceFunc::asFunction(f);
-  amd::Kernel* kernel = function->kernel();
-  std::optional<std::scoped_lock<std::recursive_mutex>> lock;
-  if (!DEBUG_HIP_KERNARG_COPY_OPT) {
-    lock.emplace(function->dflock_);
-  }
+  amd::Kernel* kernel = hip::DeviceFunc::asFunction(f)->kernel();
 
   hipError_t status =
       ihipLaunchKernel_validate(f, launch_params, kernelParams, extra, deviceId, params);

--- a/projects/clr/rocclr/utils/flags.hpp
+++ b/projects/clr/rocclr/utils/flags.hpp
@@ -251,8 +251,6 @@ release(uint, DEBUG_CLR_MAX_BATCH_SIZE, 1000,                                 \
         "Forces the callback to clean-up CPU submission queue")               \
 release(bool, DEBUG_CLR_SYSMEM_POOL, false,                                   \
         "Use sysmem pool implementation in runtime for amd commands")         \
-release(bool, DEBUG_HIP_KERNARG_COPY_OPT, true,                               \
-        "Enable/Disable multiple kern arg copies")                            \
 release(bool, DEBUG_CLR_KERNARG_HDP_FLUSH_WA, false,                          \
         "Toggle kernel arg copy workaround")                                  \
 release(uint, DEBUG_HIP_DYNAMIC_QUEUES, 2,                                    \


### PR DESCRIPTION
## Motivation

We currently use dflock_ in hip graphs and hipModules to maintain an old un-optimised kernel path, which is no longer in use. This PR removes DEBUG_HIP_KERNARG_COPY_OPT and consequently dflock_ to clean up the code.

## Technical Details

Remove old DEBUG_HIP_KERNARG_COPY_OPT = false path's and dflock_

## JIRA ID

Part of - ROCM-1580

## Test Plan

Normal testing is sufficient for verifying this change

## Test Result

Passes locally

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
