### PR TITLE
[rocprofiler-sdk] - unable to collect PMC data

### DIFF
--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-tool/tool.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-tool/tool.cpp
@@ -1810,6 +1810,10 @@ initialize_rocprofv3()
                          "force configuration");
     }
 
+    // When running as a rocplaycap scan-only child process, rocprofiler_configure()
+    // returns nullptr (ROCPROFV3_PLAYBACK_CHILD is set), so client_identifier is never
+    // assigned. Skip initialization here to avoid the fatal assertion below.
+    if(getenv("ROCPROFV3_PLAYBACK_CHILD") != nullptr) return;
     ROCP_FATAL_IF(!client_identifier) << "nullptr to client identifier!";
     ROCP_FATAL_IF(!client_finalizer && !tool::get_config().list_metrics)
         << "nullptr to client finalizer!";  // exception for listing metrics
@@ -3232,12 +3236,20 @@ wait_pid(pid_t _pid, int _opts = 0)
     int   _status = 0;
     pid_t _pid_v  = -1;
     _opts |= WUNTRACED;
+    // Add a timeout to avoid an indefinite wait if the child exits via SIGABRT during
+    // roccap AQL replay teardown and the parent waitpid() blocks due to a race.
+    auto _deadline = std::chrono::steady_clock::now() + std::chrono::seconds{5};
     do
     {
         if((_opts & WNOHANG) > 0)
         {
             std::this_thread::yield();
             std::this_thread::sleep_for(std::chrono::milliseconds{100});
+            if(std::chrono::steady_clock::now() > _deadline)
+            {
+                ROCP_WARNING << fmt::format("wait_pid timeout waiting for child {}", _pid);
+                return std::nullopt;
+            }
         }
         _pid_v = waitpid(_pid, &_status, _opts);
     } while(_pid_v == 0);
@@ -3418,8 +3430,22 @@ rocprofv3_error_signal_handler(int signo, siginfo_t* info, void* ucontext)
             this_func,
             signo);
 
-        finalize_rocprofv3(this_func);
-        if(tool::get_config().enable_process_sync) wait_peer_finished(this_pid, this_ppid);
+        // When SIGABRT is received during roccap AQL replay, HSA has already been torn
+        // down before this handler runs. Calling finalize_rocprofv3() would invoke HSA
+        // shutdown functions on freed memory, triggering a second SIGABRT (re-entrant
+        // signal). Instead, flush buffers and write output directly before exiting.
+        if(signo != SIGABRT)
+        {
+            finalize_rocprofv3(this_func);
+            if(tool::get_config().enable_process_sync) wait_peer_finished(this_pid, this_ppid);
+        }
+        else
+        {
+            ROCP_WARNING << "HSA already torn down on SIGABRT, skipping finalize to avoid re-entrant signal. Flushing output directly.";
+            flush();
+            generate_output(cleanup_mode::destroy);
+            _exit(128 + SIGABRT);  // Unix convention: 128 + signal number
+        }
 
         ROCP_INFO << fmt::format(
             "[PPID={}][PID={}][TID={}][{}] rocprofv3 finalizing after signal {}... complete",
@@ -3429,7 +3455,8 @@ rocprofv3_error_signal_handler(int signo, siginfo_t* info, void* ucontext)
             this_func,
             signo);
 
