### PR TITLE
Cherry-pick for 7.2.2

### DIFF
--- a/projects/rocr-runtime/runtime/docs/data/env_variables.rst
+++ b/projects/rocr-runtime/runtime/docs/data/env_variables.rst
@@ -28,7 +28,7 @@
         | Specifies the threshold for the amount of scratch memory allocated and reclaimed in kernel dispatches.
         | Enabling ``HSA_NO_SCRATCH_RECLAIM`` circumvents ``HSA_SCRATCH_SINGLE_LIMIT``, and treats ``HSA_SCRATCH_SINGLE_LIMIT`` as the maximum value.
         |
-        | **NOTE:** In the 7.0 release the developer can use the HIP enumerator ``hipExtLimitScratchCurrent`` to programmatically change the default scratch memory allocation size. For more information, see `Global enums and defines <https://rocm.docs.amd.com/projects/HIP/en/latest/reference/hip_runtime_api/global_defines_enums_structs_files/global_enum_and_defines.html>`_.
+        | **NOTE:** In the 7.0 release the developer can use the HIP enumerator ``hipExtLimitScratchCurrent`` to programmatically change the default scratch memory allocation size. For more information, see `Global enums and defines <https://rocm.docs.amd.com/projects/HIP/en/latest/reference/hip_runtime_api/global_defines_enums_structs_files.html>`_.
       - ``146800640``
       - 0 to 4GB per XCC
 


### PR DESCRIPTION
fix broken link to Global enums and defines (#4468) (#4471)
fix broken link to Global enums and defines in ROCr-Runtime

