### PR TITLE
[rocprofiler-sdk][aqlprofile] Remove rocm version dependency in CI workflows

### DIFF
--- a/.github/workflows/aqlprofile-continuous_integration.yml
+++ b/.github/workflows/aqlprofile-continuous_integration.yml
@@ -81,14 +81,14 @@ jobs:
       shell: bash
       working-directory: /tmp
       run: |
-        rocm_install_path="${{ env.ROCM_NIGHTLY_PATH }}"
+        rocm_nightly_path="${{ env.ROCM_NIGHTLY_PATH }}"
         rocm_tarball="${{ env.ROCM_PATH }}-${{ matrix.system.gpu-target }}.tar.gz"
-        rm -rf "${rocm_install_path}"
-        mkdir -p "${rocm_install_path}"
-        tar -xf "${rocm_tarball}" -C "${rocm_install_path}"
+        rm -rf "${rocm_nightly_path}"
+        mkdir -p "${rocm_nightly_path}"
+        tar -xf "${rocm_tarball}" -C "${rocm_nightly_path}"
         rm -rf "${{ env.ROCM_PATH }}"
-        ln -s "${rocm_install_path}" "${{ env.ROCM_PATH }}"
-        echo "ROCm installed to: ${rocm_install_path}"
+        ln -s "${rocm_nightly_path}" "${{ env.ROCM_PATH }}"
+        echo "ROCm installed to: ${rocm_nightly_path}"
         ln -s -f /usr/bin/git /usr/local/bin/git
 
     - uses: actions/checkout@v5
@@ -169,14 +169,14 @@ jobs:
       shell: bash
       working-directory: /tmp
       run: |
-        rocm_install_path="${{ env.ROCM_NIGHTLY_PATH }}"
+        rocm_nightly_path="${{ env.ROCM_NIGHTLY_PATH }}"
         rocm_tarball="${{ env.ROCM_PATH }}-${{ matrix.system.gpu-target }}.tar.gz"
-        rm -rf "${rocm_install_path}"
-        mkdir -p "${rocm_install_path}"
-        tar -xf "${rocm_tarball}" -C "${rocm_install_path}"
+        rm -rf "${rocm_nightly_path}"
+        mkdir -p "${rocm_nightly_path}"
+        tar -xf "${rocm_tarball}" -C "${rocm_nightly_path}"
         rm -rf "${{ env.ROCM_PATH }}"
-        ln -s "${rocm_install_path}" "${{ env.ROCM_PATH }}"
-        echo "ROCm installed to: ${rocm_install_path}"
+        ln -s "${rocm_nightly_path}" "${{ env.ROCM_PATH }}"
+        echo "ROCm installed to: ${rocm_nightly_path}"
 
     - name: Install requirements
       timeout-minutes: 10

--- a/.github/workflows/aqlprofile-continuous_integration.yml
+++ b/.github/workflows/aqlprofile-continuous_integration.yml
@@ -27,7 +27,7 @@ concurrency:
 
 env:
   ROCM_PATH: "/opt/rocm"
-  ROCM_VERSION: "7.2.0"
+  ROCM_NIGHTLY_PATH: "/opt/rocm-nightly"
   PYTHON_VENV_PATH: "aqlprofile"
   PYTHON_VENV_ACTIVATE: "aqlprofile/bin/activate"
   navi3_EXCLUDE_TESTS_REGEX: ""
@@ -81,9 +81,14 @@ jobs:
       shell: bash
       working-directory: /tmp
       run: |
-        tar -xf ${{ env.ROCM_PATH }}-${{ matrix.system.gpu-target }}.tar.gz -C ${{ env.ROCM_PATH }}-${{ env.ROCM_VERSION }}
-        ln -s ${{ env.ROCM_PATH }}-${{ env.ROCM_VERSION }} ${{ env.ROCM_PATH }}
-        echo "ROCm installed to: ${{ env.ROCM_PATH }}"
+        rocm_install_path="${{ env.ROCM_NIGHTLY_PATH }}"
+        rocm_tarball="${{ env.ROCM_PATH }}-${{ matrix.system.gpu-target }}.tar.gz"
+        rm -rf "${rocm_install_path}"
+        mkdir -p "${rocm_install_path}"
+        tar -xf "${rocm_tarball}" -C "${rocm_install_path}"
+        rm -rf "${{ env.ROCM_PATH }}"
+        ln -s "${rocm_install_path}" "${{ env.ROCM_PATH }}"
+        echo "ROCm installed to: ${rocm_install_path}"
         ln -s -f /usr/bin/git /usr/local/bin/git
 
     - uses: actions/checkout@v5
@@ -164,9 +169,14 @@ jobs:
       shell: bash
       working-directory: /tmp
       run: |
