### PR TITLE
[RCCL][Profiler Plugin] Fix kernelCh StopGpuClk and stopTs not recorded for channels > 0

### DIFF
--- a/projects/rccl/ext-profiler/example/event.h
+++ b/projects/rccl/ext-profiler/example/event.h
@@ -49,7 +49,7 @@ struct netPlugin {
 };
 
 struct kernelCh {
-  uint8_t type;
+  uint64_t type;
   uint8_t channelId;
   struct taskEventBase* parent;
   double startTs;


### PR DESCRIPTION
## Motivation

`kernelCh.type` is declared as `uint8_t` while all other event structs (proxyOp, proxyStep, netPlugin, group, taskEventBase, etc.) use `uint64_t`. 

The plugin reads the type via `*(uint64_t *)handle`, causing the adjacent `channelId` byte to corrupt the type check for all channels except 0.

## Technical Details

Change `kernelCh.type` to `uint64_t` to match all other event structs.

## JIRA ID

AICOMRCCL-860

## Test Plan

Validate with rccl-tests

## Test Result

Before (channel 1, StopGpuClk=0, stopTs=0):

```
{"name": "KernelCh", "cat": "GPU", "ph": "b", "id": 0, "pid": 133789, "tid": 1, "ts": 132410.886963, "args": {"Channel": 1, "StartGpuClk": 198020761006141, "StopGpuClk": 0}},
{"name": "KernelCh", "cat": "GPU", "ph": "e", "id": 0, "pid": 133789, "tid": 1, "ts": 0.000000},
```

After (channel 1, values populated):
```
{"name": "KernelCh", "cat": "GPU", "ph": "b", "id": 0, "pid": 257531, "tid": 1, "ts": 130711.244141, "args": {"Channel": 1, "StartGpuClk": 198127254153647, "StopGpuClk": 198127254178031}},
{"name": "KernelCh", "cat": "GPU", "ph": "e", "id": 0, "pid": 257531, "tid": 1, "ts": 130948.989014},
```
## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
