### PR TITLE
[rocprofiler-sdk] Migrate from glog to Abseil Logging

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -18,9 +18,6 @@
 [submodule "projects/rocprofiler-register/external/glog"]
 	path = projects/rocprofiler-register/external/glog
 	url = https://github.com/google/glog.git
-[submodule "projects/rocprofiler-sdk/external/glog"]
-	path = projects/rocprofiler-sdk/external/glog
-	url = https://github.com/google/glog.git
 [submodule "projects/rocprofiler-sdk/external/fmt"]
 	path = projects/rocprofiler-sdk/external/fmt
 	url = https://github.com/fmtlib/fmt.git
@@ -109,3 +106,6 @@
 	path = projects/rocprofiler-systems/external/onetbb
 	url = https://github.com/uxlfoundation/oneTBB.git
 	tag = v2022.3.0
+[submodule "projects/rocprofiler-sdk/external/abseil-cpp"]
+	path = projects/rocprofiler-sdk/external/abseil-cpp
+	url = https://github.com/abseil/abseil-cpp.git

--- a/projects/rocprofiler-sdk/.gitmodules
+++ b/projects/rocprofiler-sdk/.gitmodules
@@ -1,9 +1,9 @@
 [submodule "external/googletest"]
 	path = external/googletest
 	url = https://github.com/google/googletest.git
-[submodule "external/glog"]
-	path = external/glog
-	url = https://github.com/google/glog.git
+[submodule "external/abseil-cpp"]
+	path = external/abseil-cpp
+	url = https://github.com/abseil/abseil-cpp.git
 [submodule "fmt"]
 	path = external/fmt
 	url = https://github.com/fmtlib/fmt.git

--- a/projects/rocprofiler-sdk/cmake/rocprofiler_interfaces.cmake
+++ b/projects/rocprofiler-sdk/cmake/rocprofiler_interfaces.cmake
@@ -60,7 +60,8 @@ rocprofiler_add_interface_library(rocprofiler-sdk-rt "Build flags for runtime li
                                   INTERNAL)
 rocprofiler_add_interface_library(rocprofiler-sdk-atomic "atomic library" INTERNAL)
 rocprofiler_add_interface_library(rocprofiler-sdk-gtest "Google Test library" INTERNAL)
-rocprofiler_add_interface_library(rocprofiler-sdk-glog "Google Log library" INTERNAL)
+rocprofiler_add_interface_library(rocprofiler-sdk-abseil "Abseil logging library"
+                                  INTERNAL)
 rocprofiler_add_interface_library(rocprofiler-sdk-fmt "C++ format string library"
                                   INTERNAL)
 rocprofiler_add_interface_library(rocprofiler-sdk-cxx-filesystem "C++ filesystem library"

--- a/projects/rocprofiler-sdk/cmake/rocprofiler_options.cmake
+++ b/projects/rocprofiler-sdk/cmake/rocprofiler_options.cmake
@@ -57,8 +57,9 @@ rocprofiler_add_option(
     "Enable building with ghc::filesystem library (via submodule) instead of the C++ filesystem library"
     ON)
 rocprofiler_add_option(ROCPROFILER_BUILD_FMT "Enable building fmt library internally" ON)
-rocprofiler_add_option(ROCPROFILER_BUILD_GLOG
-                       "Enable building glog (Google logging) library internally" ON)
+rocprofiler_add_option(
+    ROCPROFILER_BUILD_ABSEIL
+    "Enable building abseil-cpp (Abseil logging) library internally" ON)
 rocprofiler_add_option(ROCPROFILER_BUILD_SQLITE3
                        "Enable building sqlite3 library internally" OFF)
 rocprofiler_add_option(ROCPROFILER_BUILD_PYBIND11
@@ -158,7 +159,7 @@ include(rocprofiler_memcheck)
 
 # default FAIL_REGULAR_EXPRESSION for tests
 set(ROCPROFILER_DEFAULT_FAIL_REGEX
-    "threw an exception|Permission denied|Could not create logging file|failed with error code|Subprocess aborted"
+    "threw an exception|Permission denied|failed with error code|Subprocess aborted"
     CACHE INTERNAL "Default FAIL_REGULAR_EXPRESSION for tests" FORCE)
 
 # this should be defaulted to OFF by ROCm 7.0.1 or 7.1 this should only used to disable

--- a/projects/rocprofiler-sdk/external/CMakeLists.txt
+++ b/projects/rocprofiler-sdk/external/CMakeLists.txt
@@ -69,29 +69,34 @@ if(ROCPROFILER_BUILD_TESTS)
     endif()
 endif()
 
-if(ROCPROFILER_BUILD_GLOG)
+if(ROCPROFILER_BUILD_ABSEIL)
     # checkout submodule if not already checked out or clone repo if no .gitmodules file
     rocprofiler_checkout_git_submodule(
         RECURSIVE
-        RELATIVE_PATH external/glog
+        RELATIVE_PATH external/abseil-cpp
         WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
-        REPO_URL https://github.com/google/glog.git
-        REPO_BRANCH "master")
+        REPO_URL https://github.com/abseil/abseil-cpp.git
+        REPO_BRANCH "lts_2026_01_07")
 
-    # May want to use GFLAGS in the future
-    set(WITH_GFLAGS OFF)
-    set(WITH_GTEST OFF)
-    set(WITH_UNWIND "none")
-    add_subdirectory(glog EXCLUDE_FROM_ALL)
+    set(ABSL_PROPAGATE_CXX_STD ON)
+    set(ABSL_BUILD_TESTING OFF)
+    set(ABSL_USE_GOOGLETEST_HEAD OFF)
+    add_subdirectory(abseil-cpp EXCLUDE_FROM_ALL)
 
-    target_link_libraries(rocprofiler-sdk-glog INTERFACE $<BUILD_INTERFACE:glog::glog>)
-    target_include_directories(
-        rocprofiler-sdk-glog SYSTEM
-        INTERFACE $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}/external/glog>
-                  $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/external/glog/src>)
+    target_link_libraries(
+        rocprofiler-sdk-abseil
+        INTERFACE $<BUILD_INTERFACE:absl::log>
+                  $<BUILD_INTERFACE:absl::log_initialize>
+                  $<BUILD_INTERFACE:absl::check>
+                  $<BUILD_INTERFACE:absl::log_globals>
+                  $<BUILD_INTERFACE:absl::vlog_is_on>
+                  $<BUILD_INTERFACE:absl::failure_signal_handler>)
 else()
