### PR TITLE
Add option to skip multinode/atomic tests, configuring kernel param tests

### DIFF
--- a/projects/rocm-core/rdhc/README.md
+++ b/projects/rocm-core/rdhc/README.md
@@ -4,7 +4,6 @@
 
 RDHC is a comprehensive health check tool for ROCm deployments. It validates GPU presence, driver status, kernel parameters, library dependencies, and tests installed ROCm components.
 
-
 ## Features
 
 - **Cross-Platform Support**: Works on Ubuntu, RHEL, and SLES distributions
@@ -12,7 +11,7 @@ RDHC is a comprehensive health check tool for ROCm deployments. It validates GPU
 - **Dynamic Component Detection**: Automatically identifies installed ROCm components
 - **Flexible Reporting**: Pretty table output and JSON export options
 - **Configurable Verbosity**: Support for verbose, normal, and silent modes
-
+- **Optional check control**: Skip cluster-only or environment-limited tests; relax kernel parameter strictness (see [Optional CLI behavior](#optional-cli-behavior-pr-4478))
 
 ## Test Categories
 
@@ -28,6 +27,9 @@ RDHC is a comprehensive health check tool for ROCm deployments. It validates GPU
 8. **Environment Variables** - Checks ROCm-related environment settings
 9. **Multinode Cluster Readiness** - Validates network and MPI configuration
 10. **Atomic Operations** - Checks if atomic operations are enabled on GPUs
+
+Tests **9** and **10** can be skipped when not relevant (single-node systems, containers without full PCI/RDMA).
+Kernel parameter checks (**3**) can optionally be reported as warnings only instead of failures.
 
 ### Component Tests (--all mode)
 
@@ -52,7 +54,6 @@ The tool provides three types of output:
    - Test results with status and details
 3. **JSON Export** - Detailed results in JSON format for further analysis
 
-
 ## Install dependency pip packages
 
 ```bash
@@ -76,8 +77,15 @@ optional arguments:
   -j FILE, --json FILE  Export results to JSON file
   -d DIR, --dir DIR     Directory path for temporary files (default: /tmp/rdhc/)
   --rocm-install-prefix DIR  ROCm installation prefix. If set, this path is used; otherwise `ROCM_PATH` env or `/opt/rocm` is used.
+  --skip-multinode-readiness   Skip multinode cluster readiness test (e.g. single-node or no RDMA stack)
+  --skip-atomic-operations     Skip PCIe atomic operations test (e.g. containers or limited lspci)
+  --skip-optional-cluster-checks  Same as `--skip-multinode-readiness` and `--skip-atomic-operations` together
+  --kernel-params-warnings-only   Treat kernel parameter check failures as warnings instead of errors
+```
 
-Usage examples:
+### Usage examples
+
+```bash
 # Run quick test (default tests only)
 sudo -E ./rdhc.py
 
@@ -104,10 +112,38 @@ sudo -E ./rdhc.py --rocm-install-prefix /usr/local/rocm
 
 # Custom prefix and run all tests
 sudo -E ./rdhc.py --rocm-install-prefix /usr/local/rocm --all -v
+
+# Skip multinode + atomic checks (single-node or container-friendly)
+sudo -E ./rdhc.py --skip-optional-cluster-checks
+
+# Or skip only one of them
+sudo -E ./rdhc.py --skip-multinode-readiness
+sudo -E ./rdhc.py --skip-atomic-operations
+
+# Kernel cmdline/sysctl checks: mismatches count as warnings, not FAIL
+sudo -E ./rdhc.py --kernel-params-warnings-only
+
+# Combine with other options
+sudo -E ./rdhc.py --all --skip-optional-cluster-checks --kernel-params-warnings-only -v
 ```
 
+## Optional CLI behavior (PR [#4478](https://github.com/ROCm/rocm-systems/pull/4478))
+
+These options improve usability when some checks are not applicable or cannot run reliably:
+
+| Option | Purpose |
+|--------|---------|
+| `--skip-multinode-readiness` | Skips the **Multinode Cluster Readiness** test (MPI, NIC drivers, RDMA modules). Use on **single-node** hosts or systems **without** an InfiniBand/RDMA stack. |
+| `--skip-atomic-operations` | Skips the **Atomic Operations** test (`lspci`-based). Use in **containers** or hosts where **PCIe capability** details are not visible without full access. |
+| `--skip-optional-cluster-checks` | Equivalent to passing **both** `--skip-multinode-readiness` and `--skip-atomic-operations`. |
+| `--kernel-params-warnings-only` | For the **Kernel Parameters** test, entries that would normally count as **errors** are treated as **warnings** so the overall check does not **FAIL** solely on kernel/cmdline tuning differences. |
+
+Skipped tests are recorded with status **NOT TESTED** and a short reason in the report/JSON.
+
 ## RDHC Environment VARIABLES
+
 RDHC tool will use the following ENV variables and act accordingly if they are set.
+
 ```bash
 # ROCm installation path can be set by the below ENV variable. Default is "/opt/rocm/"
 export ROCM_PATH="/opt/rocm"
@@ -140,6 +176,7 @@ pip3 install -r requirements.txt
 **Note for Ubuntu 24.04 users:** Due to enhanced security policies, `sudo -E` does not preserve the virtual environment PATH. Replace all `sudo -E` commands with `sudo --preserve-env=PATH` in the usage examples above.
 
 For example:
+
 ```bash
 # Instead of: sudo -E ./rdhc.py
 # Use:

--- a/projects/rocm-core/rdhc/README.md
+++ b/projects/rocm-core/rdhc/README.md
@@ -11,7 +11,7 @@ RDHC is a comprehensive health check tool for ROCm deployments. It validates GPU
 - **Dynamic Component Detection**: Automatically identifies installed ROCm components
 - **Flexible Reporting**: Pretty table output and JSON export options
 - **Configurable Verbosity**: Support for verbose, normal, and silent modes
-- **Optional check control**: Skip cluster-only or environment-limited tests; relax kernel parameter strictness (see [Optional CLI behavior](#optional-cli-behavior-pr-4478))
+- **Optional check control**: Skip cluster-only or environment-limited tests; relax kernel parameter strictness (see [Optional CLI behavior])
 
 ## Test Categories
 
@@ -127,7 +127,7 @@ sudo -E ./rdhc.py --kernel-params-warnings-only
 sudo -E ./rdhc.py --all --skip-optional-cluster-checks --kernel-params-warnings-only -v
 ```
 
-## Optional CLI behavior (PR [#4478](https://github.com/ROCm/rocm-systems/pull/4478))
+## Optional CLI behavior
 
 These options improve usability when some checks are not applicable or cannot run reliably:
 

--- a/projects/rocm-core/rdhc/rdhc.py
+++ b/projects/rocm-core/rdhc/rdhc.py
@@ -2011,6 +2011,7 @@ class ROCMHealthCheck:
         results["env_variables"] = {"status": status, "reason": reason}
 
         # Test 9: Multinode cluster readiness
+        self._print_test_start("Multinode cluster readiness")
         if self.skip_multinode_readiness:
             self.logger.info(
                 "Skipping multinode cluster readiness (--skip-multinode-readiness)."
@@ -2020,11 +2021,11 @@ class ROCMHealthCheck:
                 "reason": "Skipped (--skip-multinode-readiness).",
             }
         else:
-            self._print_test_start("Multinode cluster readiness")
             status, reason = self.test_check_multinode_cluster_readiness()
             results["Multinode_Readiness"] = {"status": status, "reason": reason}
 
         # Test 10: Atomic Operations
+        self._print_test_start("Is Atomic Operations Enabled")
         if self.skip_atomic_operations:
             self.logger.info(
                 "Skipping atomic operations check (--skip-atomic-operations)."
@@ -2034,7 +2035,6 @@ class ROCMHealthCheck:
                 "reason": "Skipped (--skip-atomic-operations).",
             }
         else:
-            self._print_test_start("Is Atomic Operations Enabled")
             status, reason = self.test_check_atomic_operations()
             results["atomic_operations"] = {"status": status, "reason": reason}
 

--- a/projects/rocm-core/rdhc/rdhc.py
+++ b/projects/rocm-core/rdhc/rdhc.py
@@ -243,12 +243,23 @@ def export_to_json(results, filename):
 
 
 class ROCMHealthCheck:
-    def __init__(self, logger=None, rocm_path=None):
+    def __init__(
+        self,
+        logger=None,
+        rocm_path=None,
+        skip_multinode_readiness=False,
+        skip_atomic_operations=False,
+        kernel_params_warnings_only=False,
+    ):
         if logger is None:
             self.logger = logging.getLogger("RDHC")
             self.logger.setLevel(logging.INFO)
         else:
             self.logger = logger
+
+        self.skip_multinode_readiness = skip_multinode_readiness
+        self.skip_atomic_operations = skip_atomic_operations
+        self.kernel_params_warnings_only = kernel_params_warnings_only
 
         # ROCm path: from constructor, or env, or default (used everywhere instead of os.environ.get)
         self.rocm_path = (
@@ -971,6 +982,21 @@ class ROCMHealthCheck:
                 "is_error": False,
             },
         ]
+
+        # Optional: treat all kernel_param_checks with is_error True as warnings (CLI)
+        if self.kernel_params_warnings_only:
+            adjusted = []
+            for c in kernel_param_checks:
+                nc = dict(c)
+                if nc.get("is_error"):
+                    nc["is_error"] = False
+                    if not nc.get("warning_message") and nc.get("error_message"):
+                        nc["warning_message"] = nc["error_message"]
+                adjusted.append(nc)
+            kernel_param_checks = adjusted
+            self.logger.info(
+                "----Kernel parameter checks: failures count as warnings (--kernel-params-warnings-only)."
+            )
 
         # Process each kernel parameter check
         for check in kernel_param_checks:
@@ -1985,14 +2011,32 @@ class ROCMHealthCheck:
         results["env_variables"] = {"status": status, "reason": reason}
 
         # Test 9: Multinode cluster readiness
-        self._print_test_start("Multinode cluster readiness")
-        status, reason = self.test_check_multinode_cluster_readiness()
-        results["Multinode_Readiness"] = {"status": status, "reason": reason}
+        if self.skip_multinode_readiness:
+            self.logger.info(
+                "Skipping multinode cluster readiness (--skip-multinode-readiness)."
+            )
+            results["Multinode_Readiness"] = {
+                "status": TestStatus.NOT_TESTED.value,
+                "reason": "Skipped (--skip-multinode-readiness).",
+            }
+        else:
+            self._print_test_start("Multinode cluster readiness")
+            status, reason = self.test_check_multinode_cluster_readiness()
+            results["Multinode_Readiness"] = {"status": status, "reason": reason}
 
         # Test 10: Atomic Operations
-        self._print_test_start("Is Atomic Operations Enabled")
-        status, reason = self.test_check_atomic_operations()
-        results["atomic_operations"] = {"status": status, "reason": reason}
+        if self.skip_atomic_operations:
+            self.logger.info(
+                "Skipping atomic operations check (--skip-atomic-operations)."
+            )
+            results["atomic_operations"] = {
+                "status": TestStatus.NOT_TESTED.value,
+                "reason": "Skipped (--skip-atomic-operations).",
+            }
+        else:
+            self._print_test_start("Is Atomic Operations Enabled")
+            status, reason = self.test_check_atomic_operations()
+            results["atomic_operations"] = {"status": status, "reason": reason}
 
         return results
 
@@ -2227,6 +2271,13 @@ def main():
         + "# Use a custom ROCm install prefix\n"
         + "sudo -E ./rdhc.py --rocm-install-prefix /usr/local/rocm\n"
         + "\n"
+        + "# Skip optional checks (e.g. single-node, containers without full PCI/RDMA)\n"
+        + "sudo -E ./rdhc.py --skip-optional-cluster-checks\n"
+        + "# (or: --skip-multinode-readiness --skip-atomic-operations)\n"
+        + "\n"
+        + "# Kernel cmdline/sysctl checks: failures as warnings only (no FAIL on mismatch)\n"
+        + "sudo -E ./rdhc.py --kernel-params-warnings-only\n"
+        + "\n"
         + "NOTE for Ubuntu 24.04 (Python 3.12) users:\n"
         + "Due to enhanced security policies, you must use a virtual environment:\n"
         + "  # Create and activate virtual environment (one-time setup)\n"
@@ -2274,7 +2325,31 @@ def main():
         help="ROCm installation prefix. If set, overrides ROCM_PATH; otherwise ROCM_PATH or /opt/rocm is used.",
         default=None,
     )
+    parser.add_argument(
+        "--skip-multinode-readiness",
+        action="store_true",
+        help="Skip multinode/RDMA readiness (use on nodes without InfiniBand or RDMA stack).",
+    )
+    parser.add_argument(
+        "--skip-atomic-operations",
+        action="store_true",
+        help="Skip PCIe atomic operations check (use in containers or when lspci cannot read capabilities).",
+    )
+    parser.add_argument(
+        "--skip-optional-cluster-checks",
+        action="store_true",
+        help="Skip multinode readiness and atomic operations (same as both --skip-* flags above).",
+    )
+    parser.add_argument(
+        "--kernel-params-warnings-only",
+        action="store_true",
+        help="For kernel parameter checks (numa, iommu, pci realloc, etc.), treat failures as warnings (is_error=false) instead of counting errors.",
+    )
     args = parser.parse_args()
+
+    if args.skip_optional_cluster_checks:
+        args.skip_multinode_readiness = True
+        args.skip_atomic_operations = True
 
     # Setup logger
     logger = setup_logger(args.verbose, args.silent)
@@ -2307,7 +2382,13 @@ def main():
         rocm_path = os.environ.get("ROCM_PATH", "/opt/rocm")
 
     # Create the health check instance
-    health_check = ROCMHealthCheck(logger, rocm_path=rocm_path)
+    health_check = ROCMHealthCheck(
+        logger,
+        rocm_path=rocm_path,
+        skip_multinode_readiness=args.skip_multinode_readiness,
+        skip_atomic_operations=args.skip_atomic_operations,
+        kernel_params_warnings_only=args.kernel_params_warnings_only,
+    )
 
     # Run tests with the temp_dir
     health_check.run_tests(run_all=args.all, temp_dir=temp_dir)


### PR DESCRIPTION
## Motivation

This pull request adds new command-line options to the `rdhc.py` tool, allowing users to skip certain cluster checks and to treat kernel parameter check failures as warnings instead of errors. These changes improve usability, especially for environments where some checks are not relevant or cannot be performed (e.g., single-node setups or containers).

## Technical Details

### New command-line options and configuration

* Added `--skip-multinode-readiness`, `--skip-atomic-operations`, and `--skip-optional-cluster-checks` flags to allow users to skip specific cluster readiness and atomic operations checks. The `--skip-optional-cluster-checks` flag sets both skip flags at once.
* Added `--kernel-params-warnings-only` flag to treat all kernel parameter check failures as warnings instead of errors, preventing test failures due to kernel parameter mismatches.

## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
