### PR TITLE
[rocprofiler-sdk] Add SPM AQL packet construction and HSA queue integration

### DIFF
--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/aql/packet_construct.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/aql/packet_construct.cpp
@@ -42,6 +42,12 @@ namespace rocprofiler
 {
 namespace aql
 {
+struct AQLProfileMetric
+{
+    counters::Metric                    metric;
+    std::vector<aqlprofile_pmc_event_t> events;
+};
+
 CounterPacketConstruct::CounterPacketConstruct(rocprofiler_agent_id_t               agent,
                                                const std::vector<counters::Metric>& metrics)
 : _agent(agent)
@@ -278,5 +284,138 @@ CounterPacketConstruct::can_collect()
     }
     return ROCPROFILER_STATUS_SUCCESS;
 }
+
+/** @brief Constructs the packet using the contained input parameters.
+ * Writes into ID map and spm descriptor used to decode SPM data
+ */
+std::unique_ptr<hsa::SPMPacket>
+spm_construct_packet(const rocprofiler_agent_id_t                     agent_id,
+                     const std::vector<counters::Metric>&             metrics,
+                     const std::vector<rocprofiler_spm_parameters_t>& spm_parameters)
+{
+    auto events = std::vector<aqlprofile_pmc_event_t>{};
+    auto params = std::vector<aqlprofile_spm_parameter_t>{};
+    auto id_map = std::vector<spm::spm_counter_instance_t>{};
+
+    const auto* agent     = CHECK_NOTNULL(rocprofiler::agent::get_agent(agent_id));
+    const auto* aql_cache = CHECK_NOTNULL(rocprofiler::agent::get_agent_cache(agent));
+    auto        pool      = std::make_shared<hsa::SPMMemoryPool>(
+        *aql_cache, *hsa::get_amd_ext_table(), hsa::get_core_table()->hsa_memory_copy_fn);
+    const auto* aql_agent = CHECK_NOTNULL(rocprofiler::agent::get_aql_agent(agent->id));
+
+    for(const auto& param : spm_parameters)
+    {
+        switch(param.type)
+        {
+            case ROCPROFILER_SPM_PARAMETER_TYPE_SAMPLE_INTERVAL_SCLK_CYCLES:
+                params.push_back(
+                    {AQLPROFILE_SPM_PARAMETER_TYPE_SAMPLE_INTERVAL_SCLK_CYCLES, param.value});
+                params.push_back({AQLPROFILE_SPM_PARAMETER_TYPE_SAMPLE_MODE,
+                                  AQLPROFILE_SPM_PARAMETER_SAMPLE_MODE_SCLK});
+                break;
+            default:
+                ROCP_WARNING << "Unknown SPM parameter type: " << static_cast<int>(param.type)
+                             << " parameter ignored";
+                break;
+        }
+    }
+
+    for(const auto& metric : metrics)
+    {
+        auto query_info = get_query_info(agent_id, metric);
+
+        for(unsigned block_index = 0; block_index < query_info.instance_count; ++block_index)
+        {
+            uint64_t event_id = 0;
+            if(!metric.event().empty()) event_id = std::stoul(metric.event(), nullptr);
+
+            auto event = aqlprofile_pmc_event_t{
+                .block_index = block_index,
+                .event_id    = static_cast<uint32_t>(event_id & 0xFFFFFFFF),
+                .flags       = aqlprofile_pmc_event_flags_t{metric.flags()},
+                .block_name  = static_cast<hsa_ven_amd_aqlprofile_block_name_t>(query_info.id)};
+
+            events.push_back(event);
+            id_map.push_back({rocprofiler_counter_id_t{.handle = metric.id()}, block_index});
+        }
+    }
+
+    auto pkt = std::make_unique<hsa::SPMPacket>(*aql_agent, std::move(pool), events, params);
+    ROCP_FATAL_IF(!pkt->valid()) << "SPM Packet creation failed";
+
+    pkt->spm_desc.size =
+        sizeof(spm::spm_desc_v0_t) + id_map.size() * sizeof(id_map[0]) + pkt->aql_desc.size;
+
+    pkt->container_desc_data = std::make_shared<std::vector<char>>(pkt->spm_desc.size);
+    pkt->spm_desc.data       = pkt->container_desc_data->data();
+
+    auto* desc = static_cast<spm::spm_desc_v0_t*>(pkt->spm_desc.data);
+
+    *desc               = spm::spm_desc_v0_t{};
+    desc->aql_desc_size = pkt->aql_desc.size;
+    desc->num_events    = id_map.size();
+
+    std::memcpy(desc->aqlprofile_desc(), pkt->aql_desc.data, pkt->aql_desc.size);
+    std::memcpy(desc->events(), id_map.data(), id_map.size() * sizeof(id_map[0]));
+
+    return pkt;
+}
+
+// Following the PMC check for now
+// ToDO: change this to SPM
+rocprofiler_status_t
+spm_can_collect(const rocprofiler_agent_id_t agent_id, const std::vector<counters::Metric>& metrics)
+{
+    // Verify that the counters fit within harrdware limits
+    auto counter_count =
+        std::map<std::pair<hsa_ven_amd_aqlprofile_block_name_t, uint32_t>, int64_t>{};
+    auto max_allowed =
+        std::map<std::pair<hsa_ven_amd_aqlprofile_block_name_t, uint32_t>, int64_t>{};
+    auto _metrics = std::vector<AQLProfileMetric>{};
+
+    for(const auto& metric : metrics)
+    {
+        auto query_info                = get_query_info(agent_id, metric);
+        _metrics.emplace_back().metric = metric;
+        uint64_t event_id              = 0;
+        if(!metric.event().empty())
+            event_id =
+                static_cast<uint32_t>(std::stoul(metric.event().c_str(), nullptr) & 0xFFFFFFFF);
+
+        for(unsigned block_index = 0; block_index < query_info.instance_count; ++block_index)
+        {
+            _metrics.back().events.push_back(
+                {.block_index = block_index,
+                 .event_id    = static_cast<uint32_t>(event_id),
+                 .flags       = aqlprofile_pmc_event_flags_t{metric.flags()},
+                 .block_name  = static_cast<hsa_ven_amd_aqlprofile_block_name_t>(query_info.id)});
+        }
+    }
+
+    for(auto& metric : _metrics)
+    {
+        for(auto& instance : metric.events)
+        {
+            auto block_pair       = std::make_pair(instance.block_name, instance.block_index);
+            auto [iter, inserted] = counter_count.emplace(block_pair, 0);
+            iter->second++;
+            if(inserted)
+            {
+                max_allowed.emplace(block_pair, get_block_counters(agent_id, instance));
+            }
+        }
+    }
+
+    // Check if the block count > max count
+    for(auto& [block_name, count] : counter_count)
+    {
+        if(auto* max = CHECK_NOTNULL(common::get_val(max_allowed, block_name)); count > *max)
+        {
+            return ROCPROFILER_STATUS_ERROR_EXCEEDS_HW_LIMIT;
+        }
+    }
+    return ROCPROFILER_STATUS_SUCCESS;
+}
+
 }  // namespace aql
 }  // namespace rocprofiler

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/aql/packet_construct.hpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/aql/packet_construct.hpp
@@ -26,6 +26,7 @@
 #include "lib/rocprofiler-sdk/aql/helpers.hpp"
 #include "lib/rocprofiler-sdk/counters/metrics.hpp"
 #include "lib/rocprofiler-sdk/hsa/agent_cache.hpp"
