### PR TITLE
[ROCM-2836] - fix failing negative test on MI350p

### DIFF
--- a/projects/hip-tests/catch/unit/executionControl/hipLaunchCooperativeKernel.cc
+++ b/projects/hip-tests/catch/unit/executionControl/hipLaunchCooperativeKernel.cc
@@ -148,7 +148,7 @@ HIP_TEST_CASE(Unit_hipLaunchCooperativeKernel_Negative_Parameters) {
                                                            reinterpret_cast<void*>(kernel), 1, 0));
     const unsigned int multiproc_count =
         GetDeviceAttribute(hipDeviceAttributeMultiprocessorCount, 0);
-    const unsigned int dim = std::ceil(std::cbrt(max_blocks * multiproc_count));
+    const unsigned int dim = std::ceil(std::cbrt(max_blocks * multiproc_count)) + 1u;
     HIP_CHECK_ERROR(hipLaunchCooperativeKernel(reinterpret_cast<void*>(kernel), dim3{dim, dim, dim},
                                                dim3{1, 1, 1}, nullptr, 0, nullptr),
                     hipErrorCooperativeLaunchTooLarge);


### PR DESCRIPTION
## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->
Failing negative test due to perfect cube case on MI350p.
## Technical Details
The intent is that dim^3 (total blocks) > the device limit. But it is possible that max_blocks * multiproc_count is a perfect cube, causing a case where dim^3 == device limit. That is the case on MI350p. Adding +1 ensures this doesn't happen.
<!-- Explain the changes along with any relevant GitHub links. -->

## JIRA ID
ROCM-2836
<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan
Test on gfx950 (MI350p) and other architectures.
<!-- Explain any relevant testing done to verify this PR. -->

## Test Result
Passes.
<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
