### PR TITLE
[rocshmem] fix the bitcode arch settings

### DIFF
--- a/projects/rocshmem/CMakeLists.txt
+++ b/projects/rocshmem/CMakeLists.txt
@@ -110,8 +110,7 @@ endif()
 include(cmake/rocm_local_targets.cmake)
 
 set(DEFAULT_GPUS
-    gfx90a:xnack-;
-    gfx90a:xnack+;
+    gfx90a;
     gfx1100;
     gfx1201;
     gfx942)

--- a/projects/rocshmem/cmake/DeviceBitcode.cmake
+++ b/projects/rocshmem/cmake/DeviceBitcode.cmake
@@ -28,7 +28,12 @@ endfunction()
 
 # Resolve the default arch list: GPU_TARGETS if set, otherwise auto-detect local GPUs.
 if(GPU_TARGETS)
-  strip_arch_features("${GPU_TARGETS}" _BITCODE_DEFAULT_ARCHS)
+  # Convert comma-separated string to CMake list (semicolon-separated)
+  # This handles both -DGPU_TARGETS=gfx942,gfx950 and -DGPU_TARGETS="gfx942;gfx950"
+  string(REPLACE "," ";" _GPU_TARGETS_LIST "${GPU_TARGETS}")
+  # Ensure it's treated as a list even if already semicolon-separated
+  set(_GPU_TARGETS_LIST ${_GPU_TARGETS_LIST})
+  strip_arch_features("${_GPU_TARGETS_LIST}" _BITCODE_DEFAULT_ARCHS)
 elseif(COMMAND rocm_local_targets)
   rocm_local_targets(_LOCAL_GPUS)
   if(_LOCAL_GPUS)


### PR DESCRIPTION
to allow simultanious compilation for multiple architectures.

With this PR both

  -DGPU_TARGETS=gfx942,gfx950

or
  -DGPU_TARGETS="gfx942;gfx950"

will work

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
