### PR TITLE
Add SVM support check before running KFDQMTest.mGPUShareBO

### DIFF
--- a/projects/rocr-runtime/libhsakmt/tests/kfdtest/src/KFDQMTest.cpp
+++ b/projects/rocr-runtime/libhsakmt/tests/kfdtest/src/KFDQMTest.cpp
@@ -2295,15 +2295,27 @@ TEST_F(KFDQMTest, Atomics) {
 TEST_F(KFDQMTest, mGPUShareBO) {
     TEST_START(TESTPROFILE_RUNALL);
 
-    unsigned int src_node = 2;
-    unsigned int dst_node = 1;
+    const std::vector<int> gpuNodes = m_NodeInfo.GetNodesWithGPU();
+    if (gpuNodes.size() < 2) {
+        LOG() << "Skipping test: At least two GPUs are required." << std::endl;
+        return;
+    }
 
+    unsigned int src_node, dst_node;
     if (g_TestDstNodeId != -1 && g_TestNodeId != -1) {
         src_node = g_TestNodeId;
         dst_node = g_TestDstNodeId;
+    } else {
+        src_node = gpuNodes[0];
+        dst_node = gpuNodes[1];
     }
 
     HsaMemoryBuffer shared_addr(PAGE_SIZE, dst_node, true, false, false, false);
+    if (!SVMAPISupported_GPU(src_node) || !SVMAPISupported_GPU(dst_node)) {
+        LOG() << "SVM API is not supported on nodes. Need to map to nodes." << std::endl;
+        unsigned int both_nodes[] = {(unsigned int)src_node, (unsigned int)dst_node};
+        ASSERT_SUCCESS(shared_addr.MapMemToNodes(both_nodes, 2));
+    }
 
     HsaMemoryBuffer srcNodeMem(PAGE_SIZE, src_node);
     HsaMemoryBuffer dstNodeMem(PAGE_SIZE, dst_node);


### PR DESCRIPTION
The test is checking if SVM works on the target system. If the system doesn't support SVM, we need to explicitly map the shared memory to all GPUs that need access to it before running the test.

## Motivation

Test failure observed on MI300X systems without SVM support

## Technical Details

Add SVM check before running the test. If not supported, explicitly map shared memory to all GPUs that need access to that memory.

## JIRA ID

ROCM-20946

## Test Plan

Able to recompile kfdtest and pass on failed system

## Test Result

Abled to recompile kfdtest and passed on failed system

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