+#include "lib/rocprofiler-sdk/spm/decode.hpp"
 #include "lib/rocprofiler-sdk/thread_trace/core.hpp"
 
 #include <rocprofiler-sdk/fwd.h>
@@ -125,6 +126,15 @@ public:
 private:
     hsa::TraceMemoryPool tracepool;
 };
+
+std::unique_ptr<hsa::SPMPacket>
+spm_construct_packet(const rocprofiler_agent_id_t                     agent_id,
+                     const std::vector<counters::Metric>&             metrics,
+                     const std::vector<rocprofiler_spm_parameters_t>& spm_parameters);
+
+rocprofiler_status_t
+spm_can_collect(const rocprofiler_agent_id_t         agent_id,
+                const std::vector<counters::Metric>& metrics);
 
 }  // namespace aql
 }  // namespace rocprofiler

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/hsa/aql_packet.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/hsa/aql_packet.cpp
@@ -21,6 +21,8 @@
 // THE SOFTWARE.
 
 #include "lib/rocprofiler-sdk/hsa/aql_packet.hpp"
+#include "lib/rocprofiler-sdk/hsa/agent_cache.hpp"
+
 #include <fmt/core.h>
 #include <cstdlib>
 #include <iostream>
@@ -242,5 +244,175 @@ CodeobjMarkerAQLPacket::CodeobjMarkerAQLPacket(const TraceMemoryPool& _tracepool
     clear();
 }
 
