### PR TITLE
[rocprofiler-systems] MPI file-output filtering

### DIFF
--- a/projects/rocprofiler-systems/CHANGELOG.md
+++ b/projects/rocprofiler-systems/CHANGELOG.md
@@ -11,6 +11,7 @@ Full documentation for ROCm Systems Profiler is available at [https://rocm.docs.
 - Support for pause and resume of profiling via `roctxProfilerPause` and `roctxProfilerResume`.
 - Support for selective region tracing via the `ROCPROFSYS_TRACE_REGION` environment variable, limiting tracing to specified regions.
 - Support for re-attaching to a previously profiled process. After detaching, `rocprof-sys-attach` can re-attach to the same PID for a new profiling session.
+- MPI-rank-based file output filtering feature controlled with two new CLI arguments: `--rank-filter-output` and `--rank-filter-id`.
 
 ### Changed
 

--- a/projects/rocprofiler-systems/source/lib/core/argparse.cpp
+++ b/projects/rocprofiler-systems/source/lib/core/argparse.cpp
@@ -508,6 +508,42 @@ add_core_arguments(parser_t& _parser, parser_data& _data)
         _data.processed_environs.emplace("periods");
     }
 
+    if(_data.environ_filter("rank_filter_id", _data))
+    {
+        _parser
+            .add_argument({ "--rank-filter-id" },
+                          "Sets the name of environment variable to read rank from for "
+                          "MPI output filtering")
+            .max_count(1)
+            .dtype("string")
+            .required({ "rank-filter-output" })
+            .action([&](parser_t& p) {
+                update_env(_data, "ROCPROFSYS_RANK_FILTER_ID",
+                           p.get<std::string>("rank-filter-id"));
+            });
+
+        _data.processed_environs.emplace("rank_filter_id");
+    }
+
+    if(_data.environ_filter("rank_filter_output", _data))
+    {
+        _parser
+            .add_argument({ "--rank-filter-output" },
+                          "Ranks for which file output is generated. Values should be "
+                          "separated by commas and can be explicit or ranges, e.g. "
+                          "0,1,5-8. An empty value enables output for all ranks")
+            .max_count(1)
+            .dtype("int and/or range")
+            .action([&](parser_t& p) {
+                update_env(
+                    _data, "ROCPROFSYS_RANK_FILTER_OUTPUT",
+                    fmt::format("{}",
+                                fmt::join(p.get<strvec_t>("rank-filter-output"), ",")));
+            });
+
+        _data.processed_environs.emplace("rank_filter_output");
+    }
+
     strset_t _backend_choices = { "all",        "kokkosp", "mpip", "ompt",
                                   "rcclp",      "amd-smi", "rocm", "mutex-locks",
                                   "spin-locks", "rw-locks" };

--- a/projects/rocprofiler-systems/source/lib/core/config.cpp
+++ b/projects/rocprofiler-systems/source/lib/core/config.cpp
@@ -885,6 +885,18 @@ configure_settings(bool _init)
         kill_delay_config->set(0);
     }
 
+    ROCPROFSYS_CONFIG_SETTING(
+        std::string, "ROCPROFSYS_RANK_FILTER_ID",
+        "Name of environment variable to read rank from for MPI output filtering",
+        std::string{}, "data", "io", "advanced");
+
+    ROCPROFSYS_CONFIG_SETTING(
+        std::string, "ROCPROFSYS_RANK_FILTER_OUTPUT",
+        "Ranks for which file output is generated. Values should be separated by commas "
+        "and can be explicit or ranges, e.g. 0,1,5-8. An empty value enables output "
+        "for all ranks",
+        std::string{}, "data", "io", "advanced");
+
     // set the defaults
     _config->get_flamegraph_output()     = false;
     _config->get_ctest_notes()           = false;
@@ -2595,6 +2607,97 @@ get_kill_delay()
     static auto _v = get_config()->find("ROCPROFSYS_KILL_DELAY");
     return static_cast<tim::tsettings<int>&>(*_v->second).get();
 }
