### PR TITLE
Adding trace-decoder as dependency to SDK and move decoder workflow to nightly

### DIFF
--- a/.github/workflows/rocprof-trace-decoder-continuous_integration.yml
+++ b/.github/workflows/rocprof-trace-decoder-continuous_integration.yml
@@ -23,19 +23,37 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+env:
+  ROCM_PATH: "/opt/rocm"
+
 jobs:
   build-and-test-ubuntu:
-    name: Build & Test • Ubuntu 24.04
+    name: Build & Test • mi325 • Ubuntu 22.04
 
-    runs-on: ubuntu-24.04
+    runs-on: linux-gfx942-1gpu-ossci-rocm
     container:
-      image: rocm/dev-ubuntu-24.04:latest
-      options: --user root
+      image: docker.io/rocm/rocprofiler-private:ubuntu-22.04-gfx94X-latest
+      credentials:
+        username: ${{ secrets.ROCPROFILER_AZURE_CI_USER }}
+        password: ${{ secrets.ROCPROFILER_AZURE_CI_PASS }}
+      env:
+        DEBIAN_FRONTEND: noninteractive
+      options: --privileged
 
     env:
       GIT_DISCOVERY_ACROSS_FILESYSTEM: 1
 
     steps:
+    - name: Install Latest Nightly ROCm
+      shell: bash
+      working-directory: /tmp
+      run: |
+        mv "${{ env.ROCM_PATH }}-gfx94X.tar.gz" .
+        rm -rf ${{ env.ROCM_PATH }}*
+        mkdir -p "${{ env.ROCM_PATH }}"
+        tar -xf "rocm-gfx94X.tar.gz" -C "${{ env.ROCM_PATH }}"
+        echo "ROCm installed to: ${{ env.ROCM_PATH }}"
+
     - uses: actions/checkout@v5
       with:
         sparse-checkout: projects/rocprof-trace-decoder
@@ -55,6 +73,7 @@ jobs:
         echo "PATH: ${PATH}"
         which-realpath() { echo -e "\n$1 resolves to $(realpath $(which $1))"; echo "$($(which $1) --version &> /dev/stdout | head -n 1)"; }
         for i in python3 git cmake ctest gcc g++; do which-realpath $i; done
+        cat ${{ env.ROCM_PATH }}/.info/version
         ls -la
         pwd
 
@@ -64,7 +83,7 @@ jobs:
       run: |
         cmake -B build -S projects/rocprof-trace-decoder \
           -DCMAKE_BUILD_TYPE=RelWithDebInfo \
-          -DCMAKE_PREFIX_PATH=/opt/rocm \
+          -DCMAKE_PREFIX_PATH=${{ env.ROCM_PATH }} \
           -DBUILD_TESTS=ON \
           -DBUILD_UNIT_TESTS=ON
 

--- a/.github/workflows/rocprofiler-sdk-continuous_integration.yml
+++ b/.github/workflows/rocprofiler-sdk-continuous_integration.yml
@@ -648,7 +648,24 @@ jobs:
           cmake --build build-aqlprofile --target install
           echo "✅ AQLProfile Installation complete!"
 
-      - *build_and_install_rocprof_trace_decoder
+      - name: Build and Install rocprof-trace-decoder
+        shell: bash
+        working-directory: projects/rocprof-trace-decoder
+        run: |
+          echo "Install rocprof-trace-decoder..."
+          python3 -m venv ${{ env.PYTHON_VENV_PATH }}
+          source ${{ env.PYTHON_VENV_ACTIVATE }}
+          export PATH=/opt/rh/gcc-toolset-11/root/usr/bin:$PATH
+          cmake -B build-rocprof-trace-decoder \
+            -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+            -DCMAKE_PREFIX_PATH=${{ env.ROCM_PATH }} \
+            -DCMAKE_INSTALL_PREFIX=${{ env.ROCM_PATH }} \
+            -DCMAKE_C_COMPILER_LAUNCHER=/usr/local/bin/sccache \
+            -DCMAKE_CXX_COMPILER_LAUNCHER=/usr/local/bin/sccache \
+            .
+          cmake --build build-rocprof-trace-decoder --target all --parallel 16
+          cmake --build build-rocprof-trace-decoder --target install
+          echo "✅ rocprof-trace-decoder Installation complete!"
 
       - name: Enable PC Sampling
         if: ${{ contains(matrix.system.gpu, 'mi200') || contains(matrix.system.gpu, 'mi300a') }}

