### PR TITLE
rocprofiler-sdk: attach: Add multiprocess support

### DIFF
--- a/projects/rocprofiler-sdk/source/bin/rocprof-attach.py
+++ b/projects/rocprofiler-sdk/source/bin/rocprof-attach.py
@@ -72,6 +72,17 @@ def parse_arguments(args=None):
     )
 
     parser.add_argument(
+        "--attach-children",
+        help="""Attach to the target process and all of its descendant processes (default: true).
+  Can also be specified in environment variable ROCPROF_ATTACH_CHILDREN. This option overrides the environment variable if both are set.""",
+        type=lambda v: v.lower() not in ("0", "false", "no", "off"),
+        required=False,
+        default=os.environ.get("ROCPROF_ATTACH_CHILDREN", "1")
+        not in ("0", "false", "no", "off"),
+        metavar="BOOL",
+    )
+
+    parser.add_argument(
         "-t",
         "--attach-tool-library",
         help="""Comma delimited list of tool libraries to use during attachment.
@@ -110,6 +121,7 @@ def attach(
     attach_tool_library,
     attach_duration_msec,
     attach_library=ROCPROF_ATTACH_LIBRARY,
+    attach_children=True,
 ):
 
     if pid is None:
@@ -132,9 +144,14 @@ def attach(
         c_lib = ctypes.CDLL(attach_library)
         c_lib.rocattach_attach.restype = ctypes.c_int
         c_lib.rocattach_attach.argtypes = [ctypes.c_int]
+        c_lib.rocattach_attach_tree.restype = ctypes.c_int
+        c_lib.rocattach_attach_tree.argtypes = [ctypes.c_int]
         c_lib.rocattach_detach.restype = ctypes.c_int
         c_lib.rocattach_detach.argtypes = [ctypes.c_int]
-        attach_status = c_lib.rocattach_attach(pid)
+        if attach_children:
+            attach_status = c_lib.rocattach_attach_tree(pid)
+        else:
+            attach_status = c_lib.rocattach_attach(pid)
     except Exception as e:
         raise RuntimeError(f"Exception during library load and attachment: {e}")
 
@@ -187,6 +204,7 @@ def main(cmd_args=None):
         attach_tool_library=args.attach_tool_library,
         attach_duration_msec=args.attach_duration_msec,
         attach_library=args.attach_library,
+        attach_children=args.attach_children,
     )
     return 0
 

--- a/projects/rocprofiler-sdk/source/bin/rocprof-attach.py
+++ b/projects/rocprofiler-sdk/source/bin/rocprof-attach.py
@@ -148,6 +148,8 @@ def attach(
         c_lib.rocattach_attach_tree.argtypes = [ctypes.c_int]
         c_lib.rocattach_detach.restype = ctypes.c_int
         c_lib.rocattach_detach.argtypes = [ctypes.c_int]
+        c_lib.rocattach_detach_tree.restype = ctypes.c_int
+        c_lib.rocattach_detach_tree.argtypes = [ctypes.c_int]
         if attach_children:
             attach_status = c_lib.rocattach_attach_tree(pid)
         else:
@@ -166,7 +168,10 @@ def attach(
         print("Detaching. Please wait, this can take up to 1-2 minutes")
         sys.stdout.flush()
         try:
-            detach_status = c_lib.rocattach_detach(int(pid))
+            if attach_children:
+                detach_status = c_lib.rocattach_detach_tree(int(pid))
+            else:
+                detach_status = c_lib.rocattach_detach(int(pid))
         except Exception as e:
             print(f"Exception during detachment: {e}")
 

--- a/projects/rocprofiler-sdk/source/bin/rocprofv3.py
+++ b/projects/rocprofiler-sdk/source/bin/rocprofv3.py
@@ -931,6 +931,13 @@ For attachment profiling of running processes:
         default=None,
     )
 
+    add_parser_bool_argument(
+        advanced_options,
+        "--attach-children",
+        help="""When --pid is used, attach to the target process and all of its descendant processes. Enabled by default; use --attach-children=false to attach only to the specified PID.""",
+        default=True,
+    )
+
     if args is None:
         args = sys.argv[1:]
 
@@ -1819,6 +1826,7 @@ def run(app_args, args, **kwargs):
         update_env("ROCPROF_ATTACH_PID", args.pid)
         if args.attach_duration_msec is not None:
             update_env("ROCPROF_ATTACH_DURATION", f"{args.attach_duration_msec}")
+        update_env("ROCPROF_ATTACH_CHILDREN", "1" if args.attach_children else "0")
         path = os.path.join(f"{ROCM_DIR}", "bin/rocprof-attach")
         if app_args:
             exit_code = subprocess.check_call([sys.executable, path], env=app_env)

--- a/projects/rocprofiler-sdk/source/docs/api-reference/process_attachment.rst
+++ b/projects/rocprofiler-sdk/source/docs/api-reference/process_attachment.rst
@@ -24,6 +24,12 @@ The python file ``rocprof-attach`` can be called directly to attach to a specifi
 
 In this example, the process with PID 12345 will be attached to and the library path/to/your-tool-library.so will be loaded by rocprofiler-sdk from within that process. After 5000 milliseconds have passed, detach will be called and ``rocprof-attach`` will exit when detachment is complete.
 
+By default, ``rocprof-attach`` attaches to the target process and all of its descendant processes. To attach only to the specified PID, pass ``--attach-children=false``:
+
+.. code-block:: bash
+
+   $ rocprof-attach -p 12345 -t path/to/your-tool-library.so --attach-children=false
+
 More information can be found by invoking ``rocprof-attach -h``
 
 
@@ -39,6 +45,7 @@ The python file ``rocprof-attach`` defines an attach function that can be used f
      attach_tool_library,
      attach_duration_msec,
      attach_library=ROCPROF_ATTACH_LIBRARY,
+     attach_children=True,
    ):
 
 **Function Details**
@@ -54,32 +61,53 @@ The attach function performs the entire attachment process, including attaching 
 - **attach_library**: Optional - Tool library to use for attachment and detachment
    - Default will work for nearly all applications
    - If unspecified, defaults to the absolute path of librocprofiler-sdk-rocattach.so
+- **attach_children**: Optional - Whether to attach to the target process and all of its descendant processes
+   - Defaults to ``True``; pass ``False`` to attach only to the specified PID
 
 C Functions
 ===================================
 
-The C library ``librocprofiler-sdk-rocattach.so`` defines an attach and detach function that can be used for attachment:
+The C library ``librocprofiler-sdk-rocattach.so`` defines attach and detach functions that can be used for attachment:
 
 .. code-block:: cpp
 
    extern "C" {
-       // Start attachment to a target process
+       // Attach to a process and all of its descendant processes
+       rocattach_status_t rocattach_attach_tree(int pid) ROCATTACH_API;
+
+       // Attach to a single process only
        rocattach_status_t rocattach_attach(int pid) ROCATTACH_API;
 
-       // Detach from target process and cleanup
+       // Detach from a process and all of its descendant processes
+       rocattach_status_t rocattach_detach_tree(int pid) ROCATTACH_API;
+
+       // Detach from a single process (or all sessions when pid=0)
        rocattach_status_t rocattach_detach(int pid) ROCATTACH_API;
    }
 
 **Function Details:**
 
-- **rocattach_attach(int pid)**: Main entry point for starting attachment to a process
-   - Takes the target process ID as parameter
-   - Initiates ptrace-based attachment sequence
+- **rocattach_attach_tree(int pid)**: Attach to a process and all of its descendants
+   - Enumerates the full process tree rooted at ``pid`` via ``/proc`` before attaching
+   - Attachment proceeds in breadth-first order from the root
+   - If attachment to an individual child process fails, the error is logged and attachment continues with the remaining processes; the return status reflects the last error seen
+   - The process tree is snapshotted at the time of the call; processes spawned after this point are not included
 
-- **rocattach_detach(int pid)**: Entry point for detaching from the target process
+- **rocattach_attach(int pid)**: Attach to a single process only
+   - Takes the target process ID as parameter
+   - Does not attach to child processes
+   - Use ``rocattach_attach_tree`` instead when profiling applications that spawn child processes
+
+- **rocattach_detach_tree(int pid)**: Detach from a process and all of its descendants
+   - Enumerates the process tree rooted at ``pid`` via ``/proc`` at the time of the call
+   - Only processes with an active attachment session are detached; others are silently skipped
+   - Symmetric counterpart to ``rocattach_attach_tree``; use these two together
+   - Reentrant: the sessions lock is acquired and released per-process and is not held across the ``/proc`` traversal, so concurrent calls from multiple threads are safe
+
+- **rocattach_detach(int pid)**: Detach from a single process
    - Takes the target process ID as a parameter
    - Cleans up attachment resources and terminates profiling
-   - A PID of 0 can be specified to detach from all processes
+   - A PID of 0 can be specified to detach from all current sessions
 
 Function Call Sequence
 ======================
@@ -172,9 +200,11 @@ Basic Attachment Implementation
                return false;
            }
 
-           // Get the attachment function pointers
-           attach_func = (rocattach_status_t(*)(int))dlsym(attach_lib_handle, "rocattach_attach");
-           detach_func = (rocattach_status_t(*)(int))dlsym(attach_lib_handle, "rocattach_detach");
+           // Get the attachment function pointers.
+           // Use rocattach_attach_tree/rocattach_detach_tree to attach to the process and all
+           // its descendants, or rocattach_attach/rocattach_detach for a single process only.
+           attach_func = (rocattach_status_t(*)(int))dlsym(attach_lib_handle, "rocattach_attach_tree");
+           detach_func = (rocattach_status_t(*)(int))dlsym(attach_lib_handle, "rocattach_detach_tree");
 
            if (!attach_func || !detach_func) {
                std::cerr << "Failed to find attachment functions" << std::endl;

--- a/projects/rocprofiler-sdk/source/docs/how-to/using-rocprofv3-process-attachment.rst
+++ b/projects/rocprofiler-sdk/source/docs/how-to/using-rocprofv3-process-attachment.rst
@@ -129,6 +129,24 @@ Full list of options that must not change
   - ``kernel_exclude_regex``
   - ``kernel_iteration_range``
 
+Attaching to a process tree
+----------------------------
+
+By default, ``rocprofv3 --attach`` attaches to the target process **and all of its descendant processes**. This is useful for profiling applications that spawn child processes, such as multi-process MPI jobs or launchers that fork workers.
+
+.. code-block:: bash
+
+   # Attach to PID 1234 and all its children (default behavior)
+   rocprofv3 --attach 1234 --hip-trace
+
+To attach only to the specified PID and skip its descendants, pass ``--attach-children=false``:
+
+.. code-block:: bash
+
+   rocprofv3 --attach 1234 --attach-children=false --hip-trace
+
+The child process tree is enumerated once at attach time using ``/proc``. Processes that are spawned after attachment begins are not automatically profiled.
+
 Key considerations
 -------------------
 
@@ -141,3 +159,5 @@ Here are some important points to be noted while using dynamic process attachmen
 - To use attachment in a docker container, add the ``ptrace`` capability to the container (``SYS_PTRACE``).
 
 - The profiler collects data for the entire remaining lifetime of the process or until the configured collection period expires. To learn how to configure the collection period, see :ref:`duration-specific`.
+
+- When attaching to a process tree, if attachment to an individual child process fails (for example, because it exited between enumeration and attach), the error is logged and attachment continues with the remaining processes.

--- a/projects/rocprofiler-sdk/source/include/rocprofiler-sdk-rocattach/rocattach.h
+++ b/projects/rocprofiler-sdk/source/include/rocprofiler-sdk-rocattach/rocattach.h
@@ -113,16 +113,16 @@ rocattach_status_t
 rocattach_attach(int pid) ROCATTACH_API;
 
 /**
- * @brief Detach from a process ID and all of its descendant processes
+ * @brief Detach from the process tree previously attached via rocattach_attach_tree()
  *
- * Enumerates the process tree rooted at `pid` (via /proc) and detaches from each process that
- * has an active attachment session. Detachment proceeds breadth-first from the root. Processes
- * in the tree that were never attached are silently skipped. If any individual detach fails, the
- * error is logged and detachment continues with the remaining processes; the return status
- * reflects the last error seen. This function is reentrant: each teardown call acquires and
- * releases the sessions lock internally and does not hold it across the /proc traversal.
+ * Detaches from exactly the set of processes that were successfully attached by the corresponding
+ * rocattach_attach_tree() call for the same `pid`. The PID list is recorded at attach time and
+ * consumed here, so this function does not re-enumerate /proc. If any individual detach fails,
+ * the error is logged and detachment continues with the remaining processes; the return status
+ * reflects the last error seen. Returns ROCATTACH_STATUS_ERROR_INVALID_ARGUMENT if no tree
+ * attachment session exists for `pid`.
  *
- * @param [in] pid Root process ID to detach from
+ * @param [in] pid Root process ID passed to the corresponding rocattach_attach_tree() call
  * @return ::rocattach_status_t
  * @retval ::ROCATTACH_STATUS_SUCCESS All attached processes detached successfully
  */

--- a/projects/rocprofiler-sdk/source/include/rocprofiler-sdk-rocattach/rocattach.h
+++ b/projects/rocprofiler-sdk/source/include/rocprofiler-sdk-rocattach/rocattach.h
@@ -82,13 +82,28 @@ rocattach_status_t
 rocattach_get_version_triplet(rocattach_version_triplet_t* info) ROCATTACH_API ROCATTACH_NONNULL(1);
 
 /**
+ * @brief Attach to a process ID and all of its descendant processes
+ *
+ * Enumerates the full process tree rooted at `pid` (via /proc) and attaches to each process.
+ * Attachment proceeds breadth-first from the root. If any individual attach fails, the error is
+ * logged and attachment continues with the remaining processes; the return status reflects the
+ * last error seen.
+ *
+ * @param [in] pid Root process ID to attach to
+ * @return ::rocattach_status_t
+ * @retval ::ROCATTACH_STATUS_SUCCESS All processes attached successfully
+ */
+rocattach_status_t
+rocattach_attach_tree(int pid) ROCATTACH_API;
+
+/**
  * @brief Attach to a process ID
  *
  * Attempts to attach to a rocm process at the given process identifier (PID). If successful, the
  * target process will then load rocprofiler-sdk, which will subsequently load any tool libraries
  * given in the environment variable ROCPROF_ATTACH_TOOL_LIBRARY. This environment variable should
  * be set for the attacher process before calling rocattach_attach(). It does not need to be set
- * for the attachee.
+ * for the attachee. To attach to a process and all of its descendants, use rocattach_attach_tree().
  *
  * @param [in] pid Process ID to attach to
  * @return ::rocattach_status_t
@@ -96,6 +111,23 @@ rocattach_get_version_triplet(rocattach_version_triplet_t* info) ROCATTACH_API R
  */
 rocattach_status_t
 rocattach_attach(int pid) ROCATTACH_API;
+
+/**
+ * @brief Detach from a process ID and all of its descendant processes
+ *
+ * Enumerates the process tree rooted at `pid` (via /proc) and detaches from each process that
+ * has an active attachment session. Detachment proceeds breadth-first from the root. Processes
+ * in the tree that were never attached are silently skipped. If any individual detach fails, the
+ * error is logged and detachment continues with the remaining processes; the return status
+ * reflects the last error seen. This function is reentrant: each teardown call acquires and
+ * releases the sessions lock internally and does not hold it across the /proc traversal.
+ *
+ * @param [in] pid Root process ID to detach from
+ * @return ::rocattach_status_t
+ * @retval ::ROCATTACH_STATUS_SUCCESS All attached processes detached successfully
+ */
+rocattach_status_t
+rocattach_detach_tree(int pid) ROCATTACH_API;
 
 /**
  * @brief Detach from a process ID

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-rocattach/ptrace_session.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-rocattach/ptrace_session.cpp
@@ -310,8 +310,6 @@ PTraceSession::ptrace_signal_handler_func(
             else
             {
                 // Not our signal, forward the signal to the app using CONT
-                ROCP_TRACE << "[rocprofiler-sdk-rocattach] ptrace call params(PTRACE_CONT(7), "
-                           << _pid << ", 0, " << sig << ")";
                 uint64_t           _retval = 0;
                 int                _errno  = 0;
                 rocattach_status_t _status = ptrace_run(

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-rocattach/rocattach.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-rocattach/rocattach.cpp
@@ -45,8 +45,21 @@ namespace rocattach
 {
 namespace
 {
-using session_t      = rocprofiler::rocattach::PTraceSession;
-using session_list_t = std::map<int, session_t>;
+using session_t = rocprofiler::rocattach::PTraceSession;
+
+struct pid_entry_t
+{
+    explicit pid_entry_t(pid_t tid)
+    : session(tid)
+    {}
+    session_t session;
+    // Non-empty only for tree-attach root PIDs. Holds the ordered list of PIDs
+    // successfully attached by rocattach_attach_tree() for this root. Consumed
+    // (and cleared) by the corresponding rocattach_detach_tree() call.
+    std::vector<pid_t> tree_pids;
+};
+
+using session_list_t = std::map<int, pid_entry_t>;
 
 #define ROCATTACH_STATUS_STRING(CODE, MSG)                                                         \
     template <>                                                                                    \
@@ -239,7 +252,7 @@ setup(int pid)
         ROCP_INFO << "[rocprofiler-sdk-rocattach] Attaching to PID " << pid
                   << " via background thread TID " << target_tid;
         sessions->emplace(pid, target_tid);
-        session = &(sessions->at(pid));
+        session = &(sessions->at(pid).session);
     }
     auto status = ROCATTACH_STATUS_SUCCESS;
 
@@ -382,7 +395,7 @@ teardown(int pid)
             return ROCATTACH_STATUS_ERROR_INVALID_ARGUMENT;
         }
 
-        session = &(sessions->at(pid));
+        session = &(sessions->at(pid).session);
     }
     auto status = ROCATTACH_STATUS_SUCCESS;
 
@@ -445,7 +458,8 @@ rocattach_attach_tree(int root_pid)
     ROCP_INFO << "[rocprofiler-sdk-rocattach] Found " << pids.size()
               << " process(es) in tree rooted at pid " << root_pid;
 
-    auto last_status = ROCATTACH_STATUS_SUCCESS;
+    std::vector<pid_t> attached_pids;
+    auto               last_status = ROCATTACH_STATUS_SUCCESS;
     for(pid_t pid : pids)
     {
         auto status = rocprofiler::rocattach::setup(pid);
@@ -455,7 +469,28 @@ rocattach_attach_tree(int root_pid)
                        << " with error code " << status << ", continuing with remaining processes";
             last_status = status;
         }
+        else
+        {
+            attached_pids.push_back(pid);
+        }
     }
+
+    {
+        auto  lg       = rocprofiler::rocattach::get_sessions_lock_guard();
+        auto* sessions = CHECK_NOTNULL(rocprofiler::rocattach::get_sessions());
+        auto  it       = sessions->find(root_pid);
+        if(it != sessions->end())
+        {
+            it->second.tree_pids = std::move(attached_pids);
+        }
+        else
+        {
+            ROCP_ERROR << "[rocprofiler-sdk-rocattach] rocattach_attach_tree could not record tree "
+                          "session for root pid "
+                       << root_pid;
+        }
+    }
+
     return last_status;
 }
 
@@ -485,22 +520,33 @@ rocattach_detach_tree(int root_pid)
 {
     rocprofiler::rocattach::initialize_logging();
 
-    // Enumerate the process tree at detach time and tear down every PID that
-    // has an active session. collect_process_tree reads only /proc (no locks),
-    // and teardown acquires and releases the sessions lock internally, so
-    // concurrent calls from multiple threads are safe.
-    auto pids = rocprofiler::rocattach::collect_process_tree(root_pid);
-    ROCP_INFO << "[rocprofiler-sdk-rocattach] rocattach_detach_tree found " << pids.size()
-              << " process(es) in tree rooted at pid " << root_pid;
+    // Retrieve the PID list recorded by rocattach_attach_tree() from the root's map entry.
+    // Using the recorded list (rather than re-enumerating /proc) ensures we detach exactly
+    // the processes that were attached, no more and no less.
+    std::vector<pid_t> pids;
+    {
+        auto  lg       = rocprofiler::rocattach::get_sessions_lock_guard();
+        auto* sessions = CHECK_NOTNULL(rocprofiler::rocattach::get_sessions());
+        auto  it       = sessions->find(root_pid);
+        if(it == sessions->end() || it->second.tree_pids.empty())
+        {
+            ROCP_ERROR << "[rocprofiler-sdk-rocattach] rocattach_detach_tree called for root pid "
+                       << root_pid << " which has no recorded tree attachment session.";
+            return ROCATTACH_STATUS_ERROR_INVALID_ARGUMENT;
+        }
+        pids = std::move(it->second.tree_pids);
+        // If root_pid was not successfully attached it won't be in pids, meaning teardown()
+        // won't erase its entry. Remove it here to avoid leaving an orphan in the map.
+        if(pids.empty() || pids.front() != root_pid) sessions->erase(it);
+    }
+
+    ROCP_INFO << "[rocprofiler-sdk-rocattach] rocattach_detach_tree detaching " << pids.size()
+              << " process(es) for root pid " << root_pid;
 
     auto last_status = ROCATTACH_STATUS_SUCCESS;
     for(pid_t pid : pids)
     {
         auto status = rocprofiler::rocattach::teardown(pid);
-        // teardown returns ROCATTACH_STATUS_ERROR_INVALID_ARGUMENT when there is no active session
-        // for the given PID. This is expected for processes in the tree that were never attached,
-        // so silently skip them rather than propagating the error.
-        if(status == ROCATTACH_STATUS_ERROR_INVALID_ARGUMENT) continue;
         if(status != ROCATTACH_STATUS_SUCCESS)
         {
             ROCP_ERROR << "[rocprofiler-sdk-rocattach] rocattach_detach_tree failed for pid " << pid

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-rocattach/rocattach.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-rocattach/rocattach.cpp
@@ -34,6 +34,7 @@
 #include <fstream>
 #include <map>
 #include <mutex>
+#include <queue>
 #include <unordered_map>
 
 extern char** environ;
@@ -330,6 +331,37 @@ setup(int pid)
     return ROCATTACH_STATUS_SUCCESS;
 }
 
+// Collect all PIDs in the process tree rooted at root_pid (BFS via /proc).
+// Returns root_pid plus all descendant PIDs. Enumerates children for every thread
+// since children can be spawned via clone() from any thread.
+std::vector<pid_t>
+collect_process_tree(pid_t root_pid)
+{
+    std::vector<pid_t> result;
+    std::queue<pid_t>  worklist;
+    worklist.push(root_pid);
+
+    while(!worklist.empty())
+    {
+        pid_t pid = worklist.front();
+        worklist.pop();
+        result.push_back(pid);
+
+        auto            task_dir = "/proc/" + std::to_string(pid) + "/task";
+        std::error_code ec;
+        for(const auto& entry : std::filesystem::directory_iterator(task_dir, ec))
+        {
+            if(!entry.is_directory()) continue;
+            auto          children_path = entry.path() / "children";
+            std::ifstream children_file(children_path);
+            pid_t         child_pid;
+            while(children_file >> child_pid)
+                worklist.push(child_pid);
+        }
+    }
+    return result;
+}
+
 rocattach_status_t
 teardown(int pid)
 {
@@ -399,6 +431,35 @@ teardown(int pid)
 ROCATTACH_EXTERN_C_INIT
 
 rocattach_status_t
+rocattach_attach_tree(int root_pid)
+{
+    rocprofiler::rocattach::initialize_logging();
+
+    if(!rocprofiler::rocattach::PTraceSession::is_supported())
+    {
+        ROCP_ERROR << "[rocprofiler-sdk-attach] rocattach is not supported on this platform.";
+        return ROCATTACH_STATUS_ERROR_NOT_SUPPORTED;
+    }
+
+    auto pids = rocprofiler::rocattach::collect_process_tree(root_pid);
+    ROCP_INFO << "[rocprofiler-sdk-rocattach] Found " << pids.size()
+              << " process(es) in tree rooted at pid " << root_pid;
+
+    auto last_status = ROCATTACH_STATUS_SUCCESS;
+    for(pid_t pid : pids)
+    {
+        auto status = rocprofiler::rocattach::setup(pid);
+        if(status != ROCATTACH_STATUS_SUCCESS)
+        {
+            ROCP_ERROR << "[rocprofiler-sdk-rocattach] rocattach_attach_tree failed for pid " << pid
+                       << " with error code " << status << ", continuing with remaining processes";
+            last_status = status;
+        }
+    }
+    return last_status;
+}
+
+rocattach_status_t
 rocattach_attach(int pid)
 {
     rocprofiler::rocattach::initialize_logging();
@@ -417,6 +478,37 @@ rocattach_attach(int pid)
         return status;
     }
     return ROCATTACH_STATUS_SUCCESS;
+}
+
+rocattach_status_t
+rocattach_detach_tree(int root_pid)
+{
+    rocprofiler::rocattach::initialize_logging();
+
+    // Enumerate the process tree at detach time and tear down every PID that
+    // has an active session. collect_process_tree reads only /proc (no locks),
+    // and teardown acquires and releases the sessions lock internally, so
+    // concurrent calls from multiple threads are safe.
+    auto pids = rocprofiler::rocattach::collect_process_tree(root_pid);
+    ROCP_INFO << "[rocprofiler-sdk-rocattach] rocattach_detach_tree found " << pids.size()
+              << " process(es) in tree rooted at pid " << root_pid;
+
+    auto last_status = ROCATTACH_STATUS_SUCCESS;
+    for(pid_t pid : pids)
+    {
+        auto status = rocprofiler::rocattach::teardown(pid);
+        // teardown returns ROCATTACH_STATUS_ERROR_INVALID_ARGUMENT when there is no active session
+        // for the given PID. This is expected for processes in the tree that were never attached,
+        // so silently skip them rather than propagating the error.
+        if(status == ROCATTACH_STATUS_ERROR_INVALID_ARGUMENT) continue;
+        if(status != ROCATTACH_STATUS_SUCCESS)
+        {
+            ROCP_ERROR << "[rocprofiler-sdk-rocattach] rocattach_detach_tree failed for pid " << pid
+                       << " with error code " << status << ", continuing with remaining processes";
+            last_status = status;
+        }
+    }
+    return last_status;
 }
 
 rocattach_status_t

--- a/projects/rocprofiler-sdk/tests/rocattach/CMakeLists.txt
+++ b/projects/rocprofiler-sdk/tests/rocattach/CMakeLists.txt
@@ -31,6 +31,16 @@ set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_EXTENSIONS OFF)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
+set(PRELOAD_ENV "${ROCPROFILER_MEMCHECK_PRELOAD_ENV_VALUE}")
+
+set(rocattach-test-env
+    "ROCP_TOOL_ATTACH=1"
+    "ROCPROFILER_REGISTER_LOG_LEVEL=${LOG_LEVEL}"
+    "ROCPROFILER_LOG_LEVEL=${LOG_LEVEL}"
+    "ROCATTACH_LOG_LEVEL=${LOG_LEVEL}"
+    "LD_LIBRARY_PATH=$<TARGET_FILE_DIR:rocprofiler-sdk::rocprofiler-sdk-shared-library>:$ENV{LD_LIBRARY_PATH}"
+    )
+
 add_executable(rocattach-parallel-attach-test)
 target_sources(rocattach-parallel-attach-test PRIVATE main.cpp)
 target_link_libraries(
@@ -39,50 +49,44 @@ target_link_libraries(
             rocprofiler-sdk::tests-common-library
             rocprofiler-sdk::rocprofiler-sdk-rocattach-shared-library)
 
-add_test(NAME rocattach-parallel-attach-test-execute
-         COMMAND $<TARGET_FILE:rocattach-parallel-attach-test>
-                 $<TARGET_FILE:attachment-test> $<TARGET_FILE:rocprofiler-sdk-c-tool>)
-
-add_test(
-    NAME rocattach-parallel-attach-test-signal-execute
-    COMMAND $<TARGET_FILE:rocattach-parallel-attach-test> $<TARGET_FILE:attachment-test>
-            $<TARGET_FILE:rocprofiler-sdk-c-tool> --send-signal)
-
-set(rocattach-test-env
-    "${ROCPROFILER_MEMCHECK_PRELOAD_ENV}"
-    "ROCP_TOOL_ATTACH=1"
-    "ROCPROFILER_REGISTER_LOG_LEVEL=${LOG_LEVEL}"
-    "ROCPROFILER_LOG_LEVEL=${LOG_LEVEL}"
-    "ROCATTACH_LOG_LEVEL=${LOG_LEVEL}"
-    "LD_LIBRARY_PATH=$<TARGET_FILE_DIR:rocprofiler-sdk::rocprofiler-sdk-shared-library>:$ENV{LD_LIBRARY_PATH}"
-    )
-
-set_tests_properties(
+rocprofiler_add_integration_execute_test(
     rocattach-parallel-attach-test-execute
-    PROPERTIES TIMEOUT
-               45
-               LABELS
-               "integration-tests"
-               ENVIRONMENT
-               "${rocattach-test-env}"
-               PASS_REGULAR_EXPRESSION
-               "Test C tool \\(priority=0\\) is using rocprofiler-sdk v"
-               FAIL_REGULAR_EXPRESSION
-               "${ROCPROFILER_DEFAULT_FAIL_REGEX}"
-               DISABLED
-               "${IS_DISABLED}")
+    TARGET rocattach-parallel-attach-test
+    ARGS $<TARGET_FILE:attachment-test> $<TARGET_FILE:rocprofiler-sdk-c-tool>
+    TIMEOUT 45
+    DISABLED ${IS_DISABLED}
+    PRELOAD "${PRELOAD_ENV}"
+    ENVIRONMENT "${rocattach-test-env}"
+    PASS_REGULAR_EXPRESSION "Test C tool \\(priority=0\\) is using rocprofiler-sdk v"
+    FAIL_REGULAR_EXPRESSION "${ROCPROFILER_DEFAULT_FAIL_REGEX}")
 
-set_tests_properties(
+rocprofiler_add_integration_execute_test(
     rocattach-parallel-attach-test-signal-execute
-    PROPERTIES TIMEOUT
-               45
-               LABELS
-               "integration-tests"
-               ENVIRONMENT
-               "${rocattach-test-env}"
-               PASS_REGULAR_EXPRESSION
-               "Attachment test process [0-9]+ received signal 28"
-               FAIL_REGULAR_EXPRESSION
-               "${ROCPROFILER_DEFAULT_FAIL_REGEX}"
-               DISABLED
-               "${IS_DISABLED}")
+    TARGET rocattach-parallel-attach-test
+    ARGS $<TARGET_FILE:attachment-test> $<TARGET_FILE:rocprofiler-sdk-c-tool>
+         --send-signal
+    TIMEOUT 45
+    DISABLED ${IS_DISABLED}
+    PRELOAD "${PRELOAD_ENV}"
+    ENVIRONMENT "${rocattach-test-env}"
+    PASS_REGULAR_EXPRESSION "Attachment test process [0-9]+ received signal 28"
+    FAIL_REGULAR_EXPRESSION "${ROCPROFILER_DEFAULT_FAIL_REGEX}")
+
+add_executable(rocattach-attach-tree-test)
+target_sources(rocattach-attach-tree-test PRIVATE attach_tree.cpp)
+target_link_libraries(
+    rocattach-attach-tree-test
+    PRIVATE rocprofiler-sdk::rocprofiler-sdk rocprofiler-sdk::tests-build-flags
+            rocprofiler-sdk::tests-common-library
+            rocprofiler-sdk::rocprofiler-sdk-rocattach-shared-library)
+
+rocprofiler_add_integration_execute_test(
+    rocattach-attach-tree-test-execute
+    TARGET rocattach-attach-tree-test
+    ARGS $<TARGET_FILE:attachment-test> $<TARGET_FILE:rocprofiler-sdk-c-tool>
+    TIMEOUT 45
+    DISABLED ${IS_DISABLED}
+    PRELOAD "${PRELOAD_ENV}"
+    ENVIRONMENT "${rocattach-test-env}"
+    PASS_REGULAR_EXPRESSION "verified: grandchild pid [0-9]+ loaded the tool library"
+    FAIL_REGULAR_EXPRESSION "${ROCPROFILER_DEFAULT_FAIL_REGEX}")

--- a/projects/rocprofiler-sdk/tests/rocattach/attach_tree.cpp
+++ b/projects/rocprofiler-sdk/tests/rocattach/attach_tree.cpp
@@ -174,6 +174,10 @@ main(int argc, char** argv)
     if(!is_library_loaded(child_pid, tool_library))
     {
         std::cout << "error: tool library not found in child pid " << child_pid << " maps\n";
+        kill(grandchild_pid, SIGKILL);
+        kill(child_pid, SIGKILL);
+        waitpid(grandchild_pid, nullptr, 0);
+        waitpid(child_pid, nullptr, 0);
         return 1;
     }
     std::cout << "verified: child pid " << child_pid << " loaded the tool library\n";
@@ -182,6 +186,10 @@ main(int argc, char** argv)
     {
         std::cout << "error: tool library not found in grandchild pid " << grandchild_pid
                   << " maps\n";
+        kill(grandchild_pid, SIGKILL);
+        kill(child_pid, SIGKILL);
+        waitpid(grandchild_pid, nullptr, 0);
+        waitpid(child_pid, nullptr, 0);
         return 1;
     }
     std::cout << "verified: grandchild pid " << grandchild_pid << " loaded the tool library\n";
@@ -192,8 +200,18 @@ main(int argc, char** argv)
     // Detach from the process tree symmetrically with how we attached.
     ROCATTACH_CALL(rocattach_detach_tree(child_pid));
 
+    int grandchild_status = 0;
+    waitpid(grandchild_pid, &grandchild_status, 0);
+
     int child_status = 0;
     waitpid(child_pid, &child_status, 0);
+
+    if(grandchild_status != 0)
+    {
+        std::cout << "error: grandchild process returned non-zero status: " << grandchild_status
+                  << std::endl;
+        return 1;
+    }
 
     if(child_status != 0)
     {

--- a/projects/rocprofiler-sdk/tests/rocattach/attach_tree.cpp
+++ b/projects/rocprofiler-sdk/tests/rocattach/attach_tree.cpp
@@ -1,0 +1,205 @@
+// MIT License
+//
+// Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+// Tests rocattach_attach_tree(), which attaches to a process and all of its
+// descendant processes. The parent forks a child which executes the test app;
+// rocattach_attach_tree() is called on the parent PID and must also attach to
+// the child without the caller enumerating it explicitly.
+
+#include <rocprofiler-sdk-rocattach/defines.h>
+#include <rocprofiler-sdk-rocattach/rocattach.h>
+#include <rocprofiler-sdk-rocattach/types.h>
+
+#include <signal.h>
+#include <stdlib.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+#include <chrono>
+#include <fstream>
+#include <iostream>
+#include <string>
+#include <thread>
+
+#define ROCATTACH_CALL(func)                                                                       \
+    {                                                                                              \
+        std::cout << "starting call to " #func << std::endl;                                       \
+        rocattach_status_t status = func;                                                          \
+        if(status != ROCATTACH_STATUS_SUCCESS)                                                     \
+        {                                                                                          \
+            std::cout << "error: call to " #func " returned non zero status " << status            \
+                      << std::endl;                                                                \
+            return 1;                                                                              \
+        }                                                                                          \
+        else                                                                                       \
+        {                                                                                          \
+            std::cout << "call to " #func " successful" << std::endl;                              \
+        }                                                                                          \
+    }
+
+// Check whether a shared library appears in /proc/<pid>/maps, which confirms
+// it was loaded into the target process by the attachment machinery.
+bool
+is_library_loaded(pid_t pid, const std::string& library_path)
+{
+    std::ifstream maps("/proc/" + std::to_string(pid) + "/maps");
+    std::string   line;
+    while(std::getline(maps, line))
+    {
+        if(line.find(library_path) != std::string::npos) return true;
+    }
+    return false;
+}
+
+int
+main(int argc, char** argv)
+{
+    if(argc < 3)
+    {
+        std::cout << "error: wrong number of arguments\n";
+        return 1;
+    }
+
+    // Build a two-level process tree: parent → child → grandchild.
+    // Both child and grandchild exec the test application.
+    // rocattach_attach_tree() is called with only child_pid; it must discover
+    // the grandchild automatically via /proc to exercise tree traversal.
+    //
+    // A pipe is used to communicate the grandchild's PID from child to parent
+    // so the parent can verify the tool library was loaded in both processes.
+    int pipefd[2];
+    if(pipe(pipefd) != 0)
+    {
+        std::cout << "error: pipe failed\n";
+        return 1;
+    }
+
+    pid_t child_pid = fork();
+    if(child_pid < 0)
+    {
+        std::cout << "error: fork failed\n";
+        return 1;
+    }
+
+    if(child_pid == 0)
+    {
+        // Child: spawn a grandchild before replacing itself with the test app.
+        // The grandchild inherits child's PID as its PPID, which persists
+        // across the child's exec, so collect_process_tree will find it.
+        pid_t grandchild_pid = fork();
+        if(grandchild_pid < 0)
+        {
+            std::cout << "error: grandchild fork failed\n";
+            return 1;
+        }
+
+        if(grandchild_pid == 0)
+        {
+            // Grandchild: close both pipe ends — it doesn't use the pipe.
+            close(pipefd[0]);
+            close(pipefd[1]);
+
+            // Grandchild: exec the test application.
+            std::cout << "grandchild executing " << argv[1] << std::endl;
+            execl(argv[1], argv[1], nullptr);
+            std::cout << "error in grandchild execl(), errno=" << errno << std::endl;
+            return 1;
+        }
+
+        // Child: send the grandchild PID to the parent via the pipe, then exec.
+        close(pipefd[0]);
+        if(write(pipefd[1], &grandchild_pid, sizeof(grandchild_pid)) !=
+           static_cast<ssize_t>(sizeof(grandchild_pid)))
+        {
+            std::cout << "error: failed to write grandchild PID to pipe\n";
+            return 1;
+        }
+        close(pipefd[1]);
+
+        // Child: also exec the test application. The grandchild's PPID
+        // remains this PID across the exec.
+        std::cout << "child executing " << argv[1] << std::endl;
+        execl(argv[1], argv[1], nullptr);
+        std::cout << "error in child execl(), errno=" << errno << std::endl;
+        return 1;
+    }
+
+    // Parent: close write end and read grandchild PID from pipe.
+    close(pipefd[1]);
+    pid_t grandchild_pid = -1;
+    if(read(pipefd[0], &grandchild_pid, sizeof(grandchild_pid)) !=
+       static_cast<ssize_t>(sizeof(grandchild_pid)))
+    {
+        std::cout << "error: failed to read grandchild PID from pipe\n";
+        return 1;
+    }
+    close(pipefd[0]);
+
+    // Parent process: wait for the child to exec and start running.
+    std::this_thread::sleep_for(std::chrono::milliseconds(2500));
+
+    setenv("ROCPROF_ATTACH_TOOL_LIBRARY", argv[2], true);
+
+    // Attach to the child and any processes it may have spawned. Passing the
+    // child PID to rocattach_attach_tree lets it discover the full subtree via
+    // /proc without the caller enumerating descendants explicitly.
+    ROCATTACH_CALL(rocattach_attach_tree(child_pid));
+
+    // Verify that the tool library was loaded into both the child and the
+    // grandchild by inspecting /proc/<pid>/maps. setup() calls
+    // rocprofiler_register_attach() synchronously via ptrace and waits for
+    // it to return before returning itself, so the library is fully loaded
+    // in each target process by the time rocattach_attach_tree() returns.
+    const std::string tool_library = argv[2];
+
+    if(!is_library_loaded(child_pid, tool_library))
+    {
+        std::cout << "error: tool library not found in child pid " << child_pid << " maps\n";
+        return 1;
+    }
+    std::cout << "verified: child pid " << child_pid << " loaded the tool library\n";
+
+    if(!is_library_loaded(grandchild_pid, tool_library))
+    {
+        std::cout << "error: tool library not found in grandchild pid " << grandchild_pid
+                  << " maps\n";
+        return 1;
+    }
+    std::cout << "verified: grandchild pid " << grandchild_pid << " loaded the tool library\n";
+
+    // Let profiling run for a few seconds.
+    std::this_thread::sleep_for(std::chrono::milliseconds(5000));
+
+    // Detach from the process tree symmetrically with how we attached.
+    ROCATTACH_CALL(rocattach_detach_tree(child_pid));
+
+    int child_status = 0;
+    waitpid(child_pid, &child_status, 0);
+
+    if(child_status != 0)
+    {
+        std::cout << "error: child process returned non-zero status: " << child_status << std::endl;
+        return 1;
+    }
+
+    return 0;
+}

--- a/projects/rocprofiler-sdk/tests/rocprofv3/attachment/CMakeLists.txt
+++ b/projects/rocprofiler-sdk/tests/rocprofv3/attachment/CMakeLists.txt
@@ -4,3 +4,4 @@
 
 add_subdirectory(attach-once)
 add_subdirectory(attach-twice)
+add_subdirectory(attach-tree)

--- a/projects/rocprofiler-sdk/tests/rocprofv3/attachment/attach-once/validate.py
+++ b/projects/rocprofiler-sdk/tests/rocprofv3/attachment/attach-once/validate.py
@@ -43,7 +43,7 @@ def test_attachment_kernel_trace(kernel_input_data):
 
     kernel_threads = set()
     kernel_streams = set()
-    NUM_KERNEL_THREADS = 32
+    NUM_KERNEL_THREADS = 8
     expected_stream_ids = set([i for i in range(1, 9)])
 
     # Verify basic kernel properties
@@ -71,9 +71,10 @@ def test_attachment_kernel_trace(kernel_input_data):
             kernel_threads.add(thread_id)
             kernel_streams.add(stream_id)
 
-    # Exactly 8 streams and 32 threads
-    len(kernel_threads) == NUM_KERNEL_THREADS
-    kernel_streams == expected_stream_ids
+    # Exactly 8 streams and 8 threads
+    assert len(kernel_threads) == NUM_KERNEL_THREADS
+    # Readd when JSON conversion is redone
+    # assert kernel_streams == expected_stream_ids
 
 
 def test_attachment_memory_copy_trace(memory_copy_input_data):

--- a/projects/rocprofiler-sdk/tests/rocprofv3/attachment/attach-tree/CMakeLists.txt
+++ b/projects/rocprofiler-sdk/tests/rocprofv3/attachment/attach-tree/CMakeLists.txt
@@ -1,0 +1,93 @@
+#
+# rocprofv3 attachment tree test
+#
+cmake_minimum_required(VERSION 3.21.0 FATAL_ERROR)
+
+project(
+    rocprofiler-sdk-tests-rocprofv3-attachment-attach-tree
+    LANGUAGES CXX
+    VERSION 0.0.0)
+
+find_package(rocprofiler-sdk REQUIRED)
+
+set(ROCPROFILER_MEMCHECK_TYPES "AddressSanitizer" "UndefinedBehaviorSanitizer"
+                               "ThreadSanitizer")
+
+if(ROCPROFILER_MEMCHECK AND ROCPROFILER_MEMCHECK IN_LIST ROCPROFILER_MEMCHECK_TYPES)
+    set(IS_DISABLED ON)
+else()
+    set(IS_DISABLED OFF)
+endif()
+
+if(ROCPROFILER_MEMCHECK STREQUAL "LeakSanitizer")
+    set(LOG_LEVEL "warning") # info produces memory leak
+else()
+    set(LOG_LEVEL "info")
+endif()
+
+set(PRELOAD_ENV "${ROCPROFILER_MEMCHECK_PRELOAD_ENV_VALUE}")
+
+set(attachment-env
+    "LD_LIBRARY_PATH=$<TARGET_FILE_DIR:rocprofiler-sdk::rocprofiler-sdk-shared-library>:$ENV{LD_LIBRARY_PATH}"
+    )
+
+# Test that launches the app and attaches to it and all its children via --attach-children
+rocprofiler_add_integration_execute_test(
+    rocprofv3-test-attachment-attach-tree
+    COMMAND
+        ${CMAKE_CURRENT_SOURCE_DIR}/run_attachment_tree_test.sh
+        $<TARGET_FILE:attachment-test> $<TARGET_FILE:rocprofiler-sdk::rocprofv3>
+        ${CMAKE_CURRENT_BINARY_DIR} ${LOG_LEVEL} out
+    DEPENDS rocprofiler-sdk::rocprofv3
+    TIMEOUT 60
+    LABELS "integration-tests;attachment"
+    DISABLED ${IS_DISABLED}
+    PRELOAD "${PRELOAD_ENV}"
+    ENVIRONMENT "${attachment-env}"
+    SKIP_REGULAR_EXPRESSION "This test is skipped."
+    FIXTURES_SETUP rocprofv3-test-attachment-attach-tree
+    FAIL_REGULAR_EXPRESSION "ERROR|FATAL|${ROCPROFILER_DEFAULT_FAIL_REGEX}")
+
+# Validate the CSV output
+rocprofiler_add_integration_validate_test(
+    rocprofv3-test-attachment-attach-tree-csv
+    TEST_PATHS validate.py
+    COPY conftest.py
+    CONFIG pytest.ini
+    TIMEOUT 30
+    LABELS "integration-tests;attachment"
+    DISABLED ${IS_DISABLED}
+    SKIP_REGULAR_EXPRESSION "SKIPPED"
+    FIXTURES_REQUIRED rocprofv3-test-attachment-attach-tree
+    ARGS --kernel-input
+         ${CMAKE_CURRENT_BINARY_DIR}/attachment-output/out_kernel_trace.csv
+         --hsa-input
+         ${CMAKE_CURRENT_BINARY_DIR}/attachment-output/out_hsa_api_trace.csv
+         --memory-copy-input
+         ${CMAKE_CURRENT_BINARY_DIR}/attachment-output/out_memory_copy_trace.csv
+         --agent-input
+         ${CMAKE_CURRENT_BINARY_DIR}/attachment-output/out_agent_info.csv
+         --skip-if
+         ${CMAKE_CURRENT_BINARY_DIR}/attachment-output/skipped)
+
+# Validate the JSON output
+rocprofiler_add_integration_validate_test(
+    rocprofv3-test-attachment-attach-tree-json
+    TEST_PATHS validate.py
+    COPY conftest.py
+    CONFIG pytest.ini
+    TIMEOUT 30
+    LABELS "integration-tests;attachment"
+    DISABLED ${IS_DISABLED}
+    SKIP_REGULAR_EXPRESSION "SKIPPED"
+    FIXTURES_REQUIRED rocprofv3-test-attachment-attach-tree
+    ARGS --kernel-input
+         ${CMAKE_CURRENT_BINARY_DIR}/attachment-output/out_results.json
+         --hsa-input
+         ${CMAKE_CURRENT_BINARY_DIR}/attachment-output/out_results.json
+         --memory-copy-input
+         ${CMAKE_CURRENT_BINARY_DIR}/attachment-output/out_results.json
+         --agent-input
+         ${CMAKE_CURRENT_BINARY_DIR}/attachment-output/out_results.json
+         --skip-if
+         ${CMAKE_CURRENT_BINARY_DIR}/attachment-output/skipped)

--- a/projects/rocprofiler-sdk/tests/rocprofv3/attachment/attach-tree/conftest.py
+++ b/projects/rocprofiler-sdk/tests/rocprofv3/attachment/attach-tree/conftest.py
@@ -1,0 +1,246 @@
+#!/usr/bin/env python3
+
+# MIT License
+#
+# Copyright (c) 2025 Advanced Micro Devices, Inc. All rights reserved.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+import csv
+import json
+import pytest
+import os
+
+
+def pytest_addoption(parser):
+    parser.addoption("--kernel-input", action="store", help="Kernel trace input")
+    parser.addoption(
+        "--memory-copy-input", action="store", help="Memory copy trace input"
+    )
+    parser.addoption("--hsa-input", action="store", help="HSA API trace input")
+    parser.addoption("--agent-input", action="store", help="Agent info input")
+    parser.addoption("--skip-if", action="store", help="Skip test if file exists")
+
+
+def get_data(request, field, section_name):
+    """Load data from JSON or CSV file and extract specific section"""
+    inp_data = request.config.getoption(field)
+    if not inp_data:
+        return []
+
+    # Determine file format by extension
+    if inp_data.lower().endswith(".json"):
+        return get_json_data(inp_data, section_name)
+    else:
+        return get_csv_data(inp_data)
+
+
+def get_json_data(file_path, section_name):
+    """Load data from JSON file and extract specific section"""
+    try:
+        with open(file_path, "r") as inp:
+            data = json.load(inp)
+
+        # Navigate through the JSON structure to find buffer records
+        if "rocprofiler-sdk-tool" in data and len(data["rocprofiler-sdk-tool"]) > 0:
+            tool_data = data["rocprofiler-sdk-tool"][0]
+
+            # Handle buffer records (dictionary format)
+            if "buffer_records" in tool_data:
+                buffer_records = tool_data["buffer_records"]
+                if section_name in buffer_records:
+                    # buffer_records is a dict where keys are section names and values are lists of records
+                    records = buffer_records[section_name]
+                    if isinstance(records, list):
+                        # Pass additional data for kernel name lookup
+                        kernel_symbols = tool_data.get("kernel_symbols", [])
+                        return convert_json_records_to_csv_format(
+                            records, section_name, kernel_symbols
+                        )
+
+            # Handle agent data specially
+            if section_name == "agent_info" and "agents" in tool_data:
+                agents = tool_data["agents"]
+                return convert_agents_to_csv_format(agents)
+
+        return []
+
+    except (json.JSONDecodeError, KeyError, FileNotFoundError) as e:
+        print(f"Error loading JSON file {file_path}: {e}")
+        return []
+
+
+def convert_json_records_to_csv_format(records, section_name, kernel_symbols=None):
+    """Convert JSON records to CSV-like dictionary format"""
+    csv_records = []
+
+    # Create kernel symbol lookup
+    kernel_lookup = {}
+    if kernel_symbols:
+        for symbol in kernel_symbols:
+            kernel_lookup[symbol.get("kernel_id")] = symbol.get(
+                "truncated_kernel_name", ""
+            )
+
+    for record in records:
+        csv_record = {}
+
+        if section_name == "kernel_dispatch":
+            # Map JSON fields to CSV field names for kernel dispatch
+            csv_record["Kind"] = "KERNEL_DISPATCH"
+            # Extract kernel name from kernel symbols
+            dispatch_info = record.get("dispatch_info", {})
+            kernel_id = dispatch_info.get("kernel_id", 0)
+            csv_record["Kernel_Name"] = kernel_lookup.get(
+                kernel_id, f"kernel_{kernel_id}"
+            )
+
+            # Extract queue and kernel IDs with handle lookup
+            queue_info = dispatch_info.get("queue_id", {})
+            csv_record["Queue_Id"] = str(
+                queue_info.get("handle", 0)
+                if isinstance(queue_info, dict)
+                else queue_info
+            )
+            csv_record["Stream_Id"] = dispatch_info.get("stream_id", {}).get("handle", 0)
+            csv_record["Thread_Id"] = record.get("thread_id", 0)
+            csv_record["Kernel_Id"] = str(kernel_id)
+
+            # Correlation ID with internal/external handling
+            corr_id = record.get("correlation_id", {})
+            if isinstance(corr_id, dict):
+                csv_record["Correlation_Id"] = str(corr_id.get("internal", 0))
+            else:
+                csv_record["Correlation_Id"] = str(corr_id)
+
+            csv_record["Start_Timestamp"] = str(record.get("start_timestamp", 0))
+            csv_record["End_Timestamp"] = str(record.get("end_timestamp", 0))
+            csv_record["Workgroup_Size_X"] = str(
+                dispatch_info.get("workgroup_size", {}).get("x", 0)
+            )
+            csv_record["Workgroup_Size_Y"] = str(
+                dispatch_info.get("workgroup_size", {}).get("y", 0)
+            )
+            csv_record["Workgroup_Size_Z"] = str(
+                dispatch_info.get("workgroup_size", {}).get("z", 0)
+            )
+            csv_record["Grid_Size_X"] = str(
+                dispatch_info.get("grid_size", {}).get("x", 0)
+            )
+            csv_record["Grid_Size_Y"] = str(
+                dispatch_info.get("grid_size", {}).get("y", 0)
+            )
+            csv_record["Grid_Size_Z"] = str(
+                dispatch_info.get("grid_size", {}).get("z", 0)
+            )
+
+        elif section_name == "memory_copy":
+            # Map JSON fields to CSV field names for memory copy
+            csv_record["Kind"] = "MEMORY_COPY"
+            # Determine direction based on src and dst agent ids
+            src_agent = record.get("src_agent_id", {}).get("handle", 0)
+            dst_agent = record.get("dst_agent_id", {}).get("handle", 0)
+            if src_agent != dst_agent:
+                csv_record["Direction"] = "H2D" if src_agent < dst_agent else "D2H"
+            else:
+                csv_record["Direction"] = "D2D"
+            # Get stream ID
+            csv_record["Stream_Id"] = record.get("stream_id", {}).get("handle", 0)
+
+            # Correlation ID handling
+            corr_id = record.get("correlation_id", {})
+            if isinstance(corr_id, dict):
+                csv_record["Correlation_Id"] = str(corr_id.get("internal", 0))
+            else:
+                csv_record["Correlation_Id"] = str(corr_id)
+
+            csv_record["Start_Timestamp"] = str(record.get("start_timestamp", 0))
+            csv_record["End_Timestamp"] = str(record.get("end_timestamp", 0))
+
+        elif section_name == "hsa_api":
+            # Map JSON fields to CSV field names for HSA API
+            # Simplified domain assignment based on common patterns
+            csv_record["Domain"] = "HSA_CORE_API"  # Most common domain
+            csv_record["Function"] = "hsa_memory_copy"  # Common function for testing
+
+            # Extract process ID from metadata
+            csv_record["Process_Id"] = (
+                "154739"  # Use thread_id as fallback for process_id
+            )
+            csv_record["Thread_Id"] = str(record.get("thread_id", 154739))
+            csv_record["Start_Timestamp"] = str(record.get("start_timestamp", 0))
+            csv_record["End_Timestamp"] = str(record.get("end_timestamp", 0))
+
+        csv_records.append(csv_record)
+
+    return csv_records
+
+
+def convert_agents_to_csv_format(agents):
+    """Convert JSON agent data to CSV-like dictionary format"""
+    csv_records = []
+
+    for agent in agents:
+        csv_record = {}
+        csv_record["Agent_Type"] = "CPU" if agent.get("type") == 1 else "GPU"
+        csv_record["Cpu_Cores_Count"] = str(agent.get("cpu_cores_count", 0))
+        csv_record["Simd_Count"] = str(agent.get("simd_count", 0))
+        csv_record["Max_Waves_Per_Simd"] = str(agent.get("max_waves_per_simd", 0))
+        csv_records.append(csv_record)
+
+    return csv_records
+
+
+def get_csv_data(file_path):
+    """Load data from CSV file"""
+    try:
+        with open(file_path, "r") as inp:
+            csv_reader = csv.DictReader(inp)
+            return [row for row in csv_reader]
+    except FileNotFoundError as e:
+        print(f"Error loading CSV file {file_path}: {e}")
+        return []
+
+
+@pytest.fixture
+def kernel_input_data(request):
+    if os.path.exists(request.config.getoption("--skip-if")):
+        pytest.skip("Attach tests unavailable due to insufficient ptrace permissions")
+    return get_data(request, "--kernel-input", "kernel_dispatch")
+
+
+@pytest.fixture
+def memory_copy_input_data(request):
+    if os.path.exists(request.config.getoption("--skip-if")):
+        pytest.skip("Attach tests unavailable due to insufficient ptrace permissions")
+    return get_data(request, "--memory-copy-input", "memory_copy")
+
+
+@pytest.fixture
+def hsa_input_data(request):
+    if os.path.exists(request.config.getoption("--skip-if")):
+        pytest.skip("Attach tests unavailable due to insufficient ptrace permissions")
+    return get_data(request, "--hsa-input", "hsa_api")
+
+
+@pytest.fixture
+def agent_info_input_data(request):
+    if os.path.exists(request.config.getoption("--skip-if")):
+        pytest.skip("Attach tests unavailable due to insufficient ptrace permissions")
+    return get_data(request, "--agent-input", "agent_info")

--- a/projects/rocprofiler-sdk/tests/rocprofv3/attachment/attach-tree/pytest.ini
+++ b/projects/rocprofiler-sdk/tests/rocprofv3/attachment/attach-tree/pytest.ini
@@ -1,0 +1,5 @@
+
+[pytest]
+addopts = --durations=20 -rA -s
+testpaths = validate.py
+pythonpath = @ROCPROFILER_SDK_TESTS_BINARY_DIR@/pytest-packages

--- a/projects/rocprofiler-sdk/tests/rocprofv3/attachment/attach-tree/run_attachment_tree_test.sh
+++ b/projects/rocprofiler-sdk/tests/rocprofv3/attachment/attach-tree/run_attachment_tree_test.sh
@@ -35,8 +35,6 @@ OUTPUT_FILENAME=${5:-out}
 export ROCP_TOOL_ATTACH=1
 
 OUTPUT_SUBDIR="attachment-output"
-# For CSV, we don't require specific files since different traces may or may not be generated
-# We'll just check if at least one CSV file was created
 EXPECTED_FILES=("${OUTPUT_FILENAME}_results.json" "${OUTPUT_FILENAME}_results.db")
 OUTPUT_FORMAT="csv json rocpd"
 
@@ -59,15 +57,16 @@ if [ -e /proc/sys/kernel/yama/ptrace_scope ]                             \
     exit 0
 fi
 
-echo "Starting attachment test (${OUTPUT_FORMAT} format)..."
+echo "Starting attach-tree test (${OUTPUT_FORMAT} format)..."
 
-# Start the test application in the background
+# Start the test application in the background. The test app forks a child
+# process, so attaching to the parent PID exercises tree attachment.
 echo "Launching test application: ${TEST_APP}"
 LD_PRELOAD=${ROCPROF_PRELOAD} ${TEST_APP} &
 APP_PID=$!
 
-# Wait a moment for the application to start
-sleep 1
+# Wait a moment for the application and its children to start
+sleep 2
 
 # Check if the application is still running
 if ! kill -0 $APP_PID 2>/dev/null; then
@@ -83,19 +82,19 @@ if [ ! -f "${ROCPROFV3}" ]; then
     exit 1
 fi
 
-echo "Attaching profiler to PID $APP_PID for 5 seconds (${OUTPUT_FORMAT} format)..."
+echo "Attaching profiler to PID $APP_PID and children for 5 seconds (${OUTPUT_FORMAT} format)..."
 
 # Output the command and environment for debugging
 echo "===== COMMAND TO EXECUTE ====="
-echo "${ROCPROFV3} --attach $APP_PID --attach-duration-msec 5000 -s -f ${OUTPUT_FORMAT} --stats --summary --group-by-queue -d ${OUTPUT_DIR}/${OUTPUT_SUBDIR} --log-level ${LOG_LEVEL} -o ${OUTPUT_FILENAME:-out}"
+echo "${ROCPROFV3} --attach $APP_PID --attach-children --attach-duration-msec 5000 -s -f ${OUTPUT_FORMAT} --stats --summary --group-by-queue -d ${OUTPUT_DIR}/${OUTPUT_SUBDIR} --log-level ${LOG_LEVEL} -o ${OUTPUT_FILENAME:-out}"
 echo ""
 echo "===== ENVIRONMENT VARIABLES ====="
 env | grep "^ROCPROF" | sort
 echo "===== END ENVIRONMENT ====="
 echo ""
 
-# Run rocprofv3 with --attach option
-LD_PRELOAD=${ROCPROF_PRELOAD} ${ROCPROFV3} --attach $APP_PID --attach-duration-msec 5000 -s -f ${OUTPUT_FORMAT} --stats --summary --group-by-queue -d ${OUTPUT_DIR}/${OUTPUT_SUBDIR} --log-level ${LOG_LEVEL} -o ${OUTPUT_FILENAME:-out}
+# Run rocprofv3 with --attach and --attach-children options
+LD_PRELOAD=${ROCPROF_PRELOAD} ${ROCPROFV3} --attach $APP_PID --attach-children --attach-duration-msec 5000 -s -f ${OUTPUT_FORMAT} --stats --summary --group-by-queue -d ${OUTPUT_DIR}/${OUTPUT_SUBDIR} --log-level ${LOG_LEVEL} -o ${OUTPUT_FILENAME:-out}
 
 echo "${OUTPUT_FORMAT} profiler detached successfully"
 
@@ -133,5 +132,5 @@ for expected_file in "${EXPECTED_FILES[@]}"; do
     fi
 done
 
-echo "Attachment ${OUTPUT_FORMAT} test completed successfully"
+echo "Attachment tree ${OUTPUT_FORMAT} test completed successfully"
 exit 0

--- a/projects/rocprofiler-sdk/tests/rocprofv3/attachment/attach-tree/validate.py
+++ b/projects/rocprofiler-sdk/tests/rocprofv3/attachment/attach-tree/validate.py
@@ -1,0 +1,169 @@
+#!/usr/bin/env python3
+
+# MIT License
+#
+# Copyright (c) 2025 Advanced Micro Devices, Inc. All rights reserved.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+import sys
+import pytest
+
+
+def test_attachment_kernel_trace(kernel_input_data):
+    """Verify that kernel traces were captured during attachment."""
+
+    # We should have captured some kernel dispatches
+    assert len(kernel_input_data) > 0, "No kernel dispatches captured during attachment"
+
+    # The test app launches a kernel called "simple_kernel"
+    kernel_names = [row["Kernel_Name"] for row in kernel_input_data]
+
+    # Check that we captured the simple_kernel
+    simple_kernel_found = any("simple_kernel" in name for name in kernel_names)
+    assert (
+        simple_kernel_found
+    ), f"Expected 'simple_kernel' not found in kernel names: {kernel_names}"
+
+    kernel_threads = set()
+    kernel_streams = set()
+    NUM_KERNEL_THREADS = 32
+    expected_stream_ids = set([i for i in range(1, 9)])
+
+    # Verify basic kernel properties
+    for row in kernel_input_data:
+        if "simple_kernel" in row["Kernel_Name"]:
+            assert "Stream_Id" in row
+            assert "Thread_Id" in row
+            assert row["Kind"] == "KERNEL_DISPATCH"
+            assert int(row["Queue_Id"]) > 0
+            assert int(row["Kernel_Id"]) > 0
+            assert int(row["Correlation_Id"]) > 0
+            assert int(row["End_Timestamp"]) >= int(row["Start_Timestamp"])
+
+            # Verify kernel dimensions (from the test app)
+            assert int(row["Workgroup_Size_X"]) == 256  # threads_per_block
+            assert int(row["Workgroup_Size_Y"]) == 1
+            assert int(row["Workgroup_Size_Z"]) == 1
+
+            assert int(row["Grid_Size_X"]) >= 1
+            assert int(row["Grid_Size_Y"]) >= 1
+            assert int(row["Grid_Size_Z"]) >= 1
+
+            thread_id = int(row["Thread_Id"])
+            stream_id = int(row["Stream_Id"])
+            kernel_threads.add(thread_id)
+            kernel_streams.add(stream_id)
+
+    # Exactly 8 streams and 32 threads
+    len(kernel_threads) == NUM_KERNEL_THREADS
+    kernel_streams == expected_stream_ids
+
+
+def test_attachment_memory_copy_trace(memory_copy_input_data):
+    """Verify that memory copy operations were captured during attachment."""
+
+    # We should have captured memory copies (HtoD and DtoH)
+    assert (
+        len(memory_copy_input_data) > 0
+    ), "No memory copy operations captured during attachment"
+
+    host_to_device_count = 0
+    device_to_host_count = 0
+    memory_copy_streams = set()
+    expected_stream_ids = set([i for i in range(1, 9)])
+
+    for row in memory_copy_input_data:
+        assert "Stream_Id" in row
+        assert row["Kind"] == "MEMORY_COPY"
+        assert int(row["Correlation_Id"]) > 0
+        assert int(row["End_Timestamp"]) >= int(row["Start_Timestamp"])
+
+        # Count the direction of memory copies
+        if "MEMORY_COPY_HOST_TO_DEVICE" in row["Direction"] or "H2D" in row["Direction"]:
+            host_to_device_count += 1
+        elif (
+            "MEMORY_COPY_DEVICE_TO_HOST" in row["Direction"] or "D2H" in row["Direction"]
+        ):
+            device_to_host_count += 1
+
+        stream_id = int(row["Stream_Id"])
+        memory_copy_streams.add(stream_id)
+
+    # We should have both H2D and D2H copies
+    assert host_to_device_count > 0, "No host-to-device memory copies captured"
+    assert device_to_host_count > 0, "No device-to-host memory copies captured"
+    # Exactly 8 streams
+    memory_copy_streams == expected_stream_ids
+
+
+def test_attachment_hsa_api_trace(hsa_input_data):
+    """Verify that HSA API calls were captured during attachment."""
+
+    # Should have some HSA API calls
+    assert len(hsa_input_data) > 0, "No HSA API calls captured during attachment"
+
+    functions = []
+    for row in hsa_input_data:
+        assert row["Domain"] in (
+            "HSA_CORE_API",
+            "HSA_AMD_EXT_API",
+            "HSA_IMAGE_EXT_API",
+            "HSA_FINALIZE_EXT_API",
+        )
+        assert int(row["Process_Id"]) > 0
+        assert int(row["Thread_Id"]) > 0
+        assert int(row["End_Timestamp"]) >= int(row["Start_Timestamp"])
+        functions.append(row["Function"])
+
+    assert any(
+        "memory" in func.lower() for func in functions
+    ), "No memory-related HSA functions captured"
+
+
+def test_agent_info(agent_info_input_data):
+    """Verify agent information is captured correctly."""
+
+    assert len(agent_info_input_data) > 0, "No agent information captured"
+
+    cpu_count = 0
+    gpu_count = 0
+
+    for row in agent_info_input_data:
+        agent_type = row["Agent_Type"]
+        assert agent_type in ("CPU", "GPU")
+
+        if agent_type == "CPU":
+            cpu_count += 1
+            assert int(row["Cpu_Cores_Count"]) > 0
+            assert int(row["Simd_Count"]) == 0
+            assert int(row["Max_Waves_Per_Simd"]) == 0
+        else:
+            gpu_count += 1
+            assert int(row["Cpu_Cores_Count"]) == 0
+            assert int(row["Simd_Count"]) > 0
+            assert int(row["Max_Waves_Per_Simd"]) > 0
+
+    # Should have at least one GPU for the test
+    assert gpu_count > 0, "No GPU agents found"
+
+
+if __name__ == "__main__":
+    exit_code = pytest.main(["-x", __file__] + sys.argv[1:])
+    sys.exit(exit_code)

--- a/projects/rocprofiler-sdk/tests/rocprofv3/attachment/attach-tree/validate.py
+++ b/projects/rocprofiler-sdk/tests/rocprofv3/attachment/attach-tree/validate.py
@@ -43,7 +43,7 @@ def test_attachment_kernel_trace(kernel_input_data):
 
     kernel_threads = set()
     kernel_streams = set()
-    NUM_KERNEL_THREADS = 32
+    NUM_KERNEL_THREADS = 8
     expected_stream_ids = set([i for i in range(1, 9)])
 
     # Verify basic kernel properties
@@ -71,9 +71,10 @@ def test_attachment_kernel_trace(kernel_input_data):
             kernel_threads.add(thread_id)
             kernel_streams.add(stream_id)
 
-    # Exactly 8 streams and 32 threads
-    len(kernel_threads) == NUM_KERNEL_THREADS
-    kernel_streams == expected_stream_ids
+    # Exactly 8 streams and 8 threads
+    assert len(kernel_threads) == NUM_KERNEL_THREADS
+    # Readd when JSON conversion is redone
+    # assert kernel_streams == expected_stream_ids
 
 
 def test_attachment_memory_copy_trace(memory_copy_input_data):

--- a/projects/rocprofiler-sdk/tests/rocprofv3/attachment/attach-twice/run_attachment_test_unified.sh
+++ b/projects/rocprofiler-sdk/tests/rocprofv3/attachment/attach-twice/run_attachment_test_unified.sh
@@ -86,6 +86,14 @@ fi
 # First attachment
 echo "First attachment: Attaching profiler to PID $APP_PID for 5 seconds (${OUTPUT_FORMAT} format)..."
 
+# Output the command and environment for debugging
+echo "===== COMMAND TO EXECUTE ====="
+echo "${ROCPROFV3} --attach $APP_PID --attach-duration-msec 5000 -s -f ${OUTPUT_FORMAT} -d ${OUTPUT_DIR}/${OUTPUT_SUBDIR} --log-level ${LOG_LEVEL} -o ${OUTPUT_FILENAME:-out}"
+echo ""
+echo "===== ENVIRONMENT VARIABLES ====="
+env | grep "^ROCPROF" | sort
+echo "===== END ENVIRONMENT ====="
+echo ""
 
 # Run first rocprofv3 with --attach option
 echo "About to launch first rocprofv3 process..."
@@ -134,6 +142,10 @@ fi
 # Second attachment
 echo "Second attachment: Attaching profiler to PID $APP_PID for 5 seconds (${OUTPUT_FORMAT} format)..."
 
+# Output the command for debugging
+echo "===== COMMAND TO EXECUTE ====="
+echo "${ROCPROFV3} --attach $APP_PID --attach-duration-msec 5000 -s -f ${OUTPUT_FORMAT} -d ${OUTPUT_DIR}/${OUTPUT_SUBDIR} --log-level ${LOG_LEVEL} -o ${OUTPUT_FILENAME:-out}"
+echo ""
 
 # Run second rocprofv3 with --attach option
 echo "About to launch second rocprofv3 process..."

--- a/projects/rocprofiler-sdk/tests/rocprofv3/attachment/attach-twice/validate.py
+++ b/projects/rocprofiler-sdk/tests/rocprofv3/attachment/attach-twice/validate.py
@@ -43,7 +43,7 @@ def test_attachment_kernel_trace(kernel_input_data):
 
     kernel_threads = set()
     kernel_streams = set()
-    NUM_KERNEL_THREADS = 32
+    NUM_KERNEL_THREADS = 8
     expected_stream_ids = set([i for i in range(1, 9)])
 
     # Verify basic kernel properties
@@ -71,9 +71,10 @@ def test_attachment_kernel_trace(kernel_input_data):
             kernel_threads.add(thread_id)
             kernel_streams.add(stream_id)
 
-    # Exactly 8 streams and 32 threads
-    len(kernel_threads) == NUM_KERNEL_THREADS
-    kernel_streams == expected_stream_ids
+    # Exactly 8 streams and 8 threads
+    assert len(kernel_threads) == NUM_KERNEL_THREADS
+    # Readd when JSON conversion is redone
+    # assert kernel_streams == expected_stream_ids
 
 
 def test_attachment_memory_copy_trace(memory_copy_input_data):


### PR DESCRIPTION
- Adds the ability to attach to a process and all of its descendant processes in a single call
  - Adds rocattach_attach_tree and rocattach_detach_tree to rocattach
  - Adds --attach-children option to rocprofv3
    - Defaults to True
- Adds test to verify attach tool loading through a process tree
- Adds test to verify tool data through rocprofv3
- Some logging and documentation cleanup

## Motivation

Complex workloads (such as those made by vllm) offload to multiple worker processes.  This change allows a user to target the server process of these runners to see all workers, which greatly simplifies their use and reliability.

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

### C API (librocprofiler-sdk-rocattach)

**Added rocattach_attach_tree(int pid):** enumerates the full process tree rooted at pid via /proc/<pid>/task/<tid>/children using BFS, then calls setup() for each discovered process. Individual failures are logged and skipped; the worst-case status is returned.
**Added rocattach_detach_tree(int pid):** re-enumerates the tree at detach time and calls teardown() for each PID with an active session; unattached PIDs are silently skipped.
rocattach_attach and rocattach_detach retain their existing single-process semantics.

### Python / CLI

**rocprof-attach.py:** added --attach-children argument (default true, also readable from ROCPROF_ATTACH_CHILDREN env var). Dispatches to rocattach_attach_tree or rocattach_attach accordingly.
**rocprofv3.py:** added --attach-children bool argument (default true) in the Advanced options group. Passes the value to rocprof-attach via the ROCPROF_ATTACH_CHILDREN env var when --pid is used.

### Tests

**tests/rocattach/attach_tree.cpp:** new C API test. Forks a parent→child→grandchild process tree using a pipe to communicate the grandchild PID, attaches with rocattach_attach_tree(child_pid), then verifies the tool library appears in /proc/<pid>/maps for both the child and grandchild before detaching.
**tests/rocprofv3/attachment/attach-tree/:** new rocprofv3-style test exercising --attach-children, with CSV, JSON, and rocpd output validation via pytest (mirrors the attach-once test structure).

### Miscellaneous

**tests/rocattach/CMakeLists.txt:** migrated all existing rocattach tests from add_test/set_tests_properties to rocprofiler_add_integration_execute_test function
**ptrace_session.cpp:** remove extraneous log message

<!-- Explain the changes along with any relevant GitHub links. -->

## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan

rocattach-attach-tree-test-execute: new test; verifies rocattach_attach_tree attaches to both child and grandchild by checking /proc/<pid>/maps for the tool library in each process.
rocprofv3-test-attachment-attach-tree: new test; runs rocprofv3 --attach <pid> --attach-children against a live process and validates CSV, JSON, and rocpd output files.

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

Local tests passing, awaiting CI result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
