### PR TITLE
[rocprofiler-sdk] Fix signal handler hang in rocprofv3 tool

### DIFF
--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-tool/tool.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-tool/tool.cpp
@@ -3256,6 +3256,9 @@ get_sigaction_function()
 
 bool signal_handler_exit =
     rocprofiler::tool::get_env("ROCPROF_INTERNAL_TEST_SIGNAL_HANDLER_VIA_EXIT", false);
+
+// prevent re-entry into singal handler when we're already handling a signal
+std::atomic<bool> handling_signals{};
 }  // namespace
 
 #define ROCPROFV3_INTERNAL_API __attribute__((visibility("internal")));
@@ -3418,6 +3421,18 @@ rocprofv3_error_signal_handler(int signo, siginfo_t* info, void* ucontext)
     auto this_tid  = common::get_tid();
     auto this_func = std::string_view{__FUNCTION__};
 
+    if(handling_signals.exchange(true))
+    {
+        ROCP_WARNING << fmt::format("[PPID={}][PID={}][TID={}][{}] re-entry when handling signal "
+                                    "{}, skipping chained handlers ...",
+                                    this_ppid,
+                                    this_pid,
+                                    this_tid,
+                                    this_func,
+                                    signo);
+        return;
+    }
+
     ROCP_WARNING << fmt::format("[PPID={}][PID={}][TID={}][{}] rocprofv3 caught signal {}...",
                                 this_ppid,
                                 this_pid,
@@ -3543,6 +3558,11 @@ rocprofv3_error_signal_handler(int signo, siginfo_t* info, void* ucontext)
 
     // below is for testing purposes. re-raising the signal causes CTest to ignore WILL_FAIL ON
     if(signal_handler_exit) ::quick_exit(signo);
+
+    struct sigaction _sa = {};
+    _sa.sa_handler       = SIG_DFL;
+    get_sigaction_function()(signo, &_sa, nullptr);
+
     ::raise(signo);
 }
 
@@ -3663,7 +3683,8 @@ rocprofv3_signal(int signum, sighandler_t handler)
     std::call_once(_once,
                    []() { get_signal_function() = (signal_func_t) dlsym(RTLD_NEXT, "signal"); });
 
-    if(!is_handled_signal(signum) || !tool::get_config().enable_signal_handlers)
+    if(!is_handled_signal(signum) || !tool::get_config().enable_signal_handlers ||
+       handling_signals.load())
         return CHECK_NOTNULL(get_signal_function())(signum, handler);
 
     get_chained_signals().at(signum) = chained_siginfo{signum, handler, std::nullopt};
@@ -3682,7 +3703,8 @@ rocprofv3_sigaction(int signum,
         get_sigaction_function() = (sigaction_func_t) dlsym(RTLD_NEXT, "sigaction");
     });
 
-    if(!is_handled_signal(signum) || !act || !tool::get_config().enable_signal_handlers)
+    if(!is_handled_signal(signum) || !act || !tool::get_config().enable_signal_handlers ||
+       handling_signals.load())
         return CHECK_NOTNULL(get_sigaction_function())(signum, act, oldact);
 
     // make sure rocprofv3_error_signal_handler doesn't call itself


### PR DESCRIPTION

## Motivation

Fix a hang in rocprofv3 tool when Ctrl+C is sent to a running application, which sometimes causes issues in other applications. Should improve psdb testing. 

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

Fix a hang that sometimes occurs when a signal is sent to a process when profiling with rocprofv3 tool.

Usually, the signal handling is as follows:

app -> `sigaction` -> [signal] -> kernel -> calls handler

But with `LD_PRELOAD=<...>:<...>/librocprofiler-sdk-tool.so`, we intercept both `sigaction` and `signal` install points and chain the existing handlers, if any.

The hang occurs due to this sequence of events.

```
app
  -> llvm sigaction
      -> `rocprofv3_sigaction` (because of `LD_PRELOAD`)
          -> install `rocprofv3_error_signal_handler`
          -> chain llvm's handler

  -> [signal arrives]
      -> rocprofv3_error_signal_handler
          -> std::call_once
              -> call to llvm 'SignalHandler'
                  -> `sys::unregisterHandlers`,
                      -> installs rocprofv3_error_signal_handler
                  -> raise delivered immediately (`SA_NODEFER` + `sigprocmask(SIG_UNBLOCK)`)
                  -> reentry into rocprofv3_error_signal_handler
                  -> hang at std::call_once
```

Since `rocprofv3_error_signal_handler` performs the chained call in a `std::call_once`, the process deadlocks (waiting on the same thread).

This change prevents a re-entry into `std::call_once` by returning early when a re-entry is detected.

Example callstack: 