-        tar -xf ${{ env.ROCM_PATH }}-${{ matrix.system.gpu-target }}.tar.gz -C ${{ env.ROCM_PATH }}-${{ env.ROCM_VERSION }}
-        ln -s ${{ env.ROCM_PATH }}-${{ env.ROCM_VERSION }} ${{ env.ROCM_PATH }}
-        echo "ROCm installed to: ${{ env.ROCM_PATH }}"
+        rocm_install_path="${{ env.ROCM_NIGHTLY_PATH }}"
+        rocm_tarball="${{ env.ROCM_PATH }}-${{ matrix.system.gpu-target }}.tar.gz"
+        rm -rf "${rocm_install_path}"
+        mkdir -p "${rocm_install_path}"
+        tar -xf "${rocm_tarball}" -C "${rocm_install_path}"
+        rm -rf "${{ env.ROCM_PATH }}"
+        ln -s "${rocm_install_path}" "${{ env.ROCM_PATH }}"
+        echo "ROCm installed to: ${rocm_install_path}"
 
     - name: Install requirements
       timeout-minutes: 10

--- a/.github/workflows/aqlprofile-continuous_integration.yml
+++ b/.github/workflows/aqlprofile-continuous_integration.yml
@@ -27,7 +27,6 @@ concurrency:
 
 env:
   ROCM_PATH: "/opt/rocm"
-  ROCM_NIGHTLY_PATH: "/opt/rocm-nightly"
   PYTHON_VENV_PATH: "aqlprofile"
   PYTHON_VENV_ACTIVATE: "aqlprofile/bin/activate"
   navi3_EXCLUDE_TESTS_REGEX: ""
@@ -81,14 +80,11 @@ jobs:
       shell: bash
       working-directory: /tmp
       run: |
-        rocm_nightly_path="${{ env.ROCM_NIGHTLY_PATH }}"
-        rocm_tarball="${{ env.ROCM_PATH }}-${{ matrix.system.gpu-target }}.tar.gz"
-        rm -rf "${rocm_nightly_path}"
-        mkdir -p "${rocm_nightly_path}"
-        tar -xf "${rocm_tarball}" -C "${rocm_nightly_path}"
-        rm -rf "${{ env.ROCM_PATH }}"
-        ln -s "${rocm_nightly_path}" "${{ env.ROCM_PATH }}"
-        echo "ROCm installed to: ${rocm_nightly_path}"
+        mv "${{ env.ROCM_PATH }}-${{ matrix.system.gpu-target }}.tar.gz" .
+        rm -rf ${{ env.ROCM_PATH }}*
+        mkdir -p "${{ env.ROCM_PATH }}"
+        tar -xf "rocm-${{ matrix.system.gpu-target }}.tar.gz" -C "${{ env.ROCM_PATH }}"
+        echo "ROCm installed to: ${{ env.ROCM_PATH }}"
         ln -s -f /usr/bin/git /usr/local/bin/git
 
     - uses: actions/checkout@v5

--- a/.github/workflows/aqlprofile-continuous_integration.yml
+++ b/.github/workflows/aqlprofile-continuous_integration.yml
@@ -76,7 +76,8 @@ jobs:
       GPU_RUNNER: ${{ matrix.system.gpu }}
 
     steps:
-    - name: Install Latest Nightly ROCm
+    - &install_latest_nightly_rocm
+      name: Install Latest Nightly ROCm
       shell: bash
       working-directory: /tmp
       run: |
@@ -85,6 +86,10 @@ jobs:
         mkdir -p "${{ env.ROCM_PATH }}"
         tar -xf "rocm-${{ matrix.system.gpu-target }}.tar.gz" -C "${{ env.ROCM_PATH }}"
         echo "ROCm installed to: ${{ env.ROCM_PATH }}"
+
+    - name: Git Symlink
+      shell: bash
+      run: |
         ln -s -f /usr/bin/git /usr/local/bin/git
 
     - uses: actions/checkout@v5
@@ -161,18 +166,7 @@ jobs:
         sparse-checkout: projects/aqlprofile
         set-safe-directory: true
 
-    - name: Install Latest Nightly ROCm using TheRock Tarballs
-      shell: bash
-      working-directory: /tmp
-      run: |
-        rocm_nightly_path="${{ env.ROCM_NIGHTLY_PATH }}"
-        rocm_tarball="${{ env.ROCM_PATH }}-${{ matrix.system.gpu-target }}.tar.gz"
-        rm -rf "${rocm_nightly_path}"
-        mkdir -p "${rocm_nightly_path}"
-        tar -xf "${rocm_tarball}" -C "${rocm_nightly_path}"
-        rm -rf "${{ env.ROCM_PATH }}"
-        ln -s "${rocm_nightly_path}" "${{ env.ROCM_PATH }}"
-        echo "ROCm installed to: ${rocm_nightly_path}"
+    - *install_latest_nightly_rocm
 
     - name: Install requirements
       timeout-minutes: 10

--- a/.github/workflows/rocprofiler-sdk-continuous_integration.yml
+++ b/.github/workflows/rocprofiler-sdk-continuous_integration.yml
@@ -573,6 +573,8 @@ jobs:
             -DCMAKE_BUILD_TYPE=RelWithDebInfo \
             -DCMAKE_PREFIX_PATH='${{ env.ROCM_PATH }};${{ env.ROCM_PATH }}/llvm' \
             -DCMAKE_INSTALL_PREFIX=${{ env.ROCM_PATH }} \
+            -DCMAKE_C_COMPILER=${{ env.ROCM_PATH }}/llvm/bin/clang \
+            -DCMAKE_CXX_COMPILER=${{ env.ROCM_PATH }}/llvm/bin/clang++ \
             .
           cmake --build build --target all --parallel 16
           cmake --build build --target install