-    find_package(glog REQUIRED)
-    target_link_libraries(rocprofiler-sdk-glog INTERFACE glog::glog)
+    find_package(absl REQUIRED)
+    target_link_libraries(
+        rocprofiler-sdk-abseil
+        INTERFACE absl::log absl::log_initialize absl::check absl::log_globals
+                  absl::vlog_is_on absl::failure_signal_handler)
 endif()
 
 if(ROCPROFILER_BUILD_FMT)

--- a/projects/rocprofiler-sdk/source/lib/att-tool/waitcnt/tests/CMakeLists.txt
+++ b/projects/rocprofiler-sdk/source/lib/att-tool/waitcnt/tests/CMakeLists.txt
@@ -15,7 +15,7 @@ target_link_libraries(
     PRIVATE rocprofiler-sdk::rocprofiler-sdk-att-parser
             rocprofiler-sdk::rocprofiler-sdk-json
             rocprofiler-sdk::rocprofiler-sdk-common-library
-            rocprofiler-sdk::rocprofiler-sdk-glog
+            rocprofiler-sdk::rocprofiler-sdk-abseil
             rocprofiler-sdk::rocprofiler-sdk-static-library
             GTest::gtest
             GTest::gtest_main)

--- a/projects/rocprofiler-sdk/source/lib/common/CMakeLists.txt
+++ b/projects/rocprofiler-sdk/source/lib/common/CMakeLists.txt
@@ -61,7 +61,7 @@ target_link_libraries(
            $<BUILD_INTERFACE:rocprofiler-sdk::rocprofiler-sdk-threading>
            $<BUILD_INTERFACE:rocprofiler-sdk::rocprofiler-sdk-memcheck>
            $<BUILD_INTERFACE:rocprofiler-sdk::rocprofiler-sdk-cxx-filesystem>
-           $<BUILD_INTERFACE:rocprofiler-sdk::rocprofiler-sdk-glog>
+           $<BUILD_INTERFACE:rocprofiler-sdk::rocprofiler-sdk-abseil>
            $<BUILD_INTERFACE:rocprofiler-sdk::rocprofiler-sdk-fmt>
            $<BUILD_INTERFACE:rocprofiler-sdk::rocprofiler-sdk-yaml-cpp>
            $<BUILD_INTERFACE:rocprofiler-sdk::rocprofiler-sdk-dl>

--- a/projects/rocprofiler-sdk/source/lib/common/environment.cpp
+++ b/projects/rocprofiler-sdk/source/lib/common/environment.cpp
@@ -180,7 +180,7 @@ env_store::env_store(std::initializer_list<env_config>&& _container)
     for(const auto& itr : _container)
     {
         m_original.emplace_back(env_config{itr.env_name, get_env(itr.env_name, ""), 1});
-        m_modified.emplace_back(env_config{itr.env_name, itr.env_value, 1});
+        m_modified.emplace_back(env_config{itr.env_name, itr.env_value, itr.overwrite});
     }
 }
 

