### PR TITLE
[RCCL] [RCCL-Tests] Simply rccl_float8 header

### DIFF
--- a/projects/rccl-tests/src/common.h
+++ b/projects/rccl-tests/src/common.h
@@ -30,6 +30,7 @@
 #include <pthread.h>
 #include "nccl1_compat.h"
 #include "rccl_compat.h"  // Weak symbols forward declarations
+#include <hip/hip_version.h>
 #include "timer.h"
 #include <string>
 #include <fstream>

--- a/projects/rccl-tests/src/common.h
+++ b/projects/rccl-tests/src/common.h
@@ -24,6 +24,7 @@
 #include <pthread.h>
 #include "nccl1_compat.h"
 #include "rccl_compat.h"  // Weak symbols forward declarations
+#include <hip/hip_version.h>
 #include "timer.h"
 #include <string>
 #include <fstream>

--- a/projects/rccl-tests/src/rccl_float8.h
+++ b/projects/rccl-tests/src/rccl_float8.h
@@ -24,7 +24,6 @@
 #define ROCBLAS_FLOAT8_H
 
 #include <stdint.h>
-#include <hip/hip_version.h>
 
 #if __cplusplus < 201103L || (!defined(__HIP_PLATFORM_AMD__) && !defined(__HIPCC__))
 /*! \brief Struct to represent a 8 bit floating-point number. */
@@ -40,14 +39,20 @@ typedef struct
 } rccl_bfloat8;
 
 // __cplusplus < 201103L || (!defined(__HIP_PLATFORM_AMD__) && !defined(__HIPCC__))
-#elif HIP_VERSION >= 60300000
+
+#elif __has_include(<hip/hip_fp8.h>) && \
+      (!__HIP_DEVICE_COMPILE__ || defined(__gfx942__) || defined(__gfx950__) || \
+       defined(__gfx1200__) || defined(__gfx1201__) || defined(__gfx1250__))
+
+// Path A: ROCm provides hip_fp8.h (ROCm >= 6.3) and we are either compiling for the host
+// or for a GPU with native FP8 hardware support (gfx942/gfx950/gfx1200/gfx1201).
+// rccl_float8/rccl_bfloat8 are thin typedefs over the hip_fp8 types, which internally use
+// hardware conversion intrinsics (HIP_FP8_CVT_FAST_PATH) where available.
+// All other architectures fall through to Path B (software emulation).
 
 #include <hip/hip_fp8.h>
 
-#if   __HIP_DEVICE_COMPILE__ && (defined(__gfx950__) || defined(__gfx1200__) || defined(__gfx1201__) ||  (defined(__gfx1100__) || defined(__gfx1101__)))//HIP_FP8_TYPE_OCP is enabled.
-typedef __hip_fp8_e4m3 rccl_float8;
-typedef __hip_fp8_e5m2 rccl_bfloat8;
-#elif __HIP_DEVICE_COMPILE__ && (defined(__gfx942__))
+#if __HIP_DEVICE_COMPILE__ && (defined(__gfx942__))
 typedef __hip_fp8_e4m3_fnuz rccl_float8;
 typedef __hip_fp8_e5m2_fnuz rccl_bfloat8;
 #else
@@ -55,44 +60,14 @@ typedef __hip_fp8_e4m3 rccl_float8;
 typedef __hip_fp8_e5m2 rccl_bfloat8;
 #endif
 
-#if   __HIP_DEVICE_COMPILE__
-inline std::ostream& operator<<(std::ostream& os, const rccl_float8& f8)
-{
-    return os << float(f8);
-}
-
-inline std::ostream& operator<<(std::ostream& os, const rccl_bfloat8& bf8)
-{
-    return os << float(bf8);
-}
+// __has_include(<hip/hip_fp8.h>) && \
+// (!__HIP_DEVICE_COMPILE__ || defined(__gfx942__) || defined(__gfx950__) || \
+// defined(__gfx1200__) || defined(__gfx1201__) || defined(__gfx1250__))
 
 #else
-inline std::ostream& operator<<(std::ostream& os, const __hip_fp8_e4m3& f8)
-{
-    return os << float(f8);
-}
 
-inline std::ostream& operator<<(std::ostream& os, const __hip_fp8_e5m2& bf8)
-{
-    return os << float(bf8);
-}
-
-//adding support for those operators on the host side
-inline std::ostream& operator<<(std::ostream& os, const __hip_fp8_e4m3_fnuz& f8)
-{
-    return os << float(f8);
-}
-
-inline std::ostream& operator<<(std::ostream& os, const __hip_fp8_e5m2_fnuz& bf8)
-{
-    return os << float(bf8);
-}
-#endif
-
-extern bool rccl_float8_useFnuz;
-// For older versions of ROCm that do not include hip_fp8.h,
+// Path B: For older versions of ROCm that do not include hip_fp8.h,
 // we provide a local version of the header file as a fallback.
-#else
 
 #define HIP_HOST_DEVICE __host__ __device__
 #define HIP_HOST __host__
@@ -103,11 +78,11 @@ extern bool rccl_float8_useFnuz;
 
 namespace rocblas_hip_f8_impl
 {
-    __host__ inline int clz(uint32_t x)
+    HIP_HOST inline int clz(uint32_t x)
     {
         return __builtin_clz(x);
     }
-    __device__ inline int clz(uint32_t x)
+    HIP_DEVICE inline int clz(uint32_t x)
     {
         return __clz(x);
     }
@@ -127,7 +102,7 @@ namespace rocblas_hip_f8_impl
         else
             x = reinterpret_cast<uint16_t&>(_x);
 
-        uint32_t y, head, mantissa;
+        uint32_t head, mantissa;
         int      exponent, bias;
         uint32_t sign;
 
@@ -383,9 +358,6 @@ namespace rocblas_hip_f8_impl
     }
 } // namespace rocblas_hip_f8_impl
 
-static __device__ bool rocblas_hip_f8_bias_mode_bit_device = true;
-static bool            rocblas_hip_f8_bias_mode_bit_host   = true;
-
 struct rccl_float8
 {
     uint8_t data;
@@ -546,7 +518,7 @@ struct rccl_float8
     }
 
     // assignment overloading only from the same F8 types
-    inline __host__ __device__ rccl_float8& operator=(const rccl_float8& a)
+    inline HIP_HOST_DEVICE rccl_float8& operator=(const rccl_float8& a)
     {
         data = a.data;
         return *this;
@@ -713,362 +685,12 @@ struct rccl_bfloat8
     }
 
     // assignment overloading only from the same F8 types
-    inline __host__ __device__ rccl_bfloat8& operator=(const rccl_bfloat8& a)
+    inline HIP_HOST_DEVICE rccl_bfloat8& operator=(const rccl_bfloat8& a)
     {
         data = a.data;
         return *this;
     }
 };
