### PR TITLE
rocrtst: Remove call to hsa_amd_memory_unlock

### DIFF
--- a/projects/rocr-runtime/rocrtst/suites/functional/memory_atomics.cc
+++ b/projects/rocr-runtime/rocrtst/suites/functional/memory_atomics.cc
@@ -505,8 +505,6 @@ void MemoryAtomic::MemoryAtomicTest(hsa_agent_t cpuAgent,
     ASSERT_EQ(err, HSA_STATUS_SUCCESS);
   }
   if (access == HSA_AMD_MEMORY_POOL_ACCESS_NEVER_ALLOWED) {
-    err = hsa_amd_memory_unlock(gpuRefData);
-    ASSERT_EQ(err, HSA_STATUS_SUCCESS);
     // Destroy the copy signal
     err = hsa_signal_destroy(copy_signal);
     ASSERT_EQ(err, HSA_STATUS_SUCCESS);


### PR DESCRIPTION
This seems to be some left-over code. We do not call hsa_amd_memory_lock on this pointer, so we should not call hsa_amd_memory_unlock

## Motivation

Triggers an assert when running rocrtst and ROCr is build in debug mode