### PR TITLE
Fix flaky hipDeviceSynchronize_Functional CI test

### DIFF
--- a/projects/hip-tests/catch/unit/device/hipDeviceSynchronize.cc
+++ b/projects/hip-tests/catch/unit/device/hipDeviceSynchronize.cc
@@ -120,14 +120,9 @@ HIP_TEST_CASE(Unit_hipDeviceSynchronize_Functional) {
     HIP_CHECK(hipMemcpyAsync(A[i], Ad[i], _SIZE, hipMemcpyDeviceToHost, stream[i]));
   }
 
-
-  // This first check but relies on the kernel running for so long that the
-  // D2H async memcopy has not started yet. This will be true in an optimal
-  // asynchronous implementation.
-  // Conservative implementations which synchronize the hipMemcpyAsync will
-  // fail, ie if HIP_LAUNCH_BLOCKING=true.
-
-  REQUIRE(NUM_ITERS != A[NUM_STREAMS - 1][0] - 1);
+  // Do not assert on host-visible buffers before synchronize: the kernel may
+  // finish and D2H may complete before this thread runs again (fast GPU / CI),
+  // so "value not yet updated" is not reliable.
   HIP_CHECK(hipDeviceSynchronize());
   REQUIRE(NUM_ITERS == A[NUM_STREAMS - 1][0] - 1);
   for (int i = 0; i < NUM_STREAMS; i++) {


### PR DESCRIPTION

## Motivation
Remove timing-dependent pre-sync assertion that assumed GPU work was still in flight before hipDeviceSynchronize(). Fast hardware can complete the kernel and D2H copy first, causing intermittent failures.

Assert correct results for all streams after synchronize only.

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
