### PR TITLE
[hipfile] Add io size, bandwidth, and latency stats broken down by gpu to ais-stats

### DIFF
--- a/projects/hipfile/docs/stats_collection.rst
+++ b/projects/hipfile/docs/stats_collection.rst
@@ -17,7 +17,7 @@ Collection is controlled by the environment variable ``HIPFILE_STATS_LEVEL``.
 Value Description
 ===== =================================================
 0     Disabled
-1     Basic
+1     Basic (default value)
 2     Detailed (same as basic; reserved for future use)
 ===== =================================================
 

--- a/projects/hipfile/docs/stats_collection.rst
+++ b/projects/hipfile/docs/stats_collection.rst
@@ -23,5 +23,7 @@ Value Description
 
 Stats Collected
 ---------------
-* Basic: Bytes read/written on the fastpath backend
-* Basic: Bytes read/written on the fallback backend
+* Basic: Bytes read/written on the fastpath/fallback backends.
+* Basic: Bandwidth for reads/writes on the fastpath/fallback backends.
+* Basic: Latency for reads/writes on the fastpath/fallback backends.
+* Basic: Histograms of above stats broken into buckets based on the size of the I/O.

--- a/projects/hipfile/src/amd_detail/backend/fallback.cpp
+++ b/projects/hipfile/src/amd_detail/backend/fallback.cpp
@@ -72,6 +72,7 @@ ssize_t
 Fallback::_io_impl(IoType type, std::shared_ptr<IFile> file, std::shared_ptr<IBuffer> buffer, size_t size,
                    hoff_t file_offset, hoff_t buffer_offset, size_t chunk_size)
 {
+    StatsIoTracker ioTracker{type, StatsBackend::Fallback};
     if (!Context<Configuration>::get()->fallback()) {
         throw BackendDisabled();
     }
@@ -130,16 +131,7 @@ Fallback::_io_impl(IoType type, std::shared_ptr<IFile> file, std::shared_ptr<IBu
         }
     } while (static_cast<size_t>(total_io_bytes) < size);
 
-    switch (type) {
-        case (IoType::Read):
-            statsAddFallbackPathRead(static_cast<size_t>(total_io_bytes));
-            break;
-        case (IoType::Write):
-            statsAddFallbackPathWrite(static_cast<size_t>(total_io_bytes));
-            break;
-        default:
-            break;
-    }
+    ioTracker.complete(static_cast<size_t>(total_io_bytes));
 
     return total_io_bytes;
 }

--- a/projects/hipfile/src/amd_detail/backend/fastpath.cpp
+++ b/projects/hipfile/src/amd_detail/backend/fastpath.cpp
@@ -166,6 +166,7 @@ ssize_t
 Fastpath::_io_impl(IoType type, shared_ptr<IFile> file, shared_ptr<IBuffer> buffer, size_t size,
                    hoff_t file_offset, hoff_t buffer_offset)
 {
+    StatsIoTracker ioTracker{type, StatsBackend::Fastpath};
     if (!Context<Configuration>::get()->fastpath()) {
         throw BackendDisabled();
     }
@@ -198,11 +199,11 @@ Fastpath::_io_impl(IoType type, shared_ptr<IFile> file, shared_ptr<IBuffer> buff
     switch (type) {
         case IoType::Read:
             nbytes = Context<Hip>::get()->hipAmdFileRead(handle, devptr, size, file_offset);
-            statsAddFastPathRead(nbytes);
+            ioTracker.complete(nbytes);
             break;
         case IoType::Write:
             nbytes = Context<Hip>::get()->hipAmdFileWrite(handle, devptr, size, file_offset);
-            statsAddFastPathWrite(nbytes);
+            ioTracker.complete(nbytes);
             break;
         default:
             throw std::runtime_error("Invalid IoType");

--- a/projects/hipfile/src/amd_detail/configuration.cpp
+++ b/projects/hipfile/src/amd_detail/configuration.cpp
@@ -43,7 +43,7 @@ Configuration::fallback(bool enabled) noexcept
 unsigned int
 Configuration::statsLevel() const noexcept
 {
-    HIPFILE_STATIC unsigned int stats_level_env{Environment::stats_level().value_or(0)};
+    HIPFILE_STATIC unsigned int stats_level_env{Environment::stats_level().value_or(1)};
     return stats_level_env;
 }
 

--- a/projects/hipfile/src/amd_detail/hip.cpp
+++ b/projects/hipfile/src/amd_detail/hip.cpp
@@ -199,4 +199,19 @@ Hip::hipInit() const
     (void)throwOnHipError<Hip::RuntimeError>(::hipInit(0));
 }
 
+int
+Hip::hipGetDevice() const
+{
+    int device_id;
+    (void)throwOnHipError<Hip::RuntimeError>(::hipGetDevice(&device_id));
+    return device_id;
+}
+
+int
+Hip::hipGetDeviceCount() const
+{
+    int device_count;
+    (void)throwOnHipError<Hip::RuntimeError>(::hipGetDeviceCount(&device_count));
+    return device_count;
+}
 }

--- a/projects/hipfile/src/amd_detail/hip.h
+++ b/projects/hipfile/src/amd_detail/hip.h
@@ -75,6 +75,8 @@ struct Hip {
     virtual int  hipDeviceGetAttribute(hipDeviceAttribute_t attr, int device_id) const;
     virtual hipDevice_t hipStreamGetDevice(hipStream_t stream) const;
     virtual void        hipInit() const;
+    virtual int         hipGetDevice() const;
+    virtual int         hipGetDeviceCount() const;
 
     struct RuntimeError : public std::runtime_error {
         hipError_t error;

--- a/projects/hipfile/src/amd_detail/stats.cpp
+++ b/projects/hipfile/src/amd_detail/stats.cpp
@@ -11,7 +11,9 @@
 
 #include <cerrno>
 #include <fcntl.h>
+#include <iomanip>
 #include <poll.h>
+#include <sstream>
 #include <unistd.h>
 #include <sys/eventfd.h>
 #include <sys/mman.h>
@@ -301,6 +303,45 @@ namespace reportUtil {
     }
 }
 
+static void
+generateReportHistogramV1(
+    std::ostream &stream, const StatsV1 *stats, size_t gpuId, const char *name, const char *op,
+    std::function<void(std::ostream &, PerGpuStatsV1::ConstHistograms, size_t bucket)> printFn)
+{
+    if (stats == nullptr) {
+        return;
+    }
+    static constexpr IoType       ioTypes[]{IoType::Read, IoType::Write};
+    static constexpr StatsBackend backends[]{StatsBackend::Fastpath, StatsBackend::Fallback};
+    int                           fw{16}, w{34};
+    stream << "IO " << name << " Histogram\n";
+    stream << std::left << std::setw(fw) << "IO Size (KiB)";
+    for (const auto &backend : backends) {
+        for (const auto &ioType : ioTypes) {
+            std::stringstream header{};
+            header << reportUtil::toString(backend) << ' ' << reportUtil::toString(ioType) << ' ' << op;
+            stream << std::right << std::setw(w) << header.str();
+        }
+    }
+    stream << '\n';
+    for (size_t i{}; i < StatsHistogram::MaxBuckets; ++i) {
+        auto [lower, upper] = StatsHistogram::bucketRange(i);
+        std::stringstream rowName{};
+        rowName << (lower >> 10) << '-'
+                << (i == StatsHistogram::MaxBuckets - 1 ? "..." : std::to_string(upper >> 10));
+        stream << std::left << std::setw(fw) << rowName.str();
+        for (const auto &backend : backends) {
+            for (const auto &ioType : ioTypes) {
+                if (const auto *perGpuStats{stats->getPerGpuStats(gpuId, backend)}) {
+                    stream << std::right << std::setw(w);
+                    printFn(stream, perGpuStats->getHistograms(ioType), i);
+                }
+            }
+        }
+        stream << '\n';
+    }
+}
+
 void
 StatsClient::generateReportV1(std::ostream &stream, const StatsV1 *stats)
 {
@@ -329,6 +370,45 @@ StatsClient::generateReportV1(std::ostream &stream, const StatsV1 *stats)
             stream << "Average " << reportUtil::toString(backend) << ' ' << reportUtil::toString(ioType)
                    << " Latency (us): " << reportUtil::latencyUs(totalTimeUs, totalCount) << "\n\n";
         }
+    }
+    for (size_t gpuId{}; gpuId < StatsV1::MaxGpus; ++gpuId) {
+        if (!stats->gpuInUse(gpuId)) {
+            continue;
+        }
+        stream << "GPU " << gpuId << ":\n";
+        auto ioSize = [](std::ostream &str, PerGpuStatsV1::ConstHistograms histograms, size_t bucket) {
+            const auto [sizeHist, countHist, timeHist] = histograms;
+            uint64_t size{};
+            if (sizeHist != nullptr) {
+                size = sizeHist->buckets[bucket].load();
+            }
+            str << size;
+        };
+        auto bandwidth = [](std::ostream &str, PerGpuStatsV1::ConstHistograms histograms, size_t bucket) {
+            const auto [sizeHist, countHist, timeHist] = histograms;
+            uint64_t size{}, timeUs{};
+            if (sizeHist != nullptr) {
+                size = sizeHist->buckets[bucket].load();
+            }
+            if (timeHist != nullptr) {
+                timeUs = timeHist->buckets[bucket].load();
+            }
+            str << reportUtil::bandwidthGiBs(size, timeUs);
+        };
+        auto latency = [](std::ostream &str, PerGpuStatsV1::ConstHistograms histograms, size_t bucket) {
+            const auto [sizeHist, countHist, timeHist] = histograms;
+            uint64_t timeUs{}, count{};
+            if (timeHist != nullptr) {
+                timeUs = timeHist->buckets[bucket].load();
+            }
+            if (countHist != nullptr) {
+                count = countHist->buckets[bucket].load();
+            }
+            str << reportUtil::latencyUs(timeUs, count);
+        };
+        generateReportHistogramV1(stream, stats, gpuId, "Size", "Size (B)", ioSize);
+        generateReportHistogramV1(stream, stats, gpuId, "Bandwidth", "Bandwidth (GiB/s)", bandwidth);
+        generateReportHistogramV1(stream, stats, gpuId, "Latency", "Latency (us)", latency);
     }
 }
 