--- a/.github/workflows/rocprofiler-sdk-continuous_integration.yml
+++ b/.github/workflows/rocprofiler-sdk-continuous_integration.yml
@@ -44,7 +44,7 @@ permissions:
 env:
   # TODO(jrmadsen): replace LD_RUNPATH_FLAG, GPU_TARGETS, etc. with internal handling in cmake
   ROCM_PATH: "/opt/rocm"
-  ROCM_VERSION: "7.2.0"
+  ROCM_NIGHTLY_PATH: "/opt/rocm-nightly"
   PYTHON_VENV_PATH: "rocprofiler-sdk"
   PYTHON_VENV_ACTIVATE: "rocprofiler-sdk/bin/activate"
   GPU_TARGETS: "gfx906 gfx908 gfx90a gfx942 gfx950 gfx1030 gfx1100 gfx1101 gfx1102 gfx1201"
@@ -113,9 +113,14 @@ jobs:
         shell: bash
         working-directory: /tmp
         run: |
-          tar -xf ${{ env.ROCM_PATH }}-${{ matrix.system.gpu-target }}.tar.gz -C ${{ env.ROCM_PATH }}-${{ env.ROCM_VERSION }}
-          ln -s ${{ env.ROCM_PATH }}-${{ env.ROCM_VERSION }} ${{ env.ROCM_PATH }}
-          echo "ROCm installed to: ${{ env.ROCM_PATH }}"
+          rocm_install_path="${{ env.ROCM_NIGHTLY_PATH }}"
+          rocm_tarball="${{ env.ROCM_PATH }}-${{ matrix.system.gpu-target }}.tar.gz"
+          rm -rf "${rocm_install_path}"
+          mkdir -p "${rocm_install_path}"
+          tar -xf "${rocm_tarball}" -C "${rocm_install_path}"
+          rm -rf "${{ env.ROCM_PATH }}"
+          ln -s "${rocm_install_path}" "${{ env.ROCM_PATH }}"
+          echo "ROCm installed to: ${rocm_install_path}"
 
       - name: Clone ROCProfiler SDK & AQLProfile & ROCProfiler Register & ROCR-Runtime
         uses: actions/checkout@v5
@@ -210,7 +215,7 @@ jobs:
         run: |
           echo -e "Building & Installing ROCDecode..."
           cmake -B build-rocdecode \
-            -DCMAKE_INSTALL_PREFIX=${{ env.ROCM_PATH }}-${{ env.ROCM_VERSION }} \
+            -DCMAKE_INSTALL_PREFIX=${{ env.ROCM_PATH }} \
             -DCMAKE_PREFIX_PATH=${{ env.ROCM_PATH }} \
             -DCMAKE_CXX_COMPILER=${{ env.ROCM_PATH }}/lib/llvm/bin/amdclang++ \
             -DCMAKE_C_COMPILER_LAUNCHER=/usr/bin/ccache \
@@ -221,7 +226,7 @@ jobs:
           echo -e "ROCDecode Installed Successfully!"
           echo -e "Building & Installing ROCJPEG..."
           cmake -B build-rocjpeg \
-            -DCMAKE_INSTALL_PREFIX=${{ env.ROCM_PATH }}-${{ env.ROCM_VERSION }} \
+            -DCMAKE_INSTALL_PREFIX=${{ env.ROCM_PATH }} \
             -DCMAKE_PREFIX_PATH=${{ env.ROCM_PATH }} \
             -DCMAKE_CXX_COMPILER=${{ env.ROCM_PATH }}/lib/llvm/bin/amdclang++ \
             -DCMAKE_C_COMPILER_LAUNCHER=/usr/bin/ccache \
@@ -240,8 +245,8 @@ jobs:
           echo "Install ROCProfiler-Register"
           cmake -B build-rocprofiler-register \
             -DCMAKE_BUILD_TYPE=RelWithDebInfo \
-            -DCMAKE_PREFIX_PATH=${{ env.ROCM_PATH }}-${{ env.ROCM_VERSION }} \
-            -DCMAKE_INSTALL_PREFIX=${{ env.ROCM_PATH }}-${{ env.ROCM_VERSION }} \
+            -DCMAKE_PREFIX_PATH=${{ env.ROCM_PATH }} \
+            -DCMAKE_INSTALL_PREFIX=${{ env.ROCM_PATH }} \
             -DCMAKE_C_COMPILER_LAUNCHER=/usr/bin/ccache \
             -DCMAKE_CXX_COMPILER_LAUNCHER=/usr/bin/ccache \
             .
@@ -259,8 +264,8 @@ jobs:
           echo "Install ROCR-Runtime..."
           cmake -B build \
             -DCMAKE_BUILD_TYPE=RelWithDebInfo \
