### PR TITLE
Add Python executable paths to all TheRock builds

### DIFF
--- a/.github/scripts/therock_configure_ci.py
+++ b/.github/scripts/therock_configure_ci.py
@@ -219,10 +219,21 @@ def retrieve_projects(args):
             )
             subtrees = list(subtree_to_project_map.keys())
 
+    # Holds the python-specific cmake options passed to TheRock build.
+    common_python_options = []
+
     # Linux CI skip logic: exclude Windows-only subtrees so they don't
     # produce Linux projects. If nothing remains, Linux CI is skipped.
     if args.get("platform") == "linux":
         subtrees = [s for s in subtrees if s not in windows_only_subtrees]
+
+        # Common Python executable options for all builds.
+        # Replaces TheRock's manylinux build behavior.
+        # See build_tools/github_actions/manylinux_config.py in TheRock.
+        common_python_options = [
+            "-DTHEROCK_SHARED_PYTHON_EXECUTABLES=/opt/python-shared/cp310-cp310/bin/python3;/opt/python-shared/cp311-cp311/bin/python3;/opt/python-shared/cp312-cp312/bin/python3;/opt/python-shared/cp313-cp313/bin/python3;/opt/python-shared/cp314-cp314/bin/python3",
+            "-DTHEROCK_DIST_PYTHON_EXECUTABLES=/opt/python/cp310-cp310/bin/python;/opt/python/cp311-cp311/bin/python;/opt/python/cp312-cp312/bin/python;/opt/python/cp313-cp313/bin/python",
+        ]
 
     # Windows CI skip logic: skip if neither the modified file paths nor the
     # explicitly selected subtrees require Windows CI.
@@ -272,6 +283,8 @@ def retrieve_projects(args):
         final_flags_list = sorted(merged_flags)
     # Always append -DTHEROCK_ENABLE_CORE=ON as a default at the end
     final_flags_list.append("-DTHEROCK_ENABLE_CORE=ON")
+    # Always append the Python options.
+    final_flags_list += common_python_options
     # Removing duplicates
     final_flags_list = list(set(final_flags_list))
     final_flags = " ".join(final_flags_list)

--- a/.github/workflows/therock-ci-linux.yml
+++ b/.github/workflows/therock-ci-linux.yml
@@ -22,7 +22,7 @@ jobs:
     permissions:
       id-token: write
     container:
-      image: ghcr.io/rocm/therock_build_manylinux_x86_64@sha256:583d473f263a289222c48d4b493e2956b2354a45796f09dee6f2c8ecd4504ab6
+      image: ghcr.io/rocm/therock_build_manylinux_x86_64@sha256:0e2c1b31f7e1661a3895508962f6c4e740a2dfd4575b9bfac87d538e3af20079 # 2026-03-02T08:49:42.738Z
       options: -v /runner/config:/home/awsconfig/
     strategy:
       fail-fast: true

--- a/.github/workflows/therock-rccl-ci-linux.yml
+++ b/.github/workflows/therock-rccl-ci-linux.yml
@@ -20,7 +20,7 @@ jobs:
     permissions:
       id-token: write
     container:
-      image: ghcr.io/rocm/therock_build_manylinux_x86_64@sha256:1f1ce0ab151146c7f86ee4345be74c42d8ca83200d9d26843e8a71df01ecad4e
+      image: ghcr.io/rocm/therock_build_manylinux_x86_64@sha256:0e2c1b31f7e1661a3895508962f6c4e740a2dfd4575b9bfac87d538e3af20079 # 2026-03-02T08:49:42.738Z
       options: -v /runner/config:/home/awsconfig/
     env:
       AMDGPU_FAMILIES: ${{ inputs.amdgpu_families }}


### PR DESCRIPTION
Configure shared and dist Python executables (3.10-3.14) for all build
configurations to ensure consistent Python environment across CI builds.

Also update the manylinux container hash to the latest.