### PR TITLE
[AQLProfile]Add spm config query support

### DIFF
--- a/projects/aqlprofile/src/core/include/aqlprofile-sdk/aql_profile_v2.h
+++ b/projects/aqlprofile/src/core/include/aqlprofile-sdk/aql_profile_v2.h
@@ -600,9 +600,17 @@ typedef enum
 
 typedef enum
 {
-    AQLPROFILE_SPM_PARAMETER_SAMPLE_MODE_SCLK = 0,
-    AQLPROFILE_SPM_PARAMETER_SAMPLE_MODE_REFCLK
+    AQLPROFILE_SPM_PARAMETER_SAMPLE_MODE_NONE = 0,
+    AQLPROFILE_SPM_PARAMETER_SAMPLE_MODE_SCLK,
+    AQLPROFILE_SPM_PARAMETER_SAMPLE_MODE_REFCLK,
 } aqlprofile_spm_parameter_interval_mode_t;
+
+typedef struct aqlprofile_spm_available_configuration_t
+{
+   aqlprofile_spm_parameter_interval_mode_t sample_interval_unit;
+   uint64_t min_interval;
+   uint64_t max_interval;
+} aqlprofile_spm_available_configuration_t;
 
 typedef struct
 {
@@ -744,6 +752,14 @@ aqlprofile_spm_decode_query(aqlprofile_spm_buffer_desc_t  desc,
 
 bool
 aqlprofile_spm_is_event_supported(aqlprofile_agent_handle_t agent, aqlprofile_pmc_event_t event);
+
+typedef hsa_status_t (*aqlprofile_spm_available_configurations_cb_t)(
+    const aqlprofile_spm_available_configuration_t*    config,
+    size_t*                                         num_config,
+    void*                                         user_data);
+
+hsa_status_t
+aqlprofile_spm_query_agent_capabilities(aqlprofile_agent_handle_t agent, aqlprofile_spm_available_configurations_cb_t cb, void* userdata);
 
 #ifdef __cplusplus
 }

--- a/projects/aqlprofile/src/core/include/aqlprofile-sdk/aql_profile_v2.h
+++ b/projects/aqlprofile/src/core/include/aqlprofile-sdk/aql_profile_v2.h
@@ -591,12 +591,15 @@ typedef struct
 
 typedef enum
 {
-    AQLPROFILE_SPM_PARAMETER_TYPE_BUFFER_SIZE = 0,
-    AQLPROFILE_SPM_PARAMETER_TYPE_SAMPLE_INTERVAL,
+    AQLPROFILE_SPM_PARAMETER_TYPE_NONE = 0,
+    AQLPROFILE_SPM_PARAMETER_TYPE_BUFFER_SIZE,
+    AQLPROFILE_SPM_PARAMETER_TYPE_SAMPLE_INTERVAL_SCLK_CYCLES,
+    AQLPROFILE_SPM_PARAMETER_TYPE_SAMPLE_INTERVAL_REFCLK_CYCLES,
     AQLPROFILE_SPM_PARAMETER_TYPE_TIMEOUT,
     AQLPROFILE_SPM_PARAMETER_TYPE_SAMPLE_MODE,
     AQLPROFILE_SPM_PARAMETER_TYPE_LAST,
 } aqlprofile_spm_parameter_type_t;
+
 
 typedef enum
 {
@@ -605,11 +608,12 @@ typedef enum
     AQLPROFILE_SPM_PARAMETER_SAMPLE_MODE_REFCLK,
 } aqlprofile_spm_parameter_interval_mode_t;
 
+
 typedef struct aqlprofile_spm_available_configuration_t
 {
-   aqlprofile_spm_parameter_interval_mode_t sample_interval_unit;
-   uint64_t min_interval;
-   uint64_t max_interval;
+    aqlprofile_spm_parameter_type_t        type =  AQLPROFILE_SPM_PARAMETER_TYPE_NONE;
+    uint64_t                               min_interval = 0;
+    uint64_t                               max_interval = 0;
 } aqlprofile_spm_available_configuration_t;
 
 typedef struct
@@ -755,7 +759,7 @@ aqlprofile_spm_is_event_supported(aqlprofile_agent_handle_t agent, aqlprofile_pm
 
 typedef hsa_status_t (*aqlprofile_spm_available_configurations_cb_t)(
     const aqlprofile_spm_available_configuration_t*    config,
-    size_t*                                         num_config,
+    size_t                                         num_config,
     void*                                         user_data);
 
 hsa_status_t

--- a/projects/aqlprofile/src/core/spm_v2.cpp
+++ b/projects/aqlprofile/src/core/spm_v2.cpp
@@ -572,5 +572,9 @@ aqlprofile_spm_is_event_supported(aqlprofile_agent_handle_t agent, aqlprofile_pm
 PUBLIC_API hsa_status_t
 aqlprofile_spm_query_agent_capabilities(aqlprofile_agent_handle_t agent, aqlprofile_spm_available_configurations_cb_t cb, void* userdata)
 {
-    return HSA_STATUS_SUCCESS;
+  const aqlprofile_spm_available_configuration_t sample_internel_caps[] = {
+      AQLPROFILE_SPM_PARAMETER_SAMPLE_MODE_SCLK, 32, (1 << 16) - 32};
+  size_t num_caps = 1;
+  hsa_status_t status = cb(sample_internel_caps, &num_caps, userdata);
+  return status;
 }

--- a/projects/aqlprofile/src/core/spm_v2.cpp
+++ b/projects/aqlprofile/src/core/spm_v2.cpp
@@ -166,7 +166,7 @@ bool is_agent_supported_for_spm(const AgentInfo* agentInfo) {
 std::vector<aqlprofile_spm_parameter_t> default_spm_params = {
     {AQLPROFILE_SPM_PARAMETER_TYPE_BUFFER_SIZE,     1<<26}, // 64MB
     {AQLPROFILE_SPM_PARAMETER_TYPE_SAMPLE_INTERVAL, 1<<13}, // 4us
-    {AQLPROFILE_SPM_PARAMETER_TYPE_TIMEOUT,         100},   // 100ms
+    {AQLPROFILE_SPM_PARAMETER_TYPE_TIMEOUT,         0},   // 100ms
     {AQLPROFILE_SPM_PARAMETER_TYPE_SAMPLE_MODE,     AQLPROFILE_SPM_PARAMETER_SAMPLE_MODE_SCLK}
 };
 static_assert(AQLPROFILE_SPM_PARAMETER_TYPE_LAST == 4 && "Dont forget to add default param!");
@@ -567,4 +567,10 @@ aqlprofile_spm_is_event_supported(aqlprofile_agent_handle_t agent, aqlprofile_pm
     if (event.block_name >= blocks.size()) return false;
 
     return blocks.at(event.block_name);
+}
+
+PUBLIC_API hsa_status_t
+aqlprofile_spm_query_agent_capabilities(aqlprofile_agent_handle_t agent, aqlprofile_spm_available_configurations_cb_t cb, void* userdata)
+{
+    return HSA_STATUS_SUCCESS;
 }

--- a/projects/aqlprofile/src/core/spm_v2.cpp
+++ b/projects/aqlprofile/src/core/spm_v2.cpp
@@ -165,11 +165,11 @@ bool is_agent_supported_for_spm(const AgentInfo* agentInfo) {
 
 std::vector<aqlprofile_spm_parameter_t> default_spm_params = {
     {AQLPROFILE_SPM_PARAMETER_TYPE_BUFFER_SIZE,     1<<26}, // 64MB
-    {AQLPROFILE_SPM_PARAMETER_TYPE_SAMPLE_INTERVAL, 1<<13}, // 4us
+    {AQLPROFILE_SPM_PARAMETER_TYPE_SAMPLE_INTERVAL_SCLK_CYCLES, 1<<13}, // 4us
     {AQLPROFILE_SPM_PARAMETER_TYPE_TIMEOUT,         0},   // 100ms
     {AQLPROFILE_SPM_PARAMETER_TYPE_SAMPLE_MODE,     AQLPROFILE_SPM_PARAMETER_SAMPLE_MODE_SCLK}
 };
-static_assert(AQLPROFILE_SPM_PARAMETER_TYPE_LAST == 4 && "Dont forget to add default param!");
+static_assert(AQLPROFILE_SPM_PARAMETER_TYPE_LAST == 6 && "Dont forget to add default param!");
 
 counter_des_t GetCounter(
     aql_profile::Pm4Factory* pm4_factory,
@@ -299,7 +299,7 @@ hsa_status_t _internal_aqlprofile_spm_create_packets(
         trace_config.spm_has_core1 = (pm4_factory->GetGpuId() == aql_profile::MI100_GPU_ID) ||
                                     (pm4_factory->GetGpuId() == aql_profile::MI200_GPU_ID);
         trace_config.spm_sample_delay_max = pm4_factory->GetSpmSampleDelayMax();
-        trace_config.sampleRate = (s->parameters.at(AQLPROFILE_SPM_PARAMETER_TYPE_SAMPLE_INTERVAL) + 16) & ~31ul;
+        trace_config.sampleRate = (s->parameters.at(AQLPROFILE_SPM_PARAMETER_TYPE_SAMPLE_INTERVAL_SCLK_CYCLES) + 16) & ~31ul;
         if (trace_config.sampleRate == 0) return HSA_STATUS_ERROR_INVALID_ARGUMENT;
 
         if (s->parameters.at(AQLPROFILE_SPM_PARAMETER_TYPE_SAMPLE_MODE) != AQLPROFILE_SPM_PARAMETER_SAMPLE_MODE_SCLK)
@@ -573,8 +573,8 @@ PUBLIC_API hsa_status_t
 aqlprofile_spm_query_agent_capabilities(aqlprofile_agent_handle_t agent, aqlprofile_spm_available_configurations_cb_t cb, void* userdata)
 {
   const aqlprofile_spm_available_configuration_t sample_internel_caps[] = {
-      AQLPROFILE_SPM_PARAMETER_SAMPLE_MODE_SCLK, 32, (1 << 16) - 32};
+      AQLPROFILE_SPM_PARAMETER_TYPE_SAMPLE_INTERVAL_SCLK_CYCLES, 32, (1 << 16) - 32};
   size_t num_caps = 1;
-  hsa_status_t status = cb(sample_internel_caps, &num_caps, userdata);
+  hsa_status_t status = cb(sample_internel_caps, num_caps, userdata);
   return status;
 }


### PR DESCRIPTION
## Motivation

SPM (Streaming Performance Monitor) configuration query support to aqlprofile

## Technical Details

                                                                                                                                          
Adds a function that queries the available SPM configurations for a given agent/GPU.
  Uses a callback pattern (aqlprofile_spm_available_configurations_cb_t) to return configuration data to the caller. 
  Defines a configuration descriptor with type, min_interval, and max_interval fields, used to describe supported SPM parameter ranges.  

## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
