### PR TITLE
rocr: Remove dlclose of aqlprofile during Runtime::Unload()

### DIFF
--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/runtime.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/runtime.cpp
@@ -2546,15 +2546,9 @@ void Runtime::Unload() {
   UnloadTools();
   UnloadExtensions();
 
-  // Close the aqlprofile probe handle. Skip the dlclose when
-  // running under Valgrind due to a Valgrind bug, see below:
-  // http://valgrind.org/docs/manual/faq.html#faq.unhelpful
-  if (aqlprofile_lib_ != nullptr) {
-    if (!flag_.running_valgrind()) {
-      os::CloseLib(aqlprofile_lib_);
-    }
-    aqlprofile_lib_ = nullptr;
-  }
+  // Do not dlclose: aqlprofile links against us, so during fini
+  // teardown the dlclose can unmap our own code mid-execution.
+  aqlprofile_lib_ = nullptr;
 
   amd::hsa::loader::Loader::Destroy(loader_.get());
   loader_.reset();


### PR DESCRIPTION
## Motivation

`Runtime::Unload()` crashes when called during fini teardown (e.g., when an application dlclose's `libamdhip64.so`). This blocks runtime-loaded GPU backends like [IREE](https://github.com/iree-org/iree) that dlopen/dlclose the HIP library. Discovered while upgrading TheRock in the IREE frontend project [fusilli](https://github.com/iree-org/fusilli/pull/267).

First appeared in TheRock nightly `7.13.0a20260322`

## Technical Details

Commit 439fb1c774 added a cached `dlopen` of `libhsa-amd-aqlprofile64.so` in `Runtime::Load()` and a `dlclose` in `Runtime::Unload()`. Since aqlprofile has a `NEEDED` dependency on `libhsa-runtime64.so`, this creates a circular reference.

During fini teardown, the dynamic linker unmaps aqlprofile first, releasing one reference to `libhsa-runtime64.so`. Then when `libamdhip64.so`'s fini calls `Runtime::Unload()`, the `dlclose(aqlprofile)` releases the `NEEDED` reference a second time, dropping `libhsa-runtime64.so`'s refcount to zero. The linker unmaps `libhsa-runtime64.so` immediately, and `Unload()` returns into unmapped memory.

Confirmed via GDB: stepping through `os::CloseLib` triggers `Temporarily disabling breakpoints for unloaded shared library libhsa-runtime64.so.1`, followed by SIGSEGV on return.

Fix: drop the handle without `dlclose`. The linker will unmap aqlprofile as part of normal dependency group teardown. However, if `Unload()` is called via explicit `hsa_shut_down()` (not during fini), the handle is leaked until process exit.

## Test Plan

Reproducer (no external dependencies):

```cpp
#include <cstdio>
#include <dlfcn.h>
int main() {
  void* hip = dlopen("libamdhip64.so", RTLD_NOW | RTLD_GLOBAL);
  auto hipInit = (int (*)(unsigned))dlsym(hip, "hipInit");
  hipInit(0);
  dlclose(hip);
  return 0;
}
```

```
LD_LIBRARY_PATH=/path/to/rocm/lib ./repro
```

Tested on gfx1100.

## Test Result

Segfaults before this change, does not after.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
