### PR TITLE
[rocshmem] functional_tests/driver.sh: add feature to specify custom test config

### DIFF
--- a/projects/rocshmem/scripts/functional_tests/driver.sh
+++ b/projects/rocshmem/scripts/functional_tests/driver.sh
@@ -603,10 +603,10 @@ ValidateInput() {
   INPUT_COUNT=$1
   if [ $INPUT_COUNT -lt 3 ] ; then
     echo "This script must be run with at least 3 arguments."
-    echo "Usage: ${0} <executable> <test_suit | test_name | test_config> <log_dir> [hostfile]"
+    echo "Usage: ${0} <executable> <test_suite | test_name | test_config> <log_dir> [hostfile]"
     echo
     echo "    <executable>  : path to the tester executable"
-    echo "    <test_suit>   : test suit to run, e.g. 'all', 'rma', or 'put'"
+    echo "    <test_suite>  : test suite to run, e.g. 'all', 'rma', or 'put'"
     echo "    <test_name>   : name of test to run, e.g. 'putnbi' or 'amo_fadd'"
     echo "    <test_config> : quoted test configuration to run, in the format"
     echo '                    "<test_name> <ranks> <workgroups> <threads> [max_msg_size]"'

--- a/projects/rocshmem/scripts/functional_tests/driver.sh
+++ b/projects/rocshmem/scripts/functional_tests/driver.sh
@@ -603,11 +603,20 @@ ValidateInput() {
   INPUT_COUNT=$1
   if [ $INPUT_COUNT -lt 3 ] ; then
     echo "This script must be run with at least 3 arguments."
-    echo 'Usage: ${0} argument1 argument2 argument3 [argument4]'
-    echo "  argument1 : path to the tester driver"
-    echo "  argument2 : test type to run, e.g put"
-    echo "  argument3 : directory to put the output logs"
-    echo "  argument4 : path to hostfile"
+    echo "Usage: ${0} <executable> <test_suit | test_name | test_config> <log_dir> [hostfile]"
+    echo
+    echo "    <executable>  : path to the tester executable"
+    echo "    <test_suit>   : test suit to run, e.g. 'all', 'rma', or 'put'"
+    echo "    <test_name>   : name of test to run, e.g. 'putnbi' or 'amo_fadd'"
+    echo "    <test_config> : quoted test configuration to run, in the format"
+    echo '                    "<test_name> <ranks> <workgroups> <threads> [max_msg_size]"'
+    echo '                    e.g. "putnbi 2 8 1024 65536" or "amo_fadd 2 1 64"'
+    echo "        <ranks>        : number of PEs/ranks to use for test"
+    echo "        <workgroups>   : number of workgroups per PE"
+    echo "        <threads>      : number of threads per workgroup"
+    echo "        [max_msg_size] : maximum message size to test"
+    echo "    <log_dir>     : path to output log directory"
+    echo "    [hostfile]    : path to hostfile"
     exit 1
   fi
 }
@@ -746,10 +755,25 @@ case $TEST in
     TestOther
     ;;
   *)
-    ##############################################################################
-    #       | Name             | Ranks | Workgroups | Threads | Max Message Size #
-    ##############################################################################
-    ExecTest  $TEST              2       1            1         8
+    #######################################################################################
+    #        |   Name   |   Ranks   |   Workgroups   |   Threads   |   Max Message Size   #
+    #######################################################################################
+    # Allow passing in a test config as "<test_name> <ranks> <workgroups> <threads> [max_msg_size]"
+    # e.g. "putnbi 2 8 1024 65536" or "amo_fadd 2 1 64"
+    TEST_OPTS=($TEST)
+    NAME=${TEST_OPTS[0]}
+    if [ ${#TEST_OPTS[@]} -eq 4 ] || [ ${#TEST_OPTS[@]} -eq 5 ]; then
+      RANKS=${TEST_OPTS[1]}
+      WORKGROUPS=${TEST_OPTS[2]}
+      THREADS=${TEST_OPTS[3]}
+      MAX_MESSAGE_SIZE=${TEST_OPTS[4]}
+    else
+      RANKS=2
+      WORKGROUPS=1
+      THREADS=1
+      MAX_MESSAGE_SIZE=8
+    fi
+    ExecTest  "${NAME}"  "${RANKS}"  "${WORKGROUPS}"  "${THREADS}"  "${MAX_MESSAGE_SIZE}"
     ;;
 esac
 


### PR DESCRIPTION
## Motivation

It is not currently possible to use the functional test driver script to run a single test with a custom configuration. This PR adds this feature, which can be used as follows:
```Shell
# /path/to/rocshmem_functional_driver.sh /path/to/rocshmem_functional_tests "<name> <ranks> <workgroups> <threads> [max_msg_size]" /path/to/log/dir
cd rocshmem_build_dir
mkdir functional_test_logs
# putnbi test with 2 PEs, 32 workgroups, 256 threads per workgroup, and up to 512B per message
./tests/functional_tests/rocshmem_functional_driver.sh ./tests/functional_tests/rocshmem_functional_tests "putnbi 2 32 256 512" functional_test_logs
less functional_test_logs/putnbi_n2_w32_z256_512B.log
# amo_finc test with 2 PEs, 1 workgroup, and 1024 threads per workgroup
./tests/functional_tests/rocshmem_functional_driver.sh ./tests/functional_tests/rocshmem_functional_tests "amo_finc 2 1 1024" functional_test_logs
less functional_test_logs/amo_finc_n2_w1_z1024.log
```

## Technical Details

Extend the driver script to handle arbitrary single test configurations in the same format as used for input to the ExecTest script function:
* If `$TEST` doesn't match any preset, `$TEST` is parsed into a bash array `TEST_OPTS=($TEST)`; this is implicitly split at whitespace boundary by bash
* Index 0 is the test name, `NAME=${TEST_OPTS[0]}`
* If the length of the array is 4 or 5 then indices 1–4 are parsed as ranks, workgroups, threads, and max message size
* Otherwise the same static default configuration as before is used: 2 ranks, 1 workgroup, 1 thread, and a max message size of 8B

## JIRA ID

AIROCSHMEM-356

## Test Plan

Run a variety of test configurations using the new custom test feature.

## Test Result

Feature has been in internal use for a few months with no apparent issues or regressions.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
