### PR TITLE
Add on-disk WAL write mode with optional WAL mmap

### DIFF
--- a/projects/rocpdsna/include/storage.hpp
+++ b/projects/rocpdsna/include/storage.hpp
@@ -16,7 +16,10 @@ struct reader_t;
 class storage_t
 {
 public:
-    explicit storage_t(const std::string& database_path, const std::string& uuid);
+    explicit storage_t(const std::string& database_path,
+                       const std::string& uuid,
+                       write_mode_t       write_mode    = write_mode_t::in_memory,
+                       size_t             wal_mmap_size = 0);
     virtual ~storage_t();
 
     storage_t(const storage_t&)            = delete;

--- a/projects/rocpdsna/include/storage_types.hpp
+++ b/projects/rocpdsna/include/storage_types.hpp
@@ -14,4 +14,24 @@ struct version_t
     uint32_t minor;
     uint32_t patch;
 };
+
+/***
+ * @brief Controls how the writer stores data during a profiling session.
+ *
+ * in_memory: All writes go to a SQLite in-memory database. Data is not
+ *   visible on disk until flush_in_memory_data_to_disk() is called.
+ *   Lower per-insert overhead; higher peak memory usage.
+ *
+ * on_disk: The database is opened directly on disk in WAL mode. Writes
+ *   go to the WAL file via normal I/O unless wal_mmap_size > 0 is passed
+ *   to the storage_t constructor, in which case the WAL file is
+ *   pre-allocated and memory-mapped for faster sequential appends.
+ *   flush_in_memory_data_to_disk() is a no-op in this mode.
+ *   Supports concurrent readers via IPC.
+ */
+enum class write_mode_t
+{
+    in_memory,
+    on_disk
+};
 }  // namespace rocpdsna

--- a/projects/rocpdsna/include/writer.hpp
+++ b/projects/rocpdsna/include/writer.hpp
@@ -138,7 +138,9 @@ struct writer_t
 
     /***
      * @brief Flush in-memory data to disk
-     * @note This function is only used with in-memory database option
+     * @note This function transfers data to disk when using write_mode_t::in_memory.
+     *       It is a no-op when using write_mode_t::on_disk, since data is written
+     *       directly to disk in that mode.
      */
     void flush_in_memory_data_to_disk();
 

--- a/projects/rocpdsna/source/data_storage/CMakeLists.txt
+++ b/projects/rocpdsna/source/data_storage/CMakeLists.txt
@@ -20,6 +20,8 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-set(data_storage_sources ${CMAKE_CURRENT_LIST_DIR}/backends/sqlite_backend.cpp)
+set(data_storage_sources
+    ${CMAKE_CURRENT_LIST_DIR}/backends/sqlite_backend.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/backends/wal_mmap_vfs.cpp)
 
 target_sources(rocpdsna-objects PRIVATE ${data_storage_sources})

--- a/projects/rocpdsna/source/data_storage/backends/sqlite_backend.cpp
+++ b/projects/rocpdsna/source/data_storage/backends/sqlite_backend.cpp
@@ -5,6 +5,7 @@
 
 #include "debug.hpp"
 #include "directory.hpp"
+#include "wal_mmap_vfs.hpp"
 
 #include <filesystem>
 #include <stdexcept>