--- a/projects/hipfile/src/amd_detail/stats.cpp
+++ b/projects/hipfile/src/amd_detail/stats.cpp
@@ -260,38 +260,47 @@ StatsClient::generateReportV1(std::ostream &stream, const Stats *stats)
 }
 
 void
-statsAddFastPathRead(uint64_t bytes)
+StatsIoTracker::complete(uint64_t bytes) const noexcept
 {
-    Stats *stats{Context<StatsServer>::get()->getStats()};
-    if (stats && stats->level >= StatsLevel::Basic) {
-        stats->getCounter(StatsCounters::TotalFastPathReadBytes) += bytes;
-    }
+    auto endTime{std::chrono::steady_clock::now()};
+    auto duration{std::chrono::duration_cast<std::chrono::microseconds>(endTime - m_startTime)};
+    Context<StatsCollection>::get()->addIo(m_ioType, m_backend, bytes,
+                                           static_cast<uint64_t>(duration.count()));
 }
 
 void
-statsAddFastPathWrite(uint64_t bytes)
+StatsCollection::addIo(IoType ioType, StatsBackend backend, uint64_t bytes, uint64_t timeUs) const noexcept
 {
+    (void)timeUs;
     Stats *stats{Context<StatsServer>::get()->getStats()};
-    if (stats && stats->level >= StatsLevel::Basic) {
-        stats->getCounter(StatsCounters::TotalFastPathWriteBytes) += bytes;
+    if (stats == nullptr || stats->level < StatsLevel::Basic) {
+        return;
     }
-}
-
-void
-statsAddFallbackPathRead(uint64_t bytes)
-{
-    Stats *stats{Context<StatsServer>::get()->getStats()};
-    if (stats && stats->level >= StatsLevel::Basic) {
-        stats->getCounter(StatsCounters::TotalFallbackPathReadBytes) += bytes;
+    StatsCounters counter{StatsCounters::Max};
+    switch (backend) {
+        case StatsBackend::Fastpath:
+            if (ioType == IoType::Read) {
+                counter = StatsCounters::TotalFastPathReadBytes;
+            }
+            else {
+                counter = StatsCounters::TotalFastPathWriteBytes;
+            }
+            break;
+        case StatsBackend::Fallback:
+            if (ioType == IoType::Read) {
+                counter = StatsCounters::TotalFallbackPathReadBytes;
+            }
+            else {
+                counter = StatsCounters::TotalFallbackPathWriteBytes;
+            }
+            break;
+        case StatsBackend::Count:
+            [[fallthrough]];
+        default:
+            break;
     }
-}
-
-void
-statsAddFallbackPathWrite(uint64_t bytes)
-{
-    Stats *stats{Context<StatsServer>::get()->getStats()};
-    if (stats && stats->level >= StatsLevel::Basic) {
-        stats->getCounter(StatsCounters::TotalFallbackPathWriteBytes) += bytes;
+    if (counter != StatsCounters::Max) {
+        stats->getCounter(counter) += bytes;
     }
 }
 }

--- a/projects/hipfile/src/amd_detail/stats.cpp
+++ b/projects/hipfile/src/amd_detail/stats.cpp
@@ -94,17 +94,37 @@ populateSocketAddr(sockaddr_un &addr, pid_t pid) noexcept
 }
 
 namespace hipFile {
-StatsServer::StatsServer()
+StatsContainer::StatsContainer()
     : m_fd{FileDescriptor::make_managed(Context<Sys>::get()->memfd_create("AISSTATS", MFD_ALLOW_SEALING))},
-      m_efd{FileDescriptor::make_managed(Context<Sys>::get()->eventfd(0, 0))}, m_stats{nullptr, &statsDeleter}
+      m_stats{nullptr}
 {
-    int fd{m_fd.get()};
-    Context<Sys>::get()->ftruncate(fd, sizeof(Stats));
-    void *shm = Context<Sys>::get()->mmap(nullptr, sizeof(Stats), PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0);
-    Context<Sys>::get()->fcntl(fd, F_ADD_SEALS, F_SEAL_SHRINK | F_SEAL_FUTURE_WRITE);
-    m_stats = UniqueStats{new (shm) Stats{}, &statsDeleter};
-    m_stats->level =
-        std::min(static_cast<StatsLevel>(Context<Configuration>::get()->statsLevel()), StatsLevel::Max);
+    StatsLevel level{static_cast<StatsLevel>(Context<Configuration>::get()->statsLevel())};
+    Context<Sys>::get()->ftruncate(m_fd.get(), sizeof(Stats));
+    void *shm =
+        Context<Sys>::get()->mmap(nullptr, sizeof(Stats), PROT_READ | PROT_WRITE, MAP_SHARED, m_fd.get(), 0);
+    try {
+        Context<Sys>::get()->fcntl(m_fd.get(), F_ADD_SEALS, F_SEAL_SHRINK | F_SEAL_FUTURE_WRITE);
+    }
+    catch (...) {
+        Context<Sys>::get()->munmap(shm, sizeof(Stats));
+        throw;
+    }
+    m_stats        = new (shm) Stats;
+    m_stats->level = std::min(level, StatsLevel::Max);
+}
+
+StatsContainer::~StatsContainer()
+{
+    if (m_stats == nullptr)
+        return;
+    m_stats->~Stats();
+    Context<Sys>::get()->munmap(m_stats, sizeof(Stats));
+    m_stats = nullptr;
+}
+
+StatsServer::StatsServer()
+    : m_efd{FileDescriptor::make_managed(Context<Sys>::get()->eventfd(0, 0))}, m_stats{}
+{
     m_thread = std::thread(&StatsServer::threadFn, this);
 }
 
@@ -119,19 +139,10 @@ StatsServer::~StatsServer()
 }
 
 void
-StatsServer::statsDeleter(Stats *s)
-{
-    if (s == nullptr) {
-        return;
-    }
-    s->~Stats();
-    Context<Sys>::get()->munmap(s, sizeof(Stats));
-}
-
-void
 StatsServer::threadFn()
 {
     FileDescriptor sock{FileDescriptor::make_managed(socket(AF_UNIX, SOCK_STREAM, 0))};
+    int            fd{m_stats.getFd()};
     pid_t          pid{getpid()};
     if (sock.get() == -1) {
         return;
@@ -169,7 +180,7 @@ StatsServer::threadFn()
             if (conn == -1) {
                 continue;
             }
-            sendFd(conn, m_fd.get());
+            sendFd(conn, fd);
             close(conn);
         }
         if (pfd[1].revents & (POLLIN | POLLERR | POLLNVAL)) {

--- a/projects/hipfile/src/amd_detail/stats.cpp
+++ b/projects/hipfile/src/amd_detail/stats.cpp
@@ -5,6 +5,7 @@
 
 #include "configuration.h"
 #include "context.h"
+#include "hip.h"
 #include "stats.h"
 #include "sys.h"
 
@@ -109,8 +110,8 @@ StatsContainer::StatsContainer()
         Context<Sys>::get()->munmap(shm, sizeof(Stats));
         throw;
     }
-    m_stats        = new (shm) Stats;
-    m_stats->level = std::min(level, StatsLevel::Max);
+    m_stats = new (shm) Stats;
+    m_stats->setLevel(std::min(level, StatsLevel::Max));
 }
 
 StatsContainer::~StatsContainer()
@@ -242,9 +243,9 @@ StatsClient::generateReport(std::ostream &stream) const
     if (stats == nullptr) {
         return false;
     }
-    stream << "AIS-STATS Version: " << stats->version
-           << "\nHipFile Stats Level: " << static_cast<uint64_t>(stats->level) << '\n';
-    switch (stats->version) {
+    stream << "AIS-STATS Version: " << stats->getVersion()
+           << "\nHipFile Stats Level: " << static_cast<uint64_t>(stats->getLevel()) << '\n';
+    switch (stats->getVersion()) {
         case 1:
             generateReportV1(stream, stats);
             break;
@@ -255,19 +256,80 @@ StatsClient::generateReport(std::ostream &stream) const
     return true;
 }
 
+namespace reportUtil {
+    const char *toString(IoType) noexcept;
+    const char *toString(StatsBackend) noexcept;
+    double      bandwidthGiBs(uint64_t bytes, uint64_t timeUs) noexcept;
+    double      latencyUs(uint64_t timeUs, uint64_t count) noexcept;
+
+    const char *toString(IoType ioType) noexcept
+    {
+        switch (ioType) {
+            case IoType::Read:
+                return "Read";
+            case IoType::Write:
+                return "Write";
+            default:
+                return "Unknown";
+        }
+    }
+
+    const char *toString(StatsBackend backend) noexcept
+    {
+        switch (backend) {
+            case StatsBackend::Fastpath:
+                return "Fastpath";
+            case StatsBackend::Fallback:
+                return "Fallback";
+            case StatsBackend::Count:
+                [[fallthrough]];
+            default:
+                return "Unknown";
+        }
+    }
+
+    double bandwidthGiBs(uint64_t bytes, uint64_t timeUs) noexcept
+    {
+        double time{static_cast<double>(timeUs) / 1000000.0};
+        double gigaBytes{static_cast<double>(bytes) / (1024.0 * 1024.0 * 1024.0)};
+        return time > 0 ? (gigaBytes / time) : 0.0;
+    }
+
+    double latencyUs(uint64_t timeUs, uint64_t count) noexcept
+    {
+        return count > 0 ? (static_cast<double>(timeUs) / static_cast<double>(count)) : 0.0;
+    }
+}
+
 void
-StatsClient::generateReportV1(std::ostream &stream, const Stats *stats)
+StatsClient::generateReportV1(std::ostream &stream, const StatsV1 *stats)
 {
     if (stats == nullptr) {
         return;
     }
-    stream << "Total fast path reads (B): " << stats->getCounter(StatsCounters::TotalFastPathReadBytes).load()
-           << "\nTotal fast path writes (B): "
-           << stats->getCounter(StatsCounters::TotalFastPathWriteBytes).load()
-           << "\nTotal fallback path reads (B): "
-           << stats->getCounter(StatsCounters::TotalFallbackPathReadBytes).load()
-           << "\nTotal fallback path writes (B): "
-           << stats->getCounter(StatsCounters::TotalFallbackPathWriteBytes).load() << '\n';
+    static constexpr IoType       ioTypes[]{IoType::Read, IoType::Write};
+    static constexpr StatsBackend backends[]{StatsBackend::Fastpath, StatsBackend::Fallback};
+    for (const auto &backend : backends) {
+        for (const auto &ioType : ioTypes) {
+            uint64_t totalBytes{}, totalCount{}, totalTimeUs{};
+            for (size_t i{}; i < StatsV1::MaxGpus; ++i) {
+                if (const auto *perGpuStats{stats->getPerGpuStats(i, backend)}) {
+                    if (const auto [sizeHist, countHist, timeHist] = perGpuStats->getHistograms(ioType);
+                        sizeHist != nullptr && countHist != nullptr && timeHist != nullptr) {
+                        totalBytes += sizeHist->accumulate();
+                        totalCount += countHist->accumulate();
+                        totalTimeUs += timeHist->accumulate();
+                    }
+                }
+            }
+            stream << "Total " << reportUtil::toString(backend) << ' ' << reportUtil::toString(ioType)
+                   << " Size (B): " << totalBytes << '\n';
+            stream << "Average " << reportUtil::toString(backend) << ' ' << reportUtil::toString(ioType)
+                   << " Bandwidth (GiB/s): " << reportUtil::bandwidthGiBs(totalBytes, totalTimeUs) << '\n';
+            stream << "Average " << reportUtil::toString(backend) << ' ' << reportUtil::toString(ioType)
+                   << " Latency (us): " << reportUtil::latencyUs(totalTimeUs, totalCount) << "\n\n";
+        }
+    }
 }
 
 void
@@ -282,36 +344,29 @@ StatsIoTracker::complete(uint64_t bytes) const noexcept
 void
 StatsCollection::addIo(IoType ioType, StatsBackend backend, uint64_t bytes, uint64_t timeUs) const noexcept
 {
-    (void)timeUs;
     Stats *stats{Context<StatsServer>::get()->getStats()};
-    if (stats == nullptr || stats->level < StatsLevel::Basic) {
+    if (stats == nullptr || stats->getLevel() < StatsLevel::Basic) {
         return;
     }
-    StatsCounters counter{StatsCounters::Max};
-    switch (backend) {
-        case StatsBackend::Fastpath:
-            if (ioType == IoType::Read) {
-                counter = StatsCounters::TotalFastPathReadBytes;
-            }
-            else {
-                counter = StatsCounters::TotalFastPathWriteBytes;
-            }
-            break;
-        case StatsBackend::Fallback:
-            if (ioType == IoType::Read) {
-                counter = StatsCounters::TotalFallbackPathReadBytes;
-            }
-            else {
-                counter = StatsCounters::TotalFallbackPathWriteBytes;
-            }
-            break;
-        case StatsBackend::Count:
-            [[fallthrough]];
-        default:
-            break;
+    size_t device{};
+    try {
+        device = static_cast<size_t>(Context<Hip>::get()->hipGetDevice());
     }
-    if (counter != StatsCounters::Max) {
-        stats->getCounter(counter) += bytes;
+    catch (...) {
+        return;
     }
+    auto *perGpuStats{stats->getPerGpuStats(device, backend)};
+    if (perGpuStats == nullptr) {
+        return;
+    }
+    auto [sizeHist, countHist, timeHist] = perGpuStats->getHistograms(ioType);
+    if (sizeHist == nullptr || countHist == nullptr || timeHist == nullptr) {
+        return;
+    }
+    size_t bucket = StatsHistogram::toHistogramBucket(bytes);
+    sizeHist->buckets[bucket].fetch_add(bytes, std::memory_order_relaxed);
+    countHist->buckets[bucket].fetch_add(1, std::memory_order_relaxed);
+    timeHist->buckets[bucket].fetch_add(timeUs, std::memory_order_relaxed);
+    perGpuStats->inUse.store(1, std::memory_order_relaxed);
 }
 }

--- a/projects/hipfile/src/amd_detail/stats.h
+++ b/projects/hipfile/src/amd_detail/stats.h
@@ -58,23 +58,61 @@ struct Stats {
     }
 };
 
+class StatsContainer {
+public:
+    StatsContainer();
+    ~StatsContainer();
+
+    StatsContainer(const StatsContainer &)            = delete;
+    StatsContainer &operator=(const StatsContainer &) = delete;
+
+    StatsContainer(StatsContainer &&other) noexcept : m_fd(std::move(other.m_fd)), m_stats(other.m_stats)
+    {
+        other.m_stats = nullptr;
+    }
+
+    StatsContainer &operator=(StatsContainer &&other) noexcept
+    {
+        if (this != &other) {
+            std::swap(m_fd, other.m_fd);
+            std::swap(m_stats, other.m_stats);
+        }
+        return *this;
+    }
+
+    Stats *getStats() noexcept
+    {
+        return m_stats;
+    }
+
+    const Stats *getStats() const noexcept
+    {
+        return m_stats;
+    }
+
+    int getFd() const noexcept
+    {
+        return m_fd.get();
+    }
+
+private:
+    FileDescriptor m_fd;
+    Stats         *m_stats;
+};
+
 class StatsServer {
 public:
     StatsServer();
     virtual ~StatsServer();
-    virtual Stats *getStats()
+    virtual Stats *getStats() noexcept
     {
-        return m_stats.get();
+        return m_stats.getStats();
     }
-
-    static void statsDeleter(Stats *s);
-    using UniqueStats = std::unique_ptr<Stats, decltype(&StatsServer::statsDeleter)>;
 
 private:
     void           threadFn();
-    FileDescriptor m_fd;
     FileDescriptor m_efd;
-    UniqueStats    m_stats;
+    StatsContainer m_stats;
     std::thread    m_thread;
 };
 

--- a/projects/hipfile/src/amd_detail/stats.h
+++ b/projects/hipfile/src/amd_detail/stats.h
@@ -155,34 +155,9 @@ private:
 
 using StatsV1 = StatsTemplate<PerGpuStatsV1, 16>;
 
-/// When adding new fields, remember to increment Stats::version
-enum class StatsCounters {
-    TotalFastPathReadBytes,
-    TotalFastPathWriteBytes,
-    TotalFallbackPathReadBytes,
-    TotalFallbackPathWriteBytes,
+using Stats = StatsV1;
 
-    Max,
-    Capacity = 64,
-};
-
-static_assert(StatsCounters::Max <= StatsCounters::Capacity, "Increase StatsCounters::Capacity");
-
-struct Stats {
-    using Array = std::array<std::atomic_uint64_t, static_cast<std::size_t>(StatsCounters::Capacity)>;
-    StatsLevel     level{};
-    const uint64_t version{1};
-    Array          counters;
-
-    std::atomic_uint64_t &getCounter(StatsCounters index)
-    {
-        return counters[static_cast<std::size_t>(index)];
-    }
-    const std::atomic_uint64_t &getCounter(StatsCounters index) const
-    {
-        return counters[static_cast<std::size_t>(index)];
-    }
-};
+static_assert(std::is_standard_layout_v<Stats>, "Stats must be standard layout");
 
 class StatsContainer {
 public:
@@ -257,7 +232,7 @@ public:
     bool connectServer() override;
     bool generateReport(std::ostream &stream) const override;
 
-    static void generateReportV1(std::ostream &stream, const Stats *stats);
+    static void generateReportV1(std::ostream &stream, const StatsV1 *stats);
 
 private:
     FileDescriptor m_pfd, m_sfd;

--- a/projects/hipfile/src/amd_detail/stats.h
+++ b/projects/hipfile/src/amd_detail/stats.h
@@ -8,6 +8,7 @@
 #include "io.h"
 
 #include <array>
+#include <algorithm>
 #include <atomic>
 #include <chrono>
 #include <functional>
@@ -16,6 +17,7 @@
 #include <ostream>
 #include <thread>
 #include <tuple>
+#include <type_traits>
 #include <utility>
 
 namespace hipFile {
@@ -95,6 +97,63 @@ struct PerGpuStatsV1 {
                                &ioCount[static_cast<size_t>(ioType)], &ioTimeUs[static_cast<size_t>(ioType)]};
     }
 };
+
+template <typename PerGpuStatsT, size_t gpus> class StatsTemplate {
+public:
+    static constexpr size_t MaxGpus{gpus};
+    using PerGpuStats      = PerGpuStatsT;
+    using PerBackendStats  = std::array<PerGpuStats, static_cast<size_t>(StatsBackend::Count)>;
+    using PerGpuStatsArray = std::array<PerBackendStats, MaxGpus>;
+
+    static_assert(std::is_standard_layout_v<PerGpuStats>, "PerGpuStats must be standard layout");
+
+    uint64_t getVersion() const noexcept
+    {
+        return m_version;
+    }
+
+    StatsLevel getLevel() const noexcept
+    {
+        return m_level;
+    }
+
+    void setLevel(StatsLevel level) noexcept
+    {
+        m_level = level;
+    }
+
+    PerGpuStats *getPerGpuStats(size_t gpuId, StatsBackend backend) noexcept
+    {
+        if (gpuId >= MaxGpus || static_cast<size_t>(backend) >= static_cast<size_t>(StatsBackend::Count)) {
+            return nullptr;
+        }
+        return &m_perGpuStats[gpuId][static_cast<size_t>(backend)];
+    }
+
+    const PerGpuStats *getPerGpuStats(size_t gpuId, StatsBackend backend) const noexcept
+    {
+        if (gpuId >= MaxGpus || static_cast<size_t>(backend) >= static_cast<size_t>(StatsBackend::Count)) {
+            return nullptr;
+        }
+        return &m_perGpuStats[gpuId][static_cast<size_t>(backend)];
+    }
+
+    bool gpuInUse(size_t gpuId) const noexcept
+    {
+        if (gpuId >= MaxGpus) {
+            return false;
+        }
+        return std::any_of(m_perGpuStats[gpuId].begin(), m_perGpuStats[gpuId].end(),
+                           [](const PerGpuStats &stats) { return stats.inUse.load() != 0; });
+    }
+
+private:
+    const uint64_t   m_version{PerGpuStatsT::version};
+    StatsLevel       m_level{};
+    PerGpuStatsArray m_perGpuStats{};
+};
+
+using StatsV1 = StatsTemplate<PerGpuStatsV1, 16>;
 
 /// When adding new fields, remember to increment Stats::version
 enum class StatsCounters {

--- a/projects/hipfile/src/amd_detail/stats.h
+++ b/projects/hipfile/src/amd_detail/stats.h
@@ -10,9 +10,12 @@
 #include <array>
 #include <atomic>
 #include <chrono>
+#include <functional>
 #include <memory>
+#include <numeric>
 #include <ostream>
 #include <thread>
+#include <utility>
 
 namespace hipFile {
 
@@ -27,6 +30,39 @@ enum class StatsBackend {
     Fastpath,
     Fallback,
     Count,
+};
+
+struct StatsHistogram {
+    static constexpr size_t   MaxBuckets{16};
+    static constexpr uint64_t FirstBucketBits{12};
+    using Buckets = std::array<std::atomic_uint64_t, MaxBuckets>;
+    Buckets buckets{};
+
+    static size_t toHistogramBucket(uint64_t bytes) noexcept
+    {
+        bytes >>= FirstBucketBits;
+        int idx{bytes == 0 ? 0 : 64 - __builtin_clzll(bytes)}; // log2(); clz(0) is UB
+        return std::min(static_cast<size_t>(idx), MaxBuckets - 1);
+    }
+
+    static constexpr std::pair<uint64_t, uint64_t> bucketRange(size_t bucket) noexcept
+    {
+        if (bucket == 0) {
+            return std::make_pair(uint64_t{0}, uint64_t{1} << FirstBucketBits);
+        }
+        else if (bucket < MaxBuckets - 1) {
+            uint64_t lower{uint64_t{1} << (bucket + FirstBucketBits - 1)};
+            return std::make_pair(lower, lower << 1);
+        }
+        else {
+            return std::make_pair(uint64_t{1} << (MaxBuckets + FirstBucketBits - 2), UINT64_MAX);
+        }
+    }
+
+    uint64_t accumulate() const noexcept
+    {
+        return std::accumulate(buckets.begin(), buckets.end(), uint64_t{0});
+    }
 };
 
 /// When adding new fields, remember to increment Stats::version

--- a/projects/hipfile/src/amd_detail/stats.h
+++ b/projects/hipfile/src/amd_detail/stats.h
@@ -15,6 +15,7 @@
 #include <numeric>
 #include <ostream>
 #include <thread>
+#include <tuple>
 #include <utility>
 
 namespace hipFile {
@@ -62,6 +63,36 @@ struct StatsHistogram {
     uint64_t accumulate() const noexcept
     {
         return std::accumulate(buckets.begin(), buckets.end(), uint64_t{0});
+    }
+};
+
+struct PerGpuStatsV1 {
+    static constexpr uint64_t     version{1};
+    std::atomic_uint64_t          inUse{};
+    std::array<StatsHistogram, 2> ioSizeBytes{};
+    std::array<StatsHistogram, 2> ioCount{};
+    std::array<StatsHistogram, 2> ioTimeUs{};
+
+    using Histograms = std::tuple<StatsHistogram *, StatsHistogram *, StatsHistogram *>;
+    using ConstHistograms =
+        std::tuple<const StatsHistogram *, const StatsHistogram *, const StatsHistogram *>;
+
+    Histograms getHistograms(IoType ioType) noexcept
+    {
+        if (ioType != IoType::Read && ioType != IoType::Write) {
+            return Histograms{nullptr, nullptr, nullptr};
+        }
+        return Histograms{&ioSizeBytes[static_cast<size_t>(ioType)], &ioCount[static_cast<size_t>(ioType)],
+                          &ioTimeUs[static_cast<size_t>(ioType)]};
+    }
+
+    ConstHistograms getHistograms(IoType ioType) const noexcept
+    {
+        if (ioType != IoType::Read && ioType != IoType::Write) {
+            return ConstHistograms{nullptr, nullptr, nullptr};
+        }
+        return ConstHistograms{&ioSizeBytes[static_cast<size_t>(ioType)],
+                               &ioCount[static_cast<size_t>(ioType)], &ioTimeUs[static_cast<size_t>(ioType)]};
     }
 };
 

--- a/projects/hipfile/src/amd_detail/stats.h
+++ b/projects/hipfile/src/amd_detail/stats.h
@@ -5,9 +5,11 @@
 #pragma once
 
 #include "file-descriptor.h"
+#include "io.h"
 
 #include <array>
 #include <atomic>
+#include <chrono>
 #include <memory>
 #include <ostream>
 #include <thread>
@@ -19,6 +21,12 @@ enum class StatsLevel : uint64_t {
     Basic,
     Detailed,
     Max,
+};
+
+enum class StatsBackend {
+    Fastpath,
+    Fallback,
+    Count,
 };
 
 /// When adding new fields, remember to increment Stats::version
@@ -49,11 +57,6 @@ struct Stats {
         return counters[static_cast<std::size_t>(index)];
     }
 };
-
-void statsAddFastPathRead(uint64_t bytes);
-void statsAddFastPathWrite(uint64_t bytes);
-void statsAddFallbackPathRead(uint64_t bytes);
-void statsAddFallbackPathWrite(uint64_t bytes);
 
 class StatsServer {
 public:
@@ -95,5 +98,25 @@ public:
 private:
     FileDescriptor m_pfd, m_sfd;
     pid_t          m_pid{0};
+};
+
+class StatsIoTracker {
+public:
+    StatsIoTracker(IoType ioType, StatsBackend backend) noexcept
+        : m_ioType(ioType), m_backend(backend), m_startTime{std::chrono::steady_clock::now()}
+    {
+    }
+    void complete(uint64_t bytes) const noexcept;
+
+private:
+    IoType                                m_ioType;
+    StatsBackend                          m_backend;
+    std::chrono::steady_clock::time_point m_startTime;
+};
+
+class StatsCollection {
+public:
+    virtual ~StatsCollection() = default;
+    virtual void addIo(IoType ioType, StatsBackend backend, uint64_t bytes, uint64_t timeUs) const noexcept;
 };
 }

--- a/projects/hipfile/test/amd_detail/configuration.cpp
+++ b/projects/hipfile/test/amd_detail/configuration.cpp
@@ -185,19 +185,19 @@ TEST_F(HipFileConfiguration, OverrideDisabledFallbackBackend)
 TEST_F(HipFileConfiguration, StatsLevelEnvironmentVariableIsNotSet)
 {
     expect_configuration_statslevel(nullptr);
-    ASSERT_EQ(0, Configuration().statsLevel());
+    ASSERT_EQ(1, Configuration().statsLevel());
 }
 
 TEST_F(HipFileConfiguration, StatsLevelEnvironmentVariableIsInvalid)
 {
     expect_configuration_statslevel("not-a-number");
-    ASSERT_EQ(0, Configuration().statsLevel());
+    ASSERT_EQ(1, Configuration().statsLevel());
 }
 
 TEST_F(HipFileConfiguration, StatsLevelEnvironmentVariableIsSet)
 {
-    expect_configuration_statslevel("1");
-    ASSERT_EQ(1, Configuration().statsLevel());
+    expect_configuration_statslevel("2");
+    ASSERT_EQ(2, Configuration().statsLevel());
 }
 
 TEST_F(HipFileConfiguration, UnsupportedFilesystemsDisabledIfEnvironmentVariableIsNotSet)

--- a/projects/hipfile/test/amd_detail/fallback.cpp
+++ b/projects/hipfile/test/amd_detail/fallback.cpp
@@ -18,6 +18,7 @@
 #include "mfile.h"
 #include "mhip.h"
 #include "mmountinfo.h"
+#include "mstats.h"
 #include "msys.h"
 #include "state.h"
 
@@ -113,10 +114,11 @@ struct FallbackIo : public HipFileOpened {
     std::vector<uint8_t> file_data{};
     void                *nonnull_ptr{reinterpret_cast<void *>(0x1)};
 
-    StrictMock<MHip>            mhip;
-    StrictMock<MSys>            msys;
-    StrictMock<MLibMountHelper> mlibmounthelper;
-    StrictMock<MConfiguration>  mcfg{};
+    StrictMock<MHip>             mhip;
+    StrictMock<MSys>             msys;
+    StrictMock<MLibMountHelper>  mlibmounthelper;
+    StrictMock<MConfiguration>   mcfg{};
+    StrictMock<MStatsCollection> mstats{};
 
     FallbackIo() : buffer_data(1024 * 1024)
     {
@@ -181,10 +183,11 @@ struct FallbackParam : ::testing::TestWithParam<IoType> {
     shared_ptr<IBuffer> buffer{};
     shared_ptr<IFile>   file{};
 
-    StrictMock<MHip>            mhip{};
-    StrictMock<MSys>            msys{};
-    StrictMock<MLibMountHelper> mlibmounthelper{};
-    StrictMock<MConfiguration>  mcfg{};
+    StrictMock<MHip>             mhip{};
+    StrictMock<MSys>             msys{};
+    StrictMock<MLibMountHelper>  mlibmounthelper{};
+    StrictMock<MConfiguration>   mcfg{};
+    StrictMock<MStatsCollection> mstats{};
 
     FallbackParam()
     {
@@ -264,6 +267,7 @@ TEST_P(FallbackParam, FallbackIoTruncatesSizeToMAX_RW_COUNT)
 
     EXPECT_CALL(mcfg, fallback()).WillOnce(Return(true));
     EXPECT_CALL(msys, mmap).WillOnce(testing::Return(reinterpret_cast<void *>(0xFEFEFEFE)));
+    EXPECT_CALL(mstats, addIo).Times(1);
     switch (io_type) {
         case IoType::Read:
             EXPECT_CALL(msys, pread)
@@ -305,6 +309,7 @@ TEST_P(FallbackParam, FallbackIoAllocatesChunkSizedHostBounceBuffer)
     EXPECT_CALL(mcfg, fallback()).WillOnce(Return(true));
     EXPECT_CALL(msys, mmap(testing::_, chunk_size, testing::_, testing::_, testing::_, testing::_))
         .WillOnce(testing::Return(ptr));
+    EXPECT_CALL(mstats, addIo).Times(1);
     switch (io_type) {
         case IoType::Read:
             EXPECT_CALL(msys, pread).WillOnce(testing::Return(0));
@@ -357,6 +362,7 @@ struct FallbackWrite : public FallbackIo {
         EXPECT_CALL(msys, pwrite).WillRepeatedly(testing::Invoke(this, &FallbackWrite::fake_pwrite));
         EXPECT_CALL(msys, munmap).WillOnce(testing::Invoke(::munmap));
         EXPECT_CALL(msys, fdatasync).Times(AnyNumber());
+        EXPECT_CALL(mstats, addIo).Times(1);
     }
 
     // Test if the file contains the correct data
@@ -551,6 +557,7 @@ struct FallbackRead : public FallbackIo {
         EXPECT_CALL(msys, pread).WillRepeatedly(testing::Invoke(this, &FallbackRead::fake_pread));
         EXPECT_CALL(mhip, hipMemcpy).WillRepeatedly(testing::Invoke(this, &FallbackRead::fake_hipMemcpy));
         EXPECT_CALL(msys, munmap).WillOnce(testing::Invoke(::munmap));
+        EXPECT_CALL(mstats, addIo).Times(1);
     }
 };
 
@@ -608,6 +615,7 @@ TEST_F(FallbackRead, FallbackReadHandlesEmptyFile)
     EXPECT_CALL(msys, mmap).WillOnce(testing::Invoke(::mmap));
     EXPECT_CALL(msys, pread).WillRepeatedly(testing::Invoke(this, &FallbackRead::fake_pread));
     EXPECT_CALL(msys, munmap).WillOnce(testing::Invoke(::munmap));
+    EXPECT_CALL(mstats, addIo).Times(1);
     ASSERT_EQ(file_length, Fallback().io(IoType::Read, file, buffer, buffer->getLength(), 0, 0));
     ASSERT_TRUE(device_buffer_contains_expected_data(0, 0, file_length));
 }
@@ -628,6 +636,7 @@ TEST_F(FallbackRead, FallbackReadHandlesShortPreads)
         }));
     EXPECT_CALL(mhip, hipMemcpy).WillRepeatedly(testing::Invoke(this, &FallbackRead::fake_hipMemcpy));
     EXPECT_CALL(msys, munmap).WillOnce(testing::Invoke(::munmap));
+    EXPECT_CALL(mstats, addIo).Times(1);
     ASSERT_EQ(file_length, Fallback().io(IoType::Read, file, buffer, buffer->getLength(), 0, 0));
     ASSERT_TRUE(device_buffer_contains_expected_data(0, 0, file_length));
 }
@@ -646,6 +655,7 @@ TEST_F(FallbackRead, FallbackReadHandlesInterruptedPread)
         }));
     EXPECT_CALL(mhip, hipMemcpy).WillRepeatedly(testing::Invoke(this, &FallbackRead::fake_hipMemcpy));
     EXPECT_CALL(msys, munmap).WillOnce(testing::Invoke(::munmap));
+    EXPECT_CALL(mstats, addIo).Times(1);
     ASSERT_EQ(file_length, Fallback().io(IoType::Read, file, buffer, buffer->getLength(), 0, 0));
     ASSERT_TRUE(device_buffer_contains_expected_data(0, 0, file_length));
 }

