### PR TITLE
[rocr] Fixes to make rocr-runtime and rocminfo build by default in TheRock on windows

### DIFF
--- a/projects/rocminfo/CMakeLists.txt
+++ b/projects/rocminfo/CMakeLists.txt
@@ -34,7 +34,7 @@
 #
 # Minimum version of cmake required
 #
-cmake_minimum_required(VERSION 3.6.3)
+cmake_minimum_required(VERSION 3.25)
 
 set(ROCMINFO_EXE "rocminfo")
 set(PROJECT_NAME ${ROCMINFO_EXE})
@@ -42,8 +42,7 @@ project (${PROJECT_NAME} LANGUAGES CXX)
 
 include ( GNUInstallDirs )
 if(WIN32)
-  message("This sample is not supported on Windows platform")
-  return()
+  message(STATUS "Building rocminfo on Windows")
 endif()
 
 # Debug by default
@@ -147,19 +146,23 @@ add_definitions(-DLITTLEENDIAN_CPU=1)
 # Linux Compiler options
 #
 set(CMAKE_CXX_STANDARD 11)
-set(ROCMINFO_CXX_FLAGS ${ROCMINFO_CXX_FLAGS} -fexceptions)
-set(ROCMINFO_CXX_FLAGS ${ROCMINFO_CXX_FLAGS} -fno-rtti)
-set(ROCMINFO_CXX_FLAGS ${ROCMINFO_CXX_FLAGS} -fno-math-errno)
-set(ROCMINFO_CXX_FLAGS ${ROCMINFO_CXX_FLAGS} -fno-threadsafe-statics)
-set(ROCMINFO_CXX_FLAGS ${ROCMINFO_CXX_FLAGS} -fmerge-all-constants)
-set(ROCMINFO_CXX_FLAGS ${ROCMINFO_CXX_FLAGS} -fms-extensions)
-set(ROCMINFO_CXX_FLAGS ${ROCMINFO_CXX_FLAGS} -Werror)
-set(ROCMINFO_CXX_FLAGS ${ROCMINFO_CXX_FLAGS} -Wall)
+if(MSVC)
+  set(ROCMINFO_CXX_FLAGS ${ROCMINFO_CXX_FLAGS} /EHsc /W3)
+else()
+  set(ROCMINFO_CXX_FLAGS ${ROCMINFO_CXX_FLAGS} -fexceptions)
+  set(ROCMINFO_CXX_FLAGS ${ROCMINFO_CXX_FLAGS} -fno-rtti)
+  set(ROCMINFO_CXX_FLAGS ${ROCMINFO_CXX_FLAGS} -fno-math-errno)
+  set(ROCMINFO_CXX_FLAGS ${ROCMINFO_CXX_FLAGS} -fno-threadsafe-statics)
+  set(ROCMINFO_CXX_FLAGS ${ROCMINFO_CXX_FLAGS} -fmerge-all-constants)
+  set(ROCMINFO_CXX_FLAGS ${ROCMINFO_CXX_FLAGS} -fms-extensions)
+  set(ROCMINFO_CXX_FLAGS ${ROCMINFO_CXX_FLAGS} -Werror)
+  set(ROCMINFO_CXX_FLAGS ${ROCMINFO_CXX_FLAGS} -Wall)
+endif()
 
 #
 # Extend the compiler flags for 64-bit builds
 #
-if((${CMAKE_HOST_SYSTEM_PROCESSOR} STREQUAL "x86_64") OR (${CMAKE_HOST_SYSTEM_PROCESSOR} STREQUAL "AMD64"))
+if(NOT WIN32 AND ((${CMAKE_HOST_SYSTEM_PROCESSOR} STREQUAL "x86_64") OR (${CMAKE_HOST_SYSTEM_PROCESSOR} STREQUAL "AMD64")))
   set(ROCMINFO_CXX_FLAGS ${ROCMINFO_CXX_FLAGS} -m64 -msse -msse2)
 endif()
 