-            -DCMAKE_PREFIX_PATH='${{ env.ROCM_PATH }}-${{ env.ROCM_VERSION }};${{ env.ROCM_PATH }}-${{ env.ROCM_VERSION }}/llvm' \
-            -DCMAKE_INSTALL_PREFIX=${{ env.ROCM_PATH }}-${{ env.ROCM_VERSION }} \
+            -DCMAKE_PREFIX_PATH='${{ env.ROCM_PATH }};${{ env.ROCM_PATH }}/llvm' \
+            -DCMAKE_INSTALL_PREFIX=${{ env.ROCM_PATH }} \
             .
           cmake --build build --target all --parallel 16
           cmake --build build --target install
@@ -281,8 +286,8 @@ jobs:
             -DHIP_COMMON_DIR=$HIP_DIR \
             -DCMAKE_BUILD_TYPE=RelWithDebInfo \
             -DHIP_PLATFORM=amd \
-            -DCMAKE_PREFIX_PATH='${{ env.ROCM_PATH }}-${{ env.ROCM_VERSION }};${{ env.ROCM_PATH }}-${{ env.ROCM_VERSION }}/llvm' \
-            -DCMAKE_INSTALL_PREFIX=${{ env.ROCM_PATH }}-${{ env.ROCM_VERSION }} \
+            -DCMAKE_PREFIX_PATH='${{ env.ROCM_PATH }};${{ env.ROCM_PATH }}/llvm' \
+            -DCMAKE_INSTALL_PREFIX=${{ env.ROCM_PATH }} \
             -DHIP_LLVM_ROOT=${{ env.ROCM_PATH }}/lib/llvm \
             -DHIP_CATCH_TEST=0 \
             -DCLR_BUILD_HIP=ON \
@@ -302,8 +307,8 @@ jobs:
           echo "Install Aqlprofile..."
           cmake -B build-aqlprofile \
             -DCMAKE_BUILD_TYPE=RelWithDebInfo \
-            -DCMAKE_PREFIX_PATH=${{ env.ROCM_PATH }}-${{ env.ROCM_VERSION }} \
-            -DCMAKE_INSTALL_PREFIX=${{ env.ROCM_PATH }}-${{ env.ROCM_VERSION }} \
+            -DCMAKE_PREFIX_PATH=${{ env.ROCM_PATH }} \
+            -DCMAKE_INSTALL_PREFIX=${{ env.ROCM_PATH }} \
             -DCMAKE_C_COMPILER_LAUNCHER=/usr/bin/ccache \
             -DCMAKE_CXX_COMPILER_LAUNCHER=/usr/bin/ccache \
             .
@@ -503,9 +508,14 @@ jobs:
         shell: bash
         working-directory: /tmp
         run: |
-          tar -xf ${{ env.ROCM_PATH }}-${{ matrix.system.gpu-target }}.tar.gz -C ${{ env.ROCM_PATH }}-${{ env.ROCM_VERSION }}
-          ln -s ${{ env.ROCM_PATH }}-${{ env.ROCM_VERSION }} ${{ env.ROCM_PATH }}
-          echo "ROCm installed to: ${{ env.ROCM_PATH }}"
+          rocm_install_path="${{ env.ROCM_NIGHTLY_PATH }}"
+          rocm_tarball="${{ env.ROCM_PATH }}-${{ matrix.system.gpu-target }}.tar.gz"
+          rm -rf "${rocm_install_path}"
+          mkdir -p "${rocm_install_path}"
+          tar -xf "${rocm_tarball}" -C "${rocm_install_path}"
+          rm -rf "${{ env.ROCM_PATH }}"
+          ln -s "${rocm_install_path}" "${{ env.ROCM_PATH }}"
+          echo "ROCm installed to: ${rocm_install_path}"
 
       - name: Install requirements (venv)
         timeout-minutes: 10
@@ -529,6 +539,7 @@ jobs:
         shell: bash
         run: |
           echo "PKG_CONFIG_PATH=/opt/amdgpu/lib64/pkgconfig:/opt/amdgpu/lib/pkgconfig:/opt/amdgpu/lib/$(uname -p)-linux-gnu/pkgconfig:${PKG_CONFIG_PATH}" >> $GITHUB_ENV
+          echo "LD_LIBRARY_PATH=${{ env.ROCM_PATH }}/lib64:${{ env.ROCM_PATH }}/lib:${{ env.ROCM_PATH }}/llvm/lib:${LD_LIBRARY_PATH}" >> $GITHUB_ENV
           echo "PATH=$HOME/.local/bin:$PATH" >> $GITHUB_ENV
 
       - name: Install Curl for RHEL 8.8
@@ -552,8 +563,8 @@ jobs:
           echo "Install ROCProfiler-Register"
           cmake -B build-rocprofiler-register \
             -DCMAKE_BUILD_TYPE=RelWithDebInfo \
-            -DCMAKE_PREFIX_PATH=${{ env.ROCM_PATH }}-${{ env.ROCM_VERSION }} \
-            -DCMAKE_INSTALL_PREFIX=${{ env.ROCM_PATH }}-${{ env.ROCM_VERSION }} \
+            -DCMAKE_PREFIX_PATH=${{ env.ROCM_PATH }} \
+            -DCMAKE_INSTALL_PREFIX=${{ env.ROCM_PATH }} \
             -DCMAKE_C_COMPILER_LAUNCHER=/usr/local/bin/sccache \
             -DCMAKE_CXX_COMPILER_LAUNCHER=/usr/local/bin/sccache \
             .
