### PR TITLE
[hip-tests] make STANDALONE_TESTS a cmake option

### DIFF
--- a/projects/hip-tests/catch/CMakeLists.txt
+++ b/projects/hip-tests/catch/CMakeLists.txt
@@ -31,6 +31,7 @@ option(TEST_CLOCK_CYCLE "Option to use clock64" OFF)
 option(RTC_TESTING "Run tests using HIP RTC to compile the kernels" OFF)
 option(ENABLE_SPIRV "Build hip-tests for SPIRV" OFF)
 option(ENABLE_YAML_TAGS "Enable YAML tags for test cases" ON)
+option(STANDALONE_TESTS "Generate standalone executable per source file" OFF)
 
 if(NOT CMAKE_BUILD_TYPE)
   set(CMAKE_BUILD_TYPE "Release")
@@ -85,9 +86,6 @@ endif()
 if(ENABLE_YAML_TAGS)
     add_definitions(-DENABLE_YAML_TAGS)
 endif()
-
-# flag to generate standalone exe per src file.
-message(STATUS "STANDALONE_TESTS : ${STANDALONE_TESTS}")
 
 if(NOT WIN32)
   set(CPACK_SET_DESTDIR ON CACHE BOOL "Installer package will install hip catch to CMAKE_INSTALL_PREFIX instead of CPACK_PACKAGING_INSTALL_PREFIX")

--- a/projects/hip-tests/catch/cmake/hip-tests.cmake
+++ b/projects/hip-tests/catch/cmake/hip-tests.cmake
@@ -28,8 +28,8 @@ function(hip_add_exe_to_target)
     PROPERTY ${_PROPERTY}
     STANDALONE_FLAG 0
   )
-  # If STANDALONE_TESTS==1, also generate per-file targets
-  if(STANDALONE_TESTS EQUAL "1")
+  if(STANDALONE_TESTS)
+    # Generate per-file targets
     hip_gen_exe_target(
       NAME ${_NAME}
       TEST_TARGET_NAME ${_TEST_TARGET_NAME}


### PR DESCRIPTION
## Motivation

Make STANDALONE_TESTS a cmake option. All user facing cmake variables should be a cmake option (so that tools like ccmake can also detect them...)

## Technical Details

.

## JIRA ID

AIRUNTIME-1988

## Test Plan

Ensure build passes. All tests pass

## Test Result

Local build passed, local tests pass

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
