### PR TITLE
[CLR][NFC] Optimize releasing of SDMA engines

### DIFF
--- a/projects/clr/rocclr/device/rocm/rocvirtual.cpp
+++ b/projects/clr/rocclr/device/rocm/rocvirtual.cpp
@@ -1770,8 +1770,7 @@ VirtualGPU::VirtualGPU(Device& device, bool profiling, bool cooperative,
 // ================================================================================================
 VirtualGPU::~VirtualGPU() {
   // Release SDMA engine assignment for this VirtualGPU
-  dev().ReleaseSdmaEngine(this);
-  ClearAssignedSdmaEngine();
+  ReleaseSdmaEngines();
 
   delete blitMgr_;
 
@@ -1997,6 +1996,9 @@ address VirtualGPU::allocKernelArguments(size_t size, size_t alignment) {
 
 // ================================================================================================
 void VirtualGPU::ReleaseSdmaEngines() {
+  if (!hasAssignedSdmaEngine()) {
+    return;
+  }
   // Release SDMA engine assignment when queue is idle
   // This allows the engine to be reassigned to other active streams
   dev().ReleaseSdmaEngine(this);

--- a/projects/clr/rocclr/device/rocm/rocvirtual.hpp
+++ b/projects/clr/rocclr/device/rocm/rocvirtual.hpp
@@ -479,6 +479,9 @@ class VirtualGPU : public device::VirtualDevice {
   void ClearAssignedSdmaEngine() {
     assigned_sdma_engine_ = 0;
   }
+  bool hasAssignedSdmaEngine() const {
+    return assigned_sdma_engine_ != 0;
+  }
 
  private:
   //! Dispatches a barrier with blocking HSA signals


### PR DESCRIPTION
## Motivation

Performance optimization of the runtime.

## Technical Details

SDMA engines are only assigned for blit kernels, but they are being released after every `hipDeviceSyncronize` and can be bypassed in most cases.

## JIRA ID

N/A

## Test Plan

N/A, this change is non-functional

## Test Result

N/A, this change is non-functional

## Submission Checklist

- [X] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
