### PR TITLE
[AMD-SMI] Added deprecation notice for amdsmi_get_cpusocket_handles

### DIFF
--- a/projects/amdsmi/amdsmi_cli/amdsmi_commands.py
+++ b/projects/amdsmi/amdsmi_cli/amdsmi_commands.py
@@ -123,7 +123,8 @@ class AMDSMICommands:
 
         if self.helpers.is_amd_hsmp_initialized():
             try:
-                self.cpu_handles = amdsmi_interface.amdsmi_get_cpusocket_handles()
+                ret = amdsmi_interface.amdsmi_get_cpu_handles()
+                self.cpu_handles = ret["processor_handles"]
             except amdsmi_exception.AmdSmiLibraryException as e:
                 if e.err_code in (
                     amdsmi_interface.amdsmi_wrapper.AMDSMI_STATUS_NOT_INIT,
@@ -233,7 +234,8 @@ class AMDSMICommands:
             self.logger.output["amdgpu_version"] = gpu_version_str
         if args.cpu_version:
             try:
-                cpus = amdsmi_interface.amdsmi_get_cpusocket_handles()
+                ret = amdsmi_interface.amdsmi_get_cpu_handles()
+                cpus = ret["processor_handles"]
                 if isinstance(cpus, list) and len(cpus) > 0:
                     cpu_version_info = amdsmi_interface.amdsmi_get_cpu_hsmp_driver_version(cpus[0])
                     cpu_version_str = (

--- a/projects/amdsmi/amdsmi_cli/amdsmi_helpers.py
+++ b/projects/amdsmi/amdsmi_cli/amdsmi_helpers.py
@@ -237,8 +237,9 @@ class AMDSMIHelpers:
 
         try:
             cpu_handles = []
-            # amdsmi_get_cpusocket_handles() returns the cpu socket handles stored for cpu_id
-            cpu_handles = amdsmi_interface.amdsmi_get_cpusocket_handles()
+            # amdsmi_get_cpu_handles() returns the cpu socket handles stored for cpu_id
+            ret = amdsmi_interface.amdsmi_get_cpu_handles()
+            cpu_handles = ret["processor_handles"]
         except amdsmi_interface.AmdSmiLibraryException as e:
             if e.err_code in (
                 amdsmi_interface.amdsmi_wrapper.AMDSMI_STATUS_NOT_INIT,
@@ -703,7 +704,9 @@ class AMDSMIHelpers:
             (False, str): Return False, and the first input that failed to be converted
         """
         if "all" in cpu_selections:
-            return True, True, amdsmi_interface.amdsmi_get_cpusocket_handles()
+            ret = amdsmi_interface.amdsmi_get_cpu_handles()
+            cpus = ret["processor_handles"]
+            return True, True, cpus
 
         if isinstance(cpu_selections, str):
             cpu_selections = [cpu_selections]
@@ -1157,9 +1160,10 @@ class AMDSMIHelpers:
 
     def get_cpu_id_from_device_handle(self, input_device_handle):
         """Get the cpu index from the device_handle.
-        amdsmi_interface.amdsmi_get_cpusocket_handles() returns the list of device_handles in order of cpu_index
+        amdsmi_interface.amdsmi_get_cpu_handles() returns the list of device_handles in order of cpu_index
         """
-        device_handles = amdsmi_interface.amdsmi_get_cpusocket_handles()
+        ret = amdsmi_interface.amdsmi_get_cpu_handles()
+        device_handles = ret["processor_handles"]
         for cpu_index, device_handle in enumerate(device_handles):
             if input_device_handle.value == device_handle.value:
                 return cpu_index
@@ -1171,7 +1175,7 @@ class AMDSMIHelpers:
 
     def get_core_id_from_device_handle(self, input_device_handle):
         """Get the core index from the device_handle.
-        amdsmi_interface.amdsmi_get_cpusocket_handles() returns the list of device_handles in order of cpu_index
+        amdsmi_interface.amdsmi_get_cpu_handles() returns the list of device_handles in order of cpu_index
         """
         device_handles = amdsmi_interface.amdsmi_get_cpucore_handles()
         for core_index, device_handle in enumerate(device_handles):

--- a/projects/amdsmi/amdsmi_cli/amdsmi_helpers.py
+++ b/projects/amdsmi/amdsmi_cli/amdsmi_helpers.py
@@ -235,8 +235,8 @@ class AMDSMIHelpers:
         cpu_choices = {}
         cpu_choices_str = ""
 
+        cpu_handles = []
         try:
-            cpu_handles = []
             # amdsmi_get_cpu_handles() returns the cpu socket handles stored for cpu_id
             ret = amdsmi_interface.amdsmi_get_cpu_handles()
             cpu_handles = ret["processor_handles"]
@@ -285,8 +285,8 @@ class AMDSMIHelpers:
         core_choices = {}
         core_choices_str = ""
 
+        core_handles = []
         try:
-            core_handles = []
             # amdsmi_get_cpucore_handles() returns the core handles stored for core_id
             core_handles = amdsmi_interface.amdsmi_get_cpucore_handles()
         except amdsmi_interface.AmdSmiLibraryException as e:

--- a/projects/amdsmi/docs/how-to/amdsmi-py-lib.md
+++ b/projects/amdsmi/docs/how-to/amdsmi-py-lib.md
@@ -140,10 +140,10 @@ Exceptions that can be thrown by AMD SMI are:
 
    ```python
    try:
-    cpu_handles = amdsmi_get_cpu_handles()
-    cpu_count = cpu_handles["cpu_count"]
-    processor_handles = cpu_handles["processor_handles"]
-    if cpu_count == 0:
+       cpu_handles = amdsmi_get_cpu_handles()
+       cpu_count = cpu_handles["cpu_count"]
+       processor_handles = cpu_handles["processor_handles"]
+       if cpu_count == 0:
            print("No CPU sockets on machine")
        else:
            for processor in processor_handles:

--- a/projects/amdsmi/docs/how-to/amdsmi-py-lib.md
+++ b/projects/amdsmi/docs/how-to/amdsmi-py-lib.md
@@ -140,8 +140,10 @@ Exceptions that can be thrown by AMD SMI are:
 
    ```python
    try:
-       processor_handles = amdsmi_get_cpusocket_handles()
-       if len(processor_handles) == 0:
+    cpu_handles = amdsmi_get_cpu_handles()
+    cpu_count = cpu_handles["cpu_count"]
+    processor_handles = cpu_handles["processor_handles"]
+    if cpu_count == 0:
            print("No CPU sockets on machine")
        else:
            for processor in processor_handles:

--- a/projects/amdsmi/docs/reference/amdsmi-py-api.md
+++ b/projects/amdsmi/docs/reference/amdsmi-py-api.md
@@ -5606,8 +5606,10 @@ Example:
 
 ```python
 try:
-    processor_handles = amdsmi_get_cpusocket_handles()
-    if len(processor_handles) == 0:
+    cpu_handles = amdsmi_get_cpu_handles()
+    cpu_count = cpu_handles["cpu_count"]
+    processor_handles = cpu_handles["processor_handles"]
+    if cpu_count == 0:
         print("No CPU sockets on machine")
     else:
         for processor in processor_handles:
@@ -5667,8 +5669,10 @@ Example:
 
 ```python
 try:
-    processor_handles = amdsmi_get_cpusocket_handles()
-    if len(processor_handles) == 0:
+    cpu_handles = amdsmi_get_cpu_handles()
+    cpu_count = cpu_handles["cpu_count"]
+    processor_handles = cpu_handles["processor_handles"]
+    if cpu_count == 0:
         print("No CPU sockets on machine")
     else:
         for processor in processor_handles:
@@ -5700,8 +5704,10 @@ Example:
 
 ```python
 try:
-    processor_handles = amdsmi_get_cpusocket_handles()
-    if len(processor_handles) == 0:
+    cpu_handles = amdsmi_get_cpu_handles()
+    cpu_count = cpu_handles["cpu_count"]
+    processor_handles = cpu_handles["processor_handles"]
+    if cpu_count == 0:
         print("No CPU sockets on machine")
     else:
         for processor in processor_handles:
@@ -5733,8 +5739,10 @@ Example:
 
 ```python
 try:
-    processor_handles = amdsmi_get_cpusocket_handles()
-    if len(processor_handles) == 0:
+    cpu_handles = amdsmi_get_cpu_handles()
+    cpu_count = cpu_handles["cpu_count"]
+    processor_handles = cpu_handles["processor_handles"]
+    if cpu_count == 0:
         print("No CPU sockets on machine")
     else:
         for processor in processor_handles:
@@ -5766,8 +5774,10 @@ Example:
 
 ```python
 try:
-    processor_handles = amdsmi_get_cpusocket_handles()
-    if len(processor_handles) == 0:
+    cpu_handles = amdsmi_get_cpu_handles()
+    cpu_count = cpu_handles["cpu_count"]
+    processor_handles = cpu_handles["processor_handles"]
+    if cpu_count == 0:
         print("No CPU sockets on machine")
     else:
         for processor in processor_handles:
@@ -5801,8 +5811,10 @@ Example:
 
 ```python
 try:
-    processor_handles = amdsmi_get_cpusocket_handles()
-    if len(processor_handles) == 0:
+    cpu_handles = amdsmi_get_cpu_handles()
+    cpu_count = cpu_handles["cpu_count"]
+    processor_handles = cpu_handles["processor_handles"]
+    if cpu_count == 0:
         print("No CPU sockets on machine")
     else:
         for processor in processor_handles:
@@ -5834,8 +5846,10 @@ Example:
 
 ```python
 try:
-    processor_handles = amdsmi_get_cpusocket_handles()
-    if len(processor_handles) == 0:
+    cpu_handles = amdsmi_get_cpu_handles()
+    cpu_count = cpu_handles["cpu_count"]
+    processor_handles = cpu_handles["processor_handles"]
+    if cpu_count == 0:
         print("No CPU sockets on machine")
     else:
         for processor in processor_handles:
@@ -5869,8 +5883,10 @@ Example:
 
 ```python
 try:
-    processor_handles = amdsmi_get_cpusocket_handles()
-    if len(processor_handles) == 0:
+    cpu_handles = amdsmi_get_cpu_handles()
+    cpu_count = cpu_handles["cpu_count"]
+    processor_handles = cpu_handles["processor_handles"]
+    if cpu_count == 0:
         print("No CPU sockets on machine")
     else:
         for processor in processor_handles:
@@ -5937,8 +5953,10 @@ Example:
 
 ```python
 try:
-    processor_handles = amdsmi_get_cpusocket_handles()
-    if len(processor_handles) == 0:
+    cpu_handles = amdsmi_get_cpu_handles()
+    cpu_count = cpu_handles["cpu_count"]
+    processor_handles = cpu_handles["processor_handles"]
+    if cpu_count == 0:
         print("No CPU sockets on machine")
     else:
         for processor in processor_handles:
@@ -5970,8 +5988,10 @@ Example:
 
 ```python
 try:
-    processor_handles = amdsmi_get_cpusocket_handles()
-    if len(processor_handles) == 0:
+    cpu_handles = amdsmi_get_cpu_handles()
+    cpu_count = cpu_handles["cpu_count"]
+    processor_handles = cpu_handles["processor_handles"]
+    if cpu_count == 0:
         print("No CPU sockets on machine")
     else:
         for processor in processor_handles:
@@ -6003,8 +6023,10 @@ Example:
 
 ```python
 try:
-    processor_handles = amdsmi_get_cpusocket_handles()
-    if len(processor_handles) == 0:
+    cpu_handles = amdsmi_get_cpu_handles()
+    cpu_count = cpu_handles["cpu_count"]
+    processor_handles = cpu_handles["processor_handles"]
+    if cpu_count == 0:
         print("No CPU sockets on machine")
     else:
         for processor in processor_handles:
@@ -6036,8 +6058,10 @@ Example:
 
 ```python
 try:
-    processor_handles = amdsmi_get_cpusocket_handles()
-    if len(processor_handles) == 0:
+    cpu_handles = amdsmi_get_cpu_handles()
+    cpu_count = cpu_handles["cpu_count"]
+    processor_handles = cpu_handles["processor_handles"]
+    if cpu_count == 0:
         print("No CPU sockets on machine")
     else:
         for processor in processor_handles:
@@ -6069,8 +6093,10 @@ Example:
 
 ```python
 try:
-    processor_handles = amdsmi_get_cpusocket_handles()
-    if len(processor_handles) == 0:
+    cpu_handles = amdsmi_get_cpu_handles()
+    cpu_count = cpu_handles["cpu_count"]
+    processor_handles = cpu_handles["processor_handles"]
+    if cpu_count == 0:
         print("No CPU sockets on machine")
     else:
         for processor in processor_handles:
@@ -6113,8 +6139,10 @@ Example:
 from amdsmi import *
 try:
     ret = amdsmi_init(AmdSmiInitFlags.INIT_AMD_CPUS)
-    processor_handles = amdsmi_get_cpusocket_handles()
-    if len(processor_handles) == 0:
+    cpu_handles = amdsmi_get_cpu_handles()
+    cpu_count = cpu_handles["cpu_count"]
+    processor_handles = cpu_handles["processor_handles"]
+    if cpu_count == 0:
         print("No CPUs on machine")
     else:
         for i, processor in enumerate(processor_handles):
@@ -6174,8 +6202,10 @@ Example:
 from amdsmi import *
 try:
     ret = amdsmi_init(AmdSmiInitFlags.INIT_AMD_CPUS)
-    processor_handles = amdsmi_get_cpusocket_handles()
-    if len(processor_handles) == 0:
+    cpu_handles = amdsmi_get_cpu_handles()
+    cpu_count = cpu_handles["cpu_count"]
+    processor_handles = cpu_handles["processor_handles"]
+    if cpu_count == 0:
         print("No CPUs on machine")
     else:
         for i, processor in enumerate(processor_handles):
@@ -6254,8 +6284,10 @@ Example:
 
 ```python
 try:
-    processor_handles = amdsmi_get_cpusocket_handles()
-    if len(processor_handles) == 0:
+    cpu_handles = amdsmi_get_cpu_handles()
+    cpu_count = cpu_handles["cpu_count"]
+    processor_handles = cpu_handles["processor_handles"]
+    if cpu_count == 0:
         print("No CPU sockets on machine")
     else:
         for processor in processor_handles:
@@ -6319,8 +6351,10 @@ Example:
 
 ```python
 try:
-    processor_handles = amdsmi_get_cpusocket_handles()
-    if len(processor_handles) == 0:
+    cpu_handles = amdsmi_get_cpu_handles()
+    cpu_count = cpu_handles["cpu_count"]
+    processor_handles = cpu_handles["processor_handles"]
+    if cpu_count == 0:
         print("No CPU sockets on machine")
     else:
         for processor in processor_handles:
@@ -6351,8 +6385,10 @@ Example:
 
 ```python
 try:
-    processor_handles = amdsmi_get_cpusocket_handles()
-    if len(processor_handles) == 0:
+    cpu_handles = amdsmi_get_cpu_handles()
+    cpu_count = cpu_handles["cpu_count"]
+    processor_handles = cpu_handles["processor_handles"]
+    if cpu_count == 0:
         print("No CPU sockets on machine")
     else:
         for processor in processor_handles:
@@ -6386,8 +6422,10 @@ Example:
 
 ```python
 try:
-    processor_handles = amdsmi_get_cpusocket_handles()
-    if len(processor_handles) == 0:
+    cpu_handles = amdsmi_get_cpu_handles()
+    cpu_count = cpu_handles["cpu_count"]
+    processor_handles = cpu_handles["processor_handles"]
+    if cpu_count == 0:
         print("No CPU sockets on machine")
     else:
         for processor in processor_handles:
@@ -6420,8 +6458,10 @@ Example:
 ```python
 try:
     dimm_addr =0
-    processor_handles = amdsmi_get_cpusocket_handles()
-    if len(processor_handles) == 0:
+    cpu_handles = amdsmi_get_cpu_handles()
+    cpu_count = cpu_handles["cpu_count"]
+    processor_handles = cpu_handles["processor_handles"]
+    if cpu_count == 0:
         print("No CPU sockets on machine")
     else:
         for processor in processor_handles:
@@ -6454,8 +6494,10 @@ Example:
 ```python
 try:
     dimm_addr = 0
-    processor_handles = amdsmi_get_cpusocket_handles()
-    if len(processor_handles) == 0:
+    cpu_handles = amdsmi_get_cpu_handles()
+    cpu_count = cpu_handles["cpu_count"]
+    processor_handles = cpu_handles["processor_handles"]
+    if cpu_count == 0:
         print("No CPU sockets on machine")
     else:
         for processor in processor_handles:
@@ -6490,8 +6532,10 @@ Example:
 ```python
 try:
     dimm_addr = 0
-    processor_handles = amdsmi_get_cpusocket_handles()
-    if len(processor_handles) == 0:
+    cpu_handles = amdsmi_get_cpu_handles()
+    cpu_count = cpu_handles["cpu_count"]
+    processor_handles = cpu_handles["processor_handles"]
+    if cpu_count == 0:
         print("No CPU sockets on machine")
     else:
         for processor in processor_handles:
@@ -6526,8 +6570,10 @@ Example:
 
 ```python
 try:
-    processor_handles = amdsmi_get_cpusocket_handles()
-    if len(processor_handles) == 0:
+    cpu_handles = amdsmi_get_cpu_handles()
+    cpu_count = cpu_handles["cpu_count"]
+    processor_handles = cpu_handles["processor_handles"]
+    if cpu_count == 0:
         print("No CPU sockets on machine")
     else:
         for processor in processor_handles:
@@ -6558,8 +6604,10 @@ Example:
 
 ```python
 try:
-    processor_handles = amdsmi_get_cpusocket_handles()
-    if len(processor_handles) == 0:
+    cpu_handles = amdsmi_get_cpu_handles()
+    cpu_count = cpu_handles["cpu_count"]
+    processor_handles = cpu_handles["processor_handles"]
+    if cpu_count == 0:
         print("No CPU sockets on machine")
     else:
         for processor in processor_handles:
@@ -6590,8 +6638,10 @@ Example:
 
 ```python
 try:
-    processor_handles = amdsmi_get_cpusocket_handles()
-    if len(processor_handles) == 0:
+    cpu_handles = amdsmi_get_cpu_handles()
+    cpu_count = cpu_handles["cpu_count"]
+    processor_handles = cpu_handles["processor_handles"]
+    if cpu_count == 0:
         print("No CPU sockets on machine")
     else:
         for processor in processor_handles:
@@ -6622,8 +6672,10 @@ Example:
 
 ```python
 try:
-    processor_handles = amdsmi_get_cpusocket_handles()
-    if len(processor_handles) == 0:
+    cpu_handles = amdsmi_get_cpu_handles()
+    cpu_count = cpu_handles["cpu_count"]
+    processor_handles = cpu_handles["processor_handles"]
+    if cpu_count == 0:
         print("No CPU sockets on machine")
     else:
         for processor in processor_handles:
@@ -6654,8 +6706,10 @@ Example:
 
 ```python
 try:
-    socket_handles = amdsmi_get_cpusocket_handles()
-    if len(socket_handles) == 0:
+    cpu_handles = amdsmi_get_cpu_handles()
+    cpu_count = cpu_handles["cpu_count"]
+    processor_handles = cpu_handles["processor_handles"]
+    if cpu_count == 0:
         print("No CPU sockets on machine")
     else:
         for socket in socket_handles:
@@ -6686,8 +6740,10 @@ Example:
 
 ```python
 try:
-    processor_handles = amdsmi_get_cpusocket_handles()
-    if len(processor_handles) == 0:
+    cpu_handles = amdsmi_get_cpu_handles()
+    cpu_count = cpu_handles["cpu_count"]
+    processor_handles = cpu_handles["processor_handles"]
+    if cpu_count == 0:
         print("No CPU sockets on machine")
     else:
         for processor in processor_handles:
@@ -6720,8 +6776,10 @@ Example:
 
 ```python
 try:
-    processor_handles = amdsmi_get_cpusocket_handles()
-    if len(processor_handles) == 0:
+    cpu_handles = amdsmi_get_cpu_handles()
+    cpu_count = cpu_handles["cpu_count"]
+    processor_handles = cpu_handles["processor_handles"]
+    if cpu_count == 0:
         print("No CPU sockets on machine")
     else:
         for processor in processor_handles:
@@ -6752,8 +6810,10 @@ Example:
 
 ```python
 try:
-    processor_handles = amdsmi_get_cpusocket_handles()
-    if len(processor_handles) == 0:
+    cpu_handles = amdsmi_get_cpu_handles()
+    cpu_count = cpu_handles["cpu_count"]
+    processor_handles = cpu_handles["processor_handles"]
+    if cpu_count == 0:
         print("No CPU sockets on machine")
     else:
         for processor in processor_handles:
@@ -6785,8 +6845,10 @@ Example:
 
 ```python
 try:
-    processor_handles = amdsmi_get_cpusocket_handles()
-    if len(processor_handles) == 0:
+    cpu_handles = amdsmi_get_cpu_handles()
+    cpu_count = cpu_handles["cpu_count"]
+    processor_handles = cpu_handles["processor_handles"]
+    if cpu_count == 0:
         print("No CPU sockets on machine")
     else:
         for processor in processor_handles:
@@ -6815,8 +6877,10 @@ Example:
 
 ```python
 try:
-    processor_handles = amdsmi_get_cpusocket_handles()
-    if len(processor_handles) == 0:
+    cpu_handles = amdsmi_get_cpu_handles()
+    cpu_count = cpu_handles["cpu_count"]
+    processor_handles = cpu_handles["processor_handles"]
+    if cpu_count == 0:
         print("No CPU sockets on machine")
     else:
         encoding = 0
@@ -6850,8 +6914,10 @@ Example:
 
 ```python
 try:
-    processor_handles = amdsmi_get_cpusocket_handles()
-    if len(processor_handles) == 0:
+    cpu_handles = amdsmi_get_cpu_handles()
+    cpu_count = cpu_handles["cpu_count"]
+    processor_handles = cpu_handles["processor_handles"]
+    if cpu_count == 0:
         print("No CPU sockets on machine")
     else:
         for processor in processor_handles:
@@ -6883,8 +6949,10 @@ Example:
 
 ```python
 try:
-    processor_handles = amdsmi_get_cpusocket_handles()
-    if len(processor_handles) == 0:
+    cpu_handles = amdsmi_get_cpu_handles()
+    cpu_count = cpu_handles["cpu_count"]
+    processor_handles = cpu_handles["processor_handles"]
+    if cpu_count == 0:
         print("No CPU sockets on machine")
     else:
         for processor in processor_handles:
@@ -6922,8 +6990,10 @@ Example:
 
 ```python
 try:
-    processor_handles = amdsmi_get_cpusocket_handles()
-    if len(processor_handles) == 0:
+    cpu_handles = amdsmi_get_cpu_handles()
+    cpu_count = cpu_handles["cpu_count"]
+    processor_handles = cpu_handles["processor_handles"]
+    if cpu_count == 0:
         print("No CPU sockets on machine")
     else:
         for processor in processor_handles:
@@ -7008,8 +7078,10 @@ Example:
 
 ```python
 try:
-    processor_handles = amdsmi_get_cpusocket_handles()
-    if len(processor_handles) == 0:
+    cpu_handles = amdsmi_get_cpu_handles()
+    cpu_count = cpu_handles["cpu_count"]
+    processor_handles = cpu_handles["processor_handles"]
+    if cpu_count == 0:
         print("No CPU sockets on machine")
     else:
         for processor in processor_handles: 
@@ -7102,8 +7174,10 @@ Example:
 from amdsmi import *
 try:
     ret = amdsmi_init(AmdSmiInitFlags.INIT_AMD_CPUS)
-    processor_handles = amdsmi_get_cpusocket_handles()
-    if len(processor_handles) == 0:
+    cpu_handles = amdsmi_get_cpu_handles()
+    cpu_count = cpu_handles["cpu_count"]
+    processor_handles = cpu_handles["processor_handles"]
+    if cpu_count == 0:
         print("No CPUs on machine")
     else:
         for i, processor in enumerate(processor_handles):
@@ -7150,8 +7224,10 @@ Example:
 from amdsmi import *
 try:
     ret = amdsmi_init(AmdSmiInitFlags.INIT_AMD_CPUS)
-    processor_handles = amdsmi_get_cpusocket_handles()
-    if len(processor_handles) == 0:
+    cpu_handles = amdsmi_get_cpu_handles()
+    cpu_count = cpu_handles["cpu_count"]
+    processor_handles = cpu_handles["processor_handles"]
+    if cpu_count == 0:
         print("No CPUs on machine")
     else:
         for i, processor in enumerate(processor_handles):
@@ -7200,8 +7276,10 @@ Example:
 from amdsmi import *
 try:
     ret = amdsmi_init(AmdSmiInitFlags.INIT_AMD_CPUS)
-    processor_handles = amdsmi_get_cpusocket_handles()
-    if len(processor_handles) == 0:
+    cpu_handles = amdsmi_get_cpu_handles()
+    cpu_count = cpu_handles["cpu_count"]
+    processor_handles = cpu_handles["processor_handles"]
+    if cpu_count == 0:
         print("No CPUs on machine")
     else:
         for i, processor in enumerate(processor_handles):
@@ -7247,8 +7325,10 @@ Example:
 from amdsmi import *
 try:
     ret = amdsmi_init(AmdSmiInitFlags.INIT_AMD_CPUS)
-    processor_handles = amdsmi_get_cpusocket_handles()
-    if len(processor_handles) == 0:
+    cpu_handles = amdsmi_get_cpu_handles()
+    cpu_count = cpu_handles["cpu_count"]
+    processor_handles = cpu_handles["processor_handles"]
+    if cpu_count == 0:
         print("No CPUs on machine")
     else:
         for i, processor in enumerate(processor_handles):
@@ -7295,8 +7375,10 @@ Example:
 from amdsmi import *
 try:
     ret = amdsmi_init(AmdSmiInitFlags.INIT_AMD_CPUS)
-    processor_handles = amdsmi_get_cpusocket_handles()
-    if len(processor_handles) == 0:
+    cpu_handles = amdsmi_get_cpu_handles()
+    cpu_count = cpu_handles["cpu_count"]
+    processor_handles = cpu_handles["processor_handles"]
+    if cpu_count == 0:
         print("No CPUs on machine")
     else:
         for i, processor in enumerate(processor_handles):
@@ -7342,8 +7424,10 @@ Example:
 from amdsmi import *
 try:
     ret = amdsmi_init(AmdSmiInitFlags.INIT_AMD_CPUS)
-    processor_handles = amdsmi_get_cpusocket_handles()
-    if len(processor_handles) == 0:
+    cpu_handles = amdsmi_get_cpu_handles()
+    cpu_count = cpu_handles["cpu_count"]
+    processor_handles = cpu_handles["processor_handles"]
+    if cpu_count == 0:
         print("No CPUs on machine")
     else:
         for i, processor in enumerate(processor_handles):
@@ -7391,8 +7475,10 @@ Example:
 from amdsmi import *
 try:
     ret = amdsmi_init(AmdSmiInitFlags.INIT_AMD_CPUS)
-    processor_handles = amdsmi_get_cpusocket_handles()
-    if len(processor_handles) == 0:
+    cpu_handles = amdsmi_get_cpu_handles()
+    cpu_count = cpu_handles["cpu_count"]
+    processor_handles = cpu_handles["processor_handles"]
+    if cpu_count == 0:
         print("No CPUs on machine")
     else:
         for i, processor in enumerate(processor_handles):
@@ -7438,8 +7524,10 @@ Example:
 from amdsmi import *
 try:
     ret = amdsmi_init(AmdSmiInitFlags.INIT_AMD_CPUS)
-    processor_handles = amdsmi_get_cpusocket_handles()
-    if len(processor_handles) == 0:
+    cpu_handles = amdsmi_get_cpu_handles()
+    cpu_count = cpu_handles["cpu_count"]
+    processor_handles = cpu_handles["processor_handles"]
+    if cpu_count == 0:
         print("No CPUs on machine")
     else:
         for i, processor in enumerate(processor_handles):
@@ -7487,8 +7575,10 @@ Example:
 from amdsmi import *
 try:
     ret = amdsmi_init(AmdSmiInitFlags.INIT_AMD_CPUS)
-    processor_handles = amdsmi_get_cpusocket_handles()
-    if len(processor_handles) == 0:
+    cpu_handles = amdsmi_get_cpu_handles()
+    cpu_count = cpu_handles["cpu_count"]
+    processor_handles = cpu_handles["processor_handles"]
+    if cpu_count == 0:
         print("No CPUs on machine")
     else:
         for i, processor in enumerate(processor_handles):
@@ -7534,8 +7624,10 @@ Example:
 from amdsmi import *
 try:
     ret = amdsmi_init(AmdSmiInitFlags.INIT_AMD_CPUS)
-    processor_handles = amdsmi_get_cpusocket_handles()
-    if len(processor_handles) == 0:
+    cpu_handles = amdsmi_get_cpu_handles()
+    cpu_count = cpu_handles["cpu_count"]
+    processor_handles = cpu_handles["processor_handles"]
+    if cpu_count == 0:
         print("No CPUs on machine")
     else:
         for i, processor in enumerate(processor_handles):
@@ -7587,8 +7679,10 @@ Example:
 from amdsmi import *
 try:
     ret = amdsmi_init(AmdSmiInitFlags.INIT_AMD_CPUS)
-    processor_handles = amdsmi_get_cpusocket_handles()
-    if len(processor_handles) == 0:
+    cpu_handles = amdsmi_get_cpu_handles()
+    cpu_count = cpu_handles["cpu_count"]
+    processor_handles = cpu_handles["processor_handles"]
+    if cpu_count == 0:
         print("No CPUs on machine")
     else:
         for i, processor in enumerate(processor_handles):
@@ -7651,8 +7745,10 @@ Example:
 from amdsmi import *
 try:
     ret = amdsmi_init(AmdSmiInitFlags.INIT_AMD_CPUS)
-    processor_handles = amdsmi_get_cpusocket_handles()
-    if len(processor_handles) == 0:
+    cpu_handles = amdsmi_get_cpu_handles()
+    cpu_count = cpu_handles["cpu_count"]
+    processor_handles = cpu_handles["processor_handles"]
+    if cpu_count == 0:
         print("No CPUs on machine")
     else:
         for i, processor in enumerate(processor_handles):
@@ -7742,8 +7838,10 @@ Example:
 from amdsmi import *
 try:
     ret = amdsmi_init(AmdSmiInitFlags.INIT_AMD_CPUS)
-    processor_handles = amdsmi_get_cpusocket_handles()
-    if len(processor_handles) == 0:
+    cpu_handles = amdsmi_get_cpu_handles()
+    cpu_count = cpu_handles["cpu_count"]
+    processor_handles = cpu_handles["processor_handles"]
+    if cpu_count == 0:
         print("No CPUs on machine")
     else:
         for i, processor in enumerate(processor_handles):
@@ -7794,8 +7892,10 @@ Example:
 from amdsmi import *
 try:
     ret = amdsmi_init(AmdSmiInitFlags.INIT_AMD_CPUS)
-    processor_handles = amdsmi_get_cpusocket_handles()
-    if len(processor_handles) == 0:
+    cpu_handles = amdsmi_get_cpu_handles()
+    cpu_count = cpu_handles["cpu_count"]
+    processor_handles = cpu_handles["processor_handles"]
+    if cpu_count == 0:
         print("No CPUs on machine")
     else:
         for i, processor in enumerate(processor_handles):
@@ -7849,8 +7949,10 @@ Example:
 from amdsmi import *
 try:
     ret = amdsmi_init(AmdSmiInitFlags.INIT_AMD_CPUS)
-    processor_handles = amdsmi_get_cpusocket_handles()
-    if len(processor_handles) == 0:
+    cpu_handles = amdsmi_get_cpu_handles()
+    cpu_count = cpu_handles["cpu_count"]
+    processor_handles = cpu_handles["processor_handles"]
+    if cpu_count == 0:
         print("No CPUs on machine")
     else:
         for i, processor in enumerate(processor_handles):
@@ -7983,8 +8085,10 @@ Example:
 from amdsmi import *
 try:
     ret = amdsmi_init(AmdSmiInitFlags.INIT_AMD_CPUS)
-    processor_handles = amdsmi_get_cpusocket_handles()
-    if len(processor_handles) == 0:
+    cpu_handles = amdsmi_get_cpu_handles()
+    cpu_count = cpu_handles["cpu_count"]
+    processor_handles = cpu_handles["processor_handles"]
+    if cpu_count == 0:
         print("No CPUs on machine")
     else:
         for i, processor in enumerate(processor_handles):
@@ -8024,8 +8128,10 @@ Example:
 from amdsmi import *
 try:
     ret = amdsmi_init(AmdSmiInitFlags.INIT_AMD_CPUS)
-    processor_handles = amdsmi_get_cpusocket_handles()
-    if len(processor_handles) == 0:
+    cpu_handles = amdsmi_get_cpu_handles()
+    cpu_count = cpu_handles["cpu_count"]
+    processor_handles = cpu_handles["processor_handles"]
+    if cpu_count == 0:
         print("No CPUs on machine")
     else:
         for i, processor in enumerate(processor_handles):
@@ -8145,8 +8251,10 @@ Example:
 from amdsmi import *
 try:
     ret = amdsmi_init(AmdSmiInitFlags.INIT_AMD_CPUS)
-    processor_handles = amdsmi_get_cpusocket_handles()
-    if len(processor_handles) == 0:
+    cpu_handles = amdsmi_get_cpu_handles()
+    cpu_count = cpu_handles["cpu_count"]
+    processor_handles = cpu_handles["processor_handles"]
+    if cpu_count == 0:
         print("No CPUs on machine")
     else:
         for i, processor in enumerate(processor_handles):
@@ -8193,8 +8301,10 @@ Example:
 from amdsmi import *
 try:
     ret = amdsmi_init(AmdSmiInitFlags.INIT_AMD_CPUS)
-    processor_handles = amdsmi_get_cpusocket_handles()
-    if len(processor_handles) == 0:
+    cpu_handles = amdsmi_get_cpu_handles()
+    cpu_count = cpu_handles["cpu_count"]
+    processor_handles = cpu_handles["processor_handles"]
+    if cpu_count == 0:
         print("No CPUs on machine")
     else:
         for i, processor in enumerate(processor_handles):
@@ -8285,8 +8395,10 @@ Example:
 from amdsmi import *
 try:
     ret = amdsmi_init(AmdSmiInitFlags.INIT_AMD_CPUS)
-    processor_handles = amdsmi_get_cpusocket_handles()
-    if len(processor_handles) == 0:
+    cpu_handles = amdsmi_get_cpu_handles()
+    cpu_count = cpu_handles["cpu_count"]
+    processor_handles = cpu_handles["processor_handles"]
+    if cpu_count == 0:
         print("No CPUs on machine")
     else:
         for i, processor in enumerate(processor_handles):
@@ -8332,8 +8444,10 @@ Example:
 from amdsmi import *
 try:
     ret = amdsmi_init(AmdSmiInitFlags.INIT_AMD_CPUS)
-    processor_handles = amdsmi_get_cpusocket_handles()
-    if len(processor_handles) == 0:
+    cpu_handles = amdsmi_get_cpu_handles()
+    cpu_count = cpu_handles["cpu_count"]
+    processor_handles = cpu_handles["processor_handles"]
+    if cpu_count == 0:
         print("No CPUs on machine")
     else:
         for i, processor in enumerate(processor_handles):

--- a/projects/amdsmi/py-interface/__init__.py
+++ b/projects/amdsmi/py-interface/__init__.py
@@ -36,7 +36,7 @@ from .amdsmi_interface import amdsmi_get_npm_info
 
 # ESMI Dependent Functions
 try:
-    from .amdsmi_interface import amdsmi_get_cpusocket_handles
+    from .amdsmi_interface import amdsmi_get_cpu_handles
     from .amdsmi_interface import amdsmi_get_cpucore_handles
     from .amdsmi_interface import amdsmi_get_processor_info
     from .amdsmi_interface import amdsmi_get_cpu_hsmp_proto_ver
@@ -83,7 +83,6 @@ try:
     from .amdsmi_interface import amdsmi_get_cpu_family
     from .amdsmi_interface import amdsmi_get_cpu_model
     from .amdsmi_interface import amdsmi_get_cpu_model_name
-    from .amdsmi_interface import amdsmi_get_cpu_handles
     from .amdsmi_interface import amdsmi_set_cpu_xgmi_pstate_range
     from .amdsmi_interface import amdsmi_get_cpu_xgmi_pstate_range
     from .amdsmi_interface import amdsmi_set_cpu_rail_isofreq_policy

--- a/projects/amdsmi/py-interface/__init__.py
+++ b/projects/amdsmi/py-interface/__init__.py
@@ -37,6 +37,7 @@ from .amdsmi_interface import amdsmi_get_npm_info
 # ESMI Dependent Functions
 try:
     from .amdsmi_interface import amdsmi_get_cpu_handles
+    from .amdsmi_interface import amdsmi_get_cpusocket_handles  # Deprecate in 8.0
     from .amdsmi_interface import amdsmi_get_cpucore_handles
     from .amdsmi_interface import amdsmi_get_processor_info
     from .amdsmi_interface import amdsmi_get_cpu_hsmp_proto_ver

--- a/projects/amdsmi/py-interface/amdsmi_interface.py
+++ b/projects/amdsmi/py-interface/amdsmi_interface.py
@@ -1075,7 +1075,7 @@ def amdsmi_get_socket_handles() -> List[c_void_p]:
     return sockets
 
 
-def amdsmi_get_cpu_handles() -> List[c_void_p]:
+def amdsmi_get_cpu_handles() -> Dict[str, Any]:
     """
     Function that gets cpu socket handles. Wraps the same named function call.
 
@@ -1083,7 +1083,9 @@ def amdsmi_get_cpu_handles() -> List[c_void_p]:
         `None`.
 
     Returns:
-        `List`: List containing all of the found cpu socket handles.
+        `Dict[str, Any]`: Dictionary with keys:
+            - ``cpu_count`` (`int`): Number of CPU socket handles found.
+            - ``processor_handles`` (`List[c_void_p]`): List of CPU socket handles.
     """
     cpu_count = ctypes.c_uint32(0)
     null_ptr = POINTER(amdsmi_wrapper.amdsmi_processor_handle)()
@@ -1095,6 +1097,24 @@ def amdsmi_get_cpu_handles() -> List[c_void_p]:
         for sock_idx in range(cpu_count.value)
     ]
     return {"cpu_count": len(cpu_handles), "processor_handles": cpu_handles}
+
+
+def amdsmi_get_cpusocket_handles() -> List[c_void_p]:
+    """Deprecated: Use amdsmi_get_cpu_handles() instead.\
+        Will be deprecated in Rocm 8.0.
+
+    Returns:
+        `List[c_void_p]`: List of CPU socket handles (legacy format).
+    """
+    import warnings
+
+    warnings.warn(
+        "amdsmi_get_cpusocket_handles() is deprecated, use amdsmi_get_cpu_handles() instead",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+    result = amdsmi_get_cpu_handles()
+    return result["processor_handles"]
 
 
 def amdsmi_get_socket_info(socket_handle):

--- a/projects/amdsmi/py-interface/amdsmi_interface.py
+++ b/projects/amdsmi/py-interface/amdsmi_interface.py
@@ -1075,7 +1075,7 @@ def amdsmi_get_socket_handles() -> List[c_void_p]:
     return sockets
 
 
-def amdsmi_get_cpusocket_handles() -> List[c_void_p]:
+def amdsmi_get_cpu_handles() -> List[c_void_p]:
     """
     Function that gets cpu socket handles. Wraps the same named function call.
 
@@ -1094,7 +1094,7 @@ def amdsmi_get_cpusocket_handles() -> List[c_void_p]:
         amdsmi_wrapper.amdsmi_processor_handle(proc_handles[sock_idx])
         for sock_idx in range(cpu_count.value)
     ]
-    return cpu_handles
+    return {"cpu_count": len(cpu_handles), "processor_handles": cpu_handles}
 
 
 def amdsmi_get_socket_info(socket_handle):
@@ -6705,11 +6705,6 @@ def amdsmi_get_rocm_version() -> Tuple[bool, str]:
         return False, "Could not find librocm-core.so"
     except Exception as e:
         return False, f"Unable to detect ROCm installation, Unknown Error: {e}"
-
-
-def amdsmi_get_cpu_handles() -> Dict[str, Any]:
-    cpu_handles = amdsmi_get_cpusocket_handles()
-    return {"cpu_count": len(cpu_handles), "processor_handles": cpu_handles}
 
 
 def amdsmi_get_esmi_err_msg(status: AmdSmiStatus) -> str:

--- a/projects/amdsmi/tests/python_unittest/integration_test.py
+++ b/projects/amdsmi/tests/python_unittest/integration_test.py
@@ -646,7 +646,8 @@ class TestAmdSmiPython(unittest.TestCase):
         self.common.print_func_name("")
 
         try:
-            cpu_processors = amdsmi.amdsmi_get_cpusocket_handles()
+            ret = amdsmi.amdsmi_get_cpu_handles()
+            cpu_processors = ret["processor_handles"]
         except amdsmi.AmdSmiLibraryException:
             cpu_processors = []
         if not cpu_processors:
@@ -701,7 +702,8 @@ class TestAmdSmiPython(unittest.TestCase):
         self.common.print_func_name("")
 
         try:
-            cpu_processors = amdsmi.amdsmi_get_cpusocket_handles()
+            ret = amdsmi.amdsmi_get_cpu_handles()
+            cpu_processors = ret["processor_handles"]
         except amdsmi.AmdSmiLibraryException:
             cpu_processors = []
         if not cpu_processors:

--- a/projects/amdsmi/tests/python_unittest/perf_cputests.py
+++ b/projects/amdsmi/tests/python_unittest/perf_cputests.py
@@ -49,7 +49,7 @@ except ImportError as exc:
 from amdsmi import (
     amdsmi_init,
     amdsmi_shut_down,
-    amdsmi_get_cpusocket_handles,
+    amdsmi_get_cpu_handles,
     amdsmi_get_cpu_hsmp_driver_version,
     AmdSmiInitFlags,
     AmdSmiException,
@@ -476,7 +476,8 @@ class TestAmdSmiCPUPythonPerformance(unittest.TestCase):
         # Use pstate=0 from original test
         pstate = 0
         i = 0
-        processor_handles = amdsmi.amdsmi_get_cpusocket_handles()
+        ret = amdsmi.amdsmi_get_cpu_handles()
+        processor_handles = ret["processor_handles"]
         if len(processor_handles) == 0:
             print("No CPU sockets on machine")
         else:
@@ -503,7 +504,8 @@ class TestAmdSmiCPUPythonPerformance(unittest.TestCase):
     def test_performance_cpu_apb_enable(self):
         self._print_func_name("Starting performance test for amdsmi_cpu_apb_enable")
         i = 0
-        processor_handles = amdsmi.amdsmi_get_cpusocket_handles()
+        ret = amdsmi.amdsmi_get_cpu_handles()
+        processor_handles = ret["processor_handles"]
 
         if len(processor_handles) == 0:
             print("No CPU sockets on machine")
@@ -535,7 +537,8 @@ class TestAmdSmiCPUPythonPerformance(unittest.TestCase):
             "Starting performance test for amdsmi_first_online_core_on_cpu_socket"
         )
         i = 0
-        processor_handles = amdsmi.amdsmi_get_cpusocket_handles()
+        ret = amdsmi.amdsmi_get_cpu_handles()
+        processor_handles = ret["processor_handles"]
 
         if len(processor_handles) == 0:
             print("No CPU sockets on machine")
@@ -572,7 +575,8 @@ class TestAmdSmiCPUPythonPerformance(unittest.TestCase):
     def test_performance_get_cpu_cclk_limit(self):
         self._print_func_name("Starting performance test for amdsmi_get_cpu_cclk_limit")
         i = 0
-        processor_handles = amdsmi.amdsmi_get_cpusocket_handles()
+        ret = amdsmi.amdsmi_get_cpu_handles()
+        processor_handles = ret["processor_handles"]
 
         if len(processor_handles) == 0:
             print("No CPU sockets on machine")
@@ -606,7 +610,8 @@ class TestAmdSmiCPUPythonPerformance(unittest.TestCase):
             "Starting performance test for amdsmi_get_cpu_core_current_freq_limit"
         )
         i = 0
-        processor_handles = amdsmi.amdsmi_get_cpusocket_handles()
+        ret = amdsmi.amdsmi_get_cpu_handles()
+        processor_handles = ret["processor_handles"]
 
         if len(processor_handles) == 0:
             print("No CPU sockets on machine")
@@ -642,7 +647,8 @@ class TestAmdSmiCPUPythonPerformance(unittest.TestCase):
     def test_performance_get_cpu_core_energy(self):
         self._print_func_name("Starting performance test for amdsmi_get_cpu_core_energy")
         i = 0
-        processor_handles = amdsmi.amdsmi_get_cpusocket_handles()
+        ret = amdsmi.amdsmi_get_cpu_handles()
+        processor_handles = ret["processor_handles"]
 
         if len(processor_handles) == 0:
             print("No CPU sockets on machine")
@@ -676,7 +682,8 @@ class TestAmdSmiCPUPythonPerformance(unittest.TestCase):
     def test_performance_get_cpu_current_io_bandwidth(self):
         self._print_func_name("Starting performance test for amdsmi_get_cpu_current_io_bandwidth")
         i = 0
-        processor_handles = amdsmi.amdsmi_get_cpusocket_handles()
+        ret = amdsmi.amdsmi_get_cpu_handles()
+        processor_handles = ret["processor_handles"]
 
         if len(processor_handles) == 0:
             print("No CPU sockets on machine")
@@ -716,7 +723,8 @@ class TestAmdSmiCPUPythonPerformance(unittest.TestCase):
     def test_performance_get_cpu_ddr_bw(self):
         self._print_func_name("Starting performance test for amdsmi_get_cpu_ddr_bw")
         i = 0
-        processor_handles = amdsmi.amdsmi_get_cpusocket_handles()
+        ret = amdsmi.amdsmi_get_cpu_handles()
+        processor_handles = ret["processor_handles"]
 
         if len(processor_handles) == 0:
             print("No CPU sockets on machine")
@@ -747,7 +755,8 @@ class TestAmdSmiCPUPythonPerformance(unittest.TestCase):
         self._print_func_name("Starting performance test for amdsmi_get_cpu_dimm_power_consumption")
         i = 0
         dimm_addr = 0
-        processor_handles = amdsmi.amdsmi_get_cpusocket_handles()
+        ret = amdsmi.amdsmi_get_cpu_handles()
+        processor_handles = ret["processor_handles"]
 
         if len(processor_handles) == 0:
             print("No CPU sockets on machine")
@@ -787,7 +796,8 @@ class TestAmdSmiCPUPythonPerformance(unittest.TestCase):
         )
         dimm_addr = 0
         i = 0
