### PR TITLE
Remove global documentation ownership from CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,13 +2,6 @@
 /.azuredevops/                                                        @ROCm/external-ci
 /.github/                                                             @ROCm/rocm-systems-reviewers
 
-# Global documentation ownership
-/**/*.md                                                              @ROCm/rocm-documentation
-/**/*.rst                                                             @ROCm/rocm-documentation
-**/.readthedocs.yaml                                                  @ROCm/rocm-documentation
-**/docs/                                                              @ROCm/rocm-documentation
-**/library/include/                                                   @ROCm/rocm-documentation
-
 # Project-specific ownership
 /projects/amdsmi/                                                     @ROCm/smi-reviewers
 /projects/clr/                                                        @ROCm/clr-reviewers


### PR DESCRIPTION
- ROCm documentation team pull request reviews should only be required for project-specific doc changes, leaving reviews for top-level doc changes such as the main README.md to the discretion of the pull request author.
