### PR TITLE
Change otf2 tar.gz link to point to internal mirror

### DIFF
--- a/projects/rocprofiler-sdk/external/otf2/CMakeLists.txt
+++ b/projects/rocprofiler-sdk/external/otf2/CMakeLists.txt
@@ -3,20 +3,19 @@
 # ======================================================================================
 
 set(ROCPROFILER_BINARY_DIR ${PROJECT_BINARY_DIR})
-set(OTF2_VERSION "3.0.3" CACHE STRING "OTF2 version")
+set(OTF2_VERSION
+    "3.0.3"
+    CACHE STRING "OTF2 version")
 set(OTF2_URL_HASH
     "SHA256=18a3905f7917340387e3edc8e5766f31ab1af41f4ecc5665da6c769ca21c4ee8"
-    CACHE STRING
-    "OTF2 URL download hash"
-)
+    CACHE STRING "OTF2 URL download hash")
 
 project(
     OTF2
     LANGUAGES C
     VERSION ${OTF2_VERSION}
     DESCRIPTION "Open Trace Format v2"
-    HOMEPAGE_URL "https://perftools.pages.jsc.fz-juelich.de/cicd/otf2"
-)
+    HOMEPAGE_URL "https://perftools.pages.jsc.fz-juelich.de/cicd/otf2")
 
 include(FetchContent)
 include(ExternalProject)
@@ -28,35 +27,35 @@ endif()
 
 set(FETCHCONTENT_BASE_DIR ${ROCPROFILER_BINARY_DIR}/external/packages)
 
-# Only OTF2 3.0.3 is uploaded to S3.
-# If another otf2 release is added, update the URL, OTF2_VERSION, and OTF2_URL_HASH
+# Only OTF2 3.0.3 is uploaded to S3. If another otf2 release is added, update the URL,
+# OTF2_VERSION, and OTF2_URL_HASH
 if(NOT ${OTF2_VERSION} STREQUAL "3.0.3")
     message(FATAL_ERROR "Unsupported OTF2 version: ${OTF2_VERSION}")
 endif()
 
-FetchContent_Declare(
+fetchcontent_declare(
     otf2-source
-    URL
-        https://rocm-third-party-deps.s3.us-east-2.amazonaws.com/otf2-${OTF2_VERSION}.tar.gz
-    URL_HASH ${OTF2_URL_HASH}
-)
+    URL https://rocm-third-party-deps.s3.us-east-2.amazonaws.com/otf2-${OTF2_VERSION}.tar.gz
+    URL_HASH ${OTF2_URL_HASH})
 
-FetchContent_MakeAvailable(otf2-source)
+fetchcontent_makeavailable(otf2-source)
 
 set(_otf2_root ${ROCPROFILER_BINARY_DIR}/external/otf2)
 set(_otf2_inc_dirs $<BUILD_INTERFACE:${_otf2_root}/include>)
 set(_otf2_lib_dirs $<BUILD_INTERFACE:${_otf2_root}/${CMAKE_INSTALL_LIBDIR}>)
 set(_otf2_libs
     $<BUILD_INTERFACE:${_otf2_root}/${CMAKE_INSTALL_LIBDIR}/libotf2${CMAKE_STATIC_LIBRARY_SUFFIX}>
-)
+    )
 set(_otf2_build_byproducts
     "${_otf2_root}/include/otf2/otf2.h"
-    "${_otf2_root}/${CMAKE_INSTALL_LIBDIR}/libotf2${CMAKE_STATIC_LIBRARY_SUFFIX}"
-)
+    "${_otf2_root}/${CMAKE_INSTALL_LIBDIR}/libotf2${CMAKE_STATIC_LIBRARY_SUFFIX}")
 
-find_program(MAKE_COMMAND NAMES make gmake PATH_SUFFIXES bin REQUIRED)
+find_program(
+    MAKE_COMMAND
+    NAMES make gmake
+    PATH_SUFFIXES bin REQUIRED)
 