@@ -150,10 +151,13 @@ namespace rocpdsna::data_storage
 {
 
 std::shared_ptr<sqlite_backend>
-sqlite_backend::create(std::string db_path, std::string uuid, storage_mode_t mode)
+sqlite_backend::create(std::string    db_path,
+                       std::string    uuid,
+                       storage_mode_t mode,
+                       size_t         wal_mmap_size)
 {
     auto backend = std::shared_ptr<sqlite_backend>(
-        new sqlite_backend(std::move(db_path), std::move(uuid), mode));
+        new sqlite_backend(std::move(db_path), std::move(uuid), mode, wal_mmap_size));
 
     // discover_uuids() uses create_read_statement_executor which calls
     // shared_from_this(). This must happen after the shared_ptr is fully
@@ -171,10 +175,14 @@ sqlite_backend::create(std::string db_path, std::string uuid, storage_mode_t mod
     return backend;
 }
 
-sqlite_backend::sqlite_backend(std::string db_path, std::string uuid, storage_mode_t mode)
+sqlite_backend::sqlite_backend(std::string    db_path,
+                               std::string    uuid,
+                               storage_mode_t mode,
+                               size_t         wal_mmap_size)
 : m_db_path{ std::move(db_path) }
 , m_uuid{ std::move(uuid) }
 , m_mode{ mode }
+, m_wal_mmap_size{ wal_mmap_size }
 {
     if(std::filesystem::exists(m_db_path))
     {
@@ -193,8 +201,17 @@ sqlite_backend::sqlite_backend(std::string db_path, std::string uuid, storage_mo
     }
     else if(m_mode == storage_mode_t::on_disk)
     {
+        const char* vfs_name = nullptr;
+        if(m_wal_mmap_size > 0)
+            vfs_name = rocpdsna::data_storage::register_wal_mmap_vfs(m_wal_mmap_size);
+
         validate_sqlite3_result(
-            sqlite3_open(m_db_path.c_str(), &m_sqlite3), "", "database open failed!");
+            sqlite3_open_v2(m_db_path.c_str(),
+                            &m_sqlite3,
+                            SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE,
+                            vfs_name),
+            "",
+            "database open failed!");
     }
 
     LOG_INFO("rocpdsna database initialized (uuid: {}, path: {})", m_uuid, m_db_path);
@@ -240,6 +257,14 @@ sqlite_backend::initialize_schema()
         throw std::runtime_error("Database already initialized!");
     }
 
+    if(m_mode == storage_mode_t::on_disk)
+    {
+        validate_sqlite3_result(
+            sqlite3_exec(m_sqlite3, "PRAGMA journal_mode=WAL;", nullptr, nullptr, nullptr),
+            "PRAGMA journal_mode=WAL",
+            "Failed to enable WAL mode");
+    }
+
     const std::vector<rocpd_sql_schema_kind_t> schema_kinds = {
         ROCPD_SQL_SCHEMA_ROCPD_TABLES,
         ROCPD_SQL_SCHEMA_ROCPD_VIEWS,
@@ -282,8 +307,6 @@ sqlite_backend::flush()
 {
     if(m_mode != storage_mode_t::in_memory)
     {
-        LOG_WARNING("Flushing database is not supported for database type: {}",
-                    static_cast<int>(m_mode));
         return;
     }
 

--- a/projects/rocpdsna/source/data_storage/backends/sqlite_backend.hpp
+++ b/projects/rocpdsna/source/data_storage/backends/sqlite_backend.hpp
@@ -192,7 +192,8 @@ public:
     static std::shared_ptr<sqlite_backend> create(
         std::string    db_path,
         std::string    uuid,
-        storage_mode_t mode = storage_mode_t::in_memory);
+        storage_mode_t mode          = storage_mode_t::in_memory,
+        size_t         wal_mmap_size = 0);
 
     ~sqlite_backend();
 
@@ -248,7 +249,10 @@ private:
     // =========================================================================
     // Private constructor -- use create() factory
     // =========================================================================
-    sqlite_backend(std::string db_path, std::string uuid, storage_mode_t mode);
+    sqlite_backend(std::string    db_path,
+                   std::string    uuid,
+                   storage_mode_t mode,
+                   size_t         wal_mmap_size);
 
     // =========================================================================
     // Statement preparation
@@ -496,6 +500,7 @@ private:
     std::string    m_db_path;
     std::string    m_uuid;
     storage_mode_t m_mode;
+    size_t         m_wal_mmap_size{ 0 };
     bool           m_initialized{ false };
     bool           m_flushed{ false };
 };

--- a/projects/rocpdsna/source/data_storage/backends/wal_mmap_vfs.cpp
+++ b/projects/rocpdsna/source/data_storage/backends/wal_mmap_vfs.cpp
@@ -1,0 +1,447 @@
+// Copyright (c) Advanced Micro Devices, Inc.
+// SPDX-License-Identifier:  MIT
+
+// Custom SQLite VFS: mmap-backed WAL files
+//
+// Design overview
+// ---------------
+// SQLite passes SQLITE_OPEN_WAL in the flags argument to xOpen when it opens
+// the WAL file.  This shim VFS intercepts those opens, pre-allocates the WAL
+// file to a user-supplied size, and mmap()s the region.  xWrite/xRead then
+// operate directly on the mapped memory instead of going through system calls.
+//
+// For every other file type (main database, shm) the shim delegates straight
+// to the underlying unix VFS without modification.
+//
+// File object layout
+// ------------------
+// SQLite allocates szOsFile bytes for each file object.  We set
+//   szOsFile = sizeof(WalMmapFile) + parent->szOsFile
+// so the parent file object lives immediately after our header in the same
+// allocation:
+//
+//   [ WalMmapFile | <parent sqlite3_file> ]
+//    ^              ^
+//    pFile          pFile->pUnderlying
+//
+// For non-WAL files we still call the parent xOpen with pFile as the buffer
+// (safe because szOsFile >= parent->szOsFile).  The parent sets pFile->pMethods
+// to its own io_methods, so subsequent calls on those files go directly to the
+// parent without touching WalMmapFile fields.
+
+#include "wal_mmap_vfs.hpp"
+
+#include <sqlite3.h>
+
+#include <fcntl.h>
+#include <sys/mman.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+#include <cerrno>
+#include <cstdio>
+#include <cstring>
+#include <map>
+#include <mutex>
+#include <string>
+
+namespace rocpdsna::data_storage
+{
+
+namespace
+{
+
+// ---------------------------------------------------------------------------
+// Per-WAL-file object
+// ---------------------------------------------------------------------------
+struct WalMmapFile
+{
+    sqlite3_file  base;         // must be first; holds pMethods
+    sqlite3_file* pUnderlying;  // parent file object (for locking / sync)
+    int           fd;           // our own fd for ftruncate + mmap
+    void*         pMmap;        // mmap'd region (MAP_FAILED if not mmap'd)
+    sqlite3_int64 mmapSize;     // total pre-allocated bytes
+    sqlite3_int64 logicalSize;  // bytes of valid WAL data written so far
+};
+
+// ---------------------------------------------------------------------------
+// io_methods: forwarding helpers
+// ---------------------------------------------------------------------------
+static WalMmapFile*
+wm(sqlite3_file* p)
+{
+    return reinterpret_cast<WalMmapFile*>(p);
+}
+
+static int
+walMmapClose(sqlite3_file* pFile)
+{
+    WalMmapFile* p = wm(pFile);
+    if(p->pMmap != MAP_FAILED)
+    {
+        ::msync(p->pMmap, static_cast<size_t>(p->logicalSize), MS_SYNC);
+        ::munmap(p->pMmap, static_cast<size_t>(p->mmapSize));
+        p->pMmap = MAP_FAILED;
+    }
+    if(p->fd >= 0)
+    {
+        ::close(p->fd);
+        p->fd = -1;
+    }
+    return p->pUnderlying->pMethods->xClose(p->pUnderlying);
+}
+
+static int
+walMmapRead(sqlite3_file* pFile, void* zBuf, int iAmt, sqlite3_int64 iOfst)
+{
+    WalMmapFile* p       = wm(pFile);
+    sqlite3_int64 end    = iOfst + iAmt;
+    sqlite3_int64 avail  = p->logicalSize - iOfst;
+
+    if(avail <= 0)
+    {
+        ::memset(zBuf, 0, static_cast<size_t>(iAmt));
+        return SQLITE_IOERR_SHORT_READ;
+    }
+
+    if(avail >= iAmt)
+    {
+        ::memcpy(zBuf,
+                 static_cast<char*>(p->pMmap) + iOfst,
+                 static_cast<size_t>(iAmt));
+        return SQLITE_OK;
+    }
+
+    // Partial read: copy what we have, zero-fill the rest.
+    ::memcpy(zBuf, static_cast<char*>(p->pMmap) + iOfst, static_cast<size_t>(avail));
+    ::memset(static_cast<char*>(zBuf) + avail, 0, static_cast<size_t>(iAmt - avail));
+    (void) end;
+    return SQLITE_IOERR_SHORT_READ;
+}
+
+static int
+walMmapWrite(sqlite3_file* pFile, const void* zBuf, int iAmt, sqlite3_int64 iOfst)
+{
+    WalMmapFile*  p   = wm(pFile);
+    sqlite3_int64 end = iOfst + iAmt;
+
+    if(end > p->mmapSize)
+        return SQLITE_IOERR_WRITE;  // exceeded pre-allocated region
+
+    ::memcpy(static_cast<char*>(p->pMmap) + iOfst, zBuf, static_cast<size_t>(iAmt));
+
+    if(end > p->logicalSize)
+        p->logicalSize = end;
+
+    return SQLITE_OK;
+}
+
+static int
+walMmapTruncate(sqlite3_file* pFile, sqlite3_int64 size)
+{
+    WalMmapFile* p = wm(pFile);
+    if(size < p->logicalSize)
+        p->logicalSize = size;
+    return SQLITE_OK;
+}
+
+static int
+walMmapSync(sqlite3_file* pFile, int flags)
+{
+    WalMmapFile* p = wm(pFile);
+    if(p->pMmap != MAP_FAILED && p->logicalSize > 0)
+    {
+        int ms_flags = (flags & SQLITE_SYNC_FULL) ? MS_SYNC : MS_ASYNC;
+        ::msync(p->pMmap, static_cast<size_t>(p->logicalSize), ms_flags);
+    }
+    return p->pUnderlying->pMethods->xSync(p->pUnderlying, flags);
+}
+
+static int
+walMmapFileSize(sqlite3_file* pFile, sqlite3_int64* pSize)
+{
+    *pSize = wm(pFile)->logicalSize;
+    return SQLITE_OK;
+}
+
+static int
+walMmapLock(sqlite3_file* pFile, int eLock)
+{
+    return wm(pFile)->pUnderlying->pMethods->xLock(wm(pFile)->pUnderlying, eLock);
+}
+
+static int
+walMmapUnlock(sqlite3_file* pFile, int eLock)
+{
+    return wm(pFile)->pUnderlying->pMethods->xUnlock(wm(pFile)->pUnderlying, eLock);
+}
+
+static int
+walMmapCheckReservedLock(sqlite3_file* pFile, int* pResOut)
+{
+    return wm(pFile)->pUnderlying->pMethods->xCheckReservedLock(wm(pFile)->pUnderlying,
+                                                                pResOut);
+}
+
+static int
+walMmapFileControl(sqlite3_file* pFile, int op, void* pArg)
+{
+    return wm(pFile)->pUnderlying->pMethods->xFileControl(wm(pFile)->pUnderlying, op, pArg);
+}
+
+static int
+walMmapSectorSize(sqlite3_file* pFile)
+{
+    return wm(pFile)->pUnderlying->pMethods->xSectorSize(wm(pFile)->pUnderlying);
+}
+
+static int
+walMmapDeviceCharacteristics(sqlite3_file* pFile)
+{
+    return wm(pFile)->pUnderlying->pMethods->xDeviceCharacteristics(
+        wm(pFile)->pUnderlying);
+}
+
+static const sqlite3_io_methods walMmapMethods = {
+    1,                           // iVersion (v1: no shm/fetch methods needed for WAL)
+    walMmapClose,
+    walMmapRead,
+    walMmapWrite,
+    walMmapTruncate,
+    walMmapSync,
+    walMmapFileSize,
+    walMmapLock,
+    walMmapUnlock,
+    walMmapCheckReservedLock,
+    walMmapFileControl,
+    walMmapSectorSize,
+    walMmapDeviceCharacteristics,
+};
+
+// ---------------------------------------------------------------------------
+// VFS app data: carries parent VFS pointer + mmap size to xOpen
+// ---------------------------------------------------------------------------
+struct VfsAppData
+{
+    sqlite3_vfs* pParent;
+    size_t       walMmapSize;
+};
+
+// ---------------------------------------------------------------------------
+// xOpen: intercept WAL files; pass everything else through
+// ---------------------------------------------------------------------------
+static int
+walMmapOpen(sqlite3_vfs* pVfs,
+            const char*  zPath,
+            sqlite3_file* pFile,
+            int           flags,
+            int*          pOutFlags)
+{
+    auto*         appData    = static_cast<VfsAppData*>(pVfs->pAppData);
+    sqlite3_vfs*  pParent    = appData->pParent;
+    size_t        mmapSize   = appData->walMmapSize;
+
+    // Underlying file object lives immediately after our WalMmapFile header.
+    sqlite3_file* pUnderlying =
+        reinterpret_cast<sqlite3_file*>(reinterpret_cast<char*>(pFile) +
+                                        sizeof(WalMmapFile));
+
+    // For non-WAL files (database, shm, journal, temp) delegate directly.
+    // pFile has enough space because szOsFile >= parent->szOsFile.
+    if(!(flags & SQLITE_OPEN_WAL))
+    {
+        return pParent->xOpen(pParent, zPath, pFile, flags, pOutFlags);
+    }
+
+    // --- WAL file: open via parent to get locking/sync, then set up mmap ---
+
+    int rc = pParent->xOpen(pParent, zPath, pUnderlying, flags, pOutFlags);
+    if(rc != SQLITE_OK)
+        return rc;
+
+    WalMmapFile* p    = reinterpret_cast<WalMmapFile*>(pFile);
+    p->pUnderlying    = pUnderlying;
+    p->fd             = -1;
+    p->pMmap          = MAP_FAILED;
+    p->mmapSize       = static_cast<sqlite3_int64>(mmapSize);
+    p->logicalSize    = 0;
+
+    // Open a separate fd for ftruncate + mmap.
+    p->fd = ::open(zPath, O_RDWR | O_CREAT, 0644);
+    if(p->fd < 0)
+    {
+        pUnderlying->pMethods->xClose(pUnderlying);
+        return SQLITE_CANTOPEN;
+    }
+
+    // Pre-allocate the file to mmapSize so the mapping covers the full region
+    // without needing mremap() as the WAL grows.
+    if(::ftruncate(p->fd, static_cast<off_t>(mmapSize)) != 0)
+    {
+        ::close(p->fd);
+        pUnderlying->pMethods->xClose(pUnderlying);
+        return SQLITE_IOERR_WRITE;
+    }
+
+    p->pMmap = ::mmap(nullptr,
+                      mmapSize,
+                      PROT_READ | PROT_WRITE,
+                      MAP_SHARED,
+                      p->fd,
+                      0);
+    if(p->pMmap == MAP_FAILED)
+    {
+        ::close(p->fd);
+        pUnderlying->pMethods->xClose(pUnderlying);
+        return SQLITE_IOERR_MMAP;
+    }
+
+    pFile->pMethods = &walMmapMethods;
+    return SQLITE_OK;
+}
+
+// ---------------------------------------------------------------------------
+// All other VFS methods delegate to the parent VFS
+// ---------------------------------------------------------------------------
+static int
+walMmapDelete(sqlite3_vfs* pVfs, const char* zPath, int dirSync)
+{
+    auto* d = static_cast<VfsAppData*>(pVfs->pAppData);
+    return d->pParent->xDelete(d->pParent, zPath, dirSync);
+}
+
+static int
+walMmapAccess(sqlite3_vfs* pVfs, const char* zPath, int flags, int* pResOut)
+{
+    auto* d = static_cast<VfsAppData*>(pVfs->pAppData);
+    return d->pParent->xAccess(d->pParent, zPath, flags, pResOut);
+}
+
+static int
+walMmapFullPathname(sqlite3_vfs* pVfs, const char* zPath, int nOut, char* zOut)
+{
+    auto* d = static_cast<VfsAppData*>(pVfs->pAppData);
+    return d->pParent->xFullPathname(d->pParent, zPath, nOut, zOut);
+}
+
+static void*
+walMmapDlOpen(sqlite3_vfs* pVfs, const char* zFilename)
+{
+    auto* d = static_cast<VfsAppData*>(pVfs->pAppData);
+    return d->pParent->xDlOpen(d->pParent, zFilename);
+}
+
+static void
+walMmapDlError(sqlite3_vfs* pVfs, int nByte, char* zErrMsg)
+{
+    auto* d = static_cast<VfsAppData*>(pVfs->pAppData);
+    d->pParent->xDlError(d->pParent, nByte, zErrMsg);
+}
+
+static void (*walMmapDlSym(sqlite3_vfs* pVfs, void* p, const char* zSym))(void)
+{
+    auto* d = static_cast<VfsAppData*>(pVfs->pAppData);
+    return d->pParent->xDlSym(d->pParent, p, zSym);
+}
+
+static void
+walMmapDlClose(sqlite3_vfs* pVfs, void* pHandle)
+{
+    auto* d = static_cast<VfsAppData*>(pVfs->pAppData);
+    d->pParent->xDlClose(d->pParent, pHandle);
+}
+
+static int
+walMmapRandomness(sqlite3_vfs* pVfs, int nByte, char* zOut)
+{
+    auto* d = static_cast<VfsAppData*>(pVfs->pAppData);
+    return d->pParent->xRandomness(d->pParent, nByte, zOut);
+}
+
+static int
+walMmapSleep(sqlite3_vfs* pVfs, int microseconds)
+{
+    auto* d = static_cast<VfsAppData*>(pVfs->pAppData);
+    return d->pParent->xSleep(d->pParent, microseconds);
+}
+
+static int
+walMmapCurrentTime(sqlite3_vfs* pVfs, double* pTimeOut)
+{
+    auto* d = static_cast<VfsAppData*>(pVfs->pAppData);
+    return d->pParent->xCurrentTime(d->pParent, pTimeOut);
+}
+
+static int
+walMmapGetLastError(sqlite3_vfs* pVfs, int nBuf, char* zBuf)
+{
+    auto* d = static_cast<VfsAppData*>(pVfs->pAppData);
+    return d->pParent->xGetLastError(d->pParent, nBuf, zBuf);
+}
+
+static int
+walMmapCurrentTimeInt64(sqlite3_vfs* pVfs, sqlite3_int64* pTimeOut)
+{
+    auto* d = static_cast<VfsAppData*>(pVfs->pAppData);
+    // xCurrentTimeInt64 is a v2 method; fall back if parent is v1.
+    if(d->pParent->iVersion >= 2 && d->pParent->xCurrentTimeInt64)
+        return d->pParent->xCurrentTimeInt64(d->pParent, pTimeOut);
+    double t = 0.0;
+    int    rc = d->pParent->xCurrentTime(d->pParent, &t);
+    *pTimeOut  = static_cast<sqlite3_int64>((t - 2440587.5) * 86400.0 * 1000.0);
+    return rc;
+}
+
+}  // namespace
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+const char*
+register_wal_mmap_vfs(size_t mmap_size)
+{
+    // One registration per distinct mmap_size value.
+    static std::mutex              s_mu;
+    static std::map<size_t, std::string> s_names;
+
+    std::lock_guard<std::mutex> lock(s_mu);
+
+    auto it = s_names.find(mmap_size);
+    if(it != s_names.end())
+        return it->second.c_str();
+
+    sqlite3_vfs* parent = sqlite3_vfs_find(nullptr);  // default VFS
+
+    // VfsAppData and sqlite3_vfs must outlive the process; allocate with new.
+    auto* appData       = new VfsAppData{ parent, mmap_size };
+    auto* vfs           = new sqlite3_vfs{};
+
+    vfs->iVersion          = 2;
+    vfs->szOsFile          = static_cast<int>(sizeof(WalMmapFile)) + parent->szOsFile;
+    vfs->mxPathname        = parent->mxPathname;
+    vfs->pNext             = nullptr;
+    vfs->pAppData          = appData;
+    vfs->xOpen             = walMmapOpen;
+    vfs->xDelete           = walMmapDelete;
+    vfs->xAccess           = walMmapAccess;
+    vfs->xFullPathname     = walMmapFullPathname;
+    vfs->xDlOpen           = walMmapDlOpen;
+    vfs->xDlError          = walMmapDlError;
+    vfs->xDlSym            = walMmapDlSym;
+    vfs->xDlClose          = walMmapDlClose;
+    vfs->xRandomness       = walMmapRandomness;
+    vfs->xSleep            = walMmapSleep;
+    vfs->xCurrentTime      = walMmapCurrentTime;
+    vfs->xGetLastError     = walMmapGetLastError;
+    vfs->xCurrentTimeInt64 = walMmapCurrentTimeInt64;
+
+    std::string name = "rocpdsna-wal-mmap-" + std::to_string(mmap_size);
+    auto [ins, ok]   = s_names.emplace(mmap_size, std::move(name));
+
+    vfs->zName = ins->second.c_str();
+    sqlite3_vfs_register(vfs, /* makeDflt= */ 0);
+
+    return ins->second.c_str();
+}
+
+}  // namespace rocpdsna::data_storage

--- a/projects/rocpdsna/source/data_storage/backends/wal_mmap_vfs.hpp
+++ b/projects/rocpdsna/source/data_storage/backends/wal_mmap_vfs.hpp
@@ -1,0 +1,23 @@
+// Copyright (c) Advanced Micro Devices, Inc.
+// SPDX-License-Identifier:  MIT
+
+#pragma once
+
+#include <cstddef>
+
+namespace rocpdsna::data_storage
+{
+
+// Registers (once per unique size) a custom SQLite VFS that intercepts WAL
+// file opens and services them via a pre-allocated mmap region instead of
+// read()/write() system calls.  All other file types (main database, shm)
+// pass through to the default unix VFS unchanged.
+//
+// Returns the VFS name to pass as the last argument to sqlite3_open_v2().
+// The returned pointer is valid for the lifetime of the process.
+//
+// If mmap_size == 0 this function must not be called; callers should pass
+// nullptr to sqlite3_open_v2() to select the default VFS instead.
+const char* register_wal_mmap_vfs(size_t mmap_size);
+
+}  // namespace rocpdsna::data_storage

--- a/projects/rocpdsna/source/storage.cpp
+++ b/projects/rocpdsna/source/storage.cpp
@@ -12,8 +12,11 @@
 namespace rocpdsna
 {
 
-storage_t::storage_t(const std::string& database_path, const std::string& uuid)
-: m_impl(std::make_unique<impl>(database_path, uuid))
+storage_t::storage_t(const std::string& database_path,
+                     const std::string& uuid,
+                     write_mode_t       write_mode,
+                     size_t             wal_mmap_size)
+: m_impl(std::make_unique<impl>(database_path, uuid, write_mode, wal_mmap_size))
 {}
 
 storage_t::~storage_t() { m_impl.reset(); }

--- a/projects/rocpdsna/source/storage_impl.cpp
+++ b/projects/rocpdsna/source/storage_impl.cpp
@@ -7,6 +7,8 @@
 
 #include "data_storage/backends/sqlite_backend.hpp"
 
+#include <filesystem>
+#include <filesystem>
 #include <memory>
 #include <stdexcept>
 #include <string>
@@ -20,7 +22,9 @@ struct storage_t::impl::database_factory_t
     static std::shared_ptr<data_storage::sqlite_backend> create_database(
         const std::string&    database_path,
         const std::string&    uuid,
-        const storage_type_t& storage_type)
+        const storage_type_t& storage_type,
+        write_mode_t          write_mode,
+        size_t                wal_mmap_size)
     {
         switch(storage_type)
         {
@@ -30,6 +34,15 @@ struct storage_t::impl::database_factory_t
                     uuid,
                     data_storage::sqlite_backend::storage_mode_t::on_disk);
             case storage_type_t::write:
+                if(write_mode == write_mode_t::on_disk)
+                {
+                    std::filesystem::remove(database_path);
+                    return data_storage::sqlite_backend::create(
+                        database_path,
+                        uuid,
+                        data_storage::sqlite_backend::storage_mode_t::on_disk,
+                        wal_mmap_size);
+                }
                 return data_storage::sqlite_backend::create(
                     database_path,
                     uuid,
@@ -42,9 +55,14 @@ struct storage_t::impl::database_factory_t
     }
 };
 
-storage_t::impl::impl(std::string database_path, std::string uuid)
+storage_t::impl::impl(std::string  database_path,
+                      std::string  uuid,
+                      write_mode_t write_mode,
+                      size_t       wal_mmap_size)
 : m_database_path(std::move(database_path))
 , m_uuid(std::move(uuid))
+, m_write_mode(write_mode)
+, m_wal_mmap_size(wal_mmap_size)
 {}
 
 std::string
@@ -70,8 +88,8 @@ storage_t::impl::create_database(const storage_type_t& storage_type)
 {
     if(!m_database)
     {
-        m_database =
-            database_factory_t::create_database(m_database_path, m_uuid, storage_type);
+        m_database = database_factory_t::create_database(
+            m_database_path, m_uuid, storage_type, m_write_mode, m_wal_mmap_size);
         m_storage_type = storage_type;
     }
     return m_database;

--- a/projects/rocpdsna/source/storage_impl.hpp
+++ b/projects/rocpdsna/source/storage_impl.hpp
@@ -24,7 +24,10 @@ struct storage_t::impl
         write = 2
     };
 
-    explicit impl(std::string database_path, std::string uuid);
+    explicit impl(std::string database_path,
+                  std::string  uuid,
+                  write_mode_t write_mode,
+                  size_t       wal_mmap_size);
 
     [[nodiscard]] std::string get_database_path() const;
     [[nodiscard]] std::string get_uuid() const;
@@ -42,8 +45,10 @@ private:
     storage_type_t                                m_storage_type{ storage_type_t::none };
     std::shared_ptr<data_storage::sqlite_backend> m_database{ nullptr };
 
-    std::string m_database_path;
-    std::string m_uuid;
+    std::string  m_database_path;
+    std::string  m_uuid;
+    write_mode_t m_write_mode{ write_mode_t::in_memory };
+    size_t       m_wal_mmap_size{ 0 };
 
     struct database_factory_t;
 };


### PR DESCRIPTION
## Motivation

Introduces write_mode_t::on_disk which opens the database directly on disk in WAL mode rather than buffering everything in a SQLite :memory: database until flush_in_memory_data_to_disk() is called.
This allows for limiting memory usage and uses mmap() to keep the WAL file in memory to improve performance over the naive implementation.

## Technical Details

Adds an optional wal_mmap_size parameter (default 0) to storage_t. When non-zero, a custom SQLite VFS (wal_mmap_vfs) pre-allocates the WAL file to the requested size and services all WAL reads/writes via mmap, avoiding per-write kernel copies. The main database file is intentionally not mmap'd, keeping it compatible with network filesystems.

All existing callers are unaffected; both new parameters default to the original in-memory behaviour.
## JIRA ID

## Test Result

Unitests pass.

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
