### PR TITLE
clr: hip Graph pre-allocate malloc async nodes

### DIFF
--- a/projects/clr/hipamd/src/hip_graph.cpp
+++ b/projects/clr/hipamd/src/hip_graph.cpp
@@ -2673,6 +2673,12 @@ hipError_t hipGraphExecUpdate(hipGraphExec_t hGraphExec, hipGraph_t hGraph,
     HIP_RETURN(hipErrorInvalidValue);
   }
 
+  if (HIP_GRAPH_USE_MEMPOOL &&
+      reinterpret_cast<hip::GraphExec*>(hGraphExec)->AreMemNodesPreAllocated()) {
+    *updateResult_out = hipGraphExecUpdateErrorNotSupported;
+    HIP_RETURN(hipErrorGraphExecUpdateFailure);
+  }
+
   std::vector<hip::GraphNode*> newGraphNodes;
   reinterpret_cast<hip::Graph*>(hGraph)->TopologicalOrder(newGraphNodes);
   std::vector<hip::GraphNode*>& oldGraphExecNodes =

--- a/projects/clr/hipamd/src/hip_graph_internal.cpp
+++ b/projects/clr/hipamd/src/hip_graph_internal.cpp
@@ -728,6 +728,30 @@ bool Graph::TopologicalOrder(std::vector<Node>& TopoOrder) {
 }
 
 // ================================================================================================
