### PR TITLE
fix(rocinsight): replace --kernel-names with --kernel-include-regex per AMD docs

### DIFF
--- a/experimental/python/rocinsight/rocinsight/ai_analysis/docs/LLM_REFERENCE_GUIDE.md
+++ b/experimental/python/rocinsight/rocinsight/ai_analysis/docs/LLM_REFERENCE_GUIDE.md
@@ -169,9 +169,9 @@ rocprofv3 --sys-trace --pmc FETCH_SIZE \
 rocprofv3 --sys-trace --pmc WRITE_SIZE \
   -d ./counters -o pass3 -- ./app
 
-# Scope to the hot kernel (add --kernel-names to any pass)
+# Scope to the hot kernel (add --kernel-include-regex to any pass)
 rocprofv3 --sys-trace --pmc GRBM_COUNT GRBM_GUI_ACTIVE SQ_WAVES \
-  --kernel-names "hotKernelName" -d ./counters -o pass1 -- ./app
+  --kernel-include-regex "hotKernelName" -d ./counters -o pass1 -- ./app
 ```
 
 **What you learn**:
@@ -319,7 +319,7 @@ When unsure, recommend: `rocprofv3 --list-avail | grep <BLOCK_NAME>`
 **Kernel Filtering**:
 ```bash
 # Filter by kernel name (exact match or substring)
-rocprofv3 --kernel-names "myKernel" --pmc SQ_WAVES -- ./app
+rocprofv3 --kernel-include-regex "myKernel" --pmc SQ_WAVES -- ./app
 
 # Filter by kernel name regex
 rocprofv3 --kernel-include-regex "matmul.*" --pmc SQ_WAVES -- ./app
@@ -1935,13 +1935,13 @@ Cannot calculate GPU utilization, wave occupancy, or HBM bandwidth.
 Recommended next step (Step 2) — THREE passes required (each TCC-derived counter needs its own pass):
   # Pass 1: GPU utilization + wave occupancy
   rocprofv3 --sys-trace --pmc GRBM_COUNT GRBM_GUI_ACTIVE SQ_WAVES \
-    --kernel-names "<hot_kernel>" -d ./counters -o profile_pass1 -- ./app
+    --kernel-include-regex "<hot_kernel>" -d ./counters -o profile_pass1 -- ./app
   # Pass 2: HBM read bandwidth (FETCH_SIZE alone — 3 TCC hardware counters)
   rocprofv3 --sys-trace --pmc FETCH_SIZE \
-    --kernel-names "<hot_kernel>" -d ./counters -o profile_pass2 -- ./app
+    --kernel-include-regex "<hot_kernel>" -d ./counters -o profile_pass2 -- ./app
   # Pass 3: HBM write bandwidth (WRITE_SIZE alone — 2 TCC hardware counters)
   rocprofv3 --sys-trace --pmc WRITE_SIZE \
-    --kernel-names "<hot_kernel>" -d ./counters -o profile_pass3 -- ./app
+    --kernel-include-regex "<hot_kernel>" -d ./counters -o profile_pass3 -- ./app
 
 This will enable: GPU utilization, occupancy, and HBM bandwidth analysis.
 For full roofline model, follow with: rocprof-compute profile -- ./app

--- a/experimental/python/rocinsight/rocinsight/ai_analysis/interactive.py
+++ b/experimental/python/rocinsight/rocinsight/ai_analysis/interactive.py
@@ -4436,7 +4436,8 @@ class WorkflowSession:
                         # hallucinate non-existent names — strip defensively.
                         # (a) --hip-api-trace: invalid; correct flag is --hip-trace:
                         fc = re.sub(r"\s*--hip-api-trace\b", "", fc)
