### PR TITLE
rocminfo: Add RDNA3/RDNA4 device IDs to rocm_agent_enumerator

### DIFF
--- a/projects/rocminfo/rocm_agent_enumerator
+++ b/projects/rocminfo/rocm_agent_enumerator
@@ -84,12 +84,17 @@ ISA_TO_ID = {
   # Yellow_Carp
   "gfx1035" : [0x164d, 0x1681],
 
-  # Navi31
-  "gfx1100": [0x7448, 0x7449, 0x744a, 0x744c, 0x745e],
-  # Navi32
-  "gfx1101": [0x7470, 0x747e],
-  # Navi33
-  "gfx1102": [0x7480, 0x7483, 0x7489, 0x7499],
+  # Navi31 (RDNA3) - Radeon RX 7900 series, Pro W7800, Pro V710
+  "gfx1100" : [0x7448, 0x7449, 0x744a, 0x744c, 0x745e, 0x7460, 0x7461],
+  # Navi32 (RDNA3) - Radeon RX 7800/7700 series, Pro W7700
+  "gfx1101" : [0x7470, 0x747e],
+  # Navi33 (RDNA3) - Radeon RX 7600 series, Pro W7500/W7400
+  "gfx1102" : [0x7480, 0x7481, 0x7483, 0x7489, 0x7499],
+
+  # Navi44 (RDNA4) - Radeon RX 9060 series
+  "gfx1200" : [0x7590],
+  # Navi48 (RDNA4) - Radeon RX 9070 series
+  "gfx1201" : [0x7550, 0x7551],
 }
 
 def staticVars(**kwargs):


### PR DESCRIPTION
Add missing PCI device IDs for gfx11 (RDNA3) and gfx12 (RDNA4):

gfx1100 (Navi31): Add 0x7460, 0x7461 for additional variants
gfx1102 (Navi33): Add 0x7481 for additional variants
gfx1200 (Navi44): Add 0x7590 for Radeon RX 9060 series
gfx1201 (Navi48): Add 0x7550, 0x7551 for Radeon RX 9070 series

Improve comments to identify product names for each GPU family.

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