-
-namespace std
-{
-    inline rccl_float8 sin(rccl_float8 a)
-    {
-        return rccl_float8(sinf(float(a)));
-    }
-    inline rccl_float8 cos(rccl_float8 a)
-    {
-        return rccl_float8(cosf(float(a)));
-    }
-    inline rccl_bfloat8 sin(rccl_bfloat8 a)
-    {
-        return rccl_bfloat8(sinf(float(a)));
-    }
-    inline rccl_bfloat8 cos(rccl_bfloat8 a)
-    {
-        return rccl_bfloat8(cosf(float(a)));
-    }
-    __device__ __host__ constexpr rccl_float8 real(const rccl_float8& a)
-    {
-        return a;
-    }
-    __device__ __host__ constexpr rccl_bfloat8 real(const rccl_bfloat8& a)
-    {
-        return a;
-    }
-}
-
-// Special operator overloading
-inline std::ostream& operator<<(std::ostream& os, const rccl_float8& f8)
-{
-    return os << float(f8);
-}
-
-inline std::ostream& operator<<(std::ostream& os, const rccl_bfloat8& bf8)
-{
-    return os << float(bf8);
-}
-
-// all + operator overloading with mixed types
-// mixed types, always converts to f32, does computation in f32, and returns float
-inline __host__ __device__ float operator+(const float fa, rccl_float8 b)
-{
-    return (fa + float(b));
-}
-
-inline __host__ __device__ float operator+(const float fa, rccl_bfloat8 b)
-{
-    return (fa + float(b));
-}
-
-inline __host__ __device__ float operator+(rccl_float8 a, const float fb)
-{
-    return (float(a) + fb);
-}
-
-inline __host__ __device__ float operator+(rccl_bfloat8 a, const float fb)
-{
-    return (float(a) + fb);
-}
-
-inline __host__ __device__ float operator+(rccl_float8 a, rccl_bfloat8 b)
-{
-    return (float(a) + float(b));
-}
-
-inline __host__ __device__ float operator+(rccl_bfloat8 a, rccl_float8 b)
-{
-    return (float(a) + float(b));
-}
-
-inline __host__ __device__ rccl_float8 operator+(rccl_float8 a, rccl_float8 b)
-{
-    return rccl_float8(float(a) + float(b));
-}
-
-inline __host__ __device__ rccl_bfloat8 operator+(rccl_bfloat8 a, rccl_bfloat8 b)
-{
-    return rccl_bfloat8(float(a) + float(b));
-}
-
-inline __host__ __device__ rccl_float8& operator+=(rccl_float8& a, rccl_float8 b)
-{
-    return a = rccl_float8(float(a) + float(b));
-}
-
-inline __host__ __device__ rccl_bfloat8& operator+=(rccl_bfloat8& a, rccl_bfloat8 b)
-{
-    return a = rccl_bfloat8(float(a) + float(b));
-}
-
-// overloading multiplication, always returns float,
-inline __host__ __device__ float operator*(rccl_float8 a, rccl_float8 b)
-{
-    return float(a) * float(b);
-}
-
-inline __host__ __device__ float operator*(float a, rccl_float8 b)
-{
-    return (a * float(b));
-}
-
-inline __host__ __device__ float operator*(rccl_float8 a, float b)
-{
-    return (float(a) * b);
-}
-
-inline __host__ __device__ float operator*(int32_t a, rccl_float8 b)
-{
-    return ((float)a * float(b));
-}
-
-inline __host__ __device__ float operator*(double a, rccl_float8 b)
-{
-    return ((float)a * float(b));
-}
-
-inline __host__ __device__ float operator*(rccl_bfloat8 a, rccl_bfloat8 b)
-{
-    return float(a) * float(b);
-}
-
-inline __host__ __device__ float operator*(float a, rccl_bfloat8 b)
-{
-    return (a * float(b));
-}
-
-inline __host__ __device__ float operator*(rccl_bfloat8 a, float b)
-{
-    return (float(a) * b);
-}
-
-inline __host__ __device__ float operator*(int32_t a, rccl_bfloat8 b)
-{
-    return ((float)a * float(b));
-}
-
-inline __host__ __device__ float operator*(double a, rccl_bfloat8 b)
-{
-    return ((float)a * float(b));
-}
-
-// overloading for mixed f8 and bf8 types
-inline __host__ __device__ float operator*(rccl_float8 a, rccl_bfloat8 b)
-{
-    return float(a) * float(b);
-}
-
-inline __host__ __device__ float operator*(rccl_bfloat8 a, rccl_float8 b)
-{
-    return float(a) * float(b);
-}
-
-// all - operator overloading with mixed types
-// mixed types, always converts to f32, does computation in f32, and returns float
-inline __host__ __device__ float operator-(const float fa, rccl_float8 b)
-{
-    return (fa - float(b));
-}
-
-inline __host__ __device__ float operator-(const float fa, rccl_bfloat8 b)
-{
-    return (fa - float(b));
-}
-
-inline __host__ __device__ float operator-(rccl_float8 a, const float fb)
-{
-    return (float(a) - fb);
-}
-
-inline __host__ __device__ float operator-(rccl_bfloat8 a, const float fb)
-{
-    return (float(a) - fb);
-}
-
-inline __host__ __device__ float operator-(rccl_float8 a, rccl_bfloat8 b)
-{
-    return (float(a) - float(b));
-}
-
-inline __host__ __device__ float operator-(rccl_bfloat8 a, rccl_float8 b)
-{
-    return (float(a) - float(b));
-}
-
-inline __host__ __device__ rccl_float8 operator-(rccl_float8 a, rccl_float8 b)
-{
-    return rccl_float8(float(a) - float(b));
-}
-
-inline __host__ __device__ rccl_bfloat8 operator-(rccl_bfloat8 a, rccl_bfloat8 b)
-{
-    return rccl_bfloat8(float(a) - float(b));
-}
-
-inline __host__ __device__ rccl_float8& operator-=(rccl_float8& a, rccl_float8 b)
-{
-    return a = rccl_float8(float(a) - float(b));
-}
-
-inline __host__ __device__ rccl_bfloat8& operator-=(rccl_bfloat8& a, rccl_bfloat8 b)
-{
-    return a = rccl_bfloat8(float(a) - float(b));
-}
-
-// overloading division, always returns float,
-inline __host__ __device__ float operator/(rccl_float8 a, rccl_float8 b)
-{
-    return float(a) / float(b);
-}
-
-inline __host__ __device__ float operator/(float a, rccl_float8 b)
-{
-    return (a / float(b));
-}
-
-inline __host__ __device__ float operator/(rccl_float8 a, float b)
-{
-    return (float(a) / b);
-}
-
-inline __host__ __device__ float operator/(int32_t a, rccl_float8 b)
-{
-    return ((float)a / float(b));
-}
-
-inline __host__ __device__ float operator/(double a, rccl_float8 b)
-{
-    return ((float)a / float(b));
-}
-
-inline __host__ __device__ float operator/(rccl_bfloat8 a, rccl_bfloat8 b)
-{
-    return float(a) / float(b);
-}
-
-inline __host__ __device__ float operator/(float a, rccl_bfloat8 b)
-{
-    return (a / float(b));
-}
-
-inline __host__ __device__ float operator/(rccl_bfloat8 a, float b)
-{
-    return (float(a) / b);
-}
-
-inline __host__ __device__ float operator/(int32_t a, rccl_bfloat8 b)
-{
-    return ((float)a / float(b));
-}
-
-inline __host__ __device__ float operator/(double a, rccl_bfloat8 b)
-{
-    return ((float)a / float(b));
-}
-
-// overloading for mixed f8 and bf8 types
-inline __host__ __device__ float operator/(rccl_float8 a, rccl_bfloat8 b)
-{
-    return float(a) / float(b);
-}
-
-inline __host__ __device__ float operator/(rccl_bfloat8 a, rccl_float8 b)
-{
-    return float(a) / float(b);
-}
-
-// overloading for compare
-inline __host__ __device__ bool operator==(rccl_float8 a, rccl_float8 b)
-{
-    return (a.data == b.data);
-}
-
-inline __host__ __device__ bool operator==(rccl_bfloat8 a, rccl_bfloat8 b)
-{
-    return (a.data == b.data);
-}
-
-inline __host__ __device__ bool operator!=(rccl_float8 a, rccl_float8 b)
-{
-    return (a.data != b.data);
-}
-
-inline __host__ __device__ bool operator!=(rccl_bfloat8 a, rccl_bfloat8 b)
-{
-    return (a.data != b.data);
-}
-
-// ================ Explicit downcasting to support different rounding (RNE, SR) ===============
-// NOTE: we going to remove all assignment operator overloading from other types and enforce
-// this explicit_downcast function to make any roudning behavior default
-// We have to explicitly call this function with SR flag
-
-template <typename T,
-          typename Ta,
-          bool stochastic_rounding,
-          typename std::enable_if<std::is_same<T, Ta>{}, int>::type = 0>
-inline __host__ __device__ T explicit_downcast(Ta a, uint32_t rng = 0)
-{
-    // same type, no conversion
-    return a;
-}
-
-// Use h/w intrinsic and optimized version when __gfx942__
-template <
-    typename T,
-    typename Ta,
-    bool stochastic_rounding,
-    typename std::enable_if<(!(std::is_same<T, Ta>{})
-                             && (std::is_same<T, rccl_float8>{} || std::is_same<T, rccl_bfloat8>{})),
-                            int>::type
-    = 0>
-inline __host__ __device__ T explicit_downcast(Ta a, uint32_t rng)
-{
-#if defined(__gfx942__) || defined(__gfx950__)
-    // NOTE: we are directly calling cast_to_f8_from_f32 instead of constructor to optimize away one runtime branch
-    T val;
-    if(std::is_same<T, rccl_float8>::value)
-        val.data = rccl_float8::cast_to_f8_from_f32<stochastic_rounding>(float(a), rng);
-    else
-        val.data = rccl_bfloat8::cast_to_bf8_from_f32<stochastic_rounding>(float(a), rng);
-    return val;
-#else // non gfx942
-    return T(float(a),
-             stochastic_rounding ? T::rocblas_hip_f8_rounding_mode::stochastic
-                                 : T::rocblas_hip_f8_rounding_mode::standard,
-             rng);
-#endif // __gfx942__
-}
-
-// NOTE NOTE: The above code is good if we don't consider HIP-GEMM code and only consider the quantization
-// However, if we need HIP-GEMM for fall-back, we would need explicit_cast handles Tacc=f32 to To=f16/bf16 conversion
-template <
-    typename T,
-    typename Ta,
-    bool stochastic_rounding,
-    typename std::enable_if<(!(std::is_same<T, Ta>{})
-                             && !(std::is_same<T, rccl_float8>{} || std::is_same<T, rccl_bfloat8>{})),
-                            int>::type
-    = 0>
-inline __host__ __device__ T explicit_downcast(Ta a, uint32_t rng)
-{
-    // the return type is not a F8 types, no SR for those types
-    // not sure if we have direct conversion, so converting to float first
-    // no effect if the input type is float
-    return T(float(a));
-}
-
-// =================================================================================================
 
 #endif
 

--- a/projects/rccl-tests/verifiable/verifiable.h
+++ b/projects/rccl-tests/verifiable/verifiable.h
@@ -9,8 +9,10 @@
 #define _d41d8cd98f00b204e9800998ecf8427e
 
 #include <cuda_runtime.h>
-
+#include <hip/hip_version.h>
 #include <stdint.h>
