### PR TITLE
[rocprofiler-systems] Make `fork` examples and `postfork_child()` async-signal-safe

### DIFF
--- a/projects/rocprofiler-systems/examples/fork/fork.cpp
+++ b/projects/rocprofiler-systems/examples/fork/fork.cpp
@@ -36,49 +36,46 @@ itoa_safe(int val, char* out)
     return n;
 }
 
-// async-signal-safe print: "[name] pid = X, ppid = Y\n" to stderr
+// async-signal-safe write helper
+void
+safe_write_str(const char* s, size_t n)
+{
+    auto _rc = write(STDERR_FILENO, s, n);
+    (void) _rc;
+}
+
+// async-signal-safe print: "[name] pid = X, ppid = Y\n" to stderr.
+// Uses multiple write() calls to avoid fixed-size buffer overflow
 void
 print_info(const char* name)
 {
-    char buf[256];
-    int  pos = 0;
+    char numbuf[20];
+    int  len;
 
-    buf[pos++] = '[';
-    int nlen   = strlen(name);
-    memcpy(buf + pos, name, nlen);
-    pos += nlen;
-    const char s1[] = "] pid = ";
-    memcpy(buf + pos, s1, sizeof(s1) - 1);
-    pos += sizeof(s1) - 1;
-    pos += itoa_safe(getpid(), buf + pos);
-    const char s2[] = ", ppid = ";
-    memcpy(buf + pos, s2, sizeof(s2) - 1);
-    pos += sizeof(s2) - 1;
-    pos += itoa_safe(getppid(), buf + pos);
-    buf[pos++] = '\n';
-    auto _rc   = write(STDERR_FILENO, buf, pos);
-    (void) _rc;
+    safe_write_str("[", 1);
+    safe_write_str(name, strlen(name));
+    safe_write_str("] pid = ", 8);
+    len = itoa_safe(getpid(), numbuf);
+    safe_write_str(numbuf, len);
+    safe_write_str(", ppid = ", 9);
+    len = itoa_safe(getppid(), numbuf);
+    safe_write_str(numbuf, len);
+    safe_write_str("\n", 1);
 }
 
 // async-signal-safe print: "[pid X] msg\n" to stderr
 void
 safe_write(const char* msg)
 {
-    char       buf[64];
-    int        pos  = 0;
-    const char s1[] = "[pid ";
-    memcpy(buf + pos, s1, sizeof(s1) - 1);
-    pos += sizeof(s1) - 1;
-    pos += itoa_safe(getpid(), buf + pos);
-    const char s2[] = "] ";
-    memcpy(buf + pos, s2, sizeof(s2) - 1);
-    pos += sizeof(s2) - 1;
-    int mlen = strlen(msg);
-    memcpy(buf + pos, msg, mlen);
-    pos += mlen;
-    buf[pos++] = '\n';
-    auto _rc   = write(STDERR_FILENO, buf, pos);
-    (void) _rc;
+    char numbuf[20];
+    int  len;
+
+    safe_write_str("[pid ", 5);
+    len = itoa_safe(getpid(), numbuf);
+    safe_write_str(numbuf, len);
+    safe_write_str("] ", 2);
+    safe_write_str(msg, strlen(msg));
+    safe_write_str("\n", 1);
 }
 
 int

--- a/projects/rocprofiler-systems/examples/fork/fork.cpp
+++ b/projects/rocprofiler-systems/examples/fork/fork.cpp
@@ -15,14 +15,70 @@
 #include <unistd.h>
 #include <vector>
 
