### PR TITLE
[aqlprofile] Fix ASAN build error by deferring GTest discovery to tes…

### DIFF
--- a/projects/aqlprofile/src/core/tests/CMakeLists.txt
+++ b/projects/aqlprofile/src/core/tests/CMakeLists.txt
@@ -38,6 +38,7 @@ target_link_libraries(
             GTest::gtest_main)
 gtest_discover_tests(
     gfx9-memory-manager-test
+    DISCOVERY_MODE PRE_TEST
     WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
     PROPERTIES TIMEOUT 45 LABELS "unittests")
 
@@ -65,6 +66,7 @@ target_link_libraries(
             ${CMAKE_DL_LIBS})
 gtest_discover_tests(
     aqlprofile-test
+    DISCOVERY_MODE PRE_TEST
     WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
     PROPERTIES TIMEOUT 45 LABELS "unittests")
 
@@ -93,6 +95,7 @@ target_link_libraries(
             ${CMAKE_DL_LIBS})
 gtest_discover_tests(
     command-buffer-test
+    DISCOVERY_MODE PRE_TEST
     WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
     PROPERTIES TIMEOUT 45 LABELS "unittests")
 
@@ -120,6 +123,7 @@ target_link_libraries(
             ${CMAKE_DL_LIBS})
 gtest_discover_tests(
     counters-test
+    DISCOVERY_MODE PRE_TEST
     WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
     PROPERTIES TIMEOUT 45 LABELS "unittests")
 
@@ -144,6 +148,7 @@ target_link_libraries(
             ${CMAKE_DL_LIBS})
 gtest_discover_tests(
     pm4-factory-test
+    DISCOVERY_MODE PRE_TEST
     WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
     PROPERTIES TIMEOUT 45 LABELS "unittests")
 
@@ -164,6 +169,7 @@ target_link_libraries(
             ${CMAKE_DL_LIBS})
 gtest_discover_tests(
     logger-test
+    DISCOVERY_MODE PRE_TEST
     WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
     PROPERTIES TIMEOUT 45 LABELS "unittests")
 
@@ -204,5 +210,6 @@ target_link_libraries(
             ${CMAKE_DL_LIBS})
 gtest_discover_tests(
     aql-profile-v2-test
+    DISCOVERY_MODE PRE_TEST
     WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
     PROPERTIES TIMEOUT 45 LABELS "unittests")

--- a/projects/aqlprofile/src/pm4/tests/CMakeLists.txt
+++ b/projects/aqlprofile/src/pm4/tests/CMakeLists.txt
@@ -23,6 +23,7 @@ target_link_libraries(
             ${CMAKE_DL_LIBS})
 gtest_discover_tests(
     command-builder-test
+    DISCOVERY_MODE PRE_TEST
     WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
     PROPERTIES TIMEOUT 45 LABELS "unittests")
 
@@ -45,6 +46,7 @@ target_link_libraries(
             ${CMAKE_DL_LIBS})
 gtest_discover_tests(
     pmc-builder-test
+    DISCOVERY_MODE PRE_TEST
     WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
     PROPERTIES TIMEOUT 45 LABELS "unittests")
 
@@ -67,6 +69,7 @@ target_link_libraries(
             ${CMAKE_DL_LIBS})
 gtest_discover_tests(
     gfx9-command-builder-test
+    DISCOVERY_MODE PRE_TEST
     WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
     PROPERTIES TIMEOUT 45 LABELS "unittests")
 
@@ -91,6 +94,7 @@ target_link_libraries(
             ${CMAKE_DL_LIBS})
 gtest_discover_tests(
     spm-builder-test
+    DISCOVERY_MODE PRE_TEST
     WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
     PROPERTIES TIMEOUT 45 LABELS "unittests")
 
@@ -113,6 +117,7 @@ target_link_libraries(
             ${CMAKE_DL_LIBS})
 gtest_discover_tests(
     trace-config-test
+    DISCOVERY_MODE PRE_TEST
     WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
     PROPERTIES TIMEOUT 45 LABELS "unittests")
 
@@ -135,5 +140,6 @@ target_link_libraries(
             ${CMAKE_DL_LIBS})
 gtest_discover_tests(
     sqtt-builder-test
+    DISCOVERY_MODE PRE_TEST
     WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
     PROPERTIES TIMEOUT 45 LABELS "unittests")

--- a/projects/aqlprofile/src/util/tests/CMakeLists.txt
+++ b/projects/aqlprofile/src/util/tests/CMakeLists.txt
@@ -21,5 +21,6 @@ target_link_libraries(
 
 gtest_discover_tests(
     utility_tests
+    DISCOVERY_MODE PRE_TEST
     WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
     PROPERTIES TIMEOUT 45 LABELS "unittests" FAIL_REGULAR_EXPRESSION "${AQLPROFILE_DEFAULT_FAIL_REGEX}")


### PR DESCRIPTION
…t runtime

Use DISCOVERY_MODE PRE_TEST for all gtest_discover_tests() calls to prevent test executables from running during CMake configuration when ASAN runtime libraries are not available in the library search path.

This fixes the error: "libclang_rt.asan-x86_64.so: cannot open shared object file: No such file or directory" that occurs during CMake configure in ASAN builds when GoogleTestAddTests.cmake attempts to execute test binaries.

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