-ExternalProject_Add(
+externalproject_add(
     otf2-build
     PREFIX ${_otf2_root}
     SOURCE_DIR ${otf2-source_SOURCE_DIR}
@@ -70,8 +69,7 @@ ExternalProject_Add(
         CXXFLAGS=-fPIC\ -O3\ -g LDFLAGS= PYTHON=: SPHINX=:
     BUILD_COMMAND ${MAKE_COMMAND} install -s
     BUILD_BYPRODUCTS "${_otf2_build_byproducts}"
-    INSTALL_COMMAND ""
-)
+    INSTALL_COMMAND "")
 
 add_library(otf2 INTERFACE)
 add_library(otf2::otf2 ALIAS otf2)

--- a/projects/rocprofiler-sdk/external/otf2/CMakeLists.txt
+++ b/projects/rocprofiler-sdk/external/otf2/CMakeLists.txt
@@ -3,19 +3,20 @@
 # ======================================================================================
 
 set(ROCPROFILER_BINARY_DIR ${PROJECT_BINARY_DIR})
-set(OTF2_VERSION
-    "3.0.3"
-    CACHE STRING "OTF2 version")
+set(OTF2_VERSION "3.0.3" CACHE STRING "OTF2 version")
 set(OTF2_URL_HASH
     "SHA256=18a3905f7917340387e3edc8e5766f31ab1af41f4ecc5665da6c769ca21c4ee8"
-    CACHE STRING "OTF2 URL download hash")
+    CACHE STRING
+    "OTF2 URL download hash"
+)
 
 project(
     OTF2
     LANGUAGES C
     VERSION ${OTF2_VERSION}
     DESCRIPTION "Open Trace Format v2"
-    HOMEPAGE_URL "https://perftools.pages.jsc.fz-juelich.de/cicd/otf2")
+    HOMEPAGE_URL "https://perftools.pages.jsc.fz-juelich.de/cicd/otf2"
+)
 
 include(FetchContent)
 include(ExternalProject)
@@ -27,29 +28,35 @@ endif()
 
 set(FETCHCONTENT_BASE_DIR ${ROCPROFILER_BINARY_DIR}/external/packages)
 
-fetchcontent_declare(
-    otf2-source
-    URL https://perftools.pages.jsc.fz-juelich.de/cicd/otf2/tags/otf2-${OTF2_VERSION}/otf2-${OTF2_VERSION}.tar.gz
-    URL_HASH ${OTF2_URL_HASH})
+# Only OTF2 3.0.3 is uploaded to S3.
+# If another otf2 release is added, update the URL, OTF2_VERSION, and OTF2_URL_HASH
+if(NOT ${OTF2_VERSION} STREQUAL "3.0.3")
+    message(FATAL_ERROR "Unsupported OTF2 version: ${OTF2_VERSION}")
+endif()
 
-fetchcontent_makeavailable(otf2-source)
+FetchContent_Declare(
+    otf2-source
+    URL
+        https://rocm-third-party-deps.s3.us-east-2.amazonaws.com/otf2-${OTF2_VERSION}.tar.gz
+    URL_HASH ${OTF2_URL_HASH}
+)
+
+FetchContent_MakeAvailable(otf2-source)
 
 set(_otf2_root ${ROCPROFILER_BINARY_DIR}/external/otf2)
 set(_otf2_inc_dirs $<BUILD_INTERFACE:${_otf2_root}/include>)
 set(_otf2_lib_dirs $<BUILD_INTERFACE:${_otf2_root}/${CMAKE_INSTALL_LIBDIR}>)
 set(_otf2_libs
     $<BUILD_INTERFACE:${_otf2_root}/${CMAKE_INSTALL_LIBDIR}/libotf2${CMAKE_STATIC_LIBRARY_SUFFIX}>
-    )
+)
 set(_otf2_build_byproducts
     "${_otf2_root}/include/otf2/otf2.h"
-    "${_otf2_root}/${CMAKE_INSTALL_LIBDIR}/libotf2${CMAKE_STATIC_LIBRARY_SUFFIX}")
+    "${_otf2_root}/${CMAKE_INSTALL_LIBDIR}/libotf2${CMAKE_STATIC_LIBRARY_SUFFIX}"
+)
 
-find_program(
-    MAKE_COMMAND
-    NAMES make gmake
-    PATH_SUFFIXES bin REQUIRED)
+find_program(MAKE_COMMAND NAMES make gmake PATH_SUFFIXES bin REQUIRED)
 
-externalproject_add(
+ExternalProject_Add(
     otf2-build
     PREFIX ${_otf2_root}
     SOURCE_DIR ${otf2-source_SOURCE_DIR}
@@ -63,7 +70,8 @@ externalproject_add(
         CXXFLAGS=-fPIC\ -O3\ -g LDFLAGS= PYTHON=: SPHINX=:
     BUILD_COMMAND ${MAKE_COMMAND} install -s
     BUILD_BYPRODUCTS "${_otf2_build_byproducts}"
-    INSTALL_COMMAND "")
+    INSTALL_COMMAND ""
+)
 
 add_library(otf2 INTERFACE)
 add_library(otf2::otf2 ALIAS otf2)


### PR DESCRIPTION
## Motivation

Replace the link to OTF2 third-party tar.gz with link to internal mirror

## Technical Details

Should not point to external sources as when they disappear builds and CI break immediately

## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan

Need CI pass

## Test Result

See above

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