-void
-print_info(const char* _name)
+// async-signal-safe integer to decimal string
+int
+itoa_safe(int val, char* out)
 {
-    fflush(stdout);
-    fflush(stderr);
-    printf("[%s] pid = %i, ppid = %i\n", _name, getpid(), getppid());
-    fflush(stdout);
-    fflush(stderr);
+    if(val == 0)
+    {
+        out[0] = '0';
+        return 1;
+    }
+    char tmp[12];
+    int  n = 0;
+    while(val > 0)
+    {
+        tmp[n++] = '0' + (val % 10);
+        val /= 10;
+    }
+    for(int i = 0; i < n; i++)
+        out[i] = tmp[n - 1 - i];
+    return n;
+}
+
+// async-signal-safe print: "[name] pid = X, ppid = Y\n" to stderr
+void
+print_info(const char* name)
+{
+    char buf[256];
+    int  pos = 0;
+
+    buf[pos++] = '[';
+    int nlen   = strlen(name);
+    memcpy(buf + pos, name, nlen);
+    pos += nlen;
+    const char s1[] = "] pid = ";
+    memcpy(buf + pos, s1, sizeof(s1) - 1);
+    pos += sizeof(s1) - 1;
+    pos += itoa_safe(getpid(), buf + pos);
+    const char s2[] = ", ppid = ";
+    memcpy(buf + pos, s2, sizeof(s2) - 1);
+    pos += sizeof(s2) - 1;
+    pos += itoa_safe(getppid(), buf + pos);
+    buf[pos++] = '\n';
+    auto _rc   = write(STDERR_FILENO, buf, pos);
+    (void) _rc;
+}
+
+// async-signal-safe print: "[pid X] msg\n" to stderr
+void
+safe_write(const char* msg)
+{
+    char       buf[64];
+    int        pos  = 0;
+    const char s1[] = "[pid ";
+    memcpy(buf + pos, s1, sizeof(s1) - 1);
+    pos += sizeof(s1) - 1;
+    pos += itoa_safe(getpid(), buf + pos);
+    const char s2[] = "] ";
+    memcpy(buf + pos, s2, sizeof(s2) - 1);
+    pos += sizeof(s2) - 1;
+    int mlen = strlen(msg);
+    memcpy(buf + pos, msg, mlen);
+    pos += mlen;
+    buf[pos++] = '\n';
+    auto _rc   = write(STDERR_FILENO, buf, pos);
+    (void) _rc;
 }
 
 int
