### PR TITLE
[ROCM-9294] Fix bitmask validation in rsmi_dev_gpu_clk_freq_set to exclude deep sleep from DPM levels

### DIFF
--- a/projects/amdsmi/rocm_smi/src/rocm_smi.cc
+++ b/projects/amdsmi/rocm_smi/src/rocm_smi.cc
@@ -2108,14 +2108,18 @@ rsmi_status_t rsmi_dev_gpu_clk_freq_set(uint32_t dv_ind, rsmi_clk_type_t clk_typ
     return RSMI_STATUS_UNEXPECTED_SIZE;
   }
 
-  // Deep sleep entry is not a real DPM level; exclude it from valid bitmask
+  // Deep sleep entry (index 0 in pp_dpm_sclk marked with 'S') is not a real
+  // DPM level; subtract it from the valid count so the bitmask only covers
+  // actual DPM levels.  Bitmask bit i maps to sysfs DPM level i, which
+  // corresponds to freqs.frequency[i] when has_deep_sleep is false, or
+  // freqs.frequency[i+1] when has_deep_sleep is true.
   if (freqs.num_supported > 0) {
     uint32_t max_levels = freqs.num_supported;
-    if (freqs.has_deep_sleep && max_levels > 0) {
+    if (freqs.has_deep_sleep) {
       max_levels--;
     }
     uint64_t valid_mask = (max_levels > 0) ? (1ULL << max_levels) - 1 : 0;
-    if (freq_bitmask & ~valid_mask) {
+    if (freq_bitmask == 0 || (freq_bitmask & ~valid_mask)) {
       return RSMI_STATUS_INVALID_ARGS;
     }
   }
@@ -2137,6 +2141,9 @@ rsmi_status_t rsmi_dev_gpu_clk_freq_set(uint32_t dv_ind, rsmi_clk_type_t clk_typ
     return RSMI_STATUS_NOT_SUPPORTED;
   }
 
+  // bitfield_to_freq_string iterates [0, num_supported), but the validation
+  // above already guarantees no bits are set beyond the valid DPM range, so
+  // the extra iteration over the deep sleep index (if present) is harmless.
   std::string freq_enable_str = bitfield_to_freq_string(freq_bitmask, freqs.num_supported);
 
   ret = rsmi_dev_perf_level_set_v1(dv_ind, RSMI_DEV_PERF_LEVEL_MANUAL);

--- a/projects/amdsmi/rocm_smi/src/rocm_smi.cc
+++ b/projects/amdsmi/rocm_smi/src/rocm_smi.cc
@@ -2089,6 +2089,14 @@ rsmi_status_t rsmi_dev_gpu_clk_freq_set(uint32_t dv_ind, rsmi_clk_type_t clk_typ
     return RSMI_STATUS_INVALID_ARGS;
   }
 
+  amd::smi::DevInfoTypes dev_type;
+  const auto& clk_type_it = kClkTypeMap.find(clk_type);
+  if (clk_type_it != kClkTypeMap.end()) {
+    dev_type = clk_type_it->second;
+  } else {
+    return RSMI_STATUS_INVALID_ARGS;
+  }
+
   ret = rsmi_dev_gpu_clk_freq_get(dv_ind, clk_type, &freqs);
 
   if (ret != RSMI_STATUS_SUCCESS) {
@@ -2100,16 +2108,36 @@ rsmi_status_t rsmi_dev_gpu_clk_freq_set(uint32_t dv_ind, rsmi_clk_type_t clk_typ
     return RSMI_STATUS_UNEXPECTED_SIZE;
   }
 
+  // Deep sleep entry is not a real DPM level; exclude it from valid bitmask
+  if (freqs.num_supported > 0) {
+    uint32_t max_levels = freqs.num_supported;
+    if (freqs.has_deep_sleep && max_levels > 0) {
+      max_levels--;
+    }
+    uint64_t valid_mask = (max_levels > 0) ? (1ULL << max_levels) - 1 : 0;
+    if (freq_bitmask & ~valid_mask) {
+      return RSMI_STATUS_INVALID_ARGS;
+    }
+  }
+
   amd::smi::RocmSMI& smi = amd::smi::RocmSMI::getInstance();
 
   // Above call to rsmi_dev_get_gpu_clk_freq should have emitted an error if
   // assert below is not true
   assert(dv_ind < smi.devices().size());
 
-  std::string freq_enable_str = bitfield_to_freq_string(freq_bitmask, freqs.num_supported);
-
   std::shared_ptr<amd::smi::Device> dev = smi.devices()[dv_ind];
   assert(dev != nullptr);
+
+  // If the sysfs node is read-only, force DPM level is not supported
+  std::string sysfs_path = dev->get_sys_file_path_by_type(dev_type, true);
+  bool read_only = false;
+  amd::smi::isReadOnlyForAll(sysfs_path, &read_only);
+  if (read_only) {
+    return RSMI_STATUS_NOT_SUPPORTED;
+  }
+
+  std::string freq_enable_str = bitfield_to_freq_string(freq_bitmask, freqs.num_supported);
 
   ret = rsmi_dev_perf_level_set_v1(dv_ind, RSMI_DEV_PERF_LEVEL_MANUAL);
   if (ret != RSMI_STATUS_SUCCESS) {
@@ -2117,24 +2145,12 @@ rsmi_status_t rsmi_dev_gpu_clk_freq_set(uint32_t dv_ind, rsmi_clk_type_t clk_typ
   }
 
   rsmi_status_t status;
-  amd::smi::DevInfoTypes dev_type;
-
-  const auto& clk_type_it = kClkTypeMap.find(clk_type);
-  if (clk_type_it != kClkTypeMap.end()) {
-    dev_type = clk_type_it->second;
-  } else {
-    return RSMI_STATUS_INVALID_ARGS;
-  }
-
   status = amd::smi::ErrnoToRsmiStatus(dev->writeDevInfo(dev_type, freq_enable_str));
 
-  // If an operation is not supported, the dev file, ie /sys/class/drm/card1/device/pp_dpm_pcie
-  // will have read-only perms, and the OS will deny access, before the request hits the driver
-  // level
   if (status == RSMI_STATUS_PERMISSION) {
-    bool read_only = false;
-    amd::smi::isReadOnlyForAll(dev->path(), &read_only);
-    if (read_only) {
+    bool post_read_only = false;
+    amd::smi::isReadOnlyForAll(sysfs_path, &post_read_only);
+    if (post_read_only) {
       return RSMI_STATUS_NOT_SUPPORTED;
     }
   }

--- a/projects/amdsmi/rocm_smi/src/rocm_smi.cc
+++ b/projects/amdsmi/rocm_smi/src/rocm_smi.cc
@@ -2136,7 +2136,10 @@ rsmi_status_t rsmi_dev_gpu_clk_freq_set(uint32_t dv_ind, rsmi_clk_type_t clk_typ
   // If the sysfs node is read-only, force DPM level is not supported
   std::string sysfs_path = dev->get_sys_file_path_by_type(dev_type, true);
   bool read_only = false;
-  amd::smi::isReadOnlyForAll(sysfs_path, &read_only);
+  int ro_ret = amd::smi::isReadOnlyForAll(sysfs_path, &read_only);
+  if (ro_ret != 0) {
+    return amd::smi::ErrnoToRsmiStatus(ro_ret);
+  }
   if (read_only) {
     return RSMI_STATUS_NOT_SUPPORTED;
   }

--- a/projects/amdsmi/tests/amd_smi_test/functional/frequencies_read_write.cc
+++ b/projects/amdsmi/tests/amd_smi_test/functional/frequencies_read_write.cc
@@ -132,7 +132,26 @@ void TestFrequenciesReadWrite::Run(void) {
         // Skip AMDSMI_CLK_TYPE_PCIE, which does not supported in rocm-smi.
         if (amdsmi_clk == AMDSMI_CLK_TYPE_PCIE) return;
 
-        freq_bitmask = 0b01100;  // Try the 3rd and 4th clocks
+        // Build the bitmask dynamically based on reported DPM levels.
+        // The deep sleep entry (if present) is not a valid DPM level,
+        // so exclude it from the count to stay within the valid range.
+        uint32_t dpm_levels = f.num_supported;
+        if (f.has_deep_sleep && dpm_levels > 0) {
+          dpm_levels--;
+        }
+
+        if (dpm_levels < 2) {
+          // Not enough DPM levels to test a non-trivial bitmask; skip.
+          IF_VERB(STANDARD) {
+            std::cout << "\t**Set " << FreqEnumToStr(amdsmi_clk)
+                      << ": Only " << dpm_levels
+                      << " DPM level(s), skipping write test." << std::endl;
+          }
+          return;
+        }
+
+        // Pick two valid DPM levels: the second-to-last and the last.
+        freq_bitmask = (1u << (dpm_levels - 2)) | (1u << (dpm_levels - 1));
 
         std::string freq_bm_str = std::bitset<AMDSMI_MAX_NUM_FREQUENCIES>(freq_bitmask).to_string();
 
@@ -171,8 +190,15 @@ void TestFrequenciesReadWrite::Run(void) {
           std::cout << "Frequency is now index " << f.current << std::endl;
           std::cout << "Resetting mask to all frequencies." << std::endl;
         }
+        // Build a valid "all DPM levels" bitmask instead of 0xFFFFFFFF,
+        // which would be rejected since it has bits beyond valid range.
+        uint32_t reset_levels = f.num_supported;
+        if (f.has_deep_sleep && reset_levels > 0) {
+          reset_levels--;
+        }
+        uint64_t all_levels_mask = (reset_levels > 0) ? (1ULL << reset_levels) - 1 : 0;
         DISPLAY_AMDSMI_API("amdsmi_set_clk_freq", "gpu=" + std::to_string(dv_ind), VERB(STANDARD));
-        ret = amdsmi_set_clk_freq(processor_handles_[dv_ind], amdsmi_clk, 0xFFFFFFFF);
+        ret = amdsmi_set_clk_freq(processor_handles_[dv_ind], amdsmi_clk, all_levels_mask);
         DISPLAY_AMDSMI_STATUS(VERB(STANDARD), __FILE__, __LINE__, ret, AMDSMI_STATUS_SUCCESS);
         if (ret == AMDSMI_STATUS_NOT_SUPPORTED) {
           ret = AMDSMI_STATUS_SUCCESS;

--- a/projects/amdsmi/tests/amd_smi_test/functional/frequencies_read_write.cc
+++ b/projects/amdsmi/tests/amd_smi_test/functional/frequencies_read_write.cc
@@ -64,7 +64,7 @@ void TestFrequenciesReadWrite::Close() {
 void TestFrequenciesReadWrite::Run(void) {
   amdsmi_status_t ret;
   amdsmi_frequencies_t f;
-  uint32_t freq_bitmask;
+  uint64_t freq_bitmask;
   amdsmi_clk_type_t amdsmi_clk;
   const std::map<amdsmi_clk_type_t, std::string> clk_type_map = {
       {AMDSMI_CLK_TYPE_SYS, "SYS"},     {AMDSMI_CLK_TYPE_GFX, "GFX"},
@@ -150,7 +150,7 @@ void TestFrequenciesReadWrite::Run(void) {
         }
 
         // Pick two valid DPM levels: the second-to-last and the last.
-        freq_bitmask = (1u << (dpm_levels - 2)) | (1u << (dpm_levels - 1));
+        freq_bitmask = (1ULL << (dpm_levels - 2)) | (1ULL << (dpm_levels - 1));
 
         std::string freq_bm_str = std::bitset<AMDSMI_MAX_NUM_FREQUENCIES>(freq_bitmask).to_string();
 

--- a/projects/amdsmi/tests/amd_smi_test/functional/frequencies_read_write.cc
+++ b/projects/amdsmi/tests/amd_smi_test/functional/frequencies_read_write.cc
@@ -143,8 +143,7 @@ void TestFrequenciesReadWrite::Run(void) {
         if (dpm_levels < 2) {
           // Not enough DPM levels to test a non-trivial bitmask; skip.
           IF_VERB(STANDARD) {
-            std::cout << "\t**Set " << FreqEnumToStr(amdsmi_clk)
-                      << ": Only " << dpm_levels
+            std::cout << "\t**Set " << FreqEnumToStr(amdsmi_clk) << ": Only " << dpm_levels
                       << " DPM level(s), skipping write test." << std::endl;
           }
           return;


### PR DESCRIPTION

## Motivation

Prevent the sporadic "Clock level specified 2 is over max allowed 1" kernel error in dmesg on MI300/MI325 during AGFHC/RVS tests.

## Technical Details

Added bitmask validation in rsmi_dev_gpu_clk_freq_set() that accounts for the deep sleep entry in pp_dpm_sclk, so invalid clock levels are rejected before reaching the kernel.
## JIRA ID

[ROCM-9294]

## Test Plan

Tested on MI300X hardware by calling rsmi_dev_gpu_clk_freq_set with bitmask 0x7 using both unpatched and patched library, then checked dmesg for kernel errors.
## Test Result

Unpatched library triggers Clock level specified 2 is over max allowed 1 in dmesg; patched library returns RSMI_STATUS_INVALID_ARGS with clean dmesg, and valid bitmask 0x3 still works fine.
## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.


[ROCM-9294]: https://amd-hub.atlassian.net/browse/ROCM-9294?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