### PR TITLE
[rocprofiler-systems] Disable logging in `postfork_child()`

### DIFF
--- a/projects/rocprofiler-systems/examples/fork/fork.cpp
+++ b/projects/rocprofiler-systems/examples/fork/fork.cpp
@@ -45,13 +45,9 @@ run(const char* _name, int nchildren)
                 print_info(_name);
                 printf("[%s][%i] child job starting...\n", _name, getpid());
                 auto _sleep = [=]() {
-                    rocprofsys_user_push_region("child_process_child_thread");
                     std::this_thread::sleep_for(std::chrono::seconds{ _nsec });
-                    rocprofsys_user_pop_region("child_process_child_thread");
                 };
-                rocprofsys_user_push_region("child_process");
                 std::thread{ _sleep }.join();
-                rocprofsys_user_push_region("child_process");
                 printf("[%s][%i] child job complete\n", _name, getpid());
                 exit(EXIT_SUCCESS);
             }

--- a/projects/rocprofiler-systems/source/lib/logger/debug.hpp
+++ b/projects/rocprofiler-systems/source/lib/logger/debug.hpp
@@ -8,33 +8,56 @@
 #define LOG_CRITICAL(...)                                                                \
     do                                                                                   \
     {                                                                                    \
-        rocprofsys::logger_t::instance().log(                                            \
-            spdlog::source_loc{ __FILE__, __LINE__, __func__ }, spdlog::level::critical, \
-            __VA_ARGS__);                                                                \
-        rocprofsys::logger_t::instance().flush();                                        \
+        if(!rocprofsys::logger_t::is_suppressed())                                       \
+        {                                                                                \
+            rocprofsys::logger_t::instance().log(                                        \
+                spdlog::source_loc{ __FILE__, __LINE__, __func__ },                      \
+                spdlog::level::critical, __VA_ARGS__);                                   \
+            rocprofsys::logger_t::instance().flush();                                    \
+        }                                                                                \
     } while(0)
 
 #define LOG_ERROR(...)                                                                   \
-    rocprofsys::logger_t::instance().log(                                                \
-        spdlog::source_loc{ __FILE__, __LINE__, __func__ }, spdlog::level::err,          \
-        __VA_ARGS__)
+    do                                                                                   \
+    {                                                                                    \
+        if(!rocprofsys::logger_t::is_suppressed())                                       \
+            rocprofsys::logger_t::instance().log(                                        \
+                spdlog::source_loc{ __FILE__, __LINE__, __func__ }, spdlog::level::err,  \
+                __VA_ARGS__);                                                            \
+    } while(0)
 
 #define LOG_WARNING(...)                                                                 \
-    rocprofsys::logger_t::instance().log(                                                \
-        spdlog::source_loc{ __FILE__, __LINE__, __func__ }, spdlog::level::warn,         \
-        __VA_ARGS__)
+    do                                                                                   \
+    {                                                                                    \
+        if(!rocprofsys::logger_t::is_suppressed())                                       \
+            rocprofsys::logger_t::instance().log(                                        \
+                spdlog::source_loc{ __FILE__, __LINE__, __func__ }, spdlog::level::warn, \
+                __VA_ARGS__);                                                            \
+    } while(0)
 
 #define LOG_INFO(...)                                                                    \
-    rocprofsys::logger_t::instance().log(                                                \
-        spdlog::source_loc{ __FILE__, __LINE__, __func__ }, spdlog::level::info,         \
-        __VA_ARGS__)
+    do                                                                                   \
+    {                                                                                    \
+        if(!rocprofsys::logger_t::is_suppressed())                                       \
+            rocprofsys::logger_t::instance().log(                                        \
+                spdlog::source_loc{ __FILE__, __LINE__, __func__ }, spdlog::level::info, \
+                __VA_ARGS__);                                                            \
+    } while(0)
 
 #define LOG_DEBUG(...)                                                                   \
