### PR TITLE
[ROCM-20643] Correct GPU discovery method

### DIFF
--- a/projects/cuid/lib/src/cuid_gpu.cc
+++ b/projects/cuid/lib/src/cuid_gpu.cc
@@ -34,6 +34,40 @@
 
 CuidGpu::CuidGpu(const amdcuid_gpu_info &i) : m_info(i) {}
 
+// Helper to check if a /sys/class/drm entry name is a card device (e.g.,
+// "card0", "card1"). Excludes connector entries like "card0-DP-1" or
+// "card0-HDMI-A-1".
+static bool is_card_entry(const char *name) {
+  if (strncmp(name, "card", 4) != 0 || !isdigit(name[4]))
+    return false;
+  for (size_t i = 4; name[i] != '\0'; ++i) {
+    if (!isdigit(name[i]))
+      return false;
+  }
+  return true;
+}
+
+// Resolve the renderD node path for a given card path.
+// If a renderD node exists under the card's device/drm directory, returns
+// "/sys/class/drm/renderDXXX". Otherwise, returns the original card path.
+static std::string resolve_render_node(const std::string &card_path) {
+  std::string drm_dir = card_path + "/device/drm";
+  DIR *dir = opendir(drm_dir.c_str());
+  if (dir) {
+    struct dirent *entry;
+    while ((entry = readdir(dir)) != nullptr) {
+      if (strncmp(entry->d_name, "renderD", 7) == 0 &&
+          isdigit(entry->d_name[7])) {
+        std::string result = "/sys/class/drm/" + std::string(entry->d_name);
+        closedir(dir);
+        return result;
+      }
+    }
+    closedir(dir);
+  }
+  return card_path;
+}
+
 amdcuid_status_t CuidGpu::discover(std::vector<DevicePtr> &gpus) {
   const char *drm_path = "/sys/class/drm";
   DIR *dir = opendir(drm_path);
@@ -42,11 +76,13 @@ amdcuid_status_t CuidGpu::discover(std::vector<DevicePtr> &gpus) {
 
   struct dirent *entry;
   while ((entry = readdir(dir)) != NULL) {
-    if (strncmp(entry->d_name, "renderD", 7) == 0 &&
-        isdigit(entry->d_name[7])) {
-      std::string render_name(entry->d_name);
+    // Use card entries (e.g., card0, card1) which are always present for DRM
+    // devices, unlike renderD nodes which may be absent with certain drivers
+    // (e.g., GIM) or for non-AMD GPUs.
+    if (is_card_entry(entry->d_name)) {
+      std::string card_name(entry->d_name);
       std::string device_path =
-          std::string(drm_path) + "/" + render_name + "/device";
+          std::string(drm_path) + "/" + card_name + "/device";
       amdcuid_gpu_info info = {};
       discover_single(&info, device_path);
 
@@ -137,14 +173,24 @@ amdcuid_status_t CuidGpu::discover_single(amdcuid_gpu_info *gpu_info,
         (uint16_t)strtol(revision_id.c_str(), nullptr, 16);
   }
 
-  // we use the original device path to get render node
+  // Determine the device node path. We prefer the renderD node for backward
+  // compatibility (CUID files may reference renderD paths). If no renderD node
+  // exists (e.g., GIM driver), the card path is used instead.
   std::string full_device_node;
   size_t last_slash = device_path.rfind('/');
   if (last_slash != std::string::npos && last_slash > 0) {
-    // Trim to just /sys/class/drm/renderDXXX;
+    // Trim to just /sys/class/drm/cardN or /sys/class/drm/renderDXXX
     full_device_node = device_path.substr(0, last_slash);
   } else {
     full_device_node = device_path;
+  }
+
+  // If discovered via card entry, try to resolve the associated renderD node
+  if (full_device_node.find("/card") != std::string::npos) {
+    std::string render_node = resolve_render_node(full_device_node);
+    if (render_node != full_device_node) {
+      full_device_node = render_node;
+    }
   }
 
   info.header.device_type = AMDCUID_DEVICE_TYPE_GPU;

--- a/projects/cuid/lib/src/cuid_gpu.h
+++ b/projects/cuid/lib/src/cuid_gpu.h
@@ -23,41 +23,46 @@
 #ifndef CUID_GPU_H
 #define CUID_GPU_H
 
-
-#include "src/cuid_device.h"
 #include "include/amd_cuid.h"
+#include "src/cuid_device.h"
 #include "src/cuid_internal.h"
-#include <vector>
 #include <memory>
 #include <string>
+#include <vector>
 
 struct amdcuid_gpu_info {
-    amdcuid_cuid_public_fields header;
-    std::string render_node;
-    std::string bdf;
+  amdcuid_cuid_public_fields header;
+  // DRM device node: /sys/class/drm/renderDXXX or /sys/class/drm/cardN
+  std::string render_node;
+  std::string bdf;
 };
 
 class CuidGpu : public CuidDevice {
 public:
-    CuidGpu(const amdcuid_gpu_info& i);
-    amdcuid_device_type_t type() const override { return AMDCUID_DEVICE_TYPE_GPU; }
-    amdcuid_status_t get_primary_cuid(amdcuid_primary_id& id) const override;
-    amdcuid_status_t get_hardware_fingerprint(uint64_t& fingerprint) const override;
-    static amdcuid_status_t discover(std::vector<DevicePtr> &gpus);
-    static amdcuid_status_t discover_single(amdcuid_gpu_info *gpu_info, const std::string& device_path);
+  CuidGpu(const amdcuid_gpu_info &i);
+  amdcuid_device_type_t type() const override {
+    return AMDCUID_DEVICE_TYPE_GPU;
+  }
+  amdcuid_status_t get_primary_cuid(amdcuid_primary_id &id) const override;
+  amdcuid_status_t
+  get_hardware_fingerprint(uint64_t &fingerprint) const override;
+  static amdcuid_status_t discover(std::vector<DevicePtr> &gpus);
+  static amdcuid_status_t discover_single(amdcuid_gpu_info *gpu_info,
+                                          const std::string &device_path);
 
-    // Virtual accessor overrides
-    amdcuid_status_t get_vendor_id(uint16_t& vendor_id) const override;
-    amdcuid_status_t get_device_id(uint16_t& device_id) const override;
-    amdcuid_status_t get_pci_class(uint16_t& pci_class) const override;
-    amdcuid_status_t get_revision_id(uint8_t& revision_id) const override;
-    amdcuid_status_t get_unit_id(uint16_t& unit_id) const override;
-    amdcuid_status_t get_bdf(std::string& bdf) const override;
-    amdcuid_status_t get_device_path(std::string& path) const override;
+  // Virtual accessor overrides
+  amdcuid_status_t get_vendor_id(uint16_t &vendor_id) const override;
+  amdcuid_status_t get_device_id(uint16_t &device_id) const override;
+  amdcuid_status_t get_pci_class(uint16_t &pci_class) const override;
+  amdcuid_status_t get_revision_id(uint8_t &revision_id) const override;
+  amdcuid_status_t get_unit_id(uint16_t &unit_id) const override;
+  amdcuid_status_t get_bdf(std::string &bdf) const override;
+  amdcuid_status_t get_device_path(std::string &path) const override;
 
-    const amdcuid_gpu_info& get_info() const;
+  const amdcuid_gpu_info &get_info() const;
+
 private:
-    amdcuid_gpu_info m_info;
+  amdcuid_gpu_info m_info;
 };
 
 #endif // CUID_GPU_H

--- a/projects/cuid/lib/src/cuid_util.cc
+++ b/projects/cuid/lib/src/cuid_util.cc
@@ -93,7 +93,8 @@ std::string CuidUtilities::readlink_bdf(const std::string &device_path) {
 }
 
 // Helper to get device path from BDF based on device type
-// For GPUs: returns /sys/class/drm/renderDXXX/device path
+// For GPUs: returns /sys/class/drm/renderDXXX/device or
+//           /sys/class/drm/cardN/device path
 // For NICs: returns /sys/class/net/<iface>/device path
 std::string
 CuidUtilities::bdf_to_device_path(const std::string &bdf,
@@ -109,16 +110,38 @@ CuidUtilities::bdf_to_device_path(const std::string &bdf,
     DIR *dir = opendir(subsystem_dir.c_str());
     if (dir) {
       struct dirent *entry;
+      std::string card_path;
       while ((entry = readdir(dir)) != nullptr) {
-        // Look for renderD* nodes
+        // Prefer renderD* nodes when available
         if (strncmp(entry->d_name, "renderD", 7) == 0) {
           std::string device_path =
               "/sys/class/drm/" + std::string(entry->d_name) + "/device";
           closedir(dir);
           return device_path;
         }
+        // Track card entries as fallback (e.g., card0, card1)
+        // Exclude connector entries like card0-DP-1
+        if (strncmp(entry->d_name, "card", 4) == 0 &&
+            isdigit(entry->d_name[4])) {
+          bool all_digits = true;
+          for (size_t i = 4; entry->d_name[i] != '\0'; ++i) {
+            if (!isdigit(entry->d_name[i])) {
+              all_digits = false;
+              break;
+            }
+          }
+          if (all_digits && card_path.empty()) {
+            card_path =
+                "/sys/class/drm/" + std::string(entry->d_name) + "/device";
+          }
+        }
       }
       closedir(dir);
+      // Fall back to card entry if no renderD node was found
+      // (e.g., when using GIM driver or for non-AMD GPUs)
+      if (!card_path.empty()) {
+        return card_path;
+      }
     }
   } else if (device_type == AMDCUID_DEVICE_TYPE_NIC) {
     subsystem_dir = pci_device_path + "/net";


### PR DESCRIPTION
## Motivation

The current GPU discovery method requires renderD# directories to exist in drm to recognize a GPU. This fails when using the GIM driver and when discovering non-AMD GPUs, as renderD nodes are not always present. This PR switches discovery to use card* entries which are universally available for all DRM devices.

## Technical Details

Changed CuidGpu::discover() to scan card* entries instead of renderD* in drm. Added helpers is_card_entry(), extract_drm_node_info(), and resolve_render_node() to support generic DRM node parsing and backward-compatible renderD resolution. Updated bdf_to_device_path() in cuid_util.cc to fall back to card* when no renderD* exists. Generalized get_parent_device_path() and partition detection to work with both card* and renderD* paths.

## JIRA ID

[ROCM-20643]

## Test Plan

Built the project with cmake --build and confirmed zero compilation warnings/errors across all targets (libamdcuid_shared, amdcuid_tool, amdcuid_daemon, amdcuid_example, amdcuid_test).

## Test Result

Full build success.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.


[ROCM-20643]: https://amd-hub.atlassian.net/browse/ROCM-20643?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