### PR TITLE
[CUID] Add flag to build tests and disable default build

### DIFF
--- a/projects/cuid/CMakeLists.txt
+++ b/projects/cuid/CMakeLists.txt
@@ -48,7 +48,11 @@ add_subdirectory(lib)
 add_subdirectory(cli)
 add_subdirectory(daemon)
 add_subdirectory(example)
-add_subdirectory(tests)
+
+option(BUILD_TESTS "Build test suite" OFF)
+if(BUILD_TESTS)
+    add_subdirectory(tests)
+endif()
 
 # ==============================================================================
 # CPack Configuration for Portable Packages


### PR DESCRIPTION
## Motivation

Fixes https://github.com/ROCm/rocm-systems/issues/4913

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

Disables tests from being build by default, users who want to build tests can pass `-DBUILD_TESTS=ON`
<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

Verify that a build passes successfully
<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

Verified that cuid is able to build
<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
