### PR TITLE
[ATT] Fix multiple agents sharing same dispatch ID

### DIFF
--- a/projects/rocprofiler-sdk/source/lib/output/metadata.cpp
+++ b/projects/rocprofiler-sdk/source/lib/output/metadata.cpp
@@ -384,9 +384,9 @@ std::vector<std::string>
 metadata::get_att_filenames() const
 {
     auto data = std::vector<std::string>{};
-    for(const auto& filenames : att_filenames)
+    for(const auto& [key, files] : att_filenames)
     {
-        for(const auto& file : filenames.second.second)
+        for(const auto& file : files)
         {
             data.emplace_back(fs::path{file}.filename());
         }

--- a/projects/rocprofiler-sdk/source/lib/output/metadata.hpp
+++ b/projects/rocprofiler-sdk/source/lib/output/metadata.hpp
@@ -98,10 +98,11 @@ using marker_message_ordered_map_t = std::map<uint64_t, std::string>;
 using string_entry_map_t           = std::unordered_map<size_t, std::unique_ptr<std::string>>;
 using counter_dimension_vec_t      = std::vector<rocprofiler_counter_record_dimension_info_t>;
 using external_corr_id_set_t       = std::unordered_set<uint64_t>;
-using code_obj_decoder_t    = rocprofiler::sdk::codeobj::disassembly::CodeobjAddressTranslate;
-using instruction_t         = rocprofiler::sdk::codeobj::disassembly::Instruction;
-using att_agent_filenames_t = std::pair<rocprofiler_agent_id_t, std::vector<std::string>>;
-using att_filenames_map_t   = std::unordered_map<rocprofiler_dispatch_id_t, att_agent_filenames_t>;
+using code_obj_decoder_t = rocprofiler::sdk::codeobj::disassembly::CodeobjAddressTranslate;
+using instruction_t      = rocprofiler::sdk::codeobj::disassembly::Instruction;
+using att_dispatch_agent_key_t =
+    std::pair<rocprofiler_dispatch_id_t, uint64_t>;  // (dispatch_id, agent_handle)
+using att_filenames_map_t         = std::map<att_dispatch_agent_key_t, std::vector<std::string>>;
 using code_object_load_info_vec_t = std::vector<rocprofiler::att_wrapper::CodeobjLoadInfo>;
 template <typename Tp>
 using synced_map = common::Synchronized<Tp, true>;

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-tool/tool.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-tool/tool.cpp
@@ -1618,8 +1618,8 @@ att_shader_data_callback(rocprofiler_agent_id_t  agent,
     std::string output_filename = get_output_filename(tool::get_config(), filename.str(), ".att");
 
     output_stream.stream->write(reinterpret_cast<char*>(se_data), data_size);
-    tool_metadata->att_filenames[dispatch_id].first = agent;
-    tool_metadata->att_filenames[dispatch_id].second.emplace_back(output_filename);
+    auto key = tool::att_dispatch_agent_key_t{dispatch_id, agent.handle};
+    tool_metadata->att_filenames[key].emplace_back(output_filename);
 }
 
 rocprofiler_thread_trace_control_flags_t
@@ -3086,18 +3086,18 @@ generate_output(cleanup_mode _cleanup_mode)
             perf.emplace_back(ss.str());
         }
 
-        for(auto& [dispatch_id, att_filename_data] : tool_metadata->att_filenames)
+        for(auto& [key, att_files] : tool_metadata->att_filenames)
         {
-            std::string formats = "json,csv";
+            auto [dispatch_id, agent_handle] = key;
+            std::string formats              = "json,csv";
 
             auto ui_name = std::stringstream{};
-            ui_name << fmt::format("ui_output_agent_{}_dispatch_{}",
-                                   std::to_string(att_filename_data.first.handle),
-                                   dispatch_id);
+            ui_name << fmt::format(
+                "ui_output_agent_{}_dispatch_{}", std::to_string(agent_handle), dispatch_id);
             auto out_path = fmt::format("{}/{}", output_path, ui_name.str());
             auto in_path  = std::string(".");
 
-            decoder.parse(in_path, out_path, att_filename_data.second, codeobj, perf, formats);
+            decoder.parse(in_path, out_path, att_files, codeobj, perf, formats);
         }
     }
 

