### PR TITLE
[rccl][rebase][feb] Add Missing Header Include

### DIFF
--- a/projects/rccl/src/include/rccl_common.h
+++ b/projects/rccl/src/include/rccl_common.h
@@ -22,6 +22,7 @@ THE SOFTWARE.
 #ifndef RCCL_COMMON_H_
 #define RCCL_COMMON_H_
 #include "nccl_common.h"
+#include "nccl_tuner.h"
 #include "nccl.h"
 #include "param.h"
 #include "core.h"


### PR DESCRIPTION
Add nccl_tuner.h include to rccl_common.h.

## Motivation

This header is missing which doesn't seem to fail in the default CMake build potentially with header inclusion order, but with some more customized builds this missing header does cause a build failure.

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
