### PR TITLE
[rocr-debug-agent] Adjust timeout comment on test/run-test.py

### DIFF
--- a/projects/rocr-debug-agent/test/run-test.py
+++ b/projects/rocr-debug-agent/test/run-test.py
@@ -501,9 +501,9 @@ def check_test_9():
             if not kernel_started and "Kernel started" in s:
                 kernel_started = True
                 os.kill(p.pid, signal.SIGQUIT)
-                # We give our program 30 secs to start the kernel.
+                # We give our program LOOP_TIMEOUT secs to start the kernel.
                 # Once we know that the kernel is running, we give it
-                # extra 30 seconds to process SIGQUIT.
+                # an extra LOOP_TIMEOUT seconds to process SIGQUIT.
                 deadline = deadline + LOOP_TIMEOUT
 
             if kernel_started:


### PR DESCRIPTION
The timeout was updated to 60 seconds but the comments still mention the old value of 30 seconds.

Fix this by mentioning the variable used instead of an absolute value of seconds.