### PR TITLE
[rocprofiler-compute] Skip PC sampling test if not supported on machine post profiling

### DIFF
--- a/projects/rocprofiler-compute/tests/test_pc_sampling.py
+++ b/projects/rocprofiler-compute/tests/test_pc_sampling.py
@@ -61,6 +61,14 @@ PC_SAMPLING_STOCHASTIC_FILES = sorted([
 ])
 
 
+def is_pc_sampling_not_supported(output):
+    """
+    To be called with the stdout + stderr after profiling.
+    Check whether profiling output said PC sampling is not supported on the machine
+    """
+    return "Given PC sampling configuration is not supported" in output
+
+
 def test_pc_sampling_host_trap(binary_handler_profile_rocprof_compute):
     """
     Test that PC sampling works with --block 21 and --pc-sampling-method host_trap.
@@ -114,15 +122,21 @@ def test_pc_sampling_stochastic(binary_handler_profile_rocprof_compute):
 
     workload_dir = test_utils.get_output_dir()
 
-    _ = binary_handler_profile_rocprof_compute(
+    code, stdout, stderr = binary_handler_profile_rocprof_compute(
         config,
         workload_dir,
         options,
-        check_success=True,
+        check_success=False,
+        capture_output=True,
         roof=False,
         app_name="app_mat_mul_max",
     )
 
+    output = f"{stdout}\n{stderr}"
+    if is_pc_sampling_not_supported(output):
+        pytest.skip("PC sampling is not supported")
+
+    assert code == 0
     file_dict = test_utils.check_non_pmc_files(workload_dir, num_devices, 1)
     assert sorted(list(file_dict.keys())) == sorted(PC_SAMPLING_STOCHASTIC_FILES)
 

--- a/projects/rocprofiler-compute/tests/test_pc_sampling.py
+++ b/projects/rocprofiler-compute/tests/test_pc_sampling.py
@@ -134,6 +134,7 @@ def test_pc_sampling_stochastic(binary_handler_profile_rocprof_compute):
 
     output = f"{stdout}\n{stderr}"
     if is_pc_sampling_not_supported(output):
+        test_utils.clean_output_dir(config["cleanup"], workload_dir)
         pytest.skip("PC sampling is not supported")
 
     assert code == 0


### PR DESCRIPTION
## Motivation

CI machine can sometimes run on machine which does not support stochastic pc sampling driver/firmware

Fixes https://github.com/ROCm/TheRock/issues/4034

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

In test_pc_sampling.py skip stochastic pc sampling test if profiling output complains about PC sampling configuration not supported

<!-- Explain the changes along with any relevant GitHub links. -->

## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan

Run test_pc_sampling.py locally

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

Tests pass

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
