### PR TITLE
[rccl][rebase][feb] Fix ce_coll.cc Incompatibility with ROCm 6.2

### DIFF
--- a/projects/rccl/src/ce_coll.cc
+++ b/projects/rccl/src/ce_coll.cc
@@ -20,6 +20,7 @@ static const uint32_t CE_COLL_INTRA_BATCH_SYNC_FREQ = 8;
 // Message threshold for intra-batch synchronization
 static const uint64_t CE_COLL_INTRA_BATCH_SYNC_MSG_THRESHOLD = 512*1024*1024;
 
+#if ROCM_VERSION >= 60400
 ncclResult_t ncclCeInit(struct ncclComm* comm) {
   ncclResult_t ret = ncclSuccess;
 
@@ -186,7 +187,6 @@ exit:
 fail:
   goto exit;
 }
-
 
 ncclResult_t ncclMemOpSync(struct ncclComm* comm, cudaStream_t stream) {
   ncclResult_t ret = ncclSuccess;
@@ -613,3 +613,36 @@ exit:
 fail:
   goto exit;
 }
+#else
+// Stubs for ROCm 6.2 compatibility
+bool ncclCeImplemented(ncclFunc_t coll, int/*ncclDevRedOp_t*/ red, ncclDataType_t ty) {
+  return false;
+}
+// init.cc calls this during commFree without first checking ncclCeImplemented result,
+// so need to return success to avoid failure
+ncclResult_t ncclCeFinalize(struct ncclComm* comm) {
+  return ncclSuccess;
+}
+// The remaining functions should not be called when ncclCeImplemented is false
+ncclResult_t ncclCeInit(struct ncclComm* comm) {
+  return ncclInternalError;
+}
+ncclResult_t ncclMemOpSync(struct ncclComm* comm, cudaStream_t stream) {
+  return ncclInternalError;
+}
+ncclResult_t ncclLaunchCeColl(struct ncclComm* comm, struct ncclKernelPlan* plan) {
+  return ncclInternalError;
+}
+ncclResult_t ncclCeAllGather(struct ncclComm* comm, struct ncclCeCollArgs* args, cudaStream_t stream) {
+  return ncclInternalError;
+}
+ncclResult_t ncclCeScatter(struct ncclComm* comm, struct ncclCeCollArgs* args, cudaStream_t stream) {
+  return ncclInternalError;
+}
+ncclResult_t ncclCeGather(struct ncclComm* comm, struct ncclCeCollArgs* args, cudaStream_t stream) {
+  return ncclInternalError;
+}
+ncclResult_t ncclCeAlltoAll(struct ncclComm* comm, struct ncclCeCollArgs* args, cudaStream_t stream) {
+  return ncclInternalError;
+}
+#endif


### PR DESCRIPTION
Guard against incompatible ROCm versions in ce_coll.cc

## Motivation

Changes were made adding dependencies on hipStreamBatchMemOpParams which is not available in some ROCm versions. It _is available_ in 6.4 and 7.0, but _not available_ in 6.2.

Currently this guard is not extremely tight and just handles the versions I tested against.

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
