### PR TITLE
Fix partition metrics

### DIFF
--- a/projects/rdc/CHANGELOG.md
+++ b/projects/rdc/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 Full documentation for RDC is available at [ROCm DataCenter Tool User Guide](https://rocm.docs.amd.com/projects/rdc/en/latest/).
 
+## amd_smi_lib for ROCm 7.13.0
+
+### Resolved Issues
+
+- **Fixed broken partition metrics**.  
+  - Regardless if GPU was partitioned, RDC only saw the GPU index and no instances due to upstream gpu_metrics changes
+
 ## RDC 1.2.0 for ROCm 7.1.0
 
 ### Added

--- a/projects/rdc/rdc_libs/rdc/src/SmiUtils.cc
+++ b/projects/rdc/rdc_libs/rdc/src/SmiUtils.cc
@@ -235,14 +235,20 @@ amdsmi_status_t get_num_partition(uint32_t index, uint16_t* num_partition) {
     return AMDSMI_STATUS_INVAL;
   }
 
-  amdsmi_gpu_metrics_t metrics;
-  memset(&metrics, 0, sizeof(metrics));
-  ret = get_metrics_info(proc_handle, &metrics);
+  amdsmi_accelerator_partition_profile_t profile;
+  memset(&profile, 0, sizeof(profile));
+  uint32_t partition_id{};
+
+  ret = amdsmi_get_gpu_accelerator_partition_profile(proc_handle, &profile, &partition_id);
   if (ret != AMDSMI_STATUS_SUCCESS) {
     return ret;
   }
 
-  *num_partition = metrics.num_partition;
+  if (partition_id != 0) {
+    return AMDSMI_STATUS_UNEXPECTED_DATA;
+  }
+
+  *num_partition = profile.num_partitions;
 
   return ret;
 }


### PR DESCRIPTION
## Motivation

GPU_metrics updates broke partition metrics

## Technical Details

Use `amdsmi_get_gpu_accelerator_partition_profile` instead to grab number of partitions which has correct fallback and handling for getting number of partitions

## Test Result

rdci discovery now works correctly again

