### PR TITLE
kpack: enable compression, add per-arch Tensile layout, handle MIOpen .kdb

### DIFF
--- a/shared/kpack/python/rocm_kpack/artifact_splitter.py
+++ b/shared/kpack/python/rocm_kpack/artifact_splitter.py
@@ -426,6 +426,7 @@ class ArtifactSplitter:
                 group_name=self.artifact_prefix,
                 gfx_arch_family=arch,  # Use specific arch, not family
                 gfx_arches=[arch],
+                compressor=ZstdCompressor(),
             )
 
             # Add kernels to archive

--- a/shared/kpack/python/rocm_kpack/database_handlers.py
+++ b/shared/kpack/python/rocm_kpack/database_handlers.py
@@ -89,94 +89,81 @@ class DatabaseHandler(ABC):
         return True
 
 
-class RocBLASHandler(DatabaseHandler):
+# Regex matching a library/<arch>/ path component (for per-arch subdirectory layout).
+_LIBRARY_ARCH_DIR_PATTERN = re.compile(
+    r"/library/(" + _GFX_ARCH_PATTERN.pattern + r")/"
+)
+
+
+class _TensileHandler(DatabaseHandler):
+    """Base class for Tensile-based library handlers (rocBLAS, hipBLASLt, hipSPARSELt).
+
+    Supports two directory layouts:
+
+    Flat (current):
+        lib/<lib>/library/TensileLibrary_gfx942.co
+        lib/<lib>/library/TensileLibrary_..._fallback.dat  (no arch → generic)
+
+    Per-arch subdirectory (rocm-libraries#5976):
+        lib/<lib>/library/gfx942/TensileLibrary_....co
+        lib/<lib>/library/gfx942/TensileLibrary_..._fallback.dat
+        lib/<lib>/library/gfx942/TensileManifest.txt
+
+    In the flat layout, architecture is extracted from the filename and only
+    known Tensile extensions are accepted. In the per-arch layout, the
+    architecture comes from the directory name and any file underneath is
+    accepted (manifests, fallback .dat files, etc.).
+    """
+
+    # Subclasses set this to the directory marker (e.g. "rocblas/library")
+    _library_dir: str
+
+    def detect(self, path: Path, prefix_root: Path) -> Optional[str]:
+        path_str = self._relative_path(path, prefix_root)
+
+        if self._library_dir not in path_str:
+            return None
+
+        # Try filename-based detection (flat layout, known extensions)
+        if path.suffix in (".co", ".hsaco", ".dat"):
+            match = _GFX_ARCH_PATTERN.search(path.name)
+            if match:
+                return match.group(0)
+
+        # Try directory-based detection (per-arch subdirectory layout):
+        # .../library/<arch>/anything
+        dir_match = _LIBRARY_ARCH_DIR_PATTERN.search(path_str)
+        if dir_match:
+            return dir_match.group(1)
+
+        return None
+
+
+class RocBLASHandler(_TensileHandler):
     """Handler for rocBLAS Tensile library files."""
+
+    _library_dir = "rocblas/library"
 
     def name(self) -> str:
         return "rocblas"
 
-    def detect(self, path: Path, prefix_root: Path) -> Optional[str]:
-        """
-        Detect rocBLAS kernel database files.
 
-        Pattern: lib/rocblas/library/*_gfx*.{co,hsaco,dat}
-        """
-        path_str = self._relative_path(path, prefix_root)
-
-        # Check if it's in rocblas/library directory
-        if "rocblas/library" not in path_str:
-            return None
-
-        # Check file extension
-        if path.suffix not in [".co", ".hsaco", ".dat"]:
-            return None
-
-        # Extract architecture from filename
-        # Look for patterns like _gfx1100, _gfx1101, gfx1102, etc.
-        match = _GFX_ARCH_PATTERN.search(path.name)
-        if match:
-            return match.group(0)
-
-        # Some .dat files don't have architecture suffix but are generic
-        # We don't move those
-        return None
-
-
-class HipBLASLtHandler(DatabaseHandler):
+class HipBLASLtHandler(_TensileHandler):
     """Handler for hipBLASLt kernel files."""
+
+    _library_dir = "hipblaslt/library"
 
     def name(self) -> str:
         return "hipblaslt"
 
-    def detect(self, path: Path, prefix_root: Path) -> Optional[str]:
-        """
-        Detect hipBLASLt kernel database files.
 
-        Pattern: lib/hipblaslt/library/*_gfx*.{co,hsaco,dat}
-        """
-        path_str = self._relative_path(path, prefix_root)
-
-        # Check if it's in hipblaslt/library directory
-        if "hipblaslt/library" not in path_str:
-            return None
-
-        # Check file extension
-        if path.suffix not in [".co", ".hsaco", ".dat"]:
-            return None
-
-        # Extract architecture from filename
-        match = _GFX_ARCH_PATTERN.search(path.name)
-        if match:
-            return match.group(0)
-
-        return None
-
-
-class HipSparseLtHandler(DatabaseHandler):
+class HipSparseLtHandler(_TensileHandler):
     """Handler for hipSPARSELt Tensile kernel files."""
