### PR TITLE
Removed --path and --subpath

### DIFF
--- a/projects/rocprofiler-compute/CHANGELOG.md
+++ b/projects/rocprofiler-compute/CHANGELOG.md
@@ -49,6 +49,8 @@ Full documentation for ROCm Compute Profiler is available at [https://rocm.docs.
 
 * Removed HIP API tracing since it's out-of-scope for ROCm Compute Profiler and the trace files were not being analyzed.
 
+* ``--path`` and ``--subpath`` options have been removed from profile mode. Use ``--output-directory`` instead.
+
 ### Optimized
 
 * Filtering for block 21 (`-b 21`) in profile mode, now only performs pc sampling and skips unnecessary counter collection
@@ -158,10 +160,6 @@ Full documentation for ROCm Compute Profiler is available at [https://rocm.docs.
 * Removed redundant warnings for compute/memory partition not found for AMD Instinct MI300 series and later GPUs by skipping the partition checks.
 
 * Corrected the formula for metrics related to reads from L2 cache to HBM for AMD Instinct MI350 Series GPUs.
-
-### Upcoming changes
-
-* ``--path`` and ``--subpath`` options have been deprecated in favor of ``--output-directory`` and will be removed in a future release.
 
 ### Upcoming changes
 

--- a/projects/rocprofiler-compute/CHANGELOG.md
+++ b/projects/rocprofiler-compute/CHANGELOG.md
@@ -10,6 +10,8 @@ Full documentation for ROCm Compute Profiler is available at [https://rocm.docs.
 
 ### Removed
 
+* ``--path`` and ``--subpath`` options have been removed from profile mode. Use ``--output-directory`` instead.
+
 ### Optimized
 
 ### Resolved issues
@@ -48,8 +50,6 @@ Full documentation for ROCm Compute Profiler is available at [https://rocm.docs.
 ### Removed
 
 * Removed HIP API tracing since it's out-of-scope for ROCm Compute Profiler and the trace files were not being analyzed.
-
-* ``--path`` and ``--subpath`` options have been removed from profile mode. Use ``--output-directory`` instead.
 
 ### Optimized
 

--- a/projects/rocprofiler-compute/docs/how-to/profile/mode.rst
+++ b/projects/rocprofiler-compute/docs/how-to/profile/mode.rst
@@ -252,15 +252,8 @@ directory is derived from ``--name`` and the target system information:
 * Without MPI rank detection, the default is ``./workloads/<name>/<gpu_model>``.
 * With MPI rank detection, the default is ``./workloads/<name>/<rank>``.
 
-You can override the output directory with ``--output-directory``. The
-``--path`` (``-p``) argument is deprecated for profile mode. When ``--output-directory`` is
-explicitly provided, ``--name`` is ignored.
-
-.. note::
-
-   ``--path`` and ``--subpath`` are deprecated for profile mode and will be
-   removed in a future release. Use ``--output-directory`` with parameterized
-   placeholders instead.
+You can override the output directory with ``--output-directory``. When
+``--output-directory`` is explicitly provided, ``--name`` is ignored.
 
 The output directory can be parameterized with the following keywords:
 

--- a/projects/rocprofiler-compute/docs/how-to/use.rst
+++ b/projects/rocprofiler-compute/docs/how-to/use.rst
@@ -39,12 +39,6 @@ the gpu model. Use ``--output-directory`` to override the output location.
 
 .. note::
 
-   ``--path`` and ``--subpath`` are deprecated for profile mode and will be
-   removed in a future release. Use ``--output-directory`` with parameterized
-   placeholders instead.
-
-.. note::
-
    To collect all requested profile information, ROCm Compute Profiler might replay kernels
    multiple times.
 

--- a/projects/rocprofiler-compute/src/argparser.py
+++ b/projects/rocprofiler-compute/src/argparser.py
@@ -275,19 +275,6 @@ Examples:
         ),
     )
     profile_group.add_argument(
-        "-p",
-        "--path",
-        metavar="",
-        type=str,
-        dest="path",
-        default=str(Path.cwd() / "workloads"),
-        required=False,
-        help=(
-            f"\t\t\t(DEPRECATED) Specify path to save workload.\n\t\t\t(DEFAULT: {Path.cwd()}/workloads/<name>)\n"  # noqa: E501
-            "\t\t\t --path is deprecated. Use --output-directory instead."  # noqa: E501
-        ),
-    )
-    profile_group.add_argument(
         "--output-directory",
         metavar="",
         type=str,
@@ -303,18 +290,6 @@ Examples:
             '\t\t\t   %%env{NAME}%%: Environment variable "NAME"\n'
             "\t\t\t(DEFAULT: <current-working-directory>/workloads/<name>/%%gpumodel%%) without MPI,\n"  # noqa: E501
             "\t\t\t <current-working-directory>/workloads/<name>/%%rank%% with MPI.)"
-        ),
-    )
-    profile_group.add_argument(
-        "--subpath",
-        metavar="",
-        type=str,
-        dest="subpath",
-        default="gpu_model",
-        required=False,
-        help=(
-            "\t\t\t(DEPRECATED) Specify the type of subpath to save workload: node_name, gpu_model."  # noqa: E501
-            "\n\t\t\t --subpath is deprecated. Use --output-directory with parameterization instead."  # noqa: E501
         ),
     )
     profile_group.add_argument(

--- a/projects/rocprofiler-compute/src/rocprof_compute_base.py
+++ b/projects/rocprofiler-compute/src/rocprof_compute_base.py
@@ -210,19 +210,7 @@ class RocProfCompute:
             if self.__args.name is None and self.__args.output_directory == str(
                 Path.cwd() / "workloads"
             ):
-                # Remove if statement and the else code block in a future release.
-                if self.__args.path == str(Path.cwd() / "workloads"):
-                    console_error("Either --output-directory or --name is required")
-                else:
-                    console_warning(
-                        "--path is deprecated and will be removed in future releases."
-                    )
-
-                if self.__args.subpath != "gpu_model":
-                    console_warning(
-                        "--subpath is deprecated and will be "
-                        "removed in future releases."
-                    )
+                console_error("Either --output-directory or --name is required")
 
             if self.__args.name is not None and "/" in self.__args.name:
                 console_error('"/" is not permitted in profile name')
@@ -484,18 +472,7 @@ class RocProfCompute:
     def run_profiler(self) -> None:
         self.print_graphic()
 
-        # Replace parameters in output directory when either:
-        # 1. --output-directory is explicitly given by user
-        # 2. --path and --output-directory are set to default workload directory.
-        # NOTE: --output-directory is given higher priority than --path
-        # as --path is deprecated and will be removed in future releases.
-        if self.__args.output_directory != str(
-            Path.cwd() / "workloads"
-        ) or self.__args.path == str(Path.cwd() / "workloads"):
-            self.replace_parameters_in_output_directory()
-            # Set path to output_directory for roofline
-            # Remove this while removing roofline from profiling mode
-            self.__args.path = self.__args.output_directory
+        self.replace_parameters_in_output_directory()
 
         self.load_soc_specs()
 
@@ -507,7 +484,7 @@ class RocProfCompute:
             console_error(str(e))
 
         # Create workload directory if it does not exist
-        p = Path(self.__args.path)
+        p = Path(self.__args.output_directory)
         if not p.exists():
             try:
                 p.mkdir(parents=True, exist_ok=False)
@@ -515,7 +492,7 @@ class RocProfCompute:
                 console_error("Directory already exists.")
 
         # enable file-based logging
-        setup_file_handler(self.__args.loglevel, self.__args.path)
+        setup_file_handler(self.__args.loglevel, self.__args.output_directory)
 
         profiler.pre_processing()
 

--- a/projects/rocprofiler-compute/src/rocprof_compute_profile/profiler_base.py
+++ b/projects/rocprofiler-compute/src/rocprof_compute_profile/profiler_base.py
@@ -150,7 +150,7 @@ class RocProfCompute_Base:
             )
 
         # verify not accessing parent directories
-        if ".." in str(args.path):
+        if ".." in str(args.output_directory):
             console_error(
                 "Access denied. Cannot access parent directories in path (i.e. ../)"
             )
@@ -231,7 +231,7 @@ class RocProfCompute_Base:
         self._filter_blocks = self._soc.profiling_setup()
 
         # Write profiling configuration as yaml file
-        with open(f"{self.__args.path}/profiling_config.yaml", "w") as f:
+        with open(f"{self.__args.output_directory}/profiling_config.yaml", "w") as f:
             args_dict = vars(self.__args)
             # Override filter_blocks when writing profiling config yaml
             args_dict["filter_blocks"] = self._filter_blocks
@@ -246,7 +246,7 @@ class RocProfCompute_Base:
             )
 
         gen_sysinfo(
-            workload_dir=args.path,
+            workload_dir=args.output_directory,
             app_cmd=args.remaining,
             skip_roof=args.no_roof,
             mspec=self._soc._mspec,
@@ -292,7 +292,7 @@ class RocProfCompute_Base:
             run_prof(
                 fnames=str_fnames,
                 profiler_options=options,
-                workload_dir=args.path,
+                workload_dir=args.output_directory,
                 loglevel=args.loglevel,
                 format_rocprof_output=args.format_rocprof_output,
                 torch_trace_enabled=getattr(args, "torch_trace", False),
@@ -322,7 +322,7 @@ class RocProfCompute_Base:
         # log basic info
         console_log(f"{str(prog).title()} version: {version}")
         console_log(f"Profiler choice: {self.__profiler}")
-        console_log(f"Path: {Path(self.__args.path).absolute().resolve()}")
+        console_log(f"Path: {Path(self.__args.output_directory).absolute().resolve()}")
         console_log(f"Target: {self._soc._mspec.gpu_model}")
         console_log(f"Command: {args.remaining}")
         console_log(f"Kernel Selection: {args.kernel}")
@@ -333,7 +333,9 @@ class RocProfCompute_Base:
             console_log("Filtered sections: All")
 
         # Run profiling on each input file
-        input_files = sorted(Path(args.path).glob("perfmon/pmc_perf_*.yaml"))
+        input_files = sorted(
+            Path(args.output_directory).glob("perfmon/pmc_perf_*.yaml")
+        )
         total_runs = len(input_files)
 
         if total_runs == 0 and is_only_pc_sampling(args.filter_blocks):
@@ -523,7 +525,9 @@ class RocProfCompute_Base:
             )
             return
 
-        total_runs = len(list(Path(args.path).glob("perfmon/pmc_perf_*.yaml")))
+        total_runs = len(
+            list(Path(args.output_directory).glob("perfmon/pmc_perf_*.yaml"))
+        )
 
         console_log(f"[Run {total_runs + 1}/{total_runs + 1}][PC sampling profile run]")
 
@@ -548,7 +552,7 @@ class RocProfCompute_Base:
             profiler_options=options,
             method=args.pc_sampling_method,
             interval=args.pc_sampling_interval,
-            workload_dir=args.path,
+            workload_dir=args.output_directory,
         )
         end_time = time.time()
 

