### PR TITLE
SWDEV-1 Revert buggy patch that fails image tests

### DIFF
--- a/projects/clr/rocclr/device/rocm/rocvirtual.cpp
+++ b/projects/clr/rocclr/device/rocm/rocvirtual.cpp
@@ -707,11 +707,10 @@ void VirtualGPU::HwQueueTracker::ResetCurrentSignal() {
 }
 
 // ================================================================================================
-bool VirtualGPU::processOpenCLMemObjects(const amd::Kernel& kernel, const_address params,
+bool VirtualGPU::processMemObjects(const amd::Kernel& kernel, const_address params,
                                    size_t& ldsAddress, bool cooperativeGroups,
                                    bool& imageBufferWrtBack,
                                    std::vector<device::Memory*>& wrtBackImageBuffer) {
-  assert(!amd::IS_HIP && "OpenCL-only function is called on HIP path");
   Kernel& hsaKernel =
       const_cast<Kernel&>(static_cast<const Kernel&>(*(kernel.getDeviceKernel(dev()))));
   const amd::KernelSignature& signature = kernel.signature();
@@ -725,16 +724,19 @@ bool VirtualGPU::processOpenCLMemObjects(const amd::Kernel& kernel, const_addres
   amd::Memory* const* memories =
       reinterpret_cast<amd::Memory* const*>(params + kernelParams.memoryObjOffset());
 
-  // Process cache coherency first, since the extra transfers may affect
-  // other mem dependency tracking logic: TS and signalWrite()
-  for (uint i = 0; i < signature.numMemories(); ++i) {
-    amd::Memory* mem = memories[i];
-    if (mem != nullptr) {
-      roc::Memory* gpuMem = dev().getGpuMemory(mem);
-      // Don't sync for internal objects, since they are not shared between devices
-      if (gpuMem->owner()->getVirtualDevice() == nullptr) {
-        // Synchronize data with other memory instances if necessary
-        gpuMem->syncCacheFromHost(*this);
+  // HIP shouldn't use cache coherency layer at any time
+  if (!amd::IS_HIP) {
+    // Process cache coherency first, since the extra transfers may affect
+    // other mem dependency tracking logic: TS and signalWrite()
+    for (uint i = 0; i < signature.numMemories(); ++i) {
+      amd::Memory* mem = memories[i];
+      if (mem != nullptr) {
+        roc::Memory* gpuMem = dev().getGpuMemory(mem);
+        // Don't sync for internal objects, since they are not shared between devices
+        if (gpuMem->owner()->getVirtualDevice() == nullptr) {
+          // Synchronize data with other memory instances if necessary
+          gpuMem->syncCacheFromHost(*this);
+        }
       }
     }
   }
@@ -959,71 +961,6 @@ bool VirtualGPU::processOpenCLMemObjects(const amd::Kernel& kernel, const_addres
   }
 
   return true;
-}
-
-// ================================================================================================
-bool VirtualGPU::processHIPMemObjects(const amd::Kernel& kernel, const_address params) {
-  assert(amd::IS_HIP && "HIP-only function is called on non-HIP path");
-
-  // HIP doesn't really require any processing, this whole function only exists for logging
-  // purposes, so skip it entirely if logging isn't enabled.
-  if (!IsLogEnabled(amd::LOG_INFO, amd::LOG_KERN))
-    return true;
-
-  Kernel& hsaKernel =
-      const_cast<Kernel&>(static_cast<const Kernel&>(*(kernel.getDeviceKernel(dev()))));
-  const amd::KernelSignature& signature = kernel.signature();
-
-  for (size_t i = 0; i < signature.numParameters(); ++i) {
-    const amd::KernelParameterDescriptor& desc = signature.at(i);
-
-    if (desc.type_ == T_POINTER) {
-      const void* globalAddress = *reinterpret_cast<const void* const*>(params + desc.offset_);
-
-      ClPrint(amd::LOG_DEBUG, amd::LOG_KERN, "Arg%d: %s %s = ptr:%p ", i, desc.typeName_.c_str(),
-              desc.name_.c_str(), globalAddress);
-    } else if (desc.type_ == T_VOID) {
-      const_address srcArgPtr = params + desc.offset_;
-      if (desc.size_ > 8) {
-        std::string bytes = "0x";
-        constexpr size_t kMaxBytes = 64;
-        for (size_t j = 0; j < std::min(desc.size_, kMaxBytes); j++) {
-          char byteStr[4];
-          snprintf(byteStr, sizeof(byteStr), "%02x ",
-                   reinterpret_cast<const uint8_t*>(srcArgPtr)[j]);
-          bytes += byteStr;
-        }
-        if (desc.size_ > kMaxBytes) {
-          bytes += "...";
-        }
-        ClPrint(amd::LOG_DEBUG, amd::LOG_KERN, "Arg%d: %s %s = %s (size:0x%x)", i,
-                desc.typeName_.c_str(), desc.name_.c_str(), bytes.c_str(), desc.size_);
-      } else {
-        ClPrint(amd::LOG_DEBUG, amd::LOG_KERN, "Arg%d: %s %s = val:0x%lx (size:0x%x)", i,
-                desc.typeName_.c_str(), desc.name_.c_str(),
-                (desc.size_ == 1)   ? *reinterpret_cast<const uint8_t*>(srcArgPtr)
-                : (desc.size_ == 2) ? *reinterpret_cast<const uint16_t*>(srcArgPtr)
-                : (desc.size_ == 4) ? *reinterpret_cast<const uint32_t*>(srcArgPtr)
-                : (desc.size_ == 8) ? *reinterpret_cast<const uint64_t*>(srcArgPtr)
-                                    : 0LL,
-                desc.size_);
-      }
-    }
-  }
-
-  return true;
-}
-
-// ================================================================================================
-bool VirtualGPU::processMemObjects(const amd::Kernel& kernel, const_address params,
-                                   size_t& ldsAddress, bool cooperativeGroups,
-                                   bool& imageBufferWrtBack,
-                                   std::vector<device::Memory*>& wrtBackImageBuffer) {
-  if (amd::IS_HIP)
-    return processHIPMemObjects(kernel, params);
-
-  return processOpenCLMemObjects(kernel, params, ldsAddress, cooperativeGroups, imageBufferWrtBack,
-                                 wrtBackImageBuffer);
 }
 
 // ================================================================================================

--- a/projects/clr/rocclr/device/rocm/rocvirtual.hpp
+++ b/projects/clr/rocclr/device/rocm/rocvirtual.hpp
@@ -480,22 +480,6 @@ class VirtualGPU : public device::VirtualDevice {
   }
 
  private:
-  //! OpenCL-specific version of processMemObjects.
-  //! Detects memory dependency for HSA kernels and uses appropriate AQL header
-  bool processOpenCLMemObjects(
-      const amd::Kernel& kernel,                        //!< AMD kernel object for execution
-      const_address params,                             //!< Pointer to the param's store
-      size_t& ldsAddress,                               //!< LDS usage
-      bool cooperativeGroups,                           //!< Dispatch with cooperative groups
-      bool& imageBufferWrtBack,                         //!< Image buffer write back is required
-      std::vector<device::Memory*>& wrtBackImageBuffer  //!< Images for writeback
-  );
-  //! HIP-specific version of processMemObjects.
-  //! Does nothing except logging
-  bool processHIPMemObjects(const amd::Kernel& kernel,  //!< AMD kernel object for execution
-                            const_address params        //!< Pointer to the param's store
-  );
-
   //! Dispatches a barrier with blocking HSA signals
   void dispatchBlockingWait();
 


### PR DESCRIPTION
Revert "[CLR][NFCI] Drop unnecessary kernel arguments processing for HIP (#3879)"

This reverts commit f058bd5c630ef5535fea44ee7f0c9689235eda41.

## Motivation

f058bd5c630ef5535fea44ee7f0c9689235eda41 lead to many texture test failures

## Technical Details

Need reconsider the logics 

## JIRA ID

AIRUNTIME-1953

## Test Plan

All pass

## Test Result

Passed

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
