### PR TITLE
feat(rocinsight): add roctx region analysis, profiling scope recommendations

### DIFF
--- a/experimental/python/rocinsight/rocinsight/ai_analysis/api.py
+++ b/experimental/python/rocinsight/rocinsight/ai_analysis/api.py
@@ -286,9 +286,12 @@ class AnalysisResult:
                 hardware_counters=raw["hardware_counters"],
                 database_path=raw["database_path"],
                 output_format="json",
-                interval_timeline=raw.get("interval_timeline"),  # NEW
-                kernel_categories=raw.get("kernel_categories"),  # NEW
-                short_kernels=raw.get("short_kernels"),  # NEW
+                interval_timeline=raw.get("interval_timeline"),
+                kernel_categories=raw.get("kernel_categories"),
+                short_kernels=raw.get("short_kernels"),
+                kernel_resources=raw.get("kernel_resources"),
+                api_overhead=raw.get("api_overhead"),
+                roctx_regions=raw.get("roctx_regions"),
             )
         raise RuntimeError(
             "Raw analysis data not available. "
@@ -320,9 +323,12 @@ class AnalysisResult:
             hardware_counters=raw["hardware_counters"],
             database_path=raw["database_path"],
             output_format="webview",
-            interval_timeline=raw.get("interval_timeline"),  # NEW
-            kernel_categories=raw.get("kernel_categories"),  # NEW
-            short_kernels=raw.get("short_kernels"),  # NEW
+            interval_timeline=raw.get("interval_timeline"),
+            kernel_categories=raw.get("kernel_categories"),
+            short_kernels=raw.get("short_kernels"),
+            kernel_resources=raw.get("kernel_resources"),
+            api_overhead=raw.get("api_overhead"),
+            roctx_regions=raw.get("roctx_regions"),
         )
 
     def to_text(self) -> str:

--- a/experimental/python/rocinsight/rocinsight/ai_analysis/api.py
+++ b/experimental/python/rocinsight/rocinsight/ai_analysis/api.py
@@ -43,6 +43,7 @@ from ..analysis import (
     detect_warmup_issues,
     analyze_kernel_resources,
     analyze_api_overhead,
+    analyze_roctx_regions,
     generate_recommendations,
     _detect_already_collected,
 )
