### PR TITLE
hip-tests: fix config generation for cuda testing

### DIFF
--- a/projects/hip-tests/catch/config/CMakeLists.txt
+++ b/projects/hip-tests/catch/config/CMakeLists.txt
@@ -20,10 +20,14 @@ if(WIN32)
 else()
     set(CONFIG_OS "linux")
 
-    # TODO multiple arch support
-    foreach(ARCH ${HIP_GPU_ARCH_LIST})
-        set(CONFIG_ARCH ${ARCH})
-    endforeach()
+    if (HIP_PLATFORM MATCHES "amd")
+        # TODO multiple arch support
+        foreach(ARCH ${HIP_GPU_ARCH_LIST})
+            set(CONFIG_ARCH ${ARCH})
+        endforeach()
+    else()
+        set(CONFIG_ARCH "linux")
+    endif()
 endif()
 
 set(HIP_TESTS_CONFIGS_DIR ${CMAKE_CURRENT_SOURCE_DIR}/configs)


### PR DESCRIPTION
## Motivation

- Current config cmake doesn't generate config correctly for nvidia due to missing arch param in python command
- for linux, add arch argument to generate correct hip_test_parameters.hh and config file

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
