### PR TITLE
[rocprofiler-systems] Fix aligned_static_vector warnings

### DIFF
--- a/projects/rocprofiler-systems/source/lib/core/containers/aligned_static_vector.hpp
+++ b/projects/rocprofiler-systems/source/lib/core/containers/aligned_static_vector.hpp
@@ -1,47 +1,32 @@
-// MIT License
-//
-// Copyright (c) 2022-2025 Advanced Micro Devices, Inc. All Rights Reserved.
-//
-// Permission is hereby granted, free of charge, to any person obtaining a copy
-// of this software and associated documentation files (the "Software"), to deal
-// in the Software without restriction, including without limitation the rights
-// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-// copies of the Software, and to permit persons to whom the Software is
-// furnished to do so, subject to the following conditions:
-//
-// The above copyright notice and this permission notice shall be included in all
-// copies or substantial portions of the Software.
-//
-// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-// SOFTWARE.
+// Copyright (c) Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
 
 #pragma once
 
-#include "core/common.hpp"
+#include "common/defines.h"
 #include "core/containers/operators.hpp"
 #include "core/exception.hpp"
 
+#include <algorithm>
 #include <array>
 #include <atomic>
+#include <cassert>
+#include <cstddef>
 #include <cstdlib>
-#include <new>
+#include <initializer_list>
+#include <stdexcept>
+#include <string>
+#include <type_traits>
+#include <utility>
 
 namespace rocprofsys
 {
 namespace container
 {
-#if !defined(ROCPROFSYS_CACHELINE_SIZE)
-#    ifdef __cpp_lib_hardware_interference_size
-#        define ROCPROFSYS_CACHELINE_SIZE std::hardware_destructive_interference_size
-#    else
-// 64 bytes on x86-64 │ L1_CACHE_BYTES │ L1_CACHE_SHIFT │ __cacheline_aligned │ ...
-#        define ROCPROFSYS_CACHELINE_SIZE 64
-#    endif
+#ifndef ROCPROFSYS_CACHELINE_SIZE
+// Fixed default (not std::hardware_destructive_interference_size): stable constexpr, no
+// GCC -Winterference-size. Override with ROCPROFSYS_CACHELINE_SIZE if needed.
+#    define ROCPROFSYS_CACHELINE_SIZE 64
 #endif
 
 constexpr std::size_t cacheline_align_v =
@@ -74,7 +59,7 @@ struct aligned_static_vector
     aligned_static_vector& operator=(const aligned_static_vector&)     = default;
     aligned_static_vector& operator=(aligned_static_vector&&) noexcept = default;
 
-    aligned_static_vector(size_t _n, Tp _v = {});
+    explicit aligned_static_vector(size_t _n, Tp _v = {});
 
     aligned_static_vector& operator=(std::initializer_list<Tp>&& _v);
     aligned_static_vector& operator=(std::pair<std::array<Tp, N>, size_t>&&);
@@ -111,12 +96,12 @@ struct aligned_static_vector
 
     void swap(this_type& _v);
 
-    friend void swap(this_type& _lhs, this_type& _rhs) { _lhs.swap(_rhs); }
+    friend void swap(this_type& _lhs, this_type& _rhs) noexcept { _lhs.swap(_rhs); }
 
     template <typename ContainerT>
     struct iterator_base
     {
-        iterator_base(ContainerT* c = nullptr, size_type i = 0)
+        explicit iterator_base(ContainerT* c = nullptr, size_type i = 0)
         : m_container(c)
         , m_index(i)
         {}
@@ -182,7 +167,7 @@ public:
     {
         using iterator_base<const_this_type>::iterator_base;
 
-        const_iterator(const iterator& itr)
+        explicit const_iterator(const iterator& itr)
         : iterator_base<const_this_type>(itr.m_container, itr.m_index)
         {}
 
@@ -217,9 +202,13 @@ aligned_static_vector<Tp, N, AlignN, AtomicSizeV>::aligned_static_vector(size_t 
 {
     m_data.fill(_v);
     if constexpr(AtomicSizeV)
+    {
         m_size.store(_n);
+    }
     else
+    {
         m_size = _n;
+    }
 }
 
 template <typename Tp, size_t N, size_t AlignN, bool AtomicSizeV>
@@ -236,7 +225,9 @@ aligned_static_vector<Tp, N, AlignN, AtomicSizeV>::operator=(
 
     clear();
     for(auto&& itr : _v)
+    {
         m_data[m_size++] = itr;
+    }
     return *this;
 }
 
@@ -245,15 +236,24 @@ aligned_static_vector<Tp, N, AlignN, AtomicSizeV>&
 aligned_static_vector<Tp, N, AlignN, AtomicSizeV>::operator=(
     std::pair<std::array<Tp, N>, size_t>&& _v)
 {
-    if constexpr(AtomicSizeV) m_size.store(0);
+    if constexpr(AtomicSizeV)
+    {
+        m_size.store(0);
+    }
 
     for(size_t i = 0; i < N; ++i)
+    {
         m_data[i].value = std::move(_v.first[i]);
+    }
 
     if constexpr(AtomicSizeV)
+    {
         m_size.store(_v.second);
+    }
     else
+    {
         m_size = _v.second;
+    }
 
     return *this;
 }
@@ -263,9 +263,13 @@ void
 aligned_static_vector<Tp, N, AlignN, AtomicSizeV>::clear()
 {
     if constexpr(AtomicSizeV)
+    {
         m_size.store(0);
+    }
     else
+    {
         m_size = 0;
+    }
 }
 
 template <typename Tp, size_t N, size_t AlignN, bool AtomicSizeV>
@@ -302,15 +306,21 @@ aligned_static_vector<Tp, N, AlignN, AtomicSizeV>::emplace_back(Args&&... _v)
 
     if constexpr(sizeof...(Args) > 0)
     {
-        if constexpr(std::is_assignable<Tp, decltype(std::forward<Args>(_v))...>::value)
+        if constexpr(std::is_assignable_v<Tp, decltype(std::forward<Args>(_v))...>)
+        {
             m_data[_idx].value = { std::forward<Args>(_v)... };
-        else if constexpr(std::is_constructible<Tp, decltype(std::forward<Args>(
-                                                        _v))...>::value)
+        }
+        else if constexpr(std::is_constructible_v<Tp,
+                                                  decltype(std::forward<Args>(_v))...>)
+        {
             m_data[_idx].value = Tp{ std::forward<Args>(_v)... };
+        }
         else
+        {
             static_assert(
                 sizeof...(Args) == 0,
                 "Error! Tp is not assignable or constructible with provided args");
+        }
     }
     else
     {


### PR DESCRIPTION
## Motivation

Building with strict GCC diagnostics (notably `-Winterference-size`) produced warnings tied to using `std::hardware_destructive_interference_size` for the cacheline constant. 

## Technical Details

`ROCPROFSYS_CACHELINE_SIZE` now defaults to a fixed 64-byte constexpr (documented as overridable) instead of `std::hardware_destructive_interference_size`, eliminating the interference-size warning. 

## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->
N/A

## Test Plan

- Configure and build rocprofiler-systems (or the target that compiles `aligned_static_vector.hpp`) with the same compiler flags that previously emitted `-Winterference-size` (or full `-Wextra`).

## Test Result

- Clean build: no `-Winterference-size` (or related) warnings from this header.
- No behavioral regressions: 

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
