### PR TITLE
feat: Add LoongArch Support

### DIFF
--- a/projects/clr/hipamd/src/hip_embed_pch.sh
+++ b/projects/clr/hipamd/src/hip_embed_pch.sh
@@ -142,7 +142,7 @@ EOF
 
   $LLVM_DIR/bin/clang -cc1 -O3 -emit-pch -triple amdgcn-amd-amdhsa -aux-triple "$host_triple" -fcuda-is-device -std=c++17 -fgnuc-version=4.2.1 -o $tmp/hip_wave64.pch -x hip-cpp-output - <$tmp/pch_wave64.cui &&
 
-  $LLVM_DIR/bin/llvm-mc -o hip_pch.o $tmp/hip_pch.mcin --filetype=obj &&
+  $LLVM_DIR/bin/clang -target "$host_triple" -o hip_pch.o -x assembler $tmp/hip_pch.mcin -c &&
 
   rm -rf $tmp
 }
@@ -187,9 +187,11 @@ __hipRTC_header_size:
 EOF
 
   set -x
+  host_triple="$(uname -m)"
+
   $LLVM_DIR/bin/clang -O3 --hip-path=$HIP_INC_DIR/.. -std=c++14 -nogpulib --hip-version=4.4 -isystem $HIP_INC_DIR -isystem $HIP_BUILD_INC_DIR -isystem $HIP_AMD_INC_DIR --cuda-device-only -D__HIPCC_RTC__ -x hip $tmp/hipRTC_header.h -E -P -o $tmp/hiprtc &&
   cat $macroFile >> $tmp/hiprtc &&
-  $LLVM_DIR/bin/llvm-mc -o $tmp/hiprtc_header.o $tmp/hipRTC_header.mcin --filetype=obj &&
+  $LLVM_DIR/bin/clang -target "$host_triple" -o $tmp/hiprtc_header.o -x assembler $tmp/hipRTC_header.mcin -c &&
   $LLVM_DIR/bin/clang $tmp/hiprtc_header.o -o $rtc_shared_lib_out -shared &&
   $LLVM_DIR/bin/clang -O3 --hip-path=$HIP_INC_DIR/.. -std=c++14 -nogpulib -nogpuinc -emit-llvm -c -o $tmp/tmp.bc --cuda-device-only -D__HIPCC_RTC__ --offload-arch=gfx906 -x hip-cpp-output $tmp/hiprtc &&
   rm -rf $tmp

--- a/projects/clr/hipamd/src/hiprtc/CMakeLists.txt
+++ b/projects/clr/hipamd/src/hiprtc/CMakeLists.txt
@@ -134,9 +134,8 @@ endif()
 if(DEFINED Clang_ROOT)
     set(Clang_BIN ${Clang_ROOT}/bin)
 endif()
-# Requires clang and llvm-mc to create this library.
+# Requires clang to create this library.
 find_program(clang clang HINTS ${Clang_BIN} ${ENV_Clang_BIN} ${ROCM_PATH}/llvm/bin ${ROCM_PATH})
-find_program(llvm-mc llvm-mc HINTS ${LLVM_BIN} ${ENV_LLVM_BIN} ${ROCM_PATH}/llvm/bin ${ROCM_PATH})
 set(HIPRTC_GEN_DIR "${CMAKE_CURRENT_BINARY_DIR}/hip_rtc_gen")
 set(HIPRTC_GEN_HEADER "${HIPRTC_GEN_DIR}/hipRTC_header.h")
 set(HIPRTC_GEN_MCIN "${HIPRTC_GEN_DIR}/hipRTC_header.mcin")
