### PR TITLE
[rocprofiler-systems] Remove selective_region test from TheRock

### DIFF
--- a/projects/rocprofiler-systems/tests/pytest/test_selective_regions.py
+++ b/projects/rocprofiler-systems/tests/pytest/test_selective_regions.py
@@ -14,7 +14,7 @@ from __future__ import annotations
 import pytest
 from conftest import RocprofsysTest
 
-pytestmark = [pytest.mark.gpu, pytest.mark.selective_regions, pytest.mark.ci_enable]
+pytestmark = [pytest.mark.gpu, pytest.mark.selective_regions]
 
 # =============================================================================
 # Fixtures


### PR DESCRIPTION
## Motivation

Tests are failing because of rocprofiler-sdk is logging a warning, which is being treated as an error in CI. 

Will resolve: https://github.com/ROCm/rocm-systems/issues/4607.

## Technical Details

Disable test on TheRock.

## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->
Verify results on TheRock CI. 

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