@@ -574,8 +585,8 @@ jobs:
           echo "Install ROCR-Runtime..."
           cmake -B build \
             -DCMAKE_BUILD_TYPE=RelWithDebInfo \
-            -DCMAKE_PREFIX_PATH='${{ env.ROCM_PATH }}-${{ env.ROCM_VERSION }};${{ env.ROCM_PATH }}-${{ env.ROCM_VERSION }}/llvm' \
-            -DCMAKE_INSTALL_PREFIX=${{ env.ROCM_PATH }}-${{ env.ROCM_VERSION }} \
+            -DCMAKE_PREFIX_PATH='${{ env.ROCM_PATH }};${{ env.ROCM_PATH }}/llvm' \
+            -DCMAKE_INSTALL_PREFIX=${{ env.ROCM_PATH }} \
             .
           cmake --build build --target all --parallel 16
           cmake --build build --target install
@@ -588,7 +599,6 @@ jobs:
         run: |
           export HIP_DIR=$PWD/hip
           export CLR_DIR=$PWD/clr
-          export LD_LIBRARY_PATH=${{ env.ROCM_PATH }}/lib:${{ env.ROCM_PATH }}/llvm/lib:$LD_LIBRARY_PATH
           export PATH=${{ env.ROCM_PATH }}/bin:${{ env.ROCM_PATH }}/llvm/bin:$PATH
           echo "Install HIP..."
           cd $CLR_DIR
@@ -596,8 +606,8 @@ jobs:
             -DHIP_COMMON_DIR=$HIP_DIR \
             -DCMAKE_BUILD_TYPE=RelWithDebInfo \
             -DHIP_PLATFORM=amd \
-            -DCMAKE_PREFIX_PATH='${{ env.ROCM_PATH }}-${{ env.ROCM_VERSION }};${{ env.ROCM_PATH }}-${{ env.ROCM_VERSION }}/llvm' \
-            -DCMAKE_INSTALL_PREFIX=${{ env.ROCM_PATH }}-${{ env.ROCM_VERSION }} \
+            -DCMAKE_PREFIX_PATH='${{ env.ROCM_PATH }};${{ env.ROCM_PATH }}/llvm' \
+            -DCMAKE_INSTALL_PREFIX=${{ env.ROCM_PATH }} \
             -DHIP_LLVM_ROOT=${{ env.ROCM_PATH }}/lib/llvm \
             -DHIP_CATCH_TEST=0 \
             -DCLR_BUILD_HIP=ON \
@@ -620,8 +630,8 @@ jobs:
           python3 -m pip install --upgrade cmake
           cmake -B build-aqlprofile \
             -DCMAKE_BUILD_TYPE=RelWithDebInfo \
-            -DCMAKE_PREFIX_PATH=${{ env.ROCM_PATH }}-${{ env.ROCM_VERSION }} \
-            -DCMAKE_INSTALL_PREFIX=${{ env.ROCM_PATH }}-${{ env.ROCM_VERSION }} \
+            -DCMAKE_PREFIX_PATH=${{ env.ROCM_PATH }} \
+            -DCMAKE_INSTALL_PREFIX=${{ env.ROCM_PATH }} \
             -DCMAKE_C_COMPILER_LAUNCHER=/usr/local/bin/sccache \
             -DCMAKE_CXX_COMPILER_LAUNCHER=/usr/local/bin/sccache \
             .
@@ -714,10 +724,14 @@ jobs:
       shell: bash
       working-directory: /tmp
       run: |
-        ls -lah /opt/
-        tar -xf ${{ env.ROCM_PATH }}-${{ matrix.system.gpu-target }}.tar.gz -C ${{ env.ROCM_PATH }}-${{ env.ROCM_VERSION }}
-        ln -s ${{ env.ROCM_PATH }}-${{ env.ROCM_VERSION }} ${{ env.ROCM_PATH }}
-        echo "ROCm installed to: ${{ env.ROCM_PATH }}"
+        rocm_install_path="${{ env.ROCM_NIGHTLY_PATH }}"
+        rocm_tarball="${{ env.ROCM_PATH }}-${{ matrix.system.gpu-target }}.tar.gz"
+        rm -rf "${rocm_install_path}"
+        mkdir -p "${rocm_install_path}"
+        tar -xf "${rocm_tarball}" -C "${rocm_install_path}"
+        rm -rf "${{ env.ROCM_PATH }}"
+        ln -s "${rocm_install_path}" "${{ env.ROCM_PATH }}"
+        echo "ROCm installed to: ${rocm_install_path}"
 
     - name: Clone ROCProfiler SDK & AQLProfile & ROCProfiler Register & ROCR-Runtime
       uses: actions/checkout@v5
@@ -810,8 +824,8 @@ jobs:
         echo "Install ROCProfiler-Register"
         cmake -B build-rocprofiler-register \
             -DCMAKE_BUILD_TYPE=RelWithDebInfo \
