### PR TITLE
[rocSHMEM] Implement ROCSHMEM_TEAM_SHARED in all the backends

### DIFF
--- a/projects/rocshmem/CHANGELOG.md
+++ b/projects/rocshmem/CHANGELOG.md
@@ -20,6 +20,7 @@
   `ROCSHMEM_VENDOR_PATCH_VERSION`
 * Added vendor string and backend metadata to `rocshmem_info` output
 * Added `ROCSHMEM_TEAM_WORLD` for the device code
+* Added `ROCSHMEM_TEAM_SHARED` predefined team for PEs sharing a common memory domain (same node)
 * Added new environment variables:
   * `OVERRIDE_NIC_FIRMWARE_CHECK`
   * `ROCSHMEM_GDA_NUM_QPS_PER_PE_DEFAULT_CTX`

--- a/projects/rocshmem/docs/api/teams.rst
+++ b/projects/rocshmem/docs/api/teams.rst
@@ -8,6 +8,34 @@
 Team management routines
 -------------------------
 
+Predefined teams
+----------------
+
+.. cpp:var:: rocshmem_team_t ROCSHMEM_TEAM_WORLD
+
+   Handle that corresponds to the world team that contains all PEs in the
+   rocSHMEM program. The default context is tied to the world team.
+   Contexts created without specifying a team, default to the world team.
+   Available on both host and device.
+
+.. cpp:var:: rocshmem_team_t ROCSHMEM_TEAM_SHARED
+
+   Handle that corresponds to a team of PEs that share a memory domain.
+   ``ROCSHMEM_TEAM_SHARED`` refers to the team of all PEs whose symmetric
+   heap objects are directly load/store accessible by all PEs in the team
+   (i.e. co-located on the same node). Available on both host and device.
+   Set to ``ROCSHMEM_TEAM_INVALID`` when IPC is disabled at compile-time
+   or runtime.
+
+.. cpp:var:: rocshmem_team_t ROCSHMEM_TEAM_INVALID
+
+   A value corresponding to an invalid team. This value can be used to
+   initialize or update team handles to indicate that they do not
+   reference a valid team. When managed in this way, applications can use
+   an equality comparison to test whether a given team handle references a
+   valid team. Predefined teams such as ``ROCSHMEM_TEAM_SHARED`` may also
+   hold this value when the required capability (e.g. IPC) is unavailable.
+
 ROCSHMEM_TEAM_MY_PE
 -------------------
 
@@ -77,10 +105,11 @@ ROCSHMEM_TEAM_DESTROY
 
 .. cpp:function:: __host__ void rocshmem_team_destroy(rocshmem_team_t team)
 
-  :param team: The team to destroy. The behavior is undefined if
-               the input team is ``ROCSHMEM_TEAM_WORLD`` or any other
-               invalid team. If the input is ``ROCSHMEM_TEAM_INVALID``,
-               this function will not perform any operation.
+  :param team: The team to destroy.
+               ``ROCSHMEM_TEAM_INVALID``, ``ROCSHMEM_TEAM_WORLD``, and
+               ``ROCSHMEM_TEAM_SHARED`` are silently ignored (no-op).
+               Passing a handle that was already destroyed or
+               never created results in undefined behavior.
 
   :returns:    None
 

--- a/projects/rocshmem/docs/api/teams.rst
+++ b/projects/rocshmem/docs/api/teams.rst
@@ -25,7 +25,8 @@ Predefined teams
    heap objects are directly load/store accessible by all PEs in the team
    (i.e. co-located on the same node). Available on both host and device.
    Set to ``ROCSHMEM_TEAM_INVALID`` when IPC is disabled at compile-time
-   or runtime.
+   or runtime, or when the node-local PE ranks are not uniformly strided
+   in ``ROCSHMEM_TEAM_WORLD``.
 
 .. cpp:var:: rocshmem_team_t ROCSHMEM_TEAM_INVALID
 

