### PR TITLE
Merge table lookups and improve struct layouts for performance

### DIFF
--- a/projects/rocprof-trace-decoder/source/gfx10/gfx10parser.h
+++ b/projects/rocprof-trace-decoder/source/gfx10/gfx10parser.h
@@ -21,29 +21,56 @@
 // SOFTWARE.
 
 #pragma once
-#include <unordered_map>
-#include <vector>
 #include "gfx10token.h"
 
+// Combined token lookup entry. TokenLookupTable is a 256-entry array of these, indexed by the
+// low 8 bits of the current token window. A single lookup yields the token type, its bit length,
+// and the bit range of the embedded time-delta field — replacing three separate table lookups.
+struct token_info_t
+{
+    uint8_t type;       // RdnaType
+    uint8_t length;     // total token bit length
+    uint8_t time_begin; // first bit of the time-delta field within the token
+    uint8_t time_end;   // one-past-last bit; delta mask = (1 << (time_end - time_begin)) - 1
+};
+
+// Describes how to populate TokenLookupTable entries for a given token type.
+//
+//   pattern     — the fixed low bits that identify this token, packed LSB-first.
+//                 e.g. the SQTT encoding {0,1,0} means bit0=0, bit1=1, bit2=0 → 0b010.
+//   pattern_len — how many low bits are significant (the prefix length).
+//
+// AddEncoding() fills every table slot whose low pattern_len bits match pattern,
+// so shorter prefixes cover more slots (e.g. 3-bit prefix → 32 slots).
+//
+// To add a new token type for a new GPU generation:
+//   1. Add the RdnaType to token_types.h.
+//   2. Call AddEncoding() in the new generation's TokenLookupTable constructor with:
+//        {TYPE, pattern, pattern_len, total_bit_length, time_begin, time_end}
+//      This will override any inherited entries that share the same bit prefix.
 struct encoding_t
 {
-    RdnaType type;
-    std::vector<uint8_t> bits;
+    uint8_t type;        // RdnaType
+    uint8_t pattern;     // bit pattern identifying this token (LSB-first packed)
+    uint8_t pattern_len; // number of significant bits in pattern
+    uint8_t length;      // total token bit length
+    uint8_t time_begin;  // first bit of time-delta field
+    uint8_t time_end;    // one-past-last bit of time-delta field
 };
 
 namespace gfx10
 {
-class TokenLookupTable : public std::array<uint8_t, 256>
+class TokenLookupTable : public std::array<token_info_t, 256>
 {
 public:
     TokenLookupTable();
     void AddEncoding(const encoding_t& encoding);
 
-    uint8_t lookup(uint8_t u) const { return data()[u]; };
+    const token_info_t& lookup(uint8_t u) const { return data()[u]; };
 
-    int64_t getTime(RdnaType type, uint64_t contents, int64_t cur_time, int64_t& rt)
+    int64_t getTime(const token_info_t& info, uint64_t contents, int64_t cur_time, int64_t& rt)
     {
-        if (type == RdnaType::TIMESTAMP)
+        if (info.type == RdnaType::TIMESTAMP)
         {
             timestamp_type stamp{.raw = contents};
             if (stamp.type == 1) return stamp.time + cur_time;
@@ -51,19 +78,15 @@ public:
             if (stamp.type == 2) rt = stamp.time;
             return cur_time;
         }
-        return getDelta(type, contents) + cur_time;
+        return getDelta(info, contents) + cur_time;
     };
 
 private:
-    int64_t getDelta(RdnaType type, uint64_t contents)
+    static int64_t getDelta(const token_info_t& info, uint64_t contents)
     {
-        auto res = time_bits[type];
-        uint64_t beg = res.first;
-        uint64_t mask = (1ull << (res.second - beg)) - 1;
-        return ((contents >> beg) & mask) + 4 * (type == RdnaType::TIME);
+        uint64_t mask = (1ull << (info.time_end - info.time_begin)) - 1;
+        return ((contents >> info.time_begin) & mask) + 4 * (info.type == RdnaType::TIME);
     };
-
-    static const std::array<std::pair<int, int>, NAVI_TYPE_LAST> time_bits;
 };
 
 class TokenGenerator : public NaviTokenGenerator

--- a/projects/rocprof-trace-decoder/source/gfx10/gfx10token.cpp
+++ b/projects/rocprof-trace-decoder/source/gfx10/gfx10token.cpp
@@ -20,125 +20,70 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-#include <array>
-#include <chrono>
-#include <cstring>
-#include <fstream>
-#include <iostream>
-#include <string>
-#include <unordered_map>
-
-#include "gfx10parser.h"
 #include "gfx10token.h"
+#include "gfx10parser.h"
 #include "trace_parser.hpp"
 
 namespace gfx10
 {
 
-const std::array<std::pair<int, int>, NAVI_TYPE_LAST> TokenLookupTable::time_bits = []()
-{
-    std::array<std::pair<int, int>, NAVI_TYPE_LAST> ret{};
-
-    ret.at(RdnaType::INST) = {4, 7};
-    ret.at(RdnaType::VALU_INST) = {3, 6};
-    ret.at(RdnaType::IMM_ONE) = {4, 7};
-    ret.at(RdnaType::IMMEDIATE) = {5, 8};
-    ret.at(RdnaType::WAVE_READY) = {5, 8};
-    ret.at(RdnaType::NEW_PC_GFX10) = {8, 11};
-    ret.at(RdnaType::WAVE_START) = {5, 7};
-    ret.at(RdnaType::WAVE_START_EXT) = {5, 7};
-    ret.at(RdnaType::WAVE_ALLOC) = {5, 8};
-    ret.at(RdnaType::WAVE_END) = {5, 8};
-    ret.at(RdnaType::SHADER_DATA) = {5, 8};
-    ret.at(RdnaType::SHADER_DATA_SHORT) = {5, 8};
-    ret.at(RdnaType::UTIL_COUNTER_GFX10) = {7, 9};
-    ret.at(RdnaType::TIME) = {4, 8};
-    ret.at(RdnaType::NOP) = {0, 0};
-    ret.at(RdnaType::MISC_GFX10) = {7, 16};
-    ret.at(RdnaType::EVENT) = {8, 11};
-    ret.at(RdnaType::EVENT_SYNC) = {8, 11};
-    ret.at(RdnaType::REG) = {4, 7};
-    ret.at(RdnaType::REG_INIT) = {7, 10};
-    ret.at(RdnaType::TIMESTAMP) = {16, 64};
-    ret.at(RdnaType::HEADER) = {0, 0};
-
-    return ret;
-}();
-
-static const std::vector<encoding_t> bit_encodings = {
-  // Target
-    {RdnaType::INST,               {0, 1, 0}               },
-    {RdnaType::VALU_INST,          {1, 1, 0}               },
-    {RdnaType::IMM_ONE,            {1, 0, 1, 1}            },
-    {RdnaType::IMMEDIATE,          {0, 0, 1, 0, 0}         },
-    {RdnaType::WAVE_READY,         {0, 0, 1, 0, 1}         },
-    {RdnaType::NEW_PC_GFX10,       {1, 0, 0, 0, 0, 1, 0}   },
- // global
-    {RdnaType::WAVE_START,         {0, 0, 1, 1, 0}         },
-    {RdnaType::WAVE_START_EXT,     {0, 0, 1, 1, 1}         },
-    {RdnaType::WAVE_ALLOC,         {1, 0, 1, 0, 0}         },
-    {RdnaType::WAVE_END,           {1, 0, 1, 0, 1}         },
-    {RdnaType::SHADER_DATA,        {0, 1, 1, 0, 0}         },
-    {RdnaType::SHADER_DATA_SHORT,  {0, 1, 1, 0, 1}         },
-    {RdnaType::UTIL_COUNTER_GFX10, {1, 0, 0, 0, 1, 1, 0}   },
- // reference
-    {RdnaType::TIME,               {0, 0, 0, 1}            },
-    {RdnaType::NOP,                {0, 0, 0, 0}            },
-    {RdnaType::MISC_GFX10,         {1, 0, 0, 0, 1, 0, 1}   },
-    {RdnaType::EVENT,              {1, 0, 0, 0, 0, 1, 1, 0}},
-    {RdnaType::EVENT_SYNC,         {1, 0, 0, 0, 0, 1, 1, 1}},
-
-    {RdnaType::REG,                {1, 0, 0, 1}            },
-    {RdnaType::REG_INIT,           {1, 0, 0, 0, 1, 1, 1}   },
-    {RdnaType::TIMESTAMP,          {1, 0, 0, 0, 0, 0, 0}   },
-    {RdnaType::HEADER,             {1, 0, 0, 0, 1, 0, 0}   }
+// GFX10 base token encodings. Each row defines one SQTT token type:
+//   {type, pattern, pattern_len, token_bit_length, time_begin, time_end}
+//
+// gfx11 and gfx12 inherit this table and override specific entries in their constructors.
+// To change a token's bit length or time field for a new generation, add an AddEncoding()
+// call in the subclass constructor — it overwrites all matching slots in-place.
+static constexpr encoding_t bit_encodings[] = {
+  // clang-format off
+ //                               type  pattern  plen  toklen  time_begin  time_end
+ // Target
+    {INST,               0b010,    3,  20,  4,  7},
+    {VALU_INST,          0b011,    3,  12,  3,  6},
+    {IMM_ONE,            0b1101,   4,  12,  4,  7},
+    {IMMEDIATE,          0b00100,  5,  24,  5,  8},
+    {WAVE_READY,         0b10100,  5,  24,  5,  8},
+    {NEW_PC_GFX10,       0b0100001,7,  64,  8, 11},
+ // Global
+    {WAVE_START,         0b01100,  5,  32,  5,  7},
+    {WAVE_START_EXT,     0b11100,  5,  48,  5,  7},
+    {WAVE_ALLOC,         0b00101,  5,  20,  5,  8},
+    {WAVE_END,           0b10101,  5,  20,  5,  8},
+    {SHADER_DATA,        0b00110,  5,  52,  5,  8},
+    {SHADER_DATA_SHORT,  0b10110,  5,  28,  5,  8},
+    {UTIL_COUNTER_GFX10, 0b0110001,7,  64,  7,  9},
+ // Reference
+    {TIME,               0b1000,   4,   8,  4,  8},
+    {NOP,                0b0000,   4,   4,  0,  0},
+    {MISC_GFX10,         0b1010001,7,  24,  7, 16},
+    {EVENT,              0b01100001,8, 24,  8, 11},
+    {EVENT_SYNC,         0b11100001,8, 32,  8, 11},
+    {REG,                0b1001,   4,  64,  4,  7},
+    {REG_INIT,           0b1110001,7,  64,  7, 10},
+    {TIMESTAMP,          0b0000001,7,  64, 16, 64},
+    {HEADER,             0b0010001,7,  64,  0,  0},
+  // clang-format on
 };
 
-static const std::array<uint8_t, 32> TOKEN_LEN = {
-    /*UNKNOWN*/ 8,
-    /*VALU_INST*/ 12,
-    /*IMM_ONE*/ 12,
-    /*IMMEDIATE*/ 24,
-    /*WAVE_READY*/ 24,
-    /*NEW_PC*/ 64,
-    /*WAVE_END*/ 20,
-    /*WAVE_START*/ 32,
-    /*WAVE_START_EXT*/ 48,
-    /*WAVE_ALLOC*/ 20,
-    /*SHADER_DATA*/ 52,
-    /*SHADER_DATA_SHORT*/ 28,
-    /*UTIL_COUNTER_GFX10*/ 64,
-    /*TIME*/ 8,
-    /*NOP*/ 4,
-    /*MISC*/ 24,
-    /*EVENT*/ 24,
-    /*EVENT_SYNC*/ 32,
-    /*REG*/ 64,
-    /*REG_INIT*/ 64,
-    /*TIMESTAMP*/ 64,
-    /*HEADER*/ 64,
-    /*INST*/ 20,
-    /*UTIL_COUNTER_GFX11*/ 64,
-};
-
-TokenLookupTable::TokenLookupTable() : std::array<uint8_t, 256>({})
+TokenLookupTable::TokenLookupTable() : std::array<token_info_t, 256>({})
 {
     for (const auto& encoding : bit_encodings) AddEncoding(encoding);
 }
 
-static uint32_t frombits(const std::vector<uint8_t>& vec)
-{
-    uint32_t res = 0;
-    for (int i = 0; i < vec.size(); i++) res |= vec[i] << i;
-    return res;
-}
-
+// Fills all 256-entry table slots whose low pattern_len bits equal pattern.
+// A 3-bit prefix fills 256/8 = 32 slots, a 7-bit prefix fills 2, an 8-bit prefix fills 1.
+// Later calls overwrite earlier ones, so subclass constructors can override inherited entries.
 void TokenLookupTable::AddEncoding(const encoding_t& encoding)
 {
-    int begin = frombits(encoding.bits);
-    int stepsize = 1 << encoding.bits.size();
+    int begin = encoding.pattern;
+    int stepsize = 1 << encoding.pattern_len;
 
-    for (int i = begin; i < 256; i += stepsize) data()[i] = encoding.type;
+    token_info_t info{};
+    info.type = encoding.type;
+    info.length = encoding.length;
+    info.time_begin = encoding.time_begin;
+    info.time_end = encoding.time_end;
+
+    for (int i = begin; i < 256; i += stepsize) data()[i] = info;
 }
 
 TokenGenerator::TokenGenerator(const uint8_t* _buffer, size_t size, int64_t _globaltime, int64_t _base_time) :
@@ -164,18 +109,18 @@ Token TokenGenerator::next()
 
         readOne_unsafe();
 
-        RdnaType type = (RdnaType) lookupbits.lookup(current);
+        auto& info = lookupbits.lookup(current);
+        RdnaType type = (RdnaType) info.type;
         if (type == RdnaType::NOP)
         {
             bits_toread = 4;
             continue;
         }
 
-        int token_len = TOKEN_LEN[type & 0x1F];
-        bits_toread = token_len;
+        bits_toread = info.length;
 
         int64_t real = 0;
-        globaltime = lookupbits.getTime(type, current, globaltime, real);
+        globaltime = lookupbits.getTime(info, current, globaltime, real);
 
         if (type == RdnaType::TIMESTAMP || type == RdnaType::TIME)
         {
@@ -213,18 +158,18 @@ Token TokenGenerator::next()
 
         readOne_safe();
 
-        RdnaType type = (RdnaType) lookupbits.lookup(current);
+        auto& info = lookupbits.lookup(current);
+        RdnaType type = (RdnaType) info.type;
         if (type == RdnaType::NOP)
         {
             bits_toread = 4;
             continue;
         }
 
-        int token_len = TOKEN_LEN[type & 0x1F];
-        bits_toread = token_len;
+        bits_toread = info.length;
 
         int64_t real = 0;
-        globaltime = lookupbits.getTime(type, current, globaltime, real);
+        globaltime = lookupbits.getTime(info, current, globaltime, real);
 
         if (type == RdnaType::TIMESTAMP || type == RdnaType::TIME)
         {

--- a/projects/rocprof-trace-decoder/source/gfx11/gfx11parser.h
+++ b/projects/rocprof-trace-decoder/source/gfx11/gfx11parser.h
@@ -21,7 +21,6 @@
 // SOFTWARE.
 
 #pragma once
-#include <unordered_map>
 #include "gfx11token.h"
 
 namespace gfx11
@@ -29,19 +28,11 @@ namespace gfx11
 class TokenLookupTable : public gfx10::TokenLookupTable
 {
 public:
-    TokenLookupTable()
-    {
-        AddEncoding({
-            RdnaType::MISC_GFX10, {1, 0, 0, 0, 1, 0, 1}
-        });
-        AddEncoding({
-            RdnaType::UTIL_COUNTER_GFX11, {1, 0, 0, 0, 1, 1, 0}
-        });
-    }
+    TokenLookupTable();
 
-    int64_t getTime(RdnaType type, uint64_t contents, int64_t cur_time, bool& PL, int64_t& rt)
+    int64_t getTime(const token_info_t& info, uint64_t contents, int64_t cur_time, bool& PL, int64_t& rt)
     {
-        if (type == RdnaType::TIMESTAMP)
+        if (info.type == RdnaType::TIMESTAMP)
         {
             timestamp_type stamp{.raw = contents};
             PL |= stamp.pl == 1 && stamp.rt == 0;
@@ -50,19 +41,15 @@ public:
             if (stamp.pl == 0) rt = stamp.time;
             return cur_time;
         }
-        return getDelta(type, contents) + cur_time;
+        return getDelta(info, contents) + cur_time;
     };
 
 private:
-    int64_t getDelta(RdnaType type, uint64_t contents)
+    static int64_t getDelta(const token_info_t& info, uint64_t contents)
     {
-        auto res = time_bits[type];
-        uint64_t beg = res.first;
-        uint64_t mask = (1ull << (res.second - beg)) - 1;
-        return ((contents >> beg) & mask) + 4 * (type == RdnaType::TIME);
+        uint64_t mask = (1ull << (info.time_end - info.time_begin)) - 1;
+        return ((contents >> info.time_begin) & mask) + 4 * (info.type == RdnaType::TIME);
     };
-
-    static const std::array<std::pair<int, int>, NAVI_TYPE_LAST> time_bits;
 };
 
 class TokenGenerator : public NaviTokenGenerator

--- a/projects/rocprof-trace-decoder/source/gfx11/gfx11token.cpp
+++ b/projects/rocprof-trace-decoder/source/gfx11/gfx11token.cpp
@@ -20,17 +20,8 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-#include <array>
-#include <cassert>
-#include <chrono>
-#include <cstring>
-#include <fstream>
-#include <iostream>
-#include <string>
-#include <unordered_map>
-
-#include "gfx11parser.h"
 #include "gfx11token.h"
+#include "gfx11parser.h"
 #include "trace_parser.hpp"
 
 typedef gfx10::Token Token;
@@ -38,63 +29,18 @@ typedef gfx10::Token Token;
 namespace gfx11
 {
 
-const std::array<std::pair<int, int>, NAVI_TYPE_LAST> TokenLookupTable::time_bits = []()
+TokenLookupTable::TokenLookupTable()
 {
-    std::array<std::pair<int, int>, NAVI_TYPE_LAST> ret{};
-
-    ret.at(RdnaType::INST) = {4, 7};
-    ret.at(RdnaType::VALU_INST) = {3, 6};
-    ret.at(RdnaType::IMM_ONE) = {4, 7};
-    ret.at(RdnaType::IMMEDIATE) = {5, 8};
-    ret.at(RdnaType::WAVE_READY) = {5, 8};
-    ret.at(RdnaType::NEW_PC_GFX10) = {8, 11};
-    ret.at(RdnaType::WAVE_START) = {5, 7};
-    ret.at(RdnaType::WAVE_START_EXT) = {5, 7};
-    ret.at(RdnaType::WAVE_ALLOC) = {5, 8};
-    ret.at(RdnaType::WAVE_END) = {5, 8};
-    ret.at(RdnaType::SHADER_DATA) = {5, 8};
-    ret.at(RdnaType::SHADER_DATA_SHORT) = {5, 8};
-    ret.at(RdnaType::UTIL_COUNTER_GFX10) = {7, 9};
-    ret.at(RdnaType::UTIL_COUNTER_GFX11) = {7, 9};
-    ret.at(RdnaType::TIME) = {4, 8};
-    ret.at(RdnaType::NOP) = {0, 0};
-    ret.at(RdnaType::MISC_GFX10) = {7, 16};
-    ret.at(RdnaType::EVENT) = {8, 11};
-    ret.at(RdnaType::EVENT_SYNC) = {8, 11};
-    ret.at(RdnaType::REG) = {4, 7};
-    ret.at(RdnaType::REG_INIT) = {7, 10};
-    ret.at(RdnaType::TIMESTAMP) = {12, 48};
-    ret.at(RdnaType::HEADER) = {0, 0};
-
-    return ret;
-}();
-
-static const std::array<uint8_t, 32> TOKEN_LEN = {
-    /*UNKNOWN*/ 8,
-    /*VALU_INST*/ 12,
-    /*IMM_ONE*/ 12,
-    /*IMMEDIATE*/ 24,
-    /*WAVE_READY*/ 24,
-    /*NEW_PC*/ 64,
-    /*WAVE_END*/ 20,
-    /*WAVE_START*/ 32,
-    /*WAVE_START_EXT*/ 48,
-    /*WAVE_ALLOC*/ 20,
-    /*SHADER_DATA*/ 52,
-    /*SHADER_DATA_SHORT*/ 28,
-    /*UTIL_COUNTER*/ 48,
-    /*TIME*/ 8,
-    /*NOP*/ 4,
-    /*MISC_GFX10*/ 24,
-    /*EVENT*/ 24,
-    /*EVENT_SYNC*/ 32,
-    /*REG*/ 64,
-    /*REG_INIT*/ 64,
-    /*TIMESTAMP*/ 48,
-    /*HEADER*/ 64,
-    /*INST*/ 20,
-    /*UTIL_COUNTER*/ 48,
-};
+    // GFX11 overrides on top of the inherited gfx10 table.
+    // TIMESTAMP shrinks from 64 to 48 bits; UTIL_COUNTER uses the gfx11 layout.
+    // clang-format off
+    //                  type             pattern  plen  toklen  time_begin  time_end
+    AddEncoding({MISC_GFX10,         0b1010001, 7, 24,  7, 16});
+    AddEncoding({UTIL_COUNTER_GFX11, 0b0110001, 7, 48,  7,  9});
+    AddEncoding({UTIL_COUNTER_GFX10, 0b0110001, 7, 48,  7,  9});
+    AddEncoding({TIMESTAMP,          0b0000001, 7, 48, 12, 48});
+    // clang-format on
+}
 
 gfx10::Token TokenGenerator::next()
 {
@@ -113,18 +59,18 @@ gfx10::Token TokenGenerator::next()
 
         readOne_unsafe();
 
-        RdnaType type = (RdnaType) lookupbits.lookup(current);
+        auto& info = lookupbits.lookup(current);
+        RdnaType type = (RdnaType) info.type;
         if (type == RdnaType::NOP)
         {
             bits_toread = 4;
             continue;
         }
 
-        int token_len = TOKEN_LEN[type & 0x1F];
-        bits_toread = token_len;
+        bits_toread = info.length;
 
         int64_t real = 0;
-        globaltime = lookupbits.getTime(type, current, globaltime, packetlost, real);
+        globaltime = lookupbits.getTime(info, current, globaltime, packetlost, real);
 
         if (type == RdnaType::TIMESTAMP || type == RdnaType::TIME)
         {
@@ -162,18 +108,18 @@ gfx10::Token TokenGenerator::next()
 
         readOne_safe();
 
-        RdnaType type = (RdnaType) lookupbits.lookup(current);
+        auto& info = lookupbits.lookup(current);
+        RdnaType type = (RdnaType) info.type;
         if (type == RdnaType::NOP)
         {
             bits_toread = 4;
             continue;
         }
 
-        int token_len = TOKEN_LEN[type & 0x1F];
-        bits_toread = token_len;
+        bits_toread = info.length;
 
         int64_t real = 0;
-        globaltime = lookupbits.getTime(type, current, globaltime, packetlost, real);
+        globaltime = lookupbits.getTime(info, current, globaltime, packetlost, real);
 
         if (type == RdnaType::TIMESTAMP || type == RdnaType::TIME)
         {

--- a/projects/rocprof-trace-decoder/source/gfx11/gfx11token.cpp
+++ b/projects/rocprof-trace-decoder/source/gfx11/gfx11token.cpp
@@ -37,7 +37,6 @@ TokenLookupTable::TokenLookupTable()
     //                  type             pattern  plen  toklen  time_begin  time_end
     AddEncoding({MISC_GFX10,         0b1010001, 7, 24,  7, 16});
     AddEncoding({UTIL_COUNTER_GFX11, 0b0110001, 7, 48,  7,  9});
-    AddEncoding({UTIL_COUNTER_GFX10, 0b0110001, 7, 48,  7,  9});
     AddEncoding({TIMESTAMP,          0b0000001, 7, 48, 12, 48});
     // clang-format on
 }

--- a/projects/rocprof-trace-decoder/source/gfx12/gfx12parser.h
+++ b/projects/rocprof-trace-decoder/source/gfx12/gfx12parser.h
@@ -21,7 +21,6 @@
 // SOFTWARE.
 
 #pragma once
-#include <unordered_map>
 #include "gfx12token.h"
 
 namespace gfx12
@@ -29,31 +28,11 @@ namespace gfx12
 class TokenLookupTable : public gfx11::TokenLookupTable
 {
 public:
-    TokenLookupTable()
-    {
-        AddEncoding({
-            RdnaType::INST, {0, 1, 0}
-        });
-        AddEncoding({
-            RdnaType::SHADER_DATA, {0, 1, 1, 0, 0, 0, 0}
-        });
-        AddEncoding({
-            RdnaType::SHADER_DATA_SHORT, {0, 1, 1, 0, 0, 0, 1}
-        });
-        AddEncoding({
-            RdnaType::EXEC_POPCOUNT1, {0, 1, 1, 0, 0, 1, 1}
-        });
-        AddEncoding({
-            RdnaType::EXEC_POPCOUNT3, {0, 1, 1, 0, 1, 0}
-        });
-        AddEncoding({
-            RdnaType::NEW_PC_GFX12, {1, 0, 0, 0, 0, 1, 0}
-        });
-    }
+    TokenLookupTable();
 
-    int64_t getTime(RdnaType type, uint64_t contents, int64_t cur_time, bool& PL, int64_t& rt)
+    int64_t getTime(const token_info_t& info, uint64_t contents, int64_t cur_time, bool& PL, int64_t& rt)
     {
-        if (type == RdnaType::TIMESTAMP)
+        if (info.type == RdnaType::TIMESTAMP)
         {
             timestamp_type stamp{.raw = contents};
             PL |= bool(stamp.pl && !stamp.rt);
@@ -62,18 +41,15 @@ public:
             if (stamp.pl == 0) rt = stamp.time;
             return cur_time;
         }
-        return getDelta(type, contents) + cur_time;
+        return getDelta(info, contents) + cur_time;
     };
 
 private:
-    int64_t getDelta(RdnaType type, uint64_t contents)
+    static int64_t getDelta(const token_info_t& info, uint64_t contents)
     {
-        auto res = time_bits.at(type);
-        uint64_t mask = (1ull << (res.second - res.first)) - 1;
-        return ((contents >> res.first) & mask) + 4 * (type == RdnaType::TIME);
+        uint64_t mask = (1ull << (info.time_end - info.time_begin)) - 1;
+        return ((contents >> info.time_begin) & mask) + 4 * (info.type == RdnaType::TIME);
     };
-
-    const static std::array<std::pair<int, int>, NAVI_TYPE_LAST> time_bits;
 };
 
 class TokenGenerator : public NaviTokenGenerator

--- a/projects/rocprof-trace-decoder/source/gfx12/gfx12token.cpp
+++ b/projects/rocprof-trace-decoder/source/gfx12/gfx12token.cpp
@@ -20,17 +20,8 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-#include <array>
-#include <cassert>
-#include <chrono>
-#include <cstring>
-#include <fstream>
-#include <iostream>
-#include <string>
-#include <unordered_map>
-
-#include "gfx12parser.h"
 #include "gfx12token.h"
+#include "gfx12parser.h"
 #include "trace_parser.hpp"
 
 typedef gfx10::Token Token;
@@ -38,70 +29,25 @@ typedef gfx10::Token Token;
 namespace gfx12
 {
 
-const std::array<std::pair<int, int>, NAVI_TYPE_LAST> TokenLookupTable::time_bits = []()
+TokenLookupTable::TokenLookupTable()
 {
-    std::array<std::pair<int, int>, NAVI_TYPE_LAST> ret{};
-
-    ret.at(RdnaType::INST) = {3, 6};
-    ret.at(RdnaType::INST) = {3, 6};
-    ret.at(RdnaType::INST) = {3, 6};
-    ret.at(RdnaType::VALU_INST) = {3, 6};
-    ret.at(RdnaType::IMM_ONE) = {4, 7};
-    ret.at(RdnaType::IMMEDIATE) = {5, 8};
-    ret.at(RdnaType::WAVE_READY) = {5, 8};
-    ret.at(RdnaType::NEW_PC_GFX12) = {8, 11};
-    ret.at(RdnaType::WAVE_START) = {5, 7};
-    ret.at(RdnaType::WAVE_START_EXT) = {5, 7};
-    ret.at(RdnaType::WAVE_ALLOC) = {5, 8};
-    ret.at(RdnaType::WAVE_END) = {5, 8};
-    ret.at(RdnaType::SHADER_DATA) = {7, 10};
-    ret.at(RdnaType::SHADER_DATA_SHORT) = {7, 10};
-    ret.at(RdnaType::UTIL_COUNTER_GFX10) = {7, 9};
-    ret.at(RdnaType::UTIL_COUNTER_GFX11) = {7, 9};
-    ret.at(RdnaType::TIME) = {4, 8};
-    ret.at(RdnaType::NOP) = {0, 0};
-    ret.at(RdnaType::MISC_GFX10) = {7, 16};
-    ret.at(RdnaType::EVENT) = {8, 11};
-    ret.at(RdnaType::EVENT_SYNC) = {8, 11};
-    ret.at(RdnaType::REG) = {4, 7};
-    ret.at(RdnaType::REG_INIT) = {7, 10};
-    ret.at(RdnaType::TIMESTAMP) = {12, 64};
-    ret.at(RdnaType::HEADER) = {0, 0};
-    ret.at(RdnaType::EXEC_POPCOUNT1) = {7, 10};
-    ret.at(RdnaType::EXEC_POPCOUNT3) = {6, 9};
-
-    return ret;
-}();
-
-static const std::array<uint8_t, 32> TOKEN_LEN = {
-    /*UNKNOWN*/ 8,
-    /*VALU_INST*/ 12,
-    /*IMM_ONE*/ 12,
-    /*IMMEDIATE*/ 24,
-    /*WAVE_READY*/ 24,
-    /*NEW_PC*/ 72,
-    /*WAVE_END*/ 20,
-    /*WAVE_START*/ 32,
-    /*WAVE_START_EXT*/ 40,
-    /*WAVE_ALLOC*/ 24,
-    /*SHADER_DATA*/ 56,
-    /*SHADER_DATA_SHORT*/ 32,
-    /*UTIL_COUNTER*/ 48,
-    /*TIME*/ 8,
-    /*NOP*/ 4,
-    /*MISC_GFX10*/ 24,
-    /*EVENT*/ 24,
-    /*EVENT_SYNC*/ 32,
-    /*REG*/ 64,
-    /*REG_INIT*/ 64,
-    /*TIMESTAMP*/ 64,
-    /*HEADER*/ 64,
-    /*INST*/ 20,
-    /*UTIL_COUNTER*/ 48,
-    /*EXEC_POPCOUNT1*/ 24,
-    /*EXEC_POPCOUNT3*/ 48,
-    /*NEW_PC_GFX12*/ 72,
-};
+    // GFX12 overrides on top of the inherited gfx11 table.
+    // Adds new token types (EXEC_POPCOUNT*, NEW_PC_GFX12) and changes bit lengths for several
+    // existing types (INST time field shifts, SHADER_DATA grows, WAVE_START_EXT shrinks, etc.).
+    // clang-format off
+    //                  type             pattern     plen  toklen  time_begin  time_end
+    AddEncoding({INST,              0b010,      3, 20,  3,  6});
+    AddEncoding({SHADER_DATA,       0b0000110,  7, 56,  7, 10});
+    AddEncoding({SHADER_DATA_SHORT, 0b1000110,  7, 32,  7, 10});
+    AddEncoding({EXEC_POPCOUNT1,    0b1100110,  7, 24,  7, 10});
+    AddEncoding({EXEC_POPCOUNT3,    0b010110,   6, 48,  6,  9});
+    AddEncoding({NEW_PC_GFX12,      0b0100001,  7, 72,  8, 11});
+    AddEncoding({NEW_PC_GFX10,      0b0100001,  7, 72,  8, 11});
+    AddEncoding({WAVE_START_EXT,    0b11100,    5, 40,  5,  7});
+    AddEncoding({WAVE_ALLOC,        0b00101,    5, 24,  5,  8});
+    AddEncoding({TIMESTAMP,         0b0000001,  7, 64, 12, 64});
+    // clang-format on
+}
 
 gfx10::Token TokenGenerator::next()
 {
@@ -116,18 +62,19 @@ gfx10::Token TokenGenerator::next()
             continue;
         }
 
-        RdnaType type = (RdnaType) lookupbits.lookup(current);
+        auto& info = lookupbits.lookup(current);
+        RdnaType type = (RdnaType) info.type;
         if (type == RdnaType::NOP)
         {
             bits_toread = 4;
             continue;
         }
 
-        bits_toread = TOKEN_LEN[type & 0x1F];
+        bits_toread = info.length;
         bIsExt = type == WAVE_START_EXT;
 
         int64_t real = 0;
-        globaltime = lookupbits.getTime(type, current, globaltime, packetlost, real);
+        globaltime = lookupbits.getTime(info, current, globaltime, packetlost, real);
 
         if (type == RdnaType::TIMESTAMP || type == RdnaType::TIME)
         {
@@ -159,18 +106,19 @@ gfx10::Token TokenGenerator::next()
             continue;
         }
 
-        RdnaType type = (RdnaType) lookupbits.lookup(current);
+        auto& info = lookupbits.lookup(current);
+        RdnaType type = (RdnaType) info.type;
         if (type == RdnaType::NOP)
         {
             bits_toread = 4;
             continue;
         }
 
-        bits_toread = TOKEN_LEN[type & 0x1F];
+        bits_toread = info.length;
         bIsExt = type == WAVE_START_EXT;
 
         int64_t real = 0;
-        globaltime = lookupbits.getTime(type, current, globaltime, packetlost, real);
+        globaltime = lookupbits.getTime(info, current, globaltime, packetlost, real);
 
         if (type == RdnaType::TIMESTAMP || type == RdnaType::TIME)
         {

--- a/projects/rocprof-trace-decoder/source/gfx12/gfx12token.cpp
+++ b/projects/rocprof-trace-decoder/source/gfx12/gfx12token.cpp
@@ -42,7 +42,6 @@ TokenLookupTable::TokenLookupTable()
     AddEncoding({EXEC_POPCOUNT1,    0b1100110,  7, 24,  7, 10});
     AddEncoding({EXEC_POPCOUNT3,    0b010110,   6, 48,  6,  9});
     AddEncoding({NEW_PC_GFX12,      0b0100001,  7, 72,  8, 11});
-    AddEncoding({NEW_PC_GFX10,      0b0100001,  7, 72,  8, 11});
     AddEncoding({WAVE_START_EXT,    0b11100,    5, 40,  5,  7});
     AddEncoding({WAVE_ALLOC,        0b00101,    5, 24,  5,  8});
     AddEncoding({TIMESTAMP,         0b0000001,  7, 64, 12, 64});

--- a/projects/rocprof-trace-decoder/source/mi400/mi400parser.h
+++ b/projects/rocprof-trace-decoder/source/mi400/mi400parser.h
@@ -21,7 +21,6 @@
 // SOFTWARE.
 
 #pragma once
-#include <unordered_map>
 #include "gfx12/gfx12parser.h"
 #include "mi400token.h"
 
@@ -31,40 +30,11 @@ namespace mi400
 class TokenLookupTable : public gfx12::TokenLookupTable
 {
 public:
-    TokenLookupTable()
-    {
-        AddEncoding({
-            RdnaType::INST, {0, 1, 0, 0}
-        });
-        AddEncoding({
-            RdnaType::VALU_INST, {1, 1, 0}
-        });
-        AddEncoding({
-            RdnaType::NOP, {0, 0, 0, 0}
-        });
-        AddEncoding({
-            RdnaType::IMM_ONE, {1, 0, 1, 1}
-        });
-        AddEncoding({
-            RdnaType::WAVE_END, {1, 0, 0, 0, 0, 0, 1}
-        });
-        AddEncoding({
-            RdnaType::LDS_CONFIG, {0, 1, 1, 0, 0, 1, 0, 0}
-        });
-        AddEncoding({
-            RdnaType::MISC_GFX10, {1, 0, 0, 0, 1, 0, 1}
-        });
-        AddEncoding({
-            RdnaType::TIME, {0, 1, 1, 1}
-        });
-        AddEncoding({
-            RdnaType::MEDIUM_TIME, {0, 1, 1, 0, 0, 1, 0, 1}
-        });
-    }
+    TokenLookupTable();
 
-    int64_t getTime(RdnaType type, uint64_t contents, int64_t cur_time, bool& PL, int64_t& rt)
+    int64_t getTime(const token_info_t& info, uint64_t contents, int64_t cur_time, bool& PL, int64_t& rt)
     {
-        if (type == RdnaType::TIMESTAMP)
+        if (info.type == RdnaType::TIMESTAMP)
         {
             gfx12::timestamp_type stamp{.raw = contents};
             PL |= bool(stamp.pl && !stamp.rt);
@@ -73,20 +43,18 @@ public:
             if (stamp.pl == 0) rt = stamp.time;
             return cur_time;
         }
-        else if (type == RdnaType::TIME) { cur_time += 1; }
-        return getDelta(type, contents) + cur_time;
+        else if (info.type == RdnaType::TIME) { cur_time += 1; }
+        return getDelta(info, contents) + cur_time;
     };
 
 private:
-    int64_t getDelta(RdnaType type, uint64_t contents)
+    // MI400 omits the +4 cycle adjustment that gfx10/11/12 apply to TIME tokens; the
+    // +1 above already covers it. Hides gfx12::TokenLookupTable::getDelta via name lookup.
+    static int64_t getDelta(const token_info_t& info, uint64_t contents)
     {
-        auto res = time_bits[type];
-        uint64_t beg = res.first;
-        uint64_t mask = (1ull << (res.second - beg)) - 1;
-        return ((contents >> beg) & mask);
+        uint64_t mask = (1ull << (info.time_end - info.time_begin)) - 1;
+        return ((contents >> info.time_begin) & mask);
     };
-
-    static std::array<std::pair<int, int>, NAVI_TYPE_LAST> time_bits;
 };
 
 class TokenGenerator : public NaviTokenGenerator
@@ -124,7 +92,6 @@ private:
     size_t byte_ptr = 0;
     bool bIsExt = false;
     TokenLookupTable lookupbits{};
-    static std::array<uint8_t, 64> TOKEN_LEN;
 };
 
 } // namespace mi400

--- a/projects/rocprof-trace-decoder/source/mi400/mi400token.cpp
+++ b/projects/rocprof-trace-decoder/source/mi400/mi400token.cpp
@@ -20,15 +20,8 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-#include <sys/stat.h>
 #include <array>
-#include <cassert>
-#include <chrono>
 #include <cstring>
-#include <fstream>
-#include <iostream>
-#include <string>
-#include <unordered_map>
 
 #include "mi400parser.h"
 #include "mi400token.h"
@@ -39,91 +32,24 @@ typedef mi400::Token Token;
 namespace mi400
 {
 
-std::array<std::pair<int, int>, NAVI_TYPE_LAST> TokenLookupTable::time_bits = []()
+TokenLookupTable::TokenLookupTable()
 {
-    std::unordered_map<int, std::pair<int, int>> map{};
-    map[UNKNOWN] = {0, 0};
-    map[INST] = {4, 6};
-    map[VALU_INST] = {4, 8};
-    map[WAVE_READY] = {5, 8};
-    map[IMMEDIATE] = {5, 8};
-    map[IMM_ONE] = {7, 10};
-    map[NEW_PC_GFX12] = {8, 11};
-    map[EXEC_POPCOUNT1] = {7, 10};
-    map[EXEC_POPCOUNT3] = {6, 9};
-    map[WAVE_START] = {5, 7};
-    map[WAVE_START_EXT] = {5, 7};
-    map[WAVE_ALLOC] = {5, 8};
-    map[WAVE_END] = {7, 10};
-    map[SHADER_DATA] = {7, 10};
-    map[SHADER_DATA_SHORT] = {7, 10};
-    map[LDS_CONFIG] = {8, 10};
-    map[UTIL_COUNTER_GFX11] = {7, 9};
-    map[TIME] = {4, 8};
-    map[MISC_GFX10] = {7, 10};
-    map[EVENT] = {8, 11};
-    map[EVENT_SYNC] = {8, 11};
-    map[REG] = {4, 7};
-    map[REG_INIT] = {7, 10};
-    map[TIMESTAMP] = {12, 64};
-    map[HEADER] = {0, 0};
-    map[MEDIUM_TIME] = {8, 16};
-    map[NOP] = {0, 0};
-
-    // Unused
-    map[NEW_PC_GFX10] = {0, 0};
-    map[UTIL_COUNTER_GFX10] = {0, 0};
-
-    std::array<std::pair<int, int>, NAVI_TYPE_LAST> ret{};
-
-    for (size_t i = 0; i < NAVI_TYPE_LAST; i++)
-        if (map.find(i) == map.end()) abort();
-
-    for (size_t i = 0; i < NAVI_TYPE_LAST; i++) ret[i] = map.at(i);
-
-    return ret;
-}();
-
-std::array<uint8_t, 64> TokenGenerator::TOKEN_LEN = []()
-{
-    static_assert(NAVI_TYPE_LAST <= 64);
-    std::array<uint8_t, 64> map{};
-    for (auto& v : map) v = 8;
-
-    map[UNKNOWN] = 8;
-    map[INST] = 24;
-    map[VALU_INST] = 8;
-    map[IMM_ONE] = 16;
-    map[IMMEDIATE] = 24;
-    map[WAVE_READY] = 24;
-    map[NEW_PC_GFX12] = 72;
-    map[EXEC_POPCOUNT1] = 24;
-    map[EXEC_POPCOUNT3] = 48;
-    map[WAVE_START] = 32;
-    map[WAVE_START_EXT] = 40;
-    map[WAVE_ALLOC] = 24;
-    map[WAVE_END] = 24;
-    map[SHADER_DATA] = 56;
-    map[SHADER_DATA_SHORT] = 32;
-    map[UTIL_COUNTER_GFX11] = 48;
-    map[LDS_CONFIG] = 24;
-    map[MISC_GFX10] = 24;
-    map[EVENT] = 24;
-    map[EVENT_SYNC] = 32;
-    map[REG] = 64;
-    map[REG_INIT] = 64;
-    map[TIME] = 8;
-    map[MEDIUM_TIME] = 16;
-    map[TIMESTAMP] = 64;
-    map[HEADER] = 64;
-    map[NOP] = 8;
-
-    // Unused
-    map[NEW_PC_GFX10] = 8;
-    map[UTIL_COUNTER_GFX10] = 8;
-
-    return map;
-}();
+    // MI400 overrides on top of the inherited gfx12 table.
+    // Adds LDS_CONFIG and MEDIUM_TIME, and re-points INST/VALU_INST/IMM_ONE/WAVE_END/MISC_GFX10/TIME/NOP
+    // to the bit lengths and time-field positions used by MI4xx (gfx12.5) traces.
+    // clang-format off
+    //                  type             pattern      plen  toklen  time_begin  time_end
+    AddEncoding({INST,         0b0010,      4, 24, 4,  6});
+    AddEncoding({VALU_INST,    0b011,       3,  8, 4,  8});
+    AddEncoding({NOP,          0b0000,      4,  8, 0,  0});
+    AddEncoding({IMM_ONE,      0b1101,      4, 16, 7, 10});
+    AddEncoding({WAVE_END,     0b1000001,   7, 24, 7, 10});
+    AddEncoding({LDS_CONFIG,   0b00100110,  8, 24, 8, 10});
+    AddEncoding({MISC_GFX10,   0b1010001,   7, 24, 7, 10});
+    AddEncoding({TIME,         0b1110,      4,  8, 4,  8});
+    AddEncoding({MEDIUM_TIME,  0b10100110,  8, 16, 8, 16});
+    // clang-format on
+}
 
 std::array<int, 16> TM_DELTA_TABLE = {1, 2, 3, 4, 1, 2, 3, 4, 1, 2, 3, 4, 1, 2, 1, 2};
 
@@ -140,21 +66,22 @@ gfx10::Token TokenGenerator::next()
             continue;
         }
 
-        RdnaType type = (RdnaType) lookupbits.lookup(current);
+        auto& info = lookupbits.lookup(current);
+        RdnaType type = (RdnaType) info.type;
         if (type == RdnaType::NOP)
         {
             bits_toread = 8;
             continue;
         }
 
-        bits_toread = TOKEN_LEN.at(type);
+        bits_toread = info.length;
         bIsExt = type == WAVE_START_EXT;
 
         int64_t real = 0;
         if (type == VALU_INST)
             globaltime += TM_DELTA_TABLE[valu_inst_type{.raw = current}.wavetm];
         else
-            globaltime = lookupbits.getTime(type, current, globaltime, packetlost, real);
+            globaltime = lookupbits.getTime(info, current, globaltime, packetlost, real);
 
         if (type == RdnaType::TIMESTAMP || type == RdnaType::TIME)
         {
@@ -198,21 +125,22 @@ gfx10::Token TokenGenerator::next()
             continue;
         }
 
-        RdnaType type = (RdnaType) lookupbits.lookup(current);
+        auto& info = lookupbits.lookup(current);
+        RdnaType type = (RdnaType) info.type;
         if (type == RdnaType::NOP)
         {
             bits_toread = 8;
             continue;
         }
 
-        bits_toread = TOKEN_LEN.at(type);
+        bits_toread = info.length;
         bIsExt = type == WAVE_START_EXT;
 
         int64_t real = 0;
         if (type == VALU_INST)
             globaltime += TM_DELTA_TABLE[valu_inst_type{.raw = current}.wavetm];
         else
-            globaltime = lookupbits.getTime(type, current, globaltime, packetlost, real);
+            globaltime = lookupbits.getTime(info, current, globaltime, packetlost, real);
 
         if (type == RdnaType::TIMESTAMP || type == RdnaType::TIME)
         {

--- a/projects/rocprof-trace-decoder/test/unit/mi400_test.cpp
+++ b/projects/rocprof-trace-decoder/test/unit/mi400_test.cpp
@@ -38,9 +38,9 @@ TEST(MI400LookupTableTest, BasicEncodingLookups)
 {
     mi400::TokenLookupTable lookup;
 
-    EXPECT_EQ(lookup.lookup(0b0010), RdnaType::INST);
-    EXPECT_EQ(lookup.lookup(0b011), RdnaType::VALU_INST);
-    EXPECT_EQ(lookup.lookup(0b1000001), RdnaType::WAVE_END);
+    EXPECT_EQ(lookup.lookup(0b0010).type, RdnaType::INST);
+    EXPECT_EQ(lookup.lookup(0b011).type, RdnaType::VALU_INST);
+    EXPECT_EQ(lookup.lookup(0b1000001).type, RdnaType::WAVE_END);
 }
 
 TEST(MI400LookupTableTest, GetTimeForTimestamp)
@@ -56,7 +56,7 @@ TEST(MI400LookupTableTest, GetTimeForTimestamp)
     int64_t realtime = 0;
     int64_t cur_time = 500;
 
-    auto result = lookup.getTime(RdnaType::TIMESTAMP, ts.raw, cur_time, packetlost, realtime);
+    auto result = lookup.getTime(lookup.lookup(0b0000001), ts.raw, cur_time, packetlost, realtime);
     EXPECT_EQ(result, ts.time + cur_time);
 }
 
@@ -73,7 +73,7 @@ TEST(MI400LookupTableTest, GetTimeForRealtimeTimestamp)
     int64_t realtime = 0;
     int64_t cur_time = 500;
 
-    auto result = lookup.getTime(RdnaType::TIMESTAMP, ts.raw, cur_time, packetlost, realtime);
+    auto result = lookup.getTime(lookup.lookup(0b0000001), ts.raw, cur_time, packetlost, realtime);
     EXPECT_EQ(result, cur_time);
     EXPECT_EQ(realtime, ts.time);
 }
@@ -91,7 +91,7 @@ TEST(MI400LookupTableTest, GetTimeWithPacketLoss)
     int64_t realtime = 0;
     int64_t cur_time = 500;
 
-    lookup.getTime(RdnaType::TIMESTAMP, ts.raw, cur_time, packetlost, realtime);
+    lookup.getTime(lookup.lookup(0b0000001), ts.raw, cur_time, packetlost, realtime);
     EXPECT_TRUE(packetlost);
 }
 
@@ -103,7 +103,7 @@ TEST(MI400LookupTableTest, GetTimeForTimeToken)
     int64_t realtime = 0;
     int64_t cur_time = 500;
 
-    auto result = lookup.getTime(RdnaType::TIME, 0, cur_time, packetlost, realtime);
+    auto result = lookup.getTime(lookup.lookup(0b1110), 0, cur_time, packetlost, realtime);
     EXPECT_GT(result, cur_time);
 }
 


### PR DESCRIPTION
## Motivation

The decoder uses 3 different LUTs to parse tokens on gfx10+ SQTT. This is both slow and more complicated.
This PR addresses that.

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