-        processor_handles = amdsmi.amdsmi_get_cpusocket_handles()
+        ret = amdsmi.amdsmi_get_cpu_handles()
+        processor_handles = ret["processor_handles"]
 
         if len(processor_handles) == 0:
             print("No CPU sockets on machine")
@@ -830,7 +840,8 @@ class TestAmdSmiCPUPythonPerformance(unittest.TestCase):
         self._print_func_name("Starting performance test for amdsmi_get_cpu_dimm_thermal_sensor")
         dimm_addr = 0
         i = 0
-        processor_handles = amdsmi.amdsmi_get_cpusocket_handles()
+        ret = amdsmi.amdsmi_get_cpu_handles()
+        processor_handles = ret["processor_handles"]
 
         if len(processor_handles) == 0:
             print("No CPU sockets on machine")
@@ -884,7 +895,8 @@ class TestAmdSmiCPUPythonPerformance(unittest.TestCase):
     def test_performance_get_cpu_fclk_mclk(self):
         self._print_func_name("Starting performance test for amdsmi_get_cpu_fclk_mclk")
         i = 0
-        processor_handles = amdsmi.amdsmi_get_cpusocket_handles()
+        ret = amdsmi.amdsmi_get_cpu_handles()
+        processor_handles = ret["processor_handles"]
 
         if len(processor_handles) == 0:
             print("No CPU sockets on machine")
