### PR TITLE
[rocshmem] update driver script to rerun failed tests once

### DIFF
--- a/projects/rocshmem/scripts/functional_tests/driver.sh
+++ b/projects/rocshmem/scripts/functional_tests/driver.sh
@@ -235,8 +235,9 @@ ExecTest() {
     DRIVER_RETURN_STATUS=1
     if [ $IS_RETRY -eq 0 ]; then
       # Track failed tests with their parameters for potential retry
+      # Capture environment/config state to ensure retry runs under same conditions
       FAILED_LIST="$FAILED_LIST $TEST_LOG_NAME"
-      FAILED_TESTS+=("$TEST_NAME|$NUM_RANKS|$NUM_WG|$NUM_THREADS|$MAX_MSG_SIZE")
+      FAILED_TESTS+=("$TEST_NAME|$NUM_RANKS|$NUM_WG|$NUM_THREADS|$MAX_MSG_SIZE|${ROCSHMEM_TEST_USE_DEFAULT_STREAM:-}|${ROCSHMEM_MAX_NUM_CONTEXTS:-}|${NOTIMEOUT:-}|${NOVERIF:-}")
     else
       # Track tests that failed even after retry
       RETRY_FAILED_LIST="$RETRY_FAILED_LIST $TEST_LOG_NAME"
@@ -635,10 +636,31 @@ RerunFailedTests() {
   RETRY_FAILED_LIST=""
   RETRY_PASSED_LIST=""
 
-  # Rerun each failed test
+  # Rerun each failed test with the same environment/config state
   for test_params in "${FAILED_TESTS[@]}"; do
-    IFS='|' read -r test_name num_ranks num_wg num_threads max_msg_size <<< "$test_params"
+    IFS='|' read -r test_name num_ranks num_wg num_threads max_msg_size use_default_stream max_contexts notimeout noverif <<< "$test_params"
+
+    # Restore environment state from original test run
+    if [[ -n "$use_default_stream" ]]; then
+      export ROCSHMEM_TEST_USE_DEFAULT_STREAM="$use_default_stream"
+    fi
+    if [[ -n "$max_contexts" ]]; then
+      export ROCSHMEM_MAX_NUM_CONTEXTS="$max_contexts"
+    fi
+    if [[ -n "$notimeout" ]]; then
+      NOTIMEOUT="$notimeout"
+    fi
+    if [[ -n "$noverif" ]]; then
+      NOVERIF="$noverif"
+    fi
+
     ExecTest "$test_name" "$num_ranks" "$num_wg" "$num_threads" "$max_msg_size" 1
+
+    # Clean up environment state after retry
+    unset ROCSHMEM_TEST_USE_DEFAULT_STREAM
+    unset ROCSHMEM_MAX_NUM_CONTEXTS
+    unset NOTIMEOUT
+    unset NOVERIF
   done
 
   echo ""
@@ -721,13 +743,13 @@ case $TEST in
     ;;
 esac
 
-EXIT_STATUS=$(($DRIVER_RETURN_STATUS || $?))
+EXIT_STATUS=$DRIVER_RETURN_STATUS
 
 # If there were failures, try to rerun them once (only if below threshold)
 if [ $EXIT_STATUS -ne 0 ] && [ ${#FAILED_TESTS[@]} -gt 0 ]; then
   if [ ${#FAILED_TESTS[@]} -le $RETRY_THRESHOLD ]; then
     RerunFailedTests
-    EXIT_STATUS=$(($DRIVER_RETURN_STATUS || $?))
+    EXIT_STATUS=$DRIVER_RETURN_STATUS
   else
     echo ""
     echo "========================================================================"

--- a/projects/rocshmem/scripts/functional_tests/driver.sh
+++ b/projects/rocshmem/scripts/functional_tests/driver.sh
@@ -135,6 +135,8 @@ ExecTest() {
   NUM_WG=$3
   NUM_THREADS=$4
   MAX_MSG_SIZE=$5
+  IS_RETRY=${6:-0}  # Optional 6th parameter to indicate if this is a retry
+
   if [[ "" == "$NOTIMEOUT" ]]; then
     TIMEOUT=$((5 * 60)) # Timeout in seconds
   fi
@@ -207,11 +209,20 @@ ExecTest() {
   fi
   # Create a human-readable representation of the command for logging purposes
   CMD="${cmd[@]}"
+
+  # Determine log file name based on whether this is a retry
+  if [ $IS_RETRY -eq 1 ]; then
+    LOG_FILE="$LOG_DIR/$TEST_LOG_NAME.retry.log"
+    echo "Retry:  $TEST_LOG_NAME"
+  else
+    LOG_FILE="$LOG_DIR/$TEST_LOG_NAME.log"
+    echo "Test:   $TEST_LOG_NAME"
+  fi
+
   # Run Test
   if [ $NUM_GPUS -ge $NUM_RANKS ] || [[ "" != "$HOSTFILE" ]]; then
-    echo "Test:   $TEST_LOG_NAME"
-    echo "# $CMD >> $LOG_DIR/$TEST_LOG_NAME.log" >"$LOG_DIR/$TEST_LOG_NAME.log"
-    "${cmd[@]}" >>"$LOG_DIR/$TEST_LOG_NAME.log" 2>&1
+    echo "# $CMD >> $LOG_FILE" >"$LOG_FILE"
+    "${cmd[@]}" >>"$LOG_FILE" 2>&1
   else
     echo "Skip:   $TEST_LOG_NAME ($NUM_RANKS greater than $NUM_GPUS)"
   fi
@@ -220,9 +231,22 @@ ExecTest() {
   if [ $? -ne 0 ]
   then
     echo -e "$PRETTY_FAILED: $TEST_LOG_NAME" >&2
-    cat "$LOG_DIR/$TEST_LOG_NAME.log"
+    cat "$LOG_FILE"
     DRIVER_RETURN_STATUS=1
-    FAILED_LIST="$FAILED_LIST $TEST_LOG_NAME"
+    if [ $IS_RETRY -eq 0 ]; then
+      # Track failed tests with their parameters for potential retry
+      FAILED_LIST="$FAILED_LIST $TEST_LOG_NAME"
+      FAILED_TESTS+=("$TEST_NAME|$NUM_RANKS|$NUM_WG|$NUM_THREADS|$MAX_MSG_SIZE")
+    else
+      # Track tests that failed even after retry
+      RETRY_FAILED_LIST="$RETRY_FAILED_LIST $TEST_LOG_NAME"
+    fi
+  else
+    # If this was a retry and it passed, remove from failed list
+    if [ $IS_RETRY -eq 1 ]; then
+      echo -e "$PRETTY_PASSED: $TEST_LOG_NAME (passed on retry)"
+      RETRY_PASSED_LIST="$RETRY_PASSED_LIST $TEST_LOG_NAME"
+    fi
   fi
 
   unset ROCSHMEM_MAX_NUM_CONTEXTS
@@ -595,12 +619,52 @@ ValidateLogDir() {
   fi
 }
 
+RerunFailedTests() {
+  if [ ${#FAILED_TESTS[@]} -eq 0 ]; then
+    return
+  fi
+
+  echo ""
+  echo "========================================================================"
+  echo "Rerunning ${#FAILED_TESTS[@]} failed test(s)..."
+  echo "========================================================================"
+  echo ""
+
+  # Clear the driver return status for retry
+  DRIVER_RETURN_STATUS=0
+  RETRY_FAILED_LIST=""
+  RETRY_PASSED_LIST=""
+
+  # Rerun each failed test
+  for test_params in "${FAILED_TESTS[@]}"; do
+    IFS='|' read -r test_name num_ranks num_wg num_threads max_msg_size <<< "$test_params"
+    ExecTest "$test_name" "$num_ranks" "$num_wg" "$num_threads" "$max_msg_size" 1
+  done
+
+  echo ""
+  echo "========================================================================"
+  echo "Retry Summary"
+  echo "========================================================================"
+
+  if [[ -n "$RETRY_PASSED_LIST" ]]; then
+    echo -e "$PRETTY_PASSED on retry:$RETRY_PASSED_LIST"
+  fi
+
+  if [[ -n "$RETRY_FAILED_LIST" ]]; then
+    echo -e "$PRETTY_FAILED even after retry:$RETRY_FAILED_LIST"
+  fi
+
+  echo ""
+}
+
 APP=$1
 TEST=$2
 LOG_DIR=$3
 HOSTFILE=$4
 
 DRIVER_RETURN_STATUS=0
+FAILED_TESTS=()  # Array to store failed test parameters
+RETRY_THRESHOLD=${RETRY_THRESHOLD:-5}  # Maximum number of failed tests to retry (can be overridden via env var)
 
 ValidateInput $#
 ValidateLogDir $LOG_DIR
@@ -658,9 +722,33 @@ case $TEST in
 esac
 
 EXIT_STATUS=$(($DRIVER_RETURN_STATUS || $?))
+
+# If there were failures, try to rerun them once (only if below threshold)
+if [ $EXIT_STATUS -ne 0 ] && [ ${#FAILED_TESTS[@]} -gt 0 ]; then
+  if [ ${#FAILED_TESTS[@]} -le $RETRY_THRESHOLD ]; then
+    RerunFailedTests
+    EXIT_STATUS=$(($DRIVER_RETURN_STATUS || $?))
+  else
+    echo ""
+    echo "========================================================================"
+    echo "Too many test failures (${#FAILED_TESTS[@]} > $RETRY_THRESHOLD threshold)"
+    echo "Skipping retry - this may indicate a systemic issue"
+    echo "========================================================================"
+    echo ""
+  fi
+fi
+
+# Final summary
+echo ""
+echo "========================================================================"
 if [ $EXIT_STATUS -eq 0 ]; then
   echo -e "TESTS PASSED"
 else
-  echo -e "TESTS FAILED: $FAILED_LIST"
+  if [[ -n "$RETRY_FAILED_LIST" ]]; then
+    echo -e "TESTS FAILED (even after retry): $RETRY_FAILED_LIST"
+  else
+    echo -e "TESTS FAILED: $FAILED_LIST"
+  fi
 fi
+echo "========================================================================"
 exit $EXIT_STATUS


### PR DESCRIPTION
## Motivation

update the driver script to rerun failed tests once. This is guarded by the a condition to make sure that we only rerun failed tests if only something weird seems to be happening, i.e. if all tests failed, something more fundamental is broken.

Authored by Claude based on my instructions.

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
