### PR TITLE
[rocprofiler-sdk] Relax timing tolerance in callback_registration_lambda_with_result test from 25% to 35%

### DIFF
--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/tests/registration.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/tests/registration.cpp
@@ -345,7 +345,7 @@ TEST(rocprofiler_lib, callback_registration_lambda_with_result)
     EXPECT_GT(cb_data.client_elapsed, 0);
     EXPECT_GT(elapsed, 0);
 #else
-    decltype(elapsed) elapsed_tolerance = 0.25 * elapsed;
+    decltype(elapsed) elapsed_tolerance = 0.30 * elapsed;
     int64_t           diff              = (cb_data.client_elapsed - elapsed);
     auto              frac              = std::abs(diff) / (1.0 * elapsed);
     EXPECT_NEAR(elapsed, cb_data.client_elapsed, elapsed_tolerance)

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/tests/registration.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/tests/registration.cpp
@@ -345,7 +345,7 @@ TEST(rocprofiler_lib, callback_registration_lambda_with_result)
     EXPECT_GT(cb_data.client_elapsed, 0);
     EXPECT_GT(elapsed, 0);
 #else
-    decltype(elapsed) elapsed_tolerance = 0.30 * elapsed;
+    decltype(elapsed) elapsed_tolerance = 0.35 * elapsed;
     int64_t           diff              = (cb_data.client_elapsed - elapsed);
     auto              frac              = std::abs(diff) / (1.0 * elapsed);
     EXPECT_NEAR(elapsed, cb_data.client_elapsed, elapsed_tolerance)


### PR DESCRIPTION
## Motivation

Random failures observed in CI environments: https://github.com/ROCm/rocm-systems/actions/runs/23772167349/job/69265926641?pr=4272

## Technical Details

This PR updates the elapsed time tolerance in the
rocprofiler_lib.callback_registration_lambda_with_result test from 25% to 35%.

The test compares:

- wall-clock time measured around hsa_iterate_agents(...)
- elapsed time accumulated via rocprofiler callback instrumentation

Due to the nature of this comparison, both measurements are not strictly equivalent and can diverge because of:
- system noise (CPU scheduling, contention in CI)

## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan

- CI test

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
