### PR TITLE
 [rocrtst] AILIROCR-40 Verify timestamps in AQL packets

### DIFF
--- a/projects/rocr-runtime/rocrtst/suites/functional/time_stamp.cc
+++ b/projects/rocr-runtime/rocrtst/suites/functional/time_stamp.cc
@@ -41,6 +41,13 @@ TimeStamp::TimeStamp(void) :
 }
 
 TimeStamp::~TimeStamp(void) {
+  // If Close() wasn't called (ASSERT failure), clean up here
+  if (!resources_free) {
+    FreeResources();
+    // Note: HSA is still initialized, so we can safely destroy resources
+    // TestBase::Close() will be called by gtest's TearDown if it exists,
+    // or HSA will leak but at least our signals/queue won't
+  }
 }
 
 // Any 1-time setup involving member variables used in the rest of the test
@@ -84,7 +91,26 @@ void TimeStamp::DisplayResults(void) const {
   return;
 }
 
+void TimeStamp::FreeResources() {
+  // Clean up queue and signals
+  if (queue) {
+    hsa_queue_destroy(queue);
+    queue = nullptr;
+  }
+
+  for (uint32_t i = 0; i < NUM_BARRIERS; ++i) {
+    if (completion_signals[i].handle) {
+      hsa_signal_destroy(completion_signals[i]);
+      completion_signals[i].handle = 0;
+    }
+  }
+  resources_free = true;
+}
+
 void TimeStamp::Close() {
+  // Clean up HSA resources BEFORE calling hsa_shut_down()
+  FreeResources();
+
   // This will close handles opened within rocrtst utility calls and call
   // hsa_shut_down(), so it should be done after other hsa cleanup
   TestBase::Close();
@@ -147,5 +173,80 @@ void TimeStamp::TimeStampTest (void) {
     } //for loop iterating over agent_pools ends
 }
 
+void TimeStamp::BarrierPacketTimestampValidationTest(void) {
+
+  PrinTimeStampSubtestHeader("BarrierPacketTimestampValidationTest:test to verify timestamps in AQL packets");
+  hsa_status_t err;
+  // find all gpu agents
+  std::vector<hsa_agent_t> gpus;
+  err = hsa_iterate_agents(rocrtst::IterateGPUAgents, &gpus);
+  ASSERT_EQ(err, HSA_STATUS_SUCCESS);
+
+  // - allocate queue
+  uint32_t queue_size = 0;
+  ASSERT_GT(gpus.size(), (uint32_t)0);
+  ASSERT_SUCCESS(hsa_agent_get_info(gpus[0], HSA_AGENT_INFO_QUEUE_MAX_SIZE, &queue_size));
+  
+
+  err = hsa_queue_create(gpus[0], queue_size, HSA_QUEUE_TYPE_MULTI, nullptr, nullptr, 0, 0, &queue);
+  ASSERT_EQ(err, HSA_STATUS_SUCCESS);
+  // Enable profiling on the queue to collect timestamps
+  err = hsa_amd_profiling_set_profiler_enabled(queue, 1);
+  ASSERT_EQ(err, HSA_STATUS_SUCCESS);
+  std::cout << "Profiling enabled on queue" << std::endl;
+
+  // - Create new signals
+  // - Create a completion signal for the barrier packet
+  for (uint32_t i = 0; i < NUM_BARRIERS; ++i) {
+    err = hsa_signal_create(1, 0, NULL, &completion_signals[i]);
+    ASSERT_EQ(err, HSA_STATUS_SUCCESS);
+  }
+
+  std::cout << "Submitting " << NUM_BARRIERS << " barrier packets..." << std::endl;
+
+  // Submit 100 barrier packets
+  for (uint32_t i = 0; i < NUM_BARRIERS; ++i) {
+    // Create a Barrier-AND packet
+    // - Place a Barrier-Value packet into the queue
+    hsa_barrier_and_packet_t barrier_pkt;
+    memset(&barrier_pkt, 0, sizeof(barrier_pkt));
+    barrier_pkt.header = HSA_PACKET_TYPE_BARRIER_AND | (1 << HSA_PACKET_HEADER_BARRIER) |
+                        (HSA_FENCE_SCOPE_NONE << HSA_PACKET_HEADER_SCACQUIRE_FENCE_SCOPE) |
+                        (HSA_FENCE_SCOPE_NONE << HSA_PACKET_HEADER_SCRELEASE_FENCE_SCOPE);
+    barrier_pkt.completion_signal = completion_signals[i];
+
+    // Get the write index and reserve a slot in the queue
+    uint64_t index = hsa_queue_load_write_index_relaxed(queue);
+    hsa_queue_store_write_index_relaxed(queue, index + 1);
+    reinterpret_cast<hsa_barrier_and_packet_t*>(queue->base_address)[index % queue->size] = barrier_pkt;
+
+    hsa_signal_store_relaxed(queue->doorbell_signal, index);
+  }
+  std::cout << "Waiting for barrier packets to complete..." << std::endl;
+
+  hsa_amd_profiling_dispatch_time_t dispatch_times[NUM_BARRIERS];
+  // - Wait for the completion-signals to change from 1 to 0.
+  // Wait for the last barriers to complete and collect timing data
+  while (hsa_signal_wait_scacquire(completion_signals[NUM_BARRIERS - 1],
+      HSA_SIGNAL_CONDITION_LT, 1, (uint64_t)-1, HSA_WAIT_STATE_ACTIVE)) {}
+  for (uint32_t i = 0; i < NUM_BARRIERS; ++i) {
+    // Get the dispatch time for this barrier packet
+    err = hsa_amd_profiling_get_dispatch_time(gpus[0], completion_signals[i], &dispatch_times[i]);
+    ASSERT_EQ(err, HSA_STATUS_SUCCESS);
+
+    // Assert failures for Incorrect timestamps.
+    ASSERT_GE(dispatch_times[i].end, dispatch_times[i].start);
+
+    if(i > 0) {
+      ASSERT_GE(dispatch_times[i].start, dispatch_times[i - 1].end);
+    }
+    if (verbosity() > 0) {
+      std::cout << "Barrier " << i << " - Start: " << dispatch_times[i].start
+              << ", End: " << dispatch_times[i].end
+              << ", Duration: " << (dispatch_times[i].end - dispatch_times[i].start)
+              << " ticks" << std::endl;
+    }
+  }
+}
 
 #undef RET_IF_HSA_ERR

