### PR TITLE
[ATT] [PCS] Fix for inline callstack. Add function inlining test.

### DIFF
--- a/projects/rocprofiler-sdk/source/include/rocprofiler-sdk/cxx/codeobj/code_printing.hpp
+++ b/projects/rocprofiler-sdk/source/include/rocprofiler-sdk/cxx/codeobj/code_printing.hpp
@@ -553,30 +553,31 @@ inline DIEInfo::DIEInfo(Dwarf_Die* die)
         Dwarf_Word      call_line{};
 
         // Get the file and line number where this function was called/inlined
-
-        if(!dwarf_attr(die, DW_AT_call_file, &call_file_attr) ||
-           !dwarf_attr(die, DW_AT_call_line, &call_line_attr) ||
-           dwarf_formudata(&call_file_attr, &call_file) != 0 ||
-           dwarf_formudata(&call_line_attr, &call_line) != 0)
-            return;  // No call site information available
-
-        // Get the compilation unit to resolve file names
-        Dwarf_Die cu_die{};
-        if(!dwarf_diecu(die, &cu_die, nullptr, nullptr)) return;
-
-        // Get the source files table for this compilation unit
-        Dwarf_Files* files{};
-        size_t       nfiles{};
-        if(dwarf_getsrcfiles(&cu_die, &files, &nfiles) == 0 && call_file < nfiles)
+        // Do not return early - children must always be traversed for nested inlining
+        if(dwarf_attr(die, DW_AT_call_file, &call_file_attr) &&
+           dwarf_attr(die, DW_AT_call_line, &call_line_attr) &&
+           dwarf_formudata(&call_file_attr, &call_file) == 0 &&
+           dwarf_formudata(&call_line_attr, &call_line) == 0)
         {
-            if(const char* filename = dwarf_filesrc(files, call_file, nullptr, nullptr))
+            // Get the compilation unit to resolve file names
+            Dwarf_Die cu_die{};
+            if(dwarf_diecu(die, &cu_die, nullptr, nullptr))
             {
-                // Add "filename:line" to call stack showing where this function was inlined
-                file_and_line = std::string(filename) + ":" + std::to_string(call_line);
-                return;
+                // Get the source files table for this compilation unit
+                Dwarf_Files* files{};
+                size_t       nfiles{};
+                if(dwarf_getsrcfiles(&cu_die, &files, &nfiles) == 0 && call_file < nfiles)
+                {
+                    if(const char* filename = dwarf_filesrc(files, call_file, nullptr, nullptr))
+                    {
+                        file_and_line =
+                            std::string(filename) + ":" + std::to_string(call_line);
+                    }
+                }
             }
         }
 
+        // Always include this node's range so parents can find it via children_range
         children_range = total_range;
     }
 

--- a/projects/rocprofiler-sdk/source/include/rocprofiler-sdk/cxx/codeobj/code_printing.hpp
+++ b/projects/rocprofiler-sdk/source/include/rocprofiler-sdk/cxx/codeobj/code_printing.hpp
@@ -570,8 +570,7 @@ inline DIEInfo::DIEInfo(Dwarf_Die* die)
                 {
                     if(const char* filename = dwarf_filesrc(files, call_file, nullptr, nullptr))
                     {
-                        file_and_line =
-                            std::string(filename) + ":" + std::to_string(call_line);
+                        file_and_line = std::string(filename) + ":" + std::to_string(call_line);
                     }
                 }
             }

