### PR TITLE
[rocprofiler-compute] Update test categories with complete coverage and timing-based tiers

### DIFF
--- a/projects/rocprofiler-compute/tests/test_categories.yaml
+++ b/projects/rocprofiler-compute/tests/test_categories.yaml
@@ -2,17 +2,28 @@ test_categories:
   quick:
     description: "Fast sanity checks - Run pre-commit (target: < 5 min)"
     test_patterns:
-      - test_autogen_config
-      - test_roofline_calc_ai_analyze
-      - test_num_xcds_cli_output
+      - test_profile_misc
+      - test_metric_validation
+      - test_profile_section
+      - test_pc_sampling
+      - test_analyze_workloads
+      - test_profile_iteration_multiplexing_1
+      - test_profile_sets_func
+      - test_utils
+      - test_pc_sampling_analysis
+      - test_tui_components
+      - test_analysis_db
       - test_torch_trace
-      - test_num_xcds_spec_class
       - test_L1_cache_counters
       - test_data_imputation
-      - test_tui_components
-      - test_utils
-      - test_profile_pc_sampling
-      - test_profile_sets_func
+      - test_roofline_calc_ai_analyze
+      - test_num_xcds_spec_class
+      - test_profiler_base
+      - test_num_xcds_cli_output
+      - test_utils_profile_csv
+      - test_autogen_config
+      - test_import_guard
+      - test_profile_multi_rank
     exclude:
       - test_profile_live_attach_detach
     labels:
@@ -23,15 +34,34 @@ test_categories:
   standard:
     description: "Core functionality - Run on every PR (target: < 30 min)"
     test_patterns:
+      - test_data_imputation
+      - test_profile_dispatch
+      - test_profile_kernel_execution
+      - test_profile_join
+      - test_pc_sampling
+      - test_profile_roofline_1
+      - test_profile_section
+      - test_profile_sets_func
+      - test_profile_sort
+      - test_profile_iteration_multiplexing_1
+      - test_profile_iteration_multiplexing_2
+      - test_metric_validation
       - test_autogen_config
-      - test_utils
+      - test_analyze_commands
+      - test_analyze_workloads
       - test_num_xcds_cli_output
       - test_num_xcds_spec_class
+      - test_utils
       - test_L1_cache_counters
-      - test_analyze_workloads
-      - test_analyze_commands
-      - test_metric_validation
-      - test_profile_iteration_multiplexing_1
+      - test_roofline_calc_ai_analyze
+      - test_torch_trace
+      - test_tui_components
+      - test_import_guard
+      - test_profile_multi_rank
+      - test_analysis_db
+      - test_pc_sampling_analysis
+      - test_utils_profile_csv
+      - test_profiler_base
     exclude:
       - test_profile_live_attach_detach
     labels:
@@ -45,10 +75,9 @@ test_categories:
       - test_profile_dispatch
       - test_profile_kernel_execution
       - test_profile_join
-      - test_profile_mem
       - test_profile_misc
       - test_profile_path
-      - test_profile_pc_sampling
+      - test_pc_sampling
       - test_profile_roofline_1
       - test_profile_roofline_2
       - test_profile_section
@@ -68,6 +97,12 @@ test_categories:
       - test_roofline_calc_ai_analyze
       - test_torch_trace
       - test_tui_components
+      - test_import_guard
+      - test_profile_multi_rank
+      - test_analysis_db
+      - test_pc_sampling_analysis
+      - test_utils_profile_csv
+      - test_profiler_base
     exclude:
       - test_profile_live_attach_detach
     labels:
@@ -81,10 +116,9 @@ test_categories:
       - test_profile_dispatch
       - test_profile_kernel_execution
       - test_profile_join
-      - test_profile_mem
       - test_profile_misc
       - test_profile_path
-      - test_profile_pc_sampling
+      - test_pc_sampling
       - test_profile_roofline_1
       - test_profile_roofline_2
       - test_profile_section
@@ -104,6 +138,12 @@ test_categories:
       - test_roofline_calc_ai_analyze
       - test_torch_trace
       - test_tui_components
+      - test_import_guard
+      - test_profile_multi_rank
+      - test_analysis_db
+      - test_pc_sampling_analysis
+      - test_utils_profile_csv
+      - test_profiler_base
     exclude:
       - test_profile_live_attach_detach
     labels:

--- a/projects/rocprofiler-compute/tests/test_categories.yaml
+++ b/projects/rocprofiler-compute/tests/test_categories.yaml
@@ -23,7 +23,6 @@ test_categories:
       - test_utils_profile_csv
       - test_autogen_config
       - test_import_guard
-      - test_profile_multi_rank
     exclude:
       - test_profile_live_attach_detach
     labels:


### PR DESCRIPTION
## Motivation

Align test_categories.yaml with all ctests defined in CMakeLists.txt and size category tiers based on CDash timing data.

## Technical Details

- Fix test name mismatch: `test_profile_pc_sampling` -> `test_pc_sampling` to match CMake `add_test()` names
- Remove phantom test `test_profile_mem` (no corresponding `add_test()` in CMakeLists.txt)
- Add 6 missing tests to comprehensive/full: `test_import_guard`, `test_profile_multi_rank`, `test_analysis_db`, `test_pc_sampling_analysis`, `test_utils_profile_csv`, `test_profiler_base`
- Expand quick and standard categories based on CDash timing data

## JIRA ID

## Test Plan

- Verify `ctest -L quick` runs the expected 22 tests
- Verify `ctest -L standard` runs the expected 28 tests
- Verify `ctest -L comprehensive` and `ctest -L full` include all 32 tests

## Test Result

Pending CI validation

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.