### PR TITLE
[AMD-SMI] Make amdsmi_get_clk_freq fallback to nearest discrete value

### DIFF
--- a/projects/amdsmi/src/amd_smi/amd_smi.cc
+++ b/projects/amdsmi/src/amd_smi/amd_smi.cc
@@ -4177,14 +4177,15 @@ amdsmi_status_t amdsmi_get_clk_freq(amdsmi_processor_handle processor_handle,
                                         static_cast<rsmi_clk_type_t>(clk_type),
                                         reinterpret_cast<rsmi_frequencies_t*>(f));
 
-  // The actual memory clock can sit between the discrete DPM levels listed in
-  // pp_dpm_mclk. When this happens the kernel driver omits the '*' marker from
-  // every entry, causing rsmi_dev_gpu_clk_freq_get to return UNEXPECTED_DATA.
+  // The actual clock can sit between the discrete DPM levels reported by the kernel
+  // driver. When this happens the driver may omit the active-level marker from every
+  // entry, causing rsmi_dev_gpu_clk_freq_get to return UNEXPECTED_DATA.
   if (status == AMDSMI_STATUS_UNEXPECTED_DATA && f != nullptr && f->num_supported > 0) {
     amdsmi_clk_info_t clk_info = {};
     if (amdsmi_get_clock_info(processor_handle, clk_type, &clk_info) == AMDSMI_STATUS_SUCCESS &&
         clk_info.clk != UINT32_MAX) {
-      uint64_t actual_clk_hz = static_cast<uint64_t>(clk_info.clk) * 1000000ULL;
+      uint64_t actual_clk_hz =
+          static_cast<uint64_t>(clk_info.clk) * get_multiplier_from_char('M');
       uint32_t closest_idx = 0;
       uint64_t min_diff = UINT64_MAX;
       for (uint32_t i = 0; i < f->num_supported; i++) {

--- a/projects/amdsmi/src/amd_smi/amd_smi.cc
+++ b/projects/amdsmi/src/amd_smi/amd_smi.cc
@@ -4173,9 +4173,35 @@ amdsmi_status_t amdsmi_get_clk_freq(amdsmi_processor_handle processor_handle,
     return (f->num_supported > 0) ? AMDSMI_STATUS_SUCCESS : AMDSMI_STATUS_NOT_SUPPORTED;
   }
 
-  return rsmi_wrapper(rsmi_dev_gpu_clk_freq_get, processor_handle, 0,
+  amdsmi_status_t status = rsmi_wrapper(rsmi_dev_gpu_clk_freq_get, processor_handle, 0,
                       static_cast<rsmi_clk_type_t>(clk_type),
                       reinterpret_cast<rsmi_frequencies_t*>(f));
+
+  // The actual memory clock can sit between the discrete DPM levels listed in
+  // pp_dpm_mclk. When this happens the kernel driver omits the '*' marker from
+  // every entry, causing rsmi_dev_gpu_clk_freq_get to return UNEXPECTED_DATA.
+  if (status == AMDSMI_STATUS_UNEXPECTED_DATA && f != nullptr && f->num_supported > 0) {
+    amdsmi_clk_info_t clk_info = {};
+    if (amdsmi_get_clock_info(processor_handle, clk_type, &clk_info) == AMDSMI_STATUS_SUCCESS
+        && clk_info.clk != UINT32_MAX) {
+      uint64_t actual_clk_hz = static_cast<uint64_t>(clk_info.clk) * 1000000ULL;
+      uint32_t closest_idx = 0;
+      uint64_t min_diff = UINT64_MAX;
+      for (uint32_t i = 0; i < f->num_supported; i++) {
+        uint64_t diff = (f->frequency[i] > actual_clk_hz)
+                            ? f->frequency[i] - actual_clk_hz
+                            : actual_clk_hz - f->frequency[i];
+        if (diff < min_diff) {
+          min_diff = diff;
+          closest_idx = i;
+        }
+      }
+      f->current = closest_idx;
+      status = AMDSMI_STATUS_SUCCESS;
+    }
+  }
+
+  return status;
 }
 
 amdsmi_status_t amdsmi_set_clk_freq(amdsmi_processor_handle processor_handle,

--- a/projects/amdsmi/src/amd_smi/amd_smi.cc
+++ b/projects/amdsmi/src/amd_smi/amd_smi.cc
@@ -4184,7 +4184,8 @@ amdsmi_status_t amdsmi_get_clk_freq(amdsmi_processor_handle processor_handle,
     amdsmi_clk_info_t clk_info = {};
     if (amdsmi_get_clock_info(processor_handle, clk_type, &clk_info) == AMDSMI_STATUS_SUCCESS &&
         clk_info.clk != UINT32_MAX) {
-      uint64_t actual_clk_hz = static_cast<uint64_t>(clk_info.clk) * get_multiplier_from_char('M');
+      uint64_t actual_clk_hz =
+          static_cast<uint64_t>(clk_info.clk) * amd::smi::get_multiplier_from_char('M');
       uint32_t closest_idx = 0;
       uint64_t min_diff = UINT64_MAX;
       for (uint32_t i = 0; i < f->num_supported; i++) {

--- a/projects/amdsmi/src/amd_smi/amd_smi.cc
+++ b/projects/amdsmi/src/amd_smi/amd_smi.cc
@@ -4174,23 +4174,22 @@ amdsmi_status_t amdsmi_get_clk_freq(amdsmi_processor_handle processor_handle,
   }
 
   amdsmi_status_t status = rsmi_wrapper(rsmi_dev_gpu_clk_freq_get, processor_handle, 0,
-                      static_cast<rsmi_clk_type_t>(clk_type),
-                      reinterpret_cast<rsmi_frequencies_t*>(f));
+                                        static_cast<rsmi_clk_type_t>(clk_type),
+                                        reinterpret_cast<rsmi_frequencies_t*>(f));
 
   // The actual memory clock can sit between the discrete DPM levels listed in
   // pp_dpm_mclk. When this happens the kernel driver omits the '*' marker from
   // every entry, causing rsmi_dev_gpu_clk_freq_get to return UNEXPECTED_DATA.
   if (status == AMDSMI_STATUS_UNEXPECTED_DATA && f != nullptr && f->num_supported > 0) {
     amdsmi_clk_info_t clk_info = {};
-    if (amdsmi_get_clock_info(processor_handle, clk_type, &clk_info) == AMDSMI_STATUS_SUCCESS
-        && clk_info.clk != UINT32_MAX) {
+    if (amdsmi_get_clock_info(processor_handle, clk_type, &clk_info) == AMDSMI_STATUS_SUCCESS &&
+        clk_info.clk != UINT32_MAX) {
       uint64_t actual_clk_hz = static_cast<uint64_t>(clk_info.clk) * 1000000ULL;
       uint32_t closest_idx = 0;
       uint64_t min_diff = UINT64_MAX;
       for (uint32_t i = 0; i < f->num_supported; i++) {
-        uint64_t diff = (f->frequency[i] > actual_clk_hz)
-                            ? f->frequency[i] - actual_clk_hz
-                            : actual_clk_hz - f->frequency[i];
+        uint64_t diff = (f->frequency[i] > actual_clk_hz) ? f->frequency[i] - actual_clk_hz
+                                                          : actual_clk_hz - f->frequency[i];
         if (diff < min_diff) {
           min_diff = diff;
           closest_idx = i;

--- a/projects/amdsmi/src/amd_smi/amd_smi.cc
+++ b/projects/amdsmi/src/amd_smi/amd_smi.cc
@@ -4184,8 +4184,7 @@ amdsmi_status_t amdsmi_get_clk_freq(amdsmi_processor_handle processor_handle,
     amdsmi_clk_info_t clk_info = {};
     if (amdsmi_get_clock_info(processor_handle, clk_type, &clk_info) == AMDSMI_STATUS_SUCCESS &&
         clk_info.clk != UINT32_MAX) {
-      uint64_t actual_clk_hz =
-          static_cast<uint64_t>(clk_info.clk) * get_multiplier_from_char('M');
+      uint64_t actual_clk_hz = static_cast<uint64_t>(clk_info.clk) * get_multiplier_from_char('M');
       uint32_t closest_idx = 0;
       uint64_t min_diff = UINT64_MAX;
       for (uint32_t i = 0; i < f->num_supported; i++) {


### PR DESCRIPTION
## Motivation

Fixes https://github.com/ROCm/rocm-systems/issues/3937

On MI300A (and potentially other GPUs with fine-grained frequency scaling), `amdsmi_get_clk_freq` returns `AMDSMI_STATUS_UNEXPECTED_DATA` for `MEM_CLOCK` intermittently. 

The actual memory clock was sitting between discrete DPM levels (e.g., 930 MHz or 1261 MHz when DPM levels are 900, 1100, 1200, 1300 MHz). When this happens, the `*` marker was omitted from all entries in `pp_dpm_mclk`, and `rsmi_dev_gpu_clk_freq_get` returned `RSMI_STATUS_UNEXPECTED_DATA` since it could not identify which DPM level is active.

## Technical Details

When `rsmi_dev_gpu_clk_freq_get` returns `AMDSMI_STATUS_UNEXPECTED_DATA`, `amdsmi_get_clk_freq` now falls back to `amdsmi_get_clock_info` which reads the actual current clock. The real clock value is then resolved to the nearest DPM level index.

## Test Plan

- Was not able to reproduce the issue locally but mocked a few unit tests that pass
- Verify that CI passes

## Test Result

- All unit test cases for the nearest-DPM-level logic pass.
- Waiting on CI passing

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.