--- a/projects/hipfile/test/amd_detail/fastpath.cpp
+++ b/projects/hipfile/test/amd_detail/fastpath.cpp
@@ -15,6 +15,7 @@
 #include "mbackend.h"
 #include "mfile.h"
 #include "mhip.h"
+#include "mstats.h"
 #include "msys.h"
 
 #include <array>
@@ -454,7 +455,8 @@ INSTANTIATE_TEST_SUITE_P(FastpathTest, FastpathUnalignedBufferOffsetsParam,
 
 struct FastpathIoParam : public FastpathTestBase, public TestWithParam<IoType> {
 
-    StrictMock<MHip> mhip;
+    StrictMock<MHip>             mhip;
+    StrictMock<MStatsCollection> mstats;
 
     // Setup expectations on the mocks called to validate IO arguments
     void expect_validate()
@@ -537,6 +539,7 @@ TEST_P(FastpathIoParam, IoConfiguresHandle)
     handle.fd = DEFAULT_UNBUFFERED_FD.value();
 
     expect_io();
+    EXPECT_CALL(mstats, addIo).Times(1);
     switch (GetParam()) {
         case IoType::Read:
             EXPECT_CALL(mhip, hipAmdFileRead(Eq(handle), _, _, _));
@@ -558,6 +561,7 @@ TEST_P(FastpathIoParam, IoCalculatesCorrectDevicePointer)
     void *expected_device_ptr{reinterpret_cast<void *>(0x21000)};
 
     expect_io(DEFAULT_UNBUFFERED_FD, buffer_addr, static_cast<size_t>(buffer_offset) + DEFAULT_IO_SIZE);
+    EXPECT_CALL(mstats, addIo).Times(1);
     switch (GetParam()) {
         case IoType::Read:
             EXPECT_CALL(mhip, hipAmdFileRead(_, expected_device_ptr, _, _));
@@ -575,6 +579,7 @@ TEST_P(FastpathIoParam, IoCalculatesCorrectDevicePointer)
 TEST_P(FastpathIoParam, IoPassesThroughSizeAndFileOffset)
 {
     expect_io();
+    EXPECT_CALL(mstats, addIo).Times(1);
     switch (GetParam()) {
         case IoType::Read:
             EXPECT_CALL(mhip, hipAmdFileRead(_, _, Eq(DEFAULT_IO_SIZE), Eq(DEFAULT_FILE_OFFSET)));
@@ -592,6 +597,7 @@ TEST_P(FastpathIoParam, IoPassesThroughSizeAndFileOffset)
 TEST_P(FastpathIoParam, IoReturnsBytesTransferred)
 {
     expect_io();
+    EXPECT_CALL(mstats, addIo).Times(1);
     switch (GetParam()) {
         case IoType::Read:
             EXPECT_CALL(mhip, hipAmdFileRead(_, _, _, _)).WillOnce(Return(DEFAULT_IO_SIZE));
@@ -615,6 +621,7 @@ TEST_P(FastpathIoParam, IoReturnsBytesTransferredShort)
     ASSERT_LT(nbytes, DEFAULT_IO_SIZE);
 
     expect_io();
+    EXPECT_CALL(mstats, addIo).Times(1);
     switch (GetParam()) {
         case IoType::Read:
             EXPECT_CALL(mhip, hipAmdFileRead(_, _, _, _)).WillOnce(Return(nbytes));
@@ -678,6 +685,7 @@ TEST_P(FastpathIoParam, IoSizeIsTruncatedToMaxRWCount)
     const size_t io_size{SIZE_MAX};
 
     expect_io(DEFAULT_UNBUFFERED_FD, reinterpret_cast<void *>(DEFAULT_BUFFER_ADDR), buffer_size);
+    EXPECT_CALL(mstats, addIo).Times(1);
     switch (GetParam()) {
         case IoType::Read:
             EXPECT_CALL(mhip, hipAmdFileRead(_, _, getMaxRwCount(), _)).WillOnce(Return(getMaxRwCount()));

--- a/projects/hipfile/test/amd_detail/mhip.h
+++ b/projects/hipfile/test/amd_detail/mhip.h
@@ -49,5 +49,7 @@ struct MHip : Hip {
     MOCK_METHOD(int, hipDeviceGetAttribute, (hipDeviceAttribute_t attr, int device_id), (const, override));
     MOCK_METHOD(hipDevice_t, hipStreamGetDevice, (hipStream_t stream), (const, override));
     MOCK_METHOD(void, hipInit, (), (const, override));
+    MOCK_METHOD(int, hipGetDevice, (), (const, override));
+    MOCK_METHOD(int, hipGetDeviceCount, (), (const, override));
 };
 }

--- a/projects/hipfile/test/amd_detail/mstats.h
+++ b/projects/hipfile/test/amd_detail/mstats.h
@@ -18,7 +18,7 @@ public:
     MStatsServer() : co{this}
     {
     }
-    MOCK_METHOD(Stats *, getStats, (), (override));
+    MOCK_METHOD(Stats *, getStats, (), (noexcept, override));
 };
 
 class MStatsCollection : public StatsCollection {

--- a/projects/hipfile/test/amd_detail/mstats.h
+++ b/projects/hipfile/test/amd_detail/mstats.h
@@ -20,4 +20,15 @@ public:
     }
     MOCK_METHOD(Stats *, getStats, (), (override));
 };
+
+class MStatsCollection : public StatsCollection {
+    ContextOverride<StatsCollection> co;
+
+public:
+    MStatsCollection() : co{this}
+    {
+    }
+    MOCK_METHOD(void, addIo, (IoType ioType, StatsBackend backend, uint64_t bytes, uint64_t timeUs),
+                (const, noexcept, override));
+};
 }

--- a/projects/hipfile/test/amd_detail/stats.cpp
+++ b/projects/hipfile/test/amd_detail/stats.cpp
@@ -131,4 +131,13 @@ TEST_F(HipFileStatsPerGpuStatsV1, GetHistograms)
     ASSERT_EQ(nullptr, invalidTime);
 }
 
+struct HipFileStatsV1 : public HipFileUnopened {};
+
+TEST_F(HipFileStatsV1, getPerGpuStats)
+{
+    StatsV1 stats{};
+    ASSERT_EQ(nullptr, stats.getPerGpuStats(StatsV1::MaxGpus, StatsBackend::Fastpath));
+    ASSERT_EQ(nullptr, stats.getPerGpuStats(0, static_cast<StatsBackend>(-1)));
+}
+
 HIPFILE_WARN_NO_GLOBAL_CTOR_ON

--- a/projects/hipfile/test/amd_detail/stats.cpp
+++ b/projects/hipfile/test/amd_detail/stats.cpp
@@ -40,20 +40,21 @@ TEST_F(HipFileStats, StatsCollectionAddIo)
     ASSERT_EQ(10, stats.getCounter(StatsCounters::TotalFallbackPathWriteBytes).load());
 }
 
-TEST_F(HipFileStats, StatsServerLifetime)
+TEST_F(HipFileStats, StatsContainer)
 {
     StrictMock<MSys>           msys{};
     StrictMock<MConfiguration> mcfg{};
-    char                       buff[sizeof(Stats)];
+    alignas(Stats) char        buff[sizeof(Stats)];
     EXPECT_CALL(msys, memfd_create).WillOnce(testing::Return(10));
-    EXPECT_CALL(msys, eventfd).WillOnce(testing::Return(11));
     EXPECT_CALL(msys, fcntl).WillOnce(testing::Return(0));
     EXPECT_CALL(msys, ftruncate);
     EXPECT_CALL(msys, mmap).WillOnce(testing::Return(&buff));
-    EXPECT_CALL(msys, munmap);
-    EXPECT_CALL(msys, close).Times(3);
+    EXPECT_CALL(msys, munmap).Times(1);
+    EXPECT_CALL(msys, close).Times(1);
     EXPECT_CALL(mcfg, statsLevel()).WillOnce(testing::Return(1));
-    StatsServer srvr{};
+    StatsContainer sc{};
+    ASSERT_EQ(reinterpret_cast<Stats *>(&buff), sc.getStats());
+    ASSERT_EQ(10, sc.getFd());
 }
 
 TEST_F(HipFileStats, GenerateReportV1)

--- a/projects/hipfile/test/amd_detail/stats.cpp
+++ b/projects/hipfile/test/amd_detail/stats.cpp
@@ -23,26 +23,22 @@ HIPFILE_WARN_NO_GLOBAL_CTOR_OFF
 
 struct HipFileStats : public HipFileUnopened {};
 
-#define STAT_TEST(name)                                                                                      \
-    TEST_F(HipFileStats, statsAdd##name)                                                                     \
-    {                                                                                                        \
-        Stats                    stats{};                                                                    \
-        StrictMock<MStatsServer> mstats{};                                                                   \
-        EXPECT_CALL(mstats, getStats).WillRepeatedly(testing::Return(&stats));                               \
-        stats.level = StatsLevel::Basic;                                                                     \
-        statsAdd##name(0x10);                                                                                \
-        ASSERT_EQ(0x10, stats.getCounter(StatsCounters::Total##name##Bytes).load());                         \
-        statsAdd##name(0x10);                                                                                \
-        ASSERT_EQ(0x20, stats.getCounter(StatsCounters::Total##name##Bytes).load());                         \
-        stats.level = StatsLevel::Disabled;                                                                  \
-        statsAdd##name(0x10);                                                                                \
-        ASSERT_EQ(0x20, stats.getCounter(StatsCounters::Total##name##Bytes).load());                         \
-    }
-
-STAT_TEST(FastPathRead)
-STAT_TEST(FastPathWrite)
-STAT_TEST(FallbackPathRead)
-STAT_TEST(FallbackPathWrite)
+TEST_F(HipFileStats, StatsCollectionAddIo)
+{
+    Stats                    stats{};
+    StrictMock<MStatsServer> mstats{};
+    EXPECT_CALL(mstats, getStats).WillRepeatedly(testing::Return(&stats));
+    stats.level = StatsLevel::Basic;
+    Context<StatsCollection>::get()->addIo(IoType::Read, StatsBackend::Fastpath, 10, 0);
+    ASSERT_EQ(10, stats.getCounter(StatsCounters::TotalFastPathReadBytes).load());
+    Context<StatsCollection>::get()->addIo(IoType::Write, StatsBackend::Fallback, 10, 0);
+    ASSERT_EQ(10, stats.getCounter(StatsCounters::TotalFallbackPathWriteBytes).load());
+    Context<StatsCollection>::get()->addIo(IoType::Read, StatsBackend::Fastpath, 10, 0);
+    ASSERT_EQ(20, stats.getCounter(StatsCounters::TotalFastPathReadBytes).load());
+    stats.level = StatsLevel::Disabled;
+    Context<StatsCollection>::get()->addIo(IoType::Write, StatsBackend::Fallback, 10, 0);
+    ASSERT_EQ(10, stats.getCounter(StatsCounters::TotalFallbackPathWriteBytes).load());
+}
 
 TEST_F(HipFileStats, StatsServerLifetime)
 {

--- a/projects/hipfile/test/amd_detail/stats.cpp
+++ b/projects/hipfile/test/amd_detail/stats.cpp
@@ -5,6 +5,7 @@
 
 #include "hipfile-test.h"
 #include "mconfiguration.h"
+#include "mhip.h"
 #include "mstats.h"
 #include "stats.h"
 #include "msys.h"
@@ -27,17 +28,31 @@ TEST_F(HipFileStats, StatsCollectionAddIo)
 {
     Stats                    stats{};
     StrictMock<MStatsServer> mstats{};
+    StrictMock<MHip>         mhip{};
     EXPECT_CALL(mstats, getStats).WillRepeatedly(testing::Return(&stats));
-    stats.level = StatsLevel::Basic;
+    EXPECT_CALL(mhip, hipGetDevice).WillRepeatedly(testing::Return(0));
+    stats.setLevel(StatsLevel::Basic);
     Context<StatsCollection>::get()->addIo(IoType::Read, StatsBackend::Fastpath, 10, 0);
-    ASSERT_EQ(10, stats.getCounter(StatsCounters::TotalFastPathReadBytes).load());
+    ASSERT_EQ(10, stats.getPerGpuStats(0, StatsBackend::Fastpath)
+                      ->ioSizeBytes[static_cast<size_t>(IoType::Read)]
+                      .buckets[0]
+                      .load());
     Context<StatsCollection>::get()->addIo(IoType::Write, StatsBackend::Fallback, 10, 0);
-    ASSERT_EQ(10, stats.getCounter(StatsCounters::TotalFallbackPathWriteBytes).load());
+    ASSERT_EQ(10, stats.getPerGpuStats(0, StatsBackend::Fallback)
+                      ->ioSizeBytes[static_cast<size_t>(IoType::Write)]
+                      .buckets[0]
+                      .load());
     Context<StatsCollection>::get()->addIo(IoType::Read, StatsBackend::Fastpath, 10, 0);
-    ASSERT_EQ(20, stats.getCounter(StatsCounters::TotalFastPathReadBytes).load());
-    stats.level = StatsLevel::Disabled;
+    ASSERT_EQ(20, stats.getPerGpuStats(0, StatsBackend::Fastpath)
+                      ->ioSizeBytes[static_cast<size_t>(IoType::Read)]
+                      .buckets[0]
+                      .load());
+    stats.setLevel(StatsLevel::Disabled);
     Context<StatsCollection>::get()->addIo(IoType::Write, StatsBackend::Fallback, 10, 0);
-    ASSERT_EQ(10, stats.getCounter(StatsCounters::TotalFallbackPathWriteBytes).load());
+    ASSERT_EQ(10, stats.getPerGpuStats(0, StatsBackend::Fallback)
+                      ->ioSizeBytes[static_cast<size_t>(IoType::Write)]
+                      .buckets[0]
+                      .load());
 }
 
 TEST_F(HipFileStats, StatsContainer)
@@ -61,16 +76,39 @@ TEST_F(HipFileStats, GenerateReportV1)
 {
     Stats              stats{};
     std::ostringstream os{};
-    stats.getCounter(StatsCounters::TotalFastPathReadBytes)      = 2;
-    stats.getCounter(StatsCounters::TotalFastPathWriteBytes)     = 4;
-    stats.getCounter(StatsCounters::TotalFallbackPathReadBytes)  = 6;
-    stats.getCounter(StatsCounters::TotalFallbackPathWriteBytes) = 8;
+    stats.getPerGpuStats(0, StatsBackend::Fastpath)
+        ->ioSizeBytes[static_cast<size_t>(IoType::Read)]
+        .buckets[0] = 2;
+    stats.getPerGpuStats(0, StatsBackend::Fastpath)
+        ->ioSizeBytes[static_cast<size_t>(IoType::Write)]
+        .buckets[0] = 4;
+    stats.getPerGpuStats(0, StatsBackend::Fallback)
+        ->ioSizeBytes[static_cast<size_t>(IoType::Read)]
+        .buckets[0] = 6;
+    stats.getPerGpuStats(0, StatsBackend::Fallback)
+        ->ioSizeBytes[static_cast<size_t>(IoType::Write)]
+        .buckets[0] = 8;
     StatsClient::generateReportV1(os, &stats);
     std::string str{os.str()};
-    ASSERT_GT(std::string::npos, str.find('2'));
-    ASSERT_GT(std::string::npos, str.find('4'));
-    ASSERT_GT(std::string::npos, str.find('6'));
-    ASSERT_GT(std::string::npos, str.find('8'));
+    ASSERT_GT(std::string::npos, str.find("Total Fastpath Read Size (B): 2"));
+    ASSERT_GT(std::string::npos, str.find("Total Fastpath Write Size (B): 4"));
+    ASSERT_GT(std::string::npos, str.find("Total Fallback Read Size (B): 6"));
+    ASSERT_GT(std::string::npos, str.find("Total Fallback Write Size (B): 8"));
+}
+
+TEST_F(HipFileStats, GenerateReportV1TwoGpus)
+{
+    Stats              stats{};
+    std::ostringstream os{};
+    stats.getPerGpuStats(0, StatsBackend::Fastpath)
+        ->ioSizeBytes[static_cast<size_t>(IoType::Read)]
+        .buckets[0] = 2;
+    stats.getPerGpuStats(1, StatsBackend::Fastpath)
+        ->ioSizeBytes[static_cast<size_t>(IoType::Read)]
+        .buckets[0] = 4;
+    StatsClient::generateReportV1(os, &stats);
+    std::string str{os.str()};
+    ASSERT_GT(std::string::npos, str.find("Total Fastpath Read Size (B): 6"));
 }
 
 struct HipFileStatsHistogram : public HipFileUnopened {};

--- a/projects/hipfile/test/amd_detail/stats.cpp
+++ b/projects/hipfile/test/amd_detail/stats.cpp
@@ -112,4 +112,23 @@ TEST_F(HipFileStatsHistogram, BucketRange)
     ASSERT_EQ(UINT64_MAX, upper15);
 }
 
+struct HipFileStatsPerGpuStatsV1 : public HipFileUnopened {};
+
+TEST_F(HipFileStatsPerGpuStatsV1, GetHistograms)
+{
+    PerGpuStatsV1 stats{};
+    auto [readSize, readCount, readTime]          = stats.getHistograms(IoType::Read);
+    auto [writeSize, writeCount, writeTime]       = stats.getHistograms(IoType::Write);
+    auto [invalidSize, invalidCount, invalidTime] = stats.getHistograms(static_cast<IoType>(-1));
+    ASSERT_EQ(&stats.ioSizeBytes[0], readSize);
+    ASSERT_EQ(&stats.ioCount[0], readCount);
+    ASSERT_EQ(&stats.ioTimeUs[0], readTime);
+    ASSERT_EQ(&stats.ioSizeBytes[1], writeSize);
+    ASSERT_EQ(&stats.ioCount[1], writeCount);
+    ASSERT_EQ(&stats.ioTimeUs[1], writeTime);
+    ASSERT_EQ(nullptr, invalidSize);
+    ASSERT_EQ(nullptr, invalidCount);
+    ASSERT_EQ(nullptr, invalidTime);
+}
+
 HIPFILE_WARN_NO_GLOBAL_CTOR_ON

--- a/projects/hipfile/test/amd_detail/stats.cpp
+++ b/projects/hipfile/test/amd_detail/stats.cpp
@@ -73,4 +73,43 @@ TEST_F(HipFileStats, GenerateReportV1)
     ASSERT_GT(std::string::npos, str.find('8'));
 }
 
+struct HipFileStatsHistogram : public HipFileUnopened {};
+
+TEST_F(HipFileStatsHistogram, ToHistogramBucket)
+{
+    ASSERT_EQ(0, StatsHistogram::toHistogramBucket(0));
+    ASSERT_EQ(0, StatsHistogram::toHistogramBucket(1));
+    ASSERT_EQ(0, StatsHistogram::toHistogramBucket(4095));
+    ASSERT_EQ(1, StatsHistogram::toHistogramBucket(4096));
+    ASSERT_EQ(1, StatsHistogram::toHistogramBucket(8191));
+    ASSERT_EQ(2, StatsHistogram::toHistogramBucket(8192));
+    ASSERT_EQ(2, StatsHistogram::toHistogramBucket(16383));
+    ASSERT_EQ(3, StatsHistogram::toHistogramBucket(16384));
+    ASSERT_EQ(14, StatsHistogram::toHistogramBucket(uint64_t{1} << 25));
+    ASSERT_EQ(15, StatsHistogram::toHistogramBucket(uint64_t{1} << 30));
+    ASSERT_EQ(15, StatsHistogram::toHistogramBucket(uint64_t{1} << 40));
+}
+
+TEST_F(HipFileStatsHistogram, BucketRange)
+{
+    auto [lower0, upper0] = StatsHistogram::bucketRange(0);
+    ASSERT_EQ(0, lower0);
+    ASSERT_EQ(4096, upper0);
+    auto [lower1, upper1] = StatsHistogram::bucketRange(1);
+    ASSERT_EQ(4096, lower1);
+    ASSERT_EQ(8192, upper1);
+    auto [lower2, upper2] = StatsHistogram::bucketRange(2);
+    ASSERT_EQ(8192, lower2);
+    ASSERT_EQ(16384, upper2);
+    auto [lower3, upper3] = StatsHistogram::bucketRange(3);
+    ASSERT_EQ(16384, lower3);
+    ASSERT_EQ(32768, upper3);
+    auto [lower14, upper14] = StatsHistogram::bucketRange(14);
+    ASSERT_EQ(uint64_t{1} << 25, lower14);
+    ASSERT_EQ(uint64_t{1} << 26, upper14);
+    auto [lower15, upper15] = StatsHistogram::bucketRange(15);
+    ASSERT_EQ(uint64_t{1} << 26, lower15);
+    ASSERT_EQ(UINT64_MAX, upper15);
+}
+
 HIPFILE_WARN_NO_GLOBAL_CTOR_ON


### PR DESCRIPTION
[AIHIPFILE-159]
HipFile stats stores counters in a series of buckets broken up by backend, IO operation, and IO size. This lets ais-stats show histograms for different IO sizes. Also enables stats collection by default.

[AIHIPFILE-159]: https://amd-hub.atlassian.net/browse/AIHIPFILE-159?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