### PR TITLE
fix(rocinsight): union kernels/memory_copies/regions views across multi-DB shards

### DIFF
--- a/experimental/python/rocinsight/rocinsight/connection.py
+++ b/experimental/python/rocinsight/rocinsight/connection.py
@@ -64,6 +64,10 @@ class RocinsightConnection:
         "pmc_events",
     ]
 
+    # SQL views defined inside each rocpd database that analysis code queries
+    # directly (e.g. analysis/core.py uses "kernels", "memory_copies", "regions").
+    _ANALYSIS_VIEWS = ["kernels", "memory_copies", "regions"]
+
     def __init__(
         self,
         db_paths: Union[str, Path, List[Union[str, Path]]],
@@ -151,6 +155,27 @@ class RocinsightConnection:
             conn.execute(
                 f"CREATE TEMP VIEW IF NOT EXISTS {table} AS {union_sql}"
             )
+
+        # Union analysis-facing views (kernels, memory_copies, regions) that
+        # are defined as SQL VIEWs inside each rocpd database file.
+        for view_name in self._ANALYSIS_VIEWS:
+            parts = []
+            for idx in range(n):
+                alias = f"db{idx}"
+                try:
+                    check = conn.execute(
+                        f"SELECT COUNT(*) FROM {alias}.sqlite_master "
+                        f"WHERE (type='table' OR type='view') AND name='{view_name}'"
+                    ).fetchone()
+                    if check and check[0] > 0:
+                        parts.append(f"SELECT * FROM {alias}.{view_name}")
+                except Exception:
+                    continue
+            if parts:
+                union_sql = " UNION ALL ".join(parts)
+                conn.execute(
+                    f"CREATE TEMP VIEW IF NOT EXISTS [{view_name}] AS {union_sql}"
+                )
 
 
 # ---------------------------------------------------------------------------

--- a/experimental/python/rocinsight/tests/test_multidb_union_views.py
+++ b/experimental/python/rocinsight/tests/test_multidb_union_views.py
@@ -1,0 +1,70 @@
+"""Tests for multi-database analysis view unioning across attached shards."""
+import sqlite3
+import pytest
+
+
+def _create_test_db(path, kernel_name, kernel_duration):
+    """Create a minimal DB with a kernels table (mimicking the rocpd view)."""
+    conn = sqlite3.connect(str(path))
+    conn.execute(
+        "CREATE TABLE kernels (name TEXT, start INTEGER, end INTEGER, duration INTEGER)"
+    )
+    conn.execute(
+        "INSERT INTO kernels VALUES (?, 100, ?, ?)",
+        (kernel_name, 100 + kernel_duration, kernel_duration),
+    )
+    conn.execute(
+        "CREATE TABLE memory_copies "
+        "(name TEXT, start INTEGER, end INTEGER, duration INTEGER, size INTEGER)"
+    )
+    conn.execute(
+        "CREATE TABLE regions "
+        "(name TEXT, category TEXT, start INTEGER, end INTEGER, duration INTEGER)"
+    )
+    conn.execute(
+        "CREATE TABLE pmc_events "
+        "(id INTEGER PRIMARY KEY, dispatch_id INTEGER, counter_name TEXT, counter_value REAL)"
+    )
+    conn.commit()
+    conn.close()
+
+
+class TestMultiFileUnionViews:
+    def test_kernels_visible_from_both_dbs(self, tmp_path):
+        db0 = tmp_path / "shard0.db"
+        db1 = tmp_path / "shard1.db"
+        _create_test_db(db0, "kernel_A", 1000)
+        _create_test_db(db1, "kernel_B", 2000)
+
+        from rocinsight.connection import RocinsightConnection, execute_statement
+        conn = RocinsightConnection([str(db0), str(db1)])
+        rows = execute_statement(conn, "SELECT name FROM kernels ORDER BY name").fetchall()
+        names = [r[0] for r in rows]
+        assert "kernel_A" in names
+        assert "kernel_B" in names
+        assert len(rows) == 2
+
+    def test_memory_copies_from_both_dbs(self, tmp_path):
+        db0 = tmp_path / "shard0.db"
+        db1 = tmp_path / "shard1.db"
+        _create_test_db(db0, "k", 100)
+        _create_test_db(db1, "k", 100)
+        for path, mc_name in [(db0, "h2d_0"), (db1, "h2d_1")]:
+            c = sqlite3.connect(str(path))
+            c.execute("INSERT INTO memory_copies VALUES (?, 0, 100, 100, 1024)", (mc_name,))
+            c.commit()
+            c.close()
+
+        from rocinsight.connection import RocinsightConnection, execute_statement
+        conn = RocinsightConnection([str(db0), str(db1)])
+        rows = execute_statement(conn, "SELECT name FROM memory_copies").fetchall()
+        assert len(rows) == 2
+
+    def test_single_db_still_works(self, tmp_path):
+        db0 = tmp_path / "single.db"
+        _create_test_db(db0, "kernel_only", 500)
+        from rocinsight.connection import RocinsightConnection, execute_statement
+        conn = RocinsightConnection([str(db0)])
+        rows = execute_statement(conn, "SELECT name FROM kernels").fetchall()
+        assert len(rows) == 1
+        assert rows[0][0] == "kernel_only"


### PR DESCRIPTION
## Summary
Multi-file analysis (`RocinsightConnection([db0, db1])`) only created UNION ALL views for `rocpd_*` tables, but analysis code queries `kernels`, `memory_copies`, `regions` views. This caused multi-DB analysis to silently read only the first shard. Added `_ANALYSIS_VIEWS` union logic for these views.

## Test plan
- [x] 3 new tests: both shards visible in kernels, memory_copies union, single-DB still works
- [x] E2E: two synthetic DBs → both kernel names visible

🤖 Generated with [Claude Code](https://claude.com/claude-code)