### PR TITLE
[ROCM-23881] CPER CLI refactor

### DIFF
--- a/projects/amdsmi/CHANGELOG.md
+++ b/projects/amdsmi/CHANGELOG.md
@@ -8,6 +8,10 @@ Full documentation for amd_smi_lib is available at [https://rocm.docs.amd.com/pr
 
 ### Added
 
+- **Added `--folder` support to `amd-smi ras --afid`**.
+  - `amd-smi ras --afid --folder <DIR>` decodes every `*.cper` in a directory and prints a `file_name | list of afids` table (or a JSON array under `--json`).
+  - Records with no AFIDs show `-`; files that cannot be parsed show `decode failed`.
+
 - **Added IFoE/UALoE fabric telemetry and topology support**.  
   - New `amd-smi fabric` CLI subcommand with `--topology` / `-t` and `--info` / `-i` flags for querying fabric (UALoE) information.
   - New C APIs: `amdsmi_get_fabric_telemetry_data()` and `amdsmi_get_gpu_fabric_info()`.
@@ -41,6 +45,10 @@ Full documentation for amd_smi_lib is available at [https://rocm.docs.amd.com/pr
 
 ### Changed
 - **Deprecated `amdsmi_get_gpu_vram_vendor()` in favor of `amdsmi_get_gpu_vram_info()`**.  
+
+### Removed
+
+- **Removed the non-functional `--decode` flag from `amd-smi ras`**. Out-of-band CPER decoding is available via `amd-smi ras --afid --cper-file <path>` or `--afid --folder <DIR>`.
 
 ### Resolved Issues
 

--- a/projects/amdsmi/CHANGELOG.md
+++ b/projects/amdsmi/CHANGELOG.md
@@ -13,6 +13,11 @@ Full documentation for amd_smi_lib is available at [https://rocm.docs.amd.com/pr
 
 ### Added
 
+- **Added `--folder` support to `amd-smi ras --afid`**.
+  - `amd-smi ras --afid --folder <DIR>` now decodes every `*.cper` in an existing directory and prints a `file_name | list of afids` table (or a JSON array under `--json`).
+  - `--cper-file` and `--folder` are mutually exclusive under `--afid`; exactly one must be supplied.
+  - Unlike the `--cper --folder` write path, the directory must already exist and contain at least one `.cper` file (it is not auto-created for the AFID read path).
+
 - **Added APU metrics support (table versions 2.4 and 3.0)**.  
   - New `amdsmi_apu_metrics_t` struct accessible via `amdsmi_gpu_metrics_t.apu_metrics` pointer (non-null when APU-specific metrics are available).
   - **v2.4 metrics**:

--- a/projects/amdsmi/CHANGELOG.md
+++ b/projects/amdsmi/CHANGELOG.md
@@ -169,6 +169,17 @@ Full documentation for amd_smi_lib is available at [https://rocm.docs.amd.com/pr
     - amdsmi_get_cpu_core_ccd_power(amdsmi_processor_handle processor_handle, uint32_t* power);
     - amdsmi_get_cpu_sdps_limit(amdsmi_processor_handle processor_handle, uint32_t* sdps_limit);
 
+### Removed
+
+- **Removed dead `--decode` flag from `amd-smi ras`**.
+  - The flag was non-functional: without `--cper` it was a silent no-op, and with `--cper` the
+    user-supplied `--cper-file` was only used to derive an output filename — the file was never
+    read or decoded. The flag was also absent from the `--cper`/`--afid` mutex group, so
+    combinations like `amd-smi ras --cper --decode` were silently accepted.
+  - Out-of-band decoding of CPER files captured on other systems is already supported via
+    `amd-smi ras --afid --cper-file <path>`, which uses `amdsmi_get_afids_from_cper()` and
+    requires no driver/GPU access.
+
 ## amd_smi_lib for ROCm 7.12.0
 
 ### Added

--- a/projects/amdsmi/amdsmi_cli/amdsmi_commands.py
+++ b/projects/amdsmi/amdsmi_cli/amdsmi_commands.py
@@ -12200,6 +12200,17 @@ class AMDSMICommands:
             args.gpu = self.device_handles
 
         if args.afid:
+            command = " ".join(sys.argv[1:])
+            if args.cper_file and args.folder:
+                message = f"Command '{command}' accepts only one of '--cper-file' or '--folder'."
+                raise AmdSmiInvalidCommandException(command, self.logger.format, message)
+            if not args.cper_file and not args.folder:
+                message = (
+                    f"Command '{command}' requires '--cper-file' or '--folder'."
+                    " Run '--help' for more info."
+                )
+                raise AmdSmiInvalidCommandException(command, self.logger.format, message)
+
             if args.cper_file:
                 afids = self.helpers.cper_dump_afids(args.cper_file)
                 if self.logger.is_json_format():
@@ -12209,10 +12220,35 @@ class AMDSMICommands:
                 else:
                     print(" ".join(map(str, afids)))
                 return
-            else:
-                command = " ".join(sys.argv[1:])
-                message = f"Command '{command}' requires '--cper-file'. Run '--help' for more info."
+
+            # --afid --folder: decode every *.cper in an existing directory.
+            folder = Path(args.folder)
+            cper_paths = sorted(folder.glob("*.cper"))
+            if not cper_paths:
+                message = (
+                    f"Folder '{folder}' contains no '.cper' files."
+                    " '--afid --folder' requires a folder of pre-existing CPER records."
+                )
                 raise AmdSmiInvalidCommandException(command, self.logger.format, message)
+
+            results = []
+            for cper_path in cper_paths:
+                try:
+                    afids = self.helpers.cper_dump_afids(cper_path)
+                except Exception:
+                    afids = []
+                results.append({"cper_file": str(cper_path), "afids": afids})
+
+            if self.logger.is_json_format():
+                self.logger.output = results
+                self.logger.print_output()
+            else:
+                print(f"{'file_name':<32} list of afids")
+                for entry in results:
+                    fname = Path(entry["cper_file"]).name
+                    afids_str = " ".join(map(str, entry["afids"]))
+                    print(f"{fname:<32} {afids_str}")
+            return
 
         if not self.group_check_printed:
             self.helpers.check_required_groups()

--- a/projects/amdsmi/amdsmi_cli/amdsmi_commands.py
+++ b/projects/amdsmi/amdsmi_cli/amdsmi_commands.py
@@ -12187,10 +12187,10 @@ class AMDSMICommands:
             args.cper = cper
         if afid:
             args.afid = afid
-        if decode:
-            args.decode = decode
         if severity:
             args.severity = severity
+        if decode:
+            args.decode = decode
         if folder:
             args.folder = folder
         if file_limit:

--- a/projects/amdsmi/amdsmi_cli/amdsmi_commands.py
+++ b/projects/amdsmi/amdsmi_cli/amdsmi_commands.py
@@ -12255,13 +12255,17 @@ class AMDSMICommands:
                 f"GPU{gpu_id}" for gpu_id in primary_partition_gpu_ids
             )
 
-            print("WARNING: CPER files are only available on primary partitions")
+            self.helpers.cper_print(
+                "WARNING: CPER files are only available on primary partitions", self.logger
+            )
             if len(primary_partition_gpu_ids) > 1:
-                print(f"Try with primary partitions {primary_partitions_str}", end="")
+                self.helpers.cper_print(
+                    f"Try with primary partitions {primary_partitions_str}", self.logger
+                )
             else:
-                print(f"Try with primary partition {primary_partitions_str}", end="")
-
-            print()
+                self.helpers.cper_print(
+                    f"Try with primary partition {primary_partitions_str}", self.logger
+                )
 
         while True:
             for idx, device_handle in enumerate(args.gpu):

--- a/projects/amdsmi/amdsmi_cli/amdsmi_commands.py
+++ b/projects/amdsmi/amdsmi_cli/amdsmi_commands.py
@@ -12264,9 +12264,28 @@ class AMDSMICommands:
                     f"Try with primary partition {primary_partitions_str}", self.logger
                 )
 
+        # One-shot warning, header, and follow prompt (kept out of the per-GPU helper
+        # so the helper layer stays re-entrant and free of latching state).
+        if not self.logger.is_json_format():
+            if not args.folder:
+                self.helpers.cper_print(
+                    "WARNING: No CPER files will be dumped unless "
+                    "--folder=<folder_name> is specified and cper entries exist.",
+                    self.logger,
+                )
+            self.helpers._print_header(args.folder, self.logger)
+            if args.follow:
+                # Always print to stdout so the user sees the prompt, even with --file.
+                print("Press CTRL + C to stop.")
+
+        # Shared 1-indexed counter for generated CPER filenames across all GPUs
+        # and follow iterations within this invocation.
+        cper_counter = [0]
         while True:
             for idx, device_handle in enumerate(args.gpu):
-                self.helpers.ras_cper(args, device_handle, self.logger, idx)
+                self.helpers.ras_cper(
+                    args, device_handle, self.logger, idx, cper_counter=cper_counter
+                )
             if not args.follow:
                 break
             time.sleep(1)

--- a/projects/amdsmi/amdsmi_cli/amdsmi_commands.py
+++ b/projects/amdsmi/amdsmi_cli/amdsmi_commands.py
@@ -12201,13 +12201,11 @@ class AMDSMICommands:
 
         if args.afid:
             command = " ".join(sys.argv[1:])
-            if args.cper_file and args.folder:
-                message = f"Command '{command}' accepts only one of '--cper-file' or '--folder'."
-                raise AmdSmiInvalidCommandException(command, self.logger.format, message)
-            if not args.cper_file and not args.folder:
+            # Require exactly one of --cper-file / --folder under --afid.
+            if bool(args.cper_file) == bool(args.folder):
                 message = (
-                    f"Command '{command}' requires '--cper-file' or '--folder'."
-                    " Run '--help' for more info."
+                    f"Command '{command}' requires exactly one of"
+                    " '--cper-file' or '--folder'. Run '--help' for more info."
                 )
                 raise AmdSmiInvalidCommandException(command, self.logger.format, message)
 
@@ -12221,8 +12219,14 @@ class AMDSMICommands:
                     print(" ".join(map(str, afids)))
                 return
 
-            # --afid --folder: decode every *.cper in an existing directory.
+            # --afid --folder: read-only path, folder must already exist.
             folder = Path(args.folder)
+            if not folder.exists() or not folder.is_dir():
+                message = (
+                    f"Folder '{folder}' does not exist or is not a directory."
+                    " '--afid --folder' requires a folder of pre-existing CPER records."
+                )
+                raise AmdSmiInvalidCommandException(command, self.logger.format, message)
             cper_paths = sorted(folder.glob("*.cper"))
             if not cper_paths:
                 message = (

--- a/projects/amdsmi/amdsmi_cli/amdsmi_commands.py
+++ b/projects/amdsmi/amdsmi_cli/amdsmi_commands.py
@@ -12233,9 +12233,16 @@ class AMDSMICommands:
 
             results = []
             for cper_path in cper_paths:
+                # Skip symlinks: a planted symlink (e.g. evil.cper -> /etc/shadow)
+                # would otherwise be followed by read_bytes() in cper_dump_afids,
+                # reading arbitrary files into memory.
+                if cper_path.is_symlink():
+                    logging.warning("Skipping symlink: %s", cper_path)
+                    continue
                 try:
                     afids = self.helpers.cper_dump_afids(cper_path)
-                except Exception:
+                except Exception as e:
+                    logging.debug("Failed to decode AFIDs from %s: %s", cper_path, e)
                     afids = []
                 results.append({"cper_file": str(cper_path), "afids": afids})
 

--- a/projects/amdsmi/amdsmi_cli/amdsmi_commands.py
+++ b/projects/amdsmi/amdsmi_cli/amdsmi_commands.py
@@ -12162,7 +12162,6 @@ class AMDSMICommands:
         gpu=None,
         cper=None,
         afid=None,
-        decode=None,
         severity=None,
         folder=None,
         file_limit=None,
@@ -12189,8 +12188,6 @@ class AMDSMICommands:
             args.afid = afid
         if severity:
             args.severity = severity
-        if decode:
-            args.decode = decode
         if folder:
             args.folder = folder
         if file_limit:

--- a/projects/amdsmi/amdsmi_cli/amdsmi_helpers.py
+++ b/projects/amdsmi/amdsmi_cli/amdsmi_helpers.py
@@ -33,13 +33,14 @@ import glob
 import errno
 import pwd
 import stat
-from typing import Tuple, Optional, Union
-import tempfile
+from typing import List, Optional, Set, Tuple, TYPE_CHECKING, Union
 
 from enum import Enum
 from pathlib import Path
-from typing import List, Set, Union
 from functools import lru_cache
+
+if TYPE_CHECKING:
+    from amdsmi_logger import AMDSMILogger
 
 # Import amdsmi library
 from amdsmi_init import *
@@ -69,7 +70,6 @@ class AMDSMIHelpers:
 
         # Counts and Tracking variables
         self._count_of_sets_called = 0
-        self._count_of_cper_files = 0
         self._previous_set_success_check = (
             amdsmi_interface.amdsmi_wrapper.AMDSMI_STATUS_UNKNOWN_ERROR
         )
@@ -150,12 +150,6 @@ class AMDSMIHelpers:
         This is used to determine if the last set was successful or not.
         """
         return self._previous_set_success_check
-
-    def increment_cper_count(self):
-        self._count_of_cper_files += 1
-
-    def get_cper_count(self):
-        return self._count_of_cper_files
 
     def is_virtual_os(self):
         return self._is_virtual_os
@@ -2245,42 +2239,23 @@ class AMDSMIHelpers:
             return "unknown"
         return "UNKNOWN"
 
-    def display_cper_files_generated(self, entries, device_handle, folder, logger=None):
-        """
-        Display CPER summary lines. If a logger is provided and its destination is
-        not stdout, append the output to that file instead of printing to stdout.
+    def display_cper_files_generated(
+        self, entries, device_handle, logger: Optional["AMDSMILogger"] = None
+    ):
+        """Print one human-readable summary line per CPER entry.
+
+        Only invoked when neither ``--folder`` nor JSON output is in effect, so
+        no filename column is emitted. Header / warning lines are printed by
+        the caller (``RasCommands.ras``).
+
+        Returns:
+            list: Always returns ``[]`` (kept for symmetry with
+            ``dump_cper_entries``).
         """
         if logger is not None and logger.is_json_format():
             return []
 
-        use_file = (
-            logger is not None
-            and logger.is_human_readable_format()
-            and logger.destination != "stdout"
-        )
-
-        # One‐time initialization: warning & header only once
-        if not getattr(self, "_cper_display_initialized", False):
-            # Warning if no folder was specified elsewhere
-            if not getattr(self, "_cper_warning_printed", False):
-                warning = (
-                    "WARNING: No CPER files will be dumped unless "
-                    "--folder=<folder_name> is specified and cper entries exist."
-                )
-                if use_file:
-                    with logger.destination.open("a", encoding="utf-8") as output_file:
-                        output_file.write(warning + "\n")
-                else:
-                    print(warning)
-                self._cper_warning_printed = True
-
-            # Print or log the header
-            self._print_header(folder, logger if use_file else None)
-            self._cper_display_initialized = True
-
-        # Loop through all entries in the dictionary.
-        for entry_index, entry in enumerate(entries.values()):
-            # Assume 'entry' is a dictionary with keys: "error_severity" and "notify_type".
+        for entry in entries.values():
             timestamp = entry.get("timestamp", "unknown")
             gpu_id = "-"
             output = ""
@@ -2293,44 +2268,127 @@ class AMDSMIHelpers:
                 )
                 output = f"{timestamp:<20} {gpu_id:<7} {prefix:<20}"
 
-            if folder:
-                prefix_for_filename = self._severity_as_string(
-                    entry.get("error_severity", "Unknown"),
-                    entry.get("notify_type", "Unknown"),
-                    True,
-                )
-                cper_data_file = f"{prefix_for_filename}_{self.get_cper_count() + 1}.cper"
-                afids = self.cper_dump_afids(cper_data_file)
-                afids_str = " ".join(map(str, afids))
-                output += f" {cper_data_file:<17} {afids_str}"
+            self.cper_print(output, logger)
+        return []
 
-            if use_file:
-                with logger.destination.open("a", encoding="utf-8") as output_file:
-                    output_file.write(output + "\n")
-            else:
-                print(output)
+    def cper_print(self, text, logger: Optional["AMDSMILogger"] = None):
+        """Write *text* to the logger's file destination or to stdout.
 
-            self.increment_cper_count()
+        When *logger* is provided and its destination is a Path (i.e. the
+        user passed ``--file``), the text is appended to that file.
+        Otherwise it is printed to stdout.
+        """
+        if logger is not None and isinstance(logger.destination, Path):
+            with logger.destination.open("a", encoding="utf-8") as f:
+                f.write(text + "\n")
+        else:
+            print(text)
 
-    def _print_header(self, folder, logger=None):
+    def _print_header(self, folder, logger: Optional["AMDSMILogger"] = None):
+        """Print the CPER column header line (skipped for JSON output)."""
         if logger is not None and logger.is_json_format():
             return
 
         header = f"{'timestamp':<20} {'gpu_id':<7} {'severity':<20}"
         if folder:
             header += f" {'file_name':<17} {'list of afids'}"
-        header += ""
-        use_file = (
-            logger is not None
-            and logger.is_human_readable_format()
-            and logger.destination != "stdout"
-        )
 
-        if use_file:
-            with logger.destination.open("a", encoding="utf-8") as output_file:
-                output_file.write(header + "\n")
-        else:
-            print(header)
+        self.cper_print(header, logger)
+
+    def _write_cper_files(
+        self,
+        folder,
+        entries,
+        cper_data,
+        device_handle,
+        file_limit=None,
+        cper_file=None,
+        cper_counter=None,
+    ):
+        """Write each CPER entry to ``<folder>/<prefix>-<n>.cper`` plus a sibling
+        ``.json`` metadata file, enforce ``file_limit`` rotation, and collect the
+        per-file display data.
+
+        This is the pure file-I/O half of the CPER dump; formatting and emission
+        live in ``dump_cper_entries``.
+
+        Returns:
+            dict: Ordered mapping of written ``cper_path`` to
+            ``[timestamp, gpu_id, severity, cper_name, raw_bytes]``.
+        """
+        if cper_counter is None:
+            cper_counter = [0]
+        folder = Path(folder)
+        folder.mkdir(parents=True, exist_ok=True)
+
+        output_rows = {}
+        for entry_index, entry in enumerate(entries.values()):
+            # Determine prefix/severity
+            error_severity = entry.get("error_severity", "").lower()
+            notify_type = entry.get("notify_type", "")
+            prefix = self._severity_as_string(error_severity, notify_type, True)
+
+            # Generate filenames
+            count = cper_counter[0] + 1
+            if cper_file:
+                cper_name = cper_file
+            else:
+                cper_name = f"{prefix}-{count}.cper"
+            json_name = f"{prefix}-{count}.json"
+            cper_path = folder / cper_name
+            json_path = folder / json_name
+
+            # Write CPER binary file
+            try:
+                self.write_binary(
+                    cper_data[entry_index]["bytes"], cper_data[entry_index]["size"], cper_path
+                )
+            except Exception as e:
+                logging.debug(f"Failed to write CPER file {cper_path}: {e}")
+
+            # Write JSON metadata file
+            try:
+                with json_path.open("w") as cper_json_file:
+                    json.dump(
+                        obj=entry,
+                        fp=cper_json_file,
+                        indent=2,
+                        default=lambda o: o.decode("utf-8") if isinstance(o, bytes) else o,
+                    )
+            except Exception as e:
+                logging.debug(f"Failed to write JSON file {json_path}: {e}")
+
+            # Collect data for printing. Carry the in-memory bytes alongside
+            # the path so the AFID decode loop does not have to read
+            # the file we just wrote back from disk.
+            timestamp = entry.get("timestamp", "unknown")
+            gpu_id = "-"
+            if not isinstance(device_handle, Path):
+                gpu_id = self.get_gpu_id_from_device_handle(device_handle)
+            severity = self._severity_as_string(error_severity, notify_type, False)
+            output_rows[cper_path] = [
+                timestamp,
+                gpu_id,
+                severity,
+                cper_name,
+                cper_data[entry_index]["bytes"],
+            ]
+            cper_counter[0] += 1
+
+        # Batch deletion if file limit is exceeded (AFTER writing ALL new files)
+        if file_limit:
+            folder_files = list(sorted(folder.glob("*.cper"), key=lambda p: p.stat().st_mtime))
+            if len(folder_files) > file_limit:
+                files_to_delete = len(folder_files) - file_limit
+                for old_file in folder_files[:files_to_delete]:
+                    try:
+                        old_file.unlink()
+                        json_file = old_file.with_suffix(".json")
+                        if json_file.exists():
+                            json_file.unlink()
+                    except OSError as e:
+                        logging.debug(f"Failed to delete file {old_file}: {e}")
+        return output_rows
 
     def dump_cper_entries(
         self,
@@ -2340,8 +2398,9 @@ class AMDSMIHelpers:
         device_handle,
         file_limit=None,
         cper_file=None,
-        logger=None,
-        emit=True,
+        logger: Optional["AMDSMILogger"] = None,
+        emit_inline=True,
+        cper_counter=None,
     ):
         """
         Dump CPER entries to files in the specified folder. Handles batch deletion if file limit is exceeded.
@@ -2352,89 +2411,42 @@ class AMDSMIHelpers:
         cper_data (list): List of CPER data objects with 'bytes' and 'size' keys.
         device_handle: Device handle for GPU identification.
         file_limit (int, optional): Maximum number of files to retain in the folder.
-        cper_file (str, optional): cper file name to use when saving to folder
+        cper_file (str, optional): Override filename for the CPER binary file.
+        logger (AMDSMILogger, optional): Logger for format detection and output routing.
+        emit_inline (bool): If True, emit output inline here; if False, suppress
+            inline emission so the caller can batch the returned rows (default True).
+        cper_counter (list[int], optional): Single-element mutable counter shared
+            across calls within one ``ras`` invocation so generated filenames
+            are 1-indexed and monotonically increasing across GPUs/iterations.
+            Defaults to a fresh ``[0]`` if omitted.
+
+        Returns:
+            list: JSON row dicts when JSON format is active, otherwise ``[]``.
         """
         json_output = logger is not None and logger.is_json_format()
-
-        # Initialize header display
-        if not json_output and not getattr(self, "_cper_display_initialized", False):
-            self._print_header(folder)
-            self._cper_display_initialized = True
+        if cper_counter is None:
+            cper_counter = [0]
 
         if folder:
-            folder = Path(folder)
-            folder.mkdir(parents=True, exist_ok=True)
-
-            output_rows = {}
-
-            for entry_index, entry in enumerate(entries.values()):
-                # Determine prefix/severity
-                error_severity = entry.get("error_severity", "").lower()
-                notify_type = entry.get("notify_type", "")
-                prefix = self._severity_as_string(error_severity, notify_type, True)
-
-                # Generate filenames
-                count = self.get_cper_count() + 1
-                if cper_file:
-                    cper_name = cper_file
-                else:
-                    cper_name = f"{prefix}-{count}.cper"
-                json_name = f"{prefix}-{count}.json"
-                cper_path = folder / cper_name
-                json_path = folder / json_name
-
-                # Write CPER binary file
-                try:
-                    self.write_binary(
-                        cper_data[entry_index]["bytes"], cper_data[entry_index]["size"], cper_path
-                    )
-                except Exception as e:
-                    logging.debug(f"Failed to write CPER file {cper_path}: {e}")
-
-                # Write JSON metadata file
-                try:
-                    with json_path.open("w") as cper_json_file:
-                        json.dump(
-                            obj=entry,
-                            fp=cper_json_file,
-                            indent=2,
-                            default=lambda o: o.decode("utf-8") if isinstance(o, bytes) else o,
-                        )
-                except Exception as e:
-                    logging.debug(f"Failed to write JSON file {json_path}: {e}")
-
-                # Collect data for printing
-                timestamp = entry.get("timestamp", "unknown")
-                gpu_id = "-"
-                if not isinstance(device_handle, Path):
-                    gpu_id = self.get_gpu_id_from_device_handle(device_handle)
-                severity = self._severity_as_string(error_severity, notify_type, False)
-                output_rows[cper_path] = [timestamp, gpu_id, severity, cper_name]
-                self.increment_cper_count()
-
-            # Batch deletion if file limit is exceeded (AFTER writing ALL new files)
-            if file_limit:
-                folder_files = list(sorted(folder.glob("*.cper"), key=lambda p: p.stat().st_mtime))
-                if len(folder_files) > file_limit:
-                    files_to_delete = len(folder_files) - file_limit
-                    for old_file in folder_files[:files_to_delete]:
-                        try:
-                            old_file.unlink()
-                            json_file = old_file.with_suffix(".json")
-                            if json_file.exists():
-                                json_file.unlink()
-                        except OSError as e:
-                            logging.debug(f"Failed to delete file {old_file}: {e}")
+            output_rows = self._write_cper_files(
+                folder,
+                entries,
+                cper_data,
+                device_handle,
+                file_limit=file_limit,
+                cper_file=cper_file,
+                cper_counter=cper_counter,
+            )
 
             # Print collected rows
             if json_output:
                 json_rows = []
                 for cper_path, row in output_rows.items():
-                    timestamp, gpu_id, severity, fname = row
+                    timestamp, gpu_id, severity, fname, raw_bytes = row
                     cper_path_str = str(cper_path)
                     json_path_str = str(Path(cper_path).with_suffix(".json"))
                     try:
-                        afids = self.cper_dump_afids(cper_path)
+                        afids = self.cper_dump_afids(raw_bytes)
                     except Exception as e:
                         afids = []
                         logging.debug(f"Failed to fetch AFIDs for {cper_path}: {e}")
@@ -2448,19 +2460,22 @@ class AMDSMIHelpers:
                             "afids": afids,
                         }
                     )