-            -DCMAKE_PREFIX_PATH=${{ env.ROCM_PATH }}-${{ env.ROCM_VERSION }} \
-            -DCMAKE_INSTALL_PREFIX=${{ env.ROCM_PATH }}-${{ env.ROCM_VERSION }} \
+            -DCMAKE_PREFIX_PATH=${{ env.ROCM_PATH }} \
+            -DCMAKE_INSTALL_PREFIX=${{ env.ROCM_PATH }} \
             -DCMAKE_C_COMPILER_LAUNCHER=/usr/bin/ccache \
             -DCMAKE_CXX_COMPILER_LAUNCHER=/usr/bin/ccache \
             .
@@ -827,8 +841,8 @@ jobs:
         echo "Install ROCR-Runtime..."
         cmake -B build \
             -DCMAKE_BUILD_TYPE=RelWithDebInfo \
-            -DCMAKE_PREFIX_PATH='${{ env.ROCM_PATH }}-${{ env.ROCM_VERSION }};${{ env.ROCM_PATH }}-${{ env.ROCM_VERSION }}/llvm' \
-            -DCMAKE_INSTALL_PREFIX=${{ env.ROCM_PATH }}-${{ env.ROCM_VERSION }} \
+            -DCMAKE_PREFIX_PATH='${{ env.ROCM_PATH }};${{ env.ROCM_PATH }}/llvm' \
+            -DCMAKE_INSTALL_PREFIX=${{ env.ROCM_PATH }} \
             -DCMAKE_C_COMPILER_LAUNCHER=/usr/bin/ccache \
             -DCMAKE_CXX_COMPILER_LAUNCHER=/usr/bin/ccache \
             .
@@ -851,8 +865,8 @@ jobs:
           -DHIP_COMMON_DIR=$HIP_DIR \
           -DCMAKE_BUILD_TYPE=RelWithDebInfo \
           -DHIP_PLATFORM=amd \
-          -DCMAKE_PREFIX_PATH='${{ env.ROCM_PATH }}-${{ env.ROCM_VERSION }};${{ env.ROCM_PATH }}-${{ env.ROCM_VERSION }}/llvm' \
-          -DCMAKE_INSTALL_PREFIX=${{ env.ROCM_PATH }}-${{ env.ROCM_VERSION }} \
+          -DCMAKE_PREFIX_PATH='${{ env.ROCM_PATH }};${{ env.ROCM_PATH }}/llvm' \
+          -DCMAKE_INSTALL_PREFIX=${{ env.ROCM_PATH }} \
           -DHIP_LLVM_ROOT=${{ env.ROCM_PATH }}/lib/llvm \
           -DHIP_CATCH_TEST=0 \
           -DCLR_BUILD_HIP=ON \
@@ -870,8 +884,8 @@ jobs:
         echo "Install Aqlprofile."
         cmake -B build-aqlprofile \
             -DCMAKE_BUILD_TYPE=RelWithDebInfo \
-            -DCMAKE_PREFIX_PATH=${{ env.ROCM_PATH }}-${{ env.ROCM_VERSION }} \
-            -DCMAKE_INSTALL_PREFIX=${{ env.ROCM_PATH }}-${{ env.ROCM_VERSION }} \
+            -DCMAKE_PREFIX_PATH=${{ env.ROCM_PATH }} \
+            -DCMAKE_INSTALL_PREFIX=${{ env.ROCM_PATH }} \
             -DCMAKE_C_COMPILER_LAUNCHER=/usr/bin/ccache \
             -DCMAKE_CXX_COMPILER_LAUNCHER=/usr/bin/ccache \
             .

--- a/.github/workflows/rocprofiler-sdk-continuous_integration.yml
+++ b/.github/workflows/rocprofiler-sdk-continuous_integration.yml
@@ -44,7 +44,6 @@ permissions:
 env:
   # TODO(jrmadsen): replace LD_RUNPATH_FLAG, GPU_TARGETS, etc. with internal handling in cmake
   ROCM_PATH: "/opt/rocm"
-  ROCM_NIGHTLY_PATH: "/opt/rocm-nightly"
   PYTHON_VENV_PATH: "rocprofiler-sdk"
   PYTHON_VENV_ACTIVATE: "rocprofiler-sdk/bin/activate"
   GPU_TARGETS: "gfx906 gfx908 gfx90a gfx942 gfx950 gfx1030 gfx1100 gfx1101 gfx1102 gfx1201"
@@ -114,14 +113,11 @@ jobs:
         shell: bash
         working-directory: /tmp
         run: |
-          rocm_nightly_path="${{ env.ROCM_NIGHTLY_PATH }}"
-          rocm_tarball="${{ env.ROCM_PATH }}-${{ matrix.system.gpu-target }}.tar.gz"
-          rm -rf "${rocm_nightly_path}"
-          mkdir -p "${rocm_nightly_path}"
-          tar -xf "${rocm_tarball}" -C "${rocm_nightly_path}"
-          rm -rf "${{ env.ROCM_PATH }}"
-          ln -s "${rocm_nightly_path}" "${{ env.ROCM_PATH }}"
-          echo "ROCm installed to: ${rocm_nightly_path}"
+          mv "${{ env.ROCM_PATH }}-${{ matrix.system.gpu-target }}.tar.gz" .
+          rm -rf ${{ env.ROCM_PATH }}*
+          mkdir -p "${{ env.ROCM_PATH }}"
+          tar -xf "rocm-${{ matrix.system.gpu-target }}.tar.gz" -C "${{ env.ROCM_PATH }}"
+          echo "ROCm installed to: ${{ env.ROCM_PATH }}"
 
       - name: Clone ROCProfiler SDK & AQLProfile & ROCProfiler Register & ROCR-Runtime
         uses: actions/checkout@v5

