### PR TITLE
[rocprofiler-compute] Refactor dependencies to reduce profile mode startup overhead

### DIFF
--- a/projects/rocprofiler-compute/src/rocprof_compute_analyze/analysis_base.py
+++ b/projects/rocprofiler-compute/src/rocprof_compute_analyze/analysis_base.py
@@ -23,13 +23,12 @@ from utils.logger import (
     console_warning,
     demarcate,
 )
-from utils.roofline_calc import validate_roofline_csv
 from utils.utils_analysis import (
     impute_counters_iteration_multiplex,
     is_workload_empty,
     merge_counters_spatial_multiplex,
 )
-from utils.utils_common import get_uuid
+from utils.utils_common import get_uuid, load_panel_configs, validate_roofline_csv
 
 # the build-in config to list kernel names purpose only
 TOP_STATS_BUILD_IN_CONFIG: OrderedDict[int, dict[str, Any]] = OrderedDict([
@@ -166,7 +165,7 @@ class OmniAnalyze_Base:
                         / arch
                     )
                 )
-            ac.panel_configs = file_io.load_panel_configs(arch_panel_config)
+            ac.panel_configs = load_panel_configs(arch_panel_config)
 
         # TODO: filter_metrics should/might be one per arch
         parser.build_dfs(

--- a/projects/rocprofiler-compute/src/rocprof_compute_analyze/analysis_cli.py
+++ b/projects/rocprofiler-compute/src/rocprof_compute_analyze/analysis_cli.py
@@ -11,13 +11,14 @@ from rocprof_compute_analyze.analysis_base import OmniAnalyze_Base
 from roofline import Roofline
 from utils import file_io, parser, schema, tty
 from utils.logger import console_error, console_log, console_warning, demarcate
-from utils.roofline_calc import calc_ai_analyze, validate_roofline_csv
+from utils.roofline_calc import calc_ai_analyze
 from utils.utils_analysis import (
     build_call_trees,
     build_call_trees_with_kernel_ids,
     process_torch_trace_output,
     write_torch_trace_consolidated_csv,
 )
+from utils.utils_common import validate_roofline_csv
 
 
 def parse_torch_operator_patterns(args: argparse.Namespace) -> list[str]:
@@ -191,8 +192,6 @@ class cli_analysis(OmniAnalyze_Base):
                         ai_data = calc_ai_analyze(
                             workload=workload,
                             pmc_df=pmc_df,
-                            mspec=soc_obj._mspec,
-                            sort_type=str(args.sort),
                             config=self._profiling_config,
                             arch_config=arch_config,
                         )

--- a/projects/rocprofiler-compute/src/rocprof_compute_analyze/analysis_db.py
+++ b/projects/rocprofiler-compute/src/rocprof_compute_analyze/analysis_db.py
@@ -18,7 +18,6 @@ from utils import utils_analysis
 from utils.analysis_orm import Database, get_views
 from utils.logger import console_debug, console_error, console_warning, demarcate
 from utils.parser import (
-    BUILD_IN_VARS,
     PC_SAMPLING_NOT_ISSUE_PREFIX,
     CodeTransformer,
     to_avg,
@@ -40,7 +39,7 @@ from utils.roofline_calc import (
     PEAK_OPS_DATATYPES,
     SUPPORTED_DATATYPES,
 )
-from utils.utils_common import get_uuid, get_version
+from utils.utils_common import BUILD_IN_VARS, get_uuid, get_version
 
 
 class db_analysis(OmniAnalyze_Base):

--- a/projects/rocprofiler-compute/src/rocprof_compute_analyze/analysis_webui.py
+++ b/projects/rocprofiler-compute/src/rocprof_compute_analyze/analysis_webui.py
@@ -20,7 +20,8 @@ from utils import file_io, parser, schema
 from utils.gui import build_bar_chart, build_table_chart
 from utils.gui_components.memchart import get_memchart
 from utils.logger import console_debug, console_error, console_warning, demarcate
-from utils.roofline_calc import calc_ai_analyze, validate_roofline_csv
+from utils.roofline_calc import calc_ai_analyze
+from utils.utils_common import validate_roofline_csv
 
 
 class webui_analysis(OmniAnalyze_Base):
@@ -243,8 +244,6 @@ class webui_analysis(OmniAnalyze_Base):
                     ai_data = calc_ai_analyze(
                         workload=workload,
                         pmc_df=pmc_df,
-                        mspec=soc[self.arch]._mspec,
-                        sort_type=str(args.sort),
                         config=self._profiling_config,
                         arch_config=arch_configs,
                     )

--- a/projects/rocprofiler-compute/src/rocprof_compute_base.py
+++ b/projects/rocprofiler-compute/src/rocprof_compute_base.py
@@ -7,12 +7,11 @@ import socket
 import sys
 import time
 from pathlib import Path
-from typing import Optional
+from typing import Any, Optional
 
 import config
 from argparser import omniarg_parser
 from rocprof_compute_soc.soc_base import OmniSoC_Base
-from utils import file_io, parser, schema
 from utils.logger import (
     console_debug,
     console_error,
@@ -26,11 +25,13 @@ from utils.logger import (
 from utils.mi_gpu_spec import mi_gpu_specs
 from utils.specs import MachineSpecs, generate_machine_specs
 from utils.utils_common import (
+    build_metric_list,
     detect_rocprof,
     get_panel_alias,
     get_rank,
     get_version,
     get_version_display,
+    load_panel_configs,
     parse_sets_yaml,
     replace_env,
     replace_rank,
@@ -366,11 +367,9 @@ class RocProfCompute:
         arch = self.__mspec.gpu_arch if for_current_arch else self.__args.list_metrics
 
         if arch in self.__supported_archs.keys():
-            sys_info = (
-                self.__mspec.get_class_members().iloc[0] if for_current_arch else None
-            )
-            ac = self._build_arch_metric_list(arch, sys_info)
-            for key, value in ac.metric_list.items():
+            sys_info = self.__mspec.get_class_members() if for_current_arch else None
+            metric_list = self._build_arch_metric_list(arch, sys_info)
+            for key, value in metric_list.items():
                 prefix = "\t" * min(key.count("."), 2)
                 print(f"{prefix}{key} -> {value}")
             sys.exit(0)
@@ -382,10 +381,10 @@ class RocProfCompute:
         arch = self.__args.list_blocks
 
         if arch in self.__supported_archs.keys():
-            ac = self._build_arch_metric_list(arch, sys_info=None)
+            metric_list = self._build_arch_metric_list(arch, sys_info=None)
             print(f"{'INDEX':<8} {'BLOCK ALIAS':<16} {'BLOCK NAME'}")
             panel_alias_dict = {value: key for key, value in get_panel_alias().items()}
-            for key, value in ac.metric_list.items():
+            for key, value in metric_list.items():
                 if key.count(".") > 0:
                     continue
                 print(f"{key:<8} {panel_alias_dict[key]:<16} {value}")
@@ -396,16 +395,12 @@ class RocProfCompute:
     def _build_arch_metric_list(
         self,
         arch: str,
-        sys_info: "pd.Series",  # noqa: F821
-    ) -> schema.ArchConfig:
-        """Load panel configs for arch and populate metric_list.
-        Returns the ArchConfig."""
-        ac = schema.ArchConfig()
-        ac.panel_configs = file_io.load_panel_configs([
-            str(Path(self.__args.config_dir) / arch)
-        ])
-        parser.build_metric_list(ac, sys_info)
-        return ac
+        sys_info: Optional[dict[str, Any]],
+    ) -> dict[str, str]:
+        """Load panel configs for arch and build metric_list.
+        Returns the metric_list dictionary."""
+        panel_configs = load_panel_configs([str(Path(self.__args.config_dir) / arch)])
+        return build_metric_list(panel_configs, sys_info)
 
     @demarcate
     def list_sets(self) -> None:
@@ -536,6 +531,11 @@ class RocProfCompute:
 
     @demarcate
     def run_analysis(self) -> None:
+        # Lazy import file_io since its only used in analysis mode
+        # This will prevent analysis dependencies
+        # leakage into profile mode path
+        from utils import file_io
+
         self.print_graphic()
         console_log(f"Analysis mode = {self.__analyze_mode}")
 

--- a/projects/rocprofiler-compute/src/rocprof_compute_profile/profiler_base.py
+++ b/projects/rocprofiler-compute/src/rocprof_compute_profile/profiler_base.py
@@ -238,7 +238,6 @@ class RocProfCompute_Base:
                 fnames=str_fnames,
                 profiler_options=options,
                 workload_dir=args.path,
-                mspec=self._soc._mspec,
                 loglevel=args.loglevel,
                 format_rocprof_output=args.format_rocprof_output,
                 torch_trace_enabled=getattr(args, "torch_trace", False),

--- a/projects/rocprofiler-compute/src/rocprof_compute_soc/soc_base.py
+++ b/projects/rocprofiler-compute/src/rocprof_compute_soc/soc_base.py
@@ -20,11 +20,11 @@ from utils.logger import (
     demarcate,
 )
 from utils.mi_gpu_spec import mi_gpu_specs
-from utils.parser import BUILD_IN_VARS, SUPPORTED_DENOM
-from utils.roofline_calc import validate_roofline_csv
 from utils.specs import MachineSpecs
 from utils.utils_common import (
+    BUILD_IN_VARS,
     METRIC_ID_RE,
+    SUPPORTED_DENOM,
     add_counter_extra_config_input_yaml,
     convert_metric_id_to_panel_info,
     get_panel_alias,
@@ -32,6 +32,7 @@ from utils.utils_common import (
     is_tcc_channel_counter,
     parse_sets_yaml,
     resolve_rocm_library_path,
+    validate_roofline_csv,
 )
 from vendored import yaml
 

--- a/projects/rocprofiler-compute/src/utils/parser.py
+++ b/projects/rocprofiler-compute/src/utils/parser.py
@@ -982,7 +982,7 @@ def create_sys_vars(sys_info: pd.Series) -> dict[str, Union[int, float]]:
         sys_vars_collection[f"ammolite__{var_name}"] = variable_value
 
     # Special case for total_l2_chan
-    total_l2_channel_count = calc_builtin_var("$total_l2_chan", sys_info)
+    total_l2_channel_count = calc_builtin_var("$total_l2_chan", sys_info.to_dict())
     if np.isnan(total_l2_channel_count) or total_l2_channel_count == 0:
         console_warning(
             "total_l2_chan is not available in sysinfo.csv, please provide the correct "

--- a/projects/rocprofiler-compute/src/utils/parser.py
+++ b/projects/rocprofiler-compute/src/utils/parser.py
@@ -18,7 +18,14 @@ from utils.debug_row_tracker import DebugRowTracker, debug_row_tracker
 from utils.logger import console_debug, console_error, console_warning, demarcate
 from utils.pattern_matching import PatternMatcherEngine
 from utils.specs import MachineSpecs
-from utils.utils_common import normalize_filter_to_str_list
+from utils.utils_common import (
+    BUILD_IN_VARS,
+    SUPPORTED_DENOM,
+    SUPPORTED_FIELD,
+    calc_builtin_var,
+    expand_placeholder_ranges,
+    normalize_filter_to_str_list,
+)
 
 # ------------------------------------------------------------------------------
 # Internal global definitions
@@ -34,46 +41,6 @@ from utils.utils_common import normalize_filter_to_str_list
 PMC_KERNEL_TOP_TABLE_ID: int = 1
 # 002 is ID of pmc_dispatch_info.csv table
 PMC_DISPATCH_INFO_TABLE_ID: int = 2
-
-# Build-in $denom defined in mongodb query:
-#       "denom": {
-#              "$switch" : {
-#                 "branches": [
-#                    {
-#                         "case":  { "$eq": [ $normUnit, "per Wave"]} ,
-#                         "then":  "&SQ_WAVES"
-#                    },
-#                    {
-#                         "case":  { "$eq": [ $normUnit, "per Cycle"]} ,
-#                         "then":  "&GRBM_GUI_ACTIVE"
-#                    },
-#                    {
-#                         "case":  { "$eq": [ $normUnit, "per Sec"]} ,
-#                         "then":  {"$divide":[{"$subtract": ["&End_Timestamp",
-#                                                              "&Start_Timestamp" ]},
-#                                              1000000000]}
-#              }
-#       }
-SUPPORTED_DENOM: dict[str, str] = {
-    "per_wave": "SQ_WAVES",
-    "per_cycle": "$GRBM_GUI_ACTIVE_PER_XCD",
-    "per_second": "((End_Timestamp - Start_Timestamp) / 1000000000)",
-    "per_kernel": "1",
-}
-
-# Build-in defined in mongodb variables:
-BUILD_IN_VARS: dict[str, str] = {
-    "GRBM_GUI_ACTIVE_PER_XCD": "(GRBM_GUI_ACTIVE / $num_xcd)",
-    "GRBM_COUNT_PER_XCD": "(GRBM_COUNT / $num_xcd)",
-    "GRBM_SPI_BUSY_PER_XCD": "(GRBM_SPI_BUSY / $num_xcd)",
-    "numActiveCUs": "TO_INT(MIN((((ROUND(AVG(((4 * SQ_BUSY_CU_CYCLES) / \
-        $GRBM_GUI_ACTIVE_PER_XCD)), 0) / $max_waves_per_cu) * 8) + \
-        MIN(MOD(ROUND(AVG(((4 * SQ_BUSY_CU_CYCLES) / \
-        $GRBM_GUI_ACTIVE_PER_XCD)), 0), $max_waves_per_cu), 8)), $cu_per_gpu))",
-    "kernelBusyCycles": "ROUND(AVG((((End_Timestamp - Start_Timestamp) / \
-        1000) * $max_sclk)), 0)",
-    "hbmBandwidth": "($max_mclk / 1000 * 32 * $num_hbm_channels)",
-}
 
 SUPPORTED_CALL: dict[str, str] = {
     # If the below has a single arg, like(expr), it is an aggr,
@@ -757,56 +724,6 @@ def gen_counter_list(formula: str) -> tuple[bool, list[str]]:
     return visited, counters
 
 
-def calc_builtin_var(var: Union[int, str], sys_info: pd.Series) -> int:  # type: ignore[return]
-    """
-    Calculate build-in variable based on sys_info:
-    """
-    if isinstance(var, int):
-        return var
-    elif isinstance(var, str) and var.startswith("$total_l2_chan"):
-        return int(sys_info.total_l2_chan)
-    else:
-        console_error(f'Built-in var "{var}" is not supported')
-
-
-def build_metric_list(
-    arch_configs: schema.ArchConfig,
-    sys_info: pd.Series,
-) -> None:
-    """
-    Populate arch_configs.metric_list from the panel configs.
-
-    Builds the metric_list mapping (panel/table/metric IDs -> display names)
-    without constructing DataFrames or metric_counters.  Use this directly when
-    only the metric listing is needed (e.g. --list-metrics, --list-blocks).
-    """
-    metric_list = {}
-
-    _expand_placeholder_ranges(arch_configs, sys_info)
-
-    for panel_id, panel in arch_configs.panel_configs.items():
-        for data_source in panel["data source"]:
-            for type, data_config in data_source.items():
-                if type == "metric_table":
-                    data_source_idx = str(data_config["id"] // 100)
-                    if data_source_idx != "0":
-                        metric_list[data_source_idx] = panel["title"]
-
-                    table_idx = f"{data_config['id'] // 100}.{data_config['id'] % 100}"
-                    metric_list[table_idx] = data_config["title"]
-
-                    for i, (key, entries) in enumerate(data_config["metric"].items()):
-                        metric_idx = f"{table_idx}.{i}"
-                        if _metric_has_valid_expr(entries, data_config):
-                            metric_list[metric_idx] = key
-
-                elif type in ("raw_csv_table", "pc_sampling_table"):
-                    data_source_idx = str(data_config["id"] // 100)
-                    metric_list[data_source_idx] = panel["title"]
-
-    setattr(arch_configs, "metric_list", metric_list)
-
-
 @demarcate
 def build_dfs(
     arch_configs: schema.ArchConfig,
@@ -833,7 +750,9 @@ def build_dfs(
     dfs_type = {}
     metric_counters = {}
 
-    _expand_placeholder_ranges(arch_configs, sys_info)
+    arch_configs.panel_configs = expand_placeholder_ranges(
+        arch_configs.panel_configs, sys_info
+    )
 
     for panel_id, panel in arch_configs.panel_configs.items():
         for data_source in panel["data source"]:
@@ -977,7 +896,7 @@ def build_metric_value_string(
     for id, df in dfs.items():
         if dfs_type[id] == "metric_table":
             for expr in df.columns:
-                if expr in schema.SUPPORTED_FIELD:
+                if expr in SUPPORTED_FIELD:
                     # NB: apply all build-in before building the whole string
                     df[expr] = df[expr].apply(
                         update_denominator_string, normal_unit=normal_unit
@@ -998,64 +917,6 @@ def build_metric_value_string(
                     df[expr] = df[expr].apply(
                         update_normal_unit_string, normal_unit=normal_unit
                     )
-
-
-def _metric_has_valid_expr(entries: dict, data_config: dict) -> bool:
-    """
-    Return True if a metric entry has at least one evaluatable expression field
-    that is not None and not the string "None".
-
-    Expression fields are identified by matching the header display name against
-    schema.SUPPORTED_FIELD, excluding Peak-prefixed fields which are empirical values.
-    """
-    for header_key, header_display in data_config["header"].items():
-        if header_display in schema.SUPPORTED_FIELD and not header_display.startswith(
-            "Peak"
-        ):
-            expr_value = entries.get(header_key)
-            if expr_value is not None and expr_value != "None":
-                return True
-    return False
-
-
-def _expand_placeholder_ranges(
-    arch_configs: schema.ArchConfig,
-    sys_info: pd.Series,
-) -> None:
-    """
-    Expand placeholder_range entries in metric_table data configs in-place.
-
-    Some metric tables define a range of metrics via a placeholder key that is
-    expanded into individual entries at load time. sys_info is required to
-    resolve built-in range variables; if it is None the table is cleared.
-    """
-    for _panel_id, panel in arch_configs.panel_configs.items():
-        for data_source in panel["data source"]:
-            for type, data_config in data_source.items():
-                if (
-                    type == "metric_table"
-                    and "metric" in data_config
-                    and "placeholder_range" in data_config["metric"]
-                ):
-                    new_metrics = {}
-                    if sys_info is not None:
-                        # NB: support single placeholder for now!!
-                        p_range = data_config["metric"].pop("placeholder_range")
-                        metric, metric_expr = data_config["metric"].popitem()
-                        for p, r in p_range.items():
-                            # NB: We have to resolve placeholder range first if it
-                            #   is a build-in var. It will be too late to do it in
-                            #   eval_metric(). This is the only reason we need
-                            #   sys_info at this stage.
-                            var = calc_builtin_var(r, sys_info)
-                            for i in range(var):
-                                new_key = metric.replace(p, str(i))
-                                new_val = {
-                                    k: v.replace(p, str(i))
-                                    for k, v in metric_expr.items()
-                                }
-                                new_metrics[new_key] = new_val
-                    data_config["metric"] = new_metrics
 
 
 def create_empirical_peaks_dict(empirical_peaks_df: pd.DataFrame) -> dict[str, float]:
@@ -1234,7 +1095,7 @@ def eval_metric(
         if dfs_type[df_id] == "metric_table":
             for row_id, row in df.iterrows():
                 for expr in df.columns:
-                    if expr in schema.SUPPORTED_FIELD and expr.lower() != "alias":
+                    if expr in SUPPORTED_FIELD and expr.lower() != "alias":
                         if row[expr]:
                             exprs_to_eval.append((df_id, row_id, expr, row[expr]))
 
@@ -2061,7 +1922,7 @@ def build_comparable_columns(time_unit: str) -> list[str]:
     """
     Build comparable columns/headers for display
     """
-    comparable_columns = schema.SUPPORTED_FIELD
+    comparable_columns = SUPPORTED_FIELD
     top_stat_base = [
         "Count",
         "Sum",
@@ -2096,4 +1957,5 @@ def correct_sys_info(mspec: MachineSpecs, specs_correction: str) -> pd.DataFrame
             console_error(
                 "analyze", f'Invalid spec "{key}". Use --specs to see valid options'
             )
-    return mspec.get_class_members()
+    # Convert dict to DataFrame for downstream pandas-based processing
+    return pd.DataFrame(mspec.get_class_members(), index=[0])

--- a/projects/rocprofiler-compute/src/utils/parser.py
+++ b/projects/rocprofiler-compute/src/utils/parser.py
@@ -1922,7 +1922,7 @@ def build_comparable_columns(time_unit: str) -> list[str]:
     """
     Build comparable columns/headers for display
     """
-    comparable_columns = SUPPORTED_FIELD
+    comparable_columns = list(SUPPORTED_FIELD)  # Copy to avoid mutating the original
     top_stat_base = [
         "Count",
         "Sum",

--- a/projects/rocprofiler-compute/src/utils/roofline_calc.py
+++ b/projects/rocprofiler-compute/src/utils/roofline_calc.py
@@ -12,7 +12,6 @@ import pandas as pd
 from utils import schema
 from utils.logger import console_debug, console_error, console_warning
 from utils.parser import eval_metric
-from utils.specs import MachineSpecs
 
 ################################################
 # Global vars
@@ -323,8 +322,6 @@ def calc_ceilings(
 def calc_ai_analyze(
     workload: schema.Workload,
     pmc_df: pd.DataFrame,
-    mspec: MachineSpecs,
-    sort_type: str,
     config: dict[str, Any],
     arch_config: schema.ArchConfig,
 ) -> dict[str, Union[list[list[float]], list[str]]]:
@@ -453,70 +450,6 @@ def calc_ai_analyze(
 
     console_debug("roofline", f"Generated {len(plot_points.kernelNames)} plot points")
     return plot_points.__dict__
-
-
-def validate_roofline_csv(workload_dir: Union[str, Path, list]) -> tuple[bool, str]:
-    """
-    Validate roofline.csv exists and has consistent structure.
-
-    Returns:
-        tuple: (is_valid, error_message)
-               is_valid=True if CSV is valid, False otherwise
-               error_message contains description if invalid
-    """
-    if isinstance(workload_dir, list):
-        base_dir = (
-            workload_dir[0][0]
-            if isinstance(workload_dir[0], (list, tuple))
-            else workload_dir[0]
-        )
-    else:
-        base_dir = workload_dir
-
-    benchmark_results = Path(base_dir) / "roofline.csv"
-
-    # Check if file exists
-    if not benchmark_results.exists():
-        return False, f"Benchmark results file not found: {benchmark_results}"
-
-    # Validate CSV structure
-    try:
-        with open(benchmark_results) as csvfile:
-            csv_reader = csv.reader(csvfile, delimiter=",")
-            row_count = 0
-            num_headers = 0
-
-            for row in csv_reader:
-                if row_count == 0:
-                    num_headers = len(row) - 1
-                    if num_headers <= 0:
-                        return (
-                            False,
-                            "Empty or invalid header row in benchmark_results",
-                        )
-                else:
-                    if len(row) - 1 != num_headers:
-                        return (
-                            False,
-                            f"Inconsistent row length in benchmark_results at "
-                            f"row {row_count + 1}. "
-                            f"Expected {num_headers + 1} columns, "
-                            f"found {len(row)}. "
-                            "Roofline data appears corrupted or incomplete.",
-                        )
-                row_count += 1
-
-            if row_count < 2:
-                return (
-                    False,
-                    f"Insufficient data in benchmark_results. "
-                    f"Found {row_count} rows (need at least 2)."
-                    f" Roofline data appears corrupted or incomplete.",
-                )
-    except Exception as e:
-        return False, f"Failed to read benchmark_results: {e}"
-
-    return True, ""
 
 
 def construct_roof(

--- a/projects/rocprofiler-compute/src/utils/schema.py
+++ b/projects/rocprofiler-compute/src/utils/schema.py
@@ -49,54 +49,5 @@ class Workload:
     matched_torch_trace_df: pd.DataFrame = field(default_factory=pd.DataFrame)
 
 
-# Metrics will be calculated ONLY when the header(key) is in below list
-SUPPORTED_FIELD = [
-    "Value",
-    "Minimum",
-    "Maximum",
-    "Average",
-    "Median",
-    "Min",
-    "Max",
-    "Avg",
-    "Pct of Peak",
-    "Peak",
-    "Peak (Empirical)",
-    "Count",
-    "Mean",
-    "Percent",
-    "Std Dev",
-    "Q1",
-    "Q3",
-    "Expression",
-    # Special keywords for L2 channel
-    "Channel",
-    "L2 Cache Hit Rate",
-    "Requests",
-    "L2 Read",
-    "L2 Write",
-    "L2 Atomic",
-    "L2-Fabric Requests",
-    "L2-Fabric Read",
-    "L2-Fabric Write and Atomic",
-    "L2-Fabric Atomic",
-    "L2 Read Req",
-    "L2 Write Req",
-    "L2 Atomic Req",
-    "L2-Fabric Read Req",
-    "L2-Fabric Write and Atomic Req",
-    "L2-Fabric Atomic Req",
-    "L2-Fabric Read Latency",
-    "L2-Fabric Write Latency",
-    "L2-Fabric Atomic Latency",
-    "L2-Fabric Read Stall (PCIe)",
-    "L2-Fabric Read Stall (Infinity Fabric™)",
-    "L2-Fabric Read Stall (HBM)",
-    "L2-Fabric Write Stall (PCIe)",
-    "L2-Fabric Write Stall (Infinity Fabric™)",
-    "L2-Fabric Write Stall (HBM)",
-    "L2-Fabric Write Starve",
-]
-
 # The prefix of raw pmc_perf.csv
 PMC_PERF_FILE_PREFIX = "pmc_perf"

--- a/projects/rocprofiler-compute/src/utils/specs.py
+++ b/projects/rocprofiler-compute/src/utils/specs.py
@@ -17,8 +17,6 @@ from math import ceil
 from pathlib import Path as path
 from typing import Any, Optional, TypeVar
 
-import pandas as pd
-
 import config
 from utils.amdsmi_interface import (
     amdsmi_ctx,
@@ -36,8 +34,7 @@ from utils.logger import (
     demarcate,
 )
 from utils.mi_gpu_spec import mi_gpu_specs
-from utils.tty import get_table_string
-from utils.utils_common import get_version
+from utils.utils_common import format_table_ascii, get_version
 
 T = TypeVar("T")
 
@@ -758,9 +755,10 @@ class MachineSpecs:
         else:
             return self.total_l2_chan
 
-    def get_class_members(self) -> pd.DataFrame:
-        data = {}
-        missing_required_fields = []
+    def get_class_members(self) -> dict[str, Any]:
+        """Return class members as a dictionary."""
+        data: dict[str, Any] = {}
+        missing_required_fields: list[str] = []
 
         for class_field in fields(self):
             if not class_field.metadata.get("show_in_table", True):
@@ -783,18 +781,21 @@ class MachineSpecs:
                 )
             console_warning(f"Missing specs fields for {self.gpu_arch}")
 
-        return pd.DataFrame(data, index=[0])
+        return data
 
     def __repr__(self) -> str:
         topstr = (
             "Machine Specifications: describing the state of the machine that "
             "ROCm Compute Profiler data was collected on.\n"
         )
-        data = []
+        data: list[dict[str, Any]] = []
+        has_description = False
+        has_unit = False
+
         for class_field in fields(self):
             name = class_field.name
             if class_field.metadata.get("show_in_table", True):
-                _data = {}
+                _data: dict[str, Any] = {}
                 value = getattr(self, name)
                 if class_field.metadata:
                     # check out of table before any re-naming for pretty-printing
@@ -813,20 +814,22 @@ class MachineSpecs:
                         name = class_field.metadata["name"]
                     if "unit" in class_field.metadata:
                         _data["Unit"] = class_field.metadata["unit"]
+                        has_unit = True
                     if "doc" in class_field.metadata:
                         _data["Description"] = class_field.metadata["doc"]
+                        has_description = True
                 _data["Spec"] = name
-                _data["Value"] = value
+                _data["Value"] = value if value is not None else ""
                 data.append(_data)
-        df = pd.DataFrame(data)
+
+        # Build columns list based on what data is present
         columns = ["Spec", "Value"]
-        if "Description" in df.columns:
-            columns += ["Description"]
-        if "Unit" in df.columns:
-            columns += ["Unit"]
-        df = df[columns]
-        df = df.fillna("")
-        return topstr + get_table_string(df, transpose=False, decimal=2)
+        if has_description:
+            columns.append("Description")
+        if has_unit:
+            columns.append("Unit")
+
+        return topstr + format_table_ascii(data, columns, decimal=2)
 
 
 def get_rocm_ver() -> str:

--- a/projects/rocprofiler-compute/src/utils/utils_common.py
+++ b/projects/rocprofiler-compute/src/utils/utils_common.py
@@ -2,7 +2,6 @@
 # SPDX-License-Identifier:  MIT
 
 import argparse
-import copy
 import csv
 import ctypes
 import glob
@@ -729,18 +728,15 @@ def expand_placeholder_ranges(
     sys_info: Optional[dict[str, Any]],
 ) -> OrderedDict[int, dict[str, Any]]:
     """
-    Expand placeholder_range entries in metric_table data configs.
+    Expand placeholder_range entries in metric_table data configs in-place.
 
-    Returns a new OrderedDict with expanded placeholders. The original
-    panel_configs is not modified.
+    Mutates panel_configs directly and returns the same object for convenience.
 
     Some metric tables define a range of metrics via a placeholder key that is
     expanded into individual entries at load time. sys_info is required to
     resolve built-in range variables; if it is None the table is cleared.
     """
-    result = copy.deepcopy(panel_configs)
-
-    for _panel_id, panel in result.items():
+    for _panel_id, panel in panel_configs.items():
         for data_source in panel["data source"]:
             for type_key, data_config in data_source.items():
                 if (
@@ -768,7 +764,7 @@ def expand_placeholder_ranges(
                                 new_metrics[new_key] = new_val
                     data_config["metric"] = new_metrics
 
-    return result
+    return panel_configs
 
 
 def _metric_has_valid_expr(entries: dict, data_config: dict) -> bool:

--- a/projects/rocprofiler-compute/src/utils/utils_common.py
+++ b/projects/rocprofiler-compute/src/utils/utils_common.py
@@ -2,6 +2,8 @@
 # SPDX-License-Identifier:  MIT
 
 import argparse
+import copy
+import csv
 import ctypes
 import glob
 import io
@@ -13,15 +15,15 @@ import selectors
 import shutil
 import subprocess
 import sys
+import textwrap
 import threading
 import time
 import uuid
+from collections import OrderedDict
 from collections.abc import Generator
 from contextlib import contextmanager
 from pathlib import Path
 from typing import Any, Optional, Union
-
-import yaml
 
 import config
 from utils.logger import (
@@ -30,9 +32,80 @@ from utils.logger import (
     console_log,
     console_warning,
 )
+from vendored import yaml
 
 # Global constants
 METRIC_ID_RE = re.compile(pattern=r"^\d{1,2}(?:\.\d{1,2}){0,2}$")
+
+SUPPORTED_DENOM: dict[str, str] = {
+    "per_wave": "SQ_WAVES",
+    "per_cycle": "$GRBM_GUI_ACTIVE_PER_XCD",
+    "per_second": "((End_Timestamp - Start_Timestamp) / 1000000000)",
+    "per_kernel": "1",
+}
+
+# Build-in defined in mongodb variables:
+BUILD_IN_VARS: dict[str, str] = {
+    "GRBM_GUI_ACTIVE_PER_XCD": "(GRBM_GUI_ACTIVE / $num_xcd)",
+    "GRBM_COUNT_PER_XCD": "(GRBM_COUNT / $num_xcd)",
+    "GRBM_SPI_BUSY_PER_XCD": "(GRBM_SPI_BUSY / $num_xcd)",
+    "numActiveCUs": "TO_INT(MIN((((ROUND(AVG(((4 * SQ_BUSY_CU_CYCLES) / \
+        $GRBM_GUI_ACTIVE_PER_XCD)), 0) / $max_waves_per_cu) * 8) + \
+        MIN(MOD(ROUND(AVG(((4 * SQ_BUSY_CU_CYCLES) / \
+        $GRBM_GUI_ACTIVE_PER_XCD)), 0), $max_waves_per_cu), 8)), $cu_per_gpu))",
+    "kernelBusyCycles": "ROUND(AVG((((End_Timestamp - Start_Timestamp) / \
+        1000) * $max_sclk)), 0)",
+    "hbmBandwidth": "($max_mclk / 1000 * 32 * $num_hbm_channels)",
+}
+
+# Supported expression field names for metric tables
+SUPPORTED_FIELD: list[str] = [
+    "Value",
+    "Minimum",
+    "Maximum",
+    "Average",
+    "Median",
+    "Min",
+    "Max",
+    "Avg",
+    "Pct of Peak",
+    "Peak",
+    "Peak (Empirical)",
+    "Count",
+    "Mean",
+    "Percent",
+    "Std Dev",
+    "Q1",
+    "Q3",
+    "Expression",
+    # Special keywords for L2 channel
+    "Channel",
+    "L2 Cache Hit Rate",
+    "Requests",
+    "L2 Read",
+    "L2 Write",
+    "L2 Atomic",
+    "L2-Fabric Requests",
+    "L2-Fabric Read",
+    "L2-Fabric Write and Atomic",
+    "L2-Fabric Atomic",
+    "L2 Read Req",
+    "L2 Write Req",
+    "L2 Atomic Req",
+    "L2-Fabric Read Req",
+    "L2-Fabric Write and Atomic Req",
+    "L2-Fabric Atomic Req",
+    "L2-Fabric Read Latency",
+    "L2-Fabric Write Latency",
+    "L2-Fabric Atomic Latency",
+    "L2-Fabric Read Stall (PCIe)",
+    "L2-Fabric Read Stall (Infinity Fabric™)",
+    "L2-Fabric Read Stall (HBM)",
+    "L2-Fabric Write Stall (PCIe)",
+    "L2-Fabric Write Stall (Infinity Fabric™)",
+    "L2-Fabric Write Stall (HBM)",
+    "L2-Fabric Write Starve",
+]
 
 # Global state: rocprof being used by profile mode
 _rocprof_cmd = ""
@@ -613,6 +686,145 @@ def parse_sets_yaml(arch: str) -> dict[str, Any]:
     return sets_info
 
 
+def load_panel_configs(
+    dirs: list[str],
+) -> OrderedDict[int, dict[str, Any]]:
+    """
+    Load all panel configs from yaml file.
+    """
+    configs: dict[int, dict[str, Any]] = {}
+    for dir_path in dirs:
+        for yaml_file in Path(dir_path).glob("*.yaml"):
+            with open(yaml_file) as file:
+                config_yml = yaml.safe_load(file)
+                # metric key can be None due to some metric-
+                # tables not having any metrics
+                # metric key should be empty dict instead of None
+                panel_config = config_yml["Panel Config"]
+                for data_source in panel_config["data source"]:
+                    metric_table = data_source.get("metric_table")
+                    if metric_table and metric_table["metric"] is None:
+                        metric_table["metric"] = {}
+                configs[panel_config["id"]] = panel_config
+
+    # TODO: sort metrics as the header order in case they-
+    # are not defined in the same order
+    return OrderedDict(sorted(configs.items()))
+
+
+def calc_builtin_var(var: Union[int, str], sys_info: dict[str, Any]) -> int:  # type: ignore[return]
+    """
+    Calculate build-in variable based on sys_info.
+    """
+    if isinstance(var, int):
+        return var
+    elif isinstance(var, str) and var.startswith("$total_l2_chan"):
+        return int(sys_info["total_l2_chan"])
+    else:
+        console_error(f'Built-in var "{var}" is not supported')
+
+
+def expand_placeholder_ranges(
+    panel_configs: OrderedDict[int, dict[str, Any]],
+    sys_info: Optional[dict[str, Any]],
+) -> OrderedDict[int, dict[str, Any]]:
+    """
+    Expand placeholder_range entries in metric_table data configs.
+
+    Returns a new OrderedDict with expanded placeholders. The original
+    panel_configs is not modified.
+
+    Some metric tables define a range of metrics via a placeholder key that is
+    expanded into individual entries at load time. sys_info is required to
+    resolve built-in range variables; if it is None the table is cleared.
+    """
+    result = copy.deepcopy(panel_configs)
+
+    for _panel_id, panel in result.items():
+        for data_source in panel["data source"]:
+            for type_key, data_config in data_source.items():
+                if (
+                    type_key == "metric_table"
+                    and "metric" in data_config
+                    and "placeholder_range" in data_config["metric"]
+                ):
+                    new_metrics: dict[str, Any] = {}
+                    if sys_info is not None:
+                        # NB: support single placeholder for now!!
+                        p_range = data_config["metric"].pop("placeholder_range")
+                        metric, metric_expr = data_config["metric"].popitem()
+                        for p, r in p_range.items():
+                            # NB: We have to resolve placeholder range first if it
+                            #   is a build-in var. It will be too late to do it in
+                            #   eval_metric(). This is the only reason we need
+                            #   sys_info at this stage.
+                            var = calc_builtin_var(r, sys_info)
+                            for i in range(var):
+                                new_key = metric.replace(p, str(i))
+                                new_val = {
+                                    k: v.replace(p, str(i))
+                                    for k, v in metric_expr.items()
+                                }
+                                new_metrics[new_key] = new_val
+                    data_config["metric"] = new_metrics
+
+    return result
+
+
+def _metric_has_valid_expr(entries: dict, data_config: dict) -> bool:
+    """
+    Return True if a metric entry has at least one evaluatable expression field
+    that is not None and not the string "None".
+
+    Expression fields are identified by matching the header display name against
+    SUPPORTED_FIELD, excluding Peak-prefixed fields which are empirical values.
+    """
+    for header_key, header_display in data_config["header"].items():
+        if header_display in SUPPORTED_FIELD and not header_display.startswith("Peak"):
+            expr_value = entries.get(header_key)
+            if expr_value is not None and expr_value != "None":
+                return True
+    return False
+
+
+def build_metric_list(
+    panel_configs: OrderedDict[int, dict[str, Any]],
+    sys_info: Optional[dict[str, Any]],
+) -> dict[str, str]:
+    """
+    Build metric_list from the panel configs.
+
+    Returns a mapping of (panel/table/metric IDs -> display names)
+    without constructing DataFrames or metric_counters. Use this directly when
+    only the metric listing is needed (e.g. --list-metrics, --list-blocks).
+    """
+    metric_list: dict[str, str] = {}
+
+    expanded_configs = expand_placeholder_ranges(panel_configs, sys_info)
+
+    for panel_id, panel in expanded_configs.items():
+        for data_source in panel["data source"]:
+            for type_key, data_config in data_source.items():
+                if type_key == "metric_table":
+                    data_source_idx = str(data_config["id"] // 100)
+                    if data_source_idx != "0":
+                        metric_list[data_source_idx] = panel["title"]
+
+                    table_idx = f"{data_config['id'] // 100}.{data_config['id'] % 100}"
+                    metric_list[table_idx] = data_config["title"]
+
+                    for i, (key, entries) in enumerate(data_config["metric"].items()):
+                        metric_idx = f"{table_idx}.{i}"
+                        if _metric_has_valid_expr(entries, data_config):
+                            metric_list[metric_idx] = key
+
+                elif type_key in ("raw_csv_table", "pc_sampling_table"):
+                    data_source_idx = str(data_config["id"] // 100)
+                    metric_list[data_source_idx] = panel["title"]
+
+    return metric_list
+
+
 def get_uuid(length: int = 8) -> str:
     return uuid.uuid4().hex[:length]
 
@@ -836,3 +1048,190 @@ def set_locale_encoding() -> None:
                 "Please ensure that a UTF-8-based locale is available on your system.",
                 exit=False,
             )
+
+
+def validate_roofline_csv(workload_dir: Union[str, Path, list]) -> tuple[bool, str]:
+    """
+    Validate roofline.csv exists and has consistent structure.
+
+    Returns:
+        tuple: (is_valid, error_message)
+               is_valid=True if CSV is valid, False otherwise
+               error_message contains description if invalid
+    """
+    if isinstance(workload_dir, list):
+        base_dir = (
+            workload_dir[0][0]
+            if isinstance(workload_dir[0], (list, tuple))
+            else workload_dir[0]
+        )
+    else:
+        base_dir = workload_dir
+
+    benchmark_results = Path(base_dir) / "roofline.csv"
+
+    # Check if file exists
+    if not benchmark_results.exists():
+        return False, f"Benchmark results file not found: {benchmark_results}"
+
+    # Validate CSV structure
+    try:
+        with open(benchmark_results) as csvfile:
+            csv_reader = csv.reader(csvfile, delimiter=",")
+            row_count = 0
+            num_headers = 0
+
+            for row in csv_reader:
+                if row_count == 0:
+                    num_headers = len(row) - 1
+                    if num_headers <= 0:
+                        return (
+                            False,
+                            "Empty or invalid header row in benchmark_results",
+                        )
+                else:
+                    if len(row) - 1 != num_headers:
+                        return (
+                            False,
+                            f"Inconsistent row length in benchmark_results at "
+                            f"row {row_count + 1}. "
+                            f"Expected {num_headers + 1} columns, "
+                            f"found {len(row)}. "
+                            "Roofline data appears corrupted or incomplete.",
+                        )
+                row_count += 1
+
+            if row_count < 2:
+                return (
+                    False,
+                    f"Insufficient data in benchmark_results. "
+                    f"Found {row_count} rows (need at least 2)."
+                    f" Roofline data appears corrupted or incomplete.",
+                )
+    except Exception as e:
+        return False, f"Failed to read benchmark_results: {e}"
+
+    return True, ""
+
+
+def format_table_ascii(
+    data: list[dict[str, Any]],
+    columns: list[str],
+    description_wrap_width: int = 40,
+    decimal: int = 2,
+) -> str:
+    """
+    Format a list of dicts as an ASCII table string using only stdlib.
+
+    Args:
+        data: List of dictionaries containing row data
+        columns: List of column names to display (in order)
+        description_wrap_width: Width to wrap Description column (default 40)
+        decimal: Number of decimal places for floats (default 2)
+
+    Returns:
+        Formatted ASCII table string
+    """
+    if not data:
+        return ""
+
+    # Calculate column widths
+    col_widths: dict[str, int] = {}
+    wrapped_data: list[dict[str, list[str]]] = []
+
+    for col in columns:
+        col_widths[col] = len(col)
+
+    # Process each row and wrap text as needed
+    for row in data:
+        wrapped_row: dict[str, list[str]] = {}
+        for col in columns:
+            value = row.get(col, "")
+            if value is None:
+                value = ""
+
+            # Format floats with specified decimal places (matches tabulate floatfmt)
+            if isinstance(value, float):
+                value = f"{value:.{decimal}f}"
+            elif isinstance(value, int):
+                value = str(value)
+            else:
+                value = str(value)
+
+            # Wrap Description column using textwrap.fill behavior
+            # (collapses whitespace, wraps at word boundaries)
+            if col == "Description":
+                # Use textwrap.fill to match original behavior exactly
+                wrapped_text = textwrap.fill(value, width=description_wrap_width)
+                lines = wrapped_text.split("\n") if wrapped_text else [""]
+            else:
+                lines = [value]
+
+            wrapped_row[col] = lines
+
+            # Update column width based on longest line
+            for line in lines:
+                col_widths[col] = max(col_widths[col], len(line))
+
+        wrapped_data.append(wrapped_row)
+
+    # Build the table
+    result: list[str] = []
+
+    # Index column width: max of "index" (5) and the widest row number
+    idx_width = max(5, len(str(len(data) - 1)))
+
+    # Create separator line
+    def make_separator() -> str:
+        parts = ["+"]
+        # Index column
+        parts.append("-" * (idx_width + 2) + "+")
+        for col in columns:
+            parts.append("-" * (col_widths[col] + 2) + "+")
+        return "".join(parts)
+
+    # Create header
+    def make_header() -> str:
+        parts = ["|"]
+        parts.append(f" {'index':^{idx_width}} |")
+        for col in columns:
+            parts.append(f" {col:<{col_widths[col]}} |")
+        return "".join(parts)
+
+    # Create data row (handles multi-line cells)
+    def make_row(row_idx: int, wrapped_row: dict[str, list[str]]) -> list[str]:
+        # Find max lines in this row
+        max_lines = max(len(lines) for lines in wrapped_row.values())
+
+        row_lines: list[str] = []
+        for line_idx in range(max_lines):
+            parts = ["|"]
+            # Index column - only show on first line
+            if line_idx == 0:
+                parts.append(f" {row_idx:>{idx_width}} |")
+            else:
+                parts.append(" " * (idx_width + 1) + " |")
+
+            for col in columns:
+                lines = wrapped_row[col]
+                if line_idx < len(lines):
+                    cell_value = lines[line_idx]
+                else:
+                    cell_value = ""
+                parts.append(f" {cell_value:<{col_widths[col]}} |")
+            row_lines.append("".join(parts))
+        return row_lines
+
+    # Build table
+    separator = make_separator()
+    result.append(separator)
+    result.append(make_header())
+    result.append(separator)
+
+    for idx, wrapped_row in enumerate(wrapped_data):
+        row_lines = make_row(idx, wrapped_row)
+        for line in row_lines:
+            result.append(line)
+        result.append(separator)
+
+    return "\n".join(result)

--- a/projects/rocprofiler-compute/src/utils/utils_profile.py
+++ b/projects/rocprofiler-compute/src/utils/utils_profile.py
@@ -15,8 +15,6 @@ import traceback
 from pathlib import Path
 from typing import Any, Union, cast
 
-import yaml
-
 import config
 import utils.utils_profile_csv as csv_ops
 from utils import rocpd_data
@@ -33,13 +31,13 @@ from utils.utils_common import (
     parse_text,
     perform_attach_detach,
 )
+from vendored import yaml
 
 
 def run_prof(
     fnames: Union[list[str], str],
     profiler_options: Union[list[str], dict[str, Union[str, list[str]]]],
     workload_dir: str,
-    mspec: Any,  # noqa: ANN401
     loglevel: int,
     format_rocprof_output: str,
     torch_trace_enabled: bool = False,
@@ -420,7 +418,7 @@ def gen_sysinfo(
     mspec: Any,  # noqa: ANN401
     soc: Any,  # noqa: ANN401
 ) -> None:
-    df = mspec.get_class_members()
+    data = mspec.get_class_members()
 
     # Append workload information to machine specs
     df["command"] = app_cmd
@@ -429,9 +427,9 @@ def gen_sysinfo(
     blocks = ["SQ", "LDS", "SQC", "TA", "TD", "TCP", "TCC", "SPI", "CPC", "CPF"]
     if not skip_roof:
         blocks.append("roofline")
-    df["ip_blocks"] = "|".join(blocks)
+    data["ip_blocks"] = "|".join(blocks)
 
-    df.to_csv(workload_dir + "/" + "sysinfo.csv", index=False)
+    csv_ops.write_csv_from_dicts(workload_dir + "/" + "sysinfo.csv", [data])
 
 
 def get_submodules(package_name: str) -> list[str]:

--- a/projects/rocprofiler-compute/src/utils/utils_profile.py
+++ b/projects/rocprofiler-compute/src/utils/utils_profile.py
@@ -421,8 +421,8 @@ def gen_sysinfo(
     data = mspec.get_class_members()
 
     # Append workload information to machine specs
-    df["command"] = app_cmd
-    df["workload_path"] = workload_dir
+    data["command"] = app_cmd
+    data["workload_path"] = workload_dir
 
     blocks = ["SQ", "LDS", "SQC", "TA", "TD", "TCP", "TCC", "SPI", "CPC", "CPF"]
     if not skip_roof:

--- a/projects/rocprofiler-compute/tests/test_analyze_commands.py
+++ b/projects/rocprofiler-compute/tests/test_analyze_commands.py
@@ -1338,9 +1338,9 @@ def test_parser_error_handling():
 
     from utils.parser import (
         build_eval_string,
-        calc_builtin_var,
         update_denominator_string,
     )
+    from utils.utils_common import calc_builtin_var
 
     try:
         build_eval_string("AVG(SQ_WAVES)", None, config={})
@@ -1351,10 +1351,7 @@ def test_parser_error_handling():
     assert build_eval_string("", "pmc_perf", config={}) == ""
     assert update_denominator_string("", "per_wave") == ""
 
-    class MockSysInfo:
-        total_l2_chan = 32
-
-    sys_info = MockSysInfo()
+    sys_info = {"total_l2_chan": 32}
     try:
         calc_builtin_var("$unsupported_var", sys_info)
         assert False, "Should have raised exception for unsupported var"

--- a/projects/rocprofiler-compute/tests/test_gpu_specs.py
+++ b/projects/rocprofiler-compute/tests/test_gpu_specs.py
@@ -41,7 +41,7 @@ def parse_table_dict(output: str) -> dict:
     """
     Parse an ASCII table into a dict mapping Spec -> Value.
     """
-    lines = [line for line in output.splitlines() if line.startswith("│")]
+    lines = [line for line in output.splitlines() if line.startswith("|")]
     # locate header row (the one containing 'Spec' and 'Value')
     header_idx = next(
         (i for i, ln in enumerate(lines) if "Spec" in ln and "Value" in ln), None
@@ -49,16 +49,17 @@ def parse_table_dict(output: str) -> dict:
     if header_idx is None:
         raise ValueError("Header row with Spec and Value not found")
 
-    header_cells = [c.strip() for c in lines[header_idx].strip("│").split("│")]
+    header_cells = [c.strip() for c in lines[header_idx].strip("|").split("|")]
 
     spec_i = header_cells.index("Spec")
     value_i = header_cells.index("Value")
 
     result = {}
-    for ln in lines[header_idx + 2 :]:
-        if ln.startswith("├") or ln.startswith("╘"):
+    for ln in lines[header_idx + 1 :]:
+        # Skip separator lines
+        if ln.startswith("+"):
             continue
-        cells = [c.strip() for c in ln.strip("│").split("│")]
+        cells = [c.strip() for c in ln.strip("|").split("|")]
         if len(cells) <= max(spec_i, value_i):
             continue
         spec = cells[spec_i]

--- a/projects/rocprofiler-compute/tests/test_profile_general.py
+++ b/projects/rocprofiler-compute/tests/test_profile_general.py
@@ -2066,8 +2066,8 @@ def test_comprehensive_error_paths():
     from utils.parser import (
         build_comparable_columns,
         build_eval_string,
-        calc_builtin_var,
     )
+    from utils.utils_common import calc_builtin_var
 
     columns = build_comparable_columns("ms")
     expected = [
@@ -2080,10 +2080,7 @@ def test_comprehensive_error_paths():
     for expected_col in expected:
         assert expected_col in columns
 
-    class MockSysInfo:
-        total_l2_chan = 16
-
-    sys_info = MockSysInfo()
+    sys_info = {"total_l2_chan": 16}
     result = calc_builtin_var(42, sys_info)
     assert result == 42
 

--- a/projects/rocprofiler-compute/tests/test_roofline_calc_ai_analyze.py
+++ b/projects/rocprofiler-compute/tests/test_roofline_calc_ai_analyze.py
@@ -1,7 +1,6 @@
 # Copyright (c) Advanced Micro Devices, Inc.
 # SPDX-License-Identifier:  MIT
 
-from unittest import mock
 
 import numpy as np
 import pandas as pd
@@ -72,8 +71,6 @@ def run_calc_ai_analyze_with_values(monkeypatch, metric_values):
     return calc_ai_analyze(
         workload=workload,
         pmc_df=pmc_df,
-        mspec=mock.MagicMock(),
-        sort_type="kernels",
         config={},
         arch_config=arch_config,
     )

--- a/projects/rocprofiler-compute/tests/test_utils.py
+++ b/projects/rocprofiler-compute/tests/test_utils.py
@@ -6440,7 +6440,7 @@ def test_validate_roofline_csv_valid():
     Test validate_roofline_csv returns True for a valid roofline.csv file.
     Creates a temporary directory with a properly formatted CSV.
     """
-    from utils.roofline_calc import validate_roofline_csv
+    from utils.utils_common import validate_roofline_csv
 
     with tempfile.TemporaryDirectory() as tmpdir:
         csv_path = Path(tmpdir) / "roofline.csv"
@@ -6460,7 +6460,7 @@ def test_validate_roofline_csv_invalid_inconsistent_columns():
     Test validate_roofline_csv returns False for a CSV with inconsistent row lengths.
     This simulates corrupted or incomplete benchmark data.
     """
-    from utils.roofline_calc import validate_roofline_csv
+    from utils.utils_common import validate_roofline_csv
 
     with tempfile.TemporaryDirectory() as tmpdir:
         csv_path = Path(tmpdir) / "roofline.csv"
@@ -7368,17 +7368,15 @@ class TestBuildMetricList:
         import sys
 
         sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
-        from utils import schema
-        from utils.parser import build_metric_list
+        from utils.utils_common import build_metric_list
 
-        cls.schema = schema
         cls.build_metric_list = staticmethod(build_metric_list)
 
-    def _build_test_arch_config_for_single_metric(
+    def _build_test_panel_configs_for_single_metric(
         self, metric_name: str, expression_values: dict
     ):
         """
-        Build an ArchConfig containing a single metric for testing.
+        Build panel_configs containing a single metric for testing.
         """
         from collections import OrderedDict
 
@@ -7403,62 +7401,62 @@ class TestBuildMetricList:
             "data source": [{"metric_table": table}],
         }
 
-        ac = self.schema.ArchConfig()
-        ac.panel_configs = panel_configs
-        return ac
+        return panel_configs
 
     @staticmethod
-    def _extract_leaf_metric_entries(ac):
+    def _extract_leaf_metric_entries(metric_list):
         """Return only leaf metric entries whose ID has format 'panel.table.index'."""
-        return {k: v for k, v in ac.metric_list.items() if k.count(".") == 2}
+        return {k: v for k, v in metric_list.items() if k.count(".") == 2}
 
     def test_given_metric_with_valid_value__it_presents_in_metric_list(self):
-        ac = self._build_test_arch_config_for_single_metric(
+        panel_configs = self._build_test_panel_configs_for_single_metric(
             "Valid Metric A", {"value": "AVG(COUNTER_A)"}
         )
-        self.build_metric_list(ac, None)
-        assert "Valid Metric A" in self._extract_leaf_metric_entries(ac).values()
+        metric_list = self.build_metric_list(panel_configs, None)
+        leaf_entries = self._extract_leaf_metric_entries(metric_list)
+        assert "Valid Metric A" in leaf_entries.values()
 
     def test_given_metric_with_python_none__it_doesnt_present_in_metric_list(self):
-        ac = self._build_test_arch_config_for_single_metric(
+        panel_configs = self._build_test_panel_configs_for_single_metric(
             "Unsupported Metric B", {"value": None}
         )
-        self.build_metric_list(ac, None)
-        assert (
-            "Unsupported Metric B" not in self._extract_leaf_metric_entries(ac).values()
-        )
+        metric_list = self.build_metric_list(panel_configs, None)
+        leaf_entries = self._extract_leaf_metric_entries(metric_list)
+        assert "Unsupported Metric B" not in leaf_entries.values()
 
     def test_given_metric_with_string_none__it_doesnt_present_in_metric_list(self):
-        ac = self._build_test_arch_config_for_single_metric(
+        panel_configs = self._build_test_panel_configs_for_single_metric(
             "Unsupported Metric C", {"value": "None"}
         )
-        self.build_metric_list(ac, None)
-        assert (
-            "Unsupported Metric C" not in self._extract_leaf_metric_entries(ac).values()
-        )
+        metric_list = self.build_metric_list(panel_configs, None)
+        leaf_entries = self._extract_leaf_metric_entries(metric_list)
+        assert "Unsupported Metric C" not in leaf_entries.values()
 
     def test_given_expr_metric__it_presents_in_metric_list(self):
-        ac = self._build_test_arch_config_for_single_metric(
+        panel_configs = self._build_test_panel_configs_for_single_metric(
             "Expr Metric", {"expr": "(100 * COUNTER_B / COUNTER_C)"}
         )
-        self.build_metric_list(ac, None)
-        assert "Expr Metric" in self._extract_leaf_metric_entries(ac).values()
+        metric_list = self.build_metric_list(panel_configs, None)
+        leaf_entries = self._extract_leaf_metric_entries(metric_list)
+        assert "Expr Metric" in leaf_entries.values()
 
     def test_given_metric_with_partial_avg_min_max__it_presents_in_metric_list(self):
-        ac = self._build_test_arch_config_for_single_metric(
+        panel_configs = self._build_test_panel_configs_for_single_metric(
             "Partial Metric", {"avg": "AVG(COUNTER_E)", "min": None, "max": None}
         )
-        self.build_metric_list(ac, None)
-        assert "Partial Metric" in self._extract_leaf_metric_entries(ac).values()
+        metric_list = self.build_metric_list(panel_configs, None)
+        leaf_entries = self._extract_leaf_metric_entries(metric_list)
+        assert "Partial Metric" in leaf_entries.values()
 
     def test_given_metric_with_all_none_avg_min_max__it_doesnt_present_in_metric_list(
         self,
     ):
-        ac = self._build_test_arch_config_for_single_metric(
+        panel_configs = self._build_test_panel_configs_for_single_metric(
             "All None Metric", {"avg": None, "min": None, "max": None}
         )
-        self.build_metric_list(ac, None)
-        assert "All None Metric" not in self._extract_leaf_metric_entries(ac).values()
+        metric_list = self.build_metric_list(panel_configs, None)
+        leaf_entries = self._extract_leaf_metric_entries(metric_list)
+        assert "All None Metric" not in leaf_entries.values()
 
 
 # ---------------------------------------------------------------------------
@@ -7935,3 +7933,51 @@ def test_parse_patterns_star():
 
     args = Namespace(torch_operator=["*,torch.relu"])
     assert parse_torch_operator_patterns(args) == ["*", "torch.relu"]
+
+
+# =============================================================================
+# format_table_ascii TESTS
+# =============================================================================
+
+
+def test_format_table_ascii_basic():
+    """Test format_table_ascii produces correct ASCII table output."""
+    from utils.utils_common import format_table_ascii
+
+    data = [
+        {"Spec": "GPU Model", "Value": "MI300X", "Description": "The GPU model name."},
+        {"Spec": "Max SCLK", "Value": "2100", "Description": "Maximum clock speed."},
+    ]
+    columns = ["Spec", "Value", "Description"]
+
+    result = format_table_ascii(data, columns)
+
+    # Check table structure
+    assert "+-------+" in result  # Has separators
+    assert "| index |" in result  # Has index column header
+    assert "| Spec" in result  # Has Spec column
+    assert "| GPU Model" in result  # Has data
+    assert "| MI300X" in result  # Has value
+    assert "| 2100" in result  # Has second row value
+
+
+def test_format_table_ascii_text_wrapping():
+    """Test that long Description text is wrapped at 40 characters."""
+    from utils.utils_common import format_table_ascii
+
+    long_desc = (
+        "This is a very long description that should be wrapped "
+        "across multiple lines in the table output."
+    )
+    data = [{"Spec": "Test", "Value": "123", "Description": long_desc}]
+    columns = ["Spec", "Value", "Description"]
+
+    result = format_table_ascii(data, columns)
+    lines = result.split("\n")
+
+    # Find lines containing description content (not separator lines)
+    desc_lines = [
+        ln for ln in lines if "|" in ln and "Description" not in ln and "---" not in ln
+    ]
+    # Should have multiple lines for the wrapped description
+    assert len(desc_lines) > 1, "Long description should wrap to multiple lines"

--- a/projects/rocprofiler-compute/tests/test_utils.py
+++ b/projects/rocprofiler-compute/tests/test_utils.py
@@ -43,16 +43,6 @@ SUPPORTED_ARCHS = {
 }
 
 
-class MockMSpec:
-    def __init__(
-        self, gpu_model="mi300a", gpu_arch="gfx942", compute_partition=None, l2_banks=32
-    ):
-        self.gpu_model = gpu_model
-        self.gpu_arch = gpu_arch
-        self.compute_partition = compute_partition
-        self.l2_banks = l2_banks
-
-
 class MockArgs:
     def __init__(self, **kwargs):
         # Set kwargs as attributes
@@ -1377,15 +1367,6 @@ def test_run_prof_success_v3(tmp_path, monkeypatch):
     with open(workload_dir + "/out/pmc_1/results_0.csv", "w") as f:
         f.write(csv_content)
 
-    class MockSpec:
-        def __init__(self):
-            self.gpu_model = "mi250x"
-            self.l2_banks = 32
-            self.gpu_arch = "gfx90a"
-            self.compute_partition = "CPX"
-
-    mspec = MockSpec()
-
     monkeypatch.setattr("utils.utils_common._rocprof_cmd", "rocprofv3")
     monkeypatch.setattr(
         "utils.utils_profile.capture_subprocess_output",
@@ -1397,9 +1378,7 @@ def test_run_prof_success_v3(tmp_path, monkeypatch):
         "glob.glob", lambda pattern: [workload_dir + "/out/pmc_1/results_0.csv"]
     )
 
-    utils_profile.run_prof(
-        str(fname), ["--arg"], workload_dir, mspec, logging.INFO, "csv"
-    )
+    utils_profile.run_prof(str(fname), ["--arg"], workload_dir, logging.INFO, "csv")
 
     assert Path(workload_dir + "/test.csv").exists()
 
@@ -1419,15 +1398,6 @@ def test_run_prof_success_v3_csv(tmp_path, monkeypatch):
     fname.write_text("pmc: SQ_WAVES")
     workload_dir = str(tmp_path / "workload")
     os.makedirs(workload_dir + "/out/pmc_1", exist_ok=True)
-
-    class MockSpec:
-        def __init__(self):
-            self.gpu_model = "mi300x"
-            self.gpu_arch = "gfx942"
-            self.compute_partition = "SPX"
-            self.l2_banks = 32
-
-    mspec = MockSpec()
 
     csv_files = [workload_dir + "/out/pmc_1/converted.csv"]
 
@@ -1476,9 +1446,7 @@ def test_run_prof_success_v3_csv(tmp_path, monkeypatch):
     monkeypatch.setattr("utils.utils_profile.shutil.copyfile", lambda *a, **k: None)
     monkeypatch.setattr("utils.utils_profile.shutil.rmtree", lambda *a, **k: None)
 
-    utils_profile.run_prof(
-        str(fname), ["--arg"], workload_dir, mspec, logging.INFO, "csv"
-    )
+    utils_profile.run_prof(str(fname), ["--arg"], workload_dir, logging.INFO, "csv")
 
 
 def test_run_prof_success_rocprofiler_sdk(tmp_path, monkeypatch):
@@ -1495,15 +1463,6 @@ def test_run_prof_success_rocprofiler_sdk(tmp_path, monkeypatch):
     fname = tmp_path / "test.txt"
     fname.write_text("pmc: SQ_WAVES")
     workload_dir = str(tmp_path / "workload")
-
-    class MockSpec:
-        def __init__(self):
-            self.gpu_model = "mi300x"
-            self.gpu_arch = "gfx942"
-            self.compute_partition = "SPX"
-            self.l2_banks = 32
-
-    mspec = MockSpec()
 
     profiler_options = {
         "APP_CMD": ["./test_app"],
@@ -1527,7 +1486,7 @@ def test_run_prof_success_rocprofiler_sdk(tmp_path, monkeypatch):
     monkeypatch.setattr("utils.utils_profile.console_warning", lambda *a, **k: None)
 
     utils_profile.run_prof(
-        str(fname), profiler_options, workload_dir, mspec, logging.INFO, "csv"
+        str(fname), profiler_options, workload_dir, logging.INFO, "csv"
     )
 
 
@@ -1548,15 +1507,6 @@ def test_run_prof_with_yaml_config(tmp_path, monkeypatch):
     yaml_file.write_text("counters:\n  - TCC_HIT")
     workload_dir = str(tmp_path / "workload")
 
-    class MockSpec:
-        def __init__(self):
-            self.gpu_model = "mi300x"
-            self.gpu_arch = "gfx942"
-            self.compute_partition = "SPX"
-            self.l2_banks = 32
-
-    mspec = MockSpec()
-
     monkeypatch.setattr("utils.utils_common._rocprof_cmd", "rocprofv3")
     monkeypatch.setattr(
         "utils.utils_profile.capture_subprocess_output",
@@ -1569,12 +1519,11 @@ def test_run_prof_with_yaml_config(tmp_path, monkeypatch):
     monkeypatch.setattr("utils.utils_profile.console_log", lambda *a, **k: None)
     monkeypatch.setattr("utils.utils_profile.console_warning", lambda *a, **k: None)
     monkeypatch.setattr(
-        "yaml.safe_load", lambda _: {"rocprofiler-sdk": {"counters": ["counter"]}}
+        "utils.utils_profile.yaml.safe_load",
+        lambda _: {"rocprofiler-sdk": {"counters": ["counter"]}},
     )
 
-    utils_profile.run_prof(
-        str(fname), ["--arg"], workload_dir, mspec, logging.INFO, "csv"
-    )
+    utils_profile.run_prof(str(fname), ["--arg"], workload_dir, logging.INFO, "csv")
 
 
 def test_run_prof_failure_subprocess(tmp_path, monkeypatch):
@@ -1592,15 +1541,6 @@ def test_run_prof_failure_subprocess(tmp_path, monkeypatch):
     fname.write_text("pmc: SQ_WAVES")
     workload_dir = str(tmp_path / "workload")
 
-    class MockSpec:
-        def __init__(self):
-            self.gpu_model = "mi300x"
-            self.gpu_arch = "gfx942"
-            self.compute_partition = "SPX"
-            self.l2_banks = 32
-
-    mspec = MockSpec()
-
     monkeypatch.setattr("utils.utils_common._rocprof_cmd", "rocprofv3")
     monkeypatch.setattr(
         "utils.utils_profile.capture_subprocess_output",
@@ -1616,9 +1556,7 @@ def test_run_prof_failure_subprocess(tmp_path, monkeypatch):
     monkeypatch.setattr("utils.utils_profile.console_error", mock_console_error)
 
     with pytest.raises(RuntimeError, match="console_error called"):
-        utils_profile.run_prof(
-            str(fname), ["--arg"], workload_dir, mspec, logging.INFO, "csv"
-        )
+        utils_profile.run_prof(str(fname), ["--arg"], workload_dir, logging.INFO, "csv")
 
 
 def test_run_prof_mi300_environment_setup(tmp_path, monkeypatch):
@@ -1635,15 +1573,6 @@ def test_run_prof_mi300_environment_setup(tmp_path, monkeypatch):
     fname = tmp_path / "test.txt"
     fname.write_text("pmc: SQ_WAVES")
     workload_dir = str(tmp_path / "workload")
-
-    class MockSpec:
-        def __init__(self):
-            self.gpu_model = "mi300x"
-            self.gpu_arch = "gfx942"
-            self.compute_partition = "SPX"
-            self.l2_banks = 32
-
-    mspec = MockSpec()
 
     captured_env = {}
 
@@ -1663,9 +1592,7 @@ def test_run_prof_mi300_environment_setup(tmp_path, monkeypatch):
     monkeypatch.setattr("utils.utils_profile.console_log", lambda *a, **k: None)
     monkeypatch.setattr("utils.utils_profile.console_warning", lambda *a, **k: None)
 
-    utils_profile.run_prof(
-        str(fname), ["--arg"], workload_dir, mspec, logging.INFO, "csv"
-    )
+    utils_profile.run_prof(str(fname), ["--arg"], workload_dir, logging.INFO, "csv")
 
 
 def test_run_prof_timestamps_special_case(tmp_path, monkeypatch):
@@ -1684,15 +1611,6 @@ def test_run_prof_timestamps_special_case(tmp_path, monkeypatch):
     workload_dir = str(tmp_path / "workload")
 
     os.makedirs(workload_dir + "/out/pmc_1", exist_ok=True)
-
-    class MockSpec:
-        def __init__(self):
-            self.gpu_model = "mi300x"
-            self.gpu_arch = "gfx942"
-            self.compute_partition = "SPX"
-            self.l2_banks = 32
-
-    mspec = MockSpec()
 
     csv_content = (
         "Agent_Type,Node_Id,Wave_Front_Size,Correlation_Id,Dispatch_Id,Agent_Id,Queue_Id,Process_Id,Thread_Id,"
@@ -1730,9 +1648,7 @@ def test_run_prof_timestamps_special_case(tmp_path, monkeypatch):
     monkeypatch.setattr("pandas.read_csv", lambda *a, **k: mock_df)
     monkeypatch.setattr("pandas.concat", lambda *a, **k: mock_df)
 
-    utils_profile.run_prof(
-        str(fname), ["--arg"], workload_dir, mspec, logging.INFO, "csv"
-    )
+    utils_profile.run_prof(str(fname), ["--arg"], workload_dir, logging.INFO, "csv")
 
 
 def test_run_prof_no_results_files(tmp_path, monkeypatch):
@@ -1750,15 +1666,6 @@ def test_run_prof_no_results_files(tmp_path, monkeypatch):
     fname.write_text("pmc: SQ_WAVES")
     workload_dir = str(tmp_path / "workload")
 
-    class MockSpec:
-        def __init__(self):
-            self.gpu_model = "mi300x"
-            self.gpu_arch = "gfx942"
-            self.compute_partition = "SPX"
-            self.l2_banks = 32
-
-    mspec = MockSpec()
-
     monkeypatch.setattr("utils.utils_common._rocprof_cmd", "rocprofv2")
     monkeypatch.setattr(
         "utils.utils_profile.capture_subprocess_output",
@@ -1768,9 +1675,7 @@ def test_run_prof_no_results_files(tmp_path, monkeypatch):
     monkeypatch.setattr("utils.utils_profile.console_debug", lambda *a, **k: None)
     monkeypatch.setattr("utils.utils_profile.console_log", lambda *a, **k: None)
 
-    utils_profile.run_prof(
-        str(fname), ["--arg"], workload_dir, mspec, logging.INFO, "csv"
-    )
+    utils_profile.run_prof(str(fname), ["--arg"], workload_dir, logging.INFO, "csv")
 
 
 def test_run_prof_header_standardization(tmp_path, monkeypatch):
@@ -1789,15 +1694,6 @@ def test_run_prof_header_standardization(tmp_path, monkeypatch):
     workload_dir = str(tmp_path / "workload")
 
     os.makedirs(workload_dir + "/out/pmc_1", exist_ok=True)
-
-    class MockSpec:
-        def __init__(self):
-            self.gpu_model = "mi300x"
-            self.gpu_arch = "gfx942"
-            self.compute_partition = "SPX"
-            self.l2_banks = 32
-
-    mspec = MockSpec()
 
     results_csv = workload_dir + "/out/pmc_1/results_test.csv"
 
@@ -1859,9 +1755,7 @@ def test_run_prof_header_standardization(tmp_path, monkeypatch):
     monkeypatch.setattr("utils.utils_profile.shutil.copyfile", lambda *a, **k: None)
     monkeypatch.setattr("utils.utils_profile.shutil.rmtree", lambda *a, **k: None)
 
-    utils_profile.run_prof(
-        str(fname), ["--arg"], workload_dir, mspec, logging.INFO, "csv"
-    )
+    utils_profile.run_prof(str(fname), ["--arg"], workload_dir, logging.INFO, "csv")
 
     # Verify that rename_columns was called with the header standardization mapping
     assert len(rename_calls) == 1
@@ -1888,15 +1782,6 @@ def test_run_prof_tcc_flattening_mi300(tmp_path, monkeypatch):
     fname.write_text("pmc: TCC_HIT[0]")
     workload_dir = str(tmp_path / "workload")
 
-    class MockSpec:
-        def __init__(self):
-            self.gpu_model = "mi300x"
-            self.gpu_arch = "gfx942"
-            self.compute_partition = "SPX"
-            self.l2_banks = 32
-
-    mspec = MockSpec()
-
     # Mock functions
     monkeypatch.setattr("utils.utils_common._rocprof_cmd", "rocprofv3")
     monkeypatch.setattr(
@@ -1917,9 +1802,7 @@ def test_run_prof_tcc_flattening_mi300(tmp_path, monkeypatch):
     monkeypatch.setattr("pandas.DataFrame.to_csv", lambda self, *a, **k: None)
 
     # Execute function
-    utils_profile.run_prof(
-        str(fname), ["--arg"], workload_dir, mspec, logging.INFO, "csv"
-    )
+    utils_profile.run_prof(str(fname), ["--arg"], workload_dir, logging.INFO, "csv")
 
 
 def test_run_prof_sdk_creates_new_env_copy(tmp_path, monkeypatch):
@@ -1989,7 +1872,6 @@ def test_run_prof_sdk_creates_new_env_copy(tmp_path, monkeypatch):
 
     monkeypatch.setattr("utils.utils_profile.Path", path_side_effect)
 
-    mspec = MockMSpec(gpu_model="mi250")
     loglevel = logging.DEBUG
     format_rocprof_output = True
 
@@ -2039,7 +1921,6 @@ def test_run_prof_sdk_creates_new_env_copy(tmp_path, monkeypatch):
             fname_str,
             profiler_options,
             workload_dir_str,
-            mspec,
             loglevel,
             format_rocprof_output,
         )
@@ -2084,7 +1965,6 @@ def test_run_prof_sdk_creates_new_env_copy(tmp_path, monkeypatch):
             fname_str,
             profiler_options,
             workload_dir_str,
-            mspec,
             loglevel,
             format_rocprof_output,
         )
@@ -2183,7 +2063,6 @@ def test_run_prof_v3_cli_calls_kokkos_trace_processing(tmp_path, monkeypatch):
     monkeypatch.setattr("utils.utils_profile.shutil.copyfile", lambda *a, **k: None)
     monkeypatch.setattr("utils.utils_profile.shutil.rmtree", lambda *a, **k: None)
 
-    mspec = MockMSpec()
     loglevel = logging.INFO
     format_rocprof_output = "csv"
 
@@ -2196,7 +2075,6 @@ def test_run_prof_v3_cli_calls_kokkos_trace_processing(tmp_path, monkeypatch):
         fname_str,
         profiler_options_cli_kokkos,
         workload_dir_str,
-        mspec,
         loglevel,
         format_rocprof_output,
     )


### PR DESCRIPTION
## Motivation

Reduce import-time dependencies for `rocprof-compute profile` mode by centralizing shared utilities. This enables profile mode to run without loading analysis-only dependencies at startup.

## Technical Details

- **Constants moved to utils_common.py**: `SUPPORTED_DENOM`, `BUILD_IN_VARS`, `SUPPORTED_FIELD` - centralized to avoid cross-module dependencies
- **Functions moved to utils_common.py**: 
  - `validate_roofline_csv()` - CSV validation logic
  - `load_panel_configs()` - panel configuration loader
  - `calc_builtin_var()` - built-in variable calculation
  - `build_metric_list()` - metric list construction
  - `expand_placeholder_ranges()` - placeholder range expansion
- **New stdlib-only table formatter**: `format_table_ascii()` - eliminates pandas/tabulate dependency for profile mode output formatting
- **specs.py API change**: `get_class_members()` now returns dict instead of DataFrame to avoid pandas dependency in core utilities
- **Import optimization in rocprof_compute_base.py**: Removed schema/parser imports from module level
- **Lazy imports in analysis path**: `file_io` now imported lazily in `run_analysis()` to defer heavy dependencies
- **Function signature cleanup**: Removed unused `mspec`/`sort_type` parameters from several utility functions

### New ASCII based table for --list-specs (or -s)

<img width="919" height="587" alt="image" src="https://github.com/user-attachments/assets/f4c98e89-e549-4f8e-a851-fc9f48da8573" />

### Old tabulate based table for --list-specs (or -s)

<img width="941" height="583" alt="image" src="https://github.com/user-attachments/assets/c7f203a5-1995-4745-9750-ae9fd32a193f" />

### Only difference is the table border!

## JIRA ID



## Test Plan

All ctests pass and manual test shows rocprof-compute profile works without any non-standard python dependencies

## Test Result

All ctests pass and manual test shows rocprof-compute profile works without any non-standard python dependencies

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.