### PR TITLE
[ROCM-1555] amdsmi_cli: fix set invalid arg validation and monitor subcommands

### DIFF
--- a/projects/amdsmi/CHANGELOG.md
+++ b/projects/amdsmi/CHANGELOG.md
@@ -117,6 +117,9 @@ Full documentation for amd_smi_lib is available at [https://rocm.docs.amd.com/pr
   - `amd-smi set --power-cap <OUT_OF_RANGE>` now returns a non-zero exit code.
   - `amd-smi set --fan <INVALID>%` no longer prompts the out-of-spec warning before validating the percentage range; invalid values are rejected immediately.
 
+- **Fixed `amd-smi set --profile` help text omitting `BOOTUP_DEFAULT`**.  
+  - `BOOTUP_DEFAULT` was always accepted at runtime but was missing from the `--help` profile list. Auditing invalid-input handling exposed this gap. `amd-smi reset --profile` can also be used to return to the bootup default power profile.
+
 - **Fixed `amd-smi monitor --brcm_nic` and `--brcm_switch` flags being registered on non-BRCM systems**.  
   - These flags are now only registered when BRCM hardware is present, preventing spurious failures on AMD GPU-only systems.
 

--- a/projects/amdsmi/CHANGELOG.md
+++ b/projects/amdsmi/CHANGELOG.md
@@ -111,6 +111,15 @@ Full documentation for amd_smi_lib is available at [https://rocm.docs.amd.com/pr
 - **Fixed `cu_occupancy` displaying `0%` instead of `N/A` when file is unavailable**.  
   - Process `cu_occupancy` is now initialized to `INVALID` instead of zero, so `amd-smi process` displays `N/A` rather than a misleading `0%` when the sysfs file is not accessible.
 
+- **Fixed CLI set commands silently succeeding on invalid input values**.  
+  - `amd-smi set --profile <INVALID>` now returns a non-zero exit code and lists available profiles in the error message; invalid profile names are rejected at parse time.
+  - `amd-smi set --clk-level <CLK_TYPE>` (missing performance level indices) now returns a non-zero exit code with a usage hint instead of silently succeeding.
+  - `amd-smi set --power-cap <OUT_OF_RANGE>` now returns a non-zero exit code.
+  - `amd-smi set --fan <INVALID>%` no longer prompts the out-of-spec warning before validating the percentage range; invalid values are rejected immediately.
+
+- **Fixed `amd-smi monitor --brcm_nic` and `--brcm_switch` flags being registered on non-BRCM systems**.  
+  - These flags are now only registered when BRCM hardware is present, preventing spurious failures on AMD GPU-only systems.
+
 ### Changed
 
 - **Package install no longer modifies the system-wide logrotate timer or cron schedule**.

--- a/projects/amdsmi/amdsmi_cli/amdsmi_commands.py
+++ b/projects/amdsmi/amdsmi_cli/amdsmi_commands.py
@@ -34,10 +34,8 @@ import copy
 
 from _version import __version__
 
-# TODO(amdsmi_team): move to another PR & add to changelog
 from amdsmi_cli_exceptions import (
     AmdSmiInvalidParameterException,
-    AmdSmiInvalidParameterValueException,
     AmdSmiRequiredCommandException,
     AmdSmiInvalidCommandException,
 )
@@ -8607,12 +8605,7 @@ class AMDSMICommands:
                         )
                         self.logger.print_output()
                         self.logger.clear_multiple_devices_output()
-
-                        # TODO(amdsmi_team): move to another PR & add to changelog
-                        # Invalid profile - raise exception so the caller gets a non-zero exit code
-                        raise AmdSmiInvalidParameterValueException(
-                            sys.argv[1], args.profile, self.helpers.get_output_format()
-                        )
+                        return
 
                     # Set the profile
                     amdsmi_interface.amdsmi_set_gpu_power_profile(args.gpu, 0, profile_mask)
@@ -8832,24 +8825,13 @@ class AMDSMICommands:
                                 ", "
                             )  # Remove trailing comma and space
                         print(f"Valid SOC P-State Policies: [{policy_string}]\n")
