### PR TITLE
[rocprofiler-compute] Migrate PMC file format from txt to yaml

### DIFF
--- a/projects/rocprofiler-compute/docs/how-to/profile/mode.rst
+++ b/projects/rocprofiler-compute/docs/how-to/profile/mode.rst
@@ -315,7 +315,7 @@ Examples:
     ├── results_pmc_perf_0.csv
     ├── results_pmc_perf_1.csv
     ├── results_pmc_perf_2.csv
-    ├── results_SQ_LEVEL_WAVES.csv
+    ├── results_pmc_perf_SQ_LEVEL_WAVES.csv
     ├── roofline.csv
     └── sysinfo.csv
 
@@ -363,7 +363,7 @@ on available output formats and when the final ``pmc_perf.csv`` is created.
     ├── results_pmc_perf_0.csv
     ├── results_pmc_perf_1.csv
     ├── results_pmc_perf_2.csv
-    ├── results_SQ_LEVEL_WAVES.csv
+    ├── results_pmc_perf_SQ_LEVEL_WAVES.csv
     ├── roofline.csv
     └── sysinfo.csv
 
@@ -383,7 +383,7 @@ of raw performance counter data produced by the underlying
 
 * ``rocpd`` format (default):
    * Instructs ROCprofiler-SDK to write raw performance counter data in rocpd (SQLite) format.
-   * The rocpd database files are converted to CSV files (``results_pmc_perf_0.csv``, ``results_SQ_*.csv``, etc.) for each profiling run, after which the database files are removed.
+   * The rocpd database files are converted to CSV files (``results_pmc_perf_0.csv``, ``results_pmc_perf_SQ_*.csv``, etc.) for each profiling run, after which the database files are removed.
    * These files are merged into a single ``pmc_perf.csv`` file when running ``rocprof-compute analyze``.
    * Use ``--retain-rocpd-output`` to preserve the ``rocpd`` database(s) in the workload folder for custom analysis.
 

--- a/projects/rocprofiler-compute/docs/how-to/profile/mode.rst
+++ b/projects/rocprofiler-compute/docs/how-to/profile/mode.rst
@@ -125,7 +125,7 @@ The following sample command profiles the ``vcopy`` workload.
       INFO Using native counter collection tool: /tmp/rocprofiler-compute-tool-xxxxx/librocprofiler-compute-tool.so
       INFO [profiling] Iteration multiplexing: Disabled
       INFO [Run 1/13][Approximate profiling time left: pending first measurement...]
-      INFO [profiling] Current input file: /home/auser/rocm-systems/projects/rocprofiler-compute/workloads/vcopy/MI325X/perfmon/SQC_DCACHE_INFLIGHT_LEVEL.txt
+      INFO [profiling] Current input file: /home/auser/rocm-systems/projects/rocprofiler-compute/workloads/vcopy/MI325X/perfmon/pmc_perf_SQC_DCACHE_INFLIGHT_LEVEL.yaml
       INFO    |-> [rocprofiler-sdk] [rocprofiler-compute] [rocprofiler_configure] (priority=1) is using rocprofiler-sdk v1.1.0 (1.1.0)
       INFO    |-> [rocprofiler-sdk] W20260323 16:43:44.337323 139842239868672 simple_timer.cpp:55] [rocprofv3] tool initialization ::     0.250706 sec
       INFO    |-> [rocprofiler-sdk] [rocprofiler-compute] In tool init
@@ -145,7 +145,7 @@ The following sample command profiles the ``vcopy`` workload.
       INFO    |-> [rocprofiler-sdk] Releasing GPU memory
       INFO    |-> [rocprofiler-sdk] Releasing CPU memory
       INFO [Run 13/13][Approximate profiling time left: 0 seconds]...
-      INFO [profiling] Current input file: /home/auser/rocm-systems/projects/rocprofiler-compute/workloads/vcopy/MI325X/perfmon/pmc_perf_5.txt
+      INFO [profiling] Current input file: /home/auser/rocm-systems/projects/rocprofiler-compute/workloads/vcopy/MI325X/perfmon/pmc_perf_5.yaml
       INFO    |-> [rocprofiler-sdk] [rocprofiler-compute] [rocprofiler_configure] (priority=1) is using rocprofiler-sdk v1.1.0 (1.1.0)
       INFO    |-> [rocprofiler-sdk] W20260323 16:44:43.871622 140315166887680 simple_timer.cpp:55] [rocprofv3] tool initialization ::     0.224905 sec
       INFO    |-> [rocprofiler-sdk] [rocprofiler-compute] In tool init
@@ -285,31 +285,32 @@ Examples:
    └── MI325X
     ├── log.txt
     ├── perfmon
-    │   ├── pmc_perf_0.txt
+    │   ├── counter_def_0.yaml
+    │   ├── counter_def_1.yaml
+    │   ├── counter_def_2.yaml
+    │   ├── counter_def_3.yaml
+    │   ├── counter_def_4.yaml
+    │   ├── counter_def_5.yaml
+    │   ├── counter_def_SQC_DCACHE_INFLIGHT_LEVEL.yaml
+    │   ├── counter_def_SQC_ICACHE_INFLIGHT_LEVEL.yaml
+    │   ├── counter_def_SQ_IFETCH_LEVEL.yaml
+    │   ├── counter_def_SQ_INST_LEVEL_LDS.yaml
+    │   ├── counter_def_SQ_INST_LEVEL_SMEM.yaml
+    │   ├── counter_def_SQ_INST_LEVEL_VMEM.yaml
+    │   ├── counter_def_SQ_LEVEL_WAVES.yaml
     │   ├── pmc_perf_0.yaml
-    │   ├── pmc_perf_1.txt
     │   ├── pmc_perf_1.yaml
-    │   ├── pmc_perf_2.txt
     │   ├── pmc_perf_2.yaml
-    │   ├── pmc_perf_3.txt
     │   ├── pmc_perf_3.yaml
-    │   ├── pmc_perf_4.txt
     │   ├── pmc_perf_4.yaml
-    │   ├── pmc_perf_5.txt
-    │   ├── SQC_DCACHE_INFLIGHT_LEVEL.txt
-    │   ├── SQC_DCACHE_INFLIGHT_LEVEL.yaml
-    │   ├── SQC_ICACHE_INFLIGHT_LEVEL.txt
-    │   ├── SQC_ICACHE_INFLIGHT_LEVEL.yaml
-    │   ├── SQ_IFETCH_LEVEL.txt
-    │   ├── SQ_IFETCH_LEVEL.yaml
-    │   ├── SQ_INST_LEVEL_LDS.txt
-    │   ├── SQ_INST_LEVEL_LDS.yaml
-    │   ├── SQ_INST_LEVEL_SMEM.txt
-    │   ├── SQ_INST_LEVEL_SMEM.yaml
-    │   ├── SQ_INST_LEVEL_VMEM.txt
-    │   ├── SQ_INST_LEVEL_VMEM.yaml
-    │   ├── SQ_LEVEL_WAVES.txt
-    │   └── SQ_LEVEL_WAVES.yaml
+    │   ├── pmc_perf_5.yaml
+    │   ├── pmc_perf_SQC_DCACHE_INFLIGHT_LEVEL.yaml
+    │   ├── pmc_perf_SQC_ICACHE_INFLIGHT_LEVEL.yaml
+    │   ├── pmc_perf_SQ_IFETCH_LEVEL.yaml
+    │   ├── pmc_perf_SQ_INST_LEVEL_LDS.yaml
+    │   ├── pmc_perf_SQ_INST_LEVEL_SMEM.yaml
+    │   ├── pmc_perf_SQ_INST_LEVEL_VMEM.yaml
+    │   └── pmc_perf_SQ_LEVEL_WAVES.yaml
     ├── profiling_config.yaml
     ├── results_pmc_perf_0.csv
     ├── results_pmc_perf_1.csv
@@ -332,31 +333,32 @@ on available output formats and when the final ``pmc_perf.csv`` is created.
    └── MI325X
     ├── log.txt
     ├── perfmon