+bool Graph::PreAllocateMemNodes(hip::Stream* stream) {
+  if (mem_nodes_pre_allocated_) return true;
+  for (auto node : topoOrder_) {
+    if (node->GetType() == hipGraphNodeTypeMemAlloc) {
+      if (!static_cast<GraphMemAllocNode*>(node)->PreAllocate(stream)) {
+        return false;
+      }
+    }
+  }
+  mem_nodes_pre_allocated_ = true;
+  return true;
+}
+
+void Graph::FreePreAllocatedMemNodes(hip::Stream* stream) {
+  if (!mem_nodes_pre_allocated_) return;
+  for (auto node : topoOrder_) {
+    if (node->GetType() == hipGraphNodeTypeMemFree) {
+      static_cast<GraphMemFreeNode*>(node)->PreFree(stream);
+    }
+  }
+  mem_nodes_pre_allocated_ = false;
+}
+
+// ================================================================================================
 void Graph::clone(Graph* newGraph, bool cloneNodes) const {
   newGraph->pOriginalGraph_ = this;
   for (hip::GraphNode* entry : vertices_) {
@@ -1962,7 +1986,7 @@ hipError_t GraphExec::Run(hip::Stream* launch_stream) {
   }
 
   if (flags_ & hipGraphInstantiateFlagAutoFreeOnLaunch) {
-    if (firstNode != nullptr) {
+    if (firstNode != nullptr && !(HIP_GRAPH_USE_MEMPOOL && AreMemNodesPreAllocated())) {
       firstNode->GetParentGraph()->FreeAllMemory(launch_stream);
       firstNode->GetParentGraph()->memalloc_nodes_ = 0;
       if (!AMD_DIRECT_DISPATCH) {
@@ -1976,11 +2000,16 @@ hipError_t GraphExec::Run(hip::Stream* launch_stream) {
 
   // If this is a repeat launch, make sure corresponding MemFreeNode exists for a MemAlloc node
   if (repeatLaunch_ == true) {
-    if (firstNode != nullptr && firstNode->GetParentGraph()->GetMemAllocNodeCount() > 0) {
+    if (firstNode != nullptr && firstNode->GetParentGraph()->GetMemAllocNodeCount() > 0
+        && !(HIP_GRAPH_USE_MEMPOOL && AreMemNodesPreAllocated())) {
       return hipErrorInvalidValue;
     }
   } else {
     repeatLaunch_ = true;
+  }
+
+  if (HIP_GRAPH_USE_MEMPOOL && HIP_MEM_POOL_USE_VM && !AreMemNodesPreAllocated()) {
+    PreAllocateMemNodes(launch_stream);
   }
 
   ClPrint(amd::LOG_DEBUG, amd::LOG_CODE, "GraphExec::Run max_streams: %d, on device: %d",

--- a/projects/clr/hipamd/src/hip_graph_internal.hpp
+++ b/projects/clr/hipamd/src/hip_graph_internal.hpp
@@ -851,6 +851,11 @@ class Graph {
   void IncrementMemAllocNodeCount() { memalloc_nodes_++; }
   //! Decrements the graph memory alloc node count
   void DecrementMemAllocNodeCount() { memalloc_nodes_--; }
+
+  bool AreMemNodesPreAllocated() const { return mem_nodes_pre_allocated_; }
+  bool PreAllocateMemNodes(hip::Stream* stream);
+  void FreePreAllocatedMemNodes(hip::Stream* stream);
+
   //! returns device object
   hip::Device* Device() { return device_; }
   bool IsLeafNodeSyncRequired() const {
@@ -910,6 +915,7 @@ class Graph {
   unsigned int id_;
   static int nextID;
   uint32_t memalloc_nodes_ = 0;  //!< Count of unreleased Memalloc nodes
+  bool mem_nodes_pre_allocated_ = false;
   std::vector<Node> roots_;      //!< Root nodes, used in parallel launches
   std::vector<Node> leafs_;      //!< The list of leaf nodes on every parallel stream
   //!< Used as a temporary storage for the waiting nodes
@@ -958,6 +964,9 @@ class GraphExec : public amd::ReferenceCountedObject, public Graph {
   }
 
   ~GraphExec() {
+    if (HIP_GRAPH_USE_MEMPOOL && AreMemNodesPreAllocated()) {
+      FreePreAllocatedMemNodes(g_devices[instantiateDeviceId_]->NullStream());
+    }
     for (auto streams : parallel_streams_) {
       for (auto stream : streams.second) {
         if (stream != nullptr) {
@@ -2607,6 +2616,7 @@ class GraphEmptyNode : public GraphNode {
 class GraphMemAllocNode final : public GraphNode {
   hipMemAllocNodeParams node_params_;  // Node parameters for memory allocation
   amd::Memory* va_ = nullptr;          // Memory object, which holds a virtual address
+  bool pre_allocated_ = false;
 
   // Derive the new class for VirtualMapCommand,
   // so runtime can allocate memory during the execution of command
@@ -2656,6 +2666,7 @@ class GraphMemAllocNode final : public GraphNode {
       queue()->device().SetMemAccess(vaddr_sub_obj->getSvmPtr(), aligned_size,
                                      amd::Device::VmmAccess::kReadWrite);
       graph_->IncrementMemAllocNodeCount();  // Increment count of unreleased mem alloc nodes
+      setStatus(CL_SUCCESS);
       ClPrint(amd::LOG_DETAIL_DEBUG, amd::LOG_MEM_POOL, "Graph MemAlloc execute [%p-%p], %p",
               vaddr_sub_obj->getSvmPtr(),
               reinterpret_cast<char*>(vaddr_sub_obj->getSvmPtr()) + aligned_size, memory());
@@ -2700,6 +2711,9 @@ class GraphMemAllocNode final : public GraphNode {
     auto error = GraphNode::CreateCommand(stream);
     if (!HIP_MEM_POOL_USE_VM) {
       auto ptr = Execute(stream_);
+    } else if (HIP_GRAPH_USE_MEMPOOL && pre_allocated_) {
+      amd::Command* marker = new amd::Marker(*stream, !kMarkerDisableFlush, {});
+      commands_.push_back(marker);
     } else {
       auto graph = GetParentGraph();
       if (graph != nullptr) {
@@ -2739,6 +2753,20 @@ class GraphMemAllocNode final : public GraphNode {
     return node_params_.dptr;
   }
 
+  bool PreAllocate(hip::Stream* stream) {
+    auto graph = GetParentGraph();
+    if (graph == nullptr || va_ == nullptr) return false;
+    auto cmd = new VirtualMemAllocNode(*stream, amd::Event::EventWaitList{}, va_,
+                                       node_params_.bytesize, nullptr, graph);
+    cmd->enqueue();
+    cmd->release();
+    if (cmd->status() >= CL_COMPLETE) {
+      pre_allocated_ = true;
+      return true;
+    }
+    return false;
+  }
+
   void* Execute(hip::Stream* stream = nullptr) {
     auto graph = GetParentGraph();
     if (graph != nullptr) {
@@ -2764,6 +2792,7 @@ class GraphMemAllocNode final : public GraphNode {
 // ================================================================================================
 class GraphMemFreeNode : public GraphNode {
   void* device_ptr_;  // Device pointer of the freed memory
+  bool pre_freed_ = false;
 
   // Derive the new class for VirtualMap command, since runtime has to free
   // real allocation after unmap is complete
@@ -2817,6 +2846,11 @@ class GraphMemFreeNode : public GraphNode {
     auto error = GraphNode::CreateCommand(stream);
     if (!HIP_MEM_POOL_USE_VM) {
       Execute(stream_);
+    } else if (HIP_GRAPH_USE_MEMPOOL &&
+               GetParentGraph() != nullptr &&
+               GetParentGraph()->AreMemNodesPreAllocated()) {
+      amd::Command* marker = new amd::Marker(*stream, !kMarkerDisableFlush, {});
+      commands_.push_back(marker);
     } else {
       auto graph = GetParentGraph();
       if (graph != nullptr) {
@@ -2831,6 +2865,21 @@ class GraphMemFreeNode : public GraphNode {
       }
     }
     return error;
+  }
+
+  void PreFree(hip::Stream* stream) {
+    if (pre_freed_) return;
+    auto graph = GetParentGraph();
+    if (graph == nullptr) return;
+    const auto& dev_info = stream->device().info();
+    auto va = amd::MemObjMap::FindVirtualMemObj(device_ptr_);
+    if (va == nullptr) return;
+    auto cmd = new VirtualMemFreeNode(
+        graph, stream->DeviceId(), *stream, amd::Command::EventWaitList{}, device_ptr_,
+        amd::alignUp(va->getSize(), dev_info.virtualMemAllocGranularityRecommended_), nullptr);
+    cmd->enqueue();
+    cmd->release();
+    pre_freed_ = true;
   }
 
   void Execute(hip::Stream* stream) {

--- a/projects/clr/rocclr/device/rocm/rocvirtual.cpp
+++ b/projects/clr/rocclr/device/rocm/rocvirtual.cpp
@@ -3474,7 +3474,6 @@ void VirtualGPU::submitVirtualMap(amd::VirtualMapCommand& vcmd) {
       LogError("HSA Command: hsa_amd_vmem_unmap failed");
     }
   }
-
   // Since this is a memory operation, the HW event set for barrier packet
   // may not encapsulate what the command wants to do. Hence clear the hw_event
   constexpr bool kClearHwEvent = true;

--- a/projects/clr/rocclr/utils/flags.hpp
+++ b/projects/clr/rocclr/utils/flags.hpp
@@ -245,6 +245,8 @@ release(uint, DEBUG_HIP_GRAPH_BATCH_SIZE, 256,                                \
         "Number of graph nodes to batch at a time")                           \
 release(uint, DEBUG_HIP_GRAPH_SEGMENT_SCHEDULING, 1,                          \
         "0 = Disable, 1 = Enable, 2 = Force")                                 \
+release(bool, HIP_GRAPH_USE_MEMPOOL, false,                                   \
+        "Pre-allocate graph malloc nodes from pool at first launch")          \
 release(uint, DEBUG_HIP_BLOCK_SYNC, 50,                                       \
         "Blocks synchronization on CPU until the callback processing is done")\
 release(uint, DEBUG_CLR_MAX_BATCH_SIZE, 1000,                                 \


### PR DESCRIPTION
## Motivation

- Malloc and Free Async nodes currently call map/unmap during graph launch
- This adds additional latency between graph nodes
- This change allocates all malloc async nodes before graph launch and retains allocation till graph is destroyed
- Allocation is done using PreAllocate and released using PreFree methods which reuse most of the functionality from existing Node class.
- cuda graph also shows same behavior of retaining allocation in nodes.

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## JIRA ID

https://amd-hub.atlassian.net/browse/ROCM-20755

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