--- a/projects/rocshmem/include/rocshmem/rocshmem.hpp
+++ b/projects/rocshmem/include/rocshmem/rocshmem.hpp
@@ -363,11 +363,11 @@ __host__ int rocshmem_team_split_strided(rocshmem_team_t parent_team,
  * is undefined. This call will destroy only the shareable contexts
  * created from the referenced team.
  *
- * @param[in] team The team to destroy. The behavior is undefined if
- *                 the input team is ROCSHMEM_TEAM_WORLD,
- *                 ROCSHMEM_TEAM_SHARED, or any other invalid team.
- *                 If the input is ROCSHMEM_TEAM_INVALID, this function
- *                 will not perform any operation.
+ * @param[in] team The team to destroy.
+ *                 ROCSHMEM_TEAM_INVALID, ROCSHMEM_TEAM_WORLD, and
+ *                 ROCSHMEM_TEAM_SHARED are silently ignored (no-op).
+ *                 Passing a handle that was already destroyed or
+ *                 never created results in undefined behavior.
  *
  * @return None.
  */

--- a/projects/rocshmem/include/rocshmem/rocshmem.hpp
+++ b/projects/rocshmem/include/rocshmem/rocshmem.hpp
@@ -364,9 +364,10 @@ __host__ int rocshmem_team_split_strided(rocshmem_team_t parent_team,
  * created from the referenced team.
  *
  * @param[in] team The team to destroy. The behavior is undefined if
- *                 the input team is ROCSHMEM_TEAM_WORLD or any other
- *                 invalid team. If the input is ROCSHMEM_TEAM_INVALID,
- *                 this function will not perform any operation.
+ *                 the input team is ROCSHMEM_TEAM_WORLD,
+ *                 ROCSHMEM_TEAM_SHARED, or any other invalid team.
+ *                 If the input is ROCSHMEM_TEAM_INVALID, this function
+ *                 will not perform any operation.
  *
  * @return None.
  */

--- a/projects/rocshmem/include/rocshmem/rocshmem_common.hpp
+++ b/projects/rocshmem/include/rocshmem/rocshmem_common.hpp
@@ -153,22 +153,32 @@ namespace device {
     extern "C" {
         extern __constant__ rocshmem_team_t
             __attribute__((visibility("default"))) ROCSHMEM_TEAM_WORLD;
+        extern __constant__ rocshmem_team_t
+            __attribute__((visibility("default"))) ROCSHMEM_TEAM_SHARED;
     }
 }
 namespace host {
     extern rocshmem_team_t ROCSHMEM_TEAM_WORLD;
+    extern rocshmem_team_t ROCSHMEM_TEAM_SHARED;
 }
 
 #if __HIP_DEVICE_COMPILE__
 using device::ROCSHMEM_TEAM_WORLD;
+using device::ROCSHMEM_TEAM_SHARED;
 #else
 using host::ROCSHMEM_TEAM_WORLD;
+using host::ROCSHMEM_TEAM_SHARED;
 #endif
 
 /**
  * Used internally to update the ROCSHMEM_TEAM_WORLD constant
  */
 void set_team_world_device(rocshmem_team_t team_world);
+
+/**
+ * Used internally to update the ROCSHMEM_TEAM_SHARED constant
+ */
+void set_team_shared_device(rocshmem_team_t team_shared);
 
 const rocshmem_team_t ROCSHMEM_TEAM_INVALID = nullptr;
 

--- a/projects/rocshmem/scripts/functional_tests/driver.sh
+++ b/projects/rocshmem/scripts/functional_tests/driver.sh
@@ -128,6 +128,7 @@ declare -A TEST_NUMBERS=(
   ["flood_waitadd"]="92"
   ["device_bitcode"]="93"
   ["library_info"]="94"
+  ["teamctxsharedinfra"]="95"
   ["quiet_on_stream"]="96"
   ["sync_all_on_stream"]="97"
 )
@@ -561,6 +562,8 @@ TestOther() {
   ExecTest  "teamctxblockinfra"   5       1            1
   ExecTest  "teamctxoddeveninfra" 4       1            1
   ExecTest  "teamctxoddeveninfra" 5       1            1
+  ExecTest  "teamctxsharedinfra"  2       1            1
+  ExecTest  "teamctxsharedinfra"  5       1            1
   unset ROCSHMEM_MAX_NUM_CONTEXTS
 
   ExecTest  "shmemptr"         2       1            1         8

--- a/projects/rocshmem/src/gda/backend_gda.cpp
+++ b/projects/rocshmem/src/gda/backend_gda.cpp
@@ -145,7 +145,6 @@ GDABackend::~GDABackend() {
 
   auto *team_shared{static_cast<GDATeam*>(team_tracker.get_team_shared())};
   if (team_shared) {
-    team_shared->pe_world_map_ = nullptr;
     team_shared->~GDATeam();
     CHECK_HIP(hipFree(team_shared));
   }
@@ -407,18 +406,40 @@ void GDABackend::setup_team_shared() {
   int shm_rank = ipcImpl.shm_rank;
 
   /*
-   * pe_start/stride are placeholders; actual PE-to-world mapping is handled
-   * by pe_world_map_ since shared-memory ranks may not be uniformly strided.
+   * Determine pe_start/stride from the IPC PE list. The list is on
+   * device memory, so copy it to host for inspection.
    */
+  std::vector<int> team_shared_pes(shm_size);
+  CHECK_HIP(hipMemcpy(team_shared_pes.data(), ipcImpl.pes_with_ipc_avail,
+                       shm_size * sizeof(int), hipMemcpyDeviceToHost));
+
+  int pe_start = team_shared_pes[0];
+  int stride = (shm_size > 1) ? (team_shared_pes[1] - team_shared_pes[0]) : 1;
+  bool uniform = (stride > 0);
+  for (int i = 2; i < shm_size && uniform; i++) {
+    if (team_shared_pes[i] - team_shared_pes[i - 1] != stride) {
+      uniform = false;
+    }
+  }
+
+  if (!uniform) {
+    /*
+     * Node-local ranks are not uniformly strided, so TEAM_SHARED
+     * cannot be represented with pe_start/stride. Mark it invalid
+     * since context-based operations rely on the strided formula.
+     */
+    host::ROCSHMEM_TEAM_SHARED = ROCSHMEM_TEAM_INVALID;
+    set_team_shared_device(ROCSHMEM_TEAM_INVALID);
+    return;
+  }
+
   TeamInfo team_info_wrt_parent(nullptr, 0, 1, shm_size);
-  TeamInfo team_info_wrt_world(nullptr, 0, 1, shm_size);
+  TeamInfo team_info_wrt_world(nullptr, pe_start, stride, shm_size);
 
   GDATeam *team_shared{nullptr};
   CHECK_HIP(hipMalloc(&team_shared, sizeof(GDATeam)));
   new (team_shared) GDATeam(this, team_info_wrt_parent, team_info_wrt_world,
                              shm_size, shm_rank, MPI_COMM_NULL, 1);
-
-  team_shared->pe_world_map_ = ipcImpl.pes_with_ipc_avail;
 
   team_tracker.set_team_shared(team_shared);
 

--- a/projects/rocshmem/src/gda/backend_gda.cpp
+++ b/projects/rocshmem/src/gda/backend_gda.cpp
@@ -143,15 +143,15 @@ GDABackend::~GDABackend() {
 
   cleanup_teams();
 
-  auto *team_shared{team_tracker.get_team_shared()};
+  auto *team_shared{static_cast<GDATeam*>(team_tracker.get_team_shared())};
   if (team_shared) {
     team_shared->pe_world_map_ = nullptr;
-    team_shared->~Team();
+    team_shared->~GDATeam();
     CHECK_HIP(hipFree(team_shared));
   }
 
-  auto *team_world{team_tracker.get_team_world()};
-  team_world->~Team();
+  auto *team_world{static_cast<GDATeam*>(team_tracker.get_team_world())};
+  team_world->~GDATeam();
   CHECK_HIP(hipFree(team_world));
 
   cleanup_wrk_sync_buffer();

--- a/projects/rocshmem/src/gda/backend_gda.cpp
+++ b/projects/rocshmem/src/gda/backend_gda.cpp
@@ -124,6 +124,12 @@ void GDABackend::init() {
 
   setup_ipc();
 
+  /*
+   * setup_team_shared() must follow setup_ipc() because it uses
+   * ipcImpl.pes_with_ipc_avail to determine shared-memory membership.
+   */
+  setup_team_shared();
+
   setup_ibv();
   setup_heap_memory_rkey();
   setup_gpu_qps();
@@ -136,6 +142,14 @@ GDABackend::~GDABackend() {
   cleanup_ctxs();
 
   cleanup_teams();
+
+  auto *team_shared{team_tracker.get_team_shared()};
+  if (team_shared) {
+    team_shared->pe_world_map_ = nullptr;
+    team_shared->~Team();
+    CHECK_HIP(hipFree(team_shared));
+  }
+
   auto *team_world{team_tracker.get_team_world()};
   team_world->~Team();
   CHECK_HIP(hipFree(team_world));
@@ -379,6 +393,41 @@ void GDABackend::setup_team_world() {
    */
   host::ROCSHMEM_TEAM_WORLD = reinterpret_cast<rocshmem_team_t>(team_world);
   set_team_world_device(host::ROCSHMEM_TEAM_WORLD);
+}
+
+void GDABackend::setup_team_shared() {
+#if defined(USE_IPC)
+  if (ipcImpl.pes_with_ipc_avail == nullptr) {
+    host::ROCSHMEM_TEAM_SHARED = ROCSHMEM_TEAM_INVALID;
+    set_team_shared_device(ROCSHMEM_TEAM_INVALID);
+    return;
+  }
+
+  int shm_size = ipcImpl.shm_size;
+  int shm_rank = ipcImpl.shm_rank;
+
+  /*
+   * pe_start/stride are placeholders; actual PE-to-world mapping is handled
+   * by pe_world_map_ since shared-memory ranks may not be uniformly strided.
+   */
+  TeamInfo team_info_wrt_parent(nullptr, 0, 1, shm_size);
+  TeamInfo team_info_wrt_world(nullptr, 0, 1, shm_size);
+
+  GDATeam *team_shared{nullptr};
+  CHECK_HIP(hipMalloc(&team_shared, sizeof(GDATeam)));
+  new (team_shared) GDATeam(this, team_info_wrt_parent, team_info_wrt_world,
+                             shm_size, shm_rank, MPI_COMM_NULL, 1);
+
+  team_shared->pe_world_map_ = ipcImpl.pes_with_ipc_avail;
+
+  team_tracker.set_team_shared(team_shared);
+
+  host::ROCSHMEM_TEAM_SHARED = reinterpret_cast<rocshmem_team_t>(team_shared);
+  set_team_shared_device(host::ROCSHMEM_TEAM_SHARED);
+#else
+  host::ROCSHMEM_TEAM_SHARED = ROCSHMEM_TEAM_INVALID;
+  set_team_shared_device(ROCSHMEM_TEAM_INVALID);
+#endif
 }
 
 void GDABackend::team_destroy(rocshmem_team_t team) {
@@ -665,8 +714,8 @@ void GDABackend::setup_teams() {
 
   memset(team_pool_bitmask_, 0, team_bitmask_size_);
   memset(team_reduced_bitmask_, 0, team_bitmask_size_);
-  /* Set all to available except the 0th one (reserved for TEAM_WORLD) */
-  for (int bit_i = 1; bit_i < max_num_teams; bit_i++) {
+  /* Set all to available except reserved teams (TEAM_WORLD and TEAM_SHARED) */
+  for (int bit_i = TeamTracker::NUM_RESERVED_TEAMS; bit_i < max_num_teams; bit_i++) {
     int byte_i = bit_i / CHAR_BIT;
     team_pool_bitmask_[byte_i] |= 1 << (bit_i % CHAR_BIT);
   }

--- a/projects/rocshmem/src/gda/backend_gda.hpp
+++ b/projects/rocshmem/src/gda/backend_gda.hpp
@@ -343,10 +343,10 @@ class GDABackend : public Backend {
    *
    * TEAM_SHARED contains the PEs that share a common memory domain
    * (same node). Must be called after setup_ipc() since membership
-   * is determined from ipcImpl.pes_with_ipc_avail. Uses pe_world_map_
-   * for PE-to-world translation because node-local ranks may not be
-   * uniformly strided. Set to ROCSHMEM_TEAM_INVALID when IPC is
-   * disabled at compile-time or runtime.
+   * is determined from ipcImpl.pes_with_ipc_avail. Computes real
+   * pe_start/stride from the PE list; set to ROCSHMEM_TEAM_INVALID
+   * when IPC is disabled or when node-local ranks are not uniformly
+   * strided.
    */
   void setup_team_shared();
 

--- a/projects/rocshmem/src/gda/backend_gda.hpp
+++ b/projects/rocshmem/src/gda/backend_gda.hpp
@@ -339,6 +339,15 @@ class GDABackend : public Backend {
   void setup_team_world();
 
   /**
+   * @brief Allocate and initialize team shared.
+   *
+   * TEAM_SHARED contains the PEs that share a common memory domain
+   * (same node).  The pe_start and stride are computed from the
+   * shared-memory communicator or bootstrap local-rank info.
+   */
+  void setup_team_shared();
+
+  /**
    * @brief Initialize the resources required to support teams
    */
   void setup_teams();

--- a/projects/rocshmem/src/gda/backend_gda.hpp
+++ b/projects/rocshmem/src/gda/backend_gda.hpp
@@ -342,8 +342,11 @@ class GDABackend : public Backend {
    * @brief Allocate and initialize team shared.
    *
    * TEAM_SHARED contains the PEs that share a common memory domain
-   * (same node).  The pe_start and stride are computed from the
-   * shared-memory communicator or bootstrap local-rank info.
+   * (same node). Must be called after setup_ipc() since membership
+   * is determined from ipcImpl.pes_with_ipc_avail. Uses pe_world_map_
+   * for PE-to-world translation because node-local ranks may not be
+   * uniformly strided. Set to ROCSHMEM_TEAM_INVALID when IPC is
+   * disabled at compile-time or runtime.
    */
   void setup_team_shared();
 

--- a/projects/rocshmem/src/ipc/backend_ipc.cpp
+++ b/projects/rocshmem/src/ipc/backend_ipc.cpp
@@ -141,12 +141,12 @@ IPCBackend::~IPCBackend() {
   // Close IPC handles for remote heap bases
   ipcImpl.ipcHostStop();
 
-  auto *team_shared{team_tracker.get_team_shared()};
-  team_shared->~Team();
+  auto *team_shared{static_cast<IPCTeam*>(team_tracker.get_team_shared())};
+  team_shared->~IPCTeam();
   CHECK_HIP(hipFree(team_shared));
 
-  auto *team_world{team_tracker.get_team_world()};
-  team_world->~Team();
+  auto *team_world{static_cast<IPCTeam*>(team_tracker.get_team_world())};
+  team_world->~IPCTeam();
   CHECK_HIP(hipFree(team_world));
 
   CHECK_HIP(hipFree(ctx_array));

--- a/projects/rocshmem/src/ipc/backend_ipc.cpp
+++ b/projects/rocshmem/src/ipc/backend_ipc.cpp
@@ -121,6 +121,8 @@ void IPCBackend::init() {
 
   setup_team_world();
 
+  setup_team_shared();
+
   TeamInfo *tinfo = team_tracker.get_team_world()->tinfo_wrt_world;
 
   default_context_proxy_ = IPCDefaultContextProxyT(this, tinfo);
@@ -138,6 +140,10 @@ IPCBackend::~IPCBackend() {
 
   // Close IPC handles for remote heap bases
   ipcImpl.ipcHostStop();
+
+  auto *team_shared{team_tracker.get_team_shared()};
+  team_shared->~Team();
+  CHECK_HIP(hipFree(team_shared));
 
   auto *team_world{team_tracker.get_team_world()};
   team_world->~Team();
@@ -214,6 +220,20 @@ void IPCBackend::setup_team_world() {
    */
   host::ROCSHMEM_TEAM_WORLD = reinterpret_cast<rocshmem_team_t>(team_world);
   set_team_world_device(host::ROCSHMEM_TEAM_WORLD);
+}
+
+void IPCBackend::setup_team_shared() {
+  TeamInfo team_info_wrt_parent(nullptr, 0, 1, num_pes);
+  TeamInfo team_info_wrt_world(nullptr, 0, 1, num_pes);
+
+  IPCTeam *team_shared{nullptr};
+  CHECK_HIP(hipMalloc(&team_shared, sizeof(IPCTeam)));
+  new (team_shared) IPCTeam(this, team_info_wrt_parent, team_info_wrt_world,
+                             num_pes, my_pe, backend_comm, 1);
+  team_tracker.set_team_shared(team_shared);
+
+  host::ROCSHMEM_TEAM_SHARED = reinterpret_cast<rocshmem_team_t>(team_shared);
+  set_team_shared_device(host::ROCSHMEM_TEAM_SHARED);
 }
 
 void IPCBackend::team_destroy(rocshmem_team_t team) {
@@ -558,8 +578,8 @@ void IPCBackend::teams_init() {
 
   memset(team_pool_bitmask_, 0, team_bitmask_size_);
   memset(team_reduced_bitmask_, 0, team_bitmask_size_);
-  /* Set all to available except the 0th one (reserved for TEAM_WORLD) */
-  for (int bit_i = 1; bit_i < max_num_teams; bit_i++) {
+  /* Set all to available except reserved teams (TEAM_WORLD and TEAM_SHARED) */
+  for (int bit_i = TeamTracker::NUM_RESERVED_TEAMS; bit_i < max_num_teams; bit_i++) {
     int byte_i = bit_i / CHAR_BIT;
 
     team_pool_bitmask_[byte_i] |= 1 << (bit_i % CHAR_BIT);

--- a/projects/rocshmem/src/ipc/backend_ipc.hpp
+++ b/projects/rocshmem/src/ipc/backend_ipc.hpp
@@ -195,6 +195,15 @@ class IPCBackend : public Backend {
   void setup_team_world();
 
   /**
+   * @brief Allocate and initialize team shared.
+   *
+   * In the IPC backend all PEs are on the same node, so TEAM_SHARED
+   * contains the same set of PEs as TEAM_WORLD but uses its own
+   * pool slot and sync/work resources.
+   */
+  void setup_team_shared();
+
+  /**
    * @brief Initialize the resources required to support teams
    */
   void teams_init();

--- a/projects/rocshmem/src/reverse_offload/backend_ro.cpp
+++ b/projects/rocshmem/src/reverse_offload/backend_ro.cpp
@@ -220,18 +220,40 @@ void ROBackend::setup_team_shared() {
   int shm_rank = ipcImpl.shm_rank;
 
   /*
-   * pe_start/stride are placeholders; actual PE-to-world mapping is handled
-   * by pe_world_map_ since shared-memory ranks may not be uniformly strided.
+   * Determine pe_start/stride from the IPC PE list. The list is on
+   * device memory, so copy it to host for inspection.
    */
+  std::vector<int> team_shared_pes(shm_size);
+  CHECK_HIP(hipMemcpy(team_shared_pes.data(), ipcImpl.pes_with_ipc_avail,
+                       shm_size * sizeof(int), hipMemcpyDeviceToHost));
+
+  int pe_start = team_shared_pes[0];
+  int stride = (shm_size > 1) ? (team_shared_pes[1] - team_shared_pes[0]) : 1;
+  bool uniform = (stride > 0);
+  for (int i = 2; i < shm_size && uniform; i++) {
+    if (team_shared_pes[i] - team_shared_pes[i - 1] != stride) {
+      uniform = false;
+    }
+  }
+
+  if (!uniform) {
+    /*
+     * Node-local ranks are not uniformly strided, so TEAM_SHARED
+     * cannot be represented with pe_start/stride. Mark it invalid
+     * since context-based operations rely on the strided formula.
+     */
+    host::ROCSHMEM_TEAM_SHARED = ROCSHMEM_TEAM_INVALID;
+    set_team_shared_device(ROCSHMEM_TEAM_INVALID);
+    return;
+  }
+
   TeamInfo wrt_parent(nullptr, 0, 1, shm_size);
-  TeamInfo wrt_world(nullptr, 0, 1, shm_size);
+  TeamInfo wrt_world(nullptr, pe_start, stride, shm_size);
 
   ROTeam *team_shared{nullptr};
   CHECK_HIP(hipMalloc(&team_shared, sizeof(ROTeam)));
   new (team_shared) ROTeam(this, wrt_parent, wrt_world,
                            shm_size, shm_rank, MPI_COMM_NULL);
-
-  team_shared->pe_world_map_ = ipcImpl.pes_with_ipc_avail;
 
   team_tracker.set_team_shared(team_shared);
 
@@ -366,7 +388,6 @@ void ROBackend::ro_net_free_runtime() {
    */
   auto *team_shared{static_cast<ROTeam*>(team_tracker.get_team_shared())};
   if (team_shared) {
-    team_shared->pe_world_map_ = nullptr;
     team_shared->~ROTeam();
     CHECK_HIP(hipFree(team_shared));
   }

--- a/projects/rocshmem/src/reverse_offload/backend_ro.cpp
+++ b/projects/rocshmem/src/reverse_offload/backend_ro.cpp
@@ -364,18 +364,18 @@ void ROBackend::ro_net_free_runtime() {
   /*
    * Tear down team_shared (only allocated when IPC is enabled)
    */
-  auto *team_shared{team_tracker.get_team_shared()};
+  auto *team_shared{static_cast<ROTeam*>(team_tracker.get_team_shared())};
   if (team_shared) {
     team_shared->pe_world_map_ = nullptr;
-    team_shared->~Team();
+    team_shared->~ROTeam();
     CHECK_HIP(hipFree(team_shared));
   }
 
   /*
    * Tear down team_world
    */
-  auto *team_world{team_tracker.get_team_world()};
-  team_world->~Team();
+  auto *team_world{static_cast<ROTeam*>(team_tracker.get_team_world())};
+  team_world->~ROTeam();
   // CHECK_HIP(hipFree(team_world));
 
   /*

--- a/projects/rocshmem/src/reverse_offload/backend_ro.cpp
+++ b/projects/rocshmem/src/reverse_offload/backend_ro.cpp
@@ -112,6 +112,12 @@ ROBackend::ROBackend(MPI_Comm comm)
       reinterpret_cast<rocshmem_team_t>(team_world_proxy_->get());
   set_team_world_device(host::ROCSHMEM_TEAM_WORLD);
 
+  /*
+   * setup_team_shared() must follow initIPC() because it uses
+   * ipcImpl.pes_with_ipc_avail to determine shared-memory membership.
+   */
+  setup_team_shared();
+
   default_block_handle_proxy_ = DefaultBlockHandleProxyT(
                                 g_ret_buffer_.get(),
                                 atomic_ret_buffer_.get(), &queue_,
@@ -200,6 +206,41 @@ __device__ bool ROBackend::create_ctx([[maybe_unused]] int64_t options, rocshmem
 
 __device__ void ROBackend::destroy_ctx(rocshmem_ctx_t *ctx) {
   ctx_free_list.get()->push_back(static_cast<ROContext *>(ctx->ctx_opaque));
+}
+
+void ROBackend::setup_team_shared() {
+#if defined(USE_IPC)
+  if (ipcImpl.pes_with_ipc_avail == nullptr) {
+    host::ROCSHMEM_TEAM_SHARED = ROCSHMEM_TEAM_INVALID;
+    set_team_shared_device(ROCSHMEM_TEAM_INVALID);
+    return;
+  }
+
+  int shm_size = ipcImpl.shm_size;
+  int shm_rank = ipcImpl.shm_rank;
+
+  /*
+   * pe_start/stride are placeholders; actual PE-to-world mapping is handled
+   * by pe_world_map_ since shared-memory ranks may not be uniformly strided.
+   */
+  TeamInfo wrt_parent(nullptr, 0, 1, shm_size);
+  TeamInfo wrt_world(nullptr, 0, 1, shm_size);
+
+  ROTeam *team_shared{nullptr};
+  CHECK_HIP(hipMalloc(&team_shared, sizeof(ROTeam)));
+  new (team_shared) ROTeam(this, wrt_parent, wrt_world,
+                           shm_size, shm_rank, MPI_COMM_NULL);
+
+  team_shared->pe_world_map_ = ipcImpl.pes_with_ipc_avail;
+
+  team_tracker.set_team_shared(team_shared);
+
+  host::ROCSHMEM_TEAM_SHARED = reinterpret_cast<rocshmem_team_t>(team_shared);
+  set_team_shared_device(host::ROCSHMEM_TEAM_SHARED);
+#else
+  host::ROCSHMEM_TEAM_SHARED = ROCSHMEM_TEAM_INVALID;
+  set_team_shared_device(ROCSHMEM_TEAM_INVALID);
+#endif
 }
 
 void ROBackend::team_destroy(rocshmem_team_t team) {
@@ -319,6 +360,16 @@ void ROBackend::ro_net_free_runtime() {
    * Free the profiler statistics structure.
    */
   // CHECK_HIP(hipFree(bp->profiler));
+
+  /*
+   * Tear down team_shared (only allocated when IPC is enabled)
+   */
+  auto *team_shared{team_tracker.get_team_shared()};
+  if (team_shared) {
+    team_shared->pe_world_map_ = nullptr;
+    team_shared->~Team();
+    CHECK_HIP(hipFree(team_shared));
+  }
 
   /*
    * Tear down team_world

--- a/projects/rocshmem/src/reverse_offload/backend_ro.hpp
+++ b/projects/rocshmem/src/reverse_offload/backend_ro.hpp
@@ -212,10 +212,10 @@ class ROBackend : public Backend {
    *
    * TEAM_SHARED contains the PEs that share a common memory domain
    * (same node). Must be called after initIPC() since membership
-   * is determined from ipcImpl.pes_with_ipc_avail. Uses pe_world_map_
-   * for PE-to-world translation because node-local ranks may not be
-   * uniformly strided. Set to ROCSHMEM_TEAM_INVALID when IPC is
-   * disabled at compile-time or runtime.
+   * is determined from ipcImpl.pes_with_ipc_avail. Computes real
+   * pe_start/stride from the PE list; set to ROCSHMEM_TEAM_INVALID
+   * when IPC is disabled or when node-local ranks are not uniformly
+   * strided.
    */
   void setup_team_shared();
 

--- a/projects/rocshmem/src/reverse_offload/backend_ro.hpp
+++ b/projects/rocshmem/src/reverse_offload/backend_ro.hpp
@@ -211,7 +211,11 @@ class ROBackend : public Backend {
    * @brief Allocate and initialize team shared.
    *
    * TEAM_SHARED contains the PEs that share a common memory domain
-   * (same node).
+   * (same node). Must be called after initIPC() since membership
+   * is determined from ipcImpl.pes_with_ipc_avail. Uses pe_world_map_
+   * for PE-to-world translation because node-local ranks may not be
+   * uniformly strided. Set to ROCSHMEM_TEAM_INVALID when IPC is
+   * disabled at compile-time or runtime.
    */
   void setup_team_shared();
 

--- a/projects/rocshmem/src/reverse_offload/backend_ro.hpp
+++ b/projects/rocshmem/src/reverse_offload/backend_ro.hpp
@@ -208,6 +208,14 @@ class ROBackend : public Backend {
   ROTeamProxyT *team_world_proxy_;
 
   /**
+   * @brief Allocate and initialize team shared.
+   *
+   * TEAM_SHARED contains the PEs that share a common memory domain
+   * (same node).
+   */
+  void setup_team_shared();
+
+  /**
    * @brief Workers used to poll on the device network request queues.
    */
   std::thread worker_thread{};

--- a/projects/rocshmem/src/rocshmem.cpp
+++ b/projects/rocshmem/src/rocshmem.cpp
@@ -624,7 +624,7 @@ __host__ int rocshmem_team_split_strided(
 
   auto num_user_teams{backend->team_tracker.get_num_user_teams()};
   auto max_num_teams{backend->team_tracker.get_max_num_teams()};
-  if (num_user_teams >= max_num_teams - 1) {
+  if (num_user_teams >= max_num_teams - TeamTracker::NUM_RESERVED_TEAMS) {
     /* Exceeded maximum number of teams */
     return -1;
   }
@@ -700,7 +700,8 @@ __host__ int rocshmem_team_split_strided(
 }
 
 __host__ void rocshmem_team_destroy(rocshmem_team_t team) {
-  if (team == ROCSHMEM_TEAM_INVALID || team == ROCSHMEM_TEAM_WORLD) {
+  if (team == ROCSHMEM_TEAM_INVALID || team == ROCSHMEM_TEAM_WORLD ||
+      team == ROCSHMEM_TEAM_SHARED) {
     /* Do nothing */
     return;
   }

--- a/projects/rocshmem/src/rocshmem_gpu.cpp
+++ b/projects/rocshmem/src/rocshmem_gpu.cpp
@@ -91,6 +91,8 @@ __constant__ struct logd_constants logd_constants;
 namespace device {
     extern "C" __constant__ rocshmem_team_t
     __attribute__((visibility("default"))) ROCSHMEM_TEAM_WORLD = nullptr;
+    extern "C" __constant__ rocshmem_team_t
+    __attribute__((visibility("default"))) ROCSHMEM_TEAM_SHARED = nullptr;
 }
 
 #if defined(ENABLE_IPC_BITCODE)
@@ -198,6 +200,12 @@ __host__ int rocshmem_hipmodule_init(hipModule_t module, hipStream_t stream) {
                                    "ROCSHMEM_TEAM_WORLD",
                                    sizeof(rocshmem_team_t), module, stream,
                                    "ROCSHMEM_TEAM_WORLD") != ROCSHMEM_SUCCESS) {
+    return ROCSHMEM_ERROR;
+  }
+  if (copy_device_symbol_to_module(device::ROCSHMEM_TEAM_SHARED,
+                                   "ROCSHMEM_TEAM_SHARED",
+                                   sizeof(rocshmem_team_t), module, stream,
+                                   "ROCSHMEM_TEAM_SHARED") != ROCSHMEM_SUCCESS) {
     return ROCSHMEM_ERROR;
   }
   return ROCSHMEM_SUCCESS;
@@ -408,6 +416,12 @@ __host__ void set_internal_ctx(rocshmem_ctx_t *ctx) {
 
 __host__ void set_team_world_device(rocshmem_team_t team_world) {
   CHECK_HIP(hipMemcpyToSymbol(HIP_SYMBOL(device::ROCSHMEM_TEAM_WORLD), &team_world,
+                              sizeof(rocshmem_team_t), 0,
+                              hipMemcpyHostToDevice));
+}
+
+__host__ void set_team_shared_device(rocshmem_team_t team_shared) {
+  CHECK_HIP(hipMemcpyToSymbol(HIP_SYMBOL(device::ROCSHMEM_TEAM_SHARED), &team_shared,
                               sizeof(rocshmem_team_t), 0,
                               hipMemcpyHostToDevice));
 }

--- a/projects/rocshmem/src/team.cpp
+++ b/projects/rocshmem/src/team.cpp
@@ -33,6 +33,7 @@ namespace rocshmem {
 
 namespace host {
     rocshmem_team_t ROCSHMEM_TEAM_WORLD = nullptr;
+    rocshmem_team_t ROCSHMEM_TEAM_SHARED = nullptr;
 }
 
 __host__ __device__ Team* get_internal_team(rocshmem_team_t team) {
@@ -95,6 +96,13 @@ __host__ Team::Team(Backend* handle, const TeamInfo& team_info_wrt_parent,
 }
 
 __host__ __device__ int Team::get_pe_in_world(int pe) {
+  if (pe_world_map_) {
+    if (pe < 0 || pe >= num_pes) {
+      return -1;
+    }
+    return pe_world_map_[pe];
+  }
+
   int pe_start{tinfo_wrt_world->pe_start};
   int stride{tinfo_wrt_world->stride};
 
@@ -102,6 +110,15 @@ __host__ __device__ int Team::get_pe_in_world(int pe) {
 }
 
 __host__ __device__ int Team::get_pe_in_my_team(int pe_in_world) {
+  if (pe_world_map_) {
+    for (int i = 0; i < num_pes; i++) {
+      if (pe_world_map_[i] == pe_in_world) {
+        return i;
+      }
+    }
+    return -1;
+  }
+
   int pe_start{tinfo_wrt_world->pe_start};
   int stride{tinfo_wrt_world->stride};
 

--- a/projects/rocshmem/src/team.cpp
+++ b/projects/rocshmem/src/team.cpp
@@ -96,13 +96,6 @@ __host__ Team::Team(Backend* handle, const TeamInfo& team_info_wrt_parent,
 }
 
 __host__ __device__ int Team::get_pe_in_world(int pe) {
-  if (pe_world_map_) {
-    if (pe < 0 || pe >= num_pes) {
-      return -1;
-    }
-    return pe_world_map_[pe];
-  }
-
   int pe_start{tinfo_wrt_world->pe_start};
   int stride{tinfo_wrt_world->stride};
 
@@ -110,15 +103,6 @@ __host__ __device__ int Team::get_pe_in_world(int pe) {
 }
 
 __host__ __device__ int Team::get_pe_in_my_team(int pe_in_world) {
-  if (pe_world_map_) {
-    for (int i = 0; i < num_pes; i++) {
-      if (pe_world_map_[i] == pe_in_world) {
-        return i;
-      }
-    }
-    return -1;
-  }
-
   int pe_start{tinfo_wrt_world->pe_start};
   int stride{tinfo_wrt_world->stride};
 

--- a/projects/rocshmem/src/team.hpp
+++ b/projects/rocshmem/src/team.hpp
@@ -167,21 +167,6 @@ class Team {
    */
   BackendType type{BackendType::RO_BACKEND};
 
-  /**
-   * @brief Optional explicit PE-to-world-rank mapping for teams whose
-   * members are not uniformly strided in TEAM_WORLD (e.g. TEAM_SHARED
-   * when MPI assigns non-contiguous ranks to a node).
-   *
-   * When non-null, get_pe_in_world() and get_pe_in_my_team() use this
-   * table instead of the pe_start/stride formula. Length == num_pes.
-   *
-   * Ownership is external. In the current TEAM_SHARED setup this
-   * aliases IPC-managed storage (ipcImpl.pes_with_ipc_avail), so
-   * Team must not free it. Backend teardown code must set this to
-   * nullptr before destroying the Team to avoid dangling references.
-   */
-  int* pe_world_map_{nullptr};
-
  private:
   /**
    * @brief Owns the device memory block for both TeamInfo objects.

--- a/projects/rocshmem/src/team.hpp
+++ b/projects/rocshmem/src/team.hpp
@@ -167,6 +167,17 @@ class Team {
    */
   BackendType type{BackendType::RO_BACKEND};
 
+  /**
+   * @brief Optional explicit PE-to-world-rank mapping for teams whose
+   * members are not uniformly strided in TEAM_WORLD (e.g. TEAM_SHARED
+   * when MPI assigns non-contiguous ranks to a node).
+   *
+   * When non-null, get_pe_in_world() and get_pe_in_my_team() use this
+   * table instead of the pe_start/stride formula.
+   * Allocated with hipMalloc; length == num_pes.
+   */
+  int* pe_world_map_{nullptr};
+
  private:
   /**
    * @brief Owns the device memory block for both TeamInfo objects.

--- a/projects/rocshmem/src/team.hpp
+++ b/projects/rocshmem/src/team.hpp
@@ -173,8 +173,12 @@ class Team {
    * when MPI assigns non-contiguous ranks to a node).
    *
    * When non-null, get_pe_in_world() and get_pe_in_my_team() use this
-   * table instead of the pe_start/stride formula.
-   * Allocated with hipMalloc; length == num_pes.
+   * table instead of the pe_start/stride formula. Length == num_pes.
+   *
+   * Ownership is external. In the current TEAM_SHARED setup this
+   * aliases IPC-managed storage (ipcImpl.pes_with_ipc_avail), so
+   * Team must not free it. Backend teardown code must set this to
+   * nullptr before destroying the Team to avoid dangling references.
    */
   int* pe_world_map_{nullptr};
 

--- a/projects/rocshmem/src/team_tracker.hpp
+++ b/projects/rocshmem/src/team_tracker.hpp
@@ -47,6 +47,17 @@ class Team;
 class TeamTracker {
  public:
   /**
+   * @brief Number of pool slots reserved for predefined teams.
+   * When IPC is enabled: TEAM_WORLD + TEAM_SHARED.
+   * Otherwise: TEAM_WORLD only (TEAM_SHARED is TEAM_INVALID).
+   */
+#if defined(USE_IPC)
+  static constexpr size_t NUM_RESERVED_TEAMS = 2;
+#else
+  static constexpr size_t NUM_RESERVED_TEAMS = 1;
+#endif
+
+  /**
    * @brief Primary constructor
    */
   TeamTracker();
@@ -112,6 +123,22 @@ class TeamTracker {
    */
   __host__ void set_team_world(Team* team_world) { team_world_ = team_world; }
 
+  /**
+   * @brief Get team shared pointer
+   *
+   * @return team shared pointer
+   */
+  __host__ Team* get_team_shared() { return team_shared_; }
+
+  /**
+   * @brief Set team shared pointer
+   *
+   * @param[in] team_shared pointer
+   *
+   * @return void
+   */
+  __host__ void set_team_shared(Team* team_shared) { team_shared_ = team_shared; }
+
  private:
   /**
    * @brief List of teams created by the user.
@@ -119,18 +146,21 @@ class TeamTracker {
   std::vector<rocshmem_team_t> teams_{};
 
   /**
-   * @brief The maximum number of teams the user can create.
-   *
-   * This constraint is required since the library needs to
-   * pre-allocate resources (e.g. LDS, working arrays, etc.)
-   * for teams.
+   * @brief Total pool capacity: user-requested teams plus the
+   * predefined teams.  This is the size used to pre-allocate
+   * resources (e.g. LDS, working arrays, bitmask, etc.).
    */
-  size_t max_num_teams_{envvar::max_num_teams};
+  size_t max_num_teams_{envvar::max_num_teams + NUM_RESERVED_TEAMS};
 
   /**
    * @brief Pointer to implementation of ROCSHMEM_TEAM_WORLD
    */
   Team* team_world_{nullptr};
+
+  /**
+   * @brief Pointer to implementation of ROCSHMEM_TEAM_SHARED
+   */
+  Team* team_shared_{nullptr};
 };
 
 }  // namespace rocshmem

--- a/projects/rocshmem/src/team_tracker.hpp
+++ b/projects/rocshmem/src/team_tracker.hpp
@@ -98,7 +98,7 @@ class TeamTracker {
    *
    * @return number of teams currently being tracked
    */
-  int get_num_user_teams() { return teams_.size(); }
+  size_t get_num_user_teams() { return teams_.size(); }
 
   /**
    * @brief Get maximum number of teams supported by tracker

--- a/projects/rocshmem/tests/functional_tests/hipmodule_init_tester.cpp
+++ b/projects/rocshmem/tests/functional_tests/hipmodule_init_tester.cpp
@@ -62,6 +62,9 @@ extern "C" __device__ rocshmem_ctx_t __attribute__((visibility("default"))) ROCS
 // Define ROCSHMEM_TEAM_WORLD so rocshmem_hipmodule_init() can copy the team world into this module
 extern "C" __constant__ rocshmem_team_t __attribute__((visibility("default"))) ROCSHMEM_TEAM_WORLD {nullptr};
 
+// Define ROCSHMEM_TEAM_SHARED so rocshmem_hipmodule_init() can copy the team shared into this module
+extern "C" __constant__ rocshmem_team_t __attribute__((visibility("default"))) ROCSHMEM_TEAM_SHARED {nullptr};
+
 // stub kernel function used for module verification
 extern "C" __global__ void simple_test_kernel(int *result) {
   // Simple test kernel that has the ROCSHMEM_CTX_DEFAULT symbol compiled in its module

--- a/projects/rocshmem/tests/functional_tests/team_ctx_infra_tester.cpp
+++ b/projects/rocshmem/tests/functional_tests/team_ctx_infra_tester.cpp
@@ -31,11 +31,6 @@
 
 using namespace rocshmem;
 
-/* this constant should equal ROCSHMEM_MAX_NUM_TEAMS-1 */
-#define NUM_TEAMS 39
-
-rocshmem_team_t team_world_dup[NUM_TEAMS];
-
 /******************************************************************************
  * DEVICE TEST KERNEL
  *****************************************************************************/
@@ -71,9 +66,10 @@ rocshmem_team_t team_world_dup[NUM_TEAMS];
   }
 
  __global__ void TeamCtxInfraTest(ShmemContextType ctx_type,
-                                 rocshmem_team_t *team) {
+                                rocshmem_team_t *team,
+                                int num_teams) {
   __shared__ rocshmem_ctx_t ctx1, ctx2, ctx3;
-  __shared__ rocshmem_ctx_t ctx[NUM_TEAMS];
+  extern __shared__ rocshmem_ctx_t ctx[];
 
 
   /**
@@ -114,7 +110,7 @@ rocshmem_team_t team_world_dup[NUM_TEAMS];
    * Test 2: Assert team infos of different ctxs
    * from different teams are different.
    */
-  for (int team_i = 0; team_i < NUM_TEAMS; team_i++) {
+  for (int team_i = 0; team_i < num_teams; team_i++) {
     rocshmem_wg_team_create_ctx(team[team_i], ctx_type, &ctx[team_i]);
     if (nullptr == ctx[team_i].ctx_opaque) {
       printf("Create ctx on team[%d] returned an invalid context!\n", team_i);
@@ -122,14 +118,14 @@ rocshmem_team_t team_world_dup[NUM_TEAMS];
     }
   }
 
-  if (ctx[0].team_opaque == ctx[NUM_TEAMS - 1].team_opaque) {
-    printf("Incorrect for teams of ctx[0] and ctx[NUM_TEAMS-1] to be equal to each other\n");
+  if (ctx[0].team_opaque == ctx[num_teams - 1].team_opaque) {
+    printf("Incorrect for teams of ctx[0] and ctx[num_teams-1] to be equal to each other\n");
     abort();
   }
 
   __syncthreads();
 
-  for (int team_i = 0; team_i < NUM_TEAMS; team_i++) {
+  for (int team_i = 0; team_i < num_teams; team_i++) {
     rocshmem_wg_ctx_destroy(&ctx[team_i]);
   }
 
@@ -140,9 +136,22 @@ rocshmem_team_t team_world_dup[NUM_TEAMS];
  *****************************************************************************/
 TeamCtxInfraTester::TeamCtxInfraTester(TesterArguments args) : Tester(args) {
   _splitType = args.team_type;
+
+  char* value{nullptr};
+  if ((value = getenv("ROCSHMEM_MAX_NUM_TEAMS"))) {
+    num_teams = atoi(value);
+    printf("ROCSHMEM_MAX_NUM_TEAMS==%d\n", num_teams);
+  }
+
+  printf("num_teams==%d\n", num_teams);
+
+  CHECK_HIP(hipMalloc(&team_world_dup,
+                      sizeof(rocshmem_team_t) * num_teams));
 }
 
-TeamCtxInfraTester::~TeamCtxInfraTester() {}
+TeamCtxInfraTester::~TeamCtxInfraTester() {
+  CHECK_HIP(hipFree(team_world_dup));
+}
 
 void TeamCtxInfraTester::resetBuffers([[maybe_unused]] size_t size) {}
 
@@ -151,17 +160,16 @@ void TeamCtxInfraTester::preLaunchKernel() {
   int my_pe = rocshmem_team_my_pe(_parentTeam);
 
   if (_splitType == ROCSHMEM_TEST_TEAM_DUP) {
-    // validate we can run the test
     if (auto maximum_num_contexts_str = getenv("ROCSHMEM_MAX_NUM_CONTEXTS")) {
       int max_ctx = atoi(maximum_num_contexts_str);
-      if (max_ctx <= NUM_TEAMS) {
-        printf("ROCSHMEM_MAX_NUM_CONTEXTS=%d is smaller than NUM_TEAMS %d, invalid test setup!\n", max_ctx, NUM_TEAMS);
-        assert(max_ctx > NUM_TEAMS);
+      if (max_ctx <= num_teams) {
+        printf("ROCSHMEM_MAX_NUM_CONTEXTS=%d is smaller than num_teams %d, invalid test setup!\n", max_ctx, num_teams);
+        assert(max_ctx > num_teams);
         abort();
       }
     }
 
-    for (int team_i = 0; team_i < NUM_TEAMS; team_i++) {
+    for (int team_i = 0; team_i < num_teams; team_i++) {
       team_world_dup[team_i] = ROCSHMEM_TEAM_INVALID;
       rocshmem_team_split_strided(_parentTeam, 0, 1, n_pes, nullptr, 0,
                                   &team_world_dup[team_i]);
@@ -244,33 +252,22 @@ void TeamCtxInfraTester::launchKernel(dim3 gridSize, dim3 blockSize, [[maybe_unu
                                       [[maybe_unused]] size_t size) {
   size_t shared_bytes = 0;
 
-  /* Copy array of teams to device */
-  rocshmem_team_t *teams_on_device = nullptr;
-
   if (_splitType == ROCSHMEM_TEST_TEAM_DUP) {
-    CHECK_HIP(hipMalloc(&teams_on_device, sizeof(rocshmem_team_t) * NUM_TEAMS));
-    CHECK_HIP(hipMemcpy(teams_on_device, team_world_dup,
-                        sizeof(rocshmem_team_t) * NUM_TEAMS, hipMemcpyHostToDevice));
+    shared_bytes = sizeof(rocshmem_ctx_t) * num_teams;
 
     hipLaunchKernelGGL(TeamCtxInfraTest, gridSize, blockSize, shared_bytes,
-                       stream, _shmem_context, teams_on_device);
+                       stream, _shmem_context, team_world_dup, num_teams);
   } else if (_splitType == ROCSHMEM_TEST_TEAM_SINGLE ||
              _splitType == ROCSHMEM_TEST_TEAM_BLOCK  ||
              _splitType == ROCSHMEM_TEST_TEAM_ODDEVEN ) {
-    CHECK_HIP(hipMalloc(&teams_on_device, sizeof(rocshmem_team_t)));
-    CHECK_HIP(hipMemcpy(teams_on_device, team_world_dup,
-                        sizeof(rocshmem_team_t), hipMemcpyHostToDevice));
-
     hipLaunchKernelGGL(TeamCtxInfraSimpleTest, gridSize, blockSize, shared_bytes,
-                       stream, _shmem_context, teams_on_device[0], _expected_pe, _expected_n_pes);
+                       stream, _shmem_context, team_world_dup[0], _expected_pe, _expected_n_pes);
   }
-
-  CHECK_HIP(hipFree(teams_on_device));
 }
 
 void TeamCtxInfraTester::postLaunchKernel() {
-  int num_teams = _splitType == ROCSHMEM_TEST_TEAM_DUP ? NUM_TEAMS : 1;
-  for (int team_i = 0; team_i < num_teams; team_i++) {
+  int teams_to_destroy = _splitType == ROCSHMEM_TEST_TEAM_DUP ? num_teams : 1;
+  for (int team_i = 0; team_i < teams_to_destroy; team_i++) {
     rocshmem_team_destroy(team_world_dup[team_i]);
   }
 }

--- a/projects/rocshmem/tests/functional_tests/team_ctx_infra_tester.cpp
+++ b/projects/rocshmem/tests/functional_tests/team_ctx_infra_tester.cpp
@@ -140,6 +140,10 @@ TeamCtxInfraTester::TeamCtxInfraTester(TesterArguments args) : Tester(args) {
   char* value{nullptr};
   if ((value = getenv("ROCSHMEM_MAX_NUM_TEAMS"))) {
     num_teams = atoi(value);
+    if (num_teams < 1) {
+      printf("ROCSHMEM_MAX_NUM_TEAMS must be >= 1; got %d\n", num_teams);
+      abort();
+    }
   }
 
   CHECK_HIP(hipMalloc(&team_world_dup,
@@ -157,6 +161,11 @@ void TeamCtxInfraTester::preLaunchKernel() {
   int my_pe = rocshmem_team_my_pe(_parentTeam);
 
   if (_splitType == ROCSHMEM_TEST_TEAM_DUP) {
+    if (num_teams < 2) {
+      printf("ROCSHMEM_TEST_TEAM_DUP requires num_teams >= 2; got %d\n", num_teams);
+      abort();
+    }
+
     if (auto maximum_num_contexts_str = getenv("ROCSHMEM_MAX_NUM_CONTEXTS")) {
       int max_ctx = atoi(maximum_num_contexts_str);
       if (max_ctx <= num_teams) {

--- a/projects/rocshmem/tests/functional_tests/team_ctx_infra_tester.cpp
+++ b/projects/rocshmem/tests/functional_tests/team_ctx_infra_tester.cpp
@@ -140,10 +140,7 @@ TeamCtxInfraTester::TeamCtxInfraTester(TesterArguments args) : Tester(args) {
   char* value{nullptr};
   if ((value = getenv("ROCSHMEM_MAX_NUM_TEAMS"))) {
     num_teams = atoi(value);
-    printf("ROCSHMEM_MAX_NUM_TEAMS==%d\n", num_teams);
   }
-
-  printf("num_teams==%d\n", num_teams);
 
   CHECK_HIP(hipMalloc(&team_world_dup,
                       sizeof(rocshmem_team_t) * num_teams));
@@ -245,12 +242,23 @@ void TeamCtxInfraTester::preLaunchKernel() {
       printf("ROCSHMEM_TEST_TEAM_ODDEVEN: my_pe %d expected: %d\n", _expected_pe, new_pe);
       abort();
     }
+  } else if (_splitType == ROCSHMEM_TEST_TEAM_SHARED) {
+    if (ROCSHMEM_TEAM_SHARED == ROCSHMEM_TEAM_INVALID) {
+      printf("ROCSHMEM_TEAM_SHARED is TEAM_INVALID (IPC disabled), skipping\n");
+      _skip_shared = true;
+      return;
+    }
+    team_world_dup[0] = ROCSHMEM_TEAM_SHARED;
+    _expected_pe = rocshmem_team_my_pe(ROCSHMEM_TEAM_SHARED);
+    _expected_n_pes = rocshmem_team_n_pes(ROCSHMEM_TEAM_SHARED);
   }
 }
 
 void TeamCtxInfraTester::launchKernel(dim3 gridSize, dim3 blockSize, [[maybe_unused]] int loop,
                                       [[maybe_unused]] size_t size) {
   size_t shared_bytes = 0;
+
+  if (_skip_shared) return;
 
   if (_splitType == ROCSHMEM_TEST_TEAM_DUP) {
     shared_bytes = sizeof(rocshmem_ctx_t) * num_teams;
@@ -259,13 +267,16 @@ void TeamCtxInfraTester::launchKernel(dim3 gridSize, dim3 blockSize, [[maybe_unu
                        stream, _shmem_context, team_world_dup, num_teams);
   } else if (_splitType == ROCSHMEM_TEST_TEAM_SINGLE ||
              _splitType == ROCSHMEM_TEST_TEAM_BLOCK  ||
-             _splitType == ROCSHMEM_TEST_TEAM_ODDEVEN ) {
+             _splitType == ROCSHMEM_TEST_TEAM_ODDEVEN ||
+             _splitType == ROCSHMEM_TEST_TEAM_SHARED ) {
     hipLaunchKernelGGL(TeamCtxInfraSimpleTest, gridSize, blockSize, shared_bytes,
                        stream, _shmem_context, team_world_dup[0], _expected_pe, _expected_n_pes);
   }
 }
 
 void TeamCtxInfraTester::postLaunchKernel() {
+  if (_splitType == ROCSHMEM_TEST_TEAM_SHARED || _skip_shared) return;
+
   int teams_to_destroy = _splitType == ROCSHMEM_TEST_TEAM_DUP ? num_teams : 1;
   for (int team_i = 0; team_i < teams_to_destroy; team_i++) {
     rocshmem_team_destroy(team_world_dup[team_i]);

--- a/projects/rocshmem/tests/functional_tests/team_ctx_infra_tester.hpp
+++ b/projects/rocshmem/tests/functional_tests/team_ctx_infra_tester.hpp
@@ -62,6 +62,7 @@ class TeamCtxInfraTester : public Tester {
    */
   int num_teams = 40;
   rocshmem::rocshmem_team_t *team_world_dup = nullptr;
+  bool _skip_shared = false;
 };
 
 #endif

--- a/projects/rocshmem/tests/functional_tests/team_ctx_infra_tester.hpp
+++ b/projects/rocshmem/tests/functional_tests/team_ctx_infra_tester.hpp
@@ -54,6 +54,14 @@ class TeamCtxInfraTester : public Tester {
   rocshmem::rocshmem_team_t _parentTeam = rocshmem::ROCSHMEM_TEAM_WORLD;
   int _expected_pe;
   int _expected_n_pes;
+
+ private:
+  /**
+   * Number of user-creatable teams. Should equal ROCSHMEM_MAX_NUM_TEAMS
+   * (default 40). Overridden at runtime if the env variable is set.
+   */
+  int num_teams = 40;
+  rocshmem::rocshmem_team_t *team_world_dup = nullptr;
 };
 
 #endif

--- a/projects/rocshmem/tests/functional_tests/tester.cpp
+++ b/projects/rocshmem/tests/functional_tests/tester.cpp
@@ -236,6 +236,11 @@ std::vector<Tester*> Tester::create(TesterArguments args) {
       args.team_type = ROCSHMEM_TEST_TEAM_ODDEVEN;
       testers.push_back(new TeamCtxInfraTester(args));
       return testers;
+    case TeamCtxSharedInfraTestType:
+      if (rank == 0) std::cout << "Team Ctx Infra Shared test ###" << std::endl;
+      args.team_type = ROCSHMEM_TEST_TEAM_SHARED;
+      testers.push_back(new TeamCtxInfraTester(args));
+      return testers;
     case TeamCtxGetTestType:
       if (rank == 0) std::cout << "Blocking Team Ctx Gets ###" << std::endl;
       testers.push_back(new TeamCtxPrimitiveTester(args));
@@ -726,7 +731,8 @@ void Tester::execute() {
     if (_type != TeamCtxInfraTestType       &&
         _type != TeamCtxInfraTestSingleType &&
         _type != TeamCtxInfraTestBlockType  &&
-        _type != TeamCtxInfraTestOddEvenType ) {
+        _type != TeamCtxInfraTestOddEvenType &&
+        _type != TeamCtxSharedInfraTestType ) {
       print(size);
     }
   }
@@ -748,6 +754,7 @@ bool Tester::peLaunchesKernel() {
     case TeamCtxInfraTestSingleType:
     case TeamCtxInfraTestBlockType:
     case TeamCtxInfraTestOddEvenType:
+    case TeamCtxSharedInfraTestType:
     case TeamAllToAllTestType:
     case TeamAllToAllvTestType:
     case TeamFCollectTestType:

--- a/projects/rocshmem/tests/functional_tests/tester.hpp
+++ b/projects/rocshmem/tests/functional_tests/tester.hpp
@@ -133,6 +133,7 @@ enum TestType {
   FloodWaitAmoTestType = 92,
   DeviceBitcodeTestType = 93,
   LibraryInfoTestType = 94,
+  TeamCtxSharedInfraTestType = 95,
   QuietOnStreamTestType = 96,
   SyncAllOnStreamTestType = 97,
 };

--- a/projects/rocshmem/tests/functional_tests/tester_arguments.cpp
+++ b/projects/rocshmem/tests/functional_tests/tester_arguments.cpp
@@ -246,6 +246,7 @@ void TesterArguments::get_arguments() {
     case FloodFAddTestType:
     case FloodWaitAmoTestType:
     case DeviceBitcodeTestType:
+    case TeamCtxSharedInfraTestType:
       requires_two_pes = false;
       break;
     default:

--- a/projects/rocshmem/tests/functional_tests/tester_arguments.hpp
+++ b/projects/rocshmem/tests/functional_tests/tester_arguments.hpp
@@ -37,6 +37,7 @@ enum TeamSplitType {
   ROCSHMEM_TEST_TEAM_SINGLE,     // each PE will be its own team
   ROCSHMEM_TEST_TEAM_BLOCK,      // split parent into two halves
   ROCSHMEM_TEST_TEAM_ODDEVEN,    // odd-even splitting
+  ROCSHMEM_TEST_TEAM_SHARED,     // predefined ROCSHMEM_TEAM_SHARED
 };
 
 /*-----------------------------------------


### PR DESCRIPTION
## Motivation
Implement the `ROCSHMEM_TEAM_SHARED` predefined team per the OpenSHMEM specification. TEAM_SHARED comprises all PEs sharing a common memory domain (same node), enabling node-scoped collective and point-to-point operations.

## Technical Details

- Declare and define `ROCSHMEM_TEAM_SHARED` in host/device namespaces with device symbol copy support.
- Add `pe_world_map_` to Team for non-uniformly strided PE-to-world rank mapping.
- Add team_shared_ to TeamTracker with `NUM_RESERVED_TEAMS` so predefined teams don't consume user-creatable team slots.
- Protect TEAM_SHARED from destruction in `rocshmem_team_destroy()`.
- Implement `setup_team_shared()` in all three backends (IPC, RO, GDA). In RO and GDA, TEAM_SHARED is only created when IPC is enabled at compile-time and runtime; otherwise set to `ROCSHMEM_TEAM_INVALID`.
- Update `team_ctx_infra_tester` to use runtime `ROCSHMEM_MAX_NUM_TEAMS` with dynamic sizing.
- Add `TeamCtxSharedInfraTestType` (test 94) to validate `ROCSHMEM_TEAM_SHARED` PE identity, team size, and context creation on device. Gracefully skips when IPC is disabled.

## JIRA ID

- AIROCSHMEM-355

## Test Plan

- Run teamctxsharedinfra (test 94) with 2 ranks on the same node.
- Run hipmodule_init test to verify symbol copy.
- Verify graceful skip when IPC is disabled.

## Test Result

- [x] Tested with IPC backend
- [x] Tested with RO backend (IPC enabled)
- [x] Tested with RO backend (IPC disabled, verifies graceful skip)
- [x] Tested with GDA backend (IPC enabled)
- [x] Tested with GDA backend (IPC disabled, verifies graceful skip)
