### PR TITLE
[rocprofiler-compute] Cache performance counters for metric evaluation

### DIFF
--- a/projects/rocprofiler-compute/CHANGELOG.md
+++ b/projects/rocprofiler-compute/CHANGELOG.md
@@ -31,7 +31,7 @@ Full documentation for ROCm Compute Profiler is available at [https://rocm.docs.
 ### Optimized
 
 * Flattened the analyze-mode PMC dataframe to a single-index frame.
-* Accelerated analysis mode metric evaluation by introducing `PmcDataCache`, which exposes each PMC column as a cached `pd.Series` for repeated lookup-free access.
+* Accelerated analysis mode metric evaluation by introducing `PmcDataCache`, which exposes each PMC column as a cached `pd.Series` for repeated access.
 
 ### Resolved issues
 

--- a/projects/rocprofiler-compute/CHANGELOG.md
+++ b/projects/rocprofiler-compute/CHANGELOG.md
@@ -31,6 +31,7 @@ Full documentation for ROCm Compute Profiler is available at [https://rocm.docs.
 ### Optimized
 
 * Flattened the analyze-mode PMC dataframe to a single-index frame.
+* Accelerated analysis mode metric evaluation by introducing `PmcDataCache`, which exposes each PMC column as a cached `pd.Series` for repeated lookup-free access.
 
 ### Resolved issues
 

--- a/projects/rocprofiler-compute/CMakeLists.txt
+++ b/projects/rocprofiler-compute/CMakeLists.txt
@@ -555,6 +555,18 @@ add_test(
 )
 
 # -----------------------------------
+# PMC data cache tests
+# -----------------------------------
+
+add_test(
+    NAME test_pmc_data_cache
+    COMMAND
+        ${PYTHON_TEST_COMMAND} -m pytest ${STANDALONEBINARY_TEST_OPTION}
+        --junitxml=tests/test_pmc_data_cache.xml ${COV_OPTION}
+        tests/test_pmc_data_cache.py ${WORKING_DIR_OPTION}
+)
+
+# -----------------------------------
 # Metrics unit tests
 # -----------------------------------
 
@@ -706,6 +718,7 @@ if(${ENABLE_COVERAGE})
         test_analyze_commands
         test_analyze_workloads
         test_metric_utils
+        test_pmc_data_cache
         test_L1_cache_counters
         test_num_xcds_spec_class
         test_num_xcds_cli_output

--- a/projects/rocprofiler-compute/src/utils/metrics/debug_row_tracker.py
+++ b/projects/rocprofiler-compute/src/utils/metrics/debug_row_tracker.py
@@ -12,12 +12,11 @@ from __future__ import annotations
 import re
 from typing import TYPE_CHECKING, Any, Optional
 
-import pandas as pd
-
 from utils.logger import console_warning
 
 if TYPE_CHECKING:
     from utils.metrics.metric_evaluator import MetricEvaluator
+    from utils.metrics.pmc_data_cache import PmcDataCache
 
 
 _MAX_DEBUG_ROWS = 5
@@ -70,22 +69,21 @@ def _print_debug_global_vars(row_expr: str, metric_evaluator: MetricEvaluator) -
 
 def _extract_column_data(
     col_name: str,
-    raw_pmc_df: pd.DataFrame,
+    pmc_cache: PmcDataCache,
 ) -> Optional[list[Any]]:
-    """Extract column data from a dataframe raw_pmc_df."""
-    if col_name not in raw_pmc_df.columns:
+    """Extract column data from a flat PmcDataCache."""
+    if col_name not in pmc_cache:
         return None
-    series = raw_pmc_df[col_name]
-    return series.tolist() if hasattr(series, "tolist") else list(series)
+    return pmc_cache[col_name].tolist()
 
 
 def _collect_debug_column_data(
     row_expr: str,
-    raw_pmc_df: pd.DataFrame,
+    pmc_cache: PmcDataCache,
 ) -> tuple[list[tuple[str, Optional[list[Any]]]], int]:
     """Collect column data and compute alignment width for debug output."""
     matched_cols = re.findall(
-        r"raw_pmc_df\[[\"'](\w+)[\"']\]",
+        r"pmc_df\[[\"']([^\"']+)[\"']\]",
         row_expr,
     )
     seen: set[str] = set()
@@ -97,8 +95,8 @@ def _collect_debug_column_data(
             continue
         seen.add(col_name)
         try:
-            column_data = _extract_column_data(col_name, raw_pmc_df)
-            label = f"raw_pmc_df['{col_name}']"
+            column_data = _extract_column_data(col_name, pmc_cache)
+            label = f"pmc_df['{col_name}']"
             rows_to_print.append((label, column_data))
             if column_data is not None:
                 display = column_data[:_MAX_DEBUG_ROWS]
@@ -132,14 +130,14 @@ def _print_debug_column_data(
 def _print_debug_inputs(
     row_expr: str,
     metric_evaluator: MetricEvaluator,
-    raw_pmc_df: pd.DataFrame,
+    pmc_cache: PmcDataCache,
     show_inputs: bool,
 ) -> None:
     """Print input variables and column data for debug output."""
     print("Inputs:")
     if show_inputs:
         _print_debug_global_vars(row_expr, metric_evaluator)
-        rows_to_print, global_width = _collect_debug_column_data(row_expr, raw_pmc_df)
+        rows_to_print, global_width = _collect_debug_column_data(row_expr, pmc_cache)
         _print_debug_column_data(rows_to_print, global_width)
     else:
         print("  The same as above.")
@@ -160,7 +158,7 @@ def debug_row_tracker(
     expr: str,
     row_expr: str,
     metric_evaluator: MetricEvaluator,
-    raw_pmc_df: pd.DataFrame,
+    pmc_cache: PmcDataCache,
     *,
     show_inputs: bool = True,
 ) -> None:
@@ -170,10 +168,10 @@ def debug_row_tracker(
         expr: The original metric expression (for display purposes).
         row_expr: The fully substituted expression to evaluate.
         metric_evaluator: The MetricEvaluator instance for expression evaluation.
-        raw_pmc_df: Raw PMC data (flat single-index DataFrame).
+        pmc_cache: Flat per-call PmcDataCache (Series-valued).
         show_inputs: Whether to show input variable values (default: True).
     """
     print("~" * 40 + "\nExpression:")
     print(f"{expr} = {row_expr}")
-    _print_debug_inputs(row_expr, metric_evaluator, raw_pmc_df, show_inputs)
+    _print_debug_inputs(row_expr, metric_evaluator, pmc_cache, show_inputs)
     _print_debug_output(row_expr, metric_evaluator)

--- a/projects/rocprofiler-compute/src/utils/metrics/evaluation_pipeline.py
+++ b/projects/rocprofiler-compute/src/utils/metrics/evaluation_pipeline.py
@@ -10,7 +10,6 @@ from typing import Optional
 import numpy as np
 import pandas as pd
 
-from utils import schema
 from utils.logger import console_error, console_warning, demarcate
 from utils.metrics.debug_row_tracker import DebugRowTracker, debug_row_tracker
 from utils.metrics.expression import build_eval_string
@@ -113,11 +112,7 @@ def calc_builtin_vars(
         if "PER_XCD" not in variable_key:
             continue
 
-        # NB: assume all built-in vars from pmc_perf.csv for now
-        eval_string = build_eval_string(
-            variable_value,
-            schema.PMC_PERF_FILE_PREFIX,
-        )
+        eval_string = build_eval_string(variable_value)
         try:
             # Create temporary evaluator for this calculation
             # Pass sys_vars so that $num_xcd and other system variables are available
@@ -135,10 +130,7 @@ def calc_builtin_vars(
         if "PER_XCD" in variable_key:
             continue
 
-        eval_string = build_eval_string(
-            variable_value,
-            schema.PMC_PERF_FILE_PREFIX,
-        )
+        eval_string = build_eval_string(variable_value)
         try:
             # Merge sys_vars with builtin_vars_collection for second pass
             combined_vars = {**sys_vars, **builtin_vars_collection}

--- a/projects/rocprofiler-compute/src/utils/metrics/evaluation_pipeline.py
+++ b/projects/rocprofiler-compute/src/utils/metrics/evaluation_pipeline.py
@@ -10,6 +10,7 @@ from typing import Optional
 import numpy as np
 import pandas as pd
 
+from utils import schema
 from utils.logger import console_error, console_warning, demarcate
 from utils.metrics.debug_row_tracker import DebugRowTracker, debug_row_tracker
 from utils.metrics.expression import build_eval_string
@@ -19,6 +20,7 @@ from utils.metrics.noise_clamper import (
     get_noise_clamp_warnings,
     print_noise_clamp_summary,
 )
+from utils.metrics.pmc_data_cache import PmcDataCache
 from utils.utils_common import SUPPORTED_FIELD, calc_builtin_var
 from utils.utils_counter_defs import BUILD_IN_VARS
 
@@ -98,7 +100,8 @@ def create_sys_vars(sys_info: pd.Series) -> dict[str, int | float]:
 
 
 def calc_builtin_vars(
-    raw_pmc_df: pd.DataFrame,
+    pmc_cache: PmcDataCache,
+    config: dict | None,
     sys_vars: dict[str, int | float],
 ) -> dict[str, Optional[str | float | int]]:
     """Calculate built-in variables."""
@@ -111,11 +114,16 @@ def calc_builtin_vars(
         if "PER_XCD" not in variable_key:
             continue
 
-        eval_string = build_eval_string(variable_value)
+        # NB: assume all built-in vars from pmc_perf.csv for now
+        eval_string = build_eval_string(
+            variable_value,
+            schema.PMC_PERF_FILE_PREFIX,
+            config,
+        )
         try:
             # Create temporary evaluator for this calculation
             # Pass sys_vars so that $num_xcd and other system variables are available
-            temporary_evaluator = MetricEvaluator(raw_pmc_df, sys_vars, {})
+            temporary_evaluator = MetricEvaluator(pmc_cache, sys_vars, {})
             calculation_result = temporary_evaluator.eval_expression(eval_string)
             # Convert "N/A" string to np.nan to maintain numeric type for calculations
             if np.isscalar(calculation_result) and calculation_result == "N/A":
@@ -129,11 +137,15 @@ def calc_builtin_vars(
         if "PER_XCD" in variable_key:
             continue
 
-        eval_string = build_eval_string(variable_value)
+        eval_string = build_eval_string(
+            variable_value,
+            schema.PMC_PERF_FILE_PREFIX,
+            config,
+        )
         try:
             # Merge sys_vars with builtin_vars_collection for second pass
             combined_vars = {**sys_vars, **builtin_vars_collection}
-            temporary_evaluator = MetricEvaluator(raw_pmc_df, combined_vars, {})
+            temporary_evaluator = MetricEvaluator(pmc_cache, combined_vars, {})
             calculation_result = temporary_evaluator.eval_expression(eval_string)
             # Convert "N/A" string to np.nan to maintain numeric type for calculations
             if np.isscalar(calculation_result) and calculation_result == "N/A":
@@ -153,28 +165,32 @@ def eval_metric(
     empirical_peaks_df: pd.DataFrame,
     raw_pmc_df: pd.DataFrame,
     debug: bool,
+    config: dict | None = None,
 ) -> None:
     """Execute the expr string for each metric in the df."""
+    # Build the PmcDataCache from the raw_pmc_df.
+    pmc_cache = PmcDataCache(raw_pmc_df)
+
     # confirm no illogical counter values (only consider non-roofline runs)
     roof_only_run = sys_info.ip_blocks == "roofline"
     if (
         (not roof_only_run)
-        and "GRBM_GUI_ACTIVE" in raw_pmc_df.columns
-        and (raw_pmc_df["GRBM_GUI_ACTIVE"] == 0).any()
+        and "GRBM_GUI_ACTIVE" in pmc_cache
+        and (pmc_cache["GRBM_GUI_ACTIVE"] == 0).any()
     ):
         console_warning("Detected GRBM_GUI_ACTIVE == 0")
         console_error("Halting execution for warning above.")
 
     sys_vars = create_sys_vars(sys_info)
     empirical_peaks = create_empirical_peaks_dict(empirical_peaks_df)
-    builtin_vars = calc_builtin_vars(raw_pmc_df, sys_vars)
+    builtin_vars = calc_builtin_vars(pmc_cache, config, sys_vars)
     sys_vars.update(builtin_vars)
 
     # Clear any previous noise clamp warnings before this analysis
     clear_noise_clamp_warnings()
 
     # Create metric evaluator
-    metric_evaluator = MetricEvaluator(raw_pmc_df, sys_vars, empirical_peaks)
+    metric_evaluator = MetricEvaluator(pmc_cache, sys_vars, empirical_peaks)
 
     exprs_to_eval = []
     debug_tracker = DebugRowTracker() if debug else None
@@ -198,7 +214,7 @@ def eval_metric(
                                     expr,
                                     row[expr],
                                     metric_evaluator,
-                                    raw_pmc_df,
+                                    pmc_cache,
                                     show_inputs=debug_tracker.should_show_inputs(
                                         df_id,
                                         row_id,
@@ -227,14 +243,14 @@ def eval_metric(
     print_noise_clamp_summary()
 
     # Check for metrics exceeding theoretical peak due to dual-issue
-    validate_dual_issue_metrics(dfs, dfs_type, sys_info, raw_pmc_df)
+    validate_dual_issue_metrics(dfs, dfs_type, sys_info, pmc_cache)
 
 
 def validate_dual_issue_metrics(
     dfs: dict,
     dfs_type: dict,
     sys_info: pd.Series,
-    raw_pmc_df: pd.DataFrame,
+    pmc_cache: PmcDataCache,
 ) -> None:
     """
     Check if VALU Utilization or VALU FLOPs metrics exceed theoretical peak.
@@ -270,14 +286,11 @@ def validate_dual_issue_metrics(
                 peak = float(row.get(peak_col, 0))
 
                 if peak > 0 and value > peak:
-                    dual_issue_confirmed = False
-                    if (
+                    dual_issue_confirmed = (
                         gpu_arch == "gfx950"
-                        and "SQ_ACTIVE_INST_VALU2" in raw_pmc_df.columns
-                    ):
-                        valu2_sum = raw_pmc_df["SQ_ACTIVE_INST_VALU2"].sum()
-                        if valu2_sum > 0:
-                            dual_issue_confirmed = True
+                        and "SQ_ACTIVE_INST_VALU2" in pmc_cache
+                        and pmc_cache["SQ_ACTIVE_INST_VALU2"].sum() > 0
+                    )
 
                     # Determine warning message based on metric type
                     faq_url = (
@@ -301,7 +314,7 @@ def validate_dual_issue_metrics(
                             f"See {faq_url} for more information."
                         )
 
-                    if gpu_arch == "gfx950" and dual_issue_confirmed:
+                    if dual_issue_confirmed:
                         warning_msg += (
                             " (Dual-issue activity detected "
                             "via SQ_ACTIVE_INST_VALU2 counter)"

--- a/projects/rocprofiler-compute/src/utils/metrics/evaluation_pipeline.py
+++ b/projects/rocprofiler-compute/src/utils/metrics/evaluation_pipeline.py
@@ -101,7 +101,6 @@ def create_sys_vars(sys_info: pd.Series) -> dict[str, int | float]:
 
 def calc_builtin_vars(
     pmc_cache: PmcDataCache,
-    config: dict | None,
     sys_vars: dict[str, int | float],
 ) -> dict[str, Optional[str | float | int]]:
     """Calculate built-in variables."""
@@ -118,7 +117,6 @@ def calc_builtin_vars(
         eval_string = build_eval_string(
             variable_value,
             schema.PMC_PERF_FILE_PREFIX,
-            config,
         )
         try:
             # Create temporary evaluator for this calculation
@@ -140,7 +138,6 @@ def calc_builtin_vars(
         eval_string = build_eval_string(
             variable_value,
             schema.PMC_PERF_FILE_PREFIX,
-            config,
         )
         try:
             # Merge sys_vars with builtin_vars_collection for second pass
@@ -165,7 +162,6 @@ def eval_metric(
     empirical_peaks_df: pd.DataFrame,
     raw_pmc_df: pd.DataFrame,
     debug: bool,
-    config: dict | None = None,
 ) -> None:
     """Execute the expr string for each metric in the df."""
     # Build the PmcDataCache from the raw_pmc_df.
@@ -183,7 +179,7 @@ def eval_metric(
 
     sys_vars = create_sys_vars(sys_info)
     empirical_peaks = create_empirical_peaks_dict(empirical_peaks_df)
-    builtin_vars = calc_builtin_vars(pmc_cache, config, sys_vars)
+    builtin_vars = calc_builtin_vars(pmc_cache, sys_vars)
     sys_vars.update(builtin_vars)
 
     # Clear any previous noise clamp warnings before this analysis

--- a/projects/rocprofiler-compute/src/utils/metrics/expression.py
+++ b/projects/rocprofiler-compute/src/utils/metrics/expression.py
@@ -91,7 +91,6 @@ class CodeTransformer(ast.NodeTransformer):
 def build_eval_string(
     equation: str,
     coll_level: str = "",
-    config: dict | None = None,
 ) -> str:
     """
     Convert user defined equation string to eval executable string.
@@ -271,7 +270,6 @@ def build_metric_value_string(
     dfs: dict,
     dfs_type: dict,
     normal_unit: str,
-    profiling_config: dict | None = None,
 ) -> None:
     """Apply the real eval string to its field in the metric_table df."""
     for table_id, df in dfs.items():
@@ -298,7 +296,6 @@ def build_metric_value_string(
                                 df.at[row_idx_label, expr] = build_eval_string(
                                     df.at[row_idx_label, expr],
                                     coll_level,
-                                    profiling_config,
                                 )
 
                 elif expr.lower() == "unit" or expr.lower() == "units":

--- a/projects/rocprofiler-compute/src/utils/metrics/expression.py
+++ b/projects/rocprofiler-compute/src/utils/metrics/expression.py
@@ -101,6 +101,14 @@ def build_eval_string(equation: str) -> str:
                 pmc_df["GRBM_GUI_ACTIVE"] *
                 ammolite__numCU
             )
+        input:
+            SUM(TCC_EA_RDREQ_LEVEL_31) / SUM(TCC_EA_RDREQ_31)
+        output:
+            to_sum(
+                pmc_df["TCC_EA_RDREQ_LEVEL_31"]
+            ) / to_sum(
+                pmc_df["TCC_EA_RDREQ_31"]
+            )
         We can not handle the below for now:
         input:
             AVG(

--- a/projects/rocprofiler-compute/src/utils/metrics/expression.py
+++ b/projects/rocprofiler-compute/src/utils/metrics/expression.py
@@ -75,20 +75,24 @@ class CodeTransformer(ast.NodeTransformer):
     #   - It is not straightforward to support types other than simple column
     #     in df, such as [], (). If we need to support those, have to implement
     #     in correct way or work around.
-    #   - The 'raw_pmc_df' is hack code. For other data sources, like wavefront
+    #   - The 'pmc_df' is hack code. For other data sources, like wavefront
     #     data,We need to think about template or pass it as a parameter.
     def visit_Name(self, node: ast.Name) -> ast.Name | ast.Subscript:
         self.generic_visit(node)
         if (not node.id.startswith("ammolite__")) and (not node.id in SUPPORTED_CALL):
             return ast.Subscript(
-                value=ast.Name(id="raw_pmc_df", ctx=ast.Load()),
+                value=ast.Name(id="pmc_df", ctx=ast.Load()),
                 slice=ast.Constant(value=node.id),
                 ctx=ast.Load(),
             )
         return node
 
 
-def build_eval_string(equation: str) -> str:
+def build_eval_string(
+    equation: str,
+    coll_level: str = "",
+    config: dict | None = None,
+) -> str:
     """
     Convert user defined equation string to eval executable string.
     For example,
@@ -96,18 +100,18 @@ def build_eval_string(equation: str) -> str:
             100 * SUM(SQ_ACTIVE_INST_SCA) / SUM(GRBM_GUI_ACTIVE * $numCU)
         output:
             100 * to_sum(
-                raw_pmc_df["SQ_ACTIVE_INST_SCA"]
+                pmc_df["SQ_ACTIVE_INST_SCA"]
             ) / to_sum(
-                raw_pmc_df["GRBM_GUI_ACTIVE"] *
+                pmc_df["GRBM_GUI_ACTIVE"] *
                 ammolite__numCU
             )
-        input:
-            SUM(TCC_EA_RDREQ_LEVEL_31) / SUM(TCC_EA_RDREQ_31)
+        input (with coll_level "SQ_INST_LEVEL_VMEM"):
+            SUM(SQ_ACCUM_PREV_HIRES) / SUM(SQ_INSTS_VMEM)
         output:
             to_sum(
-                raw_pmc_df["TCC_EA_RDREQ_LEVEL_31"]
+                pmc_df["SQ_INST_LEVEL_VMEM_ACCUM"]
             ) / to_sum(
-                raw_pmc_df["TCC_EA_RDREQ_31"]
+                pmc_df["SQ_INSTS_VMEM"]
             )
         We can not handle the below for now:
         input:
@@ -124,10 +128,10 @@ def build_eval_string(equation: str) -> str:
         But potential workaround is:
         output:
             to_avg(
-                raw_pmc_df["TCC_EA_RDREQ_31"].where(
-                    raw_pmc_df["TCC_EA_RDREQ_31"] == 0,
-                    raw_pmc_df["TCC_EA_RDREQ_LEVEL_31"] /
-                    raw_pmc_df["TCC_EA_RDREQ_31"]
+                pmc_df["TCC_EA_RDREQ_31"].where(
+                    pmc_df["TCC_EA_RDREQ_31"] == 0,
+                    pmc_df["TCC_EA_RDREQ_LEVEL_31"] /
+                    pmc_df["TCC_EA_RDREQ_31"]
                 )
             )
     """
@@ -151,6 +155,14 @@ def build_eval_string(equation: str) -> str:
     # the target is df['TCC_HIT[0]']
     equation_string = re.sub(r"\'\]\[(\d+)\]", r"[\g<1>]']", equation_string)
 
+    # Replace `SQ_ACCUM_PREV_HIRES` with `{coll_level}_ACCUM` only when
+    # `coll_level` is provided. Modern flat metric YAMLs already address
+    # accumulators via the canonical `<bucket>_ACCUM` column, so this
+    # rewrite is a no-op for them and runs only for legacy expressions.
+    if coll_level:
+        equation_string = re.sub(
+            "SQ_ACCUM_PREV_HIRES", f"{coll_level}_ACCUM", equation_string
+        )
     return equation_string
 
 
@@ -259,10 +271,12 @@ def build_metric_value_string(
     dfs: dict,
     dfs_type: dict,
     normal_unit: str,
+    profiling_config: dict | None = None,
 ) -> None:
     """Apply the real eval string to its field in the metric_table df."""
     for table_id, df in dfs.items():
         if dfs_type[table_id] == "metric_table":
+            has_coll_level = "coll_level" in df.columns
             for expr in df.columns:
                 if expr in SUPPORTED_FIELD:
                     # NB: apply all build-in before building the whole string
@@ -276,8 +290,15 @@ def build_metric_value_string(
                         for i in range(df.shape[0]):
                             row_idx_label = df.index.to_list()[i]
                             if expr.lower() != "alias":
+                                coll_level = (
+                                    df.at[row_idx_label, "coll_level"]
+                                    if has_coll_level
+                                    else ""
+                                )
                                 df.at[row_idx_label, expr] = build_eval_string(
                                     df.at[row_idx_label, expr],
+                                    coll_level,
+                                    profiling_config,
                                 )
 
                 elif expr.lower() == "unit" or expr.lower() == "units":

--- a/projects/rocprofiler-compute/src/utils/metrics/expression.py
+++ b/projects/rocprofiler-compute/src/utils/metrics/expression.py
@@ -88,10 +88,7 @@ class CodeTransformer(ast.NodeTransformer):
         return node
 
 
-def build_eval_string(
-    equation: str,
-    coll_level: str = "",
-) -> str:
+def build_eval_string(equation: str) -> str:
     """
     Convert user defined equation string to eval executable string.
     For example,
@@ -103,14 +100,6 @@ def build_eval_string(
             ) / to_sum(
                 pmc_df["GRBM_GUI_ACTIVE"] *
                 ammolite__numCU
-            )
-        input (with coll_level "SQ_INST_LEVEL_VMEM"):
-            SUM(SQ_ACCUM_PREV_HIRES) / SUM(SQ_INSTS_VMEM)
-        output:
-            to_sum(
-                pmc_df["SQ_INST_LEVEL_VMEM_ACCUM"]
-            ) / to_sum(
-                pmc_df["SQ_INSTS_VMEM"]
             )
         We can not handle the below for now:
         input:
@@ -154,14 +143,6 @@ def build_eval_string(
     # the target is df['TCC_HIT[0]']
     equation_string = re.sub(r"\'\]\[(\d+)\]", r"[\g<1>]']", equation_string)
 
-    # Replace `SQ_ACCUM_PREV_HIRES` with `{coll_level}_ACCUM` only when
-    # `coll_level` is provided. Modern flat metric YAMLs already address
-    # accumulators via the canonical `<bucket>_ACCUM` column, so this
-    # rewrite is a no-op for them and runs only for legacy expressions.
-    if coll_level:
-        equation_string = re.sub(
-            "SQ_ACCUM_PREV_HIRES", f"{coll_level}_ACCUM", equation_string
-        )
     return equation_string
 
 
@@ -274,7 +255,6 @@ def build_metric_value_string(
     """Apply the real eval string to its field in the metric_table df."""
     for table_id, df in dfs.items():
         if dfs_type[table_id] == "metric_table":
-            has_coll_level = "coll_level" in df.columns
             for expr in df.columns:
                 if expr in SUPPORTED_FIELD:
                     # NB: apply all build-in before building the whole string
@@ -288,14 +268,8 @@ def build_metric_value_string(
                         for i in range(df.shape[0]):
                             row_idx_label = df.index.to_list()[i]
                             if expr.lower() != "alias":
-                                coll_level = (
-                                    df.at[row_idx_label, "coll_level"]
-                                    if has_coll_level
-                                    else ""
-                                )
                                 df.at[row_idx_label, expr] = build_eval_string(
                                     df.at[row_idx_label, expr],
-                                    coll_level,
                                 )
 
                 elif expr.lower() == "unit" or expr.lower() == "units":

--- a/projects/rocprofiler-compute/src/utils/metrics/metric_evaluator.py
+++ b/projects/rocprofiler-compute/src/utils/metrics/metric_evaluator.py
@@ -25,6 +25,7 @@ from utils.metrics.aggregation import (
     to_sum,
 )
 from utils.metrics.noise_clamper import to_noise_clamp
+from utils.metrics.pmc_data_cache import PmcDataCache
 
 
 class MetricEvaluator:
@@ -32,11 +33,11 @@ class MetricEvaluator:
 
     def __init__(
         self,
-        raw_pmc_df: pd.DataFrame,
+        pmc_cache: PmcDataCache,
         sys_vars: dict[str, Any],
         empirical_peaks: dict[str, Any],
     ) -> None:
-        self.raw_pmc_df = raw_pmc_df
+        self.pmc_cache = pmc_cache
         self.sys_vars = sys_vars
         self.empirical_peaks = empirical_peaks
 
@@ -45,7 +46,7 @@ class MetricEvaluator:
         try:
             # Create comprehensive local context
             local_expr_context: dict[str, Any] = {}
-            local_expr_context.update({"raw_pmc_df": self.raw_pmc_df})
+            local_expr_context.update({"pmc_df": self.pmc_cache})
             local_expr_context.update(self.sys_vars)
             local_expr_context.update(self.empirical_peaks)
 

--- a/projects/rocprofiler-compute/src/utils/metrics/pmc_data_cache.py
+++ b/projects/rocprofiler-compute/src/utils/metrics/pmc_data_cache.py
@@ -1,0 +1,47 @@
+# Copyright (c) Advanced Micro Devices, Inc.
+# SPDX-License-Identifier:  MIT
+
+"""Flat per-call cache exposing each pmc column as a pd.Series."""
+
+from __future__ import annotations
+
+import pandas as pd
+
+from utils import schema
+
+
+class PmcDataCache:
+    """
+    Hardware counter data cache.
+
+    Keys are column names;
+    values are ``pd.Series``.
+    The ``pmc_perf`` top-level contributes every column as is;
+    each non-``pmc_perf`` top-level contributes its only
+    ``SQ_ACCUM_PREV_HIRES`` column under the key ``{coll_level}_ACCUM``.
+    """
+
+    def __init__(self, raw_pmc_df: pd.DataFrame) -> None:
+        self._cache: dict[str, pd.Series] = self._flatten(raw_pmc_df)
+
+    def __getitem__(self, col: str) -> pd.Series:
+        return self._cache[col]
+
+    def __contains__(self, col: str) -> bool:
+        return col in self._cache
+
+    @staticmethod
+    def _flatten(raw_pmc_df: pd.DataFrame) -> dict[str, pd.Series]:
+        """Flatten the MultiIndex DataFrame into a dict of column-name to Series."""
+        cache: dict[str, pd.Series] = {}
+        top_levels = raw_pmc_df.columns.get_level_values(0).unique()
+
+        for level in top_levels:
+            level_df = raw_pmc_df[level]
+            if level == schema.PMC_PERF_FILE_PREFIX:
+                for column_name in level_df.columns:
+                    cache[column_name] = level_df[column_name]
+            elif "SQ_ACCUM_PREV_HIRES" in level_df.columns:
+                cache[f"{level}_ACCUM"] = level_df["SQ_ACCUM_PREV_HIRES"]
+
+        return cache

--- a/projects/rocprofiler-compute/src/utils/metrics/pmc_data_cache.py
+++ b/projects/rocprofiler-compute/src/utils/metrics/pmc_data_cache.py
@@ -7,18 +7,16 @@ from __future__ import annotations
 
 import pandas as pd
 
-from utils import schema
-
 
 class PmcDataCache:
     """
     Hardware counter data cache.
 
-    Keys are column names;
-    values are ``pd.Series``.
-    The ``pmc_perf`` top-level contributes every column as is;
-    each non-``pmc_perf`` top-level contributes its only
-    ``SQ_ACCUM_PREV_HIRES`` column under the key ``{coll_level}_ACCUM``.
+    Wraps a flat single-index PMC DataFrame so each column is exposed as a
+    ``pd.Series`` via mapping-style access. The upstream
+    ``_create_single_df_pmc`` already produces the canonical flat layout
+    (with ``<bucket>_ACCUM`` columns) so this class is a thin lookup-free
+    accessor on top of it.
     """
 
     def __init__(self, raw_pmc_df: pd.DataFrame) -> None:
@@ -32,16 +30,5 @@ class PmcDataCache:
 
     @staticmethod
     def _flatten(raw_pmc_df: pd.DataFrame) -> dict[str, pd.Series]:
-        """Flatten the MultiIndex DataFrame into a dict of column-name to Series."""
-        cache: dict[str, pd.Series] = {}
-        top_levels = raw_pmc_df.columns.get_level_values(0).unique()
-
-        for level in top_levels:
-            level_df = raw_pmc_df[level]
-            if level == schema.PMC_PERF_FILE_PREFIX:
-                for column_name in level_df.columns:
-                    cache[column_name] = level_df[column_name]
-            elif "SQ_ACCUM_PREV_HIRES" in level_df.columns:
-                cache[f"{level}_ACCUM"] = level_df["SQ_ACCUM_PREV_HIRES"]
-
-        return cache
+        """Cache each column of the flat single-index PMC DataFrame as a Series."""
+        return {col: raw_pmc_df[col] for col in raw_pmc_df.columns}

--- a/projects/rocprofiler-compute/tests/test_categories.yaml
+++ b/projects/rocprofiler-compute/tests/test_categories.yaml
@@ -5,6 +5,7 @@ test_categories:
       - test_profile_misc
       - test_metric_validation
       - test_metric_utils
+      - test_pmc_data_cache
       - test_profile_section
       - test_pc_sampling
       - test_analyze_workloads
@@ -51,6 +52,7 @@ test_categories:
       - test_profile_iteration_multiplexing_2
       - test_metric_validation
       - test_metric_utils
+      - test_pmc_data_cache
       - test_autogen_config
       - test_analyze_commands
       - test_analyze_workloads
@@ -97,6 +99,7 @@ test_categories:
       - test_profile_iteration_multiplexing_stochastic
       - test_metric_validation
       - test_metric_utils
+      - test_pmc_data_cache
       - test_autogen_config
       - test_analyze_commands
       - test_analyze_workloads
@@ -143,6 +146,7 @@ test_categories:
       - test_profile_iteration_multiplexing_stochastic
       - test_metric_validation
       - test_metric_utils
+      - test_pmc_data_cache
       - test_autogen_config
       - test_analyze_commands
       - test_analyze_workloads

--- a/projects/rocprofiler-compute/tests/test_metric_utils.py
+++ b/projects/rocprofiler-compute/tests/test_metric_utils.py
@@ -30,6 +30,7 @@ from utils.metrics.expression import (
     update_normal_unit_string,
 )
 from utils.metrics.metric_evaluator import MetricEvaluator
+from utils.metrics.pmc_data_cache import PmcDataCache
 from utils.utils_common import calc_builtin_var
 
 # =============================================================================
@@ -262,7 +263,7 @@ class TestEvaluationPipeline:
         """
         if metric_fields is None:
             metric_fields = {
-                "Value": "to_sum(raw_pmc_df['SQ_WAVES'])",
+                "Value": "to_sum(pmc_df['SQ_WAVES'])",
                 "Average": None,
             }
 
@@ -307,7 +308,7 @@ class TestEvaluationPipeline:
         """eval_metric with debug=True invokes debug_row_tracker and writes back."""
         metric_df, dfs, dfs_type, sys_info, raw_pmc_df = self._build_eval_metric_inputs(
             metric_fields={
-                "Value": "to_sum(raw_pmc_df['SQ_WAVES'])",
+                "Value": "to_sum(pmc_df['SQ_WAVES'])",
             }
         )
         with (
@@ -335,7 +336,7 @@ class TestEvaluationPipeline:
         """eval_metric writes the computed Value back to the metric DataFrame."""
         metric_df, dfs, dfs_type, sys_info, raw_pmc_df = self._build_eval_metric_inputs(
             metric_fields={
-                "Value": "to_sum(raw_pmc_df['SQ_WAVES'])",
+                "Value": "to_sum(pmc_df['SQ_WAVES'])",
             }
         )
         with patch("utils.metrics.evaluation_pipeline.BUILD_IN_VARS", {}):
@@ -354,8 +355,8 @@ class TestEvaluationPipeline:
         metric_df, dfs, dfs_type, sys_info, _ = self._build_eval_metric_inputs(
             metric_fields={
                 "Value": (
-                    "to_sum(raw_pmc_df['SQ_INST_LEVEL_VMEM_ACCUM']) / "
-                    "to_sum(raw_pmc_df['SQ_INSTS_VMEM'])"
+                    "to_sum(pmc_df['SQ_INST_LEVEL_VMEM_ACCUM']) / "
+                    "to_sum(pmc_df['SQ_INSTS_VMEM'])"
                 ),
             }
         )
@@ -404,21 +405,33 @@ class TestMetricEvaluator:
 
     def test_eval_expression_returns_na_when_eval_returns_none(self):
         """eval_expression returns 'N/A' when the evaluated expression yields None."""
-        metric_evaluator = MetricEvaluator({}, {}, {})
+        metric_evaluator = MetricEvaluator(
+            PmcDataCache(pd.DataFrame()),
+            {},
+            {},
+        )
         with patch("builtins.eval") as mock_eval, patch("builtins.compile"):
             mock_eval.return_value = None
             assert metric_evaluator.eval_expression("Mock Metric") == "N/A"
 
     def test_eval_expression_returns_na_when_eval_returns_nan(self):
         """eval_expression returns 'N/A' when the evaluated expression yields NaN."""
-        metric_evaluator = MetricEvaluator({}, {}, {})
+        metric_evaluator = MetricEvaluator(
+            PmcDataCache(pd.DataFrame()),
+            {},
+            {},
+        )
         with patch("builtins.eval") as mock_eval, patch("builtins.compile"):
             mock_eval.return_value = np.nan
             assert metric_evaluator.eval_expression("Mock Metric") == "N/A"
 
     def test_eval_expression_returns_na_when_eval_raises_type_error(self):
         """eval_expression returns 'N/A' when eval raises a TypeError."""
-        metric_evaluator = MetricEvaluator({}, {}, {})
+        metric_evaluator = MetricEvaluator(
+            PmcDataCache(pd.DataFrame()),
+            {},
+            {},
+        )
         with patch("builtins.eval") as mock_eval, patch("builtins.compile"):
             mock_eval.side_effect = TypeError("Mock exception")
             assert metric_evaluator.eval_expression("Mock Metric") == "N/A"
@@ -427,21 +440,33 @@ class TestMetricEvaluator:
         self,
     ):
         """eval_expression returns 'N/A' for empirical_peak NameError lookups."""
-        metric_evaluator = MetricEvaluator({}, {}, {})
+        metric_evaluator = MetricEvaluator(
+            PmcDataCache(pd.DataFrame()),
+            {},
+            {},
+        )
         with patch("builtins.eval") as mock_eval, patch("builtins.compile"):
             mock_eval.side_effect = NameError("empirical_peak")
             assert metric_evaluator.eval_expression("Mock Metric") == "N/A"
 
     def test_eval_expression_returns_na_when_eval_raises_key_error(self):
         """eval_expression returns 'N/A' when eval raises a KeyError."""
-        metric_evaluator = MetricEvaluator({}, {}, {})
+        metric_evaluator = MetricEvaluator(
+            PmcDataCache(pd.DataFrame()),
+            {},
+            {},
+        )
         with patch("builtins.eval") as mock_eval, patch("builtins.compile"):
             mock_eval.side_effect = KeyError("Some KeyError")
             assert metric_evaluator.eval_expression("Mock Metric") == "N/A"
 
     def test_eval_expression_returns_na_when_eval_raises_attribute_error(self):
         """eval_expression returns 'N/A' for a generic AttributeError."""
-        metric_evaluator = MetricEvaluator({}, {}, {})
+        metric_evaluator = MetricEvaluator(
+            PmcDataCache(pd.DataFrame()),
+            {},
+            {},
+        )
         with (
             patch("builtins.eval") as mock_eval,
             patch("builtins.compile"),
@@ -454,7 +479,11 @@ class TestMetricEvaluator:
         self,
     ):
         """eval_expression returns 'N/A' for a NoneType.get AttributeError."""
-        metric_evaluator = MetricEvaluator({}, {}, {})
+        metric_evaluator = MetricEvaluator(
+            PmcDataCache(pd.DataFrame()),
+            {},
+            {},
+        )
         with patch("builtins.eval") as mock_eval, patch("builtins.compile"):
             mock_eval.side_effect = AttributeError(
                 "'NoneType' object has no attribute 'get'"
@@ -462,9 +491,9 @@ class TestMetricEvaluator:
             assert metric_evaluator.eval_expression("Mock Metric") == "N/A"
 
     def _make_evaluator(self, columns, sys_vars=None):
-        """Build a MetricEvaluator from the given raw_pmc columns and sys_vars."""
+        """Build a MetricEvaluator from flat raw_pmc columns and sys_vars."""
         raw_pmc_df = pd.DataFrame(columns)
-        return MetricEvaluator(raw_pmc_df, sys_vars or {}, {})
+        return MetricEvaluator(PmcDataCache(raw_pmc_df), sys_vars or {}, {})
 
     def _to_eval_str(self, equation):
         """Run a YAML-style equation through build_eval_string."""
@@ -568,12 +597,12 @@ class TestMetricEvaluator:
         )
 
     def test_build_eval_string_rewrites_accum_alias_as_flat_column_lookup(self):
-        """`*_ACCUM` aliases become flat ``raw_pmc_df['<alias>']`` lookups."""
+        """`*_ACCUM` aliases become flat ``pmc_df['<alias>']`` lookups."""
         eval_str = self._to_eval_str(
             "SUM(SQ_INST_LEVEL_VMEM_ACCUM) / SUM(SQ_INSTS_VMEM)"
         )
-        assert "raw_pmc_df['SQ_INST_LEVEL_VMEM_ACCUM']" in eval_str
-        assert "raw_pmc_df['SQ_INSTS_VMEM']" in eval_str
+        assert "pmc_df['SQ_INST_LEVEL_VMEM_ACCUM']" in eval_str
+        assert "pmc_df['SQ_INSTS_VMEM']" in eval_str
 
     def test_eval_expression_resolves_accum_alias_column(self):
         """SUM(<alias>_ACCUM) / SUM(...) returns the expected ratio for flat data."""

--- a/projects/rocprofiler-compute/tests/test_pmc_data_cache.py
+++ b/projects/rocprofiler-compute/tests/test_pmc_data_cache.py
@@ -20,7 +20,10 @@ class TestPmcDataCache:
         })
 
     def _make_pmc_perf_with_accum_alias_df(self):
-        """Build a flat DataFrame matching `_create_single_df_pmc` output with accumulator alias."""
+        """
+        Build a flat DataFrame matching `_create_single_df_pmc` output 
+        with accumulator alias.
+        """
         return pd.DataFrame({
             "Kernel_Name": ["k", "k"],
             "Dispatch_ID": [0, 1],

--- a/projects/rocprofiler-compute/tests/test_pmc_data_cache.py
+++ b/projects/rocprofiler-compute/tests/test_pmc_data_cache.py
@@ -12,29 +12,16 @@ from utils.metrics.pmc_data_cache import PmcDataCache
 class TestPmcDataCache:
     """Tests for utils.metrics.pmc_data_cache.PmcDataCache."""
 
-    def _make_pmc_perf_only_df(self):
-        """Build a flat DataFrame matching `_create_single_df_pmc` output."""
+    def _make_flat_pmc_df(self):
+        """Build a flat single-index PMC DataFrame with two counter columns."""
         return pd.DataFrame({
             "SQ_WAVES": [100, 200, 150],
             "GRBM_GUI_ACTIVE": [1000, 2000, 1500],
         })
 
-    def _make_pmc_perf_with_accum_alias_df(self):
-        """
-        Build a flat DataFrame matching `_create_single_df_pmc` output 
-        with accumulator alias.
-        """
-        return pd.DataFrame({
-            "Kernel_Name": ["k", "k"],
-            "Dispatch_ID": [0, 1],
-            "SQ_WAVES": [100, 200],
-            "SQ_INSTS_VMEM": [10, 20],
-            "SQ_INST_LEVEL_VMEM_ACCUM": [50, 70],
-        })
-
-    def test_pmc_perf_columns_lift_to_flat_keys(self):
-        """Every column of the flat DataFrame is exposed as a pd.Series."""
-        cache = PmcDataCache(self._make_pmc_perf_only_df())
+    def test_columns_exposed_as_series(self):
+        """Each column of the input DataFrame is exposed as a `pd.Series`."""
+        cache = PmcDataCache(self._make_flat_pmc_df())
         assert "SQ_WAVES" in cache
         assert "GRBM_GUI_ACTIVE" in cache
 
@@ -46,34 +33,13 @@ class TestPmcDataCache:
         assert isinstance(grbm, pd.Series)
         assert grbm.tolist() == [1000, 2000, 1500]
 
-    def test_accum_alias_column_is_passed_through(self):
-        """Pre-renamed `<bucket>_ACCUM` columns are exposed under their flat name."""
-        cache = PmcDataCache(self._make_pmc_perf_with_accum_alias_df())
-
-        assert "SQ_INST_LEVEL_VMEM_ACCUM" in cache
-        accum_series = cache["SQ_INST_LEVEL_VMEM_ACCUM"]
-        assert isinstance(accum_series, pd.Series)
-        assert accum_series.tolist() == [50, 70]
-
     def test_missing_key_raises_keyerror(self):
         """Direct subscript on a missing column raises KeyError."""
-        cache = PmcDataCache(self._make_pmc_perf_only_df())
+        cache = PmcDataCache(self._make_flat_pmc_df())
         with pytest.raises(KeyError):
             cache["UNKNOWN_COUNTER"]
 
     def test_contains_reports_false_for_missing_key(self):
         """`in` returns False for unknown column names."""
-        cache = PmcDataCache(self._make_pmc_perf_only_df())
+        cache = PmcDataCache(self._make_flat_pmc_df())
         assert ("UNKNOWN_COUNTER" in cache) is False
-
-    def test_dataframe_without_accum_alias_does_not_synthesize_one(self):
-        """A flat DataFrame missing any `_ACCUM` alias doesn't gain one in the cache."""
-        df_without_accum = pd.DataFrame({
-            "Kernel_Name": ["k", "k"],
-            "Dispatch_ID": [0, 1],
-            "SQ_WAVES": [100, 200],
-            "SQ_INSTS_VMEM": [10, 20],
-        })
-        cache = PmcDataCache(df_without_accum)
-        assert "SQ_WAVES" in cache
-        assert "SQ_INST_LEVEL_VMEM_ACCUM" not in cache

--- a/projects/rocprofiler-compute/tests/test_pmc_data_cache.py
+++ b/projects/rocprofiler-compute/tests/test_pmc_data_cache.py
@@ -1,0 +1,102 @@
+# Copyright (c) Advanced Micro Devices, Inc.
+# SPDX-License-Identifier:  MIT
+
+"""Unit tests for utils.metrics.pmc_data_cache.PmcDataCache (Phase 1)."""
+
+import pandas as pd
+import pytest
+
+from utils.metrics.pmc_data_cache import PmcDataCache
+
+
+class TestPmcDataCache:
+    """Tests for utils.metrics.pmc_data_cache.PmcDataCache."""
+
+    def _make_pmc_perf_only_df(self):
+        """Build a MultiIndex DataFrame whose only top-level is pmc_perf."""
+        return pd.concat(
+            {
+                "pmc_perf": pd.DataFrame({
+                    "SQ_WAVES": [100, 200, 150],
+                    "GRBM_GUI_ACTIVE": [1000, 2000, 1500],
+                })
+            },
+            axis=1,
+        )
+
+    def _make_two_level_df(self):
+        """MultiIndex DataFrame with pmc_perf and one SQ_INST_LEVEL_VMEM level."""
+        return pd.concat(
+            {
+                "pmc_perf": pd.DataFrame({
+                    "Kernel_Name": ["k", "k"],
+                    "Dispatch_ID": [0, 1],
+                    "SQ_WAVES": [100, 200],
+                    "SQ_INSTS_VMEM": [10, 20],
+                }),
+                "SQ_INST_LEVEL_VMEM": pd.DataFrame({
+                    "Kernel_Name": ["k", "k"],
+                    "Dispatch_ID": [0, 1],
+                    "SQ_ACCUM_PREV_HIRES": [50, 70],
+                }),
+            },
+            axis=1,
+        )
+
+    def test_pmc_perf_columns_lift_to_flat_keys(self):
+        """Every pmc_perf column appears at its natural name as a pd.Series."""
+        cache = PmcDataCache(self._make_pmc_perf_only_df())
+        assert "SQ_WAVES" in cache
+        assert "GRBM_GUI_ACTIVE" in cache
+
+        sq_waves = cache["SQ_WAVES"]
+        assert isinstance(sq_waves, pd.Series)
+        assert sq_waves.tolist() == [100, 200, 150]
+
+        grbm = cache["GRBM_GUI_ACTIVE"]
+        assert isinstance(grbm, pd.Series)
+        assert grbm.tolist() == [1000, 2000, 1500]
+
+    def test_accum_rename_for_non_pmc_perf_levels(self):
+        """SQ_ACCUM_PREV_HIRES from non-pmc_perf levels is renamed to {level}_ACCUM."""
+        cache = PmcDataCache(self._make_two_level_df())
+
+        assert "SQ_INST_LEVEL_VMEM_ACCUM" in cache
+        accum_series = cache["SQ_INST_LEVEL_VMEM_ACCUM"]
+        assert isinstance(accum_series, pd.Series)
+        assert accum_series.tolist() == [50, 70]
+
+        # The original SQ_ACCUM_PREV_HIRES name is not exposed; only the renamed key is.
+        assert "SQ_ACCUM_PREV_HIRES" not in cache
+
+    def test_missing_key_raises_keyerror(self):
+        """Direct subscript on a missing column raises KeyError."""
+        cache = PmcDataCache(self._make_pmc_perf_only_df())
+        with pytest.raises(KeyError):
+            cache["UNKNOWN_COUNTER"]
+
+    def test_contains_reports_false_for_missing_key(self):
+        """`in` returns False for unknown column names."""
+        cache = PmcDataCache(self._make_pmc_perf_only_df())
+        assert ("UNKNOWN_COUNTER" in cache) is False
+
+    def test_level_with_no_accum_column_is_skipped(self):
+        """A non-pmc_perf level missing SQ_ACCUM_PREV_HIRES contributes nothing."""
+        df_without_accum = pd.concat(
+            {
+                "pmc_perf": pd.DataFrame({
+                    "Kernel_Name": ["k", "k"],
+                    "Dispatch_ID": [0, 1],
+                    "SQ_WAVES": [100, 200],
+                    "SQ_INSTS_VMEM": [10, 20],
+                }),
+                "SQ_INST_LEVEL_VMEM": pd.DataFrame({
+                    "Kernel_Name": ["k", "k"],
+                    "Dispatch_ID": [0, 1],
+                }),
+            },
+            axis=1,
+        )
+        cache = PmcDataCache(df_without_accum)
+        assert "SQ_WAVES" in cache
+        assert "SQ_INST_LEVEL_VMEM_ACCUM" not in cache

--- a/projects/rocprofiler-compute/tests/test_pmc_data_cache.py
+++ b/projects/rocprofiler-compute/tests/test_pmc_data_cache.py
@@ -13,38 +13,29 @@ class TestPmcDataCache:
     """Tests for utils.metrics.pmc_data_cache.PmcDataCache."""
 
     def _make_pmc_perf_only_df(self):
-        """Build a MultiIndex DataFrame whose only top-level is pmc_perf."""
-        return pd.concat(
-            {
-                "pmc_perf": pd.DataFrame({
-                    "SQ_WAVES": [100, 200, 150],
-                    "GRBM_GUI_ACTIVE": [1000, 2000, 1500],
-                })
-            },
-            axis=1,
-        )
+        """Build a flat DataFrame matching `_create_single_df_pmc` output."""
+        return pd.DataFrame({
+            "SQ_WAVES": [100, 200, 150],
+            "GRBM_GUI_ACTIVE": [1000, 2000, 1500],
+        })
 
     def _make_two_level_df(self):
-        """MultiIndex DataFrame with pmc_perf and one SQ_INST_LEVEL_VMEM level."""
-        return pd.concat(
-            {
-                "pmc_perf": pd.DataFrame({
-                    "Kernel_Name": ["k", "k"],
-                    "Dispatch_ID": [0, 1],
-                    "SQ_WAVES": [100, 200],
-                    "SQ_INSTS_VMEM": [10, 20],
-                }),
-                "SQ_INST_LEVEL_VMEM": pd.DataFrame({
-                    "Kernel_Name": ["k", "k"],
-                    "Dispatch_ID": [0, 1],
-                    "SQ_ACCUM_PREV_HIRES": [50, 70],
-                }),
-            },
-            axis=1,
-        )
+        """Flat DataFrame whose accumulator column is already canonically named.
+
+        Upstream `soc_base.py` renames bucket-level `SQ_ACCUM_PREV_HIRES` columns
+        to `<bucket>_ACCUM` before the per-call DataFrame reaches PmcDataCache,
+        so this fixture mirrors that post-rename layout.
+        """
+        return pd.DataFrame({
+            "Kernel_Name": ["k", "k"],
+            "Dispatch_ID": [0, 1],
+            "SQ_WAVES": [100, 200],
+            "SQ_INSTS_VMEM": [10, 20],
+            "SQ_INST_LEVEL_VMEM_ACCUM": [50, 70],
+        })
 
     def test_pmc_perf_columns_lift_to_flat_keys(self):
-        """Every pmc_perf column appears at its natural name as a pd.Series."""
+        """Every column of the flat DataFrame is exposed as a pd.Series."""
         cache = PmcDataCache(self._make_pmc_perf_only_df())
         assert "SQ_WAVES" in cache
         assert "GRBM_GUI_ACTIVE" in cache
@@ -57,8 +48,8 @@ class TestPmcDataCache:
         assert isinstance(grbm, pd.Series)
         assert grbm.tolist() == [1000, 2000, 1500]
 
-    def test_accum_rename_for_non_pmc_perf_levels(self):
-        """SQ_ACCUM_PREV_HIRES from non-pmc_perf levels is renamed to {level}_ACCUM."""
+    def test_accum_alias_column_is_passed_through(self):
+        """Pre-renamed `<bucket>_ACCUM` columns are exposed under their flat name."""
         cache = PmcDataCache(self._make_two_level_df())
 
         assert "SQ_INST_LEVEL_VMEM_ACCUM" in cache
@@ -66,7 +57,8 @@ class TestPmcDataCache:
         assert isinstance(accum_series, pd.Series)
         assert accum_series.tolist() == [50, 70]
 
-        # The original SQ_ACCUM_PREV_HIRES name is not exposed; only the renamed key is.
+        # The legacy `SQ_ACCUM_PREV_HIRES` column name is no longer present
+        # because the upstream renamer has already canonicalized it.
         assert "SQ_ACCUM_PREV_HIRES" not in cache
 
     def test_missing_key_raises_keyerror(self):
@@ -80,23 +72,14 @@ class TestPmcDataCache:
         cache = PmcDataCache(self._make_pmc_perf_only_df())
         assert ("UNKNOWN_COUNTER" in cache) is False
 
-    def test_level_with_no_accum_column_is_skipped(self):
-        """A non-pmc_perf level missing SQ_ACCUM_PREV_HIRES contributes nothing."""
-        df_without_accum = pd.concat(
-            {
-                "pmc_perf": pd.DataFrame({
-                    "Kernel_Name": ["k", "k"],
-                    "Dispatch_ID": [0, 1],
-                    "SQ_WAVES": [100, 200],
-                    "SQ_INSTS_VMEM": [10, 20],
-                }),
-                "SQ_INST_LEVEL_VMEM": pd.DataFrame({
-                    "Kernel_Name": ["k", "k"],
-                    "Dispatch_ID": [0, 1],
-                }),
-            },
-            axis=1,
-        )
+    def test_dataframe_without_accum_alias_does_not_synthesize_one(self):
+        """A flat DataFrame missing any `_ACCUM` alias doesn't gain one in the cache."""
+        df_without_accum = pd.DataFrame({
+            "Kernel_Name": ["k", "k"],
+            "Dispatch_ID": [0, 1],
+            "SQ_WAVES": [100, 200],
+            "SQ_INSTS_VMEM": [10, 20],
+        })
         cache = PmcDataCache(df_without_accum)
         assert "SQ_WAVES" in cache
         assert "SQ_INST_LEVEL_VMEM_ACCUM" not in cache

--- a/projects/rocprofiler-compute/tests/test_pmc_data_cache.py
+++ b/projects/rocprofiler-compute/tests/test_pmc_data_cache.py
@@ -1,7 +1,7 @@
 # Copyright (c) Advanced Micro Devices, Inc.
 # SPDX-License-Identifier:  MIT
 
-"""Unit tests for utils.metrics.pmc_data_cache.PmcDataCache (Phase 1)."""
+"""Unit tests for utils.metrics.pmc_data_cache.PmcDataCache."""
 
 import pandas as pd
 import pytest

--- a/projects/rocprofiler-compute/tests/test_pmc_data_cache.py
+++ b/projects/rocprofiler-compute/tests/test_pmc_data_cache.py
@@ -19,13 +19,8 @@ class TestPmcDataCache:
             "GRBM_GUI_ACTIVE": [1000, 2000, 1500],
         })
 
-    def _make_two_level_df(self):
-        """Flat DataFrame whose accumulator column is already canonically named.
-
-        Upstream `soc_base.py` renames bucket-level `SQ_ACCUM_PREV_HIRES` columns
-        to `<bucket>_ACCUM` before the per-call DataFrame reaches PmcDataCache,
-        so this fixture mirrors that post-rename layout.
-        """
+    def _make_pmc_perf_with_accum_alias_df(self):
+        """Build a flat DataFrame matching `_create_single_df_pmc` output with accumulator alias."""
         return pd.DataFrame({
             "Kernel_Name": ["k", "k"],
             "Dispatch_ID": [0, 1],
@@ -50,16 +45,12 @@ class TestPmcDataCache:
 
     def test_accum_alias_column_is_passed_through(self):
         """Pre-renamed `<bucket>_ACCUM` columns are exposed under their flat name."""
-        cache = PmcDataCache(self._make_two_level_df())
+        cache = PmcDataCache(self._make_pmc_perf_with_accum_alias_df())
 
         assert "SQ_INST_LEVEL_VMEM_ACCUM" in cache
         accum_series = cache["SQ_INST_LEVEL_VMEM_ACCUM"]
         assert isinstance(accum_series, pd.Series)
         assert accum_series.tolist() == [50, 70]
-
-        # The legacy `SQ_ACCUM_PREV_HIRES` column name is no longer present
-        # because the upstream renamer has already canonicalized it.
-        assert "SQ_ACCUM_PREV_HIRES" not in cache
 
     def test_missing_key_raises_keyerror(self):
         """Direct subscript on a missing column raises KeyError."""


### PR DESCRIPTION
## Motivation

`rocprof-compute analyze` workloads repeatedly resolve counters out of the PMC DataFrame while evaluating metric expressions. This update introduces a flat per-call cache so metric evaluation, debug dumps, and dual-issue validation all use the same normalized counter namespace and pay the column-lookup cost only once.

## Technical Details

- Add `src/utils/metrics/pmc_data_cache.py` introducing `PmcDataCache`, a thin lookup-free accessor that exposes each column of the already-flat single-index PMC DataFrame (produced upstream by `_create_single_df_pmc`) as a `pd.Series` via mapping-style access (`__getitem__` / `__contains__`).
- Update `src/utils/metrics/expression.py`, `src/utils/metrics/metric_evaluator.py`, `src/utils/metrics/evaluation_pipeline.py`, and `src/utils/metrics/debug_row_tracker.py` to evaluate against `pmc_df["COUNTER"]` from `PmcDataCache` and rename the eval-time binding from `raw_pmc_df` to `pmc_df` in `CodeTransformer`, `build_eval_string`, and `MetricEvaluator.eval_expression`.
- Thread the cache through built-in variable evaluation (`calc_builtin_vars`), GRBM validation, debug input dumping, and gfx950 dual-issue confirmation (`validate_dual_issue_metrics`); the debug-column regex in `_collect_debug_column_data` now also handles bracketed counter names.
- Update the metric tests in `tests/test_metric_utils.py` to construct a flat single-index `raw_pmc_df`, wrap evaluators in `PmcDataCache(...)`, and reflect the source-side `raw_pmc_df` -> `pmc_df` rename inside metric expression strings.
- Add focused `tests/test_pmc_data_cache.py` covering the flat accessor contract (columns exposed as `pd.Series`, missing keys raise `KeyError`, `__contains__` reports `False` for unknown columns) and register it in `CMakeLists.txt` and `tests/test_categories.yaml`.
- Add a 3.7.0 changelog note in `CHANGELOG.md` for the `PmcDataCache` optimization.

## JIRA ID

AIPROFCOMP-296

## Test Plan

- Run `pytest tests/test_pmc_data_cache.py -q`
- Run `pytest tests/test_metric_utils.py -q`
- Re-run broader `ctest` coverage and the Mistral `rocprof-compute analyze` workload

## Test Result

- [x] `pytest tests/test_pmc_data_cache.py ` (`3 passed`)
- [x] `pytest tests/test_metric_utils.py` (`56 passed`)
- [x] Mistral `rocprof-compute analyze` regression re-run; output unchanged

## Benchmark

| Workload | Before | After | Speedup |
|----------|--------|-------|---------|
| Mistral  | 79 min 54s | 2 min 1s | ~39.6x |

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
