### PR TITLE
clr: Remove leftover dynamicgroupbaseptr declarations

### DIFF
--- a/projects/clr/hipamd/include/hip/amd_detail/amd_device_functions.h
+++ b/projects/clr/hipamd/include/hip/amd_detail/amd_device_functions.h
@@ -662,20 +662,6 @@ __device__ inline __hip_uint64_t __lanemask_eq() {
   return mask;
 }
 
-
-__device__ inline void* __local_to_generic(void* p) { return p; }
-
-#ifdef __HIP_DEVICE_COMPILE__
-__device__ inline void* __get_dynamicgroupbaseptr() {
-  // Get group segment base pointer.
-  return (char*)__local_to_generic((void*)__to_local(__builtin_amdgcn_groupstaticsize()));
-}
-#else
-__device__ void* __get_dynamicgroupbaseptr();
-#endif  // __HIP_DEVICE_COMPILE__
-
-__device__ inline void* __amdgcn_get_dynamicgroupbaseptr() { return __get_dynamicgroupbaseptr(); }
-
 // Memory Fence Functions
 __device__ inline static void __threadfence() { __builtin_amdgcn_fence(__ATOMIC_SEQ_CST, "agent"); }
 

--- a/projects/clr/hipamd/include/hip/amd_detail/device_library_decls.h
+++ b/projects/clr/hipamd/include/hip/amd_detail/device_library_decls.h
@@ -100,13 +100,6 @@ extern "C" __device__ __hip_uint64_t __ockl_fprintf_append_string_n(__hip_uint64
                                                                     __hip_uint64_t length,
                                                                     __hip_uint32_t is_last);
 
-// Introduce local address space
-#define __local __attribute__((address_space(3)))
-
-#ifdef __HIP_DEVICE_COMPILE__
-__device__ inline static __local void* __to_local(unsigned x) { return (__local void*)x; }
-#endif  //__HIP_DEVICE_COMPILE__
-
 // Using hip.amdgcn.bc - sync threads
 #define __CLK_LOCAL_MEM_FENCE  0x01
 #define __CLK_GLOBAL_MEM_FENCE 0x02


### PR DESCRIPTION
This is unused and a leftover from a much older version of dynamic local memory allocation.