### PR TITLE
[RCCL] Fix static library build

### DIFF
--- a/projects/rccl/CMakeLists.txt
+++ b/projects/rccl/CMakeLists.txt
@@ -615,7 +615,33 @@ configure_file(src/nccl.h.in ${PROJECT_BINARY_DIR}/include/nccl.h)      # Used b
 
 # Add subdirectories
 #==================================================================================================
-# Source directory contains library creation
+# For shared builds, PRIVATE keeps internal deps from leaking into consumers' link lines.
+# For static builds, PUBLIC is required: librccl.a has no embedded deps, so consumers
+# must satisfy all transitive deps at their own link step. CMake propagates PUBLIC deps
+# automatically when the consumer uses target_link_libraries(... rccl).
+if(BUILD_SHARED_LIBS)
+  set(_dep_vis PRIVATE)
+else()
+  set(_dep_vis PUBLIC)
+endif()
+
+if(NOT BUILD_SHARED_LIBS)
+  # CMAKE_CXX_CREATE_STATIC_LIBRARY replaces the entire archive creation step as a single
+  # command, unlike CMAKE_CXX_ARCHIVE_CREATE which is split into create/append/finish and
+  # can be bypassed for large object lists. Must be set before add_subdirectory(src) so it
+  # is in effect when the rccl target is created.
+  # Only GPU offload flags are passed here. CMAKE_CXX_FLAGS / CMAKE_CXX_FLAGS_<BUILD_TYPE>
+  # are intentionally excluded: compile flags (-O3, -std=c++17, etc.) are already baked
+  # into each .o file, and link-time runtime selectors are only valid for final
+  # executable/shared-library linking, not --emit-static-lib.
+  set(_static_flags --hip-link -fgpu-rdc --emit-static-lib)
+  foreach(_target ${GPU_TARGETS})
+    list(APPEND _static_flags --offload-arch=${_target})
+  endforeach()
+  list(JOIN _static_flags " " _static_flags_str)
+  set(CMAKE_CXX_CREATE_STATIC_LIBRARY "<CMAKE_CXX_COMPILER> ${_static_flags_str} -o <TARGET> <OBJECTS>")
+endif()
+
 add_subdirectory(src)
 
 # LLVM IR / bitcode for nccl_device APIs (HIP / AMDGPU)
@@ -631,6 +657,24 @@ if(EMIT_LLVM_IR)
   add_dependencies(llvm_ir copy_nccl_device_headers)
   # Convenience aggregate target: builds librccl.so together with the bitcode.
   add_custom_target(rccl_with_ir ALL DEPENDS rccl llvm_ir)
+endif()
+
+# rocprofiler-register: optional instrumentation support (ROCm >= 6.1).
+# find_package is called here (root scope) rather than inside add_subdirectory(src) so
+# that the rocprofiler-register::rocprofiler-register imported target is visible to all
+# sibling subdirectories (e.g. test/) that consume librccl.a transitively.
+if(ROCM_VERSION VERSION_GREATER_EQUAL "60100")
+  option(RCCL_ROCPROFILER_REGISTER "Enable rocprofiler-register support" ON)
+else()
+  if(RCCL_ROCPROFILER_REGISTER)
+    message(AUTHOR_WARNING "RCCL_ROCPROFILER_REGISTER is not valid option for ROCm < 6.1.0. Current ROCm version: ${ROCM_VERSION}")
+  endif()
+  set(RCCL_ROCPROFILER_REGISTER OFF CACHE BOOL "" FORCE)
+endif()
+if(RCCL_ROCPROFILER_REGISTER)
+  find_package(rocprofiler-register REQUIRED)
+  target_compile_definitions(rccl PRIVATE RCCL_ROCPROFILER_REGISTER=1)
+  target_link_libraries(rccl ${_dep_vis} rocprofiler-register::rocprofiler-register)
 endif()
 
 # Install settings

--- a/projects/rccl/CMakeLists.txt
+++ b/projects/rccl/CMakeLists.txt
@@ -568,8 +568,55 @@ configure_file(src/nccl.h.in ${PROJECT_BINARY_DIR}/include/nccl.h)      # Used b
 
 # Add subdirectories
 #==================================================================================================
