### PR TITLE
[rocshmem] gda/mlx5: reduce CQ depth to 1 (collapsed CQ)

### DIFF
--- a/projects/rocshmem/scripts/functional_tests/driver.sh
+++ b/projects/rocshmem/scripts/functional_tests/driver.sh
@@ -349,24 +349,20 @@ TestAMO() {
   ExecTest  "amo_add"          2       8            1
   ExecTest  "amo_add"          2       32           128
 
-  if [[ $TEST != gda* ]]; then #AIROCSHMEM-316
   ExecTest  "amo_fadd"         2       1            1
   ExecTest  "amo_fadd"         2       1            1024
   ExecTest  "amo_fadd"         2       8            1
   ExecTest  "amo_fadd"         2       32           128
-  else echo "Skip:   amo_fadd* (AIROCSHMEM-316: mlx5 fetch_amo return 0)"; fi
 
   ExecTest  "amo_inc"          2       1            1
   ExecTest  "amo_inc"          2       1            1024
   ExecTest  "amo_inc"          2       8            1
   ExecTest  "amo_inc"          2       32           128
 
-  if [[ $TEST != gda* ]]; then #AIROCSHMEM-316
   ExecTest  "amo_finc"         2       1            1
   ExecTest  "amo_finc"         2       1            1024
   ExecTest  "amo_finc"         2       8            1
   ExecTest  "amo_finc"         2       32           128
-  else echo "Skip:   amo_finc* (AIROCSHMEM-316: mlx5 fetch_amo return 0)"; fi
   else echo "Skip:   amo_add* (AIROCSHMEM-211: ro amo abort)"; fi
 
   ExecTest  "amo_set"          2       1            1

--- a/projects/rocshmem/src/gda/mlx5/provider_gda_mlx5.cpp
+++ b/projects/rocshmem/src/gda/mlx5/provider_gda_mlx5.cpp
@@ -138,8 +138,11 @@ struct mlx5_qp_umem_alloc_info {
   // WQ always at beginning of umem allocation
   static constexpr size_t wq_offset = 0;
 
+  // use only one CQE
+  static constexpr size_t cq_depth = 1;
+
   // align CQ and doorbell records to cache line size
-  static constexpr size_t cq_size       = mlx5_align_amdgpu_cache_line(sizeof(mlx5_cqe64[2]));
+  static constexpr size_t cq_size       = mlx5_align_amdgpu_cache_line(sizeof(mlx5_cqe64[cq_depth]));
   static constexpr size_t qp_dbrec_size = mlx5_align_amdgpu_cache_line(MLX5_DOORBELL_RECORD_SIZE);
   static constexpr size_t cq_dbrec_size = mlx5_align_amdgpu_cache_line(MLX5_DOORBELL_RECORD_SIZE);
 
@@ -206,13 +209,6 @@ static inline mlx5dv_devx_umem* mlx5_umem_reg(const mlx5dv_funcs_t& mlx5dv,
   }
 
   return umem;
-}
-
-static inline void mlx5_initialize_cq_buffer(mlx5_cqe64* cq, uint32_t cq_depth) {
-  // CQEs must have opcode set to Invalid = 0xF and be in hardware ownership
-  constexpr uint8_t op_own_init = (MLX5_CQE_INVALID << 4) | MLX5_CQE_OWNER_MASK;
-  // simplest way is to set all bytes in the CQ to op_own_init = 0xF1
-  QPAllocator::memset(cq, op_own_init, sizeof(mlx5_cqe64) * cq_depth);
 }
 
 static inline uint32_t mlx5_pdn(const mlx5dv_funcs_t& mlx5dv, struct ibv_pd *pd) {
@@ -411,9 +407,10 @@ static int mlx5_create_cq(const mlx5dv_funcs_t& mlx5dv, mlx5_devx_qp& qp) {
 
   DEVX_SET(create_cq_in, in, opcode, MLX5_CMD_OP_CREATE_CQ);
 
-  // use CQ length 2 until we enable true 1-CQE/collapsed CQ
-  constexpr uint32_t cq_depth = 2;
-  mlx5_initialize_cq_buffer(reinterpret_cast<mlx5_cqe64*>(qp.cq), cq_depth);
+  // CQEs must be initialized with opcode set to Invalid = 0xF and in hardware ownership
+  constexpr uint8_t op_own_init = (MLX5_CQE_INVALID << 4) | MLX5_CQE_OWNER_MASK;
+  // simplest way is to set all bytes in the CQ to op_own_init = 0xF1
+  QPAllocator::memset(qp.cq, op_own_init, sizeof(mlx5_cqe64[mlx5_qp_umem_alloc_info::cq_depth]));
 
   // get EQN, we don't use it but it needs to be set when creating the CQ
   uint32_t eqn = 0;
@@ -421,9 +418,11 @@ static int mlx5_create_cq(const mlx5dv_funcs_t& mlx5dv, mlx5_devx_qp& qp) {
   CHECK_ZERO(err, "mlx5dv_devx_query_eqn");
 
   DEVX_SET(cqc, cqc, cqe_sz,               MLX5_CQC_CQE_SZ_64_BYTES);
+  // set CQE collapsing so all CQEs are written to first CQ entry
+  DEVX_SET(cqc, cqc, cc,                   true);
   // set overrun ignore so that we don't need to ring the CQ doorbell
   DEVX_SET(cqc, cqc, oi,                   true);
-  DEVX_SET(cqc, cqc, log_cq_size,          bit_log2(cq_depth));
+  DEVX_SET(cqc, cqc, log_cq_size,          bit_log2(mlx5_qp_umem_alloc_info::cq_depth));
   // we don't ring the CQ doorbell anyway
   DEVX_SET(cqc, cqc, uar_page,             qp.uar->page_id);
   DEVX_SET(cqc, cqc, c_eqn_or_ext_element, eqn);
@@ -640,6 +639,7 @@ void mlx5_devx_qp::dump([[maybe_unused]] int conn_num) {
   DPRINTF("  (uint32_t*) qp_dbrec         = %p\n",    this->qp_dbrec);
   DPRINTF("  (uint32_t)  cqn              = 0x%x\n",  this->cqn);
   DPRINTF("  (void*)     cq               = %p\n",    this->cq);
+  DPRINTF("  (uint32_t)  cq_depth         = %u\n",    mlx5_qp_umem_alloc_info::cq_depth);
   DPRINTF("  (uint32_t*) cq_dbrec         = %p\n",    this->cq_dbrec);
   DPRINTF("  (void*)     uar->reg_addr    = %p\n",    this->uar->reg_addr);
   DPRINTF("  (void*)     uar->base_addr   = %p\n",    this->uar->base_addr);

--- a/projects/rocshmem/src/gda/mlx5/provider_gda_mlx5.cpp
+++ b/projects/rocshmem/src/gda/mlx5/provider_gda_mlx5.cpp
@@ -142,7 +142,7 @@ struct mlx5_qp_umem_alloc_info {
   static constexpr size_t cq_depth = 1;
 
   // align CQ and doorbell records to cache line size
-  static constexpr size_t cq_size       = mlx5_align_amdgpu_cache_line(sizeof(mlx5_cqe64[cq_depth]));
+  static constexpr size_t cq_size       = mlx5_align_amdgpu_cache_line(sizeof(mlx5_cqe64) * cq_depth);
   static constexpr size_t qp_dbrec_size = mlx5_align_amdgpu_cache_line(MLX5_DOORBELL_RECORD_SIZE);
   static constexpr size_t cq_dbrec_size = mlx5_align_amdgpu_cache_line(MLX5_DOORBELL_RECORD_SIZE);
 
@@ -309,6 +309,7 @@ int mlx5dv_funcs_t::create_qp(mlx5_devx_qp& qp, struct ibv_context *ctx,
   qp.cq       = umem_alloc_info.cq_addr(umem_buffer);
   qp.cq_dbrec = umem_alloc_info.cq_dbrec_addr(umem_buffer);
   qp.qp_dbrec = umem_alloc_info.qp_dbrec_addr(umem_buffer);
+  qp.cq_depth = umem_alloc_info.cq_depth;
   qp.sq_depth = umem_alloc_info.sq_depth;
 
   /* allocate UAR
@@ -392,6 +393,7 @@ int mlx5dv_funcs_t::destroy_qp(mlx5_devx_qp& qp) {
   qp.qp_dbrec    = nullptr;
   qp.cqn         = 0;
   qp.qpn         = 0;
+  qp.cq_depth    = 0;
   qp.sq_depth    = 0;
 
   return err;
@@ -410,7 +412,7 @@ static int mlx5_create_cq(const mlx5dv_funcs_t& mlx5dv, mlx5_devx_qp& qp) {
   // CQEs must be initialized with opcode set to Invalid = 0xF and in hardware ownership
   constexpr uint8_t op_own_init = (MLX5_CQE_INVALID << 4) | MLX5_CQE_OWNER_MASK;
   // simplest way is to set all bytes in the CQ to op_own_init = 0xF1
-  QPAllocator::memset(qp.cq, op_own_init, sizeof(mlx5_cqe64[mlx5_qp_umem_alloc_info::cq_depth]));
+  QPAllocator::memset(qp.cq, op_own_init, sizeof(mlx5_cqe64) * qp.cq_depth);
 
   // get EQN, we don't use it but it needs to be set when creating the CQ
   uint32_t eqn = 0;
@@ -422,7 +424,7 @@ static int mlx5_create_cq(const mlx5dv_funcs_t& mlx5dv, mlx5_devx_qp& qp) {
   DEVX_SET(cqc, cqc, cc,                   true);
   // set overrun ignore so that we don't need to ring the CQ doorbell
   DEVX_SET(cqc, cqc, oi,                   true);
-  DEVX_SET(cqc, cqc, log_cq_size,          bit_log2(mlx5_qp_umem_alloc_info::cq_depth));
+  DEVX_SET(cqc, cqc, log_cq_size,          bit_log2(qp.cq_depth));
   // we don't ring the CQ doorbell anyway
   DEVX_SET(cqc, cqc, uar_page,             qp.uar->page_id);
   DEVX_SET(cqc, cqc, c_eqn_or_ext_element, eqn);
@@ -639,7 +641,7 @@ void mlx5_devx_qp::dump([[maybe_unused]] int conn_num) {
   DPRINTF("  (uint32_t*) qp_dbrec         = %p\n",    this->qp_dbrec);
   DPRINTF("  (uint32_t)  cqn              = 0x%x\n",  this->cqn);
   DPRINTF("  (void*)     cq               = %p\n",    this->cq);
-  DPRINTF("  (uint32_t)  cq_depth         = %u\n",    mlx5_qp_umem_alloc_info::cq_depth);
+  DPRINTF("  (uint32_t)  cq_depth         = %u\n",    this->cq_depth);
   DPRINTF("  (uint32_t*) cq_dbrec         = %p\n",    this->cq_dbrec);
   DPRINTF("  (void*)     uar->reg_addr    = %p\n",    this->uar->reg_addr);
   DPRINTF("  (void*)     uar->base_addr   = %p\n",    this->uar->base_addr);

--- a/projects/rocshmem/src/gda/mlx5/provider_gda_mlx5.hpp
+++ b/projects/rocshmem/src/gda/mlx5/provider_gda_mlx5.hpp
@@ -312,6 +312,7 @@ struct mlx5_devx_qp {
   uint32_t*         qp_dbrec;
   uint32_t          cqn;
   uint32_t          qpn;
+  uint32_t          cq_depth;
   uint16_t          sq_depth;
 
   void dump(int conn_num);

--- a/projects/rocshmem/src/gda/mlx5/provider_gda_mlx5.hpp
+++ b/projects/rocshmem/src/gda/mlx5/provider_gda_mlx5.hpp
@@ -257,10 +257,9 @@ template <typename T>
 struct gda_mlx5_device_queue {
   T* buf;
   __be32* dbrec;
-  uint32_t lock;
 
   __host__ inline gda_mlx5_device_queue(T* buf, __be32* dbrec)
-    : buf{buf}, dbrec{dbrec}, lock{0} { }
+    : buf{buf}, dbrec{dbrec} { }
 
   __host__ inline gda_mlx5_device_queue() : gda_mlx5_device_queue{nullptr, nullptr} { }
 };
@@ -273,13 +272,13 @@ struct gda_mlx5_device_cq : public gda_mlx5_device_queue<mlx5_cqe64> {
 struct gda_mlx5_device_sq : public gda_mlx5_device_queue<gda_mlx5_wqe> {
   gda_mlx5_doorbell* db;
   uint64_t post;
+  uint32_t lock;
   uint16_t depth;
-  uint16_t tail;
 
   __host__ inline gda_mlx5_device_sq(gda_mlx5_wqe* buf, __be32* dbrec,
                                      gda_mlx5_doorbell* db, uint16_t depth)
     : gda_mlx5_device_queue{buf, dbrec},
-      db{db}, post{0}, depth{depth}, tail{0} { }
+      db{db}, post{0}, lock{0}, depth{depth} { }
 
   __host__ inline gda_mlx5_device_sq() : gda_mlx5_device_sq{nullptr, nullptr, nullptr, 0} { }
 
@@ -291,7 +290,8 @@ struct gda_mlx5_device_sq : public gda_mlx5_device_queue<gda_mlx5_wqe> {
 /*
  * QP layout:
  * [ [ WQ: WQE | WQE | WQE | ... | WQE ] : 64 * 2^N
- *   [ CQ: CQE | CQE ]                   : 64 * 2
+ *   [ CQ: CQE ]                         : 64
+ *   [ padding - to AMDGPU cache line  ] : 64
  *   [ padding - to page table - 256   ] : 3712 - max(4096 - 64 * 2^N, 0)
  *   [ SQ DBREC ]                        : 8
  *   [ padding - to AMDGPU cache line  ] : 120

--- a/projects/rocshmem/src/gda/mlx5/queue_pair_mlx5.cpp
+++ b/projects/rocshmem/src/gda/mlx5/queue_pair_mlx5.cpp
@@ -68,10 +68,12 @@ __device__ static inline void release_lock(uint32_t *lock) {
 }
 
 __device__ static inline uint16_t mlx5_wqe_idx(const gda_mlx5_device_sq& sq, uint8_t lane_id) {
-  return sq.tail + lane_id;
+  return static_cast<uint16_t>(sq.post + lane_id);
 }
 
-__device__ void QueuePair::mlx5_ring_doorbell(uint16_t sq_wqebb_counter, const gda_mlx5_wqe& wqe) {
+__device__ void QueuePair::mlx5_ring_doorbell(uint64_t sq_post, const gda_mlx5_wqe& wqe) {
+  // sq_wqebb_counter is the least significant bits of the post counter
+  uint16_t sq_wqebb_counter = static_cast<uint16_t>(sq_post);
   // gda_mlx5_db_register constructor extracts first 8 bytes of WQE
   gda_mlx5_db_register db_val{wqe};
   __be32 be_sq_wqebb_counter = endian::to_be<uint32_t>(sq_wqebb_counter);
@@ -179,14 +181,6 @@ __device__ void QueuePair::mlx5_check_cqe_error(const mlx5_cqe64* cqe) {
   abort();
 }
 
-template <typename T>
-__device__ static inline bool hip_atomic_compare(T* obj, T* expected, int order, int scope) {
-  T exp = *expected;
-  T val = __hip_atomic_load(obj, order, scope);
-  *expected = val;
-  return val == exp;
-}
-
 __device__ void QueuePair::mlx5_poll_cq_until(uint16_t requested_available_slots) {
   uint16_t consumed_slots;
   uint16_t available_slots;
@@ -194,19 +188,13 @@ __device__ void QueuePair::mlx5_poll_cq_until(uint16_t requested_available_slots
   uint16_t sq_depth = mlx5_sq.depth;
 
   uint64_t sq_post = __hip_atomic_load(&mlx5_sq.post, __ATOMIC_ACQUIRE, __HIP_MEMORY_SCOPE_AGENT);
-  // don't need to check CQEs if we haven't ever filled SQ and there's enough space left
-  if (sq_post <= static_cast<uint64_t>((sq_depth - requested_available_slots))) {
+  // don't need to check CQ if we haven't ever filled SQ and there's enough space left
+  if (sq_post + requested_available_slots <= sq_depth) {
     return;
   }
 
-  do {
-    /* sq_post counts the number of posted WQEs
-     *  odd count -> CQ[0]
-     * even count -> CQ[1]
-     * so use CQ[1 - (sq_post % 2)]
-     * or equivalently CQ[(sq_post + 1) % 2], etc.
-     */
-    struct mlx5_cqe64* cqe = &mlx5_cq.buf[1 - (sq_post  % 2)];
+  while (true) {
+    struct mlx5_cqe64* cqe = mlx5_cq.buf;
 
     /* Update the SQ head
      * This param provides us the sq_wqebb_counter; all our WQEs are exactly one WQEBB (64B) */
@@ -220,15 +208,14 @@ __device__ void QueuePair::mlx5_poll_cq_until(uint16_t requested_available_slots
     uint8_t opcode = static_cast<uint8_t>(wqecnt_sig_op_own >> 28);
     uint16_t sq_head = endian::from_be(be_wqe_counter);
 
-    uint16_t sq_tail = __hip_atomic_load(&mlx5_sq.tail, __ATOMIC_ACQUIRE, __HIP_MEMORY_SCOPE_AGENT);
+    // sq_tail is the least significant bits of the post counter
+    uint16_t sq_tail = static_cast<uint16_t>(sq_post);
 
-    // CQEs are sometimes invalid, just retry until we see a valid CQE
+    // CQEs are initially invalid, retry until we see a valid CQE
     if (opcode == MLX5_CQE_INVALID) {
 #if defined(DEBUG)
       printf("CQ: invalid completion (%x)\n", opcode);
 #endif
-      // reload sq_post, we might need to look at the other CQE
-      sq_post = __hip_atomic_load(&mlx5_sq.post, __ATOMIC_ACQUIRE, __HIP_MEMORY_SCOPE_AGENT);
       continue;
     }
 
@@ -238,7 +225,7 @@ __device__ void QueuePair::mlx5_poll_cq_until(uint16_t requested_available_slots
 
     /* sq_tail is an index to the next free WQE i.e. counts number of posted WQEs
      * sq_head is an index to the *last* completed WQE - need to add one to get *count* of completed WQEs */
-    uint16_t posted = sq_tail;
+    uint16_t posted    = sq_tail;
     uint16_t completed = sq_head + 1;
 
     /* posted >= completed, except when posted has wrapped around 0xFFFF and completed hasn't
@@ -246,15 +233,18 @@ __device__ void QueuePair::mlx5_poll_cq_until(uint16_t requested_available_slots
      * in some marginal cases it's maybe possible to see consumed_slots > sq_depth,
      * but in that case available_slots will be very large, > requested_available_slots,
      * and the loop will continue for another iteration */
-    consumed_slots  = posted - completed;
+    consumed_slots  = posted   - completed;
     available_slots = sq_depth - consumed_slots;
 
     /* continue until both:
      *   - no additional WQEs have been posted
      *   - the number of requested SQ slots are available */
-  } while (!hip_atomic_compare(&mlx5_sq.post, &sq_post,
-                               __ATOMIC_ACQUIRE, __HIP_MEMORY_SCOPE_AGENT) ||
-           available_slots < requested_available_slots);
+    uint64_t prior_sq_post = sq_post;
+    sq_post = __hip_atomic_load(&mlx5_sq.post, __ATOMIC_ACQUIRE, __HIP_MEMORY_SCOPE_AGENT);
+    if (sq_post == prior_sq_post && available_slots >= requested_available_slots) {
+      return;
+    }
+  }
 }
 
 // can be called with all active lanes using any number of different QPs, don't assume anything
@@ -306,11 +296,10 @@ __device__ void QueuePair::mlx5_post_wqe_rma(int32_t length, uintptr_t laddr, ui
   mlx5_sq.buf[sq_idx] = wqe;
 
   if (is_leader) {
-    // increment tail counter
-    mlx5_sq.tail += qp_lane_count;
+    // increment post counter
     mlx5_sq.post += qp_lane_count;
     // we are the last thread in the wavefront, so we have the last WQE posted
-    mlx5_ring_doorbell(mlx5_sq.tail, wqe);
+    mlx5_ring_doorbell(mlx5_sq.post, wqe);
     // release SQ lock
     release_lock(&mlx5_sq.lock);
   }
@@ -325,7 +314,7 @@ __device__ void QueuePair::mlx5_post_wqe_rma_single(int32_t length, uintptr_t la
   mlx5_poll_cq_until(1);
 
   // wqe_idx is the logical WQE id that wraps at 0xFFFF, sq_idx is the index into the actual SQ
-  uint16_t wqe_idx = mlx5_sq.tail;
+  uint16_t wqe_idx = mlx5_wqe_idx(mlx5_sq, 0);
   uint16_t sq_idx = wqe_idx % mlx5_sq.depth;
 
   // can we inline the data into the WQE?
@@ -338,13 +327,12 @@ __device__ void QueuePair::mlx5_post_wqe_rma_single(int32_t length, uintptr_t la
   // copy to SQ
   mlx5_sq.buf[sq_idx] = wqe;
 
-  // increment tail counter
-  mlx5_sq.tail += 1;
+  // increment post counter
   mlx5_sq.post += 1;
 
   if (ring_db) {
     // ring doorbell for this WQE
-    mlx5_ring_doorbell(mlx5_sq.tail, wqe);
+    mlx5_ring_doorbell(mlx5_sq.post, wqe);
   }
 
   // release SQ lock
@@ -395,14 +383,13 @@ __device__ uint64_t QueuePair::mlx5_post_wqe_amo([[maybe_unused]] int pe, [[mayb
   mlx5_sq.buf[sq_idx] = wqe;
 
   if (is_leader) {
-    // increment tail and fetching atomic counters
-    mlx5_sq.tail += qp_lane_count;
+    // increment post and fetching-atomic counters
     mlx5_sq.post += qp_lane_count;
     if (fetching) {
       fetching_atomic_idx += qp_lane_count;
     }
     // we are the last thread in the wavefront, so we have the last WQE posted
-    mlx5_ring_doorbell(mlx5_sq.tail, wqe);
+    mlx5_ring_doorbell(mlx5_sq.post, wqe);
     // release SQ lock
     release_lock(&mlx5_sq.lock);
   }
@@ -431,7 +418,7 @@ __device__ uint64_t QueuePair::mlx5_post_wqe_amo_single([[maybe_unused]] int pe,
   }
 
   // wqe_idx is the logical WQE id that wraps at 0xFFFF, sq_idx is the index into the actual SQ
-  uint16_t wqe_idx = mlx5_sq.tail;
+  uint16_t wqe_idx = mlx5_wqe_idx(mlx5_sq, 0);
   uint16_t sq_idx = wqe_idx % mlx5_sq.depth;
 
   // construct the WQE on the stack
@@ -443,14 +430,13 @@ __device__ uint64_t QueuePair::mlx5_post_wqe_amo_single([[maybe_unused]] int pe,
   // copy to SQ
   mlx5_sq.buf[sq_idx] = wqe;
 
-  // increment tail counter
-  mlx5_sq.tail += 1;
+  // increment post counter and fetching-atomic counters
   mlx5_sq.post += 1;
   if (fetching) {
     fetching_atomic_idx += 1;
   }
   // ring doorbell for this WQE (note: need to check this for correctness)
-  mlx5_ring_doorbell(mlx5_sq.tail, wqe);
+  mlx5_ring_doorbell(mlx5_sq.post, wqe);
   // release SQ lock
   release_lock(&mlx5_sq.lock);
 

--- a/projects/rocshmem/src/gda/queue_pair.hpp
+++ b/projects/rocshmem/src/gda/queue_pair.hpp
@@ -215,7 +215,7 @@ class QueuePair {
    * @param[in] db_val Doorbell value is written by method.
    */
 #if defined(GDA_MLX5)
-  __device__ void mlx5_ring_doorbell(uint16_t sq_wqebb_counter, const gda_mlx5_wqe& wqe);
+  __device__ void mlx5_ring_doorbell(uint64_t sq_post, const gda_mlx5_wqe& wqe);
 #endif
 #if defined(GDA_BNXT)
   __device__ void bnxt_ring_doorbell(uint32_t slot_idx);


### PR DESCRIPTION
## Motivation

Follow up for #2732, #3485, and #4431. Collapse CQ to one entry instead of two. Follow up PRs will enable device memory allocation for queues.

## Technical Details

* Reduce CQ depth to 1
* Set `cc` "Collapsed CQ" bit in DevX Completion Queue Context
* Remove redundant `tail` counter in `gda_mlx5_device_sq`
* Remove swapping between two CQEs; no longer necessary
* Reenable AMO functional tests: revert bae169ed7f125b2ad881ceb6f64df16f09e9ef94

## JIRA ID

* AIROCSHMEM-314
* AIROCSHMEM-316
* AIROCSHMEM-341
* AIROCSHMEM-351

## Test Plan

* Functional tests with ConnectX-7 in RoCE v2 mode
* DeepEP with ConnextX-7 in RoCE v2 mode
* Functional tests with ConnectX-7 in IB mode

## Test Result

- [ ] RoCE v2 functional tests
  - [x] ROCm 7.0.2/Ubuntu 22.04 (bare metal)
    - `teamreduction_n2_w1_z64_32768B` test fails due to illegal device memory access
    - Suspected cause is compiler bug, failure is eliminated by addition of code known to be dead at runtime
    - Testing against ROCm 7.2/Ubuntu 24.04 does not exhibit this failure
  - [ ] ROCm 7.2/Ubuntu 22.04 (docker)
  - [ ] ROCm 7.2/Ubuntu 24.04 (docker)
  - [ ] ROCm 7.2.1/Ubuntu 24.04 (docker)
- [ ] InfiniBand functional tests
- [ ] RoCE v2 DeepEP
  - [ ] ROCm 7.2/Ubuntu 22.04 (docker)
  - [ ] ROCm 7.2/Ubuntu 24.04 (docker)

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