+SPMMemoryPool::SPMMemoryPool(const AgentCache& agent, const AmdExtTable& ext, copy_fn_t copy_fn)
+{
+    allocate_fn     = ext.hsa_amd_memory_pool_allocate_fn;
+    allow_access_fn = ext.hsa_amd_agents_allow_access_fn;
+    free_fn         = ext.hsa_amd_memory_pool_free_fn;
+    fill_fn         = ext.hsa_amd_memory_fill_fn;
+    api_copy_fn     = copy_fn;
+
+    gpu_agent = agent.get_hsa_agent();
+    cpu_pool_ = agent.cpu_pool();
+}
+
+void
+SPMMemoryPool::Free(void* ptr, void* data)
+{
+    if(ptr == nullptr) return;
+    auto* pool = reinterpret_cast<SPMMemoryPool*>(data);
+
+    ROCP_FATAL_IF(!pool || !pool->free_fn) << "Unable to deallocate from HSA memory pool";
+    pool->free_fn(ptr);
+}
+
+hsa_status_t
+SPMMemoryPool::Copy(void* dst, const void* src, size_t size, void* data)
+{
+    if(size == 0) return HSA_STATUS_SUCCESS;
+    auto* pool = reinterpret_cast<SPMMemoryPool*>(data);
+    ROCP_FATAL_IF(!pool || !pool->api_copy_fn) << "Unable to copy HSA memory";
+
+    return pool->api_copy_fn(dst, src, size);
+}
+
+hsa_status_t
+SPMMemoryPool::Alloc(void** ptr, size_t size, aqlprofile_buffer_desc_flags_t flags, void* data)
+{
+    hsa_status_t status = HSA_STATUS_ERROR;
+
+    if(size == 0)
+    {
+        if(ptr != nullptr) *ptr = nullptr;
+        return HSA_STATUS_SUCCESS;
+    }
+
+    if(!ptr) return HSA_STATUS_ERROR;
+    if(!data) return HSA_STATUS_ERROR;
+
+    auto& pool = *reinterpret_cast<SPMMemoryPool*>(data);
+    if(!flags.host_access || !pool.allocate_fn || !pool.free_fn || !pool.allow_access_fn ||
+       !pool.fill_fn)
+        return HSA_STATUS_ERROR;
+
+    status = pool.allocate_fn(pool.cpu_pool_, size, hsa_amd_memory_pool_executable_flag, ptr);
+
+    return status;
+}
+
+SPMPacket::SPMPacket(aqlprofile_agent_handle_t                aql_agent,
+                     std::shared_ptr<SPMMemoryPool>           _pool,
+                     std::vector<aqlprofile_pmc_event_t>&     events,
+                     std::vector<aqlprofile_spm_parameter_t>& params)
+: agent(aql_agent)
+, pool(std::move(_pool))
+, aql_events(std::move(events))
+, aql_params(std::move(params))
+{
+    sym = rocprofiler::spm::construct_spm_interface();
+    if(!sym)
+    {
+        ROCP_ERROR << "Failed to construct SPM interface";
+        return;
+    }
+    aqlprofile_spm_profile_t profile{.aql_agent       = aql_agent,
+                                     .hsa_agent       = pool->gpu_agent,
+                                     .events          = aql_events.data(),
+                                     .event_count     = aql_events.size(),
+                                     .parameters      = aql_params.data(),
+                                     .parameter_count = aql_params.size(),
+                                     .reserved        = 0,
+                                     .alloc_cb        = &(hsa::SPMMemoryPool::Alloc),
+                                     .dealloc_cb      = &(hsa::SPMMemoryPool::Free),
+                                     .memcpy_cb       = &(hsa::SPMMemoryPool::Copy),
+                                     .userdata        = pool.get()};
+
+    auto status = sym->spm_create_packets(&handle, &aql_desc, &packets, profile, 0);
+    if(status != HSA_STATUS_SUCCESS)
+    {
+        ROCP_ERROR << "spm_create_packets failed with HSA status: " << status
+                   << " (event_count=" << aql_events.size() << ")";
+        return;
+    }
+    packets.start_packet.header            = VENDOR_BIT | BARRIER_BIT;
+    packets.stop_packet.header             = VENDOR_BIT | BARRIER_BIT;
+    packets.start_packet.completion_signal = hsa_signal_t{.handle = 0};
+    packets.stop_packet.completion_signal  = hsa_signal_t{.handle = 0};
+
+    pool->delete_packets_fn = sym->spm_delete_packets;
+    pool->handle            = handle;
+
+    status =
+        sym->spm_decode_query(aql_desc, AQLPROFILE_SPM_DECODE_QUERY_SEG_SIZE, &spm_desc.seg_size);
+    if(status != HSA_STATUS_SUCCESS) return;
+    status =
+        sym->spm_decode_query(aql_desc, AQLPROFILE_SPM_DECODE_QUERY_NUM_XCC, &spm_desc.buffer_num);
+    if(status != HSA_STATUS_SUCCESS) return;
+
+    is_valid = true;
+    empty    = false;
+}
+
+void
+SPMPacket::populate_before()
+{
+    hsa_barrier_and_packet_t barrier{};
+    barrier.header = HSA_PACKET_TYPE_BARRIER_AND << HSA_PACKET_HEADER_TYPE;
+    barrier.header |= BARRIER_BIT;
+
+    before_krn_barrier_pkt.push_back(barrier);
+    before_krn_barrier_pkt.push_back(barrier);
+    before_krn_pkt.push_back(packets.start_packet);
+};
+
+void
+SPMPacket::populate_after()
+{
+    after_krn_pkt.push_back(packets.stop_packet);
+};
+
+void
+SPMPacket::kfd_start()
+{
+    ROCP_FATAL_IF(!handle.handle) << "Attempt at starting SPM with uninitialized packet!";
+
+    running.wlock([&](auto& _running) {
+        if(_running == true)
+        {
+            ROCP_ERROR << "Double call to KFD start!";
+            return;
+        }
+        auto status = sym->spm_start(this->handle, spm::aql_data_callback, this);
+        ROCP_FATAL_IF(status != HSA_STATUS_SUCCESS) << "Unable to acquire KFD thread";
+        _running = true;
+    });
+}
+
+void
+SPMPacket::kfd_stop()
+{
+    running.wlock([&](auto& _running) {
+        if(_running == false)
+        {
+            ROCP_WARNING << "Double call to KFD stop!";
+            return;
+        }
+        auto status = sym->spm_stop(this->handle);
+        ROCP_WARNING_IF(status != HSA_STATUS_SUCCESS)
+            << "spm_stop failed with HSA status: " << status;
+        _running = false;
+    });
+}
+
+SPMPacket::~SPMPacket()
+{
+    running.wlock([&](auto& _running) {
+        if(_running == false) return;
+        auto status = sym->spm_stop(this->handle);
+        ROCP_WARNING_IF(status != HSA_STATUS_SUCCESS)
+            << "spm_stop failed with HSA status: " << status;
+        _running = false;
+    });
+}
 }  // namespace hsa
 }  // namespace rocprofiler

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/hsa/aql_packet.hpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/hsa/aql_packet.hpp
@@ -23,12 +23,20 @@
 #pragma once
 
 #include "lib/common/container/small_vector.hpp"
