### PR TITLE
[rocdbgapi] Refactor CWSR queues

### DIFF
--- a/projects/rocdbgapi/src/logging.h
+++ b/projects/rocdbgapi/src/logging.h
@@ -37,6 +37,7 @@
 #include <tuple>
 #include <type_traits>
 #include <utility>
+#include <variant>
 
 #define dbgapi_log(level, format, ...)                                        \
   do                                                                          \
@@ -105,6 +106,13 @@ to_string (std::optional<T> v)
   if (v.has_value ())
     return std::string ("{") + to_string (*v) + "}";
   return "{}";
+}
+
+template <typename... Ts>
+inline std::string
+to_string (std::variant<Ts...> var)
+{
+  return std::visit ([] (auto &&v) { return to_string (v); }, var);
 }
 
 template <>

--- a/projects/rocdbgapi/src/os_driver.cpp
+++ b/projects/rocdbgapi/src/os_driver.cpp
@@ -307,14 +307,16 @@ to_string (os_queue_snapshot_entry_t snapshot)
     "{ .queue_id=%d, .state=%s, .gpu_id=%d, .queue_type=%s, "
     ".exception_status=%s, .ring_base_address=%s, .ring_size=%" PRId64 ", "
     ".write_pointer_address=%s, .read_pointer_address=%s, "
-    ".ctx_save_restore_address=%s, .ctx_save_restore_area_size=%" PRId64 " }",
+    ".ctx_save_restore_address=%s, .ctx_save_restore_area_size=%" PRId64
+    ", .compute_tmpring_size=%s }",
     snapshot.queue_id, to_cstring (snapshot.state), snapshot.gpu_id,
     to_cstring (snapshot.queue_type), to_cstring (snapshot.exception_status),
     to_cstring (snapshot.ring_base_address), snapshot.ring_size,
     to_cstring (snapshot.write_pointer_address),
     to_cstring (snapshot.read_pointer_address),
     to_cstring (snapshot.ctx_save_restore_address),
-    snapshot.ctx_save_restore_area_size);
+    snapshot.ctx_save_restore_area_size,
+    to_cstring (snapshot.compute_tmpring_size));
 }
 
 template <>

--- a/projects/rocdbgapi/src/os_driver.h
+++ b/projects/rocdbgapi/src/os_driver.h
@@ -413,6 +413,7 @@ struct os_queue_snapshot_entry_t
   host_address_t read_pointer_address;
   agent_address_t ctx_save_restore_address;
   amd_dbgapi_size_t ctx_save_restore_area_size;
+  std::optional<uint32_t> compute_tmpring_size;
 };
 
 enum class os_wave_launch_mode_t : uint32_t

--- a/projects/rocdbgapi/src/os_driver.h
+++ b/projects/rocdbgapi/src/os_driver.h
@@ -34,6 +34,7 @@
 #include <string>
 #include <type_traits>
 #include <utility>
