### PR TITLE
Validate debug-tools for runtime changes

### DIFF
--- a/.github/scripts/therock_matrix.py
+++ b/.github/scripts/therock_matrix.py
@@ -67,9 +67,10 @@ project_map = {
         "cmake_options": ["-DTHEROCK_ENABLE_ALL=OFF", "-DTHEROCK_ENABLE_ROCSHMEM=ON"],
         "projects_to_test": "",  # rocshmem testing to be enabled in a future PR
     },
+    # Also test rocr-debug-agent and rocgdb since those depend on runtimes.
     "runtimes": {
         "cmake_options": ["-DTHEROCK_ENABLE_ALL=ON"],
-        "projects_to_test": "hip-tests, rocrtst, rocprofiler-sdk",
+        "projects_to_test": "hip-tests, rocrtst, rocprofiler-sdk, rocr-debug-agent, rocgdb",
     },
     "all": {
         "cmake_options": ["-DTHEROCK_ENABLE_ALL=ON"],


### PR DESCRIPTION
Given rocr-debug-agent and rocgdb rely on the runtime, make sure to test those components whenever there are runtime changes.