@@ -204,10 +203,11 @@ add_custom_command(
   COMMAND ${clang} -O3 --rocm-path=${PROJECT_SOURCE_DIR}/include/.. -std=c++17 -nogpulib --hip-version=${HIP_LIB_VERSION_MAJOR}.${HIP_LIB_VERSION_MINOR} -isystem ${HIP_COMMON_INCLUDE_DIR} -isystem ${PROJECT_SOURCE_DIR}/include -isystem ${PROJECT_BINARY_DIR}/include -isystem ${CMAKE_CURRENT_SOURCE_DIR}/include --cuda-device-only -D__HIPCC_RTC__ -DHIP_VERSION_MAJOR=${HIP_LIB_VERSION_MAJOR} -DHIP_VERSION_MINOR=${HIP_LIB_VERSION_MINOR} ${HIPRTC_ASAN_OPTIONS} -x hip ${HIPRTC_GEN_HEADER} -E -P -o ${HIPRTC_GEN_PREPROCESSED}
   COMMAND ${CMAKE_COMMAND} -DHIPRTC_ADD_MACROS=1 -DHIPRTC_HEADERS="${HIPRTC_HEADERS}" -DHIPRTC_PREPROCESSED_FILE=${HIPRTC_GEN_PREPROCESSED} -P ${HIPRTC_CMAKE}
   DEPENDS ${clang} ${HIPRTC_GEN_HEADER})
+# Note: LLVM_TARGET_TRIPLE defined on /opt/rocm/llvm/lib/cmake/llvm/LLVMConfig.cmake
 add_custom_command(
   OUTPUT ${HIPRTC_GEN_OBJ}
-  COMMAND ${llvm-mc} -o ${HIPRTC_GEN_OBJ} ${HIPRTC_GEN_MCIN} --filetype=obj
-  DEPENDS ${llvm-mc} ${HIPRTC_GEN_PREPROCESSED} ${HIPRTC_GEN_MCIN})
+  COMMAND ${clang} -target ${LLVM_TARGET_TRIPLE} -o ${HIPRTC_GEN_OBJ} -x assembler ${HIPRTC_GEN_MCIN} -c
+  DEPENDS ${clang} ${HIPRTC_GEN_PREPROCESSED} ${HIPRTC_GEN_MCIN})
 
 # Create hiprtc-builtins library.
 add_library(hiprtc-builtins ${HIPRTC_GEN_OBJ})

--- a/projects/clr/rocclr/include/top.hpp
+++ b/projects/clr/rocclr/include/top.hpp
@@ -14,6 +14,8 @@
     defined(__x86__) || defined(__x86_64) || defined(__x86_64__) || defined(__amd64) ||            \
     defined(__amd64__) || defined(_M_X64) || defined(_M_AMD64)
 #define ATI_ARCH_X86
+#elif defined(__loongarch_lp64)
+#define ATI_ARCH_LOONGARCH
 #endif
 
 #if defined(ATI_ARCH_ARM)

--- a/projects/clr/rocclr/os/os_posix.cpp
+++ b/projects/clr/rocclr/os/os_posix.cpp
@@ -789,6 +789,9 @@ address Os::currentStackPtr() {
 #elif defined(ATI_ARCH_ARM)
       "mov %0,sp"
       : "=r"(value)
+#elif defined(ATI_ARCH_LOONGARCH)
+      "move %0,$sp"
+      : "=r"(value)
 #else
       ""
 #endif

--- a/projects/rccl/src/init.cc
+++ b/projects/rccl/src/init.cc
@@ -80,7 +80,10 @@
 #include "dda_all_reduce.h"
 #include "ipc_init.h"
 #include "fabric_init.h"
-#include <cpuid.h>
+#if defined(__i386__) || defined(__x86_64__) || defined(_M_IX86) || defined(_M_X64)
+#define IS_X86_64
+#include  <cpuid.h>
+#endif
 #include <stdio.h>
 #include <stdlib.h>
 #include "kernel_config.h"
@@ -299,6 +302,7 @@ static ncclResult_t ncclInit() {
     if (verStr == NULL) break;
   }
   INFO(NCCL_INIT, "Kernel version: %s", verStr);
+#ifdef IS_X86_64
   if (strstr(verStr, "cray") == NULL) {
     unsigned int eax, ebx, ecx, edx;
     if (!__get_cpuid(1, &eax, &ebx, &ecx, &edx)) ecx = 0; // cpuid not supported
@@ -326,6 +330,7 @@ static ncclResult_t ncclInit() {
            "instablity or hang!");
 #endif
   }
+#endif
   std::call_once(initOnceFlag, initOnceFunc);
   return initResult;
 }

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/util/utils.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/util/utils.h
@@ -72,6 +72,19 @@
 #if defined(_MSC_VER) && (defined(_M_IX86) || defined(_M_X64))
 #include "intrin.h"
 #endif