--- a/projects/rocprofiler-sdk/tests/rocprofv3/advanced-thread-trace/CMakeLists.txt
+++ b/projects/rocprofiler-sdk/tests/rocprofv3/advanced-thread-trace/CMakeLists.txt
@@ -248,15 +248,32 @@ rocprofiler_add_integration_execute_test(
     LABELS "integration-tests;thread-trace;pc-sampling"
     DISABLED ${ATT_PLUS_PCS_DISABLE})
 
-# Trace two GPUs
 rocprofiler_add_integration_execute_test(
     rocprofv3-test-att-gpu-index-two-gpus
-    COMMAND $<TARGET_FILE:rocprofiler-sdk::rocprofv3> ${COMMON_PARAMS}/cmd_input -o out
-            --att-gpu-index 0,1 -- $<TARGET_FILE:vector-ops>
+    COMMAND
+        $<TARGET_FILE:rocprofiler-sdk::rocprofv3> -d att-multi-gpu --att --att-gpu-index
+        0,1 --att-consecutive-kernels 1 --kernel-trace --output-format csv --
+        $<TARGET_FILE:vector-ops>
     DEPENDS vector-ops
     TIMEOUT 45
     LABELS "integration-tests"
-    DISABLED ${IS_DISABLED})
+    DISABLED ${ROCPROFILER_DISABLE_UNSTABLE_CTESTS}
+    ENVIRONMENT "ROCPROF_ATT_LIBRARY_PATH=${attdecoder_LIB_DIR}"
+    FAIL_REGULAR_EXPRESSION "${ROCPROFILER_DEFAULT_FAIL_REGEX}"
+    FIXTURES_SETUP rocprofv3-test-att-gpu-index-two-gpus)
+
+rocprofiler_add_integration_validate_test(
+    rocprofv3-test-att-gpu-index-two-gpus
+    TEST_PATHS validate.py
+    COPY conftest.py
+    CONFIG pytest.ini
+    DISCOVERY_ARGS -k test_multi_gpu_separate_agents
+    TIMEOUT 45
+    LABELS "integration-tests"
+    DISABLED ${ROCPROFILER_DISABLE_UNSTABLE_CTESTS}
+    FIXTURES_REQUIRED rocprofv3-test-att-gpu-index-two-gpus
+    ARGS --att-multi-gpu-out-dir ${CMAKE_CURRENT_BINARY_DIR}/att-multi-gpu
+    FAIL_REGULAR_EXPRESSION "AssertionError")
 
 # No machine has gpu index = 9999 The FAIL regex for this test is the ROCP_ERROR specific
 # to invalid device index

--- a/projects/rocprofiler-sdk/tests/rocprofv3/advanced-thread-trace/conftest.py
+++ b/projects/rocprofiler-sdk/tests/rocprofv3/advanced-thread-trace/conftest.py
@@ -66,6 +66,11 @@ def pytest_addoption(parser):
         action="store",
         help="Path to Output directory.",
     )
+    parser.addoption(
+        "--att-multi-gpu-out-dir",
+        action="store",
+        help="Path to multi-GPU ATT output directory.",
+    )
 
 
 @pytest.fixture
@@ -111,4 +116,12 @@ def att_shaderdata_out_dir_path(request):
     output_dir_path = request.config.getoption("--att-shaderdata-out-dir")
     if not output_dir_path:
         pytest.skip("--att-shaderdata-out-dir not provided")
+    return output_dir_path
+
+
+@pytest.fixture
+def att_multi_gpu_out_dir_path(request):
+    output_dir_path = request.config.getoption("--att-multi-gpu-out-dir")
+    if not output_dir_path:
+        pytest.skip("--att-multi-gpu-out-dir not provided")
     return output_dir_path

--- a/projects/rocprofiler-sdk/tests/rocprofv3/advanced-thread-trace/validate.py
+++ b/projects/rocprofiler-sdk/tests/rocprofv3/advanced-thread-trace/validate.py
@@ -22,6 +22,7 @@
 # SOFTWARE.
 
 
