### PR TITLE
fix free(): invalid pointer on process exit

### DIFF
--- a/projects/amdsmi/rocm_smi/src/rocm_smi_main.cc
+++ b/projects/amdsmi/rocm_smi/src/rocm_smi_main.cc
@@ -516,7 +516,11 @@ void RocmSMI::Initialize(uint64_t flags) {
 
 void RocmSMI::Cleanup() {
   devices_.clear();
+  nic_devices_.clear();
+  switch_devices_.clear();
   monitors_.clear();
+  nic_monitors_.clear();
+  switch_monitors_.clear();
 
   if (kfd_notif_evt_fh() >= 0) {
     int ret = close(kfd_notif_evt_fh());


### PR DESCRIPTION
RocmSMI::Cleanup() only cleared devices_ and monitors_, leaving
nic_devices_, switch_devices_, nic_monitors_, and switch_monitors_
alive in the static singleton. When AMDSMI_MUTEX_CROSS_PROCESS=1,
device mutexes are mmap'd; if the env var is unset before the
singleton destructs, Device::~Device() calls delete on an mmap'd
pointer, causing free(): invalid pointer. Clear all device/monitor
vectors in Cleanup() so destructors run while the env var is still set.

Signed-off-by: Charis Poag <charis.poag@amd.com>

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
