### PR TITLE
[AMD-SMI] Updated changelog for AMDSMI_STATUS_MORE_DATA enum change

### DIFF
--- a/projects/amdsmi/CHANGELOG.md
+++ b/projects/amdsmi/CHANGELOG.md
@@ -1637,6 +1637,10 @@ $ amd-smi
       ...
       ```
 
+- **Modified the enum `AMDSMI_STATUS_MORE_DATA` in `amdsmi_status_t`**.  
+  - The `AMDSMI_STATUS_MORE_DATA` value changed from 57 to 39.
+  - Change was done to align all drivers on a common value.
+
 ### Removed
 
 - **Removed unnecessary API, `amdsmi_free_name_value_pairs(),` from amdsmi.h**.  


### PR DESCRIPTION
## Motivation

Changelog did not have an entry for AMDSMI_STATUS_MORE_DATA change.
Change was done to align value with all drivers

## Technical Details

Document change in the amdsmi_status_t enum, AMDSMI_STATUS_MORE_DATA changed from 57 to 39