+import csv
 import sys
 import pytest
 import re
@@ -384,6 +385,83 @@ def test_shaderdata(att_shaderdata_out_dir_path):
 
     # Require at least one ui_output_agent_* directory with shaderdata data.
     assert found_shaderdata, "No ui_output_agent_* directory contains shaderdata data."
+
+
+def test_multi_gpu_separate_agents(att_multi_gpu_out_dir_path):
+    """
+    When multiple GPUs are traced for the same dispatch, each agent must get
+    its own ui_output_agent_* directory.  Before the fix, all agents' ATT data
+    was merged into a single directory, causing shaderdata timestamp resets
+    (each GPU has its own independent SQTT counter) and silently dropping
+    occupancy data from all but the first agent.
+    """
+
+    out_dir = Path(att_multi_gpu_out_dir_path)
+
+    # Use agent_info.csv to determine how many GPUs are on this machine.
+    # The file is inside a hostname subdirectory: <out_dir>/<hostname>/<pid>_agent_info.csv
+    agent_csvs = list(out_dir.glob("**/*_agent_info.csv"))
+    assert agent_csvs, (
+        f"No *_agent_info.csv found under {out_dir}. "
+        f"Ensure the execute test runs with --output-format csv."
+    )
+    with open(agent_csvs[0], "r") as f:
+        gpu_count = sum(1 for row in csv.DictReader(f) if row["Agent_Type"] == "GPU")
+    if gpu_count < 2:
+        pytest.skip(f"Only {gpu_count} GPU(s) on this machine, need >= 2")
+
+    ui_dirs = sorted(p for p in out_dir.glob("ui_output_agent_*") if p.is_dir())
+
+    # With --att-gpu-index 0,1 we expect at least two output directories
+    # (one per agent).
+    assert len(ui_dirs) >= 2, (
+        f"Expected at least 2 ui_output_agent_* directories (one per GPU), "
+        f"found {len(ui_dirs)}.  ATT data from multiple agents may be merged."
+    )
+
+    # Extract agent ids from directory names and verify they are distinct.
+    agent_ids = set()
+    pattern = re.compile(r"ui_output_agent_(\d+)_dispatch_(\d+)")
+    for d in ui_dirs:
+        m = pattern.search(d.name)
+        assert m, f"Unexpected directory name format: {d.name}"
+        agent_ids.add(m.group(1))
+
+    assert len(agent_ids) >= 2, (
+        f"Expected directories for at least 2 distinct agents, "
+        f"found agent ids: {agent_ids}"
+    )
+
+    # For each directory that has shaderdata, verify timestamps are
+    # monotonically increasing across all chunks (no resets from other GPUs).
+    for ui_dir in ui_dirs:
+        filenames_path = ui_dir / "filenames.json"
+        if not filenames_path.exists():
+            continue
+
+        with open(filenames_path, "r") as f:
+            filenames_json = json.load(f)
+
+        shaderdata_filenames = filenames_json.get("shaderdata_filenames", {})
+        if not shaderdata_filenames:
+            continue
+
+        for se, files in shaderdata_filenames.items():
+            prev_end_time = -1
+            for file_entry in files:
+                begin_time = file_entry[1]
+                end_time = file_entry[2]
+
+                # Each chunk's begin_time must be >= the previous chunk's
+                # end_time.  A reset (begin < prev_end) indicates data from a
+                # different GPU was mixed in.
+                assert begin_time >= prev_end_time, (
+                    f"Shaderdata timestamp reset in {ui_dir.name} SE {se}: "
+                    f"chunk {file_entry[0]} begins at {begin_time} but "
+                    f"previous chunk ended at {prev_end_time}.  "
+                    f"Data from multiple agents may be merged."
+                )
+                prev_end_time = end_time
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Motivation

When using --att-consecutive-kernels on multigpu systems, all GPUs will share a single ui_ directory. This PR fixes this issue and adds a test to ensure this doesn't happen.

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan

Added a test to ensure the fix stays. Marked unstable because it requires more than one GPU to function and CI exports ROCR_VISIBLE_DEVICES.

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
