### PR TITLE
[rccl-tests]: add ionic (AINIC) support to network counter col…

### DIFF
--- a/projects/rccl-tests/src/collector.cu
+++ b/projects/rccl-tests/src/collector.cu
@@ -26,25 +26,35 @@ struct CounterRegistryEntry {
   const char*   name;
   CounterSource source;
   bool          is_prefix;
+  // bnxt_re (Thor2): actual hw_counters filename when it differs from name
+  //   NULL → use canonical name as-is
+  const char*   bnxt_key;
+  bool          bnxt_valid; // false → not displayed on bnxt_re
+  // ionic (AINIC): actual hw_counters filename, NULL → counter not on ionic
+  const char*   ionic_key;
+  CounterSource ionic_source;
 };
 
 static const CounterRegistryEntry counter_registry[] = {
-  // ethtool – PFC frame counters (prefix → expands to name0..name7)
-  {"rx_pfc_ena_frames_pri",   COUNTER_SRC_ETHTOOL,  true},
-  {"tx_pfc_ena_frames_pri",   COUNTER_SRC_ETHTOOL,  true},
-  // ethtool – PFC transition counters (exact)
-  {"pfc_pri3_rx_transitions", COUNTER_SRC_ETHTOOL,  false},
-  {"pfc_pri3_tx_transitions", COUNTER_SRC_ETHTOOL,  false},
-  // IB hw_counters
-  {"rx_cnp_pkts",             COUNTER_SRC_IB_HW,    false},
-  {"tx_cnp_pkts",             COUNTER_SRC_IB_HW,    false},
-  {"rx_roce_discards",        COUNTER_SRC_IB_HW,    false},
-  // debugfs (bnxt_re info)
-  {"rx_stat_discards",        COUNTER_SRC_DEBUGFS,   false},
-  {"to_retransmits",          COUNTER_SRC_DEBUGFS,   false},
-  {"max_retry_exceeded",      COUNTER_SRC_DEBUGFS,   false},
-  {"oos_drop_count",          COUNTER_SRC_DEBUGFS,   false},
-  {"seq_err_naks_rcvd",       COUNTER_SRC_DEBUGFS,   false},
+  //                                                                        --------- bnxt_re ---------   ----------- ionic -----------
+  // name                       source               prefix  bnxt_key         bnxt_valid  ionic_key               ionic_source
+  {"rx_pfc_ena_frames_pri",   COUNTER_SRC_ETHTOOL,  true,   NULL,            true,       "frames_rx_pripause",   COUNTER_SRC_ETHTOOL},
+  {"tx_pfc_ena_frames_pri",   COUNTER_SRC_ETHTOOL,  true,   NULL,            true,       "frames_tx_pripause",   COUNTER_SRC_ETHTOOL},
+  {"pfc_pri3_rx_transitions", COUNTER_SRC_ETHTOOL,  false,  NULL,            true,       "frames_rx_pri_3",      COUNTER_SRC_ETHTOOL},
+  {"pfc_pri3_tx_transitions", COUNTER_SRC_ETHTOOL,  false,  NULL,            true,       "frames_tx_pri_3",      COUNTER_SRC_ETHTOOL},
+  {"rx_cnp_pkts",             COUNTER_SRC_IB_HW,    false,  "rp_cnp_handled",true,       "rx_rdma_cnp_pkts",     COUNTER_SRC_IB_HW},
+  {"tx_cnp_pkts",             COUNTER_SRC_IB_HW,    false,  "np_cnp_sent",   true,       "tx_rdma_cnp_pkts",     COUNTER_SRC_IB_HW},
+  {"rx_roce_discards",        COUNTER_SRC_IB_HW,    false,  NULL,            true,       "rx_rdma_mtu_discard_pkts", COUNTER_SRC_IB_HW},
+  {"rx_stat_discards",        COUNTER_SRC_IB_HW,    false,  "rx_roce_errors",true,       "resp_rx_outof_buf",    COUNTER_SRC_IB_HW},
+  {"to_retransmits",          COUNTER_SRC_IB_HW,    false,  "roce_adp_retrans",true,     "tx_rdma_ack_timeout",  COUNTER_SRC_IB_HW},
+  {"max_retry_exceeded",      COUNTER_SRC_IB_HW,    false,  NULL,            true,       "req_tx_retry_excd_err",COUNTER_SRC_IB_HW},
+  {"oos_drop_count",          COUNTER_SRC_IB_HW,    false,  "out_of_buffer", true,       "resp_rx_outouf_seq",   COUNTER_SRC_IB_HW},
+  {"seq_err_naks_rcvd",       COUNTER_SRC_IB_HW,    false,  "out_of_sequence",true,      "req_rx_pkt_seq_err",   COUNTER_SRC_IB_HW},
+  // RDMA throughput – ionic (AINIC) only
+  {"tx_rdma_ucast_bytes",     COUNTER_SRC_IB_HW,    false,  NULL,            false,      "tx_rdma_ucast_bytes",  COUNTER_SRC_IB_HW},
+  {"rx_rdma_ucast_bytes",     COUNTER_SRC_IB_HW,    false,  NULL,            false,      "rx_rdma_ucast_bytes",  COUNTER_SRC_IB_HW},
+  {"tx_rdma_ucast_pkts",      COUNTER_SRC_IB_HW,    false,  NULL,            false,      "tx_rdma_ucast_pkts",   COUNTER_SRC_IB_HW},
+  {"rx_rdma_ucast_pkts",      COUNTER_SRC_IB_HW,    false,  NULL,            false,      "rx_rdma_ucast_pkts",   COUNTER_SRC_IB_HW},
 };
 
 static const int counter_registry_size =
