### PR TITLE
[rocprofiler-systems] Relax scratch-memory test expected row count

### DIFF
--- a/projects/rocprofiler-systems/tests/rocpd-validation-rules/scratch-memory/sdk-metrics-rules.json
+++ b/projects/rocprofiler-systems/tests/rocpd-validation-rules/scratch-memory/sdk-metrics-rules.json
@@ -2,7 +2,7 @@
     "required_tables": [
         {
             "commit": "Validation rules for scratch memory allocations",
-            "min_rows": 8,
+            "min_rows": 1,
             "name": "scratch_memory",
             "required_columns": [
                 "id",

--- a/projects/rocprofiler-systems/tests/rocpd-validation-rules/scratch-memory/sdk-metrics-rules.json
+++ b/projects/rocprofiler-systems/tests/rocpd-validation-rules/scratch-memory/sdk-metrics-rules.json
@@ -2,7 +2,7 @@
     "required_tables": [
         {
             "commit": "Validation rules for scratch memory allocations",
-            "min_rows": 12,
+            "min_rows": 8,
             "name": "scratch_memory",
             "required_columns": [
                 "id",


### PR DESCRIPTION
## Motivation

Scratch memory test currently expects to see 12 rows (i.e. scratch memory events) in rocpd database after profiling scratch-memory example.

However, under certain conditions the exact same GPU can produce 8 events instead of 12. These conditions seem to be dependent on internal GPU mechanics that is outside of our control. In such situation the test fails, but this failure does not represent failure of scratch memory tracking feature, because scratch memory events are still tracked as expected.

Furthermore, APUs could produce only a single allocation event.

Given that we cannot guarantee the exact number of events, and tracing even one event confirms that scratch memory tracing feature is working, the minimum required row count for scratch memory events is reduced to 1. 

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
