### PR TITLE
fail ocltst process if there are any failing tests

### DIFF
--- a/projects/clr/opencl/tests/ocltst/env/ocltst.cpp
+++ b/projects/clr/opencl/tests/ocltst/env/ocltst.cpp
@@ -259,7 +259,7 @@ class App {
   void ScanForTests();
 
   //! Function to run all the specified tests
-  void RunAllTests();
+  bool RunAllTests();
 
   //! Free memory
   void CleanUp();
@@ -718,7 +718,8 @@ void App::PrintTestOrder(int mod_index) {
 }
 
 //! Function that runs all the tests specified in the command-line
-void App::RunAllTests() {
+bool App::RunAllTests() {
+  bool status = true;
 #ifdef _WIN32
 
   if (!m_console) m_window = new Window("Test", 100, 100, m_width, m_height, 0);
@@ -885,6 +886,9 @@ void App::RunAllTests() {
   oclTestLog(OCLTEST_LOG_ALWAYS, "Total Run Tests:     %8d (%6.2f%s)\n", (int)total_tests,
              percent_total, "%");
   oclTestLog(OCLTEST_LOG_ALWAYS, "\n\n");
+  // fail the ocltst process if there are any failed tests
+  num_failures > 0 ? status = false : status = true;
+  return status;
 }
 
 /////////////////////////////////////////////////////////////////////////////
@@ -1401,6 +1405,7 @@ int main(int argc, char** argv) {
   platform = parseCommandLineForPlatform(argc, argv);
   // reset optind as we really didn't parse the full command line
   optind = 1;
+  bool status = true;
   App app(platform);
 #ifdef _WIN32
   // this function is registers windows service routine when ocltst is launched
@@ -1418,7 +1423,9 @@ int main(int argc, char** argv) {
     app.printOCLinfo();
     app.ScanForTests();
     for (int i = 0; i < app.GetNumItr(); i++) {
-      app.RunAllTests();
+      if(!app.RunAllTests()) {
+        status = false;
+      }
     }
     app.CleanUp();
 #ifdef AUTO_REGRESS
@@ -1427,8 +1434,8 @@ int main(int argc, char** argv) {
     return (-1);
   }
 #endif /* AUTO_REGRESS */
-
-  return 0;
+  // return 0 if all tests passed, 1 otherwise
+  return status ? 0 : 1;
 }
 
 #ifdef _WIN32

--- a/projects/clr/opencl/tests/ocltst/env/ocltst.cpp
+++ b/projects/clr/opencl/tests/ocltst/env/ocltst.cpp
@@ -258,7 +258,10 @@ class App {
   //! Function to scan for the different tests in the module
   void ScanForTests();
 
-  //! Function to run all the specified tests
+  //! Function to run all the specified tests.
+  //! \return true if all requested tests are executed and pass successfully;
+  //!         false if any test fails, if no tests are executed, or when
+  //!         running in list-only mode.
   bool RunAllTests();
 
   //! Free memory
@@ -887,7 +890,7 @@ bool App::RunAllTests() {
              percent_total, "%");
   oclTestLog(OCLTEST_LOG_ALWAYS, "\n\n");
   // fail the ocltst process if there are any failed tests
-  num_failures > 0 ? status = false : status = true;
+  status = (num_failures == 0);
   return status;
 }
 
@@ -1423,7 +1426,7 @@ int main(int argc, char** argv) {
     app.printOCLinfo();
     app.ScanForTests();
     for (int i = 0; i < app.GetNumItr(); i++) {
-      if(!app.RunAllTests()) {
+      if (!app.RunAllTests()) {
         status = false;
       }
     }


### PR DESCRIPTION
## Motivation
currently ocltst process does not fail even if there are failing tests. 
This PR makes sure any wrapper around ocltst will also fail if there are failing tests

## Technical Details
See tests failing silently.  the ocltst process needs to exit with an error instead of returning success
https://github.com/ROCm/TheRock/actions/runs/23702567407/job/69106225851 
See in this build link

## JIRA ID
AIRUNTIME-267

## Test Plan
ocltst works and passes if all tests pass. 
ocltst to fail if there are failing tests

## Test Result
ocltst works and passes if all tests pass. 
ocltst to fail if there are failing tests

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
