### PR TITLE
Mark skipped test as skipped instead of passing, when running ctest

### DIFF
--- a/projects/hip-tests/catch/cmake/hip-tests.cmake
+++ b/projects/hip-tests/catch/cmake/hip-tests.cmake
@@ -119,15 +119,17 @@ function(hip_gen_exe_target)
     endforeach()
     # add binary to global list of binaries to install
     set_property(GLOBAL APPEND PROPERTY G_INSTALL_EXE_TARGETS ${_EXE_NAME})
-    set(_DISCOVER_ARGS
-      DISCOVERY_MODE PRE_TEST
-      ADD_TAGS_AS_LABELS
+    set(_DISCOVER_PROPERTIES
       SKIP_REGULAR_EXPRESSION "HIP_SKIP_THIS_TEST"
     )
     if (DEFINED HIP_TEST_LABELS)
-      list(APPEND _DISCOVER_ARGS PROPERTIES LABELS "${HIP_TEST_LABELS}")
+      list(APPEND _DISCOVER_PROPERTIES LABELS "${HIP_TEST_LABELS}")
     endif()
-    catch_discover_tests("${_EXE_NAME}" ${_DISCOVER_ARGS})
+    catch_discover_tests("${_EXE_NAME}"
+      DISCOVERY_MODE PRE_TEST
+      ADD_TAGS_AS_LABELS
+      PROPERTIES ${_DISCOVER_PROPERTIES}
+    )
     file(GLOB CTEST_INC_FILES "${CMAKE_CURRENT_BINARY_DIR}/${_EXE_NAME}-*_include.cmake")
     set_property(GLOBAL APPEND PROPERTY G_INSTALL_CTEST_INCLUDE_FILES ${CTEST_INC_FILES})
 


### PR DESCRIPTION
## Motivation

When testing other branch with ctest, noticed the issue that skipped tests were marking as passing instead

## Technical Details

Port over the fix to develop branch

## Test Plan

Verified fully on other branch by automation

As well as verified some tests locally in develop branch

## Test Result

Tests being marked as skipped correctly now

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
