### PR TITLE
Enable CE collectives support in RCCL

### DIFF
--- a/projects/rccl/src/ce_coll.cc
+++ b/projects/rccl/src/ce_coll.cc
@@ -6,11 +6,13 @@
 
 #include "comm.h"
 #include "register_inline.h"
+#include <algorithm>
 #include <cuda.h>
 #include "rocmwrap.h"
 #include "ce_coll.h"
 #include "alloc.h"
 
+RCCL_PARAM(CeMultiStreams, "CE_MULTI_STREAMS", 0);
 // Static constant for graph synchronization
 static const uint32_t GRAPH_SYNC_VALUE = 1;
 
@@ -20,14 +22,23 @@ static const uint32_t CE_COLL_INTRA_BATCH_SYNC_FREQ = 8;
 // Message threshold for intra-batch synchronization
 static const uint64_t CE_COLL_INTRA_BATCH_SYNC_MSG_THRESHOLD = 512*1024*1024;
 
+static void ceDestroyCopyStreams(struct ncclComm* comm, int nPairs) {
+  for (int j = 0; j < nPairs; j++) {
+    CUDACHECKIGNORE(cudaEventDestroy(comm->ceColl.copyEvents[j]));
+    CUDACHECKIGNORE(cudaStreamDestroy(comm->ceColl.copyStreams[j]));
+  }
+  comm->ceColl.nCopyStreams = 0;
+}
+
 ncclResult_t ncclCeInit(struct ncclComm* comm) {
   ncclResult_t ret = ncclSuccess;
 
-  uint8_t* ceDevBase;
+  uint8_t* ceDevBase = nullptr;
   size_t ceDevBaseSize = alignUp(comm->nRanks*sizeof(uint32_t), 16) * 2;
-  ncclWindow_vidmem* ceWinDev;
-  ncclWindow_vidmem* ceWinDevHost;
-
+  ncclWindow_vidmem* ceWinDev = nullptr;
+  ncclWindow_vidmem* ceWinDevHost = nullptr;
+  int i = 0;
+  int targetStreams = 0;
   // Ensure symmetric memory runtime is initialized
   NCCLCHECKGOTO(ncclDevrInitOnce(comm), ret, fail);
   // Allocate and register memory for the symmetric memory
@@ -45,11 +56,32 @@ ncclResult_t ncclCeInit(struct ncclComm* comm) {
   comm->ceColl.useCompletePtr = false;
   comm->ceColl.intraBatchSyncFreq = CE_COLL_INTRA_BATCH_SYNC_FREQ;
   comm->ceColl.intraBatchSyncMsgThreshold = CE_COLL_INTRA_BATCH_SYNC_MSG_THRESHOLD;
+  comm->ceColl.nCopyStreams = 0;
   INFO(NCCL_INIT, "Init CE, rank %d baseUCSymReadyPtr %p, baseUCSymComplPtr %p, seq num %d", comm->rank, comm->ceColl.baseUCSymReadyPtr, comm->ceColl.baseUCSymComplPtr, comm->ceColl.ceSeqNum);
+  {
+    int multiStreams = rcclParamCeMultiStreams();
+    if (multiStreams > 0) {
+      targetStreams = std::min(multiStreams, (int)RCCL_CE_NUM_COPY_STREAMS);
+      INFO(NCCL_INIT, "CE multi-stream enabled: rank %d using %d streams (requested=%d)", comm->rank, targetStreams, multiStreams);
+      for (i = 0; i < targetStreams; i++) {
+        CUDACHECKGOTO(cudaStreamCreateWithFlags(&comm->ceColl.copyStreams[i], cudaStreamNonBlocking), ret, fail_ce_stream);
+        CUDACHECKGOTO(cudaEventCreateWithFlags(&comm->ceColl.copyEvents[i], cudaEventDisableTiming), ret, fail_ce_event);
+        comm->ceColl.nCopyStreams++;
+      }
+    }
+  }
 
 exit:
   return ret;
+fail_ce_event:
+  CUDACHECKIGNORE(cudaStreamDestroy(comm->ceColl.copyStreams[i]));
+fail_ce_stream:
+  INFO(NCCL_INIT, "CE init failed on rank %d after creating %d/%d copy streams", comm->rank, i, targetStreams);
+  ceDestroyCopyStreams(comm, i);
+  goto fail;
 fail:
+  if (ceWinDev != nullptr) ncclCommWindowDeregister(comm, ceWinDev);
+  if (ceDevBase != nullptr) ncclMemFree(ceDevBase);
   goto exit;
 }
 
@@ -72,6 +104,9 @@ ncclResult_t ncclCeFinalize(struct ncclComm* comm) {
     comm->ceColl.baseUCSymComplPtr = NULL;
     comm->ceColl.ceSyncWin = NULL;
   }
+  // Clean up copy streams and events
+  ceDestroyCopyStreams(comm, comm->ceColl.nCopyStreams);
+
 
 exit:
   return ret;
@@ -83,8 +118,9 @@ bool ncclCeImplemented(ncclFunc_t coll, int/*ncclDevRedOp_t*/ red, ncclDataType_
   int driverVersion;
   if (ncclCudaDriverVersion(&driverVersion) != ncclSuccess) return false;
 
-  // CE is supported in CUDA 12.5 and later
-  if (driverVersion >= 12050) {
+  // CE is supported in ROCm 7.12 and later
+  // hipDriverGetVersion() returns 70200000 for ROCm 7.12
+  if (driverVersion >= 70200000) {
     switch (coll) {
     case ncclFuncAllGather:
     case ncclFuncAlltoAll:
@@ -130,7 +166,7 @@ ncclResult_t ncclPrepMCSync(struct ncclComm* comm, bool isComplete, hipStreamBat
   for (int r = 0; r < comm->nRanks; ++r) {
     if (r == comm->rank) continue;
     batchParams[*opIdx] = {};
-    // batchParams[*opIdx].waitValue.operation = CU_STREAM_MEM_OP_WAIT_VALUE_32;
+    batchParams[*opIdx].waitValue.operation = CU_STREAM_MEM_OP_WAIT_VALUE_32;
     batchParams[*opIdx].waitValue.address = (CUdeviceptr)(isComplete ? (void*)&completePtrs[r] : (void*)&readyPtrs[r]);
     batchParams[*opIdx].waitValue.value = waitValue;
     batchParams[*opIdx].waitValue.flags = CU_STREAM_WAIT_VALUE_EQ;
@@ -163,10 +199,13 @@ ncclResult_t ncclPrepUCSync(struct ncclComm* comm, bool isComplete,
     size_t offset = (uint8_t*)dstPtr - (uint8_t*)comm->ceColl.ceSyncWin->userPtr;
     NCCLCHECKGOTO(ncclDevrGetLsaRankPtr(comm, comm->ceColl.ceSyncWin, offset, r, &peerDstPtr), ret, fail);
     batchParams[*opIdx] = {};
-    // batchParams[*opIdx].writeValue.operation = CU_STREAM_MEM_OP_WRITE_VALUE_32;
+    batchParams[*opIdx].writeValue.operation = CU_STREAM_MEM_OP_WRITE_VALUE_32;
     batchParams[*opIdx].writeValue.address  = (CUdeviceptr)peerDstPtr;
     batchParams[*opIdx].writeValue.value = waitValue;
-    // batchParams[*opIdx].writeValue.flags = CU_STREAM_WRITE_VALUE_DEFAULT;
+    // CU_STREAM_WRITE_VALUE_DEFAULT is a CUDA-specific constant with no HIP equivalent.
+    // This field must be initialized to satisfy the CUDA-compatible struct definition,
+    // but the HIP runtime does not use this flag and treats it as 0.
+    batchParams[*opIdx].writeValue.flags = 0;
     (*opIdx)++;
   }
 
@@ -174,7 +213,7 @@ ncclResult_t ncclPrepUCSync(struct ncclComm* comm, bool isComplete,
   for (int r = 0; r < comm->nRanks; ++r) {
     if (r == comm->rank) continue;
     batchParams[*opIdx] = {};
-    // batchParams[*opIdx].waitValue.operation = CU_STREAM_MEM_OP_WAIT_VALUE_32;
+    batchParams[*opIdx].waitValue.operation = CU_STREAM_MEM_OP_WAIT_VALUE_32;
     batchParams[*opIdx].waitValue.address  = (CUdeviceptr)(isComplete ? (void*)&completePtrs[r] : (void*)&readyPtrs[r]);
     batchParams[*opIdx].waitValue.value = waitValue;
     batchParams[*opIdx].waitValue.flags = CU_STREAM_WAIT_VALUE_EQ;
@@ -213,10 +252,13 @@ ncclResult_t ncclMemOpSync(struct ncclComm* comm, cudaStream_t stream) {
   if (ncclCudaGraphValid(comm->planner.capturingGraph)) {
     for (int i = 0; i < comm->nRanks; i++) {
       batchParams[opIdx] = {};
-      // batchParams[opIdx].writeValue.operation = CU_STREAM_MEM_OP_WRITE_VALUE_32;
+      batchParams[opIdx].writeValue.operation = CU_STREAM_MEM_OP_WRITE_VALUE_32;
       batchParams[opIdx].writeValue.address = (CUdeviceptr)(comm->ceColl.useCompletePtr ? (void*)&completePtrs[i] : (void*)&readyPtrs[i]);
       batchParams[opIdx].writeValue.value = 0;
-      // batchParams[opIdx].writeValue.flags = CU_STREAM_WRITE_VALUE_DEFAULT;
+      // CU_STREAM_WRITE_VALUE_DEFAULT is a CUDA-specific constant with no HIP equivalent.
+      // This field must be initialized to satisfy the CUDA-compatible struct definition,
+      // but the HIP runtime does not use this flag and treats it as 0.
+      batchParams[opIdx].writeValue.flags = 0;
       opIdx++;
     }
   }
@@ -242,7 +284,7 @@ ncclResult_t ncclCeInitBatchOpsParams(struct ncclCeBatchOpsParams* params, int n
   params->sizes = nullptr;
   params->numOps = 0;
   params->intraBatchSync = false;
-#if CUDART_VERSION >= 12080
+#if ROCM_VERSION >= 71200
   params->attrs = nullptr;
   params->attrIdxs = nullptr;
   params->numAttrs = 0;
@@ -251,7 +293,7 @@ ncclResult_t ncclCeInitBatchOpsParams(struct ncclCeBatchOpsParams* params, int n
   NCCLCHECKGOTO(ncclCalloc(&params->srcs, nRanks), ret, fail);
   NCCLCHECKGOTO(ncclCalloc(&params->dsts, nRanks), ret, fail);
   NCCLCHECKGOTO(ncclCalloc(&params->sizes, nRanks), ret, fail);
-#if CUDART_VERSION >= 12080
+#if ROCM_VERSION >= 71200
   NCCLCHECKGOTO(ncclCalloc(&params->attrs, nRanks), ret, fail);
   NCCLCHECKGOTO(ncclCalloc(&params->attrIdxs, nRanks), ret, fail);
 #endif
@@ -265,7 +307,7 @@ void ncclCeFreeBatchOpsParams(struct ncclCeBatchOpsParams* params) {
   if (params->srcs) free(params->srcs);
   if (params->dsts) free(params->dsts);
   if (params->sizes) free(params->sizes);
-#if CUDART_VERSION >= 12080
+#if ROCM_VERSION >= 71200
   if (params->attrs) free(params->attrs);
   if (params->attrIdxs) free(params->attrIdxs);
 #endif
@@ -300,55 +342,74 @@ ncclResult_t ncclCeLaunchBatchOps(struct ncclComm* comm, struct ncclCeBatchOpsPa
         NCCLCHECKGOTO(ncclMemOpSync(comm, stream), ret, fail);
       }
     }
-  }
+  } 
   //--------------No graph capture--------------
   else {
-    if (/*CUDART_VERSION >= 12080 &&*/ driverVersion >= 12080) {
-#if CUDART_VERSION >= 12080
-    // For CUDA 12.8+, use batch memory copy for better performance
-    params->attrs[0] = {};
-    params->attrs[0].srcAccessOrder = cudaMemcpySrcAccessOrderStream;
-    params->attrs[0].flags = cudaMemcpyFlagPreferOverlapWithCompute;
-    params->attrIdxs[0] = 0;
-    params->numAttrs = 1;
+    // driverVersion is reported as 70200000 for ROCm 7.12 when using hipDriverGetVersion().
+    if (ROCM_VERSION >= 71200 && driverVersion >= 70200000) {
+#if ROCM_VERSION >= 71200 
+      // For ROCm 7.12+, use batch memory copy for better performance
+      params->attrs[0] = {};
+      params->attrs[0].srcAccessOrder = cudaMemcpySrcAccessOrderStream;
+      params->attrs[0].flags = cudaMemcpyFlagPreferOverlapWithCompute;
+      params->attrIdxs[0] = 0;
+      params->numAttrs = 1;
 
-    if (params->intraBatchSync) {
-      // Break into multiple batches with sync between them
-      int batchSize = comm->ceColl.intraBatchSyncFreq;
-      for (int i = 0; i < params->numOps; i += batchSize) {
-        int currentBatchSize = (i + batchSize <= params->numOps) ? batchSize : params->numOps - i;
+      if (params->intraBatchSync) {
+        // Break into multiple batches with sync between them
+        int batchSize = comm->ceColl.intraBatchSyncFreq;
+        for (int i = 0; i < params->numOps; i += batchSize) {
+          int currentBatchSize = (i + batchSize <= params->numOps) ? batchSize : params->numOps - i;
+          INFO(NCCL_COLL, "CE: rank %d -> Batch path with intraBatchSync (cudaMemcpyBatchAsync, intraBatchSync), numOps=%zu, batchSize=%d", comm->rank, params->numOps, currentBatchSize);      
+          CUDACHECKGOTO(cudaMemcpyBatchAsync(
+            (void**)&params->dsts[i], (void**)&params->srcs[i], &params->sizes[i], currentBatchSize,
+            params->attrs, params->attrIdxs, params->numAttrs, nullptr, stream), ret, fail);
 
-        #if CUDART_VERSION >= 13000
-        CUDACHECKGOTO(cudaMemcpyBatchAsync(
-          &params->dsts[i], &params->srcs[i], &params->sizes[i], currentBatchSize,
-          params->attrs, params->attrIdxs, params->numAttrs, stream), ret, fail);
-        #else
-        CUDACHECKGOTO(cudaMemcpyBatchAsync(
-          &params->dsts[i], &params->srcs[i], &params->sizes[i], currentBatchSize,
-          params->attrs, params->attrIdxs, params->numAttrs, nullptr, stream), ret, fail);
-        #endif
-
-        // Sync after each batch
-        if (i + batchSize < params->numOps) {
-          NCCLCHECKGOTO(ncclMemOpSync(comm, stream), ret, fail);
+          // Sync after each batch
+          if (i + batchSize < params->numOps) {
+            NCCLCHECKGOTO(ncclMemOpSync(comm, stream), ret, fail);
+          }
         }
+      } else {
+        // Use single batch for all operations
+        INFO(NCCL_COLL, "CE: rank %d -> Batch path without intraBatchSync (cudaMemcpyBatchAsync), numOps=%zu", comm->rank, params->numOps);      
+        CUDACHECKGOTO(cudaMemcpyBatchAsync(
+          (void**)params->dsts, (void**)params->srcs, params->sizes, params->numOps,
+          params->attrs, params->attrIdxs, params->numAttrs, nullptr, stream), ret, fail);
+      }
+#endif
+    } else if (comm->ceColl.nCopyStreams > 0 && (int)params->numOps > 1 && !params->intraBatchSync) {
+
+      int nStreams = comm->ceColl.nCopyStreams;
+      int activeStreams = ((int)params->numOps < nStreams) ? (int)params->numOps : nStreams;
+      INFO(NCCL_COLL, "CE: rank %d -> No-Batch Multi-Stream path (%d streams), numOps=%zu", comm->rank, activeStreams, params->numOps);
+
+      // Make copy streams wait on the main stream
+      for (int s = 0; s < activeStreams; s++) {
+        CUDACHECKGOTO(cudaEventRecord(comm->ceColl.copyEvents[s], stream), ret, fail);
+        CUDACHECKGOTO(cudaStreamWaitEvent(comm->ceColl.copyStreams[s], comm->ceColl.copyEvents[s], 0), ret, fail);
+      }
+
+      // Distribute copies round-robin across streams
+      for (int i = 0; i < (int)params->numOps; i++) {
+        int s = i % activeStreams;
+        CUDACHECKGOTO(cudaMemcpyAsync(
+          (void*)params->dsts[i],
+          (void*)params->srcs[i],
+          params->sizes[i],
+          cudaMemcpyDeviceToDevice,
+          comm->ceColl.copyStreams[s]), ret, fail);
+      }
+
+      // Make main stream wait on all copy streams
+      for (int s = 0; s < activeStreams; s++) {
+        CUDACHECKGOTO(cudaEventRecord(comm->ceColl.copyEvents[s], comm->ceColl.copyStreams[s]), ret, fail);
+        CUDACHECKGOTO(cudaStreamWaitEvent(stream, comm->ceColl.copyEvents[s], 0), ret, fail);
       }
     } else {
-      // Use single batch for all operations
-      #if CUDART_VERSION >= 13000
-      CUDACHECKGOTO(cudaMemcpyBatchAsync(
-        params->dsts, params->srcs, params->sizes, params->numOps,
-        params->attrs, params->attrIdxs, params->numAttrs, stream), ret, fail);
-      #else
-      CUDACHECKGOTO(cudaMemcpyBatchAsync(
-        params->dsts, params->srcs, params->sizes, params->numOps,
-        params->attrs, params->attrIdxs, params->numAttrs, nullptr, stream), ret, fail);
-      #endif
-    }
-#endif
-    } else {
-      // For older CUDA versions, fall back to individual transfers
-      for (int i = 0; i < params->numOps; i++) {
+      // For older ROCm versions, fall back to individual transfers
+      INFO(NCCL_COLL, "CE: rank %d -> No-Batch Single-Stream path (cudaMemcpyAsync), numOps=%zu", comm->rank, params->numOps);
+      for (int i = 0; i < params->numOps; i++) {  
         CUDACHECKGOTO(cudaMemcpyAsync(
           (void*)params->dsts[i],
           (void*)params->srcs[i],

--- a/projects/rccl/src/ce_coll.cc
+++ b/projects/rccl/src/ce_coll.cc
@@ -326,7 +326,6 @@ ncclResult_t ncclCeLaunchBatchOps(struct ncclComm* comm, struct ncclCeBatchOpsPa
 
   int driverVersion;
   NCCLCHECKGOTO(ncclCudaDriverVersion(&driverVersion), ret, fail);
-    
   //--------------Graph capture--------------
   // cudaMemcpyBatchAsync is not supported during CUDA graph capture
   if (capturing) {
@@ -342,44 +341,42 @@ ncclResult_t ncclCeLaunchBatchOps(struct ncclComm* comm, struct ncclCeBatchOpsPa
         NCCLCHECKGOTO(ncclMemOpSync(comm, stream), ret, fail);
       }
     }
-  } 
+  }
   //--------------No graph capture--------------
   else {
     // driverVersion is reported as 70200000 for ROCm 7.12 when using hipDriverGetVersion().
     if (ROCM_VERSION >= 71200 && driverVersion >= 70200000) {
-#if ROCM_VERSION >= 71200 
-      // For ROCm 7.12+, use batch memory copy for better performance
-      params->attrs[0] = {};
-      params->attrs[0].srcAccessOrder = cudaMemcpySrcAccessOrderStream;
-      params->attrs[0].flags = cudaMemcpyFlagPreferOverlapWithCompute;
-      params->attrIdxs[0] = 0;
-      params->numAttrs = 1;
+#if ROCM_VERSION >= 71200
+    // For ROCm 7.12+, use batch memory copy for better performance
+    params->attrs[0] = {};
+    params->attrs[0].srcAccessOrder = cudaMemcpySrcAccessOrderStream;
+    params->attrs[0].flags = cudaMemcpyFlagPreferOverlapWithCompute;
+    params->attrIdxs[0] = 0;
+    params->numAttrs = 1;
 
-      if (params->intraBatchSync) {
-        // Break into multiple batches with sync between them
-        int batchSize = comm->ceColl.intraBatchSyncFreq;
-        for (int i = 0; i < params->numOps; i += batchSize) {
-          int currentBatchSize = (i + batchSize <= params->numOps) ? batchSize : params->numOps - i;
-          INFO(NCCL_COLL, "CE: rank %d -> Batch path with intraBatchSync (cudaMemcpyBatchAsync, intraBatchSync), numOps=%zu, batchSize=%d", comm->rank, params->numOps, currentBatchSize);      
-          CUDACHECKGOTO(cudaMemcpyBatchAsync(
-            (void**)&params->dsts[i], (void**)&params->srcs[i], &params->sizes[i], currentBatchSize,
-            params->attrs, params->attrIdxs, params->numAttrs, nullptr, stream), ret, fail);
-
-          // Sync after each batch
-          if (i + batchSize < params->numOps) {
-            NCCLCHECKGOTO(ncclMemOpSync(comm, stream), ret, fail);
-          }
-        }
-      } else {
-        // Use single batch for all operations
-        INFO(NCCL_COLL, "CE: rank %d -> Batch path without intraBatchSync (cudaMemcpyBatchAsync), numOps=%zu", comm->rank, params->numOps);      
+    if (params->intraBatchSync) {
+      // Break into multiple batches with sync between them
+      int batchSize = comm->ceColl.intraBatchSyncFreq;
+      for (int i = 0; i < params->numOps; i += batchSize) {
+        int currentBatchSize = (i + batchSize <= params->numOps) ? batchSize : params->numOps - i;
+        INFO(NCCL_COLL, "CE: rank %d -> Batch path with intraBatchSync (cudaMemcpyBatchAsync, intraBatchSync), numOps=%zu, batchSize=%d", comm->rank, params->numOps, currentBatchSize);
         CUDACHECKGOTO(cudaMemcpyBatchAsync(
-          (void**)params->dsts, (void**)params->srcs, params->sizes, params->numOps,
+          (void**)&params->dsts[i], (void**)&params->srcs[i], &params->sizes[i], currentBatchSize,
           params->attrs, params->attrIdxs, params->numAttrs, nullptr, stream), ret, fail);
+        // Sync after each batch
+        if (i + batchSize < params->numOps) {
+          NCCLCHECKGOTO(ncclMemOpSync(comm, stream), ret, fail);
+        }
       }
+    } else {
+      // Use single batch for all operations
+      INFO(NCCL_COLL, "CE: rank %d -> Batch path without intraBatchSync (cudaMemcpyBatchAsync), numOps=%zu", comm->rank, params->numOps);
+      CUDACHECKGOTO(cudaMemcpyBatchAsync(
+        (void**)params->dsts, (void**)params->srcs, params->sizes, params->numOps,
+        params->attrs, params->attrIdxs, params->numAttrs, nullptr, stream), ret, fail);
+    }
 #endif
     } else if (comm->ceColl.nCopyStreams > 0 && (int)params->numOps > 1 && !params->intraBatchSync) {
-
       int nStreams = comm->ceColl.nCopyStreams;
       int activeStreams = ((int)params->numOps < nStreams) ? (int)params->numOps : nStreams;
       INFO(NCCL_COLL, "CE: rank %d -> No-Batch Multi-Stream path (%d streams), numOps=%zu", comm->rank, activeStreams, params->numOps);
@@ -409,7 +406,7 @@ ncclResult_t ncclCeLaunchBatchOps(struct ncclComm* comm, struct ncclCeBatchOpsPa
     } else {
       // For older ROCm versions, fall back to individual transfers
       INFO(NCCL_COLL, "CE: rank %d -> No-Batch Single-Stream path (cudaMemcpyAsync), numOps=%zu", comm->rank, params->numOps);
-      for (int i = 0; i < params->numOps; i++) {  
+      for (int i = 0; i < params->numOps; i++) {
         CUDACHECKGOTO(cudaMemcpyAsync(
           (void*)params->dsts[i],
           (void*)params->srcs[i],

--- a/projects/rccl/src/ce_coll.cc
+++ b/projects/rccl/src/ce_coll.cc
@@ -119,8 +119,8 @@ bool ncclCeImplemented(ncclFunc_t coll, int/*ncclDevRedOp_t*/ red, ncclDataType_
   if (ncclCudaDriverVersion(&driverVersion) != ncclSuccess) return false;
 
   // CE is supported in ROCm 7.12 and later
-  // hipDriverGetVersion() returns 70200000 for ROCm 7.12
-  if (driverVersion >= 70200000) {
+  // hipDriverGetVersion() returns 71200000 for ROCm 7.12
+  if (driverVersion >= 71200000) {
     switch (coll) {
     case ncclFuncAllGather:
     case ncclFuncAlltoAll:
@@ -344,8 +344,8 @@ ncclResult_t ncclCeLaunchBatchOps(struct ncclComm* comm, struct ncclCeBatchOpsPa
   }
   //--------------No graph capture--------------
   else {
-    // driverVersion is reported as 70200000 for ROCm 7.12 when using hipDriverGetVersion().
-    if (ROCM_VERSION >= 71200 && driverVersion >= 70200000) {
+    // driverVersion is reported as 71200000 for ROCm 7.12 when using hipDriverGetVersion().
+    if (ROCM_VERSION >= 71200 && driverVersion >= 71200000) {
 #if ROCM_VERSION >= 71200
     // For ROCm 7.12+, use batch memory copy for better performance
     params->attrs[0] = {};

--- a/projects/rccl/src/include/ce_coll.h
+++ b/projects/rccl/src/include/ce_coll.h
@@ -14,6 +14,7 @@
 // Memory operations per rank for different synchronization protocols
 #define NCCL_CE_SYNC_OPS_PER_RANK_MC 2
 #define NCCL_CE_SYNC_OPS_PER_RANK_UC 3
+#define RCCL_CE_NUM_COPY_STREAMS 8
 
 struct ncclCeColl {
   uint8_t* baseUCSymReadyPtr;
@@ -25,6 +26,9 @@ struct ncclCeColl {
   uint32_t intraBatchSyncFreq;
   uint64_t intraBatchSyncMsgThreshold;
   struct ncclDevrWindow* ceSyncWin;
+  int nCopyStreams;
+  cudaStream_t copyStreams[RCCL_CE_NUM_COPY_STREAMS];
+  cudaEvent_t copyEvents[RCCL_CE_NUM_COPY_STREAMS];
 };
 
 struct ncclCeInitTask {
@@ -49,7 +53,7 @@ struct ncclCeBatchOpsParams {
   size_t* sizes;
   size_t numOps;
   bool intraBatchSync;
-#if CUDART_VERSION >= 12080
+#if ROCM_VERSION >= 71200
   cudaMemcpyAttributes* attrs;
   size_t* attrIdxs;
   size_t numAttrs;

--- a/projects/rccl/src/rccl_wrap.cc
+++ b/projects/rccl/src/rccl_wrap.cc
@@ -436,6 +436,11 @@ bool rcclUseAllGatherDirect(struct ncclComm* comm, size_t& msgSize) {
   // Only perform auto-selection if user didn't explicitly set the threshold and threshold is not -1
   if (!userThresholdInput && IsArchMatch(comm->topo->nodes[GPU].nodes[0].gpu.gcn, "gfx950") && threshold != -1) {
     if (comm->nNodes == 1) {
+      // Disable Direct AllGather on single-node when CE-based AllGather is enabled
+      if (comm->symmetricSupport && comm->config.CTAPolicy == NCCL_CTA_POLICY_ZERO){
+        INFO(NCCL_INIT, "RCCL Direct AllGather disabled: CTA policy ZERO, using CE-based AllGather.");
+        return false;
+      }
       threshold = 8388608;
     } else if (comm->nNodes < 64) {
       threshold = comm->nNodes * 2097152;


### PR DESCRIPTION
## Motivation
The PR enable CE collective in RCCL by:

- Fixing the hipMemcpyBatchAsync execution path
- Ensuring proper fallback behavior similar to NCCL:
- Use batch path when available
- Fall back to multi-stream or single-stream otherwise
- Maintain correct behavior during graph capture (no batch API usage)

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan

I tested all execution paths on MI355 using a Docker image with ROCm 7.12 on top of Bertan's PR https://github.com/ROCm/rocm-systems/pull/3741.

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
