### PR TITLE
[rocshmem] print envvars from DEBUG_LEVEL and rocshmem_info

### DIFF
--- a/projects/rocshmem/docs/api/env_variables.rst
+++ b/projects/rocshmem/docs/api/env_variables.rst
@@ -19,11 +19,21 @@ control the behavior of rocSHMEM.
       - **Default value**
       - **Value**
 
+    * - | ``ROCSHMEM_DEBUG_LEVEL``
+        | Debug output level (NONE, VERSION, WARN, ENV:MODIFIED, ENV:ALL, ENV:FULL, INFO, TRACE)
+      - `` ``
+      -
+
     * - | ``ROCSHMEM_HEAP_SIZE``
         | Defines the size of the rocSHMEM symmetric heap in bytes (per PE).
       - ``1073741824`` (1 GB)
       - | Size in bytes (per PE).
         | Note: the heap is on GPU memory.
+
+    * - | ``ROCSHMEM_MAX_NUM_HOST_CONTEXTS``
+        | Maximum number of host-side communication contexts
+      - ``1``
+      - Maximum number of host-side contexts.
 
     * - | ``ROCSHMEM_MAX_NUM_CONTEXTS``
         | Defines the number of contexts an application can use.

--- a/projects/rocshmem/docs/api/env_variables.rst
+++ b/projects/rocshmem/docs/api/env_variables.rst
@@ -54,7 +54,7 @@ control the behavior of rocSHMEM.
         | ``gda``: GPU Direct Async Backend
 
     * - | ``ROCSHMEM_UNIQUEID_WITH_MPI``
-        | Defines whether rocSHMEM is expected to use MPI when using the uniqueId based initialization.
+        | Defines whether rocSHMEM is expected to use MPI internally when using the uniqueId based initialization.
       - ``0``
       - | ``0``: Do not use MPI.
         | ``1``: Use MPI.

--- a/projects/rocshmem/docs/api/env_variables.rst
+++ b/projects/rocshmem/docs/api/env_variables.rst
@@ -144,7 +144,7 @@ control the behavior of rocSHMEM.
 
     * - | ``ROCSHMEM_GDA_SQ_SIZE``
         | This environment variable sets the length of the SQ for GDA.
-      - ``4096``
+      - ``1024``
       - | Maximum number of Work Queue Entries (WQEs) posted on the Send Queue (SQ)
 
     * - | ``ROCSHMEM_GDA_NUM_QPS_PER_PE_DEFAULT_CTX``
@@ -156,3 +156,23 @@ control the behavior of rocSHMEM.
         | Sets the number of Queue Pairs (QPs) to create per PE for each user context.
       - ``1``
       - Number of QPs per PE for each user context.
+
+    * - | ``ROCSHMEM_MAX_WF_BUFFERS``
+        | Maximum number of wavefront buffer arrays in default context (determines size of status, return, and atomic return buffers)
+      - ``1024``
+      -
+
+    * - | ``ROCSHMEM_BOOTSTRAP_TIMEOUT``
+        | Bootstrap initialization timeout in seconds
+      - ``5``
+      -
+
+    * - | ``ROCSHMEM_BOOTSTRAP_HOSTID``
+        | Override host identifier for bootstrap. Empty string uses hostname.
+      - `` ``
+      -
+
+    * - | ``ROCSHMEM_BOOTSTRAP_SOCKET_FAMILY``
+        | Socket family for bootstrap (AF_UNSPEC, AF_INET, AF_INET6)
+      - ``types::socket_family::UNSPEC``
+      -

--- a/projects/rocshmem/src/envvar.cpp
+++ b/projects/rocshmem/src/envvar.cpp
@@ -38,82 +38,82 @@ namespace rocshmem {
 namespace envvar {
   inline namespace _base {
     const var<bool> uniqueid_with_mpi("UNIQUEID_WITH_MPI",
-                                       "Use MPI when using uniqueId-based initialization",
-                                       false);
+                                      "Use MPI when using uniqueId-based initialization",
+                                      false);
     const var<types::debug_level> debug_level("DEBUG_LEVEL",
-                                                "Debug output level (NONE, VERSION, WARN, ENV, ENV:FULL, ENV:PRETTY, INFO, TRACE)",
-                                                types::debug_level::NONE);
+                                              "Debug output level (NONE, VERSION, WARN, ENV:MODIFIED, ENV:ALL, ENV:FULL, INFO, TRACE)",
+                                              types::debug_level::NONE);
     const var<size_t> heap_size("HEAP_SIZE",
-                                 "Size of the rocSHMEM symmetric heap in bytes (per PE). Note: heap is on GPU memory.",
-                                 1L << 30);
+                                "Size of the rocSHMEM symmetric heap in bytes (per PE). Note: heap is on GPU memory.",
+                                1L << 30);
     const var<size_t> max_num_teams("MAX_NUM_TEAMS",
-                                     "Maximum number of teams an application can use",
-                                     40);
+                                    "Maximum number of teams an application can use",
+                                    40);
     const var<size_t> max_num_host_contexts("MAX_NUM_HOST_CONTEXTS",
-                                              "Maximum number of host-side communication contexts",
-                                              1);
+                                            "Maximum number of host-side communication contexts",
+                                            1);
     const var<size_t> max_num_contexts("MAX_NUM_CONTEXTS",
-                                        "Maximum number of contexts an application can use",
-                                        32);
+                                       "Maximum number of contexts an application can use",
+                                       32);
     const var<size_t> max_wavefront_buffers("MAX_WF_BUFFERS",
-                                             "Maximum number of wavefront buffer arrays in default context (determines size of status, return, and atomic return buffers)",
-                                             1024);
+                                            "Maximum number of wavefront buffer arrays in default context (determines size of status, return, and atomic return buffers)",
+                                            1024);
     const var<std::string> requested_dev("USE_IB_HCA",
-                                          "Specify which NIC this PE should bind to (e.g., 'bnxt_re0'). Empty string enables auto-detection.");
+                                         "Specify which NIC this PE should bind to (e.g., 'bnxt_re0'). Empty string enables auto-detection.");
     const var<std::string> hca_list("HCA_LIST", "");
     const var<uint32_t> sq_size("SQ_SIZE",
-                                 "Send queue size for GDA backend",
-                                 1024);
+                                "Send queue size for GDA backend",
+                                1024);
     const var<std::string> backend("BACKEND",
-                                    "Backend selection (ipc, ro, gda). Empty string enables auto-selection.");
+                                   "Backend selection (ipc, ro, gda). Empty string enables auto-selection.");
     const var<bool> disable_mixed_ipc("DISABLE_MIXED_IPC",
-                                       "Force using network conduit even when IPC is available",
-                                       false);
+                                      "Force using network conduit even when IPC is available",
+                                      false);
     const var<bool> disable_ipc("DISABLE_IPC",
-                                 "DEPRECATED: Synonym for ROCSHMEM_DISABLE_MIXED_IPC. Force using network conduit even when IPC is available",
-                                 false);
+                                "DEPRECATED: Synonym for ROCSHMEM_DISABLE_MIXED_IPC. Force using network conduit even when IPC is available",
+                                false);
   }  // inline namespace _base
 
   namespace bootstrap {
     const var<int64_t> timeout("TIMEOUT",
-                                "Bootstrap initialization timeout in seconds",
-                                5);
+                               "Bootstrap initialization timeout in seconds",
+                               5);
     const var<std::string> hostid("HOSTID",
-                                   "Override host identifier for bootstrap. Empty string uses hostname.");
+                                  "Override host identifier for bootstrap. Empty string uses hostname.");
     const var<types::socket_family> socket_family("SOCKET_FAMILY",
-                                                    "Socket family for bootstrap (AF_UNSPEC, AF_INET, AF_INET6)",
-                                                    types::socket_family::UNSPEC);
+                                                  "Socket family for bootstrap (AF_UNSPEC, AF_INET, AF_INET6)",
+                                                  types::socket_family::UNSPEC);
     const var<std::string> socket_ifname("SOCKET_IFNAME",
-                                          "Interface to use for bootstrap (only valid when not using MPI, e.g., 'eno8303'). Empty string enables auto-detection.");
+                                         "Interface to use for bootstrap (only valid when not using MPI, e.g., 'eno8303'). Empty string enables auto-detection.");
   }  // namespace bootstrap
 
   namespace ro {
     const var<bool> disable_ipc("DISABLE_IPC",
-                                 "DEPRECATED: Synonym for ROCSHMEM_DISABLE_MIXED_IPC. Force using network conduit even when IPC is available",
-                                 false);
+                                "DEPRECATED: Synonym for ROCSHMEM_DISABLE_MIXED_IPC. Force using network conduit even when IPC is available",
+                                false);
     const var<useconds_t> progress_delay("PROGRESS_DELAY",
-                                          "Progress engine delay in microseconds (reduces memory subsystem load for performance)",
-                                          3);
+                                         "Progress engine delay in microseconds (reduces memory subsystem load for performance)",
+                                         3);
     const var<bool> net_cpu_queue("NET_CPU_QUEUE",
-                                   "Use CPU queue for network operations in Reverse Offload backend",
-                                   false);
+                                  "Use CPU queue for network operations in Reverse Offload backend",
+                                  false);
   }  // namespace ro
 
   namespace gda {
     const var<std::string> provider("PROVIDER",
-                                     "NIC vendor selection (bnxt, pensando, ionic, mlx5). Empty string enables auto-detection.");
+                                    "NIC vendor selection (bnxt, pensando, ionic, mlx5). Empty string enables auto-detection.");
     const var<bool> alternate_qp_ports("ALTERNATE_QP_PORTS",
-                                        "Enable alternating QP mappings across rocSHMEM contexts (helps saturate bandwidth on multiport bonded interfaces)",
-                                        true);
+                                       "Enable alternating QP mappings across rocSHMEM contexts (helps saturate bandwidth on multiport bonded interfaces)",
+                                       true);
     const var<uint8_t> traffic_class("TRAFFIC_CLASS",
-                                      "Traffic class for QPs when using Ethernet link layer",
-                                      0);
+                                     "Traffic class for QPs when using Ethernet link layer",
+                                     0);
     const var<bool> pcie_relaxed_ordering("PCIE_RELAXED_ORDERING",
-                                           "Enable PCIe Relaxed Ordering when registering symmetric heap with RDMA NICs",
-                                           false);
+                                          "Enable PCIe Relaxed Ordering when registering symmetric heap with RDMA NICs",
+                                          false);
     const var<bool> enable_dmabuf("ENABLE_DMABUF",
-                                   "Enable dmabuf support for memory registration",
-                                   false);
+                                  "Enable dmabuf support for memory registration",
+                                  false);
     const var<bool> override_nic_firmware_check("OVERRIDE_NIC_FIRMWARE_CHECK", "", false);
     const var<std::string> alltoallv_wg_algo("ALLTOALLV_WG_ALGO", "");
     const var<uint32_t> sq_size("SQ_SIZE", "", 4096);