--- a/.github/workflows/rocprofiler-sdk-continuous_integration.yml
+++ b/.github/workflows/rocprofiler-sdk-continuous_integration.yml
@@ -119,13 +119,14 @@ jobs:
           tar -xf "rocm-${{ matrix.system.gpu-target }}.tar.gz" -C "${{ env.ROCM_PATH }}"
           echo "ROCm installed to: ${{ env.ROCM_PATH }}"
 
-      - name: Clone ROCProfiler SDK & AQLProfile & ROCProfiler Register & ROCR-Runtime
+      - name: Clone ROCProfiler SDK & AQLProfile & ROCProfiler Register & ROCR-Runtime & Trace Decoder
         uses: actions/checkout@v5
         with:
           sparse-checkout: |
             projects/rocprofiler-sdk
             projects/aqlprofile
             projects/rocprofiler-register
+            projects/rocprof-trace-decoder
             projects/rocr-runtime
             projects/clr
             projects/hip
@@ -313,6 +314,24 @@ jobs:
           cmake --build build-aqlprofile --target install
           echo "✅ AQLProfile Installation complete!"
 
+      - name: Build and Install rocprof-trace-decoder
+        shell: bash
+        working-directory: projects/rocprof-trace-decoder
+        run: |
+          export LD_LIBRARY_PATH=${{ env.ROCM_PATH }}/lib:${{ env.ROCM_PATH }}/llvm/lib:$LD_LIBRARY_PATH
+          export PATH=${{ env.ROCM_PATH }}/bin:${{ env.ROCM_PATH }}/llvm/bin:$PATH
+          echo "Install rocprof-trace-decoder..."
+          cmake -B build-rocprof-trace-decoder \
+            -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+            -DCMAKE_PREFIX_PATH=${{ env.ROCM_PATH }} \
+            -DCMAKE_INSTALL_PREFIX=${{ env.ROCM_PATH }} \
+            -DCMAKE_C_COMPILER_LAUNCHER=/usr/bin/ccache \
+            -DCMAKE_CXX_COMPILER_LAUNCHER=/usr/bin/ccache \
+            .
+          cmake --build build-rocprof-trace-decoder --target all --parallel 16
+          cmake --build build-rocprof-trace-decoder --target install
+          echo "✅ rocprof-trace-decoder Installation complete!"
+
       - name: List Files
         shell: bash
         working-directory: projects/rocprofiler-sdk
@@ -462,13 +481,14 @@ jobs:
       OS_TYPE: ${{ matrix.system.os }}
       GPU_RUNNER: ${{ matrix.system.gpu }}
     steps:
-      - name: Clone ROCProfiler SDK & AQLProfile & ROCProfiler Register & ROCR-Runtime
+      - name: Clone ROCProfiler SDK & AQLProfile & ROCProfiler Register & ROCR-Runtime & Trace Decoder
         uses: actions/checkout@v5
         with:
           sparse-checkout: |
             projects/rocprofiler-sdk
             projects/aqlprofile
             projects/rocprofiler-register
+            projects/rocprof-trace-decoder
             projects/rocr-runtime
             projects/clr
             projects/hip
@@ -627,6 +647,25 @@ jobs:
           cmake --build build-aqlprofile --target install
           echo "✅ AQLProfile Installation complete!"
 