--- a/projects/rocprofiler-compute/src/rocprof_compute_profile/profiler_base.py
+++ b/projects/rocprofiler-compute/src/rocprof_compute_profile/profiler_base.py
@@ -322,7 +322,9 @@ class RocProfCompute_Base:
         # log basic info
         console_log(f"{str(prog).title()} version: {version}")
         console_log(f"Profiler choice: {self.__profiler}")
-        console_log(f"Path: {Path(self.__args.output_directory).absolute().resolve()}")
+        console_log(
+            f"Output directory: {Path(self.__args.output_directory).absolute().resolve()}"
+        )
         console_log(f"Target: {self._soc._mspec.gpu_model}")
         console_log(f"Command: {args.remaining}")
         console_log(f"Kernel Selection: {args.kernel}")

--- a/projects/rocprofiler-compute/src/rocprof_compute_profile/profiler_base.py
+++ b/projects/rocprofiler-compute/src/rocprof_compute_profile/profiler_base.py
@@ -152,7 +152,7 @@ class RocProfCompute_Base:
         # verify not accessing parent directories
         if ".." in str(args.output_directory):
             console_error(
-                "Access denied. Cannot access parent directories in path (i.e. ../)"
+                "Access denied. Cannot access parent directories in --output-directory (i.e. ../)"
             )
 
         if args.no_native_tool and args.iteration_multiplexing is not None:

--- a/projects/rocprofiler-compute/src/rocprof_compute_profile/profiler_base.py
+++ b/projects/rocprofiler-compute/src/rocprof_compute_profile/profiler_base.py
@@ -149,12 +149,6 @@ class RocProfCompute_Base:
                 "Please use only one of them."
             )
 
-        # verify not accessing parent directories
-        if ".." in str(args.output_directory):
-            console_error(
-                "Access denied. Cannot access parent directories in --output-directory (i.e. ../)"
-            )
-
         if args.no_native_tool and args.iteration_multiplexing is not None:
             console_error(
                 "--no-native-tool cannot be used with --iteration-multiplexing. "
@@ -323,7 +317,8 @@ class RocProfCompute_Base:
         console_log(f"{str(prog).title()} version: {version}")
         console_log(f"Profiler choice: {self.__profiler}")
         console_log(
-            f"Output directory: {Path(self.__args.output_directory).absolute().resolve()}"
+            f"Output directory: "
+            f"{Path(self.__args.output_directory).absolute().resolve()}"
         )
         console_log(f"Target: {self._soc._mspec.gpu_model}")
         console_log(f"Command: {args.remaining}")

--- a/projects/rocprofiler-compute/src/rocprof_compute_profile/profiler_rocprof_v3.py
+++ b/projects/rocprofiler-compute/src/rocprof_compute_profile/profiler_rocprof_v3.py
@@ -36,7 +36,7 @@ class rocprof_v3_profiler(RocProfCompute_Base):
         profiling_options = [
             # v3 requires output directory argument
             "-d",
-            f"{self.get_args().path}/out",
+            f"{self.get_args().output_directory}/out",
             trace_option,
             "--output-format",
             args.format_rocprof_output,

--- a/projects/rocprofiler-compute/src/rocprof_compute_profile/profiler_rocprofiler_sdk.py
+++ b/projects/rocprofiler-compute/src/rocprof_compute_profile/profiler_rocprofiler_sdk.py
@@ -51,7 +51,7 @@ class rocprofiler_sdk_profiler(RocProfCompute_Base):
             "LD_PRELOAD": ld_preload_value,
             "ROCPROF_KERNEL_TRACE": "1",
             "ROCPROF_OUTPUT_FORMAT": args.format_rocprof_output,
-            "ROCPROF_OUTPUT_PATH": f"{args.path}/out/pmc_1",
+            "ROCPROF_OUTPUT_PATH": f"{args.output_directory}/out/pmc_1",
         })
 
         if getattr(args, "torch_trace", False):