+
+    _library_dir = "hipsparselt/library"
 
     def name(self) -> str:
         return "hipsparselt"
-
-    def detect(self, path: Path, prefix_root: Path) -> Optional[str]:
-        """
-        Detect hipSPARSELt kernel database files.
-
-        Pattern: lib/hipsparselt/library/*_gfx*.{co,hsaco,dat}
-        """
-        path_str = self._relative_path(path, prefix_root)
-
-        if "hipsparselt/library" not in path_str:
-            return None
-
-        if path.suffix not in [".co", ".hsaco", ".dat"]:
-            return None
-
-        match = _GFX_ARCH_PATTERN.search(path.name)
-        if match:
-            return match.group(0)
-
-        return None
 
 
 class AotritonHandler(DatabaseHandler):
@@ -261,10 +248,11 @@ class MIOpenHandler(DatabaseHandler):
         if not path.is_file():
             return None
 
-        # Match .model, .db.txt, .fdb.txt, .OpenCL.fdb.txt, .HIP.fdb.txt
+        # Match .kdb, .model, .db.txt, .fdb.txt, .OpenCL.fdb.txt, .HIP.fdb.txt
         name = path.name
         if not (
-            name.endswith(".model")
+            name.endswith(".kdb")
+            or name.endswith(".model")
             or name.endswith(".db.txt")
             or name.endswith(".fdb.txt")
         ):

--- a/shared/kpack/tests/test_database_handlers.py
+++ b/shared/kpack/tests/test_database_handlers.py
@@ -102,6 +102,53 @@ class TestRocBLASHandler:
         result = handler.detect(file_path, prefix_root)
         assert result == "gfx942-xnack-"
 
+    def test_detect_arch_subdir_co(self, handler, prefix_root):
+        """Per-arch subdirectory layout: .co file under library/<arch>/."""
+        file_path = (
+            prefix_root
+            / "lib/rocblas/library/gfx942/TensileLibrary_Type_HH_gfx942.co"
+        )
+        file_path.parent.mkdir(parents=True)
+        file_path.touch()
+
+        result = handler.detect(file_path, prefix_root)
+        assert result == "gfx942"
+
+    def test_detect_arch_subdir_fallback_dat(self, handler, prefix_root):
+        """Per-arch subdirectory layout: fallback .dat with no arch in filename."""
+        file_path = (
+            prefix_root
+            / "lib/rocblas/library/gfx1100/TensileLibrary_Type_HH_fallback.dat"
+        )
+        file_path.parent.mkdir(parents=True)
+        file_path.touch()
+
+        result = handler.detect(file_path, prefix_root)
+        assert result == "gfx1100"
+
+    def test_detect_arch_subdir_manifest(self, handler, prefix_root):
+        """Per-arch subdirectory layout: TensileManifest.txt under library/<arch>/."""
+        file_path = (
+            prefix_root / "lib/rocblas/library/gfx90a/TensileManifest.txt"
+        )
+        file_path.parent.mkdir(parents=True)
+        file_path.touch()
+
+        result = handler.detect(file_path, prefix_root)
+        assert result == "gfx90a"
+
+    def test_detect_arch_subdir_xnack(self, handler, prefix_root):
+        """Per-arch subdirectory layout with xnack variant."""
+        file_path = (
+            prefix_root
+            / "lib/rocblas/library/gfx942-xnack+/TensileLibrary.co"
+        )
+        file_path.parent.mkdir(parents=True)
+        file_path.touch()
+
+        result = handler.detect(file_path, prefix_root)
+        assert result == "gfx942-xnack+"
+
     def test_reject_wrong_directory(self, handler, prefix_root):
         """Test that files not in rocblas/library are rejected."""
         file_path = prefix_root / "lib/other/library/TensileLibrary_gfx1100.dat"
@@ -112,7 +159,7 @@ class TestRocBLASHandler:
         assert result is None
 
     def test_reject_wrong_extension(self, handler, prefix_root):
-        """Test that files with unsupported extensions are rejected."""
+        """Flat layout: unknown extensions without arch subdir are rejected."""
         file_path = prefix_root / "lib/rocblas/library/TensileLibrary_gfx1100.txt"
         file_path.parent.mkdir(parents=True)
         file_path.touch()
