### PR TITLE
rccl: Sync rocm_netib.patch with the latest changes in net_ib

### DIFF
--- a/projects/rccl/cmake/rocmIb.cmake
+++ b/projects/rccl/cmake/rocmIb.cmake
@@ -59,7 +59,11 @@ execute_process(
   COMMAND ${CMAKE_COMMAND} -E echo "Applying RCCL ROCM NetIB patch to staging area: ${ROCM_NETIB_FILE}"
   COMMAND bash -c "patch -p1 -i ${ROCM_NETIB_PATCH_FILE} -o ${ROCM_NETIB_FILE}"
   WORKING_DIRECTORY ${RCCL_SRC_DIR}
+  RESULT_VARIABLE _rocm_netib_patch_rc
 )
+if(NOT _rocm_netib_patch_rc EQUAL 0)
+  message(FATAL_ERROR "Failed to apply RCCL ROCM NetIB patch.")
+endif()
 execute_process(
   COMMAND bash -c "sed -i 's/NCCL_PARAM(Ib/NCCL_PARAM(RocmIb/g' ${ROCM_NETIB_FILE}"
   WORKING_DIRECTORY ${ROCM_NETIB_STAGING_DIR}

--- a/projects/rccl/ext-src/rocm_netib.patch
+++ b/projects/rccl/ext-src/rocm_netib.patch
@@ -59,10 +59,12 @@ diff --git a/src/transport/net_ib.cc b/src/transport/net_ib.cc
  
  static ncclResult_t ncclIbStatsInit(struct ncclIbStats* stat) {
    __atomic_store_n(&stat->fatalErrorCount, 0, __ATOMIC_RELAXED);
-@@ -751,6 +781,19 @@ ncclResult_t ncclIbMakeVDeviceInternal(i
+@@ -773,8 +804,22 @@ ncclResult_t ncclIbMakeVDeviceInternal(i
+           dev0->devName, root0, dev->devName, root_i);
+       break;
      }
    }
- 
++
 +  // CTS Offload and CTS Inline are not yet compatible with NIC Fusion
 +  // (NCCL_IB_MERGE_NICS). Disable them when a multi-NIC vNIC is created.
 +  if (props->ndevs > 1) {
@@ -76,8 +78,9 @@ diff --git a/src/transport/net_ib.cc b/src/transport/net_ib.cc
 +    }
 +  }
 +
+   ncclIbMergedDevs[ncclNMergedIbDevs] = tmp;
    *d = ncclNMergedIbDevs++;
-   INFO(NCCL_NET, "NET/IB : Made virtual device [%d] name=%s speed=%d ndevs=%d", *d, mDev->devName, mDev->speed, mDev->vProps.ndevs);
+   INFO(NCCL_NET, "NET/IB : Made virtual device [%d] name=%s speed=%d ndevs=%d", *d, tmp.devName, tmp.speed, tmp.vProps.ndevs);
    return ncclSuccess;
 @@ -779,6 +822,10 @@ ncclResult_t ncclIbInit(void** ctx, uint
    static int shownIbHcaEnv = 0;

--- a/projects/rccl/ext-src/rocm_netib.patch
+++ b/projects/rccl/ext-src/rocm_netib.patch
@@ -67,13 +67,13 @@ diff --git a/src/transport/net_ib.cc b/src/transport/net_ib.cc
 +
 +  // CTS Offload and CTS Inline are not yet compatible with NIC Fusion
 +  // (NCCL_IB_MERGE_NICS). Disable them when a multi-NIC vNIC is created.
-+  if (props->ndevs > 1) {
++  if (tmp.vProps.ndevs > 1) {
 +    if (rcclCtsInlineData) {
-+      INFO(NCCL_INIT|NCCL_NET, "NET/IB : NIC Fusion (ndevs=%d) - disabling CTS Inline Data (not yet supported with merge)", props->ndevs);
++      INFO(NCCL_INIT|NCCL_NET, "NET/IB : NIC Fusion (ndevs=%d) - disabling CTS Inline Data (not yet supported with merge)", tmp.vProps.ndevs);
 +      rcclCtsInlineData = false;
 +    }
 +    if (rcclCtsOffloadEnabled) {
-+      INFO(NCCL_INIT|NCCL_NET, "NET/IB : NIC Fusion (ndevs=%d) - disabling CTS Offload (not yet supported with merge)", props->ndevs);
++      INFO(NCCL_INIT|NCCL_NET, "NET/IB : NIC Fusion (ndevs=%d) - disabling CTS Offload (not yet supported with merge)", tmp.vProps.ndevs);
 +      rcclCtsOffloadEnabled = false;
 +    }
 +  }


### PR DESCRIPTION
## Motivation

Fixed RCCL build failure caused by rocm_netib.patch being out of sync with net_ib.cc

## Technical Details

- Sync rocm_netib.patch with the latest changes in net_ib
- Add patch failure detection in cmake

## JIRA ID

## Test Plan

Locally checked RCCL build

## Test Result

Passed

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
