### PR TITLE
[rocshmem] Added fallback for UAR

### DIFF
--- a/projects/rocshmem/src/gda/mlx5/provider_gda_mlx5.cpp
+++ b/projects/rocshmem/src/gda/mlx5/provider_gda_mlx5.cpp
@@ -319,7 +319,27 @@ int mlx5dv_funcs_t::create_qp(mlx5_devx_qp& qp, struct ibv_context *ctx,
    * MLX5DV_UAR_ALLOC_TYPE_NC_DEDICATED dynamically allocates a UAR page, but these are limited
    * using MLX5DV_UAR_ALLOC_TYPE_NC_DEDICATED requires rdma-core v45 or later (released March 2023)
    * see https://github.com/linux-rdma/rdma-core/commit/bf550b9fa83374cfed51330760a583d82a7600f4 */
+  errno = 0;
   qp.uar = mlx5dv.devx_alloc_uar(ctx, MLX5DV_UAR_ALLOC_TYPE_NC_DEDICATED);
+
+  /* It is recomended that the user upgrade their network stack.
+   * However, this is a fall-back mechanism to notify the user of this issue.  */
+  if (NULL == qp.uar && EOPNOTSUPP == errno) {
+    fprintf(stderr,
+            "[Warning] Cannot provide dedicated DBs to each QP, "
+            "rocSHMEM correctness is not guaranteed "
+            "MLX5DV_UAR_ALLOC_TYPE_NC_DEDICATED is not supported by the installed rdma-core/OFED."
+            "Please upgrade network stack.\n");
+
+    errno = 0;
+    qp.uar = mlx5dv.devx_alloc_uar(ctx, MLX5DV_UAR_ALLOC_TYPE_NC);
+
+    if (NULL == qp.uar && EOPNOTSUPP == errno) {
+      fprintf(stderr, "[Warning] MLX5DV_UAR_ALLOC_TYPE_NC is also not supported.\n");
+
+      qp.uar = mlx5dv.devx_alloc_uar(ctx, MLX5DV_UAR_ALLOC_TYPE_BF);
+    }
+  }
   CHECK_NNULL(qp.uar, "mlx5dv_devx_alloc_uar");
 
   // create CQ

--- a/projects/rocshmem/src/gda/mlx5/provider_gda_mlx5.cpp
+++ b/projects/rocshmem/src/gda/mlx5/provider_gda_mlx5.cpp
@@ -331,14 +331,7 @@ int mlx5dv_funcs_t::create_qp(mlx5_devx_qp& qp, struct ibv_context *ctx,
             "MLX5DV_UAR_ALLOC_TYPE_NC_DEDICATED is not supported by the installed rdma-core/OFED."
             "Please upgrade network stack.\n");
 
-    errno = 0;
-    qp.uar = mlx5dv.devx_alloc_uar(ctx, MLX5DV_UAR_ALLOC_TYPE_NC);
-
-    if (NULL == qp.uar && EOPNOTSUPP == errno) {
-      fprintf(stderr, "[Warning] MLX5DV_UAR_ALLOC_TYPE_NC is also not supported.\n");
-
-      qp.uar = mlx5dv.devx_alloc_uar(ctx, MLX5DV_UAR_ALLOC_TYPE_BF);
-    }
+    qp.uar = mlx5dv.devx_alloc_uar(ctx, MLX5DV_UAR_ALLOC_TYPE_BF);
   }
   CHECK_NNULL(qp.uar, "mlx5dv_devx_alloc_uar");
 

--- a/projects/rocshmem/src/gda/mlx5/provider_gda_mlx5.cpp
+++ b/projects/rocshmem/src/gda/mlx5/provider_gda_mlx5.cpp
@@ -329,7 +329,7 @@ int mlx5dv_funcs_t::create_qp(mlx5_devx_qp& qp, struct ibv_context *ctx,
             "[Warning] Cannot provide dedicated DBs to each QP, "
             "rocSHMEM correctness is not guaranteed "
             "MLX5DV_UAR_ALLOC_TYPE_NC_DEDICATED is not supported by the installed rdma-core/OFED."
-            "Please upgrade network stack.\n");
+            "Please upgrade network stack to rdma-core v45 or later.\n");
 
     qp.uar = mlx5dv.devx_alloc_uar(ctx, MLX5DV_UAR_ALLOC_TYPE_BF);
   }


### PR DESCRIPTION
## Motivation

Notify users if they have an old networks stack that we do not support

## Technical Details

- MLX5DV_UAR_ALLOC_TYPE_NC_DEDICATED is not supported by all versions of rdma-core
- If `devx_alloc_uar` warn users that they should try and update their network stack
   - The fallback will work in some cases but not **all** as some applications require unique doorbells.

## JIRA ID
AIROCSHMEM-353

