### PR TITLE
[rocdbgapi: mem-cache 1/8] Remove memory_cache_t::policy_t, hardcode write-back

### DIFF
--- a/projects/rocdbgapi/src/memory.cpp
+++ b/projects/rocdbgapi/src/memory.cpp
@@ -600,7 +600,7 @@ void
 memory_cache_t<AddressType>::prefetch (AddressType address,
                                        amd_dbgapi_size_t size)
 {
-  if (policy == policy_t::uncached || size == 0)
+  if (size == 0)
     return;
 
   dbgapi_assert (address < (address + size) && "invalid size");
@@ -649,7 +649,7 @@ memory_cache_t<AddressType>::write_back (AddressType address,
                                          amd_dbgapi_size_t size)
 {
   std::exception_ptr exception;
-  if (policy != policy_t::write_back || size == 0)
+  if (size == 0)
     return;
 
   dbgapi_assert (address < (address + size) && "invalid size");
@@ -771,8 +771,8 @@ memory_cache_t<AddressType>::xfer_global_memory (AddressType address,
   auto begin = m_cache_line_map.lower_bound (first_line);
   auto end = m_cache_line_map.upper_bound (last_line);
 
-  /* If uncached or there are no cache lines affected by this access.  */
-  if (policy == policy_t::uncached || begin == end)
+  /* If there are no cache lines affected by this access.  */
+  if (begin == end)
     return m_xfer_global_memory (address, read, write, size);
 
   /* For cached accesses, handle one cache line at a time.  */
@@ -810,10 +810,6 @@ memory_cache_t<AddressType>::xfer_global_memory (AddressType address,
   else
     {
       memcpy (&cache_line.m_data[0] + offset, write, size);
-
-      if (policy != policy_t::write_back)
-        return m_xfer_global_memory (address, nullptr, write, size);
-
       cache_line.m_dirty = true;
     }
 

--- a/projects/rocdbgapi/src/memory.h
+++ b/projects/rocdbgapi/src/memory.h
@@ -530,24 +530,13 @@ public:
                  void *value) const;
 };
 
+/* A write-back memory cache.  Data is immediately updated in the cache, and
+   later updated in memory when the cache is flushed.  */
+
 template <typename AddressType> class memory_cache_t
 {
 public:
-  enum class policy_t
-  {
-    /* If uncached is used, data is immediately written to global memory, and
-       is not written to the cache.  */
-    uncached = 0,
-    /* If write-through is used, data is written both to global memory and to
-       the cache.  */
-    write_through,
-    /* If write-back is used, data is immediately updated in the cache, and
-       later updated in memory when the cache is flushed.  */
-    write_back
-  };
-
   static constexpr size_t cache_line_size = 64;
-  static constexpr policy_t policy = policy_t::write_back;
 
 private:
   using delegate_fn_type


### PR DESCRIPTION
memory_cache_t supports three policies, uncached, write-through, and
write-back, but only write-back is ever used.  Remove enum class
policy_t, and all related code, leaving just the write-back paths.

Change-Id: I1c2c90ba46444667b27ad03e83f15ae111eb3922

---

**Stack**:
- #3804
- #3803
- #3304
- #3303
- #3302
- #3301
- #4892
- #4891 ⬅


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*