### PR TITLE
[rocshmem] gda/mlx5: create CQ using DevX API

### DIFF
--- a/projects/rocshmem/src/gda/backend_gda.cpp
+++ b/projects/rocshmem/src/gda/backend_gda.cpp
@@ -799,22 +799,17 @@ void GDABackend::cleanup_ibv() {
     }
   } else if (gda_provider == GDAProvider::MLX5) {
     for (size_t i = 0; i < mlx5_qps.size(); i++) {
-      err = mlx5_qps[i].destroy(mlx5dv);
-      CHECK_ZERO(err, "mlx5_devx_qp::destroy");
-
-      err = ibv.destroy_cq(cqs[i]);
-      CHECK_ZERO(err, "ibv_destroy_cqs");
+      // mlx5dv::destroy_qp also destroys the associated CQ
+      err = mlx5dv.destroy_qp(mlx5_qps[i]);
+      CHECK_ZERO(err, "mlx5dv::destroy_qp");
     }
-
-    err = ibv.dealloc_pd(pd_parent);
-    CHECK_ZERO(err, "ibv_dealloc_pd (pd_parent)");
   } else {
     for (int i = 0; i < qps.size(); i++) {
       err = ibv.destroy_qp(qps[i]);
       CHECK_ZERO(err, "ibv_destroy_qp");
 
       err = ibv.destroy_cq(cqs[i]);
-      CHECK_ZERO(err, "ibv_destroy_cqs");
+      CHECK_ZERO(err, "ibv_destroy_cq");
     }
 
     if (gda_provider == GDAProvider::IONIC) {
@@ -1044,7 +1039,7 @@ void GDABackend::open_ib_device() {
   CHECK_NNULL(pd_orig, "ib allocate pd");
   dump_ibv_pd(pd_orig);
 
-  if (gda_provider == GDAProvider::IONIC || gda_provider == GDAProvider::MLX5) {
+  if (gda_provider == GDAProvider::IONIC) {
     create_parent_domain();
   }
 
@@ -1124,7 +1119,7 @@ void GDABackend::modify_qps_reset_to_init() {
     if (gda_provider == GDAProvider::BNXT) {
       err = bnxt_re_dv.modify_qp(qps[i], &attr, attr_mask, 0, 0);
     } else if (gda_provider == GDAProvider::MLX5) {
-      err = mlx5_qps[i].modify(mlx5dv, &attr, attr_mask, gid_type);
+      err = mlx5dv.modify_qp(mlx5_qps[i], &attr, attr_mask, gid_type);
     } else {
       err = ibv.modify_qp(qps[i], &attr, attr_mask);
     }
@@ -1178,7 +1173,7 @@ void GDABackend::modify_qps_init_to_rtr() {
     if (gda_provider == GDAProvider::BNXT) {
       err = bnxt_re_dv.modify_qp(qps[i], &attr, attr_mask, 0, 0);
     } else if (gda_provider == GDAProvider::MLX5) {
-      err = mlx5_qps[i].modify(mlx5dv, &attr, attr_mask, gid_type);
+      err = mlx5dv.modify_qp(mlx5_qps[i], &attr, attr_mask, gid_type);
     } else {
       err = ibv.modify_qp(qps[i], &attr, attr_mask);
     }
@@ -1216,7 +1211,7 @@ void GDABackend::modify_qps_rtr_to_rts() {
     if (gda_provider == GDAProvider::BNXT) {
       err = bnxt_re_dv.modify_qp(qps[i], &attr, attr_mask, 0, 0);
     } else if (gda_provider == GDAProvider::MLX5) {
-      err = mlx5_qps[i].modify(mlx5dv, &attr, attr_mask, gid_type);
+      err = mlx5dv.modify_qp(mlx5_qps[i], &attr, attr_mask, gid_type);
     } else {
       err = ibv.modify_qp(qps[i], &attr, attr_mask);
     }
@@ -1254,7 +1249,7 @@ void GDABackend::create_queues() {
     ionic_create_cqs(ncqes);
     create_qps(sq_size);
   } else if (gda_provider == GDAProvider::MLX5) {
-    create_cqs(ncqes);
+    // mlx5_create_qps also creates the associated CQs
     mlx5_create_qps(sq_size);
   }
 

--- a/projects/rocshmem/src/gda/mlx5/backend_gda_mlx5.cpp
+++ b/projects/rocshmem/src/gda/mlx5/backend_gda_mlx5.cpp
@@ -48,70 +48,39 @@ int GDABackend::mlx5_dv_dl_init() {
   DLSYM_HELPER(mlx5dv, mlx5dv_, mlx5dv_handle_, devx_obj_create);
   DLSYM_HELPER(mlx5dv, mlx5dv_, mlx5dv_handle_, devx_obj_modify);
   DLSYM_HELPER(mlx5dv, mlx5dv_, mlx5dv_handle_, devx_obj_destroy);
-  DLSYM_HELPER(mlx5dv, mlx5dv_, mlx5dv_handle_, devx_alloc_uar);
-  DLSYM_HELPER(mlx5dv, mlx5dv_, mlx5dv_handle_, devx_free_uar);
   DLSYM_HELPER(mlx5dv, mlx5dv_, mlx5dv_handle_, devx_umem_reg_ex);
   DLSYM_HELPER(mlx5dv, mlx5dv_, mlx5dv_handle_, devx_umem_dereg);
+  DLSYM_HELPER(mlx5dv, mlx5dv_, mlx5dv_handle_, devx_alloc_uar);
+  DLSYM_HELPER(mlx5dv, mlx5dv_, mlx5dv_handle_, devx_free_uar);
+  DLSYM_HELPER(mlx5dv, mlx5dv_, mlx5dv_handle_, devx_query_eqn);
   return ROCSHMEM_SUCCESS;
 }
 
 void GDABackend::mlx5_create_qps(int sq_length) {
-  struct ibv_qp_init_attr_ex attr;
-
   // mlx5 provider can support up to 28B of inline data in a WQE
   inline_threshold = sizeof(gda_mlx5_wqe_inline_data::data);
-
-  memset(&attr, 0, sizeof(struct ibv_qp_init_attr_ex));
-  attr.cap.max_send_wr     = sq_length;
-  attr.cap.max_send_sge    = 1;
-  attr.cap.max_inline_data = inline_threshold;
-  attr.sq_sig_all          = 0;
-  attr.qp_type             = IBV_QPT_RC;
-  attr.comp_mask           = IBV_QP_INIT_ATTR_PD;
-  attr.pd                  = pd_orig;
-
   for (size_t i = 0; i < mlx5_qps.size(); i++) {
-    attr.send_cq = cqs[i];
-    attr.recv_cq = cqs[i];
-
-    int err = mlx5_qps[i].create(mlx5dv, context, &attr);
+    int err = mlx5dv.create_qp(mlx5_qps[i], context, pd_orig, sq_length);
     CHECK_ZERO(err, "mlx5_devx_qp::create");
   }
 }
 
 void GDABackend::mlx5_initialize_gpu_qp(QueuePair* gpu_qp, int conn_num) {
-  mlx5dv_cq cq_out;
-  mlx5dv_obj mlx_obj;
-  mlx_obj.cq.in = cqs[conn_num];
-  mlx_obj.cq.out = &cq_out;
-  mlx5dv.init_obj(&mlx_obj, MLX5DV_OBJ_CQ);
-  dump_mlx5dv_cq(&cq_out, conn_num);
-
-  /*
-   * struct mlx5dv_cq {
-   *   void                    *buf;
-   *   __be32                  *dbrec;
-   *   uint32_t                cqe_cnt;
-   *   uint32_t                cqe_size;
-   *   void                    *cq_uar;
-   *   uint32_t                cqn;
-   *   uint64_t                comp_mask;
-   * };
-   */
-
-  gpu_qp->mlx5_cq = gda_mlx5_device_cq(reinterpret_cast<mlx5_cqe64*>(cq_out.buf), cq_out.dbrec);
-
   mlx5_devx_qp& qp = mlx5_qps[conn_num];
   qp.dump(conn_num);
 
   /*
    * struct mlx5_devx_qp {
-   *   ibv_context       *ctx;
-   *   mlx5dv_devx_obj   *devx_obj;
-   *   mlx5dv_devx_uar   *uar;
+   *   ibv_context*      ctx;
+   *   mlx5dv_devx_obj*  devx_cq_obj;
+   *   mlx5dv_devx_obj*  devx_qp_obj;
+   *   mlx5dv_devx_uar*  uar;
    *   mlx5dv_devx_umem* umem;
+   *   void*             cq;
    *   void*             sq;
-   *   uint32_t          *dbrec;
+   *   uint32_t*         cq_dbrec;
+   *   uint32_t*         qp_dbrec;
+   *   uint32_t          cqn;
    *   uint32_t          qpn;
    *   uint16_t          sq_depth;
    * };
@@ -125,6 +94,8 @@ void GDABackend::mlx5_initialize_gpu_qp(QueuePair* gpu_qp, int conn_num) {
    * };
    */
 
+  gpu_qp->mlx5_cq = gda_mlx5_device_cq(reinterpret_cast<mlx5_cqe64*>(qp.cq), qp.cq_dbrec);
+
   int hip_dev_id{-1};
   CHECK_HIP(hipGetDevice(&hip_dev_id));
   void* gpu_db_ptr{nullptr};
@@ -134,7 +105,7 @@ void GDABackend::mlx5_initialize_gpu_qp(QueuePair* gpu_qp, int conn_num) {
 
   // qp.dbrec points to two __be32 values: RQ dbrec at MLX5_RCV_DBR and SQ dbrec at MLX5_SND_DBR
   gpu_qp->mlx5_sq = gda_mlx5_device_sq{reinterpret_cast<gda_mlx5_wqe*>(qp.sq),
-                                       &qp.dbrec[MLX5_SND_DBR],
+                                       &qp.qp_dbrec[MLX5_SND_DBR],
                                        reinterpret_cast<gda_mlx5_doorbell*>(gpu_db_ptr),
                                        static_cast<uint16_t>(qp.sq_depth)};
 

--- a/projects/rocshmem/src/gda/mlx5/backend_gda_mlx5.cpp
+++ b/projects/rocshmem/src/gda/mlx5/backend_gda_mlx5.cpp
@@ -61,7 +61,7 @@ void GDABackend::mlx5_create_qps(int sq_length) {
   inline_threshold = sizeof(gda_mlx5_wqe_inline_data::data);
   for (size_t i = 0; i < mlx5_qps.size(); i++) {
     int err = mlx5dv.create_qp(mlx5_qps[i], context, pd_orig, sq_length);
-    CHECK_ZERO(err, "mlx5_devx_qp::create");
+    CHECK_ZERO(err, "mlx5dv::create_qp");
   }
 }
 

--- a/projects/rocshmem/src/gda/mlx5/mlx5_ifc_core.hpp
+++ b/projects/rocshmem/src/gda/mlx5/mlx5_ifc_core.hpp
@@ -45,6 +45,10 @@
 extern "C" {
 
 enum {
+  MLX5_CMD_OP_CREATE_CQ     = 0x400,
+  MLX5_CMD_OP_DESTROY_CQ    = 0x401,
+  MLX5_CMD_OP_QUERY_CQ      = 0x402,
+  MLX5_CMD_OP_MODIFY_CQ     = 0x403,
   MLX5_CMD_OP_CREATE_QP     = 0x500,
   MLX5_CMD_OP_DESTROY_QP    = 0x501,
   MLX5_CMD_OP_RST2INIT_QP   = 0x502,
@@ -410,6 +414,152 @@ struct mlx5_ifc_qpc_bits {
     uint8_t    rdma_key[0x20];
 
     uint8_t    dbr_umem_id[0x20];
+};
+
+enum {
+  MLX5_CQC_STATUS_OK             = 0x0,
+  MLX5_CQC_STATUS_CQ_OVERFLOW    = 0x9,
+  MLX5_CQC_STATUS_CQ_WRITE_FAIL  = 0xa,
+};
+
+enum {
+  MLX5_CQC_CQE_SZ_64_BYTES   = 0x0,
+  MLX5_CQC_CQE_SZ_128_BYTES  = 0x1,
+};
+
+enum {
+  MLX5_CQC_ST_SOLICITED_NOTIFICATION_REQUEST_ARMED  = 0x6,
+  MLX5_CQC_ST_NOTIFICATION_REQUEST_ARMED            = 0x9,
+  MLX5_CQC_ST_FIRED                                 = 0xa,
+};
+
+enum mlx5_cq_period_mode {
+  MLX5_CQ_PERIOD_MODE_START_FROM_EQE = 0x0,
+  MLX5_CQ_PERIOD_MODE_START_FROM_CQE = 0x1,
+  MLX5_CQ_PERIOD_NUM_MODES,
+};
+
+struct mlx5_ifc_cqc_bits {
+    uint8_t    status[0x4];
+    uint8_t    as_notify[0x1];
+    uint8_t    initiator_src_dct[0x1];
+    uint8_t    dbr_umem_valid[0x1];
+    uint8_t    ext_element[0x1];
+    uint8_t    cqe_sz[0x3];
+    uint8_t    cc[0x1];
+    uint8_t    reserved_at_c[0x1];
+    uint8_t    scqe_break_moderation_en[0x1];
+    uint8_t    oi[0x1];
+    uint8_t    cq_period_mode[0x2];
+    uint8_t    cqe_comp_en[0x1];
+    uint8_t    mini_cqe_res_format[0x2];
+    uint8_t    st[0x4];
+    uint8_t    always_armed_cq[0x1];
+    uint8_t    ext_element_type[0x3];
+    uint8_t    reserved_at_1c[0x2];
+    uint8_t    cqe_compression_layout[0x2];
+
+    uint8_t    dbr_umem_id[0x20];
+
+    uint8_t    reserved_at_40[0x14];
+    uint8_t    page_offset[0x6];
+    uint8_t    reserved_at_5a[0x2];
+    uint8_t    mini_cqe_res_format_ext[0x2];
+    uint8_t    cq_timestamp_format[0x2];
+
+    uint8_t    reserved_at_60[0x3];
+    uint8_t    log_cq_size[0x5];
+    uint8_t    uar_page[0x18];
+
+    uint8_t    reserved_at_80[0x4];
+    uint8_t    cq_period[0xc];
+    uint8_t    cq_max_count[0x10];
+
+    uint8_t    c_eqn_or_ext_element[0x20];
+
+    uint8_t    reserved_at_c0[0x3];
+    uint8_t    log_page_size[0x5];
+    uint8_t    reserved_at_c8[0x18];
+
+    uint8_t    reserved_at_e0[0x20];
+
+    uint8_t    reserved_at_100[0x8];
+    uint8_t    last_notified_index[0x18];
+
+    uint8_t    reserved_at_120[0x8];
+    uint8_t    last_solicit_index[0x18];
+
+    uint8_t    reserved_at_140[0x8];
+    uint8_t    consumer_counter[0x18];
+
+    uint8_t    reserved_at_160[0x8];
+    uint8_t    producer_counter[0x18];
+
+    uint8_t    local_partition_id[0xc];
+    uint8_t    process_id[0x14];
+
+    uint8_t    reserved_at_1a0[0x10];
+    uint8_t    thread_id[0x10];
+
+    uint8_t    dbr_addr[0x40];
+};
+
+struct mlx5_ifc_create_cq_out_bits {
+    uint8_t    status[0x8];
+    uint8_t    reserved_at_8[0x18];
+
+    uint8_t    syndrome[0x20];
+
+    uint8_t    reserved_at_40[0x8];
+    uint8_t    cqn[0x18];
+
+    uint8_t    reserved_at_60[0x20];
+};
+
+struct mlx5_ifc_create_cq_in_bits {
+    uint8_t    opcode[0x10];
+    uint8_t    uid[0x10];
+
+    uint8_t    reserved_at_20[0x10];
+    uint8_t    op_mod[0x10];
+
+    uint8_t    reserved_at_40[0x8];
+    uint8_t    input_cqn[0x18];
+
+    uint8_t    reserved_at_60[0x20];
+
+    struct mlx5_ifc_cqc_bits cq_context;
+
+    uint8_t    cq_umem_offset[0x40];
+
+    uint8_t    cq_umem_id[0x20];
+
+    uint8_t    cq_umem_valid[0x1];
+    uint8_t    reserved_at_2e1[0x59f];
+
+    uint8_t    pas[][0x40];
+};
+
+struct mlx5_ifc_destroy_cq_out_bits {
+    uint8_t    status[0x8];
+    uint8_t    reserved_at_8[0x18];
+
+    uint8_t    syndrome[0x20];
+
+    uint8_t    reserved_at_40[0x40];
+};
+
+struct mlx5_ifc_destroy_cq_in_bits {
+    uint8_t    opcode[0x10];
+    uint8_t    uid[0x10];
+
+    uint8_t    reserved_at_20[0x10];
+    uint8_t    op_mod[0x10];
+
+    uint8_t    reserved_at_40[0x8];
+    uint8_t    cqn[0x18];
+
+    uint8_t    reserved_at_60[0x20];
 };
 
 enum mlx5_qp_optpar {

--- a/projects/rocshmem/src/gda/mlx5/provider_gda_mlx5.cpp
+++ b/projects/rocshmem/src/gda/mlx5/provider_gda_mlx5.cpp
@@ -439,7 +439,7 @@ static int mlx5_create_cq(const mlx5dv_funcs_t& mlx5dv, mlx5_devx_qp& qp) {
 
   // create CQ
   qp.devx_cq_obj = mlx5dv.devx_obj_create(qp.ctx, in, sizeof(in), out, sizeof(out));
-  CHECK_NNULL(qp.devx_cq_obj, "mlx5dv_devx_obj_create (QP)");
+  CHECK_NNULL(qp.devx_cq_obj, "mlx5dv_devx_obj_create (CQ)");
   // extract CQ number
   qp.cqn = DEVX_GET(create_cq_out, out, cqn);
 

--- a/projects/rocshmem/src/gda/mlx5/provider_gda_mlx5.cpp
+++ b/projects/rocshmem/src/gda/mlx5/provider_gda_mlx5.cpp
@@ -635,7 +635,10 @@ void mlx5_devx_qp::dump(int conn_num) {
   DPRINTF("  (uint32_t)  qpn              = 0x%x\n",  this->qpn);
   DPRINTF("  (void*)     sq               = %p\n",    this->sq);
   DPRINTF("  (uint16_t)  sq_depth         = %hu\n",   this->sq_depth);
-  DPRINTF("  (uint32_t*) dbrec            = %p\n",    this->dbrec);
+  DPRINTF("  (uint32_t*) qp_dbrec         = %p\n",    this->qp_dbrec);
+  DPRINTF("  (uint32_t)  cqn              = 0x%x\n",  this->cqn);
+  DPRINTF("  (void*)     cq               = %p\n",    this->cq);
+  DPRINTF("  (uint32_t*) cq_dbrec         = %p\n",    this->cq_dbrec);
   DPRINTF("  (void*)     uar->reg_addr    = %p\n",    this->uar->reg_addr);
   DPRINTF("  (void*)     uar->base_addr   = %p\n",    this->uar->base_addr);
   DPRINTF("  (uint32_t)  uar->page_id     = 0x%x\n",  this->uar->page_id);

--- a/projects/rocshmem/src/gda/mlx5/provider_gda_mlx5.cpp
+++ b/projects/rocshmem/src/gda/mlx5/provider_gda_mlx5.cpp
@@ -128,11 +128,11 @@ static constexpr inline auto mlx5_align_page(const T& value) {
 }
 
 struct mlx5_qp_umem_alloc_info {
-  size_t   umem_size       = 0;
-  size_t   wq_size         = 0;
-  size_t   cq_offset       = 0;
-  size_t   qp_dbrec_offset = 0;
-  size_t   cq_dbrec_offset = 0;
+  size_t   umem_size;
+  size_t   wq_size;
+  size_t   cq_offset;
+  size_t   qp_dbrec_offset;
+  size_t   cq_dbrec_offset;
   uint16_t sq_depth;
 
   // WQ always at beginning of umem allocation
@@ -143,9 +143,10 @@ struct mlx5_qp_umem_alloc_info {
   static constexpr size_t qp_dbrec_size = mlx5_align_amdgpu_cache_line(MLX5_DOORBELL_RECORD_SIZE);
   static constexpr size_t cq_dbrec_size = mlx5_align_amdgpu_cache_line(MLX5_DOORBELL_RECORD_SIZE);
 
-  mlx5_qp_umem_alloc_info(uint16_t sq_depth) : sq_depth{sq_depth} {
+  mlx5_qp_umem_alloc_info(uint16_t sq_depth_requested)
+    : umem_size{0}, wq_size{0}, cq_offset{0}, qp_dbrec_offset{0}, cq_dbrec_offset{0}, sq_depth{0} {
     // round work queue size up to power of 2 WQEBB, then align to cache line size
-    size_t wq_size_initial = mlx5_align_amdgpu_cache_line(bit_ceil(sq_depth) * MLX5_SEND_WQE_BB);
+    size_t wq_size_initial = mlx5_align_amdgpu_cache_line(bit_ceil(sq_depth_requested) * MLX5_SEND_WQE_BB);
     // round up to page size
     umem_size = mlx5_align_page(wq_size_initial + cq_size + qp_dbrec_size + cq_dbrec_size);
     // round back down to a power of 2

--- a/projects/rocshmem/src/gda/mlx5/provider_gda_mlx5.cpp
+++ b/projects/rocshmem/src/gda/mlx5/provider_gda_mlx5.cpp
@@ -22,7 +22,9 @@
  * IN THE SOFTWARE.
  *****************************************************************************/
 
+#include <cstring>
 #include <limits>
+#include <type_traits>
 #include <hip/hip_runtime.h>
 
 #include "util.hpp"
@@ -34,6 +36,8 @@
 
 namespace rocshmem {
 
+using create_cq_in    = uint8_t[DEVX_ST_SZ_BYTES(create_cq_in)   ];
+using create_cq_out   = uint8_t[DEVX_ST_SZ_BYTES(create_cq_out)  ];
 using create_qp_in    = uint8_t[DEVX_ST_SZ_BYTES(create_qp_in)   ];
 using create_qp_out   = uint8_t[DEVX_ST_SZ_BYTES(create_qp_out)  ];
 using rst2init_qp_in  = uint8_t[DEVX_ST_SZ_BYTES(rst2init_qp_in) ];
@@ -43,11 +47,14 @@ using init2rtr_qp_out = uint8_t[DEVX_ST_SZ_BYTES(init2rtr_qp_out)];
 using rtr2rts_qp_in   = uint8_t[DEVX_ST_SZ_BYTES(rtr2rts_qp_in)  ];
 using rtr2rts_qp_out  = uint8_t[DEVX_ST_SZ_BYTES(rtr2rts_qp_out) ];
 
-static int mlx5_modify_qp_reset2init(const mlx5dv_funcs_t& mlx5dv, mlx5_devx_qp* qp,
+static int mlx5_create_cq(const mlx5dv_funcs_t& mlx5dv, mlx5_devx_qp& qp);
+static int mlx5_create_qp(const mlx5dv_funcs_t& mlx5dv, mlx5_devx_qp& qp, struct ibv_pd *pd);
+
+static int mlx5_modify_qp_reset2init(const mlx5dv_funcs_t& mlx5dv, mlx5_devx_qp& qp,
                                      struct ibv_qp_attr* attr, int attr_mask);
-static int mlx5_modify_qp_init2rtr(const mlx5dv_funcs_t& mlx5dv, mlx5_devx_qp* qp,
+static int mlx5_modify_qp_init2rtr(const mlx5dv_funcs_t& mlx5dv, mlx5_devx_qp& qp,
                                    struct ibv_qp_attr* attr, int attr_mask, uint32_t gid_type);
-static int mlx5_modify_qp_rtr2rts(const mlx5dv_funcs_t& mlx5dv, mlx5_devx_qp* qp,
+static int mlx5_modify_qp_rtr2rts(const mlx5dv_funcs_t& mlx5dv, mlx5_devx_qp& qp,
                                   struct ibv_qp_attr* attr, int attr_mask);
 
 struct hipGDAHostAllocator {
@@ -60,6 +67,10 @@ struct hipGDAHostAllocator {
 
   static void free(void* ptr) {
     CHECK_HIP(hipFree(ptr));
+  }
+
+  static void* memset(void* dest, int ch, size_t count) {
+    return std::memset(dest, ch, count);
   }
 };
 
@@ -74,6 +85,11 @@ struct hipGDAUncachedAllocator {
   static void free(void* ptr) {
     CHECK_HIP(hipFree(ptr));
   }
+
+  static void* memset(void* dest, int ch, size_t count) {
+    CHECK_HIP(hipMemset(dest, ch, count));
+    return dest;
+  }
 };
 
 using QPAllocator = hipGDAHostAllocator;
@@ -85,38 +101,81 @@ static inline bool is_device_ptr(const void* ptr) {
 }
 
 template <typename T>
-static constexpr inline size_t mlx5_align_amdgpu_cache_line(const T& value) {
-  // different cache levels can have different cache line sizes; varies by GPU arch as well
-  // L2$ is 128B on CDNA2, CDNA3, and CDNA4, so use that for now
-  constexpr size_t amdgpu_cache_line_size = 128;
-  return __builtin_align_up(value, amdgpu_cache_line_size);
+static constexpr inline auto mlx5_align_up(const T& value, size_t alignment) {
+  // helper function to align a pointer or integer to the specified alignment, rounding up
+  if constexpr (std::is_enum_v<T>) {
+    // __builtin_align_up doesn't like it when T is an enum, so use the underlying type
+    return __builtin_align_up(static_cast<std::underlying_type_t<T>>(value), alignment);
+  } else {
+    return __builtin_align_up(value, alignment);
+  }
 }
 
 template <typename T>
-static constexpr inline size_t mlx5_align_page(const T& value) {
+static constexpr inline auto mlx5_align_amdgpu_cache_line(const T& value) {
+  // different cache levels can have different cache line sizes; varies by GPU arch as well
+  // L2$ is 128B on CDNA2, CDNA3, and CDNA4, so use that for now
+  constexpr size_t amdgpu_cache_line_size = 128;
+  return mlx5_align_up(value, amdgpu_cache_line_size);
+}
+
+template <typename T>
+static constexpr inline auto mlx5_align_page(const T& value) {
   // mlx5 HCA counts pages in 4 KiB chunks, but supports larger host page sizes
   // amdgpu page size is not well-documented, but should at least support 4 KiB pages
   constexpr size_t mlx5_page_size = MLX5_ADAPTER_PAGE_SIZE;
-  return __builtin_align_up(value, mlx5_page_size);
+  return mlx5_align_up(value, mlx5_page_size);
 }
 
-static inline size_t mlx5_calc_qp_umem_size(uint16_t& sq_depth,
-                                            size_t& wq_size,
-                                            size_t& dbrec_offset) {
-  // align doorbell record to cache line size
-  constexpr size_t dbrec_size = mlx5_align_amdgpu_cache_line<size_t>(MLX5_DOORBELL_RECORD_SIZE);
-  // round up to power of 2 WQEBB
-  size_t wq_size_initial = bit_ceil(sq_depth) * MLX5_SEND_WQE_BB;
-  // round up to page size
-  size_t umem_size = mlx5_align_page(wq_size_initial + dbrec_size);
-  // doorbell record in last cache line of umem allocation
-  dbrec_offset = umem_size - dbrec_size;
-  // round back down to a power of 2
-  wq_size = bit_floor(umem_size - dbrec_size);
-  // compute WQEBB count
-  sq_depth = wq_size / MLX5_SEND_WQE_BB;
-  return umem_size;
-}
+struct mlx5_qp_umem_alloc_info {
+  size_t   umem_size       = 0;
+  size_t   wq_size         = 0;
+  size_t   cq_offset       = 0;
+  size_t   qp_dbrec_offset = 0;
+  size_t   cq_dbrec_offset = 0;
+  uint16_t sq_depth;
+
+  // WQ always at beginning of umem allocation
+  static constexpr size_t wq_offset = 0;
+
+  // align CQ and doorbell records to cache line size
+  static constexpr size_t cq_size       = mlx5_align_amdgpu_cache_line(sizeof(mlx5_cqe64[2]));
+  static constexpr size_t qp_dbrec_size = mlx5_align_amdgpu_cache_line(MLX5_DOORBELL_RECORD_SIZE);
+  static constexpr size_t cq_dbrec_size = mlx5_align_amdgpu_cache_line(MLX5_DOORBELL_RECORD_SIZE);
+
+  mlx5_qp_umem_alloc_info(uint16_t sq_depth) : sq_depth{sq_depth} {
+    // round work queue size up to power of 2 WQEBB, then align to cache line size
+    size_t wq_size_initial = mlx5_align_amdgpu_cache_line(bit_ceil(sq_depth) * MLX5_SEND_WQE_BB);
+    // round up to page size
+    umem_size = mlx5_align_page(wq_size_initial + cq_size + qp_dbrec_size + cq_dbrec_size);
+    // round back down to a power of 2
+    wq_size = bit_floor(umem_size - cq_size - qp_dbrec_size - cq_dbrec_size);
+    // CQ directly after WQ in umem allocation
+    cq_offset = wq_size;
+    // QP doorbell record in second-to-last cache line of umem allocation
+    qp_dbrec_offset = umem_size - qp_dbrec_size - cq_dbrec_size;
+    // CQ doorbell record in last cache line of umem allocation
+    cq_dbrec_offset = umem_size - cq_dbrec_size;
+    // compute WQEBB count
+    sq_depth = wq_size / MLX5_SEND_WQE_BB;
+  }
+
+  inline void* wq_addr(void* umem_buffer) {
+    return reinterpret_cast<uint8_t*>(umem_buffer) + wq_offset;
+  }
+
+  inline void* cq_addr(void* umem_buffer) {
+    return reinterpret_cast<uint8_t*>(umem_buffer) + cq_offset;
+  }
+
+  inline uint32_t* qp_dbrec_addr(void* umem_buffer) {
+    return reinterpret_cast<uint32_t*>(reinterpret_cast<uint8_t*>(umem_buffer) + qp_dbrec_offset);
+  }
+
+  inline uint32_t* cq_dbrec_addr(void* umem_buffer) {
+    return reinterpret_cast<uint32_t*>(reinterpret_cast<uint8_t*>(umem_buffer) + cq_dbrec_offset);
+  }
+};
 
 static inline mlx5dv_devx_umem* mlx5_umem_reg(const mlx5dv_funcs_t& mlx5dv,
                                               struct ibv_context *ctx, void* addr, size_t size) {
@@ -148,20 +207,19 @@ static inline mlx5dv_devx_umem* mlx5_umem_reg(const mlx5dv_funcs_t& mlx5dv,
   return umem;
 }
 
+static inline void mlx5_initialize_cq_buffer(mlx5_cqe64* cq, uint32_t cq_depth) {
+  // CQEs must have opcode set to Invalid = 0xF and be in hardware ownership
+  constexpr uint8_t op_own_init = (MLX5_CQE_INVALID << 4) | MLX5_CQE_OWNER_MASK;
+  // simplest way is to set all bytes in the CQ to op_own_init = 0xF1
+  QPAllocator::memset(cq, op_own_init, sizeof(mlx5_cqe64) * cq_depth);
+}
+
 static inline uint32_t mlx5_pdn(const mlx5dv_funcs_t& mlx5dv, struct ibv_pd *pd) {
   mlx5dv_pd mlx5_pd;
   mlx5dv_obj obj{ .pd = { .in = pd, .out = &mlx5_pd } };
   int err = mlx5dv.init_obj(&obj, MLX5DV_OBJ_PD);
   CHECK_ZERO(err, "mlx5dv_init_obj (PD)");
   return mlx5_pd.pdn;
-}
-
-static inline uint32_t mlx5_cqn(const mlx5dv_funcs_t& mlx5dv, struct ibv_cq *cq) {
-  mlx5dv_cq mlx5_cq;
-  mlx5dv_obj obj{ .cq = { .in = cq, .out = &mlx5_cq } };
-  int err = mlx5dv.init_obj(&obj, MLX5DV_OBJ_CQ);
-  CHECK_ZERO(err, "mlx5dv_init_obj (CQ)");
-  return mlx5_cq.cqn;
 }
 
 // these are technically identical, but for completeness
@@ -233,27 +291,26 @@ static inline uint32_t mlx5_calc_flow_label(uint32_t local_qpn, uint32_t remote_
   return static_cast<uint32_t>(v & IB_GRH_FLOWLABEL_MASK);
 }
 
-int mlx5_devx_qp::create(const mlx5dv_funcs_t& mlx5dv, struct ibv_context *ctx,
-                         struct ibv_qp_init_attr_ex *attr) {
-  assert(attr->cap.max_send_wr > 0 && "ibv_qp_init_attr_ex::cap::max_send_wr is 0");
-  create_qp_in  in  = {0};
-  create_qp_out out = {0};
+int mlx5dv_funcs_t::create_qp(mlx5_devx_qp& qp, struct ibv_context *ctx,
+                              struct ibv_pd* pd, uint16_t sq_depth) {
+  const mlx5dv_funcs_t& mlx5dv = *this;
+  int err = 0;
 
-  void* qpc = DEVX_ADDR_OF(create_qp_in, in, qpc);
+  qp.ctx = ctx;
 
-  uint32_t pdn = mlx5_pdn(mlx5dv, attr->pd);
-  uint32_t cqn = mlx5_cqn(mlx5dv, attr->send_cq);
+  // calculate buffer size needed for WQ + CQ + QP dbrec + CQ dbrec
+  mlx5_qp_umem_alloc_info umem_alloc_info{sq_depth};
+  // allocate buffer for WQ + CQ + QP dbrec + CQ dbrec
+  void* umem_buffer = QPAllocator::malloc(umem_alloc_info.umem_size);
+  // register buffer for WQ + CQ + QP dbrec + CQ dbrec
+  qp.umem = mlx5_umem_reg(mlx5dv, ctx, umem_buffer, umem_alloc_info.umem_size);
 
-  // calculate buffer size needed for SQ + dbrec
-  uint16_t sq_depth = attr->cap.max_send_wr;
-  size_t wq_size = 0;
-  size_t dbrec_offset = 0;
-  size_t umem_size = mlx5_calc_qp_umem_size(sq_depth, wq_size, dbrec_offset);
-
-  // allocate SQ + dbrec buffer
-  void* umem_buffer = QPAllocator::malloc(umem_size);
-  // register SQ + dbrec buffer
-  mlx5dv_devx_umem* umem = mlx5_umem_reg(mlx5dv, ctx, umem_buffer, umem_size);
+  // set addresses and SQ depth
+  qp.sq       = umem_alloc_info.wq_addr(umem_buffer);
+  qp.cq       = umem_alloc_info.cq_addr(umem_buffer);
+  qp.cq_dbrec = umem_alloc_info.cq_dbrec_addr(umem_buffer);
+  qp.qp_dbrec = umem_alloc_info.qp_dbrec_addr(umem_buffer);
+  qp.sq_depth = umem_alloc_info.sq_depth;
 
   /* allocate UAR
    *
@@ -262,56 +319,24 @@ int mlx5_devx_qp::create(const mlx5dv_funcs_t& mlx5dv, struct ibv_context *ctx,
    * MLX5DV_UAR_ALLOC_TYPE_NC_DEDICATED dynamically allocates a UAR page, but these are limited
    * using MLX5DV_UAR_ALLOC_TYPE_NC_DEDICATED requires rdma-core v45 or later (released March 2023)
    * see https://github.com/linux-rdma/rdma-core/commit/bf550b9fa83374cfed51330760a583d82a7600f4 */
-  mlx5dv_devx_uar* uar = mlx5dv.devx_alloc_uar(ctx, MLX5DV_UAR_ALLOC_TYPE_NC_DEDICATED);
-  CHECK_NNULL(uar, "mlx5dv_devx_alloc_uar");
+  qp.uar = mlx5dv.devx_alloc_uar(ctx, MLX5DV_UAR_ALLOC_TYPE_NC_DEDICATED);
+  CHECK_NNULL(qp.uar, "mlx5dv_devx_alloc_uar");
 
-  DEVX_SET(create_qp_in, in, opcode, MLX5_CMD_OP_CREATE_QP);
-
-  DEVX_SET(qpc, qpc, st,          MLX5_QPC_ST_RC);
-  DEVX_SET(qpc, qpc, pm_state,    MLX5_QPC_PM_STATE_MIGRATED);
-  DEVX_SET(qpc, qpc, pd,          pdn);
-  DEVX_SET(qpc, qpc, uar_page,    uar->page_id);
-  DEVX_SET(qpc, qpc, log_sq_size, bit_log2(sq_depth));
-  DEVX_SET(qpc, qpc, rq_type,     MLX5_QPC_RQ_TYPE_ZERO_LEN_RQ);
-  DEVX_SET(qpc, qpc, cqn_snd,     cqn);
-
-  // disable scatter CQE to requester, responder
-  DEVX_SET(qpc, qpc, cs_req, MLX5_QPC_CS_REQ_DISABLE);
-  DEVX_SET(qpc, qpc, cs_res, MLX5_QPC_CS_RES_DISABLE);
-
-  // set dbrec umem attributes, dbr_addr is offset into umem when umem_valid
-  DEVX_SET64(qpc, qpc, dbr_addr,       dbrec_offset);
-  DEVX_SET  (qpc, qpc, dbr_umem_valid, true);
-  DEVX_SET  (qpc, qpc, dbr_umem_id,    umem->umem_id);
-
-  // set WQ umem attributes, SQ is at the start of the umem buffer
-  DEVX_SET64(create_qp_in, in, wq_umem_offset, 0);
-  DEVX_SET(  create_qp_in, in, wq_umem_id,     umem->umem_id);
-  DEVX_SET(  create_qp_in, in, wq_umem_valid,  true);
+  // create CQ
+  err = mlx5_create_cq(mlx5dv, qp);
+  CHECK_ZERO(err, "mlx5_create_cq");
 
   // create QP
-  mlx5dv_devx_obj* devx_obj = mlx5dv.devx_obj_create(ctx, in, sizeof(in), out, sizeof(out));
-  CHECK_NNULL(devx_obj, "mlx5dv_devx_obj_create (QP)");
+  err = mlx5_create_qp(mlx5dv, qp, pd);
+  CHECK_ZERO(err, "mlx5_create_qp");
 
-  // extract QP number
-  uint32_t qpn = DEVX_GET(create_qp_out, out, qpn);
-
-  // set the object's fields
-  this->ctx       = ctx;
-  this->devx_obj  = devx_obj;
-  this->uar       = uar;
-  this->umem      = umem;
-  this->sq        = umem_buffer;
-  this->dbrec     = reinterpret_cast<uint32_t*>(
-      reinterpret_cast<uint8_t*>(umem_buffer) + dbrec_offset);
-  this->qpn       = qpn;
-  this->sq_depth  = sq_depth;
-
-  return 0;
+  return err;
 }
 
-int mlx5_devx_qp::modify(const mlx5dv_funcs_t& mlx5dv, struct ibv_qp_attr *attr, int attr_mask,
-                         uint32_t gid_type) {
+int mlx5dv_funcs_t::modify_qp(mlx5_devx_qp& qp, struct ibv_qp_attr *attr, int attr_mask,
+                              uint32_t gid_type) {
+  const mlx5dv_funcs_t& mlx5dv = *this;
+
   // check attr->qp_state is valid
   if (!(attr_mask & IBV_QP_STATE)) {
     assert(false && "invalid attr_mask");
@@ -321,11 +346,11 @@ int mlx5_devx_qp::modify(const mlx5dv_funcs_t& mlx5dv, struct ibv_qp_attr *attr,
   // assume QP is in correct state for transition
   switch (attr->qp_state) {
   case IBV_QPS_INIT:
-    return mlx5_modify_qp_reset2init(mlx5dv, this, attr, attr_mask);
+    return mlx5_modify_qp_reset2init(mlx5dv, qp, attr, attr_mask);
   case IBV_QPS_RTR:
-    return mlx5_modify_qp_init2rtr(mlx5dv, this, attr, attr_mask, gid_type);
+    return mlx5_modify_qp_init2rtr(mlx5dv, qp, attr, attr_mask, gid_type);
   case IBV_QPS_RTS:
-    return mlx5_modify_qp_rtr2rts(mlx5dv, this, attr, attr_mask);
+    return mlx5_modify_qp_rtr2rts(mlx5dv, qp, attr, attr_mask);
   case IBV_QPS_RESET:
   case IBV_QPS_SQD:
   case IBV_QPS_SQE:
@@ -338,7 +363,131 @@ int mlx5_devx_qp::modify(const mlx5dv_funcs_t& mlx5dv, struct ibv_qp_attr *attr,
   }
 }
 
-static int mlx5_modify_qp_reset2init(const mlx5dv_funcs_t& mlx5dv, mlx5_devx_qp* qp,
+int mlx5dv_funcs_t::destroy_qp(mlx5_devx_qp& qp) {
+  const mlx5dv_funcs_t& mlx5dv = *this;
+  int err = 0;
+
+  err = mlx5dv.devx_obj_destroy(qp.devx_qp_obj);
+  CHECK_ZERO(err, "mlx5dv_devx_obj_destroy (QP)");
+
+  err = mlx5dv.devx_obj_destroy(qp.devx_cq_obj);
+  CHECK_ZERO(err, "mlx5dv_devx_obj_destroy (CQ)");
+
+  // mlx5dv_devx_free_uar returns void, can't check for errors
+  mlx5dv.devx_free_uar(qp.uar);
+
+  err = mlx5dv.devx_umem_dereg(qp.umem);
+  CHECK_ZERO(err, "mlx5dv_devx_umem_dereg");
+
+  QPAllocator::free(qp.sq);
+
+  // clear the object's fields
+  qp.ctx         = nullptr;
+  qp.devx_cq_obj = nullptr;
+  qp.devx_qp_obj = nullptr;
+  qp.uar         = nullptr;
+  qp.umem        = nullptr;
+  qp.cq          = nullptr;
+  qp.sq          = nullptr;
+  qp.cq_dbrec    = nullptr;
+  qp.qp_dbrec    = nullptr;
+  qp.cqn         = 0;
+  qp.qpn         = 0;
+  qp.sq_depth    = 0;
+
+  return err;
+}
+
+static int mlx5_create_cq(const mlx5dv_funcs_t& mlx5dv, mlx5_devx_qp& qp) {
+  int err = 0;
+
+  create_cq_in  in  = {0};
+  create_cq_out out = {0};
+
+  void* cqc = DEVX_ADDR_OF(create_cq_in, in, cq_context);
+
+  DEVX_SET(create_cq_in, in, opcode, MLX5_CMD_OP_CREATE_CQ);
+
+  // use CQ length 2 until we enable true 1-CQE/collapsed CQ
+  constexpr uint32_t cq_depth = 2;
+  mlx5_initialize_cq_buffer(reinterpret_cast<mlx5_cqe64*>(qp.cq), cq_depth);
+
+  // get EQN, we don't use it but it needs to be set when creating the CQ
+  uint32_t eqn = 0;
+  err = mlx5dv.devx_query_eqn(qp.ctx, /* vector */ 0, &eqn);
+  CHECK_ZERO(err, "mlx5dv_devx_query_eqn");
+
+  DEVX_SET(cqc, cqc, cqe_sz,               MLX5_CQC_CQE_SZ_64_BYTES);
+  // set overrun ignore so that we don't need to ring the CQ doorbell
+  DEVX_SET(cqc, cqc, oi,                   true);
+  DEVX_SET(cqc, cqc, log_cq_size,          bit_log2(cq_depth));
+  // we don't ring the CQ doorbell anyway
+  DEVX_SET(cqc, cqc, uar_page,             qp.uar->page_id);
+  DEVX_SET(cqc, cqc, c_eqn_or_ext_element, eqn);
+  // TODO: check system page size instead of assuming 4 KiB
+  DEVX_SET(cqc, cqc, log_page_size,        MLX5_ADAPTER_PAGE_SHIFT - MLX5_ADAPTER_PAGE_SHIFT);
+
+  // set dbrec umem attributes, dbr_addr is offset into umem when umem_valid
+  DEVX_SET  (cqc, cqc, dbr_umem_valid, true);
+  DEVX_SET  (cqc, cqc, dbr_umem_id,    qp.umem->umem_id);
+  DEVX_SET64(cqc, cqc, dbr_addr,       qp.cq_dbrec_offset());
+
+  // set CQ umem attributes, CQ is after WQ in the umem buffer
+  DEVX_SET64(create_cq_in, in, cq_umem_offset, qp.cq_offset());
+  DEVX_SET(  create_cq_in, in, cq_umem_id,     qp.umem->umem_id);
+  DEVX_SET(  create_cq_in, in, cq_umem_valid,  true);
+
+  // create CQ
+  qp.devx_cq_obj = mlx5dv.devx_obj_create(qp.ctx, in, sizeof(in), out, sizeof(out));
+  CHECK_NNULL(qp.devx_cq_obj, "mlx5dv_devx_obj_create (QP)");
+  // extract CQ number
+  qp.cqn = DEVX_GET(create_cq_out, out, cqn);
+
+  return err;
+}
+
+static int mlx5_create_qp(const mlx5dv_funcs_t& mlx5dv, mlx5_devx_qp& qp, struct ibv_pd *pd) {
+  create_qp_in  in  = {0};
+  create_qp_out out = {0};
+
+  void* qpc = DEVX_ADDR_OF(create_qp_in, in, qpc);
+
+  DEVX_SET(create_qp_in, in, opcode, MLX5_CMD_OP_CREATE_QP);
+
+  DEVX_SET(qpc, qpc, st,            MLX5_QPC_ST_RC);
+  DEVX_SET(qpc, qpc, pm_state,      MLX5_QPC_PM_STATE_MIGRATED);
+  DEVX_SET(qpc, qpc, pd,            mlx5_pdn(mlx5dv, pd));
+  DEVX_SET(qpc, qpc, log_sq_size,   bit_log2(qp.sq_depth));
+  DEVX_SET(qpc, qpc, uar_page,      qp.uar->page_id);
+  // TODO: check system page size instead of assuming 4 KiB
+  DEVX_SET(qpc, qpc, log_page_size, MLX5_ADAPTER_PAGE_SHIFT - MLX5_ADAPTER_PAGE_SHIFT);
+  DEVX_SET(qpc, qpc, cqn_snd,       qp.cqn);
+  DEVX_SET(qpc, qpc, rq_type,       MLX5_QPC_RQ_TYPE_ZERO_LEN_RQ);
+
+  // disable scatter CQE to requester, responder
+  DEVX_SET(qpc, qpc, cs_req, MLX5_QPC_CS_REQ_DISABLE);
+  DEVX_SET(qpc, qpc, cs_res, MLX5_QPC_CS_RES_DISABLE);
+
+  // set dbrec umem attributes, dbr_addr is offset into umem when umem_valid
+  DEVX_SET64(qpc, qpc, dbr_addr,       qp.qp_dbrec_offset());
+  DEVX_SET  (qpc, qpc, dbr_umem_valid, true);
+  DEVX_SET  (qpc, qpc, dbr_umem_id,    qp.umem->umem_id);
+
+  // set WQ umem attributes, SQ is at the start of the umem buffer
+  DEVX_SET64(create_qp_in, in, wq_umem_offset, qp.wq_offset());
+  DEVX_SET(  create_qp_in, in, wq_umem_id,     qp.umem->umem_id);
+  DEVX_SET(  create_qp_in, in, wq_umem_valid,  true);
+
+  // create QP
+  qp.devx_qp_obj = mlx5dv.devx_obj_create(qp.ctx, in, sizeof(in), out, sizeof(out));
+  CHECK_NNULL(qp.devx_qp_obj, "mlx5dv_devx_obj_create (QP)");
+  // extract QP number
+  qp.qpn = DEVX_GET(create_qp_out, out, qpn);
+
+  return 0;
+}
+
+static int mlx5_modify_qp_reset2init(const mlx5dv_funcs_t& mlx5dv, mlx5_devx_qp& qp,
                                      struct ibv_qp_attr* attr, int attr_mask) {
   // man 3 ibv_modify_qp
   constexpr int required_attr_mask = IBV_QP_STATE | IBV_QP_PKEY_INDEX | IBV_QP_PORT |
@@ -355,7 +504,7 @@ static int mlx5_modify_qp_reset2init(const mlx5dv_funcs_t& mlx5dv, mlx5_devx_qp*
   void* primary_addr = DEVX_ADDR_OF(qpc,            qpc, primary_address_path);
 
   DEVX_SET(rst2init_qp_in, in, opcode, MLX5_CMD_OP_RST2INIT_QP);
-  DEVX_SET(rst2init_qp_in, in, qpn,    qp->qpn);
+  DEVX_SET(rst2init_qp_in, in, qpn,    qp.qpn);
 
   DEVX_SET(qpc, qpc, pm_state,    MLX5_QPC_PM_STATE_MIGRATED);
   DEVX_SET(qpc, qpc, atomic_mode, MLX5_QPC_ATOMIC_MODE_UP_TO_8B);
@@ -366,10 +515,10 @@ static int mlx5_modify_qp_reset2init(const mlx5dv_funcs_t& mlx5dv, mlx5_devx_qp*
   DEVX_SET(ads, primary_addr, vhca_port_num, attr->port_num);
   DEVX_SET(ads, primary_addr, pkey_index,    attr->pkey_index);
 
-  return mlx5dv.devx_obj_modify(qp->devx_obj, in, sizeof(in), out, sizeof(out));
+  return mlx5dv.devx_obj_modify(qp.devx_qp_obj, in, sizeof(in), out, sizeof(out));
 }
 
-static int mlx5_modify_qp_init2rtr(const mlx5dv_funcs_t& mlx5dv, mlx5_devx_qp* qp,
+static int mlx5_modify_qp_init2rtr(const mlx5dv_funcs_t& mlx5dv, mlx5_devx_qp& qp,
                                    struct ibv_qp_attr* attr, int attr_mask, uint32_t gid_type) {
   // man 3 ibv_modify_qp
   constexpr int required_attr_mask = IBV_QP_STATE | IBV_QP_AV | IBV_QP_PATH_MTU | IBV_QP_DEST_QPN |
@@ -387,7 +536,7 @@ static int mlx5_modify_qp_init2rtr(const mlx5dv_funcs_t& mlx5dv, mlx5_devx_qp* q
   void* rmac         = DEVX_ADDR_OF(ads, primary_addr, rmac_47_32);
 
   DEVX_SET(init2rtr_qp_in, in, opcode, MLX5_CMD_OP_INIT2RTR_QP);
-  DEVX_SET(init2rtr_qp_in, in, qpn,    qp->qpn);
+  DEVX_SET(init2rtr_qp_in, in, qpn,    qp.qpn);
 
   DEVX_SET(qpc, qpc, mtu,          mlx5_mtu(attr->path_mtu));
   DEVX_SET(qpc, qpc, log_msg_max,  MLX5_QPC_LOG_MSG_SZ_MAX);
@@ -401,7 +550,7 @@ static int mlx5_modify_qp_init2rtr(const mlx5dv_funcs_t& mlx5dv, mlx5_devx_qp* q
 
   // calculate new flow label if not set
   uint32_t flow_label = grh->flow_label ? grh->flow_label
-                                        : mlx5_calc_flow_label(qp->qpn, attr->dest_qp_num);
+                                        : mlx5_calc_flow_label(qp.qpn, attr->dest_qp_num);
 
   // all transports
   DEVX_SET(ads, primary_addr, stat_rate, mlx5_stat_rate(ah_attr->static_rate));
@@ -431,7 +580,7 @@ static int mlx5_modify_qp_init2rtr(const mlx5dv_funcs_t& mlx5dv, mlx5_devx_qp* q
     assert(ah_attr->is_global && "ibv_qp_attr::ah_attr::is_global not set, but gid_type is RoCE");
     // get remote MAC address
     uint8_t remote_mac[ETHERNET_LL_SIZE];
-    int err = ibv.resolve_eth_l2_from_gid(qp->ctx, ah_attr, remote_mac, /* VLAN id */ nullptr);
+    int err = ibv.resolve_eth_l2_from_gid(qp.ctx, ah_attr, remote_mac, /* VLAN id */ nullptr);
     CHECK_ZERO(err, "ibv_resolve_eth_l2_from_gid");
 
     DEVX_SET(ads, primary_addr, eth_prio, ah_attr->sl);
@@ -445,10 +594,10 @@ static int mlx5_modify_qp_init2rtr(const mlx5dv_funcs_t& mlx5dv, mlx5_devx_qp* q
     DEVX_SET(ads, primary_addr, udp_sport, ibv.flow_label_to_udp_sport(flow_label));
   }
 
-  return mlx5dv.devx_obj_modify(qp->devx_obj, in, sizeof(in), out, sizeof(out));
+  return mlx5dv.devx_obj_modify(qp.devx_qp_obj, in, sizeof(in), out, sizeof(out));
 }
 
-static int mlx5_modify_qp_rtr2rts(const mlx5dv_funcs_t& mlx5dv, mlx5_devx_qp* qp,
+static int mlx5_modify_qp_rtr2rts(const mlx5dv_funcs_t& mlx5dv, mlx5_devx_qp& qp,
                                   struct ibv_qp_attr* attr, int attr_mask) {
   // man 3 ibv_modify_qp
   constexpr int required_attr_mask = IBV_QP_STATE | IBV_QP_SQ_PSN | IBV_QP_MAX_QP_RD_ATOMIC |
@@ -463,7 +612,7 @@ static int mlx5_modify_qp_rtr2rts(const mlx5dv_funcs_t& mlx5dv, mlx5_devx_qp* qp
   void* primary_addr = DEVX_ADDR_OF(qpc, qpc, primary_address_path);
 
   DEVX_SET(rtr2rts_qp_in, in, opcode, MLX5_CMD_OP_RTR2RTS_QP);
-  DEVX_SET(rtr2rts_qp_in, in, qpn,    qp->qpn);
+  DEVX_SET(rtr2rts_qp_in, in, qpn,    qp.qpn);
 
   DEVX_SET(qpc, qpc, log_ack_req_freq, MLX5_QPC_LOG_ACK_REQ_FREQ_MAX);
   DEVX_SET(qpc, qpc, log_sra_max,      bit_log2(attr->max_rd_atomic));
@@ -473,34 +622,7 @@ static int mlx5_modify_qp_rtr2rts(const mlx5dv_funcs_t& mlx5dv, mlx5_devx_qp* qp
 
   DEVX_SET(ads, primary_addr, ack_timeout, attr->timeout);
 
-  return mlx5dv.devx_obj_modify(qp->devx_obj, in, sizeof(in), out, sizeof(out));
-}
-
-int mlx5_devx_qp::destroy(const mlx5dv_funcs_t& mlx5dv) {
-  int err = 0;
-
-  err = mlx5dv.devx_obj_destroy(this->devx_obj);
-  CHECK_ZERO(err, "mlx5dv_devx_obj_destroy (QP)");
-
-  // mlx5dv_devx_free_uar returns void, can't check for errors
-  mlx5dv.devx_free_uar(this->uar);
-
-  err = mlx5dv.devx_umem_dereg(this->umem);
-  CHECK_ZERO(err, "mlx5dv_devx_umem_dereg");
-
-  QPAllocator::free(this->sq);
-
-  // clear the object's fields
-  this->ctx       = nullptr;
-  this->devx_obj  = nullptr;
-  this->uar       = nullptr;
-  this->umem      = nullptr;
-  this->sq        = nullptr;
-  this->dbrec     = nullptr;
-  this->qpn       = 0;
-  this->sq_depth  = 0;
-
-  return err;
+  return mlx5dv.devx_obj_modify(qp.devx_qp_obj, in, sizeof(in), out, sizeof(out));
 }
 
 void mlx5_devx_qp::dump(int conn_num) {

--- a/projects/rocshmem/src/gda/mlx5/provider_gda_mlx5.hpp
+++ b/projects/rocshmem/src/gda/mlx5/provider_gda_mlx5.hpp
@@ -287,6 +287,48 @@ struct gda_mlx5_device_sq : public gda_mlx5_device_queue<gda_mlx5_wqe> {
   }
 };
 
+/*
+ * QP layout:
+ * [ [ WQ: WQE | WQE | WQE | ... | WQE ] : 64 * 2^N
+ *   [ CQ: CQE | CQE ]                   : 64 * 2
+ *   [ padding - to page table - 256   ] : 3712 - max(4096 - 64 * 2^N, 0)
+ *   [ SQ DBREC ]                        : 8
+ *   [ padding - to AMDGPU cache line  ] : 120
+ *   [ CQ DBREC ]                        : 8
+ *   [ padding - to AMDGPU cache line  ] : 120
+ * ]
+ * Total size: 4096 if sq_depth < 64, else 4096 + 64 * 2^N
+ */
+struct mlx5_devx_qp {
+  ibv_context*      ctx;
+  mlx5dv_devx_obj*  devx_cq_obj;
+  mlx5dv_devx_obj*  devx_qp_obj;
+  mlx5dv_devx_uar*  uar;
+  mlx5dv_devx_umem* umem;
+  void*             cq;
+  void*             sq;
+  uint32_t*         cq_dbrec;
+  uint32_t*         qp_dbrec;
+  uint32_t          cqn;
+  uint32_t          qpn;
+  uint16_t          sq_depth;
+
+  void dump(int conn_num);
+
+  inline size_t cq_offset() {
+    return reinterpret_cast<uint8_t*>(cq) - reinterpret_cast<uint8_t*>(sq);
+  }
+  inline size_t wq_offset() {
+    return reinterpret_cast<uint8_t*>(sq) - reinterpret_cast<uint8_t*>(sq);
+  }
+  inline size_t cq_dbrec_offset() {
+    return reinterpret_cast<uint8_t*>(cq_dbrec) - reinterpret_cast<uint8_t*>(sq);
+  }
+  inline size_t qp_dbrec_offset() {
+    return reinterpret_cast<uint8_t*>(qp_dbrec) - reinterpret_cast<uint8_t*>(sq);
+  }
+};
+
 struct mlx5dv_funcs_t {
   int (*init_obj)(struct mlx5dv_obj *obj, uint64_t obj_type);
   struct ibv_context * (*open_device)(struct ibv_device *device, struct mlx5dv_context_attr *attr);
@@ -295,29 +337,16 @@ struct mlx5dv_funcs_t {
   int (*devx_obj_modify)(
       struct mlx5dv_devx_obj *obj, const void *in, size_t inlen, void *out, size_t outlen);
   int (*devx_obj_destroy)(struct mlx5dv_devx_obj *obj);
-  struct mlx5dv_devx_uar * (*devx_alloc_uar)(struct ibv_context *context, uint32_t flags);
-  void (*devx_free_uar)(struct mlx5dv_devx_uar *devx_uar);
   struct mlx5dv_devx_umem * (*devx_umem_reg_ex)(
       struct ibv_context *ctx, struct mlx5dv_devx_umem_in *umem_in);
   int (*devx_umem_dereg)(struct mlx5dv_devx_umem *umem);
-};
+  struct mlx5dv_devx_uar * (*devx_alloc_uar)(struct ibv_context *context, uint32_t flags);
+  void (*devx_free_uar)(struct mlx5dv_devx_uar *devx_uar);
+  int (*devx_query_eqn)(struct ibv_context *context, uint32_t vector, uint32_t *eqn);
 
-struct mlx5_devx_qp {
-  ibv_context*      ctx;
-  mlx5dv_devx_obj*  devx_obj;
-  mlx5dv_devx_uar*  uar;
-  mlx5dv_devx_umem* umem;
-  void*             sq;
-  uint32_t*         dbrec;
-  uint32_t          qpn;
-  uint16_t          sq_depth;
-
-  int create(const mlx5dv_funcs_t& mlx5dv, struct ibv_context *ctx,
-             struct ibv_qp_init_attr_ex *attr);
-  int modify(const mlx5dv_funcs_t& mlx5dv, struct ibv_qp_attr *attr, int attr_mask,
-             uint32_t gid_type);
-  int destroy(const mlx5dv_funcs_t& mlx5dv);
-  void dump(int conn_num);
+  int create_qp(mlx5_devx_qp& qp, struct ibv_context *ctx, struct ibv_pd* pd, uint16_t sq_depth);
+  int modify_qp(mlx5_devx_qp& qp, struct ibv_qp_attr *attr, int attr_mask, uint32_t gid_type);
+  int destroy_qp(mlx5_devx_qp& qp);
 };
 
 }  // namespace rocshmem


### PR DESCRIPTION
## Motivation

Correctly creating a collapsed CQ for mlx5 (for #2732) requires using the DevX API. Following up on #3485, port CQ creation and management to the DevX API. Follow up PRs will enable device memory allocation for queues and enable "true" 1-CQE/collapsed CQ mode.

## Technical Details

* Add CQ creation bits to hardware interface file `mlx5_ifc_core.hpp`
* Import Direct Verbs DevX function `mlx5dv_devx_query_eqn`
* Rename DevX QP management functions:
  `mlx5_devx_qp::{create|modify|destroy}` -> `mlx5dv_funcs_t::{create|modify|destroy}_qp`
* Add DevX CQ members to `mlx5_devx_qp`
* Create CQ using DevX API when creating a QP
  * CQ memory is allocated alongside the QP's WQ, with the following layout:
    ```
    WQ : [ WQE | WQE | ... | WQE ] : 64 * 2^N
    CQ : [ CQE | CQE ]             : 64 * 2
    padding                        : 3712 - max(4096 - 64 * 2^N, 0)
    QP DBREC                       : 8
    padding                        : 120
    CQ DBREC                       : 8
    padding                        : 120
    ```
  * Total allocation is 4096 if sq_depth < 64, else 4096 + 64 * 2^N

## JIRA ID

AIROCSHMEM-265
AIROCSHMEM-336

## Test Plan

* Functional tests with ConnectX-7 in RoCE v2 mode
* DeepEP with ConnextX-7 in RoCE v2 mode
* Functional tests with ConnectX-7 in IB mode

## Test Result

- [ ] RoCE v2 functional tests
  - [x] ROCm 7.0.2/Ubuntu 22.04 (bare metal)
    - `teamreduction_n2_w1_z64_32768B` test fails due to illegal device memory access
    - Suspected cause is compiler bug, failure is eliminated by addition of code known to be dead at runtime
    - Testing against ROCm 7.2/Ubuntu 24.04 does not exhibit this failure
  - [ ] ROCm 7.2/Ubuntu 22.04 (docker)
  - [ ] ROCm 7.2/Ubuntu 24.04 (docker)
  - [ ] ROCm 7.2.1/Ubuntu 24.04 (docker)
- [x] InfiniBand functional tests
- [ ] RoCE v2 DeepEP
  - [ ] ROCm 7.2/Ubuntu 22.04 (docker)
  - [ ] ROCm 7.2/Ubuntu 24.04 (docker)

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
