### PR TITLE
[rocSHMEM] Fix data verification errors caused by loop count mismatch

### DIFF
--- a/projects/rocshmem/tests/functional_tests/amo_bitwise_tester.cpp
+++ b/projects/rocshmem/tests/functional_tests/amo_bitwise_tester.cpp
@@ -83,16 +83,18 @@ void AMOBitwiseTester<T>::resetBuffers([[maybe_unused]] size_t size) {
 }
 
 template <typename T>
-void AMOBitwiseTester<T>::launchKernel(dim3 gridsize, dim3 blocksize, [[maybe_unused]] int loop,
+void AMOBitwiseTester<T>::launchKernel(dim3 gridsize, dim3 blocksize, int loop,
                                        [[maybe_unused]] size_t size) {
   size_t shared_bytes = 0;
 
+  n_loops = loop + args.skip;
+
   hipLaunchKernelGGL(AMOBitwiseTest, gridsize, blocksize, shared_bytes, stream,
-                     args.loop, args.skip, start_time, end_time, dest,
+                     loop, args.skip, start_time, end_time, dest,
                      ret_val, args.addr_mode, _type, _shmem_context);
 
-  num_msgs       = n_loops   * gridsize.x * blocksize.x;
-  num_timed_msgs = args.loop * gridsize.x * blocksize.x;
+  num_msgs       = n_loops * gridsize.x * blocksize.x;
+  num_timed_msgs = loop    * gridsize.x * blocksize.x;
 }
 
 template <typename G>

--- a/projects/rocshmem/tests/functional_tests/amo_bitwise_tester.cpp
+++ b/projects/rocshmem/tests/functional_tests/amo_bitwise_tester.cpp
@@ -58,7 +58,7 @@ template <typename T>
 AMOBitwiseTester<T>::AMOBitwiseTester(TesterArguments args) : Tester(args) {
   n_out   = (args.addr_mode == AddrMode::PerBlock) ? args.num_wgs : 1;
   n_in    = args.num_wgs * args.wg_size;
-  n_loops = args.loop + args.skip;
+  n_loops = std::max(args.loop, args.loop_large) + args.skip;
 
   // One return per *thread* per loop
   CHECK_HIP(hipMalloc((void **)&ret_val, max_msg_size * n_in * n_loops));
@@ -78,6 +78,7 @@ AMOBitwiseTester<T>::~AMOBitwiseTester() {
 
 template <typename T>
 void AMOBitwiseTester<T>::resetBuffers([[maybe_unused]] size_t size) {
+  n_loops = num_loops + args.skip;
   memset(ret_val, 0, max_msg_size * n_in  * n_loops);
   memset(dest,    0, max_msg_size * n_out * n_loops);
 }

--- a/projects/rocshmem/tests/functional_tests/amo_extended_tester.cpp
+++ b/projects/rocshmem/tests/functional_tests/amo_extended_tester.cpp
@@ -58,7 +58,7 @@ template <typename T>
 AMOExtendedTester<T>::AMOExtendedTester(TesterArguments args) : Tester(args) {
   n_out   = (args.addr_mode == AddrMode::PerBlock) ? args.num_wgs : 1;
   n_in    = args.num_wgs * args.wg_size;
-  n_loops = args.loop + args.skip;
+  n_loops = std::max(args.loop, args.loop_large) + args.skip;
 
   // One return per *thread* per loop
   CHECK_HIP(hipMalloc((void **)&ret_val, max_msg_size * n_in * n_loops));
@@ -78,6 +78,7 @@ AMOExtendedTester<T>::~AMOExtendedTester() {
 
 template <typename T>
 void AMOExtendedTester<T>::resetBuffers([[maybe_unused]] size_t size) {
+  n_loops = num_loops + args.skip;
   memset(ret_val, 0, max_msg_size * n_in  * n_loops);
   memset(dest,    0, max_msg_size * n_out * n_loops);
 }

--- a/projects/rocshmem/tests/functional_tests/amo_extended_tester.cpp
+++ b/projects/rocshmem/tests/functional_tests/amo_extended_tester.cpp
@@ -83,16 +83,18 @@ void AMOExtendedTester<T>::resetBuffers([[maybe_unused]] size_t size) {
 }
 
 template <typename T>
-void AMOExtendedTester<T>::launchKernel(dim3 gridsize, dim3 blocksize, [[maybe_unused]] int loop,
+void AMOExtendedTester<T>::launchKernel(dim3 gridsize, dim3 blocksize, int loop,
                                         [[maybe_unused]] size_t size) {
   size_t shared_bytes = 0;
 
+  n_loops = loop + args.skip;
+
   hipLaunchKernelGGL(AMOExtendedTest, gridsize, blocksize, shared_bytes, stream,
-                     args.loop, args.skip, start_time, end_time, dest,
+                     loop, args.skip, start_time, end_time, dest,
                      ret_val, args.addr_mode, _type, _shmem_context);
 
-  num_msgs       = n_loops   * gridsize.x * blocksize.x;
-  num_timed_msgs = args.loop * gridsize.x * blocksize.x;
+  num_msgs       = n_loops * gridsize.x * blocksize.x;
+  num_timed_msgs = loop    * gridsize.x * blocksize.x;
 }
 
 template <typename G>

--- a/projects/rocshmem/tests/functional_tests/amo_standard_tester.cpp
+++ b/projects/rocshmem/tests/functional_tests/amo_standard_tester.cpp
@@ -84,16 +84,18 @@ void AMOStandardTester<T>::resetBuffers([[maybe_unused]] size_t size) {
 }
 
 template <typename T>
-void AMOStandardTester<T>::launchKernel(dim3 gridsize, dim3 blocksize, [[maybe_unused]] int loop,
+void AMOStandardTester<T>::launchKernel(dim3 gridsize, dim3 blocksize, int loop,
                                         [[maybe_unused]] size_t size) {
   size_t shared_bytes = 0;
 
+  n_loops = loop + args.skip;
+
   hipLaunchKernelGGL(AMOStandardTest, gridsize, blocksize, shared_bytes, stream,
-                     args.loop, args.skip, start_time, end_time, dest, ret_val,
+                     loop, args.skip, start_time, end_time, dest, ret_val,
                      args.addr_mode, _type, _shmem_context);
 
-  num_msgs       = n_loops   * gridsize.x * blocksize.x;
-  num_timed_msgs = args.loop * gridsize.x * blocksize.x;
+  num_msgs       = n_loops * gridsize.x * blocksize.x;
+  num_timed_msgs = loop    * gridsize.x * blocksize.x;
 }
 
 

--- a/projects/rocshmem/tests/functional_tests/amo_standard_tester.cpp
+++ b/projects/rocshmem/tests/functional_tests/amo_standard_tester.cpp
@@ -59,7 +59,7 @@ template <typename T>
 AMOStandardTester<T>::AMOStandardTester(TesterArguments args) : Tester(args) {
   n_out   = (args.addr_mode == AddrMode::PerBlock) ? args.num_wgs : 1;
   n_in    = args.num_wgs * args.wg_size;
-  n_loops = args.loop + args.skip;
+  n_loops = std::max(args.loop, args.loop_large) + args.skip;
 
   // One return per *thread* per loop
   CHECK_HIP(hipMalloc((void **)&ret_val, max_msg_size * n_in * n_loops));
@@ -79,6 +79,7 @@ AMOStandardTester<T>::~AMOStandardTester() {
 
 template <typename T>
 void AMOStandardTester<T>::resetBuffers([[maybe_unused]] size_t size) {
+  n_loops = num_loops + args.skip;
   memset(ret_val, 0, max_msg_size * n_in  * n_loops);
   memset(dest,    0, max_msg_size * n_out * n_loops);
 }

--- a/projects/rocshmem/tests/functional_tests/flood_amo_tester.cpp
+++ b/projects/rocshmem/tests/functional_tests/flood_amo_tester.cpp
@@ -229,7 +229,7 @@ void FloodAmoTester::verifyResults([[maybe_unused]] size_t size) {
 
   if (*verification_error) {
     std::cerr << "Data validation error (found by device kernel)" << std::endl;
-    uint64_t expected = static_cast<uint64_t>(args.loop + args.skip) * num_pes * (args.wg_size * (args.wg_size+1)) / 2;
+    uint64_t expected = static_cast<uint64_t>(num_loops + args.skip) * num_pes * (args.wg_size * (args.wg_size+1)) / 2;
     for(unsigned int wg = 0; wg < static_cast<unsigned int>(args.num_wgs); wg++) {
       if (expected != s_buf[wg]) {
         std::cerr << "Data validation error for wg " << wg << std::endl;

--- a/projects/rocshmem/tests/functional_tests/signal_wait_until_on_stream_tester.cpp
+++ b/projects/rocshmem/tests/functional_tests/signal_wait_until_on_stream_tester.cpp
@@ -183,7 +183,7 @@ void SignalWaitUntilOnStreamTester::verifyResults([[maybe_unused]] size_t size) 
 
   // Verify signal values
   // All PEs except PE 0 should have received the final signal value
-  uint64_t expected_signal = args.skip + args.loop;
+  uint64_t expected_signal = args.skip + num_loops;
 
   for (int stream_id = 0; stream_id < num_streams; stream_id++) {
     // PE 0 doesn't receive signals (it initiates), so skip verification

--- a/projects/rocshmem/tests/functional_tests/signaling_operations_tester.cpp
+++ b/projects/rocshmem/tests/functional_tests/signaling_operations_tester.cpp
@@ -214,15 +214,15 @@ void SignalingOperationsTester::verifyResults(size_t size) {
         switch (_type) {
           case PutSignalTestType:
           case PutSignalNBITestType:
-            expected_value += ((args.skip + args.loop) * args.wg_size * args.num_wgs);
+            expected_value += ((args.skip + num_loops) * args.wg_size * args.num_wgs);
             break;
           case WGPutSignalTestType:
           case WGPutSignalNBITestType:
-            expected_value += ((args.skip + args.loop) * args.num_wgs);
+            expected_value += ((args.skip + num_loops) * args.num_wgs);
             break;
           case WAVEPutSignalTestType:
           case WAVEPutSignalNBITestType:
-            expected_value += ((args.skip + args.loop) * args.num_wgs * num_warps);
+            expected_value += ((args.skip + num_loops) * args.num_wgs * num_warps);
             break;
           default:
             fprintf(stderr, "Invalid Test\n");

--- a/projects/rocshmem/tests/functional_tests/tester.cpp
+++ b/projects/rocshmem/tests/functional_tests/tester.cpp
@@ -657,12 +657,14 @@ void Tester::execute() {
    */
   for (size_t size = args.min_msg_size; size <= max_msg_size;
        size <<= 1) {
-    resetBuffers(size);
-
     /**
      * Restricts the number of iterations of really large messages.
      */
     if (size > args.large_message_size) num_loops = args.loop_large;
+
+    // Reset after num_loops is set so subclasses can size their
+    // buffers to the actual iteration count for this message size.
+    resetBuffers(size);
 
     barrier();
 

--- a/projects/rocshmem/tests/functional_tests/tester.hpp
+++ b/projects/rocshmem/tests/functional_tests/tester.hpp
@@ -25,6 +25,7 @@
 #ifndef _TESTER_HPP_
 #define _TESTER_HPP_
 
+#include <algorithm>
 #include <rocshmem/rocshmem.hpp>
 #include <vector>
 #include <climits>


### PR DESCRIPTION
## Motivation
Fix data verification errors in functional tests when `args.loop_large` is in effect for large message sizes. Several testers computed expected verification values using `args.loop` while the kernel actually ran with a reduced loop count (`num_loops`), causing false validation failures.

## Technical Details
- `flood_amo_tester`, `signaling_operations_tester`, and `signal_wait_until_on_stream_tester` used `args.loop` in `verifyResults` to compute expected values, but the kernel was launched with `num_loops` (which equals `args.loop_large` for large messages). Replaced `args.loop` with `num_loops` in these verification paths.
- `amo_standard_tester`, `amo_extended_tester`, and `amo_bitwise_tester` ignored the `loop` parameter in `launchKernel` and hardcoded `args.loop` for the kernel launch. Updated them to pass the `loop` parameter through and sync `n_loops` so verification matches the actual iteration count.

## JIRA ID
AIROCSHMEM-354

## Test Plan
- [x] Verify no data validation errors on put/get signal tests and AMO tests with large message sizes

## Test Result
All functional tests pass without data validation errors, including tests exercising the `loop_large` path with large message sizes.

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.