@@ -933,7 +945,8 @@ class TestAmdSmiCPUPythonPerformance(unittest.TestCase):
     def test_performance_get_cpu_hsmp_driver_version(self):
         self._print_func_name("Starting performance test for amdsmi_get_cpu_hsmp_driver_version")
         i = 0
-        processor_handles = amdsmi.amdsmi_get_cpusocket_handles()
+        ret = amdsmi.amdsmi_get_cpu_handles()
+        processor_handles = ret["processor_handles"]
 
         if len(processor_handles) == 0:
             print("No CPU sockets on machine")
@@ -967,7 +980,8 @@ class TestAmdSmiCPUPythonPerformance(unittest.TestCase):
     def test_performance_get_cpu_hsmp_proto_ver(self):
         self._print_func_name("Starting performance test for amdsmi_get_cpu_hsmp_proto_ver")
         i = 0
-        processor_handles = amdsmi.amdsmi_get_cpusocket_handles()
+        ret = amdsmi.amdsmi_get_cpu_handles()
+        processor_handles = ret["processor_handles"]
 
         if len(processor_handles) == 0:
             print("No CPU sockets on machine")
@@ -1018,7 +1032,8 @@ class TestAmdSmiCPUPythonPerformance(unittest.TestCase):
     def test_performance_get_cpu_prochot_status(self):
         self._print_func_name("Starting performance test for amdsmi_get_cpu_prochot_status")
         i = 0
