### PR TITLE
feat(clr) Add optional RPC support to the HIP runtime

### DIFF
--- a/projects/clr/rocclr/cmake/ROCclr.cmake
+++ b/projects/clr/rocclr/cmake/ROCclr.cmake
@@ -48,6 +48,7 @@ target_sources(rocclr PRIVATE
   ${ROCCLR_SRC_DIR}/device/devhcmessages.cpp
   ${ROCCLR_SRC_DIR}/device/devhcprintf.cpp
   ${ROCCLR_SRC_DIR}/device/devhostcall.cpp
+  ${ROCCLR_SRC_DIR}/device/devrpc.cpp
   ${ROCCLR_SRC_DIR}/device/device.cpp
   ${ROCCLR_SRC_DIR}/device/devkernel.cpp
   ${ROCCLR_SRC_DIR}/device/devprogram.cpp
@@ -127,6 +128,13 @@ target_include_directories(rocclr PUBLIC
   ${ROCCLR_SRC_DIR}/elf
   ${ROCCLR_SRC_DIR}/include
   ${AMD_OPENCL_INCLUDE_DIRS})
+
+# Add the compiler's LLVM libc shared include directory for the RPC interface.
+# The headers live at <compiler_bin>/../include/shared/rpc*.h.
+get_filename_component(_COMPILER_BIN_DIR "${CMAKE_CXX_COMPILER}" DIRECTORY)
+get_filename_component(_RPC_INCLUDE_DIR "${_COMPILER_BIN_DIR}/../include" REALPATH)
+set_source_files_properties(${ROCCLR_SRC_DIR}/device/devrpc.cpp PROPERTIES
+  COMPILE_OPTIONS "-I${_RPC_INCLUDE_DIR}")
 
 target_link_libraries(rocclr PUBLIC Threads::Threads)
 # IPC on Windows is not supported

--- a/projects/clr/rocclr/device/devhostcall.cpp
+++ b/projects/clr/rocclr/device/devhostcall.cpp
@@ -10,6 +10,7 @@
 
 #include "device/devhcmessages.hpp"
 #include "device/devhostcall.hpp"
+#include "device/devrpc.hpp"
 #include "device/devsignal.hpp"
 
 #include "os/os.hpp"
@@ -323,7 +324,9 @@ void HostcallBuffer::initialize(uint32_t num_packets) {
  */
 class HostcallListener {
   std::set<HostcallBuffer*> buffers_;
-  device::Signal* doorbell_;
+  std::set<RpcBufferInfo*> rpc_buffers_;
+  device::Signal* doorbell_ = nullptr;
+  device::Signal* rpc_doorbell_ = nullptr;
   MessageHandler messages_;
   // Keep track of devices for which signal creation have already been done
   std::set<const amd::Device*> devices_;
@@ -365,7 +368,10 @@ class HostcallListener {
 
   /* \brief Return true if no buffers are registered.
    */
-  bool idle() const { return buffers_.empty(); }
+  void addRpcBuffer(RpcBufferInfo* info);
+  void removeRpcBufferByPtr(void* raw);
+  void flushRpcBufferByPtr(void* raw);
+  bool idle() const { return buffers_.empty() && rpc_buffers_.empty(); }
 
   void terminate();
   bool initSignal(const amd::Device& dev);
@@ -410,6 +416,7 @@ void HostcallListener::consumePackets() {
     }
 
     ProcessResult result = ProcessResult::kIdleFull;
+    bool rpc_busy = false;
     {
       amd::ScopedLock lock{listenerLock};
       for (auto buf : buffers_) {
@@ -420,9 +427,12 @@ void HostcallListener::consumePackets() {
           buf->resetScanLimit();
         }
       }
+      for (auto info : rpc_buffers_) {
+        rpc_busy |= processRpcBuffer(info);
+      }
     }
 
-    if (result != ProcessResult::kIdleFull) {
+    if (result != ProcessResult::kIdleFull || rpc_busy) {
       if (++yield_spins >= kYieldSpins) {
         yield_spins = 0;
         amd::Os::yield();
@@ -431,6 +441,11 @@ void HostcallListener::consumePackets() {
     }
 
     yield_spins = 0;
+    // RPC and hostcall use separate doorbells.
+    if (!rpc_buffers_.empty()) {
+      rpc_doorbell_->Wait(0, device::Signal::Condition::Ne, kSignalTimeout);
+      continue;
+    }
     uint64_t new_value =
         doorbell_->Wait(signal_value, device::Signal::Condition::Ne, kSignalTimeout);
     if (new_value != signal_value) {
@@ -452,17 +467,31 @@ void HostcallListener::consumePackets() {
         kHostThreadActive.state = Init::State::kExit;
         return;
       }
-      uint64_t new_value = doorbell_->Wait(signal_value, device::Signal::Condition::Ne, timeout);
-      if (new_value != signal_value) {
-        signal_value = new_value;
-        // Reduce the timeout for quicker processing
-        timeout = timeout >> 0x1;
-        timeout = std::max(kTimeoutFloor, timeout);
+
+      bool have_hostcall = !buffers_.empty();
+      bool have_rpc = !rpc_buffers_.empty();
+
+      if (have_hostcall && !have_rpc) {
+        uint64_t new_value = doorbell_->Wait(signal_value, device::Signal::Condition::Ne, timeout);
+        if (new_value != signal_value) {
+          signal_value = new_value;
+          timeout = std::max(kTimeoutFloor, timeout >> 1);
+          break;
+        }
+        timeout = std::min(kTimeoutCeil, timeout << 1);
+      } else if (!have_hostcall && have_rpc) {
+        // RPC only — block until the device increments the doorbell.
+        rpc_doorbell_->Wait(0, device::Signal::Condition::Ne, timeout);
+        timeout = std::min(kTimeoutCeil, timeout << 1);
+        break;
+      } else {
+        uint64_t new_value =
+            doorbell_->Wait(signal_value, device::Signal::Condition::Ne, kTimeoutFloor);
+        if (new_value != signal_value) {
+          signal_value = new_value;
+        }
         break;
       }
-      // Increase the timeout since we dont need to check as frequently
-      timeout = timeout << 0x1;
-      timeout = std::min(kTimeoutCeil, timeout);
     }
 
     if (signal_value == SIGNAL_DONE) {
@@ -475,6 +504,9 @@ void HostcallListener::consumePackets() {
       for (auto ii : buffers_) {
         ii->processPackets(messages_);
       }
+      for (auto ii : rpc_buffers_) {
+        processRpcBuffer(ii);
+      }
     }
   }
 
@@ -484,8 +516,9 @@ void HostcallListener::consumePackets() {
 
 void HostcallListener::terminate() {
   if (thread_.state() >= Thread::FINISHED || amd::Os::isThreadAlive(thread_)) {
-    kHostThreadActive.state = Init::State::kExit;
+    kHostThreadActive.state = Init::State::kDestroy;
     doorbell_->Reset(SIGNAL_DONE);
+    if (rpc_doorbell_) rpc_doorbell_->Reset(1);
 
     // FIXME_lmoriche: fix termination handshake
     while (thread_.state() < Thread::FINISHED) {
@@ -498,6 +531,7 @@ void HostcallListener::terminate() {
   delete urilocator;
 #endif
 #endif
+  delete rpc_doorbell_;
   delete doorbell_;
   devices_.clear();
 }
@@ -516,6 +550,40 @@ void HostcallListener::addBuffer(HostcallBuffer* buffer) {
 void HostcallListener::removeBuffer(HostcallBuffer* buffer) {
   assert(buffers_.count(buffer) != 0 && "unknown buffer");
   buffers_.erase(buffer);
+}
+
+void HostcallListener::addRpcBuffer(RpcBufferInfo* info) {
+  info->messages = &messages_;
+  if (!rpc_doorbell_) {
+    rpc_doorbell_ = info->device->createSignal();
+#if defined(WITH_PAL_DEVICE) && !defined(_WIN32)
+    auto ws = device::Signal::WaitState::Active;
+#else
+    auto ws = device::Signal::WaitState::Blocked;
+#endif
+    rpc_doorbell_->Init(*info->device, 0, ws);
+  }
+  initRpcDoorbell(info->buffer, rpc_doorbell_->getHandle());
+  rpc_buffers_.insert(info);
+}
+
+void HostcallListener::removeRpcBufferByPtr(void* raw) {
+  for (auto* b : rpc_buffers_) {
+    if (b->buffer == raw) {
+      rpc_buffers_.erase(b);
+      delete b;
+      return;
+    }
+  }
+}
+
+void HostcallListener::flushRpcBufferByPtr(void* raw) {
+  for (auto* b : rpc_buffers_) {
+    if (b->buffer == raw) {
+      flushRpcBuffer(b);
+      return;
+    }
+  }
 }
 
 bool HostcallListener::initSignal(const amd::Device& dev) {
@@ -682,4 +750,61 @@ void disableHostcalls(void* bfr) {
   }
 }
 #endif  // USE_NEW_HOSTCALL_IMPL
+
+bool enableRpc(const amd::Device& dev, void* bfr, uint32_t num_ports) {
+  auto* info = new RpcBufferInfo{bfr, dev.info().wavefrontWidth_, num_ports, &dev};
+
+  amd::ScopedLock lock(listenerLock);
+  if (!hostcallListener) {
+    hostcallListener = new HostcallListener();
+    if (!hostcallListener->initSignal(dev)) {
+      ClPrint(amd::LOG_ERROR, (amd::LOG_INIT | amd::LOG_QUEUE | amd::LOG_RESOURCE),
+              "Failed to launch hostcall listener for RPC");
+      delete hostcallListener;
+      hostcallListener = nullptr;
+      delete info;
+      return false;
+    }
+    ClPrint(amd::LOG_INFO, (amd::LOG_INIT | amd::LOG_QUEUE | amd::LOG_RESOURCE),
+            "Launched hostcall listener at %p (for RPC)", hostcallListener);
+  }
+#if defined(WITH_PAL_DEVICE)
+  else if (!hostcallListener->initDevice(dev)) {
+    ClPrint(amd::LOG_ERROR, (amd::LOG_INIT | amd::LOG_QUEUE | amd::LOG_RESOURCE),
+            "failed to initialize device for RPC");
+    delete info;
+    return false;
+  }
+#endif
+  hostcallListener->addRpcBuffer(info);
+  ClPrint(amd::LOG_INFO, amd::LOG_QUEUE, "Registered RPC buffer %p with listener %p", bfr,
+          hostcallListener);
+  return true;
+}
+
+void flushRpc(void* bfr) {
+  amd::ScopedLock lock(listenerLock);
+  if (!hostcallListener) {
+    return;
+  }
+  assert(bfr && "expected an RPC buffer");
+  hostcallListener->flushRpcBufferByPtr(bfr);
+}
+
+void disableRpc(void* bfr) {
+  {
+    amd::ScopedLock lock(listenerLock);
+    if (!hostcallListener) {
+      return;
+    }
+    assert(bfr && "expected an RPC buffer");
+    hostcallListener->removeRpcBufferByPtr(bfr);
+  }
+  if (hostcallListener->idle()) {
+    hostcallListener->terminate();
+    delete hostcallListener;
+    hostcallListener = nullptr;
+    ClPrint(amd::LOG_INFO, amd::LOG_INIT, "Terminated hostcall listener");
+  }
+}
 }  // namespace amd

--- a/projects/clr/rocclr/device/devhostcall.hpp
+++ b/projects/clr/rocclr/device/devhostcall.hpp
@@ -80,6 +80,10 @@ bool enableHostcalls(const amd::Device& dev, void* buffer, uint32_t numPackets);
 #endif  // USE_NEW_HOSTCALL_IMPL
 void disableHostcalls(void* buffer);
 
+bool enableRpc(const amd::Device& dev, void* buffer, uint32_t num_ports);
+void flushRpc(void* buffer);
+void disableRpc(void* buffer);
+
 enum SignalValue { SIGNAL_DONE = 0, SIGNAL_INIT = 1 };
 
 /** \brief Packet payload

--- a/projects/clr/rocclr/device/devrpc.cpp
+++ b/projects/clr/rocclr/device/devrpc.cpp
@@ -1,0 +1,241 @@
+/*
+ * Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#include "device/devrpc.hpp"
+
+#if __has_include("shared/rpc.h")
+
+#include "utils/debug.hpp"
+#include "top.hpp"
+
+#include "device/devhcmessages.hpp"
+
+#if defined(__clang__)
+#if __has_feature(address_sanitizer)
+#include "device/devsanitizer.hpp"
+#endif
+#endif
+
+#include <cstring>
+
+#include "shared/rpc.h"
+#include "shared/rpc_opcodes.h"
+#include "shared/rpc_server.h"
+
+namespace amd {
+
+bool rpcAvailable() { return true; }
+
+size_t getRpcBufferSize(uint32_t num_lanes, uint32_t num_ports) {
+  return rpc::Server::allocation_size(num_lanes, num_ports);
+}
+
+static rpc::RPCStatus handleClrOpcodes(rpc::Server::Port& port, const amd::Device& dev,
+                                       MessageHandler& messages) {
+  switch (port.get_opcode()) {
+    case LIBC_MALLOC: {
+      port.recv_and_send([&](rpc::Buffer* Buffer, uint32_t) {
+        amd::Context& ctx = dev.context();
+        uint64_t size = Buffer->data[0];
+        constexpr size_t kLargePageAlign = 2 * Mi;
+        amd::Buffer* buf =
+            new (ctx) amd::Buffer(ctx, CL_MEM_READ_WRITE, size, nullptr, kLargePageAlign);
+        uintptr_t va = 0;
+        if (buf && buf->create()) {
+          va = buf->getDeviceMemory(dev)->virtualAddress();
+          amd::MemObjMap::AddMemObj(reinterpret_cast<void*>(va), buf);
+          const_cast<amd::Device*>(&dev)->TrackHostcallMemory(buf);
+        } else if (buf) {
+          buf->release();
+        }
+        Buffer->data[0] = va;
+      });
+      break;
+    }
+    case LIBC_FREE: {
+      port.recv([&](rpc::Buffer* Buffer, uint32_t) {
+        void* Ptr = reinterpret_cast<void*>(Buffer->data[0]);
+        if (Ptr) {
+          amd::Memory* mem = amd::MemObjMap::FindMemObj(Ptr);
+          if (mem) {
+            const_cast<amd::Device*>(&dev)->RemoveHostcallMemory(mem);
+            amd::MemObjMap::RemoveMemObj(Ptr);
+            mem->release();
+          }
+        }
+      });
+      break;
+    }
+    case ROCM_HOSTCALL_FUNCTION: {
+      port.recv_and_send([&](rpc::Buffer* Buffer, uint32_t) {
+        typedef void (*HostcallFn)(uint64_t* output, const uint64_t* input);
+        auto fptr = reinterpret_cast<HostcallFn>(Buffer->data[0]);
+        uint64_t output[2] = {};
+        fptr(output, &Buffer->data[1]);
+        Buffer->data[0] = output[0];
+        Buffer->data[1] = output[1];
+      });
+      break;
+    }
+    case ROCM_HOSTCALL_DEVMEM: {
+      port.recv_and_send([&](rpc::Buffer* Buffer, uint32_t) {
+        uint64_t addr = Buffer->data[0];
+        uint64_t size = Buffer->data[1];
+        guarantee(addr != 0 || size != 0, "ROCM_HOSTCALL_DEVMEM: both addr and size are zero");
+        if (addr) {
+          amd::Memory* mem = amd::MemObjMap::FindMemObj(reinterpret_cast<void*>(addr));
+          if (mem) {
+            const_cast<amd::Device*>(&dev)->RemoveHostcallMemory(mem);
+            amd::MemObjMap::RemoveMemObj(reinterpret_cast<void*>(addr));
+            mem->release();
+          } else {
+            ClPrint(amd::LOG_ERROR, amd::LOG_ALWAYS, "ROCM_HOSTCALL_DEVMEM: unknown pointer %p",
+                    reinterpret_cast<void*>(addr));
+          }
+          Buffer->data[0] = 0;
+        } else {
+          amd::Context& ctx = dev.context();
+          amd::Buffer* buf = new (ctx)
+              amd::Buffer(ctx, CL_MEM_READ_WRITE, size, nullptr, (size == 2 * Mi) ? 2 * Mi : 0);
+          uint64_t va = 0;
+          if (buf) {
+            if (buf->create()) {
+              device::Memory* dm = buf->getDeviceMemory(dev);
+              va = dm->virtualAddress();
+              amd::MemObjMap::AddMemObj(reinterpret_cast<void*>(va), buf);
+              const_cast<amd::Device*>(&dev)->TrackHostcallMemory(buf);
+            } else {
+              buf->release();
+            }
+          }
+          Buffer->data[0] = va;
+        }
+      });
+      break;
+    }
+    case ROCM_HOSTCALL_PRINTF: {
+      port.recv_and_send([&](rpc::Buffer* Buffer, uint32_t) {
+        if (!messages.handlePayload(SERVICE_PRINTF, Buffer->data)) {
+          ClPrint(amd::LOG_ERROR, amd::LOG_ALWAYS, "ROCM_HOSTCALL_PRINTF: invalid message payload");
+        }
+      });
+      break;
+    }
+#if defined(__clang__)
+#if __has_feature(address_sanitizer)
+    case ROCM_HOSTCALL_SANITIZER: {
+      constexpr uint32_t kMaxLanes = 64;
+      uint64_t addrs[kMaxLanes] = {};
+      uint64_t callstack[1] = {};
+      uint64_t entity_id[kMaxLanes + 4] = {};
+      uint64_t access_info = 0, acc_size = 0;
+      uint32_t n_lanes = 0;
+      entity_id[0] = dev.index();
+
+      port.recv([&](rpc::Buffer* Buffer, uint32_t) {
+        addrs[n_lanes] = Buffer->data[0];
+        if (n_lanes == 0) {
+          callstack[0] = Buffer->data[1];
+          entity_id[1] = Buffer->data[2];
+          entity_id[2] = Buffer->data[3];
+          entity_id[3] = Buffer->data[4];
+        }
+        entity_id[4 + n_lanes] = Buffer->data[5];
+        access_info = Buffer->data[6];
+        acc_size = Buffer->data[7];
+        n_lanes++;
+      });
+
+      bool is_write = (access_info & 1) != 0;
+      bool is_abort = (access_info & 0xFFFFFFFF00000000ULL) == 0;
+      auto uri_fd = amd::Os::FDescInit();
+      __asan_report_nonself_error(callstack, 1, addrs, n_lanes, entity_id, n_lanes + 4, is_write,
+                                  acc_size, is_abort, "amdgpu", 0, uri_fd, 0, 0);
+      port.send([](rpc::Buffer*, uint32_t) {});
+      break;
+    }
+#endif
+#endif
+    default:
+      return rpc::RPC_UNHANDLED_OPCODE;
+  }
+  return rpc::RPC_SUCCESS;
+}
+
+static void servicePort(RpcBufferInfo* info, rpc::Server::Port& port) {
+  rpc::RPCStatus status = handleClrOpcodes(port, *info->device, *info->messages);
+
+  if (status == rpc::RPC_UNHANDLED_OPCODE)
+    status = rpc::handle_libc_opcodes(port, info->num_lanes);
+
+  if (status != rpc::RPC_SUCCESS && status != rpc::RPC_UNHANDLED_OPCODE) {
+    ClPrint(amd::LOG_ERROR, amd::LOG_ALWAYS, "RPC: Unhandled or invalid opcode");
+  }
+}
+
+bool processRpcBuffer(RpcBufferInfo* info) {
+  rpc::Server server(info->port_count, info->buffer);
+
+  // Drain every port that is ready this pass.
+  bool serviced = false;
+  for (uint32_t n = 0; n < info->port_count; ++n) {
+    auto port = server.try_open(info->num_lanes);
+    if (!port) break;
+    servicePort(info, *port);
+    serviced = true;
+  }
+  return serviced;
+}
+
+void flushRpcBuffer(RpcBufferInfo* info) {
+  rpc::Server server(info->port_count, info->buffer);
+
+  while (auto port = server.try_open(info->num_lanes)) {
+    servicePort(info, *port);
+  }
+}
+
+size_t getRpcClientSize() { return sizeof(rpc::Client); }
+
+void initRpcClient(void* staging, void* buffer, uint32_t num_ports) {
+  rpc::Client client(num_ports, buffer);
+  std::memcpy(staging, &client, sizeof(rpc::Client));
+}
+
+void initRpcDoorbell(void* buffer, void* signal_handle) {
+  // Must match the prefix of amd_signal_t in ROCR's core/inc/amd_signal.h.
+  // The KFD event fields are not exposed through the public HSA API.
+  struct AMDSignal {
+    int64_t kind;
+    int64_t value;
+    uint64_t event_mailbox_ptr;
+    uint32_t event_id;
+  };
+  auto* sig = reinterpret_cast<AMDSignal*>(signal_handle);
+  auto* doorbell =
+      reinterpret_cast<rpc::Doorbell*>(static_cast<char*>(buffer) + rpc::Server::doorbell_offset());
+  doorbell->value = reinterpret_cast<uint64_t*>(&sig->value);
+  doorbell->mailbox = reinterpret_cast<uint64_t*>(sig->event_mailbox_ptr);
+  doorbell->event_id = sig->event_id;
+}
+
+}  // namespace amd
+
+#else  // !__has_include("shared/rpc.h")
+
+namespace amd {
+
+bool rpcAvailable() { return false; }
+size_t getRpcBufferSize(uint32_t, uint32_t) { return 0; }
+bool processRpcBuffer(RpcBufferInfo*) { return false; }
+void flushRpcBuffer(RpcBufferInfo*) {}
+size_t getRpcClientSize() { return 0; }
+void initRpcClient(void*, void*, uint32_t) {}
+void initRpcDoorbell(void*, void*) {}
+
+}  // namespace amd
+
+#endif

--- a/projects/clr/rocclr/device/devrpc.hpp
+++ b/projects/clr/rocclr/device/devrpc.hpp
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#pragma once
+
+#include "top.hpp"
+#include "device/device.hpp"
+#include <cstddef>
+#include <cstdint>
+
+/// ROCm-specific RPC opcodes that replace the legacy hostcall buffer services.
+enum : uint32_t {
+  /// Calls a host-side function pointer with up to seven uint64_t arguments and
+  /// returns up to two uint64_t results.
+  ///   [in]  data[0]    = function pointer  void (*)(uint64_t *out, const uint64_t *in)
+  ///   [in]  data[1..7] = input arguments
+  ///   [out] data[0..1] = output values
+  ROCM_HOSTCALL_FUNCTION = ('r' << 24) | 0,
+
+  /// Device memory allocation and deallocation.  Replaces SERVICE_DEVMEM.
+  ///   [in]  data[0] = address (non-zero to free this VA)
+  ///   [in]  data[1] = size    (when data[0] == 0, allocate this many bytes)
+  ///   [out] data[0] = virtual address of the new allocation, or 0
+  ROCM_HOSTCALL_DEVMEM = ('r' << 24) | 1,
+
+  /// Address-sanitizer violation report.
+  ///   [in]  data[0] = faulting address
+  ///   [in]  data[1] = program counter
+  ///   [in]  data[2] = workgroup index X
+  ///   [in]  data[3] = workgroup index Y
+  ///   [in]  data[4] = workgroup index Z
+  ///   [in]  data[5] = wave ID
+  ///   [in]  data[6] = access info (bit 0 = is_write; upper 32 bits nonzero = non-fatal)
+  ///   [in]  data[7] = access size in bytes
+  ROCM_HOSTCALL_SANITIZER = ('r' << 24) | 2,
+
+  /// Hostcall-style printf/fprintf using the message descriptor protocol.
+  ///   [in]  data[0]    = message descriptor (BEGIN/END flags, length, 56-bit ID)
+  ///   [in]  data[1..7] = payload elements (count given by descriptor length field)
+  ///   [out] data[0]    = updated descriptor (with assigned ID) or printf return value
+  ///   [out] data[1]    = second return value (on END)
+  ROCM_HOSTCALL_PRINTF = ('r' << 24) | 3,
+};
+
+namespace amd {
+
+class MessageHandler;
+
+constexpr uint64_t kMaxRpcPortCount = 16384;
+
+struct RpcBufferInfo {
+  void* buffer;
+  uint32_t num_lanes;
+  uint32_t port_count;
+  const amd::Device* device;
+  MessageHandler* messages = nullptr;
+};
+
+/// Returns true if the RPC headers were found at compile time, i.e. the
+/// compiler was built with LLVM libc support.
+bool rpcAvailable();
+
+size_t getRpcBufferSize(uint32_t num_lanes, uint32_t num_ports);
+
+/// Service pending RPC requests from the given buffer. Returns true if at least
+/// one port was serviced.
+bool processRpcBuffer(RpcBufferInfo* info);
+
+/// Drain all pending RPC requests from the given buffer.
+void flushRpcBuffer(RpcBufferInfo* info);
+
+/// Returns the expected size in bytes of the RPC client symbol.
+size_t getRpcClientSize();
+
+/// Construct an RPC client pointing at \p buffer and write the raw bytes to
+/// \p staging.
+void initRpcClient(void* staging, void* buffer, uint32_t num_ports);
+
+/// Extract the interrupt doorbell fields from \p signal and write them into the
+/// RPC buffer so the device can fire interrupts to wake the server thread.
+void initRpcDoorbell(void* buffer, void* signal_handle);
+
+}  // namespace amd

--- a/projects/clr/rocclr/device/rocm/rocdevice.cpp
+++ b/projects/clr/rocclr/device/rocm/rocdevice.cpp
@@ -18,6 +18,7 @@
 #include "vdi_common.hpp"
 #include "device/comgrctx.hpp"
 #include "device/devhostcall.hpp"
+#include "device/devrpc.hpp"
 #include "device/rocm/rocdevice.hpp"
 #include "device/rocm/rocblit.hpp"
 #include "device/rocm/rocvirtual.hpp"
@@ -218,6 +219,7 @@ Device::~Device() {
   // This guards OCL teardown; for HIP the drain already ran via RuntimeTearDown,
   // so this is a safe no-op in that path.
   WaitForHsaAsyncHandlersIdle();
+  destroyRpcBuffer();
 
   // Release cached map targets
   for (uint i = 0; mapCache_ != nullptr && i < mapCache_->size(); ++i) {
@@ -4401,6 +4403,7 @@ cl_int ConvertHSAErrorIntoCLError(hsa_status_t hsa_status) {
 void callbackQueue(hsa_status_t status, hsa_queue_t* queue, void* data) {
   if (status != HSA_STATUS_SUCCESS && status != HSA_STATUS_INFO_BREAK) {
     Device* dev = reinterpret_cast<Device*>(data);
+    dev->flushRpc();
     std::string hostnameStr = GetLocalHostName();
     std::string host_tag = hostnameStr.empty() ? "" : "host: " + hostnameStr + ", ";
     std::string kernelName;
@@ -4542,11 +4545,122 @@ bool Device::importExtSemaphore(void** extSemaphore, const amd::Os::FileDesc& ha
 }
 
 // ================================================================================================
+void* Device::getOrCreateRpcBuffer() {
+  amd::ScopedLock l(active_queue_access_);
+
+  if (void* existing = rpcBuffer_.load(std::memory_order_acquire)) return existing;
+
+  auto wavesPerCu = info().maxThreadsPerCU_ / info().wavefrontWidth_;
+  rpcPortCount_ = static_cast<uint32_t>(
+      std::min(static_cast<uint64_t>(info().maxComputeUnits_ * wavesPerCu), amd::kMaxRpcPortCount));
+
+  auto size = amd::getRpcBufferSize(info().wavefrontWidth_, rpcPortCount_);
+
+  void* buffer = context().svmAlloc(size, 64, CL_MEM_SVM_FINE_GRAIN_BUFFER | CL_MEM_SVM_ATOMICS);
+  if (!buffer) {
+    ClPrint(amd::LOG_ERROR, amd::LOG_QUEUE, "Failed to allocate RPC buffer for device %p", this);
+    return nullptr;
+  }
+  std::memset(buffer, 0, size);
+
+  if (!amd::enableRpc(*this, buffer, rpcPortCount_)) {
+    ClPrint(amd::LOG_ERROR, amd::LOG_QUEUE, "Failed to enable RPC for device %p", this);
+    context().svmFree(buffer);
+    return nullptr;
+  }
+
+  rpcBuffer_.store(buffer, std::memory_order_release);
+  ClPrint(amd::LOG_INFO, amd::LOG_QUEUE, "Created RPC buffer %p (ports=%u, size=%zu) for device %p",
+          buffer, rpcPortCount_, size, this);
+  return buffer;
+}
+
+// ================================================================================================
+bool Device::initRpcForProgram(hsa_executable_t executable) {
+  if (!amd::rpcAvailable()) return true;
+
+  hsa_agent_t agent = getBackendDevice();
+  hsa_executable_symbol_t rpc_symbol;
+
+  // Exit early if the program does not require an RPC server.
+  hsa_status_t status =
+      Hsa::executable_get_symbol_by_name(executable, "__llvm_rpc_client", &agent, &rpc_symbol);
+  if (status != HSA_STATUS_SUCCESS) {
+    return true;
+  }
+
+  hsa_symbol_kind_t sym_type;
+  status = Hsa::executable_symbol_get_info(rpc_symbol, HSA_EXECUTABLE_SYMBOL_INFO_TYPE, &sym_type);
+  if (status != HSA_STATUS_SUCCESS || sym_type != HSA_SYMBOL_KIND_VARIABLE) {
+    ClPrint(amd::LOG_ERROR, amd::LOG_QUEUE, "RPC: __llvm_rpc_client is not a variable symbol");
+    return false;
+  }
+
+  size_t sym_size = 0;
+  status = Hsa::executable_symbol_get_info(rpc_symbol, HSA_EXECUTABLE_SYMBOL_INFO_VARIABLE_SIZE,
+                                           &sym_size);
+  if (status != HSA_STATUS_SUCCESS) {
+    ClPrint(amd::LOG_ERROR, amd::LOG_QUEUE, "RPC: Failed to get __llvm_rpc_client size");
+    return false;
+  }
+
+  if (sym_size != amd::getRpcClientSize()) {
+    ClPrint(amd::LOG_ERROR, amd::LOG_QUEUE, "RPC: Invalid size of __llvm_rpc_client");
+    return false;
+  }
+
+  void* sym_addr = nullptr;
+  status = Hsa::executable_symbol_get_info(rpc_symbol, HSA_EXECUTABLE_SYMBOL_INFO_VARIABLE_ADDRESS,
+                                           &sym_addr);
+  if (status != HSA_STATUS_SUCCESS || !sym_addr) {
+    ClPrint(amd::LOG_ERROR, amd::LOG_QUEUE, "RPC: Failed to get __llvm_rpc_client address");
+    return false;
+  }
+
+  void* buffer = getOrCreateRpcBuffer();
+  if (!buffer) {
+    ClPrint(amd::LOG_ERROR, amd::LOG_QUEUE, "RPC: Failed to create RPC buffer for device");
+    return false;
+  }
+  auto client_staging = std::make_unique<char[]>(amd::getRpcClientSize());
+  amd::initRpcClient(client_staging.get(), buffer, rpcPortCount_);
+
+  status = Hsa::memory_copy(sym_addr, client_staging.get(), sym_size);
+  if (status != HSA_STATUS_SUCCESS) {
+    ClPrint(amd::LOG_ERROR, amd::LOG_QUEUE, "RPC: Failed to copy RPC client to device symbol");
+    return false;
+  }
+
+  ClPrint(amd::LOG_INFO, amd::LOG_QUEUE,
+          "RPC: Initialized __llvm_rpc_client at device %p (sym_addr=%p, ports=%u)", sym_addr,
+          buffer, rpcPortCount_);
+  return true;
+}
+
+// ================================================================================================
 void Device::DestroyExtSemaphore(void* extSemaphore) {
   if (extSemaphore == nullptr) return;
   auto* holder = static_cast<hsa_amd_external_semaphore_t*>(extSemaphore);
   hsa_amd_external_semaphore_handle_close(*holder);
   delete holder;
+}
+
+// ================================================================================================
+void Device::flushRpc() {
+  if (void* buffer = rpcBuffer_.load(std::memory_order_acquire)) {
+    amd::flushRpc(buffer);
+  }
+}
+
+void Device::destroyRpcBuffer() {
+  if (void* buffer = rpcBuffer_.load(std::memory_order_acquire)) {
+    // Drain any reports the device pushed before we release the buffer.
+    amd::flushRpc(buffer);
+    amd::disableRpc(buffer);
+    context().svmFree(buffer);
+    rpcBuffer_.store(nullptr, std::memory_order_release);
+    ClPrint(amd::LOG_INFO, amd::LOG_QUEUE, "Destroyed RPC buffer for device %p", this);
+  }
 }
 
 }  // namespace amd::roc

--- a/projects/clr/rocclr/device/rocm/rocdevice.hpp
+++ b/projects/clr/rocclr/device/rocm/rocdevice.hpp
@@ -627,6 +627,21 @@ class Device : public NullDevice {
   //! Return the pre-computed metadata packet version header bits
   uint32_t MetadataVersionHeader() const { return metadata_version_header_; }
 
+  //! Get or create the RPC buffer for this device. The buffer is lazily
+  //! allocated the first time a loaded program contains `__llvm_rpc_client`.
+  void* getOrCreateRpcBuffer();
+
+  //! Initialize the `__llvm_rpc_client` device symbol for the given
+  //! executable, pointing it at this device's RPC buffer.
+  bool initRpcForProgram(hsa_executable_t executable);
+
+  //! Drain all pending RPC requests on this device's buffer. Called before
+  //! teardown unloads images so sanitizer reports remain resolvable.
+  void flushRpc();
+
+  //! Free the device's RPC buffer during teardown.
+  void destroyRpcBuffer();
+
   //! Return multi GPU grid launch sync buffer
   address MGSync() const { return mg_sync_; }
 
@@ -814,6 +829,9 @@ class Device : public NullDevice {
   //! Per-queue extras (metadata ring buffer and placement), keyed by queue pointer.
   //! Populated at queue creation, erased when non-pooled queues are destroyed.
   std::unordered_map<hsa_queue_t*, QueueExtras> queue_extras_;
+
+  std::atomic<void*> rpcBuffer_{nullptr};  //!< RPC shared memory buffer for this device
+  uint32_t rpcPortCount_ = 0;              //!< Number of RPC ports allocated
 
   //! returns value for corresponding LinkAttrbutes in a vector given Memory pool.
   virtual bool findLinkInfo(const hsa_amd_memory_pool_t& pool,

--- a/projects/clr/rocclr/device/rocm/rocprogram.cpp
+++ b/projects/clr/rocclr/device/rocm/rocprogram.cpp
@@ -31,6 +31,9 @@ static inline const char* hsa_strerror(hsa_status_t status) {
 Program::~Program() {
   // Destroy the executable.
   if (hsaExecutable_.handle != 0) {
+    // Drain pending RPC reports before unloading this executable's images so
+    // any in-flight sanitizer reports referencing its code are resolvable.
+    const_cast<roc::Device&>(rocDevice()).flushRpc();
     Hsa::executable_destroy(hsaExecutable_);
   }
   if (hsaCodeObjectReader_.handle != 0) {
@@ -286,6 +289,12 @@ bool Program::setKernels(void* binary, size_t binSize, amd::Os::FileDesc fdesc,
   UriLocator::recordCodeObjects(hsaExecutable_);
 #endif
 #endif
+
+  // Initialize the RPC client if this executable contains __llvm_rpc_client.
+  if (!const_cast<roc::Device&>(rocDevice()).initRpcForProgram(hsaExecutable_)) {
+    buildLog_ += "Error: Failed to initialize RPC client for program\n";
+    return false;
+  }
 
   for (auto& kit : kernels()) {
     Kernel* kernel = static_cast<Kernel*>(kit.second);

--- a/projects/hip-tests/catch/unit/CMakeLists.txt
+++ b/projects/hip-tests/catch/unit/CMakeLists.txt
@@ -53,6 +53,7 @@ if(HIP_PLATFORM STREQUAL "amd")
   add_subdirectory(gl_interop) # Disabled on NVIDIA due to defect - EXSWHTEC-246
   add_subdirectory(TDM)
   add_subdirectory(cluster)
+  add_subdirectory(rpc)
 endif()
 add_subdirectory(synchronization)
 add_subdirectory(launchBounds)

--- a/projects/hip-tests/catch/unit/rpc/CMakeLists.txt
+++ b/projects/hip-tests/catch/unit/rpc/CMakeLists.txt
@@ -1,0 +1,52 @@
+# Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
+#
+# SPDX-License-Identifier: MIT
+
+# The RPC headers come from the installed 'clang' compiler.
+set(_rpc_candidates "")
+
+# Explicit override wins.
+if(RPC_SHARED_INCLUDE_DIR)
+  list(APPEND _rpc_candidates "${RPC_SHARED_INCLUDE_DIR}")
+endif()
+
+# Preferred: <prefix>/include derived from the compiler's resource dir.
+execute_process(
+  COMMAND "${CMAKE_CXX_COMPILER}" -print-resource-dir
+  OUTPUT_VARIABLE _rpc_resource_dir
+  OUTPUT_STRIP_TRAILING_WHITESPACE
+  ERROR_QUIET)
+if(_rpc_resource_dir)
+  get_filename_component(_rpc_prefix "${_rpc_resource_dir}/../../.." REALPATH)
+  list(APPEND _rpc_candidates "${_rpc_prefix}/include")
+endif()
+
+# Fallback: <compiler_bin>/../include.
+get_filename_component(_rpc_bin_dir "${CMAKE_CXX_COMPILER}" DIRECTORY)
+get_filename_component(_rpc_bin_inc "${_rpc_bin_dir}/../include" REALPATH)
+list(APPEND _rpc_candidates "${_rpc_bin_inc}")
+
+set(_rpc_include "")
+foreach(_cand IN LISTS _rpc_candidates)
+  if(_cand AND EXISTS "${_cand}/shared/rpc.h")
+    set(_rpc_include "${_cand}")
+    break()
+  endif()
+endforeach()
+
+if(NOT _rpc_include)
+  message(STATUS "RPC: <shared/rpc.h> not found for this compiler; skipping RPC tests")
+  return()
+endif()
+message(STATUS "RPC: using shared headers from ${_rpc_include}")
+
+set(TEST_SRC
+    rpc_ping.cc)
+
+set_source_files_properties(rpc_ping.cc PROPERTIES
+    COMPILE_OPTIONS "-I${_rpc_include}")
+
+hip_add_exe_to_target(NAME RpcTest
+                      TEST_SRC ${TEST_SRC}
+                      TEST_TARGET_NAME build_tests
+                      PROPERTY CXX_STANDARD 17)

--- a/projects/hip-tests/catch/unit/rpc/rpc_ping.cc
+++ b/projects/hip-tests/catch/unit/rpc/rpc_ping.cc
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#include <hip_test_common.hh>
+
+// The RPC interface is only available when the compiler ships the LLVM libc
+// shared headers.
+#if __has_include(<shared/rpc.h>)
+
+#include <shared/rpc.h>
+#include <shared/rpc_opcodes.h>
+
+namespace rpc {
+[[gnu::visibility("protected")]] __device__ Client client asm("__llvm_rpc_client");
+}  // namespace rpc
+
+__global__ void rpcIncrementKernel(int* results, uint32_t iters) {
+  uint32_t tid = blockIdx.x * blockDim.x + threadIdx.x;
+  uint64_t cnt = 0;
+  for (uint32_t i = 0; i < iters; ++i) {
+    rpc::Client::Port port = rpc::client.open<LIBC_TEST_INCREMENT>();
+    port.send_and_recv([=](rpc::Buffer* buf, uint32_t) { buf->data[0] = cnt; },
+                       [&](rpc::Buffer* buf, uint32_t) { cnt = buf->data[0]; });
+  }
+  results[tid] = (cnt == iters) ? 1 : 0;
+}
+
+__global__ void rpcNoopKernel() {
+  if ((blockIdx.x * blockDim.x + threadIdx.x) % 2)
+    rpc::client.open<LIBC_NOOP>().send([](rpc::Buffer* buf, uint32_t) { buf->data[0] = 1; });
+  else
+    rpc::client.open<LIBC_NOOP>().send([](rpc::Buffer* buf, uint32_t) { buf->data[0] = 2; });
+}
+
+TEST_CASE("Unit_Rpc_Increment_MultiThread") {
+  constexpr uint32_t kBlocks = 2;
+  constexpr uint32_t kThreads = 64;
+  constexpr uint32_t kTotal = kBlocks * kThreads;
+  constexpr uint32_t kIters = 64;
+
+  int* results = nullptr;
+  HIP_CHECK(hipMallocManaged(&results, kTotal * sizeof(int)));
+  for (uint32_t i = 0; i < kTotal; ++i) results[i] = -1;
+
+  rpcIncrementKernel<<<kBlocks, kThreads>>>(results, kIters);
+  HIP_CHECK(hipDeviceSynchronize());
+
+  for (uint32_t i = 0; i < kTotal; ++i) {
+    INFO("thread " << i);
+    REQUIRE(results[i] == 1);
+  }
+  HIP_CHECK(hipFree(results));
+}
+
+TEST_CASE("Unit_Rpc_Noop_Divergent") {
+  rpcNoopKernel<<<2, 64>>>();
+  HIP_CHECK(hipDeviceSynchronize());
+}
+
+#endif  // __has_include(<shared/rpc.h>)


### PR DESCRIPTION
## Summary

This PR is the first step in enabling the HIP runtime to handle the RPC
interface. This is a replacement / augmentation of hostcall that is more
extensible and performant.

The goal is to integrate RPC handling side-by-side with the existing hostcall
path. Both options can be used until we decide which to favor, and it keeps
compatibility with older runtime library builds.

The RPC headers are taken from the installed compiler, so they stay in sync with
the compiler ABI shipped in the ROCm installation. If they are not found we
fall back to the pre-RPC behavior (guarded by `__has_include("shared/rpc.h")`),
but they should always be present in current ROCm build stages.

The changes are largely mechanical, mirroring the hostcall interface. The one
subtlety is doorbell handling: when both hostcall and RPC are active, I revert to
active polling. This should not happen in practice.

## Motivation

- Shared interface with upstream LLVM libc (https://libc.llvm.org/gpu/rpc.html).
- Significantly better performance than hostcall.
- Removes divergence from upstream LLVM and out supported offloading languages

## Benchmark

Measured against hostcall using `SERVICE_FUNCTION_CALL` on gfx1030. Both paths
call a no-op host function via equivalent protocols. Release build, `-O2`,
occupancy 16 waves/SIMD for both kernels.

| Waves | Hostcall (calls/sec) | RPC (calls/sec) | Speedup |
|------:|---------------------:|----------------:|--------:|
|     1 |               73,446 |         137,126 |   1.87x |
|     8 |               77,682 |         217,051 |   2.80x |
|   128 |               37,599 |         561,957 |  14.90x |
|   512 |               17,007 |         480,623 |  28.30x |
|  2048 |                6,828 |         486,150 |  71.20x |
|  8192 |               10,924 |         487,565 |  44.60x |

## Technical Details

- Adds `device/devrpc.{cpp,hpp}` implementing the server side, reusing the
  existing hostcall listener thread and message handler.
- `rocdevice.cpp` lazily allocates a fine-grain RPC buffer and initializes the
  `__llvm_rpc_client` device symbol when a loaded executable contains it.
- CLR-specific opcodes (`ROCM_HOSTCALL_FUNCTION`, `_DEVMEM`, `_PRINTF`,
  `_SANITIZER`, plus `LIBC_MALLOC`/`LIBC_FREE`) are handled directly; all other
  opcodes fall through to `rpc::handle_libc_opcodes`.
- Reference: https://libc.llvm.org/gpu/rpc.html

## Test Plan

Adds a HIP RPC test under `projects/hip-tests/catch/unit/rpc/` that drives the
server directly.

- `Unit_Rpc_Increment_MultiThread`: multiple blocks/threads repeatedly invoke the
  built-in `LIBC_TEST_INCREMENT` opcode (a host-side "ping") and verify each
  round-trip returns the expected value.
- `Unit_Rpc_Noop_Divergent`: divergent lanes issue `LIBC_NOOP` to ensure the
  server does not hang on partial-wave requests.

The test's CMake derives the compiler's `shared/rpc*.h` include directory from
`-print-resource-dir` and skips gracefully when the toolchain was built without
LLVM libc, so CI stays green on all configurations.

A follow-up will re-implement `hostcall_preview` on top of RPC, at which point
the existing hostcall tests exercise this path as well.

## Test Result

- New RPC ping test passes on gfx1030 (2 blocks x 64 threads x 64 iterations).
- No regression of existing hostcall behavior.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
