### PR TITLE
[memcache cleanups 2/6] process_t::read_string host cache line size

### DIFF
--- a/projects/rocdbgapi/src/process.cpp
+++ b/projects/rocdbgapi/src/process.cpp
@@ -285,9 +285,8 @@ void
 process_t::read_string (host_address_t address, std::string *string,
                         size_t size) const
 {
-  constexpr size_t cache_line_size
-    = memory_cache_t<host_address_t>::cache_line_size;
-  constexpr size_t chunk_size = 4 * cache_line_size;
+  constexpr size_t host_cache_line_size = 64;
+  constexpr size_t chunk_size = 4 * host_cache_line_size;
 
   dbgapi_assert (string && "invalid argument");
 
@@ -300,8 +299,9 @@ process_t::read_string (host_address_t address, std::string *string,
          which could read less than a chunk if the start address is not
          cache line aligned.  */
 
-      static_assert (utils::is_power_of_two (cache_line_size));
-      size_t request_size = chunk_size - (address & (cache_line_size - 1));
+      static_assert (utils::is_power_of_two (host_cache_line_size));
+      size_t request_size
+        = chunk_size - (address & (host_cache_line_size - 1));
 
       size_t xfer_size
         = read_host_memory_partial (address, staging_buffer, request_size);


### PR DESCRIPTION
This decouples process_t::read_string from the memcache cache line
logic.

The cache line size in process_t::read_string is supposed to be the
host machine's cache line size, not the memcache line size, as
mentioned in the commit log of a0628efbb0 ("rocdbgapi: batch
r_debug/link_map reads"):

read_string: align the first partial read to the host memory cache line
size and use four cache lines per chunk.

There is no memory cache involved in this code at all.

Hardcode the host line cache size to 64 and rename the variable from
cache_line_size to host_cache_line_size for clarity.

Change-Id: Idac151109240ae3ba7b468683292a061683e1b3a

---

**Stack**:
- #3304
- #3303
- #3302
- #3301
- #4892 ⬅
- #4894


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*