+
+extern bool rccl_float8_useFnuz; // runtime switch: true for gfx942 (FNUZ), false otherwise (OCP)
 
 /* Routines for launching kernels that verify reduction results. A significant
  * feature of these routines is they carefully craft floating point input

--- a/projects/rccl/CMakeLists.txt
+++ b/projects/rccl/CMakeLists.txt
@@ -93,6 +93,7 @@ option(QP_TRACKING                             "Enable per-device QP tracking"  
 option(FAULT_INJECTION                         "Enable fault injection"                        ON)
 option(QUIET_WARNINGS                          "Supress compiler warnings"                     OFF)
 option(DWORDX4_INTRINSICS                      "Turn off compilation with dwordx4 intrinsics"  ON)
+option(ENABLE_FP8_INTRINSICS                   "Enable FP8 add intrinsics in rccl_float8.h"    ON)
 option(ENABLE_ROCSHMEM                         "Enable rocSHMEM support in RCCL"               OFF)
 option(ENABLE_WARP_SPEED                       "Enable WARP_SPEED optimizations"               OFF)
 

--- a/projects/rccl/install.sh
+++ b/projects/rccl/install.sh
@@ -39,6 +39,7 @@ generate_sym_kernels=true
 device_linker=true
 warp_speed_enabled=true # note that this flag will be overridden to false for non MI350/MI300 platforms
 quiet_warnings=false
+enable_fp8_intrinsics=true
 build_rocshmem_support=false
 rocshmem_mono_hash="0e2998b11f99e8302c72f1ac2ce9f2b8c1816587"
 custom_cmake_options=""
@@ -58,6 +59,7 @@ function display_help()
     echo "    -d|--dependencies          Install RCCL dependencies"
     echo "       --device-linker         Build with assembly-extract device linker (default)"
     echo "       --disable-roctx         Build without ROCTX logging"
+    echo "       --disable-fp8-intrinsics Disable FP8 add intrinsics in rccl_float8.h"
     echo "       --disable-sym-kernels   Disable symmetric memory kernels"
     echo "       --disable-warp-speed    Disable WARP_SPEED kernel optimizations"
     echo "       --dump-asm              Disassemble code and dump assembly with inline code"
@@ -114,7 +116,7 @@ function display_help()
 # check if we have a modern version of getopt that can handle whitespace and long parameters
 getopt -T
 if [[ "$?" -eq 4 ]]; then
-    GETOPT_PARSE=$(getopt --name "${0}" --options cdfhij:lprtq --longoptions address-sanitizer,amdgpu_targets:,cmake-options:,debug,debug-fast,dependencies,device-linker,disable-roctx,disable-sym-kernels,disable-warp-speed,dump-asm,enable-code-coverage,enable_backtrace,enable-mpi-tests,fast,force-reduce-pipeline,generate-sym-kernels,help,install,jobs:,kernel-resource-use,local_gpu_only,log-trace,no_clean,no-device-linker,openmp-test-enable,package_build,prefix:,quiet-warnings,rm-legacy-include-dir,rocshmem,roctx-enable,run_tests_all,run_tests_quick,static,tests_build,time-trace,verbose -- "$@")
+    GETOPT_PARSE=$(getopt --name "${0}" --options cdfhij:lprtq --longoptions address-sanitizer,amdgpu_targets:,cmake-options:,debug,debug-fast,dependencies,device-linker,disable-fp8-intrinsics,disable-roctx,disable-sym-kernels,disable-warp-speed,dump-asm,enable-code-coverage,enable_backtrace,enable-mpi-tests,fast,force-reduce-pipeline,generate-sym-kernels,help,install,jobs:,kernel-resource-use,local_gpu_only,log-trace,no_clean,no-device-linker,openmp-test-enable,package_build,prefix:,quiet-warnings,rm-legacy-include-dir,rocshmem,roctx-enable,run_tests_all,run_tests_quick,static,tests_build,time-trace,verbose -- "$@")
 else
     echo "Need a new version of getopt"
     exit 1
@@ -136,6 +138,7 @@ while true; do
          --debug-fast)               build_release=false; debug_fast=true;                                                             shift ;;
     -d | --dependencies)             install_dependencies=true;                                                                        shift ;;
          --device-linker)            device_linker=true;                                                                               shift ;;
+         --disable-fp8-intrinsics)   enable_fp8_intrinsics=false;                                                                      shift ;;
          --disable-roctx)            roctx_enabled=false;                                                                              shift ;;
          --disable-sym-kernels)      generate_sym_kernels=false;                                                                       shift ;;
          --disable-warp-speed)       warp_speed_enabled=false;                                                                         shift ;;
@@ -401,6 +404,11 @@ fi
 # Enable WARP_SPEED only on MI350/MI300 platforms
 if [[ "${warp_speed_enabled}" == true ]]; then
     cmake_common_options="${cmake_common_options} -DENABLE_WARP_SPEED=ON"
+fi
+
+# Disable FP8 add intrinsics (default is ON)
+if [[ "${enable_fp8_intrinsics}" == false ]]; then
+    cmake_common_options="${cmake_common_options} -DENABLE_FP8_INTRINSICS=OFF"
 fi
 
 # Suppress Warnings

--- a/projects/rccl/src/CMakeLists.txt
+++ b/projects/rccl/src/CMakeLists.txt
@@ -924,6 +924,13 @@ if (NOT DWORDX4_INTRINSICS)
   message(STATUS "Force disable dwordx4 intrinsics")
   target_compile_definitions(rccl PRIVATE DWORDX4_INTRINSICS_FORCE_OFF)
 endif()
+if(ENABLE_FP8_INTRINSICS)
+  message(STATUS "FP8 add intrinsics enabled")
+  target_compile_definitions(rccl PRIVATE ENABLE_FP8_INTRINSICS=1)
+else()
+  message(STATUS "FP8 add intrinsics disabled")
+  target_compile_definitions(rccl PRIVATE ENABLE_FP8_INTRINSICS=0)
+endif()
 ## Set RCCL linked library directories
 target_link_directories(rccl PRIVATE ${SMI_LIB_DIR})
 

--- a/projects/rccl/src/device/reduce_kernel.h
+++ b/projects/rccl/src/device/reduce_kernel.h
@@ -439,11 +439,13 @@ SPECIALIZE_REDUCE(FuncMinMax, half, 1, half, fn.isMinNotMax ? __hmin(x, y) : __h
 #else
   SPECIALIZE_REDUCE(FuncSum, rccl_float8, 1, rccl_float8, hadd(x,y))
   SPECIALIZE_REDUCE(FuncSum, rccl_float8, 2, fp8x2_storage_t, hadd2(x,y))
+  SPECIALIZE_REDUCE(FuncSum, rccl_float8, 8, fp8x8_storage_t, hadd8(x,y))
   SPECIALIZE_REDUCE(FuncProd, rccl_float8, 1, rccl_float8, rccl_float8(float(x) * float(y)))
   SPECIALIZE_REDUCE(FuncMinMax, rccl_float8, 1, rccl_float8, rccl_float8(fn.isMinNotMax ? fminf(float(x), float(y)) : fmaxf(float(x), float(y))))
   
   SPECIALIZE_REDUCE(FuncSum, rccl_bfloat8, 1, rccl_bfloat8, hadd_b(x,y))
   SPECIALIZE_REDUCE(FuncSum, rccl_bfloat8, 2, fp8x2_storage_t, hadd2_b(x,y))
+  SPECIALIZE_REDUCE(FuncSum, rccl_bfloat8, 8, fp8x8_storage_t, hadd8_b(x,y))
   SPECIALIZE_REDUCE(FuncProd, rccl_bfloat8, 1, rccl_bfloat8, rccl_bfloat8(float(x) * float(y)))
   SPECIALIZE_REDUCE(FuncMinMax, rccl_bfloat8, 1, rccl_bfloat8, rccl_bfloat8(fn.isMinNotMax ? fminf(float(x), float(y)) : fmaxf(float(x), float(y))))
 #endif

--- a/projects/rccl/src/include/rccl_float8.h
+++ b/projects/rccl/src/include/rccl_float8.h
@@ -28,6 +28,10 @@
 typedef uint16_t fp8x2_storage_t;
 typedef uint64_t fp8x8_storage_t;
 
+#ifndef ENABLE_FP8_INTRINSICS
+#define ENABLE_FP8_INTRINSICS 1
+#endif
+
 #if __cplusplus < 201103L || (!defined(__HIP_PLATFORM_AMD__) && !defined(__HIPCC__))
 /*! \brief Struct to represent a 8 bit floating-point number. */
 
