### PR TITLE
Code object list updates performance improvements

### DIFF
--- a/projects/rocdbgapi/src/memory.h
+++ b/projects/rocdbgapi/src/memory.h
@@ -28,6 +28,7 @@
 
 #include <cstddef>
 #include <cstdint>
+#include <functional>
 #include <map>
 #include <optional>
 #include <string>
@@ -71,6 +72,8 @@ protected:
   uint64_t m_address;
 
 public:
+  using underlying_type_t = decltype (m_address);
+
   constexpr base_address_t () = default;
   constexpr base_address_t (uint64_t address) : m_address (address) {}
   constexpr operator uint64_t () const { return m_address; }
@@ -116,8 +119,8 @@ class global_address_t : public detail::base_address_t<global_address_t>
 public:
   constexpr global_address_t () : base_address_t (){};
   constexpr global_address_t (uint64_t address) : base_address_t (address) {}
-  operator agent_address_t () { return agent_address_t{ m_address }; }
-  operator host_address_t () { return host_address_t{ m_address }; }
+  operator agent_address_t () const { return agent_address_t{ m_address }; }
+  operator host_address_t () const { return host_address_t{ m_address }; }
 };
 
 template <> std::string to_string (agent_address_t address);
@@ -560,5 +563,54 @@ public:
 };
 
 } /* namespace amd::dbgapi */
+
+/* Hash functions for host, agent, and global address types.  */
+
+namespace std
+{
+template <typename T> struct hash<amd::dbgapi::detail::base_address_t<T>>
+{
+  size_t operator() (
+    const amd::dbgapi::detail::base_address_t<T> &address) const noexcept
+  {
+    using underlying_type_t =
+      typename amd::dbgapi::detail::base_address_t<T>::underlying_type_t;
+    return hash<underlying_type_t>{}(static_cast<underlying_type_t> (address));
+  }
+};
+
+template <> struct hash<amd::dbgapi::host_address_t>
+{
+  size_t operator() (const amd::dbgapi::host_address_t &address) const noexcept
+  {
+    return hash<
+      amd::dbgapi::detail::base_address_t<amd::dbgapi::host_address_t>>{}(
+      address);
+  }
+};
+
+template <> struct hash<amd::dbgapi::agent_address_t>
+{
+  size_t
+  operator() (const amd::dbgapi::agent_address_t &address) const noexcept
+  {
+    return hash<
+      amd::dbgapi::detail::base_address_t<amd::dbgapi::agent_address_t>>{}(
+      address);
+  }
+};
+
+template <> struct hash<amd::dbgapi::global_address_t>
+{
+  size_t
+  operator() (const amd::dbgapi::global_address_t &address) const noexcept
+  {
+    return hash<
+      amd::dbgapi::detail::base_address_t<amd::dbgapi::global_address_t>>{}(
+      address);
+  }
+};
+
+} /* namespace std */
 
 #endif /* AMD_DBGAPI_MEMORY_H */

