### PR TITLE
[rocprofiler-sdk] Update Sqlite3 interface to avoid deprecation notice

### DIFF
--- a/projects/rocprofiler-sdk/external/CMakeLists.txt
+++ b/projects/rocprofiler-sdk/external/CMakeLists.txt
@@ -280,7 +280,7 @@ if(ROCPROFILER_BUILD_SQLITE3)
     add_dependencies(rocprofiler-sdk-sqlite3 rocprofiler-sdk-sqlite-build)
 else()
     find_package(SQLite3 REQUIRED)
-    target_link_libraries(rocprofiler-sdk-sqlite3 INTERFACE SQLite::SQLite3)
+    target_link_libraries(rocprofiler-sdk-sqlite3 INTERFACE SQLite3::SQLite3)
 endif()
 
 #

--- a/projects/rocprofiler-sdk/external/CMakeLists.txt
+++ b/projects/rocprofiler-sdk/external/CMakeLists.txt
@@ -280,29 +280,28 @@ if(ROCPROFILER_BUILD_SQLITE3)
     add_dependencies(rocprofiler-sdk-sqlite3 rocprofiler-sdk-sqlite-build)
 else()
     find_package(SQLite3 REQUIRED MODULE)
-    if(NOT SQLite3_INCLUDE_DIRS AND SQLite3_INCLUDE_DIR)
-        set(SQLite3_INCLUDE_DIRS "${SQLite3_INCLUDE_DIR}")
-    endif()
-    if(NOT SQLite3_LIBRARIES AND SQLite3_LIBRARY)
-        set(SQLite3_LIBRARIES "${SQLite3_LIBRARY}")
-    endif()
+    # if(NOT SQLite3_INCLUDE_DIRS AND SQLite3_INCLUDE_DIR)
+    #    set(SQLite3_INCLUDE_DIRS "${SQLite3_INCLUDE_DIR}")
+    # endif()
+    # if(NOT SQLite3_LIBRARIES AND SQLite3_LIBRARY)
+    #    set(SQLite3_LIBRARIES "${SQLite3_LIBRARY}")
+    # endif()
 
     if(TARGET SQLite3::SQLite3)
         target_link_libraries(rocprofiler-sdk-sqlite3 INTERFACE SQLite3::SQLite3)
     elseif(SQLite3_INCLUDE_DIRS AND SQLite3_LIBRARIES)
-        add_library(rocprofiler-sdk-system-sqlite3 INTERFACE IMPORTED)
-        set_target_properties(
-            rocprofiler-sdk-system-sqlite3
-            PROPERTIES INTERFACE_LINK_LIBRARIES "${SQLite3_LIBRARIES}"
-                       INTERFACE_INCLUDE_DIRECTORIES "${SQLite3_INCLUDE_DIRS}")
-        target_link_libraries(rocprofiler-sdk-sqlite3
-                              INTERFACE rocprofiler-sdk-system-sqlite3)
+        target_include_directories(
+            rocprofiler-sdk-sqlite3 SYSTEM
+            INTERFACE ${SQLite3_INCLUDE_DIRS})
+        target_link_libraries(rocprofiler-sdk-sqlite3 
+                              INTERFACE ${SQLite3_LIBRARIES})
     else()
         message(
             FATAL_ERROR
-                "find_package(SQLite3 MODULE) did not define SQLite3::SQLite3, SQLite::SQLite3, "
-                "or SQLite3_INCLUDE_DIRS and SQLite3_LIBRARIES (or *_DIR / *_LIBRARY).")
+                "find_package(SQLite3) succeeded but no usable SQLite3 target or "
+                "SQLite3_INCLUDE_DIRS/SQLite3_LIBRARIES variables were provided.")
     endif()
+
 endif()
 
 #

--- a/projects/rocprofiler-sdk/external/CMakeLists.txt
+++ b/projects/rocprofiler-sdk/external/CMakeLists.txt
@@ -279,7 +279,7 @@ if(ROCPROFILER_BUILD_SQLITE3)
         )
     add_dependencies(rocprofiler-sdk-sqlite3 rocprofiler-sdk-sqlite-build)
 else()
