### PR TITLE
[rocjitsu] Emulate multiple wavefronts

### DIFF
--- a/experimental/rocjitsu/CMakeLists.txt
+++ b/experimental/rocjitsu/CMakeLists.txt
@@ -83,7 +83,17 @@ set(FLATBUFFERS_BUILD_TESTS OFF CACHE BOOL "" FORCE)
 set(FLATBUFFERS_INSTALL OFF CACHE BOOL "" FORCE)
 set(FLATBUFFERS_BUILD_FLATLIB ON CACHE BOOL "" FORCE)
 
-FetchContent_MakeAvailable(googletest flatbuffers)
+# msgpack-cxx - header-only msgpack parser for AMDGPU kernel metadata.
+FetchContent_Declare(
+    msgpack-cxx
+    GIT_REPOSITORY https://github.com/msgpack/msgpack-c.git
+    GIT_TAG cpp-7.0.0
+)
+set(MSGPACK_USE_BOOST OFF CACHE BOOL "" FORCE)
+set(MSGPACK_BUILD_TESTS OFF CACHE BOOL "" FORCE)
+set(MSGPACK_BUILD_EXAMPLES OFF CACHE BOOL "" FORCE)
+
+FetchContent_MakeAvailable(googletest flatbuffers msgpack-cxx)
 
 # Compile FlatBuffers schemas into C++ headers.
 set(GENERATED_DIR ${CMAKE_BINARY_DIR}/generated)

--- a/experimental/rocjitsu/lib/rocjitsu/src/rocjitsu/code/code_object.h
+++ b/experimental/rocjitsu/lib/rocjitsu/src/rocjitsu/code/code_object.h
@@ -93,6 +93,12 @@ public:
   /// @returns Image size in bytes.
   std::size_t size() const { return image_.size(); }
 
+  /// @brief Raw ELF image data.
+  /// @returns Pointer to the ELF image bytes, or nullptr if empty.
+  const uint8_t *image_data() const {
+    return image_.empty() ? nullptr : reinterpret_cast<const uint8_t *>(image_.data());
+  }
+
   /// @brief .text sections containing executable machine code.
   /// @returns Vector of pointers to .text sections.
   const std::vector<const Section *> &text_sections() const { return text_sections_; }

