### PR TITLE
feat(rocinsight): add per-API overhead breakdown and kernel resource/occupancy analysis

### DIFF
--- a/experimental/python/rocinsight/rocinsight/ai_analysis/api.py
+++ b/experimental/python/rocinsight/rocinsight/ai_analysis/api.py
@@ -40,6 +40,9 @@ from ..analysis import (
     identify_hotspots,
     analyze_memory_copies,
     analyze_hardware_counters,
+    detect_warmup_issues,
+    analyze_kernel_resources,
+    analyze_api_overhead,
     generate_recommendations,
     _detect_already_collected,
 )
@@ -584,6 +587,11 @@ def analyze_database(
         hardware_counters = analyze_hardware_counters(connection)
         already_collected = _detect_already_collected(connection)
 
+        # ROCM-21553: new analysis functions
+        warmup_issues = detect_warmup_issues(connection, hotspots)
+        kernel_resources = analyze_kernel_resources(connection, hotspots)
+        api_overhead_data = analyze_api_overhead(connection)
+
         # TraceLens-derived analysis
         interval_timeline = compute_interval_timeline(connection)
         kernel_categories = analyze_kernels_by_category(
@@ -609,6 +617,8 @@ def analyze_database(
             short_kernels=short_kernels_data,
             interval_timeline=interval_timeline,
             att_analysis=att_analysis if att_dir else None,
+            warmup_issues=warmup_issues,
+            api_overhead=api_overhead_data,
         )
 
         if verbose:
@@ -631,11 +641,17 @@ def analyze_database(
     result.kernel_categories = kernel_categories
     result.short_kernels = short_kernels_data
     result.interval_timeline = interval_timeline
+    result.kernel_resources = kernel_resources
+    result.api_overhead = api_overhead_data
+    result.warmup_issues = warmup_issues
 
     # Also write into _raw so to_json() / to_webview() include them
     result._raw["interval_timeline"] = interval_timeline
     result._raw["kernel_categories"] = kernel_categories
     result._raw["short_kernels"] = short_kernels_data
+    result._raw["kernel_resources"] = kernel_resources
+    result._raw["api_overhead"] = api_overhead_data
+    result._raw["warmup_issues"] = warmup_issues
     if att_dir and att_analysis.get("has_att_data"):
         result._raw["att_trace"] = att_analysis
         result._raw["att_analysis"] = att_analysis

--- a/experimental/python/rocinsight/rocinsight/ai_analysis/tests/test_api_overhead_kernel_resources.py
+++ b/experimental/python/rocinsight/rocinsight/ai_analysis/tests/test_api_overhead_kernel_resources.py
@@ -1,4 +1,4 @@
-"""Tests for ROCM-21553 PR2: New analysis data functions.
+"""Tests for per-API overhead breakdown and kernel resource/occupancy analysis.
 
 Tests cover:
 - C2: analyze_api_overhead() per-API breakdown

--- a/experimental/python/rocinsight/rocinsight/ai_analysis/tests/test_rocm21553_pr2.py
+++ b/experimental/python/rocinsight/rocinsight/ai_analysis/tests/test_rocm21553_pr2.py
@@ -1,0 +1,147 @@
+"""Tests for ROCM-21553 PR2: New analysis data functions.
+
+Tests cover:
+- C2: analyze_api_overhead() per-API breakdown
+- I1: analyze_kernel_resources() + occupancy calculation
+- api.py wiring for interactive mode
+"""
+
+import pytest
+from unittest.mock import MagicMock, patch
+
+from rocinsight.analysis.core import (
+    analyze_api_overhead,
+    analyze_kernel_resources,
+    _ARCH_SPECS,
+)
+from rocinsight.analysis.recommendations import generate_recommendations
+
+
+# ---------------------------------------------------------------------------
+# C2: Per-API overhead breakdown
+# ---------------------------------------------------------------------------
+
+class TestC2ApiOverhead:
+    def test_returns_empty_when_no_regions(self):
+        """Gracefully handles DBs without regions view."""
+        mock_conn = MagicMock()
+        mock_cursor = MagicMock()
+        mock_cursor.fetchall.side_effect = Exception("no such table: regions")
+
+        with patch("rocinsight.analysis.core.execute_statement", side_effect=Exception("no such table")):
+            result = analyze_api_overhead(mock_conn)
+        assert result["has_api_data"] is False
+        assert result["api_calls"] == []
+
+    def test_returns_api_calls_sorted_by_time(self):
+        """API calls sorted by total_ns descending."""
+        mock_conn = MagicMock()
+        mock_cursor = MagicMock()
+        mock_cursor.fetchall.return_value = [
+            ("hipHostMalloc", 2, 350_000_000, 175_000_000),
+            ("hipMemcpy", 6, 80_000_000, 13_333_333),
+            ("hipLaunchKernel", 100, 5_000_000, 50_000),
+        ]
+
+        with patch("rocinsight.analysis.core.execute_statement", return_value=mock_cursor):
+            result = analyze_api_overhead(mock_conn)
+
+        assert result["has_api_data"] is True
+        assert len(result["api_calls"]) == 3
+        assert result["api_calls"][0]["name"] == "hipHostMalloc"
+        assert result["launch_overhead_ns"] == 5_000_000
+        assert result["total_api_ns"] == 435_000_000
+
+    def test_api_overhead_in_recommendation_issue(self):
+        """When api_overhead is available, Rule 2 shows per-API breakdown."""
+        tb = {
+            "total_kernel_time": 50_000_000,
+            "total_memcpy_time": 0,
+            "total_runtime": 200_000_000,
+            "kernel_percent": 25.0,
+            "memcpy_percent": 0.0,
+            "overhead_percent": 75.0,
+        }
+        api = {
+            "has_api_data": True,
+            "api_calls": [
+                {"name": "hipSetDevice", "calls": 1, "total_ns": 100_000_000, "avg_ns": 100_000_000},
+            ],
+            "launch_overhead_ns": 2_000_000,
+            "total_api_ns": 150_000_000,
+        }
+        recs = generate_recommendations(tb, [], {}, None, api_overhead=api)
+        api_recs = [r for r in recs if r["category"] == "API Overhead"]
+        assert len(api_recs) == 1
+        assert "hipLaunchKernel" in api_recs[0]["issue"]
+        assert "hipSetDevice" in api_recs[0]["issue"]
+
+
+# ---------------------------------------------------------------------------
+# I1: Kernel resources + occupancy
+# ---------------------------------------------------------------------------
+
+class TestI1KernelResources:
+    def test_arch_specs_contains_expected(self):
+        """_ARCH_SPECS has all documented architectures."""
+        expected = {"gfx908", "gfx90a", "gfx942", "gfx950", "gfx1030", "gfx1100"}
+        assert expected.issubset(set(_ARCH_SPECS.keys()))
+
+    def test_gfx950_lds_is_160kb(self):
+        """CDNA4 (gfx950) has 160 KB LDS per CU."""
+        assert _ARCH_SPECS["gfx950"]["lds_per_cu_kb"] == 160
+
+    def test_returns_empty_when_no_hotspots(self):
+        """No hotspots -> empty kernel list."""
+        mock_conn = MagicMock()
+        with patch("rocinsight.analysis.core.execute_statement"):
+            result = analyze_kernel_resources(mock_conn, [])
+        assert result["kernels"] == []
+
+    def test_occupancy_calculation(self):
+        """Known occupancy: 4 VGPRs, no LDS, 256-thread block on gfx942 -> 100%."""
+        mock_conn = MagicMock()
+        # First call: agent query -> gfx942
+        # Second call: kernel query -> resources
+        agent_cursor = MagicMock()
+        agent_cursor.fetchone.return_value = ("AMD Instinct MI300X gfx942",)
+        kernel_cursor = MagicMock()
+        kernel_cursor.fetchone.return_value = (
+            "test_kernel", 4, 0, 16, 0, 0, 256, 1, 1, 1024, 1, 1
+        )
+
+        call_count = [0]
+        def mock_exec(conn, query, *args, **kwargs):
+            call_count[0] += 1
+            if call_count[0] == 1:
+                return agent_cursor
+            return kernel_cursor
+
+        with patch("rocinsight.analysis.core.execute_statement", side_effect=mock_exec):
+            result = analyze_kernel_resources(
+                mock_conn,
+                [{"name": "test_kernel", "calls": 10}],
+            )
+
+        assert len(result["kernels"]) == 1
+        assert result["arch"] == "gfx942"
+        occ = result["kernels"][0].get("occupancy")
+        assert occ is not None
+        assert occ["percent"] == 100.0
+        assert occ["limiting_resource"] == "none"
+
+    def test_kernel_resources_in_json(self):
+        """kernel_resources appears in JSON output."""
+        from rocinsight.formatters.json_fmt import _format_as_json
+        import json
+
+        kr = {
+            "arch": "gfx942",
+            "arch_specs": _ARCH_SPECS["gfx942"],
+            "kernels": [{"name": "k1", "vgpr": 32, "sgpr": 16, "lds_bytes": 0, "scratch_bytes": 0, "block": "256x1x1", "grid": "1024x1x1"}],
+        }
+        tb = {"total_kernel_time": 100, "total_memcpy_time": 0, "total_runtime": 100, "kernel_percent": 100, "memcpy_percent": 0, "overhead_percent": 0}
+        output = _format_as_json(tb, [], {}, [], kernel_resources=kr)
+        doc = json.loads(output)
+        assert "kernel_resources" in doc
+        assert doc["kernel_resources"]["arch"] == "gfx942"

--- a/experimental/python/rocinsight/rocinsight/analysis/__init__.py
+++ b/experimental/python/rocinsight/rocinsight/analysis/__init__.py
@@ -34,6 +34,9 @@ from .core import (
     analyze_memory_copies,
     analyze_hardware_counters,
     detect_warmup_issues,
+    analyze_kernel_resources,
+    analyze_api_overhead,
+    _ARCH_SPECS,
 )
 
 from .att import (
@@ -70,6 +73,9 @@ __all__ = [
     "analyze_memory_copies",
     "analyze_hardware_counters",
     "detect_warmup_issues",
+    "analyze_kernel_resources",
+    "analyze_api_overhead",
+    "_ARCH_SPECS",
     # att.py
     "_ATT_STALL_CATEGORY_MAP",
     "_ATT_MIN_HITCOUNT",

--- a/experimental/python/rocinsight/rocinsight/analysis/core.py
+++ b/experimental/python/rocinsight/rocinsight/analysis/core.py
@@ -392,3 +392,191 @@ def detect_warmup_issues(
         except Exception:
             continue
     return {"has_warmup_issues": len(outliers) > 0, "outliers": outliers}
+
+
+# ---------------------------------------------------------------------------
+# Architecture specs for occupancy calculation (ROCM-21553 I1)
+# ---------------------------------------------------------------------------
+
+_ARCH_SPECS: Dict[str, Dict[str, Any]] = {
+    "gfx908": {"max_waves_per_simd": 8, "vgprs_per_simd": 512, "lds_per_cu_kb": 64, "wavefront_size": 64, "simds_per_cu": 4},
+    "gfx90a": {"max_waves_per_simd": 8, "vgprs_per_simd": 512, "lds_per_cu_kb": 64, "wavefront_size": 64, "simds_per_cu": 4},
+    "gfx942": {"max_waves_per_simd": 8, "vgprs_per_simd": 512, "lds_per_cu_kb": 64, "wavefront_size": 64, "simds_per_cu": 4},
+    "gfx950": {"max_waves_per_simd": 8, "vgprs_per_simd": 512, "lds_per_cu_kb": 160, "wavefront_size": 64, "simds_per_cu": 4},
+    "gfx1030": {"max_waves_per_simd": 16, "vgprs_per_simd": 1024, "lds_per_cu_kb": 128, "wavefront_size": 32, "simds_per_cu": 2},
+    "gfx1100": {"max_waves_per_simd": 16, "vgprs_per_simd": 1536, "lds_per_cu_kb": 128, "wavefront_size": 32, "simds_per_cu": 2},
+}
+
+
+def analyze_kernel_resources(
+    connection: RocpdImportData,
+    hotspots: List[Dict[str, Any]],
+) -> Dict[str, Any]:
+    """
+    Extract kernel resource usage (VGPR, SGPR, LDS, scratch) and compute
+    theoretical occupancy for top hotspot kernels.
+
+    Queries the ``kernels`` view which JOINs ``rocpd_kernel_dispatch`` with
+    ``rocpd_info_kernel_symbol``, exposing register counts, LDS/scratch sizes,
+    and launch configuration (block/grid dimensions).
+
+    Architecture is detected from ``rocpd_info_agent`` to look up hardware
+    limits for occupancy calculation.
+
+    Returns:
+        Dictionary with ``arch``, ``arch_specs``, and ``kernels`` list.
+    """
+    import math
+    import re as _re
+
+    # Detect architecture
+    arch = None
+    arch_specs = None
+    try:
+        agent_query = "SELECT name FROM rocpd_info_agent WHERE type='GPU' LIMIT 1"
+        row = execute_statement(connection, agent_query).fetchone()
+        if row and row[0]:
+            m = _re.search(r"gfx\d+", row[0])
+            if m:
+                arch = m.group(0)
+                arch_specs = _ARCH_SPECS.get(arch)
+    except Exception:
+        pass
+
+    kernel_list: List[Dict[str, Any]] = []
+    for kernel in hotspots[:10]:
+        kernel_name = kernel.get("name", "")
+        if not kernel_name:
+            continue
+        safe_name = kernel_name.replace("'", "''")
+        query = (
+            f"SELECT DISTINCT name, vgpr_count, accum_vgpr_count, sgpr_count, "
+            f"lds_size, scratch_size, workgroup_x, workgroup_y, workgroup_z, "
+            f"grid_x, grid_y, grid_z "
+            f"FROM kernels WHERE name = '{safe_name}' LIMIT 1"
+        )
+        try:
+            row = execute_statement(connection, query).fetchone()
+            if not row:
+                continue
+        except Exception:
+            continue
+
+        vgpr = row[1] or 0
+        accum_vgpr = row[2] or 0
+        sgpr = row[3] or 0
+        lds = row[4] or 0
+        scratch = row[5] or 0
+        wg_x, wg_y, wg_z = row[6] or 1, row[7] or 1, row[8] or 1
+        grid_x, grid_y, grid_z = row[9] or 1, row[10] or 1, row[11] or 1
+
+        entry: Dict[str, Any] = {
+            "name": kernel_name,
+            "vgpr": vgpr,
+            "accum_vgpr": accum_vgpr,
+            "sgpr": sgpr,
+            "lds_bytes": lds,
+            "scratch_bytes": scratch,
+            "block": f"{wg_x}x{wg_y}x{wg_z}",
+            "grid": f"{grid_x}x{grid_y}x{grid_z}",
+        }
+
+        # Compute occupancy if architecture known
+        if arch_specs and vgpr > 0:
+            max_w = arch_specs["max_waves_per_simd"]
+            vgprs_per_simd = arch_specs["vgprs_per_simd"]
+            lds_per_cu = arch_specs["lds_per_cu_kb"] * 1024
+            wf_size = arch_specs["wavefront_size"]
+            simds = arch_specs["simds_per_cu"]
+
+            vgpr_limited = min(math.floor(vgprs_per_simd / max(vgpr, 1)), max_w)
+
+            threads_per_block = wg_x * wg_y * wg_z
+            waves_per_block = math.ceil(threads_per_block / wf_size)
+            max_threads_per_cu = max_w * simds * wf_size
+            max_blocks = math.floor(max_threads_per_cu / max(threads_per_block, 1))
+            block_waves = max_blocks * waves_per_block
+            block_limited = min(math.floor(block_waves / simds), max_w)
+
+            if lds > 0:
+                lds_blocks = math.floor(lds_per_cu / lds)
+                lds_limited = min(math.floor(lds_blocks * waves_per_block / simds), max_w)
+            else:
+                lds_limited = max_w
+
+            achieved = min(vgpr_limited, lds_limited, block_limited)
+            occ_pct = achieved / max_w * 100.0
+
+            limiting = "none"
+            if achieved == vgpr_limited and achieved < max_w:
+                limiting = "VGPR"
+            elif achieved == lds_limited and achieved < max_w:
+                limiting = "LDS"
+            elif achieved == block_limited and achieved < max_w:
+                limiting = "block size"
+
+            entry["occupancy"] = {
+                "waves_per_simd": achieved,
+                "max_waves_per_simd": max_w,
+                "percent": round(occ_pct, 1),
+                "limiting_resource": limiting,
+                "vgpr_limited": vgpr_limited,
+                "lds_limited": lds_limited,
+                "block_limited": block_limited,
+            }
+
+        kernel_list.append(entry)
+
+    return {"arch": arch, "arch_specs": arch_specs, "kernels": kernel_list}
+
+
+def analyze_api_overhead(connection: RocpdImportData) -> Dict[str, Any]:
+    """
+    Break down HIP/HSA API overhead by individual API call.
+
+    Queries the ``regions`` SQL view for per-API-call duration aggregates
+    so recommendations can distinguish kernel launch overhead from setup
+    overhead (e.g., hipSetDevice, hipMalloc).
+
+    Returns:
+        Dictionary with ``api_calls`` list (sorted by total time DESC),
+        ``launch_overhead_ns``, ``total_api_ns``, and ``has_api_data`` flag.
+        Gracefully returns empty structure if ``regions`` view is unavailable.
+    """
+    query = """
+    SELECT name, COUNT(*) as calls, SUM(duration) as total_ns, AVG(duration) as avg_ns
+    FROM regions
+    WHERE category IN ('HIP_RUNTIME_API_EXT', 'HIP_COMPILER_API_EXT')
+    GROUP BY name
+    ORDER BY total_ns DESC
+    """
+    try:
+        rows = execute_statement(connection, query).fetchall()
+        if not rows:
+            return {"api_calls": [], "launch_overhead_ns": 0, "total_api_ns": 0, "has_api_data": False}
+
+        api_calls: List[Dict[str, Any]] = []
+        launch_overhead_ns = 0
+        total_api_ns = 0
+
+        for row in rows:
+            name, calls, total_ns, avg_ns = row[0], row[1], row[2] or 0, row[3] or 0
+            api_calls.append({
+                "name": name,
+                "calls": calls,
+                "total_ns": total_ns,
+                "avg_ns": avg_ns,
+            })
+            total_api_ns += total_ns
+            if name and "hipLaunchKernel" in name:
+                launch_overhead_ns += total_ns
+
+        return {
+            "api_calls": api_calls,
+            "launch_overhead_ns": launch_overhead_ns,
+            "total_api_ns": total_api_ns,
+            "has_api_data": True,
+        }
+    except Exception:
+        # Graceful fallback if regions view doesn't exist in older DBs
+        return {"api_calls": [], "launch_overhead_ns": 0, "total_api_ns": 0, "has_api_data": False}

--- a/experimental/python/rocinsight/rocinsight/analysis/recommendations.py
+++ b/experimental/python/rocinsight/rocinsight/analysis/recommendations.py
@@ -260,6 +260,33 @@ def _filter_rec_commands(
     return filtered
 
 
+def _build_api_overhead_issue(
+    overhead_percent: float, api_overhead: Optional[Dict[str, Any]]
+) -> str:
+    """Build the API overhead issue text with optional per-API breakdown."""
+    if api_overhead and api_overhead.get("has_api_data"):
+        top_calls = api_overhead["api_calls"][:3]
+        parts = []
+        for ac in top_calls:
+            ms = ac["total_ns"] / 1e6
+            parts.append(f"{ac['name']} x{ac['calls']} ({ms:.1f}ms)")
+        top_api_str = ", ".join(parts)
+
+        launch_ms = api_overhead["launch_overhead_ns"] / 1e6
+        total_api = max(api_overhead["total_api_ns"], 1)
+        launch_pct = api_overhead["launch_overhead_ns"] / total_api * 100
+
+        issue = (
+            f"HIP API overhead is {overhead_percent:.1f}% of total time. "
+            f"Kernel launch overhead (hipLaunchKernel) is {launch_ms:.1f}ms "
+            f"({launch_pct:.1f}% of API time)"
+        )
+        if top_api_str:
+            issue += f"\n    \u2192 top: {top_api_str}"
+        return issue
+    return f"API and launch overhead is {overhead_percent:.1f}% of total time"
+
+
 def generate_recommendations(
     time_breakdown: Dict[str, Any],
     hotspots: List[Dict[str, Any]],
@@ -270,6 +297,7 @@ def generate_recommendations(
     interval_timeline: Optional[Dict[str, Any]] = None,  # TraceLens
     att_analysis: Optional[Dict[str, Any]] = None,  # Tier 3 ATT
     warmup_issues: Optional[Dict[str, Any]] = None,  # Warmup detection
+    api_overhead: Optional[Dict[str, Any]] = None,  # Per-API breakdown
 ) -> List[Dict[str, Any]]:
     """
     Generate performance recommendations based on analysis results.
@@ -587,7 +615,7 @@ def generate_recommendations(
             {
                 "priority": "MEDIUM",
                 "category": "API Overhead",
-                "issue": f"API and launch overhead is {overhead_percent:.1f}% of total time",
+                "issue": _build_api_overhead_issue(overhead_percent, api_overhead),
                 "suggestion": "Reduce the number of API calls and kernel launches",
                 "actions": [
                     "Fuse multiple small kernels into fewer larger launches",
@@ -601,7 +629,7 @@ def generate_recommendations(
                     {
                         "tool": "rocprofv3",
                         "description": "Trace all HIP runtime API calls to identify highest-frequency calls",
-                        "flags": ["--hip-api-trace", "--hsa-trace"],
+                        "flags": ["--hip-trace", "--hsa-trace"],
                         "args": [
                             {"name": "-d", "value": "./api_output"},
                             {"name": "-o", "value": "profile"},

--- a/experimental/python/rocinsight/rocinsight/analyze.py
+++ b/experimental/python/rocinsight/rocinsight/analyze.py
@@ -66,6 +66,8 @@ from .analysis import (  # noqa: F401 -- re-exports for backward compat
     analyze_memory_copies,
     analyze_hardware_counters,
     detect_warmup_issues,
+    analyze_kernel_resources,
+    analyze_api_overhead,
     analyze_thread_trace,
     generate_recommendations,
     _split_pmc_into_passes,
@@ -281,6 +283,8 @@ def analyze_performance(
         memory_analysis = analyze_memory_copies(connection)
         hardware_counters = analyze_hardware_counters(connection)  # Tier 2
         warmup_issues = detect_warmup_issues(connection, hotspots)
+        kernel_resources = analyze_kernel_resources(connection, hotspots)
+        api_overhead_data = analyze_api_overhead(connection)
         already_collected = _detect_already_collected(connection)
         # Tier 3: ATT thread trace (optional — only when --att-dir is provided)
         att_analysis: Dict[str, Any] = {}
@@ -308,6 +312,7 @@ def analyze_performance(
             interval_timeline=interval_timeline,
             att_analysis=att_analysis if att_dir else None,
             warmup_issues=warmup_issues,
+            api_overhead=api_overhead_data,
         )
     else:
         time_breakdown = {}
@@ -320,6 +325,8 @@ def analyze_performance(
         kernel_categories = []
         short_kernels_data = {}
         warmup_issues = None
+        kernel_resources = {"arch": None, "arch_specs": None, "kernels": []}
+        api_overhead_data = {}
         recommendations = tier0_result.recommendations if tier0_result else []
 
     # Format output
@@ -338,6 +345,8 @@ def analyze_performance(
         short_kernels=short_kernels_data,
         att_analysis=att_analysis if att_analysis else None,
         custom_prompt=prompt,
+        kernel_resources=kernel_resources,
+        api_overhead=api_overhead_data,
     )
 
     # Expose structured results to caller (used by interactive mode)
@@ -345,6 +354,8 @@ def analyze_performance(
         _collect_result["recommendations"] = recommendations
         _collect_result["tier0_result"] = tier0_result
         _collect_result["database_path"] = database_path
+        _collect_result["kernel_resources"] = kernel_resources
+        _collect_result["api_overhead"] = api_overhead_data
         _collect_result["att_analysis"] = att_analysis
 
     # LLM enhancement (if enabled) — only for Tier 1/2; Tier 0 LLM runs in analyze_source_code()

--- a/experimental/python/rocinsight/rocinsight/formatters/__init__.py
+++ b/experimental/python/rocinsight/rocinsight/formatters/__init__.py
@@ -63,6 +63,8 @@ def format_analysis_output(
     short_kernels: Optional[Dict[str, Any]] = None,
     att_analysis: Optional[Dict[str, Any]] = None,  # Tier 3 ATT
     custom_prompt: Optional[str] = None,
+    kernel_resources: Optional[Dict[str, Any]] = None,
+    api_overhead: Optional[Dict[str, Any]] = None,
 ) -> str:
     """
     Format analysis results for display.
@@ -103,6 +105,8 @@ def format_analysis_output(
             short_kernels=short_kernels,
             att_analysis=att_analysis,
             custom_prompt=custom_prompt,
+            kernel_resources=kernel_resources,
+            api_overhead=api_overhead,
         )
         # Combined mode: embed tier0 into JSON document
         if tier0_result is not None:
@@ -195,6 +199,15 @@ def format_analysis_output(
     lines.append(
         f"  API Overhead:      {overhead_time_ms:10,.2f} ms  ({overhead_pct:5.1f}%)  {make_bar(overhead_pct)}"
     )
+    # Per-API annotation (ROCM-21553 C2)
+    if api_overhead and api_overhead.get("has_api_data"):
+        top_calls = api_overhead["api_calls"][:3]
+        parts = []
+        for ac in top_calls:
+            ms = ac["total_ns"] / 1e6
+            parts.append(f"{ac['name']} x{ac['calls']} ({ms:.1f}ms)")
+        if parts:
+            lines.append(f"    -> top: {', '.join(parts)}")
     lines.append("")
 
     # Hotspots
@@ -228,6 +241,49 @@ def format_analysis_output(
                 f"{i:2}  {name:<30}  {calls:6}  {total_ms:10,.2f}  {avg_us:9,.1f}  {percent:6.1f}%"
             )
 
+        lines.append("")
+
+    # Kernel Resources (ROCM-21553 I1)
+    if kernel_resources and kernel_resources.get("kernels"):
+        lines.append("\u2501" * width)
+        lines.append("KERNEL RESOURCES".center(width))
+        lines.append("\u2501" * width)
+        lines.append("")
+        lines.append(
+            f" #  {'Kernel Name':<30}  {'Block':<10}  {'VGPR':>5}  {'SGPR':>5}  {'Scratch':>9}  {'LDS':>9}"
+        )
+        lines.append("\u2500" * width)
+        for i, kr in enumerate(kernel_resources["kernels"], 1):
+            kname = kr.get("name", "unknown")
+            if len(kname) > 30:
+                kname = kname[:27] + "..."
+            block = kr.get("block", "?")
+            vgpr = kr.get("vgpr", 0)
+            sgpr = kr.get("sgpr", 0)
+            scratch = kr.get("scratch_bytes", 0)
+            lds = kr.get("lds_bytes", 0)
+            scratch_s = f"{scratch} B" if scratch < 1024 else f"{scratch / 1024:.1f} KB"
+            lds_s = f"{lds} B" if lds < 1024 else f"{lds / 1024:.1f} KB"
+            lines.append(
+                f"{i:2}  {kname:<30}  {block:<10}  {vgpr:5}  {sgpr:5}  {scratch_s:>9}  {lds_s:>9}"
+            )
+        lines.append("")
+        # Occupancy
+        arch = kernel_resources.get("arch")
+        for kr in kernel_resources["kernels"]:
+            occ = kr.get("occupancy")
+            if occ:
+                kname = kr["name"]
+                if len(kname) > 40:
+                    kname = kname[:37] + "..."
+                w = occ["waves_per_simd"]
+                mw = occ["max_waves_per_simd"]
+                pct = occ["percent"]
+                lim = occ["limiting_resource"]
+                lim_str = f"limited by {lim}" if lim != "none" else "no resource bottleneck"
+                lines.append(
+                    f"  Occupancy ({arch}): {w}/{mw} waves/SIMD ({pct:.0f}%) \u2014 {lim_str}  [{kname}]"
+                )
         lines.append("")
 
     # Memory Analysis

--- a/experimental/python/rocinsight/rocinsight/formatters/json_fmt.py
+++ b/experimental/python/rocinsight/rocinsight/formatters/json_fmt.py
@@ -44,6 +44,8 @@ def _format_as_json(
     short_kernels=None,
     att_analysis: Optional[Dict[str, Any]] = None,
     custom_prompt: Optional[str] = None,
+    kernel_resources: Optional[Dict[str, Any]] = None,
+    api_overhead: Optional[Dict[str, Any]] = None,
 ) -> str:
     """Serialize analysis results to JSON conforming to the current schema version (v0.3.0 when TraceLens fields are present, v0.1.0 otherwise).
 
@@ -162,6 +164,16 @@ def _format_as_json(
         doc["schema_version"] = "0.4.0"
         doc["metadata"]["analysis_version"] = "0.4.0"
         doc["profiling_info"]["analysis_tier"] = 3
+
+    # ROCM-21553: kernel resources and API overhead
+    if kernel_resources and kernel_resources.get("kernels"):
+        doc["kernel_resources"] = kernel_resources
+    if api_overhead and api_overhead.get("has_api_data"):
+        doc["api_breakdown"] = {
+            "total_api_ns": api_overhead["total_api_ns"],
+            "launch_overhead_ns": api_overhead["launch_overhead_ns"],
+            "api_calls": api_overhead["api_calls"],
+        }
 
     return _json.dumps(doc, indent=2)
 


### PR DESCRIPTION
## Summary
ROCM-21553 items C2, I1, I2:

- **C2+I2**: New `analyze_api_overhead()` — per-API call duration breakdown, separates hipLaunchKernel from total
- **I1**: New `analyze_kernel_resources()` — VGPR/SGPR/LDS/scratch + theoretical occupancy
- Fix: `--hip-api-trace` (invalid) replaced with `--hip-trace`

## Stacking note
Stacks on #4969 → #4968. GitHub diff includes prior changes. **This PR's own changes (8 files, +466/-2):**
- `analysis/core.py` — `analyze_api_overhead()`, `analyze_kernel_resources()`, `_ARCH_SPECS`
- `analysis/recommendations.py` — `api_overhead` param, per-API issue text
- `formatters/__init__.py` — per-API annotation + KERNEL RESOURCES section
- `formatters/json_fmt.py` — kernel_resources + api_breakdown in JSON
- `analyze.py`, `ai_analysis/api.py` — wiring
- `test_api_overhead_kernel_resources.py` — 8 new tests

Merge after #4969 lands.

## Test plan
- [x] 8 new tests, 587 total passing, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)