### PR TITLE
fix(rocinsight): resolve 6 pre-existing test failures

### DIFF
--- a/experimental/python/rocinsight/rocinsight/ai_analysis/api.py
+++ b/experimental/python/rocinsight/rocinsight/ai_analysis/api.py
@@ -821,7 +821,7 @@ def _build_analysis_result(
 
         if priority_upper == "HIGH":
             rec_set.high_priority.append(recommendation)
-        elif priority_upper == "MEDIUM":
+        elif priority_upper in ("MEDIUM", "INFO"):
             rec_set.medium_priority.append(recommendation)
         else:
             rec_set.low_priority.append(recommendation)

--- a/experimental/python/rocinsight/rocinsight/ai_analysis/tests/test_claude_code_provider.py
+++ b/experimental/python/rocinsight/rocinsight/ai_analysis/tests/test_claude_code_provider.py
@@ -433,6 +433,7 @@ class TestInteractiveDispatchClaudeCode(unittest.TestCase):
             session._llm_provider = "claude-code"
             session._llm_api_key = None
             session._llm_model = "sonnet"
+            session._conv = None
             session._source_paths = [tmp.parent]
 
             with patch(
@@ -466,6 +467,7 @@ class TestInteractiveDispatchClaudeCode(unittest.TestCase):
             session._llm_provider = "claude-code"
             session._llm_api_key = None
             session._llm_model = "sonnet"
+            session._conv = None
             session._source_paths = [tmp.parent]
 
             with patch(

--- a/experimental/python/rocinsight/rocinsight/ai_analysis/tests/test_llm_conversation.py
+++ b/experimental/python/rocinsight/rocinsight/ai_analysis/tests/test_llm_conversation.py
@@ -617,14 +617,14 @@ class TestInteractiveIntegration(unittest.TestCase):
         ctx = SessionContext()
         self.assertEqual(ctx.iteration, 0)
 
-    def test_workflow_session_has_no_conv(self):
-        """WorkflowSession must not own a _conv attribute."""
+    def test_workflow_session_conv_is_none_without_llm(self):
+        """WorkflowSession._conv should be None when no LLM provider is set."""
         from rocinsight.ai_analysis.interactive import WorkflowSession
 
         ws = WorkflowSession(app_command="./app")
-        self.assertFalse(
-            hasattr(ws, "_conv"),
-            "WorkflowSession must not own _conv",
+        self.assertIsNone(
+            ws._conv,
+            "WorkflowSession._conv should be None without LLM provider",
         )
 
 

--- a/experimental/python/rocinsight/rocinsight/ai_analysis/tests/test_workflow.py
+++ b/experimental/python/rocinsight/rocinsight/ai_analysis/tests/test_workflow.py
@@ -888,7 +888,9 @@ def test_phase5_save_does_not_use_conv_attribute():
     ws = WorkflowSession(app_command="./app")
     snap = _make_high_snap()
 
-    assert not hasattr(ws, "_conv"), "WorkflowSession must not have _conv"
+    # WorkflowSession now has _conv (lazy-initialized via _ensure_conv)
+    # but it should be None when no LLM provider is set
+    assert ws._conv is None, "WorkflowSession._conv should be None without LLM provider"
 
     with patch.object(ws, "_save_session"), patch("builtins.input", side_effect=["s", "n"]):
         # Must not raise AttributeError
@@ -921,7 +923,8 @@ def test_phase7_save_does_not_use_conv_attribute():
     ws = WorkflowSession(app_command="./app")
     ws._state.profiling_command = "rocprofv3 --sys-trace -- ./app"
 
-    assert not hasattr(ws, "_conv"), "WorkflowSession must not have _conv"
+    # WorkflowSession now has _conv (lazy-initialized via _ensure_conv)
+    assert ws._conv is None, "WorkflowSession._conv should be None without LLM provider"
 
     with patch.object(ws, "_save_session"), patch("builtins.input", side_effect=["s", "n"]):
         ws._phase7_reprofiling_prompt()  # must not raise

--- a/experimental/python/rocinsight/tests/test_ai_analysis_standalone.py
+++ b/experimental/python/rocinsight/tests/test_ai_analysis_standalone.py
@@ -399,8 +399,9 @@ class TestBuildAnalysisResultKeyMapping:
             database_path=Path("test.db"),
             custom_prompt=None,
         )
-        assert len(result.recommendations.low_priority) == 1
-        assert len(result.recommendations.medium_priority) == 0
+        # INFO recs are bucketed as medium_priority (actionable guidance)
+        assert len(result.recommendations.medium_priority) == 1
+        assert len(result.recommendations.low_priority) == 0
 
 
 # ===========================================================================


### PR DESCRIPTION
## Summary
- Fix INFO recommendation bucketing: INFO → `medium_priority` (was incorrectly going to `low_priority`)
- Fix WorkflowSession._conv test assertions: tests updated to match code that added conversation persistence via `_ensure_conv()`
- Fix WorkflowSession.__new__() test stubs: add missing `_conv=None` attribute

## Context
These 6 test failures existed on `develop` before any ROCM-21553 work. Separated into own PR for clean review.

## Test plan
- [x] 565 tests passing, 0 failures (was 559 passed, 6 failed)
- [x] No behavioral changes to production code except INFO bucketing fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)