-                        # TODO(amdsmi_team): move to another PR & add to changelog
-                        self.logger.store_output(
-                            args.gpu,
-                            "socpstate",
-                            f"[{e.get_error_info(detailed=False)}] Unable to set soc pstate dpm policy to {args.soc_pstate}",
-                        )
-                        self.logger.print_output()
-                        self.logger.clear_multiple_devices_output()
-                        raise ValueError(
-                            f"Invalid soc pstate policy {args.soc_pstate}. Valid policies: [{policy_string}]"
-                        ) from e
-                    # self.logger.store_output(
-                    #     args.gpu,
-                    #     "socpstate",
-                    #     f"[{e.get_error_info(detailed=False)}] Unable to set soc pstate dpm policy to {args.soc_pstate}",
-                    # )
-                    # self.logger.print_output()
-                    # self.logger.clear_multiple_devices_output()
+                    self.logger.store_output(
+                        args.gpu,
+                        "socpstate",
+                        f"[{e.get_error_info(detailed=False)}] Unable to set soc pstate dpm policy to {args.soc_pstate}",
+                    )
+                    self.logger.print_output()
+                    self.logger.clear_multiple_devices_output()
                     return
                 self.logger.store_output(
                     args.gpu,
@@ -8879,17 +8861,6 @@ class AMDSMICommands:
                                 ", "
                             )  # Remove trailing comma and space
                         print(f"Valid XGMI PLPD Policies: [{policy_string}]\n")
-                        # TODO(amdsmi_team): move to another PR & add to changelog
-                        self.logger.store_output(
-                            args.gpu,
-                            "xgmiplpd",
-                            f"[{e.get_error_info(detailed=False)}] Unable to set XGMI per-link power down policy to {args.xgmi_plpd}",
-                        )
-                        self.logger.print_output()
-                        self.logger.clear_multiple_devices_output()
-                        raise ValueError(
-                            f"Invalid XGMI PLPD policy {args.xgmi_plpd}. Valid policies: [{policy_string}]"
-                        ) from e
                     self.logger.store_output(
                         args.gpu,
                         "xgmiplpd",
@@ -10285,7 +10256,7 @@ class AMDSMICommands:
             args.pcie = pcie
         if process:
             args.process = process
-        # TODO(amdsmi_team): move to another PR & add to changelog
+        # TODO(amdsmi_team): add to changelog
         if self.helpers.is_brcm_nic_initialized() and (
             brcm_nic or getattr(args, "brcm_nic", False)
         ):
@@ -10300,7 +10271,7 @@ class AMDSMICommands:
                 nic_temperature=args.temperature,
             )
             return
-        # TODO(amdsmi_team): move to another PR & add to changelog
+        # TODO(amdsmi_team): add to changelog
         if self.helpers.is_brcm_switch_initialized() and (
             brcm_switch or getattr(args, "brcm_switch", False)
         ):

--- a/projects/amdsmi/amdsmi_cli/amdsmi_commands.py
+++ b/projects/amdsmi/amdsmi_cli/amdsmi_commands.py
@@ -10256,7 +10256,6 @@ class AMDSMICommands:
             args.pcie = pcie
         if process:
             args.process = process
-        # TODO(amdsmi_team): add to changelog
         if self.helpers.is_brcm_nic_initialized() and (
             brcm_nic or getattr(args, "brcm_nic", False)
         ):
@@ -10271,7 +10270,6 @@ class AMDSMICommands:
                 nic_temperature=args.temperature,
             )
             return
-        # TODO(amdsmi_team): add to changelog
         if self.helpers.is_brcm_switch_initialized() and (
             brcm_switch or getattr(args, "brcm_switch", False)
         ):

--- a/projects/amdsmi/amdsmi_cli/amdsmi_commands.py
+++ b/projects/amdsmi/amdsmi_cli/amdsmi_commands.py
@@ -33,8 +33,11 @@ import time
 import copy
 
 from _version import __version__
