### PR TITLE
Fix broken source code inclusion

### DIFF
--- a/projects/hip/docs/how-to/hip_cpp_language_extensions.rst
+++ b/projects/hip/docs/how-to/hip_cpp_language_extensions.rst
@@ -101,7 +101,7 @@ be:
 
 The kernel arguments are listed after the configuration parameters.
 
-.. literalinclude:: ../../tools/example_codes/calling_global_functions.hip
+.. literalinclude:: ../tools/example_codes/calling_global_functions.hip
   :start-after: // [sphinx-start]
   :end-before: // [sphinx-end]
   :language: cuda

--- a/projects/hip/docs/how-to/hip_cpp_language_extensions.rst
+++ b/projects/hip/docs/how-to/hip_cpp_language_extensions.rst
@@ -101,12 +101,10 @@ be:
 
 The kernel arguments are listed after the configuration parameters.
 
-.. code-block:: cpp
-
-  .. literalinclude:: ../../tools/example_codes/calling_global_functions.hip
-      :start-after: // [sphinx-start]
-      :end-before: // [sphinx-end]
-      :language: cpp
+.. literalinclude:: ../../tools/example_codes/calling_global_functions.hip
+  :start-after: // [sphinx-start]
+  :end-before: // [sphinx-end]
+  :language: cuda
 
 Inline qualifiers
 --------------------------------------------------------------------------------


### PR DESCRIPTION
## Motivation

A source code inclusion in the HIP documentation is broken.

## Technical Details

Removes the offending code lines.

## JIRA ID

n/a

## Test Plan

n/a

## Test Result

n/a

## Submission Checklist

- [X] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
