### PR TITLE
[rocshmem] Fix intermittent hang with bitcode wave tests

### DIFF
--- a/projects/rocshmem/tests/functional_tests/device_bitcode_tester.cpp
+++ b/projects/rocshmem/tests/functional_tests/device_bitcode_tester.cpp
@@ -98,13 +98,19 @@ DeviceBitcodeTester::~DeviceBitcodeTester() {
   }
 }
 
-void DeviceBitcodeTester::launch(const char* kernel, void** args,
-                                 dim3 grid, dim3 block) {
+void DeviceBitcodeTester::launch(const char* kernel, void** args) {
   hipFunction_t fn;
   CHECK_HIP(hipModuleGetFunction(&fn, module, kernel));
-  CHECK_HIP(hipModuleLaunchKernel(fn, grid.x, grid.y, grid.z,
-                                  block.x, block.y, block.z,
-                                  0, nullptr, args, nullptr));
+  if (wf_size <= 0) {
+    fprintf(stderr, "[PE %d] invalid runtime wavefront size: %d\n",
+            my_pe, wf_size);
+    rocshmem_global_exit(1);
+  }
+  // Prefer one wave per block for bitcode kernels; kernel-side wf_id gating
+  // also protects wave barrier participation if launch geometry regresses.
+  unsigned bx = static_cast<unsigned>(wf_size);
+  CHECK_HIP(hipModuleLaunchKernel(fn, 1, 1, 1, bx, 1, 1, 0, nullptr, args,
+                                  nullptr));
   CHECK_HIP(hipDeviceSynchronize());
 }
 

--- a/projects/rocshmem/tests/functional_tests/device_bitcode_tester.hpp
+++ b/projects/rocshmem/tests/functional_tests/device_bitcode_tester.hpp
@@ -44,8 +44,7 @@ class DeviceBitcodeTester : public Tester {
 
  private:
   std::string resolve_hsaco_path();
-  void launch(const char* kernel, void** args,
-              dim3 grid = 1, dim3 block = 64);
+  void launch(const char* kernel, void** args);
 
   template <typename T>
   void run_rma_test(const char* label, const char* kernel,

--- a/projects/rocshmem/tests/functional_tests/device_bitcode_tester_kernel.hip
+++ b/projects/rocshmem/tests/functional_tests/device_bitcode_tester_kernel.hip
@@ -180,13 +180,23 @@ extern "C" __global__ void test_typed_int_put_get_wave(
     int my_pe, int n_pes, int count)
 {
   if (blockIdx.x == 0) {
+    int wf_id = threadIdx.x / warpSize;
     int next_pe = (my_pe + 1) % n_pes;
     int prev_pe = (my_pe - 1 + n_pes) % n_pes;
 
-    rocshmem_int_put_wave(sym_dst, sym_src, count, next_pe);
-    rocshmem_barrier_all_wave();
+    // Restrict wave barrier participation to a single wave in the block.
+    // This avoids pSync protocol contention if launch geometry regresses to
+    // multi-wave blocks in the future.
+    if (wf_id == 0) {
+      rocshmem_int_put_wave(sym_dst, sym_src, count, next_pe);
+      rocshmem_barrier_all_wave();
+    }
+    // Keep sync outside conditionals so all block threads converge.
+    __syncthreads();
 
-    rocshmem_int_get_wave(local_result, sym_src, count, prev_pe);
+    if (wf_id == 0) {
+      rocshmem_int_get_wave(local_result, sym_src, count, prev_pe);
+    }
   }
 }
 


### PR DESCRIPTION

## Motivation

Earlier wf_size was hardcoded to 64 and that caused multi-wave launch per block on gfx1201 where wf_size is 32. This has caused both lane 0 and lane 1 to enter into `rocshmem_barrier_all_wave` simultaneously, resulting in pSync barrier contention. This has caused intermittent hangs.

## Technical Details

Fix is enforcing single-wave participation for barriers in test_typed_int_put_get_wave as well as using current wf_size from runtime instead of using hardcoded config for launch.

## JIRA ID

AIROCSHMEM-206

## Test Plan

Issue has been reproduced on gfx942 by forcing multi-wave launch in a stress testing, fix has been verified and no hang is observed on gfx942 or gfx1201

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
