### PR TITLE
ROCR: refactor VMM APIs - WIP

### DIFF
--- a/projects/rocr-runtime/libhsakmt/include/hsakmt/hsakmt.h
+++ b/projects/rocr-runtime/libhsakmt/include/hsakmt/hsakmt.h
@@ -562,6 +562,8 @@ hsaKmtRegisterGraphicsHandleToNodesExt(
  * allocation. The memory will remain allocated even after the allocation is
  * freed by hsaKmtFreeMemory for as long as a dmabuf fd remains open or any
  * importer of that fd maintains an active reference to the memory.
+ * This is the legacy API that exports dmabuf from KFD interface. To export
+ * dmabuf from DRM interface, use hsaKmtHandleExport instead
  */
 
 HSAKMT_STATUS
@@ -1300,9 +1302,17 @@ hsaKmtModelEnabled(
 HSAKMT_STATUS
 HSAKMTAPI
 hsaKmtHandleImport(
-    const HsaExternalHandleDesc* ImportDesc,
+    const HsaHandleImportDesc* ImportDesc,
     HsaHandleImportResult* ImportResult,
     HsaHandleImportFlags* Flags
+);
+
+HSAKMT_STATUS
+HSAKMTAPI
+hsaKmtHandleExport(
+    const HsaHandleExportDesc* ExportDesc,
+    HsaMemoryExportResult* ExportResult,
+    HsaHandleExportFlags* Flags
 );
 
 HSAKMT_STATUS
@@ -1342,8 +1352,14 @@ HSAKMTAPI
 hsaKmtMemoryGetCpuAddr(
   HsaAMDGPUDeviceHandle DeviceHandle,
   HsaMemoryObjectHandle MemoryHandle,
-  HSAint32* fd, // OUT
   HSAuint64* cpu_addr // OUT
+);
+
+HSAKMT_STATUS
+HSAKMTAPI
+hsaKmtGetAmdGPUDeviceFd(
+  HsaAMDGPUDeviceHandle DeviceHandle, //IN
+  int *fd //OUT
 );
 
 #ifdef __cplusplus

--- a/projects/rocr-runtime/libhsakmt/include/hsakmt/hsakmtctx.h
+++ b/projects/rocr-runtime/libhsakmt/include/hsakmt/hsakmtctx.h
@@ -376,6 +376,26 @@ hsaKmtCreateQueueExtCtx(
     );
 
 /**
+  Creates a GPU queue with user-mode access rights
+*/
+
+HSAKMT_STATUS
+HSAKMTAPI
+hsaKmtCreateQueueV2Ctx(
+    HsaKFDContext       *ctx,             //IN
+    HSAuint32           NodeId,           //IN
+    HSA_QUEUE_TYPE      Type,             //IN
+    HSAuint32           QueuePercentage,  //IN
+    HSA_QUEUE_PRIORITY  Priority,         //IN
+    HSAuint32           SdmaEngineId,     //IN
+    void*               QueueAddress,     //IN
+    HSAuint64           QueueSizeInBytes, //IN
+    HSAuint64           MetaDataQueueSizeInBytes, //IN
+    HsaEvent*           Event,            //IN
+    HsaQueueResource*   QueueResource     //OUT
+    );
+
+/**
   Updates a queue
 */
 

--- a/projects/rocr-runtime/libhsakmt/include/hsakmt/hsakmttypes.h
+++ b/projects/rocr-runtime/libhsakmt/include/hsakmt/hsakmttypes.h
@@ -1521,8 +1521,6 @@ typedef union
     } ui32;
 } HSA_REGISTER_MEM_FLAGS;
 
