### PR TITLE
RCCL: RCCL_IB_SPLIT_DATA_THRESHOLD + round-robin small-message sends

### DIFF
--- a/projects/rccl/docs/api-reference/env-variables.rst
+++ b/projects/rccl/docs/api-reference/env-variables.rst
@@ -167,6 +167,13 @@ in the following table.
         | Forces merging of network devices.
       - | String specifying forced merge configuration
 
+    * - | ``RCCL_IB_SPLIT_DATA_THRESHOLD``
+        | Minimum message size (in bytes) before the payload is split across
+        | multiple NICs/QPs.
+        | Smaller messages use one QP for data to reduce latency.
+      - | Integer value in bytes (default: ``128``)
+        | ``N``: Split only when message size >= N bytes
+
     * - | ``NCCL_RINGS``
         | Defines custom ring topology.
       - | Ring topology specification string

--- a/projects/rccl/docs/api-reference/env-variables.rst
+++ b/projects/rccl/docs/api-reference/env-variables.rst
@@ -171,6 +171,7 @@ in the following table.
         | Minimum message size (in bytes) before the payload is split across
         | multiple NICs/QPs.
         | Smaller messages use one QP for data to reduce latency.
+        | This variable can be leveraged when NIC Fusion (``NCCL_NET_MERGE_LEVEL``) and/or data splitting on QPs (``NCCL_IB_SPLIT_DATA_ON_QPS``) is enabled.
       - | Integer value in bytes (default: ``128``)
         | ``N``: Split only when message size >= N bytes
 