@@ -66,7 +70,7 @@ typedef __hip_fp8_e5m2 rccl_bfloat8;
 #endif
 
 inline __device__ rccl_float8 hadd(rccl_float8 x, rccl_float8 y) {
-#if __HIP_DEVICE_COMPILE__ && defined(__gfx950__)
+#if ENABLE_FP8_INTRINSICS && __HIP_DEVICE_COMPILE__ && defined(__gfx950__)
     typedef _Float16 half2_t __attribute__((ext_vector_type(2)));
     typedef short shortx2_t __attribute__((ext_vector_type(2)));
     half2_t v1;
@@ -80,7 +84,7 @@ inline __device__ rccl_float8 hadd(rccl_float8 x, rccl_float8 y) {
     } u{0};
     u.i16_vec = __builtin_amdgcn_cvt_scalef32_pk_fp8_f16(v1, v1, /* scale */ 1.f, 0);
     return u.fp8[0];
-#elif __HIP_DEVICE_COMPILE__ && defined(__gfx942__)
+#elif ENABLE_FP8_INTRINSICS && __HIP_DEVICE_COMPILE__ && defined(__gfx942__)
     typedef float float2_t __attribute__((ext_vector_type(2)));
     float2_t v;
     uint32_t ival = 0;
@@ -95,7 +99,7 @@ inline __device__ rccl_float8 hadd(rccl_float8 x, rccl_float8 y) {
 }
 
 inline __device__ rccl_bfloat8 hadd_b(rccl_bfloat8 x, rccl_bfloat8 y) {
-#if __HIP_DEVICE_COMPILE__ && defined(__gfx950__)
+#if ENABLE_FP8_INTRINSICS && __HIP_DEVICE_COMPILE__ && defined(__gfx950__)
     typedef _Float16 half2_t __attribute__((ext_vector_type(2)));
     typedef short shortx2_t __attribute__((ext_vector_type(2)));
     half2_t v1;
@@ -109,7 +113,7 @@ inline __device__ rccl_bfloat8 hadd_b(rccl_bfloat8 x, rccl_bfloat8 y) {
     } u1{0};
     u1.i16_vec = __builtin_amdgcn_cvt_scalef32_pk_bf8_f16(v1, v1, /* scale */ 1.f, 0);
     return u1.fp8[0];
-#elif __HIP_DEVICE_COMPILE__ && defined(__gfx942__)
+#elif ENABLE_FP8_INTRINSICS && __HIP_DEVICE_COMPILE__ && defined(__gfx942__)
     typedef float float2_t __attribute__((ext_vector_type(2)));
     float2_t v;
     uint32_t ival = 0;
@@ -124,7 +128,7 @@ inline __device__ rccl_bfloat8 hadd_b(rccl_bfloat8 x, rccl_bfloat8 y) {
 }
 
 inline __device__ fp8x2_storage_t hadd2(fp8x2_storage_t x, fp8x2_storage_t y) {
-#if __HIP_DEVICE_COMPILE__ && defined(__gfx950__)
+#if ENABLE_FP8_INTRINSICS && __HIP_DEVICE_COMPILE__ && defined(__gfx950__)
     typedef _Float16 half2_t __attribute__((ext_vector_type(2)));
     typedef short shortx2_t __attribute__((ext_vector_type(2)));
     half2_t v1;
@@ -138,7 +142,7 @@ inline __device__ fp8x2_storage_t hadd2(fp8x2_storage_t x, fp8x2_storage_t y) {
     } u{0};
     u.i16_vec = __builtin_amdgcn_cvt_scalef32_pk_fp8_f16(v1, v1, /* scale */ 1.f, 0);
     return u.fp8;
-#elif __HIP_DEVICE_COMPILE__ && defined(__gfx942__)
+#elif ENABLE_FP8_INTRINSICS && __HIP_DEVICE_COMPILE__ && defined(__gfx942__)
     typedef float float2_t __attribute__((ext_vector_type(2)));
     float2_t v;
     uint32_t ival = 0;
@@ -157,7 +161,7 @@ inline __device__ fp8x2_storage_t hadd2(fp8x2_storage_t x, fp8x2_storage_t y) {
 }
 
 inline __device__ fp8x2_storage_t hadd2_b(fp8x2_storage_t x, fp8x2_storage_t y) {
-#if __HIP_DEVICE_COMPILE__ && defined(__gfx950__)
+#if ENABLE_FP8_INTRINSICS && __HIP_DEVICE_COMPILE__ && defined(__gfx950__)
     typedef _Float16 half2_t __attribute__((ext_vector_type(2)));
     typedef short shortx2_t __attribute__((ext_vector_type(2)));
     half2_t v1;
@@ -171,7 +175,7 @@ inline __device__ fp8x2_storage_t hadd2_b(fp8x2_storage_t x, fp8x2_storage_t y) 
     } u{0};
     u.i16_vec = __builtin_amdgcn_cvt_scalef32_pk_bf8_f16(v1, v1, /* scale */ 1.f, 0);
     return u.fp8;
-#elif __HIP_DEVICE_COMPILE__ && defined(__gfx942__)
+#elif ENABLE_FP8_INTRINSICS && __HIP_DEVICE_COMPILE__ && defined(__gfx942__)
     typedef float float2_t __attribute__((ext_vector_type(2)));
     float2_t v;
     uint32_t ival = 0;
@@ -195,7 +199,7 @@ inline __device__ fp8x2_storage_t hadd2_b(fp8x2_storage_t x, fp8x2_storage_t y) 
 // back in one cvt.
 
 inline __device__ fp8x8_storage_t hadd8(fp8x8_storage_t x, fp8x8_storage_t y) {
-#if __HIP_DEVICE_COMPILE__ && defined(__gfx1250__)
+#if ENABLE_FP8_INTRINSICS && __HIP_DEVICE_COMPILE__ && defined(__gfx1250__)
     typedef float    v8f32_t  __attribute__((ext_vector_type(8)));
     typedef uint32_t v2u32_t  __attribute__((ext_vector_type(2)));
     union { fp8x8_storage_t u64; v2u32_t u32x2; } ux{x}, uy{y}, ur{0};
@@ -216,7 +220,7 @@ inline __device__ fp8x8_storage_t hadd8(fp8x8_storage_t x, fp8x8_storage_t y) {
 }
 
 inline __device__ fp8x8_storage_t hadd8_b(fp8x8_storage_t x, fp8x8_storage_t y) {
-#if __HIP_DEVICE_COMPILE__ && defined(__gfx1250__)
+#if ENABLE_FP8_INTRINSICS && __HIP_DEVICE_COMPILE__ && defined(__gfx1250__)
     typedef float    v8f32_t  __attribute__((ext_vector_type(8)));
     typedef uint32_t v2u32_t  __attribute__((ext_vector_type(2)));
     union { fp8x8_storage_t u64; v2u32_t u32x2; } ux{x}, uy{y}, ur{0};

--- a/projects/rccl/src/include/rccl_float8.h
+++ b/projects/rccl/src/include/rccl_float8.h
@@ -24,9 +24,9 @@
 #define ROCBLAS_FLOAT8_H
 
 #include <stdint.h>
-#include <hip/hip_version.h>
 
 typedef uint16_t fp8x2_storage_t;
+
 #if __cplusplus < 201103L || (!defined(__HIP_PLATFORM_AMD__) && !defined(__HIPCC__))
 /*! \brief Struct to represent a 8 bit floating-point number. */
 
@@ -41,10 +41,18 @@ typedef struct
 } rccl_bfloat8;
 
 // __cplusplus < 201103L || (!defined(__HIP_PLATFORM_AMD__) && !defined(__HIPCC__))
-#elif HIP_VERSION >= 60300000 && \
-      (!__HIP_DEVICE_COMPILE__ || \
-       defined(__gfx942__) || defined(__gfx950__) || \
+
+#elif __has_include(<hip/hip_fp8.h>) && \
+      (!__HIP_DEVICE_COMPILE__ || defined(__gfx942__) || defined(__gfx950__) || \
        defined(__gfx1200__) || defined(__gfx1201__) || defined(__gfx1250__))
+
+// Path A: ROCm provides hip_fp8.h (ROCm >= 6.3) and we are either compiling for the host
+// or for a GPU with native FP8 hardware support (gfx942/gfx950/gfx1200/gfx1201/gfx1250).
+// rccl_float8/rccl_bfloat8 are thin typedefs over the hip_fp8 types, which internally use
+// hardware conversion intrinsics (HIP_FP8_CVT_FAST_PATH) where available.
+// hadd functions delegate to hip_fp8's operator float() and constructor, which use the
+// hardware fast path on supported architectures and a software fallback elsewhere.
+// All other architectures fall through to Path B (software emulation).
 
 #include <hip/hip_fp8.h>
 
@@ -56,149 +64,38 @@ typedef __hip_fp8_e4m3 rccl_float8;
 typedef __hip_fp8_e5m2 rccl_bfloat8;
 #endif
 
-typedef _Float16 half_t;
-typedef _Float16 half2_t __attribute__((ext_vector_type(2)));
-
-typedef short shortx2_t __attribute__((ext_vector_type(2)));
-typedef short __attribute__((ext_vector_type(2))) __amd_shortx2_storage_t;
-typedef float float2_t __attribute__((ext_vector_type(2)));
-
-
-inline __device__  rccl_float8 hadd(rccl_float8 x, rccl_float8 y)
-{
-#if   __HIP_DEVICE_COMPILE__ && defined(__gfx950__)
-    half2_t v1;
-    asm volatile("v_pk_add_f16 %0, %1, %2" : "=v"(v1) : "v"(__builtin_amdgcn_cvt_scalef32_pk_f16_fp8(x.__x, 1.f, 0)), "v"(__builtin_amdgcn_cvt_scalef32_pk_f16_fp8(y.__x, 1.f, 0)));
-    union {
-      shortx2_t i16_vec;
-      rccl_float8 fp8[4];
-    } u{0};
-    u.i16_vec = __builtin_amdgcn_cvt_scalef32_pk_fp8_f16(v1, v1, /* scale */ 1.f, 0);
-    return u.fp8[0];
-#elif __HIP_DEVICE_COMPILE__ && defined(__gfx942__)
-
-    float2_t v;
-    uint32_t ival = 0;
-    asm volatile("v_pk_add_f32 %0, %1, %2" : "=v"(v) : "v"(__builtin_amdgcn_cvt_pk_f32_fp8(x.__x, 0)), "v"(__builtin_amdgcn_cvt_pk_f32_fp8(y.__x, 0)));
-    return __builtin_amdgcn_cvt_pk_fp8_f32(v[0], v[0], ival, false);
-#else
+inline __device__ rccl_float8 hadd(rccl_float8 x, rccl_float8 y) {
     return rccl_float8(float(x) + float(y));
-#endif
 }
 
-inline __device__  rccl_bfloat8 hadd_b(rccl_bfloat8 x, rccl_bfloat8 y)
-{
-#if   __HIP_DEVICE_COMPILE__ && defined(__gfx950__)
-    half2_t v1;
-    asm volatile("v_pk_add_f16 %0, %1, %2" : "=v"(v1) : "v"(__builtin_amdgcn_cvt_scalef32_pk_f16_bf8(x.__x, 1.f, 0)), "v"(__builtin_amdgcn_cvt_scalef32_pk_f16_bf8(y.__x, 1.f, 0)));
-    union {
-      shortx2_t i16_vec;
-      rccl_bfloat8 fp8[4];
-    } u1{0};
-    u1.i16_vec = __builtin_amdgcn_cvt_scalef32_pk_bf8_f16(v1, v1, /* scale */ 1.f, 0);
-    return u1.fp8[0];
-#elif __HIP_DEVICE_COMPILE__ && defined(__gfx942__)
-
-    float2_t v;
-    uint32_t ival       = 0;
-    asm volatile("v_pk_add_f32 %0, %1, %2" : "=v"(v) : "v"(__builtin_amdgcn_cvt_pk_f32_bf8(x.__x, 0)), "v"(__builtin_amdgcn_cvt_pk_f32_bf8(y.__x, 0)));
-    return __builtin_amdgcn_cvt_pk_bf8_f32(v[0], v[0], ival, false);
-#else
+inline __device__ rccl_bfloat8 hadd_b(rccl_bfloat8 x, rccl_bfloat8 y) {
     return rccl_bfloat8(float(x) + float(y));
-#endif
 }
 
-inline __device__  fp8x2_storage_t hadd2(fp8x2_storage_t x, fp8x2_storage_t y)
-{
-#if   __HIP_DEVICE_COMPILE__ && defined(__gfx950__)
-    half2_t v1;
-    asm volatile("v_pk_add_f16 %0, %1, %2" : "=v"(v1) : "v"(__builtin_amdgcn_cvt_scalef32_pk_f16_fp8(x, 1.f, 0)), "v"(__builtin_amdgcn_cvt_scalef32_pk_f16_fp8(y, 1.f, 0)));
-    union {
-      shortx2_t i16_vec;
-      fp8x2_storage_t fp8;
-    } u{0};
-    u.i16_vec = __builtin_amdgcn_cvt_scalef32_pk_fp8_f16(v1, v1, /* scale */ 1.f, 0);
-    return u.fp8;
-#elif __HIP_DEVICE_COMPILE__ && defined(__gfx942__)
-    float2_t v;
-    uint32_t ival = 0;
-    asm volatile("v_pk_add_f32 %0, %1, %2" : "=v"(v) : "v"(__builtin_amdgcn_cvt_pk_f32_fp8(x, 0)), "v"(__builtin_amdgcn_cvt_pk_f32_fp8(y, 0)));
-    return __builtin_amdgcn_cvt_pk_fp8_f32(v[0], v[1], ival, false);
-#else
-    union {
-      rccl_float8 fp8[2];
-      fp8x2_storage_t fp8x2;
-    } u, v, w;
-    u.fp8x2 = x;
-    v.fp8x2 = y;
+inline __device__ fp8x2_storage_t hadd2(fp8x2_storage_t x, fp8x2_storage_t y) {
+    union { rccl_float8 fp8[2]; fp8x2_storage_t fp8x2; } u, v, w;
+    u.fp8x2 = x; v.fp8x2 = y;
     w.fp8[0] = hadd(u.fp8[0], v.fp8[0]);
     w.fp8[1] = hadd(u.fp8[1], v.fp8[1]);
     return w.fp8x2;
-#endif
 }
 
-inline __device__  fp8x2_storage_t hadd2_b(fp8x2_storage_t x, fp8x2_storage_t y)
-{
-#if   __HIP_DEVICE_COMPILE__ && defined(__gfx950__)
-    half2_t v1;
-    asm volatile("v_pk_add_f16 %0, %1, %2" : "=v"(v1) : "v"(__builtin_amdgcn_cvt_scalef32_pk_f16_bf8(x, 1.f, 0)), "v"(__builtin_amdgcn_cvt_scalef32_pk_f16_bf8(y, 1.f, 0)));
-    union {
-      shortx2_t i16_vec;
-      fp8x2_storage_t fp8;
-    } u{0};
-    u.i16_vec = __builtin_amdgcn_cvt_scalef32_pk_bf8_f16(v1, v1, /* scale */ 1.f, 0);
-    return u.fp8;
-#elif __HIP_DEVICE_COMPILE__ && defined(__gfx942__)
-    float2_t v;
-    uint32_t ival = 0;
-    asm volatile("v_pk_add_f32 %0, %1, %2" : "=v"(v) : "v"(__builtin_amdgcn_cvt_pk_f32_bf8(x, 0)), "v"(__builtin_amdgcn_cvt_pk_f32_bf8(y, 0)));
-    return __builtin_amdgcn_cvt_pk_bf8_f32(v[0], v[1], ival, false);
-#else
-    union {
-      rccl_bfloat8 bfp8[2];
-      fp8x2_storage_t bfp8x2;
-    } u, v, w;
-    u.bfp8x2 = x;
-    v.bfp8x2 = y;
+inline __device__ fp8x2_storage_t hadd2_b(fp8x2_storage_t x, fp8x2_storage_t y) {
+    union { rccl_bfloat8 bfp8[2]; fp8x2_storage_t bfp8x2; } u, v, w;
+    u.bfp8x2 = x; v.bfp8x2 = y;
     w.bfp8[0] = hadd_b(u.bfp8[0], v.bfp8[0]);
     w.bfp8[1] = hadd_b(u.bfp8[1], v.bfp8[1]);
     return w.bfp8x2;
-#endif
 }
 
-inline std::ostream& operator<<(std::ostream& os, const rccl_float8& f8)
-{
-    return os << float(f8);
-}
+// __has_include(<hip/hip_fp8.h>) && \
+// (!__HIP_DEVICE_COMPILE__ || defined(__gfx942__) || defined(__gfx950__) || \
+// defined(__gfx1200__) || defined(__gfx1201__) || defined(__gfx1250__))
 
-inline std::ostream& operator<<(std::ostream& os, const rccl_bfloat8& bf8)
-{
-    return os << float(bf8);
-}
-
-inline __host__ __device__ float operator*(rccl_float8 a, rccl_float8 b)
-{
-    return float(a) * float(b);
-}
-
-inline __host__ __device__ float operator*(rccl_bfloat8 a, rccl_bfloat8 b)
-{
-    return float(a) * float(b);
-}
-
-inline __host__ __device__ float operator*(rccl_float8 a, float b)
-{
-    return float(a) * float(b);
-}
-
-inline __host__ __device__ float operator*(rccl_bfloat8 a, float b)
-{
-    return float(a) * float(b);
-}
-
-// For older versions of ROCm that do not include hip_fp8.h,
-// we provide a local version of the header file as a fallback.
 #else
+
+// Path B: For older versions of ROCm that do not include hip_fp8.h,
+// we provide a local version of the header file as a fallback.
 
 #define HIP_HOST_DEVICE __host__ __device__
 #define HIP_HOST __host__
@@ -209,11 +106,11 @@ inline __host__ __device__ float operator*(rccl_bfloat8 a, float b)
 
 namespace rocblas_hip_f8_impl
 {
-    __host__ inline int clz(uint32_t x)
+    HIP_HOST inline int clz(uint32_t x)
     {
         return __builtin_clz(x);
     }
-    __device__ inline int clz(uint32_t x)
+    HIP_DEVICE inline int clz(uint32_t x)
     {
         return __clz(x);
     }
@@ -488,9 +385,6 @@ namespace rocblas_hip_f8_impl
         return reinterpret_cast<const T&>(retval);
     }
 } // namespace rocblas_hip_f8_impl
-
-static __device__ bool rocblas_hip_f8_bias_mode_bit_device = true;
-static bool            rocblas_hip_f8_bias_mode_bit_host   = true;
 
 struct rccl_float8
 {
@@ -830,40 +724,12 @@ struct rccl_bfloat8
     }
 };
 
-namespace std
-{
-    inline rccl_float8 sin(rccl_float8 a)
-    {
-        return rccl_float8(sinf(float(a)));
-    }
-    inline rccl_float8 cos(rccl_float8 a)
-    {
-        return rccl_float8(cosf(float(a)));
-    }
-    inline rccl_bfloat8 sin(rccl_bfloat8 a)
-    {
-        return rccl_bfloat8(sinf(float(a)));
-    }
-    inline rccl_bfloat8 cos(rccl_bfloat8 a)
-    {
-        return rccl_bfloat8(cosf(float(a)));
-    }
-    HIP_HOST_DEVICE constexpr rccl_float8 real(const rccl_float8& a)
-    {
-        return a;
-    }
-    HIP_HOST_DEVICE constexpr rccl_bfloat8 real(const rccl_bfloat8& a)
-    {
-        return a;
-    }
-}
-
-inline __device__  rccl_float8 hadd(rccl_float8 x, rccl_float8 y)
+inline HIP_DEVICE rccl_float8 hadd(rccl_float8 x, rccl_float8 y)
 {
 	return rccl_float8(float(x) + float(y));
 }
 
-inline __device__  fp8x2_storage_t hadd2(fp8x2_storage_t x, fp8x2_storage_t y)
+inline HIP_DEVICE fp8x2_storage_t hadd2(fp8x2_storage_t x, fp8x2_storage_t y)
 {
     union {
       rccl_float8 fp8[2];
@@ -877,12 +743,12 @@ inline __device__  fp8x2_storage_t hadd2(fp8x2_storage_t x, fp8x2_storage_t y)
 	return w.fp8x2;
 }
 
-inline __device__  rccl_bfloat8 hadd_b(rccl_bfloat8 x, rccl_bfloat8 y)
+inline HIP_DEVICE rccl_bfloat8 hadd_b(rccl_bfloat8 x, rccl_bfloat8 y)
 {
     return rccl_bfloat8(float(x) + float(y));
 }
 
-inline __device__  fp8x2_storage_t hadd2_b(fp8x2_storage_t x, fp8x2_storage_t y)                                            {
+inline HIP_DEVICE fp8x2_storage_t hadd2_b(fp8x2_storage_t x, fp8x2_storage_t y)                                            {
     union {
       rccl_bfloat8 fp8[2];
       fp8x2_storage_t fp8x2;
@@ -894,328 +760,6 @@ inline __device__  fp8x2_storage_t hadd2_b(fp8x2_storage_t x, fp8x2_storage_t y)
 
 	return w.fp8x2;
 }
-
-// Special operator overloading
-inline std::ostream& operator<<(std::ostream& os, const rccl_float8& f8)
-{
-    return os << float(f8);
-}
-
-inline std::ostream& operator<<(std::ostream& os, const rccl_bfloat8& bf8)
-{
-    return os << float(bf8);
-}
-
-// all + operator overloading with mixed types
-// mixed types, always converts to f32, does computation in f32, and returns float
-inline __host__ __device__ float operator+(const float fa, rccl_float8 b)
-{
-    return (fa + float(b));
-}
-
-inline __host__ __device__ float operator+(const float fa, rccl_bfloat8 b)
-{
-    return (fa + float(b));
-}
-
-inline __host__ __device__ float operator+(rccl_float8 a, const float fb)
-{
-    return (float(a) + fb);
-}
-
-inline __host__ __device__ float operator+(rccl_bfloat8 a, const float fb)
-{
-    return (float(a) + fb);
-}
-
-inline __host__ __device__ float operator+(rccl_float8 a, rccl_bfloat8 b)
-{
-    return (float(a) + float(b));
-}
-
-inline __host__ __device__ float operator+(rccl_bfloat8 a, rccl_float8 b)
-{
-    return (float(a) + float(b));
-}
-
-inline __host__ __device__ rccl_float8 operator+(rccl_float8 a, rccl_float8 b)
-{
-    return rccl_float8(float(a) + float(b));
-}
-
-inline __host__ __device__ rccl_bfloat8 operator+(rccl_bfloat8 a, rccl_bfloat8 b)
-{
-    return rccl_bfloat8(float(a) + float(b));
-}
-
-inline __host__ __device__ rccl_float8& operator+=(rccl_float8& a, rccl_float8 b)
-{
-    return a = rccl_float8(float(a) + float(b));
-}
-
-inline __host__ __device__ rccl_bfloat8& operator+=(rccl_bfloat8& a, rccl_bfloat8 b)
-{
-    return a = rccl_bfloat8(float(a) + float(b));
-}
-
-// overloading multiplication, always returns float,
-inline __host__ __device__ float operator*(rccl_float8 a, rccl_float8 b)
-{
-    return float(a) * float(b);
-}
-
-inline __host__ __device__ float operator*(float a, rccl_float8 b)
-{
-    return (a * float(b));
-}
-
-inline __host__ __device__ float operator*(rccl_float8 a, float b)
-{
-    return (float(a) * b);
-}
-
-inline __host__ __device__ float operator*(int32_t a, rccl_float8 b)
-{
-    return ((float)a * float(b));
-}
-
-inline __host__ __device__ float operator*(double a, rccl_float8 b)
-{
-    return ((float)a * float(b));
-}
-
-inline __host__ __device__ float operator*(rccl_bfloat8 a, rccl_bfloat8 b)
-{
-    return float(a) * float(b);
-}
-
-inline __host__ __device__ float operator*(float a, rccl_bfloat8 b)
-{
-    return (a * float(b));
-}
-
-inline __host__ __device__ float operator*(rccl_bfloat8 a, float b)
-{
-    return (float(a) * b);
-}
-
-inline __host__ __device__ float operator*(int32_t a, rccl_bfloat8 b)
-{
-    return ((float)a * float(b));
-}
-
-inline __host__ __device__ float operator*(double a, rccl_bfloat8 b)
-{
-    return ((float)a * float(b));
-}
-
-// overloading for mixed f8 and bf8 types
-inline __host__ __device__ float operator*(rccl_float8 a, rccl_bfloat8 b)
-{
-    return float(a) * float(b);
-}
-
-inline __host__ __device__ float operator*(rccl_bfloat8 a, rccl_float8 b)
-{
-    return float(a) * float(b);
-}
-
-// all - operator overloading with mixed types
-// mixed types, always converts to f32, does computation in f32, and returns float
-inline __host__ __device__ float operator-(const float fa, rccl_float8 b)
-{
-    return (fa - float(b));
-}
-
-inline __host__ __device__ float operator-(const float fa, rccl_bfloat8 b)
-{
-    return (fa - float(b));
-}
-
-inline __host__ __device__ float operator-(rccl_float8 a, const float fb)
-{
-    return (float(a) - fb);
-}
-
-inline __host__ __device__ float operator-(rccl_bfloat8 a, const float fb)
-{
-    return (float(a) - fb);
-}
-
-inline __host__ __device__ float operator-(rccl_float8 a, rccl_bfloat8 b)
-{
-    return (float(a) - float(b));
-}
-
-inline __host__ __device__ float operator-(rccl_bfloat8 a, rccl_float8 b)
-{
-    return (float(a) - float(b));
-}
-
-inline __host__ __device__ rccl_float8 operator-(rccl_float8 a, rccl_float8 b)
-{
-    return rccl_float8(float(a) - float(b));
-}
-
-inline __host__ __device__ rccl_bfloat8 operator-(rccl_bfloat8 a, rccl_bfloat8 b)
-{
-    return rccl_bfloat8(float(a) - float(b));
-}
-
-inline __host__ __device__ rccl_float8& operator-=(rccl_float8& a, rccl_float8 b)
-{
-    return a = rccl_float8(float(a) - float(b));
-}
-
-inline __host__ __device__ rccl_bfloat8& operator-=(rccl_bfloat8& a, rccl_bfloat8 b)
-{
-    return a = rccl_bfloat8(float(a) - float(b));
-}
-
-// overloading division, always returns float,
-inline __host__ __device__ float operator/(rccl_float8 a, rccl_float8 b)
-{
-    return float(a) / float(b);
-}
-
-inline __host__ __device__ float operator/(float a, rccl_float8 b)
-{
-    return (a / float(b));
-}
-
-inline __host__ __device__ float operator/(rccl_float8 a, float b)
-{
-    return (float(a) / b);
-}
-
-inline __host__ __device__ float operator/(int32_t a, rccl_float8 b)
-{
-    return ((float)a / float(b));
-}
-
-inline __host__ __device__ float operator/(double a, rccl_float8 b)
-{
-    return ((float)a / float(b));
-}
-
-inline __host__ __device__ float operator/(rccl_bfloat8 a, rccl_bfloat8 b)
-{
-    return float(a) / float(b);
-}
-
-inline __host__ __device__ float operator/(float a, rccl_bfloat8 b)
-{
-    return (a / float(b));
-}
-
-inline __host__ __device__ float operator/(rccl_bfloat8 a, float b)
-{
-    return (float(a) / b);
-}
-
-inline __host__ __device__ float operator/(int32_t a, rccl_bfloat8 b)
-{
-    return ((float)a / float(b));
-}
-
-inline __host__ __device__ float operator/(double a, rccl_bfloat8 b)
-{
-    return ((float)a / float(b));
-}
-
-// overloading for mixed f8 and bf8 types
-inline __host__ __device__ float operator/(rccl_float8 a, rccl_bfloat8 b)
-{
-    return float(a) / float(b);
-}
-
-inline __host__ __device__ float operator/(rccl_bfloat8 a, rccl_float8 b)
-{
-    return float(a) / float(b);
-}
-
-// overloading for compare
-inline __host__ __device__ bool operator==(rccl_float8 a, rccl_float8 b)
-{
-    return (a.data == b.data);
-}
-
-inline __host__ __device__ bool operator==(rccl_bfloat8 a, rccl_bfloat8 b)
-{
-    return (a.data == b.data);
-}
-
-inline __host__ __device__ bool operator!=(rccl_float8 a, rccl_float8 b)
-{
-    return (a.data != b.data);
-}
-
-inline __host__ __device__ bool operator!=(rccl_bfloat8 a, rccl_bfloat8 b)
-{
-    return (a.data != b.data);
-}
-
-// ================ Explicit downcasting to support different rounding (RNE, SR) ===============
-// NOTE: we going to remove all assignment operator overloading from other types and enforce
-// this explicit_downcast function to make any roudning behavior default
-// We have to explicitly call this function with SR flag
-
-template <typename T,
-          typename Ta,
-          bool stochastic_rounding,
-          typename std::enable_if<std::is_same<T, Ta>{}, int>::type = 0>
-inline __host__ __device__ T explicit_downcast(Ta a, uint32_t rng = 0)
-{
-    // same type, no conversion
-    return a;
-}
-
-// Use h/w intrinsic and optimized version when __gfx942__
-template <
-    typename T,
-    typename Ta,
-    bool stochastic_rounding,
-    typename std::enable_if<(!(std::is_same<T, Ta>{})
-                             && (std::is_same<T, rccl_float8>{} || std::is_same<T, rccl_bfloat8>{})),
-                            int>::type
-    = 0>
-inline __host__ __device__ T explicit_downcast(Ta a, uint32_t rng)
-{
-#if defined(__gfx942__) || defined(__gfx950__)
-    // NOTE: we are directly calling cast_to_f8_from_f32 instead of constructor to optimize away one runtime branch
-    T val;
-    if(std::is_same<T, rccl_float8>::value)
-        val.data = rccl_float8::cast_to_f8_from_f32<stochastic_rounding>(float(a), rng);
-    else
-        val.data = rccl_bfloat8::cast_to_bf8_from_f32<stochastic_rounding>(float(a), rng);
-    return val;
-#else // non gfx942
-    return T(float(a),
-             stochastic_rounding ? T::rocblas_hip_f8_rounding_mode::stochastic
-                                 : T::rocblas_hip_f8_rounding_mode::standard,
-             rng);
-#endif // __gfx942__
-}
-
-// NOTE NOTE: The above code is good if we don't consider HIP-GEMM code and only consider the quantization
-// However, if we need HIP-GEMM for fall-back, we would need explicit_cast handles Tacc=f32 to To=f16/bf16 conversion
-template <
-    typename T,
-    typename Ta,
-    bool stochastic_rounding,
-    typename std::enable_if<(!(std::is_same<T, Ta>{})
-                             && !(std::is_same<T, rccl_float8>{} || std::is_same<T, rccl_bfloat8>{})),
-                            int>::type
-    = 0>
-inline __host__ __device__ T explicit_downcast(Ta a, uint32_t rng)
-{
-    // the return type is not a F8 types, no SR for those types
-    // not sure if we have direct conversion, so converting to float first
-    // no effect if the input type is float
-    return T(float(a));
-}
-
-// =================================================================================================
 
 #endif
 

--- a/projects/rccl/src/include/rccl_float8.h
+++ b/projects/rccl/src/include/rccl_float8.h
@@ -26,6 +26,7 @@
 #include <stdint.h>
 
 typedef uint16_t fp8x2_storage_t;
+typedef uint64_t fp8x8_storage_t;
 
 #if __cplusplus < 201103L || (!defined(__HIP_PLATFORM_AMD__) && !defined(__HIPCC__))
 /*! \brief Struct to represent a 8 bit floating-point number. */
@@ -65,27 +66,174 @@ typedef __hip_fp8_e5m2 rccl_bfloat8;
 #endif
 
 inline __device__ rccl_float8 hadd(rccl_float8 x, rccl_float8 y) {
+#if __HIP_DEVICE_COMPILE__ && defined(__gfx950__)
+    typedef _Float16 half2_t __attribute__((ext_vector_type(2)));
+    typedef short shortx2_t __attribute__((ext_vector_type(2)));
+    half2_t v1;
+    asm volatile("v_pk_add_f16 %0, %1, %2"
+                 : "=v"(v1)
+                 : "v"(__builtin_amdgcn_cvt_scalef32_pk_f16_fp8(x.__x, 1.f, 0)),
+                   "v"(__builtin_amdgcn_cvt_scalef32_pk_f16_fp8(y.__x, 1.f, 0)));
+    union {
+      shortx2_t i16_vec;
+      rccl_float8 fp8[4];
+    } u{0};
+    u.i16_vec = __builtin_amdgcn_cvt_scalef32_pk_fp8_f16(v1, v1, /* scale */ 1.f, 0);
+    return u.fp8[0];
+#elif __HIP_DEVICE_COMPILE__ && defined(__gfx942__)
+    typedef float float2_t __attribute__((ext_vector_type(2)));
+    float2_t v;
+    uint32_t ival = 0;
+    asm volatile("v_pk_add_f32 %0, %1, %2"
+                 : "=v"(v)
+                 : "v"(__builtin_amdgcn_cvt_pk_f32_fp8(x.__x, 0)),
+                   "v"(__builtin_amdgcn_cvt_pk_f32_fp8(y.__x, 0)));
+    return __builtin_amdgcn_cvt_pk_fp8_f32(v[0], v[0], ival, false);
+#else
     return rccl_float8(float(x) + float(y));
+#endif
 }
 
 inline __device__ rccl_bfloat8 hadd_b(rccl_bfloat8 x, rccl_bfloat8 y) {
+#if __HIP_DEVICE_COMPILE__ && defined(__gfx950__)
+    typedef _Float16 half2_t __attribute__((ext_vector_type(2)));
+    typedef short shortx2_t __attribute__((ext_vector_type(2)));
+    half2_t v1;
+    asm volatile("v_pk_add_f16 %0, %1, %2"
+                 : "=v"(v1)
+                 : "v"(__builtin_amdgcn_cvt_scalef32_pk_f16_bf8(x.__x, 1.f, 0)),
+                   "v"(__builtin_amdgcn_cvt_scalef32_pk_f16_bf8(y.__x, 1.f, 0)));
+    union {
+      shortx2_t i16_vec;
+      rccl_bfloat8 fp8[4];
+    } u1{0};
+    u1.i16_vec = __builtin_amdgcn_cvt_scalef32_pk_bf8_f16(v1, v1, /* scale */ 1.f, 0);
+    return u1.fp8[0];
+#elif __HIP_DEVICE_COMPILE__ && defined(__gfx942__)
+    typedef float float2_t __attribute__((ext_vector_type(2)));
+    float2_t v;
+    uint32_t ival = 0;
+    asm volatile("v_pk_add_f32 %0, %1, %2"
+                 : "=v"(v)
+                 : "v"(__builtin_amdgcn_cvt_pk_f32_bf8(x.__x, 0)),
+                   "v"(__builtin_amdgcn_cvt_pk_f32_bf8(y.__x, 0)));
+    return __builtin_amdgcn_cvt_pk_bf8_f32(v[0], v[0], ival, false);
+#else
     return rccl_bfloat8(float(x) + float(y));
+#endif
 }
 
 inline __device__ fp8x2_storage_t hadd2(fp8x2_storage_t x, fp8x2_storage_t y) {
+#if __HIP_DEVICE_COMPILE__ && defined(__gfx950__)
+    typedef _Float16 half2_t __attribute__((ext_vector_type(2)));
+    typedef short shortx2_t __attribute__((ext_vector_type(2)));
+    half2_t v1;
+    asm volatile("v_pk_add_f16 %0, %1, %2"
+                 : "=v"(v1)
+                 : "v"(__builtin_amdgcn_cvt_scalef32_pk_f16_fp8(x, 1.f, 0)),
+                   "v"(__builtin_amdgcn_cvt_scalef32_pk_f16_fp8(y, 1.f, 0)));
+    union {
+      shortx2_t i16_vec;
+      fp8x2_storage_t fp8;
+    } u{0};
+    u.i16_vec = __builtin_amdgcn_cvt_scalef32_pk_fp8_f16(v1, v1, /* scale */ 1.f, 0);
+    return u.fp8;
+#elif __HIP_DEVICE_COMPILE__ && defined(__gfx942__)
+    typedef float float2_t __attribute__((ext_vector_type(2)));
+    float2_t v;
+    uint32_t ival = 0;
+    asm volatile("v_pk_add_f32 %0, %1, %2"
+                 : "=v"(v)
+                 : "v"(__builtin_amdgcn_cvt_pk_f32_fp8(x, 0)),
+                   "v"(__builtin_amdgcn_cvt_pk_f32_fp8(y, 0)));
+    return __builtin_amdgcn_cvt_pk_fp8_f32(v[0], v[1], ival, false);
+#else
     union { rccl_float8 fp8[2]; fp8x2_storage_t fp8x2; } u, v, w;
     u.fp8x2 = x; v.fp8x2 = y;
     w.fp8[0] = hadd(u.fp8[0], v.fp8[0]);
     w.fp8[1] = hadd(u.fp8[1], v.fp8[1]);
     return w.fp8x2;
+#endif
 }
 
 inline __device__ fp8x2_storage_t hadd2_b(fp8x2_storage_t x, fp8x2_storage_t y) {
+#if __HIP_DEVICE_COMPILE__ && defined(__gfx950__)
+    typedef _Float16 half2_t __attribute__((ext_vector_type(2)));
+    typedef short shortx2_t __attribute__((ext_vector_type(2)));
+    half2_t v1;
+    asm volatile("v_pk_add_f16 %0, %1, %2"
+                 : "=v"(v1)
+                 : "v"(__builtin_amdgcn_cvt_scalef32_pk_f16_bf8(x, 1.f, 0)),
+                   "v"(__builtin_amdgcn_cvt_scalef32_pk_f16_bf8(y, 1.f, 0)));
+    union {
+      shortx2_t i16_vec;
+      fp8x2_storage_t fp8;
+    } u{0};
+    u.i16_vec = __builtin_amdgcn_cvt_scalef32_pk_bf8_f16(v1, v1, /* scale */ 1.f, 0);
+    return u.fp8;
+#elif __HIP_DEVICE_COMPILE__ && defined(__gfx942__)
+    typedef float float2_t __attribute__((ext_vector_type(2)));
+    float2_t v;
+    uint32_t ival = 0;
+    asm volatile("v_pk_add_f32 %0, %1, %2"
+                 : "=v"(v)
+                 : "v"(__builtin_amdgcn_cvt_pk_f32_bf8(x, 0)),
+                   "v"(__builtin_amdgcn_cvt_pk_f32_bf8(y, 0)));
+    return __builtin_amdgcn_cvt_pk_bf8_f32(v[0], v[1], ival, false);
+#else
     union { rccl_bfloat8 bfp8[2]; fp8x2_storage_t bfp8x2; } u, v, w;
     u.bfp8x2 = x; v.bfp8x2 = y;
     w.bfp8[0] = hadd_b(u.bfp8[0], v.bfp8[0]);
     w.bfp8[1] = hadd_b(u.bfp8[1], v.bfp8[1]);
     return w.bfp8x2;
+#endif
+}
+
+// 8-lane packed reductions.
+// On gfx1250 (MI400) we use the V_CVT_SCALE_PK8_F32_FP8 / V_CVT_SCALEF32_PK8_FP8_F32
+// instruction pair to convert 8 fp8 lanes in one cvt, do 4× v_pk_add_f32, then pack
+// back in one cvt.
+
+inline __device__ fp8x8_storage_t hadd8(fp8x8_storage_t x, fp8x8_storage_t y) {
+#if __HIP_DEVICE_COMPILE__ && defined(__gfx1250__)
+    typedef float    v8f32_t  __attribute__((ext_vector_type(8)));
+    typedef uint32_t v2u32_t  __attribute__((ext_vector_type(2)));
+    union { fp8x8_storage_t u64; v2u32_t u32x2; } ux{x}, uy{y}, ur{0};
+    v8f32_t fx = __builtin_amdgcn_cvt_scale_pk8_f32_fp8(ux.u32x2, 127u, 0);
+    v8f32_t fy = __builtin_amdgcn_cvt_scale_pk8_f32_fp8(uy.u32x2, 127u, 0);
+    v8f32_t fs = fx + fy;
+    ur.u32x2 = __builtin_amdgcn_cvt_scalef32_pk8_fp8_f32(fs, 1.0f);
+    return ur.u64;
+#else
+    union { fp8x2_storage_t fp8x2[4]; fp8x8_storage_t fp8x8; } u{}, v{}, w{};
+    u.fp8x8 = x; v.fp8x8 = y;
+    w.fp8x2[0] = hadd2(u.fp8x2[0], v.fp8x2[0]);
+    w.fp8x2[1] = hadd2(u.fp8x2[1], v.fp8x2[1]);
+    w.fp8x2[2] = hadd2(u.fp8x2[2], v.fp8x2[2]);
+    w.fp8x2[3] = hadd2(u.fp8x2[3], v.fp8x2[3]);
+    return w.fp8x8;
+#endif
+}
+
+inline __device__ fp8x8_storage_t hadd8_b(fp8x8_storage_t x, fp8x8_storage_t y) {
+#if __HIP_DEVICE_COMPILE__ && defined(__gfx1250__)
+    typedef float    v8f32_t  __attribute__((ext_vector_type(8)));
+    typedef uint32_t v2u32_t  __attribute__((ext_vector_type(2)));
+    union { fp8x8_storage_t u64; v2u32_t u32x2; } ux{x}, uy{y}, ur{0};
+    v8f32_t fx = __builtin_amdgcn_cvt_scale_pk8_f32_bf8(ux.u32x2, 127u, 0);
+    v8f32_t fy = __builtin_amdgcn_cvt_scale_pk8_f32_bf8(uy.u32x2, 127u, 0);
+    v8f32_t fs = fx + fy;
+    ur.u32x2 = __builtin_amdgcn_cvt_scalef32_pk8_bf8_f32(fs, 1.0f);
+    return ur.u64;
+#else
+    union { fp8x2_storage_t fp8x2[4]; fp8x8_storage_t fp8x8; } u{}, v{}, w{};
+    u.fp8x8 = x; v.fp8x8 = y;
+    w.fp8x2[0] = hadd2_b(u.fp8x2[0], v.fp8x2[0]);
+    w.fp8x2[1] = hadd2_b(u.fp8x2[1], v.fp8x2[1]);
+    w.fp8x2[2] = hadd2_b(u.fp8x2[2], v.fp8x2[2]);
+    w.fp8x2[3] = hadd2_b(u.fp8x2[3], v.fp8x2[3]);
+    return w.fp8x8;
+#endif
 }
 
 // __has_include(<hip/hip_fp8.h>) && \
@@ -759,6 +907,30 @@ inline HIP_DEVICE fp8x2_storage_t hadd2_b(fp8x2_storage_t x, fp8x2_storage_t y) 
     w.fp8[1] = hadd_b(u.fp8[1], v.fp8[1]);
 
 	return w.fp8x2;
+}
+
+// Path B has no hardware pk8 intrinsics available (this branch is the pure
+// software-emulation fallback for ROCm without hip/hip_fp8.h). Implement
+// hadd8/hadd8_b as a 4-wide cascade over hadd2/hadd2_b so the framework's
+// EltPerPack=8 specialization still resolves.
+inline HIP_DEVICE fp8x8_storage_t hadd8(fp8x8_storage_t x, fp8x8_storage_t y) {
+    union { fp8x2_storage_t fp8x2[4]; fp8x8_storage_t fp8x8; } u, v, w;
+    u.fp8x8 = x; v.fp8x8 = y;
+    w.fp8x2[0] = hadd2(u.fp8x2[0], v.fp8x2[0]);
+    w.fp8x2[1] = hadd2(u.fp8x2[1], v.fp8x2[1]);
+    w.fp8x2[2] = hadd2(u.fp8x2[2], v.fp8x2[2]);
+    w.fp8x2[3] = hadd2(u.fp8x2[3], v.fp8x2[3]);
+    return w.fp8x8;
+}
+
+inline HIP_DEVICE fp8x8_storage_t hadd8_b(fp8x8_storage_t x, fp8x8_storage_t y) {
+    union { fp8x2_storage_t fp8x2[4]; fp8x8_storage_t fp8x8; } u, v, w;
+    u.fp8x8 = x; v.fp8x8 = y;
+    w.fp8x2[0] = hadd2_b(u.fp8x2[0], v.fp8x2[0]);
+    w.fp8x2[1] = hadd2_b(u.fp8x2[1], v.fp8x2[1]);
+    w.fp8x2[2] = hadd2_b(u.fp8x2[2], v.fp8x2[2]);
+    w.fp8x2[3] = hadd2_b(u.fp8x2[3], v.fp8x2[3]);
+    return w.fp8x8;
 }
 
 #endif

--- a/projects/rccl/src/include/rccl_float8.h
+++ b/projects/rccl/src/include/rccl_float8.h
@@ -64,28 +64,132 @@ typedef __hip_fp8_e4m3 rccl_float8;
 typedef __hip_fp8_e5m2 rccl_bfloat8;
 #endif
 
+#ifndef RCCL_FP8_USE_LEGACY_HADD_INTRINSICS
+#define RCCL_FP8_USE_LEGACY_HADD_INTRINSICS 0
+#endif
+
 inline __device__ rccl_float8 hadd(rccl_float8 x, rccl_float8 y) {
+#if RCCL_FP8_USE_LEGACY_HADD_INTRINSICS && __HIP_DEVICE_COMPILE__ && defined(__gfx950__)
+    typedef _Float16 half2_t __attribute__((ext_vector_type(2)));
+    typedef short shortx2_t __attribute__((ext_vector_type(2)));
+    half2_t v1;
+    asm volatile("v_pk_add_f16 %0, %1, %2"
+                 : "=v"(v1)
+                 : "v"(__builtin_amdgcn_cvt_scalef32_pk_f16_fp8(x.__x, 1.f, 0)),
+                   "v"(__builtin_amdgcn_cvt_scalef32_pk_f16_fp8(y.__x, 1.f, 0)));
+    union {
+      shortx2_t i16_vec;
+      rccl_float8 fp8[4];
+    } u{0};
+    u.i16_vec = __builtin_amdgcn_cvt_scalef32_pk_fp8_f16(v1, v1, /* scale */ 1.f, 0);
+    return u.fp8[0];
+#elif RCCL_FP8_USE_LEGACY_HADD_INTRINSICS && __HIP_DEVICE_COMPILE__ && defined(__gfx942__)
+    typedef float float2_t __attribute__((ext_vector_type(2)));
+    float2_t v;
+    uint32_t ival = 0;
+    asm volatile("v_pk_add_f32 %0, %1, %2"
+                 : "=v"(v)
+                 : "v"(__builtin_amdgcn_cvt_pk_f32_fp8(x.__x, 0)),
+                   "v"(__builtin_amdgcn_cvt_pk_f32_fp8(y.__x, 0)));
+    return __builtin_amdgcn_cvt_pk_fp8_f32(v[0], v[0], ival, false);
+#else
     return rccl_float8(float(x) + float(y));
+#endif
 }
 
 inline __device__ rccl_bfloat8 hadd_b(rccl_bfloat8 x, rccl_bfloat8 y) {
+#if RCCL_FP8_USE_LEGACY_HADD_INTRINSICS && __HIP_DEVICE_COMPILE__ && defined(__gfx950__)
+    typedef _Float16 half2_t __attribute__((ext_vector_type(2)));
+    typedef short shortx2_t __attribute__((ext_vector_type(2)));
+    half2_t v1;
+    asm volatile("v_pk_add_f16 %0, %1, %2"
+                 : "=v"(v1)
+                 : "v"(__builtin_amdgcn_cvt_scalef32_pk_f16_bf8(x.__x, 1.f, 0)),
+                   "v"(__builtin_amdgcn_cvt_scalef32_pk_f16_bf8(y.__x, 1.f, 0)));
+    union {
+      shortx2_t i16_vec;
+      rccl_bfloat8 fp8[4];
+    } u1{0};
+    u1.i16_vec = __builtin_amdgcn_cvt_scalef32_pk_bf8_f16(v1, v1, /* scale */ 1.f, 0);
+    return u1.fp8[0];
+#elif RCCL_FP8_USE_LEGACY_HADD_INTRINSICS && __HIP_DEVICE_COMPILE__ && defined(__gfx942__)
+    typedef float float2_t __attribute__((ext_vector_type(2)));
+    float2_t v;
+    uint32_t ival = 0;
+    asm volatile("v_pk_add_f32 %0, %1, %2"
+                 : "=v"(v)
+                 : "v"(__builtin_amdgcn_cvt_pk_f32_bf8(x.__x, 0)),
+                   "v"(__builtin_amdgcn_cvt_pk_f32_bf8(y.__x, 0)));
+    return __builtin_amdgcn_cvt_pk_bf8_f32(v[0], v[0], ival, false);
+#else
     return rccl_bfloat8(float(x) + float(y));
+#endif
 }
 
 inline __device__ fp8x2_storage_t hadd2(fp8x2_storage_t x, fp8x2_storage_t y) {
+#if RCCL_FP8_USE_LEGACY_HADD_INTRINSICS && __HIP_DEVICE_COMPILE__ && defined(__gfx950__)
+    typedef _Float16 half2_t __attribute__((ext_vector_type(2)));
+    typedef short shortx2_t __attribute__((ext_vector_type(2)));
+    half2_t v1;
+    asm volatile("v_pk_add_f16 %0, %1, %2"
+                 : "=v"(v1)
+                 : "v"(__builtin_amdgcn_cvt_scalef32_pk_f16_fp8(x, 1.f, 0)),
+                   "v"(__builtin_amdgcn_cvt_scalef32_pk_f16_fp8(y, 1.f, 0)));
+    union {
+      shortx2_t i16_vec;
+      fp8x2_storage_t fp8;
+    } u{0};
+    u.i16_vec = __builtin_amdgcn_cvt_scalef32_pk_fp8_f16(v1, v1, /* scale */ 1.f, 0);
+    return u.fp8;
+#elif RCCL_FP8_USE_LEGACY_HADD_INTRINSICS && __HIP_DEVICE_COMPILE__ && defined(__gfx942__)
+    typedef float float2_t __attribute__((ext_vector_type(2)));
+    float2_t v;
+    uint32_t ival = 0;
+    asm volatile("v_pk_add_f32 %0, %1, %2"
+                 : "=v"(v)
+                 : "v"(__builtin_amdgcn_cvt_pk_f32_fp8(x, 0)),
+                   "v"(__builtin_amdgcn_cvt_pk_f32_fp8(y, 0)));
+    return __builtin_amdgcn_cvt_pk_fp8_f32(v[0], v[1], ival, false);
+#else
     union { rccl_float8 fp8[2]; fp8x2_storage_t fp8x2; } u, v, w;
     u.fp8x2 = x; v.fp8x2 = y;
     w.fp8[0] = hadd(u.fp8[0], v.fp8[0]);
     w.fp8[1] = hadd(u.fp8[1], v.fp8[1]);
     return w.fp8x2;
+#endif
 }
 
 inline __device__ fp8x2_storage_t hadd2_b(fp8x2_storage_t x, fp8x2_storage_t y) {
+#if RCCL_FP8_USE_LEGACY_HADD_INTRINSICS && __HIP_DEVICE_COMPILE__ && defined(__gfx950__)
+    typedef _Float16 half2_t __attribute__((ext_vector_type(2)));
+    typedef short shortx2_t __attribute__((ext_vector_type(2)));
+    half2_t v1;
+    asm volatile("v_pk_add_f16 %0, %1, %2"
+                 : "=v"(v1)
+                 : "v"(__builtin_amdgcn_cvt_scalef32_pk_f16_bf8(x, 1.f, 0)),
+                   "v"(__builtin_amdgcn_cvt_scalef32_pk_f16_bf8(y, 1.f, 0)));
+    union {
+      shortx2_t i16_vec;
+      fp8x2_storage_t fp8;
+    } u{0};
+    u.i16_vec = __builtin_amdgcn_cvt_scalef32_pk_bf8_f16(v1, v1, /* scale */ 1.f, 0);
+    return u.fp8;
+#elif RCCL_FP8_USE_LEGACY_HADD_INTRINSICS && __HIP_DEVICE_COMPILE__ && defined(__gfx942__)
+    typedef float float2_t __attribute__((ext_vector_type(2)));
+    float2_t v;
+    uint32_t ival = 0;
+    asm volatile("v_pk_add_f32 %0, %1, %2"
+                 : "=v"(v)
+                 : "v"(__builtin_amdgcn_cvt_pk_f32_bf8(x, 0)),
+                   "v"(__builtin_amdgcn_cvt_pk_f32_bf8(y, 0)));
+    return __builtin_amdgcn_cvt_pk_bf8_f32(v[0], v[1], ival, false);
+#else
     union { rccl_bfloat8 bfp8[2]; fp8x2_storage_t bfp8x2; } u, v, w;
     u.bfp8x2 = x; v.bfp8x2 = y;
     w.bfp8[0] = hadd_b(u.bfp8[0], v.bfp8[0]);
     w.bfp8[1] = hadd_b(u.bfp8[1], v.bfp8[1]);
     return w.bfp8x2;
+#endif
 }
 
 // __has_include(<hip/hip_fp8.h>) && \


### PR DESCRIPTION
## Motivation

`rccl/src/include/rccl_float8.h` and `rccl-tests/src/rccl_float8.h` definitions have some sections that are incompatible with newer versions of HIP compiler. Also, the (HIP_VERSION check + architecture blocklist) guard is fragile.

## Technical Details

- Replace the (HIP_VERSION check + architecture blocklist) guard with (check for `hip_fp8.h` existence + an explicit architecture allowlist) guard. This makes the guard forward-compatible => new FP8 architectures are added to the allowlist rather than maintained in a growing blocklist.
- RCCL: Simplify the four `hadd`/`hadd_b`/`hadd2`/`hadd2_b` functions by removing the manual gfx950 and gfx942 intrinsic paths. These duplicated conversions that hip_fp8.h already performs internally via `HIP_FP8_CVT_FAST_PATH` on supported architectures.
- Remove unused code sections in RCCL and RCCL-Tests rccl_float8.h

## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.