+
+namespace
+{
+std::string
+get_rank_filter_id()
+{
+    static auto _v = get_config()->at("ROCPROFSYS_RANK_FILTER_ID");
+    return static_cast<tim::tsettings<std::string>&>(*_v).get();
+}
+
+std::string
+get_rank_filter_output()
+{
+    static auto _v = get_config()->at("ROCPROFSYS_RANK_FILTER_OUTPUT");
+    return static_cast<tim::tsettings<std::string>&>(*_v).get();
+}
+
+#if(defined(ROCPROFSYS_USE_MPI_HEADERS) && ROCPROFSYS_USE_MPI_HEADERS > 0) ||            \
+    (defined(ROCPROFSYS_USE_MPI) && ROCPROFSYS_USE_MPI > 0)
+#    define ROCPROFSYS_MPI_OR_MPI_HEADERS_ENABLED 1
+#else
+#    define ROCPROFSYS_MPI_OR_MPI_HEADERS_ENABLED 0
+#endif
+
+#if ROCPROFSYS_MPI_OR_MPI_HEADERS_ENABLED
+std::optional<uint64_t>
+get_mpi_rank_from_env()
+{
+    const std::vector<std::string> rank_env_var_options = {
+        // rank env vars: user-provided then most generic to most runtime-specific
+        get_rank_filter_id(),  "MPI_RANK",
+        "MPI_LOCALRANKID",     "MPI_RANKID",
+        "MV2_COMM_WORLD_RANK", "OMPI_COMM_WORLD_RANK"
+    };
+
+    for(const auto& env_var : rank_env_var_options)
+    {
+        const std::string rank_str = get_env(env_var, std::string{}, false);
+
+        if(rank_str.empty()) continue;
+        try
+        {
+            const auto rank = std::stoul(rank_str);
+            LOG_DEBUG("MPI output filtering: using MPI rank = {} from {}", rank, env_var);
+            return rank;
+        } catch(const std::exception& e)
+        {
+            LOG_WARNING("MPI output filtering: failed to get MPI rank from {}='{}': {}",
+                        env_var, rank_str, e.what());
+        }
+    }
+
+    return std::nullopt;
+}
+#endif
+}  // namespace
+
+namespace output_filtering
+{
+bool
+is_output_enabled_for_current_mpi_rank()
+{
+#if ROCPROFSYS_MPI_OR_MPI_HEADERS_ENABLED
+    auto enabled_ranks_str = get_rank_filter_output();
+    rocprofsys::utility::trim_str(enabled_ranks_str);
+    for(auto& ch : enabled_ranks_str)
+        ch = std::tolower(ch);
+
+    if(enabled_ranks_str.empty() || enabled_ranks_str == "all") return true;
+    if(enabled_ranks_str == "none") return false;
+
+    const auto current_rank = get_mpi_rank_from_env();
+    if(!current_rank)
+    {
+        LOG_WARNING("MPI output filtering DISABLED: failed to get MPI rank");
+        return true;
+    }
+
+    const auto enabled_ranks =
+        rocprofsys::utility::parse_numeric_range<int64_t, std::unordered_set<int64_t>>(
+            enabled_ranks_str, "ranks", 1L);
+
+    const auto is_enabled = enabled_ranks.count(current_rank.value()) != 0;
+    LOG_DEBUG("Output for MPI rank {} is {}", current_rank.value(),
+              is_enabled ? "enabled" : "disabled");
+    return is_enabled;
+#else
+    return true;
+#endif
+}
+}  // namespace output_filtering
 
 tmp_file::tmp_file(std::string _v)
 : filename{ std::move(_v) }

--- a/projects/rocprofiler-systems/source/lib/core/config.hpp
+++ b/projects/rocprofiler-systems/source/lib/core/config.hpp
@@ -373,6 +373,12 @@ get_use_tmp_files();
 int
 get_kill_delay();
 
+namespace output_filtering
+{
+bool
+is_output_enabled_for_current_mpi_rank();
+}  // namespace output_filtering
+
 std::string
 get_tmpdir();
 