@@ -167,14 +170,20 @@ endif()
 # Add compiler flags to include symbol information for debug builds
 #
 if(ISDEBUG)
-  set(ROCMINFO_CXX_FLAGS ${ROCMINFO_CXX_FLAGS} -ggdb -O0)
+  if(MSVC)
+    set(ROCMINFO_CXX_FLAGS ${ROCMINFO_CXX_FLAGS} /Zi /Od)
+  else()
+    set(ROCMINFO_CXX_FLAGS ${ROCMINFO_CXX_FLAGS} -ggdb -O0)
+  endif()
 endif()
 
 ###########################
 # rocm_agent_enumerator
 ###########################
 
-configure_file(rocm_agent_enumerator rocm_agent_enumerator COPYONLY)
+if(NOT WIN32)
+  configure_file(rocm_agent_enumerator rocm_agent_enumerator COPYONLY)
+endif()
 
 
 ###########################
@@ -183,6 +192,9 @@ configure_file(rocm_agent_enumerator rocm_agent_enumerator COPYONLY)
 aux_source_directory(${CMAKE_CURRENT_SOURCE_DIR} ROCMINFO_SOURCES)
 add_executable(${ROCMINFO_EXE} ${ROCMINFO_SOURCES})
 target_link_libraries(${ROCMINFO_EXE} hsa-runtime64::hsa-runtime64)
+if(WIN32)
+  target_compile_definitions(${ROCMINFO_EXE} PRIVATE NOMINMAX)
+endif()
 
 target_compile_options(${ROCMINFO_EXE} PRIVATE ${ROCMINFO_CXX_FLAGS})
 
@@ -192,13 +204,16 @@ target_compile_options(${ROCMINFO_EXE} PRIVATE ${ROCMINFO_CXX_FLAGS})
 install (
    TARGETS ${ROCMINFO_EXE}
    DESTINATION ${CMAKE_INSTALL_BINDIR} )
-install (
-   PROGRAMS ${CMAKE_CURRENT_BINARY_DIR}/rocm_agent_enumerator
-   DESTINATION ${CMAKE_INSTALL_BINDIR} )
+if(NOT WIN32)
+  install (
+     PROGRAMS ${CMAKE_CURRENT_BINARY_DIR}/rocm_agent_enumerator
+     DESTINATION ${CMAKE_INSTALL_BINDIR} )
+endif()
 
 ###########################
 # Packaging directives
 ###########################
+if(NOT WIN32)
 if(BUILD_SHARED_LIBS)
   set(CPACK_PACKAGE_NAME "${PROJECT_NAME}")
 else()
@@ -314,3 +329,4 @@ if(BUILD_ENABLE_LINTIAN_OVERRIDES AND BUILD_DEBIAN_PKGING_FLAG)
 endif()
 
 include ( CPack )
+endif()

--- a/projects/rocminfo/CMakeLists.txt
+++ b/projects/rocminfo/CMakeLists.txt
@@ -181,9 +181,7 @@ endif()
 # rocm_agent_enumerator
 ###########################
 
-if(NOT WIN32)
-  configure_file(rocm_agent_enumerator rocm_agent_enumerator COPYONLY)
-endif()
+configure_file(rocm_agent_enumerator rocm_agent_enumerator COPYONLY)
 
 
 ###########################
@@ -204,11 +202,9 @@ target_compile_options(${ROCMINFO_EXE} PRIVATE ${ROCMINFO_CXX_FLAGS})
 install (
    TARGETS ${ROCMINFO_EXE}
    DESTINATION ${CMAKE_INSTALL_BINDIR} )
