### PR TITLE
Add --gpu-targets filter to artifact splitter

### DIFF
--- a/shared/kpack/python/rocm_kpack/artifact_splitter.py
+++ b/shared/kpack/python/rocm_kpack/artifact_splitter.py
@@ -29,6 +29,12 @@ from rocm_kpack.compression import ZstdCompressor
 from rocm_kpack.kpack_transform import kpack_offload_binary, NotFatBinaryError
 
 
+def strip_target_features(target: str) -> str:
+    """Strip GPU target feature flags (e.g. 'gfx942:sramecc+:xnack-' -> 'gfx942')."""
+    colon_pos = target.find(":")
+    return target[:colon_pos] if colon_pos >= 0 else target
+
+
 @dataclass
 class ExtractedKernel:
     """Represents a kernel extracted from a fat binary."""
@@ -57,6 +63,7 @@ class FileClassificationVisitor:
         toolchain: Toolchain,
         database_handlers: Optional[List[DatabaseHandler]] = None,
         verbose: bool = False,
+        gpu_targets: Optional[Set[str]] = None,
     ):
         """
         Initialize the classification visitor.
@@ -65,10 +72,12 @@ class FileClassificationVisitor:
             toolchain: Toolchain instance for binary operations
             database_handlers: List of database handler instances
             verbose: Enable verbose output
+            gpu_targets: If set, only classify database files for these GPU targets
         """
         self.toolchain = toolchain
         self.database_handlers = database_handlers or []
         self.verbose = verbose
+        self.gpu_targets = gpu_targets
 
         # Accumulated results
         self.fat_binaries: List[Path] = []
@@ -94,6 +103,19 @@ class FileClassificationVisitor:
         for handler in self.database_handlers:
             arch = handler.detect(file_path, prefix_path)
             if arch:
+                if self.gpu_targets is not None and arch not in self.gpu_targets:
+                    if self.verbose:
+                        print(
+                            f"  Skipping {handler.name()} file for {arch} "
+                            f"(not in gpu_targets): {file_path.relative_to(prefix_path)}"
+                        )
+                    # Exclude from generic (per-arch content doesn't belong
+                    # there) but don't add to database_files_by_arch so no
+                    # per-arch artifact is created. The correct arch job will
+                    # produce this file. The return also prevents the file
+                    # from falling through to the fat binary / kpack path.
+                    self.exclude_from_generic.add(file_path)
+                    return
                 self.database_files_by_arch[arch].append((file_path, handler))
                 self.exclude_from_generic.add(file_path)
                 if self.verbose:
@@ -195,6 +217,7 @@ class ArtifactSplitter:
         toolchain: Toolchain,
         database_handlers: Optional[List[DatabaseHandler]] = None,
         verbose: bool = False,
+        gpu_targets: Optional[List[str]] = None,
     ):
         """
         Initialize the artifact splitter.
@@ -204,11 +227,16 @@ class ArtifactSplitter:
             toolchain: Toolchain instance for binary operations
             database_handlers: Optional list of DatabaseHandler instances for kernel databases
             verbose: Enable verbose output
+            gpu_targets: If set, only create per-arch artifacts for these GPU targets.
+                         Target feature flags are stripped (e.g. 'gfx942:sramecc+:xnack-' -> 'gfx942').
         """
         self.artifact_prefix = artifact_prefix
         self.toolchain = toolchain
         self.database_handlers = database_handlers or []
         self.verbose = verbose