--- a/.github/workflows/rocprofiler-sdk-continuous_integration.yml
+++ b/.github/workflows/rocprofiler-sdk-continuous_integration.yml
@@ -109,18 +109,19 @@ jobs:
       CORE_EXT_RUNNER: mi325
       GPU_RUNNER: ${{ matrix.system.gpu }}
     steps:
-      - name: Install Latest Nightly ROCm
+      - &install_latest_nightly_rocm
+        name: Install Latest Nightly ROCm
         shell: bash
         working-directory: /tmp
         run: |
-          rocm_install_path="${{ env.ROCM_NIGHTLY_PATH }}"
+          rocm_nightly_path="${{ env.ROCM_NIGHTLY_PATH }}"
           rocm_tarball="${{ env.ROCM_PATH }}-${{ matrix.system.gpu-target }}.tar.gz"
-          rm -rf "${rocm_install_path}"
-          mkdir -p "${rocm_install_path}"
-          tar -xf "${rocm_tarball}" -C "${rocm_install_path}"
+          rm -rf "${rocm_nightly_path}"
+          mkdir -p "${rocm_nightly_path}"
+          tar -xf "${rocm_tarball}" -C "${rocm_nightly_path}"
           rm -rf "${{ env.ROCM_PATH }}"
-          ln -s "${rocm_install_path}" "${{ env.ROCM_PATH }}"
-          echo "ROCm installed to: ${rocm_install_path}"
+          ln -s "${rocm_nightly_path}" "${{ env.ROCM_PATH }}"
+          echo "ROCm installed to: ${rocm_nightly_path}"
 
       - name: Clone ROCProfiler SDK & AQLProfile & ROCProfiler Register & ROCR-Runtime
         uses: actions/checkout@v5
@@ -504,18 +505,7 @@ jobs:
       - name: Init/Update submodules
         run: git submodule update --init --recursive --jobs 16
 
-      - name: Install Latest Nightly ROCm using TheRock Tarballs
-        shell: bash
-        working-directory: /tmp
-        run: |
-          rocm_install_path="${{ env.ROCM_NIGHTLY_PATH }}"
-          rocm_tarball="${{ env.ROCM_PATH }}-${{ matrix.system.gpu-target }}.tar.gz"
-          rm -rf "${rocm_install_path}"
-          mkdir -p "${rocm_install_path}"
-          tar -xf "${rocm_tarball}" -C "${rocm_install_path}"
-          rm -rf "${{ env.ROCM_PATH }}"
-          ln -s "${rocm_install_path}" "${{ env.ROCM_PATH }}"
-          echo "ROCm installed to: ${rocm_install_path}"
+      - *install_latest_nightly_rocm
 
       - name: Install requirements (venv)
         timeout-minutes: 10
@@ -720,18 +710,7 @@ jobs:
       GPU_RUNNER: ${{ matrix.system.gpu }}
 
     steps:
-    - name: Install Latest Nightly ROCm
-      shell: bash
-      working-directory: /tmp
-      run: |
-        rocm_install_path="${{ env.ROCM_NIGHTLY_PATH }}"
-        rocm_tarball="${{ env.ROCM_PATH }}-${{ matrix.system.gpu-target }}.tar.gz"
-        rm -rf "${rocm_install_path}"
-        mkdir -p "${rocm_install_path}"
-        tar -xf "${rocm_tarball}" -C "${rocm_install_path}"
-        rm -rf "${{ env.ROCM_PATH }}"
-        ln -s "${rocm_install_path}" "${{ env.ROCM_PATH }}"
-        echo "ROCm installed to: ${rocm_install_path}"
+    - *install_latest_nightly_rocm
 
     - name: Clone ROCProfiler SDK & AQLProfile & ROCProfiler Register & ROCR-Runtime
       uses: actions/checkout@v5

--- a/.github/workflows/rocprofiler-sdk-docs.yml
+++ b/.github/workflows/rocprofiler-sdk-docs.yml
@@ -90,10 +90,10 @@ jobs:
         shell: bash
         working-directory: /tmp
         run: |
-          mv "${{ env.ROCM_PATH }}-${{ matrix.system.gpu-target }}.tar.gz" .
+          mv "${{ env.ROCM_PATH }}-gfx94X.tar.gz" .
           rm -rf ${{ env.ROCM_PATH }}*
           mkdir -p "${{ env.ROCM_PATH }}"
-          tar -xf "rocm-${{ matrix.system.gpu-target }}.tar.gz" -C "${{ env.ROCM_PATH }}"
+          tar -xf rocm-gfx94X.tar.gz -C "${{ env.ROCM_PATH }}"
           echo "ROCm installed to: ${{ env.ROCM_PATH }}"
 
       - name: Install os essentials

--- a/.github/workflows/rocprofiler-sdk-docs.yml
+++ b/.github/workflows/rocprofiler-sdk-docs.yml
@@ -91,14 +91,14 @@ jobs:
         shell: bash
         working-directory: /tmp
         run: |
