### PR TITLE
[rocprofiler-compute] Move dev dependencies to requirements-development.txt

### DIFF
--- a/projects/rocprofiler-compute/CONTRIBUTING.md
+++ b/projects/rocprofiler-compute/CONTRIBUTING.md
@@ -141,8 +141,9 @@ Pre-commit hooks automatically check your code for formatting issues before each
 
 **Setup:**
 
+First, install [development dependencies](README.md#development-dependencies), then enable the hooks:
+
 ```bash
-python3 -m pip install pre-commit
 cd rocprofiler-compute
 pre-commit install
 ```

--- a/projects/rocprofiler-compute/README.md
+++ b/projects/rocprofiler-compute/README.md
@@ -42,6 +42,14 @@ python3 -m pip install -r requirements.txt
 
 **Note**: When working from source, vendored dependencies (like PyYAML) are included as git submodules. If you see import errors about missing vendored modules, run `git submodule update --init --recursive -- src/vendored/`.
 
+### Development dependencies
+
+To install development tools (linter, pre-commit hooks, YAML utilities), run:
+
+```bash
+python3 -m pip install -r requirements-development.txt
+```
+
 ## Testing
 
 Populate the <usename> variable in `docker/docker-compose.customrocmtest.yml`.

--- a/projects/rocprofiler-compute/pyproject.toml
+++ b/projects/rocprofiler-compute/pyproject.toml
@@ -2,12 +2,6 @@
 name = "rocprof_compute"
 requires-python = ">=3.9"
 
-[project.optional-dependencies]
-developer = [
-    "ruff>=0.14.11",
-    "pre-commit",
-]
-
 [tool.ruff]
 line-length = 88
 

--- a/projects/rocprofiler-compute/requirements-development.txt
+++ b/projects/rocprofiler-compute/requirements-development.txt
@@ -1,0 +1,3 @@
+ruff==0.14.11
+pre-commit==4.5.1
+ruamel.yaml==0.19.1

--- a/projects/rocprofiler-compute/tools/config_management/README.md
+++ b/projects/rocprofiler-compute/tools/config_management/README.md
@@ -150,10 +150,7 @@ src/utils/.config_hashes.json
 > It is used to safely modify YAML files while preserving comments, ordering,
 > and formatting. The workflow scripts will not function correctly without it.
 >
-> Install it via:
-> ```bash
-> pip install ruamel.yaml
-> ```
+> See [Development dependencies](../../README.md#development-dependencies) for install instructions.
 
 ### 1. Validate the current state
 


### PR DESCRIPTION
## Motivation

The project is not pip-installable (no `[build-system]` in `pyproject.toml`), so `pip install -e ".[developer]"` does not work. Add a standalone `requirements-development.txt` with pinned versions for reproducible dev setups.

## Technical Details

- Remove `[project.optional-dependencies]` section from `pyproject.toml`
- Add `requirements-development.txt` pinning `ruff==0.14.11`, `pre-commit==4.5.1`, `ruamel.yaml==0.19.1`
- Add "Development dependencies" section to `README.md`
- Update `CONTRIBUTING.md` and `tools/config_management/README.md` to link to the new section

## JIRA ID

## Test Plan

- Verify `pip install -r requirements-development.txt` installs all three packages at pinned versions
- Verify `pre-commit run --all-files` works after install

## Test Result

Pre-commit hooks pass on this commit.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.