### PR TITLE
clr: Create the new signal of proper type during the signal swap.

### DIFF
--- a/projects/clr/rocclr/device/rocm/rocvirtual.cpp
+++ b/projects/clr/rocclr/device/rocm/rocvirtual.cpp
@@ -499,7 +499,9 @@ hsa_signal_t VirtualGPU::HwQueueTracker::ActiveSignal(hsa_signal_value_t init_va
     // The signal was assigned to the global marker's event, hence runtime can't reuse it
     // and needs a new signal
     std::unique_ptr<ProfilingSignal> signal(new ProfilingSignal());
-    if ((signal != nullptr) && CreateSignal(signal.get())) {
+    // Makes ure the same signal type is created with the same interrupt flag, since the tracking
+    // list relies on that for the reuse
+    if ((signal != nullptr) && CreateSignal(signal.get(), signal_list_[current_id_]->flags_.interrupt_)) {
       signal_list_[current_id_]->release();
       signal_list_[current_id_] = signal.release();
     } else {

--- a/projects/clr/rocclr/device/rocm/rocvirtual.cpp
+++ b/projects/clr/rocclr/device/rocm/rocvirtual.cpp
@@ -499,8 +499,9 @@ hsa_signal_t VirtualGPU::HwQueueTracker::ActiveSignal(hsa_signal_value_t init_va
     // The signal was assigned to the global marker's event, hence runtime can't reuse it
     // and needs a new signal
     std::unique_ptr<ProfilingSignal> signal(new ProfilingSignal());
-    // Makes ure the same signal type is created with the same interrupt flag, since the tracking
-    // list relies on that for the reuse
+
+    // Ensure that signals of the same type are created with the same interrupt flag,
+    // as the tracking list depends on this for reuse.
     if ((signal != nullptr) && CreateSignal(signal.get(), signal_list_[current_id_]->flags_.interrupt_)) {
       signal_list_[current_id_]->release();
       signal_list_[current_id_] = signal.release();


### PR DESCRIPTION
## Motivation
Fix a potential leak of HSA signals in CLR

## Technical Details
CLR swaps signals when HIP events are used, but it may swap them with an incorrect signal type, potentially causing a leak.

## JIRA ID
ROCM-20102

## Test Plan
Specific long running test with constant HIP events usage and device hipStreamSynchronize in a loop

## Test Result
No leak

## Submission Checklist
N/A