### PR TITLE
[rocprofiler-compute] Add development requirements to Docker image

### DIFF
--- a/projects/rocprofiler-compute/docker/Dockerfile.customrocmtest
+++ b/projects/rocprofiler-compute/docker/Dockerfile.customrocmtest
@@ -40,7 +40,7 @@ RUN python -m pip install --upgrade pip
 # Install any rocprofiler-compute dependencies specified in requirements.txt
 COPY projects/rocprofiler-compute/requirements.txt /app/projects/rocprofiler-compute/requirements.txt
 COPY projects/rocprofiler-compute/requirements-test.txt /app/projects/rocprofiler-compute/requirements-test.txt
-COPY projects/rocprofiler-compute/requirements-dev.txt /app/projects/rocprofiler-compute/requirements-development.txt
+COPY projects/rocprofiler-compute/requirements-development.txt /app/projects/rocprofiler-compute/requirements-development.txt
 RUN python -m pip install -r /app/projects/rocprofiler-compute/requirements.txt -r /app/projects/rocprofiler-compute/requirements-test.txt -r /app/projects/rocprofiler-compute/requirements-development.txt
 
 # Set the working directory

--- a/projects/rocprofiler-compute/docker/Dockerfile.customrocmtest
+++ b/projects/rocprofiler-compute/docker/Dockerfile.customrocmtest
@@ -40,7 +40,8 @@ RUN python -m pip install --upgrade pip
 # Install any rocprofiler-compute dependencies specified in requirements.txt
 COPY projects/rocprofiler-compute/requirements.txt /app/projects/rocprofiler-compute/requirements.txt
 COPY projects/rocprofiler-compute/requirements-test.txt /app/projects/rocprofiler-compute/requirements-test.txt
-RUN python -m pip install -r /app/projects/rocprofiler-compute/requirements.txt -r /app/projects/rocprofiler-compute/requirements-test.txt
+COPY projects/rocprofiler-compute/requirements-dev.txt /app/projects/rocprofiler-compute/requirements-development.txt
+RUN python -m pip install -r /app/projects/rocprofiler-compute/requirements.txt -r /app/projects/rocprofiler-compute/requirements-test.txt -r /app/projects/rocprofiler-compute/requirements-development.txt
 
 # Set the working directory
 WORKDIR /app/projects/rocprofiler-compute

--- a/projects/rocprofiler-compute/docker/docker-compose.customrocmtest.yml
+++ b/projects/rocprofiler-compute/docker/docker-compose.customrocmtest.yml
@@ -18,3 +18,5 @@ services:
       - 8050:8050
     tty: true
     stdin_open: true
+    cap_add:
+      - SYS_PTRACE


### PR DESCRIPTION
## Motivation

Add development dependencies (`requirements-dev.txt`) to the `customrocmtest` Docker image so that dev tooling (ruff, pre-commit, etc.) is available inside the container.

## Technical Details

- Copy `requirements-dev.txt` into the Docker image as `requirements-development.txt`
- Install it alongside existing `requirements.txt` and `requirements-test.txt`

## JIRA ID

## Test Plan

- Build the `customrocmtest` Docker image and verify all three requirement files are installed

## Test Result

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.