### PR TITLE
[rocprofiler-sdk] users/mcao/fix_rocprofv_counter_yaml

### DIFF
--- a/projects/rocprofiler-sdk/source/lib/output/metadata.cpp
+++ b/projects/rocprofiler-sdk/source/lib/output/metadata.cpp
@@ -119,8 +119,16 @@ process_agent_counters(rocprofiler_agent_id_t    agent_id,
                 auto _dim_ids  = std::vector<rocprofiler_counter_dimension_id_t>{};
                 auto _dim_info = std::vector<rocprofiler_counter_record_dimension_info_t>{};
 
-                ROCPROFILER_CHECK(rocprofiler_query_counter_info(
-                    counters[i], ROCPROFILER_COUNTER_INFO_VERSION_1, &_info));
+                auto status = rocprofiler_query_counter_info(
+                    counters[i], ROCPROFILER_COUNTER_INFO_VERSION_1, &_info);
+
+                // Skip invalid counters instead of aborting
+                if(status != ROCPROFILER_STATUS_SUCCESS)
+                {
+                    // Silently skip - the root cause warning was already logged in dimensions.cpp
+                    // when the counter failed dimension generation. No need to log again here.
+                    continue;
+                }
 
                 if(counters_set_data != nullptr && counters_set_data->count(_info.name) == 0)
                     continue;

--- a/projects/rocprofiler-sdk/source/lib/output/metadata.cpp
+++ b/projects/rocprofiler-sdk/source/lib/output/metadata.cpp
@@ -122,11 +122,10 @@ process_agent_counters(rocprofiler_agent_id_t    agent_id,
                 auto status = rocprofiler_query_counter_info(
                     counters[i], ROCPROFILER_COUNTER_INFO_VERSION_1, &_info);
 
-                // Skip invalid counters instead of aborting
                 if(status != ROCPROFILER_STATUS_SUCCESS)
                 {
-                    // Silently skip - the root cause warning was already logged in dimensions.cpp
-                    // when the counter failed dimension generation. No need to log again here.
+                    // Silently skip instead of aborting - the root cause warning was already logged
+                    // in dimensions.cpp
                     continue;
                 }
 

--- a/projects/rocprofiler-sdk/source/lib/output/metadata.cpp
+++ b/projects/rocprofiler-sdk/source/lib/output/metadata.cpp
@@ -124,8 +124,13 @@ process_agent_counters(rocprofiler_agent_id_t    agent_id,
 
                 if(status != ROCPROFILER_STATUS_SUCCESS)
                 {
-                    // Silently skip instead of aborting - the root cause warning was already logged
-                    // in dimensions.cpp
+                    ROCP_TRACE << fmt::format(
+                        "[{}] skipping counter metadata for handle {} because "
+                        "rocprofiler_query_counter_info(...) failed: {} :: {}",
+                        __FUNCTION__,
+                        counters[i].handle,
+                        rocprofiler_get_status_name(status),
+                        rocprofiler_get_status_string(status));
                     continue;
                 }
 

--- a/projects/rocprofiler-sdk/source/lib/output/metadata.cpp
+++ b/projects/rocprofiler-sdk/source/lib/output/metadata.cpp
@@ -124,7 +124,7 @@ process_agent_counters(rocprofiler_agent_id_t    agent_id,
 
                 if(status != ROCPROFILER_STATUS_SUCCESS)
                 {
-                    ROCP_TRACE << fmt::format(
+                    ROCP_WARNING << fmt::format(
                         "[{}] skipping counter metadata for handle {} because "
                         "rocprofiler_query_counter_info(...) failed: {} :: {}",
                         __FUNCTION__,

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/aql/helpers.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/aql/helpers.cpp
@@ -44,7 +44,6 @@ get_query_info(rocprofiler_agent_id_t agent, const counters::Metric& metric)
     hsa_ven_amd_aqlprofile_id_query_t query = {metric.block().c_str(), 0, 0};
     if(aqlprofile_get_pmc_info(&profile, AQLPROFILE_INFO_BLOCK_ID, &query) != HSA_STATUS_SUCCESS)
     {
-        ROCP_WARNING << fmt::format("AQL failed to query info for counter {}", metric);
         throw std::runtime_error(fmt::format("AQL failed to query info for counter {}", metric));
     }
     return query;

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/aql/helpers.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/aql/helpers.cpp
@@ -44,7 +44,7 @@ get_query_info(rocprofiler_agent_id_t agent, const counters::Metric& metric)
     hsa_ven_amd_aqlprofile_id_query_t query = {metric.block().c_str(), 0, 0};
     if(aqlprofile_get_pmc_info(&profile, AQLPROFILE_INFO_BLOCK_ID, &query) != HSA_STATUS_SUCCESS)
     {
-        ROCP_DFATAL << fmt::format("AQL failed to query info for counter {}", metric);
+        ROCP_WARNING << fmt::format("AQL failed to query info for counter {}", metric);
         throw std::runtime_error(fmt::format("AQL failed to query info for counter {}", metric));
     }
     return query;

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/counters/dimensions.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/counters/dimensions.cpp
@@ -120,8 +120,8 @@ generate_dimensions(rocprofiler_agent_id_t agent_id)
             continue;
         } catch(const std::exception& e)
         {
-            ROCP_WARNING << "Unexpected error processing counter '" << metric << "': " << e.what()
-                         << ". Counter will be skipped.";
+            ROCP_ERROR << "Unexpected error processing counter '" << metric << "': " << e.what()
+                       << ". Counter will be skipped.";
             continue;
         }
     }

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/counters/dimensions.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/counters/dimensions.cpp
@@ -115,17 +115,13 @@ generate_dimensions(rocprofiler_agent_id_t agent_id)
             dims.emplace(ast.out_id().handle, ast_copy.set_dimensions(agent_id));
         } catch(const std::runtime_error& e)
         {
-            ROCP_WARNING << fmt::format(
-                "Invalid counter '{}' in YAML configuration - {}. Counter will be skipped.",
-                metric,
-                e.what());
+            ROCP_WARNING << "Invalid counter '" << metric << "' in YAML configuration - "
+                         << e.what() << ". Counter will be skipped.";
             continue;
         } catch(const std::exception& e)
         {
-            ROCP_WARNING << fmt::format(
-                "Unexpected error processing counter '{}': {}. Counter will be skipped.",
-                metric,
-                e.what());
+            ROCP_WARNING << "Unexpected error processing counter '" << metric << "': " << e.what()
+                         << ". Counter will be skipped.";
             continue;
         }
     }

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/counters/dimensions.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/counters/dimensions.cpp
@@ -22,7 +22,6 @@
 
 #include "dimensions.hpp"
 
-#include "lib/common/logging.hpp"
 #include "lib/common/static_object.hpp"
 #include "lib/common/utility.hpp"
 #include "lib/rocprofiler-sdk/aql/helpers.hpp"

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/counters/dimensions.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/counters/dimensions.cpp
@@ -22,6 +22,7 @@
 
 #include "dimensions.hpp"
 
+#include "lib/common/logging.hpp"
 #include "lib/common/static_object.hpp"
 #include "lib/common/utility.hpp"
 #include "lib/rocprofiler-sdk/aql/helpers.hpp"
@@ -113,10 +114,20 @@ generate_dimensions(rocprofiler_agent_id_t agent_id)
         {
             // Generate dimensions for this specific agent
             dims.emplace(ast.out_id().handle, ast_copy.set_dimensions(agent_id));
-        } catch(std::runtime_error& e)
+        } catch(const std::runtime_error& e)
         {
-            ROCP_FATAL << metric << " has improper dimensions"
-                       << " " << e.what();
+            ROCP_WARNING << fmt::format(
+                "Invalid counter '{}' in YAML configuration - {}. Counter will be skipped.",
+                metric,
+                e.what());
+            continue;
+        } catch(const std::exception& e)
+        {
+            ROCP_WARNING << fmt::format(
+                "Unexpected error processing counter '{}': {}. Counter will be skipped.",
+                metric,
+                e.what());
+            continue;
         }
     }
     return {.id_to_dim = dims};

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/counters/dimensions.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/counters/dimensions.cpp
@@ -65,7 +65,15 @@ getBlockDimensions(rocprofiler_agent_id_t agent_id, const Metric& metric)
     {
         auto dims   = std::map<int, uint64_t>{};
         auto status = aql::get_dim_info(agent_id, event, 0, dims);
-        CHECK_EQ(status, ROCPROFILER_STATUS_SUCCESS) << rocprofiler_get_status_string(status);
+        // Event-level error handling: Skip individual events with invalid dimension info.
+        // This allows the metric to succeed partially if some events are valid.
+        if(status != ROCPROFILER_STATUS_SUCCESS)
+        {
+            ROCP_WARNING << "Failed to get dimension info for event in metric '" << metric.name()
+                         << "': " << rocprofiler_get_status_string(status)
+                         << ". Event will be skipped.";
+            continue;
+        }
 
         for(const auto& [id, extent] : dims)
         {
@@ -113,15 +121,12 @@ generate_dimensions(rocprofiler_agent_id_t agent_id)
         {
             // Generate dimensions for this specific agent
             dims.emplace(ast.out_id().handle, ast_copy.set_dimensions(agent_id));
-        } catch(const std::runtime_error& e)
+        }
+        // Metric-level error handling: Skip entire metric on validation failures
+        catch(const std::runtime_error& e)
         {
             ROCP_WARNING << "Invalid counter '" << metric << "' in YAML configuration - "
                          << e.what() << ". Counter will be skipped.";
-            continue;
-        } catch(const std::exception& e)
-        {
-            ROCP_ERROR << "Unexpected error processing counter '" << metric << "': " << e.what()
-                       << ". Counter will be skipped.";
             continue;
         }
     }

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/counters/metrics.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/counters/metrics.cpp
@@ -96,6 +96,10 @@ get_constants(uint64_t starting_id)
 void
 print_counter_yaml_schema_hint()
 {
+    static bool hint_printed = false;
+    if(hint_printed) return;
+    hint_printed = true;
+
     ROCP_ERROR << "Expected structure:\n"
                << "Each definition must be one of:\n"
                << "  (1) expression counter: architectures + expression\n"
@@ -401,14 +405,18 @@ loadYAML(const std::string& filename, std::optional<ArchMetric> add_metric)
     uint64_t current_id = 0;
     if(!override.data.empty() && override.append)
     {
-        append_yaml        = safe_load_yaml(override.data, "extra counters YAML");
-        auto append_header = get_counters_node(append_yaml, "extra counters YAML", true);
+        append_yaml = safe_load_yaml(override.data, "extra counters YAML");
 
-        if(append_header)
+        if(append_yaml)
         {
-            for(const auto& counter : append_header)
+            auto append_header = get_counters_node(append_yaml, "extra counters YAML", true);
+
+            if(append_header)
             {
-                header.push_back(counter);
+                for(const auto& counter : append_header)
+                {
+                    header.push_back(counter);
+                }
             }
         }
         else

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/counters/metrics.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/counters/metrics.cpp
@@ -280,10 +280,8 @@ should_skip_duplicate(
     auto dup_key = arch_name + ":" + counter_name;
     if(warned_duplicates.insert(dup_key).second)
     {
-        ROCP_WARNING << fmt::format("Duplicate counter '{}' found in YAML for architecture {}. "
-                                    "Using first definition, ignoring duplicate.",
-                                    counter_name,
-                                    arch_name);
+        ROCP_WARNING << "Duplicate counter '" << counter_name << "' found in YAML for architecture "
+                     << arch_name << ". Using first definition, ignoring duplicate.";
     }
 
     return true;

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/counters/metrics.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/counters/metrics.cpp
@@ -93,9 +93,6 @@ get_constants(uint64_t starting_id)
     return constants;
 }
 
-// ============================================================================
-// YAML Parsing Helper Functions
-// ============================================================================
 static void
 print_counter_yaml_schema_hint()
 {
@@ -367,7 +364,6 @@ loadYAML(const std::string& filename, std::optional<ArchMetric> add_metric)
         {
             ROCP_ERROR << "Ignoring invalid extra counters YAML";
         }
-        // Note: Continue with main counters even if append fails
     }
 
     // Track counter names per architecture to detect duplicates
@@ -440,7 +436,6 @@ loadYAML(const std::string& filename, std::optional<ArchMetric> add_metric)
                     metricVec.insert(metricVec.end(), constants.begin(), constants.end());
                     current_id += constants.size();
                 }
-
                 metricVec.emplace_back(
                     arch_name, counter_name, block, event, description, expression, "", current_id);
                 current_id++;

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/counters/metrics.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/counters/metrics.cpp
@@ -48,8 +48,6 @@
 #include <cstdlib>
 #include <memory>
 #include <system_error>
-#include <unordered_map>
-#include <unordered_set>
 #include <vector>
 
 namespace rocprofiler
@@ -94,6 +92,203 @@ get_constants(uint64_t starting_id)
     }
     return constants;
 }
