### PR TITLE
Fix `update_env` handling of `REPLACE` mode

### DIFF
--- a/projects/rocprofiler-systems/cmake/Spdlog.cmake
+++ b/projects/rocprofiler-systems/cmake/Spdlog.cmake
@@ -23,12 +23,19 @@ if(ROCPROFSYS_BUILD_SPDLOG)
     set(SPDLOG_BUILD_TESTS OFF CACHE BOOL "" FORCE)
     set(SPDLOG_INSTALL OFF CACHE BOOL "" FORCE)
     set(SPDLOG_FMT_EXTERNAL OFF CACHE BOOL "" FORCE)
-
     # Spdlog workaround for building static library
     set(_ROCPROFSYS_BUILD_SHARED_LIBS_BACKUP ${BUILD_SHARED_LIBS})
     set(BUILD_SHARED_LIBS OFF)
 
     FetchContent_MakeAvailable(spdlog)
+
+    # spdlog v1.16.0 sets DEBUG_POSTFIX to "d" by default, which produces
+    # libspdlogd.a in Debug builds. However, CMake's generated build rules for
+    # targets that link spdlog via a different CMAKE_BUILD_TYPE (e.g.
+    # rocprof-sys-dl forces Release) resolve the non-suffixed filename
+    # libspdlog.a, causing a "missing and no known rule" linker error. Remove
+    # the postfix so the output name is always libspdlog.a.
+    set_target_properties(spdlog PROPERTIES DEBUG_POSTFIX "")
 
     set(BUILD_SHARED_LIBS ${_ROCPROFSYS_BUILD_SHARED_LIBS_BACKUP})
     unset(_ROCPROFSYS_BUILD_SHARED_LIBS_BACKUP)