--- a/projects/rocprofiler-sdk/source/lib/common/environment.hpp
+++ b/projects/rocprofiler-sdk/source/lib/common/environment.hpp
@@ -87,20 +87,22 @@ struct env_config
 {
     std::string env_name  = {};
     std::string env_value = {};
-    int         overwrite = 0;
+    int         overwrite = 0;  // -1=only if set, 0=no overwrite, 1=overwrite
 
     auto operator()(bool _verbose = false) const
     {
-        if(env_name.empty())
-            return -1;
+        if(env_name.empty()) return -1;
+        // overwrite < 0: only modify if variable already exists
+        if(overwrite < 0 && ::std::getenv(env_name.c_str()) == nullptr)
+            return 0;
         else if(_verbose)
         {
             ROCP_INFO << "[rocprofiler][set_env] setenv(\"" << env_name << "\", \"" << env_value
                       << "\", " << overwrite << ")\n";
         }
-        return (env_value.empty() && overwrite > 0)
-                   ? unsetenv(env_name.c_str())
-                   : setenv(env_name.c_str(), env_value.c_str(), overwrite);
+        auto _ow = (overwrite < 0) ? 1 : overwrite;
+        return (env_value.empty() && _ow > 0) ? unsetenv(env_name.c_str())
+                                              : setenv(env_name.c_str(), env_value.c_str(), _ow);
     }
 };
 
@@ -132,7 +134,7 @@ env_store::env_store(ContainerT<env_config, TailT...>&& _container)
     for(const auto& itr : _container)
     {
         m_original.emplace_back(env_config{itr.env_name, get_env(itr.env_name, ""), 1});
-        m_modified.emplace_back(env_config{itr.env_name, itr.env_value, 1});
+        m_modified.emplace_back(env_config{itr.env_name, itr.env_value, itr.overwrite});
     }
 }
 }  // namespace common

--- a/projects/rocprofiler-sdk/source/lib/common/logging.cpp
+++ b/projects/rocprofiler-sdk/source/lib/common/logging.cpp
@@ -24,10 +24,12 @@
 #include "lib/common/environment.hpp"
 #include "lib/common/filesystem.hpp"
 
+#include <absl/debugging/failure_signal_handler.h>
+#include <absl/log/globals.h>
+#include <absl/log/initialize.h>
+#include <absl/log/log.h>
 #include <fmt/format.h>
 #include <fmt/ranges.h>
-#include <glog/logging.h>
-#include <glog/vlog_is_on.h>
 
 #include <fstream>
 #include <mutex>
@@ -46,42 +48,22 @@ void
 install_failure_signal_handler()
 {
     static auto _once = std::once_flag{};
-    std::call_once(_once, []() { google::InstallFailureSignalHandler(); });
+    std::call_once(
+        _once, []() { absl::InstallFailureSignalHandler(absl::FailureSignalHandlerOptions{}); });
 }
 
 struct log_level_info
 {
-    int32_t google_level  = 0;
-    int32_t verbose_level = 0;
+    int32_t severity_level = 0;
+    int32_t verbose_level  = 0;
 };
 
-env_store
-get_glog_env_config(const logging_config& cfg)
-{
-    auto as_env_config = [](std::string_view _var, const auto& _val) {
-        return env_config{std::string{_var}, fmt::format("{}", _val), 1};
-    };
+// Abseil log severity values: kInfo=0, kWarning=1, kError=2, kFatal=3
+constexpr int32_t log_severity_info    = 0;
+constexpr int32_t log_severity_warning = 1;
+constexpr int32_t log_severity_error   = 2;
+constexpr int32_t log_severity_fatal   = 3;
 
-    auto _data = std::vector<env_config>{
-        as_env_config("GLOG_minloglevel", cfg.loglevel),
-        as_env_config("GLOG_logtostderr", cfg.logtostderr ? 1 : 0),
-        as_env_config("GLOG_alsologtostderr", cfg.alsologtostderr ? 1 : 0),
-        as_env_config("GLOG_stderrthreshold", cfg.loglevel),
-        as_env_config("GLOG_v", cfg.vlog_level),
-    };
-
-    if(!cfg.logdir.empty())
-    {
-        _data.emplace_back(as_env_config("GOOGLE_LOG_DIR", cfg.logdir));
-        _data.emplace_back(as_env_config("GLOG_log_dir", cfg.logdir));
-    }
-    if(!cfg.vlog_modules.empty())
-    {
-        _data.emplace_back(as_env_config("GLOG_vmodule", cfg.vlog_modules));
-    }
-
-    return env_store{std::move(_data)};
-}
 }  // namespace
 
 void
