### PR TITLE
hsakmt: add wallclock to node props during init

### DIFF
--- a/projects/rocr-runtime/libhsakmt/src/dxg/topology.cpp
+++ b/projects/rocr-runtime/libhsakmt/src/dxg/topology.cpp
@@ -589,7 +589,7 @@ hsaKmtGetNodeWallclockFrequency(HSAuint32 NodeId, uint64_t* Frequency) {
   HsaNodeProperties *NodeProperties = &(dxg_topology->g_props[NodeId].node);
   *Frequency = NodeProperties->WallClockKHz * 1000ull;
 
-  return HSAKMT_STATUS_NOT_IMPLEMENTED;
+  return HSAKMT_STATUS_SUCCESS;
 }
 
 uint16_t get_device_id_by_node_id(HSAuint32 node_id) {
@@ -813,7 +813,7 @@ HSAKMT_STATUS topology_sysfs_get_node_props(uint32_t node_id, HsaNodeProperties&
     assert(props.EngineId.ui32.Major && "HSA_OVERRIDE_GFX_VERSION may be needed");
   }
 
-  props.WallClockKHz =  device->GPUCounterFrequency() / 1000ull;
+  props.WallClockKHz = device->GPUCounterFrequency() / 1000ull;
 
   return HSAKMT_STATUS_SUCCESS;
 }

--- a/projects/rocr-runtime/libhsakmt/src/dxg/topology.cpp
+++ b/projects/rocr-runtime/libhsakmt/src/dxg/topology.cpp
@@ -813,6 +813,8 @@ HSAKMT_STATUS topology_sysfs_get_node_props(uint32_t node_id, HsaNodeProperties&
     assert(props.EngineId.ui32.Major && "HSA_OVERRIDE_GFX_VERSION may be needed");
   }
 
+  props.WallClockKHz =  device->GPUCounterFrequency() / 1000ull;
+
   return HSAKMT_STATUS_SUCCESS;
 }
 

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_gpu_agent.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_gpu_agent.cpp
@@ -216,9 +216,6 @@ GpuAgent::GpuAgent(HSAuint32 node, const HsaNodeProperties& node_props, bool xna
   // Store CUID for this agent
   InitDerivedCuid();
 
-#if !defined(__linux__)
-  wallclock_frequency_ = 0;
-#else
   bool model_enabled;
   hsa_status_t status = driver().IsModelEnabled(&model_enabled);
   assert(status == HSA_STATUS_SUCCESS && "IsModelEnabled failed");
@@ -236,7 +233,6 @@ GpuAgent::GpuAgent(HSAuint32 node, const HsaNodeProperties& node_props, bool xna
       }
     }
   }
-#endif
 
   auto& first_cpu = core::Runtime::runtime_singleton_->cpu_agents()[0];
   auto link_info = core::Runtime::runtime_singleton_->GetLinkInfo(first_cpu->node_id(), node_id());


### PR DESCRIPTION
## Motivation

- Node props don't read wall clock correctly
- wall clock is always returned 0

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