--- a/experimental/rocjitsu/lib/rocjitsu/src/rocjitsu/code/kernel_metadata.h
+++ b/experimental/rocjitsu/lib/rocjitsu/src/rocjitsu/code/kernel_metadata.h
@@ -1,0 +1,159 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+
+/// @file Kernel argument metadata extracted from AMDGPU code objects.
+
+#ifndef ROCJITSU_CODE_KERNEL_METADATA_H_
+#define ROCJITSU_CODE_KERNEL_METADATA_H_
+
+#include "rocjitsu/code/amdgpu_elf.h"
+
+#include <msgpack.hpp>
+
+#include <cstdint>
+#include <cstring>
+#include <optional>
+#include <string>
+#include <unordered_map>
+
+namespace rocjitsu {
+
+/// A single kernel argument descriptor.
+struct KernelArg {
+  uint32_t offset;
+  uint32_t size;
+};
+
+/// All kernel arguments, keyed by value_kind (e.g. "global_buffer",
+/// "by_value", "hidden_block_count_x", "hidden_group_size_x").
+/// Parsed from the AMDGPU code object's .note metadata.
+using KernelArgMap = std::unordered_map<std::string, KernelArg>;
+
+/// Parse kernel argument metadata from an AMDGPU device ELF image.
+/// Returns the argument map for the first kernel, or nullopt on failure.
+inline std::optional<KernelArgMap>
+parseKernelArgs(const uint8_t *elf_data, size_t elf_size) {
+  if (elf_size < sizeof(Elf64_Ehdr)) {
+    return std::nullopt;
+  }
+
+  Elf64_Ehdr ehdr;
+  std::memcpy(&ehdr, elf_data, sizeof(ehdr));
+  if (ehdr.e_shoff + ehdr.e_shnum * sizeof(Elf64_Shdr) > elf_size) {
+    return std::nullopt;
+  }
+
+  // Find the SHT_NOTE section.
+  const uint8_t *note_data = nullptr;
+  for (uint16_t i = 0; i < ehdr.e_shnum; ++i) {
+    Elf64_Shdr shdr;
+    std::memcpy(&shdr, elf_data + ehdr.e_shoff + i * sizeof(Elf64_Shdr),
+                sizeof(shdr));
+    if (shdr.sh_type == SHT_NOTE &&
+        shdr.sh_offset + shdr.sh_size <= elf_size) {
+      note_data = elf_data + shdr.sh_offset;
+      break;
+    }
+  }
+  if (!note_data) {
+    return std::nullopt;
+  }
+
+  // Parse the ELF note header.
+  uint32_t namesz, descsz, ntype;
+  std::memcpy(&namesz, note_data, 4);
+  std::memcpy(&descsz, note_data + 4, 4);
+  std::memcpy(&ntype, note_data + 8, 4);
+  if (ntype != NT_AMDGPU_METADATA) {
+    return std::nullopt;
+  }
+
+  uint32_t name_padded = (namesz + 3) & ~3u;
+  const char *msgpack_data =
+      reinterpret_cast<const char *>(note_data + 12 + name_padded);
+
+  // Parse msgpack.
+  auto handle = msgpack::unpack(msgpack_data, descsz);
+  auto top = handle.get();
+  if (top.type != msgpack::type::MAP) {
+    return std::nullopt;
+  }
+
+  auto top_map = top.via.map;
+  for (uint32_t i = 0; i < top_map.size; ++i) {
+    auto &key = top_map.ptr[i].key;
+    if (key.type != msgpack::type::STR) {
+      continue;
+    }
+    std::string key_str(key.via.str.ptr, key.via.str.size);
+    if (key_str != "amdhsa.kernels") {
+      continue;
+    }
+
+    auto &kernels = top_map.ptr[i].val;
+    if (kernels.type != msgpack::type::ARRAY || kernels.via.array.size == 0) {
+      return std::nullopt;
+    }
+
+    auto &kernel = kernels.via.array.ptr[0];
+    if (kernel.type != msgpack::type::MAP) {
+      return std::nullopt;
+    }
+
+    auto kernel_map = kernel.via.map;
+    for (uint32_t k = 0; k < kernel_map.size; ++k) {
+      auto &kkey = kernel_map.ptr[k].key;
+      if (kkey.type != msgpack::type::STR) {
+        continue;
+      }
+      std::string kkey_str(kkey.via.str.ptr, kkey.via.str.size);
+      if (kkey_str != ".args") {
+        continue;
+      }
+
+      auto &args = kernel_map.ptr[k].val;
+      if (args.type != msgpack::type::ARRAY) {
+        return std::nullopt;
+      }
+
+      KernelArgMap result;
+      for (uint32_t a = 0; a < args.via.array.size; ++a) {
+        auto &arg = args.via.array.ptr[a];
+        if (arg.type != msgpack::type::MAP) {
+          continue;
+        }
+
+        uint32_t offset = 0;
+        uint32_t size = 0;
+        std::string value_kind;
+
+        auto arg_map = arg.via.map;
+        for (uint32_t f = 0; f < arg_map.size; ++f) {
+          auto &fkey = arg_map.ptr[f].key;
+          auto &fval = arg_map.ptr[f].val;
+          if (fkey.type != msgpack::type::STR) {
+            continue;
+          }
+          std::string fkey_str(fkey.via.str.ptr, fkey.via.str.size);
+          if (fkey_str == ".offset") {
+            offset = fval.as<uint32_t>();
+          } else if (fkey_str == ".size") {
+            size = fval.as<uint32_t>();
+          } else if (fkey_str == ".value_kind") {
+            value_kind = std::string(fval.via.str.ptr, fval.via.str.size);
+          }
+        }
+
+        if (!value_kind.empty()) {
+          result[value_kind] = {offset, size};
+        }
+      }
+      return result;
+    }
+  }
+  return std::nullopt;
+}
+
+} // namespace rocjitsu
+
+#endif // ROCJITSU_CODE_KERNEL_METADATA_H_

