### PR TITLE
rocr: Revert cached aqlprofile handle that crashes during fini

### DIFF
--- a/projects/rocr-runtime/runtime/hsa-runtime/core/inc/runtime.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/inc/runtime.h
@@ -519,7 +519,6 @@ class Runtime {
   bool VirtualMemApiSupported() const { return virtual_mem_api_supported_; }
   bool XnackEnabled() const { return xnack_enabled_; }
   void XnackEnabled(bool enable) { xnack_enabled_ = enable; }
-  bool AqlProfileAvailable() const { return (aqlprofile_lib_ != nullptr); }
 
   Driver &AgentDriver(DriverType drv_type) {
     auto is_drv_type = [&](const std::unique_ptr<Driver> &d) {
@@ -931,8 +930,6 @@ class Runtime {
 
   bool virtual_mem_api_supported_;
   bool xnack_enabled_;
-
-  os::LibHandle aqlprofile_lib_;
 
   typedef void* ThunkHandle;
 

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/inc/runtime.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/inc/runtime.h
@@ -520,7 +520,6 @@ class Runtime {
   bool XnackEnabled() const { return xnack_enabled_; }
   void XnackEnabled(bool enable) { xnack_enabled_ = enable; }
   bool AqlProfileAvailable() const { return (aqlprofile_lib_ != nullptr); }
-  os::LibHandle AqlProfileLib() const { return aqlprofile_lib_; }
 
   Driver &AgentDriver(DriverType drv_type) {
     auto is_drv_type = [&](const std::unique_ptr<Driver> &d) {

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_gpu_agent.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_gpu_agent.cpp
@@ -1831,7 +1831,8 @@ hsa_status_t GpuAgent::GetInfo(hsa_agent_info_t attribute, void* value) const {
         setFlag(HSA_EXTENSION_AMD_PC_SAMPLING);
       }
 
-      if (core::Runtime::runtime_singleton_->AqlProfileAvailable()) {
+      if (os::LibHandle lib = os::LoadLib(kAqlProfileLib)) {
+        os::CloseLib(lib);
         setFlag(HSA_EXTENSION_AMD_AQLPROFILE);
       }
 

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/hsa.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/hsa.cpp
@@ -503,7 +503,7 @@ hsa_status_t hsa_system_get_major_extension_table(uint16_t extension, uint16_t v
     // and closed in Runtime::Unload(), avoiding a dlopen handle leak.
     os::LibHandle lib = core::Runtime::runtime_singleton_->AqlProfileLib();
     if (lib == NULL) {
-      debug_print("AQL profile library '%s' is unavailable.\n", kAqlProfileLib);
+      debug_print("Loading '%s' failed\n", kAqlProfileLib);
       return HSA_STATUS_ERROR;
     }
 

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/hsa.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/hsa.cpp
@@ -498,10 +498,7 @@ hsa_status_t hsa_system_get_major_extension_table(uint16_t extension, uint16_t v
       return HSA_STATUS_ERROR;
     }
 
-    // Use the cached aqlprofile library handle from Runtime instead of
-    // opening a new one.  The handle is loaded once during Runtime::Load()
-    // and closed in Runtime::Unload(), avoiding a dlopen handle leak.
-    os::LibHandle lib = core::Runtime::runtime_singleton_->AqlProfileLib();
+    os::LibHandle lib = os::LoadLib(kAqlProfileLib);
     if (lib == NULL) {
       debug_print("Loading '%s' failed\n", kAqlProfileLib);
       return HSA_STATUS_ERROR;

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/runtime.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/runtime.cpp
@@ -760,7 +760,8 @@ hsa_status_t Runtime::GetSystemInfo(hsa_system_info_t attribute, void* value) {
         setFlag(HSA_EXTENSION_IMAGES);
       }
 
-      if (aqlprofile_lib_ != nullptr) {
+      if (os::LibHandle lib = os::LoadLib(kAqlProfileLib)) {
+        os::CloseLib(lib);
         setFlag(HSA_EXTENSION_AMD_AQLPROFILE);
       }
 
@@ -2339,7 +2340,6 @@ Runtime::Runtime()
       ipc_sock_server_fd_(os::INVALID_SOCKET_VALUE),
       ipc_sock_server_thread_(nullptr) {
   virtual_mem_api_supported_ = false;
-  aqlprofile_lib_ = nullptr;
   ipc_dmabuf_supported_ = false;
   xnack_enabled_ = false;
   g_use_interrupt_wait = true;
@@ -2403,9 +2403,6 @@ hsa_status_t Runtime::Load() {
   // Load extensions
   LoadExtensions();
 
-  // Probe aqlprofile availability once and cache the result
-  aqlprofile_lib_ = os::LoadLib(kAqlProfileLib);
-
   // Initialize per GPU scratch, blits, and trap handler
   for (core::Agent* agent : gpu_agents_) {
     hsa_status_t status =
@@ -2447,16 +2444,6 @@ void Runtime::Unload() {
 
   UnloadTools();
   UnloadExtensions();
-
-  // Close the aqlprofile probe handle. Skip the dlclose when
-  // running under Valgrind due to a Valgrind bug, see below:
-  // http://valgrind.org/docs/manual/faq.html#faq.unhelpful
-  if (aqlprofile_lib_ != nullptr) {
-    if (!flag_.running_valgrind()) {
-      os::CloseLib(aqlprofile_lib_);
-    }
-    aqlprofile_lib_ = nullptr;
-  }
 
   amd::hsa::loader::Loader::Destroy(loader_.get());
   loader_.reset();


### PR DESCRIPTION
## Motivation

Reverts commits that cause a segfault during fini teardown.

## Technical Details

Reverts:
- https://github.com/roCm/rocm-systems/pull/4106 (depends on `#3508`)
- https://github.com/ROCm/rocm-systems/pull/3508 (root cause)

Related attempted fix https://github.com/ROCm/rocm-systems/pull/4442 (closed)

## JIRA ID

AIRUNTIME-1998

## Test Plan

```cpp
#include <cstdio>
#include <dlfcn.h>
int main() {
  void* hip = dlopen("libamdhip64.so", RTLD_NOW | RTLD_GLOBAL);
  auto hipInit = (int (*)(unsigned))dlsym(hip, "hipInit");
  hipInit(0);
  dlclose(hip);
  return 0;
}
```

`LD_LIBRARY_PATH=/path/to/rocm/lib ./repro`

## Test Result

Verified locally that the reproducer no longer crashes.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.