### PR TITLE
[SWDEV-531904] Mutex and cross-process serialization test changes

### DIFF
--- a/projects/amdsmi/include/amd_smi/impl/amd_smi_gpu_mutex.h
+++ b/projects/amdsmi/include/amd_smi/impl/amd_smi_gpu_mutex.h
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#ifndef AMD_SMI_INCLUDE_AMD_SMI_GPU_MUTEX_H_
+#define AMD_SMI_INCLUDE_AMD_SMI_GPU_MUTEX_H_
+
+// NOTE: This header requires internal rocm_smi headers which are not installed.
+// It is intended for GPU code paths only (amd_smi.cc, amd_smi_utils.cc).
+// For non-GPU (NIC/CPU) code paths - TBD if needed.
+#include "rocm_smi/rocm_smi.h"
+#include "rocm_smi/rocm_smi_main.h"
+#include "rocm_smi/rocm_smi_utils.h"
+
+// GPU mutex: consults RocmSMI::init_options() to determine whether to use a
+// blocking or non-blocking lock. RSMI_INIT_FLAG_RESRV_TEST1 switches to
+// non-blocking mode so that tests can intentionally trigger AMDSMI_STATUS_BUSY.
+#define SMIGPUDEVICE_MUTEX(MUTEX)                                                    \
+  amd::smi::pthread_wrap _pw(*(MUTEX));                                              \
+  amd::smi::RocmSMI& _smigpu = amd::smi::RocmSMI::getInstance();                     \
+  bool _gpu_blocking =                                                               \
+      !(_smigpu.init_options() & static_cast<uint64_t>(RSMI_INIT_FLAG_RESRV_TEST1)); \
+  amd::smi::ScopedPthread _lock(_pw, _gpu_blocking);                                 \
+  if (_lock.mutex_not_acquired()) {                                                  \
+    return AMDSMI_STATUS_BUSY;                                                       \
+  }
+
+#endif  // AMD_SMI_INCLUDE_AMD_SMI_GPU_MUTEX_H_

--- a/projects/amdsmi/include/amd_smi/impl/amd_smi_test_flags.h
+++ b/projects/amdsmi/include/amd_smi/impl/amd_smi_test_flags.h
@@ -20,40 +20,17 @@
  * THE SOFTWARE.
  */
 
-#ifndef TESTS_AMD_SMI_TEST_FUNCTIONAL_MUTUAL_EXCLUSION_H_
-#define TESTS_AMD_SMI_TEST_FUNCTIONAL_MUTUAL_EXCLUSION_H_
+#ifndef AMD_SMI_INCLUDE_AMD_SMI_TEST_FLAGS_H_
+#define AMD_SMI_INCLUDE_AMD_SMI_TEST_FLAGS_H_
 
-#include <string>
+#include <cstdint>
 
-#include "../test_base.h"
+// Reserved test-only init flag. Passed to amdsmi_init() / rsmi_init() to
+// switch GPU device mutexes from blocking to non-blocking (trylock) mode,
+// making AMDSMI_STATUS_BUSY / RSMI_STATUS_BUSY observable by tests.
+//
+// MUST NOT overlap with any public AMDSMI_INIT_* flag defined in amdsmi.h.
+// Current public flags occupy bits [0:3]; this flag uses bit 59 (0x800_0000_0000_0000).
+static constexpr uint64_t AMD_SMI_INIT_FLAG_RESRV_TEST1 = 0x800000000000000ULL;
 
-class TestMutualExclusion : public TestBase {
- public:
-  TestMutualExclusion();
-
-  // @Brief: Destructor for test case of TestMutualExclusion
-  virtual ~TestMutualExclusion();
-
-  // @Brief: Setup the environment for measurement
-  virtual void SetUp();
-
-  // @Brief: Core measurement execution
-  virtual void Run();
-
-  // @Brief: Clean up and retrieve the resource
-  virtual void Close();
-
-  // @Brief: Display  results
-  virtual void DisplayResults() const;
-
-  // @Brief: Display information about what this test does
-  virtual void DisplayTestInfo(void);
-
- private:
-  bool sleeper_process_;
-  int child_;
-  std::string orig_cross_process_env_;
-  bool orig_cross_process_env_was_set_;
-};
-
-#endif  // TESTS_AMD_SMI_TEST_FUNCTIONAL_MUTUAL_EXCLUSION_H_
+#endif  // AMD_SMI_INCLUDE_AMD_SMI_TEST_FLAGS_H_

--- a/projects/amdsmi/include/amd_smi/impl/amd_smi_test_flags.h
+++ b/projects/amdsmi/include/amd_smi/impl/amd_smi_test_flags.h
@@ -30,7 +30,7 @@
 // making AMDSMI_STATUS_BUSY / RSMI_STATUS_BUSY observable by tests.
 //
 // MUST NOT overlap with any public AMDSMI_INIT_* flag defined in amdsmi.h.
-// Current public flags occupy bits [0:3]; this flag uses bit 59 (0x800_0000_0000_0000).
-static constexpr uint64_t AMD_SMI_INIT_FLAG_RESRV_TEST1 = 0x800000000000000ULL;
+// Current public flags occupy bits [0:3]; this flag uses bit 59 (0x0800_0000_0000_0000).
+static constexpr uint64_t AMD_SMI_INIT_FLAG_RESRV_TEST1 = 0x0800000000000000ULL;
 
 #endif  // AMD_SMI_INCLUDE_AMD_SMI_TEST_FLAGS_H_

--- a/projects/amdsmi/include/amd_smi/impl/amd_smi_test_flags.h
+++ b/projects/amdsmi/include/amd_smi/impl/amd_smi_test_flags.h
@@ -31,6 +31,6 @@
 //
 // MUST NOT overlap with any public AMDSMI_INIT_* flag defined in amdsmi.h.
 // Current public flags occupy bits [0:3]; this flag uses bit 59 (0x0800_0000_0000_0000).
-static constexpr uint64_t AMD_SMI_INIT_FLAG_RESRV_TEST1 = 0x0800000000000000ULL;
+inline constexpr uint64_t AMD_SMI_INIT_FLAG_RESRV_TEST1 = 0x0800000000000000ULL;
 
 #endif  // AMD_SMI_INCLUDE_AMD_SMI_TEST_FLAGS_H_

--- a/projects/amdsmi/include/amd_smi/impl/amd_smi_test_flags.h
+++ b/projects/amdsmi/include/amd_smi/impl/amd_smi_test_flags.h
@@ -20,15 +20,18 @@
  * THE SOFTWARE.
  */
 
-#ifndef AMD_SMI_INCLUDE_AMD_SMI_TEST_INTERNAL_H_
-#define AMD_SMI_INCLUDE_AMD_SMI_TEST_INTERNAL_H_
+#ifndef AMD_SMI_INCLUDE_AMD_SMI_TEST_FLAGS_H_
+#define AMD_SMI_INCLUDE_AMD_SMI_TEST_FLAGS_H_
 
-#include "amd_smi/amdsmi.h"
-#include "amd_smi/impl/amd_smi_test_flags.h"
+#include <cstdint>
 
-// Internal test-only wrapper around rsmi_test_sleep. Acquires the device mutex
-// for |seconds| seconds and returns an amdsmi_status_t so tests do not need to
-// extern-declare the rsmi_status_t function directly.
-amdsmi_status_t amdsmi_test_sleep(amdsmi_processor_handle processor_handle, uint32_t seconds);
+// Reserved test-only init flag. Passed to amdsmi_init() / rsmi_init() to
+// switch GPU device mutexes from blocking to non-blocking (trylock) mode,
+// making AMDSMI_STATUS_BUSY / RSMI_STATUS_BUSY observable by tests.
+//
+// MUST NOT overlap with any public AMDSMI_INIT_* flag defined in amdsmi.h.
+// Public amdsmi.h flags occupy bits [0:3]; internal rocm_smi flags use bits 58–59.
+// This flag uses bit 59 (0x0800_0000_0000_0000).
+inline constexpr uint64_t AMD_SMI_INIT_FLAG_RESRV_TEST1 = 0x0800000000000000ULL;
 
-#endif  // AMD_SMI_INCLUDE_AMD_SMI_TEST_INTERNAL_H_
+#endif  // AMD_SMI_INCLUDE_AMD_SMI_TEST_FLAGS_H_

--- a/projects/amdsmi/include/amd_smi/impl/amd_smi_test_internal.h
+++ b/projects/amdsmi/include/amd_smi/impl/amd_smi_test_internal.h
@@ -20,10 +20,12 @@
  * THE SOFTWARE.
  */
 
-#ifndef AMD_SMI_INCLUDE_AMD_SMI_TEST_FLAGS_H_
-#define AMD_SMI_INCLUDE_AMD_SMI_TEST_FLAGS_H_
+#ifndef AMD_SMI_INCLUDE_AMD_SMI_TEST_INTERNAL_H_
+#define AMD_SMI_INCLUDE_AMD_SMI_TEST_INTERNAL_H_
 
 #include <cstdint>
+
+#include "amd_smi/amdsmi.h"
 
 // Reserved test-only init flag. Passed to amdsmi_init() / rsmi_init() to
 // switch GPU device mutexes from blocking to non-blocking (trylock) mode,
@@ -33,4 +35,9 @@
 // Current public flags occupy bits [0:3]; this flag uses bit 59 (0x0800_0000_0000_0000).
 inline constexpr uint64_t AMD_SMI_INIT_FLAG_RESRV_TEST1 = 0x0800000000000000ULL;
 
-#endif  // AMD_SMI_INCLUDE_AMD_SMI_TEST_FLAGS_H_
+// Internal test-only wrapper around rsmi_test_sleep. Acquires the device mutex
+// for |seconds| seconds and returns an amdsmi_status_t so tests do not need to
+// extern-declare the rsmi_status_t function directly.
+amdsmi_status_t amdsmi_test_sleep(amdsmi_processor_handle processor_handle, uint32_t seconds);
+
+#endif  // AMD_SMI_INCLUDE_AMD_SMI_TEST_INTERNAL_H_

--- a/projects/amdsmi/include/amd_smi/impl/amd_smi_utils.h
+++ b/projects/amdsmi/include/amd_smi/impl/amd_smi_utils.h
@@ -24,6 +24,7 @@
 #define AMD_SMI_INCLUDE_AMD_SMI_UTILS_H_
 
 #include <dirent.h>
+#include <pthread.h>
 
 #include <limits>
 #include <string>
@@ -31,13 +32,6 @@
 
 #include "amd_smi/amdsmi.h"
 #include "amd_smi/impl/amd_smi_gpu_device.h"
