### PR TITLE
[rocprofiler-systems] Update CMake to 3.25 in Dockerfiles

### DIFF
--- a/projects/rocprofiler-systems/docker/Dockerfile.opensuse
+++ b/projects/rocprofiler-systems/docker/Dockerfile.opensuse
@@ -27,7 +27,8 @@ RUN zypper --non-interactive update -y && \
         gcc-c++ gcc-fortran git gmock gtest iproute2 libdrm-devel libnuma-devel \
         ninja nlohmann_json-devel openmpi3-devel python3-pip rpm-build \
         sqlite3-devel wget libucp-devel libuct-devel && \
-    python3 -m pip install 'cmake==3.21'
+    python3 -m pip install --upgrade pip && \
+    python3 -m pip install 'cmake==3.25'
 
 ARG ROCM_VERSION=0.0
 ARG ROCM_MAJOR=0

--- a/projects/rocprofiler-systems/docker/Dockerfile.opensuse.ci
+++ b/projects/rocprofiler-systems/docker/Dockerfile.opensuse.ci
@@ -32,7 +32,8 @@ RUN zypper --non-interactive update -y && \
         openmpi3-devel papi-devel python3-devel python3-pip rpm-build \
         sqlite3-devel vim wget libucp-devel libuct-devel && \
     zypper --non-interactive clean --all && \
-    python3 -m pip install 'cmake==3.21' perfetto
+    python3 -m pip install --upgrade pip && \
+    python3 -m pip install 'cmake==3.25' perfetto
 
 ARG PYTHON_VERSIONS="6 7 8 9 10 11 12 13"
 

--- a/projects/rocprofiler-systems/docker/Dockerfile.rhel
+++ b/projects/rocprofiler-systems/docker/Dockerfile.rhel
@@ -19,7 +19,8 @@ RUN yum groupinstall -y "Development Tools" && \
         iproute json-devel libdrm-devel ninja-build numactl-devel openmpi-devel \
         papi-devel python3-pip sqlite-devel texinfo wget which zlib-devel ucx-devel && \
     yum clean all && \
-    python3 -m pip install 'cmake==3.21' && \
+    python3 -m pip install --upgrade pip && \
+    python3 -m pip install 'cmake==3.25' && \
     python3 -m pip install 'perfetto'
 
 ARG ROCM_VERSION=0.0

--- a/projects/rocprofiler-systems/docker/Dockerfile.rhel.ci
+++ b/projects/rocprofiler-systems/docker/Dockerfile.rhel.ci
@@ -26,7 +26,8 @@ RUN yum groupinstall -y "Development Tools" && \
         iproute json-devel ninja-build numactl-devel openmpi-devel papi-devel \
         python3-devel python3-pip sqlite-devel texinfo wget which vim zlib-devel ucx-devel && \
     yum clean all && \
-    python3 -m pip install 'cmake==3.21' perfetto
+    python3 -m pip install --upgrade pip && \
+    python3 -m pip install 'cmake==3.25' perfetto
 
 ARG PYTHON_VERSIONS="6 7 8 9 10 11 12 13"
 

--- a/projects/rocprofiler-systems/docker/Dockerfile.ubuntu
+++ b/projects/rocprofiler-systems/docker/Dockerfile.ubuntu
@@ -34,9 +34,9 @@ RUN apt-get update && \
     OS_VERSION=$(grep '^VERSION_ID=' /etc/os-release | cut -d'=' -f2 | tr -d '"') && \
     OS_ID=$(grep '^ID=' /etc/os-release | cut -d'=' -f2 | tr -d '"') && \
     if [ "${OS_ID}" == "ubuntu" ] && [ "${OS_VERSION}" == "22.04" ]; then \
-        python3 -m pip install 'cmake==3.21'; \
+        python3 -m pip install 'cmake==3.25'; \
     else \
-        python3 -m pip install --break-system-packages 'cmake==3.21' perfetto; \
+        python3 -m pip install --break-system-packages 'cmake==3.25' perfetto; \
     fi
 
 RUN if [ "${ROCM_MAJOR}" != "0" ] || [ "${ROCM_MINOR}" != "0" ]; then \

--- a/projects/rocprofiler-systems/docker/Dockerfile.ubuntu.ci
+++ b/projects/rocprofiler-systems/docker/Dockerfile.ubuntu.ci
@@ -34,9 +34,9 @@ RUN apt-get update && \
 RUN OS_VERSION=$(grep '^VERSION_ID=' /etc/os-release | cut -d'=' -f2 | tr -d '"') && \
     OS_ID=$(grep '^ID=' /etc/os-release | cut -d'=' -f2 | tr -d '"') && \
     if [ "${OS_ID}" == "ubuntu" ] && [ "${OS_VERSION}" == "22.04" ]; then \
-        python3 -m pip install 'cmake==3.21' perfetto; \
+        python3 -m pip install 'cmake==3.25' perfetto; \
     else \
-        python3 -m pip install --break-system-packages 'cmake==3.21' perfetto; \
+        python3 -m pip install --break-system-packages 'cmake==3.25' perfetto; \
     fi
 
 RUN if ! pip show perfetto 2>&1 | tee pip_output.log | grep -q "WARNING"; then \


### PR DESCRIPTION
# Motivation
NOTE: Update of the min_required_version in CMake and workflow changes will be added in the following PR.

Raise the CMake version installed in rocprofiler-systems Docker images from 3.21 to 3.25 so containerized builds and CI use a newer toolchain consistent with project needs.

# Technical details

- Update `python3 -m pip install 'cmake==3.21'` to `cmake==3.25` in six files under `projects/rocprofiler-systems/docker/`: `Dockerfile.ubuntu`, `Dockerfile.ubuntu.ci`, `Dockerfile.rhel`, `Dockerfile.rhel.ci`, `Dockerfile.opensuse`, and `Dockerfile.opensuse.ci`.
- On RHEL and openSUSE images, run `python3 -m pip install --upgrade pip` before installing CMake (and existing `perfetto` where applicable) to keep pip installs reliable.
- Ubuntu Dockerfiles keep the existing branch (22.04 vs other) for whether `--break-system-packages` is used; only the pinned CMake version changes.

## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

# Test plan

- Rebuild each affected Docker image (or the CI variants used in pipelines) and confirm the image builds successfully.
- Inside a built container, run `cmake --version` and verify 3.25.x.
- Run the project’s usual Docker-based CI or local `docker build` workflow for rocprofiler-systems if applicable.

# Test result

- Expected: `cmake --version` reports 3.25.x in the updated images; Docker builds complete without regressions from the CMake/pip changes.

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