-# Source directory contains library creation
+# For shared builds, PRIVATE keeps internal deps from leaking into consumers' link lines.
+# For static builds, PUBLIC is required: librccl.a has no embedded deps, so consumers
+# must satisfy all transitive deps at their own link step. CMake propagates PUBLIC deps
+# automatically when the consumer uses target_link_libraries(... rccl).
+if(BUILD_SHARED_LIBS)
+  set(_dep_vis PRIVATE)
+else()
+  set(_dep_vis PUBLIC)
+endif()
+
+if(NOT BUILD_SHARED_LIBS)
+  # CMAKE_CXX_CREATE_STATIC_LIBRARY replaces the entire archive creation step as a single
+  # command, unlike CMAKE_CXX_ARCHIVE_CREATE which is split into create/append/finish and
+  # can be bypassed for large object lists. Must be set before add_subdirectory(src) so it
+  # is in effect when the rccl target is created.
+  # Only GPU offload flags are passed here. CMAKE_CXX_FLAGS / CMAKE_CXX_FLAGS_<BUILD_TYPE>
+  # are intentionally excluded: compile flags (-O3, -std=c++17, etc.) are already baked
+  # into each .o file, and link-time runtime selectors are only valid for final
+  # executable/shared-library linking, not --emit-static-lib.
+  set(_static_flags --hip-link -fgpu-rdc --emit-static-lib)
+  foreach(_target ${GPU_TARGETS})
+    list(APPEND _static_flags --offload-arch=${_target})
+  endforeach()
+  list(JOIN _static_flags " " _static_flags_str)
+  set(CMAKE_CXX_CREATE_STATIC_LIBRARY "<CMAKE_CXX_COMPILER> ${_static_flags_str} -o <TARGET> <OBJECTS>")
+endif()
+
 add_subdirectory(src)
+
+# rocprofiler-register: optional instrumentation support (ROCm >= 6.1).
+# find_package is called here (root scope) rather than inside add_subdirectory(src) so
+# that the rocprofiler-register::rocprofiler-register imported target is visible to all
+# sibling subdirectories (e.g. test/) that consume librccl.a transitively.
+if(ROCM_VERSION VERSION_GREATER_EQUAL "60100")
+  option(RCCL_ROCPROFILER_REGISTER "Enable rocprofiler-register support" ON)
+else()
+  if(RCCL_ROCPROFILER_REGISTER)
+    message(AUTHOR_WARNING "RCCL_ROCPROFILER_REGISTER is not valid option for ROCm < 6.1.0. Current ROCm version: ${ROCM_VERSION}")
+  endif()
+  set(RCCL_ROCPROFILER_REGISTER OFF CACHE BOOL "" FORCE)
+endif()
+if(RCCL_ROCPROFILER_REGISTER)
+  find_package(rocprofiler-register REQUIRED)
+  target_compile_definitions(rccl PRIVATE RCCL_ROCPROFILER_REGISTER=1)
+  target_link_libraries(rccl ${_dep_vis} rocprofiler-register::rocprofiler-register)
+endif()
+
+## Setup librccl.so version
+rocm_set_soversion(rccl "1.0")
 
 # Install settings
 #==================================================================================================

--- a/projects/rccl/src/CMakeLists.txt
+++ b/projects/rccl/src/CMakeLists.txt
@@ -979,21 +979,10 @@ if (NOT DWORDX4_INTRINSICS)
   target_compile_definitions(rccl PRIVATE DWORDX4_INTRINSICS_FORCE_OFF)
 endif()
 ## Set RCCL linked library directories
-target_link_directories(rccl PRIVATE ${SMI_LIB_DIR})
-
-if (ROCM_VERSION VERSION_GREATER_EQUAL "60100")
-    option(RCCL_ROCPROFILER_REGISTER "Enable rocprofiler-register support" ON)
-else()
-    if(RCCL_ROCPROFILER_REGISTER)
-        message(AUTHOR_WARNING "RCCL_ROCPROFILER_REGISTER is not valid option for ROCm < 6.2. Current ROCm version: ${ROCM_VERSION}")
-    endif()
-    set(RCCL_ROCPROFILER_REGISTER OFF CACHE BOOL "" FORCE)
-endif()
-if(RCCL_ROCPROFILER_REGISTER)
-  find_package(rocprofiler-register REQUIRED)
-  target_compile_definitions(rccl PRIVATE RCCL_ROCPROFILER_REGISTER=1)
-  target_link_libraries(
-      rccl PRIVATE rocprofiler-register::rocprofiler-register)
+# Only needed for plain library names (e.g. rocm_smi64). Imported targets (e.g. amd_smi)
+# carry their own location and do not require an explicit search path.
+if(DEFINED SMI_LIBRARIES AND NOT TARGET ${SMI_LIBRARIES})
+  target_link_directories(rccl ${_dep_vis} ${SMI_LIB_DIR})
 endif()
 
 # Device Linker: include pipeline and wire up dependencies
