### PR TITLE
roctracer: replace assert with graceful error handling in hsa_support

### DIFF
--- a/projects/roctracer/src/roctracer/hsa_support.cpp
+++ b/projects/roctracer/src/roctracer/hsa_support.cpp
@@ -443,10 +443,9 @@ hsa_status_t MemoryASyncCopyOnEngineIntercept(
     hsa_amd_sdma_engine_id_t engine_id, bool force_copy_on_sdma) {
   bool is_enabled = IsEnabled(ACTIVITY_DOMAIN_HSA_OPS, HSA_OP_ID_COPY);
 
-  // FIXME: what happens if the state changes before returning?
-  [[maybe_unused]] hsa_status_t status = saved_amd_ext_api.hsa_amd_profiling_async_copy_enable_fn(
+  hsa_status_t status = saved_amd_ext_api.hsa_amd_profiling_async_copy_enable_fn(
       profiling_async_copy_enable.load(std::memory_order_relaxed) || is_enabled);
-  assert(status == HSA_STATUS_SUCCESS && "hsa_amd_profiling_async_copy_enable failed");
+  if (status != HSA_STATUS_SUCCESS) return status;
 
   if (!is_enabled) {
     return saved_amd_ext_api.hsa_amd_memory_async_copy_on_engine_fn(
@@ -473,10 +472,9 @@ hsa_status_t MemoryASyncCopyIntercept(void* dst, hsa_agent_t dst_agent, const vo
                                       hsa_signal_t completion_signal) {
   bool is_enabled = IsEnabled(ACTIVITY_DOMAIN_HSA_OPS, HSA_OP_ID_COPY);
 
-  // FIXME: what happens if the state changes before returning?
-  [[maybe_unused]] hsa_status_t status = saved_amd_ext_api.hsa_amd_profiling_async_copy_enable_fn(
+  hsa_status_t status = saved_amd_ext_api.hsa_amd_profiling_async_copy_enable_fn(
       profiling_async_copy_enable.load(std::memory_order_relaxed) || is_enabled);
-  assert(status == HSA_STATUS_SUCCESS && "hsa_amd_profiling_async_copy_enable failed");
+  if (status != HSA_STATUS_SUCCESS) return status;
 
   if (!is_enabled) {
     return saved_amd_ext_api.hsa_amd_memory_async_copy_fn(
@@ -504,10 +502,9 @@ hsa_status_t MemoryASyncCopyRectIntercept(const hsa_pitched_ptr_t* dst,
                                           hsa_signal_t completion_signal) {
   bool is_enabled = IsEnabled(ACTIVITY_DOMAIN_HSA_OPS, HSA_OP_ID_COPY);
 
-  // FIXME: what happens if the state changes before returning?
-  [[maybe_unused]] hsa_status_t status = saved_amd_ext_api.hsa_amd_profiling_async_copy_enable_fn(
+  hsa_status_t status = saved_amd_ext_api.hsa_amd_profiling_async_copy_enable_fn(
       profiling_async_copy_enable.load(std::memory_order_relaxed) || is_enabled);
-  assert(status == HSA_STATUS_SUCCESS && "hsa_amd_profiling_async_copy_enable failed");
+  if (status != HSA_STATUS_SUCCESS) return status;
 
   if (!is_enabled) {
     return saved_amd_ext_api.hsa_amd_memory_async_copy_rect_fn(
@@ -623,10 +620,19 @@ void Initialize(HsaApiTable* table) {
 }
 
 void Finalize() {
-  if (hsa_status_t status =
-          saved_amd_ext_api.hsa_amd_profiling_async_copy_enable_fn(profiling_async_copy_enable.load(std::memory_order_relaxed));
-      status != HSA_STATUS_SUCCESS)
-    assert(!"hsa_amd_profiling_async_copy_enable failed");
+  // Restore the async-copy profiling state that was active before Initialize().
+  // During process teardown the HSA runtime may already be shut down (the
+  // destruction order of globals across shared libraries is undefined), so
+  // this call can legitimately fail.  Log a warning instead of aborting —
+  // Finalize() is cleanup code and must not crash the process.
+  if (saved_amd_ext_api.hsa_amd_profiling_async_copy_enable_fn) {
+    hsa_status_t status =
+        saved_amd_ext_api.hsa_amd_profiling_async_copy_enable_fn(
+            profiling_async_copy_enable.load(std::memory_order_relaxed));
+    if (status != HSA_STATUS_SUCCESS)
+      warning("hsa_amd_profiling_async_copy_enable failed during finalization "
+              "(HSA runtime may already be shut down)");
+  }
 
   memset(&saved_core_api, '\0', sizeof(saved_core_api));
   memset(&saved_amd_ext_api, '\0', sizeof(saved_amd_ext_api));


### PR DESCRIPTION
## Summary

`Finalize()` in `hsa_support.cpp` calls `hsa_amd_profiling_async_copy_enable()` during
process teardown to restore async-copy profiling state.  When the HSA runtime has already
been shut down (C++ global destruction order is undefined across shared libraries), the
call fails and `assert()` aborts the process with SIGABRT (exit code 134).

This patch:

- **`Finalize()`**: Replaces the `assert` with a `warning()` call, consistent with how
  `timestamp_ns()` in the same file already handles `HSA_STATUS_ERROR_NOT_INITIALIZED`
  (line 543–544).  Adds a null-check on the function pointer for extra safety.

- **`MemoryASyncCopy{,OnEngine,Rect}Intercept()`**: Replaces `assert` + `[[maybe_unused]]`
  with proper error propagation (`return status`).  These intercepts return `hsa_status_t`
  and should propagate failures to callers rather than aborting.  The previous code silently
  ignored the error in release builds (`NDEBUG`) but crashed in debug builds — the worst of
  both worlds.

## Motivation

Every Python process that imports PyTorch + ROCm crashes on exit when roctracer is loaded
as a transitive dependency of `libamdhip64.so`.  This affects TheRock-built ROCm with
PyTorch, FBGEMM, and other HIP frameworks.

```
python3: .../roctracer/hsa_support.cpp:629: void roctracer::hsa_support::Finalize():
  Assertion `!"hsa_amd_profiling_async_copy_enable failed"' failed.
Aborted
```

## Design principle

Cleanup/finalization code must never abort the process.  When HSA shutdown ordering is
unpredictable (which it inherently is during `atexit`/destructor teardown across shared
libraries), failures in `Finalize()` are expected and benign — they should be logged, not
fatal.

## Related

- ROCm/TheRock#3902 (ASAN build failures in roctracer)

## Test plan

- [x] Verified `import torch; import fbgemm_gpu` no longer crashes on process exit
  with TheRock-built ROCm (HOST_ASAN overlay configuration)
- [ ] Verify no regressions in `roctracer` unit tests (`MatrixTranspose_ctest` etc.)

Made with [Cursor](https://cursor.com)