### PR TITLE
[AMD-SMI] Fix num_partitions when gpu metric unavailable

### DIFF
--- a/projects/amdsmi/CHANGELOG.md
+++ b/projects/amdsmi/CHANGELOG.md
@@ -8,6 +8,11 @@ Full documentation for amd_smi_lib is available at [https://rocm.docs.amd.com/pr
 
 ### Resolved Issues
 
+- **Fixed `amdsmi_get_gpu_accelerator_partition_profile()` returning incorrect `num_partitions` when `num_partition` is unavailable from GPU metrics**.  
+  - GPU metrics no longer always provides `num_partition`. The function now derives the partition count from the active partition type when `num_partition` is not available:
+    - SPX → 1, DPX → 2, TPX → 3, QPX → 4
+    - CPX → derived from the XCD counter via `amdsmi_get_gpu_xcd_counter()`
+
 - **Fixed `amdsmi_topo_get_p2p_status()` returning a raw `ctypes.c_uint32` object instead of an integer for the `type` field**.  
   - The `'type'` key in the returned dictionary now correctly returns `type_32.value` (an `int`) rather than the unwrapped ctypes object, consistent with the pattern used in `amdsmi_topo_get_link_type()`.
 

--- a/projects/amdsmi/src/amd_smi/amd_smi.cc
+++ b/projects/amdsmi/src/amd_smi/amd_smi.cc
@@ -3670,8 +3670,8 @@ amdsmi_status_t amdsmi_get_gpu_accelerator_partition_profile(
     } else if (profile->profile_type == AMDSMI_ACCELERATOR_PARTITION_CPX) {
       // Note: # of XCDs is max # of partitions CPX supports
       uint16_t tmp_xcd_count = 0;
-      status = rsmi_wrapper(rsmi_dev_metrics_xcd_counter_get, processor_handle, 0, &tmp_xcd_count);
-      if (status == AMDSMI_STATUS_SUCCESS) {
+      amdsmi_status_t xcd_status = amdsmi_get_gpu_xcd_counter(processor_handle, &tmp_xcd_count);
+      if (xcd_status == AMDSMI_STATUS_SUCCESS) {
         profile->num_partitions = tmp_xcd_count;
       }
     }

--- a/projects/amdsmi/src/amd_smi/amd_smi.cc
+++ b/projects/amdsmi/src/amd_smi/amd_smi.cc
@@ -3657,6 +3657,24 @@ amdsmi_status_t amdsmi_get_gpu_accelerator_partition_profile(
   if (status == AMDSMI_STATUS_SUCCESS &&
       metric_info.num_partition != std::numeric_limits<uint16_t>::max()) {
     profile->num_partitions = metric_info.num_partition;
+  } else {
+    // calculate current partition's number of partitions another way
+    if (profile->profile_type == AMDSMI_ACCELERATOR_PARTITION_SPX) {
+      profile->num_partitions = 1;
+    } else if (profile->profile_type == AMDSMI_ACCELERATOR_PARTITION_DPX) {
+      profile->num_partitions = 2;
+    } else if (profile->profile_type == AMDSMI_ACCELERATOR_PARTITION_TPX) {
+      profile->num_partitions = 3;
+    } else if (profile->profile_type == AMDSMI_ACCELERATOR_PARTITION_QPX) {
+      profile->num_partitions = 4;
+    } else if (profile->profile_type == AMDSMI_ACCELERATOR_PARTITION_CPX) {
+      // Note: # of XCDs is max # of partitions CPX supports
+      uint16_t tmp_xcd_count = 0;
+      status = rsmi_wrapper(rsmi_dev_metrics_xcd_counter_get, processor_handle, 0, &tmp_xcd_count);
+      if (status == AMDSMI_STATUS_SUCCESS) {
+        profile->num_partitions = tmp_xcd_count;
+      }
+    }
   }
 
   status = rsmi_wrapper(rsmi_dev_partition_id_get, processor_handle, 0, &tmp_partition_id);


### PR DESCRIPTION
GPU metrics no longer always provides num_partition. Update
amdsmi_get_gpu_accelerator_partition_profile() to fall back to
deriving num_partitions from the active partition type (SPX=1,
DPX=2, TPX=3, QPX=4, CPX=XCD count) when num_partition is absent.

Signed-off-by: Charis Poag <charis.poag@amd.com>

## Motivation

`amdsmi_get_gpu_accelerator_partition_profile()` relied on `num_partition` from GPU metrics to populate `num_partitions` in the returned profile. Starting with newer GPU metrics versions (≥ 1.9), `num_partition` is no longer provided, causing the field to be incorrectly set to `UINT16_MAX` / `N/A`.

## Technical Details

Updated `amdsmi_get_gpu_accelerator_partition_profile()` in `amd_smi.cc` to fall back to deriving `num_partitions` from the active compute partition type when `num_partition` is not available from GPU metrics:
- SPX → 1, DPX → 2, TPX → 3, QPX → 4
- CPX → XCD counter (`rsmi_dev_metrics_xcd_counter_get`), since the number of XCDs equals the maximum number of CPX partitions supported

## JIRA ID

## Test Plan

- Built and installed `amd-smi-lib` & `amd-smi-lib-tests` on a partitioned MI300X/MI308 systems
- Ran Python unit tests: `test_get_gpu_accelerator_partition_profile`, `test_get_gpu_xcd_counter` in different partition configurations (SPX, DPX, QPX, CPX)

## Test Result

`num_partitions` is now correctly reported for all partition types on GPUs where `num_partition` is no longer present in GPU metrics.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
