### PR TITLE
[rocprofiler-compute] support rocm7.0.x so files

### DIFF
--- a/projects/rocprofiler-compute/src/rocprof_compute_soc/soc_base.py
+++ b/projects/rocprofiler-compute/src/rocprof_compute_soc/soc_base.py
@@ -433,12 +433,23 @@ class OmniSoC_Base:
             except ImportError:
                 console_error("Failed to import rocprofiler-sdk avail module.")
 
-        avail.loadLibrary.libname = resolve_rocm_library_path(
-            str(
-                Path(args.rocprofiler_sdk_tool_path).parent
-                / "librocprofv3-list-avail.so"
-            )
+        # librocprofv3-list-avail.so location varies by ROCm version:
+        #   ROCm >= 7.1: <rocm_path>/lib/rocprofiler-sdk/
+        #   ROCm 7.0.x:  <rocm_path>/libexec/rocprofiler-sdk/
+        avail_lib_name = "librocprofv3-list-avail.so"
+        avail_lib_path = resolve_rocm_library_path(
+            str(Path(args.rocprofiler_sdk_tool_path).parent / avail_lib_name)
         )
+        if not Path(avail_lib_path).exists():
+            avail_lib_path = resolve_rocm_library_path(
+                str(
+                    Path(args.rocprofiler_sdk_tool_path).parents[2]
+                    / "libexec"
+                    / "rocprofiler-sdk"
+                    / avail_lib_name
+                )
+            )
+        avail.loadLibrary.libname = avail_lib_path
         counters = avail.get_counters()
         rocprof_counters = {
             counter.name


### PR DESCRIPTION
## Motivation

Support the latest rocprof-compute features on older ROCm versions such as 7.0.2

## Technical Details

Supports `.so` file detection in older paths.

## JIRA ID

AIPROFCOMP-499

## Test Plan

latest rocprof-compute runs successfully with ROCm 7.0.2

## Test Result

- [x] latest rocprof-compute runs successfully with ROCm 7.0.2

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
