### PR TITLE
[rocprofiler-sdk] Add SPM core library implementation

### DIFF
--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/aql/packet_construct.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/aql/packet_construct.cpp
@@ -23,6 +23,7 @@
 #include "lib/rocprofiler-sdk/aql/packet_construct.hpp"
 #include "lib/common/logging.hpp"
 #include "lib/rocprofiler-sdk/hsa/details/fmt.hpp"
+#include "lib/rocprofiler-sdk/spm/decode.hpp"
 
 #include <fmt/core.h>
 #include <hsa/hsa_ext_amd.h>
@@ -41,6 +42,12 @@ namespace rocprofiler
 {
 namespace aql
 {
+struct AQLProfileMetric
+{
+    counters::Metric                    metric;
+    std::vector<aqlprofile_pmc_event_t> events;
+};
+
 CounterPacketConstruct::CounterPacketConstruct(rocprofiler_agent_id_t               agent,
                                                const std::vector<counters::Metric>& metrics)
 : _agent(agent)
@@ -282,5 +289,146 @@ CounterPacketConstruct::can_collect()
     }
     return ROCPROFILER_STATUS_SUCCESS;
 }
+
+/** @brief Constructs the packet using the contained input parameters.
+ * Writes into ID map and spm descriptor used to decode SPM data
+ */
+std::unique_ptr<hsa::SPMPacket>
+spm_construct_packet(const rocprofiler_agent_id_t                     agent_id,
+                     const std::vector<counters::Metric>&             metrics,
+                     const std::vector<rocprofiler_spm_parameters_t>& spm_parameters)
+{
+    auto events = std::vector<aqlprofile_pmc_event_t>{};
+    auto params = std::vector<aqlprofile_spm_parameter_t>{};
+    auto id_map = std::vector<spm::spm_counter_instance_t>{};
+
+    const auto* agent     = CHECK_NOTNULL(rocprofiler::agent::get_agent(agent_id));
+    const auto* aql_cache = CHECK_NOTNULL(rocprofiler::agent::get_agent_cache(agent));
+    auto        pool      = std::make_shared<hsa::SPMMemoryPool>(
+        *aql_cache, *hsa::get_amd_ext_table(), hsa::get_core_table()->hsa_memory_copy_fn);
+    const auto* aql_agent = CHECK_NOTNULL(rocprofiler::agent::get_aql_agent(agent->id));
+
+    for(const auto& param : spm_parameters)
+    {
+        switch(param.type)
+        {
+            case ROCPROFILER_SPM_PARAMETER_TYPE_SAMPLE_INTERVAL_SCLK_CYCLES:
+                params.push_back({AQLPROFILE_SPM_PARAMETER_TYPE_SAMPLE_INTERVAL, param.value});
+                params.push_back({AQLPROFILE_SPM_PARAMETER_TYPE_SAMPLE_MODE,
+                                  AQLPROFILE_SPM_PARAMETER_SAMPLE_MODE_SCLK});
+                break;
+            case ROCPROFILER_SPM_PARAMETER_TYPE_NONE:
+            case ROCPROFILER_SPM_PARAMETER_TYPE_LAST:
+                ROCP_FATAL << "Invalid SPM parameter type: " << static_cast<int>(param.type);
+                break;
+            default: break;
+        }
+    }
+
+    for(const auto& metric : metrics)
+    {
+        auto query_info = get_query_info(agent_id, metric);
+
+        for(unsigned block_index = 0; block_index < query_info.instance_count; ++block_index)
+        {
+            uint64_t event_id = 0;
+            if(!metric.event().empty()) event_id = std::stoul(metric.event(), nullptr);
+
+            auto event = aqlprofile_pmc_event_t{
+                .block_index = block_index,
+                .event_id    = static_cast<uint32_t>(
+                    event_id &
+                    0xFFFFFFFF),  // Mask to extract the lower 32 bits of the 64-bit event ID
+                .flags      = aqlprofile_pmc_event_flags_t{metric.flags()},
+                .block_name = static_cast<hsa_ven_amd_aqlprofile_block_name_t>(query_info.id)};
+
+            events.push_back(event);
+            id_map.push_back({rocprofiler_counter_id_t{.handle = metric.id()}, block_index});
+        }
+    }
+
+    auto pkt = std::make_unique<hsa::SPMPacket>(
+        *aql_agent, std::move(pool), std::move(events), std::move(params));
+    if(!pkt->valid())
+    {
+        ROCP_ERROR << "SPM Packet creation failed";
+        return nullptr;
+    }
+
+    pkt->profile.spm_desc.size =
+        sizeof(spm::spm_desc_v0_t) + id_map.size() * sizeof(id_map[0]) + pkt->profile.aql_desc.size;
+
+    pkt->profile.container_desc_data =
+        std::make_shared<std::vector<char>>(pkt->profile.spm_desc.size);
+    pkt->profile.spm_desc.data = pkt->profile.container_desc_data->data();
+
+    auto* desc = static_cast<spm::spm_desc_v0_t*>(pkt->profile.spm_desc.data);
+
+    *desc               = spm::spm_desc_v0_t{};
+    desc->aql_desc_size = pkt->profile.aql_desc.size;
+    desc->num_events    = id_map.size();
+
+    std::memcpy(desc->aqlprofile_desc(), pkt->profile.aql_desc.data, pkt->profile.aql_desc.size);
+    std::memcpy(desc->events(), id_map.data(), id_map.size() * sizeof(id_map[0]));
+
+    return pkt;
+}
+
+// Following the PMC check for now
+// ToDO: change this to SPM
+rocprofiler_status_t
+spm_can_collect(const rocprofiler_agent_id_t agent_id, const std::vector<counters::Metric>& metrics)
+{
+    // Verify that the counters fit within harrdware limits
+    auto counter_count =
+        std::map<std::pair<hsa_ven_amd_aqlprofile_block_name_t, uint32_t>, int64_t>{};
+    auto max_allowed =
+        std::map<std::pair<hsa_ven_amd_aqlprofile_block_name_t, uint32_t>, int64_t>{};
+    auto _metrics = std::vector<AQLProfileMetric>{};
+
+    for(const auto& metric : metrics)
+    {
+        auto query_info                = get_query_info(agent_id, metric);
+        _metrics.emplace_back().metric = metric;
+        uint64_t event_id              = 0;
+        if(!metric.event().empty())
+            event_id =
+                static_cast<uint32_t>(std::stoul(metric.event().c_str(), nullptr) & 0xFFFFFFFF);
+
+        for(unsigned block_index = 0; block_index < query_info.instance_count; ++block_index)
+        {
+            _metrics.back().events.push_back(
+                {.block_index = block_index,
+                 .event_id    = static_cast<uint32_t>(event_id),
+                 .flags       = aqlprofile_pmc_event_flags_t{metric.flags()},
+                 .block_name  = static_cast<hsa_ven_amd_aqlprofile_block_name_t>(query_info.id)});
+        }
+    }
+
+    for(auto& metric : _metrics)
+    {
+        for(auto& instance : metric.events)
+        {
+            auto block_pair       = std::make_pair(instance.block_name, instance.block_index);
+            auto [iter, inserted] = counter_count.emplace(block_pair, 0);
+            iter->second++;
+            if(inserted)
+            {
+                max_allowed.emplace(block_pair, get_block_counters(agent_id, instance));
+            }
+        }
+    }
+
+    // Check if the block count > max count
+    for(auto& [block_name, count] : counter_count)
+    {
+        if(auto* max = CHECK_NOTNULL(common::get_val(max_allowed, block_name)); count > *max)
+        {
+            return ROCPROFILER_STATUS_ERROR_EXCEEDS_HW_LIMIT;
+        }
+    }
+    return ROCPROFILER_STATUS_SUCCESS;
+}
+
 }  // namespace aql
 }  // namespace rocprofiler

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/aql/packet_construct.hpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/aql/packet_construct.hpp
@@ -26,6 +26,7 @@
 #include "lib/rocprofiler-sdk/aql/helpers.hpp"
 #include "lib/rocprofiler-sdk/counters/metrics.hpp"
 #include "lib/rocprofiler-sdk/hsa/agent_cache.hpp"
+#include "lib/rocprofiler-sdk/hsa/aql_packet.hpp"
 #include "lib/rocprofiler-sdk/thread_trace/core.hpp"
 
 #include <rocprofiler-sdk/fwd.h>
@@ -130,6 +131,15 @@ public:
 private:
     hsa::TraceMemoryPool tracepool;
 };
+
+std::unique_ptr<hsa::SPMPacket>
+spm_construct_packet(const rocprofiler_agent_id_t                     agent_id,
+                     const std::vector<counters::Metric>&             metrics,
+                     const std::vector<rocprofiler_spm_parameters_t>& spm_parameters);
+
+rocprofiler_status_t
+spm_can_collect(const rocprofiler_agent_id_t         agent_id,
+                const std::vector<counters::Metric>& metrics);
 
 }  // namespace aql
 }  // namespace rocprofiler

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/context/context.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/context/context.cpp
@@ -339,6 +339,7 @@ start_context(rocprofiler_context_id_t context_id)
     auto status = ROCPROFILER_STATUS_SUCCESS;
 
     if(cfg->dispatch_counter_collection) rocprofiler::counters::start_context(cfg);
+    if(cfg->dispatch_spm) status = rocprofiler::spm::start_context(cfg);
     if(cfg->device_thread_trace) cfg->device_thread_trace->start_context();
     if(cfg->dispatch_thread_trace) cfg->dispatch_thread_trace->start_context();
     if(cfg->device_counter_collection) status = rocprofiler::counters::start_agent_ctx(cfg);
@@ -373,6 +374,9 @@ stop_context(rocprofiler_context_id_t idx)
                 {
                     rocprofiler::counters::stop_context(const_cast<context*>(_expected));
                 }
+
+                if(_expected->dispatch_spm)
+                    rocprofiler::spm::stop_context(const_cast<context*>(_expected));
 
                 if(_expected->device_thread_trace) _expected->device_thread_trace->stop_context();
                 if(_expected->dispatch_thread_trace)

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/context/context.hpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/context/context.hpp
@@ -30,6 +30,7 @@
 #include "lib/rocprofiler-sdk/counters/device_counting.hpp"
 #include "lib/rocprofiler-sdk/external_correlation.hpp"
 #include "lib/rocprofiler-sdk/pc_sampling/types.hpp"
+#include "lib/rocprofiler-sdk/spm/core.hpp"
 #include "lib/rocprofiler-sdk/thread_trace/core.hpp"
 
 #include <rocprofiler-sdk/fwd.h>
@@ -87,6 +88,18 @@ struct dispatch_counter_collection_service
     common::Synchronized<bool> enabled{false};
 };
 
