### PR TITLE
Opt-in Static Huge Pages support for deterministic memory mapping on UMA/APU architectures

### DIFF
--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/interrupt_signal.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/interrupt_signal.cpp
@@ -203,7 +203,15 @@ hsa_signal_value_t InterruptSignal::WaitAcquire(
     uint64_t timeout, hsa_wait_state_t wait_hint) {
   hsa_signal_value_t ret =
       WaitRelaxed(condition, compare_value, timeout, wait_hint);
+  
   std::atomic_thread_fence(std::memory_order_acquire);
+#ifdef __linux__ 
+  if (std::getenv("HSA_FORCE_HUGETLB")) {
+  #if defined(__x86_64__) || defined(_M_X64)
+    __builtin_ia32_mfence(); // Pour le Steam Deck (x86)
+  #endif 
+  }
+#endif
   return ret;
 }
 

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/interrupt_signal.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/interrupt_signal.cpp
@@ -205,13 +205,14 @@ hsa_signal_value_t InterruptSignal::WaitAcquire(
       WaitRelaxed(condition, compare_value, timeout, wait_hint);
   
   std::atomic_thread_fence(std::memory_order_acquire);
-#ifdef __linux__ 
   if (std::getenv("HSA_FORCE_HUGETLB")) {
-  #if defined(__x86_64__) || defined(_M_X64)
-    __builtin_ia32_mfence(); // Pour le Steam Deck (x86)
-  #endif 
+    /* * HugeTLB on UMA/APU architectures can bypass standard x86 
+     * memory consistency models under heavy load. 
+     * We enforce a hardware-level fence (mfence) to ensure 
+     * CPU cache coherency with GPU-updated memory.
+     */
+    atomic::Fence(std::memory_order_acq_rel);
   }
-#endif
   return ret;
 }
 

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/util/lnx/os_linux.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/util/lnx/os_linux.cpp
@@ -861,28 +861,49 @@ size_t PageSize() {
 bool UnmapMemory(void* va, size_t size) { return ::munmap(va, size) == 0; }
 
 bool MapMemory(void* va, size_t size, MemProt perms, int fd, uint64_t cpu_addr) {
-  void* mapped_ptr = ::mmap(va, size, MemProtToOsProt(perms), 
-                            MAP_SHARED | MAP_FIXED, fd, cpu_addr);
+  void* mapped_ptr =
+        mmap(va, size, MemProtToOsProt(perms), MAP_SHARED | MAP_FIXED, fd, cpu_addr);
   if (mapped_ptr != va)
       return false;
   return true;
 }
 
 void* ReserveMemory(void* start, size_t size, size_t alignment, MemProt prot) {
-  size = AlignUp(size, PageSize());
+  bool huge_tlb = false;
+  constexpr size_t kLargePageSize = 2 * 1024 * 1024;
+
+  size_t page_size = PageSize();
+  if (std::getenv("HSA_FORCE_HUGETLB") && size >= kLargePageSize) {
+    huge_tlb = true;
+    page_size = kLargePageSize;
+  }
+  size = AlignUp(size, page_size);
   // check for invalid input size
   if (size == 0) {
     return NULL;
   }
-  alignment = std::max(PageSize(), AlignUp(alignment, PageSize()));
+  alignment = std::max(page_size, AlignUp(alignment, page_size));
   assert(IsPowerOfTwo(alignment) && "not a power of 2");
 
-  size_t requested = size + alignment - PageSize();
-  address mem = (address)::mmap(start, requested, MemProtToOsProt(prot),
-                                MAP_PRIVATE | MAP_NORESERVE | MAP_ANONYMOUS, 0, 0);
+  size_t requested = size + alignment - page_size;
+  address mem = NULL;
+  if (!huge_tlb) {
+    mem = (address)::mmap(start, requested, MemProtToOsProt(prot),
+                                  MAP_PRIVATE | MAP_NORESERVE | MAP_ANONYMOUS, 0, 0);
 
-  // check for out of memory
-  if (mem == MAP_FAILED) return NULL;
+    // check for out of memory
+    if (mem == MAP_FAILED) return NULL;
+  } else {
+    mem = (address)::mmap(start, requested, MemProtToOsProt(prot),
+                                  MAP_PRIVATE | MAP_HUGETLB | MAP_ANONYMOUS, 0, 0);
+    if (mem == MAP_FAILED) {
+      //fallback to default behavior
+      mem = (address)::mmap(start, requested, MemProtToOsProt(prot),
+                                  MAP_PRIVATE | MAP_NORESERVE | MAP_ANONYMOUS, 0, 0);
+      // check for out of memory
+      if (mem == MAP_FAILED) return NULL;
+    }
+  }
 
   address aligned = AlignUp(mem, alignment);
 
@@ -902,8 +923,7 @@ void* ReserveMemory(void* start, size_t size, size_t alignment, MemProt prot) {
   }
 
   // Hint to enable THP for large host allocations which can help in performance gain
-  constexpr size_t kLargePageSize = 2 * 1024 * 1024;
-  if (size >= kLargePageSize) {
+  if (size >= kLargePageSize && !huge_tlb) {
     int status = madvise(aligned, size, MADV_HUGEPAGE);
     if (status) {
       fprintf(stderr,

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/util/lnx/os_linux.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/util/lnx/os_linux.cpp
@@ -898,6 +898,9 @@ void* ReserveMemory(void* start, size_t size, size_t alignment, MemProt prot) {
                                   MAP_PRIVATE | MAP_HUGETLB | MAP_ANONYMOUS, 0, 0);
     if (mem == MAP_FAILED) {
       //fallback to default behavior
+      LogPrint(HSA_AMD_LOG_FLAG_INFO,"HUGETLB allocation failed, fallback to default behavior");
+      huge_tlb = false;
+
       mem = (address)::mmap(start, requested, MemProtToOsProt(prot),
                                   MAP_PRIVATE | MAP_NORESERVE | MAP_ANONYMOUS, 0, 0);
       // check for out of memory


### PR DESCRIPTION
## Motivation

As local inference increasingly shifts towards Unified Memory Architectures (UMA) like AMD APUs, allocating massive models (>8GB) using standard memory management becomes a severe bottleneck.

During extensive testing on an AMD Van Gogh APU (Steam Deck) with 10GB+ pinned to the GPU, relying on standard 4KB pages to map such a massive space leads to massive TLB thrashing, page table walking overhead, and ultimately, system instability or "SVM hangs" due to CPU/GPU coherence timeouts.

Current OS-level workarounds, such as forcing Transparent Huge Pages (THP) to always, are suboptimal for dedicated compute nodes for two main reasons:

• Background Overhead: THP spawns khugepaged kworkers that constantly scan and defragment memory, polluting the memory bus during inference and causing micro-stutters.

• Non-Determinism: Allocation is at the mercy of runtime memory fragmentation. If the OS cannot find contiguous blocks dynamically, it falls back to 4KB pages, breaking the performance consistency.

## Technical Details

This patch introduces opt-in support for pre-allocated, static Huge Pages (via MAP_HUGETLB). By bypassing the dynamic 4KB page tables or the transparent huge pages and pinning the model weights in deterministic static huge pages, we ensure:

1. Instant & Guaranteed Allocation: No runtime fragmentation issues or allocation hangs.

2. Maximum Bus Efficiency: Zero background kworker interference, ensuring the LPDDR/HBM bus is 100% dedicated to inference.

3. Hardware-Level Coherency: Significantly reduces TLB misses penalty by getting rid of all useless PT entry on page table (making it more cache friendly) and stabilizes token generation rates on high-parameter models by maintaining deterministic address translation paths between the host and the GPU.

Future-Proofing & Scaling:

While tested on consumer APUs (yielding highly stable and improved token rates), this architectural approach scales perfectly to high-end APUs and Server/Datacenter APUs (like the MI300A). For instance, mapping a 120B model using 1GB Static Huge Pages on server UMA nodes will drastically reduce the memory translation overhead, allowing the high RAM bandwidth to shine.

## JIRA ID


## Test Plan

llama.cpp inference on Van gogh APU: 


```
#!/bin/sh

# --- ENVIRONNEMENT ROCm / APU VAN GOGH ---
export HSA_OVERRIDE_GFX_VERSION=10.3.0
export HSA_ENABLE_SDMA=0
export ROC_ENABLE_PRE_VEGA=1
export HSA_AMD_P2P=1
export HSA_OVERRIDE_CPU_HSA_CAPABLE=1
export HSA_FORCE_HUGETLB=1
export LD_PRELOAD=~/rocm-systems/projects/rocr-runtime/build/rocr/lib/libhsa-runtime64.so
export GGML_CUDA_ENABLE_UNIFIED_MEMORY=1

# --- PARAMÈTRES LLAMA.CPP ---
MODEL_PATH="$HOME/Codestral-22B-v0.1-Q3_K_S.gguf"
N_GPU_LAYERS=99 # On load tout sur l'APU

echo "[+] Lancement de llama-server avec HugePages..."
echo "[+] Modèle : $MODEL_PATH"

~/llama/llama.cpp/build/bin/llama-server \
    -m "$MODEL_PATH" \
    -ngl $N_GPU_LAYERS \
    --host 0.0.0.0 \
    --port 8080 \
    --ctx-size 4096 \
    --no-mmap\

```


## Test Result

Successful model loading: 

```
load_tensors: loading model tensors, this can take a while... (mmap = false, direct_io = false)
load_tensors: offloading output layer to GPU
load_tensors: offloading 55 repeating layers to GPU
load_tensors: offloaded 57/57 layers to GPU
load_tensors:          CPU model buffer size =    82.50 MiB
load_tensors:        ROCm0 model buffer size =  9111.40 MiB
...................................................................................................
```

During inference:
 
<img width="946" height="435" alt="image" src="https://github.com/user-attachments/assets/17699218-e408-4aa6-8e8d-687641d6391b" />



<!-- Briefly summarize test outcomes. -->

I could map a 10GB model in pre-alloacted ram on my 16GB system with improved stability and predictable outcome, run the inference  and keep a 5MB page table

 **part of the model in huge page for scale (9.64 GB) and page table size:**

without static huge pages and THP set to always 150MB in 4k pages
<img width="1239" height="310" alt="always" src="https://github.com/user-attachments/assets/3d261d46-71a6-441d-9a3c-b621653b72d5" />

without static huge pages and THP set to madvise 250MB in 4k pages
<img width="1239" height="310" alt="madvise" src="https://github.com/user-attachments/assets/57ec658e-dde2-4bc7-bb84-7442ee88e251" />

without static huge pages and THP
<img width="1239" height="310" alt="never" src="https://github.com/user-attachments/assets/ab29c18d-3087-41ad-a236-1fa43c415a32" />

## Submission Checklist

- [ x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
