### PR TITLE
rocr-debug-agent: open code objects before wave dump

### DIFF
--- a/projects/rocr-debug-agent/src/code_object.cpp
+++ b/projects/rocr-debug-agent/src/code_object.cpp
@@ -316,6 +316,13 @@ code_object_t::open ()
 
   /* Calculate the size of the code object as loaded in memory.  Its size is
      the distance of the end of the highest segment from the load address.  */
+
+  if (elf_version (EV_CURRENT) == EV_NONE)
+    {
+      agent_warning ("elf_version failed");
+      return false;
+    }
+
   std::unique_ptr<Elf, void (*) (Elf *)> elf (
       elf_begin (fd, ELF_C_READ, nullptr), [] (Elf *elf) { elf_end (elf); });
   if (!elf)

--- a/projects/rocr-debug-agent/src/debug_agent.cpp
+++ b/projects/rocr-debug-agent/src/debug_agent.cpp
@@ -1078,6 +1078,17 @@ process_dbgapi_events (amd_dbgapi_process_id_t process_id, bool all_wavefronts,
 
   if (need_print_waves)
     {
+      /* With --lazy,-z, code objects may not have been opened yet.
+         Open them now so we can resolve PCs to code objects.  */
+      for (auto it = code_object_map.begin (); it != code_object_map.end ();)
+        if (!it->second.is_open () && !it->second.open ())
+          {
+            agent_warning ("could not open code_object_%ld", it->first.handle);
+            it = code_object_map.erase (it);
+          }
+        else
+          ++it;
+
       auto code_objects_disassembled
           = print_wavefronts (process_id, all_wavefronts, code_object_map);
 
@@ -1087,15 +1098,8 @@ process_dbgapi_events (amd_dbgapi_process_id_t process_id, bool all_wavefronts,
           {
             auto it = code_object_map.find (code_object_id);
             agent_assert (it != code_object_map.end ());
+
             auto &code_object = it->second;
-
-            if (!code_object.is_open () && !code_object.open ())
-              {
-                agent_warning ("could not open %s",
-                               code_object.uri ().c_str ());
-                continue;
-              }
-
             if (!code_object.save (*g_code_objects_dir))
               agent_warning ("could not save code object %s to %s",
                              code_object.uri ().c_str (),


### PR DESCRIPTION
When printing wavefronts, ensure every code object in the map is opened first so PC resolution works with --lazy/-z. Drop entries that fail to open instead of leaving half-open state.

Also, In code_object_t::open(), call elf_version(EV_CURRENT) as it is required to do so before calling elf_begin.