### PR TITLE
[rocprofiler-systems] Fix missing output_file_registry argument

### DIFF
--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library/rocprofiler-sdk.cpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library/rocprofiler-sdk.cpp
@@ -11,6 +11,7 @@
 #include "core/containers/stable_vector.hpp"
 #include "core/demangler.hpp"
 #include "core/gpu.hpp"
+#include "core/output_file_registry.hpp"
 #include "core/perfetto.hpp"
 #include "core/perfetto_fwd.hpp"
 #include "core/state.hpp"
@@ -2766,8 +2767,10 @@ tool_attach_fini(void* /* tool_data */)
     // Write Perfetto trace output
     if(get_use_perfetto())
     {
-        bool _perfetto_output_error = false;
-        ::rocprofsys::perfetto::post_process(nullptr, _perfetto_output_error);
+        bool                             _perfetto_output_error = false;
+        rocprofsys::output_file_registry _output_registry{};
+        ::rocprofsys::perfetto::post_process(nullptr, _perfetto_output_error,
+                                             _output_registry);
         if(_perfetto_output_error)
             LOG_ERROR("Perfetto output error occurred during attach finalization");
     }


### PR DESCRIPTION
…ol_attach_fini

Commit 60dfddec28 added output_file_registry as a third parameter to perfetto::post_process(), but the call site in tool_attach_fini was introduced by the re-attach feature (#3412) without this parameter, causing a build failure.

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
