### PR TITLE
libhsakmt/fmm: move alignment_order from svm_t to manageable_aperture_t

### DIFF
--- a/projects/rocr-runtime/libhsakmt/src/fmm.c
+++ b/projects/rocr-runtime/libhsakmt/src/fmm.c
@@ -178,6 +178,11 @@ struct manageable_aperture {
 	void *base;
 	void *limit;
 	uint64_t align;
+	uint32_t alignment_order; /* Alignment for mmap aperture allocations:
+			* alignment_size = PAGE_SIZE << alignment_order
+			* Not used by non-mmap apertures (left as 0,
+			* which would correspond to PAGE_SIZE alignment).
+			*/
 	uint32_t guard_pages;
 	vm_area_t *vm_ranges;
 	rbtree_t tree;
@@ -240,9 +245,6 @@ typedef struct {
 
 	/* whether all memory is coherent (GPU cache disabled) */
 	bool disable_cache;
-
-	/* specifies the alignment size as PAGE_SIZE * 2^alignment_order */
-	uint32_t alignment_order;
 } svm_t;
 
 struct hsa_kfd_fmm_context
@@ -320,7 +322,6 @@ struct hsa_kfd_fmm_context *hsakmt_kfdcontext_get_fmm_context(HsaKFDContext *ctx
 	ctx->fmm_context->svm.check_userptr = false;
 	ctx->fmm_context->svm.reserve_svm = false;
 	ctx->fmm_context->svm.disable_cache = false;
-	ctx->fmm_context->svm.alignment_order = 0;
 
 	/* Initialize cpuvm_aperture */
 	ctx->fmm_context->cpuvm_aperture = init_aperture;
@@ -868,8 +869,7 @@ static void *mmap_aperture_allocate_aligned(manageable_aperture_t *aper,
 					    uint64_t size, uint64_t align)
 {
 	uint64_t guard_size;
-	svm_t *svm = container_of(aper, svm_t, apertures);
-	uint64_t alignment_size = PAGE_SIZE << svm->alignment_order;
+	uint64_t alignment_size = PAGE_SIZE << aper->alignment_order;
 
 	if (!aper->is_cpu_accessible) {
 		pr_err("MMap Aperture must be CPU accessible\n");
@@ -1690,7 +1690,6 @@ static void* udmabuf_allocation(HsaKFDContext *ctx,
 	uint64_t guard_size;
 	void *mem;
 	int ret;
-	struct hsa_kfd_fmm_context *fmm_ctx = hsakmt_kfdcontext_get_fmm_context(ctx);
 
 	dmabuf_fd = -1;
 	memfd = -1;
@@ -1715,7 +1714,7 @@ static void* udmabuf_allocation(HsaKFDContext *ctx,
 		goto error_release_memfd;
 	}
 
-	alignment_size = PAGE_SIZE << fmm_ctx->svm.alignment_order;
+	alignment_size = PAGE_SIZE << aperture->alignment_order;
 	alignment = alignment ? alignment : aperture->align;
 	while (alignment < alignment_size && size >= (alignment << 1))
 		alignment <<= 1;
@@ -2448,7 +2447,8 @@ static HSAKMT_STATUS acquire_vm(HsaKFDContext *ctx, uint32_t gpu_id, int fd)
 
 static HSAKMT_STATUS init_mmap_apertures(svm_t *svm,
 					 HSAuint64 base, HSAuint64 limit,
-					 HSAuint32 align, HSAuint32 guard_pages)
+					 HSAuint32 align, HSAuint32 guard_pages,
+					 uint32_t alignment_order)
 {
 	void *addr;
 
@@ -2465,6 +2465,7 @@ static HSAKMT_STATUS init_mmap_apertures(svm_t *svm,
 	svm->apertures[SVM_DEFAULT].base  = (void *)base;
 	svm->apertures[SVM_DEFAULT].limit = (void *)limit;
 	svm->apertures[SVM_DEFAULT].align = align;
+	svm->apertures[SVM_DEFAULT].alignment_order = alignment_order;
 	svm->apertures[SVM_DEFAULT].guard_pages = guard_pages;
 	svm->apertures[SVM_DEFAULT].is_cpu_accessible = true;
 	svm->apertures[SVM_DEFAULT].ops = &mmap_aperture_ops;
@@ -2517,7 +2518,8 @@ static void *reserve_address(void *addr, unsigned long long int len)
 
 static HSAKMT_STATUS init_svm_apertures(struct hsa_kfd_fmm_context *fmm_ctx,
 					HSAuint64 base, HSAuint64 limit,
-					HSAuint32 align, HSAuint32 guard_pages)
+					HSAuint32 align, HSAuint32 guard_pages,
+					uint32_t alignment_order)
 {
 	const HSAuint64 ADDR_INC = GPU_HUGE_PAGE_SIZE;
 	HSAuint64 len, map_size, alt_base, alt_size;
@@ -2544,7 +2546,8 @@ static HSAKMT_STATUS init_svm_apertures(struct hsa_kfd_fmm_context *fmm_ctx,
 	 */
 	if (limit >= (1ULL << 47) - 1 && !svm->reserve_svm) {
 		HSAKMT_STATUS status = init_mmap_apertures(svm, base, limit, align,
-							   guard_pages);
+							   guard_pages,
+							   alignment_order);
 
 		if (status == HSAKMT_STATUS_SUCCESS)
 			return status;
@@ -2776,7 +2779,8 @@ static bool two_apertures_overlap(void *start_1, void *limit_1, void *start_2, v
     return (start_1 >= start_2 && start_1 <= limit_2) || (start_2 >= start_1 && start_2 <= limit_1);
 }
 
-static bool init_mem_handle_aperture(struct hsa_kfd_fmm_context *fmm_ctx, HSAuint32 align, HSAuint32 guard_pages)
+static bool init_mem_handle_aperture(struct hsa_kfd_fmm_context *fmm_ctx,
+				 HSAuint32 align, HSAuint32 guard_pages)
 {
 	bool found;
 	uint32_t i;
@@ -2887,18 +2891,20 @@ HSAKMT_STATUS hsakmt_fmm_init_process_apertures(HsaKFDContext *ctx,
 	 * size is set to 18(1G) for GFX950 to reduce TLB hits. If any non-gfx950
 	 * ASIC is found in the system, set back to 9(2MB).
 	 */
+	uint32_t svm_alignment_order;
+
 	maxVaAlignStr = getenv("HSA_MAX_VA_ALIGN");
-	if (!maxVaAlignStr || sscanf(maxVaAlignStr, "%u", &fmm_ctx->svm.alignment_order) != 1) {
-		fmm_ctx->svm.alignment_order = 18;
+	if (!maxVaAlignStr || sscanf(maxVaAlignStr, "%u", &svm_alignment_order) != 1) {
+		svm_alignment_order = 18;
 
 		for (i = 0; i < NumNodes; i++) {
 			if (hsakmt_get_gfxv_by_node_id(ctx, i) != GFX_VERSION_GFX950) {
-				fmm_ctx->svm.alignment_order = 9;
+				svm_alignment_order = 9;
 				break;
 			}
 		}
 	}
-	pr_info("SVM alignment default order is %d.", fmm_ctx->svm.alignment_order);
+	pr_info("SVM alignment default order is %d.", svm_alignment_order);
 
 	/* Trade off - NumNodes includes GPU nodes + CPU Node. So in
 	 * systems with CPU node, slightly more memory is allocated than
@@ -3112,7 +3118,7 @@ HSAKMT_STATUS hsakmt_fmm_init_process_apertures(HsaKFDContext *ctx,
 		 * space. Set up SVM apertures shared by all such GPUs
 		 */
 		ret = init_svm_apertures(fmm_ctx, svm_base, svm_limit, svm_alignment,
-					 guardPages);
+					 guardPages, svm_alignment_order);
 		if (ret != HSAKMT_STATUS_SUCCESS)
 			goto init_svm_failed;
 


### PR DESCRIPTION
## Motivation
`alignment_order` controls the VA auto-alignment upper bound for mmap aperture allocations (PAGE_SIZE << order). It was stored in `svm_t`, but the primary consumer — `mmap_aperture_allocate_aligned()` — only receives a `manageable_aperture_t *aper.` This forced the function to use `container_of(aper, svm_t, apertures)`to back-cast to the parent `svm_t`, which has several issues:

**Fragile correctness**: The container_of assumes aper always points to `svm_t.apertures[SVM_DEFAULT]` (the array's first element). If aper were `apertures[SVM_COHERENT]`, the pointer arithmetic would silently produce a wrong address. This invariant is only guaranteed by the runtime fact that only `SVM_DEFAULT` is assigned `mmap_aperture_ops`, and cannot be verified by the compiler.

**Semantic mismatch**: alignment_order is a per-aperture allocation policy, not an SVM-subsystem-wide config. SVM_COHERENT never uses it, yet it lived next to fields that apply to all apertures.

**Duplicated logic**: `fmm_alloc_and_map_udmabuf()` bypassed the ops dispatch and manually reimplemented the same alignment logic, fetching alignment_order from `fmm_ctx->svm` via a separate path. This duplication is a direct consequence of the field being stored away from the aperture.

## Technical Details
Move `alignment_order` into `manageable_aperture_t`, co-located with the aperture's existing allocation parameters (base, limit, align, guard_pages). This is the minimal-diff approach  that completely eliminates the container_of back-cast.

### Changes
 - struct `manageable_aperture`/ `svm_t`: Move `alignment_order` from `svm_t` into `manageable_aperture_t`. 
 - Initialization path (`hsakmt_fmm_init_process_apertures` → `init_svm_apertures` → `init_mmap_apertures`): Thread the locally computed svm_alignment_order down as a parameter through the call chain. 
 - `mmap_aperture_allocate_aligned()`: Replace container_of + svm->alignment_order with a direct `aper->alignment_order` read.
- `fmm_alloc_and_map_udmabuf()`: Replace `fmm_ctx->svm.alignment_order` with `aperture->alignment_order`, eliminating the need to fetch `fmm_ctx` for this purpose.


### Design alternatives considered
An alternative approach (Option 2) was to introduce a `mmap_aperture_t` sub-type wrapping `manageable_aperture_t` as a base member, keeping `alignment_order` out of the base struct entirely. While architecturally cleaner for extensibility, it requires changing `svm_t.apertures[]` element type and touching significantly more initialization code. The current approach (Option 1) was chosen for its minimal diff and zero regression risk, while still fully resolving the container_of correctness concern. 

## Impact
- No functional/behavioral change — alignment values and logic are identical.
- Non-mmap apertures leave alignment_order as 0 (zero-initialized), which is semantically consistent (unused).

## Test Plan

kfdtest

## Test Result

kfdtest passed.