-#pragma pack(pop, hsakmttypes_h)
-
 typedef enum _HsaAisFlags {
     HSA_AIS_READ = 0x1,
     HSA_AIS_WRITE= 0x2
@@ -1541,28 +1539,28 @@ typedef enum _HsaMemoryMapFlags {
 
 /* Handle type for import */
 typedef enum _HsaExternalHandleType{
-    HSA_EXTERNAL_HANDLE_GEM_FLINK_NAME = 0,
-    HSA_EXTERNAL_HANDLE_KMS     = 1,
-    HSA_EXTERNAL_HANDLE_DMA_BUF = 2
+    HSA_EXTERNAL_HANDLE_GEM_FLINK_NAME  = 0,
+    HSA_EXTERNAL_HANDLE_KMS             = 1,
+    HSA_EXTERNAL_HANDLE_DMA_BUF         = 2,
 } HsaExternalHandleType;
 
-typedef struct _HsaExternalHandleDesc {
+typedef struct HsaHandleImportDesc {
     HsaAMDGPUDeviceHandle device_handle; // GPU device handle (used for import only)
-    HSAint64 fd; // dmabuf fd
     HsaExternalHandleType type; // handle type
+    union {
+        HSAint64 dmabuf_fd; // dmabuf fd
+        HsaMemoryObjectHandle buf_handle; // Driver handle
+    };
     void *mem; // existing buffer address (for windows and WSL only)
     HSAuint32 metadata; // Used for IPC handles
-} HsaExternalHandleDesc;
+} HsaHandleImportDesc;
 
 typedef struct _HsaHandleImportResult {
-    HsaMemoryObjectHandle buf_handle; // Thunk buffer object handle
+    HsaMemoryObjectHandle buf_handle; // Buffer Object handle
+    HSAint64 dmabuf_fd;
     HSAuint64 alloc_size; // allocation size for import
     HSAuint32 metadata; // Used for IPC handles
 } HsaHandleImportResult;
-
-typedef struct _HsaMemoryExportResult {
-    HSAint32 fd; // dmabuf fd
-} HsaMemoryExportResult;
 
 typedef struct _HsaHandleImportFlags {
     struct {
@@ -1578,6 +1576,27 @@ typedef struct _HsaStructureSizes {
   HSAuint16 SizeOfHsaNodeProperties;  // sizeof(HsaNodeProperties)
   HSAuint16 Reserved[6];
 } HsaStructureSizes;
+typedef struct _HsaHandleExportDesc {
+    HsaAMDGPUDeviceHandle device_handle;
+    HsaExternalHandleType type;
+    HsaMemoryObjectHandle buf_handle; // Thunk buffer object handle
+    HSAuint64 size;
+} HsaHandleExportDesc;
+
+typedef struct _HsaMemoryExportResult {
+    union {
+        HSAint64 dmabuf_fd;
+    };
+} HsaMemoryExportResult;
+
+typedef struct _HsaHandleExportFlags {
+    struct {
+        unsigned int Reserved       : 32;
+    } ui32;
+} HsaHandleExportFlags;
+
+
+#pragma pack(pop, hsakmttypes_h)
 
 #ifdef __cplusplus
 }   //extern "C"

--- a/projects/rocr-runtime/libhsakmt/src/dxg/librocdxg.ver
+++ b/projects/rocr-runtime/libhsakmt/src/dxg/librocdxg.ver
@@ -102,6 +102,7 @@ hsaKmtMemoryVaUnmap;
 hsaKmtMemHandleFree;
 hsaKmtMemoryGetCpuAddr;
 hsaKmtMemoryCpuMap;
+hsaKmtGetAmdGPUDeviceFd;
 amdgpu_device_initialize;
 amdgpu_device_deinitialize;
 amdgpu_query_gpu_info;

--- a/projects/rocr-runtime/libhsakmt/src/dxg/memory.cpp
+++ b/projects/rocr-runtime/libhsakmt/src/dxg/memory.cpp
@@ -1221,3 +1221,9 @@ HSAKMT_STATUS HSAKMTAPI hsaKmtMemoryGetCpuAddr(HsaAMDGPUDeviceHandle DeviceHandl
   cpu_addr =  static_cast<HSAuint64*>(gpu_mem->CpuAddress());
   return HSAKMT_STATUS_SUCCESS;
 }
+
+
+HSAKMT_STATUS HSAKMTAPI hsaKmtGetAmdGPUDeviceFd(HsaAMDGPUDeviceHandle DeviceHandle, int *fd) {
+	// TODO: Implement me
+  return HSAKMT_STATUS_ERROR;
+}

--- a/projects/rocr-runtime/libhsakmt/src/dxg/memory.cpp
+++ b/projects/rocr-runtime/libhsakmt/src/dxg/memory.cpp
@@ -1093,7 +1093,7 @@ HSAKMT_STATUS HSAKMTAPI hsaKmtReturnAsanHeaderPage(void *addr) {
 }
 
 
-HSAKMT_STATUS HSAKMTAPI hsaKmtHandleImport(const HsaExternalHandleDesc* import_desc,
+HSAKMT_STATUS HSAKMTAPI hsaKmtHandleImport(const HsaHandleImportDesc* import_desc,
     					HsaHandleImportResult* import_res, HsaHandleImportFlags* flags)
 {
 	CHECK_DXG_OPEN();
@@ -1117,24 +1117,31 @@ HSAKMT_STATUS HSAKMTAPI hsaKmtHandleImport(const HsaExternalHandleDesc* import_d
     return HSAKMT_STATUS_NOT_SUPPORTED;
   }
 
-  if (static_cast<int>(import_desc->fd) == -1) {
+  if (static_cast<int>(import_desc->dmabuf_fd) == -1) {
     import_res->buf_handle = 0;
     return HSAKMT_STATUS_ERROR;
   }
 
   wsl::thunk::GpuMemoryHandle mem_handle;
   wsl::thunk::WDDMDevice *pDevice = reinterpret_cast<wsl::thunk::WDDMDevice *>(import_desc->device_handle);
-  bool is_ipc_memfd = is_ipc_sysmemfd(import_desc->fd);
+  bool is_ipc_memfd = is_ipc_sysmemfd(import_desc->dmabuf_fd);
   bool alloc_va = is_ipc_memfd;
 
   // kmt handle importer is false for dma_buf_fd
-  HSAKMT_STATUS ret = import_dmabuf_fd(import_desc->fd, pDevice->NodeId(), alloc_va, is_ipc_memfd,
+  HSAKMT_STATUS ret = import_dmabuf_fd(import_desc->dmabuf_fd, pDevice->NodeId(), alloc_va, is_ipc_memfd,
                                        &mem_handle, false);
   if (ret == HSAKMT_STATUS_SUCCESS) {
     //use GpuMemory object handle as drm buf handle
     import_res->buf_handle = reinterpret_cast<HsaMemoryObjectHandle>(mem_handle);
     return HSAKMT_STATUS_SUCCESS;
   }
+  return HSAKMT_STATUS_ERROR;
+}
+
+HSAKMT_STATUS HSAKMTAPI hsaKmtHandleExport(const HsaHandleExportDesc* desc,
+    					HsaMemoryExportResult* res, HsaHandleExportFlags* flags)
+{
+  // TODO: Implement me
   return HSAKMT_STATUS_ERROR;
 }
 
@@ -1206,7 +1213,7 @@ HSAKMT_STATUS HSAKMTAPI hsaKmtMemoryCpuMap(HsaMemoryObjectHandle Handle,
 }
 
 HSAKMT_STATUS HSAKMTAPI hsaKmtMemoryGetCpuAddr(HsaAMDGPUDeviceHandle DeviceHandle,
-              HsaMemoryObjectHandle MemoryHandle, HSAint32* fd, HSAuint64* cpu_addr)
+              HsaMemoryObjectHandle MemoryHandle, HSAuint64* cpu_addr)
 {
 	CHECK_DXG_OPEN();
   wsl::thunk::GpuMemory* gpu_mem = reinterpret_cast<wsl::thunk::GpuMemory*>(MemoryHandle);

--- a/projects/rocr-runtime/libhsakmt/src/libhsakmt.h
+++ b/projects/rocr-runtime/libhsakmt/src/libhsakmt.h
@@ -94,6 +94,8 @@ extern int hsakmt_page_shift;
 #define ALIGN_UP(x,align) (((uint64_t)(x) + (align) - 1) & ~(uint64_t)((align)-1))
 #define ALIGN_UP_32(x,align) (((uint32_t)(x) + (align) - 1) & ~(uint32_t)((align)-1))
 #define PAGE_ALIGN_UP(x) ALIGN_UP(x,PAGE_SIZE)
+#define IS_ALIGNED(x, alignment) (((uint64_t)(x) & ((alignment) - 1)) == 0)
+#define IS_PAGE_ALIGNED(x) (IS_ALIGNED(x, PAGE_SIZE))
 #define BITMASK(n) ((n) ? (UINT64_MAX >> (sizeof(UINT64_MAX) * CHAR_BIT - (n))) : 0)
 #define ARRAY_LEN(array) (sizeof(array) / sizeof(array[0]))
 

--- a/projects/rocr-runtime/libhsakmt/src/libhsakmt.ver
+++ b/projects/rocr-runtime/libhsakmt/src/libhsakmt.ver
@@ -95,11 +95,13 @@ hsaKmtAisReadWriteFile;
 hsaKmtGetMemoryHandle;
 #endif
 hsaKmtHandleImport;
+hsaKmtHandleExport;
 hsaKmtMemoryVaMap;
 hsaKmtMemoryVaUnmap;
 hsaKmtMemHandleFree;
 hsaKmtMemoryGetCpuAddr;
 hsaKmtMemoryCpuMap;
+hsaKmtGetAmdGPUDeviceFd;
 local: *;
 };
 

--- a/projects/rocr-runtime/libhsakmt/src/memory.c
+++ b/projects/rocr-runtime/libhsakmt/src/memory.c
@@ -554,6 +554,9 @@ HSAKMT_STATUS HSAKMTAPI hsaKmtMapMemoryToGPUNodesCtx(HsaKFDContext *ctx,
 
 	CHECK_KFD_OPEN();
 
+	assert(NumberOfNodes > 0);
+  	assert(NodeArray);
+
 	pr_debug("[%s] address %p number of nodes %lu\n",
 		__func__, MemoryAddress, NumberOfNodes);
 
@@ -934,10 +937,45 @@ HSAKMT_STATUS HSAKMTAPI hsaKmtGetAMDGPUDeviceHandle(HSAuint32 NodeId,
 	return hsaKmtGetAMDGPUDeviceHandleCtx(&hsakmt_primary_kfd_ctx, NodeId, DeviceHandle);
 }
 
-HSAKMT_STATUS HSAKMTAPI hsaKmtHandleImport(const HsaExternalHandleDesc* import_desc,
+HSAKMT_STATUS HSAKMTAPI hsaKmtHandleExport(const HsaHandleExportDesc* desc,
+    					HsaMemoryExportResult* res, HsaHandleExportFlags* flags)
+{
+	pr_debug("[%s] type:%s handle:%p size:%lx", __func__,
+					(desc->type == HSA_EXTERNAL_HANDLE_GEM_FLINK_NAME) 	? "GEM_FLINK" :
+					(desc->type == HSA_EXTERNAL_HANDLE_KMS) 			? "KMS" :
+					(desc->type == HSA_EXTERNAL_HANDLE_DMA_BUF) 		? "DMA_BUF" : "INVALID",
+					desc->buf_handle, desc->size);
+
+	enum amdgpu_bo_handle_type type;
+	switch (desc->type) {
+	case HSA_EXTERNAL_HANDLE_DMA_BUF: {
+		int renderFd = amdgpu_device_get_fd(desc->device_handle);
+  		if (renderFd < 0) {
+			return HSAKMT_STATUS_ERROR;
+		}
+
+		int ret = amdgpu_bo_export((amdgpu_bo_handle)desc->buf_handle, amdgpu_bo_handle_type_dma_buf_fd, (uint32_t*)&res->dmabuf_fd);
+		if (ret) {
+			return HSAKMT_STATUS_INVALID_HANDLE;
+		}
+	}
+	break;
+	default:
+		return HSAKMT_STATUS_NOT_SUPPORTED;
+	}
+	return HSAKMT_STATUS_SUCCESS;
+}
+
+
+
+HSAKMT_STATUS HSAKMTAPI hsaKmtHandleImport(const HsaHandleImportDesc* import_desc,
     					HsaHandleImportResult* import_res, HsaHandleImportFlags* flags)
 {
 	CHECK_KFD_OPEN();
+	int ret;
+	int dmabuf_fd;
+	struct amdgpu_bo_import_result res;
+
 	amdgpu_device_handle devhandle =  (amdgpu_device_handle)import_desc->device_handle;
 	enum amdgpu_bo_handle_type type;
 	switch (import_desc->type) {
@@ -948,14 +986,14 @@ HSAKMT_STATUS HSAKMTAPI hsaKmtHandleImport(const HsaExternalHandleDesc* import_d
 		type = amdgpu_bo_handle_type_kms;
 		break;
 	case HSA_EXTERNAL_HANDLE_DMA_BUF:
-	default:
 		type = amdgpu_bo_handle_type_dma_buf_fd;
+		 /* We already have the dmabuf_fd, so just return it */
+		dmabuf_fd = import_desc->dmabuf_fd;
+		ret = amdgpu_bo_import(devhandle, type, import_desc->dmabuf_fd, &res);
+		if (ret) return HSAKMT_STATUS_ERROR;
 		break;
-	}
-	struct amdgpu_bo_import_result res;
-	int ret = amdgpu_bo_import(devhandle, type, import_desc->fd, &res);
-	if (ret) {
-		return HSAKMT_STATUS_ERROR;
+	default:
+			return HSAKMT_STATUS_ERROR;
 	}
 
 	if (flags->ui32.IPCHandle) {
@@ -983,6 +1021,7 @@ HSAKMT_STATUS HSAKMTAPI hsaKmtHandleImport(const HsaExternalHandleDesc* import_d
 	}
 
 	import_res->buf_handle = (HsaMemoryObjectHandle)res.buf_handle;
+	import_res->dmabuf_fd = dmabuf_fd;
 	import_res->alloc_size = (HSAuint64)res.alloc_size;
 	return HSAKMT_STATUS_SUCCESS;
 }
@@ -1007,15 +1046,12 @@ HSAKMT_STATUS HSAKMTAPI hsaKmtMemoryVaMap(HsaMemoryObjectHandle Handle,
 {
 	CHECK_KFD_OPEN();
 	amdgpu_bo_handle drmhandle = (amdgpu_bo_handle)(Handle);
-    if (!drmhandle) {
-    	return HSAKMT_STATUS_ERROR;
-	}
+    if (!drmhandle) return HSAKMT_STATUS_ERROR;
 
     int ret = amdgpu_bo_va_op(drmhandle, offset, size, addr,
                       		  MapDrmPerm(flags), AMDGPU_VA_OP_MAP);
-	if (ret) {
+	if (ret)
 		return HSAKMT_STATUS_ERROR;
-	}
 
 	return HSAKMT_STATUS_SUCCESS;
 }
@@ -1067,8 +1103,9 @@ HSAKMT_STATUS HSAKMTAPI hsaKmtMemoryCpuMap(HsaMemoryObjectHandle Handle,
 	return HSAKMT_STATUS_SUCCESS;
 }
 
+/* TODO Rename this to hsaKmtMemoryGetOffset */
 HSAKMT_STATUS HSAKMTAPI hsaKmtMemoryGetCpuAddr(HsaAMDGPUDeviceHandle DeviceHandle,
-  						HsaMemoryObjectHandle MemoryHandle, HSAint32* fd, HSAuint64* cpu_addr)
+  						HsaMemoryObjectHandle MemoryHandle, HSAuint64* cpu_addr)
 {
 	CHECK_KFD_OPEN();
 	int renderFd = -1;
@@ -1092,10 +1129,19 @@ HSAKMT_STATUS HSAKMTAPI hsaKmtMemoryGetCpuAddr(HsaAMDGPUDeviceHandle DeviceHandl
   	 * The kernel driver ignores the offset and size parameters. */
   	args.in.handle = gem_handle;
   	ret = drmCommandWriteRead(renderFd, DRM_AMDGPU_GEM_MMAP, &args, sizeof(args));
-  	if (ret) {
-		return HSAKMT_STATUS_ERROR;
-  	}
-  	*fd = (HSAint32)renderFd;
+  	if (ret) return HSAKMT_STATUS_ERROR;
+
   	*cpu_addr = (HSAuint64)args.out.addr_ptr;
   	return HSAKMT_STATUS_SUCCESS;
+}
+
+HSAKMT_STATUS HSAKMTAPI hsaKmtGetAmdGPUDeviceFd(HsaAMDGPUDeviceHandle DeviceHandle, int *fd) {
+	CHECK_KFD_OPEN();
+	if (!hsakmt_fn_amdgpu_device_get_fd) {
+		*fd = -1;
+		return HSAKMT_STATUS_NOT_SUPPORTED;
+	}
+
+	*fd = hsakmt_fn_amdgpu_device_get_fd(DeviceHandle);
+	return HSAKMT_STATUS_SUCCESS;
 }

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/driver/kfd/amd_kfd_driver.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/driver/kfd/amd_kfd_driver.cpp
@@ -554,9 +554,13 @@ hsa_status_t KfdDriver::CreateShareableHandle(void* va, void* mem, size_t size,
 
   /*
    * We converted mem into a shareable_handle. The shareable_handle will keep the reference count inside
-   * so we can free new_alloc Kernel-Mode-Drivers
+   * so we can free new_alloc Kernel-Mode-Drivers.
+   * On DXG (WSL GPU), the allocation must stay registered so hsaKmtHandleImport can bypass import
+   * using import_desc->mem (same-GPU path). Runtime frees kmt_alloc_ptr in MemoryHandle::~MemoryHandle.
    */
-  hsaKmtFreeMemory(mem, size);
+  if (!core::Runtime::runtime_singleton_->thunkLoader()->IsDXG()) {
+    hsaKmtFreeMemory(mem, size);
+  }
 
   // Get address that memory is mapped to.
   auto devhandle = static_cast<const GpuAgent&>(agent).libThunkDev();
@@ -570,37 +574,38 @@ hsa_status_t KfdDriver::CreateShareableHandle(void* va, void* mem, size_t size,
   handle->handle = targetHandle.handle;
   *handle_fd = target_fd;
 #else
-  // Export memory.
+  // Export from KMT allocation, import to GPU memory object, then export again so we keep an open
+  // shareable fd (same pattern as Linux). The first fd is closed after import.
   int dmabuf_fd = 0;
   core::ShareableHandle targetHandle = {};
-  targetHandle.handle = reinterpret_cast<uint64>(mem);
-  printf("DYSDEBUG (%s:%s:%d)\n", __FILE__, __func__, __LINE__);
-  hsa_status_t err = ExportDMABuf(agent, &targetHandle, size, &dmabuf_fd, offset);
+  targetHandle.handle = reinterpret_cast<uint64_t>(mem);
+  hsa_status_t err =
+      ExportDMABuf(agent, &targetHandle, size, &dmabuf_fd, reinterpret_cast<size_t*>(offset));
   if (err != HSA_STATUS_SUCCESS) {
-    printf("DYSDEBUG (%s:%s:%d)\n", __FILE__, __func__, __LINE__);
     return err;
   }
 
-  // Import memory.
   size_t imported_size;
   err = ImportDMABuf(dmabuf_fd, agent, handle, &imported_size, mem);
   core::Runtime::runtime_singleton_->DmaBufClose(dmabuf_fd);
   if (err != HSA_STATUS_SUCCESS) {
-    printf("DYSDEBUG (%s:%s:%d)\n", __FILE__, __func__, __LINE__);
     return err;
   }
 
-  // Get address that memory is mapped to.
+  int share_fd = -1;
+  size_t share_off = 0;
+  err = ExportDMABuf(agent, handle, size, &share_fd, &share_off);
+  if (err != HSA_STATUS_SUCCESS) return err;
+  *handle_fd = share_fd;
+
   auto devhandle = static_cast<const GpuAgent&>(agent).libThunkDev();
   auto memhandle = reinterpret_cast<HsaMemoryObjectHandle>(handle->handle);
   HSAKMT_STATUS hsakmt_err =
       HSAKMT_CALL(hsaKmtMemoryGetCpuAddr(devhandle, memhandle,
                                          reinterpret_cast<HSAuint64*>(mmap_offset)));
   if (hsakmt_err != HSAKMT_STATUS_SUCCESS) {
-    printf("DYSDEBUG (%s:%s:%d)\n", __FILE__, __func__, __LINE__);
     return HSA_STATUS_ERROR;
   }
-  printf("DYSDEBUG (%s:%s:%d)\n", __FILE__, __func__, __LINE__);
 #endif
   return HSA_STATUS_SUCCESS;
 }

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/driver/kfd/amd_kfd_driver.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/driver/kfd/amd_kfd_driver.cpp
@@ -445,6 +445,7 @@ hsa_status_t KfdDriver::AllocQueueGWS(HSA_QUEUEID queue_id, uint32_t num_gws,
 
 hsa_status_t KfdDriver::ExportDMABuf(const core::Agent& agent, core::ShareableHandle *handle, size_t size, int *dmabuf_fd,
                                      size_t *offset) {
+#if defined(__linux__)
   const auto &gpu_agent = static_cast<const GpuAgent &>(agent);
 
   HsaHandleExportDesc desc = {};
@@ -461,6 +462,21 @@ hsa_status_t KfdDriver::ExportDMABuf(const core::Agent& agent, core::ShareableHa
   }
   *dmabuf_fd = res.dmabuf_fd;
   *offset = 0;
+
+  #else
+  int dmabuf_fd_res = -1;
+  size_t offset_res = 0;
+  HSAKMT_STATUS status =
+      HSAKMT_CALL(hsaKmtExportDMABufHandle(reinterpret_cast<void*>(handle->handle), size, &dmabuf_fd_res, &offset_res));
+  if (status != HSAKMT_STATUS_SUCCESS) {
+    if (status == HSAKMT_STATUS_INVALID_PARAMETER) {
+      return HSA_STATUS_ERROR_INVALID_ARGUMENT;
+    }
+    return HSA_STATUS_ERROR_OUT_OF_RESOURCES;
+  }
+  *dmabuf_fd = dmabuf_fd_res;
+  *offset = offset_res;
+  #endif
 
   return HSA_STATUS_SUCCESS;
 }
@@ -518,6 +534,7 @@ hsa_status_t KfdDriver::CreateShareableHandle(void* va, void* mem, size_t size,
                                               int* handle_fd, uint64_t* mmap_offset) {
   // Create handle by exporting and importing the memory from the owning agent.
 
+#if defined(__linux__)
   // Export memory from KFD
   int kfd_dmabuf_fd = 0;
   auto hsakmt_err = hsaKmtExportDMABufHandle(mem, size, &kfd_dmabuf_fd, offset);
@@ -552,6 +569,39 @@ hsa_status_t KfdDriver::CreateShareableHandle(void* va, void* mem, size_t size,
 
   handle->handle = targetHandle.handle;
   *handle_fd = target_fd;
+#else
+  // Export memory.
+  int dmabuf_fd = 0;
+  core::ShareableHandle targetHandle = {};
+  targetHandle.handle = reinterpret_cast<uint64>(mem);
+  printf("DYSDEBUG (%s:%s:%d)\n", __FILE__, __func__, __LINE__);
+  hsa_status_t err = ExportDMABuf(agent, &targetHandle, size, &dmabuf_fd, offset);
+  if (err != HSA_STATUS_SUCCESS) {
+    printf("DYSDEBUG (%s:%s:%d)\n", __FILE__, __func__, __LINE__);
+    return err;
+  }
+
+  // Import memory.
+  size_t imported_size;
+  err = ImportDMABuf(dmabuf_fd, agent, handle, &imported_size, mem);
+  core::Runtime::runtime_singleton_->DmaBufClose(dmabuf_fd);
+  if (err != HSA_STATUS_SUCCESS) {
+    printf("DYSDEBUG (%s:%s:%d)\n", __FILE__, __func__, __LINE__);
+    return err;
+  }
+
+  // Get address that memory is mapped to.
+  auto devhandle = static_cast<const GpuAgent&>(agent).libThunkDev();
+  auto memhandle = reinterpret_cast<HsaMemoryObjectHandle>(handle->handle);
+  HSAKMT_STATUS hsakmt_err =
+      HSAKMT_CALL(hsaKmtMemoryGetCpuAddr(devhandle, memhandle,
+                                         reinterpret_cast<HSAuint64*>(mmap_offset)));
+  if (hsakmt_err != HSAKMT_STATUS_SUCCESS) {
+    printf("DYSDEBUG (%s:%s:%d)\n", __FILE__, __func__, __LINE__);
+    return HSA_STATUS_ERROR;
+  }
+  printf("DYSDEBUG (%s:%s:%d)\n", __FILE__, __func__, __LINE__);
+#endif
   return HSA_STATUS_SUCCESS;
 }
 

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/driver/kfd/amd_kfd_driver.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/driver/kfd/amd_kfd_driver.cpp
@@ -280,7 +280,7 @@ KfdDriver::AllocateMemory(const core::MemoryRegion &mem_region,
     !!(alloc_flags & core::MemoryRegion::AllocateExecutableBlitKernelObject);
 
   if (m_region.IsLocalMemory()) {
-    // Allocate physically contiguous memory. AllocateKfdMemory function call
+    // Allocate physically contiguous memory. hsaKmtAllocMemory function call
     // will fail if this flag is not supported in KFD.
     kmt_alloc_flags.ui32.Contiguous =
         (alloc_flags & core::MemoryRegion::AllocateContiguous
@@ -318,15 +318,17 @@ KfdDriver::AllocateMemory(const core::MemoryRegion &mem_region,
 
   //// Allocate memory.
   //// If it fails attempt to release memory from the block allocator and retry.
-  *mem = AllocateKfdMemory(kmt_alloc_flags, node_id, size);
-  if (*mem == nullptr) {
-    m_region.owner()->Trim();
-    *mem = AllocateKfdMemory(kmt_alloc_flags, node_id, size);
-  }
 
-  if (*mem != nullptr) {
-    if (kmt_alloc_flags.ui32.NoAddress)
+  auto status = HSAKMT_CALL(hsaKmtAllocMemory(node_id, size, kmt_alloc_flags, mem));
+  if (status == HSAKMT_STATUS_NO_MEMORY) {
+    m_region.owner()->Trim();
+    status = HSAKMT_CALL(hsaKmtAllocMemory(node_id, size, kmt_alloc_flags, mem));
+  }
+  if (status == HSAKMT_STATUS_SUCCESS) {
+    if (kmt_alloc_flags.ui32.NoAddress) {
+      // returns mem
       return HSA_STATUS_SUCCESS;
+    }
 
     // Commit the memory.
     // For system memory, on non-restricted allocation, map it to all GPUs. On
@@ -357,23 +359,25 @@ KfdDriver::AllocateMemory(const core::MemoryRegion &mem_region,
     }
 
     uint64_t alternate_va = 0;
-    const bool is_resident = MakeKfdMemoryResident(
-        map_node_count, map_node_id, *mem, size, &alternate_va, map_flag);
+
+    const bool is_resident =
+      (HSAKMT_CALL(hsaKmtMapMemoryToGPUNodes(*mem, size, &alternate_va, map_flag,
+                                             map_node_count, const_cast<uint32_t*>(map_node_id))) == HSAKMT_STATUS_SUCCESS);
 
     const bool require_pinning =
         (!m_region.full_profile() || m_region.IsLocalMemory() ||
          m_region.IsScratch());
 
     if (require_pinning && !is_resident) {
-      FreeKfdMemory(*mem, size);
+      HSAKMT_CALL(hsaKmtUnmapMemoryToGPU(*mem));
+      HSAKMT_CALL(hsaKmtFreeMemory(*mem, size));
       *mem = nullptr;
       return HSA_STATUS_ERROR_OUT_OF_RESOURCES;
     }
 
     if ((alloc_flags & core::MemoryRegion::AllocateAsan) &&
         HSAKMT_CALL(hsaKmtReplaceAsanHeaderPage(*mem)) != HSAKMT_STATUS_SUCCESS) {
-      FreeKfdMemory(*mem, size);
-      *mem = nullptr;
+      HSAKMT_CALL(hsaKmtFreeMemory(*mem, size));
       return HSA_STATUS_ERROR_OUT_OF_RESOURCES;
     }
     return HSA_STATUS_SUCCESS;
@@ -383,8 +387,8 @@ KfdDriver::AllocateMemory(const core::MemoryRegion &mem_region,
 }
 
 hsa_status_t KfdDriver::FreeMemory(void *mem, size_t size) {
-  MakeKfdMemoryUnresident(mem);
-  return FreeKfdMemory(mem, size) ? HSA_STATUS_SUCCESS : HSA_STATUS_ERROR;
+  HSAKMT_CALL(hsaKmtUnmapMemoryToGPU(const_cast<void *>(mem)));
+  return (HSAKMT_CALL(hsaKmtFreeMemory(mem, size)) == HSAKMT_STATUS_SUCCESS) ? HSA_STATUS_SUCCESS : HSA_STATUS_ERROR;
 }
 
 hsa_status_t KfdDriver::CreateQueue(uint32_t node_id, HSA_QUEUE_TYPE type, uint32_t queue_pct,
@@ -439,31 +443,34 @@ hsa_status_t KfdDriver::AllocQueueGWS(HSA_QUEUEID queue_id, uint32_t num_gws,
   return HSA_STATUS_SUCCESS;
 }
 
-hsa_status_t KfdDriver::ExportDMABuf(void *mem, size_t size, int *dmabuf_fd,
+hsa_status_t KfdDriver::ExportDMABuf(const core::Agent& agent, core::ShareableHandle *handle, size_t size, int *dmabuf_fd,
                                      size_t *offset) {
-  int dmabuf_fd_res = -1;
-  size_t offset_res = 0;
-  HSAKMT_STATUS status =
-      HSAKMT_CALL(hsaKmtExportDMABufHandle(mem, size, &dmabuf_fd_res, &offset_res));
-  if (status != HSAKMT_STATUS_SUCCESS) {
-    if (status == HSAKMT_STATUS_INVALID_PARAMETER) {
-      return HSA_STATUS_ERROR_INVALID_ARGUMENT;
-    }
-    return HSA_STATUS_ERROR_OUT_OF_RESOURCES;
-  }
+  const auto &gpu_agent = static_cast<const GpuAgent &>(agent);
 
-  *dmabuf_fd = dmabuf_fd_res;
-  *offset = offset_res;
+  HsaHandleExportDesc desc = {};
+  desc.device_handle = gpu_agent.libThunkDev();
+  desc.type = HSA_EXTERNAL_HANDLE_DMA_BUF;
+  desc.buf_handle = (HsaMemoryObjectHandle)handle->handle; /* mem is of type amdgpu_bo_handle */
+  desc.size = size;
+
+  HsaHandleExportFlags flags = {};
+  HsaMemoryExportResult res = {};
+
+  if (HSAKMT_CALL(hsaKmtHandleExport(&desc, &res, &flags)) != HSAKMT_STATUS_SUCCESS) {
+    return HSA_STATUS_ERROR;
+  }
+  *dmabuf_fd = res.dmabuf_fd;
+  *offset = 0;
 
   return HSA_STATUS_SUCCESS;
 }
 
 hsa_status_t KfdDriver::ImportDMABuf(int dmabuf_fd, const core::Agent& agent,
-                                     core::ShareableHandle* handle, void* mem) {
+                                     core::ShareableHandle* handle, size_t *size, void* mem) {
   const auto& gpu_agent = static_cast<const GpuAgent&>(agent);
-  HsaExternalHandleDesc desc;
+  HsaHandleImportDesc desc;
   desc.device_handle = gpu_agent.libThunkDev();
-  desc.fd = static_cast<HSAint64>(dmabuf_fd);
+  desc.dmabuf_fd = static_cast<HSAint32>(dmabuf_fd);
   desc.type = HSA_EXTERNAL_HANDLE_DMA_BUF;
   desc.mem = mem;
   desc.metadata = 0;
@@ -473,7 +480,8 @@ hsa_status_t KfdDriver::ImportDMABuf(int dmabuf_fd, const core::Agent& agent,
   if (status != HSAKMT_STATUS_SUCCESS) {
     return HSA_STATUS_ERROR;
   }
-  *handle = core::ShareableHandle{reinterpret_cast<uint64_t>(res.buf_handle)};
+  handle->handle = reinterpret_cast<uint64_t>(res.buf_handle);
+  *size = res.alloc_size;
   return HSA_STATUS_SUCCESS;
 }
 
@@ -488,9 +496,8 @@ hsa_status_t KfdDriver::Map(core::ShareableHandle handle, void* mem, size_t offs
   HSAKMT_STATUS status = HSAKMT_CALL(hsaKmtMemoryVaMap(memhandle, static_cast<HSAuint64>(offset),
                                      static_cast<HSAuint64>(size), reinterpret_cast<HSAuint64>(mem),
                                      mem_perm(perms)));
-  if (status != HSAKMT_STATUS_SUCCESS) {
-    return HSA_STATUS_ERROR;
-  }
+  if (status != HSAKMT_STATUS_SUCCESS) return HSA_STATUS_ERROR;
+
   return HSA_STATUS_SUCCESS;
 }
 
@@ -508,38 +515,51 @@ hsa_status_t KfdDriver::Unmap(core::ShareableHandle handle, void *mem,
 hsa_status_t KfdDriver::CreateShareableHandle(void* va, void* mem, size_t size,
                                               const core::Agent& agent,
                                               core::ShareableHandle* handle, uint64_t* offset,
-                                              int* drm_fd, uint64_t* drm_fd_offset) {
+                                              int* handle_fd, uint64_t* mmap_offset) {
   // Create handle by exporting and importing the memory from the owning agent.
 
-  // Export memory.
-  int dmabuf_fd = 0;
-  hsa_status_t err = ExportDMABuf(mem, size, &dmabuf_fd, offset);
-  if (err != HSA_STATUS_SUCCESS) return err;
+  // Export memory from KFD
+  int kfd_dmabuf_fd = 0;
+  auto hsakmt_err = hsaKmtExportDMABufHandle(mem, size, &kfd_dmabuf_fd, offset);
+  if (hsakmt_err != HSAKMT_STATUS_SUCCESS) return HSA_STATUS_ERROR;
 
-  // Import memory.
-  err = ImportDMABuf(dmabuf_fd, agent, handle, mem);
-  core::Runtime::runtime_singleton_->DmaBufClose(dmabuf_fd);
-  if (err != HSA_STATUS_SUCCESS) return err;
+  // Import memory into DRM
+  core::ShareableHandle targetHandle = {};
+  size_t imported_size;
+  auto err = ImportDMABuf(kfd_dmabuf_fd, agent, &targetHandle, &imported_size, mem);
+  core::Runtime::runtime_singleton_->DmaBufClose(kfd_dmabuf_fd);
+  if (err != HSA_STATUS_SUCCESS) return HSA_STATUS_ERROR;
+  assert(imported_size == size);
+
+  int target_fd = -1;
+  err = ExportDMABuf(agent, &targetHandle, size, &target_fd, mmap_offset);
+  if (err != HSA_STATUS_SUCCESS) return HSA_STATUS_ERROR;
+
+  /*
+   * We converted mem into a shareable_handle. The shareable_handle will keep the reference count inside
+   * so we can free new_alloc Kernel-Mode-Drivers
+   */
+  hsaKmtFreeMemory(mem, size);
 
   // Get address that memory is mapped to.
   auto devhandle = static_cast<const GpuAgent&>(agent).libThunkDev();
-  auto memhandle = reinterpret_cast<HsaMemoryObjectHandle>(handle->handle);
-  HSAKMT_STATUS hsakmt_err =
-      HSAKMT_CALL(hsaKmtMemoryGetCpuAddr(devhandle, memhandle, reinterpret_cast<HSAint32*>(drm_fd),
-                                         reinterpret_cast<HSAuint64*>(drm_fd_offset)));
-  if (hsakmt_err != HSAKMT_STATUS_SUCCESS) {
-    return HSA_STATUS_ERROR;
-  }
+  auto memhandle = reinterpret_cast<HsaMemoryObjectHandle>(targetHandle.handle);
 
+  hsakmt_err =
+      HSAKMT_CALL(hsaKmtMemoryGetCpuAddr(devhandle, memhandle,
+                                         reinterpret_cast<HSAuint64*>(mmap_offset)));
+  if (hsakmt_err != HSAKMT_STATUS_SUCCESS) return HSA_STATUS_ERROR;
+
+  handle->handle = targetHandle.handle;
+  *handle_fd = target_fd;
   return HSA_STATUS_SUCCESS;
 }
 
 hsa_status_t KfdDriver::DestroyShareableHandle(core::ShareableHandle* handle) {
   auto memhandle = reinterpret_cast<HsaMemoryObjectHandle>(handle->handle);
+
   HSAKMT_STATUS status = HSAKMT_CALL(hsaKmtMemHandleFree(memhandle));
-  if (status != HSAKMT_STATUS_SUCCESS) {
-    return HSA_STATUS_ERROR;
-  }
+  if (status != HSAKMT_STATUS_SUCCESS) return HSA_STATUS_ERROR;
   *handle = {};
   return HSA_STATUS_SUCCESS;
 }
@@ -571,46 +591,6 @@ hsa_status_t KfdDriver::OpenSMI(uint32_t node_id, int* fd) const {
     return HSA_STATUS_ERROR;
   }
   return HSA_STATUS_SUCCESS;
-}
-
-void *KfdDriver::AllocateKfdMemory(const HsaMemFlags &flags, uint32_t node_id,
-                                   size_t size) {
-  void *mem = nullptr;
-  const HSAKMT_STATUS status = HSAKMT_CALL(hsaKmtAllocMemory(node_id, size, flags, &mem));
-  return (status == HSAKMT_STATUS_SUCCESS) ? mem : nullptr;
-}
-
-bool KfdDriver::FreeKfdMemory(void *mem, size_t size) {
-  if (mem == nullptr || size == 0) {
-    debug_print("Invalid free ptr:%p size:%lu\n", mem, size);
-    return false;
-  }
-
-  if (HSAKMT_CALL(hsaKmtFreeMemory(mem, size)) != HSAKMT_STATUS_SUCCESS) {
-    debug_print("Failed to free ptr:%p size:%lu\n", mem, size);
-    return false;
-  }
-  return true;
-}
-
-bool KfdDriver::MakeKfdMemoryResident(size_t num_node, const uint32_t *nodes,
-                                      const void *mem, size_t size,
-                                      uint64_t *alternate_va,
-                                      HsaMemMapFlags map_flag) {
-  assert(num_node > 0);
-  assert(nodes);
-
-  *alternate_va = 0;
-
-  HSAKMT_STATUS kmt_status(HSAKMT_CALL(hsaKmtMapMemoryToGPUNodes(
-      const_cast<void *>(mem), size, alternate_va, map_flag, num_node,
-      const_cast<uint32_t *>(nodes))));
-
-  return (kmt_status == HSAKMT_STATUS_SUCCESS);
-}
-
-void KfdDriver::MakeKfdMemoryUnresident(const void *mem) {
-  HSAKMT_CALL(hsaKmtUnmapMemoryToGPU(const_cast<void *>(mem)));
 }
 
 bool KfdDriver::BindXnackMode() {
@@ -659,10 +639,9 @@ hsa_status_t KfdDriver::AllocateScratchMemory(uint32_t node_id, uint64_t size, v
   flags.ui32.Scratch = 1;
   flags.ui32.HostAccess = 1;
 
-  void* ptr = AllocateKfdMemory(flags, node_id, size);
-  if (ptr == nullptr) return HSA_STATUS_ERROR_OUT_OF_RESOURCES;
-
-  *mem = ptr;
+  *mem = nullptr;
+  auto status = HSAKMT_CALL(hsaKmtAllocMemory(node_id, size, flags, mem));
+  if (status != HSAKMT_STATUS_SUCCESS || *mem == nullptr) return HSA_STATUS_ERROR_OUT_OF_RESOURCES;
   return HSA_STATUS_SUCCESS;
 }
 
@@ -670,6 +649,18 @@ hsa_status_t KfdDriver::GetDeviceHandle(uint32_t node_id, void** device_handle) 
   assert(device_handle);
 
   if (HSAKMT_CALL(hsaKmtGetAMDGPUDeviceHandle(node_id, reinterpret_cast<HsaAMDGPUDeviceHandle*>(device_handle))) != HSAKMT_STATUS_SUCCESS)
+    return HSA_STATUS_ERROR;
+
+  return HSA_STATUS_SUCCESS;
+}
+
+hsa_status_t KfdDriver::GetDeviceFd(uint32_t node_id, int *fd) const {
+  HsaAMDGPUDeviceHandle device_handle;
+
+  if (HSAKMT_CALL(hsaKmtGetAMDGPUDeviceHandle(node_id, &device_handle)) != HSAKMT_STATUS_SUCCESS)
+    return HSA_STATUS_ERROR;
+
+  if (HSAKMT_CALL(hsaKmtGetAmdGPUDeviceFd(device_handle, fd)) != HSAKMT_STATUS_SUCCESS)
     return HSA_STATUS_ERROR;
 
   return HSA_STATUS_SUCCESS;
@@ -724,7 +715,8 @@ hsa_status_t KfdDriver::MakeMemoryResident(const void* mem, size_t size, uint64_
       return HSA_STATUS_ERROR;
     }
   } else if (mem_flags != nullptr && nodes != nullptr) {
-    if (!MakeKfdMemoryResident(num_nodes, nodes, mem, size, alternate_va, *mem_flags)) {
+    if (HSAKMT_CALL(hsaKmtMapMemoryToGPUNodes(const_cast<void*>(mem), size, alternate_va,
+                                              *mem_flags, num_nodes, const_cast<uint32_t *>(nodes))) != HSAKMT_STATUS_SUCCESS) {
       return HSA_STATUS_ERROR;
     }
   } else {

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/driver/virtio/amd_kfd_virtio_driver.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/driver/virtio/amd_kfd_virtio_driver.cpp
@@ -194,6 +194,10 @@ hsa_status_t KfdVirtioDriver::GetDeviceHandle(uint32_t node_id, void** device_ha
   return HSA_STATUS_SUCCESS;
 }
 
+hsa_status_t KfdVirtioDriver::GetDeviceFd(uint32_t node_id, int *fd) const {
+  return HSA_STATUS_ERROR;
+}
+
 hsa_status_t KfdVirtioDriver::GetClockCounters(uint32_t node_id,
                                                HsaClockCounters* clock_counter) const {
   assert(clock_counter != nullptr);
@@ -462,11 +466,11 @@ hsa_status_t KfdVirtioDriver::AllocQueueGWS(HSA_QUEUEID queue_id, uint32_t num_G
   return HSA_STATUS_ERROR;
 }
 
-hsa_status_t KfdVirtioDriver::ExportDMABuf(void* mem, size_t size, int* dmabuf_fd, size_t* offset) {
+hsa_status_t KfdVirtioDriver::ExportDMABuf(const core::Agent& agent, core::ShareableHandle *handle, size_t size, int* dmabuf_fd, size_t* offset) {
   int dmabuf_fd_res = -1;
   size_t offset_res = 0;
   HSAKMT_STATUS status =
-      vhsaKmtExportDMABufHandle(mem, size, &dmabuf_fd_res, &offset_res);
+      vhsaKmtExportDMABufHandle(handle, size, &dmabuf_fd_res, &offset_res);
   if (status != HSAKMT_STATUS_SUCCESS) {
     if (status == HSAKMT_STATUS_INVALID_PARAMETER) {
       return HSA_STATUS_ERROR_INVALID_ARGUMENT;
@@ -481,7 +485,7 @@ hsa_status_t KfdVirtioDriver::ExportDMABuf(void* mem, size_t size, int* dmabuf_f
 }
 
 hsa_status_t KfdVirtioDriver::ImportDMABuf(int dmabuf_fd, const core::Agent& agent,
-                                           core::ShareableHandle* handle, void* mem) {
+                                           core::ShareableHandle* handle, size_t *size, void* mem) {
   const auto& gpu_agent = static_cast<const GpuAgent&>(agent);
   amdgpu_bo_import_result res;
   auto ret = vamdgpu_bo_import(
@@ -490,6 +494,7 @@ hsa_status_t KfdVirtioDriver::ImportDMABuf(int dmabuf_fd, const core::Agent& age
     return HSA_STATUS_ERROR;
 
   *handle = core::ShareableHandle{reinterpret_cast<uint64_t>(res.buf_handle)};
+  *size = res.alloc_size;
   return HSA_STATUS_SUCCESS;
 }
 

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/driver/xdna/amd_xdna_driver.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/driver/xdna/amd_xdna_driver.cpp
@@ -367,7 +367,7 @@ XdnaDriver::AllocateMemory(const core::MemoryRegion &mem_region,
   if (use_bo_shmem) {
     if (alloc_flags & core::MemoryRegion::AllocateMemoryOnly) {
       /// TODO: We create an anonymous mapping to get a unique virtual address since the memory
-      /// handle mapping, i.e., Runtime::memory_handle_map_, is indexed using ThunkHandle which is
+      /// handle mapping, i.e., Runtime::memory_handle_map_, is indexed using DriverHandle which is
       /// driver-agnostic and just a pointer to the virtual address space. We waste a page, but it
       /// ensures uniqueness across drivers.
       bo_handle.vaddr =
@@ -429,8 +429,8 @@ hsa_status_t XdnaDriver::FreeMemory(void *mem, size_t size) {
 
 hsa_status_t XdnaDriver::CreateQueue(uint32_t node_id, HSA_QUEUE_TYPE type, uint32_t queue_pct,
                                      HSA::hsa_amd_queue_priority_internal_t priority, uint32_t sdma_engine_id,
-                                     void* queue_addr, uint64_t queue_size_bytes, HsaEvent* event,
-                                     HsaQueueResource& queue_resource) const {
+                                     void* queue_addr, uint64_t queue_size_bytes,
+                                     HsaEvent* event, HsaQueueResource& queue_resource) const {
   queue_resource.QueueId = AMDXDNA_INVALID_CTX_HANDLE;
   return HSA_STATUS_SUCCESS;
 }
@@ -476,8 +476,8 @@ hsa_status_t XdnaDriver::AllocQueueGWS(HSA_QUEUEID queue_id, uint32_t num_gws,
   return HSA_STATUS_ERROR_INVALID_QUEUE;
 }
 
-hsa_status_t XdnaDriver::ExportDMABuf(void* mem, size_t size, int* dmabuf_fd, size_t* offset) {
-  auto bo_handle = FindBOHandle(mem);
+hsa_status_t XdnaDriver::ExportDMABuf(const core::Agent& agent, core::ShareableHandle *handle, size_t size, int* dmabuf_fd, size_t* offset) {
+  auto bo_handle = FindBOHandle(handle);
   if (!bo_handle.IsValid()) {
     return HSA_STATUS_ERROR_INVALID_ALLOCATION;
   }
@@ -491,13 +491,13 @@ hsa_status_t XdnaDriver::ExportDMABuf(void* mem, size_t size, int* dmabuf_fd, si
   }
 
   *dmabuf_fd = export_params.fd;
-  *offset = reinterpret_cast<uintptr_t>(mem) - reinterpret_cast<uintptr_t>(bo_handle.vaddr);
+  *offset = reinterpret_cast<uintptr_t>(handle) - reinterpret_cast<uintptr_t>(bo_handle.vaddr);
 
   return HSA_STATUS_SUCCESS;
 }
 
 hsa_status_t XdnaDriver::ImportDMABuf(int dmabuf_fd, const core::Agent& agent,
-                                      core::ShareableHandle* handle, void* mem) {
+                                      core::ShareableHandle* handle, size_t* size, void* mem) {
   drm_prime_handle import_params = {};
   import_params.handle = AMDXDNA_INVALID_BO_HANDLE;
   import_params.fd = dmabuf_fd;
@@ -505,6 +505,7 @@ hsa_status_t XdnaDriver::ImportDMABuf(int dmabuf_fd, const core::Agent& agent,
     return HSA_STATUS_ERROR;
 
   *handle = core::ShareableHandle{import_params.handle};
+  *size = 0;
   return HSA_STATUS_SUCCESS;
 }
 
@@ -1088,6 +1089,10 @@ hsa_status_t XdnaDriver::AllocateScratchMemory(uint32_t node_id, uint64_t size, 
 }
 
 hsa_status_t XdnaDriver::GetDeviceHandle(uint32_t node_id, void** device_handle) const {
+  return HSA_STATUS_ERROR;
+}
+
+hsa_status_t XdnaDriver::GetDeviceFd(uint32_t node_id, int *fd) const {
   return HSA_STATUS_ERROR;
 }
 

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/inc/amd_kfd_driver.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/inc/amd_kfd_driver.h
@@ -107,10 +107,10 @@ public:
                               uint32_t* queue_cu_mask) const override;
   hsa_status_t AllocQueueGWS(HSA_QUEUEID queue_id, uint32_t num_gws,
                              uint32_t* first_gws) const override;
-  hsa_status_t ExportDMABuf(void *mem, size_t size, int *dmabuf_fd,
+  hsa_status_t ExportDMABuf(const core::Agent& agent, core::ShareableHandle* handle, size_t size, int *dmabuf_fd,
                             size_t *offset) override;
   hsa_status_t ImportDMABuf(int dmabuf_fd, const core::Agent& agent, core::ShareableHandle* handle,
-                            void* mem) override;
+                            size_t *size, void* mem) override;
   hsa_status_t DestroyImportedShareableHandle(core::ShareableHandle* handle) override;
   hsa_status_t Map(core::ShareableHandle handle, void *mem, size_t offset,
                    size_t size, hsa_access_permission_t perms) override;
@@ -128,6 +128,7 @@ public:
   hsa_status_t SetTrapHandler(uint32_t node_id, const void* base, uint64_t base_size,
                               const void* buffer_base, uint64_t buffer_base_size) const override;
   hsa_status_t GetDeviceHandle(uint32_t node_id, void** device_handle) const override;
+  hsa_status_t GetDeviceFd(uint32_t node_id, int *fd) const override;
   hsa_status_t GetClockCounters(uint32_t node_id, HsaClockCounters* clock_counter) const override;
   hsa_status_t GetTileConfig(uint32_t node_id, HsaGpuTileConfig* config) const override;
   hsa_status_t GetWallclockFrequency(uint32_t node_id, uint64_t* frequency) const override;
@@ -147,22 +148,7 @@ public:
   hsa_status_t GetQueueSaveAreaInfo(HSA_QUEUEID queue_id, void** address, size_t* size) const override;
 
  private:
-  /// @brief Allocate agent accessible memory (system / local memory).
-  static void *AllocateKfdMemory(const HsaMemFlags &flags, uint32_t node_id,
-                                 size_t size);
-
-  /// @brief Free agent accessible memory (system / local memory).
-  static bool FreeKfdMemory(void *mem, size_t size);
-
-  /// @brief Pin memory.
-  static bool MakeKfdMemoryResident(size_t num_node, const uint32_t *nodes,
-                                    const void *mem, size_t size,
-                                    uint64_t *alternate_va,
-                                    HsaMemMapFlags map_flag);
-
-  /// @brief Unpin memory.
-  static void MakeKfdMemoryUnresident(const void *mem);
-
+ 
   /// @brief Query for user preference and use that to determine Xnack mode
   /// of ROCm system. Return true if Xnack mode is ON or false if OFF. Xnack
   /// mode of a system is orthogonal to devices that do not support Xnack mode.

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/inc/amd_virtio_driver.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/inc/amd_virtio_driver.h
@@ -74,6 +74,7 @@ class KfdVirtioDriver final : public core::Driver {
   hsa_status_t GetCacheProperties(uint32_t node_id, uint32_t processor_id,
                                   std::vector<HsaCacheProperties>& cache_props) const override;
   hsa_status_t GetDeviceHandle(uint32_t node_id, void** device_handle) const;
+  hsa_status_t GetDeviceFd(uint32_t node_id, int *fd) const override;
   hsa_status_t GetClockCounters(uint32_t node_id, HsaClockCounters* clock_counter) const;
   hsa_status_t SetTrapHandler(uint32_t node_id, const void* base, uint64_t base_size,
                               const void* buffer_base, uint64_t buffer_base_size) const;
@@ -89,7 +90,7 @@ class KfdVirtioDriver final : public core::Driver {
                                   const HsaMemMapFlags* mem_flags, uint32_t num_nodes,
                                   const uint32_t* nodes) const override;
   hsa_status_t MakeMemoryUnresident(const void* mem) const override;
-  hsa_status_t CreateQueue(uint32_t node_id, HSA_QUEUE_TYPE type, uint32_t queue_pct,
+  hsa_status_t Queue(uint32_t node_id, HSA_QUEUE_TYPE type, uint32_t queue_pct,
                            HSA::hsa_amd_queue_priority_internal_t priority, uint32_t sdma_engine_id, void* queue_addr,
                            uint64_t queue_size_bytes, HsaEvent* event,
                            HsaQueueResource& queue_resource) const override;
@@ -100,7 +101,7 @@ class KfdVirtioDriver final : public core::Driver {
   hsa_status_t SetQueueCUMask(HSA_QUEUEID queue_id, uint32_t num_cu_mask,
                               uint32_t* cu_mask) const override;
   hsa_status_t AllocQueueGWS(HSA_QUEUEID queue_id, uint32_t num_GWS, uint32_t* GWS) const override;
-  hsa_status_t ExportDMABuf(void* mem, size_t size, int* dmabuf_fd, size_t* offset) override;
+  hsa_status_t ExportDMABuf(const core::Agent& agent, core::ShareableHandle *handle, size_t size, int* dmabuf_fd, size_t* offset) override;
   hsa_status_t ImportDMABuf(int dmabuf_fd, const core::Agent& agent, core::ShareableHandle* handle,
                             void* mem) override;
   hsa_status_t DestroyImportedShareableHandle(core::ShareableHandle* handle) override;

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/inc/amd_xdna_driver.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/inc/amd_xdna_driver.h
@@ -206,9 +206,9 @@ public:
                               uint32_t* queue_cu_mask) const override;
   hsa_status_t AllocQueueGWS(HSA_QUEUEID queue_id, uint32_t num_gws,
                              uint32_t* first_gws) const override;
-  hsa_status_t ExportDMABuf(void *mem, size_t size, int *dmabuf_fd,
+  hsa_status_t ExportDMABuf(const core::Agent& agent, core::ShareableHandle *handle, size_t size, int *dmabuf_fd,
                             size_t *offset) override;
-  hsa_status_t ImportDMABuf(int dmabuf_fd, const core::Agent& agent, core::ShareableHandle* handle,
+  hsa_status_t ImportDMABuf(int dmabuf_fd, const core::Agent& agent, core::ShareableHandle* handle, size_t *size,
                             void* mem) override;
   hsa_status_t DestroyImportedShareableHandle(core::ShareableHandle* handle) override;
   hsa_status_t Map(core::ShareableHandle handle, void *mem, size_t offset,
@@ -232,6 +232,7 @@ public:
   hsa_status_t SetTrapHandler(uint32_t node_id, const void* base, uint64_t base_size,
                               const void* buffer_base, uint64_t buffer_base_size) const override;
   hsa_status_t GetDeviceHandle(uint32_t node_id, void** device_handle) const override;
+  hsa_status_t GetDeviceFd(uint32_t node_id, int *fd) const override;
   hsa_status_t GetClockCounters(uint32_t node_id, HsaClockCounters* clock_counter) const override;
   hsa_status_t GetTileConfig(uint32_t node_id, HsaGpuTileConfig* config) const override;
   hsa_status_t GetWallclockFrequency(uint32_t node_id, uint64_t* frequency) const override;

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/inc/driver.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/inc/driver.h
@@ -70,9 +70,13 @@ enum class DriverType {
 
 /// @brief Handle for exported / imported memory.
 struct ShareableHandle {
-  uint64_t handle{};
+  uint64_t handle;
 
   bool IsValid() const { return handle != 0; }
+
+  bool operator()(const ShareableHandle& a, const ShareableHandle& b) const {
+    return a.handle > b.handle;
+  }
 };
 
 /// @brief Kernel driver interface.
@@ -202,7 +206,7 @@ public:
   /// @param[in] size memory size in bytes
   /// @param[out] dmabuf_fd dma-buf file descriptor
   /// @param[out] offset memory offset in bytes
-  virtual hsa_status_t ExportDMABuf(void *mem, size_t size, int *dmabuf_fd,
+  virtual hsa_status_t ExportDMABuf(const core::Agent& agent, core::ShareableHandle *handle, size_t size, int *dmabuf_fd,
                                     size_t *offset) = 0;
 
   /// @brief Imports a memory object via dma-buf.
@@ -214,7 +218,7 @@ public:
   /// @param[out] handle handle to the imported memory
   /// @param[in] mem address of existing buffer, used to bypass import
   virtual hsa_status_t ImportDMABuf(int dmabuf_fd, const core::Agent& agent,
-                                    core::ShareableHandle* handle, void* mem = nullptr) = 0;
+                                    core::ShareableHandle* handle, size_t *size, void* mem = nullptr) = 0;
 
   /// @brief Destroys the handle created during @ref ImportDMABuf.
   ///
@@ -308,6 +312,11 @@ public:
   /// @return HSA_STATUS_SUCCESS if the driver successfully returns the device
   virtual hsa_status_t GetDeviceHandle(uint32_t node_id, void** device_handle) const = 0;
 
+  /// @brief Gets the device file descriptor for a specific node.
+  /// @param[in] node_id Node ID of the agent
+  /// @param[out] fd
+  /// @return HSA_STATUS_SUCCESS if the driver successfully returns the file descriptor
+  virtual hsa_status_t GetDeviceFd(uint32_t node_id, int *fd) const = 0;
 
   /// @brief Gets clock counters for particular Node
   /// @param[in] node_id Node ID of the agent

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/inc/runtime.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/inc/runtime.h
@@ -946,7 +946,7 @@ class Runtime {
   struct MemoryHandle {
     MemoryHandle(const MemoryRegion* region, size_t size, uint64_t flags_unused,
                  ShareableHandle shareable_handle, int dmabuf_fd, uint64_t mmap_offset,
-                 bool imported, MemoryRegion::AllocateFlags alloc_flag);
+                 void* kmt_alloc_ptr, bool imported, MemoryRegion::AllocateFlags alloc_flag);
     ~MemoryHandle();
 
     static __forceinline hsa_amd_vmem_alloc_handle_t Convert(ShareableHandle handle) {
@@ -968,6 +968,9 @@ class Runtime {
     ShareableHandle shareable_handle;  // handle returned by Driver::Allocate(NoAddress = 1)
     HSAint64 dmabuf_fd;
     uint64_t mmap_offset;
+    /// Original KMT allocation VA when it must outlive CreateShareableHandle (Windows / DXG).
+    /// nullptr on Linux KFD where the allocation is released inside CreateShareableHandle.
+    void* kmt_alloc_ptr;
     bool imported; /* True is this BO belongs to another process */
     MemoryRegion::AllocateFlags alloc_flag;
   };

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/inc/runtime.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/inc/runtime.h
@@ -931,8 +931,6 @@ class Runtime {
 
   os::LibHandle aqlprofile_lib_;
 
-  typedef void* ThunkHandle;
-
   struct AddressHandle {
     AddressHandle() : os_addr(nullptr), size(0), use_count(0), registered(false) {}
     AddressHandle(void* addr, size_t _size, bool _registered) : os_addr(addr), size(_size), use_count(0), registered(_registered) {}
@@ -947,22 +945,18 @@ class Runtime {
 
   struct MemoryHandle {
     MemoryHandle(const MemoryRegion* region, size_t size, uint64_t flags_unused,
-                 ThunkHandle thunk_handle, MemoryRegion::AllocateFlags alloc_flag)
-        : region(region),
-          size(size),
-          ref_count(1),
-          use_count(0),
-          thunk_handle(thunk_handle),
-          alloc_flag(alloc_flag) {}
+                 ShareableHandle shareable_handle, int dmabuf_fd, uint64_t mmap_offset,
+                 bool imported, MemoryRegion::AllocateFlags alloc_flag);
+    ~MemoryHandle();
 
-    static __forceinline hsa_amd_vmem_alloc_handle_t Convert(ThunkHandle handle) {
-      hsa_amd_vmem_alloc_handle_t ret_handle = {
-          static_cast<uint64_t>(reinterpret_cast<uintptr_t>(handle))};
+    static __forceinline hsa_amd_vmem_alloc_handle_t Convert(ShareableHandle handle) {
+      hsa_amd_vmem_alloc_handle_t ret_handle = { .handle = handle.handle };
       return ret_handle;
     }
 
-    static __forceinline ThunkHandle Convert(hsa_amd_vmem_alloc_handle_t handle) {
-      return reinterpret_cast<void*>(handle.handle);
+    static __forceinline ShareableHandle Convert(hsa_amd_vmem_alloc_handle_t handle) {
+      ShareableHandle shandle = { .handle = handle.handle };
+      return shandle;
     }
 
     __forceinline core::Agent* agentOwner() const { return region->owner(); }
@@ -971,10 +965,15 @@ class Runtime {
     size_t size;
     int ref_count;
     int use_count;
-    ThunkHandle thunk_handle;  // handle returned by Driver::Allocate(NoAddress = 1)
+    ShareableHandle shareable_handle;  // handle returned by Driver::Allocate(NoAddress = 1)
+    HSAint64 dmabuf_fd;
+    uint64_t mmap_offset;
+    bool imported; /* True is this BO belongs to another process */
     MemoryRegion::AllocateFlags alloc_flag;
   };
-  std::map<ThunkHandle, MemoryHandle> memory_handle_map_;
+
+
+  std::map<ShareableHandle, MemoryHandle, ShareableHandle> memory_handle_map_;
 
   struct MappedHandle;
   struct MappedHandleAllowedAgent {
@@ -995,18 +994,15 @@ class Runtime {
 
   struct MappedHandle {
     MappedHandle(MemoryHandle* mem_handle, AddressHandle* address_handle, void* va,
-                 uint64_t offset, size_t size, int drm_fd, void *drm_cpu_addr,
-                 hsa_access_permission_t perm, ShareableHandle shareable_handle);
+                 uint64_t offset, size_t size,
+                 hsa_access_permission_t perm);
 
-    __forceinline core::Agent* agentOwner() const { return mem_handle->region->owner(); }
+    __forceinline core::Agent* agentOwner() const { return mem_handle->agentOwner(); }
 
     MemoryHandle* mem_handle;
     AddressHandle* address_handle;
     uint64_t offset;
     size_t size;
-    int drm_fd;
-    void* drm_cpu_addr;  // CPU Buffer address
-    ShareableHandle shareable_handle;
     std::map<Agent*, MappedHandleAllowedAgent> allowed_agents;
   };
   std::map<const void*, MappedHandle> mapped_handle_map_;  // Indexed by VA

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/inc/thunk_loader.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/inc/thunk_loader.h
@@ -339,9 +339,12 @@ class ThunkLoader {
                                       HSAuint64 SizeInBytes, \
                                       uint64_t* SharedMemoryHandle);
 #endif
-    typedef HSAKMT_STATUS (HSAKMT_DEF(hsaKmtHandleImport))(const HsaExternalHandleDesc* ImportDesc, \
+    typedef HSAKMT_STATUS (HSAKMT_DEF(hsaKmtHandleImport))(const HsaHandleImportDesc* ImportDesc, \
                                       HsaHandleImportResult* ImportResult, \
                                       HsaHandleImportFlags* flags);
+    typedef HSAKMT_STATUS (HSAKMT_DEF(hsaKmtHandleExport))(const HsaHandleExportDesc* desc, \
+                                      HsaMemoryExportResult* res, \
+                                      HsaHandleExportFlags* flags);
     typedef HSAKMT_STATUS (HSAKMT_DEF(hsaKmtMemoryVaMap))(HsaMemoryObjectHandle Handle, \
                                       HSAuint64 offset, \
                                       HSAuint64 size, \
@@ -354,12 +357,13 @@ class ThunkLoader {
     typedef HSAKMT_STATUS (HSAKMT_DEF(hsaKmtMemHandleFree))(HsaMemoryObjectHandle Handle);
     typedef HSAKMT_STATUS (HSAKMT_DEF(hsaKmtMemoryGetCpuAddr))(HsaAMDGPUDeviceHandle DeviceHandle, \
                                       HsaMemoryObjectHandle MemoryHandle, \
-                                      HSAint32* fd, \
                                       HSAuint64* cpu_addr);
     typedef HSAKMT_STATUS (HSAKMT_DEF(hsaKmtMemoryCpuMap))(HsaMemoryObjectHandle Handle, \
                                       void** out_cpu_ptr);
     typedef HSAKMT_STATUS (HSAKMT_DEF(hsaKmtGetNodeWallclockFrequency))(HSAuint32 NodeId, \
                                       uint64_t* Frequency);
+    typedef HSAKMT_STATUS (HSAKMT_DEF(hsaKmtGetAmdGPUDeviceFd))(HsaAMDGPUDeviceHandle DeviceHandle, \
+                                      HSAint32* fd);
     /* drm API */
     typedef int (DRM_DEF(amdgpu_device_initialize))(int fd, \
                                       uint32_t *major_version, \
@@ -512,10 +516,12 @@ class ThunkLoader {
     HSAKMT_DEF(hsaKmtGetMemoryHandle)* HSAKMT_PFN(hsaKmtGetMemoryHandle);
 #endif
     HSAKMT_DEF(hsaKmtHandleImport)* HSAKMT_PFN(hsaKmtHandleImport);
+    HSAKMT_DEF(hsaKmtHandleExport)* HSAKMT_PFN(hsaKmtHandleExport);
     HSAKMT_DEF(hsaKmtMemoryVaMap)* HSAKMT_PFN(hsaKmtMemoryVaMap);
     HSAKMT_DEF(hsaKmtMemoryVaUnmap)* HSAKMT_PFN(hsaKmtMemoryVaUnmap);
     HSAKMT_DEF(hsaKmtMemHandleFree)* HSAKMT_PFN(hsaKmtMemHandleFree);
     HSAKMT_DEF(hsaKmtMemoryGetCpuAddr)* HSAKMT_PFN(hsaKmtMemoryGetCpuAddr);
+    HSAKMT_DEF(hsaKmtGetAmdGPUDeviceFd)* HSAKMT_PFN(hsaKmtGetAmdGPUDeviceFd);
     HSAKMT_DEF(hsaKmtMemoryCpuMap)* HSAKMT_PFN(hsaKmtMemoryCpuMap);
     HSAKMT_DEF(hsaKmtGetNodeWallclockFrequency)* HSAKMT_PFN(hsaKmtGetNodeWallclockFrequency);
 

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_memory_region.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_memory_region.cpp
@@ -133,14 +133,14 @@ MemoryRegion::MemoryRegion(bool fine_grain, bool kernarg, bool full_profile,
 
 MemoryRegion::~MemoryRegion() {}
 
-hsa_status_t MemoryRegion::Allocate(size_t& size, AllocateFlags alloc_flags, void** address, int agent_node_id) const {
+hsa_status_t MemoryRegion::Allocate(size_t& size, AllocateFlags alloc_flags, void** mem, int agent_node_id) const {
   std::lock_guard<std::mutex> lock(owner()->agent_memory_lock_);
-  return AllocateImpl(size, alloc_flags, address, agent_node_id);
+  return AllocateImpl(size, alloc_flags, mem, agent_node_id);
 }
 
 hsa_status_t MemoryRegion::AllocateImpl(size_t& size, AllocateFlags alloc_flags,
-                                        void** address, int agent_node_id) const {
-  if (address == NULL) {
+                                        void** mem, int agent_node_id) const {
+  if (mem == NULL) {
     return HSA_STATUS_ERROR_INVALID_ARGUMENT;
   }
 
@@ -157,7 +157,7 @@ hsa_status_t MemoryRegion::AllocateImpl(size_t& size, AllocateFlags alloc_flags,
 
   size = AlignUp(size, GetPageSize());
 
-  return owner()->driver().AllocateMemory(*this, alloc_flags, address, size,
+  return owner()->driver().AllocateMemory(*this, alloc_flags, mem, size,
                                           agent_node_id);
 }
 

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/runtime.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/runtime.cpp
@@ -3562,6 +3562,8 @@ hsa_status_t Runtime::VMemoryHandleCreate(const MemoryRegion* region, size_t siz
   std::lock_guard<std::shared_mutex> lock(memory_lock_);
   void *mem;
 
+  printf("DYSDEBUG (%s:%s:%d)\n", __FILE__, __func__, __LINE__);
+
   hsa_status_t status = region->Allocate(size, alloc_flags, &mem, 0);
   if (status == HSA_STATUS_SUCCESS) {
     uint64_t offset;
@@ -3569,8 +3571,12 @@ hsa_status_t Runtime::VMemoryHandleCreate(const MemoryRegion* region, size_t siz
     core::ShareableHandle shareable_handle = {};
     auto agentOwner = region->owner();
     int dmabuf_fd;
+    printf("DYSDEBUG (%s:%s:%d)\n", __FILE__, __func__, __LINE__);
     auto ret = agentOwner->driver().CreateShareableHandle(nullptr, mem, size, *agentOwner, &shareable_handle, &offset, &dmabuf_fd, &mmap_offset);
-    if (ret != HSA_STATUS_SUCCESS) return ret;
+    if (ret != HSA_STATUS_SUCCESS) {
+      printf("DYSDEBUG (%s:%s:%d)\n", __FILE__, __func__, __LINE__);
+      return ret;
+    }
 
     memory_handle_map_.emplace(std::piecewise_construct,
                                std::forward_as_tuple(shareable_handle),
@@ -3578,6 +3584,7 @@ hsa_status_t Runtime::VMemoryHandleCreate(const MemoryRegion* region, size_t siz
                                                      dmabuf_fd, mmap_offset, false, alloc_flags));
 
     *memoryOnlyHandle = MemoryHandle::Convert(shareable_handle);
+    printf("DYSDEBUG status:%lx (%s:%s:%d)\n", status, __FILE__, __func__, __LINE__);
   }
   return status;
 }
@@ -3708,15 +3715,22 @@ Runtime::MappedHandleAllowedAgent::MappedHandleAllowedAgent(
     : va(va), size(size), targetAgent(targetAgent), permissions(perms),
       mappedHandle(_mappedHandle) {
 
+  printf("DYSDEBUG (%s:%s:%d)\n", __FILE__, __func__, __LINE__);
+
   // CPU agents have access as the memory is already mapped to the host.
   if (targetAgent->device_type() == core::Agent::DeviceType::kAmdCpuDevice) return;
 
   MemoryHandle *memHandle = mappedHandle->mem_handle;
 
+  printf("DYSDEBUG (%s:%s:%d)\n", __FILE__, __func__, __LINE__);
+
   size_t alloc_size = 0; //Unused
   auto status = targetAgent->driver().ImportDMABuf(memHandle->dmabuf_fd, *targetAgent, &shareable_handle, &alloc_size);
-  if (status != HSA_STATUS_SUCCESS)
+  if (status != HSA_STATUS_SUCCESS) {
+    printf("DYSDEBUG (%s:%s:%d)\n", __FILE__, __func__, __LINE__);
     throw AMD::hsa_exception(status, "Failed to import dma-buf");
+  }
+  printf("DYSDEBUG (%s:%s:%d)\n", __FILE__, __func__, __LINE__);
 }
 
 Runtime::MappedHandleAllowedAgent::~MappedHandleAllowedAgent() {
@@ -3736,13 +3750,12 @@ Runtime::MappedHandleAllowedAgent::~MappedHandleAllowedAgent() {
 
 hsa_status_t Runtime::MappedHandleAllowedAgent::EnableAccess(hsa_access_permission_t perms) {
   if (targetAgent->device_type() == core::Agent::DeviceType::kAmdCpuDevice) {
+    int mmap_fd = -1;
 #if defined(__linux__)
     if (core::Runtime::runtime_singleton_->thunkLoader()->IsDXG()) return HSA_STATUS_ERROR;
-#endif
     auto agentOwner = mappedHandle->mem_handle->agentOwner();
-    int mmap_fd = -1;
     if (agentOwner->driver().GetDeviceFd(agentOwner->node_id(), &mmap_fd) != HSA_STATUS_SUCCESS) return HSA_STATUS_ERROR;
-
+#endif
     if (!rocr::os::MapMemory(va, size, PermissionsToMemProt(perms), mmap_fd,
                              mappedHandle->mem_handle->mmap_offset)) {
       return HSA_STATUS_ERROR;
@@ -3782,6 +3795,10 @@ Runtime::MappedHandle::MappedHandle(MemoryHandle *mem_handle, AddressHandle *add
   #if defined(__linux__)
   if (core::Runtime::runtime_singleton_->thunkLoader()->IsDXG()) return;
   #endif
+/* 
+DYSDEBUG here, previously we used call CreateShareableHandle.., but now we call 
+CreateShareableHandle when creating the MemoryHandle
+*/
 
   if (!mem_handle->imported) {
     /*

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/runtime.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/runtime.cpp
@@ -1376,9 +1376,9 @@ hsa_status_t Runtime::IPCCreate(void* ptr, size_t len, hsa_amd_ipc_memory_t* han
   // deferred export will not run into this problem.
   int dmabuf_fd;
   uint64_t dmabufOffset;
-  hsa_status_t err = agent->driver().ExportDMABuf(ptr, len, &dmabuf_fd, &dmabufOffset);
+  auto hsakmt_err = hsaKmtExportDMABufHandle(ptr, len, &dmabuf_fd, &dmabufOffset);
   assert(dmabufOffset/pageSize == fragOffset && "DMA Buf inconsistent with pointer offset.");
-  if (err != HSA_STATUS_SUCCESS) return err;
+  if (hsakmt_err != HSAKMT_STATUS_SUCCESS) return HSA_STATUS_ERROR;
 
   if (agent->device_type() == Agent::kAmdGpuDevice) {
     AMD::GpuAgent* agent_ = reinterpret_cast<AMD::GpuAgent*>(agent);
@@ -1388,12 +1388,11 @@ hsa_status_t Runtime::IPCCreate(void* ptr, size_t len, hsa_amd_ipc_memory_t* han
     std::uniform_int_distribution<uint32_t> distr(1, 1<<15);
     handle->handle[7] = distr(gen);
 
-    HsaExternalHandleDesc desc;
+    HsaHandleImportDesc desc;
     desc.device_handle = agent_->libThunkDev();
-    desc.fd = static_cast<HSAint64>(dmabuf_fd);
+    desc.dmabuf_fd = static_cast<HSAint64>(dmabuf_fd);
     desc.type = HSA_EXTERNAL_HANDLE_DMA_BUF;
     desc.metadata = handle->handle[7];
-    desc.mem = ptr;
     HsaHandleImportFlags hflags;
     hflags.ui32.IPCHandle = 1;
     hflags.ui32.SysMem = handle->handle[3];
@@ -1401,7 +1400,7 @@ hsa_status_t Runtime::IPCCreate(void* ptr, size_t len, hsa_amd_ipc_memory_t* han
     HsaHandleImportResult res;
     HSAKMT_STATUS status = HSAKMT_CALL(hsaKmtHandleImport(&desc, &res, &hflags));
     if (status == HSAKMT_STATUS_ERROR) {
-      runtime_singleton_->DmaBufClose(dmabuf_fd);
+      close(dmabuf_fd);
       return HSA_STATUS_ERROR;
     }
     allocation_map_[ptr].thunk_bo = res.buf_handle;
@@ -1483,9 +1482,9 @@ int Runtime::IPCClientImport(uint32_t conn_handle, uint64_t dmabuf_fd_handle,
 
       AMD::GpuAgent* agent = reinterpret_cast<AMD::GpuAgent*>(agents_by_node_[info.NodeId][0]);
 
-      HsaExternalHandleDesc desc;
+      HsaHandleImportDesc desc;
       desc.device_handle = agent->libThunkDev();
-      desc.fd = static_cast<HSAint64>(dmabuf_fd);
+      desc.dmabuf_fd = static_cast<HSAint64>(dmabuf_fd);
       desc.type = HSA_EXTERNAL_HANDLE_DMA_BUF;
       desc.metadata = static_cast<HSAuint32>(shared_handle);
       desc.mem = *importAddress;
@@ -3455,14 +3454,8 @@ hsa_status_t Runtime::DmaBufExport(const void* ptr, size_t size, int* dmabuf, ui
 
         int fd;
         uint64_t off;
-        hsa_status_t err = mem->second.region->owner()->driver().ExportDMABuf(
-            const_cast<void*>(ptr), size, &fd, &off);
-
-        if (err != HSA_STATUS_SUCCESS) {
-          assert((err != HSA_STATUS_ERROR_INVALID_ARGUMENT) &&
-                 "Thunk does not recognize an expected allocation.");
-          return err;
-        }
+        auto err = HSAKMT_CALL(hsaKmtExportDMABufHandle(const_cast<void*>(ptr), size, &fd, &off));
+        if (err == HSAKMT_STATUS_SUCCESS) return HSA_STATUS_ERROR;
 
         *dmabuf = fd;
         *offset = off;
@@ -3567,17 +3560,24 @@ hsa_status_t Runtime::VMemoryHandleCreate(const MemoryRegion* region, size_t siz
     return HSA_STATUS_ERROR_INVALID_ARGUMENT;
 
   std::lock_guard<std::shared_mutex> lock(memory_lock_);
-  ThunkHandle user_mode_driver_handle;
-  hsa_status_t status =
-      region->Allocate(size, alloc_flags, &user_mode_driver_handle, 0);
-  if (status == HSA_STATUS_SUCCESS) {
-    memory_handle_map_.emplace(std::piecewise_construct,
-                               std::forward_as_tuple(user_mode_driver_handle),
-                               std::forward_as_tuple(region, size, flags_unused,
-                                                     user_mode_driver_handle,
-                                                     alloc_flags));
+  void *mem;
 
-    *memoryOnlyHandle = MemoryHandle::Convert(user_mode_driver_handle);
+  hsa_status_t status = region->Allocate(size, alloc_flags, &mem, 0);
+  if (status == HSA_STATUS_SUCCESS) {
+    uint64_t offset;
+    uint64_t mmap_offset = 0;
+    core::ShareableHandle shareable_handle = {};
+    auto agentOwner = region->owner();
+    int dmabuf_fd;
+    auto ret = agentOwner->driver().CreateShareableHandle(nullptr, mem, size, *agentOwner, &shareable_handle, &offset, &dmabuf_fd, &mmap_offset);
+    if (ret != HSA_STATUS_SUCCESS) return ret;
+
+    memory_handle_map_.emplace(std::piecewise_construct,
+                               std::forward_as_tuple(shareable_handle),
+                               std::forward_as_tuple(region, size, flags_unused, shareable_handle,
+                                                     dmabuf_fd, mmap_offset, false, alloc_flags));
+
+    *memoryOnlyHandle = MemoryHandle::Convert(shareable_handle);
   }
   return status;
 }
@@ -3601,7 +3601,6 @@ hsa_status_t Runtime::VMemoryHandleRelease(hsa_amd_vmem_alloc_handle_t memoryOnl
 
     if (memoryHandleIt->second.use_count > 0) return HSA_STATUS_SUCCESS;
 
-    memoryHandleIt->second.region->Free(memoryHandleIt->first, memoryHandleIt->second.size);
     memory_handle_map_.erase(memoryHandleIt);
   }
   return HSA_STATUS_SUCCESS;
@@ -3641,25 +3640,13 @@ hsa_status_t Runtime::VMemoryHandleMap(void* va, size_t size, size_t in_offset,
   if (agent->device_type() == core::Agent::DeviceType::kAmdCpuDevice)
     return HSA_STATUS_ERROR_INVALID_AGENT;
 
-  // Create mapping
-  ShareableHandle shareable_handle;
   uint64_t offset = 0;
-  int drm_fd = 0;
-  uint64_t drm_fd_offset = 0;
-  hsa_status_t err = agent->driver().CreateShareableHandle(
-      va, memoryHandleIt->first, size, *agent, &shareable_handle, &offset, &drm_fd, &drm_fd_offset);
-  if (err != HSA_STATUS_SUCCESS) return err;
-
   // Register the mapping
-  mapped_handle_map_.emplace(
-      std::piecewise_construct, std::forward_as_tuple(va),
-      std::forward_as_tuple(&memoryHandleIt->second, addressHandle, va, offset, size, drm_fd,
-                            reinterpret_cast<void*>(drm_fd_offset), HSA_ACCESS_PERMISSION_NONE,
-                            shareable_handle));
-
+  mapped_handle_map_.emplace(std::piecewise_construct, std::forward_as_tuple(va),
+                             std::forward_as_tuple(&memoryHandleIt->second, addressHandle, va, offset, size,
+                              HSA_ACCESS_PERMISSION_NONE));
   addressHandle->use_count++;
   memoryHandleIt->second.use_count++;
-
   return HSA_STATUS_SUCCESS;
 }
 
@@ -3698,14 +3685,6 @@ hsa_status_t Runtime::VMemoryHandleUnmap(void* va, size_t size) {
       agentPermsIt = mappedHandleIt.second->allowed_agents.erase(agentPermsIt);
     }
 
-    if (mappedHandleIt.second->shareable_handle.IsValid()) {
-      hsa_status_t status = mappedHandleIt.second->agentOwner()->driver().DestroyShareableHandle(
-          &(mappedHandleIt.second->shareable_handle));
-      if (status != HSA_STATUS_SUCCESS) {
-        return status;
-      }
-    }
-
     assert(mappedHandleIt.second->address_handle->use_count >= 1);
     mappedHandleIt.second->address_handle->use_count--;
     assert(mappedHandleIt.second->mem_handle->use_count >= 1);
@@ -3713,16 +3692,12 @@ hsa_status_t Runtime::VMemoryHandleUnmap(void* va, size_t size) {
 
     if (!mappedHandleIt.second->mem_handle->use_count &&
         !mappedHandleIt.second->mem_handle->ref_count) {
-        // User called VMemoryHandleRelease while this mapping was still
-        // outstanding. We need to delete the MemoryHandle as it is the last
-        // MappedHandle that was using it.
-      mappedHandleIt.second->mem_handle->region->Free(mappedHandleIt.second->mem_handle->thunk_handle,
-                                                      mappedHandleIt.second->mem_handle->size);
-      memory_handle_map_.erase(mappedHandleIt.second->mem_handle->thunk_handle);
+      // User called VMemoryHandleRelease while this mapping was still
+      // outstanding. We need to delete the MemoryHandle as it is the last
+      // MappedHandle that was using it.
+      memory_handle_map_.erase(mappedHandleIt.second->mem_handle->shareable_handle);
     }
-
     mapped_handle_map_.erase(mappedHandleIt.first);
-
   }
   return HSA_STATUS_SUCCESS;
 }
@@ -3736,33 +3711,13 @@ Runtime::MappedHandleAllowedAgent::MappedHandleAllowedAgent(
   // CPU agents have access as the memory is already mapped to the host.
   if (targetAgent->device_type() == core::Agent::DeviceType::kAmdCpuDevice) return;
 
-  int dmabuf_fd = 0;
-  uint64_t offset = 0;
   MemoryHandle *memHandle = mappedHandle->mem_handle;
 
-  // Export memory from owner agent.
-  hsa_status_t status = memHandle->agentOwner()->driver().ExportDMABuf(
-      memHandle->thunk_handle, mappedHandle->size, &dmabuf_fd, &offset);
-  assert(status == HSA_STATUS_SUCCESS);
+  size_t alloc_size = 0; //Unused
+  auto status = targetAgent->driver().ImportDMABuf(memHandle->dmabuf_fd, *targetAgent, &shareable_handle, &alloc_size);
   if (status != HSA_STATUS_SUCCESS)
-    return;
-
-  void* reuse_handle = nullptr;
-  // If MappedHandle's public handle is same as target agent public handle
-  // reuse the existing memory handles instead of importing dmabuf_fd (only valid for WSL/Windows)
-  if (targetAgent->public_handle().handle == memHandle->agentOwner()->public_handle().handle) {
-    reuse_handle = memHandle->thunk_handle;
-  }
-  // Import to target agent.
-  status =
-      targetAgent->driver().ImportDMABuf(dmabuf_fd, *targetAgent, &shareable_handle, reuse_handle);
-  assert(status == HSA_STATUS_SUCCESS);
-  if (status != HSA_STATUS_SUCCESS)
-    return;
-  status = core::Runtime::runtime_singleton_->DmaBufClose(dmabuf_fd);
-  if (status != HSA_STATUS_SUCCESS)
-    return;
-  }
+    throw AMD::hsa_exception(status, "Failed to import dma-buf");
+}
 
 Runtime::MappedHandleAllowedAgent::~MappedHandleAllowedAgent() {
   if (targetAgent->device_type() == core::Agent::DeviceType::kAmdCpuDevice) {
@@ -3774,7 +3729,7 @@ Runtime::MappedHandleAllowedAgent::~MappedHandleAllowedAgent() {
     assert(result && "Failed to remap VA to anonymous");
   }
   else {
-    hsa_status_t status = targetAgent->driver().DestroyImportedShareableHandle(&shareable_handle);
+    auto status = targetAgent->driver().DestroyImportedShareableHandle(&shareable_handle);
     assert(status == HSA_STATUS_SUCCESS);
   }
 }
@@ -3784,16 +3739,17 @@ hsa_status_t Runtime::MappedHandleAllowedAgent::EnableAccess(hsa_access_permissi
 #if defined(__linux__)
     if (core::Runtime::runtime_singleton_->thunkLoader()->IsDXG()) return HSA_STATUS_ERROR;
 #endif
+    auto agentOwner = mappedHandle->mem_handle->agentOwner();
+    int mmap_fd = -1;
+    if (agentOwner->driver().GetDeviceFd(agentOwner->node_id(), &mmap_fd) != HSA_STATUS_SUCCESS) return HSA_STATUS_ERROR;
 
-    if (!rocr::os::MapMemory(va, size, PermissionsToMemProt(perms), mappedHandle->drm_fd,
-                            reinterpret_cast<uint64_t>(mappedHandle->drm_cpu_addr))) {
+    if (!rocr::os::MapMemory(va, size, PermissionsToMemProt(perms), mmap_fd,
+                             mappedHandle->mem_handle->mmap_offset)) {
       return HSA_STATUS_ERROR;
     }
   } else {
-    hsa_status_t status = targetAgent->driver().Map(
-        shareable_handle, va, mappedHandle->offset, size, perms);
-    if (status != HSA_STATUS_SUCCESS)
-      return status;
+    hsa_status_t status = targetAgent->driver().Map(shareable_handle, va, mappedHandle->offset, size, perms);
+    if (status != HSA_STATUS_SUCCESS) return status;
   }
   permissions = perms;
   return HSA_STATUS_SUCCESS;
@@ -3819,28 +3775,55 @@ hsa_status_t Runtime::MappedHandleAllowedAgent::RemoveAccess() {
 }
 
 Runtime::MappedHandle::MappedHandle(MemoryHandle *mem_handle, AddressHandle *address_handle,
-                 void* va, uint64_t offset, size_t size, int drm_fd, void *drm_cpu_addr,
-                 hsa_access_permission_t perm, ShareableHandle shareable_handle)
+                 void* va, uint64_t offset, size_t size, hsa_access_permission_t perm)
   : mem_handle(mem_handle), address_handle(address_handle), offset(offset),
-    size(size), drm_fd(drm_fd), drm_cpu_addr(drm_cpu_addr),
-    shareable_handle(shareable_handle)
-{
+    size(size) {
   /* Create a CPU mapping with PROT_NONE */
   #if defined(__linux__)
   if (core::Runtime::runtime_singleton_->thunkLoader()->IsDXG()) return;
   #endif
 
-  auto cpu_agent = static_cast<AMD::GpuAgent*>(agentOwner())->GetNearestCpuAgent();
-  auto agentPermsIt = allowed_agents.emplace(std::piecewise_construct,
-                      std::forward_as_tuple(cpu_agent),
-                      std::forward_as_tuple(this, cpu_agent, va,
-                                            size, HSA_ACCESS_PERMISSION_NONE))
-                      .first;
+  if (!mem_handle->imported) {
+    /*
+     * Create default CPU mapping. This is needed for the kfd_peerdirect drivers
+     * to look up the VA when sharing this BO to a third party driver. We only
+     * need this in the process that owns this memory allocation.
+     */
+    auto cpu_agent = static_cast<AMD::GpuAgent*>(agentOwner())->GetNearestCpuAgent();
+    auto agentPermsIt = allowed_agents.emplace(std::piecewise_construct,
+                        std::forward_as_tuple(cpu_agent),
+                        std::forward_as_tuple(this, cpu_agent, va,
+                                              size, HSA_ACCESS_PERMISSION_NONE))
+                        .first;
 
-  auto ret = agentPermsIt->second.EnableAccess(HSA_ACCESS_PERMISSION_NONE);
-  if (ret != HSA_STATUS_SUCCESS)
-    throw AMD::hsa_exception(ret, "Failed to create default CPU mapping");
+    auto ret = agentPermsIt->second.EnableAccess(HSA_ACCESS_PERMISSION_NONE);
+    if (ret != HSA_STATUS_SUCCESS)
+      throw AMD::hsa_exception(ret, "Failed to create default CPU mapping");
+  }
 }
+
+Runtime::MemoryHandle::MemoryHandle(const MemoryRegion* region, size_t size, uint64_t flags_unused,
+                 ShareableHandle /* DriverHandle */ shareable_handle, int dmabuf_fd, uint64_t mmap_offset,
+                 bool imported, MemoryRegion::AllocateFlags alloc_flag)
+          : region(region),
+          size(size),
+          ref_count(1),
+          use_count(0),
+          shareable_handle(shareable_handle),
+          dmabuf_fd(dmabuf_fd),
+          mmap_offset(mmap_offset),
+          imported(imported),
+          alloc_flag(alloc_flag) {
+
+  assert(shareable_handle.handle != 0);
+  assert(size >= 0);
+}
+
+Runtime::MemoryHandle::~MemoryHandle() {
+  agentOwner()->driver().DestroyShareableHandle(&shareable_handle);
+  core::Runtime::runtime_singleton_->DmaBufClose(dmabuf_fd);
+}
+
 
 // Note: VMemorySetAccessPerHandle should be called with &memory_lock_ held
 hsa_status_t
@@ -4030,79 +4013,51 @@ hsa_status_t Runtime::VMemoryExportShareableHandle(int* dmabuf_fd,
     return HSA_STATUS_ERROR_INVALID_ALLOCATION;
   }
 
-  uint64_t offset;
-
-  hsa_status_t err = memoryHandle->second.region->owner()->driver().ExportDMABuf(
-      memoryHandle->second.thunk_handle, memoryHandle->second.size, dmabuf_fd, &offset);
-  if (err != HSA_STATUS_SUCCESS) return err;
-
+  *dmabuf_fd = memoryHandle->second.dmabuf_fd;
   return HSA_STATUS_SUCCESS;
 }
 
 hsa_status_t Runtime::VMemoryImportShareableHandle(int dmabuf_fd,
                                                    hsa_amd_vmem_alloc_handle_t* memoryOnlyHandle) {
-  std::lock_guard<std::shared_mutex> lock(memory_lock_);
-  auto lookupRegion = [this](int nodeid, const AMD::MemoryRegion** ret) {
-    auto nodeAgent = agents_by_node_.find(nodeid);
-    if (nodeAgent == agents_by_node_.end()) {
-      *ret = NULL;
-      return;
-    }
+  /*
+   * We pick the first visible GPU agent to import the dmabuf_fd.
+   * Looking up the owner of a memory handle does not give the agent where the memory was
+   * allocated.
+   * If we really need to return back the allocation flags, we may have to store it in the BO metadata
+   */
+  if (!gpu_agents().size()) {
+    return HSA_STATUS_ERROR;
+  }
+  auto agent = gpu_agents().front();
 
-    Agent* agent = nodeAgent->second.front();
-    if (agent == nullptr || !agent->IsValid() || agent->device_type() != Agent::kAmdGpuDevice) {
-      *ret = NULL;
-      return;
-    }
-
-    for (const auto& region : agent->regions()) {
-      const AMD::MemoryRegion* amd_region = reinterpret_cast<const AMD::MemoryRegion*>(region.get());
-
-      // TODO: Verify that this works on a system with FINE_GRAINED memory.
-      // System's with FINE_GRAINED will have both COARSE and FINE grain... need to get the
-      // rigtht one.
-
-      bool alloc_allowed;
+  const MemoryRegion* region = NULL;
+  for (const auto& agent_region : agent->regions()) {
+      bool alloc_allowed = false;
       hsa_status_t status =
-          amd_region->GetInfo(HSA_REGION_INFO_RUNTIME_ALLOC_ALLOWED, &alloc_allowed);
-      if (status == HSA_STATUS_SUCCESS && alloc_allowed) *ret = amd_region;
-    }
+        agent_region.get()->GetInfo(HSA_REGION_INFO_RUNTIME_ALLOC_ALLOWED, &alloc_allowed);
+    if (status == HSA_STATUS_SUCCESS && alloc_allowed) region = agent_region.get();
   };
 
-  HsaGraphicsResourceInfo info;
-  int ret = HSAKMT_CALL(hsaKmtRegisterGraphicsHandleToNodes(dmabuf_fd, &info, 0, NULL));
-  if (ret) return HSA_STATUS_ERROR_INCOMPATIBLE_ARGUMENTS;
+  if (!region) return HSA_STATUS_ERROR_INVALID_ALLOCATION;
 
-  ThunkHandle thunk_handle = info.MemoryAddress;
-  size_t size = info.SizeInBytes;
-  int gpuid = info.NodeId;
+  ShareableHandle shareable_handle;
+  size_t size;
+  auto ret = agent->driver().ImportDMABuf(dmabuf_fd, *agent, &shareable_handle, &size);
+  if (ret != HSA_STATUS_SUCCESS) return ret;
 
-
-  auto memoryHandleIt = memory_handle_map_.find(thunk_handle);
+  auto memoryHandleIt = memory_handle_map_.find(shareable_handle);
   if (memoryHandleIt != memory_handle_map_.end()) {
     /* This handle was already imported, increment ref_count and return */
     memoryHandleIt->second.ref_count++;
-    *memoryOnlyHandle = MemoryHandle::Convert(thunk_handle);
+    *memoryOnlyHandle = MemoryHandle::Convert(shareable_handle);
     return HSA_STATUS_SUCCESS;
   }
 
-  const AMD::MemoryRegion* region = NULL;
-  lookupRegion(gpuid, &region);
-  if (!region) return HSA_STATUS_ERROR_INVALID_ALLOCATION;
-
-  HsaPointerInfo ptrInfo;
-  ret = HSAKMT_CALL(hsaKmtQueryPointerInfo(info.MemoryAddress, &ptrInfo));
-  if (ret != HSA_STATUS_SUCCESS || ptrInfo.Type == HSA_POINTER_UNKNOWN)
-    return HSA_STATUS_ERROR_INVALID_ALLOCATION;
-
-  MemoryRegion::AllocateFlags alloc_flag = core::MemoryRegion::AllocateNoFlags;
-  if (ptrInfo.MemFlags.ui32.NoSubstitute) alloc_flag |= core::MemoryRegion::AllocatePinned;
-
   memory_handle_map_.emplace(std::piecewise_construct,
-          std::forward_as_tuple(thunk_handle),
-          std::forward_as_tuple(region, size, 0, thunk_handle, alloc_flag));
-  *memoryOnlyHandle = MemoryHandle::Convert(thunk_handle);
+          std::forward_as_tuple(shareable_handle),
+          std::forward_as_tuple(region, size, 0, shareable_handle, dmabuf_fd, 0, true, core::MemoryRegion::AllocateNoFlags));
 
+  *memoryOnlyHandle = MemoryHandle::Convert(shareable_handle);
   return HSA_STATUS_SUCCESS;
 }
 
@@ -4114,8 +4069,8 @@ hsa_status_t Runtime::VMemoryRetainAllocHandle(hsa_amd_vmem_alloc_handle_t* mapp
 
   MemoryHandle* memoryHandle = mappedHandleIt->second.mem_handle;
   memoryHandle->ref_count++;
-  *mapped_handle = MemoryHandle::Convert(memoryHandle->thunk_handle);
-
+  *mapped_handle = MemoryHandle::Convert(memoryHandle->shareable_handle);
+  assert(memoryHandle->shareable_handle.handle != 0);
   return HSA_STATUS_SUCCESS;
 }
 

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/runtime.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/runtime.cpp
@@ -3562,8 +3562,6 @@ hsa_status_t Runtime::VMemoryHandleCreate(const MemoryRegion* region, size_t siz
   std::lock_guard<std::shared_mutex> lock(memory_lock_);
   void *mem;
 
-  printf("DYSDEBUG (%s:%s:%d)\n", __FILE__, __func__, __LINE__);
-
   hsa_status_t status = region->Allocate(size, alloc_flags, &mem, 0);
   if (status == HSA_STATUS_SUCCESS) {
     uint64_t offset;
@@ -3571,20 +3569,27 @@ hsa_status_t Runtime::VMemoryHandleCreate(const MemoryRegion* region, size_t siz
     core::ShareableHandle shareable_handle = {};
     auto agentOwner = region->owner();
     int dmabuf_fd;
-    printf("DYSDEBUG (%s:%s:%d)\n", __FILE__, __func__, __LINE__);
     auto ret = agentOwner->driver().CreateShareableHandle(nullptr, mem, size, *agentOwner, &shareable_handle, &offset, &dmabuf_fd, &mmap_offset);
     if (ret != HSA_STATUS_SUCCESS) {
-      printf("DYSDEBUG (%s:%s:%d)\n", __FILE__, __func__, __LINE__);
+      region->Free(mem, size);
       return ret;
     }
+
+    void* kmt_alloc_ptr = nullptr;
+#if !defined(__linux__)
+    kmt_alloc_ptr = mem;
+#else
+    if (thunkLoader()->IsDXG()) {
+      kmt_alloc_ptr = mem;
+    }
+#endif
 
     memory_handle_map_.emplace(std::piecewise_construct,
                                std::forward_as_tuple(shareable_handle),
                                std::forward_as_tuple(region, size, flags_unused, shareable_handle,
-                                                     dmabuf_fd, mmap_offset, false, alloc_flags));
+                                                     dmabuf_fd, mmap_offset, kmt_alloc_ptr, false, alloc_flags));
 
     *memoryOnlyHandle = MemoryHandle::Convert(shareable_handle);
-    printf("DYSDEBUG status:%lx (%s:%s:%d)\n", status, __FILE__, __func__, __LINE__);
   }
   return status;
 }
@@ -3715,22 +3720,22 @@ Runtime::MappedHandleAllowedAgent::MappedHandleAllowedAgent(
     : va(va), size(size), targetAgent(targetAgent), permissions(perms),
       mappedHandle(_mappedHandle) {
 
-  printf("DYSDEBUG (%s:%s:%d)\n", __FILE__, __func__, __LINE__);
-
   // CPU agents have access as the memory is already mapped to the host.
   if (targetAgent->device_type() == core::Agent::DeviceType::kAmdCpuDevice) return;
 
   MemoryHandle *memHandle = mappedHandle->mem_handle;
 
-  printf("DYSDEBUG (%s:%s:%d)\n", __FILE__, __func__, __LINE__);
-
-  size_t alloc_size = 0; //Unused
-  auto status = targetAgent->driver().ImportDMABuf(memHandle->dmabuf_fd, *targetAgent, &shareable_handle, &alloc_size);
-  if (status != HSA_STATUS_SUCCESS) {
-    printf("DYSDEBUG (%s:%s:%d)\n", __FILE__, __func__, __LINE__);
-    throw AMD::hsa_exception(status, "Failed to import dma-buf");
+  void* reuse_handle = nullptr;
+  // Same device as owner: pass existing allocation so thunk can bypass dma-buf import (WSL/DXG/Windows).
+  if (targetAgent->public_handle().handle == memHandle->agentOwner()->public_handle().handle) {
+    reuse_handle = memHandle->kmt_alloc_ptr;
   }
-  printf("DYSDEBUG (%s:%s:%d)\n", __FILE__, __func__, __LINE__);
+
+  size_t alloc_size = 0;
+  auto status = targetAgent->driver().ImportDMABuf(memHandle->dmabuf_fd, *targetAgent, &shareable_handle,
+                                                   &alloc_size, reuse_handle);
+  if (status != HSA_STATUS_SUCCESS)
+    throw AMD::hsa_exception(status, "Failed to import dma-buf");
 }
 
 Runtime::MappedHandleAllowedAgent::~MappedHandleAllowedAgent() {
@@ -3795,10 +3800,6 @@ Runtime::MappedHandle::MappedHandle(MemoryHandle *mem_handle, AddressHandle *add
   #if defined(__linux__)
   if (core::Runtime::runtime_singleton_->thunkLoader()->IsDXG()) return;
   #endif
-/* 
-DYSDEBUG here, previously we used call CreateShareableHandle.., but now we call 
-CreateShareableHandle when creating the MemoryHandle
-*/
 
   if (!mem_handle->imported) {
     /*
@@ -3821,7 +3822,7 @@ CreateShareableHandle when creating the MemoryHandle
 
 Runtime::MemoryHandle::MemoryHandle(const MemoryRegion* region, size_t size, uint64_t flags_unused,
                  ShareableHandle /* DriverHandle */ shareable_handle, int dmabuf_fd, uint64_t mmap_offset,
-                 bool imported, MemoryRegion::AllocateFlags alloc_flag)
+                 void* kmt_alloc_ptr, bool imported, MemoryRegion::AllocateFlags alloc_flag)
           : region(region),
           size(size),
           ref_count(1),
@@ -3829,6 +3830,7 @@ Runtime::MemoryHandle::MemoryHandle(const MemoryRegion* region, size_t size, uin
           shareable_handle(shareable_handle),
           dmabuf_fd(dmabuf_fd),
           mmap_offset(mmap_offset),
+          kmt_alloc_ptr(kmt_alloc_ptr),
           imported(imported),
           alloc_flag(alloc_flag) {
 
@@ -3839,6 +3841,10 @@ Runtime::MemoryHandle::MemoryHandle(const MemoryRegion* region, size_t size, uin
 Runtime::MemoryHandle::~MemoryHandle() {
   agentOwner()->driver().DestroyShareableHandle(&shareable_handle);
   core::Runtime::runtime_singleton_->DmaBufClose(dmabuf_fd);
+  if (kmt_alloc_ptr) {
+    region->Free(kmt_alloc_ptr, size);
+    kmt_alloc_ptr = nullptr;
+  }
 }
 
 
@@ -4072,7 +4078,8 @@ hsa_status_t Runtime::VMemoryImportShareableHandle(int dmabuf_fd,
 
   memory_handle_map_.emplace(std::piecewise_construct,
           std::forward_as_tuple(shareable_handle),
-          std::forward_as_tuple(region, size, 0, shareable_handle, dmabuf_fd, 0, true, core::MemoryRegion::AllocateNoFlags));
+          std::forward_as_tuple(region, size, 0, shareable_handle, dmabuf_fd, 0, nullptr, true,
+                                 core::MemoryRegion::AllocateNoFlags));
 
   *memoryOnlyHandle = MemoryHandle::Convert(shareable_handle);
   return HSA_STATUS_SUCCESS;

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/thunk_loader.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/thunk_loader.cpp
@@ -398,6 +398,9 @@ namespace core {
       HSAKMT_PFN(hsaKmtHandleImport) = (HSAKMT_DEF(hsaKmtHandleImport)*)dlsym(thunk_handle, "hsaKmtHandleImport");
       if (HSAKMT_PFN(hsaKmtHandleImport) == nullptr) goto ERROR;
 
+      HSAKMT_PFN(hsaKmtHandleExport) = (HSAKMT_DEF(hsaKmtHandleExport)*)dlsym(thunk_handle, "hsaKmtHandleExport");
+      if (HSAKMT_PFN(hsaKmtHandleExport) == nullptr) goto ERROR;
+
       HSAKMT_PFN(hsaKmtMemoryVaMap) = (HSAKMT_DEF(hsaKmtMemoryVaMap)*)dlsym(thunk_handle, "hsaKmtMemoryVaMap");
       if (HSAKMT_PFN(hsaKmtMemoryVaMap) == nullptr) goto ERROR;
 
@@ -409,6 +412,9 @@ namespace core {
 
       HSAKMT_PFN(hsaKmtMemoryGetCpuAddr) = (HSAKMT_DEF(hsaKmtMemoryGetCpuAddr)*)dlsym(thunk_handle, "hsaKmtMemoryGetCpuAddr");
       if (HSAKMT_PFN(hsaKmtMemoryGetCpuAddr) == nullptr) goto ERROR;
+
+      HSAKMT_PFN(hsaKmtGetAmdGPUDeviceFd) = (HSAKMT_DEF(hsaKmtGetAmdGPUDeviceFd)*)dlsym(thunk_handle, "hsaKmtGetAmdGPUDeviceFd");
+      if (HSAKMT_PFN(hsaKmtGetAmdGPUDeviceFd) == nullptr) goto ERROR;
 
       HSAKMT_PFN(hsaKmtMemoryCpuMap) = (HSAKMT_DEF(hsaKmtMemoryCpuMap)*)dlsym(thunk_handle, "hsaKmtMemoryCpuMap");
       if (HSAKMT_PFN(hsaKmtMemoryCpuMap) == nullptr) goto ERROR;
@@ -551,10 +557,12 @@ ERROR:
       HSAKMT_PFN(hsaKmtGetMemoryHandle) = (HSAKMT_DEF(hsaKmtGetMemoryHandle)*)(&hsaKmtGetMemoryHandle);
 #endif
       HSAKMT_PFN(hsaKmtHandleImport) = (HSAKMT_DEF(hsaKmtHandleImport)*)(&hsaKmtHandleImport);
+      HSAKMT_PFN(hsaKmtHandleExport) = (HSAKMT_DEF(hsaKmtHandleExport)*)(&hsaKmtHandleExport);
       HSAKMT_PFN(hsaKmtMemoryVaMap) = (HSAKMT_DEF(hsaKmtMemoryVaMap)*)(&hsaKmtMemoryVaMap);
       HSAKMT_PFN(hsaKmtMemoryVaUnmap) = (HSAKMT_DEF(hsaKmtMemoryVaUnmap)*)(&hsaKmtMemoryVaUnmap);
       HSAKMT_PFN(hsaKmtMemHandleFree) = (HSAKMT_DEF(hsaKmtMemHandleFree)*)(&hsaKmtMemHandleFree);
       HSAKMT_PFN(hsaKmtMemoryGetCpuAddr) = (HSAKMT_DEF(hsaKmtMemoryGetCpuAddr)*)(&hsaKmtMemoryGetCpuAddr);
+      HSAKMT_PFN(hsaKmtGetAmdGPUDeviceFd) = (HSAKMT_DEF(hsaKmtGetAmdGPUDeviceFd)*)(&hsaKmtGetAmdGPUDeviceFd);
       HSAKMT_PFN(hsaKmtMemoryCpuMap) = (HSAKMT_DEF(hsaKmtMemoryCpuMap)*)(&hsaKmtMemoryCpuMap);
       HSAKMT_PFN(hsaKmtGetNodeWallclockFrequency) = (HSAKMT_DEF(hsaKmtGetNodeWallclockFrequency)*)(&hsaKmtGetNodeWallclockFrequency);
 

--- a/projects/rocr-runtime/runtime/hsa-runtime/inc/hsa_ext_amd.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/inc/hsa_ext_amd.h
@@ -3872,7 +3872,7 @@ hsa_status_t hsa_amd_vmem_get_access(void* va, hsa_access_permission_t* perms,
                                      hsa_agent_t agent_handle);
 
 /**
- * @brief Get an exportable shareable handle
+ * @brief Get an exportable locally unique shareable handle
  *
  * Get an exportable shareable handle for a memory_handle. This shareabl handle can then be used to
  * re-create a virtual memory handle using hsa_amd_vmem_import_shareable_handle. The shareable


### PR DESCRIPTION
## Motivation
Refactor VMM APIs
WIP: Please do not review for now. Will split into smaller commits before requesting review.

## Technical Details
Create dmabuf_fd with MemoryHandle creation and to avoid having to re-export new handle on each VMemoryHandleMap, VMemoryExportShareableHandle API calls.
On KFD Driver, abstract the fact that the memory allocation is done via /dev/kfd interface and then imported into DRM interface into the CreateShareableHandle API. Always work with dmabuf_fd from DRM interface for all subsequent operations.

## Test Plan
On Linux; ROCrtst and HIP catch tests
On Windows: Test in progress

## Test Result
In progress - will remove WIP flag once test is complete.
