### PR TITLE
Set fclk max frequency

### DIFF
--- a/projects/amdsmi/amdsmi_cli/amdsmi_commands.py
+++ b/projects/amdsmi/amdsmi_cli/amdsmi_commands.py
@@ -160,6 +160,7 @@ class AMDSMICommands:
             "sys": amdsmi_interface.AmdSmiClkType.SYS,
             "mem": amdsmi_interface.AmdSmiClkType.MEM,
             "df": amdsmi_interface.AmdSmiClkType.DF,
+            "fclk": amdsmi_interface.AmdSmiClkType.DF,
             "soc": amdsmi_interface.AmdSmiClkType.SOC,
             "dcef": amdsmi_interface.AmdSmiClkType.DCEF,
             # vclk and dclk currently do not support levels so average clk is given for frequency levels
@@ -8904,22 +8905,22 @@ class AMDSMICommands:
 
             # Validate the value against the extremum
             try:
-                # Parser only allows two options sclk or mclk
+                # Parser only allows three options sclk, mclk or fclk
                 if clk_type == "sclk":
                     amdsmi_clk_type = amdsmi_interface.AmdSmiClkType.GFX
                 elif clk_type == "mclk":
                     amdsmi_clk_type = amdsmi_interface.AmdSmiClkType.MEM
+                elif clk_type == "fclk":
+                    amdsmi_clk_type = amdsmi_interface.AmdSmiClkType.DF
                 else:
-                    print(f"Valid clock types are: sclk, mclk\n")
+                    print(f"Valid clock types are: sclk, mclk, fclk\n")
                     self.logger.store_output(
                         args.gpu, "clk_limit", f"Invalid clock type {args.clk_limit.clk_type}"
                     )
                     self.logger.print_output()
                     self.logger.clear_multiple_devices_output()
                     return
-
                 clk_tuple = amdsmi_interface.amdsmi_get_clock_info(args.gpu, amdsmi_clk_type)
-
                 if lim_type == "min":
                     amdsmi_lim_type = amdsmi_interface.AmdSmiClkLimitType.MIN
                     if val > clk_tuple["max_clk"]:

--- a/projects/amdsmi/amdsmi_cli/amdsmi_parser.py
+++ b/projects/amdsmi/amdsmi_cli/amdsmi_parser.py
@@ -338,7 +338,7 @@ class AMDSMIParser(argparse.ArgumentParser):
                 option_string: Optional[str] = None,
             ) -> None:
                 # valid values
-                valid_clk_types = ("sclk", "mclk")
+                valid_clk_types = ("sclk", "mclk", "fclk")
                 valid_lim_types = ("min", "max")
                 clk_type, lim_type, val = values
 
@@ -2387,7 +2387,7 @@ class AMDSMIParser(argparse.ArgumentParser):
                 self.helpers.get_power_caps()
             )
             set_power_cap_help = f"Set either PPT0 or PPT1 power capacity limit:\n\tEx: `amd-smi set -o 1300 ppt0`\n\tPPT0 min cap: {ppt0_power_cap_min}, PPT0 max cap: {ppt0_power_cap_max}\n\tPPT1 min cap: {ppt1_power_cap_min}, PPT1 max cap: {ppt1_power_cap_max}"
-            set_clk_limit_help = "Sets the sclk (aka gfxclk) or mclk minimum and maximum frequencies. \n\tex: amd-smi set -L (sclk | mclk) (min | max) value"
+            set_clk_limit_help = "Sets the sclk (aka gfxclk), mclk, or fclk minimum and maximum frequencies. \n\tex: amd-smi set -L (sclk | mclk | fclk) (min | max) value"
             set_process_isolation_help = "Enable or disable the GPU process isolation on a per partition basis:\n    0 for disable and 1 for enable.\n"
 
         # Help text for CPU set options

--- a/projects/amdsmi/docs/how-to/amdsmi-cli-tool.md
+++ b/projects/amdsmi/docs/how-to/amdsmi-cli-tool.md
@@ -608,8 +608,8 @@ Set Arguments:
                                                 N/A
   -c, --clk-level CLK_TYPE [FREQ_LEVELS ...]  Set one or more sclk (aka gfxclk), mclk, fclk, pcie, or socclk frequency levels.
                                                 Use `amd-smi static --clock` to find acceptable levels.