-        processor_handles = amdsmi.amdsmi_get_cpusocket_handles()
+        ret = amdsmi.amdsmi_get_cpu_handles()
+        processor_handles = ret["processor_handles"]
 
         if len(processor_handles) == 0:
             print("No CPU sockets on machine")
@@ -1054,7 +1069,8 @@ class TestAmdSmiCPUPythonPerformance(unittest.TestCase):
             "Starting performance test for amdsmi_get_cpu_pwr_svi_telemetry_all_rails"
         )
         i = 0
-        processor_handles = amdsmi.amdsmi_get_cpusocket_handles()
+        ret = amdsmi.amdsmi_get_cpu_handles()
+        processor_handles = ret["processor_handles"]
 
         if len(processor_handles) == 0:
             print("No CPU sockets on machine")
@@ -1088,7 +1104,8 @@ class TestAmdSmiCPUPythonPerformance(unittest.TestCase):
     def test_performance_get_cpu_smu_fw_version(self):
         self._print_func_name("Starting performance test for amdsmi_get_cpu_smu_fw_version")
         i = 0
-        processor_handles = amdsmi.amdsmi_get_cpusocket_handles()
+        ret = amdsmi.amdsmi_get_cpu_handles()
+        processor_handles = ret["processor_handles"]
 
         if len(processor_handles) == 0:
             print("No CPU sockets on machine")
