### PR TITLE
fix(rocinsight): detect PK collisions in merge_sqlite_dbs instead of silent data loss

### DIFF
--- a/experimental/python/rocinsight/rocinsight/ai_analysis/tests/test_connection.py
+++ b/experimental/python/rocinsight/rocinsight/ai_analysis/tests/test_connection.py
@@ -318,17 +318,12 @@ class TestMergeSqliteDbs:
         assert out == dest
         assert dest.exists()
 
-    def test_merge_two_dbs_combines_rows(self, two_dbs, tmp_dir):
+    def test_merge_two_dbs_raises_on_pk_collision(self, two_dbs, tmp_dir):
         p1, p2 = two_dbs
         dest = tmp_dir / "merged.db"
-        out = merge_sqlite_dbs([p1, p2], output_path=dest)
-        assert out.exists()
-        conn = sqlite3.connect(str(out))
-        row = conn.execute("SELECT COUNT(*) FROM pmc_events").fetchone()
-        conn.close()
-        # p1 has SQ_WAVES (id=1), p2 has GRBM_COUNT (id=1) — INSERT OR IGNORE merges by id
-        # At minimum p1's data is present (base copy); p2's row has same id=1 so may be ignored
-        assert row[0] >= 1
+        # Both shards have id=1 — collision must be detected and raised
+        with pytest.raises(ValueError, match="collision"):
+            merge_sqlite_dbs([p1, p2], output_path=dest)
 
     def test_merge_returns_path_object(self, single_db):
         out = merge_sqlite_dbs([single_db])

--- a/experimental/python/rocinsight/rocinsight/connection.py
+++ b/experimental/python/rocinsight/rocinsight/connection.py
@@ -201,22 +201,49 @@ def merge_sqlite_dbs(
         for idx, src in enumerate(db_paths[1:], start=1):
             alias = f"src{idx}"
             conn.execute(f"ATTACH DATABASE ? AS {alias}", (str(src),))
-            cursor = conn.execute(f"PRAGMA {alias}.sqlite_master")
+            cursor = conn.execute(
+                f"SELECT type, name FROM {alias}.sqlite_master "
+                f"WHERE type = 'table'"
+            )
             tables = [
                 row[1]
                 for row in cursor.fetchall()
-                if row[0] == "table" and not row[1].startswith("sqlite_")
+                if not row[1].startswith("sqlite_")
             ]
             for table in tables:
                 try:
+                    # Check for primary key collisions before inserting
+                    pk_cols = [
+                        row[1] for row in conn.execute(
+                            f"PRAGMA table_info({table})"
+                        ).fetchall()
+                        if row[5] > 0  # row[5] is the 'pk' column
+                    ]
+                    if pk_cols:
+                        pk_join = " AND ".join(
+                            f"src.{c} = dst.{c}" for c in pk_cols
+                        )
+                        collision = conn.execute(
+                            f"SELECT COUNT(*) FROM {alias}.{table} src "
+                            f"INNER JOIN main.{table} dst ON {pk_join}"
+                        ).fetchone()
+                        if collision and collision[0] > 0:
+                            raise ValueError(
+                                f"Primary key collision in table '{table}': "
+                                f"{collision[0]} overlapping row(s) between "
+                                f"shards. Cannot merge losslessly. Use "
+                                f"RocinsightConnection([db1, db2]) for "
+                                f"multi-DB analysis instead of physical merge."
+                            )
+                    # No collision (or no PK) — safe to insert
                     conn.execute(
-                        f"INSERT OR IGNORE INTO main.{table} "
+                        f"INSERT INTO main.{table} "
                         f"SELECT * FROM {alias}.{table}"
                     )
                 except sqlite3.OperationalError:
                     pass  # table may have different schema in this shard
+            conn.commit()
             conn.execute(f"DETACH DATABASE {alias}")
-        conn.commit()
     finally:
         conn.close()
 

--- a/experimental/python/rocinsight/tests/test_merge_collision_detection.py
+++ b/experimental/python/rocinsight/tests/test_merge_collision_detection.py
@@ -1,0 +1,60 @@
+"""Tests for merge_sqlite_dbs primary key collision detection."""
+import sqlite3
+import pytest
+
+
+def _create_db_with_pmc(path, row_id, counter_name, counter_value):
+    conn = sqlite3.connect(str(path))
+    conn.execute(
+        "CREATE TABLE pmc_events "
+        "(id INTEGER PRIMARY KEY, dispatch_id INTEGER, counter_name TEXT, counter_value REAL)"
+    )
+    conn.execute(
+        "INSERT INTO pmc_events VALUES (?, 1, ?, ?)",
+        (row_id, counter_name, counter_value),
+    )
+    conn.commit()
+    conn.close()
+
+
+class TestMergeCollisionDetection:
+    def test_raises_on_id_collision(self, tmp_path):
+        db0 = tmp_path / "shard0.db"
+        db1 = tmp_path / "shard1.db"
+        _create_db_with_pmc(db0, 1, "SQ_WAVES", 32.0)
+        _create_db_with_pmc(db1, 1, "GRBM_COUNT", 1000.0)  # same id=1
+
+        from rocinsight.connection import merge_sqlite_dbs
+        merged = tmp_path / "merged.db"
+        with pytest.raises(ValueError, match="collision|overlap"):
+            merge_sqlite_dbs([str(db0), str(db1)], str(merged))
+
+    def test_merge_succeeds_no_collision(self, tmp_path):
+        db0 = tmp_path / "shard0.db"
+        db1 = tmp_path / "shard1.db"
+        _create_db_with_pmc(db0, 1, "SQ_WAVES", 32.0)
+        _create_db_with_pmc(db1, 2, "GRBM_COUNT", 1000.0)  # different id
+
+        from rocinsight.connection import merge_sqlite_dbs
+        merged = tmp_path / "merged.db"
+        merge_sqlite_dbs([str(db0), str(db1)], str(merged))
+        conn = sqlite3.connect(str(merged))
+        count = conn.execute("SELECT COUNT(*) FROM pmc_events").fetchone()[0]
+        assert count == 2
+
+    def test_no_pk_table_merges_without_error(self, tmp_path):
+        """Tables without primary keys should merge normally."""
+        db0 = tmp_path / "shard0.db"
+        db1 = tmp_path / "shard1.db"
+        for path, val in [(db0, "a"), (db1, "b")]:
+            conn = sqlite3.connect(str(path))
+            conn.execute("CREATE TABLE nopk (val TEXT)")
+            conn.execute("INSERT INTO nopk VALUES (?)", (val,))
+            # Also need pmc_events for the merge to work on shared tables
+            conn.execute("CREATE TABLE pmc_events (id INTEGER PRIMARY KEY, counter_name TEXT)")
+            conn.commit()
+            conn.close()
+
+        from rocinsight.connection import merge_sqlite_dbs
+        merged = tmp_path / "merged.db"
+        merge_sqlite_dbs([str(db0), str(db1)], str(merged))


### PR DESCRIPTION
## Summary
`INSERT OR IGNORE` silently dropped later-shard rows when primary keys overlapped (common with auto-increment IDs). Now detects collisions via PRAGMA table_info + INNER JOIN and raises ValueError with guidance to use `RocinsightConnection([db1, db2])` instead.

Also fixed: PRAGMA sqlite_master syntax error that caused merge to skip tables from non-first shards, and commit-before-detach ordering.

## Test plan
- [x] 3 new tests: collision raises ValueError, non-colliding merge succeeds, no-PK tables merge
- [x] E2E: overlapping id=1 correctly raises ValueError

🤖 Generated with [Claude Code](https://claude.com/claude-code)