--- a/projects/rocprofiler-systems/source/lib/core/perfetto.cpp
+++ b/projects/rocprofiler-systems/source/lib/core/perfetto.cpp
@@ -246,39 +246,42 @@ post_process(tim::manager* _timemory_manager, bool& _perfetto_output_error,
 
     auto _filename = config::get_perfetto_output_filename();
 
-    // In MPI combined-trace mode, only rank 0 has non-empty trace_data
-    // after the gather, so only rank 0 writes and registers the file.
-    if(!trace_data.empty())
+    if(config::output_filtering::is_output_enabled_for_current_mpi_rank())
     {
-        operation::file_output_message<tim::project::rocprofsys> _fom{};
-        // Write the trace into a file.
-        if(config::get_verbose() >= 0)
-            _fom(_filename, std::string{ "perfetto" },
-                 " (%.2f KB / %.2f MB / %.2f GB)... ",
-                 static_cast<double>(trace_data.size()) / units::KB,
-                 static_cast<double>(trace_data.size()) / units::MB,
-                 static_cast<double>(trace_data.size()) / units::GB);
-        std::ofstream ofs{};
-        if(!filepath::open(ofs, _filename, std::ios::out | std::ios::binary))
+        // In MPI combined-trace mode, only rank 0 has non-empty trace_data
+        // after the gather, so only rank 0 writes and registers the file.
+        if(!trace_data.empty())
         {
-            _fom.append("Error opening '%s'...", _filename.c_str());
-            _perfetto_output_error = true;
-        }
-        else
-        {
+            operation::file_output_message<tim::project::rocprofsys> _fom{};
             // Write the trace into a file.
-            ofs.write(trace_data.data(), trace_data.size());
-            if(config::get_verbose() >= 0) _fom.append("%s", "Done");  // NOLINT
-            if(_timemory_manager)
-                _timemory_manager->add_file_output("protobuf", "perfetto", _filename);
-            _output_registry.register_file(_filename, output_format::perfetto);
+            if(config::get_verbose() >= 0)
+                _fom(_filename, std::string{ "perfetto" },
+                     " (%.2f KB / %.2f MB / %.2f GB)... ",
+                     static_cast<double>(trace_data.size()) / units::KB,
+                     static_cast<double>(trace_data.size()) / units::MB,
+                     static_cast<double>(trace_data.size()) / units::GB);
+            std::ofstream ofs{};
+            if(!filepath::open(ofs, _filename, std::ios::out | std::ios::binary))
+            {
+                _fom.append("Error opening '%s'...", _filename.c_str());
+                _perfetto_output_error = true;
+            }
+            else
+            {
+                // Write the trace into a file.
+                ofs.write(trace_data.data(), trace_data.size());
+                if(config::get_verbose() >= 0) _fom.append("%s", "Done");  // NOLINT
+                if(_timemory_manager)
+                    _timemory_manager->add_file_output("protobuf", "perfetto", _filename);
+                _output_registry.register_file(_filename, output_format::perfetto);
+            }
+            ofs.close();
         }
-        ofs.close();
-    }
-    else if(dmp::rank() == 0)
-    {
-        LOG_ERROR("Perfetto trace data is empty. File '{}' will not be written...",
-                  _filename);
+        else if(dmp::rank() == 0)
+        {
+            LOG_ERROR("Perfetto trace data is empty. File '{}' will not be written...",
+                      _filename);
+        }
     }
 
     // Merge the output files, if rank 0

--- a/projects/rocprofiler-systems/source/lib/core/trace_cache/cache_manager.cpp
+++ b/projects/rocprofiler-systems/source/lib/core/trace_cache/cache_manager.cpp
@@ -588,23 +588,26 @@ cache_manager::post_process_bulk(output_file_registry& _output_registry)
         filesystem_utils::get_cache_files(root_pid, temp_directory_content);
     LOG_DEBUG("Found {} cache file pairs to process", cache_files.size());
 
-    const data::enabled_formats_t enabled_formats;
-    enabled_formats.print();
-
-    auto processor_configs =
-        processing_utils::create_processor_configs(cache_files, root_pid);
-
-    processor_configs.push_back(std::make_shared<data::processor_config_t>(
-        getpid(), root_pid, m_metadata,
-        std::make_shared<agent_manager>(get_agent_manager_instance().get_agents())));
-
-    LOG_INFO("Processing {} trace cache configurations", processor_configs.size());
-    processing_utils::dispatch_processing(processor_configs, enabled_formats,
-                                          _output_registry);
-
-    if(enabled_formats.is_perfetto_enabled() && get_merge_perfetto_files())
+    if(config::output_filtering::is_output_enabled_for_current_mpi_rank())
     {
-        filesystem_utils::merge_perfetto_files();
+        const data::enabled_formats_t enabled_formats;
+        enabled_formats.print();
+
+        auto processor_configs =
+            processing_utils::create_processor_configs(cache_files, root_pid);
+
+        processor_configs.push_back(std::make_shared<data::processor_config_t>(
+            getpid(), root_pid, m_metadata,
+            std::make_shared<agent_manager>(get_agent_manager_instance().get_agents())));
+
+        LOG_INFO("Processing {} trace cache configurations", processor_configs.size());
+        processing_utils::dispatch_processing(processor_configs, enabled_formats,
+                                              _output_registry);
+
+        if(enabled_formats.is_perfetto_enabled() && get_merge_perfetto_files())
+        {
+            filesystem_utils::merge_perfetto_files();
+        }
     }
 
     filesystem_utils::clear_cache_files(cache_files);

--- a/projects/rocprofiler-systems/source/lib/core/utility.cpp
+++ b/projects/rocprofiler-systems/source/lib/core/utility.cpp
@@ -122,5 +122,20 @@ parse_numeric_range<int64_t, std::vector<int64_t>>(std::string, const std::strin
 template std::unordered_set<int64_t>
 parse_numeric_range<int64_t, std::unordered_set<int64_t>>(std::string, const std::string&,
                                                           long);
+
+void
+trim_str(std::string& str)
+{
+    const auto start = str.find_first_not_of(" \n\r\t\f\v");
+    if(start == std::string::npos)
+    {
+        str.clear();
+        return;
+    }
+    str.erase(0, start);
+    const auto end = str.find_last_not_of(" \n\r\t\f\v");
+    str.erase(end + 1);
+}
+
 }  // namespace utility
 }  // namespace rocprofsys