-                        # (b) --kernel-names <value> — value-taking invalid flag:
+                        # (b) --kernel-names <value> — invalid flag, replaced by
+                        #     --kernel-include-regex in AMD docs:
                         fc = re.sub(
                             r"--kernel-names\s+(?:'[^']*'|\"[^\"]*\"|\S+)",
                             "",

--- a/experimental/python/rocinsight/rocinsight/ai_analysis/share/llm-reference-guide.md
+++ b/experimental/python/rocinsight/rocinsight/ai_analysis/share/llm-reference-guide.md
@@ -169,9 +169,9 @@ rocprofv3 --sys-trace --pmc FETCH_SIZE \
 rocprofv3 --sys-trace --pmc WRITE_SIZE \
   -d ./counters -o pass3 -- ./app
 
-# Scope to the hot kernel (add --kernel-names to any pass)
+# Scope to the hot kernel (add --kernel-include-regex to any pass)
 rocprofv3 --sys-trace --pmc GRBM_COUNT GRBM_GUI_ACTIVE SQ_WAVES \
-  --kernel-names "hotKernelName" -d ./counters -o pass1 -- ./app
+  --kernel-include-regex "hotKernelName" -d ./counters -o pass1 -- ./app
 ```
 
 **What you learn**:
@@ -319,7 +319,7 @@ When unsure, recommend: `rocprofv3 --list-avail | grep <BLOCK_NAME>`
 **Kernel Filtering**:
 ```bash
 # Filter by kernel name (exact match or substring)
-rocprofv3 --kernel-names "myKernel" --pmc SQ_WAVES -- ./app
+rocprofv3 --kernel-include-regex "myKernel" --pmc SQ_WAVES -- ./app
 
 # Filter by kernel name regex
 rocprofv3 --kernel-include-regex "matmul.*" --pmc SQ_WAVES -- ./app
@@ -2152,13 +2152,13 @@ Cannot calculate GPU utilization, wave occupancy, or HBM bandwidth.
 Recommended next step (Step 2) — THREE passes required (each TCC-derived counter needs its own pass):
   # Pass 1: GPU utilization + wave occupancy
   rocprofv3 --sys-trace --pmc GRBM_COUNT GRBM_GUI_ACTIVE SQ_WAVES \
-    --kernel-names "<hot_kernel>" -d ./counters -o profile_pass1 -- ./app
+    --kernel-include-regex "<hot_kernel>" -d ./counters -o profile_pass1 -- ./app
   # Pass 2: HBM read bandwidth (FETCH_SIZE alone — 3 TCC hardware counters)
   rocprofv3 --sys-trace --pmc FETCH_SIZE \
-    --kernel-names "<hot_kernel>" -d ./counters -o profile_pass2 -- ./app
+    --kernel-include-regex "<hot_kernel>" -d ./counters -o profile_pass2 -- ./app
   # Pass 3: HBM write bandwidth (WRITE_SIZE alone — 2 TCC hardware counters)
   rocprofv3 --sys-trace --pmc WRITE_SIZE \
-    --kernel-names "<hot_kernel>" -d ./counters -o profile_pass3 -- ./app
+    --kernel-include-regex "<hot_kernel>" -d ./counters -o profile_pass3 -- ./app
 
 This will enable: GPU utilization, occupancy, and HBM bandwidth analysis.
 For full roofline model, follow with: rocprof-compute profile -- ./app

--- a/experimental/python/rocinsight/rocinsight/ai_analysis/tests/test_kernel_filter_regex.py
+++ b/experimental/python/rocinsight/rocinsight/ai_analysis/tests/test_kernel_filter_regex.py
@@ -1,0 +1,148 @@
+#!/usr/bin/env python3
+###############################################################################
+# MIT License
+#
+# Copyright (c) 2025 Advanced Micro Devices, Inc.
+###############################################################################
+
+"""
+Tests that --kernel-names has been replaced with --kernel-include-regex
+across the codebase, and that kernel name values are regex-escaped.
+"""
+
+import re
+from pathlib import Path
+
+import pytest
+
+
+def _package_root() -> Path:
+    """Return the rocinsight package root directory."""
+    here = Path(__file__).resolve()
+    # tests/ -> ai_analysis/ -> rocinsight/
+    return here.parent.parent.parent
+
+
+class TestKernelFilterRegex:
+    def test_recommendations_uses_regex_flag(self):
+        """recommendations.py should use --kernel-include-regex, not --kernel-names."""
+        from rocinsight.analysis.recommendations import generate_recommendations
+
+        # Generate a kernel hotspot rec with a dominant kernel
+        time_breakdown = {
+            "total_kernel_time": 900_000,
+            "total_memcpy_time": 0,
+            "total_runtime": 1_000_000,
+            "kernel_percent": 90.0,
+            "memcpy_percent": 0.0,
+            "overhead_percent": 10.0,
+        }
+        hotspots = [
+            {
+                "name": "my_kernel(float*, int)",
+                "calls": 10,
+                "total_duration": 900_000,
+                "avg_duration": 90_000,
+                "percent_of_total": 90.0,
+            }
+        ]
+        recs = generate_recommendations(time_breakdown, hotspots, {})
+        # Find the kernel hotspot / compute rec (category varies by counter availability)
+        _rule3_cats = {"Kernel Hotspot", "Compute-Bound Kernel", "Mixed Bottleneck Kernel", "Memory-Bound Kernel"}
+        kernel_recs = [r for r in recs if r.get("category") in _rule3_cats]
+        assert len(kernel_recs) > 0, f"Expected a kernel hotspot recommendation, got categories: {[r.get('category') for r in recs]}"
+        rec = kernel_recs[0]
+        # Check commands use --kernel-include-regex
+        for cmd in rec.get("commands", []):
+            full = cmd.get("full_command", "")
+            assert "--kernel-names" not in full, (
+                f"full_command still uses --kernel-names: {full}"
+            )
+            if "--kernel-include-regex" in full:
+                # The kernel name should be regex-escaped in the command
+                assert "float\\*" in full or "float" in full, (
+                    "Kernel name with special chars should be regex-escaped"
+                )
+            for arg in cmd.get("args", []):
+                assert arg.get("name") != "--kernel-names", (
+                    "arg name still uses --kernel-names"
+                )
+
+    def test_kernel_name_regex_escaped(self):
+        """Kernel names with regex special chars should be escaped."""
+        from rocinsight.analysis.recommendations import generate_recommendations
+
+        time_breakdown = {
+            "total_kernel_time": 900_000,
+            "total_memcpy_time": 0,
+            "total_runtime": 1_000_000,
+            "kernel_percent": 90.0,
+            "memcpy_percent": 0.0,
+            "overhead_percent": 10.0,
+        }
+        hotspots = [
+            {
+                "name": "kernel(float*, int)",
+                "calls": 10,
+                "total_duration": 900_000,
+                "avg_duration": 90_000,
+                "percent_of_total": 90.0,
+            }
+        ]
+        recs = generate_recommendations(time_breakdown, hotspots, {})
+        _rule3_cats = {"Kernel Hotspot", "Compute-Bound Kernel", "Mixed Bottleneck Kernel", "Memory-Bound Kernel"}
+        kernel_recs = [r for r in recs if r.get("category") in _rule3_cats]
+        assert len(kernel_recs) > 0, "Expected a kernel hotspot recommendation"
+        for cmd in kernel_recs[0].get("commands", []):
+            for arg in cmd.get("args", []):
+                if arg.get("name") == "--kernel-include-regex":
+                    val = arg["value"]
+                    # re.escape("kernel(float*, int)") should escape parens, asterisk
+                    assert "(" not in val or "\\(" in val, (
+                        f"Kernel name not regex-escaped: {val}"
+                    )
+
+    def test_no_kernel_names_in_llm_guide(self):
+        """LLM reference guide should not contain --kernel-names."""
+        guide_path = _package_root() / "ai_analysis" / "share" / "llm-reference-guide.md"
+        if guide_path.exists():
+            content = guide_path.read_text()
+            assert "--kernel-names" not in content, (
+                "llm-reference-guide.md still contains --kernel-names"
+            )
+
+    def test_no_kernel_names_in_docs_guide(self):
+        """LLM_REFERENCE_GUIDE.md copy should not contain --kernel-names."""
+        docs_path = _package_root() / "ai_analysis" / "docs" / "LLM_REFERENCE_GUIDE.md"
+        if docs_path.exists():
+            content = docs_path.read_text()
+            assert "--kernel-names" not in content, (
+                "docs/LLM_REFERENCE_GUIDE.md still contains --kernel-names"
+            )
+
+    def test_filter_rec_commands_uses_regex_flag(self):
+        """_NON_DATA_ARGS in _filter_rec_commands should include --kernel-include-regex."""
+        from rocinsight.analysis.recommendations import _filter_rec_commands
+
+        cmd = {
+            "tool": "rocprofv3",
+            "description": "test",
+            "flags": ["--sys-trace"],
+            "args": [
+                {"name": "--pmc", "value": "GRBM_COUNT GRBM_GUI_ACTIVE SQ_WAVES"},
+                {"name": "--kernel-include-regex", "value": "my_kernel"},
+                {"name": "-d", "value": "./output"},
+                {"name": "-o", "value": "profile"},
+            ],
+            "full_command": (
+                'rocprofv3 --sys-trace --pmc GRBM_COUNT GRBM_GUI_ACTIVE SQ_WAVES'
+                ' --kernel-include-regex "my_kernel" -d ./output -o profile -- ./app'
+            ),
+        }
+        already = frozenset(
+            {"--sys-trace", "pmc:GRBM_COUNT", "pmc:GRBM_GUI_ACTIVE", "pmc:SQ_WAVES"}
+        )
+        result = _filter_rec_commands([cmd], already)
+        assert result == [], (
+            "--kernel-include-regex should be treated as non-data arg"
+        )

--- a/experimental/python/rocinsight/rocinsight/analysis/recommendations.py
+++ b/experimental/python/rocinsight/rocinsight/analysis/recommendations.py
@@ -137,7 +137,7 @@ def _filter_rec_commands(
       are dropped entirely.
     - If after stripping, a rocprofv3 command has no remaining flags AND
       its args contain only output-path or scope-filter entries (-d / -o /
-      --kernel-names / etc.), the command adds no new data and is dropped.
+      --kernel-include-regex / etc.), the command adds no new data and is dropped.
     - ``rocprof-sys --trace`` alone is equivalent to ``rocprofv3 --sys-trace``
       (same HIP/HSA API data, just in Perfetto format instead of rocpd format)
       and is dropped when sys-trace data is already present.  ``rocprof-sys``
@@ -158,7 +158,7 @@ def _filter_rec_commands(
     # data collection on their own.
     _NON_DATA_ARGS = _OUTPUT_ONLY_ARGS | frozenset(
         {
-            "--kernel-names",
+            "--kernel-include-regex",
             "--include-names",
             "--exclude-names",
         }
@@ -221,7 +221,7 @@ def _filter_rec_commands(
             continue
 
         # Meaningful args: anything that isn't an output path or a scope filter.
-        # --kernel-names scopes collection but doesn't collect new data itself.
+        # --kernel-include-regex scopes collection but doesn't collect new data itself.
         meaningful_args = [a for a in new_args if a.get("name", "") not in _NON_DATA_ARGS]
         if not new_flags and not meaningful_args:
             continue  # nothing new to collect -- drop the command entirely
@@ -728,15 +728,15 @@ def generate_recommendations(
                                     "value": "GRBM_COUNT GRBM_GUI_ACTIVE SQ_WAVES",
                                 },
                                 {
-                                    "name": "--kernel-names",
-                                    "value": kernel_name,
+                                    "name": "--kernel-include-regex",
+                                    "value": f"^{re.escape(kernel_name)}$",
                                 },  # display only; full_command uses shlex.quote
                                 {"name": "-d", "value": "./kernel_output"},
                                 {"name": "-o", "value": "profile"},
                             ],
                             "full_command": (
                                 f"rocprofv3 --sys-trace --pmc GRBM_COUNT GRBM_GUI_ACTIVE SQ_WAVES"
-                                f" --kernel-names {shlex.quote(kernel_name)}"
+                                f" --kernel-include-regex {shlex.quote(f'^{re.escape(kernel_name)}$')}"
                                 f" -d ./kernel_output -o profile -- ./app"
                             ),
                         },

--- a/experimental/python/rocinsight/tests/test_ai_analysis_standalone.py
+++ b/experimental/python/rocinsight/tests/test_ai_analysis_standalone.py
@@ -445,16 +445,18 @@ class TestBugFixes:
         compute_recs = [r for r in recs if r["category"] in _rule3_cats]
         assert compute_recs, "Expected a kernel hotspot recommendation"
 
-        quoted_name = shlex.quote(dangerous_name)
+        import re as _re
+        escaped_name = _re.escape(dangerous_name)
+        quoted_name = shlex.quote(f"^{escaped_name}$")
         rocprofv3_cmds = [
             cmd for cmd in compute_recs[0]["commands"] if cmd.get("tool") == "rocprofv3"
         ]
         assert rocprofv3_cmds, "Expected at least one rocprofv3 command"
         for cmd in rocprofv3_cmds:
             full = cmd["full_command"]
-            # The properly shell-quoted form of the kernel name must appear
+            # The properly shell-quoted, regex-escaped form must appear
             assert quoted_name in full, (
-                f"Expected shlex.quote({dangerous_name!r}) == {quoted_name!r} "
+                f"Expected shlex.quote(re.escape({dangerous_name!r})) == {quoted_name!r} "
                 f"in full_command, got: {full}"
             )
             # The raw (unquoted) name must not appear verbatim (i.e., not word-split)

--- a/experimental/python/rocinsight/tests/test_analyze.py
+++ b/experimental/python/rocinsight/tests/test_analyze.py
@@ -1195,16 +1195,16 @@ def test_filter_pmc_description_note_added():
 
 
 def test_filter_pmc_kernel_names_alone_not_meaningful():
-    """--kernel-names is a scope filter; command with only scope+output args is dropped."""
+    """--kernel-include-regex is a scope filter; command with only scope+output args is dropped."""
     from rocinsight.analyze import _filter_rec_commands
 
     cmd = _pmc_cmd(
         counters="GRBM_COUNT GRBM_GUI_ACTIVE SQ_WAVES",
-        extra_args=[{"name": "--kernel-names", "value": "my_kernel"}],
+        extra_args=[{"name": "--kernel-include-regex", "value": "my_kernel"}],
     )
     cmd["full_command"] = (
         "rocprofv3 --sys-trace --pmc GRBM_COUNT GRBM_GUI_ACTIVE SQ_WAVES"
-        ' --kernel-names "my_kernel" -d ./output -o profile -- ./app'
+        ' --kernel-include-regex "my_kernel" -d ./output -o profile -- ./app'
     )
     # All three counters already collected + sys-trace → nothing new
     already = frozenset(


### PR DESCRIPTION
## Summary
`--kernel-names` is not in current rocprofv3 documentation. AMD docs specify `--kernel-include-regex` for kernel filtering. Updated all recommendations, reference guides, interactive session, and tests. Kernel names with regex special characters are properly escaped with `re.escape()`.

## Test plan
- [x] 4 new tests: regex flag used, old flag absent, special chars escaped, filter arg classification
- [x] 0 occurrences of --kernel-names in output

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Stacking note
This PR is based on the ROCM-21553 feature stack (#4968-#4972). Its own change is: `recommendations.py`, `interactive.py`, reference guides, and tests — all replacing `--kernel-names` with `--kernel-include-regex`.

Merge after #4972 lands, then rebase onto develop for a clean diff.