### PR TITLE
rocr/aie: PDI cache retrieval fixes

### DIFF
--- a/projects/rocr-runtime/runtime/hsa-runtime/core/driver/xdna/amd_xdna_driver.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/driver/xdna/amd_xdna_driver.cpp
@@ -436,15 +436,21 @@ hsa_status_t XdnaDriver::CreateQueue(uint32_t node_id, HSA_QUEUE_TYPE type, uint
 }
 
 hsa_status_t XdnaDriver::DestroyQueue(HSA_QUEUEID queue_id) const {
-  if (queue_id == AMDXDNA_INVALID_CTX_HANDLE) {
-    return HSA_STATUS_ERROR_INVALID_QUEUE;
+  auto hw_ctx_handle = static_cast<uint32_t>(queue_id);
+  if (hw_ctx_handle == AMDXDNA_INVALID_CTX_HANDLE) {
+    // Queue was never created or already destroyed. We choose not to consider it an error since AIE
+    // queues are created with an invalid handle.
+    return HSA_STATUS_SUCCESS;
   }
 
-  auto hw_ctx_handle = static_cast<uint32_t>(queue_id);
+  // Drop PDI cache.
+  const_cast<std::unordered_map<HSA_QUEUEID, PDICache>&>(hw_ctx_pdi_cache_map).erase(queue_id);
+
+  // Destroy hardware context associated with the queue.
   amdxdna_drm_destroy_hwctx destroy_hwctx_args = {};
   destroy_hwctx_args.handle = hw_ctx_handle;
-
   if (ioctl(fd_, DRM_IOCTL_AMDXDNA_DESTROY_HWCTX, &destroy_hwctx_args) < 0) {
+    assert(false && "Failed to destroy hardware context for queue.");
     return HSA_STATUS_ERROR;
   }
 
@@ -715,7 +721,6 @@ hsa_status_t XdnaDriver::PrepareBOs(uint32_t count,
   // the operands in a command is `operand_starting_index` and the fields
   // are 32-bits we need to iterate over every two
   const uint32_t num_operands = GetOperandCount(count);
-  bo_handles.reserve(num_operands);
   for (uint32_t operand_iter = 0; operand_iter < num_operands; operand_iter++) {
     const uint32_t operand_index = operand_starting_index + 2 * operand_iter;
     const uint64_t operand_addr = Concat<uint64_t>(cmd_pkt_payload->data[operand_index + 1],
@@ -780,10 +785,14 @@ hsa_status_t XdnaDriver::CreateCmdBO(uint32_t size, BOHandle& cmd_bo_handle) {
 
 hsa_status_t XdnaDriver::SubmitCmdChain(hsa_amd_aie_ert_packet_t* first_pkt, uint32_t num_pkts,
                                         HSA_QUEUEID& queue_id, uint32_t num_core_tiles) {
-  // Stores instruction and operand BOs.
-  std::vector<uint32_t> bo_handles;
+  assert(num_pkts > 0);
 
-  // Stores commands that we are going to submit and the corresponding metadata.
+  // Instruction and operand BOs. Reserve space for instruction BOs and up to 3 operand BOs per
+  // packet.
+  std::vector<uint32_t> bo_handles;
+  bo_handles.reserve(num_pkts * 4);
+
+  // Commands to be submitted.
   std::vector<BOHandle> cmd_bo_handles;
   cmd_bo_handles.reserve(num_pkts);
   // Unmap and close the command BOs in case of an error.
@@ -793,35 +802,40 @@ hsa_status_t XdnaDriver::SubmitCmdChain(hsa_amd_aie_ert_packet_t* first_pkt, uin
     }
   });
 
-  auto hw_ctx_handle = static_cast<uint32_t>(queue_id);
-  // PDI cache. If the cache is updated, a new hardware context will be created for the queue.
-  auto pdi_cache_it = hw_ctx_pdi_cache_map.find(hw_ctx_handle);
-  auto pdi_cache = (pdi_cache_it != hw_ctx_pdi_cache_map.end()) ? pdi_cache_it->second : PDICache{};
-  bool reconfigure_queue = false;
+  // PDI cache to avoid reconfiguration. If the queue is invalid or the cache is updated, a new
+  // hardware context will be created for the queue.
+  PDICache pdi_cache;
+  if (static_cast<uint32_t>(queue_id) != AMDXDNA_INVALID_CTX_HANDLE) {
+    auto pdi_cache_it = hw_ctx_pdi_cache_map.find(queue_id);
+    if (pdi_cache_it != hw_ctx_pdi_cache_map.end()) {
+      pdi_cache = pdi_cache_it->second;
+    }
+  }
+  bool reconfigure_queue = pdi_cache.empty();
 
   // Iterating over all the contiguous HSA_AMD_AIE_ERT_CMD_CHAIN packets
   for (uint32_t pkt_iter = 0; pkt_iter < num_pkts; pkt_iter++) {
     // Getting the current command packet
     hsa_amd_aie_ert_packet_t* pkt = first_pkt + pkt_iter;
-    hsa_amd_aie_ert_start_kernel_data_t* cmd_pkt_payload =
+    auto* cmd_pkt_payload =
         reinterpret_cast<hsa_amd_aie_ert_start_kernel_data_t*>(pkt->payload_data);
 
-    // Add the handles for all of the BOs to bo_handles as well as rewrite
-    // the instruction handle to contain the device address
+    // Add the handles for all of the BOs to bo_handles and flush cache.
     hsa_status_t status = PrepareBOs(pkt->count, cmd_pkt_payload, bo_handles);
     if (status != HSA_STATUS_SUCCESS) {
+      assert(false && "Failed to prepare BOs for command packet.");
       return status;
     }
 
-    // Creating a packet that contains the command to execute the kernel
+    // Create packet that contains the command to execute the kernel.
     const uint32_t cmd_size = sizeof(amdxdna_cmd) + pkt->count * sizeof(uint32_t);
     BOHandle cmd_bo_handle;
     status = CreateCmdBO(cmd_size, cmd_bo_handle);
     if (status != HSA_STATUS_SUCCESS) {
+      assert(false && "Failed to create command BO.");
       return status;
     }
-    // Unmap and close the command BO in case of an error.
-    MAKE_NAMED_SCOPE_GUARD(cmd_bo_handle_guard, [&] { DestroyBOHandle(cmd_bo_handle); });
+    cmd_bo_handles.push_back(cmd_bo_handle);
 
     auto* cmd = static_cast<amdxdna_cmd*>(cmd_bo_handle.vaddr);
 
@@ -834,51 +848,46 @@ hsa_status_t XdnaDriver::SubmitCmdChain(hsa_amd_aie_ert_packet_t* first_pkt, uin
     cmd->count = pkt->count + CMD_COUNT_SIZE_INCREASE;
     cmd->opcode = pkt->opcode;
 
-    // Find if the PDI is cached in the queues PDI cache. If even one PDI is not found, the hardware
-    // context will need to be reconfigured and the cache updated.
+    // Determine if the PDI is cached, if not it will be added to the PDI cache and the hardware
+    // context will be reconfigured.
     auto pdi_bo_handle = FindBOHandle(cmd_pkt_payload->pdi_addr);
-    if (!pdi_bo_handle.IsValid()) return HSA_STATUS_ERROR_INVALID_ALLOCATION;
-
-    // Determine if the PDI is cached, if not it will be added to the PDI cache.
+    if (!pdi_bo_handle.IsValid()) {
+      return HSA_STATUS_ERROR_INVALID_ALLOCATION;
+    }
     auto cached_pdi_index = pdi_cache.GetIndex(pdi_bo_handle.handle);
     if (cached_pdi_index == PDICache::NotFound) {
       FlushCpuCache(pdi_bo_handle.vaddr, 0, pdi_bo_handle.size);
       status = pdi_cache.SetNext(pdi_bo_handle, cached_pdi_index);
       if (status != HSA_STATUS_SUCCESS) {
+        assert(false && "Failed to set PDI in cache.");
         return status;
       }
       reconfigure_queue = true;
     }
 
-    cmd->data[0] = 0x1 << static_cast<uint32_t>(cached_pdi_index);
+    cmd->data[0] = 0x1 << cached_pdi_index;
     memcpy((cmd->data + 1), cmd_pkt_payload->data, 4 * pkt->count);
-
-    // Keeping track of the command
-    cmd_bo_handles.push_back(cmd_bo_handle);
-    cmd_bo_handle_guard.Dismiss();
   }
 
-  // If there were PDIs that were not cached, the hardware context needs to be reconfigured.
-  // The cache map will be update with the new hardware context.
   if (reconfigure_queue) {
-    if (pdi_cache_it != hw_ctx_pdi_cache_map.end()) {
-      hw_ctx_pdi_cache_map.erase(pdi_cache_it);
-    }
-
+    // The hardware context needs to be reconfigured because a PDI was added to the cache.
     hsa_status_t status = ConfigHwCtx(pdi_cache, queue_id, num_core_tiles);
     if (status != HSA_STATUS_SUCCESS) {
+      assert(false && "Failed to configure hardware context for queue.");
       return status;
     }
-
-    // Update cache mapping.
-    hw_ctx_pdi_cache_map.emplace(hw_ctx_handle, pdi_cache);
+    hw_ctx_pdi_cache_map[queue_id] = pdi_cache;
   }
+
+  assert(queue_id != AMDXDNA_INVALID_CTX_HANDLE &&
+         "Invalid queue ID after hardware context configuration.");
 
   // Creating a packet that contains the command chain
   const uint32_t cmd_chain_size = (cmd_bo_handles.size() + 1) * sizeof(uint32_t);
   BOHandle cmd_chain_bo_handle;
   hsa_status_t status = CreateCmdBO(cmd_chain_size, cmd_chain_bo_handle);
   if (status != HSA_STATUS_SUCCESS) {
+    assert(false && "Failed to create command chain BO.");
     return status;
   }
   // Unmap and close the command chain BO in case of an error.
@@ -910,6 +919,7 @@ hsa_status_t XdnaDriver::SubmitCmdChain(hsa_amd_aie_ert_packet_t* first_pkt, uin
   // Executing all commands in the command chain
   status = ExecCmdAndWait(cmd_chain_bo_handle, bo_handles, queue_id);
   if (status != HSA_STATUS_SUCCESS) {
+    assert(false && "Failed to dispatch command chain.");
     return status;
   }
 

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/driver/xdna/amd_xdna_driver.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/driver/xdna/amd_xdna_driver.cpp
@@ -444,7 +444,7 @@ hsa_status_t XdnaDriver::DestroyQueue(HSA_QUEUEID queue_id) const {
   }
 
   // Drop PDI cache.
-  const_cast<std::unordered_map<HSA_QUEUEID, PDICache>&>(hw_ctx_pdi_cache_map).erase(queue_id);
+  const_cast<std::unordered_map<HSA_QUEUEID, PDICache>&>(queue_pdi_map_).erase(queue_id);
 
   // Destroy hardware context associated with the queue.
   amdxdna_drm_destroy_hwctx destroy_hwctx_args = {};
@@ -806,8 +806,8 @@ hsa_status_t XdnaDriver::SubmitCmdChain(hsa_amd_aie_ert_packet_t* first_pkt, uin
   // hardware context will be created for the queue.
   PDICache pdi_cache;
   if (static_cast<uint32_t>(queue_id) != AMDXDNA_INVALID_CTX_HANDLE) {
-    auto pdi_cache_it = hw_ctx_pdi_cache_map.find(queue_id);
-    if (pdi_cache_it != hw_ctx_pdi_cache_map.end()) {
+    auto pdi_cache_it = queue_pdi_map_.find(queue_id);
+    if (pdi_cache_it != queue_pdi_map_.end()) {
       pdi_cache = pdi_cache_it->second;
     }
   }
@@ -876,7 +876,7 @@ hsa_status_t XdnaDriver::SubmitCmdChain(hsa_amd_aie_ert_packet_t* first_pkt, uin
       assert(false && "Failed to configure hardware context for queue.");
       return status;
     }
-    hw_ctx_pdi_cache_map[queue_id] = pdi_cache;
+    queue_pdi_map_[queue_id] = pdi_cache;
   }
 
   assert(queue_id != AMDXDNA_INVALID_CTX_HANDLE &&

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/inc/amd_aie_aql_queue.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/inc/amd_aie_aql_queue.h
@@ -93,26 +93,12 @@ class AieAqlQueue : public core::Queue,
   uint64_t AddWriteIndexAcqRel(uint64_t value) override;
   void StoreRelaxed(hsa_signal_value_t value) override;
   void StoreRelease(hsa_signal_value_t value) override;
-
-  /// @brief Provide information about the queue.
   hsa_status_t GetInfo(hsa_queue_info_attribute_t attribute,
                        void *value) override;
-
-  // AIE-specific API
-
-  /// @brief Returns the agent associated with this queue.
-  AieAgent& GetAgent() { return agent_; }
-
-  // GPU-specific queue functions are unsupported.
-
-  hsa_status_t GetCUMasking(uint32_t num_cu_mask_count,
-                            uint32_t *cu_mask) override;
-  hsa_status_t SetCUMasking(uint32_t num_cu_mask_count,
-                            const uint32_t *cu_mask) override;
-  void ExecutePM4(uint32_t *cmd_data, size_t cmd_size_b,
-                  hsa_fence_scope_t acquireFence = HSA_FENCE_SCOPE_NONE,
-                  hsa_fence_scope_t releaseFence = HSA_FENCE_SCOPE_NONE,
-                  hsa_signal_t *signal = NULL) override;
+  hsa_status_t GetCUMasking(uint32_t num_cu_mask_count, uint32_t* cu_mask) override;
+  hsa_status_t SetCUMasking(uint32_t num_cu_mask_count, const uint32_t* cu_mask) override;
+  void ExecutePM4(uint32_t* cmd_data, size_t cmd_size_b, hsa_fence_scope_t acquireFence,
+                  hsa_fence_scope_t releaseFence, hsa_signal_t* signal) override;
 
  private:
   HSA_QUEUEID queue_id_ = INVALID_QUEUEID;

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/inc/amd_xdna_driver.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/inc/amd_xdna_driver.h
@@ -120,24 +120,32 @@ class XdnaDriver final : public core::Driver {
 
   /// @brief Per hardware context PDI cache.
   class PDICache {
+   private:
     /// @brief CU mask size.
     constexpr static size_t cu_mask_size = sizeof(uint32_t) * CHAR_BIT;
 
+   public:
+    using size_type = uint32_t;
+
+   private:
     std::array<BOHandle, cu_mask_size> entries = {};
-    size_t entry_count = 0;
+    size_type entry_count = 0;
 
    public:
     /// @brief Sentinel value for entries not found.
-    constexpr static size_t NotFound = cu_mask_size;
+    constexpr static size_type NotFound = cu_mask_size;
+
+    /// @brief Returns if the cache is empty.
+    constexpr bool empty() const { return entry_count == 0; }
 
     /// @brief Returns the size of the cache.
-    constexpr size_t size() const { return entry_count; }
+    constexpr size_type size() const { return entry_count; }
 
     /// @brief Returns the index of the BO handle if it is the cache, otherwise @ref NotFound.
     ///
     /// This function does a linear search because the mask is small (32 elements).
-    size_t GetIndex(uint32_t pdi_handle) const {
-      for (size_t i = 0; i < entry_count; ++i) {
+    size_type GetIndex(uint32_t pdi_handle) const {
+      for (size_type i = 0; i < entry_count; ++i) {
         if (entries[i].handle == pdi_handle) {
           return i;
         }
@@ -146,7 +154,7 @@ class XdnaDriver final : public core::Driver {
     }
 
     /// @brief Sets the next cache entry.
-    hsa_status_t SetNext(const BOHandle& pdi_bo_handle, size_t& index) {
+    hsa_status_t SetNext(const BOHandle& pdi_bo_handle, size_type& index) {
       if (entry_count == entries.size()) {
         // cache is full
         return HSA_STATUS_ERROR_OUT_OF_RESOURCES;
@@ -157,7 +165,7 @@ class XdnaDriver final : public core::Driver {
       return HSA_STATUS_SUCCESS;
     }
 
-    constexpr const BOHandle& operator[](size_t index) const { return entries[index]; }
+    constexpr const BOHandle& operator[](size_type index) const { return entries[index]; }
   };
 
 public:
@@ -286,8 +294,8 @@ public:
 
   std::map<void*, BOHandle> vmem_addr_mappings;
 
-  /// @brief Hardware context to PDI cache mapping.
-  std::unordered_map<uint32_t, PDICache> hw_ctx_pdi_cache_map;
+  /// @brief Queue to PDI cache mapping.
+  std::unordered_map<HSA_QUEUEID, PDICache> hw_ctx_pdi_cache_map;
 
   /// @brief Virtual address range allocated for the device heap.
   ///

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/inc/amd_xdna_driver.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/inc/amd_xdna_driver.h
@@ -294,8 +294,8 @@ public:
 
   std::map<void*, BOHandle> vmem_addr_mappings;
 
-  /// @brief Queue to PDI cache mapping.
-  std::unordered_map<HSA_QUEUEID, PDICache> hw_ctx_pdi_cache_map;
+  /// @brief Queue to PDI cache map.
+  std::unordered_map<HSA_QUEUEID, PDICache> queue_pdi_map_;
 
   /// @brief Virtual address range allocated for the device heap.
   ///

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_aie_aql_queue.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_aie_aql_queue.cpp
@@ -124,14 +124,13 @@ AieAqlQueue::~AieAqlQueue() {
 }
 
 hsa_status_t AieAqlQueue::Inactivate() {
-  bool active(active_.exchange(false, std::memory_order_relaxed));
-  hsa_status_t status(HSA_STATUS_SUCCESS);
-
+  bool active = active_.exchange(false, std::memory_order_relaxed);
   if (active) {
-    agent_.driver().DestroyQueue(queue_id_);
+    auto err = agent_.driver().DestroyQueue(queue_id_);
+    assert(err == HSA_STATUS_SUCCESS && "Destroy queue failed.");
+    atomic::Fence(std::memory_order_acquire);
   }
-
-  return status;
+  return HSA_STATUS_SUCCESS;
 }
 
 hsa_status_t AieAqlQueue::SetPriority(HSA::hsa_amd_queue_priority_internal_t priority) {

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_aie_aql_queue.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_aie_aql_queue.cpp
@@ -270,8 +270,7 @@ void AieAqlQueue::StoreRelease(hsa_signal_value_t value) {
   StoreRelaxed(value);
 }
 
-hsa_status_t AieAqlQueue::GetInfo(hsa_queue_info_attribute_t attribute,
-                                  void *value) {
+hsa_status_t AieAqlQueue::GetInfo(hsa_queue_info_attribute_t attribute, void* value) {
   switch (attribute) {
     case HSA_AMD_QUEUE_INFO_AGENT:
       *static_cast<hsa_agent_t*>(value) = agent_.public_handle();
@@ -293,22 +292,16 @@ hsa_status_t AieAqlQueue::GetInfo(hsa_queue_info_attribute_t attribute,
   return HSA_STATUS_SUCCESS;
 }
 
-hsa_status_t AieAqlQueue::GetCUMasking(uint32_t num_cu_mask_count,
-                                       uint32_t *cu_mask) {
-  assert(false && "AIE AQL queue does not support CU masking.");
-  return HSA_STATUS_ERROR;
+hsa_status_t AieAqlQueue::GetCUMasking(uint32_t num_cu_mask_count, uint32_t* cu_mask) {
+  return HSA_STATUS_ERROR_INVALID_QUEUE;
 }
 
-hsa_status_t AieAqlQueue::SetCUMasking(uint32_t num_cu_mask_count,
-                                       const uint32_t *cu_mask) {
-  assert(false && "AIE AQL queue does not support CU masking.");
-  return HSA_STATUS_ERROR;
+hsa_status_t AieAqlQueue::SetCUMasking(uint32_t num_cu_mask_count, const uint32_t* cu_mask) {
+  return HSA_STATUS_ERROR_INVALID_QUEUE;
 }
 
-void AieAqlQueue::ExecutePM4(uint32_t *cmd_data, size_t cmd_size_b,
-                             hsa_fence_scope_t acquireFence,
-                             hsa_fence_scope_t releaseFence,
-                             hsa_signal_t *signal) {
+void AieAqlQueue::ExecutePM4(uint32_t* cmd_data, size_t cmd_size_b, hsa_fence_scope_t acquireFence,
+                             hsa_fence_scope_t releaseFence, hsa_signal_t* signal) {
   assert(false && "AIE AQL queue does not support PM4 packets.");
 }
 


### PR DESCRIPTION
## Motivation

This PR solves a constant hardware context reconfiguration that was encountered upon queue tear-down and re-setup during benchmarking.

## Technical Details

The PDI cache is used to create the CU mask during command chain submission. Each cache entry is indexed by the queue ID, but AIE queues (`AieAqlQueue`) are initialized with an invalid hardware context. This was leading to the cache being set for the wrong hardware context, which led to either not being used, leading to constant reconfiguration, or using a wrong cache, which led to crashes.

## JIRA ID

NA

## Test Plan

Run local AIE tests and benchmarks with 10,000s of iterations.

## Test Result

Success.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
