### PR TITLE
[rocprofiler-compute] Add git commit and PR workflow instructions

### DIFF
--- a/projects/rocprofiler-compute/.ai/rules/commit-workflow.md
+++ b/projects/rocprofiler-compute/.ai/rules/commit-workflow.md
@@ -1,0 +1,93 @@
+# Commit Creator Agent
+
+You are an agent that creates well-structured git commits. Follow this methodology
+precisely to produce clean, reviewable commits.
+
+## Workflow
+
+### 1. Assess changes
+
+Run these commands in parallel to understand the current state:
+
+- `git status` (never use `-uall` flag)
+- `git diff` to see staged and unstaged changes
+- `git log --oneline -10` to understand the repo's commit message style
+
+### 2. Identify the correct files to stage
+
+- Only stage files relevant to the logical change. Prefer `git add <file1> <file2>`
+  over `git add -A` or `git add .`.
+- Never stage files that may contain secrets (`.env`, credentials, tokens, etc.).
+- Never stage unrelated modifications (e.g., dirty submodules, editor configs).
+
+### 3. Draft the commit message and confirm with user
+
+Draft a commit message following the repo's conventions. Present it to the user
+and wait for approval before proceeding. Do NOT commit without confirmation.
+
+**Commit message rules for this repo:**
+
+- Prefix with the project name in brackets: `[rocprofiler-compute]`
+- First line: concise summary under 72 characters
+- Body: explain the "why", not the "what" — the diff shows the what
+- Separate logical points as bullet list items
+- Highlight bugfixes explicitly and distinctly from feature changes
+- Keep descriptions concise — one to two lines per point, no verbose paragraphs
+- Do not include refactoring commentary that is obvious from the diff
+- If referencing another project's code as inspiration, keep it to a one-liner
+- End with: `Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>`
+
+**Tone guidelines (learned from user):**
+
+- Do not complain about previous behavior. Describe what the change does, not
+  what was wrong before.
+- Be concise. Three bullet points are better than six.
+- Only highlight changes that a reviewer needs to know: bugfixes, new features,
+  and notable design decisions.
+
+### 4. Create the commit
+
+- Use a HEREDOC to pass the commit message to avoid shell escaping issues:
+
+```bash
+git commit -m "$(cat <<'EOF'
+[rocprofiler-compute] Your title here
+
+- Bullet point one
+- Bullet point two
+
+Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
+EOF
+)"
+```
+
+### 5. Handle pre-commit hooks
+
+- If pre-commit hooks fail (e.g., ruff, formatting), read the output to
+  understand what was auto-fixed or what needs manual fixing.
+- Re-stage the fixed files with `git add <fixed-files>`.
+- Create a NEW commit — never use `--amend` after a hook failure, as the
+  original commit did not succeed and amending would modify the previous commit.
+- Repeat until all hooks pass.
+
+### 6. Verify success
+
+- Run `git log --oneline -3` to confirm the commit landed correctly.
+- Run `git status` to confirm a clean working tree (for staged files).
+
+## Branch safety
+
+- Never commit directly to `main` or `develop` unless the user explicitly
+  instructs you to do so. If the user doesn't specify a branch, ask.
+- If a commit was accidentally made on the wrong branch, move it:
+  1. `git branch <correct-branch>` (create branch at current HEAD)
+  2. `git reset --hard HEAD~1` (reset the wrong branch back)
+  3. `git checkout <correct-branch>` (switch to the correct branch)
+
+## What NOT to do
+
+- Do not push to remote unless explicitly asked.
+- Do not use `--no-verify` or `--no-gpg-sign` to bypass hooks.
+- Do not use interactive flags (`-i`) with git commands.
+- Do not create empty commits.
+- Do not batch multiple unrelated changes into one commit.

--- a/projects/rocprofiler-compute/.ai/rules/commit-workflow.md
+++ b/projects/rocprofiler-compute/.ai/rules/commit-workflow.md
@@ -1,7 +1,7 @@
-# Commit Creator Agent
+# Commit Workflow
 
-You are an agent that creates well-structured git commits. Follow this methodology
-precisely to produce clean, reviewable commits.
+Follow this methodology precisely when creating git commits to produce clean,
+reviewable commits.
 
 ## Workflow
 

--- a/projects/rocprofiler-compute/.ai/rules/commit-workflow.md
+++ b/projects/rocprofiler-compute/.ai/rules/commit-workflow.md
@@ -10,14 +10,14 @@ reviewable commits.
 Run these commands in parallel to understand the current state:
 
 - `git status` (never use `-uall` flag)
-- `git diff` to see staged and unstaged changes
+- `git diff` and `git diff --staged` to see staged and unstaged changes
 - `git log --oneline -10` to understand the repo's commit message style
 
 ### 2. Identify the correct files to stage
 
 - Only stage files relevant to the logical change. Prefer `git add <file1> <file2>`
   over `git add -A` or `git add .`.
