### PR TITLE
[rocprofiler-systems] [Thera] Add missing ROCPROFSYS_BUILD_TESTING guards around tests subdirectories

### DIFF
--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library/pmc/collectors/gpu/CMakeLists.txt
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library/pmc/collectors/gpu/CMakeLists.txt
@@ -2,7 +2,9 @@
 # SPDX-License-Identifier:  MIT
 
 # Add tests subdirectory
-add_subdirectory(tests)
+if(ROCPROFSYS_BUILD_TESTING)
+    add_subdirectory(tests)
+endif()
 
 # PMC GPU Collector Sources
 set(pmc_gpu_sources

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library/pmc/collectors/nic/CMakeLists.txt
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library/pmc/collectors/nic/CMakeLists.txt
@@ -2,7 +2,9 @@
 # SPDX-License-Identifier:  MIT
 
 # Add tests subdirectory
-add_subdirectory(tests)
+if(ROCPROFSYS_BUILD_TESTING)
+    add_subdirectory(tests)
+endif()
 
 # PMC NIC Collector Sources
 set(pmc_nic_sources


### PR DESCRIPTION
## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

When building on Thera with `--preset release`, build was failing due to missing `gmock`. However, this should never be reached as `gmock` is a testing framework. `release` preset has `ROCPROFSYS_BUILD_TESTING=OFF`. 

Upon investigation, there are two files missing guards around `add_subdirectory(tests)`.

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

Add:
```
if (ROCPROFSYS_BUILD_TESTING)
    add_subdirectory(...)
endif()
```

## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

AIPROFSYST-76

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

Build on Thera

## Test Result

<!-- Briefly summarize test outcomes. -->

Successfully built on Thera: `rocprof-sys-avail --help` and `rocprof-sys-instrument --help` both work.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