-                if emit:
-                    print(json.dumps(json_rows, indent=2))
+                if emit_inline:
+                    self.cper_print(json.dumps(json_rows, indent=2), logger)
                 return json_rows
             else:
                 for cper_path, row in output_rows.items():
-                    timestamp, gpu_id, severity, fname = row
+                    timestamp, gpu_id, severity, fname, raw_bytes = row
                     try:
-                        afids = self.cper_dump_afids(cper_path)
+                        afids = self.cper_dump_afids(raw_bytes)
                         afids_str = " ".join(map(str, afids))
                     except Exception as e:
                         afids_str = "Error fetching AFIDs"
                         logging.debug(f"Failed to fetch AFIDs for {cper_path}: {e}")
-                    print(f"{timestamp:<20} {gpu_id:<7} {severity:<20} {fname:<17} {afids_str}")
+                    self.cper_print(
+                        f"{timestamp:<20} {gpu_id:<7} {severity:<20} {fname:<17} {afids_str}",
+                        logger,
+                    )
         else:
             if json_output:
                 try:
@@ -2479,20 +2494,21 @@ class AMDSMIHelpers:
                                 "severity": severity,
                             }
                         )
-                    if emit:
-                        print(json.dumps(json_rows, indent=2))
+                    if emit_inline:
+                        self.cper_print(json.dumps(json_rows, indent=2), logger)
                     return json_rows
                 except Exception as e:
                     logging.debug(f"Failed to build json summary rows: {e}")
             else:
                 # Print entries as JSON if no folder is specified
                 try:
-                    print(
+                    self.cper_print(
                         json.dumps(
                             entries,
                             indent=2,
                             default=lambda o: o.decode("utf-8") if isinstance(o, bytes) else o,
-                        )
+                        ),
+                        logger,
                     )
                 except Exception as e:
                     logging.debug(f"Failed to dump entries as JSON: {e}")
@@ -2519,60 +2535,15 @@ class AMDSMIHelpers:
                 data_bytes = data[:size]
             f.write(data_bytes)
 
-    def binary_to_hexdump_string(self, data: Union[bytes, List[int]]) -> str:
-        """
-        Convert binary data to a hexdump string.
-
-        Args:
-            data: bytes object or list of integer byte values (0–255).
-
-        Returns:
-           A multiline string, each line showing:
-           offset (in hex), hex bytes (16 per line), and printable ASCII.
-        """
-        if isinstance(data, bytes):
-            data_ints = list(data)
+    def cper_dump_afids(self, cper_file: Union[bytes, Path]):
+        # Normalize the input to raw bytes. Callers pass either the in-memory
+        # CPER bytes (the --cper write path and the --afid --folder read path,
+        # which reads with O_NOFOLLOW) or a Path to a .cper file (the
+        # --afid --cper-file read path).
+        if isinstance(cper_file, Path):
+            raw = cper_file.read_bytes()
         else:
-            # Allow list of ints or single-character strings
-            data_ints = []
-            for b in data:
-                if isinstance(b, int):
-                    data_ints.append(b)
-                elif isinstance(b, str) and len(b) == 1:
-                    data_ints.append(ord(b))
-                else:
-                    raise ValueError(f"Invalid type in data: {type(b)}")
-
-        lines: List[str] = []
-        size = len(data_ints)
-
-        for offset in range(0, size, 16):
-            chunk = data_ints[offset : offset + 16]
-            hex_values = " ".join(f"{b:02x}" for b in chunk)
-            # Pad hex_values to 16*3-1 = 47 chars (two hex digits + space)
-            hex_values = hex_values.ljust(16 * 3 - 1)
-            ascii_values = "".join(chr(b) if 32 <= b <= 126 else "." for b in chunk)
-            lines.append(f"{offset:08x}  {hex_values}  |{ascii_values}|")
-
-        return "\n".join(lines)
-
-    def cper_dump_afids(self, cper_file):
-        # 1) Fetch the CPER “file” and ensure we have raw bytes
-        raw_data = cper_file
-        if hasattr(raw_data, "read"):
-            # fetch_cper_file returned a file‐object
-            raw = raw_data.read()
-        elif isinstance(raw_data, Path):
-            # Path: read the bytes directly
-            raw = raw_data.read_bytes()
-        elif isinstance(raw_data, str):
-            # fetch_cper_file returned a filename
-            with open(raw_data, "rb") as f:
-                raw = f.read()
-        else:
-            # assume it's already bytes
-            raw = raw_data
-        self.binary_to_hexdump_string(raw)
+            raw = cper_file
         try:
             afids, num_afids = amdsmi_interface.amdsmi_get_afids_from_cper(raw)
             return afids
@@ -2635,61 +2606,85 @@ class AMDSMIHelpers:
             return False
         return True
 
-    def ras_cper(self, args, device_handle, logger, gpu_idx, emit_json=True):
-        # Parse severity mask dynamically from the --severity option.
-        severity_mask = 0
-        # drop duplicates of args
-        logging.debug(args)
+    def _emit_cper_output(
+        self,
+        entries,
+        cper_data,
+        device_handle,
+        args,
+        logger: "AMDSMILogger",
+        collected_json_rows,
+        emit_inline,
+        cper_counter,
+    ):
+        """Dispatch CPER output to the appropriate handler.
 
-        for sev in list(set(args.severity)):
-            if sev == "all":
-                # Set bits for NON_FATAL_UNCORRECTED (0), FATAL (1), and NON_FATAL_CORRECTED (2)
-                severity_mask |= (1 << 0) | (1 << 1) | (1 << 2)
-            elif sev == "fatal":
-                # Set bit corresponding to AMDSMI_CPER_SEV_FATAL (which is 1)
-                severity_mask |= 1 << 1
-            elif sev in ("nonfatal", "nonfatal-uncorrected"):
-                # Set bit corresponding to AMDSMI_CPER_SEV_NON_FATAL_UNCORRECTED (which is 0)
-                severity_mask |= 1 << 0
-            elif sev in ("nonfatal-corrected", "corrected"):
-                # Set bit corresponding to AMDSMI_CPER_SEV_NON_FATAL_CORRECTED (which is 2)
-                severity_mask |= 1 << 2
+        When ``--folder`` is specified or JSON format is active, writes CPER files
+        and/or emits structured JSON via dump_cper_entries().
+        Otherwise, prints a human-readable summary via display_cper_files_generated().
 
-        buffer_size = 1048576
-
-        # Decide where to send human-readable output
-        dest = getattr(logger, "destination", "stdout") if logger is not None else "stdout"
-        log_to_file = dest != "stdout"
-        if log_to_file:
-            # destination is usually a Path; fall back to Path(string) if needed
-            log_path = dest if isinstance(dest, Path) else Path(dest)
+        Note:
+            *collected_json_rows* is mutated in place (extended with new rows).
+        """
+        if args.folder or logger.is_json_format():
+            cper_rows = self.dump_cper_entries(
+                args.folder,
+                entries,
+                cper_data,
+                device_handle,
+                args.file_limit,
+                logger=logger,
+                emit_inline=emit_inline,
+                cper_counter=cper_counter,
+            )
+            collected_json_rows.extend(cper_rows)
         else:
-            log_path = None
+            self.display_cper_files_generated(entries, device_handle, logger=logger)
+
+    def ras_cper(self, args, device_handle, logger, gpu_idx, emit_inline=True, cper_counter=None):
+        """Fetch and process CPER entries for a single GPU.
+
+        Handles:
+        - Parsing severity mask from args.severity
+        - Fetching CPER entries from the kernel driver in a loop
+        - Dispatching output via _emit_cper_output()
+
+        Args:
+            args: Parsed CLI arguments (severity, folder, file_limit, follow, cursor, etc.)
+            device_handle: GPU device handle
+            logger: AMDSMILogger instance for format detection and output routing
+            gpu_idx: Index into args.cursor for this GPU
+            emit_inline: Whether to emit output inline here vs. return rows for
+                the caller to batch (default True)
+            cper_counter: Single-element mutable counter shared across GPUs/iterations.
+                Defaults to a fresh ``[0]`` if omitted.
+
+        Returns:
+            list: Collected JSON rows (empty list if not JSON format)
+
+        Side effects:
+            ``args.cursor[gpu_idx]`` is updated with the new cursor position.
+        """
+        severity_mask = self._parse_cper_severity_mask(args.severity)
+        buffer_size = 1048576
+        if cper_counter is None:
+            cper_counter = [0]
 
         gpu_id = self.get_gpu_id_from_device_handle(device_handle)
-        if (
-            args.follow
-            and not logger.is_json_format()
-            and not getattr(self, "_cper_follow_prompted", False)
-        ):
-            print("Press CTRL + C to stop.")
-            self._cper_follow_prompted = True
 
         primary_partition = self.is_primary_partition(device_handle, gpu_id)
         if not primary_partition:
             return []
 
-        if args.folder and not getattr(self, "_cper_folder_prompted", False):
-            self._cper_folder_prompted = True
-
         logger.set_cper_exit_message(False)
-        self.stop = False
 
         num_entries = 0
         collected_json_rows = []
+        entries = {}
+        cper_data = []
         while True:
             try:
-                entries, new_cursor, cper_data, status_code = (
+                entries, new_cursor, cper_data, _status_code = (
                     amdsmi_interface.amdsmi_get_gpu_cper_entries(
                         device_handle, severity_mask, buffer_size, args.cursor[gpu_idx]
                     )
@@ -2711,9 +2706,7 @@ class AMDSMIHelpers:
                         "Error accessing CPER files. This command requires CPER to be enabled."
                     ) from e
                 if e.get_error_code() == amdsmi_interface.amdsmi_wrapper.AMDSMI_STATUS_FILE_ERROR:
-                    raise FileExistsError(
-                        "Error opening CPER file. Unable to read CPER File"
-                    ) from e
+                    raise OSError("Error opening CPER file. Unable to read CPER File") from e
                 else:
                     logging.debug(f"Cannot retrieve CPER entries: {e}")
                     break
@@ -2721,107 +2714,56 @@ class AMDSMIHelpers:
             args.cursor[gpu_idx] = new_cursor
             if len(entries) == 0:
                 break
-            if args.decode and args.cper_file:
-                if args.json:
-                    self.dump_cper_entries_as_json(entries, cper_data, device_handle)
-                elif args.folder:
-                    self.dump_cper_entries(
-                        args.folder, entries, cper_data, device_handle, args.file_limit
-                    )
-                else:
-                    with tempfile.TemporaryDirectory() as tmp_dir:
-                        self.dump_cper_entries(
-                            tmp_dir,
-                            entries,
-                            cper_data,
-                            device_handle,
-                            args.file_limit,
-                            cper_file=os.path.basename(args.cper_file),
-                        )
 
-            # When a file destination is set, temporarily redirect stdout
-            # so that helper print() calls go into that file.
-            if log_to_file and log_path is not None:
-                orig_stdout = sys.stdout
-                try:
-                    try:
-                        log_path.parent.mkdir(parents=True, exist_ok=True)
-                    except Exception:
-                        pass
-                    with log_path.open("a", encoding="utf-8") as f:
-                        sys.stdout = f
-                        if args.folder or logger.is_json_format():
-                            cper_rows = self.dump_cper_entries(
-                                args.folder,
-                                entries,
-                                cper_data,
-                                device_handle,
-                                args.file_limit,
-                                logger=logger,
-                                emit=emit_json,
-                            )
-                            collected_json_rows.extend(cper_rows)
-                        else:
-                            self.display_cper_files_generated(entries, device_handle, args.folder)
-                finally:
-                    sys.stdout = orig_stdout
-            else:
-                if args.folder or logger.is_json_format():
-                    cper_rows = self.dump_cper_entries(
-                        args.folder,
-                        entries,
-                        cper_data,
-                        device_handle,
-                        args.file_limit,
-                        logger=logger,
-                        emit=emit_json,
-                    )
-                    collected_json_rows.extend(cper_rows)
-                else:
-                    self.display_cper_files_generated(entries, device_handle, args.folder)
+            self._emit_cper_output(
+                entries,
+                cper_data,
+                device_handle,
+                args,
+                logger,
+                collected_json_rows,
+                emit_inline,
+                cper_counter,
+            )
 
         if num_entries == 0 and not args.follow:
-            # If nothing was found, still emit the warning/header logic
-            # using the same redirection logic.
-            if log_to_file and log_path is not None:
-                orig_stdout = sys.stdout
-                try:
-                    try:
-                        log_path.parent.mkdir(parents=True, exist_ok=True)
-                    except Exception:
-                        pass
-                    with log_path.open("a", encoding="utf-8") as f:
-                        sys.stdout = f
-                        if args.folder or logger.is_json_format():
-                            cper_rows = self.dump_cper_entries(
-                                args.folder,
-                                entries,
-                                cper_data,
-                                device_handle,
-                                args.file_limit,
-                                logger=logger,
-                                emit=emit_json,
-                            )
-                            collected_json_rows.extend(cper_rows)
-                        else:
-                            self.display_cper_files_generated(entries, device_handle, args.folder)
-                finally:
-                    sys.stdout = orig_stdout
-            else:
-                if args.folder or logger.is_json_format():
-                    cper_rows = self.dump_cper_entries(
-                        args.folder,
-                        entries,
-                        cper_data,
-                        device_handle,
-                        args.file_limit,
-                        logger=logger,
-                        emit=emit_json,
-                    )
-                    collected_json_rows.extend(cper_rows)
-                else:
-                    self.display_cper_files_generated(entries, device_handle, args.folder)
+            # If nothing was found, still emit the warning/header logic.
+            self._emit_cper_output(
+                entries,
+                cper_data,
+                device_handle,
+                args,
+                logger,
+                collected_json_rows,
+                emit_inline,
+                cper_counter,
+            )
         return collected_json_rows
+
+    @staticmethod
+    def _parse_cper_severity_mask(severity_list):
+        """Convert a list of severity strings into a bitmask.
+
+        Supported values: ``"all"``, ``"fatal"``, ``"nonfatal"`` /
+        ``"nonfatal-uncorrected"``, ``"corrected"`` / ``"nonfatal-corrected"``.
+
+        Args:
+            severity_list: List of severity strings from --severity arg
+
+        Returns:
+            int: Bitmask for CPER severity filtering
+        """
+        severity_mask = 0
+        for sev in set(severity_list):
+            if sev == "all":
+                severity_mask |= (1 << 0) | (1 << 1) | (1 << 2)
+            elif sev == "fatal":
+                severity_mask |= 1 << 1
+            elif sev in ("nonfatal", "nonfatal-uncorrected"):
+                severity_mask |= 1 << 0
+            elif sev in ("nonfatal-corrected", "corrected"):
+                severity_mask |= 1 << 2
+        return severity_mask
 
     def get_bitmask_ranges(self, bitmask_dict):
         ranges = {}

--- a/projects/amdsmi/amdsmi_cli/amdsmi_helpers.py
+++ b/projects/amdsmi/amdsmi_cli/amdsmi_helpers.py
@@ -2446,6 +2446,10 @@ class AMDSMIHelpers:
                     cper_path_str = str(cper_path)
                     json_path_str = str(Path(cper_path).with_suffix(".json"))
                     try:
+                        # Convert list of integers to bytes if necessary
+                        if isinstance(raw_bytes, list):
+                            # Handle signed bytes (convert negative values to unsigned)
+                            raw_bytes = bytes(x & 0xFF for x in raw_bytes)
                         afids = self.cper_dump_afids(raw_bytes)
                     except Exception as e:
                         afids = []
@@ -2467,6 +2471,10 @@ class AMDSMIHelpers:
                 for cper_path, row in output_rows.items():
                     timestamp, gpu_id, severity, fname, raw_bytes = row
                     try:
+                        # Convert list of integers to bytes if necessary
+                        if isinstance(raw_bytes, list):
+                            # Handle signed bytes (convert negative values to unsigned)
+                            raw_bytes = bytes(x & 0xFF for x in raw_bytes)
                         afids = self.cper_dump_afids(raw_bytes)
                         afids_str = " ".join(map(str, afids))
                     except Exception as e:

--- a/projects/amdsmi/amdsmi_cli/amdsmi_helpers.py
+++ b/projects/amdsmi/amdsmi_cli/amdsmi_helpers.py
@@ -71,7 +71,6 @@ class AMDSMIHelpers:
 
         # Counts and Tracking variables
         self._count_of_sets_called = 0
-        self._count_of_cper_files = 0
         self._previous_set_success_check = (
             amdsmi_interface.amdsmi_wrapper.AMDSMI_STATUS_UNKNOWN_ERROR
         )
@@ -138,12 +137,6 @@ class AMDSMIHelpers:
         This is used to determine if the last set was successful or not.
         """
         return self._previous_set_success_check
-
-    def increment_cper_count(self):
-        self._count_of_cper_files += 1
-
-    def get_cper_count(self):
-        return self._count_of_cper_files
 
     def is_virtual_os(self):
         return self._is_virtual_os
@@ -2162,35 +2155,22 @@ class AMDSMIHelpers:
         return "UNKNOWN"
 
     def display_cper_files_generated(
-        self, entries, device_handle, folder, logger: Optional["AMDSMILogger"] = None
+        self, entries, device_handle, logger: Optional["AMDSMILogger"] = None
     ):
-        """
-        Display CPER summary lines. If a logger is provided and its destination is
-        not stdout, append the output to that file instead of printing to stdout.
+        """Print one human-readable summary line per CPER entry.
+
+        Only invoked when neither ``--folder`` nor JSON output is in effect, so
+        no filename column is emitted. Header / warning lines are printed by
+        the caller (``AMDSMICommands.ras``).
 
         Returns:
-            list: Always returns ``[]``.
+            list: Always returns ``[]`` (kept for symmetry with
+            ``dump_cper_entries``).
         """
         if logger is not None and logger.is_json_format():
             return []
 
-        # One‐time initialization: warning & header only once
-        if not getattr(self, "_cper_display_initialized", False):
-            # Warning if no folder was specified elsewhere
-            if not getattr(self, "_cper_warning_printed", False):
-                warning = (
-                    "WARNING: No CPER files will be dumped unless "
-                    "--folder=<folder_name> is specified and cper entries exist."
-                )
-                self.cper_print(warning, logger)
-                self._cper_warning_printed = True
-
-            self._print_header(folder, logger)
-            self._cper_display_initialized = True
-
-        # Loop through all entries in the dictionary.
         for entry in entries.values():
-            # Assume 'entry' is a dictionary with keys: "error_severity" and "notify_type".
             timestamp = entry.get("timestamp", "unknown")
             gpu_id = "-"
             output = ""
@@ -2203,20 +2183,7 @@ class AMDSMIHelpers:
                 )
                 output = f"{timestamp:<20} {gpu_id:<7} {prefix:<20}"
 
-            if folder:
-                prefix_for_filename = self._severity_as_string(
-                    entry.get("error_severity", "Unknown"),
-                    entry.get("notify_type", "Unknown"),
-                    True,
-                )
-                cper_data_file = f"{prefix_for_filename}_{self.get_cper_count() + 1}.cper"
-                afids = self.cper_dump_afids(cper_data_file)
-                afids_str = " ".join(map(str, afids))
-                output += f" {cper_data_file:<17} {afids_str}"
-
             self.cper_print(output, logger)
-
-            self.increment_cper_count()
         return []
 
     def cper_print(self, text, logger: Optional["AMDSMILogger"] = None):
@@ -2253,6 +2220,7 @@ class AMDSMIHelpers:
         cper_file=None,
         logger: Optional["AMDSMILogger"] = None,
         emit=True,
+        cper_counter=None,
     ):
         """
         Dump CPER entries to files in the specified folder. Handles batch deletion if file limit is exceeded.
@@ -2266,16 +2234,17 @@ class AMDSMIHelpers:
         cper_file (str, optional): Override filename for the CPER binary file.
         logger (AMDSMILogger, optional): Logger for format detection and output routing.
         emit (bool): If True and JSON format is active, emit JSON output (default True).
+        cper_counter (list[int], optional): Single-element mutable counter shared
+            across calls within one ``ras`` invocation so generated filenames
+            are 1-indexed and monotonically increasing across GPUs/iterations.
+            Defaults to a fresh ``[0]`` if omitted.
 
         Returns:
             list: JSON row dicts when JSON format is active, otherwise ``[]``.
         """
         json_output = logger is not None and logger.is_json_format()
-
-        # Initialize header display
-        if not json_output and not getattr(self, "_cper_display_initialized", False):
-            self._print_header(folder, logger)
-            self._cper_display_initialized = True
+        if cper_counter is None:
+            cper_counter = [0]
 
         if folder:
             folder = Path(folder)
@@ -2290,7 +2259,7 @@ class AMDSMIHelpers:
                 prefix = self._severity_as_string(error_severity, notify_type, True)
 
                 # Generate filenames
-                count = self.get_cper_count() + 1
+                count = cper_counter[0] + 1
                 if cper_file:
                     cper_name = cper_file
                 else:
@@ -2326,7 +2295,7 @@ class AMDSMIHelpers:
                     gpu_id = self.get_gpu_id_from_device_handle(device_handle)
                 severity = self._severity_as_string(error_severity, notify_type, False)
                 output_rows[cper_path] = [timestamp, gpu_id, severity, cper_name]
-                self.increment_cper_count()
+                cper_counter[0] += 1
 
             # Batch deletion if file limit is exceeded (AFTER writing ALL new files)
             if file_limit:
@@ -2564,6 +2533,7 @@ class AMDSMIHelpers:
         logger: "AMDSMILogger",
         collected_json_rows,
         emit_json,
+        cper_counter,
     ):
         """Dispatch CPER output to the appropriate handler.
 
@@ -2573,9 +2543,6 @@ class AMDSMIHelpers:
 
         Note:
             *collected_json_rows* is mutated in place (extended with new rows).
-
-        This is a transitional method — output dispatch should migrate to the
-        command layer (amdsmi_commands.py) in the future.
         """
         if args.folder or logger.is_json_format():
             cper_rows = self.dump_cper_entries(
@@ -2586,12 +2553,13 @@ class AMDSMIHelpers:
                 args.file_limit,
                 logger=logger,
                 emit=emit_json,
+                cper_counter=cper_counter,
             )
             collected_json_rows.extend(cper_rows)
         else:
-            self.display_cper_files_generated(entries, device_handle, args.folder, logger=logger)
+            self.display_cper_files_generated(entries, device_handle, logger=logger)
 
-    def ras_cper(self, args, device_handle, logger, gpu_idx, emit_json=True):
+    def ras_cper(self, args, device_handle, logger, gpu_idx, emit_json=True, cper_counter=None):
         """Fetch and process CPER entries for a single GPU.
 
         Handles:
@@ -2605,6 +2573,8 @@ class AMDSMIHelpers:
             logger: AMDSMILogger instance for format detection and output routing
             gpu_idx: Index into args.cursor for this GPU
             emit_json: Whether to emit JSON output (default True)
+            cper_counter: Single-element mutable counter shared across GPUs/iterations.
+                Defaults to a fresh ``[0]`` if omitted.
 
         Returns:
             list: Collected JSON rows (empty list if not JSON format)
@@ -2614,16 +2584,10 @@ class AMDSMIHelpers:
         """
         severity_mask = self._parse_cper_severity_mask(args.severity)
         buffer_size = 1048576
+        if cper_counter is None:
+            cper_counter = [0]
 
         gpu_id = self.get_gpu_id_from_device_handle(device_handle)
-        if (
-            args.follow
-            and not logger.is_json_format()
-            and not getattr(self, "_cper_follow_prompted", False)
-        ):
-            # Always print to stdout so the user sees the prompt, even with --file.
-            print("Press CTRL + C to stop.")
-            self._cper_follow_prompted = True
 
         primary_partition = self.is_primary_partition(device_handle, gpu_id)
         if not primary_partition:
@@ -2671,13 +2635,27 @@ class AMDSMIHelpers:
                 break
 
             self._emit_cper_output(
-                entries, cper_data, device_handle, args, logger, collected_json_rows, emit_json
+                entries,
+                cper_data,
+                device_handle,
+                args,
+                logger,
+                collected_json_rows,
+                emit_json,
+                cper_counter,
             )
 
         if num_entries == 0 and not args.follow:
             # If nothing was found, still emit the warning/header logic.
             self._emit_cper_output(
-                entries, cper_data, device_handle, args, logger, collected_json_rows, emit_json
+                entries,
+                cper_data,
+                device_handle,
+                args,
+                logger,
+                collected_json_rows,
+                emit_json,
+                cper_counter,
             )
         return collected_json_rows
 

--- a/projects/amdsmi/amdsmi_cli/amdsmi_helpers.py
+++ b/projects/amdsmi/amdsmi_cli/amdsmi_helpers.py
@@ -2288,13 +2288,21 @@ class AMDSMIHelpers:
                 except Exception as e:
                     logging.debug(f"Failed to write JSON file {json_path}: {e}")
 
-                # Collect data for printing
+                # Collect data for printing. Carry the in-memory bytes alongside
+                # the path so the AFID decode loop below does not have to read
+                # the file we just wrote back from disk.
                 timestamp = entry.get("timestamp", "unknown")
                 gpu_id = "-"
                 if not isinstance(device_handle, Path):
                     gpu_id = self.get_gpu_id_from_device_handle(device_handle)
                 severity = self._severity_as_string(error_severity, notify_type, False)
-                output_rows[cper_path] = [timestamp, gpu_id, severity, cper_name]
+                output_rows[cper_path] = [
+                    timestamp,
+                    gpu_id,
+                    severity,
+                    cper_name,
+                    cper_data[entry_index]["bytes"],
+                ]
                 cper_counter[0] += 1
 
             # Batch deletion if file limit is exceeded (AFTER writing ALL new files)
@@ -2315,11 +2323,11 @@ class AMDSMIHelpers:
             if json_output:
                 json_rows = []
                 for cper_path, row in output_rows.items():
-                    timestamp, gpu_id, severity, fname = row
+                    timestamp, gpu_id, severity, fname, raw_bytes = row
                     cper_path_str = str(cper_path)
                     json_path_str = str(Path(cper_path).with_suffix(".json"))
                     try:
-                        afids = self.cper_dump_afids(cper_path)
+                        afids = self.cper_dump_afids(raw_bytes)
                     except Exception as e:
                         afids = []
                         logging.debug(f"Failed to fetch AFIDs for {cper_path}: {e}")
@@ -2338,9 +2346,9 @@ class AMDSMIHelpers:
                 return json_rows
             else:
                 for cper_path, row in output_rows.items():
-                    timestamp, gpu_id, severity, fname = row
+                    timestamp, gpu_id, severity, fname, raw_bytes = row
                     try:
-                        afids = self.cper_dump_afids(cper_path)
+                        afids = self.cper_dump_afids(raw_bytes)
                         afids_str = " ".join(map(str, afids))
                     except Exception as e:
                         afids_str = "Error fetching AFIDs"

--- a/projects/amdsmi/amdsmi_cli/amdsmi_helpers.py
+++ b/projects/amdsmi/amdsmi_cli/amdsmi_helpers.py
@@ -2623,9 +2623,7 @@ class AMDSMIHelpers:
                         "Error accessing CPER files. This command requires CPER to be enabled."
                     ) from e
                 if e.get_error_code() == amdsmi_interface.amdsmi_wrapper.AMDSMI_STATUS_FILE_ERROR:
-                    raise FileExistsError(
-                        "Error opening CPER file. Unable to read CPER File"
-                    ) from e
+                    raise OSError("Error opening CPER file. Unable to read CPER File") from e
                 else:
                     logging.debug(f"Cannot retrieve CPER entries: {e}")
                     break

--- a/projects/amdsmi/amdsmi_cli/amdsmi_helpers.py
+++ b/projects/amdsmi/amdsmi_cli/amdsmi_helpers.py
@@ -33,13 +33,16 @@ import glob
 import errno
 import pwd
 import stat
-from typing import Tuple, Optional, Union
+from typing import Tuple, Optional, Union, TYPE_CHECKING
 import tempfile
 
 from enum import Enum
 from pathlib import Path
 from typing import List, Set, Union
 from functools import lru_cache
+
+if TYPE_CHECKING:
+    from amdsmi_logger import AMDSMILogger
 
 # Import amdsmi library
 from amdsmi_init import *
@@ -2159,7 +2162,9 @@ class AMDSMIHelpers:
             return "unknown"
         return "UNKNOWN"
 
-    def display_cper_files_generated(self, entries, device_handle, folder, logger=None):
+    def display_cper_files_generated(
+        self, entries, device_handle, folder, logger: Optional["AMDSMILogger"] = None
+    ):
         """
         Display CPER summary lines. If a logger is provided and its destination is
         not stdout, append the output to that file instead of printing to stdout.
@@ -2193,7 +2198,7 @@ class AMDSMIHelpers:
             self._cper_display_initialized = True
 
         # Loop through all entries in the dictionary.
-        for entry_index, entry in enumerate(entries.values()):
+        for entry in entries.values():
             # Assume 'entry' is a dictionary with keys: "error_severity" and "notify_type".
             timestamp = entry.get("timestamp", "unknown")
             gpu_id = "-"
@@ -2233,7 +2238,6 @@ class AMDSMIHelpers:
         header = f"{'timestamp':<20} {'gpu_id':<7} {'severity':<20}"
         if folder:
             header += f" {'file_name':<17} {'list of afids'}"
-        header += ""
         use_file = (
             logger is not None
             and logger.is_human_readable_format()
@@ -2266,13 +2270,13 @@ class AMDSMIHelpers:
         cper_data (list): List of CPER data objects with 'bytes' and 'size' keys.
         device_handle: Device handle for GPU identification.
         file_limit (int, optional): Maximum number of files to retain in the folder.
-        cper_file (str, optional): cper file name to use when saving to folder
+        cper_file (str, optional): Override filename for the CPER binary file.
         """
         json_output = logger is not None and logger.is_json_format()
 
         # Initialize header display
         if not json_output and not getattr(self, "_cper_display_initialized", False):
-            self._print_header(folder)
+            self._print_header(folder, logger)
             self._cper_display_initialized = True
 
         if folder:
@@ -2593,17 +2597,13 @@ class AMDSMIHelpers:
         if not primary_partition:
             return []
 
-        if args.folder and not getattr(self, "_cper_folder_prompted", False):
-            self._cper_folder_prompted = True
-
         logger.set_cper_exit_message(False)
-        self.stop = False
 
         num_entries = 0
         collected_json_rows = []
         while True:
             try:
-                entries, new_cursor, cper_data, status_code = (
+                entries, new_cursor, cper_data, _status_code = (
                     amdsmi_interface.amdsmi_get_gpu_cper_entries(
                         device_handle, severity_mask, buffer_size, args.cursor[gpu_idx]
                     )
@@ -2635,23 +2635,34 @@ class AMDSMIHelpers:
             args.cursor[gpu_idx] = new_cursor
             if len(entries) == 0:
                 break
-            if args.decode and args.cper_file:
-                if args.json:
-                    self.dump_cper_entries_as_json(entries, cper_data, device_handle)
-                elif args.folder:
-                    self.dump_cper_entries(
-                        args.folder, entries, cper_data, device_handle, args.file_limit
+            # Decode mode: write CPER files from an externally-provided CPER record
+            # and skip the normal output dispatch to avoid double-processing.
+            if getattr(args, "decode", False) and getattr(args, "cper_file", None):
+                decode_folder = args.folder
+                if decode_folder:
+                    cper_rows = self.dump_cper_entries(
+                        decode_folder,
+                        entries,
+                        cper_data,
+                        device_handle,
+                        args.file_limit,
+                        logger=logger,
+                        emit=emit_json,
                     )
                 else:
                     with tempfile.TemporaryDirectory() as tmp_dir:
-                        self.dump_cper_entries(
+                        cper_rows = self.dump_cper_entries(
                             tmp_dir,
                             entries,
                             cper_data,
                             device_handle,
                             args.file_limit,
                             cper_file=os.path.basename(args.cper_file),
+                            logger=logger,
+                            emit=emit_json,
                         )
+                collected_json_rows.extend(cper_rows)
+                continue
 
             # When a file destination is set, temporarily redirect stdout
             # so that helper print() calls go into that file.

--- a/projects/amdsmi/amdsmi_cli/amdsmi_helpers.py
+++ b/projects/amdsmi/amdsmi_cli/amdsmi_helpers.py
@@ -2168,15 +2168,12 @@ class AMDSMIHelpers:
         """
         Display CPER summary lines. If a logger is provided and its destination is
         not stdout, append the output to that file instead of printing to stdout.
+
+        Returns:
+            list: Always returns ``[]``.
         """
         if logger is not None and logger.is_json_format():
             return []
-
-        use_file = (
-            logger is not None
-            and logger.is_human_readable_format()
-            and logger.destination != "stdout"
-        )
 
         # One‐time initialization: warning & header only once
         if not getattr(self, "_cper_display_initialized", False):
@@ -2186,15 +2183,10 @@ class AMDSMIHelpers:
                     "WARNING: No CPER files will be dumped unless "
                     "--folder=<folder_name> is specified and cper entries exist."
                 )
-                if use_file:
-                    with logger.destination.open("a", encoding="utf-8") as output_file:
-                        output_file.write(warning + "\n")
-                else:
-                    print(warning)
+                self.cper_print(warning, logger)
                 self._cper_warning_printed = True
 
-            # Print or log the header
-            self._print_header(folder, logger if use_file else None)
+            self._print_header(folder, logger)
             self._cper_display_initialized = True
 
         # Loop through all entries in the dictionary.
@@ -2223,32 +2215,34 @@ class AMDSMIHelpers:
                 afids_str = " ".join(map(str, afids))
                 output += f" {cper_data_file:<17} {afids_str}"
 
-            if use_file:
-                with logger.destination.open("a", encoding="utf-8") as output_file:
-                    output_file.write(output + "\n")
-            else:
-                print(output)
+            self.cper_print(output, logger)
 
             self.increment_cper_count()
+        return []
 
-    def _print_header(self, folder, logger=None):
+    def cper_print(self, text, logger: Optional["AMDSMILogger"] = None):
+        """Write *text* to the logger's file destination or to stdout.
+
+        When *logger* is provided and its destination is a Path (i.e. the
+        user passed ``--file``), the text is appended to that file.
+        Otherwise it is printed to stdout.
+        """
+        if logger is not None and isinstance(logger.destination, Path):
+            with logger.destination.open("a", encoding="utf-8") as f:
+                f.write(text + "\n")
+        else:
+            print(text)
+
+    def _print_header(self, folder, logger: Optional["AMDSMILogger"] = None):
+        """Print the CPER column header line (skipped for JSON output)."""
         if logger is not None and logger.is_json_format():
             return
 
         header = f"{'timestamp':<20} {'gpu_id':<7} {'severity':<20}"
         if folder:
             header += f" {'file_name':<17} {'list of afids'}"
-        use_file = (
-            logger is not None
-            and logger.is_human_readable_format()
-            and logger.destination != "stdout"
-        )
 
-        if use_file:
-            with logger.destination.open("a", encoding="utf-8") as output_file:
-                output_file.write(header + "\n")
-        else:
-            print(header)
+        self.cper_print(header, logger)
 
     def dump_cper_entries(
         self,
@@ -2258,7 +2252,7 @@ class AMDSMIHelpers:
         device_handle,
         file_limit=None,
         cper_file=None,
-        logger=None,
+        logger: Optional["AMDSMILogger"] = None,
         emit=True,
     ):
         """
@@ -2271,6 +2265,11 @@ class AMDSMIHelpers:
         device_handle: Device handle for GPU identification.
         file_limit (int, optional): Maximum number of files to retain in the folder.
         cper_file (str, optional): Override filename for the CPER binary file.
+        logger (AMDSMILogger, optional): Logger for format detection and output routing.
+        emit (bool): If True and JSON format is active, emit JSON output (default True).
+
+        Returns:
+            list: JSON row dicts when JSON format is active, otherwise ``[]``.
         """
         json_output = logger is not None and logger.is_json_format()
 
@@ -2367,7 +2366,7 @@ class AMDSMIHelpers:
                         }
                     )
                 if emit:
-                    print(json.dumps(json_rows, indent=2))
+                    self.cper_print(json.dumps(json_rows, indent=2), logger)
                 return json_rows
             else:
                 for cper_path, row in output_rows.items():
@@ -2378,7 +2377,10 @@ class AMDSMIHelpers:
                     except Exception as e:
                         afids_str = "Error fetching AFIDs"
                         logging.debug(f"Failed to fetch AFIDs for {cper_path}: {e}")
-                    print(f"{timestamp:<20} {gpu_id:<7} {severity:<20} {fname:<17} {afids_str}")
+                    self.cper_print(
+                        f"{timestamp:<20} {gpu_id:<7} {severity:<20} {fname:<17} {afids_str}",
+                        logger,
+                    )
         else:
             if json_output:
                 try:
@@ -2398,19 +2400,20 @@ class AMDSMIHelpers:
                             }
                         )
                     if emit:
-                        print(json.dumps(json_rows, indent=2))
+                        self.cper_print(json.dumps(json_rows, indent=2), logger)
                     return json_rows
                 except Exception as e:
                     logging.debug(f"Failed to build json summary rows: {e}")
             else:
                 # Print entries as JSON if no folder is specified
                 try:
-                    print(
+                    self.cper_print(
                         json.dumps(
                             entries,
                             indent=2,
                             default=lambda o: o.decode("utf-8") if isinstance(o, bytes) else o,
-                        )
+                        ),
+                        logger,
                     )
                 except Exception as e:
                     logging.debug(f"Failed to dump entries as JSON: {e}")
@@ -2553,36 +2556,65 @@ class AMDSMIHelpers:
             return False
         return True
 