-- Never stage files that may contain secrets (`.env`, credentials, tokens, etc.).
+- Never stage files that contain secrets (`.env`, credentials, tokens, etc.).
 - Never stage unrelated modifications (e.g., dirty submodules, editor configs).
 
 ### 3. Draft the commit message and confirm with user
@@ -27,7 +27,6 @@ and wait for approval before proceeding. Do NOT commit without confirmation.
 
 **Commit message rules for this repo:**
 
-- Prefix with the project name in brackets: `[rocprofiler-compute]`
 - First line: concise summary under 72 characters
 - Body: explain the "why", not the "what" — the diff shows the what
 - Separate logical points as bullet list items
@@ -35,7 +34,7 @@ and wait for approval before proceeding. Do NOT commit without confirmation.
 - Keep descriptions concise — one to two lines per point, no verbose paragraphs
 - Do not include refactoring commentary that is obvious from the diff
 - If referencing another project's code as inspiration, keep it to a one-liner
-- End with: `Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>`
+- End with: `Co-Authored-By: <AI model name or IDE name>`
 
 **Tone guidelines (learned from user):**
 
@@ -56,7 +55,7 @@ git commit -m "$(cat <<'EOF'
 - Bullet point one
 - Bullet point two
 
-Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
+Co-Authored-By: <AI model name or IDE name>
 EOF
 )"
 ```
@@ -77,8 +76,8 @@ EOF
 
 ## Branch safety
 
-- Never commit directly to `main` or `develop` unless the user explicitly
-  instructs you to do so. If the user doesn't specify a branch, ask.
+- Never commit directly to `develop`
+- Always check current branch and apply commit over there, unless user specifies another branch
 - If a commit was accidentally made on the wrong branch, move it:
   1. `git branch <correct-branch>` (create branch at current HEAD)
   2. `git reset --hard HEAD~1` (reset the wrong branch back)
@@ -86,8 +85,8 @@ EOF
 
 ## What NOT to do
 
-- Do not push to remote unless explicitly asked.
+- Do not use `--no-verify` to bypass hooks.
+- Do not use `--no-gpg-sign` to disable commit signing to remote unless explicitly asked.
 - Do not use `--no-verify` or `--no-gpg-sign` to bypass hooks.
-- Do not use interactive flags (`-i`) with git commands.
 - Do not create empty commits.
 - Do not batch multiple unrelated changes into one commit.

--- a/projects/rocprofiler-compute/.ai/rules/pr-workflow.md
+++ b/projects/rocprofiler-compute/.ai/rules/pr-workflow.md
@@ -32,6 +32,7 @@ Before drafting, ask the user:
 - "Do you have a JIRA ID for this PR?"
 - If yes, include it in the JIRA ID section.
 - If no, leave the JIRA ID section empty (keep the heading, leave body blank).
+- JIRA ID should never be specified using url, it should always be just the ticket id without the hyperlink part
 
 ### 4. Draft the PR title and body, then confirm with user
 
@@ -84,7 +85,7 @@ approval. Do NOT create the PR without confirmation.
 
 ### 7. Return the PR URL
 
-Always return the PR URL (e.g., `ROCm/rocm-systems#4722`) so the user can
+Always return the PR URL so the user can
 review it.
 
 ## Tone guidelines (learned from user)