@@ -1122,7 +1139,8 @@ class TestAmdSmiCPUPythonPerformance(unittest.TestCase):
     def test_performance_get_cpu_socket_c0_residency(self):
         self._print_func_name("Starting performance test for amdsmi_get_cpu_socket_c0_residency")
         i = 0
-        processor_handles = amdsmi.amdsmi_get_cpusocket_handles()
+        ret = amdsmi.amdsmi_get_cpu_handles()
+        processor_handles = ret["processor_handles"]
 
         if len(processor_handles) == 0:
             print("No CPU sockets on machine")
@@ -1158,7 +1176,8 @@ class TestAmdSmiCPUPythonPerformance(unittest.TestCase):
             "Starting performance test for amdsmi_get_cpu_socket_current_active_freq_limit"
         )
         i = 0
-        processor_handles = amdsmi.amdsmi_get_cpusocket_handles()
+        ret = amdsmi.amdsmi_get_cpu_handles()
+        processor_handles = ret["processor_handles"]
 
         if len(processor_handles) == 0:
             print("No CPU sockets on machine")
@@ -1196,7 +1215,8 @@ class TestAmdSmiCPUPythonPerformance(unittest.TestCase):
     def test_performance_get_cpu_socket_energy(self):
         self._print_func_name("Starting performance test for amdsmi_get_cpu_socket_energy")
         i = 0
