### PR TITLE
RCCL: fix ProcessIsolatedRegisterTests for NCCL_LOCAL_REGISTER default

### DIFF
--- a/projects/rccl/test/RegisterTests.cpp
+++ b/projects/rccl/test/RegisterTests.cpp
@@ -193,11 +193,11 @@ static void testDeregisterNullHandle() {
 // Test configuration helpers
 //==============================================================================
 
-// Environment configuration for disabled registration (default)
+// Environment configuration for explicitly disabled local registration
 static ProcessIsolatedTestRunner::TestConfig
 makeDisabledConfig(const std::string& name, std::function<void()> testFn) {
     return ProcessIsolatedTestRunner::TestConfig(name, testFn)
-        .clearVariable("NCCL_LOCAL_REGISTER");
+        .withEnvironment({{"NCCL_LOCAL_REGISTER", "0"}});
 }
 
 // Environment configuration for enabled registration
@@ -213,10 +213,11 @@ makeEnabledConfig(const std::string& name, std::function<void()> testFn) {
  * This test suite verifies that:
  * 1. A device buffer can be registered with ncclCommRegister (API returns success)
  * 2. When NCCL_LOCAL_REGISTER=1, the registration returns a valid (non-NULL) handle
- * 3. When NCCL_LOCAL_REGISTER is not set, NULL handle is expected (default behavior)
+ * 3. When NCCL_LOCAL_REGISTER=0, NULL handle is expected (local registration off)
  * 4. The buffer can be deregistered with ncclCommDeregister
  *
- * Note: NCCL_LOCAL_REGISTER defaults to 0 (disabled) in RCCL.
+ * Note: On newer HIP, NCCL_LOCAL_REGISTER defaults to 1 when unset; the "disabled"
+ * cases therefore set NCCL_LOCAL_REGISTER=0 explicitly rather than clearing the var.
  */
 TEST(Register, ProcessIsolatedRegisterTests)
 {

--- a/projects/rccl/tools/scripts/test_runner/configs/ci-precheckin.json
+++ b/projects/rccl/tools/scripts/test_runner/configs/ci-precheckin.json
@@ -100,18 +100,6 @@
         {"name": "GroupCall.MixedDataType", "description": "GroupCall mixed data type", "test_filter": "GroupCall.MixedDataType"},
         {"name": "GroupCall.MultiGroupCall", "description": "GroupCall multi group call", "test_filter": "GroupCall.MultiGroupCall"},
         {"name": "NonBlocking.SingleCalls", "description": "NonBlocking single calls", "test_filter": "NonBlocking.SingleCalls"},
-        {"name": "CommTests.Sorter", "description": "CommTests sorter", "test_filter": "CommTests.Sorter"},
-        {"name": "Enqueue", "description": "Enqueue operation tests", "test_filter": "Enqueue.*"},
-        {"name": "Alloc", "description": "Memory allocation tests", "test_filter": "Alloc.*"},
-        {"name": "ParamTests", "description": "Parameter handling tests", "test_filter": "ParamTests.*"},
-        {"name": "ProxyTests", "description": "Proxy service tests", "test_filter": "ProxyTests.*"},
-        {"name": "Rcclwrap", "description": "RCCL wrapper tests", "test_filter": "Rcclwrap.*"},
-        {"name": "TransportTest", "description": "Transport layer tests", "test_filter": "TransportTest.*"},
-        {"name": "ArgCheck", "description": "Argument validation tests", "test_filter": "ArgCheck.*"},
-        {"name": "BitOps", "description": "Bit operation utility tests", "test_filter": "ALIGN_*:DIVUP:ROUNDUP:u32fp*:*Hash"},
-        {"name": "AltRsmi", "description": "Alternative RSMI tests", "test_filter": "AltRsmi.*"},
-        {"name": "NetSocket", "description": "Network socket tests", "test_filter": "NetSocket.*"},
-        {"name": "Ipcsocket", "description": "IPC socket tests", "test_filter": "Ipcsocket.*"},
         {"name": "Standalone.SplitComms_RankCheck", "description": "Verify device assignment for each rank using ncclCommSplit API", "test_filter": "Standalone.SplitComms_RankCheck"},
         {"name": "Standalone.SplitComms_OneColor", "description": "Creates communicator for each device with same color", "test_filter": "Standalone.SplitComms_OneColor"},
         {"name": "Standalone.SplitComms_Reduce", "description": "Reduces communicators into fewer ranks", "test_filter": "Standalone.SplitComms_Reduce"},
@@ -165,7 +153,69 @@
         {"name": "CollTraceUtilsTest.EventQueueOperationTest", "description": "CollTrace event queue operation test", "test_filter": "CollTraceUtilsTest.EventQueueOperationTest"},
         {"name": "CollTraceUtilsTest.EventQueueMultiThreadTest", "description": "CollTrace event queue multithread test", "test_filter": "CollTraceUtilsTest.EventQueueMultiThreadTest"},
         {"name": "CollTraceUtilsTest.getSizeMbTest", "description": "CollTrace get size MB test", "test_filter": "CollTraceUtilsTest.getSizeMbTest"},
-        {"name": "ROCTX", "description": "AllReduce out-of-place with ROCTX logging", "test_filter": "AllReduce.OutOfPlace", "env_variables": {"RCCL_LOG_ROCTX": "1", "UT_MAX_GPUS": "2", "UT_PROCESS_MASK": "2"}}
+        {"name": "AllReduce.ROCTX", "description": "AllReduce with ROCTX logging (dedicated test)", "test_filter": "AllReduce.ROCTX"}
+      ]
+    },
+    "unit_tests_fixtures": {
+      "is_gtest": true,
+      "binary": "rccl-UnitTestsFixtures",
+      "num_ranks": 1,
+      "num_nodes": 1,
+      "num_gpus": 8,
+      "timeout": 90,
+      "env_variables": {
+        "NCCL_DEBUG": ""
+      },
+      "rerun_env_variables": {
+        "NCCL_DEBUG": "INFO"
+      },
+      "tests": [
+        {"name": "BitOps", "description": "Bit operation utility tests (macros and typed fixtures)", "test_filter": "ALIGN_*:DIVUP:ROUNDUP:u32fp*:*Hash:BitOpsTemplate*"},
+        {"name": "CommTests", "description": "Communicator helper tests", "test_filter": "CommTests.*"},
+        {"name": "EnqueueCountTests", "description": "Enqueue send/recv count helpers", "test_filter": "EnqueueCountTests.*"}
+      ]
+    },
+    "unit_tests_fixtures_debug": {
+      "is_gtest": true,
+      "binary": "rccl-UnitTestsFixturesDebug",
+      "num_ranks": 1,
+      "num_nodes": 1,
+      "num_gpus": 8,
+      "timeout": 90,
+      "env_variables": {
+        "NCCL_DEBUG": ""
+      },
+      "rerun_env_variables": {
+        "NCCL_DEBUG": "INFO"
+      },
+      "tests": [
+        {"name": "Alloc", "description": "Memory allocation tests (internal symbols)", "test_filter": "Alloc.*"},
+        {"name": "ParamTests", "description": "NCCL parameter / env parsing tests", "test_filter": "ParamTests.*"},
+        {"name": "ArgCheckTest", "description": "Argument validation tests", "test_filter": "ArgCheckTest.*"},
+        {"name": "EnqueueTests", "description": "Enqueue / kernel init tests", "test_filter": "EnqueueTests.*"},
+        {"name": "Ipcsocket", "description": "IPC socket tests", "test_filter": "Ipcsocket.*"},
+        {"name": "NetSocketTests", "description": "Network socket tests", "test_filter": "NetSocketTests.*"},
+        {"name": "ProxyTests", "description": "Proxy service tests", "test_filter": "ProxyTests.*"},
+        {"name": "Rcclwrap", "description": "RCCL wrapper API tests", "test_filter": "Rcclwrap.*"},
+        {"name": "TransportTest", "description": "Transport layer tests", "test_filter": "TransportTest.*"},
+        {"name": "XmlTest", "description": "XML topology parsing tests", "test_filter": "XmlTest.*"}
+      ]
+    },
+    "unit_tests_alt_rsmi": {
+      "is_gtest": true,
+      "binary": "rccl-UnitTestsAltRsmi",
+      "num_ranks": 1,
+      "num_nodes": 1,
+      "num_gpus": 1,
+      "timeout": 120,
+      "env_variables": {
+        "NCCL_DEBUG": ""
+      },
+      "rerun_env_variables": {
+        "NCCL_DEBUG": "INFO"
+      },
+      "tests": [
+        {"name": "AltRsmi_AllTests", "description": "Alternative RSMI implementation tests (ARSMI_TEST_BUILD)", "test_filter": "AltRsmiTest.*"}
       ]
     }
   },
