### PR TITLE
Disable Unit_hipMemSetAccessHost_devicealloc on Windows platform

### DIFF
--- a/projects/hip-tests/catch/config/configs/unit/virtualMemoryManagement.yaml
+++ b/projects/hip-tests/catch/config/configs/unit/virtualMemoryManagement.yaml
@@ -167,7 +167,9 @@ virtualMemoryManagement:
     <<: *level_2
     # SWDEV-555665
     disabled: [amd_windows]
-  Unit_hipMemSetAccessHost_devicealloc: *level_2
+  Unit_hipMemSetAccessHost_devicealloc:
+    <<: *level_2
+    disabled: [amd_windows]
   Unit_hipMemGetAllocationPropertiesFromHandle_functional:
     <<: *level_2
     # Patch which removes the typetraits implementation from std namespace in hiprtc is reverted

--- a/projects/hip-tests/catch/unit/virtualMemoryManagement/hipMemSetGetAccess.cc
+++ b/projects/hip-tests/catch/unit/virtualMemoryManagement/hipMemSetGetAccess.cc
@@ -1606,13 +1606,13 @@ HIP_TEST_CASE(Unit_hipMemSetAccessHost_devicealloc) {
   // SWDEV-563752: we need to allow setAccess to the host even if location is set to
   // hipMemLocationTypeDevice in hipMemCreate
   HIP_CHECK(hipMemSetAccess(addr, mapSize, &accHost, 1));
-#else
-  HIP_CHECK_ERROR(hipMemSetAccess(addr, mapSize, &accHost, 1), hipErrorNotSupported);
-#endif
 
   // Exercise access to the virtual memory range from the host
   int* hostPtr = reinterpret_cast<int*>(addr);
   for (size_t i = 0; i < N; ++i) hostPtr[i] = static_cast<int>(i);
+#else
+  HIP_CHECK_ERROR(hipMemSetAccess(addr, mapSize, &accHost, 1), hipErrorNotSupported);
+#endif
 
   HIP_CHECK(hipMemUnmap(addr, mapSize));
   HIP_CHECK(hipMemAddressFree(addr, mapSize));

--- a/projects/hip-tests/catch/unit/virtualMemoryManagement/hipMemSetGetAccess.cc
+++ b/projects/hip-tests/catch/unit/virtualMemoryManagement/hipMemSetGetAccess.cc
@@ -1610,6 +1610,10 @@ HIP_TEST_CASE(Unit_hipMemSetAccessHost_devicealloc) {
   HIP_CHECK_ERROR(hipMemSetAccess(addr, mapSize, &accHost, 1), hipErrorNotSupported);
 #endif
 
+  // Exercise access to the virtual memory range from the host
+  int* hostPtr = reinterpret_cast<int*>(addr);
+  for (size_t i = 0; i < N; ++i) hostPtr[i] = static_cast<int>(i);
+
   HIP_CHECK(hipMemUnmap(addr, mapSize));
   HIP_CHECK(hipMemAddressFree(addr, mapSize));
   HIP_CHECK(hipMemRelease(handle));


### PR DESCRIPTION
## Motivation

Test is failing on rocr-on-windows path.

## Technical Details

- On Windows, there is no support for binding a system virtual address range to a memory handle of a GPU memory allocation.
- On PAL, this test was passing because hipMemSetAccess did not attempt to map the allocation into the system virtual address space and return in CLR so hipMemSetAccess call passed. But adding actual access to the virtual address from the host side resulted in a segfault with the PAL backend as well.
- Hence, the test is disabled and access exercise is added. 

## JIRA ID

ROCM-20999

## Test Plan

N/A

## Test Result

N/A

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
