### PR TITLE
fix --rocm-domains CLI option removed by config_settings guard

### DIFF
--- a/projects/rocprofiler-systems/source/bin/rocprof-sys-avail/avail.cpp
+++ b/projects/rocprofiler-systems/source/bin/rocprof-sys-avail/avail.cpp
@@ -550,15 +550,6 @@ main(int argc, char** argv)
     _parser_set_if_exists(include_settings, "settings");
     _parser_set_if_exists(include_hw_counters, "hw-counters");
 
-    // Always register ROCm/SMI settings so they appear in settings queries
-    // (e.g., rocprof-sys-avail -bd -r ROCM). These functions query the
-    // rocprofiler-sdk and AMD SMI to discover available domains and metrics.
-    {
-        const auto& _config = tim::settings::shared_instance();
-        rocprofsys::rocprofiler_sdk::config_settings(_config);
-        rocprofsys::amd_smi::config_settings(_config);
-    }
-
     // Only query GPU devices and hardware counters when they are actually
     // requested. This avoids initializing the ROCm runtime for settings-only
     // or component-only queries, reducing startup time and allowing

--- a/projects/rocprofiler-systems/source/bin/rocprof-sys-avail/avail.cpp
+++ b/projects/rocprofiler-systems/source/bin/rocprof-sys-avail/avail.cpp
@@ -144,7 +144,7 @@ main(int argc, char** argv)
 
     tim::unwind::set_bfd_verbose(3);
     rocprofsys::set_state(rocprofsys::State::Init);
-    rocprofsys::config::configure_settings();
+    rocprofsys::config::configure_settings(false);
 
     std::set<std::string> _category_options = component_categories{}();
     {

--- a/projects/rocprofiler-systems/source/bin/rocprof-sys-avail/avail.cpp
+++ b/projects/rocprofiler-systems/source/bin/rocprof-sys-avail/avail.cpp
@@ -144,7 +144,7 @@ main(int argc, char** argv)
 
     tim::unwind::set_bfd_verbose(3);
     rocprofsys::set_state(rocprofsys::State::Init);
-    rocprofsys::config::configure_settings(false);
+    rocprofsys::config::configure_settings();
 
     std::set<std::string> _category_options = component_categories{}();
     {

--- a/projects/rocprofiler-systems/source/lib/core/config.cpp
+++ b/projects/rocprofiler-systems/source/lib/core/config.cpp
@@ -682,11 +682,8 @@ configure_settings(bool _init)
         std::string{ "perf::PERF_COUNT_HW_CACHE_REFERENCES" }, "sampling",
         "hardware_counters");
 
-    if(_init)
-    {
-        rocprofiler_sdk::config_settings(_config);
-        amd_smi::config_settings(_config);
-    }
+    rocprofiler_sdk::config_settings(_config);
+    amd_smi::config_settings(_config);
 
     ROCPROFSYS_CONFIG_SETTING(size_t, "ROCPROFSYS_PERFETTO_SHMEM_SIZE_HINT_KB",
                               "Hint for shared-memory buffer size in perfetto (in KB)",


### PR DESCRIPTION
## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->
PR #3526 unintentionally broke the `--rocm-domains` CLI option for `rocprof-sys-run` and other tools. Users passing `--rocm-domains` get "Unrecognized command line option" because the setting is never registered during CLI parsing.

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->
PR #3526 wrapped `rocprofiler_sdk::config_settings()` and `amd_smi::config_settings()` in an `if(_init)` guard in `configure_settings()`. Since `configure_settings()` has a `static _once` guard and only executes once, and `rocprof-sys-run` calls it with `_init=false` during CLI parsing, the `_init=true` path never runs. `ROCPROFSYS_ROCM_DOMAINS` is never registered, so Timemory never generates the `--rocm-domains` flag.

Hence removed the `if(_init)` guard so settings are registered unconditionally. These functions only register Timemory settings and query tracing domain names -- no GPU initialization. Also remove the compensating explicit calls in `avail.cpp` added by #3526, since `configure_settings()` now handles registration.

## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->
ROCM-20916

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->
- Built and installed rocprof-sys on MI308 with TheRock 7.13.0 tarball.
- Verified `rocprof-sys-run --help` shows `--rocm-domains` as a recognized option.
- Ran `ctest -R avail`.
- Ran `ctest -R rocprof-systems-advanced` in rocm-examples with the original `--rocm-domains hip_api` script.

## Test Result

<!-- Briefly summarize test outcomes. -->
- All 20 avail tests pass.
- `--rocm-domains` is recognized by `rocprof-sys-run`.
- `rocprof-systems-advanced` test in rocm-examples passes successfully.
<img width="825" height="697" alt="image" src="https://github.com/user-attachments/assets/87a8f4a2-2dc2-47e0-a3aa-7b7085e7e35f" />


## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