+        self.gpu_targets: Optional[Set[str]] = (
+            {strip_target_features(t) for t in gpu_targets} if gpu_targets else None
+        )
 
     def compute_kpack_search_pattern(self, binary_path: Path, prefix_root: Path) -> str:
         """
@@ -685,7 +713,10 @@ class ArtifactSplitter:
 
             # Phase 1: Classify files using visitor
             classifier = FileClassificationVisitor(
-                self.toolchain, self.database_handlers, self.verbose
+                self.toolchain,
+                self.database_handlers,
+                self.verbose,
+                gpu_targets=self.gpu_targets,
             )
             self.scan_prefix(prefix_path, classifier)
 

--- a/shared/kpack/python/rocm_kpack/tools/split_artifacts.py
+++ b/shared/kpack/python/rocm_kpack/tools/split_artifacts.py
@@ -102,6 +102,7 @@ def single_split(args, toolchain: Toolchain):
         toolchain=toolchain,
         database_handlers=database_handlers,
         verbose=args.verbose,
+        gpu_targets=args.gpu_targets,
     )
 
     print(f"Splitting artifact: {args.input_dir}")
@@ -175,6 +176,7 @@ def batch_split(args, toolchain: Toolchain):
                 toolchain=toolchain,
                 database_handlers=database_handlers,
                 verbose=args.verbose,
+                gpu_targets=args.gpu_targets,
             )
 
             splitter.split(artifact_dir, args.output_dir)
@@ -276,6 +278,14 @@ Batch Mode:
         choices=available_handlers,
         default=None,
         help=f"Enable database splitting for specified types. Available: {', '.join(available_handlers)}",
+    )
+
+    parser.add_argument(
+        "--gpu-targets",
+        nargs="+",
+        default=None,
+        help="Only create per-arch artifacts for these GPU targets. "
+        "Database files for other architectures remain in the generic artifact.",
     )
 
     parser.add_argument(

--- a/shared/kpack/tests/test_artifact_splitter_integration.py
+++ b/shared/kpack/tests/test_artifact_splitter_integration.py
@@ -412,6 +412,7 @@ class TestArtifactSplitterIntegration:
             split_databases=None,
             verbose=False,
             tmp_dir=tmp_path / "tmp",
+            gpu_targets=None,
         )
 
         # Run batch split
@@ -465,6 +466,7 @@ class TestArtifactSplitterIntegration:
             split_databases=["rocblas"],
             verbose=False,
             tmp_dir=tmp_path / "tmp",
+            gpu_targets=None,
         )
 
         # Run batch split
@@ -785,3 +787,213 @@ class TestArtifactSplitterIntegration:
         assert len(visitor.database_files_by_arch["gfx942"]) == 1
         assert visitor.database_files_by_arch["gfx942"][0][0] == ck_dll
         assert ck_dll in visitor.exclude_from_generic
+
+    def test_gpu_targets_filters_database_files(self, toolchain, tmp_path):
+        """
+        Test that gpu_targets filters which per-arch directories are created.
+
+        When gpu_targets is set, only the specified architectures should get
+        per-arch directories. Database files for other architectures should
+        remain in the generic artifact (not lost).
+        """
+        # Create artifact with MIOpen database files for multiple architectures
+        input_dir = tmp_path / "test_artifact"
+        input_dir.mkdir()
+
+        prefix = "ml-libs/MIOpen/stage"
+        write_artifact_manifest(input_dir, [prefix])
+
+        prefix_dir = input_dir / prefix
+
+        # Create MIOpen-style database files for three architectures
+        db_dir = prefix_dir / "share" / "miopen" / "db"
+        db_dir.mkdir(parents=True)
+        (db_dir / "gfx942_68.HIP.model").write_text("mock gfx942 db")
+        (db_dir / "gfx1100_68.HIP.model").write_text("mock gfx1100 db")
+        (db_dir / "gfx90a_68.HIP.model").write_text("mock gfx90a db")
+
+        # Create a regular library (not per-arch)
+        lib_dir = prefix_dir / "lib"
+        lib_dir.mkdir(parents=True)
+        (lib_dir / "libMIOpen.so").write_text("mock library")
+
+        output_dir = tmp_path / "output"
+
+        # Split with only gfx942 in gpu_targets
+        splitter = ArtifactSplitter(
+            artifact_prefix="miopen_lib",
+            toolchain=toolchain,
+            database_handlers=[MIOpenHandler()],
+            verbose=True,
+            gpu_targets=["gfx942"],
+        )
+        splitter.split(input_dir, output_dir)
+
+        # gfx942 per-arch directory should exist with its database file
+        gfx942_dir = output_dir / "miopen_lib_gfx942"
+        assert gfx942_dir.exists(), "gfx942 per-arch directory should exist"
+        gfx942_db = gfx942_dir / prefix / "share/miopen/db/gfx942_68.HIP.model"
+        assert gfx942_db.exists(), "gfx942 db file should be in per-arch dir"
+
+        # gfx942 db file should NOT be in generic
+        generic_dir = output_dir / "miopen_lib_generic"
+        generic_gfx942_db = generic_dir / prefix / "share/miopen/db/gfx942_68.HIP.model"
+        assert not generic_gfx942_db.exists(), (
+            "gfx942 db file should not be in generic artifact"
+        )
+
+        # Filtered-out architectures should NOT have per-arch directories
+        assert not (output_dir / "miopen_lib_gfx1100").exists(), (
+            "gfx1100 per-arch directory should not exist when filtered out"
+        )
+        assert not (output_dir / "miopen_lib_gfx90a").exists(), (
+            "gfx90a per-arch directory should not exist when filtered out"
+        )
+
+        # Filtered-out database files should NOT be in generic either
+        # (per-arch content doesn't belong in generic — the correct arch job produces it)
+        generic_gfx1100_db = (
+            generic_dir / prefix / "share/miopen/db/gfx1100_68.HIP.model"
+        )
+        generic_gfx90a_db = (
+            generic_dir / prefix / "share/miopen/db/gfx90a_68.HIP.model"
+        )
+        assert not generic_gfx1100_db.exists(), (
+            "gfx1100 db file should not be in generic artifact"
+        )
+        assert not generic_gfx90a_db.exists(), (
+            "gfx90a db file should not be in generic artifact"
+        )
+
+        # Regular library should be in generic
+        generic_lib = generic_dir / prefix / "lib/libMIOpen.so"
+        assert generic_lib.exists(), "libMIOpen.so should be in generic artifact"
+
+    def test_no_gpu_targets_creates_all_arches(self, toolchain, tmp_path):
+        """
+        Test that when gpu_targets is None, all architectures get per-arch directories.
+
+        This is the default behavior — no filtering applied.
+        """
+        # Create artifact with MIOpen database files for multiple architectures
+        input_dir = tmp_path / "test_artifact"
+        input_dir.mkdir()
+
+        prefix = "ml-libs/MIOpen/stage"
+        write_artifact_manifest(input_dir, [prefix])
+
+        prefix_dir = input_dir / prefix
+
+        # Create MIOpen-style database files for three architectures
+        db_dir = prefix_dir / "share" / "miopen" / "db"
+        db_dir.mkdir(parents=True)
+        (db_dir / "gfx942_68.HIP.model").write_text("mock gfx942 db")
+        (db_dir / "gfx1100_68.HIP.model").write_text("mock gfx1100 db")
+        (db_dir / "gfx90a_68.HIP.model").write_text("mock gfx90a db")
+
+        # Create a regular library
+        lib_dir = prefix_dir / "lib"
+        lib_dir.mkdir(parents=True)
+        (lib_dir / "libMIOpen.so").write_text("mock library")
+
+        output_dir = tmp_path / "output"
+
+        # Split WITHOUT gpu_targets (None — default)
+        splitter = ArtifactSplitter(
+            artifact_prefix="miopen_lib",
+            toolchain=toolchain,
+            database_handlers=[MIOpenHandler()],
+            verbose=True,
+            gpu_targets=None,
+        )
+        splitter.split(input_dir, output_dir)
+
+        # All three per-arch directories should exist
+        assert (output_dir / "miopen_lib_gfx942").exists(), (
+            "gfx942 per-arch directory should exist"
+        )
+        assert (output_dir / "miopen_lib_gfx1100").exists(), (
+            "gfx1100 per-arch directory should exist"
+        )
+        assert (output_dir / "miopen_lib_gfx90a").exists(), (
+            "gfx90a per-arch directory should exist"
+        )
+
+        # All database files should be in their respective per-arch directories
+        assert (
+            output_dir
+            / "miopen_lib_gfx942"
+            / prefix
+            / "share/miopen/db/gfx942_68.HIP.model"
+        ).exists()
+        assert (
+            output_dir
+            / "miopen_lib_gfx1100"
+            / prefix
+            / "share/miopen/db/gfx1100_68.HIP.model"
+        ).exists()
+        assert (
+            output_dir
+            / "miopen_lib_gfx90a"
+            / prefix
+            / "share/miopen/db/gfx90a_68.HIP.model"
+        ).exists()
+
+        # No database files should remain in generic
+        generic_dir = output_dir / "miopen_lib_generic"
+        generic_db_dir = generic_dir / prefix / "share/miopen/db"
+        if generic_db_dir.exists():
+            assert not (generic_db_dir / "gfx942_68.HIP.model").exists()
+            assert not (generic_db_dir / "gfx1100_68.HIP.model").exists()
+            assert not (generic_db_dir / "gfx90a_68.HIP.model").exists()
+
+    def test_gpu_targets_strips_feature_flags(self, toolchain, tmp_path):
+        """
+        Test that gpu_targets with feature flags (e.g., gfx942:sramecc+:xnack-)
+        works the same as the bare architecture name (gfx942).
+
+        Feature flags are stripped before matching against database file architectures.
+        """
+        # Create artifact with MIOpen database files for multiple architectures
+        input_dir = tmp_path / "test_artifact"
+        input_dir.mkdir()
+
+        prefix = "ml-libs/MIOpen/stage"
+        write_artifact_manifest(input_dir, [prefix])
+
+        prefix_dir = input_dir / prefix
+
+        # Create MIOpen-style database files for three architectures
+        db_dir = prefix_dir / "share" / "miopen" / "db"
+        db_dir.mkdir(parents=True)
+        (db_dir / "gfx942_68.HIP.model").write_text("mock gfx942 db")
+        (db_dir / "gfx1100_68.HIP.model").write_text("mock gfx1100 db")
+        (db_dir / "gfx90a_68.HIP.model").write_text("mock gfx90a db")
+
+        # Create a regular library
+        lib_dir = prefix_dir / "lib"
+        lib_dir.mkdir(parents=True)
+        (lib_dir / "libMIOpen.so").write_text("mock library")
+
+        output_dir = tmp_path / "output"
+
+        # Split with feature-flagged gpu_targets
+        splitter = ArtifactSplitter(
+            artifact_prefix="miopen_lib",
+            toolchain=toolchain,
+            database_handlers=[MIOpenHandler()],
+            verbose=True,
+            gpu_targets=["gfx942:sramecc+:xnack-"],
+        )
+        splitter.split(input_dir, output_dir)
+
+        # Only gfx942 per-arch directory should exist (feature flags stripped)
+        assert (output_dir / "miopen_lib_gfx942").exists(), (
+            "gfx942 per-arch directory should exist despite feature flags in target"
+        )
+        assert not (output_dir / "miopen_lib_gfx1100").exists(), (
+            "gfx1100 per-arch directory should not exist when filtered out"
+        )
+        assert not (output_dir / "miopen_lib_gfx90a").exists(), (
+            "gfx90a per-arch directory should not exist when filtered out"
+        )


### PR DESCRIPTION
## Summary
- Adds `--gpu-targets` CLI flag to `split_artifacts.py` to restrict which per-arch artifact directories are created during splitting
- Per-arch files for non-matching architectures are excluded from both the per-arch and generic artifacts — the correct arch job produces them
- Passes `THEROCK_AMDGPU_TARGETS` from CMake via `therock_artifacts.cmake` (in TheRock repo, branch `users/bharriso/dry-run-miopen-multi-arch`)

## Problem
When multiple CI arch jobs (gfx94X, gfx110X, gfx120X) build MIOpen, the splitter creates per-arch artifacts for ALL architectures found in database filenames. All jobs upload to the same flat S3 prefix, so a later arch job's `miopen_lib_gfx942.tar.zst` (containing only db files) overwrites the earlier gfx94X job's version (which had both CK `.so` files AND db files).

## Solution
Filter at classification time in `FileClassificationVisitor.visit_file()`. When a handler detects a file for an arch not in `gpu_targets`, the file is added to `exclude_from_generic` (per-arch content doesn't belong in generic) but not to `database_files_by_arch` (no per-arch artifact created). This also prevents handler-matched files (e.g. CK per-arch `.so`) from falling through to the fat binary / kpack path. Omitting `--gpu-targets` preserves existing behavior (all arches get per-arch dirs).

## Test plan
- [x] 3 new integration tests (filtering, backward compat, feature flag stripping)
- [x] 2 existing batch tests updated for new parameter
- [x] All 94 tests pass (`test_artifact_splitter_integration.py` + `test_database_handlers.py`)
- [ ] Dry-run CI with TheRock branch `users/bharriso/dry-run-miopen-multi-arch`