-          rocm_install_path="${{ env.ROCM_NIGHTLY_PATH }}"
+          rocm_nightly_path="${{ env.ROCM_NIGHTLY_PATH }}"
           rocm_tarball="${{ env.ROCM_PATH }}-gfx94X.tar.gz"
-          rm -rf "${rocm_install_path}"
-          mkdir -p "${rocm_install_path}"
-          tar -xf "${rocm_tarball}" -C "${rocm_install_path}"
+          rm -rf "${rocm_nightly_path}"
+          mkdir -p "${rocm_nightly_path}"
+          tar -xf "${rocm_tarball}" -C "${rocm_nightly_path}"
           rm -rf "${{ env.ROCM_PATH }}"
-          ln -s "${rocm_install_path}" "${{ env.ROCM_PATH }}"
-          echo "ROCm installed to: ${rocm_install_path}"
+          ln -s "${rocm_nightly_path}" "${{ env.ROCM_PATH }}"
+          echo "ROCm installed to: ${rocm_nightly_path}"
 
       - name: Install os essentials
         timeout-minutes: 10

--- a/.github/workflows/rocprofiler-sdk-docs.yml
+++ b/.github/workflows/rocprofiler-sdk-docs.yml
@@ -30,7 +30,7 @@ concurrency:
 env:
   GIT_DISCOVERY_ACROSS_FILESYSTEM: 1
   ROCM_PATH: "/opt/rocm"
-  ROCM_VERSION: "7.2.0"
+  ROCM_NIGHTLY_PATH: "/opt/rocm-nightly"
 
 jobs:
   build-docs:
@@ -91,9 +91,14 @@ jobs:
         shell: bash
         working-directory: /tmp
         run: |
-          tar -xf ${{ env.ROCM_PATH }}-gfx94X.tar.gz -C ${{ env.ROCM_PATH }}-${{ env.ROCM_VERSION }}
-          ln -s ${{ env.ROCM_PATH }}-${{ env.ROCM_VERSION }} ${{ env.ROCM_PATH }}
-          echo "ROCm installed to: ${{ env.ROCM_PATH }}"
+          rocm_install_path="${{ env.ROCM_NIGHTLY_PATH }}"
+          rocm_tarball="${{ env.ROCM_PATH }}-gfx94X.tar.gz"
+          rm -rf "${rocm_install_path}"
+          mkdir -p "${rocm_install_path}"
+          tar -xf "${rocm_tarball}" -C "${rocm_install_path}"
+          rm -rf "${{ env.ROCM_PATH }}"
+          ln -s "${rocm_install_path}" "${{ env.ROCM_PATH }}"
+          echo "ROCm installed to: ${rocm_install_path}"
 
       - name: Install os essentials
         timeout-minutes: 10

--- a/.github/workflows/rocprofiler-sdk-docs.yml
+++ b/.github/workflows/rocprofiler-sdk-docs.yml
@@ -30,7 +30,6 @@ concurrency:
 env:
   GIT_DISCOVERY_ACROSS_FILESYSTEM: 1
   ROCM_PATH: "/opt/rocm"
-  ROCM_NIGHTLY_PATH: "/opt/rocm-nightly"
 
 jobs:
   build-docs:
@@ -91,14 +90,11 @@ jobs:
         shell: bash
         working-directory: /tmp
         run: |
-          rocm_nightly_path="${{ env.ROCM_NIGHTLY_PATH }}"
-          rocm_tarball="${{ env.ROCM_PATH }}-gfx94X.tar.gz"
-          rm -rf "${rocm_nightly_path}"
-          mkdir -p "${rocm_nightly_path}"
-          tar -xf "${rocm_tarball}" -C "${rocm_nightly_path}"
-          rm -rf "${{ env.ROCM_PATH }}"
-          ln -s "${rocm_nightly_path}" "${{ env.ROCM_PATH }}"
-          echo "ROCm installed to: ${rocm_nightly_path}"
+          mv "${{ env.ROCM_PATH }}-${{ matrix.system.gpu-target }}.tar.gz" .
+          rm -rf ${{ env.ROCM_PATH }}*
+          mkdir -p "${{ env.ROCM_PATH }}"
+          tar -xf "rocm-${{ matrix.system.gpu-target }}.tar.gz" -C "${{ env.ROCM_PATH }}"
+          echo "ROCm installed to: ${{ env.ROCM_PATH }}"
 
       - name: Install os essentials
         timeout-minutes: 10


### PR DESCRIPTION
## Motivation

This PR updates the ROCProfiler SDK and AQLProfile CI workflows to stop depending on a hard-coded ROCM_VERSION by installing nightly ROCm tarballs into a stable path and pointing /opt/rocm at that install.

## Technical Details

- Replace ROCM_VERSION usage with a ROCM_NIGHTLY_PATH install root and re-point /opt/rocm via symlink.
- Update CMake install/prefix paths in rocprofiler-sdk CI to use ${{ env.ROCM_PATH }} directly.

## JIRA ID

N/A

## Test Plan

- CI Checks

## Test Result

- Build all components without issues. 

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