+      - name: Build and Install rocprof-trace-decoder
+        shell: bash
+        working-directory: projects/rocprof-trace-decoder
+        run: |
+          echo "Install rocprof-trace-decoder..."
+          python3 -m venv ${{ env.PYTHON_VENV_PATH }}
+          source ${{ env.PYTHON_VENV_ACTIVATE }}
+          export PATH=/opt/rh/gcc-toolset-11/root/usr/bin:$PATH
+          cmake -B build-rocprof-trace-decoder \
+            -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+            -DCMAKE_PREFIX_PATH=${{ env.ROCM_PATH }} \
+            -DCMAKE_INSTALL_PREFIX=${{ env.ROCM_PATH }} \
+            -DCMAKE_C_COMPILER_LAUNCHER=/usr/local/bin/sccache \
+            -DCMAKE_CXX_COMPILER_LAUNCHER=/usr/local/bin/sccache \
+            .
+          cmake --build build-rocprof-trace-decoder --target all --parallel 16
+          cmake --build build-rocprof-trace-decoder --target install
+          echo "✅ rocprof-trace-decoder Installation complete!"
+
       - name: Enable PC Sampling
         if: ${{ contains(matrix.system.gpu, 'mi200') || contains(matrix.system.gpu, 'mi300a') }}
         shell: bash
@@ -710,13 +749,14 @@ jobs:
     steps:
     - *install_latest_nightly_rocm
 
-    - name: Clone ROCProfiler SDK & AQLProfile & ROCProfiler Register & ROCR-Runtime
+    - name: Clone ROCProfiler SDK & AQLProfile & ROCProfiler Register & ROCR-Runtime & Trace Decoder
       uses: actions/checkout@v5
       with:
         sparse-checkout: |
           projects/rocprofiler-sdk
           projects/aqlprofile
           projects/rocprofiler-register
+          projects/rocprof-trace-decoder
           projects/rocr-runtime
           projects/clr
           projects/hip
@@ -869,6 +909,22 @@ jobs:
         cmake --build build-aqlprofile --target all --parallel 16
         cmake --build build-aqlprofile --target install
         echo "✅ Installation complete!"
+
+    - name: Build and Install rocprof-trace-decoder
+      shell: bash
+      working-directory: projects/rocprof-trace-decoder
+      run: |
+        echo "Install rocprof-trace-decoder..."
+        cmake -B build-rocprof-trace-decoder \
+            -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+            -DCMAKE_PREFIX_PATH=${{ env.ROCM_PATH }} \
+            -DCMAKE_INSTALL_PREFIX=${{ env.ROCM_PATH }} \
+            -DCMAKE_C_COMPILER_LAUNCHER=/usr/bin/ccache \
+            -DCMAKE_CXX_COMPILER_LAUNCHER=/usr/bin/ccache \
+            .
+        cmake --build build-rocprof-trace-decoder --target all --parallel 16
+        cmake --build build-rocprof-trace-decoder --target install
+        echo "✅ rocprof-trace-decoder Installation complete!"
 
     - name: Configure, Build, and Test
       timeout-minutes: 45

--- a/.github/workflows/rocprofiler-sdk-continuous_integration.yml
+++ b/.github/workflows/rocprofiler-sdk-continuous_integration.yml
@@ -322,6 +322,7 @@ jobs:
           export LD_LIBRARY_PATH=${{ env.ROCM_PATH }}/lib:${{ env.ROCM_PATH }}/llvm/lib:$LD_LIBRARY_PATH
           export PATH=${{ env.ROCM_PATH }}/bin:${{ env.ROCM_PATH }}/llvm/bin:$PATH
           echo "Install rocprof-trace-decoder..."
+          rm -f ${{ env.ROCM_PATH }}/lib/librocprof-trace-decoder*
           cmake -B build-rocprof-trace-decoder \
             -DCMAKE_BUILD_TYPE=RelWithDebInfo \
             -DCMAKE_PREFIX_PATH=${{ env.ROCM_PATH }} \
@@ -653,6 +654,7 @@ jobs:
         working-directory: projects/rocprof-trace-decoder
         run: |
           echo "Install rocprof-trace-decoder..."
