### PR TITLE
[rocprofiler-compute] [bugfix] Removed irrelevant multi rank PC sampling test

### DIFF
--- a/projects/rocprofiler-compute/tests/test_profile_general.py
+++ b/projects/rocprofiler-compute/tests/test_profile_general.py
@@ -3390,38 +3390,3 @@ def test_multi_rank_no_warning_with_iteration_multiplexing(
     assert "Application replay mode" not in output
 
     test_utils.clean_output_dir(config["cleanup"], workload_dir)
-
-
-@pytest.mark.multi_rank
-def test_multi_rank_warning_pc_sampling(
-    binary_handler_profile_rocprof_compute, monkeypatch
-):
-    """
-    Test that a warning is printed when running a multi-rank application
-    with PC sampling enabled.
-    """
-    # Set MPI environment variable to simulate multi-rank
-    monkeypatch.setenv("OMPI_COMM_WORLD_RANK", "0")
-
-    workload_dir = test_utils.get_output_dir()
-
-    # Enable PC sampling
-    options = ["--block", "21"]
-
-    _, stdout, stderr = binary_handler_profile_rocprof_compute(
-        config,
-        workload_dir,
-        options,
-        app_name="app_1",
-        capture_output=True,
-        check_success=False,
-    )
-
-    # Check that PC sampling warning is in output
-    output = stdout + stderr
-    assert "Multi-rank application detected with PC sampling enabled" in output
-    assert "--iteration-multiplexing" in output
-    assert "--block" not in output
-    assert "--set" in output
-
-    test_utils.clean_output_dir(config["cleanup"], workload_dir)


### PR DESCRIPTION
## Motivation

Multi rank test is failing

## Technical Details

Multi rank PC sampling test doesn't cover current behavior. So, it is removed.

## JIRA ID



## Test Plan

- [X] Run ctest 

## Test Result

- [X] ctests passed

## Submission Checklist

- [X] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
