### PR TITLE
clr: introduce CLR-native EventBus profiling interface

### DIFF
--- a/projects/clr/hipamd/src/amdhip.def
+++ b/projects/clr/hipamd/src/amdhip.def
@@ -219,6 +219,12 @@ hipLaunchKernel
 hipRegisterTracerCallback
 hipApiName
 hipKernelNameRef
+clr_prof_subscribe
+clr_prof_unsubscribe
+clr_prof_get_correlation_id
+clr_prof_api_name
+clr_prof_gpu_op_name
+clr_prof_version
 hipBindTexture
 hipBindTexture2D
 hipBindTextureToArray

--- a/projects/clr/hipamd/src/hip_context.cpp
+++ b/projects/clr/hipamd/src/hip_context.cpp
@@ -7,6 +7,7 @@
 #include <hip/hip_runtime.h>
 #include "hip_internal.hpp"
 #include "hip_platform.hpp"
+#include "platform/clr_prof_writer.hpp"
 #include "platform/runtime.hpp"
 #include "rocclr/utils/flags.hpp"
 #include "rocclr/utils/versions.hpp"
@@ -91,6 +92,12 @@ void init(bool* status) {
 
   // Complete platform initialization
   PlatformState::Instance().Init();
+
+  // Initialize built-in trace writer (no-op if CLR_TRACE_OUTPUT is not set).
+  amd::clr_prof::WriterInit();
+  amd::RuntimeTearDown::RegisterTearDownCallback("clr_prof_writer",
+                                                  []() { amd::clr_prof::WriterFini(); });
+
   *status = true;
 }
 

--- a/projects/clr/hipamd/src/hip_hcc.map.in
+++ b/projects/clr/hipamd/src/hip_hcc.map.in
@@ -499,6 +499,12 @@ global:
     hipLaunchHostFunc;
     hipLaunchHostFunc_spt;
     hipRegisterTracerCallback;
+    clr_prof_subscribe;
+    clr_prof_unsubscribe;
+    clr_prof_get_correlation_id;
+    clr_prof_api_name;
+    clr_prof_gpu_op_name;
+    clr_prof_version;
     hipGraphDebugDotPrint;
     hipGraphKernelNodeCopyAttributes;
     hipGraphNodeGetEnabled;

--- a/projects/clr/hipamd/src/hip_intercept.cpp
+++ b/projects/clr/hipamd/src/hip_intercept.cpp
@@ -8,6 +8,8 @@
 #include "hip_internal.hpp"
 #include "hip_platform.hpp"
 #include "hip_prof_api.h"
+#include "platform/clr_prof_event_bus.hpp"
+#include "platform/clr_prof_interface.h"
 
 // HIP API callback/activity
 namespace hip {
@@ -35,7 +37,61 @@ const char* hipApiName(uint32_t id) { return hip_api_name(id); }
 
 }  // namespace hip
 
+// ---------------------------------------------------------------------------
+// Legacy compatibility: hipRegisterTracerCallback
+//
+// Kept so that roctracer (and any other tool using the old single-callback
+// protocol) continues to work unchanged.  Internally this now routes through
+// the EventBus legacy shim, which bridges the old protocol to the new typed
+// event stream.  This means both old (roctracer) and new (clr_prof_subscribe)
+// subscribers can coexist in the same process.
+// ---------------------------------------------------------------------------
 extern "C" void hipRegisterTracerCallback(int (*function)(activity_domain_t domain,
                                                           uint32_t operation_id, void* data)) {
+  // Keep the raw pointer for the legacy emit path in activity.cpp so that
+  // roctracer's pool/buffer machinery (CommitRecord sentinel, etc.) still works.
   amd::activity_prof::report_activity.store(function, std::memory_order_release);
+  // Also wire it through the EventBus so CLR-level IsEnabled() can use the
+  // subscriber-count fast path even for legacy tools.
+  amd::clr_prof::EventBus::instance().set_legacy_callback(function);
 }
+
+// ---------------------------------------------------------------------------
+// clr_prof C API — forwarded to the EventBus implementation in
+// clr_prof_event_bus.cpp (compiled into rocclr, linked into libamdhip64).
+// These symbols are exported in hip_hcc.map.in / amdhip.def.
+// ---------------------------------------------------------------------------
+extern "C" {
+
+clr_prof_subscriber_t clr_prof_subscribe(const clr_prof_callbacks_t*  callbacks,
+                                          const clr_prof_api_filter_t* filter) {
+  return amd::clr_prof::EventBus::instance().subscribe(callbacks, filter);
+}
+
+void clr_prof_unsubscribe(clr_prof_subscriber_t subscriber) {
+  amd::clr_prof::EventBus::instance().unsubscribe(subscriber);
+}
+
+uint64_t clr_prof_get_correlation_id(void) {
+  return amd::activity_prof::correlation_id;
+}
+
+const char* clr_prof_api_name(uint32_t api_id) {
+  return hip_api_name(api_id);
+}
+
+const char* clr_prof_gpu_op_name(clr_prof_gpu_op_t op) {
+  switch (op) {
+    case CLR_PROF_OP_KERNEL_DISPATCH: return "KernelDispatch";
+    case CLR_PROF_OP_MEMCPY:          return "MemCopy";
+    case CLR_PROF_OP_BARRIER:         return "Barrier";
+    default:                          return "Unknown";
+  }
+}
+
+void clr_prof_version(uint32_t* major, uint32_t* minor) {
+  if (major) *major = CLR_PROF_VERSION_MAJOR;
+  if (minor) *minor = CLR_PROF_VERSION_MINOR;
+}
+
+}  // extern "C"

--- a/projects/clr/hipamd/src/hip_prof_api.h
+++ b/projects/clr/hipamd/src/hip_prof_api.h
@@ -9,13 +9,39 @@
 
 #include <atomic>
 #include <cassert>
+#include <ctime>
 #include <iostream>
 #include <shared_mutex>
 #include <utility>
 
+#if defined(__linux__)
+#  include <unistd.h>
+#  include <sys/syscall.h>
+#endif
+
 #include "hip/amd_detail/hip_prof_str.h"
+#include "platform/clr_prof_event_bus.hpp"
+#include "platform/clr_prof_interface.h"
 #include "platform/prof_protocol.h"
 