@@ -89,17 +71,6 @@ init_logging(std::string_view env_prefix, logging_config cfg)
 {
     static auto _once = std::once_flag{};
     std::call_once(_once, [env_prefix, &cfg]() {
-        auto get_argv0 = []() {
-            auto ifs  = std::ifstream{"/proc/self/cmdline"};
-            auto sarg = std::string{};
-            while(ifs && !ifs.eof())
-            {
-                ifs >> sarg;
-                if(!sarg.empty()) break;
-            }
-            return sarg;
-        };
-
         auto to_lower = [](std::string val) {
             for(auto& itr : val)
                 itr = tolower(itr);
@@ -107,11 +78,11 @@ init_logging(std::string_view env_prefix, logging_config cfg)
         };
 
         const auto env_opts = std::unordered_map<std::string_view, log_level_info>{
-            {"trace", {google::INFO, ROCP_LOG_LEVEL_TRACE}},
-            {"info", {google::INFO, ROCP_LOG_LEVEL_INFO}},
-            {"warning", {google::WARNING, ROCP_LOG_LEVEL_WARNING}},
-            {"error", {google::ERROR, ROCP_LOG_LEVEL_ERROR}},
-            {"fatal", {google::FATAL, ROCP_LOG_LEVEL_NONE}}};
+            {"trace", {log_severity_info, ROCP_LOG_LEVEL_TRACE}},
+            {"info", {log_severity_info, ROCP_LOG_LEVEL_INFO}},
+            {"warning", {log_severity_warning, ROCP_LOG_LEVEL_WARNING}},
+            {"error", {log_severity_error, ROCP_LOG_LEVEL_ERROR}},
+            {"fatal", {log_severity_fatal, ROCP_LOG_LEVEL_NONE}}};
 
         auto supported = std::vector<std::string>{};
         supported.reserve(env_opts.size());
@@ -122,8 +93,6 @@ init_logging(std::string_view env_prefix, logging_config cfg)
 
         cfg.logdir       = get_env(fmt::format("{}_LOG_DIR", env_prefix), cfg.logdir);
         cfg.vlog_modules = get_env(fmt::format("{}_vmodule", env_prefix), cfg.vlog_modules);
-        cfg.logtostderr  = cfg.logdir.empty();  // log to stderr if no log dir set
-        // cfg.alsologtostderr = !cfg.logdir.empty();  // log to file if log dir set
 
         auto loglvl = to_lower(common::get_env(fmt::format("{}_LOG_LEVEL", env_prefix), ""));
         // default to warning
@@ -134,7 +103,7 @@ init_logging(std::string_view env_prefix, logging_config cfg)
             auto val = std::stol(loglvl);
             if(val < 0)
             {
-                loglvl_v   = google::FATAL;
+                loglvl_v   = log_severity_fatal;
                 vlog_level = val;
             }
             else
@@ -149,7 +118,7 @@ init_logging(std::string_view env_prefix, logging_config cfg)
                         break;
                     }
                 }
-                loglvl_v   = itr.google_level;
+                loglvl_v   = itr.severity_level;
                 vlog_level = itr.verbose_level;
             }
         }
@@ -163,35 +132,19 @@ init_logging(std::string_view env_prefix, logging_config cfg)
                     fmt::format("{}", fmt::join(supported.begin(), supported.end(), ", ")))};
             else
             {
-                loglvl_v   = env_opts.at(loglvl).google_level;
+                loglvl_v   = env_opts.at(loglvl).severity_level;
                 vlog_level = env_opts.at(loglvl).verbose_level;
             }
         }
 
-        auto _env_store = get_glog_env_config(cfg);
-
         update_logging(cfg);
-        _env_store.push();
 
-        if(!google::IsGoogleLoggingInitialized())
-        {
-            static auto argv0 = get_argv0();
-            // Prevent glog from crashing if vmodule is empty
-            if(FLAGS_vmodule.empty()) FLAGS_vmodule = " ";
-
-            google::InitGoogleLogging(argv0.c_str());
-
-            // Swap out memory to avoid leaking the string
-            if(!FLAGS_vmodule.empty()) std::string{}.swap(FLAGS_vmodule);
-            if(!FLAGS_log_dir.empty()) std::string{}.swap(FLAGS_log_dir);
-        }
+        absl::InitializeLog();
 
         update_logging(cfg);
 
         ROCP_INFO << "logging initialized via " << fmt::format("{}_LOG_LEVEL", env_prefix)
                   << ". Log Level: " << loglvl << ". Verbose Log Level: " << vlog_level;
-
-        _env_store.pop(false);
     });
 }
 
@@ -201,30 +154,15 @@ update_logging(const logging_config& cfg)
     static auto _mtx = std::mutex{};
     auto        _lk  = std::unique_lock<std::mutex>{_mtx};
 
-    FLAGS_timestamp_in_logfile_name = false;
-    FLAGS_logtostderr               = cfg.logtostderr;
-    FLAGS_minloglevel               = cfg.loglevel;
-    FLAGS_stderrthreshold           = cfg.loglevel;
-    FLAGS_alsologtostderr           = cfg.alsologtostderr;
-    FLAGS_v                         = cfg.vlog_level;
-
-    // if(!cfg.logdir.empty()) FLAGS_log_dir = cfg.logdir.c_str();
+    absl::SetMinLogLevel(static_cast<absl::LogSeverityAtLeast>(cfg.loglevel));
+    absl::SetStderrThreshold(static_cast<absl::LogSeverityAtLeast>(cfg.loglevel));
+    absl::SetGlobalVLogLevel(cfg.vlog_level);
 
     if(cfg.install_failure_handler) install_failure_signal_handler();
 
     if(!cfg.logdir.empty() && !fs::exists(cfg.logdir))
     {
         fs::create_directories(cfg.logdir);
-
-        if(cfg.logdir_gitignore)
-        {
-            auto ignore = fs::path{cfg.logdir} / ".gitignore";
-            if(!fs::exists(ignore))
-            {
-                std::ofstream ofs{ignore.string()};
-                ofs << "/**" << std::flush;
-            }
-        }
     }
 }
 }  // namespace common

