### PR TITLE
[hotswap] Integrate with upstream COMGR data-object API

### DIFF
--- a/projects/hotswap/CMakeLists.txt
+++ b/projects/hotswap/CMakeLists.txt
@@ -8,26 +8,8 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(HSA_RUNTIME_INC "${CMAKE_CURRENT_SOURCE_DIR}/../rocr-runtime/runtime/hsa-runtime/inc"
     CACHE PATH "Path to HSA runtime include directory")
 
-# TODO(COMGR-upstream): Remove mock-comgr once amd_comgr_hotswap_rewrite
-# is available in a released libamd_comgr.so package. At that point, the
-# real amd_comgr CMake package should be required for non-test builds and
-# the mock should only be used under BUILD_TESTING.
-add_library(mock-comgr SHARED tests/mock_comgr.cpp)
-set_target_properties(mock-comgr PROPERTIES
-  OUTPUT_NAME "amd_comgr"
-  POSITION_INDEPENDENT_CODE ON)
-
-# Find real COMGR via its exported CMake package, or fall back to the mock.
-# TODO(COMGR-upstream): Once COMGR ships the hotswap API in a released package,
-# make find_package(amd_comgr CONFIG REQUIRED) for normal builds.
-find_package(amd_comgr CONFIG QUIET)
-if(TARGET amd_comgr)
-  set(COMGR_LINK_LIB amd_comgr)
-  message(STATUS "Found COMGR package: amd_comgr")
-else()
-  set(COMGR_LINK_LIB mock-comgr)
-  message(STATUS "COMGR not found, using mock for build/test")
-endif()
+# COMGR is required — provides amd_comgr_hotswap_rewrite.
+find_package(amd_comgr CONFIG REQUIRED)
 
 # Shared library for HSA_TOOLS_LIB usage — links COMGR directly
 set(HOTSWAP_PLATFORM_IO_SRC hotswap_platform_io_posix.cpp)
@@ -47,16 +29,16 @@ target_include_directories(hsa-hotswap PRIVATE
   ${HSA_RUNTIME_INC}/..
 )
 
-target_link_libraries(hsa-hotswap PRIVATE ${COMGR_LINK_LIB})
+target_link_libraries(hsa-hotswap PRIVATE amd_comgr)
 set_target_properties(hsa-hotswap PROPERTIES
   POSITION_INDEPENDENT_CODE ON)
 
