### PR TITLE
clr: Fix missing activity records in profiling traces

### DIFF
--- a/projects/clr/hipamd/src/hip_intercept.cpp
+++ b/projects/clr/hipamd/src/hip_intercept.cpp
@@ -51,5 +51,5 @@ const char* hipApiName(uint32_t id) { return hip_api_name(id); }
 
 extern "C" void hipRegisterTracerCallback(int (*function)(activity_domain_t domain,
                                                           uint32_t operation_id, void* data)) {
-  amd::activity_prof::report_activity.store(function, std::memory_order_relaxed);
+  amd::activity_prof::report_activity.store(function, std::memory_order_release);
 }

--- a/projects/clr/hipamd/src/hip_prof_api.h
+++ b/projects/clr/hipamd/src/hip_prof_api.h
@@ -50,7 +50,7 @@ template <hip_api_id_t operation_id> class api_callbacks_spawner_t {
     static_assert(operation_id >= HIP_API_ID_FIRST && operation_id <= HIP_API_ID_LAST,
                   "invalid HIP_API operation id");
 
-    if (auto function = amd::activity_prof::report_activity.load(std::memory_order_relaxed);
+    if (auto function = amd::activity_prof::report_activity.load(std::memory_order_acquire);
         function &&
         (enabled_ = function(ACTIVITY_DOMAIN_HIP_API, operation_id, &trace_data_) == 0)) {
       amd::activity_prof::correlation_id = trace_data_.api_data.correlation_id;

--- a/projects/clr/rocclr/platform/activity.cpp
+++ b/projects/clr/rocclr/platform/activity.cpp
@@ -29,6 +29,17 @@ namespace amd::activity_prof {
 
 decltype(report_activity) report_activity{nullptr};
 
+// Reserved sentinel pointer value (0x1) used to signal roctracer that CLR commits
+// to delivering an activity record for this operation. roctracer's TracerCallback
+// distinguishes this from an IsEnabled query (nullptr) and a real record (valid ptr).
+// See TracerCallback in roctracer.cpp, ACTIVITY_DOMAIN_HIP_OPS case.
+static void* const kCommitRecordSentinel = reinterpret_cast<void*>(uintptr_t{1});
+
+void CommitRecord(OpId operation_id) {
+  auto function = report_activity.load(std::memory_order_acquire);
+  if (function) function(ACTIVITY_DOMAIN_HIP_OPS, operation_id, kCommitRecordSentinel);
+}
+
 #if defined(__linux__)
 __thread activity_correlation_id_t correlation_id __attribute__((tls_model("initial-exec"))) = 0;
 #elif defined(_WIN32)
@@ -44,7 +55,7 @@ static inline size_t linearSize(const amd::Coord3D& size3d) {
 
 bool IsEnabled(OpId operation_id) {
   if (operation_id < OP_ID_NUMBER)
-    if (auto report = report_activity.load(std::memory_order_relaxed))
+    if (auto report = report_activity.load(std::memory_order_acquire))
       return report(ACTIVITY_DOMAIN_HIP_OPS, operation_id, nullptr) == 0;
   return false;
 }
@@ -58,7 +69,7 @@ void ReportActivity(const amd::Command& command) {
     return;
   }
 
-  auto function = report_activity.load(std::memory_order_relaxed);
+  auto function = report_activity.load(std::memory_order_acquire);
   if (!function) return;
 
   const auto* queue = command.queue();

--- a/projects/clr/rocclr/platform/activity.hpp
+++ b/projects/clr/rocclr/platform/activity.hpp
@@ -76,6 +76,10 @@ constexpr OpId OperationId(cl_command_type commandType) {
 bool IsEnabled(OpId operation_id);
 void ReportActivity(const amd::Command& command);
 
+// Signals roctracer that CLR commits to delivering one activity record for
+// this operation. Must be called exactly once per command that will produce
+// a record.
+void CommitRecord(OpId operation_id);
 
 const char* getOclCommandKindString(cl_command_type kind);
 }  // namespace amd::activity_prof

--- a/projects/clr/rocclr/platform/command.cpp
+++ b/projects/clr/rocclr/platform/command.cpp
@@ -149,7 +149,7 @@ bool Event::setStatus(int32_t status, uint64_t timeStamp) {
       releaseResources();
     }
 
-    if (profilingInfo().enabled_ && amd::activity_prof::IsEnabled(OP_ID_DISPATCH)) {
+    if (profilingInfo().enabled_) {
       amd::activity_prof::ReportActivity(command());
     }
 
@@ -297,10 +297,19 @@ bool Event::notifyCmdQueue(bool cpu_wait) {
 
 const Event::EventWaitList Event::nullWaitList(0);
 
+static bool IsActivityEnabledAndCommit(cl_command_type type) {
+  auto op = amd::activity_prof::OperationId(type);
+  if (amd::activity_prof::IsEnabled(op)) {
+    amd::activity_prof::CommitRecord(op);
+    return true;
+  }
+  return false;
+}
+
 // ================================================================================================
 Command::Command(HostQueue& queue, cl_command_type type, const EventWaitList& eventWaitList,
                  uint32_t commandWaitBits, const Event* waitingEvent)
-    : Event(queue, amd::activity_prof::IsEnabled(amd::activity_prof::OperationId(type)) ||
+    : Event(queue, IsActivityEnabledAndCommit(type) ||
                        queue.properties().test(CL_QUEUE_PROFILING_ENABLE) ||
                        Agent::shouldPostEventEvents()),
       queue_(&queue),
@@ -380,9 +389,10 @@ void Command::enqueue() {
     ScopedLock sl(queue_->vdev()->execution());
     queue_->FormSubmissionBatch(this);
 
-    // Enqueue flushes, except profiling markers to avoid frequent expensive callbacks
+    // Enqueue flushes, except profiling markers to avoid frequent expensive callbacks.
+    // Also flush unconditionally when the batch exceeds the size threshold.
     if (((type() == 0) && profilingInfo().batch_flush_) || (type() == CL_COMMAND_MARKER) ||
-        (type() == CL_COMMAND_TASK)) {
+        (type() == CL_COMMAND_TASK) || queue_->ShouldFlushBatch()) {
       // The current HSA signal tracking logic requires profiling enabled for the markers
       EnableProfiling();
       // Update batch head for the current marker. Hence the status of all commands can be
@@ -395,7 +405,6 @@ void Command::enqueue() {
       queue_->ResetSubmissionBatch();
     } else {
       submit(*queue_->vdev());
-      queue_->FlushSubmissionBatch(this);
     }
   } else {
     queue_->append(*this);

--- a/projects/clr/rocclr/platform/commandqueue.hpp
+++ b/projects/clr/rocclr/platform/commandqueue.hpp
@@ -288,12 +288,8 @@ class HostQueue : public CommandQueue {
     lastEnqueueCommand_ = command;
   }
 
-  //! Flushes submitted commands if the batch size significantly grew
-  void FlushSubmissionBatch(Command* command) {
-    if (size_ > DEBUG_CLR_MAX_BATCH_SIZE) {
-      command->notifyCmdQueue();
-    }
-  }
+  //! Returns true if the batch size exceeds the flush threshold
+  bool ShouldFlushBatch() const { return size_ > DEBUG_CLR_MAX_BATCH_SIZE; }
   //! Reset the command batch list
   void ResetSubmissionBatch() {
     head_ = nullptr;

--- a/projects/roctracer/src/roctracer/registration_table.h
+++ b/projects/roctracer/src/roctracer/registration_table.h
@@ -86,6 +86,17 @@ template <typename T, uint32_t N, typename IsStopped = detail::False> class Regi
                                                          : std::nullopt;
   }
 
+  // Like Get(), but skips the IsStopped check. Used to drain in-flight records
+  // that were already committed (counter incremented) before stop was signaled.
+  std::optional<T> GetForDrain(uint32_t operation_id) const {
+    assert(operation_id < N && "id is out of range");
+    const table_element_t& entry = table_.at(operation_id);
+    if (!entry.enabled.load(std::memory_order_relaxed)) return std::nullopt;
+    std::shared_lock lock(entry.mutex);
+    return entry.enabled.load(std::memory_order_relaxed) ? std::make_optional(entry.data)
+                                                         : std::nullopt;
+  }
+
   bool IsEmpty() const { return registered_count_.load(std::memory_order_relaxed) == 0; }
 
  private:

--- a/projects/roctracer/src/roctracer/roctracer.cpp
+++ b/projects/roctracer/src/roctracer/roctracer.cpp
@@ -373,6 +373,16 @@ ActivityRegistrationTable<ACTIVITY_DOMAIN_HIP_OPS, IsStopped> hip_ops_activity_t
 ActivityRegistrationTable<ACTIVITY_DOMAIN_HSA_OPS, IsStopped> hsa_ops_activity_table;
 CallbackRegistrationTable<ACTIVITY_DOMAIN_HSA_EVT, IsStopped> hsa_evt_callback_table;
 
+// Pending HIP_OPS record tracking. CLR explicitly calls CommitRecord (sentinel data=0x1)
+// once per command to increment submitted. Delivered is deduplicated by correlation_id
+// so AccumulateCommand's N records per cid count as one delivery.
+static std::atomic<uint64_t> hip_ops_submitted{0};
+static std::atomic<uint64_t> hip_ops_delivered{0};
+
+// Reserved sentinel pointer value matching kCommitRecordSentinel in CLR's activity.cpp.
+// Must never be a valid activity_record_t pointer.
+static void* const kCommitRecordSentinel = reinterpret_cast<void*>(uintptr_t{1});
+
 int TracerCallback(activity_domain_t domain, uint32_t operation_id, void* data) {
   switch (domain) {
     case ACTIVITY_DOMAIN_HSA_API:
@@ -384,11 +394,17 @@ int TracerCallback(activity_domain_t domain, uint32_t operation_id, void* data) 
                                   static_cast<HIP_ApiTracer::TraceData*>(data));
 
     case ACTIVITY_DOMAIN_HIP_OPS:
-      if (auto pool = hip_ops_activity_table.Get(operation_id)) {
-        if (auto record = static_cast<activity_record_t*>(data)) {
-          // If the record is for a kernel dispatch, write the kernel name in the pool's data,
-          // and make the record point to it. Older HIP runtimes do not provide a kernel
-          // name, so record.kernel_name might be null.
+      // data == kCommitRecordSentinel (0x1): CLR's CommitRecord() signals that a command
+      // has been created and will produce an activity record. Called once per command from
+      // IsActivityEnabledAndCommit() in command.cpp. Matched by hip_ops_delivered on the
+      // record delivery path below.
+      if (data == kCommitRecordSentinel) {
+        hip_ops_submitted.fetch_add(1, std::memory_order_relaxed);
+        return 0;
+      }
+      if (data != nullptr) {
+        auto record = static_cast<activity_record_t*>(data);
+        if (auto pool = hip_ops_activity_table.GetForDrain(operation_id)) {
           if (operation_id == HIP_OP_ID_DISPATCH && record->kernel_name != nullptr)
             (*pool)->Write(*record, record->kernel_name, strlen(record->kernel_name) + 1,
                            [](auto& record, const void* data) {
@@ -397,6 +413,17 @@ int TracerCallback(activity_domain_t domain, uint32_t operation_id, void* data) 
           else
             (*pool)->Write(*record);
         }
+        // Deduplicate by correlation_id: AccumulateCommand delivers multiple records
+        // with the same cid — only count the transition to a new cid.
+        thread_local activity_correlation_id_t last_delivered_cid{0};
+        if (record->correlation_id != last_delivered_cid) {
+          last_delivered_cid = record->correlation_id;
+          hip_ops_delivered.fetch_add(1, std::memory_order_release);
+        }
+        return 0;
+      }
+      // IsEnabled query (data == nullptr)
+      if (auto pool = hip_ops_activity_table.Get(operation_id)) {
         return 0;
       }
       break;
@@ -833,14 +860,42 @@ roctracer_activity_pop_external_correlation_id(activity_correlation_id_t* last_i
 
 // Start API
 ROCTRACER_API void roctracer_start() {
-  if (stopped_status.exchange(false, std::memory_order_relaxed) && roctracer_start_cb)
-    roctracer_start_cb();
+  if (stopped_status.exchange(false, std::memory_order_relaxed)) {
+    // Reset counters so prior divergence (e.g. from errored commands) doesn't
+    // cause spurious drain timeouts in the next stop() call.
+    hip_ops_submitted.store(0, std::memory_order_relaxed);
+    hip_ops_delivered.store(0, std::memory_order_relaxed);
+    if (roctracer_start_cb) roctracer_start_cb();
+  }
 }
 
 // Stop API
 ROCTRACER_API void roctracer_stop() {
-  if (!stopped_status.exchange(true, std::memory_order_relaxed) && roctracer_stop_cb)
-    roctracer_stop_cb();
+  if (!stopped_status.exchange(true, std::memory_order_relaxed)) {
+    // Drain in-flight activity records committed before stop.
+    // GPU work should already be complete (e.g. after hipDeviceSynchronize),
+    // async handlers just need time to fire and deliver records.
+    constexpr int kDrainTimeoutMs = 100;
+    for (int waited = 0;
+         hip_ops_delivered.load(std::memory_order_acquire) <
+             hip_ops_submitted.load(std::memory_order_acquire) &&
+         waited < kDrainTimeoutMs;
+         waited++) {
+      usleep(1000);
+    }
+    {
+      uint64_t delivered = hip_ops_delivered.load(std::memory_order_acquire);
+      uint64_t submitted = hip_ops_submitted.load(std::memory_order_acquire);
+      if (delivered < submitted) {
+        ERR_LOGGING("roctracer_stop: drain timeout after " << kDrainTimeoutMs
+                    << "ms, " << (submitted - delivered) << " activity records may be lost");
+      }
+    }
+    // Flush the pool so the client's buffer_callback_fun receives any records
+    // still sitting in the partially-filled buffer before stop returns.
+    roctracer_flush_activity_impl(nullptr);
+    if (roctracer_stop_cb) roctracer_stop_cb();
+  }
 }
 
 ROCTRACER_API roctracer_status_t roctracer_get_timestamp(roctracer_timestamp_t* timestamp) {


### PR DESCRIPTION
Fix a fundamental flaw in roctracer where it was not waiting on all activity records at stop
- Use acquire/release ordering on report_activity callback pointer
- Remove redundant IsEnabled gate at CL_COMPLETE that races with teardown
- Replace re-entrant FlushSubmissionBatch with ShouldFlushBatch
- Add pending record counter so roctracer_stop() drains in-flight records
- Add GetForDrain to bypass IsStopped for committed records

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