@@ -174,6 +224,24 @@
       "name": "RCCL Unit Tests - All Collectives",
       "description": "Standard RCCL unit tests for all collective operations",
       "config": "unit_tests",
+      "enabled": true
+    },
+    {
+      "name": "RCCL Unit Tests - Fixtures",
+      "description": "Header-only fixture tests: BitOps, CommTests, EnqueueCountTests",
+      "config": "unit_tests_fixtures",
+      "enabled": true
+    },
+    {
+      "name": "RCCL Unit Tests - Fixtures (Debug internals)",
+      "description": "Tests linking internal librccl symbols",
+      "config": "unit_tests_fixtures_debug",
+      "enabled": true
+    },
+    {
+      "name": "RCCL Unit Tests - Alt RSMI",
+      "description": "Alt RSMI tests with ARSMI_TEST_BUILD",
+      "config": "unit_tests_alt_rsmi",
       "enabled": true
     }
   ]

--- a/projects/rccl/tools/scripts/test_runner/configs/ci-precheckin.json
+++ b/projects/rccl/tools/scripts/test_runner/configs/ci-precheckin.json
@@ -174,49 +174,6 @@
         {"name": "CommTests", "description": "Communicator helper tests", "test_filter": "CommTests.*"},
         {"name": "EnqueueCountTests", "description": "Enqueue send/recv count helpers", "test_filter": "EnqueueCountTests.*"}
       ]