-    │   ├── pmc_perf_0.txt
+    │   ├── counter_def_0.yaml
+    │   ├── counter_def_1.yaml
+    │   ├── counter_def_2.yaml
+    │   ├── counter_def_3.yaml
+    │   ├── counter_def_4.yaml
+    │   ├── counter_def_5.yaml
+    │   ├── counter_def_SQC_DCACHE_INFLIGHT_LEVEL.yaml
+    │   ├── counter_def_SQC_ICACHE_INFLIGHT_LEVEL.yaml
+    │   ├── counter_def_SQ_IFETCH_LEVEL.yaml
+    │   ├── counter_def_SQ_INST_LEVEL_LDS.yaml
+    │   ├── counter_def_SQ_INST_LEVEL_SMEM.yaml
+    │   ├── counter_def_SQ_INST_LEVEL_VMEM.yaml
+    │   ├── counter_def_SQ_LEVEL_WAVES.yaml
     │   ├── pmc_perf_0.yaml
-    │   ├── pmc_perf_1.txt
     │   ├── pmc_perf_1.yaml
-    │   ├── pmc_perf_2.txt
     │   ├── pmc_perf_2.yaml
-    │   ├── pmc_perf_3.txt
     │   ├── pmc_perf_3.yaml
-    │   ├── pmc_perf_4.txt
     │   ├── pmc_perf_4.yaml
-    │   ├── pmc_perf_5.txt
-    │   ├── SQC_DCACHE_INFLIGHT_LEVEL.txt
-    │   ├── SQC_DCACHE_INFLIGHT_LEVEL.yaml
-    │   ├── SQC_ICACHE_INFLIGHT_LEVEL.txt
-    │   ├── SQC_ICACHE_INFLIGHT_LEVEL.yaml
-    │   ├── SQ_IFETCH_LEVEL.txt
-    │   ├── SQ_IFETCH_LEVEL.yaml
-    │   ├── SQ_INST_LEVEL_LDS.txt
-    │   ├── SQ_INST_LEVEL_LDS.yaml
-    │   ├── SQ_INST_LEVEL_SMEM.txt
-    │   ├── SQ_INST_LEVEL_SMEM.yaml
-    │   ├── SQ_INST_LEVEL_VMEM.txt
-    │   ├── SQ_INST_LEVEL_VMEM.yaml
-    │   ├── SQ_LEVEL_WAVES.txt
-    │   └── SQ_LEVEL_WAVES.yaml
+    │   ├── pmc_perf_5.yaml
+    │   ├── pmc_perf_SQC_DCACHE_INFLIGHT_LEVEL.yaml
+    │   ├── pmc_perf_SQC_ICACHE_INFLIGHT_LEVEL.yaml
+    │   ├── pmc_perf_SQ_IFETCH_LEVEL.yaml
+    │   ├── pmc_perf_SQ_INST_LEVEL_LDS.yaml
+    │   ├── pmc_perf_SQ_INST_LEVEL_SMEM.yaml
+    │   ├── pmc_perf_SQ_INST_LEVEL_VMEM.yaml
+    │   └── pmc_perf_SQ_LEVEL_WAVES.yaml
     ├── profiling_config.yaml
     ├── results_pmc_perf_0.csv
     ├── results_pmc_perf_1.csv
@@ -744,7 +746,7 @@ The following example demonstrates profiling roofline data only:
    INFO ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    INFO
    INFO [Run 1/3][Approximate profiling time left: pending first measurement...]
-   INFO [profiling] Current input file: /home/auser/rocprofiler-compute/workloads/occupancy/MI325X/perfmon/pmc_perf_0.txt
+   INFO [profiling] Current input file: /home/auser/rocprofiler-compute/workloads/occupancy/MI325X/perfmon/pmc_perf_0.yaml
    ...
    INFO [roofline] Checking for roofline.csv in /home/auser/rocprofiler-compute/workloads/occupancy/MI325X
    INFO [roofline] No roofline data found. Generating...
@@ -1088,7 +1090,7 @@ The following example demonstrates how to use iteration multiplexing with the
    INFO
    INFO Using native counter collection tool: /tmp/rocprofiler-compute-tool-xxxxx/librocprofiler-compute-tool.so
    INFO [profiling] Iteration multiplexing: kernel
-   INFO [profiling] Current input files: .../perfmon/SQC_DCACHE_INFLIGHT_LEVEL.txt, .../perfmon/pmc_perf_0.txt, ...
+   INFO [profiling] Current input files: .../perfmon/pmc_perf_SQC_DCACHE_INFLIGHT_LEVEL.yaml, .../perfmon/pmc_perf_0.yaml, ...
    INFO    |-> [rocprofiler-sdk] [rocprofiler-compute] [rocprofiler_configure] (priority=1) is using rocprofiler-sdk v1.1.0 (1.1.0)
    INFO    |-> [rocprofiler-sdk] [rocprofiler-compute] In tool init
    INFO    |-> [rocprofiler-sdk] vcopy testing on GCD 0
@@ -1146,31 +1148,32 @@ The example above produces:
    └── MI325X
     ├── log.txt
     ├── perfmon
-    │   ├── pmc_perf_0.txt
+    │   ├── counter_def_0.yaml
+    │   ├── counter_def_1.yaml
+    │   ├── counter_def_2.yaml
+    │   ├── counter_def_3.yaml
+    │   ├── counter_def_4.yaml
+    │   ├── counter_def_5.yaml
+    │   ├── counter_def_SQC_DCACHE_INFLIGHT_LEVEL.yaml
+    │   ├── counter_def_SQC_ICACHE_INFLIGHT_LEVEL.yaml
+    │   ├── counter_def_SQ_IFETCH_LEVEL.yaml
+    │   ├── counter_def_SQ_INST_LEVEL_LDS.yaml
+    │   ├── counter_def_SQ_INST_LEVEL_SMEM.yaml
+    │   ├── counter_def_SQ_INST_LEVEL_VMEM.yaml
+    │   ├── counter_def_SQ_LEVEL_WAVES.yaml
     │   ├── pmc_perf_0.yaml
-    │   ├── pmc_perf_1.txt
     │   ├── pmc_perf_1.yaml
-    │   ├── pmc_perf_2.txt
     │   ├── pmc_perf_2.yaml
-    │   ├── pmc_perf_3.txt
     │   ├── pmc_perf_3.yaml
-    │   ├── pmc_perf_4.txt
     │   ├── pmc_perf_4.yaml
-    │   ├── pmc_perf_5.txt
-    │   ├── SQC_DCACHE_INFLIGHT_LEVEL.txt
-    │   ├── SQC_DCACHE_INFLIGHT_LEVEL.yaml
-    │   ├── SQC_ICACHE_INFLIGHT_LEVEL.txt
-    │   ├── SQC_ICACHE_INFLIGHT_LEVEL.yaml
-    │   ├── SQ_IFETCH_LEVEL.txt
-    │   ├── SQ_IFETCH_LEVEL.yaml
-    │   ├── SQ_INST_LEVEL_LDS.txt
-    │   ├── SQ_INST_LEVEL_LDS.yaml
-    │   ├── SQ_INST_LEVEL_SMEM.txt
-    │   ├── SQ_INST_LEVEL_SMEM.yaml
-    │   ├── SQ_INST_LEVEL_VMEM.txt
-    │   ├── SQ_INST_LEVEL_VMEM.yaml
-    │   ├── SQ_LEVEL_WAVES.txt
-    │   └── SQ_LEVEL_WAVES.yaml
+    │   ├── pmc_perf_5.yaml
+    │   ├── pmc_perf_SQC_DCACHE_INFLIGHT_LEVEL.yaml
+    │   ├── pmc_perf_SQC_ICACHE_INFLIGHT_LEVEL.yaml
+    │   ├── pmc_perf_SQ_IFETCH_LEVEL.yaml
+    │   ├── pmc_perf_SQ_INST_LEVEL_LDS.yaml
+    │   ├── pmc_perf_SQ_INST_LEVEL_SMEM.yaml
+    │   ├── pmc_perf_SQ_INST_LEVEL_VMEM.yaml
+    │   └── pmc_perf_SQ_LEVEL_WAVES.yaml
     ├── pmc_perf_0.csv
     ├── pmc_perf_1.csv
     ├── pmc_perf_2.csv
@@ -1196,31 +1199,32 @@ The example above produces:
    └── MI325X
     ├── log.txt
     ├── perfmon
