### PR TITLE
rocprofiler-sdk add ROCPROFILER_BUILD_ELFIO option

### DIFF
--- a/projects/rocprofiler-sdk/cmake/rocprofiler_config_interfaces.cmake
+++ b/projects/rocprofiler-sdk/cmake/rocprofiler_config_interfaces.cmake
@@ -310,9 +310,14 @@ endif()
 #
 # ----------------------------------------------------------------------------------------#
 
+if (NOT ROCPROFILER_BUILD_ELFIO)
+    # search system installed elfio
+    find_package(elfio CONFIG REQUIRED)
+endif()
+target_link_libraries(rocprofiler-sdk-elfio INTERFACE elfio::elfio)
+
 # get_target_property(ELFIO_INCLUDE_DIR elfio::elfio INTERFACE_INCLUDE_DIRECTORIES)
 # target_include_directories(rocprofiler-sdk-elfio SYSTEM INTERFACE ${ELFIO_INCLUDE_DIR})
-target_link_libraries(rocprofiler-sdk-elfio INTERFACE elfio::elfio)
 
 # ----------------------------------------------------------------------------------------#
 #

--- a/projects/rocprofiler-sdk/cmake/rocprofiler_options.cmake
+++ b/projects/rocprofiler-sdk/cmake/rocprofiler_options.cmake
@@ -65,6 +65,8 @@ rocprofiler_add_option(ROCPROFILER_BUILD_PYBIND11
                        "Enable building pybind11 library internally" ON)
 rocprofiler_add_option(ROCPROFILER_BUILD_GOTCHA
                        "Enable building gotcha library internally" ON)
+rocprofiler_add_option(ROCPROFILER_BUILD_ELFIO
+                       "Enable building elfio library internally" ON)
 if(ROCPROFILER_BUILD_TESTS)
     rocprofiler_add_option(
         ROCPROFILER_BUILD_GTEST

--- a/projects/rocprofiler-sdk/external/CMakeLists.txt
+++ b/projects/rocprofiler-sdk/external/CMakeLists.txt
@@ -195,17 +195,19 @@ target_link_libraries(
     rocprofiler-sdk-perfetto
     INTERFACE $<BUILD_INTERFACE:rocprofiler-sdk-perfetto-static-library>)
 
-# ELFIO
-rocprofiler_checkout_git_submodule(
-    RECURSIVE
-    RELATIVE_PATH external/elfio
-    WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
-    REPO_URL https://github.com/serge1/ELFIO.git
-    REPO_BRANCH "Release_3.12")
+if (ROCPROFILER_BUILD_ELFIO)
+    # build elfio instead of using the system provided version
+    rocprofiler_checkout_git_submodule(
+        RECURSIVE
+        RELATIVE_PATH external/elfio
+        WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
+        REPO_URL https://github.com/serge1/ELFIO.git
+        REPO_BRANCH "Release_3.12")
 
-set(ELFIO_BUILD_EXAMPLES OFF)
-set(ELFIO_BUILD_TESTS OFF)
-add_subdirectory(elfio EXCLUDE_FROM_ALL)
+    set(ELFIO_BUILD_EXAMPLES OFF)
+    set(ELFIO_BUILD_TESTS OFF)
+    add_subdirectory(elfio EXCLUDE_FROM_ALL)
+endif()
 if(TARGET rocprofiler-sdk-elfio)
     get_target_property(ELFIO_INCLUDE_DIR elfio::elfio INTERFACE_INCLUDE_DIRECTORIES)
     target_include_directories(rocprofiler-sdk-elfio SYSTEM


### PR DESCRIPTION
Add new build flag ROCPROFILER_BUILD_ELFIO which
is by default on to support the current way of building.

When the option is set off, the elfio is tried to find from the system path instead of downloading it. This allows therock to install the same elfio version that rocprofiler-sdk uses and then patch it to support the gcc 15 to fix a following build error:

therock/build/third-party/elfio/build_elfio/
    dist/include/elfio/elf_types.hpp:30:20:
    error: unknown type name 'uint16_t'
    9.5        30 | using Elf_Half   = uint16_t;

Later the same elfio version may be used also on some other projects.

fixes for: https://github.com/ROCm/TheRock/issues/3517