--- a/experimental/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/command_processor.cpp
+++ b/experimental/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/command_processor.cpp
@@ -21,9 +21,9 @@ namespace {
 /// On gfx9+, the compiler implicitly places the kernarg pointer in s[0:1]
 /// regardless of kernel_code_properties flags. The system SGPR
 /// (workgroup_id_x) follows at `sbase + num_user_sgprs`.
-/// v0 is set to the lane index (workitem_id_x).
+/// v0 is set to the workitem ID (wf_index * wf_size + lane).
 void init_wavefront_regs(ComputeUnitCore *cu, Wavefront *wf, const DispatchPacket &pkt,
-                         uint32_t global_wg_id) {
+                         uint32_t global_wg_id, uint32_t wf_index) {
   uint32_t sbase = wf->sgpr_alloc().base;
 
   // User SGPRs: kernarg pointer in s[0:1] (implicit gfx9+ ABI).
@@ -35,10 +35,12 @@ void init_wavefront_regs(ComputeUnitCore *cu, Wavefront *wf, const DispatchPacke
   // System SGPR: workgroup_id_x after user SGPRs.
   cu->write_sgpr(sbase + pkt.num_user_sgprs, global_wg_id);
 
-  // Workitem ID: v0 = lane index within the wavefront.
+  // Workitem ID: v0 = global thread ID within the workgroup.
   uint32_t vbase = wf->vgpr_alloc().base;
-  for (uint32_t lane = 0; lane < cu->wf_size(); ++lane)
-    cu->write_vgpr(vbase, lane, lane);
+  uint32_t thread_offset = wf_index * cu->wf_size();
+  for (uint32_t lane = 0; lane < cu->wf_size(); ++lane) {
+    cu->write_vgpr(vbase, lane, thread_offset + lane);
+  }
 }
 
 } // namespace
@@ -103,7 +105,7 @@ bool CommandProcessor::step() {
       }
 
       if (wf && chosen_cu) {
-        init_wavefront_regs(chosen_cu, wf, pkt, global_wg_id);
+        init_wavefront_regs(chosen_cu, wf, pkt, global_wg_id, w);
       } else {
         // ALL CUs are full. Re-enqueue remaining workgroups for retry.
         util::debug::print(__func__, ": all CUs full at wg=", wg, " w=", w, " - re-enqueueing ",

--- a/experimental/rocjitsu/tests/CMakeLists.txt
+++ b/experimental/rocjitsu/tests/CMakeLists.txt
@@ -33,7 +33,7 @@ add_executable(rocjitsu_tests
     simdojo_sim_test.cpp
 )
 target_link_libraries(rocjitsu_tests PRIVATE
-    ${RJ_OBJECT_LIBS} util flatbuffers Threads::Threads GTest::gtest_main)
+    ${RJ_OBJECT_LIBS} util flatbuffers msgpack-cxx Threads::Threads GTest::gtest_main)
 rj_configure_target(rocjitsu_tests TEST)
 
 include(GoogleTest)

--- a/experimental/rocjitsu/tests/kernels/vector_add.hip
+++ b/experimental/rocjitsu/tests/kernels/vector_add.hip
@@ -21,8 +21,7 @@
 extern "C" __global__ void vector_add(const float *__restrict__ A,
                                       const float *__restrict__ B,
                                       float *__restrict__ C, unsigned N) {
-  constexpr unsigned BLOCK_SIZE = 64;
-  unsigned gid = blockIdx.x * BLOCK_SIZE + threadIdx.x;
+  unsigned gid = blockIdx.x * blockDim.x + threadIdx.x;
 
   if (gid < N)
     C[gid] = A[gid] + B[gid];

--- a/experimental/rocjitsu/tests/vector_add_test.cpp
+++ b/experimental/rocjitsu/tests/vector_add_test.cpp
@@ -54,25 +54,49 @@ constexpr uint64_t C_ADDR = 0x300000;
 constexpr uint64_t KERNARG_ADDR = 0x400000;
 
 /// Write a kernel argument to the kernarg segment.
-/// Returns false if the argument is not found in the map.
+/// Write a kernel argument to the kernarg segment in GPU memory.
+///
+/// Looks up @p name in @p args to find the byte offset and size, then writes
+/// the low bits of @p value at that offset. Handles sub-dword sizes (1 and
+/// 2 bytes) via read-modify-write to avoid clobbering adjacent fields.
+///
+/// @returns false if @p name is not found in @p args.
 bool write_kernarg(amdgpu::GpuMemory *memory, uint64_t kernarg_addr,
                    const KernelArgMap &args, const std::string &name,
-                   uint32_t value) {
+                   uint64_t value) {
   auto it = args.find(name);
   if (it == args.end()) {
     return false;
   }
   uint64_t addr = kernarg_addr + it->second.offset;
-  if (it->second.size == 2) {
-    // uint16: read-modify-write to preserve adjacent half.
+  switch (it->second.size) {
+  case 1: {
+    uint64_t aligned = addr & ~3ULL;
+    uint32_t dword = memory->read32(aligned);
+    uint32_t shift = (addr & 3) * 8;
+    dword &= ~(0xFFu << shift);
+    dword |= (static_cast<uint32_t>(value) & 0xFF) << shift;
+    memory->write32(aligned, dword);
+    break;
+  }
+  case 2: {
     uint64_t aligned = addr & ~3ULL;
     uint32_t dword = memory->read32(aligned);
     uint32_t shift = (addr & 2) * 8;
     dword &= ~(0xFFFFu << shift);
-    dword |= (value & 0xFFFF) << shift;
+    dword |= (static_cast<uint32_t>(value) & 0xFFFF) << shift;
     memory->write32(aligned, dword);
-  } else {
-    memory->write32(addr, value);
+    break;
+  }
+  case 4:
+    memory->write32(addr, static_cast<uint32_t>(value));
+    break;
+  case 8:
+    memory->write32(addr, static_cast<uint32_t>(value));
+    memory->write32(addr + 4, static_cast<uint32_t>(value >> 32));
+    break;
+  default:
+    return false;
   }
   return true;
 }

--- a/experimental/rocjitsu/tests/vector_add_test.cpp
+++ b/experimental/rocjitsu/tests/vector_add_test.cpp
@@ -9,6 +9,7 @@
 /// CPU golden reference.
 
 #include "rocjitsu/code/executable.h"
+#include "rocjitsu/code/kernel_metadata.h"
 #include "rocjitsu/config/config_loader.h"
 #include "rocjitsu/isa/decoder.h"
 #include "rocjitsu/vm/amdgpu/compute_unit.h"
@@ -51,6 +52,45 @@ constexpr uint64_t A_ADDR = 0x100000;
 constexpr uint64_t B_ADDR = 0x200000;
 constexpr uint64_t C_ADDR = 0x300000;
 constexpr uint64_t KERNARG_ADDR = 0x400000;
+
+/// Write a kernel argument to the kernarg segment.
+/// Returns false if the argument is not found in the map.
+bool write_kernarg(amdgpu::GpuMemory *memory, uint64_t kernarg_addr,
+                   const KernelArgMap &args, const std::string &name,
+                   uint32_t value) {
+  auto it = args.find(name);
+  if (it == args.end()) {
+    return false;
+  }
+  uint64_t addr = kernarg_addr + it->second.offset;
+  if (it->second.size == 2) {
+    // uint16: read-modify-write to preserve adjacent half.
+    uint64_t aligned = addr & ~3ULL;
+    uint32_t dword = memory->read32(aligned);
+    uint32_t shift = (addr & 2) * 8;
+    dword &= ~(0xFFFFu << shift);
+    dword |= (value & 0xFFFF) << shift;
+    memory->write32(aligned, dword);
+  } else {
+    memory->write32(addr, value);
+  }
+  return true;
+}
+
+/// Write HIP implicit kernel arguments using offsets from the code object.
+/// Returns false if any required implicit argument is missing.
+bool write_implicit_args(amdgpu::GpuMemory *memory, uint64_t kernarg_addr,
+                         const KernelArgMap &args,
+                         uint32_t block_count_x, uint32_t group_size_x) {
+  bool ok = true;
+  ok &= write_kernarg(memory, kernarg_addr, args, "hidden_block_count_x", block_count_x);
+  ok &= write_kernarg(memory, kernarg_addr, args, "hidden_block_count_y", 1);
+  ok &= write_kernarg(memory, kernarg_addr, args, "hidden_block_count_z", 1);
+  ok &= write_kernarg(memory, kernarg_addr, args, "hidden_group_size_x", group_size_x);
+  ok &= write_kernarg(memory, kernarg_addr, args, "hidden_group_size_y", 1);
+  ok &= write_kernarg(memory, kernarg_addr, args, "hidden_group_size_z", 1);
+  return ok;
+}
 
 struct KernelDescriptor {
   uint32_t group_segment_fixed_size;
@@ -117,7 +157,7 @@ TEST(VectorAddStressTest, AllCUsGoldenReference) {
   std::vector<float> zeros(N, 0.0f);
   memory->load_image(reinterpret_cast<const uint8_t *>(zeros.data()), vec_bytes, C_ADDR);
 
-  // Write kernel arguments: (A*, B*, C*, N).
+  // Write kernel arguments: (A*, B*, C*, N) + implicit args.
   struct {
     uint64_t A, B, C;
     uint32_t N;
@@ -133,6 +173,10 @@ TEST(VectorAddStressTest, AllCUsGoldenReference) {
   pkt.vgprs_per_wf = 256;
   pkt.kernarg_addr = KERNARG_ADDR;
   pkt.num_user_sgprs = (kd.compute_pgm_rsrc2 >> 1) & 0x1F; // bits[5:1] = USER_SGPR
+                                                           //
+  auto arg_meta = parseKernelArgs(co->image_data(), co->size());
+  ASSERT_TRUE(arg_meta.has_value()) << "Failed to parse kernel arg metadata";
+  ASSERT_TRUE(write_implicit_args(memory, KERNARG_ADDR, *arg_meta, TOTAL_CUS, WF_SIZE));
 
   for (uint32_t xi = 0; xi < TOTAL_XCDS; ++xi) {
     pkt.workgroup_count = wgs_per_xcd;
@@ -215,6 +259,9 @@ TEST(VectorAddStressTest, AllCUsGoldenReference_MultiThreaded) {
     uint32_t N;
   } args = {A_ADDR, B_ADDR, C_ADDR, N};
   memory->load_image(reinterpret_cast<const uint8_t *>(&args), sizeof(args), KERNARG_ADDR);
+  auto arg_meta = parseKernelArgs(co->image_data(), co->size());
+  ASSERT_TRUE(arg_meta.has_value()) << "Failed to parse kernel arg metadata";
+  ASSERT_TRUE(write_implicit_args(memory, KERNARG_ADDR, *arg_meta, TOTAL_CUS, WF_SIZE));
 
   uint32_t wgs_per_xcd = TOTAL_CUS / TOTAL_XCDS;
   amdgpu::DispatchPacket pkt;
@@ -246,6 +293,86 @@ TEST(VectorAddStressTest, AllCUsGoldenReference_MultiThreaded) {
   EXPECT_EQ(mismatches, 0u) << mismatches << " elements differ (showing first 10)";
 }
 
+// 2 wavefronts per workgroup: verifies that workitem IDs are correctly
+// offset per wavefront (v0 = wf_index * wf_size + lane).
+TEST(VectorAddStressTest, TwoWavefrontsPerWorkgroup) {
+  Executable exec(kernel_path("vector_add"));
+  ASSERT_TRUE(exec.is_valid()) << "Failed to load vector_add.o";
+  ASSERT_GT(exec.num_code_objects(ROCJITSU_CODE_TARGET_GFX950), 0u);
+  auto *co = exec.code_object(ROCJITSU_CODE_TARGET_GFX950, 0);
+  ASSERT_NE(co, nullptr);
+
+  auto kd = read_kernel_descriptor(*co);
+  ASSERT_NE(kd.kernel_code_entry_byte_offset, 0);
+
+  auto loaded = config::load_config(kConfigPath, kSchemaPath);
+  auto *soc = loaded.soc();
+  auto *memory = loaded.memory();
+  auto engine = std::make_unique<simdojo::SimulationEngine>(loaded.engine_config);
+  engine->topology().set_root(loaded.take_root());
+  loaded.wire_links(engine->topology());
+  engine->build();
+
+  const auto *text = co->text_sections()[0];
+  memory->load_image(reinterpret_cast<const uint8_t *>(text->data()), text->size(), CODE_ADDR);
+
+  constexpr uint32_t WFS_PER_WG = 2;
+  constexpr uint32_t THREADS_PER_WG = WFS_PER_WG * WF_SIZE;
+  constexpr uint32_t TOTAL_N = TOTAL_CUS * THREADS_PER_WG;
+
+  size_t vec_bytes = TOTAL_N * sizeof(float);
+  std::vector<float> A(TOTAL_N), B(TOTAL_N), C_expected(TOTAL_N);
+  for (uint32_t i = 0; i < TOTAL_N; ++i) {
+    A[i] = static_cast<float>(i % 97) * 0.1f;
+    B[i] = static_cast<float>(i % 61) * 0.2f;
+    C_expected[i] = A[i] + B[i];
+  }
+
+  memory->load_image(reinterpret_cast<const uint8_t *>(A.data()), vec_bytes, A_ADDR);
+  memory->load_image(reinterpret_cast<const uint8_t *>(B.data()), vec_bytes, B_ADDR);
+  std::vector<float> zeros(TOTAL_N, 0.0f);
+  memory->load_image(reinterpret_cast<const uint8_t *>(zeros.data()), vec_bytes, C_ADDR);
+
+  struct {
+    uint64_t A, B, C;
+    uint32_t N;
+  } args = {A_ADDR, B_ADDR, C_ADDR, TOTAL_N};
+  memory->load_image(reinterpret_cast<const uint8_t *>(&args), sizeof(args), KERNARG_ADDR);
+  // Implicit args start after explicit args (28 bytes, padded to 32).
+  auto arg_meta = parseKernelArgs(co->image_data(), co->size());
+  ASSERT_TRUE(arg_meta.has_value()) << "Failed to parse kernel arg metadata";
+  ASSERT_TRUE(write_implicit_args(memory, KERNARG_ADDR, *arg_meta, TOTAL_CUS, THREADS_PER_WG));
+
+  uint32_t wgs_per_xcd = TOTAL_CUS / TOTAL_XCDS;
+  amdgpu::DispatchPacket pkt;
+  pkt.kernel_entry_pc = CODE_ADDR;
+  pkt.wfs_per_workgroup = WFS_PER_WG;
+  pkt.sgprs_per_wf = 104;
+  pkt.vgprs_per_wf = 256;
+  pkt.kernarg_addr = KERNARG_ADDR;
+  pkt.num_user_sgprs = (kd.compute_pgm_rsrc2 >> 1) & 0x1F;
+
+  for (uint32_t xi = 0; xi < TOTAL_XCDS; ++xi) {
+    pkt.workgroup_count = wgs_per_xcd;
+    pkt.workgroup_id_offset = xi * wgs_per_xcd;
+    soc->xcd(xi)->command_processor()->enqueue(pkt);
+  }
+
+  engine->run();
+  soc->flush_all();
+
+  unsigned mismatches = 0;
+  for (uint32_t i = 0; i < TOTAL_N; ++i) {
+    float actual = std::bit_cast<float>(memory->read32(C_ADDR + i * sizeof(float)));
+    if (std::abs(actual - C_expected[i]) > 1e-6f) {
+      if (mismatches < 10)
+        ADD_FAILURE() << "Mismatch at C[" << i << "]: GPU=" << actual << " CPU=" << C_expected[i];
+      ++mismatches;
+    }
+  }
+  EXPECT_EQ(mismatches, 0u) << mismatches << " elements differ (showing first 10)";
+}
+
 TEST(VectorAddCodeObjectTest, LoadsAndDecodes) {
   Executable exec(kernel_path("vector_add"));
   ASSERT_TRUE(exec.is_valid()) << "Failed to load vector_add.o";
@@ -258,6 +385,29 @@ TEST(VectorAddCodeObjectTest, LoadsAndDecodes) {
   const auto *data = reinterpret_cast<const uint32_t *>(text->data());
   auto inst = decoder->decode(data);
   EXPECT_NE(inst, nullptr) << "Failed to decode first instruction";
+}
+
+TEST(VectorAddCodeObjectTest, KernelMetadataContainsImplicitArgs) {
+  Executable exec(kernel_path("vector_add"));
+  ASSERT_TRUE(exec.is_valid());
+  auto *co = exec.code_object(ROCJITSU_CODE_TARGET_GFX950, 0);
+  ASSERT_NE(co, nullptr);
+
+  auto args = parseKernelArgs(co->image_data(), co->size());
+  ASSERT_TRUE(args.has_value()) << "Failed to parse kernel metadata";
+
+  // Explicit args: 3 global buffers (A, B, C) and 1 scalar (N).
+  EXPECT_TRUE(args->count("global_buffer"));
+  EXPECT_TRUE(args->count("by_value"));
+
+  // Implicit args needed for blockDim.x / gridDim.x.
+  ASSERT_TRUE(args->count("hidden_block_count_x"));
+  ASSERT_TRUE(args->count("hidden_group_size_x"));
+  EXPECT_EQ(args->at("hidden_block_count_x").size, 4u);
+  EXPECT_EQ(args->at("hidden_group_size_x").size, 2u);
+
+  // group_size offset must come after the explicit args.
+  EXPECT_GT(args->at("hidden_group_size_x").offset, args->at("by_value").offset);
 }
 
 } // namespace


### PR DESCRIPTION
## Motivation

My starting goal was to implement a prototype race condition detector, where 2 wavefronts race in LDS. I couldn't get a 2-wave workgroup emulation working though, and that's what this PR aims to remedy.  This PR includes a small fix (in command_processor.cpp) for this: initialize vector register 0 with the a thread's workgroup ID, not wavefront ID (lane). 

This PR also includes (and this is most of the code here) some functionality for setting hidden kernel arguments. There's 2 parts: (1) `parseKernelArgs` which gets the offsets of the kernel arguments from the .co (it requires msgpack, a new cmake dep) and (2) In the new test, a helper `write_kernarg` that uses `parseKernelArgs`, and writes workgroup and grid sizes into the kernel arguments. 

Side thought: Instead of needing to manually initialize kernel arguments and then call `engine->run()`, I wonder if we can have an API somewhere that is closer to HIP's `engine->run<number_of_blocks, threads_per_block>(a, b, c);`? But maybe that should be in the user of rocjitsu's code, not rocjitsu itself? 

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## JIRA ID

N/A

## Test Plan

Some basic testing added, will add more if this PR is going in a good direction. 

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
