### PR TITLE
Increase default timeout from 30 to 60 seconds in debug-agent tests

### DIFF
--- a/projects/rocr-debug-agent/test/run-test.py
+++ b/projects/rocr-debug-agent/test/run-test.py
@@ -11,7 +11,7 @@ import shutil
 from subprocess import Popen, PIPE, CalledProcessError, run
 import signal
 
-DEFAULT_TIMEOUT = 30
+DEFAULT_TIMEOUT = 60
 
 
 def run_and_communicate(

--- a/projects/rocr-debug-agent/test/sigquit.cpp
+++ b/projects/rocr-debug-agent/test/sigquit.cpp
@@ -55,7 +55,7 @@ void
 SigquitTest ()
 {
   signal (SIGALRM, handle_alarm);
-  alarm (30);
+  alarm (60);
 
   hipError_t err;
   int start = 0;


### PR DESCRIPTION
It takes about 45 seconds to dump the debug info from debug-agent on emulator, we need to increase the timeout to 60 seconds.