+          rm -f ${{ env.ROCM_PATH }}/lib/librocprof-trace-decoder*
           python3 -m venv ${{ env.PYTHON_VENV_PATH }}
           source ${{ env.PYTHON_VENV_ACTIVATE }}
           export PATH=/opt/rh/gcc-toolset-11/root/usr/bin:$PATH

--- a/.github/workflows/rocprofiler-sdk-continuous_integration.yml
+++ b/.github/workflows/rocprofiler-sdk-continuous_integration.yml
@@ -314,7 +314,8 @@ jobs:
           cmake --build build-aqlprofile --target install
           echo "✅ AQLProfile Installation complete!"
 
-      - name: Build and Install rocprof-trace-decoder
+      - &build_and_install_rocprof_trace_decoder
+        name: Build and Install rocprof-trace-decoder
         shell: bash
         working-directory: projects/rocprof-trace-decoder
         run: |
@@ -647,24 +648,7 @@ jobs:
           cmake --build build-aqlprofile --target install
           echo "✅ AQLProfile Installation complete!"
 
-      - name: Build and Install rocprof-trace-decoder
-        shell: bash
-        working-directory: projects/rocprof-trace-decoder
-        run: |
-          echo "Install rocprof-trace-decoder..."
-          python3 -m venv ${{ env.PYTHON_VENV_PATH }}
-          source ${{ env.PYTHON_VENV_ACTIVATE }}
-          export PATH=/opt/rh/gcc-toolset-11/root/usr/bin:$PATH
-          cmake -B build-rocprof-trace-decoder \
-            -DCMAKE_BUILD_TYPE=RelWithDebInfo \
-            -DCMAKE_PREFIX_PATH=${{ env.ROCM_PATH }} \
-            -DCMAKE_INSTALL_PREFIX=${{ env.ROCM_PATH }} \
-            -DCMAKE_C_COMPILER_LAUNCHER=/usr/local/bin/sccache \
-            -DCMAKE_CXX_COMPILER_LAUNCHER=/usr/local/bin/sccache \
-            .
-          cmake --build build-rocprof-trace-decoder --target all --parallel 16
-          cmake --build build-rocprof-trace-decoder --target install
-          echo "✅ rocprof-trace-decoder Installation complete!"
+      - *build_and_install_rocprof_trace_decoder
 
       - name: Enable PC Sampling
         if: ${{ contains(matrix.system.gpu, 'mi200') || contains(matrix.system.gpu, 'mi300a') }}
@@ -910,21 +894,7 @@ jobs:
         cmake --build build-aqlprofile --target install
         echo "✅ Installation complete!"
 
-    - name: Build and Install rocprof-trace-decoder
-      shell: bash
-      working-directory: projects/rocprof-trace-decoder
-      run: |
-        echo "Install rocprof-trace-decoder..."
-        cmake -B build-rocprof-trace-decoder \
-            -DCMAKE_BUILD_TYPE=RelWithDebInfo \
-            -DCMAKE_PREFIX_PATH=${{ env.ROCM_PATH }} \
-            -DCMAKE_INSTALL_PREFIX=${{ env.ROCM_PATH }} \
-            -DCMAKE_C_COMPILER_LAUNCHER=/usr/bin/ccache \
-            -DCMAKE_CXX_COMPILER_LAUNCHER=/usr/bin/ccache \
-            .
-        cmake --build build-rocprof-trace-decoder --target all --parallel 16
-        cmake --build build-rocprof-trace-decoder --target install
-        echo "✅ rocprof-trace-decoder Installation complete!"
+    - *build_and_install_rocprof_trace_decoder
 
     - name: Configure, Build, and Test
       timeout-minutes: 45


### PR DESCRIPTION
## Motivation

* rocprofiler-sdk's thread trace tests require rocprof trace decoder installation.
* rocprof-trace-decoder tests should run on nightly

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
