### PR TITLE
Add NPU device type support

### DIFF
--- a/projects/cuid/cli/amdcuid_tool.cc
+++ b/projects/cuid/cli/amdcuid_tool.cc
@@ -409,8 +409,11 @@ int query_device(const std::string& identifier, bool show_primary, const std::st
         }
     }
     
-    // Check if identifier looks like a BDF (contains ':' and '.')
-    bool is_bdf = (identifier.find(':') != std::string::npos && identifier.find('.') != std::string::npos);
+    // Check if identifier looks like a BDF (e.g., "0000:c6:00.1" or "c6:00.1").
+    // Must not start with '/' (which would indicate a sysfs path).
+    bool is_bdf = (!identifier.empty() && identifier[0] != '/' &&
+                   identifier.find(':') != std::string::npos &&
+                   identifier.find('.') != std::string::npos);
     
     if (is_bdf) {
         // Try as BDF

--- a/projects/cuid/cli/amdcuid_tool.cc
+++ b/projects/cuid/cli/amdcuid_tool.cc
@@ -59,7 +59,7 @@ void print_usage(const char* program_name) {
     std::cout << "  --set-key <key_file>         Set HMAC key from file (32 bytes, use with --generate-cuid)\n";
     std::cout << "  --notify-daemon              Notify daemon to refresh device registry (for udev integration)\n";
     std::cout << "  --list                       List all devices and their CUIDs\n";
-    std::cout << "  --type <type>                Filter by device type (gpu, cpu, nic, platform)\n";
+    std::cout << "  --type <type>                Filter by device type (gpu, cpu, nic, npu, platform)\n";
     std::cout << "                               Use with --list or --query-device\n";
     std::cout << "  --show-primary               Show primary CUIDs (requires root privileges)\n";
     std::cout << "                               Use with --list or --query-device\n";
@@ -93,6 +93,7 @@ const char* device_type_to_string(amdcuid_device_type_t type) {
         case AMDCUID_DEVICE_TYPE_CPU: return "CPU";
         case AMDCUID_DEVICE_TYPE_GPU: return "GPU";
         case AMDCUID_DEVICE_TYPE_NIC: return "NIC";
+        case AMDCUID_DEVICE_TYPE_NPU: return "NPU";
         case AMDCUID_DEVICE_TYPE_NONE: return "NONE";
         default: return "UNKNOWN";
     }
@@ -106,6 +107,7 @@ amdcuid_device_type_t string_to_device_type(const std::string& type_str) {
     if (upper == "CPU") return AMDCUID_DEVICE_TYPE_CPU;
     if (upper == "GPU") return AMDCUID_DEVICE_TYPE_GPU;
     if (upper == "NIC") return AMDCUID_DEVICE_TYPE_NIC;
+    if (upper == "NPU") return AMDCUID_DEVICE_TYPE_NPU;
     return AMDCUID_DEVICE_TYPE_NONE;
 }
 
@@ -262,7 +264,7 @@ int list_devices(bool show_primary, const std::string* filter_type) {
         filter_device_type = string_to_device_type(*filter_type);
         if (filter_device_type == AMDCUID_DEVICE_TYPE_NONE) {
             std::cerr << "Error: Unknown device type '" << *filter_type << "'" << std::endl;
-            std::cerr << "Valid types: platform, cpu, gpu, nic" << std::endl;
+            std::cerr << "Valid types: platform, cpu, gpu, nic, npu" << std::endl;
             return 1;
         }
     }
@@ -391,7 +393,7 @@ int query_device(const std::string& identifier, bool show_primary, const std::st
         device_type = string_to_device_type(*device_type_str);
         if (device_type == AMDCUID_DEVICE_TYPE_NONE) {
             std::cerr << "Error: Unknown device type '" << *device_type_str << "'" << std::endl;
-            std::cerr << "Valid types: platform, cpu, gpu, nic" << std::endl;
+            std::cerr << "Valid types: platform, cpu, gpu, nic, npu" << std::endl;
             return 1;
         }
     } else {
@@ -402,6 +404,8 @@ int query_device(const std::string& identifier, bool show_primary, const std::st
             device_type = AMDCUID_DEVICE_TYPE_NIC;
         } else if (identifier.find("/sys/class/drm/") != std::string::npos) {
             device_type = AMDCUID_DEVICE_TYPE_GPU;
+        } else if (identifier.find("/sys/class/accel/") != std::string::npos) {
+            device_type = AMDCUID_DEVICE_TYPE_NPU;
         }
     }
     

--- a/projects/cuid/daemon/amdcuid_daemon.cc
+++ b/projects/cuid/daemon/amdcuid_daemon.cc
@@ -27,6 +27,7 @@
 #include "src/cuid_gpu.h"
 #include "src/cuid_cpu.h"
 #include "src/cuid_nic.h"
+#include "src/cuid_npu.h"
 #include "src/cuid_platform.h"
 #include "src/cuid_util.h"
 #include "src/hmac.h"
@@ -328,6 +329,32 @@ amdcuid_status_t get_device_from_udev(std::string *action_output, CuidFileEntry 
         }
         entry.derived_cuid = derived_id.UUIDv8_representation;
         entry.device_node = info.network_interface;
+        entry.bdf = info.bdf;
+        entry.device_index = 0; // could be set based on existing entries
+        entry.last_update = time(nullptr);
+    } else if (subsys_str == "accel") {
+        // NPU device (via accel subsystem, e.g. amdxdna driver)
+        amdcuid_npu_info info = {};
+        amdcuid_status_t status = CuidNpu::discover_single(&info, syspath + "/device");
+        auto npu_device = std::make_shared<CuidNpu>(info);
+
+        entry.device_type = AMDCUID_DEVICE_TYPE_NPU;
+        amdcuid_primary_id primary_id;
+        status = npu_device->get_primary_cuid(primary_id);
+        if (status != AMDCUID_STATUS_SUCCESS) {
+            log_err() << "Error: Failed to get primary CUID for NPU device" << std::endl;
+            return status;
+        }
+        entry.primary_cuid = primary_id.UUIDv8_representation;
+        amdcuid_derived_id derived_id;
+        status = npu_device->get_derived_cuid(derived_id, hmac);
+        if (status != AMDCUID_STATUS_SUCCESS) {
+            log_err() << "Error: Failed to generate derived CUID for NPU device" << std::endl;
+            return status;
+        }
+        log_out() << "Generated derived CUID for NPU device: " << CuidUtilities::get_cuid_as_string(&derived_id.UUIDv8_representation) << std::endl;
+        entry.derived_cuid = derived_id.UUIDv8_representation;
+        entry.device_node = info.accel_node;
         entry.bdf = info.bdf;
         entry.device_index = 0; // could be set based on existing entries
         entry.last_update = time(nullptr);

--- a/projects/cuid/daemon/amdcuid_daemon.cc
+++ b/projects/cuid/daemon/amdcuid_daemon.cc
@@ -27,7 +27,6 @@
 #include "src/cuid_gpu.h"
 #include "src/cuid_cpu.h"
 #include "src/cuid_nic.h"
-#include "src/cuid_npu.h"
 #include "src/cuid_platform.h"
 #include "src/cuid_util.h"
 #include "src/hmac.h"
@@ -329,32 +328,6 @@ amdcuid_status_t get_device_from_udev(std::string *action_output, CuidFileEntry 
         }
         entry.derived_cuid = derived_id.UUIDv8_representation;
         entry.device_node = info.network_interface;
-        entry.bdf = info.bdf;
-        entry.device_index = 0; // could be set based on existing entries
-        entry.last_update = time(nullptr);
-    } else if (subsys_str == "accel") {
-        // NPU device (via accel subsystem, e.g. amdxdna driver)
-        amdcuid_npu_info info = {};
-        amdcuid_status_t status = CuidNpu::discover_single(&info, syspath + "/device");
-        auto npu_device = std::make_shared<CuidNpu>(info);
-
-        entry.device_type = AMDCUID_DEVICE_TYPE_NPU;
-        amdcuid_primary_id primary_id;
-        status = npu_device->get_primary_cuid(primary_id);
-        if (status != AMDCUID_STATUS_SUCCESS) {
-            log_err() << "Error: Failed to get primary CUID for NPU device" << std::endl;
-            return status;
-        }
-        entry.primary_cuid = primary_id.UUIDv8_representation;
-        amdcuid_derived_id derived_id;
-        status = npu_device->get_derived_cuid(derived_id, hmac);
-        if (status != AMDCUID_STATUS_SUCCESS) {
-            log_err() << "Error: Failed to generate derived CUID for NPU device" << std::endl;
-            return status;
-        }
-        log_out() << "Generated derived CUID for NPU device: " << CuidUtilities::get_cuid_as_string(&derived_id.UUIDv8_representation) << std::endl;
-        entry.derived_cuid = derived_id.UUIDv8_representation;
-        entry.device_node = info.accel_node;
         entry.bdf = info.bdf;
         entry.device_index = 0; // could be set based on existing entries
         entry.last_update = time(nullptr);

--- a/projects/cuid/lib/CMakeLists.txt
+++ b/projects/cuid/lib/CMakeLists.txt
@@ -33,6 +33,7 @@ set(CUID_SOURCES
     src/cuid_cpu.cc
     src/cuid_gpu.cc
     src/cuid_nic.cc
+    src/cuid_npu.cc
     src/cuid_platform.cc
     src/cuid_file.cc
     src/hmac.cc
@@ -48,6 +49,7 @@ set(CUID_HEADERS
     src/cuid_cpu.h
     src/cuid_gpu.h
     src/cuid_nic.h
+    src/cuid_npu.h
     src/cuid_platform.h
     src/cuid_file.h
     src/hmac.h

--- a/projects/cuid/lib/include/amd_cuid.h
+++ b/projects/cuid/lib/include/amd_cuid.h
@@ -141,7 +141,8 @@ typedef enum {
     AMDCUID_DEVICE_TYPE_CPU       = 0x2,        ///< CPU core
     AMDCUID_DEVICE_TYPE_GPU       = 0x3,        ///< GPU
     AMDCUID_DEVICE_TYPE_NIC       = 0x4,        ///< NIC (Network Interface Controller)
-    AMDCUID_DEVICE_TYPE_LAST      = 0x4         ///< Last valid device type
+    AMDCUID_DEVICE_TYPE_NPU       = 0x5,        ///< NPU (Neural Processing Unit, e.g. RyzenAI)
+    AMDCUID_DEVICE_TYPE_LAST      = 0x5         ///< Last valid device type
 } amdcuid_device_type_t;
 
 /**

--- a/projects/cuid/lib/src/cuid.cc
+++ b/projects/cuid/lib/src/cuid.cc
@@ -150,6 +150,27 @@ DevicePtr discover_device_by_path(const char* dev_path, amdcuid_device_type_t de
         return std::make_shared<CuidCpu>(cpu_info);
     }
 
+    // NPU sysfs paths may be PCI device directories (e.g.,
+    // /sys/bus/pci/devices/0000:c6:00.1) when /sys/class/accel/ is not
+    // populated. These are directories, not char/block devices, so the
+    // fd-based real path resolution below would fail. Pass directly to
+    // discover_single() which knows how to read PCI sysfs attributes.
+    if (device_type == AMDCUID_DEVICE_TYPE_NPU) {
+        char buf[PATH_MAX];
+        std::string resolved_path;
+        if (realpath(dev_path, buf) != nullptr) {
+            resolved_path = std::string(buf);
+        } else {
+            resolved_path = dev_path;
+        }
+        amdcuid_npu_info npu_info = {};
+        status = CuidNpu::discover_single(&npu_info, resolved_path);
+        if (status != AMDCUID_STATUS_SUCCESS) {
+            return nullptr;
+        }
+        return std::make_shared<CuidNpu>(npu_info);
+    }
+
     int fd = open(dev_path, O_RDONLY);
     if (fd < 0) {
         // unable to open device path
@@ -334,9 +355,12 @@ amdcuid_status_t amdcuid_get_handle_by_bdf(const char* bdf, amdcuid_device_type_
         return AMDCUID_STATUS_DEVICE_NOT_FOUND;
     }
     std::string real_dev_path = device_path;
-    // if device is not a nic, attempt to resolve real device path in case of symlink for more reliable matching
-    if (device_type != AMDCUID_DEVICE_TYPE_NIC
-        || device_path.find("net") == std::string::npos) {
+    // if device is not a nic or npu, attempt to resolve real device path in case of symlink for more reliable matching.
+    // NPU paths from bdf_to_device_path may be PCI device directories (not char/block devices),
+    // so the fd-based real path resolution would fail.
+    if ((device_type != AMDCUID_DEVICE_TYPE_NIC
+         || device_path.find("net") == std::string::npos)
+        && device_type != AMDCUID_DEVICE_TYPE_NPU) {
         int fd = open(device_path.c_str(), O_RDONLY);
         if (fd < 0) {
             return AMDCUID_STATUS_DEVICE_NOT_FOUND;

--- a/projects/cuid/lib/src/cuid.cc
+++ b/projects/cuid/lib/src/cuid.cc
@@ -219,6 +219,7 @@ amdcuid_status_t amdcuid_get_handle_by_dev_path(const char* dev_path, amdcuid_de
         || dev_path_str.find("/sys/class/net/") != std::string::npos
         || dev_path_str.find("/sys/class/drm/") != std::string::npos
         || dev_path_str.find("/sys/class/accel/") != std::string::npos
+        || dev_path_str.find("/sys/bus/pci/devices/") != std::string::npos
         || dev_path_str.find("/sys/devices/system/cpu/") != std::string::npos) {
         real_dev_path = dev_path_str;
     } else {

--- a/projects/cuid/lib/src/cuid.cc
+++ b/projects/cuid/lib/src/cuid.cc
@@ -28,6 +28,7 @@
 #include "src/cuid_cpu.h"
 #include "src/cuid_gpu.h"
 #include "src/cuid_nic.h"
+#include "src/cuid_npu.h"
 #include "src/cuid_platform.h"
 #include "src/hmac.h"
 #include <climits>
@@ -180,6 +181,15 @@ DevicePtr discover_device_by_path(const char* dev_path, amdcuid_device_type_t de
             device = std::make_shared<CuidNic>(nic_info);
             break;
         }
+        case AMDCUID_DEVICE_TYPE_NPU: {
+            amdcuid_npu_info npu_info = {};
+            status = CuidNpu::discover_single(&npu_info, real_dev_path);
+            if (status != AMDCUID_STATUS_SUCCESS) {
+                return nullptr;
+            }
+            device = std::make_shared<CuidNpu>(npu_info);
+            break;
+        }
         default:
             return nullptr;
     }
@@ -205,8 +215,10 @@ amdcuid_status_t amdcuid_get_handle_by_dev_path(const char* dev_path, amdcuid_de
         || device_type == AMDCUID_DEVICE_TYPE_GPU
         || device_type == AMDCUID_DEVICE_TYPE_CPU
         || device_type == AMDCUID_DEVICE_TYPE_PLATFORM
+        || device_type == AMDCUID_DEVICE_TYPE_NPU
         || dev_path_str.find("/sys/class/net/") != std::string::npos
         || dev_path_str.find("/sys/class/drm/") != std::string::npos
+        || dev_path_str.find("/sys/class/accel/") != std::string::npos
         || dev_path_str.find("/sys/devices/system/cpu/") != std::string::npos) {
         real_dev_path = dev_path_str;
     } else {

--- a/projects/cuid/lib/src/cuid_device.cc
+++ b/projects/cuid/lib/src/cuid_device.cc
@@ -25,6 +25,7 @@
 #include "cuid_cpu.h"
 #include "cuid_gpu.h"
 #include "cuid_nic.h"
+#include "cuid_npu.h"
 #include "cuid_platform.h"
 #include "cuid_file.h"
 #include <dirent.h>
@@ -128,6 +129,21 @@ amdcuid_status_t CuidDevice::get_derived_cuid(amdcuid_derived_id& id, cuid_hmac 
                         const auto& info = nic->get_info();
                         CuidFileEntry entry;
                         amdcuid_status_t status = derived_file.find_by_device_node(info.network_interface, entry);
+                        if (status == AMDCUID_STATUS_SUCCESS) {
+                            build_derived_id_from_file_entry(entry, id);
+                            return AMDCUID_STATUS_SUCCESS;
+                        }
+                    }
+                }
+                break;
+            case AMDCUID_DEVICE_TYPE_NPU:
+                // search by accel node
+                {
+                    auto npu = reinterpret_cast<CuidNpu*>(const_cast<CuidDevice*>(this));
+                    if (npu) {
+                        const auto& info = npu->get_info();
+                        CuidFileEntry entry;
+                        amdcuid_status_t status = derived_file.find_by_device_node(info.accel_node, entry);
                         if (status == AMDCUID_STATUS_SUCCESS) {
                             build_derived_id_from_file_entry(entry, id);
                             return AMDCUID_STATUS_SUCCESS;

--- a/projects/cuid/lib/src/cuid_device_manager.cc
+++ b/projects/cuid/lib/src/cuid_device_manager.cc
@@ -25,6 +25,7 @@
 #include "src/cuid_gpu.h"
 #include "src/cuid_cpu.h"
 #include "src/cuid_nic.h"
+#include "src/cuid_npu.h"
 #include "src/cuid_platform.h"
 #include "src/cuid_util.h"
 #include "src/ipc_protocol.h"
@@ -174,14 +175,27 @@ amdcuid_status_t CuidDeviceManager::get_devices_on_system() {
             discovered_devices.push_back(nic);
         }
     }
-
+    // Discover NPU devices
+    std::vector<DevicePtr> npu_devices;
+    status = CuidNpu::discover(npu_devices);
     if (status == AMDCUID_STATUS_SUCCESS) {
+        for (const auto& npu : npu_devices) {
+            discovered_devices.push_back(npu);
+        }
+    }
+
+    // Accept discovered devices if any were found, regardless of
+    // individual subsystem discover() return codes. Some subsystems
+    // (e.g., NPU) may legitimately return UNSUPPORTED on systems
+    // that lack those devices.
+    if (!discovered_devices.empty()) {
         std::lock_guard<std::mutex> lock(manager_mutex_);
         devices_.clear();
         devices_ = discovered_devices;
     }
 
-    return status;
+    return discovered_devices.empty() ? AMDCUID_STATUS_DEVICE_NOT_FOUND
+                                      : AMDCUID_STATUS_SUCCESS;
 }
 
 // helper function to convert CuidFileEntry to appropriate CuidDevice
@@ -242,7 +256,17 @@ void _convert_entry_to_device(CuidFileEntry& entry, DevicePtr& device){
             device = std::make_shared<CuidNic>(nic_info);
             break;
         }
-        // Add cases for other device types as needed
+        case AMDCUID_DEVICE_TYPE_NPU: {
+            amdcuid_npu_info npu_info = {};
+            npu_info.header.fields.npu.vendor_id = entry.vendor_id;
+            npu_info.header.fields.npu.device_id = entry.device_id;
+            npu_info.header.fields.npu.pci_class = entry.pci_class;
+            npu_info.header.fields.npu.revision_id = entry.revision_id;
+            npu_info.accel_node = entry.device_node;
+            npu_info.bdf = entry.bdf;
+            device = std::make_shared<CuidNpu>(npu_info);
+            break;
+        }
         default: {
             device = nullptr;
             break;

--- a/projects/cuid/lib/src/cuid_device_manager.h
+++ b/projects/cuid/lib/src/cuid_device_manager.h
@@ -45,6 +45,7 @@ typedef enum {
     AMDCUID_DEVICE_TYPE_SET_CPU       = 1U << AMDCUID_DEVICE_TYPE_CPU,      ///< CPU devices
     AMDCUID_DEVICE_TYPE_SET_GPU       = 1U << AMDCUID_DEVICE_TYPE_GPU,      ///< GPU devices
     AMDCUID_DEVICE_TYPE_SET_NIC       = 1U << AMDCUID_DEVICE_TYPE_NIC,      ///< NIC devices
+    AMDCUID_DEVICE_TYPE_SET_NPU       = 1U << AMDCUID_DEVICE_TYPE_NPU,      ///< NPU devices
     AMDCUID_DEVICE_TYPE_SET_ALL       = -1U                                    ///< All device types
 } amdcuid_device_type_set_t;
 

--- a/projects/cuid/lib/src/cuid_file.cc
+++ b/projects/cuid/lib/src/cuid_file.cc
@@ -25,6 +25,7 @@
 #include "src/cuid_gpu.h"
 #include "src/cuid_cpu.h"
 #include "src/cuid_nic.h"
+#include "src/cuid_npu.h"
 #include "src/cuid_platform.h"
 #include "src/hmac.h"
 #include "src/cuid_internal.h"
@@ -332,6 +333,7 @@ amdcuid_device_type_t CuidFile::string_to_device_type(const std::string& str) co
     if (str == "CPU") return AMDCUID_DEVICE_TYPE_CPU;
     if (str == "GPU") return AMDCUID_DEVICE_TYPE_GPU;
     if (str == "NIC") return AMDCUID_DEVICE_TYPE_NIC;
+    if (str == "NPU") return AMDCUID_DEVICE_TYPE_NPU;
     return AMDCUID_DEVICE_TYPE_NONE;
 }
 
@@ -522,6 +524,7 @@ amdcuid_status_t CuidFile::save() {
         AMDCUID_DEVICE_TYPE_GPU,
         AMDCUID_DEVICE_TYPE_CPU,
         AMDCUID_DEVICE_TYPE_NIC,
+        AMDCUID_DEVICE_TYPE_NPU,
         AMDCUID_DEVICE_TYPE_PLATFORM
     };
     
@@ -830,6 +833,19 @@ amdcuid_status_t CuidFileGenerator::generate_from_devices(
                     if (nic->get_mac_address(mac_address) == AMDCUID_STATUS_SUCCESS) {
                         entry.mac_address = mac_address;
                     }
+                    entry.bdf = info.bdf;
+                }
+                break;
+            }
+            case AMDCUID_DEVICE_TYPE_NPU: {
+                auto npu = std::dynamic_pointer_cast<CuidNpu>(device);
+                if (npu) {
+                    const auto& info = npu->get_info();
+                    entry.vendor_id = info.header.fields.npu.vendor_id;
+                    entry.device_id = info.header.fields.npu.device_id;
+                    entry.revision_id = info.header.fields.npu.revision_id;
+                    entry.pci_class = info.header.fields.npu.pci_class;
+                    entry.device_node = info.accel_node;
                     entry.bdf = info.bdf;
                 }
                 break;

--- a/projects/cuid/lib/src/cuid_internal.h
+++ b/projects/cuid/lib/src/cuid_internal.h
@@ -36,6 +36,13 @@ typedef struct {
     uint16_t vendor_id;
 } amdcuid_cuid_public_fields_platform;
 
+typedef struct {
+    uint16_t vendor_id;
+    uint16_t device_id;
+    uint16_t pci_class;
+    uint8_t revision_id;
+} amdcuid_cuid_public_fields_npu;
+
 typedef struct amdcuid_cuid_public_fields {
     amdcuid_device_type_t device_type;
     union {
@@ -43,6 +50,7 @@ typedef struct amdcuid_cuid_public_fields {
         amdcuid_cuid_public_fields_gpu gpu;
         amdcuid_cuid_public_fields_nic nic;
         amdcuid_cuid_public_fields_platform platform;
+        amdcuid_cuid_public_fields_npu npu;
     } fields;
 } amdcuid_cuid_public_fields;
 

--- a/projects/cuid/lib/src/cuid_npu.cc
+++ b/projects/cuid/lib/src/cuid_npu.cc
@@ -35,9 +35,12 @@
 // AMD vendor ID used to filter for AMD NPU devices
 static const uint16_t AMD_VENDOR_ID = 0x1022;
 
-// PCI class for "Processing accelerators" (class 0x12)
-static const uint16_t PCI_CLASS_PROCESSING_ACCEL = 0x1200;
-static const uint16_t PCI_CLASS_MASK = 0xFF00;
+// PCI base classes that AMD NPUs may present as:
+//   0x11 = Signal processing controller (e.g., Strix/Strix Halo NPU 0x1180)
+//   0x12 = Processing accelerators
+static const uint16_t PCI_CLASS_SIGNAL_PROCESSING = 0x1100;
+static const uint16_t PCI_CLASS_PROCESSING_ACCEL  = 0x1200;
+static const uint16_t PCI_CLASS_BASE_MASK = 0xFF00;
 
 CuidNpu::CuidNpu(const amdcuid_npu_info& i) : m_info(i) {}
 
@@ -123,7 +126,9 @@ static amdcuid_status_t discover_via_pci_bus(std::vector<DevicePtr>& npus) {
         // sysfs class is 24-bit (class:subclass:prog_if), shift to get class:subclass
         uint16_t pci_class =
             static_cast<uint16_t>(strtol(class_str.c_str(), nullptr, 16) >> 8);
-        if ((pci_class & PCI_CLASS_MASK) != PCI_CLASS_PROCESSING_ACCEL)
+        uint16_t base_class = pci_class & PCI_CLASS_BASE_MASK;
+        if (base_class != PCI_CLASS_PROCESSING_ACCEL &&
+            base_class != PCI_CLASS_SIGNAL_PROCESSING)
             continue;
 
         amdcuid_npu_info info = {};

--- a/projects/cuid/lib/src/cuid_npu.cc
+++ b/projects/cuid/lib/src/cuid_npu.cc
@@ -1,0 +1,374 @@
+/*
+ * Copyright (c) Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#include "cuid_npu.h"
+#include "cuid_file.h"
+#include "cuid_util.h"
+#include "pci_util.h"
+#include <cstring>
+#include <dirent.h>
+#include <fstream>
+#include <iostream>
+#include <sstream>
+#include <sys/types.h>
+#include <unistd.h>
+
+// AMD vendor ID used to filter for AMD NPU devices
+static const uint16_t AMD_VENDOR_ID = 0x1022;
+
+// PCI class for "Processing accelerators" (class 0x12)
+static const uint16_t PCI_CLASS_PROCESSING_ACCEL = 0x1200;
+static const uint16_t PCI_CLASS_MASK = 0xFF00;
+
+CuidNpu::CuidNpu(const amdcuid_npu_info& i) : m_info(i) {}
+
+// Helper to check if a /sys/class/accel entry name is an accel device
+// (e.g., "accel0", "accel1").
+static bool is_accel_entry(const char* name) {
+    if (strncmp(name, "accel", 5) != 0 || !isdigit(name[5]))
+        return false;
+    for (size_t i = 5; name[i] != '\0'; ++i) {
+        if (!isdigit(name[i]))
+            return false;
+    }
+    return true;
+}
+
+// Discover NPU devices via /sys/class/accel (when amdxdna driver is loaded)
+static amdcuid_status_t discover_via_accel(std::vector<DevicePtr>& npus) {
+    const char* accel_path = "/sys/class/accel";
+    DIR* dir = opendir(accel_path);
+    if (!dir)
+        return AMDCUID_STATUS_UNSUPPORTED;
+
+    struct dirent* entry;
+    while ((entry = readdir(dir)) != NULL) {
+        if (is_accel_entry(entry->d_name)) {
+            std::string accel_name(entry->d_name);
+            std::string device_path =
+                std::string(accel_path) + "/" + accel_name + "/device";
+
+            // Read vendor to filter for AMD NPU devices only
+            std::string vendor_str =
+                CuidUtilities::read_sysfs_file(device_path + "/vendor");
+            if (vendor_str.empty())
+                continue;
+            uint16_t vendor_id =
+                static_cast<uint16_t>(strtol(vendor_str.c_str(), nullptr, 16));
+            if (vendor_id != AMD_VENDOR_ID)
+                continue;
+
+            amdcuid_npu_info info = {};
+            amdcuid_status_t status = CuidNpu::discover_single(&info, device_path);
+            if (status != AMDCUID_STATUS_SUCCESS)
+                continue;
+
+            npus.emplace_back(std::make_shared<CuidNpu>(info));
+        }
+    }
+    closedir(dir);
+
+    return npus.empty() ? AMDCUID_STATUS_UNSUPPORTED : AMDCUID_STATUS_SUCCESS;
+}
+
+// Fallback: discover NPU devices by scanning PCI bus for AMD processing
+// accelerator class devices. This handles systems where /sys/class/accel
+// is not populated (e.g., driver not loaded or accel subsystem absent).
+static amdcuid_status_t discover_via_pci_bus(std::vector<DevicePtr>& npus) {
+    const char* pci_path = "/sys/bus/pci/devices";
+    DIR* dir = opendir(pci_path);
+    if (!dir)
+        return AMDCUID_STATUS_UNSUPPORTED;
+
+    struct dirent* entry;
+    while ((entry = readdir(dir)) != NULL) {
+        if (entry->d_name[0] == '.')
+            continue;
+
+        std::string device_path =
+            std::string(pci_path) + "/" + entry->d_name;
+
+        std::string vendor_str =
+            CuidUtilities::read_sysfs_file(device_path + "/vendor");
+        if (vendor_str.empty())
+            continue;
+        uint16_t vendor_id =
+            static_cast<uint16_t>(strtol(vendor_str.c_str(), nullptr, 16));
+        if (vendor_id != AMD_VENDOR_ID)
+            continue;
+
+        std::string class_str =
+            CuidUtilities::read_sysfs_file(device_path + "/class");
+        if (class_str.empty())
+            continue;
+        // sysfs class is 24-bit (class:subclass:prog_if), shift to get class:subclass
+        uint16_t pci_class =
+            static_cast<uint16_t>(strtol(class_str.c_str(), nullptr, 16) >> 8);
+        if ((pci_class & PCI_CLASS_MASK) != PCI_CLASS_PROCESSING_ACCEL)
+            continue;
+
+        amdcuid_npu_info info = {};
+        amdcuid_status_t status = CuidNpu::discover_single(&info, device_path);
+        if (status != AMDCUID_STATUS_SUCCESS)
+            continue;
+
+        npus.emplace_back(std::make_shared<CuidNpu>(info));
+    }
+    closedir(dir);
+
+    return npus.empty() ? AMDCUID_STATUS_UNSUPPORTED : AMDCUID_STATUS_SUCCESS;
+}
+
+amdcuid_status_t CuidNpu::discover(std::vector<DevicePtr>& npus) {
+    // Try /sys/class/accel first (when amdxdna driver is loaded)
+    amdcuid_status_t status = discover_via_accel(npus);
+    if (status == AMDCUID_STATUS_SUCCESS)
+        return status;
+
+    // Fallback: scan PCI bus for processing accelerator class devices
+    return discover_via_pci_bus(npus);
+}
+
+amdcuid_status_t CuidNpu::discover_single(amdcuid_npu_info* npu_info,
+                                           const std::string& device_path) {
+    amdcuid_npu_info info = {};
+    std::string bdf = CuidUtilities::readlink_bdf(device_path);
+
+    std::string vendor =
+        CuidUtilities::read_sysfs_file(device_path + "/vendor");
+    if (vendor.empty() && !bdf.empty()) {
+        uint8_t vendor_id_bytes[2] = {0};
+        const uint16_t offset = 0x0;
+        amdcuid_status_t status =
+            PciUtil::read_pci_config_space(bdf, vendor_id_bytes, 2, offset);
+        uint16_t vendor_id_int =
+            PciUtil::le16_to_be16(*reinterpret_cast<uint16_t*>(vendor_id_bytes));
+        info.header.fields.npu.vendor_id =
+            (status == AMDCUID_STATUS_SUCCESS) ? vendor_id_int : 0;
+    } else {
+        info.header.fields.npu.vendor_id =
+            static_cast<uint16_t>(strtol(vendor.c_str(), nullptr, 16));
+    }
+
+    std::string device =
+        CuidUtilities::read_sysfs_file(device_path + "/device");
+    if (device.empty() && !bdf.empty()) {
+        uint8_t device_id_bytes[2] = {0};
+        const uint16_t offset = 0x2;
+        amdcuid_status_t status =
+            PciUtil::read_pci_config_space(bdf, device_id_bytes, 2, offset);
+        uint16_t device_id_int =
+            PciUtil::le16_to_be16(*reinterpret_cast<uint16_t*>(device_id_bytes));
+        info.header.fields.npu.device_id =
+            (status == AMDCUID_STATUS_SUCCESS) ? device_id_int : 0;
+    } else {
+        info.header.fields.npu.device_id =
+            static_cast<uint16_t>(strtol(device.c_str(), nullptr, 16));
+    }
+
+    std::string pci_class =
+        CuidUtilities::read_sysfs_file(device_path + "/class");
+    uint16_t pci_class_integer = 0;
+    if (pci_class.empty() && !bdf.empty()) {
+        uint8_t class_id_bytes[2] = {0};
+        const uint16_t offset = 0xa;
+        amdcuid_status_t status =
+            PciUtil::read_pci_config_space(bdf, class_id_bytes, 2, offset);
+        uint16_t class_id_int =
+            PciUtil::le16_to_be16(*reinterpret_cast<uint16_t*>(class_id_bytes));
+        pci_class_integer =
+            (status == AMDCUID_STATUS_SUCCESS) ? class_id_int : 0;
+    } else {
+        // sysfs class file returns 24-bit value (class:subclass:prog_if),
+        // shift right by 8 to get 16-bit class:subclass
+        pci_class_integer =
+            static_cast<uint16_t>(strtol(pci_class.c_str(), nullptr, 16) >> 8);
+    }
+    info.header.fields.npu.pci_class = pci_class_integer;
+
+    std::string revision_id =
+        CuidUtilities::read_sysfs_file(device_path + "/revision");
+    if (revision_id.empty() && !bdf.empty()) {
+        uint8_t revision_id_bytes[2] = {0};
+        const uint16_t offset = 0x8;
+        amdcuid_status_t status =
+            PciUtil::read_pci_config_space(bdf, revision_id_bytes, 2, offset);
+        uint16_t revision_id_int =
+            PciUtil::le16_to_be16(*reinterpret_cast<uint16_t*>(revision_id_bytes));
+        info.header.fields.npu.revision_id =
+            (status == AMDCUID_STATUS_SUCCESS)
+                ? static_cast<uint8_t>(revision_id_int)
+                : 0;
+    } else {
+        info.header.fields.npu.revision_id =
+            static_cast<uint8_t>(strtol(revision_id.c_str(), nullptr, 16));
+    }
+
+    // Determine the device node path.
+    // If discovered through /sys/class/accel, strip the /device suffix.
+    // If discovered through /sys/bus/pci/devices, try to resolve the accel
+    // node; if that fails, store the PCI device path as-is.
+    std::string full_device_node;
+    if (device_path.find("/sys/class/accel/") != std::string::npos) {
+        size_t last_slash = device_path.rfind('/');
+        if (last_slash != std::string::npos && last_slash > 0) {
+            full_device_node = device_path.substr(0, last_slash);
+        } else {
+            full_device_node = device_path;
+        }
+    } else if (!bdf.empty()) {
+        // Try to resolve /sys/bus/pci/devices/<bdf>/accel/accelN
+        std::string resolved =
+            CuidUtilities::bdf_to_device_path(bdf, AMDCUID_DEVICE_TYPE_NPU);
+        if (!resolved.empty()) {
+            full_device_node = resolved;
+        } else {
+            full_device_node = device_path;
+        }
+    } else {
+        full_device_node = device_path;
+    }
+
+    info.header.device_type = AMDCUID_DEVICE_TYPE_NPU;
+    info.bdf = bdf;
+    info.accel_node = full_device_node;
+
+    *npu_info = info;
+
+    return AMDCUID_STATUS_SUCCESS;
+}
+
+amdcuid_status_t
+CuidNpu::get_hardware_fingerprint(uint64_t& fingerprint) const {
+    if (geteuid() != 0) {
+        return AMDCUID_STATUS_PERMISSION_DENIED;
+    }
+
+    // Attempt to get fingerprint through PCI Config Space DSN capability
+    uint16_t offset = 0;
+    amdcuid_status_t status =
+        PciUtil::get_pci_cap_offset(m_info.bdf, 0x03, offset);
+    if (status == AMDCUID_STATUS_SUCCESS) {
+        const uint8_t fingerprint_size = 8;
+        uint8_t fingerprint_bytes[fingerprint_size] = {0};
+        status = PciUtil::read_pci_config_space(
+            m_info.bdf, fingerprint_bytes, fingerprint_size, offset);
+        if (status == AMDCUID_STATUS_SUCCESS) {
+            fingerprint = PciUtil::le64_to_be64(
+                *reinterpret_cast<uint64_t*>(fingerprint_bytes));
+            return AMDCUID_STATUS_SUCCESS;
+        }
+    }
+
+    // If DSN capability is not available, construct a fingerprint from
+    // PCI vendor/device/revision IDs as a fallback. This fingerprint is
+    // not unique per device instance — all NPUs of the same model will
+    // produce the same value. This is acceptable for integrated NPUs
+    // (one per SoC). If discrete NPU parts appear in the future, a
+    // unique identifier source (e.g., fuse ID) will be needed.
+    fingerprint = (static_cast<uint64_t>(m_info.header.fields.npu.vendor_id) << 32) |
+                  (static_cast<uint64_t>(m_info.header.fields.npu.device_id) << 16) |
+                  static_cast<uint64_t>(m_info.header.fields.npu.revision_id);
+    return AMDCUID_STATUS_SUCCESS;
+}
+
+amdcuid_status_t CuidNpu::get_primary_cuid(amdcuid_primary_id& id) const {
+    if (geteuid() != 0) {
+        return AMDCUID_STATUS_PERMISSION_DENIED;
+    }
+
+    // Attempt to read the CUID from the file first
+    std::string cuid_file_path = CuidUtilities::priv_cuid_file();
+    CuidFile primary_file(cuid_file_path, false);
+    primary_file.load();
+
+    CuidFileEntry entry;
+    amdcuid_status_t status =
+        primary_file.find_by_device_node(m_info.accel_node, entry);
+    if (status == AMDCUID_STATUS_SUCCESS) {
+        id.UUIDv8_representation = entry.primary_cuid;
+        CuidUtilities::remove_UUIDv8_bits(&id.UUIDv8_representation,
+                                          id.raw_bits);
+        return AMDCUID_STATUS_SUCCESS;
+    }
+
+    // Primary CUID not found in file, so generate it
+    uint64_t fingerprint = 0;
+    status = get_hardware_fingerprint(fingerprint);
+    if (status != AMDCUID_STATUS_SUCCESS) {
+        std::memset(&id, 0, sizeof(id));
+        return status;
+    }
+
+    status = CuidUtilities::generate_primary_cuid(
+        fingerprint,
+        0,  // unit_id: NPUs are not partitioned
+        m_info.header.fields.npu.revision_id,
+        m_info.header.fields.npu.device_id,
+        m_info.header.fields.npu.vendor_id,
+        static_cast<uint8_t>(AMDCUID_DEVICE_TYPE_NPU),
+        &id);
+    if (status != AMDCUID_STATUS_SUCCESS) {
+        std::memset(&id, 0, sizeof(id));
+        return status;
+    }
+
+    return status;
+}
+
+const amdcuid_npu_info& CuidNpu::get_info() const { return m_info; }
+
+amdcuid_status_t CuidNpu::get_vendor_id(uint16_t& vendor_id) const {
+    vendor_id = m_info.header.fields.npu.vendor_id;
+    return AMDCUID_STATUS_SUCCESS;
+}
+
+amdcuid_status_t CuidNpu::get_device_id(uint16_t& device_id) const {
+    device_id = m_info.header.fields.npu.device_id;
+    return AMDCUID_STATUS_SUCCESS;
+}
+
+amdcuid_status_t CuidNpu::get_pci_class(uint16_t& pci_class) const {
+    pci_class = m_info.header.fields.npu.pci_class;
+    return AMDCUID_STATUS_SUCCESS;
+}
+
+amdcuid_status_t CuidNpu::get_revision_id(uint8_t& revision_id) const {
+    revision_id = m_info.header.fields.npu.revision_id;
+    return AMDCUID_STATUS_SUCCESS;
+}
+
+amdcuid_status_t CuidNpu::get_bdf(std::string& bdf) const {
+    if (m_info.bdf.empty()) {
+        return AMDCUID_STATUS_UNSUPPORTED;
+    }
+    bdf = m_info.bdf;
+    return AMDCUID_STATUS_SUCCESS;
+}
+
+amdcuid_status_t CuidNpu::get_device_path(std::string& path) const {
+    if (m_info.accel_node.empty()) {
+        return AMDCUID_STATUS_UNSUPPORTED;
+    }
+    path = m_info.accel_node;
+    return AMDCUID_STATUS_SUCCESS;
+}

--- a/projects/cuid/lib/src/cuid_npu.h
+++ b/projects/cuid/lib/src/cuid_npu.h
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#ifndef CUID_NPU_H
+#define CUID_NPU_H
+
+#include "include/amd_cuid.h"
+#include "src/cuid_device.h"
+#include "src/cuid_internal.h"
+#include <memory>
+#include <string>
+#include <vector>
+
+struct amdcuid_npu_info {
+    amdcuid_cuid_public_fields header;
+    // Accel device node: /sys/class/accel/accelN
+    std::string accel_node;
+    std::string bdf;
+};
+
+class CuidNpu : public CuidDevice {
+public:
+    CuidNpu(const amdcuid_npu_info& i);
+    amdcuid_device_type_t type() const override { return AMDCUID_DEVICE_TYPE_NPU; }
+    amdcuid_status_t get_primary_cuid(amdcuid_primary_id& id) const override;
+    amdcuid_status_t get_hardware_fingerprint(uint64_t& fingerprint) const override;
+    static amdcuid_status_t discover(std::vector<DevicePtr>& npus);
+    static amdcuid_status_t discover_single(amdcuid_npu_info* npu_info,
+                                            const std::string& device_path);
+
+    // Virtual accessor overrides
+    amdcuid_status_t get_vendor_id(uint16_t& vendor_id) const override;
+    amdcuid_status_t get_device_id(uint16_t& device_id) const override;
+    amdcuid_status_t get_pci_class(uint16_t& pci_class) const override;
+    amdcuid_status_t get_revision_id(uint8_t& revision_id) const override;
+    amdcuid_status_t get_bdf(std::string& bdf) const override;
+    amdcuid_status_t get_device_path(std::string& path) const override;
+
+    const amdcuid_npu_info& get_info() const;
+
+private:
+    amdcuid_npu_info m_info;
+};
+
+#endif // CUID_NPU_H

--- a/projects/cuid/lib/src/cuid_util.cc
+++ b/projects/cuid/lib/src/cuid_util.cc
@@ -179,6 +179,11 @@ CuidUtilities::bdf_to_device_path(const std::string &bdf,
       }
       closedir(dir);
     }
+    // Fallback: when /sys/class/accel/ is not populated (e.g., amdxdna
+    // driver not loaded), return the PCI device path itself if it exists.
+    if (access(pci_device_path.c_str(), F_OK) == 0) {
+      return pci_device_path;
+    }
   }
 
   return "";

--- a/projects/cuid/lib/src/cuid_util.cc
+++ b/projects/cuid/lib/src/cuid_util.cc
@@ -159,6 +159,26 @@ CuidUtilities::bdf_to_device_path(const std::string &bdf,
       }
       closedir(dir);
     }
+  } else if (device_type == AMDCUID_DEVICE_TYPE_NPU) {
+    subsystem_dir = pci_device_path + "/accel";
+    DIR *dir = opendir(subsystem_dir.c_str());
+    if (dir) {
+      struct dirent *entry;
+      while ((entry = readdir(dir)) != nullptr) {
+        // Skip . and ..
+        if (entry->d_name[0] == '.')
+          continue;
+        // Match accelN entries
+        if (strncmp(entry->d_name, "accel", 5) == 0 &&
+            isdigit(entry->d_name[5])) {
+          std::string device_path =
+              "/sys/class/accel/" + std::string(entry->d_name) + "/device";
+          closedir(dir);
+          return device_path;
+        }
+      }
+      closedir(dir);
+    }
   }
 
   return "";
@@ -615,6 +635,8 @@ std::string CuidUtilities::device_type_to_string(amdcuid_device_type_t type) {
     return "GPU";
   case AMDCUID_DEVICE_TYPE_NIC:
     return "NIC";
+  case AMDCUID_DEVICE_TYPE_NPU:
+    return "NPU";
   default:
     return "UNKNOWN";
   }


### PR DESCRIPTION
## Motivation

Add NPU device support to CUID so RyzenAI/amdxdna devices are discoverable and assigned unique identifiers.

## Technical Details

Introduce CuidNpu class with discovery via accel, primary/derived CUID generation, PCI config space fingerprinting, and wire NPU through the daemon, CLI, device manager, and file serialization paths.

## JIRA ID

ROCM-20752

## Test Plan

Verified NPU discovery, CUID generation, and CLI listing/querying (--type npu, --list, --query-device) on a system with an amdxdna accel device.

## Test Result

NPU devices are correctly discovered, assigned primary and derived CUIDs, persisted to the CUID file, and displayed via CLI; existing GPU/CPU/NIC/platform paths remain unaffected.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
