### PR TITLE
[rocprof-compute] rocprof-compute build and profile now runs with vanilla python

### DIFF
--- a/projects/rocprofiler-compute/CHANGELOG.md
+++ b/projects/rocprofiler-compute/CHANGELOG.md
@@ -21,6 +21,9 @@ Full documentation for ROCm Compute Profiler is available at [https://rocm.docs.
   * Profile mode now creates separate counter collection files for each application replay (pmc_perf_*.csv or results_*.csv).
   * Analyze mode automatically merges these files into a unified pmc_perf.csv containing information from all application replays during pre-processing.
 
+* ROCm Compute Profiler now builds and runs profile mode with vanilla python without requiring to pip install any python dependencies
+  * Note that analysis mode will still require and complain about missing python dependencies
+
 ### Removed
 
 * Removed HIP API tracing since it's out-of-scope for ROCm Compute Profiler and the trace files were not being analyzed.

--- a/projects/rocprofiler-compute/CHANGELOG.md
+++ b/projects/rocprofiler-compute/CHANGELOG.md
@@ -21,8 +21,8 @@ Full documentation for ROCm Compute Profiler is available at [https://rocm.docs.
   * Profile mode now creates separate counter collection files for each application replay (pmc_perf_*.csv or results_*.csv).
   * Analyze mode automatically merges these files into a unified pmc_perf.csv containing information from all application replays during pre-processing.
 
-* ROCm Compute Profiler now builds and runs profile mode with vanilla python without requiring to pip install any python dependencies
-  * Note that analysis mode will still require and complain about missing python dependencies
+* ROCm Compute Profiler now builds and runs profile mode with vanilla Python without requiring any Python dependencies to be installed via `pip`.
+  * Note that analysis mode will still require Python dependencies and will report any missing packages.
 
 ### Removed
 


### PR DESCRIPTION
## Motivation

**CHANGELOG update only**

rocprof-compute build and profile now runs with vanilla python

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
