### PR TITLE
[rocprofiler-compute] Strix halo(gfx1151) support

### DIFF
--- a/projects/rocprofiler-compute/CHANGELOG.md
+++ b/projects/rocprofiler-compute/CHANGELOG.md
@@ -22,6 +22,9 @@ Full documentation for ROCm Compute Profiler is available at [https://rocm.docs.
 
 * Added L2 memory bandwidth derived metrics under `--membw-analysis` to allow L2 memory bandwidth specific profiling and analysis metric block 30.
 
+* Added AMD Strix Halo (gfx1151) support
+  * New memory hierarchy visualization for RDNA 3.5 (gfx115X) in analyze CLI mode.
+
 * Introduced support for MI350P GPU
 
 * ``--view table`` option in analyze mode to force all TTY output to plain tables and ignore ``cli_style`` from YAML config (e.g. mem_chart, Roofline charts render as tables). The ``--view`` argument is reserved for future TTY views (e.g. other chart styles).

--- a/projects/rocprofiler-compute/CHANGELOG.md
+++ b/projects/rocprofiler-compute/CHANGELOG.md
@@ -62,6 +62,11 @@ Full documentation for ROCm Compute Profiler is available at [https://rocm.docs.
 
 * `--path` and `--subpath` options will be removed as they are already deprecated
 
+### Known issues
+
+* For Strix Halo, the roofline metrics table will have N/A values for "peak" field
+  * This will be fixed by adding empirical benchmark support for Strix Halo in a future release
+
 ## ROCm Compute Profiler 3.5.0 for ROCm 7.12.0
 
 ### Added

--- a/projects/rocprofiler-compute/CMakeLists.txt
+++ b/projects/rocprofiler-compute/CMakeLists.txt
@@ -494,6 +494,15 @@ add_test(
         ${WORKING_DIR_OPTION}
 )
 
+# RDNA3.5 memory chart CLI (Rich) — no GPU required
+add_test(
+    NAME test_mem_chart_gfx11
+    COMMAND
+        ${PYTHON_TEST_COMMAND} -m pytest ${STANDALONEBINARY_TEST_OPTION}
+        --junitxml=tests/test_mem_chart_gfx11.xml ${COV_OPTION}
+        tests/test_mem_chart_gfx11.py ${WORKING_DIR_OPTION}
+)
+
 add_test(
     NAME test_roofline_calc_ai_analyze
     COMMAND
@@ -613,6 +622,18 @@ add_test(
 )
 
 # -----------------------------------
+# SoC base counter allocation tests
+# -----------------------------------
+
+add_test(
+    NAME test_soc_base
+    COMMAND
+        ${PYTHON_TEST_COMMAND} -m pytest ${STANDALONEBINARY_TEST_OPTION}
+        --junitxml=tests/test_soc_base.xml ${COV_OPTION} tests/test_soc_base.py
+        ${WORKING_DIR_OPTION}
+)
+
+# -----------------------------------
 # Generate coverage tests
 # -----------------------------------
 
@@ -635,6 +656,7 @@ if(${ENABLE_COVERAGE})
         test_num_xcds_spec_class
         test_num_xcds_cli_output
         test_utils
+        test_mem_chart_gfx11
         test_roofline_calc_ai_analyze
         test_data_imputation
         test_autogen_config

--- a/projects/rocprofiler-compute/pyproject.toml
+++ b/projects/rocprofiler-compute/pyproject.toml
@@ -20,7 +20,8 @@ extend-exclude = [
     ".github",
     ".misc",
     "external",
-    "build-rocprof_compute"
+    "build-rocprof_compute",
+    "src/vendored",
 ]
 
 [tool.ruff.lint]

--- a/projects/rocprofiler-compute/sample/rocflop.cpp
+++ b/projects/rocprofiler-compute/sample/rocflop.cpp
@@ -51,8 +51,8 @@ template<typename T> __global__ void fma_throughput(vec4<T>* buffer, int count)
     ptr[tid] = value0 + value1 + value2 + value3;
 }
 
-// MFMA instructions are only available on gfx908 and later (not supported on gfx906)
-#if !defined(__gfx906__)
+// MFMA instructions are available on selected CDNA targets, but not on gfx1151.
+#if !defined(__gfx906__) && !defined(__gfx1151__)
 __global__ void matmul_fp16_throughput(vec4<float16>* inputs, vec4<float>* outputs, int count)
 {
     int grid_size = gridDim.x * blockDim.x;
@@ -110,10 +110,11 @@ __global__ void matmul_fp32_throughput(float* inputs, vec4<float>* outputs, int 
 
     outputs[tid] = accum0 + accum1 + accum2 + accum3;
 }
-#endif // !defined(__gfx906__)
+#endif // !defined(__gfx906__) && !defined(__gfx1151__)
 
-// SMFMAC (Sparse MFMA) instructions are only available on gfx940 and later (not on gfx906, gfx908, or gfx90a)
-#if !defined(__gfx906__) && !defined(__gfx908__) && !defined(__gfx90a__)
+// SMFMAC (Sparse MFMA) instructions are only available on selected CDNA targets,
+// and are not available on gfx1151.
+#if !defined(__gfx906__) && !defined(__gfx908__) && !defined(__gfx90a__) && !defined(__gfx1151__)
 __global__ void sparse_matmul_fp16_throughput(vec4<float16>* input0, vec8<float16>* input1, vec4<float>* outputs, int count)
 {
     int grid_size = gridDim.x * blockDim.x;
@@ -126,17 +127,17 @@ __global__ void sparse_matmul_fp16_throughput(vec4<float16>* input0, vec8<float1
     vec4<float16> x1 = x_ptr[1 * grid_size + tid];
     vec4<float16> x2 = x_ptr[2 * grid_size + tid];
     vec4<float16> x3 = x_ptr[3 * grid_size + tid];
-    
+
     vec8<float16> y0 = y_ptr[0 * grid_size + tid];
     vec8<float16> y1 = y_ptr[1 * grid_size + tid];
     vec8<float16> y2 = y_ptr[2 * grid_size + tid];
     vec8<float16> y3 = y_ptr[3 * grid_size + tid];
-    
+
     vec4<float> accum0;
     vec4<float> accum1;
     vec4<float> accum2;
     vec4<float> accum3;
-   
+
     for(int i = 0; i < count; i++) {
         for(int j = 0; j < 64; j++) {
             // 4 SMFMAC ops
@@ -149,7 +150,7 @@ __global__ void sparse_matmul_fp16_throughput(vec4<float16>* input0, vec8<float1
 
     outputs[tid] = accum0 + accum1 + accum2 + accum3;
 }
-#endif // !defined(__gfx906__) && !defined(__gfx908__) && !defined(__gfx90a__)
+#endif // !defined(__gfx906__) && !defined(__gfx908__) && !defined(__gfx90a__) && !defined(__gfx1151__)
 
 int g_current_device = -1;
 
@@ -179,7 +180,7 @@ GCNArch get_gcn_arch(int device)
     // Example: gfx908:sramecc+:xnack-
     std::string arch_full(props.gcnArchName);
 
-    // Extract number e.g. "908" 
+    // Extract number e.g. "908"
     std::string gfx_str = arch_full.substr(3, arch_full.find_first_of(':'));
 
     int gfx_num = std::stoi(gfx_str, nullptr, 16);
@@ -245,13 +246,13 @@ template<typename T> double fma_throughput_test(int device, int count, int runs 
 
     hipDeviceProp_t props;
     HIP_CALL(hipGetDeviceProperties(&props, device));
-    
+
     int blocks = props.multiProcessorCount * 512;
     int threads_per_block = 64;
     int total_threads = blocks * threads_per_block;
 
     HIP_CALL(hipMalloc(&buffer, sizeof(vec4<T>) * total_threads * 4));
-    
+
     HIPTimer t;
     t.start();
     for(int i = 0; i < runs; i++) {
@@ -269,7 +270,7 @@ template<typename T> double fma_throughput_test(int device, int count, int runs 
     return flops;
 }
 
-#if !defined(__gfx906__)
+#if !defined(__gfx906__) && !defined(__gfx1151__)
 template<typename matT, typename accumT> double matmul_throughput_test(int device, int count, int runs = 1)
 {
     const int wave_size = 64;
@@ -288,7 +289,7 @@ template<typename matT, typename accumT> double matmul_throughput_test(int devic
     } else {
         assert(false);
     }
-    
+
     int ops_per_matmul = k * m * n * 2;
 
     void* buffer = nullptr;
@@ -325,9 +326,9 @@ template<typename matT, typename accumT> double matmul_throughput_test(int devic
 
     return flops;
 }
-#endif // !defined(__gfx906__)
+#endif // !defined(__gfx906__) && !defined(__gfx1151__)
 
-#if !defined(__gfx906__) && !defined(__gfx908__) && !defined(__gfx90a__)
+#if !defined(__gfx906__) && !defined(__gfx908__) && !defined(__gfx90a__) && !defined(__gfx1151__)
 template<typename matT, typename accumT> double sparse_matmul_throughput_test(int device, int count, int runs = 1)
 {
     const int wave_size = 64;
@@ -381,7 +382,7 @@ template<typename matT, typename accumT> double sparse_matmul_throughput_test(in
 
     return flops;
 }
-#endif // !defined(__gfx906__) && !defined(__gfx908__) && !defined(__gfx90a__)
+#endif // !defined(__gfx906__) && !defined(__gfx908__) && !defined(__gfx90a__) && !defined(__gfx1151__)
 
 struct Result {
     int device = -1;
@@ -457,10 +458,10 @@ Result run_tests(int device, int runs, uint32_t mask)
         res.valu_int32 = fma_throughput_test<int>(device, 4096, runs);
     }
 
-#if !defined(__gfx906__)
+#if !defined(__gfx906__) && !defined(__gfx1151__)
     // MFMA available on gfx908+ (excludes gfx906 with rev=6)
     bool has_mfma = arch.major == 0x9 && (arch.minor >= 0x4 || (arch.minor == 0 && arch.rev >= 8));
-    
+
     if(mask & MATRIX_FP16) {
         if(has_mfma) {
             res.mfma_fp16 = matmul_throughput_test<float16, float>(device, 4096, runs);
@@ -468,7 +469,7 @@ Result run_tests(int device, int runs, uint32_t mask)
             res.mfma_fp16 = 0;
         }
     }
-    
+
     if(mask & MATRIX_FP32) {
         if(has_mfma) {
             res.mfma_fp32 = matmul_throughput_test<float, float>(device, 4096, runs);
@@ -477,7 +478,7 @@ Result run_tests(int device, int runs, uint32_t mask)
         }
     }
 #else
-    // MFMA not available when compiling for gfx906
+    // MFMA not available when compiling for gfx906 or gfx1151
     if(mask & MATRIX_FP16) {
         res.mfma_fp16 = 0;
     }
@@ -486,7 +487,7 @@ Result run_tests(int device, int runs, uint32_t mask)
     }
 #endif
 
-#if !defined(__gfx906__) && !defined(__gfx908__) && !defined(__gfx90a__)
+#if !defined(__gfx906__) && !defined(__gfx908__) && !defined(__gfx90a__) && !defined(__gfx1151__)
     if(mask & SMATRIX_FP16) {
         // SMFMAC only available on gfx940 (MI300) and later, not on gfx906, gfx908, or gfx90a
         if(arch.major == 0x9 && arch.minor >= 0x4) {
@@ -496,7 +497,7 @@ Result run_tests(int device, int runs, uint32_t mask)
         }
     }
 #else
-    // SMFMAC not available when compiling for gfx906, gfx908, or gfx90a
+    // SMFMAC not available when compiling for gfx906, gfx908, gfx90a, or gfx1151
     if(mask & SMATRIX_FP16) {
         res.smfmac_fp16 = 0;
     }
@@ -579,7 +580,7 @@ void run(std::vector<int>& devices, int runs, uint32_t mask)
     // Start a new process for each GPU
     for(auto d : devices) {
         pid_t pid = fork_process(d, runs, mask, fd[1]);
-        
+
         pids.push_back(pid);
     }
 
@@ -640,7 +641,7 @@ void usage()
 {
     std::cout << "--device  ID          Use device with the given numerical ID" << std::endl;
     std::cout << "--devices IDS | ALL   Comma-separated list of device Ids (e.g., 1,2,3)" << std::endl;
-    std::cout << "                      ALL for all devices" << std::endl;                                  
+    std::cout << "                      ALL for all devices" << std::endl;
     std::cout << "--runs    RUNS        Number of times each kernel is dispatched" << std::endl;
 
     std::cout << "--fp16                Run FP16 (VALU) test" << std::endl;
@@ -685,7 +686,7 @@ int main(int argc, char** argv)
             return 0;
         } else if(arg == "--device") {
             devices.push_back(atoi(argv[i + 1]));
-            // Skip next 
+            // Skip next
             i++;
         } else if(arg == "--devices") {
             // Parse comma-separated string of numbers
@@ -700,7 +701,7 @@ int main(int argc, char** argv)
                     devices.push_back(std::stoi(r));
                 }
             }
-            // Skip next 
+            // Skip next
             i++;
         } else if(arg == "--runs") {
             runs = atoi(argv[i + 1]);
@@ -757,5 +758,3 @@ int main(int argc, char** argv)
 
     return 0;
 }
-
-

--- a/projects/rocprofiler-compute/src/rocprof_compute_base.py
+++ b/projects/rocprofiler-compute/src/rocprof_compute_base.py
@@ -23,7 +23,10 @@ from utils.logger import (
     setup_logging_priority,
 )
 from utils.mi_gpu_spec import mi_gpu_specs
-from utils.specs import MachineSpecs, generate_machine_specs
+from utils.specs import (
+    MachineSpecs,
+    generate_machine_specs,
+)
 from utils.utils_common import (
     build_metric_list,
     detect_rocprof,
@@ -515,6 +518,7 @@ class RocProfCompute:
         setup_file_handler(self.__args.loglevel, self.__args.path)
 
         profiler.pre_processing()
+
         console_debug('starting "run_profiling" and about to start rocprof\'s workload')
 
         time_start_prof = time.time()

--- a/projects/rocprofiler-compute/src/rocprof_compute_soc/analysis_configs/gfx1151/0000_Top_Stats.yaml
+++ b/projects/rocprofiler-compute/src/rocprof_compute_soc/analysis_configs/gfx1151/0000_Top_Stats.yaml
@@ -1,0 +1,15 @@
+# RDNA3.5 (gfx1151) - RDNA3.5 Architecture
+# Top-level statistics for kernel performance analysis
+Panel Config:
+  id: 0
+  title: Top Stats
+  data source:
+  - raw_csv_table:
+      id: 1
+      title: Top Kernels
+      source: pmc_kernel_top.csv
+  - raw_csv_table:
+      id: 2
+      title: Dispatch List
+      source: pmc_dispatch_info.csv
+  metrics_description: {}

--- a/projects/rocprofiler-compute/src/rocprof_compute_soc/analysis_configs/gfx1151/0100_System_Info.yaml
+++ b/projects/rocprofiler-compute/src/rocprof_compute_soc/analysis_configs/gfx1151/0100_System_Info.yaml
@@ -1,0 +1,14 @@
+# =============================================================================
+# RDNA3.5 (gfx1151) - RDNA3.5 Architecture System Information
+# =============================================================================
+# Provides system-level information about the GPU and kernel execution
+
+Panel Config:
+  id: 100
+  title: System Info
+  data source:
+  - raw_csv_table:
+      id: 101
+      title: System Info
+      source: sysinfo.csv
+  metrics_description: {}

--- a/projects/rocprofiler-compute/src/rocprof_compute_soc/analysis_configs/gfx1151/0200_System_Speed_Of_Light.yaml
+++ b/projects/rocprofiler-compute/src/rocprof_compute_soc/analysis_configs/gfx1151/0200_System_Speed_Of_Light.yaml
@@ -1,0 +1,211 @@
+# =============================================================================
+# RDNA3.5 (gfx1151) — System Speed-of-Light
+# Layout aligned with gfx950/0200_system_speed_of_light.yaml (throughput first,
+# then core/memory, then cache hierarchy). RDNA 3.5: FLOP rows use SQ_INSTS_VALU* (generic VALU
+# issue); WMMA is a separate ISA path and is not split out here.
+#
+# Public RDNA 3.5 context: dual-CU Work Group Processors (WGPs) and dual-issue VALU
+# peak is ~2× FP32 in public spec summaries; this panel uses a per-CU theoretical
+# model: 128 FP32 ops/CU/cycle and 256 FP16 ops/CU/cycle (wave64) for GFLOP/s peaks.
+#
+# $cu_per_gpu = total Compute Unit count from sysinfo (NOT WGP count). On RDNA 3.5,
+# one WGP contains two CUs — CU count ≈ 2 × WGP count. Peaks scale with CUs.
+# $max_sclk = shader/engine clock in MHz (rocprofiler system specs).
+#
+# TCP / GL1C / GL2C / SQC bandwidth peaks: heuristic ceilings (assumed B/cycle ×
+# instance count × clock); not itemized in public RDNA 3.5 tables — % of peak is
+# indicative only.
+#
+# Cache: TCP (L0) -> GL1C (L1) -> GL2C (L2). L2–fabric (EA) BW; peak N/A (no sysinfo BW).
+# Memory hierarchy reference: gfx1151/0300_Memory_Chart.yaml.
+# =============================================================================
+
+Panel Config:
+  id: 200
+  title: System Speed-of-Light
+  data source:
+  - metric_table:
+      id: 201
+      title: "System Speed-of-Light"
+      header:
+        metric: Metric
+        value: Avg
+        unit: Unit
+        peak: Peak
+        pop: Pct of Peak
+      metric:
+        # --- Throughput (gfx950-style: rates first) ---
+        VALU FLOPs (FP16):
+          value: AVG(((SQ_INSTS_VALU_sum * 64) / ((End_Timestamp - Start_Timestamp) / 1e9)) / 1e9)
+          unit: GFLOP/s
+          peak: ((($max_sclk * $cu_per_gpu) * 256) / 1000)
+          pop: ((100 * AVG(((SQ_INSTS_VALU_sum * 64) / ((End_Timestamp - Start_Timestamp) / 1e9)) / 1e9)) / ((($max_sclk * $cu_per_gpu) * 256) / 1000))
+        VALU FLOPs (FP32):
+          value: AVG(((SQ_INSTS_VALU_sum * 64) / ((End_Timestamp - Start_Timestamp) / 1e9)) / 1e9)
+          unit: GFLOP/s
+          peak: ((($max_sclk * $cu_per_gpu) * 128) / 1000)
+          pop: ((100 * AVG(((SQ_INSTS_VALU_sum * 64) / ((End_Timestamp - Start_Timestamp) / 1e9)) / 1e9)) / ((($max_sclk * $cu_per_gpu) * 128) / 1000))
+        IPC:
+          value: AVG(((SQ_INSTS_ALL_sum - SQ_INSTS_INTERNAL_sum) / SQ_BUSY_CYCLES_sum) if (SQ_BUSY_CYCLES_sum != 0) else None)
+          unit: Instr/cycle
+          peak: 5
+          pop: ((100 * AVG((SQ_INSTS_ALL_sum / SQ_BUSY_CYCLES_sum) if (SQ_BUSY_CYCLES_sum != 0) else None)) / 5)
+        Wavefront Occupancy:
+          value: AVG((SQ_WAVE_CYCLES_sum / SQ_BUSY_CYCLES_avr) if (SQ_BUSY_CYCLES_avr != 0) else None)
+          unit: Wavefronts
+          peak: ($max_waves_per_cu * $cu_per_gpu)
+          pop: ((100 * AVG((SQ_WAVE_CYCLES_sum / SQ_BUSY_CYCLES_avr) if (SQ_BUSY_CYCLES_avr != 0) else None))
+            / (($max_waves_per_cu * $cu_per_gpu)))
+        # --- L2 / fabric (EA) ---
+        L2 Cache Hit Rate:
+          value: AVG((100 * GL2C_HIT_sum / (GL2C_HIT_sum + GL2C_MISS_sum)) if ((GL2C_HIT_sum + GL2C_MISS_sum) != 0) else None)
+          unit: Percent
+          peak: 100
+          pop: AVG((100 * GL2C_HIT_sum / (GL2C_HIT_sum + GL2C_MISS_sum)) if ((GL2C_HIT_sum + GL2C_MISS_sum) != 0) else None)
+        L2-Fabric Read BW:
+          value: AVG(((GL2C_EA_RDREQ_32B_sum * 32 + GL2C_EA_RDREQ_64B_sum * 64
+            + GL2C_EA_RDREQ_96B_sum * 96 + GL2C_EA_RDREQ_128B_sum * 128)
+            / ((End_Timestamp - Start_Timestamp) / 1e9)))
+          unit: Bytes/s
+          peak: None
+          pop: None
+        L2-Fabric Write BW:
+          value: AVG((((GL2C_MC_WRREQ_sum - GL2C_EA_WRREQ_64B_sum) * 32 + GL2C_EA_WRREQ_64B_sum * 64)
+            / ((End_Timestamp - Start_Timestamp) / 1e9)))
+          unit: Bytes/s
+          peak: None
+          pop: None
+        # --- LDS ---
+        LDS Bank Conflicts:
+          value: AVG(SQC_LDS_BANK_CONFLICT)
+          unit: Conflicts
+          peak: None
+          pop: None
+        Wave Dependency Wait:
+          value: AVG(((100 * SQ_WAIT_ANY / SQ_WAVE_CYCLES) if (SQ_WAVE_CYCLES != 0) else 0))
+          unit: Percent
+          peak: 100
+          pop: AVG(((100 * SQ_WAIT_ANY / SQ_WAVE_CYCLES) if (SQ_WAVE_CYCLES != 0) else 0))
+        Wave Issue Wait:
+          value: AVG(((100 * SQ_WAIT_INST_ANY / SQ_WAVE_CYCLES) if (SQ_WAVE_CYCLES != 0) else 0))
+          unit: Percent
+          peak: 100
+          pop: AVG(((100 * SQ_WAIT_INST_ANY / SQ_WAVE_CYCLES) if (SQ_WAVE_CYCLES != 0) else 0))
+        # --- Cache hierarchy: TCP (L0) -> GL1C (L1) -> GL2C client / SQC ---
+        # BW formulas and counters match 0300_Memory_Chart.yaml; peak/pop N/A (chart has no ceilings).
+        TCP Cache Hit Rate:
+          value: AVG((100 * (TCP_REQ_sum - TCP_REQ_MISS_sum) / TCP_REQ_sum) if (TCP_REQ_sum != 0) else None)
+          unit: Percent
+          peak: 100
+          pop: AVG((100 * (TCP_REQ_sum - TCP_REQ_MISS_sum) / TCP_REQ_sum) if (TCP_REQ_sum != 0) else None)
+        TCP Cache BW:
+          value: AVG((TCP_REQ_sum * 64) / ((End_Timestamp - Start_Timestamp) / 1e9))
+          unit: Bytes/s
+          peak: None
+          pop: None
+        GL1C Hit Rate:
+          value: AVG((100 * (GL1C_REQ_sum - GL1C_REQ_MISS_sum) / GL1C_REQ_sum) if (GL1C_REQ_sum != 0) else None)
+          unit: Percent
+          peak: 100
+          pop: AVG((100 * (GL1C_REQ_sum - GL1C_REQ_MISS_sum) / GL1C_REQ_sum) if (GL1C_REQ_sum != 0) else None)
+        GL1C Read BW:
+          # Same bins as Memory Chart table 307 (GL1C–GL2 read bandwidth).
+          value: AVG((GL1C_GL2_REQ_READ_32B_sum*32 + GL1C_GL2_REQ_READ_64B_sum*64 + GL1C_GL2_REQ_READ_128B_sum*128) / ((End_Timestamp - Start_Timestamp) / 1e9))
+          unit: Bytes/s
+          peak: None
+          pop: None
+        GL2C Cache BW:
+          value: AVG((GL2C_READ_32_REQ_sum*32 + GL2C_READ_64_REQ_sum*64 + GL2C_READ_128_REQ_sum*128 + GL2C_COMPRESSED_READ_96_REQ_sum*96) / ((End_Timestamp - Start_Timestamp) / 1e9))
+          unit: Bytes/s
+          peak: None
+          pop: None
+        Scalar Data Cache Hit Rate:
+          value: AVG((100 * SQC_DCACHE_HITS_sum / (SQC_DCACHE_HITS_sum + SQC_DCACHE_MISSES_sum)) if ((SQC_DCACHE_HITS_sum + SQC_DCACHE_MISSES_sum) != 0) else None)
+          unit: Percent
+          peak: 100
+          pop: AVG((100 * SQC_DCACHE_HITS_sum / (SQC_DCACHE_HITS_sum + SQC_DCACHE_MISSES_sum)) if ((SQC_DCACHE_HITS_sum + SQC_DCACHE_MISSES_sum) != 0) else None)
+        Scalar Data Cache BW:
+          # Same as Memory Chart table 302 (Icache-GL1 uses sqc_tc_inst; Dcache uses TC data read).
+          value: AVG((SQC_TC_DATA_READ_REQ_sum * 128) / ((End_Timestamp - Start_Timestamp) / 1e9))
+          unit: Bytes/s
+          peak: None
+          pop: None
+        Instruction Cache Hit Rate:
+          value: AVG((100 * SQC_ICACHE_HITS_sum / (SQC_ICACHE_HITS_sum + SQC_ICACHE_MISSES_sum)) if ((SQC_ICACHE_HITS_sum + SQC_ICACHE_MISSES_sum) != 0) else None)
+          unit: Percent
+          peak: 100
+          pop: AVG((100 * SQC_ICACHE_HITS_sum / (SQC_ICACHE_HITS_sum + SQC_ICACHE_MISSES_sum)) if ((SQC_ICACHE_HITS_sum + SQC_ICACHE_MISSES_sum) != 0) else None)
+        Instruction Cache BW:
+          value: AVG((SQC_TC_INST_REQ_sum * 128) / ((End_Timestamp - Start_Timestamp) / 1e9))
+          unit: Bytes/s
+          peak: None
+          pop: None
+
+  metrics_description:
+    VALU FLOPs (FP16): |-
+      Sixteen-bit VALU throughput (GFLOP/s) from SQ_INSTS_VALU × 64 / kernel time.
+      Theoretical peak uses packed FP16 at 2× the FP32 per-CU rate:
+      max_sclk (MHz) × $cu_per_gpu × 256 / 1000 GFLOP/s.
+      Public RDNA 3.5 summaries cite dual-CU WGPs, dual-issue
+      VALU, and chip FP16 peak ~2× FP32; this formula is the same 2× relationship at
+      the per-CU model used here. $cu_per_gpu is total CU count, not WGP (1 WGP = 2 CUs on RDNA 3.5).
+    VALU FLOPs (FP32): |-
+      Thirty-two-bit VALU throughput (GFLOP/s) from SQ_INSTS_VALU × 64 / kernel time.
+      Theoretical peak: max_sclk (MHz) × $cu_per_gpu × 128 / 1000 GFLOP/s
+      (wave64 / dual-issue VALU class used for Navi3-style parts).
+      $cu_per_gpu is the total number of Compute Units from system info, not WGP count
+      (on RDNA 3.5, one WGP pairs two CUs).
+    IPC: |-
+      Instructions Per Cycle — ratio of instructions executed over busy cycles.
+      Calculated as (Total Instructions - Internal Instructions) / Busy Cycles.
+      Higher IPC indicates better instruction throughput.
+    Wavefront Occupancy: |-
+      Average wavefront occupancy proxy: SQ_WAVE_CYCLES_sum / SQ_BUSY_CYCLES_avr per sample,
+      where SQ_BUSY_CYCLES_avr is the mean of per–shader-engine SQ_BUSY_CYCLES (active-wave
+      cycles per SE). Peak is $max_waves_per_cu × $cu_per_gpu (theoretical in-flight cap).
+      Pct of peak scales the average against that ceiling.
+    L2 Cache Hit Rate: |-
+      GL2C last-level cache hit rate (same as Memory Chart / GL2C panel).
+      Formula: 100 * GL2C_HIT_sum / (GL2C_HIT_sum + GL2C_MISS_sum) when the denominator is non-zero.
+    L2-Fabric Read BW: |-
+      GL2C/EA read bandwidth from sized request counters (gl2c_perf_sel_ea_rdreq_32b/64B/96B/128B):
+      32·GL2C_EA_RDREQ_32B_sum + 64·GL2C_EA_RDREQ_64B_sum + 96·GL2C_EA_RDREQ_96B_sum + 128·GL2C_EA_RDREQ_128B_sum,
+      divided by kernel wall time. Sums over GL2C instances. Peak / % of peak are N/A (no sysinfo memory BW).
+    L2-Fabric Write BW: |-
+      GL2C/EA write bandwidth: GL2C_MC_WRREQ_sum is the EA write transaction count (32 B or 64 B per txn; the
+      spec names this path MC_WRREQ). Bandwidth = 32·(GL2C_MC_WRREQ_sum − GL2C_EA_WRREQ_64B_sum) + 64·GL2C_EA_WRREQ_64B_sum, over time.
+      Peak / % of peak are N/A (no sysinfo memory BW).
+    LDS Bank Conflicts: |-
+      Number of LDS bank conflicts. Peak / % of Peak are N/A for raw counts.
+    Wave Dependency Wait: |-
+      Percent of wave lifetime spent waiting for data dependencies (e.g. VMEM/LDS results).
+    Wave Issue Wait: |-
+      Percent of wave lifetime spent waiting for any instruction to be ready to issue.
+    TCP Cache Hit Rate: |-
+      Texture Cache Per-pipe (TCP) hit rate. TCP is the L0 vector cache in RDNA3.5.
+      Same as Memory Chart TCP Hit Rate: 100 * (TCP_REQ_sum - TCP_REQ_MISS_sum) / TCP_REQ_sum.
+    TCP Cache BW: |-
+      Same as Memory Chart “TCP Request Bandwidth” (table 303): TCP_REQ_sum × 64 B / kernel wall time.
+      Peak / % of peak are N/A (same as Memory Chart — no theoretical ceiling row).
+    GL1C Hit Rate: |-
+      GL1 Cache hit rate (same as Memory Chart / GL1C panel).
+      Formula: 100 * (GL1C_REQ_sum - GL1C_REQ_MISS_sum) / GL1C_REQ_sum when GL1C_REQ_sum != 0.
+    GL1C Read BW: |-
+      Same as Memory Chart table 307 “GL1C-GL2 Read Bandwidth”:
+      32·GL1C_GL2_REQ_READ_32B_sum + 64·GL1C_GL2_REQ_READ_64B_sum + 128·GL1C_GL2_REQ_READ_128B_sum, over time.
+      Peak / % of peak are N/A.
+    GL2C Cache BW: |-
+      Same as Memory Chart table 308 “GL2C Read Bandwidth”: sized client read bins plus 96 B compressed reads, over time.
+      Peak / % of peak are N/A.
+    Scalar Data Cache Hit Rate: |-
+      Same as Memory Chart Dcache Hit Rate: 100 * SQC_DCACHE_HITS_sum /
+      (SQC_DCACHE_HITS_sum + SQC_DCACHE_MISSES_sum) when the denominator is non-zero.
+    Scalar Data Cache BW: |-
+      Same as Memory Chart table 302 “Dcache-GL1 Read Bandwidth”: SQC_TC_DATA_READ_REQ_sum × 128 B / kernel time.
+      Peak / % of peak are N/A.
+    Instruction Cache Hit Rate: |-
+      Same as Memory Chart Icache Hit Rate: 100 * SQC_ICACHE_HITS_sum /
+      (SQC_ICACHE_HITS_sum + SQC_ICACHE_MISSES_sum) when the denominator is non-zero.
+    Instruction Cache BW: |-
+      Same as Memory Chart table 301 “ICache-GL1 Read Bandwidth”: SQC_TC_INST_REQ_sum × 128 B / kernel time.
+      Peak / % of peak are N/A.

--- a/projects/rocprofiler-compute/src/rocprof_compute_soc/analysis_configs/gfx1151/0300_Memory_Chart.yaml
+++ b/projects/rocprofiler-compute/src/rocprof_compute_soc/analysis_configs/gfx1151/0300_Memory_Chart.yaml
@@ -1,0 +1,410 @@
+# =============================================================================
+# RDNA3.5 (gfx1151) - RDNA3.5 Memory Hierarchy Chart Metrics
+# =============================================================================
+#
+# This panel provides detailed memory hierarchy metrics for visualization,
+# organized by cache level:
+#   - Instruction Cache (SQC)
+#   - Scalar Data Cache (SQC)
+#   - TCP Cache (L0 Vector Cache)
+#   - LDS (Local Data Share)
+#   - GL1C Cache (L1)
+#   - GL2C Cache (L2)
+#   - Graphics Core Efficiency Arbiter (GCEA) to system memory (DDR5/LPDDR5 for APU)
+# =============================================================================
+
+Panel Config:
+  id: 300
+  title: RDNA3.5 Memory Chart
+  description: |-
+    Detailed memory hierarchy metrics for RDNA3.5, showing request counts,
+    bandwidth, hit rates, and utilization at each cache level.
+    Memory hierarchy: LDS/TCP (L0) -> GL1C (L1) -> GL2C (L2) -> System Memory via GCEA
+    (Graphics Core Efficiency Arbiter).
+
+    Use this panel as the reference for **where** bandwidth is measured: GL2C Read/Write
+    Bandwidth use **client-side** GL2 counters; GCEA (Graphics Core Efficiency Arbiter)
+    tables use **DRAM interface** counters.
+    System Speed-of-Light lists separate **L2→fabric (EA)** and **memory controller** rates;
+    those are kernel-summary views and are not the same rows as GL2C client read BW here.
+
+  data source:
+
+  # =========================================================================
+  # Table 301: Instruction Cache (SQC)
+  # =========================================================================
+  - metric_table:
+      id: 301
+      title: "Instruction Cache"
+      cli_style: mem_chart
+      tui_style: mem_chart
+      comparable: false
+      header:
+        metric: Metric
+        value: Value
+        unit: Unit
+      metric:
+        ICache Requests:
+          value: AVG(SQC_ICACHE_REQ_sum / $denom)
+          unit: (Requests + $normUnit)
+        ICache Utilization:
+          value: AVG((100 * SQC_ICACHE_BUSY_CYCLES_sum / SQ_BUSY_CYCLES_sum) if (SQ_BUSY_CYCLES_sum != 0) else None)
+          unit: Percent
+        ICache Hit Rate:
+          value: AVG((100 * SQC_ICACHE_HITS_sum / (SQC_ICACHE_HITS_sum + SQC_ICACHE_MISSES_sum)) if ((SQC_ICACHE_HITS_sum + SQC_ICACHE_MISSES_sum) != 0) else None)
+          unit: Percent
+        ICache Miss Rate:
+          value: AVG((100 * SQC_ICACHE_MISSES_sum / (SQC_ICACHE_HITS_sum + SQC_ICACHE_MISSES_sum)) if ((SQC_ICACHE_HITS_sum + SQC_ICACHE_MISSES_sum) != 0) else None)
+          unit: Percent
+        ICache Request Stall Rate:
+          value: AVG((100 * SQC_ICACHE_INPUT_VALID_READYB_sum / SQ_BUSY_CYCLES_sum) if (SQ_BUSY_CYCLES_sum != 0) else None)
+          unit: Percent
+        ICache-GL1 Read Bandwidth:
+          value: AVG((SQC_TC_INST_REQ_sum * 128) / ((End_Timestamp - Start_Timestamp) / 1e9))
+          unit: Bytes/s
+
+  # =========================================================================
+  # Table 302: Scalar Data Cache (SQC)
+  # =========================================================================
+  - metric_table:
+      id: 302
+      title: "Scalar Data Cache"
+      cli_style: mem_chart
+      tui_style: mem_chart
+      comparable: false
+      header:
+        metric: Metric
+        value: Value
+        unit: Unit
+      metric:
+        Dcache Requests:
+          value: AVG(SQC_DCACHE_REQ_sum / $denom)
+          unit: (Requests + $normUnit)
+        Dcache Utilization:
+          value: AVG((100 * SQC_DCACHE_BUSY_CYCLES_sum / SQ_BUSY_CYCLES_sum) if (SQ_BUSY_CYCLES_sum != 0) else None)
+          unit: Percent
+        Dcache Hit Rate:
+          value: AVG((100 * SQC_DCACHE_HITS_sum / (SQC_DCACHE_HITS_sum + SQC_DCACHE_MISSES_sum)) if ((SQC_DCACHE_HITS_sum + SQC_DCACHE_MISSES_sum) != 0) else None)
+          unit: Percent
+        Dcache Request Stall Rate:
+          value: AVG((100 * SQC_DCACHE_INPUT_VALID_READYB_sum / SQ_BUSY_CYCLES_sum) if (SQ_BUSY_CYCLES_sum != 0) else None)
+          unit: Percent
+        Dcache-GL1 Read Bandwidth:
+          value: AVG((SQC_TC_DATA_READ_REQ_sum * 128) / ((End_Timestamp - Start_Timestamp) / 1e9))
+          unit: Bytes/s
+
+  # =========================================================================
+  # Table 303: TCP Cache (L0 Vector Cache)
+  # =========================================================================
+  - metric_table:
+      id: 303
+      title: "TCP Cache (Vector L0)"
+      cli_style: mem_chart
+      tui_style: mem_chart
+      comparable: false
+      header:
+        metric: Metric
+        value: Value
+        unit: Unit
+      metric:
+        TCP Total Requests:
+          value: AVG(TCP_REQ_sum / $denom)
+          unit: (Requests + $normUnit)
+        TCP Read Requests:
+          value: AVG(TCP_REQ_READ_sum / $denom)
+          unit: (Requests + $normUnit)
+        TCP Write Requests:
+          value: AVG(TCP_REQ_WRITE_sum / $denom)
+          unit: (Requests + $normUnit)
+        # Counter not available: tcp_req_atomic_sum
+        TCP Miss Requests:
+          value: AVG(TCP_REQ_MISS_sum / $denom)
+          unit: (Requests + $normUnit)
+        TCP Hit Rate:
+          value: AVG((100 * (TCP_REQ_sum - TCP_REQ_MISS_sum) / TCP_REQ_sum) if (TCP_REQ_sum != 0) else None)
+          unit: Percent
+        TCP Request Bandwidth:
+          value: AVG((TCP_REQ_sum * 64) / ((End_Timestamp - Start_Timestamp) / 1e9))
+          unit: Bytes/s
+
+  # =========================================================================
+  # Table 304: LDS (Local Data Share)
+  # =========================================================================
+  - metric_table:
+      id: 304
+      title: "LDS (Local Data Share)"
+      cli_style: mem_chart
+      tui_style: mem_chart
+      comparable: false
+      header:
+        metric: Metric
+        value: Value
+        unit: Unit
+      metric:
+        LDS Instructions:
+          value: AVG(SQ_INSTS_LDS_sum / $denom)
+          unit: (Instructions + $normUnit)
+        # Counters not available: sq_lds_direct_rd, sq_lds_direct_wr
+        LDS Atomic Instructions:
+          value: AVG(SQ_LDS_ATOMIC_RETURN_sum / $denom)
+          unit: (Instructions + $normUnit)
+        LDS Instruction Cycles:
+          value: AVG(SQ_INST_CYCLES_LDS_sum / $denom)
+          unit: (Cycles + $normUnit)
+        LDS Wait Cycles:
+          value: AVG(SQ_WAIT_INST_LDS_sum / $denom)
+          unit: (Cycles + $normUnit)
+        LDS Bank Conflict Rate:
+          value: AVG((100 * SQC_LDS_BANK_CONFLICT_sum / SQC_LDS_IDX_ACTIVE_sum) if (SQC_LDS_IDX_ACTIVE_sum != 0) else None)
+          unit: Percent
+        LDS Estimated Bandwidth:
+          value: AVG(((SQC_LDS_IDX_ACTIVE_sum - SQC_LDS_BANK_CONFLICT_sum) * 4 * 32) / ((End_Timestamp - Start_Timestamp) / 1e9))
+          unit: Bytes/s
+
+  # =========================================================================
+  # Table 305: TCP-GL1 Interface
+  # =========================================================================
+  - metric_table:
+      id: 305
+      title: "TCP-GL1 Interface"
+      cli_style: mem_chart
+      tui_style: mem_chart
+      comparable: false
+      header:
+        metric: Metric
+        value: Value
+        unit: Unit
+      metric:
+        TCP-GL1 Read Requests:
+          value: AVG(TCP_GL1_REQ_READ_sum / $denom)
+          unit: (Requests + $normUnit)
+        TCP-GL1 Write Requests:
+          value: AVG(TCP_GL1_REQ_WRITE_sum / $denom)
+          unit: (Requests + $normUnit)
+        TCP-GL1 Read Bandwidth:
+          value: AVG((TCP_GL1_REQ_READ_sum * 64) / ((End_Timestamp - Start_Timestamp) / 1e9))
+          unit: Bytes/s
+        TCP-GL1 Write Bandwidth:
+          value: AVG((TCP_GL1_REQ_WRITE_sum * 64) / ((End_Timestamp - Start_Timestamp) / 1e9))
+          unit: Bytes/s
+
+  # =========================================================================
+  # Table 306: GL1C Cache (L1)
+  # =========================================================================
+  - metric_table:
+      id: 306
+      title: "GL1C Cache (L1)"
+      cli_style: mem_chart
+      tui_style: mem_chart
+      comparable: false
+      header:
+        metric: Metric
+        value: Value
+        unit: Unit
+      metric:
+        GL1C Utilization:
+          value: AVG((100 * GL1C_BUSY_sum / GL1C_CYCLE_sum) if (GL1C_CYCLE_sum != 0) else None)
+          unit: Percent
+        GL1C Total Requests:
+          value: AVG(GL1C_REQ_sum / $denom)
+          unit: (Requests + $normUnit)
+        GL1C Read Requests:
+          value: AVG(GL1C_REQ_READ_sum / $denom)
+          unit: (Requests + $normUnit)
+        GL1C Write Requests:
+          value: AVG(GL1C_REQ_WRITE_sum / $denom)
+          unit: (Requests + $normUnit)
+        GL1C Miss Requests:
+          value: AVG(GL1C_REQ_MISS_sum / $denom)
+          unit: (Requests + $normUnit)
+        GL1C Hit Rate:
+          value: AVG((100 * (GL1C_REQ_sum - GL1C_REQ_MISS_sum) / GL1C_REQ_sum) if (GL1C_REQ_sum != 0) else None)
+          unit: Percent
+        GL1C Starve Rate:
+          value: AVG((100 * GL1C_STARVE_sum / GL1C_CYCLE_sum) if (GL1C_CYCLE_sum != 0) else None)
+          unit: Percent
+        GL1C Stall GL2 Backpressure:
+          value: AVG((100 * GL1C_STALL_GL2_GL1_sum / GL1C_BUSY_sum) if (GL1C_BUSY_sum != 0) else None)
+          unit: Percent
+
+  # =========================================================================
+  # Table 307: GL1C-GL2 Interface
+  # =========================================================================
+  - metric_table:
+      id: 307
+      title: "GL1C-GL2 Interface"
+      cli_style: mem_chart
+      tui_style: mem_chart
+      comparable: false
+      header:
+        metric: Metric
+        value: Value
+        unit: Unit
+      metric:
+        GL1-GL2 Read Requests:
+          value: AVG(GL1C_GL2_REQ_READ_sum / $denom)
+          unit: (Requests + $normUnit)
+        GL1-GL2 Write Requests:
+          value: AVG(GL1C_GL2_REQ_WRITE_sum / $denom)
+          unit: (Requests + $normUnit)
+        GL1-GL2 Read Bandwidth:
+          value: AVG((GL1C_GL2_REQ_READ_32B_sum*32 + GL1C_GL2_REQ_READ_64B_sum*64 + GL1C_GL2_REQ_READ_128B_sum*128) / ((End_Timestamp - Start_Timestamp) / 1e9))
+          unit: Bytes/s
+        GL1-GL2 Write Bandwidth:
+          value: AVG((GL1C_GL2_REQ_WRITE_32B_sum*32 + GL1C_GL2_REQ_WRITE_64B_sum*64) / ((End_Timestamp - Start_Timestamp) / 1e9))
+          unit: Bytes/s
+        GL1-GL2 Read Latency:
+          value: AVG((GL1C_GL2_REQ_READ_LATENCY_sum / GL1C_GL2_REQ_READ_sum) if (GL1C_GL2_REQ_READ_sum != 0) else None)
+          unit: Cycles
+        GL1-GL2 Write Latency:
+          value: AVG((GL1C_GL2_REQ_WRITE_LATENCY_sum / GL1C_GL2_REQ_WRITE_sum) if (GL1C_GL2_REQ_WRITE_sum != 0) else None)
+          unit: Cycles
+
+  # =========================================================================
+  # Table 308: GL2C Cache (L2)
+  # =========================================================================
+  - metric_table:
+      id: 308
+      title: "GL2C Cache (L2)"
+      cli_style: mem_chart
+      tui_style: mem_chart
+      comparable: false
+      header:
+        metric: Metric
+        value: Value
+        unit: Unit
+      metric:
+        GL2C Utilization:
+          value: AVG((100 * GL2C_BUSY_sum / GL2C_CYCLE_sum) if (GL2C_CYCLE_sum != 0) else None)
+          unit: Percent
+        GL2C Total Requests:
+          value: AVG(GL2C_REQ_sum / $denom)
+          unit: (Requests + $normUnit)
+        GL2C Read Requests:
+          value: AVG(GL2C_READ_sum / $denom)
+          unit: (Requests + $normUnit)
+        GL2C Write Requests:
+          value: AVG(GL2C_WRITE_sum / $denom)
+          unit: (Requests + $normUnit)
+        GL2C Atomic Requests:
+          value: AVG(GL2C_ATOMIC_sum / $denom)
+          unit: (Requests + $normUnit)
+        GL2C Hit Rate:
+          value: AVG((100 * GL2C_HIT_sum / (GL2C_HIT_sum + GL2C_MISS_sum)) if ((GL2C_HIT_sum + GL2C_MISS_sum) != 0) else None)
+          unit: Percent
+        GL2C Read Bandwidth:
+          # 32/64/128 B read bins plus 96 B compressed reads; EA 96 B (GL2C_EA_RDREQ_96B) is fabric-side (see Speed-of-Light).
+          value: AVG((GL2C_READ_32_REQ_sum*32 + GL2C_READ_64_REQ_sum*64 + GL2C_READ_128_REQ_sum*128 + GL2C_COMPRESSED_READ_96_REQ_sum*96) / ((End_Timestamp - Start_Timestamp) / 1e9))
+          unit: Bytes/s
+        GL2C Write Bandwidth:
+          # Note: GL2C write requests can be 32B or 64B (no 128B writes documented).
+          value: AVG((GL2C_WRITE_sum * 64) / ((End_Timestamp - Start_Timestamp) / 1e9))
+          unit: Bytes/s
+
+  # =========================================================================
+  # Table 309: Graphics Core Efficiency Arbiter (GCEA) to system memory (APU)
+  # =========================================================================
+  - metric_table:
+      id: 309
+      title: "Graphics Core Efficiency Arbiter (GCEA) to System Memory"
+      cli_style: mem_chart
+      tui_style: mem_chart
+      comparable: false
+      header:
+        metric: Metric
+        value: Value
+        unit: Unit
+      metric:
+        SARB Utilization:
+          value: AVG((100 * GCEA_SARB_BUSY_sum / GCEA_ALWAYS_COUNT_sum) if (GCEA_ALWAYS_COUNT_sum != 0) else None)
+          unit: Percent
+        SARB Stall Rate:
+          value: AVG((100 * GCEA_SARB_STALLED_sum / GCEA_ALWAYS_COUNT_sum) if (GCEA_ALWAYS_COUNT_sum != 0) else None)
+          unit: Percent
+        DRAM Read Requests:
+          value: AVG(GCEA_RDRAM_REQ_PER_CLIGRP_sum / $denom)
+          unit: (Requests + $normUnit)
+        DRAM Write Requests:
+          value: AVG(GCEA_WDRAM_REQ_PER_CLIGRP_sum / $denom)
+          unit: (Requests + $normUnit)
+        DRAM Read Bandwidth:
+          value: AVG((GCEA_RDRAM_SIZE_REQ_sum * 32) / ((End_Timestamp - Start_Timestamp) / 1e9))
+          unit: Bytes/s
+        DRAM Write Bandwidth:
+          value: AVG((GCEA_WDRAM_SIZE_REQ_sum * 32) / ((End_Timestamp - Start_Timestamp) / 1e9))
+          unit: Bytes/s
+        Read Returns:
+          value: AVG(GCEA_RRET_VLD_sum / $denom)
+          unit: (Count + $normUnit)
+        Write Returns:
+          value: AVG(GCEA_WRET_VLD_sum / $denom)
+          unit: (Count + $normUnit)
+
+  metrics_description:
+    ICache Utilization: |-
+      Definition: Percentage of cycles the instruction cache is busy.
+      Formula: 100 * SQC_ICACHE_BUSY_CYCLES_sum / SQ_BUSY_CYCLES_sum
+
+    ICache Hit Rate: |-
+      Definition: Share of instruction cache accesses that hit, using hit+miss as denominator.
+      Formula: 100 * SQC_ICACHE_HITS_sum / (SQC_ICACHE_HITS_sum + SQC_ICACHE_MISSES_sum)
+      when the denominator is non-zero. HITS/REQ alone can exceed 100% (per-SQ per-bank counters).
+
+    ICache Miss Rate: |-
+      Definition: Share of instruction cache accesses that miss (same denominator as hit rate).
+      Formula: 100 * SQC_ICACHE_MISSES_sum / (SQC_ICACHE_HITS_sum + SQC_ICACHE_MISSES_sum)
+
+    Dcache Utilization: |-
+      Definition: Percentage of cycles the scalar data cache is busy.
+      Formula: 100 * SQC_DCACHE_BUSY_CYCLES_sum / SQ_BUSY_CYCLES_sum
+
+    Dcache Hit Rate: |-
+      Definition: Share of scalar data cache accesses that hit (hit+miss denominator).
+      Formula: 100 * SQC_DCACHE_HITS_sum / (SQC_DCACHE_HITS_sum + SQC_DCACHE_MISSES_sum)
+      when the denominator is non-zero.
+
+    TCP Hit Rate: |-
+      Definition: Percentage of TCP (L0 vector cache) requests that hit in cache.
+      Formula: 100 * (TCP_REQ_sum - TCP_REQ_MISS_sum) / TCP_REQ_sum
+
+    LDS Atomic Instructions: |-
+      Definition: Number of LDS atomic instructions executed.
+      Description: Atomic operations on Local Data Share memory with return values.
+      Formula: SQ_LDS_ATOMIC_RETURN_sum / $denom
+
+    LDS Bank Conflict Rate: |-
+      Definition: Percentage of LDS accesses that resulted in bank conflicts.
+      Description: Bank conflicts occur when multiple work-items access the same LDS bank simultaneously.
+      Formula: 100 * SQC_LDS_BANK_CONFLICT_sum / SQC_LDS_IDX_ACTIVE_sum
+
+    LDS Estimated Bandwidth: |-
+      Definition: Estimated LDS bandwidth based on active index cycles minus bank conflicts.
+      Description: RDNA3.5 has 32 LDS banks per CU, each capable of 4 bytes per cycle.
+      Formula: ((SQC_LDS_IDX_ACTIVE_sum - SQC_LDS_BANK_CONFLICT_sum) * 4 * 32) / time
+
+    GL1C Utilization: |-
+      Definition: Percentage of cycles the GL1C (L1 cache) is busy.
+      Formula: 100 * GL1C_BUSY_sum / GL1C_CYCLE_sum
+
+    GL1C Hit Rate: |-
+      Definition: Percentage of GL1C cache requests that hit.
+      Formula: 100 * (GL1C_REQ_sum - GL1C_REQ_MISS_sum) / GL1C_REQ_sum
+
+    GL2C Hit Rate: |-
+      Definition: Percentage of GL2C (L2 cache) requests that hit.
+      Formula: 100 * GL2C_HIT_sum / (GL2C_HIT_sum + GL2C_MISS_sum)
+
+    SARB Utilization: |-
+      Definition: Percentage of cycles the System Arbiter (SARB) in GCEA (Graphics Core Efficiency Arbiter) was busy.
+      Description: SARB handles arbitration between the GPU and the system memory interface.
+      Formula: 100 * GCEA_SARB_BUSY_sum / GCEA_ALWAYS_COUNT_sum
+
+    DRAM Read Bandwidth: |-
+      Definition: Bandwidth for read requests to system memory (DRAM).
+      Description: RDNA3.5 is an APU using DDR5/LPDDR5 system memory instead of HBM.
+      Formula: GCEA_RDRAM_SIZE_REQ_sum * 32 / time
+
+    DRAM Write Bandwidth: |-
+      Definition: Bandwidth for write requests to system memory (DRAM).
+      Description: RDNA3.5 is an APU using DDR5/LPDDR5 system memory instead of HBM.
+      Formula: GCEA_WDRAM_SIZE_REQ_sum * 32 / time

--- a/projects/rocprofiler-compute/src/rocprof_compute_soc/analysis_configs/gfx1151/0400_roofline.yaml
+++ b/projects/rocprofiler-compute/src/rocprof_compute_soc/analysis_configs/gfx1151/0400_roofline.yaml
@@ -1,0 +1,131 @@
+# =============================================================================
+# RDNA3.5 (gfx1151) - RDNA3.5 Roofline Performance Metrics
+# =============================================================================
+# RDNA 3.5: VALU FLOP roofline from SQ_INSTS_VALU*; WMMA (separate ISA) is not a dedicated row.
+# Cache hierarchy: TCP (L0) -> GL1C (L1) -> GL2C (L2) -> System Memory
+# =============================================================================
+
+Panel Config:
+  id: 400
+  title: Roofline
+  data source:
+  - metric_table:
+      id: 401
+      title: Roofline Performance Rates
+      cli_style: Roofline
+      tui_style: Roofline
+      header:
+        metric: Metric
+        value: Value
+        unit: Unit
+        peak: Peak (Empirical)
+      metric:
+        VALU FLOPs (F16):
+          value: AVG((($wave_size * (SQ_INSTS_VALU_sum)) / ((End_Timestamp - Start_Timestamp) / 1e9)) / 1e9)
+          unit: GFLOP/s
+          peak: $FP16Flops_empirical_peak
+        VALU FLOPs (F32):
+          value: AVG((($wave_size * (SQ_INSTS_VALU_sum)) / ((End_Timestamp - Start_Timestamp) / 1e9)) / 1e9)
+          unit: GFLOP/s
+          peak: $FP32Flops_empirical_peak
+        VALU FLOPs (F64):
+          value: AVG((($wave_size * (SQ_INSTS_VALU_DP_sum)) / ((End_Timestamp - Start_Timestamp) / 1e9)) / 1e9)
+          unit: GFLOP/s
+          peak: $FP64Flops_empirical_peak
+        GL2 Cache Bandwidth:
+          # Note: GL1C-GL2 reads can be 32B, 64B, or 128B. Writes can be 32B or 64B.
+          value: AVG((GL1C_GL2_REQ_READ_32B_sum*32 + GL1C_GL2_REQ_READ_64B_sum*64 + GL1C_GL2_REQ_READ_128B_sum*128 + GL1C_GL2_REQ_WRITE_32B_sum*32 + GL1C_GL2_REQ_WRITE_64B_sum*64) / ((End_Timestamp - Start_Timestamp) / 1e9))
+          unit: Bytes/s
+          peak: ($L2Bw_empirical_peak * 1e9)
+        GL1 Cache Bandwidth:
+          value: AVG((TCP_GL1_REQ_READ_sum * 64 + TCP_GL1_REQ_WRITE_sum * 64) / ((End_Timestamp - Start_Timestamp) / 1e9))
+          unit: Bytes/s
+          peak: ($L1Bw_empirical_peak * 1e9)
+        TCP (L0) Cache Bandwidth:
+          value: AVG((TCP_REQ_sum * 64) / ((End_Timestamp - Start_Timestamp) / 1e9))
+          unit: Bytes/s
+          peak: ($L0Bw_empirical_peak * 1e9)
+        LDS Bandwidth:
+          value: AVG(((SQC_LDS_IDX_ACTIVE_sum - SQC_LDS_BANK_CONFLICT_sum) * 4 * $lds_banks_per_cu) / ((End_Timestamp - Start_Timestamp) / 1e9))
+          unit: Bytes/s
+          peak: ($LDSBw_empirical_peak * 1e9)
+
+  - metric_table:
+      id: 402
+      title: Roofline Plot Points
+      cli_style: Roofline
+      tui_style: Roofline
+      header:
+        metric: Metric
+        value: Value
+        unit: Unit
+      metric:
+        AI GL2:
+          # Note: GL1C-GL2 reads can be 32B, 64B, or 128B. Writes can be 32B or 64B.
+          value: ( SUM($wave_size * SQ_INSTS_VALU_sum) / SUM((GL1C_GL2_REQ_READ_32B_sum*32 + GL1C_GL2_REQ_READ_64B_sum*64 + GL1C_GL2_REQ_READ_128B_sum*128) + (GL1C_GL2_REQ_WRITE_32B_sum*32 + GL1C_GL2_REQ_WRITE_64B_sum*64)) )
+          unit: FLOPs/Byte
+        AI GL1:
+          value: ( SUM($wave_size * SQ_INSTS_VALU_sum) / SUM((TCP_GL1_REQ_READ_sum * 64) + (TCP_GL1_REQ_WRITE_sum * 64)) )
+          unit: FLOPs/Byte
+        AI TCP:
+          value: ( SUM($wave_size * SQ_INSTS_VALU_sum) / SUM(TCP_REQ_sum * 64) )
+          unit: FLOPs/Byte
+        Performance (GFLOPs):
+          value: ( SUM($wave_size * SQ_INSTS_VALU_sum) / (SUM(End_Timestamp - Start_Timestamp) / 1e9) ) / 1e9
+          unit: GFLOP/s
+
+  metrics_description:
+    VALU FLOPs (F16): >-
+      The total 16-bit floating-point operations executed per second on the VALU.
+      Theoretical FP16 throughput is 2× the FP32 FMA peak (packed half on Navi3 / RDNA3-class VALU).
+      This is presented with the value of the peak empirical F16 FLOPs achievable
+      on the specific accelerator.
+    VALU FLOPs (F32): >-
+      The total 32-bit floating-point operations executed per second on the VALU.
+      Navi3 / RDNA3-class CUs sustain up to 128 V_FMA_F32 ops per cycle per CU
+      in wave64 mode; the roofline peak column uses empirically measured F32 throughput.
+      This is presented with the value of the peak empirical F32 FLOPs achievable
+      on the specific accelerator.
+    VALU FLOPs (F64): >-
+      The total 64-bit floating-point operations executed per second on the VALU.
+      FP64 throughput is typically 1/16 or 1/32 of FP32 on RDNA3.5 consumer parts.
+      This is presented with the value of the peak empirical F64 FLOPs achievable
+      on the specific accelerator.
+    GL2 Cache Bandwidth: >-
+      The number of bytes transferred between GL1C and GL2C per unit time.
+      GL2C is the last-level cache in RDNA3.5 before system memory.
+      The peak empirically measured bandwidth achievable on the specific accelerator
+      is displayed alongside for comparison.
+    GL1 Cache Bandwidth: >-
+      The number of bytes transferred between TCP (L0) and GL1C per unit time.
+      GL1C is the shared L1 cache within each Shader Engine.
+      The peak empirically measured bandwidth achievable on the specific accelerator
+      is displayed alongside for comparison.
+    TCP (L0) Cache Bandwidth: >-
+      The number of bytes looked up in the TCP (Texture Cache Per-pipe) per unit time.
+      TCP is the L0 vector cache in RDNA3.5, one per WGP. The peak empirically
+      measured bandwidth achievable on the specific accelerator is displayed
+      alongside for comparison.
+    LDS Bandwidth: >-
+      Indicates the maximum amount of bytes that could have been loaded from,
+      stored to, or atomically updated in the LDS per unit time. RDNA3.5 has
+      32 LDS banks per CU. The peak empirically measured LDS bandwidth achievable
+      on the specific accelerator is displayed alongside for comparison.
+    AI TCP: >-
+      The Arithmetic Intensity (AI) relative to TCP (L0 Cache). It is the ratio
+      of total floating-point operations (FLOPs) to total bytes transferred
+      from TCP to the shader cores. This value is used as the x-coordinate
+      for the TCP roofline.
+    AI GL1: >-
+      The Arithmetic Intensity (AI) relative to GL1C (L1 Cache). It is the ratio
+      of total floating-point operations (FLOPs) to total bytes transferred between
+      GL1C and TCP. This value is used as the x-coordinate for the GL1 roofline.
+    AI GL2: >-
+      The Arithmetic Intensity (AI) relative to GL2C (L2 Cache). It is the ratio
+      of total floating-point operations (FLOPs) to total bytes transferred between
+      GL2C and GL1C. This value is used as the x-coordinate for the GL2 roofline.
+    Performance (GFLOPs): >-
+      The overall achieved performance, measured in GigaFLOPs per second (GFLOP/s).
+      This is calculated as the sum of all VALU floating-point operations divided
+      by the total execution time. This value is used as the y-coordinate for
+      the kernel's point on the Roofline plot.

--- a/projects/rocprofiler-compute/src/rocprof_compute_soc/analysis_configs/gfx1151/0500_CPC.yaml
+++ b/projects/rocprofiler-compute/src/rocprof_compute_soc/analysis_configs/gfx1151/0500_CPC.yaml
@@ -1,0 +1,210 @@
+# =============================================================================
+# RDNA3.5 (gfx1151) - RDNA3.5 CPC (Command Processor Compute) Performance Metrics
+# =============================================================================
+# CPC handles compute shader dispatch and command stream processing
+# =============================================================================
+
+Panel Config:
+  id: 500
+  title: Command Processor Compute (CPC)
+  data source:
+  # =========================================================================
+  # CPC Utilization
+  # =========================================================================
+  - metric_table:
+      id: 501
+      title: "CPC Utilization"
+      header:
+        metric: Metric
+        avg: Avg
+        min: Min
+        max: Max
+        unit: Unit
+      metric:
+        CPC Busy:
+          avg: AVG((100 * CPC_STAT_BUSY / CPC_ALWAYS_COUNT) if (CPC_ALWAYS_COUNT != 0) else None)
+          min: MIN((100 * CPC_STAT_BUSY / CPC_ALWAYS_COUNT) if (CPC_ALWAYS_COUNT != 0) else None)
+          max: MAX((100 * CPC_STAT_BUSY / CPC_ALWAYS_COUNT) if (CPC_ALWAYS_COUNT != 0) else None)
+          unit: Percent
+        CPC Idle:
+          avg: AVG((100 * CPC_STAT_IDLE / CPC_ALWAYS_COUNT) if (CPC_ALWAYS_COUNT != 0) else None)
+          min: MIN((100 * CPC_STAT_IDLE / CPC_ALWAYS_COUNT) if (CPC_ALWAYS_COUNT != 0) else None)
+          max: MAX((100 * CPC_STAT_IDLE / CPC_ALWAYS_COUNT) if (CPC_ALWAYS_COUNT != 0) else None)
+          unit: Percent
+        CPC Stalled:
+          avg: AVG((100 * CPC_STAT_STALL / CPC_ALWAYS_COUNT) if (CPC_ALWAYS_COUNT != 0) else None)
+          min: MIN((100 * CPC_STAT_STALL / CPC_ALWAYS_COUNT) if (CPC_ALWAYS_COUNT != 0) else None)
+          max: MAX((100 * CPC_STAT_STALL / CPC_ALWAYS_COUNT) if (CPC_ALWAYS_COUNT != 0) else None)
+          unit: Percent
+
+  # =========================================================================
+  # CPC Interface Utilization
+  # =========================================================================
+  - metric_table:
+      id: 502
+      title: "CPC Interface Utilization"
+      header:
+        metric: Metric
+        avg: Avg
+        min: Min
+        max: Max
+        unit: Unit
+      metric:
+        TCIU Busy:
+          avg: AVG((100 * CPC_TCIU_BUSY / CPC_ALWAYS_COUNT) if (CPC_ALWAYS_COUNT != 0) else None)
+          min: MIN((100 * CPC_TCIU_BUSY / CPC_ALWAYS_COUNT) if (CPC_ALWAYS_COUNT != 0) else None)
+          max: MAX((100 * CPC_TCIU_BUSY / CPC_ALWAYS_COUNT) if (CPC_ALWAYS_COUNT != 0) else None)
+          unit: Percent
+        UTCL2 Busy:
+          avg: AVG((100 * CPC_UTCL2IU_BUSY / CPC_ALWAYS_COUNT) if (CPC_ALWAYS_COUNT != 0) else None)
+          min: MIN((100 * CPC_UTCL2IU_BUSY / CPC_ALWAYS_COUNT) if (CPC_ALWAYS_COUNT != 0) else None)
+          max: MAX((100 * CPC_UTCL2IU_BUSY / CPC_ALWAYS_COUNT) if (CPC_ALWAYS_COUNT != 0) else None)
+          unit: Percent
+        GCRIU Busy:
+          avg: AVG((100 * CPC_GCRIU_BUSY / CPC_ALWAYS_COUNT) if (CPC_ALWAYS_COUNT != 0) else None)
+          min: MIN((100 * CPC_GCRIU_BUSY / CPC_ALWAYS_COUNT) if (CPC_ALWAYS_COUNT != 0) else None)
+          max: MAX((100 * CPC_GCRIU_BUSY / CPC_ALWAYS_COUNT) if (CPC_ALWAYS_COUNT != 0) else None)
+          unit: Percent
+
+  # =========================================================================
+  # MEC (Micro Engine Compute) Stalls
+  # =========================================================================
+  - metric_table:
+      id: 503
+      title: "MEC Stall Cycles"
+      header:
+        metric: Metric
+        avg: Avg
+        min: Min
+        max: Max
+        unit: Unit
+      metric:
+        ME1 Stall on RCIU Ready:
+          avg: AVG(CPC_ME1_STALL_WAIT_ON_RCIU_READY / $denom)
+          min: MIN(CPC_ME1_STALL_WAIT_ON_RCIU_READY / $denom)
+          max: MAX(CPC_ME1_STALL_WAIT_ON_RCIU_READY / $denom)
+          unit: (Cycles + $normUnit)
+        ME1 Stall on Memory Read:
+          avg: AVG(CPC_ME1_STALL_WAIT_ON_MEM_READ / $denom)
+          min: MIN(CPC_ME1_STALL_WAIT_ON_MEM_READ / $denom)
+          max: MAX(CPC_ME1_STALL_WAIT_ON_MEM_READ / $denom)
+          unit: (Cycles + $normUnit)
+        ME1 Stall on Memory Write:
+          avg: AVG(CPC_ME1_STALL_WAIT_ON_MEM_WRITE / $denom)
+          min: MIN(CPC_ME1_STALL_WAIT_ON_MEM_WRITE / $denom)
+          max: MAX(CPC_ME1_STALL_WAIT_ON_MEM_WRITE / $denom)
+          unit: (Cycles + $normUnit)
+        ME1 Stall on ROQ Data:
+          avg: AVG(CPC_ME1_STALL_ON_DATA_FROM_ROQ / $denom)
+          min: MIN(CPC_ME1_STALL_ON_DATA_FROM_ROQ / $denom)
+          max: MAX(CPC_ME1_STALL_ON_DATA_FROM_ROQ / $denom)
+          unit: (Cycles + $normUnit)
+
+  # =========================================================================
+  # CPC Memory Requests
+  # =========================================================================
+  - metric_table:
+      id: 504
+      title: "CPC Memory Requests"
+      header:
+        metric: Metric
+        avg: Avg
+        min: Min
+        max: Max
+        unit: Unit
+      metric:
+        TCIU Read Requests:
+          avg: AVG(CPC_TCIU_READ_REQUEST_SENT_sum / $denom)
+          min: MIN(CPC_TCIU_READ_REQUEST_SENT_sum / $denom)
+          max: MAX(CPC_TCIU_READ_REQUEST_SENT_sum / $denom)
+          unit: (Count + $normUnit)
+        TCIU Write Requests:
+          avg: AVG(CPC_TCIU_WRITE_REQUEST_SENT_sum / $denom)
+          min: MIN(CPC_TCIU_WRITE_REQUEST_SENT_sum / $denom)
+          max: MAX(CPC_TCIU_WRITE_REQUEST_SENT_sum / $denom)
+          unit: (Count + $normUnit)
+        GUS Read Requests:
+          avg: AVG(CPC_GUS_READ_REQUEST_SENT_sum / $denom)
+          min: MIN(CPC_GUS_READ_REQUEST_SENT_sum / $denom)
+          max: MAX(CPC_GUS_READ_REQUEST_SENT_sum / $denom)
+          unit: (Count + $normUnit)
+        GUS Write Requests:
+          avg: AVG(CPC_GUS_WRITE_REQUEST_SENT_sum / $denom)
+          min: MIN(CPC_GUS_WRITE_REQUEST_SENT_sum / $denom)
+          max: MAX(CPC_GUS_WRITE_REQUEST_SENT_sum / $denom)
+          unit: (Count + $normUnit)
+
+  # =========================================================================
+  # MEC Instruction Cache
+  # =========================================================================
+  - metric_table:
+      id: 505
+      title: "MEC Instruction Cache"
+      header:
+        metric: Metric
+        avg: Avg
+        min: Min
+        max: Max
+        unit: Unit
+      metric:
+        Instruction Cache Hits:
+          avg: AVG(CPC_MEC_INSTR_CACHE_HIT_sum / $denom)
+          min: MIN(CPC_MEC_INSTR_CACHE_HIT_sum / $denom)
+          max: MAX(CPC_MEC_INSTR_CACHE_HIT_sum / $denom)
+          unit: (Count + $normUnit)
+        Instruction Cache Misses:
+          avg: AVG(CPC_MEC_INSTR_CACHE_MISS_sum / $denom)
+          min: MIN(CPC_MEC_INSTR_CACHE_MISS_sum / $denom)
+          max: MAX(CPC_MEC_INSTR_CACHE_MISS_sum / $denom)
+          unit: (Count + $normUnit)
+        Instruction Cache Hit Rate:
+          avg: AVG((100 * CPC_MEC_INSTR_CACHE_HIT_sum / (CPC_MEC_INSTR_CACHE_HIT_sum + CPC_MEC_INSTR_CACHE_MISS_sum)) if ((CPC_MEC_INSTR_CACHE_HIT_sum + CPC_MEC_INSTR_CACHE_MISS_sum) != 0) else None)
+          min: MIN((100 * CPC_MEC_INSTR_CACHE_HIT_sum / (CPC_MEC_INSTR_CACHE_HIT_sum + CPC_MEC_INSTR_CACHE_MISS_sum)) if ((CPC_MEC_INSTR_CACHE_HIT_sum + CPC_MEC_INSTR_CACHE_MISS_sum) != 0) else None)
+          max: MAX((100 * CPC_MEC_INSTR_CACHE_HIT_sum / (CPC_MEC_INSTR_CACHE_HIT_sum + CPC_MEC_INSTR_CACHE_MISS_sum)) if ((CPC_MEC_INSTR_CACHE_HIT_sum + CPC_MEC_INSTR_CACHE_MISS_sum) != 0) else None)
+          unit: Percent
+
+  metrics_description:
+    CPC Busy: |-
+      Percentage of CPC always-count cycles the Command Processor Compute was busy
+      processing commands. Computed as 100 * CPC_STAT_BUSY / CPC_ALWAYS_COUNT.
+    CPC Idle: |-
+      Percentage of CPC always-count cycles the Command Processor Compute was idle.
+      Computed as 100 * CPC_STAT_IDLE / CPC_ALWAYS_COUNT.
+    CPC Stalled: |-
+      Percentage of CPC always-count cycles the Command Processor Compute was stalled.
+      Computed as 100 * CPC_STAT_STALL / CPC_ALWAYS_COUNT.
+    TCIU Busy: |-
+      Percentage of CPC always-count cycles the TC (Texture Cache) Interface Unit
+      was busy. Computed as 100 * CPC_TCIU_BUSY / CPC_ALWAYS_COUNT.
+    UTCL2 Busy: |-
+      Percentage of CPC always-count cycles the UTCL2 (Unified Translation Cache L2)
+      interface was busy. Computed as 100 * CPC_UTCL2IU_BUSY / CPC_ALWAYS_COUNT.
+    GCRIU Busy: |-
+      Percentage of CPC always-count cycles the GCR (Graphics Cache Rinse) Interface
+      Unit was busy. Computed as 100 * CPC_GCRIU_BUSY / CPC_ALWAYS_COUNT.
+    ME1 Stall on RCIU Ready: |-
+      Cycles ME1 was stalled waiting for RCIU (Register Cache Interface
+      Unit) to be ready (CPC_ME1_STALL_WAIT_ON_RCIU_READY).
+    ME1 Stall on Memory Read: |-
+      Cycles ME1 was stalled waiting for memory read completion
+      (CPC_ME1_STALL_WAIT_ON_MEM_READ).
+    ME1 Stall on Memory Write: |-
+      Cycles ME1 was stalled waiting for memory write completion
+      (CPC_ME1_STALL_WAIT_ON_MEM_WRITE).
+    ME1 Stall on ROQ Data: |-
+      Cycles ME1 was stalled waiting for data from the Ring Output Queue
+      (CPC_ME1_STALL_ON_DATA_FROM_ROQ).
+    TCIU Read Requests: |-
+      Number of read requests sent to the TC Interface Unit.
+    TCIU Write Requests: |-
+      Number of write requests sent to the TC Interface Unit.
+    GUS Read Requests: |-
+      Number of read requests sent to the Global Unified Shader memory interface.
+    GUS Write Requests: |-
+      Number of write requests sent to the Global Unified Shader memory interface.
+    Instruction Cache Hits: |-
+      Number of MEC instruction cache hits.
+    Instruction Cache Misses: |-
+      Number of MEC instruction cache misses.
+    Instruction Cache Hit Rate: |-
+      Percentage of MEC instruction cache accesses that hit in the cache.

--- a/projects/rocprofiler-compute/src/rocprof_compute_soc/analysis_configs/gfx1151/0600_SPI.yaml
+++ b/projects/rocprofiler-compute/src/rocprof_compute_soc/analysis_configs/gfx1151/0600_SPI.yaml
@@ -1,0 +1,73 @@
+# =============================================================================
+# RDNA3.5 (gfx1151) - RDNA3.5 SPI (Shader Processor Input) Performance Metrics
+# =============================================================================
+# SPI handles wave scheduling and resource allocation to WGPs
+# =============================================================================
+
+Panel Config:
+  id: 600
+  title: Workgroup Manager (SPI)
+  data source:
+  # =========================================================================
+  # SPI Utilization
+  # =========================================================================
+  - metric_table:
+      id: 601
+      title: "SPI Utilization"
+      header:
+        metric: Metric
+        avg: Avg
+        min: Min
+        max: Max
+        unit: Unit
+      metric:
+        SPI Busy:
+          # Use GRBM_SPI_BUSY (not SPI_BUSY): SPI_BUSY is summed over all SPI instances, so it
+          # can exceed GRBM_GUI_ACTIVE when multiple SEs are busy in the same cycle. GRBM counts
+          # "any SPI busy" vs GUI active.
+          avg: AVG((100 * GRBM_SPI_BUSY / GRBM_GUI_ACTIVE) if (GRBM_GUI_ACTIVE != 0) else None)
+          min: MIN((100 * GRBM_SPI_BUSY / GRBM_GUI_ACTIVE) if (GRBM_GUI_ACTIVE != 0) else None)
+          max: MAX((100 * GRBM_SPI_BUSY / GRBM_GUI_ACTIVE) if (GRBM_GUI_ACTIVE != 0) else None)
+          unit: Percent
+
+  # =========================================================================
+  # Wave Dispatch Statistics
+  # =========================================================================
+  - metric_table:
+      id: 602
+      title: "Wave Dispatch Statistics"
+      header:
+        metric: Metric
+        avg: Avg
+        min: Min
+        max: Max
+        unit: Unit
+      metric:
+        # Use SPI_CSN_WAVE (pmc_perf column name from collection), not SPI_CSN_WAVE_sum: the
+        # latter is a counter_defs derived alias and is often absent from pmc_perf.csv, which
+        # yields all-zero / NaN metrics. Profiler output typically already aggregates instances.
+        Compute Wave Dispatches:
+          avg: AVG(SPI_CSN_WAVE / $denom)
+          min: MIN(SPI_CSN_WAVE / $denom)
+          max: MAX(SPI_CSN_WAVE / $denom)
+          unit: (Count + $normUnit)
+        Wave Dispatch Rate:
+          avg: AVG((SPI_CSN_WAVE / GRBM_GUI_ACTIVE) if (GRBM_GUI_ACTIVE != 0) else None)
+          min: MIN((SPI_CSN_WAVE / GRBM_GUI_ACTIVE) if (GRBM_GUI_ACTIVE != 0) else None)
+          max: MAX((SPI_CSN_WAVE / GRBM_GUI_ACTIVE) if (GRBM_GUI_ACTIVE != 0) else None)
+          unit: Waves/cycle
+
+  metrics_description:
+    SPI Busy: |-
+      Percentage of GPU active (GUI) cycles where any SPI was busy. Computed as
+      100 * GRBM_SPI_BUSY / GRBM_GUI_ACTIVE (GRBM block). Do not use block-level SPI_BUSY here:
+      it is aggregated over every SPI instance, so summed busy cycles can far exceed GUI-active
+      cycles when multiple shader engines are active in parallel.
+    Compute Wave Dispatches: |-
+      SPI counter SPI_CSN_WAVE (block SPI, event 50): compute (CSN) path wave count as stored in
+      pmc_perf (column SPI_CSN_WAVE). Same idea as WGP “Dispatched Waves” (SQ_WAVES_sum) but at
+      SPI; values may differ slightly. Normalized by CLI $denom: per_kernel → ÷1; per_wave →
+      ÷SQ_WAVES; per_cycle → ÷$GRBM_GUI_ACTIVE_PER_XCD; per_second → ÷kernel wall time (s).
+    Wave Dispatch Rate: |-
+      SPI_CSN_WAVE / GRBM_GUI_ACTIVE — waves per GUI-active cycle (can exceed 1 when many SEs
+      dispatch in parallel). Uses the same SPI_CSN_WAVE column as collection emits.

--- a/projects/rocprofiler-compute/src/rocprof_compute_soc/analysis_configs/gfx1151/0700_WGP.yaml
+++ b/projects/rocprofiler-compute/src/rocprof_compute_soc/analysis_configs/gfx1151/0700_WGP.yaml
@@ -1,0 +1,365 @@
+# =============================================================================
+# RDNA3.5 (gfx1151) - RDNA3.5 Workgroup Processor (WGP) Performance Metrics
+# =============================================================================
+# RDNA3.5 WGP Structure: 2 CUs per WGP, 2 SIMD32 per CU, Wave32 primary wavefront size
+# =============================================================================
+
+Panel Config:
+  id: 700
+  title: Workgroup Processor (WGP)
+  data source:
+  # =========================================================================
+  # Utilization Metrics
+  # =========================================================================
+  - metric_table:
+      id: 701
+      title: "Utilization"
+      header:
+        metric: Metric
+        avg: Avg
+        min: Min
+        max: Max
+        unit: Unit
+      metric:
+        WGP Utilization:
+          avg: None
+          min: None
+          max: None
+          unit: Percent
+
+  - metric_table:
+      id: 702
+      title: Wavefront Launch Stats
+      header:
+        metric: Metric
+        avg: Avg
+        min: Min
+        max: Max
+        unit: Unit
+      metric:
+        Grid Size:
+          avg: AVG(Grid_Size)
+          min: MIN(Grid_Size)
+          max: MAX(Grid_Size)
+          unit: Work-items
+        Workgroup Size:
+          avg: AVG(Workgroup_Size)
+          min: MIN(Workgroup_Size)
+          max: MAX(Workgroup_Size)
+          unit: Work-items
+        VGPRs:
+          avg: AVG(Arch_VGPR)
+          min: MIN(Arch_VGPR)
+          max: MAX(Arch_VGPR)
+          unit: Registers
+        SGPRs:
+          avg: AVG(SGPR)
+          min: MIN(SGPR)
+          max: MAX(SGPR)
+          unit: Registers
+        LDS Allocation:
+          avg: AVG(LDS_Per_Workgroup)
+          min: MIN(LDS_Per_Workgroup)
+          max: MAX(LDS_Per_Workgroup)
+          unit: Bytes
+        Scratch Allocation:
+          avg: AVG(Scratch_Per_Workitem)
+          min: MIN(Scratch_Per_Workitem)
+          max: MAX(Scratch_Per_Workitem)
+          unit: Bytes per Work-item
+
+  # =========================================================================
+  # Wave Dispatch
+  # =========================================================================
+  - metric_table:
+      id: 703
+      title: "Wave Dispatch"
+      header:
+        metric: Metric
+        avg: Avg
+        min: Min
+        max: Max
+        unit: Unit
+      metric:
+        Dispatched Waves:
+          avg: AVG(SQ_WAVES_sum)
+          min: MIN(SQ_WAVES_sum)
+          max: MAX(SQ_WAVES_sum)
+          unit: Waves
+        Dispatched Threads:
+          avg: AVG(SQ_ITEMS_sum)
+          min: MIN(SQ_ITEMS_sum)
+          max: MAX(SQ_ITEMS_sum)
+          unit: Threads
+
+  # =========================================================================
+  # Wave Life
+  # =========================================================================
+  - metric_table:
+      id: 704
+      title: "Wave Life"
+      header:
+        metric: Metric
+        avg: Avg
+        min: Min
+        max: Max
+        unit: Unit
+      metric:
+        Wave Life:
+          avg: AVG((SQ_WAVE_CYCLES_sum / SQ_WAVES_sum) if (SQ_WAVES_sum != 0) else None)
+          min: MIN((SQ_WAVE_CYCLES_sum / SQ_WAVES_sum) if (SQ_WAVES_sum != 0) else None)
+          max: MAX((SQ_WAVE_CYCLES_sum / SQ_WAVES_sum) if (SQ_WAVES_sum != 0) else None)
+          unit: Cycles
+
+  # =========================================================================
+  # Wave Instruction Mix
+  # =========================================================================
+  - metric_table:
+      id: 705
+      title: "Wave Instruction Mix"
+      header:
+        metric: Metric
+        avg: Avg
+        min: Min
+        max: Max
+        unit: Unit
+      metric:
+        Total Instructions:
+          avg: AVG(SQ_INSTS_ALL_sum / $denom)
+          min: MIN(SQ_INSTS_ALL_sum / $denom)
+          max: MAX(SQ_INSTS_ALL_sum / $denom)
+          unit: (Count + $normUnit)
+        Instructions - Internal:
+          avg: AVG(SQ_INSTS_INTERNAL_sum / $denom)
+          min: MIN(SQ_INSTS_INTERNAL_sum / $denom)
+          max: MAX(SQ_INSTS_INTERNAL_sum / $denom)
+          unit: (Count + $normUnit)
+        Instructions - VALU:
+          avg: AVG(SQ_INSTS_VALU_sum / $denom)
+          min: MIN(SQ_INSTS_VALU_sum / $denom)
+          max: MAX(SQ_INSTS_VALU_sum / $denom)
+          unit: (Count + $normUnit)
+        Instructions - SALU:
+          avg: AVG(SQ_INSTS_SALU_sum / $denom)
+          min: MIN(SQ_INSTS_SALU_sum / $denom)
+          max: MAX(SQ_INSTS_SALU_sum / $denom)
+          unit: (Count + $normUnit)
+        Instructions - SMEM:
+          avg: AVG(SQ_INSTS_SMEM_sum / $denom)
+          min: MIN(SQ_INSTS_SMEM_sum / $denom)
+          max: MAX(SQ_INSTS_SMEM_sum / $denom)
+          unit: (Count + $normUnit)
+        Instructions - Transcendental:
+          avg: AVG(SQ_INSTS_VALU_TRANS_sum / $denom)
+          min: MIN(SQ_INSTS_VALU_TRANS_sum / $denom)
+          max: MAX(SQ_INSTS_VALU_TRANS_sum / $denom)
+          unit: (Count + $normUnit)
+        Instructions - VMEM:
+          avg: AVG(SQ_INSTS_TEX_sum / $denom)
+          min: MIN(SQ_INSTS_TEX_sum / $denom)
+          max: MAX(SQ_INSTS_TEX_sum / $denom)
+          unit: (Count + $normUnit)
+        Instructions - LDS:
+          avg: AVG(SQ_INSTS_LDS_sum / $denom)
+          min: MIN(SQ_INSTS_LDS_sum / $denom)
+          max: MAX(SQ_INSTS_LDS_sum / $denom)
+          unit: (Count + $normUnit)
+
+  # =========================================================================
+  # VMEM Instruction Mix
+  # =========================================================================
+  - metric_table:
+      id: 706
+      title: "VMEM Instruction Mix"
+      header:
+        metric: Metric
+        avg: Avg
+        min: Min
+        max: Max
+        unit: Unit
+      metric:
+        Instructions - VMEM Flat:
+          avg: AVG(SQ_INSTS_FLAT_sum / $denom)
+          min: MIN(SQ_INSTS_FLAT_sum / $denom)
+          max: MAX(SQ_INSTS_FLAT_sum / $denom)
+          unit: (Count + $normUnit)
+        Instructions - TEX Load:
+          avg: AVG(SQ_INSTS_TEX_LOAD_sum / $denom)
+          min: MIN(SQ_INSTS_TEX_LOAD_sum / $denom)
+          max: MAX(SQ_INSTS_TEX_LOAD_sum / $denom)
+          unit: (Count + $normUnit)
+        Instructions - TEX Store:
+          avg: AVG(SQ_INSTS_TEX_STORE_sum / $denom)
+          min: MIN(SQ_INSTS_TEX_STORE_sum / $denom)
+          max: MAX(SQ_INSTS_TEX_STORE_sum / $denom)
+          unit: (Count + $normUnit)
+        Instructions - Flat Load:
+          avg: AVG(SQ_INSTS_FLAT_LOAD_sum / $denom)
+          min: MIN(SQ_INSTS_FLAT_LOAD_sum / $denom)
+          max: MAX(SQ_INSTS_FLAT_LOAD_sum / $denom)
+          unit: (Count + $normUnit)
+        Instructions - Flat Store:
+          avg: AVG(SQ_INSTS_FLAT_STORE_sum / $denom)
+          min: MIN(SQ_INSTS_FLAT_STORE_sum / $denom)
+          max: MAX(SQ_INSTS_FLAT_STORE_sum / $denom)
+          unit: (Count + $normUnit)
+
+  # =========================================================================
+  # LDS Instruction Mix (breakdown; total LDS = "Instructions - LDS" in Wave Mix)
+  # =========================================================================
+  - metric_table:
+      id: 707
+      title: "LDS Instruction Mix"
+      header:
+        metric: Metric
+        avg: Avg
+        min: Min
+        max: Max
+        unit: Unit
+      metric:
+        LDS Direct Load Instructions:
+          avg: AVG(SQ_INSTS_LDS_DIRECT_LOAD_sum / $denom)
+          min: MIN(SQ_INSTS_LDS_DIRECT_LOAD_sum / $denom)
+          max: MAX(SQ_INSTS_LDS_DIRECT_LOAD_sum / $denom)
+          unit: (Count + $normUnit)
+        LDS Parameter Load Instructions:
+          avg: AVG(SQ_INSTS_LDS_PARAM_LOAD_sum / $denom)
+          min: MIN(SQ_INSTS_LDS_PARAM_LOAD_sum / $denom)
+          max: MAX(SQ_INSTS_LDS_PARAM_LOAD_sum / $denom)
+          unit: (Count + $normUnit)
+        WAVE32 LDS Parameter Load Instructions:
+          avg: AVG(SQ_INSTS_WAVE32_LDS_PARAM_LOAD_sum / $denom)
+          min: MIN(SQ_INSTS_WAVE32_LDS_PARAM_LOAD_sum / $denom)
+          max: MAX(SQ_INSTS_WAVE32_LDS_PARAM_LOAD_sum / $denom)
+          unit: (Count + $normUnit)
+
+  # =========================================================================
+  # Wait State Analysis
+  # =========================================================================
+  - metric_table:
+      id: 709
+      title: "Wait State Analysis"
+      header:
+        metric: Metric
+        avg: Avg
+        min: Min
+        max: Max
+        unit: Unit
+      metric:
+        Wait for Any:
+          avg: AVG((100 * SQ_WAIT_ANY / SQ_WAVE_CYCLES) if (SQ_WAVE_CYCLES != 0) else None)
+          min: MIN((100 * SQ_WAIT_ANY / SQ_WAVE_CYCLES) if (SQ_WAVE_CYCLES != 0) else None)
+          max: MAX((100 * SQ_WAIT_ANY / SQ_WAVE_CYCLES) if (SQ_WAVE_CYCLES != 0) else None)
+          unit: Percent
+        Wait for Instruction Fetch:
+          avg: AVG((100 * SQ_WAIT_IFETCH / SQ_WAVE_CYCLES) if (SQ_WAVE_CYCLES != 0) else None)
+          min: MIN((100 * SQ_WAIT_IFETCH / SQ_WAVE_CYCLES) if (SQ_WAVE_CYCLES != 0) else None)
+          max: MAX((100 * SQ_WAIT_IFETCH / SQ_WAVE_CYCLES) if (SQ_WAVE_CYCLES != 0) else None)
+          unit: Percent
+        Wait for Barrier:
+          avg: AVG((100 * SQ_WAIT_BARRIER / SQ_WAVE_CYCLES) if (SQ_WAVE_CYCLES != 0) else None)
+          min: MIN((100 * SQ_WAIT_BARRIER / SQ_WAVE_CYCLES) if (SQ_WAVE_CYCLES != 0) else None)
+          max: MAX((100 * SQ_WAIT_BARRIER / SQ_WAVE_CYCLES) if (SQ_WAVE_CYCLES != 0) else None)
+          unit: Percent
+        Wait for Counter:
+          avg: AVG((100 * SQ_WAIT_CNT_ANY / SQ_WAVE_CYCLES) if (SQ_WAVE_CYCLES != 0) else None)
+          min: MIN((100 * SQ_WAIT_CNT_ANY / SQ_WAVE_CYCLES) if (SQ_WAVE_CYCLES != 0) else None)
+          max: MAX((100 * SQ_WAIT_CNT_ANY / SQ_WAVE_CYCLES) if (SQ_WAVE_CYCLES != 0) else None)
+          unit: Percent
+
+  # =========================================================================
+  # Instruction Cache
+  # =========================================================================
+  - metric_table:
+      id: 710
+      title: "Instruction Cache"
+      header:
+        metric: Metric
+        avg: Avg
+        min: Min
+        max: Max
+        unit: Unit
+      metric:
+        # HITS and REQ are per-SQ per-bank; summed HITS can exceed REQ → >100%. Use HITS+MISSES
+        # as the outcome denominator (same pairing as Memory Chart / SoL).
+        Icache Hit Rate:
+          avg: AVG((100 * SQC_ICACHE_HITS_sum / (SQC_ICACHE_HITS_sum + SQC_ICACHE_MISSES_sum)) if ((SQC_ICACHE_HITS_sum + SQC_ICACHE_MISSES_sum) != 0) else None)
+          min: MIN((100 * SQC_ICACHE_HITS_sum / (SQC_ICACHE_HITS_sum + SQC_ICACHE_MISSES_sum)) if ((SQC_ICACHE_HITS_sum + SQC_ICACHE_MISSES_sum) != 0) else None)
+          max: MAX((100 * SQC_ICACHE_HITS_sum / (SQC_ICACHE_HITS_sum + SQC_ICACHE_MISSES_sum)) if ((SQC_ICACHE_HITS_sum + SQC_ICACHE_MISSES_sum) != 0) else None)
+          unit: Percent
+
+  # =========================================================================
+  # Scalar Data Cache
+  # =========================================================================
+  - metric_table:
+      id: 711
+      title: "Scalar Data Cache"
+      header:
+        metric: Metric
+        avg: Avg
+        min: Min
+        max: Max
+        unit: Unit
+      metric:
+        Dcache Hit Rate:
+          avg: AVG((100 * SQC_DCACHE_HITS_sum / (SQC_DCACHE_HITS_sum + SQC_DCACHE_MISSES_sum)) if ((SQC_DCACHE_HITS_sum + SQC_DCACHE_MISSES_sum) != 0) else None)
+          min: MIN((100 * SQC_DCACHE_HITS_sum / (SQC_DCACHE_HITS_sum + SQC_DCACHE_MISSES_sum)) if ((SQC_DCACHE_HITS_sum + SQC_DCACHE_MISSES_sum) != 0) else None)
+          max: MAX((100 * SQC_DCACHE_HITS_sum / (SQC_DCACHE_HITS_sum + SQC_DCACHE_MISSES_sum)) if ((SQC_DCACHE_HITS_sum + SQC_DCACHE_MISSES_sum) != 0) else None)
+          unit: Percent
+
+  metrics_description:
+    WGP Utilization: |-
+      WGP busy as a percent of GRBM GUI-active cycles. RDNA3.5 WGPs pair 2 CUs,
+      each with 2 SIMD32 units.
+    Wave Life: |-
+      Average number of cycles a wave exists from creation to completion.
+      Calculated as SQ_WAVE_CYCLES / SQ_WAVES.
+    Total Instructions: |-
+      Total number of instructions executed across all waves.
+    Instructions - VALU: |-
+      Number of Vector ALU instructions executed (SQ_INSTS_VALU). VALU handles all
+      vector arithmetic and logic operations. Transcendental VALU ops are
+      reported separately as "Instructions - Transcendental" in the same
+      Wave Instruction Mix table.
+    Instructions - SALU: |-
+      Number of Scalar ALU instructions executed. SALU handles scalar operations
+      that are uniform across the wave.
+    Instructions - SMEM: |-
+      Number of Scalar Memory instructions executed. SMEM loads uniform data
+      through the scalar cache.
+    Instructions - VMEM: |-
+      Number of Vector Memory instructions executed. Includes global, buffer,
+      and texture memory operations.
+    Instructions - LDS: |-
+      Total Local Data Share instructions (SQ_INSTS_LDS). LDS provides fast
+      shared memory within a workgroup. For LDS sub-categories (direct/param/
+      wave32 param loads), see the "LDS Instruction Mix" table.
+    LDS Direct Load Instructions: |-
+      LDS direct load instructions issued (SQ_INSTS_LDS_DIRECT_LOAD). Subset of
+      total LDS; not required to sum with other LDS mix rows to equal total.
+    LDS Parameter Load Instructions: |-
+      LDS parameter load instructions issued (SQ_INSTS_LDS_PARAM_LOAD).
+    WAVE32 LDS Parameter Load Instructions: |-
+      LDS parameter load instructions under wave32 execution (SQ_INSTS_WAVE32_LDS_PARAM_LOAD).
+    Wait for Any: |-
+      Percentage of wave lifetime spent waiting for any reason including
+      memory, barriers, or instruction fetch. Computed as 100 * SQ_WAIT_ANY /
+      SQ_WAVE_CYCLES.
+    Wait for Instruction Fetch: |-
+      Percentage of wave lifetime spent waiting for instructions to arrive
+      from the instruction cache. Computed as 100 * SQ_WAIT_IFETCH /
+      SQ_WAVE_CYCLES.
+    Wait for Barrier: |-
+      Percentage of wave lifetime spent waiting at barrier synchronization
+      points. Computed as 100 * SQ_WAIT_BARRIER / SQ_WAVE_CYCLES.
+    Wait for Counter: |-
+      Percentage of wave lifetime spent waiting for waitcnt counters (VMCNT,
+      LGKMCNT, etc.) to reach target values. Computed as 100 * SQ_WAIT_CNT_ANY /
+      SQ_WAVE_CYCLES.
+    Icache Hit Rate: |-
+      Instruction cache hit percentage using 100 × SQC_ICACHE_HITS / (SQC_ICACHE_HITS +
+      SQC_ICACHE_MISSES). Do not divide only by SQC_ICACHE_REQ — hits and requests are both
+      per-SQ per-bank, and summed hits can exceed summed requests.
+    Dcache Hit Rate: |-
+      Scalar data cache hit percentage: 100 × SQC_DCACHE_HITS / (SQC_DCACHE_HITS +
+      SQC_DCACHE_MISSES). Same rationale as Icache (HITS vs REQ can exceed 100%).

--- a/projects/rocprofiler-compute/src/rocprof_compute_soc/analysis_configs/gfx1151/0800_TCP_Cache.yaml
+++ b/projects/rocprofiler-compute/src/rocprof_compute_soc/analysis_configs/gfx1151/0800_TCP_Cache.yaml
@@ -1,0 +1,170 @@
+# =============================================================================
+# RDNA3.5 (gfx1151) - RDNA3.5 TCP (Texture Cache Per-pipe) Performance Metrics
+# =============================================================================
+# TCP is the L0 vector cache in RDNA3.5, providing per-WGP caching
+# Cache hierarchy: TCP (L0) -> GL1C (L1) -> GL2C (L2)
+# =============================================================================
+
+Panel Config:
+  id: 800
+  title: TCP Cache (L0)
+  data source:
+  # =========================================================================
+  # TCP Utilization
+  # =========================================================================
+  - metric_table:
+      id: 801
+      title: "TCP Utilization"
+      header:
+        metric: Metric
+        avg: Avg
+        min: Min
+        max: Max
+        unit: Unit
+      metric:
+        # tcp_perf_sel_gate_en2 / TCP_GATE_EN2: TCP core clocks on (counter_defs: not windowed).
+        # Use aggregate TCP_GATE_EN2 (not TCP_GATE_EN2_sum) when pmc_perf merges instances.
+        # Denominator: GRBM_GUI_ACTIVE × NUM_TCP with NUM_TCP = max(1, ⌊$cu_per_gpu / 2⌋)
+        # (one TCP per WGP, 2 CUs per WGP on RDNA3.x). AVG/MIN/MAX apply per sample.
+        TCP Busy:
+          avg: AVG((100 * TCP_GATE_EN2 / (GRBM_GUI_ACTIVE * MAX(1, TO_INT($cu_per_gpu / 2)))) if ((GRBM_GUI_ACTIVE * MAX(1, TO_INT($cu_per_gpu / 2))) != 0) else None)
+          min: MIN((100 * TCP_GATE_EN2 / (GRBM_GUI_ACTIVE * MAX(1, TO_INT($cu_per_gpu / 2)))) if ((GRBM_GUI_ACTIVE * MAX(1, TO_INT($cu_per_gpu / 2))) != 0) else None)
+          max: MAX((100 * TCP_GATE_EN2 / (GRBM_GUI_ACTIVE * MAX(1, TO_INT($cu_per_gpu / 2)))) if ((GRBM_GUI_ACTIVE * MAX(1, TO_INT($cu_per_gpu / 2))) != 0) else None)
+          unit: Percent
+
+  # =========================================================================
+  # TCP Request Statistics
+  # =========================================================================
+  - metric_table:
+      id: 802
+      title: "TCP Request Statistics"
+      header:
+        metric: Metric
+        avg: Avg
+        min: Min
+        max: Max
+        unit: Unit
+      metric:
+        Total Requests:
+          avg: AVG(TCP_REQ_sum / $denom)
+          min: MIN(TCP_REQ_sum / $denom)
+          max: MAX(TCP_REQ_sum / $denom)
+          unit: (Count + $normUnit)
+        Read Requests:
+          avg: AVG(TCP_REQ_READ_sum / $denom)
+          min: MIN(TCP_REQ_READ_sum / $denom)
+          max: MAX(TCP_REQ_READ_sum / $denom)
+          unit: (Count + $normUnit)
+        Write Requests:
+          avg: AVG(TCP_REQ_WRITE_sum / $denom)
+          min: MIN(TCP_REQ_WRITE_sum / $denom)
+          max: MAX(TCP_REQ_WRITE_sum / $denom)
+          unit: (Count + $normUnit)
+        Miss Requests:
+          avg: AVG(TCP_REQ_MISS_sum / $denom)
+          min: MIN(TCP_REQ_MISS_sum / $denom)
+          max: MAX(TCP_REQ_MISS_sum / $denom)
+          unit: (Count + $normUnit)
+
+  # =========================================================================
+  # TCP Cache Performance
+  # =========================================================================
+  - metric_table:
+      id: 803
+      title: "TCP Cache Performance"
+      header:
+        metric: Metric
+        avg: Avg
+        min: Min
+        max: Max
+        unit: Unit
+      metric:
+        Hit Rate:
+          avg: AVG((100 * (TCP_REQ_sum - TCP_REQ_MISS_sum) / TCP_REQ_sum) if (TCP_REQ_sum != 0) else None)
+          min: MIN((100 * (TCP_REQ_sum - TCP_REQ_MISS_sum) / TCP_REQ_sum) if (TCP_REQ_sum != 0) else None)
+          max: MAX((100 * (TCP_REQ_sum - TCP_REQ_MISS_sum) / TCP_REQ_sum) if (TCP_REQ_sum != 0) else None)
+          unit: Percent
+
+  # =========================================================================
+  # TCP-GL1 Interface
+  # =========================================================================
+  - metric_table:
+      id: 804
+      title: "TCP-GL1 Interface"
+      header:
+        metric: Metric
+        avg: Avg
+        min: Min
+        max: Max
+        unit: Unit
+      metric:
+        GL1 Read Requests:
+          avg: AVG(TCP_GL1_REQ_READ_sum / $denom)
+          min: MIN(TCP_GL1_REQ_READ_sum / $denom)
+          max: MAX(TCP_GL1_REQ_READ_sum / $denom)
+          unit: (Count + $normUnit)
+        GL1 Read 128B Requests:
+          avg: AVG(TCP_GL1_REQ_READ_128B_sum / $denom)
+          min: MIN(TCP_GL1_REQ_READ_128B_sum / $denom)
+          max: MAX(TCP_GL1_REQ_READ_128B_sum / $denom)
+          unit: (Count + $normUnit)
+        GL1 Write Requests:
+          avg: AVG(TCP_GL1_REQ_WRITE_sum / $denom)
+          min: MIN(TCP_GL1_REQ_WRITE_sum / $denom)
+          max: MAX(TCP_GL1_REQ_WRITE_sum / $denom)
+          unit: (Count + $normUnit)
+
+  # =========================================================================
+  # TCP Stalls
+  # =========================================================================
+  - metric_table:
+      id: 805
+      title: "TCP Stalls"
+      header:
+        metric: Metric
+        avg: Avg
+        min: Min
+        max: Max
+        unit: Unit
+      metric:
+        TA Req Stall:
+          avg: AVG(TCP_TCP_TA_REQ_STALL_sum / $denom)
+          min: MIN(TCP_TCP_TA_REQ_STALL_sum / $denom)
+          max: MAX(TCP_TCP_TA_REQ_STALL_sum / $denom)
+          unit: (Cycles + $normUnit)
+        GL1 Back Pressure:
+          avg: AVG(TCP_GL1_TCP_BACK_PRESSURE_sum / $denom)
+          min: MIN(TCP_GL1_TCP_BACK_PRESSURE_sum / $denom)
+          max: MAX(TCP_GL1_TCP_BACK_PRESSURE_sum / $denom)
+          unit: (Cycles + $normUnit)
+        Data FIFO Stall:
+          avg: AVG(TCP_DATA_FIFO_STALL_sum / $denom)
+          min: MIN(TCP_DATA_FIFO_STALL_sum / $denom)
+          max: MAX(TCP_DATA_FIFO_STALL_sum / $denom)
+          unit: (Cycles + $normUnit)
+
+  metrics_description:
+    TCP Busy: |-
+      Estimated TCP utilization: 100 × TCP_GATE_EN2 / (GRBM_GUI_ACTIVE × NUM_TCP), with
+      NUM_TCP = max(1, ⌊$cu_per_gpu / 2⌋) (one TCP per WGP, 2 CUs per WGP on RDNA3.5).
+      Uses aggregate TCP_GATE_EN2 (not TCP_GATE_EN2_sum). GRBM_GUI_ACTIVE is scaled by
+      NUM_TCP so the denominator matches multi-TCP capacity. GATE_EN2 is tcp_perf_sel_gate_en2
+      (core clocks on, not windowed). If only per-instance *_sum is available, align the
+      numerator/denominator with your CSV layout.
+    Total Requests: |-
+      Total number of requests to the TCP cache including reads, writes, and atomics.
+    Read Requests: |-
+      Number of read requests to the TCP cache.
+    Write Requests: |-
+      Number of write requests to the TCP cache.
+    Miss Requests: |-
+      Number of requests that missed in the TCP cache and required fetching from GL1C.
+    Hit Rate: |-
+      Percentage of TCP requests that hit in the cache.
+      Higher hit rates reduce traffic to GL1C and improve performance.
+    GL1 Read Requests: |-
+      Number of read requests sent from TCP to GL1C due to cache misses.
+    TA Req Stall: |-
+      Cycles TCP stalled the Texture Addresser request interface due to backpressure.
+    GL1 Back Pressure: |-
+      Cycles TCP was stalled due to back pressure from GL1C.

--- a/projects/rocprofiler-compute/src/rocprof_compute_soc/analysis_configs/gfx1151/1100_GL1C.yaml
+++ b/projects/rocprofiler-compute/src/rocprof_compute_soc/analysis_configs/gfx1151/1100_GL1C.yaml
@@ -1,0 +1,163 @@
+# =============================================================================
+# RDNA3.5 (gfx1151) - RDNA3.5 GL1C (L1 Cache) Performance Metrics
+# =============================================================================
+# GL1C is the shared L1 cache serving multiple WGPs within a Shader Engine
+# Cache hierarchy: TCP (L0) -> GL1C (L1) -> GL2C (L2)
+# =============================================================================
+
+Panel Config:
+  id: 1100
+  title: GL1 Cache (L1)
+  data source:
+  # =========================================================================
+  # GL1C Utilization
+  # =========================================================================
+  - metric_table:
+      id: 1101
+      title: "GL1C Utilization"
+      header:
+        metric: Metric
+        avg: Avg
+        min: Min
+        max: Max
+        unit: Unit
+      metric:
+        GL1C Busy:
+          avg: AVG((100 * GL1C_BUSY / GL1C_CYCLE) if (GL1C_CYCLE != 0) else None)
+          min: MIN((100 * GL1C_BUSY / GL1C_CYCLE) if (GL1C_CYCLE != 0) else None)
+          max: MAX((100 * GL1C_BUSY / GL1C_CYCLE) if (GL1C_CYCLE != 0) else None)
+          unit: Percent
+        GL1C Starve:
+          avg: AVG((100 * GL1C_STARVE / GL1C_CYCLE) if (GL1C_CYCLE != 0) else None)
+          min: MIN((100 * GL1C_STARVE / GL1C_CYCLE) if (GL1C_CYCLE != 0) else None)
+          max: MAX((100 * GL1C_STARVE / GL1C_CYCLE) if (GL1C_CYCLE != 0) else None)
+          unit: Percent
+
+  # =========================================================================
+  # GL1C Request Statistics
+  # =========================================================================
+  - metric_table:
+      id: 1102
+      title: "GL1C Request Statistics"
+      header:
+        metric: Metric
+        avg: Avg
+        min: Min
+        max: Max
+        unit: Unit
+      metric:
+        Total Requests:
+          avg: AVG(GL1C_REQ_sum / $denom)
+          min: MIN(GL1C_REQ_sum / $denom)
+          max: MAX(GL1C_REQ_sum / $denom)
+          unit: (Count + $normUnit)
+        Read Requests:
+          avg: AVG(GL1C_REQ_READ_sum / $denom)
+          min: MIN(GL1C_REQ_READ_sum / $denom)
+          max: MAX(GL1C_REQ_READ_sum / $denom)
+          unit: (Count + $normUnit)
+        Write Requests:
+          avg: AVG(GL1C_REQ_WRITE_sum / $denom)
+          min: MIN(GL1C_REQ_WRITE_sum / $denom)
+          max: MAX(GL1C_REQ_WRITE_sum / $denom)
+          unit: (Count + $normUnit)
+        Miss Requests:
+          avg: AVG(GL1C_REQ_MISS_sum / $denom)
+          min: MIN(GL1C_REQ_MISS_sum / $denom)
+          max: MAX(GL1C_REQ_MISS_sum / $denom)
+          unit: (Count + $normUnit)
+
+  # =========================================================================
+  # GL1C Cache Performance
+  # =========================================================================
+  - metric_table:
+      id: 1103
+      title: "GL1C Cache Performance"
+      header:
+        metric: Metric
+        avg: Avg
+        min: Min
+        max: Max
+        unit: Unit
+      metric:
+        Hit Rate:
+          avg: AVG((100 * (GL1C_REQ_sum - GL1C_REQ_MISS_sum) / GL1C_REQ_sum) if (GL1C_REQ_sum != 0) else None)
+          min: MIN((100 * (GL1C_REQ_sum - GL1C_REQ_MISS_sum) / GL1C_REQ_sum) if (GL1C_REQ_sum != 0) else None)
+          max: MAX((100 * (GL1C_REQ_sum - GL1C_REQ_MISS_sum) / GL1C_REQ_sum) if (GL1C_REQ_sum != 0) else None)
+          unit: Percent
+
+  # =========================================================================
+  # GL1C-GL2 Interface
+  # =========================================================================
+  - metric_table:
+      id: 1104
+      title: "GL1C-GL2 Interface"
+      header:
+        metric: Metric
+        avg: Avg
+        min: Min
+        max: Max
+        unit: Unit
+      metric:
+        GL2 Read Requests:
+          avg: AVG(GL1C_GL2_REQ_READ_sum / $denom)
+          min: MIN(GL1C_GL2_REQ_READ_sum / $denom)
+          max: MAX(GL1C_GL2_REQ_READ_sum / $denom)
+          unit: (Count + $normUnit)
+        GL2 Read 128B Requests:
+          avg: AVG(GL1C_GL2_REQ_READ_128B_sum / $denom)
+          min: MIN(GL1C_GL2_REQ_READ_128B_sum / $denom)
+          max: MAX(GL1C_GL2_REQ_READ_128B_sum / $denom)
+          unit: (Count + $normUnit)
+        GL2 Write Requests:
+          avg: AVG(GL1C_GL2_REQ_WRITE_sum / $denom)
+          min: MIN(GL1C_GL2_REQ_WRITE_sum / $denom)
+          max: MAX(GL1C_GL2_REQ_WRITE_sum / $denom)
+          unit: (Count + $normUnit)
+
+  # =========================================================================
+  # GL1C Stalls
+  # =========================================================================
+  - metric_table:
+      id: 1105
+      title: "GL1C Stalls"
+      header:
+        metric: Metric
+        avg: Avg
+        min: Min
+        max: Max
+        unit: Unit
+      metric:
+        GL2 Stall:
+          avg: AVG(GL1C_STALL_GL2_GL1_sum / $denom)
+          min: MIN(GL1C_STALL_GL2_GL1_sum / $denom)
+          max: MAX(GL1C_STALL_GL2_GL1_sum / $denom)
+          unit: (Cycles + $normUnit)
+        LFIFO Full Stall:
+          avg: AVG(GL1C_STALL_LFIFO_FULL_sum / $denom)
+          min: MIN(GL1C_STALL_LFIFO_FULL_sum / $denom)
+          max: MAX(GL1C_STALL_LFIFO_FULL_sum / $denom)
+          unit: (Cycles + $normUnit)
+
+  metrics_description:
+    GL1C Busy: |-
+      Percentage of cycles where the GL1C cache was busy processing requests.
+      GL1C is the shared L1 cache within each Shader Engine.
+      Per sample: 100 * GL1C_BUSY / GL1C_CYCLE (when GL1C_CYCLE != 0).
+    GL1C Starve: |-
+      Percentage of cycles where GL1C had no pending requests from TCP.
+      Per sample: 100 * GL1C_STARVE / GL1C_CYCLE (when GL1C_CYCLE != 0).
+    Total Requests: |-
+      Total number of requests to the GL1C cache from TCP.
+    Read Requests: |-
+      Number of read requests to the GL1C cache.
+    Write Requests: |-
+      Number of write requests to the GL1C cache.
+    Miss Requests: |-
+      Number of requests that missed in the GL1C cache.
+    Hit Rate: |-
+      Percentage of GL1C requests that hit in the cache.
+    GL2 Read Requests: |-
+      Number of read requests sent from GL1C to GL2C due to cache misses.
+    GL2 Stall: |-
+      Cycles GL1C was stalled due to backpressure from GL2C.

--- a/projects/rocprofiler-compute/src/rocprof_compute_soc/analysis_configs/gfx1151/1300_GL2C.yaml
+++ b/projects/rocprofiler-compute/src/rocprof_compute_soc/analysis_configs/gfx1151/1300_GL2C.yaml
@@ -1,0 +1,140 @@
+# =============================================================================
+# RDNA3.5 (gfx1151) - RDNA3.5 GL2C (L2 Cache) Performance Metrics
+# =============================================================================
+# GL2C is the last-level cache shared across the GPU
+# Cache hierarchy: TCP (L0) -> GL1C (L1) -> GL2C (L2) -> Memory
+# =============================================================================
+
+Panel Config:
+  id: 1300
+  title: GL2 Cache (L2)
+  data source:
+  # =========================================================================
+  # GL2C Cache Performance
+  # =========================================================================
+  - metric_table:
+      id: 1301
+      title: "GL2C Cache Performance"
+      header:
+        metric: Metric
+        avg: Avg
+        min: Min
+        max: Max
+        unit: Unit
+      metric:
+        GL2C Hit Rate:
+          avg: AVG((100 * GL2C_HIT_sum / (GL2C_HIT_sum + GL2C_MISS_sum)) if ((GL2C_HIT_sum + GL2C_MISS_sum) != 0) else None)
+          min: MIN((100 * GL2C_HIT_sum / (GL2C_HIT_sum + GL2C_MISS_sum)) if ((GL2C_HIT_sum + GL2C_MISS_sum) != 0) else None)
+          max: MAX((100 * GL2C_HIT_sum / (GL2C_HIT_sum + GL2C_MISS_sum)) if ((GL2C_HIT_sum + GL2C_MISS_sum) != 0) else None)
+          unit: Percent
+        GL2C Hits:
+          avg: AVG(GL2C_HIT_sum / $denom)
+          min: MIN(GL2C_HIT_sum / $denom)
+          max: MAX(GL2C_HIT_sum / $denom)
+          unit: (Count + $normUnit)
+        GL2C Misses:
+          avg: AVG(GL2C_MISS_sum / $denom)
+          min: MIN(GL2C_MISS_sum / $denom)
+          max: MAX(GL2C_MISS_sum / $denom)
+          unit: (Count + $normUnit)
+
+  # =========================================================================
+  # GL2C Request Statistics
+  # =========================================================================
+  - metric_table:
+      id: 1302
+      title: "GL2C Request Statistics"
+      header:
+        metric: Metric
+        avg: Avg
+        min: Min
+        max: Max
+        unit: Unit
+      metric:
+        Total Requests:
+          avg: AVG(GL2C_REQ_sum / $denom)
+          min: MIN(GL2C_REQ_sum / $denom)
+          max: MAX(GL2C_REQ_sum / $denom)
+          unit: (Count + $normUnit)
+        Read Requests:
+          avg: AVG(GL2C_READ_sum / $denom)
+          min: MIN(GL2C_READ_sum / $denom)
+          max: MAX(GL2C_READ_sum / $denom)
+          unit: (Count + $normUnit)
+        Write Requests:
+          avg: AVG(GL2C_WRITE_sum / $denom)
+          min: MIN(GL2C_WRITE_sum / $denom)
+          max: MAX(GL2C_WRITE_sum / $denom)
+          unit: (Count + $normUnit)
+        Atomic Requests:
+          avg: AVG(GL2C_ATOMIC_sum / $denom)
+          min: MIN(GL2C_ATOMIC_sum / $denom)
+          max: MAX(GL2C_ATOMIC_sum / $denom)
+          unit: (Count + $normUnit)
+        EA Read Requests (DRAM):
+          avg: AVG(GL2C_EA_RDREQ_DRAM_sum / $denom)
+          min: MIN(GL2C_EA_RDREQ_DRAM_sum / $denom)
+          max: MAX(GL2C_EA_RDREQ_DRAM_sum / $denom)
+          unit: (Count + $normUnit)
+        EA Write Requests (DRAM):
+          avg: AVG(GL2C_EA_WRREQ_DRAM_sum / $denom)
+          min: MIN(GL2C_EA_WRREQ_DRAM_sum / $denom)
+          max: MAX(GL2C_EA_WRREQ_DRAM_sum / $denom)
+          unit: (Count + $normUnit)
+
+  # =========================================================================
+  # GL2C Bandwidth
+  # =========================================================================
+  - metric_table:
+      id: 1303
+      title: "GL2C Bandwidth"
+      header:
+        metric: Metric
+        avg: Avg
+        min: Min
+        max: Max
+        unit: Unit
+      metric:
+        GL2C Read BW:
+          # 32/64/128 B read bins plus 96 B compressed reads; GL2C_EA_RDREQ_96B covers EA-side 96 B reads.
+          avg: AVG((GL2C_READ_32_REQ_sum*32 + GL2C_READ_64_REQ_sum*64 + GL2C_READ_128_REQ_sum*128 + GL2C_COMPRESSED_READ_96_REQ_sum*96) / ((End_Timestamp - Start_Timestamp) / 1e9))
+          min: MIN((GL2C_READ_32_REQ_sum*32 + GL2C_READ_64_REQ_sum*64 + GL2C_READ_128_REQ_sum*128 + GL2C_COMPRESSED_READ_96_REQ_sum*96) / ((End_Timestamp - Start_Timestamp) / 1e9))
+          max: MAX((GL2C_READ_32_REQ_sum*32 + GL2C_READ_64_REQ_sum*64 + GL2C_READ_128_REQ_sum*128 + GL2C_COMPRESSED_READ_96_REQ_sum*96) / ((End_Timestamp - Start_Timestamp) / 1e9))
+          unit: Bytes/s
+        GL2C Write BW:
+          # Note: GL2C write requests use 64B as the average transaction size.
+          avg: AVG((GL2C_WRITE_sum * 64) / ((End_Timestamp - Start_Timestamp) / 1e9))
+          min: MIN((GL2C_WRITE_sum * 64) / ((End_Timestamp - Start_Timestamp) / 1e9))
+          max: MAX((GL2C_WRITE_sum * 64) / ((End_Timestamp - Start_Timestamp) / 1e9))
+          unit: Bytes/s
+
+  metrics_description:
+    GL2C Hit Rate: |-
+      Percentage of GL2C requests that hit in the cache.
+      GL2C is the last-level cache before system memory.
+    GL2C Hits: |-
+      Number of requests that hit in the GL2C cache.
+    GL2C Misses: |-
+      Number of requests that missed in the GL2C cache and went to memory.
+    Total Requests: |-
+      Number of requests of all types to the GL2C cache (counter GL2C_REQ).
+      This is measured at the tag block (request path into GL2C tag / lookup).
+      Not guaranteed to equal Read + Write + Atomic; those use separate perf events and may omit or overlap
+      traffic relative to this aggregate.
+    Read Requests: |-
+      Number of read requests to the GL2C cache (GL2C_READ).
+    Write Requests: |-
+      Number of write requests to the GL2C cache (GL2C_WRITE).
+    Atomic Requests: |-
+      Number of atomic requests at the GL2C cache (GL2C_ATOMIC).
+    EA Read Requests (DRAM): |-
+      Number of GL2C/EA read requests destined for DRAM (memory controller).
+      gl2c_perf_sel_ea_rdreq_dram (GL2C_EA_RDREQ_DRAM). Reported values are summed over GL2C instances.
+    EA Write Requests (DRAM): |-
+      Number of GL2C/EA write requests destined for DRAM (memory controller).
+      gl2c_perf_sel_ea_wrreq_dram (GL2C_EA_WRREQ_DRAM). Reported values are summed over GL2C instances.
+    GL2C Read BW: |-
+      Read bandwidth from GL2C_READ_{32,64,128}_REQ byte accounting plus
+      GL2C_COMPRESSED_READ_96_REQ (96 B compressed reads). EA 96 B reads use GL2C_EA_RDREQ_96B.
+    GL2C Write BW: |-
+      Achieved write bandwidth at the GL2C level.

--- a/projects/rocprofiler-compute/src/rocprof_compute_soc/analysis_configs/gfx1151/1500_GCEA.yaml
+++ b/projects/rocprofiler-compute/src/rocprof_compute_soc/analysis_configs/gfx1151/1500_GCEA.yaml
@@ -1,0 +1,187 @@
+# =============================================================================
+# RDNA3.5 (gfx1151) - Graphics Core Efficiency Arbiter (GCEA) performance metrics
+# =============================================================================
+# GCEA (Graphics Core Efficiency Arbiter) interfaces to system memory (DRAM).
+# For APUs, this connects to system memory (DDR5/LPDDR5) instead of HBM
+# =============================================================================
+
+Panel Config:
+  id: 1500
+  title: Graphics Core Efficiency Arbiter (GCEA)
+  data source:
+  # =========================================================================
+  # GCEA DRAM (System Memory) Read Interface
+  # =========================================================================
+  - metric_table:
+      id: 1501
+      title: "DRAM Read Interface"
+      header:
+        metric: Metric
+        avg: Avg
+        min: Min
+        max: Max
+        unit: Unit
+      metric:
+        DRAM Read Requests:
+          avg: AVG(GCEA_RDRAM_REQ_PER_CLIGRP_sum / $denom)
+          min: MIN(GCEA_RDRAM_REQ_PER_CLIGRP_sum / $denom)
+          max: MAX(GCEA_RDRAM_REQ_PER_CLIGRP_sum / $denom)
+          unit: (Count + $normUnit)
+        DRAM Read Chained Requests:
+          avg: AVG(GCEA_RDRAM_CHAINED_REQ_PER_CLIGRP_sum / $denom)
+          min: MIN(GCEA_RDRAM_CHAINED_REQ_PER_CLIGRP_sum / $denom)
+          max: MAX(GCEA_RDRAM_CHAINED_REQ_PER_CLIGRP_sum / $denom)
+          unit: (Count + $normUnit)
+        DRAM Read Banks Active:
+          avg: AVG(GCEA_RDRAM_NUM_BANKS_VLD_sum / $denom)
+          min: MIN(GCEA_RDRAM_NUM_BANKS_VLD_sum / $denom)
+          max: MAX(GCEA_RDRAM_NUM_BANKS_VLD_sum / $denom)
+          unit: (Count + $normUnit)
+        DRAM Read Size (32B increments):
+          avg: AVG(GCEA_RDRAM_SIZE_REQ_sum / $denom)
+          min: MIN(GCEA_RDRAM_SIZE_REQ_sum / $denom)
+          max: MAX(GCEA_RDRAM_SIZE_REQ_sum / $denom)
+          unit: (Count + $normUnit)
+
+  # =========================================================================
+  # GCEA DRAM (System Memory) Write Interface
+  # =========================================================================
+  - metric_table:
+      id: 1502
+      title: "DRAM Write Interface"
+      header:
+        metric: Metric
+        avg: Avg
+        min: Min
+        max: Max
+        unit: Unit
+      metric:
+        DRAM Write Requests:
+          avg: AVG(GCEA_WDRAM_REQ_PER_CLIGRP_sum / $denom)
+          min: MIN(GCEA_WDRAM_REQ_PER_CLIGRP_sum / $denom)
+          max: MAX(GCEA_WDRAM_REQ_PER_CLIGRP_sum / $denom)
+          unit: (Count + $normUnit)
+        DRAM Write Chained Requests:
+          avg: AVG(GCEA_WDRAM_CHAINED_REQ_PER_CLIGRP_sum / $denom)
+          min: MIN(GCEA_WDRAM_CHAINED_REQ_PER_CLIGRP_sum / $denom)
+          max: MAX(GCEA_WDRAM_CHAINED_REQ_PER_CLIGRP_sum / $denom)
+          unit: (Count + $normUnit)
+        DRAM Write Banks Active:
+          avg: AVG(GCEA_WDRAM_NUM_BANKS_VLD_sum / $denom)
+          min: MIN(GCEA_WDRAM_NUM_BANKS_VLD_sum / $denom)
+          max: MAX(GCEA_WDRAM_NUM_BANKS_VLD_sum / $denom)
+          unit: (Count + $normUnit)
+        DRAM Write Size (32B increments):
+          avg: AVG(GCEA_WDRAM_SIZE_REQ_sum / $denom)
+          min: MIN(GCEA_WDRAM_SIZE_REQ_sum / $denom)
+          max: MAX(GCEA_WDRAM_SIZE_REQ_sum / $denom)
+          unit: (Count + $normUnit)
+
+  # =========================================================================
+  # GCEA Arbiter Statistics
+  # =========================================================================
+  - metric_table:
+      id: 1504
+      title: "System Arbiter (SARB)"
+      header:
+        metric: Metric
+        avg: Avg
+        min: Min
+        max: Max
+        unit: Unit
+      metric:
+        SARB Busy:
+          avg: AVG((100 * GCEA_SARB_BUSY / GCEA_ALWAYS_COUNT) if (GCEA_ALWAYS_COUNT != 0) else None)
+          min: MIN((100 * GCEA_SARB_BUSY / GCEA_ALWAYS_COUNT) if (GCEA_ALWAYS_COUNT != 0) else None)
+          max: MAX((100 * GCEA_SARB_BUSY / GCEA_ALWAYS_COUNT) if (GCEA_ALWAYS_COUNT != 0) else None)
+          unit: Percent
+        SARB Stalled:
+          avg: AVG((100 * GCEA_SARB_STALLED / GCEA_ALWAYS_COUNT) if (GCEA_ALWAYS_COUNT != 0) else None)
+          min: MIN((100 * GCEA_SARB_STALLED / GCEA_ALWAYS_COUNT) if (GCEA_ALWAYS_COUNT != 0) else None)
+          max: MAX((100 * GCEA_SARB_STALLED / GCEA_ALWAYS_COUNT) if (GCEA_ALWAYS_COUNT != 0) else None)
+          unit: Percent
+        SARB Starving:
+          avg: AVG((100 * GCEA_SARB_STARVING / GCEA_ALWAYS_COUNT) if (GCEA_ALWAYS_COUNT != 0) else None)
+          min: MIN((100 * GCEA_SARB_STARVING / GCEA_ALWAYS_COUNT) if (GCEA_ALWAYS_COUNT != 0) else None)
+          max: MAX((100 * GCEA_SARB_STARVING / GCEA_ALWAYS_COUNT) if (GCEA_ALWAYS_COUNT != 0) else None)
+          unit: Percent
+        SARB Total Requests:
+          avg: AVG(GCEA_SARB_REQ_PER_VC_sum / $denom)
+          min: MIN(GCEA_SARB_REQ_PER_VC_sum / $denom)
+          max: MAX(GCEA_SARB_REQ_PER_VC_sum / $denom)
+          unit: (Count + $normUnit)
+        SARB DRAM Requests:
+          avg: AVG(GCEA_SARB_DRAM_REQ_PER_VC_sum / $denom)
+          min: MIN(GCEA_SARB_DRAM_REQ_PER_VC_sum / $denom)
+          max: MAX(GCEA_SARB_DRAM_REQ_PER_VC_sum / $denom)
+          unit: (Count + $normUnit)
+
+  # =========================================================================
+  # GCEA Return Interface
+  # =========================================================================
+  - metric_table:
+      id: 1505
+      title: "Return Interface"
+      header:
+        metric: Metric
+        avg: Avg
+        min: Min
+        max: Max
+        unit: Unit
+      metric:
+        Read Returns:
+          avg: AVG(GCEA_RRET_VLD_sum / $denom)
+          min: MIN(GCEA_RRET_VLD_sum / $denom)
+          max: MAX(GCEA_RRET_VLD_sum / $denom)
+          unit: (Count + $normUnit)
+        Write Returns:
+          avg: AVG(GCEA_WRET_VLD_sum / $denom)
+          min: MIN(GCEA_WRET_VLD_sum / $denom)
+          max: MAX(GCEA_WRET_VLD_sum / $denom)
+          unit: (Count + $normUnit)
+        Probe Requests:
+          avg: AVG(GCEA_PRB_REQ_sum / $denom)
+          min: MIN(GCEA_PRB_REQ_sum / $denom)
+          max: MAX(GCEA_PRB_REQ_sum / $denom)
+          unit: (Count + $normUnit)
+
+  metrics_description:
+    DRAM Read Requests: |-
+      Number of read requests sent to system memory (DRAM) per client group.
+      RDNA3.5 uses DDR5/LPDDR5 system memory instead of HBM.
+    DRAM Read Chained Requests: |-
+      Number of chained (sequential) read request chains sent to DRAM.
+      Chained requests improve memory efficiency for sequential access patterns.
+    DRAM Read Banks Active: |-
+      Number of DRAM banks with pending read requests (saturates at 16).
+      More active banks indicate better memory parallelism.
+    DRAM Read Size (32B increments): |-
+      Total size of DRAM read requests in 32-byte increments.
+    DRAM Write Requests: |-
+      Number of write requests sent to system memory (DRAM) per client group.
+    DRAM Write Chained Requests: |-
+      Number of chained (sequential) write request chains sent to DRAM.
+    DRAM Write Banks Active: |-
+      Number of DRAM banks with pending write requests (saturates at 16).
+    DRAM Write Size (32B increments): |-
+      Total size of DRAM write requests in 32-byte increments.
+    SARB Busy: |-
+      Percentage of cycles the System Arbiter was actively processing requests.
+      Per sample: 100 * GCEA_SARB_BUSY / GCEA_ALWAYS_COUNT (when GCEA_ALWAYS_COUNT != 0).
+      GCEA_ALWAYS_COUNT is the cycle-count denominator for these percentages.
+    SARB Stalled: |-
+      Percentage of cycles the System Arbiter was stalled (has valid request but downstream not ready).
+      Per sample: 100 * GCEA_SARB_STALLED / GCEA_ALWAYS_COUNT (when GCEA_ALWAYS_COUNT != 0).
+    SARB Starving: |-
+      Percentage of cycles the System Arbiter was starving (no valid requests but downstream ready).
+      Per sample: 100 * GCEA_SARB_STARVING / GCEA_ALWAYS_COUNT (when GCEA_ALWAYS_COUNT != 0).
+    SARB Total Requests: |-
+      Total requests per virtual channel through the System Arbiter.
+    SARB DRAM Requests: |-
+      DRAM-bound requests per virtual channel through the System Arbiter.
+    Read Returns: |-
+      Number of read data returns from the external memory interface.
+    Write Returns: |-
+      Number of write acknowledgements from the external memory interface.
+    Probe Requests: |-
+      Number of probe-invalidate requests (cache coherency operations).

--- a/projects/rocprofiler-compute/src/rocprof_compute_soc/analysis_configs/gfx1151/1700_GRBM.yaml
+++ b/projects/rocprofiler-compute/src/rocprof_compute_soc/analysis_configs/gfx1151/1700_GRBM.yaml
@@ -1,0 +1,74 @@
+# =============================================================================
+# RDNA3.5 (gfx1151) - RDNA3.5 GRBM (Graphics Register Bus Manager) Metrics
+# =============================================================================
+# GRBM provides top-level GPU utilization metrics
+# =============================================================================
+
+Panel Config:
+  id: 1700
+  title: Graphics Register Bus Manager (GRBM)
+  data source:
+  # =========================================================================
+  # GPU Utilization
+  # =========================================================================
+  - metric_table:
+      id: 1701
+      title: "GPU Utilization"
+      header:
+        metric: Metric
+        avg: Avg
+        min: Min
+        max: Max
+        unit: Unit
+      metric:
+        GPU Busy:
+          avg: AVG((100 * GRBM_GUI_ACTIVE / GRBM_COUNT) if (GRBM_COUNT != 0) else None)
+          min: MIN((100 * GRBM_GUI_ACTIVE / GRBM_COUNT) if (GRBM_COUNT != 0) else None)
+          max: MAX((100 * GRBM_GUI_ACTIVE / GRBM_COUNT) if (GRBM_COUNT != 0) else None)
+          unit: Percent
+        CP Busy:
+          avg: AVG((100 * GRBM_CP_BUSY / GRBM_GUI_ACTIVE) if (GRBM_GUI_ACTIVE != 0) else None)
+          min: MIN((100 * GRBM_CP_BUSY / GRBM_GUI_ACTIVE) if (GRBM_GUI_ACTIVE != 0) else None)
+          max: MAX((100 * GRBM_CP_BUSY / GRBM_GUI_ACTIVE) if (GRBM_GUI_ACTIVE != 0) else None)
+          unit: Percent
+        GL2C Busy:
+          avg: AVG((100 * GRBM_GL2C_BUSY / GRBM_GUI_ACTIVE) if (GRBM_GUI_ACTIVE != 0) else None)
+          min: MIN((100 * GRBM_GL2C_BUSY / GRBM_GUI_ACTIVE) if (GRBM_GUI_ACTIVE != 0) else None)
+          max: MAX((100 * GRBM_GL2C_BUSY / GRBM_GUI_ACTIVE) if (GRBM_GUI_ACTIVE != 0) else None)
+          unit: Percent
+
+  # =========================================================================
+  # Shader Engine Utilization
+  # =========================================================================
+  - metric_table:
+      id: 1702
+      title: "Shader Engine Utilization"
+      header:
+        metric: Metric
+        avg: Avg
+        min: Min
+        max: Max
+        unit: Unit
+      metric:
+        TA Busy:
+          avg: AVG((100 * GRBM_TA_BUSY / GRBM_GUI_ACTIVE) if (GRBM_GUI_ACTIVE != 0) else None)
+          min: MIN((100 * GRBM_TA_BUSY / GRBM_GUI_ACTIVE) if (GRBM_GUI_ACTIVE != 0) else None)
+          max: MAX((100 * GRBM_TA_BUSY / GRBM_GUI_ACTIVE) if (GRBM_GUI_ACTIVE != 0) else None)
+          unit: Percent
+
+  metrics_description:
+    GPU Busy: |-
+      Percentage of time the GPU was actively processing work.
+      Per sample: 100 * GRBM_GUI_ACTIVE / GRBM_COUNT (when GRBM_COUNT != 0).
+      Avg / min / max are taken across samples.
+    CP Busy: |-
+      Percentage of GUI-active cycles the Command Processor was busy.
+      Per sample: 100 * GRBM_CP_BUSY / GRBM_GUI_ACTIVE (when GRBM_GUI_ACTIVE != 0).
+      CP handles kernel dispatch and command stream processing.
+    GL2C Busy: |-
+      Percentage of GUI-active cycles the GL2 Cache was busy.
+      Per sample: 100 * GRBM_GL2C_BUSY / GRBM_GUI_ACTIVE (when GRBM_GUI_ACTIVE != 0).
+      High utilization indicates memory-intensive workload.
+    TA Busy: |-
+      Percentage of GUI-active cycles the Texture Addresser was busy.
+      Per sample: 100 * GRBM_TA_BUSY / GRBM_GUI_ACTIVE (when GRBM_GUI_ACTIVE != 0).

--- a/projects/rocprofiler-compute/src/rocprof_compute_soc/analysis_configs/profiling_counter_grouping_policy.yaml
+++ b/projects/rocprofiler-compute/src/rocprof_compute_soc/analysis_configs/profiling_counter_grouping_policy.yaml
@@ -1,0 +1,52 @@
+# Copyright (c) Advanced Micro Devices, Inc.
+# SPDX-License-Identifier:  MIT
+# =============================================================================
+# Profiling counter grouping policy (same-bucket priority metric IDs)
+# =============================================================================
+# For each gpu_arch (see mi_gpu_spec.yaml), ``same_bucket_priority_metric_ids``
+# maps metric id token -> metadata. Keys are the metric ids used by the
+# allocator (e.g. filter strings like "2.1.3"); ``name`` matches the analysis
+# YAML metric label for that arch (documentation / review only — runtime uses
+# ids only).
+#
+# Semantics: listed metrics get coalescing tier 0 (packed before others).
+#
+# Use an empty mapping ``{}`` when an architecture has no extra policy.
+# =============================================================================
+
+architectures:
+  # CDNA / MI-class (no default same-bucket priority set here).
+  gfx908:
+    same_bucket_priority_metric_ids: {}
+
+  gfx90a:
+    same_bucket_priority_metric_ids: {}
+
+  gfx940:
+    same_bucket_priority_metric_ids: {}
+
+  gfx941:
+    same_bucket_priority_metric_ids: {}
+
+  gfx942:
+    same_bucket_priority_metric_ids: {}
+
+  gfx950:
+    same_bucket_priority_metric_ids: {}
+
+  # RDNA3.5 (gfx1151): throughput + cache hit-rate + GRBM utilization metrics
+  # that benefit from single-pass PMC grouping for stable formulas.
+  gfx1151:
+    same_bucket_priority_metric_ids:
+      # 2.1.3 = panel 200, table 201 (System Speed-of-Light), metric index 3.
+      "2.1.3":
+        name: "Wavefront Occupancy"
+      # 8.3.0 = panel 800, table 803 (TCP Cache Performance), metric index 0.
+      "8.3.0":
+        name: "Hit Rate (TCP Cache Performance)"
+      # 11.3.0 = panel 1100, table 1103 (GL1C Cache Performance), metric index 0.
+      "11.3.0":
+        name: "Hit Rate (GL1C Cache Performance)"
+      # 17.1.0 = panel 1700, table 1701 (GPU Utilization), metric index 0.
+      "17.1.0":
+        name: "GPU Busy"

--- a/projects/rocprofiler-compute/src/rocprof_compute_soc/profile_configs/sdk_config.yaml
+++ b/projects/rocprofiler-compute/src/rocprof_compute_soc/profile_configs/sdk_config.yaml
@@ -1,6 +1,4496 @@
 rocprofiler-sdk:
   counters-schema-version: 1
   counters:
+  - name: CPC_CPC_STAT_BUSY
+    description: CPC Busy.
+    properties: []
+    definitions:
+    - architectures:
+      - gfx1151
+      - gfx1152
+      - gfx90a
+      - gfx908
+      - gfx940
+      - gfx941
+      - gfx942
+      - gfx950
+      block: CPC
+      event: 25
+  - name: CPC_STAT_BUSY
+    description: CPC Busy.
+    properties: []
+    definitions:
+    - architectures:
+      - gfx1151
+      - gfx1152
+      block: CPC
+      event: 25
+  - name: CPC_CPC_STAT_IDLE
+    description: CPC Idle.
+    properties: []
+    definitions:
+    - architectures:
+      - gfx1151
+      - gfx1152
+      - gfx90a
+      - gfx908
+      - gfx940
+      - gfx941
+      - gfx942
+      - gfx950
+      block: CPC
+      event: 26
+  - name: CPC_STAT_IDLE
+    description: CPC Idle.
+    properties: []
+    definitions:
+    - architectures:
+      - gfx1151
+      - gfx1152
+      block: CPC
+      event: 26
+  - name: CPC_CPC_STAT_STALL
+    description: CPC Stalled.
+    properties: []
+    definitions:
+    - architectures:
+      - gfx1151
+      - gfx1152
+      - gfx90a
+      - gfx908
+      - gfx940
+      - gfx941
+      - gfx942
+      - gfx950
+      block: CPC
+      event: 27
+  - name: CPC_STAT_STALL
+    description: CPC Stalled.
+    properties: []
+    definitions:
+    - architectures:
+      - gfx1151
+      - gfx1152
+      block: CPC
+      event: 27
+  - name: CPC_CPC_TCIU_BUSY
+    description: CPC TCIU interface Busy.
+    properties: []
+    definitions:
+    - architectures:
+      - gfx1151
+      - gfx1152
+      - gfx90a
+      - gfx908
+      - gfx940
+      - gfx941
+      - gfx942
+      - gfx950
+      block: CPC
+      event: 28
+  - name: CPC_TCIU_BUSY
+    description: CPC TCIU interface Busy.
+    properties: []
+    definitions:
+    - architectures:
+      - gfx1151
+      - gfx1152
+      block: CPC
+      event: 28
+  - name: CPC_CPC_TCIU_IDLE
+    description: CPC TCIU interface Idle.
+    properties: []
+    definitions:
+    - architectures:
+      - gfx1151
+      - gfx1152
+      - gfx90a
+      - gfx908
+      - gfx940
+      - gfx941
+      - gfx942
+      - gfx950
+      block: CPC
+      event: 29
+  - name: CPC_CPC_UTCL2IU_BUSY
+    description: CPC UTCL2 interface Busy.
+    properties: []
+    definitions:
+    - architectures:
+      - gfx1151
+      - gfx1152
+      - gfx90a
+      - gfx908
+      - gfx940
+      - gfx941
+      - gfx942
+      - gfx950
+      block: CPC
+      event: 30
+  - name: CPC_UTCL2IU_BUSY
+    description: CPC UTCL2 interface Busy.
+    properties: []
+    definitions:
+    - architectures:
+      - gfx1151
+      - gfx1152
+      block: CPC
+      event: 30
+  - name: CPC_CPC_UTCL2IU_IDLE
+    description: CPC UTCL2 interface Idle.
+    properties: []
+    definitions:
+    - architectures:
+      - gfx1151
+      - gfx1152
+      - gfx90a
+      - gfx908
+      - gfx940
+      - gfx941
+      - gfx942
+      - gfx950
+      block: CPC
+      event: 31
+  - name: CPC_CPC_UTCL2IU_STALL
+    description: CPC UTCL2 interface Stalled waiting on Free, Tags or Translation.
+    properties: []
+    definitions:
+    - architectures:
+      - gfx1151
+      - gfx1152
+      - gfx90a
+      - gfx908
+      - gfx940
+      - gfx941
+      - gfx942
+      - gfx950
+      block: CPC
+      event: 32
+  - name: CPC_ME1_BUSY_FOR_PACKET_DECODE
+    description: Me1 busy for packet decode.
+    properties: []
+    definitions:
+    - architectures:
+      - gfx1151
+      - gfx1152
+      - gfx90a
+      - gfx908
+      - gfx940
+      - gfx941
+      - gfx942
+      - gfx950
+      block: CPC
+      event: 13
+  - name: CPC_ME1_DC0_SPI_BUSY
+    description: CPC Me1 Processor Busy.
+    properties: []
+    definitions:
+    - architectures:
+      - gfx1151
+      - gfx1152
+      - gfx90a
+      - gfx908
+      - gfx940
+      - gfx941
+      - gfx942
+      - gfx950
+      block: CPC
+      event: 33
+  - name: CPC_UTCL1_STALL_ON_TRANSLATION
+    description: One of the UTCL1s is stalled waiting on translation, XNACK or PENDING response.
+    properties: []
+    definitions:
+    - architectures:
+      - gfx1151
+      - gfx1152
+      - gfx90a
+      - gfx908
+      - gfx940
+      - gfx941
+      - gfx942
+      - gfx950
+      block: CPC
+      event: 24
+  - name: CPC_ALWAYS_COUNT
+    description: Always Count.
+    properties: []
+    definitions:
+    - architectures:
+      - gfx1151
+      - gfx1152
+      - gfx950
+      block: CPC
+      event: 0
+  - name: CPC_GCRIU_BUSY
+    description: ''
+    properties: []
+    definitions:
+    - architectures:
+      - gfx1151
+      - gfx1152
+      block: CPC
+      event: 35
+  - name: CPC_GUS_READ_REQUEST_SENT
+    description: ''
+    properties: []
+    definitions:
+    - architectures:
+      - gfx1151
+      - gfx1152
+      block: CPC
+      event: 51
+  - name: CPC_GUS_WRITE_REQUEST_SENT
+    description: ''
+    properties: []
+    definitions:
+    - architectures:
+      - gfx1151
+      - gfx1152
+      block: CPC
+      event: 50
+  - name: CPC_ME1_STALL_ON_DATA_FROM_ROQ
+    description: ''
+    properties: []
+    definitions:
+    - architectures:
+      - gfx1151
+      - gfx1152
+      block: CPC
+      event: 11
+  - name: CPC_ME1_STALL_WAIT_ON_MEM_READ
+    description: ''
+    properties: []
+    definitions:
+    - architectures:
+      - gfx1151
+      - gfx1152
+      block: CPC
+      event: 9
+  - name: CPC_ME1_STALL_WAIT_ON_MEM_WRITE
+    description: ''
+    properties: []
+    definitions:
+    - architectures:
+      - gfx1151
+      - gfx1152
+      block: CPC
+      event: 10
+  - name: CPC_ME1_STALL_WAIT_ON_RCIU_READY
+    description: ''
+    properties: []
+    definitions:
+    - architectures:
+      - gfx1151
+      - gfx1152
+      block: CPC
+      event: 6
+  - name: CPC_MEC_INSTR_CACHE_HIT
+    description: ''
+    properties: []
+    definitions:
+    - architectures:
+      - gfx1151
+      - gfx1152
+      block: CPC
+      event: 43
+  - name: CPC_MEC_INSTR_CACHE_MISS
+    description: ''
+    properties: []
+    definitions:
+    - architectures:
+      - gfx1151
+      - gfx1152
+      block: CPC
+      event: 44
+  - name: CPC_TCIU_READ_REQUEST_SENT
+    description: ''
+    properties: []
+    definitions:
+    - architectures:
+      - gfx1151
+      - gfx1152
+      block: CPC
+      event: 49
+  - name: CPC_TCIU_WRITE_REQUEST_SENT
+    description: ''
+    properties: []
+    definitions:
+    - architectures:
+      - gfx1151
+      - gfx1152
+      block: CPC
+      event: 48
+  - name: GCEA_ALWAYS_COUNT
+    description: ''
+    properties: []
+    definitions:
+    - architectures:
+      - gfx1151
+      - gfx1152
+      block: GCEA
+      event: 0
+  - name: GCEA_PRB_REQ
+    description: ''
+    properties: []
+    definitions:
+    - architectures:
+      - gfx1151
+      - gfx1152
+      block: GCEA
+      event: 68
+  - name: GCEA_RDRAM_CHAINED_REQ_PER_CLIGRP
+    description: ''
+    properties: []
+    definitions:
+    - architectures:
+      - gfx1151
+      - gfx1152
+      block: GCEA
+      event: 3
+  - name: GCEA_RDRAM_NUM_BANKS_VLD
+    description: ''
+    properties: []
+    definitions:
+    - architectures:
+      - gfx1151
+      - gfx1152
+      block: GCEA
+      event: 1
+  - name: GCEA_RDRAM_REQ_PER_CLIGRP
+    description: ''
+    properties: []
+    definitions:
+    - architectures:
+      - gfx1151
+      - gfx1152
+      block: GCEA
+      event: 2
+  - name: GCEA_RDRAM_SIZE_REQ
+    description: ''
+    properties: []
+    definitions:
+    - architectures:
+      - gfx1151
+      - gfx1152
+      block: GCEA
+      event: 77
+  - name: GCEA_RRET_VLD
+    description: ''
+    properties: []
+    definitions:
+    - architectures:
+      - gfx1151
+      - gfx1152
+      block: GCEA
+      event: 66
+  - name: GCEA_SARB_BUSY
+    description: ''
+    properties: []
+    definitions:
+    - architectures:
+      - gfx1151
+      - gfx1152
+      block: GCEA
+      event: 62
+  - name: GCEA_SARB_DRAM_REQ_PER_VC
+    description: ''
+    properties: []
+    definitions:
+    - architectures:
+      - gfx1151
+      - gfx1152
+      block: GCEA
+      event: 51
+  - name: GCEA_SARB_REQ_PER_VC
+    description: ''
+    properties: []
+    definitions:
+    - architectures:
+      - gfx1151
+      - gfx1152
+      block: GCEA
+      event: 50
+  - name: GCEA_SARB_STALLED
+    description: ''
+    properties: []
+    definitions:
+    - architectures:
+      - gfx1151
+      - gfx1152
+      block: GCEA
+      event: 63
+  - name: GCEA_SARB_STARVING
+    description: ''
+    properties: []
+    definitions:
+    - architectures:
+      - gfx1151
+      - gfx1152
+      block: GCEA
+      event: 64
+  - name: GCEA_WDRAM_CHAINED_REQ_PER_CLIGRP
+    description: ''
+    properties: []
+    definitions:
+    - architectures:
+      - gfx1151
+      - gfx1152
+      block: GCEA
+      event: 10
+  - name: GCEA_WDRAM_NUM_BANKS_VLD
+    description: ''
+    properties: []
+    definitions:
+    - architectures:
+      - gfx1151
+      - gfx1152
+      block: GCEA
+      event: 8
+  - name: GCEA_WDRAM_REQ_PER_CLIGRP
+    description: ''
+    properties: []
+    definitions:
+    - architectures:
+      - gfx1151
+      - gfx1152
+      block: GCEA
+      event: 9
+  - name: GCEA_WDRAM_SIZE_REQ
+    description: ''
+    properties: []
+    definitions:
+    - architectures:
+      - gfx1151
+      - gfx1152
+      block: GCEA
+      event: 78
+  - name: GCEA_WRET_VLD
+    description: ''
+    properties: []
+    definitions:
+    - architectures:
+      - gfx1151
+      - gfx1152
+      block: GCEA
+      event: 67
+  - name: GL1C_BUSY
+    description: ''
+    properties: []
+    definitions:
+    - architectures:
+      - gfx1151
+      - gfx1152
+      block: GL1C
+      event: 1
+  - name: GL1C_CYCLE
+    description: ''
+    properties: []
+    definitions:
+    - architectures:
+      - gfx1151
+      - gfx1152
+      block: GL1C
+      event: 0
+  - name: GL1C_GL2_REQ_READ_128B
+    description: ''
+    properties: []
+    definitions:
+    - architectures:
+      - gfx1151
+      - gfx1152
+      block: GL1C
+      event: 5
+  - name: GL1C_GL2_REQ_READ_32B
+    description: ''
+    properties: []
+    definitions:
+    - architectures:
+      - gfx1151
+      - gfx1152
+      block: GL1C
+      event: 6
+  - name: GL1C_GL2_REQ_READ_64B
+    description: ''
+    properties: []
+    definitions:
+    - architectures:
+      - gfx1151
+      - gfx1152
+      block: GL1C
+      event: 7
+  - name: GL1C_GL2_REQ_READ_LATENCY
+    description: ''
+    properties: []
+    definitions:
+    - architectures:
+      - gfx1151
+      - gfx1152
+      block: GL1C
+      event: 8
+  - name: GL1C_GL2_REQ_READ
+    description: ''
+    properties: []
+    definitions:
+    - architectures:
+      - gfx1151
+      - gfx1152
+      block: GL1C
+      event: 4
+  - name: GL1C_GL2_REQ_WRITE_32B
+    description: ''
+    properties: []
+    definitions:
+    - architectures:
+      - gfx1151
+      - gfx1152
+      block: GL1C
+      event: 10
+  - name: GL1C_GL2_REQ_WRITE_64B
+    description: ''
+    properties: []
+    definitions:
+    - architectures:
+      - gfx1151
+      - gfx1152
+      block: GL1C
+      event: 11
+  - name: GL1C_GL2_REQ_WRITE_LATENCY
+    description: ''
+    properties: []
+    definitions:
+    - architectures:
+      - gfx1151
+      - gfx1152
+      block: GL1C
+      event: 12
+  - name: GL1C_GL2_REQ_WRITE
+    description: ''
+    properties: []
+    definitions:
+    - architectures:
+      - gfx1151
+      - gfx1152
+      block: GL1C
+      event: 9
+  - name: GL1C_REQ_MISS
+    description: ''
+    properties: []
+    definitions:
+    - architectures:
+      - gfx1151
+      - gfx1152
+      block: GL1C
+      event: 18
+  - name: GL1C_REQ_READ
+    description: ''
+    properties: []
+    definitions:
+    - architectures:
+      - gfx1151
+      - gfx1152
+      block: GL1C
+      event: 21
+  - name: GL1C_REQ_WRITE
+    description: ''
+    properties: []
+    definitions:
+    - architectures:
+      - gfx1151
+      - gfx1152
+      block: GL1C
+      event: 28
+  - name: GL1C_REQ
+    description: ''
+    properties: []
+    definitions:
+    - architectures:
+      - gfx1151
+      - gfx1152
+      block: GL1C
+      event: 14
+  - name: GL1C_STALL_GL2_GL1
+    description: ''
+    properties: []
+    definitions:
+    - architectures:
+      - gfx1151
+      - gfx1152
+      block: GL1C
+      event: 31
+  - name: GL1C_STALL_LFIFO_FULL
+    description: ''
+    properties: []
+    definitions:
+    - architectures:
+      - gfx1151
+      - gfx1152
+      block: GL1C
+      event: 32
+  - name: GL1C_STARVE
+    description: ''
+    properties: []
+    definitions:
+    - architectures:
+      - gfx1151
+      - gfx1152
+      block: GL1C
+      event: 2
+  - name: GL2C_EA_RDREQ_128B
+    description: Number of 128-byte GL2C/EA read requests
+    properties: []
+    definitions:
+    - architectures:
+      - gfx1151
+      - gfx1152
+      - gfx10
+      - gfx1010
+      - gfx1030
+      - gfx1031
+      - gfx1032
+      - gfx11
+      - gfx1100
+      - gfx1101
+      - gfx1102
+      block: GL2C
+      event: 102
+    - architectures:
+      - gfx12
+      - gfx1200
+      - gfx1201
+      block: GL2C
+      event: 148
+  - name: GL2C_EA_RDREQ_32B
+    description: Number of 32-byte GL2C/EA read requests
+    properties: []
+    definitions:
+    - architectures:
+      - gfx1151
+      - gfx1152
+      - gfx10
+      - gfx1010
+      - gfx1030
+      - gfx1031
+      - gfx1032
+      - gfx11
+      - gfx1100
+      - gfx1101
+      - gfx1102
+      block: GL2C
+      event: 99
+    - architectures:
+      - gfx12
+      - gfx1200
+      - gfx1201
+      block: GL2C
+      event: 146
+  - name: GL2C_EA_RDREQ_64B
+    description: Number of 64-byte GL2C/EA read requests
+    properties: []
+    definitions:
+    - architectures:
+      - gfx1151
+      - gfx1152
+      - gfx10
+      - gfx1010
+      - gfx1030
+      - gfx1031
+      - gfx1032
+      - gfx11
+      - gfx1100
+      - gfx1101
+      - gfx1102
+      block: GL2C
+      event: 100
+    - architectures:
+      - gfx12
+      - gfx1200
+      - gfx1201
+      block: GL2C
+      event: 147
+  - name: GL2C_EA_RDREQ_96B
+    description: Number of 96-byte GL2C/EA read requests
+    properties: []
+    definitions:
+    - architectures:
+      - gfx1151
+      - gfx1152
+      - gfx10
+      - gfx1010
+      - gfx1030
+      - gfx1031
+      - gfx1032
+      - gfx11
+      - gfx1100
+      - gfx1101
+      - gfx1102
+      block: GL2C
+      event: 101
+  - name: GL2C_EA_WRREQ_64B
+    description: Number of 64-byte transactions going (64-byte write or CMPSWAP) over the TC_EA_wrreq interface.
+    properties: []
+    definitions:
+    - architectures:
+      - gfx1151
+      - gfx1152
+      - gfx10
+      - gfx1010
+      - gfx1030
+      - gfx1031
+      - gfx1032
+      - gfx11
+      - gfx1100
+      - gfx1101
+      - gfx1102
+      block: GL2C
+      event: 85
+    - architectures:
+      - gfx12
+      - gfx1200
+      - gfx1201
+      block: GL2C
+      event: 114
+  - name: GL2C_HIT
+    description: Number of cache hits
+    properties: []
+    definitions:
+    - architectures:
+      - gfx1151
+      - gfx1152
+      - gfx10
+      - gfx1010
+      - gfx1030
+      - gfx1031
+      - gfx1032
+      - gfx11
+      - gfx1100
+      - gfx1101
+      - gfx1102
+      block: GL2C
+      event: 42
+    - architectures:
+      - gfx12
+      - gfx1200
+      - gfx1201
+      block: GL2C
+      event: 41
+  - name: GL2C_MC_WRREQ
+    description: Number of transactions (either 32-byte or 64-byte) going over the GL2C_EA_wrreq interface. Atomics may travel
+      over the same interface and are generally classified as write requests. This does not include probe commands
+    properties: []
+    definitions:
+    - architectures:
+      - gfx1151
+      - gfx1152
+      - gfx10
+      - gfx1010
+      - gfx1030
+      - gfx1031
+      - gfx1032
+      - gfx11
+      - gfx1100
+      - gfx1101
+      - gfx1102
+      block: GL2C
+      event: 83
+  - name: GL2C_MC_WRREQ_STALL
+    description: Number of cycles a write request was stalled.
+    properties: []
+    definitions:
+    - architectures:
+      - gfx1151
+      - gfx1152
+      - gfx10
+      - gfx1010
+      - gfx1030
+      - gfx1031
+      - gfx1032
+      - gfx11
+      - gfx1100
+      - gfx1101
+      - gfx1102
+      block: GL2C
+      event: 88
+  - name: GL2C_MISS
+    description: Number of cache misses.  UC reads count as misses.
+    properties: []
+    definitions:
+    - architectures:
+      - gfx1151
+      - gfx1152
+      - gfx10
+      - gfx1010
+      - gfx1030
+      - gfx1031
+      - gfx1032
+      - gfx11
+      - gfx1100
+      - gfx1101
+      - gfx1102
+      block: GL2C
+      event: 43
+    - architectures:
+      - gfx12
+      - gfx1200
+      - gfx1201
+      block: GL2C
+      event: 42
+  - name: GL2C_ATOMIC
+    description: ''
+    properties: []
+    definitions:
+    - architectures:
+      - gfx1151
+      - gfx1152
+      block: GL2C
+      event: 8
+  - name: GL2C_BUSY
+    description: ''
+    properties: []
+    definitions:
+    - architectures:
+      - gfx1151
+      - gfx1152
+      block: GL2C
+      event: 2
+  - name: GL2C_COMPRESSED_READ_96_REQ
+    description: ''
+    properties: []
+    definitions:
+    - architectures:
+      - gfx1151
+      - gfx1152
+      block: GL2C
+      event: 81
+  - name: GL2C_CYCLE
+    description: ''
+    properties: []
+    definitions:
+    - architectures:
+      - gfx1151
+      - gfx1152
+      block: GL2C
+      event: 1
+  - name: GL2C_EA_RDREQ_DRAM
+    description: ''
+    properties: []
+    definitions:
+    - architectures:
+      - gfx1151
+      - gfx1152
+      block: GL2C
+      event: 110
+  - name: GL2C_EA_WRREQ_DRAM
+    description: ''
+    properties: []
+    definitions:
+    - architectures:
+      - gfx1151
+      - gfx1152
+      block: GL2C
+      event: 111
+  - name: GL2C_READ_128_REQ
+    description: ''
+    properties: []
+    definitions:
+    - architectures:
+      - gfx1151
+      - gfx1152
+      block: GL2C
+      event: 75
+  - name: GL2C_READ_32_REQ
+    description: ''
+    properties: []
+    definitions:
+    - architectures:
+      - gfx1151
+      - gfx1152
+      block: GL2C
+      event: 73
+  - name: GL2C_READ_64_REQ
+    description: ''
+    properties: []
+    definitions:
+    - architectures:
+      - gfx1151
+      - gfx1152
+      block: GL2C
+      event: 74
+  - name: GL2C_READ
+    description: ''
+    properties: []
+    definitions:
+    - architectures:
+      - gfx1151
+      - gfx1152
+      block: GL2C
+      event: 6
+  - name: GL2C_REQ
+    description: ''
+    properties: []
+    definitions:
+    - architectures:
+      - gfx1151
+      - gfx1152
+      block: GL2C
+      event: 3
+  - name: GL2C_WRITE
+    description: ''
+    properties: []
+    definitions:
+    - architectures:
+      - gfx1151
+      - gfx1152
+      block: GL2C
+      event: 7
+  - name: GRBM_COUNT
+    description: Tie High - Count Number of Clocks
+    properties: []
+    definitions:
+    - architectures:
+      - gfx1151
+      - gfx1152
+      - gfx10
+      - gfx1010
+      - gfx1030
+      - gfx1031
+      - gfx1032
+      - gfx11
+      - gfx1100
+      - gfx1101
+      - gfx1102
+      - gfx12
+      - gfx1200
+      - gfx1201
+      - gfx9
+      - gfx900
+      - gfx906
+      - gfx908
+      - gfx90a
+      - gfx940
+      - gfx941
+      - gfx942
+      - gfx950
+      block: GRBM
+      event: 0
+  - name: GRBM_CPC_BUSY
+    description: The Command Processor Compute (CPC) is busy.
+    properties: []
+    definitions:
+    - architectures:
+      - gfx1151
+      - gfx1152
+      - gfx90a
+      - gfx908
+      - gfx940
+      - gfx941
+      - gfx942
+      - gfx950
+      block: GRBM
+      event: 30
+  - name: GRBM_CPF_BUSY
+    description: The Command Processor Fetchers (CPF) is busy.
+    properties: []
+    definitions:
+    - architectures:
+      - gfx1151
+      - gfx1152
+      - gfx90a
+      - gfx908
+      - gfx940
+      - gfx941
+      - gfx942
+      - gfx950
+      block: GRBM
+      event: 31
+  - name: GRBM_CP_BUSY
+    description: Any of the Command Processor (CPG/CPC/CPF) blocks are busy.
+    properties: []
+    definitions:
+    - architectures:
+      - gfx1151
+      - gfx1152
+      - gfx10
+      - gfx1010
+      - gfx1030
+      - gfx1031
+      - gfx1032
+      - gfx90a
+      - gfx908
+      - gfx940
+      - gfx941
+      - gfx942
+      - gfx950
+      block: GRBM
+      event: 3
+  - name: GRBM_EA_BUSY
+    description: The Efficiency Arbiter (EA) block is busy.
+    properties: []
+    definitions:
+    - architectures:
+      - gfx1151
+      - gfx1152
+      - gfx10
+      - gfx1010
+      - gfx1030
+      - gfx1031
+      - gfx1032
+      - gfx90a
+      - gfx908
+      - gfx940
+      - gfx941
+      - gfx942
+      - gfx950
+      block: GRBM
+      event: 35
+  - name: GRBM_GDS_BUSY
+    description: The Global Data Share (GDS) is busy.
+    properties: []
+    definitions:
+    - architectures:
+      - gfx1151
+      - gfx1152
+      - gfx10
+      - gfx1010
+      - gfx1030
+      - gfx1031
+      - gfx1032
+      block: GRBM
+      event: 25
+  - name: GRBM_GL2C_BUSY
+    description: The GL2C block is busy.
+    properties: []
+    definitions:
+    - architectures:
+      - gfx1151
+      - gfx1152
+      block: GRBM
+      event: 40
+  - name: GRBM_GUI_ACTIVE
+    description: The GUI is Active
+    properties: []
+    definitions:
+    - architectures:
+      - gfx1151
+      - gfx1152
+      - gfx10
+      - gfx1010
+      - gfx1030
+      - gfx1031
+      - gfx1032
+      - gfx11
+      - gfx1100
+      - gfx1101
+      - gfx1102
+      - gfx12
+      - gfx1200
+      - gfx1201
+      - gfx9
+      - gfx900
+      - gfx906
+      - gfx908
+      - gfx90a
+      - gfx940
+      - gfx941
+      - gfx942
+      - gfx950
+      block: GRBM
+      event: 2
+  - name: GRBM_SPI_BUSY
+    description: Any of the Shader Pipe Interpolators (SPI) are busy in the shader engine(s).
+    properties: []
+    definitions:
+    - architectures:
+      - gfx1151
+      - gfx1152
+      - gfx10
+      - gfx1010
+      - gfx1030
+      - gfx1031
+      - gfx1032
+      - gfx90a
+      - gfx908
+      - gfx940
+      - gfx941
+      - gfx942
+      - gfx950
+      block: GRBM
+      event: 11
+  - name: GRBM_TA_BUSY
+    description: Any of the Texture Pipes (TA) are busy in the shader engine(s).
+    properties: []
+    definitions:
+    - architectures:
+      - gfx1151
+      - gfx1152
+      - gfx10
+      - gfx1010
+      - gfx1030
+      - gfx1031
+      - gfx1032
+      - gfx90a
+      - gfx908
+      - gfx940
+      - gfx941
+      - gfx942
+      - gfx950
+      block: GRBM
+      event: 13
+  - name: GRBM_UTCL2_BUSY
+    description: The Unified Translation Cache Level-2 (UTCL2) block is busy.
+    properties: []
+    definitions:
+    - architectures:
+      - gfx1151
+      - gfx1152
+      - gfx90a
+      - gfx908
+      - gfx940
+      - gfx941
+      - gfx942
+      - gfx950
+      block: GRBM
+      event: 34
+  - name: SPI_BUSY
+    description: ''
+    properties: []
+    definitions:
+    - architectures:
+      - gfx1151
+      - gfx1152
+      block: SPI
+      event: 283
+  - name: SPI_CSN_BUSY
+    description: Number of clocks with outstanding waves (SPI or SH). Requires SPI_DEBUG_CNTL.DEBUG_PIPE_SEL to select source,
+      DEBUG_PIPE_SEL = 1, source is CS1; DEBUG_PIPE_SEL = 2, source is CS2; DEBUG_PIPE_SEL = 3, source is CS3; default, source
+      is CS0;
+    properties: []
+    definitions:
+    - architectures:
+      - gfx1151
+      - gfx1152
+      block: SPI
+      event: 46
+    - architectures:
+      - gfx90a
+      - gfx908
+      - gfx940
+      - gfx941
+      - gfx942
+      - gfx950
+      block: SPI
+      event: 48
+  - name: SPI_CSN_NUM_THREADGROUPS
+    description: Number of threadgroups launched. Requires SPI_DEBUG_CNTL.DEBUG_PIPE_SEL to select source, DEBUG_PIPE_SEL
+      = 1, source is CS1; DEBUG_PIPE_SEL = 2, source is CS2; DEBUG_PIPE_SEL = 3, source is CS3; default, source is CS0;
+    properties: []
+    definitions:
+    - architectures:
+      - gfx1151
+      - gfx1152
+      block: SPI
+      event: 47
+    - architectures:
+      - gfx90a
+      - gfx908
+      - gfx940
+      - gfx941
+      - gfx942
+      - gfx950
+      block: SPI
+      event: 49
+  - name: SPI_CSN_WAVE
+    description: Number of waves. Requires SPI_DEBUG_CNTL.DEBUG_PIPE_SEL to select source, DEBUG_PIPE_SEL = 1, source is CS1;
+      DEBUG_PIPE_SEL = 2, source is CS2; DEBUG_PIPE_SEL = 3, source is CS3; default, source is CS0;
+    properties: []
+    definitions:
+    - architectures:
+      - gfx1151
+      - gfx1152
+      block: SPI
+      event: 50
+    - architectures:
+      - gfx90a
+      - gfx908
+      - gfx940
+      - gfx941
+      - gfx942
+      - gfx950
+      block: SPI
+      event: 52
+  - name: SPI_CSN_WINDOW_VALID
+    description: Clock count enabled by perfcounter_start event. Requires SPI_DEBUG_CNTL.DEBUG_PIPE_SEL to select source,
+      DEBUG_PIPE_SEL = 1, source is CS1; DEBUG_PIPE_SEL = 2, source is CS2; DEBUG_PIPE_SEL = 3, source is CS3; default, source
+      is CS0;
+    properties: []
+    definitions:
+    - architectures:
+      - gfx1151
+      - gfx1152
+      block: SPI
+      event: 45
+    - architectures:
+      - gfx90a
+      - gfx908
+      - gfx940
+      - gfx941
+      - gfx942
+      - gfx950
+      block: SPI
+      event: 47
+  - name: SPI_RA_BAR_CU_FULL_CSN
+    description: Sum of CU where BARRIER can't take csn wave when !fits. Source is RA0
+    properties: []
+    definitions:
+    - architectures:
+      - gfx1151
+      - gfx1152
+      block: SPI
+      event: 179
+    - architectures:
+      - gfx90a
+      - gfx908
+      - gfx940
+      - gfx941
+      - gfx942
+      - gfx950
+      block: SPI
+      event: 123
+  - name: SPI_RA_BULKY_CU_FULL_CSN
+    description: Sum of CU where BULKY can't take csn wave when !fits. Source is RA0
+    properties: []
+    definitions:
+    - architectures:
+      - gfx1151
+      - gfx1152
+      block: SPI
+      event: 181
+    - architectures:
+      - gfx90a
+      - gfx908
+      - gfx940
+      - gfx941
+      - gfx942
+      - gfx950
+      block: SPI
+      event: 125
+  - name: SPI_RA_LDS_CU_FULL_CSN
+    description: Sum of CU where LDS can't take csn wave when !fits. Source is RA0
+    properties: []
+    definitions:
+    - architectures:
+      - gfx1151
+      - gfx1152
+      block: SPI
+      event: 174
+    - architectures:
+      - gfx90a
+      - gfx908
+      - gfx940
+      - gfx941
+      - gfx942
+      - gfx950
+      block: SPI
+      event: 120
+  - name: SPI_RA_REQ_NO_ALLOC_CSN
+    description: Arb cycles with CSn req and no CSn alloc. Source is RA0
+    properties: []
+    definitions:
+    - architectures:
+      - gfx1151
+      - gfx1152
+      block: SPI
+      event: 149
+    - architectures:
+      - gfx90a
+      - gfx908
+      - gfx940
+      - gfx941
+      - gfx942
+      - gfx950
+      block: SPI
+      event: 85
+  - name: SPI_RA_REQ_NO_ALLOC
+    description: Arb cycles with requests but no allocation. Source is RA0
+    properties: []
+    definitions:
+    - architectures:
+      - gfx1151
+      - gfx1152
+      block: SPI
+      event: 144
+    - architectures:
+      - gfx90a
+      - gfx908
+      - gfx940
+      - gfx941
+      - gfx942
+      - gfx950
+      block: SPI
+      event: 79
+  - name: SPI_RA_RES_STALL_CSN
+    description: Arb cycles with CSn req and no CSn fits. Source is RA0
+    properties: []
+    definitions:
+    - architectures:
+      - gfx1151
+      - gfx1152
+      block: SPI
+      event: 154
+    - architectures:
+      - gfx90a
+      - gfx908
+      - gfx940
+      - gfx941
+      - gfx942
+      - gfx950
+      block: SPI
+      event: 91
+  - name: SPI_RA_TGLIM_CU_FULL_CSN
+    description: Cycles where csn wants to req but all CU are at tg_limit
+    properties: []
+    definitions:
+    - architectures:
+      - gfx1151
+      - gfx1152
+      block: SPI
+      event: 183
+    - architectures:
+      - gfx90a
+      - gfx908
+      - gfx940
+      - gfx941
+      - gfx942
+      - gfx950
+      block: SPI
+      event: 127
+  - name: SPI_RA_TMP_STALL_CSN
+    description: Cycles where csn wants to req but does not fit in temp space.
+    properties: []
+    definitions:
+    - architectures:
+      - gfx1151
+      - gfx1152
+      block: SPI
+      event: 159
+    - architectures:
+      - gfx90a
+      - gfx908
+      - gfx940
+      - gfx941
+      - gfx942
+      - gfx950
+      block: SPI
+      event: 97
+  - name: SPI_RA_VGPR_SIMD_FULL_CSN
+    description: Sum of SIMD where VGPR can't take csn wave when !fits. Source is RA0
+    properties: []
+    definitions:
+    - architectures:
+      - gfx1151
+      - gfx1152
+      block: SPI
+      event: 169
+    - architectures:
+      - gfx90a
+      - gfx908
+      - gfx940
+      - gfx941
+      - gfx942
+      - gfx950
+      block: SPI
+      event: 109
+  - name: SPI_RA_WAVE_SIMD_FULL_CSN
+    description: Sum of SIMD where WAVE can't take csn wave when !fits. Source is RA0
+    properties: []
+    definitions:
+    - architectures:
+      - gfx1151
+      - gfx1152
+      block: SPI
+      event: 164
+    - architectures:
+      - gfx90a
+      - gfx908
+      - gfx940
+      - gfx941
+      - gfx942
+      - gfx950
+      block: SPI
+      event: 103
+  - name: SPI_RA_WVLIM_STALL_CSN
+    description: Number of clocks csn is stalled due to WAVE LIMIT.
+    properties: []
+    definitions:
+    - architectures:
+      - gfx1151
+      - gfx1152
+      block: SPI
+      event: 188
+    - architectures:
+      - gfx90a
+      - gfx908
+      - gfx940
+      - gfx941
+      - gfx942
+      - gfx950
+      block: SPI
+      event: 133
+  - name: SQ_ACCUM_PREV
+    description: This is a hardware register that can be used for accumulating values for other counters. This is useful in
+      expressions where you want to integrate over time. Only accumulates once every 4 cycles. This counter is primarily for
+      use with derived counters supplied by rocprof.
+    properties: []
+    definitions:
+    - architectures:
+      - gfx1151
+      - gfx1152
+      - gfx10
+      - gfx1010
+      - gfx1030
+      - gfx1031
+      - gfx1032
+      - gfx11
+      - gfx1100
+      - gfx1101
+      - gfx1102
+      - gfx12
+      - gfx1200
+      - gfx1201
+      - gfx90a
+      - gfx908
+      - gfx940
+      - gfx941
+      - gfx942
+      - gfx950
+      block: SQ
+      event: 1
+  - name: SQ_BUSY_CYCLES
+    description: Number of clock cycles there are active waves in a shader engine (as reported by the distributed sequencer).
+      This value does not denote the number of active waves, only the clock cycle in which any wave is present in a SE. This
+      value is returned on a per-shader engine basis in clock cycles.
+    properties: []
+    definitions:
+    - architectures:
+      - gfx1151
+      - gfx1152
+      - gfx10
+      - gfx1010
+      - gfx1030
+      - gfx1031
+      - gfx1032
+      - gfx11
+      - gfx1100
+      - gfx1101
+      - gfx1102
+      - gfx12
+      - gfx1200
+      - gfx1201
+      - gfx90a
+      - gfx908
+      - gfx940
+      - gfx941
+      - gfx942
+      - gfx950
+      block: SQ
+      event: 3
+  - name: SQ_CYCLES
+    description: Clock cycles. Value is returned per-SIMD.
+    properties: []
+    definitions:
+    - architectures:
+      - gfx1151
+      - gfx1152
+      - gfx90a
+      - gfx908
+      - gfx940
+      - gfx941
+      - gfx942
+      - gfx950
+      block: SQ
+      event: 2
+  - name: SQ_INSTS_FLAT
+    description: Total number of FLAT instructions issued. When used in combination with SQ_ACTIVE_INST_FLAT (cycle count
+      for executing instructions) the average latency of FLAT instruction execution can be calculated (SQ_ACTIVE_INST_FLAT
+      / SQ_INSTS). This value is returned per-SE (aggregate of values in SIMDs in the SE).
+    properties: []
+    definitions:
+    - architectures:
+      - gfx1151
+      - gfx1152
+      - gfx11
+      - gfx1100
+      - gfx1101
+      - gfx1102
+      block: SQ
+      event: 56
+    - architectures:
+      - gfx10
+      - gfx1010
+      - gfx1030
+      - gfx1031
+      - gfx1032
+      block: SQ
+      event: 57
+    - architectures:
+      - gfx9
+      - gfx900
+      - gfx906
+      block: SQ
+      event: 32
+    - architectures:
+      - gfx908
+      block: SQ
+      event: 33
+    - architectures:
+      - gfx90a
+      block: SQ
+      event: 58
+    - architectures:
+      - gfx940
+      - gfx941
+      - gfx942
+      block: SQ
+      event: 62
+    - architectures:
+      - gfx12
+      - gfx1200
+      - gfx1201
+      block: SQ
+      event: 44
+    - architectures:
+      - gfx950
+      block: SQ
+      event: 64
+  - name: SQ_INSTS_GDS
+    description: Total number of GDS (global data sync) instructions issued. This value is returned per-SE (aggregate of values
+      in SIMDs in the SE). See AMD ISAs for more information on GDS (global data sync) instructions.
+    properties: []
+    definitions:
+    - architectures:
+      - gfx1151
+      - gfx1152
+      - gfx11
+      - gfx1100
+      - gfx1101
+      - gfx1102
+      block: SQ
+      event: 54
+    - architectures:
+      - gfx10
+      - gfx1010
+      - gfx1030
+      - gfx1031
+      - gfx1032
+      block: SQ
+      event: 55
+    - architectures:
+      - gfx9
+      - gfx900
+      - gfx906
+      block: SQ
+      event: 35
+    - architectures:
+      - gfx908
+      block: SQ
+      event: 36
+    - architectures:
+      - gfx90a
+      block: SQ
+      event: 61
+    - architectures:
+      - gfx940
+      - gfx941
+      - gfx942
+      block: SQ
+      event: 66
+    - architectures:
+      - gfx950
+      block: SQ
+      event: 68
+  - name: SQ_INSTS_LDS
+    description: Total number of LDS instructions issued (including FLAT). This value is returned per-SE (aggregate of values
+      in SIMDs in the SE). See AMD ISAs for more information on LDS instructions.
+    properties: []
+    definitions:
+    - architectures:
+      - gfx1151
+      - gfx1152
+      - gfx11
+      - gfx1100
+      - gfx1101
+      - gfx1102
+      block: SQ
+      event: 57
+    - architectures:
+      - gfx10
+      - gfx1010
+      - gfx1030
+      - gfx1031
+      - gfx1032
+      block: SQ
+      event: 59
+    - architectures:
+      - gfx9
+      - gfx900
+      - gfx906
+      block: SQ
+      event: 34
+    - architectures:
+      - gfx908
+      block: SQ
+      event: 35
+    - architectures:
+      - gfx90a
+      block: SQ
+      event: 60
+    - architectures:
+      - gfx940
+      - gfx941
+      - gfx942
+      block: SQ
+      event: 65
+    - architectures:
+      - gfx12
+      - gfx1200
+      - gfx1201
+      block: SQ
+      event: 45
+    - architectures:
+      - gfx950
+      block: SQ
+      event: 67
+  - name: SQ_INSTS_SALU
+    description: Total Number of SALU (Scalar ALU) instructions issued. This value is returned per-SE (aggregate of values
+      in SIMDs in the SE). See AMD ISAs for more information on SALU instructions.
+    properties: []
+    definitions:
+    - architectures:
+      - gfx1151
+      - gfx1152
+      - gfx11
+      - gfx1100
+      - gfx1101
+      - gfx1102
+      block: SQ
+      event: 58
+    - architectures:
+      - gfx9
+      - gfx900
+      - gfx906
+      block: SQ
+      event: 30
+    - architectures:
+      - gfx908
+      block: SQ
+      event: 31
+    - architectures:
+      - gfx90a
+      block: SQ
+      event: 56
+    - architectures:
+      - gfx10
+      - gfx1010
+      - gfx1030
+      - gfx1031
+      - gfx1032
+      - gfx940
+      - gfx941
+      - gfx942
+      block: SQ
+      event: 60
+    - architectures:
+      - gfx12
+      - gfx1200
+      - gfx1201
+      block: SQ
+      event: 46
+    - architectures:
+      - gfx950
+      block: SQ
+      event: 62
+  - name: SQ_INSTS_SMEM
+    description: Total number of SMEM (Scalar Memory Read) instructions issued. This value is returned per-SE (aggregate of
+      values in SIMDs in the SE). See AMD ISAs for more information on SMEM instructions.
+    properties: []
+    definitions:
+    - architectures:
+      - gfx1151
+      - gfx1152
+      - gfx11
+      - gfx1100
+      - gfx1101
+      - gfx1102
+      block: SQ
+      event: 59
+    - architectures:
+      - gfx9
+      - gfx900
+      - gfx906
+      block: SQ
+      event: 31
+    - architectures:
+      - gfx908
+      block: SQ
+      event: 32
+    - architectures:
+      - gfx90a
+      block: SQ
+      event: 57
+    - architectures:
+      - gfx10
+      - gfx1010
+      - gfx1030
+      - gfx1031
+      - gfx1032
+      - gfx940
+      - gfx941
+      - gfx942
+      block: SQ
+      event: 61
+    - architectures:
+      - gfx12
+      - gfx1200
+      - gfx1201
+      block: SQ
+      event: 47
+    - architectures:
+      - gfx950
+      block: SQ
+      event: 63
+  - name: SQ_INSTS_TEX_LOAD
+    description: The number of buffer load, image load, sample, or atomic (with return) texture instructions issued. The value
+      is returned per-SE (aggregate of values in SIMDs in the SE). See AMD ISAs for more information on TEX_LOAD instructions.
+    properties: []
+    definitions:
+    - architectures:
+      - gfx1151
+      - gfx1152
+      - gfx11
+      - gfx1100
+      - gfx1101
+      - gfx1102
+      block: SQ
+      event: 66
+    - architectures:
+      - gfx12
+      - gfx1200
+      - gfx1201
+      block: SQ
+      event: 54
+  - name: SQ_INSTS_TEX_STORE
+    description: The number of buffer store, image store, or atomic (without return) texture instructions issued. The value
+      is returned per-SE (aggregate of values in SIMDs in the SE). See AMD ISAs for more information on TEX_STORE instructions.
+    properties: []
+    definitions:
+    - architectures:
+      - gfx1151
+      - gfx1152
+      - gfx11
+      - gfx1100
+      - gfx1101
+      - gfx1102
+      block: SQ
+      event: 67
+    - architectures:
+      - gfx12
+      - gfx1200
+      - gfx1201
+      block: SQ
+      event: 55
+  - name: SQ_INSTS_VALU
+    description: The number of VALU (Vector ALU) instructions issued. The value is returned per-SE (aggregate of values in
+      SIMDs in the SE). See AMD ISAs for more information on VALU instructions.
+    properties: []
+    definitions:
+    - architectures:
+      - gfx1151
+      - gfx1152
+      - gfx11
+      - gfx1100
+      - gfx1101
+      - gfx1102
+      block: SQ
+      event: 62
+    - architectures:
+      - gfx10
+      - gfx1010
+      - gfx1030
+      - gfx1031
+      - gfx1032
+      block: SQ
+      event: 64
+    - architectures:
+      - gfx9
+      - gfx900
+      - gfx906
+      - gfx908
+      - gfx90a
+      - gfx940
+      - gfx941
+      - gfx942
+      - gfx950
+      block: SQ
+      event: 26
+    - architectures:
+      - gfx12
+      - gfx1200
+      - gfx1201
+      block: SQ
+      event: 50
+  - name: SQ_INST_LEVEL_LDS
+    description: Level count number of in-flight LDS instructions. This value represents the number of instructions each wave
+      spends executing instructions accessing the local data store (data shared between SIMDs on the same CU). Set next counter
+      to ACCUM_PREV and divide by INSTS_LDS for average latency. Includes FLAT instructions. This value is returned on a per-SE
+      (aggregate of values in SIMDs in the SE) basis.
+    properties: []
+    definitions:
+    - architectures:
+      - gfx1151
+      - gfx1152
+      - gfx11
+      - gfx1100
+      - gfx1101
+      - gfx1102
+      block: SQ
+      event: 88
+    - architectures:
+      - gfx10
+      - gfx1010
+      - gfx1030
+      - gfx1031
+      - gfx1032
+      block: SQ
+      event: 99
+    - architectures:
+      - gfx90a
+      block: SQ
+      event: 69
+    - architectures:
+      - gfx908
+      block: SQ
+      event: 44
+    - architectures:
+      - gfx940
+      - gfx941
+      - gfx942
+      block: SQ
+      event: 74
+    - architectures:
+      - gfx12
+      - gfx1200
+      - gfx1201
+      block: SQ
+      event: 75
+    - architectures:
+      - gfx950
+      block: SQ
+      event: 90
+  - name: SQ_INST_LEVEL_SMEM
+    description: Level count number of in-flight SMEM instructions (*2 load/store; *2 atomic; *2 memtime; *4 wb/inv). Set
+      next counter to ACCUM_PREV and divide by INSTS_SMEM for average latency per smem request. Falls slightly short of total
+      request latency because some fetches are divided into two requests that may finish at different times and this counter
+      collects the average latency of the two. This value is returned on a per-SE (aggregate of values in SIMDs in the SE)
+      basis.
+    properties: []
+    definitions:
+    - architectures:
+      - gfx1151
+      - gfx1152
+      - gfx950
+      block: SQ
+      event: 89
+    - architectures:
+      - gfx90a
+      block: SQ
+      event: 68
+    - architectures:
+      - gfx908
+      block: SQ
+      event: 43
+    - architectures:
+      - gfx940
+      - gfx941
+      - gfx942
+      block: SQ
+      event: 73
+  - name: SQ_LDS_ATOMIC_RETURN
+    description: The number of atomic return cycles in LDS (local data store). This value is returned on a per-SE (aggregate
+      of values in SIMDs in the SE) basis.
+    properties: []
+    definitions:
+    - architectures:
+      - gfx1151
+      - gfx1152
+      block: SQ
+      event: 260
+    - architectures:
+      - gfx90a
+      block: SQ
+      event: 125
+    - architectures:
+      - gfx908
+      block: SQ
+      event: 98
+    - architectures:
+      - gfx940
+      - gfx941
+      - gfx942
+      block: SQ
+      event: 130
+    - architectures:
+      - gfx950
+      block: SQ
+      event: 146
+  - name: SQ_LDS_BANK_CONFLICT
+    description: The number of cycles LDS (local data store) is stalled by bank conflicts. This value is returned on a per-SE
+      (aggregate of values in SIMDs in the SE) basis.
+    properties: []
+    definitions:
+    - architectures:
+      - gfx1151
+      - gfx1152
+      block: SQ
+      event: 256
+    - architectures:
+      - gfx9
+      - gfx900
+      - gfx906
+      block: SQ
+      event: 93
+    - architectures:
+      - gfx908
+      block: SQ
+      event: 94
+    - architectures:
+      - gfx90a
+      block: SQ
+      event: 121
+    - architectures:
+      - gfx940
+      - gfx941
+      - gfx942
+      block: SQ
+      event: 126
+    - architectures:
+      - gfx950
+      block: SQ
+      event: 142
+  - name: SQ_LDS_IDX_ACTIVE
+    description: Number of cycles LDS (local data store) is used for indexed (non-direct,non-interpolation) operations. This
+      value is returned on a per-SE (aggregate of values in SIMDs in the SE) basis.
+    properties: []
+    definitions:
+    - architectures:
+      - gfx1151
+      - gfx1152
+      block: SQ
+      event: 261
+    - architectures:
+      - gfx90a
+      block: SQ
+      event: 126
+    - architectures:
+      - gfx908
+      block: SQ
+      event: 99
+    - architectures:
+      - gfx940
+      - gfx941
+      - gfx942
+      block: SQ
+      event: 131
+    - architectures:
+      - gfx950
+      block: SQ
+      event: 147
+  - name: SQ_LDS_MEM_VIOLATIONS
+    description: Number of threads that have a memory violation in the LDS (local data store). This value is returned on a
+      per-SE (aggregate of values in SIMDs in the SE) basis.
+    properties: []
+    definitions:
+    - architectures:
+      - gfx1151
+      - gfx1152
+      block: SQ
+      event: 259
+    - architectures:
+      - gfx90a
+      block: SQ
+      event: 124
+    - architectures:
+      - gfx908
+      block: SQ
+      event: 97
+    - architectures:
+      - gfx940
+      - gfx941
+      - gfx942
+      block: SQ
+      event: 129
+    - architectures:
+      - gfx950
+      block: SQ
+      event: 145
+  - name: SQ_LDS_UNALIGNED_STALL
+    description: Number of cycles LDS (local data store) is stalled processing flat unaligned load/store ops. This value is
+      returned on a per-SE (aggregate of values in SIMDs in the SE) basis.
+    properties: []
+    definitions:
+    - architectures:
+      - gfx1151
+      - gfx1152
+      block: SQ
+      event: 258
+    - architectures:
+      - gfx90a
+      block: SQ
+      event: 123
+    - architectures:
+      - gfx908
+      block: SQ
+      event: 96
+    - architectures:
+      - gfx940
+      - gfx941
+      - gfx942
+      block: SQ
+      event: 128
+    - architectures:
+      - gfx950
+      block: SQ
+      event: 144
+  - name: SQ_LEVEL_WAVES
+    description: Level count number of waves. Set ACCUM_PREV for the next counter to use this. This value is returned on a
+      per-SIMD basis.
+    properties: []
+    definitions:
+    - architectures:
+      - gfx1151
+      - gfx1152
+      - gfx10
+      - gfx1010
+      - gfx1030
+      - gfx1031
+      - gfx1032
+      block: SQ
+      event: 7
+    - architectures:
+      - gfx90a
+      - gfx908
+      - gfx940
+      - gfx941
+      - gfx942
+      - gfx950
+      block: SQ
+      event: 5
+  - name: SQ_WAIT_ANY
+    description: Number of wave-cycles spent waiting for anything (per-simd, nondeterministic). Units in quad-cycles(4 cycles)
+    properties: []
+    definitions:
+    - architectures:
+      - gfx1151
+      - gfx1152
+      - gfx11
+      - gfx1100
+      - gfx1101
+      - gfx1102
+      block: SQ
+      event: 35
+    - architectures:
+      - gfx10
+      - gfx1010
+      - gfx1030
+      - gfx1031
+      - gfx1032
+      block: SQ
+      event: 37
+    - architectures:
+      - gfx90a
+      block: SQ
+      event: 85
+    - architectures:
+      - gfx908
+      block: SQ
+      event: 58
+    - architectures:
+      - gfx940
+      - gfx941
+      - gfx942
+      block: SQ
+      event: 90
+    - architectures:
+      - gfx12
+      - gfx1200
+      - gfx1201
+      block: SQ
+      event: 27
+    - architectures:
+      - gfx950
+      block: SQ
+      event: 106
+  - name: SQ_WAIT_INST_ANY
+    description: Number of wave-cycles spent waiting for any instruction issue. Units in quad-cycles(4 cycles).
+    properties: []
+    definitions:
+    - architectures:
+      - gfx1151
+      - gfx1152
+      - gfx11
+      - gfx1100
+      - gfx1101
+      - gfx1102
+      - gfx12
+      - gfx1200
+      - gfx1201
+      block: SQ
+      event: 26
+    - architectures:
+      - gfx10
+      - gfx1010
+      - gfx1030
+      - gfx1031
+      - gfx1032
+      block: SQ
+      event: 28
+    - architectures:
+      - gfx90a
+      block: SQ
+      event: 88
+    - architectures:
+      - gfx908
+      block: SQ
+      event: 61
+    - architectures:
+      - gfx940
+      - gfx941
+      - gfx942
+      block: SQ
+      event: 93
+    - architectures:
+      - gfx950
+      block: SQ
+      event: 109
+  - name: SQ_WAIT_INST_LDS
+    description: Number of wave-cycles spent waiting for LDS instruction issue. In units of 4 cycles. (per-simd, nondeterministic)
+    properties: []
+    definitions:
+    - architectures:
+      - gfx1151
+      - gfx1152
+      - gfx11
+      - gfx1100
+      - gfx1101
+      - gfx1102
+      block: SQ
+      event: 29
+    - architectures:
+      - gfx10
+      - gfx1010
+      - gfx1030
+      - gfx1031
+      - gfx1032
+      block: SQ
+      event: 31
+    - architectures:
+      - gfx9
+      - gfx900
+      - gfx906
+      block: SQ
+      event: 63
+    - architectures:
+      - gfx908
+      block: SQ
+      event: 64
+    - architectures:
+      - gfx90a
+      block: SQ
+      event: 91
+    - architectures:
+      - gfx940
+      - gfx941
+      - gfx942
+      block: SQ
+      event: 96
+    - architectures:
+      - gfx950
+      block: SQ
+      event: 112
+  - name: SQ_WAVES
+    description: Count number of waves sent to distributed sequencers (SQs). This value represents the number of waves that
+      are sent to each SQ. This only counts new waves sent since the start of collection (for dispatch profiling this is the
+      timeframe of kernel execution, for agent profiling it is the timeframe between start_context and read counter data).
+      A sum of all SQ_WAVES values will give the total number of waves started by the application during the collection timeframe.
+      Returns one value per-SE (aggregates of SIMD values).
+    properties: []
+    definitions:
+    - architectures:
+      - gfx1151
+      - gfx1152
+      - gfx10
+      - gfx1010
+      - gfx1030
+      - gfx1031
+      - gfx1032
+      - gfx11
+      - gfx1100
+      - gfx1101
+      - gfx1102
+      - gfx12
+      - gfx1200
+      - gfx1201
+      - gfx9
+      - gfx900
+      - gfx906
+      - gfx908
+      - gfx90a
+      - gfx940
+      - gfx941
+      - gfx942
+      - gfx950
+      block: SQ
+      event: 4
+  - name: SQ_WAVE_CYCLES
+    description: The cycles spent executing waves in the CUs. This value is reported per-SE (aggregates of SIMD values) and
+      is nondeterministic. Units are in quad-cycles (4 cycles). Useful for determining how much time is spent executing wave
+      code vs overhead/waiting. Low cycle count relative to actual number of cycles processed by the CU can indicate that
+      the CU is stalling or is overloaded.
+    properties: []
+    definitions:
+    - architectures:
+      - gfx1151
+      - gfx1152
+      - gfx11
+      - gfx1100
+      - gfx1101
+      - gfx1102
+      - gfx12
+      - gfx1200
+      - gfx1201
+      block: SQ
+      event: 24
+    - architectures:
+      - gfx10
+      - gfx1010
+      - gfx1030
+      - gfx1031
+      - gfx1032
+      block: SQ
+      event: 26
+    - architectures:
+      - gfx90a
+      block: SQ
+      event: 74
+    - architectures:
+      - gfx908
+      block: SQ
+      event: 47
+    - architectures:
+      - gfx940
+      - gfx941
+      - gfx942
+      block: SQ
+      event: 79
+    - architectures:
+      - gfx950
+      block: SQ
+      event: 95
+  - name: SQ_EVENTS
+    description: Number of events. (unwindowed, emulated, global)
+    properties: []
+    definitions:
+    - architectures:
+      - gfx1151
+      - gfx1152
+      block: SQ
+      event: 12
+    - architectures:
+      - gfx950
+      block: SQ
+      event: 16
+  - name: SQ_INST_CYCLES_LDS
+    description: ''
+    properties: []
+    definitions:
+    - architectures:
+      - gfx1151
+      - gfx1152
+      block: SQ
+      event: 109
+  - name: SQ_INST_CYCLES_VALU
+    description: Number of cycles needed to execute VALU operations (SIMD cycles), where there is overlapping V_OP32_1 and
+      V_OP32_T instruction, count them seperately.
+    properties: []
+    definitions:
+    - architectures:
+      - gfx1151
+      - gfx1152
+      block: SQ
+      event: 103
+    - architectures:
+      - gfx12
+      - gfx1200
+      - gfx1201
+      block: SQ
+      event: 99
+  - name: SQ_INSTS_ALL
+    description: ''
+    properties: []
+    definitions:
+    - architectures:
+      - gfx1151
+      - gfx1152
+      block: SQ
+      event: 48
+  - name: SQ_INSTS_BRANCH
+    description: Total number of BRANCH instructions issued. This value is returned per-SE (aggregate of values in SIMDs in
+      the SE). This value SHOULD NOT be used in combination with SQ_ACTIVE_INST_MISC to calculate latency. SQ_ACTIVE_INST_MISC
+      includes both BRANCH and SENDMSG instructions while this is only BRANCH.
+    properties: []
+    definitions:
+    - architectures:
+      - gfx1151
+      - gfx1152
+      block: SQ
+      event: 49
+    - architectures:
+      - gfx90a
+      block: SQ
+      event: 64
+    - architectures:
+      - gfx908
+      block: SQ
+      event: 39
+    - architectures:
+      - gfx940
+      - gfx941
+      - gfx942
+      block: SQ
+      event: 69
+    - architectures:
+      - gfx950
+      block: SQ
+      event: 71
+  - name: SQ_INSTS_EXP_GDS
+    description: Total number of EXPORT or GDS (global wave state) instructions issued. When used in combination with SQ_ACTIVE_INST_EXP_GDS
+      (cycle count for executing instructions) the average latency of EXPORT/GDS instruction execution can be calculated (SQ_ACTIVE_INST_EXP_GDS
+      / SQ_INSTS_EXP_GDS). This value is returned per-SE (aggregate of values in SIMDs in the SE).
+    properties: []
+    definitions:
+    - architectures:
+      - gfx1151
+      - gfx1152
+      block: SQ
+      event: 53
+    - architectures:
+      - gfx90a
+      block: SQ
+      event: 63
+    - architectures:
+      - gfx908
+      block: SQ
+      event: 38
+    - architectures:
+      - gfx940
+      - gfx941
+      - gfx942
+      block: SQ
+      event: 68
+    - architectures:
+      - gfx950
+      block: SQ
+      event: 70
+  - name: SQ_INSTS_EXP
+    description: Number of EXP instructions issued, excluding skipped export instructions. (per-simd, emulated)
+    properties: []
+    definitions:
+    - architectures:
+      - gfx1151
+      - gfx1152
+      block: SQ
+      event: 55
+    - architectures:
+      - gfx950
+      block: SQ
+      event: 69
+  - name: SQ_INSTS_FLAT_LOAD
+    description: ''
+    properties: []
+    definitions:
+    - architectures:
+      - gfx1151
+      - gfx1152
+      block: SQ
+      event: 189
+  - name: SQ_INSTS_FLAT_STORE
+    description: ''
+    properties: []
+    definitions:
+    - architectures:
+      - gfx1151
+      - gfx1152
+      block: SQ
+      event: 190
+  - name: SQ_INSTS_INTERNAL
+    description: ''
+    properties: []
+    definitions:
+    - architectures:
+      - gfx1151
+      - gfx1152
+      block: SQ
+      event: 69
+  - name: SQ_INSTS_LDS_DIRECT_LOAD
+    description: ''
+    properties: []
+    definitions:
+    - architectures:
+      - gfx1151
+      - gfx1152
+      block: SQ
+      event: 171
+  - name: SQ_INSTS_LDS_PARAM_LOAD
+    description: ''
+    properties: []
+    definitions:
+    - architectures:
+      - gfx1151
+      - gfx1152
+      block: SQ
+      event: 172
+  - name: SQ_INSTS_SENDMSG
+    description: Total number of Sendmsg (typically an interrupt to the CPU host) instructions issued. This value is returned
+      per-SE (aggregate of values in SIMDs in the SE). See AMD ISAs for more information on Sendmsg instructions.
+    properties: []
+    definitions:
+    - architectures:
+      - gfx1151
+      - gfx1152
+      block: SQ
+      event: 61
+    - architectures:
+      - gfx90a
+      block: SQ
+      event: 65
+    - architectures:
+      - gfx908
+      block: SQ
+      event: 40
+    - architectures:
+      - gfx940
+      - gfx941
+      - gfx942
+      block: SQ
+      event: 70
+    - architectures:
+      - gfx950
+      block: SQ
+      event: 72
+  - name: SQ_INSTS_SMEM_NORM
+    description: Number of SMEM instructions issued normalized to match the level of memory accessed (i.e. scratch, global,
+      etc). This normalized value is designed to give a hint of high cost memory actions being used. The formula used to calculate
+      this value is the following (INST_COUNT *2 for load/store; INST_COUNT*2 atomic; INST_COUNT*2 memtime; INST_COUNT*4 wb/inv).
+      This value is returned per-SE (aggregate of values in SIMDs in the SE).
+    properties: []
+    definitions:
+    - architectures:
+      - gfx1151
+      - gfx1152
+      block: SQ
+      event: 60
+    - architectures:
+      - gfx90a
+      block: SQ
+      event: 188
+    - architectures:
+      - gfx908
+      block: SQ
+      event: 161
+    - architectures:
+      - gfx940
+      - gfx941
+      - gfx942
+      block: SQ
+      event: 187
+    - architectures:
+      - gfx950
+      block: SQ
+      event: 203
+  - name: SQ_INSTS_TEX
+    description: ''
+    properties: []
+    definitions:
+    - architectures:
+      - gfx1151
+      - gfx1152
+      block: SQ
+      event: 65
+  - name: SQ_INSTS_VALU_DP
+    description: ''
+    properties: []
+    definitions:
+    - architectures:
+      - gfx1151
+      - gfx1152
+      block: SQ
+      event: 182
+  - name: SQ_INSTS_VALU_TRANS
+    description: ''
+    properties: []
+    definitions:
+    - architectures:
+      - gfx1151
+      - gfx1152
+      block: SQ
+      event: 170
+  - name: SQ_INSTS_WAVE32_LDS_PARAM_LOAD
+    description: ''
+    properties: []
+    definitions:
+    - architectures:
+      - gfx1151
+      - gfx1152
+      block: SQ
+      event: 173
+  - name: SQ_ITEMS
+    description: Number of valid items per wave. This value is returned on a per-SE (aggregate of values in SIMDs in the SE)
+      basis.
+    properties: []
+    definitions:
+    - architectures:
+      - gfx1151
+      - gfx1152
+      block: SQ
+      event: 8
+    - architectures:
+      - gfx90a
+      - gfx908
+      - gfx940
+      - gfx941
+      - gfx942
+      - gfx950
+      block: SQ
+      event: 14
+  - name: SQ_WAIT_BARRIER
+    description: ''
+    properties: []
+    definitions:
+    - architectures:
+      - gfx1151
+      - gfx1152
+      block: SQ
+      event: 42
+  - name: SQ_WAIT_CNT_ANY
+    description: ''
+    properties: []
+    definitions:
+    - architectures:
+      - gfx1151
+      - gfx1152
+      block: SQ
+      event: 36
+  - name: SQ_WAIT_IFETCH
+    description: ''
+    properties: []
+    definitions:
+    - architectures:
+      - gfx1151
+      - gfx1152
+      block: SQ
+      event: 41
+  - name: SQ_WAVES_EQ_64
+    description: Count number of waves with exactly 64 active threads sent to SQs. This value represents the number of waves
+      that an each individual SIMD has enqueued during the collection timeframe (for dispatch profiling this is the timeframe
+      of kernel execution, for agent profiling it is the timeframe between start_context and read counter data) with exactly
+      64 threads. A sum of all SQ_WAVES_EQ_64 values will give the total number of waves with 64 threads enqueued during the
+      collection timeframe by the application. Returns one value per-SE (aggregates of SIMD values). Useful for checking for
+      wavefront occupancy.
+    properties: []
+    definitions:
+    - architectures:
+      - gfx1151
+      - gfx1152
+      block: SQ
+      event: 14
+    - architectures:
+      - gfx90a
+      - gfx908
+      - gfx940
+      - gfx941
+      - gfx942
+      - gfx950
+      block: SQ
+      event: 6
+  - name: SQ_WAVES_LT_16
+    description: Count number of waves sent <16 active threads sent to SQs. (per-simd, emulated, global). This value represents
+      the number of waves that an each individual SIMD has enqueued during the collection timeframe (for dispatch profiling
+      this is the timeframe of kernel execution, for agent profiling it is the timeframe between start_context and read counter
+      data) with less than 16 threads. A sum of all SQ_WAVES_LT_16 values will give the total number of waves with 16 threads
+      enqueued during the collection timeframe by the application. Returns one value per-SE (aggregates of SIMD values). Useful
+      for checking for wavefront occupancy.
+    properties: []
+    definitions:
+    - architectures:
+      - gfx1151
+      - gfx1152
+      block: SQ
+      event: 18
+    - architectures:
+      - gfx90a
+      - gfx908
+      - gfx940
+      - gfx941
+      - gfx942
+      - gfx950
+      block: SQ
+      event: 10
+  - name: SQ_WAVES_LT_32
+    description: Count number of waves sent <32 active threads sent to SQs. This value represents the number of waves that
+      an each individual SIMD has enqueued during the collection timeframe (for dispatch profiling this is the timeframe of
+      kernel execution, for agent profiling it is the timeframe between start_context and read counter data) with less than
+      32 threads. A sum of all SQ_WAVES_LT_32 values will give the total number of waves with 32 threads enqueued during the
+      collection timeframe by the application. Returns one value per-SE (aggregates of SIMD values). Useful for checking for
+      wavefront occupancy.
+    properties: []
+    definitions:
+    - architectures:
+      - gfx1151
+      - gfx1152
+      block: SQ
+      event: 17
+    - architectures:
+      - gfx90a
+      - gfx908
+      - gfx940
+      - gfx941
+      - gfx942
+      - gfx950
+      block: SQ
+      event: 9
+  - name: SQ_WAVES_LT_48
+    description: Count number of waves with <48 active threads sent to SQs. This value represents the number of waves that
+      an each individual SIMD has enqueued during the collection timeframe (for dispatch profiling this is the timeframe of
+      kernel execution, for agent profiling it is the timeframe between start_context and read counter data) with less than
+      48 threads. A sum of all SQ_WAVES_LT_48 values will give the total number of waves with 48 threads enqueued during the
+      collection timeframe by the application. Returns one value per-SE (aggregates of SIMD values). Useful for checking for
+      wavefront occupancy.
+    properties: []
+    definitions:
+    - architectures:
+      - gfx1151
+      - gfx1152
+      block: SQ
+      event: 16
+    - architectures:
+      - gfx90a
+      - gfx908
+      - gfx940
+      - gfx941
+      - gfx942
+      - gfx950
+      block: SQ
+      event: 8
+  - name: SQ_WAVES_LT_64
+    description: Count number of waves with <64 active threads sent to SQs. This value represents the number of waves that
+      an each individual SIMD has enqueued during the collection timeframe (for dispatch profiling this is the timeframe of
+      kernel execution, for agent profiling it is the timeframe between start_context and read counter data) with less than
+      64 threads. A sum of all SQ_WAVES_LT_64 values will give the total number of waves with 64 threads enqueued during the
+      collection timeframe by the application. Returns one value per-SE (aggregates of SIMD values). Useful for checking for
+      wavefront occupancy.
+    properties: []
+    definitions:
+    - architectures:
+      - gfx1151
+      - gfx1152
+      block: SQ
+      event: 15
+    - architectures:
+      - gfx90a
+      - gfx908
+      - gfx940
+      - gfx941
+      - gfx942
+      - gfx950
+      block: SQ
+      event: 7
+  - name: SQ_WAVES_RESTORED
+    description: Count number of context-restored waves sent to SQs. This value represents the number of waves whos current
+      register state has been restored from a register bank during the collection timeframe (for dispatch profiling this is
+      the timeframe of kernel execution, for agent profiling it is the timeframe between start_context and read counter data).
+      Context saving/restoring is a slow operation and should be limited. High values can also indicate that stalling may
+      be taking place (waiting for free register space). Returns one value per-SE (aggregates of SIMD values).
+    properties: []
+    definitions:
+    - architectures:
+      - gfx1151
+      - gfx1152
+      block: SQ
+      event: 19
+    - architectures:
+      - gfx90a
+      block: SQ
+      event: 186
+    - architectures:
+      - gfx908
+      block: SQ
+      event: 159
+    - architectures:
+      - gfx940
+      - gfx941
+      - gfx942
+      block: SQ
+      event: 185
+    - architectures:
+      - gfx950
+      block: SQ
+      event: 201
+  - name: SQ_WAVES_SAVED
+    description: Count number of context-saved waves sent to SQs. This value represents the number of waves whos current register
+      state has been saved to a register bank during the collection timeframe (for dispatch profiling this is the timeframe
+      of kernel execution, for agent profiling it is the timeframe between start_context and read counter data) . Context
+      saving/restoring is a slow operation and should be limited. High values can also indicate that stalling may be taking
+      place (waiting for free register space). Returns one value per-SE (aggregates of SIMD values).
+    properties: []
+    definitions:
+    - architectures:
+      - gfx1151
+      - gfx1152
+      block: SQ
+      event: 20
+    - architectures:
+      - gfx90a
+      block: SQ
+      event: 187
+    - architectures:
+      - gfx908
+      block: SQ
+      event: 160
+    - architectures:
+      - gfx940
+      - gfx941
+      - gfx942
+      block: SQ
+      event: 186
+    - architectures:
+      - gfx950
+      block: SQ
+      event: 202
+  - name: SQC_DCACHE_BUSY_CYCLES
+    description: ' Clock cycles while cache is reporting that it is busy. (No-Masking, nondeterministic, unwindowed)'
+    properties: []
+    definitions:
+    - architectures:
+      - gfx1151
+      - gfx1152
+      block: SQ
+      event: 292
+    - architectures:
+      - gfx940
+      - gfx941
+      - gfx942
+      - gfx950
+      block: SQ
+      event: 289
+  - name: SQC_DCACHE_HITS
+    description: Number of cache hits. (per-SQ, per-Bank, nondeterministic)
+    properties: []
+    definitions:
+    - architectures:
+      - gfx1151
+      - gfx1152
+      block: SQ
+      event: 294
+    - architectures:
+      - gfx90a
+      - gfx908
+      - gfx940
+      - gfx941
+      - gfx942
+      - gfx950
+      block: SQ
+      event: 291
+  - name: SQC_DCACHE_INFLIGHT_LEVEL
+    description: Level count total outstanding transactions in data cache (per-SQ, nondeterministic)
+    properties: []
+    definitions:
+    - architectures:
+      - gfx1151
+      - gfx1152
+      block: SQ
+      event: 276
+    - architectures:
+      - gfx90a
+      - gfx908
+      - gfx940
+      - gfx941
+      - gfx942
+      - gfx950
+      block: SQ
+      event: 337
+  - name: SQC_DCACHE_INPUT_VALID_READYB
+    description: Input stalled by SQC (per-SQ, nondeterministic, unwindowed)
+    properties: []
+    definitions:
+    - architectures:
+      - gfx1151
+      - gfx1152
+      block: SQ
+      event: 281
+    - architectures:
+      - gfx90a
+      - gfx908
+      - gfx940
+      - gfx941
+      - gfx942
+      - gfx950
+      block: SQ
+      event: 260
+  - name: SQC_DCACHE_MISSES_DUPLICATE
+    description: Number of misses that were duplicates (access to a non-resident, miss pending CL). (per-SQ, per-Bank, nondeterministic)
+    properties: []
+    definitions:
+    - architectures:
+      - gfx1151
+      - gfx1152
+      block: SQ
+      event: 296
+    - architectures:
+      - gfx90a
+      - gfx908
+      - gfx940
+      - gfx941
+      - gfx942
+      - gfx950
+      block: SQ
+      event: 293
+  - name: SQC_DCACHE_MISSES
+    description: Number of cache misses, includes uncached requests. (per-SQ, per-Bank, nondeterministic)
+    properties: []
+    definitions:
+    - architectures:
+      - gfx1151
+      - gfx1152
+      block: SQ
+      event: 295
+    - architectures:
+      - gfx90a
+      - gfx908
+      - gfx940
+      - gfx941
+      - gfx942
+      - gfx950
+      block: SQ
+      event: 292
+  - name: SQC_DCACHE_REQ_READ_1
+    description: Number of constant cache 1 dw read requests. (per-SQ)
+    properties: []
+    definitions:
+    - architectures:
+      - gfx1151
+      - gfx1152
+      block: SQ
+      event: 306
+    - architectures:
+      - gfx90a
+      - gfx908
+      - gfx940
+      - gfx941
+      - gfx942
+      - gfx950
+      block: SQ
+      event: 323
+  - name: SQC_DCACHE_REQ_READ_16
+    description: Number of constant cache 16 dw read requests. (per-SQ)
+    properties: []
+    definitions:
+    - architectures:
+      - gfx1151
+      - gfx1152
+      block: SQ
+      event: 310
+    - architectures:
+      - gfx90a
+      - gfx908
+      - gfx940
+      - gfx941
+      - gfx942
+      - gfx950
+      block: SQ
+      event: 327
+  - name: SQC_DCACHE_REQ_READ_2
+    description: Number of constant cache 2 dw read requests. (per-SQ)
+    properties: []
+    definitions:
+    - architectures:
+      - gfx1151
+      - gfx1152
+      block: SQ
+      event: 307
+    - architectures:
+      - gfx90a
+      - gfx908
+      - gfx940
+      - gfx941
+      - gfx942
+      - gfx950
+      block: SQ
+      event: 324
+  - name: SQC_DCACHE_REQ_READ_4
+    description: Number of constant cache 4 dw read requests. (per-SQ)
+    properties: []
+    definitions:
+    - architectures:
+      - gfx1151
+      - gfx1152
+      block: SQ
+      event: 308
+    - architectures:
+      - gfx90a
+      - gfx908
+      - gfx940
+      - gfx941
+      - gfx942
+      - gfx950
+      block: SQ
+      event: 325
+  - name: SQC_DCACHE_REQ_READ_8
+    description: Number of constant cache 8 dw read requests. (per-SQ)
+    properties: []
+    definitions:
+    - architectures:
+      - gfx1151
+      - gfx1152
+      block: SQ
+      event: 309
+    - architectures:
+      - gfx90a
+      - gfx908
+      - gfx940
+      - gfx941
+      - gfx942
+      - gfx950
+      block: SQ
+      event: 326
+  - name: SQC_DCACHE_REQ
+    description: Number of requests (post-bank-serialization). (per-SQ, per-Bank)
+    properties: []
+    definitions:
+    - architectures:
+      - gfx1151
+      - gfx1152
+      block: SQ
+      event: 293
+    - architectures:
+      - gfx90a
+      - gfx908
+      - gfx940
+      - gfx941
+      - gfx942
+      - gfx950
+      block: SQ
+      event: 290
+  - name: SQC_ICACHE_BUSY_CYCLES
+    description: Clock cycles while cache is reporting that it is busy. (No-Masking, nondeterministic, unwindowed)
+    properties: []
+    definitions:
+    - architectures:
+      - gfx1151
+      - gfx1152
+      block: SQ
+      event: 268
+    - architectures:
+      - gfx940
+      - gfx941
+      - gfx942
+      - gfx950
+      block: SQ
+      event: 269
+  - name: SQC_ICACHE_HITS
+    description: Number of cache hits. (per-SQ, per-Bank, nondeterministic)
+    properties: []
+    definitions:
+    - architectures:
+      - gfx1151
+      - gfx1152
+      block: SQ
+      event: 270
+    - architectures:
+      - gfx90a
+      - gfx908
+      - gfx940
+      - gfx941
+      - gfx942
+      - gfx950
+      block: SQ
+      event: 271
+    - architectures:
+      - gfx12
+      - gfx1200
+      - gfx1201
+      block: SQ
+      event: 302
+  - name: SQC_ICACHE_INFLIGHT_LEVEL
+    description: Level count total outstanding transactions in instruction cache (per-SQ, nondeterministic)
+    properties: []
+    definitions:
+    - architectures:
+      - gfx1151
+      - gfx1152
+      block: SQ
+      event: 275
+    - architectures:
+      - gfx90a
+      - gfx908
+      - gfx940
+      - gfx941
+      - gfx942
+      - gfx950
+      block: SQ
+      event: 336
+  - name: SQC_ICACHE_INPUT_VALID_READYB
+    description: ' Input stalled by SQC (per-SQ, nondeterministic, unwindowed)'
+    properties: []
+    definitions:
+    - architectures:
+      - gfx1151
+      - gfx1152
+      block: SQ
+      event: 280
+    - architectures:
+      - gfx940
+      - gfx941
+      - gfx942
+      - gfx950
+      block: SQ
+      event: 257
+  - name: SQC_ICACHE_MISSES_DUPLICATE
+    description: Number of misses that were duplicates (access to a non-resident, miss pending CL). (per-SQ, per-Bank, nondeterministic)
+    properties: []
+    definitions:
+    - architectures:
+      - gfx1151
+      - gfx1152
+      block: SQ
+      event: 272
+    - architectures:
+      - gfx90a
+      - gfx908
+      - gfx940
+      - gfx941
+      - gfx942
+      - gfx950
+      block: SQ
+      event: 273
+  - name: SQC_ICACHE_MISSES
+    description: Number of cache misses, includes uncached requests. (per-SQ, per-Bank, nondeterministic)
+    properties: []
+    definitions:
+    - architectures:
+      - gfx1151
+      - gfx1152
+      block: SQ
+      event: 271
+    - architectures:
+      - gfx90a
+      - gfx908
+      - gfx940
+      - gfx941
+      - gfx942
+      - gfx950
+      block: SQ
+      event: 272
+    - architectures:
+      - gfx12
+      - gfx1200
+      - gfx1201
+      block: SQ
+      event: 303
+  - name: SQC_ICACHE_REQ
+    description: Number of requests. (per-SQ, per-Bank)
+    properties: []
+    definitions:
+    - architectures:
+      - gfx1151
+      - gfx1152
+      block: SQ
+      event: 269
+    - architectures:
+      - gfx90a
+      - gfx908
+      - gfx940
+      - gfx941
+      - gfx942
+      - gfx950
+      block: SQ
+      event: 270
+    - architectures:
+      - gfx12
+      - gfx1200
+      - gfx1201
+      block: SQ
+      event: 301
+  - name: SQC_LDS_BANK_CONFLICT
+    description: Number of cycles LDS is stalled by bank conflicts. (emulated, C1)
+    properties: []
+    definitions:
+    - architectures:
+      - gfx1151
+      - gfx1152
+      - gfx11
+      - gfx1100
+      - gfx1101
+      - gfx1102
+      block: SQ
+      event: 256
+    - architectures:
+      - gfx10
+      - gfx1010
+      - gfx1030
+      - gfx1031
+      - gfx1032
+      block: SQ
+      event: 285
+    - architectures:
+      - gfx12
+      - gfx1200
+      - gfx1201
+      block: SQ
+      event: 288
+  - name: SQC_LDS_IDX_ACTIVE
+    description: Number of cycles LDS is used for indexed (non-direct,non-interpolation) operations. {per-simd, emulated,
+      C1}
+    properties: []
+    definitions:
+    - architectures:
+      - gfx1151
+      - gfx1152
+      - gfx11
+      - gfx1100
+      - gfx1101
+      - gfx1102
+      block: SQ
+      event: 261
+    - architectures:
+      - gfx10
+      - gfx1010
+      - gfx1030
+      - gfx1031
+      - gfx1032
+      block: SQ
+      event: 290
+    - architectures:
+      - gfx12
+      - gfx1200
+      - gfx1201
+      block: SQ
+      event: 293
+  - name: SQC_TC_DATA_READ_REQ
+    description: Number of data read requests to the TC (No-Masking, nondeterministic)
+    properties: []
+    definitions:
+    - architectures:
+      - gfx1151
+      - gfx1152
+      block: SQ
+      event: 284
+    - architectures:
+      - gfx90a
+      - gfx908
+      - gfx940
+      - gfx941
+      - gfx942
+      - gfx950
+      block: SQ
+      event: 264
+  - name: SQC_TC_INST_REQ
+    description: Number of insruction requests to the TC (No-Masking, nondeterministic)
+    properties: []
+    definitions:
+    - architectures:
+      - gfx1151
+      - gfx1152
+      block: SQ
+      event: 283
+    - architectures:
+      - gfx90a
+      - gfx908
+      - gfx940
+      - gfx941
+      - gfx942
+      - gfx950
+      block: SQ
+      event: 263
+  - name: SQC_TC_REQ
+    description: Total number of TC requests that were issued by instruction and constant caches. (No-Masking, nondeterministic)
+    properties: []
+    definitions:
+    - architectures:
+      - gfx1151
+      - gfx1152
+      block: SQ
+      event: 282
+    - architectures:
+      - gfx90a
+      - gfx908
+      - gfx940
+      - gfx941
+      - gfx942
+      - gfx950
+      block: SQ
+      event: 262
+  - name: SQC_TC_STALL
+    description: Valid request stalled TC request interface (no-credits). (No-Masking, nondeterministic, unwindowed)
+    properties: []
+    definitions:
+    - architectures:
+      - gfx1151
+      - gfx1152
+      block: SQ
+      event: 285
+    - architectures:
+      - gfx90a
+      - gfx908
+      - gfx940
+      - gfx941
+      - gfx942
+      - gfx950
+      block: SQ
+      event: 267
+  - name: TA_TA_BUSY
+    description: TA block is busy. Perf_Windowing not supported for this counter.
+    properties: []
+    definitions:
+    - architectures:
+      - gfx1151
+      - gfx1152
+      - gfx10
+      - gfx1010
+      - gfx1030
+      - gfx1031
+      - gfx1032
+      - gfx11
+      - gfx1100
+      - gfx1101
+      - gfx1102
+      - gfx12
+      - gfx1200
+      - gfx1201
+      - gfx9
+      - gfx900
+      - gfx906
+      - gfx908
+      - gfx90a
+      block: TA
+      event: 15
+    - architectures:
+      - gfx940
+      - gfx941
+      - gfx942
+      - gfx950
+      block: TA
+      event: 13
+  - name: TCP_GATE_EN1
+    description: TCP interface clocks are turned on. Not Windowed.
+    properties: []
+    definitions:
+    - architectures:
+      - gfx1151
+      - gfx1152
+      - gfx90a
+      - gfx908
+      - gfx940
+      - gfx941
+      - gfx942
+      - gfx950
+      block: TCP
+      event: 0
+  - name: TCP_GATE_EN2
+    description: TCP core clocks are turned on. Not Windowed.
+    properties: []
+    definitions:
+    - architectures:
+      - gfx1151
+      - gfx1152
+      - gfx90a
+      - gfx908
+      - gfx940
+      - gfx941
+      - gfx942
+      - gfx950
+      block: TCP
+      event: 1
+  - name: TCP_DATA_FIFO_STALL
+    description: ''
+    properties: []
+    definitions:
+    - architectures:
+      - gfx1151
+      - gfx1152
+      block: TCP
+      event: 41
+  - name: TCP_GL1_REQ_READ_128B
+    description: ''
+    properties: []
+    definitions:
+    - architectures:
+      - gfx1151
+      - gfx1152
+      block: TCP
+      event: 31
+  - name: TCP_GL1_REQ_READ
+    description: ''
+    properties: []
+    definitions:
+    - architectures:
+      - gfx1151
+      - gfx1152
+      block: TCP
+      event: 30
+  - name: TCP_GL1_REQ_WRITE
+    description: ''
+    properties: []
+    definitions:
+    - architectures:
+      - gfx1151
+      - gfx1152
+      block: TCP
+      event: 33
+  - name: TCP_GL1_TCP_BACK_PRESSURE
+    description: ''
+    properties: []
+    definitions:
+    - architectures:
+      - gfx1151
+      - gfx1152
+      block: TCP
+      event: 51
+  - name: TCP_REQ_MISS
+    description: Total cache requests that missed
+    properties: []
+    definitions:
+    - architectures:
+      - gfx1151
+      - gfx1152
+      - gfx12
+      - gfx1200
+      - gfx1201
+      block: TCP
+      event: 17
+  - name: TCP_REQ_READ
+    description: ''
+    properties: []
+    definitions:
+    - architectures:
+      - gfx1151
+      - gfx1152
+      block: TCP
+      event: 10
+  - name: TCP_REQ_WRITE
+    description: ''
+    properties: []
+    definitions:
+    - architectures:
+      - gfx1151
+      - gfx1152
+      block: TCP
+      event: 14
+  - name: TCP_REQ
+    description: Total cache line accesses
+    properties: []
+    definitions:
+    - architectures:
+      - gfx1151
+      - gfx1152
+      - gfx12
+      - gfx1200
+      - gfx1201
+      block: TCP
+      event: 9
+  - name: TCP_TCP_LATENCY
+    description: Total TCP wave latency (from first clock of wave entering to first clock of wave leaving), divide by TA_TCP_STATE_READ
+      to avg wave latency
+    properties: []
+    definitions:
+    - architectures:
+      - gfx1151
+      - gfx1152
+      block: TCP
+      event: 38
+    - architectures:
+      - gfx90a
+      - gfx908
+      block: TCP
+      event: 65
+    - architectures:
+      - gfx950
+      block: TCP
+      event: 64
+  - name: TCP_TCP_TA_REQ_STALL
+    description: ''
+    properties: []
+    definitions:
+    - architectures:
+      - gfx1151
+      - gfx1152
+      block: TCP
+      event: 39
+  - name: GRBM_GUI_ACTIVE_sum
+    description: ''
+    properties: []
+    definitions:
+    - architectures:
+      - gfx1151
+      - gfx1152
+      expression: reduce(GRBM_GUI_ACTIVE,sum)
+  - name: SQ_BUSY_CYCLES_sum
+    description: ''
+    properties: []
+    definitions:
+    - architectures:
+      - gfx1151
+      - gfx1152
+      expression: reduce(SQ_BUSY_CYCLES,sum)
+  - name: SQ_BUSY_CYCLES_avr
+    description: SQ_BUSY_CYCLES averaged over SQ (shader engine) instances. The Shader Processor Group (SPG) perf specification
+      exposes this counter per SE; avr matches reduce(SQ_BUSY_CYCLES,avr) for occupancy-style ratios.
+    properties: []
+    definitions:
+    - architectures:
+      - gfx1151
+      - gfx1152
+      expression: reduce(SQ_BUSY_CYCLES,avr)
+  - name: SQ_INSTS_FLAT_sum
+    description: ''
+    properties: []
+    definitions:
+    - architectures:
+      - gfx1151
+      - gfx1152
+      expression: reduce(SQ_INSTS_FLAT,sum)
+  - name: SQ_INSTS_LDS_sum
+    description: ''
+    properties: []
+    definitions:
+    - architectures:
+      - gfx1151
+      - gfx1152
+      expression: reduce(SQ_INSTS_LDS,sum)
+  - name: SQ_INSTS_SALU_sum
+    description: ''
+    properties: []
+    definitions:
+    - architectures:
+      - gfx1151
+      - gfx1152
+      expression: reduce(SQ_INSTS_SALU,sum)
+  - name: SQ_INSTS_SMEM_sum
+    description: ''
+    properties: []
+    definitions:
+    - architectures:
+      - gfx1151
+      - gfx1152
+      expression: reduce(SQ_INSTS_SMEM,sum)
+  - name: SQ_INSTS_TEX_LOAD_sum
+    description: ''
+    properties: []
+    definitions:
+    - architectures:
+      - gfx1151
+      - gfx1152
+      expression: reduce(SQ_INSTS_TEX_LOAD,sum)
+  - name: SQ_INSTS_TEX_STORE_sum
+    description: ''
+    properties: []
+    definitions:
+    - architectures:
+      - gfx1151
+      - gfx1152
+      expression: reduce(SQ_INSTS_TEX_STORE,sum)
+  - name: SQ_INSTS_VALU_sum
+    description: ''
+    properties: []
+    definitions:
+    - architectures:
+      - gfx1151
+      - gfx1152
+      expression: reduce(SQ_INSTS_VALU,sum)
+  - name: SQ_WAIT_INST_LDS_sum
+    description: ''
+    properties: []
+    definitions:
+    - architectures:
+      - gfx1151
+      - gfx1152
+      expression: reduce(SQ_WAIT_INST_LDS,sum)
+  - name: SQ_WAVE_CYCLES_sum
+    description: ''
+    properties: []
+    definitions:
+    - architectures:
+      - gfx1151
+      - gfx1152
+      expression: reduce(SQ_WAVE_CYCLES,sum)
+  - name: CPC_GUS_READ_REQUEST_SENT_sum
+    description: ''
+    properties: []
+    definitions:
+    - architectures:
+      - gfx1151
+      - gfx1152
+      expression: reduce(CPC_GUS_READ_REQUEST_SENT,sum)
+  - name: CPC_GUS_WRITE_REQUEST_SENT_sum
+    description: ''
+    properties: []
+    definitions:
+    - architectures:
+      - gfx1151
+      - gfx1152
+      expression: reduce(CPC_GUS_WRITE_REQUEST_SENT,sum)
+  - name: CPC_MEC_INSTR_CACHE_HIT_sum
+    description: ''
+    properties: []
+    definitions:
+    - architectures:
+      - gfx1151
+      - gfx1152
+      expression: reduce(CPC_MEC_INSTR_CACHE_HIT,sum)
+  - name: CPC_MEC_INSTR_CACHE_MISS_sum
+    description: ''
+    properties: []
+    definitions:
+    - architectures:
+      - gfx1151
+      - gfx1152
+      expression: reduce(CPC_MEC_INSTR_CACHE_MISS,sum)
+  - name: CPC_TCIU_READ_REQUEST_SENT_sum
+    description: ''
+    properties: []
+    definitions:
+    - architectures:
+      - gfx1151
+      - gfx1152
+      expression: reduce(CPC_TCIU_READ_REQUEST_SENT,sum)
+  - name: CPC_TCIU_WRITE_REQUEST_SENT_sum
+    description: ''
+    properties: []
+    definitions:
+    - architectures:
+      - gfx1151
+      - gfx1152
+      expression: reduce(CPC_TCIU_WRITE_REQUEST_SENT,sum)
+  - name: GCEA_ALWAYS_COUNT_sum
+    description: ''
+    properties: []
+    definitions:
+    - architectures:
+      - gfx1151
+      - gfx1152
+      expression: reduce(GCEA_ALWAYS_COUNT,sum)
+  - name: GCEA_PRB_REQ_sum
+    description: ''
+    properties: []
+    definitions:
+    - architectures:
+      - gfx1151
+      - gfx1152
+      expression: reduce(GCEA_PRB_REQ,sum)
+  - name: GCEA_RDRAM_CHAINED_REQ_PER_CLIGRP_sum
+    description: ''
+    properties: []
+    definitions:
+    - architectures:
+      - gfx1151
+      - gfx1152
+      expression: reduce(GCEA_RDRAM_CHAINED_REQ_PER_CLIGRP,sum)
+  - name: GCEA_RDRAM_NUM_BANKS_VLD_sum
+    description: ''
+    properties: []
+    definitions:
+    - architectures:
+      - gfx1151
+      - gfx1152
+      expression: reduce(GCEA_RDRAM_NUM_BANKS_VLD,sum)
+  - name: GCEA_RDRAM_REQ_PER_CLIGRP_sum
+    description: ''
+    properties: []
+    definitions:
+    - architectures:
+      - gfx1151
+      - gfx1152
+      expression: reduce(GCEA_RDRAM_REQ_PER_CLIGRP,sum)
+  - name: GCEA_RDRAM_SIZE_REQ_sum
+    description: ''
+    properties: []
+    definitions:
+    - architectures:
+      - gfx1151
+      - gfx1152
+      expression: reduce(GCEA_RDRAM_SIZE_REQ,sum)
+  - name: GCEA_RRET_VLD_sum
+    description: ''
+    properties: []
+    definitions:
+    - architectures:
+      - gfx1151
+      - gfx1152
+      expression: reduce(GCEA_RRET_VLD,sum)
+  - name: GCEA_SARB_BUSY_sum
+    description: ''
+    properties: []
+    definitions:
+    - architectures:
+      - gfx1151
+      - gfx1152
+      expression: reduce(GCEA_SARB_BUSY,sum)
+  - name: GCEA_SARB_DRAM_REQ_PER_VC_sum
+    description: ''
+    properties: []
+    definitions:
+    - architectures:
+      - gfx1151
+      - gfx1152
+      expression: reduce(GCEA_SARB_DRAM_REQ_PER_VC,sum)
+  - name: GCEA_SARB_REQ_PER_VC_sum
+    description: ''
+    properties: []
+    definitions:
+    - architectures:
+      - gfx1151
+      - gfx1152
+      expression: reduce(GCEA_SARB_REQ_PER_VC,sum)
+  - name: GCEA_SARB_STALLED_sum
+    description: ''
+    properties: []
+    definitions:
+    - architectures:
+      - gfx1151
+      - gfx1152
+      expression: reduce(GCEA_SARB_STALLED,sum)
+  - name: GCEA_WDRAM_CHAINED_REQ_PER_CLIGRP_sum
+    description: ''
+    properties: []
+    definitions:
+    - architectures:
+      - gfx1151
+      - gfx1152
+      expression: reduce(GCEA_WDRAM_CHAINED_REQ_PER_CLIGRP,sum)
+  - name: GCEA_WDRAM_NUM_BANKS_VLD_sum
+    description: ''
+    properties: []
+    definitions:
+    - architectures:
+      - gfx1151
+      - gfx1152
+      expression: reduce(GCEA_WDRAM_NUM_BANKS_VLD,sum)
+  - name: GCEA_WDRAM_REQ_PER_CLIGRP_sum
+    description: ''
+    properties: []
+    definitions:
+    - architectures:
+      - gfx1151
+      - gfx1152
+      expression: reduce(GCEA_WDRAM_REQ_PER_CLIGRP,sum)
+  - name: GCEA_WDRAM_SIZE_REQ_sum
+    description: ''
+    properties: []
+    definitions:
+    - architectures:
+      - gfx1151
+      - gfx1152
+      expression: reduce(GCEA_WDRAM_SIZE_REQ,sum)
+  - name: GCEA_WRET_VLD_sum
+    description: ''
+    properties: []
+    definitions:
+    - architectures:
+      - gfx1151
+      - gfx1152
+      expression: reduce(GCEA_WRET_VLD,sum)
+  - name: GL1C_BUSY_sum
+    description: ''
+    properties: []
+    definitions:
+    - architectures:
+      - gfx1151
+      - gfx1152
+      expression: reduce(GL1C_BUSY,sum)
+  - name: GL1C_CYCLE_sum
+    description: ''
+    properties: []
+    definitions:
+    - architectures:
+      - gfx1151
+      - gfx1152
+      expression: reduce(GL1C_CYCLE,sum)
+  - name: GL1C_GL2_REQ_READ_128B_sum
+    description: ''
+    properties: []
+    definitions:
+    - architectures:
+      - gfx1151
+      - gfx1152
+      expression: reduce(GL1C_GL2_REQ_READ_128B,sum)
+  - name: GL1C_GL2_REQ_READ_32B_sum
+    description: ''
+    properties: []
+    definitions:
+    - architectures:
+      - gfx1151
+      - gfx1152
+      expression: reduce(GL1C_GL2_REQ_READ_32B,sum)
+  - name: GL1C_GL2_REQ_READ_64B_sum
+    description: ''
+    properties: []
+    definitions:
+    - architectures:
+      - gfx1151
+      - gfx1152
+      expression: reduce(GL1C_GL2_REQ_READ_64B,sum)
+  - name: GL1C_GL2_REQ_READ_LATENCY_sum
+    description: ''
+    properties: []
+    definitions:
+    - architectures:
+      - gfx1151
+      - gfx1152
+      expression: reduce(GL1C_GL2_REQ_READ_LATENCY,sum)
+  - name: GL1C_GL2_REQ_READ_sum
+    description: ''
+    properties: []
+    definitions:
+    - architectures:
+      - gfx1151
+      - gfx1152
+      expression: reduce(GL1C_GL2_REQ_READ,sum)
+  - name: GL1C_GL2_REQ_WRITE_32B_sum
+    description: ''
+    properties: []
+    definitions:
+    - architectures:
+      - gfx1151
+      - gfx1152
+      expression: reduce(GL1C_GL2_REQ_WRITE_32B,sum)
+  - name: GL1C_GL2_REQ_WRITE_64B_sum
+    description: ''
+    properties: []
+    definitions:
+    - architectures:
+      - gfx1151
+      - gfx1152
+      expression: reduce(GL1C_GL2_REQ_WRITE_64B,sum)
+  - name: GL1C_GL2_REQ_WRITE_LATENCY_sum
+    description: ''
+    properties: []
+    definitions:
+    - architectures:
+      - gfx1151
+      - gfx1152
+      expression: reduce(GL1C_GL2_REQ_WRITE_LATENCY,sum)
+  - name: GL1C_GL2_REQ_WRITE_sum
+    description: ''
+    properties: []
+    definitions:
+    - architectures:
+      - gfx1151
+      - gfx1152
+      expression: reduce(GL1C_GL2_REQ_WRITE,sum)
+  - name: GL1C_REQ_MISS_sum
+    description: ''
+    properties: []
+    definitions:
+    - architectures:
+      - gfx1151
+      - gfx1152
+      expression: reduce(GL1C_REQ_MISS,sum)
+  - name: GL1C_REQ_READ_sum
+    description: ''
+    properties: []
+    definitions:
+    - architectures:
+      - gfx1151
+      - gfx1152
+      expression: reduce(GL1C_REQ_READ,sum)
+  - name: GL1C_REQ_WRITE_sum
+    description: ''
+    properties: []
+    definitions:
+    - architectures:
+      - gfx1151
+      - gfx1152
+      expression: reduce(GL1C_REQ_WRITE,sum)
+  - name: GL1C_REQ_sum
+    description: ''
+    properties: []
+    definitions:
+    - architectures:
+      - gfx1151
+      - gfx1152
+      expression: reduce(GL1C_REQ,sum)
+  - name: GL1C_STALL_GL2_GL1_sum
+    description: ''
+    properties: []
+    definitions:
+    - architectures:
+      - gfx1151
+      - gfx1152
+      expression: reduce(GL1C_STALL_GL2_GL1,sum)
+  - name: GL1C_STALL_LFIFO_FULL_sum
+    description: ''
+    properties: []
+    definitions:
+    - architectures:
+      - gfx1151
+      - gfx1152
+      expression: reduce(GL1C_STALL_LFIFO_FULL,sum)
+  - name: GL1C_STARVE_sum
+    description: ''
+    properties: []
+    definitions:
+    - architectures:
+      - gfx1151
+      - gfx1152
+      expression: reduce(GL1C_STARVE,sum)
+  - name: GL2C_ATOMIC_sum
+    description: ''
+    properties: []
+    definitions:
+    - architectures:
+      - gfx1151
+      - gfx1152
+      expression: reduce(GL2C_ATOMIC,sum)
+  - name: GL2C_BUSY_sum
+    description: ''
+    properties: []
+    definitions:
+    - architectures:
+      - gfx1151
+      - gfx1152
+      expression: reduce(GL2C_BUSY,sum)
+  - name: GL2C_COMPRESSED_READ_96_REQ_sum
+    description: ''
+    properties: []
+    definitions:
+    - architectures:
+      - gfx1151
+      - gfx1152
+      expression: reduce(GL2C_COMPRESSED_READ_96_REQ,sum)
+  - name: GL2C_CYCLE_sum
+    description: ''
+    properties: []
+    definitions:
+    - architectures:
+      - gfx1151
+      - gfx1152
+      expression: reduce(GL2C_CYCLE,sum)
+  - name: GL2C_EA_RDREQ_DRAM_sum
+    description: ''
+    properties: []
+    definitions:
+    - architectures:
+      - gfx1151
+      - gfx1152
+      expression: reduce(GL2C_EA_RDREQ_DRAM,sum)
+  - name: GL2C_EA_WRREQ_DRAM_sum
+    description: ''
+    properties: []
+    definitions:
+    - architectures:
+      - gfx1151
+      - gfx1152
+      expression: reduce(GL2C_EA_WRREQ_DRAM,sum)
+  - name: GL2C_READ_128_REQ_sum
+    description: ''
+    properties: []
+    definitions:
+    - architectures:
+      - gfx1151
+      - gfx1152
+      expression: reduce(GL2C_READ_128_REQ,sum)
+  - name: GL2C_READ_32_REQ_sum
+    description: ''
+    properties: []
+    definitions:
+    - architectures:
+      - gfx1151
+      - gfx1152
+      expression: reduce(GL2C_READ_32_REQ,sum)
+  - name: GL2C_READ_64_REQ_sum
+    description: ''
+    properties: []
+    definitions:
+    - architectures:
+      - gfx1151
+      - gfx1152
+      expression: reduce(GL2C_READ_64_REQ,sum)
+  - name: GL2C_READ_sum
+    description: ''
+    properties: []
+    definitions:
+    - architectures:
+      - gfx1151
+      - gfx1152
+      expression: reduce(GL2C_READ,sum)
+  - name: GL2C_REQ_sum
+    description: ''
+    properties: []
+    definitions:
+    - architectures:
+      - gfx1151
+      - gfx1152
+      expression: reduce(GL2C_REQ,sum)
+  - name: GL2C_WRITE_sum
+    description: ''
+    properties: []
+    definitions:
+    - architectures:
+      - gfx1151
+      - gfx1152
+      expression: reduce(GL2C_WRITE,sum)
+  - name: SPI_CSN_WAVE_sum
+    description: ''
+    properties: []
+    definitions:
+    - architectures:
+      - gfx1151
+      - gfx1152
+      expression: reduce(SPI_CSN_WAVE,sum)
+  - name: SQ_INST_CYCLES_LDS_sum
+    description: ''
+    properties: []
+    definitions:
+    - architectures:
+      - gfx1151
+      - gfx1152
+      expression: reduce(SQ_INST_CYCLES_LDS,sum)
+  - name: SQ_INSTS_ALL_sum
+    description: ''
+    properties: []
+    definitions:
+    - architectures:
+      - gfx1151
+      - gfx1152
+      expression: reduce(SQ_INSTS_ALL,sum)
+  - name: SQ_INSTS_FLAT_LOAD_sum
+    description: ''
+    properties: []
+    definitions:
+    - architectures:
+      - gfx1151
+      - gfx1152
+      expression: reduce(SQ_INSTS_FLAT_LOAD,sum)
+  - name: SQ_INSTS_FLAT_STORE_sum
+    description: ''
+    properties: []
+    definitions:
+    - architectures:
+      - gfx1151
+      - gfx1152
+      expression: reduce(SQ_INSTS_FLAT_STORE,sum)
+  - name: SQ_INSTS_INTERNAL_sum
+    description: ''
+    properties: []
+    definitions:
+    - architectures:
+      - gfx1151
+      - gfx1152
+      expression: reduce(SQ_INSTS_INTERNAL,sum)
+  - name: SQ_INSTS_LDS_DIRECT_LOAD_sum
+    description: ''
+    properties: []
+    definitions:
+    - architectures:
+      - gfx1151
+      - gfx1152
+      expression: reduce(SQ_INSTS_LDS_DIRECT_LOAD,sum)
+  - name: SQ_INSTS_LDS_PARAM_LOAD_sum
+    description: ''
+    properties: []
+    definitions:
+    - architectures:
+      - gfx1151
+      - gfx1152
+      expression: reduce(SQ_INSTS_LDS_PARAM_LOAD,sum)
+  - name: SQ_INSTS_TEX_sum
+    description: ''
+    properties: []
+    definitions:
+    - architectures:
+      - gfx1151
+      - gfx1152
+      expression: reduce(SQ_INSTS_TEX,sum)
+  - name: SQ_INSTS_VALU_DP_sum
+    description: ''
+    properties: []
+    definitions:
+    - architectures:
+      - gfx1151
+      - gfx1152
+      expression: reduce(SQ_INSTS_VALU_DP,sum)
+  - name: SQ_INSTS_VALU_TRANS_sum
+    description: ''
+    properties: []
+    definitions:
+    - architectures:
+      - gfx1151
+      - gfx1152
+      expression: reduce(SQ_INSTS_VALU_TRANS,sum)
+  - name: SQ_INSTS_WAVE32_LDS_PARAM_LOAD_sum
+    description: ''
+    properties: []
+    definitions:
+    - architectures:
+      - gfx1151
+      - gfx1152
+      expression: reduce(SQ_INSTS_WAVE32_LDS_PARAM_LOAD,sum)
+  - name: SQ_ITEMS_sum
+    description: ''
+    properties: []
+    definitions:
+    - architectures:
+      - gfx1151
+      - gfx1152
+      expression: reduce(SQ_ITEMS,sum)
+  - name: SQC_DCACHE_BUSY_CYCLES_sum
+    description: ''
+    properties: []
+    definitions:
+    - architectures:
+      - gfx1151
+      - gfx1152
+      expression: reduce(SQC_DCACHE_BUSY_CYCLES,sum)
+  - name: SQC_DCACHE_HITS_sum
+    description: ''
+    properties: []
+    definitions:
+    - architectures:
+      - gfx1151
+      - gfx1152
+      expression: reduce(SQC_DCACHE_HITS,sum)
+  - name: SQC_DCACHE_INPUT_VALID_READYB_sum
+    description: ''
+    properties: []
+    definitions:
+    - architectures:
+      - gfx1151
+      - gfx1152
+      expression: reduce(SQC_DCACHE_INPUT_VALID_READYB,sum)
+  - name: SQC_DCACHE_MISSES_sum
+    description: ''
+    properties: []
+    definitions:
+    - architectures:
+      - gfx1151
+      - gfx1152
+      expression: reduce(SQC_DCACHE_MISSES,sum)
+  - name: SQC_DCACHE_REQ_sum
+    description: ''
+    properties: []
+    definitions:
+    - architectures:
+      - gfx1151
+      - gfx1152
+      expression: reduce(SQC_DCACHE_REQ,sum)
+  - name: SQC_ICACHE_BUSY_CYCLES_sum
+    description: ''
+    properties: []
+    definitions:
+    - architectures:
+      - gfx1151
+      - gfx1152
+      expression: reduce(SQC_ICACHE_BUSY_CYCLES,sum)
+  - name: SQC_ICACHE_HITS_sum
+    description: ''
+    properties: []
+    definitions:
+    - architectures:
+      - gfx1151
+      - gfx1152
+      expression: reduce(SQC_ICACHE_HITS,sum)
+  - name: SQC_ICACHE_INPUT_VALID_READYB_sum
+    description: ''
+    properties: []
+    definitions:
+    - architectures:
+      - gfx1151
+      - gfx1152
+      expression: reduce(SQC_ICACHE_INPUT_VALID_READYB,sum)
+  - name: SQC_ICACHE_MISSES_sum
+    description: ''
+    properties: []
+    definitions:
+    - architectures:
+      - gfx1151
+      - gfx1152
+      expression: reduce(SQC_ICACHE_MISSES,sum)
+  - name: SQC_ICACHE_REQ_sum
+    description: ''
+    properties: []
+    definitions:
+    - architectures:
+      - gfx1151
+      - gfx1152
+      expression: reduce(SQC_ICACHE_REQ,sum)
+  - name: SQC_LDS_BANK_CONFLICT_sum
+    description: ''
+    properties: []
+    definitions:
+    - architectures:
+      - gfx1151
+      - gfx1152
+      expression: reduce(SQC_LDS_BANK_CONFLICT,sum)
+  - name: SQC_LDS_IDX_ACTIVE_sum
+    description: ''
+    properties: []
+    definitions:
+    - architectures:
+      - gfx1151
+      - gfx1152
+      expression: reduce(SQC_LDS_IDX_ACTIVE,sum)
+  - name: SQC_TC_DATA_READ_REQ_sum
+    description: ''
+    properties: []
+    definitions:
+    - architectures:
+      - gfx1151
+      - gfx1152
+      expression: reduce(SQC_TC_DATA_READ_REQ,sum)
+  - name: SQC_TC_INST_REQ_sum
+    description: ''
+    properties: []
+    definitions:
+    - architectures:
+      - gfx1151
+      - gfx1152
+      expression: reduce(SQC_TC_INST_REQ,sum)
+  - name: TCP_DATA_FIFO_STALL_sum
+    description: ''
+    properties: []
+    definitions:
+    - architectures:
+      - gfx1151
+      - gfx1152
+      expression: reduce(TCP_DATA_FIFO_STALL,sum)
+  - name: TCP_GL1_REQ_READ_128B_sum
+    description: ''
+    properties: []
+    definitions:
+    - architectures:
+      - gfx1151
+      - gfx1152
+      expression: reduce(TCP_GL1_REQ_READ_128B,sum)
+  - name: TCP_GL1_REQ_READ_sum
+    description: ''
+    properties: []
+    definitions:
+    - architectures:
+      - gfx1151
+      - gfx1152
+      expression: reduce(TCP_GL1_REQ_READ,sum)
+  - name: TCP_GL1_REQ_WRITE_sum
+    description: ''
+    properties: []
+    definitions:
+    - architectures:
+      - gfx1151
+      - gfx1152
+      expression: reduce(TCP_GL1_REQ_WRITE,sum)
+  - name: TCP_GL1_TCP_BACK_PRESSURE_sum
+    description: ''
+    properties: []
+    definitions:
+    - architectures:
+      - gfx1151
+      - gfx1152
+      expression: reduce(TCP_GL1_TCP_BACK_PRESSURE,sum)
+  - name: TCP_REQ_MISS_sum
+    description: ''
+    properties: []
+    definitions:
+    - architectures:
+      - gfx1151
+      - gfx1152
+      expression: reduce(TCP_REQ_MISS,sum)
+  - name: TCP_REQ_READ_sum
+    description: ''
+    properties: []
+    definitions:
+    - architectures:
+      - gfx1151
+      - gfx1152
+      expression: reduce(TCP_REQ_READ,sum)
+  - name: TCP_REQ_WRITE_sum
+    description: ''
+    properties: []
+    definitions:
+    - architectures:
+      - gfx1151
+      - gfx1152
+      expression: reduce(TCP_REQ_WRITE,sum)
+  - name: TCP_REQ_sum
+    description: ''
+    properties: []
+    definitions:
+    - architectures:
+      - gfx1151
+      - gfx1152
+      expression: reduce(TCP_REQ,sum)
+  - name: TCP_TCP_TA_REQ_STALL_sum
+    description: ''
+    properties: []
+    definitions:
+    - architectures:
+      - gfx1151
+      - gfx1152
+      expression: reduce(TCP_TCP_TA_REQ_STALL,sum)
+  - name: GL2C_EA_RDREQ_128B_sum
+    description: Number of 128-byte GL2C/EA read requests. Sum over GL2C instances.
+    properties: []
+    definitions:
+    - architectures:
+      - gfx1151
+      - gfx1152
+      - gfx10
+      - gfx1010
+      - gfx1030
+      - gfx1031
+      - gfx1032
+      - gfx11
+      - gfx1100
+      - gfx1101
+      - gfx1102
+      - gfx12
+      - gfx1200
+      - gfx1201
+      expression: reduce(GL2C_EA_RDREQ_128B,sum)
+  - name: GL2C_EA_RDREQ_32B_sum
+    description: Number of 32-byte GL2C/EA read requests. Sum over GL2C instances.
+    properties: []
+    definitions:
+    - architectures:
+      - gfx1151
+      - gfx1152
+      - gfx10
+      - gfx1010
+      - gfx1030
+      - gfx1031
+      - gfx1032
+      - gfx11
+      - gfx1100
+      - gfx1101
+      - gfx1102
+      - gfx12
+      - gfx1200
+      - gfx1201
+      expression: reduce(GL2C_EA_RDREQ_32B,sum)
+  - name: GL2C_EA_RDREQ_64B_sum
+    description: Number of 64-byte GL2C/EA read requests. Sum over GL2C instances.
+    properties: []
+    definitions:
+    - architectures:
+      - gfx1151
+      - gfx1152
+      - gfx10
+      - gfx1010
+      - gfx1030
+      - gfx1031
+      - gfx1032
+      - gfx11
+      - gfx1100
+      - gfx1101
+      - gfx1102
+      - gfx12
+      - gfx1200
+      - gfx1201
+      expression: reduce(GL2C_EA_RDREQ_64B,sum)
+  - name: GL2C_EA_RDREQ_96B_sum
+    description: Number of 96-byte GL2C/EA read requests. Sum over GL2C instances.
+    properties: []
+    definitions:
+    - architectures:
+      - gfx1151
+      - gfx1152
+      - gfx10
+      - gfx1010
+      - gfx1030
+      - gfx1031
+      - gfx1032
+      - gfx11
+      - gfx1100
+      - gfx1101
+      - gfx1102
+      expression: reduce(GL2C_EA_RDREQ_96B,sum)
+  - name: GL2C_EA_WRREQ_64B_sum
+    description: Number of 64-byte transactions going (64-byte write or CMPSWAP) over the GL2C_EA_wrreq interface. Sum over
+      GL2C instances.
+    properties: []
+    definitions:
+    - architectures:
+      - gfx1151
+      - gfx1152
+      - gfx10
+      - gfx1010
+      - gfx1030
+      - gfx1031
+      - gfx1032
+      - gfx11
+      - gfx1100
+      - gfx1101
+      - gfx1102
+      - gfx12
+      - gfx1200
+      - gfx1201
+      expression: reduce(GL2C_EA_WRREQ_64B,sum)
+  - name: GL2C_HIT_sum
+    description: Number of cache hits. Sum over GL2C instances.
+    properties: []
+    definitions:
+    - architectures:
+      - gfx1151
+      - gfx1152
+      - gfx10
+      - gfx1010
+      - gfx1030
+      - gfx1031
+      - gfx1032
+      - gfx11
+      - gfx1100
+      - gfx1101
+      - gfx1102
+      - gfx12
+      - gfx1200
+      - gfx1201
+      expression: reduce(GL2C_HIT,sum)
+  - name: GL2C_MC_WRREQ_sum
+    description: Number of transactions (either 32-byte or 64-byte) going over the GL2C_MC_wrreq interface. Sum over GL2C
+      instances.
+    properties: []
+    definitions:
+    - architectures:
+      - gfx1151
+      - gfx1152
+      - gfx10
+      - gfx1010
+      - gfx1030
+      - gfx1031
+      - gfx1032
+      - gfx11
+      - gfx1100
+      - gfx1101
+      - gfx1102
+      expression: reduce(GL2C_MC_WRREQ,sum)
+  - name: GL2C_MISS_sum
+    description: Number of cache misses. Sum over GL2C instances.
+    properties: []
+    definitions:
+    - architectures:
+      - gfx1151
+      - gfx1152
+      - gfx10
+      - gfx1010
+      - gfx1030
+      - gfx1031
+      - gfx1032
+      - gfx11
+      - gfx1100
+      - gfx1101
+      - gfx1102
+      - gfx12
+      - gfx1200
+      - gfx1201
+      expression: reduce(GL2C_MISS,sum)
+  - name: SQ_LDS_ATOMIC_RETURN_sum
+    description: ''
+    properties: []
+    definitions:
+    - architectures:
+      - gfx1151
+      - gfx1152
+      expression: reduce(SQ_LDS_ATOMIC_RETURN,sum)
+  - name: SQ_WAVES_sum
+    description: Gives the total number of waves currently enqueued by the application during the collection timeframe (for
+      dispatch profiling this is the timeframe of kernel execution, for agent profiling it is the timeframe between start_context
+      and read counter data). See SQ_WAVES for more details.
+    properties: []
+    definitions:
+    - architectures:
+      - gfx1151
+      - gfx1152
+      - gfx10
+      - gfx1010
+      - gfx1030
+      - gfx1031
+      - gfx1032
+      - gfx11
+      - gfx1100
+      - gfx1101
+      - gfx1102
+      - gfx12
+      - gfx1200
+      - gfx1201
+      - gfx9
+      - gfx900
+      - gfx906
+      - gfx908
+      - gfx90a
+      - gfx940
+      - gfx941
+      - gfx942
+      - gfx950
+      expression: reduce(SQ_WAVES,sum)
+  - name: TA_TA_BUSY_sum
+    description: TA block is busy. Perf_Windowing not supported for this counter. Sum over TA instances.
+    properties: []
+    definitions:
+    - architectures:
+      - gfx1151
+      - gfx1152
+      - gfx90a
+      - gfx908
+      - gfx940
+      - gfx941
+      - gfx942
+      - gfx950
+      expression: reduce(TA_TA_BUSY,sum)
+  - name: TCP_GATE_EN1_sum
+    description: TCP interface clocks are turned on. Not Windowed. Sum over TCP instances.
+    properties: []
+    definitions:
+    - architectures:
+      - gfx1151
+      - gfx1152
+      - gfx90a
+      - gfx908
+      - gfx940
+      - gfx941
+      - gfx942
+      - gfx950
+      expression: reduce(TCP_GATE_EN1,sum)
+  - name: TCP_GATE_EN2_sum
+    description: TCP core clocks are turned on. Not Windowed. Sum over TCP instances.
+    properties: []
+    definitions:
+    - architectures:
+      - gfx1151
+      - gfx1152
+      - gfx90a
+      - gfx908
+      - gfx940
+      - gfx941
+      - gfx942
+      - gfx950
+      expression: reduce(TCP_GATE_EN2,sum)
+  - name: TCP_TCP_LATENCY_sum
+    description: Total TCP wave latency (from first clock of wave entering to first clock of wave leaving), divide by TA_TCP_STATE_READ
+      to avg wave latency Sum over TCP instances.
+    properties: []
+    definitions:
+    - architectures:
+      - gfx1151
+      - gfx1152
+      - gfx90a
+      - gfx908
+      - gfx950
+      expression: reduce(TCP_TCP_LATENCY,sum)
   - name: ALUStalledByLDS
     description: 'The percentage of GPUTime ALU units are stalled by the LDS input queue being full or the output queue being
       not ready. If there are LDS bank conflicts, reduce them. Otherwise, try reducing the number of LDS accesses if possible.
@@ -17,10 +4507,12 @@ rocprofiler-sdk:
       - gfx1100
       - gfx1101
       - gfx1102
+      - gfx1151
       - gfx9
       - gfx906
       - gfx908
       - gfx90a
+      - gfx1152
       expression: 400*reduce(SQ_WAIT_INST_LDS,sum)/reduce(SQ_WAVES,sum)/reduce(GRBM_GUI_ACTIVE,max)
   - name: AggSysCycles
     description: 'Unit: cycles'
@@ -36,157 +4528,6 @@ rocprofiler-sdk:
     - architectures:
       - gfx90a
       expression: reduce(SQ_THREAD_CYCLES_VALU,sum)/reduce(SQ_ACTIVE_INST_VALU,sum)
-  - name: CPC_CPC_STAT_BUSY
-    description: CPC Busy.
-    properties: []
-    definitions:
-    - architectures:
-      - gfx90a
-      - gfx908
-      - gfx940
-      - gfx941
-      - gfx942
-      - gfx950
-      block: CPC
-      event: 25
-  - name: CPC_CPC_STAT_IDLE
-    description: CPC Idle.
-    properties: []
-    definitions:
-    - architectures:
-      - gfx90a
-      - gfx908
-      - gfx940
-      - gfx941
-      - gfx942
-      - gfx950
-      block: CPC
-      event: 26
-  - name: CPC_CPC_STAT_STALL
-    description: CPC Stalled.
-    properties: []
-    definitions:
-    - architectures:
-      - gfx90a
-      - gfx908
-      - gfx940
-      - gfx941
-      - gfx942
-      - gfx950
-      block: CPC
-      event: 27
-  - name: CPC_CPC_TCIU_BUSY
-    description: CPC TCIU interface Busy.
-    properties: []
-    definitions:
-    - architectures:
-      - gfx90a
-      - gfx908
-      - gfx940
-      - gfx941
-      - gfx942
-      - gfx950
-      block: CPC
-      event: 28
-  - name: CPC_CPC_TCIU_IDLE
-    description: CPC TCIU interface Idle.
-    properties: []
-    definitions:
-    - architectures:
-      - gfx90a
-      - gfx908
-      - gfx940
-      - gfx941
-      - gfx942
-      - gfx950
-      block: CPC
-      event: 29
-  - name: CPC_CPC_UTCL2IU_BUSY
-    description: CPC UTCL2 interface Busy.
-    properties: []
-    definitions:
-    - architectures:
-      - gfx90a
-      - gfx908
-      - gfx940
-      - gfx941
-      - gfx942
-      - gfx950
-      block: CPC
-      event: 30
-  - name: CPC_CPC_UTCL2IU_IDLE
-    description: CPC UTCL2 interface Idle.
-    properties: []
-    definitions:
-    - architectures:
-      - gfx90a
-      - gfx908
-      - gfx940
-      - gfx941
-      - gfx942
-      - gfx950
-      block: CPC
-      event: 31
-  - name: CPC_CPC_UTCL2IU_STALL
-    description: CPC UTCL2 interface Stalled waiting on Free, Tags or Translation.
-    properties: []
-    definitions:
-    - architectures:
-      - gfx90a
-      - gfx908
-      - gfx940
-      - gfx941
-      - gfx942
-      - gfx950
-      block: CPC
-      event: 32
-  - name: CPC_ME1_BUSY_FOR_PACKET_DECODE
-    description: Me1 busy for packet decode.
-    properties: []
-    definitions:
-    - architectures:
-      - gfx90a
-      - gfx908
-      - gfx940
-      - gfx941
-      - gfx942
-      - gfx950
-      block: CPC
-      event: 13
-  - name: CPC_ME1_DC0_SPI_BUSY
-    description: CPC Me1 Processor Busy.
-    properties: []
-    definitions:
-    - architectures:
-      - gfx90a
-      - gfx908
-      - gfx940
-      - gfx941
-      - gfx942
-      - gfx950
-      block: CPC
-      event: 33
-  - name: CPC_UTCL1_STALL_ON_TRANSLATION
-    description: One of the UTCL1s is stalled waiting on translation, XNACK or PENDING response.
-    properties: []
-    definitions:
-    - architectures:
-      - gfx90a
-      - gfx908
-      - gfx940
-      - gfx941
-      - gfx942
-      - gfx950
-      block: CPC
-      event: 24
-  - name: CPC_ALWAYS_COUNT
-    description: Always Count.
-    properties: []
-    definitions:
-    - architectures:
-      - gfx950
-      block: CPC
-      event: 0
   - name: CPC_ADC_VALID_CHUNK_NOT_AVAIL
     description: ADC valid chunk not available when dispatch walking is in progress at multi-xcc mode.
     properties: []
@@ -431,6 +4772,7 @@ rocprofiler-sdk:
       - gfx1100
       - gfx1101
       - gfx1102
+      - gfx1151
       - gfx12
       - gfx1200
       - gfx1201
@@ -443,9 +4785,7 @@ rocprofiler-sdk:
       - gfx941
       - gfx942
       - gfx950
-      - gfx12
-      - gfx1200
-      - gfx1201
+      - gfx1152
       expression: simd_count/simd_per_cu
   - name: SIMD_NUM
     description: SIMD Number
@@ -461,6 +4801,7 @@ rocprofiler-sdk:
       - gfx1100
       - gfx1101
       - gfx1102
+      - gfx1151
       - gfx9
       - gfx900
       - gfx906
@@ -473,6 +4814,7 @@ rocprofiler-sdk:
       - gfx12
       - gfx1200
       - gfx1201
+      - gfx1152
       expression: simd_count
   - name: CpUtil
     description: 'Unit: percent'
@@ -601,6 +4943,8 @@ rocprofiler-sdk:
       - gfx1100
       - gfx1101
       - gfx1102
+      - gfx1151
+      - gfx1152
       expression: (GL2C_EA_RDREQ_32B_sum*32+GL2C_EA_RDREQ_64B_sum*64+GL2C_EA_RDREQ_96B_sum*96+GL2C_EA_RDREQ_128B_sum*128)/1024
     - architectures:
       - gfx12
@@ -614,13 +4958,11 @@ rocprofiler-sdk:
     - architectures:
       - gfx90a
       expression: 1024*(WRITE_SIZE+FETCH_SIZE)/reduce(GRBM_GUI_ACTIVE,max)
-    # Approximation which excludes TCC_EA0_RDREQ_32B due to the hardware limitation on the number of counters that can be collected.
     - architectures:
       - gfx940
       - gfx941
       - gfx942
       expression: (WRITE_SIZE*1024+TCC_BUBBLE_sum*128+(TCC_EA0_RDREQ_sum-TCC_BUBBLE_sum)*64)/reduce(GRBM_GUI_ACTIVE,max)
-    # Approximation which excludes TCC_EA0_RDREQ_32B due to the hardware limitation on the number of counters that can be collected.
     - architectures:
       - gfx950
       expression: (WRITE_SIZE*1024+TCC_EA0_RDREQ_128B_sum*128+TCC_EA0_RDREQ_64B_sum*64)/reduce(GRBM_GUI_ACTIVE,max)
@@ -681,10 +5023,12 @@ rocprofiler-sdk:
       - gfx1100
       - gfx1101
       - gfx1102
+      - gfx1151
       - gfx9
       - gfx906
       - gfx908
       - gfx90a
+      - gfx1152
       expression: reduce(SQ_INSTS_GDS,sum)/reduce(SQ_WAVES,sum)
   - name: GDS_UTIL
     description: Percentage of the GRBM_GUI_ACTIVE time that the Global Data Share (GDS) is busy.
@@ -716,157 +5060,6 @@ rocprofiler-sdk:
       - gfx1200
       - gfx1201
       expression: reduce(GL2C_EA_RDREQ,sum)
-  - name: GL2C_EA_RDREQ_128B
-    description: Number of 128-byte GL2C/EA read requests
-    properties: []
-    definitions:
-    - architectures:
-      - gfx10
-      - gfx1010
-      - gfx1030
-      - gfx1031
-      - gfx1032
-      - gfx11
-      - gfx1100
-      - gfx1101
-      - gfx1102
-      block: GL2C
-      event: 102
-    - architectures:
-      - gfx12
-      - gfx1200
-      - gfx1201
-      block: GL2C
-      event: 148
-  - name: GL2C_EA_RDREQ_128B_sum
-    description: Number of 128-byte GL2C/EA read requests. Sum over GL2C instances.
-    properties: []
-    definitions:
-    - architectures:
-      - gfx10
-      - gfx1010
-      - gfx1030
-      - gfx1031
-      - gfx1032
-      - gfx11
-      - gfx1100
-      - gfx1101
-      - gfx1102
-      - gfx12
-      - gfx1200
-      - gfx1201
-      expression: reduce(GL2C_EA_RDREQ_128B,sum)
-  - name: GL2C_EA_RDREQ_32B
-    description: Number of 32-byte GL2C/EA read requests
-    properties: []
-    definitions:
-    - architectures:
-      - gfx10
-      - gfx1010
-      - gfx1030
-      - gfx1031
-      - gfx1032
-      - gfx11
-      - gfx1100
-      - gfx1101
-      - gfx1102
-      block: GL2C
-      event: 99
-    - architectures:
-      - gfx12
-      - gfx1200
-      - gfx1201
-      block: GL2C
-      event: 146
-  - name: GL2C_EA_RDREQ_32B_sum
-    description: Number of 32-byte GL2C/EA read requests. Sum over GL2C instances.
-    properties: []
-    definitions:
-    - architectures:
-      - gfx10
-      - gfx1010
-      - gfx1030
-      - gfx1031
-      - gfx1032
-      - gfx11
-      - gfx1100
-      - gfx1101
-      - gfx1102
-      - gfx12
-      - gfx1200
-      - gfx1201
-      expression: reduce(GL2C_EA_RDREQ_32B,sum)
-  - name: GL2C_EA_RDREQ_64B
-    description: Number of 64-byte GL2C/EA read requests
-    properties: []
-    definitions:
-    - architectures:
-      - gfx10
-      - gfx1010
-      - gfx1030
-      - gfx1031
-      - gfx1032
-      - gfx11
-      - gfx1100
-      - gfx1101
-      - gfx1102
-      block: GL2C
-      event: 100
-    - architectures:
-      - gfx12
-      - gfx1200
-      - gfx1201
-      block: GL2C
-      event: 147
-  - name: GL2C_EA_RDREQ_64B_sum
-    description: Number of 64-byte GL2C/EA read requests. Sum over GL2C instances.
-    properties: []
-    definitions:
-    - architectures:
-      - gfx10
-      - gfx1010
-      - gfx1030
-      - gfx1031
-      - gfx1032
-      - gfx11
-      - gfx1100
-      - gfx1101
-      - gfx1102
-      - gfx12
-      - gfx1200
-      - gfx1201
-      expression: reduce(GL2C_EA_RDREQ_64B,sum)
-  - name: GL2C_EA_RDREQ_96B
-    description: Number of 96-byte GL2C/EA read requests
-    properties: []
-    definitions:
-    - architectures:
-      - gfx10
-      - gfx1010
-      - gfx1030
-      - gfx1031
-      - gfx1032
-      - gfx11
-      - gfx1100
-      - gfx1101
-      - gfx1102
-      block: GL2C
-      event: 101
-  - name: GL2C_EA_RDREQ_96B_sum
-    description: Number of 96-byte GL2C/EA read requests. Sum over GL2C instances.
-    properties: []
-    definitions:
-    - architectures:
-      - gfx10
-      - gfx1010
-      - gfx1030
-      - gfx1031
-      - gfx1032
-      - gfx11
-      - gfx1100
-      - gfx1101
-      - gfx1102
-      expression: reduce(GL2C_EA_RDREQ_96B,sum)
   - name: GL2C_EA_WRREQ
     description: Number of transactions (all sizes) going over the GL2C_EA_WRREQ interface for all clients. This does not
       include probe commands.
@@ -907,207 +5100,6 @@ rocprofiler-sdk:
       - gfx1200
       - gfx1201
       expression: reduce(GL2C_EA_WRREQ_STALL,max)
-  - name: GL2C_EA_WRREQ_64B
-    description: Number of 64-byte transactions going (64-byte write or CMPSWAP) over the TC_EA_wrreq interface.
-    properties: []
-    definitions:
-    - architectures:
-      - gfx10
-      - gfx1010
-      - gfx1030
-      - gfx1031
-      - gfx1032
-      - gfx11
-      - gfx1100
-      - gfx1101
-      - gfx1102
-      block: GL2C
-      event: 85
-    - architectures:
-      - gfx12
-      - gfx1200
-      - gfx1201
-      block: GL2C
-      event: 114
-  - name: GL2C_EA_WRREQ_64B_sum
-    description: Number of 64-byte transactions going (64-byte write or CMPSWAP) over the GL2C_EA_wrreq interface. Sum over
-      GL2C instances.
-    properties: []
-    definitions:
-    - architectures:
-      - gfx10
-      - gfx1010
-      - gfx1030
-      - gfx1031
-      - gfx1032
-      - gfx11
-      - gfx1100
-      - gfx1101
-      - gfx1102
-      - gfx12
-      - gfx1200
-      - gfx1201
-      expression: reduce(GL2C_EA_WRREQ_64B,sum)
-  - name: GL2C_HIT
-    description: Number of cache hits
-    properties: []
-    definitions:
-    - architectures:
-      - gfx10
-      - gfx1010
-      - gfx1030
-      - gfx1031
-      - gfx1032
-      - gfx11
-      - gfx1100
-      - gfx1101
-      - gfx1102
-      block: GL2C
-      event: 42
-    - architectures:
-      - gfx12
-      - gfx1200
-      - gfx1201
-      block: GL2C
-      event: 41
-  - name: GL2C_HIT_sum
-    description: Number of cache hits. Sum over GL2C instances.
-    properties: []
-    definitions:
-    - architectures:
-      - gfx10
-      - gfx1010
-      - gfx1030
-      - gfx1031
-      - gfx1032
-      - gfx11
-      - gfx1100
-      - gfx1101
-      - gfx1102
-      - gfx12
-      - gfx1200
-      - gfx1201
-      expression: reduce(GL2C_HIT,sum)
-  - name: GL2C_MC_RDREQ
-    description: Number of GL2C/EA read requests (either 32-byte or 64-byte or 128-byte).
-    properties: []
-    definitions:
-    - architectures:
-      - gfx10
-      - gfx1010
-      - gfx1030
-      - gfx1031
-      - gfx1032
-      - gfx11
-      - gfx1100
-      - gfx1101
-      - gfx1102
-      block: GL2C
-      event: 96
-  - name: GL2C_MC_RDREQ_sum
-    description: Number of GL2C/EA read requests (either 32-byte or 64-byte or 128-byte). Sum over GL2C instances.
-    properties: []
-    definitions:
-    - architectures:
-      - gfx10
-      - gfx1010
-      - gfx1030
-      - gfx1031
-      - gfx1032
-      - gfx11
-      - gfx1100
-      - gfx1101
-      - gfx1102
-      expression: reduce(GL2C_MC_RDREQ,sum)
-  - name: GL2C_MC_WRREQ
-    description: Number of transactions (either 32-byte or 64-byte) going over the GL2C_EA_wrreq interface. Atomics may travel
-      over the same interface and are generally classified as write requests. This does not include probe commands
-    properties: []
-    definitions:
-    - architectures:
-      - gfx10
-      - gfx1010
-      - gfx1030
-      - gfx1031
-      - gfx1032
-      - gfx11
-      - gfx1100
-      - gfx1101
-      - gfx1102
-      block: GL2C
-      event: 83
-  - name: GL2C_MC_WRREQ_STALL
-    description: Number of cycles a write request was stalled.
-    properties: []
-    definitions:
-    - architectures:
-      - gfx10
-      - gfx1010
-      - gfx1030
-      - gfx1031
-      - gfx1032
-      - gfx11
-      - gfx1100
-      - gfx1101
-      - gfx1102
-      block: GL2C
-      event: 88
-  - name: GL2C_MC_WRREQ_sum
-    description: Number of transactions (either 32-byte or 64-byte) going over the GL2C_MC_wrreq interface. Sum over GL2C
-      instances.
-    properties: []
-    definitions:
-    - architectures:
-      - gfx10
-      - gfx1010
-      - gfx1030
-      - gfx1031
-      - gfx1032
-      - gfx11
-      - gfx1100
-      - gfx1101
-      - gfx1102
-      expression: reduce(GL2C_MC_WRREQ,sum)
-  - name: GL2C_MISS
-    description: Number of cache misses.  UC reads count as misses.
-    properties: []
-    definitions:
-    - architectures:
-      - gfx10
-      - gfx1010
-      - gfx1030
-      - gfx1031
-      - gfx1032
-      - gfx11
-      - gfx1100
-      - gfx1101
-      - gfx1102
-      block: GL2C
-      event: 43
-    - architectures:
-      - gfx12
-      - gfx1200
-      - gfx1201
-      block: GL2C
-      event: 42
-  - name: GL2C_MISS_sum
-    description: Number of cache misses. Sum over GL2C instances.
-    properties: []
-    definitions:
-    - architectures:
-      - gfx10
-      - gfx1010
-      - gfx1030
-      - gfx1031
-      - gfx1032
-      - gfx11
-      - gfx1100
-      - gfx1101
-      - gfx1102
-      - gfx12
-      - gfx1200
-      - gfx1201
-      expression: reduce(GL2C_MISS,sum)
   - name: GL2C_WRREQ_STALL_max
     description: Number of cycles a write request was stalled. Max over GL2C instances.
     properties: []
@@ -1122,6 +5114,8 @@ rocprofiler-sdk:
       - gfx1100
       - gfx1101
       - gfx1102
+      - gfx1151
+      - gfx1152
       expression: reduce(GL2C_MC_WRREQ_STALL,max)
     - architectures:
       - gfx12
@@ -1142,6 +5136,7 @@ rocprofiler-sdk:
       - gfx1100
       - gfx1101
       - gfx1102
+      - gfx1151
       - gfx9
       - gfx900
       - gfx906
@@ -1150,6 +5145,7 @@ rocprofiler-sdk:
       - gfx12
       - gfx1200
       - gfx1201
+      - gfx1152
       expression: 100*reduce(GRBM_GUI_ACTIVE,max)/reduce(GRBM_COUNT,max)
   - name: GPU_UTIL
     description: Percentage of the time that GUI is active
@@ -1165,6 +5161,7 @@ rocprofiler-sdk:
       - gfx1100
       - gfx1101
       - gfx1102
+      - gfx1151
       - gfx12
       - gfx1200
       - gfx1201
@@ -1177,185 +5174,8 @@ rocprofiler-sdk:
       - gfx941
       - gfx942
       - gfx950
+      - gfx1152
       expression: 100*reduce(GRBM_GUI_ACTIVE,max)/reduce(GRBM_COUNT,max)
-  - name: GRBM_COUNT
-    description: Tie High - Count Number of Clocks
-    properties: []
-    definitions:
-    - architectures:
-      - gfx10
-      - gfx1010
-      - gfx1030
-      - gfx1031
-      - gfx1032
-      - gfx11
-      - gfx1100
-      - gfx1101
-      - gfx1102
-      - gfx12
-      - gfx1200
-      - gfx1201
-      - gfx9
-      - gfx900
-      - gfx906
-      - gfx908
-      - gfx90a
-      - gfx940
-      - gfx941
-      - gfx942
-      - gfx950
-      block: GRBM
-      event: 0
-  - name: GRBM_CPC_BUSY
-    description: The Command Processor Compute (CPC) is busy.
-    properties: []
-    definitions:
-    - architectures:
-      - gfx90a
-      - gfx908
-      - gfx940
-      - gfx941
-      - gfx942
-      - gfx950
-      block: GRBM
-      event: 30
-  - name: GRBM_CPF_BUSY
-    description: The Command Processor Fetchers (CPF) is busy.
-    properties: []
-    definitions:
-    - architectures:
-      - gfx90a
-      - gfx908
-      - gfx940
-      - gfx941
-      - gfx942
-      - gfx950
-      block: GRBM
-      event: 31
-  - name: GRBM_CP_BUSY
-    description: Any of the Command Processor (CPG/CPC/CPF) blocks are busy.
-    properties: []
-    definitions:
-    - architectures:
-      - gfx10
-      - gfx1010
-      - gfx1030
-      - gfx1031
-      - gfx1032
-      - gfx90a
-      - gfx908
-      - gfx940
-      - gfx941
-      - gfx942
-      - gfx950
-      block: GRBM
-      event: 3
-  - name: GRBM_EA_BUSY
-    description: The Efficiency Arbiter (EA) block is busy.
-    properties: []
-    definitions:
-    - architectures:
-      - gfx10
-      - gfx1010
-      - gfx1030
-      - gfx1031
-      - gfx1032
-      - gfx90a
-      - gfx908
-      - gfx940
-      - gfx941
-      - gfx942
-      - gfx950
-      block: GRBM
-      event: 35
-  - name: GRBM_GDS_BUSY
-    description: The Global Data Share (GDS) is busy.
-    properties: []
-    definitions:
-    - architectures:
-      - gfx10
-      - gfx1010
-      - gfx1030
-      - gfx1031
-      - gfx1032
-      block: GRBM
-      event: 25
-  - name: GRBM_GL2CC_BUSY
-    description: The GL2CC block is busy.
-    properties: []
-    definitions:
-    - architectures:
-      - gfx10
-      - gfx1010
-      - gfx1030
-      - gfx1031
-      - gfx1032
-      block: GRBM
-      event: 40
-  - name: GRBM_GUI_ACTIVE
-    description: The GUI is Active
-    properties: []
-    definitions:
-    - architectures:
-      - gfx10
-      - gfx1010
-      - gfx1030
-      - gfx1031
-      - gfx1032
-      - gfx11
-      - gfx1100
-      - gfx1101
-      - gfx1102
-      - gfx12
-      - gfx1200
-      - gfx1201
-      - gfx9
-      - gfx900
-      - gfx906
-      - gfx908
-      - gfx90a
-      - gfx940
-      - gfx941
-      - gfx942
-      - gfx950
-      block: GRBM
-      event: 2
-  - name: GRBM_SPI_BUSY
-    description: Any of the Shader Pipe Interpolators (SPI) are busy in the shader engine(s).
-    properties: []
-    definitions:
-    - architectures:
-      - gfx10
-      - gfx1010
-      - gfx1030
-      - gfx1031
-      - gfx1032
-      - gfx90a
-      - gfx908
-      - gfx940
-      - gfx941
-      - gfx942
-      - gfx950
-      block: GRBM
-      event: 11
-  - name: GRBM_TA_BUSY
-    description: Any of the Texture Pipes (TA) are busy in the shader engine(s).
-    properties: []
-    definitions:
-    - architectures:
-      - gfx10
-      - gfx1010
-      - gfx1030
-      - gfx1031
-      - gfx1032
-      - gfx90a
-      - gfx908
-      - gfx940
-      - gfx941
-      - gfx942
-      - gfx950
-      block: GRBM
-      event: 13
   - name: GRBM_TC_BUSY
     description: Any of the Texture Cache Blocks (TCP/TCI/TCA/TCC) are busy.
     properties: []
@@ -1369,19 +5189,6 @@ rocprofiler-sdk:
       - gfx950
       block: GRBM
       event: 28
-  - name: GRBM_UTCL2_BUSY
-    description: The Unified Translation Cache Level-2 (UTCL2) block is busy.
-    properties: []
-    definitions:
-    - architectures:
-      - gfx90a
-      - gfx908
-      - gfx940
-      - gfx941
-      - gfx942
-      - gfx950
-      block: GRBM
-      event: 34
   - name: GpuUtil
     description: 'Unit: percent'
     properties: []
@@ -1429,9 +5236,11 @@ rocprofiler-sdk:
       - gfx1100
       - gfx1101
       - gfx1102
+      - gfx1151
       - gfx12
       - gfx1200
       - gfx1201
+      - gfx1152
       expression: 100*reduce(GL2C_HIT,sum)/(reduce(GL2C_HIT,sum)+reduce(GL2C_MISS,sum))
   - name: L2CacheTagRamStallRate
     description: 'Unit: percent'
@@ -1454,9 +5263,11 @@ rocprofiler-sdk:
       - gfx1100
       - gfx1101
       - gfx1102
+      - gfx1151
       - gfx12
       - gfx1200
       - gfx1201
+      - gfx1152
       expression: 100*reduce(SQC_LDS_BANK_CONFLICT,sum)/reduce(SQC_LDS_IDX_ACTIVE,sum)
     - architectures:
       - gfx9
@@ -1502,11 +5313,13 @@ rocprofiler-sdk:
       - gfx1100
       - gfx1101
       - gfx1102
+      - gfx1151
       - gfx90a
       - gfx940
       - gfx941
       - gfx942
       - gfx950
+      - gfx1152
       expression: reduce(accumulate(SQ_INST_LEVEL_LDS, HIGH_RES),sum)/reduce(SQ_INSTS_LDS,sum)
   - name: LdsPipeIssueUtil
     description: 'Unit: percent'
@@ -1545,6 +5358,7 @@ rocprofiler-sdk:
       - gfx1100
       - gfx1101
       - gfx1102
+      - gfx1151
       - gfx9
       - gfx900
       - gfx906
@@ -1554,6 +5368,7 @@ rocprofiler-sdk:
       - gfx941
       - gfx942
       - gfx950
+      - gfx1152
       expression: wave_front_size
   - name: MeanOccupancyPerActiveCU
     description: Mean occupancy per active compute unit.
@@ -1564,9 +5379,11 @@ rocprofiler-sdk:
       - gfx1100
       - gfx1101
       - gfx1102
+      - gfx1151
       - gfx12
       - gfx1200
       - gfx1201
+      - gfx1152
       expression: reduce(SQ_WAVE_CYCLES,sum)/reduce(SQ_BUSY_CYCLES,sum)
     - architectures:
       - gfx90a
@@ -1584,9 +5401,11 @@ rocprofiler-sdk:
       - gfx1100
       - gfx1101
       - gfx1102
+      - gfx1151
       - gfx12
       - gfx1200
       - gfx1201
+      - gfx1152
       expression: reduce(SQ_WAVE_CYCLES,sum)/reduce(GRBM_GUI_ACTIVE,max)/CU_NUM
     - architectures:
       - gfx10
@@ -1614,9 +5433,11 @@ rocprofiler-sdk:
       - gfx1100
       - gfx1101
       - gfx1102
+      - gfx1151
       - gfx12
       - gfx1200
       - gfx1201
+      - gfx1152
       expression: 100*reduce(SQ_WAVE_CYCLES,sum)/reduce(GRBM_GUI_ACTIVE,max)/CU_NUM/32
     - architectures:
       - gfx90a
@@ -1641,6 +5462,7 @@ rocprofiler-sdk:
       - gfx1100
       - gfx1101
       - gfx1102
+      - gfx1151
       - gfx9
       - gfx906
       - gfx908
@@ -1648,6 +5470,7 @@ rocprofiler-sdk:
       - gfx12
       - gfx1200
       - gfx1201
+      - gfx1152
       expression: 100*reduce(TA_TA_BUSY,max)/reduce(GRBM_GUI_ACTIVE,max)
   - name: MemUnitStalled
     description: 'The percentage of GPUTime the memory unit is stalled. Try reducing the number or size of fetches and writes
@@ -1782,6 +5605,7 @@ rocprofiler-sdk:
       - gfx1100
       - gfx1101
       - gfx1102
+      - gfx1151
       - gfx9
       - gfx906
       - gfx908
@@ -1789,6 +5613,7 @@ rocprofiler-sdk:
       - gfx12
       - gfx1200
       - gfx1201
+      - gfx1152
       expression: reduce(SQ_INSTS_SALU,sum)/reduce(SQ_WAVES,sum)
   - name: SE_NUM
     description: SE_NUM
@@ -1804,6 +5629,7 @@ rocprofiler-sdk:
       - gfx1100
       - gfx1101
       - gfx1102
+      - gfx1151
       - gfx9
       - gfx900
       - gfx906
@@ -1816,6 +5642,7 @@ rocprofiler-sdk:
       - gfx12
       - gfx1200
       - gfx1201
+      - gfx1152
       expression: array_count/simd_arrays_per_engine
   - name: SFetchInsts
     description: The average number of scalar fetch instructions from the video memory executed per work-item (affected by
@@ -1832,6 +5659,7 @@ rocprofiler-sdk:
       - gfx1100
       - gfx1101
       - gfx1102
+      - gfx1151
       - gfx9
       - gfx906
       - gfx908
@@ -1839,143 +5667,8 @@ rocprofiler-sdk:
       - gfx12
       - gfx1200
       - gfx1201
+      - gfx1152
       expression: reduce(SQ_INSTS_SMEM,sum)/reduce(SQ_WAVES,sum)
-  - name: SPI_CSN_BUSY
-    description: Number of clocks with outstanding waves (SPI or SH). Requires SPI_DEBUG_CNTL.DEBUG_PIPE_SEL to select source,
-      DEBUG_PIPE_SEL = 1, source is CS1; DEBUG_PIPE_SEL = 2, source is CS2; DEBUG_PIPE_SEL = 3, source is CS3; default, source
-      is CS0;
-    properties: []
-    definitions:
-    - architectures:
-      - gfx90a
-      - gfx908
-      - gfx940
-      - gfx941
-      - gfx942
-      - gfx950
-      block: SPI
-      event: 48
-  - name: SPI_CSN_NUM_THREADGROUPS
-    description: Number of threadgroups launched. Requires SPI_DEBUG_CNTL.DEBUG_PIPE_SEL to select source, DEBUG_PIPE_SEL
-      = 1, source is CS1; DEBUG_PIPE_SEL = 2, source is CS2; DEBUG_PIPE_SEL = 3, source is CS3; default, source is CS0;
-    properties: []
-    definitions:
-    - architectures:
-      - gfx90a
-      - gfx908
-      - gfx940
-      - gfx941
-      - gfx942
-      - gfx950
-      block: SPI
-      event: 49
-  - name: SPI_CSN_WAVE
-    description: Number of waves. Requires SPI_DEBUG_CNTL.DEBUG_PIPE_SEL to select source, DEBUG_PIPE_SEL = 1, source is CS1;
-      DEBUG_PIPE_SEL = 2, source is CS2; DEBUG_PIPE_SEL = 3, source is CS3; default, source is CS0;
-    properties: []
-    definitions:
-    - architectures:
-      - gfx90a
-      - gfx908
-      - gfx940
-      - gfx941
-      - gfx942
-      - gfx950
-      block: SPI
-      event: 52
-  - name: SPI_CSN_WINDOW_VALID
-    description: Clock count enabled by perfcounter_start event. Requires SPI_DEBUG_CNTL.DEBUG_PIPE_SEL to select source,
-      DEBUG_PIPE_SEL = 1, source is CS1; DEBUG_PIPE_SEL = 2, source is CS2; DEBUG_PIPE_SEL = 3, source is CS3; default, source
-      is CS0;
-    properties: []
-    definitions:
-    - architectures:
-      - gfx90a
-      - gfx908
-      - gfx940
-      - gfx941
-      - gfx942
-      - gfx950
-      block: SPI
-      event: 47
-  - name: SPI_RA_BAR_CU_FULL_CSN
-    description: Sum of CU where BARRIER can't take csn wave when !fits. Source is RA0
-    properties: []
-    definitions:
-    - architectures:
-      - gfx90a
-      - gfx908
-      - gfx940
-      - gfx941
-      - gfx942
-      - gfx950
-      block: SPI
-      event: 123
-  - name: SPI_RA_BULKY_CU_FULL_CSN
-    description: Sum of CU where BULKY can't take csn wave when !fits. Source is RA0
-    properties: []
-    definitions:
-    - architectures:
-      - gfx90a
-      - gfx908
-      - gfx940
-      - gfx941
-      - gfx942
-      - gfx950
-      block: SPI
-      event: 125
-  - name: SPI_RA_LDS_CU_FULL_CSN
-    description: Sum of CU where LDS can't take csn wave when !fits. Source is RA0
-    properties: []
-    definitions:
-    - architectures:
-      - gfx90a
-      - gfx908
-      - gfx940
-      - gfx941
-      - gfx942
-      - gfx950
-      block: SPI
-      event: 120
-  - name: SPI_RA_REQ_NO_ALLOC
-    description: Arb cycles with requests but no allocation. Source is RA0
-    properties: []
-    definitions:
-    - architectures:
-      - gfx90a
-      - gfx908
-      - gfx940
-      - gfx941
-      - gfx942
-      - gfx950
-      block: SPI
-      event: 79
-  - name: SPI_RA_REQ_NO_ALLOC_CSN
-    description: Arb cycles with CSn req and no CSn alloc. Source is RA0
-    properties: []
-    definitions:
-    - architectures:
-      - gfx90a
-      - gfx908
-      - gfx940
-      - gfx941
-      - gfx942
-      - gfx950
-      block: SPI
-      event: 85
-  - name: SPI_RA_RES_STALL_CSN
-    description: Arb cycles with CSn req and no CSn fits. Source is RA0
-    properties: []
-    definitions:
-    - architectures:
-      - gfx90a
-      - gfx908
-      - gfx940
-      - gfx941
-      - gfx942
-      - gfx950
-      block: SPI
-      event: 91
   - name: SPI_RA_SGPR_SIMD_FULL_CSN
     description: Sum of SIMD where SGPR can't take csn wave when !fits. Source is RA0
     properties: []
@@ -1989,71 +5682,6 @@ rocprofiler-sdk:
       - gfx950
       block: SPI
       event: 115
-  - name: SPI_RA_TGLIM_CU_FULL_CSN
-    description: Cycles where csn wants to req but all CU are at tg_limit
-    properties: []
-    definitions:
-    - architectures:
-      - gfx90a
-      - gfx908
-      - gfx940
-      - gfx941
-      - gfx942
-      - gfx950
-      block: SPI
-      event: 127
-  - name: SPI_RA_TMP_STALL_CSN
-    description: Cycles where csn wants to req but does not fit in temp space.
-    properties: []
-    definitions:
-    - architectures:
-      - gfx90a
-      - gfx908
-      - gfx940
-      - gfx941
-      - gfx942
-      - gfx950
-      block: SPI
-      event: 97
-  - name: SPI_RA_VGPR_SIMD_FULL_CSN
-    description: Sum of SIMD where VGPR can't take csn wave when !fits. Source is RA0
-    properties: []
-    definitions:
-    - architectures:
-      - gfx90a
-      - gfx908
-      - gfx940
-      - gfx941
-      - gfx942
-      - gfx950
-      block: SPI
-      event: 109
-  - name: SPI_RA_WAVE_SIMD_FULL_CSN
-    description: Sum of SIMD where WAVE can't take csn wave when !fits. Source is RA0
-    properties: []
-    definitions:
-    - architectures:
-      - gfx90a
-      - gfx908
-      - gfx940
-      - gfx941
-      - gfx942
-      - gfx950
-      block: SPI
-      event: 103
-  - name: SPI_RA_WVLIM_STALL_CSN
-    description: Number of clocks csn is stalled due to WAVE LIMIT.
-    properties: []
-    definitions:
-    - architectures:
-      - gfx90a
-      - gfx908
-      - gfx940
-      - gfx941
-      - gfx942
-      - gfx950
-      block: SPI
-      event: 133
   - name: SPI_SWC_CSC_WR
     description: Number of clocks to write CSC waves to SGPRs (need to multiply this value by 4) Requires SPI_DEBUG_CNTL.DEBUG_PIPE_SEL
       to select source, DEBUG_PIPE_SEL = 1, source is CS1; DEBUG_PIPE_SEL = 2, source is CS2; DEBUG_PIPE_SEL = 3, source is
@@ -2613,290 +6241,6 @@ rocprofiler-sdk:
       - gfx950
       block: SQ
       event: 298
-  - name: SQC_DCACHE_BUSY_CYCLES
-    description: ' Clock cycles while cache is reporting that it is busy. (No-Masking, nondeterministic, unwindowed)'
-    properties: []
-    definitions:
-    - architectures:
-      - gfx940
-      - gfx941
-      - gfx942
-      - gfx950
-      block: SQ
-      event: 289
-  - name: SQC_DCACHE_HITS
-    description: Number of cache hits. (per-SQ, per-Bank, nondeterministic)
-    properties: []
-    definitions:
-    - architectures:
-      - gfx90a
-      - gfx908
-      - gfx940
-      - gfx941
-      - gfx942
-      - gfx950
-      block: SQ
-      event: 291
-  - name: SQC_DCACHE_INPUT_VALID_READYB
-    description: Input stalled by SQC (per-SQ, nondeterministic, unwindowed)
-    properties: []
-    definitions:
-    - architectures:
-      - gfx90a
-      - gfx908
-      - gfx940
-      - gfx941
-      - gfx942
-      - gfx950
-      block: SQ
-      event: 260
-  - name: SQC_DCACHE_MISSES
-    description: Number of cache misses, includes uncached requests. (per-SQ, per-Bank, nondeterministic)
-    properties: []
-    definitions:
-    - architectures:
-      - gfx90a
-      - gfx908
-      - gfx940
-      - gfx941
-      - gfx942
-      - gfx950
-      block: SQ
-      event: 292
-  - name: SQC_DCACHE_MISSES_DUPLICATE
-    description: Number of misses that were duplicates (access to a non-resident, miss pending CL). (per-SQ, per-Bank, nondeterministic)
-    properties: []
-    definitions:
-    - architectures:
-      - gfx90a
-      - gfx908
-      - gfx940
-      - gfx941
-      - gfx942
-      - gfx950
-      block: SQ
-      event: 293
-  - name: SQC_DCACHE_REQ
-    description: Number of requests (post-bank-serialization). (per-SQ, per-Bank)
-    properties: []
-    definitions:
-    - architectures:
-      - gfx90a
-      - gfx908
-      - gfx940
-      - gfx941
-      - gfx942
-      - gfx950
-      block: SQ
-      event: 290
-  - name: SQC_DCACHE_REQ_READ_1
-    description: Number of constant cache 1 dw read requests. (per-SQ)
-    properties: []
-    definitions:
-    - architectures:
-      - gfx90a
-      - gfx908
-      - gfx940
-      - gfx941
-      - gfx942
-      - gfx950
-      block: SQ
-      event: 323
-  - name: SQC_DCACHE_REQ_READ_16
-    description: Number of constant cache 16 dw read requests. (per-SQ)
-    properties: []
-    definitions:
-    - architectures:
-      - gfx90a
-      - gfx908
-      - gfx940
-      - gfx941
-      - gfx942
-      - gfx950
-      block: SQ
-      event: 327
-  - name: SQC_DCACHE_REQ_READ_2
-    description: Number of constant cache 2 dw read requests. (per-SQ)
-    properties: []
-    definitions:
-    - architectures:
-      - gfx90a
-      - gfx908
-      - gfx940
-      - gfx941
-      - gfx942
-      - gfx950
-      block: SQ
-      event: 324
-  - name: SQC_DCACHE_REQ_READ_4
-    description: Number of constant cache 4 dw read requests. (per-SQ)
-    properties: []
-    definitions:
-    - architectures:
-      - gfx90a
-      - gfx908
-      - gfx940
-      - gfx941
-      - gfx942
-      - gfx950
-      block: SQ
-      event: 325
-  - name: SQC_DCACHE_REQ_READ_8
-    description: Number of constant cache 8 dw read requests. (per-SQ)
-    properties: []
-    definitions:
-    - architectures:
-      - gfx90a
-      - gfx908
-      - gfx940
-      - gfx941
-      - gfx942
-      - gfx950
-      block: SQ
-      event: 326
-  - name: SQC_ICACHE_BUSY_CYCLES
-    description: Clock cycles while cache is reporting that it is busy. (No-Masking, nondeterministic, unwindowed)
-    properties: []
-    definitions:
-    - architectures:
-      - gfx940
-      - gfx941
-      - gfx942
-      - gfx950
-      block: SQ
-      event: 269
-  - name: SQC_ICACHE_HITS
-    description: Number of cache hits. (per-SQ, per-Bank, nondeterministic)
-    properties: []
-    definitions:
-    - architectures:
-      - gfx90a
-      - gfx908
-      - gfx940
-      - gfx941
-      - gfx942
-      - gfx950
-      block: SQ
-      event: 271
-    - architectures:
-      - gfx12
-      - gfx1200
-      - gfx1201
-      block: SQ
-      event: 302
-  - name: SQC_ICACHE_INPUT_VALID_READYB
-    description: ' Input stalled by SQC (per-SQ, nondeterministic, unwindowed)'
-    properties: []
-    definitions:
-    - architectures:
-      - gfx940
-      - gfx941
-      - gfx942
-      - gfx950
-      block: SQ
-      event: 257
-  - name: SQC_ICACHE_MISSES
-    description: Number of cache misses, includes uncached requests. (per-SQ, per-Bank, nondeterministic)
-    properties: []
-    definitions:
-    - architectures:
-      - gfx90a
-      - gfx908
-      - gfx940
-      - gfx941
-      - gfx942
-      - gfx950
-      block: SQ
-      event: 272
-    - architectures:
-      - gfx12
-      - gfx1200
-      - gfx1201
-      block: SQ
-      event: 303
-  - name: SQC_ICACHE_MISSES_DUPLICATE
-    description: Number of misses that were duplicates (access to a non-resident, miss pending CL). (per-SQ, per-Bank, nondeterministic)
-    properties: []
-    definitions:
-    - architectures:
-      - gfx90a
-      - gfx908
-      - gfx940
-      - gfx941
-      - gfx942
-      - gfx950
-      block: SQ
-      event: 273
-  - name: SQC_ICACHE_REQ
-    description: Number of requests. (per-SQ, per-Bank)
-    properties: []
-    definitions:
-    - architectures:
-      - gfx90a
-      - gfx908
-      - gfx940
-      - gfx941
-      - gfx942
-      - gfx950
-      block: SQ
-      event: 270
-    - architectures:
-      - gfx12
-      - gfx1200
-      - gfx1201
-      block: SQ
-      event: 301
-  - name: SQC_LDS_BANK_CONFLICT
-    description: Number of cycles LDS is stalled by bank conflicts. (emulated, C1)
-    properties: []
-    definitions:
-    - architectures:
-      - gfx10
-      - gfx1010
-      - gfx1030
-      - gfx1031
-      - gfx1032
-      block: SQ
-      event: 285
-    - architectures:
-      - gfx11
-      - gfx1100
-      - gfx1101
-      - gfx1102
-      block: SQ
-      event: 256
-    - architectures:
-      - gfx12
-      - gfx1200
-      - gfx1201
-      block: SQ
-      event: 288
-  - name: SQC_LDS_IDX_ACTIVE
-    description: Number of cycles LDS is used for indexed (non-direct,non-interpolation) operations. {per-simd, emulated,
-      C1}
-    properties: []
-    definitions:
-    - architectures:
-      - gfx10
-      - gfx1010
-      - gfx1030
-      - gfx1031
-      - gfx1032
-      block: SQ
-      event: 290
-    - architectures:
-      - gfx11
-      - gfx1100
-      - gfx1101
-      - gfx1102
-      block: SQ
-      event: 261
-    - architectures:
-      - gfx12
-      - gfx1200
-      - gfx1201
-      block: SQ
-      event: 293
   - name: SQC_TC_DATA_ATOMIC_REQ
     description: Number of data atomic requests to the TC (No-Masking, nondeterministic)
     properties: []
@@ -2910,19 +6254,6 @@ rocprofiler-sdk:
       - gfx950
       block: SQ
       event: 266
-  - name: SQC_TC_DATA_READ_REQ
-    description: Number of data read requests to the TC (No-Masking, nondeterministic)
-    properties: []
-    definitions:
-    - architectures:
-      - gfx90a
-      - gfx908
-      - gfx940
-      - gfx941
-      - gfx942
-      - gfx950
-      block: SQ
-      event: 264
   - name: SQC_TC_DATA_WRITE_REQ
     description: Number of data write requests to the TC (No-Masking, nondeterministic)
     properties: []
@@ -2936,72 +6267,6 @@ rocprofiler-sdk:
       - gfx950
       block: SQ
       event: 265
-  - name: SQC_TC_INST_REQ
-    description: Number of insruction requests to the TC (No-Masking, nondeterministic)
-    properties: []
-    definitions:
-    - architectures:
-      - gfx90a
-      - gfx908
-      - gfx940
-      - gfx941
-      - gfx942
-      - gfx950
-      block: SQ
-      event: 263
-  - name: SQC_TC_REQ
-    description: Total number of TC requests that were issued by instruction and constant caches. (No-Masking, nondeterministic)
-    properties: []
-    definitions:
-    - architectures:
-      - gfx90a
-      - gfx908
-      - gfx940
-      - gfx941
-      - gfx942
-      - gfx950
-      block: SQ
-      event: 262
-  - name: SQC_TC_STALL
-    description: Valid request stalled TC request interface (no-credits). (No-Masking, nondeterministic, unwindowed)
-    properties: []
-    definitions:
-    - architectures:
-      - gfx90a
-      - gfx908
-      - gfx940
-      - gfx941
-      - gfx942
-      - gfx950
-      block: SQ
-      event: 267
-  - name: SQ_ACCUM_PREV
-    description: This is a hardware register that can be used for accumulating values for other counters. This is useful in
-      expressions where you want to integrate over time. Only accumulates once every 4 cycles. This counter is primarily for
-      use with derived counters supplied by rocprof.
-    properties: []
-    definitions:
-    - architectures:
-      - gfx10
-      - gfx1010
-      - gfx1030
-      - gfx1031
-      - gfx1032
-      - gfx11
-      - gfx1100
-      - gfx1101
-      - gfx1102
-      - gfx12
-      - gfx1200
-      - gfx1201
-      - gfx90a
-      - gfx908
-      - gfx940
-      - gfx941
-      - gfx942
-      - gfx950
-      block: SQ
-      event: 1
   - name: SQ_ACCUM_PREV_HIRES
     description: This is a hardware register that can be used for accumulating values for other counters. This is useful in
       expressions where you want to integrate over time. This counter is primarily for use with derived counters supplied
@@ -3247,46 +6512,6 @@ rocprofiler-sdk:
       - gfx950
       block: SQ
       event: 13
-  - name: SQ_BUSY_CYCLES
-    description: Number of clock cycles there are active waves in a shader engine (as reported by the distributed sequencer).
-      This value does not denote the number of active waves, only the clock cycle in which any wave is present in a SE. This
-      value is returned on a per-shader engine basis in clock cycles.
-    properties: []
-    definitions:
-    - architectures:
-      - gfx10
-      - gfx1010
-      - gfx1030
-      - gfx1031
-      - gfx1032
-      - gfx11
-      - gfx1100
-      - gfx1101
-      - gfx1102
-      - gfx12
-      - gfx1200
-      - gfx1201
-      - gfx90a
-      - gfx908
-      - gfx940
-      - gfx941
-      - gfx942
-      - gfx950
-      block: SQ
-      event: 3
-  - name: SQ_CYCLES
-    description: Clock cycles. Value is returned per-SIMD.
-    properties: []
-    definitions:
-    - architectures:
-      - gfx90a
-      - gfx908
-      - gfx940
-      - gfx941
-      - gfx942
-      - gfx950
-      block: SQ
-      event: 2
   - name: SQ_IFETCH
     description: Number of instruction fetch requests from L1I (instruction) cache. This is a value returned per-SIMD.
     properties: []
@@ -3310,8 +6535,8 @@ rocprofiler-sdk:
       block: SQ
       event: 136
   - name: SQ_IFETCH_LEVEL
-    description: Level count number of inflight instruction fetch requests from the cache. This is a value returned per-sharder engine.
-      Best used with accumulate() functions as part of a derived counter.
+    description: Level count number of inflight instruction fetch requests from the cache. This is a value returned per-sharder
+      engine. Best used with accumulate() functions as part of a derived counter.
     properties: []
     definitions:
     - architectures:
@@ -3347,105 +6572,6 @@ rocprofiler-sdk:
       - gfx950
       block: SQ
       event: 25
-  - name: SQ_INSTS_BRANCH
-    description: Total number of BRANCH instructions issued. This value is returned per-SE (aggregate of values in SIMDs in
-      the SE). This value SHOULD NOT be used in combination with SQ_ACTIVE_INST_MISC to calculate latency. SQ_ACTIVE_INST_MISC
-      includes both BRANCH and SENDMSG instructions while this is only BRANCH.
-    properties: []
-    definitions:
-    - architectures:
-      - gfx90a
-      block: SQ
-      event: 64
-    - architectures:
-      - gfx908
-      block: SQ
-      event: 39
-    - architectures:
-      - gfx940
-      - gfx941
-      - gfx942
-      block: SQ
-      event: 69
-    - architectures:
-      - gfx950
-      block: SQ
-      event: 71
-  - name: SQ_INSTS_EXP_GDS
-    description: Total number of EXPORT or GDS (global wave state) instructions issued. When used in combination with SQ_ACTIVE_INST_EXP_GDS
-      (cycle count for executing instructions) the average latency of EXPORT/GDS instruction execution can be calculated (SQ_ACTIVE_INST_EXP_GDS
-      / SQ_INSTS_EXP_GDS). This value is returned per-SE (aggregate of values in SIMDs in the SE).
-    properties: []
-    definitions:
-    - architectures:
-      - gfx90a
-      block: SQ
-      event: 63
-    - architectures:
-      - gfx908
-      block: SQ
-      event: 38
-    - architectures:
-      - gfx940
-      - gfx941
-      - gfx942
-      block: SQ
-      event: 68
-    - architectures:
-      - gfx950
-      block: SQ
-      event: 70
-  - name: SQ_INSTS_FLAT
-    description: Total number of FLAT instructions issued. When used in combination with SQ_ACTIVE_INST_FLAT (cycle count
-      for executing instructions) the average latency of FLAT instruction execution can be calculated (SQ_ACTIVE_INST_FLAT
-      / SQ_INSTS). This value is returned per-SE (aggregate of values in SIMDs in the SE).
-    properties: []
-    definitions:
-    - architectures:
-      - gfx10
-      - gfx1010
-      - gfx1030
-      - gfx1031
-      - gfx1032
-      block: SQ
-      event: 57
-    - architectures:
-      - gfx9
-      - gfx900
-      - gfx906
-      block: SQ
-      event: 32
-    - architectures:
-      - gfx908
-      block: SQ
-      event: 33
-    - architectures:
-      - gfx90a
-      block: SQ
-      event: 58
-    - architectures:
-      - gfx940
-      - gfx941
-      - gfx942
-      block: SQ
-      event: 62
-    - architectures:
-      - gfx11
-      - gfx1100
-      - gfx1101
-      - gfx1102
-      block: SQ
-      event: 56
-    - architectures:
-      - gfx12
-      - gfx1200
-      - gfx1201
-      block: SQ
-      event: 44
-    - architectures:
-      - gfx950
-      block: SQ
-      event: 64
   - name: SQ_INSTS_FLAT_LDS_ONLY
     description: Total number of FLAT instructions issued that read/wrote only from/to LDS (scratch memory). Values are only
       populated if EARLY_TA_DONE is enabled. This value is returned per-SE (aggregate of values in SIMDs in the SE).
@@ -3465,100 +6591,6 @@ rocprofiler-sdk:
       - gfx90a
       block: SQ
       event: 59
-  - name: SQ_INSTS_GDS
-    description: Total number of GDS (global data sync) instructions issued. This value is returned per-SE (aggregate of values
-      in SIMDs in the SE). See AMD ISAs for more information on GDS (global data sync) instructions.
-    properties: []
-    definitions:
-    - architectures:
-      - gfx10
-      - gfx1010
-      - gfx1030
-      - gfx1031
-      - gfx1032
-      block: SQ
-      event: 55
-    - architectures:
-      - gfx9
-      - gfx900
-      - gfx906
-      block: SQ
-      event: 35
-    - architectures:
-      - gfx908
-      block: SQ
-      event: 36
-    - architectures:
-      - gfx90a
-      block: SQ
-      event: 61
-    - architectures:
-      - gfx940
-      - gfx941
-      - gfx942
-      block: SQ
-      event: 66
-    - architectures:
-      - gfx11
-      - gfx1100
-      - gfx1101
-      - gfx1102
-      block: SQ
-      event: 54
-    - architectures:
-      - gfx950
-      block: SQ
-      event: 68
-  - name: SQ_INSTS_LDS
-    description: Total number of LDS instructions issued (including FLAT). This value is returned per-SE (aggregate of values
-      in SIMDs in the SE). See AMD ISAs for more information on LDS instructions.
-    properties: []
-    definitions:
-    - architectures:
-      - gfx10
-      - gfx1010
-      - gfx1030
-      - gfx1031
-      - gfx1032
-      block: SQ
-      event: 59
-    - architectures:
-      - gfx9
-      - gfx900
-      - gfx906
-      block: SQ
-      event: 34
-    - architectures:
-      - gfx908
-      block: SQ
-      event: 35
-    - architectures:
-      - gfx90a
-      block: SQ
-      event: 60
-    - architectures:
-      - gfx940
-      - gfx941
-      - gfx942
-      block: SQ
-      event: 65
-    - architectures:
-      - gfx11
-      - gfx1100
-      - gfx1101
-      - gfx1102
-      block: SQ
-      event: 57
-    - architectures:
-      - gfx12
-      - gfx1200
-      - gfx1201
-      block: SQ
-      event: 45
-    - architectures:
-      - gfx950
-      block: SQ
-      event: 67
   - name: SQ_INSTS_MFMA
     description: Total number of MFMA (Matrix-Fused-Multiply-Add) instructions issued. This value is returned per-SE (aggregate
       of values in SIMDs in the SE). See AMD ISAs for more information on MFMA instructions.
@@ -3582,222 +6614,6 @@ rocprofiler-sdk:
       - gfx950
       block: SQ
       event: 58
-  - name: SQ_INSTS_SALU
-    description: Total Number of SALU (Scalar ALU) instructions issued. This value is returned per-SE (aggregate of values
-      in SIMDs in the SE). See AMD ISAs for more information on SALU instructions.
-    properties: []
-    definitions:
-    - architectures:
-      - gfx9
-      - gfx900
-      - gfx906
-      block: SQ
-      event: 30
-    - architectures:
-      - gfx908
-      block: SQ
-      event: 31
-    - architectures:
-      - gfx90a
-      block: SQ
-      event: 56
-    - architectures:
-      - gfx10
-      - gfx1010
-      - gfx1030
-      - gfx1031
-      - gfx1032
-      - gfx940
-      - gfx941
-      - gfx942
-      block: SQ
-      event: 60
-    - architectures:
-      - gfx11
-      - gfx1100
-      - gfx1101
-      - gfx1102
-      block: SQ
-      event: 58
-    - architectures:
-      - gfx12
-      - gfx1200
-      - gfx1201
-      block: SQ
-      event: 46
-    - architectures:
-      - gfx950
-      block: SQ
-      event: 62
-  - name: SQ_INSTS_SENDMSG
-    description: Total number of Sendmsg (typically an interrupt to the CPU host) instructions issued. This value is returned
-      per-SE (aggregate of values in SIMDs in the SE). See AMD ISAs for more information on Sendmsg instructions.
-    properties: []
-    definitions:
-    - architectures:
-      - gfx90a
-      block: SQ
-      event: 65
-    - architectures:
-      - gfx908
-      block: SQ
-      event: 40
-    - architectures:
-      - gfx940
-      - gfx941
-      - gfx942
-      block: SQ
-      event: 70
-    - architectures:
-      - gfx950
-      block: SQ
-      event: 72
-  - name: SQ_INSTS_SMEM
-    description: Total number of SMEM (Scalar Memory Read) instructions issued. This value is returned per-SE (aggregate of
-      values in SIMDs in the SE). See AMD ISAs for more information on SMEM instructions.
-    properties: []
-    definitions:
-    - architectures:
-      - gfx9
-      - gfx900
-      - gfx906
-      block: SQ
-      event: 31
-    - architectures:
-      - gfx908
-      block: SQ
-      event: 32
-    - architectures:
-      - gfx90a
-      block: SQ
-      event: 57
-    - architectures:
-      - gfx10
-      - gfx1010
-      - gfx1030
-      - gfx1031
-      - gfx1032
-      - gfx940
-      - gfx941
-      - gfx942
-      block: SQ
-      event: 61
-    - architectures:
-      - gfx11
-      - gfx1100
-      - gfx1101
-      - gfx1102
-      block: SQ
-      event: 59
-    - architectures:
-      - gfx12
-      - gfx1200
-      - gfx1201
-      block: SQ
-      event: 47
-    - architectures:
-      - gfx950
-      block: SQ
-      event: 63
-  - name: SQ_INSTS_SMEM_NORM
-    description: Number of SMEM instructions issued normalized to match the level of memory accessed (i.e. scratch, global,
-      etc). This normalized value is designed to give a hint of high cost memory actions being used. The formula used to calculate
-      this value is the following (INST_COUNT *2 for load/store; INST_COUNT*2 atomic; INST_COUNT*2 memtime; INST_COUNT*4 wb/inv).
-      This value is returned per-SE (aggregate of values in SIMDs in the SE).
-    properties: []
-    definitions:
-    - architectures:
-      - gfx90a
-      block: SQ
-      event: 188
-    - architectures:
-      - gfx908
-      block: SQ
-      event: 161
-    - architectures:
-      - gfx940
-      - gfx941
-      - gfx942
-      block: SQ
-      event: 187
-    - architectures:
-      - gfx950
-      block: SQ
-      event: 203
-  - name: SQ_INSTS_TEX_LOAD
-    description: The number of buffer load, image load, sample, or atomic (with return) texture instructions issued. The value
-      is returned per-SE (aggregate of values in SIMDs in the SE). See AMD ISAs for more information on TEX_LOAD instructions.
-    properties: []
-    definitions:
-    - architectures:
-      - gfx11
-      - gfx1100
-      - gfx1101
-      - gfx1102
-      block: SQ
-      event: 66
-    - architectures:
-      - gfx12
-      - gfx1200
-      - gfx1201
-      block: SQ
-      event: 54
-  - name: SQ_INSTS_TEX_STORE
-    description: The number of buffer store, image store, or atomic (without return) texture instructions issued. The value
-      is returned per-SE (aggregate of values in SIMDs in the SE). See AMD ISAs for more information on TEX_STORE instructions.
-    properties: []
-    definitions:
-    - architectures:
-      - gfx11
-      - gfx1100
-      - gfx1101
-      - gfx1102
-      block: SQ
-      event: 67
-    - architectures:
-      - gfx12
-      - gfx1200
-      - gfx1201
-      block: SQ
-      event: 55
-  - name: SQ_INSTS_VALU
-    description: The number of VALU (Vector ALU) instructions issued. The value is returned per-SE (aggregate of values in
-      SIMDs in the SE). See AMD ISAs for more information on VALU instructions.
-    properties: []
-    definitions:
-    - architectures:
-      - gfx10
-      - gfx1010
-      - gfx1030
-      - gfx1031
-      - gfx1032
-      block: SQ
-      event: 64
-    - architectures:
-      - gfx9
-      - gfx900
-      - gfx906
-      - gfx908
-      - gfx90a
-      - gfx940
-      - gfx941
-      - gfx942
-      - gfx950
-      block: SQ
-      event: 26
-    - architectures:
-      - gfx11
-      - gfx1100
-      - gfx1101
-      - gfx1102
-      block: SQ
-      event: 62
-    - architectures:
-      - gfx12
-      - gfx1200
-      - gfx1201
-      block: SQ
-      event: 50
   - name: SQ_INSTS_VALU_ADD_F16
     description: The number of VALU (Vector ALU) ADD/SUB instructions on float16. For maximum performance lower precision
       floating point ops are preferred to higher precision ones. The value is returned per-SE (aggregate of values in SIMDs
@@ -4337,93 +7153,6 @@ rocprofiler-sdk:
       - gfx950
       block: SQ
       event: 73
-  - name: SQ_INSTS_WAVE32
-    description: Number of wave32 instructions issued, for flat, lds, valu, tex. {emulated, C1}
-    properties: []
-    definitions:
-    - architectures:
-      - gfx10
-      - gfx1010
-      - gfx1030
-      - gfx1031
-      - gfx1032
-      block: SQ
-      event: 71
-    - architectures:
-      - gfx11
-      - gfx1100
-      - gfx1101
-      - gfx1102
-      block: SQ
-      event: 70
-    - architectures:
-      - gfx12
-      - gfx1200
-      - gfx1201
-      block: SQ
-      event: 58
-  - name: SQ_INSTS_WAVE32_LDS
-    description: Number of wave32 LDS indexed instructions issued. Wave64 may count 1 or 2, depending on what gets issued.
-      {emulated, C1}
-    properties: []
-    definitions:
-    - architectures:
-      - gfx10
-      - gfx1010
-      - gfx1030
-      - gfx1031
-      - gfx1032
-      block: SQ
-      event: 74
-    - architectures:
-      - gfx11
-      - gfx1100
-      - gfx1101
-      - gfx1102
-      block: SQ
-      event: 72
-    - architectures:
-      - gfx12
-      - gfx1200
-      - gfx1201
-      block: SQ
-      event: 60
-  - name: SQ_INSTS_WAVE32_VALU
-    description: Number of wave32 valu instructions issued. Wave64 may count 1 or 2, depending on what gets issued. {emulated,
-      C1}
-    properties: []
-    definitions:
-    - architectures:
-      - gfx10
-      - gfx1010
-      - gfx1030
-      - gfx1031
-      - gfx1032
-      block: SQ
-      event: 75
-    - architectures:
-      - gfx11
-      - gfx1100
-      - gfx1101
-      - gfx1102
-      block: SQ
-      event: 73
-    - architectures:
-      - gfx12
-      - gfx1200
-      - gfx1201
-      block: SQ
-      event: 61
-  - name: SQ_INST_CYCLES_VALU
-    description: Number of cycles needed to execute VALU operations (SIMD cycles), where there is overlapping V_OP32_1 and V_OP32_T instruction, count them seperately.
-    properties: []
-    definitions:
-      - architectures:
-        - gfx12
-        - gfx1200
-        - gfx1201
-        block: SQ
-        event: 99
   - name: SQ_INST_CYCLES_SALU
     description: The number of cycles needed to execute non-memory read scalar operations (SALU). This value is returned on
       a per-SE (aggregate of values in SIMDs in the SE) basis with units in quad-cycles(4 cycles).
@@ -4476,33 +7205,6 @@ rocprofiler-sdk:
       - gfx950
       block: SQ
       event: 132
-  - name: SQ_INST_CYCLES_VMEM
-    description: The number of cycles needed to send addr and data for VMEM (lds, buffer, image, flat, scratch, global) instructions,
-      windowed by perf_en. This value is returned on a per-SE (aggregate of values in SIMDs in the SE) basis with units in
-      quad-cycles(4 cycles).
-    properties: []
-    definitions:
-    - architectures:
-      - gfx10
-      - gfx1010
-      - gfx1030
-      - gfx1031
-      - gfx1032
-      block: SQ
-      event: 120
-    - architectures:
-      - gfx11
-      - gfx1100
-      - gfx1101
-      - gfx1102
-      block: SQ
-      event: 106
-    - architectures:
-      - gfx12
-      - gfx1200
-      - gfx1201
-      block: SQ
-      event: 102
   - name: SQ_INST_CYCLES_VMEM_RD
     description: The number of cycles needed to send addr and cmd data for VMEM read instructions. This value is returned
       on a per-SE (aggregate of values in SIMDs in the SE) basis with units in quad-cycles(4 cycles).
@@ -4549,101 +7251,10 @@ rocprofiler-sdk:
       - gfx950
       block: SQ
       event: 125
-  - name: SQ_INST_LEVEL_GDS
-    description: Level count number of in-flight GDS (global) instructions. This value represents the number of instructions each wave
-      spends synchronizing workgroups across the device (global data sync). Set next counter to ACCUM_PREV and divide by INSTS_GDS
-      for average latency. This value is returned on a per-SE (aggregate of values in SIMDs in the SE) basis.
-    properties: []
-    definitions:
-    - architectures:
-      - gfx10
-      - gfx1010
-      - gfx1030
-      - gfx1031
-      - gfx1032
-      block: SQ
-      event: 98
-    - architectures:
-      - gfx11
-      - gfx1100
-      - gfx1101
-      - gfx1102
-      block: SQ
-      event: 87
-  - name: SQ_INST_LEVEL_LDS
-    description: Level count number of in-flight LDS instructions. This value represents the number of instructions each wave spends executing
-      instructions accessing the local data store (data shared between SIMDs on the same CU). Set next counter to ACCUM_PREV
-      and divide by INSTS_LDS for average latency. Includes FLAT instructions. This value is returned on a per-SE (aggregate
-      of values in SIMDs in the SE) basis.
-    properties: []
-    definitions:
-    - architectures:
-      - gfx10
-      - gfx1010
-      - gfx1030
-      - gfx1031
-      - gfx1032
-      block: SQ
-      event: 99
-    - architectures:
-      - gfx90a
-      block: SQ
-      event: 69
-    - architectures:
-      - gfx908
-      block: SQ
-      event: 44
-    - architectures:
-      - gfx940
-      - gfx941
-      - gfx942
-      block: SQ
-      event: 74
-    - architectures:
-      - gfx11
-      - gfx1100
-      - gfx1101
-      - gfx1102
-      block: SQ
-      event: 88
-    - architectures:
-      - gfx12
-      - gfx1200
-      - gfx1201
-      block: SQ
-      event: 75
-    - architectures:
-      - gfx950
-      block: SQ
-      event: 90
-  - name: SQ_INST_LEVEL_SMEM
-    description: Level count number of in-flight SMEM instructions (*2 load/store; *2 atomic; *2 memtime; *4 wb/inv). Set next counter
-      to ACCUM_PREV and divide by INSTS_SMEM for average latency per smem request. Falls slightly short of total request latency
-      because some fetches are divided into two requests that may finish at different times and this counter collects the
-      average latency of the two. This value is returned on a per-SE (aggregate of values in SIMDs in the SE) basis.
-    properties: []
-    definitions:
-    - architectures:
-      - gfx90a
-      block: SQ
-      event: 68
-    - architectures:
-      - gfx908
-      block: SQ
-      event: 43
-    - architectures:
-      - gfx940
-      - gfx941
-      - gfx942
-      block: SQ
-      event: 73
-    - architectures:
-      - gfx950
-      block: SQ
-      event: 89
   - name: SQ_INST_LEVEL_VMEM
-    description: Level count number of in-flight VMEM instructions. Set next counter to ACCUM_PREV and divide by INSTS_VMEM for average
-      latency. Includes FLAT instructions. This value is returned on a per-SE (aggregate of values in SIMDs in the SE) basis.
+    description: Level count number of in-flight VMEM instructions. Set next counter to ACCUM_PREV and divide by INSTS_VMEM
+      for average latency. Includes FLAT instructions. This value is returned on a per-SE (aggregate of values in SIMDs in
+      the SE) basis.
     properties: []
     definitions:
     - architectures:
@@ -4664,20 +7275,6 @@ rocprofiler-sdk:
       - gfx950
       block: SQ
       event: 88
-  - name: SQ_ITEMS
-    description: Number of valid items per wave. This value is returned on a per-SE (aggregate of values in SIMDs in the SE)
-      basis.
-    properties: []
-    definitions:
-    - architectures:
-      - gfx90a
-      - gfx908
-      - gfx940
-      - gfx941
-      - gfx942
-      - gfx950
-      block: SQ
-      event: 14
   - name: SQ_LDS_ADDR_CONFLICT
     description: Number of cycles LDS (local data store) is stalled by address conflicts. This value is returned on a per-SE
       (aggregate of values in SIMDs in the SE) basis.
@@ -4701,149 +7298,6 @@ rocprofiler-sdk:
       - gfx950
       block: SQ
       event: 143
-  - name: SQ_LDS_ATOMIC_RETURN
-    description: The number of atomic return cycles in LDS (local data store). This value is returned on a per-SE (aggregate
-      of values in SIMDs in the SE) basis.
-    properties: []
-    definitions:
-    - architectures:
-      - gfx90a
-      block: SQ
-      event: 125
-    - architectures:
-      - gfx908
-      block: SQ
-      event: 98
-    - architectures:
-      - gfx940
-      - gfx941
-      - gfx942
-      block: SQ
-      event: 130
-    - architectures:
-      - gfx950
-      block: SQ
-      event: 146
-  - name: SQ_LDS_BANK_CONFLICT
-    description: The number of cycles LDS (local data store) is stalled by bank conflicts. This value is returned on a per-SE
-      (aggregate of values in SIMDs in the SE) basis.
-    properties: []
-    definitions:
-    - architectures:
-      - gfx9
-      - gfx900
-      - gfx906
-      block: SQ
-      event: 93
-    - architectures:
-      - gfx908
-      block: SQ
-      event: 94
-    - architectures:
-      - gfx90a
-      block: SQ
-      event: 121
-    - architectures:
-      - gfx940
-      - gfx941
-      - gfx942
-      block: SQ
-      event: 126
-    - architectures:
-      - gfx950
-      block: SQ
-      event: 142
-  - name: SQ_LDS_IDX_ACTIVE
-    description: Number of cycles LDS (local data store) is used for indexed (non-direct,non-interpolation) operations. This
-      value is returned on a per-SE (aggregate of values in SIMDs in the SE) basis.
-    properties: []
-    definitions:
-    - architectures:
-      - gfx90a
-      block: SQ
-      event: 126
-    - architectures:
-      - gfx908
-      block: SQ
-      event: 99
-    - architectures:
-      - gfx940
-      - gfx941
-      - gfx942
-      block: SQ
-      event: 131
-    - architectures:
-      - gfx950
-      block: SQ
-      event: 147
-  - name: SQ_LDS_MEM_VIOLATIONS
-    description: Number of threads that have a memory violation in the LDS (local data store). This value is returned on a
-      per-SE (aggregate of values in SIMDs in the SE) basis.
-    properties: []
-    definitions:
-    - architectures:
-      - gfx90a
-      block: SQ
-      event: 124
-    - architectures:
-      - gfx908
-      block: SQ
-      event: 97
-    - architectures:
-      - gfx940
-      - gfx941
-      - gfx942
-      block: SQ
-      event: 129
-    - architectures:
-      - gfx950
-      block: SQ
-      event: 145
-  - name: SQ_LDS_UNALIGNED_STALL
-    description: Number of cycles LDS (local data store) is stalled processing flat unaligned load/store ops. This value is
-      returned on a per-SE (aggregate of values in SIMDs in the SE) basis.
-    properties: []
-    definitions:
-    - architectures:
-      - gfx90a
-      block: SQ
-      event: 123
-    - architectures:
-      - gfx908
-      block: SQ
-      event: 96
-    - architectures:
-      - gfx940
-      - gfx941
-      - gfx942
-      block: SQ
-      event: 128
-    - architectures:
-      - gfx950
-      block: SQ
-      event: 144
-  - name: SQ_LEVEL_WAVES
-    description: Level count number of waves. Set ACCUM_PREV for the next counter to use this. This value is returned on a per-SIMD
-      basis.
-    properties: []
-    definitions:
-    - architectures:
-      - gfx10
-      - gfx1010
-      - gfx1030
-      - gfx1031
-      - gfx1032
-      block: SQ
-      event: 7
-    - architectures:
-      - gfx90a
-      - gfx908
-      - gfx940
-      - gfx941
-      - gfx942
-      - gfx950
-      block: SQ
-      event: 5
   - name: SQ_THREAD_CYCLES_VALU
     description: 'Number of thread-cycles used to execute VALU operations (similar to INST_CYCLES_VALU but multiplied by #
       of active threads). (per-simd)'
@@ -4892,438 +7346,16 @@ rocprofiler-sdk:
       - gfx950
       block: SQ
       event: 93
-  - name: SQ_WAIT_ANY
-    description: Number of wave-cycles spent waiting for anything (per-simd, nondeterministic). Units in quad-cycles(4 cycles)
-    properties: []
-    definitions:
-    - architectures:
-      - gfx10
-      - gfx1010
-      - gfx1030
-      - gfx1031
-      - gfx1032
-      block: SQ
-      event: 37
-    - architectures:
-      - gfx90a
-      block: SQ
-      event: 85
-    - architectures:
-      - gfx908
-      block: SQ
-      event: 58
-    - architectures:
-      - gfx940
-      - gfx941
-      - gfx942
-      block: SQ
-      event: 90
-    - architectures:
-      - gfx11
-      - gfx1100
-      - gfx1101
-      - gfx1102
-      block: SQ
-      event: 35
-    - architectures:
-      - gfx12
-      - gfx1200
-      - gfx1201
-      block: SQ
-      event: 27
-    - architectures:
-      - gfx950
-      block: SQ
-      event: 106
-  - name: SQ_WAIT_INST_ANY
-    description: Number of wave-cycles spent waiting for any instruction issue. Units in quad-cycles(4 cycles).
-    properties: []
-    definitions:
-    - architectures:
-      - gfx10
-      - gfx1010
-      - gfx1030
-      - gfx1031
-      - gfx1032
-      block: SQ
-      event: 28
-    - architectures:
-      - gfx90a
-      block: SQ
-      event: 88
-    - architectures:
-      - gfx908
-      block: SQ
-      event: 61
-    - architectures:
-      - gfx940
-      - gfx941
-      - gfx942
-      block: SQ
-      event: 93
-    - architectures:
-      - gfx11
-      - gfx1100
-      - gfx1101
-      - gfx1102
-      - gfx12
-      - gfx1200
-      - gfx1201
-      block: SQ
-      event: 26
-    - architectures:
-      - gfx950
-      block: SQ
-      event: 109
-  - name: SQ_WAIT_INST_LDS
-    description: Number of wave-cycles spent waiting for LDS instruction issue. In units of 4 cycles. (per-simd, nondeterministic)
-    properties: []
-    definitions:
-    - architectures:
-      - gfx10
-      - gfx1010
-      - gfx1030
-      - gfx1031
-      - gfx1032
-      block: SQ
-      event: 31
-    - architectures:
-      - gfx9
-      - gfx900
-      - gfx906
-      block: SQ
-      event: 63
-    - architectures:
-      - gfx908
-      block: SQ
-      event: 64
-    - architectures:
-      - gfx90a
-      block: SQ
-      event: 91
-    - architectures:
-      - gfx940
-      - gfx941
-      - gfx942
-      block: SQ
-      event: 96
-    - architectures:
-      - gfx11
-      - gfx1100
-      - gfx1101
-      - gfx1102
-      block: SQ
-      event: 29
-    - architectures:
-      - gfx950
-      block: SQ
-      event: 112
-  - name: SQ_WAVE32_INSTS
-    description: Number of instructions issued by wave32 waves. Skipped instructions are not counted. {emulated}
-    properties: []
-    definitions:
-    - architectures:
-      - gfx10
-      - gfx1010
-      - gfx1030
-      - gfx1031
-      - gfx1032
-      block: SQ
-      event: 84
-    - architectures:
-      - gfx11
-      - gfx1100
-      - gfx1101
-      - gfx1102
-      block: SQ
-      event: 82
-    - architectures:
-      - gfx12
-      - gfx1200
-      - gfx1201
-      block: SQ
-      event: 70
-  - name: SQ_WAVE64_INSTS
-    description: Number of instructions issued by wave64 waves. Skipped instructions are not counted. {emulated}
-    properties: []
-    definitions:
-    - architectures:
-      - gfx10
-      - gfx1010
-      - gfx1030
-      - gfx1031
-      - gfx1032
-      block: SQ
-      event: 85
-    - architectures:
-      - gfx11
-      - gfx1100
-      - gfx1101
-      - gfx1102
-      block: SQ
-      event: 83
-    - architectures:
-      - gfx12
-      - gfx1200
-      - gfx1201
-      block: SQ
-      event: 71
-  - name: SQ_WAVES
-    description: Count number of waves sent to distributed sequencers (SQs). This value represents the number of waves that
-      are sent to each SQ. This only counts new waves sent since the start of collection (for dispatch profiling this is the
-      timeframe of kernel execution, for agent profiling it is the timeframe between start_context and read counter data).
-      A sum of all SQ_WAVES values will give the total number of waves started by the application during the collection timeframe.
-      Returns one value per-SE (aggregates of SIMD values).
-    properties: []
-    definitions:
-    - architectures:
-      - gfx10
-      - gfx1010
-      - gfx1030
-      - gfx1031
-      - gfx1032
-      - gfx11
-      - gfx1100
-      - gfx1101
-      - gfx1102
-      - gfx12
-      - gfx1200
-      - gfx1201
-      - gfx9
-      - gfx900
-      - gfx906
-      - gfx908
-      - gfx90a
-      - gfx940
-      - gfx941
-      - gfx942
-      - gfx950
-      block: SQ
-      event: 4
-  - name: SQ_WAVES_EQ_64
-    description: Count number of waves with exactly 64 active threads sent to SQs. This value represents the number of waves
-      that an each individual SIMD has enqueued during the collection timeframe (for dispatch profiling this is the timeframe
-      of kernel execution, for agent profiling it is the timeframe between start_context and read counter data) with exactly
-      64 threads. A sum of all SQ_WAVES_EQ_64 values will give the total number of waves with 64 threads enqueued during the
-      collection timeframe by the application. Returns one value per-SE (aggregates of SIMD values). Useful for checking for
-      wavefront occupancy.
-    properties: []
-    definitions:
-    - architectures:
-      - gfx90a
-      - gfx908
-      - gfx940
-      - gfx941
-      - gfx942
-      - gfx950
-      block: SQ
-      event: 6
-  - name: SQ_WAVES_LT_16
-    description: Count number of waves sent <16 active threads sent to SQs. (per-simd, emulated, global). This value represents
-      the number of waves that an each individual SIMD has enqueued during the collection timeframe (for dispatch profiling
-      this is the timeframe of kernel execution, for agent profiling it is the timeframe between start_context and read counter
-      data) with less than 16 threads. A sum of all SQ_WAVES_LT_16 values will give the total number of waves with 16 threads
-      enqueued during the collection timeframe by the application. Returns one value per-SE (aggregates of SIMD values). Useful
-      for checking for wavefront occupancy.
-    properties: []
-    definitions:
-    - architectures:
-      - gfx90a
-      - gfx908
-      - gfx940
-      - gfx941
-      - gfx942
-      - gfx950
-      block: SQ
-      event: 10
-  - name: SQ_WAVES_LT_32
-    description: Count number of waves sent <32 active threads sent to SQs. This value represents the number of waves that
-      an each individual SIMD has enqueued during the collection timeframe (for dispatch profiling this is the timeframe of
-      kernel execution, for agent profiling it is the timeframe between start_context and read counter data) with less than
-      32 threads. A sum of all SQ_WAVES_LT_32 values will give the total number of waves with 32 threads enqueued during the
-      collection timeframe by the application. Returns one value per-SE (aggregates of SIMD values). Useful for checking for
-      wavefront occupancy.
-    properties: []
-    definitions:
-    - architectures:
-      - gfx90a
-      - gfx908
-      - gfx940
-      - gfx941
-      - gfx942
-      - gfx950
-      block: SQ
-      event: 9
-  - name: SQ_WAVES_LT_48
-    description: Count number of waves with <48 active threads sent to SQs. This value represents the number of waves that
-      an each individual SIMD has enqueued during the collection timeframe (for dispatch profiling this is the timeframe of
-      kernel execution, for agent profiling it is the timeframe between start_context and read counter data) with less than
-      48 threads. A sum of all SQ_WAVES_LT_48 values will give the total number of waves with 48 threads enqueued during the
-      collection timeframe by the application. Returns one value per-SE (aggregates of SIMD values). Useful for checking for
-      wavefront occupancy.
-    properties: []
-    definitions:
-    - architectures:
-      - gfx90a
-      - gfx908
-      - gfx940
-      - gfx941
-      - gfx942
-      - gfx950
-      block: SQ
-      event: 8
-  - name: SQ_WAVES_LT_64
-    description: Count number of waves with <64 active threads sent to SQs. This value represents the number of waves that
-      an each individual SIMD has enqueued during the collection timeframe (for dispatch profiling this is the timeframe of
-      kernel execution, for agent profiling it is the timeframe between start_context and read counter data) with less than
-      64 threads. A sum of all SQ_WAVES_LT_64 values will give the total number of waves with 64 threads enqueued during the
-      collection timeframe by the application. Returns one value per-SE (aggregates of SIMD values). Useful for checking for
-      wavefront occupancy.
-    properties: []
-    definitions:
-    - architectures:
-      - gfx90a
-      - gfx908
-      - gfx940
-      - gfx941
-      - gfx942
-      - gfx950
-      block: SQ
-      event: 7
-  - name: SQ_WAVES_RESTORED
-    description: Count number of context-restored waves sent to SQs. This value represents the number of waves whos current
-      register state has been restored from a register bank during the collection timeframe (for dispatch profiling this is
-      the timeframe of kernel execution, for agent profiling it is the timeframe between start_context and read counter data).
-      Context saving/restoring is a slow operation and should be limited. High values can also indicate that stalling may
-      be taking place (waiting for free register space). Returns one value per-SE (aggregates of SIMD values).
-    properties: []
-    definitions:
-    - architectures:
-      - gfx90a
-      block: SQ
-      event: 186
-    - architectures:
-      - gfx908
-      block: SQ
-      event: 159
-    - architectures:
-      - gfx940
-      - gfx941
-      - gfx942
-      block: SQ
-      event: 185
-    - architectures:
-      - gfx950
-      block: SQ
-      event: 201
-  - name: SQ_WAVES_SAVED
-    description: Count number of context-saved waves sent to SQs. This value represents the number of waves whos current register
-      state has been saved to a register bank during the collection timeframe (for dispatch profiling this is the timeframe
-      of kernel execution, for agent profiling it is the timeframe between start_context and read counter data) . Context
-      saving/restoring is a slow operation and should be limited. High values can also indicate that stalling may be taking
-      place (waiting for free register space). Returns one value per-SE (aggregates of SIMD values).
-    properties: []
-    definitions:
-    - architectures:
-      - gfx90a
-      block: SQ
-      event: 187
-    - architectures:
-      - gfx908
-      block: SQ
-      event: 160
-    - architectures:
-      - gfx940
-      - gfx941
-      - gfx942
-      block: SQ
-      event: 186
-    - architectures:
-      - gfx950
-      block: SQ
-      event: 202
-  - name: SQ_WAVES_sum
-    description: Gives the total number of waves currently enqueued by the application during the collection timeframe (for
-      dispatch profiling this is the timeframe of kernel execution, for agent profiling it is the timeframe between start_context
-      and read counter data). See SQ_WAVES for more details.
-    properties: []
-    definitions:
-    - architectures:
-      - gfx10
-      - gfx1010
-      - gfx1030
-      - gfx1031
-      - gfx1032
-      - gfx11
-      - gfx1100
-      - gfx1101
-      - gfx1102
-      - gfx12
-      - gfx1200
-      - gfx1201
-      - gfx9
-      - gfx900
-      - gfx906
-      - gfx908
-      - gfx90a
-      - gfx940
-      - gfx941
-      - gfx942
-      - gfx950
-      expression: reduce(SQ_WAVES,sum)
-  - name: SQ_WAVE_CYCLES
-    description: The cycles spent executing waves in the CUs. This value is reported per-SE (aggregates of SIMD values) and
-      is nondeterministic. Units are in quad-cycles (4 cycles). Useful for determining how much time is spent executing wave
-      code vs overhead/waiting. Low cycle count relative to actual number of cycles processed by the CU can indicate that
-      the CU is stalling or is overloaded.
-    properties: []
-    definitions:
-    - architectures:
-      - gfx10
-      - gfx1010
-      - gfx1030
-      - gfx1031
-      - gfx1032
-      block: SQ
-      event: 26
-    - architectures:
-      - gfx90a
-      block: SQ
-      event: 74
-    - architectures:
-      - gfx908
-      block: SQ
-      event: 47
-    - architectures:
-      - gfx940
-      - gfx941
-      - gfx942
-      block: SQ
-      event: 79
-    - architectures:
-      - gfx11
-      - gfx1100
-      - gfx1101
-      - gfx1102
-      - gfx12
-      - gfx1200
-      - gfx1201
-      block: SQ
-      event: 24
-    - architectures:
-      - gfx950
-      block: SQ
-      event: 95
   - name: SQ_INSTS_VEC32_LEVEL_LDS
     description: Number of in-flight wave32 LDS (indexed, flat) instructions issued.{level, nondeterministic}
     properties: []
     definitions:
-      - architectures:
-        - gfx12
-        - gfx1200
-        - gfx1201
-        block: SQ
-        event: 250
+    - architectures:
+      - gfx12
+      - gfx1200
+      - gfx1201
+      block: SQ
+      event: 250
   - name: SQ_INSTS_VALU_FLOPS_FP16
     description: Counts FLOPS per instruction on float 16 excluding MFMA/SMFMA.
     properties: []
@@ -5533,22 +7565,6 @@ rocprofiler-sdk:
       - gfx950
       block: SQ
       event: 66
-  - name: SQ_INSTS_EXP
-    description: Number of EXP instructions issued, excluding skipped export instructions. (per-simd, emulated)
-    properties: []
-    definitions:
-    - architectures:
-      - gfx950
-      block: SQ
-      event: 69
-  - name: SQ_EVENTS
-    description: Number of events. (unwindowed, emulated, global)
-    properties: []
-    definitions:
-    - architectures:
-      - gfx950
-      block: SQ
-      event: 16
   - name: ScaPipeIssueUtil
     description: 'Unit: percent'
     properties: []
@@ -5729,33 +7745,6 @@ rocprofiler-sdk:
       - gfx942
       - gfx950
       expression: reduce(TA_BUFFER_COALESCED_WRITE_CYCLES,sum)
-  - name: TA_BUFFER_LOAD_WAVEFRONTS
-    description: Number of buffer load vec32 packets processed by TA
-    properties: []
-    definitions:
-    - architectures:
-      - gfx11
-      - gfx1100
-      - gfx1101
-      - gfx1102
-      - gfx12
-      - gfx1200
-      - gfx1201
-      block: TA
-      event: 45
-  - name: TA_BUFFER_LOAD_WAVEFRONTS_sum
-    description: Number of buffer load vec32 packets processed by the TA. Sum over TA instances.
-    properties: []
-    definitions:
-    - architectures:
-      - gfx11
-      - gfx1100
-      - gfx1101
-      - gfx1102
-      - gfx12
-      - gfx1200
-      - gfx1201
-      expression: reduce(TA_BUFFER_LOAD_WAVEFRONTS,sum)
   - name: TA_BUFFER_READ_WAVEFRONTS
     description: Number of buffer read wavefronts processed by TA.
     properties: []
@@ -5784,33 +7773,6 @@ rocprofiler-sdk:
       - gfx942
       - gfx950
       expression: reduce(TA_BUFFER_READ_WAVEFRONTS,sum)
-  - name: TA_BUFFER_STORE_WAVEFRONTS
-    description: Number of buffer store vec32 packets processed by TA
-    properties: []
-    definitions:
-    - architectures:
-      - gfx11
-      - gfx1100
-      - gfx1101
-      - gfx1102
-      - gfx12
-      - gfx1200
-      - gfx1201
-      block: TA
-      event: 46
-  - name: TA_BUFFER_STORE_WAVEFRONTS_sum
-    description: Number of buffer store vec32 packets processed by the TA. Sum over TA instances.
-    properties: []
-    definitions:
-    - architectures:
-      - gfx11
-      - gfx1100
-      - gfx1101
-      - gfx1102
-      - gfx12
-      - gfx1200
-      - gfx1201
-      expression: reduce(TA_BUFFER_STORE_WAVEFRONTS,sum)
   - name: TA_BUFFER_TOTAL_CYCLES
     description: Number of buffer cycles issued to TC.
     properties: []
@@ -5909,6 +7871,7 @@ rocprofiler-sdk:
       - gfx1100
       - gfx1101
       - gfx1102
+      - gfx1151
       - gfx12
       - gfx1200
       - gfx1201
@@ -5921,6 +7884,7 @@ rocprofiler-sdk:
       - gfx941
       - gfx942
       - gfx950
+      - gfx1152
       expression: reduce(TA_TA_BUSY,avr)
   - name: TA_BUSY_max
     description: TA block is busy. Max over TA instances.
@@ -5936,6 +7900,7 @@ rocprofiler-sdk:
       - gfx1100
       - gfx1101
       - gfx1102
+      - gfx1151
       - gfx12
       - gfx1200
       - gfx1201
@@ -5948,6 +7913,7 @@ rocprofiler-sdk:
       - gfx941
       - gfx942
       - gfx950
+      - gfx1152
       expression: reduce(TA_TA_BUSY,max)
   - name: TA_BUSY_min
     description: TA block is busy. Min over TA instances.
@@ -5963,6 +7929,7 @@ rocprofiler-sdk:
       - gfx1100
       - gfx1101
       - gfx1102
+      - gfx1151
       - gfx12
       - gfx1200
       - gfx1201
@@ -5975,6 +7942,7 @@ rocprofiler-sdk:
       - gfx941
       - gfx942
       - gfx950
+      - gfx1152
       expression: reduce(TA_TA_BUSY,min)
   - name: TA_DATA_STALLED_BY_TC_CYCLES
     description: Number of cycles data path stalled by TC. Perf_Windowing not supported for this counter.
@@ -6174,49 +8142,6 @@ rocprofiler-sdk:
       - gfx942
       - gfx950
       expression: reduce(TA_FLAT_WRITE_WAVEFRONTS,sum)
-  - name: TA_TA_BUSY
-    description: TA block is busy. Perf_Windowing not supported for this counter.
-    properties: []
-    definitions:
-    - architectures:
-      - gfx10
-      - gfx1010
-      - gfx1030
-      - gfx1031
-      - gfx1032
-      - gfx11
-      - gfx1100
-      - gfx1101
-      - gfx1102
-      - gfx12
-      - gfx1200
-      - gfx1201
-      - gfx9
-      - gfx900
-      - gfx906
-      - gfx908
-      - gfx90a
-      block: TA
-      event: 15
-    - architectures:
-      - gfx940
-      - gfx941
-      - gfx942
-      - gfx950
-      block: TA
-      event: 13
-  - name: TA_TA_BUSY_sum
-    description: TA block is busy. Perf_Windowing not supported for this counter. Sum over TA instances.
-    properties: []
-    definitions:
-    - architectures:
-      - gfx90a
-      - gfx908
-      - gfx940
-      - gfx941
-      - gfx942
-      - gfx950
-      expression: reduce(TA_TA_BUSY,sum)
   - name: TA_TOTAL_WAVEFRONTS
     description: Total number of wavefronts processed by TA.
     properties: []
@@ -6745,8 +8670,8 @@ rocprofiler-sdk:
       - gfx950
       expression: reduce(TCC_EA0_RDREQ_IO_CREDIT_STALL,sum)
   - name: TCC_EA0_RDREQ_LEVEL
-    description: Level count the number of TCC/EA read requests in flight. This is primarily meant for measure average EA read
-      latency. Average read latency = TCC_PERF_SEL_EA_RDREQ_LEVEL/TCC_PERF_SEL_EA_RDREQ.
+    description: Level count the number of TCC/EA read requests in flight. This is primarily meant for measure average EA
+      read latency. Average read latency = TCC_PERF_SEL_EA_RDREQ_LEVEL/TCC_PERF_SEL_EA_RDREQ.
     properties: []
     definitions:
     - architectures:
@@ -7285,8 +9210,8 @@ rocprofiler-sdk:
       - gfx90a
       expression: reduce(TCC_EA_RDREQ_IO_CREDIT_STALL,sum)
   - name: TCC_EA_RDREQ_LEVEL
-    description: Level count the number of TCC/EA read requests in flight. This is primarily meant for measure average EA read
-      latency. Average read latency = TCC_PERF_SEL_EA_RDREQ_LEVEL/TCC_PERF_SEL_EA_RDREQ.
+    description: Level count the number of TCC/EA read requests in flight. This is primarily meant for measure average EA
+      read latency. Average read latency = TCC_PERF_SEL_EA_RDREQ_LEVEL/TCC_PERF_SEL_EA_RDREQ.
     properties: []
     definitions:
     - architectures:
@@ -7732,16 +9657,6 @@ rocprofiler-sdk:
       - gfx950
       block: TCC
       event: 87
-  - name: TCC_PROBE_EVICT_sum
-    description: Number of evictions/invalidations due to probes. Not windowable. Sum over TCC instances.
-    properties: []
-    definitions:
-    - architectures:
-      - gfx940
-      - gfx941
-      - gfx942
-      - gfx950
-      expression: reduce(TCC_PROBE_EVICT,sum)
   - name: TCC_PROBE_sum
     description: Number of probe requests. Not windowable. Sum over TCC instances.
     properties: []
@@ -8249,7 +10164,7 @@ rocprofiler-sdk:
       block: TCC
       event: 116
   - name: TCC_CLIENT184_REQ
-    description: 'Number of cycles client184 sent a request to this TCC.'
+    description: Number of cycles client184 sent a request to this TCC.
     properties: []
     definitions:
     - architectures:
@@ -8257,7 +10172,7 @@ rocprofiler-sdk:
       block: TCC
       event: 312
   - name: TCC_CLIENT185_REQ
-    description: 'Number of cycles client185 sent a request to this TCC.'
+    description: Number of cycles client185 sent a request to this TCC.
     properties: []
     definitions:
     - architectures:
@@ -8265,7 +10180,7 @@ rocprofiler-sdk:
       block: TCC
       event: 313
   - name: TCC_CLIENT186_REQ
-    description: 'Number of cycles client186 sent a request to this TCC.'
+    description: Number of cycles client186 sent a request to this TCC.
     properties: []
     definitions:
     - architectures:
@@ -8273,7 +10188,7 @@ rocprofiler-sdk:
       block: TCC
       event: 314
   - name: TCC_CLIENT187_REQ
-    description: 'Number of cycles client187 sent a request to this TCC.'
+    description: Number of cycles client187 sent a request to this TCC.
     properties: []
     definitions:
     - architectures:
@@ -8281,7 +10196,7 @@ rocprofiler-sdk:
       block: TCC
       event: 315
   - name: TCC_CLIENT188_REQ
-    description: 'Number of cycles client188 sent a request to this TCC.'
+    description: Number of cycles client188 sent a request to this TCC.
     properties: []
     definitions:
     - architectures:
@@ -8289,7 +10204,7 @@ rocprofiler-sdk:
       block: TCC
       event: 316
   - name: TCC_CLIENT189_REQ
-    description: 'Number of cycles client189 sent a request to this TCC.'
+    description: Number of cycles client189 sent a request to this TCC.
     properties: []
     definitions:
     - architectures:
@@ -8297,7 +10212,7 @@ rocprofiler-sdk:
       block: TCC
       event: 317
   - name: TCC_CLIENT190_REQ
-    description: 'Number of cycles client190 sent a request to this TCC.'
+    description: Number of cycles client190 sent a request to this TCC.
     properties: []
     definitions:
     - architectures:
@@ -8305,7 +10220,7 @@ rocprofiler-sdk:
       block: TCC
       event: 318
   - name: TCC_CLIENT191_REQ
-    description: 'Number of cycles client191 sent a request to this TCC.'
+    description: Number of cycles client191 sent a request to this TCC.
     properties: []
     definitions:
     - architectures:
@@ -8477,26 +10392,6 @@ rocprofiler-sdk:
     - architectures:
       - gfx950
       expression: reduce(TCC_EA0_RDREQ_DRAM_32B,sum)
-  - name: TCP_REQ
-    description: Total cache line accesses
-    properties: []
-    definitions:
-      - architectures:
-        - gfx12
-        - gfx1200
-        - gfx1201
-        block: TCP
-        event: 9
-  - name: TCP_REQ_MISS
-    description: Total cache requests that missed
-    properties: []
-    definitions:
-      - architectures:
-        - gfx12
-        - gfx1200
-        - gfx1201
-        block: TCP
-        event: 17
   - name: TCP_ATOMIC_TAGCONFLICT_STALL_CYCLES
     description: Tagram conflict stall on an atomic
     properties: []
@@ -8525,56 +10420,6 @@ rocprofiler-sdk:
       - gfx942
       - gfx950
       expression: reduce(TCP_ATOMIC_TAGCONFLICT_STALL_CYCLES,sum)
-  - name: TCP_GATE_EN1
-    description: TCP interface clocks are turned on. Not Windowed.
-    properties: []
-    definitions:
-    - architectures:
-      - gfx90a
-      - gfx908
-      - gfx940
-      - gfx941
-      - gfx942
-      - gfx950
-      block: TCP
-      event: 0
-  - name: TCP_GATE_EN1_sum
-    description: TCP interface clocks are turned on. Not Windowed. Sum over TCP instances.
-    properties: []
-    definitions:
-    - architectures:
-      - gfx90a
-      - gfx908
-      - gfx940
-      - gfx941
-      - gfx942
-      - gfx950
-      expression: reduce(TCP_GATE_EN1,sum)
-  - name: TCP_GATE_EN2
-    description: TCP core clocks are turned on. Not Windowed.
-    properties: []
-    definitions:
-    - architectures:
-      - gfx90a
-      - gfx908
-      - gfx940
-      - gfx941
-      - gfx942
-      - gfx950
-      block: TCP
-      event: 1
-  - name: TCP_GATE_EN2_sum
-    description: TCP core clocks are turned on. Not Windowed. Sum over TCP instances.
-    properties: []
-    definitions:
-    - architectures:
-      - gfx90a
-      - gfx908
-      - gfx940
-      - gfx941
-      - gfx942
-      - gfx950
-      expression: reduce(TCP_GATE_EN2,sum)
   - name: TCP_PENDING_STALL_CYCLES
     description: Stall due to data pending from L2
     properties: []
@@ -9199,30 +11044,6 @@ rocprofiler-sdk:
       - gfx942
       - gfx950
       expression: reduce(TCP_TCC_WRITE_REQ,sum)
-  - name: TCP_TCP_LATENCY
-    description: Total TCP wave latency (from first clock of wave entering to first clock of wave leaving), divide by TA_TCP_STATE_READ
-      to avg wave latency
-    properties: []
-    definitions:
-    - architectures:
-      - gfx90a
-      - gfx908
-      block: TCP
-      event: 65
-    - architectures:
-      - gfx950
-      block: TCP
-      event: 64
-  - name: TCP_TCP_LATENCY_sum
-    description: Total TCP wave latency (from first clock of wave entering to first clock of wave leaving), divide by TA_TCP_STATE_READ
-      to avg wave latency Sum over TCP instances.
-    properties: []
-    definitions:
-    - architectures:
-      - gfx90a
-      - gfx908
-      - gfx950
-      expression: reduce(TCP_TCP_LATENCY,sum)
   - name: TCP_TCP_TA_DATA_STALL_CYCLES
     description: TCP stalls TA data interface. Now Windowed.
     properties: []
@@ -9727,13 +11548,6 @@ rocprofiler-sdk:
       - gfx950
       block: TCP
       event: 63
-  - name: TCP_CACHE_MISS_sum
-    description: Total L1 cache miss requests sent from this TCP to all TCCs. Sum over TCP instances.
-    properties: []
-    definitions:
-    - architectures:
-      - gfx950
-      expression: reduce(TCP_CACHE_MISS,sum)
   - name: TCP_TCP_TA_ADDR_STALL_CYCLES
     description: TCP stalls TA addr interface.
     properties: []
@@ -9776,8 +11590,8 @@ rocprofiler-sdk:
       event: 23
   - name: TCP_UTCL1_THRASHING_STALL
     description: Stall caused by thrashing feature in any probes. Not accurate when the stall signal has overlap between probe0
-      and probe1. Even worse with MECO of thrashing deadlock. Some event of probe0 could miss to count in with
-      MECO on. Anyway this perf count can be a rough estimation of thrashing.
+      and probe1. Even worse with MECO of thrashing deadlock. Some event of probe0 could miss to count in with MECO on. Anyway
+      this perf count can be a rough estimation of thrashing.
     properties: []
     definitions:
     - architectures:
@@ -10013,8 +11827,8 @@ rocprofiler-sdk:
       expression: reduce(TCP_UTCL1_SERIALIZATION_STALL,sum)
   - name: TCP_UTCL1_THRASHING_STALL_sum
     description: Stall caused by thrashing feature in any probes. Not accurate when the stall signal has overlap between probe0
-      and probe1. Even worse with MECO of thrashing deadlock. Some event of probe0 could miss to count in with
-      MECO on. Anyway this perf count can be a rough estimation of thrashing. Sum over TCP instances.
+      and probe1. Even worse with MECO of thrashing deadlock. Some event of probe0 could miss to count in with MECO on. Anyway
+      this perf count can be a rough estimation of thrashing. Sum over TCP instances.
     properties: []
     definitions:
     - architectures:
@@ -10399,6 +12213,7 @@ rocprofiler-sdk:
       - gfx1100
       - gfx1101
       - gfx1102
+      - gfx1151
       - gfx9
       - gfx906
       - gfx908
@@ -10406,6 +12221,7 @@ rocprofiler-sdk:
       - gfx12
       - gfx1200
       - gfx1201
+      - gfx1152
       expression: reduce(SQ_INSTS_VALU,sum)/reduce(SQ_WAVES,sum)
   - name: VALUUtilization
     description: 'The percentage of active vector ALU threads in a wave. A lower number can mean either more thread divergence
@@ -10507,42 +12323,6 @@ rocprofiler-sdk:
     - architectures:
       - gfx90a
       expression: 400*(reduce(SQ_ACTIVE_INST_VMEM,sum)+reduce(SQ_ACTIVE_INST_FLAT,sum))/(reduce(GRBM_GUI_ACTIVE,max)*CU_NUM)
-  - name: WAVE_DEP_WAIT
-    description: Percentage of the SQ_WAVE_CYCLE time spent waiting for anything.
-    properties: []
-    definitions:
-    - architectures:
-      - gfx10
-      - gfx1010
-      - gfx1030
-      - gfx1031
-      - gfx1032
-      - gfx11
-      - gfx1100
-      - gfx1101
-      - gfx1102
-      - gfx12
-      - gfx1200
-      - gfx1201
-      expression: 100*reduce(SQ_WAIT_ANY,sum)/reduce(SQ_WAVE_CYCLES,sum)
-  - name: WAVE_ISSUE_WAIT
-    description: Percentage of the SQ_WAVE_CYCLE time spent waiting for any instruction issue.
-    properties: []
-    definitions:
-    - architectures:
-      - gfx10
-      - gfx1010
-      - gfx1030
-      - gfx1031
-      - gfx1032
-      - gfx11
-      - gfx1100
-      - gfx1101
-      - gfx1102
-      - gfx12
-      - gfx1200
-      - gfx1201
-      expression: 100*reduce(SQ_WAIT_INST_ANY,sum)/reduce(SQ_WAVE_CYCLES,sum)
   - name: WDATA1_SIZE
     description: The total kilobytes written to the video memory. This is measured on EA1s.
     properties: []
@@ -10593,6 +12373,8 @@ rocprofiler-sdk:
       - gfx1100
       - gfx1101
       - gfx1102
+      - gfx1151
+      - gfx1152
       expression: ((GL2C_MC_WRREQ_sum-GL2C_EA_WRREQ_64B_sum)*32+GL2C_EA_WRREQ_64B_sum*64)/1024
     - architectures:
       - gfx940
@@ -10642,6 +12424,7 @@ rocprofiler-sdk:
       - gfx1100
       - gfx1101
       - gfx1102
+      - gfx1151
       - gfx9
       - gfx906
       - gfx908
@@ -10649,6 +12432,7 @@ rocprofiler-sdk:
       - gfx12
       - gfx1200
       - gfx1201
+      - gfx1152
       expression: reduce(SQ_WAVES,sum)
   - name: WriteSize
     description: The total kilobytes written to the video memory. This is measured with all extra fetches and any cache or
@@ -10687,9 +12471,11 @@ rocprofiler-sdk:
       - gfx1100
       - gfx1101
       - gfx1102
+      - gfx1151
       - gfx12
       - gfx1200
       - gfx1201
+      - gfx1152
       expression: 100*GL2C_WRREQ_STALL_max/reduce(GRBM_GUI_ACTIVE,max)
   - name: sL1dCacheHitRate
     description: 'Unit: percent'
@@ -10805,32 +12591,6 @@ rocprofiler-sdk:
       - gfx1200
       - gfx1201
       expression: (1-(reduce(TCP_REQ_MISS,sum)/reduce(TCP_REQ,sum)))*100
-  - name: SQC_DCACHE_INFLIGHT_LEVEL
-    description: Level count total outstanding transactions in data cache (per-SQ, nondeterministic)
-    properties: []
-    definitions:
-    - architectures:
-      - gfx90a
-      - gfx908
-      - gfx940
-      - gfx941
-      - gfx942
-      - gfx950
-      block: SQ
-      event: 337
-  - name: SQC_ICACHE_INFLIGHT_LEVEL
-    description: Level count total outstanding transactions in instruction cache (per-SQ, nondeterministic)
-    properties: []
-    definitions:
-    - architectures:
-      - gfx90a
-      - gfx908
-      - gfx940
-      - gfx941
-      - gfx942
-      - gfx950
-      block: SQ
-      event: 336
   - name: SQ_IFETCH_LEVEL_ACCUM
     description: Accumulate SQ_IFETCH_LEVEL
     properties: []
@@ -10915,6 +12675,23 @@ rocprofiler-sdk:
       - gfx942
       - gfx950
       expression: accumulate(SQC_ICACHE_INFLIGHT_LEVEL, HIGH_RES)
+  - name: TCC_PROBE_EVICT_sum
+    description: Number of evictions/invalidations due to probes. Not windowable. Sum over TCC instances.
+    properties: []
+    definitions:
+    - architectures:
+      - gfx940
+      - gfx941
+      - gfx942
+      - gfx950
+      expression: reduce(TCC_PROBE_EVICT,sum)
+  - name: TCP_CACHE_MISS_sum
+    description: Total L1 cache miss requests sent from this TCP to all TCCs. Sum over TCP instances.
+    properties: []
+    definitions:
+    - architectures:
+      - gfx950
+      expression: reduce(TCP_CACHE_MISS,sum)
   fw-restriction-schema-version: 1
   firmware_restrictions:
   - affected_architectures:
@@ -10923,5 +12700,4 @@ rocprofiler-sdk:
     - gfx942
     firmware_type: CP
     min_version: 186
-    reason: CP firmware below version 186 can cause device resets and VM Page Faults
-      on MI3XX devices.
+    reason: CP firmware below version 186 can cause device resets and VM Page Faults on MI3XX devices.

--- a/projects/rocprofiler-compute/src/rocprof_compute_soc/profile_configs/sets/gfx1151_sets.yaml
+++ b/projects/rocprofiler-compute/src/rocprof_compute_soc/profile_configs/sets/gfx1151_sets.yaml
@@ -1,0 +1,34 @@
+sets:
+- title: Compute Throughput Utilization
+  set_option: compute_thruput_util
+  description: Placeholder
+  metric:
+  - 11.2.2: SALU Utilization
+  - 11.2.3: VALU Utilization
+  - 11.2.5: VMEM Utilization
+  - 11.2.6: Branch Utilization
+- title: Compute Throughput FLOPS
+  set_option: compute_thruput_flops
+  description: Placeholder
+  metric:
+  - 2.1.0: VALU FLOPs (FP16)
+  - 2.1.1: VALU FLOPs (FP32)
+- title: Memory Throughput
+  set_option: mem_thruput
+  description: Placeholder
+  metric:
+  - 2.1.7: LDS Bank Conflicts
+  - 2.1.18: Theoretical LDS Bandwidth
+  - 17.1.0: Utilization
+- title: Launch Stats
+  set_option: launch_stats
+  description: Placeholder
+  metric:
+  - 7.1.0: Grid Size
+  - 7.1.1: Workgroup Size
+  - 7.1.2: Total Wavefronts
+  - 7.1.5: VGPRs
+  - 7.1.6: AGPRs
+  - 7.1.7: SGPRs
+  - 7.1.8: LDS Allocation
+  - 7.1.9: Scratch Allocation

--- a/projects/rocprofiler-compute/src/rocprof_compute_soc/soc_base.py
+++ b/projects/rocprofiler-compute/src/rocprof_compute_soc/soc_base.py
@@ -1,13 +1,17 @@
 # Copyright (c) Advanced Micro Devices, Inc.
 # SPDX-License-Identifier:  MIT
 
+from __future__ import annotations
+
 import argparse
+import functools
 import math
 import os
 import re
 import shutil
 import sys
 from abc import abstractmethod
+from collections.abc import Iterator
 from pathlib import Path
 from typing import Any, Optional
 
@@ -37,6 +41,82 @@ from utils.utils_common import (
     validate_roofline_csv,
 )
 from vendored import yaml
+
+
+def _same_bucket_priority_ids_from_policy_value(
+    arch_name: str,
+    ids: object,
+) -> tuple[str, ...] | None:
+    """
+    Normalize ``same_bucket_priority_metric_ids`` from YAML: list of ids, or
+    mapping id -> { name: ... } (id is the key; order preserved).
+    Returns None if invalid (caller should warn).
+    """
+    if ids is None:
+        return ()
+    if isinstance(ids, list):
+        return tuple(str(x) for x in ids)
+    if isinstance(ids, dict):
+        ordered: list[str] = []
+        for key, meta in ids.items():
+            token = str(key).strip()
+            if not token:
+                continue
+            if meta is not None and not isinstance(meta, dict):
+                console_warning(
+                    "profiling",
+                    (
+                        "Ignoring same_bucket_priority_metric_ids["
+                        f"{arch_name!r}][{token!r}]: "
+                        "expected a mapping or null."
+                    ),
+                )
+                continue
+            ordered.append(token)
+        return tuple(ordered)
+    return None
+
+
+@functools.lru_cache(maxsize=1)
+def _load_same_bucket_priority_policy_map() -> dict[str, tuple[str, ...]]:
+    """Load counter grouping policy YAML into arch -> metric id tuple."""
+    path = (
+        config.rocprof_compute_home
+        / "rocprof_compute_soc"
+        / "analysis_configs"
+        / "profiling_counter_grouping_policy.yaml"
+    )
+    if not path.is_file():
+        console_warning(
+            "profiling",
+            f"Profiling counter grouping policy missing ({path}); "
+            "same-bucket priority metrics disabled.",
+        )
+        return {}
+    raw = yaml.safe_load(path.read_text(encoding="utf-8"))
+    if raw is None:
+        return {}
+    archs = raw.get("architectures")
+    if not isinstance(archs, dict):
+        return {}
+    out: dict[str, tuple[str, ...]] = {}
+    for arch_name, cfg in archs.items():
+        if not isinstance(cfg, dict):
+            continue
+        key = str(arch_name)
+        parsed = _same_bucket_priority_ids_from_policy_value(
+            key,
+            cfg.get("same_bucket_priority_metric_ids"),
+        )
+        if parsed is None:
+            console_warning(
+                "profiling",
+                f"Ignoring same_bucket_priority_metric_ids for {key!r}: "
+                "expected a list of ids or a mapping id -> metadata.",
+            )
+            continue
+        out[key] = parsed
+    return out
 
 
 class OmniSoC_Base:
@@ -204,6 +284,164 @@ class OmniSoC_Base:
 
         return gpu_model
 
+    def _append_analysis_yaml_for_filter_token(
+        self,
+        raw_token: str,
+        config_filename_dict: dict[str, str],
+        config_root_dir: str,
+        texts: list[str],
+    ) -> None:
+        block_id = raw_token
+        if METRIC_ID_RE.match(block_id):
+            pass
+        else:
+            alias = block_id
+            panel_alias_dict = get_panel_alias()
+            if alias not in panel_alias_dict:
+                raise KeyError(f"Unknown panel alias: {alias!r}")
+            block_id = str(panel_alias_dict[alias])
+            console_log(f"alias: {alias}, block id: {block_id}")
+
+        file_id, panel_id, metric_id = convert_metric_id_to_panel_info(block_id)
+
+        if file_id not in config_filename_dict:
+            console_warning(
+                f"Skipping {block_id}: file id {file_id} not found in {config_root_dir}"
+            )
+            return
+
+        with open(config_filename_dict[file_id]) as stream:
+            file_config = yaml.safe_load(stream)
+        if panel_id is None:
+            texts.append(yaml.dump(file_config, sort_keys=False))
+            return
+
+        panel_dict = {
+            section["metric_table"]["id"]: section["metric_table"]
+            for section in file_config["Panel Config"]["data source"]
+            if "metric_table" in section
+        }
+        if panel_id not in panel_dict:
+            console_warning(
+                f"Skipping {block_id}: metric table {panel_id} not found in "
+                f"{config_filename_dict[file_id]}"
+            )
+            return
+        if metric_id is None:
+            texts.append(yaml.dump(panel_dict[panel_id], sort_keys=False))
+            return
+
+        metric_dict = {
+            idx: panel_dict[panel_id]["metric"][metric]
+            for idx, metric in enumerate(panel_dict[panel_id]["metric"].keys())
+        }
+        if metric_id not in metric_dict:
+            console_warning(
+                f"Skipping {block_id}: metric id {metric_id} not found in "
+                f"panel id {panel_id}"
+            )
+            return
+        texts.append(yaml.dump(metric_dict[metric_id], sort_keys=False))
+
+    def _same_bucket_priority_metric_ids(self) -> tuple[str, ...]:
+        """Metric ids whose PMCs get tier-0 priority in the greedy coalescing pass.
+
+        Loaded from profiling_counter_grouping_policy.yaml for the current arch.
+        Returns an empty tuple when the arch has no grouping policy.
+        """
+        arch = self.__arch
+        if not arch:
+            return ()
+        return _load_same_bucket_priority_policy_map().get(arch, ())
+
+    def _metric_aware_coalesce_pass(
+        self,
+        work_set: set[str],
+        output_files: list[CounterFile],
+        file_count: int,
+    ) -> tuple[set[str], list[CounterFile], int]:
+        """Greedy heuristic: place each metric’s counters into the first feasible
+        pmc_perf bucket, else open a new one. Overflow stays for first-fit.
+
+        Accepts:
+            work_set        — counters still to be placed (not modified)
+            output_files    — existing CounterFile buckets (not modified)
+            file_count      — current bucket sequence number
+        Returns:
+            (remaining_counters, updated_files, file_count)
+        """
+        if not work_set:
+            return work_set, list(output_files), file_count
+
+        # Work on copies so the caller’s originals are untouched.
+        remaining = set(work_set)
+        files = list(output_files)
+
+        # -- Build priority keys from grouping policy YAML --
+        priority_keys: set[tuple[str, Any, int]] = set()
+        for token in self._same_bucket_priority_metric_ids():
+            tid = token.strip()
+            if not METRIC_ID_RE.match(tid):
+                continue
+            file_id, panel_id, metric_idx = convert_metric_id_to_panel_info(tid)
+            if metric_idx is None:
+                continue
+            priority_keys.add((file_id, panel_id, metric_idx))
+
+        # -- Scan arch YAML metrics and collect (sort_key, counters, label) rows --
+        rows: list[tuple[tuple, frozenset[str], str]] = []
+        for (
+            stem_id,
+            panel_id,
+            metric_idx,
+            metric_name,
+            metric_yaml,
+        ) in self._iter_arch_analysis_yaml_metrics():
+            hw = self.parse_counters(metric_yaml)
+            hw = self._expand_tcc_template_counters(hw)
+            counters = frozenset(hw & remaining)
+            if not counters:
+                continue
+            tier = 0 if (stem_id, panel_id, metric_idx) in priority_keys else 1
+            panel_s = str(panel_id) if panel_id is not None else ""
+            sort_key = (tier, -len(counters), stem_id, panel_s, metric_idx)
+            label = f"{stem_id}.{panel_s}.{metric_idx} ({metric_name})"
+            rows.append((sort_key, counters, label))
+        rows.sort(key=lambda r: r[0])
+
+        # -- Place each metric group into an existing or new bucket --
+        cfg = self.__perfmon_config
+        for _sort_key, group, label in rows:
+            # Re-filter: remaining shrinks as earlier groups are placed.
+            need_sorted = sorted(c for c in group if c in remaining)
+            if not need_sorted:
+                continue
+            placed = False
+            for bucket_idx, bucket in enumerate(files):
+                if "LEVEL" in bucket.file_name_txt:
+                    continue
+                trial = _trial_counter_file_with_extra(bucket, cfg, need_sorted)
+                if trial is not None:
+                    files[bucket_idx] = trial
+                    remaining -= set(need_sorted)
+                    placed = True
+                    break
+            if placed:
+                continue
+            new_bucket = CounterFile(str(file_count), cfg)
+            trial = _trial_counter_file_with_extra(new_bucket, cfg, need_sorted)
+            if trial is not None and _flat_counters_in_perfmon_file(trial):
+                files.append(trial)
+                file_count += 1
+                remaining -= set(need_sorted)
+            else:
+                console_debug(
+                    "profiling",
+                    f"Metric-aware pack: cannot fit all PMCs for "
+                    f"{label!r} in one bucket; deferring to first-fit.",
+                )
+        return remaining, files, file_count
+
     @demarcate
     def detect_counters(self) -> tuple[set[str], list[str]]:
         """
@@ -251,79 +489,29 @@ class OmniSoC_Base:
                     texts.append(stream.read())
 
         for block_id in filter_blocks:
-            if METRIC_ID_RE.match(block_id):
-                block_id = block_id
-            else:
-                alias = block_id
-                panel_alias_dict = get_panel_alias()
-                if alias not in panel_alias_dict:
-                    raise KeyError(f"Unknown panel alias: {alias!r}")
-                block_id = panel_alias_dict[alias]  # int
-                print(f"alias: {alias}, block id: {block_id}")
-
-            file_id, panel_id, metric_id = convert_metric_id_to_panel_info(block_id)
-
-            # File id filtering
-            if file_id not in config_filename_dict:
-                console_warning(
-                    f"Skipping {block_id}: file id {file_id} not found in "
-                    f"{config_root_dir}"
-                )
-                continue
-
-            with open(config_filename_dict[file_id]) as stream:
-                file_config = yaml.safe_load(stream)
-            if panel_id is None:
-                # If no panel id level filtering, then read the whole file
-                texts.append(yaml.dump(file_config, sort_keys=False))
-                continue
-
-            # Panel id filtering
-            panel_dict = {
-                section["metric_table"]["id"]: section["metric_table"]
-                for section in file_config["Panel Config"]["data source"]
-                if "metric_table" in section
-            }
-            if panel_id not in panel_dict:
-                console_warning(
-                    f"Skipping {block_id}: metric table {panel_id} not found in "
-                    f"{config_filename_dict[file_id]}"
-                )
-                continue
-            if metric_id is None:
-                # If no metric id level filtering, then read the whole panel
-                texts.append(yaml.dump(panel_dict[panel_id], sort_keys=False))
-                continue
-
-            # Metric id filtering
-            metric_dict = {
-                id: panel_dict[panel_id]["metric"][metric]
-                for id, metric in enumerate(panel_dict[panel_id]["metric"].keys())
-            }
-            if metric_id not in metric_dict:
-                console_warning(
-                    f"Skipping {block_id}: metric id {metric_id} not found in "
-                    f"panel id {panel_id}"
-                )
-                continue
-            texts.append(yaml.dump(metric_dict[metric_id], sort_keys=False))
+            self._append_analysis_yaml_for_filter_token(
+                block_id, config_filename_dict, config_root_dir, texts
+            )
 
         counters = self.parse_counters("\n".join(texts))
-
-        # Handle TCC channel counters: if hw_counter_matches has elems ending with '['
-        # Expand and interleve the TCC channel counters
-        # e.g.  TCC_HIT[0] TCC_ATOMIC[0] ... TCC_HIT[1] TCC_ATOMIC[1] ...
-        num_xcd_for_pmc_file = int(self._mspec.num_xcd)
-        for counter_name in counters.copy():
-            if counter_name.startswith("TCC") and counter_name.endswith("["):
-                counters.remove(counter_name)
-                counter_name = counter_name.split("[")[0]
-                counters = counters.union({
-                    f"{counter_name}[{i}]"
-                    for i in range(num_xcd_for_pmc_file * int(self._mspec.l2_banks))
-                })
+        counters = self._expand_tcc_template_counters(counters)
 
         return counters, filter_blocks
+
+    def _expand_tcc_template_counters(self, counters: set[str]) -> set[str]:
+        """
+        Expand TCC channel templates (name ending with '[') into indexed channel
+        counters, matching perfmon allocation.
+        """
+        out = set(counters)
+        num_xcd = int(self._mspec.num_xcd)
+        l2_banks = int(self._mspec.l2_banks)
+        for counter_name in counters.copy():
+            if counter_name.startswith("TCC") and counter_name.endswith("["):
+                out.discard(counter_name)
+                base = counter_name.split("[")[0]
+                out.update(f"{base}[{i}]" for i in range(num_xcd * l2_banks))
+        return out
 
     @demarcate
     def perfmon_filter(self) -> list[str]:
@@ -344,6 +532,124 @@ class OmniSoC_Base:
         self.perfmon_coalesce(counters)
 
         return filter_blocks
+
+    def _allocate_perfmon_counter_files(
+        self, counters: set[str]
+    ) -> tuple[list[CounterFile], int, int]:
+        """Bin-pack counters into perfmon buckets.
+
+        Returns (output_files, file_count, accu_file_count).
+
+        LEVEL counters get dedicated files first. If the arch has priority
+        metrics in profiling_counter_grouping_policy.yaml, a metric-aware
+        greedy pass runs before the final per-counter first-fit.
+        """
+        output_files: list[CounterFile] = []
+        accu_file_count = 0
+        work = sorted(list(counters))
+        for counter in work.copy():
+            if (
+                "LEVEL" in counter
+                and not counter.endswith("_sum")
+                and not is_tcc_channel_counter(counter)
+            ):
+                work.remove(counter)
+                output_files.append(CounterFile(counter, self.__perfmon_config))
+                output_files[-1].add(counter)
+                output_files[-1].add(f"{counter}_ACCUM")
+                accu_file_count += 1
+
+        file_count = 0
+        tcc_channel_counter_file_map: dict[str, CounterFile] = {}
+
+        work_set = set(work)
+        if self._same_bucket_priority_metric_ids():
+            work_set, output_files, file_count = self._metric_aware_coalesce_pass(
+                work_set, output_files, file_count
+            )
+        work = sorted(work_set)
+        tcc_channel_counter_file_map = _rebuild_tcc_channel_file_map(output_files)
+
+        for ctr in work:
+            if is_tcc_channel_counter(ctr):
+                output_file = tcc_channel_counter_file_map.get(ctr.split("[")[0])
+                if output_file:
+                    output_file.add(ctr)
+                    continue
+
+            added = False
+            for output_file in output_files:
+                if output_file.add(ctr):
+                    added = True
+                    if is_tcc_channel_counter(ctr):
+                        tcc_channel_counter_file_map[ctr.split("[")[0]] = output_file
+                    break
+
+            if not added:
+                output_files.append(CounterFile(str(file_count), self.__perfmon_config))
+                file_count += 1
+                output_files[-1].add(ctr)
+
+        return output_files, file_count, accu_file_count
+
+    def _iter_arch_analysis_yaml_metrics(
+        self,
+    ) -> Iterator[tuple[str, Any, int, str, str]]:
+        """Iterate analysis_configs/<arch> YAML metric_table rows.
+
+        Yields:
+            stem_id     — YAML filename prefix (e.g. "2" from "2_SQ.yaml")
+            panel_id    — metric_table "id" field (may be None)
+            metric_idx  — zero-based index of the metric within its table
+            metric_name — metric key string
+            metric_yaml — metric body serialised as YAML text
+        """
+        args = self.get_args()
+        arch = self.__arch
+        if not arch:
+            return
+        config_root = Path(args.config_dir) / arch
+        if not config_root.is_dir():
+            return
+        exclude: set[str] = set()
+        if not args.membw_analysis:
+            exclude.add("3000")
+
+        for ypath in sorted(config_root.glob("*.yaml")):
+            stem_id = ypath.name.split("_")[0]
+            if stem_id in exclude:
+                continue
+            try:
+                with open(ypath, encoding="utf-8") as stream:
+                    doc = yaml.safe_load(stream)
+            except (OSError, UnicodeError, yaml.YAMLError):
+                continue
+            if not isinstance(doc, dict):
+                continue
+            panel_cfg = doc.get("Panel Config")
+            if not isinstance(panel_cfg, dict):
+                continue
+            sources = panel_cfg.get("data source")
+            if not isinstance(sources, list):
+                continue
+            for section in sources:
+                if not isinstance(section, dict) or "metric_table" not in section:
+                    continue
+                mt = section["metric_table"]
+                if not isinstance(mt, dict):
+                    continue
+                metrics = mt.get("metric")
+                if not isinstance(metrics, dict):
+                    continue
+                panel_id = mt.get("id")
+                for idx, (metric_name, metric_body) in enumerate(metrics.items()):
+                    try:
+                        metric_text = yaml.dump(
+                            metric_body, sort_keys=False, allow_unicode=True
+                        )
+                    except (TypeError, yaml.YAMLError):
+                        continue
+                    yield stem_id, panel_id, idx, metric_name, metric_text
 
     @demarcate
     def parse_counters(self, config_text: str) -> set[str]:
@@ -383,9 +689,12 @@ class OmniSoC_Base:
         # hw counter name should have all capital letters or digits
         # and should not end with underscore
         # he counter name can either optionally end with '[' or '_sum'
-        hw_counter_regex = (
-            r"(?:SQ|SQC|TA|TD|TCP|TCC|CPC|CPF|SPI|GRBM)_[0-9A-Z_]*[0-9A-Z](?:\[|_sum)*"
+        _blk = (
+            r"(?:SQ|SQC|SP|TA|TD|TCP|TCC|GL1A|GL1C|GL2A|GL2C|"
+            r"CPC|CPF|SPI|GCEA|GRBM)"
         )
+        _sfx = r"_[0-9A-Z_]*[0-9A-Z](?:\[|_sum|_avr|_max|_min)*"
+        hw_counter_regex = _blk + _sfx
         # only capture the variable name after $ using capturing group
         variable_regex = r"\$([0-9A-Za-z_]*[0-9A-Za-z])"
         hw_counter_matches = set(re.findall(hw_counter_regex, text))
@@ -476,7 +785,6 @@ class OmniSoC_Base:
         workload_perfmon_dir = Path(self.get_args().path) / "perfmon"
         workload_perfmon_dir.mkdir(parents=True, exist_ok=True)
 
-        # Sanity check whether counters are supported by underlying rocprof tool
         rocprof_counters = self.get_rocprof_supported_counters()
         # rocprof does not support TCC channel counters in the avail output,
         # so remove channel suffix for comparison
@@ -502,52 +810,9 @@ class OmniSoC_Base:
 
         console_debug(f"Collecting following counters: {', '.join(counters)} ")
 
-        output_files: list[CounterFile] = []
-        accu_file_count = 0
-
-        # Create separate perfmon file for LEVEL counters without _sum suffix
-        # TCC LEVEL counters are handled channel wise, so ignore them
-        # Convert set to sorted list for determinism in pmc txt files
-        counters = sorted(list(counters))
-        for counter in counters.copy():
-            if (
-                "LEVEL" in counter
-                and not counter.endswith("_sum")
-                and not is_tcc_channel_counter(counter)
-            ):
-                counters.remove(counter)
-                output_files.append(CounterFile(counter, self.__perfmon_config))
-                output_files[-1].add(counter)
-                output_files[-1].add(f"{counter}_ACCUM")
-                accu_file_count += 1
-
-        file_count = 0
-        # Store all channels for a TCC channel counter in the same file
-        tcc_channel_counter_file_map: dict[str, CounterFile] = {}
-
-        for ctr in counters:
-            # Store all channels for a TCC channel counter in the same file
-            if is_tcc_channel_counter(ctr):
-                output_file = tcc_channel_counter_file_map.get(ctr.split("[")[0])
-                if output_file:
-                    output_file.add(ctr)
-                    continue
-
-            # Add counter to first file that has room
-            added = False
-            for output_file in output_files:
-                if output_file.add(ctr):
-                    added = True
-                    # Store all channels for a TCC channel counter in the same file
-                    if is_tcc_channel_counter(ctr):
-                        tcc_channel_counter_file_map[ctr.split("[")[0]] = output_file
-                    break
-
-            # All files are full, create a new file
-            if not added:
-                output_files.append(CounterFile(str(file_count), self.__perfmon_config))
-                file_count += 1
-                output_files[-1].add(ctr)
+        output_files, file_count, accu_file_count = (
+            self._allocate_perfmon_counter_files(counters)
+        )
 
         console_debug("profiling", f"perfmon_coalesce file_count {file_count}")
 
@@ -664,10 +929,12 @@ class OmniSoC_Base:
         console_debug("profiling", f"perform SoC post processing for {self.__arch}")
         # Roofline can be skipped via --no-roof
         # Roofline not supported on MI 100
+        # Roofline not supported on Strix Halo
         # If --filter-blocks is provided, roofline block (block 4) should be mentioned
         if (
             self.get_args().no_roof
             or self.__arch == "gfx908"
+            or self.__arch == "gfx1151"
             or (
                 self.get_args().filter_blocks
                 and "4" not in self.get_args().filter_blocks
@@ -736,6 +1003,7 @@ class LimitedSet:
 # block limited according to perfmon config.
 class CounterFile:
     def __init__(self, name: str, perfmon_config: dict[str, int]) -> None:
+        self.file_name_txt: str = f"pmc_perf_{name}.txt"
         self.pmc_filename: str = f"pmc_perf_{name}.yaml"
         self.counter_def_filename: str = f"counter_def_{name}.yaml"
         self.blocks: dict[str, LimitedSet] = {
@@ -748,5 +1016,46 @@ class CounterFile:
         # SQ and SQC belong to the same IP block
         if block == "SQC":
             block = "SQ"
+        if block == "SP":
+            block = "SQ"
 
         return self.blocks[block].add(counter)
+
+
+def _trial_counter_file_with_extra(
+    basis: CounterFile,
+    perfmon_config: dict[str, int],
+    extra_counters_sorted: list[str],
+) -> CounterFile | None:
+    """Clone basis, try appending extras; None if any won't fit."""
+    original_name = basis.file_name_txt.removeprefix("pmc_perf_").removesuffix(".txt")
+    trial = CounterFile(original_name, perfmon_config)
+    for ctr in _flat_counters_in_perfmon_file(basis):
+        if not trial.add(ctr):
+            msg = f"clone replay failed for {ctr!r} in {basis.file_name_txt}"
+            raise RuntimeError(msg)
+    for ctr in extra_counters_sorted:
+        if not trial.add(ctr):
+            return None
+    return trial
+
+
+def _rebuild_tcc_channel_file_map(
+    output_files: list[CounterFile],
+) -> dict[str, CounterFile]:
+    """Map TCC counter base name to the bucket that holds its channel instances."""
+    result: dict[str, CounterFile] = {}
+    for bucket in output_files:
+        for ctr in _flat_counters_in_perfmon_file(bucket):
+            if is_tcc_channel_counter(ctr):
+                result[ctr.split("[")[0]] = bucket
+    return result
+
+
+def _flat_counters_in_perfmon_file(counter_file: CounterFile) -> list[str]:
+    """Ordered list of PMC counter names assigned to one perfmon bucket file."""
+    return [
+        ctr
+        for block_name in counter_file.blocks
+        for ctr in counter_file.blocks[block_name].elements
+    ]

--- a/projects/rocprofiler-compute/src/rocprof_compute_soc/soc_gfx1151.py
+++ b/projects/rocprofiler-compute/src/rocprof_compute_soc/soc_gfx1151.py
@@ -1,0 +1,40 @@
+# Copyright (c) Advanced Micro Devices, Inc.
+# SPDX-License-Identifier:  MIT
+
+import argparse
+from typing import Optional
+
+from rocprof_compute_soc.soc_base import OmniSoC_Base
+from utils.logger import demarcate
+from utils.mi_gpu_spec import mi_gpu_specs
+from utils.specs import MachineSpecs
+
+
+class gfx1151_soc(OmniSoC_Base):
+    def __init__(self, args: argparse.Namespace, mspec: MachineSpecs) -> None:
+        super().__init__(args, mspec)
+        self.set_arch("gfx1151")
+        self.set_compatible_profilers(["rocprofv3", "rocprofiler-sdk"])
+        # Per IP block max number of simultaneous counters. GFX IP Blocks
+        self.set_perfmon_config(mi_gpu_specs.get_perfmon_config("gfx1151"))
+
+        # Set arch specific specs for RDNA3.5
+        self._mspec.l2_banks = 8
+        self._mspec.lds_banks_per_cu = 32
+        self._mspec.pipes_per_gpu = 2
+
+    # -----------------------
+    # Required child methods
+    # -----------------------
+    @demarcate
+    def profiling_setup(self) -> Optional[list[str]]:
+        """Perform any SoC-specific setup prior to profiling."""
+        super().profiling_setup()
+        # Performance counter filtering
+        filter_blocks = self.perfmon_filter()
+        return filter_blocks
+
+    @demarcate
+    def post_profiling(self) -> None:
+        """Perform any SoC-specific post profiling activities."""
+        super().post_profiling()

--- a/projects/rocprofiler-compute/src/rocprof_compute_tui/widgets/charts.py
+++ b/projects/rocprofiler-compute/src/rocprof_compute_tui/widgets/charts.py
@@ -15,7 +15,8 @@ import plotly.express as px
 import plotly.graph_objects as go
 from textual.widgets import Static
 
-from utils.mem_chart import plot_mem_chart
+from utils.mem_chart_gfx9 import plot_mem_chart as plot_mem_chart_gfx9
+from utils.mem_chart_gfx11 import plot_mem_chart as plot_mem_chart_gfx11
 
 # Constants
 MIN_PLOT_WIDTH = 20
@@ -300,6 +301,7 @@ class MemoryChart(Static):
         super().__init__("", classes="mem-chart", **kwargs)
         self.df = df
 
+    def on_mount(self) -> None:
         try:
             if self.df is None or self.df.empty:
                 self.update("No chart data generated")
@@ -311,11 +313,19 @@ class MemoryChart(Static):
 
             metric_dict = dict(zip(self.df["Metric"], self.df["Value"]))
 
+            # Route to arch-specific chart renderer
+            mspec = getattr(self.app, "mspec", None)
+            gpu_arch = mspec.gpu_arch if mspec else ""
+            if gpu_arch.startswith("gfx115"):
+                plot_func = plot_mem_chart_gfx11
+            else:
+                plot_func = plot_mem_chart_gfx9
+
             original_stdout = sys.stdout
             try:
                 with StringIO() as string_buffer:
                     sys.stdout = string_buffer
-                    result = plot_mem_chart("", "per_kernel", metric_dict)
+                    result = plot_func("", "per_kernel", metric_dict)
                     stdout_output = string_buffer.getvalue()
             finally:
                 sys.stdout = original_stdout

--- a/projects/rocprofiler-compute/src/utils/.config_hashes.json
+++ b/projects/rocprofiler-compute/src/utils/.config_hashes.json
@@ -1,8 +1,4 @@
 {
-  "0200_System_Speed_Of_Light.yaml": "e26f10cc97e46cc2585faa0e6dd619e6",
-  "0300_Memory_Chart.yaml": "740e2a539b72c3874df9870a7b0e7135",
-  "0800_TCP_Cache.yaml": "0b1ec74bb91eaa6161fd30eb49f3faf7",
-  "1300_GL2C.yaml": "f7fef8a0c25235adcd87763291f17f40",
   "archs": {
     "gfx1151": {
       "delta_hash": null,

--- a/projects/rocprofiler-compute/src/utils/.config_hashes.json
+++ b/projects/rocprofiler-compute/src/utils/.config_hashes.json
@@ -1,5 +1,27 @@
 {
+  "0200_System_Speed_Of_Light.yaml": "e26f10cc97e46cc2585faa0e6dd619e6",
+  "0300_Memory_Chart.yaml": "740e2a539b72c3874df9870a7b0e7135",
+  "0800_TCP_Cache.yaml": "0b1ec74bb91eaa6161fd30eb49f3faf7",
+  "1300_GL2C.yaml": "f7fef8a0c25235adcd87763291f17f40",
   "archs": {
+    "gfx1151": {
+      "delta_hash": null,
+      "files": {
+        "0000_Top_Stats.yaml": "e20b23bcf3d5d5f4d1fb30cb171850f3",
+        "0100_System_Info.yaml": "5bee16deca4a0b880af47a002fa7bab9",
+        "0200_System_Speed_Of_Light.yaml": "e26f10cc97e46cc2585faa0e6dd619e6",
+        "0300_Memory_Chart.yaml": "740e2a539b72c3874df9870a7b0e7135",
+        "0400_roofline.yaml": "554dc69c80ac5b4b8767c244cb5e6ba2",
+        "0500_CPC.yaml": "d32b1aea018a730d330ed82e73835ffa",
+        "0600_SPI.yaml": "4aeb74aba69b956e889242ebae2db0b2",
+        "0700_WGP.yaml": "f3ed504a5de07279cdf03779b18854f3",
+        "0800_TCP_Cache.yaml": "f462a6a3cc6ebcd81d6935601bf71011",
+        "1100_GL1C.yaml": "687b6f352560af9462a6e76619244426",
+        "1300_GL2C.yaml": "f7fef8a0c25235adcd87763291f17f40",
+        "1500_GCEA.yaml": "0e7fbc65ce1a4034b458347bbe3ed9a7",
+        "1700_GRBM.yaml": "5b688ce2905aae189a870f16b6a89a44"
+      }
+    },
     "gfx908": {
       "delta_hash": "dafcea1d4f2e6e6e52ca48599dd1ad54",
       "files": {

--- a/projects/rocprofiler-compute/src/utils/file_io.py
+++ b/projects/rocprofiler-compute/src/utils/file_io.py
@@ -29,7 +29,14 @@ def load_sys_info(f: str) -> pd.DataFrame:
     """
     Load sys running info from csv file to a df.
     """
-    return pd.read_csv(f)
+    from utils.specs import canonical_gpu_arch
+
+    df = pd.read_csv(f)
+    if "gpu_arch" in df.columns and not df.empty:
+        df["gpu_arch"] = df["gpu_arch"].map(
+            lambda x: canonical_gpu_arch(str(x)) if pd.notna(x) else x
+        )
+    return df
 
 
 def load_panel_configs(

--- a/projects/rocprofiler-compute/src/utils/hip_interface.py
+++ b/projects/rocprofiler-compute/src/utils/hip_interface.py
@@ -253,9 +253,12 @@ class HIPError(Exception):
 class HIPDeviceMemory:
     def __init__(self, ptr: POINTER) -> None:
         self.ptr = ptr
+        self._freed = False
 
     def __del__(self) -> None:
-        _lib.hipFree(self.ptr)
+        if not self._freed and self.ptr and getattr(self.ptr, "value", 0):
+            _lib.hipFree(self.ptr)
+            self._freed = True
 
 
 class HIPEvent:

--- a/projects/rocprofiler-compute/src/utils/mem_chart_gfx11.py
+++ b/projects/rocprofiler-compute/src/utils/mem_chart_gfx11.py
@@ -1,0 +1,846 @@
+# Copyright (c) Advanced Micro Devices, Inc.
+# SPDX-License-Identifier:  MIT
+
+"""
+RDNA3.5 Memory Architecture Diagram - CLI Visualization
+=============================================================================
+
+USAGE:
+    python mem_chart_gfx11.py [--data metrics.json] [--debug]
+        [--txt file.txt] [--svg file.svg]
+
+API:
+    normalize_mem_chart_metrics(metric_dict) -> flat ordered dict for UIs
+    plot_mem_chart(..., *, chart_title=...) -> str
+    format_mem_chart_heading(normal_unit, *, panel_id=300, section_label=...) -> str
+
+Metric dict keys must match the Memory Chart panel YAML for RDNA3.5:
+
+    src/rocprof_compute_soc/analysis_configs/gfx1151/0300_Memory_Chart.yaml
+
+Use ``MEM_CHART_PANEL_METRIC_KEYS`` for the authoritative ordered list.
+(If a future gfx target adds ``0300_memory_chart.yaml``, keep keys aligned there.)
+
+Bandwidth values are **Bytes/s**, matching the YAML ``unit: Bytes/s`` rows.
+
+RDNA3.5 MEMORY HIERARCHY (GCEA = Graphics Core Efficiency Arbiter):
+   Kernel -> TCP (L0 Vector Cache) -> GL1C (L1) -> GL2C (L2) -> GCEA -> System Memory
+         -> SQC (ICache/DCache)   -> GL1C (L1) -> GL2C (L2) -> GCEA -> System Memory
+         -> LDS (Local Data Share) [stays on CU, no GL1C connection]
+"""
+
+import argparse
+import json
+import re
+from io import StringIO
+from typing import Any, Optional, Union
+
+from rich.console import Console
+from rich.panel import Panel
+from rich.table import Table
+from rich.text import Text
+
+from utils.utils_analysis import format_bw_human_readable
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+# Keys = ``metric:`` names under each ``metric_table`` in
+# ``analysis_configs/gfx1151/0300_Memory_Chart.yaml`` (tables 301–309), in panel order.
+# Commented-out YAML metrics (e.g. TCP Atomic, LDS direct read/write) are omitted.
+_MEM_CHART_DEFAULT_ROWS: tuple[tuple[str, Union[int, float]], ...] = (
+    # Table 301: Instruction Cache
+    ("ICache Requests", 450),
+    ("ICache Utilization", 45.2),
+    ("ICache Hit Rate", 98.5),
+    ("ICache Miss Rate", 1.5),
+    ("ICache Request Stall Rate", 2.1),
+    ("ICache-GL1 Read Bandwidth", 57.6e9),
+    # Table 302: Scalar Data Cache
+    ("Dcache Requests", 225),
+    ("Dcache Utilization", 38.7),
+    ("Dcache Hit Rate", 95.3),
+    ("Dcache Request Stall Rate", 1.8),
+    ("Dcache-GL1 Read Bandwidth", 28.8e9),
+    # Table 303: TCP Cache (Vector L0)
+    ("TCP Total Requests", 1_250_000),
+    ("TCP Read Requests", 875_000),
+    ("TCP Write Requests", 375_000),
+    ("TCP Miss Requests", 150_000),
+    ("TCP Hit Rate", 88.0),
+    ("TCP Request Bandwidth", 80e9),
+    # Table 304: LDS
+    ("LDS Instructions", 125_000),
+    ("LDS Atomic Instructions", 10_000),
+    ("LDS Instruction Cycles", 250_000),
+    ("LDS Wait Cycles", 12_500),
+    ("LDS Bank Conflict Rate", 4.0),
+    ("LDS Estimated Bandwidth", 256e9),
+    # Table 305: TCP-GL1 Interface
+    ("TCP-GL1 Read Requests", 150_000),
+    ("TCP-GL1 Write Requests", 50_000),
+    ("TCP-GL1 Read Bandwidth", 96e9),
+    ("TCP-GL1 Write Bandwidth", 32e9),
+    # Table 306: GL1C Cache (L1)
+    ("GL1C Utilization", 65.2),
+    ("GL1C Total Requests", 200_000),
+    ("GL1C Read Requests", 150_000),
+    ("GL1C Write Requests", 50_000),
+    ("GL1C Miss Requests", 30_000),
+    ("GL1C Hit Rate", 85.0),
+    ("GL1C Starve Rate", 5.2),
+    ("GL1C Stall GL2 Backpressure", 8.5),
+    # Table 307: GL1C-GL2 Interface
+    ("GL1-GL2 Read Requests", 30_000),
+    ("GL1-GL2 Write Requests", 10_000),
+    ("GL1-GL2 Read Bandwidth", 48e9),
+    ("GL1-GL2 Write Bandwidth", 16e9),
+    ("GL1-GL2 Read Latency", 85.2),
+    ("GL1-GL2 Write Latency", 62.4),
+    # Table 308: GL2C Cache (L2)
+    ("GL2C Utilization", 74.2),
+    ("GL2C Total Requests", 40_000),
+    ("GL2C Read Requests", 30_000),
+    ("GL2C Write Requests", 10_000),
+    ("GL2C Atomic Requests", 1_000),
+    ("GL2C Hit Rate", 82.5),
+    ("GL2C Read Bandwidth", 64e9),
+    ("GL2C Write Bandwidth", 24e9),
+    # Table 309: Graphics Core Efficiency Arbiter (GCEA) to System Memory
+    ("SARB Utilization", 52.3),
+    ("SARB Stall Rate", 12.4),
+    ("DRAM Read Requests", 25_000),
+    ("DRAM Write Requests", 8_000),
+    ("DRAM Read Bandwidth", 100e9),
+    ("DRAM Write Bandwidth", 60e9),
+    ("Read Returns", 25_000),
+    ("Write Returns", 8_000),
+)
+
+MEM_CHART_PANEL_METRIC_KEYS: tuple[str, ...] = tuple(
+    k for k, _ in _MEM_CHART_DEFAULT_ROWS
+)
+
+DEFAULT_SAMPLE_METRICS: dict[str, Union[int, float]] = dict(_MEM_CHART_DEFAULT_ROWS)
+
+COLORS = {
+    "kernel": "green",
+    "block": "blue",
+    "tcp": "cyan",
+    "lds": "magenta",
+    "sqc": "yellow",
+    "read": "bright_cyan",
+    "write": "bright_yellow",
+    "atomic": "bright_magenta",
+    "util": "bright_green",
+    "hit": "yellow",
+    "stall": "indian_red",
+    "bw": "bright_cyan",
+}
+
+# ---------------------------------------------------------------------------
+# Formatting helpers
+# ---------------------------------------------------------------------------
+
+
+def format_value(
+    value: Union[int, float, str, None], unit: str = "", precision: int = 1
+) -> str:
+    if value is None:
+        return "N/A"
+    if isinstance(value, str):
+        try:
+            value = float(value)
+        except (ValueError, TypeError):
+            return value
+    if unit == "%":
+        return f"{value:.{precision}f}%"
+    elif unit in ("GB/s", "Bytes/s"):
+        return format_bw_human_readable(value, unit, precision)
+    else:
+        return f"{value:.{precision}f}{unit}"
+
+
+def format_sci(value: Union[int, float, str, None], precision: int = 2) -> str:
+    if value is None:
+        return "N/A"
+    try:
+        value = float(value)
+    except (ValueError, TypeError):
+        return "N/A"
+    if abs(value) < 1000:
+        return f"{int(value)}"
+    return f"{value:.{precision}e}"
+
+
+def metric_line(
+    label: str,
+    value: Any,  # noqa: ANN401
+    unit: str = "%",
+    color: str = "bright_green",
+) -> str:
+    formatted = format_value(value, unit)
+    return f"{label} [{color}]{formatted}[/{color}]"
+
+
+def bar(pct: float, w: int = 10) -> str:
+    if pct is None:
+        return "░" * w
+    try:
+        pct = float(pct)
+    except (ValueError, TypeError):
+        return "░" * w
+    filled = int(w * min(100, max(0, pct)) / 100)
+    return "█" * filled + "░" * (w - filled)
+
+
+def _safe_float_sum(
+    *values: Union[int, float, str, None],
+) -> Optional[float]:
+    """Sum non-None numeric values. Returns None if no value is valid."""
+    total = 0.0
+    any_valid = False
+    for v in values:
+        if v is not None:
+            try:
+                total += float(v)
+                any_valid = True
+            except (ValueError, TypeError):
+                pass
+    return total if any_valid else None
+
+
+def _fmt_edge(
+    label: str,
+    value: Any,  # noqa: ANN401
+    width: int = 7,
+) -> str:
+    label_str = f"{label:<{width}}"
+    if value is not None:
+        value_str = f": {format_sci(value):>7}"
+    else:
+        value_str = ""
+    return f"{label_str}{value_str}"
+
+
+# ---------------------------------------------------------------------------
+# Public API: heading, normalization, sample data
+# ---------------------------------------------------------------------------
+
+
+def _print_mem_chart_scope_bar(console: Console) -> None:
+    """Horizontal rule: GPU span vs System Memory (above the diagram body)."""
+    console.print(
+        "|"
+        + "-" * 62
+        + " [dim]GPU[/dim] "
+        + "-" * 62
+        + "|"
+        + "-" * 4
+        + " [dim]System Memory[/dim] "
+        + "-" * 4
+        + "|"
+    )
+
+
+def format_mem_chart_heading(
+    normal_unit: str,
+    *,
+    panel_id: int = 300,
+    section_label: str = "Memory Chart",
+) -> str:
+    """Build CLI diagram title: ``{panel_id//100}. {label} (Normalization: …)``.
+
+    Matches other panels (e.g. ``3. System Speed-of-Light``) where the leading
+    number is ``Panel Config id // 100`` (panel 300 → ``3.``).
+    """
+    section = max(0, int(panel_id)) // 100
+    return f"{section}. {section_label} (Normalization: {normal_unit})"
+
+
+def normalize_mem_chart_metrics(metric_dict: dict[str, Any]) -> dict[str, Any]:
+    """Return a single flat map: YAML metric name -> value, panel order.
+
+    All keys in ``MEM_CHART_PANEL_METRIC_KEYS`` are present; unknown input keys
+    are dropped. Use before rendering or serializing for front-ends.
+    """
+    return {k: metric_dict.get(k) for k in MEM_CHART_PANEL_METRIC_KEYS}
+
+
+def get_sample_metrics() -> dict[str, Any]:
+    """Return sample metrics (flat panel order) for testing or demos."""
+    return normalize_mem_chart_metrics(DEFAULT_SAMPLE_METRICS.copy())
+
+
+# ---------------------------------------------------------------------------
+# Diagram construction: _extract_metrics, _build_kernel_and_l0,
+#   _build_cache_columns, _build_memory_columns, create_mem_chart_diagram
+# ---------------------------------------------------------------------------
+
+
+def _extract_metrics(metric_dict: dict[str, Any]) -> dict[str, Any]:
+    """Pull all needed values from the flat metric dict."""
+    m: dict[str, Any] = {}
+
+    m["icache_req"] = metric_dict.get("ICache Requests")
+    m["icache_hit"] = metric_dict.get("ICache Hit Rate")
+    m["icache_gl1_bw"] = metric_dict.get("ICache-GL1 Read Bandwidth")
+
+    m["dcache_req"] = metric_dict.get("Dcache Requests")
+    m["dcache_hit"] = metric_dict.get("Dcache Hit Rate")
+    m["dcache_gl1_bw"] = metric_dict.get("Dcache-GL1 Read Bandwidth")
+
+    m["tcp_read_req"] = metric_dict.get("TCP Read Requests")
+    m["tcp_write_req"] = metric_dict.get("TCP Write Requests")
+    m["tcp_hit"] = metric_dict.get("TCP Hit Rate")
+    m["tcp_bw"] = metric_dict.get("TCP Request Bandwidth")
+
+    m["lds_insts"] = metric_dict.get("LDS Instructions")
+    m["lds_inst_cycles"] = metric_dict.get("LDS Instruction Cycles")
+    m["lds_atomic_insts"] = metric_dict.get("LDS Atomic Instructions")
+    m["lds_bw"] = metric_dict.get("LDS Estimated Bandwidth")
+    m["lds_bank_conflict"] = metric_dict.get("LDS Bank Conflict Rate")
+
+    m["tcp_gl1_read_bw"] = metric_dict.get("TCP-GL1 Read Bandwidth")
+    m["tcp_gl1_write_bw"] = metric_dict.get("TCP-GL1 Write Bandwidth")
+
+    m["sqc_gl1_read_bw"] = _safe_float_sum(m["icache_gl1_bw"], m["dcache_gl1_bw"])
+
+    m["gl1c_util"] = metric_dict.get("GL1C Utilization")
+    m["gl1c_hit"] = metric_dict.get("GL1C Hit Rate")
+    m["gl1c_stall_gl2"] = metric_dict.get("GL1C Stall GL2 Backpressure")
+
+    m["gl1_gl2_read_bw"] = metric_dict.get("GL1-GL2 Read Bandwidth")
+    m["gl1_gl2_write_bw"] = metric_dict.get("GL1-GL2 Write Bandwidth")
+
+    m["gl2c_util"] = metric_dict.get("GL2C Utilization")
+    m["gl2c_hit"] = metric_dict.get("GL2C Hit Rate")
+    m["gl2c_read_bw"] = metric_dict.get("GL2C Read Bandwidth")
+    m["gl2c_write_bw"] = metric_dict.get("GL2C Write Bandwidth")
+
+    m["sarb_util"] = metric_dict.get("SARB Utilization")
+    m["sarb_stall"] = metric_dict.get("SARB Stall Rate")
+    m["dram_read_bw"] = metric_dict.get("DRAM Read Bandwidth", 0)
+    m["dram_write_bw"] = metric_dict.get("DRAM Write Bandwidth", 0)
+
+    m["total_bw"] = (m["dram_read_bw"] or 0) + (m["dram_write_bw"] or 0)
+
+    return m
+
+
+def _build_kernel_and_l0(
+    m: dict[str, Any],
+    kernel_arrows: dict[str, str],
+    std_arrows: dict[str, str],
+) -> tuple[Panel, Text, Table, Text]:
+    """Build the Kernel panel, kernel edges, LDS/TCP/SQC stack, and GL1 edges.
+
+    Returns (kernel_panel, kernel_edges_text, l0_stack, gl1_edges_text).
+    """
+    fmt_bw = format_bw_human_readable
+    c_rd = COLORS["read"]
+    c_wr = COLORS["write"]
+    c_at = COLORS["atomic"]
+    c_bl = COLORS["block"]
+
+    # Kernel panel (height = 10+10+10 = 30 to match L0 stack)
+    kernel_panel = Panel(
+        "\n" * 11 + "[dim]Shader Core[/dim]\n[dim]Wave Execution[/dim]",
+        title=(f"[bold {COLORS['kernel']}]Kernel[/bold {COLORS['kernel']}]"),
+        border_style=COLORS["kernel"],
+        width=14,
+        height=30,
+    )
+
+    # Kernel edges — LDS, TCP, SQC groups
+    ka_l = kernel_arrows["left"]
+    ka_r = kernel_arrows["right"]
+    ka_b = kernel_arrows["both"]
+    kernel_edges_lines = [
+        "",
+        "     [white]Request[/white]",
+        "",
+        f"[{c_rd}]{_fmt_edge('Read', m['lds_insts'])}[/{c_rd}]",
+        f"[{c_rd}]{ka_l}[/{c_rd}]",
+        f"[{c_wr}]{_fmt_edge('Write', m['lds_inst_cycles'])}[/{c_wr}]",
+        f"[{c_wr}]{ka_r}[/{c_wr}]",
+        f"[{c_at}]{_fmt_edge('Atomic', m['lds_atomic_insts'])}[/{c_at}]",
+        f"[{c_at}]{ka_b}[/{c_at}]",
+        "",
+        "",
+        "",
+        "",
+        f"[{c_rd}]{_fmt_edge('Read', m['tcp_read_req'])}[/{c_rd}]",
+        f"[{c_rd}]{ka_l}[/{c_rd}]",
+        f"[{c_wr}]{_fmt_edge('Write', m['tcp_write_req'])}[/{c_wr}]",
+        f"[{c_wr}]{ka_r}[/{c_wr}]",
+        "",
+        "",
+        "",
+        "",
+        "",
+        "",
+        "",
+        "",
+        f"[{c_rd}]{_fmt_edge('ICache', m['icache_req'])}[/{c_rd}]",
+        f"[{c_rd}]{ka_l}[/{c_rd}]",
+        f"[{c_rd}]{_fmt_edge('DCache', m['dcache_req'])}[/{c_rd}]",
+        f"[{c_rd}]{ka_l}[/{c_rd}]",
+    ]
+    kernel_edges_text = Text.from_markup("\n".join(kernel_edges_lines))
+
+    # LDS panel
+    lds_bw_line = (
+        metric_line("BW", m["lds_bw"], "Bytes/s", COLORS["bw"]) if m["lds_bw"] else ""
+    )
+    lds_conflict_line = (
+        metric_line("Bank Conflict", m["lds_bank_conflict"], "%", COLORS["stall"])
+        if m["lds_bank_conflict"]
+        else ""
+    )
+    lds_panel = Panel(
+        f"{lds_bw_line}\n{lds_conflict_line}",
+        title=f"[bold {c_bl}]LDS[/bold {c_bl}]",
+        border_style=c_bl,
+        width=20,
+        height=10,
+    )
+
+    # TCP panel
+    tcp_bw_line = (
+        metric_line("BW", m["tcp_bw"], "Bytes/s", COLORS["bw"]) if m["tcp_bw"] else ""
+    )
+    tcp_panel = Panel(
+        f"{metric_line('Hit Rate', m['tcp_hit'], '%', COLORS['hit'])}\n{tcp_bw_line}",
+        title=f"[bold {c_bl}]TCP (L0)[/bold {c_bl}]",
+        border_style=c_bl,
+        width=20,
+        height=10,
+    )
+
+    # SQC panel
+    sqc_panel = Panel(
+        f"{metric_line('ICache', m['icache_hit'], '%', COLORS['hit'])}\n"
+        f"{metric_line('DCache', m['dcache_hit'], '%', COLORS['hit'])}",
+        title=f"[bold {c_bl}]SQC[/bold {c_bl}]",
+        border_style=c_bl,
+        width=20,
+        height=10,
+    )
+
+    # Stack LDS, TCP, SQC vertically
+    l0_stack = Table.grid(padding=0)
+    l0_stack.add_column()
+    l0_stack.add_row(lds_panel)
+    l0_stack.add_row(tcp_panel)
+    l0_stack.add_row(sqc_panel)
+
+    # Edges to GL1C (TCP and SQC connect, LDS does NOT)
+    sa_l = std_arrows["left"]
+    sa_r = std_arrows["right"]
+    tcp_gl1_rd = fmt_bw(m["tcp_gl1_read_bw"], precision=1)
+    tcp_gl1_wr = fmt_bw(m["tcp_gl1_write_bw"], precision=1)
+    sqc_gl1_rd = fmt_bw(m["sqc_gl1_read_bw"], precision=1)
+    gl1_edges_lines = [
+        "",
+        "",
+        "",
+        "",
+        "",
+        "",
+        "",
+        "",
+        "",
+        "",
+        "",
+        f"[{c_rd}]Read BW[/{c_rd}]",
+        f"[{c_rd}]{tcp_gl1_rd}[/{c_rd}]",
+        f"[{c_rd}]{sa_l}[/{c_rd}]",
+        "",
+        f"[{c_wr}]Write BW[/{c_wr}]",
+        f"[{c_wr}]{tcp_gl1_wr}[/{c_wr}]",
+        f"[{c_wr}]{sa_r}[/{c_wr}]",
+        "",
+        "",
+        "",
+        f"[{c_rd}]Read BW[/{c_rd}]",
+        f"[{c_rd}]{sqc_gl1_rd}[/{c_rd}]",
+        f"[{c_rd}]{sa_l}[/{c_rd}]",
+    ]
+    gl1_edges_text = Text.from_markup("\n".join(gl1_edges_lines))
+
+    return kernel_panel, kernel_edges_text, l0_stack, gl1_edges_text
+
+
+def _build_cache_columns(
+    m: dict[str, Any],
+    std_arrows: dict[str, str],
+) -> tuple[Panel, Text, Panel]:
+    """Build GL1C panel, GL1-GL2 edges, GL2C panel.
+
+    Returns (gl1_panel, gl1_gl2_edges_text, gl2_panel).
+    """
+    fmt_bw = format_bw_human_readable
+    c_rd = COLORS["read"]
+    c_wr = COLORS["write"]
+    c_bl = COLORS["block"]
+    sa_l = std_arrows["left"]
+    sa_r = std_arrows["right"]
+
+    gl1_panel = Panel(
+        f"{metric_line('Util', m['gl1c_util'], '%', COLORS['util'])}\n"
+        f"[dim]{bar(m['gl1c_util'])}[/dim]\n"
+        "\n"
+        f"{metric_line('Hit Rate', m['gl1c_hit'], '%', COLORS['hit'])}\n"
+        f"[dim]{bar(m['gl1c_hit'])}[/dim]\n"
+        "\n"
+        f"{metric_line('GL2 Stall', m['gl1c_stall_gl2'], '%', COLORS['stall'])}",
+        title=f"[bold {c_bl}]GL1C[/bold {c_bl}]",
+        border_style=c_bl,
+        width=16,
+        height=30,
+    )
+
+    rd_bw = fmt_bw(m["gl1_gl2_read_bw"], precision=1)
+    wr_bw = fmt_bw(m["gl1_gl2_write_bw"], precision=1)
+    gl1_gl2_edges_lines = [
+        "",
+        "",
+        "",
+        "",
+        "",
+        "",
+        "",
+        "",
+        "",
+        "",
+        "",
+        f"[{c_rd}]Read BW[/{c_rd}]",
+        f"[{c_rd}]{rd_bw}[/{c_rd}]",
+        f"[{c_rd}]{sa_l}[/{c_rd}]",
+        "",
+        f"[{c_wr}]Write BW[/{c_wr}]",
+        f"[{c_wr}]{wr_bw}[/{c_wr}]",
+        f"[{c_wr}]{sa_r}[/{c_wr}]",
+        "",
+        "",
+        "",
+        "",
+    ]
+    gl1_gl2_edges_text = Text.from_markup("\n".join(gl1_gl2_edges_lines))
+
+    gl2_panel = Panel(
+        f"{metric_line('Util', m['gl2c_util'], '%', COLORS['util'])}\n"
+        f"[dim]{bar(m['gl2c_util'])}[/dim]\n"
+        "\n"
+        f"{metric_line('Hit Rate', m['gl2c_hit'], '%', COLORS['hit'])}\n"
+        f"[dim]{bar(m['gl2c_hit'])}[/dim]",
+        title=f"[bold {c_bl}]GL2C[/bold {c_bl}]",
+        border_style=c_bl,
+        width=16,
+        height=30,
+    )
+
+    return gl1_panel, gl1_gl2_edges_text, gl2_panel
+
+
+def _build_memory_columns(
+    m: dict[str, Any],
+    std_arrows: dict[str, str],
+) -> tuple[Text, Panel, Text, Panel]:
+    """Build GL2-GCEA edges, GCEA panel, DRAM edges, DRAM panel.
+
+    Returns (gl2_gcea_edges_text, gcea_panel, dram_edges_text, dram_panel).
+    """
+    fmt_bw = format_bw_human_readable
+    c_rd = COLORS["read"]
+    c_wr = COLORS["write"]
+    c_bl = COLORS["block"]
+    sa_l = std_arrows["left"]
+    sa_r = std_arrows["right"]
+
+    gl2_rd = fmt_bw(m["gl2c_read_bw"], precision=1)
+    gl2_wr = fmt_bw(m["gl2c_write_bw"], precision=1)
+    gl2_gcea_edges_lines = [
+        "",
+        "",
+        "",
+        "",
+        "",
+        "",
+        "",
+        "",
+        "",
+        "",
+        "",
+        f"[{c_rd}]Read BW[/{c_rd}]",
+        f"[{c_rd}]{gl2_rd}[/{c_rd}]",
+        f"[{c_rd}]{sa_l}[/{c_rd}]",
+        "",
+        f"[{c_wr}]Write BW[/{c_wr}]",
+        f"[{c_wr}]{gl2_wr}[/{c_wr}]",
+        f"[{c_wr}]{sa_r}[/{c_wr}]",
+        "",
+        "",
+        "",
+        "",
+    ]
+    gl2_gcea_edges_text = Text.from_markup("\n".join(gl2_gcea_edges_lines))
+
+    gcea_panel = Panel(
+        f"{metric_line('SysArb Util', m['sarb_util'], '%', COLORS['util'])}\n"
+        f"[dim]{bar(m['sarb_util'])}[/dim]\n"
+        "\n"
+        f"{metric_line('Stall', m['sarb_stall'], '%', COLORS['stall'])}",
+        title=f"[bold {c_bl}]GCEA[/bold {c_bl}]",
+        border_style=c_bl,
+        width=16,
+        height=30,
+    )
+
+    dram_rd = fmt_bw(m["dram_read_bw"], precision=1)
+    dram_wr = fmt_bw(m["dram_write_bw"], precision=1)
+    dram_edges_lines = [
+        "",
+        "",
+        "",
+        "",
+        "",
+        "",
+        "",
+        "",
+        "",
+        "",
+        "",
+        f"[{c_rd}]Read BW[/{c_rd}]",
+        f"[{c_rd}]{dram_rd}[/{c_rd}]",
+        f"[{c_rd}]{sa_l}[/{c_rd}]",
+        "",
+        f"[{c_wr}]Write BW[/{c_wr}]",
+        f"[{c_wr}]{dram_wr}[/{c_wr}]",
+        f"[{c_wr}]{sa_r}[/{c_wr}]",
+        "",
+        "",
+        "",
+        "",
+    ]
+    dram_edges_text = Text.from_markup("\n".join(dram_edges_lines))
+
+    total = fmt_bw(m["total_bw"], precision=1)
+    dram_panel = Panel(
+        "[dim]DDR5/LPDDR5[/dim]\n"
+        "\n"
+        f"Total: [bold bright_green]{total}[/bold bright_green]",
+        title=f"[bold {c_bl}]DRAM[/bold {c_bl}]",
+        border_style=c_bl,
+        width=16,
+        height=30,
+    )
+
+    return gl2_gcea_edges_text, gcea_panel, dram_edges_text, dram_panel
+
+
+# ---------------------------------------------------------------------------
+# Main diagram assembly
+# ---------------------------------------------------------------------------
+
+
+def create_mem_chart_diagram(
+    metric_dict: dict[str, Any],
+    console: Console,
+    show_debug: bool = False,
+    chart_title: str = "",
+) -> None:
+    """Create the RDNA3.5 memory diagram (TCP, LDS, SQC blocks).
+
+    ``chart_title``: printed once above the diagram (e.g. from YAML panel title +
+    normalization unit).
+    """
+    m = _extract_metrics(metric_dict)
+
+    console.print()
+    if chart_title:
+        console.print(f"[bold]{chart_title}[/bold]")
+    _print_mem_chart_scope_bar(console)
+    console.print()
+
+    # Arrow constants
+    std_arrow_len = 8
+    std_arrows = {
+        "left": "<" + "-" * std_arrow_len,
+        "right": "-" * std_arrow_len + ">",
+    }
+
+    kernel_edge_width = 16
+    kernel_arrows = {
+        "left": "<" + "-" * (kernel_edge_width - 1),
+        "right": "-" * (kernel_edge_width - 1) + ">",
+        "both": "<" + "-" * (kernel_edge_width - 2) + ">",
+    }
+
+    # Build layout columns
+    kernel_panel, kernel_edges, l0_stack, gl1_edges = _build_kernel_and_l0(
+        m, kernel_arrows, std_arrows
+    )
+    gl1_panel, gl1_gl2_edges, gl2_panel = _build_cache_columns(m, std_arrows)
+    gl2_gcea_edges, gcea_panel, dram_edges, dram_panel = _build_memory_columns(
+        m, std_arrows
+    )
+
+    # Assemble 11-column grid
+    main_layout = Table.grid(padding=0)
+    for _ in range(11):
+        main_layout.add_column()
+
+    main_layout.add_row(
+        kernel_panel,
+        kernel_edges,
+        l0_stack,
+        gl1_edges,
+        gl1_panel,
+        gl1_gl2_edges,
+        gl2_panel,
+        gl2_gcea_edges,
+        gcea_panel,
+        dram_edges,
+        dram_panel,
+    )
+
+    console.print(main_layout)
+    console.print()
+    legend = (
+        f"[dim]Legend:[/dim] "
+        f"[{COLORS['read']}]<----[/{COLORS['read']}] Read  "
+        f"[{COLORS['write']}]---->[/{COLORS['write']}] Write  "
+        f"[{COLORS['atomic']}]<--->[/{COLORS['atomic']}] Atomic  "
+        f"[{COLORS['util']}]█[/{COLORS['util']}] Util  "
+        f"[{COLORS['hit']}]█[/{COLORS['hit']}] Hit%  "
+        f"[{COLORS['stall']}]█[/{COLORS['stall']}] Stall"
+    )
+    console.print(legend)
+    console.print()
+
+    if show_debug:
+        console.print("[dim]Architecture Notes:[/dim]")
+        console.print("  TCP (Texture Cache Pipe): L0 vector cache for VMEM operations")
+        console.print("  LDS (Local Data Share): On-CU scratchpad, NO GL1C connection")
+        console.print("  SQC (Sequencer Cache): ICache + DCache for scalar operations")
+        console.print()
+
+
+# ---------------------------------------------------------------------------
+# Public entry point
+# ---------------------------------------------------------------------------
+
+
+def plot_mem_chart(
+    arch: str,
+    normal_unit: str,
+    metric_dict: dict[str, Any],
+    *,
+    chart_title: Optional[str] = None,
+) -> str:
+    """Plot the memory chart and return as string.
+
+    ``metric_dict`` keys should match ``0300_Memory_Chart.yaml`` (gfx1151), i.e.
+    ``MEM_CHART_PANEL_METRIC_KEYS``. Values for bandwidth metrics are in **Bytes/s**.
+    Input is normalized to a flat ordered dict before rendering.
+
+    ``chart_title``: full heading line; if omitted, uses ``format_mem_chart_heading``
+    with ``panel_id=300`` (section ``3.``).
+    """
+    flat = normalize_mem_chart_metrics(metric_dict)
+    resolved_heading = (
+        format_mem_chart_heading(normal_unit, panel_id=300)
+        if chart_title is None
+        else chart_title
+    )
+    buf = StringIO()
+    console = Console(file=buf, force_terminal=True, width=200, height=80)
+    create_mem_chart_diagram(
+        flat,
+        console,
+        show_debug=False,
+        chart_title=resolved_heading,
+    )
+    return buf.getvalue()
+
+
+# ---------------------------------------------------------------------------
+# CLI entry point
+# ---------------------------------------------------------------------------
+
+
+def main() -> None:
+    arg_parser = argparse.ArgumentParser(
+        description="RDNA3.5 Memory Chart - CLI Visualization"
+    )
+    arg_parser.add_argument("--data", "-d", help="JSON file with metrics data")
+    arg_parser.add_argument("--debug", action="store_true", help="Show debug info")
+    arg_parser.add_argument("--arch", default="gfx1151", help="Architecture name")
+    arg_parser.add_argument("--norm", default="per_kernel", help="Normalization unit")
+    arg_parser.add_argument("--txt", "-t", help="Output to plain text file")
+    arg_parser.add_argument("--svg", help="Output to SVG file")
+    args = arg_parser.parse_args()
+
+    if args.data:
+        with open(args.data) as f:
+            metric_dict = normalize_mem_chart_metrics(json.load(f))
+    else:
+        metric_dict = normalize_mem_chart_metrics(DEFAULT_SAMPLE_METRICS.copy())
+
+    heading = format_mem_chart_heading(args.norm, panel_id=300)
+
+    if args.txt:
+        buf = StringIO()
+        console = Console(
+            file=buf,
+            force_terminal=True,
+            width=200,
+            height=80,
+            no_color=True,
+        )
+        create_mem_chart_diagram(
+            metric_dict,
+            console,
+            args.debug,
+            chart_title=heading,
+        )
+        output = buf.getvalue()
+        plain = re.sub(r"\x1B(?:[@-Z\\-_]|\[[0-?]*[ -/]*[@-~])", "", output)
+        with open(args.txt, "w") as f:
+            f.write(plain)
+        print(f"Output written to {args.txt}")
+    elif args.svg:
+        svg_console = Console(
+            file=StringIO(),
+            force_terminal=True,
+            width=200,
+            height=80,
+            record=True,
+        )
+        create_mem_chart_diagram(
+            metric_dict,
+            svg_console,
+            args.debug,
+            chart_title=heading,
+        )
+        svg_output = svg_console.export_svg(title=heading)
+        with open(args.svg, "w") as f:
+            f.write(svg_output)
+        print(f"SVG saved to {args.svg}")
+    else:
+        buf = StringIO()
+        console = Console(file=buf, force_terminal=True, width=200, height=80)
+        create_mem_chart_diagram(
+            metric_dict,
+            console,
+            args.debug,
+            chart_title=heading,
+        )
+        print(buf.getvalue())
+
+
+if __name__ == "__main__":
+    main()

--- a/projects/rocprofiler-compute/src/utils/mem_chart_gfx9.py
+++ b/projects/rocprofiler-compute/src/utils/mem_chart_gfx9.py
@@ -1,6 +1,13 @@
 # Copyright (c) Advanced Micro Devices, Inc.
 # SPDX-License-Identifier:  MIT
 
+"""
+CDNA Memory Architecture Diagram - CLI/TUI Visualization
+=============================================================================
+Memory chart renderer for CDNA-class GPUs (MI200, MI300, MI350 series).
+For RDNA3.5 (gfx1151) see mem_chart_gfx11.py.
+"""
+
 import re
 from dataclasses import dataclass, field
 from decimal import Decimal

--- a/projects/rocprofiler-compute/src/utils/mi_gpu_spec.py
+++ b/projects/rocprofiler-compute/src/utils/mi_gpu_spec.py
@@ -275,7 +275,7 @@ class MIGPUSpecs:
         4. Default settings (last resort)
         """
         # Constants for legacy GPUs that don't support compute partitions
-        LEGACY_ARCHS = {"gfx908", "gfx90a"}
+        LEGACY_ARCHS = {"gfx908", "gfx90a", "gfx1150", "gfx1151"}
         LEGACY_MODELS = {"mi50", "mi60", "mi100", "mi210", "mi250", "mi250x"}
 
         # Normalize inputs to lowercase for consistent comparison

--- a/projects/rocprofiler-compute/src/utils/mi_gpu_spec.yaml
+++ b/projects/rocprofiler-compute/src/utils/mi_gpu_spec.yaml
@@ -357,3 +357,26 @@ mi_gpu_spec:
             chip_ids:
               physical: 30120
               virtual: 30136
+
+  #########################################################
+  #Note: in the future, we might set a seperate file for NAVI
+  - gpu_series: navi3
+    gpu_archs:
+      - gpu_arch: gfx1151
+        perfmon_config:
+            SQ: 8
+            TA: 2
+            GRBM: 2
+            CPC:  2
+            GCEA: 2
+            TCP:  4
+            SPI:  6
+            GL1A: 4
+            GL1C: 4
+            GL2A: 4
+            GL2C: 4
+        models:
+          - gpu_model: strix_halo
+            chip_ids:
+              physical: 5510
+  #########################################################

--- a/projects/rocprofiler-compute/src/utils/roofline_calc.py
+++ b/projects/rocprofiler-compute/src/utils/roofline_calc.py
@@ -76,7 +76,7 @@ SUPPORTED_DATATYPES: dict[str, list[str]] = {
         "I8",
         "I32",
         "I64",
-    ],  # Unsupported:
+    ],
 }
 
 PEAK_OPS_DATATYPES = ["FP16", "FP32", "FP64", "I8", "I32", "I64"]

--- a/projects/rocprofiler-compute/src/utils/specs.py
+++ b/projects/rocprofiler-compute/src/utils/specs.py
@@ -38,6 +38,16 @@ from utils.utils_common import format_table_ascii, get_version
 
 T = TypeVar("T")
 
+
+def canonical_gpu_arch(gpu_arch: Optional[str]) -> Optional[str]:
+    """Map LLVM GPU targets that share one SoC and analysis config tree."""
+    if gpu_arch is None:
+        return None
+    if gpu_arch == "gfx1152":
+        return "gfx1151"
+    return gpu_arch
+
+
 VERSION_LOC: list[str] = [
     "version",
     "version-dev",
@@ -61,8 +71,9 @@ def detect_arch(rocminfo_lines: list[str]) -> Optional[tuple[str, int]]:
         if not gpu_arch:
             continue
 
-        if gpu_arch in supported_gpu_arch:
-            return (gpu_arch, idx1)
+        arch_for_support = canonical_gpu_arch(gpu_arch)
+        if arch_for_support in supported_gpu_arch:
+            return (arch_for_support, idx1)
 
         if gpu_arch not in unsupported_gpu_arch:
             unsupported_gpu_arch.add(gpu_arch)
@@ -125,7 +136,11 @@ def generate_machine_specs(
                     "You need to reprofile to update data."
                 )
 
-            return MachineSpecs(**sysinfo)
+            # Normalize arch aliases to canonical config targets
+            sysinfo_norm = dict(sysinfo)
+            gpu_arch = sysinfo_norm.get("gpu_arch")
+            sysinfo_norm["gpu_arch"] = {"gfx1152": "gfx1151"}.get(gpu_arch, gpu_arch)
+            return MachineSpecs(**sysinfo_norm)
         except KeyError:
             console_error(
                 "Detected mismatch in sysinfo versioning. You need to reprofile "
@@ -194,13 +209,17 @@ def generate_machine_specs(
             f"but couldn't find class implementation {e}."
         )
 
-    # Update arch specific specs
-    specs.gpu_model = (
-        mi_gpu_specs.get_gpu_model(specs.gpu_arch, specs.gpu_chip_id) or ""
-    )
+    # Derive SoC-dependent fields
+    if specs.rocminfo_lines is None:
+        # Yaml-only / no rocminfo: skip get_gpu_model (avoids chip-id warnings).
+        specs.gpu_model = specs.gpu_model or ""
+    else:
+        specs.gpu_model = (
+            mi_gpu_specs.get_gpu_model(specs.gpu_arch, specs.gpu_chip_id) or ""
+        )
     specs.num_xcd = str(
         mi_gpu_specs.get_num_xcds(
-            specs.gpu_arch, specs.gpu_model, specs.compute_partition
+            specs.gpu_arch, specs.gpu_model or None, specs.compute_partition
         )
     )
     specs.total_l2_chan = totall2_banks(

--- a/projects/rocprofiler-compute/src/utils/tty.py
+++ b/projects/rocprofiler-compute/src/utils/tty.py
@@ -12,12 +12,17 @@ import pandas as pd
 from tabulate import tabulate
 
 import config
-from utils import mem_chart, parser, schema
+from utils import mem_chart_gfx9, mem_chart_gfx11, parser, schema
 from utils.kernel_name_shortener import (
     kernel_name_shortener,
 )
 from utils.logger import console_error, console_log, console_warning
-from utils.utils_analysis import NS_TO_MS, CallTreeNode, simplify_kernel_name
+from utils.utils_analysis import (
+    NS_TO_MS,
+    CallTreeNode,
+    get_bw_scale_and_unit,
+    simplify_kernel_name,
+)
 from utils.utils_common import (
     METRIC_ID_RE,
     convert_metric_id_to_panel_info,
@@ -37,6 +42,87 @@ KERNEL_NAME_WRAP_WIDTH = 40
 def wrap_kernel_name(name: str) -> str:
     """Wrap a kernel name at KERNEL_NAME_WRAP_WIDTH for table display."""
     return textwrap.fill(str(name), width=KERNEL_NAME_WRAP_WIDTH)
+
+
+def _recalculate_pct_of_peak(
+    df: pd.DataFrame,
+    idx: Any,  # noqa: ANN401
+    value_col: str,
+    peak_col: str,
+    pct_cols: list[str],
+    decimal: int,
+) -> None:
+    """Recalculate Pct of Peak = (value / peak) * 100 after BW scaling."""
+    for pct_col in pct_cols:
+        if pct_col not in df.columns:
+            continue
+        try:
+            val = df.loc[idx, value_col]
+            peak = df.loc[idx, peak_col]
+            if (
+                pd.notna(val)
+                and pd.notna(peak)
+                and val != "N/A"
+                and peak != "N/A"
+                and float(peak) != 0
+            ):
+                pct = (float(val) / float(peak)) * 100
+                df.loc[idx, pct_col] = round(pct, decimal)
+        except (ValueError, TypeError, ZeroDivisionError):
+            pass
+
+
+def scale_bw_columns(
+    df: pd.DataFrame, value_columns: list[str], decimal: int = 2
+) -> pd.DataFrame:
+    """Scale Bytes/s rows to human-readable units; recalculate Pct of Peak."""
+    if "Unit" not in df.columns:
+        return df
+
+    df_copy = df.copy()
+
+    bw_rows = df_copy["Unit"].str.lower().str.contains("bytes/s", na=False)
+    if not bw_rows.any():
+        return df_copy
+
+    pct_cols = ["Pct of Peak", "PoP"]
+    value_col = "Value" if "Value" in df_copy.columns else "Avg"
+    peak_col = "Peak (Empirical)" if "Peak (Empirical)" in df_copy.columns else "Peak"
+
+    for idx in df_copy.index[bw_rows]:
+        # Determine scale from the primary value column
+        primary_value = None
+        for col in ["Value", "Avg"]:
+            if col in df_copy.columns:
+                try:
+                    val = df_copy.loc[idx, col]
+                    if pd.notna(val) and val != "N/A":
+                        primary_value = float(val)
+                        break
+                except (ValueError, TypeError):
+                    continue
+
+        if primary_value is None or primary_value == 0:
+            continue
+
+        divisor, unit = get_bw_scale_and_unit(primary_value)
+
+        # Scale all numeric bandwidth columns with the same divisor
+        for col in value_columns:
+            if col not in df_copy.columns:
+                continue
+            try:
+                val = df_copy.loc[idx, col]
+                if pd.notna(val) and val != "N/A":
+                    df_copy.loc[idx, col] = round(float(val) / divisor, decimal)
+            except (ValueError, TypeError):
+                pass
+
+        _recalculate_pct_of_peak(df_copy, idx, value_col, peak_col, pct_cols, decimal)
+
+        df_copy.loc[idx, "Unit"] = unit
+
+    return df_copy
 
 
 def string_multiple_lines(source: str, width: int, max_rows: int) -> str:
@@ -548,6 +634,20 @@ def process_table_data(
     return result_df
 
 
+def _gfx115_mem_chart_heading(panel: Optional[dict[str, Any]], normal_unit: str) -> str:
+    """Section number from ``panel id // 100`` (panel 300 → ``3. Memory Chart``)."""
+    panel_id = int((panel or {}).get("id", 300))
+    return mem_chart_gfx11.format_mem_chart_heading(normal_unit, panel_id=panel_id)
+
+
+def _panel_is_mem_chart_only(panel: dict[str, Any]) -> bool:
+    """True when every table uses ``cli_style: mem_chart`` (one merged chart)."""
+    sources = panel.get("data source") or []
+    return bool(sources) and all(
+        tcfg.get("cli_style") == "mem_chart" for ds in sources for tcfg in ds.values()
+    )
+
+
 def format_table_output(
     args: argparse.Namespace,
     table_config: dict[str, Any],
@@ -555,6 +655,8 @@ def format_table_output(
     table_type: str,
     runs: dict[str, Any],
     csv_dir: Optional[Path] = None,
+    gpu_arch: Optional[str] = None,
+    mem_data_override: Optional[dict[str, Any]] = None,
 ) -> str:
     """Format table for output, handling special cases and saving to files if needed."""
 
@@ -573,7 +675,12 @@ def format_table_output(
         console_log(f"Not showing table with empty column(s): {table_id_str} {title}")
         return content
 
-    if "title" in table_config and table_config["title"]:
+    # mem_chart diagram mode: one merged chart, no per-table titles (3.1, 3.2, …).
+    # With --view table, keep titles so tabular output stays navigable.
+    skip_mem_chart_title = table_config.get(
+        "cli_style"
+    ) == "mem_chart" and not _tty_view_is_table(args)
+    if "title" in table_config and table_config["title"] and not skip_mem_chart_title:
         content += f"{table_id_str} {table_config['title']}\n"
 
     if args.output_format == "csv" and csv_dir and csv_dir.is_dir():
@@ -600,6 +707,16 @@ def format_table_output(
     # fash for now.
     transpose = table_type != "raw_csv_table" and table_config.get("columnwise", False)
 
+    # For single run and gfx115x, format BW metrics (Bytes/s) to human-readable
+    # For multiple runs (baseline comparison), keep Bytes for accurate comparison
+    is_single_run = len(runs) == 1
+    is_gfx115x = gpu_arch and gpu_arch.startswith("gfx115")
+
+    if is_single_run and is_gfx115x and "Unit" in df.columns:
+        # Identify value columns to format
+        value_cols = ["Value", "Avg", "Min", "Max", "Peak", "Peak (Empirical)"]
+        df = scale_bw_columns(df, value_cols, args.decimal)
+
     # When --view table is set, force table output and ignore cli_style from config
     use_mem_chart = (
         not _tty_view_is_table(args)
@@ -610,14 +727,31 @@ def format_table_output(
     )
 
     if use_mem_chart:
-        mem_data = (
-            pd
-            .DataFrame([df["Metric"], df["Value"]])
-            .transpose()
-            .set_index("Metric")
-            .to_dict()["Value"]
-        )
-        content += mem_chart.plot_mem_chart("", args.normal_unit, mem_data) + "\n"
+        if mem_data_override is not None:
+            mem_data = mem_data_override
+        else:
+            mem_data = (
+                pd
+                .DataFrame([df["Metric"], df["Value"]])
+                .transpose()
+                .set_index("Metric")
+                .to_dict()["Value"]
+            )
+
+        if gpu_arch and gpu_arch.startswith("gfx115"):
+            content += (
+                mem_chart_gfx11.plot_mem_chart(
+                    "",
+                    args.normal_unit,
+                    mem_data,
+                    chart_title=_gfx115_mem_chart_heading(None, args.normal_unit),
+                )
+                + "\n"
+            )
+        else:
+            content += (
+                mem_chart_gfx9.plot_mem_chart("", args.normal_unit, mem_data) + "\n"
+            )
     else:
         content += (
             get_table_string(df, transpose=transpose, decimal=args.decimal) + "\n"
@@ -640,6 +774,14 @@ def show_all(
     comparable_columns = parser.build_comparable_columns(args.time_unit)
     raw_filter_panel_ids = profiling_config.get("filter_blocks", [])
     csv_dir = None
+
+    # Get gpu_arch from the first run's sys_info
+    first_run = next(iter(runs.values()))
+    gpu_arch = (
+        first_run.sys_info.iloc[0]["gpu_arch"]
+        if hasattr(first_run, "sys_info") and not first_run.sys_info.empty
+        else None
+    )
 
     if isinstance(raw_filter_panel_ids, dict):
         # For backward compatibility
@@ -710,6 +852,7 @@ def show_all(
             _ = is_roofline_shown(args, runs, output, panel, roof_plot, hidden_cols)
 
         panel_content = ""  # store content of all data_source from one panel
+        mem_chart_data: dict[str, Any] = {}  # merged mem_chart metrics (gfx115x)
 
         for data_source in panel["data source"]:
             for table_type, table_config in data_source.items():
@@ -782,20 +925,63 @@ def show_all(
                     hidden_cols,
                 )
 
-                if not processed_df.empty:
-                    panel_content += format_table_output(
-                        args, table_config, processed_df, table_type, runs, csv_dir
+                if processed_df.empty:
+                    continue
+
+                # For gfx115x mem_chart panels, collect all tables and merge
+                # into a single chart on the first table; skip subsequent ones.
+                is_mem_chart = table_config.get(
+                    "cli_style"
+                ) == "mem_chart" and not _tty_view_is_table(args)
+                is_gfx115x = gpu_arch and gpu_arch.startswith("gfx115")
+
+                if is_mem_chart and is_gfx115x and len(runs) == 1:
+                    has_cols = (
+                        "Metric" in processed_df.columns
+                        and "Value" in processed_df.columns
                     )
+                    if has_cols:
+                        table_mem = dict(
+                            zip(processed_df["Metric"], processed_df["Value"])
+                        )
+                        mem_chart_data.update(table_mem)
+                    # Skip individual table output; merged chart emitted below
+                    continue
+
+                panel_content += format_table_output(
+                    args,
+                    table_config,
+                    processed_df,
+                    table_type,
+                    runs,
+                    csv_dir,
+                    gpu_arch,
+                )
+
+        # Emit merged gfx115x mem_chart for the panel
+        if mem_chart_data and not _tty_view_is_table(args):
+            heading = _gfx115_mem_chart_heading(panel, args.normal_unit)
+            panel_content += (
+                mem_chart_gfx11.plot_mem_chart(
+                    "",
+                    args.normal_unit,
+                    mem_chart_data,
+                    chart_title=heading,
+                )
+                + "\n"
+            )
 
         # Roofline printing is handled separately above in is_roofline_shown.
-        # When --view table is set, roofline tables (401/402) are rendered as normal
-        # tables.
+        # With --view table, roofline tables (401/402) render as normal tables.
         if panel_content and (
             table_config["id"] not in [401, 402] or _tty_view_is_table(args)
         ):
-            print(f"\n{'-' * 80}", file=output)
-            print(f"{panel_id // 100}. {panel['title']}", file=output)
-            print(panel_content, file=output)
+            if _panel_is_mem_chart_only(panel) and not _tty_view_is_table(args):
+                print(panel_content, file=output)
+            else:
+                print(f"\n{'-' * 80}", file=output)
+                print(f"{panel_id // 100}. {panel['title']}", file=output)
+                print(panel_content, file=output)
 
 
 def show_roof_plot(roof_plot: str) -> None:

--- a/projects/rocprofiler-compute/src/utils/utils_analysis.py
+++ b/projects/rocprofiler-compute/src/utils/utils_analysis.py
@@ -1,10 +1,11 @@
 # Copyright (c) Advanced Micro Devices, Inc.
 # SPDX-License-Identifier:  MIT
 
+import math
 import shutil
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any, Optional
+from typing import Any, Optional, Union
 
 import numpy as np
 import pandas as pd
@@ -18,6 +19,43 @@ from utils.logger import (
 )
 
 NS_TO_MS = 1.0 / 1_000_000.0
+
+
+def get_bw_scale_and_unit(value: float) -> tuple[float, str]:
+    """Return the divisor and suffix for a bandwidth value in Bytes/s."""
+    if value >= 1e12:
+        return 1e12, "TB/s"
+    if value >= 1e9:
+        return 1e9, "GB/s"
+    if value >= 1e6:
+        return 1e6, "MB/s"
+    if value >= 1e3:
+        return 1e3, "KB/s"
+    return 1.0, "B/s"
+
+
+def format_bw_human_readable(
+    value: Union[int, float, str, None], unit: str = "Bytes/s", precision: int = 2
+) -> str:
+    """Format bandwidth to human-readable string (e.g. 1.5 TB/s).
+
+    Accepts Bytes/s (default) or legacy GB/s input.
+    Returns 'NaN' for NaN, 'N/A' for None/invalid.
+    """
+    if value is None:
+        return "N/A"
+
+    try:
+        numeric_value = float(value)
+    except (ValueError, TypeError):
+        return "N/A"
+
+    if math.isnan(numeric_value):
+        return "NaN"
+
+    bytes_per_sec = numeric_value * 1e9 if unit == "GB/s" else numeric_value
+    divisor, output_unit = get_bw_scale_and_unit(bytes_per_sec)
+    return f"{bytes_per_sec / divisor:.{precision}f} {output_unit}"
 
 
 @dataclass

--- a/projects/rocprofiler-compute/tests/test_analyze_commands.py
+++ b/projects/rocprofiler-compute/tests/test_analyze_commands.py
@@ -440,18 +440,21 @@ def test_list_available_metrics(binary_handler_analyze_rocprof_compute, capsys):
 
     for dir in indirs:
         workload_dir = test_utils.setup_workload_dir(dir)
-        code = binary_handler_analyze_rocprof_compute([
-            "analyze",
-            "--path",
-            workload_dir,
-            "--list-available-metrics",
-        ])
-        assert code == 0
+        try:
+            code = binary_handler_analyze_rocprof_compute([
+                "analyze",
+                "--path",
+                workload_dir,
+                "--list-available-metrics",
+            ])
+            assert code == 0
 
-        # Test output
-        output = capsys.readouterr().out
-        assert "0 -> Top Stats" in output
-        assert "1 -> System Info" in output
+            # Test output
+            output = capsys.readouterr().out
+            assert "0 -> Top Stats" in output
+            assert "1 -> System Info" in output
+        finally:
+            test_utils.clean_output_dir(config["cleanup"], workload_dir)
 
 
 @pytest.mark.list_metrics

--- a/projects/rocprofiler-compute/tests/test_gpu_specs.py
+++ b/projects/rocprofiler-compute/tests/test_gpu_specs.py
@@ -148,7 +148,7 @@ def test_num_xcds_cli_output():
         )
     except Exception:
         proc = subprocess.run(
-            ["rocprof-compute", "-s"],
+            ["./rocprof-compute", "-s"],
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
             text=True,

--- a/projects/rocprofiler-compute/tests/test_mem_chart_gfx11.py
+++ b/projects/rocprofiler-compute/tests/test_mem_chart_gfx11.py
@@ -1,0 +1,543 @@
+# Copyright (c) Advanced Micro Devices, Inc.
+# SPDX-License-Identifier:  MIT
+
+"""
+Unit tests for mem_chart_gfx11.py - RDNA3.5 Memory Architecture Visualization
+
+Tests cover:
+1. Bandwidth formatting functions (Bytes/s to human-readable)
+2. Value formatting utilities
+3. Metric extraction and display
+4. Memory chart generation
+"""
+
+import re
+
+from utils import mem_chart_gfx11
+
+ANSI_ESCAPE = re.compile(r"\x1B[@-_][0-?]*[ -/]*[@-~]")
+
+
+def strip_ansi(text: str) -> str:
+    return ANSI_ESCAPE.sub("", text)
+
+
+# =============================================================================
+# Tests for format_bw_human_readable function
+# =============================================================================
+
+
+class TestFormatBwHumanReadable:
+    """Tests for format_bw_human_readable - converts Bytes/s to human-readable."""
+
+    def test_terabytes_per_second(self):
+        """Test TB/s formatting for values >= 1e12."""
+        # 1 TB/s
+        result = mem_chart_gfx11.format_bw_human_readable(1e12, "Bytes/s", 1)
+        assert result == "1.0 TB/s"
+
+        # 2.5 TB/s
+        result = mem_chart_gfx11.format_bw_human_readable(2.5e12, "Bytes/s", 1)
+        assert result == "2.5 TB/s"
+
+        # Large value with higher precision
+        result = mem_chart_gfx11.format_bw_human_readable(1.234e12, "Bytes/s", 2)
+        assert result == "1.23 TB/s"
+
+    def test_gigabytes_per_second(self):
+        """Test GB/s formatting for values >= 1e9 and < 1e12."""
+        # 1 GB/s
+        result = mem_chart_gfx11.format_bw_human_readable(1e9, "Bytes/s", 1)
+        assert result == "1.0 GB/s"
+
+        # 100 GB/s (typical HBM bandwidth)
+        result = mem_chart_gfx11.format_bw_human_readable(100e9, "Bytes/s", 1)
+        assert result == "100.0 GB/s"
+
+        # 512.5 GB/s
+        result = mem_chart_gfx11.format_bw_human_readable(512.5e9, "Bytes/s", 1)
+        assert result == "512.5 GB/s"
+
+    def test_megabytes_per_second(self):
+        """Test MB/s formatting for values >= 1e6 and < 1e9."""
+        # 1 MB/s
+        result = mem_chart_gfx11.format_bw_human_readable(1e6, "Bytes/s", 1)
+        assert result == "1.0 MB/s"
+
+        # 500 MB/s
+        result = mem_chart_gfx11.format_bw_human_readable(500e6, "Bytes/s", 1)
+        assert result == "500.0 MB/s"
+
+    def test_kilobytes_per_second(self):
+        """Test KB/s formatting for values >= 1e3 and < 1e6."""
+        # 1 KB/s
+        result = mem_chart_gfx11.format_bw_human_readable(1e3, "Bytes/s", 1)
+        assert result == "1.0 KB/s"
+
+        # 512 KB/s
+        result = mem_chart_gfx11.format_bw_human_readable(512e3, "Bytes/s", 1)
+        assert result == "512.0 KB/s"
+
+    def test_bytes_per_second(self):
+        """Test B/s formatting for values < 1e3."""
+        # 500 B/s
+        result = mem_chart_gfx11.format_bw_human_readable(500, "Bytes/s", 1)
+        assert result == "500.0 B/s"
+
+        # 0 B/s
+        result = mem_chart_gfx11.format_bw_human_readable(0, "Bytes/s", 1)
+        assert result == "0.0 B/s"
+
+    def test_legacy_gbps_unit_conversion(self):
+        """Test conversion from legacy GB/s unit to human-readable."""
+        # Input is 100 GB/s, should convert to Bytes/s first then format
+        result = mem_chart_gfx11.format_bw_human_readable(100, "GB/s", 1)
+        assert result == "100.0 GB/s"
+
+        # 1500 GB/s -> 1.5 TB/s
+        result = mem_chart_gfx11.format_bw_human_readable(1500, "GB/s", 1)
+        assert result == "1.5 TB/s"
+
+    def test_none_value(self):
+        """Test handling of None values."""
+        result = mem_chart_gfx11.format_bw_human_readable(None, "Bytes/s", 1)
+        assert result == "N/A"
+
+    def test_invalid_string_value(self):
+        """Test handling of non-numeric string values."""
+        result = mem_chart_gfx11.format_bw_human_readable("invalid", "Bytes/s", 1)
+        assert result == "N/A"
+
+    def test_precision_parameter(self):
+        """Test different precision values."""
+        value = 123.456789e9  # 123.456789 GB/s
+
+        assert (
+            mem_chart_gfx11.format_bw_human_readable(value, "Bytes/s", 0) == "123 GB/s"
+        )
+        assert (
+            mem_chart_gfx11.format_bw_human_readable(value, "Bytes/s", 1)
+            == "123.5 GB/s"
+        )
+        assert (
+            mem_chart_gfx11.format_bw_human_readable(value, "Bytes/s", 2)
+            == "123.46 GB/s"
+        )
+        assert (
+            mem_chart_gfx11.format_bw_human_readable(value, "Bytes/s", 3)
+            == "123.457 GB/s"
+        )
+
+
+# =============================================================================
+# Tests for format_value function
+# =============================================================================
+
+
+class TestFormatValue:
+    """Tests for format_value - general value formatting."""
+
+    def test_percentage_formatting(self):
+        """Test percentage formatting."""
+        result = mem_chart_gfx11.format_value(85.5, "%", 1)
+        assert result == "85.5%"
+
+        result = mem_chart_gfx11.format_value(100, "%", 0)
+        assert result == "100%"
+
+    def test_bytes_per_second_unit(self):
+        """Test Bytes/s formatting routes to human-readable."""
+        result = mem_chart_gfx11.format_value(100e9, "Bytes/s", 1)
+        assert "GB/s" in result
+
+    def test_gbps_unit(self):
+        """Test GB/s formatting routes to human-readable."""
+        result = mem_chart_gfx11.format_value(100, "GB/s", 1)
+        assert "GB/s" in result
+
+    def test_none_value(self):
+        """Test handling of None values."""
+        result = mem_chart_gfx11.format_value(None, "%", 1)
+        assert result == "N/A"
+
+    def test_string_value_conversion(self):
+        """Test conversion of string values to float."""
+        result = mem_chart_gfx11.format_value("50.5", "%", 1)
+        assert result == "50.5%"
+
+    def test_invalid_string_value(self):
+        """Test handling of non-convertible string values."""
+        result = mem_chart_gfx11.format_value("invalid", "%", 1)
+        assert result == "invalid"
+
+
+# =============================================================================
+# Tests for format_sci function
+# =============================================================================
+
+
+class TestFormatSci:
+    """Tests for format_sci - scientific notation formatting."""
+
+    def test_small_numbers_no_scientific(self):
+        """Test that small numbers are displayed as integers."""
+        assert mem_chart_gfx11.format_sci(100) == "100"
+        assert mem_chart_gfx11.format_sci(999) == "999"
+
+    def test_large_numbers_scientific(self):
+        """Test that large numbers are displayed in scientific notation."""
+        result = mem_chart_gfx11.format_sci(1000000)
+        assert "e" in result.lower()
+
+        result = mem_chart_gfx11.format_sci(12345678, 2)
+        assert "e" in result.lower()
+
+    def test_none_value(self):
+        """Test handling of None values."""
+        result = mem_chart_gfx11.format_sci(None)
+        assert result == "N/A"
+
+    def test_invalid_value(self):
+        """Test handling of invalid values."""
+        result = mem_chart_gfx11.format_sci("invalid")
+        assert result == "N/A"
+
+    def test_negative_numbers(self):
+        """Test negative number handling."""
+        result = mem_chart_gfx11.format_sci(-500)
+        assert result == "-500"
+
+        result = mem_chart_gfx11.format_sci(-1000000)
+        assert "e" in result.lower()
+
+
+# =============================================================================
+# Tests for bar function
+# =============================================================================
+
+
+class TestBar:
+    """Tests for bar - progress bar visualization."""
+
+    def test_full_bar(self):
+        """Test 100% progress bar."""
+        result = mem_chart_gfx11.bar(100, 10)
+        assert "█" * 10 in result
+        assert "░" not in result
+
+    def test_empty_bar(self):
+        """Test 0% progress bar."""
+        result = mem_chart_gfx11.bar(0, 10)
+        assert "░" * 10 in result
+        assert "█" not in result
+
+    def test_partial_bar(self):
+        """Test 50% progress bar."""
+        result = mem_chart_gfx11.bar(50, 10)
+        assert "█" * 5 in result
+        assert "░" * 5 in result
+
+    def test_none_value(self):
+        """Test None value returns empty bar."""
+        result = mem_chart_gfx11.bar(None, 10)
+        assert "░" * 10 in result
+
+    def test_invalid_value(self):
+        """Test invalid value returns empty bar."""
+        result = mem_chart_gfx11.bar("invalid", 10)
+        assert "░" * 10 in result
+
+    def test_over_100_clamped(self):
+        """Test values over 100% are clamped."""
+        result = mem_chart_gfx11.bar(150, 10)
+        assert "█" * 10 in result
+
+    def test_negative_clamped(self):
+        """Test negative values are clamped to 0."""
+        result = mem_chart_gfx11.bar(-50, 10)
+        assert "░" * 10 in result
+
+
+# =============================================================================
+# Tests for metric_line function
+# =============================================================================
+
+
+class TestMetricLine:
+    """Tests for metric_line - formatted metric display."""
+
+    def test_basic_metric(self):
+        """Test basic metric line formatting."""
+        result = mem_chart_gfx11.metric_line("Util", 75.5, "%", "green")
+        assert "Util" in result
+        assert "75.5%" in result
+        assert "green" in result
+
+    def test_with_none_value(self):
+        """Test metric line with None value."""
+        result = mem_chart_gfx11.metric_line("BW", None, "GB/s", "cyan")
+        assert "BW" in result
+        assert "N/A" in result
+
+
+# =============================================================================
+# Tests for get_sample_metrics function
+# =============================================================================
+
+
+class TestGetSampleMetrics:
+    """Tests for get_sample_metrics - returns sample test data."""
+
+    def test_returns_dict(self):
+        """Test that sample metrics returns a dictionary."""
+        metrics = mem_chart_gfx11.get_sample_metrics()
+        assert isinstance(metrics, dict)
+
+    def test_contains_key_metrics(self):
+        """Test that sample metrics contains expected keys."""
+        metrics = mem_chart_gfx11.get_sample_metrics()
+
+        # Check for key bandwidth metrics
+        assert "TCP-GL1 Read Bandwidth" in metrics
+        assert "GL1-GL2 Read Bandwidth" in metrics
+        assert "GL2C Read Bandwidth" in metrics
+        assert "DRAM Read Bandwidth" in metrics
+
+        # Check for utilization metrics
+        assert "GL1C Utilization" in metrics
+        assert "GL2C Utilization" in metrics
+
+        # Check for hit rate metrics
+        assert "TCP Hit Rate" in metrics
+        assert "GL1C Hit Rate" in metrics
+        assert "GL2C Hit Rate" in metrics
+
+    def test_bandwidth_values_in_bytes_per_second(self):
+        """Test that bandwidth values are in Bytes/s format."""
+        metrics = mem_chart_gfx11.get_sample_metrics()
+
+        # TCP-GL1 Read Bandwidth should be 96 GB/s = 96e9 Bytes/s
+        assert metrics["TCP-GL1 Read Bandwidth"] == 96e9
+
+        # DRAM Read Bandwidth should be 100 GB/s = 100e9 Bytes/s
+        assert metrics["DRAM Read Bandwidth"] == 100e9
+
+    def test_returns_copy(self):
+        """Test that sample metrics returns a copy (not the original)."""
+        metrics1 = mem_chart_gfx11.get_sample_metrics()
+        metrics2 = mem_chart_gfx11.get_sample_metrics()
+
+        # Modify metrics1 and verify metrics2 is not affected
+        metrics1["TCP-GL1 Read Bandwidth"] = 0
+        assert metrics2["TCP-GL1 Read Bandwidth"] == 96e9
+
+
+# =============================================================================
+# Tests for plot_mem_chart function
+# =============================================================================
+
+
+class TestPlotMemChart:
+    """Tests for plot_mem_chart - main chart generation."""
+
+    def test_returns_string(self):
+        """Test that plot_mem_chart returns a string."""
+        metrics = mem_chart_gfx11.get_sample_metrics()
+        result = mem_chart_gfx11.plot_mem_chart("gfx1151", "per_kernel", metrics)
+        clean = strip_ansi(result)
+
+        assert isinstance(result, str)
+        assert len(result) > 0
+        assert "3. Memory Chart" in clean
+        assert "Normalization: per_kernel" in clean
+        assert "GPU" in clean and "System Memory" in clean
+
+    def test_chart_title_override(self):
+        """Explicit chart_title appears in output."""
+        metrics = mem_chart_gfx11.get_sample_metrics()
+        result = mem_chart_gfx11.plot_mem_chart(
+            "gfx1151",
+            "per_kernel",
+            metrics,
+            chart_title="3. Memory Chart (Normalization: per_kernel)",
+        )
+        assert "3. Memory Chart (Normalization: per_kernel)" in strip_ansi(result)
+
+    def test_contains_architecture_elements(self):
+        """Test that output contains RDNA3.5 architecture elements."""
+        metrics = mem_chart_gfx11.get_sample_metrics()
+        result = mem_chart_gfx11.plot_mem_chart("gfx1151", "per_kernel", metrics)
+
+        # Check for key components
+        assert "TCP" in result or "L0" in result  # L0 cache
+        assert "GL1C" in result  # L1 cache
+        assert "GL2C" in result  # L2 cache
+        assert (
+            "GCEA" in result
+        )  # Graphics Core Efficiency Arbiter (block label in diagram)
+        assert "DRAM" in result  # System memory
+
+    def test_contains_bandwidth_values(self):
+        """Test that output contains formatted bandwidth values."""
+        metrics = mem_chart_gfx11.get_sample_metrics()
+        result = mem_chart_gfx11.plot_mem_chart("gfx1151", "per_kernel", metrics)
+
+        # Should contain GB/s units since sample data uses GB/s range
+        assert "GB/s" in result
+
+    def test_normalize_mem_chart_metrics_flat_ordered(self):
+        """Metrics are flattened to panel YAML order; extras dropped; missing None."""
+        raw = {"TCP Hit Rate": 1.0, "noise_key": 99}
+        norm = mem_chart_gfx11.normalize_mem_chart_metrics(raw)
+        assert list(norm.keys()) == list(mem_chart_gfx11.MEM_CHART_PANEL_METRIC_KEYS)
+        assert norm["TCP Hit Rate"] == 1.0
+        assert "noise_key" not in norm
+        assert norm["ICache Requests"] is None
+
+    def test_empty_metrics(self):
+        """Test with empty metrics dictionary."""
+        result = mem_chart_gfx11.plot_mem_chart("gfx1151", "per_kernel", {})
+
+        # Should still produce output (with N/A values)
+        assert isinstance(result, str)
+        assert len(result) > 0
+
+    def test_partial_metrics(self):
+        """Test with partial metrics (some missing)."""
+        partial_metrics = {
+            "TCP-GL1 Read Bandwidth": 50e9,
+            "GL1C Utilization": 65.0,
+            # Missing many other metrics
+        }
+        result = mem_chart_gfx11.plot_mem_chart(
+            "gfx1151", "per_kernel", partial_metrics
+        )
+
+        assert isinstance(result, str)
+        assert len(result) > 0
+
+    def test_extreme_bandwidth_values(self):
+        """Test with extreme bandwidth values."""
+        extreme_metrics = {
+            "DRAM Read Bandwidth": 10e12,  # 10 TB/s
+            "DRAM Write Bandwidth": 5e12,  # 5 TB/s
+        }
+        result = mem_chart_gfx11.plot_mem_chart(
+            "gfx1151", "per_kernel", extreme_metrics
+        )
+
+        assert "TB/s" in result
+
+    def test_zero_bandwidth_values(self):
+        """Test with zero bandwidth values."""
+        zero_metrics = {
+            "DRAM Read Bandwidth": 0,
+            "DRAM Write Bandwidth": 0,
+        }
+        result = mem_chart_gfx11.plot_mem_chart("gfx1151", "per_kernel", zero_metrics)
+
+        assert "B/s" in result  # Zero formats as "0.0 B/s"
+
+
+# =============================================================================
+# Tests for DEFAULT_SAMPLE_METRICS constant
+# =============================================================================
+
+
+class TestDefaultSampleMetrics:
+    """Tests for DEFAULT_SAMPLE_METRICS constant."""
+
+    def test_keys_match_mem_chart_panel_yaml(self):
+        """Keys match gfx1151 Memory Chart YAML (MEM_CHART_PANEL_METRIC_KEYS)."""
+        assert set(mem_chart_gfx11.DEFAULT_SAMPLE_METRICS) == set(
+            mem_chart_gfx11.MEM_CHART_PANEL_METRIC_KEYS
+        )
+        assert len(mem_chart_gfx11.DEFAULT_SAMPLE_METRICS) == len(
+            mem_chart_gfx11.MEM_CHART_PANEL_METRIC_KEYS
+        )
+
+    def test_all_bandwidth_values_positive(self):
+        """Test that all bandwidth values are positive."""
+        for key, value in mem_chart_gfx11.DEFAULT_SAMPLE_METRICS.items():
+            if "Bandwidth" in key:
+                assert value >= 0, f"{key} should be non-negative"
+
+    def test_all_rate_values_in_range(self):
+        """Test that rate/percentage values are in valid range."""
+        for key, value in mem_chart_gfx11.DEFAULT_SAMPLE_METRICS.items():
+            if "Rate" in key or "Utilization" in key:
+                assert 0 <= value <= 100, f"{key} should be between 0 and 100"
+
+    def test_has_all_memory_hierarchy_levels(self):
+        """Test that all memory hierarchy levels are represented."""
+        metrics = mem_chart_gfx11.DEFAULT_SAMPLE_METRICS
+
+        # TCP (L0)
+        assert any("TCP" in k for k in metrics.keys())
+
+        # LDS
+        assert any("LDS" in k for k in metrics.keys())
+
+        # GL1C
+        assert any("GL1" in k for k in metrics.keys())
+
+        # GL2C
+        assert any("GL2" in k for k in metrics.keys())
+
+        # DRAM
+        assert any("DRAM" in k for k in metrics.keys())
+
+
+# =============================================================================
+# Integration Tests
+# =============================================================================
+
+
+class TestIntegration:
+    """Integration tests for complete workflows."""
+
+    def test_full_workflow_with_sample_data(self):
+        """Test complete workflow with sample data."""
+        # Get sample metrics
+        metrics = mem_chart_gfx11.get_sample_metrics()
+
+        # Generate chart
+        chart = mem_chart_gfx11.plot_mem_chart("gfx1151", "per_dispatch", metrics)
+
+        # Verify chart contains expected elements
+        assert isinstance(chart, str)
+        assert len(chart) > 100  # Should be substantial output
+        assert "Kernel" in chart
+        assert "Legend" in chart
+
+    def test_bandwidth_unit_consistency(self):
+        """Test that bandwidth units are consistently formatted."""
+        # Create metrics with known bandwidth values
+        metrics = {
+            "TCP-GL1 Read Bandwidth": 100e9,  # 100 GB/s
+            "TCP-GL1 Write Bandwidth": 50e9,  # 50 GB/s
+            "GL1-GL2 Read Bandwidth": 75e9,  # 75 GB/s
+            "GL1-GL2 Write Bandwidth": 25e9,  # 25 GB/s
+            "DRAM Read Bandwidth": 200e9,  # 200 GB/s
+            "DRAM Write Bandwidth": 100e9,  # 100 GB/s
+        }
+
+        chart = mem_chart_gfx11.plot_mem_chart("gfx1151", "per_kernel", metrics)
+
+        # All values should show in GB/s since they're in that range
+        assert chart.count("GB/s") >= 6
+
+    def test_mixed_bandwidth_scales(self):
+        """Test chart with mixed bandwidth scales."""
+        metrics = {
+            "DRAM Read Bandwidth": 1.5e12,  # 1.5 TB/s
+            "GL2C Read Bandwidth": 500e9,  # 500 GB/s
+            "GL1-GL2 Read Bandwidth": 100e6,  # 100 MB/s
+            "TCP-GL1 Read Bandwidth": 50e3,  # 50 KB/s
+        }
+
+        chart = mem_chart_gfx11.plot_mem_chart("gfx1151", "per_kernel", metrics)
+
+        # Should contain multiple unit types
+        assert "TB/s" in chart
+        assert "GB/s" in chart

--- a/projects/rocprofiler-compute/tests/test_pc_sampling.py
+++ b/projects/rocprofiler-compute/tests/test_pc_sampling.py
@@ -48,12 +48,20 @@ def is_pc_sampling_not_supported(output):
     return "Given PC sampling configuration is not supported" in output
 
 
+def skip_unsupported_pc_sampling_soc(is_stochastic=False):
+    unsupported_socs = {"MI100", "STRIX_HALO"}
+    if is_stochastic:
+        unsupported_socs.add("MI200")
+
+    if soc in unsupported_socs:
+        pytest.skip(f"PC sampling is not supported on {soc}")
+
+
 def test_pc_sampling_host_trap(binary_handler_profile_rocprof_compute):
     """
     Test that PC sampling works with --block 21 and --pc-sampling-method host_trap.
     """
-    if soc == "MI100":
-        pytest.skip("PC sampling is not supported on MI 100")
+    skip_unsupported_pc_sampling_soc()
 
     options = [
         "--block",
@@ -85,8 +93,7 @@ def test_pc_sampling_stochastic(binary_handler_profile_rocprof_compute):
     """
     Test that PC sampling works with --block 21 and --pc-sampling-method stochastic.
     """
-    if soc == "MI100" or soc == "MI200":
-        pytest.skip("PC sampling is not supported")
+    skip_unsupported_pc_sampling_soc(is_stochastic=True)
 
     options = [
         "--block",
@@ -128,8 +135,7 @@ def test_multi_rank_pc_sampling_only(
     Test that no multi-rank warning is printed when running with only
     --block 21 (PC sampling only mode requires a single pass) with multi-rank.
     """
-    if soc == "MI100":
-        pytest.skip("PC sampling is not supported on MI 100")
+    skip_unsupported_pc_sampling_soc()
 
     monkeypatch.setenv("OMPI_COMM_WORLD_RANK", "0")
 
@@ -167,8 +173,7 @@ def test_multi_rank_warning_pc_sampling_with_counters(
     and another block (PC sampling with counters mode requires multiple passes)
     with multi-rank.
     """
-    if soc == "MI100":
-        pytest.skip("PC sampling is not supported on MI 100")
+    skip_unsupported_pc_sampling_soc()
 
     monkeypatch.setenv("OMPI_COMM_WORLD_RANK", "0")
 
@@ -212,8 +217,7 @@ def test_pc_sampling_profile_then_analyze(
     End-to-end: profile with PC sampling (host_trap), then
     run analysis on the profiling output.
     """
-    if soc == "MI100":
-        pytest.skip("PC sampling is not supported on MI 100")
+    skip_unsupported_pc_sampling_soc()
 
     options = [
         "--block",
@@ -295,8 +299,7 @@ def test_pc_sampling_with_sol_block(binary_handler_profile_rocprof_compute):
     Test that PC sampling works with --block 21 and --block 2
     (PC sampling with counter collection)
     """
-    if soc == "MI100":
-        pytest.skip("PC sampling is not supported on MI 100")
+    skip_unsupported_pc_sampling_soc()
 
     options = [
         "--block",

--- a/projects/rocprofiler-compute/tests/test_pc_sampling_analysis.py
+++ b/projects/rocprofiler-compute/tests/test_pc_sampling_analysis.py
@@ -810,17 +810,16 @@ def test_pc_sampling_analyze_list_stats(
     and verify exit code 0.
     """
     workload_dir = test_utils.setup_workload_dir(PC_SAMPLING_WORKLOAD)
-    assert True
-    return
-    code = binary_handler_analyze_rocprof_compute([
-        "analyze",
-        "--path",
-        workload_dir,
-        "--list-stats",
-    ])
-    assert code == 0
-    captured = capsys.readouterr()
-    assert "Detected Kernels" in captured.out
-    assert "Dispatch list" in captured.out
-
-    test_utils.clean_output_dir(True, workload_dir)
+    try:
+        code = binary_handler_analyze_rocprof_compute([
+            "analyze",
+            "--path",
+            workload_dir,
+            "--list-stats",
+        ])
+        assert code == 0
+        captured = capsys.readouterr()
+        assert "Detected Kernels" in captured.out
+        assert "Dispatch list" in captured.out
+    finally:
+        test_utils.clean_output_dir(True, workload_dir)

--- a/projects/rocprofiler-compute/tests/test_profile_general.py
+++ b/projects/rocprofiler-compute/tests/test_profile_general.py
@@ -155,6 +155,12 @@ RANK_ENV_VARS = [
 # check for parallel resource allocation
 test_utils.check_resource_allocation()
 
+# Get soc info
+soc = test_utils.gpu_soc()
+
+# Set default profiler
+os.environ["ROCPROF"] = "rocprofiler-sdk"
+
 
 def counter_compare(test_name, errors_pd, baseline_df, run_df, threshold=5):
     # iterate data one row at a time
@@ -216,21 +222,20 @@ def counter_compare(test_name, errors_pd, baseline_df, run_df, threshold=5):
     return errors_pd
 
 
-soc = test_utils.gpu_soc()
-
-os.environ["ROCPROF"] = "rocprofiler-sdk"
-
-Baseline_dir = str(Path("tests/workloads/vcopy/" + soc).resolve())
-
-
 def baseline_compare_metric(test_name, workload_dir, args=[]):
+    baseline_dir = (Path("tests/workloads/vcopy") / soc).resolve()
+    if not baseline_dir.exists():
+        pytest.skip(f"Skipping test since {baseline_dir} does not exist")
+
+    baseline_dir = str(baseline_dir)
+
     t = subprocess.Popen(
         [
             sys.executable,
             "src/rocprof_compute",
             "analyze",
             "--path",
-            Baseline_dir,
+            baseline_dir,
         ]
         + args
         + ["--path", workload_dir, "--report-diff", "-1"],
@@ -242,9 +247,9 @@ def baseline_compare_metric(test_name, workload_dir, args=[]):
 
     if "DEBUG ERROR" in captured_output:
         error_df = pd.DataFrame()
-        if Path(Baseline_dir + "/metric_error_log.csv").exists():
+        if Path(baseline_dir + "/metric_error_log.csv").exists():
             error_df = pd.read_csv(
-                Baseline_dir + "/metric_error_log.csv",
+                baseline_dir + "/metric_error_log.csv",
                 index_col=0,
             )
         output_metric_errors = re.findall(r"(\')([0-9.]*)(\')", captured_output)
@@ -352,7 +357,7 @@ def baseline_compare_metric(test_name, workload_dir, args=[]):
 
                         # log into csv
                         if not error_df.empty:
-                            error_df.to_csv(Baseline_dir + "/metric_error_log.csv")
+                            error_df.to_csv(baseline_dir + "/metric_error_log.csv")
 
 
 def validate(test_name, workload_dir, file_dict, args=[]):
@@ -561,6 +566,15 @@ def clear_rank_env(monkeypatch):
         monkeypatch.delenv(key, raising=False)
 
 
+def skip_unsupported_roofline_soc():
+    if soc in {"MI100", "STRIX_HALO"}:
+        pytest.skip(f"Roofline is not supported on {soc}")
+
+
+def is_strix_halo_soc():
+    return soc == "STRIX_HALO"
+
+
 # --
 # Start of profiling tests
 # --
@@ -573,17 +587,7 @@ def test_path(binary_handler_profile_rocprof_compute):
 
     file_dict = test_utils.check_csv_files(workload_dir, num_devices, num_kernels)
 
-    if soc == "MI100":
-        assert sorted(list(file_dict.keys())) == CSVS
-    elif soc == "MI200":
-        assert sorted(list(file_dict.keys())) == CSVS
-    elif "MI300" in soc:
-        assert sorted(list(file_dict.keys())) == CSVS
-    elif "MI350" in soc:
-        assert sorted(list(file_dict.keys())) == CSVS
-    else:
-        print(f"This test is not supported for {soc}")
-        assert 0
+    assert sorted(list(file_dict.keys())) == CSVS
 
     validate(inspect.stack()[0][3], workload_dir, file_dict)
 
@@ -615,17 +619,7 @@ def test_path_no_native(binary_handler_profile_rocprof_compute):
 
     file_dict = test_utils.check_csv_files(workload_dir, num_devices, num_kernels)
 
-    if soc == "MI100":
-        assert sorted(list(file_dict.keys())) == CSVS
-    elif soc == "MI200":
-        assert sorted(list(file_dict.keys())) == CSVS
-    elif "MI300" in soc:
-        assert sorted(list(file_dict.keys())) == CSVS
-    elif "MI350" in soc:
-        assert sorted(list(file_dict.keys())) == CSVS
-    else:
-        print(f"This test is not supported for {soc}")
-        assert 0
+    assert sorted(list(file_dict.keys())) == CSVS
 
     validate(inspect.stack()[0][3], workload_dir, file_dict)
 
@@ -665,30 +659,7 @@ def test_path_csv(
     binary_handler_profile_rocprof_compute(config, workload_dir, options)
 
     file_dict = test_utils.check_csv_files(workload_dir, num_devices, num_kernels)
-    all_csvs_mi100 = sorted([
-        "sysinfo.csv",
-    ])
-    all_csvs_mi200 = sorted([
-        "sysinfo.csv",
-    ])
-    all_csvs_mi300 = sorted([
-        "sysinfo.csv",
-    ])
-    all_csvs_mi350 = sorted([
-        "sysinfo.csv",
-    ])
-
-    if soc == "MI100":
-        assert sorted(list(file_dict.keys())) == all_csvs_mi100
-    elif soc == "MI200":
-        assert sorted(list(file_dict.keys())) == all_csvs_mi200
-    elif "MI300" in soc:
-        assert sorted(list(file_dict.keys())) == all_csvs_mi300
-    elif "MI350" in soc:
-        assert sorted(list(file_dict.keys())) == all_csvs_mi350
-    else:
-        print(f"This test is not supported for {soc}")
-        assert 0
+    assert sorted(list(file_dict.keys())) == sorted(["sysinfo.csv"])
 
     validate(inspect.stack()[0][3], workload_dir, file_dict)
 
@@ -1011,11 +982,7 @@ def test_roof_basic_validation(binary_handler_profile_rocprof_compute):
     Test basic roofline CSV generation in profile mode.
     Validates that roofline.csv is generated via microbenchmarks.
     """
-    if soc in ("MI100"):
-        # roofline is not supported on MI100
-        assert True
-        # Do not continue testing
-        return
+    skip_unsupported_roofline_soc()
 
     options = ["--device", "0", "--roof-only"]
     workload_dir = test_utils.get_output_dir()
@@ -1040,9 +1007,7 @@ def test_roof_basic_validation(binary_handler_profile_rocprof_compute):
 @pytest.mark.roofline_1
 def test_roof_file_validation(binary_handler_profile_rocprof_compute):
     """Test file validation paths in roofline"""
-    if soc in ("MI100"):
-        pytest.skip("Roofline not supported on MI100")
-        return
+    skip_unsupported_roofline_soc()
 
     options = ["--device", "0", "--roof-only"]
     workload_dir = test_utils.get_output_dir()
@@ -1069,9 +1034,7 @@ def test_roof_rocpd(
     binary_handler_profile_rocprof_compute,
     binary_handler_analyze_rocprof_compute,
 ):
-    if soc == "MI100":
-        pytest.skip("Roofline not supported on MI100")
-        return
+    skip_unsupported_roofline_soc()
 
     workload_dir = test_utils.get_output_dir()
     options = ["--device", "0", "--roof-only", "--format-rocprof-output", "rocpd"]
@@ -1098,6 +1061,8 @@ def test_roof_rocpd(
 def test_analyze_rocpd(
     binary_handler_profile_rocprof_compute, binary_handler_analyze_rocprof_compute
 ):
+    skip_unsupported_roofline_soc()
+
     workload_dir = test_utils.get_output_dir()
     options = ["--device", "0", "--format-rocprof-output", "rocpd"]
     binary_handler_profile_rocprof_compute(config, workload_dir, options, roof=True)
@@ -1165,9 +1130,7 @@ def test_roofline_workload_dir_not_set_error():
     Test roof_setup() error: "Workload directory is not set. Cannot perform setup."
     This covers lines 113-117
     """
-    if soc in ("MI100"):
-        pytest.skip("Skipping roofline test for MI100")
-        return
+    skip_unsupported_roofline_soc()
 
     import sys
     from pathlib import Path
@@ -1218,9 +1181,7 @@ def test_roofline_workload_dir_not_set_error():
 
 @pytest.mark.roofline_1
 def test_roof_workload_dir_validation(binary_handler_profile_rocprof_compute):
-    if soc in ("MI100"):
-        assert True
-        return
+    skip_unsupported_roofline_soc()
 
     options = ["--device", "0", "--roof-only"]
 
@@ -1253,9 +1214,7 @@ def test_roofline_kernel_filter(binary_handler_profile_rocprof_compute):
     - one valid kernel
     - 2 kernels, one valid and one invalid
     """
-    if soc in ("MI100"):
-        pytest.skip("Skipping roofline test for MI100")
-        return
+    skip_unsupported_roofline_soc()
 
     options = [
         "--device",
@@ -1314,9 +1273,7 @@ def test_roofline_kernel_filter(binary_handler_profile_rocprof_compute):
 
 @pytest.mark.roofline_2
 def test_roof_cli_plot_generation(binary_handler_profile_rocprof_compute):
-    if soc in ("MI100"):
-        assert True
-        return
+    skip_unsupported_roofline_soc()
 
     try:
         import plotext as plt  # noqa: F401
@@ -1340,9 +1297,7 @@ def test_roof_cli_plot_generation(binary_handler_profile_rocprof_compute):
 
 @pytest.mark.roofline_2
 def test_roof_error_handling(binary_handler_profile_rocprof_compute):
-    if soc in ("MI100"):
-        assert True
-        return
+    skip_unsupported_roofline_soc()
 
     options = ["--device", "0", "--roof-only"]
     workload_dir = test_utils.get_output_dir()
@@ -1364,9 +1319,7 @@ def test_roofline_plot_points_data_generation():
     - Memory/Compute bound status
     - Cache level information
     """
-    if soc in ("MI100"):
-        pytest.skip("Skipping roofline test for MI100")
-        return
+    skip_unsupported_roofline_soc()
 
     sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
 
@@ -1468,9 +1421,7 @@ def test_roofline_bound_status_calculation():
     Test _determine_kernel_bound_status() correctly classifies kernels as
     Memory Bound or Compute Bound based on their AI and performance vs ceilings.
     """
-    if soc in ("MI100"):
-        pytest.skip("Skipping roofline test for MI100")
-        return
+    skip_unsupported_roofline_soc()
 
     sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
 
@@ -1547,9 +1498,7 @@ def test_roofline_many_kernels_dynamic_height(binary_handler_profile_rocprof_com
     """
     Test roofline CSV generation with many kernels.
     """
-    if soc in ("MI100"):
-        pytest.skip("Skipping roofline test for MI100")
-        return
+    skip_unsupported_roofline_soc()
 
     options = ["--device", "0", "--roof-only"]
     workload_dir = test_utils.get_output_dir()
@@ -1575,17 +1524,7 @@ def test_device_filter(binary_handler_profile_rocprof_compute):
     binary_handler_profile_rocprof_compute(config, workload_dir, options)
 
     file_dict = test_utils.check_csv_files(workload_dir, 1, num_kernels)
-    if soc == "MI100":
-        assert sorted(list(file_dict.keys())) == CSVS
-    elif soc == "MI200":
-        assert sorted(list(file_dict.keys())) == CSVS
-    elif "MI300" in soc:
-        assert sorted(list(file_dict.keys())) == CSVS
-    elif "MI350" in soc:
-        assert sorted(list(file_dict.keys())) == CSVS
-    else:
-        print(f"Testing isn't supported yet for {soc}")
-        assert 0
+    assert sorted(list(file_dict.keys())) == CSVS
 
     # TODO - verify expected device id in results
 
@@ -1605,17 +1544,7 @@ def test_kernel(binary_handler_profile_rocprof_compute):
     binary_handler_profile_rocprof_compute(config, workload_dir, options)
 
     file_dict = test_utils.check_csv_files(workload_dir, num_devices, num_kernels)
-    if soc == "MI100":
-        assert sorted(list(file_dict.keys())) == CSVS
-    elif soc == "MI200":
-        assert sorted(list(file_dict.keys())) == CSVS
-    elif "MI300" in soc:
-        assert sorted(list(file_dict.keys())) == CSVS
-    elif "MI350" in soc:
-        assert sorted(list(file_dict.keys())) == CSVS
-    else:
-        print(f"Testing isn't supported yet for {soc}")
-        assert 0
+    assert sorted(list(file_dict.keys())) == CSVS
 
     validate(
         inspect.stack()[0][3],
@@ -1633,17 +1562,7 @@ def test_dispatch_0(binary_handler_profile_rocprof_compute):
     binary_handler_profile_rocprof_compute(config, workload_dir, options)
 
     file_dict = test_utils.check_csv_files(workload_dir, num_devices, 1)
-    if soc == "MI100":
-        assert sorted(list(file_dict.keys())) == CSVS
-    elif soc == "MI200":
-        assert sorted(list(file_dict.keys())) == CSVS
-    elif "MI300" in soc:
-        assert sorted(list(file_dict.keys())) == CSVS
-    elif "MI350" in soc:
-        assert sorted(list(file_dict.keys())) == CSVS
-    else:
-        print(f"Testing isn't supported yet for {soc}")
-        assert 0
+    assert sorted(list(file_dict.keys())) == CSVS
 
     validate(
         inspect.stack()[0][3],
@@ -1665,17 +1584,7 @@ def test_dispatch_0_1(binary_handler_profile_rocprof_compute):
     binary_handler_profile_rocprof_compute(config, workload_dir, options)
 
     file_dict = test_utils.check_csv_files(workload_dir, num_devices, 2)
-    if soc == "MI100":
-        assert sorted(list(file_dict.keys())) == CSVS
-    elif soc == "MI200":
-        assert sorted(list(file_dict.keys())) == CSVS
-    elif "MI300" in soc:
-        assert sorted(list(file_dict.keys())) == CSVS
-    elif "MI350" in soc:
-        assert sorted(list(file_dict.keys())) == CSVS
-    else:
-        print(f"Testing isn't supported yet for {soc}")
-        assert 0
+    assert sorted(list(file_dict.keys())) == CSVS
 
     validate(
         inspect.stack()[0][3],
@@ -1694,17 +1603,7 @@ def test_dispatch_2(binary_handler_profile_rocprof_compute):
     binary_handler_profile_rocprof_compute(config, workload_dir, options)
 
     file_dict = test_utils.check_csv_files(workload_dir, num_devices, 1)
-    if soc == "MI100":
-        assert sorted(list(file_dict.keys())) == CSVS
-    elif soc == "MI200":
-        assert sorted(list(file_dict.keys())) == CSVS
-    elif "MI300" in soc:
-        assert sorted(list(file_dict.keys())) == CSVS
-    elif "MI350" in soc:
-        assert sorted(list(file_dict.keys())) == CSVS
-    else:
-        print(f"Testing isn't supported yet for {soc}")
-        assert 0
+    assert sorted(list(file_dict.keys())) == CSVS
 
     validate(
         inspect.stack()[0][3],
@@ -1726,17 +1625,7 @@ def test_join_type_grid(binary_handler_profile_rocprof_compute):
     binary_handler_profile_rocprof_compute(config, workload_dir, options)
 
     file_dict = test_utils.check_csv_files(workload_dir, num_devices, num_kernels)
-    if soc == "MI100":
-        assert sorted(list(file_dict.keys())) == CSVS
-    elif soc == "MI200":
-        assert sorted(list(file_dict.keys())) == CSVS
-    elif "MI300" in soc:
-        assert sorted(list(file_dict.keys())) == CSVS
-    elif "MI350" in soc:
-        assert sorted(list(file_dict.keys())) == CSVS
-    else:
-        print(f"Testing isn't supported yet for {soc}")
-        assert 0
+    assert sorted(list(file_dict.keys())) == CSVS
 
     validate(
         inspect.stack()[0][3],
@@ -1755,17 +1644,7 @@ def test_join_type_kernel(binary_handler_profile_rocprof_compute):
 
     file_dict = test_utils.check_csv_files(workload_dir, num_devices, num_kernels)
 
-    if soc == "MI100":
-        assert sorted(list(file_dict.keys())) == CSVS
-    elif soc == "MI200":
-        assert sorted(list(file_dict.keys())) == CSVS
-    elif "MI300" in soc:
-        assert sorted(list(file_dict.keys())) == CSVS
-    elif "MI350" in soc:
-        assert sorted(list(file_dict.keys())) == CSVS
-    else:
-        print(f"Testing isn't supported yet for {soc}")
-        assert 0
+    assert sorted(list(file_dict.keys())) == CSVS
 
     validate(
         inspect.stack()[0][3],
@@ -1782,8 +1661,7 @@ def test_roof_sort_dispatches(
     binary_handler_analyze_rocprof_compute,
 ):
     """Profile creates CSV; analyze with --sort dispatches generates output."""
-    if soc in ("MI100"):
-        pytest.skip("Roofline not supported on MI100")
+    skip_unsupported_roofline_soc()
 
     profile_options = ["--device", "0", "--roof-only"]
     workload_dir = test_utils.get_output_dir()
@@ -1817,8 +1695,7 @@ def test_roof_sort_kernels(
     binary_handler_analyze_rocprof_compute,
 ):
     """Profile creates CSV; analyze with --sort kernels generates output."""
-    if soc in ("MI100"):
-        pytest.skip("Roofline not supported on MI100")
+    skip_unsupported_roofline_soc()
 
     profile_options = ["--device", "0", "--roof-only"]
     workload_dir = test_utils.get_output_dir()
@@ -1848,7 +1725,8 @@ def test_roof_sort_kernels(
 
 @pytest.mark.section
 def test_lds_section(binary_handler_profile_rocprof_compute):
-    options = ["--block", "12"]
+    lds_block = "3" if is_strix_halo_soc() else "12"
+    options = ["--block", lds_block]
     workload_dir = test_utils.get_output_dir()
     _ = binary_handler_profile_rocprof_compute(
         config, workload_dir, options, check_success=True, roof=False
@@ -1862,7 +1740,7 @@ def test_lds_section(binary_handler_profile_rocprof_compute):
     )
 
     assert test_utils.check_file_pattern(
-        "- '12'", f"{workload_dir}/profiling_config.yaml"
+        f"- '{lds_block}'", f"{workload_dir}/profiling_config.yaml"
     )
     results_files = Path(workload_dir).glob("results_*.csv")
     assert any(
@@ -1873,7 +1751,8 @@ def test_lds_section(binary_handler_profile_rocprof_compute):
 
 @pytest.mark.section
 def test_instmix_memchart_section(binary_handler_profile_rocprof_compute):
-    options = ["--block", "10", "3"]
+    instmix_block = "7" if is_strix_halo_soc() else "10"
+    options = ["--block", instmix_block, "3"]
     workload_dir = test_utils.get_output_dir()
     _ = binary_handler_profile_rocprof_compute(
         config, workload_dir, options, check_success=True, roof=False
@@ -1887,15 +1766,15 @@ def test_instmix_memchart_section(binary_handler_profile_rocprof_compute):
     )
 
     assert test_utils.check_file_pattern(
-        "- '10'", f"{workload_dir}/profiling_config.yaml"
+        f"- '{instmix_block}'", f"{workload_dir}/profiling_config.yaml"
     )
     assert test_utils.check_file_pattern(
         "- '3'", f"{workload_dir}/profiling_config.yaml"
     )
+    instmix_counter = "SQ_INSTS_FLAT" if is_strix_halo_soc() else "TA_FLAT_WAVEFRONTS"
     results_files = Path(workload_dir).glob("results_*.csv")
     assert any(
-        test_utils.check_file_pattern("TA_FLAT_WAVEFRONTS", str(f))
-        for f in results_files
+        test_utils.check_file_pattern(instmix_counter, str(f)) for f in results_files
     )
     results_files = Path(workload_dir).glob("results_*.csv")
     assert any(
@@ -1907,7 +1786,8 @@ def test_instmix_memchart_section(binary_handler_profile_rocprof_compute):
 
 @pytest.mark.section
 def test_lds_sol_section(binary_handler_profile_rocprof_compute):
-    options = ["--block", "12.1"]
+    lds_sol_block = "3" if is_strix_halo_soc() else "12.1"
+    options = ["--block", lds_sol_block]
     workload_dir = test_utils.get_output_dir()
     _ = binary_handler_profile_rocprof_compute(
         config, workload_dir, options, check_success=True, roof=False
@@ -1921,19 +1801,22 @@ def test_lds_sol_section(binary_handler_profile_rocprof_compute):
     )
 
     assert test_utils.check_file_pattern(
-        "- '12.1'", f"{workload_dir}/profiling_config.yaml"
+        f"- '{lds_sol_block}'", f"{workload_dir}/profiling_config.yaml"
+    )
+    lds_sol_counter = (
+        "SQC_LDS_IDX_ACTIVE" if is_strix_halo_soc() else "SQ_ACTIVE_INST_LDS"
     )
     results_files = Path(workload_dir).glob("results_*.csv")
     assert any(
-        test_utils.check_file_pattern("SQ_ACTIVE_INST_LDS", str(f))
-        for f in results_files
+        test_utils.check_file_pattern(lds_sol_counter, str(f)) for f in results_files
     )
     test_utils.clean_output_dir(config["cleanup"], workload_dir)
 
 
 @pytest.mark.section
 def test_instmix_section_global_write_kernel(binary_handler_profile_rocprof_compute):
-    options = ["-k", "global_write", "--block", "10"]
+    instmix_block = "7" if is_strix_halo_soc() else "10"
+    options = ["-k", "global_write", "--block", instmix_block]
     custom_config = dict(config)
     custom_config["kernel_name_1"] = "global_write"
     custom_config["app_1"] = ["./tests/vmem"]
@@ -1952,15 +1835,17 @@ def test_instmix_section_global_write_kernel(binary_handler_profile_rocprof_comp
     )
 
     assert test_utils.check_file_pattern(
-        "- '10'", f"{workload_dir}/profiling_config.yaml"
+        f"- '{instmix_block}'", f"{workload_dir}/profiling_config.yaml"
     )
     assert test_utils.check_file_pattern(
         "- global_write", f"{workload_dir}/profiling_config.yaml"
     )
+    kernel_counter = (
+        "SQ_INSTS_FLAT_STORE" if is_strix_halo_soc() else "TA_FLAT_WAVEFRONTS"
+    )
     results_files = Path(workload_dir).glob("results_*.csv")
     assert any(
-        test_utils.check_file_pattern("TA_FLAT_WAVEFRONTS", str(f))
-        for f in results_files
+        test_utils.check_file_pattern(kernel_counter, str(f)) for f in results_files
     )
     results_files = Path(workload_dir).glob("results_*.csv")
     assert any(
@@ -2382,17 +2267,7 @@ def test_iteration_multiplexing(binary_handler_profile_rocprof_compute):
     )
 
     file_dict = test_utils.check_csv_files(workload_dir, num_devices, num_kernels)
-    if soc == "MI100":
-        assert sorted(list(file_dict.keys())) == CSVS
-    elif soc == "MI200":
-        assert sorted(list(file_dict.keys())) == CSVS
-    elif "MI300" in soc:
-        assert sorted(list(file_dict.keys())) == CSVS
-    elif "MI350" in soc:
-        assert sorted(list(file_dict.keys())) == CSVS
-    else:
-        print(f"Testing isn't supported yet for {soc}")
-        assert 0
+    assert sorted(list(file_dict.keys())) == CSVS
 
     validate(
         inspect.stack()[0][3],
@@ -2412,17 +2287,7 @@ def test_iteration_multiplexing_kernel(binary_handler_profile_rocprof_compute):
     )
 
     file_dict = test_utils.check_csv_files(workload_dir, num_devices, num_kernels)
-    if soc == "MI100":
-        assert sorted(list(file_dict.keys())) == CSVS
-    elif soc == "MI200":
-        assert sorted(list(file_dict.keys())) == CSVS
-    elif "MI300" in soc:
-        assert sorted(list(file_dict.keys())) == CSVS
-    elif "MI350" in soc:
-        assert sorted(list(file_dict.keys())) == CSVS
-    else:
-        print(f"Testing isn't supported yet for {soc}")
-        assert 0
+    assert sorted(list(file_dict.keys())) == CSVS
 
     validate(
         inspect.stack()[0][3],
@@ -2444,17 +2309,7 @@ def test_iteration_multiplexing_kernel_launch_params(
     )
 
     file_dict = test_utils.check_csv_files(workload_dir, num_devices, num_kernels)
-    if soc == "MI100":
-        assert sorted(list(file_dict.keys())) == CSVS
-    elif soc == "MI200":
-        assert sorted(list(file_dict.keys())) == CSVS
-    elif "MI300" in soc:
-        assert sorted(list(file_dict.keys())) == CSVS
-    elif "MI350" in soc:
-        assert sorted(list(file_dict.keys())) == CSVS
-    else:
-        print(f"Testing isn't supported yet for {soc}")
-        assert 0
+    assert sorted(list(file_dict.keys())) == CSVS
 
     validate(
         inspect.stack()[0][3],
@@ -2473,6 +2328,8 @@ def test_iteration_multiplexing_deterministic_counter_accuracy(
     binary_handler_profile_rocprof_compute,
     binary_handler_analyze_rocprof_compute,
 ):
+    skip_unsupported_roofline_soc()
+
     # These metrics should cover the deterministic counters being checked
     # Block 4 (roofline) included to verify roofline counters under multiplexing
     options = ["--block", "4", "6.1.5", "6.1.6", "7.2.2", "10.1"]
@@ -2541,11 +2398,9 @@ def test_iteration_multiplexing_deterministic_counter_accuracy(
         [counters_kernel, counters_kernel_launch_params], counters_no_multiplexing
     )
 
-    # Roofline assertions (MI100 doesn't support roofline)
-    if soc not in ("MI100"):
-        assert os.path.exists(f"{workload_dir_klp}/roofline.csv")
-        roofline_df = pd.read_csv(f"{workload_dir_klp}/roofline.csv")
-        assert len(roofline_df) >= num_devices
+    assert os.path.exists(f"{workload_dir_klp}/roofline.csv")
+    roofline_df = pd.read_csv(f"{workload_dir_klp}/roofline.csv")
+    assert len(roofline_df) >= num_devices
 
     test_utils.clean_output_dir(config["cleanup"], workload_dir_klp)
 
@@ -2555,6 +2410,8 @@ def test_iteration_multiplexing_stochastic_counter_accuracy(
     binary_handler_profile_rocprof_compute,
     binary_handler_analyze_rocprof_compute,
 ):
+    skip_unsupported_roofline_soc()
+
     workload_dir = test_utils.get_output_dir(param_id="no_iter_mplx")
     # These metrics should cover the L1 cache stochastic counters
     # Block 4 (roofline) included to verify roofline counters under multiplexing
@@ -2619,11 +2476,9 @@ def test_iteration_multiplexing_stochastic_counter_accuracy(
         [counters_kernel, counters_kernel_launch_params], counters_no_multiplexing
     )
 
-    # Roofline assertions (MI100 doesn't support roofline)
-    if soc not in ("MI100"):
-        assert os.path.exists(f"{workload_dir_klp}/roofline.csv")
-        roofline_df = pd.read_csv(f"{workload_dir_klp}/roofline.csv")
-        assert len(roofline_df) >= num_devices
+    assert os.path.exists(f"{workload_dir_klp}/roofline.csv")
+    roofline_df = pd.read_csv(f"{workload_dir_klp}/roofline.csv")
+    assert len(roofline_df) >= num_devices
 
     test_utils.clean_output_dir(config["cleanup"], workload_dir_klp)
 
@@ -2728,9 +2583,7 @@ def test_iteration_multiplexing_data_types(
     """Verify roofline analysis with different data types (FP32 and FP16)
     on iteration-multiplexed profiling data.
     """
-    if soc in ("MI100"):
-        pytest.skip("Roofline not supported on MI100")
-        return
+    skip_unsupported_roofline_soc()
 
     options = [
         "--block",

--- a/projects/rocprofiler-compute/tests/test_profile_general.py
+++ b/projects/rocprofiler-compute/tests/test_profile_general.py
@@ -2144,7 +2144,9 @@ class TestSetsIntegration:
 
         assert test_utils.get_num_pmc_file(workload_dir) == 1
 
-        memory_metrics = ["16.1.2", "17.1.0"]
+        memory_metrics = (
+            ["2.1.18", "17.1.0"] if is_strix_halo_soc() else ["16.1.2", "17.1.0"]
+        )
         for metric_id in memory_metrics:
             assert metric_id in open(Path(workload_dir) / "log.txt").read(), (
                 f"Expected memory metric {metric_id} not found"

--- a/projects/rocprofiler-compute/tests/test_soc_base.py
+++ b/projects/rocprofiler-compute/tests/test_soc_base.py
@@ -1,0 +1,290 @@
+# Copyright (c) Advanced Micro Devices, Inc.
+# SPDX-License-Identifier:  MIT
+
+"""
+Unit tests for counter allocation pipeline in soc_base.py.
+
+Tests LimitedSet, CounterFile, and the bin-packing helpers used by
+perfmon_coalesce — no GPU hardware required.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from rocprof_compute_soc.soc_base import (
+    CounterFile,
+    LimitedSet,
+    OmniSoC_Base,
+    _flat_counters_in_perfmon_file,
+    _rebuild_tcc_channel_file_map,
+    _trial_counter_file_with_extra,
+)
+
+# =============================================================================
+# Fixtures
+# =============================================================================
+
+PERFMON_CONFIG = {
+    "SQ": 8,
+    "TA": 2,
+    "TD": 2,
+    "TCP": 4,
+    "TCC": 4,
+    "CPC": 2,
+    "CPF": 2,
+    "SPI": 6,
+    "GRBM": 2,
+    "GDS": 4,
+}
+
+
+@pytest.fixture
+def perfmon_config():
+    return dict(PERFMON_CONFIG)
+
+
+@pytest.fixture
+def empty_counter_file(perfmon_config):
+    return CounterFile("0", perfmon_config)
+
+
+def _make_soc(perfmon_config, arch="gfx908", num_xcd=1, l2_banks=4):
+    """Build a minimal OmniSoC_Base without rocminfo or GPU access."""
+    mspec = MagicMock()
+    mspec.rocminfo_lines = None  # skip populate_mspec
+    mspec.num_xcd = num_xcd
+    mspec.l2_banks = l2_banks
+
+    args = MagicMock()
+    args.config_dir = "/dev/null"
+
+    with patch("rocprof_compute_soc.soc_base.console_debug"):
+        soc = OmniSoC_Base(args, mspec)
+
+    soc.set_arch(arch)
+    soc.set_perfmon_config(perfmon_config)
+    return soc
+
+
+# =============================================================================
+# A. LimitedSet
+# =============================================================================
+
+
+def test_limited_set_basic():
+    ls = LimitedSet(2)
+    assert ls.add("SQ_WAVES") is True
+    assert ls.add("SQ_BUSY") is True
+    assert ls.add("SQ_INSTS") is False  # capacity exhausted
+    assert ls.add("SQ_WAVES") is True  # duplicate ok
+    assert ls.avail == 0
+    assert ls.elements == ["SQ_WAVES", "SQ_BUSY"]
+
+
+def test_limited_set_tcc_channel_coalescing():
+    ls = LimitedSet(1)
+    assert ls.add("TCC_HIT[0]") is True
+    assert ls.avail == 0
+    # Same TCC base — bypasses capacity
+    assert ls.add("TCC_HIT[1]") is True
+    assert ls.add("TCC_HIT[2]") is True
+    # Different TCC base — rejected (no capacity left)
+    assert ls.add("TCC_MISS[0]") is False
+    assert len(ls.elements) == 3
+
+
+# =============================================================================
+# B. CounterFile
+# =============================================================================
+
+
+def test_counter_file_naming(perfmon_config):
+    cf = CounterFile("my_bucket", perfmon_config)
+    assert cf.file_name_txt == "pmc_perf_my_bucket.txt"
+    assert cf.pmc_filename == "pmc_perf_my_bucket.yaml"
+    assert cf.counter_def_filename == "counter_def_my_bucket.yaml"
+
+
+def test_counter_file_add_and_block_mapping(perfmon_config):
+    cf = CounterFile("0", perfmon_config)
+
+    # SQ, SQC, SP all map to the SQ block (capacity 8)
+    assert cf.add("SQ_WAVES") is True
+    assert cf.add("SQC_CACHE_HIT") is True
+    assert cf.add("SP_SOMETHING") is True
+    assert cf.blocks["SQ"].avail == 5  # 8 - 3
+
+    # TA maps to its own block (capacity 2)
+    assert cf.add("TA_ADDR") is True
+    assert cf.add("TA_DATA") is True
+    assert cf.add("TA_EXTRA") is False  # TA full
+
+    # TCP maps to its own block (capacity 4)
+    assert cf.add("TCP_READ") is True
+    assert cf.blocks["TCP"].avail == 3
+
+
+# =============================================================================
+# C. _flat_counters_in_perfmon_file
+# =============================================================================
+
+
+def test_flat_counters_in_perfmon_file(perfmon_config):
+    # Empty file returns empty list
+    cf = CounterFile("0", perfmon_config)
+    assert _flat_counters_in_perfmon_file(cf) == []
+
+    # Add counters across blocks and verify flattened order
+    cf.add("SQ_WAVES")
+    cf.add("TA_ADDR")
+    cf.add("TCP_READ")
+    result = _flat_counters_in_perfmon_file(cf)
+    assert "SQ_WAVES" in result
+    assert "TA_ADDR" in result
+    assert "TCP_READ" in result
+    assert len(result) == 3
+
+
+# =============================================================================
+# D. _trial_counter_file_with_extra
+# =============================================================================
+
+
+def test_trial_counter_file_with_extra_fits(perfmon_config):
+    basis = CounterFile("0", perfmon_config)
+    basis.add("SQ_WAVES")
+    basis.add("TA_ADDR")
+
+    extras = ["TCP_READ", "TCC_HIT[0]"]
+    trial = _trial_counter_file_with_extra(basis, perfmon_config, extras)
+    assert trial is not None
+    flat = _flat_counters_in_perfmon_file(trial)
+    assert set(flat) == {"SQ_WAVES", "TA_ADDR", "TCP_READ", "TCC_HIT[0]"}
+
+    # Original basis is unchanged
+    assert set(_flat_counters_in_perfmon_file(basis)) == {"SQ_WAVES", "TA_ADDR"}
+
+
+def test_trial_counter_file_with_extra_overflow(perfmon_config):
+    basis = CounterFile("0", perfmon_config)
+    # Fill TA to capacity (2)
+    basis.add("TA_ADDR")
+    basis.add("TA_DATA")
+
+    # Try adding a third TA counter — should fail
+    result = _trial_counter_file_with_extra(basis, perfmon_config, ["TA_EXTRA"])
+    assert result is None
+
+    # Basis still has only 2 TA counters
+    assert len(basis.blocks["TA"].elements) == 2
+
+
+# =============================================================================
+# E. _rebuild_tcc_channel_file_map
+# =============================================================================
+
+
+def test_rebuild_tcc_channel_file_map(perfmon_config):
+    bucket_a = CounterFile("a", perfmon_config)
+    bucket_a.add("TCC_HIT[0]")
+    bucket_a.add("TCC_HIT[1]")
+    bucket_a.add("SQ_WAVES")  # non-TCC, should be ignored
+
+    bucket_b = CounterFile("b", perfmon_config)
+    bucket_b.add("TCC_MISS[0]")
+
+    result = _rebuild_tcc_channel_file_map([bucket_a, bucket_b])
+    assert result["TCC_HIT"] is bucket_a
+    assert result["TCC_MISS"] is bucket_b
+    assert "SQ" not in result
+
+
+# =============================================================================
+# F. _allocate_perfmon_counter_files
+# =============================================================================
+
+
+def test_allocate_level_counters_get_dedicated_files(perfmon_config):
+    soc = _make_soc(perfmon_config)
+    counters = {"SQ_LEVEL_WAVES", "TCP_LEVEL_READ", "TA_ADDR"}
+
+    with patch.object(soc, "_same_bucket_priority_metric_ids", return_value=()):
+        files, file_count, accu_count = soc._allocate_perfmon_counter_files(counters)
+
+    # 2 LEVEL counters → 2 dedicated files with _ACCUM pairs
+    level_files = [f for f in files if "LEVEL" in f.file_name_txt]
+    assert len(level_files) == 2
+    assert accu_count == 2
+
+    for lf in level_files:
+        flat = set(_flat_counters_in_perfmon_file(lf))
+        # Each LEVEL file has the counter + its _ACCUM pair
+        assert any(n.endswith("_ACCUM") for n in flat)
+
+    # TA_ADDR placed somewhere (first-fit into a LEVEL file or its own)
+    all_ctrs = set()
+    for f in files:
+        all_ctrs.update(_flat_counters_in_perfmon_file(f))
+    assert "TA_ADDR" in all_ctrs
+
+
+def test_allocate_first_fit_packing(perfmon_config):
+    soc = _make_soc(perfmon_config)
+    # 3 SQ counters — all fit in one bucket (SQ capacity 8)
+    counters = {"SQ_WAVES", "SQ_BUSY", "SQ_INSTS"}
+
+    with patch.object(soc, "_same_bucket_priority_metric_ids", return_value=()):
+        files, file_count, accu_count = soc._allocate_perfmon_counter_files(counters)
+
+    assert accu_count == 0
+    assert len(files) == 1
+    assert file_count == 1
+    flat = set(_flat_counters_in_perfmon_file(files[0]))
+    assert flat == counters
+
+
+def test_allocate_tcc_channel_coalescing(perfmon_config):
+    soc = _make_soc(perfmon_config)
+    # TCC channels with same base should land in the same bucket
+    counters = {"TCC_HIT[0]", "TCC_HIT[1]", "TCC_HIT[2]", "SQ_WAVES"}
+
+    with patch.object(soc, "_same_bucket_priority_metric_ids", return_value=()):
+        files, file_count, accu_count = soc._allocate_perfmon_counter_files(counters)
+
+    # All TCC_HIT channels should be in the same file
+    tcc_file = None
+    for f in files:
+        flat = _flat_counters_in_perfmon_file(f)
+        if any("TCC_HIT" in c for c in flat):
+            tcc_file = f
+            break
+    assert tcc_file is not None
+    tcc_ctrs = [c for c in _flat_counters_in_perfmon_file(tcc_file) if "TCC_HIT" in c]
+    assert set(tcc_ctrs) == {"TCC_HIT[0]", "TCC_HIT[1]", "TCC_HIT[2]"}
+
+
+# =============================================================================
+# G. _expand_tcc_template_counters
+# =============================================================================
+
+
+def test_expand_tcc_templates(perfmon_config):
+    soc = _make_soc(perfmon_config, num_xcd=2, l2_banks=3)
+    result = soc._expand_tcc_template_counters({"TCC_HIT[", "SQ_WAVES"})
+
+    # Template replaced with 2*3=6 indexed counters
+    assert "TCC_HIT[" not in result
+    expected_tcc = {f"TCC_HIT[{i}]" for i in range(6)}
+    assert expected_tcc.issubset(result)
+    assert "SQ_WAVES" in result
+    assert len(result) == 7  # 6 TCC + 1 SQ
+
+
+def test_expand_tcc_no_templates(perfmon_config):
+    soc = _make_soc(perfmon_config, num_xcd=1, l2_banks=4)
+    inp = {"SQ_WAVES", "TA_ADDR", "TCC_HIT[0]"}
+    result = soc._expand_tcc_template_counters(inp)
+
+    # No templates — input unchanged
+    assert result == inp

--- a/projects/rocprofiler-compute/tests/test_utils.py
+++ b/projects/rocprofiler-compute/tests/test_utils.py
@@ -40,6 +40,7 @@ SUPPORTED_ARCHS = {
     "gfx941": {"mi300": ["MI300X_A0"]},
     "gfx942": {"mi300": ["MI300A_A1", "MI300X_A1"]},
     "gfx950": {"mi350": ["MI350"]},
+    "gfx1151": {"strix_halo": ["STRIX_HALO"]},
 }
 
 
@@ -279,11 +280,11 @@ def gpu_soc():
     soc_regex = re.compile(r"^\s*Name\s*:\s+ ([a-zA-Z0-9]+)\s*$", re.MULTILINE)
     devices = list(filter(soc_regex.match, rocminfo))
     if not devices:
-        return None
+        return ""
     gpu_arch = devices[0].split()[1]
 
     if gpu_arch not in SUPPORTED_ARCHS.keys():
-        return None
+        return ""
 
     gpu_model = list(SUPPORTED_ARCHS[gpu_arch].keys())[0].upper()
 


### PR DESCRIPTION
## Motivation

Enable rocprofiler-compute on AMD Strix Halo (gfx1151 / RDNA 3.5).
RDNA 3.5 differs from CDNA in memory hierarchy, IP block layout, and instruction set, requiring a new SoC module, analysis configs, and visualization front-end.

## Technical Details

**SoC Integration**
- New `soc_gfx1151` module with RDNA 3.5 hardware specs and perfmon counter limits
- `gfx1152` aliased to `gfx1151` via `canonical_gpu_arch()` — same ISA, different SKU
- Arch normalization applied at profiling and analysis load paths

**Analysis and Profiling**
- 13 analysis YAML configs covering all gfx1151 IP blocks
- Metric-aware counter allocation: greedy heuristic places priority metrics
  into PMC buckets first, reducing profiling passes
- Priority metrics defined per-arch in `profiling_counter_grouping_policy.yaml`

**Memory Chart**
- New `mem_chart_gfx11.py` renders the RDNA 3.5 memory hierarchy
- Existing renderer renamed to `mem_chart_gfx9.py` to clarify scope
- TUI widget routes to the correct renderer based on `gpu_arch`

**Bandwidth Formatting**
- Raw Bytes/s scaled to human-readable units (GB/s, TB/s) in CLI output
- Consistent divisor per row; Pct of Peak recalculated after scaling

**Roofline / rocflop**
- MFMA and SMFMAC kernel guards extended to exclude gfx1151

**Tests**
- New test suites for mem chart and SoC counter allocation
- Strix Halo added to profile/analysis test matrix
- Roofline and PC sampling properly skipped on unsupported SoCs

## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->
AIPROFCOMP-293

## Test Plan

Run full test suite on Strix Halo and MI GPUs

Ensure profiling and analysis meaningful in Strix Halo

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

Tests pass

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.