### PR TITLE
[AINIC] Add per-connection CTS offload control and P2P CTS disable

### DIFF
--- a/projects/rccl/CHANGELOG.md
+++ b/projects/rccl/CHANGELOG.md
@@ -9,11 +9,16 @@ Full documentation for RCCL is available at [https://rccl.readthedocs.io](https:
 * ROCTx feature needs to be verified.
 * Profiler plugin needs to be verified.
 
+### Added
+* Added `RCCL_IB_P2P_DISABLE_CTS` to disable CTS offload for P2P connections on AINIC. Defaults to 1 (disabled). When `RCCL_CTS_OFFLOAD_ENABLED=1` is explicitly set, it overrides this flag and forces CTS on all connections including P2P.
+* Merged `RCCL_CTS_INLINE_DATA` into `RCCL_CTS_OFFLOAD_ENABLED`. CTS offload and CTS inline data are now controlled by a single tri-state variable: `-1` (default, auto-enable on AINIC), `0` (force disable), `1` (force enable for all connections).
+
 ### Changed
 * Compatibility with NCCL 2.28.3.
 * The MSCCL feature is now disabled by default. The `--disable-msccl-kernel` build flag is replaced with `--enable-msccl-kernel` in the `rccl/install.sh` script.
 * MSCCL and NPKIT are deprecated and will be removed in a future release of RCCL.
 * Changed GPU Direct RDMA mode selection logic to prefer peermem over DMAbuf by default. `NCCL_DMABUF_ENABLE` now defaults to 1 (previously 0). When both peermem and DMAbuf are available, RCCL will use peermem. If peermem is unavailable, RCCL will automatically fall back to DMAbuf (if available and enabled). Setting `RCCL_FORCE_ENABLE_DMABUF=1` forces DMAbuf usage exclusively, skipping peermem even if available, and disables GPU Direct RDMA if DMAbuf is unavailable.
+* CTS offload is now controlled per-connection rather than globally, allowing P2P connections to fall back to standard RDMA writes while non-P2P traffic continues to use CTS.
 
 ### Resolved Issues
 * Fixed MSCCLPP_ENABLE_CLIP CMake build flag, which was not being properly honored.

--- a/projects/rccl/ext-src/rocm_netib.patch
+++ b/projects/rccl/ext-src/rocm_netib.patch
@@ -1,4 +1,3 @@
-diff --git a/src/transport/net_ib.cc b/src/transport/net_ib.cc
 --- a/src/transport/net_ib.cc
 +++ b/src/transport/net_ib.cc
 @@ -29,6 +29,7 @@
@@ -9,12 +8,11 @@ diff --git a/src/transport/net_ib.cc b/src/transport/net_ib.cc
  #include "graph/xml.h"
  
  #define MAXSUFFIXSIZE 16
-@@ -110,6 +111,26 @@ struct ncclIbMergedDev ncclIbMergedDevs[
+@@ -110,6 +111,25 @@
  struct ncclIbDev ncclIbDevs[MAX_IB_DEVS];
  static std::mutex ncclIbMutex;
  static int ncclIbRelaxedOrderingEnabled = 0;
 +static bool rcclAinicRoce = 0;
-+static bool rcclCtsInlineData = 0;
 +static bool rcclCtsOffloadEnabled = 0;
 +static bool ncclIbUseInline = 0;
 +static int ncclIbGdrFlushDisable = 0;
@@ -36,7 +34,7 @@ diff --git a/src/transport/net_ib.cc b/src/transport/net_ib.cc
  
  // With ncclNet_v11_t the NCCL core initializes the network plugin per-communicator
  // rather than once for all communicators. However, the internal plugin implementation
-@@ -120,6 +141,8 @@ static int netRefCount;
+@@ -120,6 +140,8 @@
  
  #define NCCL_IB_LLSTR(ll) (((ll) == IBV_LINK_LAYER_INFINIBAND) ? "IB" : (((ll) == IBV_LINK_LAYER_ETHERNET) ? "RoCE" : "UNSPECIFIED"))
  
@@ -45,22 +43,25 @@ diff --git a/src/transport/net_ib.cc b/src/transport/net_ib.cc
  #define NCCL_IB_SL_DEFAULT 0
  #define NCCL_IB_TC_DEFAULT 0
  
-@@ -141,6 +164,13 @@ NCCL_PARAM(IbEceEnable,"IB_ECE_ENABLE",1
+@@ -141,6 +163,17 @@
  NCCL_PARAM(IbDataDirect,"IB_DATA_DIRECT",1);
  NCCL_PARAM(IbQpsPerConn, "IB_QPS_PER_CONNECTION", 1);
  RCCL_PARAM(IbQpsPerP2p, "IB_QPS_PER_P2P", 0);
 +NCCL_PARAM(IbGdrFlushDisable, "GDR_FLUSH_DISABLE", 0);
 +
 +// AMD AINIC
-+RCCL_PARAM(CtsInlineData, "CTS_INLINE_DATA", -1);
 +RCCL_PARAM(CtsOffloadEnabled, "CTS_OFFLOAD_ENABLED", -1);
++RCCL_PARAM(IbP2pDisableCts, "IB_P2P_DISABLE_CTS", 0);
 +
 +extern int64_t rcclParamAinicRoce();
++
++static inline bool rcclIsCtsOffloadEnabled(int isP2p) {
++  return rcclCtsOffloadEnabled && !(isP2p && rcclParamIbP2pDisableCts());
++}
  
  static ncclResult_t ncclIbStatsInit(struct ncclIbStats* stat) {
    __atomic_store_n(&stat->fatalErrorCount, 0, __ATOMIC_RELAXED);
-@@ -773,8 +804,22 @@ ncclResult_t ncclIbMakeVDeviceInternal(i
-           dev0->devName, root0, dev->devName, root_i);
+@@ -774,6 +807,16 @@
        break;
      }
    }
@@ -68,10 +69,6 @@ diff --git a/src/transport/net_ib.cc b/src/transport/net_ib.cc
 +  // CTS Offload and CTS Inline are not yet compatible with NIC Fusion
 +  // (NCCL_IB_MERGE_NICS). Disable them when a multi-NIC vNIC is created.
 +  if (tmp.vProps.ndevs > 1) {
-+    if (rcclCtsInlineData) {
-+      INFO(NCCL_INIT|NCCL_NET, "NET/IB : NIC Fusion (ndevs=%d) - disabling CTS Inline Data (not yet supported with merge)", tmp.vProps.ndevs);
-+      rcclCtsInlineData = false;
-+    }
 +    if (rcclCtsOffloadEnabled) {
 +      INFO(NCCL_INIT|NCCL_NET, "NET/IB : NIC Fusion (ndevs=%d) - disabling CTS Offload (not yet supported with merge)", tmp.vProps.ndevs);
 +      rcclCtsOffloadEnabled = false;
@@ -81,8 +78,7 @@ diff --git a/src/transport/net_ib.cc b/src/transport/net_ib.cc
    ncclIbMergedDevs[ncclNMergedIbDevs] = tmp;
    *d = ncclNMergedIbDevs++;
    INFO(NCCL_NET, "NET/IB : Made virtual device [%d] name=%s speed=%d ndevs=%d", *d, tmp.devName, tmp.speed, tmp.vProps.ndevs);
-   return ncclSuccess;
-@@ -779,6 +822,10 @@ ncclResult_t ncclIbInit(void** ctx, uint
+@@ -803,6 +846,10 @@
    static int shownIbHcaEnv = 0;
    if(wrap_ibv_symbols() != ncclSuccess) { return ncclInternalError; }
    if(wrap_mlx5dv_symbols() != ncclSuccess) { INFO(NCCL_NET, "NET/IB : Failed to open mlx5dv symbols. Advance features like CX-8 Direct-NIC will be disabled."); }
@@ -93,7 +89,7 @@ diff --git a/src/transport/net_ib.cc b/src/transport/net_ib.cc
  
    // Detect IB cards
    int nIbDevs = 0;
-@@ -944,6 +991,37 @@ ncclResult_t ncclIbInit(void** ctx, uint
+@@ -966,6 +1013,26 @@
      INFO(NCCL_INIT|NCCL_NET, "NET/IB : Using%s %s; OOB %s:%s", line, ncclIbRelaxedOrderingEnabled ? "[RO]" : "",
            ncclIbIfName, ncclSocketToString(&ncclIbIfAddr, addrline));
  
@@ -103,35 +99,24 @@ diff --git a/src/transport/net_ib.cc b/src/transport/net_ib.cc
 +    rcclAinicRoce = (rcclUseAinic() ? true : false);
 +    if (rcclAinicRoce) {
 +      // for AINIC, these params are defaulted to enabled unless user forces it to disable(0).
-+      rcclCtsInlineData = ((rcclParamCtsInlineData() == 0) ? false : true);
++      // RCCL_CTS_OFFLOAD_ENABLED controls both CTS offload and CTS inline data.
++      // Default (-1) auto-enables on AINIC. Set to 0 to disable, 1 to force enable.
 +      rcclCtsOffloadEnabled = ((rcclParamCtsOffloadEnabled() == 0) ? false : true);
-+
-+      // CTS Offload and CTS Inline are mutually dependent — both must be
-+      // enabled for either to function. Disable both if either is missing.
-+      if (!rcclCtsOffloadEnabled || !rcclCtsInlineData) {
-+        if (rcclCtsOffloadEnabled) {
-+          INFO(NCCL_INIT|NCCL_NET, "NET/IB : CTS Inline disabled - disabling CTS Offload (requires CTS Inline)");
-+        }
-+        if (rcclCtsInlineData) {
-+          INFO(NCCL_INIT|NCCL_NET, "NET/IB : CTS Offload disabled - disabling CTS Inline (requires CTS Offload)");
-+        }
-+        rcclCtsOffloadEnabled = false;
-+        rcclCtsInlineData = false;
-+      }
 +
 +      // for AINIC IbUseInline is enabled by default always
 +      ncclIbUseInline = true;
 +      // for AINIC GDR flush is disabled by default
 +      ncclIbGdrFlushDisable = 1;
 +
-+      INFO(NCCL_INIT|NCCL_NET, "NET/IB : AINIC RoCEv2 optimizations enabled: CTS Inline Data: %s; CTS Offload: %s; "
-+           "IB Use Inline: enabled; GDR Flush: disabled", rcclCtsInlineData ? "Enabled": "Disabled",
-+           rcclCtsOffloadEnabled ? "Enabled": "Disabled");
++      INFO(NCCL_INIT|NCCL_NET, "NET/IB : AINIC RoCEv2 optimizations enabled: CTS Offload: %s; "
++           "IB Use Inline: enabled; GDR Flush: disabled; IB P2P Disable CTS: %s",
++           rcclCtsOffloadEnabled ? "Enabled": "Disabled",
++           rcclParamIbP2pDisableCts() ? "Yes" : "No");
 +    }
    }
  exit:
    ibContext.trafficClass = config->trafficClass;
-@@ -1280,6 +1358,8 @@ struct ncclIbListenComm {
+@@ -1302,6 +1369,8 @@
    struct ncclIbCommStage stage;
  };
  
@@ -140,7 +125,7 @@ diff --git a/src/transport/net_ib.cc b/src/transport/net_ib.cc
  struct alignas(64) ncclIbSendFifo {
    uint64_t addr;
    uint64_t size;
-@@ -1290,10 +1370,21 @@ struct alignas(64) ncclIbSendFifo {
+@@ -1312,10 +1381,21 @@
    char padding[16];
  };
  
@@ -162,7 +147,7 @@ diff --git a/src/transport/net_ib.cc b/src/transport/net_ib.cc
  };
  
  struct ncclIbRemSizesFifo {
-@@ -1340,6 +1431,7 @@ struct ncclIbSendComm {
+@@ -1362,6 +1442,7 @@
    struct ncclIbNetCommBase base;
    // Start with fifo and ibv structs as they have alignment restrictions
    struct ncclIbSendFifo fifo[MAX_REQUESTS][NCCL_NET_IB_MAX_RECVS];
@@ -170,7 +155,15 @@ diff --git a/src/transport/net_ib.cc b/src/transport/net_ib.cc
    struct ibv_sge sges[NCCL_NET_IB_MAX_RECVS];
    struct ibv_send_wr wrs[NCCL_NET_IB_MAX_RECVS + 1];
    // Each dev correlates to a mergedIbDev
-@@ -1355,6 +1447,7 @@ struct ncclIbSendComm {
+@@ -1370,6 +1451,7 @@
+   struct ncclIbRemSizesFifo remSizesFifo;
+   uint64_t fifoHead;
+   int ar; // Use adaptive routing when all merged devices have it enabled
++  bool useCtsOffload;
+ };
+ // The SendFifo needs to be 32-byte aligned and each element needs
+ // to be a 32-byte multiple, so that an entry does not get split and
+@@ -1377,6 +1459,7 @@
  static_assert((sizeof(struct ncclIbNetCommBase) % 32) == 0, "ncclIbNetCommBase size must be 32-byte multiple to ensure fifo is at proper offset");
  static_assert((offsetof(struct ncclIbSendComm, fifo) % 32) == 0, "ncclIbSendComm fifo must be 32-byte aligned");
  static_assert((sizeof(struct ncclIbSendFifo) % 32) == 0, "ncclIbSendFifo element size must be 32-byte multiples");
@@ -178,7 +171,7 @@ diff --git a/src/transport/net_ib.cc b/src/transport/net_ib.cc
  static_assert((offsetof(struct ncclIbSendComm, sges) % 32) == 0, "sges must be 32-byte aligned");
  static_assert((offsetof(struct ncclIbSendComm, wrs) % 32) == 0, "wrs must be 32-byte aligned");
  
-@@ -1369,6 +1462,7 @@ struct ncclIbGpuFlush {
+@@ -1391,6 +1474,7 @@
  
  struct ncclIbRemFifo {
    struct ncclIbSendFifo elems[MAX_REQUESTS][NCCL_NET_IB_MAX_RECVS];
@@ -186,14 +179,23 @@ diff --git a/src/transport/net_ib.cc b/src/transport/net_ib.cc
    uint64_t fifoTail;
    uint64_t addr;
    uint32_t flags;
-@@ -1424,20 +1518,59 @@ ncclResult_t ncclIbDestroyBase(struct nc
+@@ -1411,6 +1495,7 @@
+   int sizesFifo[MAX_REQUESTS][NCCL_NET_IB_MAX_RECVS];
+   int gpuFlushHostMem;
+   int flushEnabled;
++  bool useCtsOffload;
+ };
+ static_assert((offsetof(struct ncclIbRecvComm, remFifo) % 32) == 0, "ncclIbRecvComm fifo must be 32-byte aligned");
+ 
+@@ -1446,20 +1531,60 @@
    return ncclSuccess;
  }
  
 -ncclResult_t ncclIbCreateQp(uint8_t ib_port, struct ncclIbNetCommDevBase* base, int access_flags, void* qp_context, struct ncclIbQp* qp) {
 +ncclResult_t ncclIbCreateQp(uint8_t ib_port, struct ncclIbNetCommDevBase* base,
 +                            int access_flags, void* qp_context, struct ncclIbQp* qp,
-+                            int channel_id, bool data_qp, int8_t cts_qp_slot) {
++                            int channel_id, bool data_qp, int8_t cts_qp_slot,
++                            int isP2p = 0) {
    struct ibv_qp_init_attr qpInitAttr;
 +  enum ncclIbChannelType channel_type = (data_qp ? ncclIbChannelTypeData : ncclIbChannelTypeCts);
    memset(&qpInitAttr, 0, sizeof(struct ibv_qp_init_attr));
@@ -202,6 +204,7 @@ diff --git a/src/transport/net_ib.cc b/src/transport/net_ib.cc
    qpInitAttr.recv_cq = base->cq;
    qpInitAttr.qp_type = IBV_QPT_RC;
 +
++  bool qpCtsOffload = rcclIsCtsOffloadEnabled(isP2p);
 +  if (rcclAinicRoce) {
 +    if (!nccl_channel_ud_map[base->ibDevN][channel_id][channel_type].udAllocated) {
 +      bool lud = nccl_channel_last_ud[base->ibDevN][channel_type];
@@ -223,20 +226,19 @@ diff --git a/src/transport/net_ib.cc b/src/transport/net_ib.cc
 +    }
 +    qpInitAttr.sq_sig_all |= (1 << 18);
 +
-+    if (rcclCtsOffloadEnabled) {
++    if (qpCtsOffload) {
 +      qpInitAttr.sq_sig_all |= (1 << 19);
 +    } else {
 +      qpInitAttr.sq_sig_all &= (~(1 << 19));
 +    }
 +  }
-+
    // We might send 2 messages per send (RDMA and RDMA_WITH_IMM)
    qpInitAttr.cap.max_send_wr = 2*MAX_REQUESTS;
    qpInitAttr.cap.max_recv_wr = MAX_REQUESTS;
    qpInitAttr.cap.max_send_sge = 1;
    qpInitAttr.cap.max_recv_sge = 1;
 -  qpInitAttr.cap.max_inline_data = ncclParamIbUseInline() ? sizeof(struct ncclIbSendFifo) : 0;
-+  if (rcclCtsInlineData) {
++  if (qpCtsOffload) {
 +    qpInitAttr.cap.max_inline_data = MAX_INLINE_DATA_SIZE;
 +  } else {
 +    qpInitAttr.cap.max_inline_data = ncclIbUseInline ? sizeof(struct ncclIbSendFifo) : 0;
@@ -248,7 +250,7 @@ diff --git a/src/transport/net_ib.cc b/src/transport/net_ib.cc
    struct ibv_qp_attr qpAttr;
    memset(&qpAttr, 0, sizeof(struct ibv_qp_attr));
    qpAttr.qp_state = IBV_QPS_INIT;
-@@ -1447,6 +1580,9 @@ ncclResult_t ncclIbCreateQp(uint8_t ib_p
+@@ -1469,6 +1594,9 @@
    NCCLCHECK(wrap_ibv_modify_qp(qp->qp, &qpAttr, IBV_QP_STATE | IBV_QP_PKEY_INDEX | IBV_QP_PORT | IBV_QP_ACCESS_FLAGS));
    TRACE(NCCL_NET, "NET/IB : ncclIbCreateQp port=%d dev=%d devName=%s ndevs=%d nmdevs=%d qpn=%u pkey=%u pd=%p",
      ib_port, base->ibDevN, ncclIbDevs[base->ibDevN].devName, ncclNIbDevs, ncclNMergedIbDevs, qp->qp->qp_num, qpAttr.pkey_index, base->pd);
@@ -258,7 +260,7 @@ diff --git a/src/transport/net_ib.cc b/src/transport/net_ib.cc
    return ncclSuccess;
  }
  
-@@ -1530,16 +1666,21 @@ fail:
+@@ -1552,16 +1680,21 @@
    goto exit;
  }
  
@@ -282,21 +284,31 @@ diff --git a/src/transport/net_ib.cc b/src/transport/net_ib.cc
    if (stage->state == ncclIbCommStateConnect)      goto ib_connect_check;
    if (stage->state == ncclIbCommStateSendDevList)  goto ib_send_dev_list;
    if (stage->state == ncclIbCommStateRecvDevList)  goto ib_recv_dev_list;
-@@ -1621,7 +1762,7 @@ ib_recv_dev_list:
+@@ -1622,7 +1755,8 @@
+ 
+   // Read isP2p from handle
+   isP2p = handle->isP2p;
+-  INFO(NCCL_NET, "NET/IB: ncclIbConnect isP2p=%d", isP2p);
++  comm->useCtsOffload = rcclIsCtsOffloadEnabled(isP2p);
++  INFO(NCCL_NET, "NET/IB: ncclIbConnect isP2p=%d useCtsOffload=%d (IbP2pDisableCts=%ld)", isP2p, comm->useCtsOffload, rcclParamIbP2pDisableCts());
+   comm->base.nqps = ncclIbCalculateNqps(isP2p, comm->base.vProps.ndevs, 
+                                          remoteVProps.ndevs, __func__);
+ 
+@@ -1643,7 +1777,7 @@
    for (int q = 0; q < comm->base.nqps; q++) {
      ncclIbSendCommDev* commDev = comm->devs + devIndex;
      ncclIbDev* ibDev = ncclIbDevs + commDev->base.ibDevN;
 -    NCCLCHECKGOTO(ncclIbCreateQp(ibDev->portNum, &commDev->base, IBV_ACCESS_REMOTE_WRITE, &comm->base.stats, comm->base.qps + q), ret, fail);
-+    NCCLCHECKGOTO(ncclIbCreateQp(ibDev->portNum, &commDev->base, IBV_ACCESS_REMOTE_WRITE, &comm->base.stats, comm->base.qps + q, channel_id, true, NCCL_CTS_QP_SLOT_INVALID), ret, fail);
++    NCCLCHECKGOTO(ncclIbCreateQp(ibDev->portNum, &commDev->base, IBV_ACCESS_REMOTE_WRITE, &comm->base.stats, comm->base.qps + q, channel_id, true, NCCL_CTS_QP_SLOT_INVALID, isP2p), ret, fail);
      comm->base.qps[q].devIndex = devIndex;
      meta.qpInfo[q].qpn      = comm->base.qps[q].qp->qp_num;
      meta.qpInfo[q].devIndex = comm->base.qps[q].devIndex;
-@@ -1646,7 +1787,11 @@ ib_recv_dev_list:
+@@ -1668,7 +1802,11 @@
      devInfo->lid           = ibDev->portAttr.lid;
      devInfo->ibv_dev_index = commDev->base.ibDevN;
      // Prepare my fifo
 -    NCCLCHECKGOTO(wrap_ibv_reg_mr(&commDev->fifoMr, commDev->base.pd, comm->fifo, sizeof(struct ncclIbSendFifo)*MAX_REQUESTS*NCCL_NET_IB_MAX_RECVS, IBV_ACCESS_LOCAL_WRITE|IBV_ACCESS_REMOTE_WRITE|IBV_ACCESS_REMOTE_READ), ret, fail);
-+    if (rcclCtsInlineData) {
++    if (comm->useCtsOffload) {
 +      NCCLCHECKGOTO(wrap_ibv_reg_mr(&commDev->fifoMr, commDev->base.pd, comm->fifo_inline, sizeof(struct ncclIbSendFifoCtsInline)*MAX_REQUESTS*NCCL_NET_IB_MAX_RECVS, IBV_ACCESS_LOCAL_WRITE|IBV_ACCESS_REMOTE_WRITE|IBV_ACCESS_REMOTE_READ), ret, fail);
 +    } else {
 +      NCCLCHECKGOTO(wrap_ibv_reg_mr(&commDev->fifoMr, commDev->base.pd, comm->fifo, sizeof(struct ncclIbSendFifo)*MAX_REQUESTS*NCCL_NET_IB_MAX_RECVS, IBV_ACCESS_LOCAL_WRITE|IBV_ACCESS_REMOTE_WRITE|IBV_ACCESS_REMOTE_READ), ret, fail);
@@ -304,12 +316,12 @@ diff --git a/src/transport/net_ib.cc b/src/transport/net_ib.cc
      devInfo->fifoRkey = commDev->fifoMr->rkey;
  
      // Pack local GID info
-@@ -1689,7 +1834,11 @@ ib_recv_dev_list:
+@@ -1711,7 +1849,11 @@
      }
    }
    config = (ncclNetCommConfig_t*)ctx;
 -  meta.fifoAddr = (uint64_t)comm->fifo;
-+  if (rcclCtsInlineData) {
++  if (comm->useCtsOffload) {
 +    meta.fifoAddr = (uint64_t)comm->fifo_inline;
 +  } else {
 +    meta.fifoAddr = (uint64_t)comm->fifo;
@@ -317,7 +329,7 @@ diff --git a/src/transport/net_ib.cc b/src/transport/net_ib.cc
    meta.sl = (ncclParamIbSl() != -1) ? ncclParamIbSl() : (config && config->trafficClass != NCCL_NET_TRAFFIC_CLASS_UNDEF) ? config->trafficClass : NCCL_IB_SL_DEFAULT;
    meta.tc = (ncclParamIbTc() != -1) ? ncclParamIbTc() : (config && config->trafficClass != NCCL_NET_TRAFFIC_CLASS_UNDEF) ? config->trafficClass : NCCL_IB_TC_DEFAULT;
    strncpy(meta.devName, mergedDev->devName, MAX_MERGED_DEV_NAME);
-@@ -1834,25 +1983,35 @@ ncclResult_t ncclIbCheckVProps(ncclNetVD
+@@ -1856,25 +1998,35 @@
    return ncclSuccess;
  }
  
@@ -356,17 +368,17 @@ diff --git a/src/transport/net_ib.cc b/src/transport/net_ib.cc
    if (stage->state == ncclIbCommStateAccept)   goto ib_accept_check;
    if (stage->state == ncclIbCommStateRecvDevList) goto ib_recv_dev_list;
    if (stage->state == ncclIbCommStateSendDevList) goto ib_send_dev_list;
-@@ -1894,7 +2053,6 @@ ib_recv_dev_list:
+@@ -1916,7 +2068,6 @@
    }
-
+ 
    // Reduce the physical device list and store in the connection base
 -  struct ncclIbMergedDev* mergedDev;
    mergedDev = ncclIbMergedDevs + lComm->dev;
    NCCLCHECK(ncclIbCheckVProps(&mergedDev->vProps, &remoteVProps));
    rComm->base.vProps = mergedDev->vProps;
-@@ -1918,13 +2076,6 @@ ib_recv:
+@@ -1940,15 +2091,10 @@
    memcpy(&remMeta, stage->buffer, sizeof(struct ncclIbConnectionMetadata));
-
+ 
    // IB setup
 -  // Pre-declare variables because of goto
 -  struct ncclIbDev* ibDev;
@@ -377,17 +389,21 @@ diff --git a/src/transport/net_ib.cc b/src/transport/net_ib.cc
 -
    mergedDev = ncclIbMergedDevs + lComm->dev;
    rComm->base.nRemDevs = remMeta.ndevs;
++  rComm->useCtsOffload = rcclIsCtsOffloadEnabled(remMeta.isP2p);
++  INFO(NCCL_NET, "NET/IB: ncclIbAccept isP2p=%d useCtsOffload=%d (IbP2pDisableCts=%ld)", remMeta.isP2p, rComm->useCtsOffload, rcclParamIbP2pDisableCts());
    rComm->base.nqps = ncclIbCalculateNqps(remMeta.isP2p, rComm->base.vProps.ndevs, 
-@@ -1981,7 +2132,7 @@ ib_recv:
+                                           remMeta.ndevs, __func__);
+   if (rComm->base.nRemDevs != rComm->base.vProps.ndevs) {
+@@ -2003,7 +2149,7 @@
      // Local ibDevN
      ibDevN = rComm->devs[devIndex].base.ibDevN;
      ibDev = ncclIbDevs + ibDevN;
 -    NCCLCHECKGOTO(ncclIbCreateQp(ibDev->portNum, &rCommDev->base, IBV_ACCESS_REMOTE_WRITE, &rComm->base.stats, qp), ret, fail);
-+    NCCLCHECKGOTO(ncclIbCreateQp(ibDev->portNum, &rCommDev->base, IBV_ACCESS_REMOTE_WRITE, &rComm->base.stats, qp, channel_id, false, q), ret, fail);
++    NCCLCHECKGOTO(ncclIbCreateQp(ibDev->portNum, &rCommDev->base, IBV_ACCESS_REMOTE_WRITE, &rComm->base.stats, qp, channel_id, false, q, remMeta.isP2p), ret, fail);
      qp->devIndex = devIndex;
      devIndex = (devIndex + 1) % rComm->base.vProps.ndevs;
  
-@@ -2035,16 +2186,22 @@ ib_recv:
+@@ -2057,16 +2203,23 @@
    }
  
    rComm->flushEnabled = ((peermemAvailable || useDmaBuf)
@@ -396,11 +412,11 @@ diff --git a/src/transport/net_ib.cc b/src/transport/net_ib.cc
    for (int i = 0; i < rComm->base.vProps.ndevs; i++) {
      rCommDev = rComm->devs + i;
      ibDev = ncclIbDevs + rCommDev->base.ibDevN;
-
+ 
      // Retain remote fifo info and prepare my RDMA ops
      rComm->remFifo.addr = remMeta.fifoAddr;
 -    NCCLCHECKGOTO(wrap_ibv_reg_mr(&rCommDev->fifoMr, rCommDev->base.pd, &rComm->remFifo.elems, sizeof(struct ncclIbSendFifo)*MAX_REQUESTS*NCCL_NET_IB_MAX_RECVS, IBV_ACCESS_REMOTE_WRITE|IBV_ACCESS_LOCAL_WRITE|IBV_ACCESS_REMOTE_READ), ret, fail);
-+    if (rcclCtsInlineData) {
++    if (rComm->useCtsOffload) {
 +      NCCLCHECKGOTO(wrap_ibv_reg_mr(&rCommDev->fifoMr, rCommDev->base.pd, &rComm->remFifo.elems_cts_inline,
 +                                    sizeof(struct ncclIbSendFifoCtsInline)*MAX_REQUESTS*NCCL_NET_IB_MAX_RECVS,
 +                                    IBV_ACCESS_REMOTE_WRITE|IBV_ACCESS_LOCAL_WRITE|IBV_ACCESS_REMOTE_READ), ret, fail);
@@ -409,11 +425,12 @@ diff --git a/src/transport/net_ib.cc b/src/transport/net_ib.cc
 +    }
      rCommDev->fifoSge.lkey = rCommDev->fifoMr->lkey;
 -    if (ncclParamIbUseInline()) rComm->remFifo.flags = IBV_SEND_INLINE;
-+    if (ncclIbUseInline) rComm->remFifo.flags = IBV_SEND_INLINE;
-
++    if (ncclIbUseInline && (!rcclAinicRoce || rComm->useCtsOffload))
++      rComm->remFifo.flags = IBV_SEND_INLINE;
+ 
      // Allocate Flush dummy buffer for GPU Direct RDMA
      if (rComm->flushEnabled) {
-@@ -2082,7 +2239,7 @@ ib_recv:
+@@ -2133,7 +2286,7 @@
        rCommDev->gpuFlush.sge.addr = (uint64_t)&rComm->gpuFlushHostMem;
        rCommDev->gpuFlush.sge.length = 1;
        rCommDev->gpuFlush.sge.lkey = rCommDev->gpuFlush.hostMr->lkey;
@@ -422,9 +439,9 @@ diff --git a/src/transport/net_ib.cc b/src/transport/net_ib.cc
        struct ncclIbDevInfo devInfo;
        devInfo.lid         = ibDev->portAttr.lid;
        devInfo.link_layer  = ibDev->portAttr.link_layer;
-@@ -2304,11 +2461,16 @@ ncclResult_t ncclIbDeregMr(void* comm, v
- 
+@@ -2356,11 +2509,16 @@
  NCCL_PARAM(IbSplitDataOnQps, "IB_SPLIT_DATA_ON_QPS", 0);
+ RCCL_PARAM(IbSplitDataThreshold, "IB_SPLIT_DATA_THRESHOLD", 128);
  
 -ncclResult_t ncclIbMultiSend(struct ncclIbSendComm* comm, int slot) {
 +ncclResult_t ncclIbMultiSend(struct ncclIbSendComm* comm, int slot, bool use_write_op) {
@@ -433,7 +450,7 @@ diff --git a/src/transport/net_ib.cc b/src/transport/net_ib.cc
    ncclResult_t ret = ncclSuccess;
 -  int nreqs = slots[0].nreqs;
 +  int nreqs;
-+  if (rcclCtsOffloadEnabled) {
++  if (comm->useCtsOffload) {
 +    nreqs = 1;
 +  } else {
 +    nreqs = slots[0].nreqs;
@@ -441,12 +458,12 @@ diff --git a/src/transport/net_ib.cc b/src/transport/net_ib.cc
    if (nreqs > NCCL_NET_IB_MAX_RECVS) return ncclInternalError;
  
    uint64_t wr_id = 0ULL;
-@@ -2320,7 +2482,11 @@ ncclResult_t ncclIbMultiSend(struct nccl
+@@ -2372,7 +2530,11 @@
      sge->addr=(uintptr_t)reqs[r]->send.data;
      wr->opcode = IBV_WR_RDMA_WRITE;
      wr->send_flags = 0;
 -    wr->wr.rdma.remote_addr = slots[r].addr;
-+    if (rcclCtsOffloadEnabled) {
++    if (comm->useCtsOffload) {
 +      wr->wr.rdma.remote_addr = 0xdeadbeef;
 +    } else {
 +      wr->wr.rdma.remote_addr = slots[r].addr;
@@ -454,7 +471,7 @@ diff --git a/src/transport/net_ib.cc b/src/transport/net_ib.cc
      wr->next = wr + 1;
      wr_id += (reqs[r] - comm->base.reqs) << (r*8);
  #ifdef NCCL_ENABLE_NET_PROFILING
-@@ -2331,7 +2497,7 @@ ncclResult_t ncclIbMultiSend(struct nccl
+@@ -2383,7 +2545,7 @@
    // Write size as immediate data. In the case of multi-send, only write
    // 0 or 1 as size to indicate whether there was data sent or received.
    uint32_t immData = 0;
@@ -463,7 +480,7 @@ diff --git a/src/transport/net_ib.cc b/src/transport/net_ib.cc
      immData = reqs[0]->send.size;
    } else {
      int* sizes = comm->remSizesFifo.elems[slot];
-@@ -2341,22 +2507,24 @@ ncclResult_t ncclIbMultiSend(struct nccl
+@@ -2393,22 +2555,24 @@
    }
  
    struct ibv_send_wr* lastWr = comm->wrs+nreqs-1;
@@ -501,20 +518,20 @@ diff --git a/src/transport/net_ib.cc b/src/transport/net_ib.cc
    lastWr->next = NULL;
    lastWr->send_flags = IBV_SEND_SIGNALED;
  
-@@ -2372,7 +2540,11 @@ ncclResult_t ncclIbMultiSend(struct nccl
+@@ -2430,7 +2594,11 @@
        //ncclIbAddEvent(reqs[r], devIndex, &comm->devs[devIndex].base);
  
        // Select proper rkey (needed even for 0-size send)
 -      comm->wrs[r].wr.rdma.rkey = slots[r].rkeys[qp->remDevIdx];
-+      if (rcclCtsOffloadEnabled) {
++      if (comm->useCtsOffload) {
 +        comm->wrs[r].wr.rdma.rkey = 0xbade;
 +      } else {
 +        comm->wrs[r].wr.rdma.rkey = slots[r].rkeys[qp->remDevIdx];
 +      }
  
-       int chunkSize = DIVUP(DIVUP(reqs[r]->send.size, nqps), align) * align;
-       int length = std::min(reqs[r]->send.size-reqs[r]->send.offset, chunkSize);
-@@ -2388,7 +2560,7 @@ ncclResult_t ncclIbMultiSend(struct nccl
+       int chunkSize;
+       if (reqs[r]->send.size < splitDataThreshold) {
+@@ -2451,7 +2619,7 @@
        }
      }
  
@@ -523,7 +540,7 @@ diff --git a/src/transport/net_ib.cc b/src/transport/net_ib.cc
        // Also make sure lastWr writes remote sizes using the right lkey
        comm->remSizesFifo.sge.lkey = comm->remSizesFifo.mrs[devIndex]->lkey;
        lastWr->wr.rdma.rkey = comm->remSizesFifo.rkeys[devIndex];
-@@ -2448,6 +2620,11 @@ ncclResult_t ncclIbIsend(void* sendComm,
+@@ -2516,6 +2684,11 @@
    ncclResult_t ret = ncclSuccess;
    struct ncclIbRequest* req = NULL;
    struct ncclIbMrHandle* mhandleWrapper = (struct ncclIbMrHandle*) mhandle;
@@ -535,11 +552,11 @@ diff --git a/src/transport/net_ib.cc b/src/transport/net_ib.cc
    int nreqs = 0;
    volatile struct ncclIbSendFifo* slots = NULL;
    int slot = (comm->fifoHead) % MAX_REQUESTS;
-@@ -2461,26 +2638,36 @@ ncclResult_t ncclIbIsend(void* sendComm,
+@@ -2529,26 +2702,36 @@
    }
    NCCLCHECKGOTO(ncclIbStatsCheckFatalCount(&comm->base.stats,__func__), ret, fail);
  
-+  if (rcclCtsOffloadEnabled) {
++  if (comm->useCtsOffload) {
 +      nreqs = 1;
 +  }
 +
@@ -551,7 +568,7 @@ diff --git a/src/transport/net_ib.cc b/src/transport/net_ib.cc
 -  // Wait until all data has arrived
 -  for (int r=1; r<nreqs; r++) while(slots[r].idx != idx);
 -  __sync_synchronize(); // order the nreqsPtr load against tag/rkey/addr loads below
-+  if (!rcclCtsOffloadEnabled) {
++  if (!comm->useCtsOffload) {
 +      slots = comm->fifo[slot];
 +    idx = comm->fifoHead+1;
 +    if (slots[0].idx != idx) { *request = NULL; return ncclSuccess; }
@@ -562,7 +579,7 @@ diff --git a/src/transport/net_ib.cc b/src/transport/net_ib.cc
 +  }
    for (int r=0; r<nreqs; r++) {
 -    if (reqs[r] != NULL || slots[r].tag != tag) continue;
-+    if (!rcclCtsOffloadEnabled) {
++    if (!comm->useCtsOffload) {
 +      if (reqs[r] != NULL || slots[r].tag != tag) continue;
  
 -    if (size > slots[r].size) size = slots[r].size;
@@ -589,7 +606,7 @@ diff --git a/src/transport/net_ib.cc b/src/transport/net_ib.cc
      }
  
      NCCLCHECKGOTO(ncclIbGetRequest(&comm->base, &req), ret, fail);
-@@ -2523,10 +2710,12 @@ ncclResult_t ncclIbIsend(void* sendComm,
+@@ -2591,10 +2774,12 @@
      }
  
      TIME_START(0);
@@ -598,13 +615,13 @@ diff --git a/src/transport/net_ib.cc b/src/transport/net_ib.cc
  
      // Clear slots[0]->nreqs, as well as other fields to help debugging and sanity checks
 -    memset((void*)slots, 0, sizeof(struct ncclIbSendFifo));
-+    if (!rcclCtsOffloadEnabled) {
++    if (!comm->useCtsOffload) {
 +      memset((void*)slots, 0, sizeof(struct ncclIbSendFifo));
 +    }
      memset(reqs, 0, NCCL_NET_IB_MAX_RECVS*sizeof(struct ncclIbRequest*));
      comm->fifoHead++;
      TIME_STOP(0);
-@@ -2561,30 +2750,62 @@ fail:
+@@ -2629,39 +2814,79 @@
  
  ncclResult_t ncclIbPostFifo(struct ncclIbRecvComm* comm, int n, void** data, size_t* sizes, int* tags, void** mhandles, struct ncclIbRequest* req) {
    struct ibv_send_wr wr;
@@ -621,7 +638,7 @@ diff --git a/src/transport/net_ib.cc b/src/transport/net_ib.cc
    req->recv.sizes = comm->sizesFifo[slot];
    for (int i=0; i<n; i++) req->recv.sizes[i] = 0;
 -  struct ncclIbSendFifo* localElem = comm->remFifo.elems[slot];
-+  if (rcclCtsInlineData) {
++  if (comm->useCtsOffload) {
 +    localElemCtsInline = comm->remFifo.elems_cts_inline[slot];
 +  } else {
 +    localElem = comm->remFifo.elems[slot];
@@ -644,7 +661,7 @@ diff --git a/src/transport/net_ib.cc b/src/transport/net_ib.cc
    for (int i=0; i<n; i++) {
 -    localElem[i].addr = (uint64_t)data[i];
      struct ncclIbMrHandle* mhandleWrapper = (struct ncclIbMrHandle*) mhandles[i];
-+    if (rcclCtsInlineData) {
++    if (comm->useCtsOffload) {
 +      localElemCtsInline[i].addr = (uint64_t)data[i];
 +
 +      // Send all applicable rkeys
@@ -678,17 +695,22 @@ diff --git a/src/transport/net_ib.cc b/src/transport/net_ib.cc
 +      localElem[i].idx = comm->remFifo.fifoTail+1;
 +      localElemRef = (uint64_t)localElem;
 +    }
++  }
++  if (comm->useCtsOffload) {
++    wr.wr.rdma.remote_addr = comm->remFifo.addr + slot*NCCL_NET_IB_MAX_RECVS*sizeof(struct ncclIbSendFifoCtsInline);
++  } else {
++    wr.wr.rdma.remote_addr = comm->remFifo.addr + slot*NCCL_NET_IB_MAX_RECVS*sizeof(struct ncclIbSendFifo);
    }
-   wr.wr.rdma.remote_addr = comm->remFifo.addr + slot*NCCL_NET_IB_MAX_RECVS*sizeof(struct ncclIbSendFifo);
+-  wr.wr.rdma.remote_addr = comm->remFifo.addr + slot*NCCL_NET_IB_MAX_RECVS*sizeof(struct ncclIbSendFifo);
  
-@@ -2592,8 +2813,12 @@ ncclResult_t ncclIbPostFifo(struct ncclI
+   // Lookup the correct fifoRkey
    wr.wr.rdma.rkey = comm->base.remDevs[ctsQp->remDevIdx].fifoRkey;
  
    // Set the correct sge properties
 -  comm->devs[ctsQp->devIndex].fifoSge.addr   = (uint64_t)localElem;
 -  comm->devs[ctsQp->devIndex].fifoSge.length = n*sizeof(struct ncclIbSendFifo);
 +  comm->devs[ctsQp->devIndex].fifoSge.addr   = localElemRef;
-+  if (rcclCtsInlineData) {
++  if (comm->useCtsOffload) {
 +    comm->devs[ctsQp->devIndex].fifoSge.length = MAX_INLINE_DATA_SIZE;
 +  } else {
 +    comm->devs[ctsQp->devIndex].fifoSge.length = n*sizeof(struct ncclIbSendFifo);
@@ -696,7 +718,7 @@ diff --git a/src/transport/net_ib.cc b/src/transport/net_ib.cc
    wr.sg_list = &comm->devs[ctsQp->devIndex].fifoSge;
    wr.num_sge = 1;
  
-@@ -2623,7 +2848,14 @@ ncclResult_t ncclIbPostFifo(struct ncclI
+@@ -2691,7 +2916,14 @@
    //
    // slot == devIndex - When writing to fifo slot N, and this QP lives on device index N, it should send signalled.
    // This works out that each fifo posting QP gets drained
@@ -712,7 +734,7 @@ diff --git a/src/transport/net_ib.cc b/src/transport/net_ib.cc
      wr.send_flags |= IBV_SEND_SIGNALED;
      wr.wr_id = req - comm->base.reqs;
      ncclIbAddEvent(req, ctsQp->devIndex, &comm->devs[ctsQp->devIndex].base);
-@@ -2644,10 +2876,16 @@ ncclResult_t ncclIbPostFifo(struct ncclI
+@@ -2712,10 +2944,16 @@
  
    comm->remFifo.fifoTail++;
  
@@ -729,7 +751,7 @@ diff --git a/src/transport/net_ib.cc b/src/transport/net_ib.cc
    struct ncclIbRecvComm* comm = (struct ncclIbRecvComm*)recvComm;
    ncclResult_t ret = ncclSuccess;
    struct ncclIbRequest* req = NULL;
-@@ -2663,6 +2901,11 @@ ncclResult_t ncclIbIrecv(void* recvComm,
+@@ -2731,6 +2969,11 @@
    if (n > NCCL_NET_IB_MAX_RECVS) return ncclInternalError;
    NCCLCHECKGOTO(ncclIbStatsCheckFatalCount(&comm->base.stats,__func__), ret, fail);
  
@@ -741,7 +763,7 @@ diff --git a/src/transport/net_ib.cc b/src/transport/net_ib.cc
    NCCLCHECKGOTO(ncclIbGetRequest(&comm->base, &req), ret, fail);
    req->type = NCCL_NET_IB_REQ_RECV;
    req->sock = &comm->base.sock;
-@@ -2675,40 +2918,50 @@ ncclResult_t ncclIbIrecv(void* recvComm,
+@@ -2743,40 +2986,50 @@
      req->devBases[i] = &comm->devs[i].base;
    }
  
@@ -822,7 +844,7 @@ diff --git a/src/transport/net_ib.cc b/src/transport/net_ib.cc
  
    // Post to FIFO to notify sender
    TIME_START(2);
-@@ -2832,6 +3085,8 @@ static int getReqQpIndex(struct ncclIbRe
+@@ -2905,6 +3158,8 @@
  }
  #endif
  
@@ -831,7 +853,7 @@ diff --git a/src/transport/net_ib.cc b/src/transport/net_ib.cc
  ncclResult_t ncclIbTest(void* request, int* done, int* sizes) {
    struct ncclIbRequest *r = (struct ncclIbRequest*)request;
    ncclResult_t ret = ncclSuccess;
-@@ -2875,13 +3130,17 @@ ncclResult_t ncclIbTest(void* request, i
+@@ -2948,13 +3203,17 @@
  
      int totalWrDone = 0;
      int wrDone = 0;
@@ -851,7 +873,7 @@ diff --git a/src/transport/net_ib.cc b/src/transport/net_ib.cc
          if (ret != ncclSuccess) {
            failDevIdx = i;
            goto fail;
-@@ -3058,7 +3317,7 @@ ncclResult_t rcclNetP2pPolicy(void* hand
+@@ -3131,7 +3390,7 @@
  }
  
  ncclNet_t ncclNetIb = {


### PR DESCRIPTION
## Motivation

CTS offload is enabled globally for all connections, causing alltoall operations (which use P2P transport internally) to create large numbers of QPs with CTS offload enabled, leading to CTS cache overflow and hangs at scale.

Additionally, RCCL's AINIC CTS offload feature currently uses two separate env vars (RCCL_CTS_OFFLOAD_ENABLED and RCCL_CTS_INLINE_DATA) that are mutually dependent at the hardware level - enabling one without the other is invalid.

This PR merges the two CTS env vars into one and adds per-connection CTS offload control to selectively disable CTS offload on P2P connections while keeping it active for collective transport.

## Technical Details

**Merged env vars:**

Removed RCCL_CTS_INLINE_DATA env var - RCCL_CTS_OFFLOAD_ENABLED now controls both CTS offload and CTS inline data
Default (-1) auto-enables on AINIC. Set to 0 to disable, 1 to force enable

**New env var:**

RCCL_IB_P2P_DISABLE_CTS (default=0) - when set to 1, disables CTS offload for P2P connections while keeping it enabled for collective transport connections

**Per-connection CTS offload control:**

Added useCtsOffload field to rocmIbSendComm and rocmIbRecvComm structs
CTS offload decision made per-connection in rocmIbConnect and rocmIbAccept based on: enabled && (userForced || !(isP2p && IbP2pDisableCts)) rocmIbCreateQp receives isP2p parameter to set QP-level CTS offload bits accordingly
Data path (rocmIbIsend, rocmIbPostFifo, rocmIbMultiSend) uses per-connection comm->useCtsOffload instead of global rcclCtsOffloadEnabled

**Force override logic:**

User explicit setting (RCCL_CTS_OFFLOAD_ENABLED=1) overrides IB_P2P_DISABLE_CTS - forces CTS on all connections including P2P
Auto-detect (default -1) respects P2P filtering
Changes are in rocm_netib.patch only (AINIC-specific IB plugin).


**Environment Variables**

| Variable | Values | Behavior |
|---|---|---|
| `RCCL_CTS_OFFLOAD_ENABLED` | `-1` (default) | Auto-enable on AINIC. P2P connections respect `IB_P2P_DISABLE_CTS`. |
| | `0` | Disable CTS offload globally (all connection types). |
| | `1` | Force-enable CTS offload globally — overrides `IB_P2P_DISABLE_CTS` for P2P. |
| `RCCL_IB_P2P_DISABLE_CTS` | `1` (default) | Disable CTS offload for P2P connections (only when `CTS_OFFLOAD_ENABLED=-1`). |
| | `0` | Allow CTS offload on P2P connections. |

**Precedence:** `RCCL_CTS_OFFLOAD_ENABLED=1` is the strongest override — it forces CTS on all connections including P2P, regardless of `IB_P2P_DISABLE_CTS`. When left at default (`-1`), per-connection control is delegated to `IB_P2P_DISABLE_CTS`.

## JIRA ID

ROCM-21075

## Test Plan

Tested on 4-node TW cluster:
```
Collective	RCCL_IB_P2P_DISABLE_CTS=1	Default (=0)
allreduce	OK              	        OK  
allgather	OK  	                    OK  
broadcast	OK  	                    OK  
alltoall	OK  	                    TIMEOUT (expected)
```

With DISABLE_CTS=1: P2P connections have useCtsOffload=0 (384 P2P), collective connections have useCtsOffload=1 (470 coll)
With default =0: All connections have useCtsOffload=1 — alltoall hangs as expected (P2P CTS not yet supported at HW level)


## Test Result

Passed (4-node allreduce, allgather, broadcast, alltoall with IB_P2P_DISABLE_CTS=1)

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
