### PR TITLE
[rocprofiler-compute] Fix pc sampling bugs with rocprofv3 backend and live attach scenario

### DIFF
--- a/projects/rocprofiler-compute/CHANGELOG.md
+++ b/projects/rocprofiler-compute/CHANGELOG.md
@@ -58,6 +58,8 @@ Full documentation for ROCm Compute Profiler is available at [https://rocm.docs.
 
 * Fixed roofline benchmark MFMA FP16/BF16/INT8 peaks for MI 350
 
+* Fixed issue where pc sampling profiling fails with multi-argument commands and live process attachment
+
 ### Upcoming changes
 
 * `--path` and `--subpath` options will be removed as they are already deprecated

--- a/projects/rocprofiler-compute/src/utils/utils_profile.py
+++ b/projects/rocprofiler-compute/src/utils/utils_profile.py
@@ -423,7 +423,10 @@ def pc_sampling_prof(
                 profiler_options_list.index("--") :
             ]
         except ValueError:
-            console_error("PC sampling failed.")
+            console_error(
+                "PC sampling failed: '--' separator not found in profiler arguments. "
+                "Ensure application command is provided after '--'."
+            )
             return
 
         options = [

--- a/projects/rocprofiler-compute/src/utils/utils_profile.py
+++ b/projects/rocprofiler-compute/src/utils/utils_profile.py
@@ -38,6 +38,16 @@ _PROFILER_INTERNAL_RE = re.compile(
 )
 
 
+def _is_live_attach(
+    profiler_options: Union[list[str], dict[str, Union[str, list[str]]]],
+) -> bool:
+    """Return True if the profiler options indicate a live-attach (pid) mode."""
+    return (isinstance(profiler_options, list) and "--pid" in profiler_options) or (
+        isinstance(profiler_options, dict)
+        and profiler_options.get("ROCPROF_ATTACH_PID") is not None
+    )
+
+
 def _classify_output_line(line: str) -> None:
     """Log a subprocess output line at the appropriate level.
 
@@ -81,13 +91,6 @@ def run_prof(
         console_debug(f"pmc files: {', '.join([Path(fname).name for fname in fnames])}")
     else:
         console_debug(f"pmc file: {fpath.name}")
-
-    is_mode_live_attach = (
-        isinstance(profiler_options, list) and "--pid" in profiler_options
-    ) or (
-        isinstance(profiler_options, dict)
-        and profiler_options.get("ROCPROF_ATTACH_PID") is not None
-    )
 
     # standard rocprof options
     if get_rocprof_cmd() == "rocprofiler-sdk":
@@ -151,7 +154,7 @@ def run_prof(
             new_env[key] = value
         console_debug(f"rocprof sdk env vars: {new_env}")
 
-        if is_mode_live_attach:
+        if _is_live_attach(profiler_options):
             perform_attach_detach(new_env, options)
         else:
             if app_cmd is None:
@@ -191,7 +194,7 @@ def run_prof(
     if new_env.get("ROCPROFILER_METRICS_PATH"):
         shutil.rmtree(new_env["ROCPROFILER_METRICS_PATH"], ignore_errors=True)
 
-    if (not is_mode_live_attach) and (not success):
+    if (not _is_live_attach(profiler_options)) and (not success):
         for line in output.splitlines():
             stripped = line.strip()
             if stripped:
@@ -412,22 +415,24 @@ def pc_sampling_prof(
         for key, value in options.items():
             new_env[key] = value
         console_debug(f"pc sampling rocprof sdk env vars: {new_env}")
-        console_debug(f"pc sampling rocprof sdk user provided command: {app_cmd}")
-        success, output = capture_subprocess_output(
-            app_cmd, new_env=new_env, profileMode=True
-        )
+
+        if _is_live_attach(profiler_options):
+            perform_attach_detach(new_env, options)
+        else:
+            if app_cmd is None:
+                console_error(
+                    "APP_CMD, the workload's executable must be provided "
+                    "when not in live attach mode"
+                )
+
+            console_debug(f"pc sampling rocprof sdk user provided command: {app_cmd}")
+            success, output = capture_subprocess_output(
+                app_cmd, new_env=new_env, profileMode=True
+            )
+            if not success:
+                console_error("PC sampling failed.")
     else:
         profiler_options_list = cast(list[str], profiler_options)
-        try:
-            app_cmd_with_separator = profiler_options_list[
-                profiler_options_list.index("--") :
-            ]
-        except ValueError:
-            console_error(
-                "PC sampling failed: '--' separator not found in profiler arguments. "
-                "Ensure application command is provided after '--'."
-            )
-            return
 
         options = [
             "--kernel-trace",
@@ -445,17 +450,42 @@ def pc_sampling_prof(
             workload_dir,
             "-o",
             "ps_file",  # TODO: sync up with the name from source in 2100_.yaml
-            *app_cmd_with_separator,
         ]
+
+        if _is_live_attach(profiler_options):
+            try:
+                pid_idx = profiler_options_list.index("--pid")
+                options += ["--pid", profiler_options_list[pid_idx + 1]]
+                if "--attach-duration-msec" in profiler_options_list:
+                    dur_idx = profiler_options_list.index("--attach-duration-msec")
+                    options += [
+                        "--attach-duration-msec",
+                        profiler_options_list[dur_idx + 1],
+                    ]
+            except (ValueError, IndexError):
+                console_error(
+                    "--pid or --attach-duration-msec option not found in "
+                    "profiler arguments for live attach mode"
+                )
+        else:
+            try:
+                app_cmd_with_separator = profiler_options_list[
+                    profiler_options_list.index("--") :
+                ]
+                options += app_cmd_with_separator
+            except ValueError:
+                console_error(
+                    "APP_CMD, the workload's executable must be provided "
+                    "when not in live attach mode"
+                )
 
         console_debug(f"rocprof command: {shlex.join([get_rocprof_cmd()] + options)}")
         # profile the app
         success, output = capture_subprocess_output(
             [get_rocprof_cmd()] + options, new_env=os.environ.copy(), profileMode=True
         )
-
-    if not success:
-        console_error("PC sampling failed.")
+        if not success:
+            console_error("PC sampling failed.")
 
 
 @demarcate

--- a/projects/rocprofiler-compute/src/utils/utils_profile.py
+++ b/projects/rocprofiler-compute/src/utils/utils_profile.py
@@ -418,9 +418,14 @@ def pc_sampling_prof(
         )
     else:
         profiler_options_list = cast(list[str], profiler_options)
-        app_cmd_with_separator = profiler_options_list[
-            profiler_options_list.index("--") :
-        ]
+        try:
+            app_cmd_with_separator = profiler_options_list[
+                profiler_options_list.index("--") :
+            ]
+        except ValueError:
+            console_error("PC sampling failed.")
+            return
+
         options = [
             "--kernel-trace",
             "--pc-sampling-beta-enabled",

--- a/projects/rocprofiler-compute/src/utils/utils_profile.py
+++ b/projects/rocprofiler-compute/src/utils/utils_profile.py
@@ -417,6 +417,10 @@ def pc_sampling_prof(
             app_cmd, new_env=new_env, profileMode=True
         )
     else:
+        profiler_options_list = cast(list[str], profiler_options)
+        app_cmd_with_separator = profiler_options_list[
+            profiler_options_list.index("--") :
+        ]
         options = [
             "--kernel-trace",
             "--pc-sampling-beta-enabled",
@@ -433,8 +437,7 @@ def pc_sampling_prof(
             workload_dir,
             "-o",
             "ps_file",  # TODO: sync up with the name from source in 2100_.yaml
-            "--",
-            cast(str, profiler_options[-1]),  # app command
+            *app_cmd_with_separator,
         ]
 
         console_debug(f"rocprof command: {shlex.join([get_rocprof_cmd()] + options)}")

--- a/projects/rocprofiler-compute/tests/test_profile_general.py
+++ b/projects/rocprofiler-compute/tests/test_profile_general.py
@@ -1994,6 +1994,12 @@ def test_live_attach_detach_block(binary_handler_profile_rocprof_compute):
             print(f"[finally] killing workload pid={process_workload.pid}")
             process_workload.kill()
             process_workload.wait()
+        # Clean up any stale rocprof-attach processes to prevent interference
+        # with subsequent tests.
+        subprocess.run(
+            ["pkill", "-9", "-f", "rocprof-attach"],
+            capture_output=True,
+        )
 
     # Validate results
     file_dict = test_utils.check_csv_files(workload_dir, 1, num_kernels)
@@ -2045,6 +2051,12 @@ def test_live_attach_detach_block_thread_sleep(binary_handler_profile_rocprof_co
             print(f"[finally] killing workload pid={process_workload.pid}")
             process_workload.kill()
             process_workload.wait()
+        # Clean up any stale rocprof-attach processes to prevent interference
+        # with subsequent tests.
+        subprocess.run(
+            ["pkill", "-9", "-f", "rocprof-attach"],
+            capture_output=True,
+        )
 
     # Validate output
     file_dict = test_utils.check_csv_files(workload_dir, 1, num_kernels)
@@ -2102,6 +2114,12 @@ def test_live_attach_detach_singlepass_launch_stats(
             print(f"[finally] killing workload pid={process_workload.pid}")
             process_workload.kill()
             process_workload.wait()
+        # Clean up any stale rocprof-attach processes to prevent interference
+        # with subsequent tests.
+        subprocess.run(
+            ["pkill", "-9", "-f", "rocprof-attach"],
+            capture_output=True,
+        )
 
     # Validate CSVs & output correctness
     file_dict = test_utils.check_csv_files(workload_dir, 1, num_kernels)
@@ -2124,6 +2142,56 @@ def test_live_attach_detach_singlepass_launch_stats(
         "7.1.9",
     ]:
         assert test_utils.check_file_pattern(f"- {tag}", config_file)
+
+    test_utils.clean_output_dir(config["cleanup"], workload_dir)
+
+
+@pytest.mark.live_attach_detach
+def test_live_attach_detach_pc_sampling(
+    binary_handler_profile_rocprof_compute,
+):
+    options = ["-b", "21"]
+    workload_dir = test_utils.get_output_dir()
+
+    # TODO: temp fix for sdk defautly disable attach/detach,
+    # remove after it sets default to enable
+    env = os.environ.copy()
+    env["ROCP_TOOL_ATTACH"] = "1"
+
+    process_workload = None
+
+    try:
+        # Start workload
+        process_workload = subprocess.Popen(config["app_hip_dynamic_shared"], env=env)
+        time.sleep(5)  # Give workload time to start
+
+        attach_detach = {
+            "attach_pid": process_workload.pid,
+            "attach-duration-msec": attach_detach_interval_msec_no_delay,
+        }
+
+        # Profiling step (may fail)
+        binary_handler_profile_rocprof_compute(
+            config,
+            workload_dir,
+            options,
+            check_success=True,
+            roof=False,
+            app_name="app_hip_dynamic_shared",
+            attach_detach_para=attach_detach,
+        )
+
+    finally:
+        if process_workload and process_workload.poll() is None:
+            print(f"[finally] killing workload pid={process_workload.pid}")
+            process_workload.kill()
+            process_workload.wait()
+        # Clean up any stale rocprof-attach processes to prevent interference
+        # with subsequent tests.
+        subprocess.run(
+            ["pkill", "-9", "-f", "rocprof-attach"],
+            capture_output=True,
+        )
 
     test_utils.clean_output_dir(config["cleanup"], workload_dir)
 

--- a/projects/rocprofiler-compute/tests/test_utils.py
+++ b/projects/rocprofiler-compute/tests/test_utils.py
@@ -5701,13 +5701,10 @@ def test_pc_sampling_prof_subprocess_fails(
         interval = 5000
         workload_dir = str(tmp_path)
         options = ["another_app"]
-        rocprofiler_sdk_tool_path = "/some/path/librocprofiler_sdk.so"  # noqa: F841
-
-        mock_capture_subprocess.return_value = (False, "Error output from subprocess")
 
         utils_profile.pc_sampling_prof(options, method, interval, workload_dir)
 
-        mock_capture_subprocess.assert_called_once()
+        mock_capture_subprocess.assert_not_called()
         mock_console_error.assert_called_once_with("PC sampling failed.")
 
     mock_capture_subprocess.reset_mock()
@@ -5779,6 +5776,30 @@ def test_pc_sampling_prof_empty_appcmd(
 
         assert mock_capture_subprocess.called
         assert mock_capture_subprocess.call_args[0][0] == ""
+        mock_console_error.assert_not_called()
+
+
+@mock.patch("utils.utils_profile.capture_subprocess_output")
+@mock.patch("utils.utils_profile.console_error")
+@mock.patch("utils.utils_profile.console_debug")
+def test_pc_sampling_prof_multiarg_appcmd(
+    mock_console_debug, mock_console_error, mock_capture_subprocess, tmp_path
+):
+    """All arguments after '--' in profiler_options must appear in the subprocess call."""
+    with mock.patch("utils.utils_common._rocprof_cmd", "rocprof_cli_tool"):
+        method = "host_trap"
+        interval = 100
+        workload_dir = str(tmp_path)
+        options = ["--kernel-trace", "--", "./myapp", "arg1", "arg2"]
+
+        mock_capture_subprocess.return_value = (True, "Success")
+
+        utils_profile.pc_sampling_prof(options, method, interval, workload_dir)
+
+        assert mock_capture_subprocess.called
+        options_list = mock_capture_subprocess.call_args[0][0]
+        separator_index = options_list.index("--")
+        assert options_list[separator_index:] == ["--", "./myapp", "arg1", "arg2"]
         mock_console_error.assert_not_called()
 
 

--- a/projects/rocprofiler-compute/tests/test_utils.py
+++ b/projects/rocprofiler-compute/tests/test_utils.py
@@ -5687,31 +5687,40 @@ def test_pc_sampling_prof_sdk_path_nonexistent_librocprofiler_sdk_tool(
 
 
 @mock.patch("utils.utils_profile.capture_subprocess_output")
-@mock.patch("utils.utils_profile.console_error")
 @mock.patch("utils.utils_profile.console_debug")
 def test_pc_sampling_prof_subprocess_fails(
-    mock_console_debug, mock_console_error, mock_capture_subprocess, tmp_path
+    mock_console_debug, mock_capture_subprocess, tmp_path, monkeypatch
 ):
     """
     Edge Case: The capture_subprocess_output returns success=False.
     This should trigger the console_error("PC sampling failed.").
     """
+    console_error_calls = []
+
+    def mock_console_error(msg, exit=True):
+        console_error_calls.append(msg)
+        if exit:
+            raise RuntimeError("console_error called")
+
+    monkeypatch.setattr("utils.utils_profile.console_error", mock_console_error)
+
     with mock.patch("utils.utils_common._rocprof_cmd", "rocprof_cli_tool"):
         method = "stochastic"
         interval = 5000
         workload_dir = str(tmp_path)
         options = ["another_app"]
 
-        utils_profile.pc_sampling_prof(options, method, interval, workload_dir)
+        with pytest.raises(RuntimeError, match="console_error called"):
+            utils_profile.pc_sampling_prof(options, method, interval, workload_dir)
 
         mock_capture_subprocess.assert_not_called()
-        mock_console_error.assert_called_once_with(
-            "PC sampling failed: '--' separator not found in profiler arguments. "
-            "Ensure application command is provided after '--'."
-        )
+        assert console_error_calls == [
+            "APP_CMD, the workload's executable must be provided "
+            "when not in live attach mode"
+        ]
 
     mock_capture_subprocess.reset_mock()
-    mock_console_error.reset_mock()
+    console_error_calls.clear()
     with mock.patch("utils.utils_common._rocprof_cmd", "rocprofiler-sdk"):
         options = {"APP_CMD": "another_app"}
         sdk_lib_dir = tmp_path / "rocm_sdk_fail" / "lib"
@@ -5728,10 +5737,11 @@ def test_pc_sampling_prof_subprocess_fails(
             "Error output from SDK subprocess",
         )
 
-        utils_profile.pc_sampling_prof(options, method, interval, workload_dir)
+        with pytest.raises(RuntimeError, match="console_error called"):
+            utils_profile.pc_sampling_prof(options, method, interval, workload_dir)
 
         mock_capture_subprocess.assert_called_once()
-        mock_console_error.assert_called_once_with("PC sampling failed.")
+        assert console_error_calls == ["PC sampling failed."]
 
 
 @mock.patch("utils.utils_profile.capture_subprocess_output")
@@ -5788,7 +5798,8 @@ def test_pc_sampling_prof_empty_appcmd(
 def test_pc_sampling_prof_multiarg_appcmd(
     mock_console_debug, mock_console_error, mock_capture_subprocess, tmp_path
 ):
-    """All arguments after '--' in profiler_options must appear in the subprocess call."""
+    """All arguments after '--' in profiler_options must appear
+    in the subprocess call."""
     with mock.patch("utils.utils_common._rocprof_cmd", "rocprof_cli_tool"):
         method = "host_trap"
         interval = 100

--- a/projects/rocprofiler-compute/tests/test_utils.py
+++ b/projects/rocprofiler-compute/tests/test_utils.py
@@ -5705,7 +5705,10 @@ def test_pc_sampling_prof_subprocess_fails(
         utils_profile.pc_sampling_prof(options, method, interval, workload_dir)
 
         mock_capture_subprocess.assert_not_called()
-        mock_console_error.assert_called_once_with("PC sampling failed.")
+        mock_console_error.assert_called_once_with(
+            "PC sampling failed: '--' separator not found in profiler arguments. "
+            "Ensure application command is provided after '--'."
+        )
 
     mock_capture_subprocess.reset_mock()
     mock_console_error.reset_mock()


### PR DESCRIPTION
## Motivation

Fix PC sampling with rocprofv3 backend to properly handle multi-argument command

With rocprofiler-sdk backend

```
rocprof-compute profile --output-directory laplace_eqn --verbose -b 21 -- tests/laplace_eqn -i 1000
...
...
   INFO    |-> [rocprofiler-sdk] E20260409 04:06:22.769200 133272565870656 output_stream.cpp:111] Opened result file: laplace_eqn/ps_file_kernel_trace.csv
   INFO    |-> [rocprofiler-sdk] E20260409 04:06:22.819272 133272565870656 output_stream.cpp:111] Opened result file: laplace_eqn/ps_file_pc_sampling_stochastic.csv
   INFO    |-> [rocprofiler-sdk] E20260409 04:06:23.081847 133272565870656 output_stream.cpp:111] Opened result file: laplace_eqn/ps_file_agent_info.csv
   INFO    |-> [rocprofiler-sdk] E20260409 04:06:23.084075 133272565870656 output_stream.cpp:111] Opened result file: laplace_eqn/ps_file_results.json
   INFO    |-> [rocprofiler-sdk] W20260409 04:06:23.330861 133272565870656 simple_timer.cpp:55] [rocprofv3] output generation ::     0.582656 sec
   INFO    |-> [rocprofiler-sdk] W20260409 04:06:23.331038 133272565870656 simple_timer.cpp:55] [rocprofv3] tool finalization ::     0.583026 sec
  DEBUG [profiling] The time of pc sampling profiling is 0 m 2.0000088214874268 sec
```

With rocprofv3 backend

```
ROCPROF=rocprofv3 rocprof-compute profile --output-directory laplace_eqn --verbose -b 21 -- tests/laplace_eqn -i 1000
...
...
  DEBUG rocprof command: rocprofv3 --kernel-trace --pc-sampling-beta-enabled --pc-sampling-method stochastic --pc-sampling-unit cycles --output-format csv json --pc-sampling-interval 1048576 -d laplace_eqn -o ps_file -- 1000
   INFO    |-> [rocprofv3] Traceback (most recent call last):
   INFO    |-> [rocprofv3] File "/rocm/bin/rocprofv3", line 2048, in <module>
   INFO    |-> [rocprofv3] ec = main(sys.argv[1:])
   INFO    |-> [rocprofv3] File "/rocm/bin/rocprofv3", line 1995, in main
  ERROR PC sampling failed.
```

Also, fixed a bug where pc sampling was not working with live attach


## Technical Details

* Include the full command of target while pc sampling with rocprofv3
* Added support for live attach in pc sampling

PC Sampling with live attach works

```
ROCP_TOOL_ATTACH=1 tests/dynamic_shared
Run transpose continuously
10000 Validation cycles completed: Passes = 10000, Failures = 0
10000 Validation cycles completed: Passes = 10000, Failures = 0
W20260409 05:23:34.348132 129581062104384 simple_timer.cpp:55] [rocprofv3] tool initialization ::     0.001385 sec
W20260409 05:23:34.358893 129581062104384 tool.cpp:2688] HSA version 1.21.0 initialized (instance=0)
10000 Validation cycles completed: Passes = 10000, Failures = 0
10000 Validation cycles completed: Passes = 10000, Failures = 0
E20260409 05:23:36.394280 129581062104384 output_stream.cpp:111] Opened result file: dynamic_shared/ps_file_kernel_trace.csv
E20260409 05:23:36.587024 129581062104384 output_stream.cpp:111] Opened result file: dynamic_shared/ps_file_agent_info.csv
E20260409 05:23:36.591093 129581062104384 output_stream.cpp:111] Opened result file: dynamic_shared/ps_file_results.json
W20260409 05:23:36.839209 129581062104384 simple_timer.cpp:55] [rocprofv3] output generation ::     0.475909 sec
W20260409 05:23:36.839236 129581062104384 simple_timer.cpp:55] [rocprofv3] tool detachment ::     0.476201 sec


rocprof-compute profile --output-directory dynamic_shared --verbose -b 21 --attach-duration-msec 2000 --attach-pid 80830
...
...
   INFO Attach to process with ID 80830 is successful, detach will happen in 2000 milliseconds...
  DEBUG Error detaching with old API: /rocm/lib/librocprofiler-sdk-rocattach.so: undefined symbol: detach, trying new API
  DEBUG [profiling] The time of pc sampling profiling is 0 m 2.568544387817383 sec
  DEBUG finished "run_profiling" and finished rocprof's workload, time taken was 0 m 2.572133779525757 sec
  DEBUG [profiling] performing post-processing using rocprofiler-sdk profiler
  DEBUG [profiling] perform SoC post processing for gfx942
   INFO [roofline] Skipping roofline
  DEBUG time taken for "post_processing" was 0 seconds
```

## JIRA ID

AIPROFCOMP-517

## Test Plan

- [X] Run pc sampling with rocprofv3 backend with multi-argument command laplace_eqn -i 1000
- [x] Run pc sampling with live attach

## Test Result

- [X] pc sampling works with both live attach as well as rocprofv3 backend

## Submission Checklist

- [X] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