--- a/projects/rocprofiler-sdk/source/lib/tests/codeobj/CMakeLists.txt
+++ b/projects/rocprofiler-sdk/source/lib/tests/codeobj/CMakeLists.txt
@@ -20,6 +20,45 @@ target_compile_definitions(
 configure_file(smallkernel.bin smallkernel.bin COPYONLY)
 configure_file(hipcc_output.s hipcc_output.s COPYONLY)
 
+# Compile a HIP kernel with debug info to test DWARF inline annotation. Two-step: compile
+# to offload bundle, then unbundle to get the GPU ELF.
+find_program(
+    CODEOBJ_AMDCLANGPP REQUIRED
+    NAMES amdclang++
+    HINTS ${ROCM_PATH} ENV ROCM_PATH /opt/rocm
+    PATHS ${ROCM_PATH} ENV ROCM_PATH /opt/rocm
+    PATH_SUFFIXES bin llvm/bin NO_CACHE)
+
+find_program(
+    CODEOBJ_OFFLOAD_BUNDLER REQUIRED
+    NAMES clang-offload-bundler
+    HINTS ${ROCM_PATH} ENV ROCM_PATH /opt/rocm
+    PATHS ${ROCM_PATH} ENV ROCM_PATH /opt/rocm
+    PATH_SUFFIXES bin llvm/bin NO_CACHE)
+
+set(_SYNCKERNEL_ARCH "gfx90a")
+set(_SYNCKERNEL_SRC "${CMAKE_CURRENT_SOURCE_DIR}/syncthreads_kernel.hip")
+set(_SYNCKERNEL_BUNDLE "${CMAKE_CURRENT_BINARY_DIR}/syncthreads_kernel_bundle.o")
+set(_SYNCKERNEL_BIN "${CMAKE_CURRENT_BINARY_DIR}/syncthreads_kernel.bin")
+
+add_custom_command(
+    OUTPUT "${_SYNCKERNEL_BIN}"
+    COMMAND
+        ${CODEOBJ_AMDCLANGPP} -x hip -ggdb --offload-arch=${_SYNCKERNEL_ARCH}
+        --offload-device-only -c -fno-gpu-rdc --no-offload-new-driver -o
+        "${_SYNCKERNEL_BUNDLE}" "${_SYNCKERNEL_SRC}"
+    COMMAND
+        ${CODEOBJ_OFFLOAD_BUNDLER} --type=o --input=${_SYNCKERNEL_BUNDLE}
+        --output=${_SYNCKERNEL_BIN} --unbundle
+        --targets=hipv4-amdgcn-amd-amdhsa--${_SYNCKERNEL_ARCH}
+    DEPENDS "${_SYNCKERNEL_SRC}"
+    COMMENT
+        "Compiling syncthreads_kernel.hip -> syncthreads_kernel.bin (${_SYNCKERNEL_ARCH})"
+    VERBATIM)
+
+add_custom_target(syncthreads_kernel_bin ALL DEPENDS "${_SYNCKERNEL_BIN}")
+add_dependencies(codeobj-library-tests syncthreads_kernel_bin)
+
 install(
     FILES ${CMAKE_CURRENT_BINARY_DIR}/hipcc_output.s
     DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/${PACKAGE_NAME}/tests/unit-tests/bin

--- a/projects/rocprofiler-sdk/source/lib/tests/codeobj/CMakeLists.txt
+++ b/projects/rocprofiler-sdk/source/lib/tests/codeobj/CMakeLists.txt
@@ -36,6 +36,8 @@ find_program(
     PATHS ${ROCM_PATH} ENV ROCM_PATH /opt/rocm
     PATH_SUFFIXES bin llvm/bin NO_CACHE)
 
+# The arch only matters for compilation, not execution — the test only parses DWARF debug
+# info from the resulting ELF.  Any valid arch works here.
 set(_SYNCKERNEL_ARCH "gfx90a")
 set(_SYNCKERNEL_SRC "${CMAKE_CURRENT_SOURCE_DIR}/syncthreads_kernel.hip")
 set(_SYNCKERNEL_BUNDLE "${CMAKE_CURRENT_BINARY_DIR}/syncthreads_kernel_bundle.o")
@@ -56,8 +58,14 @@ add_custom_command(
         "Compiling syncthreads_kernel.hip -> syncthreads_kernel.bin (${_SYNCKERNEL_ARCH})"
     VERBATIM)
 
-add_custom_target(syncthreads_kernel_bin ALL DEPENDS "${_SYNCKERNEL_BIN}")
+add_custom_target(syncthreads_kernel_bin DEPENDS "${_SYNCKERNEL_BIN}")
 add_dependencies(codeobj-library-tests syncthreads_kernel_bin)
+
+install(
+    FILES "${_SYNCKERNEL_BIN}"
+    DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/${PACKAGE_NAME}/tests/unit-tests/bin
+    COMPONENT tests
+    OPTIONAL)
 
 install(
     FILES ${CMAKE_CURRENT_BINARY_DIR}/hipcc_output.s

--- a/projects/rocprofiler-sdk/source/lib/tests/codeobj/codeobj_library_test.cpp
+++ b/projects/rocprofiler-sdk/source/lib/tests/codeobj/codeobj_library_test.cpp
@@ -300,3 +300,46 @@ TEST(codeobj_library, codeobj_table_test)
     ASSERT_EQ(map.removeDecoderbyId(3), true);
     ASSERT_EQ(map.removeDecoderbyId(1), false);
 }
+
+/**
+ * Verifies that DWARF inline annotation produces " -> " separators.
+ * A __syncthreads() call always inlines through HIP headers, so the
+ * instruction comment must contain at least two source locations
+ * connected by " -> ".
+ */
+TEST(codeobj_library, inline_annotation)
+{
+    std::string path = codeobjhelper::get_data_file_path("syncthreads_kernel.bin");
+    ASSERT_FALSE(path.empty()) << "syncthreads_kernel.bin not found";
+
+    std::ifstream file(path, std::ios::binary);
+    using iterator_t = std::istreambuf_iterator<char>;
+    std::vector<char> objdata{iterator_t(file), iterator_t{}};
+    ASSERT_FALSE(objdata.empty());
+
+    CodeobjDecoderComponent comp(objdata.data(), objdata.size());
+    ASSERT_FALSE(comp.m_symbol_map.empty());
+
+    bool found_inline_separator = false;
+    for(auto& [kaddr, sym] : comp.m_symbol_map)
+    {
+        size_t vaddr = kaddr;
+        while(vaddr < kaddr + sym.mem_size)
+        {
+            auto faddr = comp.va2fo(vaddr);
+            ASSERT_TRUE(faddr.has_value());
+
+            auto inst = comp.disassemble_instruction(*faddr, vaddr);
+            ASSERT_NE(inst, nullptr);
+            ASSERT_NE(inst->size, 0u);
+
+            if(inst->comment.find(disassembly::Instruction::separator) != std::string::npos)
+                found_inline_separator = true;
+
+            vaddr += inst->size;
+        }
+    }
+    EXPECT_TRUE(found_inline_separator)
+        << "No instruction had inline annotation (' -> ' separator). "
+           "DWARF inlined subroutine traversal may be broken.";
+}

--- a/projects/rocprofiler-sdk/source/lib/tests/codeobj/codeobj_library_test.cpp
+++ b/projects/rocprofiler-sdk/source/lib/tests/codeobj/codeobj_library_test.cpp
@@ -303,9 +303,10 @@ TEST(codeobj_library, codeobj_table_test)
 
 /**
  * Verifies that DWARF inline annotation produces " -> " separators.
- * A __syncthreads() call always inlines through HIP headers, so the
- * instruction comment must contain at least two source locations
- * connected by " -> ".
+ * The test kernel calls a __device__ function that calls __syncthreads(),
+ * which inlines through HIP headers.  This guarantees at least 3 call stack
+ * levels (kernel -> device func -> HIP header), i.e. at least two " -> "
+ * separators in the comment of the s_barrier instruction.
  */
 TEST(codeobj_library, inline_annotation)
 {
@@ -320,7 +321,8 @@ TEST(codeobj_library, inline_annotation)
     CodeobjDecoderComponent comp(objdata.data(), objdata.size());
     ASSERT_FALSE(comp.m_symbol_map.empty());
 
-    bool found_inline_separator = false;
+    constexpr size_t min_depth = 3;  // kernel -> barrier_wrapper -> HIP header(s)
+    size_t           max_depth = 0;
     for(auto& [kaddr, sym] : comp.m_symbol_map)
     {
         size_t vaddr = kaddr;
@@ -333,13 +335,21 @@ TEST(codeobj_library, inline_annotation)
             ASSERT_NE(inst, nullptr);
             ASSERT_NE(inst->size, 0u);
 
-            if(inst->comment.find(disassembly::Instruction::separator) != std::string::npos)
-                found_inline_separator = true;
+            // Count separators to determine call stack depth
+            size_t depth = 1;
+            size_t pos   = 0;
+            while((pos = inst->comment.find(disassembly::Instruction::separator, pos)) !=
+                  std::string::npos)
+            {
+                depth++;
+                pos += disassembly::Instruction::separator.size();
+            }
+            max_depth = std::max(max_depth, depth);
 
             vaddr += inst->size;
         }
     }
-    EXPECT_TRUE(found_inline_separator)
-        << "No instruction had inline annotation (' -> ' separator). "
-           "DWARF inlined subroutine traversal may be broken.";
+    EXPECT_GE(max_depth, min_depth)
+        << "Deepest inline call stack was " << max_depth << " levels (expected >= " << min_depth
+        << "). DWARF inlined subroutine traversal may be broken.";
 }

--- a/projects/rocprofiler-sdk/source/lib/tests/codeobj/syncthreads_kernel.hip
+++ b/projects/rocprofiler-sdk/source/lib/tests/codeobj/syncthreads_kernel.hip
@@ -1,0 +1,9 @@
+#include <hip/hip_runtime.h>
+
+__global__ void
+syncthreads_kernel(int* data)
+{
+    data[threadIdx.x] = threadIdx.x;
+    __syncthreads();
+    data[threadIdx.x] += data[threadIdx.x ^ 1];
+}

--- a/projects/rocprofiler-sdk/source/lib/tests/codeobj/syncthreads_kernel.hip
+++ b/projects/rocprofiler-sdk/source/lib/tests/codeobj/syncthreads_kernel.hip
@@ -1,9 +1,15 @@
 #include <hip/hip_runtime.h>
 
+__device__ void
+barrier_wrapper(int* data)
+{
+    __syncthreads();
+    data[threadIdx.x] += data[threadIdx.x ^ 1];
+}
+
 __global__ void
 syncthreads_kernel(int* data)
 {
     data[threadIdx.x] = threadIdx.x;
-    __syncthreads();
-    data[threadIdx.x] += data[threadIdx.x ^ 1];
+    barrier_wrapper(data);
 }


### PR DESCRIPTION
## Motivation

Starting rocm 7.2, a compiler change surface a problem with our inline callstack unwind. This PR fixes it, and adds a test to ensure it doesn't break again.

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