+
+// ============================================================================
+// YAML Parsing Helper Functions
+// ============================================================================
+static void
+print_counter_yaml_schema_hint()
+{
+    ROCP_ERROR << "Expected structure:\n"
+               << "rocprofiler-sdk:\n"
+               << "  counters-schema-version: 1\n"
+               << "  counters:\n"
+               << "  - name: COUNTER_NAME\n"
+               << "    description: 'Counter description'\n"
+               << "    properties: []\n"
+               << "    definitions:\n"
+               << "    - architectures:\n"
+               << "      - gfx942\n"
+               << "      block: BLOCK_NAME\n"
+               << "      event: EVENT_ID\n";
+}
+
+/**
+ * @brief Safely load YAML with exception handling
+ */
+YAML::Node
+safe_load_yaml(const std::string& data, const std::string& source_name)
+{
+    try
+    {
+        return YAML::Load(data);
+    } catch(const YAML::ParserException& e)
+    {
+        ROCP_ERROR << "Failed to parse " << source_name << ": " << e.what();
+    } catch(const YAML::Exception& e)
+    {
+        ROCP_ERROR << "YAML error while loading " << source_name << ": " << e.what();
+    } catch(const std::exception& e)
+    {
+        ROCP_ERROR << "Unexpected error while loading " << source_name << ": " << e.what();
+    }
+
+    return {};
+}
+
+/**
+ * @brief Extract the counters node from YAML with validation
+ */
+YAML::Node
+get_counters_node(const YAML::Node& root, const std::string& source_name, bool print_schema_hint)
+{
+    if(!root || !root.IsMap())
+    {
+        ROCP_ERROR << "Invalid " << source_name << ": root must be a map";
+        if(print_schema_hint) print_counter_yaml_schema_hint();
+        return {};
+    }
+
+    auto sdk = root["rocprofiler-sdk"];
+    if(!sdk || !sdk.IsMap())
+    {
+        ROCP_ERROR << "Invalid " << source_name << ": missing or invalid 'rocprofiler-sdk'";
+        if(print_schema_hint) print_counter_yaml_schema_hint();
+        return {};
+    }
+
+    auto counters = sdk["counters"];
+    if(!counters || !counters.IsSequence())
+    {
+        ROCP_ERROR << "Invalid " << source_name
+                   << ": missing or invalid 'rocprofiler-sdk.counters'";
+        if(print_schema_hint) print_counter_yaml_schema_hint();
+        return {};
+    }
+
+    return counters;
+}
+
+/**
+ * @brief Safely extract a required string field from YAML node
+ * Returns std::nullopt if field missing, has wrong type, or is empty
+ * Logs appropriate warning on failure
+ */
+std::optional<std::string>
+get_required_scalar(const YAML::Node& parent, const char* key, const std::string& context)
+{
+    auto node = parent[key];
+    if(!node || !node.IsScalar())
+    {
+        ROCP_WARNING << "Skipping " << context << ": missing or invalid '" << key << "'";
+        return std::nullopt;
+    }
+
+    try
+    {
+        return node.as<std::string>();
+    } catch(const YAML::Exception& e)
+    {
+        ROCP_WARNING << "Skipping " << context << ": invalid '" << key << "': " << e.what();
+        return std::nullopt;
+    }
+}
+
+/**
+ * @brief Safely extract an optional string field from YAML node
+ * Returns empty string if field missing or wrong type
+ */
+std::string
+get_optional_scalar(const YAML::Node& parent, const char* key)
+{
+    auto node = parent[key];
+    if(!node) return {};
+    if(!node.IsScalar()) return {};
+
+    try
+    {
+        return node.as<std::string>();
+    } catch(const YAML::Exception&)
+    {
+        return {};
+    }
+}
+
+bool
+validate_definitions_node(const YAML::Node& counter, const std::string& counter_name)
+{
+    auto definitions = counter["definitions"];
+    if(!definitions || !definitions.IsSequence())
+    {
+        ROCP_WARNING << "Skipping counter '" << counter_name
+                     << "': missing or invalid 'definitions'";
+        return false;
+    }
+
+    return true;
+}
+bool
+validate_definition_node(const YAML::Node& definition, const std::string& counter_name)
+{
+    if(!definition || !definition.IsMap())
+    {
+        ROCP_WARNING << "Skipping invalid definition for counter '" << counter_name
+                     << "': definition must be a map";
+        return false;
+    }
+
+    if(!definition["architectures"] || !definition["architectures"].IsSequence())
+    {
+        ROCP_WARNING << "Skipping invalid definition for counter '" << counter_name
+                     << "': missing or invalid 'architectures'";
+        return false;
+    }
+
+    if(definition["block"] && !definition["block"].IsScalar())
+    {
+        ROCP_WARNING << "Skipping invalid definition for counter '" << counter_name
+                     << "': 'block' must be a scalar";
+        return false;
+    }
+
+    if(definition["event"] && !definition["event"].IsScalar())
+    {
+        ROCP_WARNING << "Skipping invalid definition for counter '" << counter_name
+                     << "': 'event' must be a scalar";
+        return false;
+    }
+
+    if(definition["expression"] && !definition["expression"].IsScalar())
+    {
+        ROCP_WARNING << "Skipping invalid definition for counter '" << counter_name
+                     << "': 'expression' must be a scalar";
+        return false;
+    }
+
+    return true;
+}
+
+bool
+should_skip_duplicate(
+    std::unordered_map<std::string, std::unordered_set<std::string>>& arch_counter_names,
+    std::unordered_set<std::string>&                                  warned_duplicates,
+    const std::string&                                                arch_name,
+    const std::string&                                                counter_name)
+{
+    if(arch_counter_names[arch_name].insert(counter_name).second) return false;
+
+    auto dup_key = arch_name + ":" + counter_name;
+    if(warned_duplicates.insert(dup_key).second)
+    {
+        ROCP_WARNING << fmt::format("Duplicate counter '{}' found in YAML for architecture {}. "
+                                    "Using first definition, ignoring duplicate.",
+                                    counter_name,
+                                    arch_name);
+    }
+
+    return true;
+}
+
 /**
  * Expected YAML Format:
  * COUNTER_NAME:
@@ -120,7 +315,6 @@ loadYAML(const std::string& filename, std::optional<ArchMetric> add_metric)
         return data;
     });
 
-    // Helper lambda to return empty counter_metrics_t on error
     auto return_empty = []() {
         return counter_metrics_t{
             .arch_to_metric = MetricMap{}, .id_to_metric = {}, .arch_to_id = {}};
@@ -131,22 +325,13 @@ loadYAML(const std::string& filename, std::optional<ArchMetric> add_metric)
     {
         ROCP_INFO << "Loading Counter Config: " << filename;
         std::ifstream file(filename);
-
-        // Validate file was opened successfully
-        if(!file.is_open() || !file.good())
+        if(!file)
         {
             ROCP_ERROR << "Failed to open counter configuration file: " << filename;
             return return_empty();
         }
 
         counter_data << file.rdbuf();
-
-        // Check if file was empty or read failed
-        if(counter_data.str().empty())
-        {
-            ROCP_ERROR << "Counter configuration file is empty or unreadable: " << filename;
-            return return_empty();
-        }
     }
     else
     {
@@ -154,229 +339,103 @@ loadYAML(const std::string& filename, std::optional<ArchMetric> add_metric)
         counter_data << override.data;
     }
 
-    // Wrap YAML parsing in exception handling
-    YAML::Node yaml;
-    try
+    auto yaml = safe_load_yaml(counter_data.str(), "counter config YAML");
+    if(!yaml)
     {
-        yaml = YAML::Load(counter_data.str());
-    } catch(const YAML::ParserException& e)
-    {
-        ROCP_ERROR << "YAML parsing error in counter configuration: " << e.what();
-        return return_empty();
-    } catch(const YAML::Exception& e)
-    {
-        ROCP_ERROR << "YAML error in counter configuration: " << e.what();
-        return return_empty();
-    } catch(const std::exception& e)
-    {
-        ROCP_ERROR << "Unexpected error parsing counter configuration: " << e.what();
         return return_empty();
     }
 
-    // Validate required YAML structure
-    if(!yaml["rocprofiler-sdk"])
+    // Extract and validate the counters node
+    auto header = get_counters_node(yaml, "counter config YAML", false);
+    if(!header)
     {
-        ROCP_ERROR << "YAML missing required top-level key 'rocprofiler-sdk'";
         return return_empty();
     }
 
-    if(!yaml["rocprofiler-sdk"]["counters"])
-    {
-        ROCP_ERROR << "YAML missing required key 'rocprofiler-sdk.counters'";
-        return return_empty();
-    }
-
-    auto     header     = yaml["rocprofiler-sdk"]["counters"];
     uint64_t current_id = 0;
     if(!override.data.empty() && override.append)
     {
-        try
+        append_yaml        = safe_load_yaml(override.data, "extra counters YAML");
+        auto append_header = get_counters_node(append_yaml, "extra counters YAML", true);
+
+        if(append_header)
         {
-            append_yaml = YAML::Load(override.data);
-            if(append_yaml["rocprofiler-sdk"] && append_yaml["rocprofiler-sdk"]["counters"])
+            for(const auto& counter : append_header)
             {
-                for(const auto& counter : append_yaml["rocprofiler-sdk"]["counters"])
-                {
-                    header.push_back(counter);
-                }
+                header.push_back(counter);
             }
-            else
-            {
-                ROCP_ERROR << "Invalid extra counters YAML format. Expected structure:\n"
-                           << "rocprofiler-sdk:\n"
-                           << "  counters-schema-version: 1\n"
-                           << "  counters:\n"
-                           << "  - name: COUNTER_NAME\n"
-                           << "    description: 'Counter description'\n"
-                           << "    properties: []\n"
-                           << "    definitions:\n"
-                           << "    - architectures:\n"
-                           << "      - gfx942\n"
-                           << "      block: BLOCK_NAME\n"
-                           << "      event: EVENT_ID\n"
-                           << "Got:\n"
-                           << override.data;
-            }
-        } catch(const YAML::Exception& e)
-        {
-            ROCP_ERROR << "YAML error in override data: " << e.what();
-        } catch(const std::exception& e)
-        {
-            ROCP_ERROR << "Unexpected error parsing override data: " << e.what();
         }
+        else
+        {
+            ROCP_ERROR << "Ignoring invalid extra counters YAML";
+        }
+        // Note: Continue with main counters even if append fails
     }
 
     // Track counter names per architecture to detect duplicates
     std::unordered_map<std::string, std::unordered_set<std::string>> arch_counter_names;
-    // Track which duplicates we've already warned about (static to persist across calls)
-    static std::unordered_set<std::string> warned_duplicates;
+    static std::unordered_set<std::string>                           warned_duplicates;
 
     for(const auto& counter : header)
     {
-        // Validate required counter fields exist and have correct types
-        if(!counter["name"])
+        // Extract and validate required counter fields
+        if(!counter || !counter.IsMap())
         {
-            ROCP_WARNING << "Counter entry missing required 'name' field. Skipping counter.";
+            ROCP_WARNING << "Skipping invalid counter entry: counter must be a map";
             continue;
         }
 
-        if(!counter["description"])
-        {
-            ROCP_WARNING << "Counter entry missing required 'description' field. Skipping counter.";
-            continue;
-        }
+        auto counter_name_opt = get_required_scalar(counter, "name", "counter entry");
+        if(!counter_name_opt) continue;
+        const auto& counter_name = *counter_name_opt;
 
-        if(!counter["definitions"])
-        {
-            ROCP_WARNING << "Counter entry missing required 'definitions' field. Skipping counter.";
-            continue;
-        }
+        auto description_opt =
+            get_required_scalar(counter, "description", "counter '" + counter_name + "'");
+        if(!description_opt) continue;
+        const auto& description = *description_opt;
 
-        std::string counter_name;
-        std::string description;
-
-        // Safely extract counter name and description with type checking
-        try
-        {
-            counter_name = counter["name"].as<std::string>();
-            description  = counter["description"].as<std::string>();
-
-            // Validate name is not empty (description can be empty)
-            if(counter_name.empty())
-            {
-                ROCP_WARNING << "Counter has empty name field. Skipping counter.";
-                continue;
-            }
-        } catch(const YAML::BadConversion& e)
-        {
-            ROCP_WARNING << "Counter has invalid type for 'name' or 'description' field "
-                         << "(expected string). Skipping counter.";
-            continue;
-        }
+        if(!validate_definitions_node(counter, counter_name)) continue;
 
         for(const auto& definition : counter["definitions"])
         {
-            if(!definition["architectures"])
-            {
-                ROCP_WARNING << fmt::format(
-                    "Counter '{}' definition missing 'architectures' field. Skipping definition.",
-                    counter_name);
-                continue;
-            }
+            if(!validate_definition_node(definition, counter_name)) continue;
 
-            if(!definition["architectures"].IsSequence() || definition["architectures"].size() == 0)
+            auto block      = get_optional_scalar(definition, "block");
+            auto event      = get_optional_scalar(definition, "event");
+            auto expression = get_optional_scalar(definition, "expression");
+
+            if(event.empty() && expression.empty())
             {
-                ROCP_WARNING << fmt::format(
-                    "Counter '{}' has empty or invalid 'architectures' list. Skipping definition.",
-                    counter_name);
+                ROCP_WARNING << "Skipping invalid definition for counter '" << counter_name
+                             << "': definition must contain 'event' or 'expression'";
                 continue;
             }
 
             for(const auto& arch : definition["architectures"])
             {
-                std::string arch_str;
+                if(!arch || !arch.IsScalar())
+                {
+                    ROCP_WARNING << "Skipping invalid architecture entry for counter '"
+                                 << counter_name << "': architecture must be a scalar";
+                    continue;
+                }
+
+                std::string arch_name;
                 try
                 {
-                    arch_str = arch.as<std::string>();
-
-                    if(arch_str.empty())
-                    {
-                        ROCP_WARNING << fmt::format(
-                            "Counter '{}' has empty architecture string. Skipping.", counter_name);
-                        continue;
-                    }
-                } catch(const YAML::BadConversion& e)
+                    arch_name = arch.as<std::string>();
+                } catch(const YAML::Exception& e)
                 {
-                    ROCP_WARNING << fmt::format(
-                        "Counter '{}' has invalid architecture type (expected string). Skipping.",
-                        counter_name);
+                    ROCP_WARNING << "Skipping invalid architecture entry for counter '"
+                                 << counter_name << "': " << e.what();
                     continue;
                 }
 
-                // Check for duplicate counter name in this architecture
-                if(!arch_counter_names[arch_str].insert(counter_name).second)
-                {
-                    // Only warn once per unique counter+arch combination
-                    auto dup_key = arch_str + ":" + counter_name;
-                    if(warned_duplicates.insert(dup_key).second)
-                    {
-                        ROCP_WARNING << fmt::format(
-                            "Duplicate counter '{}' found in YAML for architecture {}. "
-                            "Using first definition, ignoring duplicate.",
-                            counter_name,
-                            arch_str);
-                    }
-                    continue;  // Skip this duplicate definition
-                }
-
-                // Extract and validate block, event, and expression fields
-                std::string block_str;
-                std::string event_str;
-                std::string expression_str;
-
-                try
-                {
-                    block_str = (definition["block"] ? definition["block"].as<std::string>() : "");
-                    event_str = (definition["event"] ? definition["event"].as<std::string>() : "");
-                    expression_str =
-                        (definition["expression"] ? definition["expression"].as<std::string>()
-                                                  : "");
-                } catch(const YAML::BadConversion& e)
-                {
-                    ROCP_WARNING << fmt::format(
-                        "Counter '{}' has invalid type for block/event/expression field. "
-                        "Expected string. Skipping definition.",
-                        counter_name);
+                if(should_skip_duplicate(
+                       arch_counter_names, warned_duplicates, arch_name, counter_name))
                     continue;
-                }
 
-                // Validate counter definition is complete
-                // Counter must have either: (block AND event) OR expression
-                bool has_block      = !block_str.empty();
-                bool has_event      = !event_str.empty();
-                bool has_expression = !expression_str.empty();
-
-                // Validate: must have expression OR both block+event
-                if(!has_expression && !(has_block && has_event))
-                {
-                    std::string issue;
-                    if(has_block && !has_event)
-                        issue = fmt::format("has block '{}' but missing event", block_str);
-                    else if(!has_block && has_event)
-                        issue = fmt::format("has event '{}' but missing block", event_str);
-                    else
-                        issue = "missing both block/event and expression";
-
-                    ROCP_WARNING << fmt::format(
-                        "Counter '{}' for architecture {} {}. "
-                        "Hardware counters need both block AND event, OR an expression. Skipping.",
-                        counter_name,
-                        arch_str,
-                        issue);
-                    continue;
-                }
-
-                auto& metricVec = ret.emplace(arch_str, std::vector<Metric>()).first->second;
+                auto& metricVec = ret.emplace(arch_name, std::vector<Metric>()).first->second;
                 if(metricVec.empty())
                 {
                     const auto constants = get_constants(current_id);
@@ -384,14 +443,8 @@ loadYAML(const std::string& filename, std::optional<ArchMetric> add_metric)
                     current_id += constants.size();
                 }
 
-                metricVec.emplace_back(arch_str,
-                                       counter_name,
-                                       block_str,
-                                       event_str,
-                                       description,
-                                       expression_str,
-                                       "",
-                                       current_id);
+                metricVec.emplace_back(
+                    arch_name, counter_name, block, event, description, expression, "", current_id);
                 current_id++;
             }
         }

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/counters/metrics.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/counters/metrics.cpp
@@ -97,6 +97,9 @@ void
 print_counter_yaml_schema_hint()
 {
     ROCP_ERROR << "Expected structure:\n"
+               << "Each definition must be one of:\n"
+               << "  (1) expression counter: architectures + expression\n"
+               << "  (2) hardware counter: architectures + block + event\n"
                << "rocprofiler-sdk:\n"
                << "  counters-schema-version: 1\n"
                << "  counters:\n"
@@ -104,6 +107,10 @@ print_counter_yaml_schema_hint()
                << "    description: 'Counter description'\n"
                << "    properties: []\n"
                << "    definitions:\n"
+               << "    - architectures:\n"
+               << "      - gfx942\n"
+               << "      expression: reduce(GRBM_GUI_ACTIVE,max)*CU_NUM\n"
+               << "      # OR\n"
                << "    - architectures:\n"
                << "      - gfx942\n"
                << "      block: BLOCK_NAME\n"
@@ -183,7 +190,13 @@ get_required_scalar(const YAML::Node& parent, const char* key, const std::string
 
     try
     {
-        return node.as<std::string>();
+        auto value = node.as<std::string>();
+        if(value.empty())
+        {
+            ROCP_WARNING << "Skipping " << context << ": empty '" << key << "'";
+            return std::nullopt;
+        }
+        return value;
     } catch(const YAML::Exception& e)
     {
         ROCP_WARNING << "Skipping " << context << ": invalid '" << key << "': " << e.what();
@@ -224,6 +237,7 @@ validate_definitions_node(const YAML::Node& counter, const std::string& counter_
 
     return true;
 }
+
 bool
 validate_definition_node(const YAML::Node& definition, const std::string& counter_name)
 {
@@ -234,10 +248,11 @@ validate_definition_node(const YAML::Node& definition, const std::string& counte
         return false;
     }
 
-    if(!definition["architectures"] || !definition["architectures"].IsSequence())
+    if(!definition["architectures"] || !definition["architectures"].IsSequence() ||
+       definition["architectures"].size() == 0)
     {
         ROCP_WARNING << "Skipping invalid definition for counter '" << counter_name
-                     << "': missing or invalid 'architectures'";
+                     << "': missing, invalid, or empty 'architectures'";
         return false;
     }
 
@@ -259,6 +274,42 @@ validate_definition_node(const YAML::Node& definition, const std::string& counte
     {
         ROCP_WARNING << "Skipping invalid definition for counter '" << counter_name
                      << "': 'expression' must be a scalar";
+        return false;
+    }
+
+    // Validate mutually exclusive counter types:
+    // Allowed forms:
+    //   1) expression counter: architectures + expression
+    //   2) hardware counter: architectures + block + event
+    const bool has_block      = static_cast<bool>(definition["block"]);
+    const bool has_event      = static_cast<bool>(definition["event"]);
+    const bool has_expression = static_cast<bool>(definition["expression"]);
+
+    if(!has_expression && !has_event)
+    {
+        ROCP_WARNING << "Skipping invalid definition for counter '" << counter_name
+                     << "': missing both 'event' and 'expression'";
+        return false;
+    }
+
+    if(has_event && !has_block)
+    {
+        ROCP_WARNING << "Skipping invalid definition for counter '" << counter_name
+                     << "': 'event' requires 'block'";
+        return false;
+    }
+
+    if(has_block && !has_event)
+    {
+        ROCP_WARNING << "Skipping invalid definition for counter '" << counter_name
+                     << "': 'block' requires 'event'";
+        return false;
+    }
+
+    if(has_expression && (has_block || has_event))
+    {
+        ROCP_WARNING << "Skipping invalid definition for counter '" << counter_name
+                     << "': definition must be either 'expression' or 'block' + 'event', not both";
         return false;
     }
 
@@ -368,7 +419,7 @@ loadYAML(const std::string& filename, std::optional<ArchMetric> add_metric)
 
     // Track counter names per architecture to detect duplicates
     std::unordered_map<std::string, std::unordered_set<std::string>> arch_counter_names;
-    static std::unordered_set<std::string>                           warned_duplicates;
+    std::unordered_set<std::string>                                  warned_duplicates;
 
     for(const auto& counter : header)
     {
@@ -397,13 +448,6 @@ loadYAML(const std::string& filename, std::optional<ArchMetric> add_metric)
             auto block      = get_optional_scalar(definition, "block");
             auto event      = get_optional_scalar(definition, "event");
             auto expression = get_optional_scalar(definition, "expression");
-
-            if(event.empty() && expression.empty())
-            {
-                ROCP_WARNING << "Skipping invalid definition for counter '" << counter_name
-                             << "': definition must contain 'event' or 'expression'";
-                continue;
-            }
 
             for(const auto& arch : definition["architectures"])
             {

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/counters/metrics.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/counters/metrics.cpp
@@ -93,7 +93,7 @@ get_constants(uint64_t starting_id)
     return constants;
 }
 
-static void
+void
 print_counter_yaml_schema_hint()
 {
     ROCP_ERROR << "Expected structure:\n"

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/counters/metrics.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/counters/metrics.cpp
@@ -229,20 +229,6 @@ get_optional_scalar(const YAML::Node& parent, const char* key)
 }
 
 bool
-validate_definitions_node(const YAML::Node& counter, const std::string& counter_name)
-{
-    auto definitions = counter["definitions"];
-    if(!definitions || !definitions.IsSequence())
-    {
-        ROCP_WARNING << "Skipping counter '" << counter_name
-                     << "': missing or invalid 'definitions'";
-        return false;
-    }
-
-    return true;
-}
-
-bool
 validate_definition_node(const YAML::Node& definition, const std::string& counter_name)
 {
     if(!definition || !definition.IsMap())
@@ -260,6 +246,7 @@ validate_definition_node(const YAML::Node& definition, const std::string& counte
         return false;
     }
 
+    // Validate types of optional fields
     if(definition["block"] && !definition["block"].IsScalar())
     {
         ROCP_WARNING << "Skipping invalid definition for counter '" << counter_name
@@ -278,42 +265,6 @@ validate_definition_node(const YAML::Node& definition, const std::string& counte
     {
         ROCP_WARNING << "Skipping invalid definition for counter '" << counter_name
                      << "': 'expression' must be a scalar";
-        return false;
-    }
-
-    // Validate mutually exclusive counter types:
-    // Allowed forms:
-    //   1) expression counter: architectures + expression
-    //   2) hardware counter: architectures + block + event
-    const bool has_block      = static_cast<bool>(definition["block"]);
-    const bool has_event      = static_cast<bool>(definition["event"]);
-    const bool has_expression = static_cast<bool>(definition["expression"]);
-
-    if(!has_expression && !has_event)
-    {
-        ROCP_WARNING << "Skipping invalid definition for counter '" << counter_name
-                     << "': missing both 'event' and 'expression'";
-        return false;
-    }
-
-    if(has_event && !has_block)
-    {
-        ROCP_WARNING << "Skipping invalid definition for counter '" << counter_name
-                     << "': 'event' requires 'block'";
-        return false;
-    }
-
-    if(has_block && !has_event)
-    {
-        ROCP_WARNING << "Skipping invalid definition for counter '" << counter_name
-                     << "': 'block' requires 'event'";
-        return false;
-    }
-
-    if(has_expression && (has_block || has_event))
-    {
-        ROCP_WARNING << "Skipping invalid definition for counter '" << counter_name
-                     << "': definition must be either 'expression' or 'block' + 'event', not both";
         return false;
     }
 
@@ -447,15 +398,61 @@ loadYAML(const std::string& filename, std::optional<ArchMetric> add_metric)
         if(!description_opt) continue;
         const auto& description = *description_opt;
 
-        if(!validate_definitions_node(counter, counter_name)) continue;
+        auto definitions = counter["definitions"];
+        if(!definitions || !definitions.IsSequence())
+        {
+            ROCP_WARNING << "Skipping counter '" << counter_name
+                         << "': missing or invalid 'definitions'";
+            continue;
+        }
 
-        for(const auto& definition : counter["definitions"])
+        for(const auto& definition : definitions)
         {
             if(!validate_definition_node(definition, counter_name)) continue;
 
             auto block      = get_optional_scalar(definition, "block");
             auto event      = get_optional_scalar(definition, "event");
             auto expression = get_optional_scalar(definition, "expression");
+
+            // Validate mutually exclusive counter types based on extracted values
+            // Allowed forms:
+            //   1) expression counter: architectures + expression
+            //   2) hardware counter: architectures + block + event
+            // Note: get_optional_scalar() returns empty string for missing, wrong type,
+            // or empty fields, so we validate the actual extracted strings here.
+            const bool has_block      = !block.empty();
+            const bool has_event      = !event.empty();
+            const bool has_expression = !expression.empty();
+
+            if(!has_expression && !has_event)
+            {
+                ROCP_WARNING << "Skipping invalid definition for counter '" << counter_name
+                             << "': definition must provide either non-empty 'expression' or both "
+                                "non-empty 'block' and 'event'";
+                continue;
+            }
+
+            if(has_event && !has_block)
+            {
+                ROCP_WARNING << "Skipping invalid definition for counter '" << counter_name
+                             << "': 'event' requires 'block'";
+                continue;
+            }
+
+            if(has_block && !has_event)
+            {
+                ROCP_WARNING << "Skipping invalid definition for counter '" << counter_name
+                             << "': 'block' requires 'event'";
+                continue;
+            }
+
+            if(has_expression && (has_block || has_event))
+            {
+                ROCP_WARNING << "Skipping invalid definition for counter '" << counter_name
+                             << "': definition must be either 'expression' or 'block' + 'event', "
+                                "not both";
+                continue;
+            }
 
             for(const auto& arch : definition["architectures"])
             {

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/counters/metrics.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/counters/metrics.cpp
@@ -48,6 +48,8 @@
 #include <cstdlib>
 #include <memory>
 #include <system_error>
+#include <unordered_map>
+#include <unordered_set>
 #include <vector>
 
 namespace rocprofiler
@@ -118,12 +120,33 @@ loadYAML(const std::string& filename, std::optional<ArchMetric> add_metric)
         return data;
     });
 
+    // Helper lambda to return empty counter_metrics_t on error
+    auto return_empty = []() {
+        return counter_metrics_t{
+            .arch_to_metric = MetricMap{}, .id_to_metric = {}, .arch_to_id = {}};
+    };
+
     std::stringstream counter_data;
     if(override.data.empty() || override.append)
     {
         ROCP_INFO << "Loading Counter Config: " << filename;
         std::ifstream file(filename);
+
+        // Validate file was opened successfully
+        if(!file.is_open() || !file.good())
+        {
+            ROCP_ERROR << "Failed to open counter configuration file: " << filename;
+            return return_empty();
+        }
+
         counter_data << file.rdbuf();
+
+        // Check if file was empty or read failed
+        if(counter_data.str().empty())
+        {
+            ROCP_ERROR << "Counter configuration file is empty or unreadable: " << filename;
+            return return_empty();
+        }
     }
     else
     {
@@ -131,63 +154,244 @@ loadYAML(const std::string& filename, std::optional<ArchMetric> add_metric)
         counter_data << override.data;
     }
 
-    auto     yaml       = YAML::Load(counter_data.str());
+    // Wrap YAML parsing in exception handling
+    YAML::Node yaml;
+    try
+    {
+        yaml = YAML::Load(counter_data.str());
+    } catch(const YAML::ParserException& e)
+    {
+        ROCP_ERROR << "YAML parsing error in counter configuration: " << e.what();
+        return return_empty();
+    } catch(const YAML::Exception& e)
+    {
+        ROCP_ERROR << "YAML error in counter configuration: " << e.what();
+        return return_empty();
+    } catch(const std::exception& e)
+    {
+        ROCP_ERROR << "Unexpected error parsing counter configuration: " << e.what();
+        return return_empty();
+    }
+
+    // Validate required YAML structure
+    if(!yaml["rocprofiler-sdk"])
+    {
+        ROCP_ERROR << "YAML missing required top-level key 'rocprofiler-sdk'";
+        return return_empty();
+    }
+
+    if(!yaml["rocprofiler-sdk"]["counters"])
+    {
+        ROCP_ERROR << "YAML missing required key 'rocprofiler-sdk.counters'";
+        return return_empty();
+    }
+
     auto     header     = yaml["rocprofiler-sdk"]["counters"];
     uint64_t current_id = 0;
     if(!override.data.empty() && override.append)
     {
-        append_yaml = YAML::Load(override.data);
-        if(append_yaml["rocprofiler-sdk"] && append_yaml["rocprofiler-sdk"]["counters"])
+        try
         {
-            for(const auto& counter : append_yaml["rocprofiler-sdk"]["counters"])
+            append_yaml = YAML::Load(override.data);
+            if(append_yaml["rocprofiler-sdk"] && append_yaml["rocprofiler-sdk"]["counters"])
             {
-                header.push_back(counter);
+                for(const auto& counter : append_yaml["rocprofiler-sdk"]["counters"])
+                {
+                    header.push_back(counter);
+                }
             }
-        }
-        else
+            else
+            {
+                ROCP_ERROR << "Invalid extra counters YAML format. Expected structure:\n"
+                           << "rocprofiler-sdk:\n"
+                           << "  counters-schema-version: 1\n"
+                           << "  counters:\n"
+                           << "  - name: COUNTER_NAME\n"
+                           << "    description: 'Counter description'\n"
+                           << "    properties: []\n"
+                           << "    definitions:\n"
+                           << "    - architectures:\n"
+                           << "      - gfx942\n"
+                           << "      block: BLOCK_NAME\n"
+                           << "      event: EVENT_ID\n"
+                           << "Got:\n"
+                           << override.data;
+            }
+        } catch(const YAML::Exception& e)
         {
-            ROCP_ERROR << "Invalid extra counters YAML format. Expected structure:\n"
-                       << "rocprofiler-sdk:\n"
-                       << "  counters-schema-version: 1\n"
-                       << "  counters:\n"
-                       << "  - name: COUNTER_NAME\n"
-                       << "    description: 'Counter description'\n"
-                       << "    properties: []\n"
-                       << "    definitions:\n"
-                       << "    - architectures:\n"
-                       << "      - gfx942\n"
-                       << "      block: BLOCK_NAME\n"
-                       << "      event: EVENT_ID\n"
-                       << "Got:\n"
-                       << override.data;
+            ROCP_ERROR << "YAML error in override data: " << e.what();
+        } catch(const std::exception& e)
+        {
+            ROCP_ERROR << "Unexpected error parsing override data: " << e.what();
         }
     }
 
+    // Track counter names per architecture to detect duplicates
+    std::unordered_map<std::string, std::unordered_set<std::string>> arch_counter_names;
+    // Track which duplicates we've already warned about (static to persist across calls)
+    static std::unordered_set<std::string> warned_duplicates;
+
     for(const auto& counter : header)
     {
-        auto counter_name = counter["name"].as<std::string>();
-        auto description  = counter["description"].as<std::string>();
+        // Validate required counter fields exist and have correct types
+        if(!counter["name"])
+        {
+            ROCP_WARNING << "Counter entry missing required 'name' field. Skipping counter.";
+            continue;
+        }
+
+        if(!counter["description"])
+        {
+            ROCP_WARNING << "Counter entry missing required 'description' field. Skipping counter.";
+            continue;
+        }
+
+        if(!counter["definitions"])
+        {
+            ROCP_WARNING << "Counter entry missing required 'definitions' field. Skipping counter.";
+            continue;
+        }
+
+        std::string counter_name;
+        std::string description;
+
+        // Safely extract counter name and description with type checking
+        try
+        {
+            counter_name = counter["name"].as<std::string>();
+            description  = counter["description"].as<std::string>();
+
+            // Validate name is not empty (description can be empty)
+            if(counter_name.empty())
+            {
+                ROCP_WARNING << "Counter has empty name field. Skipping counter.";
+                continue;
+            }
+        } catch(const YAML::BadConversion& e)
+        {
+            ROCP_WARNING << "Counter has invalid type for 'name' or 'description' field "
+                         << "(expected string). Skipping counter.";
+            continue;
+        }
+
         for(const auto& definition : counter["definitions"])
         {
+            if(!definition["architectures"])
+            {
+                ROCP_WARNING << fmt::format(
+                    "Counter '{}' definition missing 'architectures' field. Skipping definition.",
+                    counter_name);
+                continue;
+            }
+
+            if(!definition["architectures"].IsSequence() || definition["architectures"].size() == 0)
+            {
+                ROCP_WARNING << fmt::format(
+                    "Counter '{}' has empty or invalid 'architectures' list. Skipping definition.",
+                    counter_name);
+                continue;
+            }
+
             for(const auto& arch : definition["architectures"])
             {
-                auto& metricVec =
-                    ret.emplace(arch.as<std::string>(), std::vector<Metric>()).first->second;
+                std::string arch_str;
+                try
+                {
+                    arch_str = arch.as<std::string>();
+
+                    if(arch_str.empty())
+                    {
+                        ROCP_WARNING << fmt::format(
+                            "Counter '{}' has empty architecture string. Skipping.", counter_name);
+                        continue;
+                    }
+                } catch(const YAML::BadConversion& e)
+                {
+                    ROCP_WARNING << fmt::format(
+                        "Counter '{}' has invalid architecture type (expected string). Skipping.",
+                        counter_name);
+                    continue;
+                }
+
+                // Check for duplicate counter name in this architecture
+                if(!arch_counter_names[arch_str].insert(counter_name).second)
+                {
+                    // Only warn once per unique counter+arch combination
+                    auto dup_key = arch_str + ":" + counter_name;
+                    if(warned_duplicates.insert(dup_key).second)
+                    {
+                        ROCP_WARNING << fmt::format(
+                            "Duplicate counter '{}' found in YAML for architecture {}. "
+                            "Using first definition, ignoring duplicate.",
+                            counter_name,
+                            arch_str);
+                    }
+                    continue;  // Skip this duplicate definition
+                }
+
+                // Extract and validate block, event, and expression fields
+                std::string block_str;
+                std::string event_str;
+                std::string expression_str;
+
+                try
+                {
+                    block_str = (definition["block"] ? definition["block"].as<std::string>() : "");
+                    event_str = (definition["event"] ? definition["event"].as<std::string>() : "");
+                    expression_str =
+                        (definition["expression"] ? definition["expression"].as<std::string>()
+                                                  : "");
+                } catch(const YAML::BadConversion& e)
+                {
+                    ROCP_WARNING << fmt::format(
+                        "Counter '{}' has invalid type for block/event/expression field. "
+                        "Expected string. Skipping definition.",
+                        counter_name);
+                    continue;
+                }
+
+                // Validate counter definition is complete
+                // Counter must have either: (block AND event) OR expression
+                bool has_block      = !block_str.empty();
+                bool has_event      = !event_str.empty();
+                bool has_expression = !expression_str.empty();
+
+                // Validate: must have expression OR both block+event
+                if(!has_expression && !(has_block && has_event))
+                {
+                    std::string issue;
+                    if(has_block && !has_event)
+                        issue = fmt::format("has block '{}' but missing event", block_str);
+                    else if(!has_block && has_event)
+                        issue = fmt::format("has event '{}' but missing block", event_str);
+                    else
+                        issue = "missing both block/event and expression";
+
+                    ROCP_WARNING << fmt::format(
+                        "Counter '{}' for architecture {} {}. "
+                        "Hardware counters need both block AND event, OR an expression. Skipping.",
+                        counter_name,
+                        arch_str,
+                        issue);
+                    continue;
+                }
+
+                auto& metricVec = ret.emplace(arch_str, std::vector<Metric>()).first->second;
                 if(metricVec.empty())
                 {
                     const auto constants = get_constants(current_id);
                     metricVec.insert(metricVec.end(), constants.begin(), constants.end());
                     current_id += constants.size();
                 }
-                metricVec.emplace_back(
-                    arch.as<std::string>(),
-                    counter_name,
-                    (definition["block"] ? definition["block"].as<std::string>() : ""),
-                    (definition["event"] ? definition["event"].as<std::string>() : ""),
-                    description,
-                    (definition["expression"] ? definition["expression"].as<std::string>() : ""),
-                    "",
-                    current_id);
+
+                metricVec.emplace_back(arch_str,
+                                       counter_name,
+                                       block_str,
+                                       event_str,
+                                       description,
+                                       expression_str,
+                                       "",
+                                       current_id);
                 current_id++;
             }
         }

--- a/projects/rocprofiler-sdk/tests/rocprofv3/counter-collection/extra_counters/CMakeLists.txt
+++ b/projects/rocprofiler-sdk/tests/rocprofv3/counter-collection/extra_counters/CMakeLists.txt
@@ -10,6 +10,21 @@ project(
 
 find_package(rocprofiler-sdk REQUIRED)
 
+rocprofiler_configure_pytest_files(
+    CONFIG pytest.ini
+    COPY validate.py
+         conftest.py
+         input.txt
+         extra_counters.yaml
+         duplicate_counters.yaml
+         invalid_block.yaml
+         missing_name.yaml
+         wrong_type.yaml
+         malformed.yaml
+         no_block_event.yaml
+         missing_top_key.yaml
+         empty_architectures.yaml)
+
 string(REPLACE "LD_PRELOAD=" "ROCPROF_PRELOAD=" PRELOAD_ENV
                "${ROCPROFILER_MEMCHECK_PRELOAD_ENV}")
 # pmc1 with extra counters
@@ -29,7 +44,6 @@ rocprofiler_add_integration_execute_test(
 rocprofiler_add_integration_validate_test(
     rocprofv3-test-counter-collection-pmc1-extra-counters
     TEST_PATHS validate.py
-    COPY conftest.py input.txt extra_counters.yaml
     CONFIG pytest.ini
     DISCOVERY_ARGS -k test_validate_counter_collection_pmc1_extra_counters
     ARGS --input

--- a/projects/rocprofiler-sdk/tests/rocprofv3/counter-collection/extra_counters/CMakeLists.txt
+++ b/projects/rocprofiler-sdk/tests/rocprofv3/counter-collection/extra_counters/CMakeLists.txt
@@ -4,7 +4,7 @@
 cmake_minimum_required(VERSION 3.21.0 FATAL_ERROR)
 
 project(
-    rocprofiler-sdk-tests-counter-collection-list-metrics
+    rocprofiler-sdk-tests-counter-collection-extra-counters
     LANGUAGES CXX
     VERSION 0.0.0)
 
@@ -31,8 +31,108 @@ rocprofiler_add_integration_validate_test(
     TEST_PATHS validate.py
     COPY conftest.py input.txt extra_counters.yaml
     CONFIG pytest.ini
+    DISCOVERY_ARGS -k test_validate_counter_collection_pmc1_extra_counters
     ARGS --input
          ${CMAKE_CURRENT_BINARY_DIR}/out_counter_collection_1_extra/pmc_1/pmc1_counter_collection.csv
     TIMEOUT 45
     LABELS "integration-tests"
     FIXTURES_REQUIRED rocprofv3-test-counter-collection-txt-pmc1-extra-counters)
+
+#
+# YAML Validation Tests - Invalid YAMLs should be handled gracefully without crashes
+#
+rocprofiler_add_integration_execute_test(
+    rocprofv3-test-yaml-validation-duplicate-counters
+    COMMAND
+        $<TARGET_FILE:rocprofiler-sdk::rocprofv3> -i ${CMAKE_CURRENT_BINARY_DIR}/input.txt
+        -E ${CMAKE_CURRENT_BINARY_DIR}/duplicate_counters.yaml -d
+        ${CMAKE_CURRENT_BINARY_DIR}/out_duplicate -o duplicate_test --output-format csv --
+        $<TARGET_FILE:vector-ops>
+    DEPENDS vector-ops
+    TIMEOUT 45
+    LABELS "integration-tests"
+    PRELOAD "${PRELOAD_ENV}")
+
+rocprofiler_add_integration_execute_test(
+    rocprofv3-test-yaml-validation-invalid-block
+    COMMAND
+        $<TARGET_FILE:rocprofiler-sdk::rocprofv3> -i ${CMAKE_CURRENT_BINARY_DIR}/input.txt
+        -E ${CMAKE_CURRENT_BINARY_DIR}/invalid_block.yaml -d
+        ${CMAKE_CURRENT_BINARY_DIR}/out_invalid_block -o invalid_block_test
+        --output-format csv -- $<TARGET_FILE:vector-ops>
+    DEPENDS vector-ops
+    TIMEOUT 45
+    LABELS "integration-tests"
+    PRELOAD "${PRELOAD_ENV}")
+
+rocprofiler_add_integration_execute_test(
+    rocprofv3-test-yaml-validation-missing-name
+    COMMAND
+        $<TARGET_FILE:rocprofiler-sdk::rocprofv3> -i ${CMAKE_CURRENT_BINARY_DIR}/input.txt
+        -E ${CMAKE_CURRENT_BINARY_DIR}/missing_name.yaml -d
+        ${CMAKE_CURRENT_BINARY_DIR}/out_missing_name -o missing_name_test --output-format
+        csv -- $<TARGET_FILE:vector-ops>
+    DEPENDS vector-ops
+    TIMEOUT 45
+    LABELS "integration-tests"
+    PRELOAD "${PRELOAD_ENV}")
+
+rocprofiler_add_integration_execute_test(
+    rocprofv3-test-yaml-validation-wrong-type
+    COMMAND
+        $<TARGET_FILE:rocprofiler-sdk::rocprofv3> -i ${CMAKE_CURRENT_BINARY_DIR}/input.txt
+        -E ${CMAKE_CURRENT_BINARY_DIR}/wrong_type.yaml -d
+        ${CMAKE_CURRENT_BINARY_DIR}/out_wrong_type -o wrong_type_test --output-format csv
+        -- $<TARGET_FILE:vector-ops>
+    DEPENDS vector-ops
+    TIMEOUT 45
+    LABELS "integration-tests"
+    PRELOAD "${PRELOAD_ENV}")
+
+rocprofiler_add_integration_execute_test(
+    rocprofv3-test-yaml-validation-malformed
+    COMMAND
+        $<TARGET_FILE:rocprofiler-sdk::rocprofv3> -i ${CMAKE_CURRENT_BINARY_DIR}/input.txt
+        -E ${CMAKE_CURRENT_BINARY_DIR}/malformed.yaml -d
+        ${CMAKE_CURRENT_BINARY_DIR}/out_malformed -o malformed_test --output-format csv --
+        $<TARGET_FILE:vector-ops>
+    DEPENDS vector-ops
+    TIMEOUT 45
+    LABELS "integration-tests"
+    PRELOAD "${PRELOAD_ENV}")
+
+rocprofiler_add_integration_execute_test(
+    rocprofv3-test-yaml-validation-no-block-event
+    COMMAND
+        $<TARGET_FILE:rocprofiler-sdk::rocprofv3> -i ${CMAKE_CURRENT_BINARY_DIR}/input.txt
+        -E ${CMAKE_CURRENT_BINARY_DIR}/no_block_event.yaml -d
+        ${CMAKE_CURRENT_BINARY_DIR}/out_no_block_event -o no_block_event_test
+        --output-format csv -- $<TARGET_FILE:vector-ops>
+    DEPENDS vector-ops
+    TIMEOUT 45
+    LABELS "integration-tests"
+    PRELOAD "${PRELOAD_ENV}")
+
+rocprofiler_add_integration_execute_test(
+    rocprofv3-test-yaml-validation-missing-top-key
+    COMMAND
+        $<TARGET_FILE:rocprofiler-sdk::rocprofv3> -i ${CMAKE_CURRENT_BINARY_DIR}/input.txt
+        -E ${CMAKE_CURRENT_BINARY_DIR}/missing_top_key.yaml -d
+        ${CMAKE_CURRENT_BINARY_DIR}/out_missing_top_key -o missing_top_key_test
+        --output-format csv -- $<TARGET_FILE:vector-ops>
+    DEPENDS vector-ops
+    TIMEOUT 45
+    LABELS "integration-tests"
+    PRELOAD "${PRELOAD_ENV}")
+
+rocprofiler_add_integration_execute_test(
+    rocprofv3-test-yaml-validation-empty-architectures
+    COMMAND
+        $<TARGET_FILE:rocprofiler-sdk::rocprofv3> -i ${CMAKE_CURRENT_BINARY_DIR}/input.txt
+        -E ${CMAKE_CURRENT_BINARY_DIR}/empty_architectures.yaml -d
+        ${CMAKE_CURRENT_BINARY_DIR}/out_empty_architectures -o empty_architectures_test
+        --output-format csv -- $<TARGET_FILE:vector-ops>
+    DEPENDS vector-ops
+    TIMEOUT 45
+    LABELS "integration-tests"
+    PRELOAD "${PRELOAD_ENV}")

--- a/projects/rocprofiler-sdk/tests/rocprofv3/counter-collection/extra_counters/CMakeLists.txt
+++ b/projects/rocprofiler-sdk/tests/rocprofv3/counter-collection/extra_counters/CMakeLists.txt
@@ -25,7 +25,8 @@ rocprofiler_configure_pytest_files(
          missing_top_key.yaml
          empty_architectures.yaml
          expression_plus_event.yaml
-         block_without_event.yaml)
+         block_without_event.yaml
+         mixed_valid_invalid.yaml)
 
 string(REPLACE "LD_PRELOAD=" "ROCPROF_PRELOAD=" PRELOAD_ENV
                "${ROCPROFILER_MEMCHECK_PRELOAD_ENV}")
@@ -55,10 +56,37 @@ rocprofiler_add_integration_validate_test(
     FIXTURES_REQUIRED rocprofv3-test-counter-collection-txt-pmc1-extra-counters)
 
 #
+# YAML Validation Test - Mixed Valid/Invalid Counter Test - Validates graceful degradation
+#
+rocprofiler_add_integration_execute_test(
+    rocprofv3-test-yaml-validation-mixed-valid-invalid-execute
+    COMMAND
+        $<TARGET_FILE:rocprofiler-sdk::rocprofv3> -i ${CMAKE_CURRENT_BINARY_DIR}/input.txt
+        -E ${CMAKE_CURRENT_BINARY_DIR}/mixed_valid_invalid.yaml -d
+        ${CMAKE_CURRENT_BINARY_DIR}/out_mixed_valid_invalid -o mixed_test --output-format
+        csv -- $<TARGET_FILE:vector-ops>
+    DEPENDS vector-ops
+    TIMEOUT 45
+    LABELS "integration-tests"
+    PRELOAD "${PRELOAD_ENV}"
+    FIXTURES_SETUP rocprofv3-test-yaml-validation-mixed-valid-invalid)
+
+rocprofiler_add_integration_validate_test(
+    rocprofv3-test-yaml-validation-mixed-valid-invalid-validate
+    TEST_PATHS validate.py
+    CONFIG pytest.ini
+    DISCOVERY_ARGS -k test_mixed_valid_invalid_counters
+    ARGS --input
+         ${CMAKE_CURRENT_BINARY_DIR}/out_mixed_valid_invalid/pmc_1/mixed_test_counter_collection.csv
+    TIMEOUT 45
+    LABELS "integration-tests"
+    FIXTURES_REQUIRED rocprofv3-test-yaml-validation-mixed-valid-invalid)
+
+#
 # YAML Validation Tests - Invalid YAMLs should be handled gracefully without crashes
 #
 rocprofiler_add_integration_execute_test(
-    rocprofv3-test-yaml-validation-duplicate-counters
+    rocprofv3-test-yaml-validation-duplicate-counters-execute
     COMMAND
         $<TARGET_FILE:rocprofiler-sdk::rocprofv3> -i ${CMAKE_CURRENT_BINARY_DIR}/input.txt
         -E ${CMAKE_CURRENT_BINARY_DIR}/duplicate_counters.yaml -d
@@ -67,7 +95,19 @@ rocprofiler_add_integration_execute_test(
     DEPENDS vector-ops
     TIMEOUT 45
     LABELS "integration-tests"
-    PRELOAD "${PRELOAD_ENV}")
+    PRELOAD "${PRELOAD_ENV}"
+    FIXTURES_SETUP rocprofv3-test-yaml-validation-duplicate-counters)
+
+rocprofiler_add_integration_validate_test(
+    rocprofv3-test-yaml-validation-duplicate-counters-validate
+    TEST_PATHS validate.py
+    CONFIG pytest.ini
+    DISCOVERY_ARGS -k test_duplicate_counter_handling
+    ARGS --input
+         ${CMAKE_CURRENT_BINARY_DIR}/out_duplicate/pmc_1/duplicate_test_counter_collection.csv
+    TIMEOUT 45
+    LABELS "integration-tests"
+    FIXTURES_REQUIRED rocprofv3-test-yaml-validation-duplicate-counters)
 
 rocprofiler_add_integration_execute_test(
     rocprofv3-test-yaml-validation-invalid-block

--- a/projects/rocprofiler-sdk/tests/rocprofv3/counter-collection/extra_counters/CMakeLists.txt
+++ b/projects/rocprofiler-sdk/tests/rocprofv3/counter-collection/extra_counters/CMakeLists.txt
@@ -23,7 +23,9 @@ rocprofiler_configure_pytest_files(
          malformed.yaml
          no_block_event.yaml
          missing_top_key.yaml
-         empty_architectures.yaml)
+         empty_architectures.yaml
+         expression_plus_event.yaml
+         block_without_event.yaml)
 
 string(REPLACE "LD_PRELOAD=" "ROCPROF_PRELOAD=" PRELOAD_ENV
                "${ROCPROFILER_MEMCHECK_PRELOAD_ENV}")
@@ -145,6 +147,30 @@ rocprofiler_add_integration_execute_test(
         $<TARGET_FILE:rocprofiler-sdk::rocprofv3> -i ${CMAKE_CURRENT_BINARY_DIR}/input.txt
         -E ${CMAKE_CURRENT_BINARY_DIR}/empty_architectures.yaml -d
         ${CMAKE_CURRENT_BINARY_DIR}/out_empty_architectures -o empty_architectures_test
+        --output-format csv -- $<TARGET_FILE:vector-ops>
+    DEPENDS vector-ops
+    TIMEOUT 45
+    LABELS "integration-tests"
+    PRELOAD "${PRELOAD_ENV}")
+
+rocprofiler_add_integration_execute_test(
+    rocprofv3-test-yaml-validation-expression-plus-event
+    COMMAND
+        $<TARGET_FILE:rocprofiler-sdk::rocprofv3> -i ${CMAKE_CURRENT_BINARY_DIR}/input.txt
+        -E ${CMAKE_CURRENT_BINARY_DIR}/expression_plus_event.yaml -d
+        ${CMAKE_CURRENT_BINARY_DIR}/out_expression_plus_event -o
+        expression_plus_event_test --output-format csv -- $<TARGET_FILE:vector-ops>
+    DEPENDS vector-ops
+    TIMEOUT 45
+    LABELS "integration-tests"
+    PRELOAD "${PRELOAD_ENV}")
+
+rocprofiler_add_integration_execute_test(
+    rocprofv3-test-yaml-validation-block-without-event
+    COMMAND
+        $<TARGET_FILE:rocprofiler-sdk::rocprofv3> -i ${CMAKE_CURRENT_BINARY_DIR}/input.txt
+        -E ${CMAKE_CURRENT_BINARY_DIR}/block_without_event.yaml -d
+        ${CMAKE_CURRENT_BINARY_DIR}/out_block_without_event -o block_without_event_test
         --output-format csv -- $<TARGET_FILE:vector-ops>
     DEPENDS vector-ops
     TIMEOUT 45

--- a/projects/rocprofiler-sdk/tests/rocprofv3/counter-collection/extra_counters/block_without_event.yaml
+++ b/projects/rocprofiler-sdk/tests/rocprofv3/counter-collection/extra_counters/block_without_event.yaml
@@ -1,0 +1,10 @@
+rocprofiler-sdk:
+  counters-schema-version: 1
+  counters:
+    - name: INVALID_BLOCK_ONLY
+      description: "Should be rejected - block requires event"
+      properties: []
+      definitions:
+        - architectures:
+            - gfx942
+          block: CPC

--- a/projects/rocprofiler-sdk/tests/rocprofv3/counter-collection/extra_counters/conftest.py
+++ b/projects/rocprofiler-sdk/tests/rocprofv3/counter-collection/extra_counters/conftest.py
@@ -42,6 +42,8 @@ def pytest_addoption(parser):
 @pytest.fixture
 def input_data(request):
     filename = request.config.getoption("--input")
+    if filename is None:
+        return None
     with open(filename, "r") as inp:
         return pd.read_csv(inp)
 
@@ -49,5 +51,7 @@ def input_data(request):
 @pytest.fixture
 def json_data(request):
     filename = request.config.getoption("--json-input")
+    if filename is None:
+        return None
     with open(filename, "r") as inp:
         return dotdict(collapse_dict_list(json.load(inp)))

--- a/projects/rocprofiler-sdk/tests/rocprofv3/counter-collection/extra_counters/duplicate_counters.yaml
+++ b/projects/rocprofiler-sdk/tests/rocprofv3/counter-collection/extra_counters/duplicate_counters.yaml
@@ -1,0 +1,19 @@
+rocprofiler-sdk:
+  counters-schema-version: 1
+  counters:
+  - name: SQC_LDS_BANK_CONFLICT
+    description: Number of cycles LDS is stalled by bank conflicts. (emulated, C1)
+    properties: []
+    definitions:
+    - architectures:
+      - gfx942
+      block: SQ
+      event: 256
+  - name: SQC_LDS_BANK_CONFLICT
+    description: Number of cycles LDS is stalled by bank conflicts. (emulated, C1)
+    properties: []
+    definitions:
+    - architectures:
+      - gfx942
+      block: SQ
+      event: 256

--- a/projects/rocprofiler-sdk/tests/rocprofv3/counter-collection/extra_counters/duplicate_counters.yaml
+++ b/projects/rocprofiler-sdk/tests/rocprofv3/counter-collection/extra_counters/duplicate_counters.yaml
@@ -1,19 +1,27 @@
 rocprofiler-sdk:
   counters-schema-version: 1
   counters:
-  - name: SQC_LDS_BANK_CONFLICT
-    description: Number of cycles LDS is stalled by bank conflicts. (emulated, C1)
+  - name: TEST_YAML_LOAD
+    description: Test counter for duplicate handling - first definition
     properties: []
     definitions:
     - architectures:
+      - gfx940
       - gfx942
-      block: SQ
-      event: 256
-  - name: SQC_LDS_BANK_CONFLICT
-    description: Number of cycles LDS is stalled by bank conflicts. (emulated, C1)
+      - gfx90a
+      - gfx906
+      - gfx908
+      block: GRBM
+      event: 0
+  - name: TEST_YAML_LOAD
+    description: Test counter for duplicate handling - duplicate definition (should be ignored)
     properties: []
     definitions:
     - architectures:
+      - gfx940
       - gfx942
-      block: SQ
-      event: 256
+      - gfx90a
+      - gfx906
+      - gfx908
+      block: GRBM
+      event: 0

--- a/projects/rocprofiler-sdk/tests/rocprofv3/counter-collection/extra_counters/empty_architectures.yaml
+++ b/projects/rocprofiler-sdk/tests/rocprofv3/counter-collection/extra_counters/empty_architectures.yaml
@@ -1,0 +1,10 @@
+rocprofiler-sdk:
+  counters-schema-version: 1
+  counters:
+  - name: EMPTY_ARCH
+    description: Counter with empty architectures list
+    properties: []
+    definitions:
+    - architectures: []
+      block: SQ
+      event: 256

--- a/projects/rocprofiler-sdk/tests/rocprofv3/counter-collection/extra_counters/expression_plus_event.yaml
+++ b/projects/rocprofiler-sdk/tests/rocprofv3/counter-collection/extra_counters/expression_plus_event.yaml
@@ -1,0 +1,12 @@
+rocprofiler-sdk:
+  counters-schema-version: 1
+  counters:
+    - name: INVALID_MIXED_COUNTER
+      description: "Should be rejected - mixing expression with block/event"
+      properties: []
+      definitions:
+        - architectures:
+            - gfx942
+          expression: reduce(GRBM_GUI_ACTIVE,max)*CU_NUM
+          block: GRBM
+          event: 1

--- a/projects/rocprofiler-sdk/tests/rocprofv3/counter-collection/extra_counters/invalid_block.yaml
+++ b/projects/rocprofiler-sdk/tests/rocprofv3/counter-collection/extra_counters/invalid_block.yaml
@@ -1,0 +1,11 @@
+rocprofiler-sdk:
+  counters-schema-version: 1
+  counters:
+  - name: SQC_LDS_BANK_CONFLICT
+    description: Number of cycles LDS is stalled by bank conflicts. (emulated, C1)
+    properties: []
+    definitions:
+    - architectures:
+      - gfx942
+      block: GL2A
+      event: 256

--- a/projects/rocprofiler-sdk/tests/rocprofv3/counter-collection/extra_counters/malformed.yaml
+++ b/projects/rocprofiler-sdk/tests/rocprofv3/counter-collection/extra_counters/malformed.yaml
@@ -1,0 +1,8 @@
+rocprofiler-sdk:
+  counters-schema-version: 1
+  counters:
+  - name: TEST_COUNTER
+    description: test
+    definitions
+    - architectures:
+      - gfx942

--- a/projects/rocprofiler-sdk/tests/rocprofv3/counter-collection/extra_counters/missing_name.yaml
+++ b/projects/rocprofiler-sdk/tests/rocprofv3/counter-collection/extra_counters/missing_name.yaml
@@ -1,0 +1,10 @@
+rocprofiler-sdk:
+  counters-schema-version: 1
+  counters:
+  - description: Missing name field
+    properties: []
+    definitions:
+    - architectures:
+      - gfx942
+      block: SQ
+      event: 256

--- a/projects/rocprofiler-sdk/tests/rocprofv3/counter-collection/extra_counters/missing_top_key.yaml
+++ b/projects/rocprofiler-sdk/tests/rocprofv3/counter-collection/extra_counters/missing_top_key.yaml
@@ -1,0 +1,4 @@
+bad-key:
+  counters:
+  - name: TEST
+    description: test

--- a/projects/rocprofiler-sdk/tests/rocprofv3/counter-collection/extra_counters/mixed_valid_invalid.yaml
+++ b/projects/rocprofiler-sdk/tests/rocprofv3/counter-collection/extra_counters/mixed_valid_invalid.yaml
@@ -1,0 +1,22 @@
+rocprofiler-sdk:
+  counters-schema-version: 1
+  counters:
+    - name: TEST_YAML_LOAD
+      description: Test counter for mixed valid/invalid handling - valid definition
+      properties: []
+      definitions:
+        - architectures:
+            - gfx940
+            - gfx942
+            - gfx90a
+            - gfx906
+            - gfx908
+          block: GRBM
+          event: 2
+
+    - name: INVALID_COUNTER_NO_PAYLOAD
+      description: Test counter for mixed valid/invalid handling - invalid definition (missing block/event/expression)
+      properties: []
+      definitions:
+        - architectures:
+            - gfx942

--- a/projects/rocprofiler-sdk/tests/rocprofv3/counter-collection/extra_counters/no_block_event.yaml
+++ b/projects/rocprofiler-sdk/tests/rocprofv3/counter-collection/extra_counters/no_block_event.yaml
@@ -1,0 +1,9 @@
+rocprofiler-sdk:
+  counters-schema-version: 1
+  counters:
+  - name: MISSING_BOTH
+    description: Counter with no block/event and no expression
+    properties: []
+    definitions:
+    - architectures:
+      - gfx942

--- a/projects/rocprofiler-sdk/tests/rocprofv3/counter-collection/extra_counters/validate.py
+++ b/projects/rocprofiler-sdk/tests/rocprofv3/counter-collection/extra_counters/validate.py
@@ -77,69 +77,67 @@ def test_validate_counter_collection_pmc1_extra_counters(input_data: pd.DataFram
 
 def test_mixed_valid_invalid_counters(input_data: pd.DataFrame):
     """
-    Verify that valid counters work even when the YAML file contains invalid ones.
-    This tests graceful degradation - invalid entries should be skipped without
-    breaking the collection of valid counters.
+    Verify that valid counters are still collected when the YAML file also
+    contains invalid counter definitions. Invalid entries should be skipped
+    without breaking collection of valid ones.
     """
     df = input_data
 
-    # Basic sanity checks
     assert not df.empty
-    assert len(df["Counter_Value"]) > 0
 
-    # Get all counter names that were actually collected
+    required_cols = {"Counter_Name", "Counter_Value"}
+    missing = required_cols - set(df.columns)
+    assert not missing, f"Missing expected columns: {missing}"
+
     collected_counters = set(df["Counter_Name"].unique())
 
-    # The valid counter should be present
     assert (
         "TEST_YAML_LOAD" in collected_counters
-    ), f"Expected TEST_YAML_LOAD counter, got: {collected_counters}"
+    ), f"Expected TEST_YAML_LOAD in collected counters, got: {collected_counters}"
 
-    # Invalid counter should NOT be present
     assert (
         "INVALID_COUNTER_NO_PAYLOAD" not in collected_counters
     ), "Invalid counter should not appear in output"
 
-    # All collected counter values should be valid (non-negative)
-    assert (df["Counter_Value"].astype(int).values >= 0).all()
+    # In this test, only the valid counter should be collected
+    assert (
+        df["Counter_Name"] == "TEST_YAML_LOAD"
+    ).all(), f"Unexpected counter names found: {df['Counter_Name'].unique().tolist()}"
 
-    # Ensure all counter names are TEST_YAML_LOAD (invalid ones should be skipped)
-    assert df["Counter_Name"].str.contains("TEST_YAML_LOAD").all()
+    values = pd.to_numeric(df["Counter_Value"], errors="raise")
+    assert (values >= 0).all(), "Found negative counter values"
 
 
 def test_duplicate_counter_handling(input_data: pd.DataFrame):
     """
-    Verify that duplicate counter definitions don't create corrupt output.
-    The tool should handle duplicates gracefully - either using the first definition
-    or producing a clean error, but not generating invalid data.
+    Verify that duplicate counter definitions do not corrupt output.
+    Expected behavior: the duplicate definition is ignored and the counter
+    is collected cleanly once per dispatch.
     """
     df = input_data
 
-    # Basic sanity checks
     assert not df.empty
 
-    # Get unique counter names
-    counter_names = df["Counter_Name"].unique().tolist()
+    required_cols = {"Counter_Name", "Counter_Value", "Dispatch_Id"}
+    missing = required_cols - set(df.columns)
+    assert not missing, f"Missing expected columns: {missing}"
 
-    # The duplicate counter should appear in output
-    assert "TEST_YAML_LOAD" in counter_names
+    # Only the requested counter should appear in this test
+    assert (
+        df["Counter_Name"] == "TEST_YAML_LOAD"
+    ).all(), f"Unexpected counter names found: {df['Counter_Name'].unique().tolist()}"
 
-    # Verify all counter values are valid
-    assert (df["Counter_Value"].astype(int).values >= 0).all()
+    # Values should be numeric and non-negative
+    values = pd.to_numeric(df["Counter_Value"], errors="raise")
+    assert (values >= 0).all(), "Found negative counter values"
 
-    # Ensure all counter names are TEST_YAML_LOAD (duplicates should be resolved)
-    assert df["Counter_Name"].str.contains("TEST_YAML_LOAD").all()
-
-    # Check that duplicate doesn't cause malformed output
-    # Each dispatch should have a consistent set of counters
-    for dispatch_id in df["Dispatch_Id"].unique():
-        dispatch_data = df[df["Dispatch_Id"] == dispatch_id]
-        # All rows for this dispatch should have the same counter name
-        # (no duplicate columns for the same counter)
-        counter_counts = dispatch_data["Counter_Name"].value_counts()
-        assert (
-            counter_counts <= 1
-        ).all(), f"Duplicate counter appears multiple times in dispatch {dispatch_id}: {counter_counts}"
+    # Ensure duplicate definitions do not produce repeated rows for the same
+    # dispatch/counter combination
+    dup_rows = df.duplicated(subset=["Dispatch_Id", "Counter_Name"], keep=False)
+    assert not dup_rows.any(), (
+        "Found duplicate rows for the same Dispatch_Id and Counter_Name:\n"
+        f"{df.loc[dup_rows, ['Dispatch_Id', 'Counter_Name', 'Counter_Value']]}"
+    )
 
 
 if __name__ == "__main__":

--- a/projects/rocprofiler-sdk/tests/rocprofv3/counter-collection/extra_counters/validate.py
+++ b/projects/rocprofiler-sdk/tests/rocprofv3/counter-collection/extra_counters/validate.py
@@ -75,6 +75,73 @@ def test_validate_counter_collection_pmc1_extra_counters(input_data: pd.DataFram
     assert di_expect == di_uniq
 
 
+def test_mixed_valid_invalid_counters(input_data: pd.DataFrame):
+    """
+    Verify that valid counters work even when the YAML file contains invalid ones.
+    This tests graceful degradation - invalid entries should be skipped without
+    breaking the collection of valid counters.
+    """
+    df = input_data
+
+    # Basic sanity checks
+    assert not df.empty
+    assert len(df["Counter_Value"]) > 0
+
+    # Get all counter names that were actually collected
+    collected_counters = set(df["Counter_Name"].unique())
+
+    # The valid counter should be present
+    assert (
+        "TEST_YAML_LOAD" in collected_counters
+    ), f"Expected TEST_YAML_LOAD counter, got: {collected_counters}"
+
+    # Invalid counter should NOT be present
+    assert (
+        "INVALID_COUNTER_NO_PAYLOAD" not in collected_counters
+    ), "Invalid counter should not appear in output"
+
+    # All collected counter values should be valid (non-negative)
+    assert (df["Counter_Value"].astype(int).values >= 0).all()
+
+    # Ensure all counter names are TEST_YAML_LOAD (invalid ones should be skipped)
+    assert df["Counter_Name"].str.contains("TEST_YAML_LOAD").all()
+
+
+def test_duplicate_counter_handling(input_data: pd.DataFrame):
+    """
+    Verify that duplicate counter definitions don't create corrupt output.
+    The tool should handle duplicates gracefully - either using the first definition
+    or producing a clean error, but not generating invalid data.
+    """
+    df = input_data
+
+    # Basic sanity checks
+    assert not df.empty
+
+    # Get unique counter names
+    counter_names = df["Counter_Name"].unique().tolist()
+
+    # The duplicate counter should appear in output
+    assert "TEST_YAML_LOAD" in counter_names
+
+    # Verify all counter values are valid
+    assert (df["Counter_Value"].astype(int).values >= 0).all()
+
+    # Ensure all counter names are TEST_YAML_LOAD (duplicates should be resolved)
+    assert df["Counter_Name"].str.contains("TEST_YAML_LOAD").all()
+
+    # Check that duplicate doesn't cause malformed output
+    # Each dispatch should have a consistent set of counters
+    for dispatch_id in df["Dispatch_Id"].unique():
+        dispatch_data = df[df["Dispatch_Id"] == dispatch_id]
+        # All rows for this dispatch should have the same counter name
+        # (no duplicate columns for the same counter)
+        counter_counts = dispatch_data["Counter_Name"].value_counts()
+        assert (
+            counter_counts <= 1
+        ).all(), f"Duplicate counter appears multiple times in dispatch {dispatch_id}: {counter_counts}"
+
+
 if __name__ == "__main__":
     exit_code = pytest.main(["-x", __file__] + sys.argv[1:])
     sys.exit(exit_code)

--- a/projects/rocprofiler-sdk/tests/rocprofv3/counter-collection/extra_counters/wrong_type.yaml
+++ b/projects/rocprofiler-sdk/tests/rocprofv3/counter-collection/extra_counters/wrong_type.yaml
@@ -1,0 +1,11 @@
+rocprofiler-sdk:
+  counters-schema-version: 1
+  counters:
+  - name: 123
+    description: Name is number not string
+    properties: []
+    definitions:
+    - architectures:
+      - gfx942
+      block: SQ
+      event: 256


### PR DESCRIPTION
To be closed. See new PR: https://github.com/ROCm/rocm-systems/pull/5551

## Motivation

Fix SIGSEGV crash in rocprofv3 when invalid counter YAML files are provided via the` -E` flag. Invalid counter definitions should be handled gracefully with warnings rather than aborting the program.

## Technical Details

### YAML Validation Framework:
Added comprehensive validation logic in `metrics.cpp` and `dimensions.cpp` according to the following validation design philosophy:
- Reject / warn
  - parse failure
  - missing/wrong top-level counters node
  - missing name
  - missing/wrong definitions
  - empty or invalid architectures
  - missing both event and expression
  - event without block
  - block without event
  - bad field types
  - duplicate counter definitions that are being ignored
- Ignore silently
  - unknown optional fields
  - extra keys not used by current implementation
- Keep non-fatal
  - one bad counter should not abort the entire file or tool run

### Crash Fix:
Changed `ROCP_DFATAL` to `ROCP_WARNING` in `helpers.cpp:47` when AQL profile queries fail. This allows exceptions to propagate properly for error handling in `RelWithDebInfo` builds instead of aborting the program.

### Test Coverage:
Added 11 tests for extra counters. Extra Counters Test Summary:

- Tests with both Execute + Validate:
  - (existing) rocprofv3-test-counter-collection-pmc1-extra-counters - Happy path: basic extra counter loading and collection
  - rocprofv3-test-yaml-validation-mixed-valid-invalid - Graceful degradation: valid counters work despite invalid ones in same YAML
  - rocprofv3-test-yaml-validation-duplicate-counters - Duplicate handling: duplicate counter definitions don't corrupt output
- Execute-only tests (smoke tests - verify no crashes):
  - rocprofv3-test-yaml-validation-invalid-block - Invalid block name
  - rocprofv3-test-yaml-validation-missing-name - Counter missing name field
  - rocprofv3-test-yaml-validation-wrong-type - Field has wrong type
  - rocprofv3-test-yaml-validation-malformed - Malformed YAML syntax
  - rocprofv3-test-yaml-validation-no-block-event - Counter with neither block/event nor expression
  - rocprofv3-test-yaml-validation-missing-top-key - Missing rocprofiler-sdk top-level key
  - rocprofv3-test-yaml-validation-empty-architectures - Empty architectures list
  - rocprofv3-test-yaml-validation-expression-plus-event - Counter with both expression and event
  - rocprofv3-test-yaml-validation-block-without-event - Block specified without event number


## JIRA ID

AIPROFSDK-22

## Test Plan

## Test Result

All YAML validation tests pass without crashes. Invalid counter definitions now produce appropriate warning messages and gracefully skip the invalid counters instead of aborting the program.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