+namespace {
+inline uint64_t clr_prof_clock_ns() noexcept {
+  struct timespec ts{};
+  clock_gettime(CLOCK_MONOTONIC, &ts);
+  return static_cast<uint64_t>(ts.tv_sec) * 1'000'000'000ULL +
+         static_cast<uint64_t>(ts.tv_nsec);
+}
+inline uint32_t clr_prof_tid() noexcept {
+#if defined(__linux__)
+  return static_cast<uint32_t>(syscall(SYS_gettid));
+#else
+  return 0;
+#endif
+}
+}  // namespace
+
+// hip_api_trace_data_t is kept for the legacy roctracer path.  When the
+// EventBus path is active, it is not used.
 struct hip_api_trace_data_t {
   hip_api_data_t api_data;
   uint64_t phase_enter_timestamp;
@@ -36,27 +62,85 @@ template <hip_api_id_t operation_id> class api_callbacks_spawner_t {
     static_assert(operation_id >= HIP_API_ID_FIRST && operation_id <= HIP_API_ID_LAST,
                   "invalid HIP_API operation id");
 
+    auto& bus = amd::clr_prof::EventBus::instance();
+
+    // ── New path: EventBus ─────────────────────────────────────────────────
+    new_enabled_ = bus.api_enabled(static_cast<uint32_t>(operation_id));
+    if (new_enabled_) {
+      // Allocate a CLR-owned correlation ID for this call.
+      correlation_id_ = amd::clr_prof::EventBus::next_correlation_id();
+      // Write it to the TLS slot so GPU commands created during this call
+      // pick it up automatically.
+      amd::activity_prof::correlation_id = correlation_id_;
+
+      // Populate and emit the ENTER record.
+      // api_args will be set below after init_cb_args_data(); we emit after
+      // args are populated so subscribers see them on ENTER.
+      enter_record_.struct_size    = sizeof(clr_prof_api_record_t);
+      enter_record_.phase          = CLR_PROF_PHASE_ENTER;
+      enter_record_.api_id         = static_cast<uint32_t>(operation_id);
+      enter_record_.correlation_id = correlation_id_;
+      enter_record_.timestamp_ns   = clr_prof_clock_ns();
+      enter_record_.pid            = static_cast<uint32_t>(getpid());
+      enter_record_.tid            = clr_prof_tid();
+      enter_record_.api_args       = nullptr;  // set after init below
+
+      init_cb_args_data(new_api_data_);
+      enter_record_.api_args = &new_api_data_;
+      bus.emit_api(enter_record_);
+    }
+
+    // ── Legacy path: roctracer callback ────────────────────────────────────
     if (auto function = amd::activity_prof::report_activity.load(std::memory_order_acquire);
         function &&
-        (enabled_ = function(ACTIVITY_DOMAIN_HIP_API, operation_id, &trace_data_) == 0)) {
-      amd::activity_prof::correlation_id = trace_data_.api_data.correlation_id;
+        (legacy_enabled_ = function(ACTIVITY_DOMAIN_HIP_API, operation_id, &trace_data_) == 0)) {
+      // If the EventBus already set a correlation ID, don't overwrite it;
+      // otherwise adopt the roctracer-provided one.
+      if (!new_enabled_)
+        amd::activity_prof::correlation_id = trace_data_.api_data.correlation_id;
 
       if (trace_data_.phase_enter != nullptr) {
-        init_cb_args_data(trace_data_.api_data);
+        if (!new_enabled_) init_cb_args_data(trace_data_.api_data);
         trace_data_.phase_enter(operation_id, &trace_data_);
       }
     }
   }
 
   ~api_callbacks_spawner_t() {
-    if (enabled_) {
-      if (trace_data_.phase_exit != nullptr) trace_data_.phase_exit(operation_id, &trace_data_);
-      amd::activity_prof::correlation_id = 0;
+    auto& bus = amd::clr_prof::EventBus::instance();
+
+    // ── New path: emit EXIT ────────────────────────────────────────────────
+    if (new_enabled_) {
+      clr_prof_api_record_t exit_rec{};
+      exit_rec.struct_size    = sizeof(clr_prof_api_record_t);
+      exit_rec.phase          = CLR_PROF_PHASE_EXIT;
+      exit_rec.api_id         = static_cast<uint32_t>(operation_id);
+      exit_rec.correlation_id = correlation_id_;
+      exit_rec.timestamp_ns   = clr_prof_clock_ns();
+      exit_rec.pid            = enter_record_.pid;
+      exit_rec.tid            = enter_record_.tid;
+      exit_rec.api_args       = nullptr;  // args not available at exit
+      bus.emit_api(exit_rec);
     }
+
+    // ── Legacy path: roctracer exit callback ───────────────────────────────
+    if (legacy_enabled_) {
+      if (trace_data_.phase_exit != nullptr) trace_data_.phase_exit(operation_id, &trace_data_);
+    }
+
+    // Clear TLS correlation ID when both paths are done.
+    if (new_enabled_ || legacy_enabled_) amd::activity_prof::correlation_id = 0;
   }
 
  private:
-  bool enabled_{false};
+  // New-path state.
+  bool                  new_enabled_{false};
+  uint64_t              correlation_id_{0};
+  clr_prof_api_record_t enter_record_{};
+  hip_api_data_t        new_api_data_{};
+
+  // Legacy-path state.
+  bool legacy_enabled_{false};
   union {
     hip_api_trace_data_t trace_data_;
   };

--- a/projects/clr/rocclr/cmake/ROCclr.cmake
+++ b/projects/clr/rocclr/cmake/ROCclr.cmake
@@ -57,6 +57,8 @@ target_sources(rocclr PRIVATE
   ${ROCCLR_SRC_DIR}/os/os_win32.cpp
   ${ROCCLR_SRC_DIR}/os/os.cpp
   ${ROCCLR_SRC_DIR}/platform/activity.cpp
+  ${ROCCLR_SRC_DIR}/platform/clr_prof_event_bus.cpp
+  ${ROCCLR_SRC_DIR}/platform/clr_prof_writer.cpp
   ${ROCCLR_SRC_DIR}/platform/agent.cpp
   ${ROCCLR_SRC_DIR}/platform/command.cpp
   ${ROCCLR_SRC_DIR}/platform/commandqueue.cpp

--- a/projects/clr/rocclr/platform/activity.cpp
+++ b/projects/clr/rocclr/platform/activity.cpp
@@ -5,6 +5,7 @@
  */
 
 #include "platform/activity.hpp"
+#include "platform/clr_prof_event_bus.hpp"
 #include "platform/command.hpp"
 #include "platform/commandqueue.hpp"
 #include "platform/command_utils.hpp"
@@ -22,8 +23,11 @@ decltype(report_activity) report_activity{nullptr};
 static void* const kCommitRecordSentinel = reinterpret_cast<void*>(uintptr_t{1});
 
 void CommitRecord(OpId operation_id) {
+  // Legacy path: signal roctracer via the old sentinel protocol.
   auto function = report_activity.load(std::memory_order_acquire);
   if (function) function(ACTIVITY_DOMAIN_HIP_OPS, operation_id, kCommitRecordSentinel);
+  // New path: no commit-record concept; the EventBus delivers records directly
+  // on GPU completion without a pre-commitment step.
 }
 
 #if defined(__linux__)
@@ -40,79 +44,121 @@ static inline size_t linearSize(const amd::Coord3D& size3d) {
 }
 
 bool IsEnabled(OpId operation_id) {
-  if (operation_id < OP_ID_NUMBER)
-    if (auto report = report_activity.load(std::memory_order_acquire))
-      return report(ACTIVITY_DOMAIN_HIP_OPS, operation_id, nullptr) == 0;
+  if (operation_id >= OP_ID_NUMBER) return false;
+  // New path: check the EventBus subscriber count (O(1), no callback).
+  if (amd::clr_prof::EventBus::instance().gpu_activity_enabled()) return true;
+  // Legacy path: probe the roctracer callback with data=nullptr.
+  if (auto report = report_activity.load(std::memory_order_acquire))
+    return report(ACTIVITY_DOMAIN_HIP_OPS, operation_id, nullptr) == 0;
   return false;
+}
+
+// Build a clr_prof_gpu_record_t from a completed command and emit it to the
+// EventBus.  Also forward to the legacy roctracer callback when registered.
+static void EmitGpuRecord(const amd::Command& command, activity_op_t operation_id,
+                           uint64_t begin_ns, uint64_t end_ns,
+                           const char* kernel_name, size_t bytes,
+                           int device_id, uint64_t queue_id) {
+  auto& bus = amd::clr_prof::EventBus::instance();
+
+  // ── New path: EventBus ───────────────────────────────────────────────────
+  if (bus.gpu_activity_enabled()) {
+    clr_prof_gpu_record_t rec{};
+    rec.struct_size    = sizeof(clr_prof_gpu_record_t);
+    rec.op             = static_cast<clr_prof_gpu_op_t>(operation_id);
+    rec.correlation_id = command.profilingInfo().correlation_id_;
+    rec.begin_ns       = begin_ns;
+    rec.end_ns         = end_ns;
+    rec.device_id      = device_id;
+    rec.queue_id       = queue_id;
+    if (operation_id == OP_ID_DISPATCH)
+      rec.kernel_name = kernel_name;
+    else
+      rec.bytes = bytes;
+    bus.emit_gpu(rec);
+  }
+
+  // ── Legacy path: roctracer callback ─────────────────────────────────────
+  auto function = report_activity.load(std::memory_order_acquire);
+  if (function) {
+    activity_record_t legacy{};
+    legacy.domain         = ACTIVITY_DOMAIN_HIP_OPS;
+    legacy.kind           = command.type();
+    legacy.op             = operation_id;
+    legacy.correlation_id = command.profilingInfo().correlation_id_;
+    legacy.begin_ns       = begin_ns;
+    legacy.end_ns         = end_ns;
+    legacy.device_id      = device_id;
+    legacy.queue_id       = queue_id;
+    if (operation_id == OP_ID_DISPATCH)
+      legacy.kernel_name = kernel_name;
+    else
+      legacy.bytes = bytes;
+    function(ACTIVITY_DOMAIN_HIP_OPS, operation_id, &legacy);
+  }
 }
 
 void ReportActivity(const amd::Command& command) {
   assert(command.profilingInfo().enabled_ && "Profiling must be enabled for this command");
   activity_op_t operation_id = OperationId(command.type());
   if (operation_id >= OP_ID_NUMBER) {
-    // This command does not translate into a profiler activity (dispatch, memcopy, etc...), there
-    // is nothing to report to the profiler.
+    // This command does not translate into a profiler activity; nothing to report.
     return;
   }
 
-  auto function = report_activity.load(std::memory_order_acquire);
-  if (!function) return;
+  // Early-out when nothing is listening (fast path).
+  bool has_new = amd::clr_prof::EventBus::instance().gpu_activity_enabled();
+  bool has_legacy = report_activity.load(std::memory_order_acquire) != nullptr;
+  if (!has_new && !has_legacy) return;
 
   const auto* queue = command.queue();
   assert(queue != nullptr);
-  activity_record_t record{
-      ACTIVITY_DOMAIN_HIP_OPS,                  // activity domain
-      command.type(),                           // activity kind
-      operation_id,                             // operation id
-      command.profilingInfo().correlation_id_,  // activity correlation id
-      command.profilingInfo().start_,           // begin timestamp, ns
-      command.profilingInfo().end_,             // end timestamp, ns
-      {{
-          static_cast<int>(queue->device().info().driverNodeId_),  // device id
-          queue->vdev()->index()                                   // queue id
-      }},
-      {}  // copied data size for memcpy, or kernel name for dispatch
-  };
+
+  const int      device_id = static_cast<int>(queue->device().info().driverNodeId_);
+  const uint64_t queue_id  = queue->vdev()->index();
+
+  const char* kernel_name = nullptr;
+  size_t      bytes       = 0;
 
   switch (command.type()) {
     case CL_COMMAND_NDRANGE_KERNEL:
-      record.kernel_name =
+      kernel_name =
           static_cast<const amd::NDRangeKernelCommand&>(command).kernel().name().c_str();
       break;
     case CL_COMMAND_READ_BUFFER:
     case CL_COMMAND_READ_BUFFER_RECT:
-      record.bytes = linearSize(static_cast<const amd::ReadMemoryCommand&>(command).size());
+      bytes = linearSize(static_cast<const amd::ReadMemoryCommand&>(command).size());
       break;
     case CL_COMMAND_WRITE_BUFFER:
     case CL_COMMAND_WRITE_BUFFER_RECT:
-      record.bytes = linearSize(static_cast<const amd::WriteMemoryCommand&>(command).size());
+      bytes = linearSize(static_cast<const amd::WriteMemoryCommand&>(command).size());
       break;
     case CL_COMMAND_COPY_BUFFER:
     case CL_COMMAND_COPY_BUFFER_RECT:
-      record.bytes = linearSize(static_cast<const amd::CopyMemoryCommand&>(command).size());
+      bytes = linearSize(static_cast<const amd::CopyMemoryCommand&>(command).size());
       break;
     case CL_COMMAND_FILL_BUFFER:
-      record.bytes = linearSize(static_cast<const amd::FillMemoryCommand&>(command).size());
+      bytes = linearSize(static_cast<const amd::FillMemoryCommand&>(command).size());
       break;
     default:
       break;
   }
 
   if (command.type() == CL_COMMAND_TASK) {
+    // Batched graph commands: each sub-kernel has its own timestamp pair.
     auto timestamps = static_cast<const amd::AccumulateCommand&>(command).getTimestamps();
     const auto& kernel_names =
         static_cast<const amd::AccumulateCommand&>(command).getKernelNames();
-    for (uint32_t i = 0; i < timestamps.size() && i < kernel_names.size(); i++) {
-      auto it = timestamps[i];
-      record.begin_ns = it.first;
-      record.end_ns = it.second;
-      record.kernel_name = kernel_names[i] != nullptr ? kernel_names[i]->c_str() : "";
-      function(ACTIVITY_DOMAIN_HIP_OPS, operation_id, &record);
+    for (uint32_t i = 0; i < timestamps.size() && i < kernel_names.size(); ++i) {
+      const char* kn = kernel_names[i] != nullptr ? kernel_names[i]->c_str() : "";
+      EmitGpuRecord(command, operation_id,
+                    timestamps[i].first, timestamps[i].second,
+                    kn, 0, device_id, queue_id);
     }
   } else {
-    record.begin_ns = command.profilingInfo().start_;
-    record.end_ns = command.profilingInfo().end_;
-    function(ACTIVITY_DOMAIN_HIP_OPS, operation_id, &record);
+    EmitGpuRecord(command, operation_id,
+                  command.profilingInfo().start_, command.profilingInfo().end_,
+                  kernel_name, bytes, device_id, queue_id);
   }
 }
 

--- a/projects/clr/rocclr/platform/activity.hpp
+++ b/projects/clr/rocclr/platform/activity.hpp
@@ -24,9 +24,20 @@ enum OpId { OP_ID_DISPATCH = 0, OP_ID_COPY = 1, OP_ID_BARRIER = 2, OP_ID_NUMBER 
 
 namespace amd::activity_prof {
 
+// ---------------------------------------------------------------------------
+// Legacy single-callback pointer — kept for backward compatibility with
+// roctracer's hipRegisterTracerCallback() path.  New code should use the
+// clr_prof EventBus (clr_prof_event_bus.hpp) and the public C API
+// (clr_prof_interface.h) instead.
+// ---------------------------------------------------------------------------
 extern std::atomic<int (*)(activity_domain_t domain, uint32_t operation_id, void* data)>
     report_activity;
 
+// Thread-local correlation ID.
+// * Legacy path: written by api_callbacks_spawner_t from the value roctracer
+//   injects via hip_api_trace_data_t::api_data.correlation_id.
+// * New path: written by api_callbacks_spawner_t from the CLR-owned counter
+//   (EventBus::next_correlation_id()), making roctracer unnecessary.
 #if defined(__linux__)
 extern __thread activity_correlation_id_t correlation_id __attribute__((tls_model("initial-exec")));
 #elif defined(_WIN32)

--- a/projects/clr/rocclr/platform/clr_prof_event_bus.cpp
+++ b/projects/clr/rocclr/platform/clr_prof_event_bus.cpp
@@ -1,0 +1,283 @@
+/*
+ * Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#include "platform/clr_prof_event_bus.hpp"
+#include "platform/clr_prof_interface.h"
+#include "platform/prof_protocol.h"
+
+#include <cassert>
+#include <cstring>
+
+namespace amd::clr_prof {
+
+/* ── Static members ─────────────────────────────────────────────────────── */
+
+std::atomic<uint64_t> EventBus::correlation_id_counter_{0};
+
+/* ── Singleton ──────────────────────────────────────────────────────────── */
+
+EventBus& EventBus::instance() {
+  static EventBus bus;
+  return bus;
+}
+
+/* ── subscribe ──────────────────────────────────────────────────────────── */
+
+clr_prof_subscriber_t EventBus::subscribe(const clr_prof_callbacks_t*  cbs,
+                                           const clr_prof_api_filter_t* filter) {
+  if (!cbs || cbs->struct_size < sizeof(clr_prof_callbacks_t)) return nullptr;
+
+  std::unique_lock lock(mutex_);
+
+  // Find a free slot.
+  SubscriberSlot* slot = nullptr;
+  for (auto& s : slots_) {
+    if (!s.active.load(std::memory_order_relaxed)) {
+      slot = &s;
+      break;
+    }
+  }
+  if (!slot) return nullptr;  // All slots occupied.
+
+  // Copy callbacks.
+  slot->cbs = *cbs;
+
+  // Apply API filter if provided.
+  slot->api_filter.reset();
+  slot->filter_active = false;
+  if (filter && filter->struct_size >= sizeof(clr_prof_api_filter_t) && filter->api_ids &&
+      filter->count > 0) {
+    slot->filter_active = true;
+    for (uint32_t i = 0; i < filter->count; ++i) {
+      uint32_t id = filter->api_ids[i];
+      if (id < kMaxApiIds) slot->api_filter.set(id);
+    }
+  }
+
+  // Mark active before updating reference counts so emit_* can't race.
+  slot->active.store(true, std::memory_order_release);
+
+  // Update fast-path counters.
+  if (slot->cbs.gpu_activity) gpu_subscriber_count_.fetch_add(1, std::memory_order_relaxed);
+
+  if (slot->cbs.hip_api) {
+    if (!slot->filter_active) {
+      // All APIs.
+      for (auto& cnt : api_subscriber_counts_) cnt.fetch_add(1, std::memory_order_relaxed);
+    } else {
+      for (size_t i = 0; i < kMaxApiIds; ++i) {
+        if (slot->api_filter.test(i))
+          api_subscriber_counts_[i].fetch_add(1, std::memory_order_relaxed);
+      }
+    }
+  }
+
+  return reinterpret_cast<clr_prof_subscriber_t>(slot);
+}
+
+/* ── unsubscribe ────────────────────────────────────────────────────────── */
+
+void EventBus::unsubscribe(clr_prof_subscriber_t handle) {
+  if (!handle) return;
+  auto* slot = reinterpret_cast<SubscriberSlot*>(handle);
+
+  std::unique_lock lock(mutex_);
+
+  // Validate the slot belongs to our array.
+  if (slot < slots_.data() || slot >= slots_.data() + kMaxSubscribers) return;
+  if (!slot->active.load(std::memory_order_relaxed)) return;
+
+  // Decrement fast-path counters before clearing.
+  if (slot->cbs.gpu_activity) gpu_subscriber_count_.fetch_sub(1, std::memory_order_relaxed);
+
+  if (slot->cbs.hip_api) {
+    if (!slot->filter_active) {
+      for (auto& cnt : api_subscriber_counts_) cnt.fetch_sub(1, std::memory_order_relaxed);
+    } else {
+      for (size_t i = 0; i < kMaxApiIds; ++i) {
+        if (slot->api_filter.test(i))
+          api_subscriber_counts_[i].fetch_sub(1, std::memory_order_relaxed);
+      }
+    }
+  }
+
+  // Clear the slot.  The write lock ensures no emit_* is mid-iteration.
+  slot->active.store(false, std::memory_order_release);
+  slot->cbs = {};
+  slot->api_filter.reset();
+  slot->filter_active = false;
+
+  if (legacy_slot_idx_ >= 0 && &slots_[legacy_slot_idx_] == slot) legacy_slot_idx_ = -1;
+}
+
+/* ── api_enabled ────────────────────────────────────────────────────────── */
+
+bool EventBus::api_enabled(uint32_t api_id) const noexcept {
+  if (api_id >= kMaxApiIds) return false;
+  return api_subscriber_counts_[api_id].load(std::memory_order_acquire) > 0;
+}
+
+/* ── emit_gpu ────────────────────────────────────────────────────────────── */
+
+void EventBus::emit_gpu(const clr_prof_gpu_record_t& record) {
+  std::shared_lock lock(mutex_);
+  for (auto& slot : slots_) {
+    if (slot.active.load(std::memory_order_acquire) && slot.cbs.gpu_activity) {
+      slot.cbs.gpu_activity(&record, slot.cbs.user_data);
+    }
+  }
+}
+
+/* ── emit_api ────────────────────────────────────────────────────────────── */
+
+void EventBus::emit_api(const clr_prof_api_record_t& record) {
+  std::shared_lock lock(mutex_);
+  for (auto& slot : slots_) {
+    if (slot.active.load(std::memory_order_acquire) && slot.cbs.hip_api &&
+        slot.api_enabled(record.api_id)) {
+      slot.cbs.hip_api(&record, slot.cbs.user_data);
+    }
+  }
+}
+
+/* ── emit_code_object ────────────────────────────────────────────────────── */
+
+void EventBus::emit_code_object(const clr_prof_code_object_record_t& record) {
+  std::shared_lock lock(mutex_);
+  for (auto& slot : slots_) {
+    if (slot.active.load(std::memory_order_acquire) && slot.cbs.code_object) {
+      slot.cbs.code_object(&record, slot.cbs.user_data);
+    }
+  }
+}
+
+/* ── emit_queue ──────────────────────────────────────────────────────────── */
+
+void EventBus::emit_queue(const clr_prof_queue_record_t& record) {
+  std::shared_lock lock(mutex_);
+  for (auto& slot : slots_) {
+    if (slot.active.load(std::memory_order_acquire) && slot.cbs.queue) {
+      slot.cbs.queue(&record, slot.cbs.user_data);
+    }
+  }
+}
+
+/* ── Legacy shim ─────────────────────────────────────────────────────────── */
+
+namespace {
+
+// State for the legacy shim subscriber.
+struct LegacyShimState {
+  int (*fn)(activity_domain_t domain, uint32_t op, void* data){nullptr};
+
+  // Sentinel value used by the old protocol to signal record commitment.
+  static void* const kCommitSentinel;
+
+  // Called at api_callbacks_spawner_t construction time via emit_api ENTER.
+  // We reconstruct a hip_api_trace_data_t and call fn(ACTIVITY_DOMAIN_HIP_API, ...).
+  // The legacy callback expects to return phase_enter/phase_exit function pointers
+  // embedded in a hip_api_trace_data_t.  We approximate this by providing
+  // pass-through phase functions that call back into the legacy fn.
+  // NOTE: This is a best-effort bridge; tools that rely on fine-grained
+  // hip_api_trace_data_t fields should migrate to the new interface.
+};
+void* const LegacyShimState::kCommitSentinel = reinterpret_cast<void*>(uintptr_t{1});
+
+// Thread-local storage for the per-call legacy trace data (mirrors the old
+// hip_prof_api.h approach).
+thread_local struct {
+  bool     enabled{false};
+  uint32_t api_id{0};
+} tls_legacy_api{};
+
+void legacy_gpu_cb(const clr_prof_gpu_record_t* rec, void* ud) {
+  auto* state = static_cast<LegacyShimState*>(ud);
+  if (!state->fn) return;
+
+  // Reconstruct an activity_record_t for the legacy callback.
+  activity_record_t legacy{};
+  legacy.domain         = ACTIVITY_DOMAIN_HIP_OPS;
+  legacy.op             = static_cast<activity_op_t>(rec->op);
+  legacy.correlation_id = rec->correlation_id;
+  legacy.begin_ns       = rec->begin_ns;
+  legacy.end_ns         = rec->end_ns;
+  legacy.device_id      = rec->device_id;
+  legacy.queue_id       = rec->queue_id;
+  if (rec->op == CLR_PROF_OP_KERNEL_DISPATCH)
+    legacy.kernel_name = rec->kernel_name;
+  else
+    legacy.bytes = rec->bytes;
+
+  state->fn(ACTIVITY_DOMAIN_HIP_OPS, static_cast<uint32_t>(rec->op), &legacy);
+}
+
+void legacy_api_cb(const clr_prof_api_record_t* rec, void* ud) {
+  auto* state = static_cast<LegacyShimState*>(ud);
+  if (!state->fn) return;
+  // The legacy protocol for HIP API uses the report_activity callback with a
+  // hip_api_trace_data_t*.  Since the new interface separates enter/exit, we
+  // call the legacy fn once with phase embedded in api_data.  Legacy tools
+  // that inspect phase_enter/phase_exit pointers must migrate; this shim
+  // delivers the minimum expected signal.
+  state->fn(ACTIVITY_DOMAIN_HIP_API, rec->api_id, nullptr);
+}
+
+}  // namespace
+
+// One static shim state per process — only one legacy callback can be active.
+static LegacyShimState g_legacy_shim_state{};
+
+void EventBus::set_legacy_callback(int (*fn)(activity_domain_t domain, uint32_t op, void* data)) {
+  std::unique_lock lock(mutex_);
+
+  // Remove existing legacy slot if present.
+  if (legacy_slot_idx_ >= 0) {
+    auto& old = slots_[legacy_slot_idx_];
+    if (old.cbs.gpu_activity)
+      gpu_subscriber_count_.fetch_sub(1, std::memory_order_relaxed);
+    if (old.cbs.hip_api)
+      for (auto& cnt : api_subscriber_counts_) cnt.fetch_sub(1, std::memory_order_relaxed);
+    old.active.store(false, std::memory_order_release);
+    old.cbs = {};
+    legacy_slot_idx_ = -1;
+  }
+
+  if (!fn) return;
+
+  // Find a free slot for the legacy shim.
+  SubscriberSlot* slot = nullptr;
+  int idx = 0;
+  for (auto& s : slots_) {
+    if (!s.active.load(std::memory_order_relaxed)) {
+      slot = &s;
+      break;
+    }
+    ++idx;
+  }
+  if (!slot) return;  // No room.
+
+  g_legacy_shim_state.fn = fn;
+
+  slot->cbs.struct_size  = sizeof(clr_prof_callbacks_t);
+  slot->cbs.gpu_activity = legacy_gpu_cb;
+  slot->cbs.hip_api      = legacy_api_cb;
+  slot->cbs.user_data    = &g_legacy_shim_state;
+  slot->filter_active    = false;
+  slot->api_filter.reset();
+
+  slot->active.store(true, std::memory_order_release);
+  legacy_slot_idx_ = idx;
+
+  gpu_subscriber_count_.fetch_add(1, std::memory_order_relaxed);
+  for (auto& cnt : api_subscriber_counts_) cnt.fetch_add(1, std::memory_order_relaxed);
+}
+
+}  // namespace amd::clr_prof
+// The public C API entry points (clr_prof_subscribe, clr_prof_unsubscribe,
+// clr_prof_get_correlation_id, clr_prof_api_name, clr_prof_gpu_op_name,
+// clr_prof_version) are defined in hipamd/src/hip_intercept.cpp so they
+// are part of libamdhip64 and can be exported from hip_hcc.map.in.
+// rocclr (this file) is a static library; it cannot directly export symbols.

--- a/projects/clr/rocclr/platform/clr_prof_event_bus.hpp
+++ b/projects/clr/rocclr/platform/clr_prof_event_bus.hpp
@@ -1,0 +1,162 @@
+/*
+ * Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+/**
+ * @file clr_prof_event_bus.hpp
+ * @brief Internal CLR profiling event bus.
+ *
+ * The EventBus is the single authoritative source of profiling events inside
+ * CLR.  It replaces the single-callback report_activity atomic with a
+ * multi-subscriber, typed publish/subscribe system.
+ *
+ * Callers inside CLR use the static emit_* methods directly.  External clients
+ * use the C API in clr_prof_interface.h, which forwards to these methods.
+ */
+
+#pragma once
+
+#include "platform/clr_prof_interface.h"
+
+#include <array>
+#include <atomic>
+#include <bitset>
+#include <cstdint>
+#include <memory>
+#include <shared_mutex>
+
+// Forward declare to avoid pulling in the whole command headers here.
+namespace amd {
+class Command;
+}
+
+namespace amd::clr_prof {
+
+/* ── Constants ────────────────────────────────────────────────────────────── */
+
+/// Maximum number of concurrently registered subscribers.
+static constexpr size_t kMaxSubscribers = 16;
+
+/// Total number of HIP API IDs (from hip_api_id_t; keep in sync with
+/// hip_prof_str.h).  512 covers the current range with room to grow.
+static constexpr size_t kMaxApiIds = 512;
+
+/* ── Subscriber slot ─────────────────────────────────────────────────────── */
+
+struct SubscriberSlot {
+  clr_prof_callbacks_t cbs{};
+  std::bitset<kMaxApiIds> api_filter;  ///< empty == all APIs enabled
+  bool                    filter_active{false};
+  std::atomic<bool>       active{false};
+
+  /// Returns true when this slot should fire for api_id.
+  bool api_enabled(uint32_t api_id) const noexcept {
+    if (!filter_active) return true;
+    return api_id < kMaxApiIds && api_filter.test(api_id);
+  }
+};
+
+/* ── EventBus ────────────────────────────────────────────────────────────── */
+
+class EventBus {
+ public:
+  /// Singleton accessor.
+  static EventBus& instance();
+
+  // Non-copyable, non-movable.
+  EventBus(const EventBus&) = delete;
+  EventBus& operator=(const EventBus&) = delete;
+
+  /* ── Subscription management ──────────────────────────────────────────── */
+
+  /**
+   * Register a new subscriber.  Thread-safe.
+   * Returns a pointer to the slot (used as the opaque handle), or nullptr
+   * if all slots are occupied.
+   */
+  clr_prof_subscriber_t subscribe(const clr_prof_callbacks_t* cbs,
+                                   const clr_prof_api_filter_t* filter);
+
+  /**
+   * Unregister a subscriber.  Blocks until in-flight callbacks complete.
+   * Thread-safe.
+   */
+  void unsubscribe(clr_prof_subscriber_t handle);
+
+  /* ── Event emission (called by CLR internals) ─────────────────────────── */
+
+  /**
+   * Emit a GPU activity record to all interested subscribers.
+   * Called from the HSA signal completion worker thread.
+   */
+  void emit_gpu(const clr_prof_gpu_record_t& record);
+
+  /**
+   * Emit a HIP API enter/exit record to all interested subscribers.
+   * Called synchronously from the application thread.
+   */
+  void emit_api(const clr_prof_api_record_t& record);
+
+  /**
+   * Emit a code-object load/unload record.
+   */
+  void emit_code_object(const clr_prof_code_object_record_t& record);
+
+  /**
+   * Emit a queue create/destroy record.
+   */
+  void emit_queue(const clr_prof_queue_record_t& record);
+
+  /* ── Fast-path query helpers ──────────────────────────────────────────── */
+
+  /// Returns true if at least one subscriber wants GPU activity.
+  bool gpu_activity_enabled() const noexcept {
+    return gpu_subscriber_count_.load(std::memory_order_acquire) > 0;
+  }
+
+  /// Returns true if at least one subscriber wants hip_api callbacks for api_id.
+  bool api_enabled(uint32_t api_id) const noexcept;
+
+  /* ── Correlation ID ───────────────────────────────────────────────────── */
+
+  /**
+   * Allocate a new CLR-owned correlation ID.
+   * Called once per HIP API entry from api_callbacks_spawner_t.
+   */
+  static uint64_t next_correlation_id() noexcept {
+    return correlation_id_counter_.fetch_add(1, std::memory_order_relaxed) + 1;
+  }
+
+  /* ── Legacy shim ──────────────────────────────────────────────────────── */
+
+  /**
+   * Install a roctracer-style legacy callback.  Used by
+   * hipRegisterTracerCallback() for backward compatibility.
+   * Installs a special SubscriberSlot that bridges the new typed events
+   * back to the old single-function protocol.
+   *
+   * Passing nullptr removes the legacy subscriber.
+   */
+  void set_legacy_callback(int (*fn)(activity_domain_t domain, uint32_t op, void* data));
+
+ private:
+  EventBus() = default;
+
+  std::array<SubscriberSlot, kMaxSubscribers> slots_{};
+  mutable std::shared_mutex                   mutex_;
+
+  /// Counts active subscribers that have a gpu_activity callback.
+  std::atomic<int> gpu_subscriber_count_{0};
+  /// Per-API-id count of subscribers that want hip_api callbacks.
+  std::array<std::atomic<int>, kMaxApiIds> api_subscriber_counts_{};
+
+  /// Monotonically increasing correlation ID counter (CLR-owned).
+  static std::atomic<uint64_t> correlation_id_counter_;
+
+  /// Index of the legacy-shim slot (-1 if unused).
+  int legacy_slot_idx_{-1};
+};
+
+}  // namespace amd::clr_prof

--- a/projects/clr/rocclr/platform/clr_prof_interface.h
+++ b/projects/clr/rocclr/platform/clr_prof_interface.h
@@ -1,0 +1,210 @@
+/*
+ * Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+/**
+ * @file clr_prof_interface.h
+ * @brief CLR Native Profiling Interface — stable C ABI
+ *
+ * Provides a direct, roctracer-free profiling interface that any client
+ * (rpd_tracer, rocprofiler, custom tools) can use by subscribing to typed
+ * event callbacks emitted by CLR.
+ *
+ * Versioning: every struct carries a struct_size field that must be set to
+ * sizeof(<struct>) by the caller before passing it to CLR.  CLR uses this
+ * to detect ABI mismatches and to safely skip fields added in future versions.
+ *
+ * Exported from libamdhip64.so.
+ */
+
+#pragma once
+
+#include <stddef.h>
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* ── Version ─────────────────────────────────────────────────────────────── */
+
+#define CLR_PROF_VERSION_MAJOR 1
+#define CLR_PROF_VERSION_MINOR 0
+
+/* ── Opaque subscriber handle ─────────────────────────────────────────────── */
+
+typedef struct clr_prof_subscriber_s* clr_prof_subscriber_t;
+
+/* ── GPU Activity (async, delivered from CLR worker thread) ───────────────── */
+
+typedef enum {
+  CLR_PROF_OP_KERNEL_DISPATCH = 0,
+  CLR_PROF_OP_MEMCPY          = 1,
+  CLR_PROF_OP_BARRIER         = 2,
+} clr_prof_gpu_op_t;
+
+typedef struct {
+  uint32_t          struct_size;    /**< Must be set to sizeof(clr_prof_gpu_record_t). */
+  clr_prof_gpu_op_t op;
+  uint64_t          correlation_id; /**< Links this GPU record to the API record that
+                                         submitted the work. */
+  uint64_t          begin_ns;       /**< GPU hardware start timestamp, nanoseconds. */
+  uint64_t          end_ns;         /**< GPU hardware end timestamp, nanoseconds. */
+  int32_t           device_id;      /**< Driver node (logical device) id. */
+  uint64_t          queue_id;       /**< Queue/stream index on the device. */
+  union {
+    const char* kernel_name;        /**< Valid when op == CLR_PROF_OP_KERNEL_DISPATCH.
+                                         Pointer is valid only during the callback. */
+    size_t bytes;                   /**< Valid when op == CLR_PROF_OP_MEMCPY. */
+  };
+} clr_prof_gpu_record_t;
+
+/**
+ * GPU activity callback.  Invoked from a CLR worker thread after the GPU
+ * completes the operation.  Must not block for extended periods.
+ */
+typedef void (*clr_prof_gpu_activity_cb_t)(const clr_prof_gpu_record_t* record, void* user_data);
+
+/* ── HIP API Tracing (synchronous, in-thread at every HIP call) ───────────── */
+
+typedef enum {
+  CLR_PROF_PHASE_ENTER = 0,
+  CLR_PROF_PHASE_EXIT  = 1,
+} clr_prof_phase_t;
+
+typedef struct {
+  uint32_t          struct_size;    /**< Must be set to sizeof(clr_prof_api_record_t). */
+  clr_prof_phase_t  phase;
+  uint32_t          api_id;         /**< hip_api_id_t value identifying the HIP function. */
+  uint64_t          correlation_id; /**< CLR-managed monotonic ID; same value on enter
+                                         and exit for the same call. */
+  uint64_t          timestamp_ns;   /**< Host clock (CLOCK_MONOTONIC) at enter or exit. */
+  uint32_t          pid;
+  uint32_t          tid;
+  /**
+   * Pointer to the hip_api_data_t argument union for this api_id.
+   * Valid only during the ENTER phase (arguments are populated before the
+   * actual HIP implementation runs).  NULL during EXIT phase.
+   */
+  const void*       api_args;
+} clr_prof_api_record_t;
+
+/**
+ * HIP API callback.  Called synchronously, in the application thread that
+ * issued the HIP call.  Do not call back into HIP from within this callback.
+ */
+typedef void (*clr_prof_api_cb_t)(const clr_prof_api_record_t* record, void* user_data);
+
+/* ── Code Object / Kernel Symbol Events ──────────────────────────────────── */
+
+typedef enum {
+  CLR_PROF_CODE_OBJECT_LOAD   = 0,
+  CLR_PROF_CODE_OBJECT_UNLOAD = 1,
+} clr_prof_code_object_op_t;
+
+typedef struct {
+  uint32_t                   struct_size;
+  clr_prof_code_object_op_t  op;
+  const char*                kernel_name;      /**< Demangled kernel name. */
+  const char*                kernel_name_raw;  /**< Mangled (raw) kernel name. */
+  uint64_t                   base_address;     /**< HSA code object load address. */
+  int32_t                    device_id;
+} clr_prof_code_object_record_t;
+
+typedef void (*clr_prof_code_object_cb_t)(const clr_prof_code_object_record_t* record,
+                                          void* user_data);
+
+/* ── Queue Lifecycle Events ───────────────────────────────────────────────── */
+
+typedef enum {
+  CLR_PROF_QUEUE_CREATE  = 0,
+  CLR_PROF_QUEUE_DESTROY = 1,
+} clr_prof_queue_op_t;
+
+typedef struct {
+  uint32_t            struct_size;
+  clr_prof_queue_op_t op;
+  int32_t             device_id;
+  uint64_t            queue_id;
+} clr_prof_queue_record_t;
+
+typedef void (*clr_prof_queue_cb_t)(const clr_prof_queue_record_t* record, void* user_data);
+
+/* ── Subscriber Callbacks Descriptor ─────────────────────────────────────── */
+
+/**
+ * Fill in only the callbacks you need; set unused pointers to NULL.
+ * CLR skips callbacks that are NULL, so you pay only for what you use.
+ */
+typedef struct {
+  uint32_t                    struct_size; /**< Must be sizeof(clr_prof_callbacks_t). */
+  clr_prof_gpu_activity_cb_t  gpu_activity;
+  clr_prof_api_cb_t           hip_api;
+  clr_prof_code_object_cb_t   code_object;
+  clr_prof_queue_cb_t         queue;
+  void*                       user_data;   /**< Passed as-is to every callback. */
+} clr_prof_callbacks_t;
+
+/* ── API Filter ───────────────────────────────────────────────────────────── */
+
+/**
+ * Restrict which HIP API IDs trigger hip_api callbacks.
+ * Pass NULL to clr_prof_subscribe() to trace all APIs.
+ */
+typedef struct {
+  uint32_t        struct_size;
+  const uint32_t* api_ids; /**< Array of hip_api_id_t values. */
+  uint32_t        count;   /**< Number of entries in api_ids. */
+} clr_prof_api_filter_t;
+
+/* ── Registration ─────────────────────────────────────────────────────────── */
+
+/**
+ * Register a new subscriber.
+ *
+ * @param callbacks  Pointer to a caller-filled clr_prof_callbacks_t.  CLR
+ *                   copies the contents; the caller can free it after return.
+ * @param filter     Optional API filter.  NULL means trace all HIP APIs.
+ * @return           Opaque subscriber handle, or NULL on error.
+ *
+ * Thread-safe.  May be called before or after hipInit().
+ */
+clr_prof_subscriber_t clr_prof_subscribe(const clr_prof_callbacks_t*  callbacks,
+                                          const clr_prof_api_filter_t* filter);
+
+/**
+ * Unregister a subscriber.
+ *
+ * Blocks until any in-flight callbacks for this subscriber have completed,
+ * then removes it.  The handle is invalid after this call.
+ *
+ * Thread-safe.
+ */
+void clr_prof_unsubscribe(clr_prof_subscriber_t subscriber);
+
+/* ── Utilities ────────────────────────────────────────────────────────────── */
+
+/**
+ * Return the CLR-managed correlation ID associated with the current thread.
+ * This is the same value reported in clr_prof_api_record_t::correlation_id
+ * and clr_prof_gpu_record_t::correlation_id.  Useful to correlate external
+ * instrumentation (e.g., roctx markers) with CLR records.
+ *
+ * Returns 0 when no HIP call is in progress on this thread.
+ */
+uint64_t clr_prof_get_correlation_id(void);
+
+/** Human-readable name for a hip_api_id_t value (e.g., "hipLaunchKernel"). */
+const char* clr_prof_api_name(uint32_t api_id);
+
+/** Human-readable name for a clr_prof_gpu_op_t value. */
+const char* clr_prof_gpu_op_name(clr_prof_gpu_op_t op);
+
+/** Populate *major and *minor with the CLR profiling interface version. */
+void clr_prof_version(uint32_t* major, uint32_t* minor);
+
+#ifdef __cplusplus
+}
+#endif

--- a/projects/clr/rocclr/platform/clr_prof_writer.cpp
+++ b/projects/clr/rocclr/platform/clr_prof_writer.cpp
@@ -1,0 +1,215 @@
+/*
+ * Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#include "platform/clr_prof_writer.hpp"
+#include "platform/clr_prof_event_bus.hpp"
+#include "platform/clr_prof_interface.h"
+
+#include <atomic>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <mutex>
+#include <string>
+#include <string_view>
+#include <unistd.h>
+
+namespace amd::clr_prof {
+
+// ---------------------------------------------------------------------------
+// Chrome Trace Event Format writer
+// https://docs.google.com/document/d/1CvAClvFfyA5R-PhYUmn5OOQtYMH4h6I0nSsKchNAySU
+// ---------------------------------------------------------------------------
+
+namespace {
+
+enum class OutputFormat { kNone, kJson };
+
+struct WriterState {
+  FILE*               file{nullptr};
+  OutputFormat        format{OutputFormat::kNone};
+  clr_prof_subscriber_t subscriber{nullptr};
+  std::mutex          mu;
+  bool                first_event{true};  // for JSON comma-separation
+  std::atomic<bool>   finalized{false};
+};
+
+WriterState g_writer;
+
+// ── JSON helpers ─────────────────────────────────────────────────────────────
+
+// Escape a C-string for JSON embedding.
+static std::string JsonEscape(const char* s) {
+  if (!s) return "null";
+  std::string out;
+  out.reserve(std::strlen(s) + 2);
+  for (const char* p = s; *p; ++p) {
+    switch (*p) {
+      case '"':  out += "\\\""; break;
+      case '\\': out += "\\\\"; break;
+      case '\n': out += "\\n";  break;
+      case '\r': out += "\\r";  break;
+      case '\t': out += "\\t";  break;
+      default:   out += *p;
+    }
+  }
+  return out;
+}
+
+// Emit one JSON trace event object.  Caller holds g_writer.mu.
+static void JsonEmitEvent(const char* ph, const char* cat, const char* name,
+                           uint64_t ts_ns, uint64_t dur_ns,
+                           int32_t pid, uint32_t tid, uint64_t id,
+                           const char* extra_key, const char* extra_val) {
+  if (!g_writer.file) return;
+  if (!g_writer.first_event) std::fputs(",\n", g_writer.file);
+  g_writer.first_event = false;
+
+  // Convert ns to µs (Chrome Trace uses microseconds).
+  double ts_us  = static_cast<double>(ts_ns)  / 1e3;
+  double dur_us = static_cast<double>(dur_ns)  / 1e3;
+
+  std::fprintf(g_writer.file,
+               R"({"ph":"%s","cat":"%s","name":"%s","ts":%.3f,"dur":%.3f,"pid":%d,"tid":%u,"id":%llu)",
+               ph, cat, name, ts_us, dur_us, pid, tid,
+               static_cast<unsigned long long>(id));
+
+  if (extra_key && extra_val)
+    std::fprintf(g_writer.file, R"(,"args":{"%s":"%s"})", extra_key, extra_val);
+
+  std::fputc('}', g_writer.file);
+}
+
+// ── Subscriber callbacks ───────────────────────────────────────────────────
+
+// We accumulate API enter timestamps in a simple TLS struct to avoid a map.
+struct ApiEnterInfo {
+  uint64_t timestamp_ns{0};
+  uint32_t pid{0};
+  uint32_t tid{0};
+};
+thread_local ApiEnterInfo tls_api_enter{};
+
+static void OnGpuActivity(const clr_prof_gpu_record_t* rec, void* /*ud*/) {
+  if (!rec || g_writer.finalized.load(std::memory_order_acquire)) return;
+
+  const char* name = clr_prof_gpu_op_name(rec->op);
+  const char* kname = (rec->op == CLR_PROF_OP_KERNEL_DISPATCH && rec->kernel_name)
+                          ? rec->kernel_name
+                          : nullptr;
+  uint64_t dur_ns = (rec->end_ns >= rec->begin_ns) ? rec->end_ns - rec->begin_ns : 0;
+
+  std::string escaped = kname ? JsonEscape(kname) : std::string{};
+
+  std::lock_guard lock(g_writer.mu);
+  if (g_writer.format == OutputFormat::kJson) {
+    JsonEmitEvent("X",  // Complete event (has dur)
+                  "gpu", kname ? escaped.c_str() : name,
+                  rec->begin_ns, dur_ns,
+                  rec->device_id, static_cast<uint32_t>(rec->queue_id),
+                  rec->correlation_id,
+                  kname ? nullptr : nullptr, nullptr);
+  }
+}
+
+static void OnHipApi(const clr_prof_api_record_t* rec, void* /*ud*/) {
+  if (!rec || g_writer.finalized.load(std::memory_order_acquire)) return;
+
+  if (rec->phase == CLR_PROF_PHASE_ENTER) {
+    // Save enter info in TLS; emit the complete event on EXIT when we have dur.
+    tls_api_enter.timestamp_ns = rec->timestamp_ns;
+    tls_api_enter.pid          = rec->pid;
+    tls_api_enter.tid          = rec->tid;
+    return;
+  }
+
+  // EXIT: emit complete event.
+  uint64_t begin_ns = tls_api_enter.timestamp_ns;
+  uint64_t dur_ns   = (rec->timestamp_ns >= begin_ns) ? rec->timestamp_ns - begin_ns : 0;
+  const char* name  = clr_prof_api_name(rec->api_id);
+
+  std::lock_guard lock(g_writer.mu);
+  if (g_writer.format == OutputFormat::kJson) {
+    JsonEmitEvent("X", "hip", name ? name : "unknown",
+                  begin_ns, dur_ns,
+                  static_cast<int32_t>(rec->pid), rec->tid,
+                  rec->correlation_id, nullptr, nullptr);
+  }
+}
+
+}  // namespace
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+void WriterInit() {
+  const char* path = std::getenv("CLR_TRACE_OUTPUT");
+  if (!path || path[0] == '\0') return;
+
+  // Determine format from extension.
+  std::string_view sv(path);
+  OutputFormat fmt = OutputFormat::kNone;
+  if (sv.ends_with(".json"))
+    fmt = OutputFormat::kJson;
+  else if (sv.ends_with(".perfetto"))
+    // Perfetto proto support is a future extension; fall back to JSON for now.
+    fmt = OutputFormat::kJson;
+  else
+    fmt = OutputFormat::kJson;  // Default: treat as JSON.
+
+  FILE* f = std::fopen(path, "w");
+  if (!f) {
+    std::fprintf(stderr, "[CLR] Warning: cannot open trace output file '%s'\n", path);
+    return;
+  }
+
+  {
+    std::lock_guard lock(g_writer.mu);
+    g_writer.file        = f;
+    g_writer.format      = fmt;
+    g_writer.first_event = true;
+    g_writer.finalized.store(false, std::memory_order_relaxed);
+  }
+
+  // Write JSON header.
+  if (fmt == OutputFormat::kJson) std::fputs("{\"traceEvents\":[\n", f);
+
+  // Register with the EventBus.
+  clr_prof_callbacks_t cbs{};
+  cbs.struct_size  = sizeof(cbs);
+  cbs.gpu_activity = OnGpuActivity;
+  cbs.hip_api      = OnHipApi;
+  cbs.user_data    = nullptr;
+
+  g_writer.subscriber = EventBus::instance().subscribe(&cbs, nullptr);
+}
+
+void WriterFini() {
+  if (g_writer.finalized.exchange(true, std::memory_order_acq_rel)) return;
+
+  if (g_writer.subscriber) {
+    EventBus::instance().unsubscribe(g_writer.subscriber);
+    g_writer.subscriber = nullptr;
+  }
+
+  std::lock_guard lock(g_writer.mu);
+  if (!g_writer.file) return;
+
+  if (g_writer.format == OutputFormat::kJson) {
+    // Close the traceEvents array and add metadata.
+    std::fprintf(g_writer.file,
+                 "\n],\n"
+                 "\"displayTimeUnit\":\"ns\",\n"
+                 "\"otherData\":{\"generator\":\"CLR clr_prof built-in writer\"}\n"
+                 "}\n");
+  }
+
+  std::fclose(g_writer.file);
+  g_writer.file = nullptr;
+}
+
+}  // namespace amd::clr_prof

--- a/projects/clr/rocclr/platform/clr_prof_writer.hpp
+++ b/projects/clr/rocclr/platform/clr_prof_writer.hpp
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+/**
+ * @file clr_prof_writer.hpp
+ * @brief Built-in CLR trace writer.
+ *
+ * Activated by setting the environment variable CLR_TRACE_OUTPUT before
+ * launching the application:
+ *
+ *   CLR_TRACE_OUTPUT=trace.json      → Chrome Trace Event Format (JSON)
+ *   CLR_TRACE_OUTPUT=trace.perfetto  → Perfetto proto binary (future)
+ *
+ * The writer registers itself as a clr_prof subscriber during hipInit and
+ * flushes the file on process exit.  Zero overhead when the env var is unset.
+ */
+
+#pragma once
+
+namespace amd::clr_prof {
+
+/**
+ * Initialize the built-in trace writer if CLR_TRACE_OUTPUT is set.
+ * Called once from hipInit.  Idempotent.
+ */
+void WriterInit();
+
+/**
+ * Flush and close the trace file.  Called from hipTearDown / atexit.
+ * Safe to call multiple times (subsequent calls are no-ops).
+ */
+void WriterFini();
+
+}  // namespace amd::clr_prof


### PR DESCRIPTION
Replace the single report_activity atomic callback with a typed, multi-subscriber EventBus (clr_prof_event_bus.hpp/.cpp).

- Add stable C ABI (clr_prof_interface.h) covering GPU activity, HIP API enter/exit, code-object, and queue events with versioned struct_size fields for ABI safety.
- Refactor activity.cpp to emit via EmitGpuRecord(); handle batched graph commands (CL_COMMAND_TASK) with per-kernel timestamps.
- Add legacy shim in EventBus::set_legacy_callback() to bridge existing hipRegisterTracerCallback() users without API breakage.
- Export new clr_prof_subscribe/unsubscribe/etc. symbols from libamdhip64 (hip_hcc.map.in, amdhip.def) via hip_intercept.cpp.
- Wire clr_prof_event_bus.cpp and clr_prof_writer.cpp into ROCclr.cmake.

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
