### PR TITLE
clr: Fix VMM imported memory routing to SDMA batch copy path

### DIFF
--- a/projects/clr/rocclr/device/rocm/rocblit.cpp
+++ b/projects/clr/rocclr/device/rocm/rocblit.cpp
@@ -608,15 +608,18 @@ inline void DmaBlitManager::resolveAgents(const Memory& srcMem, const Memory& ds
     srcAgent = srcMem.isHostMemDirectAccess() ? dev().getCpuAgent() : dev().getBackendDevice();
     dstAgent = dstMem.isHostMemDirectAccess() ? dev().getCpuAgent() : dev().getBackendDevice();
 
-    // IPC buffers: the runtime doesn't know the real owning agent, query pointer_info
-    if (static_cast<const amd::Memory*>(srcMem.owner())->ipcShared()) {
+    // IPC/VMM-imported buffers: the runtime doesn't know the real owning agent,
+    // so query pointer_info to resolve the true agent.
+    if (static_cast<const amd::Memory*>(srcMem.owner())->ipcShared() ||
+        static_cast<const amd::Memory*>(srcMem.owner())->vmmImported()) {
       hsa_amd_pointer_info_t info = {sizeof(hsa_amd_pointer_info_t)};
       if (HSA_STATUS_SUCCESS ==
           Hsa::pointer_info(const_cast<address>(srcAddr), &info, nullptr, nullptr, nullptr)) {
         srcAgent = info.agentOwner;
       }
     }
-    if (static_cast<const amd::Memory*>(dstMem.owner())->ipcShared()) {
+    if (static_cast<const amd::Memory*>(dstMem.owner())->ipcShared() ||
+        static_cast<const amd::Memory*>(dstMem.owner())->vmmImported()) {
       hsa_amd_pointer_info_t info = {sizeof(hsa_amd_pointer_info_t)};
       if (HSA_STATUS_SUCCESS == Hsa::pointer_info(dstAddr, &info, nullptr, nullptr, nullptr)) {
         dstAgent = info.agentOwner;
@@ -2700,7 +2703,8 @@ bool KernelBlitManager::copyBuffer(device::Memory& srcMemory, device::Memory& ds
   uint32_t blitWg = dev().settings().limit_blit_wg_;
 
   bool isP2pOrIpc = (&gpuMem(srcMemory).dev() != &gpuMem(dstMemory).dev()) ||
-                    srcMemory.owner()->ipcShared() || dstMemory.owner()->ipcShared();
+                    srcMemory.owner()->ipcShared() || dstMemory.owner()->ipcShared() ||
+                    srcMemory.owner()->vmmImported() || dstMemory.owner()->vmmImported();
 
   // Use SDMA for large P2P/IPC transfers, shader for small ones
   if (isP2pOrIpc && sizeIn[0] <= dev().settings().sdma_p2p_threshold_) {

--- a/projects/clr/rocclr/device/rocm/rocvirtual.cpp
+++ b/projects/clr/rocclr/device/rocm/rocvirtual.cpp
@@ -3444,6 +3444,9 @@ void VirtualGPU::submitVirtualMap(amd::VirtualMapCommand& vcmd) {
       amd::MemObjMap::AddMemObj(vcmd.ptr(), vaddr_sub_obj);
       vaddr_sub_obj->getUserData().phys_mem_obj = phys_mem_obj;
       phys_mem_obj->getUserData().vaddr_mem_obj = vaddr_sub_obj;
+      if (phys_mem_obj->getMemFlags() & ROCCLR_MEM_INTERPROCESS) {
+        vaddr_sub_obj->setVmmImported(true);
+      }
     } else {
       LogError("HSA Command: hsa_amd_vmem_map failed!");
     }

--- a/projects/clr/rocclr/platform/memory.hpp
+++ b/projects/clr/rocclr/platform/memory.hpp
@@ -195,6 +195,7 @@ class Memory : public amd::RuntimeObject {
       uint32_t canBeCached_ : 1;       //!< flag to if the object can be cached
       uint32_t p2pAccess_ : 1;         //!< Memory object allows P2P access
       uint32_t ipcShared_ : 1;         //!< Memory shared between processes
+      uint32_t vmmImported_ : 1;       //!< VMM buffer whose physical memory may be on another device
       uint32_t largeBarSystem_ : 1;    //!< VRAM is visiable for host
       uint32_t image_view_ : 1;        //!< Memory object is an image view
     };
@@ -398,6 +399,11 @@ class Memory : public amd::RuntimeObject {
   void setIpcShared(bool ipcShared) { ipcShared_ = ipcShared; }
   //! Check if this object allows IPC
   bool ipcShared() const { return ipcShared_; }
+
+  //! Set vmmImported status (VMM buffer backed by imported physical memory)
+  void setVmmImported(bool vmmImported) { vmmImported_ = vmmImported; }
+  //! Check if this VMM buffer's physical memory may reside on another device
+  bool vmmImported() const { return vmmImported_; }
 
   //! Returns the base device memory object for possible P2P access
   device::Memory* BaseP2PMemory() const { return deviceMemories_[0].value_; }


### PR DESCRIPTION
- VMM buffers imported via hipMemImportFromShareableHandle have their deviceId set to the importing device, causing resolveAgents() to assign the local agent for both src and dst. This misroutes cross-device copies through the kernel blit (d2dCopyOps) instead of the SDMA batch engine (hsaCopyBatch -> rocrCopyBufferBatch).

- Add a vmmImported_ flag on amd::Memory, set it during submitVirtualMap when the backing physical memory has ROCCLR_MEM_INTERPROCESS, and check it alongside ipcShared() in resolveAgents() and copyBuffer() so that pointer_info resolves the true owning agent.

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