+#include <variant>
 
 namespace amd::dbgapi
 {
@@ -407,10 +408,12 @@ struct os_queue_snapshot_entry_t
   os_agent_id_t gpu_id;
   os_queue_type_t queue_type{ os_queue_type_t::unknown };
   os_exception_mask_t exception_status;
-  host_address_t ring_base_address;
+  std::variant<host_address_t, agent_address_t> ring_base_address;
   amd_dbgapi_size_t ring_size;
-  host_address_t write_pointer_address;
-  host_address_t read_pointer_address;
+  std::optional<std::variant<host_address_t, agent_address_t>>
+    write_pointer_address;
+  std::optional<std::variant<host_address_t, agent_address_t>>
+    read_pointer_address;
   agent_address_t ctx_save_restore_address;
   amd_dbgapi_size_t ctx_save_restore_area_size;
   std::optional<uint32_t> compute_tmpring_size;

--- a/projects/rocdbgapi/src/os_driver_kfd.cpp
+++ b/projects/rocdbgapi/src/os_driver_kfd.cpp
@@ -749,9 +749,12 @@ kfd_driver_base_t::queue_snapshot (
       queue_info.queue_type = os_queue_type (entry.queue_type);
       queue_info.exception_status
         = kfd_to_os_exception_mask (entry.exception_status);
-      queue_info.ring_base_address = entry.ring_base_address;
-      queue_info.write_pointer_address = entry.write_pointer_address;
-      queue_info.read_pointer_address = entry.read_pointer_address;
+      queue_info.ring_base_address
+        = static_cast<host_address_t> (entry.ring_base_address);
+      queue_info.write_pointer_address
+        = static_cast<host_address_t> (entry.write_pointer_address);
+      queue_info.read_pointer_address
+        = static_cast<host_address_t> (entry.read_pointer_address);
       queue_info.ctx_save_restore_address = entry.ctx_save_restore_address;
       queue_info.ctx_save_restore_area_size = entry.ctx_save_restore_area_size;
       queue_info.ring_size = entry.ring_size;

--- a/projects/rocdbgapi/src/os_driver_kmd.cpp
+++ b/projects/rocdbgapi/src/os_driver_kmd.cpp
@@ -1950,8 +1950,8 @@ kmd_driver_t::queue_snapshot (os_queue_snapshot_entry_t *snapshots,
       else
         {
           queue.queue_type = os_queue_type (snap.queueType);
-          queue.ring_base_address = static_cast<host_address_t> (
-            snap.ringBufferAddress);
+          queue.ring_base_address
+            = static_cast<host_address_t> (snap.ringBufferAddress);
           queue.write_pointer_address
             = static_cast<host_address_t> (snap.writePtrAddress);
           queue.read_pointer_address

--- a/projects/rocdbgapi/src/os_driver_kmd.cpp
+++ b/projects/rocdbgapi/src/os_driver_kmd.cpp
@@ -1895,6 +1895,7 @@ kmd_driver_t::queue_snapshot (os_queue_snapshot_entry_t *snapshots,
     {
       auto &[agent_id, snap] = queues[queue_idx];
       os_queue_snapshot_entry_t &queue = snapshots[queue_idx];
+      queue = {};
       queue.queue_id = make_queue_id (agent_id, snap.queueId);
       queue.gpu_id = agent_id;
       queue.exception_status = os_exception_mask (snap.queueExceptionMask);
@@ -1956,6 +1957,7 @@ kmd_driver_t::queue_snapshot (os_queue_snapshot_entry_t *snapshots,
           queue.read_pointer_address
             = static_cast<host_address_t> (snap.readPtrAddress);
           queue.ring_size = static_cast<amd_dbgapi_size_t> (snap.ringSize);
+          queue.compute_tmpring_size = snap.computeTmpRingSize;
         }
     }
 

--- a/projects/rocdbgapi/src/os_driver_kmd.cpp
+++ b/projects/rocdbgapi/src/os_driver_kmd.cpp
@@ -1926,8 +1926,7 @@ kmd_driver_t::queue_snapshot (os_queue_snapshot_entry_t *snapshots,
 
           queue.read_pointer_address = read_pointer_address;
           queue.write_pointer_address
-            = queue.read_pointer_address
-              + offsetof (amd_queue_t, write_dispatch_id)
+            = read_pointer_address + offsetof (amd_queue_t, write_dispatch_id)
               - offsetof (amd_queue_t, read_dispatch_id);
 
           uint32_t hsa_queue_base_offset;
@@ -1941,9 +1940,8 @@ kmd_driver_t::queue_snapshot (os_queue_snapshot_entry_t *snapshots,
           read_host_memory (read_pointer_address - hsa_queue_base_offset,
                             &hsa_queue);
 
-          queue.ring_base_address
-            = reinterpret_cast<amd_dbgapi_global_address_t> (
-              hsa_queue.base_address);
+          queue.ring_base_address = static_cast<host_address_t> (
+            reinterpret_cast<uint64_t> (hsa_queue.base_address));
           queue.ring_size
             = static_cast<amd_dbgapi_size_t> (hsa_queue.size << 6);
         }
@@ -1951,11 +1949,13 @@ kmd_driver_t::queue_snapshot (os_queue_snapshot_entry_t *snapshots,
         {
           queue.queue_type = os_queue_type (snap.queueType);
           queue.ring_base_address
-            = static_cast<host_address_t> (snap.ringBufferAddress);
-          queue.write_pointer_address
-            = static_cast<host_address_t> (snap.writePtrAddress);
-          queue.read_pointer_address
-            = static_cast<host_address_t> (snap.readPtrAddress);
+            = static_cast<agent_address_t> (snap.ringBufferAddress);
+          if (snap.writePtrAddress != 0)
+            queue.write_pointer_address
+              = static_cast<agent_address_t> (snap.writePtrAddress);
+          if (snap.readPtrAddress != 0)
+            queue.read_pointer_address
+              = static_cast<agent_address_t> (snap.readPtrAddress);
           queue.ring_size = static_cast<amd_dbgapi_size_t> (snap.ringSize);
           queue.compute_tmpring_size = snap.computeTmpRingSize;
         }

--- a/projects/rocdbgapi/src/process.cpp
+++ b/projects/rocdbgapi/src/process.cpp
@@ -823,6 +823,8 @@ process_t::suspend_queues (const std::vector<queue_t *> &queues,
   size_t num_all_stopped_queues = 0;
   std::vector<os_queue_id_t> queue_ids;
   queue_ids.reserve (queues.size ());
+  std::vector<queue_t *> queues_needing_update;
+  queues_needing_update.reserve (queues.size ());
 
   for (queue_t *queue : queues)
     {
@@ -845,6 +847,13 @@ process_t::suspend_queues (const std::vector<queue_t *> &queues,
           std::optional<os_queue_id_t> os_id = queue->os_queue_id ();
           dbgapi_assert (os_id.has_value ());
           queue_ids.emplace_back (os_id.value ());
+          /* After we suspend queues, we need to go and update the queue_info
+             for the PM4-based queues so we read the compute_tmpring_size value
+             out of the MQD.  This is not needed for AQL queues as we can find
+             this information in the amd_queue_t.  */
+          if (queue->type ()
+              == amd_dbgapi_os_queue_type_t::AMD_DBGAPI_OS_QUEUE_TYPE_AMD_PM4)
+            queues_needing_update.emplace_back (queue);
         }
     }
 
@@ -909,6 +918,10 @@ process_t::suspend_queues (const std::vector<queue_t *> &queues,
   for (queue_t *queue : queues)
     if (queue->is_valid ())
       queue->set_state (queue_t::state_t::suspended);
+
+  /* Refresh our knowledge of the queues, as some properties are only stable
+     when the queue is suspended (compute_tmpringsize for example).  */
+  update_queue_info (queues_needing_update);
 
   dbgapi_assert (
     (num_suspended_queues + num_invalid_queues) == queue_ids.size ()
@@ -1252,6 +1265,55 @@ process_t::update_queues ()
       }
     else
       ++it;
+}
+
+void
+process_t::update_queue_info (const std::vector<queue_t *> &queues) const
+{
+  if (queues.empty ())
+    return;
+
+  std::vector<os_queue_snapshot_entry_t> snapshots;
+  size_t snapshot_count;
+
+  /* Prime the queue count with the current number of queues.  */
+  size_t queue_count = count<queue_t> ();
+
+  do
+    {
+      /* We should allocate enough memory for the snapshots. Let's start with
+         the current number of queues + 16.  */
+      snapshot_count = queue_count + 16;
+      snapshots.resize (snapshot_count);
+
+      /* Query the driver.  Unlike update_waves, we do not want handle new
+         queues, so make sure to not clear any exception status.  */
+      amd_dbgapi_status_t status = os_driver ().queue_snapshot (
+        snapshots.data (), snapshot_count, &queue_count, {});
+
+      if (status == AMD_DBGAPI_STATUS_ERROR_PROCESS_EXITED)
+        throw process_exited_exception_t (id ());
+      else if (status != AMD_DBGAPI_STATUS_SUCCESS)
+        fatal_error ("queue_snapshot failed (%s)", to_cstring (status));
+      snapshots.resize (std::min (queue_count, snapshot_count));
+    }
+  while (queue_count > snapshot_count);
+
+  for (auto &&queue : queues)
+    {
+      dbgapi_assert (queue->state () == queue_t::state_t::suspended);
+
+      auto it = std::find_if (snapshots.begin (), snapshots.end (),
+                              [&queue] (const os_queue_snapshot_entry_t &s)
+                              { return queue->os_queue_id () == s.queue_id; });
+
+      if (it == snapshots.end ())
+        fatal_error ("Suspended queue disapeared");
+      if ((it->exception_status & os_exception_mask_t::queue_new)
+          != os_exception_mask_t::none)
+        fatal_error ("Cannot have a suspended new queue");
+      queue->update (*it);
+    }
 }
 
 void

--- a/projects/rocdbgapi/src/process.cpp
+++ b/projects/rocdbgapi/src/process.cpp
@@ -1210,6 +1210,7 @@ process_t::update_queues ()
                   /* This isn't a new queue, and it is fully initialized.
                      Mark it as active, and continue to the next snapshot.  */
                   queue->set_mark (queue_mark);
+                  queue->update (queue_info);
                   continue;
                 }
             }

--- a/projects/rocdbgapi/src/process.h
+++ b/projects/rocdbgapi/src/process.h
@@ -307,6 +307,10 @@ public:
   void update_queues ();
   void update_code_objects ();
 
+  /* Refresh the metadata of queues we know of.  Unlike update_queues, this
+     will not try to create new queues reported by the os_driver.  */
+  void update_queue_info (const std::vector<queue_t *> &queues) const;
+
   void runtime_enable (os_runtime_info_t runtime_info);
 
   void send_exceptions (

--- a/projects/rocdbgapi/src/queue.cpp
+++ b/projects/rocdbgapi/src/queue.cpp
@@ -467,29 +467,40 @@ compute_queue_t::queue_state_changed ()
       break;
 
     case state_t::suspended:
-      /* Discard the previously cached wave saved state lines.  The saved state
-         areas may be mapped to a different address in this new context wave
-         save.  */
-      agent ().memory_cache ().discard (
-        m_os_queue_info.ctx_save_restore_address,
-        xcc_count * m_os_queue_info.ctx_save_restore_area_size);
+      {
+        /* Discard the previously cached wave saved state lines.  The saved
+           state areas may be mapped to a different address in this new context
+           wave save.  */
+        agent ().memory_cache ().discard (
+          m_os_queue_info.ctx_save_restore_address,
+          xcc_count * m_os_queue_info.ctx_save_restore_area_size);
 
-      refresh_scratch_on_suspend ();
+        refresh_scratch_on_suspend ();
 
-      /* Read the queue's write_packet_id and read_packet_id.  */
+        auto read_memory = [this] (auto &&address, auto *buffer)
+        {
+          if (std::holds_alternative<host_address_t> (address))
+            this->process ().read_host_memory (
+              std::get<host_address_t> (address), buffer);
+          else if (std::holds_alternative<agent_address_t> (address))
+            this->agent ().read_agent_memory (
+              std::get<agent_address_t> (address), buffer);
+          else
+            dbgapi_assert (false);
+        };
 
-      if (m_os_queue_info.write_pointer_address != 0)
-        process ().read_host_memory (m_os_queue_info.write_pointer_address,
-                                     &m_write_packet_id.emplace ());
+        if (m_os_queue_info.read_pointer_address.has_value ())
+          read_memory (*m_os_queue_info.read_pointer_address,
+                       &m_read_packet_id.emplace ());
+        if (m_os_queue_info.write_pointer_address.has_value ())
+          read_memory (*m_os_queue_info.write_pointer_address,
+                       &m_write_packet_id.emplace ());
 
-      if (m_os_queue_info.read_pointer_address != 0)
-        process ().read_host_memory (m_os_queue_info.read_pointer_address,
-                                     &m_read_packet_id.emplace ());
-
-      /* Iterate the control stack and update/create waves that were saved in
-         the last context wave save.  Waves that are no longer present will be
-         destroyed.  */
-      update_waves ();
+        /* Iterate the control stack and update/create waves that were saved in
+           the last context wave save.  Waves that are no longer present will
+           be destroyed.  */
+        update_waves ();
+      }
       break;
 
     case state_t::invalid:
@@ -616,8 +627,9 @@ aql_queue_t::aql_dispatch_t::aql_dispatch_t (
   amd_dbgapi_os_queue_packet_id_t os_queue_packet_id)
   : dispatch_t (dispatch_id, queue, os_queue_packet_id)
 {
+  dbgapi_assert (std::holds_alternative<host_address_t> (queue.address ()));
   amd_dbgapi_global_address_t packet_address
-    = queue.address ()
+    = std::get<host_address_t> (queue.address ())
       + (os_queue_packet_id * aql_packet_size) % queue.size ();
 
   /* Read the dispatch packet and kernel descriptor.  */
@@ -825,8 +837,10 @@ aql_queue_t::get_os_queue_packet_id (
     fatal_error ("dispatch_packet_index %#" PRIx64 " is out of bounds in %s",
                  dispatch_packet_id.value (), to_cstring (id ()));
 
+  dbgapi_assert (std::holds_alternative<host_address_t> (address ()));
   amd_dbgapi_global_address_t packet_address
-    = address () + (dispatch_packet_id.value () * packet_size ());
+    = std::get<host_address_t> (address ())
+      + (dispatch_packet_id.value () * packet_size ());
 
   /* Calculate the monotonic dispatch id for this packet.  It is
        between read_packet_id and write_packet_id.  */
@@ -838,7 +852,8 @@ aql_queue_t::get_os_queue_packet_id (
   dbgapi_assert (m_read_packet_id && m_write_packet_id);
 
   amd_dbgapi_os_queue_packet_id_t os_queue_packet_id
-    = (packet_address - address ()) / aql_packet_size
+    = (packet_address - std::get<host_address_t> (address ()))
+        / aql_packet_size
       + (*m_read_packet_id / ring_size) * ring_size;
 
   if (os_queue_packet_id < *m_read_packet_id
@@ -884,16 +899,21 @@ aql_queue_t::refresh_scratch_on_suspend ()
      it.  We cannot cache this value as the runtime may change the
      allocation dynamically.  */
 
+  dbgapi_assert (m_os_queue_info.read_pointer_address.has_value ()
+                 && std::holds_alternative<host_address_t> (
+                   *m_os_queue_info.read_pointer_address));
+
   process ().read_host_memory (
-    m_os_queue_info.read_pointer_address
+    std::get<host_address_t> (*m_os_queue_info.read_pointer_address)
       + offsetof (amd_queue_t, scratch_backing_memory_location)
       - offsetof (amd_queue_t, read_dispatch_id),
     &m_scratch_backing_memory_address);
 
-  process ().read_host_memory (m_os_queue_info.read_pointer_address
-                                 + offsetof (amd_queue_t, compute_tmpring_size)
-                                 - offsetof (amd_queue_t, read_dispatch_id),
-                               &m_compute_tmpring_size);
+  process ().read_host_memory (
+    std::get<host_address_t> (*m_os_queue_info.read_pointer_address)
+      + offsetof (amd_queue_t, compute_tmpring_size)
+      - offsetof (amd_queue_t, read_dispatch_id),
+    &m_compute_tmpring_size);
 }
 
 std::pair<agent_address_t /* address */, amd_dbgapi_size_t /* size */>
@@ -913,14 +933,11 @@ aql_queue_t::active_packets_info (
   size_t *packets_byte_size_p) const
 {
   dbgapi_assert (is_suspended ());
+  dbgapi_assert (m_read_packet_id.has_value ());
+  dbgapi_assert (m_write_packet_id.has_value ());
 
-  amd_dbgapi_os_queue_packet_id_t read_packet_id;
-  process ().read_host_memory (m_os_queue_info.read_pointer_address,
-                               &read_packet_id);
-
-  amd_dbgapi_os_queue_packet_id_t write_packet_id;
-  process ().read_host_memory (m_os_queue_info.write_pointer_address,
-                               &write_packet_id);
+  amd_dbgapi_os_queue_packet_id_t read_packet_id = m_read_packet_id.value ();
+  amd_dbgapi_os_queue_packet_id_t write_packet_id = m_write_packet_id.value ();
 
   if (read_packet_id > write_packet_id)
     fatal_error ("corrupted read/write packet ids");
@@ -953,24 +970,26 @@ aql_queue_t::active_packets_bytes (
 
   const uint64_t id_mask = size () / aql_packet_size - 1;
 
+  dbgapi_assert (std::holds_alternative<host_address_t> (address ()));
+  const host_address_t queue_address = std::get<host_address_t> (address ());
   host_address_t read_packet_ptr
-    = address () + (read_packet_id & id_mask) * aql_packet_size;
+    = queue_address + (read_packet_id & id_mask) * aql_packet_size;
   host_address_t write_packet_ptr
-    = address () + (write_packet_id & id_mask) * aql_packet_size;
+    = queue_address + (write_packet_id & id_mask) * aql_packet_size;
 
   if (read_packet_ptr < write_packet_ptr)
     process ().read_host_memory (read_packet_ptr, memory, packets_byte_size);
 
   else if (read_packet_ptr > write_packet_ptr)
     {
-      size_t first_part_size = address () + size () - read_packet_ptr;
+      size_t first_part_size = queue_address + size () - read_packet_ptr;
 
       process ().read_host_memory (read_packet_ptr, memory, first_part_size);
 
-      size_t second_part_size = write_packet_ptr - address ();
+      size_t second_part_size = write_packet_ptr - queue_address;
 
       process ().read_host_memory (
-        address (), static_cast<char *> (memory) + first_part_size,
+        queue_address, static_cast<char *> (memory) + first_part_size,
         second_part_size);
     }
 }
@@ -1116,7 +1135,7 @@ queue_t::set_state (state_t state)
     log_info ("invalidated %s", to_cstring (id ()));
 }
 
-host_address_t
+std::variant<host_address_t, agent_address_t>
 queue_t::address () const
 {
   return m_os_queue_info.ring_base_address;
@@ -1167,7 +1186,9 @@ queue_t::get_info (amd_dbgapi_queue_info_t query, size_t value_size,
       }
 
     case AMD_DBGAPI_QUEUE_INFO_ADDRESS:
-      utils::get_info (value_size, value, address ());
+      utils::get_info (value_size, value,
+                       std::visit ([] (auto v) -> amd_dbgapi_global_address_t
+                                   { return v; }, address ()));
       return;
 
     case AMD_DBGAPI_QUEUE_INFO_SIZE:

--- a/projects/rocdbgapi/src/queue.cpp
+++ b/projects/rocdbgapi/src/queue.cpp
@@ -60,6 +60,482 @@ queue_t::architecture () const
   return *agent ().architecture ();
 }
 
+/* Return the address of a park instruction.  */
+agent_address_t
+compute_queue_t::park_instruction_address ()
+{
+  /* When the queue is loaded from a core dump, there is no running wave, and
+     we cannot allocate nor initialize displaced instruction buffers. Setting
+     the PC to 0 is harmless for a stopped wave.  */
+  if (process ().from_core ())
+    return {};
+
+  if (!m_park_instruction_ptr)
+    m_park_instruction_ptr.emplace (
+      allocate_displaced_instruction (architecture ().assert_instruction ()));
+
+  return m_park_instruction_ptr->get ();
+}
+
+/* Return the address of a terminating instruction.  */
+agent_address_t
+compute_queue_t::terminating_instruction_address ()
+{
+  /* See park_instruction_address.  */
+  if (process ().from_core ())
+    return {};
+
+  if (!m_terminating_instruction_ptr)
+    m_terminating_instruction_ptr.emplace (allocate_displaced_instruction (
+      architecture ().terminating_instruction ()));
+
+  return m_terminating_instruction_ptr->get ();
+}
+
+compute_queue_t::displaced_instruction_ptr_t
+compute_queue_t::allocate_displaced_instruction (
+  const instruction_t &instruction)
+{
+  dbgapi_assert (!process ().from_core ());
+
+  if (!m_debugger_memory_base)
+    {
+      auto ctx_save_base = m_os_queue_info.ctx_save_restore_address;
+
+      struct context_save_area_header_s header;
+      agent ().read_agent_memory (ctx_save_base, &header);
+
+      if (!header.debugger_memory_offset || !header.debugger_memory_size)
+        fatal_error ("Per-queue memory reserved for the debugger is missing");
+
+      /* Make sure the debugger memory is aligned so that it can be used to
+         store displaced instructions, and that each chunk out of that memory
+         register is also aligned.  */
+      dbgapi_assert (
+        utils::is_aligned (debugger_memory_chunk_size,
+                           architecture ().minimum_instruction_alignment ()));
+
+      m_debugger_memory_base.emplace (agent_address_t{
+        utils::align_up (ctx_save_base + header.debugger_memory_offset,
+                         debugger_memory_chunk_size) });
+
+      auto chunk_count = ((ctx_save_base + header.debugger_memory_size
+                           + header.debugger_memory_offset)
+                          - *m_debugger_memory_base)
+                         / debugger_memory_chunk_size;
+
+      /* Ensure that the number of chunks does not overflow the 16 bit index.
+       */
+      utils::narrow_assign (m_debugger_memory_chunk_count, chunk_count);
+
+      m_debugger_memory_free_chunks.reserve (m_debugger_memory_chunk_count);
+    }
+
+  auto assert_instruction = architecture ().assert_instruction ();
+  agent_address_t instruction_buffer_address;
+
+  if (!m_debugger_memory_free_chunks.empty ())
+    {
+      auto index = m_debugger_memory_free_chunks.back ();
+      m_debugger_memory_free_chunks.pop_back ();
+
+      instruction_buffer_address
+        = *m_debugger_memory_base + index * debugger_memory_chunk_size;
+    }
+  else if (m_debugger_memory_next_chunk < m_debugger_memory_chunk_count)
+    {
+      instruction_buffer_address
+        = *m_debugger_memory_base
+          + m_debugger_memory_next_chunk++ * debugger_memory_chunk_size;
+
+      /* An instruction buffer is always terminated by a 'guard' instruction
+         (assert_trap) so that the pc never points to an invalid instruction or
+         unmapped memory if the instruction is single-stepped.  We use a trap
+         instruction to prevent runaway waves from executing from unmapped
+         memory.  */
+
+      agent ().write_agent_memory (
+        instruction_buffer_address + debugger_memory_chunk_size
+          - assert_instruction.size (),
+        assert_instruction.data (), assert_instruction.size ());
+    }
+  else
+    fatal_error ("could not allocate debugger memory");
+
+  auto deleter = [this] (agent_address_t ptr)
+  {
+    size_t index
+      = (ptr - *m_debugger_memory_base) / debugger_memory_chunk_size;
+
+    dbgapi_assert (index < m_debugger_memory_chunk_count);
+    m_debugger_memory_free_chunks.emplace_back (static_cast<uint16_t> (index));
+  };
+
+  dbgapi_assert (instruction.size () + assert_instruction.size ()
+                 <= debugger_memory_chunk_size);
+
+  auto displaced_instruction_address
+    = instruction_buffer_address + debugger_memory_chunk_size
+      - assert_instruction.size () - instruction.size ();
+
+  /* Make sure the new displaced instruction is properly aligned for this
+     architecture.  */
+  dbgapi_assert (
+    utils::is_aligned (displaced_instruction_address,
+                       architecture ().minimum_instruction_alignment ()));
+
+  agent ().write_agent_memory (displaced_instruction_address,
+                               instruction.data (), instruction.size ());
+
+  return { displaced_instruction_address, deleter };
+}
+
+void
+compute_queue_t::update_waves ()
+{
+  /* Value used to mark waves that are found in the context save area. When
+     sweeping, any wave found with a mark less than the current mark will be
+     deleted, as these waves are no longer active.  */
+  const epoch_t wave_mark = wave_t::next_mark ();
+  wave_t *group_leader = nullptr;
+
+  auto process_cwsr_record
+    = [this, wave_mark, &group_leader] (auto cwsr_record)
+  {
+    dbgapi_assert (*this == cwsr_record->queue ());
+    process_t &process = cwsr_record->process ();
+
+    auto prefetch_begin
+      = cwsr_record->register_address (amdgpu_regnum_t::first_hwreg).value ();
+    auto prefetch_end
+      = cwsr_record->register_address (amdgpu_regnum_t::last_ttmp).value ()
+        + architecture ().register_size (amdgpu_regnum_t::last_ttmp);
+
+    dbgapi_assert (prefetch_end > prefetch_begin);
+    cwsr_record->agent ().memory_cache ().prefetch (
+      prefetch_begin, prefetch_end - prefetch_begin);
+
+    wave_t *wave = nullptr;
+
+    if (process.is_flag_set (process_t::flag_t::runtime_enable_during_attach))
+      {
+        /* Assign new ids to all waves regardless of the content of their
+           wave_id register.  This is needed during attach as waves created
+           before the debugger attached to the process may have stale
+           wave_ids.  */
+      }
+    else if (amd_dbgapi_wave_id_t wave_id = cwsr_record->id ();
+             wave_id != wave_t::undefined)
+      {
+        /* The wave already has a wave_id, so we should find it in this queue.
+           Search all visible and invisible waves.  */
+        wave = process.find (wave_id, true /* include invisible waves  */);
+
+        if (!wave)
+          {
+            /* The wave_id saved in the ttmp registers may be corrupted.  */
+            fatal_error ("%s not found in %s", to_cstring (wave_id),
+                         to_cstring (id ()));
+          }
+      }
+
+    if (!wave)
+      {
+        workgroup_t *workgroup = nullptr;
+
+        if (group_leader)
+          {
+            /* We already have identified the workgroup_t this wave belongs to,
+               it is the same workgroup_t as the thread group leader's.  */
+            workgroup = &group_leader->workgroup ();
+
+            if (workgroup->group_ids () != cwsr_record->group_ids ())
+              fatal_error ("not in the same workgroup as the group_leader");
+          }
+        else
+          {
+            const auto packet_id = get_os_queue_packet_id (*cwsr_record);
+            const auto group_ids = cwsr_record->group_ids ();
+
+            /* Find the dispatch this wave belongs to using the packet_id.  The
+               packet_id is only unique for a given queue.  */
+            dispatch_t *dispatch = process.find_if (
+              [this, packet_id] (const dispatch_t &d) {
+                return d.queue () == *this
+                       && d.os_queue_packet_id () == packet_id;
+              });
+
+            if (dispatch)
+              {
+                workgroup = process.find_if (
+                  [dispatch, group_ids] (const workgroup_t &w) {
+                    return w.dispatch () == *dispatch
+                           && w.group_ids () == group_ids;
+                  });
+              }
+            else if (packet_id)
+              {
+                dispatch = create_dispatch (*packet_id);
+              }
+            else
+              {
+                /* If this wave does not have a packet_id (ttmps are not setup
+                   or may be corrupted), then create a new workgroup associated
+                   with the dummy_dispatch.  All waves belonging to this
+                   workgroup will be associated with this instance.  */
+                dispatch = &m_dummy_dispatch;
+              }
+
+            if (!workgroup)
+              workgroup = &process.create<workgroup_t> (
+                *dispatch, group_ids, cwsr_record->lds_size ());
+          }
+
+        dbgapi_assert (workgroup != nullptr);
+        wave = &process.create<wave_t> (*workgroup,
+                                        cwsr_record->position_in_group ());
+      }
+
+    bool is_first_wave = cwsr_record->is_first_wave ();
+    bool is_last_wave = cwsr_record->is_last_wave ();
+
+    /* The first wave in the group is the group leader.  The group leader owns
+       the backing store for the group memory (LDS).  */
+    if (is_first_wave)
+      {
+        group_leader = wave;
+
+        auto shared_memory_base_address
+          = cwsr_record->register_address (amdgpu_regnum_t::lds_0);
+
+        dbgapi_assert (shared_memory_base_address);
+        group_leader->workgroup ().update (*shared_memory_base_address);
+      }
+
+    if (!group_leader)
+      fatal_error ("No group_leader, the control stack may be corrupted");
+
+    /* Update this wave's state using the context save area as it may have
+       changed since the queue was last suspended (or the wave is new).  */
+    wave->update (std::move (cwsr_record));
+
+    if (wave->state () != AMD_DBGAPI_WAVE_STATE_STOP)
+      ++*m_waves_running;
+
+    /* Hide new waves halted at launch until the process' wave creation mode is
+       changed to not stopped.  A wave is halted at launch if it is halted
+       (status.halt=1) without having entered the trap handler, and its pc
+       points to the kernel entry point.  */
+    if (!wave->mark () /* A wave without a mark is a new wave that has not been
+                          seen by queue_t::update_waves before.  */
+        && wave->state () == AMD_DBGAPI_WAVE_STATE_RUN && wave->is_halted ()
+        && wave->dispatch ().kernel_descriptor ().is_at_kernel_entry (
+          global_address_t{ wave->pc () }))
+      {
+        log_verbose ("%s is halted at launch", to_cstring (wave->id ()));
+
+        wave->set_visibility (wave_t::visibility_t::hidden_halted_at_launch);
+        wave->set_halted (false);
+        wave->set_state (AMD_DBGAPI_WAVE_STATE_STOP);
+      }
+
+    /* This was the last wave in the group. Make sure we have a new group
+       leader for the remaining waves.  */
+    if (is_last_wave)
+      group_leader = nullptr;
+
+    wave->set_mark (wave_mark);
+    if (is_first_wave)
+      wave->workgroup ().set_mark (wave_mark);
+  };
+
+  process_t &process = this->process ();
+  size_t wave_count = 0; /* Number of waves seen in the context save area.  */
+
+  /* Start with 0 running waves.  When iterating the control stack (below)
+     each discovered wave in the running state will increment this count.  */
+  m_waves_running.emplace (0);
+
+  for (uint32_t xcc_id = 0; xcc_id < agent ().os_info ().xcc_count; ++xcc_id)
+    {
+      auto ctx_save_address
+        = m_os_queue_info.ctx_save_restore_address
+          + xcc_id * m_os_queue_info.ctx_save_restore_area_size;
+
+      /* Retrieve the control stack and wave save area memory locations.  */
+      context_save_area_header_s header;
+      agent ().read_agent_memory (ctx_save_address, &header);
+
+      auto control_stack_begin
+        = ctx_save_address + header.control_stack_offset;
+      auto control_stack_end = control_stack_begin + header.control_stack_size;
+      auto wave_area_end = ctx_save_address + header.wave_state_offset;
+      auto wave_area_begin = wave_area_end - header.wave_state_size;
+
+      /* The control stack and the wave save area should be contiguous.  */
+      if (control_stack_end != wave_area_begin)
+        fatal_error ("corrupted context save area header");
+
+      if (control_stack_begin != control_stack_end)
+        {
+          log_info ("decoding %s's context save area #%u: "
+                    "ctrl_stk:[%s..%s[, wave_area:[%s..%s[",
+                    to_cstring (id ()), xcc_id,
+                    to_cstring (control_stack_begin),
+                    to_cstring (control_stack_end),
+                    to_cstring (wave_area_begin), to_cstring (wave_area_end));
+
+          /* Read the entire control stack from the inferior in one go.  */
+          amd_dbgapi_size_t size = control_stack_end - control_stack_begin;
+          if (!utils::is_aligned (size, sizeof (uint32_t)))
+            fatal_error ("corrupted control stack");
+
+          auto memory
+            = std::make_unique<uint32_t[]> (size / sizeof (uint32_t));
+          agent ().read_agent_memory (control_stack_begin, &memory[0], size);
+
+          /* Decode the control stack.  For each entry in the control stack,
+             the provided callback function is called with a CWSR record.  */
+          wave_count += architecture ().control_stack_iterate (
+            *this, xcc_id, &memory[0], size / sizeof (uint32_t), wave_area_end,
+            wave_area_end - wave_area_begin, process_cwsr_record);
+        }
+    }
+
+  if (wave_count)
+    log_info ("%zu out of %zu wave%s running on %s", *m_waves_running,
+              wave_count, wave_count > 1 ? "s" : "", to_cstring (id ()));
+
+  /* Iterate all waves, workgroups and dispatches belonging to this queue, and
+     prune waves and workgroups with a mark older than the current mark, and
+     dispatches with ids older (smaller) than the queue current read dispatch
+     id.
+
+     Note that the waves must be pruned before the workgroups and the
+     workgroups must be pruned before the dispatches to ensure there are no
+     dangling pointers to pruned objects.  */
+
+  auto &&wave_range = process.range<wave_t> ();
+  for (auto it = wave_range.begin (); it != wave_range.end ();)
+    if (it->queue () == *this && it->mark () < wave_mark)
+      {
+        dbgapi_assert (it->state () != AMD_DBGAPI_WAVE_STATE_STOP
+                       && "a stopped wave cannot terminate");
+        it = process.destroy (it);
+      }
+    else
+      ++it;
+
+  auto &&workgroup_range = process.range<workgroup_t> ();
+  for (auto it = workgroup_range.begin (); it != workgroup_range.end ();)
+    if (it->queue () == *this && it->mark () < wave_mark)
+      it = process.destroy (it);
+    else
+      ++it;
+
+  auto &&dispatch_range = process.range<dispatch_t> ();
+  for (auto it = dispatch_range.begin (); it != dispatch_range.end ();)
+    if (it->queue () == *this && it->os_queue_packet_id () < m_read_packet_id)
+      it = process.destroy (it);
+    else
+      ++it;
+}
+
+void
+compute_queue_t::queue_state_changed ()
+{
+  const auto xcc_count = agent ().os_info ().xcc_count;
+
+  switch (state ())
+    {
+    case state_t::running:
+      /* Reset member variables that are undefined while the queue is in the
+         running state.  */
+      m_read_packet_id.reset ();
+      m_write_packet_id.reset ();
+      m_waves_running.reset ();
+
+      /* The queue just changed state and is about to be placed back onto the
+         hardware.  Write back dirty cache lines in the wave saved state
+         region, but leave the cache lines valid so that accessing stopped
+         waves' cached registers does not require a queue suspend/resume.  The
+         saved state cache lines will be discarded when this queue is next
+         suspended again (see the 'case state_t::suspended:' below).  */
+      agent ().memory_cache ().write_back (
+        m_os_queue_info.ctx_save_restore_address,
+        xcc_count * m_os_queue_info.ctx_save_restore_area_size);
+      break;
+
+    case state_t::suspended:
+      /* Discard the previously cached wave saved state lines.  The saved state
+         areas may be mapped to a different address in this new context wave
+         save.  */
+      agent ().memory_cache ().discard (
+        m_os_queue_info.ctx_save_restore_address,
+        xcc_count * m_os_queue_info.ctx_save_restore_area_size);
+
+      refresh_scratch_on_suspend ();
+
+      /* Read the queue's write_packet_id and read_packet_id.  */
+
+      if (m_os_queue_info.write_pointer_address != 0)
+        process ().read_host_memory (m_os_queue_info.write_pointer_address,
+                                     &m_write_packet_id.emplace ());
+
+      if (m_os_queue_info.read_pointer_address != 0)
+        process ().read_host_memory (m_os_queue_info.read_pointer_address,
+                                     &m_read_packet_id.emplace ());
+
+      /* Iterate the control stack and update/create waves that were saved in
+         the last context wave save.  Waves that are no longer present will be
+         destroyed.  */
+      update_waves ();
+      break;
+
+    case state_t::invalid:
+      break;
+    }
+}
+
+dispatch_t *
+compute_queue_t::create_dispatch (
+  amd_dbgapi_os_queue_packet_id_t /* packet_id  */)
+{
+  dbgapi_assert (false);
+  return nullptr;
+}
+
+void
+compute_queue_t::refresh_scratch_on_suspend ()
+{
+  std::optional<os_queue_id_t> queue_id = os_queue_id ();
+  if (!queue_id.has_value ())
+    fatal_error ("No scratch info for invalidated queue");
+
+  /* The compute_tmpring_size was updated during queue_suspend, so reflects
+     what was effective when the queue was last running.  */
+  dbgapi_assert (m_os_queue_info.compute_tmpring_size.has_value ());
+  m_compute_tmpring_size = *m_os_queue_info.compute_tmpring_size;
+}
+
+std::pair<agent_address_t /* address */, amd_dbgapi_size_t /* size */>
+compute_queue_t::scratch_memory_region (
+  const architecture_t::cwsr_record_t &cwsr_record) const
+{
+  if (!architecture ().has_architected_flat_scratch ())
+    fatal_error ("Unsupported architecture for raw compute queue");
+
+  auto scratch_base_reg_addr
+    = cwsr_record.register_address (amdgpu_regnum_t::flat_scratch);
+
+  dbgapi_assert (scratch_base_reg_addr.has_value ());
+  agent_address_t scratch_base;
+  agent ().read_agent_memory (scratch_base_reg_addr.value (), &scratch_base);
+
+  /* TODO, assume the full 32 bits address range.  */
+  return { scratch_base, 0xffffff };
+}
+
 namespace detail
 {
 
@@ -67,17 +543,6 @@ class aql_queue_t : public compute_queue_t
 {
 private:
   static constexpr uint64_t aql_packet_size = 64;
-  static constexpr amd_dbgapi_size_t debugger_memory_chunk_size = 32;
-
-  struct context_save_area_header_s
-  {
-    uint32_t control_stack_offset;
-    uint32_t control_stack_size;
-    uint32_t wave_state_offset;
-    uint32_t wave_state_size;
-    uint32_t debugger_memory_offset;
-    uint32_t debugger_memory_size;
-  };
 
   class aql_dispatch_t : public dispatch_t
   {
@@ -87,8 +552,7 @@ private:
       m_kernel_descriptor{};
 
   public:
-    aql_dispatch_t (amd_dbgapi_dispatch_id_t dispatch_id,
-                    compute_queue_t &queue,
+    aql_dispatch_t (amd_dbgapi_dispatch_id_t dispatch_id, aql_queue_t &queue,
                     amd_dbgapi_os_queue_packet_id_t os_queue_packet_id);
 
     const architecture_t::kernel_descriptor_t &
@@ -106,23 +570,7 @@ private:
                    void *value) const override;
   };
 
-  std::optional<amd_dbgapi_os_queue_packet_id_t> m_read_packet_id{};
-  std::optional<amd_dbgapi_os_queue_packet_id_t> m_write_packet_id{};
   amd_dbgapi_global_address_t m_scratch_backing_memory_address{ 0 };
-  uint32_t m_compute_tmpring_size{ 0 };
-
-  /* The memory reserved by the thunk library for the debugger is used to store
-     instruction buffers.  Instruction buffers are lazily allocated from the
-     reserved memory, and when freed, their index is returned to a free list.
-     Each wave is guaranteed its own unique instruction buffer.  */
-  std::optional<agent_address_t> m_debugger_memory_base{};
-
-  uint16_t m_debugger_memory_chunk_count{ 0 };
-  uint16_t m_debugger_memory_next_chunk{ 0 };
-  std::vector<uint16_t> m_debugger_memory_free_chunks{};
-
-  std::optional<displaced_instruction_ptr_t> m_park_instruction_ptr{};
-  std::optional<displaced_instruction_ptr_t> m_terminating_instruction_ptr{};
 
   /* Value used to mark waves that are found in the context save area. When
      sweeping, any wave found with a mark less than the current mark will be
@@ -130,14 +578,12 @@ private:
   monotonic_counter_t<epoch_t, 1> m_next_wave_mark{};
 
   std::optional<amd_dbgapi_os_queue_packet_id_t> get_os_queue_packet_id (
-    const architecture_t::cwsr_record_t &cwsr_record) const;
+    const architecture_t::cwsr_record_t &cwsr_record) const override;
 
-  displaced_instruction_ptr_t
-  allocate_displaced_instruction (const instruction_t &instruction) override;
+  dispatch_t *
+  create_dispatch (amd_dbgapi_os_queue_packet_id_t packet_id) override;
 
-  void queue_state_changed () override;
-
-  void update_waves ();
+  void refresh_scratch_on_suspend () override;
 
 public:
   aql_queue_t (amd_dbgapi_queue_id_t queue_id, const agent_t &agent,
@@ -148,36 +594,6 @@ public:
   amd_dbgapi_os_queue_type_t type () const override
   {
     return AMD_DBGAPI_OS_QUEUE_TYPE_HSA_AQL;
-  }
-
-  /* Return the address of a park instruction.  */
-  agent_address_t park_instruction_address () override
-  {
-    /* When the queue is loaded from a core dump, there is no running wave, and
-       we cannot allocate nor initialize displaced instruction buffers. Setting
-       the PC to 0 is harmless for a stopped wave.  */
-    if (process ().from_core ())
-      return {};
-
-    if (!m_park_instruction_ptr)
-      m_park_instruction_ptr.emplace (allocate_displaced_instruction (
-        architecture ().assert_instruction ()));
-
-    return m_park_instruction_ptr->get ();
-  }
-
-  /* Return the address of a terminating instruction.  */
-  agent_address_t terminating_instruction_address () override
-  {
-    /* See park_instruction_address.  */
-    if (process ().from_core ())
-      return {};
-
-    if (!m_terminating_instruction_ptr)
-      m_terminating_instruction_ptr.emplace (allocate_displaced_instruction (
-        architecture ().terminating_instruction ()));
-
-    return m_terminating_instruction_ptr->get ();
   }
 
   std::pair<agent_address_t /* address */, amd_dbgapi_size_t /* size */>
@@ -196,7 +612,7 @@ public:
 };
 
 aql_queue_t::aql_dispatch_t::aql_dispatch_t (
-  amd_dbgapi_dispatch_id_t dispatch_id, compute_queue_t &queue,
+  amd_dbgapi_dispatch_id_t dispatch_id, aql_queue_t &queue,
   amd_dbgapi_os_queue_packet_id_t os_queue_packet_id)
   : dispatch_t (dispatch_id, queue, os_queue_packet_id)
 {
@@ -396,178 +812,6 @@ aql_queue_t::~aql_queue_t ()
     xcc_count * m_os_queue_info.ctx_save_restore_area_size, true);
 }
 
-compute_queue_t::displaced_instruction_ptr_t
-aql_queue_t::allocate_displaced_instruction (const instruction_t &instruction)
-{
-  dbgapi_assert (!process ().from_core ());
-
-  if (!m_debugger_memory_base)
-    {
-      auto ctx_save_base = m_os_queue_info.ctx_save_restore_address;
-
-      struct context_save_area_header_s header;
-      agent ().read_agent_memory (ctx_save_base, &header);
-
-      if (!header.debugger_memory_offset || !header.debugger_memory_size)
-        fatal_error ("Per-queue memory reserved for the debugger is missing");
-
-      /* Make sure the debugger memory is aligned so that it can be used to
-         store displaced instructions, and that each chunk out of that memory
-         register is also aligned.  */
-      dbgapi_assert (
-        utils::is_aligned (debugger_memory_chunk_size,
-                           architecture ().minimum_instruction_alignment ()));
-
-      m_debugger_memory_base.emplace (agent_address_t{
-        utils::align_up (ctx_save_base + header.debugger_memory_offset,
-                         debugger_memory_chunk_size) });
-
-      auto chunk_count = ((ctx_save_base + header.debugger_memory_size
-                           + header.debugger_memory_offset)
-                          - *m_debugger_memory_base)
-                         / debugger_memory_chunk_size;
-
-      /* Ensure that the number of chunks does not overflow the 16 bit index.
-       */
-      utils::narrow_assign (m_debugger_memory_chunk_count, chunk_count);
-
-      m_debugger_memory_free_chunks.reserve (m_debugger_memory_chunk_count);
-    }
-
-  auto assert_instruction = architecture ().assert_instruction ();
-  agent_address_t instruction_buffer_address;
-
-  if (!m_debugger_memory_free_chunks.empty ())
-    {
-      auto index = m_debugger_memory_free_chunks.back ();
-      m_debugger_memory_free_chunks.pop_back ();
-
-      instruction_buffer_address
-        = *m_debugger_memory_base + index * debugger_memory_chunk_size;
-    }
-  else if (m_debugger_memory_next_chunk < m_debugger_memory_chunk_count)
-    {
-      instruction_buffer_address
-        = *m_debugger_memory_base
-          + m_debugger_memory_next_chunk++ * debugger_memory_chunk_size;
-
-      /* An instruction buffer is always terminated by a 'guard' instruction
-         (assert_trap) so that the pc never points to an invalid instruction or
-         unmapped memory if the instruction is single-stepped.  We use a trap
-         instruction to prevent runaway waves from executing from unmapped
-         memory.  */
-
-      agent ().write_agent_memory (
-        instruction_buffer_address + debugger_memory_chunk_size
-          - assert_instruction.size (),
-        assert_instruction.data (), assert_instruction.size ());
-    }
-  else
-    fatal_error ("could not allocate debugger memory");
-
-  auto deleter = [this] (agent_address_t ptr)
-  {
-    size_t index
-      = (ptr - *m_debugger_memory_base) / debugger_memory_chunk_size;
-
-    dbgapi_assert (index < m_debugger_memory_chunk_count);
-    m_debugger_memory_free_chunks.emplace_back (static_cast<uint16_t> (index));
-  };
-
-  dbgapi_assert (instruction.size () + assert_instruction.size ()
-                 <= debugger_memory_chunk_size);
-
-  auto displaced_instruction_address
-    = instruction_buffer_address + debugger_memory_chunk_size
-      - assert_instruction.size () - instruction.size ();
-
-  /* Make sure the new displaced instruction is properly aligned for this
-     architecture.  */
-  dbgapi_assert (
-    utils::is_aligned (displaced_instruction_address,
-                       architecture ().minimum_instruction_alignment ()));
-
-  agent ().write_agent_memory (displaced_instruction_address,
-                               instruction.data (), instruction.size ());
-
-  return { displaced_instruction_address, deleter };
-}
-
-void
-aql_queue_t::queue_state_changed ()
-{
-  const auto xcc_count = agent ().os_info ().xcc_count;
-
-  switch (state ())
-    {
-    case state_t::running:
-      /* Reset member variables that are undefined while the queue is in the
-         running state.  */
-      m_read_packet_id.reset ();
-      m_write_packet_id.reset ();
-      m_waves_running.reset ();
-
-      /* The queue just changed state and is about to be placed back onto the
-         hardware.  Write back dirty cache lines in the wave saved state
-         region, but leave the cache lines valid so that accessing stopped
-         waves' cached registers does not require a queue suspend/resume.  The
-         saved state cache lines will be discarded when this queue is next
-         suspended again (see the 'case state_t::suspended:' below).  */
-      agent ().memory_cache ().write_back (
-        m_os_queue_info.ctx_save_restore_address,
-        xcc_count * m_os_queue_info.ctx_save_restore_area_size);
-      break;
-
-    case state_t::suspended:
-      /* Discard the previously cached wave saved state lines.  The saved state
-         areas may be mapped to a different address in this new context wave
-         save.  */
-      agent ().memory_cache ().discard (
-        m_os_queue_info.ctx_save_restore_address,
-        xcc_count * m_os_queue_info.ctx_save_restore_area_size);
-
-      /* Refresh the scratch_backing_memory_location and
-         scratch_backing_memory_size everytime the queue is suspended.
-
-         The scratch backing memory address is stored in the ABI-stable part of
-         the amd_queue_t. Since we know the address of the read_dispatch_id
-         (obtained from the KFD through the queue snapshot info), which is also
-         stored in the ABI-stable part of the amd_queue_t, we can calculate the
-         address of the pointer to the scratch_backing_memory_location and read
-         it.  We cannot cache this value as the runtime may change the
-         allocation dynamically.  */
-
-      process ().read_host_memory (
-        m_os_queue_info.read_pointer_address
-          + offsetof (amd_queue_t, scratch_backing_memory_location)
-          - offsetof (amd_queue_t, read_dispatch_id),
-        &m_scratch_backing_memory_address);
-
-      process ().read_host_memory (
-        m_os_queue_info.read_pointer_address
-          + offsetof (amd_queue_t, compute_tmpring_size)
-          - offsetof (amd_queue_t, read_dispatch_id),
-        &m_compute_tmpring_size);
-
-      /* Read the queue's write_packet_id and read_packet_id.  */
-
-      process ().read_host_memory (m_os_queue_info.write_pointer_address,
-                                   &m_write_packet_id.emplace ());
-
-      process ().read_host_memory (m_os_queue_info.read_pointer_address,
-                                   &m_read_packet_id.emplace ());
-
-      /* Iterate the control stack and update/create waves that were saved in
-         the last context wave save.  Waves that are no longer present will be
-         destroyed.  */
-      update_waves ();
-      break;
-
-    case state_t::invalid:
-      break;
-    }
-}
-
 std::optional<amd_dbgapi_os_queue_packet_id_t>
 aql_queue_t::get_os_queue_packet_id (
   const architecture_t::cwsr_record_t &cwsr_record) const
@@ -620,256 +864,36 @@ aql_queue_t::get_os_queue_packet_id (
   return os_queue_packet_id;
 }
 
-void
-aql_queue_t::update_waves ()
+dispatch_t *
+aql_queue_t::create_dispatch (amd_dbgapi_os_queue_packet_id_t packet_id)
 {
-  /* Value used to mark waves that are found in the context save area. When
-     sweeping, any wave found with a mark less than the current mark will be
-     deleted, as these waves are no longer active.  */
-  const epoch_t wave_mark = wave_t::next_mark ();
-  wave_t *group_leader = nullptr;
+  return &process ().create<aql_dispatch_t> (*this, packet_id);
+}
 
-  auto process_cwsr_record
-    = [this, wave_mark, &group_leader] (auto cwsr_record)
-  {
-    dbgapi_assert (*this == cwsr_record->queue ());
-    process_t &process = cwsr_record->process ();
+void
+aql_queue_t::refresh_scratch_on_suspend ()
+{
+  /* Refresh the scratch_backing_memory_location and
+     scratch_backing_memory_size everytime the queue is suspended.
 
-    auto prefetch_begin
-      = cwsr_record->register_address (amdgpu_regnum_t::first_hwreg).value ();
-    auto prefetch_end
-      = cwsr_record->register_address (amdgpu_regnum_t::last_ttmp).value ()
-        + architecture ().register_size (amdgpu_regnum_t::last_ttmp);
+     The scratch backing memory address is stored in the ABI-stable part of
+     the amd_queue_t. Since we know the address of the read_dispatch_id
+     (obtained from the KFD through the queue snapshot info), which is also
+     stored in the ABI-stable part of the amd_queue_t, we can calculate the
+     address of the pointer to the scratch_backing_memory_location and read
+     it.  We cannot cache this value as the runtime may change the
+     allocation dynamically.  */
 
-    dbgapi_assert (prefetch_end > prefetch_begin);
-    cwsr_record->agent ().memory_cache ().prefetch (
-      prefetch_begin, prefetch_end - prefetch_begin);
+  process ().read_host_memory (
+    m_os_queue_info.read_pointer_address
+      + offsetof (amd_queue_t, scratch_backing_memory_location)
+      - offsetof (amd_queue_t, read_dispatch_id),
+    &m_scratch_backing_memory_address);
 
-    wave_t *wave = nullptr;
-
-    if (process.is_flag_set (process_t::flag_t::runtime_enable_during_attach))
-      {
-        /* Assign new ids to all waves regardless of the content of their
-           wave_id register.  This is needed during attach as waves created
-           before the debugger attached to the process may have stale
-           wave_ids.  */
-      }
-    else if (amd_dbgapi_wave_id_t wave_id = cwsr_record->id ();
-             wave_id != wave_t::undefined)
-      {
-        /* The wave already has a wave_id, so we should find it in this queue.
-           Search all visible and invisible waves.  */
-        wave = process.find (wave_id, true /* include invisible waves  */);
-
-        if (!wave)
-          {
-            /* The wave_id saved in the ttmp registers may be corrupted.  */
-            fatal_error ("%s not found in %s", to_cstring (wave_id),
-                         to_cstring (id ()));
-          }
-      }
-
-    if (!wave)
-      {
-        workgroup_t *workgroup = nullptr;
-
-        if (group_leader)
-          {
-            /* We already have identified the workgroup_t this wave belongs to,
-               it is the same workgroup_t as the thread group leader's.  */
-            workgroup = &group_leader->workgroup ();
-
-            if (workgroup->group_ids () != cwsr_record->group_ids ())
-              fatal_error ("not in the same workgroup as the group_leader");
-          }
-        else
-          {
-            const auto packet_id = get_os_queue_packet_id (*cwsr_record);
-            const auto group_ids = cwsr_record->group_ids ();
-
-            /* Find the dispatch this wave belongs to using the packet_id.  The
-               packet_id is only unique for a given queue.  */
-            dispatch_t *dispatch = process.find_if (
-              [this, packet_id] (const dispatch_t &d) {
-                return d.queue () == *this
-                       && d.os_queue_packet_id () == packet_id;
-              });
-
-            if (dispatch)
-              {
-                workgroup = process.find_if (
-                  [dispatch, group_ids] (const workgroup_t &w) {
-                    return w.dispatch () == *dispatch
-                           && w.group_ids () == group_ids;
-                  });
-              }
-            else if (packet_id)
-              {
-                dispatch = &process.create<aql_dispatch_t> (*this, *packet_id);
-              }
-            else
-              {
-                /* If this wave does not have a packet_id (ttmps are not setup
-                   or may be corrupted), then create a new workgroup associated
-                   with the dummy_dispatch.  All waves belonging to this
-                   workgroup will be associated with this instance.  */
-                dispatch = &m_dummy_dispatch;
-              }
-
-            if (!workgroup)
-              workgroup = &process.create<workgroup_t> (
-                *dispatch, group_ids, cwsr_record->lds_size ());
-          }
-
-        dbgapi_assert (workgroup != nullptr);
-        wave = &process.create<wave_t> (*workgroup,
-                                        cwsr_record->position_in_group ());
-      }
-
-    bool is_first_wave = cwsr_record->is_first_wave ();
-    bool is_last_wave = cwsr_record->is_last_wave ();
-
-    /* The first wave in the group is the group leader.  The group leader owns
-       the backing store for the group memory (LDS).  */
-    if (is_first_wave)
-      {
-        group_leader = wave;
-
-        auto shared_memory_base_address
-          = cwsr_record->register_address (amdgpu_regnum_t::lds_0);
-
-        dbgapi_assert (shared_memory_base_address);
-        group_leader->workgroup ().update (*shared_memory_base_address);
-      }
-
-    if (!group_leader)
-      fatal_error ("No group_leader, the control stack may be corrupted");
-
-    /* Update this wave's state using the context save area as it may have
-       changed since the queue was last suspended (or the wave is new).  */
-    wave->update (std::move (cwsr_record));
-
-    if (wave->state () != AMD_DBGAPI_WAVE_STATE_STOP)
-      ++*m_waves_running;
-
-    /* Hide new waves halted at launch until the process' wave creation mode is
-       changed to not stopped.  A wave is halted at launch if it is halted
-       (status.halt=1) without having entered the trap handler, and its pc
-       points to the kernel entry point.  */
-    if (!wave->mark () /* A wave without a mark is a new wave that has not been
-                          seen by queue_t::update_waves before.  */
-        && wave->state () == AMD_DBGAPI_WAVE_STATE_RUN
-        && wave->dispatch ().kernel_descriptor ().is_at_kernel_entry (
-          global_address_t{wave->pc ()})
-        && wave->is_halted ())
-      {
-        log_verbose ("%s is halted at launch", to_cstring (wave->id ()));
-
-        wave->set_visibility (wave_t::visibility_t::hidden_halted_at_launch);
-        wave->set_halted (false);
-        wave->set_state (AMD_DBGAPI_WAVE_STATE_STOP);
-      }
-
-    /* This was the last wave in the group. Make sure we have a new group
-       leader for the remaining waves.  */
-    if (is_last_wave)
-      group_leader = nullptr;
-
-    wave->set_mark (wave_mark);
-    if (is_first_wave)
-      wave->workgroup ().set_mark (wave_mark);
-  };
-
-  process_t &process = this->process ();
-  size_t wave_count = 0; /* Number of waves seen in the context save area.  */
-
-  /* Start with 0 running waves.  When iterating the control stack (below)
-     each discovered wave in the running state will increment this count.  */
-  m_waves_running.emplace (0);
-
-  for (uint32_t xcc_id = 0; xcc_id < agent ().os_info ().xcc_count; ++xcc_id)
-    {
-      auto ctx_save_address
-        = m_os_queue_info.ctx_save_restore_address
-          + xcc_id * m_os_queue_info.ctx_save_restore_area_size;
-
-      /* Retrieve the control stack and wave save area memory locations.  */
-      context_save_area_header_s header;
-      agent ().read_agent_memory (ctx_save_address, &header);
-
-      auto control_stack_begin
-        = ctx_save_address + header.control_stack_offset;
-      auto control_stack_end = control_stack_begin + header.control_stack_size;
-      auto wave_area_end = ctx_save_address + header.wave_state_offset;
-      auto wave_area_begin = wave_area_end - header.wave_state_size;
-
-      /* The control stack and the wave save area should be contiguous.  */
-      if (control_stack_end != wave_area_begin)
-        fatal_error ("corrupted context save area header");
-
-      if (control_stack_begin != control_stack_end)
-        {
-          log_info ("decoding %s's context save area #%u: "
-                    "ctrl_stk:[%s..%s[, wave_area:[%s..%s[",
-                    to_cstring (id ()), xcc_id,
-                    to_cstring (control_stack_begin),
-                    to_cstring (control_stack_end),
-                    to_cstring (wave_area_begin), to_cstring (wave_area_end));
-
-          /* Read the entire control stack from the inferior in one go.  */
-          amd_dbgapi_size_t size = control_stack_end - control_stack_begin;
-          if (!utils::is_aligned (size, sizeof (uint32_t)))
-            fatal_error ("corrupted control stack");
-
-          auto memory
-            = std::make_unique<uint32_t[]> (size / sizeof (uint32_t));
-          agent ().read_agent_memory (control_stack_begin, &memory[0], size);
-
-          /* Decode the control stack.  For each entry in the control stack,
-             the provided callback function is called with a CWSR record.  */
-          wave_count += architecture ().control_stack_iterate (
-            *this, xcc_id, &memory[0], size / sizeof (uint32_t), wave_area_end,
-            wave_area_end - wave_area_begin, process_cwsr_record);
-        }
-    }
-
-  if (wave_count)
-    log_info ("%zu out of %zu wave%s running on %s", *m_waves_running,
-              wave_count, wave_count > 1 ? "s" : "", to_cstring (id ()));
-
-  /* Iterate all waves, workgroups and dispatches belonging to this queue, and
-     prune waves and workgroups with a mark older than the current mark, and
-     dispatches with ids older (smaller) than the queue current read dispatch
-     id.
-
-     Note that the waves must be pruned before the workgroups and the
-     workgroups must be pruned before the dispatches to ensure there are no
-     dangling pointers to pruned objects.  */
-
-  auto &&wave_range = process.range<wave_t> ();
-  for (auto it = wave_range.begin (); it != wave_range.end ();)
-    if (it->queue () == *this && it->mark () < wave_mark)
-      {
-        dbgapi_assert (it->state () != AMD_DBGAPI_WAVE_STATE_STOP
-                       && "a stopped wave cannot terminate");
-        it = process.destroy (it);
-      }
-    else
-      ++it;
-
-  auto &&workgroup_range = process.range<workgroup_t> ();
-  for (auto it = workgroup_range.begin (); it != workgroup_range.end ();)
-    if (it->queue () == *this && it->mark () < wave_mark)
-      it = process.destroy (it);
-    else
-      ++it;
-
-  auto &&dispatch_range = process.range<dispatch_t> ();
-  for (auto it = dispatch_range.begin (); it != dispatch_range.end ();)
-    if (it->queue () == *this && it->os_queue_packet_id () < m_read_packet_id)
-      it = process.destroy (it);
-    else
-      ++it;
+  process ().read_host_memory (m_os_queue_info.read_pointer_address
+                                 + offsetof (amd_queue_t, compute_tmpring_size)
+                                 - offsetof (amd_queue_t, read_dispatch_id),
+                               &m_compute_tmpring_size);
 }
 
 std::pair<agent_address_t /* address */, amd_dbgapi_size_t /* size */>
@@ -1047,6 +1071,9 @@ queue_t::create (std::optional<amd_dbgapi_queue_id_t> queue_id,
       return agent.process ().create<detail::aql_queue_t> (queue_id, agent,
                                                            os_queue_info);
 
+    case os_queue_type_t::compute:
+      return agent.process ().create<compute_queue_t> (queue_id, agent,
+                                                       os_queue_info);
     default:
       return agent.process ().create<detail::unsupported_queue_t> (
         queue_id, agent, os_queue_info);

--- a/projects/rocdbgapi/src/queue.h
+++ b/projects/rocdbgapi/src/queue.h
@@ -155,6 +155,16 @@ public:
                                std::function<void (agent_address_t)>>;
 
 protected:
+  struct context_save_area_header_s
+  {
+    uint32_t control_stack_offset;
+    uint32_t control_stack_size;
+    uint32_t wave_state_offset;
+    uint32_t wave_state_size;
+    uint32_t debugger_memory_offset;
+    uint32_t debugger_memory_size;
+  };
+
   class dummy_dispatch_t : public dispatch_t
   {
   private:
@@ -197,34 +207,88 @@ protected:
      is suspended.  */
   std::optional<size_t> m_waves_running{};
 
+  static constexpr amd_dbgapi_size_t debugger_memory_chunk_size = 32;
+
+  uint16_t m_debugger_memory_chunk_count{ 0 };
+  uint16_t m_debugger_memory_next_chunk{ 0 };
+  std::vector<uint16_t> m_debugger_memory_free_chunks{};
+
+  std::optional<displaced_instruction_ptr_t> m_park_instruction_ptr{};
+  std::optional<displaced_instruction_ptr_t> m_terminating_instruction_ptr{};
+
+  /* The memory reserved by the thunk library for the debugger is used to store
+     instruction buffers.  Instruction buffers are lazily allocated from the
+     reserved memory, and when freed, their index is returned to a free list.
+     Each wave is guaranteed its own unique instruction buffer.  */
+  std::optional<agent_address_t> m_debugger_memory_base{};
+
+  std::optional<amd_dbgapi_os_queue_packet_id_t> m_read_packet_id{};
+  std::optional<amd_dbgapi_os_queue_packet_id_t> m_write_packet_id{};
+  uint32_t m_compute_tmpring_size{ 0 };
+
+  /* Called whenever the queue changes state.  */
+  virtual void queue_state_changed () override;
+
+  void update_waves ();
+
+  virtual dispatch_t *
+  create_dispatch (amd_dbgapi_os_queue_packet_id_t packet_id);
+  virtual std::optional<amd_dbgapi_os_queue_packet_id_t>
+  get_os_queue_packet_id (
+    const architecture_t::cwsr_record_t & /* cwsr_record  */) const
+  {
+    /* Raw compute queue do not have have link to the dispatch packets.  */
+    return {};
+  }
+
+  /* TODO lsix: make that better.  */
+  virtual void refresh_scratch_on_suspend ();
+
+public:
   compute_queue_t (amd_dbgapi_queue_id_t queue_id, const agent_t &agent,
                    const os_queue_snapshot_entry_t &os_queue_info)
     : queue_t (queue_id, agent, os_queue_info), m_dummy_dispatch (*this)
   {
   }
 
-public:
   void wave_state_changed (const wave_t &wave);
 
   bool is_all_stopped () const override;
 
   /* Return the address of a park instruction.  */
-  virtual agent_address_t park_instruction_address () = 0;
+  virtual agent_address_t park_instruction_address ();
   /* Return the address of a terminating instruction.  */
-  virtual agent_address_t terminating_instruction_address () = 0;
+  virtual agent_address_t terminating_instruction_address ();
 
   /* Return the wave's scratch memory region (address and size).  */
   virtual std::pair<agent_address_t /* address */,
                     amd_dbgapi_size_t /* size */>
   scratch_memory_region (
-    const architecture_t::cwsr_record_t &cwsr_record) const
-    = 0;
+    const architecture_t::cwsr_record_t &cwsr_record) const;
 
   /* Return a pointer to device accessible memory containing the given
      instruction bytes.  */
   virtual displaced_instruction_ptr_t
-  allocate_displaced_instruction (const instruction_t &instruction)
-    = 0;
+  allocate_displaced_instruction (const instruction_t &instruction);
+
+  amd_dbgapi_os_queue_type_t type () const override
+  {
+    return AMD_DBGAPI_OS_QUEUE_TYPE_AMD_PM4;
+  }
+
+  size_t packet_size () const override { return 0; }
+
+  void active_packets_info (amd_dbgapi_os_queue_packet_id_t *,
+                            amd_dbgapi_os_queue_packet_id_t *,
+                            size_t *) const override
+  {
+  }
+
+  void active_packets_bytes (amd_dbgapi_os_queue_packet_id_t,
+                             amd_dbgapi_os_queue_packet_id_t, void *,
+                             size_t) const override
+  {
+  }
 };
 
 /* Wraps a queue and provides a RAII mechanism to suspend it if it wasn't

--- a/projects/rocdbgapi/src/queue.h
+++ b/projects/rocdbgapi/src/queue.h
@@ -60,7 +60,7 @@ public:
   };
 
 protected:
-  os_queue_snapshot_entry_t const m_os_queue_info;
+  os_queue_snapshot_entry_t m_os_queue_info;
 
 private:
   state_t m_state{ state_t::running };
@@ -84,6 +84,11 @@ public:
   }
 
   virtual ~queue_t () = default;
+
+  void update (const os_queue_snapshot_entry_t &queue_info)
+  {
+    m_os_queue_info = queue_info;
+  }
 
   /* Return the queue's type.  */
   virtual amd_dbgapi_os_queue_type_t type () const = 0;

--- a/projects/rocdbgapi/src/queue.h
+++ b/projects/rocdbgapi/src/queue.h
@@ -111,7 +111,7 @@ public:
   void set_mark (epoch_t mark) { m_mark = mark; }
 
   /* Return the address of the memory holding the queue packets.  */
-  host_address_t address () const;
+  std::variant<host_address_t, agent_address_t> address () const;
 
   /* Return the size of the memory holding the queue packets.  */
   amd_dbgapi_size_t size () const;


### PR DESCRIPTION
## Motivation

Refactor queue management to allow non-AQL compute queues.

## Technical Details

Compute queues might not all use AQL, but dbgapi has them tied up together.  Split things up.  No functional change expected.