### PR TITLE
[CLR] Fix missing kernel dispatch records in HIP graph profiling

### DIFF
--- a/projects/clr/rocclr/device/rocm/rocvirtual.cpp
+++ b/projects/clr/rocclr/device/rocm/rocvirtual.cpp
@@ -1520,6 +1520,15 @@ bool VirtualGPU::dispatchAqlPacketBatch(const std::vector<uint8_t*>& packets,
       reinterpret_cast<const std::vector<hsa_kernel_dispatch_packet_t*>&>(packets);
   bool result = dispatchGenericAqlPacketBatch(aqlPackets, false, attach_signal, &kernelNames);
 
+  // When a profiling tracer is active, synchronously wait for all batch dispatch
+  // signals and extract per-kernel timing data. Without this, the async signal
+  // handlers may not fire before ReportActivity reads tsList_, causing missing
+  // kernel dispatch records in profiling output.
+  if (timestamp_ != nullptr && amd::activity_prof::IsEnabled(OP_ID_DISPATCH)) {
+    Barriers().WaitCurrent();
+    timestamp_->checkGpuTime();
+  }
+
   profilingEnd();
 
   return result;


### PR DESCRIPTION
## Summary
- Fix race condition in batch AQL dispatch path that causes missing kernel dispatch records when profiling HIP graph replay
- Only ~65% of graph-replayed kernel dispatches were visible to roctracer/rocprofiler-sdk due to async signal handlers not firing before ReportActivity reads tsList_
- Added synchronous signal timing extraction in `dispatchAqlPacketBatch` when a profiling tracer is active (zero overhead when not profiling)

## Root Cause
`dispatchAqlPacketBatch()` attaches completion signals to each kernel dispatch for timing extraction via async handlers. The `AccumulateCommand` reaches `CL_COMPLETE` and calls `ReportActivity` before all handlers fire, so `tsList_` is only partially populated. This is a race condition — the percentage of visible kernels varies per run (26-65%).

## Fix
After dispatching batch packets, when `amd::activity_prof::IsEnabled(OP_ID_DISPATCH)` is true, synchronously wait for all signals (`Barriers().WaitCurrent()`) and extract timing data (`timestamp_->checkGpuTime()`) before `profilingEnd()` clears the timestamp.

## Test Results (MI300, Llama-2-7b-chat-hf, vLLM latency benchmark)

| Metric | ROCm 7.0 | 7.2 (broken) | 7.2 (fixed) |
|--------|----------|--------------|-------------|
| paged_attention calls | 4,128 | 2,688 (65%) | **4,128 (100%)** |
| fused_qk_rope calls | 4,096 | 2,688 | **4,096** |
| argmax calls | 129 | 128 | **129** |
| Self CUDA total | 791ms | 475ms | **737ms** |

## Test plan
- [x] vLLM Llama-2-7b latency benchmark with torch profiler on MI300
- [ ] Verify no performance regression when profiler is not active
- [ ] Test with rocprofiler-sdk tracing
- [ ] Test with larger models (70B)

Fixes: AIPROFSDK-784

🤖 Generated with [Claude Code](https://claude.com/claude-code)