### PR TITLE
Revert "[clr] use compiler builtins for reduce operations"

### DIFF
--- a/projects/clr/hipamd/include/hip/amd_detail/amd_warp_sync_functions.h
+++ b/projects/clr/hipamd/include/hip/amd_detail/amd_warp_sync_functions.h
@@ -465,135 +465,7 @@ __device__ inline T __reduce_op_sync(MaskT mask, T val, BinaryOp op, WfReduce wf
   }
 }
 
-// Compiler now provides builtins to optimized code for reduce device functions
-// Checking for one, they all were added at the same time.
-// Quite a lot of our work should be offloaded now, all we need to do is validations
-#if __has_builtin(__builtin_amdgcn_wave_reduce_add_u32)
-#define HIP_WARP_REDUCE_COMPILER_BUILTINS
-
-template <
-    typename MaskT, typename ValueT,
-    typename __hip_internal::enable_if<__hip_internal::is_same<ValueT, int>::value ||
-                                           __hip_internal::is_same<ValueT, unsigned int>::value,
-                                       int>::type = 0>
-static __device__ ValueT __reduce_add_sync_builtins_variant(MaskT mask, ValueT val) {
-  // Mask size checks
-  static_assert(__hip_internal::is_integral<MaskT>::value && sizeof(MaskT) == 8,
-                "The mask must be a 64-bit integer. "
-                "Implicitly promoting a smaller integer is almost always an error.");
-
-  // Adjust mask for 32 warp size
-  __hip_adjust_mask_for_wave32(mask);
-
-  unsigned int ret{};
-  __hip_do_sync(ret, __builtin_amdgcn_wave_reduce_add_u32, mask, val, 0);
-  // the builtin is unsigned but it should work fine for signed as well
-  return static_cast<ValueT>(ret);
-}
-
-template <
-    typename MaskT, typename ValueT,
-    typename __hip_internal::enable_if<__hip_internal::is_same<ValueT, int>::value ||
-                                           __hip_internal::is_same<ValueT, unsigned int>::value,
-                                       int>::type = 0>
-static __device__ ValueT __reduce_min_sync_builtins_variant(MaskT mask, ValueT val) {
-  // Mask size checks
-  static_assert(__hip_internal::is_integral<MaskT>::value && sizeof(MaskT) == 8,
-                "The mask must be a 64-bit integer. "
-                "Implicitly promoting a smaller integer is almost always an error.");
-
-  // Adjust mask for 32 warp size
-  __hip_adjust_mask_for_wave32(mask);
-
-  ValueT ret{};
-  if constexpr (__hip_internal::is_same<ValueT, int>::value) {
-    __hip_do_sync(ret, __builtin_amdgcn_wave_reduce_min_i32, mask, val, 0);
-  } else {
-    __hip_do_sync(ret, __builtin_amdgcn_wave_reduce_min_u32, mask, val, 0);
-  }
-  return ret;
-}
-
-template <
-    typename MaskT, typename ValueT,
-    typename __hip_internal::enable_if<__hip_internal::is_same<ValueT, int>::value ||
-                                           __hip_internal::is_same<ValueT, unsigned int>::value,
-                                       int>::type = 0>
-static __device__ ValueT __reduce_max_sync_builtins_variant(MaskT mask, ValueT val) {
-  // Mask size checks
-  static_assert(__hip_internal::is_integral<MaskT>::value && sizeof(MaskT) == 8,
-                "The mask must be a 64-bit integer. "
-                "Implicitly promoting a smaller integer is almost always an error.");
-
-  // Adjust mask for 32 warp size
-  __hip_adjust_mask_for_wave32(mask);
-
-  ValueT ret{};
-  if constexpr (__hip_internal::is_same<ValueT, int>::value) {
-    __hip_do_sync(ret, __builtin_amdgcn_wave_reduce_max_i32, mask, val, 0);
-  } else {
-    __hip_do_sync(ret, __builtin_amdgcn_wave_reduce_max_u32, mask, val, 0);
-  }
-  return ret;
-}
-
-
-template <typename MaskT, typename ValueT,
-          typename __hip_internal::enable_if<__hip_internal::is_same<ValueT, unsigned int>::value,
-                                             int>::type = 0>
-static __device__ ValueT __reduce_and_sync_builtins_variant(MaskT mask, ValueT val) {
-  // Mask size checks
-  static_assert(__hip_internal::is_integral<MaskT>::value && sizeof(MaskT) == 8,
-                "The mask must be a 64-bit integer. "
-                "Implicitly promoting a smaller integer is almost always an error.");
-
-  // Adjust mask for 32 warp size
-  __hip_adjust_mask_for_wave32(mask);
-
-  ValueT ret{};
-  __hip_do_sync(ret, __builtin_amdgcn_wave_reduce_and_b32, mask, val, 0);
-  return ret;
-}
-
-template <typename MaskT, typename ValueT,
-          typename __hip_internal::enable_if<__hip_internal::is_same<ValueT, unsigned int>::value,
-                                             int>::type = 0>
-static __device__ ValueT __reduce_or_sync_builtins_variant(MaskT mask, ValueT val) {
-  // Mask size checks
-  static_assert(__hip_internal::is_integral<MaskT>::value && sizeof(MaskT) == 8,
-                "The mask must be a 64-bit integer. "
-                "Implicitly promoting a smaller integer is almost always an error.");
-
-  // Adjust mask for 32 warp size
-  __hip_adjust_mask_for_wave32(mask);
-
-  ValueT ret{};
-  __hip_do_sync(ret, __builtin_amdgcn_wave_reduce_or_b32, mask, val, 0);
-  return ret;
-}
-
-template <typename MaskT, typename ValueT,
-          typename __hip_internal::enable_if<__hip_internal::is_same<ValueT, unsigned int>::value,
-                                             int>::type = 0>
-static __device__ ValueT __reduce_xor_sync_builtins_variant(MaskT mask, ValueT val) {
-  // Mask size checks
-  static_assert(__hip_internal::is_integral<MaskT>::value && sizeof(MaskT) == 8,
-                "The mask must be a 64-bit integer. "
-                "Implicitly promoting a smaller integer is almost always an error.");
-
-  // Adjust mask for 32 warp size
-  __hip_adjust_mask_for_wave32(mask);
-
-  ValueT ret{};
-  __hip_do_sync(ret, __builtin_amdgcn_wave_reduce_xor_b32, mask, val, 0);
-  return ret;
-}
-#endif
-
 template <typename MaskT> __device__ inline int __reduce_add_sync(MaskT mask, int val) {
-#if defined(HIP_WARP_REDUCE_COMPILER_BUILTINS)
-  return __reduce_add_sync_builtins_variant(mask, val);
-#else
   // although C++ has std::plus and other functors, we do not use them because
   // they are in the header <functional> and they were causing problems with hipRTC
   // at this time
@@ -601,101 +473,68 @@ template <typename MaskT> __device__ inline int __reduce_add_sync(MaskT mask, in
   auto wfReduce = [](decltype(val) v) { return __ockl_wfred_add_i32(v); };
 
   return __reduce_op_sync(mask, val, op, wfReduce);
-#endif
 }
 
 template <typename MaskT>
 __device__ inline unsigned int __reduce_add_sync(MaskT mask, unsigned int val) {
-#if defined(HIP_WARP_REDUCE_COMPILER_BUILTINS)
-  return __reduce_add_sync_builtins_variant(mask, val);
-#else
   auto op = [](decltype(val)& a, decltype(val)& b) { return a + b; };
   auto wfReduce = [](decltype(val) v) { return __ockl_wfred_add_u32(v); };
 
   return __reduce_op_sync(mask, val, op, wfReduce);
-#endif
 }
 
 template <typename MaskT> __device__ inline int __reduce_min_sync(MaskT mask, int val) {
-#if defined(HIP_WARP_REDUCE_COMPILER_BUILTINS)
-  return __reduce_min_sync_builtins_variant(mask, val);
-#else
   auto op = [](decltype(val) lhs, decltype(val) rhs) { return rhs < lhs ? rhs : lhs; };
   auto wfReduce = [](decltype(val) v) { return __ockl_wfred_min_i32(v); };
 
   return __reduce_op_sync(mask, val, op, wfReduce);
-#endif
 }
 
 template <typename MaskT>
 __device__ inline unsigned int __reduce_min_sync(MaskT mask, unsigned int val) {
-#if defined(HIP_WARP_REDUCE_COMPILER_BUILTINS)
-  return __reduce_min_sync_builtins_variant(mask, val);
-#else
   auto op = [](decltype(val) lhs, decltype(val) rhs) { return rhs < lhs ? rhs : lhs; };
   auto wfReduce = [](decltype(val) v) { return __ockl_wfred_min_u32(v); };
 
   return __reduce_op_sync(mask, val, op, wfReduce);
-#endif
 }
 
 template <typename MaskT> __device__ inline int __reduce_max_sync(MaskT mask, int val) {
-#if defined(HIP_WARP_REDUCE_COMPILER_BUILTINS)
-  return __reduce_max_sync_builtins_variant(mask, val);
-#else
   auto op = [](decltype(val) lhs, decltype(val) rhs) { return lhs < rhs ? rhs : lhs; };
   auto wfReduce = [](decltype(val) v) { return __ockl_wfred_max_i32(v); };
 
   return __reduce_op_sync(mask, val, op, wfReduce);
-#endif
 }
 
 template <typename MaskT>
 __device__ inline unsigned int __reduce_max_sync(MaskT mask, unsigned int val) {
-#if defined(HIP_WARP_REDUCE_COMPILER_BUILTINS)
-  return __reduce_max_sync_builtins_variant(mask, val);
-#else
   auto op = [](decltype(val) lhs, decltype(val) rhs) { return lhs < rhs ? rhs : lhs; };
   auto wfReduce = [](decltype(val) v) { return __ockl_wfred_max_u32(v); };
 
   return __reduce_op_sync(mask, val, op, wfReduce);
-#endif
 }
 
 template <typename MaskT>
 __device__ inline unsigned int __reduce_or_sync(MaskT mask, unsigned int val) {
-#if defined(HIP_WARP_REDUCE_COMPILER_BUILTINS)
-  return __reduce_or_sync_builtins_variant(mask, val);
-#else
   auto op = [](decltype(val) lhs, decltype(val) rhs) { return lhs | rhs; };
   auto wfReduce = [](decltype(val) v) { return __ockl_wfred_or_u32(v); };
 
   return __reduce_op_sync(mask, val, op, wfReduce);
-#endif
 }
 
 template <typename MaskT>
 __device__ inline unsigned int __reduce_and_sync(MaskT mask, unsigned int val) {
-#if defined(HIP_WARP_REDUCE_COMPILER_BUILTINS)
-  return __reduce_and_sync_builtins_variant(mask, val);
-#else
   auto op = [](decltype(val) lhs, decltype(val) rhs) { return lhs & rhs; };
   auto wfReduce = [](decltype(val) v) { return __ockl_wfred_and_u32(v); };
 
   return __reduce_op_sync(mask, val, op, wfReduce);
-#endif
 }
 
 template <typename MaskT>
 __device__ inline unsigned int __reduce_xor_sync(MaskT mask, unsigned int val) {
-#if defined(HIP_WARP_REDUCE_COMPILER_BUILTINS)
-  return __reduce_xor_sync_builtins_variant(mask, val);
-#else
   auto op = [](decltype(val) lhs, decltype(val) rhs) { return lhs ^ rhs; };
   auto wfReduce = [](decltype(val) v) { return __ockl_wfred_xor_u32(v); };
 
   return __reduce_op_sync(mask, val, op, wfReduce);
-#endif
 }
 
 #ifdef HIP_ENABLE_EXTRA_WARP_SYNC_TYPES
@@ -857,10 +696,6 @@ __device__ inline unsigned long long __reduce_xor_sync(MaskT mask, unsigned long
 #undef __hip_adjust_mask_for_wave32
 
 #endif  // HIP_ENABLE_EXTRA_WARP_SYNC_TYPES
-
-#if defined(HIP_WARP_REDUCE_COMPILER_BUILTINS)
-#undef HIP_WARP_REDUCE_COMPILER_BUILTINS
-#endif
 
 #pragma pop_macro("MAYBE_UNDEF")
 


### PR DESCRIPTION
## Motivation

Reverts ROCm/rocm-systems#4226

## Technical Details

Seeing some reduce tests failing in CI, which is weird. These tests did not fail during CI run of original PR, will revert and investigate so that it does not block anyone.

## JIRA ID

NA

## Test Plan

NA

## Test Result

NA

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
