### PR TITLE
[rocprofiler-sdk] Add rocprofiler-sdk tests for runtimes

### DIFF
--- a/.github/scripts/therock_matrix.py
+++ b/.github/scripts/therock_matrix.py
@@ -69,7 +69,7 @@ project_map = {
     },
     "runtimes": {
         "cmake_options": ["-DTHEROCK_ENABLE_ALL=ON"],
-        "projects_to_test": "hip-tests, rocrtst",
+        "projects_to_test": "hip-tests, rocrtst, rocprofiler-sdk",
     },
     "all": {
         "cmake_options": ["-DTHEROCK_ENABLE_ALL=ON"],


### PR DESCRIPTION
## Motivation

- This PR will enable rocprofiler-sdk tests for HIP/HSA changes on The RockCI.
- This is helpful in gating PRs where they do code changes that impacts counter collection, ATT, etc.
## Technical Details

- Add `rocprofiler-sdk` to the `runtimes` `projects_to_test` list in the CI matrix configuration.

## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
