### PR TITLE
rocr/clr: Add per-queue VM fault state via hsa_amd_queue_get_info

### DIFF
--- a/projects/clr/rocclr/device/rocm/rocdevice.cpp
+++ b/projects/clr/rocclr/device/rocm/rocdevice.cpp
@@ -3490,10 +3490,26 @@ device::Signal* Device::createIpcSignal() const { return new roc::IpcSignal(); }
 hsa_status_t Device::BackendErrorCallBackHandler(const hsa_amd_event_t* event, void* data) {
   cl_int gpu_error = CL_SUCCESS;
   switch (event->event_type) {
-    case HSA_AMD_GPU_MEMORY_FAULT_EVENT:
+    case HSA_AMD_GPU_MEMORY_FAULT_EVENT: {
       gpu_error = CL_INVALID_MEM_OBJECT;
       LogError("Memory Fault Error");
+      for (auto* amd_dev : amd::Device::devices()) {
+        if (amd_dev->type() != CL_DEVICE_TYPE_GPU) continue;
+        Device* roc_dev = reinterpret_cast<Device*>(amd_dev);
+        for (auto it : roc_dev->vgpus()) {
+          roc::VirtualGPU* vgpu = reinterpret_cast<roc::VirtualGPU*>(it);
+          bool faulted = false;
+          if (vgpu->gpu_queue() != nullptr &&
+              hsa_amd_queue_get_info(vgpu->gpu_queue(),
+                                     HSA_AMD_QUEUE_INFO_VM_FAULT_STATUS,
+                                     &faulted) == HSA_STATUS_SUCCESS &&
+              faulted) {
+            vgpu->AnalyzeAqlQueue();
+          }
+        }
+      }
       break;
+    }
     case HSA_AMD_GPU_HW_EXCEPTION_EVENT:
       gpu_error = CL_INVALID_OPERATION;
       LogError("HW Exception Error");

--- a/projects/clr/rocclr/device/rocm/rocvirtual.cpp
+++ b/projects/clr/rocclr/device/rocm/rocvirtual.cpp
@@ -1241,17 +1241,12 @@ void VirtualGPU::AnalyzeAqlQueue() const {
   uint64_t index = Hsa::queue_load_write_index_relaxed(gpu_queue_);
   uint64_t read = Hsa::queue_load_read_index_relaxed(gpu_queue_);
 
-  uint64_t scan_start = read;
-  if (index == read && index > 0) {
-    scan_start = index - 1;
-  }
-
-  if (index > read || (index == read && index > 0)) {
+  if (index > read) {
     int valid_packet_idx = 0;
     constexpr int kAqlSearchWindow = 32;
     while (valid_packet_idx < kAqlSearchWindow) {
       auto aql_loc = &(reinterpret_cast<hsa_kernel_dispatch_packet_t*>(
-          gpu_queue_->base_address))[(scan_start + valid_packet_idx) & queueMask];
+          gpu_queue_->base_address))[(read + valid_packet_idx) & queueMask];
       if (extractAqlBits((*aql_loc).header, HSA_PACKET_HEADER_TYPE, HSA_PACKET_HEADER_WIDTH_TYPE) ==
           HSA_PACKET_TYPE_INVALID) {
         if (index == read) {

--- a/projects/clr/rocclr/device/rocm/rocvirtual.cpp
+++ b/projects/clr/rocclr/device/rocm/rocvirtual.cpp
@@ -1238,69 +1238,108 @@ static inline void packet_store_release(uint32_t* packet, uint16_t header, uint1
 void VirtualGPU::AnalyzeAqlQueue() const {
   const uint32_t queueSize = gpu_queue_->size;
   const uint32_t queueMask = queueSize - 1;
-  const uint32_t sw_queue_size = queueMask;
   uint64_t index = Hsa::queue_load_write_index_relaxed(gpu_queue_);
   uint64_t read = Hsa::queue_load_read_index_relaxed(gpu_queue_);
-  if (index > read) {
+
+  uint64_t scan_start = read;
+  if (index == read && index > 0) {
+    scan_start = index - 1;
+  }
+
+  if (index > read || (index == read && index > 0)) {
     int valid_packet_idx = 0;
     constexpr int kAqlSearchWindow = 32;
     while (valid_packet_idx < kAqlSearchWindow) {
-      // Read AQL packet header and check if it's invalid, which means it's done
       auto aql_loc = &(reinterpret_cast<hsa_kernel_dispatch_packet_t*>(
-          gpu_queue_->base_address))[(read + valid_packet_idx) & queueMask];
-      // If the packet is invalid, then continue search
+          gpu_queue_->base_address))[(scan_start + valid_packet_idx) & queueMask];
       if (extractAqlBits((*aql_loc).header, HSA_PACKET_HEADER_TYPE, HSA_PACKET_HEADER_WIDTH_TYPE) ==
           HSA_PACKET_TYPE_INVALID) {
+        if (index == read) {
+          break;
+        }
         valid_packet_idx++;
       } else {
         break;
       }
     }
     if (valid_packet_idx == kAqlSearchWindow) {
-      printf("VGPU(%p) Queue(%p). Couldn't find the hang AQL packet!\n", this, gpu_queue_);
+      fprintf(stderr, "VGPU(%p) Queue(%p). Couldn't find the hang AQL packet!\n", this, gpu_queue_);
       return;
     }
-    // Read AQL packet and check if it's a kernel dispatch
     auto aql_loc = &(reinterpret_cast<hsa_kernel_dispatch_packet_t*>(
-        gpu_queue_->base_address))[(read + valid_packet_idx) & queueMask];
+        gpu_queue_->base_address))[(scan_start + valid_packet_idx) & queueMask];
     auto packet = *aql_loc;
     auto header = packet.header;
-    if (extractAqlBits(header, HSA_PACKET_HEADER_TYPE, HSA_PACKET_HEADER_WIDTH_TYPE) ==
-        HSA_PACKET_TYPE_KERNEL_DISPATCH) {
-      auto it = dev().KernelMap().find(packet.kernel_object);
+    auto pkt_type = extractAqlBits(header, HSA_PACKET_HEADER_TYPE, HSA_PACKET_HEADER_WIDTH_TYPE);
+
+    auto printKernelName = [&](uint64_t kernel_object) {
+      auto it = dev().KernelMap().find(kernel_object);
       if (it != dev().KernelMap().end()) {
-        // @note: It's possible to demangle the name with comgr
-        printf("Kernel Name: %s\n", it->second.name().c_str());
+        fprintf(stderr, "Kernel Name: %s\n", it->second.name().c_str());
       } else {
-        printf("VGPU(%p) Queue(%p). Couldn't find kernel\n", this, gpu_queue_);
+        fprintf(stderr, "VGPU(%p) Queue(%p). Couldn't find kernel\n", this, gpu_queue_);
       }
-      printf("VGPU=%p SWq=%p, HWq=%p, id=%" PRIu64
-             "\n\tDispatch Header ="
-             "0x%x (type=%d, barrier=%d, acquire=%d, release=%d), "
-             "setup=%d\n\tgrid=[%u, %u, %u], workgroup=[%u, %u, %u]\n\tprivate_seg_size=%u, "
-             "group_seg_size=%u\n\tkernel_obj=0x%" PRIx64
-             ", "
-             "kernarg_address=0x%p\n\tcompletion_signal=0x%" PRIx64
-             ", "
-             "correlation_id=%" PRIu64 "\n\trptr=%" PRIu64 ", wptr=%" PRIu64 "\n ",
-             this, gpu_queue_, gpu_queue_->base_address, gpu_queue_->id, header,
+    };
+
+    auto printHeader = [&](const char* label) {
+      fprintf(stderr, "VGPU=%p SWq=%p, HWq=%p, id=%" PRIu64 "\n\t%s Header ="
+             "0x%x (type=%d, barrier=%d, acquire=%d, release=%d), ",
+             this, gpu_queue_, gpu_queue_->base_address, gpu_queue_->id, label, header,
              extractAqlBits(header, HSA_PACKET_HEADER_TYPE, HSA_PACKET_HEADER_WIDTH_TYPE),
              extractAqlBits(header, HSA_PACKET_HEADER_BARRIER, HSA_PACKET_HEADER_WIDTH_BARRIER),
              extractAqlBits(header, HSA_PACKET_HEADER_SCACQUIRE_FENCE_SCOPE,
                             HSA_PACKET_HEADER_WIDTH_SCACQUIRE_FENCE_SCOPE),
              extractAqlBits(header, HSA_PACKET_HEADER_SCRELEASE_FENCE_SCOPE,
-                            HSA_PACKET_HEADER_WIDTH_SCRELEASE_FENCE_SCOPE),
-             0, packet.grid_size_x, packet.grid_size_y, packet.grid_size_z, packet.workgroup_size_x,
-             packet.workgroup_size_y, packet.workgroup_size_z, packet.private_segment_size,
-             packet.group_segment_size, packet.kernel_object, packet.kernarg_address,
+                            HSA_PACKET_HEADER_WIDTH_SCRELEASE_FENCE_SCOPE));
+    };
+
+    if (pkt_type == HSA_PACKET_TYPE_VENDOR_SPECIFIC) {
+      auto* vendor_hdr = reinterpret_cast<const hsa_amd_vendor_packet_header_t*>(aql_loc);
+      if (vendor_hdr->AmdFormat == HSA_AMD_PACKET_TYPE_EXT_KERNEL_DISPATCH) {
+        auto* ext = reinterpret_cast<const hsa_amd_ext_kernel_dispatch_packet_t*>(aql_loc);
+        printKernelName(ext->kernel_object);
+        printHeader("Ext Dispatch");
+        fprintf(stderr,
+               "amd_format=%d, setup=%d\n\tcluster_count=[%u, %u, %u], "
+               "cluster_size=[%u, %u, %u], workgroup=[%u, %u, %u]\n\t"
+               "private_seg_size=%u, group_seg_size=%u\n\t"
+               "kernel_obj=0x%" PRIx64 ", kernarg_address=0x%p\n\t"
+               "dep_signal=0x%" PRIx64 ", completion_signal=0x%" PRIx64
+               "\n\trptr=%" PRIu64 ", wptr=%" PRIu64 "\n",
+               (int)ext->amd_format, ext->setup,
+               ext->cluster_count_x, ext->cluster_count_y, ext->cluster_count_z,
+               ext->cluster_size_x, ext->cluster_size_y, ext->cluster_size_z,
+               ext->workgroup_size_x, ext->workgroup_size_y, ext->workgroup_size_z,
+               ext->private_segment_size, ext->group_segment_size,
+               ext->kernel_object, ext->kernarg_address,
+               ext->dep_signal.handle, ext->completion_signal.handle, read, index);
+      } else {
+        fprintf(stderr, "VGPU(%p) Queue(%p) rptr=%" PRIu64 ", wptr=%" PRIu64
+               ". Vendor packet (amd_format=%d)\n",
+               this, gpu_queue_, read, index, (int)vendor_hdr->AmdFormat);
+      }
+    } else if (pkt_type == HSA_PACKET_TYPE_KERNEL_DISPATCH ||
+               (index == read && packet.kernel_object != 0)) {
+      printKernelName(packet.kernel_object);
+      printHeader("Dispatch");
+      fprintf(stderr,
+             "setup=%d\n\tgrid=[%u, %u, %u], workgroup=[%u, %u, %u]\n\t"
+             "private_seg_size=%u, group_seg_size=%u\n\t"
+             "kernel_obj=0x%" PRIx64 ", kernarg_address=0x%p\n\t"
+             "completion_signal=0x%" PRIx64 ", correlation_id=%" PRIu64
+             "\n\trptr=%" PRIu64 ", wptr=%" PRIu64 "\n",
+             packet.setup, packet.grid_size_x, packet.grid_size_y, packet.grid_size_z,
+             packet.workgroup_size_x, packet.workgroup_size_y, packet.workgroup_size_z,
+             packet.private_segment_size, packet.group_segment_size,
+             packet.kernel_object, packet.kernarg_address,
              packet.completion_signal.handle, packet.reserved2, read, index);
     } else {
-      printf("VGPU(%p) Queue(%p) rptr=%" PRIu64 ", wptr=%" PRIu64
+      fprintf(stderr, "VGPU(%p) Queue(%p) rptr=%" PRIu64 ", wptr=%" PRIu64
              ". A barrier packet in the queue!\n",
              this, gpu_queue_, read, index);
     }
   } else {
-    printf("VGPU(%p) Queue(%p) is idle\n", this, gpu_queue_);
+    fprintf(stderr, "VGPU(%p) Queue(%p) is idle\n", this, gpu_queue_);
   }
 }
 

--- a/projects/clr/rocclr/device/rocm/rocvirtual.cpp
+++ b/projects/clr/rocclr/device/rocm/rocvirtual.cpp
@@ -1249,9 +1249,6 @@ void VirtualGPU::AnalyzeAqlQueue() const {
           gpu_queue_->base_address))[(read + valid_packet_idx) & queueMask];
       if (extractAqlBits((*aql_loc).header, HSA_PACKET_HEADER_TYPE, HSA_PACKET_HEADER_WIDTH_TYPE) ==
           HSA_PACKET_TYPE_INVALID) {
-        if (index == read) {
-          break;
-        }
         valid_packet_idx++;
       } else {
         break;
@@ -1262,7 +1259,7 @@ void VirtualGPU::AnalyzeAqlQueue() const {
       return;
     }
     auto aql_loc = &(reinterpret_cast<hsa_kernel_dispatch_packet_t*>(
-        gpu_queue_->base_address))[(scan_start + valid_packet_idx) & queueMask];
+        gpu_queue_->base_address))[(read + valid_packet_idx) & queueMask];
     auto packet = *aql_loc;
     auto header = packet.header;
     auto pkt_type = extractAqlBits(header, HSA_PACKET_HEADER_TYPE, HSA_PACKET_HEADER_WIDTH_TYPE);

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/inc/amd_aql_queue.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/inc/amd_aql_queue.h
@@ -89,8 +89,16 @@ class AqlQueue : public core::Queue, private core::LocalSignal, public core::Doo
     }
   }
 
+  /// @brief Mark this queue as having experienced a VM fault.
+  /// Called by the per-queue ExceptionHandler thread on memory-fault exceptions.
   void MarkVMFaulted() { vm_faulted_.store(true, std::memory_order_release); }
+
+  /// @brief Check whether this queue has been marked as VM-faulted.
   bool IsVMFaulted() const { return vm_faulted_.load(std::memory_order_acquire); }
+
+  /// @brief Store the fault address and reason bitmask on this queue.
+  /// Called by VMFaultHandler after it identifies which queues faulted,
+  /// so that hsa_amd_queue_get_info() can report the details.
   void SetVMFaultDetails(uint64_t address, uint32_t reason) {
     vm_fault_address_ = address;
     vm_fault_reason_ = reason;

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/inc/amd_aql_queue.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/inc/amd_aql_queue.h
@@ -80,6 +80,22 @@ class AqlQueue : public core::Queue, private core::LocalSignal, public core::Doo
   /// @brief Destroy ref counted queue
   void Destroy() override;
 
+  /// @brief Invoke the per-queue error callback if one is registered
+  /// and it is not the default handler.
+  void InvokeErrorCallback(hsa_status_t error) {
+    if (errors_callback_ != nullptr &&
+        errors_callback_ != core::Queue::DefaultErrorHandler) {
+      errors_callback_(error, public_handle(), errors_data_);
+    }
+  }
+
+  void MarkVMFaulted() { vm_faulted_.store(true, std::memory_order_release); }
+  bool IsVMFaulted() const { return vm_faulted_.load(std::memory_order_acquire); }
+  void SetVMFaultDetails(uint64_t address, uint32_t reason) {
+    vm_fault_address_ = address;
+    vm_fault_reason_ = reason;
+  }
+
   /// @brief Atomically reads the Read index of with Acquire semantics
   ///
   /// @return uint64_t Value of read index
@@ -334,6 +350,12 @@ class AqlQueue : public core::Queue, private core::LocalSignal, public core::Doo
 
   // Exception notification signal
   Signal* exception_signal_;
+
+  // Per-queue VM fault state, set by ExceptionHandler and stamped
+  // with address/reason by VMFaultHandler.
+  std::atomic<bool> vm_faulted_{false};
+  uint64_t          vm_fault_address_{0};
+  uint32_t          vm_fault_reason_{0};
 
   // CU mask lock
   std::mutex mask_lock_;

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/inc/runtime.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/inc/runtime.h
@@ -51,6 +51,8 @@
 #include <tuple>
 #include <utility>
 #include <thread>
+#include <mutex>
+#include <condition_variable>
 #include <shared_mutex>
 #include <random>
 #include <cinttypes>
@@ -459,7 +461,7 @@ class Runtime {
 
   amd::hsa::code::AmdHsaCodeManager* code_manager() { return &code_manager_; }
 
-  // Helper to iterate over allocation_map_ and add code object allocations 
+  // Helper to iterate over allocation_map_ and add code object allocations
   // to lightweight coredump filter
   void IterateCodeObjectAllocations(std::function<void(uint64_t start, size_t size)> cb) {
     std::lock_guard<std::shared_mutex> lock(memory_lock_);
@@ -923,6 +925,25 @@ class Runtime {
 
   // Kfd version
   KfdVersion_t kfd_version;
+
+  // Signaled by per-queue ExceptionHandler when it marks a queue as
+  // VM-faulted, so VMFaultHandler can wait for it before stamping details.
+  std::mutex              vm_fault_mutex_;
+  std::condition_variable vm_fault_cv_;
+  bool                    vm_fault_signaled_{false};
+
+ public:
+  void SignalVMFault() {
+    std::lock_guard<std::mutex> lock(vm_fault_mutex_);
+    vm_fault_signaled_ = true;
+    vm_fault_cv_.notify_all();
+  }
+
+  bool WaitForVMFault(int timeout_ms) {
+    std::unique_lock<std::mutex> lock(vm_fault_mutex_);
+    return vm_fault_cv_.wait_for(lock, std::chrono::milliseconds(timeout_ms),
+                                 [this] { return vm_fault_signaled_; });
+  }
 
   std::unique_ptr<AMD::SvmProfileControl> svm_profile_;
 

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/inc/runtime.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/inc/runtime.h
@@ -926,19 +926,27 @@ class Runtime {
   // Kfd version
   KfdVersion_t kfd_version;
 
-  // Signaled by per-queue ExceptionHandler when it marks a queue as
-  // VM-faulted, so VMFaultHandler can wait for it before stamping details.
+  // Synchronization between the per-queue ExceptionHandler thread and the
+  // global VMFaultHandler thread.  ExceptionHandler marks the faulting queue
+  // first (AqlQueue::MarkVMFaulted), then signals this condvar so that
+  // VMFaultHandler can stamp the fault address/reason onto the correct queue
+  // before the system-event callback fires.
   std::mutex              vm_fault_mutex_;
   std::condition_variable vm_fault_cv_;
   bool                    vm_fault_signaled_{false};
 
  public:
+  /// @brief Signal that a per-queue ExceptionHandler has marked a queue as
+  /// VM-faulted.  Wakes VMFaultHandler so it can proceed to stamp details.
   void SignalVMFault() {
     std::lock_guard<std::mutex> lock(vm_fault_mutex_);
     vm_fault_signaled_ = true;
     vm_fault_cv_.notify_all();
   }
 
+  /// @brief Block until a VM fault is signaled or the timeout expires.
+  /// @param timeout_ms Maximum time to wait in milliseconds.
+  /// @return true if a fault was signaled, false on timeout.
   bool WaitForVMFault(int timeout_ms) {
     std::unique_lock<std::mutex> lock(vm_fault_mutex_);
     return vm_fault_cv_.wait_for(lock, std::chrono::milliseconds(timeout_ms),

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_aql_queue.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_aql_queue.cpp
@@ -551,6 +551,15 @@ hsa_status_t AqlQueue::GetInfo(hsa_queue_info_attribute_t attribute, void* value
     case HSA_AMD_QUEUE_INFO_PROPERTIES:
       GetInfoProperties(reinterpret_cast<uint8_t*>(value));
       break;
+    case HSA_AMD_QUEUE_INFO_VM_FAULT_STATUS:
+      *static_cast<bool*>(value) = vm_faulted_.load(std::memory_order_acquire);
+      break;
+    case HSA_AMD_QUEUE_INFO_VM_FAULT_ADDRESS:
+      *reinterpret_cast<uint64_t*>(value) = vm_fault_address_;
+      break;
+    case HSA_AMD_QUEUE_INFO_VM_FAULT_REASON:
+      *reinterpret_cast<uint32_t*>(value) = vm_fault_reason_;
+      break;
     default:
       return HSA_STATUS_ERROR_INVALID_ARGUMENT;
   }
@@ -1426,9 +1435,11 @@ bool AqlQueue::ExceptionHandler(hsa_signal_value_t error_code, void* arg) {
   // Undefined or unexpected code
   assert((errorCode != HSA_STATUS_ERROR) && "Undefined or unexpected queue error code");
 
-  // Suppress VM fault reporting.  This is more useful when reported through the system error
-  // handler.
+  // VM fault callback is handled by VMFaultHandler. Mark this queue as
+  // faulted so VMFaultHandler can identify it and stamp fault details.
   if (errorCode == static_cast<hsa_status_t>(HSA_STATUS_ERROR_MEMORY_FAULT)) {
+    queue->MarkVMFaulted();
+    core::Runtime::runtime_singleton_->SignalVMFault();
     debug_print("Queue error - HSA_STATUS_ERROR_MEMORY_FAULT\n");
     return exceptionHandlerDone();
   }

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/runtime.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/runtime.cpp
@@ -41,6 +41,8 @@
 ////////////////////////////////////////////////////////////////////////////////
 
 #include <cassert>
+#include <chrono>
+#include <thread>
 #include <cstring>
 #include <regex>
 #include <string>
@@ -63,6 +65,7 @@
 #include "core/inc/amd_core_dump.hpp"
 #include "core/inc/amd_cpu_agent.h"
 #include "core/inc/amd_gpu_agent.h"
+#include "core/inc/amd_aql_queue.h"
 #include "core/inc/amd_memory_region.h"
 #include "core/inc/amd_topology.h"
 #include "core/inc/exceptions.h"
@@ -1410,7 +1413,7 @@ hsa_status_t Runtime::IPCCreate(void* ptr, size_t len, hsa_amd_ipc_memory_t* han
       runtime_singleton_->DmaBufClose(dmabuf_fd);
       return HSA_STATUS_ERROR;
     }
-    // Reuse token already stored on the BO 
+    // Reuse token already stored on the BO
     if (res.metadata != 0) handle->handle[7] = res.metadata;
     allocation_map_[ptr].thunk_bo = res.buf_handle;
   }
@@ -2151,6 +2154,45 @@ bool Runtime::VMFaultHandler(hsa_signal_value_t val, void* arg) {
   HsaMemoryAccessFault& fault =
       vm_fault_event->EventData.EventData.MemoryAccessFault;
 
+  // The per-queue ExceptionHandler runs on a separate thread and marks the
+  // faulting queue.  Wait for it so we can stamp address/reason onto the
+  // correct queue before the system-event callback fires.
+  if (runtime_singleton_->KfdVersion().supports_exception_debugging) {
+    runtime_singleton_->WaitForVMFault(50);
+  }
+
+  // Build the fault-reason mask once.
+  auto buildReasonMask = [](const HsaAccessAttributeFailure& f) -> uint32_t {
+    uint32_t mask = 0;
+    if (f.NotPresent == 1) mask |= HSA_AMD_MEMORY_FAULT_PAGE_NOT_PRESENT;
+    if (f.ReadOnly == 1)   mask |= HSA_AMD_MEMORY_FAULT_READ_ONLY;
+    if (f.NoExecute == 1)  mask |= HSA_AMD_MEMORY_FAULT_NX;
+    if (f.GpuAccess == 1)  mask |= HSA_AMD_MEMORY_FAULT_HOST_ONLY;
+    if (f.Imprecise == 1)  mask |= HSA_AMD_MEMORY_FAULT_IMPRECISE;
+    if (f.ECC == 1 && f.ErrorType == 0) mask |= HSA_AMD_MEMORY_FAULT_DRAMECC;
+    if (f.ErrorType == 1)  mask |= HSA_AMD_MEMORY_FAULT_SRAMECC;
+    if (f.ErrorType == 2)  mask |= HSA_AMD_MEMORY_FAULT_DRAMECC;
+    if (f.ErrorType == 3)  mask |= HSA_AMD_MEMORY_FAULT_HANG;
+    return mask;
+  };
+  uint32_t reason_mask = buildReasonMask(fault.Failure);
+
+  // Stamp fault address and reason onto any queues that ExceptionHandler
+  // marked as faulted on this agent.
+  auto node_it = runtime_singleton_->agents_by_node_.find(fault.NodeId);
+  if (node_it != runtime_singleton_->agents_by_node_.end()) {
+    Agent* agent = node_it->second.front();
+    if (agent->device_type() == Agent::DeviceType::kAmdGpuDevice) {
+      AMD::GpuAgent* gpu_agent = static_cast<AMD::GpuAgent*>(agent);
+      for (auto* q : gpu_agent->GetAqlQueues()) {
+        auto* aql_q = static_cast<AMD::AqlQueue*>(q);
+        if (aql_q->IsVMFaulted()) {
+          aql_q->SetVMFaultDetails(fault.VirtualAddress, reason_mask);
+        }
+      }
+    }
+  }
+
   hsa_status_t custom_handler_status = HSA_STATUS_ERROR;
   auto system_event_handlers = runtime_singleton_->GetSystemEventHandlers();
   Agent* faulty_agent = nullptr;
@@ -2167,34 +2209,7 @@ bool Runtime::VMFaultHandler(hsa_signal_value_t val, void* arg) {
     fault_info.agent = Agent::Convert(faulty_agent);
 
     fault_info.virtual_address = fault.VirtualAddress;
-    fault_info.fault_reason_mask = 0;
-    if (fault.Failure.NotPresent == 1) {
-      fault_info.fault_reason_mask |= HSA_AMD_MEMORY_FAULT_PAGE_NOT_PRESENT;
-    }
-    if (fault.Failure.ReadOnly == 1) {
-      fault_info.fault_reason_mask |= HSA_AMD_MEMORY_FAULT_READ_ONLY;
-    }
-    if (fault.Failure.NoExecute == 1) {
-      fault_info.fault_reason_mask |= HSA_AMD_MEMORY_FAULT_NX;
-    }
-    if (fault.Failure.GpuAccess == 1) {
-      fault_info.fault_reason_mask |= HSA_AMD_MEMORY_FAULT_HOST_ONLY;
-    }
-    if (fault.Failure.Imprecise == 1) {
-      fault_info.fault_reason_mask |= HSA_AMD_MEMORY_FAULT_IMPRECISE;
-    }
-    if (fault.Failure.ECC == 1 && fault.Failure.ErrorType == 0) {
-      fault_info.fault_reason_mask |= HSA_AMD_MEMORY_FAULT_DRAMECC;
-    }
-    if (fault.Failure.ErrorType == 1) {
-      fault_info.fault_reason_mask |= HSA_AMD_MEMORY_FAULT_SRAMECC;
-    }
-    if (fault.Failure.ErrorType == 2) {
-      fault_info.fault_reason_mask |= HSA_AMD_MEMORY_FAULT_DRAMECC;
-    }
-    if (fault.Failure.ErrorType == 3) {
-      fault_info.fault_reason_mask |= HSA_AMD_MEMORY_FAULT_HANG;
-    }
+    fault_info.fault_reason_mask = reason_mask;
 
     for (auto& callback : system_event_handlers) {
       hsa_status_t err = callback.first(&memory_fault_event, callback.second);
@@ -3440,7 +3455,7 @@ hsa_status_t Runtime::SvmBatchDiscard(void** ptrs, size_t* sizes, uint32_t count
   return HSA_STATUS_ERROR;
 #else
   const size_t kPageSize = os::PageSize();
-  
+
   // Get a CPU agent for migration target
   if (cpu_agents().empty()) return HSA_STATUS_ERROR;
 
@@ -3453,7 +3468,7 @@ hsa_status_t Runtime::SvmBatchDiscard(void** ptrs, size_t* sizes, uint32_t count
       debug_warning(false && "Retrieving SVM pointer information failed");
       return status;
     }
-    
+
     // Only SVM allocations that were reserved using hsa_amd_vmem_address_reserve are valid for discard
     if (ptr_info.type != HSA_EXT_POINTER_TYPE_RESERVED_ADDR || ptr_info.registered) {
       return HSA_STATUS_ERROR_INVALID_ARGUMENT;
@@ -3470,7 +3485,7 @@ hsa_status_t Runtime::SvmBatchDiscard(void** ptrs, size_t* sizes, uint32_t count
 
   DiscardOp* op = new DiscardOp();
   MAKE_NAMED_SCOPE_GUARD(OpGuard, [&]() { delete op; });
-  
+
   // Prepare memory regions with page alignment and store target cpu agent for each region
   op->regions.reserve(count);
   op->target_cpus.reserve(count);
@@ -3491,10 +3506,10 @@ hsa_status_t Runtime::SvmBatchDiscard(void** ptrs, size_t* sizes, uint32_t count
     AMD::CpuAgent* cpu = nullptr;
     HSAKMT_STATUS status = HSAKMT_CALL(hsaKmtSVMGetAttr(base, len, 1, &attr));
 
-    if (status == HSAKMT_STATUS_SUCCESS && 
+    if (status == HSAKMT_STATUS_SUCCESS &&
         (attr.value != 0xFFFFFFFF && attr.value != INVALID_NODEID)) {
       core::Agent* agent = agents_by_node_[attr.value][0];
-      
+
       if (agent->device_type() == core::Agent::kAmdCpuDevice) {
         // Already on a CPU agent; skip prefetch for this region
         op->target_cpus.push_back(UINT32_MAX);
@@ -3553,7 +3568,7 @@ hsa_status_t Runtime::SvmBatchDiscard(void** ptrs, size_t* sizes, uint32_t count
     delete op;
   };
 
-  /* Each pending dep signal calls this handler when it reaches 0. 
+  /* Each pending dep signal calls this handler when it reaches 0.
   The last one to decrement remaining_deps to 0 will triggers the discard. */
   static hsa_amd_signal_handler signal_handler = [](hsa_signal_value_t value, void* arg) {
     DiscardOp* op = reinterpret_cast<DiscardOp*>(arg);
@@ -3577,15 +3592,15 @@ hsa_status_t Runtime::SvmBatchDiscard(void** ptrs, size_t* sizes, uint32_t count
     op->remaining_deps.store(static_cast<uint32_t>(pending_deps.size()),
                              std::memory_order_release);
     for (size_t i = 0; i < pending_deps.size(); i++) {
-      /* SetAsyncSignalHandler currently always returns HSA_STATUS_SUCCESS. If it is modified to 
-      return errors in the future, we need to handle the possibility of use-after-free and double deletion 
+      /* SetAsyncSignalHandler currently always returns HSA_STATUS_SUCCESS. If it is modified to
+      return errors in the future, we need to handle the possibility of use-after-free and double deletion
       of op if this call fails midway and leaves some handlers set but not others. */
       SetAsyncSignalHandler(pending_deps[i], HSA_SIGNAL_CONDITION_EQ, 0, signal_handler, op);
     }
   }
 
   OpGuard.Dismiss();
-  return HSA_STATUS_SUCCESS;  
+  return HSA_STATUS_SUCCESS;
 #endif
 }
 

--- a/projects/rocr-runtime/runtime/hsa-runtime/inc/hsa_ext_amd.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/inc/hsa_ext_amd.h
@@ -72,6 +72,7 @@
  * - 1.19 - hsa_amd_agent_preload
  * - 1.20 - Memory batch discard API: hsa_amd_svm_discard_batch_async
  * - 1.21 - hsa_amd_signal_get_event_id
+ * - 1.22 - hsa_amd_queue_get_info: per-queue VM fault state queries
  */
 #define HSA_AMD_INTERFACE_VERSION_MAJOR 1
 #define HSA_AMD_INTERFACE_VERSION_MINOR 21
@@ -4326,6 +4327,28 @@ typedef enum {
    * The type of this attribute is uint8_t[8].
    */
   HSA_AMD_QUEUE_INFO_PROPERTIES,
+
+  /*
+   * Per-queue VM fault state — populated after a GPU memory fault.
+   */
+
+  /*
+   * Whether this queue has experienced a VM fault.
+   * The type of this attribute is bool.
+   */
+  HSA_AMD_QUEUE_INFO_VM_FAULT_STATUS,
+  /*
+   * The virtual address that caused the VM fault on this queue.
+   * Only valid when HSA_AMD_QUEUE_INFO_VM_FAULT_STATUS is true.
+   * The type of this attribute is uint64_t.
+   */
+  HSA_AMD_QUEUE_INFO_VM_FAULT_ADDRESS,
+  /*
+   * A bitmask of HSA_AMD_MEMORY_FAULT_* flags describing the reason for the
+   * VM fault on this queue.  Only valid when HSA_AMD_QUEUE_INFO_VM_FAULT_STATUS
+   * is true.  The type of this attribute is uint32_t.
+   */
+  HSA_AMD_QUEUE_INFO_VM_FAULT_REASON,
 } hsa_queue_info_attribute_t;
 
 hsa_status_t hsa_amd_queue_get_info(hsa_queue_t* queue, hsa_queue_info_attribute_t attribute,


### PR DESCRIPTION
- ExceptionHandler marks the faulting queue (MarkVMFaulted) and signals
  a condvar so VMFaultHandler can wait for it reliably instead of
  polling.
- VMFaultHandler stamps fault address and reason onto each faulted
  queue via SetVMFaultDetails, then reuses the same reason mask for
  the system-event callback (eliminating duplicate computation).
- New hsa_queue_info_attribute_t enums:
    HSA_AMD_QUEUE_INFO_VM_FAULT_STATUS  (bool)
    HSA_AMD_QUEUE_INFO_VM_FAULT_ADDRESS (uint64_t)
    HSA_AMD_QUEUE_INFO_VM_FAULT_REASON  (uint32_t)
  These extend the existing hsa_amd_queue_get_info() API; no new
  public function or symbol is introduced.
- CLR BackendErrorCallBackHandler queries per-queue fault status to
  drive AnalyzeAqlQueue() only on faulted queues, correctly handling
  the case of multiple simultaneous queue faults.

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
