### PR TITLE
[rocprofiler-systems] FIX call stack entries in rocpd database

### DIFF
--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library/components/backtrace_metrics.cpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library/components/backtrace_metrics.cpp
@@ -260,9 +260,9 @@ cache_backtrace_metrics_events(const uint32_t device_id, uint64_t timestamp_ns,
     size_t      stack_id        = 0;
     size_t      parent_stack_id = 0;
     size_t      correlation_id  = 0;
-    const auto* event_metadata  = "";
-    const auto* call_stack      = "";
-    const auto* line_info       = "";
+    const auto* event_metadata  = "{}";
+    const auto* call_stack      = "{}";
+    const auto* line_info       = "{}";
 
     std::optional<int64_t> _system_tid{ std::nullopt };
     const auto&            _thread_info = thread_info::get(_tid, SequentTID);

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library/components/category_region.hpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library/components/category_region.hpp
@@ -59,7 +59,7 @@ cache_region(uint64_t thread_id, const std::string& name, uint64_t start_ts,
              uint64_t end_ts, const std::string& category)
 {
     constexpr size_t      NO_CORRELATION_ID = 0;
-    constexpr const char* CALLSTACK         = "";
+    constexpr const char* CALLSTACK         = "{}";
     constexpr const char* ARGUMENTS         = "";
     rocprofsys::trace_cache::get_buffer_storage().store(
         rocprofsys::trace_cache::region_sample{

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library/rocprofiler-sdk.cpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library/rocprofiler-sdk.cpp
@@ -429,7 +429,7 @@ consume_args(Tp&&...)
 auto
 get_backtrace(std::optional<std::vector<tim::unwind::processed_entry>>& _bt_data)
 {
-    auto backtrace = nlohmann::json();
+    auto backtrace = nlohmann::json::object();
 
     if(_bt_data && !_bt_data->empty())
     {


### PR DESCRIPTION
## Motivation

It has been noticed that in `rocpd_events` table the handling of `call stack` entries for events differs depending on where the event was captured. This PR aligns this entries so that they all represent an empty JSON object which is represented in table entry as `{}`

## Technical Details

## JIRA ID

N/A

## Test Plan

Test with existing tests since this fix doesn't add/change any business logic

## Test Result

Tests are passing

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