@@ -1007,19 +996,21 @@ if(ENABLE_DEVICE_LINKER)
 endif()
 
 ## Set RCCL linked libraries
+# _dep_vis is PRIVATE for shared builds (deps baked into .so) and PUBLIC for static builds
+# (consumers must satisfy all transitive deps at their own link step). Set in root CMakeLists.txt.
 if (HAVE_BFD)
-  target_link_libraries(rccl PRIVATE bfd)
+  target_link_libraries(rccl ${_dep_vis} bfd)
   if(HAVE_IBERTY)
-    target_link_libraries(rccl PRIVATE iberty z)
+    target_link_libraries(rccl ${_dep_vis} iberty z)
   endif()
 endif()
 if (ROCTX_ENABLE)
-  target_link_libraries(rccl PRIVATE ${ROCTX_LIB})
+  target_link_libraries(rccl ${_dep_vis} ${ROCTX_LIB})
 endif()
 if(NOT ENABLE_DEVICE_LINKER)
   target_link_libraries(rccl PRIVATE   -fgpu-rdc)             # Required when linking relocatable device code
 endif()
-target_link_libraries(rccl PRIVATE   Threads::Threads)
+target_link_libraries(rccl ${_dep_vis} Threads::Threads)
 target_link_libraries(rccl INTERFACE hip::host)
 if(ENABLE_DEVICE_LINKER)
   # Device code is compiled separately by the DeviceLinker pipeline.
@@ -1040,18 +1031,18 @@ if(ENABLE_DEVICE_LINKER)
 else()
   target_link_libraries(rccl PRIVATE hip::device)
 endif()
-target_link_libraries(rccl PRIVATE   dl)
+target_link_libraries(rccl ${_dep_vis} dl)
 # Direct-link the HSA runtime. RCCL already depends on it transitively through the
 # HIP runtime, so this is runtime-neutral. The linker records DT_NEEDED
 # libhsa-runtime64.so.1 automatically (no SONAME string in source) and it resolves
 # via librccl's existing RPATH, the same entry that already resolves libamdhip64.
 # This replaces the previous dlopen("libhsa-runtime64.so") which broke on runtime
 # trees (e.g. TheRock pip wheels) that ship no unversioned developer symlink.
-target_link_libraries(rccl PRIVATE   hsa-runtime64::hsa-runtime64)
-target_link_libraries(rccl PRIVATE   ${SMI_LIBRARIES})
+target_link_libraries(rccl ${_dep_vis} hsa-runtime64::hsa-runtime64)
+target_link_libraries(rccl ${_dep_vis} ${SMI_LIBRARIES})
 # librocm-core provides getROCmVersion() for reporting the runtime ROCm version.
 if(ROCM_MAJOR_VERSION GREATER_EQUAL 6)
-  target_link_libraries(rccl PRIVATE -L${ROCM_PATH}/lib -lrocm-core)
+  target_link_libraries(rccl ${_dep_vis} -L${ROCM_PATH}/lib -lrocm-core)
 endif()
 # Wrap fmt in $<BUILD_INTERFACE:...> so it's only used while building rccl
 # and is omitted from the exported rccl-targets export set. Without this,

--- a/projects/rccl/src/CMakeLists.txt
+++ b/projects/rccl/src/CMakeLists.txt
@@ -1041,8 +1041,12 @@ target_link_libraries(rccl ${_dep_vis} dl)
 target_link_libraries(rccl ${_dep_vis} hsa-runtime64::hsa-runtime64)
 target_link_libraries(rccl ${_dep_vis} ${SMI_LIBRARIES})
 # librocm-core provides getROCmVersion() for reporting the runtime ROCm version.
+# Only link if the library is actually available (not present in all build environments).
 if(ROCM_MAJOR_VERSION GREATER_EQUAL 6)
-  target_link_libraries(rccl ${_dep_vis} -L${ROCM_PATH}/lib -lrocm-core)
+  find_library(ROCM_CORE_LIB rocm-core PATHS ${ROCM_PATH}/lib NO_DEFAULT_PATH)
+  if(ROCM_CORE_LIB)
+    target_link_libraries(rccl ${_dep_vis} ${ROCM_CORE_LIB})
+  endif()
 endif()
 # Wrap fmt in $<BUILD_INTERFACE:...> so it's only used while building rccl
 # and is omitted from the exported rccl-targets export set. Without this,