-        processor_handles = amdsmi.amdsmi_get_cpusocket_handles()
+        ret = amdsmi.amdsmi_get_cpu_handles()
+        processor_handles = ret["processor_handles"]
 
         if len(processor_handles) == 0:
             print("No CPU sockets on machine")
@@ -1230,7 +1250,8 @@ class TestAmdSmiCPUPythonPerformance(unittest.TestCase):
     def test_performance_get_cpu_socket_freq_range(self):
         self._print_func_name("Starting performance test for amdsmi_get_cpu_socket_freq_range")
         i = 0
-        processor_handles = amdsmi.amdsmi_get_cpusocket_handles()
+        ret = amdsmi.amdsmi_get_cpu_handles()
+        processor_handles = ret["processor_handles"]
 
         if len(processor_handles) == 0:
             print("No CPU sockets on machine")
@@ -1265,7 +1286,8 @@ class TestAmdSmiCPUPythonPerformance(unittest.TestCase):
         self._print_func_name("Starting performance test for amdsmi_get_cpu_socket_lclk_dpm_level")
         nbio_id = 0
         i = 0
-        processor_handles = amdsmi.amdsmi_get_cpusocket_handles()
+        ret = amdsmi.amdsmi_get_cpu_handles()
+        processor_handles = ret["processor_handles"]
 
         if len(processor_handles) == 0:
             print("No CPU sockets on machine")