--- a/projects/rocprofiler-compute/src/rocprof_compute_soc/soc_base.py
+++ b/projects/rocprofiler-compute/src/rocprof_compute_soc/soc_base.py
@@ -782,7 +782,7 @@ class OmniSoC_Base:
         Sort and bucket all related performance counters to minimize required
         application passes
         """
-        workload_perfmon_dir = Path(self.get_args().path) / "perfmon"
+        workload_perfmon_dir = Path(self.get_args().output_directory) / "perfmon"
         workload_perfmon_dir.mkdir(parents=True, exist_ok=True)
 
         rocprof_counters = self.get_rocprof_supported_counters()
@@ -947,13 +947,14 @@ class OmniSoC_Base:
             from roofline.run_benchmark import load_bench
 
             console_log(
-                "roofline", f"Checking for roofline.csv in {self.get_args().path}"
+                "roofline",
+                f"Checking for roofline.csv in {self.get_args().output_directory}",
             )
-            if not (Path(self.get_args().path) / "roofline.csv").is_file():
+            if not (Path(self.get_args().output_directory) / "roofline.csv").is_file():
                 try:
                     bench = load_bench([self.get_args().device])
                     result = bench.run_on_devices([self.get_args().device])
-                    bench.dump_csv(result, f"{self.get_args().path}/roofline.csv")
+                    bench.dump_csv(result, f"{self.get_args().output_directory}/roofline.csv")
                 except Exception as e:
                     console_error(
                         "roofline",
@@ -962,7 +963,9 @@ class OmniSoC_Base:
                     )
                     return
 
-            is_valid, error_msg = validate_roofline_csv(self.get_args().path)
+            is_valid, error_msg = validate_roofline_csv(
+                self.get_args().output_directory
+            )
             if not is_valid:
                 console_error(
                     "roofline",
@@ -973,9 +976,11 @@ class OmniSoC_Base:
 
             console_log(
                 "roofline",
-                f"Roofline data saved to {self.get_args().path}/roofline.csv\n"
-                f"  Run 'rocprof-compute analyze -p {self.get_args().path}' "
-                f"for charts",
+                "Roofline data saved to "
+                f"{self.get_args().output_directory}/roofline.csv\n"
+                "  Run 'rocprof-compute analyze -p "
+                f"{self.get_args().output_directory}' "
+                "for charts",
             )
 
 

--- a/projects/rocprofiler-compute/src/rocprof_compute_soc/soc_base.py
+++ b/projects/rocprofiler-compute/src/rocprof_compute_soc/soc_base.py
@@ -954,7 +954,9 @@ class OmniSoC_Base:
                 try:
                     bench = load_bench([self.get_args().device])
                     result = bench.run_on_devices([self.get_args().device])
-                    bench.dump_csv(result, f"{self.get_args().output_directory}/roofline.csv")
+                    bench.dump_csv(
+                        result, f"{self.get_args().output_directory}/roofline.csv"
+                    )
                 except Exception as e:
                     console_error(
                         "roofline",

--- a/projects/rocprofiler-compute/tests/test_utils.py
+++ b/projects/rocprofiler-compute/tests/test_utils.py
@@ -1841,7 +1841,7 @@ def test_run_prof_sdk_creates_new_env_copy(tmp_path, monkeypatch):
             rocprofiler_sdk_tool_path="sdk_tool",
             roof_only=True,
             format_rocprof_output="format",
-            path="path",
+            output_directory="path",
             remaining="remaining",
             iteration_multiplexing=None,
             attach_pid=None,

--- a/projects/rocprofiler-compute/tests/workloads/no_roof/MI350/profiling_config.yaml
+++ b/projects/rocprofiler-compute/tests/workloads/no_roof/MI350/profiling_config.yaml
@@ -14,7 +14,7 @@ mem_level: ALL
 mode: profile
 name: vcopy
 no_roof: true
-path: /app/workloads/vcopy/MI350
+output_directory: /app/workloads/vcopy/MI350
 quiet: false
 remaining:
 - --
@@ -31,7 +31,6 @@ roofline_data_type:
 sort: kernels
 spatial_multiplexing: null
 specs: false
-subpath: gpu
 summaries: false
 target: null
 use_rocscope: false

--- a/projects/rocprofiler-compute/tests/workloads/torch_trace/MI350/profiling_config.yaml
+++ b/projects/rocprofiler-compute/tests/workloads/torch_trace/MI350/profiling_config.yaml
@@ -23,7 +23,6 @@ name: simple_net
 no_native_tool: false
 no_roof: true
 output_directory: /tmp/tt
-path: /tmp/tt
 pc_sampling_interval: 1048576
 pc_sampling_method: stochastic
 quiet: false
@@ -37,7 +36,6 @@ set_selected: null
 sort: kernels
 spatial_multiplexing: null
 specs: false
-subpath: gpu_model
 target: null
 torch_trace: true
 verbose: 0

--- a/projects/rocprofiler-compute/tests/workloads/vcopy/MI350/profiling_config.yaml
+++ b/projects/rocprofiler-compute/tests/workloads/vcopy/MI350/profiling_config.yaml
@@ -13,7 +13,7 @@ mem_level: ALL
 mode: profile
 name: vcopy
 no_roof: true
-path: /app/workloads/vcopy/MI350
+output_directory: /app/workloads/vcopy/MI350
 quiet: false
 remaining:
 - --
@@ -30,7 +30,6 @@ roofline_data_type:
 sort: kernels
 spatial_multiplexing: null
 specs: false
-subpath: gpu
 summaries: false
 target: null
 use_rocscope: false

--- a/projects/rocprofiler-compute/tests/workloads/vcopy_iteration_multiplexing/MI350/profiling_config.yaml
+++ b/projects/rocprofiler-compute/tests/workloads/vcopy_iteration_multiplexing/MI350/profiling_config.yaml
@@ -20,7 +20,7 @@ mode: profile
 name: vcopy_kernel
 no_native_tool: false
 no_roof: true
-path: /home/abchoudh/rocm/iteration_multiplexing/projects/rocprofiler-compute/sample/workloads/vcopy_kernel/MI350
+output_directory: /home/abchoudh/rocm/iteration_multiplexing/projects/rocprofiler-compute/sample/workloads/vcopy_kernel/MI350
 pc_sampling_interval: 1048576
 pc_sampling_method: stochastic
 quiet: false
@@ -34,6 +34,5 @@ set_selected: null
 sort: kernels
 spatial_multiplexing: null
 specs: false
-subpath: gpu_model
 target: null
 verbose: 0

--- a/projects/rocprofiler-compute/tests/workloads/vcopy_iteration_multiplexing/MI350/profiling_config.yaml
+++ b/projects/rocprofiler-compute/tests/workloads/vcopy_iteration_multiplexing/MI350/profiling_config.yaml
@@ -20,7 +20,7 @@ mode: profile
 name: vcopy_kernel
 no_native_tool: false
 no_roof: true
-output_directory: /home/abchoudh/rocm/iteration_multiplexing/projects/rocprofiler-compute/sample/workloads/vcopy_kernel/MI350
+output_directory: tests/workloads/vcopy_iteration_multiplexing/MI350
 pc_sampling_interval: 1048576
 pc_sampling_method: stochastic
 quiet: false

--- a/projects/rocprofiler-compute/tests/workloads/vcopy_pc_sampling_only/MI300A_A1/profiling_config.yaml
+++ b/projects/rocprofiler-compute/tests/workloads/vcopy_pc_sampling_only/MI300A_A1/profiling_config.yaml
@@ -32,7 +32,6 @@ roof_only: false
 set_selected: null
 spatial_multiplexing: null
 specs: false
-subpath: gpu_model
 target: null
 torch_trace: false
 verbose: 1

--- a/projects/rocprofiler-compute/tests/workloads/vcopy_pc_sampling_only/MI300A_A1/profiling_config.yaml
+++ b/projects/rocprofiler-compute/tests/workloads/vcopy_pc_sampling_only/MI300A_A1/profiling_config.yaml
@@ -22,7 +22,6 @@ name: null
 no_native_tool: false
 no_roof: false
 output_directory: vcopy
-path: vcopy
 pc_sampling_interval: 1048576
 pc_sampling_method: stochastic
 quiet: false


### PR DESCRIPTION
## Motivation

`--path` and `--subpath` were deprecated in profile mode.

## Technical Details

- Removed `--path` and `--subpath` from profile mode
- Use `output-directory` where `path` is used in profile mode
- Updated tests

## JIRA ID

AIPROFCOMP-472

## Test Plan

- [x] Run ctests

## Test Result

- [x] ctests passed

## Submission Checklist

- [X] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
