### PR TITLE
[rocprofiler-sdk] Fix rocprofv3 temp file path generation when tmp_directory resolves to /

### DIFF
--- a/projects/rocprofiler-sdk/source/lib/output/tmp_file_buffer.cpp
+++ b/projects/rocprofiler-sdk/source/lib/output/tmp_file_buffer.cpp
@@ -38,7 +38,7 @@ std::string
 compose_tmp_file_name(const output_config& cfg, domain_type buffer_type)
 {
     auto tmp_directory = fs::path{rocprofiler::tool::format_path(cfg.tmp_directory)};
-    auto filename      =
+    auto filename =
         tmp_directory / ".rocprofv3" /
         fmt::format("{}-{}.dat", "%ppid%-%pid%", get_domain_trace_file_name(buffer_type));
 

--- a/projects/rocprofiler-sdk/source/lib/output/tmp_file_buffer.cpp
+++ b/projects/rocprofiler-sdk/source/lib/output/tmp_file_buffer.cpp
@@ -22,6 +22,7 @@
 
 #include "tmp_file_buffer.hpp"
 #include "domain_type.hpp"
+#include "lib/common/filesystem.hpp"
 
 #include <fmt/format.h>
 
@@ -31,13 +32,17 @@ namespace rocprofiler
 {
 namespace tool
 {
+namespace fs = common::filesystem;
+
 std::string
 compose_tmp_file_name(const output_config& cfg, domain_type buffer_type)
 {
-    return rocprofiler::tool::format_path(fmt::format("{}/.rocprofv3/{}-{}.dat",
-                                                      cfg.tmp_directory,
-                                                      "%ppid%-%pid%",
-                                                      get_domain_trace_file_name(buffer_type)));
+    auto tmp_directory = fs::path{rocprofiler::tool::format_path(cfg.tmp_directory)};
+    auto filename      =
+        tmp_directory / ".rocprofv3" /
+        fmt::format("{}-{}.dat", "%ppid%-%pid%", get_domain_trace_file_name(buffer_type));
+
+    return rocprofiler::tool::format_path(filename.string());
 }
 
 tmp_file_name_callback_t&


### PR DESCRIPTION
## Motivation

fix error `ring_buffer: munmap failed: Invalid argument`
when running from rocprofv3 from root directory

## Technical Details

This change updates `compose_tmp_file_name()` in `tmp_file_buffer.cpp` to construct temporary output paths with `fs::path` instead of formatting the full path as a string.

Previously, when `cfg.tmp_directory` expanded to `/`, rocprofv3 produced paths like `//.rocprofv3/%ppid%-%pid% hip_api_trace.dat`. This change first expands `cfg.tmp_directory`, then joins `".rocprofv3"` and the trace filename as filesystem path components, which yields the correct root-relative path `/.rocprofv3/...`.


## JIRA ID

AIPROFSDK-791

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