--- a/projects/rocr-runtime/rocrtst/suites/functional/time_stamp.h
+++ b/projects/rocr-runtime/rocrtst/suites/functional/time_stamp.h
@@ -35,6 +35,14 @@ class TimeStamp : public TestBase {
 
   void TimeStampTest (void);
 
+  void BarrierPacketTimestampValidationTest(void);
+private:
+  void FreeResources();  // Helper to clean up queue and signals
+
+  const static uint32_t NUM_BARRIERS = 100;
+  hsa_signal_t completion_signals[NUM_BARRIERS] = {0};
+  hsa_queue_t *queue = NULL;
+  bool resources_free = false;  // Track if cleanup happened
 };
 
 #endif  // ROCRTST_SUITES_FUNCTIONAL_TIME_STAMP_H_

--- a/projects/rocr-runtime/rocrtst/suites/test_common/main.cc
+++ b/projects/rocr-runtime/rocrtst/suites/test_common/main.cc
@@ -347,6 +347,13 @@ TEST(rocrtstFunc, Time_Stamp) {
   RunCustomTestEpilog(&ts);
 }
 
+TEST(rocrtstFunc, BarrierPkt_TimeStamp) {
+    TimeStamp ts;
+    RunCustomTestProlog(&ts);
+    ts.BarrierPacketTimestampValidationTest();
+    RunCustomTestEpilog(&ts);
+}
+
 TEST(rocrtstFunc, GpuCoreDump_DefaultPattern) {
     GpuCoreDumpTest gcd;
     if (!RunCustomTestProlog(&gcd)) return;

--- a/projects/rocr-runtime/rocrtst/suites/test_common/main.cc
+++ b/projects/rocr-runtime/rocrtst/suites/test_common/main.cc
@@ -331,6 +331,13 @@ TEST(rocrtstFunc, Time_Stamp) {
   RunCustomTestEpilog(&ts);
 }
 
+TEST(rocrtstFunc, BarrierPkt_TimeStamp) {
+    TimeStamp ts;
+    RunCustomTestProlog(&ts);
+    ts.BarrierPacketTimestampValidationTest();
+    RunCustomTestEpilog(&ts);
+}
+
 TEST(rocrtstFunc, GpuCoreDump_DefaultPattern) {
     GpuCoreDumpTest gcd;
     if (!RunCustomTestProlog(&gcd)) return;


### PR DESCRIPTION
 This change will go over AILIROCR-39. Please only check BarrierPkt_TimeStamp in main.cc
 BarrierPacketTimestampValidationTest in timeStamp.cc

 The purpose of this test is to verify that:
   1. The non-translated start and end timestamps in the AQL packets are always monotonically increasing.

   2. The translated timetamps are also always monotonically increasing.

## Motivation

AILIROCR-40

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## JIRA ID

AILIROCR-40

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
