### PR TITLE
Add migrated TheRock test scripts under test/therock

### DIFF
--- a/test/therock/test_rocdecode.py
+++ b/test/therock/test_rocdecode.py
@@ -1,3 +1,6 @@
+# Copyright Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
 import logging
 import os
 import platform

--- a/test/therock/test_rocdecode.py
+++ b/test/therock/test_rocdecode.py
@@ -1,0 +1,102 @@
+import logging
+import os
+import platform
+import re
+import shlex
+import subprocess
+import sys
+from pathlib import Path
+
+logging.basicConfig(level=logging.INFO)
+THEROCK_BIN_DIR_STR = os.getenv("THEROCK_BIN_DIR")
+if THEROCK_BIN_DIR_STR is None:
+    logging.info(
+        "++ Error: env(THEROCK_BIN_DIR) is not set. Please set it before executing tests."
+    )
+    sys.exit(1)
+THEROCK_BIN_DIR = Path(THEROCK_BIN_DIR_STR)
+SCRIPT_DIR = Path(__file__).resolve().parent
+THEROCK_DIR = Path(
+    os.environ.get("THEROCK_DIR") or SCRIPT_DIR.parent.parent.parent
+).resolve()
+THEROCK_TEST_DIR = THEROCK_DIR / "build"
+
+ROCDECODE_TEST_PATH = str(
+    THEROCK_BIN_DIR.resolve().parent / "share" / "rocdecode" / "test"
+)
+if not os.path.isdir(ROCDECODE_TEST_PATH):
+    logging.info(f"++ Error: rocdecode tests not found in {ROCDECODE_TEST_PATH}")
+    sys.exit(1)
+else:
+    logging.info(f"++ INFO: rocdecode tests found in {ROCDECODE_TEST_PATH}")
+env = os.environ.copy()
+
+
+def setup_env(env):
+    ROCM_PATH = THEROCK_BIN_DIR.resolve().parent
+    env["ROCM_PATH"] = str(ROCM_PATH)
+    logging.info(f"++ rocdecode setting ROCM_PATH={ROCM_PATH}")
+    if platform.system() == "Linux":
+        hip_lib_path = THEROCK_BIN_DIR.resolve().parent / "lib"
+        logging.info(f"++ rocdecode setting LD_LIBRARY_PATH={hip_lib_path}")
+        if "LD_LIBRARY_PATH" in env:
+            env["LD_LIBRARY_PATH"] = f"{hip_lib_path}:{env['LD_LIBRARY_PATH']}"
+        else:
+            env["LD_LIBRARY_PATH"] = str(hip_lib_path)
+    else:
+        logging.info("++ rocdecode tests only supported on Linux")
+        sys.exit(0)
+
+
+def execute_tests(env):
+    rocdecode_test_dir = THEROCK_TEST_DIR / "rocdecode-test"
+
+    rocdecode_test_dir.mkdir(parents=True, exist_ok=True)
+
+    # rocdecode tests are shipped as CMake source and must be built on the target
+    # machine. This serves two purposes:
+    # 1. Verifies that the installed rocdecode headers and libraries are functional.
+    # 2. Some test dependencies (e.g. video codec libraries) are not bundled in the
+    #    TheRock artifacts and must be linked from the system at build time.
+    cmd = [
+        "cmake",
+        "-GNinja",
+        ROCDECODE_TEST_PATH,
+    ]
+    logging.info(f"++ Exec [{rocdecode_test_dir}]$ {shlex.join(cmd)}")
+    subprocess.run(cmd, cwd=rocdecode_test_dir, check=True, env=env)
+
+    cmd = [
+        "ctest",
+        "-N",
+    ]
+    logging.info(f"++ Exec [{rocdecode_test_dir}]$ {shlex.join(cmd)}")
+    ctest_list = subprocess.run(
+        cmd,
+        cwd=rocdecode_test_dir,
+        check=True,
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+    logging.info(ctest_list.stdout)
+    match = re.search(r"Total Tests:\s*(\d+)", ctest_list.stdout)
+    if match is None:
+        raise RuntimeError(
+            "Failed to determine CTest test count from `ctest -N` output"
+        )
+    if int(match.group(1)) == 0:
+        raise RuntimeError("CTest discovered zero rocdecode tests")
+
+    cmd = [
+        "ctest",
+        "--extra-verbose",
+        "--output-on-failure",
+    ]
+    logging.info(f"++ Exec [{rocdecode_test_dir}]$ {shlex.join(cmd)}")
+    subprocess.run(cmd, cwd=rocdecode_test_dir, check=True, env=env)
+
+
+if __name__ == "__main__":
+    setup_env(env)
+    execute_tests(env)

--- a/test/therock/test_rocjpeg.py
+++ b/test/therock/test_rocjpeg.py
@@ -1,3 +1,6 @@
+# Copyright Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
 import logging
 import os
 import platform

--- a/test/therock/test_rocjpeg.py
+++ b/test/therock/test_rocjpeg.py
@@ -1,0 +1,99 @@
+import logging
+import os
+import platform
+import re
+import shlex
+import subprocess
+import sys
+from pathlib import Path
+
+logging.basicConfig(level=logging.INFO)
+THEROCK_BIN_DIR_STR = os.getenv("THEROCK_BIN_DIR")
+if THEROCK_BIN_DIR_STR is None:
+    logging.info(
+        "++ Error: env(THEROCK_BIN_DIR) is not set. Please set it before executing tests."
+    )
+    sys.exit(1)
+THEROCK_BIN_DIR = Path(THEROCK_BIN_DIR_STR)
+SCRIPT_DIR = Path(__file__).resolve().parent
+THEROCK_DIR = Path(
+    os.environ.get("THEROCK_DIR") or SCRIPT_DIR.parent.parent.parent
+).resolve()
+THEROCK_TEST_DIR = THEROCK_DIR / "build"
+
+ROCJPEG_TEST_PATH = str(THEROCK_BIN_DIR.resolve().parent / "share" / "rocjpeg" / "test")
+if not os.path.isdir(ROCJPEG_TEST_PATH):
+    logging.info(f"++ Error: rocjpeg tests not found in {ROCJPEG_TEST_PATH}")
+    sys.exit(1)
+else:
+    logging.info(f"++ INFO: rocjpeg tests found in {ROCJPEG_TEST_PATH}")
+env = os.environ.copy()
+
+
+def setup_env(env):
+    ROCM_PATH = THEROCK_BIN_DIR.resolve().parent
+    env["ROCM_PATH"] = str(ROCM_PATH)
+    logging.info(f"++ rocjpeg setting ROCM_PATH={ROCM_PATH}")
+    if platform.system() == "Linux":
+        hip_lib_path = THEROCK_BIN_DIR.resolve().parent / "lib"
+        logging.info(f"++ rocjpeg setting LD_LIBRARY_PATH={hip_lib_path}")
+        if "LD_LIBRARY_PATH" in env:
+            env["LD_LIBRARY_PATH"] = f"{hip_lib_path}:{env['LD_LIBRARY_PATH']}"
+        else:
+            env["LD_LIBRARY_PATH"] = str(hip_lib_path)
+    else:
+        logging.info("++ rocjpeg tests only supported on Linux")
+        sys.exit(0)
+
+
+def execute_tests(env):
+    rocjpeg_test_dir = THEROCK_TEST_DIR / "rocjpeg-test"
+    rocjpeg_test_dir.mkdir(parents=True, exist_ok=True)
+
+    # rocjpeg tests are shipped as CMake source and must be built on the target
+    # machine. This serves two purposes:
+    # 1. Verifies that the installed rocjpeg headers and libraries are functional.
+    # 2. Some test dependencies are not bundled in the TheRock artifacts and must
+    #    be linked from the system at build time.
+    cmd = [
+        "cmake",
+        "-GNinja",
+        ROCJPEG_TEST_PATH,
+    ]
+    logging.info(f"++ Exec [{rocjpeg_test_dir}]$ {shlex.join(cmd)}")
+    subprocess.run(cmd, cwd=rocjpeg_test_dir, check=True, env=env)
+
+    cmd = [
+        "ctest",
+        "-N",
+    ]
+    logging.info(f"++ Exec [{rocjpeg_test_dir}]$ {shlex.join(cmd)}")
+    ctest_list = subprocess.run(
+        cmd,
+        cwd=rocjpeg_test_dir,
+        check=True,
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+    logging.info(ctest_list.stdout)
+    match = re.search(r"Total Tests:\s*(\d+)", ctest_list.stdout)
+    if match is None:
+        raise RuntimeError(
+            "Failed to determine CTest test count from `ctest -N` output"
+        )
+    if int(match.group(1)) == 0:
+        raise RuntimeError("CTest discovered zero rocjpeg tests")
+
+    cmd = [
+        "ctest",
+        "--extra-verbose",
+        "--output-on-failure",
+    ]
+    logging.info(f"++ Exec [{rocjpeg_test_dir}]$ {shlex.join(cmd)}")
+    subprocess.run(cmd, cwd=rocjpeg_test_dir, check=True, env=env)
+
+
+if __name__ == "__main__":
+    setup_env(env)
+    execute_tests(env)

--- a/test/therock/test_rocprofiler_sdk.py
+++ b/test/therock/test_rocprofiler_sdk.py
@@ -1,0 +1,117 @@
+# Copyright Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+import logging
+import os
+import shlex
+import subprocess
+import sys
+from pathlib import Path
+
+# Base Paths
+THEROCK_BIN_DIR = os.getenv("THEROCK_BIN_DIR")
+THEROCK_BIN_PATH = Path(THEROCK_BIN_DIR).resolve()
+THEROCK_PATH = THEROCK_BIN_PATH.parent
+
+# LIB Paths
+THEROCK_LIB_PATH = THEROCK_PATH / "lib"
+THEROCK_SYSDEPS_PATH = THEROCK_LIB_PATH / "rocm_sysdeps"
+THEROCK_SYSDEPS_LIB_PATH = THEROCK_SYSDEPS_PATH / "lib"
+
+# LLVM Paths
+THEROCK_LLVM_BIN_PATH = THEROCK_PATH / "llvm" / "bin"
+THEROCK_CLANG_PATH = THEROCK_LLVM_BIN_PATH / "amdclang"
+THEROCK_CLANG_PLUS_PATH = THEROCK_LLVM_BIN_PATH / "amdclang++"
+
+# SDK Paths
+ROCPROFILER_SDK_PATH = THEROCK_PATH / "share" / "rocprofiler-sdk"
+ROCPROFILER_SDK_TESTS_PATH = ROCPROFILER_SDK_PATH / "tests"
+
+logging.basicConfig(level=logging.INFO)
+environ_vars = os.environ.copy()
+
+
+def setup_env():
+    environ_vars["ROCM_PATH"] = str(THEROCK_PATH)
+    environ_vars["HIP_PATH"] = str(THEROCK_PATH)
+    environ_vars["ROCPROFILER_METRICS_PATH"] = str(ROCPROFILER_SDK_PATH)
+    environ_vars["HIP_PLATFORM"] = "amd"
+
+    old_ld_lib_path = os.getenv("LD_LIBRARY_PATH", "").split(":")
+    environ_vars["LD_LIBRARY_PATH"] = ":".join(
+        [f"{THEROCK_LIB_PATH}", f"{THEROCK_SYSDEPS_LIB_PATH}"] + old_ld_lib_path
+    )
+
+
+def cmake_config():
+    cmake_config_cmd = [
+        "cmake",
+        "-B",
+        "build",
+        "-G",
+        "Ninja",
+        f"-DCMAKE_PREFIX_PATH={THEROCK_PATH};{THEROCK_SYSDEPS_PATH}",
+        f"-DCMAKE_HIP_COMPILER={THEROCK_CLANG_PLUS_PATH}",
+        f"-DCMAKE_C_COMPILER={THEROCK_CLANG_PATH}",
+        f"-DCMAKE_CXX_COMPILER={THEROCK_CLANG_PLUS_PATH}",
+        f"-DPython3_EXECUTABLE={sys.executable}",
+    ]
+
+    logging.info(
+        f"++ Exec [{ROCPROFILER_SDK_TESTS_PATH}]$ {shlex.join(cmake_config_cmd)}"
+    )
+    subprocess.run(
+        cmake_config_cmd,
+        cwd=ROCPROFILER_SDK_TESTS_PATH,
+        check=True,
+        env=environ_vars,
+    )
+
+
+# SDK requires test binaries to be built on the gfx architecture being tested on
+# Certain tests are enabled/disabled based on the GPU architecture.
+# Ensuring that these tests build properly against an install is also part of the overall test coverage for SDK (emulates tool developers building tools with rocprofiler-sdk)
+def cmake_build():
+    cmake_build_cmd = [
+        "cmake",
+        "--build",
+        "build",
+        "--parallel",
+        "8",
+    ]
+
+    logging.info(
+        f"++ Exec [{ROCPROFILER_SDK_TESTS_PATH}]$ {shlex.join(cmake_build_cmd)}"
+    )
+    subprocess.run(
+        cmake_build_cmd,
+        cwd=ROCPROFILER_SDK_TESTS_PATH,
+        check=True,
+        env=environ_vars,
+    )
+
+
+def execute_tests():
+    ctest_cmd = [
+        "ctest",
+        "--test-dir",
+        "build",
+        "--parallel",
+        "8",
+        "--output-on-failure",
+    ]
+
+    logging.info(f"++ Exec [{ROCPROFILER_SDK_TESTS_PATH}]$ {shlex.join(ctest_cmd)}")
+    subprocess.run(
+        ctest_cmd,
+        cwd=ROCPROFILER_SDK_TESTS_PATH,
+        check=True,
+        env=environ_vars,
+    )
+
+
+if __name__ == "__main__":
+    setup_env()
+    cmake_config()
+    cmake_build()
+    execute_tests()

--- a/test/therock/test_sanity.py
+++ b/test/therock/test_sanity.py
@@ -1,0 +1,46 @@
+# Copyright Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+import logging
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+logging.basicConfig(level=logging.INFO)
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+THEROCK_DIR = Path(
+    os.environ.get("THEROCK_DIR") or SCRIPT_DIR.parent.parent.parent
+).resolve()
+
+env = os.environ.copy()
+# Enable verbose ROCm logging, see
+# https://rocm.docs.amd.com/projects/HIP/en/latest/how-to/debugging.html
+# Note: ROCM_KPACK_DEBUG is set for all components by test_component.yml.
+env["AMD_LOG_LEVEL"] = "4"
+
+# The sanity checks run tools like 'offload-arch' which may search for DLLs on
+# multiple search paths (PATH, CWD, system32, etc.).
+# For typical "installs" of ROCm, the rocm/bin/ dir can be expected to be
+# added to PATH, so we do that here. If we don't do this, DLLs on test runners
+# in system32 may be picked up instead and the tests may not be representative,
+# see https://github.com/ROCm/TheRock/issues/2019 and
+# https://github.com/ROCm/TheRock/pull/3230#issuecomment-3844854922.
+if sys.platform == "win32":
+    output_artifacts_dir = Path(os.getenv("OUTPUT_ARTIFACTS_DIR", "./build")).resolve()
+    env["HIP_CLANG_PATH"] = str(output_artifacts_dir / "lib" / "llvm" / "bin")
+    env["PATH"] = str(output_artifacts_dir / "bin") + os.pathsep + env.get("PATH", "")
+
+cmd = [
+    sys.executable,
+    "-m",
+    "pytest",
+    "tests/",
+    "--log-cli-level=info",
+    "--timeout=300",
+]
+
+logging.info(f"++ Exec [{THEROCK_DIR}]$ {' '.join(cmd)}")
+
+subprocess.run(cmd, cwd=THEROCK_DIR, env=env, check=True)


### PR DESCRIPTION
## Summary

Add the current TheRock test scripts that should live in `rocm-systems/test/therock/` before TheRock CI caller updates land.

This copies in:
- `test_sanity.py`
- `test_rocdecode.py`
- `test_rocjpeg.py`
- `test_rocprofiler_sdk.py`

Each script was copied from the current `TheRock` version and updated to use the migrated-repo-friendly `THEROCK_DIR` fallback pattern where applicable:
- `Path(os.environ.get("THEROCK_DIR") or SCRIPT_DIR.parent.parent.parent).resolve()`

## Why

ROCm/TheRock#4045 will update `fetch_test_configurations.py` to point at the super-repo copies. These scripts need to exist in `rocm-systems` first so that PR can merge safely afterward.

## Validation

- Reviewed copied script contents against current `TheRock`
- Ran `pre-commit` successfully on the added files
- Ran Python syntax checks on the added files

## Notes

This PR is limited to scripts whose tested code belongs in `rocm-systems`, plus the shared sanity test that should now live here.