-
-#define SMIGPUDEVICE_MUTEX(MUTEX)           \
-  amd::smi::pthread_wrap _pw(*(MUTEX));     \
-  amd::smi::ScopedPthread _lock(_pw, true); \
-  if (_lock.mutex_not_acquired()) {         \
-    return AMDSMI_STATUS_BUSY;              \
-  }
 
 extern "C" {
 void amdsmi_free_name_value_pairs(void* p);

--- a/projects/amdsmi/include/amd_smi/impl/amd_smi_utils.h
+++ b/projects/amdsmi/include/amd_smi/impl/amd_smi_utils.h
@@ -24,7 +24,6 @@
 #define AMD_SMI_INCLUDE_AMD_SMI_UTILS_H_
 
 #include <dirent.h>
-#include <pthread.h>
 
 #include <limits>
 #include <string>

--- a/projects/amdsmi/rocm_smi/include/rocm_smi/rocm_smi.h
+++ b/projects/amdsmi/rocm_smi/include/rocm_smi/rocm_smi.h
@@ -126,14 +126,14 @@ typedef enum {
  */
 
 typedef enum {
-  RSMI_INIT_FLAG_ALL_GPUS = 0x1,                        //!< Attempt to add all GPUs found
-                                                        //!< (including non-AMD) to the list
-                                                        //!< of devices from which SMI
-                                                        //!< information can be retrieved. By
-                                                        //!< default, only AMD devices are
-                                                        //!<  enumerated by RSMI.
-  RSMI_INIT_FLAG_THRAD_ONLY_MUTEX = 0x400000000000000,  //!< The mutex limit to thread
-  RSMI_INIT_FLAG_RESRV_TEST1 = 0x800000000000000,       //!< Reserved for test
+  RSMI_INIT_FLAG_ALL_GPUS = 0x1,                         //!< Attempt to add all GPUs found
+                                                         //!< (including non-AMD) to the list
+                                                         //!< of devices from which SMI
+                                                         //!< information can be retrieved. By
+                                                         //!< default, only AMD devices are
+                                                         //!<  enumerated by RSMI.
+  RSMI_INIT_FLAG_THRAD_ONLY_MUTEX = 0x0400000000000000,  //!< The mutex limit to thread
+  RSMI_INIT_FLAG_RESRV_TEST1 = 0x0800000000000000,       //!< Reserved for test
 } rsmi_init_flags_t;
 
 /**

--- a/projects/amdsmi/rocm_smi/include/rocm_smi/rocm_smi_utils.h
+++ b/projects/amdsmi/rocm_smi/include/rocm_smi/rocm_smi_utils.h
@@ -636,6 +636,8 @@ uint64_t bdfid_from_domain(uint64_t bdfid, uint64_t domain);
 // Sleep for the given number of whole seconds, retrying on signal interruption
 // (EINTR) so the full duration is always served.
 void sleep_interruptible(uint32_t seconds);
+// Sleep for the given timespec duration, retrying on EINTR.
+void sleep_interruptible(const struct timespec& duration);
 }  // namespace amd::smi
 
 #endif  // INCLUDE_ROCM_SMI_ROCM_SMI_UTILS_H_

--- a/projects/amdsmi/rocm_smi/include/rocm_smi/rocm_smi_utils.h
+++ b/projects/amdsmi/rocm_smi/include/rocm_smi/rocm_smi_utils.h
@@ -632,6 +632,10 @@ inline ostream_joiner<std::decay_t<DelimiterType>, CharType, TraitsType> make_os
 }
 
 uint64_t bdfid_from_domain(uint64_t bdfid, uint64_t domain);
+
+// Sleep for the given number of whole seconds, retrying on signal interruption
+// (EINTR) so the full duration is always served.
+void sleep_interruptible(uint32_t seconds);
 }  // namespace amd::smi
 
 #endif  // INCLUDE_ROCM_SMI_ROCM_SMI_UTILS_H_

--- a/projects/amdsmi/rocm_smi/src/rocm_smi.cc
+++ b/projects/amdsmi/rocm_smi/src/rocm_smi.cc
@@ -3292,6 +3292,9 @@ rsmi_status_t rsmi_dev_temp_metric_get(uint32_t dv_ind, uint32_t sensor_type,
   amd::smi::MonitorTypes mon_type = amd::smi::kMonInvalid;
   uint16_t val_ui16;
   GET_DEV_FROM_INDX
+  // DEVICE_MUTEX moved before the HBM/gpuboard early-return paths so that
+  // all code paths — including the HBM temperature block — hold the lock.
+  // Previously the mutex was acquired after those blocks, leaving them unprotected.
   DEVICE_MUTEX
 
   // handle gpu board temp

--- a/projects/amdsmi/rocm_smi/src/rocm_smi.cc
+++ b/projects/amdsmi/rocm_smi/src/rocm_smi.cc
@@ -7780,7 +7780,8 @@ rsmi_status_t rsmi_test_sleep(uint32_t dv_ind, uint32_t seconds) {
     return RSMI_STATUS_BUSY;
   }
 
-  sleep(seconds);
+  amd::smi::sleep_interruptible(seconds);
+
   return RSMI_STATUS_SUCCESS;
 }
 

--- a/projects/amdsmi/rocm_smi/src/rocm_smi.cc
+++ b/projects/amdsmi/rocm_smi/src/rocm_smi.cc
@@ -998,6 +998,7 @@ rsmi_status_t rsmi_dev_id_get(uint32_t dv_ind, uint16_t* id) {
   if (id == nullptr) {
     return RSMI_STATUS_INVALID_ARGS;
   }
+  DEVICE_MUTEX
   CHK_SUPPORT_NAME_ONLY(id)
   // Set the device ID to max value
   *id = std::numeric_limits<uint16_t>::max();
@@ -2973,12 +2974,10 @@ rsmi_status_t rsmi_dev_vendor_name_get(uint32_t dv_ind, char* name, size_t len) 
   if (name == nullptr || len == 0) {
     return RSMI_STATUS_INVALID_ARGS;
   }
+  DEVICE_MUTEX
   CHK_SUPPORT_NAME_ONLY(name)
 
   assert(len > 0);
-
-  DEVICE_MUTEX
-
   ret = get_dev_name_from_id(dv_ind, name, len, NAME_STR_VENDOR);
   return ret;
   CATCH
@@ -3022,9 +3021,8 @@ rsmi_status_t rsmi_dev_pci_bandwidth_get(uint32_t dv_ind, rsmi_pcie_bandwidth_t*
   LOG_TRACE(ss);
 
   GET_DEV_AND_KFDNODE_FROM_INDX
-  CHK_API_SUPPORT_ONLY((b), RSMI_DEFAULT_VARIANT, RSMI_DEFAULT_VARIANT)
-
   DEVICE_MUTEX
+  CHK_API_SUPPORT_ONLY((b), RSMI_DEFAULT_VARIANT, RSMI_DEFAULT_VARIANT)
 
   ret = get_frequencies(amd::smi::kDevPCIEClk, RSMI_CLK_TYPE_PCIE, dv_ind, &b->transfer_rate,
                         b->lanes);
@@ -3294,6 +3292,7 @@ rsmi_status_t rsmi_dev_temp_metric_get(uint32_t dv_ind, uint32_t sensor_type,
   amd::smi::MonitorTypes mon_type = amd::smi::kMonInvalid;
   uint16_t val_ui16;
   GET_DEV_FROM_INDX
+  DEVICE_MUTEX
 
   // handle gpu board temp
   if (sensor_type >= RSMI_TEMP_TYPE_GPUBOARD_NODE_FIRST &&
@@ -3443,8 +3442,6 @@ rsmi_status_t rsmi_dev_temp_metric_get(uint32_t dv_ind, uint32_t sensor_type,
     LOG_INFO(ss);
     return RSMI_STATUS_SUCCESS;
   }  // end HBM temperature
-
-  DEVICE_MUTEX
 
   if (dev->monitor() == nullptr) {
     ss << __PRETTY_FUNCTION__ << " | ======= end ======= "

--- a/projects/amdsmi/rocm_smi/src/rocm_smi_binary_parser.cc
+++ b/projects/amdsmi/rocm_smi/src/rocm_smi_binary_parser.cc
@@ -23,7 +23,6 @@
 #include "rocm_smi/rocm_smi_binary_parser.h"
 
 #include <dirent.h>
-#include <pthread.h>
 
 #include <cassert>
 #include <cinttypes>

--- a/projects/amdsmi/rocm_smi/src/rocm_smi_device.cc
+++ b/projects/amdsmi/rocm_smi/src/rocm_smi_device.cc
@@ -22,7 +22,6 @@
 
 #include "rocm_smi/rocm_smi_device.h"
 
-#include <pthread.h>
 #include <sys/stat.h>
 #include <sys/types.h>
 #include <unistd.h>

--- a/projects/amdsmi/rocm_smi/src/rocm_smi_gpu_metrics.cc
+++ b/projects/amdsmi/rocm_smi/src/rocm_smi_gpu_metrics.cc
@@ -23,7 +23,6 @@
 #include "rocm_smi/rocm_smi_gpu_metrics.h"
 
 #include <dirent.h>
-#include <pthread.h>
 #include <unistd.h>
 
 #include <algorithm>

--- a/projects/amdsmi/rocm_smi/src/rocm_smi_utils.cc
+++ b/projects/amdsmi/rocm_smi/src/rocm_smi_utils.cc
@@ -1467,4 +1467,17 @@ uint64_t bdfid_from_domain(uint64_t bdfid, uint64_t domain) {
   bdfid |= (domain & 0xFFFFFFFF) << 32;  // Add domain to top of pci_id
   return bdfid;
 }
+
+// Use nanosleep in a loop so that signals (e.g. SIGCHLD) do not
+// shorten the sleep and cause the full duration to be skipped.
+void sleep_interruptible(uint32_t seconds) {
+  struct timespec remaining = {static_cast<time_t>(seconds), 0};
+  while (remaining.tv_sec > 0 || remaining.tv_nsec > 0) {
+    struct timespec interval = remaining;
+    if (nanosleep(&interval, &remaining) == 0) {
+      break;
+    }
+    // EINTR: a signal interrupted the sleep; remaining has time left, retry.
+  }
+}
 }  // namespace amd::smi

--- a/projects/amdsmi/rocm_smi/src/rocm_smi_utils.cc
+++ b/projects/amdsmi/rocm_smi/src/rocm_smi_utils.cc
@@ -38,6 +38,7 @@
 #include <cmath>
 #include <cstdint>
 #include <cstring>
+#include <ctime>
 #include <fstream>
 #include <iomanip>
 #include <iostream>
@@ -1470,14 +1471,22 @@ uint64_t bdfid_from_domain(uint64_t bdfid, uint64_t domain) {
 
 // Use nanosleep in a loop so that signals (e.g. SIGCHLD) do not
 // shorten the sleep and cause the full duration to be skipped.
-void sleep_interruptible(uint32_t seconds) {
-  struct timespec remaining = {static_cast<time_t>(seconds), 0};
+void sleep_interruptible(const struct timespec& duration) {
+  struct timespec remaining = duration;
   while (remaining.tv_sec > 0 || remaining.tv_nsec > 0) {
     struct timespec interval = remaining;
     if (nanosleep(&interval, &remaining) == 0) {
       break;
     }
     // EINTR: a signal interrupted the sleep; remaining has time left, retry.
+    // Any other error (e.g. EINVAL) is unrecoverable — stop to avoid looping forever.
+    if (errno != EINTR) {
+      break;
+    }
   }
+}
+
+void sleep_interruptible(uint32_t seconds) {
+  sleep_interruptible({static_cast<time_t>(seconds), 0});
 }
 }  // namespace amd::smi

--- a/projects/amdsmi/src/amd_smi/amd_smi.cc
+++ b/projects/amdsmi/src/amd_smi/amd_smi.cc
@@ -64,6 +64,7 @@
 #include "amd_smi/impl/nic/amd_smi_nic_device.h"
 #include "amd_smi/impl/nic/amd_smi_switch_device.h"
 #endif  // BRCM_NIC
+#include "amd_smi/impl/amd_smi_gpu_mutex.h"
 #include "amd_smi/impl/amd_smi_processor.h"
 #include "amd_smi/impl/amd_smi_utils.h"
 #include "amd_smi/impl/amd_smi_uuid.h"
@@ -1444,6 +1445,7 @@ amdsmi_status_t amdsmi_get_gpu_board_info(amdsmi_processor_handle processor_hand
   amd::smi::AMDSmiGPUDevice* gpu_device = nullptr;
   amdsmi_status_t r = get_gpu_device_from_handle(processor_handle, &gpu_device);
   if (r != AMDSMI_STATUS_SUCCESS) return r;
+  SMIGPUDEVICE_MUTEX(gpu_device->get_mutex())
 
   status = smi_amdgpu_get_board_info(gpu_device, board_info);
   if (board_info->product_serial[0] == '\0') {

--- a/projects/amdsmi/src/amd_smi/amd_smi.cc
+++ b/projects/amdsmi/src/amd_smi/amd_smi.cc
@@ -66,6 +66,7 @@
 #endif  // BRCM_NIC
 #include "amd_smi/impl/amd_smi_gpu_mutex.h"
 #include "amd_smi/impl/amd_smi_processor.h"
+#include "amd_smi/impl/amd_smi_test_internal.h"
 #include "amd_smi/impl/amd_smi_utils.h"
 #include "amd_smi/impl/amd_smi_uuid.h"
 #include "amd_smi/impl/xf86drm.h"
@@ -8580,4 +8581,12 @@ amdsmi_status_t amdsmi_reset_ttm_pages_limit(void) {
   }
 
   return AMDSMI_STATUS_SUCCESS;
+}
+
+// Test-only wrapper: acquires the device mutex for |seconds| seconds.
+// Not declared in amdsmi.h — internal use via amd_smi_test_internal.h only.
+// rsmi_test_sleep is undocumented and not in rocm_smi.h, so forward-declare it.
+extern rsmi_status_t rsmi_test_sleep(uint32_t dv_ind, uint32_t seconds);
+amdsmi_status_t amdsmi_test_sleep(amdsmi_processor_handle processor_handle, uint32_t seconds) {
+  return rsmi_wrapper(rsmi_test_sleep, processor_handle, 0, seconds);
 }

--- a/projects/amdsmi/src/amd_smi/amd_smi_system.cc
+++ b/projects/amdsmi/src/amd_smi/amd_smi_system.cc
@@ -42,13 +42,12 @@
 #include <regex>
 
 #include "amd_smi/impl/amd_smi_common.h"
+#include "amd_smi/impl/amd_smi_test_flags.h"
 #include "amd_smi/impl/amd_smi_utils.h"
 #include "rocm_smi/rocm_smi.h"
 #include "rocm_smi/rocm_smi_logger.h"
 
 namespace amd::smi {
-
-#define AMD_SMI_INIT_FLAG_RESRV_TEST1 0x800000000000000  //!< Reserved for test
 
 AMDSmiSystem& AMDSmiSystem::getInstance() {
   static AMDSmiSystem instance;
@@ -272,7 +271,8 @@ amdsmi_status_t AMDSmiSystem::init(uint64_t flags) {
   amdsmi_status_t amd_smi_status;
 
   // populate GPU sockets and processors
-  if (flags & AMDSMI_INIT_AMD_GPUS) {
+  // Also initialize GPU devices when the test flag is set (for mutual exclusion testing)
+  if ((flags & AMDSMI_INIT_AMD_GPUS) || (flags & AMD_SMI_INIT_FLAG_RESRV_TEST1)) {
     amd_smi_status = populate_amd_gpu_devices();
     if (amd_smi_status != AMDSMI_STATUS_SUCCESS) return amd_smi_status;
   }
@@ -341,9 +341,11 @@ amdsmi_status_t AMDSmiSystem::populate_amd_cpus() {
 
 amdsmi_status_t AMDSmiSystem::populate_amd_gpu_devices() {
   AMDSmiSystem::cleanup();
-  // init rsmi
+  // init rsmi — forward the test flag so the mutex becomes non-blocking
   rsmi_driver_state_t state;
-  rsmi_status_t ret = rsmi_init(0);
+  uint64_t rsmi_flags =
+      (init_flag_ & AMD_SMI_INIT_FLAG_RESRV_TEST1) ? RSMI_INIT_FLAG_RESRV_TEST1 : 0;
+  rsmi_status_t ret = rsmi_init(rsmi_flags);
   if (ret != RSMI_STATUS_SUCCESS) {
     if (rsmi_driver_status(&state) == RSMI_STATUS_SUCCESS &&
         state != RSMI_DRIVER_MODULE_STATE_LIVE) {

--- a/projects/amdsmi/src/amd_smi/amd_smi_system.cc
+++ b/projects/amdsmi/src/amd_smi/amd_smi_system.cc
@@ -42,7 +42,7 @@
 #include <regex>
 
 #include "amd_smi/impl/amd_smi_common.h"
-#include "amd_smi/impl/amd_smi_test_internal.h"
+#include "amd_smi/impl/amd_smi_test_flags.h"
 #include "amd_smi/impl/amd_smi_utils.h"
 #include "rocm_smi/rocm_smi.h"
 #include "rocm_smi/rocm_smi_logger.h"
@@ -271,8 +271,7 @@ amdsmi_status_t AMDSmiSystem::init(uint64_t flags) {
   amdsmi_status_t amd_smi_status;
 
   // populate GPU sockets and processors
-  // Also initialize GPU devices when the test flag is set (for mutual exclusion testing)
-  if ((flags & AMDSMI_INIT_AMD_GPUS) || (flags & AMD_SMI_INIT_FLAG_RESRV_TEST1)) {
+  if (flags & AMDSMI_INIT_AMD_GPUS) {
     amd_smi_status = populate_amd_gpu_devices();
     if (amd_smi_status != AMDSMI_STATUS_SUCCESS) return amd_smi_status;
   }

--- a/projects/amdsmi/src/amd_smi/amd_smi_system.cc
+++ b/projects/amdsmi/src/amd_smi/amd_smi_system.cc
@@ -42,7 +42,7 @@
 #include <regex>
 
 #include "amd_smi/impl/amd_smi_common.h"
-#include "amd_smi/impl/amd_smi_test_flags.h"
+#include "amd_smi/impl/amd_smi_test_internal.h"
 #include "amd_smi/impl/amd_smi_utils.h"
 #include "rocm_smi/rocm_smi.h"
 #include "rocm_smi/rocm_smi_logger.h"

--- a/projects/amdsmi/src/amd_smi/amd_smi_utils.cc
+++ b/projects/amdsmi/src/amd_smi/amd_smi_utils.cc
@@ -45,6 +45,7 @@
 #include <regex>
 #include <sstream>
 
+#include "amd_smi/impl/amd_smi_gpu_mutex.h"
 #include "amd_smi/impl/amd_smi_system.h"
 #include "amd_smi/impl/scoped_fd.h"
 #include "config/amd_smi_config.h"

--- a/projects/amdsmi/tests/amd_smi_test/functional/cross_process_serialization.cc
+++ b/projects/amdsmi/tests/amd_smi_test/functional/cross_process_serialization.cc
@@ -1,0 +1,347 @@
+/*
+ * Copyright (c) Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+#include "cross_process_serialization.h"
+
+#include <gtest/gtest.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+#include <cerrno>
+#include <chrono>
+#include <csignal>
+#include <cstdint>
+#include <cstdlib>
+#include <cstring>
+#include <ctime>
+#include <iostream>
+#include <string>
+#include <vector>
+
+#include "../test_common.h"
+#include "amd_smi/amdsmi.h"
+
+// How long the holder process holds the mutex (seconds).
+static constexpr unsigned int kHoldSeconds = 5;
+// Minimum elapsed time (seconds) the waiter must observe to prove it blocked.
+// Set below kHoldSeconds to absorb scheduling jitter.
+static constexpr double kMinWaitSeconds = 3.0;
+// Nanoseconds the waiter pauses after receiving the run_pipe_ signal before
+// calling amdsmi_get_gpu_id. rsmi_test_sleep's mutex acquisition is
+// sub-microsecond; 200ms is a 200,000x margin.
+static constexpr long kWaiterMutexPauseNs = 200000000L;  // 200 ms
+
+extern amdsmi_status_t rsmi_test_sleep(uint32_t dv_ind, uint32_t seconds);
+
+TestCrossProcessSerialization::TestCrossProcessSerialization() : TestBase() {
+  set_title("Cross-Process Serialization Test");
+  set_description(
+      "Verifies that AMDSMI_MUTEX_CROSS_PROCESS=1 (blocking mode) correctly "
+      "serializes GPU API calls across processes. Process A holds the device "
+      "mutex for several seconds via rsmi_test_sleep. Process B then calls an "
+      "AMDSMI API and measures how long it blocks. A wait time >= " +
+      std::to_string(kMinWaitSeconds) +
+      " seconds proves Process B was serialized rather than racing"
+      " through concurrently.");
+}
+
+TestCrossProcessSerialization::~TestCrossProcessSerialization() {}
+
+void TestCrossProcessSerialization::SetUp(void) {
+  std::string label;
+  amdsmi_status_t ret;
+
+  IF_VERB(STANDARD) {
+    MakeHeaderStr(kSetupLabel, &label);
+    std::cout << "\n\t" << label << std::endl;
+  }
+
+  holder_process_ = false;
+  child_ = 0;
+
+  // Cross-process shared memory mutex is required.
+  // Must be set before fork() so both processes inherit it and amdsmi_init()
+  // uses shm_open/mmap instead of a per-process pthread_mutex_t.
+  // Save original value so Close() can restore it after the test.
+  const char* orig = getenv("AMDSMI_MUTEX_CROSS_PROCESS");
+  orig_cross_process_env_ = orig ? orig : "";
+  orig_cross_process_env_was_set_ = (orig != nullptr);
+  setenv("AMDSMI_MUTEX_CROSS_PROCESS", "1", 1);
+
+  // Three pipes provide a fully deterministic two-phase handshake:
+  //   init_pipe_:         holder → waiter  (holder init complete)
+  //   waiter_ready_pipe_: waiter → holder  (waiter init complete)
+  //   run_pipe_:          holder → waiter  (holder about to acquire mutex)
+  // This guarantees both processes finish amdsmi_init before the holder
+  // calls rsmi_test_sleep, which would otherwise block the waiter's own
+  // amdsmi_init (device enumeration acquires the shared device mutex).
+  if (pipe(init_pipe_) < 0 || pipe(waiter_ready_pipe_) < 0 || pipe(run_pipe_) < 0) {
+    std::cout << "pipe() failed: " << strerror(errno) << std::endl;
+    setup_failed_ = true;
+    return;
+  }
+
+  child_ = fork();
+  if (child_ < 0) {
+    std::cout << "fork() failed: " << strerror(errno) << std::endl;
+    close(init_pipe_[0]);
+    close(init_pipe_[1]);
+    close(waiter_ready_pipe_[0]);
+    close(waiter_ready_pipe_[1]);
+    close(run_pipe_[0]);
+    close(run_pipe_[1]);
+    setup_failed_ = true;
+    return;
+  }
+
+  if (child_ != 0) {
+    // Parent = mutex holder process. Init without RESRV_TEST1 so locks block.
+    holder_process_ = true;
+    // Holder: does not read init_pipe or waiter_ready_pipe write-end,
+    // does not read run_pipe.
+    close(init_pipe_[0]);
+    close(waiter_ready_pipe_[1]);
+    close(run_pipe_[0]);
+
+    DISPLAY_AMDSMI_API("[holder] amdsmi_init", "", VERB(STANDARD));
+    ret = amdsmi_init(AMDSMI_INIT_AMD_GPUS);
+    DISPLAY_AMDSMI_STATUS(VERB(STANDARD), __FILE__, __LINE__, ret, AMDSMI_STATUS_SUCCESS);
+    if (ret != AMDSMI_STATUS_SUCCESS) {
+      setup_failed_ = true;
+    }
+    // Phase 1: signal waiter that holder's amdsmi_init is complete.
+    char ready = 1;
+    write(init_pipe_[1], &ready, 1);
+    close(init_pipe_[1]);
+
+    // Phase 2: wait for waiter to also finish amdsmi_init before entering
+    // Run(). Without this barrier the holder would call rsmi_test_sleep
+    // (acquiring the device mutex) while the waiter's amdsmi_init is still
+    // trying to enumerate devices — which also acquires that same mutex.
+    // Then amdsmi_get_gpu_id would see a free mutex and return instantly.
+    char waiter_done = 0;
+    if (read(waiter_ready_pipe_[0], &waiter_done, 1) < 0) {
+      std::cout << "read(waiter_ready_pipe_) failed: " << strerror(errno) << std::endl;
+      setup_failed_ = true;
+    }
+    close(waiter_ready_pipe_[0]);
+    ASSERT_EQ(ret, AMDSMI_STATUS_SUCCESS);
+  } else {
+    // Waiter: does not write to init_pipe, does not read waiter_ready_pipe
+    // read-end, does not write to run_pipe.
+    close(init_pipe_[1]);
+    close(waiter_ready_pipe_[0]);
+    close(run_pipe_[1]);
+
+    // Phase 1: block until holder's amdsmi_init is complete.
+    char ready = 0;
+    if (read(init_pipe_[0], &ready, 1) < 0) {
+      std::cout << "read(init_pipe_) failed: " << strerror(errno) << std::endl;
+      setup_failed_ = true;
+    }
+    close(init_pipe_[0]);
+
+    DISPLAY_AMDSMI_API("[waiter] amdsmi_init", "", VERB(STANDARD));
+    ret = amdsmi_init(AMDSMI_INIT_AMD_GPUS);
+    DISPLAY_AMDSMI_STATUS(VERB(STANDARD), __FILE__, __LINE__, ret, AMDSMI_STATUS_SUCCESS);
+    if (ret != AMDSMI_STATUS_SUCCESS) {
+      setup_failed_ = true;
+    }
+    // Phase 2: signal holder that waiter's amdsmi_init is also complete.
+    char waiter_done = 1;
+    write(waiter_ready_pipe_[1], &waiter_done, 1);
+    close(waiter_ready_pipe_[1]);
+    ASSERT_EQ(ret, AMDSMI_STATUS_SUCCESS);
+  }
+
+  // Enumerate processor handles in each process after amdsmi_init()
+  uint32_t socket_count = 0;
+  amdsmi_status_t enum_err = amdsmi_get_socket_handles(&socket_count, nullptr);
+  if (enum_err != AMDSMI_STATUS_SUCCESS) {
+    setup_failed_ = true;
+    return;
+  }
+  std::vector<amdsmi_socket_handle> sockets(socket_count);
+  enum_err = amdsmi_get_socket_handles(&socket_count, &sockets[0]);
+  if (enum_err != AMDSMI_STATUS_SUCCESS) {
+    setup_failed_ = true;
+    return;
+  }
+  num_monitor_devs_ = 0;
+  for (uint32_t i = 0; i < socket_count; i++) {
+    uint32_t device_count = 0;
+    amdsmi_status_t status = amdsmi_get_processor_handles(sockets[i], &device_count, nullptr);
+    if (status != AMDSMI_STATUS_SUCCESS || device_count == 0) {
+      continue;
+    }
+    std::vector<amdsmi_processor_handle> handles(device_count);
+    status = amdsmi_get_processor_handles(sockets[i], &device_count, &handles[0]);
+    if (status != AMDSMI_STATUS_SUCCESS) {
+      continue;
+    }
+    for (uint32_t j = 0; j < device_count && num_monitor_devs_ < MAX_MONITOR_DEVICES; j++) {
+      processor_handles_[num_monitor_devs_++] = handles[j];
+    }
+  }
+
+  if (num_monitor_devs_ == 0) {
+    std::cout << "No monitor devices found on this machine." << std::endl;
+    setup_failed_ = true;
+  }
+}
+
+void TestCrossProcessSerialization::DisplayTestInfo(void) {
+  IF_VERB(STANDARD) { TestBase::DisplayTestInfo(); }
+}
+
+void TestCrossProcessSerialization::DisplayResults(void) const {
+  IF_VERB(STANDARD) { TestBase::DisplayResults(); }
+}
+
+void TestCrossProcessSerialization::Close() {
+  // Shut down while AMDSMI_MUTEX_CROSS_PROCESS is still set so that
+  // shared_mutex_close() correctly munmaps instead of calling delete.
+  TestBase::Close();
+
+  if (orig_cross_process_env_was_set_) {
+    setenv("AMDSMI_MUTEX_CROSS_PROCESS", orig_cross_process_env_.c_str(), 1);
+  } else {
+    unsetenv("AMDSMI_MUTEX_CROSS_PROCESS");
+  }
+}
+
+void TestCrossProcessSerialization::Run(void) {
+  if (setup_failed_) {
+    std::cout << "** SetUp Failed for this test. Skipping.**" << std::endl;
+    if (!holder_process_) {
+      // In the child process, _exit() immediately to avoid running gtest/AMDSMI cleanup
+      // cleanup that was never meant to run here.
+      std::cout.flush();
+      _exit(1);
+    }
+    // Holder process: reap the child to avoid leaving a zombie.
+    if (child_ > 0) {
+      int child_status = 0;
+      waitpid(child_, &child_status, 0);
+    }
+    return;
+  }
+
+  if (holder_process_) {
+    PRINT_VERBOSITY();
+
+    // Block SIGCHLD so it doesn't interrupt sleep inside rsmi_test_sleep.
+    sigset_t sigchld_mask, old_mask;
+    sigemptyset(&sigchld_mask);
+    sigaddset(&sigchld_mask, SIGCHLD);
+    sigprocmask(SIG_BLOCK, &sigchld_mask, &old_mask);
+
+    IF_VERB(STANDARD) {
+      std::cout << "HOLDER process: acquiring mutex and sleeping for " << kHoldSeconds << "s..."
+                << std::endl;
+    }
+    // Signal waiter that holder is about to enter rsmi_test_sleep (acquire
+    // mutex), then immediately call it. The waiter reads this signal and
+    // pauses kWaiterMutexPauseNs before calling amdsmi_get_gpu_id.
+    char run_ready = 1;
+    write(run_pipe_[1], &run_ready, 1);
+    close(run_pipe_[1]);
+    amdsmi_status_t ret = rsmi_test_sleep(0, kHoldSeconds);
+    ASSERT_EQ(ret, AMDSMI_STATUS_SUCCESS);
+    IF_VERB(STANDARD) {
+      std::cout << "HOLDER process: released mutex after " << kHoldSeconds << "s." << std::endl;
+    }
+
+    sigprocmask(SIG_SETMASK, &old_mask, nullptr);
+    int child_status = 0;
+    pid_t cpid = wait(&child_status);
+    ASSERT_EQ(cpid, child_);
+    ASSERT_TRUE(WIFEXITED(child_status) && WEXITSTATUS(child_status) == 0)
+        << "WAITER process exited with non-zero status " << WEXITSTATUS(child_status)
+        << " — child assertions failed (see output above)";
+
+  } else {
+    TestBase::Run();
+
+    // Exit the child process with failure. GTEST_FAIL() cannot be used here
+    // because gtest state does not cross fork() boundaries — the parent reports
+    // child failure by inspecting the exit status via wait().
+    auto fail_child = [](const std::string& msg) {
+      std::cout << msg << std::endl;
+      std::cout.flush();
+      _exit(1);
+    };
+
+    // Block until holder signals it is about to acquire the mutex, then
+    // pause briefly so rsmi_test_sleep's pthread_mutex_lock completes
+    // before we attempt to acquire the same lock via amdsmi_get_gpu_id.
+    char run_ready = 0;
+    read(run_pipe_[0], &run_ready, 1);
+    close(run_pipe_[0]);
+
+    // Print after the pipe read so this message always follows the holder's
+    // "acquiring mutex" message in the output (the holder writes to the pipe
+    // immediately after printing its own message).
+    IF_VERB(STANDARD) {
+      std::cout << "WAITER process: calling amdsmi_get_gpu_id() — should block until "
+                   "HOLDER releases mutex..."
+                << std::endl;
+    }
+
+    struct timespec pause_ts = {0, kWaiterMutexPauseNs};
+    nanosleep(&pause_ts, nullptr);
+
+    uint16_t gpu_id = 0;
+    auto t0 = std::chrono::steady_clock::now();
+
+    DISPLAY_AMDSMI_API("[waiter] amdsmi_get_gpu_id(processor_handles_[0], &gpu_id)", "",
+                       VERB(STANDARD));
+    // This call must wait for the holder's rsmi_test_sleep to finish.
+    amdsmi_status_t ret = amdsmi_get_gpu_id(processor_handles_[0], &gpu_id);
+    DISPLAY_AMDSMI_STATUS(VERB(STANDARD), __FILE__, __LINE__, ret, AMDSMI_STATUS_SUCCESS);
+
+    auto t1 = std::chrono::steady_clock::now();
+    double elapsed = std::chrono::duration<double>(t1 - t0).count();
+
+    IF_VERB(STANDARD) {
+      std::cout << "WAITER process: amdsmi_get_gpu_id() returned after " << elapsed << "s"
+                << " (expected >= " << kMinWaitSeconds << "s)" << std::endl;
+    }
+
+    if (ret != AMDSMI_STATUS_SUCCESS) {
+      fail_child("WAITER process: amdsmi_get_gpu_id() returned " + std::to_string(ret) +
+                 " — expected AMDSMI_STATUS_SUCCESS after mutex was released");
+    }
+    if (elapsed < kMinWaitSeconds) {
+      fail_child("WAITER process: elapsed " + std::to_string(elapsed) + "s < " +
+                 std::to_string(kMinWaitSeconds) +
+                 "s — waiter did not block, cross-process serialization is broken");
+    }
+
+    IF_VERB(STANDARD) {
+      std::cout << "WAITER process: serialization verified after " << elapsed << "s. gpu_id=0x"
+                << std::hex << gpu_id << std::dec << std::endl;
+    }
+
+    std::cout.flush();
+    _exit(0);
+  }
+}

--- a/projects/amdsmi/tests/amd_smi_test/functional/cross_process_serialization.cc
+++ b/projects/amdsmi/tests/amd_smi_test/functional/cross_process_serialization.cc
@@ -300,9 +300,9 @@ void TestCrossProcessSerialization::Run(void) {
     int child_status = 0;
     pid_t cpid = wait(&child_status);
     ASSERT_EQ(cpid, child_);
-    ASSERT_TRUE(WIFEXITED(child_status) && WEXITSTATUS(child_status) == 0)
-        << "WAITER process exited with non-zero status " << WEXITSTATUS(child_status)
-        << " — child assertions failed (see output above)";
+    ASSERT_TRUE(WIFEXITED(child_status))
+        << "WAITER process terminated by signal " << WTERMSIG(child_status);
+    EXPECT_EQ(WEXITSTATUS(child_status), 0) << "WAITER process reported assertion failure(s)";
 
   } else {
     TestBase::Run();

--- a/projects/amdsmi/tests/amd_smi_test/functional/cross_process_serialization.cc
+++ b/projects/amdsmi/tests/amd_smi_test/functional/cross_process_serialization.cc
@@ -37,6 +37,7 @@
 
 #include "../test_common.h"
 #include "amd_smi/amdsmi.h"
+#include "amd_smi/impl/amd_smi_test_internal.h"
 #include "rocm_smi/rocm_smi_utils.h"
 
 // How long the holder process holds the mutex (seconds).
@@ -48,8 +49,6 @@ static constexpr double kMinWaitSeconds = 3.0;
 // calling amdsmi_get_gpu_id. rsmi_test_sleep's mutex acquisition is
 // sub-microsecond; 200ms is a 200,000x margin.
 static constexpr long kWaiterMutexPauseNs = 200000000L;  // 200 ms
-
-extern amdsmi_status_t rsmi_test_sleep(uint32_t dv_ind, uint32_t seconds);
 
 TestCrossProcessSerialization::TestCrossProcessSerialization() : TestBase() {
   set_title("Cross-Process Serialization Test");
@@ -289,7 +288,7 @@ void TestCrossProcessSerialization::Run(void) {
     ASSERT_GT(write(run_pipe_[1], &run_ready, 1), 0)
         << "HOLDER: write(run_pipe_) failed: " << strerror(errno);
     close(run_pipe_[1]);
-    amdsmi_status_t ret = rsmi_test_sleep(0, kHoldSeconds);
+    amdsmi_status_t ret = amdsmi_test_sleep(processor_handles_[0], kHoldSeconds);
     ASSERT_EQ(ret, AMDSMI_STATUS_SUCCESS);
     IF_VERB(STANDARD) {
       std::cout << "HOLDER process: released mutex after " << kHoldSeconds << "s." << std::endl;

--- a/projects/amdsmi/tests/amd_smi_test/functional/cross_process_serialization.cc
+++ b/projects/amdsmi/tests/amd_smi_test/functional/cross_process_serialization.cc
@@ -146,7 +146,10 @@ void TestCrossProcessSerialization::SetUp(void) {
     }
     // Phase 1: signal waiter that holder's amdsmi_init is complete.
     char ready = 1;
-    write(init_pipe_[1], &ready, 1);
+    if (write(init_pipe_[1], &ready, 1) < 0) {
+      std::cout << "write(init_pipe_) failed: " << strerror(errno) << std::endl;
+      setup_failed_ = true;
+    }
     close(init_pipe_[1]);
 
     // Phase 2: wait for waiter to also finish amdsmi_init before entering
@@ -185,7 +188,10 @@ void TestCrossProcessSerialization::SetUp(void) {
     }
     // Phase 2: signal holder that waiter's amdsmi_init is also complete.
     char waiter_done = 1;
-    write(waiter_ready_pipe_[1], &waiter_done, 1);
+    if (write(waiter_ready_pipe_[1], &waiter_done, 1) < 0) {
+      std::cout << "write(waiter_ready_pipe_) failed: " << strerror(errno) << std::endl;
+      setup_failed_ = true;
+    }
     close(waiter_ready_pipe_[1]);
     ASSERT_EQ(ret, AMDSMI_STATUS_SUCCESS);
   }
@@ -280,7 +286,8 @@ void TestCrossProcessSerialization::Run(void) {
     // mutex), then immediately call it. The waiter reads this signal and
     // pauses kWaiterMutexPauseNs before calling amdsmi_get_gpu_id.
     char run_ready = 1;
-    write(run_pipe_[1], &run_ready, 1);
+    ASSERT_GT(write(run_pipe_[1], &run_ready, 1), 0)
+        << "HOLDER: write(run_pipe_) failed: " << strerror(errno);
     close(run_pipe_[1]);
     amdsmi_status_t ret = rsmi_test_sleep(0, kHoldSeconds);
     ASSERT_EQ(ret, AMDSMI_STATUS_SUCCESS);
@@ -312,7 +319,11 @@ void TestCrossProcessSerialization::Run(void) {
     // pause briefly so rsmi_test_sleep's pthread_mutex_lock completes
     // before we attempt to acquire the same lock via amdsmi_get_gpu_id.
     char run_ready = 0;
-    read(run_pipe_[0], &run_ready, 1);
+    ssize_t n = read(run_pipe_[0], &run_ready, 1);
+    if (n <= 0) {
+      const char* reason = (n == 0) ? "pipe closed (holder crashed?)" : strerror(errno);
+      fail_child(std::string("WAITER: read(run_pipe_) failed: ") + reason);
+    }
     close(run_pipe_[0]);
 
     // Print after the pipe read so this message always follows the holder's

--- a/projects/amdsmi/tests/amd_smi_test/functional/cross_process_serialization.cc
+++ b/projects/amdsmi/tests/amd_smi_test/functional/cross_process_serialization.cc
@@ -31,13 +31,13 @@
 #include <cstdint>
 #include <cstdlib>
 #include <cstring>
-#include <ctime>
 #include <iostream>
 #include <string>
 #include <vector>
 
 #include "../test_common.h"
 #include "amd_smi/amdsmi.h"
+#include "rocm_smi/rocm_smi_utils.h"
 
 // How long the holder process holds the mutex (seconds).
 static constexpr unsigned int kHoldSeconds = 5;
@@ -75,6 +75,7 @@ void TestCrossProcessSerialization::SetUp(void) {
   }
 
   holder_process_ = false;
+  is_child_process_ = false;
   child_ = 0;
 
   // Cross-process shared memory mutex is required.
@@ -93,8 +94,24 @@ void TestCrossProcessSerialization::SetUp(void) {
   // This guarantees both processes finish amdsmi_init before the holder
   // calls rsmi_test_sleep, which would otherwise block the waiter's own
   // amdsmi_init (device enumeration acquires the shared device mutex).
-  if (pipe(init_pipe_) < 0 || pipe(waiter_ready_pipe_) < 0 || pipe(run_pipe_) < 0) {
-    std::cout << "pipe() failed: " << strerror(errno) << std::endl;
+  if (pipe(init_pipe_) < 0) {
+    std::cout << "pipe(init_pipe_) failed: " << strerror(errno) << std::endl;
+    setup_failed_ = true;
+    return;
+  }
+  if (pipe(waiter_ready_pipe_) < 0) {
+    std::cout << "pipe(waiter_ready_pipe_) failed: " << strerror(errno) << std::endl;
+    close(init_pipe_[0]);
+    close(init_pipe_[1]);
+    setup_failed_ = true;
+    return;
+  }
+  if (pipe(run_pipe_) < 0) {
+    std::cout << "pipe(run_pipe_) failed: " << strerror(errno) << std::endl;
+    close(init_pipe_[0]);
+    close(init_pipe_[1]);
+    close(waiter_ready_pipe_[0]);
+    close(waiter_ready_pipe_[1]);
     setup_failed_ = true;
     return;
   }
@@ -145,6 +162,7 @@ void TestCrossProcessSerialization::SetUp(void) {
     close(waiter_ready_pipe_[0]);
     ASSERT_EQ(ret, AMDSMI_STATUS_SUCCESS);
   } else {
+    is_child_process_ = true;
     // Waiter: does not write to init_pipe, does not read waiter_ready_pipe
     // read-end, does not write to run_pipe.
     close(init_pipe_[1]);
@@ -231,9 +249,9 @@ void TestCrossProcessSerialization::Close() {
 void TestCrossProcessSerialization::Run(void) {
   if (setup_failed_) {
     std::cout << "** SetUp Failed for this test. Skipping.**" << std::endl;
-    if (!holder_process_) {
+    if (is_child_process_) {
       // In the child process, _exit() immediately to avoid running gtest/AMDSMI cleanup
-      // cleanup that was never meant to run here.
+      // that was never meant to run here.
       std::cout.flush();
       _exit(1);
     }
@@ -306,8 +324,9 @@ void TestCrossProcessSerialization::Run(void) {
                 << std::endl;
     }
 
-    struct timespec pause_ts = {0, kWaiterMutexPauseNs};
-    nanosleep(&pause_ts, nullptr);
+    // Pause for the full duration, retrying on EINTR, so the holder always
+    // holds the mutex before we attempt to acquire it.
+    amd::smi::sleep_interruptible({0, kWaiterMutexPauseNs});
 
     uint16_t gpu_id = 0;
     auto t0 = std::chrono::steady_clock::now();

--- a/projects/amdsmi/tests/amd_smi_test/functional/cross_process_serialization.cc
+++ b/projects/amdsmi/tests/amd_smi_test/functional/cross_process_serialization.cc
@@ -41,6 +41,8 @@
 #include "rocm_smi/rocm_smi_utils.h"
 
 // How long the holder process holds the mutex (seconds).
+// NOTE: This test takes at least kHoldSeconds (~5s) to run by design — the
+// waiter must block for the full hold duration to prove cross-process serialization.
 static constexpr unsigned int kHoldSeconds = 5;
 // Minimum elapsed time (seconds) the waiter must observe to prove it blocked.
 // Set below kHoldSeconds to absorb scheduling jitter.

--- a/projects/amdsmi/tests/amd_smi_test/functional/cross_process_serialization.h
+++ b/projects/amdsmi/tests/amd_smi_test/functional/cross_process_serialization.h
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#ifndef TESTS_AMD_SMI_TEST_FUNCTIONAL_CROSS_PROCESS_SERIALIZATION_H_
+#define TESTS_AMD_SMI_TEST_FUNCTIONAL_CROSS_PROCESS_SERIALIZATION_H_
+
+#include <string>
+
+#include "../test_base.h"
+
+// Verifies that AMDSMI_MUTEX_CROSS_PROCESS=1 (blocking mode) actually
+// serializes API calls across processes. Unlike TestMutualExclusion (which
+// uses RSMI_INIT_FLAG_RESRV_TEST1 to get observable BUSY returns), this test
+// uses normal blocking mode and measures elapsed time to prove Process B
+// waited behind Process A's held mutex rather than racing through.
+class TestCrossProcessSerialization : public TestBase {
+ public:
+  TestCrossProcessSerialization();
+  virtual ~TestCrossProcessSerialization();
+
+  virtual void SetUp();
+  virtual void Run();
+  virtual void Close();
+  virtual void DisplayResults() const;
+  virtual void DisplayTestInfo(void);
+
+ private:
+  bool holder_process_;
+  int child_;
+  std::string orig_cross_process_env_;
+  bool orig_cross_process_env_was_set_;
+  // Phase-1 init sync (holder → waiter): holder writes after amdsmi_init;
+  // waiter reads before calling amdsmi_init, so holder always inits first.
+  int init_pipe_[2];
+  // Phase-2 init sync (waiter → holder): waiter writes after amdsmi_init;
+  // holder reads before entering Run(), so holder only acquires the mutex
+  // after both processes have completed amdsmi_init. Without this, the
+  // waiter's amdsmi_init blocks on the shared device mutex held by
+  // rsmi_test_sleep, so amdsmi_get_gpu_id never sees a contended mutex.
+  int waiter_ready_pipe_[2];
+  // Run() ordering (holder → waiter): holder writes just before rsmi_test_sleep;
+  // waiter reads before amdsmi_get_gpu_id, guaranteeing holder holds the
+  // mutex before waiter attempts to acquire it.
+  int run_pipe_[2];
+};
+
+#endif  // TESTS_AMD_SMI_TEST_FUNCTIONAL_CROSS_PROCESS_SERIALIZATION_H_

--- a/projects/amdsmi/tests/amd_smi_test/functional/cross_process_serialization.h
+++ b/projects/amdsmi/tests/amd_smi_test/functional/cross_process_serialization.h
@@ -45,6 +45,7 @@ class TestCrossProcessSerialization : public TestBase {
 
  private:
   bool holder_process_;
+  bool is_child_process_;
   int child_;
   std::string orig_cross_process_env_;
   bool orig_cross_process_env_was_set_;

--- a/projects/amdsmi/tests/amd_smi_test/functional/mutual_exclusion.cc
+++ b/projects/amdsmi/tests/amd_smi_test/functional/mutual_exclusion.cc
@@ -205,6 +205,8 @@ void TestMutualExclusion::Run(void) {
     int child_status = 0;
     pid_t cpid = wait(&child_status);
     ASSERT_EQ(cpid, child_);
+    ASSERT_TRUE(WIFEXITED(child_status))
+        << "TESTER child process terminated by signal " << WTERMSIG(child_status);
     EXPECT_EQ(WEXITSTATUS(child_status), 0) << "TESTER child process reported CHECK_RET failure(s)";
   } else {
     // Both processes should have completed amdsmi_init().

--- a/projects/amdsmi/tests/amd_smi_test/functional/mutual_exclusion.cc
+++ b/projects/amdsmi/tests/amd_smi_test/functional/mutual_exclusion.cc
@@ -37,7 +37,7 @@
 
 #include "../test_common.h"
 #include "amd_smi/amdsmi.h"
-#include "amd_smi/impl/amd_smi_test_flags.h"
+#include "amd_smi/impl/amd_smi_test_internal.h"
 #include "amd_smi/impl/amd_smi_utils.h"
 
 TestMutualExclusion::TestMutualExclusion() : TestBase() {
@@ -52,8 +52,6 @@ TestMutualExclusion::TestMutualExclusion() : TestBase() {
 }
 
 TestMutualExclusion::~TestMutualExclusion(void) {}
-
-extern amdsmi_status_t rsmi_test_sleep(uint32_t dv_ind, uint32_t seconds);
 
 void TestMutualExclusion::SetUp(void) {
   std::string label;
@@ -263,7 +261,7 @@ void TestMutualExclusion::Run(void) {
     IF_VERB(STANDARD) {
       std::cout << "MUTEX_HOLDER process: started sleeping for 10 seconds..." << std::endl;
     }
-    ret = rsmi_test_sleep(0, 10);
+    ret = amdsmi_test_sleep(processor_handles_[0], 10);
     ASSERT_EQ(ret, AMDSMI_STATUS_SUCCESS);
     IF_VERB(STANDARD) { std::cout << "MUTEX_HOLDER process: Sleep process woke up." << std::endl; }
 

--- a/projects/amdsmi/tests/amd_smi_test/functional/mutual_exclusion.cc
+++ b/projects/amdsmi/tests/amd_smi_test/functional/mutual_exclusion.cc
@@ -40,6 +40,16 @@
 #include "amd_smi/impl/amd_smi_test_internal.h"
 #include "amd_smi/impl/amd_smi_utils.h"
 
+// How long the mutex-holder process holds the device mutex (seconds).
+// The tester process uses trylock (RESRV_TEST1 mode) so all its API calls
+// return AMDSMI_STATUS_BUSY immediately — it completes well within kTesterWaitSeconds.
+// kHoldSeconds only needs to exceed kTesterWaitSeconds by a comfortable margin.
+// NOTE: minimum expected test runtime is ~kHoldSeconds.
+static constexpr uint32_t kHoldSeconds = 4;
+// How long the tester process waits after SetUp before making API calls,
+// giving the holder enough time to acquire the mutex first.
+static constexpr unsigned int kTesterWaitSeconds = 2;
+
 TestMutualExclusion::TestMutualExclusion() : TestBase() {
   set_title("Mutual Exclusion Test");
   set_description(
@@ -258,10 +268,13 @@ void TestMutualExclusion::Run(void) {
     sigaddset(&sigchld_mask, SIGCHLD);
     sigprocmask(SIG_BLOCK, &sigchld_mask, &old_mask);
 
+    // NOTE: minimum expected test runtime is ~kHoldSeconds;
+    // CI timeouts should account for this.
     IF_VERB(STANDARD) {
-      std::cout << "MUTEX_HOLDER process: started sleeping for 10 seconds..." << std::endl;
+      std::cout << "MUTEX_HOLDER process: started sleeping for " << kHoldSeconds << " seconds..."
+                << std::endl;
     }
-    ret = amdsmi_test_sleep(processor_handles_[0], 10);
+    ret = amdsmi_test_sleep(processor_handles_[0], kHoldSeconds);
     ASSERT_EQ(ret, AMDSMI_STATUS_SUCCESS);
     IF_VERB(STANDARD) { std::cout << "MUTEX_HOLDER process: Sleep process woke up." << std::endl; }
 
@@ -276,8 +289,8 @@ void TestMutualExclusion::Run(void) {
     EXPECT_EQ(WEXITSTATUS(child_status), 0) << "TESTER child process reported CHECK_RET failure(s)";
   } else {
     // Both processes should have completed amdsmi_init().
-    // let the other process get started on rsmi_test_sleep().
-    sleep(2);
+    // Wait for the holder to acquire the mutex before making API calls.
+    sleep(kTesterWaitSeconds);
     TestBase::Run();
     IF_VERB(STANDARD) {
       std::cout << "TESTER process: verifying that all amdsmi_dev_* functions "
@@ -465,6 +478,7 @@ void TestMutualExclusion::Run(void) {
     ret = amdsmi_get_gpu_ecc_status(processor_handles_[0], AMDSMI_GPU_BLOCK_UMC, &dmy_ras_err_st);
     DISPLAY_AMDSMI_STATUS(VERB(STANDARD), __FILE__, __LINE__, ret, AMDSMI_STATUS_BUSY);
     CHECK_RET(ret, AMDSMI_STATUS_BUSY);
+#undef CHECK_RET
 
     /* Other functions holding device mutexes. Listed for reference.
     amdsmi_dev_sku_get

--- a/projects/amdsmi/tests/amd_smi_test/functional/mutual_exclusion.cc
+++ b/projects/amdsmi/tests/amd_smi_test/functional/mutual_exclusion.cc
@@ -19,18 +19,26 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-
 #include "mutual_exclusion.h"
 
 #include <gtest/gtest.h>
+#include <sys/wait.h>
+#include <unistd.h>
 
+#include <cerrno>
+#include <csignal>
 #include <cstdint>
+#include <cstdlib>
+#include <cstring>
+#include <initializer_list>
 #include <iostream>
 #include <string>
+#include <vector>
 
+#include "../test_common.h"
 #include "amd_smi/amdsmi.h"
-
-#define AMD_SMI_INIT_FLAG_RESRV_TEST1 0x800000000000000  //!< Reserved for test
+#include "amd_smi/impl/amd_smi_test_flags.h"
+#include "amd_smi/impl/amd_smi_utils.h"
 
 TestMutualExclusion::TestMutualExclusion() : TestBase() {
   set_title("Mutual Exclusion Test");
@@ -59,14 +67,32 @@ void TestMutualExclusion::SetUp(void) {
 
   sleeper_process_ = false;
   child_ = 0;
+
+  // Cross-process shared memory mutex is required for this test.
+  // Must be set before fork() so both processes inherit it and amdsmi_init()
+  // uses shm_open/mmap instead of a per-process pthread_mutex_t.
+  // Save original value so Close() can restore it after the test.
+  const char* orig = getenv("AMDSMI_MUTEX_CROSS_PROCESS");
+  orig_cross_process_env_ = orig ? orig : "";
+  orig_cross_process_env_was_set_ = (orig != nullptr);
+  setenv("AMDSMI_MUTEX_CROSS_PROCESS", "1", 1);
+
   child_ = fork();
+  if (child_ < 0) {
+    std::cout << "fork() failed: " << strerror(errno) << std::endl;
+    setup_failed_ = true;
+    return;
+  }
 
   if (child_ != 0) {
     sleeper_process_ = true;  // sleeper_process is parent
 
     // AMD_SMI_INIT_FLAG_RESRV_TEST1 tells rsmi to fail immediately
     // if it can't get the mutex instead of waiting.
-    ret = amdsmi_init(AMD_SMI_INIT_FLAG_RESRV_TEST1);
+    DISPLAY_AMDSMI_API("[before sleep] amdsmi_init(AMD_SMI_INIT_FLAG_RESRV_TEST1)", "",
+                       VERB(STANDARD));
+    ret = amdsmi_init(AMDSMI_INIT_AMD_GPUS | AMD_SMI_INIT_FLAG_RESRV_TEST1);
+    DISPLAY_AMDSMI_STATUS(VERB(STANDARD), __FILE__, __LINE__, ret, AMDSMI_STATUS_SUCCESS);
     if (ret != AMDSMI_STATUS_SUCCESS) {
       setup_failed_ = true;
     }
@@ -76,7 +102,10 @@ void TestMutualExclusion::SetUp(void) {
   } else {
     sleep(1);  // Let the sleeper process get through amdsmi_init() before
                // this one goes, so it doesn't fail.
-    ret = amdsmi_init(AMD_SMI_INIT_FLAG_RESRV_TEST1);
+    DISPLAY_AMDSMI_API("[after sleep] amdsmi_init(AMD_SMI_INIT_FLAG_RESRV_TEST1)", "",
+                       VERB(STANDARD));
+    ret = amdsmi_init(AMDSMI_INIT_AMD_GPUS | AMD_SMI_INIT_FLAG_RESRV_TEST1);
+    DISPLAY_AMDSMI_STATUS(VERB(STANDARD), __FILE__, __LINE__, ret, AMDSMI_STATUS_SUCCESS);
     if (ret != AMDSMI_STATUS_SUCCESS) {
       setup_failed_ = true;
     }
@@ -85,7 +114,34 @@ void TestMutualExclusion::SetUp(void) {
     sleep(2);  // Let both processes get through amdsmi_init;
   }
 
-  num_monitor_devs_ = num_monitor_devs();
+  // Enumerate sockets and processor handles in each process after amdsmi_init()
+  amdsmi_status_t enum_err = amdsmi_get_socket_handles(&socket_count_, nullptr);
+  if (enum_err != AMDSMI_STATUS_SUCCESS) {
+    setup_failed_ = true;
+    return;
+  }
+  sockets_.resize(socket_count_);
+  enum_err = amdsmi_get_socket_handles(&socket_count_, &sockets_[0]);
+  if (enum_err != AMDSMI_STATUS_SUCCESS) {
+    setup_failed_ = true;
+    return;
+  }
+  num_monitor_devs_ = 0;
+  for (uint32_t i = 0; i < socket_count_; i++) {
+    uint32_t device_count = 0;
+    amdsmi_status_t status = amdsmi_get_processor_handles(sockets_[i], &device_count, nullptr);
+    if (status != AMDSMI_STATUS_SUCCESS || device_count == 0) {
+      continue;
+    }
+    std::vector<amdsmi_processor_handle> handles(device_count);
+    status = amdsmi_get_processor_handles(sockets_[i], &device_count, &handles[0]);
+    if (status != AMDSMI_STATUS_SUCCESS) {
+      continue;
+    }
+    for (uint32_t j = 0; j < device_count && num_monitor_devs_ < MAX_MONITOR_DEVICES; j++) {
+      processor_handles_[num_monitor_devs_++] = handles[j];
+    }
+  }
 
   if (num_monitor_devs_ == 0) {
     std::cout << "No monitor devices found on this machine." << std::endl;
@@ -106,9 +162,18 @@ void TestMutualExclusion::DisplayResults(void) const {
 }
 
 void TestMutualExclusion::Close() {
-  // This will close handles opened within rsmitst utility calls and call
-  // amdsmi_shut_down(), so it should be done after other hsa cleanup
+  // Shut down first while AMDSMI_MUTEX_CROSS_PROCESS is still set, so that
+  // shared_mutex_close() correctly munmaps the shared-memory mutex instead of
+  // calling delete on it (which would crash with "free(): invalid pointer").
   TestBase::Close();
+
+  // Restore AMDSMI_MUTEX_CROSS_PROCESS to its original state so subsequent
+  // tests in this process are not affected.
+  if (orig_cross_process_env_was_set_) {
+    setenv("AMDSMI_MUTEX_CROSS_PROCESS", orig_cross_process_env_.c_str(), 1);
+  } else {
+    unsetenv("AMDSMI_MUTEX_CROSS_PROCESS");
+  }
 }
 
 void TestMutualExclusion::Run(void) {
@@ -120,14 +185,27 @@ void TestMutualExclusion::Run(void) {
   }
 
   if (sleeper_process_) {
+    // Block SIGCHLD so that when the child exits, the signal does not interrupt
+    // sleep() inside rsmi_test_sleep and cause the mutex to be released early.
+    sigset_t sigchld_mask, old_mask;
+    sigemptyset(&sigchld_mask);
+    sigaddset(&sigchld_mask, SIGCHLD);
+    sigprocmask(SIG_BLOCK, &sigchld_mask, &old_mask);
+
     IF_VERB(STANDARD) {
       std::cout << "MUTEX_HOLDER process: started sleeping for 10 seconds..." << std::endl;
     }
     ret = rsmi_test_sleep(0, 10);
     ASSERT_EQ(ret, AMDSMI_STATUS_SUCCESS);
     IF_VERB(STANDARD) { std::cout << "MUTEX_HOLDER process: Sleep process woke up." << std::endl; }
-    pid_t cpid = wait(nullptr);
+
+    // Restore signal mask before wait() so SIGCHLD can be delivered and the
+    // child can be reaped normally.
+    sigprocmask(SIG_SETMASK, &old_mask, nullptr);
+    int child_status = 0;
+    pid_t cpid = wait(&child_status);
     ASSERT_EQ(cpid, child_);
+    EXPECT_EQ(WEXITSTATUS(child_status), 0) << "TESTER child process reported CHECK_RET failure(s)";
   } else {
     // Both processes should have completed amdsmi_init().
     // let the other process get started on rsmi_test_sleep().
@@ -154,70 +232,170 @@ void TestMutualExclusion::Run(void) {
     amdsmi_error_count_t dmy_err_cnt{};
     amdsmi_ras_err_state_t dmy_ras_err_st;
 
-    // This can be replaced with ASSERT_EQ() once env. stabilizes
-#define CHECK_RET(A, B)                                                               \
-  {                                                                                   \
-    if ((A) != (B)) {                                                                 \
-      std::cout << "Expected return value of " << B << " but got " << A << std::endl; \
-      std::cout << "at " << __FILE__ << ":" << __LINE__ << std::endl;                 \
-    }                                                                                 \
+// Accepts one or more expected values; passes if actual matches any of them.
+#define CHECK_RET(retVal, ...)                                                             \
+  {                                                                                        \
+    auto _tst_ret_val = (retVal);                                                          \
+    std::initializer_list<decltype(_tst_ret_val)> _expected_returns = {__VA_ARGS__};       \
+    bool _chk_matched = false;                                                             \
+    for (auto _chk_e : _expected_returns) {                                                \
+      if (_tst_ret_val == _chk_e) {                                                        \
+        _chk_matched = true;                                                               \
+        break;                                                                             \
+      }                                                                                    \
+    }                                                                                      \
+    if (!_chk_matched) {                                                                   \
+      std::cout << "Expected return value of one of {";                                    \
+      bool _chk_first = true;                                                              \
+      for (auto _chk_e : _expected_returns) {                                              \
+        if (!_chk_first) std::cout << ", ";                                                \
+        std::string status = smi_amdgpu_get_status_string(_chk_e, false);                  \
+        std::cout << status << " (" << _chk_e << ")";                                      \
+        _chk_first = false;                                                                \
+      }                                                                                    \
+      std::string ret_status = smi_amdgpu_get_status_string(_tst_ret_val, false);          \
+      std::cout << "} but got " << ret_status << " (" << _tst_ret_val << ")" << std::endl; \
+      std::cout << "at " << __FILE__ << ":" << __LINE__ << std::endl;                      \
+    }                                                                                      \
+    EXPECT_TRUE(_chk_matched);                                                             \
   }
+    // TODO(amdsmi_team): Add more device calls here, we should also check how CPU/NIC/etc handle
+    // These are APIs which either need to include:
+    // DEVICE_MUTEX or SMIGPUDEVICE_MUTEX (refer to AMDSMI_MUTEX_CROSS_PROCESS references)
+    // to safely handle multithreaded/process access, or need to be checked for AMDSMI_STATUS_BUSY
+    // if the mutex is held by another process. These are not exhaustive lists, just examples.
+    DISPLAY_AMDSMI_API("amdsmi_get_gpu_id", "0", VERB(STANDARD));
     ret = amdsmi_get_gpu_id(processor_handles_[0], &dmy_ui16);
+    DISPLAY_AMDSMI_STATUS(VERB(STANDARD), __FILE__, __LINE__, ret, AMDSMI_STATUS_BUSY);
+    CHECK_RET(ret, AMDSMI_STATUS_BUSY);
+
+    DISPLAY_AMDSMI_API("amdsmi_get_temp_metric", "0", VERB(STANDARD));
+    ret = amdsmi_get_temp_metric(processor_handles_[0], AMDSMI_TEMPERATURE_TYPE_EDGE,
+                                 AMDSMI_TEMP_CURRENT, &dmy_i64);
+    DISPLAY_AMDSMI_STATUS(VERB(STANDARD), __FILE__, __LINE__, ret, AMDSMI_STATUS_BUSY);
+    CHECK_RET(ret, AMDSMI_STATUS_BUSY);
 
     // vendor_id, unique_id
     amdsmi_asic_info_t asic_info;
+    DISPLAY_AMDSMI_API("amdsmi_get_gpu_asic_info", "0", VERB(STANDARD));
     ret = amdsmi_get_gpu_asic_info(processor_handles_[0], &asic_info);
+    DISPLAY_AMDSMI_STATUS(VERB(STANDARD), __FILE__, __LINE__, ret, AMDSMI_STATUS_BUSY);
     CHECK_RET(ret, AMDSMI_STATUS_BUSY);
 
     // device name, brand, serial_number
     amdsmi_board_info_t board_info;
+    DISPLAY_AMDSMI_API("amdsmi_get_gpu_board_info", "0", VERB(STANDARD));
     ret = amdsmi_get_gpu_board_info(processor_handles_[0], &board_info);
+    DISPLAY_AMDSMI_STATUS(VERB(STANDARD), __FILE__, __LINE__, ret, AMDSMI_STATUS_BUSY);
     CHECK_RET(ret, AMDSMI_STATUS_BUSY);
 
+    DISPLAY_AMDSMI_API("amdsmi_get_gpu_vendor_name", "0", VERB(STANDARD));
     ret = amdsmi_get_gpu_vendor_name(processor_handles_[0], dmy_str, 10);
+    DISPLAY_AMDSMI_STATUS(VERB(STANDARD), __FILE__, __LINE__, ret, AMDSMI_STATUS_BUSY);
     CHECK_RET(ret, AMDSMI_STATUS_BUSY);
+
+    DISPLAY_AMDSMI_API("amdsmi_get_gpu_vram_vendor", "0", VERB(STANDARD));
     ret = amdsmi_get_gpu_vram_vendor(processor_handles_[0], dmy_str, 10);
+    DISPLAY_AMDSMI_STATUS(VERB(STANDARD), __FILE__, __LINE__, ret, AMDSMI_STATUS_BUSY);
     CHECK_RET(ret, AMDSMI_STATUS_BUSY);
+
+    DISPLAY_AMDSMI_API("amdsmi_get_gpu_subsystem_id", "0", VERB(STANDARD));
     ret = amdsmi_get_gpu_subsystem_id(processor_handles_[0], &dmy_ui16);
+    DISPLAY_AMDSMI_STATUS(VERB(STANDARD), __FILE__, __LINE__, ret, AMDSMI_STATUS_BUSY);
     CHECK_RET(ret, AMDSMI_STATUS_BUSY);
+
+    DISPLAY_AMDSMI_API("amdsmi_get_gpu_bdf_id", "0", VERB(STANDARD));
     ret = amdsmi_get_gpu_bdf_id(processor_handles_[0], &dmy_ui64);
+    DISPLAY_AMDSMI_STATUS(VERB(STANDARD), __FILE__, __LINE__, ret, AMDSMI_STATUS_BUSY);
     CHECK_RET(ret, AMDSMI_STATUS_BUSY);
+
+    DISPLAY_AMDSMI_API("amdsmi_get_gpu_pci_throughput", "0", VERB(STANDARD));
     ret = amdsmi_get_gpu_pci_throughput(processor_handles_[0], &dmy_ui64, &dmy_ui64, &dmy_ui64);
+    DISPLAY_AMDSMI_STATUS(VERB(STANDARD), __FILE__, __LINE__, ret, AMDSMI_STATUS_BUSY);
     CHECK_RET(ret, AMDSMI_STATUS_BUSY);
+
+    DISPLAY_AMDSMI_API("amdsmi_get_gpu_pci_replay_counter", "0", VERB(STANDARD));
     ret = amdsmi_get_gpu_pci_replay_counter(processor_handles_[0], &dmy_ui64);
+    DISPLAY_AMDSMI_STATUS(VERB(STANDARD), __FILE__, __LINE__, ret, AMDSMI_STATUS_BUSY);
     CHECK_RET(ret, AMDSMI_STATUS_BUSY);
+
+    DISPLAY_AMDSMI_API("amdsmi_set_gpu_pci_bandwidth", "0", VERB(STANDARD));
     ret = amdsmi_set_gpu_pci_bandwidth(processor_handles_[0], 0);
-    CHECK_RET(ret, AMDSMI_STATUS_BUSY);
+    DISPLAY_AMDSMI_STATUS(VERB(STANDARD), __FILE__, __LINE__, ret, AMDSMI_STATUS_BUSY,
+                          AMDSMI_STATUS_NO_PERM);
+    CHECK_RET(ret, AMDSMI_STATUS_BUSY, AMDSMI_STATUS_NO_PERM);
+
+    DISPLAY_AMDSMI_API("amdsmi_get_gpu_fan_rpms", "0", VERB(STANDARD));
     ret = amdsmi_get_gpu_fan_rpms(processor_handles_[0], dmy_ui32, &dmy_i64);
+    DISPLAY_AMDSMI_STATUS(VERB(STANDARD), __FILE__, __LINE__, ret, AMDSMI_STATUS_BUSY);
     CHECK_RET(ret, AMDSMI_STATUS_BUSY);
+
+    DISPLAY_AMDSMI_API("amdsmi_get_gpu_fan_speed", "0", VERB(STANDARD));
     ret = amdsmi_get_gpu_fan_speed(processor_handles_[0], 0, &dmy_i64);
+    DISPLAY_AMDSMI_STATUS(VERB(STANDARD), __FILE__, __LINE__, ret, AMDSMI_STATUS_BUSY);
     CHECK_RET(ret, AMDSMI_STATUS_BUSY);
+
+    DISPLAY_AMDSMI_API("amdsmi_get_gpu_fan_speed_max", "0", VERB(STANDARD));
     ret = amdsmi_get_gpu_fan_speed_max(processor_handles_[0], 0, &dmy_ui64);
+    DISPLAY_AMDSMI_STATUS(VERB(STANDARD), __FILE__, __LINE__, ret, AMDSMI_STATUS_BUSY);
     CHECK_RET(ret, AMDSMI_STATUS_BUSY);
-    ret = amdsmi_get_temp_metric(processor_handles_[0], AMDSMI_TEMPERATURE_TYPE_EDGE,
-                                 AMDSMI_TEMP_CURRENT, &dmy_i64);
-    CHECK_RET(ret, AMDSMI_STATUS_BUSY);
+
+    DISPLAY_AMDSMI_API("amdsmi_reset_gpu_fan", "0", VERB(STANDARD));
     ret = amdsmi_reset_gpu_fan(processor_handles_[0], 0);
-    CHECK_RET(ret, AMDSMI_STATUS_BUSY);
+    DISPLAY_AMDSMI_STATUS(VERB(STANDARD), __FILE__, __LINE__, ret, AMDSMI_STATUS_BUSY,
+                          AMDSMI_STATUS_NO_PERM);
+    CHECK_RET(ret, AMDSMI_STATUS_BUSY, AMDSMI_STATUS_NO_PERM);
+
+    DISPLAY_AMDSMI_API("amdsmi_set_gpu_fan_speed", "0", VERB(STANDARD));
     ret = amdsmi_set_gpu_fan_speed(processor_handles_[0], dmy_ui32, 0);
-    CHECK_RET(ret, AMDSMI_STATUS_BUSY);
+    DISPLAY_AMDSMI_STATUS(VERB(STANDARD), __FILE__, __LINE__, ret, AMDSMI_STATUS_BUSY,
+                          AMDSMI_STATUS_NO_PERM);
+    CHECK_RET(ret, AMDSMI_STATUS_BUSY, AMDSMI_STATUS_NO_PERM);
+
+    DISPLAY_AMDSMI_API("amdsmi_get_gpu_perf_level", "0", VERB(STANDARD));
     ret = amdsmi_get_gpu_perf_level(processor_handles_[0], &dmy_perf_lvl);
+    DISPLAY_AMDSMI_STATUS(VERB(STANDARD), __FILE__, __LINE__, ret, AMDSMI_STATUS_BUSY);
     CHECK_RET(ret, AMDSMI_STATUS_BUSY);
+
+    DISPLAY_AMDSMI_API("amdsmi_get_gpu_overdrive_level", "0", VERB(STANDARD));
     ret = amdsmi_get_gpu_overdrive_level(processor_handles_[0], &dmy_ui32);
+    DISPLAY_AMDSMI_STATUS(VERB(STANDARD), __FILE__, __LINE__, ret, AMDSMI_STATUS_BUSY);
     CHECK_RET(ret, AMDSMI_STATUS_BUSY);
+
+    DISPLAY_AMDSMI_API("amdsmi_get_clk_freq", "0", VERB(STANDARD));
     ret = amdsmi_get_clk_freq(processor_handles_[0], AMDSMI_CLK_TYPE_SYS, &dmy_freqs);
+    DISPLAY_AMDSMI_STATUS(VERB(STANDARD), __FILE__, __LINE__, ret, AMDSMI_STATUS_BUSY);
     CHECK_RET(ret, AMDSMI_STATUS_BUSY);
+
+    DISPLAY_AMDSMI_API("amdsmi_get_gpu_od_volt_info", "0", VERB(STANDARD));
     ret = amdsmi_get_gpu_od_volt_info(processor_handles_[0], &dmy_od_volt);
+    DISPLAY_AMDSMI_STATUS(VERB(STANDARD), __FILE__, __LINE__, ret, AMDSMI_STATUS_BUSY);
     CHECK_RET(ret, AMDSMI_STATUS_BUSY);
+
+    DISPLAY_AMDSMI_API("amdsmi_get_gpu_od_volt_curve_regions", "0", VERB(STANDARD));
     ret = amdsmi_get_gpu_od_volt_curve_regions(processor_handles_[0], &dmy_ui32, &dmy_vlt_reg);
+    DISPLAY_AMDSMI_STATUS(VERB(STANDARD), __FILE__, __LINE__, ret, AMDSMI_STATUS_BUSY);
     CHECK_RET(ret, AMDSMI_STATUS_BUSY);
+
+    DISPLAY_AMDSMI_API("amdsmi_set_clk_freq", "0", VERB(STANDARD));
     ret = amdsmi_set_clk_freq(processor_handles_[0], AMDSMI_CLK_TYPE_SYS, 0);
-    CHECK_RET(ret, AMDSMI_STATUS_BUSY);
+    DISPLAY_AMDSMI_STATUS(VERB(STANDARD), __FILE__, __LINE__, ret, AMDSMI_STATUS_BUSY,
+                          AMDSMI_STATUS_NO_PERM);
+    CHECK_RET(ret, AMDSMI_STATUS_BUSY, AMDSMI_STATUS_NO_PERM);
+
+    DISPLAY_AMDSMI_API("amdsmi_get_gpu_ecc_count", "0", VERB(STANDARD));
     ret = amdsmi_get_gpu_ecc_count(processor_handles_[0], AMDSMI_GPU_BLOCK_UMC, &dmy_err_cnt);
+    DISPLAY_AMDSMI_STATUS(VERB(STANDARD), __FILE__, __LINE__, ret, AMDSMI_STATUS_BUSY);
     CHECK_RET(ret, AMDSMI_STATUS_BUSY);
+
+    DISPLAY_AMDSMI_API("amdsmi_get_gpu_ecc_enabled", "0", VERB(STANDARD));
     ret = amdsmi_get_gpu_ecc_enabled(processor_handles_[0], &dmy_ui64);
+    DISPLAY_AMDSMI_STATUS(VERB(STANDARD), __FILE__, __LINE__, ret, AMDSMI_STATUS_BUSY);
     CHECK_RET(ret, AMDSMI_STATUS_BUSY);
+
+    DISPLAY_AMDSMI_API("amdsmi_get_gpu_ecc_status", "0", VERB(STANDARD));
     ret = amdsmi_get_gpu_ecc_status(processor_handles_[0], AMDSMI_GPU_BLOCK_UMC, &dmy_ras_err_st);
+    DISPLAY_AMDSMI_STATUS(VERB(STANDARD), __FILE__, __LINE__, ret, AMDSMI_STATUS_BUSY);
     CHECK_RET(ret, AMDSMI_STATUS_BUSY);
 
     /* Other functions holding device mutexes. Listed for reference.
@@ -275,6 +453,12 @@ void TestMutualExclusion::Run(void) {
                    "amdsmi_dev_* functions returned AMDSMI_STATUS_BUSY"
                 << std::endl;
     }
-    exit(0);
+    std::cout.flush();
+    // Use _exit() to terminate immediately without running atexit handlers or
+    // static destructors — exit() would trigger gtest/RocmSMI cleanup that
+    // was never meant to run in the child process, causing heap corruption.
+    // Exit with 1 if any EXPECT_* in this process failed, so the parent can
+    // detect and report the failure via WEXITSTATUS.
+    _exit(::testing::Test::HasFailure() ? 1 : 0);
   }
 }

--- a/projects/amdsmi/tests/amd_smi_test/functional/mutual_exclusion.cc
+++ b/projects/amdsmi/tests/amd_smi_test/functional/mutual_exclusion.cc
@@ -77,41 +77,97 @@ void TestMutualExclusion::SetUp(void) {
   orig_cross_process_env_was_set_ = (orig != nullptr);
   setenv("AMDSMI_MUTEX_CROSS_PROCESS", "1", 1);
 
+  // Two pipes provide deterministic init ordering, replacing the previous
+  // sleep(1)/sleep(2) approach that was fragile under load with
+  // AMDSMI_MUTEX_CROSS_PROCESS=1 and RSMI_INIT_FLAG_RESRV_TEST1 (trylock mode):
+  //   init_pipe_:         sleeper → tester  (sleeper amdsmi_init complete)
+  //   tester_ready_pipe_: tester → sleeper  (tester amdsmi_init complete)
+  if (pipe(init_pipe_) < 0) {
+    std::cout << "pipe(init_pipe_) failed: " << strerror(errno) << std::endl;
+    setup_failed_ = true;
+    return;
+  }
+  if (pipe(tester_ready_pipe_) < 0) {
+    std::cout << "pipe(tester_ready_pipe_) failed: " << strerror(errno) << std::endl;
+    close(init_pipe_[0]);
+    close(init_pipe_[1]);
+    setup_failed_ = true;
+    return;
+  }
+
   child_ = fork();
   if (child_ < 0) {
     std::cout << "fork() failed: " << strerror(errno) << std::endl;
+    close(init_pipe_[0]);
+    close(init_pipe_[1]);
+    close(tester_ready_pipe_[0]);
+    close(tester_ready_pipe_[1]);
     setup_failed_ = true;
     return;
   }
 
   if (child_ != 0) {
     sleeper_process_ = true;  // sleeper_process is parent
+    // Sleeper: does not read init_pipe, does not write tester_ready_pipe.
+    close(init_pipe_[0]);
+    close(tester_ready_pipe_[1]);
 
     // AMD_SMI_INIT_FLAG_RESRV_TEST1 tells rsmi to fail immediately
     // if it can't get the mutex instead of waiting.
-    DISPLAY_AMDSMI_API("[before sleep] amdsmi_init(AMD_SMI_INIT_FLAG_RESRV_TEST1)", "",
-                       VERB(STANDARD));
+    DISPLAY_AMDSMI_API("[sleeper] amdsmi_init(AMD_SMI_INIT_AMD_GPUS|AMD_SMI_INIT_FLAG_RESRV_TEST1)",
+                       "", VERB(STANDARD));
     ret = amdsmi_init(AMDSMI_INIT_AMD_GPUS | AMD_SMI_INIT_FLAG_RESRV_TEST1);
     DISPLAY_AMDSMI_STATUS(VERB(STANDARD), __FILE__, __LINE__, ret, AMDSMI_STATUS_SUCCESS);
     if (ret != AMDSMI_STATUS_SUCCESS) {
       setup_failed_ = true;
     }
-    ASSERT_EQ(ret, AMDSMI_STATUS_SUCCESS);
+    // Phase 1: signal tester that sleeper's amdsmi_init is complete.
+    // Always write even on failure so tester doesn't hang.
+    char ready = 1;
+    if (write(init_pipe_[1], &ready, 1) < 0) {
+      std::cout << "write(init_pipe_) failed: " << strerror(errno) << std::endl;
+      setup_failed_ = true;
+    }
+    close(init_pipe_[1]);
 
-    sleep(2);  // Let both processes get through amdsmi_init
+    // Phase 2: wait for tester to also finish amdsmi_init before entering Run().
+    char tester_done = 0;
+    if (read(tester_ready_pipe_[0], &tester_done, 1) < 0) {
+      std::cout << "read(tester_ready_pipe_) failed: " << strerror(errno) << std::endl;
+      setup_failed_ = true;
+    }
+    close(tester_ready_pipe_[0]);
+
+    ASSERT_EQ(ret, AMDSMI_STATUS_SUCCESS);
   } else {
-    sleep(1);  // Let the sleeper process get through amdsmi_init() before
-               // this one goes, so it doesn't fail.
-    DISPLAY_AMDSMI_API("[after sleep] amdsmi_init(AMD_SMI_INIT_FLAG_RESRV_TEST1)", "",
-                       VERB(STANDARD));
+    // Tester: does not write init_pipe, does not read tester_ready_pipe.
+    close(init_pipe_[1]);
+    close(tester_ready_pipe_[0]);
+
+    // Phase 1: block until sleeper's amdsmi_init is complete.
+    char ready = 0;
+    if (read(init_pipe_[0], &ready, 1) < 0) {
+      std::cout << "read(init_pipe_) failed: " << strerror(errno) << std::endl;
+      setup_failed_ = true;
+    }
+    close(init_pipe_[0]);
+
+    DISPLAY_AMDSMI_API("[tester] amdsmi_init(AMD_SMI_INIT_AMD_GPUS|AMD_SMI_INIT_FLAG_RESRV_TEST1)",
+                       "", VERB(STANDARD));
     ret = amdsmi_init(AMDSMI_INIT_AMD_GPUS | AMD_SMI_INIT_FLAG_RESRV_TEST1);
     DISPLAY_AMDSMI_STATUS(VERB(STANDARD), __FILE__, __LINE__, ret, AMDSMI_STATUS_SUCCESS);
     if (ret != AMDSMI_STATUS_SUCCESS) {
       setup_failed_ = true;
     }
-    ASSERT_EQ(ret, AMDSMI_STATUS_SUCCESS);
+    // Phase 2: signal sleeper that tester's amdsmi_init is also complete.
+    char tester_done = 1;
+    if (write(tester_ready_pipe_[1], &tester_done, 1) < 0) {
+      std::cout << "write(tester_ready_pipe_) failed: " << strerror(errno) << std::endl;
+      setup_failed_ = true;
+    }
+    close(tester_ready_pipe_[1]);
 
-    sleep(2);  // Let both processes get through amdsmi_init;
+    ASSERT_EQ(ret, AMDSMI_STATUS_SUCCESS);
   }
 
   // Enumerate sockets and processor handles in each process after amdsmi_init()
@@ -181,10 +237,22 @@ void TestMutualExclusion::Run(void) {
 
   if (setup_failed_) {
     std::cout << "** SetUp Failed for this test. Skipping.**" << std::endl;
+    if (!sleeper_process_) {
+      // Child (tester) process: exit immediately to avoid running GTest/AMDSMI
+      // cleanup that was never meant to run here.
+      std::cout.flush();
+      _exit(1);
+    }
+    // Sleeper (parent) process: reap the child to avoid leaving a zombie.
+    if (child_ > 0) {
+      int child_status = 0;
+      waitpid(child_, &child_status, 0);
+    }
     return;
   }
 
   if (sleeper_process_) {
+    PRINT_VERBOSITY();
     // Block SIGCHLD so that when the child exits, the signal does not interrupt
     // sleep() inside rsmi_test_sleep and cause the mutex to be released early.
     sigset_t sigchld_mask, old_mask;

--- a/projects/amdsmi/tests/amd_smi_test/functional/mutual_exclusion.h
+++ b/projects/amdsmi/tests/amd_smi_test/functional/mutual_exclusion.h
@@ -54,6 +54,11 @@ class TestMutualExclusion : public TestBase {
   int child_;
   std::string orig_cross_process_env_;
   bool orig_cross_process_env_was_set_;
+  // Pipe-based init handshake (replaces sleep-based ordering):
+  //   init_pipe_:         sleeper → tester  (sleeper amdsmi_init complete)
+  //   tester_ready_pipe_: tester → sleeper  (tester amdsmi_init complete)
+  int init_pipe_[2];
+  int tester_ready_pipe_[2];
 };
 
 #endif  // TESTS_AMD_SMI_TEST_FUNCTIONAL_MUTUAL_EXCLUSION_H_

--- a/projects/amdsmi/tests/amd_smi_test/main.cc
+++ b/projects/amdsmi/tests/amd_smi_test/main.cc
@@ -287,7 +287,6 @@ TEST(amdsmitstReadOnly, TestMutualExclusion) {
   SetFlags(&tst);
   tst.DisplayTestInfo();
   tst.SetUp();
-  PRINT_VERBOSITY();
   tst.Run();
   RunCustomTestEpilog(&tst);
 }

--- a/projects/amdsmi/tests/amd_smi_test/main.cc
+++ b/projects/amdsmi/tests/amd_smi_test/main.cc
@@ -24,6 +24,7 @@
 #include "amd_smi/impl/amd_smi_utils.h"
 #include "functional/api_support_read.h"
 #include "functional/computepartition_read_write.h"
+#include "functional/cross_process_serialization.h"
 #include "functional/err_cnt_read.h"
 #include "functional/evt_notif_read_write.h"
 #include "functional/fan_read.h"
@@ -41,6 +42,7 @@
 #include "functional/memory_read_write.h"
 #include "functional/memorypartition_read_write.h"
 #include "functional/metrics_counter_read.h"
+#include "functional/mutual_exclusion.h"
 #include "functional/overdrive_read.h"
 #include "functional/overdrive_read_write.h"
 #include "functional/pci_read_write.h"
@@ -108,100 +110,121 @@ static void RunGenericTest(TestBase* test) {
 //  // from the standard pattern implemented there.
 //  RunGenericTest(&<test_obj>);
 // }
+
 TEST(amdsmitstReadOnly, TestVersionRead) {
   TestVersionRead tst;
   RunGenericTest(&tst);
 }
+
 TEST(amdsmitstReadOnly, FanRead) {
   TestFanRead tst;
   RunGenericTest(&tst);
 }
+
 TEST(amdsmitstReadWrite, FanReadWrite) {
   if (!amd::smi::is_sudo_user()) GTEST_SKIP_("Invalid permission - Must run as super user");
   TestFanReadWrite tst;
   RunGenericTest(&tst);
 }
+
 TEST(amdsmitstReadOnly, TempRead) {
   TestTempRead tst;
   RunGenericTest(&tst);
 }
+
 TEST(amdsmitstReadOnly, VoltRead) {
   TestVoltRead tst;
   RunGenericTest(&tst);
 }
+
 TEST(amdsmitstReadOnly, TestVoltCurvRead) {
   TestVoltCurvRead tst;
   RunGenericTest(&tst);
 }
+
 TEST(amdsmitstReadOnly, TestPerfLevelRead) {
   if (amd::smi::is_vm_guest()) GTEST_SKIP();
   TestPerfLevelRead tst;
   RunGenericTest(&tst);
 }
+
 TEST(amdsmitstReadWrite, TestPerfLevelReadWrite) {
   if (amd::smi::is_vm_guest()) GTEST_SKIP();
   if (!amd::smi::is_sudo_user()) GTEST_SKIP_("Invalid permission - Must run as super user");
   TestPerfLevelReadWrite tst;
   RunGenericTest(&tst);
 }
+
 TEST(amdsmitstReadOnly, TestOverdriveRead) {
   TestOverdriveRead tst;
   RunGenericTest(&tst);
 }
+
 TEST(amdsmitstReadWrite, TestOverdriveReadWrite) {
   if (!amd::smi::is_sudo_user()) GTEST_SKIP_("Invalid permission - Must run as super user");
   TestOverdriveReadWrite tst;
   RunGenericTest(&tst);
 }
+
 TEST(amdsmitstReadOnly, TestFrequenciesRead) {
   TestFrequenciesRead tst;
   RunGenericTest(&tst);
 }
+
 TEST(amdsmitstReadWrite, TestFrequenciesReadWrite) {
   if (!amd::smi::is_sudo_user()) GTEST_SKIP_("Invalid permission - Must run as super user");
   TestFrequenciesReadWrite tst;
   RunGenericTest(&tst);
 }
+
 TEST(amdsmitstReadWrite, TestPciReadWrite) {
   if (amd::smi::is_vm_guest()) GTEST_SKIP();
   if (!amd::smi::is_sudo_user()) GTEST_SKIP_("Invalid permission - Must run as super user");
   TestPciReadWrite tst;
   RunGenericTest(&tst);
 }
+
 TEST(amdsmitstReadOnly, TestSysInfoRead) {
   if (amd::smi::is_vm_guest()) GTEST_SKIP();
   TestSysInfoRead tst;
   RunGenericTest(&tst);
 }
+
 TEST(amdsmitstReadOnly, TestGPUBusyRead) {
   TestGPUBusyRead tst;
   RunGenericTest(&tst);
 }
+
 TEST(amdsmitstReadOnly, TestPowerRead) {
   if (amd::smi::is_vm_guest()) GTEST_SKIP();
   TestPowerRead tst;
   RunGenericTest(&tst);
 }
+
 TEST(amdsmitstReadWrite, TestPowerReadWrite) {
   if (amd::smi::is_vm_guest()) GTEST_SKIP();
   if (!amd::smi::is_sudo_user()) GTEST_SKIP_("Invalid permission - Must run as super user");
   TestPowerReadWrite tst;
   RunGenericTest(&tst);
 }
+
 TEST(amdsmitstReadWrite, TestPowerCapReadWrite) {
   if (amd::smi::is_vm_guest()) GTEST_SKIP();
   if (!amd::smi::is_sudo_user()) GTEST_SKIP_("Invalid permission - Must run as super user");
   TestPowerCapReadWrite tst;
   RunGenericTest(&tst);
 }
+
 TEST(amdsmitstReadOnly, TestErrCntRead) {
   TestErrCntRead tst;
   RunGenericTest(&tst);
 }
+
 TEST(amdsmitstReadOnly, TestMemUtilRead) {
   TestMemUtilRead tst;
   RunGenericTest(&tst);
 }
+
 TEST(amdsmitstReadOnly, TestIdInfoRead) {
   if (amd::smi::is_vm_guest()) GTEST_SKIP();
   TestIdInfoRead tst;
@@ -212,14 +235,17 @@ TEST(amdsmitstReadWrite, TestPerfCntrReadWrite) {
   TestPerfCntrReadWrite tst;
   RunGenericTest(&tst);
 }
+
 TEST(amdsmitstReadOnly, TestProcInfoRead) {
   TestProcInfoRead tst;
   RunGenericTest(&tst);
 }
+
 TEST(amdsmitstReadOnly, TestHWTopologyRead) {
   TestHWTopologyRead tst;
   RunGenericTest(&tst);
 }
+
 TEST(amdsmitstReadOnly, TestGpuMetricsRead) {
   TestGpuMetricsRead tst;
   RunGenericTest(&tst);
@@ -228,30 +254,34 @@ TEST(amdsmitstReadOnly, TestGpuPartitionMetricsRead) {
   TestGpuPartitionMetricsRead tst;
   RunGenericTest(&tst);
 }
+
 TEST(amdsmitstReadOnly, TestMetricsCounterRead) {
   TestMetricsCounterRead tst;
   RunGenericTest(&tst);
 }
+
 TEST(amdsmitstReadWrite, TestPerfDeterminism) {
   if (!amd::smi::is_sudo_user()) GTEST_SKIP_("Invalid permission - Must run as super user");
   TestPerfDeterminism tst;
   RunGenericTest(&tst);
 }
+
 TEST(amdsmitstReadWrite, TestXGMIReadWrite) {
   if (!amd::smi::is_sudo_user()) GTEST_SKIP_("Invalid permission - Must run as super user");
   TestXGMIReadWrite tst;
   RunGenericTest(&tst);
 }
+
 TEST(amdsmitstReadOnly, TestMemPageInfoRead) {
   TestMemPageInfoRead tst;
   RunGenericTest(&tst);
 }
+
 TEST(amdsmitstReadOnly, TestAPISupportRead) {
   TestAPISupportRead tst;
   RunGenericTest(&tst);
 }
 
-/*
 TEST(amdsmitstReadOnly, TestMutualExclusion) {
   TestMutualExclusion tst;
   SetFlags(&tst);
@@ -261,7 +291,15 @@ TEST(amdsmitstReadOnly, TestMutualExclusion) {
   tst.Run();
   RunCustomTestEpilog(&tst);
 }
-*/
+
+TEST(amdsmitstReadOnly, TestCrossProcessSerialization) {
+  TestCrossProcessSerialization tst;
+  SetFlags(&tst);
+  tst.DisplayTestInfo();
+  tst.SetUp();
+  tst.Run();
+  RunCustomTestEpilog(&tst);
+}
 
 TEST(amdsmitstReadWrite, TestComputePartitionReadWrite) {
   if (!amd::smi::is_sudo_user()) GTEST_SKIP_("Invalid permission - Must run as super user");


### PR DESCRIPTION
Requires: #4660 & #4479 to be in for tests to pass.

## Summary
This PR contains the mutex-focused portion split out from the original SWDEV-531904 branch.

## Included changes
- `mutual_exclusion` and `cross_process_serialization` test updates
- `sleep_interruptible(uint32_t seconds)` declaration/implementation/call usage
- `DEVICE_MUTEX` / `SMIGPUDEVICE_MUTEX` related test-path updates
- `AMD_SMI_INIT_FLAG_RESRV_TEST1` wiring for test behavior

## Notes
- This is the second PR in the split.
- The companion PR keeps the remaining non-mutex changes.