+struct spm_dispatch_counter_collection_service
+{
+    // Contains a SPM collection instance associated with this context.
+    // Contains callback information along with other data needed to collect/process
+    // SPM counters.
+    std::vector<std::shared_ptr<spm::spm_counter_callback_info>> callbacks{};
+    // A flag to state wether or not the counter set is currently enabled. This is primarily
+    // to protect against multithreaded calls to enable a context (and enabling already enabled
+    // counters).
+    common::Synchronized<bool> enabled{false};
+};
+
 struct device_counting_service
 {
     std::unordered_set<uint64_t>                            conf_agents;
@@ -133,6 +146,8 @@ struct context
     std::unique_ptr<pc_sampling_service>                 pc_sampler                  = {};
     std::unique_ptr<thread_trace::DispatchThreadTracer>  dispatch_thread_trace       = {};
     std::unique_ptr<thread_trace::DeviceThreadTracer>    device_thread_trace         = {};
+
+    std::unique_ptr<spm_dispatch_counter_collection_service> dispatch_spm = {};
 
     template <typename KindT>
     bool is_tracing(KindT _kind) const;

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/counters/controller.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/counters/controller.cpp
@@ -85,6 +85,8 @@ CounterController::configure_agent_collection(rocprofiler_context_id_t          
     // cannot coexist in the same context for now.
     if(ctx.pc_sampler) return ROCPROFILER_STATUS_ERROR_CONTEXT_CONFLICT;
 
+    if(ctx.dispatch_spm) return ROCPROFILER_STATUS_ERROR_CONTEXT_CONFLICT;
+
     if(!rocprofiler::buffer::get_buffer(buffer_id) &&
        buffer_id != rocprofiler_buffer_id_t{.handle = 0})
     {
@@ -144,6 +146,8 @@ CounterController::configure_dispatch(rocprofiler_context_id_t                  
     // FIXME: Due to the clock gating issue, counter collection and PC sampling service
     // cannot coexist in the same context for now.
     if(ctx.pc_sampler) return ROCPROFILER_STATUS_ERROR_CONTEXT_CONFLICT;
+
+    if(ctx.dispatch_spm) return ROCPROFILER_STATUS_ERROR_CONTEXT_CONFLICT;
 
     if(!ctx.dispatch_counter_collection)
     {

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/hsa/aql_packet.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/hsa/aql_packet.cpp
@@ -22,6 +22,9 @@
 
 #include "lib/rocprofiler-sdk/hsa/aql_packet.hpp"
 #include "lib/common/logging.hpp"
+#include "lib/rocprofiler-sdk/hsa/agent_cache.hpp"
+#include "lib/rocprofiler-sdk/spm/decode.hpp"
+#include "lib/rocprofiler-sdk/spm/interface.hpp"
 #include "lib/rocprofiler-sdk/thread_trace/dl.hpp"
 
 #include <fmt/core.h>
@@ -300,5 +303,186 @@ CodeobjMarkerAQLPacket::CodeobjMarkerAQLPacket(const TraceMemoryPool& _tracepool
     clear();
 }
 
+SPMMemoryPool::SPMMemoryPool(const AgentCache& agent, const AmdExtTable& ext, copy_fn_t copy_fn)
+{
+    allocate_fn     = ext.hsa_amd_memory_pool_allocate_fn;
+    allow_access_fn = ext.hsa_amd_agents_allow_access_fn;
+    free_fn         = ext.hsa_amd_memory_pool_free_fn;
+    fill_fn         = ext.hsa_amd_memory_fill_fn;
+    api_copy_fn     = copy_fn;
+
+    gpu_agent = agent.get_hsa_agent();
+    cpu_pool_ = agent.cpu_pool();
+}
+
+void
+SPMMemoryPool::Free(void* ptr, void* data)
+{
+    if(ptr == nullptr) return;
+    auto* pool = reinterpret_cast<SPMMemoryPool*>(data);
+
+    ROCP_FATAL_IF(!pool || !pool->free_fn) << "Unable to deallocate from HSA memory pool";
+    pool->free_fn(ptr);
+}
+
+hsa_status_t
+SPMMemoryPool::Copy(void* dst, const void* src, size_t size, void* data)
+{
+    if(size == 0) return HSA_STATUS_SUCCESS;
+    auto* pool = reinterpret_cast<SPMMemoryPool*>(data);
+    ROCP_FATAL_IF(!pool || !pool->api_copy_fn) << "Unable to copy HSA memory";
+
+    return pool->api_copy_fn(dst, src, size);
+}
+
+hsa_status_t
+SPMMemoryPool::Alloc(void** ptr, size_t size, aqlprofile_buffer_desc_flags_t flags, void* data)
+{
+    hsa_status_t status = HSA_STATUS_ERROR;
+
+    if(size == 0)
+    {
+        if(ptr != nullptr) *ptr = nullptr;
+        return HSA_STATUS_SUCCESS;
+    }
+
+    if(!ptr) return HSA_STATUS_ERROR;
+    if(!data) return HSA_STATUS_ERROR;
+
+    auto& pool = *reinterpret_cast<SPMMemoryPool*>(data);
+    if(!flags.host_access || !pool.allocate_fn || !pool.free_fn || !pool.allow_access_fn ||
+       !pool.fill_fn)
+        return HSA_STATUS_ERROR;
+
+    status = pool.allocate_fn(pool.cpu_pool_, size, hsa_amd_memory_pool_executable_flag, ptr);
+    if(status != HSA_STATUS_SUCCESS)
+    {
+        ROCP_FATAL << "Could not allocate memory";
+        return status;
+    }
+
+    return status;
+}
+
+SPMPacket::SPMPacket(aqlprofile_agent_handle_t                 aql_agent,
+                     std::shared_ptr<SPMMemoryPool>            _pool,
+                     std::vector<aqlprofile_pmc_event_t>&&     events,
+                     std::vector<aqlprofile_spm_parameter_t>&& params)
+: pool(std::move(_pool))
+{
+    profile.aql_events = std::move(events);
+    profile.aql_params = std::move(params);
+
+    sym = rocprofiler::spm::construct_spm_interface();
+    if(!sym)
+    {
+        ROCP_ERROR << "Failed to construct SPM interface";
+        return;
+    }
+    aqlprofile_spm_profile_t aql_profile{.aql_agent       = aql_agent,
+                                         .hsa_agent       = pool->gpu_agent,
+                                         .events          = profile.aql_events.data(),
+                                         .event_count     = profile.aql_events.size(),
+                                         .parameters      = profile.aql_params.data(),
+                                         .parameter_count = profile.aql_params.size(),
+                                         .reserved        = 0,
+                                         .alloc_cb        = &(hsa::SPMMemoryPool::Alloc),
+                                         .dealloc_cb      = &(hsa::SPMMemoryPool::Free),
+                                         .memcpy_cb       = &(hsa::SPMMemoryPool::Copy),
+                                         .userdata        = pool.get()};
+
+    auto status =
+        sym->spm_create_packets(&handle, &profile.aql_desc, &profile.packets, aql_profile, 0);
+    if(status != HSA_STATUS_SUCCESS)
+    {
+        ROCP_ERROR << "spm_create_packets failed with HSA status: " << status
+                   << " (event_count=" << profile.aql_events.size() << ")";
+        return;
+    }
+    profile.packets.start_packet.header            = VENDOR_BIT | BARRIER_BIT;
+    profile.packets.stop_packet.header             = VENDOR_BIT | BARRIER_BIT;
+    profile.packets.start_packet.completion_signal = hsa_signal_t{.handle = 0};
+    profile.packets.stop_packet.completion_signal  = hsa_signal_t{.handle = 0};
+
+    status = sym->spm_decode_query(
+        profile.aql_desc, AQLPROFILE_SPM_DECODE_QUERY_SEG_SIZE, &profile.spm_desc.seg_size);
+    if(status != HSA_STATUS_SUCCESS) return;
+    status = sym->spm_decode_query(
+        profile.aql_desc, AQLPROFILE_SPM_DECODE_QUERY_NUM_XCC, &profile.spm_desc.buffer_num);
+    if(status != HSA_STATUS_SUCCESS) return;
+
+    is_valid = true;
+    empty    = false;
+}
+
+void
+SPMPacket::populate_before()
+{
+    hsa_barrier_and_packet_t barrier{};
+    barrier.header = HSA_PACKET_TYPE_BARRIER_AND << HSA_PACKET_HEADER_TYPE;
+    barrier.header |= BARRIER_BIT;
+
+    before_krn_barrier_pkt.push_back(barrier);
+    before_krn_barrier_pkt.push_back(barrier);
+    before_krn_pkt.push_back(profile.packets.start_packet);
+};
+
+void
+SPMPacket::populate_after()
+{
+    after_krn_pkt.push_back(profile.packets.stop_packet);
+};
+
+bool
+SPMPacket::kfd_start()
+{
+    ROCP_FATAL_IF(!handle.handle) << "Attempt at starting SPM with uninitialized packet!";
+
+    bool success = false;
+    running.wlock([&](auto& _running) {
+        if(_running == true)
+        {
+            ROCP_WARNING << "Double call to KFD start!";
+            success = true;
+            return;
+        }
+        auto status = sym->spm_start(this->handle, spm::aql_data_callback, this);
+        ROCP_FATAL_IF(status != HSA_STATUS_SUCCESS) << "Unable to acquire KFD thread: " << status;
+        _running = true;
+        success  = true;
+    });
+    return success;
+}
+
+bool
+SPMPacket::kfd_stop()
+{
+    bool success = false;
+    running.wlock([&](auto& _running) {
+        if(_running == false)
+        {
+            ROCP_WARNING << "Double call to KFD stop!";
+            success = true;
+            return;
+        }
+        auto status = sym->spm_stop(this->handle);
+        ROCP_FATAL_IF(status != HSA_STATUS_SUCCESS)
+            << "spm_stop failed with HSA status: " << status;
+        _running = false;
+        success  = true;
+    });
+    return success;
+}
+
+SPMPacket::~SPMPacket()
+{
+    running.wlock([&](auto& _running) {
+        if(_running == false) return;
+        auto status = sym->spm_stop(this->handle);
+        ROCP_WARNING_IF(status != HSA_STATUS_SUCCESS)
+            << "spm_stop failed with HSA status: " << status;
+        _running = false;
+    });
+}
 }  // namespace hsa
 }  // namespace rocprofiler

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/hsa/aql_packet.hpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/hsa/aql_packet.hpp
@@ -24,16 +24,42 @@
 
 #include "lib/aqlprofile/aqlprofile.hpp"
 #include "lib/common/container/small_vector.hpp"
+#include "lib/common/synchronized.hpp"
 
+#include <rocprofiler-sdk/experimental/spm.h>
 #include <rocprofiler-sdk/hsa.h>
+#include <rocprofiler-sdk/rocprofiler.h>
 
 #include <hsa/hsa_ext_amd.h>
 #include <hsa/hsa_ven_amd_aqlprofile.h>
 
+#include <atomic>
+#include <cstddef>
 #include <optional>
 
 namespace rocprofiler
 {
+namespace spm
+{
+/**
+ * @brief hsa::SPMPacket contains spm_descriptor_t
+ * aqlprofile_spm_buffer_desc_t is returned from aqlprofile
+ * aqlprofile_spm_buffer_desc_t has the metadata needed to decode the packet
+ * Data contains spm_desc_v0_t + event_map + data in aqlprofile_spm_buffer_desc_t
+ * size = sizeof(spm_desc_v0_t) + sizeof(spm_counter_instance_t)*num_events + aql_desc.size
+ * seg_size = output segment size
+ * buffer_num = number of XCCs
+ */
+typedef struct spm_descriptor_t
+{
+    void*  data{nullptr};
+    size_t size{0};
+    size_t seg_size{0};
+    size_t buffer_num{0};
+} spm_descriptor_t;
+struct spm_interface;
+}  // namespace spm
+
 namespace aql
 {
 class CounterPacketConstruct;
@@ -78,6 +104,7 @@ public:
     {
         before_krn_pkt.clear();
         after_krn_pkt.clear();
+        before_krn_barrier_pkt.clear();
     }
     bool isEmpty() const { return empty; }
 
@@ -88,8 +115,9 @@ public:
     aqlprofile_handle_t handle = {.handle = 0};
     bool                empty  = {true};
 
-    common::container::small_vector<hsa_ext_amd_aql_pm4_packet_t, 3> before_krn_pkt = {};
-    common::container::small_vector<hsa_ext_amd_aql_pm4_packet_t, 2> after_krn_pkt  = {};
+    common::container::small_vector<hsa_ext_amd_aql_pm4_packet_t, 3> before_krn_pkt         = {};
+    common::container::small_vector<hsa_ext_amd_aql_pm4_packet_t, 2> after_krn_pkt          = {};
+    common::container::small_vector<hsa_barrier_and_packet_t, 2>     before_krn_barrier_pkt = {};
 };
 
 class EmptyAQLPacket : public AQLPacket
@@ -264,6 +292,80 @@ public:
 private:
     size_t                                    current_buffer{0};
     std::vector<hsa_ext_amd_aql_pm4_packet_t> buffer_swap{};
+};
+struct SPMMemoryPool
+{
+    using desc_t                                            = aqlprofile_buffer_desc_flags_t;
+    using copy_fn_t                                         = decltype(hsa_memory_copy);
+    hsa_agent_t                             gpu_agent       = {.handle = 0};
+    hsa_amd_memory_pool_t                   cpu_pool_       = {.handle = 0};
+    hsa_amd_memory_pool_t                   gpu_pool_       = {.handle = 0};
+    hsa_amd_memory_pool_t                   kernarg_pool_   = {.handle = 0};
+    decltype(hsa_amd_memory_pool_allocate)* allocate_fn     = nullptr;
+    decltype(hsa_amd_agents_allow_access)*  allow_access_fn = nullptr;
+    decltype(hsa_amd_memory_pool_free)*     free_fn         = nullptr;
+    decltype(hsa_memory_copy)*              api_copy_fn     = nullptr;
+    decltype(hsa_amd_memory_fill)*          fill_fn         = nullptr;
+
+    SPMMemoryPool(const class AgentCache& agent, const class AmdExtTable& ext, copy_fn_t copy_fn);
+    ~SPMMemoryPool()                    = default;
+    SPMMemoryPool(const SPMMemoryPool&) = delete;
+    SPMMemoryPool& operator=(const SPMMemoryPool&) = delete;
+    explicit SPMMemoryPool()                       = default;
+    static hsa_status_t Alloc(void**                         ptr,
+                              size_t                         size,
+                              aqlprofile_buffer_desc_flags_t flags,
+                              void*                          data);
+    static void         Free(void* ptr, void* data);
+    static hsa_status_t Copy(void* dst, const void* src, size_t size, void* data);
+};
+
+struct SPMCallbackContext
+{
+    std::optional<rocprofiler_buffer_id_t>           buffer;
+    rocprofiler_user_data_t                          user_data{};
+    void*                                            record_callback_args{};
+    rocprofiler_spm_dispatch_counting_record_cb_t    record_cb{};
+    rocprofiler_spm_dispatch_counting_service_data_t dispatch_data{};
+};
+
+struct SPMProfileData
+{
+    aqlprofile_spm_buffer_desc_t            aql_desc{};
+    rocprofiler::spm::spm_descriptor_t      spm_desc{};
+    std::shared_ptr<std::vector<char>>      container_desc_data{};
+    aqlprofile_spm_aql_packets_t            packets{};
+    std::vector<aqlprofile_pmc_event_t>     aql_events{};
+    std::vector<aqlprofile_spm_parameter_t> aql_params{};
+};
+
+class SPMPacket : public AQLPacket
+{
+public:
+    SPMPacket(aqlprofile_agent_handle_t                 aql_agent,
+              std::shared_ptr<SPMMemoryPool>            _pool,
+              std::vector<aqlprofile_pmc_event_t>&&     events,
+              std::vector<aqlprofile_spm_parameter_t>&& params);
+
+    ~SPMPacket() override;
+    SPMPacket& operator=(const SPMPacket&) = delete;
+    SPMPacket(const SPMPacket&)            = delete;
+
+    bool        kfd_start();
+    bool        kfd_stop();
+    hsa_agent_t GetAgent() const { return pool ? pool->gpu_agent : hsa_agent_t{}; }
+    void        populate_before() override;
+    void        populate_after() override;
+    bool        valid() const { return is_valid; }
+
+    SPMCallbackContext             cb{};
+    SPMProfileData                 profile{};
+    std::shared_ptr<SPMMemoryPool> pool{};
+    const spm::spm_interface*      sym = nullptr;
+
+private:
+    common::Synchronized<bool> running{false};
+    bool                       is_valid{false};
 };
 
 }  // namespace hsa

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/hsa/queue.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/hsa/queue.cpp
@@ -640,6 +640,16 @@ WriteInterceptor(const void* packets,
 
             for(const auto& pkt_injection : _packet_data.instrumentation_packets)
             {
+                if(!pkt_injection.first->before_krn_barrier_pkt.empty())
+                {
+                    for(const auto& pkt : pkt_injection.first->before_krn_barrier_pkt)
+                    {
+                        transformed_packets.emplace_back(pkt);
+                    }
+                }
+            }
+            for(const auto& pkt_injection : _packet_data.instrumentation_packets)
+            {
                 for(const auto& pkt : pkt_injection.first->before_krn_pkt)
                 {
                     inserted_before = true;
@@ -821,7 +831,7 @@ Queue::Queue(const AgentCache&  agent,
 
     if(!context::get_registered_contexts([](const context::context* ctx) {
             return (ctx->dispatch_counter_collection || ctx->device_counter_collection ||
-                    ctx->dispatch_thread_trace || ctx->device_thread_trace);
+                    ctx->dispatch_spm || ctx->dispatch_thread_trace || ctx->device_thread_trace);
         }).empty())
     {
         CHECK(_agent.cpu_pool().handle != 0);

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/hsa/queue_controller.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/hsa/queue_controller.cpp
@@ -504,7 +504,7 @@ enable_queue_intercept()
 {
     for(const auto& itr : context::get_registered_contexts())
     {
-        constexpr auto expected_context_size = 216UL;
+        constexpr auto expected_context_size = 224UL;
         static_assert(
             sizeof(context::context) == expected_context_size,
             "If you added a new field to context struct, make sure there is a check here if it "
@@ -517,8 +517,8 @@ enable_queue_intercept()
                                      itr->is_tracing(ROCPROFILER_BUFFER_TRACING_SCRATCH_MEMORY);
 
         if(itr->dispatch_counter_collection || itr->pc_sampler || has_kernel_tracing ||
-           has_scratch_reporting || itr->device_counter_collection || itr->device_thread_trace ||
-           itr->dispatch_thread_trace)
+           itr->dispatch_spm || has_scratch_reporting || itr->device_counter_collection ||
+           itr->device_thread_trace || itr->dispatch_thread_trace)
             return true;
     }
 

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/pc_sampling/service.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/pc_sampling/service.cpp
@@ -174,6 +174,8 @@ configure_pc_sampling_service(context::context*                ctx,
         return ROCPROFILER_STATUS_ERROR_CONTEXT_CONFLICT;
     }
 
+    if(ctx->dispatch_spm) return ROCPROFILER_STATUS_ERROR_CONTEXT_CONFLICT;
+
     // Check if this agent is already configured by another context. If so, report an error.
     // Otherwise, register the session.
     return get_global_pc_sampling_sessions().wlock([&](auto& sessions) -> rocprofiler_status_t {

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/spm/CMakeLists.txt
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/spm/CMakeLists.txt
@@ -1,4 +1,8 @@
-set(ROCPROFILER_LIB_SPM_SOURCES interface.cpp)
-set(ROCPROFILER_LIB_SPM_HEADERS interface.hpp)
+set(ROCPROFILER_LIB_SPM_SOURCES core.cpp service.cpp decode.cpp interface.cpp
+                                dispatch_handlers.cpp)
+set(ROCPROFILER_LIB_SPM_HEADERS core.hpp interface.hpp decode.hpp dispatch_handlers.hpp)
 target_sources(rocprofiler-sdk-object-library PRIVATE ${ROCPROFILER_LIB_SPM_SOURCES}
                                                       ${ROCPROFILER_LIB_SPM_HEADERS})
+if(ROCPROFILER_BUILD_TESTS)
+    add_subdirectory(tests)
+endif()

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/spm/core.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/spm/core.cpp
@@ -1,0 +1,350 @@
+// MIT License
+//
+// Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#include "lib/rocprofiler-sdk/spm/core.hpp"
+#include "lib/common/utility.hpp"
+#include "lib/rocprofiler-sdk/context/context.hpp"
+#include "lib/rocprofiler-sdk/counters/metrics.hpp"
+#include "lib/rocprofiler-sdk/hsa/queue_controller.hpp"
+#include "lib/rocprofiler-sdk/spm/dispatch_handlers.hpp"
+
+#include <rocprofiler-sdk/rocprofiler.h>
+
+#include <atomic>
+#include <cstdint>
+#include <stdexcept>
+#include <vector>
+
+namespace rocprofiler
+{
+namespace spm
+{
+/**
+ *This is a singleton class with lazy initialization
+ */
+class SpmCounterController
+{
+public:
+    SpmCounterController() = default;
+    // Adds a counter collection profile to our global cache.
+    // Note: these profiles can be used across multiple contexts
+    //       and are independent of the context.
+    void spm_add_profile(std::shared_ptr<spm_counter_config>&& config);
+
+    rocprofiler_status_t spm_destroy_profile(rocprofiler_counter_config_id_t id);
+
+    std::shared_ptr<spm_counter_config> get_profile_cfg(rocprofiler_counter_config_id_t id);
+
+private:
+    // Cache to contain the map of config id handle to spm counter config
+    common::Synchronized<
+        std::unordered_map<rocprofiler_counter_config_id_t, std::shared_ptr<spm_counter_config>>>
+        _configs;
+};
+
+SpmCounterController&
+spm_get_controller()
+{
+    static auto* controller = rocprofiler::common::static_object<SpmCounterController>::construct();
+    return *CHECK_NOTNULL(controller);
+}
+
+/**
+ * @brief The functions checks if the `ROCPROFILER_SPM_BETA_ENABLED` is set.
+ * If so, it will enable SPM service. Otherwise, the API is reported
+ * as not implemented.
+ *
+ * The SPM is in experimental phase .
+   By enabling the `ROCPROFILER_SPM_BETA_ENABLED`,
+ * user accepts all consequences of using early implementation of SPM API.
+ */
+bool
+is_spm_explicitly_enabled()
+{
+    auto spm_sampling_enabled = rocprofiler::common::get_env("ROCPROFILER_SPM_BETA_ENABLED", false);
+
+    if(!spm_sampling_enabled)
+        ROCP_INFO << " SPM unavailable. The feature is implicitly disabled. "
+                  << "To use it on a supported architecture, "
+                  << "set ROCPROFILER_SPM_BETA_ENABLED=ON in the environment";
+
+    return spm_sampling_enabled;
+}
+
+/**
+ * Adds a counter collection profile to our global cache.
+ * Note: these profiles can be used across multiple contexts and are independent of the context.
+ * Note: these profiles are per agent
+ * Assigns the config id and increments the monotonic counter.
+ */
+void
+SpmCounterController::spm_add_profile(std::shared_ptr<spm_counter_config>&& config)
+{
+    // Offset from PMC counter IDs (which start at 1) to avoid config ID collision
+    // since both share rocprofiler_counter_config_id_t
+    static std::atomic<uint64_t> profile_val{1};
+
+    _configs.wlock([&](auto& data) {
+        config->id = rocprofiler_counter_config_id_t{.handle = profile_val};
+        data.emplace(config->id, std::move(config));
+        profile_val++;
+    });
+}
+
+/**
+ * @brief Removes the profile entry from the global cache
+ */
+rocprofiler_status_t
+SpmCounterController::spm_destroy_profile(rocprofiler_counter_config_id_t id)
+{
+    return _configs.wlock([&](auto& data) {
+        auto itr = data.find(id);
+        if(itr == data.end()) return ROCPROFILER_STATUS_ERROR_PROFILE_NOT_FOUND;
+        if(data.erase(id) != 1) return ROCPROFILER_STATUS_ERROR;
+        return ROCPROFILER_STATUS_SUCCESS;
+    });
+}
+
+/**
+ * @brief Queries the global cache for the config using config id
+ */
+std::shared_ptr<spm_counter_config>
+SpmCounterController::get_profile_cfg(rocprofiler_counter_config_id_t id)
+{
+    std::shared_ptr<spm_counter_config> cfg = nullptr;
+    _configs.rlock([&](const auto& map) {
+        auto it = map.find(id);
+        if(it != map.end()) cfg = it->second;
+    });
+    return cfg;
+}
+
+rocprofiler_status_t
+destroy_spm_counter_profile(rocprofiler_counter_config_id_t id)
+{
+    return spm_get_controller().spm_destroy_profile(id);
+}
+
+/**
+ * @brief looks into the config's packet cache to re-use the packet
+ * If not, constructs the packet using packet generator
+ * updates packet_return map
+ */
+rocprofiler_status_t
+get_spm_packet(std::unique_ptr<rocprofiler::hsa::AQLPacket>& ret_pkt,
+               std::shared_ptr<spm_counter_config>&          profile)
+{
+    profile->packets.wlock([&](auto& pkt_vector) {
+        if(!pkt_vector.empty())
+        {
+            ret_pkt = std::move(pkt_vector.back());
+            pkt_vector.pop_back();
+        }
+    });
+
+    if(!ret_pkt)
+    {
+        // If we do not have a packet in the cache, create one.
+        ret_pkt = rocprofiler::aql::spm_construct_packet(
+            CHECK_NOTNULL(profile->agent)->id,
+            std::vector<counters::Metric>{profile->metrics.begin(), profile->metrics.end()},
+            profile->spm_parameters);
+        if(!ret_pkt)
+        {
+            ROCP_ERROR << "SPM packet construction failed";
+            return ROCPROFILER_STATUS_ERROR;
+        }
+    };
+
+    return ROCPROFILER_STATUS_SUCCESS;
+}
+
+/** @brief  Creates spm the counter config
+ * Checks if the input counters does not exceed hardware limit
+ * Adds the config to configs cache
+ */
+rocprofiler_status_t
+create_spm_counter_profile(std::shared_ptr<spm_counter_config> config)
+{
+    auto status = ROCPROFILER_STATUS_SUCCESS;
+    if(status = rocprofiler::aql::spm_can_collect(config->agent->id, config->metrics);
+       status != ROCPROFILER_STATUS_SUCCESS)
+    {
+        return status;
+    }
+
+    spm_get_controller().spm_add_profile(std::move(config));
+
+    return status;
+}
+
+std::shared_ptr<spm_counter_config>
+get_spm_counter_config(rocprofiler_counter_config_id_t id)
+{
+    try
+    {
+        return spm_get_controller().get_profile_cfg(id);
+    } catch(std::out_of_range&)
+    {
+        return nullptr;
+    }
+}
+
+/** @brief  Configures SPM dispatch for the context
+ * Checks for conflicting services
+ * Instantiates spm_dispatch_counter_collection_service
+ */
+rocprofiler_status_t
+configure_callback_spm_dispatch(rocprofiler_context_id_t                       context_id,
+                                rocprofiler_spm_dispatch_counting_service_cb_t callback,
+                                void*                                          callback_args,
+                                rocprofiler_spm_dispatch_counting_record_cb_t  record_callback,
+                                void*                                          record_callback_args)
+{
+    auto* ctx_p = rocprofiler::context::get_mutable_registered_context(context_id);
+    if(!ctx_p) return ROCPROFILER_STATUS_ERROR_CONTEXT_INVALID;
+
+    auto& ctx = *ctx_p;
+
+    // FIXME: Due to the clock gating issue, counter collection and PC sampling service
+    // cannot coexist in the same context for now.
+    if(ctx.pc_sampler) return ROCPROFILER_STATUS_ERROR_CONTEXT_CONFLICT;
+    if(ctx.dispatch_counter_collection) return ROCPROFILER_STATUS_ERROR_CONTEXT_CONFLICT;
+    if(ctx.device_counter_collection) return ROCPROFILER_STATUS_ERROR_CONTEXT_CONFLICT;
+    if(!ctx.dispatch_spm)
+        ctx.dispatch_spm =
+            std::make_unique<rocprofiler::context::spm_dispatch_counter_collection_service>();
+    auto& cb = *ctx.dispatch_spm->callbacks.emplace_back(
+        std::make_shared<rocprofiler::spm::spm_counter_callback_info>());
+
+    cb.user_cb              = callback;
+    cb.callback_args        = callback_args;
+    cb.context              = context_id;
+    cb.record_callback      = record_callback;
+    cb.record_callback_args = record_callback_args;
+    cb.internal_context     = ctx_p;
+
+    return ROCPROFILER_STATUS_SUCCESS;
+}
+
+/** @brief start SPM dispatch context
+ * Enables serialization
+ * Returns if callback has already been added by checking the queue id
+ * Adds a pre kernel and a post kernel callback
+ * Enabled flag is used to check if context has already been enabled
+ */
+
+rocprofiler_status_t
+start_context(const context::context* ctx)
+{
+    if(!ctx || !ctx->dispatch_spm) return ROCPROFILER_STATUS_ERROR;
+
+    auto* controller = hsa::get_queue_controller();
+
+    bool already_enabled = true;
+    CHECK_NOTNULL(controller)->enable_serialization();
+    ctx->dispatch_spm->enabled.wlock([&](auto& enabled) {
+        if(enabled) return;
+        already_enabled = false;
+        enabled         = true;
+    });
+
+    if(!already_enabled)
+    {
+        // Insert our callbacks into HSA Interceptor. This
+        // turns on counter instrumentation.
+        for(auto& cb : ctx->dispatch_spm->callbacks)
+        {
+            if(cb->queue_id != rocprofiler::hsa::ClientID{-1}) continue;
+            cb->queue_id = controller->add_callback(
+                std::nullopt,
+                hsa::queue_callbacks_t{
+                    .batch_packets = []() { return false; },
+                    .write_interceptor =
+                        [=](const hsa::Queue&              q,
+                            const hsa::rocprofiler_packet& kern_pkt,
+                            rocprofiler_kernel_id_t        kernel_id,
+                            rocprofiler_dispatch_id_t      dispatch_id,
+                            rocprofiler_user_data_t*       user_data,
+                            const hsa::queue_info_session_t::external_corr_id_map_t&
+                                                           extern_corr_ids,
+                            const context::correlation_id* correlation_id) {
+                            return pre_kernel_call(ctx,
+                                                   cb,
+                                                   q,
+                                                   kern_pkt,
+                                                   kernel_id,
+                                                   dispatch_id,
+                                                   user_data,
+                                                   extern_corr_ids,
+                                                   correlation_id);
+                        },
+                    .signal_completion =
+                        [=](const hsa::Queue& /* q */,
+                            const hsa::rocprofiler_packet& /* kern_pkt */,
+                            std::shared_ptr<hsa::queue_info_session_t>& session,
+                            hsa::packet_data_t& /* pkt_data */,
+                            inst_pkt_t&                     aql,
+                            kernel_dispatch::profiling_time dispatch_time) {
+                            post_kernel_call(ctx, cb, session, aql, dispatch_time);
+                        }});
+        }
+    }
+
+    return ROCPROFILER_STATUS_SUCCESS;
+}
+
+/** @brief stop SPM dispatch context
+ * Disables serialization
+ * Sets Enabled flag to false
+ */
+
+void
+stop_context(const context::context* ctx)
+{
+    if(!ctx || !ctx->dispatch_spm) return;
+
+    auto* controller = hsa::get_queue_controller();
+
+    ctx->dispatch_spm->enabled.wlock([&](auto& enabled) {
+        if(!enabled) return;
+        enabled = false;
+    });
+
+    if(controller)
+    {
+        hsa::queue_controller_sync();
+        controller->disable_serialization();
+        for(auto& cb : ctx->dispatch_spm->callbacks)
+        {
+            if(cb->queue_id != rocprofiler::hsa::ClientID{-1})
+            {
+                controller->remove_callback(cb->queue_id);
+                cb->queue_id = rocprofiler::hsa::ClientID{-1};
+            }
+        }
+    }
+}
+
+}  // namespace spm
+
+}  // namespace rocprofiler

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/spm/core.hpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/spm/core.hpp
@@ -1,0 +1,128 @@
+// MIT License
+//
+// Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#pragma once
+
+#include "lib/rocprofiler-sdk/aql/packet_construct.hpp"
+#include "lib/rocprofiler-sdk/hsa/agent_cache.hpp"
+#include "lib/rocprofiler-sdk/hsa/aql_packet.hpp"
+
+#include <rocprofiler-sdk/experimental/spm.h>
+#include <rocprofiler-sdk/cxx/hash.hpp>
+#include <rocprofiler-sdk/cxx/operators.hpp>
+
+#include <cstdint>
+#include <memory>
+#include <unordered_map>
+#include <vector>
+
+namespace rocprofiler
+{
+namespace hsa
+{
+class AQLPacket;
+};
+namespace spm
+{
+/**
+ * @brief  SPM counter config contains SPM parameters and counters
+ * SPM config is per agent
+ * Pkt generator is used to construct the packet, pkt generator can be created before HSA init
+ * Has a packet cache to store the AQLpackets for SPM, it is constructed using the pkt generator.
+ * Its valid function checks if config has parameters and metrics initialized
+ */
+struct spm_counter_config
+{
+    const rocprofiler_agent_t*    agent = nullptr;
+    std::vector<counters::Metric> metrics{};
+
+    std::vector<rocprofiler_spm_parameters_t> spm_parameters{};
+
+    rocprofiler_counter_config_id_t id{.handle = 0};
+    // A packet cache of AQL packets. This allows reuse of AQL packets (preventing costly
+    // allocation of new packets/destruction).
+    common::Synchronized<std::vector<std::unique_ptr<rocprofiler::hsa::AQLPacket>>> packets;
+};
+
+/**
+ * @brief spm_counter_callback_info has the callbacks and user data associated with a context
+ * It has a cache of AQLPackets associated with configs which is used in post kernel callback
+ *    to retrieve the config information for the given AQLPacket
+ *
+ */
+struct spm_counter_callback_info
+{
+    rocprofiler_spm_dispatch_counting_service_cb_t user_cb{nullptr};
+    void*                                          callback_args{nullptr};
+    // Link to the context this is associated with
+    rocprofiler_context_id_t context{.handle = 0};
+    // HSA Queue ClientID. This is an ID we get when we insert a callback into the
+    // HSA queue interceptor. This ID can be used to disable the callback.
+    rocprofiler::hsa::ClientID queue_id{-1};
+    // Buffer to use for storing counter data. Used if callback is not set.
+    std::optional<rocprofiler_buffer_id_t> buffer;
+    // Link to the internal context this is associated with
+    // Internal context is used as a key to obtain external correlation id in pre kernel call
+    const context::context*                       internal_context{nullptr};
+    rocprofiler_spm_dispatch_counting_record_cb_t record_callback{nullptr};
+    void*                                         record_callback_args{nullptr};
+    common::Synchronized<
+        std::unordered_map<rocprofiler::hsa::AQLPacket*, std::shared_ptr<spm_counter_config>>>
+        packet_return_map{};
+};
+
+rocprofiler_status_t
+get_spm_packet(std::unique_ptr<rocprofiler::hsa::AQLPacket>&, std::shared_ptr<spm_counter_config>&);
+
+rocprofiler_status_t
+create_spm_counter_profile(std::shared_ptr<spm_counter_config> config);
+
+rocprofiler_status_t
+destroy_spm_counter_profile(rocprofiler_counter_config_id_t id);
+
+std::shared_ptr<spm_counter_config>
+get_spm_counter_config(rocprofiler_counter_config_id_t id);
+
+rocprofiler_status_t
+configure_callback_spm_dispatch(rocprofiler_context_id_t                       context_id,
+                                rocprofiler_spm_dispatch_counting_service_cb_t callback,
+                                void*                                          callback_data_args,
+                                rocprofiler_spm_dispatch_counting_record_cb_t  record_callback,
+                                void* record_callback_args);
+
+bool
+is_spm_explicitly_enabled();
+
+/*
+ * start dispatch SPM context
+ */
+rocprofiler_status_t
+start_context(const context::context*);
+
+/*
+ * stop dispatch SPM context
+ */
+void
+stop_context(const context::context*);
+
+}  // namespace spm
+}  // namespace rocprofiler

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/spm/decode.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/spm/decode.cpp
@@ -1,0 +1,163 @@
+// MIT License
+//
+// Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#include "lib/rocprofiler-sdk/spm/decode.hpp"
+#include "lib/common/static_object.hpp"
+#include "lib/common/utility.hpp"
+#include "lib/rocprofiler-sdk/agent.hpp"
+#include "lib/rocprofiler-sdk/buffer.hpp"
+#include "lib/rocprofiler-sdk/counters/id_decode.hpp"
+#include "lib/rocprofiler-sdk/hsa/aql_packet.hpp"
+#include "lib/rocprofiler-sdk/spm/interface.hpp"
+
+#include <cstdint>
+#include <memory>
+#include <mutex>
+
+namespace rocprofiler
+{
+namespace spm
+{
+std::mutex&
+get_buffer_mut()
+{
+    static auto*& mut = common::static_object<std::mutex>::construct();
+    return *CHECK_NOTNULL(mut);
+}
+
+void
+decode_cb(uint64_t timestamp, uint64_t value, uint64_t index, int shader_engine, void* userdata)
+{
+    auto& samples   = *reinterpret_cast<spm_sample_vec*>(userdata);
+    bool  is_global = (shader_engine < 0);
+    if(is_global) shader_engine = 0;
+    samples.emplace_back(spm_sample_t{timestamp, value, index, shader_engine, is_global});
+}
+
+/** @brief  Callback for aqlprofile to return SPM data
+ * buffer id - XCC of the data
+ * flags - Indicates if there was a data loss
+ */
+void
+aql_data_callback(size_t buffer_id, void* data, size_t data_size, int flags, void* userdata)
+{
+    auto*                          spm_packet = static_cast<hsa::SPMPacket*>(userdata);
+    auto                           samples    = spm_sample_vec{};
+    rocprofiler::buffer::instance* buf        = nullptr;
+    if(data_size == 0) return;
+
+    auto& desc_v0 = *static_cast<rocprofiler::spm::spm_desc_v0_t*>(
+        CHECK_NOTNULL(spm_packet->profile.spm_desc.data));
+    if(!desc_v0.valid()) return;
+
+    {
+        uint64_t count  = 0;
+        auto     status = spm_packet->sym->spm_decode_query(
+            spm_packet->profile.aql_desc, AQLPROFILE_SPM_DECODE_QUERY_EVENT_COUNT, &count);
+        if(status != HSA_STATUS_SUCCESS) return;
+        if(count != desc_v0.num_events) return;
+    }
+
+    auto status = spm_packet->sym->spm_decode_stream_v1(
+        spm_packet->profile.aql_desc, decode_cb, data, data_size, &samples);
+    if(status != HSA_STATUS_SUCCESS) return;
+
+    auto records     = std::vector<std::unique_ptr<rocprofiler_spm_counter_record_t>>{};
+    auto buf_records = std::vector<rocprofiler_spm_counter_record_t>{};
+
+    if(spm_packet->cb.buffer) buf = buffer::get_buffer(spm_packet->cb.buffer->handle);
+
+    auto agent_id =
+        CHECK_NOTNULL(rocprofiler::agent::get_rocprofiler_agent(spm_packet->GetAgent()))->id;
+    auto dispatch_id = spm_packet->cb.dispatch_data.dispatch_info.dispatch_id;
+
+    for(const auto& s : samples)
+    {
+        if(s.index >= desc_v0.num_events) continue;
+        auto& event = desc_v0.events()[s.index];
+
+        auto instance_id = rocprofiler_counter_instance_id_t{};
+        counters::set_dim_in_rec(
+            instance_id, rocprofiler::counters::ROCPROFILER_DIMENSION_XCC, buffer_id);
+        counters::set_dim_in_rec(
+            instance_id, rocprofiler::counters::ROCPROFILER_DIMENSION_INSTANCE, event.instance);
+        counters::set_counter_in_rec(instance_id, event.id);
+        if(!s.is_global)
+            counters::set_dim_in_rec(instance_id,
+                                     rocprofiler::counters::ROCPROFILER_DIMENSION_SHADER_ENGINE,
+                                     s.shader_engine);
+
+        if(buf)
+        {
+            buf_records.emplace_back(
+                common::init_public_api_struct(rocprofiler_spm_counter_record_t{},
+                                               dispatch_id,
+                                               instance_id,
+                                               agent_id,
+                                               s.timestamp,
+                                               static_cast<double>(s.value)));
+        }
+        else
+        {
+            records.emplace_back(std::make_unique<rocprofiler_spm_counter_record_t>(
+                common::init_public_api_struct(rocprofiler_spm_counter_record_t{},
+                                               dispatch_id,
+                                               instance_id,
+                                               agent_id,
+                                               s.timestamp,
+                                               static_cast<double>(s.value))));
+        }
+    }
+
+    if(buf)
+    {
+        auto _lk = std::unique_lock{get_buffer_mut()};
+
+        buf->emplace(ROCPROFILER_BUFFER_CATEGORY_COUNTERS,
+                     ROCPROFILER_COUNTER_RECORD_PROFILE_COUNTING_DISPATCH_HEADER,
+                     spm_packet->cb.dispatch_data);
+        for(const auto& itr : buf_records)
+        {
+            buf->emplace(
+                ROCPROFILER_BUFFER_CATEGORY_COUNTERS, ROCPROFILER_COUNTER_RECORD_VALUE, itr);
+        }
+    }
+    else if(spm_packet->cb.record_cb)
+    {
+        auto record_ptrs = std::vector<const rocprofiler_spm_counter_record_t*>{};
+        record_ptrs.reserve(records.size());
+        for(const auto& rec : records)
+            record_ptrs.push_back(rec.get());
+
+        spm_packet->cb.record_cb(&(spm_packet->cb.dispatch_data),
+                                 record_ptrs.data(),
+                                 record_ptrs.size(),
+                                 static_cast<rocprofiler_spm_record_flag_t>(
+                                     ROCPROFILER_SPM_RECORD_FLAG_DATA |
+                                     ((flags != 0) ? ROCPROFILER_SPM_RECORD_FLAG_DATA_LOSS : 0)),
+                                 spm_packet->cb.user_data,
+                                 spm_packet->cb.record_callback_args);
+    }
+}
+
+}  // namespace spm
+}  // namespace rocprofiler

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/spm/decode.hpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/spm/decode.hpp
@@ -1,0 +1,83 @@
+// MIT License
+//
+// Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#pragma once
+
+#include <rocprofiler-sdk/fwd.h>
+
+#include <cstddef>
+#include <cstdint>
+#include <vector>
+
+namespace rocprofiler
+{
+namespace spm
+{
+struct spm_sample_t
+{
+    uint64_t timestamp{0};
+    uint64_t value{0};
+    uint64_t index{0};
+    int      shader_engine{0};
+    bool     is_global{false};
+};
+
+using spm_sample_vec = std::vector<spm_sample_t>;
+
+typedef struct spm_counter_instance_t
+{
+    rocprofiler_counter_id_t id{0};
+    uint64_t                 instance{0};
+} spm_counter_instance_t;
+
+/** @brief defines the layout of data buffer from spm_descriptor_t
+ * Event map is the list of spm_counter_instance_t
+ */
+typedef struct spm_desc_v0_t
+{
+    uint64_t version{0};
+    size_t   struct_size{sizeof(spm_desc_v0_t)};
+    uint64_t aql_desc_size{0};
+    uint64_t num_events{0};
+    size_t   event_elem_size{sizeof(spm_counter_instance_t)};
+    uint64_t reserved{0};
+
+    bool valid() const
+    {
+        return version == 0 && aql_desc_size != 0 && struct_size == sizeof(spm_desc_v0_t) &&
+               event_elem_size == sizeof(spm_counter_instance_t);
+    }
+    spm_counter_instance_t* events() { return reinterpret_cast<spm_counter_instance_t*>(this + 1); }
+    void*                   aqlprofile_desc() { return events() + num_events; }
+} spm_desc_v0_t;
+
+static_assert((sizeof(spm_desc_v0_t) % sizeof(spm_counter_instance_t)) == 0,
+              "invalid descriptor and counter combination");
+
+void
+decode_cb(uint64_t timestamp, uint64_t value, uint64_t index, int shader_engine, void* userdata);
+
+void
+aql_data_callback(size_t len, void* data, size_t data_len, int flags, void* userdata);
+
+}  // namespace spm
+}  // namespace rocprofiler

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/spm/dispatch_handlers.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/spm/dispatch_handlers.cpp
@@ -1,0 +1,268 @@
+// MIT License
+//
+// Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#include "lib/rocprofiler-sdk/spm/dispatch_handlers.hpp"
+#include "lib/common/utility.hpp"
+#include "lib/rocprofiler-sdk/hsa/queue_controller.hpp"
+
+#include <rocprofiler-sdk/rocprofiler.h>
+
+namespace rocprofiler
+{
+namespace spm
+{
+/**
+ * @brief Async Handler for barrier=packet1 completion signal
+ * Destroys the barrier-packet1 completion signal
+ * Sets the dependency signal of barrier packet-2 to 0, so that barrier-packet2 can complete
+ * This guarantees that SPM has been started before the dispatch
+ **/
+bool
+AsyncSignalHandler(hsa_signal_value_t /*signal_v*/, void* data)
+{
+    auto* pkt    = CHECK_NOTNULL(static_cast<hsa::AQLPacket*>(data));
+    auto* packet = CHECK_NOTNULL(dynamic_cast<hsa::SPMPacket*>(pkt));
+
+    if(!packet->kfd_start())
+    {
+        ROCP_ERROR << "SPM KFD start failed in async signal handler";
+    }
+
+    CHECK_NOTNULL(hsa::get_queue_controller())
+        ->get_core_table()
+        .hsa_signal_destroy_fn(packet->before_krn_barrier_pkt.at(0).completion_signal);
+    CHECK_NOTNULL(hsa::get_queue_controller())
+        ->get_core_table()
+        .hsa_signal_store_screlease_fn(packet->before_krn_barrier_pkt.at(1).dep_signal[0], 0);
+    return false;
+}
+
+namespace
+{
+hsa_status_t
+setup_spm_barrier_signals(hsa::SPMPacket& spm_pkt)
+{
+    auto& signal_to_start_kfd    = spm_pkt.before_krn_barrier_pkt.at(0).completion_signal;
+    auto& signal_kfd_has_started = spm_pkt.before_krn_barrier_pkt.at(1).dep_signal[0];
+
+    auto* queue_controller = CHECK_NOTNULL(hsa::get_queue_controller());
+
+    auto status_signal_to_start_kfd = queue_controller->get_ext_table().hsa_amd_signal_create_fn(
+        1, 0, nullptr, 0, &signal_to_start_kfd);
+    auto status_signal_kfd_has_started = queue_controller->get_ext_table().hsa_amd_signal_create_fn(
+        1, 0, nullptr, 0, &signal_kfd_has_started);
+
+    if(status_signal_to_start_kfd != HSA_STATUS_SUCCESS ||
+       status_signal_kfd_has_started != HSA_STATUS_SUCCESS)
+    {
+        if(status_signal_to_start_kfd == HSA_STATUS_SUCCESS)
+            queue_controller->get_core_table().hsa_signal_destroy_fn(signal_to_start_kfd);
+        if(status_signal_kfd_has_started == HSA_STATUS_SUCCESS)
+            queue_controller->get_core_table().hsa_signal_destroy_fn(signal_kfd_has_started);
+        return HSA_STATUS_ERROR;
+    }
+
+    queue_controller->get_core_table().hsa_signal_store_screlease_fn(signal_kfd_has_started, -1);
+    queue_controller->get_core_table().hsa_signal_store_screlease_fn(signal_to_start_kfd, 0);
+
+    auto status_async_handler = queue_controller->get_ext_table().hsa_amd_signal_async_handler_fn(
+        signal_to_start_kfd,
+        HSA_SIGNAL_CONDITION_EQ,
+        -1,
+        rocprofiler::spm::AsyncSignalHandler,
+        &spm_pkt);
+
+    if(status_async_handler != HSA_STATUS_SUCCESS && status_async_handler != HSA_STATUS_INFO_BREAK)
+    {
+        queue_controller->get_core_table().hsa_signal_destroy_fn(signal_to_start_kfd);
+        queue_controller->get_core_table().hsa_signal_destroy_fn(signal_kfd_has_started);
+        ROCP_WARNING << "hsa_amd_signal_async_handler failed with error code "
+                     << status_async_handler
+                     << " :: " << hsa::get_hsa_status_string(status_async_handler);
+        return HSA_STATUS_ERROR;
+    }
+
+    return HSA_STATUS_SUCCESS;
+}
+}  // namespace
+
+/**
+ * @brief Callback we get from HSA interceptor when a kernel packet is being enqueued.
+ * We return an AQLPacket containing the start/stop .
+ * Barrier_packet1-barrier_packet2-SPM Start Packet - kernel packets- SPM stop packet
+ * AsyncSignalHandler - barrier-packet1 completion signal handler
+ * barrier-packet2 - dependency signal- initialized to value -1
+ * Update callback, user data, and dispatch data in the SPM packet
+ * handshake protocol with aqlprofile SPM start kfd - SPM start packet- kernel dispatch - SPM stop
+ * packet - SPM stop KFD
+ */
+hsa::write_packet_t
+pre_kernel_call(const context::context*                                  ctx,
+                const std::shared_ptr<spm_counter_callback_info>&        info,
+                const hsa::Queue&                                        queue,
+                const hsa::rocprofiler_packet&                           pkt,
+                uint64_t                                                 kernel_id,
+                rocprofiler_dispatch_id_t                                dispatch_id,
+                rocprofiler_user_data_t*                                 user_data,
+                const hsa::queue_info_session_t::external_corr_id_map_t& extern_corr_ids,
+                const context::correlation_id*                           correlation_id)
+{
+    CHECK(info && ctx);
+    auto no_instrumentation = [&]() {
+        auto ret_pkt = std::make_unique<rocprofiler::hsa::EmptyAQLPacket>();
+        info->packet_return_map.wlock([&](auto& data) { data.emplace(ret_pkt.get(), nullptr); });
+        // If we have a SPM counter collection context but it is not enabled, we still might need
+        // to add barrier packets to transition from serialized -> unserialized execution. This
+        // transition is coordinated by the serializer.
+        return ret_pkt;
+    };
+
+    if(!ctx || !ctx->dispatch_spm) return {nullptr, false};
+
+    bool is_enabled = false;
+    ctx->dispatch_spm->enabled.rlock([&](const auto& collect_ctx) { is_enabled = collect_ctx; });
+
+    if(!is_enabled || !info->user_cb) return {no_instrumentation(), true};
+
+    auto _corr_id_v =
+        rocprofiler_async_correlation_id_t{.internal = 0, .external = context::null_user_data};
+    if(const auto* _corr_id = correlation_id)
+    {
+        _corr_id_v.internal = _corr_id->internal;
+        if(const auto* external =
+               rocprofiler::common::get_val(extern_corr_ids, info->internal_context))
+        {
+            _corr_id_v.external = *external;
+        }
+    }
+
+    auto req_profile = rocprofiler_counter_config_id_t{.handle = 0};
+    auto dispatch_data =
+        common::init_public_api_struct(rocprofiler_spm_dispatch_counting_service_data_t{});
+
+    dispatch_data.correlation_id = _corr_id_v;
+
+    auto dispatch_info      = common::init_public_api_struct(rocprofiler_kernel_dispatch_info_t{});
+    dispatch_info.kernel_id = kernel_id;
+    dispatch_info.dispatch_id          = dispatch_id;
+    dispatch_info.agent_id             = CHECK_NOTNULL(queue.get_agent().get_rocp_agent())->id;
+    dispatch_info.queue_id             = queue.get_id();
+    dispatch_info.private_segment_size = pkt.kernel_dispatch.private_segment_size;
+    dispatch_info.group_segment_size   = pkt.kernel_dispatch.group_segment_size;
+    dispatch_info.workgroup_size       = {pkt.kernel_dispatch.workgroup_size_x,
+                                    pkt.kernel_dispatch.workgroup_size_y,
+                                    pkt.kernel_dispatch.workgroup_size_z};
+    dispatch_info.grid_size            = {pkt.kernel_dispatch.grid_size_x,
+                               pkt.kernel_dispatch.grid_size_y,
+                               pkt.kernel_dispatch.grid_size_z};
+    dispatch_data.dispatch_info        = dispatch_info;
+
+    info->user_cb(&dispatch_data, &req_profile, user_data, info->callback_args);
+
+    if(req_profile.handle == 0) return {no_instrumentation(), true};
+
+    auto prof_config = get_spm_counter_config(req_profile);
+    CHECK(prof_config);
+
+    std::unique_ptr<rocprofiler::hsa::AQLPacket> ret_pkt    = nullptr;
+    auto                                         ret_status = get_spm_packet(ret_pkt, prof_config);
+
+    CHECK_EQ(ret_status, ROCPROFILER_STATUS_SUCCESS) << rocprofiler_get_status_string(ret_status);
+
+    if(!ret_pkt->empty)
+    {
+        auto* spm_pkt = CHECK_NOTNULL(dynamic_cast<hsa::SPMPacket*>(ret_pkt.get()));
+        spm_pkt->clear();
+        spm_pkt->populate_before();
+        spm_pkt->populate_after();
+
+        spm_pkt->cb.dispatch_data = dispatch_data;
+        spm_pkt->cb.user_data     = *user_data;
+        if(info->buffer)
+            spm_pkt->cb.buffer = info->buffer;
+        else
+        {
+            spm_pkt->cb.record_cb            = info->record_callback;
+            spm_pkt->cb.record_callback_args = info->record_callback_args;
+        }
+
+        if(setup_spm_barrier_signals(*spm_pkt) != HSA_STATUS_SUCCESS)
+        {
+            ROCP_WARNING << "SPM signal creation failed, skipping instrumentation";
+            return {no_instrumentation(), true};
+        }
+
+        info->packet_return_map.wlock(
+            [&](auto& data) { data.emplace(ret_pkt.get(), prof_config); });
+    }
+    return {std::move(ret_pkt), true};
+}
+
+/**
+ * @brief Callback called by HSA interceptor when the kernel has completed processing.
+ * Destroys the depedency signal of barrier packet2
+ * Invokes KFD SPM stop
+ * Removes entry in packet_return_map
+ * Puts the aql packet into config's packets cache for re-use
+ */
+void
+post_kernel_call(const context::context*                           ctx,
+                 const std::shared_ptr<spm_counter_callback_info>& info,
+                 std::shared_ptr<hsa::queue_info_session_t>& /*ptr_session*/,
+                 inst_pkt_t& pkts,
+                 kernel_dispatch::profiling_time /*dispatch_time*/)
+{
+    CHECK(info && ctx);
+
+    std::shared_ptr<spm_counter_config>          prof_config;
+    std::unique_ptr<rocprofiler::hsa::AQLPacket> rel_pkt;
+    // Get the Profile Config
+    info->packet_return_map.wlock([&](auto& data) {
+        for(auto& [aql_pkt, _] : pkts)
+        {
+            const auto& profile = rocprofiler::common::get_val(data, aql_pkt.get());
+            if(profile)
+            {
+                prof_config = *profile;
+                data.erase(aql_pkt.get());
+
+                auto* pkt = dynamic_cast<hsa::SPMPacket*>(aql_pkt.get());
+                if(!pkt) continue;
+
+                CHECK_NOTNULL(hsa::get_queue_controller())
+                    ->get_core_table()
+                    .hsa_signal_destroy_fn(pkt->before_krn_barrier_pkt.at(1).dep_signal[0]);
+                if(!pkt->kfd_stop())
+                {
+                    ROCP_ERROR << "SPM KFD stop failed in post-kernel completion";
+                }
+                rel_pkt = std::move(aql_pkt);
+                return;
+            }
+        }
+    });
+    if(rel_pkt)
+        prof_config->packets.wlock(
+            [&](auto& pkt_vector) { pkt_vector.emplace_back(std::move(rel_pkt)); });
+}
+}  // namespace spm
+}  // namespace rocprofiler

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/spm/dispatch_handlers.hpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/spm/dispatch_handlers.hpp
@@ -1,0 +1,56 @@
+// MIT License
+//
+// Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#pragma once
+
+#include "lib/rocprofiler-sdk/context/context.hpp"
+#include "lib/rocprofiler-sdk/hsa/aql_packet.hpp"
+#include "lib/rocprofiler-sdk/kernel_dispatch/profiling_time.hpp"
+#include "lib/rocprofiler-sdk/spm/core.hpp"
+
+namespace rocprofiler
+{
+namespace spm
+{
+using ClientID   = int64_t;
+using inst_pkt_t = common::container::
+    small_vector<std::pair<std::unique_ptr<rocprofiler::hsa::AQLPacket>, ClientID>, 4>;
+
+hsa::write_packet_t
+pre_kernel_call(const context::context*                                  ctx,
+                const std::shared_ptr<spm_counter_callback_info>&        info,
+                const hsa::Queue&                                        queue,
+                const hsa::rocprofiler_packet&                           pkt,
+                uint64_t                                                 kernel_id,
+                rocprofiler_dispatch_id_t                                dispatch_id,
+                rocprofiler_user_data_t*                                 user_data,
+                const hsa::queue_info_session_t::external_corr_id_map_t& extern_corr_ids,
+                const context::correlation_id*                           correlation_id);
+
+void
+post_kernel_call(const context::context*                           ctx,
+                 const std::shared_ptr<spm_counter_callback_info>& info,
+                 std::shared_ptr<hsa::queue_info_session_t>&       session,
+                 inst_pkt_t&                                       aql,
+                 kernel_dispatch::profiling_time                   dispatch_time);
+}  // namespace spm
+}  // namespace rocprofiler

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/spm/interface.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/spm/interface.cpp
@@ -23,10 +23,6 @@
 #include "lib/rocprofiler-sdk/spm/interface.hpp"
 #include "lib/common/static_object.hpp"
 
-#include <fmt/format.h>
-
-#include <cstdint>
-
 namespace rocprofiler
 {
 namespace spm
@@ -42,7 +38,6 @@ construct_spm_interface()
 
 #if defined(ROCPROFILER_BUILD_AQLPROFILE) && ROCPROFILER_BUILD_AQLPROFILE
     cached->spm_create_packets             = &aqlprofile_spm_create_packets;
-    cached->spm_delete_packets             = &aqlprofile_spm_delete_packets;
     cached->spm_start                      = &aqlprofile_spm_start;
     cached->spm_stop                       = &aqlprofile_spm_stop;
     cached->spm_decode_stream_v1           = &aqlprofile_spm_decode_stream_v1;

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/spm/interface.hpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/spm/interface.hpp
@@ -33,7 +33,6 @@ namespace spm
 struct spm_interface
 {
     using spm_create_packets_fn_t             = decltype(aqlprofile_spm_create_packets);
-    using spm_delete_packets_fn_t             = decltype(aqlprofile_spm_delete_packets);
     using spm_start_fn_t                      = decltype(aqlprofile_spm_start);
     using spm_stop_fn_t                       = decltype(aqlprofile_spm_stop);
     using spm_decode_stream_v1_fn_t           = decltype(aqlprofile_spm_decode_stream_v1);
@@ -42,7 +41,6 @@ struct spm_interface
     using spm_query_agent_configurations_fn_t = decltype(aqlprofile_spm_query_agent_configurations);
 
     spm_create_packets_fn_t*             spm_create_packets             = nullptr;
-    spm_delete_packets_fn_t*             spm_delete_packets             = nullptr;
     spm_start_fn_t*                      spm_start                      = nullptr;
     spm_stop_fn_t*                       spm_stop                       = nullptr;
     spm_decode_stream_v1_fn_t*           spm_decode_stream_v1           = nullptr;

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/spm/service.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/spm/service.cpp
@@ -1,0 +1,308 @@
+// MIT License
+//
+// Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#include "lib/common/utility.hpp"
+#include "lib/rocprofiler-sdk/agent.hpp"
+#include "lib/rocprofiler-sdk/context/context.hpp"
+#include "lib/rocprofiler-sdk/counters/id_decode.hpp"
+#include "lib/rocprofiler-sdk/counters/metrics.hpp"
+#include "lib/rocprofiler-sdk/spm/interface.hpp"
+
+#include <rocprofiler-sdk/experimental/spm.h>
+#include <rocprofiler-sdk/rocprofiler.h>
+
+#include <cstdint>
+#include <memory>
+#include <vector>
+
+extern "C" {
+
+/**
+ * @brief Create Profile Configuration.
+ *
+ * @param [in] agent Agent identifier
+ * @param [in] counters_list List of GPU counters
+ * @param [in] counters_count Size of counters list
+ * @param [in/out] config_id Identifier for GPU counters group. If an existing
+                   profile is supplied, that profiles counters will be copied
+                   over to a new profile (returned via this id).
+ * @return ::rocprofiler_status_t
+ */
+rocprofiler_status_t
+rocprofiler_spm_create_counter_config(rocprofiler_agent_id_t           agent_id,
+                                      rocprofiler_counter_id_t*        counters_list,
+                                      size_t                           counters_count,
+                                      rocprofiler_spm_parameters_t**   parameters,
+                                      size_t                           parameters_count,
+                                      rocprofiler_counter_config_id_t* config_id)
+{
+    const auto* sym = rocprofiler::spm::construct_spm_interface();
+    if(!sym) return ROCPROFILER_STATUS_ERROR_INCOMPATIBLE_ABI;
+
+    if(!rocprofiler::spm::is_spm_explicitly_enabled())
+        return ROCPROFILER_STATUS_ERROR_NOT_IMPLEMENTED;
+
+    std::unordered_set<uint64_t> already_added;
+    const auto*                  agent = ::rocprofiler::agent::get_agent(agent_id);
+    if(!agent) return ROCPROFILER_STATUS_ERROR_AGENT_NOT_FOUND;
+
+    std::shared_ptr<rocprofiler::spm::spm_counter_config> config =
+        std::make_shared<rocprofiler::spm::spm_counter_config>();
+
+    auto        metrics_map = rocprofiler::counters::loadMetrics();
+    const auto& id_map      = metrics_map->id_to_metric;
+
+    for(size_t i = 0; i < counters_count; i++)
+    {
+        auto& counter_id       = counters_list[i];
+        auto  base_metric_id   = rocprofiler::counters::get_base_metric_from_counter_id(counter_id);
+        const auto* metric_ptr = rocprofiler::common::get_val(id_map, base_metric_id);
+
+        if(!metric_ptr) return ROCPROFILER_STATUS_ERROR_COUNTER_NOT_FOUND;
+        // Don't add duplicates
+        if(!already_added.emplace(metric_ptr->id()).second) continue;
+
+        if(!rocprofiler::counters::checkValidMetric(std::string(agent->name), *metric_ptr) ||
+           !rocprofiler::counters::has_spm_support(*metric_ptr, agent->id))
+        {
+            return ROCPROFILER_STATUS_ERROR_METRIC_NOT_VALID_FOR_AGENT;
+        }
+        config->metrics.push_back(*metric_ptr);
+    }
+
+    for(size_t i = 0; i < parameters_count; i++)
+    {
+        config->spm_parameters.emplace_back(
+            rocprofiler_spm_parameters_t{.size  = sizeof(rocprofiler_spm_parameters_t),
+                                         .type  = CHECK_NOTNULL(parameters[i])->type,
+                                         .value = CHECK_NOTNULL(parameters[i])->value});
+    }
+
+    if(config_id->handle != 0)
+    {
+        // Copy existing counters from previous config
+        if(auto existing = rocprofiler::spm::get_spm_counter_config(*config_id))
+        {
+            for(const auto& metric : existing->metrics)
+            {
+                if(!already_added.emplace(metric.id()).second) continue;
+                config->metrics.push_back(metric);
+            }
+        }
+    }
+
+    config->agent = agent;
+    if(auto status = rocprofiler::spm::create_spm_counter_profile(config);
+       status != ROCPROFILER_STATUS_SUCCESS)
+    {
+        return status;
+    }
+    *config_id = config->id;
+
+    return ROCPROFILER_STATUS_SUCCESS;
+}
+
+rocprofiler_status_t
+rocprofiler_spm_destroy_counter_config(rocprofiler_counter_config_id_t config_id)
+{
+    return rocprofiler::spm::destroy_spm_counter_profile(config_id);
+}
+
+rocprofiler_status_t
+rocprofiler_spm_configure_callback_dispatch_service(
+    rocprofiler_context_id_t                       context_id,
+    rocprofiler_spm_dispatch_counting_service_cb_t dispatch_callback,
+    void*                                          dispatch_callback_args,
+    rocprofiler_spm_dispatch_counting_record_cb_t  record_callback,
+    void*                                          record_callback_args)
+{
+    const auto* sym = rocprofiler::spm::construct_spm_interface();
+    if(!sym) return ROCPROFILER_STATUS_ERROR_INCOMPATIBLE_ABI;
+
+    if(!rocprofiler::spm::is_spm_explicitly_enabled())
+        return ROCPROFILER_STATUS_ERROR_NOT_IMPLEMENTED;
+
+    return rocprofiler::spm::configure_callback_spm_dispatch(context_id,
+                                                             dispatch_callback,
+                                                             dispatch_callback_args,
+                                                             record_callback,
+                                                             record_callback_args);
+}
+
+/**
+ * @brief Query Agent Counters Availability.
+ *
+ * @param [in]  agent_id agent for which the supported counters are queried
+ * @param [in]  callback to return available counters
+ * @param [in]  user_data data to be passed to the callback
+ * @return ::rocprofiler_status_t
+ */
+rocprofiler_status_t
+rocprofiler_spm_iterate_agent_supported_counters(rocprofiler_agent_id_t              agent_id,
+                                                 rocprofiler_available_counters_cb_t cb,
+                                                 void*                               user_data)
+{
+    const auto* agent = rocprofiler::agent::get_agent(agent_id);
+    if(!agent) return ROCPROFILER_STATUS_ERROR_AGENT_NOT_FOUND;
+
+    const auto* sym = rocprofiler::spm::construct_spm_interface();
+    if(!sym) return ROCPROFILER_STATUS_ERROR_INCOMPATIBLE_ABI;
+
+    auto metrics = rocprofiler::counters::getMetricsForAgent(agent);
+
+    auto ids = std::vector<rocprofiler_counter_id_t>{};
+
+    for(const auto& m : metrics)
+    {
+        if(rocprofiler::counters::has_spm_support(m, agent->id))
+        {
+            rocprofiler_counter_id_t counter_id{.handle = 0};
+            rocprofiler::counters::set_base_metric_in_counter_id(counter_id, m.id());
+            ids.push_back(counter_id);
+        }
+    }
+    if(ids.empty()) return ROCPROFILER_STATUS_ERROR_AGENT_ARCH_NOT_SUPPORTED;
+
+    return cb(agent_id, ids.data(), ids.size(), user_data);
+}
+
+/**
+ * @brief Configure buffered dispatch profile Counting Service.
+ *        Collects the counters in dispatch packets and stores them
+ *        in buffer_id. The buffer may contain packets from more than
+ *        one dispatch (denoted by dispatch id). Will trigger the
+ *        callback based on the parameters setup in buffer_id_t.
+ *
+ * @param [in] context_id context to configure spm buffer service
+ * @param [in] buffer_id buffer to use for the counting service
+ * @param [in] callback  callback to be invoked when a kernel is dispatched
+ * @param [in] callback_data_args  callback data passed to the callback
+ * @return ::rocprofiler_status_t
+ */
+rocprofiler_status_t
+rocprofiler_spm_configure_buffer_dispatch_service(
+    rocprofiler_context_id_t                       context_id,
+    rocprofiler_buffer_id_t                        buffer_id,
+    rocprofiler_spm_dispatch_counting_service_cb_t callback,
+    void*                                          callback_data_args)
+{
+    auto* ctx_p = rocprofiler::context::get_mutable_registered_context(context_id);
+    if(!ctx_p) return ROCPROFILER_STATUS_ERROR_CONTEXT_INVALID;
+
+    const auto* sym = rocprofiler::spm::construct_spm_interface();
+    if(!sym) return ROCPROFILER_STATUS_ERROR_INCOMPATIBLE_ABI;
+
+    if(!rocprofiler::spm::is_spm_explicitly_enabled())
+        return ROCPROFILER_STATUS_ERROR_NOT_IMPLEMENTED;
+
+    // checking if the buffer is registered
+    auto const* buff = rocprofiler::buffer::get_buffer(buffer_id);
+    if(!buff) return ROCPROFILER_STATUS_ERROR_BUFFER_NOT_FOUND;
+
+    auto& ctx = *ctx_p;
+
+    if(ctx.pc_sampler) return ROCPROFILER_STATUS_ERROR_CONTEXT_CONFLICT;
+    if(ctx.dispatch_counter_collection) return ROCPROFILER_STATUS_ERROR_CONTEXT_CONFLICT;
+    if(ctx.device_counter_collection) return ROCPROFILER_STATUS_ERROR_CONTEXT_CONFLICT;
+    if(!ctx.dispatch_spm)
+        ctx.dispatch_spm =
+            std::make_unique<rocprofiler::context::spm_dispatch_counter_collection_service>();
+    auto& cb = *ctx.dispatch_spm->callbacks.emplace_back(
+        std::make_shared<rocprofiler::spm::spm_counter_callback_info>());
+
+    cb.user_cb          = callback;
+    cb.callback_args    = callback_data_args;
+    cb.context          = context_id;
+    cb.buffer           = buffer_id;
+    cb.internal_context = ctx_p;
+
+    return ROCPROFILER_STATUS_SUCCESS;
+}
+
+using spm_config_vec_t = std::vector<std::unique_ptr<rocprofiler_spm_available_configuration_t>>;
+
+rocprofiler_spm_parameter_type_t
+get_type(aqlprofile_spm_parameter_type_t src)
+{
+    switch(src)
+    {
+        case AQLPROFILE_SPM_PARAMETER_TYPE_SAMPLE_INTERVAL:
+            return ROCPROFILER_SPM_PARAMETER_TYPE_SAMPLE_INTERVAL_SCLK_CYCLES;
+        default: break;
+    }
+    return ROCPROFILER_SPM_PARAMETER_TYPE_NONE;
+}
+
+hsa_status_t
+query_cb(const aqlprofile_spm_available_configuration_t* config,
+         size_t                                          configs_size,
+         void*                                           userdata)
+{
+    auto& configs_supported = *reinterpret_cast<spm_config_vec_t*>(userdata);
+    for(size_t itr = 0; itr < configs_size; itr++)
+    {
+        auto cfg = rocprofiler_spm_available_configuration_t{};
+        cfg.size = sizeof(rocprofiler_spm_available_configuration_t);
+        cfg.type = get_type(config[itr].type);
+        switch(cfg.type)
+        {
+            case ROCPROFILER_SPM_PARAMETER_TYPE_SAMPLE_INTERVAL_SCLK_CYCLES:
+                cfg.interval.min_interval = config[itr].interval.min_interval;
+                cfg.interval.max_interval = config[itr].interval.max_interval;
+                break;
+            case ROCPROFILER_SPM_PARAMETER_TYPE_NONE:
+            case ROCPROFILER_SPM_PARAMETER_TYPE_LAST: continue;
+        }
+        configs_supported.emplace_back(
+            std::make_unique<rocprofiler_spm_available_configuration_t>(cfg));
+    }
+    return HSA_STATUS_SUCCESS;
+}
+
+rocprofiler_status_t
+rocprofiler_spm_query_agent_configurations(rocprofiler_agent_id_t                        agent_id,
+                                           rocprofiler_spm_available_configurations_cb_t cb,
+                                           void*                                         user_data)
+{
+    const auto* sym = rocprofiler::spm::construct_spm_interface();
+    if(!sym) return ROCPROFILER_STATUS_ERROR_INCOMPATIBLE_ABI;
+
+    const auto* aql_agent = rocprofiler::agent::get_aql_agent(agent_id);
+    if(!aql_agent) return ROCPROFILER_STATUS_ERROR_AGENT_NOT_FOUND;
+
+    spm_config_vec_t configs_supported{};
+    auto status = sym->spm_query_agent_configurations(*aql_agent, query_cb, &configs_supported);
+
+    if(status == HSA_STATUS_SUCCESS)
+    {
+        std::vector<const rocprofiler_spm_available_configuration_t*> config_ptrs;
+        config_ptrs.reserve(configs_supported.size());
+        for(auto& cfg : configs_supported)
+            config_ptrs.push_back(cfg.get());
+
+        cb(config_ptrs.data(), config_ptrs.size(), user_data);
+        return ROCPROFILER_STATUS_SUCCESS;
+    }
+    else
+        return ROCPROFILER_STATUS_ERROR;
+}
+}

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/spm/tests/CMakeLists.txt
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/spm/tests/CMakeLists.txt
@@ -1,0 +1,42 @@
+rocprofiler_deactivate_clang_tidy()
+
+project(rocprofiler-sdk-unit-tests-spm-counters LANGUAGES C CXX)
+
+include(GoogleTest)
+
+find_program(
+    amdclangpp_EXECUTABLE REQUIRED
+    NAMES amdclang++
+    HINTS ${ROCM_PATH} ENV ROCM_PATH /opt/rocm
+    PATHS ${ROCM_PATH} ENV ROCM_PATH /opt/rocm
+    PATH_SUFFIXES bin llvm/bin NO_CACHE)
+
+set(_ROCPROFILER_SHARE_DIR
+    "${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_DATAROOTDIR}/${PACKAGE_NAME}")
+
+set(ROCPROFILER_LIB_SPM_COUNTER_TEST_SOURCES core.cpp spm_memory_pool_test.cpp)
+
+add_executable(spm-counter-test)
+
+target_sources(spm-counter-test PRIVATE ${ROCPROFILER_LIB_SPM_COUNTER_TEST_SOURCES})
+
+add_dependencies(spm-counter-test agent_hsaco_targets)
+
+target_link_libraries(
+    spm-counter-test
+    PRIVATE rocprofiler-sdk::rocprofiler-sdk-hsa-runtime
+            rocprofiler-sdk::rocprofiler-sdk-hip
+            rocprofiler-sdk::rocprofiler-sdk-common-library
+            rocprofiler-sdk::rocprofiler-sdk-static-library
+            GTest::gtest
+            GTest::gtest_main)
+
+rocprofiler_add_unit_test(
+    TARGET spm-counter-test
+    SOURCES ${ROCPROFILER_LIB_SPM_COUNTER_TEST_SOURCES}
+    TIMEOUT 60
+    ENVIRONMENT
+        "ROCPROFILER_METRICS_PATH=${_ROCPROFILER_SHARE_DIR}"
+        "ROCPROFILER_SPM_BETA_ENABLED=True"
+        "LD_LIBRARY_PATH=${CMAKE_INSTALL_PREFIX}/lib:${CMAKE_INSTALL_PREFIX}/llvm/lib:/opt/rocm/lib:/opt/rocm/llvm/lib:$ENV{LD_LIBRARY_PATH}"
+    FAIL_REGULAR_EXPRESSION "${ROCPROFILER_DEFAULT_FAIL_REGEX}")

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/spm/tests/core.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/spm/tests/core.cpp
@@ -1,0 +1,986 @@
+// MIT License
+//
+// Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#include "lib/rocprofiler-sdk/spm/core.hpp"
+#include "lib/common/utility.hpp"
+#include "lib/rocprofiler-sdk/agent.hpp"
+#include "lib/rocprofiler-sdk/context/context.hpp"
+#include "lib/rocprofiler-sdk/hsa/agent_cache.hpp"
+#include "lib/rocprofiler-sdk/hsa/aql_packet.hpp"
+#include "lib/rocprofiler-sdk/hsa/hsa.hpp"
+#include "lib/rocprofiler-sdk/hsa/queue.hpp"
+#include "lib/rocprofiler-sdk/hsa/queue_controller.hpp"
+#include "lib/rocprofiler-sdk/kernel_dispatch/profiling_time.hpp"
+#include "lib/rocprofiler-sdk/registration.hpp"
+#include "lib/rocprofiler-sdk/spm/decode.hpp"
+#include "lib/rocprofiler-sdk/spm/dispatch_handlers.hpp"
+
+#include <rocprofiler-sdk/dispatch_counting_service.h>
+#include <rocprofiler-sdk/experimental/spm.h>
+#include <rocprofiler-sdk/fwd.h>
+#include <rocprofiler-sdk/registration.h>
+#include <rocprofiler-sdk/rocprofiler.h>
+#include <rocprofiler-sdk/cxx/operators.hpp>
+
+#include <fmt/core.h>
+#include <gtest/gtest.h>
+#include <hsa/hsa.h>
+#include <hsa/hsa_api_trace.h>
+#include <hsa/hsa_ext_amd.h>
+
+#include <cstdint>
+#include <sstream>
+
+using namespace rocprofiler::counters;
+using namespace rocprofiler;
+
+AmdExtTable&
+get_ext_table()
+{
+    static auto _v = []() {
+        auto val                                  = AmdExtTable{};
+        val.version.major_id                      = HSA_AMD_EXT_API_TABLE_MAJOR_VERSION;
+        val.version.minor_id                      = sizeof(AmdExtTable);
+        val.version.step_id                       = HSA_AMD_EXT_API_TABLE_STEP_VERSION;
+        val.hsa_amd_memory_pool_get_info_fn       = hsa_amd_memory_pool_get_info;
+        val.hsa_amd_agent_iterate_memory_pools_fn = hsa_amd_agent_iterate_memory_pools;
+        val.hsa_amd_memory_pool_allocate_fn       = hsa_amd_memory_pool_allocate;
+        val.hsa_amd_memory_pool_free_fn           = hsa_amd_memory_pool_free;
+        val.hsa_amd_agent_memory_pool_get_info_fn = hsa_amd_agent_memory_pool_get_info;
+        val.hsa_amd_agents_allow_access_fn        = hsa_amd_agents_allow_access;
+        val.hsa_amd_memory_fill_fn                = hsa_amd_memory_fill;
+        val.hsa_amd_signal_create_fn              = hsa_amd_signal_create;
+        val.hsa_amd_spm_acquire_fn                = hsa_amd_spm_acquire;
+        val.hsa_amd_spm_release_fn                = hsa_amd_spm_release;
+        val.hsa_amd_signal_async_handler_fn       = hsa_amd_signal_async_handler;
+        return val;
+    }();
+    return _v;
+}
+
+CoreApiTable&
+get_api_table()
+{
+    static auto _v = []() {
+        auto val                          = CoreApiTable{};
+        val.version.major_id              = HSA_CORE_API_TABLE_MAJOR_VERSION;
+        val.version.minor_id              = sizeof(CoreApiTable);
+        val.version.step_id               = HSA_CORE_API_TABLE_STEP_VERSION;
+        val.hsa_iterate_agents_fn         = hsa_iterate_agents;
+        val.hsa_agent_get_info_fn         = hsa_agent_get_info;
+        val.hsa_queue_create_fn           = hsa_queue_create;
+        val.hsa_queue_destroy_fn          = hsa_queue_destroy;
+        val.hsa_signal_wait_relaxed_fn    = hsa_signal_wait_relaxed;
+        val.hsa_memory_copy_fn            = hsa_memory_copy;
+        val.hsa_signal_create_fn          = hsa_signal_create;
+        val.hsa_signal_destroy_fn         = hsa_signal_destroy;
+        val.hsa_signal_store_relaxed_fn   = hsa_signal_store_relaxed;
+        val.hsa_signal_store_screlease_fn = hsa_signal_store_screlease;
+        return val;
+    }();
+    return _v;
+}
+
+#define ROCPROFILER_CALL(result, msg)                                                              \
+    {                                                                                              \
+        rocprofiler_status_t CHECKSTATUS = result;                                                 \
+        if(CHECKSTATUS != ROCPROFILER_STATUS_SUCCESS)                                              \
+        {                                                                                          \
+            std::string status_msg = rocprofiler_get_status_string(CHECKSTATUS);                   \
+            std::cerr << "[" #result "][" << __FILE__ << ":" << __LINE__ << "] " << msg            \
+                      << " failed with error code " << CHECKSTATUS << ": " << status_msg           \
+                      << std::endl;                                                                \
+            std::stringstream errmsg{};                                                            \
+            errmsg << "[" #result "][" << __FILE__ << ":" << __LINE__ << "] " << msg " failure ("  \
+                   << status_msg << ")";                                                           \
+            ASSERT_EQ(CHECKSTATUS, ROCPROFILER_STATUS_SUCCESS) << errmsg.str();                    \
+        }                                                                                          \
+    }
+
+namespace
+{
+auto
+findSPMDeviceMetrics(const hsa::AgentCache& agent, const std::unordered_set<std::string>& metrics)
+{
+    std::vector<counters::Metric> ret;
+    auto                          mets         = counters::loadMetrics();
+    const auto&                   all_counters = mets->arch_to_metric;
+
+    ROCP_INFO << "Looking up counters for " << std::string(agent.name());
+    const auto* gfx_metrics = common::get_val(all_counters, std::string(agent.name()));
+    if(!gfx_metrics)
+    {
+        ROCP_ERROR << "No counters found for " << std::string(agent.name());
+        return ret;
+    }
+
+    for(const auto& counter : *gfx_metrics)
+    {
+        auto rocp_agent = CHECK_NOTNULL(agent.get_rocp_agent());
+
+        if((metrics.count(counter.name()) > 0 || metrics.empty()) &&
+           rocprofiler::counters::has_spm_support(counter, rocp_agent->id))
+        {
+            ret.push_back(counter);
+        }
+    }
+    return ret;
+}
+
+void
+test_init()
+{
+    HsaApiTable table;
+    table.amd_ext_ = &get_ext_table();
+    table.core_    = &get_api_table();
+    rocprofiler::hsa::copy_table(table.core_, 0);
+    rocprofiler::hsa::copy_table(table.amd_ext_, 0);
+    agent::construct_agent_cache(&table);
+    ASSERT_TRUE(hsa::get_queue_controller() != nullptr);
+
+    hsa::get_queue_controller()->init(get_api_table(), get_ext_table());
+}
+
+}  // namespace
+
+namespace
+{
+rocprofiler_context_id_t&
+get_client_ctx()
+{
+    static rocprofiler_context_id_t ctx{0};
+    return ctx;
+}
+
+void
+set_client_ctx(rocprofiler_context_id_t& ctx)
+{
+    ctx = rocprofiler_context_id_t{0};
+}
+
+void
+null_dispatch_callback(const rocprofiler_spm_dispatch_counting_service_data_t*,
+                       rocprofiler_counter_config_id_t*,
+                       rocprofiler_user_data_t*,
+                       void*)
+{}
+
+void
+null_record_callback(const rocprofiler_spm_dispatch_counting_service_data_t*,
+                     const rocprofiler_spm_counter_record_t**,
+                     size_t,
+                     rocprofiler_spm_record_flag_t,
+                     rocprofiler_user_data_t,
+                     void*)
+{}
+
+void
+null_buffered_callback(rocprofiler_context_id_t,
+                       rocprofiler_buffer_id_t,
+                       rocprofiler_record_header_t**,
+                       size_t,
+                       void*,
+                       uint64_t)
+{}
+}  // namespace
+
+TEST(spm_core, check_packet_generation)
+{
+    ASSERT_EQ(hsa_init(), HSA_STATUS_SUCCESS);
+    test_init();
+    ASSERT_TRUE(hsa::get_queue_controller() != nullptr);
+    auto agents = hsa::get_queue_controller()->get_supported_agents();
+    ASSERT_GT(agents.size(), 0);
+    for(const auto& [_, agent] : agents)
+    {
+        auto rocp_agent = CHECK_NOTNULL(agent.get_rocp_agent());
+        if(rocp_agent->runtime_visibility.hsa && rocp_agent->runtime_visibility.hip)
+        {
+            auto metrics = findSPMDeviceMetrics(agent, {});
+            ASSERT_FALSE(metrics.empty());
+            ASSERT_TRUE(agent.get_rocp_agent());
+            for(auto& metric : metrics)
+            {
+                /**
+                 * Check profile construction
+                 */
+                rocprofiler_counter_config_id_t cfg_id = {.handle = 0};
+                rocprofiler_counter_id_t        id     = {.handle = metric.id()};
+                ROCP_ERROR << fmt::format("Generating packet for {}", metric);
+
+                std::vector<rocprofiler_spm_parameters_t*> input_params{};
+                rocprofiler_spm_parameters_t               param{
+                    .size = sizeof(rocprofiler_spm_parameters_t),
+                    .type = ROCPROFILER_SPM_PARAMETER_TYPE_SAMPLE_INTERVAL_SCLK_CYCLES,
+                    .value = 1200};
+                input_params.push_back(&param);
+
+                ROCPROFILER_CALL(rocprofiler_spm_create_counter_config(agent.get_rocp_agent()->id,
+                                                                       &id,
+                                                                       1,
+                                                                       input_params.data(),
+                                                                       input_params.size(),
+                                                                       &cfg_id),
+                                 "Unable to create profile");
+                auto profile = spm::get_spm_counter_config(cfg_id);
+                ASSERT_TRUE(profile);
+
+                /**
+                 * Check that a packet generator was created
+                 */
+
+                /**
+                 * Check packet generation
+                 */
+                std::unique_ptr<hsa::AQLPacket> pkt = nullptr;
+                EXPECT_EQ(get_spm_packet(pkt, profile), ROCPROFILER_STATUS_SUCCESS)
+                    << "Unable to generate packet";
+                EXPECT_TRUE(pkt) << "Expected a packet to be generated";
+            }
+        }
+    }
+}
+
+namespace rocprofiler
+{
+namespace hsa
+{
+class FakeQueue : public Queue
+{
+public:
+    FakeQueue(const AgentCache& a, rocprofiler_queue_id_t id)
+    : Queue(a, get_api_table())
+    , _agent(a)
+    , _id(id)
+    {}
+    const AgentCache&      get_agent() const final { return _agent; };
+    rocprofiler_queue_id_t get_id() const final { return _id; };
+
+    ~FakeQueue() override = default;
+
+private:
+    const AgentCache&      _agent;
+    rocprofiler_queue_id_t _id = {};
+};
+
+}  // namespace hsa
+}  // namespace rocprofiler
+
+namespace
+{
+struct expected_dispatch
+{
+    // To pass back
+    rocprofiler_counter_config_id_t    id             = {.handle = 0};
+    rocprofiler_queue_id_t             queue_id       = {.handle = 0};
+    rocprofiler_agent_id_t             agent_id       = {.handle = 0};
+    uint64_t                           kernel_id      = 0;
+    uint64_t                           dispatch_id    = 0;
+    rocprofiler_async_correlation_id_t correlation_id = {.internal = 0, .external = {.value = 0}};
+    rocprofiler_dim3_t                 workgroup_size = {0, 0, 0};
+    rocprofiler_dim3_t                 grid_size      = {0, 0, 0};
+    rocprofiler_counter_config_id_t*   config         = nullptr;
+};
+
+void
+user_dispatch_cb(const rocprofiler_spm_dispatch_counting_service_data_t* dispatch_data,
+                 rocprofiler_counter_config_id_t*                        config,
+                 rocprofiler_user_data_t*                                user_data,
+                 void*                                                   callback_data_args)
+{
+    expected_dispatch& expected = *static_cast<expected_dispatch*>(callback_data_args);
+
+    auto agent_id       = dispatch_data->dispatch_info.agent_id;
+    auto queue_id       = dispatch_data->dispatch_info.queue_id;
+    auto correlation_id = dispatch_data->correlation_id;
+    auto kernel_id      = dispatch_data->dispatch_info.kernel_id;
+    auto dispatch_id    = dispatch_data->dispatch_info.dispatch_id;
+
+    EXPECT_EQ(sizeof(rocprofiler_spm_dispatch_counting_service_data_t), dispatch_data->size);
+    EXPECT_EQ(expected.kernel_id, kernel_id);
+    EXPECT_EQ(expected.dispatch_id, dispatch_id);
+    EXPECT_EQ(expected.agent_id, agent_id);
+    EXPECT_EQ(expected.queue_id.handle, queue_id.handle);
+    EXPECT_EQ(expected.correlation_id.internal, correlation_id.internal);
+    EXPECT_EQ(expected.correlation_id.external.ptr, correlation_id.external.ptr);
+    EXPECT_EQ(expected.correlation_id.external.value, correlation_id.external.value);
+    EXPECT_EQ(expected.workgroup_size, dispatch_data->dispatch_info.workgroup_size);
+    EXPECT_EQ(expected.grid_size, dispatch_data->dispatch_info.grid_size);
+
+    ASSERT_NE(config, nullptr);
+    config->handle = expected.id.handle;
+
+    (void) user_data;
+}
+
+}  // namespace
+
+namespace rocprofiler
+{
+namespace buffer
+{
+uint64_t
+get_buffer_offset();
+}
+}  // namespace rocprofiler
+
+TEST(spm_core, check_callbacks)
+{
+    int64_t count = 0;
+    ASSERT_EQ(hsa_init(), HSA_STATUS_SUCCESS);
+    test_init();
+
+    registration::init_logging();
+    registration::set_init_status(-1);
+    context::push_client(1);
+    ROCPROFILER_CALL(rocprofiler_create_context(&get_client_ctx()), "context creation failed");
+
+    context::context ctx;
+    ctx.dispatch_spm =
+        std::make_unique<rocprofiler::context::spm_dispatch_counter_collection_service>();
+    ctx.dispatch_spm->enabled.wlock([](auto& data) { data = true; });
+
+    ASSERT_TRUE(hsa::get_queue_controller() != nullptr);
+    auto agents = hsa::get_queue_controller()->get_supported_agents();
+    ASSERT_GT(agents.size(), 0);
+    hsa::get_queue_controller()->disable_serialization();
+
+    for(const auto& [_, agent] : agents)
+    {
+        /**
+         * Setup
+         */
+        auto rocp_agent = CHECK_NOTNULL(agent.get_rocp_agent());
+        if(rocp_agent->runtime_visibility.hsa && rocp_agent->runtime_visibility.hip)
+        {
+            rocprofiler_queue_id_t qid = {.handle = static_cast<uint64_t>(count++)};
+            hsa::FakeQueue         fq(agent, qid);
+            auto                   metrics = findSPMDeviceMetrics(agent, {});
+            ASSERT_FALSE(metrics.empty());
+            ASSERT_TRUE(agent.get_rocp_agent());
+            for(auto& metric : metrics)
+            {
+                if(!metric.expression().empty()) continue;
+
+                /**
+                 * Setup
+                 */
+                expected_dispatch                          expected = {};
+                rocprofiler_counter_id_t                   id       = {.handle = metric.id()};
+                std::vector<rocprofiler_spm_parameters_t*> input_params{};
+                rocprofiler_spm_parameters_t               param{
+                    .size = sizeof(rocprofiler_spm_parameters_t),
+                    .type = ROCPROFILER_SPM_PARAMETER_TYPE_SAMPLE_INTERVAL_SCLK_CYCLES,
+                    .value = 1200};
+                input_params.push_back(&param);
+
+                ROCPROFILER_CALL(rocprofiler_spm_create_counter_config(agent.get_rocp_agent()->id,
+                                                                       &id,
+                                                                       1,
+                                                                       input_params.data(),
+                                                                       input_params.size(),
+                                                                       &expected.id),
+                                 "Unable to create profile");
+                auto profile = spm::get_spm_counter_config(expected.id);
+                ASSERT_TRUE(profile);
+
+                std::shared_ptr<spm::spm_counter_callback_info> cb_info =
+                    std::make_shared<spm::spm_counter_callback_info>();
+                cb_info->user_cb              = user_dispatch_cb;
+                cb_info->callback_args        = static_cast<void*>(&expected);
+                cb_info->record_callback      = null_record_callback;
+                cb_info->record_callback_args = nullptr;
+                context::correlation_id corr_id;
+                corr_id.internal = count++;
+
+                hsa::rocprofiler_packet pkt;
+                pkt.ext_amd_aql_pm4.header = count++;
+
+                expected.correlation_id = {.internal = corr_id.internal,
+                                           .external = context::null_user_data};
+                expected.workgroup_size = {pkt.kernel_dispatch.workgroup_size_x,
+                                           pkt.kernel_dispatch.workgroup_size_y,
+                                           pkt.kernel_dispatch.workgroup_size_z};
+                expected.grid_size      = {pkt.kernel_dispatch.grid_size_x,
+                                      pkt.kernel_dispatch.grid_size_y,
+                                      pkt.kernel_dispatch.grid_size_z};
+                expected.kernel_id      = count++;
+                expected.dispatch_id    = count++;
+                expected.queue_id       = qid;
+                expected.agent_id       = fq.get_agent().get_rocp_agent()->id;
+
+                hsa::queue_info_session_t::external_corr_id_map_t extern_ids = {};
+
+                auto user_data       = rocprofiler_user_data_t{.value = corr_id.internal};
+                auto ret_pkt         = spm::pre_kernel_call(&ctx,
+                                                    cb_info,
+                                                    fq,
+                                                    pkt,
+                                                    expected.kernel_id,
+                                                    expected.dispatch_id,
+                                                    &user_data,
+                                                    extern_ids,
+                                                    &corr_id);
+                auto _sess           = hsa::queue_info_session_t{.queue = fq};
+                _sess.correlation_id = &corr_id;
+
+                auto sess = std::make_shared<hsa::queue_info_session_t>(std::move(_sess));
+                ASSERT_TRUE(ret_pkt.packet)
+                    << fmt::format("Expected a packet to be generated for - {}", metric.name());
+                cb_info->packet_return_map.rlock([&](const auto& map) {
+                    EXPECT_EQ(map.size(), 1) << "Expected packet_return_map to have one entry";
+                    EXPECT_TRUE(common::get_val(map, ret_pkt.packet.get()))
+                        << "Expected packet in packet_return_map";
+                });
+                auto  data    = std::vector<int>(10, 1);
+                auto* spm_pkt = dynamic_cast<hsa::SPMPacket*>(ret_pkt.packet.get());
+                rocprofiler::spm::aql_data_callback(0, &(data[0]), data.size(), 0, spm_pkt);
+                spm::inst_pkt_t pkts;
+                pkts.emplace_back(
+                    std::make_pair(std::move(ret_pkt.packet), static_cast<spm::ClientID>(0)));
+                post_kernel_call(&ctx, cb_info, sess, pkts, kernel_dispatch::profiling_time{});
+            }
+        }
+    }
+
+    registration::set_init_status(1);
+
+    registration::finalize();
+    context::pop_client(1);
+    set_client_ctx(get_client_ctx());
+}
+
+TEST(spm_core, destroy_counter_profile)
+{
+    ASSERT_EQ(hsa_init(), HSA_STATUS_SUCCESS);
+    test_init();
+
+    registration::init_logging();
+    registration::set_init_status(-1);
+    context::push_client(1);
+
+    ROCPROFILER_CALL(rocprofiler_create_context(&get_client_ctx()), "context creation failed");
+
+    auto agents = hsa::get_queue_controller()->get_supported_agents();
+    ASSERT_GT(agents.size(), 0);
+    for(const auto& [_, agent] : agents)
+    {
+        auto rocp_agent = CHECK_NOTNULL(agent.get_rocp_agent());
+        if(rocp_agent->runtime_visibility.hsa && rocp_agent->runtime_visibility.hip)
+        {
+            auto metrics = findSPMDeviceMetrics(agent, {});
+            ASSERT_FALSE(metrics.empty());
+            ASSERT_TRUE(agent.get_rocp_agent());
+            for(auto& metric : metrics)
+            {
+                expected_dispatch        expected = {};
+                rocprofiler_counter_id_t id       = {.handle = metric.id()};
+
+                std::vector<rocprofiler_spm_parameters_t*> input_params{};
+                rocprofiler_spm_parameters_t               param{
+                    .size = sizeof(rocprofiler_spm_parameters_t),
+                    .type = ROCPROFILER_SPM_PARAMETER_TYPE_SAMPLE_INTERVAL_SCLK_CYCLES,
+                    .value = 1200};
+                input_params.push_back(&param);
+                ROCPROFILER_CALL(rocprofiler_spm_create_counter_config(agent.get_rocp_agent()->id,
+                                                                       &id,
+                                                                       1,
+                                                                       input_params.data(),
+                                                                       input_params.size(),
+                                                                       &expected.id),
+                                 "Unable to create profile");
+                ROCPROFILER_CALL(rocprofiler_spm_destroy_counter_config(expected.id),
+                                 "Could not delete profile id");
+                /**
+                 * Check the profile was actually destroyed
+                 */
+                auto profile = spm::get_spm_counter_config(expected.id);
+                EXPECT_FALSE(profile);
+            }
+        }
+    }
+    registration::set_init_status(1);
+
+    registration::finalize();
+    context::pop_client(1);
+    set_client_ctx(get_client_ctx());
+}
+
+TEST(spm_core, start_stop_callback_ctx)
+{
+    rocprofiler::common::set_env("ROCPROFILER_SPM_BETA_ENABLED", true);
+    ASSERT_EQ(hsa_init(), HSA_STATUS_SUCCESS);
+    test_init();
+
+    registration::init_logging();
+    registration::set_init_status(-1);
+    context::push_client(1);
+    registration::set_fini_status(0);
+
+    ROCPROFILER_CALL(rocprofiler_create_context(&get_client_ctx()), "context creation failed");
+
+    ROCPROFILER_CALL(rocprofiler_spm_configure_callback_dispatch_service(get_client_ctx(),
+                                                                         null_dispatch_callback,
+                                                                         (void*) 0x12345,
+                                                                         null_record_callback,
+                                                                         (void*) 0x54321),
+                     "Could not setup counting service");
+    ROCPROFILER_CALL(rocprofiler_start_context(get_client_ctx()), "start context");
+
+    /**
+     * Check that the context was actually started
+     */
+    auto* ctx_p = context::get_mutable_registered_context(get_client_ctx());
+    ASSERT_TRUE(ctx_p);
+    auto& ctx = *ctx_p;
+
+    ASSERT_TRUE(ctx.dispatch_spm);
+    ASSERT_EQ(ctx.dispatch_spm->callbacks.size(), 1);
+    EXPECT_EQ(ctx.dispatch_spm->callbacks.at(0)->user_cb, null_dispatch_callback);
+    EXPECT_EQ(ctx.dispatch_spm->callbacks.at(0)->callback_args, (void*) 0x12345);
+    EXPECT_EQ(ctx.dispatch_spm->callbacks.at(0)->record_callback, null_record_callback);
+    EXPECT_EQ(ctx.dispatch_spm->callbacks.at(0)->record_callback_args, (void*) 0x54321);
+    EXPECT_EQ(ctx.dispatch_spm->callbacks.at(0)->context.handle, get_client_ctx().handle);
+
+    bool found = false;
+    ctx.dispatch_spm->enabled.rlock([&](const auto& data) { found = data; });
+    EXPECT_TRUE(found);
+
+    found = false;
+    hsa::get_queue_controller()->iterate_callbacks([&](auto cid, const auto&) {
+        if(cid == ctx.dispatch_spm->callbacks.at(0)->queue_id)
+        {
+            found = true;
+        }
+    });
+    EXPECT_TRUE(found);
+
+    /**
+     * Check if context can be disabled correctly
+     */
+    ROCPROFILER_CALL(rocprofiler_stop_context(get_client_ctx()), "stop context");
+
+    found = false;
+    ctx.dispatch_spm->enabled.rlock([&](const auto& data) { found = data; });
+    EXPECT_FALSE(found);
+
+    registration::set_init_status(1);
+    registration::finalize();
+    context::pop_client(1);
+    set_client_ctx(get_client_ctx());
+}
+
+TEST(spm_core, start_stop_buffered_ctx)
+{
+    ASSERT_EQ(hsa_init(), HSA_STATUS_SUCCESS);
+    test_init();
+
+    registration::init_logging();
+    registration::set_init_status(-1);
+    context::push_client(1);
+    ROCPROFILER_CALL(rocprofiler_create_context(&get_client_ctx()), "context creation failed");
+
+    rocprofiler_buffer_id_t opt_buff_id = {.handle = 0};
+    ROCPROFILER_CALL(rocprofiler_create_buffer(get_client_ctx(),
+                                               500 * sizeof(size_t),
+                                               500 * sizeof(size_t),
+                                               ROCPROFILER_BUFFER_POLICY_LOSSLESS,
+                                               null_buffered_callback,
+                                               nullptr,
+                                               &opt_buff_id),
+                     "Could not create buffer");
+
+    ROCPROFILER_CALL(rocprofiler_spm_configure_buffer_dispatch_service(
+                         get_client_ctx(), opt_buff_id, null_dispatch_callback, (void*) 0x12345),
+                     "Could not setup buffered service");
+    ROCPROFILER_CALL(rocprofiler_start_context(get_client_ctx()), "start context");
+
+    /**
+     * Check that the context was actually started
+     */
+    auto* ctx_p = context::get_mutable_registered_context(get_client_ctx());
+    ASSERT_TRUE(ctx_p);
+    auto& ctx = *ctx_p;
+
+    ASSERT_TRUE(ctx.dispatch_spm);
+    ASSERT_EQ(ctx.dispatch_spm->callbacks.size(), 1);
+    EXPECT_EQ(ctx.dispatch_spm->callbacks.at(0)->user_cb, null_dispatch_callback);
+    EXPECT_EQ(ctx.dispatch_spm->callbacks.at(0)->callback_args, (void*) 0x12345);
+    EXPECT_EQ(ctx.dispatch_spm->callbacks.at(0)->context.handle, get_client_ctx().handle);
+    ASSERT_TRUE(ctx.dispatch_spm->callbacks.at(0)->buffer);
+    EXPECT_EQ(ctx.dispatch_spm->callbacks.at(0)->buffer->handle, opt_buff_id.handle);
+
+    bool found = false;
+    ctx.dispatch_spm->enabled.rlock([&](const auto& data) { found = data; });
+    EXPECT_TRUE(found);
+
+    found = false;
+    hsa::get_queue_controller()->iterate_callbacks([&](auto cid, const auto&) {
+        if(cid == ctx.dispatch_spm->callbacks.at(0)->queue_id)
+        {
+            found = true;
+        }
+    });
+    EXPECT_TRUE(found);
+
+    /**
+     * Check if context can be disabled correctly
+     */
+    ROCPROFILER_CALL(rocprofiler_stop_context(get_client_ctx()), "stop context");
+
+    found = false;
+    ctx.dispatch_spm->enabled.rlock([&](const auto& data) { found = data; });
+    EXPECT_FALSE(found);
+
+    rocprofiler_flush_buffer(opt_buff_id);
+    rocprofiler_destroy_buffer(opt_buff_id);
+
+    registration::set_init_status(1);
+
+    registration::finalize();
+}
+
+TEST(spm_core, test_profile_incremental)
+{
+    ASSERT_EQ(hsa_init(), HSA_STATUS_SUCCESS);
+    test_init();
+    ASSERT_TRUE(hsa::get_queue_controller() != nullptr);
+    auto agents = hsa::get_queue_controller()->get_supported_agents();
+    ASSERT_GT(agents.size(), 0);
+    for(const auto& [_, agent] : agents)
+    {
+        auto rocp_agent = CHECK_NOTNULL(agent.get_rocp_agent());
+        if(rocp_agent->runtime_visibility.hsa && rocp_agent->runtime_visibility.hip)
+        {
+            auto metrics = findSPMDeviceMetrics(agent, {});
+            ASSERT_FALSE(metrics.empty());
+            ASSERT_TRUE(agent.get_rocp_agent());
+
+            std::map<std::string, std::vector<counters::Metric>> metric_blocks;
+            for(const auto& metric : metrics)
+            {
+                if(!metric.block().empty())
+                {
+                    metric_blocks[metric.block()].push_back(metric);
+                }
+            }
+
+            rocprofiler_counter_config_id_t cfg_id = {};
+
+            // Add one counter from each block to incrementally to make sure we can
+            // add them incrementally
+            for(const auto& [block_name, block_metrics] : metric_blocks)
+            {
+                rocprofiler_counter_config_id_t old_id = cfg_id;
+                rocprofiler_counter_id_t        id     = {.handle = block_metrics.front().id()};
+
+                std::vector<rocprofiler_spm_parameters_t*> input_params{};
+                rocprofiler_spm_parameters_t               param{
+                    .size = sizeof(rocprofiler_spm_parameters_t),
+                    .type = ROCPROFILER_SPM_PARAMETER_TYPE_SAMPLE_INTERVAL_SCLK_CYCLES,
+                    .value = 1200};
+                input_params.push_back(&param);
+                ROCPROFILER_CALL(
+                    rocprofiler_spm_create_counter_config(agent.get_rocp_agent()->id,
+                                                          &id,
+                                                          1,
+                                                          input_params.data(),
+                                                          input_params.size(),
+                                                          &cfg_id),
+                    "Unable to create profile incrementally when we should be able to");
+                EXPECT_NE(old_id.handle, cfg_id.handle) << "We expect that the handle changes this "
+                                                           "is due to the existing profile being "
+                                                           "unmodifiable after creation: "
+                                                        << block_name;
+            }
+
+            // Check that we encounter an error of exceeds hardware limits eventually
+            auto status = ROCPROFILER_STATUS_SUCCESS;
+            for(const auto& metric : metrics)
+            {
+                /**
+                 * Check profile construction
+                 */
+                std::vector<rocprofiler_spm_parameters_t*> input_params{};
+                rocprofiler_spm_parameters_t               param{
+                    .size = sizeof(rocprofiler_spm_parameters_t),
+                    .type = ROCPROFILER_SPM_PARAMETER_TYPE_SAMPLE_INTERVAL_SCLK_CYCLES,
+                    .value = 1200};
+                input_params.push_back(&param);
+                rocprofiler_counter_id_t id = {.handle = metric.id()};
+                if(status = rocprofiler_spm_create_counter_config(agent.get_rocp_agent()->id,
+                                                                  &id,
+                                                                  1,
+                                                                  input_params.data(),
+                                                                  input_params.size(),
+                                                                  &cfg_id);
+                   status != ROCPROFILER_STATUS_SUCCESS)
+                {
+                    break;
+                }
+            }
+            EXPECT_EQ(status, ROCPROFILER_STATUS_ERROR_EXCEEDS_HW_LIMIT);
+        }
+    }
+
+    set_client_ctx(get_client_ctx());
+}
+
+TEST(spm_core, public_api_iterate_agents)
+{
+    ASSERT_EQ(hsa_init(), HSA_STATUS_SUCCESS);
+    test_init();
+
+    registration::init_logging();
+    registration::set_init_status(-1);
+    context::push_client(1);
+    auto agents = hsa::get_queue_controller()->get_supported_agents();
+    for(const auto& [_, agent] : agents)
+    {
+        auto rocp_agent = CHECK_NOTNULL(agent.get_rocp_agent());
+        if(rocp_agent->runtime_visibility.hsa && rocp_agent->runtime_visibility.hip)
+        {
+            std::set<uint64_t> from_api{};
+
+            // Iterate through the agents and get the counters available on that agent
+            ROCPROFILER_CALL(rocprofiler_spm_iterate_agent_supported_counters(
+                                 agent.get_rocp_agent()->id,
+                                 [](rocprofiler_agent_id_t,
+                                    rocprofiler_counter_id_t* counters,
+                                    size_t                    num_counters,
+                                    void*                     user_data) {
+                                     std::set<uint64_t>* vec =
+                                         static_cast<std::set<uint64_t>*>(user_data);
+                                     for(size_t i = 0; i < num_counters; i++)
+                                     {
+                                         vec->insert(counters[i].handle);
+                                     }
+                                     return ROCPROFILER_STATUS_SUCCESS;
+                                 },
+                                 static_cast<void*>(&from_api)),
+                             "Could not fetch supported counters");
+
+            auto expected = findSPMDeviceMetrics(agent, {});
+            for(const auto& x : expected)
+            {
+                bool found = false;
+                for(auto it = from_api.begin(); it != from_api.end(); ++it)
+                {
+                    rocprofiler_counter_id_t counter_id = {.handle = *it};
+                    if(counters::get_base_metric_from_counter_id(counter_id) == x.id())
+                    {
+                        from_api.erase(it);
+                        found = true;
+                        break;
+                    }
+                }
+                ASSERT_TRUE(found)
+                    << "Expected counter ID " << x.id() << " not found in API results";
+            }
+
+            EXPECT_TRUE(from_api.empty());
+        }
+    }
+    registration::set_init_status(1);
+    registration::finalize();
+    context::pop_client(1);
+}
+
+TEST(spm_core, query_agent_configurations)
+{
+    ASSERT_EQ(hsa_init(), HSA_STATUS_SUCCESS);
+    test_init();
+
+    registration::init_logging();
+    registration::set_init_status(-1);
+    context::push_client(1);
+
+    auto agents = hsa::get_queue_controller()->get_supported_agents();
+    ASSERT_GT(agents.size(), 0);
+
+    for(const auto& [_, agent] : agents)
+    {
+        auto rocp_agent = CHECK_NOTNULL(agent.get_rocp_agent());
+        if(rocp_agent->runtime_visibility.hsa && rocp_agent->runtime_visibility.hip)
+        {
+            struct query_result
+            {
+                size_t                                                 num_configs = 0;
+                std::vector<rocprofiler_spm_available_configuration_t> configs;
+            };
+
+            query_result result{};
+
+            auto status = rocprofiler_spm_query_agent_configurations(
+                rocp_agent->id,
+                [](const rocprofiler_spm_available_configuration_t** config,
+                   size_t                                            num_config,
+                   void* user_data) -> rocprofiler_status_t {
+                    auto* res        = static_cast<query_result*>(user_data);
+                    res->num_configs = num_config;
+                    for(size_t i = 0; i < num_config; i++)
+                        res->configs.push_back(*config[i]);
+                    return ROCPROFILER_STATUS_SUCCESS;
+                },
+                &result);
+
+            if(status != ROCPROFILER_STATUS_SUCCESS)
+            {
+                continue;
+            }
+            ASSERT_GT(result.num_configs, 0) << "Expected at least one configuration";
+
+            bool found_interval = false;
+            for(const auto& cfg : result.configs)
+            {
+                EXPECT_EQ(cfg.size, sizeof(rocprofiler_spm_available_configuration_t));
+                if(cfg.type == ROCPROFILER_SPM_PARAMETER_TYPE_SAMPLE_INTERVAL_SCLK_CYCLES)
+                {
+                    found_interval = true;
+                    EXPECT_EQ(cfg.interval.min_interval, 32);
+                    EXPECT_GT(cfg.interval.max_interval, cfg.interval.min_interval);
+                }
+                EXPECT_NE(cfg.type, ROCPROFILER_SPM_PARAMETER_TYPE_NONE);
+                EXPECT_NE(cfg.type, ROCPROFILER_SPM_PARAMETER_TYPE_LAST);
+            }
+            EXPECT_TRUE(found_interval) << "Expected a sample interval configuration";
+        }
+    }
+
+    registration::set_init_status(1);
+    registration::finalize();
+    context::pop_client(1);
+    set_client_ctx(get_client_ctx());
+}
+
+TEST(spm_core, stop_context_removes_callbacks)
+{
+    rocprofiler::common::set_env("ROCPROFILER_SPM_BETA_ENABLED", true);
+    ASSERT_EQ(hsa_init(), HSA_STATUS_SUCCESS);
+    test_init();
+
+    registration::init_logging();
+    registration::set_init_status(-1);
+    context::push_client(1);
+    registration::set_fini_status(0);
+
+    ROCPROFILER_CALL(rocprofiler_create_context(&get_client_ctx()), "context creation failed");
+
+    ROCPROFILER_CALL(rocprofiler_spm_configure_callback_dispatch_service(get_client_ctx(),
+                                                                         null_dispatch_callback,
+                                                                         (void*) 0x12345,
+                                                                         null_record_callback,
+                                                                         (void*) 0x54321),
+                     "Could not setup counting service");
+    ROCPROFILER_CALL(rocprofiler_start_context(get_client_ctx()), "start context");
+
+    auto* ctx_p = context::get_mutable_registered_context(get_client_ctx());
+    ASSERT_TRUE(ctx_p);
+    auto& ctx = *ctx_p;
+    ASSERT_TRUE(ctx.dispatch_spm);
+    ASSERT_EQ(ctx.dispatch_spm->callbacks.size(), 1);
+
+    auto pre_stop_queue_id = ctx.dispatch_spm->callbacks.at(0)->queue_id;
+    bool found             = false;
+    hsa::get_queue_controller()->iterate_callbacks([&](auto cid, const auto&) {
+        if(cid == pre_stop_queue_id) found = true;
+    });
+    EXPECT_TRUE(found) << "Callback should be registered after start";
+
+    // Stop exercises queue_controller_sync + remove_callback
+    ROCPROFILER_CALL(rocprofiler_stop_context(get_client_ctx()), "stop context");
+
+    bool enabled = true;
+    ctx.dispatch_spm->enabled.rlock([&](const auto& data) { enabled = data; });
+    EXPECT_FALSE(enabled);
+
+    EXPECT_EQ(ctx.dispatch_spm->callbacks.at(0)->queue_id, hsa::ClientID{-1})
+        << "queue_id should be reset to -1 after stop";
+
+    found = false;
+    hsa::get_queue_controller()->iterate_callbacks([&](auto cid, const auto&) {
+        if(cid == pre_stop_queue_id) found = true;
+    });
+    EXPECT_FALSE(found) << "Callback should be removed from queue controller after stop";
+
+    registration::set_init_status(1);
+    registration::finalize();
+    context::pop_client(1);
+    set_client_ctx(get_client_ctx());
+}
+
+TEST(spm_core, stop_context_sync_and_restart)
+{
+    rocprofiler::common::set_env("ROCPROFILER_SPM_BETA_ENABLED", true);
+    ASSERT_EQ(hsa_init(), HSA_STATUS_SUCCESS);
+    test_init();
+
+    registration::init_logging();
+    registration::set_init_status(-1);
+    context::push_client(1);
+    registration::set_fini_status(0);
+
+    ROCPROFILER_CALL(rocprofiler_create_context(&get_client_ctx()), "context creation failed");
+
+    ROCPROFILER_CALL(rocprofiler_spm_configure_callback_dispatch_service(get_client_ctx(),
+                                                                         null_dispatch_callback,
+                                                                         (void*) 0x12345,
+                                                                         null_record_callback,
+                                                                         (void*) 0x54321),
+                     "Could not setup counting service");
+    ROCPROFILER_CALL(rocprofiler_start_context(get_client_ctx()), "start context");
+
+    auto* ctx_p = context::get_mutable_registered_context(get_client_ctx());
+    ASSERT_TRUE(ctx_p);
+    auto& ctx = *ctx_p;
+    ASSERT_TRUE(ctx.dispatch_spm);
+
+    auto pre_stop_queue_id = ctx.dispatch_spm->callbacks.at(0)->queue_id;
+
+    ROCPROFILER_CALL(rocprofiler_stop_context(get_client_ctx()), "stop context");
+
+    // Restart to verify queue controller is in a clean state after sync + teardown
+    ROCPROFILER_CALL(rocprofiler_start_context(get_client_ctx()), "restart context");
+
+    bool enabled = false;
+    ctx.dispatch_spm->enabled.rlock([&](const auto& data) { enabled = data; });
+    EXPECT_TRUE(enabled) << "Context should be enabled after restart";
+
+    auto post_restart_queue_id = ctx.dispatch_spm->callbacks.at(0)->queue_id;
+    EXPECT_NE(post_restart_queue_id, hsa::ClientID{-1})
+        << "Restarted context should have a valid queue_id";
+    EXPECT_NE(post_restart_queue_id, pre_stop_queue_id)
+        << "Restarted context should get a fresh callback ID";
+
+    bool found = false;
+    hsa::get_queue_controller()->iterate_callbacks([&](auto cid, const auto&) {
+        if(cid == post_restart_queue_id) found = true;
+    });
+    EXPECT_TRUE(found) << "New callback should be registered after restart";
+
+    ROCPROFILER_CALL(rocprofiler_stop_context(get_client_ctx()), "stop context final");
+
+    registration::set_init_status(1);
+    registration::finalize();
+    context::pop_client(1);
+    set_client_ctx(get_client_ctx());
+}

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/spm/tests/spm_memory_pool_test.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/spm/tests/spm_memory_pool_test.cpp
@@ -1,0 +1,272 @@
+// MIT License
+//
+// Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#include "lib/rocprofiler-sdk/hsa/aql_packet.hpp"
+
+#include <gtest/gtest.h>
+
+#include <cstdint>
+
+using namespace rocprofiler::hsa;
+
+namespace
+{
+struct MockState
+{
+    void*        last_freed_ptr  = nullptr;
+    size_t       last_alloc_size = 0;
+    void*        alloc_out       = nullptr;
+    hsa_status_t alloc_return    = HSA_STATUS_SUCCESS;
+    void*        last_copy_dst   = nullptr;
+    const void*  last_copy_src   = nullptr;
+    size_t       last_copy_size  = 0;
+};
+
+MockState&
+mock_state()
+{
+    static MockState s{};
+    return s;
+}
+
+void
+reset_mock_state()
+{
+    mock_state() = MockState{};
+}
+
+hsa_status_t
+mock_free(void* ptr)
+{
+    mock_state().last_freed_ptr = ptr;
+    return HSA_STATUS_SUCCESS;
+}
+
+hsa_status_t
+mock_allocate(hsa_amd_memory_pool_t, size_t size, uint32_t, void** ptr)
+{
+    mock_state().last_alloc_size = size;
+    *ptr                         = &mock_state().alloc_out;
+    return mock_state().alloc_return;
+}
+
+hsa_status_t
+mock_copy(void* dst, const void* src, size_t size)
+{
+    mock_state().last_copy_dst  = dst;
+    mock_state().last_copy_src  = src;
+    mock_state().last_copy_size = size;
+    return HSA_STATUS_SUCCESS;
+}
+
+hsa_status_t
+mock_allow_access(uint32_t, const hsa_agent_t*, const uint32_t*, const void*)
+{
+    return HSA_STATUS_SUCCESS;
+}
+
+hsa_status_t
+mock_fill(void*, uint32_t, size_t)
+{
+    return HSA_STATUS_SUCCESS;
+}
+
+void
+make_pool_valid(SPMMemoryPool& pool)
+{
+    pool.free_fn     = &mock_free;
+    pool.allocate_fn = &mock_allocate;
+    pool.api_copy_fn = &mock_copy;
+    pool.cpu_pool_   = {.handle = 1};
+}
+
+}  // namespace
+
+// ---------------------------------------------------------------------------
+// Free tests
+// ---------------------------------------------------------------------------
+
+// Freeing a null pointer should be a safe no-op (free_fn must not be called)
+TEST(spm_memory_pool, free_nullptr)
+{
+    reset_mock_state();
+    auto pool = SPMMemoryPool{};
+    make_pool_valid(pool);
+    SPMMemoryPool::Free(nullptr, &pool);
+    EXPECT_EQ(mock_state().last_freed_ptr, nullptr);
+}
+
+// Freeing a valid pointer should delegate to the pool's free_fn
+TEST(spm_memory_pool, free_validptr)
+{
+    reset_mock_state();
+    auto pool = SPMMemoryPool{};
+    make_pool_valid(pool);
+    int dummy = 42;
+    SPMMemoryPool::Free(&dummy, &pool);
+    EXPECT_EQ(mock_state().last_freed_ptr, &dummy);
+}
+
+// ---------------------------------------------------------------------------
+// Alloc tests
+// ---------------------------------------------------------------------------
+
+// Zero-size allocation with a valid output pointer should set the pointer to null
+TEST(spm_memory_pool, alloc_zero_size)
+{
+    reset_mock_state();
+    auto pool = SPMMemoryPool{};
+    make_pool_valid(pool);
+    int                            dummy = 0;
+    void*                          out   = &dummy;
+    aqlprofile_buffer_desc_flags_t flags{};
+    flags.host_access = 1;
+
+    auto status = SPMMemoryPool::Alloc(&out, 0, flags, &pool);
+    EXPECT_EQ(status, HSA_STATUS_SUCCESS);
+    EXPECT_EQ(out, nullptr);
+}
+
+// Zero-size allocation with a null output pointer should succeed without side effects
+TEST(spm_memory_pool, alloc_zero_size_nullptr)
+{
+    auto status = SPMMemoryPool::Alloc(nullptr, 0, {}, nullptr);
+    EXPECT_EQ(status, HSA_STATUS_SUCCESS);
+}
+
+// Non-zero allocation with a null output pointer is an invalid call
+TEST(spm_memory_pool, alloc_nullptr)
+{
+    auto                           pool = SPMMemoryPool{};
+    aqlprofile_buffer_desc_flags_t flags{};
+    flags.host_access = 1;
+
+    auto status = SPMMemoryPool::Alloc(nullptr, 1024, flags, &pool);
+    EXPECT_EQ(status, HSA_STATUS_ERROR);
+}
+
+// Non-zero allocation with a null pool (data) pointer is an invalid call
+TEST(spm_memory_pool, alloc_null_data)
+{
+    void*                          out = nullptr;
+    aqlprofile_buffer_desc_flags_t flags{};
+    flags.host_access = 1;
+
+    auto status = SPMMemoryPool::Alloc(&out, 1024, flags, nullptr);
+    EXPECT_EQ(status, HSA_STATUS_ERROR);
+}
+
+// Allocation without host_access flag set should be rejected
+TEST(spm_memory_pool, alloc_nohostaccess)
+{
+    auto pool = SPMMemoryPool{};
+    make_pool_valid(pool);
+    pool.allow_access_fn = &mock_allow_access;
+    pool.fill_fn         = &mock_fill;
+
+    void*                          out = nullptr;
+    aqlprofile_buffer_desc_flags_t flags{};
+    flags.host_access = 0;
+
+    auto status = SPMMemoryPool::Alloc(&out, 1024, flags, &pool);
+    EXPECT_EQ(status, HSA_STATUS_ERROR);
+}
+
+// Allocation should fail if the pool has no allocate_fn set
+TEST(spm_memory_pool, alloc_missingallocatefn)
+{
+    auto pool = SPMMemoryPool{};
+    make_pool_valid(pool);
+    pool.allocate_fn     = nullptr;
+    pool.allow_access_fn = &mock_allow_access;
+    pool.fill_fn         = &mock_fill;
+
+    void*                          out = nullptr;
+    aqlprofile_buffer_desc_flags_t flags{};
+    flags.host_access = 1;
+
+    auto status = SPMMemoryPool::Alloc(&out, 1024, flags, &pool);
+    EXPECT_EQ(status, HSA_STATUS_ERROR);
+}
+
+// Allocation should fail if the pool has no free_fn set
+TEST(spm_memory_pool, alloc_missingfreefn)
+{
+    auto pool = SPMMemoryPool{};
+    make_pool_valid(pool);
+    pool.free_fn         = nullptr;
+    pool.allow_access_fn = &mock_allow_access;
+    pool.fill_fn         = &mock_fill;
+
+    void*                          out = nullptr;
+    aqlprofile_buffer_desc_flags_t flags{};
+    flags.host_access = 1;
+
+    auto status = SPMMemoryPool::Alloc(&out, 1024, flags, &pool);
+    EXPECT_EQ(status, HSA_STATUS_ERROR);
+}
+
+// Valid allocation should succeed and forward the requested size to allocate_fn
+TEST(spm_memory_pool, alloc)
+{
+    reset_mock_state();
+    auto pool = SPMMemoryPool{};
+    make_pool_valid(pool);
+    pool.allow_access_fn = &mock_allow_access;
+    pool.fill_fn         = &mock_fill;
+
+    void*                          out = nullptr;
+    aqlprofile_buffer_desc_flags_t flags{};
+    flags.host_access = 1;
+
+    auto status = SPMMemoryPool::Alloc(&out, 4096, flags, &pool);
+    EXPECT_EQ(status, HSA_STATUS_SUCCESS);
+    EXPECT_NE(out, nullptr);
+    EXPECT_EQ(mock_state().last_alloc_size, 4096u);
+}
+
+// ---------------------------------------------------------------------------
+// Copy tests
+// ---------------------------------------------------------------------------
+
+// Zero-size copy should succeed without requiring valid pointers or pool
+TEST(spm_memory_pool, copy_zero_size)
+{
+    auto status = SPMMemoryPool::Copy(nullptr, nullptr, 0, nullptr);
+    EXPECT_EQ(status, HSA_STATUS_SUCCESS);
+}
+
+// Valid copy should delegate to the pool's api_copy_fn with correct arguments
+TEST(spm_memory_pool, copy)
+{
+    reset_mock_state();
+    auto pool = SPMMemoryPool{};
+    make_pool_valid(pool);
+    char dst[16] = {};
+    char src[16] = "hello";
+
+    auto status = SPMMemoryPool::Copy(dst, src, 16, &pool);
+    EXPECT_EQ(status, HSA_STATUS_SUCCESS);
+    EXPECT_EQ(mock_state().last_copy_dst, dst);
+    EXPECT_EQ(mock_state().last_copy_src, src);
+    EXPECT_EQ(mock_state().last_copy_size, 16u);
+}


### PR DESCRIPTION
## Motivation

 This PR adds the core SPM counter collection infrastructure to rocprofiler-sdk

## Technical Details
Adds core data structures 
Lifecycle management — singleton SpmCounterController, packet caching, context start/stop
Declares pre/post kernel dispatch callback signatures 
Decodes SPM data into rocprofiler_spm_counter_record_t records, routes to buffer or user callback
 This commit builds the AQL packet layer for SPM and integrates it into the HSA queue infrastructure
 Builds an SPMPacket from metrics, agent info, and SPM parameters
Manages HSA memory allocation/deallocation/copy for SPM buffers
WriteInterceptor now injects before_krn_barrier_pkt packets                            
Bumps expected_context_size from 216 to 224 (reflects the new dispatch_spm field added to the context struct).
Queue creation now checks for dispatch_spm contexts alongside existing counter/trace checks.
Adds dispatch_spm to the queue intercept enable check, so SPM contexts trigger queue interception.

## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan

Added unit tests for SPM core implemetation

## Test Result

Pass

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