--- a/projects/rocprofiler-systems/source/lib/core/utility.hpp
+++ b/projects/rocprofiler-systems/source/lib/core/utility.hpp
@@ -265,5 +265,9 @@ parse_numeric_range<int64_t, std::vector<int64_t>>(std::string, const std::strin
 extern template std::unordered_set<int64_t>
 parse_numeric_range<int64_t, std::unordered_set<int64_t>>(std::string, const std::string&,
                                                           long);
+
+void
+trim_str(std::string& str);
+
 }  // namespace utility
 }  // namespace rocprofsys

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library.cpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library.cpp
@@ -1215,6 +1215,18 @@ rocprofsys_finalize_hidden(void)
         if(attach_add_session_id)
             settings::default_process_suffix() = fmt::format("%pid%-{}", session_id++);
 
+        // Disable Timemory file output for disabled ranks
+        if(!config::output_filtering::is_output_enabled_for_current_mpi_rank())
+        {
+            auto* _settings = tim::settings::instance();
+            if(_settings)
+            {
+                _settings->file_output() = false;
+                _settings->text_output() = false;
+                _settings->json_output() = false;
+            }
+        }
+
         LOG_DEBUG("Finalizing timemory...");
         tim::timemory_finalize(_timemory_manager.get());
 


### PR DESCRIPTION
## Motivation

Add filtering of output based on MPI rank.

This feature enables the user to specify ranks for which output files (rocpd, Perfetto, Timemory) are created. 

## Technical Details

Two new CLI arguments are introduced:

- `--rank-filter-output`:  specifies MPI ranks for which file output will be produces. If provided, this argument enables MPI output filtering, and file output from other ranks is suppressed.
  - The corresponding configuration setting is `ROCPROFSYS_RANK_FILTER_OUTPUT`. 

- `--rank-filter-id`: specifies the name of environment variable that is used to determine the rank of each process. This argument can only be used together with --rank-filter-output
  - The corresponding configuration setting is `ROCPROFSYS_RANK_FILTER_ID`.

Rank is obtained from one of the following environment variables (in that order):
- `--rank-filter-id` value, if provided
- MPI_RANK
- MPI_LOCALRANKID
- MPI_RANKID
- MV2_COMM_WORLD_RANK
- OMPI_COMM_WORLD_RANK

If rank could not be obtained from the list above, then output filtering is disabled and file output is produced for all ranks.

## JIRA ID

- AIPROFSYST-170
- AIPROFSYST-111

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
