### PR TITLE
SQTT: Enable event_cs. Fix double buffer reset.

### DIFF
--- a/projects/aqlprofile/gfxip/gfx9/gfx9_primitives.h
+++ b/projects/aqlprofile/gfxip/gfx9/gfx9_primitives.h
@@ -579,6 +579,7 @@ class gfx9_cntx_prim {
   static const uint32_t SQTT_TOKEN_WAVE_START = 1 << 3;
   static const uint32_t SQTT_TOKEN_REG_CS = 1 << 5;
   static const uint32_t SQTT_TOKEN_WAVE_END = 1 << 6;
+  static const uint32_t SQTT_TOKEN_EVENT_CS = 1 << 8;
   static const uint32_t SQTT_TOKEN_INST = 1 << 10;
   static const uint32_t SQTT_TOKEN_INST_PC = 1 << 11;
   static const uint32_t SQTT_TOKEN_USERDATA = 1 << 12;
@@ -590,7 +591,7 @@ class gfx9_cntx_prim {
     uint32_t sq_thread_trace_token_mask_token_mask =
         SQTT_TOKEN_MISC | SQTT_TOKEN_TIME | SQTT_TOKEN_REG | SQTT_TOKEN_WAVE_START |
         SQTT_TOKEN_WAVE_END | SQTT_TOKEN_INST | SQTT_TOKEN_INST_PC | SQTT_TOKEN_USERDATA |
-        SQTT_TOKEN_ISSUE | SQTT_TOKEN_REG_CS | SQTT_TOKEN_REG_CS_PRIV;
+        SQTT_TOKEN_ISSUE | SQTT_TOKEN_REG_CS | SQTT_TOKEN_REG_CS_PRIV | SQTT_TOKEN_EVENT_CS;
 
     sq_thread_trace_token_mask = SET_REG_FIELD_BITS(SQ_THREAD_TRACE_TOKEN_MASK, REG_MASK, 0xF) |
                                  SET_REG_FIELD_BITS(SQ_THREAD_TRACE_TOKEN_MASK, TOKEN_MASK,
@@ -609,7 +610,8 @@ class gfx9_cntx_prim {
     uint32_t sq_thread_trace_token_mask;
     uint32_t sq_thread_trace_token_mask_token_mask =
         SQTT_TOKEN_MISC | SQTT_TOKEN_TIME | SQTT_TOKEN_REG | SQTT_TOKEN_WAVE_START |
-        SQTT_TOKEN_WAVE_END | SQTT_TOKEN_REG_CS_PRIV | SQTT_TOKEN_REG_CS | SQTT_TOKEN_USERDATA;
+        SQTT_TOKEN_WAVE_END | SQTT_TOKEN_REG_CS_PRIV | SQTT_TOKEN_REG_CS | SQTT_TOKEN_USERDATA |
+        SQTT_TOKEN_EVENT_CS;
 
     sq_thread_trace_token_mask = SET_REG_FIELD_BITS(SQ_THREAD_TRACE_TOKEN_MASK, REG_MASK, 0xF) |
                                  SET_REG_FIELD_BITS(SQ_THREAD_TRACE_TOKEN_MASK, TOKEN_MASK,

--- a/projects/aqlprofile/src/core/threadtrace.cpp
+++ b/projects/aqlprofile/src/core/threadtrace.cpp
@@ -119,6 +119,8 @@ hsa_status_t _internal_aqlprofile_att_iterate_data(aqlprofile_handle_t handle,
       size_t buf_num = memorymgr->config.buffer_data.at(se_index).size();
       sample_ptr = memorymgr->config.buffer_data.at(se_index)[(memorymgr->buffer_swaps + buf_num - 1) % buf_num];
       callback(se_index, sample_ptr, sample_size, userdata);
+      // Reset swaps for next thread trace start
+      memorymgr->buffer_swaps = 0;
       return status;
     }
   }


### PR DESCRIPTION
## Motivation

This PR adds CS Events to SQTT collection and ports over a buffer reset fix from the double/tripple buffering PR.

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
