### PR TITLE
[rocshmem] gda/topology: don't abort without NICs

### DIFF
--- a/projects/rocshmem/src/gda/topology.cpp
+++ b/projects/rocshmem/src/gda/topology.cpp
@@ -434,8 +434,7 @@ namespace rocshmem
           ibvDeviceList.push_back(ibvDevice);
         }
       } else {
-        fprintf(stderr, "[Error] No visible InfiniBand devices found.\n");
-        exit(1);
+        fprintf(stderr, "[Warning] No visible InfiniBand devices found.\n");
       }
       ibv.free_device_list(deviceList);
       isInitialized = true;


### PR DESCRIPTION
## Motivation

the topology code aborted if we didn't find any active NICs. Don't do that, just print a warning instead. This causes otherwise issues with the unit tests on some platforms.

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
