### PR TITLE
feat(rocinsight): expose private/local LLM providers in CLI, deprecate output_format param

### DIFF
--- a/experimental/python/rocinsight/rocinsight/ai_analysis/api.py
+++ b/experimental/python/rocinsight/rocinsight/ai_analysis/api.py
@@ -23,6 +23,7 @@ Example:
         print(f"- {rec.title}")
 """
 
+import warnings
 from dataclasses import dataclass, field, asdict
 from enum import Enum
 from pathlib import Path
@@ -526,7 +527,7 @@ def analyze_database(
     llm_provider: Optional[str] = None,
     llm_api_key: Optional[str] = None,
     llm_thinking_tokens: Optional[int] = None,
-    output_format: OutputFormat = OutputFormat.PYTHON_OBJECT,
+    output_format: Any = None,
     verbose: bool = False,
     top_kernels: int = 10,
     att_dir: Optional[str] = None,
@@ -546,7 +547,10 @@ def analyze_database(
         llm_thinking_tokens: Enable extended thinking with this token budget.
             Only supported with the Anthropic provider and compatible models
             (claude-opus-4, claude-sonnet-4-5, claude-3-7-sonnet).
-        output_format: Desired output format
+        output_format: Deprecated. This parameter is ignored. The function
+            always returns an AnalysisResult object. Use `result.to_json()`,
+            `result.to_text()`, `result.to_markdown()`, or `result.to_webview()`
+            to obtain formatted output.
         verbose: Enable verbose logging
         top_kernels: Number of top kernels to analyze
 
@@ -568,6 +572,18 @@ def analyze_database(
         ...     print(f"- {rec.title}")
     """
     database_path = Path(database_path)