-        if(get_chained_signals().at(signo))
+        // Skip chained handler for SIGABRT to avoid re-entrant abort when HSA is already torn down.
+        if(signo != SIGABRT && get_chained_signals().at(signo))
         {
             ROCP_INFO << fmt::format(
                 "[PPID={}][PID={}][TID={}][{}] rocprofv3 found chained signal handler for {}",
@@ -3517,6 +3544,10 @@ rocprofiler_configure(uint32_t                 version,
                       uint32_t                 priority,
                       rocprofiler_client_id_t* id)
 {
+    // Skip tool initialization in rocplaycap scan-only child processes to prevent
+    // duplicate /dev/kfd opens under the same PID with different memory mappings,
+    // which triggers a NULL ptr deref in the KFD driver and corrupts the GPU context.
+    if(getenv("ROCPROFV3_PLAYBACK_CHILD") != nullptr) return nullptr;
     initialize_logging();
 
     // set the client name

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/counters/device_counting.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/counters/device_counting.cpp
@@ -192,8 +192,9 @@ agent_async_handler(hsa_signal_value_t /*signal_v*/, void* data)
     auto* buf = buffer::get_buffer(callback_data.buffer.handle);
     if(!buf && callback_data.buffer != rocprofiler_buffer_id_t{.handle = 0})
     {
-        ROCP_FATAL << fmt::format("Buffer {} destroyed before record was written",
-                                  callback_data.buffer.handle);
+        // Fix ROCM-1214: buffer destroyed before AQL completion callback (race on teardown)
+        ROCP_WARNING << fmt::format("Buffer {} destroyed before record was written (skipping)",
+                                    callback_data.buffer.handle);
         return false;
     }
 

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/counters/sample_consumer.hpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/counters/sample_consumer.hpp
@@ -62,7 +62,10 @@ public:
         valid.store(false);
         cv.notify_all();
 
-        if(!exited) cv.wait(lk, [&] { return exited.load(); });
+        if(!exited)
+            cv.wait_for(lk, std::chrono::seconds(5), [&] {
+                return exited.load();
+            });  // Fix ROCM-1214: timeout to avoid hang
         if(consumer.joinable()) consumer.join();
     }
 

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/counters/sample_processing.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/counters/sample_processing.cpp
@@ -72,7 +72,16 @@ proccess_completed_cb(completed_cb_params_t&& params)
 
     if(info->buffer)
     {
-        buf = CHECK_NOTNULL(buffer::get_buffer(info->buffer->handle));
+        // During normal profiling this buffer should always be valid (CHECK_NOTNULL invariant).
+        // However during roccap AQL replay, the process exits via SIGABRT and the buffer can
+        // be destroyed before all in-flight AQL completion callbacks have fired.
+        buf = buffer::get_buffer(info->buffer->handle);
+        if(!buf)
+        {
+            ROCP_WARNING << fmt::format(
+                "Buffer {} destroyed before sample was processed (skipping)", info->buffer->handle);
+            return;
+        }
     }
 
     auto _corr_id_v =

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/hsa/queue_controller.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/hsa/queue_controller.cpp
@@ -543,7 +543,12 @@ void
 queue_controller_fini()
 {
     if(get_queue_controller())
-        get_queue_controller()->iterate_queues([](const Queue* _queue) { _queue->sync(); });
+        get_queue_controller()->iterate_queues([](const Queue* _queue) {
+            // During roccap AQL replay, the process exits via SIGABRT and HSA is already
+            // torn down before fini runs. Calling sync() (hsa_signal_wait) on freed HSA
+            // memory causes a crash. Skip sync only in that scenario.
+            if(getenv("ROCPROFV3_PLAYBACK_CHILD") == nullptr) _queue->sync();
+        });
 }
 
 void


### PR DESCRIPTION
## Problem

When running `rocprofv3 -A absolute --pmc SQ_WAVES -- roccap play <trace>` , PMC counter data could not be collected and the command might caused SSH disconnect and node destabilization.

## Motivation

Enable `rocprofv3 --pmc` to work correctly with `roccap play` (AQL trace replay)
without causing node destabilization or data loss.


## Technical Details

See ticket ROCM-1214

## JIRA ID

Resolves ROCM-1214


## Test Plan

Run the following command on server with rocplaycap AQL trace replay:
```bash
rocprofv3 -A absolute --pmc SQ_WAVES --output-format csv \
  -d <output_dir> -- roccap play <trace.cap>
```

Verify:
1. PMC counter data is correctly collected and written to CSV
2. Node remains stable (no SSH disconnect, no GPU reset)
3. `dmesg` is clean 
4. Process exits naturally without requiring Ctrl+C


## Test Result

**ROCm 7.1 —  VALIDATED**

**ROCm 7.2 —  PENDING**
