### PR TITLE
[Rocprof-systems]: Add CMake version guard for LLVM flang

### DIFF
--- a/projects/rocprofiler-systems/examples/hpc/hpc-helper.cmake
+++ b/projects/rocprofiler-systems/examples/hpc/hpc-helper.cmake
@@ -50,14 +50,18 @@ mark_as_advanced(HIPCC_EXECUTABLE)
 # For HIPCC, this returns the underlying CLANG version, not HIP version
 function(CHECK_COMPILER_VERSION _COMPILER _OUTPUT)
     execute_process(
-        COMMAND ${_COMPILER} --version
+        COMMAND ${${_COMPILER}} --version
         OUTPUT_VARIABLE _VERSION_OUTPUT
         OUTPUT_STRIP_TRAILING_WHITESPACE
         ERROR_QUIET
     )
-    # Match "clang version X" or "flang-new version X" (AMD compiler line)
+    # Match "clang version X", "flang-new version X", or "flang version X" (AMD compiler line)
     # This skips "HIP version:" which appears first in hipcc output
-    string(REGEX MATCH "(clang|flang-new) version ([0-9]+)" _MATCH "${_VERSION_OUTPUT}")
+    string(
+        REGEX MATCH "(clang|flang-new|flang) version ([0-9]+)"
+        _MATCH
+        "${_VERSION_OUTPUT}"
+    )
     set(${_OUTPUT} "${CMAKE_MATCH_2}" PARENT_SCOPE)
 endfunction()
 

--- a/projects/rocprofiler-systems/examples/hpc/jacobi-fortran-targetdata-markers/CMakeLists.txt
+++ b/projects/rocprofiler-systems/examples/hpc/jacobi-fortran-targetdata-markers/CMakeLists.txt
@@ -15,7 +15,15 @@ endif()
 
 check_compiler_version(amdflang_EXECUTABLE _AMDFLANG_VERSION)
 if(_AMDFLANG_VERSION LESS 20) # amdflang openmp requirement
-    rocprofiler_systems_message(AUTHOR_WARNING "amdflang version ${_AMDFLANG_VERSION} is less than the minimum required version 20 for jacobi-fortran-usm example")
+    rocprofiler_systems_message(AUTHOR_WARNING "amdflang version ${_AMDFLANG_VERSION} is less than the minimum required version 20 for jacobi-fortran-targetdata-markers example")
+    return()
+endif()
+
+if(_AMDFLANG_VERSION GREATER_EQUAL 20 AND CMAKE_VERSION VERSION_LESS "3.24")
+    rocprofiler_systems_message(AUTHOR_WARNING
+        "CMake ${CMAKE_VERSION} does not support LLVM flang-new (amdflang >= 20). "
+        "CMake 3.24+ is required for jacobi-fortran-targetdata-markers example."
+    )
     return()
 endif()
 

--- a/projects/rocprofiler-systems/examples/hpc/jacobi-fortran-usm/CMakeLists.txt
+++ b/projects/rocprofiler-systems/examples/hpc/jacobi-fortran-usm/CMakeLists.txt
@@ -18,6 +18,14 @@ if(_AMDFLANG_VERSION LESS 20) # amdflang openmp requirement
     return()
 endif()
 
+if(_AMDFLANG_VERSION GREATER_EQUAL 20 AND CMAKE_VERSION VERSION_LESS "3.24")
+    rocprofiler_systems_message(AUTHOR_WARNING
+        "CMake ${CMAKE_VERSION} does not support LLVM flang-new (amdflang >= 20). "
+        "CMake 3.24+ is required for jacobi-fortran-usm example."
+    )
+    return()
+endif()
+
 set(offload_arch_flags "-fopenmp")
 set(offload_link_flags "-fopenmp")
 foreach(arch IN LISTS ROCPROFSYS_GFX_TARGETS)


### PR DESCRIPTION
## Motivation

When building with rocm 7.3 following error is encountered:

```
- The Fortran compiler identification is unknown
error: unknown integrated tool '-cc1'. Valid tools include '-fc1'.
-- Check for working Fortran compiler: /opt/rocm-7.3.0/bin/amdflang
CMake Error: Error required internal CMake variable not set, cmake may not be built correctly.
Missing variable is:
CMAKE_Fortran_PREPROCESS_SOURCE
CMake Error at /usr/share/cmake-3.22/Modules/CMakeTestFortranCompiler.cmake:49 (try_compile):
  Failed to generate test project build system.
Call Stack (most recent call first):
  examples/hpc/jacobi-fortran-targetdata-markers/CMakeLists.txt:30 (enable_language)
```

## Technical Details

When CMake runs `enable_language(Fortran)`, it probes the compiler to identify it — checking flags like -fpp (Fortran preprocessing) and -cc1 (the C compiler frontend invocation). These are flags the old classic flang and other traditional Fortran compilers understood. The new LLVM flang doesn't recognize either:

-`fpp` → `flang-22: error: unknown argument`: '-fpp'
-`cc1` → `error: unknown integrated tool '-cc1'. Valid tools include '-fc1'`
CMake 3.24 added the LLVMFlang compiler module (Modules/Compiler/LLVMFlang-Fortran.cmake) that knows how to properly identify and configure this new compiler. CMake 3.22 simply has no knowledge of it.

Fixed by correcting the variable dereference, extending the regex, and adding a CMake version guard that skips the Fortran examples with a warning when CMake < 3.24.

## JIRA ID

## Test Plan

Manual testing performed. Build succeeded without failures.

## Test Result

Pass.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
