### PR TITLE
[perf-dkms] Remove patched kernel requirement from README

### DIFF
--- a/experimental/perf-dkms/README.md
+++ b/experimental/perf-dkms/README.md
@@ -6,7 +6,6 @@
 >
 > **Requirements:**
 > - GFX12/RDNA4 GPUs only (RX 9070 series)
-> - **Patched Linux kernel required** (see Prerequisites section)
 >
 > Use at your own risk in development/testing environments only.
 


### PR DESCRIPTION
## Summary
- Remove outdated "Patched Linux kernel required" line from README
- A patched kernel is no longer needed since the module uses KFD ioctls via vm_mmap bridge

## Test plan
- [x] Documentation-only change, no code impact