### PR TITLE
[libhsakmt] Replace lazy-init sub-context getters with pre-allocation in init_context

### DIFF
--- a/projects/rocr-runtime/libhsakmt/src/debug.c
+++ b/projects/rocr-runtime/libhsakmt/src/debug.c
@@ -46,32 +46,26 @@ struct hsa_kfd_debug_context {
 	uint32_t runtime_capabilities_mask;
 };
 
-struct hsa_kfd_debug_context *hsakmt_kfdcontext_get_debug_context(HsaKFDContext *ctx)
+int hsakmt_kfdcontext_init_debug_context(HsaKFDContext *ctx)
 {
-	assert(ctx);
-	if (!ctx) {
-		pr_err("Expected a non-null ptr for HsaKFDContext");
-		return NULL;
-	}
+	CHECK_CTX(ctx, -1);
 
 	if (ctx->debug_context)
-		return ctx->debug_context;
+		return 0;
 
 	ctx->debug_context = calloc(1, sizeof(struct hsa_kfd_debug_context));
 	if (!ctx->debug_context) {
 		pr_err("Alloc memory failed for struct hsa_kfd_debug_context size %zu\n",
 				 sizeof(struct hsa_kfd_debug_context));
-		return NULL;
+		return -1;
 	}
-	return ctx->debug_context;
+	return 0;
 }
 
 HSAKMT_STATUS hsakmt_init_device_debugging_memory(HsaKFDContext *ctx, unsigned int NumNodes)
 {
 	unsigned int i;
-	struct hsa_kfd_debug_context *debug_ctx = hsakmt_kfdcontext_get_debug_context(ctx);
-	if (!debug_ctx)
-		return HSAKMT_STATUS_NO_MEMORY;
+	struct hsa_kfd_debug_context *debug_ctx = ctx->debug_context;
 
 	debug_ctx->is_device_debugged = malloc(NumNodes * sizeof(bool));
 	if (!debug_ctx->is_device_debugged)
@@ -85,9 +79,7 @@ HSAKMT_STATUS hsakmt_init_device_debugging_memory(HsaKFDContext *ctx, unsigned i
 
 void hsakmt_destroy_device_debugging_memory(HsaKFDContext *ctx)
 {
-	struct hsa_kfd_debug_context *debug_ctx = hsakmt_kfdcontext_get_debug_context(ctx);
-	if (!debug_ctx)
-		return;
+	struct hsa_kfd_debug_context *debug_ctx = ctx->debug_context;
 
 	if (debug_ctx->is_device_debugged) {
 		free(debug_ctx->is_device_debugged);
@@ -97,8 +89,8 @@ void hsakmt_destroy_device_debugging_memory(HsaKFDContext *ctx)
 
 bool hsakmt_debug_get_reg_status(HsaKFDContext *ctx, uint32_t node_id)
 {
-	struct hsa_kfd_debug_context *debug_ctx = hsakmt_kfdcontext_get_debug_context(ctx);
-	if (!debug_ctx || !debug_ctx->is_device_debugged)
+	struct hsa_kfd_debug_context *debug_ctx = ctx->debug_context;
+	if (!debug_ctx->is_device_debugged)
 		return false;
 
 	return debug_ctx->is_device_debugged[node_id];
@@ -111,7 +103,7 @@ HSAKMT_STATUS HSAKMTAPI hsaKmtDbgRegister(HSAuint32 NodeId)
 
 	CHECK_KFD_OPEN();
 	struct hsa_kfd_debug_context *debug_ctx =
-				hsakmt_kfdcontext_get_debug_context(&hsakmt_primary_kfd_ctx);
+				hsakmt_primary_kfd_ctx.debug_context;
 	if (!debug_ctx->is_device_debugged)
 		return HSAKMT_STATUS_NO_MEMORY;
 
@@ -140,7 +132,7 @@ HSAKMT_STATUS HSAKMTAPI hsaKmtDbgUnregister(HSAuint32 NodeId)
 
 	CHECK_KFD_OPEN();
 	struct hsa_kfd_debug_context *debug_ctx =
-				hsakmt_kfdcontext_get_debug_context(&hsakmt_primary_kfd_ctx);
+				hsakmt_primary_kfd_ctx.debug_context;
 	if (!debug_ctx->is_device_debugged)
 		return HSAKMT_STATUS_NO_MEMORY;
 
@@ -356,7 +348,7 @@ HSAKMT_STATUS HSAKMTAPI hsaKmtRuntimeEnableCtx(HsaKFDContext *ctx,
 					    void *rDebug,
 					    bool setupTtmp)
 {
-	struct hsa_kfd_debug_context *debug_ctx = hsakmt_kfdcontext_get_debug_context(ctx);
+	struct hsa_kfd_debug_context *debug_ctx = ctx->debug_context;
 
 	struct kfd_ioctl_runtime_enable_args args = {0};
 	HSAKMT_STATUS result = hsaKmtCheckRuntimeDebugSupportCtx(ctx);
@@ -401,7 +393,7 @@ HSAKMT_STATUS HSAKMTAPI hsaKmtRuntimeDisableCtx(HsaKFDContext *ctx)
 HSAKMT_STATUS HSAKMTAPI hsaKmtGetRuntimeCapabilitiesCtx(HsaKFDContext *ctx,
 						  HSAuint32 *caps_mask)
 {
-	struct hsa_kfd_debug_context *debug_ctx = hsakmt_kfdcontext_get_debug_context(ctx);
+	struct hsa_kfd_debug_context *debug_ctx = ctx->debug_context;
 
 	*caps_mask = debug_ctx->runtime_capabilities_mask;
 	return HSAKMT_STATUS_SUCCESS;

--- a/projects/rocr-runtime/libhsakmt/src/events.c
+++ b/projects/rocr-runtime/libhsakmt/src/events.c
@@ -34,38 +34,30 @@
 #include "hsakmt/hsakmtmodel.h"
 #include <assert.h>
 
-
 struct hsa_kfd_event_context
 {
 	HSAuint64 *events_page;
 };
 
-struct hsa_kfd_event_context *hsakmt_kfdcontext_get_event_context(HsaKFDContext *ctx)
+int hsakmt_kfdcontext_init_event_context(HsaKFDContext *ctx)
 {
-	assert(ctx);
-	if (!ctx) {
-		pr_err("Expected a non-null ptr for HsaKFDContext");
-		return NULL;
-	}
+	CHECK_CTX(ctx, -1);
 
 	if (ctx->event_context)
-		return ctx->event_context;
+		return 0;
 
 	ctx->event_context = calloc(1, sizeof(struct hsa_kfd_event_context));
 	if (!ctx->event_context) {
 		pr_err("Alloc memory failed for struct hsa_kfd_event_context size %zu\n",
 				 sizeof(struct hsa_kfd_event_context));
-		return NULL;
+		return -1;
 	}
-	return ctx->event_context;
+	return 0;
 }
 
 void hsakmt_clear_events_page(HsaKFDContext *ctx)
 {
-	struct hsa_kfd_event_context *event_ctx = hsakmt_kfdcontext_get_event_context(ctx);
-	if (event_ctx) {
-		event_ctx->events_page = NULL;
-	}
+	ctx->event_context->events_page = NULL;
 }
 
 static bool IsSystemEventType(HSA_EVENTTYPE type)
@@ -104,7 +96,7 @@ HSAKMT_STATUS HSAKMTAPI hsaKmtCreateEventCtx(HsaKFDContext *ctx,
 
 	/* dGPU code */
 	pthread_mutex_lock(&hsakmt_mutex);
-	event_ctx = hsakmt_kfdcontext_get_event_context(ctx);
+	event_ctx = ctx->event_context;
 	events_page = event_ctx->events_page;
 
 	if (hsakmt_is_dgpu && !events_page) {

--- a/projects/rocr-runtime/libhsakmt/src/fmm.c
+++ b/projects/rocr-runtime/libhsakmt/src/fmm.c
@@ -37,7 +37,6 @@
 #include <inttypes.h>
 #include <sys/mman.h>
 #include <sys/time.h>
-#include <errno.h>
 #include <assert.h>
 
 #include <numa.h>
@@ -45,7 +44,6 @@
 #include "rbtree.h"
 #include <amdgpu.h>
 
-#include <fcntl.h>
 #include <sys/ioctl.h>
 #include <sys/stat.h>
 #include "hsakmt/linux/udmabuf.h"
@@ -293,27 +291,24 @@ struct hsa_kfd_fmm_context
 	struct amdgpu_device *amdgpu_handle[DRM_LAST_RENDER_NODE + 1 - DRM_FIRST_RENDER_NODE];
 } fmm_kfd_context_t;
 
-struct hsa_kfd_fmm_context *hsakmt_kfdcontext_get_fmm_context(HsaKFDContext *ctx)
+int hsakmt_kfdcontext_init_fmm_context(HsaKFDContext *ctx)
 {
-	assert(ctx);
-	if (!ctx) {
-		pr_err("Expected a non-null ptr for HsaKFDContext");
-		return NULL;
-	}
+	CHECK_CTX(ctx, -1);
 
 	if (ctx->fmm_context)
-		return ctx->fmm_context;
+		return 0;
 
 	ctx->fmm_context = calloc(1, sizeof(struct hsa_kfd_fmm_context));
 	if (!ctx->fmm_context) {
 		pr_err("Alloc memory failed for struct hsa_kfd_fmm_context size %zu\n",
 				 sizeof(struct hsa_kfd_fmm_context));
-		return NULL;
+		return -1;
 	}
 
 	/* Initialize svm members */
 	manageable_aperture_t init_aperture = INIT_MANAGEABLE_APERTURE(0, 0);
-	manageable_aperture_t mem_handle_init = INIT_MANAGEABLE_APERTURE(START_NON_CANONICAL_ADDR, (START_NON_CANONICAL_ADDR + (1ULL << 47)));
+	manageable_aperture_t mem_handle_init =
+		INIT_MANAGEABLE_APERTURE(START_NON_CANONICAL_ADDR, (START_NON_CANONICAL_ADDR + (1ULL << 47)));
 
 	ctx->fmm_context->svm.apertures[SVM_DEFAULT] = init_aperture;
 	ctx->fmm_context->svm.apertures[SVM_COHERENT] = init_aperture;
@@ -331,7 +326,7 @@ struct hsa_kfd_fmm_context *hsakmt_kfdcontext_get_fmm_context(HsaKFDContext *ctx
 	/* Initialize mem_handle_aperture */
 	ctx->fmm_context->mem_handle_aperture = mem_handle_init;
 
-	return ctx->fmm_context;
+	return 0;
 }
 
 /* IPC structures and helper functions */
@@ -1123,7 +1118,7 @@ static HSAKMT_STATUS fmm_register_mem_svm_api(HsaKFDContext *ctx,
 	HSAuint32 page_offset = (HSAuint64)address & (PAGE_SIZE-1);
 	HSAuint64 aligned_addr = (HSAuint64)address - page_offset;
 	HSAuint64 aligned_size = PAGE_ALIGN_UP(page_offset + size);
-	struct hsa_kfd_fmm_context *fmm_ctx = hsakmt_kfdcontext_get_fmm_context(ctx);
+	struct hsa_kfd_fmm_context *fmm_ctx = ctx->fmm_context;
 
 	if (!fmm_ctx->first_gpu_mem)
 		return HSAKMT_STATUS_ERROR;
@@ -1160,7 +1155,7 @@ static HSAKMT_STATUS fmm_map_mem_svm_api(HsaKFDContext *ctx,
 	struct kfd_ioctl_svm_args *args;
 	size_t s_attr;
 	uint32_t i, nattr;
-	struct hsa_kfd_fmm_context *fmm_ctx = hsakmt_kfdcontext_get_fmm_context(ctx);
+	struct hsa_kfd_fmm_context *fmm_ctx = ctx->fmm_context;
 
 	if (!fmm_ctx->first_gpu_mem)
 		return HSAKMT_STATUS_ERROR;
@@ -1201,7 +1196,7 @@ static vm_object_t *fmm_allocate_memory_object(HsaKFDContext *ctx,
 	vm_object_t *vm_obj = NULL;
 	HsaMemFlags mflags;
 	uint64_t offset = 0, total_size, size;
-	struct hsa_kfd_fmm_context *fmm_ctx = hsakmt_kfdcontext_get_fmm_context(ctx);
+	struct hsa_kfd_fmm_context *fmm_ctx = ctx->fmm_context;
 
 	if (!mem)
 		return NULL;
@@ -1320,7 +1315,7 @@ static void manageable_aperture_print(manageable_aperture_t *app)
 
 void hsakmt_fmm_print(HsaKFDContext *ctx, uint32_t gpu_id)
 {
-	struct hsa_kfd_fmm_context *fmm_ctx = hsakmt_kfdcontext_get_fmm_context(ctx);
+	struct hsa_kfd_fmm_context *fmm_ctx = ctx->fmm_context;
 	int32_t gpu_mem_id = gpu_mem_find_by_gpu_id(fmm_ctx, gpu_id);
 
 	if (gpu_mem_id >= 0) { /* Found */
@@ -1478,7 +1473,7 @@ static void fmm_release_scratch(HsaKFDContext *ctx, uint32_t gpu_id)
 	vm_object_t *obj;
 	manageable_aperture_t *aperture;
 	rbtree_node_t *n;
-	struct hsa_kfd_fmm_context *fmm_ctx = hsakmt_kfdcontext_get_fmm_context(ctx);
+	struct hsa_kfd_fmm_context *fmm_ctx = ctx->fmm_context;
 
 	gpu_mem_id = gpu_mem_find_by_gpu_id(fmm_ctx, gpu_id);
 	if (gpu_mem_id < 0)
@@ -1542,7 +1537,7 @@ void *hsakmt_fmm_allocate_scratch(HsaKFDContext *ctx,
 	int32_t gpu_mem_id;
 	void *mem = NULL;
 	uint64_t aligned_size = ALIGN_UP(MemorySizeInBytes, SCRATCH_ALIGN);
-	struct hsa_kfd_fmm_context *fmm_ctx = hsakmt_kfdcontext_get_fmm_context(ctx);
+	struct hsa_kfd_fmm_context *fmm_ctx = ctx->fmm_context;
 
 	/* Retrieve gpu_mem id according to gpu_id */
 	gpu_mem_id = gpu_mem_find_by_gpu_id(fmm_ctx, gpu_id);
@@ -1693,7 +1688,7 @@ static void* udmabuf_allocation(HsaKFDContext *ctx,
 	uint64_t guard_size;
 	void *mem;
 	int ret;
-	struct hsa_kfd_fmm_context *fmm_ctx = hsakmt_kfdcontext_get_fmm_context(ctx);
+	struct hsa_kfd_fmm_context *fmm_ctx = ctx->fmm_context;
 
 	dmabuf_fd = -1;
 	memfd = -1;
@@ -1810,7 +1805,7 @@ void *hsakmt_fmm_allocate_device(HsaKFDContext *ctx,
 	uint64_t size, mmap_offset;
 	void *mem;
 	vm_object_t *vm_obj = NULL;
-	struct hsa_kfd_fmm_context *fmm_ctx = hsakmt_kfdcontext_get_fmm_context(ctx);
+	struct hsa_kfd_fmm_context *fmm_ctx = ctx->fmm_context;
 
 	/* Retrieve gpu_mem id according to gpu_id */
 	gpu_mem_id = gpu_mem_find_by_gpu_id(fmm_ctx, gpu_id);
@@ -1913,7 +1908,7 @@ void *hsakmt_fmm_allocate_doorbell(HsaKFDContext *ctx,
 	uint32_t ioc_flags;
 	void *mem;
 	vm_object_t *vm_obj = NULL;
-	struct hsa_kfd_fmm_context *fmm_ctx = hsakmt_kfdcontext_get_fmm_context(ctx);
+	struct hsa_kfd_fmm_context *fmm_ctx = ctx->fmm_context;
 
 	/* Retrieve gpu_mem id according to gpu_id */
 	gpu_mem_id = gpu_mem_find_by_gpu_id(fmm_ctx, gpu_id);
@@ -1963,7 +1958,7 @@ static void *fmm_allocate_host_cpu(HsaKFDContext *ctx, void *address, uint64_t M
 	void *mem = NULL;
 	vm_object_t *vm_obj;
 	int mmap_prot = PROT_READ;
-	struct hsa_kfd_fmm_context *fmm_ctx = hsakmt_kfdcontext_get_fmm_context(ctx);
+	struct hsa_kfd_fmm_context *fmm_ctx = ctx->fmm_context;
 
 	if (address)
 		return NULL;
@@ -2076,7 +2071,7 @@ static void *fmm_allocate_host_gpu(HsaKFDContext *ctx,
 	uint64_t size;
 	void *mem;
 
-	struct hsa_kfd_fmm_context *fmm_ctx = hsakmt_kfdcontext_get_fmm_context(ctx);
+	struct hsa_kfd_fmm_context *fmm_ctx = ctx->fmm_context;
 	if (!fmm_ctx->first_gpu_mem)
 		return NULL;
 
@@ -2261,7 +2256,7 @@ HSAKMT_STATUS hsakmt_fmm_release(HsaKFDContext *ctx, void *address)
 	manageable_aperture_t *aperture = NULL;
 	vm_object_t *object = NULL;
 	gpu_mem_t *gpu_mem_ptr = NULL;
-	struct hsa_kfd_fmm_context *fmm_ctx = hsakmt_kfdcontext_get_fmm_context(ctx);
+	struct hsa_kfd_fmm_context *fmm_ctx = ctx->fmm_context;
 
 	/* Special handling for scratch memory */
 	gpu_mem_ptr = fmm_is_scratch_aperture(fmm_ctx, address);
@@ -2361,7 +2356,7 @@ int hsakmt_open_drm_render_device(HsaKFDContext *ctx, int minor)
 	int index, fd, dev_init_ret;
 	uint32_t major_drm, minor_drm;
 	struct amdgpu_device **device_handle;
-	struct hsa_kfd_fmm_context *fmm_ctx = hsakmt_kfdcontext_get_fmm_context(ctx);
+	struct hsa_kfd_fmm_context *fmm_ctx = ctx->fmm_context;
 
 	if (minor < DRM_FIRST_RENDER_NODE || minor > DRM_LAST_RENDER_NODE) {
 		pr_err("DRM render minor %d out of range [%d, %d]\n", minor,
@@ -2396,12 +2391,12 @@ int hsakmt_open_drm_render_device(HsaKFDContext *ctx, int minor)
 	 *    This also makes the application completely separate (e.g.: each one gets
 	 *    its own VM space).
 	*/
-	if (ctx->hsakmt_is_primary_ctx)
-		dev_init_ret = hsakmt_amdgpu_device_initialize(fd, &major_drm, &minor_drm, device_handle);
-	else if (hsakmt_fn_amdgpu_device_initialize2)
+	if (ctx->hsakmt_is_primary_ctx) {
+		dev_init_ret = amdgpu_device_initialize(fd, &major_drm, &minor_drm, device_handle);
+	} else if (hsakmt_fn_amdgpu_device_initialize2) {
 		dev_init_ret = hsakmt_fn_amdgpu_device_initialize2(fd, false, &major_drm, &minor_drm,
 						    (HsaAMDGPUDeviceHandle *)device_handle);
-	else {
+	} else {
 		pr_err("Secondary context amdgpu device init failed: libdrm version < 2.4.121\n");
 		dev_init_ret = -1;
 		*device_handle = 0;
@@ -2682,7 +2677,7 @@ static void *map_mmio(HsaKFDContext *ctx,
 				uint32_t node_id, uint32_t gpu_id, int mmap_fd)
 {
 	void *mem;
-	struct hsa_kfd_fmm_context *fmm_ctx = hsakmt_kfdcontext_get_fmm_context(ctx);
+	struct hsa_kfd_fmm_context *fmm_ctx = ctx->fmm_context;
 	manageable_aperture_t *aperture = fmm_ctx->svm.dgpu_alt_aperture;
 	uint32_t ioc_flags;
 	vm_object_t *vm_obj = NULL;
@@ -2736,7 +2731,7 @@ static void *map_mmio(HsaKFDContext *ctx,
 static void release_mmio(HsaKFDContext *ctx)
 {
 	uint32_t gpu_mem_id;
-	struct hsa_kfd_fmm_context *fmm_ctx = hsakmt_kfdcontext_get_fmm_context(ctx);
+	struct hsa_kfd_fmm_context *fmm_ctx = ctx->fmm_context;
 
 	for (gpu_mem_id = 0; gpu_mem_id < fmm_ctx->gpu_mem_count; gpu_mem_id++) {
 		if (!fmm_ctx->gpu_mem[gpu_mem_id].mmio_aperture.base)
@@ -2751,7 +2746,7 @@ HSAKMT_STATUS hsakmt_fmm_get_amdgpu_device_handle(HsaKFDContext *ctx,
 						uint32_t node_id,
 						HsaAMDGPUDeviceHandle *DeviceHandle)
 {
-	struct hsa_kfd_fmm_context *fmm_ctx = hsakmt_kfdcontext_get_fmm_context(ctx);
+	struct hsa_kfd_fmm_context *fmm_ctx = ctx->fmm_context;
 	int32_t i = gpu_mem_find_by_node_id(fmm_ctx, node_id);
 	int index;
 
@@ -2847,7 +2842,7 @@ HSAKMT_STATUS hsakmt_fmm_init_process_apertures(HsaKFDContext *ctx,
 	unsigned int guardPages = 1;
 	uint64_t svm_base = 0, svm_limit = 0;
 	uint32_t svm_alignment = 0, mfma_high_precision_mode = 0;
-	struct hsa_kfd_fmm_context *fmm_ctx = hsakmt_kfdcontext_get_fmm_context(ctx);
+	struct hsa_kfd_fmm_context *fmm_ctx = ctx->fmm_context;
 
 	/* If HSA_DISABLE_CACHE is set to a non-0 value, disable caching */
 	disableCache = getenv("HSA_DISABLE_CACHE");
@@ -3188,7 +3183,7 @@ gpu_mem_init_failed:
 
 void hsakmt_fmm_destroy_process_apertures(HsaKFDContext *ctx)
 {
-	struct hsa_kfd_fmm_context *fmm_ctx = hsakmt_kfdcontext_get_fmm_context(ctx);
+	struct hsa_kfd_fmm_context *fmm_ctx = ctx->fmm_context;
 
 	release_mmio(ctx);
 
@@ -3213,7 +3208,7 @@ HSAKMT_STATUS hsakmt_fmm_get_aperture_base_and_limit(HsaKFDContext *ctx,
 			HSAuint64 *aperture_base, HSAuint64 *aperture_limit)
 {
 	HSAKMT_STATUS err = HSAKMT_STATUS_ERROR;
-	struct hsa_kfd_fmm_context *fmm_ctx = hsakmt_kfdcontext_get_fmm_context(ctx);
+	struct hsa_kfd_fmm_context *fmm_ctx = ctx->fmm_context;
 	int32_t slot = gpu_mem_find_by_gpu_id(fmm_ctx, gpu_id);
 
 	if (slot < 0)
@@ -3355,7 +3350,7 @@ static HSAKMT_STATUS _fmm_map_to_gpu(HsaKFDContext *ctx,
 	HSAKMT_STATUS ret = HSAKMT_STATUS_SUCCESS;
 	int ret_ioctl;
 	uint32_t i;
-	struct hsa_kfd_fmm_context *fmm_ctx = hsakmt_kfdcontext_get_fmm_context(ctx);
+	struct hsa_kfd_fmm_context *fmm_ctx = ctx->fmm_context;
 
 	if (!obj)
 		pthread_mutex_lock(&aperture->fmm_mutex);
@@ -3456,7 +3451,7 @@ static HSAKMT_STATUS _fmm_map_to_gpu_scratch(HsaKFDContext *ctx,
 	void *mmap_ret = NULL;
 	uint64_t mmap_offset = 0;
 	vm_object_t *obj;
-	struct hsa_kfd_fmm_context *fmm_ctx = hsakmt_kfdcontext_get_fmm_context(ctx);
+	struct hsa_kfd_fmm_context *fmm_ctx = ctx->fmm_context;
 
 	/* Retrieve gpu_mem id according to gpu_id */
 	gpu_mem_id = gpu_mem_find_by_gpu_id(fmm_ctx, gpu_id);
@@ -3507,7 +3502,7 @@ static HSAKMT_STATUS _fmm_map_to_gpu_userptr(HsaKFDContext *ctx,
 	void *svm_addr;
 	HSAuint32 page_offset = (HSAuint64)addr & (PAGE_SIZE-1);
 	HSAKMT_STATUS ret = HSAKMT_STATUS_SUCCESS;
-	struct hsa_kfd_fmm_context *fmm_ctx = hsakmt_kfdcontext_get_fmm_context(ctx);
+	struct hsa_kfd_fmm_context *fmm_ctx = ctx->fmm_context;
 
 	aperture = fmm_ctx->svm.dgpu_aperture;
 
@@ -3547,7 +3542,7 @@ HSAKMT_STATUS hsakmt_fmm_map_to_gpu(HsaKFDContext *ctx,
 	vm_object_t *object;
 	HSAKMT_STATUS ret = HSAKMT_STATUS_SUCCESS;
 	gpu_mem_t *gpu_mem_ptr = NULL;
-	struct hsa_kfd_fmm_context *fmm_ctx = hsakmt_kfdcontext_get_fmm_context(ctx);
+	struct hsa_kfd_fmm_context *fmm_ctx = ctx->fmm_context;
 
 	/* Special handling for scratch memory */
 	gpu_mem_ptr = fmm_is_scratch_aperture(fmm_ctx, address);
@@ -3697,7 +3692,7 @@ static int _fmm_unmap_from_gpu_scratch(HsaKFDContext *ctx,
 	vm_object_t *object;
 	struct kfd_ioctl_unmap_memory_from_gpu_args args = {0};
 	int ret;
-	struct hsa_kfd_fmm_context *fmm_ctx = hsakmt_kfdcontext_get_fmm_context(ctx);
+	struct hsa_kfd_fmm_context *fmm_ctx = ctx->fmm_context;
 
 	/* Retrieve gpu_mem id according to gpu_id */
 	gpu_mem_id = gpu_mem_find_by_gpu_id(fmm_ctx, gpu_id);
@@ -3761,7 +3756,7 @@ int hsakmt_fmm_unmap_from_gpu(HsaKFDContext *ctx, void *address)
 	vm_object_t *object;
 	int ret;
 	gpu_mem_t *gpu_mem_ptr = NULL;
-	struct hsa_kfd_fmm_context *fmm_ctx = hsakmt_kfdcontext_get_fmm_context(ctx);
+	struct hsa_kfd_fmm_context *fmm_ctx = ctx->fmm_context;
 
 	/* Special handling for scratch memory */
 	gpu_mem_ptr = fmm_is_scratch_aperture(fmm_ctx, address);
@@ -3806,7 +3801,7 @@ bool hsakmt_fmm_get_handle(HsaKFDContext *ctx,
 	manageable_aperture_t *aperture = NULL;
 	vm_object_t *object;
 	bool found = false;
-	struct hsa_kfd_fmm_context *fmm_ctx = hsakmt_kfdcontext_get_fmm_context(ctx);
+	struct hsa_kfd_fmm_context *fmm_ctx = ctx->fmm_context;
 
 	/* Find the aperture the requested address belongs to */
 	for (i = 0; i < fmm_ctx->gpu_mem_count; i++) {
@@ -3873,7 +3868,7 @@ static HSAKMT_STATUS fmm_register_user_memory(HsaKFDContext *ctx,
 	void *svm_addr;
 	HSAuint32 gpu_id;
 	vm_object_t *obj, *exist_obj;
-	struct hsa_kfd_fmm_context *fmm_ctx = hsakmt_kfdcontext_get_fmm_context(ctx);
+	struct hsa_kfd_fmm_context *fmm_ctx = ctx->fmm_context;
 	manageable_aperture_t *aperture = fmm_ctx->svm.dgpu_aperture;
 	/* Find first GPU for creating the userptr BO */
 	if (!fmm_ctx->first_gpu_mem)
@@ -3936,7 +3931,7 @@ HSAKMT_STATUS hsakmt_fmm_register_memory(HsaKFDContext *ctx,
 	manageable_aperture_t *aperture = NULL;
 	vm_object_t *object = NULL;
 	HSAKMT_STATUS ret;
-	struct hsa_kfd_fmm_context *fmm_ctx = hsakmt_kfdcontext_get_fmm_context(ctx);
+	struct hsa_kfd_fmm_context *fmm_ctx = ctx->fmm_context;
 
 	if (gpu_id_array_size > 0 && !gpu_id_array)
 		return HSAKMT_STATUS_INVALID_PARAMETER;
@@ -4031,7 +4026,7 @@ HSAKMT_STATUS hsakmt_fmm_register_graphics_handle(HsaKFDContext *ctx,
 	int r;
 	HSAKMT_STATUS status = HSAKMT_STATUS_ERROR;
 	static const uint64_t IMAGE_ALIGN = 256*1024;
-	struct hsa_kfd_fmm_context *fmm_ctx = hsakmt_kfdcontext_get_fmm_context(ctx);
+	struct hsa_kfd_fmm_context *fmm_ctx = ctx->fmm_context;
 
 	if (gpu_id_array_size > 0 && !gpu_id_array)
 		return HSAKMT_STATUS_INVALID_PARAMETER;
@@ -4143,7 +4138,7 @@ HSAKMT_STATUS hsakmt_fmm_export_dma_buf_fd(HsaKFDContext *ctx,
 	vm_object_t *obj;
 	HSAuint64 offset;
 	int r;
-	struct hsa_kfd_fmm_context *fmm_ctx = hsakmt_kfdcontext_get_fmm_context(ctx);
+	struct hsa_kfd_fmm_context *fmm_ctx = ctx->fmm_context;
 
 	aperture = fmm_find_aperture(fmm_ctx, MemoryAddress, &ApeInfo);
 	if (!aperture)
@@ -4188,7 +4183,7 @@ HSAKMT_STATUS hsakmt_fmm_share_memory(HsaKFDContext *ctx,
 	HsaApertureInfo ApeInfo;
 	HsaSharedMemoryStruct *SharedMemoryStruct =
 		to_hsa_shared_memory_struct(SharedMemoryHandle);
-	struct hsa_kfd_fmm_context *fmm_ctx = hsakmt_kfdcontext_get_fmm_context(ctx);
+	struct hsa_kfd_fmm_context *fmm_ctx = ctx->fmm_context;
 
 	if (SizeInBytes >= (1ULL << ((sizeof(HSAuint32) * 8) + PAGE_SHIFT)))
 		return HSAKMT_STATUS_INVALID_PARAMETER;
@@ -4250,7 +4245,7 @@ HSAKMT_STATUS hsakmt_fmm_register_shared_memory(HsaKFDContext *ctx,
 		to_const_hsa_shared_memory_struct(SharedMemoryHandle);
 	HSAuint64 SizeInPages = SharedMemoryStruct->SizeInPages;
 	HsaMemFlags mflags;
-	struct hsa_kfd_fmm_context *fmm_ctx = hsakmt_kfdcontext_get_fmm_context(ctx);
+	struct hsa_kfd_fmm_context *fmm_ctx = ctx->fmm_context;
 
 	if (gpu_id_array_size > 0 && !gpu_id_array)
 		return HSAKMT_STATUS_INVALID_PARAMETER;
@@ -4342,7 +4337,7 @@ HSAKMT_STATUS hsakmt_fmm_deregister_memory(HsaKFDContext *ctx, void *address)
 {
 	manageable_aperture_t *aperture;
 	vm_object_t *object;
-	struct hsa_kfd_fmm_context *fmm_ctx = hsakmt_kfdcontext_get_fmm_context(ctx);
+	struct hsa_kfd_fmm_context *fmm_ctx = ctx->fmm_context;
 
 	object = vm_find_object(fmm_ctx, address, 0, &aperture);
 	if (!object)
@@ -4409,7 +4404,7 @@ HSAKMT_STATUS hsakmt_fmm_map_to_gpu_nodes(HsaKFDContext *ctx,
 	uint32_t *registered_node_id_array, registered_node_id_array_size;
 	HSAKMT_STATUS ret;
 	int retcode = 0;
-	struct hsa_kfd_fmm_context *fmm_ctx = hsakmt_kfdcontext_get_fmm_context(ctx);
+	struct hsa_kfd_fmm_context *fmm_ctx = ctx->fmm_context;
 
 	if (!num_of_nodes || !nodes_to_map || !address)
 		return HSAKMT_STATUS_INVALID_PARAMETER;
@@ -4522,7 +4517,7 @@ HSAKMT_STATUS hsakmt_fmm_get_mem_info(HsaKFDContext *ctx,
 	uint32_t i;
 	manageable_aperture_t *aperture;
 	vm_object_t *vm_obj;
-	struct hsa_kfd_fmm_context *fmm_ctx = hsakmt_kfdcontext_get_fmm_context(ctx);
+	struct hsa_kfd_fmm_context *fmm_ctx = ctx->fmm_context;
 
 	memset(info, 0, sizeof(HsaPointerInfo));
 
@@ -4607,7 +4602,7 @@ HSAKMT_STATUS hsakmt_fmm_replace_asan_header_page(HsaKFDContext *ctx, void* addr
 	HSAKMT_STATUS ret = HSAKMT_STATUS_SUCCESS;
 	manageable_aperture_t* aperture;
 	vm_object_t* vm_obj;
-	struct hsa_kfd_fmm_context *fmm_ctx = hsakmt_kfdcontext_get_fmm_context(ctx);
+	struct hsa_kfd_fmm_context *fmm_ctx = ctx->fmm_context;
 
 	vm_obj = vm_find_object(fmm_ctx, address, UINT64_MAX, &aperture);
 	if (!vm_obj)
@@ -4635,7 +4630,7 @@ HSAKMT_STATUS hsakmt_fmm_return_asan_header_page(HsaKFDContext *ctx, void* addre
 	HSAKMT_STATUS ret = HSAKMT_STATUS_SUCCESS;
 	manageable_aperture_t* aperture;
 	vm_object_t* vm_obj;
-	struct hsa_kfd_fmm_context *fmm_ctx = hsakmt_kfdcontext_get_fmm_context(ctx);
+	struct hsa_kfd_fmm_context *fmm_ctx = ctx->fmm_context;
 
 	vm_obj = vm_find_object(fmm_ctx, address, UINT64_MAX, &aperture);
 	if (!vm_obj)
@@ -4666,7 +4661,7 @@ HSAKMT_STATUS hsakmt_fmm_set_mem_user_data(HsaKFDContext *ctx,
 {
 	manageable_aperture_t *aperture;
 	vm_object_t *vm_obj;
-	struct hsa_kfd_fmm_context *fmm_ctx = hsakmt_kfdcontext_get_fmm_context(ctx);
+	struct hsa_kfd_fmm_context *fmm_ctx = ctx->fmm_context;
 
 	vm_obj = vm_find_object(fmm_ctx, mem, 0, &aperture);
 	if (!vm_obj)
@@ -4702,7 +4697,7 @@ void hsakmt_fmm_clear_all_mem(HsaKFDContext *ctx)
 {
 	uint32_t i;
 	
-	struct hsa_kfd_fmm_context *fmm_ctx = hsakmt_kfdcontext_get_fmm_context(ctx);
+	struct hsa_kfd_fmm_context *fmm_ctx = ctx->fmm_context;
 	/* Close render node FDs. The child process needs to open new ones */
 	for (i = 0; i <= DRM_LAST_RENDER_NODE - DRM_FIRST_RENDER_NODE; i++) {
 
@@ -4723,7 +4718,7 @@ void hsakmt_fmm_clear_all_aperture(HsaKFDContext *ctx)
 	uint32_t i;
 	void *map_addr;
 	
-	struct hsa_kfd_fmm_context *fmm_ctx = hsakmt_kfdcontext_get_fmm_context(ctx);
+	struct hsa_kfd_fmm_context *fmm_ctx = ctx->fmm_context;
 
 	fmm_clear_aperture(&fmm_ctx->mem_handle_aperture);
 	fmm_clear_aperture(&fmm_ctx->cpuvm_aperture);

--- a/projects/rocr-runtime/libhsakmt/src/kfdcontext.c
+++ b/projects/rocr-runtime/libhsakmt/src/kfdcontext.c
@@ -35,9 +35,10 @@ int hsakmt_kfdcontext_init_context(int fd, HsaKFDContext *ctx)
 
     ctx->fd = fd;
     ctx->topology_context = NULL;
-    ctx->queue_context = NULL;
     ctx->fmm_context = NULL;
 
+    if (hsakmt_kfdcontext_init_queue_context(ctx))
+        return -1;
     if (hsakmt_kfdcontext_init_event_context(ctx))
         return -1;
     if (hsakmt_kfdcontext_init_debug_context(ctx))

--- a/projects/rocr-runtime/libhsakmt/src/kfdcontext.c
+++ b/projects/rocr-runtime/libhsakmt/src/kfdcontext.c
@@ -28,7 +28,7 @@
 #include <stddef.h>
 #include <assert.h>
 
-void hsakmt_kfdcontext_init_context(int fd, HsaKFDContext *ctx)
+int hsakmt_kfdcontext_init_context(int fd, HsaKFDContext *ctx)
 {
     assert(fd >= 0);
     assert(ctx);
@@ -37,9 +37,13 @@ void hsakmt_kfdcontext_init_context(int fd, HsaKFDContext *ctx)
     ctx->topology_context = NULL;
     ctx->queue_context = NULL;
     ctx->fmm_context = NULL;
-    ctx->event_context = NULL;
     ctx->debug_context = NULL;
     ctx->perf_context = NULL;
+
+    if (hsakmt_kfdcontext_init_event_context(ctx))
+        return -1;
+
+    return 0;
 }
 
 void hsakmt_kfdcontext_clear_context(HsaKFDContext *ctx)

--- a/projects/rocr-runtime/libhsakmt/src/kfdcontext.c
+++ b/projects/rocr-runtime/libhsakmt/src/kfdcontext.c
@@ -37,9 +37,10 @@ int hsakmt_kfdcontext_init_context(int fd, HsaKFDContext *ctx)
     ctx->topology_context = NULL;
     ctx->queue_context = NULL;
     ctx->fmm_context = NULL;
-    ctx->debug_context = NULL;
 
     if (hsakmt_kfdcontext_init_event_context(ctx))
+        return -1;
+    if (hsakmt_kfdcontext_init_debug_context(ctx))
         return -1;
     if (hsakmt_kfdcontext_init_perf_context(ctx))
         return -1;

--- a/projects/rocr-runtime/libhsakmt/src/kfdcontext.c
+++ b/projects/rocr-runtime/libhsakmt/src/kfdcontext.c
@@ -34,8 +34,9 @@ int hsakmt_kfdcontext_init_context(int fd, HsaKFDContext *ctx)
     assert(ctx);
 
     ctx->fd = fd;
-    ctx->fmm_context = NULL;
 
+    if (hsakmt_kfdcontext_init_fmm_context(ctx))
+        return -1;
     if (hsakmt_kfdcontext_init_topology_context(ctx))
         return -1;
     if (hsakmt_kfdcontext_init_queue_context(ctx))

--- a/projects/rocr-runtime/libhsakmt/src/kfdcontext.c
+++ b/projects/rocr-runtime/libhsakmt/src/kfdcontext.c
@@ -34,9 +34,10 @@ int hsakmt_kfdcontext_init_context(int fd, HsaKFDContext *ctx)
     assert(ctx);
 
     ctx->fd = fd;
-    ctx->topology_context = NULL;
     ctx->fmm_context = NULL;
 
+    if (hsakmt_kfdcontext_init_topology_context(ctx))
+        return -1;
     if (hsakmt_kfdcontext_init_queue_context(ctx))
         return -1;
     if (hsakmt_kfdcontext_init_event_context(ctx))

--- a/projects/rocr-runtime/libhsakmt/src/kfdcontext.c
+++ b/projects/rocr-runtime/libhsakmt/src/kfdcontext.c
@@ -38,9 +38,10 @@ int hsakmt_kfdcontext_init_context(int fd, HsaKFDContext *ctx)
     ctx->queue_context = NULL;
     ctx->fmm_context = NULL;
     ctx->debug_context = NULL;
-    ctx->perf_context = NULL;
 
     if (hsakmt_kfdcontext_init_event_context(ctx))
+        return -1;
+    if (hsakmt_kfdcontext_init_perf_context(ctx))
         return -1;
 
     return 0;

--- a/projects/rocr-runtime/libhsakmt/src/kfdcontext.h
+++ b/projects/rocr-runtime/libhsakmt/src/kfdcontext.h
@@ -105,6 +105,6 @@ struct hsa_kfd_topology_context *hsakmt_kfdcontext_get_topology_context(HsaKFDCo
 struct hsa_kfd_fmm_context *hsakmt_kfdcontext_get_fmm_context(HsaKFDContext *ctx);
 struct hsa_kfd_queue_context *hsakmt_kfdcontext_get_queue_context(HsaKFDContext *ctx);
 int hsakmt_kfdcontext_init_event_context(HsaKFDContext *ctx);
-struct hsa_kfd_debug_context *hsakmt_kfdcontext_get_debug_context(HsaKFDContext *ctx);
+int hsakmt_kfdcontext_init_debug_context(HsaKFDContext *ctx);
 int hsakmt_kfdcontext_init_perf_context(HsaKFDContext *ctx);
 #endif /* _KFDCONTEXT_H_ */

--- a/projects/rocr-runtime/libhsakmt/src/kfdcontext.h
+++ b/projects/rocr-runtime/libhsakmt/src/kfdcontext.h
@@ -101,8 +101,8 @@ int hsakmt_kfdcontext_init_context(int fd, HsaKFDContext *ctx);
  */
 void hsakmt_kfdcontext_clear_context(HsaKFDContext *ctx);
 
-struct hsa_kfd_topology_context *hsakmt_kfdcontext_get_topology_context(HsaKFDContext *ctx);
 struct hsa_kfd_fmm_context *hsakmt_kfdcontext_get_fmm_context(HsaKFDContext *ctx);
+int hsakmt_kfdcontext_init_topology_context(HsaKFDContext *ctx);
 int hsakmt_kfdcontext_init_queue_context(HsaKFDContext *ctx);
 int hsakmt_kfdcontext_init_event_context(HsaKFDContext *ctx);
 int hsakmt_kfdcontext_init_debug_context(HsaKFDContext *ctx);

--- a/projects/rocr-runtime/libhsakmt/src/kfdcontext.h
+++ b/projects/rocr-runtime/libhsakmt/src/kfdcontext.h
@@ -101,7 +101,7 @@ int hsakmt_kfdcontext_init_context(int fd, HsaKFDContext *ctx);
  */
 void hsakmt_kfdcontext_clear_context(HsaKFDContext *ctx);
 
-struct hsa_kfd_fmm_context *hsakmt_kfdcontext_get_fmm_context(HsaKFDContext *ctx);
+int hsakmt_kfdcontext_init_fmm_context(HsaKFDContext *ctx);
 int hsakmt_kfdcontext_init_topology_context(HsaKFDContext *ctx);
 int hsakmt_kfdcontext_init_queue_context(HsaKFDContext *ctx);
 int hsakmt_kfdcontext_init_event_context(HsaKFDContext *ctx);

--- a/projects/rocr-runtime/libhsakmt/src/kfdcontext.h
+++ b/projects/rocr-runtime/libhsakmt/src/kfdcontext.h
@@ -103,7 +103,7 @@ void hsakmt_kfdcontext_clear_context(HsaKFDContext *ctx);
 
 struct hsa_kfd_topology_context *hsakmt_kfdcontext_get_topology_context(HsaKFDContext *ctx);
 struct hsa_kfd_fmm_context *hsakmt_kfdcontext_get_fmm_context(HsaKFDContext *ctx);
-struct hsa_kfd_queue_context *hsakmt_kfdcontext_get_queue_context(HsaKFDContext *ctx);
+int hsakmt_kfdcontext_init_queue_context(HsaKFDContext *ctx);
 int hsakmt_kfdcontext_init_event_context(HsaKFDContext *ctx);
 int hsakmt_kfdcontext_init_debug_context(HsaKFDContext *ctx);
 int hsakmt_kfdcontext_init_perf_context(HsaKFDContext *ctx);

--- a/projects/rocr-runtime/libhsakmt/src/kfdcontext.h
+++ b/projects/rocr-runtime/libhsakmt/src/kfdcontext.h
@@ -61,7 +61,12 @@ typedef struct _HsaKFDContext
      */
     bool hsakmt_is_primary_ctx;
 
-    /* whether to check all dGPUs in the topology support SVM API */
+    /*
+     * Indicates whether the SVM API is available for use
+     * in this context. True only if HSA_USE_SVM is not
+     * explicitly disabled (via env var) and all dGPUs in
+     * the topology report SVM API capability.
+     */
     bool hsakmt_is_svm_api_supported;
 
     /* Topology context for managing system topology information */
@@ -83,15 +88,23 @@ typedef struct _HsaKFDContext
     struct hsa_kfd_perf_context *perf_context;
 } HsaKFDContext;
 
-// Initialize a pre-allocated HsaKFDContext with the given file descriptor
-void hsakmt_kfdcontext_init_context(int fd, HsaKFDContext *ctx);
-// Release all resources associated with the given KFD context
+/* Initialize a pre-allocated HsaKFDContext with the given fd.
+ * Returns 0 on success, -1 on allocation failure.
+ */
+int hsakmt_kfdcontext_init_context(int fd, HsaKFDContext *ctx);
+
+/*
+ * Free all sub-context allocations. Also resets fd to -1 to
+ * mark the context as invalid.
+ * Does NOT free the HsaKFDContext struct itself;
+ * the caller retains ownership.
+ */
 void hsakmt_kfdcontext_clear_context(HsaKFDContext *ctx);
 
 struct hsa_kfd_topology_context *hsakmt_kfdcontext_get_topology_context(HsaKFDContext *ctx);
 struct hsa_kfd_fmm_context *hsakmt_kfdcontext_get_fmm_context(HsaKFDContext *ctx);
 struct hsa_kfd_queue_context *hsakmt_kfdcontext_get_queue_context(HsaKFDContext *ctx);
-struct hsa_kfd_event_context *hsakmt_kfdcontext_get_event_context(HsaKFDContext *ctx);
+int hsakmt_kfdcontext_init_event_context(HsaKFDContext *ctx);
 struct hsa_kfd_debug_context *hsakmt_kfdcontext_get_debug_context(HsaKFDContext *ctx);
 struct hsa_kfd_perf_context *hsakmt_kfdcontext_get_perf_context(HsaKFDContext *ctx);
 #endif /* _KFDCONTEXT_H_ */

--- a/projects/rocr-runtime/libhsakmt/src/kfdcontext.h
+++ b/projects/rocr-runtime/libhsakmt/src/kfdcontext.h
@@ -106,5 +106,5 @@ struct hsa_kfd_fmm_context *hsakmt_kfdcontext_get_fmm_context(HsaKFDContext *ctx
 struct hsa_kfd_queue_context *hsakmt_kfdcontext_get_queue_context(HsaKFDContext *ctx);
 int hsakmt_kfdcontext_init_event_context(HsaKFDContext *ctx);
 struct hsa_kfd_debug_context *hsakmt_kfdcontext_get_debug_context(HsaKFDContext *ctx);
-struct hsa_kfd_perf_context *hsakmt_kfdcontext_get_perf_context(HsaKFDContext *ctx);
+int hsakmt_kfdcontext_init_perf_context(HsaKFDContext *ctx);
 #endif /* _KFDCONTEXT_H_ */

--- a/projects/rocr-runtime/libhsakmt/src/libhsakmt.h
+++ b/projects/rocr-runtime/libhsakmt/src/libhsakmt.h
@@ -34,6 +34,7 @@
 #include <stdint.h>
 #include <limits.h>
 #include <stdio.h>
+#include <assert.h>
 
 extern int hsakmt_udmabuf_dev_fd;
 extern unsigned long hsakmt_kfd_open_count;
@@ -133,6 +134,15 @@ extern int hsakmt_debug_level;
                 pr_warn(fmt, ##__VA_ARGS__);    \
         }                                       \
 })
+
+#define CHECK_CTX(ctx, ret_val) \
+	do { \
+		assert(ctx); \
+		if (!(ctx)) { \
+			pr_err("Expected a non-null ptr for HsaKFDContext"); \
+			return (ret_val); \
+		} \
+	} while (0)
 
 /* Expects gfxv (full) in decimal */
 #define HSA_GET_GFX_VERSION_MAJOR(gfxv)   (((gfxv) / 10000) % 100)

--- a/projects/rocr-runtime/libhsakmt/src/openclose.c
+++ b/projects/rocr-runtime/libhsakmt/src/openclose.c
@@ -214,7 +214,12 @@ HSAKMT_STATUS HSAKMTAPI hsaKmtOpenKFDCtx(HsaKFDContext **pCtx)
 				result = HSAKMT_STATUS_KERNEL_IO_CHANNEL_NOT_OPENED;
 				goto open_failed;
 			}
-			hsakmt_kfdcontext_init_context(fd, &hsakmt_primary_kfd_ctx);
+			if (hsakmt_kfdcontext_init_context(fd, &hsakmt_primary_kfd_ctx)) {
+				close(fd);
+				hsakmt_kfdcontext_clear_context(&hsakmt_primary_kfd_ctx);
+				result = HSAKMT_STATUS_NO_MEMORY;
+				goto open_failed;
+			}
 		}
 
 		init_page_size();
@@ -340,7 +345,13 @@ HSAKMT_STATUS HSAKMTAPI hsaKmtOpenSecondaryKFDCtx(HsaKFDContext **pCtx)
 				result = HSAKMT_STATUS_NO_MEMORY;
 				goto create_process_failed;
 			}
-			hsakmt_kfdcontext_init_context(kfd_fd, new_ctx);
+			if (hsakmt_kfdcontext_init_context(kfd_fd, new_ctx)) {
+				close(kfd_fd);
+				hsakmt_kfdcontext_clear_context(new_ctx);
+				free(new_ctx);
+				result = HSAKMT_STATUS_NO_MEMORY;
+				goto create_process_failed;
+			}
 			new_ctx->hsakmt_is_primary_ctx = false;
 			new_ctx->hsakmt_is_svm_api_supported = false;
 

--- a/projects/rocr-runtime/libhsakmt/src/perfctr.c
+++ b/projects/rocr-runtime/libhsakmt/src/perfctr.c
@@ -82,25 +82,20 @@ struct hsa_kfd_perf_context
 	unsigned int counter_props_count;
 };
 
-struct hsa_kfd_perf_context *hsakmt_kfdcontext_get_perf_context(HsaKFDContext *ctx)
+int hsakmt_kfdcontext_init_perf_context(HsaKFDContext *ctx)
 {
-	assert(ctx);
-	if (!ctx) {
-		pr_err("Expected a non-null ptr for HsaKFDContext");
-		return NULL;
-	}
+	CHECK_CTX(ctx, -1);
 
 	if (ctx->perf_context)
-		return ctx->perf_context;
+		return 0;
 
 	ctx->perf_context = calloc(1, sizeof(struct hsa_kfd_perf_context));
 	if (!ctx->perf_context) {
 		pr_err("Alloc memory failed for struct hsa_kfd_perf_context size %zu\n",
 				 sizeof(struct hsa_kfd_perf_context));
-		return NULL;
+		return -1;
 	}
-
-	return ctx->perf_context;
+	return 0;
 }
 
 static ssize_t readn(int fd, void *buf, size_t n)
@@ -126,7 +121,7 @@ static ssize_t readn(int fd, void *buf, size_t n)
 
 HSAKMT_STATUS hsakmt_init_counter_props(HsaKFDContext *ctx, unsigned int NumNodes)
 {
-	struct hsa_kfd_perf_context *perf_ctx = hsakmt_kfdcontext_get_perf_context(ctx);
+	struct hsa_kfd_perf_context *perf_ctx = ctx->perf_context;
 	perf_ctx->counter_props = calloc(NumNodes, sizeof(struct HsaCounterProperties *));
 	if (!perf_ctx->counter_props) {
 		pr_warn("Profiling is not available.\n");
@@ -141,7 +136,7 @@ HSAKMT_STATUS hsakmt_init_counter_props(HsaKFDContext *ctx, unsigned int NumNode
 void hsakmt_destroy_counter_props(HsaKFDContext *ctx)
 {
 	unsigned int i;
-	struct hsa_kfd_perf_context *perf_ctx = hsakmt_kfdcontext_get_perf_context(ctx);
+	struct hsa_kfd_perf_context *perf_ctx = ctx->perf_context;
 
 	if (!perf_ctx->counter_props)
 		return;
@@ -294,7 +289,7 @@ HSAKMT_STATUS HSAKMTAPI hsaKmtPmcGetCounterPropertiesCtx(HsaKFDContext *ctx,
 	struct perf_counter_block block = {0};
 	uint32_t total_blocks = 0;
 	HsaCounterBlockProperties *block_prop;
-	struct hsa_kfd_perf_context *perf_ctx = hsakmt_kfdcontext_get_perf_context(ctx);
+	struct hsa_kfd_perf_context *perf_ctx = ctx->perf_context;
 
 	if (!perf_ctx->counter_props)
 		return HSAKMT_STATUS_NO_MEMORY;
@@ -384,7 +379,7 @@ HSAKMT_STATUS HSAKMTAPI hsaKmtPmcRegisterTraceCtx(HsaKFDContext* ctx,
 	uint32_t block, num_blocks = 0, total_counters = 0;
 	uint64_t *counter_id_ptr;
 	int *fd_ptr;
-	struct hsa_kfd_perf_context *perf_ctx = hsakmt_kfdcontext_get_perf_context(ctx);
+	struct hsa_kfd_perf_context *perf_ctx = ctx->perf_context;
 
 	pr_debug("[%s] Number of counters %d\n", __func__, NumberOfCounters);
 

--- a/projects/rocr-runtime/libhsakmt/src/queues.c
+++ b/projects/rocr-runtime/libhsakmt/src/queues.c
@@ -89,25 +89,20 @@ struct hsa_kfd_queue_context
 	struct process_doorbells *doorbells;
 };
 
-struct hsa_kfd_queue_context *hsakmt_kfdcontext_get_queue_context(HsaKFDContext *ctx)
+int hsakmt_kfdcontext_init_queue_context(HsaKFDContext *ctx)
 {
-	assert(ctx);
-	if (!ctx) {
-		pr_err("Expected a non-null ptr for HsaKFDContext");
-		return NULL;
-	}
+	CHECK_CTX(ctx, -1);
 
 	if (ctx->queue_context)
-		return ctx->queue_context;
+		return 0;
 
 	ctx->queue_context = calloc(1, sizeof(struct hsa_kfd_queue_context));
 	if (!ctx->queue_context) {
 		pr_err("Alloc memory failed for struct hsa_kfd_queue_context size %zu\n",
 				 sizeof(struct hsa_kfd_queue_context));
-		return NULL;
+		return -1;
 	}
-
-	return ctx->queue_context;
+	return 0;
 }
 
 static uint32_t get_hwreg_size_per_cu(uint32_t gfxv)
@@ -175,7 +170,7 @@ HSAKMT_STATUS hsakmt_init_process_doorbells(HsaKFDContext *ctx, unsigned int Num
 {
 	unsigned int i;
 	HSAKMT_STATUS ret = HSAKMT_STATUS_SUCCESS;
-	struct hsa_kfd_queue_context *queue_ctx = hsakmt_kfdcontext_get_queue_context(ctx);
+	struct hsa_kfd_queue_context *queue_ctx = ctx->queue_context;
 
 	/* queue_ctx->doorbells[] is accessed using Topology NodeId. This means doorbells[0],
 	 * which corresponds to CPU only Node, might not be used
@@ -218,7 +213,7 @@ static void get_doorbell_map_info(HsaKFDContext *ctx,
 void hsakmt_destroy_process_doorbells(HsaKFDContext *ctx)
 {
 	unsigned int i;
-	struct hsa_kfd_queue_context *queue_ctx = hsakmt_kfdcontext_get_queue_context(ctx);
+	struct hsa_kfd_queue_context *queue_ctx = ctx->queue_context;
 	struct process_doorbells *doorbells = queue_ctx->doorbells;
 
 	if (!doorbells)
@@ -246,7 +241,7 @@ void hsakmt_destroy_process_doorbells(HsaKFDContext *ctx)
 void hsakmt_clear_process_doorbells(HsaKFDContext *ctx)
 {
 	unsigned int i;
-	struct hsa_kfd_queue_context *queue_ctx = hsakmt_kfdcontext_get_queue_context(ctx);
+	struct hsa_kfd_queue_context *queue_ctx = ctx->queue_context;
 
 	if (!queue_ctx->doorbells)
 		return;
@@ -269,7 +264,7 @@ static HSAKMT_STATUS map_doorbell_apu(HsaKFDContext *ctx,
 				      HSAuint64 doorbell_mmap_offset)
 {
 	void *ptr;
-	struct hsa_kfd_queue_context *queue_ctx = hsakmt_kfdcontext_get_queue_context(ctx);
+	struct hsa_kfd_queue_context *queue_ctx = ctx->queue_context;
 
 	ptr = mmap(0, queue_ctx->doorbells[NodeId].size, PROT_READ|PROT_WRITE,
 		   MAP_SHARED, ctx->fd, doorbell_mmap_offset);
@@ -287,7 +282,7 @@ static HSAKMT_STATUS map_doorbell_dgpu(HsaKFDContext *ctx,
 				       HSAuint64 doorbell_mmap_offset)
 {
 	void *ptr;
-	struct hsa_kfd_queue_context *queue_ctx = hsakmt_kfdcontext_get_queue_context(ctx);
+	struct hsa_kfd_queue_context *queue_ctx = ctx->queue_context;
 
 	ptr = hsakmt_fmm_allocate_doorbell(ctx,
 				gpu_id, queue_ctx->doorbells[NodeId].size,
@@ -312,7 +307,7 @@ static HSAKMT_STATUS map_doorbell(HsaKFDContext *ctx,
 				  HSAuint64 doorbell_mmap_offset)
 {
 	HSAKMT_STATUS status = HSAKMT_STATUS_SUCCESS;
-	struct hsa_kfd_queue_context *queue_ctx = hsakmt_kfdcontext_get_queue_context(ctx);
+	struct hsa_kfd_queue_context *queue_ctx = ctx->queue_context;
 	struct process_doorbells *doorbells = queue_ctx->doorbells;
 
 	pthread_mutex_lock(&doorbells[NodeId].mutex);
@@ -706,12 +701,13 @@ HSAKMT_STATUS HSAKMTAPI hsaKmtCreateQueueV2Ctx(
 
 	CHECK_KFD_OPEN();
 
-	struct hsa_kfd_queue_context *queue_ctx = hsakmt_kfdcontext_get_queue_context(ctx);
+	struct hsa_kfd_queue_context *queue_ctx = ctx->queue_context;
 	if (MetaDataQueueSizeInBytes) {
 		CHECK_KFD_MINOR_VERSION(19);
 		if (!IS_PAGE_ALIGNED(MetaDataQueueSizeInBytes))
 			return HSAKMT_STATUS_INVALID_PARAMETER;
 	}
+
 
 	if (Priority < HSA_QUEUE_PRIORITY_MINIMUM ||
 		Priority > HSA_QUEUE_PRIORITY_MAXIMUM)

--- a/projects/rocr-runtime/libhsakmt/src/svm.c
+++ b/projects/rocr-runtime/libhsakmt/src/svm.c
@@ -31,7 +31,6 @@
 #include <inttypes.h>
 #include <sys/mman.h>
 #include <sys/time.h>
-#include <errno.h>
 
 /* Helper functions for calling KFD SVM ioctl */
 

--- a/projects/rocr-runtime/libhsakmt/src/topology.c
+++ b/projects/rocr-runtime/libhsakmt/src/topology.c
@@ -103,24 +103,20 @@ struct hsa_kfd_topology_context
 	uint32_t num_sysfs_nodes;
 };
 
-struct hsa_kfd_topology_context *hsakmt_kfdcontext_get_topology_context(HsaKFDContext *ctx)
+int hsakmt_kfdcontext_init_topology_context(HsaKFDContext *ctx)
 {
-	assert(ctx);
-	if (!ctx) {
-		pr_err("Expected a non-null ptr for HsaKFDContext");
-		return NULL;
-	}
+	CHECK_CTX(ctx, -1);
 
 	if (ctx->topology_context)
-		return ctx->topology_context;
+		return 0;
 
 	ctx->topology_context = calloc(1, sizeof(struct hsa_kfd_topology_context));
 	if (!ctx->topology_context) {
 		pr_err("Alloc memory failed for struct hsa_kfd_topology_context size %zu\n",
 				 sizeof(struct hsa_kfd_topology_context));
-		return NULL;
+		return -1;
 	}
-	return ctx->topology_context;
+	return 0;
 }
 
 static HSAKMT_STATUS topology_take_snapshot(HsaKFDContext *ctx);
@@ -767,7 +763,7 @@ HSAKMT_STATUS hsakmt_topology_sysfs_get_system_props(HsaKFDContext *ctx,
 	HSAKMT_STATUS ret = HSAKMT_STATUS_SUCCESS;
 	bool is_node_supported = true;
 	uint32_t num_supported_nodes = 0;
-	struct hsa_kfd_topology_context *topology_ctx = hsakmt_kfdcontext_get_topology_context(ctx);
+	struct hsa_kfd_topology_context *topology_ctx = ctx->topology_context;
 
 	assert(props);
 	snprintf(path, sizeof(path), KFD_SYSFS_PATH_SYSTEM_PROPERTIES, get_topology_dir());
@@ -1129,7 +1125,7 @@ static HSAKMT_STATUS topology_sysfs_get_node_props(HsaKFDContext *ctx,
 	uint32_t simd_arrays_count = 0;
 
 	HSAKMT_STATUS ret = HSAKMT_STATUS_SUCCESS;
-	struct hsa_kfd_topology_context *topology_ctx = hsakmt_kfdcontext_get_topology_context(ctx);
+	struct hsa_kfd_topology_context *topology_ctx = ctx->topology_context;
 	assert(props);
 	ret = topology_sysfs_map_node_id(topology_ctx, node_id, &sys_node_id);
 	if (ret != HSAKMT_STATUS_SUCCESS)
@@ -1722,7 +1718,7 @@ static HSAKMT_STATUS topology_sysfs_get_iolink_props(HsaKFDContext *ctx,
 	int read_size;
 	HSAKMT_STATUS ret = HSAKMT_STATUS_SUCCESS;
 	uint32_t sys_node_id;
-	struct hsa_kfd_topology_context *topology_ctx = hsakmt_kfdcontext_get_topology_context(ctx);
+	struct hsa_kfd_topology_context *topology_ctx = ctx->topology_context;
 
 	assert(props);
 	ret = topology_sysfs_map_node_id(topology_ctx, node_id, &sys_node_id);
@@ -2045,7 +2041,7 @@ HSAKMT_STATUS topology_take_snapshot(HsaKFDContext *ctx)
 	uint32_t num_ioLinks;
 	bool p2p_links = false;
 	uint32_t num_p2pLinks = 0;
-	struct hsa_kfd_topology_context *topology_ctx = hsakmt_kfdcontext_get_topology_context(ctx);
+	struct hsa_kfd_topology_context *topology_ctx = ctx->topology_context;
 
 	cpuinfo = calloc(num_procs, sizeof(struct proc_cpuinfo));
 	if (!cpuinfo) {
@@ -2217,7 +2213,7 @@ err:
  void topology_drop_snapshot(HsaKFDContext *ctx)
 {
 	struct hsa_kfd_topology_context *topology_ctx =
-				hsakmt_kfdcontext_get_topology_context(ctx);
+				ctx->topology_context;
 
 	if (!!topology_ctx->system_props != !!topology_ctx->node_props)
 		pr_warn("Probably inconsistency?\n");
@@ -2241,7 +2237,7 @@ err:
 HSAKMT_STATUS hsakmt_validate_nodeid(HsaKFDContext *ctx, uint32_t nodeid, uint32_t *gpu_id)
 {
 	struct hsa_kfd_topology_context *topology_ctx =
-				hsakmt_kfdcontext_get_topology_context(ctx);
+				ctx->topology_context;
 
 	if (!topology_ctx->node_props || !topology_ctx->system_props ||
 		topology_ctx->system_props->NumNodes <= nodeid)
@@ -2257,7 +2253,7 @@ HSAKMT_STATUS hsakmt_gpuid_to_nodeid(HsaKFDContext *ctx, uint32_t gpu_id, uint32
 	uint64_t node_idx;
 
 	struct hsa_kfd_topology_context *topology_ctx =
-				hsakmt_kfdcontext_get_topology_context(ctx);
+				ctx->topology_context;
 
 	for (node_idx = 0; node_idx < topology_ctx->system_props->NumNodes; node_idx++) {
 		if (topology_ctx->node_props[node_idx].node.KFDGpuID == gpu_id) {
@@ -2277,7 +2273,7 @@ HSAKMT_STATUS HSAKMTAPI hsaKmtAcquireSystemPropertiesCtx(HsaKFDContext *ctx,
 
 	CHECK_KFD_OPEN();
 	struct hsa_kfd_topology_context *topology_ctx =
-				hsakmt_kfdcontext_get_topology_context(ctx);
+				ctx->topology_context;
 
 	if (!SystemProperties)
 		return HSAKMT_STATUS_INVALID_PARAMETER;
@@ -2347,7 +2343,7 @@ HSAKMT_STATUS hsakmt_topology_get_node_props(HsaKFDContext *ctx,
 				      HSAuint32 NodeId,
 				      HsaNodeProperties *NodeProperties)
 {
-	struct hsa_kfd_topology_context *topology_ctx = hsakmt_kfdcontext_get_topology_context(ctx);
+	struct hsa_kfd_topology_context *topology_ctx = ctx->topology_context;
 
 	if (!topology_ctx->system_props || !topology_ctx->node_props ||
 		NodeId >= topology_ctx->system_props->NumNodes)
@@ -2403,7 +2399,7 @@ HSAKMT_STATUS HSAKMTAPI hsaKmtGetNodeMemoryPropertiesCtx(HsaKFDContext *ctx,
 	HSAKMT_STATUS err = HSAKMT_STATUS_SUCCESS;
 	uint32_t i, gpu_id;
 	HSAuint64 aperture_limit;
-	struct hsa_kfd_topology_context *topology_ctx = hsakmt_kfdcontext_get_topology_context(ctx);
+	struct hsa_kfd_topology_context *topology_ctx = ctx->topology_context;
 	node_props_t *node_props = topology_ctx->node_props;
 
 	if (!MemoryProperties)
@@ -2490,7 +2486,7 @@ HSAKMT_STATUS HSAKMTAPI hsaKmtGetNodeCachePropertiesCtx(HsaKFDContext *ctx,
 {
 	HSAKMT_STATUS err;
 	uint32_t i;
-	struct hsa_kfd_topology_context *topology_ctx = hsakmt_kfdcontext_get_topology_context(ctx);
+	struct hsa_kfd_topology_context *topology_ctx = ctx->topology_context;
 
 	if (!CacheProperties)
 		return HSAKMT_STATUS_INVALID_PARAMETER;
@@ -2526,7 +2522,7 @@ HSAKMT_STATUS hsakmt_topology_get_iolink_props(HsaKFDContext *ctx,
 					HSAuint32 NumIoLinks,
 					HsaIoLinkProperties *IoLinkProperties)
 {
-	struct hsa_kfd_topology_context *topology_ctx = hsakmt_kfdcontext_get_topology_context(ctx);
+	struct hsa_kfd_topology_context *topology_ctx = ctx->topology_context;
 
 	if (!topology_ctx->system_props || !topology_ctx->node_props ||
 		NodeId >= topology_ctx->system_props->NumNodes)
@@ -2544,7 +2540,7 @@ HSAKMT_STATUS HSAKMTAPI hsaKmtGetNodeIoLinkPropertiesCtx(HsaKFDContext *ctx,
 						      HsaIoLinkProperties *IoLinkProperties)
 {
 	HSAKMT_STATUS err;
-	struct hsa_kfd_topology_context *topology_ctx = hsakmt_kfdcontext_get_topology_context(ctx);
+	struct hsa_kfd_topology_context *topology_ctx = ctx->topology_context;
 
 	if (!IoLinkProperties)
 		return HSAKMT_STATUS_INVALID_PARAMETER;
@@ -2574,13 +2570,13 @@ out:
 
 uint32_t hsakmt_get_gfxv_by_node_id(HsaKFDContext *ctx, HSAuint32 node_id)
 {
-	struct hsa_kfd_topology_context *topology_ctx = hsakmt_kfdcontext_get_topology_context(ctx);
+	struct hsa_kfd_topology_context *topology_ctx = ctx->topology_context;
 	return HSA_GET_GFX_VERSION_FULL(topology_ctx->node_props[node_id].node.EngineId.ui32);
 }
 
 uint16_t hsakmt_get_device_id_by_node_id(HsaKFDContext *ctx, HSAuint32 node_id)
 {
-	struct hsa_kfd_topology_context *topology_ctx = hsakmt_kfdcontext_get_topology_context(ctx);
+	struct hsa_kfd_topology_context *topology_ctx = ctx->topology_context;
 
 	if (!topology_ctx->node_props || !topology_ctx->system_props ||
 		topology_ctx->system_props->NumNodes <= node_id)
@@ -2591,7 +2587,7 @@ uint16_t hsakmt_get_device_id_by_node_id(HsaKFDContext *ctx, HSAuint32 node_id)
 
 HSAuint8 hsakmt_device_is_apu_by_node_id(HsaKFDContext *ctx, HSAuint32 node_id)
 {
-	struct hsa_kfd_topology_context *topology_ctx = hsakmt_kfdcontext_get_topology_context(ctx);
+	struct hsa_kfd_topology_context *topology_ctx = ctx->topology_context;
 
 	/* if no node prop available treat is as dGPU */
 	if (!topology_ctx->node_props || !topology_ctx->system_props ||
@@ -2603,7 +2599,7 @@ HSAuint8 hsakmt_device_is_apu_by_node_id(HsaKFDContext *ctx, HSAuint32 node_id)
 
 bool hsakmt_prefer_ats(HsaKFDContext *ctx, HSAuint32 node_id)
 {
-	struct hsa_kfd_topology_context *topology_ctx = hsakmt_kfdcontext_get_topology_context(ctx);
+	struct hsa_kfd_topology_context *topology_ctx = ctx->topology_context;
 	return topology_ctx->node_props[node_id].node.Capability.ui32.HSAMMUPresent
 			&& topology_ctx->node_props[node_id].node.NumCPUCores
 			&& topology_ctx->node_props[node_id].node.NumFComputeCores;
@@ -2612,7 +2608,7 @@ bool hsakmt_prefer_ats(HsaKFDContext *ctx, HSAuint32 node_id)
 uint16_t hsakmt_get_device_id_by_gpu_id(HsaKFDContext *ctx, HSAuint32 gpu_id)
 {
 	unsigned int i;
-	struct hsa_kfd_topology_context *topology_ctx = hsakmt_kfdcontext_get_topology_context(ctx);
+	struct hsa_kfd_topology_context *topology_ctx = ctx->topology_context;
 	if (!topology_ctx->node_props || !topology_ctx->system_props)
 		return 0;
 
@@ -2629,7 +2625,7 @@ uint32_t hsakmt_get_direct_link_cpu(HsaKFDContext *ctx, HSAuint32 gpu_node)
 	HSAuint64 size = 0;
 	int32_t cpu_id;
 	HSAuint32 i;
-	struct hsa_kfd_topology_context *topology_ctx = hsakmt_kfdcontext_get_topology_context(ctx);
+	struct hsa_kfd_topology_context *topology_ctx = ctx->topology_context;
 
 	cpu_id = gpu_get_direct_link_cpu(gpu_node, topology_ctx->node_props);
 	if (cpu_id == -1)
@@ -2670,8 +2666,7 @@ HSAKMT_STATUS hsakmt_validate_nodeid_array(HsaKFDContext *ctx,
 
 uint32_t hsakmt_get_num_sysfs_nodes(HsaKFDContext *ctx)
 {
-	struct hsa_kfd_topology_context *topology_ctx = hsakmt_kfdcontext_get_topology_context(ctx);
-	return topology_ctx->num_sysfs_nodes;
+	return ctx->topology_context->num_sysfs_nodes;
 }
 
 
@@ -2695,7 +2690,7 @@ HSAKMT_STATUS HSAKMTAPI
 hsaKmtGetNodeWallclockFrequency(HSAuint32 NodeId, uint64_t* Frequency)
 {
 	struct hsa_kfd_topology_context *topology_ctx =
-				hsakmt_kfdcontext_get_topology_context(&hsakmt_primary_kfd_ctx);
+				hsakmt_primary_kfd_ctx.topology_context;
 	HsaNodeProperties *NodeProperties = &(topology_ctx->node_props[NodeId].node);
 
 	*Frequency = NodeProperties->WallClockKHz * 1000ull;


### PR DESCRIPTION
## Motivation

The original getter pattern combined two responsibilities in a single function:

1. **Lazy allocation** (cold path, once): `calloc` the sub-context on first access
2. **Pointer retrieval** (hot path, every call): return the already-initialized pointer

Every call site — even after initialization — paid the cost of redundant NULL checks and lazy-init branches. More importantly, allocation failures in the getters were silently swallowed: some callers checked for NULL returns, others did not, creating potential NULL-pointer dereference bugs.

## Technical Details

Replace the 6 lazy-init getter functions (`hsakmt_kfdcontext_get_{event,perf,debug,queue,topology,fmm}_context()`)
with pre-allocation in `hsakmt_kfdcontext_init_context()`. Callers now access sub-context pointers directly via `ctx->xxx_context` instead of going through a getter.

### Changes
- **`kfdcontext.h`/`kfdcontext.c`**: 6 getter declarations replaced with 6 `_init` declarations. `init_context()` now returns `int` (0 on success, -1 on failure) and calls all 6 `_init_xxx_context()` functions with error checking.
- **`openclose.c`**: Both call sites (`hsaKmtOpenKFDCtx`, `hsaKmtOpenSecondaryKFDCtx`) check the return value and propagate `HSAKMT_STATUS_NO_MEMORY` on failure.
- **`events.c`, `perfctr.c`, `debug.c`, `queues.c`, `topology.c`, `fmm.c`**: Each getter is replaced with an `_init` function (calloc + initialization only).
  ~80 call sites changed from `hsakmt_kfdcontext_get_xxx_context(ctx)` to `ctx->xxx_context`.


## Benefits

1. **Proper error propagation**: `calloc` failures during init are now caught and returned as `HSAKMT_STATUS_NO_MEMORY` to the caller, instead of silently returning NULL pointers that may crash later.
2. **Centralized lifecycle**: All sub-context allocation happens in one place  (`init_context`), making the create/destroy lifecycle clear and symmetric.
3. **Code simplification**: Removed ~120 lines of boilerplate getter code (assert + NULL check + lazy-init branch) across 6 files.
4. **Eliminates redundant branches**: ~80 call sites no longer execute NULL checks and lazy-init conditionals on every access.

## Test Plan
kfdtest

## Test Result
kfdtest suite passes under all three build configurations:
- ✅ Original API (no macros)
- ✅ Context-aware API with primary context (`HSAKMT_CTX=1`)
- ✅ Context-aware API with secondary context (`HSAKMT_CTX=1`, `HSAKMT_SECONDARY_CTX=1`)