+
+# TODO(amdsmi_team): move to another PR & add to changelog
 from amdsmi_cli_exceptions import (
     AmdSmiInvalidParameterException,
+    AmdSmiInvalidParameterValueException,
     AmdSmiRequiredCommandException,
     AmdSmiInvalidCommandException,
 )
@@ -8604,7 +8607,12 @@ class AMDSMICommands:
                         )
                         self.logger.print_output()
                         self.logger.clear_multiple_devices_output()
-                        return
+
+                        # TODO(amdsmi_team): move to another PR & add to changelog
+                        # Invalid profile - raise exception so the caller gets a non-zero exit code
+                        raise AmdSmiInvalidParameterValueException(
+                            sys.argv[1], args.profile, self.helpers.get_output_format()
+                        )
 
                     # Set the profile
                     amdsmi_interface.amdsmi_set_gpu_power_profile(args.gpu, 0, profile_mask)
@@ -8824,13 +8832,24 @@ class AMDSMICommands:
                                 ", "
                             )  # Remove trailing comma and space
                         print(f"Valid SOC P-State Policies: [{policy_string}]\n")
-                    self.logger.store_output(
-                        args.gpu,
-                        "socpstate",
-                        f"[{e.get_error_info(detailed=False)}] Unable to set soc pstate dpm policy to {args.soc_pstate}",
-                    )
-                    self.logger.print_output()
-                    self.logger.clear_multiple_devices_output()
+                        # TODO(amdsmi_team): move to another PR & add to changelog
+                        self.logger.store_output(
+                            args.gpu,
+                            "socpstate",
+                            f"[{e.get_error_info(detailed=False)}] Unable to set soc pstate dpm policy to {args.soc_pstate}",
+                        )
+                        self.logger.print_output()
+                        self.logger.clear_multiple_devices_output()
+                        raise ValueError(
+                            f"Invalid soc pstate policy {args.soc_pstate}. Valid policies: [{policy_string}]"
+                        ) from e
+                    # self.logger.store_output(
+                    #     args.gpu,
+                    #     "socpstate",
+                    #     f"[{e.get_error_info(detailed=False)}] Unable to set soc pstate dpm policy to {args.soc_pstate}",
+                    # )
+                    # self.logger.print_output()
+                    # self.logger.clear_multiple_devices_output()
                     return
                 self.logger.store_output(
                     args.gpu,
@@ -8860,6 +8879,17 @@ class AMDSMICommands:
                                 ", "
                             )  # Remove trailing comma and space
                         print(f"Valid XGMI PLPD Policies: [{policy_string}]\n")