-    │   ├── pmc_perf_0.txt
+    │   ├── counter_def_0.yaml
+    │   ├── counter_def_1.yaml
+    │   ├── counter_def_2.yaml
+    │   ├── counter_def_3.yaml
+    │   ├── counter_def_4.yaml
+    │   ├── counter_def_5.yaml
+    │   ├── counter_def_SQC_DCACHE_INFLIGHT_LEVEL.yaml
+    │   ├── counter_def_SQC_ICACHE_INFLIGHT_LEVEL.yaml
+    │   ├── counter_def_SQ_IFETCH_LEVEL.yaml
+    │   ├── counter_def_SQ_INST_LEVEL_LDS.yaml
+    │   ├── counter_def_SQ_INST_LEVEL_SMEM.yaml
+    │   ├── counter_def_SQ_INST_LEVEL_VMEM.yaml
+    │   ├── counter_def_SQ_LEVEL_WAVES.yaml
     │   ├── pmc_perf_0.yaml
-    │   ├── pmc_perf_1.txt
     │   ├── pmc_perf_1.yaml
-    │   ├── pmc_perf_2.txt
     │   ├── pmc_perf_2.yaml
-    │   ├── pmc_perf_3.txt
     │   ├── pmc_perf_3.yaml
-    │   ├── pmc_perf_4.txt
     │   ├── pmc_perf_4.yaml
-    │   ├── pmc_perf_5.txt
-    │   ├── SQC_DCACHE_INFLIGHT_LEVEL.txt
-    │   ├── SQC_DCACHE_INFLIGHT_LEVEL.yaml
-    │   ├── SQC_ICACHE_INFLIGHT_LEVEL.txt
-    │   ├── SQC_ICACHE_INFLIGHT_LEVEL.yaml
-    │   ├── SQ_IFETCH_LEVEL.txt
-    │   ├── SQ_IFETCH_LEVEL.yaml
-    │   ├── SQ_INST_LEVEL_LDS.txt
-    │   ├── SQ_INST_LEVEL_LDS.yaml
-    │   ├── SQ_INST_LEVEL_SMEM.txt
-    │   ├── SQ_INST_LEVEL_SMEM.yaml
-    │   ├── SQ_INST_LEVEL_VMEM.txt
-    │   ├── SQ_INST_LEVEL_VMEM.yaml
-    │   ├── SQ_LEVEL_WAVES.txt
-    │   └── SQ_LEVEL_WAVES.yaml
+    │   ├── pmc_perf_5.yaml
+    │   ├── pmc_perf_SQC_DCACHE_INFLIGHT_LEVEL.yaml
+    │   ├── pmc_perf_SQC_ICACHE_INFLIGHT_LEVEL.yaml
+    │   ├── pmc_perf_SQ_IFETCH_LEVEL.yaml
+    │   ├── pmc_perf_SQ_INST_LEVEL_LDS.yaml
+    │   ├── pmc_perf_SQ_INST_LEVEL_SMEM.yaml
+    │   ├── pmc_perf_SQ_INST_LEVEL_VMEM.yaml
+    │   └── pmc_perf_SQ_LEVEL_WAVES.yaml
     ├── pmc_perf_0.csv
     ├── pmc_perf_1.csv
     ├── pmc_perf_2.csv
@@ -1244,31 +1248,32 @@ to your output directory. The following example is run on the host ``amd-ryzen``
    └── MI325X
     ├── log.txt
     ├── perfmon
-    │   ├── pmc_perf_0.txt
+    │   ├── counter_def_0.yaml
+    │   ├── counter_def_1.yaml
+    │   ├── counter_def_2.yaml
+    │   ├── counter_def_3.yaml
+    │   ├── counter_def_4.yaml
+    │   ├── counter_def_5.yaml
+    │   ├── counter_def_SQC_DCACHE_INFLIGHT_LEVEL.yaml
+    │   ├── counter_def_SQC_ICACHE_INFLIGHT_LEVEL.yaml
+    │   ├── counter_def_SQ_IFETCH_LEVEL.yaml
+    │   ├── counter_def_SQ_INST_LEVEL_LDS.yaml
+    │   ├── counter_def_SQ_INST_LEVEL_SMEM.yaml
+    │   ├── counter_def_SQ_INST_LEVEL_VMEM.yaml
+    │   ├── counter_def_SQ_LEVEL_WAVES.yaml
     │   ├── pmc_perf_0.yaml
-    │   ├── pmc_perf_1.txt
     │   ├── pmc_perf_1.yaml
-    │   ├── pmc_perf_2.txt
     │   ├── pmc_perf_2.yaml
-    │   ├── pmc_perf_3.txt
     │   ├── pmc_perf_3.yaml
-    │   ├── pmc_perf_4.txt
     │   ├── pmc_perf_4.yaml
-    │   ├── pmc_perf_5.txt
-    │   ├── SQC_DCACHE_INFLIGHT_LEVEL.txt
-    │   ├── SQC_DCACHE_INFLIGHT_LEVEL.yaml
-    │   ├── SQC_ICACHE_INFLIGHT_LEVEL.txt
-    │   ├── SQC_ICACHE_INFLIGHT_LEVEL.yaml
-    │   ├── SQ_IFETCH_LEVEL.txt
-    │   ├── SQ_IFETCH_LEVEL.yaml
-    │   ├── SQ_INST_LEVEL_LDS.txt
-    │   ├── SQ_INST_LEVEL_LDS.yaml
-    │   ├── SQ_INST_LEVEL_SMEM.txt
-    │   ├── SQ_INST_LEVEL_SMEM.yaml
-    │   ├── SQ_INST_LEVEL_VMEM.txt
-    │   ├── SQ_INST_LEVEL_VMEM.yaml
-    │   ├── SQ_LEVEL_WAVES.txt
-    │   └── SQ_LEVEL_WAVES.yaml
+    │   ├── pmc_perf_5.yaml
+    │   ├── pmc_perf_SQC_DCACHE_INFLIGHT_LEVEL.yaml
+    │   ├── pmc_perf_SQC_ICACHE_INFLIGHT_LEVEL.yaml
+    │   ├── pmc_perf_SQ_IFETCH_LEVEL.yaml
+    │   ├── pmc_perf_SQ_INST_LEVEL_LDS.yaml
+    │   ├── pmc_perf_SQ_INST_LEVEL_SMEM.yaml
+    │   ├── pmc_perf_SQ_INST_LEVEL_VMEM.yaml
+    │   └── pmc_perf_SQ_LEVEL_WAVES.yaml
     ├── pmc_perf_0.csv
     ├── pmc_perf_1.csv
     ├── pmc_perf_2.csv

--- a/projects/rocprofiler-compute/src/rocprof_compute_analyze/analysis_base.py
+++ b/projects/rocprofiler-compute/src/rocprof_compute_analyze/analysis_base.py
@@ -81,7 +81,10 @@ def detect_missing_counters(
     if join_type == "grid":
         group_labels.append("Grid_Size")
 
-    num_files = len(list(workload_dir.glob("perfmon/*.txt")))
+    # Old workloads have *.txt, new workloads have pmc_perf_*.yaml
+    num_files = len(list(workload_dir.glob("perfmon/*.txt"))) + len(
+        list(workload_dir.glob("perfmon/pmc_perf_*.yaml"))
+    )
     kernels_with_missing_counters = []
     for _, groups in df.groupby(group_labels):
         if groups["Dispatch_ID"].nunique() < num_files:

--- a/projects/rocprofiler-compute/src/rocprof_compute_profile/profiler_base.py
+++ b/projects/rocprofiler-compute/src/rocprof_compute_profile/profiler_base.py
@@ -278,7 +278,7 @@ class RocProfCompute_Base:
             console_log("Filtered sections: All")
 
         # Run profiling on each input file
-        input_files = sorted(Path(args.path).glob("perfmon/*.txt"))
+        input_files = sorted(Path(args.path).glob("perfmon/pmc_perf_*.yaml"))
         total_runs = len(input_files)
 
         if total_runs == 0 and is_only_pc_sampling(args.filter_blocks):
@@ -397,37 +397,6 @@ class RocProfCompute_Base:
 
         total_profiling_time = 0.0
 
-        for fname in input_files:
-            # Kernel filtering (in-place replacement)
-            if not args.kernel == None:
-                success, output = capture_subprocess_output([
-                    "sed",
-                    "-i",
-                    "-r",
-                    f"s%^(kernel:).*%kernel: {','.join(self.__args.kernel)}%g",
-                    str(fname),
-                ])
-                # log output from profile filtering
-                if not success:
-                    console_error(output)
-                else:
-                    console_debug(output)
-
-            # Dispatch filtering (inplace replacement)
-            if args.dispatch is not None:
-                success, output = capture_subprocess_output([
-                    "sed",
-                    "-i",
-                    "-r",
-                    f"s%^(range:).*%range: {' '.join(self.__args.dispatch)}%g",
-                    str(fname),
-                ])
-                # log output from profile filtering
-                if not success:
-                    console_error(output)
-                else:
-                    console_debug(output)
-
         if args.iteration_multiplexing is not None:
             if native_tool_path is None:
                 console_error(
@@ -495,7 +464,7 @@ class RocProfCompute_Base:
             )
             return
 
-        total_runs = len(list(Path(args.path).glob("perfmon/*.txt")))
+        total_runs = len(list(Path(args.path).glob("perfmon/pmc_perf_*.yaml")))
 
         console_log(f"[Run {total_runs + 1}/{total_runs + 1}][PC sampling profile run]")
 

--- a/projects/rocprofiler-compute/src/rocprof_compute_soc/soc_base.py
+++ b/projects/rocprofiler-compute/src/rocprof_compute_soc/soc_base.py
@@ -505,9 +505,7 @@ class OmniSoC_Base:
                 and not is_tcc_channel_counter(counter)
             ):
                 counters.remove(counter)
