### PR TITLE
Fix regression in hip-tests printf trailing spaces

### DIFF
--- a/projects/hip-tests/catch/unit/device/hipDeviceSynchronize.cc
+++ b/projects/hip-tests/catch/unit/device/hipDeviceSynchronize.cc
@@ -120,14 +120,9 @@ HIP_TEST_CASE(Unit_hipDeviceSynchronize_Functional) {
     HIP_CHECK(hipMemcpyAsync(A[i], Ad[i], _SIZE, hipMemcpyDeviceToHost, stream[i]));
   }
 
-
-  // This first check but relies on the kernel running for so long that the
-  // D2H async memcopy has not started yet. This will be true in an optimal
-  // asynchronous implementation.
-  // Conservative implementations which synchronize the hipMemcpyAsync will
-  // fail, ie if HIP_LAUNCH_BLOCKING=true.
-
-  REQUIRE(NUM_ITERS != A[NUM_STREAMS - 1][0] - 1);
+  // Do not assert on host-visible buffers before synchronize: the kernel may
+  // finish and D2H may complete before this thread runs again (fast GPU / CI),
+  // so "value not yet updated" is not reliable.
   HIP_CHECK(hipDeviceSynchronize());
   REQUIRE(NUM_ITERS == A[NUM_STREAMS - 1][0] - 1);
   for (int i = 0; i < NUM_STREAMS; i++) {

--- a/projects/hip-tests/catch/unit/device/hipDeviceSynchronize.cc
+++ b/projects/hip-tests/catch/unit/device/hipDeviceSynchronize.cc
@@ -120,9 +120,14 @@ HIP_TEST_CASE(Unit_hipDeviceSynchronize_Functional) {
     HIP_CHECK(hipMemcpyAsync(A[i], Ad[i], _SIZE, hipMemcpyDeviceToHost, stream[i]));
   }
 
-  // Do not assert on host-visible buffers before synchronize: the kernel may
-  // finish and D2H may complete before this thread runs again (fast GPU / CI),
-  // so "value not yet updated" is not reliable.
+
+  // This first check but relies on the kernel running for so long that the
+  // D2H async memcopy has not started yet. This will be true in an optimal
+  // asynchronous implementation.
+  // Conservative implementations which synchronize the hipMemcpyAsync will
+  // fail, ie if HIP_LAUNCH_BLOCKING=true.
+
+  REQUIRE(NUM_ITERS != A[NUM_STREAMS - 1][0] - 1);
   HIP_CHECK(hipDeviceSynchronize());
   REQUIRE(NUM_ITERS == A[NUM_STREAMS - 1][0] - 1);
   for (int i = 0; i < NUM_STREAMS; i++) {

--- a/projects/hip-tests/catch/unit/printf/hipPrintfAltForms.cc
+++ b/projects/hip-tests/catch/unit/printf/hipPrintfAltForms.cc
@@ -50,7 +50,8 @@ HIP_TEST_CASE(Unit_Printf_PrintfAltFormsTsts) {
     HipTest::HIP_SKIP_TEST("Device doesn't support pcie atomic, Skipped");
     return;
   }
-  std::string reference(R"here(042
+  std::string reference =
+      std::string(R"here(042
 0x42
 0X42
 0x000042
@@ -64,8 +65,8 @@ HIP_TEST_CASE(Unit_Printf_PrintfAltFormsTsts) {
 -0X1.EDD2F1A9FBE77P+6
 0x00000042
       0x00000042
-0x00000042      
-)here");
+)here") +
+      std::string("0x00000042") + std::string(6, ' ') + "\n";
   CaptureStream captured(stdout);
   hipLaunchKernelGGL(test_kernel, dim3(1), dim3(1), 0, 0);
   HIP_CHECK(hipStreamSynchronize(0));

--- a/projects/hip-tests/catch/unit/printf/hipPrintfAltForms.cc
+++ b/projects/hip-tests/catch/unit/printf/hipPrintfAltForms.cc
@@ -64,7 +64,7 @@ HIP_TEST_CASE(Unit_Printf_PrintfAltFormsTsts) {
 -0X1.EDD2F1A9FBE77P+6
 0x00000042
       0x00000042
-0x00000042
+0x00000042      
 )here");
   CaptureStream captured(stdout);
   hipLaunchKernelGGL(test_kernel, dim3(1), dim3(1), 0, 0);

--- a/projects/hip-tests/catch/unit/printf/hipPrintfStar.cc
+++ b/projects/hip-tests/catch/unit/printf/hipPrintfStar.cc
@@ -41,7 +41,7 @@ HIP_TEST_CASE(Unit_Printf_PrintfStar) {
   }
   std::string reference(R"here(              42
 00000042
-00000042
+00000042        
     123.45600000 hello * world
 )here");
   CaptureStream captured(stdout);

--- a/projects/hip-tests/catch/unit/printf/hipPrintfStar.cc
+++ b/projects/hip-tests/catch/unit/printf/hipPrintfStar.cc
@@ -39,11 +39,12 @@ HIP_TEST_CASE(Unit_Printf_PrintfStar) {
     HipTest::HIP_SKIP_TEST("Device doesn't support pcie atomic, Skipped");
     return;
   }
-  std::string reference(R"here(              42
+  std::string reference =
+      std::string(R"here(              42
 00000042
-00000042        
-    123.45600000 hello * world
-)here");
+)here") +
+      std::string("00000042") + std::string(8, ' ') + "\n" +
+      std::string("    123.45600000 hello * world\n");
   CaptureStream captured(stdout);
   hipLaunchKernelGGL(test_kernel_star, dim3(1), dim3(1), 0, 0);
   HIP_CHECK(hipStreamSynchronize(0));

--- a/projects/hip-tests/catch/unit/printf/printfFlags.cc
+++ b/projects/hip-tests/catch/unit/printf/printfFlags.cc
@@ -35,18 +35,19 @@ HIP_TEST_CASE(Unit_Printf_flags_Sanity_Positive) {
     HipTest::HIP_SKIP_TEST("Device doesn't support pcie atomic, Skipped");
     return;
   }
-  std::string reference(R"here(00000042
+  std::string reference =
+      std::string(R"here(00000042
 -0000042
 00000042
 0123.456
 +0000042
 -42
 +0000042
-xyzzy   
--42
- 42
-00000042        
-        00000042
+)here") +
+      std::string("xyzzy") + std::string(3, ' ') + "\n" +
+      std::string("-42\n 42\n") +
+      std::string("00000042") + std::string(8, ' ') + "\n" +
+      std::string(R"here(        00000042
 052
 0x2a
 0X2A

--- a/projects/hip-tests/catch/unit/printf/printfFlags.cc
+++ b/projects/hip-tests/catch/unit/printf/printfFlags.cc
@@ -42,10 +42,10 @@ HIP_TEST_CASE(Unit_Printf_flags_Sanity_Positive) {
 +0000042
 -42
 +0000042
-xyzzy
+xyzzy   
 -42
  42
-00000042
+00000042        
         00000042
 052
 0x2a

--- a/projects/hip-tests/catch/unit/printf/printfFlagsNonHost.cc
+++ b/projects/hip-tests/catch/unit/printf/printfFlagsNonHost.cc
@@ -43,9 +43,9 @@ HIP_TEST_CASE(Unit_Buffered_Printf_Flags) {
 +0000042
 -42
 +0000042
-xyzzy
+xyzzy   
 -42
-00000042
+00000042        
         00000042
 )here");
 

--- a/projects/hip-tests/catch/unit/printf/printfFlagsNonHost.cc
+++ b/projects/hip-tests/catch/unit/printf/printfFlagsNonHost.cc
@@ -36,18 +36,19 @@ HIP_TEST_CASE(Unit_Buffered_Printf_Flags) {
     HipTest::HIP_SKIP_TEST("Device doesn't support pcie atomic, Skipped");
     return;
   }
-  std::string reference(R"here(00000042
+  std::string reference =
+      std::string(R"here(00000042
 -0000042
 00000042
 0123.456
 +0000042
 -42
 +0000042
-xyzzy   
--42
-00000042        
-        00000042
-)here");
+)here") +
+      std::string("xyzzy") + std::string(3, ' ') + "\n" +
+      std::string("-42\n") +
+      std::string("00000042") + std::string(8, ' ') + "\n" +
+      std::string("        00000042\n");
 
   hip::SpawnProc proc("printfFlagsNonHost_exe", true);
   REQUIRE(proc.run() == 0);


### PR DESCRIPTION
## Motivation
Fix regression after https://github.com/ROCm/rocm-systems/pull/3685/changes#diff-eb79bcc5fc6aa1df25b6d0c9bf512191014807541029283bbf2fe41680efbff7. The trailing spaces are needed in printf tests.

These are now added explicitly to avoid accidental removal or removal from pre-commit hooks

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