@@ -178,10 +178,12 @@ namespace envvar {
           level = debug_level::WARN;
         } else if (level_str == "ENV") {
           level = debug_level::ENV;
+        } else if (level_str == "ENV:MODIFIED") {
+          level = debug_level::ENV;
+        } else if (level_str == "ENV:ALL") {
+          level = debug_level::ENV_ALL;
         } else if (level_str == "ENV:FULL") {
           level = debug_level::ENV_FULL;
-        } else if (level_str == "ENV:PRETTY") {
-          level = debug_level::ENV_PRETTY;
         } else if (level_str == "INFO") {
           level = debug_level::INFO;
         } else if (level_str == "TRACE") {
@@ -203,11 +205,11 @@ namespace envvar {
         case debug_level::WARN:
           return os << "WARN";
         case debug_level::ENV:
-          return os << "ENV";
+          return os << "ENV:MODIFIED";
+        case debug_level::ENV_ALL:
+          return os << "ENV:ALL";
         case debug_level::ENV_FULL:
           return os << "ENV:FULL";
-        case debug_level::ENV_PRETTY:
-          return os << "ENV:PRETTY";
         case debug_level::INFO:
           return os << "INFO";
         case debug_level::TRACE:
@@ -217,7 +219,7 @@ namespace envvar {
     }  // inline namespace _debug
   }  // namespace types
 
-  void print_all_envvars(print_mode mode, std::ostream& os) {
+  void print_envvars(print_mode mode, std::ostream& os) {
     auto [var_map, map_mutex] = _detail::get_var_map();
     std::lock_guard map_lock(map_mutex);
 
@@ -270,8 +272,8 @@ namespace envvar {
         std::visit([&os, mode](const auto& v) {
           using T = typename std::decay_t<decltype(v.get())>::value_type;
 
-          // For MODIFIED_ONLY mode, skip variables using default values
-          if (mode == print_mode::MODIFIED_ONLY && v.get().is_default()) {
+          // For MODIFIED mode, skip variables using default values
+          if (mode == print_mode::MODIFIED && v.get().is_default()) {
             return;
           }
 
@@ -287,7 +289,7 @@ namespace envvar {
             }
           };
 
-          if (mode == print_mode::MODIFIED_ONLY || mode == print_mode::ALL_VALUES) {
+          if (mode == print_mode::MODIFIED || mode == print_mode::ALL_VALUES) {
             // Simple format: NAME=value
             os << v.get().get_name() << "=" << format_value(v.get().get_value()) << "\n";
           } else {

--- a/projects/rocshmem/src/envvar.cpp
+++ b/projects/rocshmem/src/envvar.cpp
@@ -46,33 +46,30 @@ namespace envvar {
     const var<size_t> heap_size("HEAP_SIZE",
       "Defines the size of the rocSHMEM symmetric heap in bytes (per PE). Size in bytes (per PE); Note: the heap is on GPU memory",
       1L << 30);
-    const var<size_t> max_num_teams("MAX_NUM_TEAMS",
-      "Defines the number of teams an application can use.",
-      40);
-    const var<size_t> max_num_host_contexts("MAX_NUM_HOST_CONTEXTS",
-      "Maximum number of host-side communication contexts",
-      1);
+    const var<std::string> backend("BACKEND",
+      "When rocSHMEM is compiled for all backends, this environment variable selects which backend to execute. The default value is an empty string and rocSHMEM auto-selects the most appropriate backend. ipc: IPC Backend; ro: Reverse Offload Backend; gda: GPU Direct Async Backend");
     const var<size_t> max_num_contexts("MAX_NUM_CONTEXTS",
       "Defines the number of contexts an application can use.",
       32);
-    const var<size_t> max_wavefront_buffers("MAX_WF_BUFFERS",
-      "Maximum number of wavefront buffer arrays in default context (determines size of status, return, and atomic return buffers)",
-      1024);
-    const var<std::string> requested_nic("USE_IB_HCA",
-      "Forces the NIC that this PE uses. When this value is set NIC auto-detection and mapping is disabled, the NIC specified in the variable will be selected. The default value is an empty string and rocSHMEM auto-detects the most appropriate NIC. Example value: bnxt_re0");
+    const var<size_t> max_num_host_contexts("MAX_NUM_HOST_CONTEXTS",
+      "Maximum number of host-side communication contexts",
+      1);
+    const var<size_t> max_num_teams("MAX_NUM_TEAMS",
+      "Defines the number of teams an application can use.",
+      40);
     const var<std::string> hca_list("HCA_LIST",
       "Comma separated list of NIC names that can be used by rocSHMEM. Unlike ROCSHMEM_USE_IB_HCA, when this variable is set, NIC auto-detection and mapping still executes, but NICs that are not in the list are discarded before auto-detection runs. Prefixing the list with ^ turns the list in an exclude list, NICs that are in the list are discarded before auto-detection runs. The default value is an empty string and rocSHMEM auto-detects the most appropriate NIC. Example value: bnxt_re1,bnxt_re11, ^mlx5_0,mlx5_3");
-    const var<uint32_t> sq_size("SQ_SIZE",
-      "Send queue size for GDA backend",
-      1024);
-    const var<std::string> backend("BACKEND",
-      "When rocSHMEM is compiled for all backends, this environment variable selects which backend to execute. The default value is an empty string and rocSHMEM auto-selects the most appropriate backend. ipc: IPC Backend; ro: Reverse Offload Backend; gda: GPU Direct Async Backend");
+    const var<std::string> requested_nic("USE_IB_HCA",
+      "Forces the NIC that this PE uses. When this value is set NIC auto-detection and mapping is disabled, the NIC specified in the variable will be selected. The default value is an empty string and rocSHMEM auto-detects the most appropriate NIC. Example value: bnxt_re0");
     const var<bool> disable_mixed_ipc("DISABLE_MIXED_IPC",
       "Defines whether to force using the network conduit even when IPC is available. 0: Use IPC when available; 1: Force network conduit",
       false);
     const var<bool> disable_ipc("DISABLE_IPC",
       "DEPRECATED: Synonym for ROCSHMEM_DISABLE_MIXED_IPC. Force using network conduit even when IPC is available",
       false);
+    const var<size_t> max_wavefront_buffers("MAX_WF_BUFFERS",
+      "Maximum number of wavefront buffer arrays in default context (determines size of status, return, and atomic return buffers)",
+      1024);
   }  // inline namespace _base
 
   namespace bootstrap {
@@ -122,7 +119,7 @@ namespace envvar {
       "Selects between two algorithms to use for GDA based alltoallv. The GET algorithm uses an initial round of alltoallv communication to distribute displacements then a second round to get transfer data. This algorithm has a higher latency but has better performance for large messages. The COPY algorithm does an alltoallv communication pattern into a staging buffer then does a copy into the destination buffers. This reduces latency but requires more memory, this algorithm only works for small messages.");
     const var<uint32_t> sq_size("SQ_SIZE",
       "This environment variable sets the length of the SQ for GDA. Maximum number of Work Queue Entries (WQEs) posted on the Send Queue (SQ)",
-      4096);
+      1024);
     const var<size_t> num_qps_per_pe_default_ctx("NUM_QPS_PER_PE_DEFAULT_CTX",
       "Sets the number of Queue Pairs (QPs) to create per PE for the default context.",
       1);

--- a/projects/rocshmem/src/envvar.cpp
+++ b/projects/rocshmem/src/envvar.cpp
@@ -38,7 +38,7 @@ namespace rocshmem {
 namespace envvar {
   inline namespace _base {
     const var<bool> uniqueid_with_mpi("UNIQUEID_WITH_MPI",
-      "Defines whether rocSHMEM is expected to use MPI when using the uniqueId based initialization. 0: Do not use MPI; 1: Use MPI",
+      "Defines whether rocSHMEM is expected to use MPI internally when using the uniqueId based initialization. 0: Do not use MPI; 1: Use MPI",
       false);
     const var<types::debug_level> debug_level("DEBUG_LEVEL",
       "Debug output level (NONE, VERSION, WARN, ENV:MODIFIED, ENV:ALL, ENV:FULL, INFO, TRACE)",

--- a/projects/rocshmem/src/envvar.cpp
+++ b/projects/rocshmem/src/envvar.cpp
@@ -238,13 +238,9 @@ namespace envvar {
       {category::tag::GDA, "GPU Direct Async backend variables"}
     };
 
-    // Print header only for FULL_DOCUMENTATION mode
-    if (mode == print_mode::FULL_DOCUMENTATION) {
-      os << "\n";
-      os << "================================================================================\n";
-      os << "                    rocSHMEM Environment Variables\n";
-      os << "================================================================================\n";
-    }
+    os << "################################################################################\n";
+    os << "#                   rocSHMEM Environment Variables                             #\n";
+    os << "################################################################################\n";
 
     // Iterate through each category
     for (const auto& cat : {category::tag::ROCSHMEM,
@@ -261,9 +257,10 @@ namespace envvar {
 
       // Print category header only for FULL_DOCUMENTATION mode
       if (mode == print_mode::FULL_DOCUMENTATION) {
-        os << "\n" << category_names.at(cat) << "\n";
-        os << category_descriptions.at(cat) << "\n";
-        os << std::string(80, '-') << "\n";
+        os << "#" << std::string(78, '-') << "#\n";
+        os << "# " << category_names.at(cat) << ": "
+           << category_descriptions.at(cat) << "\n";
+        os << "#" << std::string(78, '-') << "#\n";
       }
 
       // Iterate through each variable in the category
@@ -291,21 +288,21 @@ namespace envvar {
 
           if (mode == print_mode::MODIFIED || mode == print_mode::ALL_VALUES) {
             // Simple format: NAME=value
-            os << v.get().get_name() << "=" << format_value(v.get().get_value()) << "\n";
+            os << "# " << v.get().get_name() << "=" << format_value(v.get().get_value()) << "\n";
           } else {
             // FULL_DOCUMENTATION mode
-            os << "\n  " << v.get().get_name() << "\n";
+            os << "# " << v.get().get_name() << "\n";
 
             // Print documentation if available
             if (!v.get().get_doc().empty()) {
-              os << "    Description:   " << v.get().get_doc() << "\n";
+              os << "#   Description:   " << v.get().get_doc() << "\n";
             }
 
             // Print default value
-            os << "    Default:       " << format_value(v.get().get_default()) << "\n";
+            os << "#   Default:       " << format_value(v.get().get_default()) << "\n";
 
             // Print current value and whether it was set
-            os << "    Current:       " << format_value(v.get().get_value());
+            os << "#   Current:       " << format_value(v.get().get_value());
 
             if (v.get().is_default()) {
               os << " (using default)";
@@ -318,13 +315,12 @@ namespace envvar {
       }
     }
 
-    // Print footer only for FULL_DOCUMENTATION mode
-    if (mode == print_mode::FULL_DOCUMENTATION) {
-      os << "\n";
-      os << "================================================================================\n";
-      os << "For more information, see:\n";
-      os << "https://rocm.docs.amd.com/projects/rocSHMEM/en/latest/api/env_variables.html\n";
-      os << "================================================================================\n";
+    if (mode != print_mode::MODIFIED) {
+      os << "#\n";
+      os << "#------------------------------------------------------------------------------#\n";
+      os << "# For more information, see:\n";
+      os << "# https://rocm.docs.amd.com/projects/rocSHMEM/en/latest/api/env_variables.html\n";
+      os << "#------------------------------------------------------------------------------#\n";
     }
   }
 

--- a/projects/rocshmem/src/envvar.cpp
+++ b/projects/rocshmem/src/envvar.cpp
@@ -37,39 +37,83 @@
 namespace rocshmem {
 namespace envvar {
   inline namespace _base {
-    const var<bool> uniqueid_with_mpi("UNIQUEID_WITH_MPI", "", false);
-    const var<types::debug_level> debug_level("DEBUG_LEVEL", "", types::debug_level::NONE);
-    const var<size_t> heap_size("HEAP_SIZE", "", 1L << 30);
-    const var<size_t> max_num_teams("MAX_NUM_TEAMS", "", 40);
-    const var<size_t> max_num_host_contexts("MAX_NUM_HOST_CONTEXTS", "", 1);
-    const var<size_t> max_num_contexts("MAX_NUM_CONTEXTS", "", 32);
-    const var<size_t> max_wavefront_buffers("MAX_WF_BUFFERS", "", 1024);
-    const var<std::string> requested_nic("USE_IB_HCA", "");
+    const var<bool> uniqueid_with_mpi("UNIQUEID_WITH_MPI",
+                                       "Use MPI when using uniqueId-based initialization",
+                                       false);
+    const var<types::debug_level> debug_level("DEBUG_LEVEL",
+                                                "Debug output level (NONE, VERSION, WARN, ENV, ENV:FULL, ENV:PRETTY, INFO, TRACE)",
+                                                types::debug_level::NONE);
+    const var<size_t> heap_size("HEAP_SIZE",
+                                 "Size of the rocSHMEM symmetric heap in bytes (per PE). Note: heap is on GPU memory.",
+                                 1L << 30);
+    const var<size_t> max_num_teams("MAX_NUM_TEAMS",
+                                     "Maximum number of teams an application can use",
+                                     40);
+    const var<size_t> max_num_host_contexts("MAX_NUM_HOST_CONTEXTS",
+                                              "Maximum number of host-side communication contexts",
+                                              1);
+    const var<size_t> max_num_contexts("MAX_NUM_CONTEXTS",
+                                        "Maximum number of contexts an application can use",
+                                        32);
+    const var<size_t> max_wavefront_buffers("MAX_WF_BUFFERS",
+                                             "Maximum number of wavefront buffer arrays in default context (determines size of status, return, and atomic return buffers)",
+                                             1024);
+    const var<std::string> requested_dev("USE_IB_HCA",
+                                          "Specify which NIC this PE should bind to (e.g., 'bnxt_re0'). Empty string enables auto-detection.");
     const var<std::string> hca_list("HCA_LIST", "");
-    const var<std::string> backend("BACKEND", "");
-    const var<bool> disable_mixed_ipc("DISABLE_MIXED_IPC", "", false);
-    const var<bool> disable_ipc("DISABLE_IPC", "", false);
+    const var<uint32_t> sq_size("SQ_SIZE",
+                                 "Send queue size for GDA backend",
+                                 1024);
+    const var<std::string> backend("BACKEND",
+                                    "Backend selection (ipc, ro, gda). Empty string enables auto-selection.");
+    const var<bool> disable_mixed_ipc("DISABLE_MIXED_IPC",
+                                       "Force using network conduit even when IPC is available",
+                                       false);
+    const var<bool> disable_ipc("DISABLE_IPC",
+                                 "DEPRECATED: Synonym for ROCSHMEM_DISABLE_MIXED_IPC. Force using network conduit even when IPC is available",
+                                 false);
   }  // inline namespace _base
 
   namespace bootstrap {
-    const var<int64_t> timeout("TIMEOUT", "", 5);
-    const var<std::string> hostid("HOSTID", "");
-    const var<types::socket_family> socket_family("SOCKET_FAMILY", "", types::socket_family::UNSPEC);
-    const var<std::string> socket_ifname("SOCKET_IFNAME", "");
+    const var<int64_t> timeout("TIMEOUT",
+                                "Bootstrap initialization timeout in seconds",
+                                5);
+    const var<std::string> hostid("HOSTID",
+                                   "Override host identifier for bootstrap. Empty string uses hostname.");
+    const var<types::socket_family> socket_family("SOCKET_FAMILY",
+                                                    "Socket family for bootstrap (AF_UNSPEC, AF_INET, AF_INET6)",
+                                                    types::socket_family::UNSPEC);
+    const var<std::string> socket_ifname("SOCKET_IFNAME",
+                                          "Interface to use for bootstrap (only valid when not using MPI, e.g., 'eno8303'). Empty string enables auto-detection.");
   }  // namespace bootstrap
 
   namespace ro {
-    const var<bool> disable_ipc("DISABLE_IPC", "", false);
-    const var<useconds_t> progress_delay("PROGRESS_DELAY", "", 3);
-    const var<bool> net_cpu_queue("NET_CPU_QUEUE", "", false);
+    const var<bool> disable_ipc("DISABLE_IPC",
+                                 "DEPRECATED: Synonym for ROCSHMEM_DISABLE_MIXED_IPC. Force using network conduit even when IPC is available",
+                                 false);
+    const var<useconds_t> progress_delay("PROGRESS_DELAY",
+                                          "Progress engine delay in microseconds (reduces memory subsystem load for performance)",
+                                          3);
+    const var<bool> net_cpu_queue("NET_CPU_QUEUE",
+                                   "Use CPU queue for network operations in Reverse Offload backend",
+                                   false);
   }  // namespace ro
 
   namespace gda {
-    const var<std::string> provider("PROVIDER", "");
-    const var<bool> alternate_qp_ports("ALTERNATE_QP_PORTS", "", true);
-    const var<uint8_t> traffic_class("TRAFFIC_CLASS", "", 0);
-    const var<bool> pcie_relaxed_ordering("PCIE_RELAXED_ORDERING", "", false);
-    const var<bool> enable_dmabuf("ENABLE_DMABUF", "", false);
+    const var<std::string> provider("PROVIDER",
+                                     "NIC vendor selection (bnxt, pensando, ionic, mlx5). Empty string enables auto-detection.");
+    const var<bool> alternate_qp_ports("ALTERNATE_QP_PORTS",
+                                        "Enable alternating QP mappings across rocSHMEM contexts (helps saturate bandwidth on multiport bonded interfaces)",
+                                        true);
+    const var<uint8_t> traffic_class("TRAFFIC_CLASS",
+                                      "Traffic class for QPs when using Ethernet link layer",
+                                      0);
+    const var<bool> pcie_relaxed_ordering("PCIE_RELAXED_ORDERING",
+                                           "Enable PCIe Relaxed Ordering when registering symmetric heap with RDMA NICs",
+                                           false);
+    const var<bool> enable_dmabuf("ENABLE_DMABUF",
+                                   "Enable dmabuf support for memory registration",
+                                   false);
     const var<bool> override_nic_firmware_check("OVERRIDE_NIC_FIRMWARE_CHECK", "", false);
     const var<std::string> alltoallv_wg_algo("ALLTOALLV_WG_ALGO", "");
     const var<uint32_t> sq_size("SQ_SIZE", "", 4096);
@@ -132,6 +176,12 @@ namespace envvar {
           level = debug_level::VERSION;
         } else if (level_str == "WARN") {
           level = debug_level::WARN;
+        } else if (level_str == "ENV") {
+          level = debug_level::ENV;
+        } else if (level_str == "ENV:FULL") {
+          level = debug_level::ENV_FULL;
+        } else if (level_str == "ENV:PRETTY") {
+          level = debug_level::ENV_PRETTY;
         } else if (level_str == "INFO") {
           level = debug_level::INFO;
         } else if (level_str == "TRACE") {
@@ -152,6 +202,12 @@ namespace envvar {
           return os << "VERSION";
         case debug_level::WARN:
           return os << "WARN";
+        case debug_level::ENV:
+          return os << "ENV";
+        case debug_level::ENV_FULL:
+          return os << "ENV:FULL";
+        case debug_level::ENV_PRETTY:
+          return os << "ENV:PRETTY";
         case debug_level::INFO:
           return os << "INFO";
         case debug_level::TRACE:
@@ -160,5 +216,115 @@ namespace envvar {
       }
     }  // inline namespace _debug
   }  // namespace types
+
+  void print_all_envvars(print_mode mode, std::ostream& os) {
+    auto [var_map, map_mutex] = _detail::get_var_map();
+    std::lock_guard map_lock(map_mutex);
+
+    // Category names for display
+    const std::unordered_map<category::tag, std::string> category_names = {
+      {category::tag::ROCSHMEM, "ROCSHMEM"},
+      {category::tag::BOOTSTRAP, "BOOTSTRAP"},
+      {category::tag::REVERSE_OFFLOAD, "REVERSE_OFFLOAD"},
+      {category::tag::GDA, "GDA (GPU Direct Async)"}
+    };
+
+    const std::unordered_map<category::tag, std::string> category_descriptions = {
+      {category::tag::ROCSHMEM, "Core rocSHMEM configuration variables"},
+      {category::tag::BOOTSTRAP, "Bootstrap initialization variables"},
+      {category::tag::REVERSE_OFFLOAD, "Reverse Offload backend variables"},
+      {category::tag::GDA, "GPU Direct Async backend variables"}
+    };
+
+    // Print header only for FULL_DOCUMENTATION mode
+    if (mode == print_mode::FULL_DOCUMENTATION) {
+      os << "\n";
+      os << "================================================================================\n";
+      os << "                    rocSHMEM Environment Variables\n";
+      os << "================================================================================\n";
+    }
+
+    // Iterate through each category
+    for (const auto& cat : {category::tag::ROCSHMEM,
+                            category::tag::BOOTSTRAP,
+                            category::tag::REVERSE_OFFLOAD,
+                            category::tag::GDA}) {
+
+      // Skip if category not in map
+      if (var_map.find(cat) == var_map.end()) {
+        continue;
+      }
+
+      const auto& var_list = var_map.at(cat);
+
+      // Print category header only for FULL_DOCUMENTATION mode
+      if (mode == print_mode::FULL_DOCUMENTATION) {
+        os << "\n" << category_names.at(cat) << "\n";
+        os << category_descriptions.at(cat) << "\n";
+        os << std::string(80, '-') << "\n";
+      }
+
+      // Iterate through each variable in the category
+      for (const auto& var_ref : var_list) {
+        // Visit the variant to extract information from the var
+        std::visit([&os, mode](const auto& v) {
+          using T = typename std::decay_t<decltype(v.get())>::value_type;
+
+          // For MODIFIED_ONLY mode, skip variables using default values
+          if (mode == print_mode::MODIFIED_ONLY && v.get().is_default()) {
+            return;
+          }
+
+          // Helper lambda to format value
+          auto format_value = [](const auto& value) -> std::string {
+            using ValueType = std::decay_t<decltype(value)>;
+            if constexpr (std::is_same_v<ValueType, bool>) {
+              return value ? "true" : "false";
+            } else {
+              std::ostringstream oss;
+              oss << value;
+              return oss.str();
+            }
+          };
+
+          if (mode == print_mode::MODIFIED_ONLY || mode == print_mode::ALL_VALUES) {
+            // Simple format: NAME=value
+            os << v.get().get_name() << "=" << format_value(v.get().get_value()) << "\n";
+          } else {
+            // FULL_DOCUMENTATION mode
+            os << "\n  " << v.get().get_name() << "\n";
+
+            // Print documentation if available
+            if (!v.get().get_doc().empty()) {
+              os << "    Description:   " << v.get().get_doc() << "\n";
+            }
+
+            // Print default value
+            os << "    Default:       " << format_value(v.get().get_default()) << "\n";
+
+            // Print current value and whether it was set
+            os << "    Current:       " << format_value(v.get().get_value());
+
+            if (v.get().is_default()) {
+              os << " (using default)";
+            } else {
+              os << " (set from environment)";
+            }
+            os << "\n";
+          }
+        }, var_ref);
+      }
+    }
+
+    // Print footer only for FULL_DOCUMENTATION mode
+    if (mode == print_mode::FULL_DOCUMENTATION) {
+      os << "\n";
+      os << "================================================================================\n";
+      os << "For more information, see:\n";
+      os << "https://rocm.docs.amd.com/projects/rocSHMEM/en/latest/api/env_variables.html\n";
+      os << "================================================================================\n";
+    }
+  }
+
 }  // namespace envvar
 }  // namespace rocshmem

--- a/projects/rocshmem/src/envvar.cpp
+++ b/projects/rocshmem/src/envvar.cpp
@@ -58,7 +58,7 @@ namespace envvar {
     const var<size_t> max_wavefront_buffers("MAX_WF_BUFFERS",
                                             "Maximum number of wavefront buffer arrays in default context (determines size of status, return, and atomic return buffers)",
                                             1024);
-    const var<std::string> requested_dev("USE_IB_HCA",
+    const var<std::string> requested_nic("USE_IB_HCA",
                                          "Specify which NIC this PE should bind to (e.g., 'bnxt_re0'). Empty string enables auto-detection.");
     const var<std::string> hca_list("HCA_LIST", "");
     const var<uint32_t> sq_size("SQ_SIZE",

--- a/projects/rocshmem/src/envvar.cpp
+++ b/projects/rocshmem/src/envvar.cpp
@@ -38,87 +38,97 @@ namespace rocshmem {
 namespace envvar {
   inline namespace _base {
     const var<bool> uniqueid_with_mpi("UNIQUEID_WITH_MPI",
-                                      "Use MPI when using uniqueId-based initialization",
-                                      false);
+      "Defines whether rocSHMEM is expected to use MPI when using the uniqueId based initialization. 0: Do not use MPI; 1: Use MPI",
+      false);
     const var<types::debug_level> debug_level("DEBUG_LEVEL",
-                                              "Debug output level (NONE, VERSION, WARN, ENV:MODIFIED, ENV:ALL, ENV:FULL, INFO, TRACE)",
-                                              types::debug_level::NONE);
+      "Debug output level (NONE, VERSION, WARN, ENV:MODIFIED, ENV:ALL, ENV:FULL, INFO, TRACE)",
+      types::debug_level::NONE);
     const var<size_t> heap_size("HEAP_SIZE",
-                                "Size of the rocSHMEM symmetric heap in bytes (per PE). Note: heap is on GPU memory.",
-                                1L << 30);
+      "Defines the size of the rocSHMEM symmetric heap in bytes (per PE). Size in bytes (per PE); Note: the heap is on GPU memory",
+      1L << 30);
     const var<size_t> max_num_teams("MAX_NUM_TEAMS",
-                                    "Maximum number of teams an application can use",
-                                    40);
+      "Defines the number of teams an application can use.",
+      40);
     const var<size_t> max_num_host_contexts("MAX_NUM_HOST_CONTEXTS",
-                                            "Maximum number of host-side communication contexts",
-                                            1);
+      "Maximum number of host-side communication contexts",
+      1);
     const var<size_t> max_num_contexts("MAX_NUM_CONTEXTS",
-                                       "Maximum number of contexts an application can use",
-                                       32);
+      "Defines the number of contexts an application can use.",
+      32);
     const var<size_t> max_wavefront_buffers("MAX_WF_BUFFERS",
-                                            "Maximum number of wavefront buffer arrays in default context (determines size of status, return, and atomic return buffers)",
-                                            1024);
+      "Maximum number of wavefront buffer arrays in default context (determines size of status, return, and atomic return buffers)",
+      1024);
     const var<std::string> requested_nic("USE_IB_HCA",
-                                         "Specify which NIC this PE should bind to (e.g., 'bnxt_re0'). Empty string enables auto-detection.");
-    const var<std::string> hca_list("HCA_LIST", "");
+      "Forces the NIC that this PE uses. When this value is set NIC auto-detection and mapping is disabled, the NIC specified in the variable will be selected. The default value is an empty string and rocSHMEM auto-detects the most appropriate NIC. Example value: bnxt_re0");
+    const var<std::string> hca_list("HCA_LIST",
+      "Comma separated list of NIC names that can be used by rocSHMEM. Unlike ROCSHMEM_USE_IB_HCA, when this variable is set, NIC auto-detection and mapping still executes, but NICs that are not in the list are discarded before auto-detection runs. Prefixing the list with ^ turns the list in an exclude list, NICs that are in the list are discarded before auto-detection runs. The default value is an empty string and rocSHMEM auto-detects the most appropriate NIC. Example value: bnxt_re1,bnxt_re11, ^mlx5_0,mlx5_3");
     const var<uint32_t> sq_size("SQ_SIZE",
-                                "Send queue size for GDA backend",
-                                1024);
+      "Send queue size for GDA backend",
+      1024);
     const var<std::string> backend("BACKEND",
-                                   "Backend selection (ipc, ro, gda). Empty string enables auto-selection.");
+      "When rocSHMEM is compiled for all backends, this environment variable selects which backend to execute. The default value is an empty string and rocSHMEM auto-selects the most appropriate backend. ipc: IPC Backend; ro: Reverse Offload Backend; gda: GPU Direct Async Backend");
     const var<bool> disable_mixed_ipc("DISABLE_MIXED_IPC",
-                                      "Force using network conduit even when IPC is available",
-                                      false);
+      "Defines whether to force using the network conduit even when IPC is available. 0: Use IPC when available; 1: Force network conduit",
+      false);
     const var<bool> disable_ipc("DISABLE_IPC",
-                                "DEPRECATED: Synonym for ROCSHMEM_DISABLE_MIXED_IPC. Force using network conduit even when IPC is available",
-                                false);
+      "DEPRECATED: Synonym for ROCSHMEM_DISABLE_MIXED_IPC. Force using network conduit even when IPC is available",
+      false);
   }  // inline namespace _base
 
   namespace bootstrap {
     const var<int64_t> timeout("TIMEOUT",
-                               "Bootstrap initialization timeout in seconds",
-                               5);
+      "Bootstrap initialization timeout in seconds",
+      5);
     const var<std::string> hostid("HOSTID",
-                                  "Override host identifier for bootstrap. Empty string uses hostname.");
+      "Override host identifier for bootstrap. Empty string uses hostname.");
     const var<types::socket_family> socket_family("SOCKET_FAMILY",
-                                                  "Socket family for bootstrap (AF_UNSPEC, AF_INET, AF_INET6)",
-                                                  types::socket_family::UNSPEC);
+      "Socket family for bootstrap (AF_UNSPEC, AF_INET, AF_INET6)",
+      types::socket_family::UNSPEC);
     const var<std::string> socket_ifname("SOCKET_IFNAME",
-                                         "Interface to use for bootstrap (only valid when not using MPI, e.g., 'eno8303'). Empty string enables auto-detection.");
+      "Chooses the interface to bootstrap rocSHMEM with. Only valid when not using MPI. The default value is an empty string and rocSHMEM auto-detects the most appropriate interface. Example value: eno8303");
   }  // namespace bootstrap
 
   namespace ro {
     const var<bool> disable_ipc("DISABLE_IPC",
-                                "DEPRECATED: Synonym for ROCSHMEM_DISABLE_MIXED_IPC. Force using network conduit even when IPC is available",
-                                false);
+      "DEPRECATED: Synonym for ROCSHMEM_DISABLE_MIXED_IPC. Force using network conduit even when IPC is available",
+      false);
     const var<useconds_t> progress_delay("PROGRESS_DELAY",
-                                         "Progress engine delay in microseconds (reduces memory subsystem load for performance)",
-                                         3);
+      "Progress engine delay in microseconds (reduces memory subsystem load for performance)",
+      3);
     const var<bool> net_cpu_queue("NET_CPU_QUEUE",
-                                  "Use CPU queue for network operations in Reverse Offload backend",
-                                  false);
+      "Use CPU queue for network operations in Reverse Offload backend",
+      false);
   }  // namespace ro
 
   namespace gda {
     const var<std::string> provider("PROVIDER",
-                                    "NIC vendor selection (bnxt, pensando, ionic, mlx5). Empty string enables auto-detection.");
+      "When rocSHMEM is compiled with support for multiple NIC vendors, the environment variable selects the desired provider. The default value is an empty string and rocSHMEM auto-detects the most appropriate NIC. bnxt: Broadcom Thor 2; pensando: AMD Pensando Pollara; ionic: AMD Pensando Pollara (alias); mlx5: Mellanox ConnectX-7");
     const var<bool> alternate_qp_ports("ALTERNATE_QP_PORTS",
-                                       "Enable alternating QP mappings across rocSHMEM contexts (helps saturate bandwidth on multiport bonded interfaces)",
-                                       true);
+      "Enables or disables alternating QP mappings across rocSHMEM contexts. 0: Disabled; 1: Enabled. This helps saturate bandwidth on multiport bonded interfaces",
+      true);
     const var<uint8_t> traffic_class("TRAFFIC_CLASS",
-                                     "Traffic class for QPs when using Ethernet link layer",
-                                     0);
+      "When using an NIC with an Ethernet link layer, this sets the traffic class for the QPs.",
+      0);
     const var<bool> pcie_relaxed_ordering("PCIE_RELAXED_ORDERING",
-                                          "Enable PCIe Relaxed Ordering when registering symmetric heap with RDMA NICs",
-                                          false);
+      "Enables PCIe Relaxed Ordering when registering the symmetric heap with the RDMA NICs. 0: Disabled; 1: Enabled",
+      false);
     const var<bool> enable_dmabuf("ENABLE_DMABUF",
-                                  "Enable dmabuf support for memory registration",
-                                  false);
-    const var<bool> override_nic_firmware_check("OVERRIDE_NIC_FIRMWARE_CHECK", "", false);
-    const var<std::string> alltoallv_wg_algo("ALLTOALLV_WG_ALGO", "");
-    const var<uint32_t> sq_size("SQ_SIZE", "", 4096);
-    const var<size_t> num_qps_per_pe_default_ctx("NUM_QPS_PER_PE_DEFAULT_CTX", "", 1);
-    const var<size_t> num_qps_per_pe_usr_ctx("NUM_QPS_PER_PE_USR_CTX", "", 1);
+      "Enable dmabuf support for memory registration. 0: Disabled; 1: Enabled",
+      false);
+    const var<bool> override_nic_firmware_check("OVERRIDE_NIC_FIRMWARE_CHECK",
+      "This environment variable should be used with caution. It overrides the NIC firmware check if a user wants to use an unsupported NIC firmware. If the firmware check is disabled rocSHMEM is not guaranteed to work. 0: Disabled; 1: Enabled",
+      false);
+    const var<std::string> alltoallv_wg_algo("ALLTOALLV_WG_ALGO",
+      "Selects between two algorithms to use for GDA based alltoallv. The GET algorithm uses an initial round of alltoallv communication to distribute displacements then a second round to get transfer data. This algorithm has a higher latency but has better performance for large messages. The COPY algorithm does an alltoallv communication pattern into a staging buffer then does a copy into the destination buffers. This reduces latency but requires more memory, this algorithm only works for small messages.");
+    const var<uint32_t> sq_size("SQ_SIZE",
+      "This environment variable sets the length of the SQ for GDA. Maximum number of Work Queue Entries (WQEs) posted on the Send Queue (SQ)",
+      4096);
+    const var<size_t> num_qps_per_pe_default_ctx("NUM_QPS_PER_PE_DEFAULT_CTX",
+      "Sets the number of Queue Pairs (QPs) to create per PE for the default context.",
+      1);
+    const var<size_t> num_qps_per_pe_usr_ctx("NUM_QPS_PER_PE_USR_CTX",
+      "Sets the number of Queue Pairs (QPs) to create per PE for each user context.",
+      1);
   }  // namespace gda
 
   namespace _detail {

--- a/projects/rocshmem/src/envvar.hpp
+++ b/projects/rocshmem/src/envvar.hpp
@@ -295,8 +295,8 @@ namespace envvar {
         VERSION,
         WARN,
         ENV,
+        ENV_ALL,
         ENV_FULL,
-        ENV_PRETTY,
         INFO,
         TRACE,
       };
@@ -535,7 +535,7 @@ namespace envvar {
      * Print only modified variables (name=value)
      * Example: ROCSHMEM_HEAP_SIZE=2147483648
      */
-    MODIFIED_ONLY,
+    MODIFIED,
 
     /**
      * Print all variables with name and value
@@ -560,26 +560,26 @@ namespace envvar {
    * This function prints rocSHMEM environment variables in different formats
    * depending on the mode parameter.
    *
-   * @param mode Print mode (MODIFIED_ONLY, ALL_VALUES, or FULL_DOCUMENTATION)
+   * @param mode Print mode (MODIFIED, ALL_VALUES, or FULL_DOCUMENTATION)
    * @param os Output stream to write to (defaults to std::cout)
    *
    * Example usage:
    * @code
    *   // Print only modified variables
-   *   rocshmem::envvar::print_all_envvars(rocshmem::envvar::print_mode::MODIFIED_ONLY);
+   *   rocshmem::envvar::print_envvars(rocshmem::envvar::print_mode::MODIFIED);
    *
    *   // Print all variables with values
-   *   rocshmem::envvar::print_all_envvars(rocshmem::envvar::print_mode::ALL_VALUES);
+   *   rocshmem::envvar::print_envvars(rocshmem::envvar::print_mode::ALL_VALUES);
    *
    *   // Print full documentation
-   *   rocshmem::envvar::print_all_envvars(rocshmem::envvar::print_mode::FULL_DOCUMENTATION);
+   *   rocshmem::envvar::print_envvars(rocshmem::envvar::print_mode::FULL_DOCUMENTATION);
    * @endcode
    *
    * @note This function is thread-safe and acquires a lock on the internal
    *       environment variable map.
    */
-  void print_all_envvars(print_mode mode = print_mode::MODIFIED_ONLY,
-                         std::ostream& os = std::cout);
+  void print_envvars(print_mode mode = print_mode::MODIFIED,
+                     std::ostream& os = std::cout);
 
 }  // namespace envvar
 }  // namespace rocshmem

