### PR TITLE
[hip-tests] Replace HIP_SKIP_THIS_TEST with Catch2 SKIP macro

### DIFF
--- a/projects/hip-tests/catch/README.md
+++ b/projects/hip-tests/catch/README.md
@@ -161,15 +161,14 @@ Please also note that you can not return values in functions calling ```HIP_CHEC
 ### Skipping Tests if certain criteria is not met
 If there arises a condition where certain flag is disabled and due to which a test can not run at that time, the following macro can be of use. It will highlight the test in ctest report as well.
 
-- ```HIP_SKIP_TEST``` : The API takes in an input of the reason as well and prints out the line HIP_SKIP_THIS_TEST. This causes ctest to mark the test as skipped and the test shows up in the report as skipped prompting proper response from the team.
+- ```HIP_SKIP_TEST``` : The API takes in an input of the reason as well and prints out the line HIP_SKIP_THIS_TEST. This causes ctest to mark the test as skipped and the test shows up in the report as skipped prompting proper response from the team. Internally uses the Catch2 SKIP macro to actually end the test execution and report the status as skipped. ctest also marks the test as skipped
 
   Usage:
 
   ```cpp
   TEST_CASE("TestOnlyOnXnack") {
     if(!XNACKEnabled) {
-      HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kGpuXnackNotEnabled);
-      return;
+      HIP_SKIP_TEST(HipTest::SkipReason::kGpuXnackNotEnabled);
     }
     // Rest of test functionality
   }

--- a/projects/hip-tests/catch/TypeQualifiers/hipManagedKeyword.cc
+++ b/projects/hip-tests/catch/TypeQualifiers/hipManagedKeyword.cc
@@ -32,8 +32,7 @@ HIP_TEST_CASE(Unit_hipManagedKeyword_SingleGpu) {
     int managed_memory = 0;
     HIP_CHECK(hipDeviceGetAttribute(&managed_memory, hipDeviceAttributeManagedMemory, i));
     if (!managed_memory) {
-      HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kManagedMemoryUnsupported);
-      return;
+      HIP_SKIP_TEST(HipTest::SkipReason::kManagedMemoryUnsupported);
     }
   }
 
@@ -63,8 +62,7 @@ HIP_TEST_CASE(Unit_hipManagedKeyword_MultiGpu) {
     int managed_memory = 0;
     HIP_CHECK(hipDeviceGetAttribute(&managed_memory, hipDeviceAttributeManagedMemory, i));
     if (!managed_memory) {
-      HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kManagedMemoryUnsupported);
-      return;
+      HIP_SKIP_TEST(HipTest::SkipReason::kManagedMemoryUnsupported);
     }
   }
 

--- a/projects/hip-tests/catch/cmake/hip-tests.cmake
+++ b/projects/hip-tests/catch/cmake/hip-tests.cmake
@@ -119,9 +119,7 @@ function(hip_gen_exe_target)
     endforeach()
     # add binary to global list of binaries to install
     set_property(GLOBAL APPEND PROPERTY G_INSTALL_EXE_TARGETS ${_EXE_NAME})
-    set(_DISCOVER_PROPERTIES
-      SKIP_REGULAR_EXPRESSION "HIP_SKIP_THIS_TEST"
-    )
+    set(_DISCOVER_PROPERTIES "")
     if (DEFINED HIP_TEST_LABELS)
       list(APPEND _DISCOVER_PROPERTIES LABELS "${HIP_TEST_LABELS}")
     endif()

--- a/projects/hip-tests/catch/hipTestMain/main.cc
+++ b/projects/hip-tests/catch/hipTestMain/main.cc
@@ -7,7 +7,6 @@
 #define CATCH_CONFIG_RUNNER
 #include <cmd_options.hh>
 #include <hip_test_common.hh>
-#include <iostream>
 
 CmdOptions cmd_options;
 

--- a/projects/hip-tests/catch/include/hip_test_checkers.hh
+++ b/projects/hip-tests/catch/include/hip_test_checkers.hh
@@ -376,7 +376,7 @@ static bool assemblyFile_Verification(std::string assemfilename, std::string ins
     }
   } else {
     result = true;
-    HipTest::HIP_SKIP_TEST("expected assembly file not found.");
+    HIP_SKIP_TEST("expected assembly file not found.");
   }
   return result;
 }

--- a/projects/hip-tests/catch/include/hip_test_common.hh
+++ b/projects/hip-tests/catch/include/hip_test_common.hh
@@ -222,6 +222,13 @@
     abort();                                                                                       \
   }
 
+// Causes the test to stop and be skipped at runtime.
+#define HIP_SKIP_TEST(reason)                                                                      \
+  {                                                                                                \
+    std::cout << "HIP_SKIP_THIS_TEST" << std::endl;                                                \
+    SKIP(reason);                                                                                  \
+  }
+
 #if HT_NVIDIA
 #define CTX_CREATE()                                                                               \
   hipCtx_t context;                                                                                \
@@ -481,7 +488,7 @@ inline bool isKernelArgPrefetchSupported() {
 }
 
 /**
- * Canonical skip reasons for HipTest::HIP_SKIP_TEST (stable strings for logs / ctest filters).
+ * Canonical skip reasons for HIP_SKIP_TEST (stable strings for logs / ctest filters).
  * Use these instead of duplicating slightly different wording for the same condition.
  */
 namespace SkipReason {
@@ -545,15 +552,6 @@ inline constexpr char const kNotEnoughFreeHostMemory[] =
     "not enough free host memory";
 inline constexpr char const kRequiresLinux[] = "this test requires Linux.";
 }  // namespace SkipReason
-
-/**
- * Causes the test to stop and be skipped at runtime.
- * reason: Message describing the reason the test has been skipped.
- */
-static inline void HIP_SKIP_TEST(char const* const reason) noexcept {
-  // ctest is setup to parse for "HIP_SKIP_THIS_TEST", at which point it will skip the test.
-  std::cout << "Skipping test. Reason: " << reason << '\n' << "HIP_SKIP_THIS_TEST" << std::endl;
-}
 
 /**
  * @brief Helper template that returns the expected arguments of a kernel.
@@ -714,8 +712,7 @@ class BlockingContext {
 // is supported on the current device.
 #define CHECK_IMAGE_SUPPORT                                                                        \
   if (!HipTest::isImageSupported()) {                                                              \
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kTextureImageUnsupported);                         \
-    return;                                                                                        \
+    HIP_SKIP_TEST(HipTest::SkipReason::kTextureImageUnsupported);                                  \
   }
 
 // Call at the start of tests that require managed memory support to indicate
@@ -724,14 +721,12 @@ class BlockingContext {
   int current_device_ = 0;                                                     \
   HIP_CHECK(hipGetDevice(&current_device_));                                   \
   if (!HipTest::isManagedMemorySupportedOnDevice(current_device_)) {           \
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kManagedMemoryUnsupported);    \
-    return;                                                                    \
+    HIP_SKIP_TEST(HipTest::SkipReason::kManagedMemoryUnsupported);             \
   }
 
 #define CHECK_PCIE_ATOMIC_SUPPORT                                                                 \
   if (!HipTest::isPcieAtomicSupported()) {                                                        \
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kPcieAtomicUnsupported);                         \
-    return;                                                                                        \
+    HIP_SKIP_TEST(HipTest::SkipReason::kPcieAtomicUnsupported);                                   \
   }
 
 #define CHECK_P2P_SUPPORT                                                                          \
@@ -739,15 +734,13 @@ class BlockingContext {
   if (!HipTest::isP2PSupported(d1,d2)) {                                                           \
     std::string msg = "P2P access check failed between dev1:" + std::to_string(d1) + ",dev2:" +    \
                                                                 std::to_string(d2);                \
-    HipTest::HIP_SKIP_TEST(msg.c_str());                                                           \
-    return;                                                                                        \
+    HIP_SKIP_TEST(msg.c_str());                                                                    \
   }                                                                                                \
 // Use this before running tests that rely on warp match functions to check device support and
 // skip the current test if they are not available.
 #define CHECK_WARP_MATCH_FUNCTIONS_SUPPORT                                                         \
   if (!HipTest::areWarpMatchFunctionsSupported()) {                                                \
-    HipTest::HIP_SKIP_TEST("warp match functions are not supported on this device.");      \
-    return;                                                                                        \
+    HIP_SKIP_TEST("warp match functions are not supported on this device.");                       \
   }
 
 // Call GENERATE_CAPTURE macro at the start of the test, before using BEGIN/END_CAPTURE.

--- a/projects/hip-tests/catch/include/hip_test_context.hh
+++ b/projects/hip-tests/catch/include/hip_test_context.hh
@@ -100,6 +100,7 @@ class TestContext {
   bool isLinux() const;
   bool isNvidia() const;
   bool isAmd() const;
+  bool skipTest() const;
 
   std::string currentPath() const;
 

--- a/projects/hip-tests/catch/include/memcpy1d_tests_common.hh
+++ b/projects/hip-tests/catch/include/memcpy1d_tests_common.hh
@@ -123,8 +123,7 @@ void MemcpyDeviceToDeviceShell(F memcpy_func, const hipStream_t kernel_stream = 
     int can_access_peer = 0;
     HIP_CHECK(hipDeviceCanAccessPeer(&can_access_peer, src_device, dst_device));
     if (!can_access_peer) {
-      HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kPeerAccessUnavailable);
-      return;
+      HIP_SKIP_TEST(HipTest::SkipReason::kPeerAccessUnavailable);
     }
     if constexpr (enable_peer_access) {
       HIP_CHECK(hipDeviceEnablePeerAccess(dst_device, 0));

--- a/projects/hip-tests/catch/include/memcpy3d_tests_common.hh
+++ b/projects/hip-tests/catch/include/memcpy3d_tests_common.hh
@@ -173,11 +173,10 @@ void Memcpy3DDeviceToDeviceShell(F memcpy_func, hipStream_t kernel_stream = null
     int can_access_peer = 0;
     HIP_CHECK(hipDeviceCanAccessPeer(&can_access_peer, src_device, dst_device));
     if (!can_access_peer) {
-      HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kPeerAccessUnavailable);
       if (device_count > 0 && kernel_stream != nullptr && kernel_stream != hipStreamPerThread) {
-        HIP_CHECK(hipStreamDestroy(kernel_stream));
+          HIP_CHECK(hipStreamDestroy(kernel_stream));
       }
-      return;
+      HIP_SKIP_TEST(HipTest::SkipReason::kPeerAccessUnavailable);
     }
     HIP_CHECK(hipDeviceEnablePeerAccess(dst_device, 0));
   }

--- a/projects/hip-tests/catch/multiproc/hipDeviceComputeCapabilityMproc.cc
+++ b/projects/hip-tests/catch/multiproc/hipDeviceComputeCapabilityMproc.cc
@@ -138,7 +138,7 @@ HIP_TEST_CASE(Unit_hipDeviceGet_MaskedDevices) {
     ret = runMaskedDeviceTest(count);
     REQUIRE(ret == true);
   } else {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
+    HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
   }
 }
 

--- a/projects/hip-tests/catch/multiproc/hipDeviceGetPCIBusIdMproc.cc
+++ b/projects/hip-tests/catch/multiproc/hipDeviceGetPCIBusIdMproc.cc
@@ -152,7 +152,7 @@ HIP_TEST_CASE(Unit_hipDeviceGetPCIBusId_MaskedDevices) {
     ret = hipDeviceGetPCIBusIdTests::testWithMaskedDevices(count);
     REQUIRE(ret == true);
   } else {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
+    HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
   }
 }
 
@@ -198,8 +198,7 @@ HIP_TEST_CASE(Unit_hipDeviceGetPCIBusId_CheckPciBusIDWithLspci) {
     pclose(fpipe);
 
     if (lspciCheck == nullptr) {
-      HipTest::HIP_SKIP_TEST("lspci is not available on this system.");
-      return;
+      HIP_SKIP_TEST("lspci is not available on this system.");
     }
   }
 

--- a/projects/hip-tests/catch/multiproc/hipDeviceGetPCIBusIdMproc.cc
+++ b/projects/hip-tests/catch/multiproc/hipDeviceGetPCIBusIdMproc.cc
@@ -178,7 +178,7 @@ HIP_TEST_CASE(Unit_hipDeviceGetPCIBusId_CheckPciBusIDWithLspci) {
   }();
 
   if (are_devices_hidden) {
-    HipTest::HIP_SKIP_TEST(
+    HIP_SKIP_TEST(
         "There are hidden devices, which means lscpi might report something different than what we "
         "have here");
   }

--- a/projects/hip-tests/catch/multiproc/hipDeviceTotalMemMproc.cc
+++ b/projects/hip-tests/catch/multiproc/hipDeviceTotalMemMproc.cc
@@ -150,7 +150,7 @@ HIP_TEST_CASE(Unit_hipDeviceTotalMem_MaskedDevices) {
     ret = getTotalMemoryOfMaskedDevices(count);
     REQUIRE(ret == true);
   } else {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
+    HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
   }
 }
 

--- a/projects/hip-tests/catch/multiproc/hipGetDeviceAttributeMproc.cc
+++ b/projects/hip-tests/catch/multiproc/hipGetDeviceAttributeMproc.cc
@@ -141,7 +141,7 @@ HIP_TEST_CASE(Unit_hipDeviceGetAttribute_MaskedDevices) {
     ret = validateGetAttributeOfMaskedDevices(count);
     REQUIRE(ret == true);
   } else {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
+    HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
   }
 }
 #endif

--- a/projects/hip-tests/catch/multiproc/hipGetDevicePropertiesMproc.cc
+++ b/projects/hip-tests/catch/multiproc/hipGetDevicePropertiesMproc.cc
@@ -140,7 +140,7 @@ HIP_TEST_CASE(Unit_hipGetDeviceProperties_MaskedDevices) {
     ret = validateGetPropsOfMaskedDevices(count);
     REQUIRE(ret == true);
   } else {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kRequiredDeviceCountNotMet);
+    HIP_SKIP_TEST(HipTest::SkipReason::kRequiredDeviceCountNotMet);
   }
 }
 #endif

--- a/projects/hip-tests/catch/multiproc/hipIpcEventHandle.cc
+++ b/projects/hip-tests/catch/multiproc/hipIpcEventHandle.cc
@@ -235,8 +235,7 @@ HIP_TEST_CASE(Unit_hipIpcEventHandle_Functional) {
   getDevices(shmDevices);
 
   if (shmDevices->count < 2) {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
-    return;
+    HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
   }
 
   g_processCnt = (shmDevices->count > MAX_DEVICES) ? MAX_DEVICES : shmDevices->count;

--- a/projects/hip-tests/catch/multiproc/hipMemCoherencyTstMProc.cc
+++ b/projects/hip-tests/catch/multiproc/hipMemCoherencyTstMProc.cc
@@ -109,7 +109,7 @@ HIP_TEST_CASE(Unit_malloc_CoherentTst) {
       REQUIRE(ret);
     }
   } else {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kGpuXnackNotEnabled);
+    HIP_SKIP_TEST(HipTest::SkipReason::kGpuXnackNotEnabled);
   }
 }
 #endif
@@ -142,7 +142,7 @@ HIP_TEST_CASE(Unit_malloc_CoherentTstWthAdvise) {
       free(Ptr);
     }
   } else {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kGpuXnackNotEnabled);
+    HIP_SKIP_TEST(HipTest::SkipReason::kGpuXnackNotEnabled);
   }
 }
 #endif
@@ -176,7 +176,7 @@ HIP_TEST_CASE(Unit_mmap_CoherentTst) {
       REQUIRE(ret);
     }
   } else {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kGpuXnackNotEnabled);
+    HIP_SKIP_TEST(HipTest::SkipReason::kGpuXnackNotEnabled);
   }
 }
 #endif
@@ -220,7 +220,7 @@ HIP_TEST_CASE(Unit_mmap_CoherentTstWthAdvise) {
       HIP_CHECK(hipStreamDestroy(strm));
     }
   } else {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kGpuXnackNotEnabled);
+    HIP_SKIP_TEST(HipTest::SkipReason::kGpuXnackNotEnabled);
   }
 }
 #endif

--- a/projects/hip-tests/catch/multiproc/hipSetGetDeviceMproc.cc
+++ b/projects/hip-tests/catch/multiproc/hipSetGetDeviceMproc.cc
@@ -156,8 +156,7 @@ static void testValidDevices(int numDevices, bool useRocrEnv, int* deviceList,
   std::string visibleDeviceString;
 
   if ((NULL == deviceList) || ((deviceListLength < 1) || deviceListLength > numDevices)) {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kRequiredDeviceCountNotMet);
-    return;
+    HIP_SKIP_TEST(HipTest::SkipReason::kRequiredDeviceCountNotMet);
   }
 
   for (int i = 0; i < deviceListLength; i++) {

--- a/projects/hip-tests/catch/performance/kernelLaunch/hipLaunchCooperativeKernel.cc
+++ b/projects/hip-tests/catch/performance/kernelLaunch/hipLaunchCooperativeKernel.cc
@@ -81,8 +81,7 @@ template <KernelType kernel_type, bool timer_type> static void RunBenchmark(bool
  */
 HIP_TEST_CASE(Performance_hipLaunchCooperativeKernel) {
   if (!DeviceAttributesSupport(0, hipDeviceAttributeCooperativeLaunch)) {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kCooperativeLaunchUnsupported);
-    return;
+    HIP_SKIP_TEST(HipTest::SkipReason::kCooperativeLaunchUnsupported);
   }
 
   bool sync = GENERATE(true, false);

--- a/projects/hip-tests/catch/performance/memcpy/hipMemcpy.cc
+++ b/projects/hip-tests/catch/performance/memcpy/hipMemcpy.cc
@@ -34,9 +34,6 @@ static void RunBenchmark(LinearAllocs dst_allocation_type, LinearAllocs src_allo
   } else {
     int src_device = std::get<0>(GetDeviceIds(enable_peer_access));
     int dst_device = std::get<1>(GetDeviceIds(enable_peer_access));
-    if (src_device == -1 && dst_device == -1) {
-      return;
-    }
 
     LinearAllocGuard<int> src_allocation(src_allocation_type, size);
     HIP_CHECK(hipSetDevice(dst_device));
@@ -143,8 +140,7 @@ HIP_TEST_CASE(Performance_hipMemcpy_HostToHost) {
  */
 HIP_TEST_CASE(Performance_hipMemcpy_DeviceToDevice_EnablePeerAccess) {
   if (HipTest::getDeviceCount() < 2) {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
-    return;
+    HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
   }
   const auto allocation_size = GENERATE(4_KB, 4_MB, 16_MB);
   const auto src_allocation_type = LinearAllocs::hipMalloc;

--- a/projects/hip-tests/catch/performance/memcpy/hipMemcpy2D.cc
+++ b/projects/hip-tests/catch/performance/memcpy/hipMemcpy2D.cc
@@ -50,9 +50,6 @@ static void RunBenchmark(size_t width, size_t height, hipMemcpyKind kind,
     // hipMemcpyDeviceToDevice
     int src_device = std::get<0>(GetDeviceIds(enable_peer_access));
     int dst_device = std::get<1>(GetDeviceIds(enable_peer_access));
-    if (src_device == -1 && dst_device == -1) {
-      return;
-    }
 
     LinearAllocGuard2D<int> src_allocation(width, height);
     HIP_CHECK(hipSetDevice(dst_device));
@@ -163,8 +160,7 @@ HIP_TEST_CASE(Performance_hipMemcpy2D_DeviceToDevice_DisablePeerAccess) {
  */
 HIP_TEST_CASE(Performance_hipMemcpy2D_DeviceToDevice_EnablePeerAccess) {
   if (HipTest::getDeviceCount() < 2) {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
-    return;
+    HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
   }
   const auto width = GENERATE(4_KB, 4_MB, 16_MB);
   RunBenchmark(width, 32, hipMemcpyDeviceToDevice, true);

--- a/projects/hip-tests/catch/performance/memcpy/hipMemcpy2DAsync.cc
+++ b/projects/hip-tests/catch/performance/memcpy/hipMemcpy2DAsync.cc
@@ -54,9 +54,6 @@ static void RunBenchmark(size_t width, size_t height, hipMemcpyKind kind,
     // hipMemcpyDeviceToDevice
     int src_device = std::get<0>(GetDeviceIds(enable_peer_access));
     int dst_device = std::get<1>(GetDeviceIds(enable_peer_access));
-    if (src_device == -1 && dst_device == -1) {
-      return;
-    }
 
     LinearAllocGuard2D<int> src_allocation(width, height);
     HIP_CHECK(hipSetDevice(dst_device));
@@ -168,8 +165,7 @@ HIP_TEST_CASE(Performance_hipMemcpy2DAsync_DeviceToDevice_DisablePeerAccess) {
  */
 HIP_TEST_CASE(Performance_hipMemcpy2DAsync_DeviceToDevice_EnablePeerAccess) {
   if (HipTest::getDeviceCount() < 2) {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
-    return;
+    HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
   }
   const auto width = GENERATE(4_KB, 4_MB, 16_MB);
   RunBenchmark(width, 32, hipMemcpyDeviceToDevice, true);

--- a/projects/hip-tests/catch/performance/memcpy/hipMemcpy2DFromArray.cc
+++ b/projects/hip-tests/catch/performance/memcpy/hipMemcpy2DFromArray.cc
@@ -37,9 +37,6 @@ static void RunBenchmark(size_t width, size_t height, hipMemcpyKind kind,
     // hipMemcpyDeviceToDevice
     int src_device = std::get<0>(GetDeviceIds(enable_peer_access));
     int dst_device = std::get<1>(GetDeviceIds(enable_peer_access));
-    if (src_device == -1 && dst_device == -1) {
-      return;
-    }
 
     LinearAllocGuard2D<int> device_allocation(width, height);
     HIP_CHECK(hipSetDevice(dst_device));
@@ -115,8 +112,7 @@ HIP_TEST_CASE(Performance_hipMemcpy2DFromArray_DeviceToDevice_EnablePeerAccess) 
   CHECK_IMAGE_SUPPORT
 
   if (HipTest::getDeviceCount() < 2) {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
-    return;
+    HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
   }
   const auto width = GENERATE(4_KB, 8_KB, 16_KB);
   RunBenchmark(width, 32, hipMemcpyDeviceToDevice, true);

--- a/projects/hip-tests/catch/performance/memcpy/hipMemcpy2DFromArrayAsync.cc
+++ b/projects/hip-tests/catch/performance/memcpy/hipMemcpy2DFromArrayAsync.cc
@@ -41,9 +41,6 @@ static void RunBenchmark(size_t width, size_t height, hipMemcpyKind kind,
     // hipMemcpyDeviceToDevice
     int src_device = std::get<0>(GetDeviceIds(enable_peer_access));
     int dst_device = std::get<1>(GetDeviceIds(enable_peer_access));
-    if (src_device == -1 && dst_device == -1) {
-      return;
-    }
 
     LinearAllocGuard2D<int> device_allocation(width, height);
     HIP_CHECK(hipSetDevice(dst_device));
@@ -120,8 +117,7 @@ HIP_TEST_CASE(Performance_hipMemcpy2DFromArrayAsync_DeviceToDevice_EnablePeerAcc
   CHECK_IMAGE_SUPPORT
 
   if (HipTest::getDeviceCount() < 2) {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
-    return;
+    HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
   }
   const auto width = GENERATE(4_KB, 8_KB, 16_KB);
   RunBenchmark(width, 32, hipMemcpyDeviceToDevice, true);

--- a/projects/hip-tests/catch/performance/memcpy/hipMemcpy2DToArray.cc
+++ b/projects/hip-tests/catch/performance/memcpy/hipMemcpy2DToArray.cc
@@ -37,9 +37,6 @@ static void RunBenchmark(size_t width, size_t height, hipMemcpyKind kind,
     // hipMemcpyDeviceToDevice
     int src_device = std::get<0>(GetDeviceIds(enable_peer_access));
     int dst_device = std::get<1>(GetDeviceIds(enable_peer_access));
-    if (src_device == -1 && dst_device == -1) {
-      return;
-    }
 
     LinearAllocGuard2D<int> device_allocation(width, height);
     HIP_CHECK(hipSetDevice(dst_device));
@@ -115,8 +112,7 @@ HIP_TEST_CASE(Performance_hipMemcpy2DToArray_DeviceToDevice_EnablePeerAccess) {
   CHECK_IMAGE_SUPPORT
 
   if (HipTest::getDeviceCount() < 2) {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
-    return;
+    HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
   }
   const auto width = GENERATE(4_KB, 8_KB, 16_KB);
   RunBenchmark(width, 32, hipMemcpyDeviceToDevice, true);

--- a/projects/hip-tests/catch/performance/memcpy/hipMemcpy2DToArrayAsync.cc
+++ b/projects/hip-tests/catch/performance/memcpy/hipMemcpy2DToArrayAsync.cc
@@ -41,9 +41,6 @@ static void RunBenchmark(size_t width, size_t height, hipMemcpyKind kind,
     // hipMemcpyDeviceToDevice
     int src_device = std::get<0>(GetDeviceIds(enable_peer_access));
     int dst_device = std::get<1>(GetDeviceIds(enable_peer_access));
-    if (src_device == -1 && dst_device == -1) {
-      return;
-    }
 
     LinearAllocGuard2D<int> device_allocation(width, height);
     HIP_CHECK(hipSetDevice(dst_device));
@@ -120,8 +117,7 @@ HIP_TEST_CASE(Performance_hipMemcpy2DToArrayAsync_DeviceToDevice_EnablePeerAcces
   CHECK_IMAGE_SUPPORT
 
   if (HipTest::getDeviceCount() < 2) {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
-    return;
+    HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
   }
   const auto width = GENERATE(4_KB, 8_KB, 16_KB);
   RunBenchmark(width, 32, hipMemcpyDeviceToDevice, true);

--- a/projects/hip-tests/catch/performance/memcpy/hipMemcpy3D.cc
+++ b/projects/hip-tests/catch/performance/memcpy/hipMemcpy3D.cc
@@ -60,9 +60,6 @@ static void RunBenchmark(const hipExtent extent, hipMemcpyKind kind,
     // hipMemcpyDeviceToDevice
     int src_device = std::get<0>(GetDeviceIds(enable_peer_access));
     int dst_device = std::get<1>(GetDeviceIds(enable_peer_access));
-    if (src_device == -1 && dst_device == -1) {
-      return;
-    }
 
     LinearAllocGuard3D<int> src_allocation(extent);
     HIP_CHECK(hipSetDevice(dst_device));
@@ -173,8 +170,7 @@ HIP_TEST_CASE(Performance_hipMemcpy3D_DeviceToDevice_DisablePeerAccess) {
  */
 HIP_TEST_CASE(Performance_hipMemcpy3D_DeviceToDevice_EnablePeerAccess) {
   if (HipTest::getDeviceCount() < 2) {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
-    return;
+    HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
   }
   const auto width = GENERATE(4_KB, 4_MB, 16_MB);
   RunBenchmark(make_hipExtent(width, 16, 4), hipMemcpyDeviceToDevice, true);

--- a/projects/hip-tests/catch/performance/memcpy/hipMemcpy3DAsync.cc
+++ b/projects/hip-tests/catch/performance/memcpy/hipMemcpy3DAsync.cc
@@ -64,9 +64,6 @@ static void RunBenchmark(const hipExtent extent, hipMemcpyKind kind,
     // hipMemcpyDeviceToDevice
     int src_device = std::get<0>(GetDeviceIds(enable_peer_access));
     int dst_device = std::get<1>(GetDeviceIds(enable_peer_access));
-    if (src_device == -1 && dst_device == -1) {
-      return;
-    }
 
     LinearAllocGuard3D<int> src_allocation(extent);
     HIP_CHECK(hipSetDevice(dst_device));
@@ -174,8 +171,7 @@ HIP_TEST_CASE(Performance_hipMemcpy3DAsync_DeviceToDevice_DisablePeerAccess) {
  */
 HIP_TEST_CASE(Performance_hipMemcpy3DAsync_DeviceToDevice_EnablePeerAccess) {
   if (HipTest::getDeviceCount() < 2) {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
-    return;
+    HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
   }
   const auto width = GENERATE(4_KB, 4_MB, 16_MB);
   RunBenchmark(make_hipExtent(width, 16, 4), hipMemcpyDeviceToDevice, true);

--- a/projects/hip-tests/catch/performance/memcpy/hipMemcpyAsync.cc
+++ b/projects/hip-tests/catch/performance/memcpy/hipMemcpyAsync.cc
@@ -39,9 +39,6 @@ static void RunBenchmark(LinearAllocs dst_allocation_type, LinearAllocs src_allo
   } else {
     int src_device = std::get<0>(GetDeviceIds(enable_peer_access));
     int dst_device = std::get<1>(GetDeviceIds(enable_peer_access));
-    if (src_device == -1 && dst_device == -1) {
-      return;
-    }
 
     LinearAllocGuard<int> src_allocation(src_allocation_type, size);
     HIP_CHECK(hipSetDevice(dst_device));
@@ -173,8 +170,7 @@ HIP_TEST_CASE(Performance_hipMemcpyAsync_DeviceToDevice_DisablePeerAccess) {
  */
 HIP_TEST_CASE(Performance_hipMemcpyAsync_DeviceToDevice_EnablePeerAccess) {
   if (HipTest::getDeviceCount() < 2) {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
-    return;
+    HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
   }
   const auto allocation_size = GENERATE(4_KB, 4_MB, 16_MB);
   const auto src_allocation_type = LinearAllocs::hipMalloc;

--- a/projects/hip-tests/catch/performance/memcpy/hipMemcpyDtoD.cc
+++ b/projects/hip-tests/catch/performance/memcpy/hipMemcpyDtoD.cc
@@ -25,9 +25,6 @@ static void RunBenchmark(size_t size, bool enable_peer_access = false) {
 
   int src_device = std::get<0>(GetDeviceIds(enable_peer_access));
   int dst_device = std::get<1>(GetDeviceIds(enable_peer_access));
-  if (src_device == -1 && dst_device == -1) {
-    return;
-  }
 
   LinearAllocGuard<int> src_allocation(LinearAllocs::hipMalloc, size);
   HIP_CHECK(hipSetDevice(dst_device));
@@ -60,8 +57,7 @@ static void RunBenchmark(size_t size, bool enable_peer_access = false) {
  */
 HIP_TEST_CASE(Performance_hipMemcpyDtoD_PeerAccessEnabled) {
   if (HipTest::getDeviceCount() < 2) {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
-    return;
+    HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
   }
   const auto allocation_size = GENERATE(4_KB, 4_MB, 16_MB);
   RunBenchmark(allocation_size, true);

--- a/projects/hip-tests/catch/performance/memcpy/hipMemcpyDtoDAsync.cc
+++ b/projects/hip-tests/catch/performance/memcpy/hipMemcpyDtoDAsync.cc
@@ -31,9 +31,6 @@ static void RunBenchmark(size_t size, bool enable_peer_access = false) {
   const hipStream_t stream = stream_guard.stream();
   int src_device = std::get<0>(GetDeviceIds(enable_peer_access));
   int dst_device = std::get<1>(GetDeviceIds(enable_peer_access));
-  if (src_device == -1 && dst_device == -1) {
-    return;
-  }
 
   LinearAllocGuard<int> src_allocation(LinearAllocs::hipMalloc, size);
   HIP_CHECK(hipSetDevice(dst_device));
@@ -65,8 +62,7 @@ static void RunBenchmark(size_t size, bool enable_peer_access = false) {
  */
 HIP_TEST_CASE(Performance_hipMemcpyDtoDAsync_PeerAccessEnabled) {
   if (HipTest::getDeviceCount() < 2) {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
-    return;
+    HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
   }
   const auto allocation_size = GENERATE(4_KB, 4_MB, 16_MB);
   RunBenchmark(allocation_size, true);

--- a/projects/hip-tests/catch/performance/memcpy/hipMemcpyParam2D.cc
+++ b/projects/hip-tests/catch/performance/memcpy/hipMemcpyParam2D.cc
@@ -49,9 +49,6 @@ static void RunBenchmark(size_t width, size_t height, hipMemcpyKind kind,
     // hipMemcpyDeviceToDevice
     int src_device = std::get<0>(GetDeviceIds(enable_peer_access));
     int dst_device = std::get<1>(GetDeviceIds(enable_peer_access));
-    if (src_device == -1 && dst_device == -1) {
-      return;
-    }
 
     LinearAllocGuard2D<int> src_allocation(width, height);
     HIP_CHECK(hipSetDevice(dst_device));
@@ -166,8 +163,7 @@ HIP_TEST_CASE(Performance_hipMemcpyParam2D_DeviceToDevice_DisablePeerAccess) {
  */
 HIP_TEST_CASE(Performance_hipMemcpyParam2D_DeviceToDevice_EnablePeerAccess) {
   if (HipTest::getDeviceCount() < 2) {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
-    return;
+    HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
   }
   const auto width = GENERATE(4_KB, 4_MB, 16_MB);
   RunBenchmark(width, 32, hipMemcpyDeviceToDevice, true);

--- a/projects/hip-tests/catch/performance/memcpy/hipMemcpyParam2DAsync.cc
+++ b/projects/hip-tests/catch/performance/memcpy/hipMemcpyParam2DAsync.cc
@@ -53,9 +53,6 @@ static void RunBenchmark(size_t width, size_t height, hipMemcpyKind kind,
     // hipMemcpyDeviceToDevice
     int src_device = std::get<0>(GetDeviceIds(enable_peer_access));
     int dst_device = std::get<1>(GetDeviceIds(enable_peer_access));
-    if (src_device == -1 && dst_device == -1) {
-      return;
-    }
 
     LinearAllocGuard2D<int> src_allocation(width, height);
     HIP_CHECK(hipSetDevice(dst_device));
@@ -170,8 +167,7 @@ HIP_TEST_CASE(Performance_hipMemcpyParam2DAsync_DeviceToDevice_DisablePeerAccess
  */
 HIP_TEST_CASE(Performance_hipMemcpyParam2DAsync_DeviceToDevice_EnablePeerAccess) {
   if (HipTest::getDeviceCount() < 2) {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
-    return;
+    HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
   }
   const auto width = GENERATE(4_KB, 4_MB, 16_MB);
   RunBenchmark(width, 32, hipMemcpyDeviceToDevice, true);

--- a/projects/hip-tests/catch/performance/memcpy/hipMemcpyWithStream.cc
+++ b/projects/hip-tests/catch/performance/memcpy/hipMemcpyWithStream.cc
@@ -36,9 +36,6 @@ static void RunBenchmark(LinearAllocs dst_allocation_type, LinearAllocs src_allo
   } else {
     int src_device = std::get<0>(GetDeviceIds(enable_peer_access));
     int dst_device = std::get<1>(GetDeviceIds(enable_peer_access));
-    if (src_device == -1 && dst_device == -1) {
-      return;
-    }
 
     LinearAllocGuard<int> src_allocation(LinearAllocs::hipMalloc, size);
     HIP_CHECK(hipSetDevice(dst_device));
@@ -170,8 +167,7 @@ HIP_TEST_CASE(Performance_hipMemcpyWithStream_DeviceToDevice_DisablePeerAccess) 
  */
 HIP_TEST_CASE(Performance_hipMemcpyWithStream_DeviceToDevice_EnablePeerAccess) {
   if (HipTest::getDeviceCount() < 2) {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
-    return;
+    HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
   }
   const auto allocation_size = GENERATE(4_KB, 4_MB, 16_MB);
   const auto src_allocation_type = LinearAllocs::hipMalloc;

--- a/projects/hip-tests/catch/performance/memcpy/memcpy_performance_common.hh
+++ b/projects/hip-tests/catch/performance/memcpy/memcpy_performance_common.hh
@@ -80,8 +80,7 @@ static std::tuple<int, int> GetDeviceIds(bool enable_peer_access) {
     int can_access_peer = 0;
     HIP_CHECK(hipDeviceCanAccessPeer(&can_access_peer, src_device, dst_device));
     if (!can_access_peer) {
-      HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kPeerAccessUnavailable);
-      return {-1, -1};
+      HIP_SKIP_TEST(HipTest::SkipReason::kPeerAccessUnavailable);
     }
     HIP_CHECK(hipDeviceEnablePeerAccess(dst_device, 0));
   } else {

--- a/projects/hip-tests/catch/performance/stream/hipMallocFromPoolAsync.cc
+++ b/projects/hip-tests/catch/performance/stream/hipMallocFromPoolAsync.cc
@@ -60,8 +60,7 @@ static void RunBenchmark(const size_t array_size) {
  */
 HIP_TEST_CASE(Performance_hipMallocFromPoolAsync) {
   if (!AreMemPoolsSupported(0)) {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kMemoryPoolUnsupported);
-    return;
+    HIP_SKIP_TEST(HipTest::SkipReason::kMemoryPoolUnsupported);
   }
   size_t array_size = GENERATE(4_KB, 4_MB, 16_MB);
   RunBenchmark(array_size);

--- a/projects/hip-tests/catch/performance/stream/hipMemPoolCreate.cc
+++ b/projects/hip-tests/catch/performance/stream/hipMemPoolCreate.cc
@@ -48,8 +48,7 @@ static void RunBenchmark() {
  */
 HIP_TEST_CASE(Performance_hipMemPoolCreate) {
   if (!AreMemPoolsSupported(0)) {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kMemoryPoolUnsupported);
-    return;
+    HIP_SKIP_TEST(HipTest::SkipReason::kMemoryPoolUnsupported);
   }
   RunBenchmark();
 }

--- a/projects/hip-tests/catch/performance/stream/hipMemPoolDestroy.cc
+++ b/projects/hip-tests/catch/performance/stream/hipMemPoolDestroy.cc
@@ -47,8 +47,7 @@ static void RunBenchmark() {
  */
 HIP_TEST_CASE(Performance_hipMemPoolDestroy) {
   if (!AreMemPoolsSupported(0)) {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kMemoryPoolUnsupported);
-    return;
+    HIP_SKIP_TEST(HipTest::SkipReason::kMemoryPoolUnsupported);
   }
   RunBenchmark();
 }

--- a/projects/hip-tests/catch/performance/stream/hipMemPoolExportPointer.cc
+++ b/projects/hip-tests/catch/performance/stream/hipMemPoolExportPointer.cc
@@ -60,8 +60,7 @@ static void RunBenchmark(const size_t array_size) {
  */
 HIP_TEST_CASE(Performance_hipMemPoolExportPointer) {
   if (!AreMemPoolsSupported(0)) {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kMemoryPoolUnsupported);
-    return;
+    HIP_SKIP_TEST(HipTest::SkipReason::kMemoryPoolUnsupported);
   }
   size_t array_size = GENERATE(4_KB, 4_MB, 16_MB);
   RunBenchmark(array_size);

--- a/projects/hip-tests/catch/performance/stream/hipMemPoolExportToShareableHandle.cc
+++ b/projects/hip-tests/catch/performance/stream/hipMemPoolExportToShareableHandle.cc
@@ -54,8 +54,7 @@ static void RunBenchmark() {
  */
 HIP_TEST_CASE(Performance_hipMemPoolExportToShareableHandle) {
   if (!AreMemPoolsSupported(0)) {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kMemoryPoolUnsupported);
-    return;
+    HIP_SKIP_TEST(HipTest::SkipReason::kMemoryPoolUnsupported);
   }
   RunBenchmark();
 }

--- a/projects/hip-tests/catch/performance/stream/hipMemPoolGetAccess.cc
+++ b/projects/hip-tests/catch/performance/stream/hipMemPoolGetAccess.cc
@@ -50,8 +50,7 @@ static void RunBenchmark() {
  */
 HIP_TEST_CASE(Performance_hipMemPoolGetAccess) {
   if (!AreMemPoolsSupported(0)) {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kMemoryPoolUnsupported);
-    return;
+    HIP_SKIP_TEST(HipTest::SkipReason::kMemoryPoolUnsupported);
   }
   RunBenchmark();
 }

--- a/projects/hip-tests/catch/performance/stream/hipMemPoolGetAttribute.cc
+++ b/projects/hip-tests/catch/performance/stream/hipMemPoolGetAttribute.cc
@@ -56,8 +56,7 @@ static void RunBenchmark(const hipMemPoolAttr attribute) {
  */
 HIP_TEST_CASE(Performance_hipMemPoolGetAttribute) {
   if (!AreMemPoolsSupported(0)) {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kMemoryPoolUnsupported);
-    return;
+    HIP_SKIP_TEST(HipTest::SkipReason::kMemoryPoolUnsupported);
   }
   hipMemPoolAttr attribute =
       GENERATE(hipMemPoolAttrReleaseThreshold, hipMemPoolReuseFollowEventDependencies,

--- a/projects/hip-tests/catch/performance/stream/hipMemPoolImportFromShareableHandle.cc
+++ b/projects/hip-tests/catch/performance/stream/hipMemPoolImportFromShareableHandle.cc
@@ -62,8 +62,7 @@ static void RunBenchmark() {
  */
 HIP_TEST_CASE(Performance_hipMemPoolImportFromShareableHandle) {
   if (!AreMemPoolsSupported(0)) {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kMemoryPoolUnsupported);
-    return;
+    HIP_SKIP_TEST(HipTest::SkipReason::kMemoryPoolUnsupported);
   }
   RunBenchmark();
 }

--- a/projects/hip-tests/catch/performance/stream/hipMemPoolImportPointer.cc
+++ b/projects/hip-tests/catch/performance/stream/hipMemPoolImportPointer.cc
@@ -66,8 +66,7 @@ static void RunBenchmark(const size_t array_size) {
  */
 HIP_TEST_CASE(Performance_hipMemPoolImportPointer) {
   if (!AreMemPoolsSupported(0)) {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kMemoryPoolUnsupported);
-    return;
+    HIP_SKIP_TEST(HipTest::SkipReason::kMemoryPoolUnsupported);
   }
   size_t array_size = GENERATE(4_KB, 4_MB, 16_MB);
   RunBenchmark(array_size);

--- a/projects/hip-tests/catch/performance/stream/hipMemPoolSetAccess.cc
+++ b/projects/hip-tests/catch/performance/stream/hipMemPoolSetAccess.cc
@@ -50,8 +50,7 @@ static void RunBenchmark() {
  */
 HIP_TEST_CASE(Performance_hipMemPoolSetAccess) {
   if (!AreMemPoolsSupported(0)) {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kMemoryPoolUnsupported);
-    return;
+    HIP_SKIP_TEST(HipTest::SkipReason::kMemoryPoolUnsupported);
   }
   RunBenchmark();
 }

--- a/projects/hip-tests/catch/performance/stream/hipMemPoolSetAttribute.cc
+++ b/projects/hip-tests/catch/performance/stream/hipMemPoolSetAttribute.cc
@@ -64,8 +64,7 @@ static void RunBenchmark(const hipMemPoolAttr attribute) {
  */
 HIP_TEST_CASE(Performance_hipMemPoolSetAttribute) {
   if (!AreMemPoolsSupported(0)) {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kMemoryPoolUnsupported);
-    return;
+    HIP_SKIP_TEST(HipTest::SkipReason::kMemoryPoolUnsupported);
   }
   hipMemPoolAttr attribute =
       GENERATE(hipMemPoolAttrReleaseThreshold, hipMemPoolReuseFollowEventDependencies,

--- a/projects/hip-tests/catch/performance/stream/hipMemPoolTrimTo.cc
+++ b/projects/hip-tests/catch/performance/stream/hipMemPoolTrimTo.cc
@@ -53,8 +53,7 @@ static void RunBenchmark(const size_t min_bytes_to_hold) {
  */
 HIP_TEST_CASE(Performance_hipMemPoolTrimTo) {
   if (!AreMemPoolsSupported(0)) {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kMemoryPoolUnsupported);
-    return;
+    HIP_SKIP_TEST(HipTest::SkipReason::kMemoryPoolUnsupported);
   }
   size_t min_bytes_to_hold = GENERATE(4_KB, 4_MB, 16_MB);
   RunBenchmark(min_bytes_to_hold);

--- a/projects/hip-tests/catch/performance/stream/hipStreamWaitValue.cc
+++ b/projects/hip-tests/catch/performance/stream/hipStreamWaitValue.cc
@@ -111,10 +111,9 @@ static void RunBenchmark(const size_t array_size, unsigned int flag) {
 HIP_TEST_CASE(Performance_hipStreamWaitValue32) {
 #if HT_AMD
   if (!IsStreamWaitValueSupported(0)) {
-    HipTest::HIP_SKIP_TEST(
+    HIP_SKIP_TEST(
         "GPU 0 doesn't support hipStreamWaitValue32() function. "
-        "Hence skipping the testing with Pass result.\n");
-    return;
+        "Hence skipping the testing with Pass result.");
   }
 
   size_t array_size = GENERATE(4_KB, 4_MB, 16_MB);
@@ -147,10 +146,9 @@ HIP_TEST_CASE(Performance_hipStreamWaitValue32) {
  */
 HIP_TEST_CASE(Performance_hipStreamWaitValue64) {
   if (!IsStreamWaitValueSupported(0)) {
-    HipTest::HIP_SKIP_TEST(
+    HIP_SKIP_TEST(
         "GPU 0 doesn't support hipStreamWaitValue64() function. "
-        "Hence skipping the testing with Pass result.\n");
-    return;
+        "Hence skipping the testing with Pass result.");
   }
   size_t array_size = GENERATE(4_KB, 4_MB, 16_MB);
   unsigned int flag = GENERATE(hipStreamWaitValueGte, hipStreamWaitValueEq, hipStreamWaitValueAnd,

--- a/projects/hip-tests/catch/performance/stream/hipStreamWriteValue.cc
+++ b/projects/hip-tests/catch/performance/stream/hipStreamWriteValue.cc
@@ -99,10 +99,9 @@ HIP_TEST_CASE(Performance_hipStreamWriteValue32) {
 HIP_TEST_CASE(Performance_hipStreamWriteValue64) {
 #if HT_NVIDIA
   if (!IsStreamWriteValueSupported(0)) {
-    HipTest::HIP_SKIP_TEST(
+    HIP_SKIP_TEST(
         "GPU 0 doesn't support hipStreamWriteValue64() function. "
-        "Hence skipping the testing with Pass result.\n");
-    return;
+        "Hence skipping the testing with Pass result.");
   }
 #endif
   size_t array_size = GENERATE(4_KB, 4_MB, 16_MB);

--- a/projects/hip-tests/catch/perftests/compute/hipPerfDotProduct.cc
+++ b/projects/hip-tests/catch/perftests/compute/hipPerfDotProduct.cc
@@ -223,8 +223,7 @@ HIP_TEST_CASE(Perf_hipPerfDotProduct) {
   HIP_CHECK(hipGetDeviceCount(&nGpu));
 
   if (nGpu < 1) {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kNoGpuDevice);
-    return;
+    HIP_SKIP_TEST(HipTest::SkipReason::kNoGpuDevice);
   }
   hipDeviceProp_t props;
   HIP_CHECK(hipSetDevice(p_gpuDevice));

--- a/projects/hip-tests/catch/perftests/compute/hipPerfMandelbrot.cc
+++ b/projects/hip-tests/catch/perftests/compute/hipPerfMandelbrot.cc
@@ -355,8 +355,7 @@ void hipPerfMandelBrot::open(int deviceId) {
   int nGpu = 0;
   HIP_CHECK(hipGetDeviceCount(&nGpu));
   if (nGpu < 1) {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kNoGpuDevice);
-    return;
+    HIP_SKIP_TEST(HipTest::SkipReason::kNoGpuDevice);
   }
   HIP_CHECK(hipSetDevice(deviceId));
   hipDeviceProp_t props;

--- a/projects/hip-tests/catch/perftests/memory/hipPerfBufferCopyInterGpuPerformance.cc
+++ b/projects/hip-tests/catch/perftests/memory/hipPerfBufferCopyInterGpuPerformance.cc
@@ -41,8 +41,7 @@ HIP_TEST_CASE(Perf_PerfBufferCopySpeedAll2All_Inter_GPU) {
   int nGpus = 0;
   HIP_CHECK(hipGetDeviceCount(&nGpus));
   if (nGpus < 2) {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
-    return;
+    HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
   }
   int** ArrayOfDevicePointers = reinterpret_cast<int**>(malloc(nGpus * sizeof(int*)));
 

--- a/projects/hip-tests/catch/perftests/memory/hipPerfBufferCopyRectSpeed.cc
+++ b/projects/hip-tests/catch/perftests/memory/hipPerfBufferCopyRectSpeed.cc
@@ -208,7 +208,7 @@ HIP_TEST_CASE(Perf_hipPerfBufferCopyRectSpeed_test) {
   HIP_CHECK(hipGetDeviceCount(&numDevices));
 
   if (numDevices <= 0) {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kNoGpuDevice);
+    HIP_SKIP_TEST(HipTest::SkipReason::kNoGpuDevice);
   } else {
     int deviceId = 0;
     HIP_CHECK(hipSetDevice(deviceId));

--- a/projects/hip-tests/catch/perftests/memory/hipPerfBufferCopySpeed.cc
+++ b/projects/hip-tests/catch/perftests/memory/hipPerfBufferCopySpeed.cc
@@ -373,7 +373,7 @@ HIP_TEST_CASE(Perf_hipPerfBufferCopySpeed_test) {
   int numDevices = 0;
   HIP_CHECK(hipGetDeviceCount(&numDevices));
   if (numDevices <= 0) {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kNoGpuDevice);
+    HIP_SKIP_TEST(HipTest::SkipReason::kNoGpuDevice);
   } else {
     int deviceId = 0;
     HIP_CHECK(hipSetDevice(deviceId));

--- a/projects/hip-tests/catch/perftests/memory/hipPerfBufferCopySpeedAll2All.cc
+++ b/projects/hip-tests/catch/perftests/memory/hipPerfBufferCopySpeedAll2All.cc
@@ -85,8 +85,7 @@ static void testCopyPerf(bool toRemote, bool kernelCopy, bool onOneGpu, DEV_MEM_
   unsigned int blocks = 16;  // DEBUG_CLR_LIMIT_BLIT_WG
   HIP_CHECK(hipGetDeviceCount(&nGpus));
   if (nGpus < 2) {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
-    return;
+    HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
   }
 #if 0
   if (kernelCopy) {

--- a/projects/hip-tests/catch/perftests/memory/hipPerfBufferCopySpeedP2P.cc
+++ b/projects/hip-tests/catch/perftests/memory/hipPerfBufferCopySpeedP2P.cc
@@ -120,8 +120,7 @@ static void testP2PUniDirMemPerf(const int iterations, const TIMING_MODE timingM
   int gpuCount = 0;
   HIP_CHECK(hipGetDeviceCount(&gpuCount));
   if (gpuCount < 1) {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kNoGpuDevice);
-    return;
+    HIP_SKIP_TEST(HipTest::SkipReason::kNoGpuDevice);
   }
   vector<double> timeMs(gpuCount * gpuCount, 0.);
   vector<double> bandWidth(gpuCount * gpuCount, 0.);
@@ -263,8 +262,7 @@ static void testP2PBiDirMemPerf(const int iterations, const bool useHipMemcpyAsy
   int gpuCount = 0;
   HIP_CHECK(hipGetDeviceCount(&gpuCount));
   if (gpuCount < 1) {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kNoGpuDevice);
-    return;
+    HIP_SKIP_TEST(HipTest::SkipReason::kNoGpuDevice);
   }
   vector<double> timeMs(gpuCount * gpuCount, 0.);
   vector<double> bandWidth(gpuCount * gpuCount, 0.);

--- a/projects/hip-tests/catch/perftests/memory/hipPerfDevMemReadSpeed.cc
+++ b/projects/hip-tests/catch/perftests/memory/hipPerfDevMemReadSpeed.cc
@@ -133,7 +133,7 @@ HIP_TEST_CASE(Perf_hipPerfDevMemReadSpeed_test) {
   HIP_CHECK(hipGetDeviceCount(&numDevices));
 
   if (numDevices <= 0) {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kNoGpuDevice);
+    HIP_SKIP_TEST(HipTest::SkipReason::kNoGpuDevice);
   } else {
     REQUIRE(true == hipPerfDevMemReadSpeed_test());
   }

--- a/projects/hip-tests/catch/perftests/memory/hipPerfDevMemWriteSpeed.cc
+++ b/projects/hip-tests/catch/perftests/memory/hipPerfDevMemWriteSpeed.cc
@@ -125,7 +125,7 @@ HIP_TEST_CASE(Perf_hipPerfDevMemWriteSpeed_test) {
   HIP_CHECK(hipGetDeviceCount(&numDevices));
 
   if (numDevices <= 0) {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kNoGpuDevice);
+    HIP_SKIP_TEST(HipTest::SkipReason::kNoGpuDevice);
   } else {
     REQUIRE(true == hipPerfDevMemWriteSpeed_test());
   }

--- a/projects/hip-tests/catch/perftests/memory/hipPerfHostNumaAlloc.cc
+++ b/projects/hip-tests/catch/perftests/memory/hipPerfHostNumaAlloc.cc
@@ -138,8 +138,7 @@ HIP_TEST_CASE(Perf_hipPerfHostNumaAlloc_test) {
   CONSOLE_PRINT("Cpu count %d, Gpu count %d, page_size %d\n", cpuCount, gpuCount, page_size);
 
   if (cpuCount < 0 || gpuCount < 0) {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kNoGpuDevice);
-    return;
+    HIP_SKIP_TEST(HipTest::SkipReason::kNoGpuDevice);
   }
 
   REQUIRE(true == runTest(cpuCount, gpuCount, hipHostMallocDefault | hipHostMallocNumaUser,

--- a/projects/hip-tests/catch/perftests/memory/hipPerfHostNumaAllocWin.cc
+++ b/projects/hip-tests/catch/perftests/memory/hipPerfHostNumaAllocWin.cc
@@ -292,8 +292,7 @@ HIP_TEST_CASE(Perf_hipPerfHostNumaAlloc_test_preferred_host_numa_node_on_each_GP
   int numaNode = -1;
   HIP_CHECK(hipDeviceGetAttribute(&numaNode, hipDeviceAttributeHostNumaId, 0));
   if (numaNode == -1) {
-    HipTest::HIP_SKIP_TEST("host NUMA is not supported.");
-    return;
+    HIP_SKIP_TEST("host NUMA is not supported.");
   }
   HIP_CHECK(hipSetDevice(0));
   // In windows, it is the same with / without hipHostMallocNumaUser

--- a/projects/hip-tests/catch/perftests/memory/hipPerfMemMallocCpyFree.cc
+++ b/projects/hip-tests/catch/perftests/memory/hipPerfMemMallocCpyFree.cc
@@ -123,7 +123,7 @@ HIP_TEST_CASE(Perf_hipPerfMemMallocCpyFree_test) {
   HIP_CHECK(hipGetDeviceCount(&numDevices));
 
   if (numDevices <= 0) {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kNoGpuDevice);
+    HIP_SKIP_TEST(HipTest::SkipReason::kNoGpuDevice);
   } else {
     REQUIRE(true == hipPerfMemMallocCpyFree_test());
   }

--- a/projects/hip-tests/catch/perftests/memory/hipPerfMemcpy.cc
+++ b/projects/hip-tests/catch/perftests/memory/hipPerfMemcpy.cc
@@ -200,7 +200,7 @@ HIP_TEST_CASE(Perf_hipPerfMemcpy_test) {
   HIP_CHECK(hipGetDeviceCount(&numDevices));
 
   if (numDevices <= 0) {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kNoGpuDevice);
+    HIP_SKIP_TEST(HipTest::SkipReason::kNoGpuDevice);
   } else {
     int deviceId = 0;
     HIP_CHECK(hipSetDevice(deviceId));

--- a/projects/hip-tests/catch/perftests/memory/hipPerfMempool.cc
+++ b/projects/hip-tests/catch/perftests/memory/hipPerfMempool.cc
@@ -55,8 +55,7 @@ HIP_TEST_CASE(Perf_MempoolManager_hipMallocAsync_hipFreeAsync) {
   size_t free = 0, total = 0;
   HIP_CHECK(hipMemGetInfo(&free, &total));
   if (free < 30_GB) {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kNotEnoughFreeGpuMemory);
-    return;
+    HIP_SKIP_TEST(HipTest::SkipReason::kNotEnoughFreeGpuMemory);
   }
 
   hipMemPool_t pool;

--- a/projects/hip-tests/catch/perftests/memory/hipPerfSharedMemReadSpeed.cc
+++ b/projects/hip-tests/catch/perftests/memory/hipPerfSharedMemReadSpeed.cc
@@ -238,7 +238,7 @@ HIP_TEST_CASE(Perf_hipPerfSharedMemReadSpeed_test) {
   HIP_CHECK(hipGetDeviceCount(&numDevices));
 
   if (numDevices <= 0) {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kNoGpuDevice);
+    HIP_SKIP_TEST(HipTest::SkipReason::kNoGpuDevice);
   } else {
     REQUIRE(true == hipPerfSharedMemReadSpeed_test());
   }

--- a/projects/hip-tests/catch/perftests/stream/hipPerfDeviceConcurrency.cc
+++ b/projects/hip-tests/catch/perftests/stream/hipPerfDeviceConcurrency.cc
@@ -79,8 +79,7 @@ void hipPerfDeviceConcurrency::open(void) {
   HIP_CHECK(hipGetDeviceCount(&nGpu));
   setNumGpus(nGpu);
   if (nGpu < 1) {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kNoGpuDevice);
-    return;
+    HIP_SKIP_TEST(HipTest::SkipReason::kNoGpuDevice);
   }
 }
 

--- a/projects/hip-tests/catch/perftests/stream/hipPerfStreamConcurrency.cc
+++ b/projects/hip-tests/catch/perftests/stream/hipPerfStreamConcurrency.cc
@@ -199,8 +199,7 @@ bool hipPerfStreamConcurrency::open(int deviceId) {
   int nGpu = 0;
   HIP_CHECK(hipGetDeviceCount(&nGpu));
   if (nGpu < 1) {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kNoGpuDevice);
-    return false;
+    HIP_SKIP_TEST(HipTest::SkipReason::kNoGpuDevice);
   }
 
   HIP_CHECK(hipSetDevice(deviceId));

--- a/projects/hip-tests/catch/perftests/stream/hipPerfStreamCreateCopyDestroy.cc
+++ b/projects/hip-tests/catch/perftests/stream/hipPerfStreamCreateCopyDestroy.cc
@@ -44,8 +44,7 @@ bool hipPerfStreamCreateCopyDestroy::open(int deviceId) {
   int nGpu = 0;
   HIP_CHECK(hipGetDeviceCount(&nGpu));
   if (nGpu < 1) {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kNoGpuDevice);
-    return false;
+    HIP_SKIP_TEST(HipTest::SkipReason::kNoGpuDevice);
   }
   HIP_CHECK(hipSetDevice(deviceId));
   hipDeviceProp_t props;

--- a/projects/hip-tests/catch/perftests/vmm/hipPerfVMMAlloc.cc
+++ b/projects/hip-tests/catch/perftests/vmm/hipPerfVMMAlloc.cc
@@ -276,7 +276,7 @@ HIP_TEST_CASE(Perf_hipPerfVMMAllocSpeed_test) {
   int numDevices = 0;
   HIP_CHECK(hipGetDeviceCount(&numDevices));
   if (numDevices <= 0) {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kNoGpuDevice);
+    HIP_SKIP_TEST(HipTest::SkipReason::kNoGpuDevice);
   } else {
     // Test on Primary Device first
     int deviceId = 0;

--- a/projects/hip-tests/catch/stress/memory/hipHmmOvrSubscriptionTst.cc
+++ b/projects/hip-tests/catch/stress/memory/hipHmmOvrSubscriptionTst.cc
@@ -93,6 +93,6 @@ HIP_TEST_CASE(Stress_HMM_OverSubscriptionTst) {
     HIP_CHECK_THREAD_FINALIZE();
     REQUIRE(proc.wait() == 0);
   } else {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kGpuXnackNotEnabled);
+    HIP_SKIP_TEST(HipTest::SkipReason::kGpuXnackNotEnabled);
   }
 }

--- a/projects/hip-tests/catch/stress/memory/hipHostMallocStress.cc
+++ b/projects/hip-tests/catch/stress/memory/hipHostMallocStress.cc
@@ -66,7 +66,7 @@ HIP_TEST_CASE(Stress_hipHostMalloc_MaxAllocation_AllGpu) {
       HIP_CHECK(hipMemset((A + allocsize - 1 - samplesize), val, samplesize));
       HIP_CHECK(hipHostFree(A));
     } else {
-      HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kNotEnoughFreeHostMemory);
+      HIP_SKIP_TEST(HipTest::SkipReason::kNotEnoughFreeHostMemory);
     }
   }
 }

--- a/projects/hip-tests/catch/stress/memory/hipHostRegisterStress.cc
+++ b/projects/hip-tests/catch/stress/memory/hipHostRegisterStress.cc
@@ -45,8 +45,7 @@ HIP_TEST_CASE(Stress_hipHostRegister_Oversubscription) {
   std::string arch = prop.gcnArchName;
 #if HT_AMD
   if (std::string::npos == arch.find("xnack+")) {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kGpuXnackNotEnabled);
-    return;
+    HIP_SKIP_TEST(HipTest::SkipReason::kGpuXnackNotEnabled);
   }
 #endif
   size_t maxGpuMem = 0, availableMem = 0;
@@ -68,8 +67,7 @@ HIP_TEST_CASE(Stress_hipHostRegister_Oversubscription) {
   INFO("Free Host Memory = " << hostMemFree);
   // Ensure that allocsize < hostMemFree
   if (allocsize >= hostMemFree) {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kNotEnoughFreeHostMemory);
-    return;
+    HIP_SKIP_TEST(HipTest::SkipReason::kNotEnoughFreeHostMemory);
   }
   uint8_t* A = reinterpret_cast<uint8_t*>(malloc(allocsize));
   uint8_t* ptr;

--- a/projects/hip-tests/catch/stress/memory/hipMallocManagedStress.cc
+++ b/projects/hip-tests/catch/stress/memory/hipMallocManagedStress.cc
@@ -172,7 +172,7 @@ HIP_TEST_CASE(Stress_hipMallocManaged_MultiSize) {
     }
     HIP_CHECK(hipStreamDestroy(strm));
   } else {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kManagedMemoryUnsupported);
+    HIP_SKIP_TEST(HipTest::SkipReason::kManagedMemoryUnsupported);
   }
 }
 
@@ -215,7 +215,7 @@ HIP_TEST_CASE(Stress_hipMallocManaged_KrnlWth2MemTypes) {
     delete[] Hptr;
     REQUIRE(IfTestPassed);
   } else {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kManagedMemoryUnsupported);
+    HIP_SKIP_TEST(HipTest::SkipReason::kManagedMemoryUnsupported);
   }
 }
 
@@ -228,7 +228,7 @@ HIP_TEST_CASE(Stress_hipMallocManaged_MultiKrnlHmmAccess) {
     int InitVal = 123, NumElms = (1024 * 1024);
     LaunchKrnl4(NumElms, InitVal);
   } else {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kManagedMemoryUnsupported);
+    HIP_SKIP_TEST(HipTest::SkipReason::kManagedMemoryUnsupported);
   }
 }
 
@@ -308,6 +308,6 @@ HIP_TEST_CASE(Stress_hipMallocManaged_ExtremeSizes) {
     }
     REQUIRE(IfTestPassed);
   } else {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kManagedMemoryUnsupported);
+    HIP_SKIP_TEST(HipTest::SkipReason::kManagedMemoryUnsupported);
   }
 }

--- a/projects/hip-tests/catch/stress/memory/hipMemPrftchAsyncStressTst.cc
+++ b/projects/hip-tests/catch/stress/memory/hipMemPrftchAsyncStressTst.cc
@@ -116,6 +116,6 @@ HIP_TEST_CASE(Stress_hipMemPrefetchAsyncOneToAll) {
     // Releasing the resources in case all the scenarios passed
     HIP_CHECK(hipFree(Hmm1));
   } else {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kManagedMemoryUnsupported);
+    HIP_SKIP_TEST(HipTest::SkipReason::kManagedMemoryUnsupported);
   }
 }

--- a/projects/hip-tests/catch/stress/printf/Stress_printf_ComplexKernels.cc
+++ b/projects/hip-tests/catch/stress/printf/Stress_printf_ComplexKernels.cc
@@ -398,7 +398,7 @@ HIP_TEST_CASE(Stress_printf_ComplexKernelMultStream) {
   REQUIRE(TestPassed);
   printf("Test - Stress_printf_ComplexKernelMultStream completed \n");
 #else
-  HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kRequiresLinux);
+  HIP_SKIP_TEST(HipTest::SkipReason::kRequiresLinux);
 #endif
 }
 
@@ -414,8 +414,7 @@ HIP_TEST_CASE(Stress_printf_ComplexKernelMultStreamMultGpu) {
   int numOfGPUs = 0;
   HIP_CHECK(hipGetDeviceCount(&numOfGPUs));
   if (numOfGPUs < 2) {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
-    return;
+    HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
   }
   // num_blocks is calculated using an approximate formula to arrive at
   // the required print data quantity. CONST_WEIGHTING_FACT1 and
@@ -429,6 +428,6 @@ HIP_TEST_CASE(Stress_printf_ComplexKernelMultStreamMultGpu) {
   REQUIRE(TestPassed);
   printf("Test - Stress_printf_ComplexKernelMultStreamMultGpu end \n");
 #else
-  HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kRequiresLinux);
+  HIP_SKIP_TEST(HipTest::SkipReason::kRequiresLinux);
 #endif
 }

--- a/projects/hip-tests/catch/stress/printf/Stress_printf_SimpleKernels.cc
+++ b/projects/hip-tests/catch/stress/printf/Stress_printf_SimpleKernels.cc
@@ -588,7 +588,7 @@ HIP_TEST_CASE(Stress_printf_ConstStr) {
       hipPrintfStressTest::test_printf_conststr(num_blocks, threads_per_block, print_limit);
   REQUIRE(TestPassed);
 #else
-  HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kRequiresLinux);
+  HIP_SKIP_TEST(HipTest::SkipReason::kRequiresLinux);
 #endif
 }
 
@@ -605,7 +605,7 @@ HIP_TEST_CASE(Stress_printf_IfElseConditionalStr) {
                                                                    print_limit);
   REQUIRE(TestPassed);
 #else
-  HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kRequiresLinux);
+  HIP_SKIP_TEST(HipTest::SkipReason::kRequiresLinux);
 #endif
 }
 
@@ -622,7 +622,7 @@ HIP_TEST_CASE(Stress_printf_IfConditionalStr) {
                                                                       print_limit);
   REQUIRE(TestPassed);
 #else
-  HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kRequiresLinux);
+  HIP_SKIP_TEST(HipTest::SkipReason::kRequiresLinux);
 #endif
 }
 
@@ -638,7 +638,7 @@ HIP_TEST_CASE(Stress_printf_VariableStr) {
       hipPrintfStressTest::EmpiricalValues1);
   REQUIRE(TestPassed);
 #else
-  HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kRequiresLinux);
+  HIP_SKIP_TEST(HipTest::SkipReason::kRequiresLinux);
 #endif
 }
 
@@ -654,7 +654,7 @@ HIP_TEST_CASE(Stress_printf_DependentCalc) {
                                                       hipPrintfStressTest::EmpiricalValues2);
   REQUIRE(TestPassed);
 #else
-  HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kRequiresLinux);
+  HIP_SKIP_TEST(HipTest::SkipReason::kRequiresLinux);
 #endif
 }
 
@@ -670,7 +670,7 @@ HIP_TEST_CASE(Stress_printf_DecimalStr) {
   TestPassed = hipPrintfStressTest::test_decimal_str(num_blocks, threads_per_block, print_limit);
   REQUIRE(TestPassed);
 #else
-  HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kRequiresLinux);
+  HIP_SKIP_TEST(HipTest::SkipReason::kRequiresLinux);
 #endif
 }
 
@@ -686,7 +686,7 @@ HIP_TEST_CASE(Stress_printf_SharedMem) {
   TestPassed = hipPrintfStressTest::test_shared_mem(num_blocks, threads_per_block, print_limit);
   REQUIRE(TestPassed);
 #else
-  HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kRequiresLinux);
+  HIP_SKIP_TEST(HipTest::SkipReason::kRequiresLinux);
 #endif
 }
 
@@ -701,7 +701,7 @@ HIP_TEST_CASE(Stress_printf_SynchronizedPrintf) {
   TestPassed = hipPrintfStressTest::test_synchronized_printf(1, threads_per_block, print_limit);
   REQUIRE(TestPassed);
 #else
-  HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kRequiresLinux);
+  HIP_SKIP_TEST(HipTest::SkipReason::kRequiresLinux);
 #endif
 }
 
@@ -717,6 +717,6 @@ HIP_TEST_CASE(Stress_printf_AtomicCalc) {
       hipPrintfStressTest::EmpiricalValues2);
   REQUIRE(TestPassed);
 #else
-  HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kRequiresLinux);
+  HIP_SKIP_TEST(HipTest::SkipReason::kRequiresLinux);
 #endif
 }

--- a/projects/hip-tests/catch/stress/printf/printf_common.h
+++ b/projects/hip-tests/catch/stress/printf/printf_common.h
@@ -35,10 +35,9 @@ static inline bool gpuCompositorLikelyActive() {
 
 #define SKIP_IF_GPU_COMPOSITOR_ACTIVE()                                                         \
   if (gpuCompositorLikelyActive()) {                                                            \
-    HipTest::HIP_SKIP_TEST(                                                                     \
+    HIP_SKIP_TEST(                                                                              \
         "likely running under a GPU compositor; long printf kernels may trigger a GPU reset. "  \
         "Run from a VT (chvt 3) or over SSH, or set HIP_PRINTF_STRESS_FORCE_RUN=1 to bypass."); \
-    return;                                                                                     \
   }
 
 #ifdef __linux__

--- a/projects/hip-tests/catch/stress/stream/streamEnqueue.cc
+++ b/projects/hip-tests/catch/stress/stream/streamEnqueue.cc
@@ -115,8 +115,7 @@ HIP_TEST_CASE(Stress_StreamEnqueue_DifferentThreads_MultiGPU) {
 
   // Skip the test if devices less than 2
   if (deviceCount <= 1) {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
-    return;
+    HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
   }
 
   constexpr size_t streamPerGPU{3};  // Stream per gpu

--- a/projects/hip-tests/catch/unit/assertion/assert.cc
+++ b/projects/hip-tests/catch/unit/assertion/assert.cc
@@ -63,15 +63,12 @@ bool isAbortOnErrorEnabled() {
 HIP_TEST_CASE(Unit_Assert_Positive_Basic_KernelPass) {
 
 #ifdef NDEBUG
-  HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kAssertionsDisabled);
-  return;
+  HIP_SKIP_TEST(HipTest::SkipReason::kAssertionsDisabled);
 #endif
 
 #if HT_AMD
   if (isAbortOnErrorEnabled()) {
-    HipTest::HIP_SKIP_TEST(
-        "Test incompatible with aborts enabled through HIP_SKIP_ABORT_ON_GPU_ERROR.");
-    return;
+    HIP_SKIP_TEST("Test incompatible with aborts enabled through HIP_SKIP_ABORT_ON_GPU_ERROR.");
   }
 #endif
 
@@ -105,15 +102,12 @@ HIP_TEST_CASE(Unit_Assert_Positive_Basic_KernelPass) {
 HIP_TEST_CASE(Unit_Assert_Positive_Basic_KernelFail) {
 
 #ifdef NDEBUG
-  HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kAssertionsDisabled);
-  return;
+  HIP_SKIP_TEST(HipTest::SkipReason::kAssertionsDisabled);
 #endif
 
 #if HT_AMD
   if (isAbortOnErrorEnabled()) {
-    HipTest::HIP_SKIP_TEST(
-        "Test incompatible with aborts enabled through HIP_SKIP_ABORT_ON_GPU_ERROR.");
-    return;
+    HIP_SKIP_TEST("Test incompatible with aborts enabled through HIP_SKIP_ABORT_ON_GPU_ERROR.");
   }
 #endif
 

--- a/projects/hip-tests/catch/unit/atomics/arithmetic_common.hh
+++ b/projects/hip-tests/catch/unit/atomics/arithmetic_common.hh
@@ -518,8 +518,7 @@ void SingleDeviceMultipleKernelTest(const unsigned int kernel_count, const unsig
   int concurrent_kernels = 0;
   HIP_CHECK(hipDeviceGetAttribute(&concurrent_kernels, hipDeviceAttributeConcurrentKernels, 0));
   if (!concurrent_kernels) {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kConcurrentKernelExecutionUnsupported);
-    return;
+    HIP_SKIP_TEST(HipTest::SkipReason::kConcurrentKernelExecutionUnsupported);
   }
 
   TestParams params;
@@ -549,14 +548,12 @@ void MultipleDeviceMultipleKernelAndHostTest(const unsigned int num_devices,
                                              const unsigned int host_thread_count = 0u) {
   if (num_devices > 1) {
     if (HipTest::getDeviceCount() < num_devices) {
-      HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kRequiredDeviceCountNotMet);
-      return;
+      HIP_SKIP_TEST(HipTest::SkipReason::kRequiredDeviceCountNotMet);
     }
   }
 
   if (!HipTest::checkConcurrentKernels(num_devices)) {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kConcurrentKernelExecutionUnsupported);
-    return;
+    HIP_SKIP_TEST(HipTest::SkipReason::kConcurrentKernelExecutionUnsupported);
   }
 
   TestParams params;

--- a/projects/hip-tests/catch/unit/atomics/atomicExch_common.hh
+++ b/projects/hip-tests/catch/unit/atomics/atomicExch_common.hh
@@ -342,8 +342,7 @@ void AtomicExchSingleDeviceMultipleKernelTest(const unsigned int kernel_count,
   int concurrent_kernels = 0;
   HIP_CHECK(hipDeviceGetAttribute(&concurrent_kernels, hipDeviceAttributeConcurrentKernels, 0));
   if (!concurrent_kernels) {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kConcurrentKernelExecutionUnsupported);
-    return;
+    HIP_SKIP_TEST(HipTest::SkipReason::kConcurrentKernelExecutionUnsupported);
   }
 
   AtomicExchParams params;
@@ -372,14 +371,12 @@ void AtomicExchMultipleDeviceMultipleKernelAndHostTest(const unsigned int num_de
                                                        const unsigned int host_thread_count = 0u) {
   if (num_devices > 1) {
     if (HipTest::getDeviceCount() < num_devices) {
-      HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kRequiredDeviceCountNotMet);
-      return;
+      HIP_SKIP_TEST(HipTest::SkipReason::kRequiredDeviceCountNotMet);
     }
   }
 
   if (!HipTest::checkConcurrentKernels(num_devices)) {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kConcurrentKernelExecutionUnsupported);
-    return;
+    HIP_SKIP_TEST(HipTest::SkipReason::kConcurrentKernelExecutionUnsupported);
   }
 
   AtomicExchParams params;

--- a/projects/hip-tests/catch/unit/atomics/bitwise_common.hh
+++ b/projects/hip-tests/catch/unit/atomics/bitwise_common.hh
@@ -345,8 +345,7 @@ void SingleDeviceMultipleKernelTest(const unsigned int kernel_count, const unsig
   int concurrent_kernels = 0;
   HIP_CHECK(hipDeviceGetAttribute(&concurrent_kernels, hipDeviceAttributeConcurrentKernels, 0));
   if (!concurrent_kernels) {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kConcurrentKernelExecutionUnsupported);
-    return;
+    HIP_SKIP_TEST(HipTest::SkipReason::kConcurrentKernelExecutionUnsupported);
   }
 
   TestParams params;
@@ -373,14 +372,12 @@ void MultipleDeviceMultipleKernelTest(const unsigned int num_devices,
                                       const unsigned int pitch) {
   if (num_devices > 1) {
     if (HipTest::getDeviceCount() < num_devices) {
-      HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kRequiredDeviceCountNotMet);
-      return;
+      HIP_SKIP_TEST(HipTest::SkipReason::kRequiredDeviceCountNotMet);
     }
   }
 
   if (!HipTest::checkConcurrentKernels(num_devices)) {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kConcurrentKernelExecutionUnsupported);
-    return;
+    HIP_SKIP_TEST(HipTest::SkipReason::kConcurrentKernelExecutionUnsupported);
   }
 
   TestParams params;

--- a/projects/hip-tests/catch/unit/atomics/min_max_common.hh
+++ b/projects/hip-tests/catch/unit/atomics/min_max_common.hh
@@ -366,8 +366,7 @@ void SingleDeviceMultipleKernelTest(const unsigned int kernel_count, const unsig
   int concurrent_kernels = 0;
   HIP_CHECK(hipDeviceGetAttribute(&concurrent_kernels, hipDeviceAttributeConcurrentKernels, 0));
   if (!concurrent_kernels) {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kConcurrentKernelExecutionUnsupported);
-    return;
+    HIP_SKIP_TEST(HipTest::SkipReason::kConcurrentKernelExecutionUnsupported);
   }
 
   TestParams params;
@@ -394,13 +393,11 @@ void MultipleDeviceMultipleKernelTest(const unsigned int num_devices,
                                       const unsigned int pitch) {
   if (num_devices > 1) {
     if (HipTest::getDeviceCount() < num_devices) {
-      HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kRequiredDeviceCountNotMet);
-      return;
+      HIP_SKIP_TEST(HipTest::SkipReason::kRequiredDeviceCountNotMet);
     }
   }
   if (!HipTest::checkConcurrentKernels(num_devices)) {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kConcurrentKernelExecutionUnsupported);
-    return;
+    HIP_SKIP_TEST(HipTest::SkipReason::kConcurrentKernelExecutionUnsupported);
   }
   TestParams params;
   params.num_devices = num_devices;

--- a/projects/hip-tests/catch/unit/clock/hipClockCheck.cc
+++ b/projects/hip-tests/catch/unit/clock/hipClockCheck.cc
@@ -133,8 +133,7 @@ void execute_clock_kernels(void (*kernel)(long long*, long long*, float*, float*
 
 HIP_TEST_CASE(Unit_hipClock64_Positive_Basic) {
   if (IsGfx11()) {
-    HipTest::HIP_SKIP_TEST("clock64() issue on gfx11 devices.");
-    return;
+    HIP_SKIP_TEST("clock64() issue on gfx11 devices.");
   }
 
   execute_clock_kernels(reduce_c64);
@@ -155,8 +154,7 @@ HIP_TEST_CASE(Unit_hipClock64_Positive_Basic) {
  */
 HIP_TEST_CASE(Unit_hipClock_Positive_Basic) {
   if (IsGfx11()) {
-    HipTest::HIP_SKIP_TEST("clock() issue on gfx11 devices.");
-    return;
+    HIP_SKIP_TEST("clock() issue on gfx11 devices.");
   }
 
   execute_clock_kernels(reduce_c);

--- a/projects/hip-tests/catch/unit/compiler/hipSquareGenericTarget.cc
+++ b/projects/hip-tests/catch/unit/compiler/hipSquareGenericTarget.cc
@@ -24,8 +24,7 @@ HIP_TEST_CASE(Unit_test_generic_target_in_compressed_fatbin) {
 HIP_TEST_CASE(Unit_test_generic_target_in_regular_fatbin) {
 #endif
   if (!isGenericTargetSupported()) {
-    HipTest::HIP_SKIP_TEST("generic target is not supported on this device.");
-    return;
+    HIP_SKIP_TEST("generic target is not supported on this device.");
   }
   float *A_d, *C_d;
   float *A_h, *C_h;

--- a/projects/hip-tests/catch/unit/cooperativeGrps/grid_group.cc
+++ b/projects/hip-tests/catch/unit/cooperativeGrps/grid_group.cc
@@ -107,8 +107,7 @@ HIP_TEST_CASE(Unit_Grid_Group_Getters_Positive_Basic) {
   HIP_CHECK(hipGetDeviceProperties(&device_properties, device));
 
   if (!device_properties.cooperativeLaunch) {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kCooperativeLaunchUnsupported);
-    return;
+    HIP_SKIP_TEST(HipTest::SkipReason::kCooperativeLaunchUnsupported);
   }
 
   const auto blocks = GenerateBlockDimensions();
@@ -187,8 +186,7 @@ HIP_TEST_CASE(Unit_Grid_Group_Getters_Via_Non_Member_Functions_Positive_Basic) {
   HIP_CHECK(hipGetDeviceProperties(&device_properties, device));
 
   if (!device_properties.cooperativeLaunch) {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kCooperativeLaunchUnsupported);
-    return;
+    HIP_SKIP_TEST(HipTest::SkipReason::kCooperativeLaunchUnsupported);
   }
 
   const auto blocks = GenerateBlockDimensions();
@@ -256,8 +254,7 @@ HIP_TEST_CASE(Unit_Grid_Group_Sync_Positive_Basic) {
   HIP_CHECK(hipGetDeviceProperties(&device_properties, device));
 
   if (!device_properties.cooperativeLaunch) {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kCooperativeLaunchUnsupported);
-    return;
+    HIP_SKIP_TEST(HipTest::SkipReason::kCooperativeLaunchUnsupported);
   }
 
   auto loops = GENERATE(2, 4, 8, 16);

--- a/projects/hip-tests/catch/unit/cooperativeGrps/hipCGGridGroupType_old.cc
+++ b/projects/hip-tests/catch/unit/cooperativeGrps/hipCGGridGroupType_old.cc
@@ -316,8 +316,7 @@ HIP_TEST_CASE(Unit_hipCGGridGroupType_Basic) {
   HIP_CHECK(hipGetDeviceProperties(&device_properties, device));
 
   if (!device_properties.cooperativeLaunch) {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kCooperativeLaunchUnsupported);
-    return;
+    HIP_SKIP_TEST(HipTest::SkipReason::kCooperativeLaunchUnsupported);
   }
 
   void* kernel_func;
@@ -362,8 +361,7 @@ HIP_TEST_CASE(Unit_hipCGGridGroupType_DataSharing) {
   HIP_CHECK(hipGetDeviceProperties(&device_properties, device));
 
   if (!device_properties.cooperativeLaunch) {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kCooperativeLaunchUnsupported);
-    return;
+    HIP_SKIP_TEST(HipTest::SkipReason::kCooperativeLaunchUnsupported);
   }
 
   int loops = GENERATE(1, 2, 3, 4);
@@ -442,8 +440,7 @@ HIP_TEST_CASE(Unit_hipCGGridGroupType_Barrier) {
   HIP_CHECK(hipGetDeviceProperties(&device_properties, device));
 
   if (!device_properties.cooperativeLaunch) {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kCooperativeLaunchUnsupported);
-    return;
+    HIP_SKIP_TEST(HipTest::SkipReason::kCooperativeLaunchUnsupported);
   }
 
   uint32_t loops = GENERATE(1, 2, 3, 4);

--- a/projects/hip-tests/catch/unit/cooperativeGrps/hipCGMultiGridGroupType_old.cc
+++ b/projects/hip-tests/catch/unit/cooperativeGrps/hipCGMultiGridGroupType_old.cc
@@ -374,8 +374,7 @@ HIP_TEST_CASE(Unit_hipCGMultiGridGroupType_Basic) {
   for (int i = 0; i < num_devices; i++) {
     HIP_CHECK(hipGetDeviceProperties(&device_properties, i));
     if (!device_properties.cooperativeMultiDeviceLaunch) {
-      HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kCooperativeLaunchUnsupported);
-      return;
+      HIP_SKIP_TEST(HipTest::SkipReason::kCooperativeLaunchUnsupported);
     }
     max_threads_per_blk = min(max_threads_per_blk, device_properties.maxThreadsPerBlock);
   }
@@ -418,16 +417,14 @@ HIP_TEST_CASE(Unit_hipCGMultiGridGroupType_Barrier) {
 
   HIP_CHECK(hipGetDeviceCount(&num_devices));
   if (num_devices < 2) {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
-    return;
+    HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
   }
 
   std::vector<hipDeviceProp_t> device_properties(num_devices);
   for (int i = 0; i < num_devices; i++) {
     HIP_CHECK(hipGetDeviceProperties(&device_properties[i], i));
     if (!device_properties[i].cooperativeMultiDeviceLaunch) {
-      HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kCooperativeLaunchUnsupported);
-      return;
+      HIP_SKIP_TEST(HipTest::SkipReason::kCooperativeLaunchUnsupported);
     }
   }
 

--- a/projects/hip-tests/catch/unit/cooperativeGrps/hipCGThreadBlockTileTypeShfl_old.cc
+++ b/projects/hip-tests/catch/unit/cooperativeGrps/hipCGThreadBlockTileTypeShfl_old.cc
@@ -169,8 +169,7 @@ HIP_TEST_CASE(Unit_hipCGThreadBlockTileType_Shfl) {
   HIP_CHECK(hipGetDeviceProperties(&device_properties, device));
 
   if (!device_properties.cooperativeLaunch) {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kCooperativeLaunchUnsupported);
-    return;
+    HIP_SKIP_TEST(HipTest::SkipReason::kCooperativeLaunchUnsupported);
   }
 
   TiledGroupShflTests shfl_test = GENERATE(

--- a/projects/hip-tests/catch/unit/cooperativeGrps/hipCGThreadBlockType_old.cc
+++ b/projects/hip-tests/catch/unit/cooperativeGrps/hipCGThreadBlockType_old.cc
@@ -183,8 +183,7 @@ HIP_TEST_CASE(Unit_hipCGThreadBlockType) {
   HIP_CHECK(hipGetDeviceProperties(&device_properties, device));
 
   if (!device_properties.cooperativeLaunch) {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kCooperativeLaunchUnsupported);
-    return;
+    HIP_SKIP_TEST(HipTest::SkipReason::kCooperativeLaunchUnsupported);
   }
 
   ThreadBlockTypeTests test_type = ThreadBlockTypeTests::basicApi;

--- a/projects/hip-tests/catch/unit/cooperativeGrps/hipCGTiledPartitionType_old.cc
+++ b/projects/hip-tests/catch/unit/cooperativeGrps/hipCGTiledPartitionType_old.cc
@@ -331,8 +331,7 @@ HIP_TEST_CASE(Unit_hipCGThreadBlockTileType) {
   HIP_CHECK(hipGetDeviceProperties(&device_properties, device));
 
   if (!device_properties.cooperativeLaunch) {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kCooperativeLaunchUnsupported);
-    return;
+    HIP_SKIP_TEST(HipTest::SkipReason::kCooperativeLaunchUnsupported);
   }
 
   bool use_global_mem = GENERATE(true, false);

--- a/projects/hip-tests/catch/unit/cooperativeGrps/hipLaunchCooperativeKernelMultiDevice_old.cc
+++ b/projects/hip-tests/catch/unit/cooperativeGrps/hipLaunchCooperativeKernelMultiDevice_old.cc
@@ -134,8 +134,7 @@ HIP_TEST_CASE(Unit_hipLaunchCooperativeKernelMultiDevice_Basic) {
     // Calculate the device occupancy to know how many blocks can be run concurrently
     HIP_CHECK(hipGetDeviceProperties(&device_properties[i], 0));
     if (!device_properties[i].cooperativeMultiDeviceLaunch) {
-      HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kCooperativeLaunchUnsupported);
-      return;
+      HIP_SKIP_TEST(HipTest::SkipReason::kCooperativeLaunchUnsupported);
     }
   }
 

--- a/projects/hip-tests/catch/unit/cooperativeGrps/hipLaunchCooperativeKernel_old.cc
+++ b/projects/hip-tests/catch/unit/cooperativeGrps/hipLaunchCooperativeKernel_old.cc
@@ -55,8 +55,7 @@ HIP_TEST_CASE(Unit_hipLaunchCooperativeKernel_Basic) {
   HIP_CHECK(hipGetDeviceProperties(&device_properties, device));
 
   if (!device_properties.cooperativeLaunch) {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kCooperativeLaunchUnsupported);
-    return;
+    HIP_SKIP_TEST(HipTest::SkipReason::kCooperativeLaunchUnsupported);
   }
 
   size_t buffer_size = kBufferLen * sizeof(int);

--- a/projects/hip-tests/catch/unit/cooperativeGrps/multi_grid_group.cc
+++ b/projects/hip-tests/catch/unit/cooperativeGrps/multi_grid_group.cc
@@ -152,8 +152,7 @@ HIP_TEST_CASE(Unit_Multi_Grid_Group_Getters_Positive_Basic) {
   for (int i = 0; i < num_devices; i++) {
     HIP_CHECK(hipGetDeviceProperties(&device_properties[i], i));
     if (!device_properties[i].cooperativeMultiDeviceLaunch) {
-      HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kCooperativeLaunchUnsupported);
-      return;
+      HIP_SKIP_TEST(HipTest::SkipReason::kCooperativeLaunchUnsupported);
     }
   }
   const auto test_case = GENERATE(range(0, 20));
@@ -299,8 +298,7 @@ HIP_TEST_CASE(Unit_Multi_Grid_Group_Getters_Positive_Base_Type) {
   for (int i = 0; i < num_devices; i++) {
     HIP_CHECK(hipGetDeviceProperties(&device_properties[i], i));
     if (!device_properties[i].cooperativeMultiDeviceLaunch) {
-      HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kCooperativeLaunchUnsupported);
-      return;
+      HIP_SKIP_TEST(HipTest::SkipReason::kCooperativeLaunchUnsupported);
     }
   }
 
@@ -421,8 +419,7 @@ HIP_TEST_CASE(Unit_Multi_Grid_Group_Getters_Positive_Non_Member_Functions) {
   for (int i = 0; i < num_devices; i++) {
     HIP_CHECK(hipGetDeviceProperties(&device_properties[i], i));
     if (!device_properties[i].cooperativeMultiDeviceLaunch) {
-      HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kCooperativeLaunchUnsupported);
-      return;
+      HIP_SKIP_TEST(HipTest::SkipReason::kCooperativeLaunchUnsupported);
     }
   }
   const auto test_case = GENERATE(range(0, 20));
@@ -533,8 +530,7 @@ HIP_TEST_CASE(Unit_Multi_Grid_Group_Positive_Sync) {
   for (int i = 0; i < num_devices; i++) {
     HIP_CHECK(hipGetDeviceProperties(&device_properties[i], i));
     if (!device_properties[i].cooperativeMultiDeviceLaunch) {
-      HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kCooperativeLaunchUnsupported);
-      return;
+      HIP_SKIP_TEST(HipTest::SkipReason::kCooperativeLaunchUnsupported);
     }
   }
   auto loops = GENERATE(2, 4, 8);

--- a/projects/hip-tests/catch/unit/device/hipDeviceAPUCheck.cc
+++ b/projects/hip-tests/catch/unit/device/hipDeviceAPUCheck.cc
@@ -29,8 +29,7 @@ HIP_TEST_CASE(Unit_hipDeviceAPUCheck) {
   hipDeviceProp_t prop;
   HIP_CHECK(hipGetDeviceProperties(&prop, 0));
   if (!prop.integrated) {
-    HipTest::HIP_SKIP_TEST("test requires integrated APU; discrete GPU detected.");
-    return;
+    HIP_SKIP_TEST("test requires integrated APU; discrete GPU detected.");
   } else {
     std::cout << "This device is an APU" << std::endl;
   }

--- a/projects/hip-tests/catch/unit/device/hipDeviceCanAccessPeer.cc
+++ b/projects/hip-tests/catch/unit/device/hipDeviceCanAccessPeer.cc
@@ -31,8 +31,7 @@ HIP_TEST_CASE(Unit_hipDeviceCanAccessPeer_positive) {
   int canAccessPeer = 0;
   int deviceCount = HipTest::getGeviceCount();
   if (deviceCount < 2) {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
-    return;
+    HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
   }
 
   int dev = GENERATE(range(0, HipTest::getGeviceCount()));
@@ -75,8 +74,7 @@ HIP_TEST_CASE(Unit_hipDeviceCanAccessPeer_negative) {
   int canAccessPeer = 0;
   int deviceCount = HipTest::getGeviceCount();
   if (deviceCount < 2) {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
-    return;
+    HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
   }
 
   SECTION("canAccessPeer is nullptr") {

--- a/projects/hip-tests/catch/unit/device/hipDeviceComputeCapability.cc
+++ b/projects/hip-tests/catch/unit/device/hipDeviceComputeCapability.cc
@@ -60,8 +60,7 @@ HIP_TEST_CASE(Unit_hipDeviceComputeCapability_Negative) {
       REQUIRE_FALSE(hipDeviceComputeCapability(&major, &minor, numDevices) == hipSuccess);
     }
   } else {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kNoGpuDevice);
-    return;
+    HIP_SKIP_TEST(HipTest::SkipReason::kNoGpuDevice);
   }
 }
 

--- a/projects/hip-tests/catch/unit/device/hipDeviceEnableDisablePeerAccess.cc
+++ b/projects/hip-tests/catch/unit/device/hipDeviceEnableDisablePeerAccess.cc
@@ -34,8 +34,7 @@ HIP_TEST_CASE(Unit_hipDeviceEnableDisablePeerAccess_positive) {
   int canAccessPeer = 0;
   int deviceCount = HipTest::getGeviceCount();
   if (deviceCount < 2) {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
-    return;
+    HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
   }
 
   int dev = GENERATE(range(0, HipTest::getGeviceCount()));
@@ -53,8 +52,7 @@ HIP_TEST_CASE(Unit_hipDeviceEnableDisablePeerAccess_positive) {
     HIP_CHECK(hipStreamDestroy(stream));
 
     if (canAccessPeer == 0) {
-      HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kPeerAccessUnavailable);
-      return;
+      HIP_SKIP_TEST(HipTest::SkipReason::kPeerAccessUnavailable);
     }
     HIP_CHECK(hipDeviceEnablePeerAccess(peerDev, 0));
     HIP_CHECK(hipDeviceDisablePeerAccess(peerDev));
@@ -82,8 +80,7 @@ HIP_TEST_CASE(Unit_hipDeviceEnableDisablePeerAccess_positive) {
 HIP_TEST_CASE(Unit_hipDeviceEnablePeerAccess_negative) {
   int deviceCount = HipTest::getGeviceCount();
   if (deviceCount < 2) {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
-    return;
+    HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
   }
 
   SECTION("peerDeviceId is invalid") {
@@ -146,8 +143,7 @@ HIP_TEST_CASE(Unit_hipDeviceEnablePeerAccess_negative) {
 HIP_TEST_CASE(Unit_hipDeviceDisablePeerAccess_negative) {
   int deviceCount = HipTest::getGeviceCount();
   if (deviceCount < 2) {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
-    return;
+    HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
   }
 
   SECTION("peerDeviceId is invalid") {

--- a/projects/hip-tests/catch/unit/device/hipDeviceEnableDisablePeerAccess.cc
+++ b/projects/hip-tests/catch/unit/device/hipDeviceEnableDisablePeerAccess.cc
@@ -155,8 +155,7 @@ HIP_TEST_CASE(Unit_hipDeviceDisablePeerAccess_negative) {
     int canAccessPeer = 0;
     HIP_CHECK(hipDeviceCanAccessPeer(&canAccessPeer, 0, 1));
     if (canAccessPeer == 0) {
-      HipTest::HIP_SKIP_TEST("Skipping because no P2P support between device 0 and 1");
-      return;
+      HIP_SKIP_TEST("Skipping because no P2P support between device 0 and 1");
     }
     HIP_CHECK_ERROR(hipDeviceDisablePeerAccess(1), hipErrorPeerAccessNotEnabled);
   }

--- a/projects/hip-tests/catch/unit/device/hipDeviceGetDefaultMemPool.cc
+++ b/projects/hip-tests/catch/unit/device/hipDeviceGetDefaultMemPool.cc
@@ -33,8 +33,7 @@ HIP_TEST_CASE(Unit_hipDeviceGetDefaultMemPool_Positive_Basic) {
   HIP_CHECK(
       hipDeviceGetAttribute(&mem_pool_support, hipDeviceAttributeMemoryPoolsSupported, device));
   if (!mem_pool_support) {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kMemoryPoolUnsupported);
-    return;
+    HIP_SKIP_TEST(HipTest::SkipReason::kMemoryPoolUnsupported);
   }
 
   hipMemPool_t mem_pool;

--- a/projects/hip-tests/catch/unit/device/hipDeviceGetName.cc
+++ b/projects/hip-tests/catch/unit/device/hipDeviceGetName.cc
@@ -197,15 +197,13 @@ HIP_TEST_CASE(Unit_hipDeviceName_gcnArchName_And_rocm_agent_enumerator) {
   int deviceCount = 0;
   HIP_CHECK(hipGetDeviceCount(&deviceCount));
   if (deviceCount <= 0) {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kNoGpuDevice);
-    return;
+    HIP_SKIP_TEST(HipTest::SkipReason::kNoGpuDevice);
   }
 
   FILE* fpipe;
   fpipe = popen("rocm_agent_enumerator", "r");
   if (fpipe == nullptr) {
-    HipTest::HIP_SKIP_TEST("unable to create command file.");
-    return;
+    HIP_SKIP_TEST("unable to create command file.");
   }
   char command_op[BUFFER_LEN];
   const char* defCpu = "gfx000";

--- a/projects/hip-tests/catch/unit/device/hipDeviceGetUuid.cc
+++ b/projects/hip-tests/catch/unit/device/hipDeviceGetUuid.cc
@@ -467,7 +467,7 @@ HIP_TEST_CASE(Unit_Uuid_FntlTstsFor_SetEnv_HIP_VISIBLE_DEVICES) {
     }
 #endif
   } else {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kNoGpuDevice);  // NOLINT
+    HIP_SKIP_TEST(HipTest::SkipReason::kNoGpuDevice);  // NOLINT
   }
 }
 
@@ -521,7 +521,7 @@ void setEnv() {
     setenv("HIP_VISIBLE_DEVICES", uuidEnv.c_str(), 1);
   } else {
     tState = 2;
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);  // NOLINT
+    HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);  // NOLINT
   }
 }
 /**

--- a/projects/hip-tests/catch/unit/device/hipDeviceGetUuid.cc
+++ b/projects/hip-tests/catch/unit/device/hipDeviceGetUuid.cc
@@ -521,7 +521,6 @@ void setEnv() {
     setenv("HIP_VISIBLE_DEVICES", uuidEnv.c_str(), 1);
   } else {
     tState = 2;
-    HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);  // NOLINT
   }
 }
 /**
@@ -542,6 +541,9 @@ HIP_TEST_CASE(Unit_UUID_setEnv_Thread) {
   // Create Thread one
   std::thread t1(setEnv);
   t1.join();
+  if (tState == 2) {
+    HIP_SKIP_TEST("Skipping because this machine has total GPUs < 2");
+  }
   // Create Thread two
   std::thread t2(ChkUUID);
   t2.join();

--- a/projects/hip-tests/catch/unit/device/hipDeviceSetGetLimit.cc
+++ b/projects/hip-tests/catch/unit/device/hipDeviceSetGetLimit.cc
@@ -246,10 +246,9 @@ HIP_TEST_CASE(Unit_hipDeviceGetSetLimit_Scratch_Negative) {
  */
 HIP_TEST_CASE(Unit_hipDeviceGetSetLimit_Scratch_SetMinAndMaxAsCurrent) {
   if (!isSetScratchLimitSupported()) {
-    HipTest::HIP_SKIP_TEST(
+    HIP_SKIP_TEST(
         "Set Scratch Limit Not Supported on Current Device."
         " Only Mi300+ and Linux supports");
-    return;
   }
 
   size_t scratchLimitCurrent = 0;
@@ -286,10 +285,9 @@ HIP_TEST_CASE(Unit_hipDeviceGetSetLimit_Scratch_SetMinAndMaxAsCurrent) {
  */
 HIP_TEST_CASE(Unit_hipDeviceGetSetLimit_Scratch_DecreaseIncrease) {
   if (!isSetScratchLimitSupported()) {
-    HipTest::HIP_SKIP_TEST(
+    HIP_SKIP_TEST(
         "Set Scratch Limit Not Supported on Current Device."
         " Only Mi300+ and Linux supports");
-    return;
   }
 
   // Get the current scratch
@@ -365,10 +363,9 @@ __global__ void addOneKernelUseScratch(int* arr) {
  */
 HIP_TEST_CASE(Unit_hipDeviceGetSetLimit_Scratch_SetBeforeKernelLaunch) {
   if (!isSetScratchLimitSupported()) {
-    HipTest::HIP_SKIP_TEST(
+    HIP_SKIP_TEST(
         "Set Scratch Limit Not Supported on Current Device."
         " Only Mi300+ and Linux supports");
-    return;
   }
 
   hipStream_t stream;
@@ -450,15 +447,13 @@ HIP_TEST_CASE(Unit_hipDeviceGetSetLimit_Scratch_MultiDevice) {
   int deviceCount = 0;
   HIP_CHECK(hipGetDeviceCount(&deviceCount));
   if (deviceCount < 2) {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
-    return;
+    HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
   }
 
   if (!isSetScratchLimitSupported()) {
-    HipTest::HIP_SKIP_TEST(
+    HIP_SKIP_TEST(
         "Set Scratch Limit Not Supported on Current Device."
         " Only Mi300+ and Linux supports");
-    return;
   }
 
   for (int deviceId = 0; deviceId < deviceCount; deviceId++) {
@@ -484,10 +479,9 @@ HIP_TEST_CASE(Unit_hipDeviceGetSetLimit_Scratch_MultiDevice) {
  */
 HIP_TEST_CASE(Unit_hipDeviceGetSetLimit_Scratch_InThread) {
   if (!isSetScratchLimitSupported()) {
-    HipTest::HIP_SKIP_TEST(
+    HIP_SKIP_TEST(
         "Set Scratch Limit Not Supported on Current Device."
         " Only Mi300+ and Linux supports");
-    return;
   }
 
   std::thread threadObj(getMinMaxCurrentAndSetCurrent);
@@ -510,10 +504,9 @@ HIP_TEST_CASE(Unit_hipDeviceGetSetLimit_Scratch_InThread) {
  */
 HIP_TEST_CASE(Unit_hipDeviceGetSetLimit_Scratch_InChildProcess) {
   if (!isSetScratchLimitSupported()) {
-    HipTest::HIP_SKIP_TEST(
+    HIP_SKIP_TEST(
         "Set Scratch Limit Not Supported on Current Device."
         " Only Mi300+ and Linux supports");
-    return;
   }
 
   hip::SpawnProc proc("hipDeviceSetGetScratchExe", true);
@@ -556,10 +549,9 @@ void getScratchCurrent(size_t checkValue) {
  */
 HIP_TEST_CASE(Unit_hipDeviceGetSetLimit_Scratch_SetGetThreads) {
   if (!isSetScratchLimitSupported()) {
-    HipTest::HIP_SKIP_TEST(
+    HIP_SKIP_TEST(
         "Set Scratch Limit Not Supported on Current Device."
         " Only Mi300+ and Linux supports");
-    return;
   }
 
   size_t max = 0, orgCurrent = 0;

--- a/projects/hip-tests/catch/unit/device/hipDeviceSetGetMemPool.cc
+++ b/projects/hip-tests/catch/unit/device/hipDeviceSetGetMemPool.cc
@@ -18,15 +18,13 @@
  * The memory pool must be local to the specified device.
  */
 
-static inline bool CheckMemPoolSupport(const int device) {
+static inline void CheckMemPoolSupport(const int device) {
   int mem_pool_support = 0;
   HIP_CHECK(
       hipDeviceGetAttribute(&mem_pool_support, hipDeviceAttributeMemoryPoolsSupported, device));
   if (!mem_pool_support) {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kMemoryPoolUnsupported);
-    return false;
+    HIP_SKIP_TEST(HipTest::SkipReason::kMemoryPoolUnsupported);
   }
-  return true;
 }
 
 static inline hipMemPool_t CreateMemPool(const int device) {
@@ -59,9 +57,7 @@ static inline hipMemPool_t CreateMemPool(const int device) {
 HIP_TEST_CASE(Unit_hipDeviceSetMemPool_Positive_Basic) {
   const int device = GENERATE(range(0, HipTest::getDeviceCount()));
 
-  if (!CheckMemPoolSupport(device)) {
-    return;
-  }
+  CheckMemPoolSupport(device);
 
   hipMemPool_t mem_pool = CreateMemPool(device);
   HIP_CHECK(hipDeviceSetMemPool(device, mem_pool));
@@ -132,9 +128,7 @@ HIP_TEST_CASE(Unit_hipDeviceSetMemPool_Negative_Parameters) {
 HIP_TEST_CASE(Unit_hipDeviceGetMemPool_Positive_Default) {
   const int device = GENERATE(range(0, HipTest::getDeviceCount()));
 
-  if (!CheckMemPoolSupport(device)) {
-    return;
-  }
+  CheckMemPoolSupport(device);
 
   hipMemPool_t default_mem_pool;
   HIP_CHECK(hipDeviceGetDefaultMemPool(&default_mem_pool, device));
@@ -160,9 +154,7 @@ HIP_TEST_CASE(Unit_hipDeviceGetMemPool_Positive_Default) {
 HIP_TEST_CASE(Unit_hipDeviceGetMemPool_Positive_Basic) {
   const int device = GENERATE(range(0, HipTest::getDeviceCount()));
 
-  if (!CheckMemPoolSupport(device)) {
-    return;
-  }
+  CheckMemPoolSupport(device);
 
   hipMemPool_t mem_pool = CreateMemPool(device);
   HIP_CHECK(hipDeviceSetMemPool(device, mem_pool));
@@ -206,9 +198,7 @@ HIP_TEST_CASE(Unit_hipDeviceGetMemPool_Positive_Threaded) {
     hipMemPool_t mem_pool_;
   };
 
-  if (!CheckMemPoolSupport(0)) {
-    return;
-  }
+  CheckMemPoolSupport(0);
 
   HipDeviceGetMemPoolTest test;
   test.run();

--- a/projects/hip-tests/catch/unit/device/hipDeviceTotalMem.cc
+++ b/projects/hip-tests/catch/unit/device/hipDeviceTotalMem.cc
@@ -105,8 +105,7 @@ HIP_TEST_CASE(Unit_hipDeviceTotalMem_ValidateTotalMem) {
 HIP_TEST_CASE(Unit_hipDeviceTotalMem_NonSelectedDevice) {
   auto deviceCount = HipTest::getDeviceCount();
   if (deviceCount < 2) {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
-    return;
+    HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
   }
 
   for (int i = 1; i < deviceCount; i++) {

--- a/projects/hip-tests/catch/unit/device/hipExtGetLinkTypeAndHopCount.cc
+++ b/projects/hip-tests/catch/unit/device/hipExtGetLinkTypeAndHopCount.cc
@@ -40,8 +40,7 @@ HIP_TEST_CASE(Unit_hipExtGetLinkTypeAndHopCount_Positive_Basic) {
   int can_access_peer = 0;
   HIP_CHECK(hipDeviceCanAccessPeer(&can_access_peer, device1, device2));
   if (!can_access_peer) {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kPeerAccessUnavailable);
-    return;
+    HIP_SKIP_TEST(HipTest::SkipReason::kPeerAccessUnavailable);
   }
 
   uint32_t link_type1 = -1, hop_count1 = -1;

--- a/projects/hip-tests/catch/unit/device/hipGetDeviceAttribute.cc
+++ b/projects/hip-tests/catch/unit/device/hipGetDeviceAttribute.cc
@@ -260,10 +260,9 @@ HIP_TEST_CASE(Unit_hipGetDeviceAttribute_hipDevAttrHostRegisterSupported) {
     HIP_CHECK(hipHostUnregister(x.get()));
     HIP_CHECK_ERROR(hipHostGetDevicePointer(&device_memory, x.get(), 0), hipErrorInvalidValue);
   } else {
-    HipTest::HIP_SKIP_TEST(
+    HIP_SKIP_TEST(
         "Skipping the test as GPU 0 doesn't support "
         "hipDeviceAttributeHostRegisterSupported attribute.\n");
-    return;
   }
 }
 

--- a/projects/hip-tests/catch/unit/device/hipGetDeviceCount.cc
+++ b/projects/hip-tests/catch/unit/device/hipGetDeviceCount.cc
@@ -46,8 +46,7 @@ HIP_TEST_CASE(Unit_hipGetDeviceCount_NegTst) {
 HIP_TEST_CASE(Unit_hipGetDeviceCount_HideDevices) {
   int deviceCount = HipTest::getDeviceCount();
   if (deviceCount < 2) {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
-    return;
+    HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
   }
 
   for (int i = deviceCount; i >= 1; i--) {

--- a/projects/hip-tests/catch/unit/device/hipGetProcAddressDevMgmt.cc
+++ b/projects/hip-tests/catch/unit/device/hipGetProcAddressDevMgmt.cc
@@ -393,8 +393,7 @@ HIP_TEST_CASE(Unit_hipGetProcAddress_PeerDeviceAccessAPIs) {
     int canAccessPeer_ptr = 0, canAccessPeer = 0, devCount = 0;
     HIP_CHECK(hipGetDeviceCount(&devCount));
     if (devCount < 2) {
-      HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
-      return;
+      HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
     }
     // hipDeviceCanAccessPeer API
     int devId{};
@@ -418,8 +417,7 @@ HIP_TEST_CASE(Unit_hipGetProcAddress_PeerDeviceAccessAPIs) {
         HIP_CHECK(hipSetDevice(dev));
         HIP_CHECK(hipDeviceCanAccessPeer(&canAccessPeer, dev, peerDev));
         if (canAccessPeer == 0) {
-          HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kPeerAccessUnavailable);
-          return;
+          HIP_SKIP_TEST(HipTest::SkipReason::kPeerAccessUnavailable);
         }
         HIP_CHECK(hipDeviceEnablePeerAccess(peerDev, 0));
         HIP_CHECK_ERROR(dyn_hipDeviceEnablePeerAccess_ptr(peerDev, 0),
@@ -430,15 +428,13 @@ HIP_TEST_CASE(Unit_hipGetProcAddress_PeerDeviceAccessAPIs) {
     }
   }
 }
-bool CheckMemPoolSupport(const int device) {
+void CheckMemPoolSupport(const int device) {
   int mem_pool_support = 0;
   HIP_CHECK(
       hipDeviceGetAttribute(&mem_pool_support, hipDeviceAttributeMemoryPoolsSupported, device));
   if (!mem_pool_support) {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kMemoryPoolUnsupported);
-    return false;
+    HIP_SKIP_TEST(HipTest::SkipReason::kMemoryPoolUnsupported);
   }
-  return true;
 }
 
 HIP_TEST_CASE(Unit_hipGetProcAddress_SetGetMemPoolAPIs) {
@@ -458,23 +454,16 @@ HIP_TEST_CASE(Unit_hipGetProcAddress_SetGetMemPoolAPIs) {
   int devCount = 0;
   HIP_CHECK(hipGetDeviceCount(&devCount));
   if (devCount < 2) {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
-    return;
+    HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
   }
   // hipDeviceSetMemPool API
   hipMemPool_t getMemPool = nullptr, getMemPool_ptr = nullptr;
   HIP_CHECK(hipSetDevice(0));
-  if (!CheckMemPoolSupport(0)) {
-    return;
-  } else {
-    CreateMemPool(0, getMemPool);
-  }
+  CheckMemPoolSupport(0);
+  CreateMemPool(0, getMemPool);
   HIP_CHECK(hipSetDevice(1));
-  if (!CheckMemPoolSupport(1)) {
-    return;
-  } else {
-    CreateMemPool(1, getMemPool_ptr);
-  }
+  CheckMemPoolSupport(1);
+  CreateMemPool(1, getMemPool_ptr);
   HIP_CHECK(hipDeviceSetMemPool(0, getMemPool));
   HIP_CHECK(dyn_hipDeviceSetMemPool_ptr(1, getMemPool_ptr));
   REQUIRE(getMemPool != nullptr);

--- a/projects/hip-tests/catch/unit/device/hipIpcOpenMemHandle.cc
+++ b/projects/hip-tests/catch/unit/device/hipIpcOpenMemHandle.cc
@@ -202,8 +202,7 @@ HIP_TEST_CASE(Unit_hipIpcOpenMemHandle_Multiproc) {
 HIP_TEST_CASE(Unit_hipIpcOpenMemHandle_Multiproc_Child) {
   const char* hex = std::getenv("HIP_IPC_HANDLE");
   if (hex == nullptr || hex[0] == '\0') {
-    HipTest::HIP_SKIP_TEST("This test must be launched by parent multiprocess test.");
-    return;
+    HIP_SKIP_TEST("This test must be launched by parent multiprocess test.");
   }
 
   hipIpcMemHandle_t handle = hexToIpcHandle(hex);

--- a/projects/hip-tests/catch/unit/device/hipSetGetDevice.cc
+++ b/projects/hip-tests/catch/unit/device/hipSetGetDevice.cc
@@ -141,8 +141,7 @@ HIP_TEST_CASE(Unit_hipSetGetDevice_Positive_Threaded_Basic) {
   };
 
   if (HipTest::getDeviceCount() < 2) {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
-    return;
+    HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
   }
 
   HipSetGetDeviceThreadedTest test;

--- a/projects/hip-tests/catch/unit/device/hipSetValidDevices.cc
+++ b/projects/hip-tests/catch/unit/device/hipSetValidDevices.cc
@@ -145,8 +145,7 @@ HIP_TEST_CASE(Unit_hipSetValidDevices_Negative_Length_Lessthan_DeviceArrSize) {
 HIP_TEST_CASE(Unit_hipSetValidDevices_Positive_Basic) {
   int totalDevices = HipTest::getDeviceCount();
   if (totalDevices < 2) {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
-    return;
+    HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
   }
 
   // By default, without setting any device, validate that 0th device is being used
@@ -247,8 +246,7 @@ HIP_TEST_CASE(Unit_hipSetValidDevices_WithAllDevicesInSystem) {
 HIP_TEST_CASE(Unit_hipSetValidDevices_Positive_Cases) {
   int deviceCount = HipTest::getDeviceCount();
   if (deviceCount < 2) {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
-    return;
+    HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
   }
 
   SECTION("length is 0 and deviceArr is nullPtr") {
@@ -303,8 +301,7 @@ HIP_TEST_CASE(Unit_hipSetValidDevices_Positive_Cases) {
 HIP_TEST_CASE(Unit_hipSetValidDevices_MultiProcess) {
   int deviceCount = HipTest::getDeviceCount();
   if (deviceCount < 2) {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
-    return;
+    HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
   }
 
   auto pid = fork();
@@ -369,8 +366,7 @@ void launchFunction(int deviceId) {
 HIP_TEST_CASE(Unit_hipSetValidDevices_MultiThread) {
   int deviceCount = HipTest::getDeviceCount();
   if (deviceCount < 2) {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
-    return;
+    HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
   }
 
   REQUIRE(getCurrentDevice() == 0);
@@ -411,14 +407,12 @@ HIP_TEST_CASE(Unit_hipSetValidDevices_MultiThread) {
 HIP_TEST_CASE(Unit_hipSetValidDevices_with_hipMemcpyPeer) {
   int deviceCount = HipTest::getDeviceCount();
   if (deviceCount < 2) {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
-    return;
+    HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
   }
   int canAccessPeer = -1;
   HIP_CHECK(hipDeviceCanAccessPeer(&canAccessPeer, 1, 0));
   if (!canAccessPeer) {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kPeerAccessUnavailable);
-    return;
+    HIP_SKIP_TEST(HipTest::SkipReason::kPeerAccessUnavailable);
   }
   REQUIRE(canAccessPeer == 1);
   HIP_CHECK(hipDeviceEnablePeerAccess(1, 0));

--- a/projects/hip-tests/catch/unit/deviceLib/AtomicAdd_Coherent.cc
+++ b/projects/hip-tests/catch/unit/deviceLib/AtomicAdd_Coherent.cc
@@ -149,7 +149,7 @@ TEST_CASE(Unit_AtomicAdd_Coherent) {
 
   if (CheckIfFeatSupported(CTFeatures::CT_FEATURE_FINEGRAIN_HWSUPPORT, gfxName)) {
     if (prop.canMapHostMemory != 1) {
-      HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kHostPinnedMemoryUnsupported);
+      HIP_SKIP_TEST(HipTest::SkipReason::kHostPinnedMemoryUnsupported);
     } else {
       SECTION("with -mno-unsafe-atomics flag") {
         SECTION("float") { runAtomicAddCoherentNoUnsafeFlagTest<float>(); }
@@ -167,6 +167,6 @@ TEST_CASE(Unit_AtomicAdd_Coherent) {
       }
     }
   } else {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kFineGrainHwUnsupported);
+    HIP_SKIP_TEST(HipTest::SkipReason::kFineGrainHwUnsupported);
   }
 }

--- a/projects/hip-tests/catch/unit/deviceLib/AtomicAdd_NonCoherent.cc
+++ b/projects/hip-tests/catch/unit/deviceLib/AtomicAdd_NonCoherent.cc
@@ -143,7 +143,7 @@ TEST_CASE(Unit_AtomicAdd_NonCoherent) {
 
   if (CheckIfFeatSupported(CTFeatures::CT_FEATURE_FINEGRAIN_HWSUPPORT, gfxName)) {
     if (prop.canMapHostMemory != 1) {
-      HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kHostPinnedMemoryUnsupported);
+      HIP_SKIP_TEST(HipTest::SkipReason::kHostPinnedMemoryUnsupported);
     } else {
       SECTION("with -mno-unsafe-atomics flag") {
         SECTION("float") { runAtomicAddNonCoherentNoUnsafeFlagTest<float>(); }
@@ -161,6 +161,6 @@ TEST_CASE(Unit_AtomicAdd_NonCoherent) {
       }
     }
   } else {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kFineGrainHwUnsupported);
+    HIP_SKIP_TEST(HipTest::SkipReason::kFineGrainHwUnsupported);
   }
 }

--- a/projects/hip-tests/catch/unit/deviceLib/BuiltIns_fmax.cc
+++ b/projects/hip-tests/catch/unit/deviceLib/BuiltIns_fmax.cc
@@ -69,7 +69,7 @@ HIP_TEST_CASE(Unit_BuiltinAtomics_fmaxCoherentGlobalMem) {
   std::string gfxName(prop.gcnArchName);
   if ((gfxName == "gfx90a" || gfxName.find("gfx90a:")) == 0) {
     if (prop.canMapHostMemory != 1) {
-      HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kHostPinnedMemoryUnsupported);
+      HIP_SKIP_TEST(HipTest::SkipReason::kHostPinnedMemoryUnsupported);
     } else {
       double *A_h, *B_h;
       double* A_d;
@@ -97,7 +97,7 @@ HIP_TEST_CASE(Unit_BuiltinAtomics_fmaxCoherentGlobalMem) {
           "Memory model feature is only supported for gfx90a, Hence"
           "skipping the testcase for this GPU ") +
           std::to_string(device);
-      HipTest::HIP_SKIP_TEST(skip_gfx_msg.c_str());
+      HIP_SKIP_TEST(skip_gfx_msg.c_str());
     }
   }
 }
@@ -120,7 +120,7 @@ HIP_TEST_CASE(Unit_BuiltinAtomics_fmaxNonCoherentGlobalFlatMem) {
   std::string gfxName(prop.gcnArchName);
   if ((gfxName == "gfx90a" || gfxName.find("gfx90a:")) == 0) {
     if (prop.canMapHostMemory != 1) {
-      HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kHostPinnedMemoryUnsupported);
+      HIP_SKIP_TEST(HipTest::SkipReason::kHostPinnedMemoryUnsupported);
     } else {
       double *A_h, *B_h;
       double* A_d;
@@ -154,7 +154,7 @@ HIP_TEST_CASE(Unit_BuiltinAtomics_fmaxNonCoherentGlobalFlatMem) {
           "Memory model feature is only supported for gfx90a, Hence"
           "skipping the testcase for this GPU ") +
           std::to_string(device);
-      HipTest::HIP_SKIP_TEST(skip_gfx_msg.c_str());
+      HIP_SKIP_TEST(skip_gfx_msg.c_str());
     }
   }
 }
@@ -173,7 +173,7 @@ HIP_TEST_CASE(Unit_BuiltinAtomicsRTC_fmaxCoherentGlobalMem) {
   std::string gfxName(prop.gcnArchName);
   if ((gfxName == "gfx90a" || gfxName.find("gfx90a:")) == 0) {
     if (prop.canMapHostMemory != 1) {
-      HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kHostPinnedMemoryUnsupported);
+      HIP_SKIP_TEST(HipTest::SkipReason::kHostPinnedMemoryUnsupported);
     } else {
       hiprtcProgram prog;
       hiprtcCreateProgram(&prog,          // prog
@@ -236,7 +236,7 @@ HIP_TEST_CASE(Unit_BuiltinAtomicsRTC_fmaxCoherentGlobalMem) {
           "Memory model feature is only supported for gfx90a, Hence"
           "skipping the testcase for this GPU ") +
           std::to_string(device);
-      HipTest::HIP_SKIP_TEST(skip_gfx_msg.c_str());
+      HIP_SKIP_TEST(skip_gfx_msg.c_str());
     }
   }
 }
@@ -258,7 +258,7 @@ HIP_TEST_CASE(Unit_BuiltinAtomicsRTC_fmaxNonCoherentGlobalFlatMem) {
   std::string gfxName(prop.gcnArchName);
   if ((gfxName == "gfx90a" || gfxName.find("gfx90a:")) == 0) {
     if (prop.canMapHostMemory != 1) {
-      HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kHostPinnedMemoryUnsupported);
+      HIP_SKIP_TEST(HipTest::SkipReason::kHostPinnedMemoryUnsupported);
     } else {
       hiprtcProgram prog;
       if (mem_type) {
@@ -331,7 +331,7 @@ HIP_TEST_CASE(Unit_BuiltinAtomicsRTC_fmaxNonCoherentGlobalFlatMem) {
           "Memory model feature is only supported for gfx90a, Hence"
           "skipping the testcase for this GPU ") +
           std::to_string(device);
-      HipTest::HIP_SKIP_TEST(skip_gfx_msg.c_str());
+      HIP_SKIP_TEST(skip_gfx_msg.c_str());
     }
   }
 }

--- a/projects/hip-tests/catch/unit/deviceLib/BuiltIns_fmin.cc
+++ b/projects/hip-tests/catch/unit/deviceLib/BuiltIns_fmin.cc
@@ -69,7 +69,7 @@ HIP_TEST_CASE(Unit_BuiltinAtomics_fminCoherentGlobalMem) {
   std::string gfxName(prop.gcnArchName);
   if ((gfxName == "gfx90a" || gfxName.find("gfx90a:")) == 0) {
     if (prop.canMapHostMemory != 1) {
-      HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kHostPinnedMemoryUnsupported);
+      HIP_SKIP_TEST(HipTest::SkipReason::kHostPinnedMemoryUnsupported);
     } else {
       double *A_h, *B_h;
       double* A_d;
@@ -97,7 +97,7 @@ HIP_TEST_CASE(Unit_BuiltinAtomics_fminCoherentGlobalMem) {
           "Memory model feature is only supported for gfx90a, Hence"
           "skipping the testcase for this GPU ") +
           std::to_string(device);
-      HipTest::HIP_SKIP_TEST(skip_gfx_msg.c_str());
+      HIP_SKIP_TEST(skip_gfx_msg.c_str());
     }
   }
 }
@@ -120,7 +120,7 @@ HIP_TEST_CASE(Unit_BuiltinAtomics_fminNonCoherentGlobalFlatMem) {
   std::string gfxName(prop.gcnArchName);
   if ((gfxName == "gfx90a" || gfxName.find("gfx90a:")) == 0) {
     if (prop.canMapHostMemory != 1) {
-      HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kHostPinnedMemoryUnsupported);
+      HIP_SKIP_TEST(HipTest::SkipReason::kHostPinnedMemoryUnsupported);
     } else {
       double *A_h, *B_h;
       double* A_d;
@@ -154,7 +154,7 @@ HIP_TEST_CASE(Unit_BuiltinAtomics_fminNonCoherentGlobalFlatMem) {
           "Memory model feature is only supported for gfx90a, Hence"
           "skipping the testcase for this GPU ") +
           std::to_string(device);
-      HipTest::HIP_SKIP_TEST(skip_gfx_msg.c_str());
+      HIP_SKIP_TEST(skip_gfx_msg.c_str());
     }
   }
 }
@@ -174,7 +174,7 @@ HIP_TEST_CASE(Unit_BuiltinAtomicsRTC__fminCoherentGlobalMem) {
   std::string gfxName(prop.gcnArchName);
   if ((gfxName == "gfx90a" || gfxName.find("gfx90a:")) == 0) {
     if (prop.canMapHostMemory != 1) {
-      HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kHostPinnedMemoryUnsupported);
+      HIP_SKIP_TEST(HipTest::SkipReason::kHostPinnedMemoryUnsupported);
     } else {
       hiprtcProgram prog;
       hiprtcCreateProgram(&prog,          // prog
@@ -237,7 +237,7 @@ HIP_TEST_CASE(Unit_BuiltinAtomicsRTC__fminCoherentGlobalMem) {
           "Memory model feature is only supported for gfx90a, Hence"
           "skipping the testcase for this GPU ") +
           std::to_string(device);
-      HipTest::HIP_SKIP_TEST(skip_gfx_msg.c_str());
+      HIP_SKIP_TEST(skip_gfx_msg.c_str());
     }
   }
 }
@@ -260,7 +260,7 @@ HIP_TEST_CASE(Unit_BuiltinAtomicsRTC_fminNonCoherentGlobalFlatMem) {
   std::string gfxName(prop.gcnArchName);
   if ((gfxName == "gfx90a" || gfxName.find("gfx90a:")) == 0) {
     if (prop.canMapHostMemory != 1) {
-      HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kHostPinnedMemoryUnsupported);
+      HIP_SKIP_TEST(HipTest::SkipReason::kHostPinnedMemoryUnsupported);
     } else {
       hiprtcProgram prog;
       if (mem_type) {
@@ -334,7 +334,7 @@ HIP_TEST_CASE(Unit_BuiltinAtomicsRTC_fminNonCoherentGlobalFlatMem) {
           "Memory model feature is only supported for gfx90a, Hence"
           "skipping the testcase for this GPU ") +
           std::to_string(device);
-      HipTest::HIP_SKIP_TEST(skip_gfx_msg.c_str());
+      HIP_SKIP_TEST(skip_gfx_msg.c_str());
     }
   }
 }

--- a/projects/hip-tests/catch/unit/deviceLib/deviceAllocation.cc
+++ b/projects/hip-tests/catch/unit/deviceLib/deviceAllocation.cc
@@ -866,8 +866,7 @@ HIP_TEST_CASE(Unit_deviceAllocation_Malloc_PerThread_PrimitiveDataType) {
   constexpr size_t sizePerThread = 128;
   HIP_CHECK(hipDeviceGetAttribute(&pcieAtomic, hipDeviceAttributeHostNativeAtomicSupported, 0));
   if (!pcieAtomic) {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kPcieAtomicUnsupported);
-    return;
+    HIP_SKIP_TEST(HipTest::SkipReason::kPcieAtomicUnsupported);
   }
 
   SECTION("PerThread - char with malloc") {
@@ -1081,8 +1080,7 @@ HIP_TEST_CASE(Unit_deviceAllocation_ComplexDataType) {
   constexpr size_t sizePerThread = 64;
   HIP_CHECK(hipDeviceGetAttribute(&pcieAtomic, hipDeviceAttributeHostNativeAtomicSupported, 0));
   if (!pcieAtomic) {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kPcieAtomicUnsupported);
-    return;
+    HIP_SKIP_TEST(HipTest::SkipReason::kPcieAtomicUnsupported);
   }
 
   SECTION("Struct - malloc") {
@@ -1123,8 +1121,7 @@ HIP_TEST_CASE(Unit_deviceAllocation_CodeObjects) {
   constexpr size_t sizePerThread = 128;
   HIP_CHECK(hipDeviceGetAttribute(&pcieAtomic, hipDeviceAttributeHostNativeAtomicSupported, 0));
   if (!pcieAtomic) {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kPcieAtomicUnsupported);
-    return;
+    HIP_SKIP_TEST(HipTest::SkipReason::kPcieAtomicUnsupported);
   }
 
   SECTION("SingleCodeObj - malloc") {
@@ -1200,8 +1197,7 @@ HIP_TEST_CASE(Unit_deviceAllocation_Malloc_PerThread_Graph) {
   int pcieAtomic = 0;
   HIP_CHECK(hipDeviceGetAttribute(&pcieAtomic, hipDeviceAttributeHostNativeAtomicSupported, 0));
   if (!pcieAtomic) {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kPcieAtomicUnsupported);
-    return;
+    HIP_SKIP_TEST(HipTest::SkipReason::kPcieAtomicUnsupported);
   }
   // malloc()/free() tests
   SECTION("Test char datatype allocation with malloc") {
@@ -1233,8 +1229,7 @@ HIP_TEST_CASE(Unit_deviceAllocation_New_PerThread_Graph) {
   int pcieAtomic = 0;
   HIP_CHECK(hipDeviceGetAttribute(&pcieAtomic, hipDeviceAttributeHostNativeAtomicSupported, 0));
   if (!pcieAtomic) {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kPcieAtomicUnsupported);
-    return;
+    HIP_SKIP_TEST(HipTest::SkipReason::kPcieAtomicUnsupported);
   }
   // new/delete tests
   SECTION("Test char datatype allocation with new") {
@@ -1266,8 +1261,7 @@ HIP_TEST_CASE(Unit_deviceAllocation_DeviceFunc) {
   int pcieAtomic = 0;
   HIP_CHECK(hipDeviceGetAttribute(&pcieAtomic, hipDeviceAttributeHostNativeAtomicSupported, 0));
   if (!pcieAtomic) {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kPcieAtomicUnsupported);
-    return;
+    HIP_SKIP_TEST(HipTest::SkipReason::kPcieAtomicUnsupported);
   }
 
   SECTION("Test device function allocation with malloc") {
@@ -1286,8 +1280,7 @@ HIP_TEST_CASE(Unit_deviceAllocation_VirtualFunction) {
   int pcieAtomic = 0;
   HIP_CHECK(hipDeviceGetAttribute(&pcieAtomic, hipDeviceAttributeHostNativeAtomicSupported, 0));
   if (!pcieAtomic) {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kPcieAtomicUnsupported);
-    return;
+    HIP_SKIP_TEST(HipTest::SkipReason::kPcieAtomicUnsupported);
   }
   int *outputVec_d{nullptr}, *outputVec_h{nullptr};
   constexpr size_t sizeBufferPerThread = 8;
@@ -1322,8 +1315,7 @@ HIP_TEST_CASE(Unit_deviceAllocation_SingKernels_MulThreads) {
   int pcieAtomic = 0;
   HIP_CHECK(hipDeviceGetAttribute(&pcieAtomic, hipDeviceAttributeHostNativeAtomicSupported, 0));
   if (!pcieAtomic) {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kPcieAtomicUnsupported);
-    return;
+    HIP_SKIP_TEST(HipTest::SkipReason::kPcieAtomicUnsupported);
   }
 
   SECTION("Test single kernel multi-thread allocation with malloc") {
@@ -1370,8 +1362,7 @@ HIP_TEST_CASE(Unit_deviceAllocation_Malloc_MulCodeObj) {
   int pcieAtomic = 0;
   HIP_CHECK(hipDeviceGetAttribute(&pcieAtomic, hipDeviceAttributeHostNativeAtomicSupported, 0));
   if (!pcieAtomic) {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kPcieAtomicUnsupported);
-    return;
+    HIP_SKIP_TEST(HipTest::SkipReason::kPcieAtomicUnsupported);
   }
   REQUIRE(true == TestAlloc_Load_MultKernels(TEST_MALLOC_FREE, INT_MAX));
 }
@@ -1384,8 +1375,7 @@ HIP_TEST_CASE(Unit_deviceAllocation_New_MulCodeObj) {
   int pcieAtomic = 0;
   HIP_CHECK(hipDeviceGetAttribute(&pcieAtomic, hipDeviceAttributeHostNativeAtomicSupported, 0));
   if (!pcieAtomic) {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kPcieAtomicUnsupported);
-    return;
+    HIP_SKIP_TEST(HipTest::SkipReason::kPcieAtomicUnsupported);
   }
   REQUIRE(true == TestAlloc_Load_MultKernels(TEST_NEW_DELETE, INT_MAX));
 }
@@ -1399,8 +1389,7 @@ HIP_TEST_CASE(Unit_deviceAllocationFollowedByDeviceReset) {
   int pcieAtomic = 0;
   HIP_CHECK(hipDeviceGetAttribute(&pcieAtomic, hipDeviceAttributeHostNativeAtomicSupported, 0));
   if (!pcieAtomic) {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kPcieAtomicUnsupported);
-    return;
+    HIP_SKIP_TEST(HipTest::SkipReason::kPcieAtomicUnsupported);
   }
   REQUIRE(true == TestAllocInDeviceFunc(TEST_MALLOC_FREE));
   HIP_CHECK(hipDeviceReset());

--- a/projects/hip-tests/catch/unit/deviceLib/fp8_fnuz.cc
+++ b/projects/hip-tests/catch/unit/deviceLib/fp8_fnuz.cc
@@ -35,8 +35,7 @@ std::string get_arch_type() {
 #define FP8_FNUZ_SKIP_TEST                                                                         \
   std::string gfxName = get_arch_type();                                                           \
   if (!(ARCH_TYPE_GFX940(gfxName))) {                                                              \
-    HipTest::HIP_SKIP_TEST("this test requires gfx942 architecture.");                            \
-    return;                                                                                        \
+    HIP_SKIP_TEST("this test requires gfx942 architecture.");                                      \
   }
 
 #define __FP8_DEVICE__ __device__ static inline

--- a/projects/hip-tests/catch/unit/deviceLib/fp8_ocp.cc
+++ b/projects/hip-tests/catch/unit/deviceLib/fp8_ocp.cc
@@ -33,8 +33,7 @@ std::string arch_type() {
 #define FP8_OCP_SKIP_TEST                                                                          \
   std::string gfxName = arch_type();                                                               \
   if (!(ARCH_TYPE_GFX1200(gfxName))) {                                                             \
-    HipTest::HIP_SKIP_TEST("this test requires GFX1200.");                                \
-    return;                                                                                        \
+    HIP_SKIP_TEST("this test requires GFX1200.");                                                  \
   }
 
 #define __FP8_DEVICE__ __device__ static inline

--- a/projects/hip-tests/catch/unit/deviceLib/threadfence_system.cc
+++ b/projects/hip-tests/catch/unit/deviceLib/threadfence_system.cc
@@ -42,8 +42,7 @@ HIP_TEST_CASE(Unit_threadfence_system) {
 
   volatile int* data = nullptr;
   if (hipHostMalloc(&data, sizeof(int), hipHostMallocCoherent) != hipSuccess) {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kCoherentHostAllocFailed);
-    return;
+    HIP_SKIP_TEST(HipTest::SkipReason::kCoherentHostAllocFailed);
   }
 
   constexpr int init_data = 1000;
@@ -51,9 +50,8 @@ HIP_TEST_CASE(Unit_threadfence_system) {
 
   volatile int* flag = nullptr;
   if (hipHostMalloc(&flag, sizeof(int), hipHostMallocCoherent) != hipSuccess) {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kCoherentHostAllocFailed);
     HIP_CHECK(hipHostFree((void*)data));
-    return;
+    HIP_SKIP_TEST(HipTest::SkipReason::kCoherentHostAllocFailed);
   }
   *flag = 0;
 

--- a/projects/hip-tests/catch/unit/deviceLib/unsafeAtomicAddDevice.cc
+++ b/projects/hip-tests/catch/unit/deviceLib/unsafeAtomicAddDevice.cc
@@ -115,6 +115,6 @@ HIP_TEST_CASE(Unit_unsafeAtomicAdd) {
     REQUIRE(fabs((res_f / 1000) - f_val) <= 0.2f);
     REQUIRE(fabs((res_d / 1000) - d_val) <= 0.2);
   } else {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kFineGrainHwUnsupported);
+    HIP_SKIP_TEST(HipTest::SkipReason::kFineGrainHwUnsupported);
   }
 }

--- a/projects/hip-tests/catch/unit/deviceLib/unsafeAtomicAdd_RTC.cc
+++ b/projects/hip-tests/catch/unit/deviceLib/unsafeAtomicAdd_RTC.cc
@@ -89,7 +89,7 @@ HIP_TEMPLATE_TEST_CASE(Unit_unsafeAtomicAdd_CoherentRTCnounsafeatomicflag, float
     HIP_CHECK(hipModuleLoadData(&module, code.data()));
     HIP_CHECK(hipModuleGetFunction(&f_kernel, module, "AtomicCheck"));
     if (props.canMapHostMemory != 1) {
-      HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kHostPinnedMemoryUnsupported);
+      HIP_SKIP_TEST(HipTest::SkipReason::kHostPinnedMemoryUnsupported);
     } else {
       TestType *A_h, *result;
       TestType *A_d, *result_d;
@@ -121,7 +121,7 @@ HIP_TEMPLATE_TEST_CASE(Unit_unsafeAtomicAdd_CoherentRTCnounsafeatomicflag, float
     }
     HIP_CHECK(hipModuleUnload(module));
   } else {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kFineGrainHwUnsupported);
+    HIP_SKIP_TEST(HipTest::SkipReason::kFineGrainHwUnsupported);
   }
 }
 
@@ -179,7 +179,7 @@ HIP_TEMPLATE_TEST_CASE(Unit_unsafeAtomicAdd_CoherentRTCunsafeatomicflag, float, 
     HIP_CHECK(hipModuleGetFunction(&f_kernel, module, "AtomicCheck"));
 
     if (props.canMapHostMemory != 1) {
-      HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kHostPinnedMemoryUnsupported);
+      HIP_SKIP_TEST(HipTest::SkipReason::kHostPinnedMemoryUnsupported);
     } else {
       TestType *A_h, *result;
       TestType *A_d, *result_d;
@@ -211,7 +211,7 @@ HIP_TEMPLATE_TEST_CASE(Unit_unsafeAtomicAdd_CoherentRTCunsafeatomicflag, float, 
     }
     HIP_CHECK(hipModuleUnload(module));
   } else {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kFineGrainHwUnsupported);
+    HIP_SKIP_TEST(HipTest::SkipReason::kFineGrainHwUnsupported);
   }
 }
 
@@ -266,7 +266,7 @@ HIP_TEMPLATE_TEST_CASE(Unit_unsafeAtomicAdd_CoherentRTCwithoutflag, float, doubl
     HIP_CHECK(hipModuleGetFunction(&f_kernel, module, "AtomicCheck"));
 
     if (props.canMapHostMemory != 1) {
-      HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kHostPinnedMemoryUnsupported);
+      HIP_SKIP_TEST(HipTest::SkipReason::kHostPinnedMemoryUnsupported);
     } else {
       TestType *A_h, *result;
       TestType *A_d, *result_d;
@@ -298,7 +298,7 @@ HIP_TEMPLATE_TEST_CASE(Unit_unsafeAtomicAdd_CoherentRTCwithoutflag, float, doubl
     }
     HIP_CHECK(hipModuleUnload(module));
   } else {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kFineGrainHwUnsupported);
+    HIP_SKIP_TEST(HipTest::SkipReason::kFineGrainHwUnsupported);
   }
 }
 
@@ -351,7 +351,7 @@ HIP_TEMPLATE_TEST_CASE(Unit_unsafeAtomicAdd_NonCoherentRTCnounsafeatomicflag, fl
     HIP_CHECK(hipModuleLoadData(&module, code.data()));
     HIP_CHECK(hipModuleGetFunction(&f_kernel, module, "AtomicCheck"));
     if (props.canMapHostMemory != 1) {
-      HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kHostPinnedMemoryUnsupported);
+      HIP_SKIP_TEST(HipTest::SkipReason::kHostPinnedMemoryUnsupported);
     } else {
       TestType *A_h, *result;
       TestType *A_d, *result_d;
@@ -377,7 +377,7 @@ HIP_TEMPLATE_TEST_CASE(Unit_unsafeAtomicAdd_NonCoherentRTCnounsafeatomicflag, fl
     }
     HIP_CHECK(hipModuleUnload(module));
   } else {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kFineGrainHwUnsupported);
+    HIP_SKIP_TEST(HipTest::SkipReason::kFineGrainHwUnsupported);
   }
 }
 
@@ -432,7 +432,7 @@ HIP_TEMPLATE_TEST_CASE(Unit_unsafeAtomicAdd_NonCoherentRTCunsafeatomicflag, floa
     HIP_CHECK(hipModuleGetFunction(&f_kernel, module, "AtomicCheck"));
 
     if (props.canMapHostMemory != 1) {
-      HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kHostPinnedMemoryUnsupported);
+      HIP_SKIP_TEST(HipTest::SkipReason::kHostPinnedMemoryUnsupported);
     } else {
       TestType *A_h, *result;
       TestType *A_d, *result_d;
@@ -458,7 +458,7 @@ HIP_TEMPLATE_TEST_CASE(Unit_unsafeAtomicAdd_NonCoherentRTCunsafeatomicflag, floa
     }
     HIP_CHECK(hipModuleUnload(module));
   } else {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kFineGrainHwUnsupported);
+    HIP_SKIP_TEST(HipTest::SkipReason::kFineGrainHwUnsupported);
   }
 }
 
@@ -513,7 +513,7 @@ HIP_TEMPLATE_TEST_CASE(Unit_unsafeAtomicAdd_NonCoherentRTC, float, double) {
     HIP_CHECK(hipModuleGetFunction(&f_kernel, module, "AtomicCheck"));
 
     if (props.canMapHostMemory != 1) {
-      HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kHostPinnedMemoryUnsupported);
+      HIP_SKIP_TEST(HipTest::SkipReason::kHostPinnedMemoryUnsupported);
     } else {
       TestType *A_h, *result;
       TestType *A_d, *result_d;
@@ -539,6 +539,6 @@ HIP_TEMPLATE_TEST_CASE(Unit_unsafeAtomicAdd_NonCoherentRTC, float, double) {
     }
     HIP_CHECK(hipModuleUnload(module));
   } else {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kFineGrainHwUnsupported);
+    HIP_SKIP_TEST(HipTest::SkipReason::kFineGrainHwUnsupported);
   }
 }

--- a/projects/hip-tests/catch/unit/errorHandling/hipDynamicLogging.cc
+++ b/projects/hip-tests/catch/unit/errorHandling/hipDynamicLogging.cc
@@ -83,8 +83,7 @@ HIP_TEST_CASE(Unit_hipDynamicLogging_Positive_Basic) {
   HIP_CHECK(hipGetDeviceCount(&numDevices));
 
   if (numDevices <= 0) {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kNoGpuDevice);
-    return;
+    HIP_SKIP_TEST(HipTest::SkipReason::kNoGpuDevice);
   }
 
   REQUIRE(hipDynamicLoggingTest() == true);
@@ -107,8 +106,7 @@ HIP_TEST_CASE(Unit_hipDynamicLogging_Positive_MultipleEnableDisable) {
   HIP_CHECK(hipGetDeviceCount(&numDevices));
 
   if (numDevices <= 0) {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kNoGpuDevice);
-    return;
+    HIP_SKIP_TEST(HipTest::SkipReason::kNoGpuDevice);
   }
 
   // Test multiple enable/disable cycles

--- a/projects/hip-tests/catch/unit/errorHandling/hipExtGetLastError.cc
+++ b/projects/hip-tests/catch/unit/errorHandling/hipExtGetLastError.cc
@@ -83,8 +83,7 @@ HIP_TEST_CASE(Unit_hipExtGetLastError_Positive_Threaded) {
 HIP_TEST_CASE(Unit_hipExtGetLastError_with_hipMemcpyPeerAsync) {
   const auto device_count = HipTest::getDeviceCount();
   if (device_count < 2) {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
-    return;
+    HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
   }
 
   int can_access_peer = 0;

--- a/projects/hip-tests/catch/unit/errorHandling/hipGetLastError.cc
+++ b/projects/hip-tests/catch/unit/errorHandling/hipGetLastError.cc
@@ -84,8 +84,7 @@ HIP_TEST_CASE(Unit_hipGetLastError_Positive_Threaded) {
 HIP_TEST_CASE(Unit_hipGetLastError_with_hipMemcpyPeerAsync) {
   const auto device_count = HipTest::getDeviceCount();
   if (device_count < 2) {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
-    return;
+    HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
   }
 
   int can_access_peer = 0;

--- a/projects/hip-tests/catch/unit/errorHandling/hipGetLastErrorOnAbort.cc
+++ b/projects/hip-tests/catch/unit/errorHandling/hipGetLastErrorOnAbort.cc
@@ -95,8 +95,7 @@ HIP_TEST_CASE(Unit_hipGetLastError_KernelFailure_TwoDevices) {
   int deviceCount = 0;
   HIP_CHECK(hipGetDeviceCount(&deviceCount));
   if (deviceCount < 2) {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
-    return;
+    HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
   }
 
   DISABLE_CORE_DUMPS();

--- a/projects/hip-tests/catch/unit/event/Unit_hipEventElapsedTime.cc
+++ b/projects/hip-tests/catch/unit/event/Unit_hipEventElapsedTime.cc
@@ -95,8 +95,7 @@ HIP_TEST_CASE(Unit_hipEventElapsedTime_DisableTiming) {
 HIP_TEST_CASE(Unit_hipEventElapsedTime_DifferentDevices) {
   const auto device_count = HipTest::getDeviceCount();
   if (device_count < 2) {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
-    return;
+    HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
   }
 
   // create event on dev=0

--- a/projects/hip-tests/catch/unit/event/Unit_hipEventMGpuMThreads.cc
+++ b/projects/hip-tests/catch/unit/event/Unit_hipEventMGpuMThreads.cc
@@ -210,7 +210,7 @@ HIP_TEST_CASE(Unit_hipEventMGpuMThreads_2) {
   if (numDevices > 1) {
     testEventMGpuMThreads(numDevices);
   } else {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
+    HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
   }
 }
 
@@ -234,7 +234,7 @@ HIP_TEST_CASE(Unit_hipEventMGpuMThreads_3) {
     fprintf(stderr, "Second round\n");
     testEventMGpuMThreads(numDevices);
   } else {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
+    HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
   }
 }
 

--- a/projects/hip-tests/catch/unit/event/hipEventCreateWithFlags.cc
+++ b/projects/hip-tests/catch/unit/event/hipEventCreateWithFlags.cc
@@ -98,8 +98,7 @@ static void testMemCoherency(eSyncToTest test, eMemoryToTest mem, uint32_t flags
   HIP_CHECK(hipGetDeviceProperties(&prop, 0));
   // If the GPU is not large bar then exit the test
   if (prop.isLargeBar != 1) {
-    HipTest::HIP_SKIP_TEST("large BAR (resizable BAR) is not supported on this device.");
-    return;
+    HIP_SKIP_TEST("large BAR (resizable BAR) is not supported on this device.");
   }
   constexpr auto blocksPerCU = 6;
   unsigned grid_size = HipTest::setNumBlocks(blocksPerCU, block_size, buffer_size);

--- a/projects/hip-tests/catch/unit/executionControl/hipFuncSetAttribute.cc
+++ b/projects/hip-tests/catch/unit/executionControl/hipFuncSetAttribute.cc
@@ -206,8 +206,7 @@ HIP_TEST_CASE(Unit_hipFuncSetAttribute_Negative_Parameters) {
  */
 HIP_TEST_CASE(Unit_hipFuncSetAttribute_Positive_MaxDynamicSharedMemorySize_Not_Supported) {
 #if HT_NVIDIA
-  HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kApiUnsupportedOnNvidia);
-  return;
+  HIP_SKIP_TEST(HipTest::SkipReason::kApiUnsupportedOnNvidia);
 #endif
 
   hipFuncAttributes old_attributes;
@@ -238,8 +237,7 @@ HIP_TEST_CASE(Unit_hipFuncSetAttribute_Positive_MaxDynamicSharedMemorySize_Not_S
  */
 HIP_TEST_CASE(Unit_hipFuncSetAttribute_Positive_PreferredSharedMemoryCarveout_Not_Supported) {
 #if HT_NVIDIA
-  HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kApiUnsupportedOnNvidia);
-  return;
+  HIP_SKIP_TEST(HipTest::SkipReason::kApiUnsupportedOnNvidia);
 #endif
 
   hipFuncAttributes old_attributes;

--- a/projects/hip-tests/catch/unit/executionControl/hipFuncSetCacheConfig.cc
+++ b/projects/hip-tests/catch/unit/executionControl/hipFuncSetCacheConfig.cc
@@ -85,8 +85,7 @@ HIP_TEST_CASE(Unit_hipFuncSetCacheConfig_Negative_Parameters) {
  */
 HIP_TEST_CASE(Unit_hipFuncSetCacheConfig_Negative_Not_Supported) {
 #if HT_NVIDIA
-  HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kApiUnsupportedOnNvidia);
-  return;
+  HIP_SKIP_TEST(HipTest::SkipReason::kApiUnsupportedOnNvidia);
 #endif
 
   HIP_CHECK_ERROR(hipFuncSetCacheConfig(reinterpret_cast<void*>(kernel), hipFuncCachePreferNone),

--- a/projects/hip-tests/catch/unit/executionControl/hipFuncSetSharedMemConfig.cc
+++ b/projects/hip-tests/catch/unit/executionControl/hipFuncSetSharedMemConfig.cc
@@ -85,8 +85,7 @@ HIP_TEST_CASE(Unit_hipFuncSetSharedMemConfig_Negative_Parameters) {
  */
 HIP_TEST_CASE(Unit_hipFuncSetSharedMemConfig_Negative_Not_Supported) {
 #if HT_NVIDIA
-  HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kApiUnsupportedOnNvidia);
-  return;
+  HIP_SKIP_TEST(HipTest::SkipReason::kApiUnsupportedOnNvidia);
 #endif
 
   HIP_CHECK_ERROR(

--- a/projects/hip-tests/catch/unit/executionControl/hipLaunchCooperativeKernel.cc
+++ b/projects/hip-tests/catch/unit/executionControl/hipLaunchCooperativeKernel.cc
@@ -13,8 +13,7 @@
 
 HIP_TEST_CASE(Unit_hipLaunchCooperativeKernel_Positive_Basic) {
   if (!DeviceAttributesSupport(0, hipDeviceAttributeCooperativeLaunch)) {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kCooperativeLaunchUnsupported);
-    return;
+    HIP_SKIP_TEST(HipTest::SkipReason::kCooperativeLaunchUnsupported);
   }
 
   SECTION("Cooperative kernel with no arguments") {
@@ -40,8 +39,7 @@ HIP_TEST_CASE(Unit_hipLaunchCooperativeKernel_Positive_Basic) {
 
 HIP_TEST_CASE(Unit_hipLaunchCooperativeKernel_Positive_Parameters) {
   if (!DeviceAttributesSupport(0, hipDeviceAttributeCooperativeLaunch)) {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kCooperativeLaunchUnsupported);
-    return;
+    HIP_SKIP_TEST(HipTest::SkipReason::kCooperativeLaunchUnsupported);
   }
 
   SECTION("blockDim.x == maxBlockDimX") {
@@ -65,8 +63,7 @@ HIP_TEST_CASE(Unit_hipLaunchCooperativeKernel_Positive_Parameters) {
 
 HIP_TEST_CASE(Unit_hipLaunchCooperativeKernel_Negative_Parameters) {
   if (!DeviceAttributesSupport(0, hipDeviceAttributeCooperativeLaunch)) {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kCooperativeLaunchUnsupported);
-    return;
+    HIP_SKIP_TEST(HipTest::SkipReason::kCooperativeLaunchUnsupported);
   }
 
   SECTION("f == nullptr") {
@@ -164,8 +161,7 @@ HIP_TEST_CASE(Unit_hipLaunchCooperativeKernel_Negative_Parameters) {
 
 HIP_TEST_CASE(Unit_hipLaunchCooperativeKernel_Verify_Capture) {
   if (!DeviceAttributesSupport(0, hipDeviceAttributeCooperativeLaunch)) {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kCooperativeLaunchUnsupported);
-    return;
+    HIP_SKIP_TEST(HipTest::SkipReason::kCooperativeLaunchUnsupported);
   }
 
   hipStream_t stream;

--- a/projects/hip-tests/catch/unit/executionControl/hipLaunchCooperativeKernelMultiDevice.cc
+++ b/projects/hip-tests/catch/unit/executionControl/hipLaunchCooperativeKernelMultiDevice.cc
@@ -18,8 +18,7 @@ HIP_TEST_CASE(Unit_hipLaunchCooperativeKernelMultiDevice_Positive_Basic) {
 
   const auto device_count = HipTest::getDeviceCount();
   if (device_count < 2) {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
-    return;
+    HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
   }
 
   std::vector<hipLaunchParams> params_list(device_count);
@@ -53,8 +52,7 @@ HIP_TEST_CASE(Unit_hipLaunchCooperativeKernelMultiDevice_Negative_Parameters) {
 
   const auto device_count = HipTest::getDeviceCount();
   if (device_count < 2) {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
-    return;
+    HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
   }
 
   std::vector<hipLaunchParams> params_list(device_count);
@@ -133,8 +131,7 @@ HIP_TEST_CASE(Unit_hipLaunchCooperativeKernelMultiDevice_Negative_MultiKernelSam
 
   const auto device_count = HipTest::getDeviceCount();
   if (device_count < 2) {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
-    return;
+    HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
   }
 
   HIP_CHECK(hipSetDevice(0));

--- a/projects/hip-tests/catch/unit/executionControl/hipLaunchCooperativeKernelMultiDevice.cc
+++ b/projects/hip-tests/catch/unit/executionControl/hipLaunchCooperativeKernelMultiDevice.cc
@@ -13,8 +13,7 @@
 
 HIP_TEST_CASE(Unit_hipLaunchCooperativeKernelMultiDevice_Positive_Basic) {
   if (!DeviceAttributesSupport(0, hipDeviceAttributeCooperativeLaunch)) {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kCooperativeLaunchUnsupported);
-    return;
+    HIP_SKIP_TEST(HipTest::SkipReason::kCooperativeLaunchUnsupported);
   }
 
   const auto device_count = HipTest::getDeviceCount();
@@ -49,8 +48,7 @@ HIP_TEST_CASE(Unit_hipLaunchCooperativeKernelMultiDevice_Positive_Basic) {
 
 HIP_TEST_CASE(Unit_hipLaunchCooperativeKernelMultiDevice_Negative_Parameters) {
   if (!DeviceAttributesSupport(0, hipDeviceAttributeCooperativeLaunch)) {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kCooperativeLaunchUnsupported);
-    return;
+    HIP_SKIP_TEST(HipTest::SkipReason::kCooperativeLaunchUnsupported);
   }
 
   const auto device_count = HipTest::getDeviceCount();
@@ -130,8 +128,7 @@ HIP_TEST_CASE(Unit_hipLaunchCooperativeKernelMultiDevice_Negative_Parameters) {
 
 HIP_TEST_CASE(Unit_hipLaunchCooperativeKernelMultiDevice_Negative_MultiKernelSameDevice) {
   if (!DeviceAttributesSupport(0, hipDeviceAttributeCooperativeLaunch)) {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kCooperativeLaunchUnsupported);
-    return;
+    HIP_SKIP_TEST(HipTest::SkipReason::kCooperativeLaunchUnsupported);
   }
 
   const auto device_count = HipTest::getDeviceCount();

--- a/projects/hip-tests/catch/unit/gl_interop/gl_interop_common.hh
+++ b/projects/hip-tests/catch/unit/gl_interop/gl_interop_common.hh
@@ -74,25 +74,24 @@ public:
 };
 
 static std::once_flag glut_init_flag;
+static bool glut_init_failed = false;
 static void GlutError(const char *fmt, va_list ap)
 {
     // Print what error occurred
     fprintf(stderr, "GlutError:");
     vfprintf(stderr, fmt, ap);
     fprintf(stderr, "\n");
-
-    // Mark this test as skipped because this error could be
-    // due to system doesn't have display connected, e.g: Jenkins CI machine
-    HipTest::HIP_SKIP_TEST("GLUT initialization failed.");
-
-    glutExit();
-    exit(1);
+    
+    glut_init_failed = true;
 }
 
 class GLUTContextScopeGuard : public IContextScopeGuard {
  public:
   GLUTContextScopeGuard() {
     std::call_once(glut_init_flag, &GLUTContextScopeGuard::init);
+    if (glut_init_failed) {
+      HIP_SKIP_TEST("GLUT Init Failed");
+    }
     glut_window_ = glutCreateWindow("");
   }
 
@@ -115,6 +114,7 @@ class GLUTContextScopeGuard : public IContextScopeGuard {
     static int glut_argc = 1;
     glutInitErrorFunc(&GlutError);
     glutInit(&glut_argc, glut_argv.data());
+    if (glut_init_failed) return;
     glutInitDisplayMode(GLUT_RGB | GLUT_DOUBLE | GLUT_DEPTH);
     glutInitWindowSize(512, 512);
   }
@@ -207,11 +207,6 @@ class GLContextScopeGuard {
 
   GLContextScopeGuard() {
 
-    if(!HipTest::isImageSupported()) {
-      HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kTextureImageUnsupported);
-      exit(0);
-    }
-
     char* val = std::getenv(kEnvarName);
     std::string val_str = val == NULL ? "" : val;
 
@@ -234,10 +229,8 @@ class GLContextScopeGuard {
 #ifdef USE_GLEW
     GLenum err = glewInit();
     if (err != GLEW_OK) {
-      fprintf(stderr, "GLEW initialization failed: %s\n",
-              glewGetErrorString(err));
-      HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kGlewInitFailed);
-      exit(1);
+      fprintf(stderr, "GLEW initialization failed: %s\n", glewGetErrorString(err));
+      HIP_SKIP_TEST(HipTest::SkipReason::kGlewInitFailed);
     }
 #endif
   }

--- a/projects/hip-tests/catch/unit/gl_interop/hipGLContextSwitch.cc
+++ b/projects/hip-tests/catch/unit/gl_interop/hipGLContextSwitch.cc
@@ -89,8 +89,9 @@ class GLUTWindow {
     GLenum err = glewInit();
     if (err != GLEW_OK) {
       fprintf(stderr, "GLEW init failed: %s\n", glewGetErrorString(err));
-      HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kGlewInitFailed);
-      exit(1);
+      glutDestroyWindow(window_id_);
+      window_id_ = 0;
+      HIP_SKIP_TEST(HipTest::SkipReason::kGlewInitFailed);
     }
 #endif
   }
@@ -259,8 +260,7 @@ BufferInteropResult performBufferInteropCycle(unsigned int flags = hipGraphicsRe
   */
  HIP_TEST_CASE(Unit_hipGL_ContextSwitch_Basic) {
    if (!HipTest::isImageSupported()) {
-     HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kTextureImageUnsupported);
-     return;
+     HIP_SKIP_TEST(HipTest::SkipReason::kTextureImageUnsupported);
    }
 
    // Create first GL context
@@ -303,8 +303,7 @@ BufferInteropResult performBufferInteropCycle(unsigned int flags = hipGraphicsRe
   */
  HIP_TEST_CASE(Unit_hipGL_ContextSwitch_SeparateContextSetups) {
    if (!HipTest::isImageSupported()) {
-     HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kTextureImageUnsupported);
-     return;
+     HIP_SKIP_TEST(HipTest::SkipReason::kTextureImageUnsupported);
    }
 
    // Create two contexts
@@ -365,8 +364,7 @@ BufferInteropResult performBufferInteropCycle(unsigned int flags = hipGraphicsRe
   */
  HIP_TEST_CASE(Unit_hipGL_ContextSwitch_BackAndForth) {
    if (!HipTest::isImageSupported()) {
-     HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kTextureImageUnsupported);
-     return;
+     HIP_SKIP_TEST(HipTest::SkipReason::kTextureImageUnsupported);
    }
 
    GLUTWindow window1;
@@ -400,8 +398,7 @@ BufferInteropResult performBufferInteropCycle(unsigned int flags = hipGraphicsRe
   */
  HIP_TEST_CASE(Unit_hipGL_ContextSwitch_RapidSwitching) {
    if (!HipTest::isImageSupported()) {
-     HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kTextureImageUnsupported);
-     return;
+     HIP_SKIP_TEST(HipTest::SkipReason::kTextureImageUnsupported);
    }
 
    GLUTWindow window1;
@@ -431,8 +428,7 @@ BufferInteropResult performBufferInteropCycle(unsigned int flags = hipGraphicsRe
   */
  HIP_TEST_CASE(Unit_hipGL_ContextSwitch_Patterns) {
    if (!HipTest::isImageSupported()) {
-     HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kTextureImageUnsupported);
-     return;
+     HIP_SKIP_TEST(HipTest::SkipReason::kTextureImageUnsupported);
    }
 
    std::vector<std::unique_ptr<GLUTWindow>> windows;
@@ -496,8 +492,7 @@ BufferInteropResult performBufferInteropCycle(unsigned int flags = hipGraphicsRe
   */
  HIP_TEST_CASE(Unit_hipGL_ContextSwitch_RegisterWithoutGetDevices) {
    if (!HipTest::isImageSupported()) {
-     HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kTextureImageUnsupported);
-     return;
+     HIP_SKIP_TEST(HipTest::SkipReason::kTextureImageUnsupported);
    }
 
    // First context - explicit initialization
@@ -545,8 +540,7 @@ BufferInteropResult performBufferInteropCycle(unsigned int flags = hipGraphicsRe
   */
  HIP_TEST_CASE(Unit_hipGL_ContextSwitch_AllAPIsDetectSwitch) {
    if (!HipTest::isImageSupported()) {
-     HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kTextureImageUnsupported);
-     return;
+     HIP_SKIP_TEST(HipTest::SkipReason::kTextureImageUnsupported);
    }
 
    GLUTWindow window1;
@@ -613,8 +607,7 @@ BufferInteropResult performBufferInteropCycle(unsigned int flags = hipGraphicsRe
  */
  HIP_TEST_CASE(Unit_hipGL_ContextSwitch_SequentialStableContext) {
    if (!HipTest::isImageSupported()) {
-     HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kTextureImageUnsupported);
-     return;
+     HIP_SKIP_TEST(HipTest::SkipReason::kTextureImageUnsupported);
    }
 
    GLUTWindow window;
@@ -694,8 +687,7 @@ BufferInteropResult performBufferInteropCycle(unsigned int flags = hipGraphicsRe
  */
  HIP_TEST_CASE(Unit_hipGL_ContextSwitch_InterleavedWithSwitch) {
    if (!HipTest::isImageSupported()) {
-     HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kTextureImageUnsupported);
-     return;
+     HIP_SKIP_TEST(HipTest::SkipReason::kTextureImageUnsupported);
    }
 
    GLUTWindow window1;
@@ -740,8 +732,7 @@ BufferInteropResult performBufferInteropCycle(unsigned int flags = hipGraphicsRe
  */
  HIP_TEST_CASE(Unit_hipGL_ContextSwitch_RapidMultiContextSwitching) {
    if (!HipTest::isImageSupported()) {
-     HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kTextureImageUnsupported);
-     return;
+     HIP_SKIP_TEST(HipTest::SkipReason::kTextureImageUnsupported);
    }
 
    std::vector<std::unique_ptr<GLUTWindow>> windows;
@@ -787,8 +778,7 @@ BufferInteropResult performBufferInteropCycle(unsigned int flags = hipGraphicsRe
   */
  HIP_TEST_CASE(Unit_hipGL_ContextSwitch_SameContextRepeated) {
    if (!HipTest::isImageSupported()) {
-     HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kTextureImageUnsupported);
-     return;
+     HIP_SKIP_TEST(HipTest::SkipReason::kTextureImageUnsupported);
    }
 
    GLUTWindow window;
@@ -813,8 +803,7 @@ BufferInteropResult performBufferInteropCycle(unsigned int flags = hipGraphicsRe
   */
  HIP_TEST_CASE(Unit_hipGL_ContextSwitch_ReturnToPreviousContext) {
    if (!HipTest::isImageSupported()) {
-     HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kTextureImageUnsupported);
-     return;
+     HIP_SKIP_TEST(HipTest::SkipReason::kTextureImageUnsupported);
    }
 
    GLUTWindow window1;
@@ -850,8 +839,7 @@ BufferInteropResult performBufferInteropCycle(unsigned int flags = hipGraphicsRe
   */
  HIP_TEST_CASE(Unit_hipGL_ContextSwitch_ResourceContextAssociation) {
    if (!HipTest::isImageSupported()) {
-     HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kTextureImageUnsupported);
-     return;
+     HIP_SKIP_TEST(HipTest::SkipReason::kTextureImageUnsupported);
    }
 
    GLUTWindow window1;
@@ -907,8 +895,7 @@ BufferInteropResult performBufferInteropCycle(unsigned int flags = hipGraphicsRe
   */
  HIP_TEST_CASE(Unit_hipGL_ContextSwitch_DataIntegrity) {
    if (!HipTest::isImageSupported()) {
-     HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kTextureImageUnsupported);
-     return;
+     HIP_SKIP_TEST(HipTest::SkipReason::kTextureImageUnsupported);
    }
 
    GLUTWindow window1;
@@ -977,8 +964,7 @@ BufferInteropResult performBufferInteropCycle(unsigned int flags = hipGraphicsRe
   */
  HIP_TEST_CASE(Unit_hipGL_ContextSwitch_AlternatingDataOperations) {
    if (!HipTest::isImageSupported()) {
-     HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kTextureImageUnsupported);
-     return;
+     HIP_SKIP_TEST(HipTest::SkipReason::kTextureImageUnsupported);
    }
 
    GLUTWindow window1;
@@ -1058,8 +1044,7 @@ BufferInteropResult performBufferInteropCycle(unsigned int flags = hipGraphicsRe
   */
  HIP_TEST_CASE(Unit_hipGL_ContextSwitch_TextureInterop) {
    if (!HipTest::isImageSupported()) {
-     HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kTextureImageUnsupported);
-     return;
+     HIP_SKIP_TEST(HipTest::SkipReason::kTextureImageUnsupported);
    }
 
    GLUTWindow window1;
@@ -1110,8 +1095,7 @@ BufferInteropResult performBufferInteropCycle(unsigned int flags = hipGraphicsRe
   */
  HIP_TEST_CASE(Unit_hipGL_ContextSwitch_MixedResources) {
    if (!HipTest::isImageSupported()) {
-     HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kTextureImageUnsupported);
-     return;
+     HIP_SKIP_TEST(HipTest::SkipReason::kTextureImageUnsupported);
    }
 
    GLUTWindow window1;
@@ -1168,8 +1152,7 @@ BufferInteropResult performBufferInteropCycle(unsigned int flags = hipGraphicsRe
   */
  HIP_TEST_CASE(Unit_hipGL_ContextSwitch_StreamOperations) {
    if (!HipTest::isImageSupported()) {
-     HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kTextureImageUnsupported);
-     return;
+     HIP_SKIP_TEST(HipTest::SkipReason::kTextureImageUnsupported);
    }
 
    GLUTWindow window1;
@@ -1224,8 +1207,7 @@ BufferInteropResult performBufferInteropCycle(unsigned int flags = hipGraphicsRe
   */
  HIP_TEST_CASE(Unit_hipGL_ContextSwitch_MultipleStreams) {
    if (!HipTest::isImageSupported()) {
-     HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kTextureImageUnsupported);
-     return;
+     HIP_SKIP_TEST(HipTest::SkipReason::kTextureImageUnsupported);
    }
 
    GLUTWindow window1;
@@ -1286,8 +1268,7 @@ BufferInteropResult performBufferInteropCycle(unsigned int flags = hipGraphicsRe
  */
 HIP_TEST_CASE(Unit_hipGL_ContextSwitch_HighFrequencyStress) {
   if (!HipTest::isImageSupported()) {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kTextureImageUnsupported);
-    return;
+    HIP_SKIP_TEST(HipTest::SkipReason::kTextureImageUnsupported);
   }
 
   constexpr int kNumContexts = 3;
@@ -1319,8 +1300,7 @@ HIP_TEST_CASE(Unit_hipGL_ContextSwitch_HighFrequencyStress) {
   */
  HIP_TEST_CASE(Unit_hipGL_ContextSwitch_ManyBuffersStress) {
    if (!HipTest::isImageSupported()) {
-     HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kTextureImageUnsupported);
-     return;
+     HIP_SKIP_TEST(HipTest::SkipReason::kTextureImageUnsupported);
    }
 
    GLUTWindow window1;
@@ -1391,8 +1371,7 @@ HIP_TEST_CASE(Unit_hipGL_ContextSwitch_HighFrequencyStress) {
   */
  HIP_TEST_CASE(Unit_hipGL_ContextSwitch_LongRunningStress) {
    if (!HipTest::isImageSupported()) {
-     HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kTextureImageUnsupported);
-     return;
+     HIP_SKIP_TEST(HipTest::SkipReason::kTextureImageUnsupported);
    }
 
    GLUTWindow window1;
@@ -1439,8 +1418,7 @@ HIP_TEST_CASE(Unit_hipGL_ContextSwitch_HighFrequencyStress) {
   */
  HIP_TEST_CASE(Unit_hipGL_ContextSwitch_RegistrationFlags) {
    if (!HipTest::isImageSupported()) {
-     HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kTextureImageUnsupported);
-     return;
+     HIP_SKIP_TEST(HipTest::SkipReason::kTextureImageUnsupported);
    }
 
    GLUTWindow window1;
@@ -1488,8 +1466,7 @@ HIP_TEST_CASE(Unit_hipGL_ContextSwitch_HighFrequencyStress) {
   */
  HIP_TEST_CASE(Unit_hipGL_ContextSwitch_ContextDestruction) {
    if (!HipTest::isImageSupported()) {
-     HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kTextureImageUnsupported);
-     return;
+     HIP_SKIP_TEST(HipTest::SkipReason::kTextureImageUnsupported);
    }
 
    // Create and use first context
@@ -1519,8 +1496,7 @@ HIP_TEST_CASE(Unit_hipGL_ContextSwitch_HighFrequencyStress) {
   */
  HIP_TEST_CASE(Unit_hipGL_ContextSwitch_MultipleDestructionCycles) {
    if (!HipTest::isImageSupported()) {
-     HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kTextureImageUnsupported);
-     return;
+     HIP_SKIP_TEST(HipTest::SkipReason::kTextureImageUnsupported);
    }
 
    for (int cycle = 0; cycle < kDefaultIterations; ++cycle) {
@@ -1545,8 +1521,7 @@ HIP_TEST_CASE(Unit_hipGL_ContextSwitch_HighFrequencyStress) {
   */
  HIP_TEST_CASE(Unit_hipGL_ContextSwitch_DeviceListTypes) {
    if (!HipTest::isImageSupported()) {
-     HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kTextureImageUnsupported);
-     return;
+     HIP_SKIP_TEST(HipTest::SkipReason::kTextureImageUnsupported);
    }
 
    const int device_count = HipTest::getDeviceCount();
@@ -1583,8 +1558,7 @@ HIP_TEST_CASE(Unit_hipGL_ContextSwitch_HighFrequencyStress) {
   */
  HIP_TEST_CASE(Unit_hipGL_ContextSwitch_FirstOperationInitialization) {
    if (!HipTest::isImageSupported()) {
-     HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kTextureImageUnsupported);
-     return;
+     HIP_SKIP_TEST(HipTest::SkipReason::kTextureImageUnsupported);
    }
 
    GLUTWindow window;

--- a/projects/hip-tests/catch/unit/gl_interop/hipGLGetDevices.cc
+++ b/projects/hip-tests/catch/unit/gl_interop/hipGLGetDevices.cc
@@ -16,6 +16,8 @@ constexpr std::array<hipGLDeviceList, 3> kDeviceLists{
 }  // anonymous namespace
 
 HIP_TEST_CASE(Unit_hipGLGetDevices_Positive_Basic) {
+  CHECK_IMAGE_SUPPORT
+
   GLContextScopeGuard gl_context;
 
   const auto device_list = GENERATE(from_range(begin(kDeviceLists), end(kDeviceLists)));
@@ -38,6 +40,8 @@ HIP_TEST_CASE(Unit_hipGLGetDevices_Positive_Basic) {
 }
 
 HIP_TEST_CASE(Unit_hipGLGetDevices_Positive_Parameters) {
+  CHECK_IMAGE_SUPPORT
+  
   GLContextScopeGuard gl_context;
 
   const int device_count = HipTest::getDeviceCount();
@@ -66,6 +70,8 @@ HIP_TEST_CASE(Unit_hipGLGetDevices_Positive_Parameters) {
 }
 
 HIP_TEST_CASE(Unit_hipGLGetDevices_Negative_Parameters) {
+  CHECK_IMAGE_SUPPORT
+
   GLContextScopeGuard gl_context;
 
   const int device_count = HipTest::getDeviceCount();

--- a/projects/hip-tests/catch/unit/gl_interop/hipGraphicsGLRegisterBuffer.cc
+++ b/projects/hip-tests/catch/unit/gl_interop/hipGraphicsGLRegisterBuffer.cc
@@ -17,6 +17,8 @@ constexpr std::array<unsigned int, 3> kFlags{hipGraphicsRegisterFlagsNone,
 }  // anonymous namespace
 
 HIP_TEST_CASE(Unit_hipGraphicsGLRegisterBuffer_Positive_Basic) {
+  CHECK_IMAGE_SUPPORT
+
   GLContextScopeGuard gl_context;
 
   const int device_count = HipTest::getDeviceCount();
@@ -40,6 +42,8 @@ HIP_TEST_CASE(Unit_hipGraphicsGLRegisterBuffer_Positive_Basic) {
 }
 
 HIP_TEST_CASE(Unit_hipGraphicsGLRegisterBuffer_Positive_Register_Twice) {
+  CHECK_IMAGE_SUPPORT
+
   GLContextScopeGuard gl_context;
 
   const int device_count = HipTest::getDeviceCount();
@@ -63,6 +67,8 @@ HIP_TEST_CASE(Unit_hipGraphicsGLRegisterBuffer_Positive_Register_Twice) {
 }
 
 HIP_TEST_CASE(Unit_hipGraphicsGLRegisterBuffer_Negative_Parameters) {
+  CHECK_IMAGE_SUPPORT
+
   GLContextScopeGuard gl_context;
 
   GLBufferObject vbo;

--- a/projects/hip-tests/catch/unit/gl_interop/hipGraphicsGLRegisterImage.cc
+++ b/projects/hip-tests/catch/unit/gl_interop/hipGraphicsGLRegisterImage.cc
@@ -18,6 +18,8 @@ constexpr std::array<unsigned int, 5> kFlags{
 }  // anonymous namespace
 
 HIP_TEST_CASE(Unit_hipGraphicsGLRegisterImage_Positive_Basic) {
+  CHECK_IMAGE_SUPPORT
+
   GLContextScopeGuard gl_context;
 
   const int device_count = HipTest::getDeviceCount();
@@ -41,6 +43,8 @@ HIP_TEST_CASE(Unit_hipGraphicsGLRegisterImage_Positive_Basic) {
 }
 
 HIP_TEST_CASE(Unit_hipGraphicsGLRegisterImage_Positive_Register_Twice) {
+  CHECK_IMAGE_SUPPORT
+
   GLContextScopeGuard gl_context;
   const int device_count = HipTest::getDeviceCount();
   unsigned int gl_device_count = 0;
@@ -65,6 +69,8 @@ HIP_TEST_CASE(Unit_hipGraphicsGLRegisterImage_Positive_Register_Twice) {
 }
 
 HIP_TEST_CASE(Unit_hipGraphicsGLRegisterImage_Negative_Parameters) {
+  CHECK_IMAGE_SUPPORT
+
   GLContextScopeGuard gl_context;
 
   GLImageObject tex;

--- a/projects/hip-tests/catch/unit/gl_interop/hipGraphicsMapResources.cc
+++ b/projects/hip-tests/catch/unit/gl_interop/hipGraphicsMapResources.cc
@@ -11,6 +11,8 @@
 #include "gl_interop_common.hh"
 
 HIP_TEST_CASE(Unit_hipGraphicsMapResources_Positive_Basic) {
+  CHECK_IMAGE_SUPPORT
+
   GLContextScopeGuard gl_context;
 
   const int device_count = HipTest::getDeviceCount();
@@ -45,6 +47,8 @@ HIP_TEST_CASE(Unit_hipGraphicsMapResources_Positive_Basic) {
 }
 
 HIP_TEST_CASE(Unit_hipGraphicsMapResources_Negative_Parameters) {
+  CHECK_IMAGE_SUPPORT
+
   GLContextScopeGuard gl_context;
 
   const int device_count = HipTest::getDeviceCount();

--- a/projects/hip-tests/catch/unit/gl_interop/hipGraphicsResourceGetMappedPointer.cc
+++ b/projects/hip-tests/catch/unit/gl_interop/hipGraphicsResourceGetMappedPointer.cc
@@ -11,6 +11,8 @@
 #include "gl_interop_common.hh"
 
 HIP_TEST_CASE(Unit_hipGraphicsResourceGetMappedPointer_Positive_Basic) {
+  CHECK_IMAGE_SUPPORT
+
   GLContextScopeGuard gl_context;
 
   const int device_count = HipTest::getDeviceCount();
@@ -45,6 +47,8 @@ HIP_TEST_CASE(Unit_hipGraphicsResourceGetMappedPointer_Positive_Basic) {
 }
 
 HIP_TEST_CASE(Unit_hipGraphicsResourceGetMappedPointer_Null_Parameters) {
+  CHECK_IMAGE_SUPPORT
+
   GLContextScopeGuard gl_context;
 
   const int device_count = HipTest::getDeviceCount();
@@ -93,6 +97,8 @@ HIP_TEST_CASE(Unit_hipGraphicsResourceGetMappedPointer_Null_Parameters) {
 }
 
 HIP_TEST_CASE(Unit_hipGraphicsResourceGetMappedPointer_Negative_Parameters) {
+  CHECK_IMAGE_SUPPORT
+
   GLContextScopeGuard gl_context;
 
   const int device_count = HipTest::getDeviceCount();

--- a/projects/hip-tests/catch/unit/gl_interop/hipGraphicsSubResourceGetMappedArray.cc
+++ b/projects/hip-tests/catch/unit/gl_interop/hipGraphicsSubResourceGetMappedArray.cc
@@ -11,6 +11,8 @@
 #include "gl_interop_common.hh"
 
 HIP_TEST_CASE(Unit_hipGraphicsSubResourceGetMappedArray_Positive_Basic) {
+  CHECK_IMAGE_SUPPORT
+
   GLContextScopeGuard gl_context;
 
   const int device_count = HipTest::getDeviceCount();
@@ -42,6 +44,8 @@ HIP_TEST_CASE(Unit_hipGraphicsSubResourceGetMappedArray_Positive_Basic) {
 }
 
 HIP_TEST_CASE(Unit_hipGraphicsSubResourceGetMappedArray_Negative_Parameters) {
+  CHECK_IMAGE_SUPPORT
+
   GLContextScopeGuard gl_context;
 
   const int device_count = HipTest::getDeviceCount();

--- a/projects/hip-tests/catch/unit/gl_interop/hipGraphicsUnmapResources.cc
+++ b/projects/hip-tests/catch/unit/gl_interop/hipGraphicsUnmapResources.cc
@@ -11,6 +11,8 @@
 #include "gl_interop_common.hh"
 
 HIP_TEST_CASE(Unit_hipGraphicsUnmapResources_Negative_Parameters) {
+  CHECK_IMAGE_SUPPORT
+
   GLContextScopeGuard gl_context;
 
   const int device_count = HipTest::getDeviceCount();

--- a/projects/hip-tests/catch/unit/gl_interop/hipGraphicsUnregisterResource.cc
+++ b/projects/hip-tests/catch/unit/gl_interop/hipGraphicsUnregisterResource.cc
@@ -11,6 +11,8 @@
 #include "gl_interop_common.hh"
 
 HIP_TEST_CASE(Unit_hipGraphicsUnregisterResource_Negative_Parameters) {
+  CHECK_IMAGE_SUPPORT
+
   GLContextScopeGuard gl_context;
 
   const int device_count = HipTest::getDeviceCount();

--- a/projects/hip-tests/catch/unit/graph/hipDeviceGetGraphMemAttribute.cc
+++ b/projects/hip-tests/catch/unit/graph/hipDeviceGetGraphMemAttribute.cc
@@ -206,10 +206,7 @@ static void hipDeviceGetGraphMemAttribute_Functional_Test(unsigned deviceId = 0)
   int mem_pool_support = 0;
   HIP_CHECK(hipDeviceGetAttribute(&mem_pool_support, hipDeviceAttributeMemoryPoolsSupported, 0));
   if (!mem_pool_support) {
-    HipTest::HIP_SKIP_TEST(
-        "Runtime doesn't support Memory Pool."
-        " Skip the test case.");
-    return;
+    HIP_SKIP_TEST("Runtime doesn't support Memory Pool. Skip the test case.");
   }
 
   constexpr size_t Nbytes = 512 * 1024 * 1024;
@@ -302,7 +299,7 @@ HIP_TEST_CASE(Unit_hipDeviceGetGraphMemAttribute_Functional_Multi_Device) {
       hipDeviceGetGraphMemAttribute_Functional_Test(i);
     }
   } else {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kNoGpuDevice);
+    HIP_SKIP_TEST(HipTest::SkipReason::kNoGpuDevice);
   }
 }
 

--- a/projects/hip-tests/catch/unit/graph/hipDrvGraphAddMemcpyNode.cc
+++ b/projects/hip-tests/catch/unit/graph/hipDrvGraphAddMemcpyNode.cc
@@ -365,8 +365,7 @@ HIP_TEST_CASE(Unit_hipDrvGraphAddMemcpyNode_MulitDevice) {
       hipDrvGraphAddMemcpyNode_test(device);
     }
   } else {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
-    return;
+    HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
   }
 }
 #endif

--- a/projects/hip-tests/catch/unit/graph/hipGraphAddChildGraphNode.cc
+++ b/projects/hip-tests/catch/unit/graph/hipGraphAddChildGraphNode.cc
@@ -1085,8 +1085,7 @@ HIP_TEST_CASE(Unit_hipGraphAddChildGraphNode_CmplxNstGrph_MultGPU) {
   HIP_CHECK(hipGetDeviceCount(&devcount));
   // If only single GPU is detected then return
   if (devcount < 2) {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
-    return;
+    HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
   }
   hipGraph_t** graph = new hipGraph_t*[devcount]();
   REQUIRE(graph != nullptr);

--- a/projects/hip-tests/catch/unit/graph/hipGraphAddMemAllocNode.cc
+++ b/projects/hip-tests/catch/unit/graph/hipGraphAddMemAllocNode.cc
@@ -454,10 +454,7 @@ HIP_TEST_CASE(Unit_hipGraphAddMemAllocNode_Functional_1) {
   int mem_pool_support = 0;
   HIP_CHECK(hipDeviceGetAttribute(&mem_pool_support, hipDeviceAttributeMemoryPoolsSupported, 0));
   if (!mem_pool_support) {
-    HipTest::HIP_SKIP_TEST(
-        "Runtime doesn't support Memory Pool."
-        " Skip the test case.");
-    return;
+    HIP_SKIP_TEST("Runtime doesn't support Memory Pool. Skip the test case.");
   }
 
   constexpr size_t N = 1024 * 1024;
@@ -564,10 +561,7 @@ HIP_TEST_CASE(Unit_hipGraphAddMemAllocNode_Functional_2) {
   int mem_pool_support = 0;
   HIP_CHECK(hipDeviceGetAttribute(&mem_pool_support, hipDeviceAttributeMemoryPoolsSupported, 0));
   if (!mem_pool_support) {
-    HipTest::HIP_SKIP_TEST(
-        "Runtime doesn't support Memory Pool."
-        " Skip the test case.");
-    return;
+    HIP_SKIP_TEST("Runtime doesn't support Memory Pool. Skip the test case.");
   }
 
   constexpr size_t Nbytes = 512 * 1024 * 1024;
@@ -633,10 +627,7 @@ HIP_TEST_CASE(Unit_hipGraphAddMemAllocNode_Functional_3) {
   int mem_pool_support = 0;
   HIP_CHECK(hipDeviceGetAttribute(&mem_pool_support, hipDeviceAttributeMemoryPoolsSupported, 0));
   if (!mem_pool_support) {
-    HipTest::HIP_SKIP_TEST(
-        "Runtime doesn't support Memory Pool."
-        " Skip the test case.");
-    return;
+    HIP_SKIP_TEST("Runtime doesn't support Memory Pool. Skip the test case.");
   }
 
   constexpr size_t Nbytes = 512 * 1024 * 1024;
@@ -707,10 +698,7 @@ HIP_TEST_CASE(Unit_hipGraphAddMemAllocNode_Functional_4) {
   int mem_pool_support = 0;
   HIP_CHECK(hipDeviceGetAttribute(&mem_pool_support, hipDeviceAttributeMemoryPoolsSupported, 0));
   if (!mem_pool_support) {
-    HipTest::HIP_SKIP_TEST(
-        "Runtime doesn't support Memory Pool."
-        " Skip the test case.");
-    return;
+    HIP_SKIP_TEST("Runtime doesn't support Memory Pool. Skip the test case.");
   }
 
   constexpr size_t Nbytes = 512 * 1024 * 1024;
@@ -796,10 +784,7 @@ HIP_TEST_CASE(Unit_hipGraphAddMemAllocNode_Argument_Check) {
   int mem_pool_support = 0;
   HIP_CHECK(hipDeviceGetAttribute(&mem_pool_support, hipDeviceAttributeMemoryPoolsSupported, 0));
   if (!mem_pool_support) {
-    HipTest::HIP_SKIP_TEST(
-        "Runtime doesn't support Memory Pool."
-        " Skip the test case.");
-    return;
+    HIP_SKIP_TEST("Runtime doesn't support Memory Pool. Skip the test case.");
   }
 
   constexpr size_t Nbytes = 512 * 1024 * 1024;
@@ -1016,10 +1001,7 @@ HIP_TEST_CASE(Unit_hipGraphAddMemAllocNode_Negative_Instanciate_Graph_Again) {
   int mem_pool_support = 0;
   HIP_CHECK(hipDeviceGetAttribute(&mem_pool_support, hipDeviceAttributeMemoryPoolsSupported, 0));
   if (!mem_pool_support) {
-    HipTest::HIP_SKIP_TEST(
-        "Runtime doesn't support Memory Pool."
-        " Skip the test case.");
-    return;
+    HIP_SKIP_TEST("Runtime doesn't support Memory Pool. Skip the test case.");
   }
 
   constexpr size_t Nbytes = 512 * 1024 * 1024;
@@ -1078,10 +1060,7 @@ HIP_TEST_CASE(Unit_hipGraphAddMemAllocNode_Negative_Free_Alloc_Memory_Again) {
   int mem_pool_support = 0;
   HIP_CHECK(hipDeviceGetAttribute(&mem_pool_support, hipDeviceAttributeMemoryPoolsSupported, 0));
   if (!mem_pool_support) {
-    HipTest::HIP_SKIP_TEST(
-        "Runtime doesn't support Memory Pool."
-        " Skip the test case.");
-    return;
+    HIP_SKIP_TEST("Runtime doesn't support Memory Pool. Skip the test case.");
   }
 
   constexpr size_t Nbytes = 512 * 1024 * 1024;
@@ -1143,10 +1122,7 @@ HIP_TEST_CASE(Unit_hipGraphAddMemAllocNode_Negative_With_Cloneed_Graph) {
   int mem_pool_support = 0;
   HIP_CHECK(hipDeviceGetAttribute(&mem_pool_support, hipDeviceAttributeMemoryPoolsSupported, 0));
   if (!mem_pool_support) {
-    HipTest::HIP_SKIP_TEST(
-        "Runtime doesn't support Memory Pool."
-        " Skip the test case.");
-    return;
+    HIP_SKIP_TEST("Runtime doesn't support Memory Pool. Skip the test case.");
   }
 
   constexpr size_t N = 512 * 1024 * 1024;

--- a/projects/hip-tests/catch/unit/graph/hipGraphAddMemFreeNode.cc
+++ b/projects/hip-tests/catch/unit/graph/hipGraphAddMemFreeNode.cc
@@ -191,10 +191,7 @@ HIP_TEST_CASE(Unit_hipGraphAddMemFreeNode_Functional) {
   int mem_pool_support = 0;
   HIP_CHECK(hipDeviceGetAttribute(&mem_pool_support, hipDeviceAttributeMemoryPoolsSupported, 0));
   if (!mem_pool_support) {
-    HipTest::HIP_SKIP_TEST(
-        "Runtime doesn't support Memory Pool."
-        " Skip the test case.");
-    return;
+    HIP_SKIP_TEST("Runtime doesn't support Memory Pool. Skip the test case.");
   }
 
   constexpr size_t Nbytes = 512 * 1024 * 1024;

--- a/projects/hip-tests/catch/unit/graph/hipGraphAddMemcpyNodeFromSymbol_old.cc
+++ b/projects/hip-tests/catch/unit/graph/hipGraphAddMemcpyNodeFromSymbol_old.cc
@@ -250,11 +250,10 @@ HIP_TEST_CASE(Unit_hipGraphAddMemcpyNodeFromSymbol_GlobalMemoryPeerDevice) {
     if (canAccessPeer) {
       hipGraphAddMemcpyNodeFromSymbol_GlobalMemory(true, false);
     } else {
-      HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kPeerAccessUnavailable);
+      HIP_SKIP_TEST(HipTest::SkipReason::kPeerAccessUnavailable);
     }
   } else {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
-    return;
+    HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
   }
 }
 
@@ -272,11 +271,10 @@ HIP_TEST_CASE(Unit_hipGraphAddMemcpyNodeFromSymbol_GlobalConstMemoryPeerDevice) 
     if (canAccessPeer) {
       hipGraphAddMemcpyNodeFromSymbol_GlobalMemory(true, true);
     } else {
-      HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kPeerAccessUnavailable);
+      HIP_SKIP_TEST(HipTest::SkipReason::kPeerAccessUnavailable);
     }
   } else {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
-    return;
+    HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
   }
 }
 #endif

--- a/projects/hip-tests/catch/unit/graph/hipGraphAddMemcpyNodeToSymbol_old.cc
+++ b/projects/hip-tests/catch/unit/graph/hipGraphAddMemcpyNodeToSymbol_old.cc
@@ -233,11 +233,10 @@ HIP_TEST_CASE(Unit_hipGraphAddMemcpyNodeToSymbol_GlobalMemoryPeerDevice) {
     if (canAccessPeer) {
       hipGraphAddMemcpyNodeToSymbol_GlobalMemory(true, false);
     } else {
-      HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kPeerAccessUnavailable);
+      HIP_SKIP_TEST(HipTest::SkipReason::kPeerAccessUnavailable);
     }
   } else {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
-    return;
+    HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
   }
 }
 /*
@@ -254,11 +253,10 @@ HIP_TEST_CASE(Unit_hipGraphAddMemcpyNodeToSymbol_GlobalConstMemoryPeerDevice) {
     if (canAccessPeer) {
       hipGraphAddMemcpyNodeToSymbol_GlobalMemory(true, true);
     } else {
-      HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kPeerAccessUnavailable);
+      HIP_SKIP_TEST(HipTest::SkipReason::kPeerAccessUnavailable);
     }
   } else {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
-    return;
+    HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
   }
 }
 #endif

--- a/projects/hip-tests/catch/unit/graph/hipGraphCloneComplx.cc
+++ b/projects/hip-tests/catch/unit/graph/hipGraphCloneComplx.cc
@@ -1730,8 +1730,7 @@ HIP_TEST_CASE(Unit_hipGraphClone_multi_GPU_test) {
   HIP_CHECK(hipGetDeviceCount(&devcount));
   // If only single GPU is detected then return
   if (devcount < 2) {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
-    return;
+    HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
   }
 
   for (int dev = 0; dev < devcount; dev++) {

--- a/projects/hip-tests/catch/unit/graph/hipGraphExecEventRecordNodeSetEvent.cc
+++ b/projects/hip-tests/catch/unit/graph/hipGraphExecEventRecordNodeSetEvent.cc
@@ -177,8 +177,7 @@ HIP_TEST_CASE(Unit_hipGraphExecEventRecordNodeSetEvent_VerifyEventNotChanged) {
 HIP_TEST_CASE(Unit_hipGraphExecEventRecordNodeSetEvent_Positive_DifferentDevices) {
   const auto device_count = HipTest::getDeviceCount();
   if (device_count < 2) {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
-    return;
+    HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
   }
   hipGraphExec_t graphExec;
   hipStream_t streamForGraph;

--- a/projects/hip-tests/catch/unit/graph/hipGraphExecUpdate.cc
+++ b/projects/hip-tests/catch/unit/graph/hipGraphExecUpdate.cc
@@ -647,8 +647,7 @@ HIP_TEST_CASE(Unit_hipGraphExecUpdate_Negative_MultiDevice_Context_Changed) {
     HIP_CHECK(hipDeviceCanAccessPeer(&peerAccess, 1, 0));
   }
   if (!peerAccess) {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kPeerAccessUnavailable);
-    return;
+    HIP_SKIP_TEST(HipTest::SkipReason::kPeerAccessUnavailable);
   }
   HIP_CHECK(hipSetDevice(0));
   int *A_d, *B_d, *C_d, *A_h, *B_h, *C_h;

--- a/projects/hip-tests/catch/unit/graph/hipGraphInstantiateWithFlags.cc
+++ b/projects/hip-tests/catch/unit/graph/hipGraphInstantiateWithFlags.cc
@@ -264,11 +264,10 @@ HIP_TEST_CASE(Unit_hipGraphInstantiateWithFlags_DependencyGraphDeviceCtxtChg) {
     if (canAccessPeer) {
       GraphInstantiateWithFlags_DependencyGraph(true);
     } else {
-      HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kPeerAccessUnavailable);
+      HIP_SKIP_TEST(HipTest::SkipReason::kPeerAccessUnavailable);
     }
   } else {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
-    return;
+    HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
   }
 }
 
@@ -286,11 +285,10 @@ HIP_TEST_CASE(Unit_hipGraphInstantiateWithFlags_StreamCapture) {
     if (canAccessPeer) {
       GraphInstantiateWithFlags_StreamCapture();
     } else {
-      HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kPeerAccessUnavailable);
+      HIP_SKIP_TEST(HipTest::SkipReason::kPeerAccessUnavailable);
     }
   } else {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
-    return;
+    HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
   }
 }
 
@@ -308,11 +306,10 @@ HIP_TEST_CASE(Unit_hipGraphInstantiateWithFlags_StreamCaptureDeviceContextChg) {
     if (canAccessPeer) {
       GraphInstantiateWithFlags_StreamCapture(true);
     } else {
-      HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kPeerAccessUnavailable);
+      HIP_SKIP_TEST(HipTest::SkipReason::kPeerAccessUnavailable);
     }
   } else {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
-    return;
+    HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
   }
 }
 

--- a/projects/hip-tests/catch/unit/graph/hipGraphLaunch_old.cc
+++ b/projects/hip-tests/catch/unit/graph/hipGraphLaunch_old.cc
@@ -102,7 +102,7 @@ HIP_TEST_CASE(Unit_hipGraphLaunch_Functional_multidevice_test) {
       hipGraphLaunch_test();
     }
   } else {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kNoGpuDevice);
+    HIP_SKIP_TEST(HipTest::SkipReason::kNoGpuDevice);
   }
 }
 

--- a/projects/hip-tests/catch/unit/graph/hipGraphMemAllocNodeGetParams.cc
+++ b/projects/hip-tests/catch/unit/graph/hipGraphMemAllocNodeGetParams.cc
@@ -131,7 +131,7 @@ HIP_TEST_CASE(Unit_hipGraphMem_Alloc_Free_NodeGetParams_Functional_MultiDevice) 
       hipGraphMemAllocNodeGetParams_Functional(i);
     }
   } else {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kNoGpuDevice);
+    HIP_SKIP_TEST(HipTest::SkipReason::kNoGpuDevice);
   }
 }
 

--- a/projects/hip-tests/catch/unit/graph/hipGraphMultiDevice.cc
+++ b/projects/hip-tests/catch/unit/graph/hipGraphMultiDevice.cc
@@ -52,8 +52,7 @@ HIP_TEST_CASE(Unit_hipGraphMultiDevice) {
   int nGpus = 0;
   HIP_CHECK(hipGetDeviceCount(&nGpus));
   if (nGpus < 2) {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
-    return;
+    HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
   }
   hipStream_t streamdev1, streamdev2;
   hipEvent_t eventdev1, eventdev2;

--- a/projects/hip-tests/catch/unit/graph/hipGraphPerf.cc
+++ b/projects/hip-tests/catch/unit/graph/hipGraphPerf.cc
@@ -490,10 +490,7 @@ static void checkGraphEventcontinuousKernelCallIn2Blocks(const unsigned int kNum
 
 HIP_TEST_CASE(Unit_hipGraph_PerfCheck_MemcpyKernelMixCall) {
   if ((setenv("DEBUG_CLR_GRAPH_PACKET_CAPTURE", "true", 1)) != 0) {
-    HipTest::HIP_SKIP_TEST(
-        "Unable to turn on "
-        "DEBUG_CLR_GRAPH_PACKET_CAPTURE, hence exit!");
-    return;
+    HIP_SKIP_TEST("Unable to turn on DEBUG_CLR_GRAPH_PACKET_CAPTURE, hence exit!");
   }
 
   constexpr int kNumIter1 = 25;
@@ -603,10 +600,7 @@ static void hipGraph_PerfCheck_hipGraphExecKernelNodeSetParams(const hipStream_t
  */
 HIP_TEST_CASE(Unit_hipGraph_PerfCheck_hipGraphExecKernelNodeSetParams) {
   if ((setenv("DEBUG_CLR_GRAPH_PACKET_CAPTURE", "true", 1)) != 0) {
-    HipTest::HIP_SKIP_TEST(
-        "Unable to turn on "
-        "DEBUG_CLR_GRAPH_PACKET_CAPTURE, hence exit!");
-    return;
+    HIP_SKIP_TEST("Unable to turn on DEBUG_CLR_GRAPH_PACKET_CAPTURE, hence exit!");
   }
 
   hipStream_t stream;
@@ -721,10 +715,7 @@ static void hipGraph_PerfCheck_hipGraphExecKernelNodeSetParams_inLoop(const hipS
  */
 HIP_TEST_CASE(Unit_hipGraph_PerfCheck_hipGraphExecKernelNodeSetParams_inLoop) {
   if ((setenv("DEBUG_CLR_GRAPH_PACKET_CAPTURE", "true", 1)) != 0) {
-    HipTest::HIP_SKIP_TEST(
-        "Unable to turn on "
-        "DEBUG_CLR_GRAPH_PACKET_CAPTURE, hence exit!");
-    return;
+    HIP_SKIP_TEST("Unable to turn on DEBUG_CLR_GRAPH_PACKET_CAPTURE, hence exit!");
   }
 
   hipStream_t stream;
@@ -770,10 +761,7 @@ HIP_TEST_CASE(Unit_hipGraph_PerfCheck_hipGraphExecKernelNodeSetParams_inLoop) {
 
 HIP_TEST_CASE(Unit_hipGraph_PerfCheck_hipGraphExecMemcpyNodeSetParams) {
   if ((setenv("DEBUG_CLR_GRAPH_PACKET_CAPTURE", "true", 1)) != 0) {
-    HipTest::HIP_SKIP_TEST(
-        "Unable to turn on "
-        "DEBUG_CLR_GRAPH_PACKET_CAPTURE, hence exit!");
-    return;
+    HIP_SKIP_TEST("Unable to turn on DEBUG_CLR_GRAPH_PACKET_CAPTURE, hence exit!");
   }
   constexpr int kNumNode = 1;
   unsigned blocks = HipTest::setNumBlocks(blocksPerCU, threadsPerBlock, N);
@@ -943,10 +931,7 @@ static void hipGraph_PerfCheck_hipGraphExecMemcpyNodeSetParams_inLoop(const hipS
 
 HIP_TEST_CASE(Unit_hipGraph_PerfCheck_hipGraphExecMemcpyNodeSetParams_inLoop) {
   if ((setenv("DEBUG_CLR_GRAPH_PACKET_CAPTURE", "true", 1)) != 0) {
-    HipTest::HIP_SKIP_TEST(
-        "Unable to turn on "
-        "DEBUG_CLR_GRAPH_PACKET_CAPTURE, hence exit!");
-    return;
+    HIP_SKIP_TEST("Unable to turn on DEBUG_CLR_GRAPH_PACKET_CAPTURE, hence exit!");
   }
 
   hipStream_t stream;
@@ -1059,10 +1044,7 @@ static void hipGraph_PerfCheck_hipGraphExecMemcpyNodeSetParams1D_inLoop(const hi
 
 HIP_TEST_CASE(Unit_hipGraph_PerfCheck_hipGraphExecMemcpyNodeSetParams1D_inLoop) {
   if ((setenv("DEBUG_CLR_GRAPH_PACKET_CAPTURE", "true", 1)) != 0) {
-    HipTest::HIP_SKIP_TEST(
-        "Unable to turn on "
-        "DEBUG_CLR_GRAPH_PACKET_CAPTURE, hence exit!");
-    return;
+    HIP_SKIP_TEST("Unable to turn on DEBUG_CLR_GRAPH_PACKET_CAPTURE, hence exit!");
   }
 
   hipStream_t stream;
@@ -1167,10 +1149,7 @@ static void hipGraph_PerfCheck_hipGraphExecMemcpyNodeSetParamsFrmSymbol(const hi
 
 HIP_TEST_CASE(Unit_hipGraph_PerfCheck_hipGraphExecMemcpyNodeSetParamsFrmSymbol) {
   if ((setenv("DEBUG_CLR_GRAPH_PACKET_CAPTURE", "true", 1)) != 0) {
-    HipTest::HIP_SKIP_TEST(
-        "Unable to turn on "
-        "DEBUG_CLR_GRAPH_PACKET_CAPTURE, hence exit!");
-    return;
+    HIP_SKIP_TEST("Unable to turn on DEBUG_CLR_GRAPH_PACKET_CAPTURE, hence exit!");
   }
 
   hipStream_t stream;
@@ -1274,10 +1253,7 @@ static void hipGraph_PerfCheck_hipGraphExecMemcpyNodeSetParamsToSymbol(const hip
  */
 HIP_TEST_CASE(Unit_hipGraph_PerfCheck_hipGraphExecMemcpyNodeSetParamsToSymbol) {
   if ((setenv("DEBUG_CLR_GRAPH_PACKET_CAPTURE", "true", 1)) != 0) {
-    HipTest::HIP_SKIP_TEST(
-        "Unable to turn on "
-        "DEBUG_CLR_GRAPH_PACKET_CAPTURE, hence exit!");
-    return;
+    HIP_SKIP_TEST("Unable to turn on DEBUG_CLR_GRAPH_PACKET_CAPTURE, hence exit!");
   }
 
   hipStream_t stream;
@@ -1427,10 +1403,7 @@ static void hipGraph_PerfCheck_hipGraphExecMemsetNodeSetParams(const hipStream_t
  */
 HIP_TEST_CASE(Unit_hipGraph_PerfCheck_hipGraphExecMemsetNodeSetParams) {
   if ((setenv("DEBUG_CLR_GRAPH_PACKET_CAPTURE", "true", 1)) != 0) {
-    HipTest::HIP_SKIP_TEST(
-        "Unable to turn on "
-        "DEBUG_CLR_GRAPH_PACKET_CAPTURE, hence exit!");
-    return;
+    HIP_SKIP_TEST("Unable to turn on DEBUG_CLR_GRAPH_PACKET_CAPTURE, hence exit!");
   }
 
   hipStream_t stream;
@@ -1860,10 +1833,7 @@ static void hipGraph_PerfCheck_hipGraphExecChildGraphNodeSetParams_mKernel(
  */
 HIP_TEST_CASE(Unit_hipGraph_PerfCheck_hipGraphExecChildGraphNodeSetParams) {
   if ((setenv("DEBUG_CLR_GRAPH_PACKET_CAPTURE", "true", 1)) != 0) {
-    HipTest::HIP_SKIP_TEST(
-        "Unable to turn on "
-        "DEBUG_CLR_GRAPH_PACKET_CAPTURE, hence exit!");
-    return;
+    HIP_SKIP_TEST("Unable to turn on DEBUG_CLR_GRAPH_PACKET_CAPTURE, hence exit!");
   }
 
   hipStream_t stream;
@@ -2007,10 +1977,7 @@ static void hipGraph_PerfCheck_hipGraphExecEventRecordNodeSetEvent(const hipStre
  */
 HIP_TEST_CASE(Unit_hipGraph_PerfCheck_hipGraphExecEventRecordNodeSetEvent) {
   if ((setenv("DEBUG_CLR_GRAPH_PACKET_CAPTURE", "true", 1)) != 0) {
-    HipTest::HIP_SKIP_TEST(
-        "Unable to turn on "
-        "DEBUG_CLR_GRAPH_PACKET_CAPTURE, hence exit!");
-    return;
+    HIP_SKIP_TEST("Unable to turn on DEBUG_CLR_GRAPH_PACKET_CAPTURE, hence exit!");
   }
 
   hipStream_t stream;
@@ -2194,10 +2161,7 @@ static void hipGraph_PerfCheck_hipGraphExecEventWaitNodeSetEvent(const hipStream
  */
 HIP_TEST_CASE(Unit_hipGraph_PerfCheck_hipGraphExecEventWaitNodeSetEvent) {
   if ((setenv("DEBUG_CLR_GRAPH_PACKET_CAPTURE", "true", 1)) != 0) {
-    HipTest::HIP_SKIP_TEST(
-        "Unable to turn on "
-        "DEBUG_CLR_GRAPH_PACKET_CAPTURE, hence exit!");
-    return;
+    HIP_SKIP_TEST("Unable to turn on DEBUG_CLR_GRAPH_PACKET_CAPTURE, hence exit!");
   }
 
   hipStream_t stream;
@@ -2348,10 +2312,7 @@ static void hipGraph_PerfCheck_hipGraphExecHostNodeSetParams(const hipStream_t& 
  */
 HIP_TEST_CASE(Unit_hipGraph_PerfCheck_hipGraphExecHostNodeSetParams) {
   if ((setenv("DEBUG_CLR_GRAPH_PACKET_CAPTURE", "true", 1)) != 0) {
-    HipTest::HIP_SKIP_TEST(
-        "Unable to turn on "
-        "DEBUG_CLR_GRAPH_PACKET_CAPTURE, hence exit!");
-    return;
+    HIP_SKIP_TEST("Unable to turn on DEBUG_CLR_GRAPH_PACKET_CAPTURE, hence exit!");
   }
 
   hipStream_t stream;
@@ -2471,10 +2432,7 @@ static void hipGraph_PerfCheck_hipGraphExecUpdate(const hipStream_t& stream) {
  */
 HIP_TEST_CASE(Unit_hipGraph_PerfCheck_hipGraphExecUpdate) {
   if ((setenv("DEBUG_CLR_GRAPH_PACKET_CAPTURE", "true", 1)) != 0) {
-    HipTest::HIP_SKIP_TEST(
-        "Unable to turn on "
-        "DEBUG_CLR_GRAPH_PACKET_CAPTURE, hence exit!");
-    return;
+    HIP_SKIP_TEST("Unable to turn on DEBUG_CLR_GRAPH_PACKET_CAPTURE, hence exit!");
   }
 
   hipStream_t stream;
@@ -2615,10 +2573,7 @@ static void hipGraph_PerfCheck_hipGraphExecUpdate_kernel_inLoop(const hipStream_
  */
 HIP_TEST_CASE(Unit_hipGraph_PerfCheck_hipGraphExecUpdate_kernel_inLoop) {
   if ((setenv("DEBUG_CLR_GRAPH_PACKET_CAPTURE", "true", 1)) != 0) {
-    HipTest::HIP_SKIP_TEST(
-        "Unable to turn on "
-        "DEBUG_CLR_GRAPH_PACKET_CAPTURE, hence exit!");
-    return;
+    HIP_SKIP_TEST("Unable to turn on DEBUG_CLR_GRAPH_PACKET_CAPTURE, hence exit!");
   }
 
   hipStream_t stream;

--- a/projects/hip-tests/catch/unit/graph/hipGraphUpload.cc
+++ b/projects/hip-tests/catch/unit/graph/hipGraphUpload.cc
@@ -192,7 +192,7 @@ HIP_TEST_CASE(Unit_hipGraphUpload_Functional_multidevice_test) {
       }
     }
   } else {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kNoGpuDevice);
+    HIP_SKIP_TEST(HipTest::SkipReason::kNoGpuDevice);
   }
 }
 

--- a/projects/hip-tests/catch/unit/graph/hipSimpleGraphWithKernel.cc
+++ b/projects/hip-tests/catch/unit/graph/hipSimpleGraphWithKernel.cc
@@ -146,8 +146,7 @@ static void hipTestWithoutGraph() {
 #ifdef KERNEL_ARG_PREFETCH
 TEST_CASE("Unit_hipGraph_SimpleGraphWithKernel_kernel_arg_prefetch") {
   if (!HipTest::isKernelArgPrefetchSupported()) {
-    HipTest::HIP_SKIP_TEST("Kernel arg prefetch is not supported on the device. Skipped.");
-    return;
+    HIP_SKIP_TEST("Kernel arg prefetch is not supported on the device. Skipped.");
   }
 #else
 TEST_CASE("Unit_hipGraph_SimpleGraphWithKernel") {

--- a/projects/hip-tests/catch/unit/graph/hipStreamBeginCapture.cc
+++ b/projects/hip-tests/catch/unit/graph/hipStreamBeginCapture.cc
@@ -1056,8 +1056,7 @@ HIP_TEST_CASE(Unit_hipStreamBeginCapture_Positive_MultiGPU) {
   HIP_CHECK(hipGetDeviceCount(&devcount));
   // If only single GPU is detected then return
   if (devcount < 2) {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
-    return;
+    HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
   }
   hipStream_t* stream = reinterpret_cast<hipStream_t*>(malloc(devcount * sizeof(hipStream_t)));
   REQUIRE(stream != nullptr);

--- a/projects/hip-tests/catch/unit/graph/hipStreamBeginCapture_old.cc
+++ b/projects/hip-tests/catch/unit/graph/hipStreamBeginCapture_old.cc
@@ -924,8 +924,7 @@ HIP_TEST_CASE(Unit_hipStreamBeginCapture_MultiGPU) {
   HIP_CHECK(hipGetDeviceCount(&devcount));
   // If only single GPU is detected then return
   if (devcount < 2) {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
-    return;
+    HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
   }
   hipStream_t* stream = reinterpret_cast<hipStream_t*>(malloc(devcount * sizeof(hipStream_t)));
   REQUIRE(stream != nullptr);

--- a/projects/hip-tests/catch/unit/hip_specific/hip_check_VGPRs.cpp
+++ b/projects/hip-tests/catch/unit/hip_specific/hip_check_VGPRs.cpp
@@ -66,7 +66,7 @@ HIP_TEST_CASE(Unit_Device__hip_check_VGPRs) {
                                 hipDeviceAttributeMaxAvailableVgprsPerThread, device));
   if (maxAvailableVgprsPerThread > 1024) {
     // The test should work on all current devices as of writing.
-    HipTest::HIP_SKIP_TEST(
+    HIP_SKIP_TEST(
         "maxAvailableVgprsPerThread > 1024 is not supported in this test.");
   }
   HIP_CHECK(hipFuncGetAttributes(&attr, reinterpret_cast<void*>(test1024)));

--- a/projects/hip-tests/catch/unit/kernel/hipLaunchKernelEx.cc
+++ b/projects/hip-tests/catch/unit/kernel/hipLaunchKernelEx.cc
@@ -127,8 +127,7 @@ __global__ void normalKernel(int* output, int totalThreads) {
  */
 HIP_TEST_CASE(Unit_hipLaunchKernelExC_NegetiveTsts) {
   if (!DeviceAttributesSupport(0, hipDeviceAttributeCooperativeLaunch)) {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kCooperativeLaunchUnsupported);
-    return;
+    HIP_SKIP_TEST(HipTest::SkipReason::kCooperativeLaunchUnsupported);
   }
   int blockSize = 16;
   int totalThreads = 64;
@@ -197,8 +196,7 @@ HIP_TEST_CASE(Unit_hipLaunchKernelExC_NegetiveTsts) {
 
 HIP_TEST_CASE(Unit_hipLaunchKernelEx_NegetiveTsts) {
   if (!DeviceAttributesSupport(0, hipDeviceAttributeCooperativeLaunch)) {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kCooperativeLaunchUnsupported);
-    return;
+    HIP_SKIP_TEST(HipTest::SkipReason::kCooperativeLaunchUnsupported);
   }
   int blockSize = 16;
   int totalThreads = 64;
@@ -320,8 +318,7 @@ bool runTest(const char* testName, const void* kernelFunc, int totalThreads, int
  */
 HIP_TEST_CASE(Unit_hipLaunchKernelEx_Functional) {
   if (!DeviceAttributesSupport(0, hipDeviceAttributeCooperativeLaunch)) {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kCooperativeLaunchUnsupported);
-    return;
+    HIP_SKIP_TEST(HipTest::SkipReason::kCooperativeLaunchUnsupported);
   }
   std::string api_type = GENERATE("hipLaunchKernelEx", "hipLaunchKernelExC");
   if (api_type == "hipLaunchKernelEx") {
@@ -352,8 +349,7 @@ HIP_TEST_CASE(Unit_hipLaunchKernelEx_Functional) {
  */
 HIP_TEST_CASE(Unit_hipLaunchKernelEx_With_Different_Kernels) {
   if (!DeviceAttributesSupport(0, hipDeviceAttributeCooperativeLaunch)) {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kCooperativeLaunchUnsupported);
-    return;
+    HIP_SKIP_TEST(HipTest::SkipReason::kCooperativeLaunchUnsupported);
   }
 
   hipLaunchConfig_t config = {};
@@ -424,8 +420,7 @@ HIP_TEST_CASE(Unit_hipLaunchKernelEx_With_Different_Kernels) {
  */
 HIP_TEST_CASE(Unit_hipLaunchKernelEx_With_CooperativeKernelWithArgs) {
   if (!DeviceAttributesSupport(0, hipDeviceAttributeCooperativeLaunch)) {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kCooperativeLaunchUnsupported);
-    return;
+    HIP_SKIP_TEST(HipTest::SkipReason::kCooperativeLaunchUnsupported);
   }
 
   hipLaunchConfig_t config = {};
@@ -487,8 +482,7 @@ HIP_TEST_CASE(Unit_hipLaunchKernelEx_With_CooperativeKernelWithArgs) {
  */
 HIP_TEST_CASE(Unit_hipLaunchKernelEx_With_MaxBlockDims) {
   if (!DeviceAttributesSupport(0, hipDeviceAttributeCooperativeLaunch)) {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kCooperativeLaunchUnsupported);
-    return;
+    HIP_SKIP_TEST(HipTest::SkipReason::kCooperativeLaunchUnsupported);
   }
 
   hipLaunchConfig_t config = {};

--- a/projects/hip-tests/catch/unit/kernel/hipLaunchParmFunctor.cc
+++ b/projects/hip-tests/catch/unit/kernel/hipLaunchParmFunctor.cc
@@ -411,8 +411,7 @@ void HipFunctorTests::TestForFunctorContainInStructObj(void) {
  */
 TEST_CASE("Unit_hipLaunchParmFunctor_kernel_arg_prefetch") {
   if (!HipTest::isKernelArgPrefetchSupported()) {
-    HipTest::HIP_SKIP_TEST("Kernel arg prefetch is not supported on the device. Skipped.");
-    return;
+    HIP_SKIP_TEST("Kernel arg prefetch is not supported on the device. Skipped.");
   }
 #else
 TEST_CASE("Unit_hipLaunchParmFunctor") {

--- a/projects/hip-tests/catch/unit/memory/hipArray3DCreate.cc
+++ b/projects/hip-tests/catch/unit/memory/hipArray3DCreate.cc
@@ -91,8 +91,7 @@ HIP_TEMPLATE_TEST_CASE(Unit_hipArray3DCreate_MaxTexture, int, uint4, short, usho
 #else
   desc.Flags = GENERATE(0, hipArraySurfaceLoadStore);
   if (desc.Flags == hipArraySurfaceLoadStore) {
-    HipTest::HIP_SKIP_TEST("tracked issue EXSWCPHIPT-58.");
-    return;
+    HIP_SKIP_TEST("tracked issue EXSWCPHIPT-58.");
   }
 #endif
   CAPTURE(desc.Flags);
@@ -325,8 +324,7 @@ HIP_TEMPLATE_TEST_CASE(Unit_hipArray3DCreate_Negative_Non2DTextureGather, char, 
   CHECK_IMAGE_SUPPORT
 
 #if HT_AMD
-  HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kTextureGatherUnsupportedAmd);
-  return;
+  HIP_SKIP_TEST(HipTest::SkipReason::kTextureGatherUnsupportedAmd);
 #endif
   using vec_info = vector_info<TestType>;
   DriverContext ctx;

--- a/projects/hip-tests/catch/unit/memory/hipArrayCommon.hh
+++ b/projects/hip-tests/catch/unit/memory/hipArrayCommon.hh
@@ -86,8 +86,7 @@ struct Sizes {
         return;
       }
       default: {
-        HipTest::HIP_SKIP_TEST("array flag not supported.");
-        return;
+        HIP_SKIP_TEST("array flag not supported.");
       }
     }
   }

--- a/projects/hip-tests/catch/unit/memory/hipDrvMemcpy3DAsync_old.cc
+++ b/projects/hip-tests/catch/unit/memory/hipDrvMemcpy3DAsync_old.cc
@@ -307,7 +307,7 @@ void DrvMemcpy3DAsync<T>::HostDevice_DrvMemcpy3DAsync(bool device_context_change
   if (device_context_change) {
     HIP_CHECK(hipDeviceCanAccessPeer(&peerAccess, 0, 1));
     if (!peerAccess) {
-      HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kPeerAccessUnavailable);
+      HIP_SKIP_TEST(HipTest::SkipReason::kPeerAccessUnavailable);
       skip_test = true;
     } else {
       HIP_CHECK(hipSetDevice(1));
@@ -381,7 +381,7 @@ void DrvMemcpy3DAsync<T>::HostArray_DrvMemcpy3DAsync(bool device_context_change)
   if (device_context_change) {
     HIP_CHECK(hipDeviceCanAccessPeer(&peerAccess, 0, 1));
     if (!peerAccess) {
-      HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kPeerAccessUnavailable);
+      HIP_SKIP_TEST(HipTest::SkipReason::kPeerAccessUnavailable);
       skip_test = true;
     } else {
       HIP_CHECK(hipSetDevice(1));
@@ -454,8 +454,7 @@ HIP_TEST_CASE(Unit_hipDrvMemcpy3DAsync_H2DDeviceContextChange) {
     DrvMemcpy3DAsync<float> memcpy3d(10, 10, 1, HIP_AD_FORMAT_FLOAT);
     memcpy3d.HostDevice_DrvMemcpy3DAsync(true);
   } else {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
-    return;
+    HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
   }
 }
 
@@ -480,8 +479,7 @@ HIP_TEST_CASE(Unit_hipDrvMemcpy3DAsync_Host2ArrayDeviceContextChange) {
     DrvMemcpy3DAsync<float> memcpy3d(10, 10, 10, HIP_AD_FORMAT_FLOAT);
     memcpy3d.HostArray_DrvMemcpy3DAsync(true);
   } else {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
-    return;
+    HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
   }
 }
 

--- a/projects/hip-tests/catch/unit/memory/hipDrvMemcpy3D_old.cc
+++ b/projects/hip-tests/catch/unit/memory/hipDrvMemcpy3D_old.cc
@@ -299,7 +299,7 @@ template <typename T> void DrvMemcpy3D<T>::HostDevice_DrvMemcpy3D(bool device_co
   if (device_context_change) {
     HIP_CHECK(hipDeviceCanAccessPeer(&peerAccess, 0, 1));
     if (!peerAccess) {
-      HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kPeerAccessUnavailable);
+      HIP_SKIP_TEST(HipTest::SkipReason::kPeerAccessUnavailable);
       skip_test = true;
     } else {
       HIP_CHECK(hipSetDevice(1));
@@ -369,7 +369,7 @@ template <typename T> void DrvMemcpy3D<T>::HostArray_DrvMemcpy3D(bool device_con
   if (device_context_change) {
     HIP_CHECK(hipDeviceCanAccessPeer(&peerAccess, 0, 1));
     if (!peerAccess) {
-      HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kPeerAccessUnavailable);
+      HIP_SKIP_TEST(HipTest::SkipReason::kPeerAccessUnavailable);
       skip_test = true;
     } else {
       HIP_CHECK(hipSetDevice(1));
@@ -520,8 +520,7 @@ HIP_TEST_CASE(Unit_hipDrvMemcpy3D_H2DDeviceContextChange) {
     DrvMemcpy3D<float> memcpy3d(10, 10, 1, HIP_AD_FORMAT_FLOAT);
     memcpy3d.HostDevice_DrvMemcpy3D(true);
   } else {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
-    return;
+    HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
   }
 }
 
@@ -546,8 +545,7 @@ HIP_TEST_CASE(Unit_hipDrvMemcpy3D_Host2ArrayDeviceContextChange) {
     DrvMemcpy3D<float> memcpy3d(10, 10, 1, HIP_AD_FORMAT_FLOAT);
     memcpy3d.HostArray_DrvMemcpy3D(true);
   } else {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
-    return;
+    HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
   }
 }
 

--- a/projects/hip-tests/catch/unit/memory/hipExtMallocWithFlags.cc
+++ b/projects/hip-tests/catch/unit/memory/hipExtMallocWithFlags.cc
@@ -52,8 +52,7 @@ HIP_TEST_CASE(Unit_hipExtMallocWithFlags_Positive_Alignment) {
   const auto flag = GENERATE(hipDeviceMallocDefault, hipDeviceMallocFinegrained);
   if (flag == hipDeviceMallocFinegrained &&
       !DeviceAttributesSupport(0, hipDeviceAttributeFineGrainSupport)) {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kFineGrainHwUnsupported);
-    return;
+    HIP_SKIP_TEST(HipTest::SkipReason::kFineGrainHwUnsupported);
   }
   HIP_CHECK(hipExtMallocWithFlags(&ptr1, 1, flag));
   HIP_CHECK(hipExtMallocWithFlags(&ptr2, 10, flag));

--- a/projects/hip-tests/catch/unit/memory/hipFree.cc
+++ b/projects/hip-tests/catch/unit/memory/hipFree.cc
@@ -218,8 +218,7 @@ HIP_TEST_CASE(Unit_hipFreeDoubleHost) {
 
 #if HT_NVIDIA
 HIP_TEST_CASE(Unit_hipFreeDoubleArrayFree) {
-  HipTest::HIP_SKIP_TEST("tracked issue EXSWCPHIPT-120.");
-  return;
+  HIP_SKIP_TEST("tracked issue EXSWCPHIPT-120.");
 
   size_t width = GENERATE(32, 512, 1024);
   size_t height = GENERATE(0, 32, 512, 1024);
@@ -236,8 +235,7 @@ HIP_TEST_CASE(Unit_hipFreeDoubleArrayFree) {
 }
 
 HIP_TEST_CASE(Unit_hipFreeDoubleArrayDestroy) {
-  HipTest::HIP_SKIP_TEST("tracked issue EXSWCPHIPT-120.");
-  return;
+  HIP_SKIP_TEST("tracked issue EXSWCPHIPT-120.");
   using vec_info = vector_info<char>;
 
   size_t width = GENERATE(32, 512, 1024);

--- a/projects/hip-tests/catch/unit/memory/hipFreeArray.cc
+++ b/projects/hip-tests/catch/unit/memory/hipFreeArray.cc
@@ -43,8 +43,7 @@ HIP_TEST_CASE(Unit_hipFreeArray_NegativeArray) {
 
 HIP_TEST_CASE(Unit_hipFreeArray_DoubleFree) {
 #if HT_NVIDIA
-  HipTest::HIP_SKIP_TEST("tracked issue EXSWCPHIPT-120.");
-  return;
+  HIP_SKIP_TEST("tracked issue EXSWCPHIPT-120.");
 #endif
 
   CHECK_IMAGE_SUPPORT

--- a/projects/hip-tests/catch/unit/memory/hipGetProcAddressMemoryApis.cc
+++ b/projects/hip-tests/catch/unit/memory/hipGetProcAddressMemoryApis.cc
@@ -5382,8 +5382,7 @@ HIP_TEST_CASE(Unit_hipGetProcAddress_MemoryApisAddressRelated) {
  */
 HIP_TEST_CASE(Unit_hipGetProcAddress_MemoryApisManagedMemory) {
   if (HmmAttrPrint() != 1) {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kManagedMemoryUnsupported);
-    return;
+    HIP_SKIP_TEST(HipTest::SkipReason::kManagedMemoryUnsupported);
   }
 
   void* hipMallocManaged_ptr = nullptr;
@@ -5676,8 +5675,7 @@ HIP_TEST_CASE(Unit_hipGetProcAddress_MemoryApisStreamOrderedMemory) {
   HIP_CHECK(hipDeviceGetAttribute(&mem_pool_support, hipDeviceAttributeMemoryPoolsSupported, 0));
 
   if (mem_pool_support != 1) {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kMemoryPoolUnsupported);
-    return;
+    HIP_SKIP_TEST(HipTest::SkipReason::kMemoryPoolUnsupported);
   }
 
   void* hipMallocAsync_ptr = nullptr;
@@ -6020,8 +6018,7 @@ HIP_TEST_CASE(Unit_hipGetProcAddress_MemoryApisPeerToPeer) {
   HIP_CHECK(hipGetDeviceCount(&deviceCount));
 
   if (deviceCount < 2) {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
-    return;
+    HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
   }
 
   void* hipMemGetAddressRange_ptr = nullptr;
@@ -6052,8 +6049,7 @@ HIP_TEST_CASE(Unit_hipGetProcAddress_MemoryApisPeerToPeer) {
   int canAccessPeer = 0;
   HIP_CHECK(hipDeviceCanAccessPeer(&canAccessPeer, deviceId, peerDeviceId));
   if (!canAccessPeer) {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kPeerAccessUnavailable);
-    return;
+    HIP_SKIP_TEST(HipTest::SkipReason::kPeerAccessUnavailable);
   }
 
   const int N = 16;

--- a/projects/hip-tests/catch/unit/memory/hipHostAlloc.cc
+++ b/projects/hip-tests/catch/unit/memory/hipHostAlloc.cc
@@ -175,7 +175,7 @@ HIP_TEST_CASE(Unit_hipHostAlloc_Basic) {
   HIP_CHECK(hipGetDevice(&device));
   HIP_CHECK(hipGetDeviceProperties(&prop, device));
   if (prop.canMapHostMemory != 1) {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kHostPinnedMemoryUnsupported);
+    HIP_SKIP_TEST(HipTest::SkipReason::kHostPinnedMemoryUnsupported);
   } else {
     float *A_h, *B_h, *C_h;
     float *A_d, *B_d, *C_d;
@@ -320,8 +320,7 @@ HIP_TEST_CASE(Unit_hipHostAlloc_AllocateMoreThanTotalSystemMemory) {
   char* host_ptr = nullptr;
   const size_t total_ram_mb = HipTest::getTotalSystemMemoryInMB();
   if (total_ram_mb == 0) {
-    HipTest::HIP_SKIP_TEST("total system memory could not be queried.");
-    return;
+    HIP_SKIP_TEST("total system memory could not be queried.");
   }
 
   const size_t total_ram_bytes = total_ram_mb * 1024 * 1024;

--- a/projects/hip-tests/catch/unit/memory/hipHostGetDevicePointer.cc
+++ b/projects/hip-tests/catch/unit/memory/hipHostGetDevicePointer.cc
@@ -47,8 +47,7 @@ template <typename T> __global__ void set(T* ptr, T val) { *ptr = val; }
 
 HIP_TEST_CASE(Unit_hipHostGetDevicePointer_UseCase) {
   if (!DeviceAttributesSupport(0, hipDeviceAttributeCanMapHostMemory)) {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kHostPinnedMemoryUnsupported);
-    return;
+    HIP_SKIP_TEST(HipTest::SkipReason::kHostPinnedMemoryUnsupported);
   }
 
   int* hPtr{nullptr};
@@ -87,8 +86,7 @@ HIP_TEST_CASE(Unit_hipHostGetDevicePointer_UseCase) {
 
 HIP_TEST_CASE(Unit_hipHostGetDevicePointer_Capture) {
   if (!DeviceAttributesSupport(0, hipDeviceAttributeCanMapHostMemory)) {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kHostPinnedMemoryUnsupported);
-    return;
+    HIP_SKIP_TEST(HipTest::SkipReason::kHostPinnedMemoryUnsupported);
   }
 
   int* host_ptr = nullptr;

--- a/projects/hip-tests/catch/unit/memory/hipHostGetFlags.cc
+++ b/projects/hip-tests/catch/unit/memory/hipHostGetFlags.cc
@@ -85,8 +85,7 @@ HIP_TEST_CASE(Unit_hipHostGetFlags_flagCombos) {
 
   // Skip test if device does not support the property canMapHostMemory
   if (prop.canMapHostMemory != 1) {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kHostPinnedMemoryUnsupported);
-    return;
+    HIP_SKIP_TEST(HipTest::SkipReason::kHostPinnedMemoryUnsupported);
   } else {
     // Allocate using the generated flags combos
     INFO("Flag passed when allocating: 0x" << std::hex << FlagComp << "\n");
@@ -117,8 +116,7 @@ HIP_TEST_CASE(Unit_hipHostGetFlags_DifferentThreads) {
   HIP_CHECK(hipGetDevice(&device));
   HIP_CHECK(hipGetDeviceProperties(&prop, device));
   if (prop.canMapHostMemory != 1) {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kHostPinnedMemoryUnsupported);
-    return;
+    HIP_SKIP_TEST(HipTest::SkipReason::kHostPinnedMemoryUnsupported);
   } else {
     // Make sure we allocate before trying to get the flags
     std::thread malloc_thread(
@@ -146,8 +144,7 @@ HIP_TEST_CASE(Unit_hipHostGetFlags_InvalidArgs) {
 
   // Skip test if device does not support the property canMapHostMemory
   if (prop.canMapHostMemory != 1) {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kHostPinnedMemoryUnsupported);
-    return;
+    HIP_SKIP_TEST(HipTest::SkipReason::kHostPinnedMemoryUnsupported);
   } else {
     SECTION("Invalid flag ptr being passed to hipHostGetFlags") {
       // Use default flag

--- a/projects/hip-tests/catch/unit/memory/hipHostMalloc.cc
+++ b/projects/hip-tests/catch/unit/memory/hipHostMalloc.cc
@@ -95,7 +95,7 @@ HIP_TEST_CASE(Unit_hipHostMalloc_Basic) {
   HIP_CHECK(hipGetDevice(&device));
   HIP_CHECK(hipGetDeviceProperties(&prop, device));
   if (prop.canMapHostMemory != 1) {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kHostPinnedMemoryUnsupported);
+    HIP_SKIP_TEST(HipTest::SkipReason::kHostPinnedMemoryUnsupported);
   } else {
     float *A_h, *B_h, *C_h;
     float *A_d, *B_d, *C_d;
@@ -191,7 +191,7 @@ HIP_TEST_CASE(Unit_hipHostMalloc_Coherent) {
 
     HIP_CHECK(hipFreeHost(A));
   } else {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kCoherentHostAllocFailed);
+    HIP_SKIP_TEST(HipTest::SkipReason::kCoherentHostAllocFailed);
   }
 }
 
@@ -221,8 +221,7 @@ HIP_TEST_CASE(Unit_hipHostMalloc_AllocateMoreThanTotalSystemMemory) {
   char* host_ptr = nullptr;
   const size_t total_ram_mb = HipTest::getTotalSystemMemoryInMB();
   if (total_ram_mb == 0) {
-    HipTest::HIP_SKIP_TEST("total system memory could not be queried.");
-    return;
+    HIP_SKIP_TEST("total system memory could not be queried.");
   }
 
   const size_t total_ram_bytes = total_ram_mb * 1024 * 1024;

--- a/projects/hip-tests/catch/unit/memory/hipHostMallocTests.cc
+++ b/projects/hip-tests/catch/unit/memory/hipHostMallocTests.cc
@@ -23,7 +23,7 @@ Testcase Scenarios :
  */
 HIP_TEST_CASE(Unit_hipHostMalloc_ArgValidation) {
 #if HT_NVIDIA
-  HipTest::HIP_SKIP_TEST("host malloc test path pending debug.");
+  HIP_SKIP_TEST("host malloc test path pending debug.");
 #endif
   constexpr size_t allocSize = 1000;
   char* ptr;

--- a/projects/hip-tests/catch/unit/memory/hipHostRegister.cc
+++ b/projects/hip-tests/catch/unit/memory/hipHostRegister.cc
@@ -28,16 +28,6 @@ static constexpr auto LEN{1024};
 static constexpr auto LARGE_CHUNK_LEN{128 * LEN};
 static constexpr auto SMALL_CHUNK_LEN{8 * LEN};
 
-#if HT_AMD
-#define TEST_SKIP(arch)                                                                            \
-  if (std::string::npos == arch.find("xnack+")) {                                                  \
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kGpuXnackNotEnabled);                                \
-    return;                                                                                        \
-  }
-#else
-#define TEST_SKIP(arch)
-#endif
-
 template <typename T> __global__ void SetVal(T* in, T val) {
   int i = threadIdx.x + blockIdx.x * blockDim.x;
   in[i] = val;
@@ -562,9 +552,7 @@ HIP_TEST_CASE(Unit_hipHostRegister_MemAdvise_SetGet) {
   hipDeviceProp_t prop;
   HIP_CHECK(hipGetDeviceProperties(&prop, 0));
   if (prop.concurrentManagedAccess == 0) {
-    HipTest::HIP_SKIP_TEST(
-        "concurrent managed access is not supported for this test.");
-    return;
+    HIP_SKIP_TEST("concurrent managed access is not supported for this test.");
   }
   int numDevices = HipTest::getDeviceCount();
   size_t sizeBytes{LEN * sizeof(uint8_t)};

--- a/projects/hip-tests/catch/unit/memory/hipHostUnregister.cc
+++ b/projects/hip-tests/catch/unit/memory/hipHostUnregister.cc
@@ -17,22 +17,18 @@ constexpr unsigned int allFlags = hipHostRegisterDefault |   // 0
     ;
 #endif
 
-inline bool hipHostRegisterSupported() {
+inline void hipHostRegisterSupported() {
 #if HT_NVIDIA
   // unable to query for cudaDevAttrHostRegisterSupported equivalent
-  HipTest::HIP_SKIP_TEST("tracked issue EXSWCPHIPT-40.");
-  HipTest::HIP_SKIP_TEST("hipHostRegister is not supported on this device.");
-  return false;
-#else
-  return true;
+
+  HIP_SKIP_TEST("hipHostRegister is not supported on this device.");
 #endif
 }
 
 
 TEST_CASE("Unit_hipHostUnregister_MemoryNotAccessibleAfterUnregister") {
-  if (!hipHostRegisterSupported()) {
-    return;
-  }
+  hipHostRegisterSupported();
+
   // try all combinations of flags
   for (unsigned int flag = 0; flag <= allFlags; ++flag) {
 #if defined(_WIN32)
@@ -69,9 +65,8 @@ HIP_TEST_CASE(Unit_hipHostUnregister_NotRegisteredPointer) {
 }
 
 HIP_TEST_CASE(Unit_hipHostUnregister_AlreadyUnregisteredPointer) {
-  if (!hipHostRegisterSupported()) {
-    return;
-  }
+  hipHostRegisterSupported();
+
   // try all combinations of flags
   for (unsigned int flag = 0; flag <= allFlags; ++flag) {
 #if defined(_WIN32)

--- a/projects/hip-tests/catch/unit/memory/hipMalloc3DArray.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMalloc3DArray.cc
@@ -154,8 +154,7 @@ HIP_TEMPLATE_TEST_CASE(Unit_hipMalloc3DArray_MaxTexture, int, uint4, short, usho
   const unsigned int flag = GENERATE(hipArrayDefault, hipArraySurfaceLoadStore);
 #endif
   if (flag == hipArraySurfaceLoadStore) {
-    HipTest::HIP_SKIP_TEST("tracked issue EXSWCPHIPT-58.");
-    return;
+    HIP_SKIP_TEST("tracked issue EXSWCPHIPT-58.");
   }
   CAPTURE(flag);
   const Sizes sizes(flag);
@@ -426,8 +425,7 @@ HIP_TEST_CASE(Unit_hipMalloc3DArray_Negative_NumericLimit) {
 HIP_TEMPLATE_TEST_CASE(Unit_hipMalloc3DArray_Negative_Non2DTextureGather, char, uchar2, short4,
                    float2, float4) {
 #if HT_AMD
-  HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kTextureGatherUnsupportedAmd);
-  return;
+  HIP_SKIP_TEST(HipTest::SkipReason::kTextureGatherUnsupportedAmd);
 #endif
   hipArray_t array;
   const auto desc = hipCreateChannelDesc<TestType>();

--- a/projects/hip-tests/catch/unit/memory/hipMallocManaged.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMallocManaged.cc
@@ -70,8 +70,7 @@ HIP_TEST_CASE(Unit_hipMallocManaged_Basic) {
 HIP_TEST_CASE(Unit_hipMallocManaged_Advanced) {
   auto managed = HmmAttrPrint();
   if (managed != 1) {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kManagedMemoryUnsupported);
-    return;
+    HIP_SKIP_TEST(HipTest::SkipReason::kManagedMemoryUnsupported);
   }
 
   float *A, *B, *C;

--- a/projects/hip-tests/catch/unit/memory/hipMallocManagedFlagsTst.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMallocManagedFlagsTst.cc
@@ -18,8 +18,7 @@ __global__ void MallcMangdFlgTst(int n, float* x, float* y) {
 HIP_TEST_CASE(Unit_hipMallocManaged_FlgParam) {
   auto managed = HmmAttrPrint();
   if (managed != 1) {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kManagedMemoryUnsupported);
-    return;
+    HIP_SKIP_TEST(HipTest::SkipReason::kManagedMemoryUnsupported);
   }
 
   std::atomic<int> DataMismatch{0};
@@ -106,8 +105,7 @@ HIP_TEST_CASE(Unit_hipMallocManaged_FlgParam) {
 HIP_TEST_CASE(Unit_hipMallocManaged_AccessMultiStream) {
   auto managed = HmmAttrPrint();
   if (managed != 1) {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kManagedMemoryUnsupported);
-    return;
+    HIP_SKIP_TEST(HipTest::SkipReason::kManagedMemoryUnsupported);
   }
 
   std::atomic<int> DataMismatch{0};

--- a/projects/hip-tests/catch/unit/memory/hipMallocManaged_MultiScenario.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMallocManaged_MultiScenario.cc
@@ -63,8 +63,7 @@ void HostKernelDouble(float* Hmm, float* hPtr, size_t n) {
 HIP_TEST_CASE(Unit_hipMallocManaged_HostDeviceConcurrent) {
   auto managed = HmmAttrPrint();
   if (managed != 1) {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kManagedMemoryUnsupported);
-    return;
+    HIP_SKIP_TEST(HipTest::SkipReason::kManagedMemoryUnsupported);
   }
 
   float *Hmm = nullptr, *hPtr = nullptr, *dPtr = nullptr, *resPtr = nullptr;
@@ -100,8 +99,7 @@ HIP_TEST_CASE(Unit_hipMallocManaged_HostDeviceConcurrent) {
 HIP_TEST_CASE(Unit_hipMallocManaged_MultiChunkSingleDevice) {
   auto managed = HmmAttrPrint();
   if (managed != 1) {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kManagedMemoryUnsupported);
-    return;
+    HIP_SKIP_TEST(HipTest::SkipReason::kManagedMemoryUnsupported);
   }
 
   std::atomic<int> DataMismatch{0};
@@ -152,8 +150,7 @@ HIP_TEST_CASE(Unit_hipMallocManaged_MultiChunkSingleDevice) {
 HIP_TEST_CASE(Unit_hipMallocManaged_MultiChunkMultiDevice) {
   auto managed = HmmAttrPrint();
   if (managed != 1) {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kManagedMemoryUnsupported);
-    return;
+    HIP_SKIP_TEST(HipTest::SkipReason::kManagedMemoryUnsupported);
   }
 
   std::atomic<int> DataMismatch{0};
@@ -161,8 +158,7 @@ HIP_TEST_CASE(Unit_hipMallocManaged_MultiChunkMultiDevice) {
   int NumDevices = 0;
   HIP_CHECK(hipGetDeviceCount(&NumDevices));
   if (NumDevices < 2) {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
-    return;
+    HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
   }
   unsigned int NUM_ELMS = (1024 * 1024);
   float *Ad[MAX_GPU], *Hmm = NULL, *Ah = new float[NUM_ELMS];
@@ -208,8 +204,7 @@ HIP_TEST_CASE(Unit_hipMallocManaged_MultiChunkMultiDevice) {
 HIP_TEST_CASE(Unit_hipMallocManaged_OverSubscription) {
   auto managed = HmmAttrPrint();
   if (managed != 1) {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kManagedMemoryUnsupported);
-    return;
+    HIP_SKIP_TEST(HipTest::SkipReason::kManagedMemoryUnsupported);
   }
 
 #if HT_AMD
@@ -293,8 +288,7 @@ HIP_TEMPLATE_TEST_CASE(Unit_hipMallocManaged_TwoPointers, int,
                    float, double) {
   auto managed = HmmAttrPrint();
   if (managed != 1) {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kManagedMemoryUnsupported);
-    return;
+    HIP_SKIP_TEST(HipTest::SkipReason::kManagedMemoryUnsupported);
   }
 
   int NumDevices = 0;
@@ -334,15 +328,13 @@ HIP_TEMPLATE_TEST_CASE(Unit_hipMallocManaged_DeviceContextChange,
                    unsigned char, int, float, double) {
   auto managed = HmmAttrPrint();
   if (managed != 1) {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kManagedMemoryUnsupported);
-    return;
+    HIP_SKIP_TEST(HipTest::SkipReason::kManagedMemoryUnsupported);
   }
 
   int NumDevices = 0;
   HIP_CHECK(hipGetDeviceCount(&NumDevices));
   if (NumDevices < 2) {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
-    return;
+    HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
   }
 
   std::atomic<unsigned int> DataMismatch;

--- a/projects/hip-tests/catch/unit/memory/hipMallocManaged_MultiScenario.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMallocManaged_MultiScenario.cc
@@ -211,8 +211,7 @@ HIP_TEST_CASE(Unit_hipMallocManaged_OverSubscription) {
   int isPageableHMM = 0;
   HIP_CHECK(hipDeviceGetAttribute(&isPageableHMM, hipDeviceAttributePageableMemoryAccess, 0));
   if (!isPageableHMM) {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kPageableMemoryAccessUnsupported);
-    return;
+    HIP_SKIP_TEST(HipTest::SkipReason::kPageableMemoryAccessUnsupported);
   }
 #endif
 

--- a/projects/hip-tests/catch/unit/memory/hipMallocMipmappedArray.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMallocMipmappedArray.cc
@@ -356,8 +356,7 @@ HIP_TEST_CASE(Unit_hipMallocMipmappedArray_Negative_NumericLimit) {
 HIP_TEMPLATE_TEST_CASE(Unit_hipMallocMipmappedArray_Negative_Non2DTextureGather, char, uchar2,
                    float2) {
 #if HT_AMD
-  HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kTextureGatherUnsupportedAmd);
-  return;
+  HIP_SKIP_TEST(HipTest::SkipReason::kTextureGatherUnsupportedAmd);
 #endif
   hipMipmappedArray_t array;
   unsigned int numLevels = 1;

--- a/projects/hip-tests/catch/unit/memory/hipMallocMngdMultiThread.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMallocMngdMultiThread.cc
@@ -285,8 +285,7 @@ static void AllocateHmmMemory(int flag, int device) {
 HIP_TEST_CASE(Unit_hipMallocManaged_MultiThread) {
   auto managed = HmmAttrPrint();
   if (managed != 1) {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kManagedMemoryUnsupported);
-    return;
+    HIP_SKIP_TEST(HipTest::SkipReason::kManagedMemoryUnsupported);
   }
 
   IfTestPassed = true;
@@ -339,16 +338,14 @@ HIP_TEST_CASE(Unit_hipMallocManaged_MultiThread) {
 HIP_TEST_CASE(Unit_hipMallocManaged_MGpuMThread) {
   auto managed = HmmAttrPrint();
   if (managed != 1) {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kManagedMemoryUnsupported);
-    return;
+    HIP_SKIP_TEST(HipTest::SkipReason::kManagedMemoryUnsupported);
   }
 
   IfTestPassed = true;
   int Ngpus = 0;
   HIP_CHECK(hipGetDeviceCount(&Ngpus));
   if (Ngpus < 2) {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
-    return;
+    HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
   }
 
   int InitVal = 123, *Hmm1 = NULL, NumElms = 4096 * 4;
@@ -382,8 +379,7 @@ HIP_TEST_CASE(Unit_hipMallocManaged_MGpuMThread) {
 HIP_TEST_CASE(Unit_hipMallocManaged_MultiKrnlComnHmm) {
   auto managed = HmmAttrPrint();
   if (managed != 1) {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kManagedMemoryUnsupported);
-    return;
+    HIP_SKIP_TEST(HipTest::SkipReason::kManagedMemoryUnsupported);
   }
 
   IfTestPassed = true;
@@ -417,8 +413,7 @@ HIP_TEST_CASE(Unit_hipMallocManaged_MultiKrnlComnHmm) {
 HIP_TEST_CASE(Unit_hipMallocManaged_MultiKrnlComnMalloc) {
   auto managed = HmmAttrPrint();
   if (managed != 1) {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kManagedMemoryUnsupported);
-    return;
+    HIP_SKIP_TEST(HipTest::SkipReason::kManagedMemoryUnsupported);
   }
 
   IfTestPassed = true;
@@ -448,8 +443,7 @@ HIP_TEST_CASE(Unit_hipMallocManaged_MultiKrnlComnMalloc) {
 HIP_TEST_CASE(Unit_hipMallocManaged_MultiThrdMultiStrm) {
   auto managed = HmmAttrPrint();
   if (managed != 1) {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kManagedMemoryUnsupported);
-    return;
+    HIP_SKIP_TEST(HipTest::SkipReason::kManagedMemoryUnsupported);
   }
 
   IfTestPassed = true;
@@ -482,8 +476,7 @@ HIP_TEST_CASE(Unit_hipMallocManaged_MultiThrdMultiStrm) {
 HIP_TEST_CASE(Unit_hipMallocManaged_TwoKrnlsComnHmmMem) {
   auto managed = HmmAttrPrint();
   if (managed != 1) {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kManagedMemoryUnsupported);
-    return;
+    HIP_SKIP_TEST(HipTest::SkipReason::kManagedMemoryUnsupported);
   }
 
   IfTestPassed = true;

--- a/projects/hip-tests/catch/unit/memory/hipMemAdvise.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemAdvise.cc
@@ -53,8 +53,7 @@ std::vector<int> GetDevicesWithAdviseSupport() {
 HIP_TEST_CASE(Unit_hipMemAdvise_Set_Unset_Basic) {
   auto supported_devices = GetDevicesWithAdviseSupport();
   if (supported_devices.empty()) {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kManagedMemoryUnsupported);
-    return;
+    HIP_SKIP_TEST(HipTest::SkipReason::kManagedMemoryUnsupported);
   }
   supported_devices.push_back(hipCpuDeviceId);
   const auto device = GENERATE_COPY(from_range(supported_devices));
@@ -83,8 +82,7 @@ HIP_TEST_CASE(Unit_hipMemAdvise_Set_Unset_Basic) {
 HIP_TEST_CASE(Unit_hipMemAdvise_No_Flag_Interference) {
   auto supported_devices = GetDevicesWithAdviseSupport();
   if (supported_devices.empty()) {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kManagedMemoryUnsupported);
-    return;
+    HIP_SKIP_TEST(HipTest::SkipReason::kManagedMemoryUnsupported);
   }
   supported_devices.push_back(hipCpuDeviceId);
   const auto device = GENERATE_COPY(from_range(supported_devices));
@@ -111,8 +109,7 @@ HIP_TEST_CASE(Unit_hipMemAdvise_No_Flag_Interference) {
 HIP_TEST_CASE(Unit_hipMemAdvise_Rounding) {
   auto supported_devices = GetDevicesWithAdviseSupport();
   if (supported_devices.empty()) {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kManagedMemoryUnsupported);
-    return;
+    HIP_SKIP_TEST(HipTest::SkipReason::kManagedMemoryUnsupported);
   }
   supported_devices.push_back(hipCpuDeviceId);
   const auto device = supported_devices.front();
@@ -143,8 +140,7 @@ HIP_TEST_CASE(Unit_hipMemAdvise_Rounding) {
 HIP_TEST_CASE(Unit_hipMemAdvise_Flags_Do_Not_Cause_Prefetch) {
   auto supported_devices = GetDevicesWithAdviseSupport();
   if (supported_devices.empty()) {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kManagedMemoryUnsupported);
-    return;
+    HIP_SKIP_TEST(HipTest::SkipReason::kManagedMemoryUnsupported);
   }
   supported_devices.push_back(hipCpuDeviceId);
 
@@ -170,8 +166,7 @@ HIP_TEST_CASE(Unit_hipMemAdvise_Flags_Do_Not_Cause_Prefetch) {
 HIP_TEST_CASE(Unit_hipMemAdvise_Read_Write_After_Advise) {
   auto supported_devices = GetDevicesWithAdviseSupport();
   if (supported_devices.empty()) {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kManagedMemoryUnsupported);
-    return;
+    HIP_SKIP_TEST(HipTest::SkipReason::kManagedMemoryUnsupported);
   }
   LinearAllocGuard<int> alloc(LinearAllocs::hipMallocManaged, kPageSize);
   constexpr size_t count = kPageSize / sizeof(*alloc.ptr());
@@ -215,8 +210,7 @@ HIP_TEST_CASE(Unit_hipMemAdvise_Read_Write_After_Advise) {
 HIP_TEST_CASE(Unit_hipMemAdvise_Prefetch_After_Advise) {
   auto supported_devices = GetDevicesWithAdviseSupport();
   if (supported_devices.empty()) {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kManagedMemoryUnsupported);
-    return;
+    HIP_SKIP_TEST(HipTest::SkipReason::kManagedMemoryUnsupported);
   }
   supported_devices.push_back(hipCpuDeviceId);
   const auto advice = GENERATE(hipMemAdviseSetReadMostly, hipMemAdviseSetPreferredLocation
@@ -247,8 +241,7 @@ HIP_TEST_CASE(Unit_hipMemAdvise_Prefetch_After_Advise) {
 HIP_TEST_CASE(Unit_hipMemAdvise_AccessedBy_All_Devices) {
   auto supported_devices = GetDevicesWithAdviseSupport();
   if (supported_devices.empty()) {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kManagedMemoryUnsupported);
-    return;
+    HIP_SKIP_TEST(HipTest::SkipReason::kManagedMemoryUnsupported);
   }
   // Disabling this hipCpuDeviceId scenario as it fails due to ROCr issue
   // Enable it once SWDEV-36994, SWDEV-392002 are fixed
@@ -267,8 +260,7 @@ HIP_TEST_CASE(Unit_hipMemAdvise_AccessedBy_All_Devices) {
 HIP_TEST_CASE(Unit_hipMemAdvise_Negative_Parameters) {
   auto supported_devices = GetDevicesWithAdviseSupport();
   if (supported_devices.empty()) {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kManagedMemoryUnsupported);
-    return;
+    HIP_SKIP_TEST(HipTest::SkipReason::kManagedMemoryUnsupported);
   }
   const auto device = supported_devices.front();
 

--- a/projects/hip-tests/catch/unit/memory/hipMemAdviseMmap.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemAdviseMmap.cc
@@ -63,6 +63,6 @@ HIP_TEST_CASE(Unit_hipMemAdvise_MmapMem) {
     close(fd);
 #endif
   } else {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kPageableMemoryAccessUnsupported);
+    HIP_SKIP_TEST(HipTest::SkipReason::kPageableMemoryAccessUnsupported);
   }
 }

--- a/projects/hip-tests/catch/unit/memory/hipMemAdvise_old.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemAdvise_old.cc
@@ -118,8 +118,7 @@ HIP_TEST_CASE(Unit_hipMemAdvise_TstAccessedByPeer) {
 
     HIP_CHECK(hipGetDeviceCount(&NumDevs));
     if (NumDevs < 2) {
-      HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
-      return;
+      HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
     }
     HIP_CHECK(hipMallocManaged(&Hmm, MEM_SIZE, hipMemAttachGlobal));
     for (int i = 0; i < NumDevs; ++i) {
@@ -154,7 +153,7 @@ HIP_TEST_CASE(Unit_hipMemAdvise_TstAccessedByPeer) {
     HIP_CHECK(hipFree(Hmm));
     REQUIRE(IfTestPassed);
   } else {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kManagedMemoryUnsupported);
+    HIP_SKIP_TEST(HipTest::SkipReason::kManagedMemoryUnsupported);
   }
 }
 #endif
@@ -184,7 +183,7 @@ HIP_TEST_CASE(Unit_hipMemAdvise_TstAccessedByFlg2) {
       HIP_CHECK(hipFree(Hmm));
     }
   } else {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kManagedMemoryUnsupported);
+    HIP_SKIP_TEST(HipTest::SkipReason::kManagedMemoryUnsupported);
   }
 }
 
@@ -223,7 +222,7 @@ HIP_TEST_CASE(Unit_hipMemAdvise_TstAccessedByFlg3) {
       HIP_CHECK(hipFree(Hmm));
     }
   } else {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kManagedMemoryUnsupported);
+    HIP_SKIP_TEST(HipTest::SkipReason::kManagedMemoryUnsupported);
   }
 }
 
@@ -268,7 +267,7 @@ HIP_TEST_CASE(Unit_hipMemAdvise_TstAccessedByFlg4) {
     HIP_CHECK(hipFree(Hmm));
     HIP_CHECK(hipStreamDestroy(strm));
   } else {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kManagedMemoryUnsupported);
+    HIP_SKIP_TEST(HipTest::SkipReason::kManagedMemoryUnsupported);
   }
 }
 
@@ -354,8 +353,7 @@ HIP_TEST_CASE(Unit_hipMemAdvise_ReadMosltyMgpuTst) {
     int Ngpus = 0;
     HIP_CHECK(hipGetDeviceCount(&Ngpus));
     if (Ngpus < 2) {
-      HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
-      return;
+      HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
     }
     int *Hmm = NULL, NumElms = (1024 * 1024), InitVal = 123;
     int *Hmm1 = NULL, DataMismatch = 0;
@@ -417,6 +415,6 @@ HIP_TEST_CASE(Unit_hipMemAdvise_ReadMosltyMgpuTst) {
     HIP_CHECK(hipFree(Hmm));
 
   } else {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kManagedMemoryUnsupported);
+    HIP_SKIP_TEST(HipTest::SkipReason::kManagedMemoryUnsupported);
   }
 }

--- a/projects/hip-tests/catch/unit/memory/hipMemAdvise_old.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemAdvise_old.cc
@@ -318,14 +318,13 @@ HIP_TEST_CASE(Unit_hipMemAdvise_TstAlignedAllocMem) {
       HIP_CHECK(hipStreamDestroy(strm));
     }
   } else {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kGpuXnackNotEnabled);
+    HIP_SKIP_TEST(HipTest::SkipReason::kGpuXnackNotEnabled);
   }
 }
 
 HIP_TEST_CASE(Unit_hipMemAdvise_TstAlignedAllocMem_XNACK) {
   if (setenv("HSA_XNACK", "1", 1) != 0) {
-    HipTest::HIP_SKIP_TEST("cannot set XNACK via environment.");
-    return;
+    HIP_SKIP_TEST("cannot set XNACK via environment.");
   }
 
   hipDeviceProp_t prop;
@@ -338,7 +337,7 @@ HIP_TEST_CASE(Unit_hipMemAdvise_TstAlignedAllocMem_XNACK) {
     hip::SpawnProc proc("hipMemAdviseTstAlignedAllocMem", true);
     REQUIRE(proc.run() == 0);
   } else {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kGpuXnackNotEnabled);
+    HIP_SKIP_TEST(HipTest::SkipReason::kGpuXnackNotEnabled);
   }
 }
 #endif

--- a/projects/hip-tests/catch/unit/memory/hipMemAdvise_v2.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemAdvise_v2.cc
@@ -58,8 +58,7 @@ static std::vector<int> getSupportedDevices() {
 HIP_TEST_CASE(Unit_hipMemAdvise_v2_Device_Host) {
   auto supportedDevices = getSupportedDevices();
   if (supportedDevices.empty()) {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kManagedMemoryUnsupported);
-    return;
+    HIP_SKIP_TEST(HipTest::SkipReason::kManagedMemoryUnsupported);
   }
 
   HIP_CHECK(hipSetDevice(supportedDevices[0]));
@@ -145,12 +144,10 @@ HIP_TEST_CASE(Unit_hipMemAdvise_v2_Device_Host) {
 HIP_TEST_CASE(Unit_hipMemAdvise_v2_HostNuma_HostNumaCurrent) {
   auto supportedDevices = getSupportedDevices();
   if (supportedDevices.empty()) {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kManagedNoConcurrentAccess);
-    return;
+    HIP_SKIP_TEST(HipTest::SkipReason::kManagedNoConcurrentAccess);
   }
   if (numa_available() < 0) {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kHostNumaUnavailable);
-    return;
+    HIP_SKIP_TEST(HipTest::SkipReason::kHostNumaUnavailable);
   }
 
   HIP_CHECK(hipSetDevice(supportedDevices[0]));
@@ -225,8 +222,7 @@ HIP_TEST_CASE(Unit_hipMemAdvise_v2_HostNuma_HostNumaCurrent) {
 HIP_TEST_CASE(Unit_hipMemAdvise_v2_Negative) {
   auto supportedDevices = getSupportedDevices();
   if (supportedDevices.empty()) {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kManagedMemoryUnsupported);
-    return;
+    HIP_SKIP_TEST(HipTest::SkipReason::kManagedMemoryUnsupported);
   }
 
   HIP_CHECK(hipSetDevice(supportedDevices[0]));

--- a/projects/hip-tests/catch/unit/memory/hipMemAllocHost.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemAllocHost.cc
@@ -91,8 +91,7 @@ HIP_TEST_CASE(Unit_hipMemAllocHost_VerifyAccess) {
                                     device_index));
 
     if (!support_unified_adressing) {
-      HipTest::HIP_SKIP_TEST("unified addressing is not supported.");
-      return;
+      HIP_SKIP_TEST("unified addressing is not supported.");
     }
   }
 

--- a/projects/hip-tests/catch/unit/memory/hipMemCoherencyTst.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemCoherencyTst.cc
@@ -138,7 +138,7 @@ HIP_TEST_CASE(Unit_hipMallocManaged_CoherentTst) {
     HIP_CHECK(hipFree(Ptr));
     REQUIRE(YES_COHERENT);
   } else {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kManagedMemoryUnsupported);
+    HIP_SKIP_TEST(HipTest::SkipReason::kManagedMemoryUnsupported);
   }
 }
 #endif
@@ -177,7 +177,7 @@ HIP_TEST_CASE(Unit_hipMallocManaged_CoherentTstWthAdvise) {
     HIP_CHECK(hipStreamDestroy(strm));
     REQUIRE(YES_COHERENT);
   } else {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kManagedMemoryUnsupported);
+    HIP_SKIP_TEST(HipTest::SkipReason::kManagedMemoryUnsupported);
   }
 }
 
@@ -218,12 +218,10 @@ HIP_TEST_CASE(Unit_hipExtMallocWithFlags_CoherentTst) {
   HIP_CHECK(hipDeviceGetAttribute(&managed, hipDeviceAttributeManagedMemory, 0));
   INFO("hipDeviceAttributeManagedMemory: " << managed);
   if (managed != 1) {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kManagedMemoryUnsupported);
-    return;
+    HIP_SKIP_TEST(HipTest::SkipReason::kManagedMemoryUnsupported);
   }
   if (Pageable != 1) {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kPageableMemoryAccessUnsupported);
-    return;
+    HIP_SKIP_TEST(HipTest::SkipReason::kPageableMemoryAccessUnsupported);
   }
 
   // Allocating hipExtMallocWithFlags() memory with flags

--- a/projects/hip-tests/catch/unit/memory/hipMemPoolApi.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemPoolApi.cc
@@ -34,8 +34,7 @@ HIP_TEST_CASE(Unit_hipMemPoolApi_Basic) {
   int mem_pool_support = 0;
   HIP_CHECK(hipDeviceGetAttribute(&mem_pool_support, hipDeviceAttributeMemoryPoolsSupported, 0));
   if (!mem_pool_support) {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kMemoryPoolUnsupported);
-    return;
+    HIP_SKIP_TEST(HipTest::SkipReason::kMemoryPoolUnsupported);
   }
 
   int numElements = 64 * 1024 * 1024;
@@ -91,8 +90,7 @@ HIP_TEST_CASE(Unit_hipMemPoolApi_BasicAlloc) {
 
   HIP_CHECK(hipDeviceGetAttribute(&mem_pool_support, hipDeviceAttributeMemoryPoolsSupported, 0));
   if (!mem_pool_support) {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kMemoryPoolUnsupported);
-    return;
+    HIP_SKIP_TEST(HipTest::SkipReason::kMemoryPoolUnsupported);
   }
   unsigned int* notified = nullptr;
   HIP_CHECK(hipHostMalloc(&notified, sizeof(unsigned int)));
@@ -180,8 +178,7 @@ HIP_TEST_CASE(Unit_hipMemPoolApi_BasicTrim) {
   int mem_pool_support = 0;
   HIP_CHECK(hipDeviceGetAttribute(&mem_pool_support, hipDeviceAttributeMemoryPoolsSupported, 0));
   if (!mem_pool_support) {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kMemoryPoolUnsupported);
-    return;
+    HIP_SKIP_TEST(HipTest::SkipReason::kMemoryPoolUnsupported);
   }
   unsigned int* notified = nullptr;
   HIP_CHECK(hipHostMalloc(&notified, sizeof(unsigned int)));
@@ -268,8 +265,7 @@ HIP_TEST_CASE(Unit_hipMemPoolApi_BasicReuse) {
   int mem_pool_support = 0;
   HIP_CHECK(hipDeviceGetAttribute(&mem_pool_support, hipDeviceAttributeMemoryPoolsSupported, 0));
   if (!mem_pool_support) {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kMemoryPoolUnsupported);
-    return;
+    HIP_SKIP_TEST(HipTest::SkipReason::kMemoryPoolUnsupported);
   }
   unsigned int* notified = nullptr;
   HIP_CHECK(hipHostMalloc(&notified, sizeof(unsigned int)));
@@ -343,8 +339,7 @@ HIP_TEST_CASE(Unit_hipMemPoolApi_Opportunistic) {
   int mem_pool_support = 0;
   HIP_CHECK(hipDeviceGetAttribute(&mem_pool_support, hipDeviceAttributeMemoryPoolsSupported, 0));
   if (!mem_pool_support) {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kMemoryPoolUnsupported);
-    return;
+    HIP_SKIP_TEST(HipTest::SkipReason::kMemoryPoolUnsupported);
   }
   unsigned int *notified1 = nullptr, *notified2 = nullptr;
   HIP_CHECK(hipHostMalloc(&notified1, sizeof(unsigned int)));
@@ -500,8 +495,7 @@ HIP_TEST_CASE(Unit_hipMemPoolApi_Default) {
   int mem_pool_support = 0;
   HIP_CHECK(hipDeviceGetAttribute(&mem_pool_support, hipDeviceAttributeMemoryPoolsSupported, 0));
   if (!mem_pool_support) {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kMemoryPoolUnsupported);
-    return;
+    HIP_SKIP_TEST(HipTest::SkipReason::kMemoryPoolUnsupported);
   }
   unsigned int* notified = nullptr;
   HIP_CHECK(hipHostMalloc(&notified, sizeof(unsigned int)));

--- a/projects/hip-tests/catch/unit/memory/hipMemPoolExportToShareableHandle.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemPoolExportToShareableHandle.cc
@@ -462,14 +462,12 @@ HIP_TEST_CASE(Unit_hipMemPoolExportToShareableHandle_multiproc) {
   hipMemAllocationHandleType handleType;
 #if HT_WIN
   if (!(handleTypesSupported & hipMemHandleTypeWin32)) {
-    HipTest::HIP_SKIP_TEST("Win32 handle type not supported. Skipping Test..");
-    return;
+    HIP_SKIP_TEST("Win32 handle type not supported. Skipping Test..");
   }
   handleType = hipMemHandleTypeWin32;
 #else
   if (!(handleTypesSupported & hipMemHandleTypePosixFileDescriptor)) {
-    HipTest::HIP_SKIP_TEST("POSIX FD handle type not supported. Skipping Test..");
-    return;
+    HIP_SKIP_TEST("POSIX FD handle type not supported. Skipping Test..");
   }
   handleType = hipMemHandleTypePosixFileDescriptor;
 #endif
@@ -564,8 +562,7 @@ HIP_TEST_CASE(Unit_hipMemPoolExportToShareableHandle_multiproc) {
 HIP_TEST_CASE(Unit_hipMemPoolExportToShareableHandle_multiproc_child) {
   unsigned long parentPid = getParentProcessId();
   if (parentPid == 0) {
-    HipTest::HIP_SKIP_TEST("Not launched by parent test. Skipping..");
-    return;
+    HIP_SKIP_TEST("Not launched by parent test. Skipping..");
   }
   char shmName[64];
 #if HT_WIN
@@ -576,10 +573,10 @@ HIP_TEST_CASE(Unit_hipMemPoolExportToShareableHandle_multiproc_child) {
 
   SharedMemory shm;
   if (shm.open(shmName, sizeof(mempoolIpcShmStruct)) != 0) {
-    HipTest::HIP_SKIP_TEST("Parent shared memory not found. "
-                            "This test should only be invoked by "
-                            "Unit_hipMemPoolExportToShareableHandle_multiproc. Skipping..");
-    return;
+    HIP_SKIP_TEST(
+        "Parent shared memory not found. "
+        "This test should only be invoked by "
+        "Unit_hipMemPoolExportToShareableHandle_multiproc. Skipping..");
   }
   auto *shmData = shm.as<mempoolIpcShmStruct>();
 

--- a/projects/hip-tests/catch/unit/memory/hipMemPoolMaxAlloc.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemPoolMaxAlloc.cc
@@ -36,8 +36,7 @@ hipError_t Test() {
   HIP_CHECK_LT(hipMemGetInfo(&free, &total));
   if (free < 30_GB) {
     std::cout << "Free memory is too low: " << free / 1_MB << " MiB" << std::endl;
-    HipTest::HIP_SKIP_TEST("test requires more than 30 GiB of free memory.");
-    return hipSuccess;
+    HIP_SKIP_TEST("test requires more than 30 GiB of free memory.");
   }
 
   uint64_t threshold = std::numeric_limits<uint64_t>::max();

--- a/projects/hip-tests/catch/unit/memory/hipMemPoolSetGetAccess.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemPoolSetGetAccess.cc
@@ -88,8 +88,7 @@ int CheckP2PMemPoolSupport(int src_device, int dst_device) {
 HIP_TEST_CASE(Unit_hipMemPoolSetGetAccess_Positive_MultipleGPU) {
   const auto device_count = HipTest::getDeviceCount();
   if (device_count < 2) {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
-    return;
+    HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
   }
   const auto src_device = GENERATE(range(0, HipTest::getDeviceCount()));
   const auto dst_device = GENERATE(range(0, HipTest::getDeviceCount()));
@@ -97,8 +96,7 @@ HIP_TEST_CASE(Unit_hipMemPoolSetGetAccess_Positive_MultipleGPU) {
 
   int mem_pool_support = CheckP2PMemPoolSupport(src_device, dst_device);
   if (!mem_pool_support) {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kMemoryPoolUnsupported);
-    return;
+    HIP_SKIP_TEST(HipTest::SkipReason::kMemoryPoolUnsupported);
   }
 
   const auto mempool_type = GENERATE(MemPools::dev_default, MemPools::created);
@@ -121,8 +119,7 @@ void MemPoolSetGetAccess_P2P(const MemPools mempool_type) {
 
   int mem_pool_support = CheckP2PMemPoolSupport(src_device, dst_device);
   if (!mem_pool_support) {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kMemoryPoolUnsupported);
-    return;
+    HIP_SKIP_TEST(HipTest::SkipReason::kMemoryPoolUnsupported);
   }
 
   int *alloc_mem1, *alloc_mem2;
@@ -203,8 +200,7 @@ void MemPoolSetGetAccess_P2P(const MemPools mempool_type) {
 HIP_TEST_CASE(Unit_hipMemPoolSetGetAccess_Positive_P2P) {
   const auto device_count = HipTest::getDeviceCount();
   if (device_count < 2) {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
-    return;
+    HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
   }
 
   SECTION("Default MemPool") { MemPoolSetGetAccess_P2P(MemPools::dev_default); }

--- a/projects/hip-tests/catch/unit/memory/hipMemPoolTrimTo.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemPoolTrimTo.cc
@@ -210,8 +210,7 @@ HIP_TEST_CASE(Unit_hipMemPoolTrimTo_MGpuVaryingMinBytesToHold) {
   int numDevices = 0;
   HIP_CHECK(hipGetDeviceCount(&numDevices));
   if (numDevices < 2) {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
-    return;
+    HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
   }
   for (int dev = 0; dev < numDevices; dev++) {
     checkMempoolSupported(dev) HIP_CHECK(hipSetDevice(dev));

--- a/projects/hip-tests/catch/unit/memory/hipMemPrefetchAsync.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemPrefetchAsync.cc
@@ -35,8 +35,7 @@ __global__ void MemPrefetchAsyncKernel(int* C_d, const int* A_d, size_t N) {
 HIP_TEST_CASE(Unit_hipMemPrefetchAsync_Basic_AllDevices) {
   const auto supported_devices = GetDevicesWithPrefetchSupport();
   if (supported_devices.empty()) {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kManagedMemoryUnsupported);
-    return;
+    HIP_SKIP_TEST(HipTest::SkipReason::kManagedMemoryUnsupported);
   }
 
   LinearAllocGuard<int> alloc1(LinearAllocs::hipMallocManaged, kPageSize);
@@ -65,8 +64,7 @@ HIP_TEST_CASE(Unit_hipMemPrefetchAsync_Basic_AllDevices) {
 HIP_TEST_CASE(Unit_hipMemPrefetchAsync_Sync_Behavior) {
   const auto supported_devices = GetDevicesWithPrefetchSupport();
   if (supported_devices.empty()) {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kManagedMemoryUnsupported);
-    return;
+    HIP_SKIP_TEST(HipTest::SkipReason::kManagedMemoryUnsupported);
   }
   const auto device = supported_devices.front();
   const auto stream_type = GENERATE(Streams::nullstream, Streams::perThread, Streams::created);
@@ -82,8 +80,7 @@ HIP_TEST_CASE(Unit_hipMemPrefetchAsync_Sync_Behavior) {
 HIP_TEST_CASE(Unit_hipMemPrefetchAsync_Rounding_Behavior) {
   auto supported_devices = GetDevicesWithPrefetchSupport();
   if (supported_devices.empty()) {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kManagedMemoryUnsupported);
-    return;
+    HIP_SKIP_TEST(HipTest::SkipReason::kManagedMemoryUnsupported);
   }
   const auto device = supported_devices.front();
   LinearAllocGuard<uint8_t> alloc(LinearAllocs::hipMallocManaged, 3 * kPageSize);
@@ -115,8 +112,7 @@ HIP_TEST_CASE(Unit_hipMemPrefetchAsync_Rounding_Behavior) {
 HIP_TEST_CASE(Unit_hipMemPrefetchAsync_Negative_Parameters) {
   auto supported_devices = GetDevicesWithPrefetchSupport();
   if (supported_devices.empty()) {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kManagedMemoryUnsupported);
-    return;
+    HIP_SKIP_TEST(HipTest::SkipReason::kManagedMemoryUnsupported);
   }
   supported_devices.push_back(hipCpuDeviceId);
   const auto device = GENERATE_COPY(from_range(supported_devices));

--- a/projects/hip-tests/catch/unit/memory/hipMemPrefetchAsyncExtTsts.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemPrefetchAsyncExtTsts.cc
@@ -104,10 +104,10 @@ HIP_TEST_CASE(Unit_hipMemPrefetchAsyncAdviseFlgTst) {
       HIP_CHECK(hipFree(Hmm));
       REQUIRE(IfTestPassed);
     } else {
-      HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kManagedMemoryUnsupported);
+      HIP_SKIP_TEST(HipTest::SkipReason::kManagedMemoryUnsupported);
     }
   } else {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
+    HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
   }
 }
 
@@ -195,10 +195,10 @@ HIP_TEST_CASE(Unit_hipMemPrefetchAsyncAccsdByTst) {
       HIP_CHECK(hipStreamDestroy(strm));
       REQUIRE(IfTestPassed);
     } else {
-      HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kManagedMemoryUnsupported);
+      HIP_SKIP_TEST(HipTest::SkipReason::kManagedMemoryUnsupported);
     }
   } else {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
+    HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
   }
 }
 
@@ -294,7 +294,7 @@ HIP_TEST_CASE(Unit_hipMemPrefetchAsyncNegativeTst) {
     REQUIRE(IfTestPassed);
 
   } else {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kManagedMemoryUnsupported);
+    HIP_SKIP_TEST(HipTest::SkipReason::kManagedMemoryUnsupported);
   }
 }
 

--- a/projects/hip-tests/catch/unit/memory/hipMemPrefetchAsync_v2.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemPrefetchAsync_v2.cc
@@ -58,8 +58,7 @@ static std::vector<int> getSupportedDevices() {
 HIP_TEST_CASE(Unit_hipMemPrefetchAsync_v2_Device_Host) {
   auto supportedDevices = getSupportedDevices();
   if (supportedDevices.empty()) {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kManagedMemoryUnsupported);
-    return;
+    HIP_SKIP_TEST(HipTest::SkipReason::kManagedMemoryUnsupported);
   }
 
   HIP_CHECK(hipSetDevice(supportedDevices[0]));
@@ -170,12 +169,10 @@ HIP_TEST_CASE(Unit_hipMemPrefetchAsync_v2_Device_Host) {
 HIP_TEST_CASE(Unit_hipMemPrefetchAsync_v2_HostNuma_HostNumaCurrent) {
   auto supportedDevices = getSupportedDevices();
   if (supportedDevices.empty()) {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kManagedNoConcurrentAccess);
-    return;
+    HIP_SKIP_TEST(HipTest::SkipReason::kManagedNoConcurrentAccess);
   }
   if (numa_available() < 0) {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kHostNumaUnavailable);
-    return;
+    HIP_SKIP_TEST(HipTest::SkipReason::kHostNumaUnavailable);
   }
 
   HIP_CHECK(hipSetDevice(supportedDevices[0]));
@@ -293,8 +290,7 @@ HIP_TEST_CASE(Unit_hipMemPrefetchAsync_v2_HostNuma_HostNumaCurrent) {
 HIP_TEST_CASE(Unit_hipMemPrefetchAsync_v2_Negative) {
   auto supportedDevices = getSupportedDevices();
   if (supportedDevices.empty()) {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kManagedMemoryUnsupported);
-    return;
+    HIP_SKIP_TEST(HipTest::SkipReason::kManagedMemoryUnsupported);
   }
 
   HIP_CHECK(hipSetDevice(supportedDevices[0]));

--- a/projects/hip-tests/catch/unit/memory/hipMemPrefetchBatchAsync.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemPrefetchBatchAsync.cc
@@ -38,8 +38,7 @@ constexpr size_t kTestBufferBytes = kTestBufferElements * sizeof(int);
   int device_var = 0;                                                                              \
   HIP_CHECK(hipSetDevice(device_var));                                                             \
   if (!DeviceAttributesSupport(device_var, hipDeviceAttributeConcurrentManagedAccess)) {           \
-    HipTest::HIP_SKIP_TEST("Device does not support concurrent managed access");                   \
-    return;                                                                                        \
+    HIP_SKIP_TEST("Device does not support concurrent managed access");                            \
   }
 
 }  // namespace
@@ -575,8 +574,7 @@ TEST_CASE("Unit_hipMemPrefetchBatchAsync_MultiDevice") {
   HIP_CHECK(hipGetDeviceCount(&device_count));
 
   if (device_count < 2) {
-    HipTest::HIP_SKIP_TEST("Multi-device test requires at least 2 GPUs");
-    return;
+    HIP_SKIP_TEST("Multi-device test requires at least 2 GPUs");
   }
 
   std::vector<int> supported_devices;
@@ -587,9 +585,7 @@ TEST_CASE("Unit_hipMemPrefetchBatchAsync_MultiDevice") {
   }
 
   if (supported_devices.size() < 2) {
-    HipTest::HIP_SKIP_TEST(
-        "Multi-device test requires at least 2 GPUs with concurrent managed access");
-    return;
+    HIP_SKIP_TEST("Multi-device test requires at least 2 GPUs with concurrent managed access");
   }
 
   int device = supported_devices[0];

--- a/projects/hip-tests/catch/unit/memory/hipMemRangeGetAttribute.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemRangeGetAttribute.cc
@@ -11,8 +11,7 @@
 
 HIP_TEST_CASE(Unit_hipMemRangeGetAttribute_Positive_ReadMostly_Basic) {
   if (!DeviceAttributesSupport(0, hipDeviceAttributeManagedMemory)) {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kManagedMemoryUnsupported);
-    return;
+    HIP_SKIP_TEST(HipTest::SkipReason::kManagedMemoryUnsupported);
   }
 
   LinearAllocGuard<void> allocation(LinearAllocs::hipMallocManaged, kPageSize);
@@ -32,8 +31,7 @@ HIP_TEST_CASE(Unit_hipMemRangeGetAttribute_Positive_ReadMostly_Basic) {
 
 HIP_TEST_CASE(Unit_hipMemRangeGetAttribute_Positive_ReadMostly_Partial_Range) {
   if (!DeviceAttributesSupport(0, hipDeviceAttributeManagedMemory)) {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kManagedMemoryUnsupported);
-    return;
+    HIP_SKIP_TEST(HipTest::SkipReason::kManagedMemoryUnsupported);
   }
 
   LinearAllocGuard<void> allocation(LinearAllocs::hipMallocManaged, 2 * kPageSize);
@@ -54,8 +52,7 @@ HIP_TEST_CASE(Unit_hipMemRangeGetAttribute_Positive_ReadMostly_Partial_Range) {
 
 HIP_TEST_CASE(Unit_hipMemRangeGetAttribute_Positive_PreferredLocation_Basic) {
   if (!DeviceAttributesSupport(0, hipDeviceAttributeManagedMemory)) {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kManagedMemoryUnsupported);
-    return;
+    HIP_SKIP_TEST(HipTest::SkipReason::kManagedMemoryUnsupported);
   }
 
   LinearAllocGuard<void> allocation(LinearAllocs::hipMallocManaged, kPageSize);
@@ -75,8 +72,7 @@ HIP_TEST_CASE(Unit_hipMemRangeGetAttribute_Positive_PreferredLocation_Basic) {
 
 HIP_TEST_CASE(Unit_hipMemRangeGetAttribute_Positive_PreferredLocation_CPU) {
   if (!DeviceAttributesSupport(0, hipDeviceAttributeManagedMemory)) {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kManagedMemoryUnsupported);
-    return;
+    HIP_SKIP_TEST(HipTest::SkipReason::kManagedMemoryUnsupported);
   }
 
   LinearAllocGuard<void> allocation(LinearAllocs::hipMallocManaged, kPageSize);
@@ -93,8 +89,7 @@ HIP_TEST_CASE(Unit_hipMemRangeGetAttribute_Positive_PreferredLocation_CPU) {
 
 HIP_TEST_CASE(Unit_hipMemRangeGetAttribute_Positive_PreferredLocation_Partial_Range) {
   if (!DeviceAttributesSupport(0, hipDeviceAttributeManagedMemory)) {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kManagedMemoryUnsupported);
-    return;
+    HIP_SKIP_TEST(HipTest::SkipReason::kManagedMemoryUnsupported);
   }
 
   LinearAllocGuard<void> allocation(LinearAllocs::hipMallocManaged, 2 * kPageSize);
@@ -115,8 +110,7 @@ HIP_TEST_CASE(Unit_hipMemRangeGetAttribute_Positive_PreferredLocation_Partial_Ra
 
 HIP_TEST_CASE(Unit_hipMemRangeGetAttribute_Positive_LastPrefetchLocation_Basic) {
   if (!DeviceAttributesSupport(0, hipDeviceAttributeManagedMemory)) {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kManagedMemoryUnsupported);
-    return;
+    HIP_SKIP_TEST(HipTest::SkipReason::kManagedMemoryUnsupported);
   }
 
   LinearAllocGuard<void> allocation(LinearAllocs::hipMallocManaged, kPageSize);
@@ -136,8 +130,7 @@ HIP_TEST_CASE(Unit_hipMemRangeGetAttribute_Positive_LastPrefetchLocation_Basic) 
 
 HIP_TEST_CASE(Unit_hipMemRangeGetAttribute_Positive_LastPrefetchLocation_CPU) {
   if (!DeviceAttributesSupport(0, hipDeviceAttributeManagedMemory)) {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kManagedMemoryUnsupported);
-    return;
+    HIP_SKIP_TEST(HipTest::SkipReason::kManagedMemoryUnsupported);
   }
 
   LinearAllocGuard<void> allocation(LinearAllocs::hipMallocManaged, kPageSize);
@@ -153,8 +146,7 @@ HIP_TEST_CASE(Unit_hipMemRangeGetAttribute_Positive_LastPrefetchLocation_CPU) {
 
 HIP_TEST_CASE(Unit_hipMemRangeGetAttribute_Positive_LastPrefetchLocation_Partial_Range) {
   if (!DeviceAttributesSupport(0, hipDeviceAttributeManagedMemory)) {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kManagedMemoryUnsupported);
-    return;
+    HIP_SKIP_TEST(HipTest::SkipReason::kManagedMemoryUnsupported);
   }
 
   LinearAllocGuard<void> allocation(LinearAllocs::hipMallocManaged, 2 * kPageSize);
@@ -175,8 +167,7 @@ HIP_TEST_CASE(Unit_hipMemRangeGetAttribute_Positive_LastPrefetchLocation_Partial
 
 HIP_TEST_CASE(Unit_hipMemRangeGetAttribute_Positive_AccessedBy_Basic) {
   if (!DeviceAttributesSupport(0, hipDeviceAttributeManagedMemory)) {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kManagedMemoryUnsupported);
-    return;
+    HIP_SKIP_TEST(HipTest::SkipReason::kManagedMemoryUnsupported);
   }
 
   LinearAllocGuard<void> allocation(LinearAllocs::hipMallocManaged, kPageSize);
@@ -206,8 +197,7 @@ HIP_TEST_CASE(Unit_hipMemRangeGetAttribute_Positive_AccessedBy_Basic) {
 
 HIP_TEST_CASE(Unit_hipMemRangeGetAttribute_Positive_AccessedBy_Partial_Range) {
   if (!DeviceAttributesSupport(0, hipDeviceAttributeManagedMemory)) {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kManagedMemoryUnsupported);
-    return;
+    HIP_SKIP_TEST(HipTest::SkipReason::kManagedMemoryUnsupported);
   }
 
   LinearAllocGuard<void> allocation(LinearAllocs::hipMallocManaged, 2 * kPageSize);
@@ -238,14 +228,12 @@ HIP_TEST_CASE(Unit_hipMemRangeGetAttribute_Positive_AccessedBy_Partial_Range) {
 
 HIP_TEST_CASE(Unit_hipMemRangeGetAttribute_Positive_AccessedBy_MultiDevice) {
   if (!DeviceAttributesSupport(0, hipDeviceAttributeManagedMemory)) {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kManagedMemoryUnsupported);
-    return;
+    HIP_SKIP_TEST(HipTest::SkipReason::kManagedMemoryUnsupported);
   }
 
   const auto device_count = HipTest::getDeviceCount();
   if (device_count < 2) {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
-    return;
+    HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
   }
 
   LinearAllocGuard<void> allocation(LinearAllocs::hipMallocManaged, kPageSize);
@@ -273,8 +261,7 @@ HIP_TEST_CASE(Unit_hipMemRangeGetAttribute_Positive_AccessedBy_MultiDevice) {
 
 HIP_TEST_CASE(Unit_hipMemRangeGetAttribute_Negative_Parameters) {
   if (!DeviceAttributesSupport(0, hipDeviceAttributeManagedMemory)) {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kManagedMemoryUnsupported);
-    return;
+    HIP_SKIP_TEST(HipTest::SkipReason::kManagedMemoryUnsupported);
   }
 
   int32_t data;

--- a/projects/hip-tests/catch/unit/memory/hipMemRangeGetAttribute_old.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemRangeGetAttribute_old.cc
@@ -48,8 +48,7 @@ HIP_TEST_CASE(Unit_hipMemRangeGetAttribute_TstCountParam) {
     int isPageableHMM = 0;
     HIP_CHECK(hipDeviceGetAttribute(&isPageableHMM, hipDeviceAttributePageableMemoryAccess, 0));
     if (!isPageableHMM) {
-      HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kPageableMemoryAccessUnsupported);
-      return;
+      HIP_SKIP_TEST(HipTest::SkipReason::kPageableMemoryAccessUnsupported);
     }
 #endif
 
@@ -91,7 +90,7 @@ HIP_TEST_CASE(Unit_hipMemRangeGetAttribute_TstCountParam) {
 
     REQUIRE(IfTestPassed);
   } else {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kManagedMemoryUnsupported);
+    HIP_SKIP_TEST(HipTest::SkipReason::kManagedMemoryUnsupported);
   }
 }
 
@@ -144,7 +143,7 @@ HIP_TEST_CASE(Unit_hipMemRangeGetAttribute_AccessedBy1) {
     }
     HIP_CHECK(hipFree(Hmm));
   } else {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kManagedMemoryUnsupported);
+    HIP_SKIP_TEST(HipTest::SkipReason::kManagedMemoryUnsupported);
   }
 }
 
@@ -189,6 +188,6 @@ HIP_TEST_CASE(Unit_hipMemRangeGetAttribute_4) {
     HIP_CHECK(hipFree(Hmm));
     delete[] OutData;
   } else {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kManagedMemoryUnsupported);
+    HIP_SKIP_TEST(HipTest::SkipReason::kManagedMemoryUnsupported);
   }
 }

--- a/projects/hip-tests/catch/unit/memory/hipMemRangeGetAttributes.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemRangeGetAttributes.cc
@@ -11,8 +11,7 @@
 
 HIP_TEST_CASE(Unit_hipMemRangeGetAttributes_Positive_Basic) {
   if (!DeviceAttributesSupport(0, hipDeviceAttributeManagedMemory)) {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kManagedMemoryUnsupported);
-    return;
+    HIP_SKIP_TEST(HipTest::SkipReason::kManagedMemoryUnsupported);
   }
 
   LinearAllocGuard<void> allocation(LinearAllocs::hipMallocManaged, kPageSize);
@@ -49,8 +48,7 @@ HIP_TEST_CASE(Unit_hipMemRangeGetAttributes_Positive_Basic) {
 
 HIP_TEST_CASE(Unit_hipMemRangeGetAttributes_Negative_Parameters) {
   if (!DeviceAttributesSupport(0, hipDeviceAttributeManagedMemory)) {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kManagedMemoryUnsupported);
-    return;
+    HIP_SKIP_TEST(HipTest::SkipReason::kManagedMemoryUnsupported);
   }
 
   constexpr size_t num_attributes = 4;

--- a/projects/hip-tests/catch/unit/memory/hipMemVmm.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemVmm.cc
@@ -29,8 +29,7 @@ HIP_TEST_CASE(Unit_hipMemVmm_Basic) {
   INFO("hipDeviceAttributeVirtualMemoryManagementSupported: " << vmm);
 
   if (vmm == 0) {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kVmmUnsupported);
-    return;
+    HIP_SKIP_TEST(HipTest::SkipReason::kVmmUnsupported);
   }
 
   size_t granularity = 0;
@@ -87,8 +86,7 @@ HIP_TEST_CASE(Unit_hipMemVmm_Uncached) {
   INFO("hipDeviceAttributeVirtualMemoryManagementSupported: " << vmm);
 
   if (vmm == 0) {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kVmmUnsupported);
-    return;
+    HIP_SKIP_TEST(HipTest::SkipReason::kVmmUnsupported);
   }
 
   size_t granularity = 0;

--- a/projects/hip-tests/catch/unit/memory/hipMemcpy2DAsync_old.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemcpy2DAsync_old.cc
@@ -180,11 +180,10 @@ HIP_TEMPLATE_TEST_CASE(Unit_hipMemcpy2DAsync_multiDevice_StreamOnDiffDevice, int
       HIP_CHECK(hipFree(X_d));
       HIP_CHECK(hipStreamDestroy(stream));
     } else {
-      HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kPeerAccessUnavailable);
+      HIP_SKIP_TEST(HipTest::SkipReason::kPeerAccessUnavailable);
     }
   } else {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
-    return;
+    HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
   }
 }
 

--- a/projects/hip-tests/catch/unit/memory/hipMemcpy2DFromArrayAsync_old.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemcpy2DFromArrayAsync_old.cc
@@ -60,11 +60,10 @@ HIP_TEST_CASE(Unit_hipMemcpy2DFromArrayAsync_multiDevicePinnedHostMem) {
       HIP_CHECK(hipStreamDestroy(stream));
       HipTest::freeArrays<float>(nullptr, nullptr, nullptr, A_h, nullptr, nullptr, false);
     } else {
-      HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kPeerAccessUnavailable);
+      HIP_SKIP_TEST(HipTest::SkipReason::kPeerAccessUnavailable);
     }
   } else {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
-    return;
+    HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
   }
 }
 
@@ -115,11 +114,10 @@ HIP_TEST_CASE(Unit_hipMemcpy2DFromArrayAsync_multiDeviceContextChange) {
       HIP_CHECK(hipStreamDestroy(stream));
       HipTest::freeArrays<float>(nullptr, nullptr, nullptr, A_h, hData, nullptr, false);
     } else {
-      HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kPeerAccessUnavailable);
+      HIP_SKIP_TEST(HipTest::SkipReason::kPeerAccessUnavailable);
     }
   } else {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
-    return;
+    HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
   }
 }
 

--- a/projects/hip-tests/catch/unit/memory/hipMemcpy2DFromArray_old.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemcpy2DFromArray_old.cc
@@ -54,11 +54,10 @@ HIP_TEST_CASE(Unit_hipMemcpy2DFromArray_multiDevicePinnedMemPeerGpu) {
       HIP_CHECK(hipHostFree(E_h));
       HipTest::freeArrays<float>(nullptr, nullptr, nullptr, A_h, nullptr, nullptr, false);
     } else {
-      HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kPeerAccessUnavailable);
+      HIP_SKIP_TEST(HipTest::SkipReason::kPeerAccessUnavailable);
     }
   } else {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
-    return;
+    HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
   }
 }
 
@@ -104,10 +103,9 @@ HIP_TEST_CASE(Unit_hipMemcpy2DFromArray_multiDeviceContextChange) {
       HIP_CHECK(hipFreeArray(A_d));
       HipTest::freeArrays<float>(nullptr, nullptr, nullptr, A_h, hData, nullptr, false);
     } else {
-      HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kPeerAccessUnavailable);
+      HIP_SKIP_TEST(HipTest::SkipReason::kPeerAccessUnavailable);
     }
   } else {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
-    return;
+    HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
   }
 }

--- a/projects/hip-tests/catch/unit/memory/hipMemcpy2DToArrayAsync_old.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemcpy2DToArrayAsync_old.cc
@@ -63,11 +63,10 @@ HIP_TEST_CASE(Unit_hipMemcpy2DToArrayAsync_multiDevicePinnedHostMem) {
       HIP_CHECK(hipStreamDestroy(stream));
       HipTest::freeArrays<float>(nullptr, nullptr, nullptr, A_h, nullptr, nullptr, false);
     } else {
-      HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kPeerAccessUnavailable);
+      HIP_SKIP_TEST(HipTest::SkipReason::kPeerAccessUnavailable);
     }
   } else {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
-    return;
+    HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
   }
 }
 
@@ -118,10 +117,9 @@ HIP_TEST_CASE(Unit_hipMemcpy2DToArrayAsync_multiDeviceDeviceContextChange) {
       HIP_CHECK(hipStreamDestroy(stream));
       HipTest::freeArrays<float>(nullptr, nullptr, nullptr, A_h, hData, nullptr, false);
     } else {
-      HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kPeerAccessUnavailable);
+      HIP_SKIP_TEST(HipTest::SkipReason::kPeerAccessUnavailable);
     }
   } else {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
-    return;
+    HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
   }
 }

--- a/projects/hip-tests/catch/unit/memory/hipMemcpy2DToArray_old.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemcpy2DToArray_old.cc
@@ -56,11 +56,10 @@ HIP_TEST_CASE(Unit_hipMemcpy2DToArray_multiDevicePinnedMemPeerGpu) {
       HIP_CHECK(hipHostFree(E_h));
       HipTest::freeArrays<float>(nullptr, nullptr, nullptr, A_h, nullptr, nullptr, false);
     } else {
-      HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kPeerAccessUnavailable);
+      HIP_SKIP_TEST(HipTest::SkipReason::kPeerAccessUnavailable);
     }
   } else {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
-    return;
+    HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
   }
 }
 
@@ -106,10 +105,9 @@ HIP_TEST_CASE(Unit_hipMemcpy2DToArray_multiDeviceDeviceContextChange) {
       HIP_CHECK(hipFreeArray(A_d));
       HipTest::freeArrays<float>(nullptr, nullptr, nullptr, A_h, hData, nullptr, false);
     } else {
-      HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kPeerAccessUnavailable);
+      HIP_SKIP_TEST(HipTest::SkipReason::kPeerAccessUnavailable);
     }
   } else {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
-    return;
+    HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
   }
 }

--- a/projects/hip-tests/catch/unit/memory/hipMemcpy3DAsync_old.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemcpy3DAsync_old.cc
@@ -166,7 +166,7 @@ template <typename T> void Memcpy3DAsync<T>::D2H_H2D_DeviceMem_OnDiffDevice() {
     // DeAllocating the Memory
     DeAllocateMemory();
   } else {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kPeerAccessUnavailable);
+    HIP_SKIP_TEST(HipTest::SkipReason::kPeerAccessUnavailable);
   }
 }
 
@@ -254,7 +254,7 @@ template <typename T> void Memcpy3DAsync<T>::D2D_DeviceMem_OnDiffDevice() {
     free(hOutputData);
     DeAllocateMemory();
   } else {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kPeerAccessUnavailable);
+    HIP_SKIP_TEST(HipTest::SkipReason::kPeerAccessUnavailable);
   }
 }
 
@@ -496,7 +496,7 @@ template <typename T> void Memcpy3DAsync<T>::D2D_SameDeviceMem_StreamDiffDevice(
     free(hOutputData);
     DeAllocateMemory();
   } else {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kPeerAccessUnavailable);
+    HIP_SKIP_TEST(HipTest::SkipReason::kPeerAccessUnavailable);
   }
 }
 
@@ -631,8 +631,7 @@ HIP_TEST_CASE(Unit_hipMemcpy3DAsync_multiDevice_Negative) {
     Memcpy3DAsync<int> memcpy3d(width, height, depth, hipChannelFormatKindSigned);
     memcpy3d.NegativeTests();
   } else {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
-    return;
+    HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
   }
 }
 
@@ -657,8 +656,7 @@ HIP_TEST_CASE(Unit_hipMemcpy3DAsync_multiDevice_DiffStream) {
     Memcpy3DAsync<float> memcpy3dAsync(width, height, depth, hipChannelFormatKindFloat);
     memcpy3dAsync.D2D_SameDeviceMem_StreamDiffDevice();
   } else {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
-    return;
+    HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
   }
 }
 

--- a/projects/hip-tests/catch/unit/memory/hipMemcpy3DPeer.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemcpy3DPeer.cc
@@ -34,22 +34,19 @@ HIP_TEST_CASE(Unit_hipMemcpy3DPeer_BasicFunctional) {
   hipExtent extent = make_hipExtent(numW, numH, depth);
   const auto device_count = HipTest::getDeviceCount();
   if (device_count <= 1) {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
-    return;
+    HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
   }
   const auto src_device = GENERATE_COPY(range(0, device_count));
   const auto dst_device = GENERATE_COPY(range(0, device_count));
   if (src_device == dst_device) {
     INFO("Src device: " << src_device << ", Dst device: " << dst_device);
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kMemcpyPeerSameSrcDstDevice);
-    return;
+    HIP_SKIP_TEST(HipTest::SkipReason::kMemcpyPeerSameSrcDstDevice);
   }
   HIP_CHECK(hipSetDevice(src_device));
   int can_access_peer = 0;
   HIP_CHECK(hipDeviceCanAccessPeer(&can_access_peer, src_device, dst_device));
   if (!can_access_peer) {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kPeerAccessUnavailable);
-    return;
+    HIP_SKIP_TEST(HipTest::SkipReason::kPeerAccessUnavailable);
   }
   // Array-1 Memory allocation
   hipChannelFormatDesc channelDesc_1 = hipCreateChannelDesc<char>();

--- a/projects/hip-tests/catch/unit/memory/hipMemcpy3DPeerAsync.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemcpy3DPeerAsync.cc
@@ -37,22 +37,19 @@ HIP_TEST_CASE(Unit_hipMemcpy3DPeerAsync_BasicFunctional) {
   hipExtent extent = make_hipExtent(numW, numH, depth);
   const auto device_count = HipTest::getDeviceCount();
   if (device_count <= 1) {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
-    return;
+    HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
   }
   const auto src_device = GENERATE_COPY(range(0, device_count));
   const auto dst_device = GENERATE_COPY(range(0, device_count));
   if (src_device == dst_device) {
     INFO("Src device: " << src_device << ", Dst device: " << dst_device);
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kMemcpyPeerSameSrcDstDevice);
-    return;
+    HIP_SKIP_TEST(HipTest::SkipReason::kMemcpyPeerSameSrcDstDevice);
   }
   HIP_CHECK(hipSetDevice(src_device));
   int can_access_peer = 0;
   HIP_CHECK(hipDeviceCanAccessPeer(&can_access_peer, src_device, dst_device));
   if (!can_access_peer) {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kPeerAccessUnavailable);
-    return;
+    HIP_SKIP_TEST(HipTest::SkipReason::kPeerAccessUnavailable);
   }
   // Array-1 Memory allocation
   hipChannelFormatDesc channelDesc_1 = hipCreateChannelDesc<char>();

--- a/projects/hip-tests/catch/unit/memory/hipMemcpy3D_old.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemcpy3D_old.cc
@@ -158,7 +158,7 @@ template <typename T> void Memcpy3D<T>::D2H_H2D_DeviceMem_OnDiffDevice() {
     free(hOutputData);
     DeAllocateMemory();
   } else {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kPeerAccessUnavailable);
+    HIP_SKIP_TEST(HipTest::SkipReason::kPeerAccessUnavailable);
   }
 }
 /*
@@ -238,7 +238,7 @@ template <typename T> void Memcpy3D<T>::D2D_DeviceMem_OnDiffDevice() {
     free(hOutputData);
     DeAllocateMemory();
   } else {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kPeerAccessUnavailable);
+    HIP_SKIP_TEST(HipTest::SkipReason::kPeerAccessUnavailable);
   }
 }
 /*
@@ -522,8 +522,7 @@ HIP_TEST_CASE(Unit_hipMemcpy3D_multiDevice_Negative) {
     Memcpy3D<int> memcpy3d(width, height, depth, hipChannelFormatKindSigned);
     memcpy3d.NegativeTests();
   } else {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
-    return;
+    HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
   }
 }
 

--- a/projects/hip-tests/catch/unit/memory/hipMemcpyAsync_derivatives.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemcpyAsync_derivatives.cc
@@ -67,10 +67,8 @@ HIP_TEST_CASE(Unit_hipMemcpyHtoDAsync_Positive_Synchronization_Behavior) {
   // This behavior differs on NVIDIA and AMD, on AMD the hipMemcpy calls is synchronous with
   // respect to the host
 #if HT_AMD
-  HipTest::HIP_SKIP_TEST(
-      "EXSWCPHIPT-127 - MemcpyAsync from host to device memory behavior differs on AMD and "
-      "Nvidia");
-  return;
+  HIP_SKIP_TEST(
+      "EXSWCPHIPT-127 - MemcpyAsync from host to device memory behavior differs on AMD and Nvidia");
 #endif
   MemcpyHPinnedtoDSyncBehavior(
       [](void* dst, void* src, size_t count) {

--- a/projects/hip-tests/catch/unit/memory/hipMemcpyAsync_old.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemcpyAsync_old.cc
@@ -255,8 +255,7 @@ HIP_TEMPLATE_TEST_CASE(Unit_hipMemcpyAsync_PinnedRegMemWithKernelLaunch, int, fl
   int numDevices = 0;
   HIP_CHECK(hipGetDeviceCount(&numDevices));
   if (numDevices < 2) {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
-    return;
+    HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
   }
   {
     // 1 refers to pinned Memory

--- a/projects/hip-tests/catch/unit/memory/hipMemcpyAtoA.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemcpyAtoA.cc
@@ -33,8 +33,7 @@
 
 HIP_TEST_CASE(Unit_hipMemcpyAtoA_Basic) {
 #if HT_NVIDIA
-  HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kApiUnsupportedOnNvidia);
-  return;
+  HIP_SKIP_TEST(HipTest::SkipReason::kApiUnsupportedOnNvidia);
 #else
   HIP_CHECK(hipSetDevice(0));
   CHECK_IMAGE_SUPPORT

--- a/projects/hip-tests/catch/unit/memory/hipMemcpyAtoD.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemcpyAtoD.cc
@@ -31,8 +31,7 @@
  */
 HIP_TEST_CASE(Unit_hipMemcpyAtoD_Basic) {
 #if HT_NVIDIA
-  HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kApiUnsupportedOnNvidia);
-  return;
+  HIP_SKIP_TEST(HipTest::SkipReason::kApiUnsupportedOnNvidia);
 #else
   HIP_CHECK(hipSetDevice(0));
   CHECK_IMAGE_SUPPORT

--- a/projects/hip-tests/catch/unit/memory/hipMemcpyAtoHAsync.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemcpyAtoHAsync.cc
@@ -31,8 +31,7 @@
  */
 HIP_TEST_CASE(Unit_hipMemcpyAtoHAsync_Basic) {
 #if HT_NVIDIA
-  HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kApiUnsupportedOnNvidia);
-  return;
+  HIP_SKIP_TEST(HipTest::SkipReason::kApiUnsupportedOnNvidia);
 #else
   HIP_CHECK(hipSetDevice(0));
   CHECK_IMAGE_SUPPORT

--- a/projects/hip-tests/catch/unit/memory/hipMemcpyAtoH_old.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemcpyAtoH_old.cc
@@ -39,7 +39,7 @@ HIP_TEMPLATE_TEST_CASE(Unit_hipMemcpyAtoH_multiDevice_PeerDeviceContext, char, i
     int peerAccess = 0;
     HIP_CHECK(hipDeviceCanAccessPeer(&peerAccess, 1, 0));
     if (!peerAccess) {
-      HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kPeerAccessUnavailable);
+      HIP_SKIP_TEST(HipTest::SkipReason::kPeerAccessUnavailable);
     } else {
       HIP_CHECK(hipSetDevice(0));
       hipArray_t A_d;
@@ -68,8 +68,7 @@ HIP_TEMPLATE_TEST_CASE(Unit_hipMemcpyAtoH_multiDevice_PeerDeviceContext, char, i
                                             false) == true);
     }
   } else {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
-    return;
+    HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
   }
 }
 #endif

--- a/projects/hip-tests/catch/unit/memory/hipMemcpyDtoD.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemcpyDtoD.cc
@@ -34,16 +34,14 @@ HIP_TEMPLATE_TEST_CASE(Unit_hipMemcpyDtoD_Basic, int, float,
 
   HIP_CHECK(hipGetDeviceCount(&numDevices));
   if (numDevices < 2) {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
-    return;
+    HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
   }
 
   int canAccessPeer = 0;
   HIP_CHECK(hipDeviceCanAccessPeer(&canAccessPeer, 0, 1));
   HIP_CHECK(hipSetDevice(0));
   if (!canAccessPeer) {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kPeerAccessUnavailable);
-    return;
+    HIP_SKIP_TEST(HipTest::SkipReason::kPeerAccessUnavailable);
   }
   HIP_CHECK(hipDeviceEnablePeerAccess(1, 0));
   HipTest::initArrays<TestType>(&A_d, &B_d, &C_d, &A_h, &B_h, &C_h, NUM_ELM, false);

--- a/projects/hip-tests/catch/unit/memory/hipMemcpyDtoDAsync.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemcpyDtoDAsync.cc
@@ -106,15 +106,13 @@ HIP_TEST_CASE(Unit_hipMemcpyDtoDAsync_Capture) {
   int device_count = 0;
   HIP_CHECK(hipGetDeviceCount(&device_count));
   if (device_count <= 1) {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
-    return;
+    HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
   }
 
   int peer_access = 0;
   HIP_CHECK(hipDeviceCanAccessPeer(&peer_access, 0, 1));
   if (!peer_access) {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kPeerAccessUnavailable);
-    return;
+    HIP_SKIP_TEST(HipTest::SkipReason::kPeerAccessUnavailable);
   }
 
   constexpr size_t kNumElements = NUM_ELM;

--- a/projects/hip-tests/catch/unit/memory/hipMemcpyDtoDAsync.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemcpyDtoDAsync.cc
@@ -37,8 +37,7 @@ HIP_TEMPLATE_TEST_CASE(Unit_hipMemcpyDtoDAsync_Basic, int, float,
 
   HIP_CHECK(hipGetDeviceCount(&numDevices));
   if (numDevices < 2) {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
-    return;
+    HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
   }
 
   int canAccessPeer = 0;
@@ -48,8 +47,7 @@ HIP_TEMPLATE_TEST_CASE(Unit_hipMemcpyDtoDAsync_Basic, int, float,
     HIP_CHECK(hipDeviceEnablePeerAccess(1, 0));
   } else {
     INFO("Machine does not have P2P Capabilities");
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kPeerAccessUnavailable);
-    return;
+    HIP_SKIP_TEST(HipTest::SkipReason::kPeerAccessUnavailable);
   }
   HipTest::initArrays<TestType>(&A_d, &B_d, &C_d, &A_h, &B_h, &C_h, NUM_ELM, false);
   HIP_CHECK(hipSetDevice(1));

--- a/projects/hip-tests/catch/unit/memory/hipMemcpyHtoAAsync.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemcpyHtoAAsync.cc
@@ -93,8 +93,7 @@ HIP_TEST_CASE(Unit_hipMemcpyHtoAAsync_Negative) {
  */
 HIP_TEST_CASE(Unit_hipMemcpyHtoAAsync_BasicTstsWithDiffStreams) {
 #if HT_NVIDIA
-  HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kApiUnsupportedOnNvidia);
-  return;
+  HIP_SKIP_TEST(HipTest::SkipReason::kApiUnsupportedOnNvidia);
 #else
   CHECK_IMAGE_SUPPORT
   HIP_CHECK(hipSetDevice(0));
@@ -155,8 +154,7 @@ HIP_TEST_CASE(Unit_hipMemcpyHtoAAsync_BasicTstsWithDiffStreams) {
  */
 HIP_TEST_CASE(Unit_hipMemcpyHtoAAsync_MultiDevice) {
 #if HT_NVIDIA
-  HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kApiUnsupportedOnNvidia);
-  return;
+  HIP_SKIP_TEST(HipTest::SkipReason::kApiUnsupportedOnNvidia);
 #else
   CHECK_IMAGE_SUPPORT
   int devCount = 0;

--- a/projects/hip-tests/catch/unit/memory/hipMemcpyHtoA_old.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemcpyHtoA_old.cc
@@ -38,7 +38,7 @@ HIP_TEMPLATE_TEST_CASE(Unit_hipMemcpyHtoA_multiDevice_PeerDeviceContext, char, i
     int peerAccess = 0;
     HIP_CHECK(hipDeviceCanAccessPeer(&peerAccess, 1, 0));
     if (!peerAccess) {
-      HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kPeerAccessUnavailable);
+      HIP_SKIP_TEST(HipTest::SkipReason::kPeerAccessUnavailable);
     } else {
       HIP_CHECK(hipSetDevice(0));
       hipArray_t A_d;
@@ -69,8 +69,7 @@ HIP_TEMPLATE_TEST_CASE(Unit_hipMemcpyHtoA_multiDevice_PeerDeviceContext, char, i
                                             false) == true);
     }
   } else {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
-    return;
+    HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
   }
 }
 #endif

--- a/projects/hip-tests/catch/unit/memory/hipMemcpyParam2DAsync_old.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemcpyParam2DAsync_old.cc
@@ -47,10 +47,9 @@ HIP_TEMPLATE_TEST_CASE(Unit_hipMemcpyParam2DAsync_multiDevice_StreamOnDiffDevice
     int peerAccess = 0;
     HIP_CHECK(hipDeviceCanAccessPeer(&peerAccess, 1, 0));
     if (!peerAccess) {
-      HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kPeerAccessUnavailable);
       HIP_CHECK(hipFree(A_d));
       HipTest::freeArrays<TestType>(nullptr, nullptr, nullptr, A_h, nullptr, C_h, false);
-      return;
+      HIP_SKIP_TEST(HipTest::SkipReason::kPeerAccessUnavailable);
     }
     {
       TestType* E_d{nullptr};
@@ -94,7 +93,6 @@ HIP_TEMPLATE_TEST_CASE(Unit_hipMemcpyParam2DAsync_multiDevice_StreamOnDiffDevice
       HipTest::freeArrays<TestType>(nullptr, nullptr, nullptr, A_h, nullptr, C_h, false);
     }
   } else {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
-    return;
+    HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
   }
 }

--- a/projects/hip-tests/catch/unit/memory/hipMemcpyPeer.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemcpyPeer.cc
@@ -35,8 +35,7 @@
 HIP_TEST_CASE(Unit_hipMemcpyPeer_Positive_Default) {
   const auto device_count = HipTest::getDeviceCount();
   if (device_count < 2) {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
-    return;
+    HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
   }
 
   const auto allocation_size = GENERATE(kPageSize / 2, kPageSize, kPageSize * 2);
@@ -102,8 +101,7 @@ HIP_TEST_CASE(Unit_hipMemcpyPeer_Positive_Synchronization_Behavior) {
 
   const auto device_count = HipTest::getDeviceCount();
   if (device_count < 2) {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
-    return;
+    HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
   }
 
   int can_access_peer = 0;
@@ -148,8 +146,7 @@ HIP_TEST_CASE(Unit_hipMemcpyPeer_Positive_Synchronization_Behavior) {
 HIP_TEST_CASE(Unit_hipMemcpyPeer_Positive_ZeroSize) {
   const auto device_count = HipTest::getDeviceCount();
   if (device_count < 2) {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
-    return;
+    HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
   }
 
   const auto allocation_size = kPageSize;
@@ -231,8 +228,7 @@ HIP_TEST_CASE(Unit_hipMemcpyPeer_Positive_ZeroSize) {
 HIP_TEST_CASE(Unit_hipMemcpyPeer_Negative_Parameters) {
   const auto device_count = HipTest::getDeviceCount();
   if (device_count < 2) {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
-    return;
+    HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
   }
 
   int can_access_peer = 0;

--- a/projects/hip-tests/catch/unit/memory/hipMemcpyPeerAsync.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemcpyPeerAsync.cc
@@ -35,8 +35,7 @@
 HIP_TEST_CASE(Unit_hipMemcpyPeerAsync_Positive_Default) {
   const auto device_count = HipTest::getDeviceCount();
   if (device_count < 2) {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
-    return;
+    HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
   }
 
   const auto allocation_size = GENERATE(kPageSize / 2, kPageSize, kPageSize * 2);
@@ -106,8 +105,7 @@ HIP_TEST_CASE(Unit_hipMemcpyPeerAsync_Positive_Synchronization_Behavior) {
 
   const auto device_count = HipTest::getDeviceCount();
   if (device_count < 2) {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
-    return;
+    HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
   }
 
   const StreamGuard stream_guard(Streams::created);
@@ -155,8 +153,7 @@ HIP_TEST_CASE(Unit_hipMemcpyPeerAsync_Positive_Synchronization_Behavior) {
 HIP_TEST_CASE(Unit_hipMemcpyPeerAsync_Positive_ZeroSize) {
   const auto device_count = HipTest::getDeviceCount();
   if (device_count < 2) {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
-    return;
+    HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
   }
 
   const StreamGuard stream_guard(Streams::created);
@@ -240,8 +237,7 @@ HIP_TEST_CASE(Unit_hipMemcpyPeerAsync_Positive_ZeroSize) {
 HIP_TEST_CASE(Unit_hipMemcpyPeerAsync_Negative_Parameters) {
   const auto device_count = HipTest::getDeviceCount();
   if (device_count < 2) {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
-    return;
+    HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
   }
 
   const StreamGuard stream_guard(Streams::created);
@@ -300,8 +296,7 @@ HIP_TEST_CASE(Unit_hipMemcpyPeerAsync_Negative_Parameters) {
 HIP_TEST_CASE(Unit_hipMemcpyPeerAsync_Capture) {
   const int device_count = HipTest::getDeviceCount();
   if (device_count < 2) {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
-    return;
+    HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
   }
 
   hipStream_t stream = nullptr;

--- a/projects/hip-tests/catch/unit/memory/hipMemcpyPeerAsync_old.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemcpyPeerAsync_old.cc
@@ -77,10 +77,9 @@ HIP_TEST_CASE(Unit_hipMemcpyPeerAsync_StreamOnDiffDevice) {
       HipTest::freeArrays<int>(X_d, Y_d, Z_d, nullptr, nullptr, nullptr, false);
       HIP_CHECK(hipStreamDestroy(stream));
     } else {
-      HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kPeerAccessUnavailable);
+      HIP_SKIP_TEST(HipTest::SkipReason::kPeerAccessUnavailable);
     }
   } else {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
-    return;
+    HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
   }
 }

--- a/projects/hip-tests/catch/unit/memory/hipMemcpySync.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemcpySync.cc
@@ -163,9 +163,8 @@ static void runMemcpyTests(hipStream_t stream, bool async, allocType type, memTy
 
 HIP_TEST_CASE(Unit_hipMemcpySync) {
 #if HT_AMD  // To be removed when EXSWCPHIPT-127 is fixed
-  HipTest::HIP_SKIP_TEST(
+  HIP_SKIP_TEST(
       "tracked issue EXSWCPHIPT-127 (sync behaviour differs on AMD and NVIDIA).");
-  return;
 #endif
   allocType type = GENERATE(allocType::deviceMalloc, allocType::hostMalloc, allocType::hostRegisted,
                             allocType::devRegistered);
@@ -178,9 +177,8 @@ HIP_TEST_CASE(Unit_hipMemcpySync) {
 
 HIP_TEST_CASE(Unit_hipMemcpy2DSync) {
 #if HT_AMD
-  HipTest::HIP_SKIP_TEST(
+  HIP_SKIP_TEST(
       "tracked issue EXSWCPHIPT-127 (sync behaviour differs on AMD and NVIDIA).");
-  return;
 #endif
   allocType mallocType = GENERATE(allocType::deviceMalloc, allocType::hostMalloc,
                                   allocType::hostRegisted, allocType::devRegistered);
@@ -195,9 +193,8 @@ HIP_TEST_CASE(Unit_hipMemcpy2DSync) {
 
 HIP_TEST_CASE(Unit_hipMemcpy3DSync) {
 #if HT_AMD
-  HipTest::HIP_SKIP_TEST(
+  HIP_SKIP_TEST(
       "tracked issue EXSWCPHIPT-127 (sync behaviour differs on AMD and NVIDIA).");
-  return;
 #endif
   allocType mallocType = GENERATE(allocType::deviceMalloc, allocType::hostMalloc,
                                   allocType::hostRegisted, allocType::devRegistered);

--- a/projects/hip-tests/catch/unit/memory/hipMemcpyWithStream_old.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemcpyWithStream_old.cc
@@ -179,8 +179,7 @@ void TestOnMultiGPUwithOneStream(void) {
   HIP_CHECK(hipGetDeviceCount(&NumDevices));
   // If you have single GPU machine the return
   if (NumDevices <= 1) {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
-    return;
+    HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
   }
   unsigned blocks = HipTest::setNumBlocks(blocksPerCU, threadsPerBlock, N);
   int *A_d[MaxGPUDevices], *B_d[MaxGPUDevices], *C_d[MaxGPUDevices];
@@ -258,8 +257,7 @@ void TestkindDtoD(void) {
   HIP_CHECK(hipGetDeviceCount(&NumDevices));
   // If you have single GPU machine the return
   if (NumDevices <= 1) {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
-    return;
+    HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
   }
   int *A_d[MaxGPUDevices], *B_d[MaxGPUDevices], *C_d[MaxGPUDevices];
   int *A_h[MaxGPUDevices], *B_h[MaxGPUDevices], *C_h[MaxGPUDevices];
@@ -365,8 +363,7 @@ void TestkindDefaultForDtoD(void) {
   HIP_CHECK(hipGetDeviceCount(&NumDevices));
   // Test case will not run on single GPU setup.
   if (NumDevices <= 1) {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
-    return;
+    HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
   }
   int *A_d[MaxGPUDevices], *B_d[MaxGPUDevices], *C_d[MaxGPUDevices];
   int *A_h[MaxGPUDevices], *B_h[MaxGPUDevices], *C_h[MaxGPUDevices];

--- a/projects/hip-tests/catch/unit/memory/hipMemcpy_EdgeCases.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemcpy_EdgeCases.cc
@@ -492,8 +492,7 @@ HIP_TEMPLATE_TEST_CASE(Unit_hipMemcpy_PinnedRegMemWithKernelLaunch,
   int numDevices = 0;
   HIP_CHECK(hipGetDeviceCount(&numDevices));
   if (numDevices < 2) {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
-    return;
+    HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
   }
   {
     // 1 refers to pinned Memory

--- a/projects/hip-tests/catch/unit/memory/hipMemcpy_derivatives.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemcpy_derivatives.cc
@@ -78,9 +78,8 @@ HIP_TEST_CASE(Unit_hipMemcpyDtoD_Positive_Synchronization_Behavior) {
   // This behavior differs on NVIDIA and AMD, on AMD the hipMemcpy calls is synchronous with
   // respect to the host
 #if HT_AMD
-  HipTest::HIP_SKIP_TEST(
+  HIP_SKIP_TEST(
       "EXSWCPHIPT-127 - Memcpy from device to device memory behavior differs on AMD and Nvidia");
-  return;
 #endif
   MemcpyDtoDSyncBehavior(
       [](void* dst, void* src, size_t count) {

--- a/projects/hip-tests/catch/unit/memory/hipMemsetAsync.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemsetAsync.cc
@@ -104,8 +104,7 @@ HIP_TEMPLATE_TEST_CASE(Unit_hipMemsetDASyncMulti, int8_t, int16_t, uint32_t) {
  */
 HIP_TEST_CASE(Unit_hipMemset2DASyncMulti) {
 #if HT_AMD
-  HipTest::HIP_SKIP_TEST("tracked issue EXSWCPHIPT-127.");
-  return;
+  HIP_SKIP_TEST("tracked issue EXSWCPHIPT-127.");
 #endif
   allocType mallocType = GENERATE(allocType::deviceMalloc, allocType::hostMalloc,
                                   allocType::hostRegisted, allocType::devRegistered);
@@ -126,8 +125,7 @@ HIP_TEST_CASE(Unit_hipMemset2DASyncMulti) {
  */
 HIP_TEST_CASE(Unit_hipMemset3DASyncMulti) {
 #if HT_AMD
-  HipTest::HIP_SKIP_TEST("tracked issue EXSWCPHIPT-127.");
-  return;
+  HIP_SKIP_TEST("tracked issue EXSWCPHIPT-127.");
 #endif
   allocType mallocType = GENERATE(allocType::deviceMalloc, allocType::hostMalloc,
                                   allocType::hostRegisted, allocType::devRegistered);

--- a/projects/hip-tests/catch/unit/memory/hipPointerGetAttribute.cc
+++ b/projects/hip-tests/catch/unit/memory/hipPointerGetAttribute.cc
@@ -37,8 +37,7 @@ behaviour
   hipDeviceAttribute_t attr = hipDeviceAttributeVirtualMemoryManagementSupported;                \
   HIP_CHECK(hipDeviceGetAttribute(&value, attr, device));                                        \
   if (value == 0) {                                                                              \
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kVmmUnsupported);                                  \
-    return;                                                                                      \
+    HIP_SKIP_TEST(HipTest::SkipReason::kVmmUnsupported);                                         \
   }                                                                                              \
 }
 
@@ -161,12 +160,11 @@ HIP_TEST_CASE(Unit_hipPointerGetAttribute_PeerGPU) {
                                        reinterpret_cast<hipDeviceptr_t>(A_d)));
       REQUIRE(data == 0);
     } else {
-      HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kPeerAccessUnavailable);
+      HIP_SKIP_TEST(HipTest::SkipReason::kPeerAccessUnavailable);
     }
   } else {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
     HIP_CHECK(hipFree(A_d));
-    return;
+    HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
   }
   HIP_CHECK(hipFree(A_d));
 }

--- a/projects/hip-tests/catch/unit/memory/hipSVMTestByteGranularity.cpp
+++ b/projects/hip-tests/catch/unit/memory/hipSVMTestByteGranularity.cpp
@@ -76,8 +76,7 @@ HIP_TEST_CASE(Unit_svm_byte_granularity) {
   int pcieAtomic = 0;
   HIP_CHECK(hipDeviceGetAttribute(&pcieAtomic, hipDeviceAttributeHostNativeAtomicSupported, 0));
   if (!pcieAtomic) {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kPcieAtomicUnsupported);
-    return;
+    HIP_SKIP_TEST(HipTest::SkipReason::kPcieAtomicUnsupported);
   }
   const int num_elements = 2048;
   int num_devices = 0;

--- a/projects/hip-tests/catch/unit/memory/hipSVMTestFineGrainMemoryConsistency.cpp
+++ b/projects/hip-tests/catch/unit/memory/hipSVMTestFineGrainMemoryConsistency.cpp
@@ -235,8 +235,7 @@ HIP_TEST_CASE(Unit_svm_fine_grain_memory_consistency) {
     int pcieAtomic = 0;
     HIP_CHECK(hipDeviceGetAttribute(&pcieAtomic, hipDeviceAttributeHostNativeAtomicSupported, id));
     if (!pcieAtomic) {
-      HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kPcieAtomicUnsupported);
-      return;
+      HIP_SKIP_TEST(HipTest::SkipReason::kPcieAtomicUnsupported);
     }
   }
   const int num_elements = 2167;

--- a/projects/hip-tests/catch/unit/memory/hipSVMTestFineGrainSyncBuffers.cpp
+++ b/projects/hip-tests/catch/unit/memory/hipSVMTestFineGrainSyncBuffers.cpp
@@ -75,8 +75,7 @@ HIP_TEST_CASE(Unit_svm_fine_grain_sync_buffers) {
   int pcieAtomic = 0;
   HIP_CHECK(hipDeviceGetAttribute(&pcieAtomic, hipDeviceAttributeHostNativeAtomicSupported, 0));
   if (!pcieAtomic) {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kPcieAtomicUnsupported);
-    return;
+    HIP_SKIP_TEST(HipTest::SkipReason::kPcieAtomicUnsupported);
   }
   size_t num_pixels = 1024 * 1024 * 2;
   hipStream_t stream;

--- a/projects/hip-tests/catch/unit/memory/hipSVMTestSharedAddressSpaceFineGrain.cpp
+++ b/projects/hip-tests/catch/unit/memory/hipSVMTestSharedAddressSpaceFineGrain.cpp
@@ -166,8 +166,7 @@ HIP_TEST_CASE(Unit_svm_shared_address_space_fine_grain_buffers) {
     int pcieAtomic = 0;
     HIP_CHECK(hipDeviceGetAttribute(&pcieAtomic, hipDeviceAttributeHostNativeAtomicSupported, id));
     if (!pcieAtomic) {
-      HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kPcieAtomicUnsupported);
-      return;
+      HIP_SKIP_TEST(HipTest::SkipReason::kPcieAtomicUnsupported);
     }
   }
 
@@ -254,16 +253,14 @@ HIP_TEST_CASE(Unit_svm_shared_address_space_fine_grain_system) {
     int pcieAtomic = 0;
     HIP_CHECK(hipDeviceGetAttribute(&pcieAtomic, hipDeviceAttributeHostNativeAtomicSupported, id));
     if (!pcieAtomic) {
-      HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kPcieAtomicUnsupported);
-      return;
+      HIP_SKIP_TEST(HipTest::SkipReason::kPcieAtomicUnsupported);
     }
 
     int pageableAccess = 0;
     // This need xnack+ on MiXXX. If xnack is off on MiXXX, try ENV HSA_XNACK=1
     HIP_CHECK(hipDeviceGetAttribute(&pageableAccess, hipDeviceAttributePageableMemoryAccess, id));
     if (!pageableAccess) {
-      HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kPageableMemoryAccessUnsupported);
-      return;
+      HIP_SKIP_TEST(HipTest::SkipReason::kPageableMemoryAccessUnsupported);
     }
   }
 

--- a/projects/hip-tests/catch/unit/memory/hipStreamAttachMemAsync.cc
+++ b/projects/hip-tests/catch/unit/memory/hipStreamAttachMemAsync.cc
@@ -12,8 +12,7 @@
 
 HIP_TEST_CASE(Unit_hipStreamAttachMemAsync_Positive_Basic) {
   if (!DeviceAttributesSupport(0, hipDeviceAttributeManagedMemory)) {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kManagedMemoryUnsupported);
-    return;
+    HIP_SKIP_TEST(HipTest::SkipReason::kManagedMemoryUnsupported);
   }
 
   StreamGuard stream(Streams::created);
@@ -26,13 +25,11 @@ HIP_TEST_CASE(Unit_hipStreamAttachMemAsync_Positive_Basic) {
 
 HIP_TEST_CASE(Unit_hipStreamAttachMemAsync_Positive_Pageable) {
   if (!DeviceAttributesSupport(0, hipDeviceAttributeManagedMemory)) {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kManagedMemoryUnsupported);
-    return;
+    HIP_SKIP_TEST(HipTest::SkipReason::kManagedMemoryUnsupported);
   }
 
   if (!DeviceAttributesSupport(0, hipDeviceAttributePageableMemoryAccess)) {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kPageableMemoryAccessUnsupported);
-    return;
+    HIP_SKIP_TEST(HipTest::SkipReason::kPageableMemoryAccessUnsupported);
   }
 
   StreamGuard stream(Streams::created);
@@ -47,8 +44,7 @@ HIP_TEST_CASE(Unit_hipStreamAttachMemAsync_Positive_Pageable) {
 // device.
 HIP_TEST_CASE(Unit_hipStreamAttachMemAsync_Positive_AttachGlobal) {
   if (!DeviceAttributesSupport(0, hipDeviceAttributeManagedMemory)) {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kManagedMemoryUnsupported);
-    return;
+    HIP_SKIP_TEST(HipTest::SkipReason::kManagedMemoryUnsupported);
   }
 
   const auto device_count = HipTest::getDeviceCount();
@@ -92,13 +88,11 @@ HIP_TEST_CASE(Unit_hipStreamAttachMemAsync_Positive_AttachGlobal) {
 // attribute cudaDevAttrConcurrentManagedAccess.
 HIP_TEST_CASE(Unit_hipStreamAttachMemAsync_Positive_AttachHost) {
   if (!DeviceAttributesSupport(0, hipDeviceAttributeManagedMemory)) {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kManagedMemoryUnsupported);
-    return;
+    HIP_SKIP_TEST(HipTest::SkipReason::kManagedMemoryUnsupported);
   }
 
   if (DeviceAttributesSupport(0, hipDeviceAttributeConcurrentManagedAccess)) {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kManagedNoConcurrentAccess);
-    return;
+    HIP_SKIP_TEST(HipTest::SkipReason::kManagedNoConcurrentAccess);
   }
 
   StreamGuard stream(Streams::created);
@@ -123,13 +117,11 @@ HIP_TEST_CASE(Unit_hipStreamAttachMemAsync_Positive_AttachHost) {
 // guarantee that it will only access the memory on the device from stream.
 HIP_TEST_CASE(Unit_hipStreamAttachMemAsync_Positive_AttachSingle) {
   if (!DeviceAttributesSupport(0, hipDeviceAttributeManagedMemory)) {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kManagedMemoryUnsupported);
-    return;
+    HIP_SKIP_TEST(HipTest::SkipReason::kManagedMemoryUnsupported);
   }
 
   if (DeviceAttributesSupport(0, hipDeviceAttributeConcurrentManagedAccess)) {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kManagedNoConcurrentAccess);
-    return;
+    HIP_SKIP_TEST(HipTest::SkipReason::kManagedNoConcurrentAccess);
   }
 
   StreamGuard stream1(Streams::created);
@@ -160,8 +152,7 @@ HIP_TEST_CASE(Unit_hipStreamAttachMemAsync_Positive_AttachSingle) {
 
 HIP_TEST_CASE(Unit_hipStreamAttachMemAsync_Negative_Parameters) {
   if (!DeviceAttributesSupport(0, hipDeviceAttributeManagedMemory)) {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kManagedMemoryUnsupported);
-    return;
+    HIP_SKIP_TEST(HipTest::SkipReason::kManagedMemoryUnsupported);
   }
 
   StreamGuard stream(Streams::created);

--- a/projects/hip-tests/catch/unit/memory/memcpy2d_tests_common.hh
+++ b/projects/hip-tests/catch/unit/memory/memcpy2d_tests_common.hh
@@ -61,8 +61,7 @@ void Memcpy2DDeviceToDeviceShell(F memcpy_func, const hipStream_t kernel_stream 
     int can_access_peer = 0;
     HIP_CHECK(hipDeviceCanAccessPeer(&can_access_peer, src_device, dst_device));
     if (!can_access_peer) {
-      HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kPeerAccessUnavailable);
-      return;
+      HIP_SKIP_TEST(HipTest::SkipReason::kPeerAccessUnavailable);
     }
   }
 

--- a/projects/hip-tests/catch/unit/memory/mempool_common.hh
+++ b/projects/hip-tests/catch/unit/memory/mempool_common.hh
@@ -19,21 +19,19 @@ namespace {
 constexpr auto wait_ms = 500;
 }  // anonymous namespace
 
-#define checkMempoolSupported(device) {\
-  int deviceSupportsMemoryPools = 0;\
-  HIP_CHECK(hipDeviceGetAttribute(&deviceSupportsMemoryPools,\
-        hipDeviceAttributeMemoryPoolsSupported, device));\
-  if (0 == deviceSupportsMemoryPools) {\
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kMemoryPoolUnsupported);\
-    return;\
-  }\
+#define checkMempoolSupported(device) {                                                            \
+  int deviceSupportsMemoryPools = 0;                                                               \
+  HIP_CHECK(hipDeviceGetAttribute(&deviceSupportsMemoryPools,                                      \
+        hipDeviceAttributeMemoryPoolsSupported, device));                                          \
+  if (0 == deviceSupportsMemoryPools) {                                                            \
+    HIP_SKIP_TEST(HipTest::SkipReason::kMemoryPoolUnsupported);                                    \
+  }                                                                                                \
 }
 
-#define checkIfMultiDev(numOfDev) {\
-  if (numOfDev < 2) {\
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);\
-    return;\
-  }\
+#define checkIfMultiDev(numOfDev) {                                                                \
+  if (numOfDev < 2) {                                                                              \
+    HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);                                         \
+  }                                                                                                \
 }
 
 template <typename T> __global__ void kernel_500ms(T* host_res, int clk_rate) {

--- a/projects/hip-tests/catch/unit/memory/mempool_common.hh
+++ b/projects/hip-tests/catch/unit/memory/mempool_common.hh
@@ -84,8 +84,7 @@ template <typename F> void MallocMemPoolAsync_OneAlloc(F malloc_func, const MemP
   int mem_pool_support = 0;
   HIP_CHECK(hipDeviceGetAttribute(&mem_pool_support, hipDeviceAttributeMemoryPoolsSupported, 0));
   if (!mem_pool_support) {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kMemoryPoolUnsupported);
-    return;
+    HIP_SKIP_TEST(HipTest::SkipReason::kMemoryPoolUnsupported);
   }
   unsigned int *notified = nullptr;
   HIP_CHECK(hipHostMalloc(&notified, sizeof(unsigned int)));
@@ -144,8 +143,7 @@ void MallocMemPoolAsync_TwoAllocs(F malloc_func, const MemPools mempool_type) {
   int mem_pool_support = 0;
   HIP_CHECK(hipDeviceGetAttribute(&mem_pool_support, hipDeviceAttributeMemoryPoolsSupported, 0));
   if (!mem_pool_support) {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kMemoryPoolUnsupported);
-    return;
+    HIP_SKIP_TEST(HipTest::SkipReason::kMemoryPoolUnsupported);
   }
   unsigned int *notified = nullptr;
   HIP_CHECK(hipHostMalloc(&notified, sizeof(unsigned int)));
@@ -224,8 +222,7 @@ template <typename F> void MallocMemPoolAsync_Reuse(F malloc_func, const MemPool
   int mem_pool_support = 0;
   HIP_CHECK(hipDeviceGetAttribute(&mem_pool_support, hipDeviceAttributeMemoryPoolsSupported, 0));
   if (!mem_pool_support) {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kMemoryPoolUnsupported);
-    return;
+    HIP_SKIP_TEST(HipTest::SkipReason::kMemoryPoolUnsupported);
   }
   unsigned int *notified = nullptr;
   HIP_CHECK(hipHostMalloc(&notified, sizeof(unsigned int)));

--- a/projects/hip-tests/catch/unit/module/hipDrvLaunchKernelEx.cc
+++ b/projects/hip-tests/catch/unit/module/hipDrvLaunchKernelEx.cc
@@ -36,8 +36,7 @@ static constexpr auto kernel_name = "cooperativeKernelEx";
  */
 HIP_TEST_CASE(Unit_hipDrvLaunchKernelEx_NegTsts) {
   if (!DeviceAttributesSupport(0, hipDeviceAttributeCooperativeLaunch)) {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kCooperativeLaunchUnsupported);
-    return;
+    HIP_SKIP_TEST(HipTest::SkipReason::kCooperativeLaunchUnsupported);
   }
   int totalThreads = 64;
   int blockSize = 16;
@@ -206,8 +205,7 @@ bool runTestDrvLaunch(const char* testName, std::string kernelFunc, int totalThr
  */
 HIP_TEST_CASE(Unit_hipDrvLaunchKernelEx_Functional) {
   if (!DeviceAttributesSupport(0, hipDeviceAttributeCooperativeLaunch)) {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kCooperativeLaunchUnsupported);
-    return;
+    HIP_SKIP_TEST(HipTest::SkipReason::kCooperativeLaunchUnsupported);
   }
   REQUIRE(runTestDrvLaunch("hipDrvLaunchKernelEx", kernel_name, 64, 16, 2222) == true);
 }
@@ -230,8 +228,7 @@ HIP_TEST_CASE(Unit_hipDrvLaunchKernelEx_Functional) {
 HIP_TEST_CASE(Unit_hipDrvLaunchKernelEx_With_Different_Kernels) {
   CTX_CREATE();
   if (!DeviceAttributesSupport(0, hipDeviceAttributeCooperativeLaunch)) {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kCooperativeLaunchUnsupported);
-    return;
+    HIP_SKIP_TEST(HipTest::SkipReason::kCooperativeLaunchUnsupported);
   }
 
   hipModule_t module;
@@ -310,8 +307,7 @@ HIP_TEST_CASE(Unit_hipDrvLaunchKernelEx_With_Different_Kernels) {
 HIP_TEST_CASE(Unit_hipDrvLaunchKernelEx_With_CooperativeKernelWithArgs) {
   CTX_CREATE();
   if (!DeviceAttributesSupport(0, hipDeviceAttributeCooperativeLaunch)) {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kCooperativeLaunchUnsupported);
-    return;
+    HIP_SKIP_TEST(HipTest::SkipReason::kCooperativeLaunchUnsupported);
   }
 
   hipModule_t module;
@@ -386,8 +382,7 @@ HIP_TEST_CASE(Unit_hipDrvLaunchKernelEx_With_CooperativeKernelWithArgs) {
 HIP_TEST_CASE(Unit_hipDrvLaunchKernelEx_With_MaxBlockDims) {
   CTX_CREATE();
   if (!DeviceAttributesSupport(0, hipDeviceAttributeCooperativeLaunch)) {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kCooperativeLaunchUnsupported);
-    return;
+    HIP_SKIP_TEST(HipTest::SkipReason::kCooperativeLaunchUnsupported);
   }
 
   hipModule_t module;

--- a/projects/hip-tests/catch/unit/module/hipExtModuleLaunchKernel.cc
+++ b/projects/hip-tests/catch/unit/module/hipExtModuleLaunchKernel.cc
@@ -106,8 +106,7 @@ HIP_TEST_CASE(Unit_hipExtModuleLaunchKernel_NonUniformWorkGroup) {
   // first check if uniform_work_group_size = 1.
   const std::regex regexp("uniform_work_group_size\\s*:\\s*1");
   if (false == searchRegExpr(regexp, "copyKernel.s")) {
-    HipTest::HIP_SKIP_TEST("test requires uniform work group size 1.");
-    return;
+    HIP_SKIP_TEST("test requires uniform work group size 1.");
   }
   REQUIRE(true == searchRegExpr(regexp, "copyKernel.s"));
   auto isEven = GENERATE(0, 1);

--- a/projects/hip-tests/catch/unit/module/hipGetFuncBySymbol.cc
+++ b/projects/hip-tests/catch/unit/module/hipGetFuncBySymbol.cc
@@ -198,8 +198,7 @@ HIP_TEST_CASE(Unit_hipGetFuncBySymbol_MultiDev) {
   int deviceCount = 0;
   HIP_CHECK(hipGetDeviceCount(&deviceCount));
   if (deviceCount < 2) {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
-    return;
+    HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
   }
 
   hipFunction_t funcPointer;
@@ -314,8 +313,7 @@ HIP_TEST_CASE(Unit_hipGetFuncBySymbol_MultiDevMultiThread) {
   int deviceCount = 0;
   HIP_CHECK(hipGetDeviceCount(&deviceCount));
   if (deviceCount < 2) {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
-    return;
+    HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
   }
 
   ::std::vector< ::std::thread> threads;

--- a/projects/hip-tests/catch/unit/module/hipGetProcAddressModuleApis.cc
+++ b/projects/hip-tests/catch/unit/module/hipGetProcAddressModuleApis.cc
@@ -317,8 +317,7 @@ HIP_TEST_CASE(Unit_hipGetProcAddress_ModuleApisLoadData) {
  */
 HIP_TEST_CASE(Unit_hipGetProcAddress_ModuleApisCooperativeKernels) {
   if (!DeviceAttributesSupport(0, hipDeviceAttributeCooperativeLaunch)) {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kCooperativeLaunchUnsupported);
-    return;
+    HIP_SKIP_TEST(HipTest::SkipReason::kCooperativeLaunchUnsupported);
   }
 
   HIP_CHECK(hipSetDevice(0));

--- a/projects/hip-tests/catch/unit/module/hipManagedKeywordBasic.cc
+++ b/projects/hip-tests/catch/unit/module/hipManagedKeywordBasic.cc
@@ -42,8 +42,7 @@ HIP_TEST_CASE(Unit_hipModuleGetGlobal_Functional) {
     int managed_memory = 0;
     HIPCHECK(hipDeviceGetAttribute(&managed_memory, hipDeviceAttributeManagedMemory, i));
     if (!managed_memory) {
-      HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kManagedMemoryUnsupported);
-      return;
+      HIP_SKIP_TEST(HipTest::SkipReason::kManagedMemoryUnsupported);
     }
   }
   for (int i = 0; i < numDevices; i++) {

--- a/projects/hip-tests/catch/unit/module/hipModuleGetFunction.cc
+++ b/projects/hip-tests/catch/unit/module/hipModuleGetFunction.cc
@@ -60,8 +60,7 @@ HIP_TEST_CASE(Unit_hipModuleGetFunction_DiffDevice) {
   int numDevices = 0;
   HIP_CHECK(hipGetDeviceCount(&numDevices));
   if (numDevices < 2) {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
-    return;
+    HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
   }
 
   auto mg = ModuleGuard::InitModule("get_function_module.code");

--- a/projects/hip-tests/catch/unit/module/hipModuleGetGlobal.cc
+++ b/projects/hip-tests/catch/unit/module/hipModuleGetGlobal.cc
@@ -137,8 +137,7 @@ HIP_TEST_CASE(Unit_hipModuleGetGlobal_DiffDevice) {
   int numDevices = 0;
   HIP_CHECK(hipGetDeviceCount(&numDevices));
   if (numDevices < 2) {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
-    return;
+    HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
   }
   auto module = GetModule();
   HIP_CHECK(hipSetDevice(1));

--- a/projects/hip-tests/catch/unit/module/hipModuleLaunchCooperativeKernel.cc
+++ b/projects/hip-tests/catch/unit/module/hipModuleLaunchCooperativeKernel.cc
@@ -36,8 +36,7 @@
 HIP_TEST_CASE(Unit_hipModuleLaunchCooperativeKernel_Positive_Basic) {
   auto mg = ModuleGuard::InitModule("launch_kernel_module.code");
   if (!DeviceAttributesSupport(0, hipDeviceAttributeCooperativeLaunch)) {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kCooperativeLaunchUnsupported);
-    return;
+    HIP_SKIP_TEST(HipTest::SkipReason::kCooperativeLaunchUnsupported);
   }
 
   SECTION("Cooperative kernel with no arguments") {
@@ -76,8 +75,7 @@ HIP_TEST_CASE(Unit_hipModuleLaunchCooperativeKernel_Positive_Basic) {
 HIP_TEST_CASE(Unit_hipModuleLaunchCooperativeKernel_Positive_Parameters) {
   auto mg = ModuleGuard::InitModule("launch_kernel_module.code");
   if (!DeviceAttributesSupport(0, hipDeviceAttributeCooperativeLaunch)) {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kCooperativeLaunchUnsupported);
-    return;
+    HIP_SKIP_TEST(HipTest::SkipReason::kCooperativeLaunchUnsupported);
   }
 
   hipFunction_t f = GetKernel(mg.module(), "NOPKernel");
@@ -112,8 +110,7 @@ HIP_TEST_CASE(Unit_hipModuleLaunchCooperativeKernel_Positive_Parameters) {
 HIP_TEST_CASE(Unit_hipModuleLaunchCooperativeKernel_Negative_Parameters) {
   auto mg = ModuleGuard::InitModule("launch_kernel_module.code");
   if (!DeviceAttributesSupport(0, hipDeviceAttributeCooperativeLaunch)) {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kCooperativeLaunchUnsupported);
-    return;
+    HIP_SKIP_TEST(HipTest::SkipReason::kCooperativeLaunchUnsupported);
   }
 
   hipFunction_t f = GetKernel(mg.module(), "NOPKernel");
@@ -210,8 +207,7 @@ HIP_TEST_CASE(Unit_hipModuleLaunchCooperativeKernel_Negative_Parameters) {
  */
 HIP_TEST_CASE(Unit_hipModuleLaunchCooperativeKernel_Verify_Capture) {
   if (!DeviceAttributesSupport(0, hipDeviceAttributeCooperativeLaunch)) {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kCooperativeLaunchUnsupported);
-    return;
+    HIP_SKIP_TEST(HipTest::SkipReason::kCooperativeLaunchUnsupported);
   }
 
   auto mg = ModuleGuard::InitModule("launch_kernel_module.code");

--- a/projects/hip-tests/catch/unit/module/hipModuleLaunchCooperativeKernelMultiDevice.cc
+++ b/projects/hip-tests/catch/unit/module/hipModuleLaunchCooperativeKernelMultiDevice.cc
@@ -35,8 +35,7 @@
 HIP_TEST_CASE(Unit_hipModuleLaunchCooperativeKernelMultiDevice_Positive_Basic) {
   auto mg = ModuleGuard::InitModule("launch_kernel_module.code");
   if (!DeviceAttributesSupport(0, hipDeviceAttributeCooperativeLaunch)) {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kCooperativeLaunchUnsupported);
-    return;
+    HIP_SKIP_TEST(HipTest::SkipReason::kCooperativeLaunchUnsupported);
   }
 
   const auto device_count = HipTest::getDeviceCount();
@@ -93,8 +92,7 @@ HIP_TEST_CASE(Unit_hipModuleLaunchCooperativeKernelMultiDevice_Positive_Basic) {
 HIP_TEST_CASE(Unit_hipModuleLaunchCooperativeKernelMultiDevice_Negative_Parameters) {
   auto mg = ModuleGuard::InitModule("launch_kernel_module.code");
   if (!DeviceAttributesSupport(0, hipDeviceAttributeCooperativeLaunch)) {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kCooperativeLaunchUnsupported);
-    return;
+    HIP_SKIP_TEST(HipTest::SkipReason::kCooperativeLaunchUnsupported);
   }
 
   const auto device_count = HipTest::getDeviceCount();
@@ -211,15 +209,13 @@ HIP_TEST_CASE(Unit_hipModuleLaunchCooperativeKernelMultiDevice_Negative_Paramete
 HIP_TEST_CASE(Unit_hipModuleLaunchCooperativeKernelMultiDevice_Negative_MultiKernelSameDevice) {
   auto mg = ModuleGuard::InitModule("launch_kernel_module.code");
   if (!DeviceAttributesSupport(0, hipDeviceAttributeCooperativeLaunch)) {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kCooperativeLaunchUnsupported);
-    return;
+    HIP_SKIP_TEST(HipTest::SkipReason::kCooperativeLaunchUnsupported);
   }
 
   int device_count;
   HIP_CHECK(hipGetDeviceCount(&device_count));
   if (device_count < 2) {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
-    return;
+    HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
   }
   std::vector<hipFunctionLaunchParams> params_list(device_count);
   std::vector<hipModule_t> modules_list(device_count);

--- a/projects/hip-tests/catch/unit/occupancy/hipOccupancyMaxPotentialBlockSizeVariableSMemWithFlags.cc
+++ b/projects/hip-tests/catch/unit/occupancy/hipOccupancyMaxPotentialBlockSizeVariableSMemWithFlags.cc
@@ -101,8 +101,7 @@ HIP_TEST_CASE(Unit_hipOccupancyMaxPotBlkSizeVariableSMemWithFlags_mgpu) {
   HIP_CHECK(hipGetDeviceCount(&devcount));
   // If only single GPU is detected then return
   if (devcount < 2) {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
-    return;
+    HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
   }
   // Get current device property
   for (int dev = 0; dev < devcount; dev++) {

--- a/projects/hip-tests/catch/unit/p2p/hipDeviceGetP2PAttribute.cc
+++ b/projects/hip-tests/catch/unit/p2p/hipDeviceGetP2PAttribute.cc
@@ -49,14 +49,12 @@
 
 HIP_TEST_CASE(Unit_hipDeviceGetP2PAttribute_Basic) {
 #if HT_AMD
-  HipTest::HIP_SKIP_TEST("tracked issue EXSWCPHIPT-119.");
-  return;
+  HIP_SKIP_TEST("tracked issue EXSWCPHIPT-119.");
 #else
 
   int deviceCount = HipTest::getGeviceCount();
   if (deviceCount < 2) {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
-    return;
+    HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
   }
 
   hipDeviceP2PAttr attribute =
@@ -109,14 +107,12 @@ HIP_TEST_CASE(Unit_hipDeviceGetP2PAttribute_Basic) {
 
 HIP_TEST_CASE(Unit_hipDeviceGetP2PAttribute_Negative) {
 #if HT_AMD
-  HipTest::HIP_SKIP_TEST("tracked issue EXSWCPHIPT-122.");
-  return;
+  HIP_SKIP_TEST("tracked issue EXSWCPHIPT-122.");
 #else
 
   int deviceCount = HipTest::getGeviceCount();
   if (deviceCount < 2) {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
-    return;
+    HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
   }
 
   int value;

--- a/projects/hip-tests/catch/unit/p2p/hipP2pLinkTypeAndHopFunc.cc
+++ b/projects/hip-tests/catch/unit/p2p/hipP2pLinkTypeAndHopFunc.cc
@@ -295,8 +295,7 @@ HIP_TEST_CASE(Unit_hipP2pLinkTypeAndHopFunc) {
   bool TestPassed = true;
   HIP_CHECK(hipGetDeviceCount(&numDevices));
   if (numDevices < 2) {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
-    return;
+    HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
   }
   SECTION("Test running for testhipInvalidDevice") {
     TestPassed = testhipInvalidDevice(numDevices);

--- a/projects/hip-tests/catch/unit/printf/hipPrintfAltForms.cc
+++ b/projects/hip-tests/catch/unit/printf/hipPrintfAltForms.cc
@@ -47,8 +47,7 @@ HIP_TEST_CASE(Unit_Printf_PrintfAltFormsTsts) {
   int pcieAtomic = 0;
   HIP_CHECK(hipDeviceGetAttribute(&pcieAtomic, hipDeviceAttributeHostNativeAtomicSupported, 0));
   if (!pcieAtomic) {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kPcieAtomicUnsupported);
-    return;
+    HIP_SKIP_TEST(HipTest::SkipReason::kPcieAtomicUnsupported);
   }
   std::string reference =
       std::string(R"here(042

--- a/projects/hip-tests/catch/unit/printf/hipPrintfBasic.cc
+++ b/projects/hip-tests/catch/unit/printf/hipPrintfBasic.cc
@@ -182,8 +182,7 @@ HIP_TEST_CASE(Unit_Printf_PrintfBasicTsts) {
   int pcieAtomic = 0;
   HIP_CHECK(hipDeviceGetAttribute(&pcieAtomic, hipDeviceAttributeHostNativeAtomicSupported, 0));
   if (!pcieAtomic) {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kPcieAtomicUnsupported);
-    return;
+    HIP_SKIP_TEST(HipTest::SkipReason::kPcieAtomicUnsupported);
   }
   uint num_blocks = 1;
   uint threads_per_block = 64;

--- a/projects/hip-tests/catch/unit/printf/hipPrintfManyDevices.cc
+++ b/projects/hip-tests/catch/unit/printf/hipPrintfManyDevices.cc
@@ -39,8 +39,7 @@ HIP_TEST_CASE(Unit_Printf_ManyDevicesTest) {
   int pcieAtomic = 0;
   HIP_CHECK(hipDeviceGetAttribute(&pcieAtomic, hipDeviceAttributeHostNativeAtomicSupported, 0));
   if (!pcieAtomic) {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kPcieAtomicUnsupported);
-    return;
+    HIP_SKIP_TEST(HipTest::SkipReason::kPcieAtomicUnsupported);
   }
   uint num_blocks = 14;
   uint threads_per_block = 250;

--- a/projects/hip-tests/catch/unit/printf/hipPrintfManyWaves.cc
+++ b/projects/hip-tests/catch/unit/printf/hipPrintfManyWaves.cc
@@ -226,8 +226,7 @@ HIP_TEST_CASE(Unit_Printf_PrintfManyWaves) {
   int pcieAtomic = 0;
   HIP_CHECK(hipDeviceGetAttribute(&pcieAtomic, hipDeviceAttributeHostNativeAtomicSupported, 0));
   if (!pcieAtomic) {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kPcieAtomicUnsupported);
-    return;
+    HIP_SKIP_TEST(HipTest::SkipReason::kPcieAtomicUnsupported);
   }
   uint num_blocks = 150;
   uint threads_per_block = 250;

--- a/projects/hip-tests/catch/unit/printf/hipPrintfStar.cc
+++ b/projects/hip-tests/catch/unit/printf/hipPrintfStar.cc
@@ -36,8 +36,7 @@ HIP_TEST_CASE(Unit_Printf_PrintfStar) {
   int pcieAtomic = 0;
   HIP_CHECK(hipDeviceGetAttribute(&pcieAtomic, hipDeviceAttributeHostNativeAtomicSupported, 0));
   if (!pcieAtomic) {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kPcieAtomicUnsupported);
-    return;
+    HIP_SKIP_TEST(HipTest::SkipReason::kPcieAtomicUnsupported);
   }
   std::string reference =
       std::string(R"here(              42

--- a/projects/hip-tests/catch/unit/printf/hipPrintfWidthPrecision.cc
+++ b/projects/hip-tests/catch/unit/printf/hipPrintfWidthPrecision.cc
@@ -46,8 +46,7 @@ HIP_TEST_CASE(Unit_Printf_PrintfWidthPrecision) {
   int pcieAtomic = 0;
   HIP_CHECK(hipDeviceGetAttribute(&pcieAtomic, hipDeviceAttributeHostNativeAtomicSupported, 0));
   if (!pcieAtomic) {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kPcieAtomicUnsupported);
-    return;
+    HIP_SKIP_TEST(HipTest::SkipReason::kPcieAtomicUnsupported);
   }
   std::string reference(R"here(              42
 00000042

--- a/projects/hip-tests/catch/unit/printf/printfFlags.cc
+++ b/projects/hip-tests/catch/unit/printf/printfFlags.cc
@@ -32,8 +32,7 @@ HIP_TEST_CASE(Unit_Printf_flags_Sanity_Positive) {
   int pcieAtomic = 0;
   HIP_CHECK(hipDeviceGetAttribute(&pcieAtomic, hipDeviceAttributeHostNativeAtomicSupported, 0));
   if (!pcieAtomic) {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kPcieAtomicUnsupported);
-    return;
+    HIP_SKIP_TEST(HipTest::SkipReason::kPcieAtomicUnsupported);
   }
   std::string reference =
       std::string(R"here(00000042

--- a/projects/hip-tests/catch/unit/printf/printfFlagsNonHost.cc
+++ b/projects/hip-tests/catch/unit/printf/printfFlagsNonHost.cc
@@ -33,8 +33,7 @@ HIP_TEST_CASE(Unit_Buffered_Printf_Flags) {
   int pcieAtomic = 0;
   HIP_CHECK(hipDeviceGetAttribute(&pcieAtomic, hipDeviceAttributeHostNativeAtomicSupported, 0));
   if (!pcieAtomic) {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kPcieAtomicUnsupported);
-    return;
+    HIP_SKIP_TEST(HipTest::SkipReason::kPcieAtomicUnsupported);
   }
   std::string reference =
       std::string(R"here(00000042

--- a/projects/hip-tests/catch/unit/printf/printfHost.cc
+++ b/projects/hip-tests/catch/unit/printf/printfHost.cc
@@ -31,8 +31,7 @@ HIP_TEST_CASE(Unit_Host_Printf) {
   int pcieAtomic = 0;
   HIP_CHECK(hipDeviceGetAttribute(&pcieAtomic, hipDeviceAttributeHostNativeAtomicSupported, 0));
   if (!pcieAtomic) {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kPcieAtomicUnsupported);
-    return;
+    HIP_SKIP_TEST(HipTest::SkipReason::kPcieAtomicUnsupported);
   }
   int *count{nullptr}, *count_d{nullptr};
   count = reinterpret_cast<int*>(malloc(sizeof(int)));

--- a/projects/hip-tests/catch/unit/printf/printfLength.cc
+++ b/projects/hip-tests/catch/unit/printf/printfLength.cc
@@ -31,8 +31,7 @@ HIP_TEST_CASE(Unit_Printf_length_Sanity_Positive) {
   int pcieAtomic = 0;
   HIP_CHECK(hipDeviceGetAttribute(&pcieAtomic, hipDeviceAttributeHostNativeAtomicSupported, 0));
   if (!pcieAtomic) {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kPcieAtomicUnsupported);
-    return;
+    HIP_SKIP_TEST(HipTest::SkipReason::kPcieAtomicUnsupported);
   }
 #if HT_NVIDIA
   std::string reference(R"here(-42 -42

--- a/projects/hip-tests/catch/unit/printf/printfNonHost.cc
+++ b/projects/hip-tests/catch/unit/printf/printfNonHost.cc
@@ -57,8 +57,7 @@ HIP_TEST_CASE(Unit_NonHost_Printf_basic) {
   int pcieAtomic = 0;
   HIP_CHECK(hipDeviceGetAttribute(&pcieAtomic, hipDeviceAttributeHostNativeAtomicSupported, 0));
   if (!pcieAtomic) {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kPcieAtomicUnsupported);
-    return;
+    HIP_SKIP_TEST(HipTest::SkipReason::kPcieAtomicUnsupported);
   }
   int *count{nullptr}, *count_d{nullptr};
 
@@ -92,8 +91,7 @@ HIP_TEST_CASE(Unit_NonHost_Printf_loop) {
   int pcieAtomic = 0;
   HIP_CHECK(hipDeviceGetAttribute(&pcieAtomic, hipDeviceAttributeHostNativeAtomicSupported, 0));
   if (!pcieAtomic) {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kPcieAtomicUnsupported);
-    return;
+    HIP_SKIP_TEST(HipTest::SkipReason::kPcieAtomicUnsupported);
   }
   int *count{nullptr}, *count_d{nullptr};
   count = reinterpret_cast<int*>(malloc(ITER_COUNT * sizeof(int)));
@@ -134,8 +132,7 @@ HIP_TEST_CASE(Unit_NonHost_Printf_multiple_Threads) {
   int pcieAtomic = 0;
   HIP_CHECK(hipDeviceGetAttribute(&pcieAtomic, hipDeviceAttributeHostNativeAtomicSupported, 0));
   if (!pcieAtomic) {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kPcieAtomicUnsupported);
-    return;
+    HIP_SKIP_TEST(HipTest::SkipReason::kPcieAtomicUnsupported);
   }
   int *count{nullptr}, *count_d{nullptr};
   fprintf(stderr, "VALID_COUNT=%d, ITER_COUNT_FOR_THREAD=%d\n", VALID_COUNT, ITER_COUNT_FOR_THREAD);
@@ -179,8 +176,7 @@ HIP_TEST_CASE(Unit_NonHost_Printf_BufferAvailability) {
   int pcieAtomic = 0;
   HIP_CHECK(hipDeviceGetAttribute(&pcieAtomic, hipDeviceAttributeHostNativeAtomicSupported, 0));
   if (!pcieAtomic) {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kPcieAtomicUnsupported);
-    return;
+    HIP_SKIP_TEST(HipTest::SkipReason::kPcieAtomicUnsupported);
   }
   int *count{nullptr}, *count_d{nullptr};
 

--- a/projects/hip-tests/catch/unit/printf/printfSpecifiers.cc
+++ b/projects/hip-tests/catch/unit/printf/printfSpecifiers.cc
@@ -34,8 +34,7 @@ HIP_TEST_CASE(Unit_Printf_specifier_Sanity_Positive) {
   int pcieAtomic = 0;
   HIP_CHECK(hipDeviceGetAttribute(&pcieAtomic, hipDeviceAttributeHostNativeAtomicSupported, 0));
   if (!pcieAtomic) {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kPcieAtomicUnsupported);
-    return;
+    HIP_SKIP_TEST(HipTest::SkipReason::kPcieAtomicUnsupported);
   }
 #if HT_NVIDIA
   std::string reference(R"here(xyzzy
@@ -140,8 +139,7 @@ HIP_TEST_CASE(Unit_Printf_Negative_Parameters_RTC) {
   int pcieAtomic = 0;
   HIP_CHECK(hipDeviceGetAttribute(&pcieAtomic, hipDeviceAttributeHostNativeAtomicSupported, 0));
   if (!pcieAtomic) {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kPcieAtomicUnsupported);
-    return;
+    HIP_SKIP_TEST(HipTest::SkipReason::kPcieAtomicUnsupported);
   }
   hiprtcProgram program{};
 

--- a/projects/hip-tests/catch/unit/printf/printfSpecifiersNonHost.cc
+++ b/projects/hip-tests/catch/unit/printf/printfSpecifiersNonHost.cc
@@ -33,8 +33,7 @@ HIP_TEST_CASE(Unit_Buffered_Printf_Specifier) {
   int pcieAtomic = 0;
   HIP_CHECK(hipDeviceGetAttribute(&pcieAtomic, hipDeviceAttributeHostNativeAtomicSupported, 0));
   if (!pcieAtomic) {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kPcieAtomicUnsupported);
-    return;
+    HIP_SKIP_TEST(HipTest::SkipReason::kPcieAtomicUnsupported);
   }
 #ifdef __HIP_PLATFORM_NVIDIA__
   std::string reference(R"here(xyzzy

--- a/projects/hip-tests/catch/unit/rtc/hipRTCDeviceMalloc.cc
+++ b/projects/hip-tests/catch/unit/rtc/hipRTCDeviceMalloc.cc
@@ -40,8 +40,7 @@ HIP_TEST_CASE(Unit_hiprtc_devicemalloc) {
   int pcieAtomic = 0;
   HIP_CHECK(hipDeviceGetAttribute(&pcieAtomic, hipDeviceAttributeHostNativeAtomicSupported, 0));
   if (!pcieAtomic) {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kPcieAtomicUnsupported);
-    return;
+    HIP_SKIP_TEST(HipTest::SkipReason::kPcieAtomicUnsupported);
   }
 
   using namespace std;

--- a/projects/hip-tests/catch/unit/stream/hipLaunchHostFunc.cc
+++ b/projects/hip-tests/catch/unit/stream/hipLaunchHostFunc.cc
@@ -304,8 +304,7 @@ HIP_TEST_CASE(Unit_hipLaunchHostFunc_multidevice) {
   int num_devices;
   HIP_CHECK(hipGetDeviceCount(&num_devices));
   if (num_devices < 2) {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
-    return;
+    HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
   }
   usrDataS* usrDataptr = reinterpret_cast<usrDataS*>(malloc(sizeof(usrDataS)));
   REQUIRE(usrDataptr != nullptr);

--- a/projects/hip-tests/catch/unit/stream/hipMultiStream.cc
+++ b/projects/hip-tests/catch/unit/stream/hipMultiStream.cc
@@ -57,8 +57,7 @@ HIP_TEST_CASE(Unit_hipMultiStream_multimeDevice) {
   int nGpu = 0;
   HIP_CHECK(hipGetDeviceCount(&nGpu));
   if (nGpu < 1) {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kNoGpuDevice);
-    return;
+    HIP_SKIP_TEST(HipTest::SkipReason::kNoGpuDevice);
   }
   static int device = 0;
   HIP_CHECK(hipSetDevice(device));

--- a/projects/hip-tests/catch/unit/stream/hipStreamGetCUMask.cc
+++ b/projects/hip-tests/catch/unit/stream/hipStreamGetCUMask.cc
@@ -32,8 +32,7 @@ HIP_TEST_CASE(Unit_hipExtStreamGetCUMask_verifyDefaultAndCustomMask) {
   int nGpu = 0;
   HIP_CHECK(hipGetDeviceCount(&nGpu));
   if (nGpu < 1) {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kNoGpuDevice);
-    return;
+    HIP_SKIP_TEST(HipTest::SkipReason::kNoGpuDevice);
   }
 
   HIP_CHECK(hipSetDevice(0));

--- a/projects/hip-tests/catch/unit/stream/hipStreamGetDevice.cc
+++ b/projects/hip-tests/catch/unit/stream/hipStreamGetDevice.cc
@@ -178,8 +178,7 @@ HIP_TEST_CASE(Unit_hipStreamGetDevice_SetDiffDevice) {
   int device_count = 0;
   HIP_CHECK(hipGetDeviceCount(&device_count));
   if (device_count < 2) {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
-    return;
+    HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
   }
   for (int i = 0; i < device_count; ++i) {
     HIP_CHECK(hipSetDevice(i));

--- a/projects/hip-tests/catch/unit/stream/hipStreamGetId.cc
+++ b/projects/hip-tests/catch/unit/stream/hipStreamGetId.cc
@@ -183,8 +183,7 @@ HIP_TEST_CASE(Unit_hipStreamGetId_MultiDevice) {
   int deviceCount = 0;
   HIP_CHECK(hipGetDeviceCount(&deviceCount));
   if (deviceCount < 2) {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
-    return;
+    HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
   }
 
   std::vector<unsigned long long> streamIds;

--- a/projects/hip-tests/catch/unit/stream/hipStreamLegacy_Ext.cc
+++ b/projects/hip-tests/catch/unit/stream/hipStreamLegacy_Ext.cc
@@ -286,8 +286,7 @@ HIP_TEST_CASE(Unit_hipStreamLegacy_MultiDevice) {
   int deviceCount = 0;
   HIP_CHECK(hipGetDeviceCount(&deviceCount));
   if (deviceCount < 2) {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
-    return;
+    HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
   }
 
   for (int deviceId = 0; deviceId < deviceCount; deviceId++) {
@@ -409,8 +408,7 @@ HIP_TEST_CASE(Unit_hipStreamLegacy_MultiDeviceMultiOperation) {
   int deviceCount = 0;
   HIP_CHECK(hipGetDeviceCount(&deviceCount));
   if (deviceCount < 2) {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
-    return;
+    HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
   }
 
   int currentDevice = 0;
@@ -531,8 +529,7 @@ HIP_TEST_CASE(Unit_hipStreamLegacy_TwoThreadsEachOneDiffOperation) {
   const unsigned int threadsSupported = std::thread::hardware_concurrency();
 
   if (threadsSupported < 2) {
-    HipTest::HIP_SKIP_TEST("machine does not support two concurrent hardware threads.");
-    return;
+    HIP_SKIP_TEST("machine does not support two concurrent hardware threads.");
   }
 
   int* hostArrSrc = new int[N];
@@ -583,8 +580,7 @@ HIP_TEST_CASE(Unit_hipStreamLegacy_TwoDevicesEachOneDiffOperation) {
   int deviceCount = 0;
   HIP_CHECK(hipGetDeviceCount(&deviceCount));
   if (deviceCount < 2) {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
-    return;
+    HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
   }
 
   // Set arrays in device 0
@@ -668,8 +664,7 @@ HIP_TEST_CASE(Unit_hipStreamLegacy_TwoThreadsInTwoDevicesEachOneDiffOperation) {
   int deviceCount = 0;
   HIP_CHECK(hipGetDeviceCount(&deviceCount));
   if (deviceCount < 2) {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
-    return;
+    HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
   }
 
   // Set arrays in device 0

--- a/projects/hip-tests/catch/unit/stream/hipStreamLegacy_compiler_options.cc
+++ b/projects/hip-tests/catch/unit/stream/hipStreamLegacy_compiler_options.cc
@@ -99,10 +99,7 @@ HIP_TEST_CASE(Unit_hipStreamLegacy_TwoThreadsDiffOperationWithSptCompOption) {
   const unsigned int threadsSupported = std::thread::hardware_concurrency();
 
   if (threadsSupported < 2) {
-    HipTest::HIP_SKIP_TEST(
-        "Skipping due to machine does't "
-        "support two concurrent threads");
-    return;
+    HIP_SKIP_TEST("Skipping due to machine doesn't support two concurrent threads");
   }
 
   int* hostArrSrc = new int[N];

--- a/projects/hip-tests/catch/unit/stream/hipStreamSynchronize.cc
+++ b/projects/hip-tests/catch/unit/stream/hipStreamSynchronize.cc
@@ -88,7 +88,7 @@ HIP_TEST_CASE(Unit_hipStreamSynchronize_NullStreamSynchronization) {
  */
 HIP_TEST_CASE(Unit_hipStreamSynchronize_SynchronizeStreamAndQueryNullStream) {
 #if HT_AMD
-  HipTest::HIP_SKIP_TEST("tracked issue EXSWCPHIPT-22.");
+  HIP_SKIP_TEST("tracked issue EXSWCPHIPT-22.");
 #else
 
   hipStream_t stream1;

--- a/projects/hip-tests/catch/unit/stream/hipStreamValue.cc
+++ b/projects/hip-tests/catch/unit/stream/hipStreamValue.cc
@@ -71,7 +71,6 @@ bool streamWaitValueSupported() {
     auto getAttributeError = hipDeviceGetAttribute(
         &waitValueSupport, hipDeviceAttributeCanUseStreamWaitValue, device_id);
     if (getAttributeError != hipSuccess) {
-      HipTest::HIP_SKIP_TEST("required stream attribute is not supported.");
       return false;
     }
     if (waitValueSupport == 1) return true;
@@ -237,8 +236,7 @@ HIP_TEMPLATE_TEST_CASE(Unit_hipStreamValue_Write, (TestParams<uint32_t, PtrType:
                    (TestParams<uint64_t, PtrType::DevicePtrToHost>)) {
 #endif
   if (!streamWaitValueSupported()) {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kStreamWaitValueUnsupported);
-    return;
+    HIP_SKIP_TEST(HipTest::SkipReason::kStreamWaitValueUnsupported);
   }
 
   using UIntT = typename TestType::UIntType;
@@ -289,8 +287,7 @@ void syncAndCheckData(hipStream_t stream, UIntT* dataPtr, TestPtr signalPtr, siz
 template <typename TestType, bool isBlocking>
 void testWait(TEST_WAIT<typename TestType::UIntType> tc) {
   if (!streamWaitValueSupported()) {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kStreamWaitValueUnsupported);
-    return;
+    HIP_SKIP_TEST(HipTest::SkipReason::kStreamWaitValueUnsupported);
   }
   using UIntT = typename TestType::UIntType;
   constexpr auto ptrType = TestType::ptrType;
@@ -345,8 +342,7 @@ void testWait(TEST_WAIT<typename TestType::UIntType> tc) {
 // Combined blocking test case for both uint32_t and uint64_t
 HIP_TEMPLATE_TEST_CASE(Unit_hipStreamValue_Wait_Blocking, uint32_t, uint64_t) {
   if (!streamWaitValueSupported()) {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kStreamWaitValueUnsupported);
-    return;
+    HIP_SKIP_TEST(HipTest::SkipReason::kStreamWaitValueUnsupported);
   }
 
   using UIntT = TestType;
@@ -556,8 +552,7 @@ HIP_TEMPLATE_TEST_CASE(Unit_hipStreamValue_Wait_Blocking, uint32_t, uint64_t) {
 // Negative Tests
 HIP_TEST_CASE(Unit_hipStreamValue_Negative_InvalidMemory) {
   if (!streamWaitValueSupported()) {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kStreamWaitValueUnsupported);
-    return;
+    HIP_SKIP_TEST(HipTest::SkipReason::kStreamWaitValueUnsupported);
   }
 
   hipStream_t stream{nullptr};
@@ -588,8 +583,7 @@ HIP_TEST_CASE(Unit_hipStreamValue_Negative_InvalidMemory) {
 // Merge the two similar negative tests
 HIP_TEMPLATE_TEST_CASE(Unit_hipStreamValue_Negative_StreamAndFlag, uint32_t, uint64_t) {
   if (!streamWaitValueSupported()) {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kStreamWaitValueUnsupported);
-    return;
+    HIP_SKIP_TEST(HipTest::SkipReason::kStreamWaitValueUnsupported);
   }
 
   SECTION("Invalid Stream handle") {
@@ -643,8 +637,7 @@ HIP_TEMPLATE_TEST_CASE(Unit_hipStreamValue_Negative_StreamAndFlag, uint32_t, uin
 
 HIP_TEMPLATE_TEST_CASE(Unit_hipStreamWriteValue_Default, uint32_t, uint64_t) {
   if (!streamWaitValueSupported()) {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kStreamWaitValueUnsupported);
-    return;
+    HIP_SKIP_TEST(HipTest::SkipReason::kStreamWaitValueUnsupported);
   }
 
   hipStream_t stream{nullptr};
@@ -816,8 +809,7 @@ template <typename T> __global__ void add(T* a, T* b, T* c, size_t size) {
 
 HIP_TEMPLATE_TEST_CASE(Unit_hipStreamWaitValue_Default, uint32_t, uint64_t) {
   if (!streamWaitValueSupported()) {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kStreamWaitValueUnsupported);
-    return;
+    HIP_SKIP_TEST(HipTest::SkipReason::kStreamWaitValueUnsupported);
   }
 
   auto size = GENERATE(as<size_t>{}, 100, 500, 1000);

--- a/projects/hip-tests/catch/unit/stream/hipStreamValue.cc
+++ b/projects/hip-tests/catch/unit/stream/hipStreamValue.cc
@@ -662,8 +662,7 @@ HIP_TEMPLATE_TEST_CASE(Unit_hipStreamWriteValue_Default, uint32_t, uint64_t) {
 
 TEMPLATE_TEST_CASE("Unit_hipStreamWriteValue_Increment_Default", "", uint32_t, uint64_t) {
   if (!streamWaitValueSupported()) {
-    HipTest::HIP_SKIP_TEST("hipStreamWriteValue not supported on this device.");
-    return;
+    HIP_SKIP_TEST("hipStreamWriteValue not supported on this device.");
   }
 
   hipStream_t stream{nullptr};
@@ -688,8 +687,7 @@ TEMPLATE_TEST_CASE("Unit_hipStreamWriteValue_Increment_Default", "", uint32_t, u
 
 TEMPLATE_TEST_CASE("Unit_hipStreamWriteValue_Decrement_Default", "", uint32_t, uint64_t) {
   if (!streamWaitValueSupported()) {
-    HipTest::HIP_SKIP_TEST("hipStreamWriteValue not supported on this device.");
-    return;
+    HIP_SKIP_TEST("hipStreamWriteValue not supported on this device.");
   }
 
   hipStream_t stream{nullptr};
@@ -714,8 +712,7 @@ TEMPLATE_TEST_CASE("Unit_hipStreamWriteValue_Decrement_Default", "", uint32_t, u
 template <typename TestType>
 void testIncrementDecrementMultiStreamMultiDevice(uint32_t operationFlag) {
   if (!streamWaitValueSupported()) {
-    HipTest::HIP_SKIP_TEST("hipStreamWriteValue not supported on this device.");
-    return;
+    HIP_SKIP_TEST("hipStreamWriteValue not supported on this device.");
   }
 
   constexpr size_t streams_per_device = 2;

--- a/projects/hip-tests/catch/unit/stream/hipStreamWithCUMask.cc
+++ b/projects/hip-tests/catch/unit/stream/hipStreamWithCUMask.cc
@@ -169,8 +169,7 @@ HIP_TEST_CASE(Unit_hipExtStreamCreateWithCUMask_Functionality) {
   int nGpu = 0;
   HIP_CHECK(hipGetDeviceCount(&nGpu));
   if (nGpu < 1) {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kNoGpuDevice);
-    return;
+    HIP_SKIP_TEST(HipTest::SkipReason::kNoGpuDevice);
   }
 
   static int device = 0;

--- a/projects/hip-tests/catch/unit/streamperthread/hipGetProcAddressSptApis.cc
+++ b/projects/hip-tests/catch/unit/streamperthread/hipGetProcAddressSptApis.cc
@@ -2505,8 +2505,7 @@ HIP_TEST_CASE(Unit_hipGetProcAddress_spt_LaunchCooperativeKernel) {
   HIP_CHECK(hipGetDeviceProperties(&device_properties, 0));
 
   if (!device_properties.cooperativeLaunch) {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kCooperativeLaunchUnsupported);
-    return;
+    HIP_SKIP_TEST(HipTest::SkipReason::kCooperativeLaunchUnsupported);
   }
 
   void* hipLaunchCooperativeKernel_spt_ptr = nullptr;

--- a/projects/hip-tests/catch/unit/streamperthread/hipStreamPerThrdCompilerOptn.cc
+++ b/projects/hip-tests/catch/unit/streamperthread/hipStreamPerThrdCompilerOptn.cc
@@ -274,8 +274,7 @@ void DefaultPT2_StrmWaitEvent() {
   int device;
   HIP_CHECK(hipGetDevice(&device));
   if (!DeviceAttributesSupport(device, hipDeviceAttributeManagedMemory)) {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kManagedMemoryUnsupported);
-    return;
+    HIP_SKIP_TEST(HipTest::SkipReason::kManagedMemoryUnsupported);
   }
 
   hipEvent_t evt;

--- a/projects/hip-tests/catch/unit/streamperthread/hipStreamPerThrdTsts.cc
+++ b/projects/hip-tests/catch/unit/streamperthread/hipStreamPerThrdTsts.cc
@@ -332,7 +332,7 @@ HIP_TEST_CASE(Unit_hipStreamPerThread_MangdMem) {
       REQUIRE(false);
     }
   } else {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kManagedMemoryUnsupported);
+    HIP_SKIP_TEST(HipTest::SkipReason::kManagedMemoryUnsupported);
   }
 }
 
@@ -472,7 +472,7 @@ HIP_TEST_CASE(Unit_hipStreamPerThread_CoopLaunch) {
   HIPCHECK(hipGetDeviceProperties(&device_properties, 0));
   /* Test whether target device supports cooperative groups ****************/
   if (device_properties.cooperativeLaunch == 0) {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kCooperativeLaunchUnsupported);
+    HIP_SKIP_TEST(HipTest::SkipReason::kCooperativeLaunchUnsupported);
   } else {
     /* We will launch enough waves to fill up all of the GPU *****************/
     int warp_size = device_properties.warpSize;

--- a/projects/hip-tests/catch/unit/synchronization/cache_coherency_cpu_gpu.cc
+++ b/projects/hip-tests/catch/unit/synchronization/cache_coherency_cpu_gpu.cc
@@ -243,7 +243,7 @@ static bool cpu_to_gpu_coherency() {
  */
 
 HIP_TEST_CASE(Unit_cache_coherency_cpu_gpu) {
-  bool passed = true;
   // Coherency between CPU and GPU sharing host and device memory.
-  REQUIRE(passed == cpu_to_gpu_coherency());
+  bool result = cpu_to_gpu_coherency();
+  REQUIRE(result);
 }

--- a/projects/hip-tests/catch/unit/synchronization/cache_coherency_cpu_gpu.cc
+++ b/projects/hip-tests/catch/unit/synchronization/cache_coherency_cpu_gpu.cc
@@ -113,15 +113,13 @@ static bool cpu_to_gpu_coherency() {
 
   HIP_CHECK(hipGetDeviceCount(&numDevices));
   if (numDevices < 1) {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kNoGpuDevice);
-    return true;
+    HIP_SKIP_TEST(HipTest::SkipReason::kNoGpuDevice);
   }
 
   SECTION("With device fine grained buffer") {
     HIP_CHECK(hipDeviceGetAttribute(&deviceFineGrain, hipDeviceAttributeFineGrainSupport, 0));
     if (deviceFineGrain == 0) {
-      HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kFineGrainHwUnsupported);
-      return true;
+      HIP_SKIP_TEST(HipTest::SkipReason::kFineGrainHwUnsupported);
     }
     fprintf(stderr, "info: allocate device mem (%zu bytes) on device 0\n", Nbytes);
     HIP_CHECK(

--- a/projects/hip-tests/catch/unit/synchronization/cache_coherency_gpu_gpu.cc
+++ b/projects/hip-tests/catch/unit/synchronization/cache_coherency_gpu_gpu.cc
@@ -99,19 +99,16 @@ static bool gpu_to_gpu_coherency() {
 
   HIP_CHECK(hipGetDeviceCount(&numDevices));
   if (numDevices < numTestDevices) {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
-    return true;
+    HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
   }
   SECTION("With device fine grained buffer") {
     HIP_CHECK(hipDeviceGetAttribute(&deviceFineGrain, hipDeviceAttributeFineGrainSupport, 0));
     if (deviceFineGrain == 0) {
-      HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kFineGrainHwUnsupported);
-      return true;
+      HIP_SKIP_TEST(HipTest::SkipReason::kFineGrainHwUnsupported);
     }
     HIP_CHECK(hipDeviceGetAttribute(&deviceFineGrain, hipDeviceAttributeFineGrainSupport, 1));
     if (deviceFineGrain == 0) {
-      HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kFineGrainHwUnsupported);
-      return true;
+      HIP_SKIP_TEST(HipTest::SkipReason::kFineGrainHwUnsupported);
     }
     HIP_CHECK(hipSetDevice(0));
     HIP_CHECK(hipDeviceEnablePeerAccess(1, 0));

--- a/projects/hip-tests/catch/unit/synchronization/cache_coherency_gpu_gpu.cc
+++ b/projects/hip-tests/catch/unit/synchronization/cache_coherency_gpu_gpu.cc
@@ -270,7 +270,7 @@ static bool gpu_to_gpu_coherency() {
  */
 
 HIP_TEST_CASE(Unit_cache_coherency_gpu_gpu) {
-  bool passed = true;
   // Coherency between GPUs accessing local or remote FB.
-  REQUIRE(passed == gpu_to_gpu_coherency());
+  bool result = gpu_to_gpu_coherency();
+  REQUIRE(result);
 }

--- a/projects/hip-tests/catch/unit/texture/hipBindTextureToMipmappedArray.cc
+++ b/projects/hip-tests/catch/unit/texture/hipBindTextureToMipmappedArray.cc
@@ -136,7 +136,7 @@ HIP_TEST_CASE(Unit_hipTextureMipmapRef2D_Positive_Check) {
     }
   }
 #else
-  HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kMipmappedArraysUnsupported);
+  HIP_SKIP_TEST(HipTest::SkipReason::kMipmappedArraysUnsupported);
 #endif
 }
 
@@ -196,7 +196,7 @@ HIP_TEST_CASE(Unit_hipTextureMipmapRef2D_Negative_Parameters) {
 
   HIP_CHECK(hipFreeMipmappedArray(mip_array_ptr));
 #else
-  HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kMipmappedArraysUnsupported);
+  HIP_SKIP_TEST(HipTest::SkipReason::kMipmappedArraysUnsupported);
 #endif
 }
 #endif

--- a/projects/hip-tests/catch/unit/texture/hipTextureObj1DCheckSRGBModes.cc
+++ b/projects/hip-tests/catch/unit/texture/hipTextureObj1DCheckSRGBModes.cc
@@ -84,9 +84,7 @@ static void runTest(const int width, const float offsetX = 0) {
   if (ret == hipErrorInvalidValue && resType == hipResourceTypeLinear) {
     free(hData);
     HIP_CHECK(hipFree(hipBuff));
-    HipTest::HIP_SKIP_TEST(
-        "sRGB is not supported for hipResourceTypeLinear on AMD devices.");
-    return;
+    HIP_SKIP_TEST("sRGB is not supported for hipResourceTypeLinear on AMD devices.");
   }
 #endif
   HIP_CHECK(ret);

--- a/projects/hip-tests/catch/unit/texture/texCubemap.cc
+++ b/projects/hip-tests/catch/unit/texture/texCubemap.cc
@@ -35,8 +35,7 @@
 HIP_TEMPLATE_TEST_CASE(Unit_texCubemap_Positive_ReadModeElementType, char, unsigned char, short,
                    unsigned short, int, unsigned int, float) {
   CHECK_IMAGE_SUPPORT;
-  HipTest::HIP_SKIP_TEST("texCubemap isn't supported.");
-  return;
+  HIP_SKIP_TEST("texCubemap isn't supported.");
   TextureTestParams<TestType> params = {};
   params.extent = make_hipExtent(2, 2, 6);
   params.num_subdivisions = 4;
@@ -117,8 +116,7 @@ HIP_TEMPLATE_TEST_CASE(Unit_texCubemap_Positive_ReadModeElementType, char, unsig
 HIP_TEMPLATE_TEST_CASE(Unit_texCubemap_Positive_ReadModeNormalizedFloat, char, unsigned char,
                    short, unsigned short) {
   CHECK_IMAGE_SUPPORT;
-  HipTest::HIP_SKIP_TEST("texCubemap isn't supported.");
-  return;
+  HIP_SKIP_TEST("texCubemap isn't supported.");
   TextureTestParams<TestType> params = {};
   params.extent = make_hipExtent(2, 2, 6);
   params.num_subdivisions = 4;

--- a/projects/hip-tests/catch/unit/texture/texCubemapGrad.cc
+++ b/projects/hip-tests/catch/unit/texture/texCubemapGrad.cc
@@ -35,8 +35,7 @@
 HIP_TEMPLATE_TEST_CASE(Unit_texCubemapGrad_Positive_ReadModeElementType, char, unsigned char,
                    short, unsigned short, int, unsigned int, float) {
   CHECK_IMAGE_SUPPORT;
-  HipTest::HIP_SKIP_TEST("texCubemap isn't supported.");
-  return;
+  HIP_SKIP_TEST("texCubemap isn't supported.");
   TextureTestParams<TestType> params = {};
   params.extent = make_hipExtent(2, 2, 6);
   params.num_subdivisions = 4;
@@ -117,8 +116,7 @@ HIP_TEMPLATE_TEST_CASE(Unit_texCubemapGrad_Positive_ReadModeElementType, char, u
 HIP_TEMPLATE_TEST_CASE(Unit_texCubemapGrad_Positive_ReadModeNormalizedFloat, char, unsigned char,
                    short, unsigned short) {
   CHECK_IMAGE_SUPPORT;
-  HipTest::HIP_SKIP_TEST("texCubemap isn't supported.");
-  return;
+  HIP_SKIP_TEST("texCubemap isn't supported.");
   TextureTestParams<TestType> params = {};
   params.extent = make_hipExtent(2, 2, 6);
   params.num_subdivisions = 4;

--- a/projects/hip-tests/catch/unit/texture/texCubemapLayered.cc
+++ b/projects/hip-tests/catch/unit/texture/texCubemapLayered.cc
@@ -35,8 +35,7 @@
 HIP_TEMPLATE_TEST_CASE(Unit_texCubemapLayered_Positive_ReadModeElementType, char, unsigned char,
                    short, unsigned short, int, unsigned int, float) {
   CHECK_IMAGE_SUPPORT;
-  HipTest::HIP_SKIP_TEST("texCubemap isn't supported.");
-  return;
+  HIP_SKIP_TEST("texCubemap isn't supported.");
   TextureTestParams<TestType> params = {};
   params.extent = make_hipExtent(2, 2, 6);
   params.num_subdivisions = 4;
@@ -120,8 +119,7 @@ HIP_TEMPLATE_TEST_CASE(Unit_texCubemapLayered_Positive_ReadModeElementType, char
 HIP_TEMPLATE_TEST_CASE(Unit_texCubemapLayered_Positive_ReadModeNormalizedFloat, char,
                    unsigned char, short, unsigned short) {
   CHECK_IMAGE_SUPPORT;
-  HipTest::HIP_SKIP_TEST("texCubemap isn't supported.");
-  return;
+  HIP_SKIP_TEST("texCubemap isn't supported.");
   TextureTestParams<TestType> params = {};
   params.extent = make_hipExtent(2, 2, 6);
   params.num_subdivisions = 4;

--- a/projects/hip-tests/catch/unit/texture/texCubemapLayeredGrad.cc
+++ b/projects/hip-tests/catch/unit/texture/texCubemapLayeredGrad.cc
@@ -35,8 +35,7 @@
 HIP_TEMPLATE_TEST_CASE(Unit_texCubemapLayeredGrad_Positive_ReadModeElementType, char,
                    unsigned char, short, unsigned short, int, unsigned int, float) {
   CHECK_IMAGE_SUPPORT;
-  HipTest::HIP_SKIP_TEST("texCubemap isn't supported.");
-  return;
+  HIP_SKIP_TEST("texCubemap isn't supported.");
   TextureTestParams<TestType> params = {};
   params.extent = make_hipExtent(2, 2, 6);
   params.num_subdivisions = 4;
@@ -121,8 +120,7 @@ HIP_TEMPLATE_TEST_CASE(Unit_texCubemapLayeredGrad_Positive_ReadModeElementType, 
 HIP_TEMPLATE_TEST_CASE(Unit_texCubemapLayeredGrad_Positive_ReadModeNormalizedFloat, char,
                    unsigned char, short, unsigned short) {
   CHECK_IMAGE_SUPPORT;
-  HipTest::HIP_SKIP_TEST("texCubemap isn't supported.");
-  return;
+  HIP_SKIP_TEST("texCubemap isn't supported.");
   TextureTestParams<TestType> params = {};
   params.extent = make_hipExtent(2, 2, 6);
   params.num_subdivisions = 4;

--- a/projects/hip-tests/catch/unit/texture/texCubemapLayeredLod.cc
+++ b/projects/hip-tests/catch/unit/texture/texCubemapLayeredLod.cc
@@ -35,8 +35,7 @@
 HIP_TEMPLATE_TEST_CASE(Unit_texCubemapLayeredLod_Positive_ReadModeElementType, char,
                    unsigned char, short, unsigned short, int, unsigned int, float) {
   CHECK_IMAGE_SUPPORT;
-  HipTest::HIP_SKIP_TEST("texCubemap isn't supported.");
-  return;
+  HIP_SKIP_TEST("texCubemap isn't supported.");
   TextureTestParams<TestType> params = {};
   params.extent = make_hipExtent(2, 2, 6);
   params.num_subdivisions = 4;
@@ -121,8 +120,7 @@ HIP_TEMPLATE_TEST_CASE(Unit_texCubemapLayeredLod_Positive_ReadModeElementType, c
 HIP_TEMPLATE_TEST_CASE(Unit_texCubemapLayeredLod_Positive_ReadModeNormalizedFloat, char,
                    unsigned char, short, unsigned short) {
   CHECK_IMAGE_SUPPORT;
-  HipTest::HIP_SKIP_TEST("texCubemap isn't supported.");
-  return;
+  HIP_SKIP_TEST("texCubemap isn't supported.");
   TextureTestParams<TestType> params = {};
   params.extent = make_hipExtent(2, 2, 6);
   params.num_subdivisions = 4;

--- a/projects/hip-tests/catch/unit/texture/texCubemapLod.cc
+++ b/projects/hip-tests/catch/unit/texture/texCubemapLod.cc
@@ -35,8 +35,7 @@
 HIP_TEMPLATE_TEST_CASE(Unit_texCubemapLod_Positive_ReadModeElementType, char, unsigned char,
                    short, unsigned short, int, unsigned int, float) {
   CHECK_IMAGE_SUPPORT;
-  HipTest::HIP_SKIP_TEST("texCubemap isn't supported.");
-  return;
+  HIP_SKIP_TEST("texCubemap isn't supported.");
   TextureTestParams<TestType> params = {};
   params.extent = make_hipExtent(2, 2, 6);
   params.num_subdivisions = 4;
@@ -117,8 +116,7 @@ HIP_TEMPLATE_TEST_CASE(Unit_texCubemapLod_Positive_ReadModeElementType, char, un
 HIP_TEMPLATE_TEST_CASE(Unit_texCubemapLod_Positive_ReadModeNormalizedFloat, char, unsigned char,
                    short, unsigned short) {
   CHECK_IMAGE_SUPPORT;
-  HipTest::HIP_SKIP_TEST("texCubemap isn't supported.");
-  return;
+  HIP_SKIP_TEST("texCubemap isn't supported.");
   TextureTestParams<TestType> params = {};
   params.extent = make_hipExtent(2, 2, 6);
   params.num_subdivisions = 4;

--- a/projects/hip-tests/catch/unit/threadfence/__threadfence.cc
+++ b/projects/hip-tests/catch/unit/threadfence/__threadfence.cc
@@ -151,15 +151,13 @@ HIP_TEST_CASE(Unit___threadfence_Positive_Basic_Managed) {
 HIP_TEST_CASE(Unit___threadfence_Positive_Basic_Peer) {
   const auto device_count = HipTest::getDeviceCount();
   if (device_count < 2) {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
-    return;
+    HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
   }
 
   int can_access_peer = 0;
   HIP_CHECK(hipDeviceCanAccessPeer(&can_access_peer, 0, 1));
   if (!can_access_peer) {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kPeerAccessUnavailable);
-    return;
+    HIP_SKIP_TEST(HipTest::SkipReason::kPeerAccessUnavailable);
   }
 
   HIP_CHECK(hipSetDevice(0));

--- a/projects/hip-tests/catch/unit/threadfence/__threadfence_block.cc
+++ b/projects/hip-tests/catch/unit/threadfence/__threadfence_block.cc
@@ -151,15 +151,13 @@ HIP_TEST_CASE(Unit___threadfence_block_Positive_Basic_Managed) {
 HIP_TEST_CASE(Unit___threadfence_block_Positive_Basic_Peer) {
   const auto device_count = HipTest::getDeviceCount();
   if (device_count < 2) {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
-    return;
+    HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
   }
 
   int can_access_peer = 0;
   HIP_CHECK(hipDeviceCanAccessPeer(&can_access_peer, 0, 1));
   if (!can_access_peer) {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kPeerAccessUnavailable);
-    return;
+    HIP_SKIP_TEST(HipTest::SkipReason::kPeerAccessUnavailable);
   }
 
   HIP_CHECK(hipSetDevice(0));

--- a/projects/hip-tests/catch/unit/threadfence/__threadfence_system.cc
+++ b/projects/hip-tests/catch/unit/threadfence/__threadfence_system.cc
@@ -47,15 +47,13 @@ __global__ void ReadKernel(int* out, int* in) {
 HIP_TEST_CASE(Unit___threadfence_system_Positive_Basic_Peer) {
   const auto device_count = HipTest::getDeviceCount();
   if (device_count < 2) {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
-    return;
+    HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
   }
 
   int can_access_peer = 0;
   HIP_CHECK(hipDeviceCanAccessPeer(&can_access_peer, 0, 1));
   if (!can_access_peer) {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kPeerAccessUnavailable);
-    return;
+    HIP_SKIP_TEST(HipTest::SkipReason::kPeerAccessUnavailable);
   }
 
   HIP_CHECK(hipSetDevice(0));

--- a/projects/hip-tests/catch/unit/virtualMemoryManagement/hipGetProcAddressVmmApis.cc
+++ b/projects/hip-tests/catch/unit/virtualMemoryManagement/hipGetProcAddressVmmApis.cc
@@ -28,8 +28,7 @@ HIP_TEST_CASE(Unit_hipGetProcAddress_VMM) {
   int value = 0;
   HIP_CHECK(hipDeviceGetAttribute(&value, hipDeviceAttributeVirtualMemoryManagementSupported, 0));
   if (value == 0) {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kVmmUnsupported);
-    return;
+    HIP_SKIP_TEST(HipTest::SkipReason::kVmmUnsupported);
   }
 
   hipDeviceProp_t devProp;

--- a/projects/hip-tests/catch/unit/virtualMemoryManagement/hipMemGetHandleForAddressRange.cc
+++ b/projects/hip-tests/catch/unit/virtualMemoryManagement/hipMemGetHandleForAddressRange.cc
@@ -458,8 +458,7 @@ HIP_TEST_CASE(Unit_hipMemGetHandleForAddressRange_DeviceMemory_InAnotherDevice) 
   int deviceCount = 0;
   HIP_CHECK(hipGetDeviceCount(&deviceCount));
   if (deviceCount < 2) {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
-    return;
+    HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
   }
 
   constexpr int srcDeviceId = 0;
@@ -513,8 +512,7 @@ HIP_TEST_CASE(Unit_hipMemGetHandleForAddressRange_VM_InAnotherDevice) {
   int deviceCount = 0;
   HIP_CHECK(hipGetDeviceCount(&deviceCount));
   if (deviceCount < 2) {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
-    return;
+    HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
   }
 
   constexpr int srcDeviceId = 0;

--- a/projects/hip-tests/catch/unit/virtualMemoryManagement/hipMemMap.cc
+++ b/projects/hip-tests/catch/unit/virtualMemoryManagement/hipMemMap.cc
@@ -281,8 +281,7 @@ void physicalMemoryReuse_MultiDev (hipMemAllocationProp prop) {
   int devicecount = 0;
   HIP_CHECK(hipGetDeviceCount(&devicecount));
   if (devicecount < 2) {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
-    return;
+    HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
   }
   size_t granularity = 0;
   size_t buffer_size = N * sizeof(int);
@@ -454,8 +453,7 @@ void vMMMemoryReuse_MultiGPU (hipMemAllocationProp prop) {
   int deviceId = 0, devicecount = 0;
   HIP_CHECK(hipGetDeviceCount(&devicecount));
   if (devicecount < 2) {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
-    return;
+    HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
   }
   size_t granularity = 0;
   size_t buffer_size = N * sizeof(int);

--- a/projects/hip-tests/catch/unit/virtualMemoryManagement/hipMemSetGetAccess.cc
+++ b/projects/hip-tests/catch/unit/virtualMemoryManagement/hipMemSetGetAccess.cc
@@ -140,8 +140,7 @@ HIP_TEST_CASE(Unit_hipMemSetAccess_MultDevSetGet) {
   hipDevice_t device0, device1;
   HIP_CHECK(hipGetDeviceCount(&device_count));
   if (device_count < 2) {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
-    return;
+    HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
   }
 
   HIP_CHECK(hipDeviceGet(&device0, deviceId));
@@ -332,8 +331,7 @@ HIP_TEST_CASE(Unit_hipMemSetAccess_FuncTstOnMultDev) {
   int deviceId = 0, devicecount = 0;
   HIP_CHECK(hipGetDeviceCount(&devicecount));
   if (devicecount < 2) {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
-    return;
+    HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
   }
   for (deviceId = 0; deviceId < devicecount; deviceId++) {
     HIP_CHECK(hipSetDevice(deviceId));
@@ -614,8 +612,7 @@ HIP_TEST_CASE(Unit_hipMemSetAccess_Vmm2UnifiedMemCpy) {
   CTX_CREATE();
   auto managed = HmmAttrPrint();
   if (managed != 1) {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kManagedMemoryUnsupported);
-    return;
+    HIP_SKIP_TEST(HipTest::SkipReason::kManagedMemoryUnsupported);
   }
   size_t granularity = 0;
   constexpr int N = DATA_SIZE;
@@ -754,8 +751,7 @@ HIP_TEST_CASE(Unit_hipMemSetAccess_Vmm2PeerDevMemCpy) {
   int devicecount = 0;
   HIP_CHECK(hipGetDeviceCount(&devicecount));
   if (devicecount < 2) {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
-    return;
+    HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
   }
   int deviceId = 0, value = 0;
   hipDevice_t device;
@@ -845,8 +841,7 @@ HIP_TEST_CASE(Unit_hipMemSetAccess_Vmm2PeerPeerMemCpy) {
   int devicecount = 0;
   HIP_CHECK(hipGetDeviceCount(&devicecount));
   if (devicecount < 2) {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
-    return;
+    HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
   }
   int deviceId = 0, value = 0;
   hipDevice_t device;
@@ -1007,8 +1002,7 @@ HIP_TEST_CASE(Unit_hipMemSetAccess_Vmm2VMMInterDevMemCpy) {
   int devicecount = 0;
   HIP_CHECK(hipGetDeviceCount(&devicecount));
   if (devicecount < 2) {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
-    return;
+    HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
   }
   int deviceId = 0, value = 0;
   hipDevice_t device;

--- a/projects/hip-tests/catch/unit/virtualMemoryManagement/hip_vmm_common.hh
+++ b/projects/hip-tests/catch/unit/virtualMemoryManagement/hip_vmm_common.hh
@@ -25,8 +25,7 @@
     hipDeviceAttribute_t attr = hipDeviceAttributeVirtualMemoryManagementSupported;                \
     HIP_CHECK(hipDeviceGetAttribute(&value, attr, device));                                        \
     if (value == 0) {                                                                              \
-      HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kVmmUnsupported);                     \
-      return;                                                                                      \
+      HIP_SKIP_TEST(HipTest::SkipReason::kVmmUnsupported);                                         \
     }                                                                                              \
   }
 
@@ -36,8 +35,7 @@
     hipDeviceAttribute_t attr = hipDeviceAttributeDmaBufSupported;                                 \
     HIP_CHECK(hipDeviceGetAttribute(&value, attr, device));                                        \
     if (value == 0) {                                                                              \
-      HipTest::HIP_SKIP_TEST("DMA-BUF is not supported for this test on this device.");                  \
-      return;                                                                                      \
+      HIP_SKIP_TEST("DMA-BUF is not supported for this test on this device.");                     \
     }                                                                                              \
   }
 #ifdef __linux__

--- a/projects/hip-tests/catch/unit/warp/warp_all.cc
+++ b/projects/hip-tests/catch/unit/warp/warp_all.cc
@@ -108,8 +108,7 @@ HIP_TEST_CASE(Unit_Warp_Vote_All_Positive_Basic) {
   HIP_CHECK(hipGetDeviceProperties(&device_properties, device));
 
   if (!device_properties.arch.hasWarpVote) {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kWarpVoteUnsupported);
-    return;
+    HIP_SKIP_TEST(HipTest::SkipReason::kWarpVoteUnsupported);
   }
 
   SECTION("Warp Vote All with specified active mask") { WarpAll().run(false); }

--- a/projects/hip-tests/catch/unit/warp/warp_any.cc
+++ b/projects/hip-tests/catch/unit/warp/warp_any.cc
@@ -99,8 +99,7 @@ HIP_TEST_CASE(Unit_Warp_Vote_Any_Positive_Basic) {
   HIP_CHECK(hipGetDeviceProperties(&device_properties, device));
 
   if (!device_properties.arch.hasWarpVote) {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kWarpVoteUnsupported);
-    return;
+    HIP_SKIP_TEST(HipTest::SkipReason::kWarpVoteUnsupported);
   }
 
   SECTION("Warp Vote Any with specified active mask") { WarpAny().run(false); }

--- a/projects/hip-tests/catch/unit/warp/warp_ballot.cc
+++ b/projects/hip-tests/catch/unit/warp/warp_ballot.cc
@@ -98,8 +98,7 @@ HIP_TEST_CASE(Unit_Warp_Ballot_Positive_Basic) {
   HIP_CHECK(hipGetDeviceProperties(&device_properties, device));
 
   if (!device_properties.arch.hasWarpBallot) {
-    HipTest::HIP_SKIP_TEST("warp ballot is not supported on this device.");
-    return;
+    HIP_SKIP_TEST("warp ballot is not supported on this device.");
   }
 
   SECTION("Warp Ballot with specified active mask") { WarpBallot().run(false); }

--- a/projects/hip-tests/catch/unit/warp/warp_shfl.cc
+++ b/projects/hip-tests/catch/unit/warp/warp_shfl.cc
@@ -94,8 +94,7 @@ HIP_TEMPLATE_TEST_CASE(Unit_Warp_Shfl_Positive_Basic, int, unsigned int, long, u
   HIP_CHECK(hipGetDeviceProperties(&device_properties, device));
 
   if (!device_properties.arch.hasWarpShuffle) {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kWarpShuffleUnsupported);
-    return;
+    HIP_SKIP_TEST(HipTest::SkipReason::kWarpShuffleUnsupported);
   }
 
   SECTION("Shfl with specified active mask and input values") { WarpShfl<TestType>().run(false); }

--- a/projects/hip-tests/catch/unit/warp/warp_shfl_down.cc
+++ b/projects/hip-tests/catch/unit/warp/warp_shfl_down.cc
@@ -94,8 +94,7 @@ HIP_TEMPLATE_TEST_CASE(Unit_Warp_Shfl_Down_Positive_Basic, int, unsigned int, lo
   HIP_CHECK(hipGetDeviceProperties(&device_properties, device));
 
   if (!device_properties.arch.hasWarpShuffle) {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kWarpShuffleUnsupported);
-    return;
+    HIP_SKIP_TEST(HipTest::SkipReason::kWarpShuffleUnsupported);
   }
 
   SECTION("Shfl Down with specified active mask and input values") {

--- a/projects/hip-tests/catch/unit/warp/warp_shfl_up.cc
+++ b/projects/hip-tests/catch/unit/warp/warp_shfl_up.cc
@@ -93,8 +93,7 @@ HIP_TEMPLATE_TEST_CASE(Unit_Warp_Shfl_Up_Positive_Basic, int, unsigned int, long
   HIP_CHECK(hipGetDeviceProperties(&device_properties, device));
 
   if (!device_properties.arch.hasWarpShuffle) {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kWarpShuffleUnsupported);
-    return;
+    HIP_SKIP_TEST(HipTest::SkipReason::kWarpShuffleUnsupported);
   }
 
   SECTION("Shfl Up with specified active mask and input values") {

--- a/projects/hip-tests/catch/unit/warp/warp_shfl_xor.cc
+++ b/projects/hip-tests/catch/unit/warp/warp_shfl_xor.cc
@@ -100,8 +100,7 @@ HIP_TEMPLATE_TEST_CASE(Unit_Warp_Shfl_XOR_Positive_Basic, int, unsigned int, lon
   HIP_CHECK(hipGetDeviceProperties(&device_properties, device));
 
   if (!device_properties.arch.hasWarpShuffle) {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kWarpShuffleUnsupported);
-    return;
+    HIP_SKIP_TEST(HipTest::SkipReason::kWarpShuffleUnsupported);
   }
 
   SECTION("Shfl Xor with specified active mask and input values") {


### PR DESCRIPTION
## Motivation

Starting with Catch2 version v3.3.0, SKIP macro was added.
This means that the custom hip-tests solution for skipping test cases is no longer required.
Due to the initiative to streamline/standardize hip-tests, replace the HIP_SKIP_THIS_TEST mechanism with the new Catch2 SKIP macro.

## Technical Details

Remove HIP_SKIP_TEST function and replace it with HIP_SKIP_TEST macro.

## JIRA ID

AIRUNTIME-1987

## Test Plan

Ensure build passes. All tests pass

## Test Result

Local build passed, local tests pass

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