+
+    # Deprecation warning for output_format parameter
+    if output_format is not None:
+        warnings.warn(
+            "The 'output_format' parameter is deprecated and ignored. "
+            "analyze_database() always returns an AnalysisResult object. "
+            "Use result.to_json(), result.to_text(), result.to_markdown(), "
+            "or result.to_webview() for formatted output.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+
     # Validate database exists
     if not database_path.exists():
         raise DatabaseNotFoundError(f"Database file not found: {database_path}")

--- a/experimental/python/rocinsight/rocinsight/ai_analysis/tests/test_cli_llm_providers.py
+++ b/experimental/python/rocinsight/rocinsight/ai_analysis/tests/test_cli_llm_providers.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python3
+###############################################################################
+# MIT License
+#
+# Copyright (c) 2025 Advanced Micro Devices, Inc.
+###############################################################################
+
+"""
+Tests for CLI LLM provider choices and output_format deprecation.
+"""
+
+import warnings
+
+import pytest
+
+
+class TestCliLlmProviders:
+    def test_llm_choices_include_private(self):
+        """--llm choices should include 'private'."""
+        from rocinsight.analyze import add_args
+        import argparse
+
+        parser = argparse.ArgumentParser()
+        subparsers = parser.add_subparsers()
+        sub = subparsers.add_parser("analyze")
+        add_args(sub)
+
+        # Parse with --llm private to verify it is accepted
+        args = parser.parse_args(["analyze", "--llm", "private"])
+        assert args.llm == "private"
+
+    def test_llm_choices_include_local(self):
+        """--llm choices should include 'local'."""
+        from rocinsight.analyze import add_args
+        import argparse
+
+        parser = argparse.ArgumentParser()
+        subparsers = parser.add_subparsers()
+        sub = subparsers.add_parser("analyze")
+        add_args(sub)
+
+        args = parser.parse_args(["analyze", "--llm", "local"])
+        assert args.llm == "local"
+
+    def test_llm_choices_still_include_anthropic(self):
+        """--llm choices should still include the original providers."""
+        from rocinsight.analyze import add_args
+        import argparse
+
+        parser = argparse.ArgumentParser()
+        subparsers = parser.add_subparsers()
+        sub = subparsers.add_parser("analyze")
+        add_args(sub)
+
+        for provider in ["anthropic", "openai", "claude-code"]:
+            args = parser.parse_args(["analyze", "--llm", provider])
+            assert args.llm == provider
+
+    def test_llm_invalid_choice_rejected(self):
+        """--llm with an invalid choice should fail."""
+        from rocinsight.analyze import add_args
+        import argparse
+
+        parser = argparse.ArgumentParser()
+        subparsers = parser.add_subparsers()
+        sub = subparsers.add_parser("analyze")
+        add_args(sub)
+
+        with pytest.raises(SystemExit):
+            parser.parse_args(["analyze", "--llm", "invalid-provider"])
+
+
+class TestOutputFormatDeprecation:
+    def test_output_format_none_no_warning(self):
+        """Passing output_format=None (default) should not trigger a warning."""
+        # We can't easily call analyze_database without a real DB,
+        # but we can test the import and type signature
+        from rocinsight.ai_analysis.api import analyze_database
+        import inspect
+
+        sig = inspect.signature(analyze_database)
+        param = sig.parameters["output_format"]
+        # Default should be None, not OutputFormat.PYTHON_OBJECT
+        assert param.default is None, (
+            f"output_format default should be None, got {param.default}"
+        )
+
+    def test_output_format_type_annotation_is_any(self):
+        """output_format type annotation should be Any (not OutputFormat)."""
+        from rocinsight.ai_analysis.api import analyze_database
+        import inspect
+        from typing import Any
+
+        sig = inspect.signature(analyze_database)
+        param = sig.parameters["output_format"]
+        assert param.annotation is Any, (
+            f"output_format annotation should be Any, got {param.annotation}"
+        )
+
+    def test_output_format_enum_still_importable(self):
+        """OutputFormat enum should still be importable for backward compat."""
+        from rocinsight.ai_analysis.api import OutputFormat
+
+        assert hasattr(OutputFormat, "PYTHON_OBJECT")
+        assert hasattr(OutputFormat, "JSON")

--- a/experimental/python/rocinsight/rocinsight/analyze.py
+++ b/experimental/python/rocinsight/rocinsight/analyze.py
@@ -972,7 +972,7 @@ def add_args(parser: argparse.ArgumentParser):
     llm_options.add_argument(
         "--llm",
         type=str,
-        choices=["anthropic", "openai", "claude-code"],
+        choices=["anthropic", "openai", "claude-code", "private", "local"],
         default=None,
         help=(
             "Enable LLM-powered analysis enhancement. "
@@ -980,6 +980,11 @@ def add_args(parser: argparse.ArgumentParser):
             "'openai' uses the OpenAI API (requires OPENAI_API_KEY). "
             "'claude-code' uses the Claude Code CLI installed on this machine — "
             "no API key needed, uses existing Claude Code credentials. "
+            "'private' uses an OpenAI-compatible endpoint configured via "
+            "ROCINSIGHT_LLM_PRIVATE_URL (required), ROCINSIGHT_LLM_PRIVATE_MODEL, "
+            "ROCINSIGHT_LLM_PRIVATE_API_KEY, and ROCINSIGHT_LLM_PRIVATE_HEADERS. "
+            "'local' uses a locally-running model (e.g. Ollama) configured via "
+            "ROCINSIGHT_LLM_LOCAL_URL (default: http://localhost:11434). "
             "Local analysis always runs first; LLM provides additional natural language insights."
         ),
     )


### PR DESCRIPTION
## Summary
- **feat**: Added `private` and `local` to `--llm` CLI choices. These providers were already supported by the LLM layer (private = enterprise OpenAI-compatible endpoint, local = Ollama) but not exposed in the argument parser.
- **deprecate**: `output_format` parameter in `analyze_database()` now emits `DeprecationWarning` when passed (backwards compatible — not removed). Callers should use `result.to_json()`, `result.to_webview()`, or `result.to_text()` instead.

## Stacking note
This PR is based on the ROCM-21553 feature stack (#4968 → #4969 → #4970 → #4971 → #4972). The GitHub diff against `develop` includes those prior changes. **This PR's own changes are only 3 files:**
- `rocinsight/analyze.py` — 1 line (--llm choices)
- `rocinsight/ai_analysis/api.py` — output_format deprecation
- `rocinsight/ai_analysis/tests/test_cli_llm_providers.py` — 5 new tests

Merge after #4972 lands, then rebase onto develop for a clean diff.

## Test plan
- [x] 5 new tests, all passing
- [x] Backwards compatible — existing callers passing output_format get a warning, not an error

🤖 Generated with [Claude Code](https://claude.com/claude-code)