### PR TITLE
[rocprofiler-sdk] Fix incorrect original signal update in async copy handler

### DIFF
--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/hsa/async_copy.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/hsa/async_copy.cpp
@@ -338,7 +338,7 @@ convert_hsa_handle(Up _hsa_object)
 }
 
 bool
-async_copy_handler(hsa_signal_value_t , void* arg)
+async_copy_handler(hsa_signal_value_t, void* arg)
 {
     // if we have fully finalized, delete the data and return
     if(registration::get_fini_status() > 0)

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/hsa/async_copy.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/hsa/async_copy.cpp
@@ -338,7 +338,7 @@ convert_hsa_handle(Up _hsa_object)
 }
 
 bool
-async_copy_handler(hsa_signal_value_t signal_value, void* arg)
+async_copy_handler(hsa_signal_value_t , void* arg)
 {
     // if we have fully finalized, delete the data and return
     if(registration::get_fini_status() > 0)
@@ -432,13 +432,9 @@ async_copy_handler(hsa_signal_value_t signal_value, void* arg)
         std::tie(orig_amd_signal->start_ts, orig_amd_signal->end_ts) =
             std::tie(rocp_amd_signal->start_ts, rocp_amd_signal->end_ts);
 
-        const hsa_signal_value_t new_value =
-            get_core_table()->hsa_signal_load_relaxed_fn(_data->orig_signal) - 1;
-
-        ROCP_ERROR_IF(signal_value != new_value) << "bad original signal value in " << __FUNCTION__;
         // Move to ROCP_TRACE when rebasing
         ROCP_INFO << "Decrementing Signal: " << std::hex << _data->orig_signal.handle << std::dec;
-        get_core_table()->hsa_signal_store_screlease_fn(_data->orig_signal, signal_value);
+        get_core_table()->hsa_signal_subtract_screlease_fn(_data->orig_signal, 1);
     }
 
     ROCP_HSA_TABLE_CALL(ERROR, get_core_table()->hsa_signal_destroy_fn(_data->rocp_signal));


### PR DESCRIPTION
## Motivation

- The async copy handler incorrectly propagated the completion signal value back to the original signal using the callback-provided `signal_value`. However, this value corresponds to the internal rocprofiler signal (`rocp_signal`), not the original user-provided completion signal. This resulted in incorrect signal semantics and potential mismatches in expected completion behavior.

## Technical Details

Fix this by replacing the store operation with an atomic decrement on
the original signal:

    hsa_signal_subtract_screlease_fn(orig_signal, 1)

## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan

CI Checks
- https://gist.github.com/venkat1361/8251f97ceef907028f68c27f1b1823b2

## Test Result

Passed

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