@@ -1302,7 +1324,8 @@ class TestAmdSmiCPUPythonPerformance(unittest.TestCase):
     def test_performance_get_cpu_socket_power(self):
         self._print_func_name("Starting performance test for amdsmi_get_cpu_socket_power")
         i = 0
-        processor_handles = amdsmi.amdsmi_get_cpusocket_handles()
+        ret = amdsmi.amdsmi_get_cpu_handles()
+        processor_handles = ret["processor_handles"]
 
         if len(processor_handles) == 0:
             print("No CPU sockets on machine")
@@ -1335,7 +1358,8 @@ class TestAmdSmiCPUPythonPerformance(unittest.TestCase):
     def test_performance_get_cpu_socket_power_cap_max(self):
         self._print_func_name("Starting performance test for amdsmi_get_cpu_socket_power_cap_max")
         i = 0
-        processor_handles = amdsmi.amdsmi_get_cpusocket_handles()
+        ret = amdsmi.amdsmi_get_cpu_handles()
+        processor_handles = ret["processor_handles"]
 
         if len(processor_handles) == 0:
             print("No CPU sockets on machine")
@@ -1368,7 +1392,8 @@ class TestAmdSmiCPUPythonPerformance(unittest.TestCase):
     def test_performance_get_cpu_socket_temperature(self):
         self._print_func_name("Starting performance test for amdsmi_get_cpu_socket_temperature")
         i = 0
-        processor_handles = amdsmi.amdsmi_get_cpusocket_handles()
+        ret = amdsmi.amdsmi_get_cpu_handles()
+        processor_handles = ret["processor_handles"]
 
         if len(processor_handles) == 0:
             print("No CPU sockets on machine")
@@ -1426,7 +1451,8 @@ class TestAmdSmiCPUPythonPerformance(unittest.TestCase):
     def test_performance_get_hsmp_metrics_table(self):
         self._print_func_name("Starting performance test for amdsmi_get_hsmp_metrics_table")
         i = 0
-        processor_handles = amdsmi.amdsmi_get_cpusocket_handles()
+        ret = amdsmi.amdsmi_get_cpu_handles()
+        processor_handles = ret["processor_handles"]
 
         if len(processor_handles) == 0:
             print("No CPU sockets on machine")
@@ -1458,7 +1484,8 @@ class TestAmdSmiCPUPythonPerformance(unittest.TestCase):
     def test_performance_get_hsmp_metrics_table_version(self):
         self._print_func_name("Starting performance test for amdsmi_get_hsmp_metrics_table_version")
         i = 0
-        processor_handles = amdsmi.amdsmi_get_cpusocket_handles()
+        ret = amdsmi.amdsmi_get_cpu_handles()
+        processor_handles = ret["processor_handles"]
 
         if len(processor_handles) == 0:
             print("No CPU sockets on machine")
@@ -1512,7 +1539,8 @@ class TestAmdSmiCPUPythonPerformance(unittest.TestCase):
         # Test with different rate_ctrl values
         rate_ctrls = [0]  # Starting with 0 as in original test
         i = 0
