### PR TITLE
[rocprofiler-compute] Refactor SDK config

### DIFF
--- a/projects/rocprofiler-compute/src/rocprof_compute_soc/profile_configs/sdk_config.yaml
+++ b/projects/rocprofiler-compute/src/rocprof_compute_soc/profile_configs/sdk_config.yaml
@@ -10911,3 +10911,13 @@ rocprofiler-sdk:
       - gfx942
       - gfx950
       expression: accumulate(SQC_ICACHE_INFLIGHT_LEVEL, HIGH_RES)
+  fw-restriction-schema-version: 1
+  firmware_restrictions:
+  - affected_architectures:
+    - gfx940
+    - gfx941
+    - gfx942
+    firmware_type: CP
+    min_version: 186
+    reason: CP firmware below version 186 can cause device resets and VM Page Faults
+      on MI3XX devices.

--- a/projects/rocprofiler-compute/src/rocprof_compute_soc/soc_base.py
+++ b/projects/rocprofiler-compute/src/rocprof_compute_soc/soc_base.py
@@ -445,13 +445,11 @@ class OmniSoC_Base:
             for counter in counters[list(counters.keys())[0]]
             if hasattr(counter, "block") or hasattr(counter, "expression")
         }
+        # Delete counter definition temporary directory
+        if os.environ.get("ROCPROFILER_METRICS_PATH"):
+            shutil.rmtree(os.environ["ROCPROFILER_METRICS_PATH"], ignore_errors=True)
         # Reset env. var.
         if old_rocprofiler_metrics_path is None:
-            # Delete counter definition temporary directory
-            if os.environ.get("ROCPROFILER_METRICS_PATH"):
-                shutil.rmtree(
-                    os.environ["ROCPROFILER_METRICS_PATH"], ignore_errors=True
-                )
             del os.environ["ROCPROFILER_METRICS_PATH"]
         else:
             os.environ["ROCPROFILER_METRICS_PATH"] = old_rocprofiler_metrics_path

--- a/projects/rocprofiler-compute/src/rocprof_compute_soc/soc_base.py
+++ b/projects/rocprofiler-compute/src/rocprof_compute_soc/soc_base.py
@@ -5,6 +5,7 @@ import argparse
 import math
 import os
 import re
+import shutil
 import sys
 from abc import abstractmethod
 from pathlib import Path