-                output_files.append(
-                    CounterFile(counter + ".txt", self.__perfmon_config)
-                )
+                output_files.append(CounterFile(counter, self.__perfmon_config))
                 output_files[-1].add(counter)
                 output_files[-1].add(f"{counter}_ACCUM")
                 accu_file_count += 1
@@ -536,9 +534,7 @@ class OmniSoC_Base:
 
             # All files are full, create a new file
             if not added:
-                output_files.append(
-                    CounterFile(f"pmc_perf_{file_count}.txt", self.__perfmon_config)
-                )
+                output_files.append(CounterFile(file_count, self.__perfmon_config))
                 file_count += 1
                 output_files[-1].add(ctr)
 
@@ -579,7 +575,8 @@ class OmniSoC_Base:
 
             for f_idx in range(groups_per_bucket):
                 file_name = (
-                    Path(workload_perfmon_dir) / f"pmc_perf_node_{node_idx}_{f_idx}.txt"
+                    Path(workload_perfmon_dir)
+                    / f"pmc_perf_node_{node_idx}_{f_idx}.yaml"
                 )
 
                 pmc = []
@@ -594,12 +591,12 @@ class OmniSoC_Base:
 
                 # Write counters to file
                 with open(file_name, "w") as fd:
-                    fd.write(f"pmc: {' '.join(pmc)}\n\n")
+                    fd.write(yaml.dump({"jobs": [{"pmc": pmc}]}, sort_keys=False))
         else:
             # Output to files
             for f in output_files:
-                file_name_txt = workload_perfmon_dir / f.file_name_txt
-                file_name_yaml = workload_perfmon_dir / f.file_name_yaml
+                pmc_filename = workload_perfmon_dir / f.pmc_filename
+                counter_def_filename = workload_perfmon_dir / f.counter_def_filename
 
                 pmc = []
                 counter_def: dict[str, Any] = {}
@@ -634,15 +631,12 @@ class OmniSoC_Base:
                         )
 
                 # Write counters to file
-                with open(file_name_txt, "w") as fd:
-                    fd.write(f"pmc: {' '.join(pmc)}\n\n")
-                    fd.write("gpu:\n")
-                    fd.write("range:\n")
-                    fd.write("kernel:\n")
+                with open(pmc_filename, "w") as fd:
+                    fd.write(yaml.dump({"jobs": [{"pmc": pmc}]}, sort_keys=False))
 
                 # Write counter definitions to file
                 if counter_def:
-                    with open(file_name_yaml, "w") as fp:
+                    with open(counter_def_filename, "w") as fp:
                         fp.write(yaml.dump(counter_def, sort_keys=False))
 
     # ----------------------------------------------------
@@ -730,9 +724,8 @@ class LimitedSet:
 # block limited according to perfmon config.
 class CounterFile:
     def __init__(self, name: str, perfmon_config: dict[str, int]) -> None:
-        name_no_extension = name.split(".")[0]
-        self.file_name_txt: str = name_no_extension + ".txt"
-        self.file_name_yaml: str = name_no_extension + ".yaml"
+        self.pmc_filename: str = f"pmc_perf_{name}.yaml"
+        self.counter_def_filename: str = f"counter_def_{name}.yaml"
         self.blocks: dict[str, LimitedSet] = {
             block: LimitedSet(capacity) for block, capacity in perfmon_config.items()
         }

--- a/projects/rocprofiler-compute/src/rocprof_compute_soc/soc_base.py
+++ b/projects/rocprofiler-compute/src/rocprof_compute_soc/soc_base.py
@@ -534,7 +534,7 @@ class OmniSoC_Base:
 
             # All files are full, create a new file
             if not added:
-                output_files.append(CounterFile(file_count, self.__perfmon_config))
+                output_files.append(CounterFile(str(file_count), self.__perfmon_config))
                 file_count += 1
                 output_files[-1].add(ctr)
 

