### PR TITLE
ICD Loader: prefer vendor DLLs from OpenCL.dll's own directory

### DIFF
--- a/projects/clr/opencl/khronos/icd/loader/windows/icd_windows.c
+++ b/projects/clr/opencl/khronos/icd/loader/windows/icd_windows.c
@@ -90,6 +90,77 @@ void adapterFree(WinAdapter* pWinAdapter) {
 
 /*
  *
+ * Local library path resolution
+ *
+ */
+
+// If a DLL with the same base filename as libraryName exists in OpenCL.dll's
+// own directory, return a pointer to the local path (valid until the next call).
+// Otherwise return libraryName unchanged.
+static const char* khrIcdGetLocalLibraryPath(const char* libraryName) {
+  static char localDir[MAX_PATH] = {0};
+  static BOOL localDirResolved = FALSE;
+  static size_t localDirLen = 0;
+  static char localPath[MAX_PATH];
+
+  if (!libraryName) {
+    return libraryName;
+  }
+
+  // Resolve OpenCL.dll's directory once.
+  if (!localDirResolved) {
+    HMODULE hSelf = NULL;
+    if (GetModuleHandleExA(
+            GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS |
+                GET_MODULE_HANDLE_EX_FLAG_UNCHANGED_REFCOUNT,
+            (LPCSTR)&khrIcdGetLocalLibraryPath, &hSelf)) {
+      DWORD pathLen = GetModuleFileNameA(hSelf, localDir, MAX_PATH);
+      if (pathLen > 0 && pathLen < MAX_PATH) {
+        // Strip the filename to get the directory (keep trailing backslash).
+        char* lastSlash = strrchr(localDir, '\\');
+        if (lastSlash) {
+          *(lastSlash + 1) = '\0';
+          localDirLen = (size_t)(lastSlash + 1 - localDir);
+        }
+      }
+    }
+    localDirResolved = TRUE;
+  }
+
+  if (localDirLen == 0) {
+    return libraryName;
+  }
+
+  // Extract base filename from libraryName (strip directory prefix).
+  const char* baseName = libraryName;
+  const char* c;
+  for (c = libraryName; *c; ++c) {
+    if (*c == '\\' || *c == '/') {
+      baseName = c + 1;
+    }
+  }
+
+  if (*baseName == '\0') {
+    return libraryName;
+  }
+
+  // Construct <OpenCL.dll dir>\<baseName> and check if it exists.
+  if (localDirLen + strlen(baseName) >= MAX_PATH) {
+    return libraryName;
+  }
+  memcpy(localPath, localDir, localDirLen);
+  strcpy(localPath + localDirLen, baseName);
+
+  if (GetFileAttributesA(localPath) != INVALID_FILE_ATTRIBUTES) {
+    KHR_ICD_TRACE("Preferring local library %s over %s\n", localPath, libraryName);
+    return localPath;
+  }
+
+  return libraryName;
+}
+
+/*
+ *
  * Vendor enumeration functions
  *
  */
@@ -170,7 +241,7 @@ BOOL CALLBACK khrIcdOsVendorsEnumerate(PINIT_ONCE InitOnce, PVOID Parameter, PVO
                  ++iterAdapter) {
               if (iterAdapter->luid.LowPart == AdapterDesc.AdapterLuid.LowPart &&
                   iterAdapter->luid.HighPart == AdapterDesc.AdapterLuid.HighPart) {
-                khrIcdVendorAdd(iterAdapter->szName);
+                khrIcdVendorAdd(khrIcdGetLocalLibraryPath(iterAdapter->szName));
                 break;
               }
             }
@@ -187,7 +258,7 @@ BOOL CALLBACK khrIcdOsVendorsEnumerate(PINIT_ONCE InitOnce, PVOID Parameter, PVO
   // Go through the list again, putting any remaining adapters at the end of the list in an
   // undefined order
   for (WinAdapter* iterAdapter = pWinAdapterBegin; iterAdapter != pWinAdapterEnd; ++iterAdapter) {
-    khrIcdVendorAdd(iterAdapter->szName);
+    khrIcdVendorAdd(khrIcdGetLocalLibraryPath(iterAdapter->szName));
     adapterFree(iterAdapter);
   }
 

--- a/projects/clr/opencl/khronos/icd/test/CMakeLists.txt
+++ b/projects/clr/opencl/khronos/icd/test/CMakeLists.txt
@@ -5,3 +5,8 @@ add_subdirectory (driver_stub)
 add_subdirectory (loader_test)
 
 add_test (NAME opencl_icd_loader_test COMMAND icd_loader_test)
+
+if (WIN32)
+    add_subdirectory (local_path_test)
+    add_test (NAME opencl_icd_local_path_test COMMAND icd_local_path_test)
+endif ()

--- a/projects/clr/opencl/khronos/icd/test/CMakeLists.txt
+++ b/projects/clr/opencl/khronos/icd/test/CMakeLists.txt
@@ -6,7 +6,8 @@ add_subdirectory (loader_test)
 
 add_test (NAME opencl_icd_loader_test COMMAND icd_loader_test)
 
-if (WIN32)
+if (WIN32 AND BUILD_TESTS)
     add_subdirectory (local_path_test)
     add_test (NAME opencl_icd_local_path_test COMMAND icd_local_path_test)
+    install (TARGETS icd_local_path_test RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
 endif ()

--- a/projects/clr/opencl/khronos/icd/test/local_path_test/CMakeLists.txt
+++ b/projects/clr/opencl/khronos/icd/test/local_path_test/CMakeLists.txt
@@ -1,0 +1,1 @@
+add_executable (icd_local_path_test test_local_path.c)

--- a/projects/clr/opencl/khronos/icd/test/local_path_test/test_local_path.c
+++ b/projects/clr/opencl/khronos/icd/test/local_path_test/test_local_path.c
@@ -1,0 +1,199 @@
+/* Copyright(C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * Smoke test for the local-library-path resolution logic used by the
+ * ICD Loader on Windows (khrIcdGetLocalLibraryPath in icd_windows.c).
+ *
+ * The test uses the executable's own directory as a stand-in for
+ * OpenCL.dll's directory:
+ *   - creates a dummy file there,
+ *   - verifies that basename extraction, path construction, and the
+ *     GetFileAttributesA existence check produce correct results,
+ *   - cleans up.
+ *
+ * No registry access is required.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <windows.h>
+
+static int g_failures = 0;
+static int g_passes   = 0;
+
+static void check(int cond, const char *description) {
+    if (cond) {
+        printf("  PASS: %s\n", description);
+        ++g_passes;
+    } else {
+        printf("  FAIL: %s\n", description);
+        ++g_failures;
+    }
+}
+
+/* ------------------------------------------------------------------ */
+/* Replicates the basename-extraction loop from                        */
+/* khrIcdGetLocalLibraryPath (icd_windows.c).                          */
+/* ------------------------------------------------------------------ */
+static const char *extractBaseName(const char *libraryName) {
+    const char *baseName = libraryName;
+    const char *c;
+    for (c = libraryName; *c; ++c) {
+        if (*c == '\\' || *c == '/') {
+            baseName = c + 1;
+        }
+    }
+    return baseName;
+}
+
+/* ------------------------------------------------------------------ */
+/* Replicates the "construct local path and check existence" portion.   */
+/* dir       – directory with trailing backslash                       */
+/* dirLen    – strlen(dir)                                             */
+/* inputPath – full path as it would come from the registry            */
+/* Returns 1 if a local copy exists, 0 otherwise.                      */
+/* outPath receives the constructed path (must be MAX_PATH bytes).     */
+/* ------------------------------------------------------------------ */
+static int resolveLocalPath(const char *dir, size_t dirLen,
+                            const char *inputPath, char *outPath) {
+    const char *baseName = extractBaseName(inputPath);
+
+    if (*baseName == '\0')
+        return 0;
+
+    if (dirLen + strlen(baseName) >= MAX_PATH)
+        return 0;
+
+    memcpy(outPath, dir, dirLen);
+    strcpy(outPath + dirLen, baseName);
+
+    return GetFileAttributesA(outPath) != INVALID_FILE_ATTRIBUTES;
+}
+
+/* ------------------------------------------------------------------ */
+/* Tests                                                               */
+/* ------------------------------------------------------------------ */
+
+static void test_basename_extraction(void) {
+    printf("basename extraction:\n");
+
+    check(strcmp(extractBaseName("C:\\Windows\\System32\\vendor.dll"),
+                "vendor.dll") == 0,
+          "backslash path");
+
+    check(strcmp(extractBaseName("C:/unix/style/vendor.dll"),
+                "vendor.dll") == 0,
+          "forward-slash path");
+
+    check(strcmp(extractBaseName("C:\\mixed/slashes\\vendor.dll"),
+                "vendor.dll") == 0,
+          "mixed separators");
+
+    check(strcmp(extractBaseName("vendor.dll"),
+                "vendor.dll") == 0,
+          "bare filename (no directory)");
+
+    check(*extractBaseName("C:\\trailing\\") == '\0',
+          "trailing backslash yields empty basename");
+
+    check(*extractBaseName("") == '\0',
+          "empty string yields empty basename");
+}
+
+static void test_local_resolution(const char *exeDir, size_t exeDirLen,
+                                  const char *dummyFileName) {
+    char resolved[MAX_PATH];
+    char inputFull[MAX_PATH];
+
+    printf("local path resolution:\n");
+
+    /* File that EXISTS in the exe directory. */
+    snprintf(inputFull, MAX_PATH,
+             "C:\\DriverStore\\SomeVendor\\%s", dummyFileName);
+    check(resolveLocalPath(exeDir, exeDirLen, inputFull, resolved) == 1,
+          "local copy found when file exists");
+
+    /* The resolved path must point into exeDir. */
+    check(strncmp(resolved, exeDir, exeDirLen) == 0,
+          "resolved path starts with exe directory");
+    check(strcmp(resolved + exeDirLen, dummyFileName) == 0,
+          "resolved path ends with base filename");
+
+    /* File that does NOT exist locally. */
+    check(resolveLocalPath(exeDir, exeDirLen,
+                           "C:\\no\\such\\nonexistent_98765.dll",
+                           resolved) == 0,
+          "returns 0 for nonexistent local file");
+
+    /* Empty basename (trailing separator). */
+    check(resolveLocalPath(exeDir, exeDirLen,
+                           "C:\\path\\", resolved) == 0,
+          "returns 0 for empty basename");
+
+    /* Forward-slash input with an existing local file. */
+    snprintf(inputFull, MAX_PATH,
+             "C:/unix/path/%s", dummyFileName);
+    check(resolveLocalPath(exeDir, exeDirLen, inputFull, resolved) == 1,
+          "forward-slash input still finds local copy");
+}
+
+static void test_max_path_guard(const char *exeDir, size_t exeDirLen) {
+    char resolved[MAX_PATH];
+    char longInput[MAX_PATH + 64];
+
+    printf("MAX_PATH overflow guard:\n");
+
+    /* Construct a basename that, combined with exeDir, exceeds MAX_PATH. */
+    size_t need = MAX_PATH - exeDirLen + 1;   /* guaranteed overflow */
+    memset(longInput, 'x', need);
+    memcpy(longInput + need - 4, ".dll", 4);
+    longInput[need] = '\0';
+
+    check(resolveLocalPath(exeDir, exeDirLen, longInput, resolved) == 0,
+          "overlong basename rejected");
+}
+
+/* ------------------------------------------------------------------ */
+
+int main(void) {
+    /* Determine this executable's directory (stand-in for OpenCL.dll dir). */
+    char exeDir[MAX_PATH] = {0};
+    DWORD pathLen = GetModuleFileNameA(NULL, exeDir, MAX_PATH);
+    if (pathLen == 0 || pathLen >= MAX_PATH) {
+        printf("FATAL: cannot determine exe directory\n");
+        return 1;
+    }
+    char *lastSlash = strrchr(exeDir, '\\');
+    if (!lastSlash) {
+        printf("FATAL: exe path has no backslash\n");
+        return 1;
+    }
+    *(lastSlash + 1) = '\0';
+    size_t exeDirLen = (size_t)(lastSlash + 1 - exeDir);
+
+    /* Create a dummy file to simulate a vendor DLL placed alongside OpenCL.dll. */
+    const char *dummyName = "icd_test_local_dummy.dll";
+    char dummyPath[MAX_PATH];
+    snprintf(dummyPath, MAX_PATH, "%s%s", exeDir, dummyName);
+
+    HANDLE hFile = CreateFileA(dummyPath, GENERIC_WRITE, 0, NULL,
+                               CREATE_ALWAYS, FILE_ATTRIBUTE_NORMAL, NULL);
+    if (hFile == INVALID_HANDLE_VALUE) {
+        printf("FATAL: cannot create dummy file %s (error %lu)\n",
+               dummyPath, GetLastError());
+        return 1;
+    }
+    CloseHandle(hFile);
+
+    /* Run tests. */
+    test_basename_extraction();
+    test_local_resolution(exeDir, exeDirLen, dummyName);
+    test_max_path_guard(exeDir, exeDirLen);
+
+    /* Cleanup. */
+    DeleteFileA(dummyPath);
+
+    printf("\n%d passed, %d failed\n",
+           g_passes, g_failures);
+    return g_failures == 0 ? 0 : 1;
+}


### PR DESCRIPTION
## Motivation

When the ICD Loader enumerates vendor DLLs via the registry, the paths typically point to a system directory (DriverStore or System32). This makes it such that a local amdocl64.dll is ignored by OpenCL.dll.

This change is necessary for OpenCL support through TheRock-based builds.

## Technical Details

Add `khrIcdGetLocalLibraryPath()` which resolves OpenCL.dll's directory at the first call, then for each vendor DLL checks whether a file with the same base name exists locally. If so, the local path is passed to `khrIcdVendorAdd` instead of the registry path. This keeps `khrIcdVendorAdd` and `khrIcdOsLibraryLoad` completely unchanged.

## JIRA ID

N/A

## Test Plan

Add a standalone Windows-only CTest (`icd_local_path_test`) that exercises the basename-extraction, path-construction, and file-existence-check logic used by `khrIcdGetLocalLibraryPath`.

The test uses the executable's own directory as a stand-in for OpenCL.dll's directory, creates a dummy file, verifies the resolution logic, and cleans up.  No registry access is needed.

## Test Result

Passing tests.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
