### PR TITLE
rocinsight: warn at runtime when SSL verification is opted out

### DIFF
--- a/experimental/python/rocinsight/rocinsight/ai_analysis/llm_analyzer.py
+++ b/experimental/python/rocinsight/rocinsight/ai_analysis/llm_analyzer.py
@@ -1082,13 +1082,20 @@ Follow the reference guide strictly for analysis methodology and output format."
         verify_ssl = verify_ssl_env not in ("0", "false", "no")
         http_client = None
         if not verify_ssl:
+            import warnings
+
+            warnings.warn(
+                "[LLMAnalyzer] SSL certificate verification is DISABLED via "
+                "ROCINSIGHT_LLM_PRIVATE_VERIFY_SSL — LLM traffic is exposed "
+                "to MITM. Only use this for trusted private endpoints with "
+                "self-signed certs.",
+                stacklevel=2,
+            )
             try:
                 import httpx as _httpx
 
                 http_client = _httpx.Client(verify=False)
             except ImportError:
-                import warnings
-
                 warnings.warn(
                     "ROCINSIGHT_LLM_PRIVATE_VERIFY_SSL=0 requested but httpx is not installed. "
                     "SSL verification will remain enabled. Run: pip install httpx",

--- a/experimental/python/rocinsight/rocinsight/ai_analysis/llm_conversation.py
+++ b/experimental/python/rocinsight/rocinsight/ai_analysis/llm_conversation.py
@@ -85,6 +85,13 @@ def _build_private_client(api_key: Optional[str], model_override: Optional[str])
     verify_ssl = verify_ssl_env not in ("0", "false", "no")
     http_client = None
     if not verify_ssl:
+        warnings.warn(
+            "[LLMConversation] SSL certificate verification is DISABLED via "
+            "ROCINSIGHT_LLM_PRIVATE_VERIFY_SSL — LLM traffic is exposed to "
+            "MITM. Only use this for trusted private endpoints with self-"
+            "signed certs.",
+            stacklevel=3,
+        )
         try:
             import httpx as _httpx
 

--- a/experimental/python/rocinsight/rocinsight/ai_analysis/tests/test_llm_private.py
+++ b/experimental/python/rocinsight/rocinsight/ai_analysis/tests/test_llm_private.py
@@ -469,3 +469,44 @@ class TestBuildPrivateClientSSL:
 
         mock_httpx.Client.assert_called_once_with(verify=False)
         assert captured_kwargs.get("http_client") is mock_httpx_client
+
+    def test_ssl_disabled_emits_security_warning(self, monkeypatch, recwarn):
+        """Opting out of SSL verification must surface a runtime warning."""
+        monkeypatch.setenv("ROCINSIGHT_LLM_PRIVATE_URL", "https://example.com/v1")
+        monkeypatch.setenv("ROCINSIGHT_LLM_PRIVATE_VERIFY_SSL", "0")
+        monkeypatch.delenv("ROCINSIGHT_LLM_PRIVATE_HEADERS", raising=False)
+
+        mock_httpx = MagicMock()
+        mock_httpx.Client.return_value = MagicMock()
+        mock_openai_cls = MagicMock()
+        mock_openai_cls.side_effect = lambda **kwargs: MagicMock()
+
+        with patch.dict(
+            "sys.modules",
+            {
+                "openai": MagicMock(OpenAI=mock_openai_cls),
+                "httpx": mock_httpx,
+            },
+        ):
+            _build_private_client("k", None)
+
+        msgs = [str(w.message) for w in recwarn.list]
+        assert any("SSL certificate verification is DISABLED" in m for m in msgs), (
+            f"Expected an SSL-disabled warning; got: {msgs}"
+        )
+
+    def test_ssl_enabled_no_warning(self, monkeypatch, recwarn):
+        """Default (SSL enabled) must not emit the SSL-disabled warning."""
+        monkeypatch.setenv("ROCINSIGHT_LLM_PRIVATE_URL", "https://example.com/v1")
+        monkeypatch.delenv("ROCINSIGHT_LLM_PRIVATE_HEADERS", raising=False)
+        monkeypatch.delenv("ROCINSIGHT_LLM_PRIVATE_VERIFY_SSL", raising=False)
+
+        mock_openai_cls = MagicMock()
+        mock_openai_cls.side_effect = lambda **kwargs: MagicMock()
+        with patch.dict("sys.modules", {"openai": MagicMock(OpenAI=mock_openai_cls)}):
+            _build_private_client("k", None)
+
+        msgs = [str(w.message) for w in recwarn.list]
+        assert not any("SSL certificate verification is DISABLED" in m for m in msgs), (
+            f"Did not expect an SSL-disabled warning; got: {msgs}"
+        )


### PR DESCRIPTION
## Motivation

`ROCINSIGHT_LLM_PRIVATE_VERIFY_SSL=0` disables SSL certificate verification for the private LLM client. The code currently only emits a warning when `httpx` is *missing*; when `httpx` is installed (the normal case) the opt-out is **silent** — users can lower their security posture with zero console feedback, and MITM-intercepted LLM traffic leaves no local signal that anything changed.

## Impact — what users see today

- User sets `ROCINSIGHT_LLM_PRIVATE_VERIFY_SSL=0` (e.g. for a private endpoint with a self-signed cert, as documented in the README).
- Profiling data + source snippets are sent over an unverified HTTPS connection.
- No warning, no log line, no indication the session is unprotected.
- An attacker positioned on the network path can intercept requests and inject modified LLM responses.

## What this changes

Emits a single `warnings.warn()` at the opt-out site in both private-client constructors:
- `rocinsight/ai_analysis/llm_conversation.py::_build_private_client`
- `rocinsight/ai_analysis/llm_analyzer.py::_call_private`

The warning explains the risk and the intended use case (trusted private endpoints with self-signed certs). Default behaviour (verification enabled) is unchanged — no warning fires.

## Provenance

Found while triaging bandit `B501 (request_with_no_cert_validation)` in the static-analysis backlog. Bandit correctly flags the `verify=False` literal. After review, the opt-in pattern and env-var gating are the correct remediation for B501, but the *absence of a runtime notice on opt-out* is a small, real UX/security gap worth closing.

## Files changed

- `experimental/python/rocinsight/rocinsight/ai_analysis/llm_conversation.py` — 7 lines
- `experimental/python/rocinsight/rocinsight/ai_analysis/llm_analyzer.py` — 11 lines
- `experimental/python/rocinsight/rocinsight/ai_analysis/tests/test_llm_private.py` — 2 new tests covering opt-out-warns and default-no-warning

## Test plan

- [x] `pytest rocinsight/ai_analysis/tests/test_llm_private.py` — 20/20 pass locally
- [x] New `test_ssl_disabled_emits_security_warning` passes
- [x] New `test_ssl_enabled_no_warning` passes
- [x] Existing tests unchanged and pass

## Test result

```
20 passed, 2 warnings in 0.06s
```

The "2 warnings" are the intentional SSL-disabled notices captured from the two opt-out tests — evidence the warning fires when expected.