-if(NOT WIN32)
-  install (
-     PROGRAMS ${CMAKE_CURRENT_BINARY_DIR}/rocm_agent_enumerator
-     DESTINATION ${CMAKE_INSTALL_BINDIR} )
-endif()
+install (
+   PROGRAMS ${CMAKE_CURRENT_BINARY_DIR}/rocm_agent_enumerator
+   DESTINATION ${CMAKE_INSTALL_BINDIR} )
 
 ###########################
 # Packaging directives

--- a/projects/rocminfo/cmake_modules/utils.cmake
+++ b/projects/rocminfo/cmake_modules/utils.cmake
@@ -89,6 +89,7 @@ function(get_version_from_tag DEFAULT_VERSION_STRING VERSION_PREFIX GIT)
                           WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
                           OUTPUT_VARIABLE GIT_TAG_STRING
                           OUTPUT_STRIP_TRAILING_WHITESPACE
+                          ERROR_QUIET
                           RESULT_VARIABLE RESULT )
         if ( ${RESULT} EQUAL 0 )
             parse_version ( ${GIT_TAG_STRING} )
@@ -105,17 +106,18 @@ function(num_change_since_prev_pkg VERSION_PREFIX)
     find_program(get_commits NAMES version_util.sh
                  PATHS ${CMAKE_CURRENT_SOURCE_DIR}/cmake_modules)
     if (get_commits)
-       execute_process( COMMAND ${get_commits} -c ${VERSION_PREFIX}
-                          WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
-                          OUTPUT_VARIABLE NUM_COMMITS
-                          OUTPUT_STRIP_TRAILING_WHITESPACE
-                          RESULT_VARIABLE RESULT )
-
-        set(NUM_COMMITS "${NUM_COMMITS}" PARENT_SCOPE )
+        execute_process( COMMAND ${get_commits} -c ${VERSION_PREFIX}
+                           WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+                           OUTPUT_VARIABLE NUM_COMMITS
+                           OUTPUT_STRIP_TRAILING_WHITESPACE
+                           ERROR_QUIET
+                           RESULT_VARIABLE RESULT )
 
         if ( ${RESULT} EQUAL 0 )
+          set(NUM_COMMITS "${NUM_COMMITS}" PARENT_SCOPE )
           message("${NUM_COMMITS} were found since previous release")
         else()
+          set(NUM_COMMITS "0" PARENT_SCOPE )
           message("Unable to determine number of commits since previous release")
         endif()
     else()

--- a/projects/rocminfo/rocm_agent_enumerator
+++ b/projects/rocminfo/rocm_agent_enumerator
@@ -12,6 +12,7 @@ import re
 import subprocess
 import sys
 import time
+import platform
 
 # get current working directory
 CWD = os.path.dirname(os.path.realpath(__file__))