--- a/projects/rocshmem/src/envvar.hpp
+++ b/projects/rocshmem/src/envvar.hpp
@@ -294,6 +294,9 @@ namespace envvar {
         NONE,
         VERSION,
         WARN,
+        ENV,
+        ENV_FULL,
+        ENV_PRETTY,
         INFO,
         TRACE,
       };
@@ -523,6 +526,61 @@ namespace envvar {
     // Number of QPs to create per PE for each user context
     extern const var<size_t> num_qps_per_pe_usr_ctx;
   }  // namespace gda
+
+  /**
+   * @brief Print mode for environment variables
+   */
+  enum class print_mode {
+    /**
+     * Print only modified variables (name=value)
+     * Example: ROCSHMEM_HEAP_SIZE=2147483648
+     */
+    MODIFIED_ONLY,
+
+    /**
+     * Print all variables with name and value
+     * Example: ROCSHMEM_HEAP_SIZE=1073741824
+     */
+    ALL_VALUES,
+
+    /**
+     * Print all variables with full documentation (name, description, default, current)
+     * Example:
+     *   ROCSHMEM_HEAP_SIZE
+     *     Description: Size of symmetric heap...
+     *     Default: 1073741824
+     *     Current: 1073741824 (using default)
+     */
+    FULL_DOCUMENTATION
+  };
+
+  /**
+   * @brief Print rocSHMEM environment variables
+   *
+   * This function prints rocSHMEM environment variables in different formats
+   * depending on the mode parameter.
+   *
+   * @param mode Print mode (MODIFIED_ONLY, ALL_VALUES, or FULL_DOCUMENTATION)
+   * @param os Output stream to write to (defaults to std::cout)
+   *
+   * Example usage:
+   * @code
+   *   // Print only modified variables
+   *   rocshmem::envvar::print_all_envvars(rocshmem::envvar::print_mode::MODIFIED_ONLY);
+   *
+   *   // Print all variables with values
+   *   rocshmem::envvar::print_all_envvars(rocshmem::envvar::print_mode::ALL_VALUES);
+   *
+   *   // Print full documentation
+   *   rocshmem::envvar::print_all_envvars(rocshmem::envvar::print_mode::FULL_DOCUMENTATION);
+   * @endcode
+   *
+   * @note This function is thread-safe and acquires a lock on the internal
+   *       environment variable map.
+   */
+  void print_all_envvars(print_mode mode = print_mode::MODIFIED_ONLY,
+                         std::ostream& os = std::cout);
+
 }  // namespace envvar
 }  // namespace rocshmem
 

