### PR TITLE
[rocshmem] Improve IPC conduit bandwidth and synchronization

### DIFF
--- a/projects/rocshmem/src/assembly.hpp
+++ b/projects/rocshmem/src/assembly.hpp
@@ -42,10 +42,6 @@ namespace rocshmem {
 
 __device__ __forceinline__ int uncached_load_ubyte([[maybe_unused]] uint8_t* src) {
   int ret = 0;
-#if defined(__gfx906__)
-#endif
-#if defined(__gfx908__)
-#endif
 #if defined(__gfx90a__) || defined(__gfx1100__)
   asm volatile(
       "global_load_ubyte %0 %1 off glc slc \n"
@@ -72,10 +68,6 @@ __device__ __forceinline__ int uncached_load_ubyte([[maybe_unused]] uint8_t* src
 
 __device__ __forceinline__ void refresh_volatile_sbyte([[maybe_unused]] volatile int *assigned_value,
                                                        [[maybe_unused]] volatile char *read_value) {
-#if defined(__gfx906__)
-#endif
-#if defined(__gfx908__)
-#endif
 #if defined(__gfx90a__) || defined(__gfx1100__)
   asm volatile(
     "global_load_sbyte %0 %1 off glc slc\n "
@@ -101,10 +93,6 @@ __device__ __forceinline__ void refresh_volatile_sbyte([[maybe_unused]] volatile
 
 __device__ __forceinline__ void refresh_volatile_dwordx2([[maybe_unused]] volatile uint64_t *assigned_value,
                                                          [[maybe_unused]] volatile uint64_t *read_value) {
-#if defined(__gfx906__)
-#endif
-#if defined(__gfx908__)
-#endif
 #if defined(__gfx90a__) || defined(__gfx1100__)
   asm volatile(
     "global_load_dwordx2 %0 %1 off glc slc\n "
@@ -139,10 +127,6 @@ NOWARN(-Wdeprecated-volatile,
     T ret{};
     switch (sizeof(T)) {
       case 4:
-#if defined(__gfx906__)
-#endif
-#if defined(__gfx908__)
-#endif
 #if defined(__gfx90a__) || defined(__gfx1100__)
         asm volatile(
             "global_load_dword %0 %1 off glc slc \n"
@@ -166,10 +150,6 @@ NOWARN(-Wdeprecated-volatile,
 #endif
         break;
       case 8:
-#if defined(__gfx906__)
-#endif
-#if defined(__gfx908__)
-#endif
 #if defined(__gfx90a__) || defined(__gfx1100__)
         asm volatile(
             "global_load_dwordx2 %0 %1 off glc slc \n"
@@ -221,10 +201,6 @@ __device__ __forceinline__ void store_asm(uint8_t* val, [[maybe_unused]] uint8_t
                                           int size) {
   switch (size) {
     case 2: {
-#if defined(__gfx906__)
-#endif
-#if defined(__gfx908__)
-#endif
 #if defined(__gfx90a__)
       int16_t val16{*(reinterpret_cast<int16_t*>(val))};
       asm volatile("flat_store_short %0 %1 glc slc" : : "v"(dst), "v"(val16));
@@ -245,10 +221,6 @@ __device__ __forceinline__ void store_asm(uint8_t* val, [[maybe_unused]] uint8_t
     }
     case 4: {
       [[maybe_unused]] int32_t val32{*(reinterpret_cast<int32_t*>(val))};
-#if defined(__gfx906__)
-#endif
-#if defined(__gfx908__)
-#endif
 #if defined(__gfx90a__) || defined(__gfx1100__)
       asm volatile("flat_store_dword %0 %1 glc slc" : : "v"(dst), "v"(val32));
 #endif
@@ -262,10 +234,6 @@ __device__ __forceinline__ void store_asm(uint8_t* val, [[maybe_unused]] uint8_t
     }
     case 8: {
       [[maybe_unused]] int64_t val64{*(reinterpret_cast<int64_t*>(val))};
-#if defined(__gfx906__)
-#endif
-#if defined(__gfx908__)
-#endif
 #if defined(__gfx90a__) || defined(__gfx1100__)
       asm volatile("flat_store_dwordx2 %0 %1 glc slc" : : "v"(dst), "v"(val64));
 #endif
@@ -278,11 +246,7 @@ __device__ __forceinline__ void store_asm(uint8_t* val, [[maybe_unused]] uint8_t
       break;
     }
     case 16: {
-      __int128_t val128{*(reinterpret_cast<__int128_t*>(val))};
-#if defined(__gfx906__)
-#endif
-#if defined(__gfx908__)
-#endif
+      [[maybe_unused]] __int128_t val128{*(reinterpret_cast<__int128_t*>(val))};
 #if defined(__gfx90a__) || defined(__gfx1100__)
       asm volatile("flat_store_dwordx4 %0 %1 glc slc" : : "v"(dst), "v"(val128));
 #endif

--- a/projects/rocshmem/src/assembly.hpp
+++ b/projects/rocshmem/src/assembly.hpp
@@ -277,6 +277,23 @@ __device__ __forceinline__ void store_asm(uint8_t* val, [[maybe_unused]] uint8_t
 #endif
       break;
     }
+    case 16: {
+      __int128_t val128{*(reinterpret_cast<__int128_t*>(val))};
+#if defined(__gfx906__)
+#endif
+#if defined(__gfx908__)
+#endif
+#if defined(__gfx90a__) || defined(__gfx1100__)
+      asm volatile("flat_store_dwordx4 %0 %1 glc slc" : : "v"(dst), "v"(val128));
+#endif
+#if defined(__gfx942__) || defined(__gfx950__)
+      asm volatile("flat_store_dwordx4 %0 %1 sc0 sc1" : : "v"(dst), "v"(val128));
+#endif
+#if defined(__gfx1201__)
+      asm volatile("flat_store_b128 %0 %1 scope:SCOPE_SYS" : : "v"(dst), "v"(val128));
+#endif
+      break;
+    }
     default:
       break;
   }

--- a/projects/rocshmem/src/atomic.hpp
+++ b/projects/rocshmem/src/atomic.hpp
@@ -136,6 +136,57 @@ void threadfence() {
   }
 }
 
+template <rocshmem_memory_order order>
+__device__ __forceinline__ void fence_workgroup() {
+  if constexpr (order == memory_order_acquire)
+    __builtin_amdgcn_fence(__ATOMIC_ACQUIRE, "workgroup");
+  else if constexpr (order == memory_order_release)
+    __builtin_amdgcn_fence(__ATOMIC_RELEASE, "workgroup");
+  else if constexpr (order == memory_order_acq_rel)
+    __builtin_amdgcn_fence(__ATOMIC_ACQ_REL, "workgroup");
+  else
+    __builtin_amdgcn_fence(__ATOMIC_SEQ_CST, "workgroup");
+}
+
+template <rocshmem_memory_order order>
+__device__ __forceinline__ void fence_agent() {
+  if constexpr (order == memory_order_acquire)
+    __builtin_amdgcn_fence(__ATOMIC_ACQUIRE, "agent");
+  else if constexpr (order == memory_order_release)
+    __builtin_amdgcn_fence(__ATOMIC_RELEASE, "agent");
+  else if constexpr (order == memory_order_acq_rel)
+    __builtin_amdgcn_fence(__ATOMIC_ACQ_REL, "agent");
+  else
+    __builtin_amdgcn_fence(__ATOMIC_SEQ_CST, "agent");
+}
+
+template <rocshmem_memory_order order>
+__device__ __forceinline__ void fence_system() {
+  if constexpr (order == memory_order_acquire)
+    __builtin_amdgcn_fence(__ATOMIC_ACQUIRE, "");
+  else if constexpr (order == memory_order_release)
+    __builtin_amdgcn_fence(__ATOMIC_RELEASE, "");
+  else if constexpr (order == memory_order_acq_rel)
+    __builtin_amdgcn_fence(__ATOMIC_ACQ_REL, "");
+  else
+    __builtin_amdgcn_fence(__ATOMIC_SEQ_CST, "");
+}
+
+template <rocshmem_memory_scope scope = memory_scope_system,
+          rocshmem_memory_order order = memory_order_seq_cst>
+__device__ __forceinline__
+void fence() {
+  if constexpr (scope == memory_scope_thread   ||
+                scope == memory_scope_wavefront ||
+                scope == memory_scope_workgroup) {
+    fence_workgroup<order>();
+  } else if constexpr (scope == memory_scope_agent) {
+    fence_agent<order>();
+  } else {
+    fence_system<order>();
+  }
+}
+
 } // namespace atomic
 } // namespace detail
 } // namespace rocshmem

--- a/projects/rocshmem/src/atomic.hpp
+++ b/projects/rocshmem/src/atomic.hpp
@@ -124,68 +124,31 @@ T fetch_min(T* obj, U arg, rocshmem_memory_orders o) {
   return __hip_atomic_fetch_min(obj, arg, o.atomic, s);
 }
 
-template <rocshmem_memory_scope s>
-__device__
-void threadfence() {
-  if constexpr (s == memory_scope_system) {
-    __threadfence_system();
-  } else if constexpr (s == memory_scope_agent) {
-    __threadfence();
-  } else if constexpr (s == memory_scope_workgroup) {
-    __threadfence_block();
-  }
-}
-
-template <rocshmem_memory_order order>
-__device__ __forceinline__ void fence_workgroup() {
-  if constexpr (order == memory_order_acquire)
-    __builtin_amdgcn_fence(__ATOMIC_ACQUIRE, "workgroup");
-  else if constexpr (order == memory_order_release)
-    __builtin_amdgcn_fence(__ATOMIC_RELEASE, "workgroup");
-  else if constexpr (order == memory_order_acq_rel)
-    __builtin_amdgcn_fence(__ATOMIC_ACQ_REL, "workgroup");
-  else
-    __builtin_amdgcn_fence(__ATOMIC_SEQ_CST, "workgroup");
-}
-
-template <rocshmem_memory_order order>
-__device__ __forceinline__ void fence_agent() {
-  if constexpr (order == memory_order_acquire)
-    __builtin_amdgcn_fence(__ATOMIC_ACQUIRE, "agent");
-  else if constexpr (order == memory_order_release)
-    __builtin_amdgcn_fence(__ATOMIC_RELEASE, "agent");
-  else if constexpr (order == memory_order_acq_rel)
-    __builtin_amdgcn_fence(__ATOMIC_ACQ_REL, "agent");
-  else
-    __builtin_amdgcn_fence(__ATOMIC_SEQ_CST, "agent");
-}
-
-template <rocshmem_memory_order order>
-__device__ __forceinline__ void fence_system() {
-  if constexpr (order == memory_order_acquire)
-    __builtin_amdgcn_fence(__ATOMIC_ACQUIRE, "");
-  else if constexpr (order == memory_order_release)
-    __builtin_amdgcn_fence(__ATOMIC_RELEASE, "");
-  else if constexpr (order == memory_order_acq_rel)
-    __builtin_amdgcn_fence(__ATOMIC_ACQ_REL, "");
-  else
-    __builtin_amdgcn_fence(__ATOMIC_SEQ_CST, "");
-}
+#define ROCSHMEM_DISPATCH_FENCE_ORDER(SCOPE_STR)         \
+  if constexpr (order == memory_order_acquire)           \
+    __builtin_amdgcn_fence(__ATOMIC_ACQUIRE, SCOPE_STR); \
+  else if constexpr (order == memory_order_release)      \
+    __builtin_amdgcn_fence(__ATOMIC_RELEASE, SCOPE_STR); \
+  else if constexpr (order == memory_order_acq_rel)      \
+    __builtin_amdgcn_fence(__ATOMIC_ACQ_REL, SCOPE_STR); \
+  else                                                   \
+    __builtin_amdgcn_fence(__ATOMIC_SEQ_CST, SCOPE_STR)
 
 template <rocshmem_memory_scope scope = memory_scope_system,
           rocshmem_memory_order order = memory_order_seq_cst>
-__device__ __forceinline__
-void fence() {
-  if constexpr (scope == memory_scope_thread   ||
+__device__ __forceinline__ void threadfence() {
+  if constexpr (scope == memory_scope_thread ||
                 scope == memory_scope_wavefront ||
                 scope == memory_scope_workgroup) {
-    fence_workgroup<order>();
+    ROCSHMEM_DISPATCH_FENCE_ORDER("workgroup");
   } else if constexpr (scope == memory_scope_agent) {
-    fence_agent<order>();
+    ROCSHMEM_DISPATCH_FENCE_ORDER("agent");
   } else {
-    fence_system<order>();
+    ROCSHMEM_DISPATCH_FENCE_ORDER("");  // system scope
   }
 }
+
+#undef ROCSHMEM_DISPATCH_FENCE_ORDER
 
 } // namespace atomic
 } // namespace detail

--- a/projects/rocshmem/src/ipc/context_ipc_device.cpp
+++ b/projects/rocshmem/src/ipc/context_ipc_device.cpp
@@ -113,17 +113,17 @@ __device__ void *IPCContext::shmem_ptr(const void *dest, int pe) {
 __device__ void IPCContext::putmem_wg(void *dest, const void *source,
                                      size_t nelems, int pe) {
   putmem_nbi_wg(dest, source, nelems, pe);
+  __builtin_amdgcn_s_barrier();
   ipcImpl_.ipcFence<detail::atomic::memory_scope_system, 
                     detail::atomic::memory_order_release>();
-  __builtin_amdgcn_s_barrier();
 }
 
 __device__ void IPCContext::getmem_wg(void *dest, const void *source,
                                      size_t nelems, int pe) {
   getmem_nbi_wg(dest, source, nelems, pe);
+  __builtin_amdgcn_s_barrier();
   ipcImpl_.ipcFence<detail::atomic::memory_scope_system, 
                     detail::atomic::memory_order_acquire>();
-  __builtin_amdgcn_s_barrier();
 }
 
 __device__ void IPCContext::putmem_nbi_wg(void *dest, const void *source,
@@ -187,9 +187,9 @@ __device__ void IPCContext::internal_putmem_wg(void *dest, const void *source,
                                      size_t nelems, int pe) {
   uint64_t L_offset = reinterpret_cast<char *>(dest) - wrk_sync_pool_bases_[my_pe];
   memcpy_wg(wrk_sync_pool_bases_[pe] + L_offset, const_cast<void *>(source), nelems);
+  __builtin_amdgcn_s_barrier();
   ipcImpl_.ipcFence<detail::atomic::memory_scope_system, 
                     detail::atomic::memory_order_release>();
-  __builtin_amdgcn_s_barrier();
 }
 
 __device__ void IPCContext::internal_getmem_wg(void *dest, const void *source,
@@ -197,9 +197,9 @@ __device__ void IPCContext::internal_getmem_wg(void *dest, const void *source,
   const char *src_typed = reinterpret_cast<const char *>(source);
   uint64_t L_offset = const_cast<char *>(src_typed) - wrk_sync_pool_bases_[my_pe];
   memcpy_wg(dest, wrk_sync_pool_bases_[pe] + L_offset, nelems);
+  __builtin_amdgcn_s_barrier();
   ipcImpl_.ipcFence<detail::atomic::memory_scope_system, 
                     detail::atomic::memory_order_acquire>();
-  __builtin_amdgcn_s_barrier();
 }
 
 __device__ void IPCContext::internal_putmem_wave(void *dest,

--- a/projects/rocshmem/src/ipc/context_ipc_device.cpp
+++ b/projects/rocshmem/src/ipc/context_ipc_device.cpp
@@ -113,17 +113,17 @@ __device__ void *IPCContext::shmem_ptr(const void *dest, int pe) {
 __device__ void IPCContext::putmem_wg(void *dest, const void *source,
                                      size_t nelems, int pe) {
   putmem_nbi_wg(dest, source, nelems, pe);
-  __builtin_amdgcn_s_barrier();
   ipcImpl_.ipcFence<detail::atomic::memory_scope_system, 
-                    detail::atomic::memory_order_release>();
+  detail::atomic::memory_order_release>();
+  __builtin_amdgcn_s_barrier();
 }
 
 __device__ void IPCContext::getmem_wg(void *dest, const void *source,
                                      size_t nelems, int pe) {
   getmem_nbi_wg(dest, source, nelems, pe);
-  __builtin_amdgcn_s_barrier();
   ipcImpl_.ipcFence<detail::atomic::memory_scope_system, 
-                    detail::atomic::memory_order_acquire>();
+  detail::atomic::memory_order_acquire>();
+  __builtin_amdgcn_s_barrier();
 }
 
 __device__ void IPCContext::putmem_nbi_wg(void *dest, const void *source,
@@ -187,9 +187,9 @@ __device__ void IPCContext::internal_putmem_wg(void *dest, const void *source,
                                      size_t nelems, int pe) {
   uint64_t L_offset = reinterpret_cast<char *>(dest) - wrk_sync_pool_bases_[my_pe];
   memcpy_wg(wrk_sync_pool_bases_[pe] + L_offset, const_cast<void *>(source), nelems);
-  __builtin_amdgcn_s_barrier();
   ipcImpl_.ipcFence<detail::atomic::memory_scope_system, 
-                    detail::atomic::memory_order_release>();
+  detail::atomic::memory_order_release>();
+  __builtin_amdgcn_s_barrier();
 }
 
 __device__ void IPCContext::internal_getmem_wg(void *dest, const void *source,
@@ -197,9 +197,9 @@ __device__ void IPCContext::internal_getmem_wg(void *dest, const void *source,
   const char *src_typed = reinterpret_cast<const char *>(source);
   uint64_t L_offset = const_cast<char *>(src_typed) - wrk_sync_pool_bases_[my_pe];
   memcpy_wg(dest, wrk_sync_pool_bases_[pe] + L_offset, nelems);
-  __builtin_amdgcn_s_barrier();
   ipcImpl_.ipcFence<detail::atomic::memory_scope_system, 
-                    detail::atomic::memory_order_acquire>();
+  detail::atomic::memory_order_acquire>();
+  __builtin_amdgcn_s_barrier();
 }
 
 __device__ void IPCContext::internal_putmem_wave(void *dest,

--- a/projects/rocshmem/src/ipc/context_ipc_device.cpp
+++ b/projects/rocshmem/src/ipc/context_ipc_device.cpp
@@ -60,13 +60,15 @@ __device__ void IPCContext::ctx_destroy(){
 __device__ void IPCContext::putmem(void *dest, const void *source, size_t nelems,
                                   int pe) {
   putmem_nbi(dest, source, nelems, pe);
-  ipcImpl_.ipcFence();
+  ipcImpl_.ipcFence<detail::atomic::memory_scope_system, 
+                    detail::atomic::memory_order_release>();
 }
 
 __device__ void IPCContext::getmem(void *dest, const void *source, size_t nelems,
                                   int pe) {
   getmem_nbi(dest, source, nelems, pe);
-  ipcImpl_.ipcFence();
+  ipcImpl_.ipcFence<detail::atomic::memory_scope_system, 
+                    detail::atomic::memory_order_acquire>();
 }
 
 __device__ void IPCContext::putmem_nbi(void *dest, const void *source,
@@ -111,15 +113,17 @@ __device__ void *IPCContext::shmem_ptr(const void *dest, int pe) {
 __device__ void IPCContext::putmem_wg(void *dest, const void *source,
                                      size_t nelems, int pe) {
   putmem_nbi_wg(dest, source, nelems, pe);
-  __syncthreads();
-  ipcImpl_.ipcFence();
+  ipcImpl_.ipcFence<detail::atomic::memory_scope_system, 
+                    detail::atomic::memory_order_release>();
+  __builtin_amdgcn_s_barrier();
 }
 
 __device__ void IPCContext::getmem_wg(void *dest, const void *source,
                                      size_t nelems, int pe) {
   getmem_nbi_wg(dest, source, nelems, pe);
-  __syncthreads();
-  ipcImpl_.ipcFence();
+  ipcImpl_.ipcFence<detail::atomic::memory_scope_system, 
+                    detail::atomic::memory_order_acquire>();
+  __builtin_amdgcn_s_barrier();
 }
 
 __device__ void IPCContext::putmem_nbi_wg(void *dest, const void *source,
@@ -138,13 +142,15 @@ __device__ void IPCContext::getmem_nbi_wg(void *dest, const void *source,
 __device__ void IPCContext::putmem_wave(void *dest, const void *source,
                                        size_t nelems, int pe) {
   putmem_nbi_wave(dest, source, nelems, pe);
-  ipcImpl_.ipcFence();
+  ipcImpl_.ipcFence<detail::atomic::memory_scope_system, 
+                    detail::atomic::memory_order_release>();
 }
 
 __device__ void IPCContext::getmem_wave(void *dest, const void *source,
                                        size_t nelems, int pe) {
   getmem_nbi_wave(dest, source, nelems, pe);
-  ipcImpl_.ipcFence();
+  ipcImpl_.ipcFence<detail::atomic::memory_scope_system, 
+                    detail::atomic::memory_order_acquire>();
 }
 
 __device__ void IPCContext::putmem_nbi_wave(void *dest, const void *source,
@@ -164,7 +170,8 @@ __device__ void IPCContext::internal_putmem(void *dest, const void *source,
                                             size_t nelems, int pe) {
   uint64_t L_offset = reinterpret_cast<char *>(dest) - wrk_sync_pool_bases_[my_pe];
   memcpy_lane(wrk_sync_pool_bases_[pe] + L_offset, const_cast<void *>(source), nelems);
-  ipcImpl_.ipcFence();
+  ipcImpl_.ipcFence<detail::atomic::memory_scope_system, 
+                    detail::atomic::memory_order_release>();
 }
 
 __device__ void IPCContext::internal_getmem(void *dest, const void *source,
@@ -172,15 +179,17 @@ __device__ void IPCContext::internal_getmem(void *dest, const void *source,
   const char *src_typed = reinterpret_cast<const char *>(source);
   uint64_t L_offset = const_cast<char *>(src_typed) - wrk_sync_pool_bases_[my_pe];
   memcpy_lane(dest, wrk_sync_pool_bases_[pe] + L_offset, nelems);
-  ipcImpl_.ipcFence();
+  ipcImpl_.ipcFence<detail::atomic::memory_scope_system, 
+                    detail::atomic::memory_order_acquire>();
 }
 
 __device__ void IPCContext::internal_putmem_wg(void *dest, const void *source,
                                      size_t nelems, int pe) {
   uint64_t L_offset = reinterpret_cast<char *>(dest) - wrk_sync_pool_bases_[my_pe];
   memcpy_wg(wrk_sync_pool_bases_[pe] + L_offset, const_cast<void *>(source), nelems);
-  __syncthreads();
-  ipcImpl_.ipcFence();
+  ipcImpl_.ipcFence<detail::atomic::memory_scope_system, 
+                    detail::atomic::memory_order_release>();
+  __builtin_amdgcn_s_barrier();
 }
 
 __device__ void IPCContext::internal_getmem_wg(void *dest, const void *source,
@@ -188,15 +197,17 @@ __device__ void IPCContext::internal_getmem_wg(void *dest, const void *source,
   const char *src_typed = reinterpret_cast<const char *>(source);
   uint64_t L_offset = const_cast<char *>(src_typed) - wrk_sync_pool_bases_[my_pe];
   memcpy_wg(dest, wrk_sync_pool_bases_[pe] + L_offset, nelems);
-  __syncthreads();
-  ipcImpl_.ipcFence();
+  ipcImpl_.ipcFence<detail::atomic::memory_scope_system, 
+                    detail::atomic::memory_order_acquire>();
+  __builtin_amdgcn_s_barrier();
 }
 
 __device__ void IPCContext::internal_putmem_wave(void *dest,
                         const void *source, size_t nelems, int pe) {
   uint64_t L_offset = reinterpret_cast<char *>(dest) - wrk_sync_pool_bases_[my_pe];
   memcpy_wave(wrk_sync_pool_bases_[pe] + L_offset, const_cast<void *>(source), nelems);
-  ipcImpl_.ipcFence();
+  ipcImpl_.ipcFence<detail::atomic::memory_scope_system, 
+                    detail::atomic::memory_order_release>();
 }
 
 __device__ void IPCContext::internal_getmem_wave(void *dest,
@@ -204,7 +215,8 @@ __device__ void IPCContext::internal_getmem_wave(void *dest,
   const char *src_typed = reinterpret_cast<const char *>(source);
   uint64_t L_offset = const_cast<char *>(src_typed) - wrk_sync_pool_bases_[my_pe];
   memcpy_wave(dest, wrk_sync_pool_bases_[pe] + L_offset, nelems);
-  ipcImpl_.ipcFence();
+  ipcImpl_.ipcFence<detail::atomic::memory_scope_system, 
+                    detail::atomic::memory_order_acquire>();
 }
 
 __device__ void IPCContext::putmem_signal(void *dest, const void *source, size_t nelems,

--- a/projects/rocshmem/src/ipc/context_ipc_device.cpp
+++ b/projects/rocshmem/src/ipc/context_ipc_device.cpp
@@ -22,18 +22,19 @@
  * IN THE SOFTWARE.
  *****************************************************************************/
 
-#include <hip/amd_detail/amd_device_functions.h>
 #include <hip/hip_runtime.h>
+#include <hip/amd_detail/amd_device_functions.h>
 
+#include "rocshmem/rocshmem_config.h"  // NOLINT(build/include_subdir)
+#include "rocshmem/rocshmem.hpp"
 #include "backend_ipc.hpp"
 #include "context_ipc_device.hpp"
 #include "context_ipc_tmpl_device.hpp"
-#include "rocshmem/rocshmem.hpp"
-#include "rocshmem/rocshmem_config.h"  // NOLINT(build/include_subdir)
 
 namespace rocshmem {
 
-__host__ IPCContext::IPCContext(Backend *b, unsigned int ctx_id) : Context(b) {
+__host__ IPCContext::IPCContext(Backend *b, unsigned int ctx_id)
+    : Context(b) {
   IPCBackend *backend{static_cast<IPCBackend *>(b)};
   ipcImpl_.ipc_bases = b->ipcImpl.ipc_bases;
   ipcImpl_.shm_size = b->ipcImpl.shm_size;
@@ -46,36 +47,38 @@ __host__ IPCContext::IPCContext(Backend *b, unsigned int ctx_id) : Context(b) {
   orders_.store = detail::atomic::rocshmem_memory_order::memory_order_seq_cst;
 }
 
-__device__ void IPCContext::threadfence_system() { __threadfence_system(); }
+__device__ void IPCContext::threadfence_system() {
+  __threadfence_system();
+}
 
-__device__ void IPCContext::ctx_create() {}
+__device__ void IPCContext::ctx_create() {
+}
 
-__device__ void IPCContext::ctx_destroy() {}
+__device__ void IPCContext::ctx_destroy(){
+}
 
-__device__ void IPCContext::putmem(void *dest, const void *source,
-                                   size_t nelems, int pe) {
+__device__ void IPCContext::putmem(void *dest, const void *source, size_t nelems,
+                                  int pe) {
   putmem_nbi(dest, source, nelems, pe);
   ipcImpl_.ipcFence<detail::atomic::memory_scope_system,
                     detail::atomic::memory_order_release>();
 }
 
-__device__ void IPCContext::getmem(void *dest, const void *source,
-                                   size_t nelems, int pe) {
+__device__ void IPCContext::getmem(void *dest, const void *source, size_t nelems,
+                                  int pe) {
   getmem_nbi(dest, source, nelems, pe);
   ipcImpl_.ipcFence<detail::atomic::memory_scope_system,
                     detail::atomic::memory_order_acquire>();
 }
 
 __device__ void IPCContext::putmem_nbi(void *dest, const void *source,
-                                       size_t nelems, int pe) {
-  uint64_t L_offset =
-      reinterpret_cast<char *>(dest) - ipcImpl_.ipc_bases[my_pe];
-  ipcImpl_.ipcCopy(ipcImpl_.ipc_bases[pe] + L_offset,
-                   const_cast<void *>(source), nelems);
+                                      size_t nelems, int pe) {
+  uint64_t L_offset = reinterpret_cast<char *>(dest) - ipcImpl_.ipc_bases[my_pe];
+  ipcImpl_.ipcCopy(ipcImpl_.ipc_bases[pe] + L_offset, const_cast<void *>(source), nelems);
 }
 
 __device__ void IPCContext::getmem_nbi(void *dest, const void *source,
-                                       size_t nelems, int pe) {
+                                      size_t nelems, int pe) {
   const char *src_typed = reinterpret_cast<const char *>(source);
   uint64_t L_offset = const_cast<char *>(src_typed) - ipcImpl_.ipc_bases[my_pe];
   ipcImpl_.ipcCopy(dest, ipcImpl_.ipc_bases[pe] + L_offset, nelems);
@@ -83,19 +86,21 @@ __device__ void IPCContext::getmem_nbi(void *dest, const void *source,
 
 __device__ void IPCContext::fence() {
   for (int i{0}, j{tinfo->pe_start}; i < tinfo->size; i++, j += tinfo->stride) {
-    detail::atomic::store<int, detail::atomic::memory_scope_system>(
-        &fence_pool[j], 1, orders_);
+    detail::atomic::store<int, detail::atomic::memory_scope_system>(&fence_pool[j], 1, orders_);
   }
 }
 
 __device__ void IPCContext::fence(int pe) {
-  detail::atomic::store<int, detail::atomic::memory_scope_system>(
-      &fence_pool[pe], 1, orders_);
+  detail::atomic::store<int, detail::atomic::memory_scope_system>(&fence_pool[pe], 1, orders_);
 }
 
-__device__ void IPCContext::quiet() { fence(); }
+__device__ void IPCContext::quiet() {
+  fence();
+}
 
-__device__ void IPCContext::pe_quiet(size_t pe) { fence(pe); }
+__device__ void IPCContext::pe_quiet(size_t pe) {
+  fence(pe);
+}
 
 __device__ void *IPCContext::shmem_ptr(const void *dest, int pe) {
   void *ret = nullptr;
@@ -106,7 +111,7 @@ __device__ void *IPCContext::shmem_ptr(const void *dest, int pe) {
 }
 
 __device__ void IPCContext::putmem_wg(void *dest, const void *source,
-                                      size_t nelems, int pe) {
+                                     size_t nelems, int pe) {
   putmem_nbi_wg(dest, source, nelems, pe);
   ipcImpl_.ipcFence<detail::atomic::memory_scope_system,
                     detail::atomic::memory_order_release>();
@@ -114,7 +119,7 @@ __device__ void IPCContext::putmem_wg(void *dest, const void *source,
 }
 
 __device__ void IPCContext::getmem_wg(void *dest, const void *source,
-                                      size_t nelems, int pe) {
+                                     size_t nelems, int pe) {
   getmem_nbi_wg(dest, source, nelems, pe);
   ipcImpl_.ipcFence<detail::atomic::memory_scope_system,
                     detail::atomic::memory_order_acquire>();
@@ -122,44 +127,40 @@ __device__ void IPCContext::getmem_wg(void *dest, const void *source,
 }
 
 __device__ void IPCContext::putmem_nbi_wg(void *dest, const void *source,
-                                          size_t nelems, int pe) {
-  uint64_t L_offset =
-      reinterpret_cast<char *>(dest) - ipcImpl_.ipc_bases[my_pe];
-  ipcImpl_.ipcCopy_wg(ipcImpl_.ipc_bases[pe] + L_offset,
-                      const_cast<void *>(source), nelems);
+                                         size_t nelems, int pe) {
+  uint64_t L_offset = reinterpret_cast<char *>(dest) - ipcImpl_.ipc_bases[my_pe];
+  ipcImpl_.ipcCopy_wg(ipcImpl_.ipc_bases[pe] + L_offset, const_cast<void *>(source), nelems);
 }
 
 __device__ void IPCContext::getmem_nbi_wg(void *dest, const void *source,
-                                          size_t nelems, int pe) {
+                                         size_t nelems, int pe) {
   const char *src_typed = reinterpret_cast<const char *>(source);
   uint64_t L_offset = const_cast<char *>(src_typed) - ipcImpl_.ipc_bases[my_pe];
   ipcImpl_.ipcCopy_wg(dest, ipcImpl_.ipc_bases[pe] + L_offset, nelems);
 }
 
 __device__ void IPCContext::putmem_wave(void *dest, const void *source,
-                                        size_t nelems, int pe) {
+                                       size_t nelems, int pe) {
   putmem_nbi_wave(dest, source, nelems, pe);
   ipcImpl_.ipcFence<detail::atomic::memory_scope_system,
                     detail::atomic::memory_order_release>();
 }
 
 __device__ void IPCContext::getmem_wave(void *dest, const void *source,
-                                        size_t nelems, int pe) {
+                                       size_t nelems, int pe) {
   getmem_nbi_wave(dest, source, nelems, pe);
   ipcImpl_.ipcFence<detail::atomic::memory_scope_system,
                     detail::atomic::memory_order_acquire>();
 }
 
 __device__ void IPCContext::putmem_nbi_wave(void *dest, const void *source,
-                                            size_t nelems, int pe) {
-  uint64_t L_offset =
-      reinterpret_cast<char *>(dest) - ipcImpl_.ipc_bases[my_pe];
-  ipcImpl_.ipcCopy_wave(ipcImpl_.ipc_bases[pe] + L_offset,
-                        const_cast<void *>(source), nelems);
+                                           size_t nelems, int pe) {
+  uint64_t L_offset = reinterpret_cast<char *>(dest) - ipcImpl_.ipc_bases[my_pe];
+  ipcImpl_.ipcCopy_wave(ipcImpl_.ipc_bases[pe] + L_offset, const_cast<void *>(source), nelems);
 }
 
 __device__ void IPCContext::getmem_nbi_wave(void *dest, const void *source,
-                                            size_t nelems, int pe) {
+                                           size_t nelems, int pe) {
   const char *src_typed = reinterpret_cast<const char *>(source);
   uint64_t L_offset = const_cast<char *>(src_typed) - ipcImpl_.ipc_bases[my_pe];
   ipcImpl_.ipcCopy_wave(dest, ipcImpl_.ipc_bases[pe] + L_offset, nelems);
@@ -167,10 +168,8 @@ __device__ void IPCContext::getmem_nbi_wave(void *dest, const void *source,
 
 __device__ void IPCContext::internal_putmem(void *dest, const void *source,
                                             size_t nelems, int pe) {
-  uint64_t L_offset =
-      reinterpret_cast<char *>(dest) - wrk_sync_pool_bases_[my_pe];
-  memcpy_lane(wrk_sync_pool_bases_[pe] + L_offset, const_cast<void *>(source),
-              nelems);
+  uint64_t L_offset = reinterpret_cast<char *>(dest) - wrk_sync_pool_bases_[my_pe];
+  memcpy_lane(wrk_sync_pool_bases_[pe] + L_offset, const_cast<void *>(source), nelems);
   ipcImpl_.ipcFence<detail::atomic::memory_scope_system,
                     detail::atomic::memory_order_release>();
 }
@@ -178,150 +177,137 @@ __device__ void IPCContext::internal_putmem(void *dest, const void *source,
 __device__ void IPCContext::internal_getmem(void *dest, const void *source,
                                             size_t nelems, int pe) {
   const char *src_typed = reinterpret_cast<const char *>(source);
-  uint64_t L_offset =
-      const_cast<char *>(src_typed) - wrk_sync_pool_bases_[my_pe];
+  uint64_t L_offset = const_cast<char *>(src_typed) - wrk_sync_pool_bases_[my_pe];
   memcpy_lane(dest, wrk_sync_pool_bases_[pe] + L_offset, nelems);
   ipcImpl_.ipcFence<detail::atomic::memory_scope_system,
                     detail::atomic::memory_order_acquire>();
 }
 
 __device__ void IPCContext::internal_putmem_wg(void *dest, const void *source,
-                                               size_t nelems, int pe) {
-  uint64_t L_offset =
-      reinterpret_cast<char *>(dest) - wrk_sync_pool_bases_[my_pe];
-  memcpy_wg(wrk_sync_pool_bases_[pe] + L_offset, const_cast<void *>(source),
-            nelems);
+                                     size_t nelems, int pe) {
+  uint64_t L_offset = reinterpret_cast<char *>(dest) - wrk_sync_pool_bases_[my_pe];
+  memcpy_wg(wrk_sync_pool_bases_[pe] + L_offset, const_cast<void *>(source), nelems);
   ipcImpl_.ipcFence<detail::atomic::memory_scope_system,
                     detail::atomic::memory_order_release>();
   __builtin_amdgcn_s_barrier();
 }
 
 __device__ void IPCContext::internal_getmem_wg(void *dest, const void *source,
-                                               size_t nelems, int pe) {
+                                     size_t nelems, int pe) {
   const char *src_typed = reinterpret_cast<const char *>(source);
-  uint64_t L_offset =
-      const_cast<char *>(src_typed) - wrk_sync_pool_bases_[my_pe];
+  uint64_t L_offset = const_cast<char *>(src_typed) - wrk_sync_pool_bases_[my_pe];
   memcpy_wg(dest, wrk_sync_pool_bases_[pe] + L_offset, nelems);
   ipcImpl_.ipcFence<detail::atomic::memory_scope_system,
                     detail::atomic::memory_order_acquire>();
   __builtin_amdgcn_s_barrier();
 }
 
-__device__ void IPCContext::internal_putmem_wave(void *dest, const void *source,
-                                                 size_t nelems, int pe) {
-  uint64_t L_offset =
-      reinterpret_cast<char *>(dest) - wrk_sync_pool_bases_[my_pe];
-  memcpy_wave(wrk_sync_pool_bases_[pe] + L_offset, const_cast<void *>(source),
-              nelems);
+__device__ void IPCContext::internal_putmem_wave(void *dest,
+                        const void *source, size_t nelems, int pe) {
+  uint64_t L_offset = reinterpret_cast<char *>(dest) - wrk_sync_pool_bases_[my_pe];
+  memcpy_wave(wrk_sync_pool_bases_[pe] + L_offset, const_cast<void *>(source), nelems);
   ipcImpl_.ipcFence<detail::atomic::memory_scope_system,
                     detail::atomic::memory_order_release>();
 }
 
-__device__ void IPCContext::internal_getmem_wave(void *dest, const void *source,
-                                                 size_t nelems, int pe) {
+__device__ void IPCContext::internal_getmem_wave(void *dest,
+                        const void *source, size_t nelems, int pe) {
   const char *src_typed = reinterpret_cast<const char *>(source);
-  uint64_t L_offset =
-      const_cast<char *>(src_typed) - wrk_sync_pool_bases_[my_pe];
+  uint64_t L_offset = const_cast<char *>(src_typed) - wrk_sync_pool_bases_[my_pe];
   memcpy_wave(dest, wrk_sync_pool_bases_[pe] + L_offset, nelems);
   ipcImpl_.ipcFence<detail::atomic::memory_scope_system,
                     detail::atomic::memory_order_acquire>();
 }
 
-__device__ void IPCContext::putmem_signal(void *dest, const void *source,
-                                          size_t nelems, uint64_t *sig_addr,
-                                          uint64_t signal, int sig_op, int pe) {
+__device__ void IPCContext::putmem_signal(void *dest, const void *source, size_t nelems,
+                                          uint64_t *sig_addr, uint64_t signal, int sig_op,
+                                          int pe) {
   putmem(dest, source, nelems, pe);
   fence();
 
   switch (sig_op) {
-    case ROCSHMEM_SIGNAL_SET:
-      amo_set<uint64_t>(static_cast<void *>(sig_addr), signal, pe);
-      break;
-    case ROCSHMEM_SIGNAL_ADD:
-      amo_add<uint64_t>(static_cast<void *>(sig_addr), signal, pe);
-      break;
-    default:
-      DPRINTF("[%s] Invalid sig_op value (%d)\n", __func__, sig_op);
-      break;
+  case ROCSHMEM_SIGNAL_SET:
+    amo_set<uint64_t>(static_cast<void*>(sig_addr), signal, pe);
+    break;
+  case ROCSHMEM_SIGNAL_ADD:
+    amo_add<uint64_t>(static_cast<void*>(sig_addr), signal, pe);
+    break;
+  default:
+    DPRINTF("[%s] Invalid sig_op value (%d)\n", __func__, sig_op);
+    break;
   }
 }
 
-__device__ void IPCContext::putmem_signal_wg(void *dest, const void *source,
-                                             size_t nelems, uint64_t *sig_addr,
-                                             uint64_t signal, int sig_op,
+__device__ void IPCContext::putmem_signal_wg(void *dest, const void *source, size_t nelems,
+                                             uint64_t *sig_addr, uint64_t signal, int sig_op,
                                              int pe) {
   putmem_wg(dest, source, nelems, pe);
   fence();
 
   if (is_thread_zero_in_block()) {
     switch (sig_op) {
-      case ROCSHMEM_SIGNAL_SET:
-        amo_set<uint64_t>(static_cast<void *>(sig_addr), signal, pe);
-        break;
-      case ROCSHMEM_SIGNAL_ADD:
-        amo_add<uint64_t>(static_cast<void *>(sig_addr), signal, pe);
-        break;
-      default:
-        DPRINTF("[%s] Invalid sig_op value (%d)\n", __func__, sig_op);
-        break;
+    case ROCSHMEM_SIGNAL_SET:
+      amo_set<uint64_t>(static_cast<void*>(sig_addr), signal, pe);
+      break;
+    case ROCSHMEM_SIGNAL_ADD:
+      amo_add<uint64_t>(static_cast<void*>(sig_addr), signal, pe);
+      break;
+    default:
+      DPRINTF("[%s] Invalid sig_op value (%d)\n", __func__, sig_op);
+      break;
     }
   }
 }
 
-__device__ void IPCContext::putmem_signal_wave(void *dest, const void *source,
-                                               size_t nelems,
-                                               uint64_t *sig_addr,
-                                               uint64_t signal, int sig_op,
+__device__ void IPCContext::putmem_signal_wave(void *dest, const void *source, size_t nelems,
+                                               uint64_t *sig_addr, uint64_t signal, int sig_op,
                                                int pe) {
   putmem_wave(dest, source, nelems, pe);
   fence();
 
   if (is_thread_zero_in_wave()) {
     switch (sig_op) {
-      case ROCSHMEM_SIGNAL_SET:
-        amo_set<uint64_t>(static_cast<void *>(sig_addr), signal, pe);
-        break;
-      case ROCSHMEM_SIGNAL_ADD:
-        amo_add<uint64_t>(static_cast<void *>(sig_addr), signal, pe);
-        break;
-      default:
-        DPRINTF("[%s] Invalid sig_op value (%d)\n", __func__, sig_op);
-        break;
+    case ROCSHMEM_SIGNAL_SET:
+      amo_set<uint64_t>(static_cast<void*>(sig_addr), signal, pe);
+      break;
+    case ROCSHMEM_SIGNAL_ADD:
+      amo_add<uint64_t>(static_cast<void*>(sig_addr), signal, pe);
+      break;
+    default:
+      DPRINTF("[%s] Invalid sig_op value (%d)\n", __func__, sig_op);
+      break;
     }
   }
 }
 
-__device__ void IPCContext::putmem_signal_nbi(void *dest, const void *source,
-                                              size_t nelems, uint64_t *sig_addr,
-                                              uint64_t signal, int sig_op,
+__device__ void IPCContext::putmem_signal_nbi(void *dest, const void *source, size_t nelems,
+                                              uint64_t *sig_addr, uint64_t signal, int sig_op,
                                               int pe) {
   putmem_signal(dest, source, nelems, sig_addr, signal, sig_op, pe);
 }
 
-__device__ void IPCContext::putmem_signal_nbi_wg(void *dest, const void *source,
-                                                 size_t nelems,
-                                                 uint64_t *sig_addr,
-                                                 uint64_t signal, int sig_op,
+__device__ void IPCContext::putmem_signal_nbi_wg(void *dest, const void *source, size_t nelems,
+                                                 uint64_t *sig_addr, uint64_t signal, int sig_op,
                                                  int pe) {
   putmem_signal_wg(dest, source, nelems, sig_addr, signal, sig_op, pe);
 }
 
-__device__ void IPCContext::putmem_signal_nbi_wave(
-    void *dest, const void *source, size_t nelems, uint64_t *sig_addr,
-    uint64_t signal, int sig_op, int pe) {
+__device__ void IPCContext::putmem_signal_nbi_wave(void *dest, const void *source, size_t nelems,
+                                                   uint64_t *sig_addr, uint64_t signal, int sig_op,
+                                                   int pe) {
   putmem_signal_wave(dest, source, nelems, sig_addr, signal, sig_op, pe);
 }
 
 __device__ uint64_t IPCContext::signal_fetch(const uint64_t *sig_addr) {
-  uint64_t *dst = const_cast<uint64_t *>(sig_addr);
-  return amo_fetch_add<uint64_t>(static_cast<void *>(dst), 0, my_pe);
+  uint64_t *dst = const_cast<uint64_t*>(sig_addr);
+  return amo_fetch_add<uint64_t>(static_cast<void*>(dst), 0, my_pe);
 }
 
 __device__ uint64_t IPCContext::signal_fetch_wg(const uint64_t *sig_addr) {
   __shared__ uint64_t value;
   if (is_thread_zero_in_block()) {
-    uint64_t *dst = const_cast<uint64_t *>(sig_addr);
-    value = amo_fetch_add<uint64_t>(static_cast<void *>(dst), 0, my_pe);
+    uint64_t *dst = const_cast<uint64_t*>(sig_addr);
+    value = amo_fetch_add<uint64_t>(static_cast<void*>(dst), 0, my_pe);
   }
   __threadfence_block();
   return value;
@@ -330,8 +316,8 @@ __device__ uint64_t IPCContext::signal_fetch_wg(const uint64_t *sig_addr) {
 __device__ uint64_t IPCContext::signal_fetch_wave(const uint64_t *sig_addr) {
   uint64_t value{0};
   if (is_thread_zero_in_wave()) {
-    uint64_t *dst = const_cast<uint64_t *>(sig_addr);
-    value = amo_fetch_add<uint64_t>(static_cast<void *>(dst), 0, my_pe);
+    uint64_t *dst = const_cast<uint64_t*>(sig_addr);
+    value = amo_fetch_add<uint64_t>(static_cast<void*>(dst), 0, my_pe);
   }
   __threadfence_block();
   value = __shfl(value, 0);

--- a/projects/rocshmem/src/ipc/context_ipc_device.cpp
+++ b/projects/rocshmem/src/ipc/context_ipc_device.cpp
@@ -22,19 +22,18 @@
  * IN THE SOFTWARE.
  *****************************************************************************/
 
-#include <hip/hip_runtime.h>
 #include <hip/amd_detail/amd_device_functions.h>
+#include <hip/hip_runtime.h>
 
-#include "rocshmem/rocshmem_config.h"  // NOLINT(build/include_subdir)
-#include "rocshmem/rocshmem.hpp"
 #include "backend_ipc.hpp"
 #include "context_ipc_device.hpp"
 #include "context_ipc_tmpl_device.hpp"
+#include "rocshmem/rocshmem.hpp"
+#include "rocshmem/rocshmem_config.h"  // NOLINT(build/include_subdir)
 
 namespace rocshmem {
 
-__host__ IPCContext::IPCContext(Backend *b, unsigned int ctx_id)
-    : Context(b) {
+__host__ IPCContext::IPCContext(Backend *b, unsigned int ctx_id) : Context(b) {
   IPCBackend *backend{static_cast<IPCBackend *>(b)};
   ipcImpl_.ipc_bases = b->ipcImpl.ipc_bases;
   ipcImpl_.shm_size = b->ipcImpl.shm_size;
@@ -47,38 +46,36 @@ __host__ IPCContext::IPCContext(Backend *b, unsigned int ctx_id)
   orders_.store = detail::atomic::rocshmem_memory_order::memory_order_seq_cst;
 }
 
-__device__ void IPCContext::threadfence_system() {
-  __threadfence_system();
-}
+__device__ void IPCContext::threadfence_system() { __threadfence_system(); }
 
-__device__ void IPCContext::ctx_create() {
-}
+__device__ void IPCContext::ctx_create() {}
 
-__device__ void IPCContext::ctx_destroy(){
-}
+__device__ void IPCContext::ctx_destroy() {}
 
-__device__ void IPCContext::putmem(void *dest, const void *source, size_t nelems,
-                                  int pe) {
+__device__ void IPCContext::putmem(void *dest, const void *source,
+                                   size_t nelems, int pe) {
   putmem_nbi(dest, source, nelems, pe);
-  ipcImpl_.ipcFence<detail::atomic::memory_scope_system, 
+  ipcImpl_.ipcFence<detail::atomic::memory_scope_system,
                     detail::atomic::memory_order_release>();
 }
 
-__device__ void IPCContext::getmem(void *dest, const void *source, size_t nelems,
-                                  int pe) {
+__device__ void IPCContext::getmem(void *dest, const void *source,
+                                   size_t nelems, int pe) {
   getmem_nbi(dest, source, nelems, pe);
-  ipcImpl_.ipcFence<detail::atomic::memory_scope_system, 
+  ipcImpl_.ipcFence<detail::atomic::memory_scope_system,
                     detail::atomic::memory_order_acquire>();
 }
 
 __device__ void IPCContext::putmem_nbi(void *dest, const void *source,
-                                      size_t nelems, int pe) {
-  uint64_t L_offset = reinterpret_cast<char *>(dest) - ipcImpl_.ipc_bases[my_pe];
-  ipcImpl_.ipcCopy(ipcImpl_.ipc_bases[pe] + L_offset, const_cast<void *>(source), nelems);
+                                       size_t nelems, int pe) {
+  uint64_t L_offset =
+      reinterpret_cast<char *>(dest) - ipcImpl_.ipc_bases[my_pe];
+  ipcImpl_.ipcCopy(ipcImpl_.ipc_bases[pe] + L_offset,
+                   const_cast<void *>(source), nelems);
 }
 
 __device__ void IPCContext::getmem_nbi(void *dest, const void *source,
-                                      size_t nelems, int pe) {
+                                       size_t nelems, int pe) {
   const char *src_typed = reinterpret_cast<const char *>(source);
   uint64_t L_offset = const_cast<char *>(src_typed) - ipcImpl_.ipc_bases[my_pe];
   ipcImpl_.ipcCopy(dest, ipcImpl_.ipc_bases[pe] + L_offset, nelems);
@@ -86,21 +83,19 @@ __device__ void IPCContext::getmem_nbi(void *dest, const void *source,
 
 __device__ void IPCContext::fence() {
   for (int i{0}, j{tinfo->pe_start}; i < tinfo->size; i++, j += tinfo->stride) {
-    detail::atomic::store<int, detail::atomic::memory_scope_system>(&fence_pool[j], 1, orders_);
+    detail::atomic::store<int, detail::atomic::memory_scope_system>(
+        &fence_pool[j], 1, orders_);
   }
 }
 
 __device__ void IPCContext::fence(int pe) {
-  detail::atomic::store<int, detail::atomic::memory_scope_system>(&fence_pool[pe], 1, orders_);
+  detail::atomic::store<int, detail::atomic::memory_scope_system>(
+      &fence_pool[pe], 1, orders_);
 }
 
-__device__ void IPCContext::quiet() {
-  fence();
-}
+__device__ void IPCContext::quiet() { fence(); }
 
-__device__ void IPCContext::pe_quiet(size_t pe) {
-  fence(pe);
-}
+__device__ void IPCContext::pe_quiet(size_t pe) { fence(pe); }
 
 __device__ void *IPCContext::shmem_ptr(const void *dest, int pe) {
   void *ret = nullptr;
@@ -111,56 +106,60 @@ __device__ void *IPCContext::shmem_ptr(const void *dest, int pe) {
 }
 
 __device__ void IPCContext::putmem_wg(void *dest, const void *source,
-                                     size_t nelems, int pe) {
+                                      size_t nelems, int pe) {
   putmem_nbi_wg(dest, source, nelems, pe);
-  ipcImpl_.ipcFence<detail::atomic::memory_scope_system, 
-  detail::atomic::memory_order_release>();
+  ipcImpl_.ipcFence<detail::atomic::memory_scope_system,
+                    detail::atomic::memory_order_release>();
   __builtin_amdgcn_s_barrier();
 }
 
 __device__ void IPCContext::getmem_wg(void *dest, const void *source,
-                                     size_t nelems, int pe) {
+                                      size_t nelems, int pe) {
   getmem_nbi_wg(dest, source, nelems, pe);
-  ipcImpl_.ipcFence<detail::atomic::memory_scope_system, 
-  detail::atomic::memory_order_acquire>();
+  ipcImpl_.ipcFence<detail::atomic::memory_scope_system,
+                    detail::atomic::memory_order_acquire>();
   __builtin_amdgcn_s_barrier();
 }
 
 __device__ void IPCContext::putmem_nbi_wg(void *dest, const void *source,
-                                         size_t nelems, int pe) {
-  uint64_t L_offset = reinterpret_cast<char *>(dest) - ipcImpl_.ipc_bases[my_pe];
-  ipcImpl_.ipcCopy_wg(ipcImpl_.ipc_bases[pe] + L_offset, const_cast<void *>(source), nelems);
+                                          size_t nelems, int pe) {
+  uint64_t L_offset =
+      reinterpret_cast<char *>(dest) - ipcImpl_.ipc_bases[my_pe];
+  ipcImpl_.ipcCopy_wg(ipcImpl_.ipc_bases[pe] + L_offset,
+                      const_cast<void *>(source), nelems);
 }
 
 __device__ void IPCContext::getmem_nbi_wg(void *dest, const void *source,
-                                         size_t nelems, int pe) {
+                                          size_t nelems, int pe) {
   const char *src_typed = reinterpret_cast<const char *>(source);
   uint64_t L_offset = const_cast<char *>(src_typed) - ipcImpl_.ipc_bases[my_pe];
   ipcImpl_.ipcCopy_wg(dest, ipcImpl_.ipc_bases[pe] + L_offset, nelems);
 }
 
 __device__ void IPCContext::putmem_wave(void *dest, const void *source,
-                                       size_t nelems, int pe) {
+                                        size_t nelems, int pe) {
   putmem_nbi_wave(dest, source, nelems, pe);
-  ipcImpl_.ipcFence<detail::atomic::memory_scope_system, 
+  ipcImpl_.ipcFence<detail::atomic::memory_scope_system,
                     detail::atomic::memory_order_release>();
 }
 
 __device__ void IPCContext::getmem_wave(void *dest, const void *source,
-                                       size_t nelems, int pe) {
+                                        size_t nelems, int pe) {
   getmem_nbi_wave(dest, source, nelems, pe);
-  ipcImpl_.ipcFence<detail::atomic::memory_scope_system, 
+  ipcImpl_.ipcFence<detail::atomic::memory_scope_system,
                     detail::atomic::memory_order_acquire>();
 }
 
 __device__ void IPCContext::putmem_nbi_wave(void *dest, const void *source,
-                                           size_t nelems, int pe) {
-  uint64_t L_offset = reinterpret_cast<char *>(dest) - ipcImpl_.ipc_bases[my_pe];
-  ipcImpl_.ipcCopy_wave(ipcImpl_.ipc_bases[pe] + L_offset, const_cast<void *>(source), nelems);
+                                            size_t nelems, int pe) {
+  uint64_t L_offset =
+      reinterpret_cast<char *>(dest) - ipcImpl_.ipc_bases[my_pe];
+  ipcImpl_.ipcCopy_wave(ipcImpl_.ipc_bases[pe] + L_offset,
+                        const_cast<void *>(source), nelems);
 }
 
 __device__ void IPCContext::getmem_nbi_wave(void *dest, const void *source,
-                                           size_t nelems, int pe) {
+                                            size_t nelems, int pe) {
   const char *src_typed = reinterpret_cast<const char *>(source);
   uint64_t L_offset = const_cast<char *>(src_typed) - ipcImpl_.ipc_bases[my_pe];
   ipcImpl_.ipcCopy_wave(dest, ipcImpl_.ipc_bases[pe] + L_offset, nelems);
@@ -168,146 +167,161 @@ __device__ void IPCContext::getmem_nbi_wave(void *dest, const void *source,
 
 __device__ void IPCContext::internal_putmem(void *dest, const void *source,
                                             size_t nelems, int pe) {
-  uint64_t L_offset = reinterpret_cast<char *>(dest) - wrk_sync_pool_bases_[my_pe];
-  memcpy_lane(wrk_sync_pool_bases_[pe] + L_offset, const_cast<void *>(source), nelems);
-  ipcImpl_.ipcFence<detail::atomic::memory_scope_system, 
+  uint64_t L_offset =
+      reinterpret_cast<char *>(dest) - wrk_sync_pool_bases_[my_pe];
+  memcpy_lane(wrk_sync_pool_bases_[pe] + L_offset, const_cast<void *>(source),
+              nelems);
+  ipcImpl_.ipcFence<detail::atomic::memory_scope_system,
                     detail::atomic::memory_order_release>();
 }
 
 __device__ void IPCContext::internal_getmem(void *dest, const void *source,
                                             size_t nelems, int pe) {
   const char *src_typed = reinterpret_cast<const char *>(source);
-  uint64_t L_offset = const_cast<char *>(src_typed) - wrk_sync_pool_bases_[my_pe];
+  uint64_t L_offset =
+      const_cast<char *>(src_typed) - wrk_sync_pool_bases_[my_pe];
   memcpy_lane(dest, wrk_sync_pool_bases_[pe] + L_offset, nelems);
-  ipcImpl_.ipcFence<detail::atomic::memory_scope_system, 
+  ipcImpl_.ipcFence<detail::atomic::memory_scope_system,
                     detail::atomic::memory_order_acquire>();
 }
 
 __device__ void IPCContext::internal_putmem_wg(void *dest, const void *source,
-                                     size_t nelems, int pe) {
-  uint64_t L_offset = reinterpret_cast<char *>(dest) - wrk_sync_pool_bases_[my_pe];
-  memcpy_wg(wrk_sync_pool_bases_[pe] + L_offset, const_cast<void *>(source), nelems);
-  ipcImpl_.ipcFence<detail::atomic::memory_scope_system, 
-  detail::atomic::memory_order_release>();
+                                               size_t nelems, int pe) {
+  uint64_t L_offset =
+      reinterpret_cast<char *>(dest) - wrk_sync_pool_bases_[my_pe];
+  memcpy_wg(wrk_sync_pool_bases_[pe] + L_offset, const_cast<void *>(source),
+            nelems);
+  ipcImpl_.ipcFence<detail::atomic::memory_scope_system,
+                    detail::atomic::memory_order_release>();
   __builtin_amdgcn_s_barrier();
 }
 
 __device__ void IPCContext::internal_getmem_wg(void *dest, const void *source,
-                                     size_t nelems, int pe) {
+                                               size_t nelems, int pe) {
   const char *src_typed = reinterpret_cast<const char *>(source);
-  uint64_t L_offset = const_cast<char *>(src_typed) - wrk_sync_pool_bases_[my_pe];
+  uint64_t L_offset =
+      const_cast<char *>(src_typed) - wrk_sync_pool_bases_[my_pe];
   memcpy_wg(dest, wrk_sync_pool_bases_[pe] + L_offset, nelems);
-  ipcImpl_.ipcFence<detail::atomic::memory_scope_system, 
-  detail::atomic::memory_order_acquire>();
+  ipcImpl_.ipcFence<detail::atomic::memory_scope_system,
+                    detail::atomic::memory_order_acquire>();
   __builtin_amdgcn_s_barrier();
 }
 
-__device__ void IPCContext::internal_putmem_wave(void *dest,
-                        const void *source, size_t nelems, int pe) {
-  uint64_t L_offset = reinterpret_cast<char *>(dest) - wrk_sync_pool_bases_[my_pe];
-  memcpy_wave(wrk_sync_pool_bases_[pe] + L_offset, const_cast<void *>(source), nelems);
-  ipcImpl_.ipcFence<detail::atomic::memory_scope_system, 
+__device__ void IPCContext::internal_putmem_wave(void *dest, const void *source,
+                                                 size_t nelems, int pe) {
+  uint64_t L_offset =
+      reinterpret_cast<char *>(dest) - wrk_sync_pool_bases_[my_pe];
+  memcpy_wave(wrk_sync_pool_bases_[pe] + L_offset, const_cast<void *>(source),
+              nelems);
+  ipcImpl_.ipcFence<detail::atomic::memory_scope_system,
                     detail::atomic::memory_order_release>();
 }
 
-__device__ void IPCContext::internal_getmem_wave(void *dest,
-                        const void *source, size_t nelems, int pe) {
+__device__ void IPCContext::internal_getmem_wave(void *dest, const void *source,
+                                                 size_t nelems, int pe) {
   const char *src_typed = reinterpret_cast<const char *>(source);
-  uint64_t L_offset = const_cast<char *>(src_typed) - wrk_sync_pool_bases_[my_pe];
+  uint64_t L_offset =
+      const_cast<char *>(src_typed) - wrk_sync_pool_bases_[my_pe];
   memcpy_wave(dest, wrk_sync_pool_bases_[pe] + L_offset, nelems);
-  ipcImpl_.ipcFence<detail::atomic::memory_scope_system, 
+  ipcImpl_.ipcFence<detail::atomic::memory_scope_system,
                     detail::atomic::memory_order_acquire>();
 }
 
-__device__ void IPCContext::putmem_signal(void *dest, const void *source, size_t nelems,
-                                          uint64_t *sig_addr, uint64_t signal, int sig_op,
-                                          int pe) {
+__device__ void IPCContext::putmem_signal(void *dest, const void *source,
+                                          size_t nelems, uint64_t *sig_addr,
+                                          uint64_t signal, int sig_op, int pe) {
   putmem(dest, source, nelems, pe);
   fence();
 
   switch (sig_op) {
-  case ROCSHMEM_SIGNAL_SET:
-    amo_set<uint64_t>(static_cast<void*>(sig_addr), signal, pe);
-    break;
-  case ROCSHMEM_SIGNAL_ADD:
-    amo_add<uint64_t>(static_cast<void*>(sig_addr), signal, pe);
-    break;
-  default:
-    DPRINTF("[%s] Invalid sig_op value (%d)\n", __func__, sig_op);
-    break;
+    case ROCSHMEM_SIGNAL_SET:
+      amo_set<uint64_t>(static_cast<void *>(sig_addr), signal, pe);
+      break;
+    case ROCSHMEM_SIGNAL_ADD:
+      amo_add<uint64_t>(static_cast<void *>(sig_addr), signal, pe);
+      break;
+    default:
+      DPRINTF("[%s] Invalid sig_op value (%d)\n", __func__, sig_op);
+      break;
   }
 }
 
-__device__ void IPCContext::putmem_signal_wg(void *dest, const void *source, size_t nelems,
-                                             uint64_t *sig_addr, uint64_t signal, int sig_op,
+__device__ void IPCContext::putmem_signal_wg(void *dest, const void *source,
+                                             size_t nelems, uint64_t *sig_addr,
+                                             uint64_t signal, int sig_op,
                                              int pe) {
   putmem_wg(dest, source, nelems, pe);
   fence();
 
   if (is_thread_zero_in_block()) {
     switch (sig_op) {
-    case ROCSHMEM_SIGNAL_SET:
-      amo_set<uint64_t>(static_cast<void*>(sig_addr), signal, pe);
-      break;
-    case ROCSHMEM_SIGNAL_ADD:
-      amo_add<uint64_t>(static_cast<void*>(sig_addr), signal, pe);
-      break;
-    default:
-      DPRINTF("[%s] Invalid sig_op value (%d)\n", __func__, sig_op);
-      break;
+      case ROCSHMEM_SIGNAL_SET:
+        amo_set<uint64_t>(static_cast<void *>(sig_addr), signal, pe);
+        break;
+      case ROCSHMEM_SIGNAL_ADD:
+        amo_add<uint64_t>(static_cast<void *>(sig_addr), signal, pe);
+        break;
+      default:
+        DPRINTF("[%s] Invalid sig_op value (%d)\n", __func__, sig_op);
+        break;
     }
   }
 }
 
-__device__ void IPCContext::putmem_signal_wave(void *dest, const void *source, size_t nelems,
-                                               uint64_t *sig_addr, uint64_t signal, int sig_op,
+__device__ void IPCContext::putmem_signal_wave(void *dest, const void *source,
+                                               size_t nelems,
+                                               uint64_t *sig_addr,
+                                               uint64_t signal, int sig_op,
                                                int pe) {
   putmem_wave(dest, source, nelems, pe);
   fence();
 
   if (is_thread_zero_in_wave()) {
     switch (sig_op) {
-    case ROCSHMEM_SIGNAL_SET:
-      amo_set<uint64_t>(static_cast<void*>(sig_addr), signal, pe);
-      break;
-    case ROCSHMEM_SIGNAL_ADD:
-      amo_add<uint64_t>(static_cast<void*>(sig_addr), signal, pe);
-      break;
-    default:
-      DPRINTF("[%s] Invalid sig_op value (%d)\n", __func__, sig_op);
-      break;
+      case ROCSHMEM_SIGNAL_SET:
+        amo_set<uint64_t>(static_cast<void *>(sig_addr), signal, pe);
+        break;
+      case ROCSHMEM_SIGNAL_ADD:
+        amo_add<uint64_t>(static_cast<void *>(sig_addr), signal, pe);
+        break;
+      default:
+        DPRINTF("[%s] Invalid sig_op value (%d)\n", __func__, sig_op);
+        break;
     }
   }
 }
 
-__device__ void IPCContext::putmem_signal_nbi(void *dest, const void *source, size_t nelems,
-                                              uint64_t *sig_addr, uint64_t signal, int sig_op,
+__device__ void IPCContext::putmem_signal_nbi(void *dest, const void *source,
+                                              size_t nelems, uint64_t *sig_addr,
+                                              uint64_t signal, int sig_op,
                                               int pe) {
   putmem_signal(dest, source, nelems, sig_addr, signal, sig_op, pe);
 }
 
-__device__ void IPCContext::putmem_signal_nbi_wg(void *dest, const void *source, size_t nelems,
-                                                 uint64_t *sig_addr, uint64_t signal, int sig_op,
+__device__ void IPCContext::putmem_signal_nbi_wg(void *dest, const void *source,
+                                                 size_t nelems,
+                                                 uint64_t *sig_addr,
+                                                 uint64_t signal, int sig_op,
                                                  int pe) {
   putmem_signal_wg(dest, source, nelems, sig_addr, signal, sig_op, pe);
 }
 
-__device__ void IPCContext::putmem_signal_nbi_wave(void *dest, const void *source, size_t nelems,
-                                                   uint64_t *sig_addr, uint64_t signal, int sig_op,
-                                                   int pe) {
+__device__ void IPCContext::putmem_signal_nbi_wave(
+    void *dest, const void *source, size_t nelems, uint64_t *sig_addr,
+    uint64_t signal, int sig_op, int pe) {
   putmem_signal_wave(dest, source, nelems, sig_addr, signal, sig_op, pe);
 }
 
 __device__ uint64_t IPCContext::signal_fetch(const uint64_t *sig_addr) {
-  uint64_t *dst = const_cast<uint64_t*>(sig_addr);
-  return amo_fetch_add<uint64_t>(static_cast<void*>(dst), 0, my_pe);
+  uint64_t *dst = const_cast<uint64_t *>(sig_addr);
+  return amo_fetch_add<uint64_t>(static_cast<void *>(dst), 0, my_pe);
 }
 
 __device__ uint64_t IPCContext::signal_fetch_wg(const uint64_t *sig_addr) {
   __shared__ uint64_t value;
   if (is_thread_zero_in_block()) {
-    uint64_t *dst = const_cast<uint64_t*>(sig_addr);
-    value = amo_fetch_add<uint64_t>(static_cast<void*>(dst), 0, my_pe);
+    uint64_t *dst = const_cast<uint64_t *>(sig_addr);
+    value = amo_fetch_add<uint64_t>(static_cast<void *>(dst), 0, my_pe);
   }
   __threadfence_block();
   return value;
@@ -316,8 +330,8 @@ __device__ uint64_t IPCContext::signal_fetch_wg(const uint64_t *sig_addr) {
 __device__ uint64_t IPCContext::signal_fetch_wave(const uint64_t *sig_addr) {
   uint64_t value{0};
   if (is_thread_zero_in_wave()) {
-    uint64_t *dst = const_cast<uint64_t*>(sig_addr);
-    value = amo_fetch_add<uint64_t>(static_cast<void*>(dst), 0, my_pe);
+    uint64_t *dst = const_cast<uint64_t *>(sig_addr);
+    value = amo_fetch_add<uint64_t>(static_cast<void *>(dst), 0, my_pe);
   }
   __threadfence_block();
   value = __shfl(value, 0);

--- a/projects/rocshmem/src/ipc_policy.hpp
+++ b/projects/rocshmem/src/ipc_policy.hpp
@@ -35,6 +35,7 @@
 #include "memory/std_allocator.hpp"
 #include "util.hpp"
 #include "bootstrap/bootstrap.hpp"
+#include "atomic.hpp"
 
 namespace rocshmem {
 
@@ -82,7 +83,11 @@ class IpcOnImpl {
 
   __device__ void ipcCopy_wave(void *dst, void *src, size_t size);
 
-  __device__ void ipcFence() { __threadfence_system(); }
+  template <detail::atomic::rocshmem_memory_scope scope = detail::atomic::memory_scope_system,
+            detail::atomic::rocshmem_memory_order order = detail::atomic::memory_order_seq_cst>
+  __device__ __forceinline__ void ipcFence() {
+    detail::atomic::fence<scope, order>();
+  }
 
   template <typename T>
   __device__ void ipcAMOAdd(T *val, T value) {
@@ -192,7 +197,9 @@ class IpcOffImpl {
 
   __device__ void ipcCopy_wave(void *dst, void *src, size_t size) {}
 
-  __device__ void ipcFence() {}
+  template <detail::atomic::rocshmem_memory_scope scope = detail::atomic::memory_scope_system,
+            detail::atomic::rocshmem_memory_order order = detail::atomic::memory_order_seq_cst>
+  __device__ __forceinline__ void ipcFence() {}
 
   template <typename T>
   __device__ T ipcAMOFetchAdd(T *val, T value) {

--- a/projects/rocshmem/src/ipc_policy.hpp
+++ b/projects/rocshmem/src/ipc_policy.hpp
@@ -86,7 +86,7 @@ class IpcOnImpl {
   template <detail::atomic::rocshmem_memory_scope scope = detail::atomic::memory_scope_system,
             detail::atomic::rocshmem_memory_order order = detail::atomic::memory_order_seq_cst>
   __device__ __forceinline__ void ipcFence() {
-    detail::atomic::fence<scope, order>();
+    detail::atomic::threadfence<scope, order>();
   }
 
   template <typename T>

--- a/projects/rocshmem/src/util.hpp
+++ b/projects/rocshmem/src/util.hpp
@@ -512,9 +512,9 @@ template <typename... Args>
   dst_bytes = dst_def;
   src_bytes = src_def;
 
-  for (int j= 16; j > 1; j >>= 1) {
+  for (int j = 16; j > 1; j >>= 1) {
     cpy_size = size / j;
-    for (int i= wave_tid; i < cpy_size; i += wave_size) {
+    for (int i = wave_tid; i < cpy_size; i += wave_size) {
       dst_bytes = dst_def;
       src_bytes = src_def;
 

--- a/projects/rocshmem/src/util.hpp
+++ b/projects/rocshmem/src/util.hpp
@@ -445,7 +445,7 @@ template <typename... Args>
   uint8_t* dst_bytes{static_cast<uint8_t*>(dst)};
   uint8_t* src_bytes{static_cast<uint8_t*>(src)};
 
-  for (size_t i = 8; i > 1; i >>= 1) {
+  for (int i = 16; i > 1; i >>= 1) {
     while (size >= i) {
       store_asm(src_bytes, dst_bytes, i);
       src_bytes += i;
@@ -474,9 +474,9 @@ template <typename... Args>
   dst_bytes = dst_def;
   src_bytes = src_def;
 
-  for (int j{8}; j > 1; j >>= 1) {
+  for (int j = 16; j > 1; j >>= 1) {
     cpy_size = size / j;
-    for (int i{thread_id}; i < cpy_size; i += block_size) {
+    for (int i = thread_id; i < cpy_size; i += block_size) {
       dst_bytes = dst_def;
       src_bytes = src_def;
 
@@ -512,9 +512,9 @@ template <typename... Args>
   dst_bytes = dst_def;
   src_bytes = src_def;
 
-  for (int j{8}; j > 1; j >>= 1) {
+  for (int j= 16; j > 1; j >>= 1) {
     cpy_size = size / j;
-    for (int i{wave_tid}; i < cpy_size; i += wave_size) {
+    for (int i= wave_tid; i < cpy_size; i += wave_size) {
       dst_bytes = dst_def;
       src_bytes = src_def;
 


### PR DESCRIPTION
## Motivation

Improve IPC conduit bandwidth. This is a base for another followup PR.

## Technical Details

This PR has two main contributions:

- [ ] Add another width (16) to `store_asm` functionality to be used in `memcpy_wg` and `memcpy_wave`

- [ ] (A) The synchronization after each memory operation on IPC had a `__syncthreads()` call followed by a `__threadfence_system()`. This means that threads within the whole workgroup sync first then they flush fence requests all together. Fence operations are scalar operations that are initiated once per wavefront, and with the current implementation, the waves are getting blocked by the latest wave. 

- [ ] (B) Under the hood, the `__threadfence_system()` uses `__ATOMIC_SEQ_CST` semantic for memory ordering. The scope is correct (system), but the memory ordering is wasteful. For instance, for put operations, this can be set as `__ATOMIC_RELEASE`, and for get operations it can be set as `__ATOMIC_REQUIRE`. So, to provide this functionality, a few methods were added to `atomic.hpp` where other memory ordering stuff was already implemented. Then in IPC implementation the fence operation can become a wrapper instead of calling threadfence_system blindly. By default, it will be `system` and `__ATOMIC_SEQ_CST`. 

## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
AIROCSHMEM-365

## Test Result

All functional tests pass with good performance. DeepEP `LowLatency` test also passes.

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.


[AIROCSHMEM-365]: https://amd-hub.atlassian.net/browse/AIROCSHMEM-365?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