-    rocprofsys::logger_t::instance().log(                                                \
-        spdlog::source_loc{ __FILE__, __LINE__, __func__ }, spdlog::level::debug,        \
-        __VA_ARGS__)
+    do                                                                                   \
+    {                                                                                    \
+        if(!rocprofsys::logger_t::is_suppressed())                                       \
+            rocprofsys::logger_t::instance().log(                                        \
+                spdlog::source_loc{ __FILE__, __LINE__, __func__ },                      \
+                spdlog::level::debug, __VA_ARGS__);                                      \
+    } while(0)
 
 #define LOG_TRACE(...)                                                                   \
-    rocprofsys::logger_t::instance().log(                                                \
-        spdlog::source_loc{ __FILE__, __LINE__, __func__ }, spdlog::level::trace,        \
-        __VA_ARGS__)
+    do                                                                                   \
+    {                                                                                    \
+        if(!rocprofsys::logger_t::is_suppressed())                                       \
+            rocprofsys::logger_t::instance().log(                                        \
+                spdlog::source_loc{ __FILE__, __LINE__, __func__ },                      \
+                spdlog::level::trace, __VA_ARGS__);                                      \
+    } while(0)

--- a/projects/rocprofiler-systems/source/lib/logger/logger.hpp
+++ b/projects/rocprofiler-systems/source/lib/logger/logger.hpp
@@ -152,6 +152,16 @@ protected:
 class logger_t
 {
 public:
+    // Required for async-signal-safe contexts like postfork_child
+    static inline bool __attribute__((always_inline)) is_suppressed()
+    {
+        return __builtin_expect(get_suppressed().load(std::memory_order_relaxed), false);
+    }
+
+    static void suppress() { get_suppressed().store(true, std::memory_order_relaxed); }
+
+    static void unsuppress() { get_suppressed().store(false, std::memory_order_relaxed); }
+
     static spdlog::logger& instance()
     {
         static std::shared_ptr<spdlog::logger> _instance;
@@ -212,6 +222,12 @@ private:
     }
 
     static constexpr const char* s_logger_name = "rocprofiler-systems";
+
+    static std::atomic<bool>& get_suppressed()
+    {
+        static std::atomic<bool> _v{ false };
+        return _v;
+    }
 };
 
 }  // namespace rocprofsys

--- a/projects/rocprofiler-systems/source/lib/logger/logger.hpp
+++ b/projects/rocprofiler-systems/source/lib/logger/logger.hpp
@@ -155,12 +155,12 @@ public:
     // Required for async-signal-safe contexts like postfork_child
     static inline bool __attribute__((always_inline)) is_suppressed()
     {
-        return __builtin_expect(get_suppressed().load(std::memory_order_relaxed), false);
+        return __builtin_expect(s_suppressed.load(std::memory_order_relaxed), false);
     }
 
-    static void suppress() { get_suppressed().store(true, std::memory_order_relaxed); }
+    static void suppress() { s_suppressed.store(true, std::memory_order_relaxed); }
 
-    static void unsuppress() { get_suppressed().store(false, std::memory_order_relaxed); }
+    static void unsuppress() { s_suppressed.store(false, std::memory_order_relaxed); }
 
     static spdlog::logger& instance()
     {
@@ -221,13 +221,8 @@ private:
         return log;
     }
 