-    },
-    "unit_tests_fixtures_debug": {
-      "is_gtest": true,
-      "binary": "rccl-UnitTestsFixturesDebug",
-      "num_ranks": 1,
-      "num_nodes": 1,
-      "num_gpus": 8,
-      "timeout": 90,
-      "env_variables": {
-        "NCCL_DEBUG": ""
-      },
-      "rerun_env_variables": {
-        "NCCL_DEBUG": "INFO"
-      },
-      "tests": [
-        {"name": "Alloc", "description": "Memory allocation tests (internal symbols)", "test_filter": "Alloc.*"},
-        {"name": "ParamTests", "description": "NCCL parameter / env parsing tests", "test_filter": "ParamTests.*"},
-        {"name": "ArgCheckTest", "description": "Argument validation tests", "test_filter": "ArgCheckTest.*"},
-        {"name": "EnqueueTests", "description": "Enqueue / kernel init tests", "test_filter": "EnqueueTests.*"},
-        {"name": "Ipcsocket", "description": "IPC socket tests", "test_filter": "Ipcsocket.*"},
-        {"name": "NetSocketTests", "description": "Network socket tests", "test_filter": "NetSocketTests.*"},
-        {"name": "ProxyTests", "description": "Proxy service tests", "test_filter": "ProxyTests.*"},
-        {"name": "Rcclwrap", "description": "RCCL wrapper API tests", "test_filter": "Rcclwrap.*"},
-        {"name": "TransportTest", "description": "Transport layer tests", "test_filter": "TransportTest.*"},
-        {"name": "XmlTest", "description": "XML topology parsing tests", "test_filter": "XmlTest.*"}
-      ]
-    },
-    "unit_tests_alt_rsmi": {
-      "is_gtest": true,
-      "binary": "rccl-UnitTestsAltRsmi",
-      "num_ranks": 1,
-      "num_nodes": 1,
-      "num_gpus": 1,
-      "timeout": 120,
-      "env_variables": {
-        "NCCL_DEBUG": ""
-      },
-      "rerun_env_variables": {
-        "NCCL_DEBUG": "INFO"
-      },
-      "tests": [
-        {"name": "AltRsmi_AllTests", "description": "Alternative RSMI implementation tests (ARSMI_TEST_BUILD)", "test_filter": "AltRsmiTest.*"}
-      ]
     }
   },
   "test_suites": [
@@ -230,18 +187,6 @@
       "name": "RCCL Unit Tests - Fixtures",
       "description": "Header-only fixture tests: BitOps, CommTests, EnqueueCountTests",
       "config": "unit_tests_fixtures",
-      "enabled": true
-    },
-    {
-      "name": "RCCL Unit Tests - Fixtures (Debug internals)",
-      "description": "Tests linking internal librccl symbols",
-      "config": "unit_tests_fixtures_debug",
-      "enabled": true
-    },
-    {
-      "name": "RCCL Unit Tests - Alt RSMI",
-      "description": "Alt RSMI tests with ARSMI_TEST_BUILD",
-      "config": "unit_tests_alt_rsmi",
       "enabled": true
     }
   ]

