### PR TITLE
[rocprofiler-sdk] Fix SIGABRT in construct_agent_cache on WSL2 with DXG backend

### DIFF
--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/agent.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/agent.cpp
@@ -1189,6 +1189,19 @@ construct_agent_cache(::HsaApiTable* table)
         }
     }
 
+    // When sysfs topology is unavailable (e.g. WSL2 with the DXG backend, or
+    // containers without /sys mounted), read_topology() returns 0 agents while
+    // the HSA runtime may still discover agents.  Rather than fatally aborting
+    // (which kills the host process), log a warning and return early so
+    // profiling gracefully degrades.
+    if(!rocp_hsa_agent_node_ids.empty() && rocp_agents.empty())
+    {
+        ROCP_WARNING << "rocprofiler agent discovery unavailable ("
+                     << rocp_agents.size() << " rocprofiler agents vs " << hsa_agents.size()
+                     << " HSA agents). Profiling features will be disabled.";
+        return;
+    }
+
     ROCP_FATAL_IF(!rocp_hsa_agent_node_ids.empty())
         << "Found " << rocp_agents.size() << " rocprofiler agents and " << hsa_agents.size()
         << " HSA agents. HSA agents contained " << rocp_hsa_agent_node_ids.size()

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/tests/agent.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/tests/agent.cpp
@@ -45,6 +45,7 @@
 #include <array>
 #include <cstdint>
 #include <cstdlib>
+#include <filesystem>
 #include <iostream>
 #include <random>
 #include <sstream>
@@ -301,6 +302,54 @@ TEST(rocprofiler_lib, agent)
     // clean up memory leak
     for(auto& itr : _rocm_info.isas)
         delete[] itr.name_str;
+}
+
+// Verify that construct_agent_cache does not abort when sysfs topology is
+// unavailable (e.g. WSL2 with DXG, or containers without /sys).
+// On systems with sysfs this is a no-op; on systems without it, this is
+// the regression test for the ROCP_FATAL_IF crash.
+TEST(rocprofiler_lib, agent_no_topology_no_crash)
+{
+    namespace agent = ::rocprofiler::agent;
+
+    const bool has_sysfs = std::filesystem::exists("/sys/class/kfd/kfd/topology/nodes");
+
+    if(has_sysfs)
+    {
+        GTEST_SKIP() << "sysfs topology exists — no-topology path not exercised";
+    }
+
+    rocprofiler::registration::init_logging();
+
+    hsa_init();
+    {
+        auto table         = ::HsaApiTable{};
+        auto core_table    = ::CoreApiTable{};
+        auto amd_ext_table = ::AmdExtTable{};
+
+        memset(&table, 0, sizeof(table));
+        memset(&core_table, 0, sizeof(core_table));
+        memset(&amd_ext_table, 0, sizeof(amd_ext_table));
+
+        core_table.hsa_iterate_agents_fn                    = &hsa_iterate_agents;
+        core_table.hsa_status_string_fn                     = &hsa_status_string;
+        core_table.hsa_agent_get_info_fn                    = &hsa_agent_get_info;
+        amd_ext_table.hsa_amd_agent_iterate_memory_pools_fn = &hsa_amd_agent_iterate_memory_pools;
+        amd_ext_table.hsa_amd_memory_pool_get_info_fn       = &hsa_amd_memory_pool_get_info;
+        table.core_                                         = &core_table;
+        table.amd_ext_                                      = &amd_ext_table;
+
+        // Before the fix this call would SIGABRT.  After the fix it logs a
+        // warning and returns early, leaving the agent cache empty.
+        EXPECT_NO_FATAL_FAILURE(agent::construct_agent_cache(&table));
+    }
+
+    // Agent list should be empty since topology was unavailable
+    auto agents = agent::get_agents();
+    EXPECT_TRUE(agents.empty())
+        << "expected no agents when sysfs topology is unavailable, got " << agents.size();
+
+    hsa_shut_down();
 }
 
 namespace


### PR DESCRIPTION
## Summary

- Fix fatal abort in `construct_agent_cache()` when running on WSL2 with the DXG GPU passthrough backend (`HSA_ENABLE_DXG_DETECTION=1`)
- When sysfs topology is unavailable, `read_topology()` returns 0 agents but the HSA runtime discovers agents — the agent count mismatch triggers `ROCP_FATAL_IF` → `SIGABRT`
- Add an early-return path that logs a warning instead of crashing, allowing profiling to gracefully degrade
- Add a GTest (`agent_no_topology_no_crash`) that validates the early-return path

## Problem

Any program that triggers rocprofiler-sdk agent enumeration crashes on WSL2:

```
F agent.cpp:1192] Found 0 rocprofiler agents and 2 HSA agents.
HSA agents contained 2 internal node ids not found by rocprofiler: 0, 1
*** SIGABRT (@0x3e80000e17d) received by PID 57725 ***
```

This affects `rocprofv3 --hip-trace`, PyTorch with kineto profiling, and any custom tool using rocprofiler-sdk on WSL2. Also affects containers without `/sys` mounted.

## Root Cause

1. `read_topology()` reads agents from `/sys/class/kfd/kfd/topology/nodes`
2. On WSL2 with DXG (or containers), this sysfs path does not exist → returns empty
3. `construct_agent_cache()` enumerates HSA agents via the runtime (works via DXG, finds CPU + GPU)
4. Agent count mismatch (0 vs 2) hits `ROCP_FATAL_IF` → `abort()`

## Fix

Before the fatal check, detect when rocprofiler agents are empty (topology unavailable) and return early with a warning. Uses `rocp_agents.empty()` rather than re-checking the filesystem, which is both simpler and more general.

## Test Results (WSL2, AMD RX 9070 XT, ROCm 7.2.1)

**New GTest:**
```
[ RUN      ] rocprofiler_lib.agent_no_topology_no_crash
W agent.cpp:608] sysfs nodes path '/sys/class/kfd/kfd/topology/nodes' does not exist
W agent.cpp:1199] rocprofiler agent discovery unavailable (0 rocprofiler agents vs 2 HSA agents). Profiling features will be disabled.
[       OK ] rocprofiler_lib.agent_no_topology_no_crash (24 ms)
[  PASSED  ] 1 test.
```

**End-to-end (before → after):**
| Test | Before | After |
|------|--------|-------|
| `rocprofv3 --hip-trace` | SIGABRT (exit 134) | Warning + clean exit (0) |
| GPU compute kernel under profiler | SIGABRT (exit 134) | Correct result + clean exit (0) |
| HIP without profiler | Works | Works (no change) |
| Native Linux (sysfs exists) | Works | No behavioral change |

## Related

- Previously filed as ROCm/rocprofiler-sdk#149 (deprecated repo, auto-closed)
- ROCm/rocprofiler-sdk#148 (iGPU agent mismatch — same fatal check, different trigger)

🤖 Generated with [Claude Code](https://claude.com/claude-code)