-    def ras_cper(self, args, device_handle, logger, gpu_idx, emit_json=True):
-        # Parse severity mask dynamically from the --severity option.
-        severity_mask = 0
-        # drop duplicates of args
-        logging.debug(args)
+    def _emit_cper_output(
+        self,
+        entries,
+        cper_data,
+        device_handle,
+        args,
+        logger: "AMDSMILogger",
+        collected_json_rows,
+        emit_json,
+    ):
+        """Dispatch CPER output to the appropriate handler.
 
-        for sev in list(set(args.severity)):
-            if sev == "all":
-                # Set bits for NON_FATAL_UNCORRECTED (0), FATAL (1), and NON_FATAL_CORRECTED (2)
-                severity_mask |= (1 << 0) | (1 << 1) | (1 << 2)
-            elif sev == "fatal":
-                # Set bit corresponding to AMDSMI_CPER_SEV_FATAL (which is 1)
-                severity_mask |= 1 << 1
-            elif sev in ("nonfatal", "nonfatal-uncorrected"):
-                # Set bit corresponding to AMDSMI_CPER_SEV_NON_FATAL_UNCORRECTED (which is 0)
-                severity_mask |= 1 << 0
-            elif sev in ("nonfatal-corrected", "corrected"):
-                # Set bit corresponding to AMDSMI_CPER_SEV_NON_FATAL_CORRECTED (which is 2)
-                severity_mask |= 1 << 2
+        When ``--folder`` is specified or JSON format is active, writes CPER files
+        and/or emits structured JSON via dump_cper_entries().
+        Otherwise, prints a human-readable summary via display_cper_files_generated().
 
-        buffer_size = 1048576
+        Note:
+            *collected_json_rows* is mutated in place (extended with new rows).
 
-        # Decide where to send human-readable output
-        dest = getattr(logger, "destination", "stdout") if logger is not None else "stdout"
-        log_to_file = dest != "stdout"
-        if log_to_file:
-            # destination is usually a Path; fall back to Path(string) if needed
-            log_path = dest if isinstance(dest, Path) else Path(dest)
+        This is a transitional method — output dispatch should migrate to the
+        command layer (amdsmi_commands.py) in the future.
+        """
+        if args.folder or logger.is_json_format():
+            cper_rows = self.dump_cper_entries(
+                args.folder,
+                entries,
+                cper_data,
+                device_handle,
+                args.file_limit,
+                logger=logger,
+                emit=emit_json,
+            )
+            collected_json_rows.extend(cper_rows)
         else:
-            log_path = None
+            self.display_cper_files_generated(entries, device_handle, args.folder, logger=logger)
+
+    def ras_cper(self, args, device_handle, logger, gpu_idx, emit_json=True):
+        """Fetch and process CPER entries for a single GPU.
+
+        Handles:
+        - Parsing severity mask from args.severity
+        - Fetching CPER entries from the kernel driver in a loop
+        - Dispatching output via _emit_cper_output()
+
+        Args:
+            args: Parsed CLI arguments (severity, folder, file_limit, follow, cursor, etc.)
+            device_handle: GPU device handle
+            logger: AMDSMILogger instance for format detection and output routing
+            gpu_idx: Index into args.cursor for this GPU
+            emit_json: Whether to emit JSON output (default True)
+
+        Returns:
+            list: Collected JSON rows (empty list if not JSON format)
+
+        Side effects:
+            ``args.cursor[gpu_idx]`` is updated with the new cursor position.
+        """
+        severity_mask = self._parse_cper_severity_mask(args.severity)
+        buffer_size = 1048576
 
         gpu_id = self.get_gpu_id_from_device_handle(device_handle)
         if (
@@ -2590,6 +2622,7 @@ class AMDSMIHelpers:
             and not logger.is_json_format()
             and not getattr(self, "_cper_follow_prompted", False)
         ):
+            # Always print to stdout so the user sees the prompt, even with --file.
             print("Press CTRL + C to stop.")
             self._cper_follow_prompted = True
 
@@ -2601,6 +2634,8 @@ class AMDSMIHelpers:
 
         num_entries = 0
         collected_json_rows = []
+        entries = {}
+        cper_data = []
         while True:
             try:
                 entries, new_cursor, cper_data, _status_code = (
@@ -2635,6 +2670,7 @@ class AMDSMIHelpers:
             args.cursor[gpu_idx] = new_cursor
             if len(entries) == 0:
                 break
+
             # Decode mode: write CPER files from an externally-provided CPER record
             # and skip the normal output dispatch to avoid double-processing.
             if getattr(args, "decode", False) and getattr(args, "cper_file", None):
@@ -2664,89 +2700,41 @@ class AMDSMIHelpers:
                 collected_json_rows.extend(cper_rows)
                 continue
 
-            # When a file destination is set, temporarily redirect stdout
-            # so that helper print() calls go into that file.
-            if log_to_file and log_path is not None:
-                orig_stdout = sys.stdout
-                try:
-                    try:
-                        log_path.parent.mkdir(parents=True, exist_ok=True)
-                    except Exception:
-                        pass
-                    with log_path.open("a", encoding="utf-8") as f:
-                        sys.stdout = f
-                        if args.folder or logger.is_json_format():
-                            cper_rows = self.dump_cper_entries(
-                                args.folder,
-                                entries,
-                                cper_data,
-                                device_handle,
-                                args.file_limit,
-                                logger=logger,
-                                emit=emit_json,
-                            )
-                            collected_json_rows.extend(cper_rows)
-                        else:
-                            self.display_cper_files_generated(entries, device_handle, args.folder)
-                finally:
-                    sys.stdout = orig_stdout
-            else:
-                if args.folder or logger.is_json_format():
-                    cper_rows = self.dump_cper_entries(
-                        args.folder,
-                        entries,
-                        cper_data,
-                        device_handle,
-                        args.file_limit,
-                        logger=logger,
-                        emit=emit_json,
-                    )
-                    collected_json_rows.extend(cper_rows)
-                else:
-                    self.display_cper_files_generated(entries, device_handle, args.folder)
+            self._emit_cper_output(
+                entries, cper_data, device_handle, args, logger, collected_json_rows, emit_json
+            )
 
         if num_entries == 0 and not args.follow:
-            # If nothing was found, still emit the warning/header logic
-            # using the same redirection logic.
-            if log_to_file and log_path is not None:
-                orig_stdout = sys.stdout
-                try:
-                    try:
-                        log_path.parent.mkdir(parents=True, exist_ok=True)
-                    except Exception:
-                        pass
-                    with log_path.open("a", encoding="utf-8") as f:
-                        sys.stdout = f
-                        if args.folder or logger.is_json_format():
-                            cper_rows = self.dump_cper_entries(
-                                args.folder,
-                                entries,
-                                cper_data,
-                                device_handle,
-                                args.file_limit,
-                                logger=logger,
-                                emit=emit_json,
-                            )
-                            collected_json_rows.extend(cper_rows)
-                        else:
-                            self.display_cper_files_generated(entries, device_handle, args.folder)
-                finally:
-                    sys.stdout = orig_stdout
-            else:
-                if args.folder or logger.is_json_format():
-                    cper_rows = self.dump_cper_entries(
-                        args.folder,
-                        entries,
-                        cper_data,
-                        device_handle,
-                        args.file_limit,
-                        logger=logger,
-                        emit=emit_json,
-                    )
-                    collected_json_rows.extend(cper_rows)
-                else:
-                    self.display_cper_files_generated(entries, device_handle, args.folder)
+            # If nothing was found, still emit the warning/header logic.
+            self._emit_cper_output(
+                entries, cper_data, device_handle, args, logger, collected_json_rows, emit_json
+            )
         return collected_json_rows
+
+    @staticmethod
+    def _parse_cper_severity_mask(severity_list):
+        """Convert a list of severity strings into a bitmask.
+
+        Supported values: ``"all"``, ``"fatal"``, ``"nonfatal"`` /
+        ``"nonfatal-uncorrected"``, ``"corrected"`` / ``"nonfatal-corrected"``.
+
+        Args:
+            severity_list: List of severity strings from --severity arg
+
+        Returns:
+            int: Bitmask for CPER severity filtering
+        """
+        severity_mask = 0
+        for sev in set(severity_list):
+            if sev == "all":
+                severity_mask |= (1 << 0) | (1 << 1) | (1 << 2)
+            elif sev == "fatal":
+                severity_mask |= 1 << 1
+            elif sev in ("nonfatal", "nonfatal-uncorrected"):
+                severity_mask |= 1 << 0
+            elif sev in ("nonfatal-corrected", "corrected"):
+                severity_mask |= 1 << 2
+        return severity_mask
 
     def get_bitmask_ranges(self, bitmask_dict):
         ranges = {}

--- a/projects/amdsmi/amdsmi_cli/amdsmi_helpers.py
+++ b/projects/amdsmi/amdsmi_cli/amdsmi_helpers.py
@@ -34,7 +34,6 @@ import errno
 import pwd
 import stat
 from typing import Tuple, Optional, Union, TYPE_CHECKING
-import tempfile
 
 from enum import Enum
 from pathlib import Path
@@ -2670,35 +2669,6 @@ class AMDSMIHelpers:
             args.cursor[gpu_idx] = new_cursor
             if len(entries) == 0:
                 break
-
-            # Decode mode: write CPER files from an externally-provided CPER record
-            # and skip the normal output dispatch to avoid double-processing.
-            if getattr(args, "decode", False) and getattr(args, "cper_file", None):
-                decode_folder = args.folder
-                if decode_folder:
-                    cper_rows = self.dump_cper_entries(
-                        decode_folder,
-                        entries,
-                        cper_data,
-                        device_handle,
-                        args.file_limit,
-                        logger=logger,
-                        emit=emit_json,
-                    )
-                else:
-                    with tempfile.TemporaryDirectory() as tmp_dir:
-                        cper_rows = self.dump_cper_entries(
-                            tmp_dir,
-                            entries,
-                            cper_data,
-                            device_handle,
-                            args.file_limit,
-                            cper_file=os.path.basename(args.cper_file),
-                            logger=logger,
-                            emit=emit_json,
-                        )
-                collected_json_rows.extend(cper_rows)
-                continue
 
             self._emit_cper_output(
                 entries, cper_data, device_handle, args, logger, collected_json_rows, emit_json

--- a/projects/amdsmi/amdsmi_cli/amdsmi_parser.py
+++ b/projects/amdsmi/amdsmi_cli/amdsmi_parser.py
@@ -635,33 +635,6 @@ class AMDSMIParser(argparse.ArgumentParser):
 
         return CPUSvi3VrControllerTempArgs
 
-    def _check_folder_path(self):
-        """Argument action validator:
-        Returns a path to folder from the folder path provided.
-        If the path doesn't exist create it.
-        """
-
-        class CheckOutputFilePath(argparse.Action):
-            outputformat = self.helpers.get_output_format()
-
-            # Checks the values
-            def __call__(self, parser, args, values, option_string=None):
-                path = Path(values)
-                try:
-                    path.mkdir(parents=True, exist_ok=True)
-                except OSError as e:
-                    raise amdsmi_cli_exceptions.AmdSmiInvalidFilePathException(
-                        path, CheckOutputFilePath.outputformat, f"Unable to make '{path}' a folder."
-                    )
-                if not path.exists():
-                    raise amdsmi_cli_exceptions.AmdSmiInvalidFilePathException(
-                        path, CheckOutputFilePath.outputformat
-                    )
-                elif path.is_dir():
-                    setattr(args, self.dest, path)
-
-        return CheckOutputFilePath
-
     def _check_output_file_path(self):
         """Argument action validator:
         Returns a path to a file from the output file path provided.
@@ -3176,12 +3149,14 @@ class AMDSMIParser(argparse.ArgumentParser):
 
         # Help text for RAS arguments
         cper_help = "Trigger current CPER data retrieval"
-        afid_help = "Generate an AFID (AMD Field ID) given a CPER record file"
-        decode_help = "Decode out-of-band CPER files captured by or collected from other systems"
+        afid_help = "Generate an AFID (AMD Field ID) given a CPER record file or folder"
         severity_choices = ["nonfatal-uncorrected", "fatal", "nonfatal-corrected", "all"]
         severity_choices_str = ", ".join(severity_choices)
         severity_help = f"Set the SEVERITY filters from the following:\n    {severity_choices_str}"
-        folder_help = "Folder to dump current CPER report files"
+        folder_help = (
+            "With --cper: folder to dump current CPER report files (created if missing)."
+            "\n    With --afid: existing folder of CPER records to decode."
+        )
         file_limit_help = "Maximum number of current CPER files in target folder\n    Older files beyond limit will be deleted"
         cper_file_help = "Full path of a retrieved CPER record file to generate the AFID"
         follow_help = "Continuously monitor for new CPER entries"
@@ -3207,9 +3182,7 @@ class AMDSMIParser(argparse.ArgumentParser):
             choices=severity_choices,
             metavar="SEVERITY",
         )
-        cper_group.add_argument(
-            "--folder", type=str, action=self._check_folder_path(), help=folder_help
-        )
+        cper_group.add_argument("--folder", type=Path, help=folder_help)
         cper_group.add_argument(
             "--file-limit", type=self._positive_int, action="store", help=file_limit_help
         )
@@ -3223,7 +3196,6 @@ class AMDSMIParser(argparse.ArgumentParser):
             metavar="CPER_FILE",
             help=cper_file_help,
         )
-        afid_group.add_argument("--decode", action="store_true", help=decode_help)
 
         # Add common modifiers and device selection arguments.
         self._add_device_arguments(ras_parser, required=False)

--- a/projects/amdsmi/amdsmi_cli/amdsmi_parser.py
+++ b/projects/amdsmi/amdsmi_cli/amdsmi_parser.py
@@ -3186,11 +3186,14 @@ class AMDSMIParser(argparse.ArgumentParser):
 
         # Help text for RAS arguments
         cper_help = "Trigger current CPER data retrieval"
-        afid_help = "Generate an AFID (AMD Field ID) given a CPER record file"
+        afid_help = "Generate an AFID (AMD Field ID) given a CPER record file or folder"
         severity_choices = ["nonfatal-uncorrected", "fatal", "nonfatal-corrected", "all"]
         severity_choices_str = ", ".join(severity_choices)
         severity_help = f"Set the SEVERITY filters from the following:\n    {severity_choices_str}"
-        folder_help = "Folder to dump current CPER report files"
+        folder_help = (
+            "With --cper: folder to dump current CPER report files (created if missing)."
+            "\n    With --afid: existing folder of CPER records to decode."
+        )
         file_limit_help = "Maximum number of current CPER files in target folder\n    Older files beyond limit will be deleted"
         cper_file_help = "Full path of a retrieved CPER record file to generate the AFID"
         follow_help = "Continuously monitor for new CPER entries"

--- a/projects/amdsmi/amdsmi_cli/amdsmi_parser.py
+++ b/projects/amdsmi/amdsmi_cli/amdsmi_parser.py
@@ -627,33 +627,6 @@ class AMDSMIParser(argparse.ArgumentParser):
 
         return CPUSvi3VrControllerTempArgs
 
-    def _check_folder_path(self):
-        """Argument action validator:
-        Returns a path to folder from the folder path provided.
-        If the path doesn't exist create it.
-        """
-
-        class CheckOutputFilePath(argparse.Action):
-            outputformat = self.helpers.get_output_format()
-
-            # Checks the values
-            def __call__(self, parser, args, values, option_string=None):
-                path = Path(values)
-                try:
-                    path.mkdir(parents=True, exist_ok=True)
-                except OSError as e:
-                    raise amdsmi_cli_exceptions.AmdSmiInvalidFilePathException(
-                        path, CheckOutputFilePath.outputformat, f"Unable to make '{path}' a folder."
-                    )
-                if not path.exists():
-                    raise amdsmi_cli_exceptions.AmdSmiInvalidFilePathException(
-                        path, CheckOutputFilePath.outputformat
-                    )
-                elif path.is_dir():
-                    setattr(args, self.dest, path)
-
-        return CheckOutputFilePath
-
     def _check_output_file_path(self):
         """Argument action validator:
         Returns a path to a file from the output file path provided.
@@ -3219,9 +3192,7 @@ class AMDSMIParser(argparse.ArgumentParser):
             choices=severity_choices,
             metavar="SEVERITY",
         )
-        cper_group.add_argument(
-            "--folder", type=str, action=self._check_folder_path(), help=folder_help
-        )
+        cper_group.add_argument("--folder", type=Path, help=folder_help)
         cper_group.add_argument(
             "--file-limit", type=self._positive_int, action="store", help=file_limit_help
         )

--- a/projects/amdsmi/amdsmi_cli/amdsmi_parser.py
+++ b/projects/amdsmi/amdsmi_cli/amdsmi_parser.py
@@ -3187,7 +3187,6 @@ class AMDSMIParser(argparse.ArgumentParser):
         # Help text for RAS arguments
         cper_help = "Trigger current CPER data retrieval"
         afid_help = "Generate an AFID (AMD Field ID) given a CPER record file"
-        decode_help = "Decode out-of-band CPER files captured by or collected from other systems"
         severity_choices = ["nonfatal-uncorrected", "fatal", "nonfatal-corrected", "all"]
         severity_choices_str = ", ".join(severity_choices)
         severity_help = f"Set the SEVERITY filters from the following:\n    {severity_choices_str}"
@@ -3233,7 +3232,6 @@ class AMDSMIParser(argparse.ArgumentParser):
             metavar="CPER_FILE",
             help=cper_file_help,
         )
