### PR TITLE
[rocprofiler-systems] Fix counter sidecar output finalization across timemory managers

### DIFF
--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library/rocprofiler-sdk.cpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library/rocprofiler-sdk.cpp
@@ -2192,7 +2192,6 @@ flush_counter_storage_outputs()
             counter_storage::write(storage->storage.get(), storage->metric_name,
                                    storage->metric_description);
         }
-        storage->manager->cleanup(cleanup_key);
     }
 }
 

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library/rocprofiler-sdk.cpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library/rocprofiler-sdk.cpp
@@ -2192,7 +2192,7 @@ flush_counter_storage_outputs()
             counter_storage::write(storage->storage.get(), storage->metric_name,
                                    storage->metric_description);
         }
-            storage->manager->cleanup(cleanup_key);
+        storage->manager->cleanup(cleanup_key);
     }
 }
 

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library/rocprofiler-sdk.cpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library/rocprofiler-sdk.cpp
@@ -2159,6 +2159,33 @@ get_counter_storage()
 }
 
 void
+flush_counter_storage_outputs()
+{
+    auto* _agent_counter_storage = get_counter_storage();
+    if(!_agent_counter_storage) return;
+
+    auto _cleanup_keys = std::vector<std::pair<std::string, const counter_storage*>>{};
+    for(const auto& [agent_id, counter_map] : *_agent_counter_storage)
+    {
+        static_cast<void>(agent_id);
+        for(const auto& [counter_id, storage] : counter_map)
+        {
+            static_cast<void>(counter_id);
+            _cleanup_keys.emplace_back(storage.storage_name + "cleanup", &storage);
+        }
+    }
+
+    std::sort(_cleanup_keys.begin(), _cleanup_keys.end(),
+              [](const auto& lhs, const auto& rhs) { return *lhs.second < *rhs.second; });
+
+    for(const auto& [cleanup_key, storage] : _cleanup_keys)
+    {
+        if(storage && storage->storage && storage->manager)
+            storage->manager->cleanup(cleanup_key);
+    }
+}
+
+void
 counter_record_callback(rocprofiler_dispatch_counting_service_data_t dispatch_data,
                         rocprofiler_record_counter_t* record_data, size_t record_count,
                         rocprofiler_user_data_t /*user_data*/,
@@ -2744,6 +2771,7 @@ finalize_sdk_common()
 
     if(get_counter_storage())
     {
+        flush_counter_storage_outputs();
         get_counter_storage()->clear();
         delete get_counter_storage();
         get_counter_storage() = nullptr;

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library/rocprofiler-sdk.cpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library/rocprofiler-sdk.cpp
@@ -2180,7 +2180,18 @@ flush_counter_storage_outputs()
 
     for(const auto& [cleanup_key, storage] : _cleanup_keys)
     {
-        if(storage && storage->storage && storage->manager)
+        if(!storage || !storage->storage) continue;
+        if(storage->manager)
+        {
+            storage->manager->cleanup(cleanup_key);
+        }
+        else
+        {
+            // No tim::manager at construction (add_cleanup was skipped); still flush
+            // timemory storage once at shutdown.
+            counter_storage::write(storage->storage.get(), storage->metric_name,
+                                   storage->metric_description);
+        }
             storage->manager->cleanup(cleanup_key);
     }
 }

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library/rocprofiler-sdk/counters.cpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library/rocprofiler-sdk/counters.cpp
@@ -134,13 +134,13 @@ counter_storage::counter_storage(const client_data* _tool_data, uint64_t _devid,
                                                      storage_name);
     if(manager)
     {
-        manager->add_cleanup(
-            storage_name + "cleanup",
-            [storage_ptr = storage.get(), metric_name = metric_name,
-             metric_description = metric_description]() {
-                if(storage_ptr)
-                    counter_storage::write(storage_ptr, metric_name, metric_description);
-            });
+        manager->add_cleanup(storage_name + "cleanup",
+                             [storage_ptr = storage.get(), metric_name = metric_name,
+                              metric_description = metric_description]() {
+                                 if(storage_ptr)
+                                     counter_storage::write(storage_ptr, metric_name,
+                                                            metric_description);
+                             });
     }
     else
     {

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library/rocprofiler-sdk/counters.cpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library/rocprofiler-sdk/counters.cpp
@@ -129,14 +129,19 @@ counter_storage::counter_storage(const client_data* _tool_data, uint64_t _devid,
     _metric_name =
         std::regex_replace(_metric_name, std::regex{ "(.*)\\[([0-9]+)\\]" }, "$1_$2");
     storage_name = fmt::format("rocprof-device-{}-{}", device_id, _metric_name);
+    manager      = tim::manager::instance();
     storage = std::make_unique<counter_storage_type>(tim::standalone_storage{}, index,
                                                      storage_name);
-    tim::manager::instance()->add_cleanup(
-        storage_name + "cleanup", [storage_ptr = storage.get(), metric_name = metric_name,
-                                   metric_description = metric_description]() {
-            if(storage_ptr)
-                counter_storage::write(storage_ptr, metric_name, metric_description);
-        });
+    if(manager)
+    {
+        manager->add_cleanup(
+            storage_name + "cleanup",
+            [storage_ptr = storage.get(), metric_name = metric_name,
+             metric_description = metric_description]() {
+                if(storage_ptr)
+                    counter_storage::write(storage_ptr, metric_name, metric_description);
+            });
+    }
 
     {
         constexpr auto _unit = ::perfetto::CounterTrack::Unit::UNIT_COUNT;

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library/rocprofiler-sdk/counters.cpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library/rocprofiler-sdk/counters.cpp
@@ -142,6 +142,11 @@ counter_storage::counter_storage(const client_data* _tool_data, uint64_t _devid,
                     counter_storage::write(storage_ptr, metric_name, metric_description);
             });
     }
+    else
+    {
+        LOG_WARNING("{} counter_data_tracker is disabled. Can't add cleanup.",
+                    metric_name);
+    }
 
     {
         constexpr auto _unit = ::perfetto::CounterTrack::Unit::UNIT_COUNT;

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library/rocprofiler-sdk/counters.hpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library/rocprofiler-sdk/counters.hpp
@@ -87,6 +87,7 @@ struct counter_storage
     std::string                           metric_description = {};
     std::string                           storage_name       = {};
     std::string                           track_name         = {};
+    tim::manager::pointer_t               manager            = {};
     std::unique_ptr<counter_storage_type> storage            = {};
     std::unique_ptr<counter_track_type>   track              = {};
 


### PR DESCRIPTION
## Motivation

- https://github.com/ROCm/rocm-systems/actions/runs/24197370578/job/70673222051?pr=4276
- Hardware counters were collected correctly, but the rocprof-device-*.txt/.json artifacts were not generated because their cleanup callbacks were registered on a callback thread’s thread-local timemory manager while shutdown flushed a different manager, causing the transpose-rocprofiler-sampling validation tests to fail.

## Technical Details

-  counters.hpp now stores the owning tim::manager in each counter_storage, counters.cpp registers cleanup on that exact manager, and rocprofiler-sdk.cpp flushes those per-storage cleanup hooks before clearing counter storage during SDK finalization.

## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
