### PR TITLE
[rocprofiler-systems] Update workflows to use four cores instead of two

### DIFF
--- a/.github/workflows/rocprofiler-systems-debian.yml
+++ b/.github/workflows/rocprofiler-systems-debian.yml
@@ -113,7 +113,7 @@ jobs:
         TAG=""
         python3 ./scripts/run-ci.py -B build \
           --name ${{ github.repository_owner }}-${{ github.ref_name }}-debian-${{matrix.os-release}}-${{ matrix.compiler }}${TAG} \
-          --build-jobs 2 \
+          --build-jobs $(nproc) \
           --site GitHub \
           -- \
           -DCMAKE_C_COMPILER=$(echo '${{ matrix.compiler }}' | sed 's/+/c/g') \
@@ -164,7 +164,7 @@ jobs:
       timeout-minutes: 10
       working-directory: projects/rocprofiler-systems/
       run: |
-        cmake --build build --target install --parallel 2
+        cmake --build build --target install --parallel $(nproc)
         rm -rf /opt/rocprofiler-systems
 
     - name: CPack and Install

--- a/.github/workflows/rocprofiler-systems-redhat.yml
+++ b/.github/workflows/rocprofiler-systems-redhat.yml
@@ -124,7 +124,7 @@ jobs:
         TAG="${{ github.repository_owner }}-${{ github.ref_name }}-rhel-${{ matrix.os-release }}-${{ matrix.compiler }}-python-mpip-rocm-${{ matrix.rocm-version }}" &&
         python3 ./scripts/run-ci.py -B build
           --name ${TAG}
-          --build-jobs 2
+          --build-jobs $(nproc)
           --site GitHub
           --
           -DCMAKE_C_COMPILER=$(echo '${{ matrix.compiler }}' | sed 's/+/c/g')
@@ -177,7 +177,7 @@ jobs:
       timeout-minutes: 10
       working-directory: projects/rocprofiler-systems/
       run:
-        cmake --build build --target install --parallel 2
+        cmake --build build --target install --parallel $(nproc)
 
     - name: Test Install
       timeout-minutes: 10

--- a/.github/workflows/rocprofiler-systems-ubuntu-jammy.yml
+++ b/.github/workflows/rocprofiler-systems-ubuntu-jammy.yml
@@ -147,7 +147,7 @@ jobs:
         append-tagname ${{ matrix.hidden }} hidden-viz
         python3 ./scripts/run-ci.py -B build \
           --name ${{ github.repository_owner }}-${{ github.ref_name }}-ubuntu-jammy-${{ matrix.compiler }}${TAG} \
-          --build-jobs 2 \
+          --build-jobs $(nproc) \
           --site GitHub \
           -- \
           -DCMAKE_C_COMPILER=$(echo '${{ matrix.compiler }}' | sed 's/+/c/g') \
@@ -200,7 +200,7 @@ jobs:
       timeout-minutes: 10
       working-directory: projects/rocprofiler-systems/
       run: |
-        cmake --build build --target install --parallel 2
+        cmake --build build --target install --parallel $(nproc)
         rm -fr /opt/rocprofiler-systems-dev/
 
     - name: CPack and Install
@@ -319,7 +319,7 @@ jobs:
         echo "Testing build with SYSTEM dependencies (ROCPROFSYS_BUILD_*=OFF)"
         python3 ./scripts/run-ci.py -B build \
           --name ${{ github.repository_owner }}-${{ github.ref_name }}-ubuntu-jammy-system-deps \
-          --build-jobs 2 \
+          --build-jobs $(nproc) \
           --site GitHub \
           -- \
           -DCMAKE_C_COMPILER=gcc \
@@ -455,7 +455,7 @@ jobs:
         echo "Compiler version: $(gcc --version | head -n 1)"
         python3 ./scripts/run-ci.py -B build \
           --name ${{ github.repository_owner }}-${{ github.ref_name }}-ubuntu-jammy-codecov-mpi-python-ompt-papi \
-          --build-jobs 2 \
+          --build-jobs $(nproc) \
           --site GitHub \
           --coverage \
           -- \

--- a/.github/workflows/rocprofiler-systems-ubuntu-noble.yml
+++ b/.github/workflows/rocprofiler-systems-ubuntu-noble.yml
@@ -112,7 +112,7 @@ jobs:
         TAG=""
         python3 ./scripts/run-ci.py -B build \
           --name ${{ github.repository_owner }}-${{ github.ref_name }}-ubuntu-noble-${{ matrix.compiler }}${TAG} \
-          --build-jobs 2 \
+          --build-jobs $(nproc) \
           --site GitHub \
           -- \
           -DCMAKE_C_COMPILER=$(echo '${{ matrix.compiler }}' | sed 's/+/c/g') \
@@ -163,7 +163,7 @@ jobs:
       timeout-minutes: 10
       working-directory: projects/rocprofiler-systems/
       run: |
-        cmake --build build --target install --parallel 2
+        cmake --build build --target install --parallel $(nproc)
         rm -fr /opt/rocprofiler-systems/
 
     - name: CPack and Install
@@ -282,7 +282,7 @@ jobs:
         echo "Testing build with SYSTEM dependencies (ROCPROFSYS_BUILD_{BOOST,TBB,ELFUTILS,LIBIBERTY}=OFF)"
         python3 ./scripts/run-ci.py -B build \
           --name ${{ github.repository_owner }}-${{ github.ref_name }}-ubuntu-noble-system-deps \
-          --build-jobs 2 \
+          --build-jobs $(nproc) \
           --site GitHub \
           -- \
           -DCMAKE_C_COMPILER=gcc \


### PR DESCRIPTION
## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->
Change rocprofiler-systems workflows to use four cores instead of two, this will improve build time on workflows.
## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->
Bump from two to four. Four is free for open-source projects. As well, other workflows use 4.

## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->
- CI Pass
## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