-    find_package(SQLite3 REQUIRED)
+    find_package(SQLite3 REQUIRED MODULE)
     target_link_libraries(rocprofiler-sdk-sqlite3 INTERFACE SQLite3::SQLite3)
 endif()
 

--- a/projects/rocprofiler-sdk/external/CMakeLists.txt
+++ b/projects/rocprofiler-sdk/external/CMakeLists.txt
@@ -280,7 +280,28 @@ if(ROCPROFILER_BUILD_SQLITE3)
     add_dependencies(rocprofiler-sdk-sqlite3 rocprofiler-sdk-sqlite-build)
 else()
     find_package(SQLite3 REQUIRED MODULE)
-    target_link_libraries(rocprofiler-sdk-sqlite3 INTERFACE SQLite3::SQLite3)
+    if(NOT SQLite3_INCLUDE_DIRS AND SQLite3_INCLUDE_DIR)
+        set(SQLite3_INCLUDE_DIRS "${SQLite3_INCLUDE_DIR}")
+    endif()
+    if(NOT SQLite3_LIBRARIES AND SQLite3_LIBRARY)
+        set(SQLite3_LIBRARIES "${SQLite3_LIBRARY}")
+    endif()
+
+    if(TARGET SQLite3::SQLite3)
+        target_link_libraries(rocprofiler-sdk-sqlite3 INTERFACE SQLite3::SQLite3)
+    elseif(SQLite3_INCLUDE_DIRS AND SQLite3_LIBRARIES)
+        add_library(rocprofiler-sdk-system-sqlite3 INTERFACE IMPORTED)
+        set_target_properties(
+            rocprofiler-sdk-system-sqlite3
+            PROPERTIES INTERFACE_LINK_LIBRARIES "${SQLite3_LIBRARIES}"
+                       INTERFACE_INCLUDE_DIRECTORIES "${SQLite3_INCLUDE_DIRS}")
+        target_link_libraries(rocprofiler-sdk-sqlite3 INTERFACE rocprofiler-sdk-system-sqlite3)
+    else()
+        message(
+            FATAL_ERROR
+                "find_package(SQLite3 MODULE) did not define SQLite3::SQLite3, SQLite::SQLite3, "
+                "or SQLite3_INCLUDE_DIRS and SQLite3_LIBRARIES (or *_DIR / *_LIBRARY).")
+    endif()
 endif()
 
 #

--- a/projects/rocprofiler-sdk/external/CMakeLists.txt
+++ b/projects/rocprofiler-sdk/external/CMakeLists.txt
@@ -295,7 +295,8 @@ else()
             rocprofiler-sdk-system-sqlite3
             PROPERTIES INTERFACE_LINK_LIBRARIES "${SQLite3_LIBRARIES}"
                        INTERFACE_INCLUDE_DIRECTORIES "${SQLite3_INCLUDE_DIRS}")
-        target_link_libraries(rocprofiler-sdk-sqlite3 INTERFACE rocprofiler-sdk-system-sqlite3)
+        target_link_libraries(rocprofiler-sdk-sqlite3
+                              INTERFACE rocprofiler-sdk-system-sqlite3)
     else()
         message(
             FATAL_ERROR


### PR DESCRIPTION
## Motivation

When building locally, saw deprecation notice for SQLite3.  Updating to the newer interface.

## Technical Details

Deprecation notice:
```
CMake Warning (dev) at external/CMakeLists.txt:278 (target_link_libraries):
  The library that is being linked to, SQLite::SQLite3, is marked as being
  deprecated by the owner.  The message provided by the developer is:

  The target name SQLite::SQLite3 is deprecated.  Please use SQLite3::SQLite3
  instead.

This warning is for project developers.  Use -Wno-dev to suppress it.

CMake Warning (dev) at external/CMakeLists.txt:278 (target_link_libraries):
  The library that is being linked to, SQLite::SQLite3, is marked as being
  deprecated by the owner.  The message provided by the developer is:

  The target name SQLite::SQLite3 is deprecated.  Please use SQLite3::SQLite3
  instead.

This warning is for project developers.  Use -Wno-dev to suppress it.
```


## JIRA ID

N/A

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