--- a/projects/rocdbgapi/src/process.cpp
+++ b/projects/rocdbgapi/src/process.cpp
@@ -284,8 +284,9 @@ void
 process_t::read_string (host_address_t address, std::string *string,
                         size_t size) const
 {
-  constexpr size_t chunk_size
+  constexpr size_t cache_line_size
     = memory_cache_t<host_address_t>::cache_line_size;
+  constexpr size_t chunk_size = 4 * cache_line_size;
 
   dbgapi_assert (string && "invalid argument");
 
@@ -296,9 +297,11 @@ process_t::read_string (host_address_t address, std::string *string,
 
       /* Transfer one aligned chunk at a time, except for the first read
          which could read less than a chunk if the start address is not
-         aligned.  */
+         cache line aligned.  */
 
-      size_t request_size = chunk_size - (address & (chunk_size - 1));
+      static_assert (utils::is_power_of_two (cache_line_size));
+      size_t request_size = chunk_size - (address & (cache_line_size - 1));
+
       size_t xfer_size
         = read_host_memory_partial (address, staging_buffer, request_size);
 
@@ -1268,9 +1271,8 @@ process_t::update_code_objects ()
 
   try
     {
-      decltype (r_debug::r_state) state;
-      read_host_memory (m_runtime_info.r_debug + offsetof (r_debug, r_state),
-                        &state);
+      struct r_debug r_debug;
+      read_host_memory (m_runtime_info.r_debug, &r_debug);
 
       /* If the state is not RT_CONSISTENT then that indicates there is a
          thread actively updating the code object list.  We cannot read the
@@ -1278,25 +1280,18 @@ process_t::update_code_objects ()
          it will set state back to RT_CONSISTENT and hit the exiting breakpoint
          in the r_brk function which will trigger a read of the code object
          list.  */
-      if (state != r_debug::RT_CONSISTENT)
+      if (r_debug.r_state != r_debug::RT_CONSISTENT)
         return;
 
-      host_address_t link_map_address;
-      read_host_memory (m_runtime_info.r_debug + offsetof (r_debug, r_map),
-                        &link_map_address);
-
+      host_address_t link_map_address
+        = reinterpret_cast<uintptr_t> (r_debug.r_map);
       while (link_map_address != 0)
         {
-          global_address_t load_address;
-          read_host_memory (link_map_address + offsetof (link_map, l_addr),
-                            &load_address);
-
-          host_address_t l_name_address;
-          read_host_memory (link_map_address + offsetof (link_map, l_name),
-                            &l_name_address);
+          struct link_map entry;
+          read_host_memory (link_map_address, &entry);
 
           std::string uri;
-          read_string (l_name_address, &uri, -1);
+          read_string (reinterpret_cast<uintptr_t> (entry.l_name), &uri, -1);
 
           /* Check if the code object already exists.  */
           code_object_t *code_object = find_if (
@@ -1306,16 +1301,14 @@ process_t::update_code_objects ()
                  new code object of the same size could have been loaded at the
                  same address as an old stale code object. We could add a
                  unique identifier to the URI.  */
-              return x.load_address () == load_address && x.uri () == uri;
+              return x.load_address () == entry.l_addr && x.uri () == uri;
             });
 
           if (code_object == nullptr)
-            code_object = &create<code_object_t> (*this, uri, load_address);
+            code_object = &create<code_object_t> (*this, uri, entry.l_addr);
 
           code_object->set_mark (code_object_mark);
-
-          read_host_memory (link_map_address + offsetof (link_map, l_next),
-                            &link_map_address);
+          link_map_address = reinterpret_cast<uintptr_t> (entry.l_next);
         }
     }
   catch (const process_exited_exception_t &)

--- a/projects/rocdbgapi/src/process.cpp
+++ b/projects/rocdbgapi/src/process.cpp
@@ -272,6 +272,7 @@ process_t::detach ()
 
   /* Destruct the breakpoints before the shared libraries and code objects  */
   std::get<handle_object_set_t<breakpoint_t>> (m_handle_object_sets).clear ();
+  m_code_objects_index.clear ();
   std::get<handle_object_set_t<code_object_t>> (m_handle_object_sets).clear ();
 
   log_info ("detached %s", to_cstring (id ()));
@@ -1293,19 +1294,38 @@ process_t::update_code_objects ()
           std::string uri;
           read_string (reinterpret_cast<uintptr_t> (entry.l_name), &uri, -1);
 
-          /* Check if the code object already exists.  */
-          code_object_t *code_object = find_if (
-            [&] (const code_object_t &x)
+          code_object_t *code_object = nullptr;
+          if (auto found = m_code_objects_index.find (entry.l_addr);
+              found != m_code_objects_index.end ())
             {
+              code_object = found->second;
+
               /* FIXME: We have an ABA problem for memory based code objects. A
                  new code object of the same size could have been loaded at the
                  same address as an old stale code object. We could add a
                  unique identifier to the URI.  */
-              return x.load_address () == entry.l_addr && x.uri () == uri;
-            });
+              if (code_object->uri () != uri)
+                {
+                  /* Two code objects cannot be loaded at the same address,
+                     destroy the old one and remove it from the index.  */
+                  m_code_objects_index.erase (found);
+                  destroy (code_object);
+
+                  /* Create a new code object for this entry.  */
+                  code_object = nullptr;
+                }
+            }
 
           if (code_object == nullptr)
-            code_object = &create<code_object_t> (*this, uri, entry.l_addr);
+            {
+              code_object = &create<code_object_t> (*this, uri, entry.l_addr);
+
+              [[maybe_unused]] bool success
+                = m_code_objects_index.emplace (entry.l_addr, code_object)
+                    .second;
+              dbgapi_assert (success
+                             && "failed to insert code object in index");
+            }
 
           code_object->set_mark (code_object_mark);
           link_map_address = reinterpret_cast<uintptr_t> (entry.l_next);
@@ -1323,7 +1343,13 @@ process_t::update_code_objects ()
        code_object_it != range<code_object_t> ().end ();)
     {
       if (code_object_it->mark () < code_object_mark)
-        code_object_it = destroy (code_object_it);
+        {
+          [[maybe_unused]] size_t count
+            = m_code_objects_index.erase (code_object_it->load_address ());
+          dbgapi_assert (count == 1);
+
+          code_object_it = destroy (code_object_it);
+        }
       else
         ++code_object_it;
     }
@@ -1402,6 +1428,7 @@ process_t::runtime_enable (os_runtime_info_t runtime_info)
                      to_cstring (status));
 
       /* Destruct the code objects.  */
+      m_code_objects_index.clear ();
       std::get<handle_object_set_t<code_object_t>> (m_handle_object_sets)
         .clear ();
 

--- a/projects/rocdbgapi/src/process.h
+++ b/projects/rocdbgapi/src/process.h
@@ -32,6 +32,7 @@
 #include "handle_object.h"
 #include "initialization.h"
 #include "logging.h"
+#include "memory.h"
 #include "os_driver.h"
 #include "queue.h"
 #include "runtime_rdebug.h"
@@ -132,6 +133,10 @@ private:
     m_handle_object_sets{};
 
   const agent_t m_dummy_agent;
+
+  /* Maintain an index of all the loaded code objects, keyed by
+     load address.  */
+  std::unordered_map<host_address_t, code_object_t *> m_code_objects_index;
 
   std::pair<std::variant<process_t *, agent_t *, queue_t *>,
             os_exception_mask_t>


### PR DESCRIPTION
    rocdbgapi: keep an index for loaded code objects

    Replace the linear search over code objects when walking the dynamic
    linker map with an unordered_map keyed by {loaded_address, uri}.

    Clear the index whenever the code-object set is torn down (detach,
    runtime_enable failure) and remove entries in the existing mark/sweep
    pass so the map stays consistent with the handle set.

    rocdbgapi: batch r_debug/link_map reads

    update_code_objects: read full struct r_debug and struct link_map per
    iteration instead of separate offsetof reads for each field.  This
    reduces the number of iocts needed to process the updated code object
    list.

    read_string: align the first partial read to the host memory cache line
    size and use four cache lines per chunk.