### PR TITLE
rocr: HSA_VRAM_ALLOC_LIMIT_MB to reject excess VRAM allocations

### DIFF
--- a/projects/rocr-runtime/runtime/hsa-runtime/core/inc/runtime.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/inc/runtime.h
@@ -52,6 +52,7 @@
 #include <utility>
 #include <thread>
 #include <shared_mutex>
+#include <mutex>
 #include <random>
 #include <cinttypes>
 #if defined(__linux__)
@@ -802,6 +803,10 @@ class Runtime {
   // KFD map/unmap, register/unregister, and access to hsaKmtQueryPointerInfo
   // registered & mapped arrays.
   std::shared_mutex memory_lock_;
+
+  // Serialize HSA_VRAM_ALLOC_LIMIT_MB accounting (local VRAM only).
+  std::mutex vram_limit_mutex_;
+  uint64_t vram_alloc_accounted_bytes_ = 0;
 
   // Array containing driver interfaces for compatible agent kernel-mode
   // drivers. Currently supports AIE agents.

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/runtime.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/runtime.cpp
@@ -320,8 +320,34 @@ hsa_status_t Runtime::IterateAgent(hsa_status_t (*callback)(hsa_agent_t agent,
 hsa_status_t Runtime::AllocateMemory(const MemoryRegion* region, size_t size,
                                      MemoryRegion::AllocateFlags alloc_flags,
                                      void** address, int agent_node_id) {
+  const auto* amd_region = dynamic_cast<const AMD::MemoryRegion*>(region);
+  const uint32_t vram_limit_mb = flag().vram_alloc_limit_mb();
+  const bool vram_limit_active =
+      vram_limit_mb != 0 && amd_region != nullptr && amd_region->IsLocalMemory();
+  const uint64_t vram_limit_bytes =
+      vram_limit_active ? (static_cast<uint64_t>(vram_limit_mb) * 1024u * 1024u) : 0u;
+
   size_t size_requested = size;  // region->Allocate(...) may align-up size to granularity
+
+  if (vram_limit_active) {
+    std::lock_guard<std::mutex> lock(vram_limit_mutex_);
+    if (vram_alloc_accounted_bytes_ + static_cast<uint64_t>(size_requested) > vram_limit_bytes)
+      return HSA_STATUS_ERROR_OUT_OF_RESOURCES;
+  }
+
   hsa_status_t status = region->Allocate(size, alloc_flags, address, agent_node_id);
+
+  if (status == HSA_STATUS_SUCCESS && vram_limit_active) {
+    std::lock_guard<std::mutex> lock(vram_limit_mutex_);
+    if (vram_alloc_accounted_bytes_ + static_cast<uint64_t>(size) > vram_limit_bytes) {
+      region->Free(*address, size);
+      *address = nullptr;
+      status = HSA_STATUS_ERROR_OUT_OF_RESOURCES;
+    } else {
+      vram_alloc_accounted_bytes_ += static_cast<uint64_t>(size);
+    }
+  }
+
   // Track the allocation result so that it could be freed properly.
   if (status == HSA_STATUS_SUCCESS) {
     std::lock_guard<std::shared_mutex> lock(memory_lock_);
@@ -436,6 +462,15 @@ hsa_status_t Runtime::FreeMemory(void* ptr) {
       std::abort();
     }
     return HSA_STATUS_ERROR;
+  }
+
+  if (flag().vram_alloc_limit_mb() != 0) {
+    const auto* amd_region = dynamic_cast<const AMD::MemoryRegion*>(region);
+    if (amd_region != nullptr && amd_region->IsLocalMemory()) {
+      std::lock_guard<std::mutex> lock(vram_limit_mutex_);
+      assert(vram_alloc_accounted_bytes_ >= static_cast<uint64_t>(size));
+      vram_alloc_accounted_bytes_ -= static_cast<uint64_t>(size);
+    }
   }
 
   return HSA_STATUS_SUCCESS;

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/util/flag.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/util/flag.h
@@ -45,6 +45,8 @@
 
 #include <stdint.h>
 
+#include <cstdlib>
+
 #include <vector>
 #include <map>
 #include <string>
@@ -323,6 +325,17 @@ class Flag {
     // hsa_amd_counted_queue_acquire API. If not set, default queue size is set to 16384.
     var = os::GetEnvVar("HSA_COUNTED_QUEUE_SIZE");
     counted_queue_size_ = var.empty() ? DEFAULT_COUNTED_QUEUE_SIZE : atoi(var.c_str());
+
+    // Hard cap on total VRAM (framebuffer heap) allocated via HSA for this process (MiB).
+    // 0 = disabled. Excess requests fail with HSA_STATUS_ERROR_OUT_OF_RESOURCES.
+    var = os::GetEnvVar("HSA_VRAM_ALLOC_LIMIT_MB");
+    vram_alloc_limit_mb_ = 0;
+    if (!var.empty()) {
+      char* end = nullptr;
+      unsigned long ul = std::strtoul(var.c_str(), &end, 10);
+      if (end != var.c_str() && *end == '\0' && ul <= 4194303UL)
+        vram_alloc_limit_mb_ = static_cast<uint32_t>(ul);
+    }
   }
 
   void parse_masks(uint32_t maxGpu, uint32_t maxCU) {
@@ -446,6 +459,9 @@ class Flag {
   uint32_t cp_queues_limit() const { return cp_queues_limit_; }
 
   size_t counted_queue_size() const { return counted_queue_size_; }
+
+  /// 0 = no limit. Otherwise max MiB of VRAM (local framebuffer heap) tracked via Runtime alloc path.
+  uint32_t vram_alloc_limit_mb() const { return vram_alloc_limit_mb_; }
 
   bool dev_mem_queue_buf() const { return dev_mem_queue_buf_; }
 
@@ -576,6 +592,7 @@ class Flag {
 
   uint32_t cp_queues_limit_;
   size_t counted_queue_size_;
+  uint32_t vram_alloc_limit_mb_ = 0;
 
   // Map GPU index post RVD to its default cu mask.
   std::map<uint32_t, std::vector<uint32_t>> cu_mask_;


### PR DESCRIPTION
- Parse HSA_VRAM_ALLOC_LIMIT_MB (MiB, 0 = off); cap at 4194303 to avoid overflow.
- Track framebuffer-heap (local VRAM) bytes through Runtime::AllocateMemory/FreeMemory.
- Return HSA_STATUS_ERROR_OUT_OF_RESOURCES when a new allocation would exceed the cap; roll back if alignment pushes past the limit after Allocate.

Made-with: chun-wan/ Curor

## Motivation

Provide an opt-in, process-wide cap on HSA-tracked local VRAM (framebuffer heap) allocations so workloads can fail fast with HSA_STATUS_ERROR_OUT_OF_RESOURCES instead of relying solely on driver/TTM behavior. Useful for testing, resource isolation, and avoiding runaway VRAM use in multi-tenant or stress scenarios.

## Technical Details

Env: HSA_VRAM_ALLOC_LIMIT_MB — unsigned MiB; 0 or unset = disabled. Parsed once at Flag init; values above 4194303 are rejected (invalid parse leaves limit at 0).
Scope: Only allocations whose region is AMD::MemoryRegion with IsLocalMemory() (private/public framebuffer heap), accounted in core::Runtime::AllocateMemory and released in FreeMemory (same path as typical hsa_memory_allocate / hsa_memory_free).
Logic:
Before region->Allocate, if limit is active: reject when accounted + requested_size would exceed limit_mb * 1024 * 1024.
After successful Allocate, if aligned size would exceed cap: region->Free, clear *address, return HSA_STATUS_ERROR_OUT_OF_RESOURCES.
Otherwise add aligned size to vram_alloc_accounted_bytes_.
Concurrency: vram_limit_mutex_ protects the byte counter (independent of memory_lock_ to avoid holding the allocation map lock across the full Allocate path).
Not counted: Paths that do not go through Runtime::AllocateMemory (e.g. some interop entries with region == nullptr in the map) are outside this cap.
Relevant tree: projects/rocr-runtime/runtime/hsa-runtime/ (flag.h, runtime.h, runtime.cpp).

## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