-  -L, --clk-limit CLK_TYPE LIM_TYPE VALUE     Sets the sclk (aka gfxclk) or mclk minimum and maximum frequencies.
-                                                ex: amd-smi set -L (sclk | mclk) (min | max) value
+  -L, --clk-limit CLK_TYPE LIM_TYPE VALUE     Sets the sclk (aka gfxclk), mclk, or fclk minimum and maximum frequencies.
+                                                ex: amd-smi set -L (sclk | mclk | fclk) (min | max) value
   -R, --process-isolation STATUS              Enable or disable the GPU process isolation on a per partition basis: 0 for disable and 1 for enable.
   --ptl-status STATUS                         Enable or disable the PTL on a GPU processor: 0 for disable and 1 for enable
   --ptl-format FRMT1,FRMT2                    Set the PTL format on a GPU processor. For example, --ptl-format I8,F32

--- a/projects/amdsmi/include/amd_smi/amdsmi.h
+++ b/projects/amdsmi/include/amd_smi/amdsmi.h
@@ -1979,8 +1979,10 @@ typedef struct {
 typedef struct {
   amdsmi_range_t curr_sclk_range;   //!< The current SCLK frequency range in MHz
   amdsmi_range_t curr_mclk_range;   //!< The current MCLK frequency range, upper bound only in MHz
+  amdsmi_range_t curr_fclk_range;   //!< The current FCLK frequency range in MHz
   amdsmi_range_t sclk_freq_limits;  //!< The range possible of SCLK values in MHz
   amdsmi_range_t mclk_freq_limits;  //!< The range possible of MCLK values in MHz
+  amdsmi_range_t fclk_freq_limits;  //!< The range possible of FCLK values in MHz
   amdsmi_od_volt_curve_t curve;     //!< The current voltage curve
   uint32_t num_regions;             //!< The number of voltage curve regions
 } amdsmi_od_volt_freq_data_t;

--- a/projects/amdsmi/py-interface/amdsmi_interface.py
+++ b/projects/amdsmi/py-interface/amdsmi_interface.py
@@ -5124,10 +5124,17 @@ def amdsmi_set_gpu_clk_limit(
         clk_type_conversion = amdsmi_wrapper.AMDSMI_CLK_TYPE_SYS
     elif clk_type.lower() == "mclk":
         clk_type_conversion = amdsmi_wrapper.AMDSMI_CLK_TYPE_MEM
+    elif clk_type.lower() == "fclk":
+        clk_type_conversion = amdsmi_wrapper.AMDSMI_CLK_TYPE_DF
+    else:
+        raise AmdSmiParameterException(f"Unsupported clock type: {clk_type}", str)
+    
     if limit_type.lower() == "min":
         limit_type_conversion = amdsmi_wrapper.CLK_LIMIT_MIN
     elif limit_type.lower() == "max":
         limit_type_conversion = amdsmi_wrapper.CLK_LIMIT_MAX
+    else:
+        raise AmdSmiParameterException(f"Unsupported limit type: {limit_type}", str)
     _check_res(
         amdsmi_wrapper.amdsmi_set_gpu_clk_limit(
             processor_handle, clk_type_conversion, limit_type_conversion, ctypes.c_uint64(value)

--- a/projects/amdsmi/rocm_smi/include/rocm_smi/rocm_smi.h
+++ b/projects/amdsmi/rocm_smi/include/rocm_smi/rocm_smi.h
@@ -1113,8 +1113,10 @@ typedef struct {
   rsmi_range_t curr_sclk_range;   //!< The current SCLK frequency range
   rsmi_range_t curr_mclk_range;   //!< The current MCLK frequency range;
                                   //!< (upper bound only)
+  rsmi_range_t curr_fclk_range;   //!< The current FCLK frequency range
   rsmi_range_t sclk_freq_limits;  //!< The range possible of SCLK values
   rsmi_range_t mclk_freq_limits;  //!< The range possible of MCLK values
+  rsmi_range_t fclk_freq_limits;  //!< The range possible of FCLK values
 
   /**
    * @brief The current voltage curve

--- a/projects/amdsmi/rocm_smi/src/rocm_smi.cc
+++ b/projects/amdsmi/rocm_smi/src/rocm_smi.cc
@@ -1499,6 +1499,9 @@ OD_SCLK:
 1:       1837Mhz
 OD_MCLK:
 1:       1000Mhz
+OD_FCLK:
+0:       1200Mhz
+1:       1300Mhz
 OD_VDDC_CURVE:
 0:        872Mhz        736mV
 1:       1354Mhz        860mV
@@ -1506,6 +1509,7 @@ OD_VDDC_CURVE:
 OD_RANGE:
 SCLK:     872Mhz       1900Mhz
 MCLK:     168Mhz       1200Mhz
+FCLK:     1200Mhz      1400Mhz
 VDDC_CURVE_SCLK[0]:     872Mhz       1900Mhz
 VDDC_CURVE_VOLT[0]:     737mV        1137mV
 VDDC_CURVE_SCLK[1]:     872Mhz       1900Mhz
@@ -1523,6 +1527,9 @@ MCLK:
 1: 700Mhz
 2: 1200Mhz
 3: 1600Mhz *
+FCLK:
+0: 1200Mhz
+1: 1300Mhz *
 
 For the new format, GFXCLK field will show min and max values(0/1). If the current
 frequency in neither min/max but lies within the range, this is indicated by
@@ -1544,6 +1551,8 @@ static rsmi_status_t get_od_clk_volt_info(uint32_t dv_ind, rsmi_od_volt_freq_dat
   p->curr_sclk_range.upper_bound = UINT64_MAX;
   p->curr_mclk_range.lower_bound = UINT64_MAX;
   p->curr_mclk_range.upper_bound = UINT64_MAX;
+  p->curr_fclk_range.lower_bound = UINT64_MAX;
+  p->curr_fclk_range.upper_bound = UINT64_MAX;
 
   ret = GetDevValueVec(amd::smi::kDevPowerODVoltage, dv_ind, &val_vec);
   if (ret != RSMI_STATUS_SUCCESS) {
@@ -1559,9 +1568,11 @@ static rsmi_status_t get_od_clk_volt_info(uint32_t dv_ind, rsmi_od_volt_freq_dat
   // Tags expected in this file
   const std::string kTAG_OD_SCLK{"OD_SCLK:"};
   const std::string KTAG_OD_MCLK{"OD_MCLK:"};
+  const std::string kTAG_OD_FCLK{"OD_FCLK:"};
   const std::string kTAG_GFXCLK{"GFXCLK:"};
   const std::string KTAG_MCLK{"MCLK:"};
   const std::string KTAG_SCLK{"SCLK:"};
+  const std::string KTAG_FCLK{"FCLK:"};
   const std::string KTAG_OD_RANGE{"OD_RANGE:"};
   const std::string KTAG_FIRST_FREQ_IDX{"0:"};
 
@@ -1592,7 +1603,7 @@ static rsmi_status_t get_od_clk_volt_info(uint32_t dv_ind, rsmi_od_volt_freq_dat
 
   // track the number of keys found, if this goes down to 0 then that means that there is no valid
   // data
-  const uint8_t kNumStructuredKeysToCheck = 6;
+  const uint8_t kNumStructuredKeysToCheck = 9;
   uint8_t structured_key_counter = kNumStructuredKeysToCheck;
   // Validates 'OD_SCLK' is in the structure
   if (txt_power_dev_od_voltage.contains_structured_key(kTAG_OD_SCLK, KTAG_FIRST_FREQ_IDX)) {
@@ -1610,6 +1621,14 @@ static rsmi_status_t get_od_clk_volt_info(uint32_t dv_ind, rsmi_od_volt_freq_dat
         freq_string_to_int(build_upper_bound(KTAG_OD_MCLK), nullptr, nullptr, 0);
   } else
     structured_key_counter--;
+  // Validates 'OD_FCLK' is in the structure
+  if (txt_power_dev_od_voltage.contains_structured_key(kTAG_OD_FCLK, KTAG_FIRST_FREQ_IDX)) {
+    p->curr_fclk_range.lower_bound =
+        freq_string_to_int(build_lower_bound(kTAG_OD_FCLK), nullptr, nullptr, 0);
+    p->curr_fclk_range.upper_bound =
+        freq_string_to_int(build_upper_bound(kTAG_OD_FCLK), nullptr, nullptr, 0);
+  } else
+    structured_key_counter--;
 
   // Validates 'OD_RANGE' is in the structure
   if (txt_power_dev_od_voltage.contains_structured_key(KTAG_OD_RANGE, KTAG_SCLK)) {
@@ -1622,6 +1641,12 @@ static rsmi_status_t get_od_clk_volt_info(uint32_t dv_ind, rsmi_od_volt_freq_dat
     od_value_pair_str_to_range(
         txt_power_dev_od_voltage.get_structured_value_by_keys(KTAG_OD_RANGE, KTAG_MCLK),
         &p->mclk_freq_limits);
+  } else
+    structured_key_counter--;
+  if (txt_power_dev_od_voltage.contains_structured_key(KTAG_OD_RANGE, KTAG_FCLK)) {
+    od_value_pair_str_to_range(
+        txt_power_dev_od_voltage.get_structured_value_by_keys(KTAG_OD_RANGE, KTAG_FCLK),
+        &p->fclk_freq_limits);
   } else
     structured_key_counter--;
   // Validates 'GFXCLK' is in the structure
@@ -1638,6 +1663,14 @@ static rsmi_status_t get_od_clk_volt_info(uint32_t dv_ind, rsmi_od_volt_freq_dat
         freq_string_to_int(build_lower_bound(KTAG_MCLK), nullptr, nullptr, 0);
     p->curr_mclk_range.upper_bound =
         freq_string_to_int(build_upper_bound(KTAG_MCLK), nullptr, nullptr, 0);
+  } else
+    structured_key_counter--;
+  // Validates 'FCLK' is in the structure
+  if (txt_power_dev_od_voltage.contains_structured_key(KTAG_FCLK, KTAG_FIRST_FREQ_IDX)) {
+    p->curr_fclk_range.lower_bound =
+        freq_string_to_int(build_lower_bound(KTAG_FCLK), nullptr, nullptr, 0);
+    p->curr_fclk_range.upper_bound =
+        freq_string_to_int(build_upper_bound(KTAG_FCLK), nullptr, nullptr, 0);
   } else
     structured_key_counter--;
 
@@ -1659,7 +1692,7 @@ rsmi_status_t rsmi_dev_clk_extremum_set(uint32_t dv_ind, rsmi_freq_ind_t level, 
   ss << __PRETTY_FUNCTION__ << "| ======= start =======";
   LOG_TRACE(ss);
 
-  if (clkType != RSMI_CLK_TYPE_SYS && clkType != RSMI_CLK_TYPE_MEM) {
+  if (clkType != RSMI_CLK_TYPE_SYS && clkType != RSMI_CLK_TYPE_MEM && clkType != RSMI_CLK_TYPE_DF) {
     return RSMI_STATUS_INVALID_ARGS;
   }
   if (level != RSMI_FREQ_IND_MIN && level != RSMI_FREQ_IND_MAX) {
@@ -1669,6 +1702,7 @@ rsmi_status_t rsmi_dev_clk_extremum_set(uint32_t dv_ind, rsmi_freq_ind_t level, 
   std::map<rsmi_clk_type_t, std::string> clk_char_map = {
       {RSMI_CLK_TYPE_SYS, "s"},
       {RSMI_CLK_TYPE_MEM, "m"},
+      {RSMI_CLK_TYPE_DF, "f"},
   };
   DEVICE_MUTEX
 

--- a/projects/amdsmi/src/amd_smi/amd_smi_drm.cc
+++ b/projects/amdsmi/src/amd_smi/amd_smi_drm.cc
@@ -136,8 +136,6 @@ amdsmi_status_t AMDSmiDrm::init() {
       if (drm_get_device(fd, &device) == 0) {
         vendor_id = device->deviceinfo.pci->vendor_id;
         drm_free_device(&device);
-      } else {
-        //drm_free_device(&device);
       }
       drm_free_version(version);
     }

--- a/projects/amdsmi/src/amd_smi/amd_smi_drm.cc
+++ b/projects/amdsmi/src/amd_smi/amd_smi_drm.cc
@@ -137,7 +137,7 @@ amdsmi_status_t AMDSmiDrm::init() {
         vendor_id = device->deviceinfo.pci->vendor_id;
         drm_free_device(&device);
       } else {
-        drm_free_device(&device);
+        //drm_free_device(&device);
       }
       drm_free_version(version);
     }

--- a/projects/amdsmi/src/amd_smi/amd_smi_utils.cc
+++ b/projects/amdsmi/src/amd_smi/amd_smi_utils.cc
@@ -277,10 +277,12 @@ amdsmi_status_t smi_amdgpu_get_ranges(amd::smi::AMDSmiGPUDevice* device, amdsmi_
                                       int* sleep_state_freq) {
   SMIGPUDEVICE_MUTEX(device->get_mutex())
   std::string fullpath = "/sys/class/drm/" + device->get_gpu_path() + "/device";
+
   std::string smclk_min_max_fullpath = "";
 
   bool sclk = false;
   bool mclk = false;
+  bool fclk = false;
   switch (domain) {
     case AMDSMI_CLK_TYPE_GFX:
       smclk_min_max_fullpath = fullpath + "/pp_od_clk_voltage";
@@ -308,14 +310,15 @@ amdsmi_status_t smi_amdgpu_get_ranges(amd::smi::AMDSmiGPUDevice* device, amdsmi_
       fullpath += "/pp_dpm_socclk";
       break;
     case AMDSMI_CLK_TYPE_DF:
+      smclk_min_max_fullpath = fullpath + "/pp_od_clk_voltage";
       fullpath += "/pp_dpm_fclk";
+      fclk = true;
       break;
     default:
       return AMDSMI_STATUS_INVAL;
   }
 
   std::ifstream ranges(fullpath.c_str());
-
   if (ranges.fail()) {
     return AMDSMI_STATUS_NOT_SUPPORTED;
   }
@@ -328,41 +331,50 @@ amdsmi_status_t smi_amdgpu_get_ranges(amd::smi::AMDSmiGPUDevice* device, amdsmi_
   dpm = 0;
   sleep_freq = UINT_MAX;
   current_freq = 0;
-
-  // if getting sclk or mclk info, read pp_od_clk_voltage for min and max info
-  if (sclk || mclk) {
+  // if getting sclk, mclk or fclk info, read pp_od_clk_voltage for min and max info
+  if (sclk || mclk || fclk) {
     std::ifstream smclk_ranges(smclk_min_max_fullpath.c_str());
     unsigned int smax = 0;
     unsigned int mmax = 0;
+    unsigned int fmax = 0;
     unsigned int smin = UINT_MAX;
     unsigned int mmin = UINT_MAX;
+    unsigned int fmin = UINT_MAX;
 
     // if pp_od_clk_voltage is not found, then go back to using the original pp_dpm files
     if (!smclk_ranges.is_open()) {
       sclk = false;
       mclk = false;
+      fclk = false;
     } else {
-      // using bool to switch between recording for s or mclk. true will be sclk, false will be mclk
-      bool s_or_m = true;
+      // using enum to switch between recording for sclk, mclk, or fclk
+      enum ClkType { PARSING_SCLK = 0, PARSING_MCLK = 1, PARSING_FCLK = 2 };
+      ClkType current_clk_type = PARSING_SCLK;
       unsigned int dpm_level, freq;
       for (std::string line; getline(smclk_ranges, line);) {
         if (line.compare("GFXCLK:") == 0 || line.compare("OD_SCLK:") == 0) {
-          s_or_m = true;
+          current_clk_type = PARSING_SCLK;
           continue;
         } else if (line.compare("MCLK:") == 0 || line.compare("OD_MCLK:") == 0) {
-          s_or_m = false;
+          current_clk_type = PARSING_MCLK;
+          continue;
+        } else if (line.compare("FCLK:") == 0 || line.compare("OD_FCLK:") == 0) {
+          current_clk_type = PARSING_FCLK;
           continue;
         }
         if (sscanf(line.c_str(), "%u: %d%s", &dpm_level, &freq, str) <= 2) {
           // skip lines that don't conform to the format
           continue;
         }
-        if (s_or_m) {
+        if (current_clk_type == PARSING_SCLK) {
           if (freq > smax) smax = freq;
           if (freq < smin) smin = freq;
-        } else {
+        } else if (current_clk_type == PARSING_MCLK) {
           if (freq > mmax) mmax = freq;
           if (freq < mmin) mmin = freq;
+        } else if (current_clk_type == PARSING_FCLK) {
+          if (freq > fmax) fmax = freq;
+          if (freq < fmin) fmin = freq;
         }
       }
 
@@ -372,6 +384,9 @@ amdsmi_status_t smi_amdgpu_get_ranges(amd::smi::AMDSmiGPUDevice* device, amdsmi_
       } else if (mclk) {
         max = mmax;
         min = mmin;
+      } else if (fclk) {
+        max = fmax;
+        min = fmin;
       }
 
       smclk_ranges.close();
@@ -407,8 +422,8 @@ amdsmi_status_t smi_amdgpu_get_ranges(amd::smi::AMDSmiGPUDevice* device, amdsmi_
         current_freq = freq;
       }
 
-      // not * was detected so check for the min max if not s or mclk, which are user defined
-      if (!sclk && !mclk) {
+      // not * was detected so check for the min max if not sclk, mclk, or fclk, which are user defined
+      if (!sclk && !mclk && !fclk) {
         max = freq > max ? freq : max;
         min = freq < min ? freq : min;
       }


### PR DESCRIPTION
Add support to fclk max frequency.

## Motivation

set max fclk on MI300A

## Technical Details

In addition to sclk/fclk, provide user to control fclk max frequency

## JIRA ID
ROCM-20187


## Test Plan
Test prototype with driver patch on latest rocm release


## Test Result

The flck max frequency can be set.

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