--- a/projects/rccl/src/CMakeLists.txt
+++ b/projects/rccl/src/CMakeLists.txt
@@ -901,21 +901,10 @@ if (NOT DWORDX4_INTRINSICS)
   target_compile_definitions(rccl PRIVATE DWORDX4_INTRINSICS_FORCE_OFF)
 endif()
 ## Set RCCL linked library directories
-target_link_directories(rccl PRIVATE ${SMI_LIB_DIR})
-
-if (ROCM_VERSION VERSION_GREATER_EQUAL "60100")
-    option(RCCL_ROCPROFILER_REGISTER "Enable rocprofiler-register support" ON)
-else()
-    if(RCCL_ROCPROFILER_REGISTER)
-        message(AUTHOR_WARNING "RCCL_ROCPROFILER_REGISTER is not valid option for ROCm < 6.2. Current ROCm version: ${ROCM_VERSION}")
-    endif()
-    set(RCCL_ROCPROFILER_REGISTER OFF CACHE BOOL "" FORCE)
-endif()
-if(RCCL_ROCPROFILER_REGISTER)
-  find_package(rocprofiler-register REQUIRED)
-  target_compile_definitions(rccl PRIVATE RCCL_ROCPROFILER_REGISTER=1)
-  target_link_libraries(
-      rccl PRIVATE rocprofiler-register::rocprofiler-register)
+# Only needed for plain library names (e.g. rocm_smi64). Imported targets (e.g. amd_smi)
+# carry their own location and do not require an explicit search path.
+if(DEFINED SMI_LIBRARIES AND NOT TARGET ${SMI_LIBRARIES})
+  target_link_directories(rccl ${_dep_vis} ${SMI_LIB_DIR})
 endif()
 
 # Device Linker: include pipeline and wire up dependencies
@@ -929,19 +918,22 @@ if(ENABLE_DEVICE_LINKER)
 endif()
 
 ## Set RCCL linked libraries
+# _dep_vis is PRIVATE for shared builds (deps baked into .so) and PUBLIC for static builds
+# (consumers must satisfy all transitive deps at their own link step). Set in root CMakeLists.txt.
 if (HAVE_BFD)
-  target_link_libraries(rccl PRIVATE bfd)
+  target_link_libraries(rccl ${_dep_vis} bfd)
   if(HAVE_IBERTY)
-    target_link_libraries(rccl PRIVATE iberty z)
+    target_link_libraries(rccl ${_dep_vis} iberty z)
   endif()
 endif()
 if (ROCTX_ENABLE)
-  target_link_libraries(rccl PRIVATE ${ROCTX_LIB})
+  target_link_libraries(rccl ${_dep_vis} ${ROCTX_LIB})
 endif()
+<<<<<<< HEAD
 if(NOT ENABLE_DEVICE_LINKER)
   target_link_libraries(rccl PRIVATE   -fgpu-rdc)             # Required when linking relocatable device code
 endif()
-target_link_libraries(rccl PRIVATE   Threads::Threads)
+target_link_libraries(rccl ${_dep_vis} Threads::Threads)
 target_link_libraries(rccl INTERFACE hip::host)
 if(ENABLE_DEVICE_LINKER)
   # Device code is compiled separately by the DeviceLinker pipeline.
@@ -962,8 +954,8 @@ if(ENABLE_DEVICE_LINKER)
 else()
   target_link_libraries(rccl PRIVATE hip::device)
 endif()
-target_link_libraries(rccl PRIVATE   dl)
-target_link_libraries(rccl PRIVATE   ${SMI_LIBRARIES})
+target_link_libraries(rccl ${_dep_vis} dl)
+target_link_libraries(rccl ${_dep_vis} ${SMI_LIBRARIES})
 # Wrap fmt in $<BUILD_INTERFACE:...> so it's only used while building rccl
 # and is omitted from the exported rccl-targets export set. Without this,
 # a FetchContent-built fmt-header-only target leaks into rccl's link

--- a/projects/rccl/test/CMakeLists.txt
+++ b/projects/rccl/test/CMakeLists.txt
@@ -199,14 +199,6 @@ if(BUILD_TESTS)
     ../src/misc/latency_profiler/CollTraceUtils.cc
     )
 
-  # _RecorderTests.cpp uses RcclMockFuncs.hpp which defines ncclDebugLog and getHostName as
-  # non-weak stubs. With a shared library these override the library symbols at runtime, but
-  # with a static library the linker sees duplicate definitions and errors out. Exclude from
-  # static builds.
-  if(BUILD_SHARED_LIBS)
-    list(APPEND TEST_SOURCE_FILES _RecorderTests.cpp)
-  endif()
-
   # Due to default hidden symbol visibility, append source file if build type is not Debug.
   # It requires explicit addition of the following source file(s)
   # to the unit tests to ensure it is included for the existing rccl-UnitTests execution
