### PR TITLE
[rocprofiler-sdk] Fix Warning Type - Missing sys node paths are no longer fatal

### DIFF
--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/agent.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/agent.cpp
@@ -635,11 +635,9 @@ read_topology()
 
     if(!fs::exists(sysfs_nodes_path))
     {
-        // Not ROCP_CI_LOG: ROCPROFILER_CI maps CI logs to FATAL, but missing KFD sysfs is
-        // normal on CPU-only hosts, containers, and CI runners doing import/smoke tests.
         ROCP_WARNING << fmt::format("sysfs nodes path '{}' does not exist",
-            sysfs_nodes_path.string());
-            
+                                    sysfs_nodes_path.string());
+
         return data;
     }
 

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/agent.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/agent.cpp
@@ -635,8 +635,11 @@ read_topology()
 
     if(!fs::exists(sysfs_nodes_path))
     {
-        ROCP_CI_LOG(WARNING) << fmt::format("sysfs nodes path '{}' does not exist",
-                                            sysfs_nodes_path.string());
+        // Not ROCP_CI_LOG: ROCPROFILER_CI maps CI logs to FATAL, but missing KFD sysfs is
+        // normal on CPU-only hosts, containers, and CI runners doing import/smoke tests.
+        ROCP_WARNING << fmt::format("sysfs nodes path '{}' does not exist",
+            sysfs_nodes_path.string());
+            
         return data;
     }
 


### PR DESCRIPTION
## Motivation
Fix for [[Issue] ROCm Sanity Check Aborts with sysfs topology/nodes Not Found](https://github.com/ROCm/TheRock/issues/4176) - PyTorch wheel builds break on single-cpu systems due to missing nodes path (/sys/class/kfd/kfd/topology/nodes)

## Technical Details
Change missing sysfs KFD topology node paths (e.g. on single-CPU setups) from a fatal error to a warning so ROCm sanity checks and PyTorch wheel builds no longer abort when those paths are absent

## GitHub Issue

 [[Issue] ROCm Sanity Check Aborts with sysfs topology/nodes Not Found](https://github.com/ROCm/TheRock/issues/4176) 

## Test Plan

- Build ROCm packages via release_portable_linux_packages workflow

- The above step will trigger automatic PyTorch wheel builds via release_portable_linux_pytorch_wheels

Acceptance Criteria: PyTorch wheels build successfully across all build combinations.

## Test Result

- release_portable_linux_packages -  **PASSING**:
https://github.com/ROCm/TheRock/actions/runs/24353223206

- release_portable_linux_pytorch_wheels - builds **PASSING**:
https://github.com/ROCm/TheRock/actions/runs/24364885335

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
