### PR TITLE
[rocprofiler-compute] [Bugfix] rename workload_name to workload_path in sysinfo.csv since --name is optional when profiling

### DIFF
--- a/projects/rocprofiler-compute/src/rocprof_compute_profile/profiler_base.py
+++ b/projects/rocprofiler-compute/src/rocprof_compute_profile/profiler_base.py
@@ -213,7 +213,6 @@ class RocProfCompute_Base:
             )
 
         gen_sysinfo(
-            workload_name=args.name,
             workload_dir=args.path,
             app_cmd=args.remaining,
             skip_roof=args.no_roof,

--- a/projects/rocprofiler-compute/src/utils/specs.py
+++ b/projects/rocprofiler-compute/src/utils/specs.py
@@ -353,11 +353,11 @@ class MachineSpecs:
     # _are_ included in profiling/analysis, so we mark them as 'optional'
     # in the metadata to avoid erroring out on missing fields on
     # serialization
-    workload_name: Optional[str] = field(
+    workload_path: Optional[str] = field(
         default=None,
         metadata={
-            "doc": "The name of the workload data was collected for.",
-            "name": "Workload Name",
+            "doc": "Path to the workload data directory.",
+            "name": "Workload Path",
             "optional": True,
             "show_in_table": True,
         },

--- a/projects/rocprofiler-compute/src/utils/utils_profile.py
+++ b/projects/rocprofiler-compute/src/utils/utils_profile.py
@@ -430,7 +430,6 @@ def pc_sampling_prof(
 
 @demarcate
 def gen_sysinfo(
-    workload_name: str,
     workload_dir: str,
     app_cmd: str,
     skip_roof: bool,
@@ -441,7 +440,7 @@ def gen_sysinfo(
 
     # Append workload information to machine specs
     df["command"] = app_cmd
-    df["workload_name"] = workload_name
+    df["workload_path"] = workload_dir
 
     blocks = ["SQ", "LDS", "SQC", "TA", "TD", "TCP", "TCC", "SPI", "CPC", "CPF"]
     if not skip_roof:


### PR DESCRIPTION
## Motivation

When --output-directory is used instead of --name in profile mode, the workload_name become null in sysinfo.csv
This propagates to analysis database causing downstream issues for optiq

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

Rename workload_name to workload_path in sysinfo.csv which will now contain the path to the workload directory.
This is because --name was made optional for profile mode, so name will not always be available.

<!-- Explain the changes along with any relevant GitHub links. -->

## JIRA ID

AIPROFCOMP-487

AIPROFVIS-231

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan

Check workload_path in sysinfo.csv
Ensure no workload_name in sysinfo.csv

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

workload_path was correct in sysinfo.csv

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