@@ -270,6 +262,7 @@ if(BUILD_TESTS)
       RcclWrapTests.cpp
       TransportTests.cpp
       TimeoutTests.cpp
+      _RecorderTests.cpp
       mem_manager/MemManagerTests.cpp
       graph/XmlTests.cpp
       graph/NetDevsPolicyP2pNetTests.cpp
@@ -437,7 +430,8 @@ if(BUILD_TESTS)
         endif()
     endif()
 
-    if(ROCM_VERSION VERSION_GREATER_EQUAL "60400" AND CMAKE_BUILD_TYPE MATCHES "Debug")
+    if(ROCM_VERSION VERSION_GREATER_EQUAL "60400" AND
+        (CMAKE_BUILD_TYPE MATCHES "Debug" OR NOT BUILD_SHARED_LIBS))
         set(_rccl_test_categories_fixtures_debug_yaml "${CMAKE_CURRENT_SOURCE_DIR}/test_categories_fixtures_debug.yaml")
         if(EXISTS "${_rccl_test_categories_fixtures_debug_yaml}")
             message(STATUS "Applying test categories for rccl-UnitTestsFixturesDebug")
@@ -450,7 +444,9 @@ if(BUILD_TESTS)
         else()
             message(WARNING "Skipping test categories for rccl-UnitTestsFixturesDebug: missing ${_rccl_test_categories_fixtures_debug_yaml}")
         endif()
+    endif()
 
+    if(ROCM_VERSION VERSION_GREATER_EQUAL "60400" AND CMAKE_BUILD_TYPE MATCHES "Debug")
         set(_rccl_test_categories_altrsmi_yaml "${CMAKE_CURRENT_SOURCE_DIR}/test_categories_altrsmi.yaml")
         if(EXISTS "${_rccl_test_categories_altrsmi_yaml}")
             message(STATUS "Applying test categories for rccl-UnitTestsAltRsmi")

--- a/projects/rccl/test/CMakeLists.txt
+++ b/projects/rccl/test/CMakeLists.txt
@@ -250,8 +250,10 @@ if(BUILD_TESTS)
   endif()
 
   # rccl-UnitTestsFixturesDebug: Tests that access internal symbols compiled into
-  # librccl.so which are only visible in Debug builds (hidden visibility in Release).
-  if (ROCM_VERSION VERSION_GREATER_EQUAL "60400" AND CMAKE_BUILD_TYPE MATCHES "Debug")
+  # librccl.so which are only visible in Debug builds (hidden visibility in Release)
+  # or static builds.
+  if (ROCM_VERSION VERSION_GREATER_EQUAL "60400" AND
+      (CMAKE_BUILD_TYPE MATCHES "Debug" OR NOT BUILD_SHARED_LIBS))
     list(APPEND RCCL_TEST_EXECUTABLES rccl-UnitTestsFixturesDebug)
 
     set(TEST_FIXTURE_DEBUG_SOURCE_FILES

--- a/projects/rccl/test/CMakeLists.txt
+++ b/projects/rccl/test/CMakeLists.txt
@@ -140,6 +140,8 @@ if(BUILD_TESTS)
     hip::host hip::device hsa-runtime64::hsa-runtime64
     Threads::Threads
     dl
+    rt
+    numa
     fmt::fmt-header-only
   )
   if(OPENMP_TESTS_ENABLED)
@@ -181,7 +183,6 @@ if(BUILD_TESTS)
     SendRecvTests.cpp
     StandaloneTests.cpp
     TeardownStressTests.cpp
-    _RecorderTests.cpp
     common/main.cpp
     common/CallCollectiveForked.cpp
     common/CollectiveArgs.cpp
@@ -197,6 +198,14 @@ if(BUILD_TESTS)
     latency_profiler/LatencyProfilerUnitTest.cpp
     ../src/misc/latency_profiler/CollTraceUtils.cc
     )
+
+  # _RecorderTests.cpp uses RcclMockFuncs.hpp which defines ncclDebugLog and getHostName as
+  # non-weak stubs. With a shared library these override the library symbols at runtime, but
+  # with a static library the linker sees duplicate definitions and errors out. Exclude from
+  # static builds.
+  if(BUILD_SHARED_LIBS)
+    list(APPEND TEST_SOURCE_FILES _RecorderTests.cpp)
+  endif()
 
   # Due to default hidden symbol visibility, append source file if build type is not Debug.
   # It requires explicit addition of the following source file(s)