-    static constexpr const char* s_logger_name = "rocprofiler-systems";
-
-    static std::atomic<bool>& get_suppressed()
-    {
-        static std::atomic<bool> _v{ false };
-        return _v;
-    }
+    static constexpr const char*    s_logger_name = "rocprofiler-systems";
+    static inline std::atomic<bool> s_suppressed{ false };
 };
 
 }  // namespace rocprofsys

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library/components/fork_gotcha.cpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library/components/fork_gotcha.cpp
@@ -166,7 +166,7 @@ fork_gotcha::operator()(const gotcha_data_t&, pid_t (*_real_fork)()) const
     // permanently locked in the child after a multi-threaded fork)
     if(_pid != 0 && !settings::use_output_suffix())
     {
-        LOG_DEBUG("Application which make calls to fork() should enable using an process "
+        LOG_DEBUG("Application that makes calls to fork() should enable using a process "
                   "identifier output suffix (i.e. set ROCPROFSYS_USE_PID=ON)");
     }
 

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library/components/fork_gotcha.cpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library/components/fork_gotcha.cpp
@@ -1,24 +1,5 @@
-// MIT License
-//
-// Copyright (c) 2022-2025 Advanced Micro Devices, Inc. All Rights Reserved.
-//
-// Permission is hereby granted, free of charge, to any person obtaining a copy
-// of this software and associated documentation files (the "Software"), to deal
-// in the Software without restriction, including without limitation the rights
-// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-// copies of the Software, and to permit persons to whom the Software is
-// furnished to do so, subject to the following conditions:
-//
-// The above copyright notice and this permission notice shall be included in all
-// copies or substantial portions of the Software.
-//
-// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-// SOFTWARE.
+// Copyright (c) Advanced Micro Devices, Inc.
+// SPDX-License-Identifier:  MIT
 
 #include "api.hpp"
 
@@ -123,6 +104,10 @@ postfork_child()
         std::exit(1);
     }
 
+    // Suppress all spdlog logging (the mutex may be permanently locked)
+    // The atomic check in each LOG_* macro is async-signal-safe.
+    logger_t::suppress();
+
     set_state(State::Finalized);
 
     // Clean up AMD SMI in child process before other shutdowns
@@ -177,7 +162,9 @@ fork_gotcha::operator()(const gotcha_data_t&, pid_t (*_real_fork)()) const
         postfork_child();
     }
 
-    if(!settings::use_output_suffix())
+    // Only log in parent (LOG_DEBUG uses the logging mutex which may be
+    // permanently locked in the child after a multi-threaded fork)
+    if(_pid != 0 && !settings::use_output_suffix())
     {
         LOG_DEBUG("Application which make calls to fork() should enable using an process "
                   "identifier output suffix (i.e. set ROCPROFSYS_USE_PID=ON)");


### PR DESCRIPTION
## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

Fork tests could sporadically timeout. This PR aims to address the **main** factor that causes this. 

**Root cause**: When profiling, our tool creates threads before the program runs to help. Since `fork()` only clones the calling thread, the profiler's threads vanish in the child but any mutexes they held are copied as permanently locked. The main issue is `spdlog`'s logging mutex. It's essentially everywhere in the profiler, so the lock is frequently held. If `fork()` is called when the lock is held, game over, a deadlock occurs in the child.

**NOTE**: Technically, even with these changes, *I believe* that `fork()` can still deadlock. For example, the `print` statements in the child code, or the `std::thread...` call... these all hold *mutexes*. However, the mutexes that are used here are infrequently used and if they are, for a very short duration. The chance of a problem occurring is very low.
I believe that a full fix would require making many things `async-signal-safe`, but that is a larger change for what amounts to avoiding a small problem that can be solved by just re-running the code.
*It may be worth revisiting in the future if anything changes, I suppose*

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

Add `suppress` and `unsuppress` options to the logger. 
Suppress logging output in `postfork_child()`.

Also removed push/pop in `fork` example as they are no-ops. Having the state as finalized means these never show up. Not quite sure why they were there in the first place.

## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

AIPROFSYST-208

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

Using #3962 (as I noticed the deadlock would appear more frequently with pytests)

Run:
```
for i in $(seq 1 20); do echo "=== Run $i/20 ==="; ctest --test-dir rocprof-sys-build -L "fork" -LE "gpu"; if [ $? -ne 0 ]; then echo "=== Failed on run $i ==="; break; fi; done
```
many, many times.

(Essentially rerun the `fork` tests at least >= 100 times)

## Test Result

<!-- Briefly summarize test outcomes. -->

Tests always pass.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
