### PR TITLE
[ROCM-20642] Refactoring unit_id calculation for GPUs

### DIFF
--- a/projects/cuid/lib/src/cuid_gpu.cc
+++ b/projects/cuid/lib/src/cuid_gpu.cc
@@ -48,7 +48,7 @@ amdcuid_status_t CuidGpu::discover(std::vector<DevicePtr> &gpus) {
       std::string device_path =
           std::string(drm_path) + "/" + render_name + "/device";
       amdcuid_gpu_info info = {};
-      amdcuid_status_t status = discover_single(&info, device_path);
+      discover_single(&info, device_path);
 
       gpus.emplace_back(std::make_shared<CuidGpu>(info));
     }
@@ -62,7 +62,6 @@ amdcuid_status_t CuidGpu::discover_single(amdcuid_gpu_info *gpu_info,
 
   amdcuid_gpu_info info = {};
   std::string bdf = CuidUtilities::readlink_bdf(device_path);
-  info.header.fields.gpu.unit_id = 0;
 
   // Determine unit_id from SR-IOV VF (Virtual Function) status via ioctl.
   // In bare metal or passthrough, unit_id is 0.

--- a/projects/cuid/lib/src/cuid_gpu.cc
+++ b/projects/cuid/lib/src/cuid_gpu.cc
@@ -21,339 +21,281 @@
  */
 
 #include "cuid_gpu.h"
+#include "cuid_file.h"
 #include "cuid_util.h"
 #include "pci_util.h"
-#include "cuid_file.h"
+#include <cstring>
 #include <dirent.h>
+#include <fstream>
+#include <iostream>
+#include <sstream>
 #include <sys/types.h>
 #include <unistd.h>
-#include <cstring>
-#include <fstream>
-#include <sstream>
-#include <iostream>
 
-CuidGpu::CuidGpu(const amdcuid_gpu_info& i)
-    : m_info(i)
-{}
+CuidGpu::CuidGpu(const amdcuid_gpu_info &i) : m_info(i) {}
 
 amdcuid_status_t CuidGpu::discover(std::vector<DevicePtr> &gpus) {
-    const char *drm_path = "/sys/class/drm";
-    DIR *dir = opendir(drm_path);
-    if (!dir) return AMDCUID_STATUS_UNSUPPORTED;
+  const char *drm_path = "/sys/class/drm";
+  DIR *dir = opendir(drm_path);
+  if (!dir)
+    return AMDCUID_STATUS_UNSUPPORTED;
 
-    struct dirent *entry;
-    while ((entry = readdir(dir)) != NULL) {
-        if (strncmp(entry->d_name, "renderD", 7) == 0 && isdigit(entry->d_name[7])) {
-            std::string render_name(entry->d_name);
-            std::string device_path = std::string(drm_path) + "/" + render_name + "/device";
-            amdcuid_gpu_info info = {};
-            amdcuid_status_t status = discover_single(&info, device_path);
+  struct dirent *entry;
+  while ((entry = readdir(dir)) != NULL) {
+    if (strncmp(entry->d_name, "renderD", 7) == 0 &&
+        isdigit(entry->d_name[7])) {
+      std::string render_name(entry->d_name);
+      std::string device_path =
+          std::string(drm_path) + "/" + render_name + "/device";
+      amdcuid_gpu_info info = {};
+      amdcuid_status_t status = discover_single(&info, device_path);
 
-            gpus.emplace_back(std::make_shared<CuidGpu>(info));
-        }
+      gpus.emplace_back(std::make_shared<CuidGpu>(info));
     }
-    closedir(dir);
-    return AMDCUID_STATUS_SUCCESS;
+  }
+  closedir(dir);
+  return AMDCUID_STATUS_SUCCESS;
 }
 
-std::string get_parent_device_path(const std::string& device_path, uint16_t unit_id) {
-    if (unit_id == 0) return device_path;
+amdcuid_status_t CuidGpu::discover_single(amdcuid_gpu_info *gpu_info,
+                                          const std::string &device_path) {
 
-    size_t render_pos = device_path.find("renderD");
-    if (render_pos != std::string::npos) {
-        size_t num_start = render_pos + 7; // length of "renderD"
-        size_t num_end = device_path.find('/', num_start);
-        if (num_end != std::string::npos) {
-            std::string render_num_str = device_path.substr(num_start, num_end - num_start);
-            int render_num = std::stoi(render_num_str);
-            int parent_render_num = render_num - unit_id;
-            std::string parent_device_path = device_path.substr(0, render_pos) + "renderD" +
-                                             std::to_string(parent_render_num) +
-                                             device_path.substr(num_end);
-            return parent_device_path;
-        }
-    }
-    return device_path;
+  amdcuid_gpu_info info = {};
+  std::string bdf = CuidUtilities::readlink_bdf(device_path);
+  info.header.fields.gpu.unit_id = 0;
+
+  // Determine unit_id from SR-IOV VF (Virtual Function) status via ioctl.
+  // In bare metal or passthrough, unit_id is 0.
+  // For VFs, unit_id is the 1-based VF index.
+  // Falls back to 0 if VF detection is unavailable.
+  info.header.fields.gpu.unit_id = CuidUtilities::get_gpu_vf_id(device_path);
+
+  std::string vendor = CuidUtilities::read_sysfs_file(device_path + "/vendor");
+  if (vendor.empty() && !bdf.empty()) {
+    // if file read fails, attempt to get from pci config
+    uint8_t vendor_id_bytes[2] = {0};
+    const uint16_t offset = 0x0;
+    amdcuid_status_t status =
+        PciUtil::read_pci_config_space(bdf, vendor_id_bytes, 2, offset);
+    uint16_t vendor_id_int =
+        PciUtil::le16_to_be16(*reinterpret_cast<uint16_t *>(vendor_id_bytes));
+    info.header.fields.gpu.vendor_id =
+        (status == AMDCUID_STATUS_SUCCESS) ? vendor_id_int : 0;
+  } else {
+    info.header.fields.gpu.vendor_id =
+        (uint16_t)strtol(vendor.c_str(), nullptr, 16);
+  }
+
+  std::string device = CuidUtilities::read_sysfs_file(device_path + "/device");
+  if (device.empty() && !bdf.empty()) {
+    // if file read fails, attempt to get from pci config
+    uint8_t device_id_bytes[2] = {0};
+    const uint16_t offset = 0x2;
+    amdcuid_status_t status =
+        PciUtil::read_pci_config_space(bdf, device_id_bytes, 2, offset);
+    uint16_t device_id_int =
+        PciUtil::le16_to_be16(*reinterpret_cast<uint16_t *>(device_id_bytes));
+    info.header.fields.gpu.device_id =
+        (status == AMDCUID_STATUS_SUCCESS) ? device_id_int : 0;
+  } else {
+    info.header.fields.gpu.device_id =
+        (uint16_t)strtol(device.c_str(), nullptr, 16);
+  }
+
+  std::string pci_class =
+      CuidUtilities::read_sysfs_file(device_path + "/class");
+  uint16_t pci_class_integer = 0;
+  if (pci_class.empty() && !bdf.empty()) {
+    // if file read fails, attempt to get from pci config
+    uint8_t class_id_bytes[2] = {0};
+    const uint16_t offset = 0xa;
+    amdcuid_status_t status =
+        PciUtil::read_pci_config_space(bdf, class_id_bytes, 2, offset);
+    uint16_t class_id_int =
+        PciUtil::le16_to_be16(*reinterpret_cast<uint16_t *>(class_id_bytes));
+    pci_class_integer = (status == AMDCUID_STATUS_SUCCESS) ? class_id_int : 0;
+  } else {
+    // sysfs class file returns 24-bit value (class:subclass:prog_if), shift
+    // right by 8 to get 16-bit class:subclass
+    pci_class_integer = (uint16_t)(strtol(pci_class.c_str(), nullptr, 16) >> 8);
+  }
+  info.header.fields.gpu.pci_class = pci_class_integer;
+
+  std::string revision_id =
+      CuidUtilities::read_sysfs_file(device_path + "/revision");
+  if (revision_id.empty() && !bdf.empty()) {
+    // if file read fails, attempt to get from pci config
+    uint8_t revision_id_bytes[2] = {0};
+    const uint16_t offset = 0x8;
+    amdcuid_status_t status =
+        PciUtil::read_pci_config_space(bdf, revision_id_bytes, 2, offset);
+    uint16_t revision_id_int =
+        PciUtil::le16_to_be16(*reinterpret_cast<uint16_t *>(revision_id_bytes));
+    info.header.fields.gpu.revision_id =
+        (status == AMDCUID_STATUS_SUCCESS) ? revision_id_int : 0;
+  } else {
+    info.header.fields.gpu.revision_id =
+        (uint16_t)strtol(revision_id.c_str(), nullptr, 16);
+  }
+
+  // we use the original device path to get render node
+  std::string full_device_node;
+  size_t last_slash = device_path.rfind('/');
+  if (last_slash != std::string::npos && last_slash > 0) {
+    // Trim to just /sys/class/drm/renderDXXX;
+    full_device_node = device_path.substr(0, last_slash);
+  } else {
+    full_device_node = device_path;
+  }
+
+  info.header.device_type = AMDCUID_DEVICE_TYPE_GPU;
+  info.bdf = bdf;
+  info.render_node = full_device_node;
+
+  *gpu_info = info;
+
+  return AMDCUID_STATUS_SUCCESS;
 }
 
-amdcuid_status_t CuidGpu::discover_single(amdcuid_gpu_info *gpu_info, const std::string& device_path) {
+amdcuid_status_t
+CuidGpu::get_hardware_fingerprint(uint64_t &fingerprint) const {
+  if (geteuid() != 0) {
+    return AMDCUID_STATUS_PERMISSION_DENIED;
+  }
 
-    std::string device_path_in_use = device_path;
-    amdcuid_gpu_info info = {};
-    std::string bdf = CuidUtilities::readlink_bdf(device_path);
-    info.header.fields.gpu.unit_id = 0;
+  std::string unique_id_path = m_info.render_node + "/device/unique_id";
 
-    // If BDF is empty, this might be a partition device - try to get BDF from parent
-    // and determine unit_id from the renderD number difference
-    if (bdf.empty()) {
-        // Extract renderD number from device_path
-        size_t render_pos = device_path.find("renderD");
-        if (render_pos != std::string::npos) {
-            size_t num_start = render_pos + 7;
-            size_t num_end = device_path.find('/', num_start);
-            if (num_end != std::string::npos) {
-                int render_num = std::stoi(device_path.substr(num_start, num_end - num_start));
-                // Try parent renderD nodes (up to 7 partitions possible based on function numbers 1-7)
-                for (int offset = 1; offset <= 7; ++offset) {
-                    std::string parent_path = device_path.substr(0, render_pos) + "renderD" +
-                                              std::to_string(render_num - offset) +
-                                              device_path.substr(num_end);
-                    std::string parent_bdf = CuidUtilities::readlink_bdf(parent_path);
-                    if (!parent_bdf.empty()) {
-                        // Found parent - unit_id is the offset, construct partition BDF
-                        info.header.fields.gpu.unit_id = static_cast<uint16_t>(offset);
-                        // Replace the function number in BDF with the unit_id
-                        size_t dot_pos = parent_bdf.rfind('.');
-                        if (dot_pos != std::string::npos) {
-                            bdf = parent_bdf.substr(0, dot_pos + 1) + std::to_string(offset);
-                        }
-                        device_path_in_use = parent_path;
-                        break;
-                    }
-                }
-            }
-        }
-    }
-    // if bdf ends in non zero digit, then we have a partitioned device and we will use that as unit id
-    else {
-        size_t last_dot = bdf.rfind('.');
-        if (last_dot != std::string::npos && last_dot + 1 < bdf.size()) {
-            char last_char = bdf[last_dot + 1];
-            if (isdigit(last_char) && last_char != '0') {
-                uint16_t unit_id = static_cast<uint16_t>(last_char - '0');
-                info.header.fields.gpu.unit_id = unit_id;
+  // Try to read the unique_id from the device sysfs file
+  std::ifstream fin(unique_id_path);
 
-                // partition device path will not have any of the other info, so we need to get parent device path
-                // Calculate parent renderD number by subtracting unit_id from current renderD number
-                // e.g., /sys/class/drm/renderD129/device with unit_id=1 -> /sys/class/drm/renderD128/device
-                device_path_in_use = get_parent_device_path(device_path, unit_id);
-            }
-        }
+  // If not available and this is a VF, try the PF's unique_id via physfn
+  if (!fin.is_open() && m_info.header.fields.gpu.unit_id != 0) {
+    std::string physfn_path = m_info.render_node + "/device/physfn/unique_id";
+    fin.open(physfn_path);
+  }
+  if (fin.is_open()) {
+    std::string hex_str;
+    std::getline(fin, hex_str);
+    fin.close();
+    if (hex_str.empty()) {
+      fingerprint = 0;
+      return AMDCUID_STATUS_UNSUPPORTED;
     }
-
-    std::string vendor = CuidUtilities::read_sysfs_file(device_path_in_use + "/vendor");
-    // if this is a partitioned device, we won't be able to get information from pci config space so skip in the check
-    if (vendor.empty() && !bdf.empty() && info.header.fields.gpu.unit_id == 0){
-        // if file read fails, attempt to get from pci config
-        uint8_t vendor_id_bytes[2] = {0};
-        const uint16_t offset = 0x0;
-        amdcuid_status_t status = PciUtil::read_pci_config_space(bdf, vendor_id_bytes, 2, offset);
-        uint16_t vendor_id_int = PciUtil::le16_to_be16(*reinterpret_cast<uint16_t*>(vendor_id_bytes));
-        info.header.fields.gpu.vendor_id = (status == AMDCUID_STATUS_SUCCESS) ? vendor_id_int : 0;
+    // Parse as 64-bit hex value (if possible)
+    try {
+      fingerprint = std::stoull(hex_str, nullptr, 16);
+    } catch (...) {
+      fingerprint = 0;
+      return AMDCUID_STATUS_UNSUPPORTED;
     }
-    else
-    {
-        info.header.fields.gpu.vendor_id = (uint16_t)strtol(vendor.c_str(), nullptr, 16);
-    }
-
-    std::string device = CuidUtilities::read_sysfs_file(device_path_in_use + "/device");
-    if (device.empty() && !bdf.empty() && info.header.fields.gpu.unit_id == 0){
-        // if file read fails, attempt to get from pci config
-        uint8_t device_id_bytes[2] = {0};
-        const uint16_t offset = 0x2;
-        amdcuid_status_t status = PciUtil::read_pci_config_space(bdf, device_id_bytes, 2, offset);
-        uint16_t device_id_int = PciUtil::le16_to_be16(*reinterpret_cast<uint16_t*>(device_id_bytes));
-        info.header.fields.gpu.device_id = (status ==  AMDCUID_STATUS_SUCCESS) ? device_id_int : 0;
-    }
-    else
-    {
-        info.header.fields.gpu.device_id = (uint16_t)strtol(device.c_str(), nullptr, 16);
-    }
-
-    std::string pci_class = CuidUtilities::read_sysfs_file(device_path_in_use + "/class");
-    uint16_t pci_class_integer = 0;
-    if (pci_class.empty() && !bdf.empty() && info.header.fields.gpu.unit_id == 0){
-        // if file read fails, attempt to get from pci config
-        uint8_t class_id_bytes[2] = {0};
-        const uint16_t offset = 0xa;
-        amdcuid_status_t status = PciUtil::read_pci_config_space(bdf, class_id_bytes, 2, offset);
-        uint16_t class_id_int = PciUtil::le16_to_be16(*reinterpret_cast<uint16_t*>(class_id_bytes));
-        pci_class_integer = (status ==  AMDCUID_STATUS_SUCCESS) ? class_id_int : 0;
-    }
-    else
-    {
-        // sysfs class file returns 24-bit value (class:subclass:prog_if), shift right by 8
-        // to get 16-bit class:subclass
-        pci_class_integer = (uint16_t)(strtol(pci_class.c_str(), nullptr, 16) >> 8);
-    }
-    info.header.fields.gpu.pci_class = pci_class_integer;
-
-    std::string revision_id = CuidUtilities::read_sysfs_file(device_path_in_use + "/revision");
-    if (revision_id.empty() && !bdf.empty() && info.header.fields.gpu.unit_id == 0){
-        // if file read fails, attempt to get from pci config
-        uint8_t revision_id_bytes[2] = {0};
-        const uint16_t offset = 0x8;
-        amdcuid_status_t status = PciUtil::read_pci_config_space(bdf, revision_id_bytes, 2, offset);
-        uint16_t revision_id_int = PciUtil::le16_to_be16(*reinterpret_cast<uint16_t*>(revision_id_bytes));
-        info.header.fields.gpu.revision_id = (status ==  AMDCUID_STATUS_SUCCESS) ? revision_id_int : 0;
-    }
-    else
-    {
-        info.header.fields.gpu.revision_id = (uint16_t)strtol(revision_id.c_str(), nullptr, 16);
-    }
-
-    // we use the original device path to get render node
-    std::string full_device_node;
-    size_t last_slash = device_path.rfind('/');
-    if (last_slash != std::string::npos && last_slash > 0) {
-        // Trim to just /sys/class/drm/renderDXXX;
-        full_device_node = device_path.substr(0, last_slash);
-    }
-    else {
-        full_device_node = device_path;
-    }
-
-    info.header.device_type = AMDCUID_DEVICE_TYPE_GPU;
-    info.bdf = bdf;
-    info.render_node = full_device_node;
-
-    *gpu_info = info;
-
-    return AMDCUID_STATUS_SUCCESS;
-}
-
-amdcuid_status_t CuidGpu::get_hardware_fingerprint(uint64_t& fingerprint) const {
-    if (geteuid() != 0)
-    {
-        return AMDCUID_STATUS_PERMISSION_DENIED;
-    }
-
-    std::string unique_id_path = m_info.render_node + "/device/unique_id";
-    // check if device is partition first by checking unit id
-    if (m_info.header.fields.gpu.unit_id != 0) {
-        unique_id_path = get_parent_device_path(unique_id_path, m_info.header.fields.gpu.unit_id);
-    }
-    // Try to read the unique_id from the device sysfs file
-    std::ifstream fin(unique_id_path);
-    if (fin.is_open()) {
-        std::string hex_str;
-        std::getline(fin, hex_str);
-        fin.close();
-        if (hex_str.empty()) {
-            fingerprint = 0;
-            return AMDCUID_STATUS_UNSUPPORTED;
-        }
-        // Parse as 64-bit hex value (if possible)
-        try {
-            fingerprint = std::stoull(hex_str, nullptr, 16);
-        } catch (...) {
-            fingerprint = 0;
-            return AMDCUID_STATUS_UNSUPPORTED;
-        }
-    }
-    else if (m_info.header.fields.gpu.unit_id == 0) {
-        // attempt to get fingerprint through PCI Config Space if not a partition
-        uint16_t offset = 0;
-        amdcuid_status_t status = PciUtil::get_pci_cap_offset(m_info.bdf, 0x03, offset);
-        if (status != AMDCUID_STATUS_SUCCESS) {
-            return status;
-        }
-
-        uint8_t fingerprint_size = 8;
-        uint8_t* fingerprint_buffer = new uint8_t[fingerprint_size];
-        status = PciUtil::read_pci_config_space(m_info.bdf, fingerprint_buffer, fingerprint_size, offset);
-        if (status != AMDCUID_STATUS_SUCCESS) {
-            fingerprint = 0;
-            delete[] fingerprint_buffer;
-            return status;
-        }
-        // pcie config file is little endian, so need to convert to big endian
-        fingerprint = PciUtil::le64_to_be64(*reinterpret_cast<uint64_t*>(fingerprint_buffer));
-        delete[] fingerprint_buffer;
-    }
-    else {
-        // partitioned device without unique_id file cannot get fingerprint
-        fingerprint = 0;
-        return AMDCUID_STATUS_UNSUPPORTED;
-    }
-    return AMDCUID_STATUS_SUCCESS;
-}
-
-amdcuid_status_t CuidGpu::get_primary_cuid(amdcuid_primary_id& id) const {
-    if (geteuid() != 0)
-    {
-        return AMDCUID_STATUS_PERMISSION_DENIED;
-    }
-
-    // attempt to read the CUID from the file first
-    std::string cuid_file_path = CuidUtilities::priv_cuid_file();
-    CuidFile primary_file(cuid_file_path, false);
-    primary_file.load();
-    std::vector<CuidFileEntry> entries = primary_file.get_entries();
-
-    CuidFileEntry entry;
-    amdcuid_status_t status = primary_file.find_by_device_node(m_info.render_node, entry);
-    if (status == AMDCUID_STATUS_SUCCESS) {
-        id.UUIDv8_representation = entry.primary_cuid;
-        CuidUtilities::remove_UUIDv8_bits(&id.UUIDv8_representation, id.raw_bits);
-        return AMDCUID_STATUS_SUCCESS;
-    }
-
-    // primary CUID not found in file so generate it
-    uint64_t fingerprint = 0;
-    status = get_hardware_fingerprint(fingerprint);
+  } else if (m_info.header.fields.gpu.unit_id == 0) {
+    // attempt to get fingerprint through PCI Config Space if not a partition
+    uint16_t offset = 0;
+    amdcuid_status_t status =
+        PciUtil::get_pci_cap_offset(m_info.bdf, 0x03, offset);
     if (status != AMDCUID_STATUS_SUCCESS) {
-        std::memset(&id, 0, sizeof(id));
-        return status;
+      return status;
     }
-    // Use header fields for the rest
-    amdcuid_primary_id result = {};
-    const auto& h = m_info.header;
-    CuidUtilities::generate_primary_cuid(
-        fingerprint,
-        h.fields.gpu.unit_id,
-        h.fields.gpu.revision_id,
-        h.fields.gpu.device_id,
-        h.fields.gpu.vendor_id,
-        static_cast<uint8_t>(AMDCUID_DEVICE_TYPE_GPU),
-        &result
-    );
 
-    id = result;
-    return AMDCUID_STATUS_SUCCESS;
-}
-
-const amdcuid_gpu_info& CuidGpu::get_info() const {
-    return m_info;
-}
-
-amdcuid_status_t CuidGpu::get_vendor_id(uint16_t& vendor_id) const {
-    vendor_id = m_info.header.fields.gpu.vendor_id;
-    return AMDCUID_STATUS_SUCCESS;
-}
-
-amdcuid_status_t CuidGpu::get_device_id(uint16_t& device_id) const {
-    device_id = m_info.header.fields.gpu.device_id;
-    return AMDCUID_STATUS_SUCCESS;
-}
-
-amdcuid_status_t CuidGpu::get_pci_class(uint16_t& pci_class) const {
-    pci_class = m_info.header.fields.gpu.pci_class;
-    return AMDCUID_STATUS_SUCCESS;
-}
-
-amdcuid_status_t CuidGpu::get_revision_id(uint8_t& revision_id) const {
-    revision_id = m_info.header.fields.gpu.revision_id;
-    return AMDCUID_STATUS_SUCCESS;
-}
-
-amdcuid_status_t CuidGpu::get_unit_id(uint16_t& unit_id) const {
-    unit_id = m_info.header.fields.gpu.unit_id;
-    return AMDCUID_STATUS_SUCCESS;
-}
-
-amdcuid_status_t CuidGpu::get_bdf(std::string& bdf) const {
-    if (m_info.bdf.empty()) {
-        return AMDCUID_STATUS_UNSUPPORTED;
+    uint8_t fingerprint_size = 8;
+    uint8_t *fingerprint_buffer = new uint8_t[fingerprint_size];
+    status = PciUtil::read_pci_config_space(m_info.bdf, fingerprint_buffer,
+                                            fingerprint_size, offset);
+    if (status != AMDCUID_STATUS_SUCCESS) {
+      fingerprint = 0;
+      delete[] fingerprint_buffer;
+      return status;
     }
-    bdf = m_info.bdf;
-    return AMDCUID_STATUS_SUCCESS;
+    // pcie config file is little endian, so need to convert to big endian
+    fingerprint = PciUtil::le64_to_be64(
+        *reinterpret_cast<uint64_t *>(fingerprint_buffer));
+    delete[] fingerprint_buffer;
+  } else {
+    // partitioned device without unique_id file cannot get fingerprint
+    fingerprint = 0;
+    return AMDCUID_STATUS_UNSUPPORTED;
+  }
+  return AMDCUID_STATUS_SUCCESS;
 }
 
-amdcuid_status_t CuidGpu::get_device_path(std::string& path) const {
-    if (m_info.render_node.empty()) {
-        return AMDCUID_STATUS_UNSUPPORTED;
-    }
-    path = m_info.render_node;
+amdcuid_status_t CuidGpu::get_primary_cuid(amdcuid_primary_id &id) const {
+  if (geteuid() != 0) {
+    return AMDCUID_STATUS_PERMISSION_DENIED;
+  }
+
+  // attempt to read the CUID from the file first
+  std::string cuid_file_path = CuidUtilities::priv_cuid_file();
+  CuidFile primary_file(cuid_file_path, false);
+  primary_file.load();
+  std::vector<CuidFileEntry> entries = primary_file.get_entries();
+
+  CuidFileEntry entry;
+  amdcuid_status_t status =
+      primary_file.find_by_device_node(m_info.render_node, entry);
+  if (status == AMDCUID_STATUS_SUCCESS) {
+    id.UUIDv8_representation = entry.primary_cuid;
+    CuidUtilities::remove_UUIDv8_bits(&id.UUIDv8_representation, id.raw_bits);
     return AMDCUID_STATUS_SUCCESS;
+  }
+
+  // primary CUID not found in file so generate it
+  uint64_t fingerprint = 0;
+  status = get_hardware_fingerprint(fingerprint);
+  if (status != AMDCUID_STATUS_SUCCESS) {
+    std::memset(&id, 0, sizeof(id));
+    return status;
+  }
+  // Use header fields for the rest
+  amdcuid_primary_id result = {};
+  const auto &h = m_info.header;
+  CuidUtilities::generate_primary_cuid(
+      fingerprint, h.fields.gpu.unit_id, h.fields.gpu.revision_id,
+      h.fields.gpu.device_id, h.fields.gpu.vendor_id,
+      static_cast<uint8_t>(AMDCUID_DEVICE_TYPE_GPU), &result);
+
+  id = result;
+  return AMDCUID_STATUS_SUCCESS;
+}
+
+const amdcuid_gpu_info &CuidGpu::get_info() const { return m_info; }
+
+amdcuid_status_t CuidGpu::get_vendor_id(uint16_t &vendor_id) const {
+  vendor_id = m_info.header.fields.gpu.vendor_id;
+  return AMDCUID_STATUS_SUCCESS;
+}
+
+amdcuid_status_t CuidGpu::get_device_id(uint16_t &device_id) const {
+  device_id = m_info.header.fields.gpu.device_id;
+  return AMDCUID_STATUS_SUCCESS;
+}
+
+amdcuid_status_t CuidGpu::get_pci_class(uint16_t &pci_class) const {
+  pci_class = m_info.header.fields.gpu.pci_class;
+  return AMDCUID_STATUS_SUCCESS;
+}
+
+amdcuid_status_t CuidGpu::get_revision_id(uint8_t &revision_id) const {
+  revision_id = m_info.header.fields.gpu.revision_id;
+  return AMDCUID_STATUS_SUCCESS;
+}
+
+amdcuid_status_t CuidGpu::get_unit_id(uint16_t &unit_id) const {
+  unit_id = m_info.header.fields.gpu.unit_id;
+  return AMDCUID_STATUS_SUCCESS;
+}
+
+amdcuid_status_t CuidGpu::get_bdf(std::string &bdf) const {
+  if (m_info.bdf.empty()) {
+    return AMDCUID_STATUS_UNSUPPORTED;
+  }
+  bdf = m_info.bdf;
+  return AMDCUID_STATUS_SUCCESS;
+}
+
+amdcuid_status_t CuidGpu::get_device_path(std::string &path) const {
+  if (m_info.render_node.empty()) {
+    return AMDCUID_STATUS_UNSUPPORTED;
+  }
+  path = m_info.render_node;
+  return AMDCUID_STATUS_SUCCESS;
 }

--- a/projects/cuid/lib/src/cuid_util.cc
+++ b/projects/cuid/lib/src/cuid_util.cc
@@ -168,7 +168,7 @@ std::string CuidUtilities::real_dev_path_from_fd(int fd) {
   return "";
 }
 
-std::string CuidUtilities::get_real_path(const std::string path) {
+std::string CuidUtilities::get_real_path(const std::string &path) {
   char buf[PATH_MAX];
   if (realpath(path.c_str(), buf) != nullptr) {
     return std::string(buf) + "/device";
@@ -195,6 +195,9 @@ int CuidUtilities::extract_render_minor(const std::string &path) {
 
 // Minimal structures matching the kernel DRM UAPI (stable ABI).
 // Only the fields up to ids_flags are needed for VF detection.
+// The kernel ioctl handler (amdgpu_info_ioctl) respects return_size via
+// copy_to_user(out, &dev_info, min(size, sizeof(dev_info))), so providing
+// a smaller buffer than the full drm_amdgpu_info_device is safe.
 namespace {
 
 struct cuid_drm_amdgpu_info {
@@ -334,7 +337,6 @@ CuidUtilities::generate_derived_cuid(const amdcuid_primary_id *primary_id,
                                      cuid_hmac *hmac) {
   if (!primary_id || !hmac) {
     // Return invalid on null input
-    amdcuid_id_t empty = {};
     return AMDCUID_STATUS_INVALID_ARGUMENT;
   }
 

--- a/projects/cuid/lib/src/cuid_util.cc
+++ b/projects/cuid/lib/src/cuid_util.cc
@@ -21,361 +21,576 @@
  */
 
 #include "cuid_util.h"
+#include <cstring>
 #include <dirent.h>
-#include <sys/types.h>
+#include <fcntl.h>
+#include <fstream>
+#include <iostream>
+#include <mutex>
+#include <sstream>
+#include <sys/ioctl.h>
 #include <sys/stat.h>
 #include <sys/sysmacros.h>
+#include <sys/types.h>
 #include <unistd.h>
 #include <vector>
-#include <mutex>
-#include <cstring>
-#include <fstream>
-#include <sstream>
-#include <iostream>
 
-
-const char* Logger::LogLevelName(LogLevel level) const {
-    switch (level) {
-        case DEBUG: return "DEBUG";
-        case INFO:  return "INFO";
-        case WARN:  return "WARN";
-        case ERROR: return "ERROR";
-        default:    return "UNKNOWN";
-    }
+const char *Logger::LogLevelName(LogLevel level) const {
+  switch (level) {
+  case DEBUG:
+    return "DEBUG";
+  case INFO:
+    return "INFO";
+  case WARN:
+    return "WARN";
+  case ERROR:
+    return "ERROR";
+  default:
+    return "UNKNOWN";
+  }
 }
 
-void Logger::log(LogLevel level, const std::string& msg) const {
-    if (level < level_) return;
-    std::cerr << "[" << LogLevelName(level) << "] " << msg << std::endl;
+void Logger::log(LogLevel level, const std::string &msg) const {
+  if (level < level_)
+    return;
+  std::cerr << "[" << LogLevelName(level) << "] " << msg << std::endl;
 }
-
 
 // Helper to read a sysfs file into a string
 std::string CuidUtilities::read_sysfs_file(const std::string &path) {
-    std::ifstream file(path);
-    if (!file.is_open()) return "";
-    std::stringstream ss;
-    ss << file.rdbuf();
-    std::string result = ss.str();
-    // Remove trailing newline if present
-    if (!result.empty() && result.back() == '\n') result.pop_back();
-    return result;
+  std::ifstream file(path);
+  if (!file.is_open())
+    return "";
+  std::stringstream ss;
+  ss << file.rdbuf();
+  std::string result = ss.str();
+  // Remove trailing newline if present
+  if (!result.empty() && result.back() == '\n')
+    result.pop_back();
+  return result;
 }
 
-// Helper to get BDF from symlink, filter out non-PCI BDFs (e.g., USB like 3-10.2:2.0)
+// Helper to get BDF from symlink, filter out non-PCI BDFs (e.g., USB like
+// 3-10.2:2.0)
 std::string CuidUtilities::readlink_bdf(const std::string &device_path) {
-    char buf[256];
-    ssize_t len = readlink(device_path.c_str(), buf, sizeof(buf)-1);
-    if (len > 0) {
-        buf[len] = '\0';
-        // The symlink is typically ../../../0000:65:00.0 or ../../../3-10.2:2.0
-        const char *bdf = strrchr(buf, '/');
-        if (bdf && strlen(bdf+1) < 32) {
-            std::string bdf_str = bdf + 1;
-            // Only accept PCI BDFs of the form "dddd:bb:dd.f"
-            // Example: 0000:65:00.0
-            if (bdf_str.size() == 12 &&
-                bdf_str[4] == ':' && bdf_str[7] == ':' && bdf_str[10] == '.') {
-                return bdf_str;
-            }
-        }
+  char buf[256];
+  ssize_t len = readlink(device_path.c_str(), buf, sizeof(buf) - 1);
+  if (len > 0) {
+    buf[len] = '\0';
+    // The symlink is typically ../../../0000:65:00.0 or ../../../3-10.2:2.0
+    const char *bdf = strrchr(buf, '/');
+    if (bdf && strlen(bdf + 1) < 32) {
+      std::string bdf_str = bdf + 1;
+      // Only accept PCI BDFs of the form "dddd:bb:dd.f"
+      // Example: 0000:65:00.0
+      if (bdf_str.size() == 12 && bdf_str[4] == ':' && bdf_str[7] == ':' &&
+          bdf_str[10] == '.') {
+        return bdf_str;
+      }
     }
-    return "";
+  }
+  return "";
 }
 
 // Helper to get device path from BDF based on device type
 // For GPUs: returns /sys/class/drm/renderDXXX/device path
 // For NICs: returns /sys/class/net/<iface>/device path
-std::string CuidUtilities::bdf_to_device_path(const std::string &bdf, amdcuid_device_type_t device_type) {
-    if (bdf.empty()) return "";
-
-    std::string pci_device_path = "/sys/bus/pci/devices/" + bdf;
-    std::string subsystem_dir;
-
-    if (device_type == AMDCUID_DEVICE_TYPE_GPU) {
-        subsystem_dir = pci_device_path + "/drm";
-        DIR* dir = opendir(subsystem_dir.c_str());
-        if (dir) {
-            struct dirent* entry;
-            while ((entry = readdir(dir)) != nullptr) {
-                // Look for renderD* nodes
-                if (strncmp(entry->d_name, "renderD", 7) == 0) {
-                    std::string device_path = "/sys/class/drm/" + std::string(entry->d_name) + "/device";
-                    closedir(dir);
-                    return device_path;
-                }
-            }
-            closedir(dir);
-        }
-    } else if (device_type == AMDCUID_DEVICE_TYPE_NIC) {
-        subsystem_dir = pci_device_path + "/net";
-        DIR* dir = opendir(subsystem_dir.c_str());
-        if (dir) {
-            struct dirent* entry;
-            while ((entry = readdir(dir)) != nullptr) {
-                // Skip . and ..
-                if (entry->d_name[0] == '.') continue;
-                std::string device_path = "/sys/class/net/" + std::string(entry->d_name) + "/device";
-                closedir(dir);
-                return device_path;
-            }
-            closedir(dir);
-        }
-    }
-
+std::string
+CuidUtilities::bdf_to_device_path(const std::string &bdf,
+                                  amdcuid_device_type_t device_type) {
+  if (bdf.empty())
     return "";
+
+  std::string pci_device_path = "/sys/bus/pci/devices/" + bdf;
+  std::string subsystem_dir;
+
+  if (device_type == AMDCUID_DEVICE_TYPE_GPU) {
+    subsystem_dir = pci_device_path + "/drm";
+    DIR *dir = opendir(subsystem_dir.c_str());
+    if (dir) {
+      struct dirent *entry;
+      while ((entry = readdir(dir)) != nullptr) {
+        // Look for renderD* nodes
+        if (strncmp(entry->d_name, "renderD", 7) == 0) {
+          std::string device_path =
+              "/sys/class/drm/" + std::string(entry->d_name) + "/device";
+          closedir(dir);
+          return device_path;
+        }
+      }
+      closedir(dir);
+    }
+  } else if (device_type == AMDCUID_DEVICE_TYPE_NIC) {
+    subsystem_dir = pci_device_path + "/net";
+    DIR *dir = opendir(subsystem_dir.c_str());
+    if (dir) {
+      struct dirent *entry;
+      while ((entry = readdir(dir)) != nullptr) {
+        // Skip . and ..
+        if (entry->d_name[0] == '.')
+          continue;
+        std::string device_path =
+            "/sys/class/net/" + std::string(entry->d_name) + "/device";
+        closedir(dir);
+        return device_path;
+      }
+      closedir(dir);
+    }
+  }
+
+  return "";
 }
 
 std::string CuidUtilities::real_dev_path_from_fd(int fd) {
-    struct stat st;
-    if (fstat(fd, &st) != 0) {
-        return "";
-    }
-    dev_t dev = st.st_rdev;
-    uint32_t major_num = major(dev);
-    uint32_t minor_num = minor(dev);
-
-    // Construct sysfs path from char device numbers first
-    std::string sys_path = "/sys/dev/char/" + std::to_string(major_num) + ":" + std::to_string(minor_num);
-    char buf[PATH_MAX];
-    if (realpath(sys_path.c_str(), buf) != nullptr) {
-        return std::string(buf) + "/device";
-    }
-    else {
-        // attempt to find as a block device now
-        sys_path = "/sys/dev/block/" + std::to_string(major_num) + ":" + std::to_string(minor_num);
-        if (realpath(sys_path.c_str(), buf) != nullptr) {
-            return std::string(buf) + "/device";
-        }
-    }
-    // If all fails, return empty string
+  struct stat st;
+  if (fstat(fd, &st) != 0) {
     return "";
+  }
+  dev_t dev = st.st_rdev;
+  uint32_t major_num = major(dev);
+  uint32_t minor_num = minor(dev);
+
+  // Construct sysfs path from char device numbers first
+  std::string sys_path = "/sys/dev/char/" + std::to_string(major_num) + ":" +
+                         std::to_string(minor_num);
+  char buf[PATH_MAX];
+  if (realpath(sys_path.c_str(), buf) != nullptr) {
+    return std::string(buf) + "/device";
+  } else {
+    // attempt to find as a block device now
+    sys_path = "/sys/dev/block/" + std::to_string(major_num) + ":" +
+               std::to_string(minor_num);
+    if (realpath(sys_path.c_str(), buf) != nullptr) {
+      return std::string(buf) + "/device";
+    }
+  }
+  // If all fails, return empty string
+  return "";
 }
 
 std::string CuidUtilities::get_real_path(const std::string path) {
-    char buf[PATH_MAX];
-    if (realpath(path.c_str(), buf) != nullptr) {
-        return std::string(buf) + "/device";
-    }
-    return "";
+  char buf[PATH_MAX];
+  if (realpath(path.c_str(), buf) != nullptr) {
+    return std::string(buf) + "/device";
+  }
+  return "";
 }
 
-amdcuid_status_t CuidUtilities::generate_derived_cuid(const amdcuid_primary_id* primary_id, amdcuid_derived_id* derived_id, cuid_hmac* hmac) {
-    if (!primary_id || !hmac) {
-        // Return invalid on null input
-        amdcuid_id_t empty = {};
-        return AMDCUID_STATUS_INVALID_ARGUMENT;
-    }
+int CuidUtilities::extract_render_minor(const std::string &path) {
+  size_t render_pos = path.find("renderD");
+  if (render_pos == std::string::npos)
+    return -1;
 
-    uint8_t hash[EVP_MAX_MD_SIZE];
-    size_t hash_len = 0;
-
-    amdcuid_status_t status = static_cast<amdcuid_status_t>(hmac->generate_hmac_sha256(reinterpret_cast<const uint8_t*>(primary_id->raw_bits), sizeof(primary_id->raw_bits), hash, &hash_len));
-    if (status != AMDCUID_STATUS_SUCCESS) {
-        std::cerr << "Error generating HMAC" << std::endl;
-        return status;
-    }
-
-    // copy 110 LSB bits of hash to derived_id->hash
-    // Using only first 14 bytes (112 bits) of hash, then will mask last 2 bits
-    memcpy(derived_id->hash, hash, 14);
-    derived_id->hash[13] &= 0xFC; // 11111100
-
-    // Get the unit id parts from the primary ID
-    uint8_t reserved_1 = 0;
-    uint8_t reserved_2 = 0;
-    // Map the 256-bit hash to 122-bit CUID format
-    uint8_t id_bits[16] = {0};
-
-    // Copy first 8 bytes (64 bits) from hash
-    memcpy(id_bits, derived_id->hash, 8);
-
-    // insert unit id part 1 at bits 64-71
-    id_bits[8] = reserved_1;
-
-    // copy next 6 bytes (46 bits) from hash and mask off last 2 bits for bits 72-117 
-    memcpy(id_bits + 9, derived_id->hash + 8, 6);
-    id_bits[14] &= 0xFC;
-
-    // bits 118-121: UnitID part 2 (4 bits)
-    id_bits[14] |= (reserved_2 >> 2); // upper 2 bits of unit id part 2
-    id_bits[15] |= (reserved_2 & 0x03) << 6; // lower 2 bits of unit id part 2
-    // last 6 bits are padding (bits 122-127)
-    id_bits[15] &= 0xC0;
-
-    memcpy(derived_id->raw_bits, id_bits, 16);
-
-    // Apply UUIDv8 format according to RFC 9562
-    // Bits 0-47: ID value part 1 (LSB)
-    derived_id->UUIDv8_representation.bytes[0] = id_bits[0];
-    derived_id->UUIDv8_representation.bytes[1] = id_bits[1];
-    derived_id->UUIDv8_representation.bytes[2] = id_bits[2];
-    derived_id->UUIDv8_representation.bytes[3] = id_bits[3];
-    derived_id->UUIDv8_representation.bytes[4] = id_bits[4];
-    derived_id->UUIDv8_representation.bytes[5] = id_bits[5];
-
-    // Bits 48-51: Version (8) + Bits 52-63: ID value part 2
-    derived_id->UUIDv8_representation.bytes[6] = ((id_bits[6] & 0xF0) >> 4) | 0x80; // Version 8 in upper 4 bits
-    derived_id->UUIDv8_representation.bytes[7] = ((id_bits[6] & 0x0F) << 4) | ((id_bits[7] & 0xF0) >> 4);
-
-    // Bits 64-65: Variant (10b) + Bits 66-127: ID value part 3 (MSB)
-    derived_id->UUIDv8_representation.bytes[8] = 0x80 | (id_bits[7] & 0x0F) << 2 | (id_bits[8] & 0xC0) >> 6;
-    // everything past here is now shifted by 6 bits
-    derived_id->UUIDv8_representation.bytes[9] = ((id_bits[8] & 0x3F) << 2) | ((id_bits[9] & 0xC0) >> 6);
-    derived_id->UUIDv8_representation.bytes[10] = ((id_bits[9] & 0x3F) << 2) | ((id_bits[10] & 0xC0) >> 6);
-    derived_id->UUIDv8_representation.bytes[11] = ((id_bits[10] & 0x3F) << 2) | ((id_bits[11] & 0xC0) >> 6);
-    derived_id->UUIDv8_representation.bytes[12] = ((id_bits[11] & 0x3F) << 2) | ((id_bits[12] & 0xC0) >> 6);
-    derived_id->UUIDv8_representation.bytes[13] = ((id_bits[12] & 0x3F) << 2) | ((id_bits[13] & 0xC0) >> 6);
-    derived_id->UUIDv8_representation.bytes[14] = ((id_bits[13] & 0x3F) << 2) | ((id_bits[14] & 0xC0) >> 6);
-    derived_id->UUIDv8_representation.bytes[15] = ((id_bits[14] & 0x3F) << 2) | ((id_bits[15] & 0xC0) >> 6);
-
-    return AMDCUID_STATUS_SUCCESS;
+  size_t num_start = render_pos + 7; // length of "renderD"
+  size_t num_end = path.find('/', num_start);
+  std::string num_str = (num_end != std::string::npos)
+                            ? path.substr(num_start, num_end - num_start)
+                            : path.substr(num_start);
+  try {
+    return std::stoi(num_str);
+  } catch (...) {
+    return -1;
+  }
 }
 
-amdcuid_status_t CuidUtilities::generate_primary_cuid(uint64_t serial_number, uint16_t unit_id,
-                                 uint8_t revision_id, uint16_t device_id, uint16_t vendor_id,
-                                 uint8_t device_type, amdcuid_primary_id* primary_id) {
+// Minimal structures matching the kernel DRM UAPI (stable ABI).
+// Only the fields up to ids_flags are needed for VF detection.
+namespace {
 
-    // Build 122-bit value in little-endian order
-    uint8_t id_bits[16] = {0}; // 128 bits total (122 bits + 6 bits padding)
+struct cuid_drm_amdgpu_info {
+  uint64_t return_pointer;
+  uint32_t return_size;
+  uint32_t query;
+  uint8_t padding[16]; // matches the union in the kernel struct
+};
 
-    uint8_t unit_id_part1 = unit_id & 0xFF;
-    uint8_t unit_id_part2 = (unit_id >> 8) & 0x3F;
+struct cuid_amdgpu_dev_info {
+  uint32_t device_id;
+  uint32_t chip_rev;
+  uint32_t external_rev;
+  uint32_t pci_rev;
+  uint32_t family;
+  uint32_t num_shader_engines;
+  uint32_t num_shader_arrays_per_engine;
+  uint32_t gpu_counter_freq;
+  uint64_t max_engine_clock;
+  uint64_t max_memory_clock;
+  uint32_t cu_active_number;
+  uint32_t cu_ao_mask;
+  uint32_t cu_bitmap[4][4];
+  uint32_t enabled_rb_pipes_mask;
+  uint32_t num_rb_pipes;
+  uint32_t num_hw_gfx_contexts;
+  uint32_t pcie_gen;
+  uint64_t ids_flags;
+};
 
-    // Bits 0-63: Serial number (8 bytes)
-    memcpy(id_bits, &serial_number, 8);
+constexpr uint32_t kAmdgpuInfoDevInfo = 0x16;
+constexpr uint32_t kAmdgpuIdsFlagsModeShift = 0x8;
+constexpr uint32_t kAmdgpuIdsFlagsModeVf = 0x1;
 
-    // Bits 64-71: UnitID part 1 (1 byte)
-    id_bits[8] = unit_id_part1;
+// DRM_IOCTL_AMDGPU_INFO = _IOW('d', DRM_COMMAND_BASE + DRM_AMDGPU_INFO, ...)
+// DRM_COMMAND_BASE = 0x40, DRM_AMDGPU_INFO = 0x05
+// NOLINTNEXTLINE(cppcoreguidelines-macro-usage)
+#define CUID_DRM_IOCTL_AMDGPU_INFO _IOW('d', 0x45, cuid_drm_amdgpu_info)
 
-    // Bits 72-79: RevisionID (1 byte) 
-    id_bits[9] = revision_id;
+bool is_gpu_vf_mode(int fd) {
+  cuid_drm_amdgpu_info info_req = {};
+  cuid_amdgpu_dev_info dev_info = {};
 
-    // Bits 80-95: DeviceID (2 bytes); These format changes are necessary to make the final ID little Endian, as specified in the design
-    id_bits[10] = device_id & 0xFF;
-    id_bits[11] = (device_id >> 8) & 0xFF;
+  info_req.return_pointer = reinterpret_cast<uint64_t>(&dev_info);
+  info_req.return_size = sizeof(dev_info);
+  info_req.query = kAmdgpuInfoDevInfo;
 
-    // Bits 96-111: VendorID (2 bytes)
-    id_bits[12] = vendor_id & 0xFF;
-    id_bits[13] = (vendor_id >> 8) & 0xFF;
+  if (ioctl(fd, CUID_DRM_IOCTL_AMDGPU_INFO, &info_req) != 0) {
+    return false;
+  }
 
-    // Bits 112-117: UnitID part 2 (6 bits) + Bits 118-121: Component Type (4 bits)
-    id_bits[14] = (unit_id_part2 << 2) | ((device_type & 0xC) >> 2);
-    id_bits[15] = (device_type & 0x3) << 6; // Last 6 bits are padding
-
-    memcpy(primary_id->raw_bits, id_bits, 16);
-
-    // Apply UUIDv8 format according to RFC 9562
-    // Bits 0-47: ID value part 1 (LSB)
-    primary_id->UUIDv8_representation.bytes[0] = id_bits[0];
-    primary_id->UUIDv8_representation.bytes[1] = id_bits[1]; 
-    primary_id->UUIDv8_representation.bytes[2] = id_bits[2];
-    primary_id->UUIDv8_representation.bytes[3] = id_bits[3];
-    primary_id->UUIDv8_representation.bytes[4] = id_bits[4];
-    primary_id->UUIDv8_representation.bytes[5] = id_bits[5];
-    
-    // Bits 48-51: Version (8) + Bits 52-63: ID value part 2
-    primary_id->UUIDv8_representation.bytes[6] = ((id_bits[6] & 0xF0) >> 4) | 0x80; // Version 8 in upper 4 bits
-    primary_id->UUIDv8_representation.bytes[7] = ((id_bits[6] & 0x0F) << 4) | ((id_bits[7] & 0xF0) >> 4);
-
-    // Bits 64-65: Variant (10b) + Bits 66-127: ID value part 3 (MSB)
-    primary_id->UUIDv8_representation.bytes[8] = 0x80 | (id_bits[7] & 0x0F) << 2 | (id_bits[8] & 0xC0) >> 6;
-    // everything past here is now shifted by 6 bits
-    primary_id->UUIDv8_representation.bytes[9] = ((id_bits[8] & 0x3F) << 2) | ((id_bits[9] & 0xC0) >> 6);
-    primary_id->UUIDv8_representation.bytes[10] = ((id_bits[9] & 0x3F) << 2) | ((id_bits[10] & 0xC0) >> 6);
-    primary_id->UUIDv8_representation.bytes[11] = ((id_bits[10] & 0x3F) << 2) | ((id_bits[11] & 0xC0) >> 6);
-    primary_id->UUIDv8_representation.bytes[12] = ((id_bits[11] & 0x3F) << 2) | ((id_bits[12] & 0xC0) >> 6);
-    primary_id->UUIDv8_representation.bytes[13] = ((id_bits[12] & 0x3F) << 2) | ((id_bits[13] & 0xC0) >> 6);
-    primary_id->UUIDv8_representation.bytes[14] = ((id_bits[13] & 0x3F) << 2) | ((id_bits[14] & 0xC0) >> 6);
-    primary_id->UUIDv8_representation.bytes[15] = ((id_bits[14] & 0x3F) << 2) | ((id_bits[15] & 0xC0) >> 6);
-
-    return AMDCUID_STATUS_SUCCESS;
+  uint32_t mode = (dev_info.ids_flags >> kAmdgpuIdsFlagsModeShift) & 0x3;
+  return mode == kAmdgpuIdsFlagsModeVf;
 }
 
-void CuidUtilities::remove_UUIDv8_bits(amdcuid_id_t* id, uint8_t out_raw_bits[16]) {
-    if (!id || !out_raw_bits) {
-        return;
+uint16_t get_vf_index_from_sysfs(const std::string &device_path) {
+  // device_path is /sys/class/drm/renderDXXX/device
+  // Check if physfn symlink exists (present on VFs visible from the host)
+  std::string physfn_path = device_path + "/physfn";
+
+  // Get our own BDF from the device symlink
+  char dev_link[PATH_MAX];
+  ssize_t len = readlink(device_path.c_str(), dev_link, sizeof(dev_link) - 1);
+  if (len <= 0)
+    return 0;
+  dev_link[len] = '\0';
+
+  const char *our_bdf_ptr = strrchr(dev_link, '/');
+  if (our_bdf_ptr == nullptr)
+    return 0;
+  std::string our_bdf(our_bdf_ptr + 1);
+
+  // Resolve PF sysfs path via physfn symlink
+  char pf_real[PATH_MAX];
+  if (realpath(physfn_path.c_str(), pf_real) == nullptr)
+    return 0;
+  std::string pf_path(pf_real);
+
+  // Enumerate virtfnX symlinks on the PF to find our VF index
+  for (int idx = 0; idx < 256; ++idx) {
+    std::string virtfn_symlink = pf_path + "/virtfn" + std::to_string(idx);
+    char vfn_link[PATH_MAX];
+    len = readlink(virtfn_symlink.c_str(), vfn_link, sizeof(vfn_link) - 1);
+    if (len <= 0)
+      break; // no more VFs
+    vfn_link[len] = '\0';
+
+    const char *vfn_bdf_ptr = strrchr(vfn_link, '/');
+    if (vfn_bdf_ptr == nullptr)
+      continue;
+    if (our_bdf == (vfn_bdf_ptr + 1)) {
+      return static_cast<uint16_t>(idx + 1);
     }
+  }
+  return 0;
+}
 
-    // Reverse the UUIDv8 formatting to get back the original raw bits
-    // Bits 0-47: ID value part 1 (LSB)
-    out_raw_bits[0] = id->bytes[0];
-    out_raw_bits[1] = id->bytes[1];
-    out_raw_bits[2] = id->bytes[2];
-    out_raw_bits[3] = id->bytes[3];
-    out_raw_bits[4] = id->bytes[4];
-    out_raw_bits[5] = id->bytes[5];
+} // anonymous namespace
 
-    // Bits 48-51: Version (8) + Bits 52-63: ID value part 2
-    out_raw_bits[6] = ((id->bytes[6] & 0x0F) << 4) | ((id->bytes[7] & 0xFC) >> 2);
-    out_raw_bits[7] = ((id->bytes[7] & 0x03) << 6) | ((id->bytes[8] & 0xFC) >> 2);
+uint16_t CuidUtilities::get_gpu_vf_id(const std::string &device_path) {
+  // Determine if the GPU is an SR-IOV Virtual Function (VF) and return its
+  // 1-based VF index as the unit_id. Returns 0 for bare metal, PF,
+  // passthrough, or when VF detection is unavailable.
+  int render_minor = extract_render_minor(device_path);
+  if (render_minor < 0)
+    return 0;
 
-    // Bits 64-65: Variant (10b) + Bits 66-127: ID value part 3 (MSB)
-    out_raw_bits[8] = ((id->bytes[8] & 0x03) << 6) | ((id->bytes[9] & 0xFC) >> 2);
-    out_raw_bits[9] = ((id->bytes[9] & 0x03) << 6) | ((id->bytes[10] & 0xFC) >> 2);
-    out_raw_bits[10] = ((id->bytes[10] & 0x03) << 6) | ((id->bytes[11] & 0xFC) >> 2);
-    out_raw_bits[11] = ((id->bytes[11] & 0x03) << 6) | ((id->bytes[12] & 0xFC) >> 2);
-    out_raw_bits[12] = ((id->bytes[12] & 0x03) << 6) | ((id->bytes[13] & 0xFC) >> 2);
-    out_raw_bits[13] = ((id->bytes[13] & 0x03) << 6) | ((id->bytes[14] & 0xFC) >> 2);
-    out_raw_bits[14] = ((id->bytes[14] & 0x03) << 6) | ((id->bytes[15] & 0xFC) >> 2);
-    out_raw_bits[15] = (id->bytes[15] & 0x03) << 6; // last 6 bits are padding
+  std::string dev_node = "/dev/dri/renderD" + std::to_string(render_minor);
+
+  int fd = open(dev_node.c_str(), O_RDWR | O_CLOEXEC);
+  if (fd < 0) {
+    // Fall back to read-only if we lack write permission
+    fd = open(dev_node.c_str(), O_RDONLY | O_CLOEXEC);
+    if (fd < 0)
+      return 0;
+  }
+
+  bool is_vf = is_gpu_vf_mode(fd);
+  close(fd);
+
+  if (!is_vf)
+    return 0;
+
+  // VF detected via ioctl. Try to determine VF index from sysfs.
+  uint16_t vf_index = get_vf_index_from_sysfs(device_path);
+  if (vf_index > 0)
+    return vf_index;
+
+  // Could not determine VF index (e.g. inside a guest VM where physfn
+  // is not visible). Fall back to 0 per specification.
+  return 0;
+}
+
+amdcuid_status_t
+CuidUtilities::generate_derived_cuid(const amdcuid_primary_id *primary_id,
+                                     amdcuid_derived_id *derived_id,
+                                     cuid_hmac *hmac) {
+  if (!primary_id || !hmac) {
+    // Return invalid on null input
+    amdcuid_id_t empty = {};
+    return AMDCUID_STATUS_INVALID_ARGUMENT;
+  }
+
+  uint8_t hash[EVP_MAX_MD_SIZE];
+  size_t hash_len = 0;
+
+  amdcuid_status_t status =
+      static_cast<amdcuid_status_t>(hmac->generate_hmac_sha256(
+          reinterpret_cast<const uint8_t *>(primary_id->raw_bits),
+          sizeof(primary_id->raw_bits), hash, &hash_len));
+  if (status != AMDCUID_STATUS_SUCCESS) {
+    std::cerr << "Error generating HMAC" << std::endl;
+    return status;
+  }
+
+  // copy 110 LSB bits of hash to derived_id->hash
+  // Using only first 14 bytes (112 bits) of hash, then will mask last 2 bits
+  memcpy(derived_id->hash, hash, 14);
+  derived_id->hash[13] &= 0xFC; // 11111100
+
+  // Get the unit id parts from the primary ID
+  uint8_t reserved_1 = 0;
+  uint8_t reserved_2 = 0;
+  // Map the 256-bit hash to 122-bit CUID format
+  uint8_t id_bits[16] = {0};
+
+  // Copy first 8 bytes (64 bits) from hash
+  memcpy(id_bits, derived_id->hash, 8);
+
+  // insert unit id part 1 at bits 64-71
+  id_bits[8] = reserved_1;
+
+  // copy next 6 bytes (46 bits) from hash and mask off last 2 bits for bits
+  // 72-117
+  memcpy(id_bits + 9, derived_id->hash + 8, 6);
+  id_bits[14] &= 0xFC;
+
+  // bits 118-121: UnitID part 2 (4 bits)
+  id_bits[14] |= (reserved_2 >> 2);        // upper 2 bits of unit id part 2
+  id_bits[15] |= (reserved_2 & 0x03) << 6; // lower 2 bits of unit id part 2
+  // last 6 bits are padding (bits 122-127)
+  id_bits[15] &= 0xC0;
+
+  memcpy(derived_id->raw_bits, id_bits, 16);
+
+  // Apply UUIDv8 format according to RFC 9562
+  // Bits 0-47: ID value part 1 (LSB)
+  derived_id->UUIDv8_representation.bytes[0] = id_bits[0];
+  derived_id->UUIDv8_representation.bytes[1] = id_bits[1];
+  derived_id->UUIDv8_representation.bytes[2] = id_bits[2];
+  derived_id->UUIDv8_representation.bytes[3] = id_bits[3];
+  derived_id->UUIDv8_representation.bytes[4] = id_bits[4];
+  derived_id->UUIDv8_representation.bytes[5] = id_bits[5];
+
+  // Bits 48-51: Version (8) + Bits 52-63: ID value part 2
+  derived_id->UUIDv8_representation.bytes[6] =
+      ((id_bits[6] & 0xF0) >> 4) | 0x80; // Version 8 in upper 4 bits
+  derived_id->UUIDv8_representation.bytes[7] =
+      ((id_bits[6] & 0x0F) << 4) | ((id_bits[7] & 0xF0) >> 4);
+
+  // Bits 64-65: Variant (10b) + Bits 66-127: ID value part 3 (MSB)
+  derived_id->UUIDv8_representation.bytes[8] =
+      0x80 | (id_bits[7] & 0x0F) << 2 | (id_bits[8] & 0xC0) >> 6;
+  // everything past here is now shifted by 6 bits
+  derived_id->UUIDv8_representation.bytes[9] =
+      ((id_bits[8] & 0x3F) << 2) | ((id_bits[9] & 0xC0) >> 6);
+  derived_id->UUIDv8_representation.bytes[10] =
+      ((id_bits[9] & 0x3F) << 2) | ((id_bits[10] & 0xC0) >> 6);
+  derived_id->UUIDv8_representation.bytes[11] =
+      ((id_bits[10] & 0x3F) << 2) | ((id_bits[11] & 0xC0) >> 6);
+  derived_id->UUIDv8_representation.bytes[12] =
+      ((id_bits[11] & 0x3F) << 2) | ((id_bits[12] & 0xC0) >> 6);
+  derived_id->UUIDv8_representation.bytes[13] =
+      ((id_bits[12] & 0x3F) << 2) | ((id_bits[13] & 0xC0) >> 6);
+  derived_id->UUIDv8_representation.bytes[14] =
+      ((id_bits[13] & 0x3F) << 2) | ((id_bits[14] & 0xC0) >> 6);
+  derived_id->UUIDv8_representation.bytes[15] =
+      ((id_bits[14] & 0x3F) << 2) | ((id_bits[15] & 0xC0) >> 6);
+
+  return AMDCUID_STATUS_SUCCESS;
+}
+
+amdcuid_status_t
+CuidUtilities::generate_primary_cuid(uint64_t serial_number, uint16_t unit_id,
+                                     uint8_t revision_id, uint16_t device_id,
+                                     uint16_t vendor_id, uint8_t device_type,
+                                     amdcuid_primary_id *primary_id) {
+
+  // Build 122-bit value in little-endian order
+  uint8_t id_bits[16] = {0}; // 128 bits total (122 bits + 6 bits padding)
+
+  uint8_t unit_id_part1 = unit_id & 0xFF;
+  uint8_t unit_id_part2 = (unit_id >> 8) & 0x3F;
+
+  // Bits 0-63: Serial number (8 bytes)
+  memcpy(id_bits, &serial_number, 8);
+
+  // Bits 64-71: UnitID part 1 (1 byte)
+  id_bits[8] = unit_id_part1;
+
+  // Bits 72-79: RevisionID (1 byte)
+  id_bits[9] = revision_id;
+
+  // Bits 80-95: DeviceID (2 bytes); These format changes are necessary to make
+  // the final ID little Endian, as specified in the design
+  id_bits[10] = device_id & 0xFF;
+  id_bits[11] = (device_id >> 8) & 0xFF;
+
+  // Bits 96-111: VendorID (2 bytes)
+  id_bits[12] = vendor_id & 0xFF;
+  id_bits[13] = (vendor_id >> 8) & 0xFF;
+
+  // Bits 112-117: UnitID part 2 (6 bits) + Bits 118-121: Component Type (4
+  // bits)
+  id_bits[14] = (unit_id_part2 << 2) | ((device_type & 0xC) >> 2);
+  id_bits[15] = (device_type & 0x3) << 6; // Last 6 bits are padding
+
+  memcpy(primary_id->raw_bits, id_bits, 16);
+
+  // Apply UUIDv8 format according to RFC 9562
+  // Bits 0-47: ID value part 1 (LSB)
+  primary_id->UUIDv8_representation.bytes[0] = id_bits[0];
+  primary_id->UUIDv8_representation.bytes[1] = id_bits[1];
+  primary_id->UUIDv8_representation.bytes[2] = id_bits[2];
+  primary_id->UUIDv8_representation.bytes[3] = id_bits[3];
+  primary_id->UUIDv8_representation.bytes[4] = id_bits[4];
+  primary_id->UUIDv8_representation.bytes[5] = id_bits[5];
+
+  // Bits 48-51: Version (8) + Bits 52-63: ID value part 2
+  primary_id->UUIDv8_representation.bytes[6] =
+      ((id_bits[6] & 0xF0) >> 4) | 0x80; // Version 8 in upper 4 bits
+  primary_id->UUIDv8_representation.bytes[7] =
+      ((id_bits[6] & 0x0F) << 4) | ((id_bits[7] & 0xF0) >> 4);
+
+  // Bits 64-65: Variant (10b) + Bits 66-127: ID value part 3 (MSB)
+  primary_id->UUIDv8_representation.bytes[8] =
+      0x80 | (id_bits[7] & 0x0F) << 2 | (id_bits[8] & 0xC0) >> 6;
+  // everything past here is now shifted by 6 bits
+  primary_id->UUIDv8_representation.bytes[9] =
+      ((id_bits[8] & 0x3F) << 2) | ((id_bits[9] & 0xC0) >> 6);
+  primary_id->UUIDv8_representation.bytes[10] =
+      ((id_bits[9] & 0x3F) << 2) | ((id_bits[10] & 0xC0) >> 6);
+  primary_id->UUIDv8_representation.bytes[11] =
+      ((id_bits[10] & 0x3F) << 2) | ((id_bits[11] & 0xC0) >> 6);
+  primary_id->UUIDv8_representation.bytes[12] =
+      ((id_bits[11] & 0x3F) << 2) | ((id_bits[12] & 0xC0) >> 6);
+  primary_id->UUIDv8_representation.bytes[13] =
+      ((id_bits[12] & 0x3F) << 2) | ((id_bits[13] & 0xC0) >> 6);
+  primary_id->UUIDv8_representation.bytes[14] =
+      ((id_bits[13] & 0x3F) << 2) | ((id_bits[14] & 0xC0) >> 6);
+  primary_id->UUIDv8_representation.bytes[15] =
+      ((id_bits[14] & 0x3F) << 2) | ((id_bits[15] & 0xC0) >> 6);
+
+  return AMDCUID_STATUS_SUCCESS;
+}
+
+void CuidUtilities::remove_UUIDv8_bits(amdcuid_id_t *id,
+                                       uint8_t out_raw_bits[16]) {
+  if (!id || !out_raw_bits) {
+    return;
+  }
+
+  // Reverse the UUIDv8 formatting to get back the original raw bits
+  // Bits 0-47: ID value part 1 (LSB)
+  out_raw_bits[0] = id->bytes[0];
+  out_raw_bits[1] = id->bytes[1];
+  out_raw_bits[2] = id->bytes[2];
+  out_raw_bits[3] = id->bytes[3];
+  out_raw_bits[4] = id->bytes[4];
+  out_raw_bits[5] = id->bytes[5];
+
+  // Bits 48-51: Version (8) + Bits 52-63: ID value part 2
+  out_raw_bits[6] = ((id->bytes[6] & 0x0F) << 4) | ((id->bytes[7] & 0xFC) >> 2);
+  out_raw_bits[7] = ((id->bytes[7] & 0x03) << 6) | ((id->bytes[8] & 0xFC) >> 2);
+
+  // Bits 64-65: Variant (10b) + Bits 66-127: ID value part 3 (MSB)
+  out_raw_bits[8] = ((id->bytes[8] & 0x03) << 6) | ((id->bytes[9] & 0xFC) >> 2);
+  out_raw_bits[9] =
+      ((id->bytes[9] & 0x03) << 6) | ((id->bytes[10] & 0xFC) >> 2);
+  out_raw_bits[10] =
+      ((id->bytes[10] & 0x03) << 6) | ((id->bytes[11] & 0xFC) >> 2);
+  out_raw_bits[11] =
+      ((id->bytes[11] & 0x03) << 6) | ((id->bytes[12] & 0xFC) >> 2);
+  out_raw_bits[12] =
+      ((id->bytes[12] & 0x03) << 6) | ((id->bytes[13] & 0xFC) >> 2);
+  out_raw_bits[13] =
+      ((id->bytes[13] & 0x03) << 6) | ((id->bytes[14] & 0xFC) >> 2);
+  out_raw_bits[14] =
+      ((id->bytes[14] & 0x03) << 6) | ((id->bytes[15] & 0xFC) >> 2);
+  out_raw_bits[15] = (id->bytes[15] & 0x03) << 6; // last 6 bits are padding
 }
 
 std::string CuidUtilities::get_cuid_as_string(const amdcuid_id_t *id) {
-    // Format as UUIDv8 string: 8-4-4-4-12 hex digits from id->bytes[16]
-    // UUID: xxxxxxxx-xxxx-8xxx-yxxx-xxxxxxxxxxxx
-    char uuid_str[37]; // 36 chars + null
-    // Format the bytes into a UUID string
-    snprintf(uuid_str, sizeof(uuid_str),
-             "%02x%02x%02x%02x-%02x%02x-%02x%02x-%02x%02x-%02x%02x%02x%02x%02x%02x",
-             id->bytes[0], id->bytes[1], id->bytes[2], id->bytes[3],
-             id->bytes[4], id->bytes[5],
-             id->bytes[6], id->bytes[7],
-             id->bytes[8], id->bytes[9],
-             id->bytes[10], id->bytes[11], id->bytes[12], id->bytes[13], id->bytes[14], id->bytes[15]);
+  // Format as UUIDv8 string: 8-4-4-4-12 hex digits from id->bytes[16]
+  // UUID: xxxxxxxx-xxxx-8xxx-yxxx-xxxxxxxxxxxx
+  char uuid_str[37]; // 36 chars + null
+  // Format the bytes into a UUID string
+  snprintf(
+      uuid_str, sizeof(uuid_str),
+      "%02x%02x%02x%02x-%02x%02x-%02x%02x-%02x%02x-%02x%02x%02x%02x%02x%02x",
+      id->bytes[0], id->bytes[1], id->bytes[2], id->bytes[3], id->bytes[4],
+      id->bytes[5], id->bytes[6], id->bytes[7], id->bytes[8], id->bytes[9],
+      id->bytes[10], id->bytes[11], id->bytes[12], id->bytes[13], id->bytes[14],
+      id->bytes[15]);
 
-    return std::string(uuid_str);
+  return std::string(uuid_str);
 }
 
-amdcuid_status_t CuidUtilities::uuid_string_to_uint8(const std::string& uuid_str, uint8_t* uuid) {
-    if (!uuid) {
+amdcuid_status_t
+CuidUtilities::uuid_string_to_uint8(const std::string &uuid_str,
+                                    uint8_t *uuid) {
+  if (!uuid) {
+    return AMDCUID_STATUS_INVALID_ARGUMENT;
+  }
+
+  // UUID format: XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX (36 chars with hyphens)
+  // Remove hyphens and validate length
+  std::string hex_str;
+  for (char c : uuid_str) {
+    if (c != '-') {
+      if (!isxdigit(c)) {
+        std::cerr << "Invalid UUID format: non-hex character found"
+                  << std::endl;
         return AMDCUID_STATUS_INVALID_ARGUMENT;
+      }
+      hex_str += c;
     }
+  }
 
-    // UUID format: XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX (36 chars with hyphens)
-    // Remove hyphens and validate length
-    std::string hex_str;
-    for (char c : uuid_str) {
-        if (c != '-') {
-            if (!isxdigit(c)) {
-                std::cerr << "Invalid UUID format: non-hex character found" << std::endl;
-                return AMDCUID_STATUS_INVALID_ARGUMENT;
-            }
-            hex_str += c;
-        }
-    }
+  // UUID should be 128 bits = 32 hex characters
+  if (hex_str.length() != 32) {
+    std::cerr << "Invalid UUID length: expected 32 hex digits, got "
+              << hex_str.length() << std::endl;
+    return AMDCUID_STATUS_INVALID_ARGUMENT;
+  }
 
-    // UUID should be 128 bits = 32 hex characters
-    if (hex_str.length() != 32) {
-        std::cerr << "Invalid UUID length: expected 32 hex digits, got " << hex_str.length() << std::endl;
-        return AMDCUID_STATUS_INVALID_ARGUMENT;
-    }
+  // convert hex_str to uint8_t array
+  for (size_t i = 0; i < 16; ++i) {
+    std::string byte_str = hex_str.substr(i * 2, 2);
+    uuid[i] = static_cast<uint8_t>(std::stoul(byte_str, nullptr, 16));
+  }
 
-    // convert hex_str to uint8_t array
-    for (size_t i = 0; i < 16; ++i) {
-        std::string byte_str = hex_str.substr(i * 2, 2);
-        uuid[i] = static_cast<uint8_t>(std::stoul(byte_str, nullptr, 16));
-    }
-
-    return AMDCUID_STATUS_SUCCESS;
+  return AMDCUID_STATUS_SUCCESS;
 }
 
 std::string CuidUtilities::device_type_to_string(amdcuid_device_type_t type) {
-    switch (type) {
-        case AMDCUID_DEVICE_TYPE_PLATFORM: return "PLATFORM";
-        case AMDCUID_DEVICE_TYPE_CPU: return "CPU";
-        case AMDCUID_DEVICE_TYPE_GPU: return "GPU";
-        case AMDCUID_DEVICE_TYPE_NIC: return "NIC";
-        default: return "UNKNOWN";
-    }
+  switch (type) {
+  case AMDCUID_DEVICE_TYPE_PLATFORM:
+    return "PLATFORM";
+  case AMDCUID_DEVICE_TYPE_CPU:
+    return "CPU";
+  case AMDCUID_DEVICE_TYPE_GPU:
+    return "GPU";
+  case AMDCUID_DEVICE_TYPE_NIC:
+    return "NIC";
+  default:
+    return "UNKNOWN";
+  }
 }

--- a/projects/cuid/lib/src/cuid_util.h
+++ b/projects/cuid/lib/src/cuid_util.h
@@ -66,7 +66,7 @@ std::string readlink_bdf(const std::string &device_path);
 std::string bdf_to_device_path(const std::string &bdf,
                                amdcuid_device_type_t device_type);
 std::string real_dev_path_from_fd(int fd);
-std::string get_real_path(const std::string path);
+std::string get_real_path(const std::string &path);
 amdcuid_status_t generate_derived_cuid(const amdcuid_primary_id *primary_id,
                                        amdcuid_derived_id *derived_id,
                                        cuid_hmac *hmac);

--- a/projects/cuid/lib/src/cuid_util.h
+++ b/projects/cuid/lib/src/cuid_util.h
@@ -23,67 +23,76 @@
 #ifndef CUID_UTIL_H
 #define CUID_UTIL_H
 
+#include "hmac.h"
 #include "include/amd_cuid.h"
 #include "src/cuid_internal.h"
-#include "hmac.h"
-#include <vector>
-#include <memory>
-#include <string>
 #include <iostream>
+#include <memory>
 #include <sstream>
+#include <string>
+#include <vector>
 
 enum LogLevel { DEBUG, INFO, WARN, ERROR };
 
 class Logger {
 public:
-    static Logger& instance() {
-        static Logger logger_;
-        return logger_;
-    }
+  static Logger &instance() {
+    static Logger logger_;
+    return logger_;
+  }
 
-    void set_level(LogLevel level) { level_ = level; }
-    LogLevel level() const { return level_; }
+  void set_level(LogLevel level) { level_ = level; }
+  LogLevel level() const { return level_; }
 
-    const char* LogLevelName(LogLevel level) const;
+  const char *LogLevelName(LogLevel level) const;
 
-    void log(LogLevel level, const std::string& msg) const;
+  void log(LogLevel level, const std::string &msg) const;
 
 private:
-    Logger() : level_(INFO) {}
-    LogLevel level_;
+  Logger() : level_(INFO) {}
+  LogLevel level_;
 };
 
-#define LOG(level, msg) \
-    do { \
-        std::ostringstream _log_stream_; \
-        _log_stream_ << msg; \
-        Logger::instance().log(level, _log_stream_.str()); \
-    } while (0)
+#define LOG(level, msg)                                                        \
+  do {                                                                         \
+    std::ostringstream _log_stream_;                                           \
+    _log_stream_ << msg;                                                       \
+    Logger::instance().log(level, _log_stream_.str());                         \
+  } while (0)
 
 namespace CuidUtilities {
-    std::string read_sysfs_file(const std::string &path);
-    std::string readlink_bdf(const std::string &device_path);
-    std::string bdf_to_device_path(const std::string &bdf, amdcuid_device_type_t device_type);
-    std::string real_dev_path_from_fd(int fd);
-    std::string get_real_path(const std::string path);
-    amdcuid_status_t generate_derived_cuid(const amdcuid_primary_id* primary_id, amdcuid_derived_id* derived_id, cuid_hmac* hmac);
-    amdcuid_status_t generate_primary_cuid(uint64_t serial_number, uint16_t unit_id,
-                                 uint8_t revision_id, uint16_t device_id, uint16_t vendor_id,
-                                 uint8_t device_type, amdcuid_primary_id* primary_id);
-    void remove_UUIDv8_bits(amdcuid_id_t* id, uint8_t out_raw_bits[16]);
-    std::string get_cuid_as_string(const amdcuid_id_t *id);
-    amdcuid_status_t uuid_string_to_uint8(const std::string& uuid_str, uint8_t* uuid);
-    std::string device_type_to_string(amdcuid_device_type_t type);
+std::string read_sysfs_file(const std::string &path);
+std::string readlink_bdf(const std::string &device_path);
+std::string bdf_to_device_path(const std::string &bdf,
+                               amdcuid_device_type_t device_type);
+std::string real_dev_path_from_fd(int fd);
+std::string get_real_path(const std::string path);
+amdcuid_status_t generate_derived_cuid(const amdcuid_primary_id *primary_id,
+                                       amdcuid_derived_id *derived_id,
+                                       cuid_hmac *hmac);
+amdcuid_status_t generate_primary_cuid(uint64_t serial_number, uint16_t unit_id,
+                                       uint8_t revision_id, uint16_t device_id,
+                                       uint16_t vendor_id, uint8_t device_type,
+                                       amdcuid_primary_id *primary_id);
+void remove_UUIDv8_bits(amdcuid_id_t *id, uint8_t out_raw_bits[16]);
+std::string get_cuid_as_string(const amdcuid_id_t *id);
+amdcuid_status_t uuid_string_to_uint8(const std::string &uuid_str,
+                                      uint8_t *uuid);
+std::string device_type_to_string(amdcuid_device_type_t type);
 
-    // Use inline functions to avoid static initialization order fiasco
-    inline const std::string& cuid_file() {
-        static const std::string path = "/tmp/cuid";
-        return path;
-    }
-    inline const std::string& priv_cuid_file() {
-        static const std::string path = "/tmp/priv_cuid";
-        return path;
-    }
+// GPU VF (SR-IOV Virtual Function) utilities
+int extract_render_minor(const std::string &path);
+uint16_t get_gpu_vf_id(const std::string &device_path);
+
+// Use inline functions to avoid static initialization order fiasco
+inline const std::string &cuid_file() {
+  static const std::string path = "/tmp/cuid";
+  return path;
 }
+inline const std::string &priv_cuid_file() {
+  static const std::string path = "/tmp/priv_cuid";
+  return path;
+}
+} // namespace CuidUtilities
 
 #endif


### PR DESCRIPTION
## Motivation

Refactor GPU unit_id calculation to use SR-IOV Virtual Function (VF) detection via DRM ioctl instead of the previous KFD partition-based approach. VF is the correct source for unit_id; compute partition ID was incorrectly being used. In bare metal scenarios, unit_id is always 0.

## Technical Details

Replaced KFD topology functions (get_kfd_partition_id, get_parent_render_minor_from_kfd, etc.) with get_gpu_vf_id() which uses DRM_IOCTL_AMDGPU_INFO to query ids_flags for VF mode detection (AMDGPU_IDS_FLAGS_MODE_VF), then resolves the VF index via sysfs physfn/virtfnX enumeration. Changes span cuid_util.h, cuid_util.cc, and cuid_gpu.cc. Fingerprint retrieval for VFs now falls back to physfn/unique_id instead of arithmetic-based parent device path calculation.

## JIRA ID

[ROCM-20642]

## Test Plan

Built the project with make -j$(nproc) — no errors or warnings. Ran the full unit test suite (amdcuid_test).

## Test Result

15/18 tests passed, 2 skipped (require root for HMAC key operations), 1 pre-existing failure (RefreshDevices — daemon not running, IPC error, unrelated to this change). All formatting checks pass clean.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.


[ROCM-20642]: https://amd-hub.atlassian.net/browse/ROCM-20642?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