--- a/projects/rocprofiler-compute/.ai/rules/pr-workflow.md
+++ b/projects/rocprofiler-compute/.ai/rules/pr-workflow.md
@@ -1,0 +1,108 @@
+# PR Creator Agent
+
+You are an agent that creates well-structured GitHub pull requests. Follow this
+methodology precisely to produce clean, reviewable PRs.
+
+## Workflow
+
+### 1. Understand the full scope of changes
+
+Run these in parallel:
+
+- `git status` (never use `-uall`)
+- `git diff <base-branch>...HEAD` to see the full diff from base
+- `git log --oneline <base-branch>..HEAD` to see all commits in the branch
+- `git remote -v` to identify the correct repository
+
+Look at ALL commits, not just the latest one.
+
+### 2. Infer the repo's PR template from recent PRs
+
+Never hardcode the PR template. Always infer it from recent PRs:
+
+- Use GitHub MCP tools to search for recent rocprofiler-compute PRs in the repo.
+- Read 2-3 recent PR bodies to identify the required sections and format.
+- Match the template exactly — section names, ordering, and checklist format.
+
+The template may change over time. Always check recent PRs for the latest format.
+
+### 3. Ask the user for JIRA ID
+
+Before drafting, ask the user:
+- "Do you have a JIRA ID for this PR?"
+- If yes, include it in the JIRA ID section.
+- If no, leave the JIRA ID section empty (keep the heading, leave body blank).
+
+### 4. Draft the PR title and body, then confirm with user
+
+Present the full PR (title + body with all sections) to the user and wait for
+approval. Do NOT create the PR without confirmation.
+
+**Title rules:**
+
+- Prefix with the project name: `[rocprofiler-compute]`
+- Keep under 72 characters
+- Use imperative mood ("Add X" not "Added X")
+
+**Body rules:**
+
+- **Motivation**: Describe what this PR does and why, in 2-3 concise lines.
+  Do not complain about previous behavior — focus on the positive framing of
+  the current change. Highlight bugfixes as a distinct line starting with
+  "Bugfix:" to make them stand out during review.
+- **Technical Details**: Bullet list of key changes. Only include what a
+  reviewer needs to know — omit obvious refactoring details. Keep each point
+  to one line where possible.
+- **JIRA ID**: The JIRA ticket ID (e.g., `AIPROFCOMP-123`), or empty if none.
+- **Test Plan**: Concrete steps to verify the change works.
+- **Test Result**: Fill in if tests were run, leave empty if pending.
+- **Submission Checklist**: Check off items that apply.
+
+**Reference style:**
+
+- When referencing code from other projects as inspiration, use a hyperlink
+  to the specific file and line on GitHub. Format as:
+  [`function_name()`](https://github.com/org/repo/blob/branch/path/to/file.py#L127)
+- Keep references concise — one to two lines max.
+
+### 5. Identify the correct repository and create the PR
+
+- Identify the correct remote repository from `git remote -v`. Do not assume
+  the repo name — verify it. The rocprofiler-compute project lives within the
+  `rocm-systems` monorepo.
+- Ensure the branch is pushed to the remote before creating the PR.
+- Use GitHub MCP tools to create the PR.
+- When using MCP tools, pass the body as a plain string with actual newlines,
+  NOT with escaped `\n` characters — escaped newlines render as literal `\n`
+  in the PR body and break markdown formatting.
+
+### 6. Verify and fix formatting
+
+- After creation, read back the PR to verify markdown renders correctly.
+- If formatting is broken (e.g., literal `\n`, HTML-escaped characters),
+  update the PR body immediately using the update PR tool.
+
+### 7. Return the PR URL
+
+Always return the PR URL (e.g., `ROCm/rocm-systems#4722`) so the user can
+review it.
+
+## Tone guidelines (learned from user)
+
+- Be concise. If you can say it in one line, don't use three.
+- Do not use negative framing about old code ("The old function was broken").
+  Use positive framing about the new behavior ("Add total ranks detection").
+- Separate bugfixes from feature work — reviewers scan for these differently.
+- Do not add refactoring commentary that is obvious from the diff.
+- Do not duplicate the same information in Motivation and Technical Details.
+
+## What NOT to do
+
+- Do not create a PR without user confirmation of title and body.
+- Do not create a PR to the wrong base branch (default: `develop`).
+- Do not create a PR on the wrong repository.
+- Do not use escaped `\n` in PR body strings passed to MCP tools.
+- Do not hardcode the PR template — always infer it from recent PRs.
+- Do not skip asking the user for JIRA ID.
+- Do not include sensitive information (API keys, tokens) in PR descriptions.
+- Do not force-push or modify commits as part of PR creation.

--- a/projects/rocprofiler-compute/.ai/rules/pr-workflow.md
+++ b/projects/rocprofiler-compute/.ai/rules/pr-workflow.md
@@ -1,7 +1,7 @@
-# PR Creator Agent
+# PR Workflow
 
-You are an agent that creates well-structured GitHub pull requests. Follow this
-methodology precisely to produce clean, reviewable PRs.
+Follow this methodology precisely when creating GitHub pull requests to produce
+clean, reviewable PRs.
 
 ## Workflow
 

--- a/projects/rocprofiler-compute/AGENTS.md
+++ b/projects/rocprofiler-compute/AGENTS.md
@@ -10,3 +10,11 @@ nesting, and code organization.
 
 All code in `src/` must pass Ruff checks. Read **[`.ai/rules/ruff-tooling.md`](.ai/rules/ruff-tooling.md)**
 for enforced rules including type annotations, f-strings, and `pathlib` usage.
+
+## Git Workflows
+
+When asked to commit changes, follow **[`.ai/rules/commit-workflow.md`](.ai/rules/commit-workflow.md)**
+for staging, commit message conventions, pre-commit hook handling, and branch safety.
+
+When asked to create a pull request, follow **[`.ai/rules/pr-workflow.md`](.ai/rules/pr-workflow.md)**
+for PR template inference, JIRA handling, formatting, and repo identification.


### PR DESCRIPTION
## Motivation

Add structured workflow instructions for git commit and PR creation under
`.ai/rules/`, enabling AI coding assistants (Claude Code, Copilot, Cursor)
to follow consistent commit message conventions and PR formatting for
rocprofiler-compute.

## Technical Details

- Add `commit-workflow.md` covering staging, message format, pre-commit
  hook handling, and branch safety.
- Add `pr-workflow.md` covering PR template inference from recent PRs,
  JIRA handling, GitHub MCP usage, and formatting.
- Update `AGENTS.md` to route to the new workflow files.

## JIRA ID



## Test Plan

- Verify AI assistants follow commit-workflow.md when asked to commit
- Verify AI assistants follow pr-workflow.md when asked to create a PR

## Test Result



## Submission Checklist

- [X] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.