### PR TITLE
hip-tests: Update test names to fix errors when running without YAML …

### DIFF
--- a/projects/hip-tests/catch/unit/cooperativeGrps/thread_block_tile.cc
+++ b/projects/hip-tests/catch/unit/cooperativeGrps/thread_block_tile.cc
@@ -586,7 +586,7 @@ void testReduceForTileSize()
 }
 
 
-TEMPLATE_TEST_CASE(Unit_Thread_Block_Tile_Reduce_Basic, int)
+HIP_TEMPLATE_TEST_CASE(Unit_Thread_Block_Tile_Reduce_Basic, int)
 {
   unsigned int wavefrontSize = getWarpSize();
 
@@ -613,7 +613,7 @@ void __global__ partialSum(int* result)
   }
 }
 
-TEST_CASE(Unit_Thread_Block_Tile_Reduce_Non_Participating_Threads)
+HIP_TEST_CASE(Unit_Thread_Block_Tile_Reduce_Non_Participating_Threads)
 {
   LinearAllocGuard<int> h_result(LinearAllocs::malloc, sizeof(int));
   LinearAllocGuard<int> d_result(LinearAllocs::hipMalloc, sizeof(int));
@@ -814,7 +814,7 @@ void runReduceRandomForOps(const std::tuple<Op, Ops...>)
 
 // for all the tile sizes and all input types, using random input values, calculates the reduce()
 // values. Additionally, randomly make some threads not participate
-TEMPLATE_TEST_CASE(Unit_Thread_Block_Tile_Reduce_Random_arithmetic, int, unsigned int, long long,
+HIP_TEMPLATE_TEST_CASE(Unit_Thread_Block_Tile_Reduce_Random_arithmetic, int, unsigned int, long long,
                    unsigned long long, float, half, double)
 {
   std::tuple<cooperative_groups::plus<TestType>,
@@ -828,7 +828,7 @@ TEMPLATE_TEST_CASE(Unit_Thread_Block_Tile_Reduce_Random_arithmetic, int, unsigne
   }
 }
 
-TEMPLATE_TEST_CASE(Unit_Thread_Block_Tile_Reduce_Random_boolean, int, unsigned int, long long,
+HIP_TEMPLATE_TEST_CASE(Unit_Thread_Block_Tile_Reduce_Random_boolean, int, unsigned int, long long,
                    unsigned long long)
 {
   std::tuple<cooperative_groups::bit_and<TestType>,
@@ -843,7 +843,7 @@ TEMPLATE_TEST_CASE(Unit_Thread_Block_Tile_Reduce_Random_boolean, int, unsigned i
 }
 
 // passes a custom operator to cooperative_groups::reduce()
-TEST_CASE(Unit_Thread_Block_Tile_Reduce_Custom_Op)
+HIP_TEST_CASE(Unit_Thread_Block_Tile_Reduce_Custom_Op)
 {
   if (getWarpSize() == 32) {
     runReduceRandomForType<false, MaxOfAbsolute<int>, int, 32>();
@@ -882,7 +882,7 @@ void __global__ maxMagnitude(Vector* result)
 }
 
 // tests that we can pass trivially copyable structs as values to reduce
-TEST_CASE(Unit_Thread_Block_Tile_Reduce_Trivially_Copyable_Parameters)
+HIP_TEST_CASE(Unit_Thread_Block_Tile_Reduce_Trivially_Copyable_Parameters)
 {
   LinearAllocGuard<Vector> h_result(LinearAllocs::malloc, sizeof(Vector));
   LinearAllocGuard<Vector> d_result(LinearAllocs::hipMalloc, sizeof(Vector));
@@ -989,7 +989,7 @@ void testReduceSizes()
 
 // we allow any reduction size of T of up to 32 bytes; this tests that reduction works with user-defined
 // types in that range; including non-powers of two
-TEST_CASE(Unit_Thread_Block_Tile_Reduce_All_Parameter_Sizes)
+HIP_TEST_CASE(Unit_Thread_Block_Tile_Reduce_All_Parameter_Sizes)
 {
   SECTION("sum") {
     testReduceSizes<32, Sum>();
@@ -1025,7 +1025,7 @@ __global__ void sumPoints(Point* result)
 }
 
 // using a standard functor in the cooperative_groups namespace with a type that is not primitive
-TEST_CASE(Unit_Thread_Block_Tile_Reduce_Standard_Op_Custom_Type)
+HIP_TEST_CASE(Unit_Thread_Block_Tile_Reduce_Standard_Op_Custom_Type)
 {
   LinearAllocGuard<Point> h_result(LinearAllocs::malloc, sizeof(Point) * 32);
   LinearAllocGuard<Point> d_result(LinearAllocs::hipMalloc, sizeof(Point) * 32);
@@ -1048,7 +1048,7 @@ TEST_CASE(Unit_Thread_Block_Tile_Reduce_Standard_Op_Custom_Type)
   }
 }
 
-TEMPLATE_TEST_CASE(Unit_Thread_Block_Coalesced_Reduce_arithmetic, int, unsigned int, long long,
+HIP_TEMPLATE_TEST_CASE(Unit_Thread_Block_Coalesced_Reduce_arithmetic, int, unsigned int, long long,
                    unsigned long long, float, half, double)
 {
   std::tuple<cooperative_groups::plus<TestType>,
@@ -1063,7 +1063,7 @@ TEMPLATE_TEST_CASE(Unit_Thread_Block_Coalesced_Reduce_arithmetic, int, unsigned 
 }
 
 
-TEMPLATE_TEST_CASE(Unit_Thread_Block_Coalesced_Reduce_boolean, int, unsigned int, long long, unsigned long long)
+HIP_TEMPLATE_TEST_CASE(Unit_Thread_Block_Coalesced_Reduce_boolean, int, unsigned int, long long, unsigned long long)
 {
   std::tuple<cooperative_groups::bit_and<TestType>,
              cooperative_groups::bit_or<TestType>,

--- a/projects/hip-tests/catch/unit/memory/hipMallocFromPoolAsync.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMallocFromPoolAsync.cc
@@ -815,11 +815,11 @@ static void runMThreadReleaseThresholdTest(enum eTestValue testtype) {
  * ------------------------
  *    - HIP_VERSION >= 6.2
  */
-TEST_CASE(Unit_hipMallocFromPoolAsync_MThread_DefaultThresh) {
+HIP_TEST_CASE(Unit_hipMallocFromPoolAsync_MThread_DefaultThresh) {
   runMThreadReleaseThresholdTest(testdefault);
 }
 
-TEST_CASE(Unit_hipMallocFromPoolAsync_MThread_MaxThresh) {
+HIP_TEST_CASE(Unit_hipMallocFromPoolAsync_MThread_MaxThresh) {
   runMThreadReleaseThresholdTest(testMaximum);
 }
 


### PR DESCRIPTION
…config

## Motivation

1. HIP_TEST_CASE macro was not used causing build failure when ENABLE_YAML_TAGS=false
2. Updated to use macros HIP_TEST_CASE and HIP_TEMPLATE_TEST_CASE

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
