### PR TITLE
[rocm-smi] Show GPU index in showPids when --showpids=details is passed

### DIFF
--- a/projects/rocm-smi-lib/python_smi_tools/rocm_smi.py
+++ b/projects/rocm-smi-lib/python_smi_tools/rocm_smi.py
@@ -2981,7 +2981,7 @@ def showPids(verbose):
                     [
                         pid,
                         getProcessName(pid),
-                        str(gpuNumber),
+                        str(dv_ind),
                         str(vramUsage),
                         str(sdmaUsage),
                         str(cuOccupancy),


### PR DESCRIPTION
Fix on how showPids shows GPU index. 


Fixes #4405 