@@ -189,10 +199,11 @@ std::string NetCounterFindIbDeviceForNic(const std::string& nic) {
 }
 
 std::string NetCounterFindNicForIbDevice(const std::string& ib_device) {
+  std::string ib_base = ib_device.substr(0, ib_device.find(':'));
   char cmd[512] = {0};
   snprintf(cmd, sizeof(cmd),
            "ls /sys/class/infiniband/%s/device/net 2>/dev/null | head -1",
-           ib_device.c_str());
+           ib_base.c_str());
   return RunShellOneLiner(cmd);
 }
 
@@ -223,21 +234,72 @@ void NetCounterGetNetworkInterfaces(std::vector<std::string>& interfaces) {
 }
 
 // =====================================================================
+// NIC type detection
+// =====================================================================
+
+NicType NetCounterDetectNicType(const std::string& ib_device) {
+  if (ib_device.empty()) return NIC_UNKNOWN;
+
+  // Strip port suffix (e.g. "rdma0:1" → "rdma0")
+  std::string ib_base = ib_device.substr(0, ib_device.find(':'));
+
+  // "bnxt_reN" is a logical alias even when the sysfs entry does not exist
+  // (kernel 6.8 names devices as "rocep*"); trust the prefix.
+  if (ib_base.compare(0, 7, "bnxt_re") == 0) return NIC_BNXT_RE;
+
+  char link[4096] = {0};
+  std::string driver_path =
+      "/sys/class/infiniband/" + ib_base + "/device/driver";
+  ssize_t len = readlink(driver_path.c_str(), link, sizeof(link) - 1);
+  if (len <= 0) return NIC_UNKNOWN;
+  link[len] = '\0';
+
+  const char* drv = strrchr(link, '/');
+  drv = drv ? drv + 1 : link;
+
+  if (strcmp(drv, "bnxt_re") == 0 || strcmp(drv, "bnxt_en") == 0)
+    return NIC_BNXT_RE;
+  if (strcmp(drv, "ionic") == 0)
+    return NIC_IONIC;
+  return NIC_UNKNOWN;
+}
+
+static const char* NicTypeStr(NicType t) {
+  switch (t) {
+    case NIC_BNXT_RE: return "BNXT_RE";
+    case NIC_IONIC:   return "IONIC";
+    default:          return "UNKNOWN";
+  }
+}
+
+// =====================================================================
 // Per-source collection
 // =====================================================================
 
 static void CollectEthtoolCounters(const std::string& nic,
                                    const std::vector<CounterDescriptor>& selected,
+                                   NicType nic_type,
                                    std::map<std::string, uint64_t>& out) {
   std::set<std::string> exact;
+  std::map<std::string, std::string> key_to_canon; // ethtool key → canonical name
   std::vector<std::string> prefixes;
   for (const auto& d : selected) {
     if (d.source != COUNTER_SRC_ETHTOOL) { continue; }
 
+    const CounterRegistryEntry* e = FindInRegistry(d.name);
+    const char* ethtool_key = d.name.c_str();
+    if (nic_type == NIC_IONIC && e && e->ionic_key &&
+        e->ionic_source == COUNTER_SRC_ETHTOOL) {
+      ethtool_key = e->ionic_key;
+    } else if (nic_type == NIC_BNXT_RE && e && e->bnxt_key) {
+      ethtool_key = e->bnxt_key;
+    }
+
     if (d.is_prefix) {
-      prefixes.push_back(d.name);
+      prefixes.push_back(ethtool_key);
     } else {
-      exact.insert(d.name);
+      exact.insert(ethtool_key);
+      key_to_canon[ethtool_key] = d.name;
     }
   }
   if (exact.empty() && prefixes.empty()) { return; }
@@ -256,7 +318,10 @@ static void CollectEthtoolCounters(const std::string& nic,
       char* start = key;
       while (*start == ' ' || *start == '\t') { start++; }
       std::string k(start);
-      if (exact.count(k)) { out[k] = value; continue; }
+      if (exact.count(k)) {
+        out[key_to_canon.count(k) ? key_to_canon[k] : k] = value;
+        continue;
+      }
       for (const auto& pfx : prefixes) {
         if (k.compare(0, pfx.size(), pfx) == 0) { out[k] = value; break; }
       }
@@ -267,15 +332,38 @@ static void CollectEthtoolCounters(const std::string& nic,
 
 static void CollectIbHwCounters(const std::string& ib_device,
                                 const std::vector<CounterDescriptor>& selected,
+                                NicType nic_type,
                                 std::map<std::string, uint64_t>& out) {
   if (ib_device.empty()) { return; }
 
-  std::string base =
-      "/sys/class/infiniband/" + ib_device + "/ports/1/hw_counters/";
+  std::string ib_base = ib_device.substr(0, ib_device.find(':'));
+  std::string base_port =
+      "/sys/class/infiniband/" + ib_base + "/ports/1/hw_counters/";
+  std::string base_dev =
+      "/sys/class/infiniband/" + ib_base + "/hw_counters/";
 
   for (const auto& d : selected) {
+    const CounterRegistryEntry* e = FindInRegistry(d.name);
+
+    // For ionic: use ionic_key and ionic_source; skip if not on ionic
+    if (nic_type == NIC_IONIC) {
+      if (!e || !e->ionic_key || e->ionic_source != COUNTER_SRC_IB_HW) continue;
+      // Try port-level first, fall back to device-level
+      std::string path = base_port + e->ionic_key;
+      FILE* fp = fopen(path.c_str(), "r");
+      if (!fp) fp = fopen((base_dev + e->ionic_key).c_str(), "r");
+      if (fp) {
+        uint64_t value = 0;
+        if (fscanf(fp, "%lu", &value) == 1) out[d.name] = value;
+        fclose(fp);
+      }
+      continue;
+    }
+
+    // bnxt_re / unknown: original path
     if (d.source != COUNTER_SRC_IB_HW) { continue; }
-    std::string path = base + d.name;
+    const char* hw_key = (e && e->bnxt_key) ? e->bnxt_key : d.name.c_str();
+    std::string path = base_port + hw_key;
     FILE* fp = fopen(path.c_str(), "r");
     if (fp) {
       uint64_t value = 0;
@@ -298,8 +386,9 @@ static void CollectDebugCounters(const std::string& ib_device,
   }
   if (wanted.empty()) { return; }
 
+  std::string ib_base = ib_device.substr(0, ib_device.find(':'));
   std::string info_path =
-      "/sys/kernel/debug/bnxt_re/" + ib_device + "/info";
+      "/sys/kernel/debug/bnxt_re/" + ib_base + "/info";
   FILE* fp = fopen(info_path.c_str(), "r");
   if (!fp) { return; }
 
@@ -348,10 +437,13 @@ NetworkCounterSnapshot NetCounterCollectSnapshot(
   }
 
   snap.timestamp = time(NULL);
+  snap.nic_type = NetCounterDetectNicType(ib_dev);
 
-  CollectEthtoolCounters(nic, selected, snap.counters);
-  CollectIbHwCounters(ib_dev, selected, snap.counters);
-  CollectDebugCounters(ib_dev, selected, snap.counters);
+  CollectEthtoolCounters(nic, selected, snap.nic_type, snap.counters);
+  CollectIbHwCounters(ib_dev, selected, snap.nic_type, snap.counters);
+  if (snap.nic_type != NIC_IONIC) {
+    CollectDebugCounters(ib_dev, selected, snap.counters);
+  }
 
   return snap;
 }
@@ -394,6 +486,33 @@ uint64_t NetCounterComputeDelta(
 }
 
 // =====================================================================
+// NIC-type-aware column filter
+// =====================================================================
+
+std::vector<CounterDescriptor> NetCounterFilterByNicType(
+    const std::vector<CounterDescriptor>& selected,
+    const std::vector<NetworkCounterSnapshot>& snapshots) {
+  if (snapshots.empty()) return selected;
+
+  NicType nic_type = NIC_UNKNOWN;
+  for (size_t i = 0; i < snapshots.size(); i++) {
+    if (snapshots[i].nic_type != NIC_UNKNOWN) { nic_type = snapshots[i].nic_type; break; }
+  }
+
+  if (nic_type == NIC_UNKNOWN) return selected;
+
+  std::vector<CounterDescriptor> result;
+  for (const auto& d : selected) {
+    const CounterRegistryEntry* e = FindInRegistry(d.name);
+    if (!e) { result.push_back(d); continue; }
+    if (nic_type == NIC_IONIC && !e->ionic_key) continue;   // not on ionic
+    if (nic_type == NIC_BNXT_RE && !e->bnxt_valid) continue;
+    result.push_back(d);
+  }
+  return result;
+}
+
+// =====================================================================
 // Table printer
 // =====================================================================
 
@@ -421,6 +540,16 @@ void NetCounterPrintTable(
     return;
   }
 
+  // Filter counters to those valid for the detected NIC type
+  std::vector<CounterDescriptor> active = NetCounterFilterByNicType(selected, before);
+  num_counters = active.size();
+
+  // Determine dominant NIC type for display (ignore NIC_UNKNOWN entries)
+  NicType nic_type = NIC_UNKNOWN;
+  for (size_t n = 0; n < num_nics; n++) {
+    if (before[n].nic_type != NIC_UNKNOWN) { nic_type = before[n].nic_type; break; }
+  }
+
   // Pre-compute deltas, rates, durations
   std::vector<std::vector<uint64_t>> deltas(
       num_nics, std::vector<uint64_t>(num_counters, 0));
@@ -433,7 +562,7 @@ void NetCounterPrintTable(
   for (size_t n = 0; n < num_nics; n++) {
     durations[n] = after[n].timestamp - before[n].timestamp;
     for (size_t c = 0; c < num_counters; c++) {
-      deltas[n][c] = NetCounterComputeDelta(before[n], after[n], selected[c]);
+      deltas[n][c] = NetCounterComputeDelta(before[n], after[n], active[c]);
       rates[n][c] = (durations[n] > 0)
                         ? (double)deltas[n][c] / durations[n]
                         : 0.0;
@@ -473,7 +602,7 @@ void NetCounterPrintTable(
       snprintf(buf, sizeof(buf), "%.2f", rates[n][c]);
       rt_w[c] = std::max(rt_w[c], (int)strlen(buf));
     }
-    int name_len = (int)selected[c].name.size();
+    int name_len = (int)active[c].name.size();
     int pair_w   = cnt_w[c] + 2 + rt_w[c];
     if (name_len > pair_w) {
       rt_w[c] += (name_len - pair_w);
@@ -490,14 +619,14 @@ void NetCounterPrintTable(
   }
 
   // Print
-  printf("\nNET_COUNTER_TABLE: node=%s  rank=%d  duration_sec=%ld\n",
-         hostname, rank, durations[0]);
+  printf("\nNET_COUNTER_TABLE: node=%s  rank=%d  duration_sec=%ld  nic_type=%s\n",
+         hostname, rank, durations[0], NicTypeStr(nic_type));
   printf("%s\n", sep.c_str());
 
   printf("%-*s", nic_w, "Device");
   for (size_t c = 0; c < num_counters; c++) {
     int pair_w = cnt_w[c] + 2 + rt_w[c];
-    printf("  %-*s", pair_w, selected[c].name.c_str());
+    printf("  %-*s", pair_w, active[c].name.c_str());
   }
   printf("\n");
 
@@ -511,7 +640,7 @@ void NetCounterPrintTable(
 
   for (size_t n = 0; n < num_nics; n++) {
     printf("%-*s", nic_w, labels[n].c_str());
-    for (size_t c = 0; c < num_counters; c++) {
+    for (size_t c = 0; c < active.size(); c++) {
       printf("  %*lu  %*.2f", cnt_w[c], deltas[n][c], rt_w[c], rates[n][c]);
     }
     printf("\n");

--- a/projects/rccl-tests/src/collector.h
+++ b/projects/rccl-tests/src/collector.h
@@ -7,9 +7,10 @@
 /*************************************************************************
  * Network Counter Collector
  *
- * Self-contained library for collecting Thor2 NIC counters before/after
- * an operation and printing a summary table.  No dependency on NCCL,
- * RCCL, or any GPU runtime -- can be integrated into any application.
+ * Self-contained library for collecting Thor2 / AINIC NIC counters
+ * before/after an operation and printing a summary table.  No dependency
+ * on NCCL, RCCL, or any GPU runtime -- can be integrated into any
+ * application.
  *
  * Environment variables:
  *   RCCL_TESTS_NET_COUNTER_ENABLE=1   – enable collection
@@ -46,11 +47,14 @@ struct CounterDescriptor {
   bool is_prefix;   // true  → prefix match (expands to name0..name7)
 };
 
+typedef enum { NIC_UNKNOWN, NIC_BNXT_RE, NIC_IONIC } NicType;
+
 struct NetworkCounterSnapshot {
   std::map<std::string, uint64_t> counters;
-  char nic_name[256];
-  char ib_device[256];
-  long timestamp;
+  char    nic_name[256];
+  char    ib_device[256];
+  long    timestamp;
+  NicType nic_type;
 };
 
 struct NetworkCounterContext {
@@ -65,6 +69,9 @@ struct NetworkCounterContext {
 };
 
 // ---- public API ---------------------------------------------------------
+
+// Detect NIC type from IB device driver symlink
+NicType NetCounterDetectNicType(const std::string& ib_device);
 
 // Check RCCL_TESTS_NET_COUNTER_ENABLE=1
 bool NetCounterIsEnabled();
@@ -98,6 +105,11 @@ uint64_t NetCounterComputeDelta(
     const NetworkCounterSnapshot& before,
     const NetworkCounterSnapshot& after,
     const CounterDescriptor& desc);
+
+// Filter counter list to only those valid for the NIC types in snapshots
+std::vector<CounterDescriptor> NetCounterFilterByNicType(
+    const std::vector<CounterDescriptor>& selected,
+    const std::vector<NetworkCounterSnapshot>& snapshots);
 
 // Print one table per node to stdout
 void NetCounterPrintTable(

--- a/projects/rccl-tests/src/common.cu
+++ b/projects/rccl-tests/src/common.cu
@@ -1153,12 +1153,15 @@ NetworkCounterContext NetCounterCollectBefore(struct threadArgs* args) {
       ctx.nic_names.push_back(NetCounterFindNicForIbDevice(ib));
     }
   } else {
-    NetCounterGetNetworkInterfaces(ctx.nic_names);
-    if (ctx.nic_names.empty()) { ctx.nic_names.push_back("eth0"); }
-    ctx.ib_names.resize(ctx.nic_names.size());
-    for (size_t i = 0; i < ctx.nic_names.size(); i++) {
-      ctx.ib_names[i] = NetCounterFindIbDeviceForNic(ctx.nic_names[i]);
+    std::vector<std::string> all_nics;
+    NetCounterGetNetworkInterfaces(all_nics);
+    for (const auto& nic : all_nics) {
+      std::string ib = NetCounterFindIbDeviceForNic(nic);
+      if (ib.empty()) continue;
+      ctx.nic_names.push_back(nic);
+      ctx.ib_names.push_back(ib);
     }
+    if (ctx.nic_names.empty()) { ctx.nic_names.push_back("eth0"); ctx.ib_names.push_back(""); }
   }
 
   size_t ndevs = ctx.nic_names.size();
@@ -1168,6 +1171,9 @@ NetworkCounterContext NetCounterCollectBefore(struct threadArgs* args) {
         NetCounterCollectSnapshot(ctx.nic_names[i], ctx.ib_names[i],
                                   ctx.selected_counters);
   }
+
+  ctx.selected_counters =
+      NetCounterFilterByNicType(ctx.selected_counters, ctx.snapshots_before);
 
   char hostname[256] = {0};
   gethostname(hostname, sizeof(hostname));


### PR DESCRIPTION
## Motivation

[PR #3963](https://github.com/ROCm/rocm-systems/pull/3963) introduced a generalized network counter collector for Thor2 (bnxt\_re) NIC diagnostics. This PR extends it with **AINIC (ionic) NIC support**, enabling the same congestion monitoring workflow on systems equipped with AMD Pensando ionic NICs. ).

## Technical Details

**NIC type auto-detection** — `NetCounterDetectNicType()` reads the driver symlink at `/sys/class/infiniband/<dev>/device/driver` and returns `NIC_BNXT_RE` or `NIC_IONIC`. The detected type is stored in each `NetworkCounterSnapshot` and used to select the correct counter names and sources at collection time.

**Dual-NIC counter registry** — `CounterRegistryEntry` is extended with `bnxt_key`, `bnxt_valid`, `ionic_key`, and `ionic_source` fields. Each canonical counter maps to its NIC-specific hw\_counters filename:

| # | Canonical Counter | Thor2 (bnxt\_re) hw\_counters file | AINIC (ionic) hw\_counters file |
|---|---|---|---|
| 1 | rx\_pfc\_ena\_frames\_pri\[0-7\] | (same, ethtool) | frames\_rx\_pripause\[0-7\] (ethtool) |
| 2 | rx\_cnp\_pkts | rp\_cnp\_handled | rx\_rdma\_cnp\_pkts |
| 3 | tx\_cnp\_pkts | np\_cnp\_sent | tx\_rdma\_cnp\_pkts |
| 4 | rx\_roce\_discards | (same) | rx\_rdma\_mtu\_discard\_pkts |
| 5 | rx\_stat\_discards | rx\_roce\_errors | resp\_rx\_outof\_buf |
| 6 | to\_retransmits | roce\_adp\_retrans | tx\_rdma\_ack\_timeout |
| 7 | max\_retry\_exceeded | (same) | req\_tx\_retry\_excd\_err |
| 8 | oos\_drop\_count | out\_of\_buffer | resp\_rx\_outouf\_seq |
| 9 | seq\_err\_naks\_rcvd | out\_of\_sequence | req\_rx\_pkt\_seq\_err |

**AINIC-only throughput counters** — `tx/rx_rdma_ucast_bytes` and `tx/rx_rdma_ucast_pkts` are added with `bnxt_valid=false` so they appear only on ionic systems.

**NIC-type-aware column filtering** — `NetCounterFilterByNicType()` removes counters that don't exist on the detected NIC (e.g., ionic-only throughput counters are hidden on Thor2, Thor2-only PFC transition counters are hidden on AINIC).

**bug fixes:**
- Fixed `NetCounterFindNicForIbDevice()` to strip port suffix before sysfs lookup.
- Fallback NIC discovery now skips non-RDMA interfaces.

**Files changed:**
- `collector.h` - Add `NicType` enum, `nic_type` field in `NetworkCounterSnapshot`, updated API declarations
- `collector.cu` - Extended registry, NIC type detection, per-NIC collection logic, column filtering
- `common.cu` - Post-snapshot counter filtering, skip non-RDMA interfaces in fallback discovery

## JIRA ID

AICOMNET-162

## Test Plan

- [x] Run 2-node 16-GPU alltoall\_perf with `RCCL_TESTS_NET_COUNTER_ENABLE=1` and `NCCL_IB_HCA` set on Thor2 (bnxt\_re) - verify CNP counters are non-zero and all 12 congestion monitoring columns display correctly
- [x] Verify AINIC-only throughput columns (`tx/rx_rdma_ucast_bytes/pkts`) are hidden on Thor2
- [x] Verify `nic_type=BNXT_RE` is printed in table header
- [x] Verify all hw\_counters file mappings against sysfs (rp\_cnp\_handled, np\_cnp\_sent, etc.)
- [ ] Verify AINIC running TODO

## Test Result

2-node alltoall\_perf on Dell Thor2 cluster (MI300X, kernel 6.8, `rocep*` IB device naming):

```
NET_COUNTER_TABLE: node=dell300x-ccs-aus-k13-41  rank=0  duration_sec=1  nic_type=BNXT_RE
Device                     rx_pfc_ena_frames_pri  tx_pfc_ena_frames_pri  ...  rx_cnp_pkts     tx_cnp_pkts     ...
rocep28s0(enp28s0np0)          0            0.00      0            0.00  ...  371727    0.00  173221    0.00  ...
rocep62s0(enp62s0np0)          0            0.00      0            0.00  ...  369480    0.00  174699    0.00  ...
...
```
AINIC (ionic) - expected output on ionic-equipped systems (not yet tested on hardware):
//TOADD


## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.