--- a/projects/rocshmem/src/rocshmem.cpp
+++ b/projects/rocshmem/src/rocshmem.cpp
@@ -185,13 +185,13 @@ static void setFilesLimit() {
       debug_val == debug_level::ENV_PRETTY) {
     envvar::print_mode mode;
     if (debug_val == debug_level::ENV) {
-      mode = envvar::print_mode::MODIFIED_ONLY;
+      mode = envvar::print_mode::MODIFIED;
     } else if (debug_val == debug_level::ENV_FULL) {
       mode = envvar::print_mode::ALL_VALUES;
     } else {
       mode = envvar::print_mode::FULL_DOCUMENTATION;
     }
-    envvar::print_all_envvars(mode, std::cout);
+    envvar::print_envvars(mode, std::cout);
   }
 
   int ret;
@@ -322,13 +322,13 @@ static void setFilesLimit() {
       debug_val == debug_level::ENV_PRETTY) {
     envvar::print_mode mode;
     if (debug_val == debug_level::ENV) {
-      mode = envvar::print_mode::MODIFIED_ONLY;
+      mode = envvar::print_mode::MODIFIED;
     } else if (debug_val == debug_level::ENV_FULL) {
       mode = envvar::print_mode::ALL_VALUES;
     } else {
       mode = envvar::print_mode::FULL_DOCUMENTATION;
     }
-    envvar::print_all_envvars(mode, std::cout);
+    envvar::print_envvars(mode, std::cout);
   }
 
 #if defined(USE_GDA) && defined(USE_RO) && defined(USE_IPC)

