### PR TITLE
clr: Cleanup Func and Var classes

### DIFF
--- a/projects/clr/hipamd/src/hip_code_object.cpp
+++ b/projects/clr/hipamd/src/hip_code_object.cpp
@@ -51,19 +51,19 @@ DynCO::~DynCO() {
   std::scoped_lock lock(dclock_);
 
   for (auto& elem : vars_) {
-    if (elem.second->getVarKind() == Var::DVK_Managed) {
-      hipError_t err = ihipFree(elem.second->getManagedVarPtr());
+    if (elem.second->GetVarKind() == Var::DVK_Managed) {
+      hipError_t err = ihipFree(elem.second->GetManagedVarPtr());
       assert(err == hipSuccess);
     }
 
-    if (elem.second->getVarKind() == Var::DVK_Variable) {
+    if (elem.second->GetVarKind() == Var::DVK_Variable) {
       for (auto dev : g_devices) {
-        DeviceVar* dvar = nullptr;
-        hipError_t err = elem.second->getDeviceVarPtr(&dvar, dev->deviceId());
+        amd::Memory* mem = nullptr;
+        hipError_t err = elem.second->GetDeviceVarPtr(&mem, dev->deviceId());
         assert(err == hipSuccess);
-        if (dvar != nullptr) {
+        if (mem != nullptr) {
           // free also deletes the device ptr
-          err = ihipFree(dvar->device_ptr());
+          err = ihipFree(memDevPtr(mem));
           assert(err == hipSuccess);
         }
       }
@@ -80,7 +80,7 @@ DynCO::~DynCO() {
   delete fb_info_;
 }
 
-hipError_t DynCO::getDeviceVar(DeviceVar** dvar, const std::string& var_name) {
+hipError_t DynCO::GetDeviceVar(amd::Memory** mem, const std::string& var_name) {
   std::scoped_lock lock(dclock_);
 
   auto it = vars_.find(var_name);
@@ -89,8 +89,13 @@ hipError_t DynCO::getDeviceVar(DeviceVar** dvar, const std::string& var_name) {
     return hipErrorNotFound;
   }
 
-  hipError_t err = it->second->getDeviceVar(dvar, device_id_, module_);
-  return err;
+  return it->second->GetDeviceVar(mem, device_id_, module_);
+}
+
+hip::Var* DynCO::getVar(const std::string& var_name) {
+  std::scoped_lock lock(dclock_);
+  auto it = vars_.find(var_name);
+  return (it != vars_.end()) ? it->second : nullptr;
 }
 
 hipError_t DynCO::getDynFunc(hipFunction_t* hfunc, const std::string& func_name) {
@@ -107,7 +112,7 @@ hipError_t DynCO::getDynFunc(hipFunction_t* hfunc, const std::string& func_name)
   }
 
   /* See if this could be solved */
-  return it->second->getDynFunc(hfunc, module_);
+  return it->second->GetDynFunc(hfunc, module_);
 }
 
 hipError_t DynCO::getFuncCount(unsigned int* count) {
@@ -122,33 +127,33 @@ hipError_t DynCO::getFuncCount(unsigned int* count) {
 bool DynCO::isValidDynFunc(const void* hfunc) {
   std::scoped_lock lock(dclock_);
   return std::any_of(functions_.begin(), functions_.end(),
-                     [&](auto& it) { return it.second->isValidDynFunc(hfunc); });
+                     [&](auto& it) { return it.second->IsValidDynFunc(hfunc); });
 }
 
 hipError_t DynCO::initDynManagedVars(const std::string& managedVar) {
   std::scoped_lock lock(dclock_);
-  DeviceVar* dvar;
+  amd::Memory* mem = nullptr;
   void* pointer = nullptr;
   hipError_t status = hipSuccess;
   // To get size of the managed variable
-  status = getDeviceVar(&dvar, managedVar + ".managed");
+  status = GetDeviceVar(&mem, managedVar + ".managed");
   if (status != hipSuccess) {
     ClPrint(amd::LOG_ERROR, amd::LOG_API, "Status %d, failed to get .managed device variable:%s",
             status, managedVar.c_str());
     return status;
   }
   // Allocate managed memory for these symbols
-  status = ihipMallocManaged(&pointer, dvar->size(), 0, 0);
+  status = ihipMallocManaged(&pointer, mem->getSize(), 0, 0);
   guarantee(status == hipSuccess, "Status %d, failed to allocate managed memory", status);
 
   // update as manager variable and set managed memory pointer and size
   auto it = vars_.find(managedVar);
-  it->second->setManagedVarInfo(pointer, dvar->size());
+  it->second->SetManagedVarInfo(pointer, mem->getSize());
 
   // copy initial value to the managed variable to the managed memory allocated
   hip::Stream* stream = hip::getNullStream();
   if (stream != nullptr) {
-    status = ihipMemcpy(pointer, reinterpret_cast<address>(dvar->device_ptr()), dvar->size(),
+    status = ihipMemcpy(pointer, reinterpret_cast<address>(memDevPtr(mem)), mem->getSize(),
                         hipMemcpyDeviceToDevice, *stream);
     if (status != hipSuccess) {
       ClPrint(amd::LOG_ERROR, amd::LOG_API, "Status %d, failed to copy device ptr:%s", status,
@@ -160,15 +165,15 @@ hipError_t DynCO::initDynManagedVars(const std::string& managedVar) {
     return hipErrorInvalidResourceHandle;
   }
 
-  // Get deivce ptr to initialize with managed memory pointer
-  status = getDeviceVar(&dvar, managedVar);
+  // Get device ptr to initialize with managed memory pointer
+  status = GetDeviceVar(&mem, managedVar);
   if (status != hipSuccess) {
     ClPrint(amd::LOG_ERROR, amd::LOG_API, "Status %d, failed to get managed device variable:%s",
             status, managedVar.c_str());
     return status;
   }
   // copy managed memory pointer to the managed device variable
-  status = ihipMemcpy(reinterpret_cast<address>(dvar->device_ptr()), &pointer, dvar->size(),
+  status = ihipMemcpy(reinterpret_cast<address>(memDevPtr(mem)), &pointer, mem->getSize(),
                       hipMemcpyHostToDevice, *stream);
   if (status != hipSuccess) {
     ClPrint(amd::LOG_ERROR, amd::LOG_API, "Status %d, failed to copy device ptr:%s", status,
@@ -348,19 +353,19 @@ hipError_t StatCO::RemoveFatBinary(FatBinaryInfo** module) {
     for (auto& managedVar : managedVarsIter->second) {
       hipError_t err = hipSuccess;
       for (auto dev : g_devices) {
-        DeviceVar* dvar = nullptr;
-        IHIP_RETURN_ONFAIL(managedVar->getDeviceVarPtr(&dvar, dev->deviceId()));
-        if (dvar != nullptr) {
+        amd::Memory* mem = nullptr;
+        IHIP_RETURN_ONFAIL(managedVar->GetDeviceVarPtr(&mem, dev->deviceId()));
+        if (mem != nullptr) {
           // free also deletes the device ptr
-          err = ihipFree(dvar->device_ptr());
+          err = ihipFree(memDevPtr(mem));
           assert(err == hipSuccess);
         }
       }
-      if (managedVar->getAllocFlag()) {  // check if it is a managed or host alloc
-        err = ihipFree(*(static_cast<void**>(managedVar->getManagedVarPtr())));
+      if (managedVar->GetAllocFlag()) {  // check if it is a managed or host alloc
+        err = ihipFree(*(static_cast<void**>(managedVar->GetManagedVarPtr())));
       } else {
-        void** pointer = static_cast<void**>(managedVar->getManagedVarPtr());
-        amd::Os::releaseMemory(*pointer, managedVar->getSize());
+        void** pointer = static_cast<void**>(managedVar->GetManagedVarPtr());
+        amd::Os::releaseMemory(*pointer, managedVar->GetSize());
       }
       assert(err == hipSuccess);
       delete managedVar;
@@ -420,23 +425,23 @@ void StatCO::RemoveAllFatBinaries() {
     for (auto& managed_var : managed_vars) {
       // Free device-specific allocations across all devices
       for (auto dev : g_devices) {
-        DeviceVar* dvar = nullptr;
-        if (managed_var->getDeviceVarPtr(&dvar, dev->deviceId()) == hipSuccess && dvar) {
+        amd::Memory* mem = nullptr;
+        if (managed_var->GetDeviceVarPtr(&mem, dev->deviceId()) == hipSuccess && mem) {
           // Free device memory (also deletes the device ptr)
-          [[maybe_unused]] hipError_t err = ihipFree(dvar->device_ptr());
+          [[maybe_unused]] hipError_t err = ihipFree(memDevPtr(mem));
           assert(err == hipSuccess);
         }
       }
 
       // Free the managed memory allocation itself
-      void** managed_ptr = static_cast<void**>(managed_var->getManagedVarPtr());
-      if (managed_var->getAllocFlag()) {
+      void** managed_ptr = static_cast<void**>(managed_var->GetManagedVarPtr());
+      if (managed_var->GetAllocFlag()) {
         // Memory was allocated with ihipMallocManaged - use ihipFree
         [[maybe_unused]] hipError_t err = ihipFree(*managed_ptr);
         assert(err == hipSuccess);
       } else {
         // Memory was allocated with OS-level allocator - use OS release
-        amd::Os::releaseMemory(*managed_ptr, managed_var->getSize());
+        amd::Os::releaseMemory(*managed_ptr, managed_var->GetSize());
       }
       delete managed_var;
     }
@@ -465,7 +470,7 @@ hipError_t StatCO::RegisterFunction(const void* hostFunction, Function* func) {
     delete func;
   } else {
     functions_.insert(std::make_pair(hostFunction, func));
-    module_to_hostFunctions_[func->moduleInfo()].push_back(hostFunction);
+    module_to_hostFunctions_[func->ModuleInfo()].push_back(hostFunction);
   }
 
   return hipSuccess;
@@ -478,7 +483,7 @@ const char* StatCO::GetFuncName(const void* hostFunction) {
   if (it == functions_.end()) {
     return nullptr;
   }
-  return it->second->name().c_str();
+  return it->second->GetName().c_str();
 }
 
 hipError_t StatCO::GetFunc(hipFunction_t* hfunc, const void* hostFunction, int deviceId) {
@@ -488,7 +493,7 @@ hipError_t StatCO::GetFunc(hipFunction_t* hfunc, const void* hostFunction, int d
   }
 
   // Lazy load
-  FatBinaryInfo** module = it->second->moduleInfo();
+  FatBinaryInfo** module = it->second->ModuleInfo();
   if (module != nullptr) {
     std::scoped_lock lock(sclock_);
     if (*(module) == nullptr) {
@@ -503,7 +508,7 @@ hipError_t StatCO::GetFunc(hipFunction_t* hfunc, const void* hostFunction, int d
     return hipErrorInvalidDeviceFunction;
   }
 
-  return it->second->getStatFunc(hfunc, deviceId);
+  return it->second->GetStatFunc(hfunc, deviceId);
 }
 
 hipError_t StatCO::GetFuncAttr(hipFuncAttributes* func_attr, const void* hostFunction,
@@ -516,24 +521,24 @@ hipError_t StatCO::GetFuncAttr(hipFuncAttributes* func_attr, const void* hostFun
   }
 
   // Lazy load
-  FatBinaryInfo** module = it->second->moduleInfo();
+  FatBinaryInfo** module = it->second->ModuleInfo();
   if (*(module) == nullptr) {
     std::ignore = DigestFatBinary(module_to_hostModule_[module], *module);
   }
 
-  return it->second->getStatFuncAttr(func_attr, deviceId);
+  return it->second->GetStatFuncAttr(func_attr, deviceId);
 }
 
 hipError_t StatCO::RegisterGlobalVar(const void* hostVar, Var* var) {
   std::scoped_lock lock(sclock_);
 
   auto var_it = vars_.find(hostVar);
-  if ((var_it != vars_.end()) && (var_it->second->getName() != var->getName())) {
+  if ((var_it != vars_.end()) && (var_it->second->GetName() != var->GetName())) {
     return hipErrorInvalidSymbol;
   }
 
   vars_.insert(std::make_pair(hostVar, var));
-  module_to_hostVars_[var->moduleInfo()].push_back(hostVar);
+  module_to_hostVars_[var->ModuleInfo()].push_back(hostVar);
   return hipSuccess;
 }
 
@@ -547,21 +552,21 @@ hipError_t StatCO::GetGlobalVar(const void* hostVar, int deviceId, hipDeviceptr_
   }
 
   // Lazy load
-  FatBinaryInfo** module = it->second->moduleInfo();
+  FatBinaryInfo** module = it->second->ModuleInfo();
   if (*(module) == nullptr) {
     std::ignore = DigestFatBinary(module_to_hostModule_[module], *module);
   }
 
-  DeviceVar* dvar = nullptr;
-  IHIP_RETURN_ONFAIL(it->second->getStatDeviceVar(&dvar, deviceId));
+  amd::Memory* mem = nullptr;
+  IHIP_RETURN_ONFAIL(it->second->GetStatDeviceVar(&mem, deviceId));
 
-  *dev_ptr = dvar->device_ptr();
-  *size_ptr = dvar->size();
+  *dev_ptr = memDevPtr(mem);
+  *size_ptr = mem->getSize();
   return hipSuccess;
 }
 
 hipError_t StatCO::RegisterManagedVar(Var* var) {
-  managedVars_[var->moduleInfo()].push_back(var);
+  managedVars_[var->ModuleInfo()].push_back(var);
   return hipSuccess;
 }
 
@@ -569,15 +574,15 @@ hipError_t StatCO::RegisterManagedVar(Var* var) {
 void StatCO::ResizeForDevices(size_t device_count) {
   std::scoped_lock lock(sclock_);
   for (const auto& it : vars_) {
-    it.second->resize_dVar(device_count);
+    it.second->ResizeDVar(device_count);
   }
   for (const auto& it : managedVars_) {
     for (const auto& var : it.second) {
-      var->resize_dVar(device_count);
+      var->ResizeDVar(device_count);
     }
   }
   for (const auto& it : functions_) {
-    it.second->resize_dFunc(device_count);
+    it.second->ResizeDFunc(device_count);
   }
 }
 
@@ -590,7 +595,7 @@ hipError_t StatCO::InitManagedVarDevicePtr(int deviceId) {
     for (auto& vecIter : managedVars_) {
       for (auto& var : vecIter.second) {
         // Lazy load
-        FatBinaryInfo** module = var->moduleInfo();
+        FatBinaryInfo** module = var->ModuleInfo();
         if (*(module) == nullptr) {
           std::ignore = DigestFatBinary(module_to_hostModule_[module], *module);
         }
@@ -600,12 +605,12 @@ hipError_t StatCO::InitManagedVarDevicePtr(int deviceId) {
           return hipErrorInvalidResourceHandle;
         }
         // Allocate managed var for deferred loading
-        IHIP_RETURN_ONFAIL(var->allocateManagedVarPtr());
+        IHIP_RETURN_ONFAIL(var->AllocateManagedVarPtr());
         // Copy from managed var host to device ptr
-        DeviceVar* dvar = nullptr;
-        IHIP_RETURN_ONFAIL(var->getStatDeviceVar(&dvar, deviceId));
-        err = ihipMemcpy(reinterpret_cast<address>(dvar->device_ptr()), var->getManagedVarPtr(),
-                         dvar->size(), hipMemcpyHostToDevice, *stream);
+        amd::Memory* mem = nullptr;
+        IHIP_RETURN_ONFAIL(var->GetStatDeviceVar(&mem, deviceId));
+        err = ihipMemcpy(reinterpret_cast<address>(memDevPtr(mem)), var->GetManagedVarPtr(),
+                         mem->getSize(), hipMemcpyHostToDevice, *stream);
       }
     }
     managedVarsDevicePtrInitalized_[deviceId] = true;

--- a/projects/clr/hipamd/src/hip_code_object.cpp
+++ b/projects/clr/hipamd/src/hip_code_object.cpp
@@ -560,6 +560,12 @@ hipError_t StatCO::GetGlobalVar(const void* hostVar, int deviceId, hipDeviceptr_
   amd::Memory* mem = nullptr;
   IHIP_RETURN_ONFAIL(it->second->GetStatDeviceVar(&mem, deviceId));
 
+  if (mem == nullptr) {
+    // Handle size-0 globals: return null device pointer and size 0.
+    *dev_ptr = 0;
+    *size_ptr = 0;
+    return hipSuccess;
+  }
   *dev_ptr = memDevPtr(mem);
   *size_ptr = mem->getSize();
   return hipSuccess;

--- a/projects/clr/hipamd/src/hip_code_object.hpp
+++ b/projects/clr/hipamd/src/hip_code_object.hpp
@@ -101,16 +101,17 @@ class DynCO : public CodeObject {
   hipError_t getDynFunc(hipFunction_t* hfunc, const std::string& func_name);
   hipError_t getFuncCount(unsigned int* count);
   bool isValidDynFunc(const void* hfunc);
-  hipError_t getDeviceVar(DeviceVar** dvar, const std::string& var_name);
+  hipError_t GetDeviceVar(amd::Memory** mem, const std::string& var_name);
+  hip::Var* getVar(const std::string& var_name);
 
   hipError_t getManagedVarPointer(std::string name, void** pointer, size_t* size_ptr) const {
     auto it = vars_.find(name);
-    if (it != vars_.end() && it->second->getVarKind() == Var::DVK_Managed) {
+    if (it != vars_.end() && it->second->GetVarKind() == Var::DVK_Managed) {
       if (pointer != nullptr) {
-        *pointer = it->second->getManagedVarPtr();
+        *pointer = it->second->GetManagedVarPtr();
       }
       if (size_ptr != nullptr) {
-        *size_ptr = it->second->getSize();
+        *size_ptr = it->second->GetSize();
       }
     }
     return hipSuccess;

--- a/projects/clr/hipamd/src/hip_global.cpp
+++ b/projects/clr/hipamd/src/hip_global.cpp
@@ -42,130 +42,79 @@ namespace hip {
 // forward declaration of methods required for managed variables
 hipError_t ihipMallocManaged(void** ptr, size_t size, size_t align = 0, bool use_host_ptr = 0);
 
-// Device Vars
-DeviceVar::DeviceVar(const std::string &name, hipModule_t hmod, int deviceId)
-    : shadowVptr(nullptr), name_(name), amd_mem_obj_(nullptr), device_ptr_(nullptr), size_(0) {
-  amd::Program* program = as_amd(reinterpret_cast<cl_program>(hmod));
-  device::Program* dev_program = program->getDeviceProgram(*g_devices.at(deviceId)->devices()[0]);
-
-  guarantee(dev_program != nullptr, "Cannot get Device Program for module: 0x%x", hmod);
-
-  if (!dev_program->createGlobalVarObj(&amd_mem_obj_, &device_ptr_, &size_, name.c_str())) {
-    guarantee(false, "Cannot create GlobalVar Obj for symbol: %s", name.c_str());
-  }
-
-  // Handle size 0 symbols
-  if (size_ != 0) {
-    if (amd_mem_obj_ == nullptr || device_ptr_ == nullptr) {
-      LogPrintfError("Cannot get memory for creating device Var: %s", name.c_str());
-      guarantee(false, "Cannot get memory for creating device var");
-    }
-    amd::MemObjMap::AddMemObj(device_ptr_, amd_mem_obj_);
-  }
-}
-
-DeviceVar::~DeviceVar() {
-  // device_ptr_ is being removed and its amd:Memory obj is being released/deleted during
-  // ihipFree in hip::StatCO::removeFatBinary however in DynCO path, it seems to bypass
-  // ihipFree and hence it needs to be removed+released here. In order to avoid issue with
-  // StatCO, It is better to check if mem obj is found.
-  if (amd::MemObjMap::FindMemObj(device_ptr_) != nullptr && amd_mem_obj_ != nullptr) {
-    amd::MemObjMap::RemoveMemObj(device_ptr_);
-    amd_mem_obj_->release();
-  }
-  if (shadowVptr != nullptr) {
-    textureReference* texRef = reinterpret_cast<textureReference*>(shadowVptr);
-    hipError_t err = ihipUnbindTexture(texRef);
-    delete texRef;
-    shadowVptr = nullptr;
-  }
-
-  device_ptr_ = nullptr;
-  size_ = 0;
-}
-
-// Device Functions
-DeviceFunc::DeviceFunc(const std::string &name, hipModule_t hmod) : kernel_(nullptr) {
-  amd::Program* program = as_amd(reinterpret_cast<cl_program>(hmod));
-
-  const amd::Symbol* symbol = program->findSymbol(name.c_str());
-  guarantee(symbol != nullptr, "Cannot find Symbol with name: %s", name.c_str());
-
-  kernel_ = new amd::Kernel(*program, *symbol, name);
-}
-
-DeviceFunc::~DeviceFunc() {
-  if (kernel_ != nullptr) {
-    kernel_->release();
-  }
-}
-
-// Abstract functions
+// ================================================================================================
 Function::Function(const std::string& name, FatBinaryInfo** modules)
     : name_(name), modules_(modules) {
   dFunc_.resize(g_devices.size());
 }
 
+// ================================================================================================
 Function::~Function() {
-  for (auto& elem : dFunc_) {
-    delete elem;
+  for (auto& kernel : dFunc_) {
+    if (kernel != nullptr) {
+      kernel->release();
+    }
   }
-  name_ = "";
-  modules_ = nullptr;
 }
 
-hipError_t Function::getDynFunc(hipFunction_t* hfunc, hipModule_t hmod) {
-  guarantee((dFunc_.size() == g_devices.size()), "dFunc Size mismatch");
-  if (dFunc_[ihipGetDevice()] == nullptr) {
-    dFunc_[ihipGetDevice()] = new DeviceFunc(name_, hmod);
-  }
-  *hfunc = dFunc_[ihipGetDevice()]->asHipFunction();
+// ================================================================================================
+amd::Kernel* Function::BuildKernel(hipModule_t hmod) const {
+  amd::Program* program = as_amd(reinterpret_cast<cl_program>(hmod));
+  const amd::Symbol* symbol = program->findSymbol(name_.c_str());
+  guarantee(symbol != nullptr, "Cannot find Symbol with name: %s", name_.c_str());
+  return new amd::Kernel(*program, *symbol, name_);
+}
 
+// ================================================================================================
+hipError_t Function::GetDynFunc(hipFunction_t* hfunc, hipModule_t hmod) {
+  guarantee((dFunc_.size() == g_devices.size()), "dFunc Size mismatch");
+  int dev = ihipGetDevice();
+  if (dFunc_[dev] == nullptr) {
+    dFunc_[dev] = BuildKernel(hmod);
+  }
+  *hfunc = asHipFunction(dFunc_[dev]);
   return hipSuccess;
 }
 
-bool Function::isValidDynFunc(const void* hfunc) {
-  return (hfunc == dFunc_[ihipGetDevice()]->asHipFunction());
+// ================================================================================================
+bool Function::IsValidDynFunc(const void* hfunc) {
+  return (hfunc == asHipFunction(dFunc_[ihipGetDevice()]));
 }
 
-hipError_t Function::getStatFunc(hipFunction_t* hfunc, int deviceId) {
-  if (deviceId >= dFunc_.size()) {
+// ================================================================================================
+hipError_t Function::GetStatFunc(hipFunction_t* hfunc, int deviceId) {
+  if (deviceId >= static_cast<int>(dFunc_.size())) {
     return hipErrorNoBinaryForGpu;
   }
   if (dFunc_[deviceId] != nullptr) {
-    *hfunc = dFunc_[deviceId]->asHipFunction();
+    *hfunc = asHipFunction(dFunc_[deviceId]);
     return hipSuccess;
   }
   std::scoped_lock lock((*modules_)->FatBinaryLock());
-  // Check for the compiled kernel again, to make sure only one thread does compilation
+  // Check again after acquiring lock — another thread may have built it
   if (dFunc_[deviceId] != nullptr) {
-    *hfunc = dFunc_[deviceId]->asHipFunction();
+    *hfunc = asHipFunction(dFunc_[deviceId]);
     return hipSuccess;
   }
   hipModule_t hmod = nullptr;
   IHIP_RETURN_ONFAIL((*modules_)->BuildProgram(deviceId));
   IHIP_RETURN_ONFAIL((*modules_)->GetModule(deviceId, &hmod));
-  dFunc_[deviceId] = new DeviceFunc(name_, hmod);
-  *hfunc = dFunc_[deviceId]->asHipFunction();
+  dFunc_[deviceId] = BuildKernel(hmod);
+  *hfunc = asHipFunction(dFunc_[deviceId]);
   return hipSuccess;
 }
 
-hipError_t Function::getStatFuncAttr(hipFuncAttributes* func_attr, int deviceId) {
+// ================================================================================================
+hipError_t Function::GetStatFuncAttr(hipFuncAttributes* func_attr, int deviceId) {
   if (modules_ == nullptr || *modules_ == nullptr) {
     return hipErrorInvalidDeviceFunction;
   }
-
-  hipModule_t hmod = nullptr;
-  IHIP_RETURN_ONFAIL((*modules_)->BuildProgram(deviceId));
-  IHIP_RETURN_ONFAIL((*modules_)->GetModule(deviceId, &hmod));
-
-  if (dFunc_[deviceId] == nullptr) {
-    dFunc_[deviceId] = new DeviceFunc(name_, hmod);
-  }
+  // Ensure kernel is built for this device (reuses getStatFunc path)
+  hipFunction_t hfunc = nullptr;
+  IHIP_RETURN_ONFAIL(GetStatFunc(&hfunc, deviceId));
 
   const std::vector<amd::Device*>& devices = amd::Device::getDevices(CL_DEVICE_TYPE_GPU, false);
-
-  amd::Kernel* kernel = dFunc_[deviceId]->kernel();
+  amd::Kernel* kernel = dFunc_[deviceId];
   auto* device_handle = devices[deviceId];
   const device::Kernel::WorkGroupInfo* wginfo =
       kernel->getDeviceKernel(*device_handle)->workGroupInfo();
@@ -184,7 +133,7 @@ hipError_t Function::getStatFuncAttr(hipFuncAttributes* func_attr, int deviceId)
   return hipSuccess;
 }
 
-// Abstract Vars
+// ================================================================================================
 Var::Var(const std::string& name, DeviceVarKind dVarKind, size_t size, int type, int norm,
          FatBinaryInfo** modules)
     : name_(name),
@@ -195,9 +144,10 @@ Var::Var(const std::string& name, DeviceVarKind dVarKind, size_t size, int type,
       modules_(modules),
       managedVarPtr_(nullptr),
       align_(0) {
-  dVar_.resize(g_devices.size());
+  dMem_.resize(g_devices.size());
 }
 
+// ================================================================================================
 Var::Var(const std::string& name, DeviceVarKind dVarKind, void* pointer, size_t size,
          unsigned align, FatBinaryInfo** modules)
     : name_(name),
@@ -209,54 +159,99 @@ Var::Var(const std::string& name, DeviceVarKind dVarKind, void* pointer, size_t 
       align_(align),
       type_(0),
       norm_(0) {
-  dVar_.resize(g_devices.size());
+  dMem_.resize(g_devices.size());
 }
 
+// ================================================================================================
 Var::~Var() {
-  for (auto& elem : dVar_) {
-    delete elem;
+  // device_ptr is being removed and its amd::Memory obj is being released during
+  // ihipFree in hip::StatCO::removeFatBinary; however in DynCO path it bypasses ihipFree,
+  // so we check the map first to avoid double-release.
+  for (auto& mem : dMem_) {
+    if (mem != nullptr) {
+      void* ptr = mem->getSvmPtr();
+      if (amd::MemObjMap::FindMemObj(ptr) != nullptr) {
+        amd::MemObjMap::RemoveMemObj(ptr);
+        mem->release();
+      }
+    }
+  }
+  if (shadowVptr != nullptr) {
+    textureReference* texRef = reinterpret_cast<textureReference*>(shadowVptr);
+    (void)ihipUnbindTexture(texRef);
+    delete texRef;
+    shadowVptr = nullptr;
   }
   modules_ = nullptr;
 }
 
-hipError_t Var::getDeviceVarPtr(DeviceVar** dvar, int deviceId) {
+// ================================================================================================
+hipError_t Var::GetDeviceVarPtr(amd::Memory** mem, int deviceId) {
   guarantee((deviceId >= 0), "Invalid DeviceId, less than zero");
   guarantee((static_cast<size_t>(deviceId) < g_devices.size()),
             "Invalid DeviceId, greater than no of code objects");
-  guarantee((dVar_.size() == g_devices.size()), "Device Var not initialized to size");
-  *dvar = dVar_[deviceId];
+  guarantee((dMem_.size() == g_devices.size()), "Device Var not initialized to size");
+  *mem = dMem_[deviceId];
   return hipSuccess;
 }
 
-hipError_t Var::getDeviceVar(DeviceVar** dvar, int deviceId, hipModule_t hmod) {
+// ================================================================================================
+static hipError_t createVarMem(amd::Memory** mem_out, const std::string& name,
+                               hipModule_t hmod, int deviceId) {
+  amd::Program* program = as_amd(reinterpret_cast<cl_program>(hmod));
+  device::Program* dev_program = program->getDeviceProgram(*g_devices.at(deviceId)->devices()[0]);
+  guarantee(dev_program != nullptr, "Cannot get Device Program for module: 0x%x", hmod);
+
+  amd::Memory* mem = nullptr;
+  void* device_ptr = nullptr;
+  size_t size = 0;
+  if (!dev_program->createGlobalVarObj(&mem, &device_ptr, &size, name.c_str())) {
+    guarantee(false, "Cannot create GlobalVar Obj for symbol: %s", name.c_str());
+  }
+  // Handle size 0 symbols
+  if (size != 0) {
+    if (mem == nullptr || device_ptr == nullptr) {
+      LogPrintfError("Cannot get memory for creating device Var: %s", name.c_str());
+      guarantee(false, "Cannot get memory for creating device var");
+    }
+    amd::MemObjMap::AddMemObj(device_ptr, mem);
+  }
+  *mem_out = mem;
+  return hipSuccess;
+}
+
+// ================================================================================================
+hipError_t Var::GetDeviceVar(amd::Memory** mem, int deviceId, hipModule_t hmod) {
   guarantee((deviceId >= 0), "Invalid DeviceId, less than zero");
   guarantee((static_cast<size_t>(deviceId) < g_devices.size()),
             "Invalid DeviceId, greater than no of code objects");
-  guarantee((dVar_.size() == g_devices.size()), "Device Var not initialized to size");
+  guarantee((dMem_.size() == g_devices.size()), "Device Var not initialized to size");
 
-  if (dVar_[deviceId] == nullptr) {
-    dVar_[deviceId] = new DeviceVar(name_, hmod, deviceId);
+  if (dMem_[deviceId] == nullptr) {
+    IHIP_RETURN_ONFAIL(createVarMem(&dMem_[deviceId], name_, hmod, deviceId));
   }
 
-  *dvar = dVar_[deviceId];
+  *mem = dMem_[deviceId];
   return hipSuccess;
 }
 
-hipError_t Var::getStatDeviceVar(DeviceVar** dvar, int deviceId) {
+// ================================================================================================
+hipError_t Var::GetStatDeviceVar(amd::Memory** mem, int deviceId) {
   guarantee((deviceId >= 0), "Invalid DeviceId, less than zero");
   guarantee((static_cast<size_t>(deviceId) < g_devices.size()),
             "Invalid DeviceId, greater than no of code objects");
-  if (dVar_[deviceId] == nullptr) {
+  if (dMem_[deviceId] == nullptr) {
     hipModule_t hmod = nullptr;
     IHIP_RETURN_ONFAIL((*modules_)->BuildProgram(deviceId));
     IHIP_RETURN_ONFAIL((*modules_)->GetModule(deviceId, &hmod));
-    dVar_[deviceId] = new DeviceVar(name_, hmod, deviceId);
+    IHIP_RETURN_ONFAIL(createVarMem(&dMem_[deviceId], name_, hmod, deviceId));
   }
-  *dvar = dVar_[deviceId];
+  *mem = dMem_[deviceId];
   return hipSuccess;
 }
-// this method is added for allocation of managed var
-hipError_t Var::allocateManagedVarPtr() {
+
+// ================================================================================================
+hipError_t Var::AllocateManagedVarPtr() {
   void** pointer = static_cast<void**>(managedVarPtr_);
   // check if it is deffered allocation
   if (!allocFlag_) {
@@ -265,8 +260,8 @@ hipError_t Var::allocateManagedVarPtr() {
     IHIP_RETURN_ONFAIL(ihipMallocManaged(pointer, size_, align_, use_host_ptr));
     allocFlag_ = true;
   }
-  if (dVar_.empty()) {
-    resize_dVar(g_devices.size());
+  if (dMem_.empty()) {
+    ResizeDVar(g_devices.size());
   }
   return hipSuccess;
 }

--- a/projects/clr/hipamd/src/hip_global.hpp
+++ b/projects/clr/hipamd/src/hip_global.hpp
@@ -15,48 +15,21 @@
 #include "hip_internal.hpp"
 #include "hip_fatbin.hpp"
 #include "platform/program.hpp"
+#include "platform/kernel.hpp"
+#include "platform/memory.hpp"
 
 namespace hip {
 
 // Forward Declaration
 class CodeObject;
 
-// Device Structures
-class DeviceVar {
- public:
-  DeviceVar(const std::string &name, hipModule_t hmod, int deviceId);
-  ~DeviceVar();
-
-  // Accessors for device ptr and size, populated during constructor.
-  hipDeviceptr_t device_ptr() const { return device_ptr_; }
-  size_t size() const { return size_; }
-  const std::string& name() const { return name_; }
-  void* shadowVptr;
-
- private:
-  std::string name_;           // Name of the var
-  amd::Memory* amd_mem_obj_;   // amd_mem_obj abstraction
-  hipDeviceptr_t device_ptr_;  // Device Pointer
-  size_t size_;                // Size of the var
-};
-
-class DeviceFunc {
- public:
-  DeviceFunc(const std::string &name, hipModule_t hmod);
-  ~DeviceFunc();
-
-  // Converts DeviceFunc to hipFunction_t(used by app) and vice versa.
-  hipFunction_t asHipFunction() { return reinterpret_cast<hipFunction_t>(this); }
-  static DeviceFunc* asFunction(hipFunction_t f) { return reinterpret_cast<DeviceFunc*>(f); }
-  static DeviceFunc* asFunction(hipKernel_t k) { return reinterpret_cast<DeviceFunc*>(k); }
-
-  // Accessor for kernel_ and name_ populated during constructor.
-  const std::string &name() const { return kernel_->name(); }
-  amd::Kernel* kernel() const { return kernel_; }
-
- private:
-  amd::Kernel* kernel_;  // Kernel ptr referencing to ROCclr Symbol
-};
+// Cast helpers replacing the old DeviceFunc/DeviceVar wrappers
+inline amd::Kernel* asKernel(hipFunction_t f) { return reinterpret_cast<amd::Kernel*>(f); }
+inline amd::Kernel* asKernel(hipKernel_t k)   { return reinterpret_cast<amd::Kernel*>(k); }
+inline hipFunction_t asHipFunction(amd::Kernel* k) { return reinterpret_cast<hipFunction_t>(k); }
+inline hipDeviceptr_t memDevPtr(const amd::Memory* m) {
+  return reinterpret_cast<hipDeviceptr_t>(m->getSvmPtr());
+}
 
 // Abstract Structures
 class Function {
@@ -64,20 +37,20 @@ class Function {
   Function(const std::string& name, FatBinaryInfo** modules = nullptr);
   ~Function();
 
-  // Return DeviceFunc for this this dynamically loaded module
-  hipError_t getDynFunc(hipFunction_t* hfunc, hipModule_t hmod);
-  bool isValidDynFunc(const void* hfunc);
-  // Return Device Func & attr . Generate/build if not already done so.
-  hipError_t getStatFunc(hipFunction_t* hfunc, int deviceId);
-  hipError_t getStatFuncAttr(hipFuncAttributes* func_attr, int deviceId);
-  void resize_dFunc(size_t size) { dFunc_.resize(size); }
-  FatBinaryInfo** moduleInfo() { return modules_; }
-  const std::string& name() const { return name_; }
+  hipError_t GetDynFunc(hipFunction_t* hfunc, hipModule_t hmod);
+  bool IsValidDynFunc(const void* hfunc);
+  hipError_t GetStatFunc(hipFunction_t* hfunc, int deviceId);
+  hipError_t GetStatFuncAttr(hipFuncAttributes* func_attr, int deviceId);
+  void ResizeDFunc(size_t size) { dFunc_.resize(size); }
+  FatBinaryInfo** ModuleInfo() { return modules_; }
+  const std::string& GetName() const { return name_; }
 
  private:
-  std::vector<DeviceFunc*> dFunc_;  //!< DeviceFuncObj per Device
-  std::string name_;                //!< name of the func(not unique identifier)
-  FatBinaryInfo** modules_;         //!< static module where it is referenced
+  amd::Kernel* BuildKernel(hipModule_t hmod) const;
+
+  std::vector<amd::Kernel*> dFunc_;  //!< Per-device kernel objects; index matches g_devices
+  std::string name_;                 //!< Symbol name for kernel lookup in the program
+  FatBinaryInfo** modules_;          //!< Owning fat binary; nullptr for dynamic COs
 };
 
 class Var {
@@ -93,46 +66,42 @@ class Var {
 
   ~Var();
 
-  // Return DeviceVar for this dynamically loaded module
-  hipError_t getDeviceVar(DeviceVar** dvar, int deviceId, hipModule_t hmod);
+  hipError_t GetDeviceVar(amd::Memory** mem, int deviceId, hipModule_t hmod);
+  hipError_t GetStatDeviceVar(amd::Memory** mem, int deviceId);
+  hipError_t GetDeviceVarPtr(amd::Memory** mem, int deviceId);
 
-  // Return DeviceVar for module Generate/build if not already done so.
-  hipError_t getStatDeviceVar(DeviceVar** dvar, int deviceId);
+  hipError_t AllocateManagedVarPtr();
 
-  hipError_t getDeviceVarPtr(DeviceVar** dvar, int deviceId);
+  void ResizeDVar(size_t size) { dMem_.resize(size); }
 
-  hipError_t allocateManagedVarPtr();
+  FatBinaryInfo** ModuleInfo() { return modules_; }
+  DeviceVarKind GetVarKind() const { return dVarKind_; }
+  size_t GetSize() const { return size_; }
+  size_t GetAlignment() const { return align_; }
+  const std::string& GetName() const { return name_; }
 
-  void resize_dVar(size_t size) { dVar_.resize(size); }
-  // bool isEmpty_dVar() const { return dVar_.empty(); }
+  void* shadowVptr = nullptr;  //!< Host-side textureReference shadow; device-independent
 
-
-  FatBinaryInfo** moduleInfo() { return modules_; };
-  DeviceVarKind getVarKind() const { return dVarKind_; }
-  size_t getSize() const { return size_; }
-  size_t getAlignment() const { return align_; }
-  const std::string& getName() const { return name_; }
-
-  void* getManagedVarPtr() const { return managedVarPtr_; }
-  void setManagedVarInfo(void* pointer, size_t size) {
+  void* GetManagedVarPtr() const { return managedVarPtr_; }
+  void SetManagedVarInfo(void* pointer, size_t size) {
     managedVarPtr_ = pointer;
     size_ = size;
     dVarKind_ = DVK_Managed;
   }
-  bool getAllocFlag() const { return allocFlag_; }
-  void setAllocFlag(bool val) { allocFlag_ = val; }
+  bool GetAllocFlag() const { return allocFlag_; }
+  void SetAllocFlag(bool val) { allocFlag_ = val; }
 
  private:
-  std::vector<DeviceVar*> dVar_;  // DeviceVarObj per Device
-  std::string name_;              // Variable name (not unique identifier)
-  DeviceVarKind dVarKind_;        // Variable kind
-  size_t size_;                   // Size of the variable
-  int type_;                      // Type(Textures/Surfaces only)
-  int norm_;                      // Type(Textures/Surfaces only)
-  FatBinaryInfo** modules_;       // static module where it is referenced
-  void* managedVarPtr_;           // Managed memory pointer with size_ & align_
-  size_t align_;                  // Managed memory alignment
-  bool allocFlag_;                // 0 : host alloc, 1: managed alloc
+  std::vector<amd::Memory*> dMem_;  //!< Per-device memory objects; index matches g_devices
+  std::string name_;                //!< Symbol name for code-object lookup (not a unique key)
+  DeviceVarKind dVarKind_;          //!< Classification: regular, surface, texture, or managed
+  size_t size_;                     //!< Size of the variable in bytes
+  int type_;                        //!< Channel type (textures/surfaces only)
+  int norm_;                        //!< Normalisation flag (textures/surfaces only)
+  FatBinaryInfo** modules_;         //!< Owning fat binary; nullptr for dynamic COs
+  void* managedVarPtr_;             //!< Host pointer to managed-memory allocation (DVK_Managed)
+  size_t align_;                    //!< Alignment of the managed allocation in bytes
+  bool allocFlag_;                  //!< false = host alloc; true = ihipMallocManaged alloc
 };
 
 };  // namespace hip

--- a/projects/clr/hipamd/src/hip_graph_internal.hpp
+++ b/projects/clr/hipamd/src/hip_graph_internal.hpp
@@ -1252,7 +1252,7 @@ class GraphKernelNode : public GraphNode {
 
   virtual std::string GetLabel(hipGraphDebugDotFlags flag) override {
     hipFunction_t func = getFunc(kernelParams_, dev_id_);
-    hip::DeviceFunc* function = hip::DeviceFunc::asFunction(func);
+    amd::Kernel* kernel = hip::asKernel(func);
     std::string label;
     char buffer[4096];
     if (flag == hipGraphDebugDotFlagsVerbose) {
@@ -1261,7 +1261,7 @@ class GraphKernelNode : public GraphNode {
               "handle | func handle} | {%p | %p}}\n| {accessPolicyWindow | {base_ptr | num_bytes | "
               "hitRatio | hitProp | missProp} | {%p | %zu | %f | %d | %d}}\n| {cooperative | "
               "%u}\n| {priority | %d}\n}",
-              label_, GetID(), function->name().c_str(), kernelParams_.gridDim.x,
+              label_, GetID(), kernel->name().c_str(), kernelParams_.gridDim.x,
               kernelParams_.gridDim.y, kernelParams_.gridDim.z, kernelParams_.blockDim.x,
               kernelParams_.blockDim.y, kernelParams_.blockDim.z,
               globalWorkSizeX_remainder_, globalWorkSizeY_remainder_, globalWorkSizeZ_remainder_,
@@ -1277,7 +1277,7 @@ class GraphKernelNode : public GraphNode {
               "| {accessPolicyWindow | {base_ptr | num_bytes | "
               "hitRatio | hitProp | missProp} |\n| {%p | %zu | %f | %d | %d}}\n| {cooperative | "
               "%u}\n| {priority | %d}\n}",
-              label_, GetID(), function->name().c_str(), kernelAttr_.accessPolicyWindow.base_ptr,
+              label_, GetID(), kernel->name().c_str(), kernelAttr_.accessPolicyWindow.base_ptr,
               kernelAttr_.accessPolicyWindow.num_bytes, kernelAttr_.accessPolicyWindow.hitRatio,
               kernelAttr_.accessPolicyWindow.hitProp, kernelAttr_.accessPolicyWindow.missProp,
               kernelAttr_.cooperative, kernelAttr_.priority);
@@ -1285,14 +1285,14 @@ class GraphKernelNode : public GraphNode {
     }
     else if (flag == hipGraphDebugDotFlagsKernelNodeParams) {
       sprintf(buffer, "%d\n%s\n\\<\\<\\<(%u,%u,%u),(%u,%u,%u),(%u,%u,%u),%u\\>\\>\\>",
-              GetID(), function->name().c_str(), kernelParams_.gridDim.x,
+              GetID(), kernel->name().c_str(), kernelParams_.gridDim.x,
               kernelParams_.gridDim.y, kernelParams_.gridDim.z,
               kernelParams_.blockDim.x, kernelParams_.blockDim.y, kernelParams_.blockDim.z,
               globalWorkSizeX_remainder_, globalWorkSizeY_remainder_, globalWorkSizeZ_remainder_,
               kernelParams_.sharedMemBytes);
       label = buffer;
     } else {
-      label = std::to_string(GetID()) + "\n" + function->name() + "\n";
+      label = std::to_string(GetID()) + "\n" + kernel->name() + "\n";
     }
     return label;
   }
@@ -1324,8 +1324,7 @@ class GraphKernelNode : public GraphNode {
     if (!func) {
       return hipErrorInvalidDeviceFunction;
     }
-    hip::DeviceFunc* function = hip::DeviceFunc::asFunction(func);
-    amd::Kernel* kernel = function->kernel();
+    amd::Kernel* kernel = hip::asKernel(func);
     if (parentGraph_ != nullptr && parentGraph_->IsSegmentSchedulingEnabled()) {
       auto device = g_devices[dev_id_]->devices()[0];
       device::Kernel* devKernel = const_cast<device::Kernel*>(kernel->getDeviceKernel(*device));

--- a/projects/clr/hipamd/src/hip_library.cpp
+++ b/projects/clr/hipamd/src/hip_library.cpp
@@ -53,7 +53,7 @@ hipError_t LibraryContainer::EnumerateKernels(hipKernel_t* k, unsigned int maxKe
     if (auto ki = kernels_.find(std::make_pair(f.first, device_id)); ki!= kernels_.end()) {
       kern = ki->second;
     } else {
-      auto ret = f.second.get()->getDynFunc(reinterpret_cast<hipFunction_t*>(&kern), m);
+      auto ret = f.second.get()->GetDynFunc(reinterpret_cast<hipFunction_t*>(&kern), m);
       if (ret != hipSuccess) {
         return ret;
       }
@@ -75,7 +75,7 @@ hipError_t LibraryContainer::Kernel(hipKernel_t* k, const std::string &name) {
   if (f == functions_.end()) {
     return hipErrorNotFound;
   }
-  auto ret = f->second.get()->getDynFunc(reinterpret_cast<hipFunction_t*>(k), m);
+  auto ret = f->second.get()->GetDynFunc(reinterpret_cast<hipFunction_t*>(k), m);
   if (ret != hipSuccess) {
     return ret;
   }
@@ -260,11 +260,7 @@ hipError_t hipKernelGetParamInfo(hipKernel_t kernel, size_t paramIndex, size_t* 
   if (kernel == nullptr || paramOffset == nullptr) {
     HIP_RETURN(hipErrorInvalidValue);
   }
-  const auto* const d_function = hip::DeviceFunc::asFunction(reinterpret_cast<hipFunction_t>(kernel));
-  if (d_function == nullptr) {
-    HIP_RETURN(hipErrorInvalidHandle);
-  }
-  const auto* const d_kernel = d_function->kernel();
+  const auto* const d_kernel = hip::asKernel(reinterpret_cast<hipFunction_t>(kernel));
   if (d_kernel == nullptr) {
     HIP_RETURN(hipErrorInvalidDeviceFunction);
   }
@@ -287,11 +283,7 @@ hipError_t hipKernelGetAttribute(int* pi, hipFunction_attribute attrib, hipKerne
     HIP_RETURN(hipErrorInvalidValue);
   }
 
-  const auto* const d_function = hip::DeviceFunc::asFunction(kernel);
-  if (d_function == nullptr) {
-    HIP_RETURN(hipErrorInvalidHandle);
-  }
-  const auto* const d_kernel = d_function->kernel();
+  const auto* const d_kernel = hip::asKernel(kernel);
   if (d_kernel == nullptr) {
     HIP_RETURN(hipErrorInvalidDeviceFunction);
   }
@@ -301,8 +293,8 @@ hipError_t hipKernelGetAttribute(int* pi, hipFunction_attribute attrib, hipKerne
   if (dev < 0 || static_cast<size_t>(dev) >= devices.size()) {
     HIP_RETURN(hipErrorInvalidDevice);
   }
-  const auto& device = *devices[dev]; 
-  
+  const auto& device = *devices[dev];
+
   auto* dev_kernel = d_kernel->getDeviceKernel(device);
   if (dev_kernel == nullptr) {
     HIP_RETURN(hipErrorMissingConfiguration);
@@ -360,11 +352,7 @@ hipError_t hipKernelSetAttribute(hipFunction_attribute attrib, int value, hipKer
     HIP_RETURN(hipErrorInvalidValue);
   }
 
-  const auto* const d_function = hip::DeviceFunc::asFunction(kernel);
-  if (d_function == nullptr) {
-    HIP_RETURN(hipErrorInvalidHandle);
-  }
-  amd::Kernel* d_kernel = d_function->kernel();
+  amd::Kernel* d_kernel = hip::asKernel(kernel);
   if (d_kernel == nullptr) {
     HIP_RETURN(hipErrorInvalidDeviceFunction);
   }

--- a/projects/clr/hipamd/src/hip_library.cpp
+++ b/projects/clr/hipamd/src/hip_library.cpp
@@ -285,7 +285,7 @@ hipError_t hipKernelGetAttribute(int* pi, hipFunction_attribute attrib, hipKerne
 
   const auto* const d_kernel = hip::asKernel(kernel);
   if (d_kernel == nullptr) {
-    HIP_RETURN(hipErrorInvalidDeviceFunction);
+    HIP_RETURN(hipErrorInvalidHandle);
   }
 
   auto* currentDevice = hip::getCurrentDevice();

--- a/projects/clr/hipamd/src/hip_module.cpp
+++ b/projects/clr/hipamd/src/hip_module.cpp
@@ -24,7 +24,7 @@ extern hipError_t ihipLaunchKernel(const void* hostFunction, dim3 gridDim, dim3 
                                    hipEvent_t startEvent, hipEvent_t stopEvent, int flags);
 
 const std::string& FunctionName(const hipFunction_t f) {
-  return hip::DeviceFunc::asFunction(f)->kernel()->name();
+  return hip::asKernel(f)->name();
 }
 
 hipError_t hipModuleUnload(hipModule_t hmod) {
@@ -117,12 +117,7 @@ hipError_t hipFuncGetAttribute(int* value, hipFunction_attribute attrib, hipFunc
     HIP_RETURN(hipErrorInvalidValue);
   }
 
-  hip::DeviceFunc* function = hip::DeviceFunc::asFunction(hfunc);
-  if (function == nullptr) {
-    HIP_RETURN(hipErrorInvalidHandle);
-  }
-
-  amd::Kernel* kernel = function->kernel();
+  amd::Kernel* kernel = hip::asKernel(hfunc);
   if (kernel == nullptr) {
     HIP_RETURN(hipErrorInvalidDeviceFunction);
   }
@@ -196,20 +191,17 @@ hipError_t hipFuncSetAttribute(const void* func, hipFuncAttribute attr, int valu
   }
 
   hipFunction_t h_func = nullptr;
-  const hip::DeviceFunc* function = nullptr;
 
   hipError_t err = PlatformState::Instance().StatCO().GetFunc(&h_func, func, ihipGetDevice());
   if (h_func == nullptr) {
     if (PlatformState::Instance().IsValidDynFunc((func))) {
-      function = reinterpret_cast<const hip::DeviceFunc*>(func);
+      h_func = reinterpret_cast<hipFunction_t>(const_cast<void*>(func));
     } else {
       HIP_RETURN(hipErrorInvalidDeviceFunction);
     }
-  } else {
-    function = reinterpret_cast<const hip::DeviceFunc*>(h_func);
   }
 
-  amd::Kernel* kernel = function->kernel();
+  amd::Kernel* kernel = hip::asKernel(h_func);
 
   if (kernel == nullptr) {
     HIP_RETURN(hipErrorInvalidDeviceFunction);
@@ -297,8 +289,7 @@ hipError_t ihipLaunchKernel_validate(hipFunction_t f, const amd::LaunchParams& l
   if (launch_params.local_.product() > info.maxWorkGroupSize_) {
     return hipErrorInvalidConfiguration;
   }
-  hip::DeviceFunc* function = hip::DeviceFunc::asFunction(f);
-  amd::Kernel* kernel = function->kernel();
+  amd::Kernel* kernel = hip::asKernel(f);
   if (!kernel) {
     LogPrintfError("%s", "Kernel object is invalid or null, possibly due to architecture mismatch.");
     return hipErrorInvalidValue;
@@ -317,7 +308,7 @@ hipError_t ihipLaunchKernel_validate(hipFunction_t f, const amd::LaunchParams& l
     LogPrintfError("Launch params (%u, %u, %u) are larger than launch bounds (%lu) for kernel %s",
                    launch_params.local_[0], launch_params.local_[1], launch_params.local_[2],
                    kernel->getDeviceKernel(*device)->workGroupInfo()->size_,
-                   function->name().c_str());
+                   kernel->name().c_str());
     return hipErrorLaunchFailure;
   }
 
@@ -354,8 +345,7 @@ hipError_t ihipLaunchKernelCommand(amd::Command*& command, hipFunction_t f,
                                    uint32_t flags = 0, uint32_t params = 0, uint32_t gridId = 0,
                                    uint32_t numGrids = 0, uint64_t prevGridSum = 0,
                                    uint64_t allGridSum = 0, uint32_t firstDevice = 0) {
-  hip::DeviceFunc* function = hip::DeviceFunc::asFunction(f);
-  amd::Kernel* kernel = function->kernel();
+  amd::Kernel* kernel = hip::asKernel(f);
 
   size_t globalWorkOffset[3] = {0};
   amd::NDRangeContainer ndrange(3, globalWorkOffset, launch_params.global_.Data(),
@@ -429,7 +419,7 @@ hipError_t ihipModuleLaunchKernel(hipFunction_t f, amd::LaunchParams& launch_par
     LogPrintfError("%s", "Function passed is null");
     return hipErrorInvalidResourceHandle;
   }
-  amd::Kernel* kernel = hip::DeviceFunc::asFunction(f)->kernel();
+  amd::Kernel* kernel = hip::asKernel(f);
 
   hipError_t status =
       ihipLaunchKernel_validate(f, launch_params, kernelParams, extra, deviceId, params);

--- a/projects/clr/hipamd/src/hip_module.cpp
+++ b/projects/clr/hipamd/src/hip_module.cpp
@@ -119,7 +119,7 @@ hipError_t hipFuncGetAttribute(int* value, hipFunction_attribute attrib, hipFunc
 
   amd::Kernel* kernel = hip::asKernel(hfunc);
   if (kernel == nullptr) {
-    HIP_RETURN(hipErrorInvalidDeviceFunction);
+    HIP_RETURN(hipErrorInvalidResourceHandle);
   }
 
   const device::Kernel::WorkGroupInfo* wrkGrpInfo =

--- a/projects/clr/hipamd/src/hip_platform.cpp
+++ b/projects/clr/hipamd/src/hip_platform.cpp
@@ -972,7 +972,9 @@ hipError_t PlatformState::GetDynTexRef(const char* hostVar, hipModule_t hmod,
   }
 
   hip::Var* var = it->second->getVar(hostVar);
-  var->shadowVptr = new texture<char>();
+  if (var->shadowVptr == nullptr) {
+    var->shadowVptr = new texture<char>();
+  }
   *texRef = reinterpret_cast<textureReference*>(var->shadowVptr);
   return hipSuccess;
 }

--- a/projects/clr/hipamd/src/hip_platform.cpp
+++ b/projects/clr/hipamd/src/hip_platform.cpp
@@ -20,8 +20,7 @@ namespace hip_impl {
 hipError_t ihipOccupancyMaxActiveBlocksPerMultiprocessor(
     int* maxBlocksPerCU, int* numBlocksPerGrid, int* bestBlockSize, const amd::Device& device,
     hipFunction_t func, int inputBlockSize, size_t dynamicSMemSize, bool bCalcPotentialBlkSz) {
-  auto* function = hip::DeviceFunc::asFunction(func);
-  const auto* kernel = function->kernel();
+  const auto* kernel = hip::asKernel(func);
 
   const auto* wrkGrpInfo = kernel->getDeviceKernel(device)->workGroupInfo();
   const int maxWorkGroupSize = static_cast<int>(device.info().maxWorkGroupSize_);
@@ -263,7 +262,7 @@ void __hipRegisterManagedVar(
   } else {
     HIP_INIT_VOID();
     status = ihipMallocManaged(pointer, size, align, 0);
-    var_ptr->setAllocFlag(true);
+    var_ptr->SetAllocFlag(true);
     if (status == hipSuccess) {
       hip::Stream* stream = hip::getNullStream();
       if (stream != nullptr) {
@@ -461,8 +460,8 @@ hipError_t hipOccupancyAvailableDynamicSMemPerBlock(size_t* dynamicSmemSize, con
     HIP_RETURN(hipErrorInvalidDeviceFunction);
   }
 
-  auto* function = hip::DeviceFunc::asFunction(func);
-  if (function == nullptr) {
+  amd::Kernel* func_kernel = hip::asKernel(func);
+  if (func_kernel == nullptr) {
     HIP_RETURN(hipErrorInvalidHandle);
   }
 
@@ -474,7 +473,7 @@ hipError_t hipOccupancyAvailableDynamicSMemPerBlock(size_t* dynamicSmemSize, con
   }
 
   const amd::Device& device = *hip::getCurrentDevice()->devices()[dev_id];
-  const amd::Kernel& kernel = *function->kernel();
+  const amd::Kernel& kernel = *func_kernel;
   const auto* wrkGrpInfo = kernel.getDeviceKernel(device)->workGroupInfo();
 
   const int staticSharedMemoryUsage = wrkGrpInfo->usedLDSSize_;
@@ -908,13 +907,13 @@ hipError_t PlatformState::GetDynGlobalVar(const char* hostVar, hipModule_t hmod,
   IHIP_RETURN_ONFAIL(it->second->getManagedVarPointer(hostVar, dev_ptr, size_ptr));
   // if dev_ptr is nullptr, hostvar is not in managed variable list
   if ((dev_ptr && !*dev_ptr) || (size_ptr && *size_ptr == 0)) {
-    auto* dvar = static_cast<hip::DeviceVar*>(nullptr);
-    IHIP_RETURN_ONFAIL(it->second->getDeviceVar(&dvar, hostVar));
+    amd::Memory* mem = nullptr;
+    IHIP_RETURN_ONFAIL(it->second->GetDeviceVar(&mem, hostVar));
     if (dev_ptr) {
-      *dev_ptr = dvar->device_ptr();
+      *dev_ptr = memDevPtr(mem);
     }
     if (size_ptr) {
-      *size_ptr = dvar->size();
+      *size_ptr = mem->getSize();
     }
   }
   return hipSuccess;
@@ -946,10 +945,10 @@ hipError_t PlatformState::GetDynTexGlobalVar(textureReference* texRef, hipDevice
     return hipErrorNotFound;
   }
 
-  hip::DeviceVar* dvar;
-  IHIP_RETURN_ONFAIL(it->second->getDeviceVar(&dvar, tex_ref_entry.second));
-  *dev_ptr = dvar->device_ptr();
-  *size_ptr = dvar->size();
+  amd::Memory* mem = nullptr;
+  IHIP_RETURN_ONFAIL(it->second->GetDeviceVar(&mem, tex_ref_entry.second));
+  *dev_ptr = memDevPtr(mem);
+  *size_ptr = mem->getSize();
 
   return hipSuccess;
 }
@@ -965,15 +964,16 @@ hipError_t PlatformState::GetDynTexRef(const char* hostVar, hipModule_t hmod,
     return hipErrorNotFound;
   }
 
-  hip::DeviceVar* dvar;
-  IHIP_RETURN_ONFAIL(it->second->getDeviceVar(&dvar, hostVar));
+  amd::Memory* mem = nullptr;
+  IHIP_RETURN_ONFAIL(it->second->GetDeviceVar(&mem, hostVar));
 
-  if (dvar->size() != sizeof(textureReference)) {
+  if (mem->getSize() != sizeof(textureReference)) {
     return hipErrorNotFound;
   }
 
-  dvar->shadowVptr = new texture<char>();
-  *texRef = reinterpret_cast<textureReference*>(dvar->shadowVptr);
+  hip::Var* var = it->second->getVar(hostVar);
+  var->shadowVptr = new texture<char>();
+  *texRef = reinterpret_cast<textureReference*>(var->shadowVptr);
   return hipSuccess;
 }
 


### PR DESCRIPTION
## Motivation
Cleaner code

## Technical Details
Removed wrapper classes
- DeviceFunc — eliminated; replaced with direct amd::Kernel* throughout.
  Three cast helpers added to hip_global.hpp to replace the wrapper's casting
- DeviceVar — eliminated; replaced with direct amd::Memory* throughout.
  device_ptr_ is recoverable via mem->getSvmPtr(), size_ via mem->getSize()
- shadowVptr (host-side texture reference shadow) moved from per-device
  DeviceVar to a single field on Var, since it is device-independent.                                                                                                       
 ---                                                                      
Class Function cleanup 
- Extracted BuildKernel(hipModule_t) const to eliminate copy-pasted
 findSymbol + new amd::Kernel in three places.
- GetStatFuncAttr now delegates to GetStatFunc instead of
 duplicating the build-module logic.                     
---
Class Var cleanup
- dVar_: vector<DeviceVar*> → dMem_: vector<amd::Memory*>.
- createVarMem extracted as a file-scope static helper,
 shared by GetDeviceVar and GetStatDeviceVar.

## JIRA ID
AIRUNTIME-84

## Test Plan
N/A

## Test Result
N/A

## Submission Checklist
N/A