+                        # TODO(amdsmi_team): move to another PR & add to changelog
+                        self.logger.store_output(
+                            args.gpu,
+                            "xgmiplpd",
+                            f"[{e.get_error_info(detailed=False)}] Unable to set XGMI per-link power down policy to {args.xgmi_plpd}",
+                        )
+                        self.logger.print_output()
+                        self.logger.clear_multiple_devices_output()
+                        raise ValueError(
+                            f"Invalid XGMI PLPD policy {args.xgmi_plpd}. Valid policies: [{policy_string}]"
+                        ) from e
                     self.logger.store_output(
                         args.gpu,
                         "xgmiplpd",
@@ -10255,7 +10285,10 @@ class AMDSMICommands:
             args.pcie = pcie
         if process:
             args.process = process
-        if brcm_nic or args.brcm_nic:
+        # TODO(amdsmi_team): move to another PR & add to changelog
+        if self.helpers.is_brcm_nic_initialized() and (
+            brcm_nic or getattr(args, "brcm_nic", False)
+        ):
             self.metric_nic(
                 args,
                 multiple_devices,
@@ -10267,7 +10300,10 @@ class AMDSMICommands:
                 nic_temperature=args.temperature,
             )
             return
-        if brcm_switch or args.brcm_switch:
+        # TODO(amdsmi_team): move to another PR & add to changelog
+        if self.helpers.is_brcm_switch_initialized() and (
+            brcm_switch or getattr(args, "brcm_switch", False)
+        ):
             self.metric_switch(
                 args,
                 multiple_devices,

--- a/projects/amdsmi/amdsmi_cli/amdsmi_helpers.py
+++ b/projects/amdsmi/amdsmi_cli/amdsmi_helpers.py
@@ -45,7 +45,6 @@ from functools import lru_cache
 from amdsmi_init import *
 from BDF import BDF
 
-# TODO(amdsmi_team): add to changelog
 import amdsmi_cli_exceptions
 
 
@@ -1363,7 +1362,6 @@ class AMDSMIHelpers:
         clock_types_int = list(set(clock.value for clock in amdsmi_interface.AmdSmiClkType))
         return clock_types_str, clock_types_int
 
-    # TODO(amdsmi_team): add to changelog
     def get_power_profiles(self):
         return list(self.get_power_profile_name_mapping().keys())
 
@@ -3110,7 +3108,7 @@ class AMDSMIHelpers:
             ):
                 # setting power cap to 0 will return the current power cap so the technical minimum value is 1
                 min_cap_display = 1 if min_power_cap == 0 else min_power_cap
-                # TODO(amdsmi_team): add to changelog
+
                 # Raise so the caller exits with a non-zero return code
                 raise amdsmi_cli_exceptions.AmdSmiInvalidParameterValueException(
                     sys.argv[1] if len(sys.argv) > 1 else "unknown",

--- a/projects/amdsmi/amdsmi_cli/amdsmi_helpers.py
+++ b/projects/amdsmi/amdsmi_cli/amdsmi_helpers.py
@@ -45,6 +45,9 @@ from functools import lru_cache
 from amdsmi_init import *
 from BDF import BDF
 
+# TODO(amdsmi_team): move to another PR & add to changelog
+import amdsmi_cli_exceptions
+
 
 class AMDSMIHelpers:
     """Helper functions that aren't apart of the AMDSMI API
@@ -1360,13 +1363,9 @@ class AMDSMIHelpers:
         clock_types_int = list(set(clock.value for clock in amdsmi_interface.AmdSmiClkType))
         return clock_types_str, clock_types_int
 
+    # TODO(amdsmi_team): move to another PR & add to changelog
     def get_power_profiles(self):
-        power_profiles_str = [
-            profile.name for profile in amdsmi_interface.AmdSmiPowerProfilePresetMasks
-        ]
-        if "UNKNOWN" in power_profiles_str:
-            power_profiles_str.remove("UNKNOWN")
-        return power_profiles_str
+        return list(self.get_power_profile_name_mapping().keys())
 
     def get_power_profile_name_mapping(self):
         """Returns dict mapping friendly names to enum values"""
@@ -3111,16 +3110,13 @@ class AMDSMIHelpers:
             ):
                 # setting power cap to 0 will return the current power cap so the technical minimum value is 1
                 min_cap_display = 1 if min_power_cap == 0 else min_power_cap
-                if logger.is_json_format() or logger.is_csv_format():
-                    return {
-                        "status": "error",
-                        "sensor": power_type_key,
-                        "requested_power_cap": self.unit_format(logger, requested_power_cap, "W"),
-                        "min_power_cap": self.unit_format(logger, min_cap_display, "W"),
-                        "max_power_cap": self.unit_format(logger, max_power_cap, "W"),
-                        "message": f"Power cap must be between {min_cap_display}W and {max_power_cap}W",
-                    }
-                return f"Power cap must be between {min_cap_display}W and {max_power_cap}W"
+                # TODO(amdsmi_team): move to another PR & add to changelog
+                # Raise so the caller exits with a non-zero return code
+                raise amdsmi_cli_exceptions.AmdSmiInvalidParameterValueException(
+                    sys.argv[1] if len(sys.argv) > 1 else "unknown",
+                    f"{requested_power_cap}W (must be between {min_cap_display}W and {max_power_cap}W)",
+                    self.get_output_format(),
+                )
             # Set the power cap
             new_power_cap = self.convert_SI_unit(
                 requested_power_cap, AMDSMIHelpers.SI_Unit.BASE, AMDSMIHelpers.SI_Unit.MICRO

--- a/projects/amdsmi/amdsmi_cli/amdsmi_helpers.py
+++ b/projects/amdsmi/amdsmi_cli/amdsmi_helpers.py
@@ -45,7 +45,7 @@ from functools import lru_cache
 from amdsmi_init import *
 from BDF import BDF
 
-# TODO(amdsmi_team): move to another PR & add to changelog
+# TODO(amdsmi_team): add to changelog
 import amdsmi_cli_exceptions
 
 
@@ -1363,7 +1363,7 @@ class AMDSMIHelpers:
         clock_types_int = list(set(clock.value for clock in amdsmi_interface.AmdSmiClkType))
         return clock_types_str, clock_types_int
 
-    # TODO(amdsmi_team): move to another PR & add to changelog
+    # TODO(amdsmi_team): add to changelog
     def get_power_profiles(self):
         return list(self.get_power_profile_name_mapping().keys())
 
@@ -3110,7 +3110,7 @@ class AMDSMIHelpers:
             ):
                 # setting power cap to 0 will return the current power cap so the technical minimum value is 1
                 min_cap_display = 1 if min_power_cap == 0 else min_power_cap
-                # TODO(amdsmi_team): move to another PR & add to changelog
+                # TODO(amdsmi_team): add to changelog
                 # Raise so the caller exits with a non-zero return code
                 raise amdsmi_cli_exceptions.AmdSmiInvalidParameterValueException(
                     sys.argv[1] if len(sys.argv) > 1 else "unknown",

--- a/projects/amdsmi/amdsmi_cli/amdsmi_helpers.py
+++ b/projects/amdsmi/amdsmi_cli/amdsmi_helpers.py
@@ -3112,8 +3112,9 @@ class AMDSMIHelpers:
                 # Raise so the caller exits with a non-zero return code
                 raise amdsmi_cli_exceptions.AmdSmiInvalidParameterValueException(
                     sys.argv[1] if len(sys.argv) > 1 else "unknown",
-                    f"{requested_power_cap}W (must be between {min_cap_display}W and {max_power_cap}W)",
+                    f"{requested_power_cap}W",
                     self.get_output_format(),
+                    hint=f"Power cap must be between {min_cap_display}W and {max_power_cap}W",
                 )
             # Set the power cap
             new_power_cap = self.convert_SI_unit(

--- a/projects/amdsmi/amdsmi_cli/amdsmi_logger.py
+++ b/projects/amdsmi/amdsmi_cli/amdsmi_logger.py
@@ -744,8 +744,18 @@ class AMDSMILogger:
                 with self.destination.open("w", encoding="utf-8") as output_file:
                     json.dump(self.watch_output, output_file, indent=4)
             else:
-                with self.destination.open("a", encoding="utf-8") as output_file:
-                    json.dump(json_output, output_file, indent=4)
+                # TODO(amdsmi_team): move to another PR & add to changelog
+                # Read existing content to build a valid JSON array across multiple writes
+                existing = []
+                if self.destination.exists():
+                    try:
+                        with self.destination.open("r", encoding="utf-8") as existing_file:
+                            existing = json.load(existing_file)
+                    except (json.JSONDecodeError, ValueError):
+                        existing = []
+                existing.extend(json_output)
+                with self.destination.open("w", encoding="utf-8") as output_file:
+                    json.dump(existing, output_file, indent=4)
 
     def combine_arrays_to_json(self):
         combined_json = {}

--- a/projects/amdsmi/amdsmi_cli/amdsmi_logger.py
+++ b/projects/amdsmi/amdsmi_cli/amdsmi_logger.py
@@ -744,18 +744,8 @@ class AMDSMILogger:
                 with self.destination.open("w", encoding="utf-8") as output_file:
                     json.dump(self.watch_output, output_file, indent=4)
             else:
-                # TODO(amdsmi_team): move to another PR & add to changelog
-                # Read existing content to build a valid JSON array across multiple writes
-                existing = []
-                if self.destination.exists():
-                    try:
-                        with self.destination.open("r", encoding="utf-8") as existing_file:
-                            existing = json.load(existing_file)
-                    except (json.JSONDecodeError, ValueError):
-                        existing = []
-                existing.extend(json_output)
-                with self.destination.open("w", encoding="utf-8") as output_file:
-                    json.dump(existing, output_file, indent=4)
+                with self.destination.open("a", encoding="utf-8") as output_file:
+                    json.dump(json_output, output_file, indent=4)
 
     def combine_arrays_to_json(self):
         combined_json = {}

--- a/projects/amdsmi/amdsmi_cli/amdsmi_parser.py
+++ b/projects/amdsmi/amdsmi_cli/amdsmi_parser.py
@@ -3040,16 +3040,19 @@ class AMDSMIParser(argparse.ArgumentParser):
         monitor_parser.add_argument(
             "-q", "--process", action="store_true", required=False, help=process_help
         )
-        monitor_parser.add_argument(
-            "-nic", "--brcm_nic", action="store_true", required=False, help=nic_monitor_help
-        )
-        monitor_parser.add_argument(
-            "-switch",
-            "--brcm_switch",
-            action="store_true",
-            required=False,
-            help=switch_monitor_help,
-        )
+        # TODO(amdsmi_team): move to another PR & add to changelog
+        if self.helpers.is_brcm_nic_initialized():
+            monitor_parser.add_argument(
+                "-nic", "--brcm_nic", action="store_true", required=False, help=nic_monitor_help
+            )
+        if self.helpers.is_brcm_switch_initialized():
+            monitor_parser.add_argument(
+                "-switch",
+                "--brcm_switch",
+                action="store_true",
+                required=False,
+                help=switch_monitor_help,
+            )
         if not self.helpers.is_virtual_os():
             monitor_parser.add_argument(
                 "-V", "--violation", action="store_true", required=False, help=violation_help

--- a/projects/amdsmi/amdsmi_cli/amdsmi_parser.py
+++ b/projects/amdsmi/amdsmi_cli/amdsmi_parser.py
@@ -424,6 +424,11 @@ class AMDSMIParser(argparse.ArgumentParser):
                         sys.argv[1], clk_type, output_format
                     )
 
+                if not perf_levels_str:
+                    raise amdsmi_cli_exceptions.AmdSmiMissingParameterValueException(
+                        "--clk-level", output_format
+                    )
+
                 perf_levels = []
                 # Check if every item in perf level is valid
                 for level in perf_levels_str:

--- a/projects/amdsmi/amdsmi_cli/amdsmi_parser.py
+++ b/projects/amdsmi/amdsmi_cli/amdsmi_parser.py
@@ -3054,7 +3054,7 @@ class AMDSMIParser(argparse.ArgumentParser):
         monitor_parser.add_argument(
             "-q", "--process", action="store_true", required=False, help=process_help
         )
-        # TODO(amdsmi_team): add to changelog
+
         if self.helpers.is_brcm_nic_initialized():
             monitor_parser.add_argument(
                 "-nic", "--brcm_nic", action="store_true", required=False, help=nic_monitor_help

--- a/projects/amdsmi/amdsmi_cli/amdsmi_parser.py
+++ b/projects/amdsmi/amdsmi_cli/amdsmi_parser.py
@@ -1149,11 +1149,15 @@ class AMDSMIParser(argparse.ArgumentParser):
                 if isinstance(values, str):
                     if "%" in values:
                         try:
-                            amdsmi_helpers.confirm_out_of_spec_warning()
                             # Store percentage value with is_percentage flag
                             # CLI will convert based on gpu_od availability
                             percentage_value = int(values[:-1])
                             if 0 <= percentage_value <= 100:
+                                # Making behavior consistent with recent non-percentage path changes
+                                # 1. Check input validity (0-100%)
+                                # 2. If valid, prompt out-of-spec warning. If not valid, raise argparse error without prompt.
+                                # This ensures users are only prompted for valid inputs that may be out-of-spec, not for invalid inputs.
+                                amdsmi_helpers.confirm_out_of_spec_warning()
                                 # Store as tuple: (percentage_value, is_percentage=True)
                                 setattr(args, self.dest, (percentage_value, True))
                             else:
@@ -2519,6 +2523,8 @@ class AMDSMIParser(argparse.ArgumentParser):
                     "-P",
                     "--profile",
                     action="store",
+                    choices=self.helpers.get_power_profiles(),
+                    type=str.upper,
                     required=False,
                     help=set_profile_help,
                     metavar="PROFILE_LEVEL",
@@ -3045,7 +3051,7 @@ class AMDSMIParser(argparse.ArgumentParser):
         monitor_parser.add_argument(
             "-q", "--process", action="store_true", required=False, help=process_help
         )
-        # TODO(amdsmi_team): move to another PR & add to changelog
+        # TODO(amdsmi_team): add to changelog
         if self.helpers.is_brcm_nic_initialized():
             monitor_parser.add_argument(
                 "-nic", "--brcm_nic", action="store_true", required=False, help=nic_monitor_help

--- a/projects/amdsmi/amdsmi_cli/amdsmi_parser.py
+++ b/projects/amdsmi/amdsmi_cli/amdsmi_parser.py
@@ -425,8 +425,11 @@ class AMDSMIParser(argparse.ArgumentParser):
                     )
 
                 if not perf_levels_str:
-                    raise amdsmi_cli_exceptions.AmdSmiMissingParameterValueException(
-                        "--clk-level", output_format
+                    raise amdsmi_cli_exceptions.AmdSmiInvalidParameterValueException(
+                        sys.argv[1],
+                        clk_type,
+                        output_format,
+                        hint=f"\n--clk-level requires at least one performance level index (e.g. --clk-level {clk_type} 0 1)",
                     )
 
                 perf_levels = []

--- a/projects/amdsmi/amdsmi_cli/amdsmi_parser.py
+++ b/projects/amdsmi/amdsmi_cli/amdsmi_parser.py
@@ -2423,7 +2423,7 @@ class AMDSMIParser(argparse.ArgumentParser):
                 set_perf_level_help = (
                     f"Set one of the following performance levels:\n\t{perf_level_help_choices_str}"
                 )
-                power_profile_choices_str = ", ".join(self.helpers.get_power_profiles()[0:-1])
+                power_profile_choices_str = ", ".join(self.helpers.get_power_profiles())
                 set_profile_help = f"Set power profile level (#) or choose one of available profiles:\n\t{power_profile_choices_str}"
                 set_perf_det_help = (
                     "Enable performance determinism mode and set GFXCLK softmax limit (in MHz)"


### PR DESCRIPTION
## Summary

Fixes several cases where the AMD SMI CLI returned exit code 0 on invalid input, and corrects hardware-specific argument registration for the `monitor` subcommand.

## Changes

### `amdsmi_commands.py`
- `set --profile INVALID`: raise `AmdSmiInvalidParameterValueException` on unrecognized profile name so the process exits non-zero instead of printing an error and returning 0.
- `set --power-cap` out-of-range: raise exception on values outside the min/max power limit range.

### `amdsmi_helpers.py` / `amdsmi_parser.py`
- `monitor --brcm_nic` / `monitor --brcm_switch`: register these arguments only when BRCM hardware is initialized. Previously they were always registered, causing `amd-smi monitor --help` to list them on AMD GPU-only systems and test automation (e.g. `cli_unit_test.py`) to generate PASS-expected commands that unconditionally failed.
- `set --clk-level <CLK_TYPE>` (no perf level values): add explicit validation in the `_level_select()` parser action to raise `AmdSmiInvalidParameterValueException` when no perf level values are provided. Previously the command succeeded silently with an empty perf_levels list.

## Testing
Validated with `cli_unit_test.py` on a 2-GPU system (Navi/RDNA). The following previously-failing cases now correctly return non-zero:
- `amd-smi set --profile INVALID`
- `amd-smi set --clk-level SCLK` (no value)
- `amd-smi set --power-cap <out-of-range> ppt0 --gpu N`
- `amd-smi set --fan 150%` now has same behavior as `amd-smi set --fan 500` -> they both check for valid inputs first -> prompt out of spec warning if input is valid

## Notes
The companion test infrastructure PR (fix-cli-unit-test-sudo-startup) depends on this PR merging first.