@@ -27,6 +28,7 @@ from utils.utils_common import (
     SUPPORTED_DENOM,
     add_counter_extra_config_input_yaml,
     convert_metric_id_to_panel_info,
+    create_temp_rocprofiler_metrics_path,
     get_panel_alias,
     is_only_pc_sampling,
     is_tcc_channel_counter,
@@ -398,8 +400,15 @@ class OmniSoC_Base:
 
         # Point to counter definition
         old_rocprofiler_metrics_path = os.environ.get("ROCPROFILER_METRICS_PATH")
-        os.environ["ROCPROFILER_METRICS_PATH"] = str(
-            config.rocprof_compute_home / "rocprof_compute_soc" / "profile_configs"
+        with open(
+            config.rocprof_compute_home
+            / "rocprof_compute_soc"
+            / "profile_configs"
+            / "sdk_config.yaml",
+        ) as filename:
+            sdk_config = yaml.safe_load(filename)
+        os.environ["ROCPROFILER_METRICS_PATH"] = create_temp_rocprofiler_metrics_path(
+            sdk_config
         )
 
         # Backward compatibility support for sdk avail module moved from
@@ -438,6 +447,11 @@ class OmniSoC_Base:
         }
         # Reset env. var.
         if old_rocprofiler_metrics_path is None:
+            # Delete counter definition temporary directory
+            if os.environ.get("ROCPROFILER_METRICS_PATH"):
+                shutil.rmtree(
+                    os.environ["ROCPROFILER_METRICS_PATH"], ignore_errors=True
+                )
             del os.environ["ROCPROFILER_METRICS_PATH"]
         else:
             os.environ["ROCPROFILER_METRICS_PATH"] = old_rocprofiler_metrics_path

--- a/projects/rocprofiler-compute/src/utils/utils_common.py
+++ b/projects/rocprofiler-compute/src/utils/utils_common.py
@@ -14,8 +14,8 @@ import selectors
 import shutil
 import subprocess
 import sys
-import textwrap
 import tempfile
+import textwrap
 import threading
 import time
 import uuid

--- a/projects/rocprofiler-compute/src/utils/utils_common.py
+++ b/projects/rocprofiler-compute/src/utils/utils_common.py
@@ -15,6 +15,7 @@ import shutil
 import subprocess
 import sys
 import textwrap
+import tempfile
 import threading
 import time
 import uuid
@@ -1023,6 +1024,47 @@ def print_status(msg: str) -> None:
     console_log(msg)
     console_log("~" * (msg_length + 1))
     console_log("")
+
+
+def create_temp_rocprofiler_metrics_path(sdk_config: dict[str, Any]) -> str:
+    """
+    Create temporary directory with rocprofiler metrics config files.
+
+    Writes two config files:
+    - counter_defs.yaml: For backward compatibility (excludes firmware restrictions)
+    - config.yaml: Current version with full config
+
+    Args:
+        sdk_config: The rocprofiler-sdk configuration dictionary.
+
+    Returns:
+        Path to the temporary directory (for ROCPROFILER_METRICS_PATH env var).
+    """
+    tmpfile_parent = Path(
+        tempfile.mkdtemp(prefix="rocprof_compute_sdk_config_", dir="/tmp")
+    )
+
+    # counter_defs.yaml is for backward compatibility with previous versions of sdk
+    tmpfile_path_old = tmpfile_parent / "counter_defs.yaml"
+    # Current version of sdk uses config.yaml instead of counter_defs.yaml
+    tmpfile_path_new = tmpfile_parent / "config.yaml"
+
+    with open(tmpfile_path_old, "w") as tmpfile:
+        # Old sdk does not support firmware restrictions
+        sdk_config_old = {
+            **sdk_config,
+            "rocprofiler-sdk": {
+                k: v
+                for k, v in sdk_config["rocprofiler-sdk"].items()
+                if k not in {"fw-restriction-schema-version", "firmware_restrictions"}
+            },
+        }
+        yaml.dump(sdk_config_old, tmpfile, default_flow_style=False, sort_keys=False)
+
+    with open(tmpfile_path_new, "w") as tmpfile:
+        yaml.dump(sdk_config, tmpfile, default_flow_style=False, sort_keys=False)
+
+    return str(tmpfile_parent)
 
 
 def set_locale_encoding() -> None:

--- a/projects/rocprofiler-compute/src/utils/utils_profile.py
+++ b/projects/rocprofiler-compute/src/utils/utils_profile.py
@@ -9,7 +9,6 @@ import pkgutil
 import re
 import shlex
 import shutil
-import tempfile
 import time
 import traceback
 from pathlib import Path
@@ -27,6 +26,7 @@ from utils.logger import (
 )
 from utils.utils_common import (
     capture_subprocess_output,
+    create_temp_rocprofiler_metrics_path,
     get_rocprof_cmd,
     parse_text,
     perform_attach_detach,
@@ -101,26 +101,20 @@ def run_prof(
         config.rocprof_compute_home
         / "rocprof_compute_soc"
         / "profile_configs"
-        / "counter_defs.yaml",
-    ) as file:
-        counter_defs = yaml.safe_load(file)
+        / "sdk_config.yaml",
+    ) as filename:
+        sdk_config = yaml.safe_load(filename)
     # Extra counter definitions
     for fname in fnames if multiple_files else [fnames]:
         if Path(fname).with_suffix(".yaml").exists():
             with open(Path(fname).with_suffix(".yaml")) as file:
-                counter_defs["rocprofiler-sdk"]["counters"].extend(
+                sdk_config["rocprofiler-sdk"]["counters"].extend(
                     yaml.safe_load(file)["rocprofiler-sdk"]["counters"]
                 )
-    # TODO: Write counter definitions to a user specified path
-    # Write counter definitions to a temporary file
-    tmpfile_path = (
-        Path(tempfile.mkdtemp(prefix="rocprof_counter_defs_", dir="/tmp"))
-        / "counter_defs.yaml"
-    )
-    with open(tmpfile_path, "w") as tmpfile:
-        yaml.dump(counter_defs, tmpfile, default_flow_style=False, sort_keys=False)
     # Set counter definitions
-    new_env["ROCPROFILER_METRICS_PATH"] = str(tmpfile_path.parent)
+    new_env["ROCPROFILER_METRICS_PATH"] = create_temp_rocprofiler_metrics_path(
+        sdk_config
+    )
     console_debug(
         "Adding env var for counter definitions: "
         f"ROCPROFILER_METRICS_PATH={new_env['ROCPROFILER_METRICS_PATH']}"

--- a/projects/rocprofiler-compute/tests/test_utils.py
+++ b/projects/rocprofiler-compute/tests/test_utils.py
@@ -1845,10 +1845,6 @@ def test_run_prof_sdk_creates_new_env_copy(tmp_path, monkeypatch):
     mock_fname_path_obj.name = "counters.txt"
     mock_fname_path_obj.with_suffix.return_value.exists.return_value = False
 
-    mock_div_result = mock.Mock(spec=Path)
-    mock_div_result.parent = "dummy_path"
-    mock_fname_path_obj.__truediv__.return_value = mock_div_result
-
     mock_out_path_obj = mock.Mock(spec=Path)
     mock_out_path_obj.exists.return_value = False
 
@@ -1880,7 +1876,10 @@ def test_run_prof_sdk_creates_new_env_copy(tmp_path, monkeypatch):
     monkeypatch.setattr("pandas.DataFrame.to_csv", lambda self, *a, **k: None)
     monkeypatch.setattr("shutil.copyfile", lambda *a, **k: None)
     monkeypatch.setattr("shutil.rmtree", lambda *a, **k: None)
-    monkeypatch.setattr("tempfile.mkdtemp", lambda *a, **k: None)
+    monkeypatch.setattr(
+        "utils.utils_profile.create_temp_rocprofiler_metrics_path",
+        lambda *a, **k: "dummy_path",
+    )
     monkeypatch.setattr("yaml.dump", lambda *a, **k: None)
     monkeypatch.setattr("utils.utils_profile.console_warning", lambda *a, **k: None)
     monkeypatch.setattr("builtins.open", lambda *a, **k: io.StringIO(""))


### PR DESCRIPTION
## Motivation

Due to rocprofiler-sdk team now using `config.yaml` instead of `counter_defs.yaml` in the folder pointed by `ROCPROFILER_METRICS_PATH` in the PR https://github.com/ROCm/rocm-systems/pull/344

This PR supports new sdk config (which supports firmware restrictions) as well as provides backward compatibility for previous sdk config

cc @bwelton for FYI on rocprofiler-compute uses ROCPROFILER_METRICS_PATH env var

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

- Rename counter_defs.yaml to sdk_config.yaml in profile_configs
    - Add firmware restriction schema (fw-restriction-schema-version and firmware_restrictions)
    - Extract temp rocprofiler metrics path creation to shared function create_temp_rocprofiler_metrics_path() in utils_common.py
    - Update callers in utils_profile.py and soc_base.py to use new shared function
    - Add cleanup of temp directory in soc_base.py when ROCPROFILER_METRICS_PATH is unset
    - Maintain backward compatibility by generating both counter_defs.yaml (old SDK) and config.yaml (new SDK) in temp directory

<!-- Explain the changes along with any relevant GitHub links. -->

## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan

Test manual profiling by renaming `$ROCM_PATH/share/rocprofiler-sdk/config.yaml` so that sdk/v3 only uses our config yaml and ensure available counter listing and profiling works.

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

Tests pass

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