@@ -366,16 +375,17 @@ if(BUILD_TESTS)
         set_target_properties(${test_executable} PROPERTIES LINK_FLAGS "${MPI_CXX_LINK_FLAGS}")
       endif()
     endif()
+    # For shared builds: CMake links librccl.so and its PRIVATE deps are baked in.
+    # For static builds: CMake links librccl.a and propagates all PUBLIC deps from the
+    # rccl target automatically (set via _dep_vis=PUBLIC in the root CMakeLists.txt).
+    # No manual dep listing needed in either case.
+    target_link_libraries(${test_executable} PRIVATE rccl)
     if(BUILD_SHARED_LIBS)
-      target_link_libraries(${test_executable} PRIVATE rccl)
       if(${HOST_OS_ID} STREQUAL "debian")
         set_property(TARGET ${test_executable} PROPERTY INSTALL_RPATH "${CMAKE_BINARY_DIR}")
       elseif(DEFINED HOST_OS_FAMILY AND "${HOST_OS_FAMILY}" STREQUAL "debian")
         set_property(TARGET ${test_executable} PROPERTY INSTALL_RPATH "${CMAKE_BINARY_DIR}")
       endif()
-    else()
-      add_dependencies(${test_executable} rccl)
-      target_link_libraries(${test_executable} PRIVATE dl rt numa -lrccl -L${CMAKE_BINARY_DIR} -lrocm_smi64 -L${ROCM_PATH}/lib -L${ROCM_PATH}/rocm_smi/lib)
     endif()
 
     rocm_install(TARGETS ${test_executable} COMPONENT tests)

--- a/projects/rccl/test/CMakeLists.txt
+++ b/projects/rccl/test/CMakeLists.txt
@@ -127,6 +127,8 @@ if(BUILD_TESTS)
     hip::host hip::device hsa-runtime64::hsa-runtime64
     Threads::Threads
     dl
+    rt
+    numa
     fmt::fmt-header-only
   )
   if(OPENMP_TESTS_ENABLED)
@@ -166,7 +168,6 @@ if(BUILD_TESTS)
     ScatterTests.cpp
     SendRecvTests.cpp
     StandaloneTests.cpp
-    _RecorderTests.cpp
     common/main.cpp
     common/CallCollectiveForked.cpp
     common/CollectiveArgs.cpp
@@ -182,6 +183,14 @@ if(BUILD_TESTS)
     latency_profiler/LatencyProfilerUnitTest.cpp
     ../src/misc/latency_profiler/CollTraceUtils.cc
     )
+
+  # _RecorderTests.cpp uses RcclMockFuncs.hpp which defines ncclDebugLog and getHostName as
+  # non-weak stubs. With a shared library these override the library symbols at runtime, but
+  # with a static library the linker sees duplicate definitions and errors out. Exclude from
+  # static builds.
+  if(BUILD_SHARED_LIBS)
+    list(APPEND TEST_SOURCE_FILES _RecorderTests.cpp)
+  endif()
 
   # Due to default hidden symbol visibility, append source file if build type is not Debug.
   # It requires explicit addition of the following source file(s)
@@ -324,16 +333,17 @@ if(BUILD_TESTS)
         set_target_properties(${test_executable} PROPERTIES LINK_FLAGS "${MPI_CXX_LINK_FLAGS}")
       endif()
     endif()
+    # For shared builds: CMake links librccl.so and its PRIVATE deps are baked in.
+    # For static builds: CMake links librccl.a and propagates all PUBLIC deps from the
+    # rccl target automatically (set via _dep_vis=PUBLIC in the root CMakeLists.txt).
+    # No manual dep listing needed in either case.
+    target_link_libraries(${test_executable} PRIVATE rccl)
     if(BUILD_SHARED_LIBS)
-      target_link_libraries(${test_executable} PRIVATE rccl)
       if(${HOST_OS_ID} STREQUAL "debian")
         set_property(TARGET ${test_executable} PROPERTY INSTALL_RPATH "${CMAKE_BINARY_DIR}")
       elseif(DEFINED HOST_OS_FAMILY AND "${HOST_OS_FAMILY}" STREQUAL "debian")
         set_property(TARGET ${test_executable} PROPERTY INSTALL_RPATH "${CMAKE_BINARY_DIR}")
       endif()