-        processor_handles = amdsmi.amdsmi_get_cpusocket_handles()
+        ret = amdsmi.amdsmi_get_cpu_handles()
+        processor_handles = ret["processor_handles"]
 
         if len(processor_handles) == 0:
             print("No CPU sockets on machine")
@@ -1580,7 +1608,8 @@ class TestAmdSmiCPUPythonPerformance(unittest.TestCase):
     def test_performance_get_processor_handle_from_bdf(self):
         self._print_func_name("Starting performance test for amdsmi_get_processor_handle_from_bdf")
         i = 0
-        processor_handles = amdsmi.amdsmi_get_cpusocket_handles()
+        ret = amdsmi.amdsmi_get_cpu_handles()
+        processor_handles = ret["processor_handles"]
 
         if len(processor_handles) == 0:
             print("No CPU sockets on machine")
@@ -1692,7 +1721,8 @@ class TestAmdSmiCPUPythonPerformance(unittest.TestCase):
     def test_performance_get_processor_info(self):
         self._print_func_name("Starting performance test for amdsmi_get_processor_info")
         i = 0
-        processor_handles = amdsmi.amdsmi_get_cpusocket_handles()
+        ret = amdsmi.amdsmi_get_cpu_handles()
+        processor_handles = ret["processor_handles"]
 
         if len(processor_handles) == 0:
             print("No CPU sockets on machine")
@@ -1721,7 +1751,8 @@ class TestAmdSmiCPUPythonPerformance(unittest.TestCase):
     def test_performance_get_processor_type(self):
         self._print_func_name("Starting performance test for amdsmi_get_processor_type")
         i = 0
-        processor_handles = amdsmi.amdsmi_get_cpusocket_handles()
+        ret = amdsmi.amdsmi_get_cpu_handles()
+        processor_handles = ret["processor_handles"]
 
         if len(processor_handles) == 0:
             print("No CPU sockets on machine")
@@ -1798,7 +1829,8 @@ class TestAmdSmiCPUPythonPerformance(unittest.TestCase):
     def test_performance_get_temp_metric(self):
         self._print_func_name("Starting performance test for amdsmi_get_temp_metric")
         i = 0
-        processor_handles = amdsmi.amdsmi_get_cpusocket_handles()
+        ret = amdsmi.amdsmi_get_cpu_handles()
+        processor_handles = ret["processor_handles"]
 
         if len(processor_handles) == 0:
             print("No CPU sockets on machine")
@@ -1918,7 +1950,8 @@ class TestAmdSmiCPUPythonPerformance(unittest.TestCase):
     def test_performance_cpu_core_boostlimit(self):
         self._print_func_name("Starting performance test for CPU core boostlimit workflow")
         i = 0
-        processor_handles = amdsmi.amdsmi_get_cpusocket_handles()
+        ret = amdsmi.amdsmi_get_cpu_handles()
+        processor_handles = ret["processor_handles"]
 
         if len(processor_handles) == 0:
             print("No CPU sockets on machine")
@@ -1976,7 +2009,8 @@ class TestAmdSmiCPUPythonPerformance(unittest.TestCase):
         max_pstate = 0
         min_pstate = 0
         i = 0
-        processor_handles = amdsmi.amdsmi_get_cpusocket_handles()
+        ret = amdsmi.amdsmi_get_cpu_handles()
+        processor_handles = ret["processor_handles"]
 
         if len(processor_handles) == 0:
             print("No CPU sockets on machine")
@@ -2021,7 +2055,8 @@ class TestAmdSmiCPUPythonPerformance(unittest.TestCase):
         min_link_width = 0
         max_link_width = 0
         i = 0
-        processor_handles = amdsmi.amdsmi_get_cpusocket_handles()
+        ret = amdsmi.amdsmi_get_cpu_handles()
+        processor_handles = ret["processor_handles"]
 
         if len(processor_handles) == 0:
             print("No CPU sockets on machine")
@@ -2065,7 +2100,8 @@ class TestAmdSmiCPUPythonPerformance(unittest.TestCase):
         # Use modes from original test
         modes = [0, 1, 2]
         i = 0
-        processor_handles = amdsmi.amdsmi_get_cpusocket_handles()
+        ret = amdsmi.amdsmi_get_cpu_handles()
+        processor_handles = ret["processor_handles"]
 
         if len(processor_handles) == 0:
             print("No CPU sockets on machine")
@@ -2108,7 +2144,8 @@ class TestAmdSmiCPUPythonPerformance(unittest.TestCase):
         # Use TODO placeholder value like original test
         boost_limit = 0
         i = 0
-        processor_handles = amdsmi.amdsmi_get_cpusocket_handles()
+        ret = amdsmi.amdsmi_get_cpu_handles()
+        processor_handles = ret["processor_handles"]
 
         if len(processor_handles) == 0:
             print("No CPU sockets on machine")
@@ -2149,7 +2186,8 @@ class TestAmdSmiCPUPythonPerformance(unittest.TestCase):
         min_val = 0
         max_val = 0
         i = 0
-        processor_handles = amdsmi.amdsmi_get_cpusocket_handles()
+        ret = amdsmi.amdsmi_get_cpu_handles()
+        processor_handles = ret["processor_handles"]
 
         if len(processor_handles) == 0:
             print("No CPU sockets on machine")
@@ -2192,7 +2230,8 @@ class TestAmdSmiCPUPythonPerformance(unittest.TestCase):
     def test_performance_cpu_socket_power_cap(self):
         self._print_func_name("Starting performance test for CPU socket power cap workflow")
         i = 0
-        processor_handles = amdsmi.amdsmi_get_cpusocket_handles()
+        ret = amdsmi.amdsmi_get_cpu_handles()
+        processor_handles = ret["processor_handles"]
 
         if len(processor_handles) == 0:
             print("No CPU sockets on machine")
@@ -2246,7 +2285,8 @@ class TestAmdSmiCPUPythonPerformance(unittest.TestCase):
         min_width = 0
         max_width = 0
         i = 0
-        processor_handles = amdsmi.amdsmi_get_cpusocket_handles()
+        ret = amdsmi.amdsmi_get_cpu_handles()
+        processor_handles = ret["processor_handles"]
 
         if len(processor_handles) == 0:
             print("No CPU sockets on machine")

--- a/projects/amdsmi/tests/python_unittest/unit_tests.py
+++ b/projects/amdsmi/tests/python_unittest/unit_tests.py
@@ -1720,7 +1720,8 @@ class TestAmdSmiPython(unittest.TestCase):
         self.common.print_func_name("")
 
         try:
-            cpu_processors = amdsmi.amdsmi_get_cpusocket_handles()
+            ret = amdsmi.amdsmi_get_cpu_handles()
+            cpu_processors = ret["processor_handles"]
         except amdsmi.AmdSmiLibraryException:
             cpu_processors = []
         if not cpu_processors:

--- a/projects/amdsmi/tools/amdsmi_quick_start.py
+++ b/projects/amdsmi/tools/amdsmi_quick_start.py
@@ -72,7 +72,8 @@ signal.signal(signal.SIGTERM, signal_handler)
 atexit.register(amdsmi_shut_down)
 
 gpus = amdsmi_get_processor_handles()
-cpus = amdsmi_get_cpusocket_handles()
+ret = amdsmi_get_cpu_handles()
+cpus = ret["processor_handles"]
 
 print(f"gpus variable populated with:{gpus}")
 print(f"cpus variable populated with:{cpus}")


### PR DESCRIPTION
## Motivation

This change addresses technical debt by removing a deprecated API and consolidating CPU handle management. The motivation is:
	- API Standardization: Eliminates duplicate functionality between amdsmi_get_cpusocket_handles() and amdsmi_get_cpu_handles()
	- Enhanced Return Information: The newer API provides both CPU count and handles in structured format
	- Maintenance Reduction: Removes deprecated code paths that require ongoing support

## Technical Details

Key Architectural Improvements
	1. Structured Return Format
	2. Consistent Error Handling
		change maintains the same exception handling patterns across all usage sites.
	3. Import Reorganization
		Removed amdsmi_get_cpusocket_handles() from public API exports

## Test Plan

C++ (amdsmitst): N/A — Python interface changes only
Python: Ran full test suite including updated integration and performance tests
Python: Ran amd-smi cli

## Test Result

python unit_tests.py and integration.py tests passed
amdsmi_cli.py ran without issues

