### PR TITLE
[rocprofiler-systems] Fix sanitizer issues: buffer teardown ordering, Perfetto string lifetimes, and container safety

### DIFF
--- a/projects/rocprofiler-systems/source/lib/core/perfetto.hpp
+++ b/projects/rocprofiler-systems/source/lib/core/perfetto.hpp
@@ -112,9 +112,15 @@ perfetto_counter_track<Tp>::emplace(size_t _idx, const std::string& _v,
     }
     auto        _index     = _track_data.size();
     auto&       _name      = _name_data.emplace_back(std::make_unique<std::string>(_v));
-    const char* _unit_name = (_units && strlen(_units) > 0) ? _units : nullptr;
+    const char* _name_cstr = _name->c_str();
+    const char* _unit_name = nullptr;
+    if(_units && strlen(_units) > 0)
+    {
+        auto& _unit_str = _name_data.emplace_back(std::make_unique<std::string>(_units));
+        _unit_name      = _unit_str->c_str();
+    }
     _track_data.emplace_back(
-        ::perfetto::CounterTrack{ ::perfetto::DynamicString{ _name->c_str() } }
+        ::perfetto::CounterTrack{ ::perfetto::DynamicString{ _name_cstr } }
             .set_unit_name(_unit_name)
             .set_category(_category)
             .set_unit_multiplier(_mult)

--- a/projects/rocprofiler-systems/source/lib/core/trace_cache/buffer_storage.cpp
+++ b/projects/rocprofiler-systems/source/lib/core/trace_cache/buffer_storage.cpp
@@ -74,11 +74,10 @@ flush_worker_t::start(const pid_t& current_pid)
     m_flushing_thread = std::make_unique<std::thread>([&]() {
         LOG_TRACE("Flush worker thread started for pid={}",
                   m_worker_synchronization->origin_pid);
-        std::mutex _shutdown_condition_mutex;
         while(m_worker_synchronization->is_running)
         {
             m_worker_function(m_ofs, false);
-            std::unique_lock _lock{ _shutdown_condition_mutex };
+            std::unique_lock _lock{ m_worker_synchronization->is_running_mutex };
             m_worker_synchronization->is_running_condition.wait_for(
                 _lock, CACHE_FILE_FLUSH_TIMEOUT,
                 [&]() { return !m_worker_synchronization->is_running; });
@@ -87,7 +86,10 @@ flush_worker_t::start(const pid_t& current_pid)
         LOG_TRACE("Flush worker thread performing final flush");
         m_worker_function(m_ofs, true);
         m_ofs.close();
-        m_worker_synchronization->exit_finished = true;
+        {
+            std::lock_guard _lock{ m_worker_synchronization->exit_finished_mutex };
+            m_worker_synchronization->exit_finished = true;
+        }
         m_worker_synchronization->exit_finished_condition.notify_one();
         LOG_TRACE("Flush worker thread exiting");
     });
@@ -105,21 +107,28 @@ flush_worker_t::stop(const pid_t& current_pid)
 
     if(flushing_thread_exist && worker_is_running)
     {
-        LOG_TRACE("Signaling flush worker to stop");
-        m_worker_synchronization->is_running = false;
-        m_worker_synchronization->is_running_condition.notify_all();
-
         const bool thread_is_created_in_this_process =
             current_pid == m_worker_synchronization->origin_pid;
+
         if(!thread_is_created_in_this_process)
         {
+            // Child process after fork(): the flush thread does not exist here
+            // and the inherited mutex may be locked by a thread that is gone.
+            // Skip all mutex/CV/join logic — a plain atomic store is enough.
             LOG_DEBUG("Flush worker was created in different process, skipping join");
+            m_worker_synchronization->is_running.store(false, std::memory_order_release);
             return;
         }
 
+        LOG_TRACE("Signaling flush worker to stop");
+        {
+            std::lock_guard _lock{ m_worker_synchronization->is_running_mutex };
+            m_worker_synchronization->is_running = false;
+        }
+        m_worker_synchronization->is_running_condition.notify_all();
+
         LOG_TRACE("Waiting for flush worker thread to finish");
-        std::mutex       _exit_mutex;
-        std::unique_lock _exit_lock{ _exit_mutex };
+        std::unique_lock _exit_lock{ m_worker_synchronization->exit_finished_mutex };
         m_worker_synchronization->exit_finished_condition.wait(
             _exit_lock, [&]() { return m_worker_synchronization->exit_finished.load(); });
 

--- a/projects/rocprofiler-systems/source/lib/core/trace_cache/buffer_storage.hpp
+++ b/projects/rocprofiler-systems/source/lib/core/trace_cache/buffer_storage.hpp
@@ -52,9 +52,16 @@ using worker_function_t = std::function<void(ofs_t& ofs, bool force)>;
 
 struct worker_synchronization_t
 {
+    // std::condition_variable::wait_for requires a std::mutex — that is a
+    // C++17 API constraint, not a guard on the atomic values themselves.
+    // Both mutexes must live here (not as stack-locals in the thread lambda)
+    // so they are never destroyed during thread TLS teardown, which would
+    // trigger a TSan DTLS_Destroy deadlock.
+    std::mutex              is_running_mutex;
     std::condition_variable is_running_condition;
     std::atomic_bool        is_running{ false };
 
+    std::mutex              exit_finished_mutex;
     std::condition_variable exit_finished_condition;
     std::atomic_bool        exit_finished{ false };
 
@@ -163,8 +170,16 @@ public:
 
         size_t sample_size      = get_size(value);
         size_t bytes_to_reserve = header_size<TypeIdentifierEnum> + sample_size;
-        auto*  buf              = reserve_memory_space(bytes_to_reserve);
-        size_t position         = 0;
+
+        // Hold the mutex for the entire reserve-and-write operation so that
+        // the flush worker thread never reads a buffer region whose write is
+        // still in flight.  Writers were already serialised through m_mutex
+        // for position management; extending the critical section to cover the
+        // actual memcpy closes the window that TSan (correctly) flags.
+        std::lock_guard scope{ m_mutex };
+
+        auto*  buf      = reserve_memory_space(bytes_to_reserve);
+        size_t position = 0;
         auto   type_identifier_value =
             static_cast<TypeIdentifierEnumUderlayingType>(Type::type_identifier);
 
@@ -182,25 +197,24 @@ public:
 private:
     void flush(ofs_t& ofs, bool force)
     {
-        size_t _head, _tail;
+        // Hold m_mutex for the full read so store() cannot write into the
+        // region we are draining to the file.
+        std::lock_guard guard{ m_mutex };
+
+        size_t _head = m_head;
+        size_t _tail = m_tail;
+
+        if(_head == _tail)
         {
-            std::lock_guard guard{ m_mutex };
-            _head = m_head;
-            _tail = m_tail;
-
-            if(_head == _tail)
-            {
-                return;
-            }
-
-            auto used_space =
-                m_head > m_tail ? (m_head - m_tail) : (buffer_size - m_tail + m_head);
-            if(!force && used_space < flush_threshold)
-            {
-                return;
-            }
-            m_tail = m_head;
+            return;
         }
+
+        auto used_space = _head > _tail ? (_head - _tail) : (buffer_size - _tail + _head);
+        if(!force && used_space < flush_threshold)
+        {
+            return;
+        }
+        m_tail = m_head;
 
         if(_head > _tail)
         {
@@ -234,23 +248,18 @@ private:
         m_head = 0;
     }
 
+    // Caller must hold m_mutex.
     ROCPROFSYS_INLINE uint8_t* reserve_memory_space(const size_t& number_of_bytes)
     {
-        size_t _size;
+        if(__builtin_expect((m_head + number_of_bytes + header_size<TypeIdentifierEnum>) >
+                                buffer_size,
+                            0))
         {
-            std::lock_guard scope{ m_mutex };
-
-            if(__builtin_expect((m_head + number_of_bytes +
-                                 header_size<TypeIdentifierEnum>) > buffer_size,
-                                0))
-            {
-                fragment_memory();
-            }
-            _size = m_head;
-            m_head += number_of_bytes;
+            fragment_memory();
         }
-
-        return m_buffer->data() + _size;
+        auto* ptr = m_buffer->data() + m_head;
+        m_head += number_of_bytes;
+        return ptr;
     }
 
 private:

--- a/projects/rocprofiler-systems/source/lib/core/trace_cache/perfetto_processor.cpp
+++ b/projects/rocprofiler-systems/source/lib/core/trace_cache/perfetto_processor.cpp
@@ -52,7 +52,7 @@ namespace
 {
 struct annotation_entry
 {
-    const char*                                                             key;
+    std::string                                                             key;
     std::variant<std::string, uint64_t, int64_t, double, int32_t, uint32_t> value;
 };
 

--- a/projects/rocprofiler-systems/source/lib/core/trace_cache/tests/test_cache_integration.cpp
+++ b/projects/rocprofiler-systems/source/lib/core/trace_cache/tests/test_cache_integration.cpp
@@ -405,7 +405,7 @@ TEST_F(trace_cache_module_integration_test, content_validation_edge_cases)
     test_sample_3        large_payload(max_vector);
     test_sample_3        empty_payload;
     std::vector<uint8_t> single_zero = { 0x00 };
-    test_sample_3        zero_payload(single_zero);
+    test_sample_3        zero_payload(std::move(single_zero));
 
     std::vector<test_sample_1> expected_1;
     std::vector<test_sample_2> expected_2;

--- a/projects/rocprofiler-systems/source/lib/core/trace_cache/tests/test_cache_integration.cpp
+++ b/projects/rocprofiler-systems/source/lib/core/trace_cache/tests/test_cache_integration.cpp
@@ -404,8 +404,7 @@ TEST_F(trace_cache_module_integration_test, content_validation_edge_cases)
     std::vector<uint8_t> max_vector(10000, 0xFF);
     test_sample_3        large_payload(max_vector);
     test_sample_3        empty_payload;
-    std::vector<uint8_t> single_zero = { 0x00 };
-    test_sample_3        zero_payload(std::move(single_zero));
+    test_sample_3        zero_payload({ 0x00 });
 
     std::vector<test_sample_1> expected_1;
     std::vector<test_sample_2> expected_2;

--- a/projects/rocprofiler-systems/source/lib/logger/logger.hpp
+++ b/projects/rocprofiler-systems/source/lib/logger/logger.hpp
@@ -18,6 +18,7 @@
 #include <string>
 #include <string_view>
 #include <sys/cdefs.h>
+#include <thread>
 #include <unistd.h>
 #include <vector>
 
@@ -159,45 +160,40 @@ public:
         static std::shared_ptr<spdlog::logger> _instance;
         static std::atomic<bool>               _initialized{ false };
         static std::mutex                      _init_mutex;
-        static std::shared_mutex               _fork_gate;
+        static std::atomic<bool>               _log_lock{ false };
 
         static std::once_flag _atfork_flag;
         std::call_once(_atfork_flag, [] {
             pthread_atfork(
-                // prefork: acquire _init_mutex then exclusively lock the
-                // fork-gate. The exclusive lock drains all in-flight
-                // shared-lock holders (log calls), guaranteeing every _mt
-                // sink mutex is unlocked when fork() clones the process.
+                // prefork: lock _init_mutex.  Safe because it is only held
+                // briefly during one-time logger creation, never during
+                // normal log calls — so no lock-ordering inversion with
+                // glibc-internal locks acquired by fork().
+                [] { _init_mutex.lock(); },
+                // parent postfork: unlock, resume normal operation.
+                [] { _init_mutex.unlock(); },
+                // child postfork: reset the atomic spinlock (well-defined
+                // atomic store — no UB unlike placement-new on a mutex),
+                // then safely delete the old logger (_st sinks have no
+                // internal mutex).  No leak.
                 [] {
-                    _init_mutex.lock();
-                    _fork_gate.lock();
-                },
-                // parent postfork: unlock in reverse order, resume logging
-                [] {
-                    _fork_gate.unlock();
-                    _init_mutex.unlock();
-                },
-                // child postfork: all _mt sink mutexes are unlocked (no
-                // thread was mid-write), so reset() safely destroys the
-                // old logger. Do NOT call spdlog::drop() — the registry
-                // mutex may be held by a thread that no longer exists.
-                [] {
+                    _log_lock.store(false, std::memory_order_relaxed);
                     _instance.reset();
                     _initialized.store(false, std::memory_order_release);
-                    ::new(&_init_mutex) std::mutex();
-                    ::new(&_fork_gate) std::shared_mutex();
+                    _init_mutex.unlock();
                 });
         });
 
-        if(!_initialized.load(std::memory_order_acquire))
+        if(_initialized.load(std::memory_order_acquire))
         {
-            std::lock_guard<std::mutex> lock(_init_mutex);
+            return *_instance;
+        }
 
-            if(!_initialized.load(std::memory_order_relaxed))
-            {
-                _instance = create_logger(_fork_gate);
-                _initialized.store(true, std::memory_order_release);
-            }
+        std::lock_guard<std::mutex> lock(_init_mutex);
+        if(!_initialized.load(std::memory_order_relaxed))
+        {
+            _instance = create_logger(_log_lock);
+            _initialized.store(true, std::memory_order_release);
         }
 
         return *_instance;
@@ -206,43 +202,50 @@ public:
     logger_t() = delete;
 
 private:
-    // Gates sink access through a shared_mutex (fork-gate). Logging takes a
-    // shared lock (concurrent, ~1 atomic op). Fork takes an exclusive lock,
-    // draining all in-flight log calls so every _mt sink mutex is unlocked
-    // when the process is cloned — enabling safe destruction in the child.
+    // Serializes _st sink access through an atomic spinlock.  Unlike a
+    // mutex or shared_mutex the spinlock can be safely reset in a
+    // post-fork child with a plain atomic store — no undefined behaviour,
+    // no TSan complaints, and the old logger can be cleanly deleted.
     class fork_safe_logger : public spdlog::logger
     {
     public:
         template <typename It>
-        fork_safe_logger(std::string name, It begin, It end, std::shared_mutex& fork_gate)
+        fork_safe_logger(std::string name, It begin, It end, std::atomic<bool>& log_lock)
         : spdlog::logger(std::move(name), begin, end)
-        , m_fork_gate(fork_gate)
+        , m_log_lock(log_lock)
         {}
 
     protected:
         void sink_it_(const spdlog::details::log_msg& msg) override
         {
-            std::shared_lock<std::shared_mutex> lock(m_fork_gate);
+            while(m_log_lock.exchange(true, std::memory_order_acquire))
+                std::this_thread::yield();
             spdlog::logger::sink_it_(msg);
+            m_log_lock.store(false, std::memory_order_release);
         }
 
         void flush_() override
         {
-            std::shared_lock<std::shared_mutex> lock(m_fork_gate);
+            while(m_log_lock.exchange(true, std::memory_order_acquire))
+                std::this_thread::yield();
             spdlog::logger::flush_();
+            m_log_lock.store(false, std::memory_order_release);
         }
 
     private:
-        std::shared_mutex& m_fork_gate;
+        std::atomic<bool>& m_log_lock;
     };
 
-    static std::shared_ptr<spdlog::logger> create_logger(std::shared_mutex& fork_gate)
+    static std::shared_ptr<spdlog::logger> create_logger(std::atomic<bool>& log_lock)
     {
         logger_settings_t logger_settings;
 
         std::vector<spdlog::sink_ptr> sinks;
 
-        sinks.push_back(std::make_shared<spdlog::sinks::stdout_color_sink_mt>());
+        // Use _st sinks — no internal mutex.  Thread safety is provided
+        // by fork_safe_logger's atomic spinlock, which can be safely
+        // reset after fork() with a plain atomic store (no UB).
+        sinks.push_back(std::make_shared<spdlog::sinks::stdout_color_sink_st>());
 
         auto log_file = logger_settings.get_log_file();
         if(!log_file.empty())
@@ -250,11 +253,11 @@ private:
             log_file = include_process_id_in_filename(log_file);
 
             sinks.push_back(
-                std::make_shared<spdlog::sinks::basic_file_sink_mt>(log_file, true));
+                std::make_shared<spdlog::sinks::basic_file_sink_st>(log_file, true));
         }
 
         auto log = std::shared_ptr<spdlog::logger>(
-            new fork_safe_logger(s_logger_name, sinks.begin(), sinks.end(), fork_gate));
+            new fork_safe_logger(s_logger_name, sinks.begin(), sinks.end(), log_lock));
 
         log->set_pattern(logger_settings.get_log_pattern());
         log->set_level(logger_settings.get_log_level());

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library/components/category_region.hpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library/components/category_region.hpp
@@ -104,8 +104,8 @@ cache_stop(const char* name)
     auto      x = map_name_to_args.find(key);
     if(x != map_name_to_args.end())
     {
-        map_name_to_args.erase(key);
         auto timestamp = x->second;
+        map_name_to_args.erase(x);
 
         const auto end_ts =
             static_cast<timestamp_t>(rocprofsys::comp::wall_clock::record());

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library/rocprofiler-sdk.cpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library/rocprofiler-sdk.cpp
@@ -2797,6 +2797,21 @@ tool_fini(void* callback_data)
     stop();
     finalize_sdk_common();
 
+    // Destroy buffers to drain in-flight async flush callbacks before
+    // deleting tool_data, which those callbacks may still be accessing.
+    // rocprofiler_destroy_buffer returns BUFFER_BUSY if a flush is still
+    // in progress, so retry until it succeeds or buffer is not found.
+    for(auto itr : tool_data->get_buffers())
+    {
+        if(itr.handle > 0)
+        {
+            while(rocprofiler_destroy_buffer(itr) == ROCPROFILER_STATUS_ERROR_BUFFER_BUSY)
+            {
+                std::this_thread::yield();
+            }
+        }
+    }
+
     auto* _data        = as_client_data(callback_data);
     _data->client_id   = nullptr;
     _data->client_fini = nullptr;

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library/rocprofiler-sdk.cpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library/rocprofiler-sdk.cpp
@@ -840,7 +840,7 @@ tool_code_object_callback(rocprofiler_callback_tracing_record_t record,
                 tool_data->kernel_symbol_records.wlock(
                     [ts, &record, &data_v](auto& _data) {
                         _data.emplace_back(
-                            new kernel_symbol_callback_record_t{ ts, record, data_v });
+                            kernel_symbol_callback_record_t{ ts, record, data_v });
                     });
                 trace_cache::get_metadata_registry().add_kernel_symbol(data_v);
             }

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library/rocprofiler-sdk.cpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library/rocprofiler-sdk.cpp
@@ -279,7 +279,7 @@ create_agent_profile(rocprofiler_agent_id_t          agent_id,
                 LOG_CRITICAL("invalid device qualifier format (':device=N) "
                              "where N is the GPU id: {}",
                              itr);
-                ::rocprofsys::set_state(::rocprofsys ::State ::Finalized);
+                ::rocprofsys::set_state(::rocprofsys::State::Finalized);
                 std::abort();
             }
 
@@ -354,8 +354,8 @@ create_agent_profile(rocprofiler_agent_id_t          agent_id,
                          tool_agent_v->agent->node_id, tool_agent_v->device_id,
                          tool_agent_v->agent->name, requested_counters, found_counters);
 
-            ::rocprofsys::set_state(::rocprofsys ::State ::Finalized);
-            ::std ::abort();
+            ::rocprofsys::set_state(::rocprofsys::State::Finalized);
+            ::std::abort();
         }
     }
 
@@ -1670,8 +1670,8 @@ tool_tracing_callback(rocprofiler_callback_tracing_record_t record,
         {
             LOG_CRITICAL("unhandled callback record phase: {}",
                          static_cast<int>(record.phase));
-            ::rocprofsys::set_state(::rocprofsys ::State ::Finalized);
-            ::std ::abort();
+            ::rocprofsys::set_state(::rocprofsys::State::Finalized);
+            ::std::abort();
         }
         LOG_WARNING("tool_tracing_callback: unhandled callback record: {}", info.str());
     }
@@ -2245,16 +2245,16 @@ counter_record_callback(rocprofiler_dispatch_counting_service_data_t dispatch_da
             {
                 LOG_CRITICAL("unable to find tool agent for agent (id={})",
                              _agent_id.handle);
-                ::rocprofsys::set_state(::rocprofsys ::State ::Finalized);
-                ::std ::abort();
+                ::rocprofsys::set_state(::rocprofsys::State::Finalized);
+                ::std::abort();
             }
             if(!_info)
             {
                 LOG_CRITICAL("unable to find counter info for counter (id={}) on "
                              "agent (id={})",
                              itr.first.handle, _agent_id.handle);
-                ::rocprofsys::set_state(::rocprofsys ::State ::Finalized);
-                ::std ::abort();
+                ::rocprofsys::set_state(::rocprofsys::State::Finalized);
+                ::std::abort();
             }
 
             auto _dev_id = static_cast<uint32_t>(_agent->device_id);
@@ -2420,8 +2420,8 @@ tool_hip_stream_callback(rocprofiler_callback_tracing_record_t record,
     else
     {
         LOG_CRITICAL("Unknown operation for hip_stream_callback!");
-        ::rocprofsys::set_state(::rocprofsys ::State ::Finalized);
-        ::std ::exit(1);
+        ::rocprofsys::set_state(::rocprofsys::State::Finalized);
+        ::std::exit(1);
     }
 }
 #endif
@@ -2581,8 +2581,8 @@ tool_init(rocprofiler_client_finalize_t fini_func, void* user_data)
             if(get_is_continuous_integration())
             {
                 LOG_CRITICAL("Failed to create memory allocation buffer");
-                ::rocprofsys::set_state(::rocprofsys ::State ::Finalized);
-                ::std ::abort();
+                ::rocprofsys::set_state(::rocprofsys::State::Finalized);
+                ::std::abort();
             }
         }
         auto _ops =
@@ -2803,12 +2803,10 @@ tool_fini(void* callback_data)
     // in progress, so retry until it succeeds or buffer is not found.
     for(auto itr : tool_data->get_buffers())
     {
-        if(itr.handle > 0)
+        while(itr.handle > 0 &&
+              rocprofiler_destroy_buffer(itr) == ROCPROFILER_STATUS_ERROR_BUFFER_BUSY)
         {
-            while(rocprofiler_destroy_buffer(itr) == ROCPROFILER_STATUS_ERROR_BUFFER_BUSY)
-            {
-                std::this_thread::yield();
-            }
+            std::this_thread::yield();
         }
     }
 

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library/rocprofiler-sdk/fwd.hpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library/rocprofiler-sdk/fwd.hpp
@@ -128,7 +128,7 @@ struct client_data
 
     using buffer_name_info_t   = rocprofiler::sdk::buffer_name_info_t<std::string_view>;
     using callback_name_info_t = rocprofiler::sdk::callback_name_info_t<std::string_view>;
-    using kernel_symbol_vec_t  = std::vector<kernel_symbol_callback_record_t*>;
+    using kernel_symbol_vec_t  = std::vector<kernel_symbol_callback_record_t>;
     using code_object_vec_t    = std::vector<code_object_callback_record_t>;
     using buffer_id_vec_t      = std::array<rocprofiler_buffer_id_t, num_buffers>;
     using context_id_vec_t     = std::array<rocprofiler_context_id_t, num_contexts>;
@@ -241,9 +241,9 @@ client_data::get_kernel_symbol_info(uint64_t _kernel_id) const
         [_kernel_id](const auto& _data) -> const kernel_symbol_data_t* {
             for(const auto& itr : _data)
             {
-                if(_kernel_id == itr->payload.kernel_id)
+                if(_kernel_id == itr.payload.kernel_id)
                 {
-                    return &itr->payload;
+                    return &itr.payload;
                     break;
                 }
             }


### PR DESCRIPTION
## Motivation

ThreadSanitizer and related checks exposed use-after-free, data-race, and lifetime bugs: async buffer flush callbacks could still touch `tool_data` after teardown, `CounterTrack` held dangling pointers to unit strings, the logger's fork-handling with `std::shared_mutex` triggered TSan warnings and undefined behavior on mutex reset, trace-cache flush workers used condition variables with stack-local mutexes (UB), and `cache_stop` invalidated iterators before use. These changes align shutdown with the ROCprofiler buffer API, make string/container handling safe for async and tracing code paths, and fix fork-safety issues in the logger and trace-cache.

## Technical Details

- In `tool_fini`, destroy all profiler buffers with a busy-loop on `rocprofiler_destroy_buffer` until buffers are idle so async flushes finish before `tool_data` is freed.
- Store Perfetto counter unit names in the same owning storage as track names so `DynamicString`/`set_unit_name` do not reference freed stack or transient memory.
- Replace `std::vector<kernel_symbol_callback_record_t*>` with a vector of values and adjust lookups accordingly.
- In `cache_stop`, read the timestamp then erase via the iterator (`erase(x)`) to avoid iterator invalidation.
- In the trace cache processor, use `std::string` for annotation keys; in the cache integration test, move the single-byte vector into the test payload.
- Refactor `logger.hpp`: replace `std::shared_mutex` with an atomic spinlock for fork-safety (can be reset with a plain atomic store post-fork, avoiding undefined behavior), and switch from `_mt` sinks to `_st` sinks (no internal mutex, thread safety provided by the spinlock).
- In `buffer_storage`, move mutex members into `worker_synchronization_t` so condition variables use the same mutex instance across wait/notify, and use atomic store with `memory_order_release` for fork-safe stop signaling in child processes.

## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan

- Build with TSan/ASan (or the project's sanitizer CI configuration) and run the rocprofiler-systems test suite, especially `trace_cache` integration tests and any scenarios that exercise tool shutdown and Perfetto output.
- Run workloads that trigger buffer flush and kernel symbol callbacks, then exit cleanly and confirm no sanitizer reports on teardown.
- Exercise fork scenarios to verify no deadlocks or TSan warnings on logger/trace-cache mutex handling.

## Test Result

- No TSan/ASan reports on shutdown (no races on `tool_data` vs buffer callbacks, no invalid memory for Perfetto strings).
- Trace cache / integration tests pass; profiling output remains correct for counters and annotations.
- Fork handling is clean with no undefined behavior on mutex/spinlock reset.

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