--- a/projects/rocprofiler-sdk/source/lib/common/logging.hpp
+++ b/projects/rocprofiler-sdk/source/lib/common/logging.hpp
@@ -24,7 +24,9 @@
 
 #include "lib/common/defines.hpp"
 
-#include <glog/logging.h>
+#include <absl/log/check.h>
+#include <absl/log/log.h>
+#include <absl/log/vlog_is_on.h>
 
 #include <fmt/format.h>  // usually used in conjunction with logging
 #include <fmt/ranges.h>
@@ -39,6 +41,16 @@
 #define ROCP_LOG_LEVEL_WARNING 2
 #define ROCP_LOG_LEVEL_ERROR   1
 #define ROCP_LOG_LEVEL_NONE    0
+
+// Abseil does not provide VLOG_IF or LOG_ASSERT. Define compatibility macros.
+#ifndef VLOG_IF
+#    define VLOG_IF(level, condition)                                                              \
+        if(VLOG_IS_ON(level) && (condition)) VLOG(level)
+#endif
+
+#ifndef LOG_ASSERT
+#    define LOG_ASSERT(condition) CHECK(condition)
+#endif
 
 #define ROCP_TRACE   VLOG(ROCP_LOG_LEVEL_TRACE)
 #define ROCP_INFO    LOG(INFO)
@@ -66,13 +78,30 @@ namespace rocprofiler
 {
 namespace common
 {
+/// CHECK_NOTNULL compatibility wrapper (abseil does not provide one).
+/// Returns the value so it can be used as an expression:
+///   auto* p = CHECK_NOTNULL(some_ptr);
+/// Takes by const& to support move-only types like unique_ptr.
+template <typename T>
+const T&
+check_notnull_impl(const char* expr, const T& ptr)
+{
+    CHECK(ptr != nullptr) << "'" << expr << "' Must be non NULL";
+    return ptr;
+}
+
+template <typename T>
+T&
+check_notnull_impl(const char* expr, T& ptr)
+{
+    CHECK(ptr != nullptr) << "'" << expr << "' Must be non NULL";
+    return ptr;
+}
+
 struct logging_config
 {
     bool        install_failure_handler = false;
-    bool        logtostderr             = true;
-    bool        alsologtostderr         = false;
-    bool        logdir_gitignore        = false;  // add .gitignore to logdir
-    int32_t     loglevel                = google::WARNING;
+    int32_t     loglevel                = 1;  // WARNING
     int32_t     vlog_level              = ROCP_LOG_LEVEL_WARNING;
     std::string vlog_modules            = {};
     std::string name                    = {};
@@ -86,3 +115,5 @@ void
 update_logging(const logging_config& cfg);
 }  // namespace common
 }  // namespace rocprofiler
+
+#define CHECK_NOTNULL(val) ::rocprofiler::common::check_notnull_impl(#val, (val))

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-rocattach/rocattach.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-rocattach/rocattach.cpp
@@ -96,7 +96,6 @@ initialize_logging()
 {
     auto logging_cfg = rocprofiler::common::logging_config{.install_failure_handler = true};
     common::init_logging("ROCATTACH", logging_cfg);
-    FLAGS_colorlogtostderr = true;
 }
 
 session_list_t*

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-tool/helper.hpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-tool/helper.hpp
@@ -49,7 +49,7 @@
 #include <hsa/hsa_ven_amd_aqlprofile.h>
 #include <hsa/hsa_ven_amd_loader.h>
 
-#include <glog/logging.h>
+#include "lib/common/logging.hpp"
 
 #include <cxxabi.h>
 #include <semaphore.h>

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-tool/kokkosp/CMakeLists.txt
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-tool/kokkosp/CMakeLists.txt
@@ -15,7 +15,7 @@ target_link_libraries(
     PRIVATE rocprofiler-sdk-roctx::rocprofiler-sdk-roctx-shared-library
             rocprofiler-sdk::rocprofiler-sdk-headers
             rocprofiler-sdk::rocprofiler-sdk-common-library
-            rocprofiler-sdk::rocprofiler-sdk-glog)
+            rocprofiler-sdk::rocprofiler-sdk-abseil)
 
 set_target_properties(
     rocprofiler-sdk-tool-kokkosp

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-tool/tool.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-tool/tool.cpp
@@ -1794,7 +1794,6 @@ initialize_logging()
     {
         auto logging_cfg = rocprofiler::common::logging_config{.install_failure_handler = true};
         common::init_logging("ROCPROF", logging_cfg);
-        FLAGS_colorlogtostderr = isatty(fileno(stderr)) == 1 ? true : false;
     }
 }
 

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/aql/packet_construct.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/aql/packet_construct.cpp
@@ -26,7 +26,6 @@
 
 #include <fmt/core.h>
 #include <hsa/hsa_ext_amd.h>