@@ -280,11 +281,12 @@ def main():
     """
     target_list = readFromTargetLstFile()
 
-    if len(target_list) == 0:
-      target_list = readFromKFD()
+    if platform.system() == "Linux":
+      if len(target_list) == 0:
+        target_list = readFromKFD()
 
-    if len(target_list) == 0:
-      target_list = readFromLSPCI()
+      if len(target_list) == 0:
+        target_list = readFromLSPCI()
 
     if len(target_list) == 0:
       target_list = readFromROCMINFO()

--- a/projects/rocminfo/rocminfo.cc
+++ b/projects/rocminfo/rocminfo.cc
@@ -44,12 +44,17 @@
  */
 #include <stdio.h>
 #include <string.h>
+#include <stdlib.h>
+#include <errno.h>
+
+#ifndef _WIN32
 #include <sys/stat.h>
 #include <sys/types.h>
 #include <fcntl.h>
 #include <grp.h>
 #include <unistd.h>
 #include <pwd.h>
+#endif
 
 #include <fstream>
 #include <vector>
@@ -231,25 +236,57 @@ std::string int_to_string(uint32_t i,
   return sd.str();
 }
 
+std::string int_to_string(uint64_t i,
+                   uint32_t fmt = ROCMI_INT_FORMAT_DEC|ROCMI_INT_FORMAT_HEX) {
+  std::stringstream sd;
+  bool need_parens = false;
+
+  if (fmt & ROCMI_INT_FORMAT_DEC) {
+    sd << std::dec << i << " ";
+    need_parens = true;
+  }
+
+  if (fmt & ROCMI_INT_FORMAT_HEX) {
+    if (need_parens) {
+      sd << "(0x";
+    }
+    sd << std::hex << i;
+    if (need_parens) {
+      sd << ") ";
+    }
+  }
+
+  return sd.str();
+}
+
 static void DetectWSLEnvironment() {
   const char *filePath = "/dev/dxg";
-  FILE *file = fopen(filePath, "r");
+  std::ifstream file(filePath);
   if (file) {
     printf("WSL environment detected.\n");
-    fclose(file);
     wsl_env = true;
   }
 }
 
 static void DetectDTIFEnvironment() {
-  char *var = getenv("HSA_ENABLE_DTIF");
+#if defined(_WIN32) && defined(_MSC_VER)
+  char *var = nullptr;
+  size_t var_size = 0;
+  if (_dupenv_s(&var, &var_size, "HSA_ENABLE_DTIF") != 0 || var == nullptr)
+    return;
+#else
+  const char *var = getenv("HSA_ENABLE_DTIF");
   if (var == NULL)
     return;
+#endif
 
   if (0 == strncmp(var, "1", 1)) {
     printf("HSA-DTIF environment detected.\n");
     dtif_env = true;
   }
+#if defined(_WIN32) && defined(_MSC_VER)
+  free(var);
+#endif
 }
 
 static void printLabelInt(char const *l, int d, uint32_t indent_lvl = 0) {
@@ -351,8 +388,9 @@ static void DisplaySystemInfo(system_info_t const *sys_info) {
   printLabel("System Timestamp Freq.:");
   printf("%fMHz\n", sys_info->timestamp_frequency / 1e6);
   printLabel("Sig. Max Wait Duration:");
-  printf("%lu (0x%lX) (timestamp count)\n", sys_info->max_wait,
-                                                           sys_info->max_wait);
+  printf("%llu (0x%llX) (timestamp count)\n",
+         static_cast<unsigned long long>(sys_info->max_wait),
+         static_cast<unsigned long long>(sys_info->max_wait));
 
   printLabel("Machine Model:");
   if (HSA_MACHINE_MODEL_SMALL == sys_info->machine_model) {
@@ -863,7 +901,7 @@ static void DumpSegment(pool_info_t *pool_i, uint32_t ind_lvl) {
 static void DisplayPoolInfo(pool_info_t *pool_i, uint32_t indent) {
   DumpSegment(pool_i, indent);
 
-  size_t sz = pool_i->pool_size/1024;
+  uint64_t sz = pool_i->pool_size/1024;
   printLabelStr("Size:", int_to_string(sz) + "KB", indent);
   printLabelStr("Allocatable:", (pool_i->alloc_allowed ? "TRUE" : "FALSE"),
                                                                       indent);
@@ -1179,6 +1217,9 @@ AcquireAndDisplayAgentInfo(hsa_agent_t agent, void* data) {
 }
 
 int CheckInitialState(void) {
+#ifdef _WIN32
+  return 0;
+#else
   // Check kernel module for ROCk is loaded
 
   std::ifstream amdgpu_initstate("/sys/module/amdgpu/initstate");
@@ -1303,6 +1344,7 @@ int CheckInitialState(void) {
 
   delete []groups;
   return -1;
+#endif
 }
 
 // Print out all static information known to HSA about the target system.

--- a/projects/rocr-runtime/CMakeLists.txt
+++ b/projects/rocr-runtime/CMakeLists.txt
@@ -41,7 +41,16 @@
 ################################################################################
 
 
-cmake_minimum_required(VERSION 3.7)
+cmake_minimum_required(VERSION 3.25)
+
+# The binary-only wkmi.lib is compiled with /MT so ROCR must follow suit.
+# Otherwise, the default is /MD and the library cannot be linked.
+# If the linkage of wkmi.lib is ever changed to /MD, this must be updated
+# or deleted.
+# Must come before project and after cmake_minimum_required
+if(WIN32)
+  set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
+endif()
 
 # Set the project name
 project("rocr")

--- a/projects/rocr-runtime/libhsakmt/CMakeLists.txt
+++ b/projects/rocr-runtime/libhsakmt/CMakeLists.txt
@@ -295,18 +295,25 @@ else()
       ## Fall back to pre-built wkmi.lib
       set(WKMI_SRC_BUILD OFF CACHE INTERNAL "wkmi is built from source")
       message(STATUS "Using pre-built wkmi.lib (set WKMI_SRC_DIR to build from source)")
+      set(WKMI_INCLUDE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/src/dxg/wkmi)
       if(CMAKE_BUILD_TYPE STREQUAL "Debug")
-        set(WKMI_LIB_PATH ${CMAKE_CURRENT_SOURCE_DIR}/src/dxg/wkmi/win/dbg/wkmi.lib)
+        set(WKMI_LIB_PATH ${WKMI_INCLUDE_DIR}/win/dbg/wkmi.lib)
       else()
-        set(WKMI_LIB_PATH ${CMAKE_CURRENT_SOURCE_DIR}/src/dxg/wkmi/win/rel/wkmi.lib)
+        set(WKMI_LIB_PATH ${WKMI_INCLUDE_DIR}/win/rel/wkmi.lib)
       endif()
-      target_include_directories(${HSAKMT_TARGET} PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/src/dxg/wkmi)
+      target_include_directories(${HSAKMT_TARGET} PUBLIC
+        $<BUILD_INTERFACE:${WKMI_INCLUDE_DIR}>
+        $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/hsakmt/wkmi>)
       
       # Link wkmi.lib and ensure it's propagated to downstream targets (hsa-runtime64)
-      target_link_libraries(${HSAKMT_TARGET} PUBLIC ${WKMI_LIB_PATH})
+      target_link_libraries(${HSAKMT_TARGET} PUBLIC
+        $<BUILD_INTERFACE:${WKMI_LIB_PATH}>
+        $<INSTALL_INTERFACE:$<INSTALL_PREFIX>/${CMAKE_INSTALL_LIBDIR}/wkmi.lib>)
       
       # Export wkmi.lib path for downstream static linking
-      set_property(TARGET ${HSAKMT_TARGET} APPEND PROPERTY INTERFACE_LINK_LIBRARIES ${WKMI_LIB_PATH})
+      set_property(TARGET ${HSAKMT_TARGET} APPEND PROPERTY INTERFACE_LINK_LIBRARIES
+        $<BUILD_INTERFACE:${WKMI_LIB_PATH}>
+        $<INSTALL_INTERFACE:$<INSTALL_PREFIX>/${CMAKE_INSTALL_LIBDIR}/wkmi.lib>)
     endif()
   endif()
 
@@ -317,7 +324,18 @@ else()
   set ( CMAKE_INSTALL_PREFIX ${CMAKE_INSTALL_PREFIX} CACHE STRING "Default installation directory." FORCE )
 
   # Installs binaries and exports the library usage data to ${HSAKMT_TARGET}Targets
-  if (NOT WIN32)
+  if (WIN32)
+    install ( TARGETS ${HSAKMT_TARGET} EXPORT ${HSAKMT_TARGET}Targets
+      ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR} COMPONENT dev )
+    if(NOT WKMI_SRC_BUILD)
+      install ( FILES ${WKMI_LIB_PATH}
+        DESTINATION ${CMAKE_INSTALL_LIBDIR}
+        COMPONENT dev )
+      install ( FILES ${WKMI_INCLUDE_DIR}/wkmi.h
+        DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/hsakmt/wkmi
+        COMPONENT dev )
+    endif()
+  else()
     install ( TARGETS ${HSAKMT_TARGET} EXPORT ${HSAKMT_TARGET}Targets
       ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR} COMPONENT asan
       LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR} COMPONENT asan )
@@ -331,13 +349,11 @@ else()
     COMPONENT dev PATTERN "linux" EXCLUDE PATTERN "*virtio*" EXCLUDE)
 
   # Record our usage data for clients find_package calls.
-  if (NOT WIN32)
-    install ( EXPORT ${HSAKMT_TARGET}Targets
-      FILE ${HSAKMT_TARGET}Targets.cmake
-      NAMESPACE ${HSAKMT_TARGET}::
-      DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/${HSAKMT_TARGET}
-      COMPONENT dev)
-  endif()
+  install ( EXPORT ${HSAKMT_TARGET}Targets
+    FILE ${HSAKMT_TARGET}Targets.cmake
+    NAMESPACE ${HSAKMT_TARGET}::
+    DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/${HSAKMT_TARGET}
+    COMPONENT dev)
   # Adds the target alias hsakmt::hsakmt to the local cmake cache.
   # This isn't necessary today.  It's harmless preparation for some
   # hypothetical future in which the we might be included by add_subdirectory()
@@ -358,14 +374,12 @@ else()
                    VERSION ${BUILD_VERSION_STRING}
                    COMPATIBILITY
                    AnyNewerVersion)
-  if (NOT WIN32)
-    install(FILES
-            ${CMAKE_CURRENT_BINARY_DIR}/${HSAKMT_TARGET}-config.cmake
-            ${CMAKE_CURRENT_BINARY_DIR}/${HSAKMT_TARGET}-config-version.cmake
-            DESTINATION
-            ${CMAKE_INSTALL_LIBDIR}/cmake/${HSAKMT_TARGET}
-            COMPONENT dev)
-  endif()
+  install(FILES
+          ${CMAKE_CURRENT_BINARY_DIR}/${HSAKMT_TARGET}-config.cmake
+          ${CMAKE_CURRENT_BINARY_DIR}/${HSAKMT_TARGET}-config-version.cmake
+          DESTINATION
+          ${CMAKE_INSTALL_LIBDIR}/cmake/${HSAKMT_TARGET}
+          COMPONENT dev)
 
   # Optionally record the package's find module in the user's package cache.
   if ( NOT DEFINED EXPORT_TO_USER_PACKAGE_REGISTRY )

--- a/projects/rocr-runtime/libhsakmt/src/dxg/dxcore_loader.cpp
+++ b/projects/rocr-runtime/libhsakmt/src/dxg/dxcore_loader.cpp
@@ -84,7 +84,7 @@ bool DxcoreLoader::Initialize() {
 
 void DxcoreLoader::Shutdown() {
     if (dxcore_handle_) {
-        if (rocr::os::CloseLib(dxcore_handle_) != 0) {
+        if (!rocr::os::CloseLib(dxcore_handle_)) {
             pr_err("[DxcoreLoader] Cannot unload libdxcore.so: %s\n", rocr::os::DlError());
         } else {
             pr_info("[DxcoreLoader] libdxcore.so unloaded successfully\n");

--- a/projects/rocr-runtime/runtime/hsa-runtime/CMakeLists.txt
+++ b/projects/rocr-runtime/runtime/hsa-runtime/CMakeLists.txt
@@ -448,7 +448,11 @@ endif()
 
 ## Set install information
 # Installs binaries and exports the library usage data to ${HSAKMT_TARGET}Targets
-if (NOT WIN32)
+if (WIN32)
+  install ( TARGETS ${CORE_RUNTIME_TARGET} EXPORT ${CORE_RUNTIME_NAME}Targets
+    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR} COMPONENT dev
+    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR} COMPONENT binary )
+else()
   install ( TARGETS ${CORE_RUNTIME_TARGET} EXPORT ${CORE_RUNTIME_NAME}Targets
     ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR} COMPONENT binary
     LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR} COMPONENT binary )
@@ -461,22 +465,18 @@ endif()
 if(ENABLE_ASAN_PACKAGING)
   install ( FILES ${CMAKE_CURRENT_SOURCE_DIR}/LICENSE.md DESTINATION ${CMAKE_INSTALL_DOCDIR}-asan COMPONENT asan )
 endif()
-if (NOT WIN32)
-  install ( FILES ${CMAKE_CURRENT_SOURCE_DIR}/LICENSE.md DESTINATION ${CMAKE_INSTALL_DOCDIR} COMPONENT binary )
-endif()
+install ( FILES ${CMAKE_CURRENT_SOURCE_DIR}/LICENSE.md DESTINATION ${CMAKE_INSTALL_DOCDIR} COMPONENT binary )
 
 # Install public headers
 install ( DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/inc/ DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/hsa COMPONENT dev )
 
 ## Configure and install package config file
 # Record our usage data for clients find_package calls.
-if (NOT WIN32)
-  install ( EXPORT ${CORE_RUNTIME_NAME}Targets
-    FILE ${CORE_RUNTIME_NAME}Targets.cmake
-    NAMESPACE ${CORE_RUNTIME_NAME}::
-    DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/${CORE_RUNTIME_NAME}
-    COMPONENT dev)
-endif()
+install ( EXPORT ${CORE_RUNTIME_NAME}Targets
+  FILE ${CORE_RUNTIME_NAME}Targets.cmake
+  NAMESPACE ${CORE_RUNTIME_NAME}::
+  DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/${CORE_RUNTIME_NAME}
+  COMPONENT dev)
 
 # Adds the target alias hsa-runtime64::hsa-runtime64 to the local cmake cache.
 # This isn't necessary today.  It's harmless preparation for some
@@ -496,11 +496,9 @@ configure_package_config_file(${CORE_RUNTIME_NAME}-config.cmake.in
 write_basic_package_version_file(${CORE_RUNTIME_NAME}-config-version.cmake
   VERSION ${SO_VERSION_STRING} COMPATIBILITY AnyNewerVersion )
 
-if (NOT WIN32)
-  install(FILES ${CMAKE_CURRENT_BINARY_DIR}/${CORE_RUNTIME_NAME}-config.cmake ${CMAKE_CURRENT_BINARY_DIR}/${CORE_RUNTIME_NAME}-config-version.cmake
-    DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/${CORE_RUNTIME_NAME}
-    COMPONENT dev)
-endif()
+install(FILES ${CMAKE_CURRENT_BINARY_DIR}/${CORE_RUNTIME_NAME}-config.cmake ${CMAKE_CURRENT_BINARY_DIR}/${CORE_RUNTIME_NAME}-config-version.cmake
+  DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/${CORE_RUNTIME_NAME}
+  COMPONENT dev)
 
 # Install build files needed only when using a static build.
 if( NOT ${BUILD_SHARED_LIBS} )

--- a/projects/rocr-runtime/runtime/hsa-runtime/cmake_modules/FindLibElf.cmake
+++ b/projects/rocr-runtime/runtime/hsa-runtime/cmake_modules/FindLibElf.cmake
@@ -73,7 +73,7 @@ if (UNIX)
     set_property(TARGET elf::elf PROPERTY INTERFACE_INCLUDE_DIRECTORIES ${LIBELF_INCLUDE_DIRS})
   endif()
 else()
-  find_path(ROCR_LIBELF_INCLUDE_DIR libelf.h
+  find_path(ROCR_LIBELF_SOURCE_DIR libelf.h
       HINTS
         ${AMD_LIBELF_PATH}
       PATHS
@@ -83,13 +83,19 @@ else()
         ${CMAKE_SOURCE_DIR}/../../shared/amdgpu-windows-interop/hsail-compiler/lib/loaders/elf/utils/libelf
       NO_DEFAULT_PATH)
 
-  message("=> LibElf paths:" ${CMAKE_CURRENT_BINARY_DIR} ${ROCR_LIBELF_INCLUDE_DIR})
-  if (${BUILD_SHARED_LIBS})
-    mark_as_advanced(ROCR_LIBELF_INCLUDE_DIR)
-    add_subdirectory("${ROCR_LIBELF_INCLUDE_DIR}" ${CMAKE_CURRENT_BINARY_DIR}/libelf)
+  if(NOT ROCR_LIBELF_SOURCE_DIR)
+    message(FATAL_ERROR "AMD LibElf source directory not found")
   endif()
-  set(USE_AMD_LIBELF "yes" CACHE FORCE "")
-  set(AMD_ELFTOOLCHAIN_DIR ${ROCR_LIBELF_INCLUDE_DIR}/../..;${ROCR_LIBELF_INCLUDE_DIR}/../common/win32;${ROCR_LIBELF_INCLUDE_DIR}/../common)
-  set(ROCR_LIBELF_INCLUDE_DIR ${ROCR_LIBELF_INCLUDE_DIR};${AMD_ELFTOOLCHAIN_DIR})
+
+  message("=> LibElf paths:" ${CMAKE_CURRENT_BINARY_DIR} ${ROCR_LIBELF_SOURCE_DIR})
+  if (BUILD_SHARED_LIBS AND NOT TARGET oclelf)
+    mark_as_advanced(ROCR_LIBELF_SOURCE_DIR)
+    add_subdirectory("${ROCR_LIBELF_SOURCE_DIR}" ${CMAKE_CURRENT_BINARY_DIR}/libelf)
+  endif()
+  set(USE_AMD_LIBELF "yes" CACHE STRING "" FORCE)
+  set(AMD_ELFTOOLCHAIN_DIR ${ROCR_LIBELF_SOURCE_DIR}/../..;${ROCR_LIBELF_SOURCE_DIR}/../common/win32;${ROCR_LIBELF_SOURCE_DIR}/../common)
+  set(ROCR_LIBELF_INCLUDE_DIR ${ROCR_LIBELF_SOURCE_DIR};${AMD_ELFTOOLCHAIN_DIR})
   set(LIBELF_INCLUDE_DIR ${ROCR_LIBELF_INCLUDE_DIR})
+  set(LIBELF_FOUND TRUE)
+  set(LibElf_FOUND TRUE)
 endif()


### PR DESCRIPTION
- Fix Windows LibElf discovery and use the bundled AMD libelf source without re-entering the target.
- Match the MSVC runtime expected by the binary wkmi library and export/install ROCR, hsakmt, wkmi, and CMake package artifacts on Windows.
- Enable rocminfo to build and install on Windows while skipping Linux-only probes, packaging paths, and script installation.
- Clean up rocminfo Windows warnings from CRT probes, 64-bit formatting, narrowing conversions, and tag-version probing.
- Fixes a bad bool vs int check on shutdown/unload of a wsl lib (avoids a shutdown stderr print).
- Fixes rocm_agent_enumerator to work on windows (supersedes #4912).

Note that the FindElf probing was not working in my environment because it was trying to add_subdirectory() a list of probe paths. I suspect that testing of this was done with an explicit source dir vs a probe. I restructured it to separate the probe from the found path. I don't have access to a wkmi source build on this system so did my best to preserve that behavior, but since there is no way to test it, it is best effort.

With these changes, I was able to build (with minor build system patches) ROCR and rocminfo on Windows in TheRock. Tested rocminfo on a Strix Halo and it seems to function. Once this lands, I will enable these by default in TheRock and enable testing.