+#include "lib/common/synchronized.hpp"
 #include "lib/rocprofiler-sdk/aql/aql_profile_v2.h"
+#include "lib/rocprofiler-sdk/spm/decode.hpp"
+#include "lib/rocprofiler-sdk/spm/interface.hpp"
 
+#include <rocprofiler-sdk/experimental/spm.h>
 #include <rocprofiler-sdk/hsa.h>
+#include <rocprofiler-sdk/rocprofiler.h>
 
 #include <hsa/hsa_ext_amd.h>
 #include <hsa/hsa_ven_amd_aqlprofile.h>
+
+#include <atomic>
+#include <optional>
 
 namespace rocprofiler
 {
@@ -76,6 +84,7 @@ public:
     {
         before_krn_pkt.clear();
         after_krn_pkt.clear();
+        before_krn_barrier_pkt.clear();
     }
     bool isEmpty() const { return empty; }
 
@@ -86,8 +95,9 @@ public:
     aqlprofile_handle_t handle = {.handle = 0};
     bool                empty  = {true};
 
-    common::container::small_vector<hsa_ext_amd_aql_pm4_packet_t, 3> before_krn_pkt = {};
-    common::container::small_vector<hsa_ext_amd_aql_pm4_packet_t, 2> after_krn_pkt  = {};
+    common::container::small_vector<hsa_ext_amd_aql_pm4_packet_t, 3> before_krn_pkt         = {};
+    common::container::small_vector<hsa_ext_amd_aql_pm4_packet_t, 2> after_krn_pkt          = {};
+    common::container::small_vector<hsa_barrier_and_packet_t, 2>     before_krn_barrier_pkt = {};
 };
 
 class EmptyAQLPacket : public AQLPacket