-#include "glog/logging.h"
 
 #define CHECK_HSA(fn, message)                                                                     \
     {                                                                                              \

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/aql/tests/CMakeLists.txt
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/aql/tests/CMakeLists.txt
@@ -12,7 +12,7 @@ target_link_libraries(
     aql-test
     PRIVATE rocprofiler-sdk::counter-test-constants
             rocprofiler-sdk::rocprofiler-sdk-static-library
-            rocprofiler-sdk::rocprofiler-sdk-glog
+            rocprofiler-sdk::rocprofiler-sdk-abseil
             rocprofiler-sdk::rocprofiler-sdk-hsa-runtime
             rocprofiler-sdk::rocprofiler-sdk-hip
             rocprofiler-sdk::rocprofiler-sdk-common-library

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/buffer.hpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/buffer.hpp
@@ -36,6 +36,7 @@
 #include <atomic>
 #include <cstdint>
 #include <optional>
+#include <thread>
 
 namespace rocprofiler
 {

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/counters/core.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/counters/core.cpp
@@ -235,7 +235,7 @@ configure_buffered_dispatch(rocprofiler_context_id_t                   context_i
                             rocprofiler_dispatch_counting_service_cb_t callback,
                             void*                                      callback_args)
 {
-    CHECK_NE(buffer.handle, 0);
+    CHECK_NE(buffer.handle, 0ULL);
     return get_controller().configure_dispatch(
         context_id, buffer, callback, callback_args, nullptr, nullptr);
 }

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/counters/metrics.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/counters/metrics.cpp
@@ -33,7 +33,6 @@
 #include <rocprofiler-sdk/fwd.h>
 #include <rocprofiler-sdk/cxx/details/tokenize.hpp>
 
-#include "glog/logging.h"
 #include "yaml-cpp/exceptions.h"
 #include "yaml-cpp/node/convert.h"
 #include "yaml-cpp/node/detail/impl.h"

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/counters/tests/device_counting.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/counters/tests/device_counting.cpp
@@ -506,9 +506,9 @@ protected:
         int*                             gpuMem;
         [[maybe_unused]] hipDeviceProp_t devProp;
         auto                             status = hipGetDeviceProperties(&devProp, 0);
-        CHECK_EQ(status, HSA_STATUS_SUCCESS);
+        CHECK_EQ(status, hipSuccess);
         status = hipMalloc((void**) &gpuMem, 1 * sizeof(int));
-        CHECK_EQ(status, HSA_STATUS_SUCCESS);
+        CHECK_EQ(status, hipSuccess);
 
         bool test_ran = false;
         CHECK(!supported_agents.empty());

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/hsa/async_copy.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/hsa/async_copy.cpp
@@ -42,7 +42,6 @@
 #include <rocprofiler-sdk/hsa/table_id.h>
 #include <rocprofiler-sdk/cxx/constants.hpp>
 
-#include <glog/logging.h>
 #include <hsa/amd_hsa_signal.h>
 #include <hsa/hsa.h>
 

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/hsa/memory_allocation.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/hsa/memory_allocation.cpp
@@ -41,7 +41,6 @@
 #include <rocprofiler-sdk/hsa/table_id.h>
 #include <rocprofiler-sdk/cxx/constants.hpp>
 
-#include <glog/logging.h>
 #include <hsa/amd_hsa_signal.h>
 #include <hsa/hsa.h>
 

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/hsa/pc_sampling.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/hsa/pc_sampling.cpp
@@ -33,7 +33,6 @@
 #    include <rocprofiler-sdk/hsa/api_id.h>
 #    include <rocprofiler-sdk/hsa/table_id.h>
 
-#    include <glog/logging.h>
 #    include <hsa/amd_hsa_signal.h>
 #    include <hsa/hsa.h>
 #    include <hsa/hsa_api_trace.h>

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/ompt/ompt.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/ompt/ompt.cpp
@@ -37,8 +37,6 @@
 #include <rocprofiler-sdk/ompt/api_args.h>
 #include <rocprofiler-sdk/ompt/omp-tools.h>
 
-#include <glog/logging.h>
-
 #include <cstddef>
 #include <cstdint>
 #include <unordered_map>

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/pc_sampling/code_object.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/pc_sampling/code_object.cpp
@@ -34,7 +34,6 @@
 #    include <rocprofiler-sdk/pc_sampling.h>
 #    include <rocprofiler-sdk/cxx/operators.hpp>
 
-#    include <glog/logging.h>
 #    include <hsa/hsa.h>
 #    include <hsa/hsa_api_trace.h>
 #    include <hsa/hsa_ven_amd_loader.h>

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/rocprofiler-avail/rocprofv3_avail.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/rocprofiler-avail/rocprofv3_avail.cpp
@@ -78,7 +78,6 @@ initialize_logging()
 {
     auto logging_cfg = rocprofiler::common::logging_config{.install_failure_handler = true};
     common::init_logging("ROCPROF", logging_cfg);
-    FLAGS_colorlogtostderr = isatty(fileno(stderr)) == 1 ? true : false;
 }
 
 tool::metadata&

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/thread_trace/decode.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/thread_trace/decode.cpp
@@ -33,7 +33,7 @@
 #include <rocprofiler-sdk/cxx/hash.hpp>
 #include <rocprofiler-sdk/cxx/operators.hpp>
 
-#include <glog/logging.h>
+#include "lib/common/logging.hpp"
 
 #include <atomic>
 #include <cstdint>

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/thread_trace/service.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/thread_trace/service.cpp
@@ -27,7 +27,7 @@
 
 #include <rocprofiler-sdk/experimental/thread_trace.h>
 
-#include <glog/logging.h>
+#include "lib/common/logging.hpp"
 
 #include <cstdint>
 

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/thread_trace/tests/CMakeLists.txt
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/thread_trace/tests/CMakeLists.txt
@@ -11,7 +11,7 @@ target_sources(thread-trace-packet-test PRIVATE ${ROCPROFILER_THREAD_TRACE_TEST_
 target_link_libraries(
     thread-trace-packet-test
     PRIVATE rocprofiler-sdk::rocprofiler-sdk-static-library
-            rocprofiler-sdk::rocprofiler-sdk-glog
+            rocprofiler-sdk::rocprofiler-sdk-abseil
             rocprofiler-sdk::rocprofiler-sdk-hsa-runtime
             rocprofiler-sdk::rocprofiler-sdk-hip
             rocprofiler-sdk::rocprofiler-sdk-common-library

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/thread_trace/tests/att_packet_test.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/thread_trace/tests/att_packet_test.cpp
@@ -34,8 +34,8 @@
 #include "lib/rocprofiler-sdk/registration.hpp"
 #include "lib/rocprofiler-sdk/thread_trace/core.hpp"
 
-#include <glog/logging.h>
 #include <gtest/gtest.h>
+#include "lib/common/logging.hpp"
 
 #include <algorithm>
 #include <cstdint>

--- a/projects/rocprofiler-sdk/source/lib/tests/buffering/buffering-parallel.cpp
+++ b/projects/rocprofiler-sdk/source/lib/tests/buffering/buffering-parallel.cpp
@@ -31,6 +31,7 @@
 #include <cstdint>
 #include <cstdlib>
 #include <limits>
+#include <thread>
 #include <typeinfo>
 #include <utility>
 

--- a/projects/rocprofiler-sdk/source/lib/tests/buffering/buffering-save-load.cpp
+++ b/projects/rocprofiler-sdk/source/lib/tests/buffering/buffering-save-load.cpp
@@ -32,6 +32,7 @@
 #include <cstdlib>
 #include <fstream>
 #include <limits>
+#include <thread>
 #include <typeinfo>
 #include <utility>
 

--- a/projects/rocprofiler-sdk/source/lib/tests/codeobj/CMakeLists.txt
+++ b/projects/rocprofiler-sdk/source/lib/tests/codeobj/CMakeLists.txt
@@ -111,7 +111,7 @@ endif()
 target_link_libraries(
     codeobj-library-tests
     PRIVATE rocprofiler-sdk::rocprofiler-sdk-static-library
-            rocprofiler-sdk::rocprofiler-sdk-glog
+            rocprofiler-sdk::rocprofiler-sdk-abseil
             rocprofiler-sdk::rocprofiler-sdk-hsa-runtime
             rocprofiler-sdk::rocprofiler-sdk-hip
             rocprofiler-sdk::rocprofiler-sdk-common-library

--- a/projects/rocprofiler-sdk/source/lib/tests/codeobj/codeobj_library_test.cpp
+++ b/projects/rocprofiler-sdk/source/lib/tests/codeobj/codeobj_library_test.cpp
@@ -20,12 +20,12 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-#include <glog/logging.h>
 #include <gtest/gtest.h>
 #include <fstream>
 #include <rocprofiler-sdk/cxx/codeobj/code_printing.hpp>
 #include <string_view>
 #include <vector>
+#include "lib/common/logging.hpp"
 
 #include "lib/common/filesystem.hpp"
 

--- a/projects/rocprofiler-sdk/source/lib/tests/common/environment.cpp
+++ b/projects/rocprofiler-sdk/source/lib/tests/common/environment.cpp
@@ -131,7 +131,7 @@ TEST(common, environment_push_pop)
     common::set_env("ROCPROFILER_ENV_TEST_A", "0", 1);
     common::set_env("ROCPROFILER_ENV_TEST_B", "2", 1);
 
-    auto _store = env_store{{env_config{"ROCPROFILER_ENV_TEST_A", "1"},
+    auto _store = env_store{{env_config{"ROCPROFILER_ENV_TEST_A", "1", 1},
                              env_config{"ROCPROFILER_ENV_TEST_B", "2", 1},
                              env_config{"ROCPROFILER_ENV_TEST_C", "3", 0}}};
 

--- a/projects/rocprofiler-sdk/source/scripts/thread-sanitizer-suppr.txt
+++ b/projects/rocprofiler-sdk/source/scripts/thread-sanitizer-suppr.txt
@@ -22,8 +22,6 @@ mutex:libhsa-runtime64.so
 # unlock of an unlocked mutex (or by a wrong thread)
 mutex:librocm_smi64.so
 
-# google logging
-race:google::LogMessageTime::CalcGmtOffset
 race:tzset_internal
 
 # bug in libtsan.so.0 which thinks there is a

--- a/projects/rocprofiler-sdk/source/scripts/undef-behavior-sanitizer-suppr.txt
+++ b/projects/rocprofiler-sdk/source/scripts/undef-behavior-sanitizer-suppr.txt
@@ -42,9 +42,6 @@ function:__kmp_resume_template
 vptr:__kmp_suspend_initialize_thread
 function:__kmp_suspend_initialize_thread
 
-# Suppress issues in google logging
-vptr:google::LogMessageTime::CalcGmtOffset
-function:google::LogMessageTime::CalcGmtOffset
 vptr:tzset_internal
 function:tzset_internal
 


### PR DESCRIPTION
## Summary

Migrate rocprofiler-sdk from the deprecated [glog](https://github.com/google/glog) library to [Abseil Logging](https://github.com/abseil/abseil-cpp) (`absl::log`).

### Why

- **glog is archived** (deprecated 2025-06-30) and no longer maintained
- **Static destruction crash**: glog's `log_destinations_[]` uses `static unique_ptr<LogDestination>` which gets destroyed during static destruction, causing SIGSEGV when the SDK's `finalize()` logs during teardown. Abseil solves this with `NoDestructor<T>` — logging infrastructure is never destroyed
- **Environment variable pollution**: glog required setting `GLOG_*` environment variables which could conflict with host applications. Abseil uses a programmatic API (`absl::SetMinLogLevel()`, `absl::SetStderrThreshold()`, `absl::SetGlobalVLogLevel()`)
- **Static linking + hidden visibility**: Abseil is statically linked with hidden visibility, preventing the SDK's logging config from leaking to host applications

### Changes

- **Replace glog submodule with abseil-cpp** (`lts_2026_01_07`)
- **Rewrite `logging.cpp`**: Use `absl::InitializeLog()`, `absl::SetMinLogLevel()`, `absl::SetStderrThreshold()`, `absl::SetGlobalVLogLevel()` instead of glog FLAGS
- **Add compatibility macros**: `VLOG_IF` and `LOG_ASSERT` (abseil intentionally omits these)
- **Add `CHECK_NOTNULL` wrapper**: Abseil doesn't provide one; our template handles raw pointers and move-only types (`unique_ptr`)
- **Remove all `#include <glog/logging.h>`** directives (11 files), replace with `#include "lib/common/logging.hpp"`
- **Remove `FLAGS_colorlogtostderr`** usage (3 files) — abseil auto-detects TTY
- **Remove glog sanitizer suppressions** (2 files)
- **Add explicit `#include <thread>`** where glog transitively provided it (3 files)
- **Fix `env_store` to preserve overwrite flag** from `env_config` — previously hardcoded `overwrite=1`
- **Update `environment_push_pop` test** to match env_store fix

### Files Modified: 38

| Category | Count |
|---|---|
| Submodule swap (glog → abseil-cpp) | 3 |
| CMake (options, interfaces, external, test CMakeLists) | 9 |
| Core logging (logging.hpp, logging.cpp) | 2 |
| Direct glog include removal | 11 |
| FLAGS_colorlogtostderr removal | 3 |
| Sanitizer suppressions | 2 |
| Missing `<thread>` include | 3 |
| env_store fix + test | 5 |

### Zero-change files

All 44+ files using `CHECK_NOTNULL`, `ROCP_*` macros, `CHECK`/`CHECK_EQ`/`CHECK_NE`, or `LOG`/`VLOG` — these macro names are identical between glog and abseil.

## Test Plan

- [x] Full build succeeds (0 errors, 0 warnings related to migration)
- [x] All non-GPU unit tests pass (parser, evaluate_ast, FirmwareRestrictions, aql_helpers, buffering, logging, environment)
- [x] `environment_push_pop` test passes with env_store overwrite fix
- [ ] Full CI with GPU hardware (GPU tests require `/dev/kfd` access)

**Note**: `FirmwareRestrictions.EmptyArchitecturesListAppliesToAll` is a pre-existing failure unrelated to this migration.

## Test Result

Container testing on `smc300x-clt-r4c7-26` (no GPU access): all non-GPU unit tests pass. All GPU-dependent test failures are `hsa_init() == 4104` (HSA_STATUS_ERROR_NOT_INITIALIZED) due to missing `/dev/kfd` in the test container — not related to the logging migration.