-    else()
-      add_dependencies(${test_executable} rccl)
-      target_link_libraries(${test_executable} PRIVATE dl rt numa -lrccl -L${CMAKE_BINARY_DIR} -lrocm_smi64 -L${ROCM_PATH}/lib -L${ROCM_PATH}/rocm_smi/lib)
     endif()
 
     rocm_install(TARGETS ${test_executable} COMPONENT tests)

--- a/projects/rccl/test/CMakeLists.txt
+++ b/projects/rccl/test/CMakeLists.txt
@@ -232,8 +232,10 @@ if(BUILD_TESTS)
   endif()
 
   # rccl-UnitTestsFixturesDebug: Tests that access internal symbols compiled into
-  # librccl.so which are only visible in Debug builds (hidden visibility in Release).
-  if (ROCM_VERSION VERSION_GREATER_EQUAL "60400" AND CMAKE_BUILD_TYPE MATCHES "Debug")
+  # librccl.so which are only visible in Debug builds (hidden visibility in Release)
+  # or static builds.
+  if (ROCM_VERSION VERSION_GREATER_EQUAL "60400" AND
+      (CMAKE_BUILD_TYPE MATCHES "Debug" OR NOT BUILD_SHARED_LIBS))
     list(APPEND RCCL_TEST_EXECUTABLES rccl-UnitTestsFixturesDebug)
 
     set(TEST_FIXTURE_DEBUG_SOURCE_FILES

--- a/projects/rccl/test/_RecorderTests.cpp
+++ b/projects/rccl/test/_RecorderTests.cpp
@@ -7,7 +7,6 @@
 #include <gtest/gtest.h>
 #include <rccl/rccl.h>
 
-#include "RcclMockFuncs.hpp"
 #include "comm.h"
 #include "common/ProcessIsolatedTestRunner.hpp"
 

--- a/projects/rccl/test/common/TransportUtils.hpp
+++ b/projects/rccl/test/common/TransportUtils.hpp
@@ -47,10 +47,21 @@ inline ncclResult_t bootstrapIntraNodeAllGather(struct ncclBootstrap* bootstrap,
 //Helper function for capturing the output for DumpDataTest
 inline std::string captureStdout(std::function<void()> func) {
   int pipefd[2];
-  pipe(pipefd);
+  if (pipe(pipefd) == -1) return "";
 
   int saved_stdout = dup(STDOUT_FILENO);
-  dup2(pipefd[1], STDOUT_FILENO);
+  if (saved_stdout == -1) {
+    close(pipefd[0]);
+    close(pipefd[1]);
+    return "";
+  }
+
+  if (dup2(pipefd[1], STDOUT_FILENO) == -1) {
+    close(pipefd[0]);
+    close(pipefd[1]);
+    close(saved_stdout);
+    return "";
+  }
   close(pipefd[1]);
 
   func();
@@ -62,6 +73,7 @@ inline std::string captureStdout(std::function<void()> func) {
   char buffer[4096];
   ssize_t count = read(pipefd[0], buffer, sizeof(buffer) - 1);
   close(pipefd[0]);
+  if (count < 0) return "";
   buffer[count] = '\0';
 
   return std::string(buffer);

--- a/projects/rccl/test/common/TransportUtils.hpp
+++ b/projects/rccl/test/common/TransportUtils.hpp
@@ -12,7 +12,7 @@
 #include "TestBed.hpp"
 
 void dumpData(struct ncclConnect* data, int ndata);
-ncclResult_t bootstrapAllGather(void* bootstrap, void* data, int size) {
+inline ncclResult_t bootstrapAllGather(void* bootstrap, void* data, int size) {
   memcpy((char*)data + size, data, size); // Simulate copying rank 0 connect to rank 1
   return ncclSuccess;
 }
@@ -20,15 +20,15 @@ ncclResult_t bootstrapAllGather(void* bootstrap, void* data, int size) {
 namespace RcclUnitTesting
 {
 //Mock functions for CollNetRecvSetup and CollNetSendSetup
-ncclResult_t mockSetup(struct ncclComm* comm, struct ncclTopoGraph* graph,
-                       struct ncclPeerInfo* myInfo, struct ncclPeerInfo* peerInfo,
-                       struct ncclConnect* connect, struct ncclConnector* connector,
-                       int channelId, int type) {
+inline ncclResult_t mockSetup(struct ncclComm* comm, struct ncclTopoGraph* graph,
+                              struct ncclPeerInfo* myInfo, struct ncclPeerInfo* peerInfo,
+                              struct ncclConnect* connect, struct ncclConnector* connector,
+                              int channelId, int type) {
   memset(connect, 42, sizeof(struct ncclConnect)); // dummy data
   return ncclSuccess;
 }
 
-ncclResult_t mockConnect(struct ncclComm* comm, struct ncclConnect* connect,
+inline ncclResult_t mockConnect(struct ncclComm* comm, struct ncclConnect* connect,
                          int nranks, int rank, struct ncclConnector* connector) {
   memset(&connector->conn, 99, sizeof(connector->conn)); // dummy
   return ncclSuccess;
@@ -37,21 +37,15 @@ ncclResult_t mockConnect(struct ncclComm* comm, struct ncclConnect* connect,
 // Dummy bootstrap implementation for testing NcclTransportCollNetCheckTestSuccess and NcclTransportCollNetCheckTestFails
 struct ncclBootstrap {};
 
-ncclResult_t bootstrapIntraNodeAllGather(
-struct ncclBootstrap* bootstrap,
-int* localRankToRank,
-int localRank,
-int localRanks,
-int* data,
-size_t size
-) {
+inline ncclResult_t bootstrapIntraNodeAllGather(struct ncclBootstrap* bootstrap, int* localRankToRank, int localRank,
+                                                int localRanks, int* data, size_t size) {
   data[0] = 0; // Rank 0 is fine
   data[1] = 1; // Rank 1 reports failure
   return ncclSuccess;
 }
 
 //Helper function for capturing the output for DumpDataTest
-std::string captureStdout(std::function<void()> func) {
+inline std::string captureStdout(std::function<void()> func) {
   int pipefd[2];
   pipe(pipefd);
 


### PR DESCRIPTION
## Motivation

RCCL static builds were successful, but caused missing and duplicate symbol errors when used to build rccl-tests. This PR fixes RCCL static library build and transitive dependency propagation. Also, fixes RCCL UnitTests build for static librccl.

We need to fix both RCCL and RCCL-Tests (which will be fixed in a different PR).

## Technical Details

**root `CMakeLists.txt`**:
- Add `_dep_vis` (PRIVATE for shared, PUBLIC for static) before `add_subdirectory(src)` so src/ inherits it. PUBLIC causes CMake to record transitive dependencies in the rccl target's INTERFACE, propagating them automatically to all consumers.
- Fix `_static_flags`: remove stale `${CXXFLAGS}` reference and clarify why compile flags are intentionally excluded from `--emit-static-lib` invocation.
- Move `RCCL_ROCPROFILER_REGISTER` block from `src/CMakeLists.txt` to root scope, placed between `add_subdirectory(src)` and `add_subdirectory(test)`. Imported targets from `find_package` are directory-scoped; calling it at root makes `rocprofiler-register::rocprofiler-register` visible to `test/` as a sibling.

**`src/CMakeLists.txt`**:
- Remove `src/ras/client.cc` from the library source list — it defines `main()` and causes duplicate symbol errors when linked into any executable.
- Apply `${_dep_vis}` to all host-side transitive deps: `Threads::Threads`, `dl`, `SMI_LIBRARIES`, `ROCTX_LIB`, `bfd`/`iberty`/`z`, `rocprofiler-register`.
- Make `target_link_directories` conditional: imported targets (e.g. `amd_smi`) carry their own location; only plain lib names (e.g. `rocm_smi64`) need an explicit `-L`.
- Remove `RCCL_ROCPROFILER_REGISTER` block (moved to root CMakeLists.txt).

**`test/CMakeLists.txt`**:
- Replace `if(BUILD_SHARED_LIBS)/else()` manual dep block with a single `target_link_libraries(${test_executable} PRIVATE rccl)`. For shared builds CMake links librccl.so as before; for static builds CMake propagates all PUBLIC deps from the rccl target automatically — no manual listing required.
- Add `rt` and `numa` to `RCCL_COMMON_LINK_LIBS` (used directly by the test harness, not transitive from librccl.a).
- Exclude `_RecorderTests.cpp` from static builds: RcclMockFuncs.hpp defines non-weak stubs that conflict with symbols already compiled into librccl.a.

**`test/common/TransportUtils.hpp`**:
- Mark `bootstrapAllGather`, `mockSetup`, `mockConnect`, `bootstrapIntraNodeAllGather`, and `captureStdout` as `inline` to prevent duplicate symbol errors when the header is included across multiple TUs that also link against `librccl.a`.
- Check return values of `pipe()`, `dup()`, `dup2()`, and `read()` in `captureStdout`.

## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