-        afid_group.add_argument("--decode", action="store_true", help=decode_help)
 
         # Add common modifiers and device selection arguments.
         self._add_device_arguments(ras_parser, required=False)

--- a/projects/amdsmi/amdsmi_cli/subcommands/ras.py
+++ b/projects/amdsmi/amdsmi_cli/subcommands/ras.py
@@ -133,8 +133,8 @@ class RasCommands:
             )
 
         if self.logger.is_json_format():
-            self.logger.output = results
-            self.logger.print_output()
+            self.logger.multiple_device_output = results
+            self.logger.print_output(multiple_device_enabled=True)
         else:
             print(f"{'file_name':<32} list of afids")
             for entry in results:

--- a/projects/amdsmi/amdsmi_cli/subcommands/ras.py
+++ b/projects/amdsmi/amdsmi_cli/subcommands/ras.py
@@ -19,13 +19,134 @@
 # IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 # CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+import logging
+import os
 import sys
 import time
+from pathlib import Path
 
-from amdsmi_cli_exceptions import AmdSmiInvalidCommandException
+from amdsmi_cli_exceptions import AmdSmiInvalidCommandException, AmdSmiInvalidFilePathException
 
 
 class RasCommands:
+    def _validate_ras_args(self, args):
+        """Validate ``ras`` arguments up front, before any driver call or file I/O.
+
+        Runs after argparse has fully populated the namespace, so the mode flags
+        (``--cper`` / ``--afid``) are reliable here even though an argparse action
+        on ``--folder`` could not see them (the action fires mid-parse, before the
+        mode flag may have been read). This is the single place that decides
+        whether a ``--folder`` is a write target (``--cper``) or a pre-existing
+        read source (``--afid``).
+        """
+        command = " ".join(sys.argv[1:])
+
+        if args.afid:
+            # Require exactly one of --cper-file / --folder under --afid.
+            if bool(args.cper_file) == bool(args.folder):
+                message = (
+                    f"Command '{command}' requires exactly one of"
+                    " '--cper-file' or '--folder'. Run '--help' for more info."
+                )
+                raise AmdSmiInvalidCommandException(command, self.logger.format, message)
+
+            if args.folder:
+                folder = Path(args.folder)
+                # Refuse to follow a symlinked folder (it could redirect the read
+                # into an arbitrary directory).
+                if folder.is_symlink():
+                    message = (
+                        f"Folder '{folder}' is a symlink; refusing to follow it for"
+                        " '--afid --folder'."
+                    )
+                    raise AmdSmiInvalidFilePathException(command, self.logger.format, message)
+                if not folder.exists() or not folder.is_dir():
+                    message = (
+                        f"Folder '{folder}' does not exist or is not a directory."
+                        " '--afid --folder' requires a folder of pre-existing CPER records."
+                    )
+                    raise AmdSmiInvalidFilePathException(command, self.logger.format, message)
+        elif args.cper:
+            if args.folder:
+                folder = Path(args.folder)
+                # Refuse to write into a symlinked folder.
+                if folder.is_symlink():
+                    message = (
+                        f"Folder '{folder}' is a symlink; refusing to write CPER files into it."
+                    )
+                    raise AmdSmiInvalidFilePathException(command, self.logger.format, message)
+                # Create the destination up front (and fail early if we cannot),
+                # rather than deferring the error to the per-GPU write loop.
+                try:
+                    folder.mkdir(parents=True, exist_ok=True)
+                except OSError as e:
+                    message = f"Unable to create or access folder '{folder}': {e}"
+                    raise AmdSmiInvalidFilePathException(command, self.logger.format, message)
+
+    def _decode_afid_folder(self, args):
+        """Decode AFIDs for every ``*.cper`` in ``args.folder``.
+
+        The folder is already validated (exists, is a directory, not a symlink)
+        by :meth:`_validate_ras_args`. Each file is opened with ``O_NOFOLLOW`` so a
+        planted symlink (e.g. ``evil.cper`` -> ``/etc/shadow``) cannot be followed
+        into an arbitrary-file read; this also closes the check-then-read TOCTOU
+        window by rejecting symlinks atomically at ``open()`` time.
+        """
+        folder = Path(args.folder)
+        cper_paths = sorted(folder.glob("*.cper"))
+        if not cper_paths:
+            command = " ".join(sys.argv[1:])
+            message = (
+                f"Folder '{folder}' contains no '.cper' files."
+                " '--afid --folder' requires a folder of pre-existing CPER records."
+            )
+            raise AmdSmiInvalidFilePathException(command, self.logger.format, message)
+
+        results = []
+        for cper_path in cper_paths:
+            try:
+                fd = os.open(cper_path, os.O_RDONLY | os.O_NOFOLLOW)
+            except OSError as e:
+                # Symlink (O_NOFOLLOW -> ELOOP) or otherwise unreadable: skip it.
+                # This is not a decode failure, so it is not surfaced as one.
+                logging.debug("Skipping symlink/unreadable CPER file %s: %s", cper_path, e)
+                continue
+            try:
+                raw = b""
+                while True:
+                    chunk = os.read(fd, 65536)
+                    if not chunk:
+                        break
+                    raw += chunk
+            finally:
+                os.close(fd)
+
+            decode_failed = False
+            afids = []
+            try:
+                afids = self.helpers.cper_dump_afids(raw)
+            except Exception as e:
+                logging.debug("Failed to decode AFIDs from %s: %s", cper_path, e)
+                decode_failed = True
+            results.append(
+                {"cper_file": str(cper_path), "afids": afids, "decode_failed": decode_failed}
+            )
+
+        if self.logger.is_json_format():
+            self.logger.output = results
+            self.logger.print_output()
+        else:
+            print(f"{'file_name':<32} list of afids")
+            for entry in results:
+                if entry["decode_failed"]:
+                    afids_str = "decode failed"
+                elif entry["afids"]:
+                    afids_str = " ".join(map(str, entry["afids"]))
+                else:
+                    afids_str = "-"
+                fname = Path(entry["cper_file"]).name
+                print(f"{fname:<32} {afids_str}")
+
     def ras(
         self,
         args,
@@ -33,7 +154,6 @@ class RasCommands:
         gpu=None,
         cper=None,
         afid=None,
-        decode=None,
         severity=None,
         folder=None,
         file_limit=None,
@@ -58,8 +178,6 @@ class RasCommands:
             args.cper = cper
         if afid:
             args.afid = afid
-        if decode:
-            args.decode = decode
         if severity:
             args.severity = severity
         if folder:
@@ -70,8 +188,11 @@ class RasCommands:
             args.cper_file = cper_file
         if follow:
             args.follow = follow
-        if args.gpu == None:
+        if args.gpu is None:
             args.gpu = self.device_handles
+
+        # Validate all arguments before touching the driver or the filesystem.
+        self._validate_ras_args(args)
 
         if args.afid:
             if args.cper_file:
@@ -81,12 +202,12 @@ class RasCommands:
                     self.logger.output = afid_output
                     self.logger.print_output()
                 else:
-                    print(" ".join(map(str, afids)))
+                    print(" ".join(map(str, afids)) if afids else "-")
                 return
-            else:
-                command = " ".join(sys.argv[1:])
-                message = f"Command '{command}' requires '--cper-file'. Run '--help' for more info."
-                raise AmdSmiInvalidCommandException(command, self.logger.format, message)
+
+            # --afid --folder: read-only decode of a pre-existing folder.
+            self._decode_afid_folder(args)
+            return
 
         if not self.group_check_printed:
             self.helpers.check_required_groups()
@@ -126,20 +247,46 @@ class RasCommands:
                 f"GPU{gpu_id}" for gpu_id in primary_partition_gpu_ids
             )
 
-            print("WARNING: CPER files are only available on primary partitions")
+            self.helpers.cper_print(
+                "WARNING: CPER files are only available on primary partitions", self.logger
+            )
             if len(primary_partition_gpu_ids) > 1:
-                print(f"Try with primary partitions {primary_partitions_str}", end="")
+                self.helpers.cper_print(
+                    f"Try with primary partitions {primary_partitions_str}", self.logger
+                )
             else:
-                print(f"Try with primary partition {primary_partitions_str}", end="")
+                self.helpers.cper_print(
+                    f"Try with primary partition {primary_partitions_str}", self.logger
+                )
 
-            print()
+        # One-shot warning, header, and follow prompt (kept out of the per-GPU helper
+        # so the helper layer stays re-entrant and free of latching state).
+        if not self.logger.is_json_format():
+            if not args.folder:
+                self.helpers.cper_print(
+                    "WARNING: No CPER files will be dumped unless "
+                    "--folder=<folder_name> is specified and cper entries exist.",
+                    self.logger,
+                )
+            self.helpers._print_header(args.folder, self.logger)
+            if args.follow:
+                # Always print to stdout so the user sees the prompt, even with --file.
+                print("Press CTRL + C to stop.")
 
+        # Shared 1-indexed counter for generated CPER filenames across all GPUs
+        # and follow iterations within this invocation.
+        cper_counter = [0]
         is_json = self.logger.is_json_format()
         while True:
             all_json_rows = []
             for idx, device_handle in enumerate(args.gpu):
                 rows = self.helpers.ras_cper(
-                    args, device_handle, self.logger, idx, emit_json=not is_json
+                    args,
+                    device_handle,
+                    self.logger,
+                    idx,
+                    emit_inline=not is_json,
+                    cper_counter=cper_counter,
                 )
                 all_json_rows.extend(rows)
             if is_json and all_json_rows:

--- a/projects/amdsmi/docs/conceptual/ras.md
+++ b/projects/amdsmi/docs/conceptual/ras.md
@@ -87,6 +87,196 @@ amd-smi ras --help
 ::::
 :::::
 
