### PR TITLE
[AMD-SMI] Updated default reset message for power limit reset

### DIFF
--- a/projects/amdsmi/amdsmi_cli/amdsmi_commands.py
+++ b/projects/amdsmi/amdsmi_cli/amdsmi_commands.py
@@ -9859,8 +9859,8 @@ class AMDSMICommands:
                 return
             if args.power_cap:
                 final_output = {
-                    "ppt0": "[AMDSMI_STATUS_NOT_SUPPORTED] Unable to reset to default power cap",
-                    "ppt1": "[AMDSMI_STATUS_NOT_SUPPORTED] Unable to reset to default power cap",
+                    "ppt0": "N/A",
+                    "ppt1": "N/A",
                 }
                 power_limit_types = {}
                 for power_type in amdsmi_interface.AmdSmiPowerCapType:


### PR DESCRIPTION
## Motivation
Users were experiencing confusion when resetting the power limit and receiving a message stating that the PPT1 power limit was not able to be reset, even though it was actually not applicable since it didn't exist.

## Technical Details
Updates the default message to N/A so that users will experience less confusion.

## JIRA ID
N/A

## Test Plan
Verify that new output uses N/A on a system lacking PPT1 capability

## Test Result
<img width="475" height="157" alt="image" src="https://github.com/user-attachments/assets/fb131afc-2924-4013-904e-544968c3b1f9" />

## Submission Checklist
N/A