### PR TITLE
clr: Fix batch flush to use explicit Marker instead of EnableProfiling

### DIFF
--- a/projects/clr/rocclr/platform/command.cpp
+++ b/projects/clr/rocclr/platform/command.cpp
@@ -388,10 +388,9 @@ void Command::enqueue() {
     std::scoped_lock sl(queue_->vdev()->execution());
     queue_->FormSubmissionBatch(this);
 
-    // Enqueue flushes, except profiling markers to avoid frequent expensive callbacks.
-    // Also flush unconditionally when the batch exceeds the size threshold.
+    // Enqueue flushes, except profiling markers to avoid frequent expensive callbacks
     if (((type() == 0) && profilingInfo().batch_flush_) || (type() == CL_COMMAND_MARKER) ||
-        (type() == CL_COMMAND_TASK) || queue_->ShouldFlushBatch()) {
+        (type() == CL_COMMAND_TASK)) {
       // The current HSA signal tracking logic requires profiling enabled for the markers
       EnableProfiling();
       // Update batch head for the current marker. Hence the status of all commands can be
@@ -404,6 +403,7 @@ void Command::enqueue() {
       queue_->ResetSubmissionBatch();
     } else {
       submit(*queue_->vdev());
+      queue_->FlushSubmissionBatch();
     }
   } else {
     queue_->append(*this);

--- a/projects/clr/rocclr/platform/commandqueue.cpp
+++ b/projects/clr/rocclr/platform/commandqueue.cpp
@@ -128,6 +128,16 @@ bool HostQueue::terminate() {
   return true;
 }
 
+void HostQueue::FlushSubmissionBatch() {
+  if (size_ > DEBUG_CLR_MAX_BATCH_SIZE) {
+    auto marker = new Marker(*this, false);
+    if (marker != nullptr) {
+      marker->enqueue();
+      marker->release();
+    }
+  }
+}
+
 void HostQueue::finishCommand(Command* command) {
   if (command == nullptr) {
     command = getLastQueuedCommand(true);

--- a/projects/clr/rocclr/platform/commandqueue.hpp
+++ b/projects/clr/rocclr/platform/commandqueue.hpp
@@ -280,8 +280,8 @@ class HostQueue : public CommandQueue {
     lastEnqueueCommand_ = command;
   }
 
-  //! Returns true if the batch size exceeds the flush threshold
-  bool ShouldFlushBatch() const { return size_ > DEBUG_CLR_MAX_BATCH_SIZE; }
+  //! Flushes submitted commands if the batch size significantly grew
+  void FlushSubmissionBatch();
   //! Reset the command batch list
   void ResetSubmissionBatch() {
     head_ = nullptr;


### PR DESCRIPTION
- The original FlushSubmissionBatch called notifyCmdQueue(), which is gated by ((HwEvent() == nullptr) || !amd::IS_HIP) — always false for HIP kernel dispatches since they carry HSA signals. The batch was never flushed at the threshold for HIP.
- Fix by creating an explicit Marker in FlushSubmissionBatch when the batch exceeds the threshold.

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
