### PR TITLE
[rocprofiler-sdk][attach] Stop rocprofiler contexts in tool_detach() 

### DIFF
--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-tool/tool.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-tool/tool.cpp
@@ -3109,18 +3109,8 @@ tool_detach(void* /*tool_data*/)
 {
     auto _detach_timer = common::simple_timer{"[rocprofv3] tool detachment"};
 
-<<<<<<< HEAD
-    // Set process end timestamp for this detachment cycle
-    if(tool_metadata->process_end_ns == 0)
-        rocprofiler_get_timestamp(&(tool_metadata->process_end_ns));
-
-    // Flush buffered records, stop the context to prevent further callbacks and
-    // finalize tracing state, then flush again to capture any final records
-    // emitted during shutdown (same pattern as tool_fini)
-=======
     // Flush all buffers, stop context to ensure in-flight GPU operations complete,
     // then flush again to capture any final events (same pattern as tool_fini)
->>>>>>> 4dbf48977c (Fix detach end timestamp ordering)
     flush();
     rocprofiler_stop_context(get_client_ctx());
     flush();

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-tool/tool.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-tool/tool.cpp
@@ -3113,8 +3113,9 @@ tool_detach(void* /*tool_data*/)
     if(tool_metadata->process_end_ns == 0)
         rocprofiler_get_timestamp(&(tool_metadata->process_end_ns));
 
-    // Flush all buffers, stop context to ensure in-flight GPU operations complete,
-    // then flush again to capture any final events (same pattern as tool_fini)
+    // Flush buffered records, stop the context to prevent further callbacks and
+    // finalize tracing state, then flush again to capture any final records
+    // emitted during shutdown (same pattern as tool_fini)
     flush();
     rocprofiler_stop_context(get_client_ctx());
     flush();

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-tool/tool.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-tool/tool.cpp
@@ -3109,12 +3109,15 @@ tool_detach(void* /*tool_data*/)
 {
     auto _detach_timer = common::simple_timer{"[rocprofv3] tool detachment"};
 
-    // Flush all buffers (same as tool_fini)
-    flush();
-
     // Set process end timestamp for this detachment cycle
     if(tool_metadata->process_end_ns == 0)
         rocprofiler_get_timestamp(&(tool_metadata->process_end_ns));
+
+    // Flush all buffers, stop context to ensure in-flight GPU operations complete,
+    // then flush again to capture any final events (same pattern as tool_fini)
+    flush();
+    rocprofiler_stop_context(get_client_ctx());
+    flush();
 
     generate_output(cleanup_mode::reset);
 }

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-tool/tool.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-tool/tool.cpp
@@ -3109,6 +3109,7 @@ tool_detach(void* /*tool_data*/)
 {
     auto _detach_timer = common::simple_timer{"[rocprofv3] tool detachment"};
 
+<<<<<<< HEAD
     // Set process end timestamp for this detachment cycle
     if(tool_metadata->process_end_ns == 0)
         rocprofiler_get_timestamp(&(tool_metadata->process_end_ns));
@@ -3116,9 +3117,18 @@ tool_detach(void* /*tool_data*/)
     // Flush buffered records, stop the context to prevent further callbacks and
     // finalize tracing state, then flush again to capture any final records
     // emitted during shutdown (same pattern as tool_fini)
+=======
+    // Flush all buffers, stop context to ensure in-flight GPU operations complete,
+    // then flush again to capture any final events (same pattern as tool_fini)
+>>>>>>> 4dbf48977c (Fix detach end timestamp ordering)
     flush();
     rocprofiler_stop_context(get_client_ctx());
     flush();
+
+    // Capture the fallback end timestamp after shutdown flushes complete so it
+    // reflects when profiling actually stopped.
+    if(tool_metadata->process_end_ns == 0)
+        rocprofiler_get_timestamp(&(tool_metadata->process_end_ns));
 
     generate_output(cleanup_mode::reset);
 }
@@ -3135,12 +3145,14 @@ tool_fini(void* /*tool_data*/)
 
     auto _fini_timer = common::simple_timer{"[rocprofv3] tool finalization"};
 
-    if(tool_metadata->process_end_ns == 0)
-        rocprofiler_get_timestamp(&(tool_metadata->process_end_ns));
-
     flush();
     rocprofiler_stop_context(get_client_ctx());
     flush();
+
+    // Capture the fallback end timestamp after shutdown flushes complete so it
+    // reflects when profiling actually stopped.
+    if(tool_metadata->process_end_ns == 0)
+        rocprofiler_get_timestamp(&(tool_metadata->process_end_ns));
 
     generate_output(cleanup_mode::destroy);
 


### PR DESCRIPTION
## Motivation

When the profiled application is small:

1. `tool_detach()` runs, calls `flush()`, and writes output with valid data
2. Application exits quickly
3. `tool_fini()` runs, calls `flush()` again, but the context was still "active" (not stopped)
4. Since no new GPU operations occurred after detachment, `tool_fini()` writes empty data
5. The empty output from `tool_fini()` __overwrites__ the valid output from `tool_detach()`

This explains the intermittent nature - it only fails when the app exits quickly enough for `tool_fini()` to run and overwrite the output. https://github.com/ROCm/rocm-systems/actions/runs/23957463896/job/70329025190?pr=4696


## Technical Details

Added `rocprofiler_stop_context()` in `tool_detach()`:

```cpp
void tool_detach(...) {
    flush();
    rocprofiler_stop_context(get_client_ctx());  // NEW: Stop context
    flush();
    generate_output(cleanup_mode::reset);
}
```

By stopping the context in `tool_detach()`:

1. All in-flight GPU operations complete and their events are captured
2. When `tool_fini()` runs later, the context is already stopped
3. No new records are generated, so `tool_fini()`'s output won't overwrite valid data


## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan

- Tested failing tests over 100 times in local and no visible similar failure in CI

## Test Result

- No failure in attach tests related to records missing.

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
