### PR TITLE
rocr: Move hsa_pointer update back inside else (!wait_any)

### DIFF
--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/runtime.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/runtime.cpp
@@ -1747,10 +1747,6 @@ void Runtime::AsyncEventsLoop(void* _eventsInfo) {
   };
 
   while (!async_events_control_.exit) {
-    // Update hsa_signals pointer at start of each iteration since PushBack
-    // at the end of the previous iteration may have reallocated the vector.
-    hsa_signals = reinterpret_cast<hsa_signal_handle*>(&async_events_.signal_[0]);
-
     // Wait for a signal
     std::vector<hsa_signal_value_t> value(1);
     value[0] = 0;
@@ -1769,6 +1765,8 @@ void Runtime::AsyncEventsLoop(void* _eventsInfo) {
         // Skip wake-up signal logic
         index = 1;
         wait_any = false;
+	// The new events can reallocate the signals, hence update the pointer
+	hsa_signals = reinterpret_cast<hsa_signal_handle*>(&async_events_.signal_[0]);
       }
     }
 
@@ -2465,7 +2463,6 @@ void Runtime::Unload() {
   }
 
   hw_exception_event_.reset();
-
 
   mapped_handle_map_.clear();
   memory_handle_map_.clear();


### PR DESCRIPTION
Revert `AsyncEventsLoop` _hsa_signals_ refresh to else-branch as the commit [1517a398 ](https://github.com/ROCm/rocm-systems/pull/2318) had moved the _hsa_signals_ pointer refresh to the top of the while loop unconditionally.

## Motivation

We observed an ~17% regression in half-precision LSTM inference throughput (8.6 ms → 10.1 ms per step) on MI300X with ROCm 7.13, traced via _rocprof_ to increased time in _hsa_signal_wait_scacquire_ and _hipDeviceSynchronize_ with no change in GPU kernel times.

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## JIRA ID

[ROCM-3913](https://amd-hub.atlassian.net/browse/ROCM-3913)

[ROCM-3913]: https://amd-hub.atlassian.net/browse/ROCM-3913?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