### PR TITLE
[ci] Adding core build for all components for `sanity tests`

### DIFF
--- a/.github/scripts/therock_configure_ci.py
+++ b/.github/scripts/therock_configure_ci.py
@@ -254,11 +254,12 @@ def retrieve_projects(args):
         if tests:
             merged_tests.update(t.strip() for t in tests.split(","))
     if enable_all:
-        final_flags = "-DTHEROCK_ENABLE_ALL=ON"
+        final_flags_list = ["-DTHEROCK_ENABLE_ALL=ON"]
     else:
-        final_flags = " ".join(sorted(merged_flags))
+        final_flags_list = sorted(merged_flags)
     # Always append -DTHEROCK_ENABLE_CORE=ON as a default at the end
-    final_flags += " -DTHEROCK_ENABLE_CORE=ON"
+    final_flags_list.append("-DTHEROCK_ENABLE_CORE=ON")
+    final_flags = " ".join(final_flags_list)
 
     return [
         {

--- a/.github/scripts/therock_configure_ci.py
+++ b/.github/scripts/therock_configure_ci.py
@@ -259,6 +259,8 @@ def retrieve_projects(args):
         final_flags_list = sorted(merged_flags)
     # Always append -DTHEROCK_ENABLE_CORE=ON as a default at the end
     final_flags_list.append("-DTHEROCK_ENABLE_CORE=ON")
+    # Removing duplicates
+    final_flags_list = list(set(final_flags_list))
     final_flags = " ".join(final_flags_list)
 
     return [

--- a/.github/scripts/therock_configure_ci.py
+++ b/.github/scripts/therock_configure_ci.py
@@ -241,7 +241,12 @@ def retrieve_projects(args):
         config = project_map.get(project)
         if not config:
             continue
-        flags = [f.strip() for f in config.get("cmake_options", "").split()]
+        cmake_options = config.get("cmake_options", [])
+        # Handle both array and string formats for backwards compatibility
+        if isinstance(cmake_options, str):
+            flags = [f.strip() for f in cmake_options.split()]
+        else:
+            flags = cmake_options
         if "-DTHEROCK_ENABLE_ALL=ON" in flags:
             enable_all = True
         merged_flags.update(flags)
@@ -252,6 +257,8 @@ def retrieve_projects(args):
         final_flags = "-DTHEROCK_ENABLE_ALL=ON"
     else:
         final_flags = " ".join(sorted(merged_flags))
+    # Always append -DTHEROCK_ENABLE_CORE=ON as a default at the end
+    final_flags += " -DTHEROCK_ENABLE_CORE=ON"
 
     return [
         {

--- a/.github/scripts/therock_matrix.py
+++ b/.github/scripts/therock_matrix.py
@@ -31,38 +31,38 @@ subtree_to_project_map = {
 
 project_map = {
     "core": {
-        "cmake_options": "-DTHEROCK_ENABLE_CORE=ON -DTHEROCK_ENABLE_ALL=OFF",
+        "cmake_options": ["-DTHEROCK_ENABLE_ALL=OFF"],
         "projects_to_test": "",  # will run sanity test to cover rocminfo and amdsmi
     },
     "dc_tools": {
-        "cmake_options": "-DTHEROCK_ENABLE_DC_TOOLS=ON -DTHEROCK_ENABLE_ALL=OFF",
+        "cmake_options": ["-DTHEROCK_ENABLE_ALL=OFF", "-DTHEROCK_ENABLE_DC_TOOLS=ON"],
         "projects_to_test": "",  # rdc-tests is not built by TheRock build system - TBD
     },
     # Make sure we enable THEROCK_ENABLE_CORE so we build amdsmitst to run sanity tests.
     "debug_tools": {
-        "cmake_options": "-DTHEROCK_ENABLE_DEBUG_TOOLS=ON -DTHEROCK_ENABLE_ALL=OFF -DTHEROCK_ENABLE_CORE=ON",
+        "cmake_options": ["-DTHEROCK_ENABLE_ALL=OFF", "-DTHEROCK_ENABLE_DEBUG_TOOLS=ON"],
         "projects_to_test": "rocr-debug-agent, rocgdb",
     },
     # media libs to be enabled in following PR
     # "media-libs": {
-    #     "cmake_options": "-DTHEROCK_ENABLE_CORE=ON -DTHEROCK_ENABLE_PROFILER=ON -DTHEROCK_ENABLE_MEDIA_LIBS=ON",
+    #     "cmake_options": ["-DTHEROCK_ENABLE_ALL=OFF", "-DTHEROCK_ENABLE_PROFILER=ON", "-DTHEROCK_ENABLE_MEDIA_LIBS=ON"],
     #     "projects_to_test": "", # "rocdecode-tests, rocjpeg-tests",
     # },
     "profiler": {
-        "cmake_options": "-DTHEROCK_ENABLE_ALL=ON",
+        "cmake_options": ["-DTHEROCK_ENABLE_ALL=ON"],
         "projects_to_test": "aqlprofile, rocprofiler-compute, rocprofiler-systems",
     },
     # Make sure we enable THEROCK_ENABLE_CORE so we build amdsmitst to run sanity tests.
     "rocshmem": {
-        "cmake_options": "-DTHEROCK_ENABLE_ROCSHMEM=ON -DTHEROCK_ENABLE_ALL=OFF -DTHEROCK_ENABLE_CORE=ON",
+        "cmake_options": ["-DTHEROCK_ENABLE_ALL=OFF", "-DTHEROCK_ENABLE_ROCSHMEM=ON"],
         "projects_to_test": "",  # rocshmem testing to be enabled in a future PR
     },
     "runtimes": {
-        "cmake_options": "-DTHEROCK_ENABLE_ALL=ON",
+        "cmake_options": ["-DTHEROCK_ENABLE_ALL=ON"],
         "projects_to_test": "hip-tests, rocrtst",
     },
     "all": {
-        "cmake_options": "-DTHEROCK_ENABLE_ALL=ON",
+        "cmake_options": ["-DTHEROCK_ENABLE_ALL=ON"],
         "projects_to_test": "hip-tests, rocrtst, aqlprofile, rocprofiler-compute, rocprofiler-systems, rocr-debug-agent, rocgdb",
     },
 }

--- a/.github/scripts/therock_matrix.py
+++ b/.github/scripts/therock_matrix.py
@@ -38,7 +38,6 @@ project_map = {
         "cmake_options": ["-DTHEROCK_ENABLE_ALL=OFF", "-DTHEROCK_ENABLE_DC_TOOLS=ON"],
         "projects_to_test": "",  # rdc-tests is not built by TheRock build system - TBD
     },
-    # Make sure we enable THEROCK_ENABLE_CORE so we build amdsmitst to run sanity tests.
     "debug_tools": {
         "cmake_options": ["-DTHEROCK_ENABLE_ALL=OFF", "-DTHEROCK_ENABLE_DEBUG_TOOLS=ON"],
         "projects_to_test": "rocr-debug-agent, rocgdb",
@@ -52,7 +51,6 @@ project_map = {
         "cmake_options": ["-DTHEROCK_ENABLE_ALL=ON"],
         "projects_to_test": "aqlprofile, rocprofiler-compute, rocprofiler-systems",
     },
-    # Make sure we enable THEROCK_ENABLE_CORE so we build amdsmitst to run sanity tests.
     "rocshmem": {
         "cmake_options": ["-DTHEROCK_ENABLE_ALL=OFF", "-DTHEROCK_ENABLE_ROCSHMEM=ON"],
         "projects_to_test": "",  # rocshmem testing to be enabled in a future PR

--- a/.github/scripts/therock_matrix.py
+++ b/.github/scripts/therock_matrix.py
@@ -31,7 +31,7 @@ subtree_to_project_map = {
 
 project_map = {
     "core": {
-        "cmake_options": ["-DTHEROCK_ENABLE_ALL=OFF"],
+        "cmake_options": ["-DTHEROCK_ENABLE_CORE=ON", "-DTHEROCK_ENABLE_ALL=OFF"],
         "projects_to_test": "",  # will run sanity test to cover rocminfo and amdsmi
     },
     "dc_tools": {


### PR DESCRIPTION
Sanity check requires `amdsmi`, which requires core build. some components don't require it, so adding it as default