```
#0  futex_wait (private=0, expected=1, futex_word=0x7fde350e2100 <rocprofv3_error_signal_handler::_once>) at ../sysdeps/nptl/futex-internal.h:146
#1  futex_wait_simple (private=0, expected=1, futex_word=0x7fde350e2100 <rocprofv3_error_signal_handler::_once>) at ../sysdeps/nptl/futex-internal.h:177
#2  __pthread_once_slow (once_control=0x7fde350e2100 <rocprofv3_error_signal_handler::_once>, init_routine=0x7fde31814420 <__once_proxy>) at ./nptl/pthread_once.c:105
#3  0x00007fde346b06ce in __gthread_once (__once=0x7fde350e2100 <rocprofv3_error_signal_handler::_once>, __func=0x7fde31814420 <__once_proxy>) at /usr/include/x86_64-linux-gnu/c++/13/bits/gthr-default.h:700
#4  0x00007fde346cde6d in std::call_once<rocprofv3_error_signal_handler(int, siginfo_t*, void*)::<lambda()> >(std::once_flag &, struct {...} &&) (__once=..., __f=...) at /usr/include/c++/13/mutex:907
#5  0x00007fde346cb583 in rocprofv3_error_signal_handler (signo=2, info=0x7ffcb3517bb0, ucontext=0x7ffcb3517a80) at /rocm-systems/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-tool/tool.cpp:3383
#6  <signal handler called>
#7  __pthread_kill_implementation (no_tid=0, signo=2, threadid=<optimized out>) at ./nptl/pthread_kill.c:44
#8  __pthread_kill_internal (signo=2, threadid=<optimized out>) at ./nptl/pthread_kill.c:78
#9  __GI___pthread_kill (threadid=<optimized out>, signo=signo@entry=2) at ./nptl/pthread_kill.c:89
#10 0x00007fde3144527e in __GI_raise (sig=2) at ../sysdeps/posix/raise.c:26
#11 0x00007fde2721f316 in SignalHandler(int, siginfo_t*, void*) () from /opt/rocm-7.3.0/lib/libamd_comgr.so.3
#12 0x00007fde346cad5a in operator() (__closure=0x7ffcb35190f0) at /rocm-systems/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-tool/tool.cpp:3463
#13 0x00007fde346cfa0c in std::__invoke_impl<void, rocprofv3_error_signal_handler(int, siginfo_t*, void*)::<lambda()> >(std::__invoke_other, struct {...} &&) (__f=...) at /usr/include/c++/13/bits/invoke.h:61
#14 0x00007fde346cec76 in std::__invoke<rocprofv3_error_signal_handler(int, siginfo_t*, void*)::<lambda()> >(struct {...} &&) (__fn=...) at /usr/include/c++/13/bits/invoke.h:96
#15 0x00007fde346cde15 in operator() (__closure=0x7ffcb3519060) at /usr/include/c++/13/mutex:900
#16 0x00007fde346ceca1 in operator() (__closure=0x0) at /usr/include/c++/13/mutex:836
#17 0x00007fde346cecb6 in _FUN () at /usr/include/c++/13/mutex:836
#18 0x00007fde314a1ed3 in __pthread_once_slow (once_control=0x7fde350e2100 <rocprofv3_error_signal_handler::_once>, init_routine=0x7fde31814420 <__once_proxy>) at ./nptl/pthread_once.c:116
#19 0x00007fde346b06ce in __gthread_once (__once=0x7fde350e2100 <rocprofv3_error_signal_handler::_once>, __func=0x7fde31814420 <__once_proxy>) at /usr/include/x86_64-linux-gnu/c++/13/bits/gthr-default.h:700
#20 0x00007fde346cde6d in std::call_once<rocprofv3_error_signal_handler(int, siginfo_t*, void*)::<lambda()> >(std::once_flag &, struct {...} &&) (__once=..., __f=...) at /usr/include/c++/13/mutex:907
#21 0x00007fde346cb583 in rocprofv3_error_signal_handler (signo=2, info=0x7ffcb3519330, ucontext=0x7ffcb3519200) at /rocm-systems/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-tool/tool.cpp:3383
#22 <signal handler called>
# <...truncated...>
```

re-entry + wait on the same `once` object 

```
#3  0x00007fde346b06ce in __gthread_once (__once=0x7fde350e2100 <rocprofv3_error_signal_handler::_once>, __func=0x7fde31814420 <__once_proxy>) at /usr/include/x86_64-linux-gnu/c++/13/bits/gthr-default.h:700
...
#19 0x00007fde346b06ce in __gthread_once (__once=0x7fde350e2100 <rocprofv3_error_signal_handler::_once>, __func=0x7fde31814420 <__once_proxy>) at /usr/include/x86_64-linux-gnu/c++/13/bits/gthr-default.h:700
```

This hung process also holds onto pending HSA resources, causing issues in other HIP applications (they also seem to hang, sometimes).

<!-- Explain the changes along with any relevant GitHub links. -->

## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

Ctrl+C with rocprofv3 should return after running all the handlers, instead of requiring a second Ctrl+C. 

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
