### PR TITLE
Partially revert c76140fa277895b3886cf1780a36fe504a1aac3a: revert amdsmi-related cmake changes only

### DIFF
--- a/projects/rccl/src/graph/xml.cc
+++ b/projects/rccl/src/graph/xml.cc
@@ -1004,10 +1004,7 @@ ncclResult_t ncclTopoFillGpu(struct ncclXml* xml, const char* busId, struct nccl
 #if defined(__HIP_PLATFORM_AMD__) || defined(__HIPCC__)
   uint32_t devIndex = 0;
 #ifdef USE_AMDSMI
-  static int amdsmiInit = 0;
-  if (amdsmiInit == 0) {
-    NCCLCHECK(amd_smi_init());
-  }
+  NCCLCHECK(amd_smi_init());
   NCCLCHECK(amd_smi_getDeviceIndexByPciBusId(busId, &devIndex));
 #else
   static int rocmsmiInit = 0;

--- a/projects/rccl/src/misc/amdsmi_wrap.cc
+++ b/projects/rccl/src/misc/amdsmi_wrap.cc
@@ -16,9 +16,13 @@ static int is_wsl2 = -1;
 #define AMDSMICHECK(cmd) do {                \
   amdsmi_status_t ret = cmd;                 \
   if( ret != AMDSMI_STATUS_SUCCESS ) {       \
-    const char *err;                         \
-    pfn_amdsmi_status_code_to_string(ret, &err);         \
-    ERROR("AMD SMI failure: %s at line: %d in file: %s", err, __LINE__, __FILE__);    \
+    if (pfn_amdsmi_status_code_to_string) {  \
+      const char *err;                       \
+      pfn_amdsmi_status_code_to_string(ret, &err); \
+      ERROR("AMD SMI failure: %s at line: %d in file: %s", err, __LINE__, __FILE__); \
+    } else {                                 \
+      ERROR("AMD SMI failure: status %d at line: %d in file: %s", (int)ret, __LINE__, __FILE__); \
+    }                                        \
     return ncclInternalError;                \
   }                                          \
 } while(false)
@@ -36,15 +40,45 @@ static int is_wsl2 = -1;
     return ncclInternalError; /* missing symbol is not a warned error */ \
   amdsmi_status_t ret = pfn_##name(__VA_ARGS__); \
   if( ret != AMDSMI_STATUS_SUCCESS ) {       \
-    const char *err;                         \
-    pfn_amdsmi_status_code_to_string(ret, &err); \
-    ERROR("AMD SMI failure: %s at line: %d in file: %s", err, __LINE__, __FILE__);    \
+    if (pfn_amdsmi_status_code_to_string) {  \
+      const char *err;                       \
+      pfn_amdsmi_status_code_to_string(ret, &err); \
+      ERROR("AMD SMI failure: %s at line: %d in file: %s", err, __LINE__, __FILE__); \
+    } else {                                 \
+      ERROR("AMD SMI failure: status %d at line: %d in file: %s", (int)ret, __LINE__, __FILE__); \
+    }                                        \
     return ncclInternalError;                \
   }                                          \
 } while(0)
 
-RCCL_PARAM(UseAmdSmiLib, "USE_AMD_SMI_LIB", 0); // Opt-in environment variable for enabling using amd_smi_lib instead of internal code
+#define AMDSMITRYSET(name, result, ...) do { \
+  if (!AMDSMI_DIRECT && pfn_##name == nullptr) { \
+    result = ncclInternalError; \
+    return ncclInternalError; /* missing symbol is not a warned error */ \
+  } \
+  amdsmi_status_t ret = pfn_##name(__VA_ARGS__); \
+  if( ret != AMDSMI_STATUS_SUCCESS ) {       \
+    if (pfn_amdsmi_status_code_to_string) {  \
+      const char *err;                       \
+      pfn_amdsmi_status_code_to_string(ret, &err); \
+      ERROR("AMD SMI failure: %s at line: %d in file: %s", err, __LINE__, __FILE__); \
+    } else {                                 \
+      ERROR("AMD SMI failure: status %d at line: %d in file: %s", (int)ret, __LINE__, __FILE__); \
+    }                                        \
+    result = ncclInternalError; \
+    return ncclInternalError;                \
+  }                                          \
+} while(0)
 
