### PR TITLE
rocr: Use RTLD_NODELETE in LoadLib to prevent dlclose crash

### DIFF
--- a/projects/rocr-runtime/runtime/hsa-runtime/core/util/lnx/os_linux.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/util/lnx/os_linux.cpp
@@ -265,7 +265,13 @@ static_assert(sizeof(SharedMutex) == sizeof(pthread_rwlock_t*), "OS abstraction 
 static_assert(sizeof(Thread) == sizeof(os_thread*), "OS abstraction size mismatch");
 
 LibHandle LoadLib(std::string filename) {
-  void* ret = dlopen(filename.c_str(), RTLD_LAZY);
+  // RTLD_NODELETE keeps the library mapped even after dlclose.
+  // This prevents crashes when the library has circular dependencies:
+  // if libA loads libB, and libB links against libA, then dlclose(libB)
+  // could unmap libA while libA's code is still executing.
+  // With RTLD_NODELETE, dlclose still decrements refcount and runs
+  // destructors, but the code pages remain mapped until process exit.
+  void* ret = dlopen(filename.c_str(), RTLD_LAZY | RTLD_NODELETE);
   if (ret == nullptr) debug_print("LoadLib(%s) failed: %s\n", filename.c_str(), dlerror());
   return *(LibHandle*)&ret;
 }

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/util/lnx/os_linux.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/util/lnx/os_linux.cpp
@@ -271,7 +271,11 @@ LibHandle LoadLib(std::string filename) {
   // could unmap libA while libA's code is still executing.
   // With RTLD_NODELETE, dlclose still decrements refcount and runs
   // destructors, but the code pages remain mapped until process exit.
-  void* ret = dlopen(filename.c_str(), RTLD_LAZY | RTLD_NODELETE);
+  int dlopen_flags = RTLD_LAZY;
+#ifdef RTLD_NODELETE
+  dlopen_flags |= RTLD_NODELETE;
+#endif
+  void* ret = dlopen(filename.c_str(), dlopen_flags);
   if (ret == nullptr) debug_print("LoadLib(%s) failed: %s\n", filename.c_str(), dlerror());
   return *(LibHandle*)&ret;
 }

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/util/lnx/os_linux.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/util/lnx/os_linux.cpp
@@ -269,15 +269,15 @@ LibHandle LoadLib(std::string filename) {
   // This prevents crashes when the library has circular dependencies:
   // if libA loads libB, and libB links against libA, then dlclose(libB)
   // could unmap libA while libA's code is still executing.
-  // With RTLD_NODELETE, dlclose still decrements refcount and runs
-  // destructors, but the code pages remain mapped until process exit.
+  // With RTLD_NODELETE, dlclose decrements the refcount but does not
+  // unmap the code pages or run destructors - those happen at process exit.
   int dlopen_flags = RTLD_LAZY;
 #ifdef RTLD_NODELETE
   dlopen_flags |= RTLD_NODELETE;
 #endif
   void* ret = dlopen(filename.c_str(), dlopen_flags);
   if (ret == nullptr) debug_print("LoadLib(%s) failed: %s\n", filename.c_str(), dlerror());
-  return *(LibHandle*)&ret;
+  return ret;
 }
 
 void* GetExportAddress(LibHandle lib, std::string export_name) {

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/util/os.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/util/os.h
@@ -79,7 +79,8 @@ static_assert(false, "Operating System not detected!");
 #endif
 
 /// @brief: Loads dynamic library based on file name. Return value will be NULL
-/// if failed.
+/// if failed. Uses RTLD_NODELETE to keep the library mapped after dlclose,
+/// preventing crashes when libraries have circular dependencies back to ROCR.
 /// @param: filename(Input), file name of the library.
 /// @return: LibHandle.
 LibHandle LoadLib(std::string filename);

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/util/os.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/util/os.h
@@ -79,8 +79,9 @@ static_assert(false, "Operating System not detected!");
 #endif
 
 /// @brief: Loads dynamic library based on file name. Return value will be NULL
-/// if failed. Uses RTLD_NODELETE to keep the library mapped after dlclose,
-/// preventing crashes when libraries have circular dependencies back to ROCR.
+/// if failed. Uses platform-specific mechanisms to keep the library mapped
+/// after close (RTLD_NODELETE on Linux, module pinning on Windows) to prevent
+/// crashes when libraries have circular dependencies back to ROCR.
 /// @param: filename(Input), file name of the library.
 /// @return: LibHandle.
 LibHandle LoadLib(std::string filename);

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/util/os.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/util/os.h
@@ -92,8 +92,10 @@ LibHandle LoadLib(std::string filename);
 /// @return: void*.
 void* GetExportAddress(LibHandle lib, std::string export_name);
 
-/// @brief: Unloads the dynamic library.
-/// @param: lib(Input), library handle which will be unloaded.
+/// @brief: Closes the dynamic library handle. Note: With RTLD_NODELETE on Linux
+/// or module pinning on Windows, this decrements the reference count but may not
+/// actually unmap the library from memory.
+/// @param: lib(Input), library handle to close.
 bool CloseLib(LibHandle lib);
 
 /// @brief: Lists loaded tool libraries that contain

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/util/win/os_win.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/util/win/os_win.cpp
@@ -76,7 +76,15 @@ static_assert(sizeof(EventHandle) == sizeof(::HANDLE),
               "OS abstraction size mismatch");
 
 LibHandle LoadLib(std::string filename) {
+  // Pin the library to prevent unloading, equivalent to RTLD_NODELETE on Linux.
+  // This prevents crashes when the library has circular dependencies back to ROCR.
   HMODULE ret = LoadLibrary(filename.c_str());
+  if (ret != NULL) {
+    HMODULE pinned;
+    if (!GetModuleHandleExA(GET_MODULE_HANDLE_EX_FLAG_PIN, filename.c_str(), &pinned)) {
+      // Pinning failed, but library is still loaded - continue anyway
+    }
+  }
   return *(LibHandle*)&ret;
 }
 

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/util/win/os_win.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/util/win/os_win.cpp
@@ -80,8 +80,11 @@ LibHandle LoadLib(std::string filename) {
   // This prevents crashes when the library has circular dependencies back to ROCR.
   HMODULE ret = LoadLibrary(filename.c_str());
   if (ret != NULL) {
+    // Pin by address rather than filename to avoid path resolution issues.
     HMODULE pinned;
-    if (!GetModuleHandleExA(GET_MODULE_HANDLE_EX_FLAG_PIN, filename.c_str(), &pinned)) {
+    if (!GetModuleHandleExA(
+            GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS | GET_MODULE_HANDLE_EX_FLAG_PIN,
+            reinterpret_cast<LPCSTR>(ret), &pinned)) {
       // Pinning failed, but library is still loaded - continue anyway
     }
   }

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/util/win/os_win.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/util/win/os_win.cpp
@@ -85,10 +85,10 @@ LibHandle LoadLib(std::string filename) {
     if (!GetModuleHandleExA(
             GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS | GET_MODULE_HANDLE_EX_FLAG_PIN,
             reinterpret_cast<LPCSTR>(ret), &pinned)) {
-      // Pinning failed, but library is still loaded - continue anyway
+      debug_print("LoadLib(%s) pinning failed: error %lu\n", filename.c_str(), GetLastError());
     }
   }
-  return *(LibHandle*)&ret;
+  return reinterpret_cast<LibHandle>(ret);
 }
 
 void* GetExportAddress(LibHandle lib, std::string export_name) {


### PR DESCRIPTION
Libraries loaded by ROCR (aqlprofile, extensions, tools) link back to ROCR. Without RTLD_NODELETE, dlclose can unmap ROCR while still executing it, causing SIGSEGV during Runtime::Unload().

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