+## CLI examples
+
+The following sections summarize the `amd-smi` flags that drive each RAS feature.
+Global modifiers (`--json`, `--csv`, `--file`, `--gpu`, etc.) are documented in
+[`amd-smi --help`](/how-to/amdsmi-cli-tool.md) and apply uniformly; the tabs
+below focus on the flags specific to ECC, CPER, and AFID.
+
+### ECC
+
+ECC counters are surfaced through `amd-smi metric` (one-shot snapshot) and
+`amd-smi monitor` (live tabular stream). There is no dedicated `amd-smi ecc`
+subcommand.
+
+:::::{tab-set}
+
+::::{tab-item} Total counts
+Print the per-GPU total correctable / uncorrectable / deferred ECC error
+counts (alias `--ecc`).
+
+```shell-session
+~$ amd-smi metric -e --gpu 0
+GPU: 0
+    ECC:
+        TOTAL_CORRECTABLE_COUNT: 0
+        TOTAL_UNCORRECTABLE_COUNT: 0
+        TOTAL_DEFERRED_COUNT: 0
+        CACHE_CORRECTABLE_COUNT: 0
+        CACHE_UNCORRECTABLE_COUNT: 0
+```
+::::
+
+::::{tab-item} Per block
+Break the counts down per IP block (UMC, SDMA, GFX, MMHUB, PCIE_BIF, HDP, …)
+with `-k` (alias `--ecc-blocks`).
+
+```shell-session
+~$ amd-smi metric -k --gpu 0
+GPU: 0
+    ECC_BLOCKS:
+        UMC:
+            CORRECTABLE_COUNT: 0
+            UNCORRECTABLE_COUNT: 0
+            DEFERRED_COUNT: 0
+        SDMA:
+            CORRECTABLE_COUNT: 0
+            UNCORRECTABLE_COUNT: 0
+            DEFERRED_COUNT: 0
+        GFX:
+            CORRECTABLE_COUNT: 0
+            UNCORRECTABLE_COUNT: 0
+            DEFERRED_COUNT: 0
+        ...
+```
+::::
+
+::::{tab-item} Live monitor
+Continuously monitor ECC single-bit (correctable), double-bit (uncorrectable),
+and PCIe replay error counts in a watch-style table. Press CTRL+C to stop.
+
+```shell-session
+~$ amd-smi monitor -e
+GPU  XCP  SINGLE_ECC  DOUBLE_ECC  PCIE_REPLAY
+  0    0           0           0            0
+  1    0           0           0            0
+  ...
+```
+::::
+
+:::::
+
+### CPER
+
+CPER retrieval is exposed through `amd-smi ras --cper`. Without `--folder` only
+a summary table is printed; with `--folder` each entry is also dumped as a
+matching `.cper` (raw binary) and `.json` (decoded metadata) pair.
+
+:::::{tab-set}
+
+::::{tab-item} List
+List current CPER entries from the kernel driver as a summary table. No files
+are written; a warning is printed reminding the user to pass `--folder` to
+dump them.
+
+```shell-session
+~$ sudo amd-smi ras --cper
+WARNING: No CPER files will be dumped unless --folder=<folder_name> is specified and cper entries exist.
+timestamp            gpu_id  severity
+2000/06/27 10:45:13  0       FATAL
+2000/06/27 10:45:13  1       FATAL
+```
+::::
+
+::::{tab-item} Dump
+Same listing as **List**, plus dump each entry to `<DIR>` as
+`<severity>-<n>.cper` (raw bytes) and `<severity>-<n>.json` (decoded
+metadata). The summary table gains `file_name` and `list of afids` columns.
+
+```shell-session
+~$ sudo amd-smi ras --cper --folder /tmp/cper_dump/
+timestamp            gpu_id  severity             file_name         list of afids
+2000/06/27 10:45:13  0       FATAL                fatal-1.cper      30
+2000/06/27 10:45:13  1       FATAL                fatal-2.cper      30
+```
+::::
+
+::::{tab-item} Filter
+Filter the listing by severity. Accepted values: `nonfatal-uncorrected`,
+`nonfatal-corrected`, `fatal`, `all`. Combine with any other CPER flag.
+
+```shell-session
+~$ sudo amd-smi ras --cper --severity fatal --folder /tmp/cper_dump/
+timestamp            gpu_id  severity             file_name         list of afids
+2000/06/27 10:45:13  0       FATAL                fatal-1.cper      30
+```
+::::
+
+::::{tab-item} Rotate
+After dumping, prune the oldest `.cper`/`.json` pairs in `<DIR>` so at most
+`N` `.cper` files remain.
+
+```shell-session
+~$ sudo amd-smi ras --cper --severity all --folder /tmp/cper_dump --file-limit 5
+timestamp            gpu_id  severity             file_name         list of afids
+2000/06/27 10:45:13  0       FATAL                fatal-1.cper      30
+2000/06/27 10:45:13  1       FATAL                fatal-2.cper      30
+2000/06/27 10:45:13  2       FATAL                fatal-3.cper      30
+2000/06/27 10:45:13  3       FATAL                fatal-4.cper      30
+2000/06/27 10:45:13  4       FATAL                fatal-5.cper      30
+```
+::::
+
+::::{tab-item} Follow
+Continuously poll for new CPER entries until interrupted with CTRL+C.
+`Press CTRL + C to stop.` is printed once at startup. Combine with `--folder`
+to also dump new entries as they arrive.
+
+```shell-session
+~$ sudo amd-smi ras --cper --follow --severity all --folder /tmp/cper_dump
+timestamp            gpu_id  severity             file_name         list of afids
+Press CTRL + C to stop.
+2000/06/27 10:45:13  0       FATAL                fatal-1.cper      30
+...
+```
+::::
+
+:::::
+
+### AFID
+
+AFID extraction is a pure offline operation: it parses one or more CPER record
+files with `amdsmi_get_afids_from_cper()` and prints the AFIDs found in each.
+No driver or GPU access is required, so the source CPER(s) may have been
+captured on another system. Each CPER record carries up to 12 AFIDs.
+
+`--cper-file` and `--folder` are mutually exclusive under `--afid`; exactly one
+must be supplied. Unlike the `--cper --folder` write path, the AFID `--folder`
+must already exist and contain at least one `.cper` file — it is not
+auto-created.
+
+:::::{tab-set}
+
+::::{tab-item} Single file
+Parse one CPER record and print the space-separated list of AFIDs encoded in
+it. A single `-` is printed when the record contains no AFID payload (e.g.
+corrected entries).
+
+```shell-session
+~$ amd-smi ras --afid --cper-file /tmp/cper_dump/fatal-1.cper
+30 31 32 33
+```
+::::
+
+::::{tab-item} Folder
+Parse every `*.cper` in a pre-existing directory and print a
+`file_name | list of afids` table, one row per record. A record with no AFID
+payload shows `-`, and a file that cannot be parsed shows `decode failed`.
+Symlinks in the folder are skipped (they are never followed).
+
+```shell-session
+~$ amd-smi ras --afid --folder /tmp/cper_dump/
+file_name                        list of afids
+fatal-1.cper                     30 31 32 33
+fatal-2.cper                     30 31 32 33
+nonfatal-1.cper                  -
+truncated.cper                   decode failed
+```
+::::
+
+:::::
+
 ## Further reading
 
 - [AMD Field ID](https://docs.amd.com/r/en-US/AMD_Field_ID_70122_v1.0/Introduction)

--- a/projects/amdsmi/docs/conceptual/ras.md
+++ b/projects/amdsmi/docs/conceptual/ras.md
@@ -88,6 +88,54 @@ amd-smi ras --help
 ::::
 :::::
 
+## CLI examples
+
+The following sections summarize the `amd-smi` flags that drive each RAS feature.
+Global modifiers (`--json`, `--csv`, `--file`, `--gpu`, etc.) are documented in
+[`amd-smi --help`](/how-to/amdsmi-cli-tool.md) and apply uniformly; the tables
+below focus on the flags specific to ECC, CPER, and AFID.
+
+### ECC
+
+ECC counters are surfaced through `amd-smi metric` (one-shot snapshot) and
+`amd-smi monitor` (live tabular stream). There is no dedicated `amd-smi ecc`
+subcommand.
+
+| Command | Result |
+|---|---|
+| `amd-smi metric -e` *(alias `--ecc`)* | Print the per-GPU total correctable / uncorrectable / deferred ECC error counts. |
+| `amd-smi metric -k` *(alias `--ecc-blocks`)* | Print the ECC error counts broken down per IP block (UMC, SDMA, GFX, MMHUB, etc.). |
+| `amd-smi metric -e -k` | Combine the totals and the per-block breakdown in a single snapshot. |
+| `amd-smi monitor -e` *(alias `--ecc`)* | Continuously monitor ECC single-bit (correctable), double-bit (uncorrectable), and PCIe replay error counts in a watch-style table. |
+
+### CPER
+
+CPER retrieval is exposed through `amd-smi ras --cper`. Without `--folder` only
+a summary table is printed; with `--folder` each entry is also dumped as a
+matching `.cper` (raw binary) and `.json` (decoded metadata) pair.
+
+| Command | Result |
+|---|---|
+| `amd-smi ras --cper` | List current CPER entries from the kernel driver as a summary table (timestamp, GPU ID, severity). No files written; warns that `--folder` is required to dump them. |
+| `amd-smi ras --cper --folder <DIR>` | Same listing, plus dump each entry to `<DIR>` as `<severity>-<n>.cper` and `<severity>-<n>.json`; the table gains `file_name` and `list of afids` columns. |
+| `amd-smi ras --cper --severity <SEV[,SEV…]>` | Filter by severity. Accepted values: `nonfatal-uncorrected`, `nonfatal-corrected`, `fatal`, `all`. Combine with any other CPER flag. |
+| `amd-smi ras --cper --folder <DIR> --file-limit <N>` | After dumping, prune the oldest `.cper`/`.json` pairs in `<DIR>` so at most `N` `.cper` files remain. |
+| `amd-smi ras --cper --follow` | Continuously poll for new CPER entries until interrupted with CTRL+C. Prints `Press CTRL + C to stop.` once at startup. Combine with `--folder` to also dump new entries as they arrive. |
+
+### AFID
+
+AFID extraction is a pure offline operation: it parses a CPER record file with
+`amdsmi_get_afids_from_cper()` and prints the AFIDs found in it. No driver or
+GPU access is required, so the source CPER may have been captured on another
+system.
+
+| Command | Result |
+|---|---|
+| `amd-smi ras --afid --cper-file <PATH>` | Parse the single CPER record at `<PATH>` and print the space-separated list of AFIDs encoded in it. Output is empty when the record contains no AFID payload. |
+
+`<PATH>` must be an existing, non-empty regular file (directories are
+rejected). `--afid` and `--cper` are mutually exclusive.
+
 ## Further reading
 
 - [AMD Field ID](https://docs.amd.com/r/en-US/AMD_Field_ID_70122_v1.0/Introduction)

--- a/projects/amdsmi/docs/conceptual/ras.md
+++ b/projects/amdsmi/docs/conceptual/ras.md
@@ -124,17 +124,20 @@ matching `.cper` (raw binary) and `.json` (decoded metadata) pair.
 
 ### AFID
 
-AFID extraction is a pure offline operation: it parses a CPER record file with
-`amdsmi_get_afids_from_cper()` and prints the AFIDs found in it. No driver or
-GPU access is required, so the source CPER may have been captured on another
-system.
+AFID extraction is a pure offline operation: it parses one or more CPER record
+files with `amdsmi_get_afids_from_cper()` and prints the AFIDs found in each.
+No driver or GPU access is required, so the source CPER(s) may have been
+captured on another system. Each CPER record carries up to 12 AFIDs.
 
 | Command | Result |
 |---|---|
 | `amd-smi ras --afid --cper-file <PATH>` | Parse the single CPER record at `<PATH>` and print the space-separated list of AFIDs encoded in it. Output is empty when the record contains no AFID payload. |
+| `amd-smi ras --afid --folder <DIR>` | Parse every `*.cper` in `<DIR>` (must already exist and contain at least one `.cper`) and print a `file_name | list of afids` table, one row per record. |
 
-`<PATH>` must be an existing, non-empty regular file (directories are
-rejected). `--afid` and `--cper` are mutually exclusive.
+`--cper-file` and `--folder` are mutually exclusive under `--afid`; exactly one
+must be supplied. `<PATH>` must be an existing, non-empty regular file.
+`<DIR>` must be an existing directory containing at least one `.cper` file —
+unlike the `--cper --folder` write path, it is not auto-created.
 
 ## Further reading
 

--- a/projects/amdsmi/docs/conceptual/ras.md
+++ b/projects/amdsmi/docs/conceptual/ras.md
@@ -143,23 +143,6 @@ GPU: 0
 ```
 ::::
 
-::::{tab-item} Combined
-Combine totals and the per-block breakdown in a single snapshot.
-
-```shell-session
-~$ amd-smi metric -e -k --gpu 0
-GPU: 0
-    ECC:
-        TOTAL_CORRECTABLE_COUNT: 0
-        TOTAL_UNCORRECTABLE_COUNT: 0
-        ...
-    ECC_BLOCKS:
-        UMC:
-            CORRECTABLE_COUNT: 0
-            ...
-```
-::::
-
 ::::{tab-item} Live monitor
 Continuously monitor ECC single-bit (correctable), double-bit (uncorrectable),
 and PCIe replay error counts in a watch-style table. Press CTRL+C to stop.

--- a/projects/amdsmi/docs/conceptual/ras.md
+++ b/projects/amdsmi/docs/conceptual/ras.md
@@ -92,7 +92,7 @@ amd-smi ras --help
 
 The following sections summarize the `amd-smi` flags that drive each RAS feature.
 Global modifiers (`--json`, `--csv`, `--file`, `--gpu`, etc.) are documented in
-[`amd-smi --help`](/how-to/amdsmi-cli-tool.md) and apply uniformly; the tables
+[`amd-smi --help`](/how-to/amdsmi-cli-tool.md) and apply uniformly; the tabs
 below focus on the flags specific to ECC, CPER, and AFID.
 
 ### ECC
@@ -101,12 +101,79 @@ ECC counters are surfaced through `amd-smi metric` (one-shot snapshot) and
 `amd-smi monitor` (live tabular stream). There is no dedicated `amd-smi ecc`
 subcommand.
 
-| Command | Result |
-|---|---|
-| `amd-smi metric -e` *(alias `--ecc`)* | Print the per-GPU total correctable / uncorrectable / deferred ECC error counts. |
-| `amd-smi metric -k` *(alias `--ecc-blocks`)* | Print the ECC error counts broken down per IP block (UMC, SDMA, GFX, MMHUB, etc.). |
-| `amd-smi metric -e -k` | Combine the totals and the per-block breakdown in a single snapshot. |
-| `amd-smi monitor -e` *(alias `--ecc`)* | Continuously monitor ECC single-bit (correctable), double-bit (uncorrectable), and PCIe replay error counts in a watch-style table. |
+:::::{tab-set}
+
+::::{tab-item} Total counts
+Print the per-GPU total correctable / uncorrectable / deferred ECC error
+counts (alias `--ecc`).
+
+```shell-session
+~$ amd-smi metric -e --gpu 0
+GPU: 0
+    ECC:
+        TOTAL_CORRECTABLE_COUNT: 0
+        TOTAL_UNCORRECTABLE_COUNT: 0
+        TOTAL_DEFERRED_COUNT: 0
+        CACHE_CORRECTABLE_COUNT: 0
+        CACHE_UNCORRECTABLE_COUNT: 0
+```
+::::
+
+::::{tab-item} Per block
+Break the counts down per IP block (UMC, SDMA, GFX, MMHUB, PCIE_BIF, HDP, …)
+with `-k` (alias `--ecc-blocks`).
+
+```shell-session
+~$ amd-smi metric -k --gpu 0
+GPU: 0
+    ECC_BLOCKS:
+        UMC:
+            CORRECTABLE_COUNT: 0
+            UNCORRECTABLE_COUNT: 0
+            DEFERRED_COUNT: 0
+        SDMA:
+            CORRECTABLE_COUNT: 0
+            UNCORRECTABLE_COUNT: 0
+            DEFERRED_COUNT: 0
+        GFX:
+            CORRECTABLE_COUNT: 0
+            UNCORRECTABLE_COUNT: 0
+            DEFERRED_COUNT: 0
+        ...
+```
+::::
+
+::::{tab-item} Combined
+Combine totals and the per-block breakdown in a single snapshot.
+
+```shell-session
+~$ amd-smi metric -e -k --gpu 0
+GPU: 0
+    ECC:
+        TOTAL_CORRECTABLE_COUNT: 0
+        TOTAL_UNCORRECTABLE_COUNT: 0
+        ...
+    ECC_BLOCKS:
+        UMC:
+            CORRECTABLE_COUNT: 0
+            ...
+```
+::::
+
+::::{tab-item} Live monitor
+Continuously monitor ECC single-bit (correctable), double-bit (uncorrectable),
+and PCIe replay error counts in a watch-style table. Press CTRL+C to stop.
+
+```shell-session
+~$ amd-smi monitor -e
+GPU  XCP  SINGLE_ECC  DOUBLE_ECC  PCIE_REPLAY
+  0    0           0           0            0
+  1    0           0           0            0
+  ...
+```
+::::
+
+:::::
 
 ### CPER
 
@@ -114,13 +181,76 @@ CPER retrieval is exposed through `amd-smi ras --cper`. Without `--folder` only
 a summary table is printed; with `--folder` each entry is also dumped as a
 matching `.cper` (raw binary) and `.json` (decoded metadata) pair.
 
-| Command | Result |
-|---|---|
-| `amd-smi ras --cper` | List current CPER entries from the kernel driver as a summary table (timestamp, GPU ID, severity). No files written; warns that `--folder` is required to dump them. |
-| `amd-smi ras --cper --folder <DIR>` | Same listing, plus dump each entry to `<DIR>` as `<severity>-<n>.cper` and `<severity>-<n>.json`; the table gains `file_name` and `list of afids` columns. |
-| `amd-smi ras --cper --severity <SEV[,SEV…]>` | Filter by severity. Accepted values: `nonfatal-uncorrected`, `nonfatal-corrected`, `fatal`, `all`. Combine with any other CPER flag. |
-| `amd-smi ras --cper --folder <DIR> --file-limit <N>` | After dumping, prune the oldest `.cper`/`.json` pairs in `<DIR>` so at most `N` `.cper` files remain. |
-| `amd-smi ras --cper --follow` | Continuously poll for new CPER entries until interrupted with CTRL+C. Prints `Press CTRL + C to stop.` once at startup. Combine with `--folder` to also dump new entries as they arrive. |
+:::::{tab-set}
+
+::::{tab-item} List
+List current CPER entries from the kernel driver as a summary table. No files
+are written; a warning is printed reminding the user to pass `--folder` to
+dump them.
+
+```shell-session
+~$ sudo amd-smi ras --cper
+WARNING: No CPER files will be dumped unless --folder=<folder_name> is specified and cper entries exist.
+timestamp            gpu_id  severity
+2000/06/27 10:45:13  0       FATAL
+2000/06/27 10:45:13  1       FATAL
+```
+::::
+
+::::{tab-item} Dump
+Same listing as **List**, plus dump each entry to `<DIR>` as
+`<severity>-<n>.cper` (raw bytes) and `<severity>-<n>.json` (decoded
+metadata). The summary table gains `file_name` and `list of afids` columns.
+
+```shell-session
+~$ sudo amd-smi ras --cper --folder /tmp/cper_dump/
+timestamp            gpu_id  severity             file_name         list of afids
+2000/06/27 10:45:13  0       FATAL                fatal-1.cper      30
+2000/06/27 10:45:13  1       FATAL                fatal-2.cper      30
+```
+::::
+
+::::{tab-item} Filter
+Filter the listing by severity. Accepted values: `nonfatal-uncorrected`,
+`nonfatal-corrected`, `fatal`, `all`. Combine with any other CPER flag.
+
+```shell-session
+~$ sudo amd-smi ras --cper --severity fatal --folder /tmp/cper_dump/
+timestamp            gpu_id  severity             file_name         list of afids
+2000/06/27 10:45:13  0       FATAL                fatal-1.cper      30
+```
+::::
+
+::::{tab-item} Rotate
+After dumping, prune the oldest `.cper`/`.json` pairs in `<DIR>` so at most
+`N` `.cper` files remain.
+
+```shell-session
+~$ sudo amd-smi ras --cper --severity all --folder /tmp/cper_dump --file-limit 5
+timestamp            gpu_id  severity             file_name         list of afids
+2000/06/27 10:45:13  0       FATAL                fatal-1.cper      30
+2000/06/27 10:45:13  1       FATAL                fatal-2.cper      30
+2000/06/27 10:45:13  2       FATAL                fatal-3.cper      30
+2000/06/27 10:45:13  3       FATAL                fatal-4.cper      30
+2000/06/27 10:45:13  4       FATAL                fatal-5.cper      30
+```
+::::
+
+::::{tab-item} Follow
+Continuously poll for new CPER entries until interrupted with CTRL+C.
+`Press CTRL + C to stop.` is printed once at startup. Combine with `--folder`
+to also dump new entries as they arrive.
+
+```shell-session
+~$ sudo amd-smi ras --cper --follow --severity all --folder /tmp/cper_dump
+Press CTRL + C to stop.
+timestamp            gpu_id  severity             file_name         list of afids
+2000/06/27 10:45:13  0       FATAL                fatal-1.cper      30
+...
+```
+::::
+
+:::::
 
 ### AFID
 
@@ -129,15 +259,38 @@ files with `amdsmi_get_afids_from_cper()` and prints the AFIDs found in each.
 No driver or GPU access is required, so the source CPER(s) may have been
 captured on another system. Each CPER record carries up to 12 AFIDs.
 
-| Command | Result |
-|---|---|
-| `amd-smi ras --afid --cper-file <PATH>` | Parse the single CPER record at `<PATH>` and print the space-separated list of AFIDs encoded in it. Output is empty when the record contains no AFID payload. |
-| `amd-smi ras --afid --folder <DIR>` | Parse every `*.cper` in `<DIR>` (must already exist and contain at least one `.cper`) and print a `file_name | list of afids` table, one row per record. |
-
 `--cper-file` and `--folder` are mutually exclusive under `--afid`; exactly one
-must be supplied. `<PATH>` must be an existing, non-empty regular file.
-`<DIR>` must be an existing directory containing at least one `.cper` file —
-unlike the `--cper --folder` write path, it is not auto-created.
+must be supplied. Unlike the `--cper --folder` write path, the AFID `--folder`
+must already exist and contain at least one `.cper` file — it is not
+auto-created.
+
+:::::{tab-set}
+
+::::{tab-item} Single file
+Parse one CPER record and print the space-separated list of AFIDs encoded in
+it. Output is empty when the record contains no AFID payload (e.g. corrected
+entries).
+
+```shell-session
+~$ amd-smi ras --afid --cper-file /tmp/cper_dump/fatal-1.cper
+30 31 32 33
+```
+::::
+
+::::{tab-item} Folder
+Parse every `*.cper` in a pre-existing directory and print a
+`file_name | list of afids` table, one row per record.
+
+```shell-session
+~$ amd-smi ras --afid --folder /tmp/cper_dump/
+file_name                        list of afids
+fatal-1.cper                     30 31 32 33
+fatal-2.cper                     30 31 32 33
+fatal-3.cper                     30 31 32 33
+```
+::::
+
+:::::
 
 ## Further reading
 

--- a/projects/amdsmi/docs/how-to/amdsmi-cli-tool.md
+++ b/projects/amdsmi/docs/how-to/amdsmi-cli-tool.md
@@ -886,10 +886,10 @@ Displays RAS information of specified devices.
 
 ```shell-session
 ~$ amd-smi ras --help
-usage: amd-smi ras [-h] --cper [--severity SEVERITY [SEVERITY ...]] [--folder FOLDER]
-                   [--file-limit FILE_LIMIT] [--follow]
-                   [-g GPU [GPU ...] | -U CPU [CPU ...] | -O CORE [CORE ...]]
-                   [--json | --csv] [--file FILE] [--loglevel LEVEL]
+usage: amd-smi ras [-h] (--cper | --afid) [--severity SEVERITY [SEVERITY ...]]
+                   [--folder FOLDER] [--file-limit FILE_LIMIT] [--follow]
+                   [--cper-file CPER_FILE] [-g GPU [GPU ...]] [--json | --csv]
+                   [--file FILE] [--overwrite] [--append] [--loglevel LEVEL]
 
 Retrieve and decode RAS (CPER) entries from the kernel driver.
 Supports filtering by severity, exporting to different formats, and continuous monitoring.
@@ -897,14 +897,20 @@ This command accepts options only; no positional arguments are required.
 
 RAS arguments:
   -h, --help                          show this help message and exit
-  --cper                              Trigger CPER data retrieval
-  --afid                              Generate an AFID (AMD Field ID) given a CPER record file.
+  --cper                              Trigger current CPER data retrieval
+  --afid                              Generate an AFID (AMD Field ID) given a CPER record file or folder
+
+CPER Arguments:
   --severity SEVERITY [SEVERITY ...]  Set the SEVERITY filters from the following:
                                           nonfatal-uncorrected, fatal, nonfatal-corrected, all
-  --folder FOLDER                     Folder to dump CPER report files
-  --file-limit FILE_LIMIT             Maximum number of entries per output file
-  --cper-file CPER_FILE               Full path of the CPER record file to generate the AFID
-  --follow                            Continuously monitor for new entries
+  --folder FOLDER                     With --cper: folder to dump current CPER report files (created if missing).
+                                          With --afid: existing folder of CPER records to decode.
+  --file-limit FILE_LIMIT             Maximum number of current CPER files in target folder
+                                          Older files beyond limit will be deleted
+  --follow                            Continuously monitor for new CPER entries
+
+AFID Arguments:
+  --cper-file CPER_FILE               Full path of a retrieved CPER record file to generate the AFID
 
 Device Arguments:
   -g, --gpu GPU [GPU ...]     Select a GPU ID, BDF, or UUID from the possible choices:

--- a/projects/amdsmi/docs/how-to/amdsmi-cli-tool.md
+++ b/projects/amdsmi/docs/how-to/amdsmi-cli-tool.md
@@ -884,12 +884,13 @@ This command accepts options only; no positional arguments are required.
 RAS arguments:
   -h, --help                          show this help message and exit
   --cper                              Trigger current CPER data retrieval
-  --afid                              Generate an AFID (AMD Field ID) given a CPER record file
+  --afid                              Generate an AFID (AMD Field ID) given a CPER record file or folder
 
 CPER Arguments:
   --severity SEVERITY [SEVERITY ...]  Set the SEVERITY filters from the following:
                                           nonfatal-uncorrected, fatal, nonfatal-corrected, all
-  --folder FOLDER                     Folder to dump current CPER report files
+  --folder FOLDER                     With --cper: folder to dump current CPER report files (created if missing).
+                                          With --afid: existing folder of CPER records to decode.
   --file-limit FILE_LIMIT             Maximum number of current CPER files in target folder
                                           Older files beyond limit will be deleted
   --follow                            Continuously monitor for new CPER entries

--- a/projects/amdsmi/docs/how-to/amdsmi-cli-tool.md
+++ b/projects/amdsmi/docs/how-to/amdsmi-cli-tool.md
@@ -872,10 +872,10 @@ Displays RAS information of specified devices.
 
 ```shell-session
 ~$ amd-smi ras --help
-usage: amd-smi ras [-h] --cper [--severity SEVERITY [SEVERITY ...]] [--folder FOLDER]
-                   [--file-limit FILE_LIMIT] [--follow]
-                   [-g GPU [GPU ...] | -U CPU [CPU ...] | -O CORE [CORE ...]]
-                   [--json | --csv] [--file FILE] [--loglevel LEVEL]
+usage: amd-smi ras [-h] (--cper | --afid) [--severity SEVERITY [SEVERITY ...]]
+                   [--folder FOLDER] [--file-limit FILE_LIMIT] [--follow]
+                   [--cper-file CPER_FILE] [-g GPU [GPU ...]] [--json | --csv]
+                   [--file FILE] [--overwrite] [--append] [--loglevel LEVEL]
 
 Retrieve and decode RAS (CPER) entries from the kernel driver.
 Supports filtering by severity, exporting to different formats, and continuous monitoring.
@@ -883,14 +883,19 @@ This command accepts options only; no positional arguments are required.
 
 RAS arguments:
   -h, --help                          show this help message and exit
-  --cper                              Trigger CPER data retrieval
-  --afid                              Generate an AFID (AMD Field ID) given a CPER record file.
+  --cper                              Trigger current CPER data retrieval
+  --afid                              Generate an AFID (AMD Field ID) given a CPER record file
+
+CPER Arguments:
   --severity SEVERITY [SEVERITY ...]  Set the SEVERITY filters from the following:
                                           nonfatal-uncorrected, fatal, nonfatal-corrected, all
-  --folder FOLDER                     Folder to dump CPER report files
-  --file-limit FILE_LIMIT             Maximum number of entries per output file
-  --cper-file CPER_FILE               Full path of the CPER record file to generate the AFID
-  --follow                            Continuously monitor for new entries
+  --folder FOLDER                     Folder to dump current CPER report files
+  --file-limit FILE_LIMIT             Maximum number of current CPER files in target folder
+                                          Older files beyond limit will be deleted
+  --follow                            Continuously monitor for new CPER entries
+
+AFID Arguments:
+  --cper-file CPER_FILE               Full path of a retrieved CPER record file to generate the AFID
 
 Device Arguments:
   -g, --gpu GPU [GPU ...]     Select a GPU ID, BDF, or UUID from the possible choices:

--- a/projects/amdsmi/tests/python_unittest/cli_unit_test.py
+++ b/projects/amdsmi/tests/python_unittest/cli_unit_test.py
@@ -1403,6 +1403,24 @@ class TestAmdSmiCli(unittest.TestCase):
                 (f"amd-smi ras --afid --folder {symlink_dir}", self.FAIL),
             ]
             self.RunCmds(cmds)
+
+            # The --json output must be a flat list of per-file objects, not a
+            # doubly-wrapped [[...]]. Guards against the logger wrapping a list
+            # assigned to self.output a second time.
+            cmd = f"amd-smi ras --afid --folder {tmp_dir} --json"
+            (rc, data, std_err) = self.util.RunCmdSync(cmd)
+            self.assertEqual(rc, self.PASS, f"Command '{cmd}' failed with rc={rc}")
+            json_data = json.loads(data)
+            self.assertIsInstance(json_data, list, f"'{cmd}' did not emit a JSON list")
+            for entry in json_data:
+                self.assertIsInstance(
+                    entry,
+                    dict,
+                    f"'{cmd}' emitted a non-object element (double-wrapped?): {entry!r}",
+                )
+                self.assertIn("cper_file", entry)
+                self.assertIn("afids", entry)
+                self.assertIn("decode_failed", entry)
         finally:
             shutil.rmtree(tmp_dir, ignore_errors=True)
         return

--- a/projects/amdsmi/tests/python_unittest/cli_unit_test.py
+++ b/projects/amdsmi/tests/python_unittest/cli_unit_test.py
@@ -22,8 +22,10 @@
 import ctypes
 import json
 import os
+import shutil
 import stat
 import sys
+import tempfile
 
 import unittest
 
@@ -885,6 +887,10 @@ class TestAmdSmiCli(unittest.TestCase):
             ("amd-smi ras --cper --severity INVALID", self.FAIL),
             ("amd-smi ras --afid", self.FAIL),
             ("amd-smi ras --afid INVALID", self.FAIL),
+            # --afid --folder requires an existing directory of CPER records
+            ("amd-smi ras --afid --folder /nonexistent_amdsmi_pr4812_dir", self.FAIL),
+            # --decode is not a valid flag
+            ("amd-smi ras --decode", self.FAIL),
             # Test invalid watch order
             ("amd-smi monitor --interval 2 --watch 1", self.FAIL),
             ("amd-smi monitor --watch_time 2 --watch 1", self.FAIL),
@@ -1349,6 +1355,56 @@ class TestAmdSmiCli(unittest.TestCase):
             "ras", "RAS arguments:", "CPER Arguments", "Device Arguments:", "Command Modifiers:"
         )
         self.RunCmds(cmds)
+        return
+
+    def test_ras_afid_folder(self):
+        """Exercise the pure-Python validation/decode branches of
+        ``amd-smi ras --afid --folder`` against on-disk fixtures (no GPU needed).
+        """
+        self.common.print_func_name("")
+        msg = f"{self.tab}### amd-smi ras --afid --folder"
+        self.common.print(msg)
+
+        if self.PrintCmdsOnly:
+            return
+
+        tmp_dir = tempfile.mkdtemp(prefix="amdsmi_ras_afid_")
+        try:
+            # A real but undecodable .cper (non-empty garbage bytes): decodes to
+            # "decode failed" in the table, but the command still exits 0.
+            garbage = os.path.join(tmp_dir, "garbage.cper")
+            with open(garbage, "wb") as fout:
+                fout.write(b"\x00" * 64)
+
+            # An existing folder with no .cper files.
+            empty_dir = os.path.join(tmp_dir, "empty")
+            os.mkdir(empty_dir)
+
+            # A symlink to a folder that does contain a .cper, so only the
+            # symlink rejection (not a missing-file error) can make this FAIL.
+            target_dir = os.path.join(tmp_dir, "target")
+            os.mkdir(target_dir)
+            with open(os.path.join(target_dir, "g.cper"), "wb") as fout:
+                fout.write(b"\x00" * 64)
+            symlink_dir = os.path.join(tmp_dir, "link")
+            os.symlink(target_dir, symlink_dir)
+
+            cmds = [
+                # Folder with a (garbage) .cper: undecodable rows are reported but
+                # the command exits 0.
+                (f"amd-smi ras --afid --folder {tmp_dir}", self.PASS),
+                # --cper-file and --folder are mutually exclusive under --afid.
+                (f"amd-smi ras --afid --cper-file {garbage} --folder {tmp_dir}", self.FAIL),
+                # Nonexistent folder.
+                (f"amd-smi ras --afid --folder {os.path.join(tmp_dir, 'nope')}", self.FAIL),
+                # Existing folder with no .cper files.
+                (f"amd-smi ras --afid --folder {empty_dir}", self.FAIL),
+                # Symlinked folder is refused even though it contains a .cper.
+                (f"amd-smi ras --afid --folder {symlink_dir}", self.FAIL),
+            ]
+            self.RunCmds(cmds)
+        finally:
+            shutil.rmtree(tmp_dir, ignore_errors=True)
         return
 
     def test_node(self):

--- a/projects/amdsmi/tests/python_unittest/cli_unit_test.py
+++ b/projects/amdsmi/tests/python_unittest/cli_unit_test.py
@@ -877,6 +877,9 @@ class TestAmdSmiCli(unittest.TestCase):
             ("amd-smi ras --cper --severity INVALID", self.FAIL),
             ("amd-smi ras --afid", self.FAIL),
             ("amd-smi ras --afid INVALID", self.FAIL),
+            # --decode is not a valid flag
+            ("amd-smi ras --decode", self.FAIL),
+            ("amd-smi ras --decode --cper-file /tmp/nonexistent.cper", self.FAIL),
             # Test invalid watch order
             ("amd-smi monitor --interval 2 --watch 1", self.FAIL),
             ("amd-smi monitor --watch_time 2 --watch 1", self.FAIL),


### PR DESCRIPTION
### Added
- `amd-smi ras --afid --folder <DIR>`: bulk-decode every `*.cper` in a directory.
  Prints a `file_name | list of afids` table, or a flat JSON array under `--json`.
  - Records with no AFIDs show `-`; unparseable files show `decode failed`.

### Changed
- All `ras` arguments are now validated up front (before any driver call or file I/O):
  - `--cper-file` and `--folder` are mutually exclusive under `--afid` (exactly one required).
  - `--afid --folder` must already exist; `--cper --folder` is created if missing.
  - Symlinked folders are rejected.
- Refactored the per-GPU CPER output path in `amdsmi_helpers.py`:
  - Split `dump_cper_entries` (file I/O + rotation extracted into `_write_cper_files`).
  - Dropped a redundant write-then-re-read disk round-trip.
  - Narrowed `cper_dump_afids` to `bytes`/`Path` inputs.
  - Renamed the `emit`/`emit_json` flag to `emit_inline`.

### Fixed
- AFID extraction: convert signed bytes to unsigned (`x & 0xFF`) to avoid
  "bytes must be in range(0, 256)" / "Error fetching AFIDs" in `--cper --folder`.
- `--afid --folder --json` no longer emits a doubly-wrapped `[[...]]`; it now
  emits a flat list of per-file objects.

### Security
- Each `.cper` is opened with `O_NOFOLLOW`, so a planted symlink (e.g.
  `evil.cper -> /etc/shadow`) is skipped instead of read. Closes the
  check-then-read (TOCTOU) window.

### Removed
- Dropped the dead `--decode` flag and the unused `_check_folder_path` argparse action.
- Removed dead `binary_to_hexdump_string` helper.

### Tests & Docs
- Added fixture-based `test_ras_afid_folder` (no GPU needed) covering mutual-exclusion,
  missing/empty/symlinked folders, decode paths, and the `--json` flat-list shape.
- Documented `--afid`/`--folder` usage and rendering rules in the RAS docs.