### PR TITLE
Reduce Kernel Gaps - Update acquire fence bits based on environment variable

### DIFF
--- a/projects/clr/rocclr/device/device.cpp
+++ b/projects/clr/rocclr/device/device.cpp
@@ -1239,6 +1239,13 @@ Settings::Settings() : value_(0) {
   waitCommand_ = AMD_OCL_WAIT_COMMAND;
   supportDepthsRGB_ = false;
   fenceScopeAgent_ = AMD_OPT_FLUSH;
+  {
+    unsigned m = static_cast<unsigned>(HIP_AQL_KERNEL_DISPATCH_FENCE_NONE);
+    if(m > 1) {
+      m = 0;
+    }
+    hipAqlKernelDispatchFenceMode_ = m;
+  }
 
   // Amend certain flags for OpenCL
   if (!amd::IS_HIP) {

--- a/projects/clr/rocclr/device/device.hpp
+++ b/projects/clr/rocclr/device/device.hpp
@@ -698,7 +698,7 @@ class Settings : public amd::HeapObject {
       uint kernel_arg_opt_ : 1;               //!< Enables kernel arg optimization for blit kernels
       uint kernel_arg_impl_ : 2;              //!< Kernel argument implementation
       uint sdma_swap_supported_ : 1;         //!< SDMA linear swap copy (gfx94x/gfx95x)
-      uint reserved_ : 13;
+      uint reserved_ : 12;
     };
     uint value_;
   };

--- a/projects/clr/rocclr/device/device.hpp
+++ b/projects/clr/rocclr/device/device.hpp
@@ -692,6 +692,7 @@ class Settings : public amd::HeapObject {
       uint enableCoopGroups_ : 1;             //!< Enable cooperative groups feature
       uint enableCoopMultiDeviceGroups_ : 1;  //!< Enable cooperative groups multi device
       uint fenceScopeAgent_ : 1;              //!< Enable fence scope agent in AQL dispatch packet
+      uint hipAqlKernelDispatchFenceMode_ : 1;  //!< HIP_AQL_KERNEL_DISPATCH_FENCE_NONE: 0 default,1 acquire NONE only
       uint rocr_backend_ : 1;                 //!< Device uses ROCr backend for submissions
       uint gwsInitSupported_ : 1;             //!< Check if GWS is supported on this machine.
       uint kernel_arg_opt_ : 1;               //!< Enables kernel arg optimization for blit kernels

--- a/projects/clr/rocclr/device/rocm/rocvirtual.cpp
+++ b/projects/clr/rocclr/device/rocm/rocvirtual.cpp
@@ -29,6 +29,7 @@
 #include <vector>
 #include <atomic>
 #include <cinttypes>
+#include <cstdio>
 
 #if defined(__AVX__)
 #if defined(__MINGW64__)
@@ -174,6 +175,15 @@ static inline void logAqlBarrierValuePacket(const hsa_queue_t* queue, uint16_t h
           pkt->signal.handle, pkt->value, pkt->mask,
           pkt->cond == 0 ? "EQ" : pkt->cond == 1 ? "NE" : pkt->cond == 2 ? "LT" : "GTE",
           pkt->completion_signal.handle, rptr, wptr);
+}
+
+/** Clear only the kernel-dispatch acquire fence scope sub-field to HSA_FENCE_SCOPE_NONE. */
+static uint16_t hipKernelDispatchClearAcquireFence(uint16_t header) {
+  header &= ~(((1u << HSA_PACKET_HEADER_WIDTH_SCACQUIRE_FENCE_SCOPE) - 1u)
+              << HSA_PACKET_HEADER_SCACQUIRE_FENCE_SCOPE);
+  header |= static_cast<uint16_t>(HSA_FENCE_SCOPE_NONE)
+            << HSA_PACKET_HEADER_SCACQUIRE_FENCE_SCOPE;
+  return header;
 }
 
 // ================================================================================================
@@ -1138,10 +1148,17 @@ bool VirtualGPU::dispatchGenericAqlPacket(AqlPacket* packet, uint16_t header, ui
   setFenceDirty(true);
 
   if (addSystemScope_) {
-    header &= ~(HSA_FENCE_SCOPE_AGENT << HSA_PACKET_HEADER_SCACQUIRE_FENCE_SCOPE |
-                HSA_FENCE_SCOPE_AGENT << HSA_PACKET_HEADER_SCRELEASE_FENCE_SCOPE);
-    header |= (HSA_FENCE_SCOPE_SYSTEM << HSA_PACKET_HEADER_SCACQUIRE_FENCE_SCOPE |
-               HSA_FENCE_SCOPE_SYSTEM << HSA_PACKET_HEADER_SCRELEASE_FENCE_SCOPE);
+    const unsigned fm = dev().settings().hipAqlKernelDispatchFenceMode_;
+    if (fm == 0) {
+      header &= ~(HSA_FENCE_SCOPE_AGENT << HSA_PACKET_HEADER_SCACQUIRE_FENCE_SCOPE |
+                  HSA_FENCE_SCOPE_AGENT << HSA_PACKET_HEADER_SCRELEASE_FENCE_SCOPE);
+      header |= (HSA_FENCE_SCOPE_SYSTEM << HSA_PACKET_HEADER_SCACQUIRE_FENCE_SCOPE |
+                 HSA_FENCE_SCOPE_SYSTEM << HSA_PACKET_HEADER_SCRELEASE_FENCE_SCOPE);
+    } else if (fm == 1) {
+      header &= ~(HSA_FENCE_SCOPE_AGENT << HSA_PACKET_HEADER_SCRELEASE_FENCE_SCOPE);
+      header |= (HSA_FENCE_SCOPE_SYSTEM << HSA_PACKET_HEADER_SCRELEASE_FENCE_SCOPE);
+      header = hipKernelDispatchClearAcquireFence(header);
+    }
     addSystemScope_ = false;
   }
 
@@ -1310,10 +1327,17 @@ bool VirtualGPU::dispatchAqlPacketBatchFlat(const std::vector<uint8_t>& flatPack
   uint16_t firstSetup  = static_cast<uint16_t>(validFullHeaders[0] >> 16);
   uint16_t lastHeader  = static_cast<uint16_t>(validFullHeaders[numPackets - 1]);
   if (addSystemScope_) {
-    firstHeader &= ~(HSA_FENCE_SCOPE_AGENT << HSA_PACKET_HEADER_SCACQUIRE_FENCE_SCOPE);
-    firstHeader |= (HSA_FENCE_SCOPE_SYSTEM << HSA_PACKET_HEADER_SCACQUIRE_FENCE_SCOPE);
-    lastHeader &= ~(HSA_FENCE_SCOPE_AGENT << HSA_PACKET_HEADER_SCRELEASE_FENCE_SCOPE);
-    lastHeader |= (HSA_FENCE_SCOPE_SYSTEM << HSA_PACKET_HEADER_SCRELEASE_FENCE_SCOPE);
+    const unsigned fm = dev().settings().hipAqlKernelDispatchFenceMode_;
+    if (fm == 0) {
+      firstHeader &= ~(HSA_FENCE_SCOPE_AGENT << HSA_PACKET_HEADER_SCACQUIRE_FENCE_SCOPE);
+      firstHeader |= (HSA_FENCE_SCOPE_SYSTEM << HSA_PACKET_HEADER_SCACQUIRE_FENCE_SCOPE);
+      lastHeader &= ~(HSA_FENCE_SCOPE_AGENT << HSA_PACKET_HEADER_SCRELEASE_FENCE_SCOPE);
+      lastHeader |= (HSA_FENCE_SCOPE_SYSTEM << HSA_PACKET_HEADER_SCRELEASE_FENCE_SCOPE);
+    } else if (fm == 1) {
+      firstHeader = hipKernelDispatchClearAcquireFence(firstHeader);
+      lastHeader &= ~(HSA_FENCE_SCOPE_AGENT << HSA_PACKET_HEADER_SCRELEASE_FENCE_SCOPE);
+      lastHeader |= (HSA_FENCE_SCOPE_SYSTEM << HSA_PACKET_HEADER_SCRELEASE_FENCE_SCOPE);
+    }
     addSystemScope_ = false;
   }
 
@@ -1708,18 +1732,29 @@ VirtualGPU::VirtualGPU(Device& device, bool profiling, bool cooperative,
       (HSA_FENCE_SCOPE_SYSTEM << HSA_PACKET_HEADER_SCACQUIRE_FENCE_SCOPE) |
       (HSA_FENCE_SCOPE_AGENT << HSA_PACKET_HEADER_SCRELEASE_FENCE_SCOPE);
 
+  const unsigned fenceMode = device.settings().hipAqlKernelDispatchFenceMode_;
+  uint16_t defaultFenceBits;
   if (device.settings().fenceScopeAgent_) {
     const auto& isa = device.isa();
     const bool isGfx12 = (isa.versionMajor() == 12) && (isa.versionMinor() == 0) &&
                          (isa.versionStepping() == 0 || isa.versionStepping() == 1);
-
-    dispatchPacketHeaderNoSync_ =
-        (kernelDispatchHBits | (isGfx12 ? sysAcquireAgentReleaseHBits : agentScopeHBits));
-    dispatchPacketHeader_ = (kernelDispatchHBits | barrierHBits |
-                             (isGfx12 ? sysAcquireAgentReleaseHBits : agentScopeHBits));
+    defaultFenceBits = isGfx12 ? sysAcquireAgentReleaseHBits : agentScopeHBits;
   } else {
-    dispatchPacketHeaderNoSync_ = (kernelDispatchHBits | systemScopeHBits);
-    dispatchPacketHeader_ = (kernelDispatchHBits | barrierHBits | systemScopeHBits);
+    defaultFenceBits = systemScopeHBits;
+  }
+
+  if (fenceMode == 1) {
+    dispatchPacketHeaderNoSync_ =
+        hipKernelDispatchClearAcquireFence(kernelDispatchHBits | defaultFenceBits);
+    dispatchPacketHeader_ = hipKernelDispatchClearAcquireFence(
+        (kernelDispatchHBits | barrierHBits | defaultFenceBits));
+    std::fprintf(stderr,
+                 "[CLR] HIP_AQL_KERNEL_DISPATCH_FENCE_NONE=1: acquire AQL fence scope is NONE; "
+                 "release follows AMD_OPT_FLUSH/agent-or-system defaults (VirtualGPU index=%u)\n",
+                 index_);
+  } else {
+    dispatchPacketHeaderNoSync_ = (kernelDispatchHBits | defaultFenceBits);
+    dispatchPacketHeader_ = (kernelDispatchHBits | barrierHBits | defaultFenceBits);
   }
 
   aqlHeader_ = dispatchPacketHeader_;
@@ -4105,10 +4140,17 @@ bool VirtualGPU::submitKernelInternal(const amd::NDRangeContainer& sizes, const 
   // Copy scheduler's AQL packet for possible relaunch from the scheduler itself
   if (aql_packet != nullptr) {
     *aql_packet = dispatchPacket;
+    const unsigned fm = dev().settings().hipAqlKernelDispatchFenceMode_;
+    const uint16_t relaunchFenceBits = [&]() -> uint16_t {
+      constexpr uint16_t kSys = (HSA_FENCE_SCOPE_SYSTEM << HSA_PACKET_HEADER_SCACQUIRE_FENCE_SCOPE) |
+                                (HSA_FENCE_SCOPE_SYSTEM << HSA_PACKET_HEADER_SCRELEASE_FENCE_SCOPE);
+      if(fm == 1) {
+        return hipKernelDispatchClearAcquireFence(kSys);
+      }
+      return kSys;
+    }();
     aql_packet->header = (HSA_PACKET_TYPE_KERNEL_DISPATCH << HSA_PACKET_HEADER_TYPE) |
-                         (1 << HSA_PACKET_HEADER_BARRIER) |
-                         (HSA_FENCE_SCOPE_SYSTEM << HSA_PACKET_HEADER_ACQUIRE_FENCE_SCOPE) |
-                         (HSA_FENCE_SCOPE_SYSTEM << HSA_PACKET_HEADER_RELEASE_FENCE_SCOPE);
+                         (1 << HSA_PACKET_HEADER_BARRIER) | relaunchFenceBits;
     aql_packet->setup = sizes.dimensions() << HSA_KERNEL_DISPATCH_PACKET_SETUP_DIMENSIONS;
   }
 

--- a/projects/clr/rocclr/utils/flags.hpp
+++ b/projects/clr/rocclr/utils/flags.hpp
@@ -169,6 +169,9 @@ release(uint, HIP_HOST_COHERENT, 0,                                           \
 release(uint, AMD_OPT_FLUSH, 1,                                               \
         "Kernel flush option , 0x0 = Use system-scope fence operations."      \
         "0x1 = Use device-scope fence operations when possible.")             \
+release(uint, HIP_AQL_KERNEL_DISPATCH_FENCE_NONE, 0,                         \
+        "Kernel dispatch AQL fence override: 0=default, 1=acquire "          \
+        "HSA_FENCE_SCOPE_NONE only (release follows AMD_OPT_FLUSH).")          \
 release(bool, AMD_DIRECT_DISPATCH, IS_LINUX,                                  \
         "Enable direct kernel dispatch.")                                     \
 release(uint, HIP_HIDDEN_FREE_MEM, 0,                                         \


### PR DESCRIPTION
## Motivation

To improve performance and reduce kernel gaps on gfx1100, gfx1151
## Technical Details
The PR adds a new environment variable HIP_AQL_KERNEL_DISPATCH_FENCE_NONE which when set to 1, creates the AQL packet with acquire fence scope bits as 0. 
This changed help to reduce the GPU time on both Navi31 and StrixHalo.

## JIRA ID
https://jira.xilinx.com/browse/AIESW-27612

## Test Plan

Verified a unit test with 1000 kernel dispatches

## Test Result
========================================

Testing HIP Graph Performance (GRAPH ONLY)

N=512, NSTEP=10, NKERNEL=1000

========================================



--- Graph Mode ---

info: running on device #0 Radeon 8050S Graphics

[CLR] HIP_AQL_KERNEL_DISPATCH_FENCE_NONE=1: acquire AQL fence scope is NONE; release follows AMD_OPT_FLUSH/agent-or-system defaults (VirtualGPU index=0)

[CLR] HIP_AQL_KERNEL_DISPATCH_FENCE_NONE=1: acquire AQL fence scope is NONE; release follows AMD_OPT_FLUSH/agent-or-system defaults (VirtualGPU index=1)

Graph mode: Running 10 warm-up iterations...

Graph mode: Warm-up complete.



Time taken for graph with Init: 2111 microseconds, without Init: 170 microseconds, GPU time: 10494 microseconds

Out_h[510] = 10001 (expected: 10001)

Validation: PASSED





========================================

Results: Graph: PASS

========================================

**Performance measurement results on StrixHalo:**
<img width="724" height="132" alt="image" src="https://github.com/user-attachments/assets/b03a0915-444b-46a9-b709-5a0cc3e9e091" />

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