-# Test executable — links COMGR directly (mock or real)
+# Test executable — links COMGR directly
 add_executable(hotswap_test tests/hotswap_test.cpp
   hotswap.cpp
 )
 target_include_directories(hotswap_test PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
-target_link_libraries(hotswap_test PRIVATE ${COMGR_LINK_LIB})
+target_link_libraries(hotswap_test PRIVATE amd_comgr)
 
 enable_testing()
 add_test(NAME hotswap_test COMMAND hotswap_test)

--- a/projects/hotswap/hotswap.cpp
+++ b/projects/hotswap/hotswap.cpp
@@ -5,18 +5,11 @@
 //===----------------------------------------------------------------------===//
 
 #include "hotswap.hpp"
+#include <amd_comgr.h>
 #include <cstdio>
 #include <cstdlib>
+#include <cstring>
 #include <memory>
-
-// TODO(COMGR-upstream): Replace this forward declaration with
-// #include <amd_comgr.h> once the hotswap API lands in a released COMGR.
-// The return type is amd_comgr_status_t (enum, ABI-compatible with int).
-extern "C" int amd_comgr_hotswap_rewrite(const void *elf_data, size_t elf_size,
-                                         const char *source_isa_name,
-                                         const char *target_isa_name,
-                                         void **out_elf,
-                                         size_t *out_elf_size);
 
 namespace rocr::hotswap {
 
@@ -38,21 +31,62 @@ int RetargetCodeObject(const void *elf_data, size_t elf_size,
     return -1;
   }
 
-  void *out_elf = nullptr;
-  size_t out_elf_size = 0;
-  const int rc = amd_comgr_hotswap_rewrite(elf_data, elf_size, source_isa,
-                                           target_isa, &out_elf, &out_elf_size);
-  OwnedElf owned_elf(out_elf, &std::free);
-  if (rc != 0) {
-    fprintf(stderr, "hotswap: COMGR rewrite failed for %s -> %s (rc=%d)\n",
-            source_isa, target_isa, rc);
-    return rc;
+  // Wrap input bytes in a COMGR data object.
+  amd_comgr_data_t input = {0};
+  amd_comgr_status_t status =
+      amd_comgr_create_data(AMD_COMGR_DATA_KIND_EXECUTABLE, &input);
+  if (status != AMD_COMGR_STATUS_SUCCESS) {
+    fprintf(stderr, "hotswap: failed to create COMGR input data object\n");
+    return static_cast<int>(status);
   }
 
-  if (owned_elf) {
-    *out_data = owned_elf.release();
-    *out_size = out_elf_size;
+  status = amd_comgr_set_data(input, elf_size, static_cast<const char *>(elf_data));
+  if (status != AMD_COMGR_STATUS_SUCCESS) {
+    fprintf(stderr, "hotswap: failed to set COMGR input data\n");
+    amd_comgr_release_data(input);
+    return static_cast<int>(status);
   }
+
+  // Call the hotswap rewrite API.
+  amd_comgr_data_t output = {0};
+  status = amd_comgr_hotswap_rewrite(input, source_isa, target_isa, &output);
+  amd_comgr_release_data(input);
+
+  if (status != AMD_COMGR_STATUS_SUCCESS) {
+    fprintf(stderr, "hotswap: COMGR rewrite failed for %s -> %s (rc=%d)\n",
+            source_isa, target_isa, static_cast<int>(status));
+    return static_cast<int>(status);
+  }
+
+  // Extract output bytes.
+  size_t output_size = 0;
+  status = amd_comgr_get_data(output, &output_size, nullptr);
+  if (status != AMD_COMGR_STATUS_SUCCESS || output_size == 0) {
+    amd_comgr_release_data(output);
+    fprintf(stderr, "hotswap: failed to query COMGR output size\n");
+    return static_cast<int>(status);
+  }
+
+  void *output_buf = std::malloc(output_size);
+  if (!output_buf) {
+    amd_comgr_release_data(output);
+    fprintf(stderr, "hotswap: failed to allocate output buffer\n");
+    return -1;
+  }
+
+  status = amd_comgr_get_data(output, &output_size,
+                              static_cast<char *>(output_buf));
+  amd_comgr_release_data(output);
+
+  if (status != AMD_COMGR_STATUS_SUCCESS) {
+    std::free(output_buf);
+    fprintf(stderr, "hotswap: failed to extract COMGR output data\n");
+    return static_cast<int>(status);
+  }
+
+  OwnedElf owned_output(output_buf, &std::free);
+  *out_data = owned_output.release();
+  *out_size = output_size;
   return 0;
 }
 


### PR DESCRIPTION
## Motivation
Connect the hotswap tools library to the real upstream COMGR amd_comgr_hotswap_rewrite API, which has now landed in ROCm/llvm-project amd-staging (#1975). This removes the transitional mock COMGR and makes hotswap fully functional against the real rewriting backend.

## Technical Details
The upstream COMGR API uses amd_comgr_data_t objects rather than the raw void* buffers from the pre-merge prototype:

amd_comgr_status_t amd_comgr_hotswap_rewrite(
    amd_comgr_data_t input,
    const char *source_isa_name,
    const char *target_isa_name,
    amd_comgr_data_t *output);

## Changes:

hotswap.cpp: Uses #include <amd_comgr.h> and the standard data-object API. Input ELF bytes are wrapped in amd_comgr_data_t (AMD_COMGR_DATA_KIND_EXECUTABLE), passed to amd_comgr_hotswap_rewrite, and output bytes extracted via amd_comgr_get_data. The RetargetCodeObject wrapper still presents the same raw-buffer interface to the tool layer — the data-object wrapping is internal.
CMakeLists.txt: COMGR is now required via find_package(amd_comgr CONFIG REQUIRED). Mock fallback and all TODO(COMGR-upstream) markers removed.
COMGR-side API: https://github.com/ROCm/llvm-project/pull/1975 Hotswap tools lib: https://github.com/ROCm/rocm-systems/pull/4752

##JIRA ID

##Test Plan
Build COMGR from rocm/amd-staging with hotswap enabled
Build projects/hotswap/ with -Damd_comgr_DIR=<path to COMGR cmake config>
Verify ldd libhsa-hotswap.so shows direct linkage to libamd_comgr.so.3
Run hotswap_test and ctest --output-on-failure
Test Result
ldd libhsa-hotswap.so confirms libamd_comgr.so.3 (real library, not mock)
hotswap_test: 12 passed, 0 failed
ctest: 1/1 passed (100%)
