### PR TITLE
[rocprofiler-system] Update version of libiberty used by Dyninst to 2.46.0

### DIFF
--- a/projects/rocprofiler-systems/cmake/DyninstLibIberty.cmake
+++ b/projects/rocprofiler-systems/cmake/DyninstLibIberty.cmake
@@ -87,12 +87,10 @@ else()
             ${DYNINST_BINUTILS_DOWNLOAD_URL}
             https://ftp.gnu.org/gnu/binutils/binutils-2.46.0.tar.gz
             https://sourceware.org/pub/binutils/releases/binutils-2.46.0.tar.gz
-        PATCH_COMMAND
-            ${CMAKE_COMMAND} -E chdir <SOURCE_DIR> patch -p1 -i
-            ${CMAKE_CURRENT_LIST_DIR}/patches/binutils-readelf-dump-relocations-rels.patch
         BUILD_IN_SOURCE 1
         CONFIGURE_COMMAND
-            ${CMAKE_COMMAND} -E env CC=${CMAKE_C_COMPILER} CFLAGS=-fPIC\ -O3
+            ${CMAKE_COMMAND} -E env CC=${CMAKE_C_COMPILER}
+            CFLAGS=-fPIC\ -O3\ -Wno-maybe-uninitialized\ -Wno-format-truncation
             CXX=${CMAKE_CXX_COMPILER} CXXFLAGS=-fPIC\ -O3 <SOURCE_DIR>/configure
             --prefix=${_li_root}
         BUILD_COMMAND make

--- a/projects/rocprofiler-systems/cmake/DyninstLibIberty.cmake
+++ b/projects/rocprofiler-systems/cmake/DyninstLibIberty.cmake
@@ -85,8 +85,8 @@ else()
         PREFIX ${_li_root}
         URL
             ${DYNINST_BINUTILS_DOWNLOAD_URL}
-            http://ftpmirror.gnu.org/gnu/binutils/binutils-2.45.tar.gz
-            http://mirrors.kernel.org/sourceware/binutils/releases/binutils-2.45.tar.gz
+            https://ftp.gnu.org/gnu/binutils/binutils-2.46.0.tar.gz
+            https://sourceware.org/pub/binutils/releases/binutils-2.46.0.tar.gz
         BUILD_IN_SOURCE 1
         CONFIGURE_COMMAND
             ${CMAKE_COMMAND} -E env CC=${CMAKE_C_COMPILER} CFLAGS=-fPIC\ -O3

--- a/projects/rocprofiler-systems/cmake/DyninstLibIberty.cmake
+++ b/projects/rocprofiler-systems/cmake/DyninstLibIberty.cmake
@@ -87,6 +87,9 @@ else()
             ${DYNINST_BINUTILS_DOWNLOAD_URL}
             https://ftp.gnu.org/gnu/binutils/binutils-2.46.0.tar.gz
             https://sourceware.org/pub/binutils/releases/binutils-2.46.0.tar.gz
+        PATCH_COMMAND
+            ${CMAKE_COMMAND} -E chdir <SOURCE_DIR> patch -p1 -i
+            ${CMAKE_CURRENT_LIST_DIR}/patches/binutils-readelf-dump-relocations-rels.patch
         BUILD_IN_SOURCE 1
         CONFIGURE_COMMAND
             ${CMAKE_COMMAND} -E env CC=${CMAKE_C_COMPILER} CFLAGS=-fPIC\ -O3

--- a/projects/rocprofiler-systems/cmake/patches/binutils-readelf-dump-relocations-rels.patch
+++ b/projects/rocprofiler-systems/cmake/patches/binutils-readelf-dump-relocations-rels.patch
@@ -1,0 +1,17 @@
+Fix -Werror=maybe-uninitialized on dump_relocations (GCC 14+).
+
+GCC does not prove that rels is set on all paths before free(rels); initializing
+matches the intended contract (slurp_* always assigns through &rels when entered).
+
+--- a/binutils/readelf.c
++++ b/binutils/readelf.c
+@@ -2259,7 +2259,7 @@ dump_relocations (Filedata *          filedata,
+ 		  bool                is_dynsym,
+ 		  bool                dump_reloc)
+ {
+   size_t i;
+-  Elf_Internal_Rela * rels;
++  Elf_Internal_Rela * rels = NULL;
+   bool res = true;
+
+   if (rel_type == reltype_unknown)


### PR DESCRIPTION
## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->
Update binutils used to build libiberty for Dyninst to version 2.46.0. 

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->
- Update link to download the latest binary.
- Apply patch to fix build issues: 
```
./readelf.c: In function ‘dump_relocations’:
./readelf.c:2935:3: error: ‘rels’ may be used uninitialized [-Werror=maybe-uninitialized]
 2935 |   free (rels);
      |   ^~~~~~~~~~~
./readelf.c:2262:23: note: ‘rels’ declared here
 2262 |   Elf_Internal_Rela * rels;
      |                       ^~~~
cc1: all warnings being treated as errors
make[7]: *** [Makefile:1940: readelf.o] Error 1
```

## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->
- Part of ROCM-20844

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->
Run pre-commit workflows

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
