### PR TITLE
Fallback to RelationNumaNode when RelationNumaNodeEx fails

### DIFF
--- a/projects/rocr-runtime/libhsakmt/src/dxg/topology_win.cpp
+++ b/projects/rocr-runtime/libhsakmt/src/dxg/topology_win.cpp
@@ -95,13 +95,23 @@ HSAKMT_STATUS topology_parse_numa_node_info(
                                       std::vector<proc_numa_node_info>& numa_node_info,
                                       const std::vector<proc_cpu_info>& cpu_info) {
   DWORD length = 0;
-  GetLogicalProcessorInformationEx(RelationNumaNodeEx, nullptr, &length);
+  auto relationship = RelationNumaNodeEx;
+  if (!GetLogicalProcessorInformationEx(relationship, nullptr, &length) &&
+      GetLastError() != ERROR_INSUFFICIENT_BUFFER) {
+    relationship = RelationNumaNode;
+    length = 0;
+    if (!GetLogicalProcessorInformationEx(relationship, nullptr, &length) &&
+        GetLastError() != ERROR_INSUFFICIENT_BUFFER) {
+      pr_err("GetLogicalProcessorInformationEx failed with error %lu\n", GetLastError());
+      return HSAKMT_STATUS_ERROR;
+    }
+  }
   std::vector<char> buffer(length);
   auto* info = reinterpret_cast<PSYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX>(buffer.data());
   const auto* end = reinterpret_cast<PSYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX>(buffer.data() + length);
 
-  if (!GetLogicalProcessorInformationEx(RelationNumaNodeEx, info, &length)) {
-    pr_err("GetLogicalProcessorInformationEx failed\n");
+  if (!GetLogicalProcessorInformationEx(relationship, info, &length)) {
+    pr_err("GetLogicalProcessorInformationEx failed with error %lu\n", GetLastError());
     return HSAKMT_STATUS_ERROR;
   }
 

--- a/projects/rocr-runtime/libhsakmt/src/dxg/topology_win.cpp
+++ b/projects/rocr-runtime/libhsakmt/src/dxg/topology_win.cpp
@@ -96,14 +96,18 @@ HSAKMT_STATUS topology_parse_numa_node_info(
                                       const std::vector<proc_cpu_info>& cpu_info) {
   DWORD length = 0;
   auto relationship = RelationNumaNodeEx;
-  if (!GetLogicalProcessorInformationEx(relationship, nullptr, &length) &&
-      GetLastError() != ERROR_INSUFFICIENT_BUFFER) {
-    relationship = RelationNumaNode;
-    length = 0;
-    if (!GetLogicalProcessorInformationEx(relationship, nullptr, &length) &&
-        GetLastError() != ERROR_INSUFFICIENT_BUFFER) {
-      pr_err("GetLogicalProcessorInformationEx failed with error %lu\n", GetLastError());
-      return HSAKMT_STATUS_ERROR;
+  if (!GetLogicalProcessorInformationEx(relationship, nullptr, &length)) {
+    const auto error = GetLastError();
+    if (error != ERROR_INSUFFICIENT_BUFFER) {
+      pr_warn("GetLogicalProcessorInformationEx(RelationNumaNodeEx) failed with error %lu, "
+              "falling back to RelationNumaNode\n", error);
+      relationship = RelationNumaNode;
+      length = 0;
+      if (!GetLogicalProcessorInformationEx(relationship, nullptr, &length) &&
+          GetLastError() != ERROR_INSUFFICIENT_BUFFER) {
+        pr_err("GetLogicalProcessorInformationEx failed with error %lu\n", GetLastError());
+        return HSAKMT_STATUS_ERROR;
+      }
     }
   }
   std::vector<char> buffer(length);


### PR DESCRIPTION
## Motivation

- On older Windows (Windows 10), RelationNumaNodeEx is not supported and returns error.

## Technical Details

- On older Windows, RelationNumaNodeEx is not supported and returns error.
- Added a fallback to RelationNumaNode.

## JIRA ID

SWDEV-1

## Test Plan

Run any HIP app

## Test Result

HIP app initializes successfully.

## Submission Checklist

- [s] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