+// Disabled by default due to a critical concurrency issue in amdsmi library init
+// (communicated to the amdsmi team). Once a known ROCm version ships with the fix,
+// re-enable the version-gated default here (e.g. #if ROCM_VERSION >= <fixed_version>)
+// and update this comment with the resolved ROCm version.
+// Users can opt-in in the meantime by setting RCCL_USE_AMD_SMI_LIB=1.
+#define AMDSMI_DEFAULT_ENABLED 0
+
+// Enable use of amd_smi_lib instead of internal ARSMI code by default; set RCCL_USE_AMD_SMI_LIB=1 to enable amd_smi_lib and use the AMD SMI path
+RCCL_PARAM(UseAmdSmiLib, "USE_AMD_SMI_LIB", AMDSMI_DEFAULT_ENABLED);
 #include <dlfcn.h>
 #define RCCL_AMDSMI_FN(name, rettype, arglist) rettype(*pfn_##name)arglist = nullptr;
 
@@ -94,6 +128,7 @@ namespace {
   ncclResult_t fabricInitResult = ncclSuccess;
   ncclResult_t amdSmiInitResult = ncclSuccess;
   std::atomic<bool> amdSmiInitCalled{false};  // Track if amd_smi_init has been called
+  std::mutex amdsmiInitLock;
 }
 
 /*************************************************************************
@@ -139,10 +174,7 @@ static bool amd_smi_FabricFunctionsLoaded() {
  * Existing AMD SMI Wrapper Functions
  ************************************************************************/
 
-ncclResult_t amd_smi_init() {
-  // Ensure we only initialize once
-  if (amdSmiInitCalled.exchange(true)) return amdSmiInitResult;
-
+static ncclResult_t amd_smi_init_impl() {
   if (__atomic_load_n(&is_wsl2, __ATOMIC_ACQUIRE) == -1)
     __atomic_store_n(&is_wsl2, (access("/dev/dxg", F_OK) == -1) ? 0 : 1, __ATOMIC_RELEASE);
   if (__atomic_load_n(&is_wsl2, __ATOMIC_ACQUIRE)) {
@@ -155,7 +187,6 @@ ncclResult_t amd_smi_init() {
       static void *libhandle = dlopen("libamd_smi.so", RTLD_NOW);
       if (libhandle == nullptr) {
         WARN("Failed to open libamd_smi.so");
-        amdSmiInitResult = ncclInternalError;
         return ncclInternalError;
       }
 
@@ -183,7 +214,7 @@ ncclResult_t amd_smi_init() {
         {(void**)&pfn_amdsmi_free_fabric_telemetry, "amdsmi_free_fabric_telemetry"},
         {(void**)&pfn_amdsmi_get_fw_info, "amdsmi_get_fw_info"},
       };
-      for(Symbol sym: symbols) {
+      for (Symbol sym: symbols) {
         *sym.ppfn = dlsym(libhandle, sym.name);
       }
     }
@@ -204,6 +235,20 @@ ncclResult_t amd_smi_init() {
     INFO(NCCL_INIT, "initialized internal alternative rsmi functionality");
   }
   return ncclSuccess;
+}
+
+ncclResult_t amd_smi_init() {
+  // Ensure we only initialize once and avoid grabbing the mutex for every call
+  if (!amdSmiInitCalled.load(std::memory_order_acquire)) {
+    std::lock_guard<std::mutex> lock(amdsmiInitLock);
+    if (!amdSmiInitCalled.load(std::memory_order_relaxed)) {
+      // Always cache the result and mark init as done regardless of outcome
+      // (WSL2 skip, dlopen failure, AMDSMI/ARSMI errors all included)
+      amdSmiInitResult = amd_smi_init_impl();
+      amdSmiInitCalled.store(true, std::memory_order_release);
+    }
+  }
+  return amdSmiInitResult;
 }
 
 ncclResult_t amd_smi_shutdown() {


### PR DESCRIPTION
This PR is intended to partially land back reverted changes in https://github.com/ROCm/rocm-systems/commit/c76140fa277895b3886cf1780a36fe504a1aac3a other than the amdsmi cmake changes which were landed as part of the PR.

The Primary revert https://github.com/ROCm/rocm-systems/pull/4802 was originally applied to get Pytorch builds back to green as explained in #4802 description.

Adding back changes for thread-safety and wrapper usage as requested in the issue comment https://github.com/ROCm/rocm-systems/pull/4802#issuecomment-4215041075

These changes were tested with a submodule bump in TheRock:

Passing Pytorch builds:
https://github.com/ROCm/TheRock/actions/runs/24211884393
https://github.com/ROCm/TheRock/actions/runs/24208190701

