### PR TITLE
[github/scripts] Pass -DTHEROCK_ENABLE_CORE=ON to debug-tools/rocshmem CI builds

### DIFF
--- a/.github/scripts/therock_matrix.py
+++ b/.github/scripts/therock_matrix.py
@@ -38,8 +38,9 @@ project_map = {
         "cmake_options": "-DTHEROCK_ENABLE_DC_TOOLS=ON -DTHEROCK_ENABLE_ALL=OFF",
         "projects_to_test": "",  # rdc-tests is not built by TheRock build system - TBD
     },
+    # Make sure we enable THEROCK_ENABLE_CORE so we build amdsmitst to run sanity tests.
     "debug_tools": {
-        "cmake_options": "-DTHEROCK_ENABLE_DEBUG_TOOLS=ON -DTHEROCK_ENABLE_ALL=OFF",
+        "cmake_options": "-DTHEROCK_ENABLE_DEBUG_TOOLS=ON -DTHEROCK_ENABLE_ALL=OFF -DTHEROCK_ENABLE_CORE=ON",
         "projects_to_test": "rocr-debug-agent, rocgdb",
     },
     # media libs to be enabled in following PR
@@ -51,8 +52,9 @@ project_map = {
         "cmake_options": "-DTHEROCK_ENABLE_ALL=ON",
         "projects_to_test": "aqlprofile, rocprofiler-compute, rocprofiler-systems",
     },
+    # Make sure we enable THEROCK_ENABLE_CORE so we build amdsmitst to run sanity tests.
     "rocshmem": {
-        "cmake_options": "-DTHEROCK_ENABLE_ROCSHMEM=ON -DTHEROCK_ENABLE_ALL=OFF",
+        "cmake_options": "-DTHEROCK_ENABLE_ROCSHMEM=ON -DTHEROCK_ENABLE_ALL=OFF -DTHEROCK_ENABLE_CORE=ON",
         "projects_to_test": "",  # rocshmem testing to be enabled in a future PR
     },
     "runtimes": {


### PR DESCRIPTION
The debug-tools currently build with everything but the debug-tools +
dependencies disabled. The dependencies don't include AMDSMI, and we need
AMDSMI for running the sanity checks.

Without it, the sanity checks fail and as a consequence we fail to run
the debug agent and rocgdb tests.

Do the same for rocshmem, as it also does a partial build that does not
enable AMDSMI.