### PR TITLE
[RCCL] Move tuning logs from NCCL_INIT to NCCL_TUNING in enqueue.cc

### DIFF
--- a/projects/rccl/src/enqueue.cc
+++ b/projects/rccl/src/enqueue.cc
@@ -2287,15 +2287,15 @@ static ncclResult_t topoGetAlgoInfo(
     }
   } else {
     rcclUpdateThreadThreshold(comm, nBytes, info, threadThreshold);
-    INFO(NCCL_INIT, "pre-adjustment threadThreshold:%i nBytes:%lu nc:%i", threadThreshold, nBytes, nc);
+    INFO(NCCL_TUNING, "pre-adjustment threadThreshold:%i nBytes:%lu nc:%i", threadThreshold, nBytes, nc);
 
     int minNChannels = ncclParamMinNchannels();
     // Ring/Tree channel tuning
-    INFO(NCCL_INIT, "minNChannels:%i", minNChannels);
+    INFO(NCCL_TUNING, "minNChannels:%i", minNChannels);
     if(nBytes < nc * nt * threadThreshold && nc > minNChannels){
       nc = std::max(1,std::max(minNChannels,(int)(nBytes/std::max(1,nt * threadThreshold))));
     }
-    INFO(NCCL_INIT, "post-adjustment based on threadThreshold:%i nBytes:%lu nc:%i", threadThreshold, nBytes, nc);
+    INFO(NCCL_TUNING, "post-adjustment based on threadThreshold:%i nBytes:%lu nc:%i", threadThreshold, nBytes, nc);
     rcclOverrideChannels(comm, info->func, nBytes, nc);
   }
 


### PR DESCRIPTION
## Motivation

 Move tuning-related log traces from `NCCL_INIT` to `NCCL_TUNING` so `NCCL_DEBUG=INFO` stays readable. These tuning logs can now be viewed by setting `NCCL_DEBUG_SUBSYS=TUNING`.

## Technical Details

In `enqueue.cc`, pre-adjustment, minNChannels, and post-adjustment logs now use `INFO(NCCL_TUNING, …)` instead of `INFO(NCCL_INIT, …)`.

## JIRA ID

ROCM-20909

## Test Plan

Check logs with and without TUNING subsys enabled.

## Test Result

Tuning logs don't appear when only `NCCL_DEBUG=INFO` is set. With both `NCCL_DEBUG=INFO` and `NCCL_DEBUG_SUBSYS=TUNING`, these enqueue tuning logs do appear, as expected.

## Submission Checklist

- [X] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
