### PR TITLE
[rocshmem] gda/mlx5: initialize all variables in mlx5_poll_cq_until()

### DIFF
--- a/projects/rocshmem/src/gda/mlx5/queue_pair_mlx5.cpp
+++ b/projects/rocshmem/src/gda/mlx5/queue_pair_mlx5.cpp
@@ -182,9 +182,6 @@ __device__ void QueuePair::mlx5_check_cqe_error(const mlx5_cqe64* cqe) {
 }
 
 __device__ void QueuePair::mlx5_poll_cq_until(uint16_t requested_available_slots) {
-  uint16_t consumed_slots;
-  uint16_t available_slots;
-
   uint16_t sq_depth = mlx5_sq.depth;
 
   uint64_t sq_post = __hip_atomic_load(&mlx5_sq.post, __ATOMIC_ACQUIRE, __HIP_MEMORY_SCOPE_AGENT);
@@ -233,8 +230,8 @@ __device__ void QueuePair::mlx5_poll_cq_until(uint16_t requested_available_slots
      * in some marginal cases it's maybe possible to see consumed_slots > sq_depth,
      * but in that case available_slots will be very large, > requested_available_slots,
      * and the loop will continue for another iteration */
-    consumed_slots  = posted   - completed;
-    available_slots = sq_depth - consumed_slots;
+    uint16_t consumed_slots  = posted   - completed;
+    uint16_t available_slots = sq_depth - consumed_slots;
 
     /* continue until both:
      *   - no additional WQEs have been posted


### PR DESCRIPTION
## Motivation

Prior to 200a3dd77bc80fdafdb2d9385dc3b29695b82ae4, `consumed_slots` and `available_slots` could be read in `mlx5_poll_cq_until()` before being initialized when an invalid WQE was read. This lead to bugs where `quiet()` did not properly quiet the QP.

## Technical Details

Prevent future regressions by ensuring that all variables are initialized.

## JIRA ID

AIROCSHMEM-316
AIROCSHMEM-341

## Test Plan

N/A

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