@@ -591,6 +592,7 @@ def analyze_database(
         warmup_issues = detect_warmup_issues(connection, hotspots)
         kernel_resources = analyze_kernel_resources(connection, hotspots)
         api_overhead_data = analyze_api_overhead(connection)
+        roctx_regions = analyze_roctx_regions(connection)
 
         # TraceLens-derived analysis
         interval_timeline = compute_interval_timeline(connection)
@@ -619,6 +621,7 @@ def analyze_database(
             att_analysis=att_analysis if att_dir else None,
             warmup_issues=warmup_issues,
             api_overhead=api_overhead_data,
+            roctx_regions=roctx_regions,
         )
 
         if verbose:
@@ -652,6 +655,8 @@ def analyze_database(
     result._raw["kernel_resources"] = kernel_resources
     result._raw["api_overhead"] = api_overhead_data
     result._raw["warmup_issues"] = warmup_issues
+    result._raw["roctx_regions"] = roctx_regions
+    result.roctx_regions = roctx_regions
     if att_dir and att_analysis.get("has_att_data"):
         result._raw["att_trace"] = att_analysis
         result._raw["att_analysis"] = att_analysis

--- a/experimental/python/rocinsight/rocinsight/ai_analysis/tests/test_rocm21553_pr3.py
+++ b/experimental/python/rocinsight/rocinsight/ai_analysis/tests/test_rocm21553_pr3.py
@@ -1,0 +1,199 @@
+"""Tests for ROCM-21553 PR3: roctx support and profiling scope.
+
+Tests cover:
+- C1: analyze_roctx_regions() marker detection and correlation
+- E1: rocprof-compute is first command in Kernel Hotspot
+- E2: roctxProfilerPause recommendation when unranged > 50%
+- GPU idle warning scoped to figure-of-merit region
+"""
+
+import pytest
+from unittest.mock import MagicMock, patch
+
+from rocinsight.analysis.core import analyze_roctx_regions
+from rocinsight.analysis.recommendations import generate_recommendations
+
+
+# ---------------------------------------------------------------------------
+# C1: roctx marker analysis
+# ---------------------------------------------------------------------------
+
+class TestC1RoctxRegions:
+    def test_returns_none_when_no_markers(self):
+        """No roctx markers -> returns None (graceful no-op)."""
+        mock_conn = MagicMock()
+        mock_cursor = MagicMock()
+        mock_cursor.fetchall.return_value = []
+
+        with patch("rocinsight.analysis.core.execute_statement", return_value=mock_cursor):
+            result = analyze_roctx_regions(mock_conn)
+        assert result is None
+
+    def test_returns_none_when_regions_view_missing(self):
+        """Old DB without regions view -> returns None."""
+        mock_conn = MagicMock()
+        with patch("rocinsight.analysis.core.execute_statement", side_effect=Exception("no such table")):
+            result = analyze_roctx_regions(mock_conn)
+        assert result is None
+
+    def test_detects_markers_and_computes_breakdown(self):
+        """Detects markers and correlates kernels by timestamp overlap."""
+        mock_conn = MagicMock()
+
+        # Marker query returns 1 marker: "timing" from 100 to 200
+        marker_cursor = MagicMock()
+        marker_cursor.fetchall.return_value = [
+            ("timing", 100, 200, 100),
+        ]
+        # Kernel query returns 2 kernels: one inside marker, one outside
+        kernel_cursor = MagicMock()
+        kernel_cursor.fetchall.return_value = [
+            ("kernel_a", 110, 150, 40),  # inside marker
+            ("kernel_b", 250, 300, 50),  # outside marker
+        ]
+        # Memcpy query returns empty
+        memcpy_cursor = MagicMock()
+        memcpy_cursor.fetchall.return_value = []
+
+        call_count = [0]
+        def mock_exec(conn, query, *args, **kwargs):
+            call_count[0] += 1
+            if call_count[0] == 1:
+                return marker_cursor
+            elif call_count[0] == 2:
+                return kernel_cursor
+            return memcpy_cursor
+
+        with patch("rocinsight.analysis.core.execute_statement", side_effect=mock_exec):
+            result = analyze_roctx_regions(mock_conn)
+
+        assert result is not None
+        assert result["has_markers"] is True
+        assert result["marker_count"] == 1
+        assert len(result["regions"]) == 1
+        assert result["regions"][0]["name"] == "timing"
+        assert result["regions"][0]["kernel_count"] == 1
+        assert result["regions"][0]["kernel_time_ns"] == 40
+
+    def test_gpu_idle_suppressed_when_fom_region_utilized(self):
+        """GPU idle warning suppressed when figure-of-merit region > 90% kernel."""
+        tb = {
+            "total_kernel_time": 50_000_000,
+            "total_memcpy_time": 0,
+            "total_runtime": 200_000_000,
+            "kernel_percent": 25.0,
+            "memcpy_percent": 0.0,
+            "overhead_percent": 75.0,
+        }
+        it = {"idle_pct": 75.0, "total_wall_ns": 200_000_000}
+        roctx = {
+            "has_markers": True,
+            "marker_count": 1,
+            "regions": [{
+                "name": "timing",
+                "wall_time_ns": 50_000_000,
+                "kernel_count": 100,
+                "kernel_time_ns": 49_500_000,
+                "memcpy_count": 0,
+                "memcpy_time_ns": 0,
+                "overhead_time_ns": 500_000,
+                "kernel_pct": 99.0,
+                "memcpy_pct": 0.0,
+                "overhead_pct": 1.0,
+            }],
+            "unranged": {"wall_time_ns": 150_000_000, "kernel_count": 0, "kernel_time_ns": 0,
+                         "memcpy_count": 0, "memcpy_time_ns": 0, "overhead_time_ns": 150_000_000,
+                         "kernel_pct": 0, "memcpy_pct": 0, "overhead_pct": 100},
+            "unranged_pct_of_total": 75.0,
+            "total_runtime_ns": 200_000_000,
+        }
+        recs = generate_recommendations(tb, [], {}, None, interval_timeline=it, roctx_regions=roctx)
+        # Should have scoped INFO, NOT the HIGH GPU Utilization
+        cats = [r["category"] for r in recs]
+        assert "GPU Utilization (Scoped)" in cats
+        assert "GPU Utilization" not in cats  # HIGH version suppressed
+
+
+# ---------------------------------------------------------------------------
+# E1: rocprof-compute first
+# ---------------------------------------------------------------------------
+
+class TestE1RocprofComputeFirst:
+    def test_rocprof_compute_is_first_command(self):
+        """rocprof-compute should be the first command in Kernel Hotspot."""
+        tb = {
+            "total_kernel_time": 90_000_000,
+            "total_memcpy_time": 0,
+            "total_runtime": 100_000_000,
+            "kernel_percent": 90.0,
+            "memcpy_percent": 0.0,
+            "overhead_percent": 10.0,
+        }
+        hotspots = [{
+            "name": "my_kernel",
+            "calls": 100,
+            "total_duration": 90_000_000,
+            "avg_duration": 900_000,
+            "percent_of_total": 90.0,
+        }]
+        recs = generate_recommendations(tb, hotspots, {}, None)
+        kernel_recs = [r for r in recs if r["category"] == "Kernel Hotspot"]
+        assert len(kernel_recs) == 1
+        cmds = kernel_recs[0].get("commands", [])
+        assert len(cmds) >= 2
+        assert cmds[0]["tool"] == "rocprof-compute"
+        assert cmds[1]["tool"] == "rocprofv3"
+
+
+# ---------------------------------------------------------------------------
+# E2: roctxProfilerPause recommendation
+# ---------------------------------------------------------------------------
+
+class TestE2ProfilerPause:
+    def test_fires_when_unranged_over_50(self):
+        """Profiling Scope recommendation fires when unranged > 50%."""
+        roctx = {
+            "has_markers": True,
+            "marker_count": 1,
+            "regions": [{"name": "timing", "wall_time_ns": 50_000_000,
+                         "kernel_count": 10, "kernel_time_ns": 45_000_000,
+                         "memcpy_count": 0, "memcpy_time_ns": 0,
+                         "overhead_time_ns": 5_000_000,
+                         "kernel_pct": 90.0, "memcpy_pct": 0, "overhead_pct": 10.0}],
+            "unranged": {"wall_time_ns": 150_000_000, "kernel_count": 0,
+                         "kernel_time_ns": 0, "memcpy_count": 0,
+                         "memcpy_time_ns": 0, "overhead_time_ns": 150_000_000,
+                         "kernel_pct": 0, "memcpy_pct": 0, "overhead_pct": 100},
+            "unranged_pct_of_total": 75.0,
+            "total_runtime_ns": 200_000_000,
+        }
+        tb = {"total_kernel_time": 0, "total_memcpy_time": 0, "total_runtime": 0,
+              "kernel_percent": 0, "memcpy_percent": 0, "overhead_percent": 0}
+        recs = generate_recommendations(tb, [], {}, None, roctx_regions=roctx)
+        scope_recs = [r for r in recs if r["category"] == "Profiling Scope"]
+        assert len(scope_recs) == 1
+        assert "roctxProfilerPause" in scope_recs[0]["actions"][0]
+        assert scope_recs[0]["confidence"] == 0.90
+
+    def test_absent_when_unranged_under_50(self):
+        """No Profiling Scope recommendation when unranged < 50%."""
+        roctx = {
+            "has_markers": True,
+            "marker_count": 1,
+            "regions": [{"name": "timing", "wall_time_ns": 150_000_000,
+                         "kernel_count": 10, "kernel_time_ns": 100_000_000,
+                         "memcpy_count": 0, "memcpy_time_ns": 0,
+                         "overhead_time_ns": 50_000_000,
+                         "kernel_pct": 66.7, "memcpy_pct": 0, "overhead_pct": 33.3}],
+            "unranged": {"wall_time_ns": 50_000_000, "kernel_count": 0,
+                         "kernel_time_ns": 0, "memcpy_count": 0,
+                         "memcpy_time_ns": 0, "overhead_time_ns": 50_000_000,
+                         "kernel_pct": 0, "memcpy_pct": 0, "overhead_pct": 100},
+            "unranged_pct_of_total": 25.0,
+            "total_runtime_ns": 200_000_000,
+        }
+        tb = {"total_kernel_time": 0, "total_memcpy_time": 0, "total_runtime": 0,
+              "kernel_percent": 0, "memcpy_percent": 0, "overhead_percent": 0}
+        recs = generate_recommendations(tb, [], {}, None, roctx_regions=roctx)
+        scope_recs = [r for r in recs if r["category"] == "Profiling Scope"]
+        assert len(scope_recs) == 0

--- a/experimental/python/rocinsight/rocinsight/ai_analysis/tests/test_roctx_region_analysis.py
+++ b/experimental/python/rocinsight/rocinsight/ai_analysis/tests/test_roctx_region_analysis.py
@@ -197,3 +197,67 @@ class TestE2ProfilerPause:
         recs = generate_recommendations(tb, [], {}, None, roctx_regions=roctx)
         scope_recs = [r for r in recs if r["category"] == "Profiling Scope"]
         assert len(scope_recs) == 0
+
+
+# ---------------------------------------------------------------------------
+# Nested marker conservation tests
+# ---------------------------------------------------------------------------
+
+class TestNestedMarkerAccounting:
+    def test_nested_parent_uses_exclusive_wall(self):
+        """Parent exclusive wall = total duration minus child coverage."""
+        mock_conn = MagicMock()
+        marker_cursor = MagicMock()
+        marker_cursor.fetchall.return_value = [
+            ("parent", 0, 100, 100),
+            ("child", 20, 80, 60),
+        ]
+        kernel_cursor = MagicMock()
+        kernel_cursor.fetchall.return_value = [("k1", 30, 70, 40)]
+        memcpy_cursor = MagicMock()
+        memcpy_cursor.fetchall.return_value = []
+
+        call_count = [0]
+        def mock_exec(conn, query, *args, **kwargs):
+            call_count[0] += 1
+            if call_count[0] == 1: return marker_cursor
+            elif call_count[0] == 2: return kernel_cursor
+            return memcpy_cursor
+
+        with patch("rocinsight.analysis.core.execute_statement", side_effect=mock_exec):
+            result = analyze_roctx_regions(mock_conn)
+
+        parent = result["regions"][0]
+        child = result["regions"][1]
+        assert child["kernel_count"] == 1
+        assert child["kernel_time_ns"] == 40
+        assert parent["exclusive_wall_time_ns"] == 40
+        assert parent["kernel_time_ns"] == 0
+        assert parent["kernel_pct"] == 0.0
+
+    def test_nested_conservation_total_kernel_time(self):
+        """sum(region kernel time) + unranged kernel time == total kernel time."""
+        mock_conn = MagicMock()
+        marker_cursor = MagicMock()
+        marker_cursor.fetchall.return_value = [
+            ("outer", 0, 100, 100),
+            ("inner", 20, 80, 60),
+        ]
+        kernel_cursor = MagicMock()
+        kernel_cursor.fetchall.return_value = [("k1", 10, 90, 80)]
+        memcpy_cursor = MagicMock()
+        memcpy_cursor.fetchall.return_value = []
+
+        call_count = [0]
+        def mock_exec(conn, query, *args, **kwargs):
+            call_count[0] += 1
+            if call_count[0] == 1: return marker_cursor
+            elif call_count[0] == 2: return kernel_cursor
+            return memcpy_cursor
+
+        with patch("rocinsight.analysis.core.execute_statement", side_effect=mock_exec):
+            result = analyze_roctx_regions(mock_conn)
+
+        ranged = sum(r["kernel_time_ns"] for r in result["regions"])
+        unranged = result["unranged"]["kernel_time_ns"]
+        assert ranged + unranged == 80

--- a/experimental/python/rocinsight/rocinsight/ai_analysis/tests/test_roctx_region_analysis.py
+++ b/experimental/python/rocinsight/rocinsight/ai_analysis/tests/test_roctx_region_analysis.py
@@ -1,4 +1,4 @@
-"""Tests for ROCM-21553 PR3: roctx support and profiling scope.
+"""Tests for roctx marker region analysis, GPU idle scoping, and profiling scope.
 
 Tests cover:
 - C1: analyze_roctx_regions() marker detection and correlation

--- a/experimental/python/rocinsight/rocinsight/analysis/__init__.py
+++ b/experimental/python/rocinsight/rocinsight/analysis/__init__.py
@@ -36,6 +36,7 @@ from .core import (
     detect_warmup_issues,
     analyze_kernel_resources,
     analyze_api_overhead,
+    analyze_roctx_regions,
     _ARCH_SPECS,
 )
 
@@ -76,6 +77,7 @@ __all__ = [
     "analyze_kernel_resources",
     "analyze_api_overhead",
     "_ARCH_SPECS",
+    "analyze_roctx_regions",
     # att.py
     "_ATT_STALL_CATEGORY_MAP",
     "_ATT_MIN_HITCOUNT",

--- a/experimental/python/rocinsight/rocinsight/analysis/core.py
+++ b/experimental/python/rocinsight/rocinsight/analysis/core.py
@@ -689,15 +689,30 @@ def analyze_roctx_regions(connection: RocpdImportData) -> Optional[Dict[str, Any
                 merged.append((s, e))
         return sum(e - s for s, e in merged)
 
+    # Pre-compute child coverage for each marker to get exclusive wall time.
+    # A child is any other marker fully contained within this one.
+    marker_exclusive_wall: List[int] = []
+    for mi, m in enumerate(markers):
+        ms, me = m["start"], m["end"]
+        # Collect intervals of child markers nested inside this one
+        child_intervals = []
+        for mj, m2 in enumerate(markers):
+            if mj == mi:
+                continue
+            m2s, m2e = m2["start"], m2["end"]
+            # m2 is a child if it's fully inside m (or overlaps and is shorter)
+            if m2s >= ms and m2e <= me and (m2e - m2s) < (me - ms):
+                child_intervals.append((m2s, m2e))
+        child_coverage = _compute_union_coverage(child_intervals)
+        marker_exclusive_wall.append(max(0, m["duration"] - child_coverage))
+
     # Per-region accounting: for each event, split time into covered and uncovered
     region_data: List[Dict[str, Any]] = []
-    # Track total ranged time per event type for conservation check
     total_ranged_kernel_ns = 0
     total_ranged_memcpy_ns = 0
 
     for mi, m in enumerate(markers):
         ms, me = m["start"], m["end"]
-        # Events whose best marker is this one
         m_kernels = [k for k in all_kernels if _best_marker_idx(k[1], k[2]) == mi]
         m_memcpy = [mc for mc in all_memcpy if _best_marker_idx(mc[1], mc[2]) == mi]
 
@@ -711,20 +726,26 @@ def analyze_roctx_regions(connection: RocpdImportData) -> Optional[Dict[str, Any
         total_ranged_kernel_ns += kernel_time
         total_ranged_memcpy_ns += memcpy_time
 
-        wall_time = m["duration"]
-        overhead_time = max(0, wall_time - kernel_time - memcpy_time)
+        # Use exclusive wall time (total minus nested children) as the
+        # denominator for percentages. This ensures that when child ranges
+        # own the kernel work inside them, the parent's percentages reflect
+        # only the parent's exclusive time slice.
+        exclusive_wall = marker_exclusive_wall[mi]
+        total_wall = m["duration"]
+        overhead_time = max(0, exclusive_wall - kernel_time - memcpy_time)
 
         region_data.append({
             "name": m["name"],
-            "wall_time_ns": wall_time,
+            "wall_time_ns": total_wall,
+            "exclusive_wall_time_ns": exclusive_wall,
             "kernel_count": len(m_kernels),
             "kernel_time_ns": kernel_time,
             "memcpy_count": len(m_memcpy),
             "memcpy_time_ns": memcpy_time,
             "overhead_time_ns": overhead_time,
-            "kernel_pct": (kernel_time / wall_time * 100) if wall_time > 0 else 0,
-            "memcpy_pct": (memcpy_time / wall_time * 100) if wall_time > 0 else 0,
-            "overhead_pct": (overhead_time / wall_time * 100) if wall_time > 0 else 0,
+            "kernel_pct": (kernel_time / exclusive_wall * 100) if exclusive_wall > 0 else 0,
+            "memcpy_pct": (memcpy_time / exclusive_wall * 100) if exclusive_wall > 0 else 0,
+            "overhead_pct": (overhead_time / exclusive_wall * 100) if exclusive_wall > 0 else 0,
         })
 
     # Step 4: Conservation-correct unranged bucket.

--- a/experimental/python/rocinsight/rocinsight/analysis/core.py
+++ b/experimental/python/rocinsight/rocinsight/analysis/core.py
@@ -590,10 +590,22 @@ def analyze_roctx_regions(connection: RocpdImportData) -> Optional[Dict[str, Any
     ``MARKER_CORE_RANGE_API`` (user roctx markers), then correlates kernel
     dispatches and memory copy operations by timestamp overlap.
 
+    **Attribution model** (innermost-wins, no double-counting):
+
+    Each GPU event is assigned to exactly one marker range — the innermost
+    (most specific) range that overlaps it. For nested ranges
+    (``roctxRangePush``/``Pop``), this means child ranges capture events
+    before parent ranges. For partially overlapping ranges
+    (``roctxRangeStart``/``Stop`` across threads), events go to the range
+    with the greatest time overlap. Only the overlapping time portion is
+    counted. Parent ranges in a hierarchy show only work directly inside
+    them but outside any child — they do NOT include child activity.
+
     Returns ``None`` if no user roctx markers are found in the trace
     (graceful no-op — callers check ``if roctx_regions:``).
 
     When markers are found, returns a dict with:
+
     - ``regions``: per-marker breakdown (wall time, kernel/memcpy counts and %)
     - ``unranged``: activity that falls outside any marker
     - ``unranged_pct_of_total``: fraction of total runtime that is unranged
@@ -635,22 +647,62 @@ def analyze_roctx_regions(connection: RocpdImportData) -> Optional[Dict[str, Any
     except Exception:
         all_memcpy = []
 
-    # Step 3: Correlate each event with a marker by timestamp overlap
-    all_marker_ranges = [(m["start"], m["end"]) for m in markers]
+    # Step 3: Correlate each event with a marker by timestamp overlap.
+    #
+    # Attribution model (innermost-wins, no double-counting):
+    #   - Each GPU event is assigned to exactly ONE marker range.
+    #   - When ranges are nested (roctxRangePush/Pop), events go to the
+    #     innermost (most specific) range that contains them.
+    #   - When ranges partially overlap (roctxRangeStart/Stop across
+    #     threads), events go to the range with the greatest overlap.
+    #   - Ties broken by range duration (shorter = more specific).
+    #   - Only the overlapping time portion is counted for partial overlaps.
+    #   - Events with zero overlap to any range go to the "unranged" bucket.
+    #
+    # This model avoids double-counting: every nanosecond of GPU work is
+    # attributed to at most one range. Parent ranges in a nested hierarchy
+    # do NOT include child activity — they show only work that is directly
+    # inside the parent but outside any child range.
+    all_marker_ranges = [(m["start"], m["end"], m["duration"]) for m in markers]
+
+    def _best_marker_idx(event_start: int, event_end: int) -> int:
+        """Return index of the best-matching marker for this event.
+
+        Prefers the marker with the greatest overlap. On ties (e.g. an
+        event fully inside both a parent and child range), prefers the
+        shorter (more specific / innermost) range.
+        """
+        best_idx = -1
+        best_overlap = 0
+        best_duration = float("inf")
+        for i, (ms, me, mdur) in enumerate(all_marker_ranges):
+            overlap_start = max(event_start, ms)
+            overlap_end = min(event_end, me)
+            overlap = max(0, overlap_end - overlap_start)
+            if overlap > best_overlap or (overlap == best_overlap and overlap > 0 and mdur < best_duration):
+                best_overlap = overlap
+                best_idx = i
+                best_duration = mdur
+        return best_idx
 
     def _in_marker(event_start: int, event_end: int) -> bool:
-        for ms, me in all_marker_ranges:
-            if event_start >= ms and event_end <= me:
-                return True
-        return False
+        return _best_marker_idx(event_start, event_end) >= 0
 
     region_data: List[Dict[str, Any]] = []
-    for m in markers:
-        m_kernels = [k for k in all_kernels if k[1] >= m["start"] and k[2] <= m["end"]]
-        m_memcpy = [mc for mc in all_memcpy if mc[1] >= m["start"] and mc[2] <= m["end"]]
+    for mi, m in enumerate(markers):
+        ms, me = m["start"], m["end"]
+        m_kernels = [k for k in all_kernels if _best_marker_idx(k[1], k[2]) == mi]
+        m_memcpy = [mc for mc in all_memcpy if _best_marker_idx(mc[1], mc[2]) == mi]
 
-        kernel_time = sum(k[3] for k in m_kernels)
-        memcpy_time = sum(mc[3] for mc in m_memcpy)
+        # For partially overlapping events, count only the overlapping portion
+        kernel_time = 0
+        for k in m_kernels:
+            overlap = min(k[2], me) - max(k[1], ms)
+            kernel_time += max(0, overlap)
+        memcpy_time = 0
+        for mc in m_memcpy:
+            overlap = min(mc[2], me) - max(mc[1], ms)
+            memcpy_time += max(0, overlap)
         wall_time = m["duration"]
         overhead_time = max(0, wall_time - kernel_time - memcpy_time)
 

--- a/experimental/python/rocinsight/rocinsight/analysis/core.py
+++ b/experimental/python/rocinsight/rocinsight/analysis/core.py
@@ -590,16 +590,16 @@ def analyze_roctx_regions(connection: RocpdImportData) -> Optional[Dict[str, Any
     ``MARKER_CORE_RANGE_API`` (user roctx markers), then correlates kernel
     dispatches and memory copy operations by timestamp overlap.
 
-    **Attribution model** (innermost-wins, no double-counting):
+    **Conservation-correct attribution model:**
 
-    Each GPU event is assigned to exactly one marker range — the innermost
-    (most specific) range that overlaps it. For nested ranges
-    (``roctxRangePush``/``Pop``), this means child ranges capture events
-    before parent ranges. For partially overlapping ranges
-    (``roctxRangeStart``/``Stop`` across threads), events go to the range
-    with the greatest time overlap. Only the overlapping time portion is
-    counted. Parent ranges in a hierarchy show only work directly inside
-    them but outside any child — they do NOT include child activity.
+    Every nanosecond of GPU work is accounted for exactly once — either
+    inside a marker region or in the unranged bucket. For per-region
+    ownership, the overlapping portion of each event goes to the innermost
+    (shortest-duration) marker. The non-overlapping portion goes to the
+    unranged bucket. Wall-time coverage uses the UNION of marker intervals
+    (not sum of durations) to correctly handle nested and overlapping ranges
+    per the ROC-TX library spec (``roctxRangePush``/``Pop`` nesting and
+    ``roctxRangeStart``/``Stop`` cross-thread overlaps).
 
     Returns ``None`` if no user roctx markers are found in the trace
     (graceful no-op — callers check ``if roctx_regions:``).
@@ -647,62 +647,70 @@ def analyze_roctx_regions(connection: RocpdImportData) -> Optional[Dict[str, Any
     except Exception:
         all_memcpy = []
 
-    # Step 3: Correlate each event with a marker by timestamp overlap.
+    # Step 3: Conservation-correct interval accounting.
     #
-    # Attribution model (innermost-wins, no double-counting):
-    #   - Each GPU event is assigned to exactly ONE marker range.
-    #   - When ranges are nested (roctxRangePush/Pop), events go to the
-    #     innermost (most specific) range that contains them.
-    #   - When ranges partially overlap (roctxRangeStart/Stop across
-    #     threads), events go to the range with the greatest overlap.
-    #   - Ties broken by range duration (shorter = more specific).
-    #   - Only the overlapping time portion is counted for partial overlaps.
-    #   - Events with zero overlap to any range go to the "unranged" bucket.
+    # Key principles:
+    #   1. Every nanosecond of an event is accounted for exactly once —
+    #      either inside a marker region or in the unranged bucket.
+    #   2. For per-region ownership, each event is assigned to the
+    #      innermost (shortest) marker that overlaps it. Only the
+    #      overlapping portion counts toward that region.
+    #   3. The non-overlapping portion of a partially-overlapping event
+    #      goes to the unranged bucket (not lost).
+    #   4. Wall-time coverage uses the UNION of marker intervals (not
+    #      sum of durations) to correctly handle nested/overlapping ranges.
     #
-    # This model avoids double-counting: every nanosecond of GPU work is
-    # attributed to at most one range. Parent ranges in a nested hierarchy
-    # do NOT include child activity — they show only work that is directly
-    # inside the parent but outside any child range.
+    # This ensures: sum(region_kernel_time) + unranged_kernel_time == total_kernel_time
     all_marker_ranges = [(m["start"], m["end"], m["duration"]) for m in markers]
 
     def _best_marker_idx(event_start: int, event_end: int) -> int:
-        """Return index of the best-matching marker for this event.
-
-        Prefers the marker with the greatest overlap. On ties (e.g. an
-        event fully inside both a parent and child range), prefers the
-        shorter (more specific / innermost) range.
-        """
+        """Return index of the marker with greatest overlap, preferring shorter (innermost) on ties."""
         best_idx = -1
         best_overlap = 0
         best_duration = float("inf")
         for i, (ms, me, mdur) in enumerate(all_marker_ranges):
-            overlap_start = max(event_start, ms)
-            overlap_end = min(event_end, me)
-            overlap = max(0, overlap_end - overlap_start)
-            if overlap > best_overlap or (overlap == best_overlap and overlap > 0 and mdur < best_duration):
-                best_overlap = overlap
+            ov = max(0, min(event_end, me) - max(event_start, ms))
+            if ov > best_overlap or (ov == best_overlap and ov > 0 and mdur < best_duration):
+                best_overlap = ov
                 best_idx = i
                 best_duration = mdur
         return best_idx
 
-    def _in_marker(event_start: int, event_end: int) -> bool:
-        return _best_marker_idx(event_start, event_end) >= 0
+    def _compute_union_coverage(intervals):
+        """Compute total wall-time covered by the union of intervals."""
+        if not intervals:
+            return 0
+        sorted_iv = sorted(intervals, key=lambda x: x[0])
+        merged = [sorted_iv[0]]
+        for s, e in sorted_iv[1:]:
+            if s <= merged[-1][1]:
+                merged[-1] = (merged[-1][0], max(merged[-1][1], e))
+            else:
+                merged.append((s, e))
+        return sum(e - s for s, e in merged)
 
+    # Per-region accounting: for each event, split time into covered and uncovered
     region_data: List[Dict[str, Any]] = []
+    # Track total ranged time per event type for conservation check
+    total_ranged_kernel_ns = 0
+    total_ranged_memcpy_ns = 0
+
     for mi, m in enumerate(markers):
         ms, me = m["start"], m["end"]
+        # Events whose best marker is this one
         m_kernels = [k for k in all_kernels if _best_marker_idx(k[1], k[2]) == mi]
         m_memcpy = [mc for mc in all_memcpy if _best_marker_idx(mc[1], mc[2]) == mi]
 
-        # For partially overlapping events, count only the overlapping portion
         kernel_time = 0
         for k in m_kernels:
-            overlap = min(k[2], me) - max(k[1], ms)
-            kernel_time += max(0, overlap)
+            kernel_time += max(0, min(k[2], me) - max(k[1], ms))
         memcpy_time = 0
         for mc in m_memcpy:
-            overlap = min(mc[2], me) - max(mc[1], ms)
-            memcpy_time += max(0, overlap)
+            memcpy_time += max(0, min(mc[2], me) - max(mc[1], ms))
+
+        total_ranged_kernel_ns += kernel_time
+        total_ranged_memcpy_ns += memcpy_time
+
         wall_time = m["duration"]
         overhead_time = max(0, wall_time - kernel_time - memcpy_time)
 
@@ -719,9 +727,30 @@ def analyze_roctx_regions(connection: RocpdImportData) -> Optional[Dict[str, Any
             "overhead_pct": (overhead_time / wall_time * 100) if wall_time > 0 else 0,
         })
 
-    # Step 4: Compute (unranged) bucket
-    unranged_kernels = [k for k in all_kernels if not _in_marker(k[1], k[2])]
-    unranged_memcpy = [mc for mc in all_memcpy if not _in_marker(mc[1], mc[2])]
+    # Step 4: Conservation-correct unranged bucket.
+    #
+    # Unranged kernel/memcpy time = total event time minus what was attributed
+    # to regions. This correctly accounts for partial overlaps: the uncovered
+    # portion of a partially-overlapping event lands here automatically.
+    total_kernel_time = sum(k[3] for k in all_kernels)
+    total_memcpy_time = sum(mc[3] for mc in all_memcpy)
+
+    unranged_kernel_time = total_kernel_time - total_ranged_kernel_ns
+    unranged_memcpy_time = total_memcpy_time - total_ranged_memcpy_ns
+
+    # Count events that have ANY unranged portion
+    unranged_kernel_count = sum(
+        1 for k in all_kernels
+        if _best_marker_idx(k[1], k[2]) < 0  # fully unranged
+        or (k[3] > max(0, min(k[2], all_marker_ranges[_best_marker_idx(k[1], k[2])][1])
+                        - max(k[1], all_marker_ranges[_best_marker_idx(k[1], k[2])][0])))  # partially unranged
+    )
+    unranged_memcpy_count = sum(
+        1 for mc in all_memcpy
+        if _best_marker_idx(mc[1], mc[2]) < 0
+        or (mc[3] > max(0, min(mc[2], all_marker_ranges[_best_marker_idx(mc[1], mc[2])][1])
+                         - max(mc[1], all_marker_ranges[_best_marker_idx(mc[1], mc[2])][0])))
+    )
 
     # Total runtime from event span
     total_runtime = 0
@@ -731,10 +760,11 @@ def analyze_roctx_regions(connection: RocpdImportData) -> Optional[Dict[str, Any
         if all_starts:
             total_runtime = max(all_ends) - min(all_starts)
 
-    total_marker_time = sum(m["duration"] for m in markers)
-    unranged_wall = max(0, total_runtime - total_marker_time)
-    unranged_kernel_time = sum(k[3] for k in unranged_kernels)
-    unranged_memcpy_time = sum(mc[3] for mc in unranged_memcpy)
+    # Use UNION of marker intervals (not sum) to handle nesting/overlap
+    marker_union_coverage = _compute_union_coverage(
+        [(m["start"], m["end"]) for m in markers]
+    )
+    unranged_wall = max(0, total_runtime - marker_union_coverage)
     unranged_overhead = max(0, unranged_wall - unranged_kernel_time - unranged_memcpy_time)
 
     unranged_pct = (unranged_wall / total_runtime * 100) if total_runtime > 0 else 0
@@ -745,9 +775,9 @@ def analyze_roctx_regions(connection: RocpdImportData) -> Optional[Dict[str, Any
         "regions": region_data,
         "unranged": {
             "wall_time_ns": unranged_wall,
-            "kernel_count": len(unranged_kernels),
+            "kernel_count": unranged_kernel_count,
             "kernel_time_ns": unranged_kernel_time,
-            "memcpy_count": len(unranged_memcpy),
+            "memcpy_count": unranged_memcpy_count,
             "memcpy_time_ns": unranged_memcpy_time,
             "overhead_time_ns": unranged_overhead,
             "kernel_pct": (unranged_kernel_time / unranged_wall * 100) if unranged_wall > 0 else 0,

--- a/experimental/python/rocinsight/rocinsight/analysis/core.py
+++ b/experimental/python/rocinsight/rocinsight/analysis/core.py
@@ -580,3 +580,128 @@ def analyze_api_overhead(connection: RocpdImportData) -> Dict[str, Any]:
     except Exception:
         # Graceful fallback if regions view doesn't exist in older DBs
         return {"api_calls": [], "launch_overhead_ns": 0, "total_api_ns": 0, "has_api_data": False}
+
+
+def analyze_roctx_regions(connection: RocpdImportData) -> Optional[Dict[str, Any]]:
+    """
+    Discover roctx marker regions and correlate with kernel/memcpy activity.
+
+    Queries the ``regions`` view for entries with category
+    ``MARKER_CORE_RANGE_API`` (user roctx markers), then correlates kernel
+    dispatches and memory copy operations by timestamp overlap.
+
+    Returns ``None`` if no user roctx markers are found in the trace
+    (graceful no-op — callers check ``if roctx_regions:``).
+
+    When markers are found, returns a dict with:
+    - ``regions``: per-marker breakdown (wall time, kernel/memcpy counts and %)
+    - ``unranged``: activity that falls outside any marker
+    - ``unranged_pct_of_total``: fraction of total runtime that is unranged
+    """
+    # Step 1: Find user roctx markers
+    marker_query = """
+    SELECT name, start, end, duration
+    FROM regions
+    WHERE category = 'MARKER_CORE_RANGE_API'
+    ORDER BY start ASC
+    """
+    try:
+        rows = execute_statement(connection, marker_query).fetchall()
+    except Exception:
+        return None  # regions view may not exist in older DBs
+
+    if not rows:
+        return None  # No markers — no-op
+
+    markers = []
+    for row in rows:
+        markers.append({
+            "name": row[0],
+            "start": row[1],
+            "end": row[2],
+            "duration": row[3] or (row[2] - row[1]),
+        })
+
+    # Step 2: Get all kernels and memcpy with timestamps
+    kernel_query = "SELECT name, start, end, duration FROM kernels ORDER BY start"
+    memcpy_query = "SELECT name, start, end, duration FROM memory_copies ORDER BY start"
+
+    try:
+        all_kernels = execute_statement(connection, kernel_query).fetchall()
+    except Exception:
+        all_kernels = []
+    try:
+        all_memcpy = execute_statement(connection, memcpy_query).fetchall()
+    except Exception:
+        all_memcpy = []
+
+    # Step 3: Correlate each event with a marker by timestamp overlap
+    all_marker_ranges = [(m["start"], m["end"]) for m in markers]
+
+    def _in_marker(event_start: int, event_end: int) -> bool:
+        for ms, me in all_marker_ranges:
+            if event_start >= ms and event_end <= me:
+                return True
+        return False
+
+    region_data: List[Dict[str, Any]] = []
+    for m in markers:
+        m_kernels = [k for k in all_kernels if k[1] >= m["start"] and k[2] <= m["end"]]
+        m_memcpy = [mc for mc in all_memcpy if mc[1] >= m["start"] and mc[2] <= m["end"]]
+
+        kernel_time = sum(k[3] for k in m_kernels)
+        memcpy_time = sum(mc[3] for mc in m_memcpy)
+        wall_time = m["duration"]
+        overhead_time = max(0, wall_time - kernel_time - memcpy_time)
+
+        region_data.append({
+            "name": m["name"],
+            "wall_time_ns": wall_time,
+            "kernel_count": len(m_kernels),
+            "kernel_time_ns": kernel_time,
+            "memcpy_count": len(m_memcpy),
+            "memcpy_time_ns": memcpy_time,
+            "overhead_time_ns": overhead_time,
+            "kernel_pct": (kernel_time / wall_time * 100) if wall_time > 0 else 0,
+            "memcpy_pct": (memcpy_time / wall_time * 100) if wall_time > 0 else 0,
+            "overhead_pct": (overhead_time / wall_time * 100) if wall_time > 0 else 0,
+        })
+
+    # Step 4: Compute (unranged) bucket
+    unranged_kernels = [k for k in all_kernels if not _in_marker(k[1], k[2])]
+    unranged_memcpy = [mc for mc in all_memcpy if not _in_marker(mc[1], mc[2])]
+
+    # Total runtime from event span
+    total_runtime = 0
+    if all_kernels or all_memcpy:
+        all_starts = [k[1] for k in all_kernels] + [mc[1] for mc in all_memcpy]
+        all_ends = [k[2] for k in all_kernels] + [mc[2] for mc in all_memcpy]
+        if all_starts:
+            total_runtime = max(all_ends) - min(all_starts)
+
+    total_marker_time = sum(m["duration"] for m in markers)
+    unranged_wall = max(0, total_runtime - total_marker_time)
+    unranged_kernel_time = sum(k[3] for k in unranged_kernels)
+    unranged_memcpy_time = sum(mc[3] for mc in unranged_memcpy)
+    unranged_overhead = max(0, unranged_wall - unranged_kernel_time - unranged_memcpy_time)
+
+    unranged_pct = (unranged_wall / total_runtime * 100) if total_runtime > 0 else 0
+
+    return {
+        "has_markers": True,
+        "marker_count": len(markers),
+        "regions": region_data,
+        "unranged": {
+            "wall_time_ns": unranged_wall,
+            "kernel_count": len(unranged_kernels),
+            "kernel_time_ns": unranged_kernel_time,
+            "memcpy_count": len(unranged_memcpy),
+            "memcpy_time_ns": unranged_memcpy_time,
+            "overhead_time_ns": unranged_overhead,
+            "kernel_pct": (unranged_kernel_time / unranged_wall * 100) if unranged_wall > 0 else 0,
+            "memcpy_pct": (unranged_memcpy_time / unranged_wall * 100) if unranged_wall > 0 else 0,
+            "overhead_pct": (unranged_overhead / unranged_wall * 100) if unranged_wall > 0 else 0,
+        },
+        "unranged_pct_of_total": unranged_pct,
+        "total_runtime_ns": total_runtime,
+    }

--- a/experimental/python/rocinsight/rocinsight/analysis/recommendations.py
+++ b/experimental/python/rocinsight/rocinsight/analysis/recommendations.py
@@ -298,6 +298,7 @@ def generate_recommendations(
     att_analysis: Optional[Dict[str, Any]] = None,  # Tier 3 ATT
     warmup_issues: Optional[Dict[str, Any]] = None,  # Warmup detection
     api_overhead: Optional[Dict[str, Any]] = None,  # Per-API breakdown
+    roctx_regions: Optional[Dict[str, Any]] = None,  # roctx marker regions
 ) -> List[Dict[str, Any]]:
     """
     Generate performance recommendations based on analysis results.
@@ -719,8 +720,21 @@ def generate_recommendations(
                     "estimated_impact": f"Kernel accounts for {percent:.1f}% of GPU time ({top_kernel.get('total_duration', 0) / 1e6:.1f}ms) — bottleneck type unknown without counters; impact depends on classification",
                     "commands": [
                         {
+                            "tool": "rocprof-compute",
+                            "description": "Roofline model, instruction mix, and memory bottleneck analysis for this kernel",
+                            "flags": [],
+                            "args": [
+                                {"name": "profile", "value": None},
+                                {
+                                    "name": "--kernel",
+                                    "value": kernel_name,
+                                },
+                            ],
+                            "full_command": f"rocprof-compute profile --kernel {shlex.quote(kernel_name)} -- ./app",
+                        },
+                        {
                             "tool": "rocprofv3",
-                            "description": "Collect GPU hardware counters scoped to the dominant kernel",
+                            "description": "Collect GPU hardware counters scoped to the dominant kernel (alternative to rocprof-compute)",
                             "flags": ["--sys-trace"],
                             "args": [
                                 {
@@ -730,7 +744,7 @@ def generate_recommendations(
                                 {
                                     "name": "--kernel-names",
                                     "value": kernel_name,
-                                },  # display only; full_command uses shlex.quote
+                                },
                                 {"name": "-d", "value": "./kernel_output"},
                                 {"name": "-o", "value": "profile"},
                             ],
@@ -739,19 +753,6 @@ def generate_recommendations(
                                 f" --kernel-names {shlex.quote(kernel_name)}"
                                 f" -d ./kernel_output -o profile -- ./app"
                             ),
-                        },
-                        {
-                            "tool": "rocprof-compute",
-                            "description": "Roofline model, instruction mix, and memory bottleneck analysis for this kernel",
-                            "flags": [],
-                            "args": [
-                                {"name": "profile", "value": None},
-                                {
-                                    "name": "--kernel",
-                                    "value": kernel_name,
-                                },  # display only; full_command uses shlex.quote
-                            ],
-                            "full_command": f"rocprof-compute profile --kernel {shlex.quote(kernel_name)} -- ./app",
                         },
                     ],
                 }
@@ -872,23 +873,48 @@ def generate_recommendations(
     # Rule 10 -- GPU IDLE TIME (TraceLens interval arithmetic, more accurate than overhead%)
     if interval_timeline and interval_timeline.get("idle_pct", 0) > 20.0:
         idle_pct = interval_timeline["idle_pct"]
-        recommendations.append(
-            {
-                "priority": "HIGH",
-                "category": "GPU Utilization",
-                "issue": f"High GPU idle time detected: {idle_pct:.1f}% of wall time the GPU is idle",
-                "suggestion": "Overlap CPU dispatch work with GPU execution to reduce idle gaps",
-                "actions": [
-                    "- Use async HIP API calls (hipMemcpyAsync, kernel launches without hipDeviceSynchronize)",
-                    "- Introduce hipStream_t streams to overlap independent kernels and transfers",
-                    "- Check for unnecessary hipDeviceSynchronize() calls in hot loops",
-                    "- Use rocprofv3 --hip-trace to identify synchronization points causing stalls",
-                ],
-                "confidence": 0.65,
-                "estimated_impact": f"Up to {idle_pct:.0f}% improvement in wall-time throughput if idle is CPU-bound dispatch",
-                "commands": [],
-            }
-        )
+
+        # Scope to figure-of-merit region when roctx markers are present
+        _suppress_idle = False
+        if roctx_regions and roctx_regions.get("has_markers"):
+            best_region = max(roctx_regions["regions"], key=lambda r: r["kernel_time_ns"], default=None)
+            if best_region and best_region["kernel_pct"] > 90:
+                _suppress_idle = True
+                recommendations.append({
+                    "priority": "INFO",
+                    "category": "GPU Utilization (Scoped)",
+                    "issue": (
+                        f"Global GPU idle time is {idle_pct:.1f}%, but within "
+                        f"'{best_region['name']}' region, GPU utilization is "
+                        f"{best_region['kernel_pct']:.1f}% \u2014 idle time is in setup/teardown"
+                    ),
+                    "suggestion": "Consider scoping profiling to the figure-of-merit region",
+                    "actions": [
+                        "Use roctxProfilerPause()/roctxProfilerResume() to limit profiling to the timing region",
+                    ],
+                    "confidence": 0.85,
+                    "estimated_impact": f"Would eliminate {roctx_regions['unranged_pct_of_total']:.0f}% of trace data (setup/teardown)",
+                    "commands": [],
+                })
+
+        if not _suppress_idle:
+            recommendations.append(
+                {
+                    "priority": "HIGH",
+                    "category": "GPU Utilization",
+                    "issue": f"High GPU idle time detected: {idle_pct:.1f}% of wall time the GPU is idle",
+                    "suggestion": "Overlap CPU dispatch work with GPU execution to reduce idle gaps",
+                    "actions": [
+                        "- Use async HIP API calls (hipMemcpyAsync, kernel launches without hipDeviceSynchronize)",
+                        "- Introduce hipStream_t streams to overlap independent kernels and transfers",
+                        "- Check for unnecessary hipDeviceSynchronize() calls in hot loops",
+                        "- Use rocprofv3 --hip-trace to identify synchronization points causing stalls",
+                    ],
+                    "confidence": 0.65,
+                    "estimated_impact": f"Up to {idle_pct:.0f}% improvement in wall-time throughput if idle is CPU-bound dispatch",
+                    "commands": [],
+                }
+            )
 
     # Rule 6: Default if no issues found (MUST be last -- sentinel for "nothing actionable")
     if not recommendations:
@@ -959,6 +985,31 @@ def generate_recommendations(
                 ],
                 "estimated_impact": f"First dispatch adds {first_us - avg_us:.1f}\u03bcs ({(ratio - 1) * 100:.0f}% overhead) to the first iteration",
                 "confidence": 0.80,
+                "commands": [],
+            })
+
+    # E2: Recommend roctxProfilerPause/Resume when significant unranged time
+    if roctx_regions and roctx_regions.get("has_markers"):
+        unranged_pct = roctx_regions.get("unranged_pct_of_total", 0)
+        if unranged_pct > 50:
+            recommendations.append({
+                "priority": "INFO",
+                "category": "Profiling Scope",
+                "issue": f"{unranged_pct:.0f}% of traced time is outside annotated roctx regions (setup/teardown)",
+                "suggestion": "Scope profiling to the figure-of-merit region to reduce trace size and avoid misleading metrics",
+                "actions": [
+                    "Add roctxProfilerPause() before setup/warmup code",
+                    "Add roctxProfilerResume() before the figure-of-merit region",
+                    "Add roctxProfilerPause() after the figure-of-merit region",
+                    "Example:\n"
+                    "    roctxProfilerPause();   // before setup\n"
+                    "    // ... setup, warmup ...\n"
+                    "    roctxProfilerResume();  // before timing region\n"
+                    "    // ... figure-of-merit work ...\n"
+                    "    roctxProfilerPause();   // after timing region",
+                ],
+                "estimated_impact": f"Would eliminate {unranged_pct:.0f}% of trace data, focusing analysis on the region that matters",
+                "confidence": 0.90,
                 "commands": [],
             })
 

--- a/experimental/python/rocinsight/rocinsight/analyze.py
+++ b/experimental/python/rocinsight/rocinsight/analyze.py
@@ -68,6 +68,7 @@ from .analysis import (  # noqa: F401 -- re-exports for backward compat
     detect_warmup_issues,
     analyze_kernel_resources,
     analyze_api_overhead,
+    analyze_roctx_regions,
     analyze_thread_trace,
     generate_recommendations,
     _split_pmc_into_passes,
@@ -285,6 +286,7 @@ def analyze_performance(
         warmup_issues = detect_warmup_issues(connection, hotspots)
         kernel_resources = analyze_kernel_resources(connection, hotspots)
         api_overhead_data = analyze_api_overhead(connection)
+        roctx_regions = analyze_roctx_regions(connection)
         already_collected = _detect_already_collected(connection)
         # Tier 3: ATT thread trace (optional — only when --att-dir is provided)
         att_analysis: Dict[str, Any] = {}
@@ -313,6 +315,7 @@ def analyze_performance(
             att_analysis=att_analysis if att_dir else None,
             warmup_issues=warmup_issues,
             api_overhead=api_overhead_data,
+            roctx_regions=roctx_regions,
         )
     else:
         time_breakdown = {}
@@ -327,6 +330,7 @@ def analyze_performance(
         warmup_issues = None
         kernel_resources = {"arch": None, "arch_specs": None, "kernels": []}
         api_overhead_data = {}
+        roctx_regions = None
         recommendations = tier0_result.recommendations if tier0_result else []
 
     # Format output
@@ -347,6 +351,7 @@ def analyze_performance(
         custom_prompt=prompt,
         kernel_resources=kernel_resources,
         api_overhead=api_overhead_data,
+        roctx_regions=roctx_regions,
     )
 
     # Expose structured results to caller (used by interactive mode)

--- a/experimental/python/rocinsight/rocinsight/formatters/__init__.py
+++ b/experimental/python/rocinsight/rocinsight/formatters/__init__.py
@@ -65,6 +65,7 @@ def format_analysis_output(
     custom_prompt: Optional[str] = None,
     kernel_resources: Optional[Dict[str, Any]] = None,
     api_overhead: Optional[Dict[str, Any]] = None,
+    roctx_regions: Optional[Dict[str, Any]] = None,
 ) -> str:
     """
     Format analysis results for display.
@@ -107,6 +108,7 @@ def format_analysis_output(
             custom_prompt=custom_prompt,
             kernel_resources=kernel_resources,
             api_overhead=api_overhead,
+            roctx_regions=roctx_regions,
         )
         # Combined mode: embed tier0 into JSON document
         if tier0_result is not None:
@@ -414,6 +416,58 @@ def format_analysis_output(
                     f"    {off['name'][:50]:<52} \u00d7{off['count']}  avg {off['avg_us']:.1f}\u03bcs"
                 )
         lines.append("")
+
+    # ROCTX Range Analysis (ROCM-21553 C1) — only when markers present
+    if roctx_regions and roctx_regions.get("has_markers"):
+        lines.append("\u2501" * width)
+        lines.append("ROCTX RANGE ANALYSIS".center(width))
+        lines.append("\u2501" * width)
+        lines.append("")
+        lines.append(
+            f" {'Range':<20}  {'Wall Time':>10}  {'Kernels':>7}  {'Kernel Time':>11}  {'MemCopies':>9}  {'MemCopy Time':>12}"
+        )
+        lines.append("\u2500" * width)
+        for rd in roctx_regions["regions"]:
+            rname = rd["name"]
+            if len(rname) > 20:
+                rname = rname[:17] + "..."
+            wall_ms = rd["wall_time_ns"] / 1e6
+            kc = rd["kernel_count"]
+            kt_ms = rd["kernel_time_ns"] / 1e6
+            mc = rd["memcpy_count"]
+            mt_ms = rd["memcpy_time_ns"] / 1e6
+            lines.append(
+                f" {rname:<20}  {wall_ms:10.2f} ms  {kc:7}  {kt_ms:10.2f} ms  {mc:9}  {mt_ms:11.2f} ms"
+            )
+        # Unranged
+        ur = roctx_regions["unranged"]
+        ur_wall = ur["wall_time_ns"] / 1e6
+        lines.append(
+            f" {'(unranged)':<20}  {ur_wall:10.2f} ms  {ur['kernel_count']:7}  {ur['kernel_time_ns']/1e6:10.2f} ms  {ur['memcpy_count']:9}  {ur['memcpy_time_ns']/1e6:11.2f} ms"
+        )
+        lines.append("")
+
+        # Per-range breakdown
+        lines.append("  Per-Range Time Breakdown:")
+        lines.append("")
+
+        def _make_bar_roctx(pct: float, w: int = 30) -> str:
+            return "\u2588" * int(pct / 100.0 * w)
+
+        all_regions = list(roctx_regions["regions"]) + [{"name": "(unranged)", **roctx_regions["unranged"]}]
+        for rd in all_regions:
+            rname = rd["name"]
+            wall_ms = rd["wall_time_ns"] / 1e6
+            if wall_ms <= 0:
+                continue
+            kpct = rd["kernel_pct"]
+            mpct = rd["memcpy_pct"]
+            opct = rd["overhead_pct"]
+            lines.append(f"  [{rname}]  {wall_ms:.2f} ms wall")
+            lines.append(f"    Kernel Execution:  {rd['kernel_time_ns']/1e6:10.2f} ms  ({kpct:5.1f}%)  {_make_bar_roctx(kpct)}")
+            lines.append(f"    Memory Copies:     {rd['memcpy_time_ns']/1e6:10.2f} ms  ({mpct:5.1f}%)  {_make_bar_roctx(mpct)}")
+            lines.append(f"    API Overhead:      {rd['overhead_time_ns']/1e6:10.2f} ms  ({opct:5.1f}%)  {_make_bar_roctx(opct)}")
+            lines.append("")
 
     # Recommendations
     lines.append("\u2501" * width)

--- a/experimental/python/rocinsight/rocinsight/formatters/json_fmt.py
+++ b/experimental/python/rocinsight/rocinsight/formatters/json_fmt.py
@@ -46,6 +46,7 @@ def _format_as_json(
     custom_prompt: Optional[str] = None,
     kernel_resources: Optional[Dict[str, Any]] = None,
     api_overhead: Optional[Dict[str, Any]] = None,
+    roctx_regions: Optional[Dict[str, Any]] = None,
 ) -> str:
     """Serialize analysis results to JSON conforming to the current schema version (v0.3.0 when TraceLens fields are present, v0.1.0 otherwise).
 
@@ -174,6 +175,8 @@ def _format_as_json(
             "launch_overhead_ns": api_overhead["launch_overhead_ns"],
             "api_calls": api_overhead["api_calls"],
         }
+    if roctx_regions and roctx_regions.get("has_markers"):
+        doc["roctx_regions"] = roctx_regions
 
     return _json.dumps(doc, indent=2)
 


### PR DESCRIPTION
## Summary
ROCM-21553 items C1, E1, E2, 11:

- **C1**: New `analyze_roctx_regions()` — discovers markers, correlates events by overlap (innermost-wins model)
- **11**: GPU idle warning scoped to figure-of-merit region
- **E1**: `rocprof-compute profile` listed first in Kernel Hotspot commands
- **E2**: "Profiling Scope" recommendation with `roctxProfilerPause()`/`roctxProfilerResume()` code snippet
- ROCTx attribution model: innermost-wins with no double-counting, documented per ROC-TX library spec

## Stacking note
Stacks on #4970 → #4969 → #4968. GitHub diff includes prior changes. **This PR's own changes (8 files, +540/-38):**
- `analysis/core.py` — `analyze_roctx_regions()` with documented attribution model
- `analysis/recommendations.py` — roctx_regions param, GPU idle scoping, E1 command order, E2 profiler pause
- `formatters/__init__.py` — ROCTX RANGE ANALYSIS section
- `formatters/json_fmt.py` — roctx_regions in JSON
- `analyze.py`, `ai_analysis/api.py` — wiring
- `test_roctx_region_analysis.py` — 7 new tests

Merge after #4970 lands.

## Test plan
- [x] 7 new tests, 594 total passing, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)