@@ -223,6 +270,29 @@ class TestHipBLASLtHandler:
         result = handler.detect(file_path, prefix_root)
         assert result == "gfx942-xnack-"
 
+    def test_detect_arch_subdir_fallback_dat(self, handler, prefix_root):
+        """Per-arch subdirectory layout: fallback .dat with no arch in filename."""
+        file_path = (
+            prefix_root
+            / "lib/hipblaslt/library/gfx942/TensileLibrary_Type_SS_fallback.dat"
+        )
+        file_path.parent.mkdir(parents=True)
+        file_path.touch()
+
+        result = handler.detect(file_path, prefix_root)
+        assert result == "gfx942"
+
+    def test_detect_arch_subdir_manifest(self, handler, prefix_root):
+        """Per-arch subdirectory layout: manifest .txt under library/<arch>/."""
+        file_path = (
+            prefix_root / "lib/hipblaslt/library/gfx1100/TensileManifest.txt"
+        )
+        file_path.parent.mkdir(parents=True)
+        file_path.touch()
+
+        result = handler.detect(file_path, prefix_root)
+        assert result == "gfx1100"
+
     def test_reject_wrong_directory(self, handler, prefix_root):
         """Test that files not in hipblaslt/library are rejected."""
         file_path = prefix_root / "lib/rocblas/library/TensileLibrary_gfx1100.dat"
@@ -233,7 +303,7 @@ class TestHipBLASLtHandler:
         assert result is None
 
     def test_reject_wrong_extension(self, handler, prefix_root):
-        """Test that files with unsupported extensions are rejected."""
+        """Flat layout: unknown extensions without arch subdir are rejected."""
         file_path = prefix_root / "lib/hipblaslt/library/TensileLibrary_gfx1100.json"
         file_path.parent.mkdir(parents=True)
         file_path.touch()
@@ -299,6 +369,18 @@ class TestHipSparseLtHandler:
 
         result = handler.detect(file_path, prefix_root)
         assert result == "gfx942"
+
+    def test_detect_arch_subdir_dat(self, handler, prefix_root):
+        """Per-arch subdirectory layout: .dat file under library/<arch>/."""
+        file_path = (
+            prefix_root
+            / "lib/hipsparselt/library/gfx950/TensileLibrary_BB_BB_A_fallback.dat"
+        )
+        file_path.parent.mkdir(parents=True)
+        file_path.touch()
+
+        result = handler.detect(file_path, prefix_root)
+        assert result == "gfx950"
 
     def test_reject_wrong_directory(self, handler, prefix_root):
         file_path = prefix_root / "lib/rocblas/library/something_gfx942.co"
@@ -455,6 +537,32 @@ class TestMIOpenHandler:
 
     def test_name(self, handler):
         assert handler.name() == "miopen"
+
+    def test_detect_kdb(self, handler, prefix_root):
+        """MIOpen .kdb files (SQLite compiled kernel databases)."""
+        file_path = prefix_root / "share/miopen/db/gfx942.kdb"
+        file_path.parent.mkdir(parents=True)
+        file_path.touch()
+
+        result = handler.detect(file_path, prefix_root)
+        assert result == "gfx942"
+
+    def test_detect_kdb_various_arches(self, handler, prefix_root):
+        """MIOpen .kdb files across multiple architectures."""
+        test_cases = [
+            ("gfx90a.kdb", "gfx90a"),
+            ("gfx908.kdb", "gfx908"),
+            ("gfx1100.kdb", "gfx1100"),
+            ("gfx950.kdb", "gfx950"),
+        ]
+
+        for filename, expected_arch in test_cases:
+            file_path = prefix_root / f"share/miopen/db/{filename}"
+            file_path.parent.mkdir(parents=True, exist_ok=True)
+            file_path.touch()
+
+            result = handler.detect(file_path, prefix_root)
+            assert result == expected_arch, f"Failed for {filename}"
 
     def test_detect_tn_model(self, handler, prefix_root):
         file_path = prefix_root / "share/miopen/db/gfx908.tn.model"


### PR DESCRIPTION
Three related improvements to the kpack database handler system:

Changes:
- Enable zstd compression on kpack archives created during database file splitting (addresses PR #4603 review comment).
- Refactor rocBLAS/hipBLASLt/hipSPARSELt handlers into a shared _TensileHandler base class that supports both the current flat library/ layout and the upcoming library/<arch>/ subdirectory layout from rocm-libraries#5976. This handles fallback .dat files, TensileManifest.txt, and other artifacts that will move into per-architecture subdirectories.
- Add .kdb extension to MIOpenHandler so arch-specific SQLite kernel databases (e.g. gfx942.kdb) are routed to arch-specific artifacts instead of falling through to generic.

Related:
* rocm-libraries#5976
* rocm-libraries#6076