### PR TITLE
[rocprofiler-systems] Remove get_is_continuous_integration

### DIFF
--- a/projects/rocprofiler-systems/source/lib/core/config.cpp
+++ b/projects/rocprofiler-systems/source/lib/core/config.cpp
@@ -67,7 +67,6 @@ namespace
 {
 int  verbose_value  = tim::get_env<int>("ROCPROFSYS_VERBOSE", 0, false);
 bool debug_value    = tim::get_env<bool>("ROCPROFSYS_DEBUG", false, false);
-bool is_ci_value    = tim::get_env<bool>("ROCPROFSYS_CI", false, false);
 auto configure_once = std::once_flag{};
 
 TIMEMORY_NOINLINE bool&
@@ -197,7 +196,7 @@ configure_settings(bool _init)
 
     if(settings_are_configured()) return;
 
-    if(is_ci_value && get_state() < State::Init)
+    if(get_state() < State::Init)
     {
         timemory_print_demangled_backtrace<64>();
 
@@ -1085,7 +1084,6 @@ configure_settings(bool _init)
 
     if(auto opt = get_setting_value<int>("ROCPROFSYS_VERBOSE"); opt) verbose_value = *opt;
     if(auto opt = get_setting_value<bool>("ROCPROFSYS_DEBUG"); opt) debug_value = *opt;
-    if(auto opt = get_setting_value<bool>("ROCPROFSYS_CI"); opt) is_ci_value = *opt;
 
     if(get_env("ROCPROFSYS_MONOCHROME", _config->get<bool>("ROCPROFSYS_MONOCHROME")))
         tim::log::monochrome() = true;
@@ -1153,7 +1151,6 @@ configure_settings(bool _init)
 
     if(auto opt = get_setting_value<int>("ROCPROFSYS_VERBOSE"); opt) verbose_value = *opt;
     if(auto opt = get_setting_value<bool>("ROCPROFSYS_DEBUG"); opt) debug_value = *opt;
-    if(auto opt = get_setting_value<bool>("ROCPROFSYS_CI"); opt) is_ci_value = *opt;
 
     _settings_are_configured() = true;
 }
@@ -1505,7 +1502,7 @@ handle_deprecated_setting(const std::string& _old, const std::string& _new,
 
     if(_old_setting == _config->end()) return;
 
-    if(get_is_continuous_integration() && _new_setting == _config->end())
+    if(_new_setting == _config->end())
     {
         throw std::runtime_error(
             fmt::format("New configuration setting not found: '{}'", _new));
@@ -1829,12 +1826,6 @@ get_debug_env()
 }
 
 bool
-get_is_continuous_integration()
-{
-    return is_ci_value;
-}
-
-bool
 get_debug_init()
 {
     return tim::get_env<bool>("ROCPROFSYS_DEBUG_INIT", get_debug_env());
@@ -2144,8 +2135,7 @@ get_category_config()
             std::abort();
         }
 
-        if(get_is_continuous_integration() &&
-           _enabled.size() + _disabled.size() != _avail.size())
+        if(_enabled.size() + _disabled.size() != _avail.size())
         {
             throw std::runtime_error(
                 fmt::format("Error! Internal error for categories: {} (enabled) + {} "

--- a/projects/rocprofiler-systems/source/lib/core/config.hpp
+++ b/projects/rocprofiler-systems/source/lib/core/config.hpp
@@ -151,9 +151,6 @@ bool&
 is_binary_rewrite();
 
 bool
-get_is_continuous_integration() ROCPROFSYS_HOT;
-
-bool
 get_debug_env() ROCPROFSYS_HOT;
 
 bool

--- a/projects/rocprofiler-systems/source/lib/core/perfetto.cpp
+++ b/projects/rocprofiler-systems/source/lib/core/perfetto.cpp
@@ -128,7 +128,7 @@ stop()
 
     auto& tracing_session = get_perfetto_session();
 
-    if(get_is_continuous_integration() && tracing_session == nullptr)
+    if(tracing_session == nullptr)
     {
         throw std::runtime_error("Null pointer to the tracing session");
     }
@@ -179,7 +179,7 @@ post_process(tim::manager* _timemory_manager, bool& _perfetto_output_error,
             auto _fnum_read = ::fread(_data.data(), sizeof(char), _fnum_elem, _fdata);
             ::fclose(_fdata);
 
-            if(get_is_continuous_integration() && _fnum_read != _fnum_elem)
+            if(_fnum_read != _fnum_elem)
             {
                 throw std::runtime_error(fmt::format(
                     "read {} elements from perfetto trace file '{}'. Expected {}",

--- a/projects/rocprofiler-systems/source/lib/core/perfetto.hpp
+++ b/projects/rocprofiler-systems/source/lib/core/perfetto.hpp
@@ -84,14 +84,12 @@ perfetto_counter_track<Tp>::emplace(size_t _idx, const std::string& _v,
     auto& _name_data  = get_data().first[_idx];
     auto& _track_data = get_data().second[_idx];
     std::vector<std::tuple<std::string, const char*, bool>> _missing = {};
-    if(config::get_is_continuous_integration())
+
+    for(const auto& itr : _name_data)
     {
-        for(const auto& itr : _name_data)
-        {
-            _missing.emplace_back(std::make_tuple(*itr, itr->c_str(), false));
-            // TODO: _missing.emplace_back(*itr, itr->c_str(), false);
-        }
+        _missing.emplace_back(*itr, itr->c_str(), false);
     }
+
     auto        _index     = _track_data.size();
     auto&       _name      = _name_data.emplace_back(std::make_unique<std::string>(_v));
     const char* _name_cstr = _name->c_str();
@@ -107,40 +105,37 @@ perfetto_counter_track<Tp>::emplace(size_t _idx, const std::string& _v,
             .set_category(_category)
             .set_unit_multiplier(_mult)
             .set_is_incremental(_incr));
-    if(config::get_is_continuous_integration())
+
+    for(auto& itr : _missing)
     {
-        for(auto& itr : _missing)
+        const char* citr = std::get<1>(itr);
+        for(const auto& ditr : _name_data)
         {
-            const char* citr = std::get<1>(itr);
-            for(const auto& ditr : _name_data)
+            if(citr == ditr->c_str() && strcmp(citr, ditr->c_str()) == 0)
             {
-                if(citr == ditr->c_str() && strcmp(citr, ditr->c_str()) == 0)
-                {
-                    std::get<2>(itr) = true;
-                    break;
-                }
+                std::get<2>(itr) = true;
+                break;
             }
-            if(!std::get<2>(itr))
-            {
-                std::set<void*> _prev = {};
-                std::set<void*> _curr = {};
-                for(const auto& eitr : _missing)
-                    _prev.emplace(
-                        static_cast<void*>(const_cast<char*>(std::get<1>(eitr))));
-                for(const auto& eitr : _name_data)
-                    _curr.emplace(static_cast<void*>(const_cast<char*>(eitr->c_str())));
-                std::stringstream _pss{};
-                for(auto&& eitr : _prev)
-                    _pss << " " << std::hex << std::setw(12) << std::left << eitr;
-                std::stringstream _css{};
-                for(auto&& eitr : _curr)
-                    _css << " " << std::hex << std::setw(12) << std::left << eitr;
-                throw std::runtime_error(fmt::format(
-                    "perfetto_counter_track emplace method for '{}' ({:p}) "
-                    "invalidated C-string '{}' ({p}).\nprevious: {}\ncurrent: {}\n",
-                    _v, (void*) _name->c_str(), std::get<0>(itr),
-                    (void*) std::get<0>(itr).c_str(), _pss.str(), _css.str()));
-            }
+        }
+        if(!std::get<2>(itr))
+        {
+            std::set<void*> _prev = {};
+            std::set<void*> _curr = {};
+            for(const auto& eitr : _missing)
+                _prev.emplace(static_cast<void*>(const_cast<char*>(std::get<1>(eitr))));
+            for(const auto& eitr : _name_data)
+                _curr.emplace(static_cast<void*>(const_cast<char*>(eitr->c_str())));
+            std::stringstream _pss{};
+            for(auto&& eitr : _prev)
+                _pss << " " << std::hex << std::setw(12) << std::left << eitr;
+            std::stringstream _css{};
+            for(auto&& eitr : _curr)
+                _css << " " << std::hex << std::setw(12) << std::left << eitr;
+            throw std::runtime_error(fmt::format(
+                "perfetto_counter_track emplace method for '{}' ({:p}) "
+                "invalidated C-string '{}' ({p}).\nprevious: {}\ncurrent: {}\n",
+                _v, (void*) _name->c_str(), std::get<0>(itr),
+                (void*) std::get<0>(itr).c_str(), _pss.str(), _css.str()));
         }
     }
     return _index;

--- a/projects/rocprofiler-systems/source/lib/core/state.cpp
+++ b/projects/rocprofiler-systems/source/lib/core/state.cpp
@@ -68,7 +68,7 @@ set_state(State _n)
                   std::to_string(_n));
     }
     // state should always be increased, not decreased
-    if(get_is_continuous_integration() && _n < get_state())
+    if(_n < get_state())
     {
         throw std::runtime_error(
             fmt::format("State is being assigned to a lesser value :: {} -> {}",

--- a/projects/rocprofiler-systems/source/lib/core/trace_cache/metadata_registry.cpp
+++ b/projects/rocprofiler-systems/source/lib/core/trace_cache/metadata_registry.cpp
@@ -734,15 +734,13 @@ metadata_registry::overwrite_callback_names(
             modified_ops[i] = extract_operations(i);
         }
 
-        if(get_is_continuous_integration() &&
-           modified_ops.find(callback_kind) != modified_ops.end())
+        if(modified_ops.find(callback_kind) != modified_ops.end())
         {
             throw std::runtime_error(
                 "Overwriting a previously overwritten entry is forbidden");
         }
 
-        if(get_is_continuous_integration() && !modified_ops.empty() &&
-           callback_kind >= modified_ops.begin()->first)
+        if(!modified_ops.empty() && callback_kind >= modified_ops.begin()->first)
         {
             throw std::runtime_error(
                 "Category must have a larger enum value than all previously "
@@ -753,8 +751,7 @@ metadata_registry::overwrite_callback_names(
         auto operation_names = extract_operations(callback_kind);
         for(const auto& [index, new_value] : category_info.second)
         {
-            if(get_is_continuous_integration() &&
-               (index < 0 || static_cast<size_t>(index) >= operation_names.size()))
+            if((index < 0 || static_cast<size_t>(index) >= operation_names.size()))
             {
                 throw std::runtime_error("Index is invalid");
             }
@@ -771,7 +768,7 @@ metadata_registry::overwrite_callback_names(
     {
         auto renaming_entry = modified_ops.find(i);
 
-        if(get_is_continuous_integration() && renaming_entry == modified_ops.end())
+        if(renaming_entry == modified_ops.end())
         {
             throw std::runtime_error("A category that needs to be emplaced is missing");
         }

--- a/projects/rocprofiler-systems/source/lib/core/trace_cache/perfetto_processor.cpp
+++ b/projects/rocprofiler-systems/source/lib/core/trace_cache/perfetto_processor.cpp
@@ -461,7 +461,7 @@ perfetto_processor_t::get_session_data()
         auto _fnum_read = ::fread(_data.data(), sizeof(char), _fnum_elem, _fdata);
         ::fclose(_fdata);
 
-        if(get_is_continuous_integration() && _fnum_read != _fnum_elem)
+        if(_fnum_read != _fnum_elem)
         {
             throw std::runtime_error(fmt::format(
                 "Error! read {} elements from perfetto trace file '{}'. Expected {}",

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library.cpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library.cpp
@@ -199,14 +199,13 @@ ensure_finalization(bool _static_init = false)
     const auto& _tid  = _info->index_data;
     if(_tid)
     {
-        if(get_is_continuous_integration() && _tid->sequent_value != threading::get_id())
+        if(_tid->sequent_value != threading::get_id())
         {
             throw std::runtime_error(fmt::format("Error! internal tid != {} :: {}",
                                                  threading::get_id(),
                                                  _tid->sequent_value));
         }
-        if(get_is_continuous_integration() &&
-           _tid->system_value != threading::get_sys_tid())
+        if(_tid->system_value != threading::get_sys_tid())
         {
             throw std::runtime_error(fmt::format("Error! system tid != {} :: {}",
                                                  threading::get_sys_tid(),
@@ -506,7 +505,7 @@ rocprofsys_init_library_hidden()
         LOG_DEBUG("State is {}...", std::to_string(get_state()));
     }
 
-    if(get_is_continuous_integration() && get_state() != State::PreInit)
+    if(get_state() != State::PreInit)
     {
         throw std::runtime_error(
             fmt::format("State is not PreInit :: {}", std::to_string(get_state())));
@@ -533,7 +532,7 @@ rocprofsys_init_library_hidden()
 
     set_state(State::Init);
 
-    if(get_is_continuous_integration() && get_state() != State::Init)
+    if(get_state() != State::Init)
     {
         throw std::runtime_error(fmt::format("set_state(State::Init) failed. state is {}",
                                              std::to_string(get_state())));
@@ -830,7 +829,7 @@ rocprofsys_init_hidden(const char* _mode, bool _is_binary_rewrite, const char* _
     }
 
     tracing::get_finalization_functions().emplace_back([_argv0_c]() {
-        if(get_is_continuous_integration() && get_state() != State::Active)
+        if(get_state() != State::Active)
         {
             throw std::runtime_error(
                 fmt::format("Finalizer function for popping main invoked in non-active "
@@ -1255,7 +1254,7 @@ rocprofsys_finalize_hidden(void)
                                              get_perfetto_output_filename()));
     }
 
-    if(get_is_continuous_integration() && _push_count > _pop_count &&
+    if(_push_count > _pop_count &&
        !get_env<bool>("ROCPROFSYS_CI_SKIP_PUSH_POP_CHECK", false, false))
     {
         throw std::runtime_error(fmt::format(

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library/causal/data.cpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library/causal/data.cpp
@@ -69,7 +69,7 @@ auto speedup_dist      = []() {
     size_t _nzero = std::ceil(_v.size() / 4.0);
     _v.resize(_v.size() + _nzero, 0);
     std::sort(_v.begin(), _v.end());
-    if(get_is_continuous_integration() && _v.back() > 100)
+    if(_v.back() > 100)
     {
         throw std::runtime_error(
             fmt::format("Error! last value is too large: {}", _v.back()));
@@ -803,9 +803,7 @@ sample_selection(size_t _nitr, size_t _wait_ns)
             // unlikely this will be empty but just in case
             if(linfo.empty()) continue;
 
-            // debugging for continuous integration
-            if(ROCPROFSYS_UNLIKELY(config::get_is_continuous_integration() ||
-                                   config::get_debug()))
+            if(ROCPROFSYS_UNLIKELY(config::get_debug()))
             {
                 auto _location =
                     (_dl_info.location)

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library/components/backtrace_metrics.cpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library/components/backtrace_metrics.cpp
@@ -177,7 +177,7 @@ apply_for_all_thread_names(std::int64_t                            _tid,
         {
             std::string _desc = tim::papi::get_event_info(itr).short_descr;
             if(_desc.empty()) _desc = itr;
-            if(get_is_continuous_integration() && _desc.empty())
+            if(_desc.empty())
             {
                 throw std::runtime_error(
                     fmt::format("Empty description for {}", itr.c_str()));
@@ -394,7 +394,7 @@ backtrace_metrics::init_perfetto(std::int64_t _tid, valid_array_t _valid)
         {
             std::string _desc = tim::papi::get_event_info(itr).short_descr;
             if(_desc.empty()) _desc = itr;
-            if(get_is_continuous_integration() && _desc.empty())
+            if(_desc.empty())
             {
                 throw std::runtime_error(
                     fmt::format("Empty description for {}", itr.c_str()));
@@ -411,7 +411,7 @@ backtrace_metrics::fini_perfetto(std::int64_t _tid, valid_array_t _valid)
     auto        _hw_cnt_labels = *get_papi_labels(_tid);
     const auto& _thread_info   = thread_info::get(_tid, SequentTID);
 
-    if(get_is_continuous_integration() && !_thread_info)
+    if(!_thread_info)
     {
         throw std::runtime_error(
             fmt::format("Error! missing thread info for tid={}", _tid));

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library/components/mpi_gotcha.cpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library/components/mpi_gotcha.cpp
@@ -59,7 +59,7 @@ struct comm_rank_data
 
     friend bool operator>(const comm_rank_data& _lhs, const comm_rank_data& _rhs)
     {
-        if(get_is_continuous_integration() && !_lhs.updated() && !_rhs.updated())
+        if(!_lhs.updated() && !_rhs.updated())
         {
             throw std::runtime_error("Error! Comparing rank data that is not updated");
         }

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library/components/pthread_mutex_gotcha.cpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library/components/pthread_mutex_gotcha.cpp
@@ -61,7 +61,7 @@ pthread_mutex_gotcha::get_hashes()
                 LOG_WARNING("pthread_mutex_gotcha tool id at index {} was empty!", i);
             }
 
-            if(get_is_continuous_integration() && (_id.empty() || _init.at(i) == 0))
+            if(_id.empty() || _init.at(i) == 0)
             {
                 LOG_CRITICAL("pthread_mutex_gotcha tool id at index {} has no hash value",
                              i);

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library/coverage.cpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library/coverage.cpp
@@ -196,7 +196,7 @@ post_process()
 
     auto _get_setting = [](const std::string& _v) {
         auto&& _b = config::get_setting_value<bool>(_v);
-        if(!_b && get_is_continuous_integration())
+        if(!_b)
         {
             throw std::runtime_error(
                 fmt::format("Error! No configuration setting named '{}'", _v));

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library/process_sampler.cpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library/process_sampler.cpp
@@ -179,7 +179,7 @@ sampler::shutdown()
         }
 
         // during CI, throw an error if polling_finished is not valid
-        if(!polling_finished && get_is_continuous_integration())
+        if(!polling_finished)
         {
             throw std::runtime_error("polling_finished is not valid");
         }

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library/rocprofiler-sdk.cpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library/rocprofiler-sdk.cpp
@@ -339,24 +339,12 @@ create_agent_profile(rocprofiler_agent_id_t          agent_id,
         }
         auto missing_counters_str = fmt::format("{}", fmt::join(missing_counters, ", "));
 
-        // In production, warn and continue with available counters
         LOG_WARNING("Unable to find all counters for agent {} (gpu-{}, {}). "
                     "Requested: {}. Found: {}. Missing: {}. Continuing with "
                     "available counters.",
                     tool_agent_v->agent->node_id, tool_agent_v->device_id,
                     tool_agent_v->agent->name, requested_counters, found_counters,
                     missing_counters_str);
-
-        if(get_is_continuous_integration())
-        {
-            LOG_CRITICAL("Unable to find all counters for agent {} (gpu-{}, {}) in "
-                         "{}. Found: {}",
-                         tool_agent_v->agent->node_id, tool_agent_v->device_id,
-                         tool_agent_v->agent->name, requested_counters, found_counters);
-
-            ::rocprofsys::set_state(::rocprofsys::State::Finalized);
-            ::std::abort();
-        }
     }
 
     if(!counters_v.empty())
@@ -1454,7 +1442,6 @@ tool_tracing_callback(rocprofiler_callback_tracing_record_t record,
             case ROCPROFILER_CALLBACK_TRACING_HIP_STREAM:
 #endif
             {
-                if(get_is_continuous_integration())
                 {
                     LOG_CRITICAL("Unhandled callback record: {}",
                                  static_cast<int>(record.kind));
@@ -1465,7 +1452,6 @@ tool_tracing_callback(rocprofiler_callback_tracing_record_t record,
             }
             default:
             {
-                if(get_is_continuous_integration())
                 {
                     LOG_CRITICAL("Unhandled callback record: {}", info.str());
                     ::rocprofsys::set_state(::rocprofsys::State::Finalized);
@@ -1547,7 +1533,6 @@ tool_tracing_callback(rocprofiler_callback_tracing_record_t record,
             case ROCPROFILER_CALLBACK_TRACING_HIP_STREAM:
 #endif
             {
-                if(get_is_continuous_integration())
                 {
                     LOG_CRITICAL("Unhandled callback record: {}",
                                  static_cast<int>(record.kind));
@@ -1558,7 +1543,6 @@ tool_tracing_callback(rocprofiler_callback_tracing_record_t record,
             }
             default:
             {
-                if(get_is_continuous_integration())
                 {
                     LOG_CRITICAL("Unhandled callback record: {}", info.str());
                     ::rocprofsys::set_state(::rocprofsys::State::Finalized);
@@ -1669,14 +1653,10 @@ tool_tracing_callback(rocprofiler_callback_tracing_record_t record,
     }
     else
     {
-        if(get_is_continuous_integration())
-        {
-            LOG_CRITICAL("unhandled callback record phase: {}",
-                         static_cast<int>(record.phase));
-            ::rocprofsys::set_state(::rocprofsys::State::Finalized);
-            ::std::abort();
-        }
-        LOG_WARNING("tool_tracing_callback: unhandled callback record: {}", info.str());
+        LOG_CRITICAL("unhandled callback record phase: {}",
+                     static_cast<int>(record.phase));
+        ::rocprofsys::set_state(::rocprofsys::State::Finalized);
+        ::std::abort();
     }
 }
 
@@ -2582,12 +2562,9 @@ tool_init(rocprofiler_client_finalize_t fini_func, void* user_data)
             &_data->memory_alloc_buffer));
         if(_data->memory_alloc_buffer.handle == 0UL)
         {
-            if(get_is_continuous_integration())
-            {
-                LOG_CRITICAL("Failed to create memory allocation buffer");
-                ::rocprofsys::set_state(::rocprofsys::State::Finalized);
-                ::std::abort();
-            }
+            LOG_CRITICAL("Failed to create memory allocation buffer");
+            ::rocprofsys::set_state(::rocprofsys::State::Finalized);
+            ::std::abort();
         }
         auto _ops =
             rocprofiler_sdk::get_operations(ROCPROFILER_BUFFER_TRACING_MEMORY_ALLOCATION);

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library/sampling.cpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library/sampling.cpp
@@ -220,7 +220,7 @@ void
 metadata_initialize_thread_info(size_t tid)
 {
     const auto& _thread_info = thread_info::get(tid, SequentTID);
-    if(get_is_continuous_integration() && !_thread_info)
+    if(!_thread_info)
     {
         throw std::runtime_error(fmt::format("No valid thread info for tid={}", tid));
     }
@@ -237,7 +237,7 @@ void
 metadata_initialize_track(std::int64_t tid)
 {
     const auto& _thread_info = thread_info::get(tid, SequentTID);
-    if(get_is_continuous_integration() && !_thread_info)
+    if(!_thread_info)
     {
         throw std::runtime_error(fmt::format("No valid thread info for tid={}", tid));
     }
@@ -295,7 +295,7 @@ cache_sampling_data(std::int64_t                               _tid,
     }
 
     const auto& _thread_info = thread_info::get(_tid, SequentTID);
-    if(get_is_continuous_integration() && !_thread_info)
+    if(!_thread_info)
     {
         throw std::runtime_error(fmt::format("No valid thread info for tid={}", _tid));
     }
@@ -597,7 +597,7 @@ get_offload_file()
         if(get_use_tmp_files())
         {
             auto _success = _tmp_v->open();
-            if(get_is_continuous_integration() && !_success)
+            if(!_success)
             {
                 LOG_CRITICAL("Error opening sampling offload temporary file '{}'",
                              _tmp_v->filename);
@@ -1202,8 +1202,7 @@ post_process()
                       _raw_data.size());
         }
 
-        if(get_is_continuous_integration() &&
-           _sampler->get_sample_count() != _raw_data.size())
+        if(_sampler->get_sample_count() != _raw_data.size())
         {
             throw std::runtime_error(fmt::format(
                 "Error! sampler recorded {} samples but {} samples were returned",
@@ -1412,7 +1411,7 @@ post_process_perfetto(std::int64_t                               _tid,
     }
 
     const auto& _thread_info = thread_info::get(_tid, SequentTID);
-    if(get_is_continuous_integration() && !_thread_info)
+    if(!_thread_info)
     {
         throw std::runtime_error(fmt::format("No valid thread info for tid={}", _tid));
     }

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library/thread_info.cpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library/thread_info.cpp
@@ -209,7 +209,7 @@ thread_info::get(native_handle_t&& _tid)
         }
     }
 
-    if(get_is_continuous_integration() && unknown_thread)
+    if(unknown_thread)
     {
         throw std::runtime_error("Unknown thread has been assigned a value");
     }
@@ -228,7 +228,7 @@ thread_info::get(std::thread::id _tid)
         }
     }
 
-    if(get_is_continuous_integration() && unknown_thread)
+    if(unknown_thread)
     {
         throw std::runtime_error("Unknown thread has been assigned a value");
     }
@@ -278,7 +278,7 @@ thread_info::get(std::int64_t _tid, ThreadIdType _type)
             "ThreadIdType) with ThreadIdType::StlThreadID");
     }
 
-    if(get_is_continuous_integration() && unknown_thread)
+    if(unknown_thread)
     {
         throw std::runtime_error("Unknown thread has been assigned a value");
     }

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library/tracing.hpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library/tracing.hpp
@@ -181,7 +181,7 @@ get_perfetto_track(CategoryT, FuncT&& _desc_generator, Args&&... _args)
     // overhead of generating string during releases
 #if defined(ROCPROFSYS_CI) && ROCPROFSYS_CI > 0
     auto _name = std::forward<FuncT>(_desc_generator)(std::forward<Args>(_args)...);
-    if(get_is_continuous_integration() && _track_uuids.at(_uuid) != _name)
+    if(_track_uuids.at(_uuid) != _name)
     {
         throw std::runtime_error(
             fmt::format("Error! Multiple invocations of UUID {} produced different "


### PR DESCRIPTION
## Motivation

`ROCPROFSYS_CI` and `get_is_continuous_integration()` gated many internal consistency checks and fatal error paths so they only ran when CI was enabled. Production and local runs could therefore miss the same bugs or undefined behavior that CI would surface. This change removes that split: validations and abort-on-error behavior apply in all environments, so regressions show up immediately for every user and developer.

## Technical Details

### Summary

Drop the CI flag and thread its removal through config, Perfetto, and the rocprof-sys library so defensive checks are no longer conditional on `ROCPROFSYS_CI`.

### Key changes

- **Config (`config.cpp` / `config.hpp`):** Remove `is_ci_value`, `ROCPROFSYS_CI` wiring, and `get_is_continuous_integration()`. Always print a demangled backtrace when `configure_settings` runs before `State::Init`. Always throw if a deprecated setting maps to a missing new key. Always enforce that enabled plus disabled categories cover exactly the available category set.
- **Perfetto (`perfetto.hpp`):** Run C-string invalidation validation in `perfetto_counter_track::emplace` unconditionally (previously only when CI was set).
- **Runtime assertions:** Remove `get_is_continuous_integration()` guards around throws/aborts in `library.cpp`, `rocprofiler-sdk.cpp`, `sampling.cpp`, thread info, causal data, AMD SMI paths, gotcha components, trace cache, coverage, and related code. Examples: thread ID consistency, init state machine invariants, finalize push/pop imbalance (still subject to `ROCPROFSYS_CI_SKIP_PUSH_POP_CHECK`), missing GPU counters (abort after critical log), unhandled tracing callbacks/phases, and failed memory allocation buffer creation.

### Design note

`ROCPROFSYS_CI_SKIP_PUSH_POP_CHECK` remains for opting out of the push/pop balance check at finalize when needed.

## JIRA ID

<!-- If applicable, add the JIRA ID (e.g. Resolves SWDEV-12345). Do not post JIRA links. -->

## Test Plan

- Run the rocprofiler-systems CI / ctest suite on this branch.
- Spot-check a workload that previously required `ROCPROFSYS_CI=1` to hit stricter paths; behavior should now match without setting the env var (except where documented opt-outs apply).

## Test Result

<!-- Fill in after CI / local verification. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