--- a/projects/rocprofiler-compute/src/utils/file_io.py
+++ b/projects/rocprofiler-compute/src/utils/file_io.py
@@ -229,34 +229,45 @@ def create_df_pmc(
         dfs: list[pd.DataFrame] = []
         coll_levels: list[str] = []
 
-        for csv_file in Path(raw_data_dir).rglob("*.csv"):
-            file_name = csv_file.name
+        coll_level_map = {}
+        for file_name in Path(raw_data_dir).rglob("*.csv"):
+            # In csv format accumulator counters are specified as
+            # SQ_ACCUM_PREV_HIRES counter in the coll_level specific csv
+            if config_dict.get(
+                "format_rocprof_output"
+            ) == "csv" and file_name.name.startswith("pmc_perf_SQ"):
+                coll_level_map[file_name] = file_name.name[
+                    len("pmc_perf_") : -len(".csv")
+                ]
 
-            is_sq_file = file_name.startswith("SQ")
-            is_pmc_perf = file_name == f"{schema.PMC_PERF_FILE_PREFIX}.csv"
+            # coll_level for pmc_perf.csv
+            if file_name.name == f"{schema.PMC_PERF_FILE_PREFIX}.csv":
+                coll_level_map[file_name] = schema.PMC_PERF_FILE_PREFIX
 
-            if is_sq_file or is_pmc_perf:
-                tmp_df = pd.read_csv(csv_file)
+        for csv_file in coll_level_map:
+            tmp_df = pd.read_csv(csv_file)
 
-                if config_dict.get("format_rocprof_output") == "rocpd":
-                    tmp_df = utils_analysis.process_rocpd_csv(tmp_df)
+            if config_dict.get("format_rocprof_output") == "rocpd":
+                tmp_df = utils_analysis.process_rocpd_csv(tmp_df)
 
-                # Demangle original KernelNames
-                # Skip for Standalone Roofline with -1 to keep full kernel names
-                if kernel_verbose >= 0:
-                    kernel_name_shortener(tmp_df, kernel_verbose)
+            # Demangle original KernelNames
+            # Skip for Standalone Roofline with -1 to keep full kernel names
+            if kernel_verbose >= 0:
+                kernel_name_shortener(tmp_df, kernel_verbose)
 
-                # NB:
-                #   Idealy, the Node column should be added out of
-                #   multiindexing level. Here, we add it into pmc_perf
-                #   as it is the main sub-df which can be handled easily
-                #   later.
-                if file_name == "pmc_perf.csv" and node_name is not None:
-                    tmp_df.insert(0, "Node", node_name)
+            # NB:
+            #   Idealy, the Node column should be added out of
+            #   multiindexing level. Here, we add it into pmc_perf
+            #   as it is the main sub-df which can be handled easily
+            #   later.
+            if (
+                csv_file.name == f"{schema.PMC_PERF_FILE_PREFIX}.csv"
+                and node_name is not None
+            ):
+                tmp_df.insert(0, "Node", node_name)
 
-                dfs.append(tmp_df)
-                # Remove .csv extension for collection level
-                coll_levels.append(csv_file.stem)
+            dfs.append(tmp_df)
+            coll_levels.append(coll_level_map[csv_file])
 
         if not dfs:
             return pd.DataFrame()

--- a/projects/rocprofiler-compute/src/utils/utils_common.py
+++ b/projects/rocprofiler-compute/src/utils/utils_common.py
@@ -619,7 +619,7 @@ def parse_pmc_perf(pmc_perf_file: str) -> list[str]:
     jobs = data.get("jobs", [])
     if not jobs:
         return []
-    return jobs[0].get("pmc", [])
+    return jobs[0].get("pmc") or []
 
 
 def is_only_pc_sampling(filter_blocks: list[str]) -> bool:

--- a/projects/rocprofiler-compute/src/utils/utils_common.py
+++ b/projects/rocprofiler-compute/src/utils/utils_common.py
@@ -609,33 +609,14 @@ def get_gpuid_dict(data: dict[str, Any]) -> dict[Any, int]:
     return gpu_map
 
 
-def parse_text(text_file: str) -> list[str]:
+def parse_pmc_perf(pmc_perf_file: str) -> list[str]:
     """
-    Parse the text file to get the pmc counters.
+    Parse the YAML file to get the pmc counters.
+    Assumes only one job per file.
     """
-
-    def process_line(line: str) -> list[str]:
-        if "pmc:" not in line:
-            return []
-        line = line.strip()
-        pos = line.find("#")
-        if pos >= 0:
-            line = line[0:pos]
-
-        def _dedup(_line: str, _sep: list[str]) -> str:
-            for itr in _sep:
-                _line = " ".join(_line.split(itr))
-            return _line.strip()
-
-        # remove tabs and duplicate spaces
-        return _dedup(line.replace("pmc:", ""), ["\n", "\t", " "]).split(" ")
-
-    with open(text_file) as file:
-        return [
-            counter
-            for litr in [process_line(itr) for itr in file.readlines()]
-            for counter in litr
-        ]
+    with open(pmc_perf_file) as file:
+        data = yaml.safe_load(file) or {}
+    return data.get("jobs", [{}])[0].get("pmc", [])
 
 
 def is_only_pc_sampling(filter_blocks: list[str]) -> bool:

--- a/projects/rocprofiler-compute/src/utils/utils_common.py
+++ b/projects/rocprofiler-compute/src/utils/utils_common.py
@@ -616,7 +616,10 @@ def parse_pmc_perf(pmc_perf_file: str) -> list[str]:
     """
     with open(pmc_perf_file) as file:
         data = yaml.safe_load(file) or {}
-    return data.get("jobs", [{}])[0].get("pmc", [])
+    jobs = data.get("jobs", [])
+    if not jobs:
+        return []
+    return jobs[0].get("pmc", [])
 
 
 def is_only_pc_sampling(filter_blocks: list[str]) -> bool:

--- a/projects/rocprofiler-compute/src/utils/utils_profile.py
+++ b/projects/rocprofiler-compute/src/utils/utils_profile.py
@@ -106,10 +106,13 @@ def run_prof(
         sdk_config = yaml.safe_load(filename)
     # Extra counter definitions
     for fname in fnames if multiple_files else [fnames]:
-        if not fname.startswith("pmc_perf_"):
+        fname_path = Path(fname)
+        if not fname_path.name.startswith("pmc_perf_"):
             continue
-        counter_def_fname = "counter_def_" + fname[len("pmc_perf_") :]
-        if Path(counter_def_fname).exists():
+        counter_def_fname = fname_path.parent / (
+            "counter_def_" + fname_path.name[len("pmc_perf_") :]
+        )
+        if counter_def_fname.exists():
             with open(Path(counter_def_fname)) as file:
                 sdk_config["rocprofiler-sdk"]["counters"].extend(
                     yaml.safe_load(file)["rocprofiler-sdk"]["counters"]

--- a/projects/rocprofiler-compute/src/utils/utils_profile.py
+++ b/projects/rocprofiler-compute/src/utils/utils_profile.py
@@ -107,8 +107,6 @@ def run_prof(
     # Extra counter definitions
     for fname in fnames if multiple_files else [fnames]:
         fname_path = Path(fname)
-        if not fname_path.name.startswith("pmc_perf_"):
-            continue
         counter_def_fname = fname_path.parent / (
             "counter_def_" + fname_path.name[len("pmc_perf_") :]
         )
@@ -172,7 +170,6 @@ def run_prof(
             shutil.copytree(
                 pass_1, Path(workload_dir) / "out" / "pmc_1", dirs_exist_ok=True
             )
-            shutil.rmtree(pass_1)
 
     # Delete counter definition temporary directory
     if new_env.get("ROCPROFILER_METRICS_PATH"):

--- a/projects/rocprofiler-compute/src/utils/utils_profile.py
+++ b/projects/rocprofiler-compute/src/utils/utils_profile.py
@@ -28,7 +28,7 @@ from utils.utils_common import (
     capture_subprocess_output,
     create_temp_rocprofiler_metrics_path,
     get_rocprof_cmd,
-    parse_text,
+    parse_pmc_perf,
     perform_attach_detach,
 )
 from vendored import yaml
@@ -78,10 +78,10 @@ def run_prof(
         options = cast(dict[str, Union[str, list[str]]], profiler_options).copy()
         if multiple_files:
             options["ROCPROF_COUNTERS"] = ", ".join([
-                f"pmc: {' '.join(parse_text(fname))}" for fname in fnames
+                f"pmc: {' '.join(parse_pmc_perf(fname))}" for fname in fnames
             ])
         else:
-            options["ROCPROF_COUNTERS"] = f"pmc: {' '.join(parse_text(fnames))}"
+            options["ROCPROF_COUNTERS"] = f"pmc: {' '.join(parse_pmc_perf(fnames))}"
         options["ROCPROF_AGENT_INDEX"] = "absolute"
     else:
         if multiple_files:
@@ -106,8 +106,9 @@ def run_prof(
         sdk_config = yaml.safe_load(filename)
     # Extra counter definitions
     for fname in fnames if multiple_files else [fnames]:
-        if Path(fname).with_suffix(".yaml").exists():
-            with open(Path(fname).with_suffix(".yaml")) as file:
+        counter_def_fname = fname.replace("pmc_perf", "counter_def")
+        if Path(counter_def_fname).exists():
+            with open(Path(counter_def_fname)) as file:
                 sdk_config["rocprofiler-sdk"]["counters"].extend(
                     yaml.safe_load(file)["rocprofiler-sdk"]["counters"]
                 )
@@ -154,9 +155,19 @@ def run_prof(
 
     time_2 = time.time()
     console_debug(
-        f"Finishing subprocess of fname {fname}, the time taken is "
+        f"Finishing subprocess of pmc file(s), the time taken is "
         f"{int((time_2 - time_1) / 60)} m {str((time_2 - time_1) % 60)} sec "
     )
+
+    if get_rocprof_cmd() != "rocprofiler-sdk":
+        # rocprofv3 with yaml input file can write out/pass_1 instead of out/pmc_1
+        # Move files from out/pass_1 to out/pmc_1 if pass_1 exists
+        pass_1 = Path(workload_dir) / "out" / "pass_1"
+        if pass_1.exists():
+            shutil.copytree(
+                pass_1, Path(workload_dir) / "out" / "pmc_1", dirs_exist_ok=True
+            )
+            shutil.rmtree(pass_1)
 
     # Delete counter definition temporary directory
     if new_env.get("ROCPROFILER_METRICS_PATH"):

--- a/projects/rocprofiler-compute/src/utils/utils_profile.py
+++ b/projects/rocprofiler-compute/src/utils/utils_profile.py
@@ -106,7 +106,9 @@ def run_prof(
         sdk_config = yaml.safe_load(filename)
     # Extra counter definitions
     for fname in fnames if multiple_files else [fnames]:
-        counter_def_fname = fname.replace("pmc_perf", "counter_def")
+        if not fname.startswith("pmc_perf_"):
+            continue
+        counter_def_fname = "counter_def_" + fname[len("pmc_perf_") :]
         if Path(counter_def_fname).exists():
             with open(Path(counter_def_fname)) as file:
                 sdk_config["rocprofiler-sdk"]["counters"].extend(

--- a/projects/rocprofiler-compute/tests/test_profile_general.py
+++ b/projects/rocprofiler-compute/tests/test_profile_general.py
@@ -666,41 +666,15 @@ def test_path_csv(
 
     file_dict = test_utils.check_csv_files(workload_dir, num_devices, num_kernels)
     all_csvs_mi100 = sorted([
-        "SQC_DCACHE_INFLIGHT_LEVEL.csv",
-        "SQC_ICACHE_INFLIGHT_LEVEL.csv",
-        "SQ_IFETCH_LEVEL.csv",
-        "SQ_INST_LEVEL_LDS.csv",
-        "SQ_LEVEL_WAVES.csv",
         "sysinfo.csv",
     ])
     all_csvs_mi200 = sorted([
-        "SQC_DCACHE_INFLIGHT_LEVEL.csv",
-        "SQC_ICACHE_INFLIGHT_LEVEL.csv",
-        "SQ_IFETCH_LEVEL.csv",
-        "SQ_INST_LEVEL_LDS.csv",
-        "SQ_INST_LEVEL_SMEM.csv",
-        "SQ_INST_LEVEL_VMEM.csv",
-        "SQ_LEVEL_WAVES.csv",
         "sysinfo.csv",
     ])
     all_csvs_mi300 = sorted([
-        "SQC_DCACHE_INFLIGHT_LEVEL.csv",
-        "SQC_ICACHE_INFLIGHT_LEVEL.csv",
-        "SQ_IFETCH_LEVEL.csv",
-        "SQ_INST_LEVEL_LDS.csv",
-        "SQ_INST_LEVEL_SMEM.csv",
-        "SQ_INST_LEVEL_VMEM.csv",
-        "SQ_LEVEL_WAVES.csv",
         "sysinfo.csv",
     ])
     all_csvs_mi350 = sorted([
-        "SQC_DCACHE_INFLIGHT_LEVEL.csv",
-        "SQC_ICACHE_INFLIGHT_LEVEL.csv",
-        "SQ_IFETCH_LEVEL.csv",
-        "SQ_INST_LEVEL_LDS.csv",
-        "SQ_INST_LEVEL_SMEM.csv",
-        "SQ_INST_LEVEL_VMEM.csv",
-        "SQ_LEVEL_WAVES.csv",
         "sysinfo.csv",
     ])
 

--- a/projects/rocprofiler-compute/tests/test_utils.py
+++ b/projects/rocprofiler-compute/tests/test_utils.py
@@ -1447,7 +1447,7 @@ def test_run_prof_with_yaml_config(tmp_path, monkeypatch):
     fname = tmp_path / "pmc_perf_test.yaml"
     fname.write_text("jobs:\n  - pmc:\n    - SQ_WAVES\n")
     yaml_file = tmp_path / "counter_def_test.yaml"
-    yaml_file.write_text("counters:\n  - TCC_HIT")
+    yaml_file.write_text("rocprofiler-sdk:\n  counters:\n    - TCC_HIT\n")
     workload_dir = str(tmp_path / "workload")
 
     monkeypatch.setattr("utils.utils_common._rocprof_cmd", "rocprofv3")
@@ -1461,10 +1461,6 @@ def test_run_prof_with_yaml_config(tmp_path, monkeypatch):
     monkeypatch.setattr("utils.utils_profile.console_debug", lambda *a, **k: None)
     monkeypatch.setattr("utils.utils_profile.console_log", lambda *a, **k: None)
     monkeypatch.setattr("utils.utils_profile.console_warning", lambda *a, **k: None)
-    monkeypatch.setattr(
-        "utils.utils_profile.yaml.safe_load",
-        lambda _: {"rocprofiler-sdk": {"counters": ["counter"]}},
-    )
 
     utils_profile.run_prof(str(fname), ["--arg"], workload_dir, logging.INFO, "csv")
 

--- a/projects/rocprofiler-compute/tests/test_utils.py
+++ b/projects/rocprofiler-compute/tests/test_utils.py
@@ -256,12 +256,14 @@ def check_non_pmc_files(output_dir, num_devices, num_kernels):
 def get_num_pmc_file(output_dir):
     """
     Returns:
-        int: number of pmc perf text files in perfmon dir
+        int: number of pmc perf yaml files in perfmon dir
     """
 
     perfmon_path = Path(output_dir) / "perfmon"
     return len([
-        f for f in perfmon_path.iterdir() if f.is_file() and f.suffix == ".txt"
+        f
+        for f in perfmon_path.iterdir()
+        if f.is_file() and f.name.startswith("pmc_perf_") and f.suffix == ".yaml"
     ])
 
 
@@ -1181,12 +1183,12 @@ def test_check_file_pattern_file_not_found():
 
 
 # =============================================================================
-# TEXT PARSING UTILITIES TESTS
+# PMC PERF PARSING UTILITIES TESTS
 # =============================================================================
 
 
-def test_parse_text_basic(tmp_path):
-    """Test parse_text with a simple valid input file.
+def test_parse_pmc_perf_basic(tmp_path):
+    """Test parse_pmc_perf with a simple valid YAML input file.
 
     Args:
         tmp_path (Path): Temporary path fixture provided by pytest.
@@ -1194,15 +1196,17 @@ def test_parse_text_basic(tmp_path):
     Returns:
         None: Asserts that counters are correctly extracted from a simple file.
     """
-    test_file = tmp_path / "test_counters.txt"
-    test_file.write_text("pmc: counter1 counter2 counter3")
+    test_file = tmp_path / "test_counters.yaml"
+    test_file.write_text(
+        "jobs:\n  - pmc:\n    - counter1\n    - counter2\n    - counter3\n"
+    )
 
-    result = utils_common.parse_text(str(test_file))
+    result = utils_common.parse_pmc_perf(str(test_file))
     assert result == ["counter1", "counter2", "counter3"]
 
 
-def test_parse_text_empty_file(tmp_path):
-    """Test parse_text with an empty file.
+def test_parse_pmc_perf_empty_file(tmp_path):
+    """Test parse_pmc_perf with an empty file.
 
     Args:
         tmp_path (Path): Temporary path fixture provided by pytest.
@@ -1210,130 +1214,69 @@ def test_parse_text_empty_file(tmp_path):
     Returns:
         None: Asserts that an empty file returns an empty list.
     """
-    test_file = tmp_path / "empty.txt"
+    test_file = tmp_path / "empty.yaml"
     test_file.write_text("")
 
-    result = utils_common.parse_text(str(test_file))
+    result = utils_common.parse_pmc_perf(str(test_file))
     assert result == []
 
 
-def test_parse_text_no_pmc_entries(tmp_path):
-    """Test parse_text with a file that doesn't contain any 'pmc:' entries.
+def test_parse_pmc_perf_no_pmc_entries(tmp_path):
+    """Test parse_pmc_perf with a YAML file that doesn't contain any 'pmc' entries.
 
     Args:
         tmp_path (Path): Temporary path fixture provided by pytest.
 
     Returns:
-        None: Asserts that a file without 'pmc:' returns an empty list.
+        None: Asserts that a file without 'pmc' returns an empty list.
     """
-    test_file = tmp_path / "no_pmc.txt"
-    test_file.write_text("line1\nline2\nline3")
+    test_file = tmp_path / "no_pmc.yaml"
+    test_file.write_text("jobs:\n  - other: value\n")
 
-    result = utils_common.parse_text(str(test_file))
+    result = utils_common.parse_pmc_perf(str(test_file))
     assert result == []
 
 
-def test_parse_text_with_comments(tmp_path):
-    """Test parse_text with lines that have comments after the counters.
+def test_parse_pmc_perf_no_jobs_key(tmp_path):
+    """Test parse_pmc_perf with missing jobs key.
 
     Args:
         tmp_path (Path): Temporary path fixture provided by pytest.
 
     Returns:
-        None: Asserts that comments are properly stripped from counter lines.
+        None: Asserts that missing jobs key returns an empty list.
     """
-    test_file = tmp_path / "comments.txt"
-    test_file.write_text("pmc: counter1 counter2 # This is a comment")
+    test_file = tmp_path / "no_jobs.yaml"
+    test_file.write_text("other_key: value\n")
 
-    result = utils_common.parse_text(str(test_file))
-    assert result == ["counter1", "counter2"]
+    result = utils_common.parse_pmc_perf(str(test_file))
+    assert result == []
 
 
-def test_parse_text_multiple_lines(tmp_path):
-    """Test parse_text with multiple 'pmc:' lines.
+def test_parse_pmc_perf_empty_pmc(tmp_path):
+    """Test parse_pmc_perf with empty pmc list.
 
     Args:
         tmp_path (Path): Temporary path fixture provided by pytest.
 
     Returns:
-        None: Asserts counters from multiple lines are correctly combined.
+        None: Asserts that empty pmc returns an empty list.
     """
-    test_file = tmp_path / "multiple_lines.txt"
-    test_file.write_text("pmc: counter1 counter2\npmc: counter3 counter4")
+    test_file = tmp_path / "empty_pmc.yaml"
+    test_file.write_text("jobs:\n  - pmc: []\n")
 
-    result = utils_common.parse_text(str(test_file))
-    assert result == ["counter1", "counter2", "counter3", "counter4"]
-
-
-def test_parse_text_mixed_lines(tmp_path):
-    """Test parse_text with a mix of 'pmc:' and non-'pmc:' lines.
-
-    Args:
-        tmp_path (Path): Temporary path fixture provided by pytest.
-
-    Returns:
-        None: Asserts that only counters from 'pmc:' lines are extracted.
-    """
-    test_file = tmp_path / "mixed_lines.txt"
-    test_file.write_text(
-        "line1\npmc: counter1 counter2\nline3\npmc: counter3 counter4\nline5"
-    )
-
-    result = utils_common.parse_text(str(test_file))
-    assert result == ["counter1", "counter2", "counter3", "counter4"]
+    result = utils_common.parse_pmc_perf(str(test_file))
+    assert result == []
 
 
-def test_parse_text_whitespace_handling(tmp_path):
-    """Test parse_text with various whitespace combinations.
-
-    Args:
-        tmp_path (Path): Temporary path fixture provided by pytest.
-
-    Returns:
-        None: Asserts that whitespace is properly handled in counter extraction.
-    """
-    test_file = tmp_path / "whitespace.txt"
-    test_file.write_text("pmc:    counter1\t\tcounter2   counter3")
-
-    result = utils_common.parse_text(str(test_file))
-
-    result = [item for item in result if item.strip()]
-
-    expected = ["counter1", "counter2", "counter3"]
-    assert result == expected
-
-    test_file.write_text("pmc: counter1 counter2\npmc: counter3 counter4")
-    result = utils_common.parse_text(str(test_file))
-    result = [item for item in result if item.strip()]
-    expected = ["counter1", "counter2", "counter3", "counter4"]
-    assert result == expected
-
-
-def test_parse_text_edge_cases(tmp_path):
-    """Test parse_text with edge cases like empty 'pmc:' lines.
-
-    Args:
-        tmp_path (Path): Temporary path fixture provided by pytest.
-
-    Returns:
-        None: Asserts that edge cases are handled correctly.
-    """
-    test_file = tmp_path / "edge_cases.txt"
-    test_file.write_text("pmc:\npmc: \npmc: counter1")
-
-    result = utils_common.parse_text(str(test_file))
-    result = [item for item in result if item.strip()]
-    assert result == ["counter1"]
-
-
-def test_parse_text_file_not_found():
-    """Test parse_text with a nonexistent file.
+def test_parse_pmc_perf_file_not_found():
+    """Test parse_pmc_perf with a nonexistent file.
 
     Returns:
         None: Asserts that FileNotFoundError is raised for nonexistent files.
     """
     with pytest.raises(FileNotFoundError):
-        utils_common.parse_text("nonexistent_file.txt")
+        utils_common.parse_pmc_perf("nonexistent_file.yaml")
 
 
 # =============================================================================
@@ -1352,8 +1295,8 @@ def test_run_prof_success_v3(tmp_path, monkeypatch):
     Returns:
         None: Asserts successful execution and file creation.
     """
-    fname = tmp_path / "test.txt"
-    fname.write_text("pmc: SQ_WAVES")
+    fname = tmp_path / "pmc_perf_test.yaml"
+    fname.write_text("jobs:\n  - pmc:\n    - SQ_WAVES\n")
     workload_dir = str(tmp_path / "workload")
     os.makedirs(workload_dir + "/out/pmc_1", exist_ok=True)
 
@@ -1380,7 +1323,7 @@ def test_run_prof_success_v3(tmp_path, monkeypatch):
 
     utils_profile.run_prof(str(fname), ["--arg"], workload_dir, logging.INFO, "csv")
 
-    assert Path(workload_dir + "/test.csv").exists()
+    assert Path(workload_dir + "/pmc_perf_test.csv").exists()
 
 
 def test_run_prof_success_v3_csv(tmp_path, monkeypatch):
@@ -1394,8 +1337,8 @@ def test_run_prof_success_v3_csv(tmp_path, monkeypatch):
     Returns:
         None: Asserts successful execution with v3 CSV processing.
     """
-    fname = tmp_path / "test.txt"
-    fname.write_text("pmc: SQ_WAVES")
+    fname = tmp_path / "pmc_perf_test.yaml"
+    fname.write_text("jobs:\n  - pmc:\n    - SQ_WAVES\n")
     workload_dir = str(tmp_path / "workload")
     os.makedirs(workload_dir + "/out/pmc_1", exist_ok=True)
 
@@ -1460,8 +1403,8 @@ def test_run_prof_success_rocprofiler_sdk(tmp_path, monkeypatch):
     Returns:
         None: Asserts successful execution with SDK configuration.
     """
-    fname = tmp_path / "test.txt"
-    fname.write_text("pmc: SQ_WAVES")
+    fname = tmp_path / "pmc_perf_test.yaml"
+    fname.write_text("jobs:\n  - pmc:\n    - SQ_WAVES\n")
     workload_dir = str(tmp_path / "workload")
 
     profiler_options = {
@@ -1477,7 +1420,7 @@ def test_run_prof_success_rocprofiler_sdk(tmp_path, monkeypatch):
         "utils.utils_profile.capture_subprocess_output",
         lambda *a, **k: (True, "success"),
     )
-    monkeypatch.setattr("utils.utils_common.parse_text", lambda f: ["SQ_WAVES"])
+    monkeypatch.setattr("utils.utils_common.parse_pmc_perf", lambda f: ["SQ_WAVES"])
     monkeypatch.setattr(
         "utils.utils_profile.process_rocprofv3_output", lambda *a, **k: []
     )
@@ -1501,9 +1444,9 @@ def test_run_prof_with_yaml_config(tmp_path, monkeypatch):
     Returns:
         None: Asserts YAML config is properly handled.
     """
-    fname = tmp_path / "test.txt"
-    fname.write_text("pmc: SQ_WAVES")
-    yaml_file = tmp_path / "test.yaml"
+    fname = tmp_path / "pmc_perf_test.yaml"
+    fname.write_text("jobs:\n  - pmc:\n    - SQ_WAVES\n")
+    yaml_file = tmp_path / "counter_def_test.yaml"
     yaml_file.write_text("counters:\n  - TCC_HIT")
     workload_dir = str(tmp_path / "workload")
 
@@ -1537,8 +1480,8 @@ def test_run_prof_failure_subprocess(tmp_path, monkeypatch):
     Returns:
         None: Asserts proper error handling on subprocess failure.
     """
-    fname = tmp_path / "test.txt"
-    fname.write_text("pmc: SQ_WAVES")
+    fname = tmp_path / "pmc_perf_test.yaml"
+    fname.write_text("jobs:\n  - pmc:\n    - SQ_WAVES\n")
     workload_dir = str(tmp_path / "workload")
 
     monkeypatch.setattr("utils.utils_common._rocprof_cmd", "rocprofv3")
@@ -1570,8 +1513,8 @@ def test_run_prof_mi300_environment_setup(tmp_path, monkeypatch):
     Returns:
         None: Asserts MI300 environment variable is set correctly.
     """
-    fname = tmp_path / "test.txt"
-    fname.write_text("pmc: SQ_WAVES")
+    fname = tmp_path / "pmc_perf_test.yaml"
+    fname.write_text("jobs:\n  - pmc:\n    - SQ_WAVES\n")
     workload_dir = str(tmp_path / "workload")
 
     captured_env = {}
@@ -1606,8 +1549,8 @@ def test_run_prof_timestamps_special_case(tmp_path, monkeypatch):
     Returns:
         None: Asserts timestamps processing is handled correctly.
     """
-    fname = tmp_path / "timestamps.txt"
-    fname.write_text("pmc: SQ_WAVES")
+    fname = tmp_path / "pmc_perf_timestamps.yaml"
+    fname.write_text("jobs:\n  - pmc:\n    - SQ_WAVES\n")
     workload_dir = str(tmp_path / "workload")
 
     os.makedirs(workload_dir + "/out/pmc_1", exist_ok=True)
@@ -1662,8 +1605,8 @@ def test_run_prof_no_results_files(tmp_path, monkeypatch):
     Returns:
         None: Asserts proper handling when no results are found.
     """
-    fname = tmp_path / "test.txt"
-    fname.write_text("pmc: SQ_WAVES")
+    fname = tmp_path / "pmc_perf_test.yaml"
+    fname.write_text("jobs:\n  - pmc:\n    - SQ_WAVES\n")
     workload_dir = str(tmp_path / "workload")
 
     monkeypatch.setattr("utils.utils_common._rocprof_cmd", "rocprofv2")
@@ -1689,8 +1632,8 @@ def test_run_prof_header_standardization(tmp_path, monkeypatch):
     Returns:
         None: Asserts CSV headers are standardized correctly.
     """
-    fname = tmp_path / "test.txt"
-    fname.write_text("pmc: SQ_WAVES")
+    fname = tmp_path / "pmc_perf_test.yaml"
+    fname.write_text("jobs:\n  - pmc:\n    - SQ_WAVES\n")
     workload_dir = str(tmp_path / "workload")
 
     os.makedirs(workload_dir + "/out/pmc_1", exist_ok=True)
@@ -1778,8 +1721,8 @@ def test_run_prof_tcc_flattening_mi300(tmp_path, monkeypatch):
     Returns:
         None: Asserts TCC flattening is applied for MI300 GPUs.
     """
-    fname = tmp_path / "test.txt"
-    fname.write_text("pmc: TCC_HIT[0]")
+    fname = tmp_path / "pmc_perf_test.yaml"
+    fname.write_text("jobs:\n  - pmc:\n    - TCC_HIT[0]\n")
     workload_dir = str(tmp_path / "workload")
 
     # Mock functions
@@ -1811,8 +1754,8 @@ def test_run_prof_sdk_creates_new_env_copy(tmp_path, monkeypatch):
             when rocprof_cmd == "rocprofiler-sdk" and new_env was not previously set
             by the mspec.gpu_model check.
     """
-    fname_str = str(tmp_path / "counters.txt")
-    Path(fname_str).touch()
+    fname_str = str(tmp_path / "pmc_perf_counters.yaml")
+    Path(fname_str).write_text("jobs:\n  - pmc:\n    - COUNTER1\n")
     workload_dir_str = str(tmp_path)
 
     monkeypatch.setattr("utils.utils_common._rocprof_cmd", "rocprofiler-sdk")
@@ -1837,27 +1780,32 @@ def test_run_prof_sdk_creates_new_env_copy(tmp_path, monkeypatch):
     monkeypatch.setattr("utils.utils_profile.console_error", mock_console_error_no_exit)
     monkeypatch.setattr("utils.utils_profile.console_debug", lambda *a, **k: None)
     monkeypatch.setattr(
-        "utils.utils_profile.parse_text", lambda *a, **k: ["COUNTER1", "COUNTER2"]
+        "utils.utils_profile.parse_pmc_perf", lambda *a, **k: ["COUNTER1", "COUNTER2"]
     )
 
     mock_fname_path_obj = mock.MagicMock(spec=Path)
-    mock_fname_path_obj.stem = "counters"
-    mock_fname_path_obj.name = "counters.txt"
+    mock_fname_path_obj.stem = "pmc_perf_counters"
+    mock_fname_path_obj.name = "pmc_perf_counters.yaml"
     mock_fname_path_obj.with_suffix.return_value.exists.return_value = False
 
     mock_out_path_obj = mock.Mock(spec=Path)
     mock_out_path_obj.exists.return_value = False
 
+    mock_counter_def_path_obj = mock.Mock(spec=Path)
+    mock_counter_def_path_obj.exists.return_value = False
+
     def path_side_effect(p_arg, *args):
         if isinstance(p_arg, Path):
-            if p_arg.name == "counters.txt":
+            if p_arg.name == "pmc_perf_counters.yaml":
                 return mock_fname_path_obj
             return p_arg
         if isinstance(p_arg, str):
             if p_arg.endswith("/out"):
                 return mock_out_path_obj
-            if p_arg.endswith("counters.txt"):
+            if p_arg.endswith("pmc_perf_counters.yaml"):
                 return mock_fname_path_obj
+            if "counter_def" in p_arg:
+                return mock_counter_def_path_obj
         if (
             p_arg == mock_fname_path_obj
             and args == ()
@@ -1998,9 +1946,9 @@ def test_run_prof_v3_cli_calls_kokkos_trace_processing(tmp_path, monkeypatch):
     CLI: if "--kokkos-trace" in options:
         process_kokkos_trace_output(...)
     """
-    fname_str = str(tmp_path) + "/counters.txt"
-    Path(fname_str).touch()
-    fbase_str = "counters"
+    fname_str = str(tmp_path) + "/pmc_perf_counters.yaml"
+    Path(fname_str).write_text("jobs:\n  - pmc:\n    - C1\n")
+    fbase_str = "pmc_perf_counters"
     workload_dir_str = str(tmp_path)
     (tmp_path / "out" / "pmc_1").mkdir(parents=True, exist_ok=True)
 
@@ -2027,7 +1975,7 @@ def test_run_prof_v3_cli_calls_kokkos_trace_processing(tmp_path, monkeypatch):
 
     monkeypatch.setattr("utils.utils_profile.console_debug", lambda *a, **k: None)
     monkeypatch.setattr("utils.utils_profile.console_warning", lambda *a, **k: None)
-    monkeypatch.setattr("utils.utils_common.parse_text", lambda *a, **k: ["C1"])
+    monkeypatch.setattr("utils.utils_common.parse_pmc_perf", lambda *a, **k: ["C1"])
 
     # Mock csv_ops functions to avoid disk I/O
     mock_rows = [

--- a/projects/rocprofiler-compute/tests/test_utils.py
+++ b/projects/rocprofiler-compute/tests/test_utils.py
@@ -1786,13 +1786,16 @@ def test_run_prof_sdk_creates_new_env_copy(tmp_path, monkeypatch):
     mock_fname_path_obj = mock.MagicMock(spec=Path)
     mock_fname_path_obj.stem = "pmc_perf_counters"
     mock_fname_path_obj.name = "pmc_perf_counters.yaml"
-    mock_fname_path_obj.with_suffix.return_value.exists.return_value = False
+    mock_fname_path_obj.exists.return_value = False
 
     mock_out_path_obj = mock.Mock(spec=Path)
     mock_out_path_obj.exists.return_value = False
 
     mock_counter_def_path_obj = mock.Mock(spec=Path)
     mock_counter_def_path_obj.exists.return_value = False
+    mock_fname_path_obj.parent.__truediv__ = mock.Mock(
+        return_value=mock_counter_def_path_obj
+    )
 
     def path_side_effect(p_arg, *args):
         if isinstance(p_arg, Path):


### PR DESCRIPTION
## Motivation

Align rocprofiler-compute's PMC file format with rocprofv3's expected YAML input to improve compatibility and maintain consistency across the profiling ecosystem.

Lnik to documentation for input pmc file format for rocprofiler-sdk/rocprofv3 https://rocm.docs.amd.com/projects/rocprofiler-sdk/en/latest/how-to/using-rocprofv3.html#counter-collection-using-input-file

## Technical Details

### File Format Migration

- Migrated all PMC counter files from `.txt` to `.yaml` format
- New file naming scheme:
  - `pmc_perf_*.yaml`: PMC counters in YAML format (`jobs: [{pmc: [...]}]`) for rocprofv3 to parse via `parse_yaml()` and set `ROCPROF_COUNTERS` env var
  - `counter_def_*.yaml`: TCC channel counter definitions for rocprofiler-sdk's `ROCPROFILER_METRICS_PATH` (renamed from `pmc_perf_*.yaml` to avoid confusion)

### Implementation Changes

- Removed legacy `gpu:/range:/kernel:` fields from PMC files (already applied via CLI options and environment variables)
- Updated `parse_text()` to `parse_pmc_perf()` for YAML parsing
- Added backward compatibility in `analysis_base.py` for old `.txt` workloads
- Updated all references from `pmc_perf_*.txt` to `pmc_perf_*.yaml`
- Updated tests and profiling mode documentation for new file naming scheme

## JIRA ID

AIPROFCOMP-208

## Test Plan

Verify that:
- All existing PMC-based profiling workflows continue to work with the new YAML format
- rocprofv3 correctly parses the new `pmc_perf_*.yaml` files
- Backward compatibility handles legacy `.txt` workloads without errors
- All test cases pass with updated file references

## Test Result

- [x] PMC YAML files are correctly parsed by rocprofv3
- [x] `parse_pmc_perf()` successfully extracts counter definitions
- [x] Backward compatibility with `.txt` workloads verified
- [x] All test cases updated and passing
- [x] Documentation reflects new file naming scheme

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.