@@ -42,18 +98,12 @@ run(const char* _name, int nchildren)
             if(_children.at(i) == 0)
             {
                 // child code
+                // must be async-signal-safe (see signal-safety(7))
                 print_info(_name);
-                printf("[%s][%i] child job starting...\n", _name, getpid());
-                auto _sleep = [=]() {
-                    rocprofsys_user_push_region("child_process_child_thread");
-                    std::this_thread::sleep_for(std::chrono::seconds{ _nsec });
-                    rocprofsys_user_pop_region("child_process_child_thread");
-                };
-                rocprofsys_user_push_region("child_process");
-                std::thread{ _sleep }.join();
-                rocprofsys_user_push_region("child_process");
-                printf("[%s][%i] child job complete\n", _name, getpid());
-                exit(EXIT_SUCCESS);
+                safe_write("child job starting");
+                sleep(_nsec);
+                safe_write("child job complete");
+                _exit(EXIT_SUCCESS);
             }
             else
             {

--- a/projects/rocprofiler-systems/examples/fork/fork.cpp
+++ b/projects/rocprofiler-systems/examples/fork/fork.cpp
@@ -15,67 +15,14 @@
 #include <unistd.h>
 #include <vector>
 
-// async-signal-safe integer to decimal string
-int
-itoa_safe(int val, char* out)
-{
-    if(val == 0)
-    {
-        out[0] = '0';
-        return 1;
-    }
-    char tmp[12];
-    int  n = 0;
-    while(val > 0)
-    {
-        tmp[n++] = '0' + (val % 10);
-        val /= 10;
-    }
-    for(int i = 0; i < n; i++)
-        out[i] = tmp[n - 1 - i];
-    return n;
-}
-
-// async-signal-safe write helper
 void
-safe_write_str(const char* s, size_t n)
+print_info(const char* _name)
 {
-    auto _rc = write(STDERR_FILENO, s, n);
-    (void) _rc;
-}
-
-// async-signal-safe print: "[name] pid = X, ppid = Y\n" to stderr.
-// Uses multiple write() calls to avoid fixed-size buffer overflow
-void
-print_info(const char* name)
-{
-    char numbuf[20];
-    int  len;
-
-    safe_write_str("[", 1);
-    safe_write_str(name, strlen(name));
-    safe_write_str("] pid = ", 8);
-    len = itoa_safe(getpid(), numbuf);
-    safe_write_str(numbuf, len);
-    safe_write_str(", ppid = ", 9);
-    len = itoa_safe(getppid(), numbuf);
-    safe_write_str(numbuf, len);
-    safe_write_str("\n", 1);
-}
-
-// async-signal-safe print: "[pid X] msg\n" to stderr
-void
-safe_write(const char* msg)
-{
-    char numbuf[20];
-    int  len;
-
-    safe_write_str("[pid ", 5);
-    len = itoa_safe(getpid(), numbuf);
-    safe_write_str(numbuf, len);
-    safe_write_str("] ", 2);
-    safe_write_str(msg, strlen(msg));
-    safe_write_str("\n", 1);
+    fflush(stdout);
+    fflush(stderr);
+    printf("[%s] pid = %i, ppid = %i\n", _name, getpid(), getppid());
+    fflush(stdout);
+    fflush(stderr);
 }
 
 int
@@ -95,12 +42,13 @@ run(const char* _name, int nchildren)
             if(_children.at(i) == 0)
             {
                 // child code
-                // must be async-signal-safe (see signal-safety(7))
                 print_info(_name);
-                safe_write("child job starting");
-                sleep(_nsec);
-                safe_write("child job complete");
-                _exit(EXIT_SUCCESS);
+                printf("[%s][%i] child job starting...\n", _name, getpid());
+                rocprofsys_user_push_region("child_process");
+                std::this_thread::sleep_for(std::chrono::seconds{ _nsec });
+                rocprofsys_user_push_region("child_process");
+                printf("[%s][%i] child job complete\n", _name, getpid());
+                exit(EXIT_SUCCESS);
             }
             else
             {

--- a/projects/rocprofiler-systems/source/lib/core/state.cpp
+++ b/projects/rocprofiler-systems/source/lib/core/state.cpp
@@ -1,24 +1,5 @@
-// MIT License
-//
-// Copyright (c) 2022-2025 Advanced Micro Devices, Inc. All Rights Reserved.
-//
-// Permission is hereby granted, free of charge, to any person obtaining a copy
-// of this software and associated documentation files (the "Software"), to deal
-// in the Software without restriction, including without limitation the rights
-// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-// copies of the Software, and to permit persons to whom the Software is
-// furnished to do so, subject to the following conditions:
-//
-// The above copyright notice and this permission notice shall be included in all
-// copies or substantial portions of the Software.
-//
-// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-// SOFTWARE.
+// Copyright (c) Advanced Micro Devices, Inc.
+// SPDX-License-Identifier:  MIT
 
 #include "state.hpp"
 #include "common/static_object.hpp"
@@ -78,9 +59,9 @@ get_thread_state()
 }
 
 State
-set_state(State _n)
+set_state(State _n, bool _async_safe)
 {
-    if(get_debug_init())
+    if(get_debug_init() && !_async_safe)
     {
         LOG_DEBUG("Setting state :: {} -> {}", std::to_string(get_state()),
                   std::to_string(_n));
@@ -88,9 +69,16 @@ set_state(State _n)
     // state should always be increased, not decreased
     if(get_is_continuous_integration() && _n < get_state())
     {
-        throw std::runtime_error(
-            fmt::format("State is being assigned to a lesser value :: {} -> {}",
-                        std::to_string(get_state()), std::to_string(_n)));
+        if(!_async_safe)
+        {
+            throw std::runtime_error(
+                fmt::format("State is being assigned to a lesser value :: {} -> {}",
+                            std::to_string(get_state()), std::to_string(_n)));
+        }
+        else
+        {
+            _exit(1);
+        }
     }
 
     auto _v = get_state();

--- a/projects/rocprofiler-systems/source/lib/core/state.hpp
+++ b/projects/rocprofiler-systems/source/lib/core/state.hpp
@@ -1,24 +1,5 @@
-// MIT License
-//
-// Copyright (c) 2022-2025 Advanced Micro Devices, Inc. All Rights Reserved.
-//
-// Permission is hereby granted, free of charge, to any person obtaining a copy
-// of this software and associated documentation files (the "Software"), to deal
-// in the Software without restriction, including without limitation the rights
-// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-// copies of the Software, and to permit persons to whom the Software is
-// furnished to do so, subject to the following conditions:
-//
-// The above copyright notice and this permission notice shall be included in all
-// copies or substantial portions of the Software.
-//
-// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-// SOFTWARE.
+// Copyright (c) Advanced Micro Devices, Inc.
+// SPDX-License-Identifier:  MIT
 
 #pragma once
 
@@ -79,8 +60,10 @@ get_state() ROCPROFSYS_HOT;
 ThreadState
 get_thread_state() ROCPROFSYS_HOT;
 
-/// returns old state
-State set_state(State) ROCPROFSYS_COLD;  // does not change often
+/// returns old state. Set _async_safe=true to skip LOG_DEBUG and throw
+/// (required for async-signal-safe contexts like postfork_child).
+State
+set_state(State, bool _async_safe = false) ROCPROFSYS_COLD;  // does not change often
 
 /// returns old state
 ThreadState set_thread_state(ThreadState) ROCPROFSYS_HOT;  // changes often

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library/components/exit_gotcha.cpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library/components/exit_gotcha.cpp
@@ -1,24 +1,5 @@
-// MIT License
-//
-// Copyright (c) 2022-2025 Advanced Micro Devices, Inc. All Rights Reserved.
-//
-// Permission is hereby granted, free of charge, to any person obtaining a copy
-// of this software and associated documentation files (the "Software"), to deal
-// in the Software without restriction, including without limitation the rights
-// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-// copies of the Software, and to permit persons to whom the Software is
-// furnished to do so, subject to the following conditions:
-//
-// The above copyright notice and this permission notice shall be included in all
-// copies or substantial portions of the Software.
-//
-// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-// SOFTWARE.
+// Copyright (c) Advanced Micro Devices, Inc.
+// SPDX-License-Identifier:  MIT
 
 #include "library/components/exit_gotcha.hpp"
 #include "core/common.hpp"
@@ -91,6 +72,10 @@ invoke_exit_gotcha(const exit_gotcha::gotcha_data& _data, FuncT _func, Args... _
 void
 exit_gotcha::operator()(const gotcha_data& _data, exit_func_t _func, int _ec) const
 {
+    // In a forked child of a multi-threaded parent, this can deadlock.
+    // Call async-signal-safe _exit() instead
+    if(is_child_process()) _exit(_ec);
+
     _exit_info = { true, _data.tool_id.find("quick") != std::string::npos, _ec };
     invoke_exit_gotcha(_data, _func, _ec);
 }

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library/components/fork_gotcha.cpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library/components/fork_gotcha.cpp
@@ -88,10 +88,14 @@ postfork_child()
 {
     if(postfork_child_lock) return;
 
+    // Even if the program is single-threaded and calls fork(), the profiler
+    // spawns threads to help profile BEFORE fork() is called.
     // After fork() in a multi-threaded process, only async-signal-safe functions
     // may be called (mutexes are NOT async-signal-safe).
     // Do NOT call any shutdown or logging functions as
     // they all use mutexes internally and will sporadically deadlock.
+
+    // no exit handler can be used. on_exit() is not async-signal-safe.
 
     if(!is_child_process())
     {
@@ -119,19 +123,6 @@ fork_gotcha::configure()
     fork_gotcha_t::get_initializer() = []() {
         TIMEMORY_C_GOTCHA(fork_gotcha_t, 0, fork);
     };
-
-    // Register exit handler in the parent
-    // Terminates immediately without acquiring any locks.
-    static bool _exit_handler_registered = false;
-    if(!_exit_handler_registered)
-    {
-        _exit_handler_registered = true;
-        on_exit(
-            [](int ec, void*) {
-                if(is_child_process()) _exit(ec);
-            },
-            nullptr);
-    }
 
     // registering the pthread_atfork and gotcha means that we might execute twice
     // handlers twice, hence the locks

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library/components/fork_gotcha.cpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library/components/fork_gotcha.cpp
@@ -1,24 +1,5 @@
-// MIT License
-//
-// Copyright (c) 2022-2025 Advanced Micro Devices, Inc. All Rights Reserved.
-//
-// Permission is hereby granted, free of charge, to any person obtaining a copy
-// of this software and associated documentation files (the "Software"), to deal
-// in the Software without restriction, including without limitation the rights
-// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-// copies of the Software, and to permit persons to whom the Software is
-// furnished to do so, subject to the following conditions:
-//
-// The above copyright notice and this permission notice shall be included in all
-// copies or substantial portions of the Software.
-//
-// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-// SOFTWARE.
+// Copyright (c) Advanced Micro Devices, Inc.
+// SPDX-License-Identifier:  MIT
 
 #include "api.hpp"
 
@@ -120,7 +101,7 @@ postfork_child()
         _exit(1);
     }
 
-    set_state(State::Finalized);
+    set_state(State::Finalized, /*_async_safe=*/true);
     settings::enabled() = false;
     settings::verbose() = -127;
     settings::debug()   = false;

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library/components/fork_gotcha.cpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library/components/fork_gotcha.cpp
@@ -53,15 +53,6 @@ bool prefork_lock         = false;
 bool postfork_parent_lock = false;
 bool postfork_child_lock  = false;
 
-// this does a quick exit (no cleanup) on child processes
-// because perfetto has a tendency to access memory it
-// shouldn't during cleanup
-void
-child_exit(int _ec, void*)
-{
-    std::quick_exit(_ec);
-}
-
 void
 prefork_setup()
 {
@@ -116,30 +107,24 @@ postfork_child()
 {
     if(postfork_child_lock) return;
 
+    // After fork() in a multi-threaded process, only async-signal-safe functions
+    // may be called (mutexes are NOT async-signal-safe).
+    // Do NOT call any shutdown or logging functions as
+    // they all use mutexes internally and will sporadically deadlock.
+
     if(!is_child_process())
     {
-        LOG_ERROR("Child process {} believes it is the root process {}",
-                  process::get_id(), get_root_process_id());
-        std::exit(1);
+        const char msg[] = "Child process believes it is the root process\n";
+        auto       _rc   = write(STDERR_FILENO, msg, sizeof(msg) - 1);
+        (void) _rc;
+        _exit(1);
     }
 
     set_state(State::Finalized);
-
-    // Clean up AMD SMI in child process before other shutdowns
-    if(config::get_use_sampling()) sampling::postfork_child_cleanup();
-
     settings::enabled() = false;
     settings::verbose() = -127;
     settings::debug()   = false;
-    rocprofsys::sampling::shutdown();
-    rocprofsys::categories::shutdown();
     set_thread_state(::rocprofsys::ThreadState::Disabled);
-
-    rocprofsys::get_perfetto_session(process::get_parent_id()).release();
-
-    // register these exit handlers to avoid cleaning up resources
-    on_exit(&child_exit, nullptr);
-    std::atexit([]() { child_exit(EXIT_SUCCESS, nullptr); });
 
     // prevent re-entry until prefork has been called
     postfork_child_lock = true;
@@ -153,6 +138,19 @@ fork_gotcha::configure()
     fork_gotcha_t::get_initializer() = []() {
         TIMEMORY_C_GOTCHA(fork_gotcha_t, 0, fork);
     };
+
+    // Register exit handler in the parent
+    // Terminates immediately without acquiring any locks.
+    static bool _exit_handler_registered = false;
+    if(!_exit_handler_registered)
+    {
+        _exit_handler_registered = true;
+        on_exit(
+            [](int ec, void*) {
+                if(is_child_process()) _exit(ec);
+            },
+            nullptr);
+    }
 
     // registering the pthread_atfork and gotcha means that we might execute twice
     // handlers twice, hence the locks
@@ -177,7 +175,9 @@ fork_gotcha::operator()(const gotcha_data_t&, pid_t (*_real_fork)()) const
         postfork_child();
     }
 
-    if(!settings::use_output_suffix())
+    // Only log in parent (LOG_DEBUG uses the logging mutex which may be
+    // permanently locked in the child after a multi-threaded fork)
+    if(_pid != 0 && !settings::use_output_suffix())
     {
         LOG_DEBUG("Application which make calls to fork() should enable using an process "
                   "identifier output suffix (i.e. set ROCPROFSYS_USE_PID=ON)");


### PR DESCRIPTION
## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

Previously, it was possible for the `fork` tests to timeout. This PR aims to address this issue.

Root cause: After `fork()` in a multi-threaded process, only the calling thread survives in the child. All other threads "cease" to exist, but ANY mutexes they held *could* remain locked (if the parent was using the lock while `fork()` is called, `fork()` would copy the address space for the child). Although the `fork` examples are fine on their own, when profiling is introduced (and our threads are spawned), we fall into the problem of these locks being possible locked.  

For example, I've noticed that it could hang on:
 - The `exit(EXIT_SUCCESS)` call in the child code (`fork.cpp`).
 - Two `LOG_DEBUG...` messages within `amd-smi` (got here through `postfork_child()` logic in `fork_goatcha.cpp`).

**(̶A̶l̶s̶o̶,̶ ̶t̶h̶e̶ ̶`̶h̶i̶p̶M̶a̶l̶l̶o̶c̶C̶o̶n̶c̶u̶r̶r̶e̶n̶c̶y̶M̶p̶r̶o̶c̶`̶ ̶e̶x̶a̶m̶p̶l̶e̶ ̶i̶s̶ ̶t̶e̶c̶h̶n̶i̶c̶a̶l̶l̶y̶ ̶f̶l̶a̶w̶e̶d̶,̶ ̶b̶u̶t̶ ̶i̶t̶ ̶o̶n̶l̶y̶ ̶s̶p̶a̶w̶n̶s̶ ̶1̶-̶2̶ ̶t̶h̶r̶e̶a̶d̶s̶ ̶w̶i̶t̶h̶ ̶1̶ ̶f̶o̶r̶k̶,̶ ̶m̶a̶k̶i̶n̶g̶ ̶i̶t̶ ̶h̶a̶v̶e̶ ̶a̶ ̶L̶O̶W̶ ̶p̶r̶o̶b̶a̶b̶i̶l̶i̶t̶y̶ ̶o̶f̶ ̶d̶e̶a̶d̶l̶o̶c̶k̶)̶**

*Change of plans, this has to be fixed as well*

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

**Changes in `fork.cpp`**: Per POSIX, after `fork()` is a multi-threaded process, the child may only call *async-signal-safe* functions.
 - Remove `std::thread{ _sleep }.join()`: `std::thread` constructor calls `pthread_create`, which uses an internal lock `=` not *async-signal-safe*.
 - Remove both `rocprofsys_user_push_region("child_process_child_thread")` and `rocprofsys_user_push_region("child_process")` and their corresponding pops. They never did anything, even before this change (in `fork_gotcha.cpp`, setting the state to `Finalized` results in this be skipped).
 - Every `printf` call replaced with `write` (within critical region). This is signal safe according to https://www.man7.org/linux/man-pages/man7/signal-safety.7.html
 - `exit` replaced with `_exit` in critical region.

**Changes in `fork_gotcha.cpp`**: We need to modify `postfork_child` as it runs within `fork()` (GOTCHA). Thus, it too needs to be *async-signal-safe*.
 - Ensure logic within this function never reaches a `LOG_...` function. These internally use mutexes and **will** cause a deadlock.
   - The log call was replaced with a `write` call.
 - Move the `on_exit` handler to be set up in the parent for the child. `on_exit` is NOT *async-signal-safe*.
 - `set_state(state::Finalized)` changed to also set `_async_safe` boolean to `true`. That way, it avoids non *async-signal-safe* functions such as `throw` and `LOG`. 

**Changes in `state.hpp` and `state.cpp`**: Added `_async_safe` boolean, defaulted to `false`. Used exclusively to avoid the log and throw (not *async-signal-safe*).

## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

AIPROFSYST-208

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

Run:
`for i in $(seq 1 20); do echo "=== Run $i/20 ==="; ctest --test-dir rocprof-sys-build -L "fork" -LE "gpu"; if [ $? -ne 0 ]; then echo "=== Failed on run $i ==="; break; fi; done`
*many many* times (this uses pytests, because I noticed the problem is "more" reproducible there)
Pytest PR: https://github.com/ROCm/rocm-systems/pull/3962

Before these changes, it would, on average, fail every 4-5 test sessions.

## Test Result

With the change, no failure observed after 80+ runs in a row. 

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