@@ -233,6 +243,74 @@ protected:
     aqlprofile_att_control_aql_packets_t packets;
 
     std::unordered_map<code_object_id_t, std::shared_ptr<CodeobjMarkerAQLPacket>> loaded_codeobj;
+};
+
+struct SPMMemoryPool
+{
+    using desc_t                                            = aqlprofile_buffer_desc_flags_t;
+    using copy_fn_t                                         = decltype(hsa_memory_copy);
+    hsa_agent_t                             gpu_agent       = {.handle = 0};
+    hsa_amd_memory_pool_t                   cpu_pool_       = {.handle = 0};
+    hsa_amd_memory_pool_t                   gpu_pool_       = {.handle = 0};
+    hsa_amd_memory_pool_t                   kernarg_pool_   = {.handle = 0};
+    decltype(hsa_amd_memory_pool_allocate)* allocate_fn     = nullptr;
+    decltype(hsa_amd_agents_allow_access)*  allow_access_fn = nullptr;
+    decltype(hsa_amd_memory_pool_free)*     free_fn         = nullptr;
+    decltype(hsa_memory_copy)*              api_copy_fn     = nullptr;
+    decltype(hsa_amd_memory_fill)*          fill_fn         = nullptr;
+
+    SPMMemoryPool(const class AgentCache& agent, const class AmdExtTable& ext, copy_fn_t copy_fn);
+    ~SPMMemoryPool()
+    {
+        if(delete_packets_fn != nullptr && handle.handle != 0) delete_packets_fn(handle);
+    };
+    explicit SPMMemoryPool() = default;
+    static hsa_status_t Alloc(void**                         ptr,
+                              size_t                         size,
+                              aqlprofile_buffer_desc_flags_t flags,
+                              void*                          data);
+    static void         Free(void* ptr, void* data);
+    static hsa_status_t Copy(void* dst, const void* src, size_t size, void* data);
+    spm::spm_interface::spm_delete_packets_fn_t* delete_packets_fn{nullptr};
+    aqlprofile_handle_t                          handle{};
+};
+
+class SPMPacket : public AQLPacket
+{
+public:
+    SPMPacket(aqlprofile_agent_handle_t                aql_agent,
+              std::shared_ptr<SPMMemoryPool>           _pool,
+              std::vector<aqlprofile_pmc_event_t>&     events,
+              std::vector<aqlprofile_spm_parameter_t>& params);
+
+    ~SPMPacket() override;
+    SPMPacket& operator=(const SPMPacket&) = delete;
+    SPMPacket(const SPMPacket&)            = delete;
+
+    void        kfd_start();
+    void        kfd_stop();
+    hsa_agent_t GetAgent() const { return pool ? pool->gpu_agent : hsa_agent_t{}; }
+    std::optional<rocprofiler_buffer_id_t>           buffer;
+    aqlprofile_agent_handle_t                        agent;
+    rocprofiler_user_data_t                          user_data{};
+    void*                                            record_callback_args{};
+    aqlprofile_spm_buffer_desc_t                     aql_desc{};
+    rocprofiler::spm::spm_descriptor_t               spm_desc{};
+    rocprofiler_spm_dispatch_counting_record_cb_t    record_cb{};
+    rocprofiler_spm_dispatch_counting_service_data_t dispatch_data{};
+    std::shared_ptr<std::vector<char>>               container_desc_data{};
+    aqlprofile_spm_aql_packets_t                     packets{};
+    std::shared_ptr<SPMMemoryPool>                   pool{};
+    void                                             populate_before() override;
+    void                                             populate_after() override;
+    bool                                             valid() const { return is_valid; }
+    const spm::spm_interface*                        sym = nullptr;
+    std::vector<aqlprofile_pmc_event_t>              aql_events{};
+    std::vector<aqlprofile_spm_parameter_t>          aql_params{};
+
+private:
+    common::Synchronized<bool> running{false};
+    bool                       is_valid{false};
 };
 
 }  // namespace hsa

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/hsa/queue.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/hsa/queue.cpp
@@ -564,6 +564,16 @@ WriteInterceptor(const void* packets,
 
             for(const auto& pkt_injection : _packet_data.instrumentation_packets)
             {
+                if(!pkt_injection.first->before_krn_barrier_pkt.empty())
+                {
+                    for(const auto& pkt : pkt_injection.first->before_krn_barrier_pkt)
+                    {
+                        transformed_packets.emplace_back(pkt);
+                    }
+                }
+            }
+            for(const auto& pkt_injection : _packet_data.instrumentation_packets)
+            {
                 for(const auto& pkt : pkt_injection.first->before_krn_pkt)
                 {
                     inserted_before = true;
@@ -745,7 +755,7 @@ Queue::Queue(const AgentCache&  agent,
 
     if(!context::get_registered_contexts([](const context::context* ctx) {
             return (ctx->dispatch_counter_collection || ctx->device_counter_collection ||
-                    ctx->dispatch_thread_trace || ctx->device_thread_trace);
+                    ctx->dispatch_spm || ctx->dispatch_thread_trace || ctx->device_thread_trace);
         }).empty())
     {
         CHECK(_agent.cpu_pool().handle != 0);

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/hsa/queue_controller.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/hsa/queue_controller.cpp
@@ -504,7 +504,7 @@ enable_queue_intercept()
 {
     for(const auto& itr : context::get_registered_contexts())
     {
-        constexpr auto expected_context_size = 216UL;
+        constexpr auto expected_context_size = 224UL;
         static_assert(
             sizeof(context::context) == expected_context_size,
             "If you added a new field to context struct, make sure there is a check here if it "
@@ -517,8 +517,8 @@ enable_queue_intercept()
                                      itr->is_tracing(ROCPROFILER_BUFFER_TRACING_SCRATCH_MEMORY);
 
         if(itr->dispatch_counter_collection || itr->pc_sampler || has_kernel_tracing ||
-           has_scratch_reporting || itr->device_counter_collection || itr->device_thread_trace ||
-           itr->dispatch_thread_trace)
+           itr->dispatch_spm || has_scratch_reporting || itr->device_counter_collection ||
+           itr->device_thread_trace || itr->dispatch_thread_trace)
             return true;
     }
 


### PR DESCRIPTION
## Motivation

This PR wires up the low-level AQL packet machinery needed for SPM dispatch-level counter sampling — packet construction, memory management, HSA queue injection.

## Technical Details
Converts metrics to aqlprofile_pmc_event_t events 
Builds an SPM AQL profile packet
Provides kfd_start()/kfd_stop()
Injects barrier packets before kernel dispatch



## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