--- a/projects/rocshmem/src/rocshmem.cpp
+++ b/projects/rocshmem/src/rocshmem.cpp
@@ -177,6 +177,23 @@ static void setFilesLimit() {
   setFilesLimit();
   rocm_init();
 
+  // Print environment variables if DEBUG_LEVEL is set to ENV modes
+  using rocshmem::envvar::types::debug_level;
+  auto debug_val = envvar::debug_level.get_value();
+  if (debug_val == debug_level::ENV ||
+      debug_val == debug_level::ENV_FULL ||
+      debug_val == debug_level::ENV_PRETTY) {
+    envvar::print_mode mode;
+    if (debug_val == debug_level::ENV) {
+      mode = envvar::print_mode::MODIFIED_ONLY;
+    } else if (debug_val == debug_level::ENV_FULL) {
+      mode = envvar::print_mode::ALL_VALUES;
+    } else {
+      mode = envvar::print_mode::FULL_DOCUMENTATION;
+    }
+    envvar::print_all_envvars(mode, std::cout);
+  }
+
   int ret;
   ret = MPIInstance::mpilib_dl_init();
   if (ret != ROCSHMEM_SUCCESS) {
@@ -296,6 +313,23 @@ static void setFilesLimit() {
 
   setFilesLimit();
   rocm_init();
+
+  // Print environment variables if DEBUG_LEVEL is set to ENV modes
+  using rocshmem::envvar::types::debug_level;
+  auto debug_val = envvar::debug_level.get_value();
+  if (debug_val == debug_level::ENV ||
+      debug_val == debug_level::ENV_FULL ||
+      debug_val == debug_level::ENV_PRETTY) {
+    envvar::print_mode mode;
+    if (debug_val == debug_level::ENV) {
+      mode = envvar::print_mode::MODIFIED_ONLY;
+    } else if (debug_val == debug_level::ENV_FULL) {
+      mode = envvar::print_mode::ALL_VALUES;
+    } else {
+      mode = envvar::print_mode::FULL_DOCUMENTATION;
+    }
+    envvar::print_all_envvars(mode, std::cout);
+  }
 
 #if defined(USE_GDA) && defined(USE_RO) && defined(USE_IPC)
   BackendType type = select_backend_type(MPI_COMM_NULL, bootstrap);

--- a/projects/rocshmem/src/rocshmem.cpp
+++ b/projects/rocshmem/src/rocshmem.cpp
@@ -181,12 +181,12 @@ static void setFilesLimit() {
   using rocshmem::envvar::types::debug_level;
   auto debug_val = envvar::debug_level.get_value();
   if (debug_val == debug_level::ENV ||
-      debug_val == debug_level::ENV_FULL ||
-      debug_val == debug_level::ENV_PRETTY) {
+      debug_val == debug_level::ENV_ALL ||
+      debug_val == debug_level::ENV_FULL) {
     envvar::print_mode mode;
     if (debug_val == debug_level::ENV) {
       mode = envvar::print_mode::MODIFIED;
-    } else if (debug_val == debug_level::ENV_FULL) {
+    } else if (debug_val == debug_level::ENV_ALL) {
       mode = envvar::print_mode::ALL_VALUES;
     } else {
       mode = envvar::print_mode::FULL_DOCUMENTATION;
@@ -318,12 +318,12 @@ static void setFilesLimit() {
   using rocshmem::envvar::types::debug_level;
   auto debug_val = envvar::debug_level.get_value();
   if (debug_val == debug_level::ENV ||
-      debug_val == debug_level::ENV_FULL ||
-      debug_val == debug_level::ENV_PRETTY) {
+      debug_val == debug_level::ENV_ALL ||
+      debug_val == debug_level::ENV_FULL) {
     envvar::print_mode mode;
     if (debug_val == debug_level::ENV) {
       mode = envvar::print_mode::MODIFIED;
-    } else if (debug_val == debug_level::ENV_FULL) {
+    } else if (debug_val == debug_level::ENV_ALL) {
       mode = envvar::print_mode::ALL_VALUES;
     } else {
       mode = envvar::print_mode::FULL_DOCUMENTATION;

--- a/projects/rocshmem/src/tools/rocshmem_info.cpp
+++ b/projects/rocshmem/src/tools/rocshmem_info.cpp
@@ -23,8 +23,10 @@
  *****************************************************************************/
 
 #include "util.hpp"
+#include "envvar.hpp"
 
 #include <stdio.h>
+#include <cstring>
 #include <fstream>
 #include <iostream>
 #include <string>
@@ -145,7 +147,74 @@ void print_rocm_info() {
   PRINT_ENTRY("ROCm", rocm_version);
 }
 
+void print_usage(const char* progname) {
+  std::cout << "Usage: " << progname << " [OPTIONS]\n\n";
+  std::cout << "Display rocSHMEM build information and environment variables.\n\n";
+  std::cout << "Options:\n";
+  std::cout << "  -h, --help       Show this help message\n";
+  std::cout << "  -o FILE          Write output to FILE instead of stdout\n";
+  std::cout << "  --env            Print only modified environment variables (name=value)\n";
+  std::cout << "  --envfull        Print all environment variables (name=value)\n";
+  std::cout << "  --envpretty      Print all environment variables with full documentation\n";
+  std::cout << "\n";
+  std::cout << "Default mode: Display build information only\n";
+  std::cout << "\n";
+  std::cout << "Examples:\n";
+  std::cout << "  " << progname << "                    # Show build information\n";
+  std::cout << "  " << progname << " --env              # Show build info + modified env vars\n";
+  std::cout << "  " << progname << " --envfull          # Show build info + all env vars\n";
+  std::cout << "  " << progname << " --envpretty        # Show build info + env vars with docs\n";
+  std::cout << "  " << progname << " --env -o info.txt  # Write to file\n";
+}
+
 int main ([[maybe_unused]] int argc, [[maybe_unused]] char **argv) {
+  const char* output_file = nullptr;
+  bool print_env = false;
+  rocshmem::envvar::print_mode env_mode = rocshmem::envvar::print_mode::MODIFIED_ONLY;
+
+  // Parse command line arguments
+  for (int i = 1; i < argc; i++) {
+    if (std::strcmp(argv[i], "-h") == 0 || std::strcmp(argv[i], "--help") == 0) {
+      print_usage(argv[0]);
+      return 0;
+    } else if (std::strcmp(argv[i], "-o") == 0) {
+      if (i + 1 < argc) {
+        output_file = argv[++i];
+      } else {
+        std::cerr << "Error: -o requires a filename argument\n";
+        print_usage(argv[0]);
+        return 1;
+      }
+    } else if (std::strcmp(argv[i], "--env") == 0) {
+      print_env = true;
+      env_mode = rocshmem::envvar::print_mode::MODIFIED_ONLY;
+    } else if (std::strcmp(argv[i], "--envfull") == 0) {
+      print_env = true;
+      env_mode = rocshmem::envvar::print_mode::ALL_VALUES;
+    } else if (std::strcmp(argv[i], "--envpretty") == 0) {
+      print_env = true;
+      env_mode = rocshmem::envvar::print_mode::FULL_DOCUMENTATION;
+    } else {
+      std::cerr << "Error: Unknown option: " << argv[i] << "\n";
+      print_usage(argv[0]);
+      return 1;
+    }
+  }
+
+  // Redirect output if requested
+  std::ofstream file;
+  std::streambuf* cout_buf = std::cout.rdbuf();
+  std::streambuf* cerr_buf = std::cerr.rdbuf();
+
+  if (output_file) {
+    file.open(output_file);
+    if (!file) {
+      std::cerr << "Error: Could not open file '" << output_file << "' for writing\n";
+      return 1;
+    }
+    std::cout.rdbuf(file.rdbuf());
+    std::cerr.rdbuf(file.rdbuf());
+  }
 
   printf("################################################################################\n");
   printf("#                                rocSHMEM Info                                 #\n");
@@ -168,5 +237,20 @@ int main ([[maybe_unused]] int argc, [[maybe_unused]] char **argv) {
   rocshmem::DisplayTopology(false);
   printf("################################################################################\n");
 #endif //defined(USE_GDA)
+
+  // Print environment variables if requested
+  if (print_env) {
+    std::cout << "\n";
+    rocshmem::envvar::print_all_envvars(env_mode, std::cout);
+  }
+
+  // Restore cout/cerr if redirected
+  if (output_file) {
+    std::cout.rdbuf(cout_buf);
+    std::cerr.rdbuf(cerr_buf);
+    file.close();
+    std::cout << "Information written to: " << output_file << "\n";
+  }
+
   return 0;
 }

--- a/projects/rocshmem/src/tools/rocshmem_info.cpp
+++ b/projects/rocshmem/src/tools/rocshmem_info.cpp
@@ -170,7 +170,7 @@ void print_usage(const char* progname) {
 int main ([[maybe_unused]] int argc, [[maybe_unused]] char **argv) {
   const char* output_file = nullptr;
   bool print_env = false;
-  rocshmem::envvar::print_mode env_mode = rocshmem::envvar::print_mode::MODIFIED_ONLY;
+  rocshmem::envvar::print_mode env_mode = rocshmem::envvar::print_mode::MODIFIED;
 
   // Parse command line arguments
   for (int i = 1; i < argc; i++) {
@@ -187,7 +187,7 @@ int main ([[maybe_unused]] int argc, [[maybe_unused]] char **argv) {
       }
     } else if (std::strcmp(argv[i], "--env") == 0) {
       print_env = true;
-      env_mode = rocshmem::envvar::print_mode::MODIFIED_ONLY;
+      env_mode = rocshmem::envvar::print_mode::MODIFIED;
     } else if (std::strcmp(argv[i], "--envfull") == 0) {
       print_env = true;
       env_mode = rocshmem::envvar::print_mode::ALL_VALUES;
@@ -241,7 +241,7 @@ int main ([[maybe_unused]] int argc, [[maybe_unused]] char **argv) {
   // Print environment variables if requested
   if (print_env) {
     std::cout << "\n";
-    rocshmem::envvar::print_all_envvars(env_mode, std::cout);
+    rocshmem::envvar::print_envvars(env_mode, std::cout);
   }
 
   // Restore cout/cerr if redirected

--- a/projects/rocshmem/src/tools/rocshmem_info.cpp
+++ b/projects/rocshmem/src/tools/rocshmem_info.cpp
@@ -153,23 +153,18 @@ void print_usage(const char* progname) {
   std::cout << "Options:\n";
   std::cout << "  -h, --help       Show this help message\n";
   std::cout << "  -o FILE          Write output to FILE instead of stdout\n";
-  std::cout << "  --env            Print only modified environment variables (name=value)\n";
-  std::cout << "  --envfull        Print all environment variables (name=value)\n";
-  std::cout << "  --envpretty      Print all environment variables with full documentation\n";
+  std::cout << "  --env:all        Print all environment variables (name=value)\n";
+  std::cout << "  --env:full       Print all environment variables with full documentation\n";
   std::cout << "\n";
-  std::cout << "Default mode: Display build information only\n";
+  std::cout << "Default mode: Display build information and modified env vars\n";
   std::cout << "\n";
   std::cout << "Examples:\n";
-  std::cout << "  " << progname << "                    # Show build information\n";
-  std::cout << "  " << progname << " --env              # Show build info + modified env vars\n";
-  std::cout << "  " << progname << " --envfull          # Show build info + all env vars\n";
-  std::cout << "  " << progname << " --envpretty        # Show build info + env vars with docs\n";
-  std::cout << "  " << progname << " --env -o info.txt  # Write to file\n";
+  std::cout << "  " << progname << " --env:all          # Show build info + all env vars\n";
+  std::cout << "  " << progname << " --env:full         # Show build info + env vars with docs\n";
 }
 
 int main ([[maybe_unused]] int argc, [[maybe_unused]] char **argv) {
   const char* output_file = nullptr;
-  bool print_env = false;
   rocshmem::envvar::print_mode env_mode = rocshmem::envvar::print_mode::MODIFIED;
 
   // Parse command line arguments
@@ -185,14 +180,9 @@ int main ([[maybe_unused]] int argc, [[maybe_unused]] char **argv) {
         print_usage(argv[0]);
         return 1;
       }
-    } else if (std::strcmp(argv[i], "--env") == 0) {
-      print_env = true;
-      env_mode = rocshmem::envvar::print_mode::MODIFIED;
-    } else if (std::strcmp(argv[i], "--envfull") == 0) {
-      print_env = true;
+    } else if (std::strcmp(argv[i], "--env:all") == 0) {
       env_mode = rocshmem::envvar::print_mode::ALL_VALUES;
-    } else if (std::strcmp(argv[i], "--envpretty") == 0) {
-      print_env = true;
+    } else if (std::strcmp(argv[i], "--env:full") == 0) {
       env_mode = rocshmem::envvar::print_mode::FULL_DOCUMENTATION;
     } else {
       std::cerr << "Error: Unknown option: " << argv[i] << "\n";
@@ -233,16 +223,15 @@ int main ([[maybe_unused]] int argc, [[maybe_unused]] char **argv) {
   }
 
   printf("################################################################################\n");
+  std::cout << "\n";
+  rocshmem::envvar::print_envvars(env_mode, std::cout);
+  printf("################################################################################\n");
+
 #if defined(USE_GDA)
+  printf("\n################################################################################");
   rocshmem::DisplayTopology(false);
   printf("################################################################################\n");
 #endif //defined(USE_GDA)
-
-  // Print environment variables if requested
-  if (print_env) {
-    std::cout << "\n";
-    rocshmem::envvar::print_envvars(env_mode, std::cout);
-  }
 
   // Restore cout/cerr if redirected
   if (output_file) {

--- a/projects/rocshmem/src/tools/rocshmem_info.cpp
+++ b/projects/rocshmem/src/tools/rocshmem_info.cpp
@@ -152,7 +152,6 @@ void print_usage(const char* progname) {
   std::cout << "Display rocSHMEM build information and environment variables.\n\n";
   std::cout << "Options:\n";
   std::cout << "  -h, --help       Show this help message\n";
-  std::cout << "  -o FILE          Write output to FILE instead of stdout\n";
   std::cout << "  --env:all        Print all environment variables (name=value)\n";
   std::cout << "  --env:full       Print all environment variables with full documentation\n";
   std::cout << "\n";
@@ -163,8 +162,7 @@ void print_usage(const char* progname) {
   std::cout << "  " << progname << " --env:full         # Show build info + env vars with docs\n";
 }
 
-int main ([[maybe_unused]] int argc, [[maybe_unused]] char **argv) {
-  const char* output_file = nullptr;
+int main (int argc, char **argv) {
   rocshmem::envvar::print_mode env_mode = rocshmem::envvar::print_mode::MODIFIED;
 
   // Parse command line arguments
@@ -172,14 +170,6 @@ int main ([[maybe_unused]] int argc, [[maybe_unused]] char **argv) {
     if (std::strcmp(argv[i], "-h") == 0 || std::strcmp(argv[i], "--help") == 0) {
       print_usage(argv[0]);
       return 0;
-    } else if (std::strcmp(argv[i], "-o") == 0) {
-      if (i + 1 < argc) {
-        output_file = argv[++i];
-      } else {
-        std::cerr << "Error: -o requires a filename argument\n";
-        print_usage(argv[0]);
-        return 1;
-      }
     } else if (std::strcmp(argv[i], "--env:all") == 0) {
       env_mode = rocshmem::envvar::print_mode::ALL_VALUES;
     } else if (std::strcmp(argv[i], "--env:full") == 0) {
@@ -189,21 +179,6 @@ int main ([[maybe_unused]] int argc, [[maybe_unused]] char **argv) {
       print_usage(argv[0]);
       return 1;
     }
-  }
-
-  // Redirect output if requested
-  std::ofstream file;
-  std::streambuf* cout_buf = std::cout.rdbuf();
-  std::streambuf* cerr_buf = std::cerr.rdbuf();
-
-  if (output_file) {
-    file.open(output_file);
-    if (!file) {
-      std::cerr << "Error: Could not open file '" << output_file << "' for writing\n";
-      return 1;
-    }
-    std::cout.rdbuf(file.rdbuf());
-    std::cerr.rdbuf(file.rdbuf());
   }
 
   printf("################################################################################\n");
@@ -232,14 +207,6 @@ int main ([[maybe_unused]] int argc, [[maybe_unused]] char **argv) {
   rocshmem::DisplayTopology(false);
   printf("################################################################################\n");
 #endif //defined(USE_GDA)
-
-  // Restore cout/cerr if redirected
-  if (output_file) {
-    std::cout.rdbuf(cout_buf);
-    std::cerr.rdbuf(cerr_buf);
-    file.close();
-    std::cout << "Information written to: " << output_file << "\n";
-  }
 
   return 0;
 }


### PR DESCRIPTION
## Motivation

Let users introspect what environment variables are available and active. Helps debugging.

## Technical Details

Add print_envvars routine, read ROCSHMEM_DEBUG_LEVEL and print the values conditioned on that configuration. Integrate with rocshmem_info. 3 modes: modified only, all, all+doc.

## JIRA ID

AIROCSHMEM-286
AIROCSHMEM-180

## Test Plan

* Run rocshmem_info --env:full: envvars and doc printed
* Run `mpiexec -n 1 -x ROCSHMEM_DEBUG_LEVEL=ENV -x ROCSHMEM_BACKEND=gda -x ROCSHMEM_DISABLE_MIXED_IPC=1 -x ROCSHMEM_TEST_UUID=1 tests/functional_tests/rocshmem_functional_tests -a 83 -w 1 -z 1`: modified envvars printed

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
