### PR TITLE
[rocr-runtime] rocrtst test suites use ENV for kernels path

### DIFF
--- a/projects/rocr-runtime/rocrtst/common/base_rocr_utils.cc
+++ b/projects/rocr-runtime/rocrtst/common/base_rocr_utils.cc
@@ -304,16 +304,22 @@ std::string LocateKernelFile(std::string filename, hsa_agent_t agent) {
   hsa_status_t err = hsa_agent_get_info(agent, HSA_AGENT_INFO_NAME, agent_name);
   RET_IF_HSA_UTILS_ERR_RET(err, obj_file);
 
-  // Try current directory
-  obj_file = "./" + filename;
-  int file_handle = open(obj_file.c_str(), O_RDONLY);
+  // Get base from ENV if defined, otherwise use current directory
+  const char* env_path = getenv("ROCRTST_KERNELS_PATH");
+  std::string base = (env_path && env_path[0] != '\0') ? env_path : ".";
+
+  int file_handle;
+
+  // Try <base>/<filename>
+  obj_file = base + "/" + filename;
+  file_handle = open(obj_file.c_str(), O_RDONLY);
   if (file_handle >= 0) {
     close(file_handle);
     return obj_file;
   }
 
-  // Try ./<agent_name>/<filename>
-  obj_file = "./" + std::string(agent_name) + "/" + filename;
+  // Try <base>/<agent_name>/<filename>
+  obj_file = base + "/" + std::string(agent_name) + "/" + filename;
   file_handle = open(obj_file.c_str(), O_RDONLY);
   if (file_handle >= 0) {
     close(file_handle);


### PR DESCRIPTION
## Motivation

Allow tests to locate kernel object files outside the current working directory. This is particularly useful in environments like autopkgtest where the execution path differs from the build/output layout.

## Technical Details

Introduce support for a `ROCRTST_KERNELS_PATH` environment variable to override the default base directory (.) used when locating kernel files. The lookup logic now first checks <base>/<filename> and then <base>/<agent_name>/<filename>, preserving the existing fallback behavior while making the base path configurable.

## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan

Running autopkgtest of a packaged rocrtst with specified `ROCRTST_KERNELS_PATH` on a machine with gfx1151.

## Test Result

```
autopkgtest [11:26:12]: test libhsa-runtime64-tests:  - - - - - - - - - - results - - - - - - - - - -
libhsa-runtime64-tests PASS
autopkgtest [11:26:12]: @@@@@@@@@@@@@@@@@@@@ summary
libhsa-runtime64-tests PASS
```

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