+#if defined(__loongarch_lp64)
+// See linux-kernel arch/loongarch/include/asm/barrier.h
+// full barrier-mb
+static inline void _mm_clflush(const void* ptr) { (void)ptr; asm volatile ("dbar 0" ::: "memory"); }
+// sfence->wmb->c_wsync->c_w_w
+// LoongArch barrier:  c_w_w completion previous(W) succeeding(W)
+static inline void _mm_sfence(void) { asm volatile ("dbar 0xa" ::: "memory"); }
+// mfence->mb->c_sync->crwrw
+// LoongArch barrier:  crwrw completion previous(R/W) succeeding(R/W)
+static inline void _mm_mfence(void) { asm volatile ("dbar 0" ::: "memory"); }
+// LoongArch does not have an alternative to mm_pause. It is set to execute empty here.
+static inline void _mm_pause(void) {}
+#endif
 
 namespace rocr {
 extern FILE* log_file;

--- a/projects/rocr-runtime/runtime/hsa-runtime/image/util.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/image/util.h
@@ -74,10 +74,10 @@ namespace image {
 
 
 #if defined(__GNUC__)
-#include "mm_malloc.h"
 #if defined(__i386__) || defined(__x86_64__)
+#include "mm_malloc.h"
 #include <x86intrin.h>
-#elif defined(__loongarch64)
+#elif defined(__loongarch_lp64)
 #else
 #error                                                                                             \
     "Processor not identified.  " \


### PR DESCRIPTION
## Motivation

To improve ROCm support for the LoongArch architecture. Porting work has been underway for several years, and ROCm and AMD-RDNA-GPU run very well on LoongArch.


## Technical Details
Porting is performed on parts of the code that involve architectural features, such as memory stacks and memory barriers.

The adjustments here are based on the [ABI documentation](https://github.com/loongson/la-abi-specs) and the [barrier directives section](https://github.com/loongson/la-asm-manual/blob/e706139e69868840ad33a72526ac072cc6a81510/adoc/CHAPTER-8.Instruction_Set/8.1-Base_Instruction/8.1.1-Base_Integer_Instruction/8.1.1.8-Barrier_Instructions.adoc).


## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan

For existing x86 Linux platforms, there should be no impact. For the new LoongArch Linux platform, basic ROCm commands should be executable.


## Test Result
<details>
<summary>Tests pass</summary>

```shell
# /usr/lib/rocm/bin/rocm-smi
======================================== ROCm System Management Interface ========================================
================================================== Concise Info ==================================================
Device  Node  IDs              Temp    Power  Partitions          SCLK   MCLK    Fan  Perf  PwrCap  VRAM%  GPU%  
              (DID,     GUID)  (Edge)  (Avg)  (Mem, Compute, ID)                                                 
==================================================================================================================
0       1     0x7590,   37051  45.0°C  14.0W  N/A, N/A, 0         17Mhz  772Mhz  0%   auto  182.0W  4%     1%    
==================================================================================================================
============================================== End of ROCm SMI Log ===============================================
# uname -a
Linux aosc-3c6000-temp-server 6.18.16-aosc-main-4k #2 SMP PREEMPT_DYNAMIC Tue Mar 10 15:30:43 UTC 2026 loongarch64 GNU/Linux
```

</details>

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