--- a/projects/rccl/tools/scripts/test_runner/configs/mi300x_mellanox_ib.json
+++ b/projects/rccl/tools/scripts/test_runner/configs/mi300x_mellanox_ib.json
@@ -421,6 +421,7 @@
         {"name": "ReduceScatter.InPlaceGraph", "description": "ReduceScatter in-place graph", "test_filter": "ReduceScatter.InPlaceGraph"},
         {"name": "ReduceScatter.ManagedMem", "description": "ReduceScatter managed memory", "test_filter": "ReduceScatter.ManagedMem"},
         {"name": "ReduceScatter.ManagedMemGraph", "description": "ReduceScatter managed memory graph", "test_filter": "ReduceScatter.ManagedMemGraph"},
+        {"name": "Register.ProcessIsolatedRegisterTests", "description": "Process isolated buffer registration tests", "test_filter": "Register.ProcessIsolatedRegisterTests"},
         {"name": "SendRecv.SinglePairs", "description": "SendRecv single pairs", "test_filter": "SendRecv.SinglePairs"},
         {"name": "SendRecv.UserBufferRegister", "description": "SendRecv user buffer register", "test_filter": "SendRecv.UserBufferRegister"},
         {"name": "GroupCall.Identical", "description": "GroupCall identical", "test_filter": "GroupCall.Identical"},


### PR DESCRIPTION
## Motivation

ROCM-21297

## Technical Details

- RegisterTests: use NCCL_LOCAL_REGISTER=0 for disabled cases; unset no longer means disabled on HIP where LOCAL_REGISTER defaults to 1 (ROCM-21297).
- ci-precheckin.json: keep unit_tests on rccl-UnitTests only; add separate configs for rccl-UnitTestsFixtures, rccl-UnitTestsFixturesDebug, and rccl-UnitTestsAltRsmi with correct gtest filters (EnqueueCountTests.*, EnqueueTests.*, ArgCheckTest.*, NetSocketTests.*, AltRsmiTest.*, BitOpsTemplate*). Run AllReduce.ROCTX via its dedicated test instead of AllReduce.OutOfPlace + env.
- mi300x_mellanox_ib.json: register Register.ProcessIsolatedRegisterTests in unit_tests_standard.

## JIRA ID

ROCM-21297

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
