### PR TITLE
rocr: fix allocation map for multi node ipc

### DIFF
--- a/projects/rocr-runtime/libhsakmt/src/dxg/memory.cpp
+++ b/projects/rocr-runtime/libhsakmt/src/dxg/memory.cpp
@@ -506,8 +506,7 @@ bool is_ipc_sysmemfd(uint64_t fd) {
   linkTarget[bytes] = '\0';
   return strstr(linkTarget, "rocr4wsl_gtt") != nullptr;
 #else
-  assert(!"Unimplemeted!");
-  return true;
+  return false;
 #endif
 }
 
@@ -1100,16 +1099,17 @@ HSAKMT_STATUS HSAKMTAPI hsaKmtHandleImport(const HsaExternalHandleDesc* import_d
   if (import_desc->mem != nullptr) {
     void *memaddr = import_desc->mem;
     auto phys_mem = GetGpuMemoryFromAddress(memaddr);
-    if (!phys_mem) return HSAKMT_STATUS_INVALID_HANDLE;
-    if (!phys_mem->IsPhysicalCreated()) {
-      auto code = phys_mem->CreatePhysicalMemory();
-      if (code != ErrorCode::Success) {
-        return HSAKMT_STATUS_OUT_OF_RESOURCES;
+    if (phys_mem) {
+      if (!phys_mem->IsPhysicalCreated()) {
+        auto code = phys_mem->CreatePhysicalMemory();
+        if (code != ErrorCode::Success) {
+          return HSAKMT_STATUS_OUT_OF_RESOURCES;
+        }
       }
+      import_res->buf_handle = reinterpret_cast<HsaMemoryObjectHandle>(
+                               phys_mem->GetGpuMemoryHandle());
+      return HSAKMT_STATUS_SUCCESS;
     }
-    import_res->buf_handle = reinterpret_cast<HsaMemoryObjectHandle>(
-                             phys_mem->GetGpuMemoryHandle());
-    return HSAKMT_STATUS_SUCCESS;
   }
 
   if (import_desc->type != HSA_EXTERNAL_HANDLE_DMA_BUF) {

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/runtime.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/runtime.cpp
@@ -1539,11 +1539,9 @@ hsa_status_t Runtime::IPCAttach(const hsa_amd_ipc_memory_t* handle, size_t len, 
       len = Min(len, importSize - fragOffset);
     }
     std::lock_guard<std::shared_mutex> lock(memory_lock_);
-    if (allocation_map_.find(importAddress) == allocation_map_.end()) {
-      allocation_map_[importAddress] =
-          AllocationRegion(nullptr, len, len, core::MemoryRegion::AllocateNoFlags);
-      allocation_map_[importAddress].thunk_bo = thunk_bo;
-    }
+    allocation_map_.try_emplace(
+        importAddress, nullptr, len, len, core::MemoryRegion::AllocateNoFlags);
+    allocation_map_[importAddress].thunk_bo = thunk_bo;
   };
 
   auto importMemory = [&](unsigned int numNodes, HSAuint32 *nodes, bool isSysMem) {


### PR DESCRIPTION
## Motivation

1. Fix failure in hipIpcMemAccess_Semaphores testcase
2. allocation_map_ in rocr needs to be updated after client finishes the IPC. thunk BO is set to NULL for ipcDetach to follow correct code path.
3. hsaKmtHandleImport needs to handle the case where addr is not found in map. Import the dmabuf fd in case ptr is not in map. This fixes the Unit_hipIpcGetMemHandle_Positive_Unique_Handles_Separate_Allocations testcase on windows/wsl

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
