### PR TITLE
fix(rocinsight): specify encoding='utf-8' for reference guide loading (Windows compat)

### DIFF
--- a/experimental/python/rocinsight/rocinsight/ai_analysis/llm_analyzer.py
+++ b/experimental/python/rocinsight/rocinsight/ai_analysis/llm_analyzer.py
@@ -138,7 +138,7 @@ def load_reference_guide() -> str:
     Raises:
         ReferenceGuideNotFoundError: If guide file not found.
     """
-    return get_reference_guide_path().read_text()
+    return get_reference_guide_path().read_text(encoding="utf-8")
 
 
 # ---------------------------------------------------------------------------
@@ -414,7 +414,7 @@ class LLMAnalyzer:
         if not self.reference_guide_path.exists():
             raise ReferenceGuideNotFoundError([str(self.reference_guide_path)])
 
-        return self.reference_guide_path.read_text()
+        return self.reference_guide_path.read_text(encoding="utf-8")
 
     def _sanitize_data(self, analysis_data: Dict[str, Any]) -> Dict[str, Any]:
         """

--- a/experimental/python/rocinsight/rocinsight/ai_analysis/tests/test_utf8_guide_loading.py
+++ b/experimental/python/rocinsight/rocinsight/ai_analysis/tests/test_utf8_guide_loading.py
@@ -1,0 +1,28 @@
+"""Tests for UTF-8 reference guide loading (Windows compatibility)."""
+import pytest
+from unittest.mock import patch
+
+
+class TestUTF8GuideLoading:
+    def _make_utf8_guide(self, tmp_path):
+        content = "# Guide\n\nHardware Counter Limits \u2014 MUST NOT EXCEED\n\u2192 split into\n\u2705 SAFE\n\u274c UNSAFE\n"
+        p = tmp_path / "test-guide.md"
+        p.write_text(content, encoding="utf-8")
+        return p
+
+    def test_load_reference_guide_public(self, tmp_path):
+        guide_path = self._make_utf8_guide(tmp_path)
+        with patch("rocinsight.ai_analysis.llm_analyzer.get_reference_guide_path", return_value=guide_path):
+            from rocinsight.ai_analysis.llm_analyzer import load_reference_guide
+            text = load_reference_guide()
+        assert "\u2014" in text
+        assert "\u2192" in text
+
+    def test_load_reference_guide_instance(self, tmp_path):
+        guide_path = self._make_utf8_guide(tmp_path)
+        from rocinsight.ai_analysis.llm_analyzer import LLMAnalyzer
+        analyzer = LLMAnalyzer.__new__(LLMAnalyzer)
+        analyzer.reference_guide_path = guide_path
+        text = analyzer._load_reference_guide()
+        assert "\u2014" in text
+        assert "\u2705" in text


### PR DESCRIPTION
## Summary
`load_reference_guide()` and `LLMAnalyzer._load_reference_guide()` called `read_text()` without `encoding` parameter. On Windows (cp1252 locale), this fails on UTF-8 characters (em-dash, arrows, checkmarks) in the shipped reference guide.

## Test plan
- [x] 2 new tests: public and instance methods load UTF-8 guide with special chars

🤖 Generated with [Claude Code](https://claude.com/claude-code)