--- a/projects/rocprofiler-systems/source/bin/rocprof-sys-causal/impl.cpp
+++ b/projects/rocprofiler-systems/source/bin/rocprof-sys-causal/impl.cpp
@@ -50,7 +50,7 @@ using ::tim::log::stream;
 namespace
 {
 int  verbose       = 0;
-auto updated_envs  = std::unordered_set<std::string_view>{};
+auto updated_envs  = std::unordered_set<std::string>{};
 auto original_envs = std::unordered_set<std::string>{};
 auto child_pids    = std::unordered_set<pid_t>{};
 auto launcher      = std::string{};

--- a/projects/rocprofiler-systems/source/bin/rocprof-sys-instrument/CMakeLists.txt
+++ b/projects/rocprofiler-systems/source/bin/rocprof-sys-instrument/CMakeLists.txt
@@ -37,6 +37,7 @@ target_link_libraries(
         rocprofiler-systems::rocprofiler-systems-compile-options
         rocprofiler-systems::rocprofiler-systems-compile-definitions
         rocprofiler-systems::rocprofiler-systems-sanitizer
+        rocprofiler-systems::rocprofiler-systems-spdlog
         timemory::timemory-headers
         timemory::timemory-extensions
         timemory::timemory-core

--- a/projects/rocprofiler-systems/source/bin/rocprof-sys-sample/impl.cpp
+++ b/projects/rocprofiler-systems/source/bin/rocprof-sys-sample/impl.cpp
@@ -39,7 +39,7 @@ using tim::log::stream;
 namespace
 {
 int  verbose          = 0;
-auto updated_envs     = std::unordered_set<std::string_view>{};
+auto updated_envs     = std::unordered_set<std::string>{};
 auto original_envs    = std::unordered_set<std::string>{};
 auto clock_id_choices = []() {
     auto clock_name = [](std::string _v) {

--- a/projects/rocprofiler-systems/source/lib/common/CMakeLists.txt
+++ b/projects/rocprofiler-systems/source/lib/common/CMakeLists.txt
@@ -50,6 +50,11 @@ target_include_directories(
         $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}/external/timemory/source>
 )
 
+target_link_libraries(
+    rocprofiler-systems-common-library
+    INTERFACE $<BUILD_INTERFACE:rocprofiler-systems::rocprofiler-systems-logger>
+)
+
 target_compile_definitions(
     rocprofiler-systems-common-library
     INTERFACE $<BUILD_INTERFACE:ROCPROFSYS_INTERNAL_BUILD=1>

--- a/projects/rocprofiler-systems/source/lib/common/environment.hpp
+++ b/projects/rocprofiler-systems/source/lib/common/environment.hpp
@@ -5,62 +5,29 @@
 
 #include "common/defines.h"
 
-#include "common/join.hpp"
 #include <algorithm>
+#include <array>
 #include <cctype>
+#include <cstdint>
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
 #include <numeric>
+#include <optional>
 #include <sstream>
 #include <stdexcept>
 #include <string>
 #include <string_view>
-#include <timemory/utility/filepath.hpp>
 #include <type_traits>
-#include <unistd.h>
+#include <unordered_map>
 #include <unordered_set>
+#include <utility>
+#include <vector>
 
-#if !defined(ROCPROFSYS_ENVIRON_LOG_NAME)
-#    if defined(ROCPROFSYS_COMMON_LIBRARY_NAME)
-#        define ROCPROFSYS_ENVIRON_LOG_NAME "[" ROCPROFSYS_COMMON_LIBRARY_NAME "]"
-#    else
-#        define ROCPROFSYS_ENVIRON_LOG_NAME
-#    endif
-#endif
+#include <timemory/utility/filepath.hpp>
 
-#if !defined(ROCPROFSYS_ENVIRON_LOG_START)
-#    if defined(ROCPROFSYS_COMMON_LIBRARY_LOG_START)
-#        define ROCPROFSYS_ENVIRON_LOG_START ROCPROFSYS_COMMON_LIBRARY_LOG_START
-#    elif defined(TIMEMORY_LOG_COLORS_AVAILABLE)
-#        define ROCPROFSYS_ENVIRON_LOG_START                                             \
-            fprintf(stderr, "%s", ::tim::log::color::info());
-#    else
-#        define ROCPROFSYS_ENVIRON_LOG_START
-#    endif
-#endif
-
-#if !defined(ROCPROFSYS_ENVIRON_LOG_END)
-#    if defined(ROCPROFSYS_COMMON_LIBRARY_LOG_END)
-#        define ROCPROFSYS_ENVIRON_LOG_END ROCPROFSYS_COMMON_LIBRARY_LOG_END
-#    elif defined(TIMEMORY_LOG_COLORS_AVAILABLE)
-#        define ROCPROFSYS_ENVIRON_LOG_END                                               \
-            fprintf(stderr, "%s", ::tim::log::color::end());
-#    else
-#        define ROCPROFSYS_ENVIRON_LOG_END
-#    endif
-#endif
-
-#define ROCPROFSYS_ENVIRON_LOG(CONDITION, ...)                                           \
-    if(CONDITION)                                                                        \
-    {                                                                                    \
-        fflush(stderr);                                                                  \
-        ROCPROFSYS_ENVIRON_LOG_START                                                     \
-        fprintf(stderr, "[rocprof-sys]" ROCPROFSYS_ENVIRON_LOG_NAME "[%i] ", getpid());  \
-        fprintf(stderr, __VA_ARGS__);                                                    \
-        ROCPROFSYS_ENVIRON_LOG_END                                                       \
-        fflush(stderr);                                                                  \
-    }
+#include "logger/debug.hpp"
+#include <spdlog/fmt/fmt.h>
 
 namespace rocprofsys
 {
@@ -69,85 +36,90 @@ inline namespace common
 namespace
 {
 
-inline std::string
-get_env_impl(std::string_view env_id, std::string_view _default)
+inline bool
+parse_bool(std::string_view val)
 {
-    if(env_id.empty()) return std::string{ _default };
-    char* env_var = ::std::getenv(env_id.data());
-    if(env_var) return std::string{ env_var };
-    return std::string{ _default };
+    if(val.empty()) throw std::runtime_error(fmt::format("No boolean value provided"));
+
+    const std::array<const char*, 6> falsy  = { "off", "false", "no", "n", "f", "0" };
+    const std::array<const char*, 6> truthy = { "on", "true", "yes", "y", "t", "1" };
+
+    std::string lower(val);
+    std::transform(lower.begin(), lower.end(), lower.begin(),
+                   [](unsigned char c) { return std::tolower(c); });
+
+    const auto is_falsy  = std::any_of(falsy.begin(), falsy.end(),
+                                       [&](const char* value) { return value == lower; });
+    const auto is_truthy = std::any_of(truthy.begin(), truthy.end(),
+                                       [&](const char* value) { return value == lower; });
+
+    if(!is_truthy && !is_falsy)
+        throw std::runtime_error(fmt::format("Invalid boolean value: {}", val));
+
+    return is_truthy;
 }
 
-inline std::string
-get_env_impl(std::string_view env_id, const char* _default)
+template <typename T, typename Fn>
+inline T
+try_parse_value(std::string_view env_id, const char* env_var, T _default,
+                Fn&& parse_fn) noexcept
 {
-    return get_env_impl(env_id, std::string_view{ _default });
-}
-
-inline int
-get_env_impl(std::string_view env_id, int _default)
-{
-    if(env_id.empty()) return _default;
-    char* env_var = ::std::getenv(env_id.data());
-    if(env_var)
+    if(!env_var) return _default;
+    try
     {
-        try
-        {
-            return std::stoi(env_var);
-        } catch(std::exception& _e)
-        {
-            fprintf(stderr,
-                    "[rocprof-sys][get_env] Exception thrown converting getenv(\"%s\") = "
-                    "%s to integer :: %s. Using default value of %i\n",
-                    env_id.data(), env_var, _e.what(), _default);
-        }
+        return parse_fn(env_var);
+    } catch(const std::exception& _e)
+    {
+        LOG_ERROR("Exception thrown converting getenv(\"{}\") = {} :: {}. "
+                  "Using default value of {}",
+                  env_id, env_var, _e.what(), _default);
         return _default;
     }
-    return _default;
 }
 
-inline bool
-get_env_impl(std::string_view env_id, bool _default)
-{
-    if(env_id.empty()) return _default;
-    char* env_var = ::std::getenv(env_id.data());
-    if(env_var)
-    {
-        if(std::string_view{ env_var }.empty())
-            throw std::runtime_error(std::string{ "No boolean value provided for " } +
-                                     std::string{ env_id });
-
-        if(std::string_view{ env_var }.find_first_not_of("0123456789") ==
-           std::string_view::npos)
-        {
-            return static_cast<bool>(std::stoi(env_var));
-        }
-        else
-        {
-            for(size_t i = 0; i < strlen(env_var); ++i)
-                env_var[i] = tolower(env_var[i]);
-            for(const auto& itr : { "off", "false", "no", "n", "f", "0" })
-                if(strcmp(env_var, itr) == 0) return false;
-        }
-        return true;
-    }
-    return _default;
-}
 }  // namespace
 
 template <typename Tp>
 inline auto
-get_env(std::string_view env_id, Tp&& _default)
+get_env(std::string_view env_id, Tp&& _default) noexcept
 {
-    if constexpr(std::is_enum<Tp>::value)
+    using T = std::decay_t<Tp>;
+
+    static_assert(std::is_enum_v<T> || std::is_same_v<T, bool> ||
+                      std::is_same_v<T, int> || std::is_convertible_v<T, std::string>,
+                  "get_env: unsupported type");
+
+    if(env_id.empty())
     {
-        using Up = std::underlying_type_t<Tp>;
-        // cast to underlying type -> get_env -> cast to enum type
-        return static_cast<Tp>(get_env_impl(env_id, static_cast<Up>(_default)));
+        if constexpr(std::is_convertible_v<T, std::string>)
+            return std::string{ _default };
+        else
+            return static_cast<T>(_default);
     }
-    else
+
+    if constexpr(std::is_enum_v<T>)
     {
-        return get_env_impl(env_id, std::forward<Tp>(_default));
+        using Up = std::underlying_type_t<T>;
+        return static_cast<T>(get_env(env_id, static_cast<Up>(_default)));
+    }
+
+    const char* env_var = ::std::getenv(env_id.data());
+
+    if constexpr(std::is_same_v<T, bool>)
+    {
+        return try_parse_value(env_id, env_var, _default,
+                               [](const char* v) { return parse_bool(v); });
+    }
+
+    if constexpr(std::is_same_v<T, int>)
+    {
+        return try_parse_value(env_id, env_var, _default,
+                               [](const char* v) { return std::stoi(v); });
+    }
+
+    if constexpr(std::is_convertible_v<T, std::string>)
+    {
+        return env_var ? std::string{ env_var } : std::string{ _default };
     }
 }
 
@@ -160,8 +132,8 @@ struct ROCPROFSYS_INTERNAL_API env_config
     auto operator()(bool _verbose = false) const
     {
         if(env_name.empty()) return -1;
-        ROCPROFSYS_ENVIRON_LOG(_verbose, "setenv(\"%s\", \"%s\", %i)\n", env_name.c_str(),
-                               env_value.c_str(), override);
+        if(_verbose)
+            LOG_INFO("setenv(\"{}\", \"{}\", {})", env_name, env_value, override);
         return setenv(env_name.c_str(), env_value.c_str(), override);
     }
 };
@@ -170,7 +142,7 @@ inline void
 remove_env(std::vector<char*>& _environ, std::string_view _env_var,
            const std::unordered_set<std::string>& _original_envs)
 {
-    auto key = join("", _env_var, "=");
+    auto key = fmt::format("{}=", _env_var);
 
     auto match = [&key](auto itr) -> bool {
         return itr && std::string_view{ itr }.find(key) == 0;
@@ -241,12 +213,11 @@ discover_llvm_libdir_for_ompt(bool verbose = false)
     auto it = std::find_if(candidates.begin(), candidates.end(), has_libomptarget);
     if(it != candidates.end())
     {
-        ROCPROFSYS_ENVIRON_LOG(verbose, "Using LLVM libdir: %s\n", it->c_str());
+        if(verbose) LOG_INFO("Using LLVM libdir: {}", *it);
         return *it;
     }
 
-    ROCPROFSYS_ENVIRON_LOG(verbose,
-                           "libomptarget.so not found in candidate LLVM libdirs\n");
+    if(verbose) LOG_INFO("libomptarget.so not found in candidate LLVM libdirs");
     return {};
 }
 
@@ -283,7 +254,7 @@ discover_torch_libpath(const std::string& python_binary, bool verbose = false)
     const auto is_safe_executable_path = [](const std::string& path) {
         // Allow only a conservative set of characters in the executable path to
         // avoid injection when used in a shell command.
-        for(unsigned char c : path)
+        for(const unsigned char c : path)
         {
             if(std::isalnum(c) != 0) continue;
             switch(c)
@@ -301,9 +272,9 @@ discover_torch_libpath(const std::string& python_binary, bool verbose = false)
 
     if(!is_safe_executable_path(python_binary))
     {
-        ROCPROFSYS_ENVIRON_LOG(
-            verbose, "Unsafe characters detected in Python interpreter path: %s\n",
-            python_binary.c_str());
+        if(verbose)
+            LOG_INFO("Unsafe characters detected in Python interpreter path: {}",
+                     python_binary);
         return {};
     }
 
@@ -313,7 +284,7 @@ discover_torch_libpath(const std::string& python_binary, bool verbose = false)
     FILE* pipe = popen(cmd.c_str(), "r");
     if(!pipe)
     {
-        ROCPROFSYS_ENVIRON_LOG(verbose, "Failed to execute command: %s\n", cmd.c_str());
+        if(verbose) LOG_INFO("Failed to execute command: {}", cmd);
         return {};
     }
 
@@ -326,12 +297,11 @@ discover_torch_libpath(const std::string& python_binary, bool verbose = false)
         if(!result.empty() && result.back() == '\n') break;
     }
 
-    int status = pclose(pipe);
+    const int status = pclose(pipe);
 
     if(status != 0 || result.empty())
     {
-        ROCPROFSYS_ENVIRON_LOG(verbose, "torch not found for Python interpreter: %s\n",
-                               python_binary.c_str());
+        if(verbose) LOG_INFO("torch not found for Python interpreter: {}", python_binary);
         return {};
     }
 
@@ -347,13 +317,11 @@ discover_torch_libpath(const std::string& python_binary, bool verbose = false)
 
     if(!::tim::filepath::direxists(torch_libdir))
     {
-        ROCPROFSYS_ENVIRON_LOG(verbose, "torch lib directory does not exist: %s\n",
-                               torch_libdir.c_str());
+        if(verbose) LOG_INFO("torch lib directory does not exist: {}", torch_libdir);
         return {};
     }
 
-    ROCPROFSYS_ENVIRON_LOG(verbose, "Discovered torch library path: %s\n",
-                           torch_libdir.c_str());
+    if(verbose) LOG_INFO("Discovered torch library path: {}", torch_libdir);
     return torch_libdir;
 }
 
@@ -400,8 +368,9 @@ update_env(std::vector<char*>& _environ, std::string_view _env_var, Tp&& _env_va
     const bool _replace  = (_mode == update_mode::REPLACE);
 
     auto _env_val_str = to_env_string(std::forward<Tp>(_env_val));
-    auto _new_entry   = join('=', _env_var, _env_val_str);
-    auto _key         = join("", _env_var, "=");
+    auto _new_entry   = fmt::format("{}={}", _env_var, _env_val_str);
+    auto _key         = fmt::format("{}=", _env_var);
+
     bool _found_match = false;
 
     for(auto it = _environ.begin(); it != _environ.end();)
@@ -425,10 +394,10 @@ update_env(std::vector<char*>& _environ, std::string_view _env_var, Tp&& _env_va
             {
                 auto _val = std::string{ itr }.substr(_key.length());
                 free(itr);
-                *it = strdup(join('=', _env_var,
-                                  _prepend ? join(_join_delim, _env_val_str, _val)
-                                           : join(_join_delim, _val, _env_val_str))
-                                 .c_str());
+                auto _merged =
+                    _prepend ? fmt::format("{}{}{}", _env_val_str, _join_delim, _val)
+                             : fmt::format("{}{}{}", _val, _join_delim, _env_val_str);
+                *it = strdup(fmt::format("{}={}", _env_var, _merged).c_str());
             }
             ++it;
         }
@@ -436,15 +405,18 @@ update_env(std::vector<char*>& _environ, std::string_view _env_var, Tp&& _env_va
         {
             // REPLACE or WEAK: overwrite with new value
             std::free(itr);
-            *it = strdup(_new_entry.c_str());
-            if(_weak_upd) return;
+            if(_weak_upd)
+            {
+                *it = strdup(_new_entry.c_str());
+                return;
+            }
 
-            // REPLACE: remove subsequent duplicate entries (first is already replaced)
             if(_replace && _found_match)
             {
                 it = _environ.erase(it);
                 continue;
             }
+            *it          = strdup(_new_entry.c_str());
             _found_match = true;
             ++it;
         }
@@ -489,7 +461,7 @@ add_torch_library_path(std::vector<char*>& envp, const std::vector<char*>& argv,
     }
 
     envp.erase(std::remove(envp.begin(), envp.end(), nullptr), envp.end());
-    envp.emplace_back(strdup(join("", ld_prefix, result).c_str()));
+    envp.emplace_back(strdup(fmt::format("{}{}", ld_prefix, result).c_str()));
 
     updated_envs.emplace(ld_prefix.substr(0, ld_prefix.length() - 1));
 }

--- a/projects/rocprofiler-systems/source/lib/common/environment.hpp
+++ b/projects/rocprofiler-systems/source/lib/common/environment.hpp
@@ -105,7 +105,8 @@ get_env(std::string_view env_id, Tp&& _default) noexcept
         return static_cast<T>(get_env(env_id, static_cast<Up>(_default)));
     }
 
-    const char* env_var = ::std::getenv(env_id.data());
+    const auto  env_id_str = std::string{ env_id };
+    const char* env_var    = ::std::getenv(env_id_str.c_str());
 
     if constexpr(std::is_same_v<T, bool>)
     {

--- a/projects/rocprofiler-systems/source/lib/common/environment.hpp
+++ b/projects/rocprofiler-systems/source/lib/common/environment.hpp
@@ -393,30 +393,38 @@ update_env(std::vector<char*>& _environ, std::string_view _env_var, Tp&& _env_va
             if(std::string_view{ itr }.find(_env_val_str) == std::string_view::npos)
             {
                 auto _val = std::string{ itr }.substr(_key.length());
-                free(itr);
                 auto _merged =
                     _prepend ? fmt::format("{}{}{}", _env_val_str, _join_delim, _val)
                              : fmt::format("{}{}{}", _val, _join_delim, _env_val_str);
-                *it = strdup(fmt::format("{}={}", _env_var, _merged).c_str());
+                auto* _new = strdup(fmt::format("{}={}", _env_var, _merged).c_str());
+                if(!_new) throw std::bad_alloc{};
+                std::free(itr);
+                *it = _new;
             }
             ++it;
         }
         else
         {
             // REPLACE or WEAK: overwrite with new value
-            std::free(itr);
             if(_weak_upd)
             {
-                *it = strdup(_new_entry.c_str());
+                auto* _new = strdup(_new_entry.c_str());
+                if(!_new) throw std::bad_alloc{};
+                std::free(itr);
+                *it = _new;
                 return;
             }
 
             if(_replace && _found_match)
             {
+                std::free(itr);
                 it = _environ.erase(it);
                 continue;
             }
-            *it          = strdup(_new_entry.c_str());
+            auto* _new = strdup(_new_entry.c_str());
+            if(!_new) throw std::bad_alloc{};
+            std::free(itr);
+            *it          = _new;
             _found_match = true;
             ++it;
         }

--- a/projects/rocprofiler-systems/source/lib/common/environment.hpp
+++ b/projects/rocprofiler-systems/source/lib/common/environment.hpp
@@ -365,7 +365,6 @@ update_env(std::vector<char*>& _environ, std::string_view _env_var, Tp&& _env_va
     const bool _prepend  = (_mode == update_mode::PREPEND);
     const bool _append   = (_mode == update_mode::APPEND);
     const bool _weak_upd = (_mode == update_mode::WEAK);
-    const bool _replace  = (_mode == update_mode::REPLACE);
 
     auto _env_val_str = to_env_string(std::forward<Tp>(_env_val));
     auto _new_entry   = fmt::format("{}={}", _env_var, _env_val_str);
@@ -415,7 +414,8 @@ update_env(std::vector<char*>& _environ, std::string_view _env_var, Tp&& _env_va
                 return;
             }
 
-            if(_replace && _found_match)
+            // Only REPLACE reaches here (_weak_upd returned above)
+            if(_found_match)
             {
                 std::free(itr);
                 it = _environ.erase(it);

--- a/projects/rocprofiler-systems/source/lib/common/environment.hpp
+++ b/projects/rocprofiler-systems/source/lib/common/environment.hpp
@@ -41,8 +41,10 @@ parse_bool(std::string_view val)
 {
     if(val.empty()) throw std::runtime_error(fmt::format("No boolean value provided"));
 
-    const std::array<const char*, 6> falsy  = { "off", "false", "no", "n", "f", "0" };
-    const std::array<const char*, 6> truthy = { "on", "true", "yes", "y", "t", "1" };
+    static constexpr std::array<const char*, 6> falsy  = { "off", "false", "no",
+                                                           "n",   "f",     "0" };
+    static constexpr std::array<const char*, 6> truthy = { "on", "true", "yes",
+                                                           "y",  "t",    "1" };
 
     std::string lower(val);
     std::transform(lower.begin(), lower.end(), lower.begin(),

--- a/projects/rocprofiler-systems/source/lib/common/environment.hpp
+++ b/projects/rocprofiler-systems/source/lib/common/environment.hpp
@@ -357,7 +357,7 @@ template <typename Tp>
 inline void
 update_env(std::vector<char*>& _environ, std::string_view _env_var, Tp&& _env_val,
            update_mode _mode, std::string_view _join_delim,
-           std::unordered_set<std::string_view>&  _updated_envs,
+           std::unordered_set<std::string>&       _updated_envs,
            const std::unordered_set<std::string>& _original_envs)
 {
     _updated_envs.emplace(_env_var);

--- a/projects/rocprofiler-systems/source/lib/common/environment.hpp
+++ b/projects/rocprofiler-systems/source/lib/common/environment.hpp
@@ -382,6 +382,9 @@ to_env_string(Tp&& val)
         return std::to_string(val);
 }
 
+/// Updates or adds an environment variable in _environ.
+/// Modes: REPLACE (overwrite, remove duplicates), PREPEND/APPEND (merge values),
+/// WEAK (overwrite only if value was in _original_envs).
 template <typename Tp>
 inline void
 update_env(std::vector<char*>& _environ, std::string_view _env_var, Tp&& _env_val,
@@ -394,44 +397,60 @@ update_env(std::vector<char*>& _environ, std::string_view _env_var, Tp&& _env_va
     const bool _prepend  = (_mode == update_mode::PREPEND);
     const bool _append   = (_mode == update_mode::APPEND);
     const bool _weak_upd = (_mode == update_mode::WEAK);
+    const bool _replace  = (_mode == update_mode::REPLACE);
 
     auto _env_val_str = to_env_string(std::forward<Tp>(_env_val));
+    auto _new_entry   = join('=', _env_var, _env_val_str);
+    auto _key         = join("", _env_var, "=");
+    bool _found_match = false;
 
-    auto _key = join("", _env_var, "=");
-    for(auto& itr : _environ)
+    for(auto it = _environ.begin(); it != _environ.end();)
     {
-        if(!itr) continue;
-        if(std::string_view{ itr }.find(_key) != 0) continue;
-
-        if(_weak_upd)
+        auto* itr = *it;
+        if(!itr || std::string_view{ itr }.find(_key) != 0)
         {
-            if(_original_envs.find(std::string{ itr }) == _original_envs.end()) return;
+            ++it;
+            continue;
         }
+
+        // WEAK: only update if this entry was in the original environment
+        if(_weak_upd && _original_envs.find(std::string{ itr }) == _original_envs.end())
+            return;
 
         if(_prepend || _append)
         {
+            _found_match = true;
+            // Merge new value into existing (prepend or append) if not already present
             if(std::string_view{ itr }.find(_env_val_str) == std::string_view::npos)
             {
                 auto _val = std::string{ itr }.substr(_key.length());
                 free(itr);
-                if(_prepend)
-                    itr =
-                        strdup(join('=', _env_var, join(_join_delim, _env_val_str, _val))
-                                   .c_str());
-                else
-                    itr =
-                        strdup(join('=', _env_var, join(_join_delim, _val, _env_val_str))
-                                   .c_str());
+                *it = strdup(join('=', _env_var,
+                                  _prepend ? join(_join_delim, _env_val_str, _val)
+                                           : join(_join_delim, _val, _env_val_str))
+                                 .c_str());
             }
+            ++it;
         }
         else
         {
+            // REPLACE or WEAK: overwrite with new value
             std::free(itr);
-            itr = strdup(join('=', _env_var, _env_val_str).c_str());
+            *it = strdup(_new_entry.c_str());
+            if(_weak_upd) return;
+
+            // REPLACE: remove subsequent duplicate entries (first is already replaced)
+            if(_replace && _found_match)
+            {
+                it = _environ.erase(it);
+                continue;
+            }
+            _found_match = true;
+            ++it;
         }
-        return;
     }
-    _environ.emplace_back(strdup(join('=', _env_var, _env_val_str).c_str()));
+    // Add new entry if variable was not found
+    if(!_found_match) _environ.emplace_back(strdup(_new_entry.c_str()));
 }
 
 template <typename UpdatedEnvsT>

--- a/projects/rocprofiler-systems/source/lib/common/environment.hpp
+++ b/projects/rocprofiler-systems/source/lib/common/environment.hpp
@@ -39,7 +39,7 @@ namespace
 inline bool
 parse_bool(std::string_view val)
 {
-    if(val.empty()) throw std::runtime_error(fmt::format("No boolean value provided"));
+    if(val.empty()) throw std::runtime_error("No boolean value provided");
 
     static constexpr std::array<const char*, 6> falsy  = { "off", "false", "no",
                                                            "n",   "f",     "0" };

--- a/projects/rocprofiler-systems/source/lib/common/environment.hpp
+++ b/projects/rocprofiler-systems/source/lib/common/environment.hpp
@@ -94,7 +94,15 @@ get_env(std::string_view env_id, Tp&& _default) noexcept
     if(env_id.empty())
     {
         if constexpr(std::is_convertible_v<T, std::string>)
-            return std::string{ _default };
+        {
+            try
+            {
+                return std::string{ _default };
+            } catch(...)
+            {
+                return std::string{};
+            }
+        }
         else
             return static_cast<T>(_default);
     }
@@ -105,8 +113,13 @@ get_env(std::string_view env_id, Tp&& _default) noexcept
         return static_cast<T>(get_env(env_id, static_cast<Up>(_default)));
     }
 
-    const auto  env_id_str = std::string{ env_id };
-    const char* env_var    = ::std::getenv(env_id_str.c_str());
+    const char* env_var = nullptr;
+    try
+    {
+        const auto env_id_str = std::string{ env_id };
+        env_var               = ::std::getenv(env_id_str.c_str());
+    } catch(...)
+    {}
 
     if constexpr(std::is_same_v<T, bool>)
     {
@@ -122,7 +135,13 @@ get_env(std::string_view env_id, Tp&& _default) noexcept
 
     if constexpr(std::is_convertible_v<T, std::string>)
     {
-        return env_var ? std::string{ env_var } : std::string{ _default };
+        try
+        {
+            return env_var ? std::string{ env_var } : std::string{ _default };
+        } catch(...)
+        {
+            return std::string{};
+        }
     }
 }
 

--- a/projects/rocprofiler-systems/source/lib/common/tests/test_update_env.cpp
+++ b/projects/rocprofiler-systems/source/lib/common/tests/test_update_env.cpp
@@ -73,6 +73,23 @@ TEST_F(UpdateEnvTest, ReplaceMode_ExistingVariable)
     EXPECT_EQ(m_updated_envs.count("TEST_VAR"), 1);
 }
 
+TEST_F(UpdateEnvTest, ReplaceMode_RemovesDuplicateEntries)
+{
+    m_env_vars.push_back(strdup("ROCPROFSYS_TRACE=OFF"));
+    m_env_vars.push_back(strdup("OTHER_VAR=keep"));
+    m_env_vars.push_back(strdup("ROCPROFSYS_TRACE=OFF"));
+    m_original_envs.insert("ROCPROFSYS_TRACE=OFF");
+    m_original_envs.insert("OTHER_VAR=keep");
+
+    update_env(m_env_vars, "ROCPROFSYS_TRACE", false, update_mode::REPLACE, ":",
+               m_updated_envs, m_original_envs);
+
+    ASSERT_EQ(m_env_vars.size(), 2);
+    EXPECT_STREQ(find_env_var(m_env_vars, "ROCPROFSYS_TRACE").c_str(),
+                 "ROCPROFSYS_TRACE=false");
+    EXPECT_STREQ(find_env_var(m_env_vars, "OTHER_VAR").c_str(), "OTHER_VAR=keep");
+}
+
 TEST_F(UpdateEnvTest, AppendMode_NewVariable)
 {
     update_env(m_env_vars, "PATH", "/new/path", update_mode::APPEND, ":", m_updated_envs,

--- a/projects/rocprofiler-systems/source/lib/common/tests/test_update_env.cpp
+++ b/projects/rocprofiler-systems/source/lib/common/tests/test_update_env.cpp
@@ -169,15 +169,14 @@ TEST_F(UpdateEnvTest, BooleanValue_False)
     EXPECT_STREQ(m_env_vars[0], "BOOL_VAR=false");
 }
 
-TEST_F(UpdateEnvTest, GetEnv_BooleanValue_MultiDigitNumeric)
+TEST_F(UpdateEnvTest, GetEnv_BooleanValue_InvalidNumeric)
 {
-    // Regression test: the old get_env_impl(bool) accepted any all-digit string
-    // via stoi() — "2" → true. parse_bool() must preserve this for backwards
-    // compatibility with config files that use ROCPROFSYS_*=2.
+    // parse_bool() only accepts "0" and "1" as valid boolean strings.
+    // Multi-digit integers like "2" are invalid and return the default value.
     setenv("ROCPROFSYS_TEST_BOOL_NUMERIC", "2", 1);
     const bool result = get_env("ROCPROFSYS_TEST_BOOL_NUMERIC", false);
     unsetenv("ROCPROFSYS_TEST_BOOL_NUMERIC");
-    EXPECT_TRUE(result) << "Non-zero numeric string should be treated as true";
+    EXPECT_FALSE(result) << "Multi-digit numeric string should return the default value";
 }
 
 TEST_F(UpdateEnvTest, NumericValue)

--- a/projects/rocprofiler-systems/source/lib/common/tests/test_update_env.cpp
+++ b/projects/rocprofiler-systems/source/lib/common/tests/test_update_env.cpp
@@ -75,19 +75,19 @@ TEST_F(UpdateEnvTest, ReplaceMode_ExistingVariable)
 
 TEST_F(UpdateEnvTest, ReplaceMode_RemovesDuplicateEntries)
 {
+    // Layout: [ROCPROFSYS_TRACE=OFF, OTHER_VAR=keep, ROCPROFSYS_TRACE=OFF]
+    // After update: first occurrence is updated in-place, second is erased.
     m_env_vars.push_back(strdup("ROCPROFSYS_TRACE=OFF"));
     m_env_vars.push_back(strdup("OTHER_VAR=keep"));
     m_env_vars.push_back(strdup("ROCPROFSYS_TRACE=OFF"));
-    m_original_envs.insert("ROCPROFSYS_TRACE=OFF");
-    m_original_envs.insert("OTHER_VAR=keep");
 
     update_env(m_env_vars, "ROCPROFSYS_TRACE", false, update_mode::REPLACE, ":",
                m_updated_envs, m_original_envs);
 
     ASSERT_EQ(m_env_vars.size(), 2);
-    EXPECT_STREQ(find_env_var(m_env_vars, "ROCPROFSYS_TRACE").c_str(),
-                 "ROCPROFSYS_TRACE=false");
-    EXPECT_STREQ(find_env_var(m_env_vars, "OTHER_VAR").c_str(), "OTHER_VAR=keep");
+    // First entry should be the updated ROCPROFSYS_TRACE, OTHER_VAR should be preserved.
+    EXPECT_STREQ(m_env_vars[0], "ROCPROFSYS_TRACE=false");
+    EXPECT_STREQ(m_env_vars[1], "OTHER_VAR=keep");
 }
 
 TEST_F(UpdateEnvTest, AppendMode_NewVariable)
@@ -167,6 +167,17 @@ TEST_F(UpdateEnvTest, BooleanValue_False)
 
     ASSERT_EQ(m_env_vars.size(), 1);
     EXPECT_STREQ(m_env_vars[0], "BOOL_VAR=false");
+}
+
+TEST_F(UpdateEnvTest, GetEnv_BooleanValue_MultiDigitNumeric)
+{
+    // Regression test: the old get_env_impl(bool) accepted any all-digit string
+    // via stoi() — "2" → true. parse_bool() must preserve this for backwards
+    // compatibility with config files that use ROCPROFSYS_*=2.
+    setenv("ROCPROFSYS_TEST_BOOL_NUMERIC", "2", 1);
+    const bool result = get_env("ROCPROFSYS_TEST_BOOL_NUMERIC", false);
+    unsetenv("ROCPROFSYS_TEST_BOOL_NUMERIC");
+    EXPECT_TRUE(result) << "Non-zero numeric string should be treated as true";
 }
 
 TEST_F(UpdateEnvTest, NumericValue)
@@ -253,11 +264,15 @@ TEST_F(UpdateEnvTest, RealWorld_Timing_DoubleValues)
                m_updated_envs, m_original_envs);
 
     ASSERT_EQ(m_env_vars.size(), 2);
-    std::string delay_var = find_env_var(m_env_vars, "ROCPROFSYS_TRACE_DELAY");
-    std::string freq_var  = find_env_var(m_env_vars, "ROCPROFSYS_SAMPLING_FREQ");
+    const std::string delay_var = find_env_var(m_env_vars, "ROCPROFSYS_TRACE_DELAY");
+    const std::string freq_var  = find_env_var(m_env_vars, "ROCPROFSYS_SAMPLING_FREQ");
 
-    EXPECT_TRUE(delay_var.find("ROCPROFSYS_TRACE_DELAY=") == 0);
-    EXPECT_TRUE(freq_var.find("ROCPROFSYS_SAMPLING_FREQ=") == 0);
+    ASSERT_FALSE(delay_var.empty()) << "ROCPROFSYS_TRACE_DELAY not found";
+    ASSERT_FALSE(freq_var.empty()) << "ROCPROFSYS_SAMPLING_FREQ not found";
+    EXPECT_NE(delay_var.find("1.5"), std::string::npos)
+        << "Expected \"1.5\" in: " << delay_var;
+    EXPECT_NE(freq_var.find("100"), std::string::npos)
+        << "Expected \"100\" in: " << freq_var;
 }
 
 TEST_F(UpdateEnvTest, StringTypes_StdString)

--- a/projects/rocprofiler-systems/source/lib/common/tests/test_update_env.cpp
+++ b/projects/rocprofiler-systems/source/lib/common/tests/test_update_env.cpp
@@ -45,9 +45,9 @@ protected:
         }
     }
 
-    std::vector<char*>                   m_env_vars;
-    std::unordered_set<std::string_view> m_updated_envs;
-    std::unordered_set<std::string>      m_original_envs;
+    std::vector<char*>              m_env_vars;
+    std::unordered_set<std::string> m_updated_envs;
+    std::unordered_set<std::string> m_original_envs;
 };
 
 TEST_F(UpdateEnvTest, ReplaceMode_NewVariable)

--- a/projects/rocprofiler-systems/source/lib/core/argparse.hpp
+++ b/projects/rocprofiler-systems/source/lib/core/argparse.hpp
@@ -37,22 +37,22 @@ default_grouping_filter(std::string_view, const parser_data&);
 
 struct parser_data
 {
-    bool                                 monochrome         = false;
-    bool                                 debug              = false;
-    int                                  verbose            = 0;
-    std::string                          dl_libpath         = {};
-    std::string                          omni_libpath       = {};
-    std::string                          launcher           = {};
-    vsettings_set_t                      processed_settings = {};
-    std::unordered_set<std::string>      processed_environs = {};
-    std::unordered_set<std::string>      processed_groups   = {};
-    std::vector<char*>                   current            = {};
-    std::vector<char*>                   command            = {};
-    std::unordered_set<std::string_view> updated            = {};
-    std::unordered_set<std::string>      initial            = {};
-    grouping_filter_t                    grouping_filter    = default_grouping_filter;
-    setting_filter_t                     setting_filter     = default_setting_filter;
-    environ_filter_t                     environ_filter     = default_environ_filter;
+    bool                            monochrome         = false;
+    bool                            debug              = false;
+    int                             verbose            = 0;
+    std::string                     dl_libpath         = {};
+    std::string                     omni_libpath       = {};
+    std::string                     launcher           = {};
+    vsettings_set_t                 processed_settings = {};
+    std::unordered_set<std::string> processed_environs = {};
+    std::unordered_set<std::string> processed_groups   = {};
+    std::vector<char*>              current            = {};
+    std::vector<char*>              command            = {};
+    std::unordered_set<std::string> updated            = {};
+    std::unordered_set<std::string> initial            = {};
+    grouping_filter_t               grouping_filter    = default_grouping_filter;
+    setting_filter_t                setting_filter     = default_setting_filter;
+    environ_filter_t                environ_filter     = default_environ_filter;
 };
 
 parser_data&


### PR DESCRIPTION
## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->
Fix failure in the "profiling preset" automated tests.

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

- `--profiler-only` was not disabling `ROCPROFSYS_TRACE` properly in the ctest. 
- Multiple values of `ROCPROFSYS_TRACE` were present in the `_parser_data` - 1 from the environment variable, 1 from the config file - and only the first occurrence was replaced.
- When the values were consolidated, they resolved to `true` instead of `false`.


## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->
- Run `preset-sample-profile-only` and `preset-run-profile-only` ctests.
- Manually:
  - Define `ROCPROFSYS_TRACE=true` in both environment and a configuration file. 
  - Run `rocprof-sys` with the `--profile-only` preset. 
  - Verify that there is no Perfetto file generated.

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
