### PR TITLE
rocminfo: skip linux-based enumerators on rocm_agent_enumerator

### DIFF
--- a/projects/rocminfo/rocm_agent_enumerator
+++ b/projects/rocminfo/rocm_agent_enumerator
@@ -12,6 +12,7 @@ import re
 import subprocess
 import sys
 import time
+import platform
 
 # get current working directory
 CWD = os.path.dirname(os.path.realpath(__file__))
@@ -280,11 +281,12 @@ def main():
     """
     target_list = readFromTargetLstFile()
 
-    if len(target_list) == 0:
-      target_list = readFromKFD()
+    if platform.system() == "Linux":
+      if len(target_list) == 0:
+        target_list = readFromKFD()
 
-    if len(target_list) == 0:
-      target_list = readFromLSPCI()
+      if len(target_list) == 0:
+        target_list = readFromLSPCI()
 
     if len(target_list) == 0:
       target_list = readFromROCMINFO()


### PR DESCRIPTION
Skip readFromKFD and readFromLSPCI if OS is not Linux.
## Motivation
These functions are not valid on Windows