--- a/projects/rccl/src/transport/net_ib.cc
+++ b/projects/rccl/src/transport/net_ib.cc
@@ -2389,7 +2389,7 @@ ncclResult_t ncclIbMultiSend(struct ncclIbSendComm* comm, int slot) {
 
   // For small messages (< splitDataThreshold) with multiple QPs, avoid splitting:
   // send the entire payload through one QP selected via round-robin, post zero-length WRs on the rest.
-  int smallMsgActiveQp = slot % nqps;
+  int smallMsgActiveQp = comm->fifoHead % nqps;
   int64_t splitDataThreshold = rcclParamIbSplitDataThreshold();
 
   for (int i = 0; i < nqps; i++) {

--- a/projects/rccl/src/transport/net_ib.cc
+++ b/projects/rccl/src/transport/net_ib.cc
@@ -2325,6 +2325,7 @@ ncclResult_t ncclIbDeregMr(void* comm, void* mhandle) {
 }
 
 NCCL_PARAM(IbSplitDataOnQps, "IB_SPLIT_DATA_ON_QPS", 0);
+RCCL_PARAM(IbSplitDataThreshold, "IB_SPLIT_DATA_THRESHOLD", 128);
 
 ncclResult_t ncclIbMultiSend(struct ncclIbSendComm* comm, int slot) {
   struct ncclIbRequest** reqs = comm->fifoReqs[slot];
@@ -2385,6 +2386,8 @@ ncclResult_t ncclIbMultiSend(struct ncclIbSendComm* comm, int slot) {
   // Multi-QP: make sure IB writes are multiples of 128B so that LL and LL128 protocols still work
   const int align = 128;
   int nqps = ncclParamIbSplitDataOnQps() ? comm->base.nqps : comm->base.nDataQps;
+  int64_t splitDataThreshold = rcclParamIbSplitDataThreshold();
+
   for (int i = 0; i < nqps; i++) {
     int qpIndex = comm->base.qpIndex;
     ncclIbQp* qp = comm->base.qps + qpIndex;
@@ -2396,7 +2399,8 @@ ncclResult_t ncclIbMultiSend(struct ncclIbSendComm* comm, int slot) {
       // Select proper rkey (needed even for 0-size send)
       comm->wrs[r].wr.rdma.rkey = slots[r].rkeys[qp->remDevIdx];
 
-      int chunkSize = DIVUP(DIVUP(reqs[r]->send.size, nqps), align) * align;
+      int dataQps = (reqs[r]->send.size >= splitDataThreshold) ? nqps : 1;
+      int chunkSize = DIVUP(DIVUP(reqs[r]->send.size, dataQps), align) * align;
       int length = std::min(reqs[r]->send.size-reqs[r]->send.offset, chunkSize);
       if (length <= 0) {
         comm->wrs[r].sg_list = NULL;
@@ -2447,7 +2451,8 @@ ncclResult_t ncclIbMultiSend(struct ncclIbSendComm* comm, int slot) {
     }
 
     for (int r=0; r<nreqs; r++) {
-      int chunkSize = DIVUP(DIVUP(reqs[r]->send.size, nqps), align) * align;
+      int dataQps = (reqs[r]->send.size >= splitDataThreshold) ? nqps : 1;
+      int chunkSize = DIVUP(DIVUP(reqs[r]->send.size, dataQps), align) * align;
       reqs[r]->send.offset += chunkSize;
       comm->sges[r].addr += chunkSize;
       comm->wrs[r].wr.rdma.remote_addr += chunkSize;

--- a/projects/rccl/src/transport/net_ib.cc
+++ b/projects/rccl/src/transport/net_ib.cc
@@ -2386,6 +2386,10 @@ ncclResult_t ncclIbMultiSend(struct ncclIbSendComm* comm, int slot) {
   // Multi-QP: make sure IB writes are multiples of 128B so that LL and LL128 protocols still work
   const int align = 128;
   int nqps = ncclParamIbSplitDataOnQps() ? comm->base.nqps : comm->base.nDataQps;
+
+  // For small messages (< splitDataThreshold) with multiple QPs, avoid splitting:
+  // send the entire payload through one QP selected via round-robin, post zero-length WRs on the rest.
+  int smallMsgActiveQp = slot % nqps;
   int64_t splitDataThreshold = rcclParamIbSplitDataThreshold();
 
   for (int i = 0; i < nqps; i++) {
@@ -2399,8 +2403,12 @@ ncclResult_t ncclIbMultiSend(struct ncclIbSendComm* comm, int slot) {
       // Select proper rkey (needed even for 0-size send)
       comm->wrs[r].wr.rdma.rkey = slots[r].rkeys[qp->remDevIdx];
 
-      int dataQps = (reqs[r]->send.size >= splitDataThreshold) ? nqps : 1;
-      int chunkSize = DIVUP(DIVUP(reqs[r]->send.size, dataQps), align) * align;
+      int chunkSize;
+      if (reqs[r]->send.size < splitDataThreshold) {
+        chunkSize = (i == smallMsgActiveQp) ? reqs[r]->send.size : 0;
+      } else {
+        chunkSize = DIVUP(DIVUP(reqs[r]->send.size, nqps), align) * align;
+      }
       int length = std::min(reqs[r]->send.size-reqs[r]->send.offset, chunkSize);
       if (length <= 0) {
         comm->wrs[r].sg_list = NULL;
@@ -2451,8 +2459,12 @@ ncclResult_t ncclIbMultiSend(struct ncclIbSendComm* comm, int slot) {
     }
 
     for (int r=0; r<nreqs; r++) {
-      int dataQps = (reqs[r]->send.size >= splitDataThreshold) ? nqps : 1;
-      int chunkSize = DIVUP(DIVUP(reqs[r]->send.size, dataQps), align) * align;
+      int chunkSize;
+      if (reqs[r]->send.size < splitDataThreshold) {
+        chunkSize = (i == smallMsgActiveQp) ? reqs[r]->send.size : 0;
+      } else {
+        chunkSize = DIVUP(DIVUP(reqs[r]->send.size, nqps), align) * align;
+      }
       reqs[r]->send.offset += chunkSize;
       comm->sges[r].addr += chunkSize;
       comm->wrs[r].wr.rdma.remote_addr += chunkSize;


### PR DESCRIPTION
## Motivation

Add tunable parameter to control when IB splits the data across merged NICs/QPs

## Technical Details

- Added new environment variable RCCL_IB_SPLIT_DATA_THRESHOLD, which controls when ncclIbMultiSend splits the data across all QPs
- Below the threshold, the data is sent on a single QP per operation: the active QP is chosen in round-robin fashion, and the remaining QPs post zero-byte sends

## JIRA ID

AICOMNET-119

## Test Plan

Checked rccl-tests on 2 nodes + RCCL_IB_SPLIT_DATA_THRESHOLD=$(( 1024 * 1024 ))

## Test Result

Passed

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
