### PR TITLE
clr: Fix HSA agent parameters in rocrCopyBuffer to correct rocprofiler-sdk memory copy tracing

### DIFF
--- a/projects/clr/rocclr/device/rocm/rocblit.cpp
+++ b/projects/clr/rocclr/device/rocm/rocblit.cpp
@@ -497,9 +497,10 @@ inline bool DmaBlitManager::rocrCopyBuffer(address dst, hsa_agent_t& dstAgent, c
     // Different devices
     if (srcAgent.handle == dev().getCpuAgent().handle) {
       // Host to device
+      // Keep (dst=GPU, src=CPU) ordering for ROCr SDMA engine selection queries.
       engine = HwQueueEngine::SdmaH2D;
-      copyAgent = dstAgent;
-      peerAgent = srcAgent;
+      copyAgent = srcAgent;
+      peerAgent = dstAgent;
     } else if (dstAgent.handle == dev().getCpuAgent().handle) {
       // Device to host
       engine = HwQueueEngine::SdmaD2H;

--- a/projects/clr/rocclr/device/rocm/rocblit.cpp
+++ b/projects/clr/rocclr/device/rocm/rocblit.cpp
@@ -486,6 +486,9 @@ inline bool DmaBlitManager::rocrCopyBuffer(address dst, hsa_agent_t& dstAgent, c
       (copyMetadata.copyEnginePreference_ == amd::CopyMetadata::CopyEnginePreference::SDMA);
   HwQueueEngine engine = HwQueueEngine::Unknown;
 
+  // copyAgent/peerAgent are used for SDMA engine allocation queries only.
+  // The HSA API calls must use the original dstAgent/srcAgent to maintain
+  // correct memory ownership semantics for profiling tools.
   hsa_agent_t copyAgent, peerAgent;
   // Determine engine based on source and destination agents
   if (srcAgent.handle == dstAgent.handle) {
@@ -496,19 +499,17 @@ inline bool DmaBlitManager::rocrCopyBuffer(address dst, hsa_agent_t& dstAgent, c
   } else {
     // Different devices
     if (srcAgent.handle == dev().getCpuAgent().handle) {
-      // Host to device
+      // Host to device: copyAgent is the GPU that performs the copy
       engine = HwQueueEngine::SdmaH2D;
       copyAgent = dstAgent;
       peerAgent = srcAgent;
     } else if (dstAgent.handle == dev().getCpuAgent().handle) {
-      // Device to host
+      // Device to host: copyAgent is the GPU that performs the copy
       engine = HwQueueEngine::SdmaD2H;
       copyAgent = srcAgent;
       peerAgent = dstAgent;
     } else {
-      // For P2P, always use the backendDevice as the copy agent. ROCr selects the
-      // SDMA engine from the src_agent, so we place backendDevice there.
-      // peerAgent must be the peer
+      // For P2P, always use the backendDevice as the copy agent for engine selection.
       engine = HwQueueEngine::SdmaP2P;
       copyAgent = dev().getBackendDevice();
       peerAgent = (srcAgent.handle == copyAgent.handle) ? dstAgent : srcAgent;
@@ -559,6 +560,16 @@ inline bool DmaBlitManager::rocrCopyBuffer(address dst, hsa_agent_t& dstAgent, c
       // Copy on the first available free engine if ROCr returns a valid mask
       hsa_amd_sdma_engine_id_t copyEngine = static_cast<hsa_amd_sdma_engine_id_t>(copyMask);
 
+      // For P2P copies, we need to pass the backendDevice as src_agent to ROCr so it
+      // selects the correct SDMA engine from the local device. However, we must preserve
+      // the original dstAgent/srcAgent semantics for profiling tools.
+      hsa_agent_t apiDstAgent = dstAgent;
+      hsa_agent_t apiSrcAgent = srcAgent;
+      if (engine == HwQueueEngine::SdmaP2P) {
+        // ROCr selects SDMA engine from src_agent, so place backendDevice there
+        apiSrcAgent = dev().getBackendDevice();
+      }
+
       ClPrint(amd::LOG_DEBUG, amd::LOG_COPY2,
               "HSA Copy copy_engine=0x%x, dst=0x%zx, src=0x%zx, "
               "size=%ld, forceSDMA=%d, engineOp=%s, wait_event=0x%zx, completion_signal=0x%zx",
@@ -566,7 +577,7 @@ inline bool DmaBlitManager::rocrCopyBuffer(address dst, hsa_agent_t& dstAgent, c
               (wait_events.size() != 0) ? wait_events[0].handle : 0, active.handle);
 
       status =
-          Hsa::memory_async_copy_on_engine(dst, peerAgent, src, copyAgent, size, wait_events.size(),
+          Hsa::memory_async_copy_on_engine(dst, apiDstAgent, src, apiSrcAgent, size, wait_events.size(),
                                            wait_events.data(), active, copyEngine, forceSDMA);
     } else {
       kUseRegularCopyApi = true;
@@ -574,13 +585,20 @@ inline bool DmaBlitManager::rocrCopyBuffer(address dst, hsa_agent_t& dstAgent, c
   }
 
   if (engine == HwQueueEngine::Unknown || kUseRegularCopyApi) {
+    // For P2P copies using the regular copy API, also need to adjust src_agent
+    hsa_agent_t apiDstAgent = dstAgent;
+    hsa_agent_t apiSrcAgent = srcAgent;
+    if (engine == HwQueueEngine::SdmaP2P) {
+      apiSrcAgent = dev().getBackendDevice();
+    }
+
     ClPrint(amd::LOG_DEBUG, amd::LOG_COPY2,
             "HSA Copy dst=0x%zx, src=0x%zx, size=%ld, wait_event=0x%zx, "
             "completion_signal=0x%zx, engineOp=%s",
             dst, src, size, (wait_events.size() != 0) ? wait_events[0].handle : 0, active.handle,
             EngineOpName(engine));
 
-    status = Hsa::memory_async_copy(dst, peerAgent, src, copyAgent, size, wait_events.size(),
+    status = Hsa::memory_async_copy(dst, apiDstAgent, src, apiSrcAgent, size, wait_events.size(),
                                     wait_events.data(), active);
   }
 

--- a/projects/clr/rocclr/device/rocm/rocblit.cpp
+++ b/projects/clr/rocclr/device/rocm/rocblit.cpp
@@ -486,9 +486,6 @@ inline bool DmaBlitManager::rocrCopyBuffer(address dst, hsa_agent_t& dstAgent, c
       (copyMetadata.copyEnginePreference_ == amd::CopyMetadata::CopyEnginePreference::SDMA);
   HwQueueEngine engine = HwQueueEngine::Unknown;
 
-  // copyAgent/peerAgent are used for SDMA engine allocation queries only.
-  // The HSA API calls must use the original dstAgent/srcAgent to maintain
-  // correct memory ownership semantics for profiling tools.
   hsa_agent_t copyAgent, peerAgent;
   // Determine engine based on source and destination agents
   if (srcAgent.handle == dstAgent.handle) {
@@ -499,17 +496,19 @@ inline bool DmaBlitManager::rocrCopyBuffer(address dst, hsa_agent_t& dstAgent, c
   } else {
     // Different devices
     if (srcAgent.handle == dev().getCpuAgent().handle) {
-      // Host to device: copyAgent is the GPU that performs the copy
+      // Host to device
       engine = HwQueueEngine::SdmaH2D;
       copyAgent = dstAgent;
       peerAgent = srcAgent;
     } else if (dstAgent.handle == dev().getCpuAgent().handle) {
-      // Device to host: copyAgent is the GPU that performs the copy
+      // Device to host
       engine = HwQueueEngine::SdmaD2H;
       copyAgent = srcAgent;
       peerAgent = dstAgent;
     } else {
-      // For P2P, always use the backendDevice as the copy agent for engine selection.
+      // For P2P, always use the backendDevice as the copy agent. ROCr selects the
+      // SDMA engine from the src_agent, so we place backendDevice there.
+      // peerAgent must be the peer
       engine = HwQueueEngine::SdmaP2P;
       copyAgent = dev().getBackendDevice();
       peerAgent = (srcAgent.handle == copyAgent.handle) ? dstAgent : srcAgent;
@@ -560,16 +559,6 @@ inline bool DmaBlitManager::rocrCopyBuffer(address dst, hsa_agent_t& dstAgent, c
       // Copy on the first available free engine if ROCr returns a valid mask
       hsa_amd_sdma_engine_id_t copyEngine = static_cast<hsa_amd_sdma_engine_id_t>(copyMask);
 
-      // For P2P copies, we need to pass the backendDevice as src_agent to ROCr so it
-      // selects the correct SDMA engine from the local device. However, we must preserve
-      // the original dstAgent/srcAgent semantics for profiling tools.
-      hsa_agent_t apiDstAgent = dstAgent;
-      hsa_agent_t apiSrcAgent = srcAgent;
-      if (engine == HwQueueEngine::SdmaP2P) {
-        // ROCr selects SDMA engine from src_agent, so place backendDevice there
-        apiSrcAgent = dev().getBackendDevice();
-      }
-
       ClPrint(amd::LOG_DEBUG, amd::LOG_COPY2,
               "HSA Copy copy_engine=0x%x, dst=0x%zx, src=0x%zx, "
               "size=%ld, forceSDMA=%d, engineOp=%s, wait_event=0x%zx, completion_signal=0x%zx",
@@ -577,7 +566,7 @@ inline bool DmaBlitManager::rocrCopyBuffer(address dst, hsa_agent_t& dstAgent, c
               (wait_events.size() != 0) ? wait_events[0].handle : 0, active.handle);
 
       status =
-          Hsa::memory_async_copy_on_engine(dst, apiDstAgent, src, apiSrcAgent, size, wait_events.size(),
+          Hsa::memory_async_copy_on_engine(dst, peerAgent, src, copyAgent, size, wait_events.size(),
                                            wait_events.data(), active, copyEngine, forceSDMA);
     } else {
       kUseRegularCopyApi = true;
@@ -585,20 +574,13 @@ inline bool DmaBlitManager::rocrCopyBuffer(address dst, hsa_agent_t& dstAgent, c
   }
 
   if (engine == HwQueueEngine::Unknown || kUseRegularCopyApi) {
-    // For P2P copies using the regular copy API, also need to adjust src_agent
-    hsa_agent_t apiDstAgent = dstAgent;
-    hsa_agent_t apiSrcAgent = srcAgent;
-    if (engine == HwQueueEngine::SdmaP2P) {
-      apiSrcAgent = dev().getBackendDevice();
-    }
-
     ClPrint(amd::LOG_DEBUG, amd::LOG_COPY2,
             "HSA Copy dst=0x%zx, src=0x%zx, size=%ld, wait_event=0x%zx, "
             "completion_signal=0x%zx, engineOp=%s",
             dst, src, size, (wait_events.size() != 0) ? wait_events[0].handle : 0, active.handle,
             EngineOpName(engine));
 
-    status = Hsa::memory_async_copy(dst, apiDstAgent, src, apiSrcAgent, size, wait_events.size(),
+    status = Hsa::memory_async_copy(dst, peerAgent, src, copyAgent, size, wait_events.size(),
                                     wait_events.data(), active);
   }
 


### PR DESCRIPTION
## Motivation

- Regression from https://github.com/ROCm/rocm-systems/pull/4073
- A previous P2P copy fix introduced copyAgent/peerAgent variables to correctly select SDMA engines. However, these variables used in the HSA API calls, breaking the agent semantics that profiling tools rely on.
- https://github.com/ROCm/rocm-systems/actions/runs/23501414502/job/68397260874?pr=2707

## Technical Details

- For H2D (srcAgent == CPU), set:
  `copyAgent = srcAgent (CPU)`
  `peerAgent = dstAgent (GPU)`

- This preserves the intended direction semantics for H2D copies as observed by rocprofv3.

## JIRA ID

N/A

## Test Plan

- Verified with rocprofiler-sdk async-copy-tracing validation tests

## Test Result

- Memory copy direction reporting now matches expected HSA semantics

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
