### PR TITLE
[rocprofiler-compute][tui] update tui yamls

### DIFF
--- a/projects/rocprofiler-compute/src/rocprof_compute_tui/utils/gfx942/3200_gpu_speed_of_light.yaml
+++ b/projects/rocprofiler-compute/src/rocprof_compute_tui/utils/gfx942/3200_gpu_speed_of_light.yaml
@@ -4,35 +4,46 @@ Panel Config:
   id: 3200
   title: GPU Speed-of-Light
   metrics_description:
-    Theoretical LDS Bandwidth: Indicates the maximum amount of bytes that could have
-      been loaded from, stored to, or atomically updated in the LDS per unit time
-      (see LDS Bandwidth example for more detail). This is also presented as a percent
-      of the peak theoretical F64 MFMA operations achievable on the specific accelerator.
-    vL1D Cache BW: The number of bytes looked up in the vL1D cache as a result of
-      VMEM instructions per unit time. The number of bytes is calculated as the number
-      of cache lines requested multiplied by the cache line size. This value does
-      not consider partial requests, so e.g., if only a single value is requested
-      in a cache line, the data movement will still be counted as a full cache line.
-      This is also presented as a percent of the peak theoretical bandwidth achievable
-      on the specific accelerator.
-    L2 Cache BW: The number of bytes looked up in the L2 cache per unit time. The
-      number of bytes is calculated as the number of cache lines requested multiplied
-      by the cache line size. This value does not consider partial requests, so e.g.,
-      if only a single value is requested in a cache line, the data movement will
-      still be counted as a full cache line. This is also presented as a percent of
-      the peak theoretical bandwidth achievable on the specific accelerator.
-    L2-Fabric Read BW: "The number of bytes read by the L2 over the Infinity Fabric\u2122\
-      \ interface per unit time. This is also presented as a percent of the peak theoretical\
-      \ bandwidth achievable on the specific accelerator."
-    L2-Fabric Write BW: The number of bytes sent by the L2 over the Infinity Fabric
-      interface by write and atomic operations per unit time. This is also presented
-      as a percent of the peak theoretical bandwidth achievable on the specific accelerator.
-    Kernel Time: The total duration of the executed kernel.
-    Kernel Time (Cycles): The total duration of the executed kernel in cycles.
-    SIMD Utilization: The percent of total SIMD cycles in the kernel where any SIMD
-      on a CU was actively doing any work, summed over all CUs. Low values (less than
-      100%) indicate that the accelerator was not fully saturated by the kernel, or
-      a potential load-imbalance issue.
+    Theoretical LDS Bandwidth: >-
+      Indicates the maximum amount of bytes that could have been loaded from,
+      stored to, or atomically updated in the LDS per unit time (see LDS
+      Bandwidth example for more detail). This is also presented as a percent of
+      the peak theoretical F64 MFMA operations achievable on the specific
+      accelerator.
+    vL1D Cache BW: >-
+      The number of bytes looked up in the vL1D cache as a result of VMEM
+      instructions per unit time. The number of bytes is calculated as the
+      number of cache lines requested multiplied by the cache line size. This
+      value does not consider partial requests, so e.g., if only a single value
+      is requested in a cache line, the data movement will still be counted as a
+      full cache line. This is also presented as a percent of the peak
+      theoretical bandwidth achievable on the specific accelerator.
+    L2 Cache BW: >-
+      The number of bytes looked up in the L2 cache per unit time. The number of
+      bytes is calculated as the number of cache lines requested multiplied by
+      the cache line size. This value does not consider partial requests, so
+      e.g., if only a single value is requested in a cache line, the data
+      movement will still be counted as a full cache line. This is also
+      presented as a percent of the peak theoretical bandwidth achievable on the
+      specific accelerator.
+    L2-Fabric Read BW: >-
+      The number of bytes read by the L2 over the Infinity Fabric™ interface per
+      unit time. This is also presented as a percent of the peak theoretical
+      bandwidth achievable on the specific accelerator.
+    L2-Fabric Write BW: >-
+      The number of bytes sent by the L2 over the Infinity Fabric interface by
+      write and atomic operations per unit time. This is also presented as a
+      percent of the peak theoretical bandwidth achievable on the specific
+      accelerator.
+    Kernel Time: >-
+      The total duration of the executed kernel.
+    Kernel Time (Cycles): >-
+      The total duration of the executed kernel in cycles.
+    SIMD Utilization: >-
+      The percent of total SIMD cycles in the kernel where any SIMD on a CU was
+      actively doing any work, summed over all CUs. Low values (less than 100%)
+      indicate that the accelerator was not fully saturated by the kernel, or a
+      potential load-imbalance issue.
     Clock Rate:
   data source:
   - metric_table:
@@ -46,43 +57,42 @@ Panel Config:
         pop: Pct of Peak
       metric:
         Theoretical LDS Bandwidth:
-          value: AVG(((((SQ_LDS_IDX_ACTIVE - SQ_LDS_BANK_CONFLICT) * 4) * TO_INT($lds_banks_per_cu))
-            / (End_Timestamp - Start_Timestamp)))
+          value: SUM((SQ_LDS_IDX_ACTIVE - SQ_LDS_BANK_CONFLICT) * 4 * TO_INT($lds_banks_per_cu)) /
+            SUM(End_Timestamp - Start_Timestamp)
           unit: GB/s
-          peak: (($max_sclk * $cu_per_gpu) * 0.128)
-          pop: AVG((((((SQ_LDS_IDX_ACTIVE - SQ_LDS_BANK_CONFLICT) * 4) * TO_INT($lds_banks_per_cu))
-            / (End_Timestamp - Start_Timestamp)) / (($max_sclk * $cu_per_gpu) * 0.00128)))
+          peak: $max_sclk * $cu_per_gpu * 0.128
+          pop: 100 * SUM((SQ_LDS_IDX_ACTIVE - SQ_LDS_BANK_CONFLICT) * 4 * TO_INT($lds_banks_per_cu))
+            / SUM(End_Timestamp - Start_Timestamp) / ($max_sclk * $cu_per_gpu * 0.128)
         vL1D Cache BW:
-          value: AVG(((TCP_TOTAL_CACHE_ACCESSES_sum * 128) / (End_Timestamp - Start_Timestamp)))
+          value: SUM(TCP_TOTAL_CACHE_ACCESSES_sum * 128) / SUM(End_Timestamp - Start_Timestamp)
           unit: GB/s
-          peak: ((($max_sclk / 1000) * 128) * $cu_per_gpu)
-          pop: ((100 * AVG(((TCP_TOTAL_CACHE_ACCESSES_sum * 128) / (End_Timestamp
-            - Start_Timestamp)))) / ((($max_sclk / 1000) * 128) * $cu_per_gpu))
+          peak: $max_sclk / 1000 * 128 * $cu_per_gpu
+          pop: 100 * SUM(TCP_TOTAL_CACHE_ACCESSES_sum * 128) / SUM(End_Timestamp - Start_Timestamp)
+            / ($max_sclk / 1000 * 128 * $cu_per_gpu)
         L2 Cache BW:
-          value: AVG(((TCC_REQ_sum * 128) / (End_Timestamp - Start_Timestamp)))
+          value: SUM(TCC_REQ_sum * 128) / SUM(End_Timestamp - Start_Timestamp)
           unit: GB/s
-          peak: ((($max_sclk / 1000) * 128) * TO_INT($total_l2_chan))
-          pop: ((100 * AVG(((TCC_REQ_sum * 128) / (End_Timestamp - Start_Timestamp))))
-            / ((($max_sclk / 1000) * 128) * TO_INT($total_l2_chan)))
+          peak: $max_sclk / 1000 * 128 * TO_INT($total_l2_chan)
+          pop: 100 * SUM(TCC_REQ_sum * 128) / SUM(End_Timestamp - Start_Timestamp) / ($max_sclk /
+            1000 * 128 * TO_INT($total_l2_chan))
         L2-Fabric Read BW:
-          value: AVG((128 * TCC_BUBBLE_sum + 64 * (TCC_EA0_RDREQ_sum - TCC_BUBBLE_sum
-            - TCC_EA0_RDREQ_32B_sum) + 32 * TCC_EA0_RDREQ_32B_sum) / (End_Timestamp
-            - Start_Timestamp))
+          value: SUM(128 * TCC_BUBBLE_sum + 64 * (TCC_EA0_RDREQ_sum - TCC_BUBBLE_sum -
+            TCC_EA0_RDREQ_32B_sum) + 32 * TCC_EA0_RDREQ_32B_sum) / SUM(End_Timestamp -
+            Start_Timestamp)
           unit: GB/s
           peak: $hbmBandwidth
-          pop: ((100 * (AVG((128 * TCC_BUBBLE_sum + 64 * (TCC_EA0_RDREQ_sum - TCC_BUBBLE_sum
-            - TCC_EA0_RDREQ_32B_sum) + 32 * TCC_EA0_RDREQ_32B_sum) / (End_Timestamp
-            - Start_Timestamp)))) / $hbmBandwidth)
+          pop: 100 * SUM(128 * TCC_BUBBLE_sum + 64 * (TCC_EA0_RDREQ_sum - TCC_BUBBLE_sum -
+            TCC_EA0_RDREQ_32B_sum) + 32 * TCC_EA0_RDREQ_32B_sum) / SUM(End_Timestamp -
+            Start_Timestamp) / $hbmBandwidth
         L2-Fabric Write BW:
-          value: AVG((((TCC_EA0_WRREQ_64B_sum * 64) + ((TCC_EA0_WRREQ_sum - TCC_EA0_WRREQ_64B_sum)
-            * 32)) / (End_Timestamp - Start_Timestamp)))
+          value: SUM(TCC_EA0_WRREQ_64B_sum * 64 + (TCC_EA0_WRREQ_sum - TCC_EA0_WRREQ_64B_sum) * 32)
+            / SUM(End_Timestamp - Start_Timestamp)
           unit: GB/s
           peak: $hbmBandwidth
-          pop: ((100 * AVG((((TCC_EA0_WRREQ_64B_sum * 64) + ((TCC_EA0_WRREQ_sum -
-            TCC_EA0_WRREQ_64B_sum) * 32)) / (End_Timestamp - Start_Timestamp)))) /
-            $hbmBandwidth)
+          pop: 100 * SUM(TCC_EA0_WRREQ_64B_sum * 64 + (TCC_EA0_WRREQ_sum - TCC_EA0_WRREQ_64B_sum) *
+            32) / SUM(End_Timestamp - Start_Timestamp) / $hbmBandwidth
         Kernel Time:
-          avg: AVG((End_Timestamp - Start_Timestamp))
+          avg: AVG(End_Timestamp - Start_Timestamp)
           unit: ns
           peak: N/A
           pop: N/A
@@ -92,12 +102,12 @@ Panel Config:
           peak: N/A
           pop: N/A
         SIMD Utilization:
-          value: AVG(100 * SQ_BUSY_CU_CYCLES / ($GRBM_GUI_ACTIVE_PER_XCD * $cu_per_gpu))
+          value: SUM(100 * SQ_BUSY_CU_CYCLES) / SUM($GRBM_GUI_ACTIVE_PER_XCD * $cu_per_gpu)
           unit: Percent
           peak: 100
-          pop: AVG(100 * SQ_BUSY_CU_CYCLES / ($GRBM_GUI_ACTIVE_PER_XCD * $cu_per_gpu))
+          pop: SUM(100 * SQ_BUSY_CU_CYCLES) / SUM($GRBM_GUI_ACTIVE_PER_XCD * $cu_per_gpu)
         Clock Rate:
-          value: (GRBM_GUI_ACTIVE_PER_XCD * $cu_per_gpu) / (End_Timestamp - Start_Timestamp)
-          unit: MHz
+          value: GRBM_GUI_ACTIVE_PER_XCD * $cu_per_gpu / (End_Timestamp - Start_Timestamp)
+          unit: GHz
           peak: N/A # attainable peak? theoretical freq?
           pop: N/A

--- a/projects/rocprofiler-compute/src/rocprof_compute_tui/utils/gfx942/3300_compute_throughput.yaml
+++ b/projects/rocprofiler-compute/src/rocprof_compute_tui/utils/gfx942/3300_compute_throughput.yaml
@@ -4,61 +4,78 @@ Panel Config:
   id: 3300
   title: Compute Throughput
   metrics_description:
-    VALU FLOPs: 'The total floating-point operations executed per second on the VALU.
-      This is also presented as a percent of the peak theoretical FLOPs achievable
-      on the specific accelerator. Note: this does not include any floating-point
-      operations from MFMA instructions.'
-    VALU IOPs: 'The total integer operations executed per second on the VALU. This
-      is also presented as a percent of the peak theoretical IOPs achievable on the
-      specific accelerator. Note: this does not include any integer operations from
-      MFMA instructions.'
-    MFMA FLOPs (F8): The total number of 8-bit brain floating point MFMA operations
-      executed per second. This does not include any 16-bit brain floating point operations
-      from VALU instructions. This is also presented as a percent of the peak theoretical
-      F8 MFMA operations achievable on the specific accelerator. It is supported on
-      AMD Instinct MI300 series and later only.
-    MFMA FLOPs (BF16): 'The total number of 16-bit brain floating point MFMA operations
-      executed per second. Note: this does not include any 16-bit brain floating point
-      operations from VALU instructions. This is also presented as a percent of the
-      peak theoretical BF16 MFMA operations achievable on the specific accelerator.'
-    MFMA FLOPs (F16): 'The total number of 16-bit floating point MFMA operations executed
-      per second. Note: this does not include any 16-bit floating point operations
-      from VALU instructions. This is also presented as a percent of the peak theoretical
-      F16 MFMA operations achievable on the specific accelerator.'
-    MFMA FLOPs (F32): 'The total number of 32-bit floating point MFMA operations executed
-      per second. Note: this does not include any 32-bit floating point operations
-      from VALU instructions. This is also presented as a percent of the peak theoretical
-      F32 MFMA operations achievable on the specific accelerator.'
-    MFMA FLOPs (F64): 'The total number of 64-bit floating point MFMA operations executed
-      per second. Note: this does not include any 64-bit floating point operations
-      from VALU instructions. This is also presented as a percent of the peak theoretical
-      F64 MFMA operations achievable on the specific accelerator.'
-    MFMA IOPs (Int8): 'The total number of 8-bit integer MFMA operations executed
-      per second. Note: this does not include any 8-bit integer operations from VALU
-      instructions. This is also presented as a percent of the peak theoretical INT8
-      MFMA operations achievable on the specific accelerator.'
-    SALU Utilization: Indicates what percent of the kernel's duration the SALU was
-      busy executing instructions. Computed as the ratio of the total number of cycles
-      spent by the scheduler issuing SALU or SMEM instructions over the total CU cycles.
-    VALU Utilization: Indicates what percent of the kernel's duration the VALU was
-      busy executing instructions. Does not include VMEM operations. Computed as the
-      ratio of the total number of cycles spent by the scheduler issuing VALU instructions
-      over the total CU cycles.
-    MFMA Utilization: Indicates what percent of the kernel's duration the MFMA unit
-      was busy executing instructions. Computed as the ratio of the total number of
+    VALU FLOPs: >-
+      The total floating-point operations executed per second on the VALU. This
+      is also presented as a percent of the peak theoretical FLOPs achievable on
+      the specific accelerator. Note: this does not include any floating-point
+      operations from MFMA instructions.
+    VALU IOPs: >-
+      The total integer operations executed per second on the VALU. This is also
+      presented as a percent of the peak theoretical IOPs achievable on the
+      specific accelerator. Note: this does not include any integer operations
+      from MFMA instructions.
+    MFMA FLOPs (F8): >-
+      The total number of 8-bit brain floating point MFMA operations executed
+      per second. This does not include any 16-bit brain floating point
+      operations from VALU instructions. This is also presented as a percent of
+      the peak theoretical F8 MFMA operations achievable on the specific
+      accelerator. It is supported on AMD Instinct MI300 series and later only.
+    MFMA FLOPs (BF16): >-
+      The total number of 16-bit brain floating point MFMA operations executed
+      per second. Note: this does not include any 16-bit brain floating point
+      operations from VALU instructions. This is also presented as a percent of
+      the peak theoretical BF16 MFMA operations achievable on the specific
+      accelerator.
+    MFMA FLOPs (F16): >-
+      The total number of 16-bit floating point MFMA operations executed per
+      second. Note: this does not include any 16-bit floating point operations
+      from VALU instructions. This is also presented as a percent of the peak
+      theoretical F16 MFMA operations achievable on the specific accelerator.
+    MFMA FLOPs (F32): >-
+      The total number of 32-bit floating point MFMA operations executed per
+      second. Note: this does not include any 32-bit floating point operations
+      from VALU instructions. This is also presented as a percent of the peak
+      theoretical F32 MFMA operations achievable on the specific accelerator.
+    MFMA FLOPs (F64): >-
+      The total number of 64-bit floating point MFMA operations executed per
+      second. Note: this does not include any 64-bit floating point operations
+      from VALU instructions. This is also presented as a percent of the peak
+      theoretical F64 MFMA operations achievable on the specific accelerator.
+    MFMA IOPs (Int8): >-
+      The total number of 8-bit integer MFMA operations executed per second.
+      Note: this does not include any 8-bit integer operations from VALU
+      instructions. This is also presented as a percent of the peak theoretical
+      INT8 MFMA operations achievable on the specific accelerator.
+    SALU Utilization: >-
+      Indicates what percent of the kernel's duration the SALU was busy
+      executing instructions. Computed as the ratio of the total number of
+      cycles spent by the scheduler issuing SALU or SMEM instructions over the
+      total CU cycles.
+    VALU Utilization: >-
+      Indicates what percent of the kernel's duration the VALU was busy
+      executing instructions. Does not include VMEM operations. Computed as the
+      ratio of the total number of cycles spent by the scheduler issuing VALU
+      instructions over the total CU cycles.
+    MFMA Utilization: >-
+      Indicates what percent of the kernel's duration the MFMA unit was busy
+      executing instructions. Computed as the ratio of the total number of
       cycles the MFMA was busy over the total CU cycles.
-    VMEM Utilization: Indicates what percent of the kernel's duration the VMEM unit
-      was busy executing instructions, including both global/generic and spill/scratch
-      operations (see the VMEM instruction count metrics) for more detail). Does not
-      include VALU operations. Computed as the ratio of the total number of cycles
-      spent by the scheduler issuing VMEM instructions over the total CU cycles.
-    Branch Utilization: Indicates what percent of the kernel's duration the branch
-      unit was busy executing instructions. Computed as the ratio of the total number
-      of cycles spent by the scheduler issuing branch instructions over the total
+    VMEM Utilization: >-
+      Indicates what percent of the kernel's duration the VMEM unit was busy
+      executing instructions, including both global/generic and spill/scratch
+      operations (see the VMEM instruction count metrics) for more detail). Does
+      not include VALU operations. Computed as the ratio of the total number of
+      cycles spent by the scheduler issuing VMEM instructions over the total CU
+      cycles.
+    Branch Utilization: >-
+      Indicates what percent of the kernel's duration the branch unit was busy
+      executing instructions. Computed as the ratio of the total number of
+      cycles spent by the scheduler issuing branch instructions over the total
       CU cycles
-    IPC: The ratio of the total number of instructions executed on the CU over the
-      total active CU cycles. This is also presented as a percent of the peak theoretical
-      bandwidth achievable on the specific accelerator.
+    IPC: >-
+      The ratio of the total number of instructions executed on the CU over the
+      total active CU cycles. This is also presented as a percent of the peak
+      theoretical bandwidth achievable on the specific accelerator.
   data source:
   - metric_table:
       id: 3301
@@ -71,93 +88,92 @@ Panel Config:
         pop: Pct of Peak
       metric:
         VALU FLOPs:
-          value: AVG(((((64 * (((SQ_INSTS_VALU_ADD_F16 + SQ_INSTS_VALU_MUL_F16) +
-            SQ_INSTS_VALU_TRANS_F16) + (2 * SQ_INSTS_VALU_FMA_F16))) + (64 * (((SQ_INSTS_VALU_ADD_F32
-            + SQ_INSTS_VALU_MUL_F32) + SQ_INSTS_VALU_TRANS_F32) + (2 * SQ_INSTS_VALU_FMA_F32))))
-            + (64 * (((SQ_INSTS_VALU_ADD_F64 + SQ_INSTS_VALU_MUL_F64) + SQ_INSTS_VALU_TRANS_F64)
-            + (2 * SQ_INSTS_VALU_FMA_F64)))) / (End_Timestamp - Start_Timestamp)))
+          value: SUM(64 * (SQ_INSTS_VALU_ADD_F16 + SQ_INSTS_VALU_MUL_F16 + SQ_INSTS_VALU_TRANS_F16 +
+            2 * SQ_INSTS_VALU_FMA_F16) + 64 * (SQ_INSTS_VALU_ADD_F32 + SQ_INSTS_VALU_MUL_F32 +
+            SQ_INSTS_VALU_TRANS_F32 + 2 * SQ_INSTS_VALU_FMA_F32) + 64 * (SQ_INSTS_VALU_ADD_F64 +
+            SQ_INSTS_VALU_MUL_F64 + SQ_INSTS_VALU_TRANS_F64 + 2 * SQ_INSTS_VALU_FMA_F64)) /
+            SUM(End_Timestamp - Start_Timestamp)
           unit: GFLOP/s
-          peak: (((($max_sclk * $cu_per_gpu) * 64) * 2) / 1000)
-          pop: ((100 * AVG(((((64 * (((SQ_INSTS_VALU_ADD_F16 + SQ_INSTS_VALU_MUL_F16)
-            + SQ_INSTS_VALU_TRANS_F16) + (2 * SQ_INSTS_VALU_FMA_F16))) + (64 * (((SQ_INSTS_VALU_ADD_F32
-            + SQ_INSTS_VALU_MUL_F32) + SQ_INSTS_VALU_TRANS_F32) + (2 * SQ_INSTS_VALU_FMA_F32))))
-            + (64 * (((SQ_INSTS_VALU_ADD_F64 + SQ_INSTS_VALU_MUL_F64) + SQ_INSTS_VALU_TRANS_F64)
-            + (2 * SQ_INSTS_VALU_FMA_F64)))) / (End_Timestamp - Start_Timestamp))))
-            / (((($max_sclk * $cu_per_gpu) * 64) * 2) / 1000))
+          peak: $max_sclk * $cu_per_gpu * 64 * 2 / 1000
+          pop: 100 * SUM(64 * (SQ_INSTS_VALU_ADD_F16 + SQ_INSTS_VALU_MUL_F16 +
+            SQ_INSTS_VALU_TRANS_F16 + 2 * SQ_INSTS_VALU_FMA_F16) + 64 * (SQ_INSTS_VALU_ADD_F32 +
+            SQ_INSTS_VALU_MUL_F32 + SQ_INSTS_VALU_TRANS_F32 + 2 * SQ_INSTS_VALU_FMA_F32) + 64 *
+            (SQ_INSTS_VALU_ADD_F64 + SQ_INSTS_VALU_MUL_F64 + SQ_INSTS_VALU_TRANS_F64 + 2 *
+            SQ_INSTS_VALU_FMA_F64)) / SUM(End_Timestamp - Start_Timestamp) / ($max_sclk *
+            $cu_per_gpu * 64 * 2 / 1000)
         VALU IOPs:
-          value: AVG(((64 * (SQ_INSTS_VALU_INT32 + SQ_INSTS_VALU_INT64)) / (End_Timestamp
-            - Start_Timestamp)))
+          value: SUM(64 * (SQ_INSTS_VALU_INT32 + SQ_INSTS_VALU_INT64)) / SUM(End_Timestamp -
+            Start_Timestamp)
           unit: GIOP/s
-          peak: (((($max_sclk * $cu_per_gpu) * 64) * 2) / 1000)
-          pop: ((100 * AVG(((64 * (SQ_INSTS_VALU_INT32 + SQ_INSTS_VALU_INT64)) / (End_Timestamp
-            - Start_Timestamp)))) / (((($max_sclk * $cu_per_gpu) * 64) * 2) / 1000))
+          peak: $max_sclk * $cu_per_gpu * 64 * 2 / 1000
+          pop: 100 * SUM(64 * (SQ_INSTS_VALU_INT32 + SQ_INSTS_VALU_INT64)) / SUM(End_Timestamp -
+            Start_Timestamp) / ($max_sclk * $cu_per_gpu * 64 * 2 / 1000)
         MFMA FLOPs (F8):
-          value: AVG(((SQ_INSTS_VALU_MFMA_MOPS_F8 * 512) / (End_Timestamp - Start_Timestamp)))
+          value: SUM(SQ_INSTS_VALU_MFMA_MOPS_F8 * 512) / SUM(End_Timestamp - Start_Timestamp)
           unit: GFLOP/s
-          peak: ((($max_sclk * $cu_per_gpu) * 4096) / 1000)
-          pop: ((100 * AVG(((SQ_INSTS_VALU_MFMA_MOPS_F8 * 512) / (End_Timestamp -
-            Start_Timestamp)))) / ((($max_sclk * $cu_per_gpu) * 4096) / 1000))
+          peak: $max_sclk * $cu_per_gpu * 4096 / 1000
+          pop: 100 * SUM(SQ_INSTS_VALU_MFMA_MOPS_F8 * 512) / SUM(End_Timestamp - Start_Timestamp) /
+            ($max_sclk * $cu_per_gpu * 4096 / 1000)
         MFMA FLOPs (BF16):
-          value: AVG(((SQ_INSTS_VALU_MFMA_MOPS_BF16 * 512) / (End_Timestamp - Start_Timestamp)))
+          value: SUM(SQ_INSTS_VALU_MFMA_MOPS_BF16 * 512) / SUM(End_Timestamp - Start_Timestamp)
           unit: GFLOP/s
-          peak: ((($max_sclk * $cu_per_gpu) * 2048) / 1000)
-          pop: ((100 * AVG(((SQ_INSTS_VALU_MFMA_MOPS_BF16 * 512) / (End_Timestamp
-            - Start_Timestamp)))) / ((($max_sclk * $cu_per_gpu) * 2048) / 1000))
+          peak: $max_sclk * $cu_per_gpu * 2048 / 1000
+          pop: 100 * SUM(SQ_INSTS_VALU_MFMA_MOPS_BF16 * 512) / SUM(End_Timestamp - Start_Timestamp)
+            / ($max_sclk * $cu_per_gpu * 2048 / 1000)
         MFMA FLOPs (F16):
-          value: AVG(((SQ_INSTS_VALU_MFMA_MOPS_F16 * 512) / (End_Timestamp - Start_Timestamp)))
+          value: SUM(SQ_INSTS_VALU_MFMA_MOPS_F16 * 512) / SUM(End_Timestamp - Start_Timestamp)
           unit: GFLOP/s
-          peak: ((($max_sclk * $cu_per_gpu) * 2048) / 1000)
-          pop: ((100 * AVG(((SQ_INSTS_VALU_MFMA_MOPS_F16 * 512) / (End_Timestamp -
-            Start_Timestamp)))) / ((($max_sclk * $cu_per_gpu) * 2048) / 1000))
+          peak: $max_sclk * $cu_per_gpu * 2048 / 1000
+          pop: 100 * SUM(SQ_INSTS_VALU_MFMA_MOPS_F16 * 512) / SUM(End_Timestamp - Start_Timestamp) /
+            ($max_sclk * $cu_per_gpu * 2048 / 1000)
         MFMA FLOPs (F32):
-          value: AVG(((SQ_INSTS_VALU_MFMA_MOPS_F32 * 512) / (End_Timestamp - Start_Timestamp)))
+          value: SUM(SQ_INSTS_VALU_MFMA_MOPS_F32 * 512) / SUM(End_Timestamp - Start_Timestamp)
           unit: GFLOP/s
-          peak: ((($max_sclk * $cu_per_gpu) * 256) / 1000)
-          pop: ((100 * AVG(((SQ_INSTS_VALU_MFMA_MOPS_F32 * 512) / (End_Timestamp -
-            Start_Timestamp)))) / ((($max_sclk * $cu_per_gpu) * 256) / 1000))
+          peak: $max_sclk * $cu_per_gpu * 256 / 1000
+          pop: 100 * SUM(SQ_INSTS_VALU_MFMA_MOPS_F32 * 512) / SUM(End_Timestamp - Start_Timestamp) /
+            ($max_sclk * $cu_per_gpu * 256 / 1000)
         MFMA FLOPs (F64):
-          value: AVG(((SQ_INSTS_VALU_MFMA_MOPS_F64 * 512) / (End_Timestamp - Start_Timestamp)))
+          value: SUM(SQ_INSTS_VALU_MFMA_MOPS_F64 * 512) / SUM(End_Timestamp - Start_Timestamp)
           unit: GFLOP/s
-          peak: ((($max_sclk * $cu_per_gpu) * 256) / 1000)
-          pop: ((100 * AVG(((SQ_INSTS_VALU_MFMA_MOPS_F64 * 512) / (End_Timestamp -
-            Start_Timestamp)))) / ((($max_sclk * $cu_per_gpu) * 256) / 1000))
+          peak: $max_sclk * $cu_per_gpu * 256 / 1000
+          pop: 100 * SUM(SQ_INSTS_VALU_MFMA_MOPS_F64 * 512) / SUM(End_Timestamp - Start_Timestamp) /
+            ($max_sclk * $cu_per_gpu * 256 / 1000)
         MFMA IOPs (Int8):
-          value: AVG(((SQ_INSTS_VALU_MFMA_MOPS_I8 * 512) / (End_Timestamp - Start_Timestamp)))
+          value: SUM(SQ_INSTS_VALU_MFMA_MOPS_I8 * 512) / SUM(End_Timestamp - Start_Timestamp)
           unit: GIOP/s
-          peak: ((($max_sclk * $cu_per_gpu) * 4096) / 1000)
-          pop: ((100 * AVG(((SQ_INSTS_VALU_MFMA_MOPS_I8 * 512) / (End_Timestamp -
-            Start_Timestamp)))) / ((($max_sclk * $cu_per_gpu) * 4096) / 1000))
+          peak: $max_sclk * $cu_per_gpu * 4096 / 1000
+          pop: 100 * SUM(SQ_INSTS_VALU_MFMA_MOPS_I8 * 512) / SUM(End_Timestamp - Start_Timestamp) /
+            ($max_sclk * $cu_per_gpu * 4096 / 1000)
         SALU Utilization:
-          value: AVG(((100 * SQ_ACTIVE_INST_SCA) / ($GRBM_GUI_ACTIVE_PER_XCD * $cu_per_gpu)))
+          value: SUM(100 * SQ_ACTIVE_INST_SCA) / SUM($GRBM_GUI_ACTIVE_PER_XCD * $cu_per_gpu)
           unit: Percent
           peak: 100
-          pop: AVG(((100 * SQ_ACTIVE_INST_SCA) / ($GRBM_GUI_ACTIVE_PER_XCD * $cu_per_gpu)))
+          pop: SUM(100 * SQ_ACTIVE_INST_SCA) / SUM($GRBM_GUI_ACTIVE_PER_XCD * $cu_per_gpu)
         VALU Utilization:
-          value: AVG(((100 * SQ_ACTIVE_INST_VALU) / ($GRBM_GUI_ACTIVE_PER_XCD * $cu_per_gpu)))
+          value: SUM(100 * SQ_ACTIVE_INST_VALU) / SUM($GRBM_GUI_ACTIVE_PER_XCD * $cu_per_gpu)
           unit: Percent
           peak: 100
-          pop: AVG(((100 * SQ_ACTIVE_INST_VALU) / ($GRBM_GUI_ACTIVE_PER_XCD * $cu_per_gpu)))
+          pop: SUM(100 * SQ_ACTIVE_INST_VALU) / SUM($GRBM_GUI_ACTIVE_PER_XCD * $cu_per_gpu)
         MFMA Utilization:
-          value: AVG(((100 * SQ_VALU_MFMA_BUSY_CYCLES) / (($GRBM_GUI_ACTIVE_PER_XCD
-            * $cu_per_gpu) * 4)))
+          value: SUM(100 * SQ_VALU_MFMA_BUSY_CYCLES) / SUM($GRBM_GUI_ACTIVE_PER_XCD * $cu_per_gpu *
+            4)
           unit: Percent
           peak: 100
-          pop: AVG(((100 * SQ_VALU_MFMA_BUSY_CYCLES) / (($GRBM_GUI_ACTIVE_PER_XCD
-            * $cu_per_gpu) * 4)))
+          pop: SUM(100 * SQ_VALU_MFMA_BUSY_CYCLES) / SUM($GRBM_GUI_ACTIVE_PER_XCD * $cu_per_gpu * 4)
         VMEM Utilization:
-          value: AVG((((100 * (SQ_ACTIVE_INST_FLAT+SQ_ACTIVE_INST_VMEM)) / $GRBM_GUI_ACTIVE_PER_XCD)
-            / $cu_per_gpu))
+          value: SUM(100 * (SQ_ACTIVE_INST_FLAT + SQ_ACTIVE_INST_VMEM)) /
+            SUM($GRBM_GUI_ACTIVE_PER_XCD * $cu_per_gpu)
           unit: Percent
           peak: 100
-          pop: AVG((((100 * (SQ_ACTIVE_INST_FLAT+SQ_ACTIVE_INST_VMEM)) / $GRBM_GUI_ACTIVE_PER_XCD)
-            / $cu_per_gpu))
+          pop: SUM(100 * (SQ_ACTIVE_INST_FLAT + SQ_ACTIVE_INST_VMEM)) / SUM($GRBM_GUI_ACTIVE_PER_XCD
+            * $cu_per_gpu)
         Branch Utilization:
-          value: AVG((((100 * SQ_ACTIVE_INST_MISC) / $GRBM_GUI_ACTIVE_PER_XCD) / $cu_per_gpu))
+          value: SUM(100 * SQ_ACTIVE_INST_MISC) / SUM($GRBM_GUI_ACTIVE_PER_XCD * $cu_per_gpu)
           unit: Percent
           peak: 100
-          pop: AVG((((100 * SQ_ACTIVE_INST_MISC) / $GRBM_GUI_ACTIVE_PER_XCD) / $cu_per_gpu))
+          pop: SUM(100 * SQ_ACTIVE_INST_MISC) / SUM($GRBM_GUI_ACTIVE_PER_XCD * $cu_per_gpu)
         IPC:
-          value: AVG((SQ_INSTS / SQ_BUSY_CU_CYCLES))
+          value: SUM(SQ_INSTS) / SUM(SQ_BUSY_CU_CYCLES)
           unit: Instr/cycle
           peak: 5
-          pop: ((100 * AVG((SQ_INSTS / SQ_BUSY_CU_CYCLES))) / 5)
+          pop: 100 * SUM(SQ_INSTS) / SUM(SQ_BUSY_CU_CYCLES) / 5

--- a/projects/rocprofiler-compute/src/rocprof_compute_tui/utils/gfx942/3400_memory_throughput.yaml
+++ b/projects/rocprofiler-compute/src/rocprof_compute_tui/utils/gfx942/3400_memory_throughput.yaml
@@ -4,54 +4,71 @@ Panel Config:
   id: 3400
   title: Memory Throughput
   metrics_description:
-    vL1D Cache BW: The number of bytes looked up in the vL1D cache as a result of
-      VMEM instructions per unit time. The number of bytes is calculated as the number
-      of cache lines requested multiplied by the cache line size. This value does
-      not consider partial requests, so e.g., if only a single value is requested
-      in a cache line, the data movement will still be counted as a full cache line.
-      This is also presented as a percent of the peak theoretical bandwidth achievable
+    vL1D Cache BW: >-
+      The number of bytes looked up in the vL1D cache as a result of VMEM
+      instructions per unit time. The number of bytes is calculated as the
+      number of cache lines requested multiplied by the cache line size. This
+      value does not consider partial requests, so e.g., if only a single value
+      is requested in a cache line, the data movement will still be counted as a
+      full cache line. This is also presented as a percent of the peak
+      theoretical bandwidth achievable on the specific accelerator.
+    vL1D Cache Utilization: >-
+      Indicates how busy the vL1D Cache RAM was during the kernel execution. The
+      number of cycles where the vL1D Cache RAM is actively processing any
+      request divided by the number of cycles where the vL1D is active.
+    Theoretical LDS Bandwidth: >-
+      Indicates the maximum amount of bytes that could have been loaded from,
+      stored to, or atomically updated in the LDS per unit time (see LDS
+      Bandwidth example for more detail). This is also presented as a percent of
+      the peak theoretical F64 MFMA operations achievable on the specific
+      accelerator.
+    LDS Utilization: >-
+      Indicates what percent of the kernel's duration the LDS was actively
+      executing instructions (including, but not limited to, load, store, atomic
+      and HIP's __shfl operations). Calculated as the ratio of the total number
+      of cycles LDS was active over the total CU cycles.
+    L2 Cache BW: >-
+      The number of bytes looked up in the L2 cache per unit time. The number of
+      bytes is calculated as the number of cache lines requested multiplied by
+      the cache line size. This value does not consider partial requests, so
+      e.g., if only a single value is requested in a cache line, the data
+      movement will still be counted as a full cache line. This is also
+      presented as a percent of the peak theoretical bandwidth achievable on the
+      specific accelerator.
+    L2 Cache Utilization: >-
+      The ratio of the number of cycles an L2 channel was active, summed over
+      all L2 channels on the accelerator over the total L2 cycles.
+    L2-Fabric Read BW: >-
+      The number of bytes read by the L2 over the Infinity Fabric™ interface per
+      unit time. This is also presented as a percent of the peak theoretical
+      bandwidth achievable on the specific accelerator.
+    L2-Fabric Write BW: >-
+      The number of bytes sent by the L2 over the Infinity Fabric interface by
+      write and atomic operations per unit time. This is also presented as a
+      percent of the peak theoretical bandwidth achievable on the specific
+      accelerator.
+    sL1D Cache BW: >-
+      The number of bytes looked up in the sL1D cache per unit time. This is
+      also presented as a percent of the peak theoretical bandwidth achievable
       on the specific accelerator.
-    vL1D Cache Utilization: Indicates how busy the vL1D Cache RAM was during the kernel execution.
-      The number of cycles where the vL1D Cache RAM is actively processing any request
-      divided by the number of cycles where the vL1D is active.
-    Theoretical LDS Bandwidth: Indicates the maximum amount of bytes that could have
-      been loaded from, stored to, or atomically updated in the LDS per unit time
-      (see LDS Bandwidth example for more detail). This is also presented as a percent
-      of the peak theoretical F64 MFMA operations achievable on the specific accelerator.
-    LDS Utilization: Indicates what percent of the kernel's duration the LDS was actively
-      executing instructions (including, but not limited to, load, store, atomic and
-      HIP's __shfl operations). Calculated as the ratio of the total number of cycles
-      LDS was active over the total CU cycles.
-    L2 Cache BW: The number of bytes looked up in the L2 cache per unit time. The
-      number of bytes is calculated as the number of cache lines requested multiplied
-      by the cache line size. This value does not consider partial requests, so e.g.,
-      if only a single value is requested in a cache line, the data movement will
-      still be counted as a full cache line. This is also presented as a percent of
-      the peak theoretical bandwidth achievable on the specific accelerator.
-    L2 Cache Utilization: The ratio of the number of cycles an L2 channel was active, summed
-      over all L2 channels on the accelerator over the total L2 cycles.
-    L2-Fabric Read BW: "The number of bytes read by the L2 over the Infinity Fabric\u2122\
-      \ interface per unit time. This is also presented as a percent of the peak theoretical\
-      \ bandwidth achievable on the specific accelerator."
-    L2-Fabric Write BW: The number of bytes sent by the L2 over the Infinity Fabric
-      interface by write and atomic operations per unit time. This is also presented
-      as a percent of the peak theoretical bandwidth achievable on the specific accelerator.
-    sL1D Cache BW: The number of bytes looked up in the sL1D cache per unit time.
-      This is also presented as a percent of the peak theoretical bandwidth achievable
-      on the specific accelerator.
-    L1I BW: The percent of L1I requests that hit on a previously loaded line the cache.
-      Calculated as the ratio of the number of L1I requests that hit over the number
-      of all L1I requests.
-    Address Processing Unit Busy: Percent of the total CU cycles the address processor
-      was busy.
-    Data-Return Busy: Percent of the total CU cycles the data-return unit was busy
-      processing or waiting on data to return to the CU.
-    L1I-L2 Bandwidth: Total number of bytes transferred across L1I - L2 interface
-      divided by total duration.
-    sL1D-L2 BW: "The total number of bytes read from, written to, or atomically updated\
-      \ across the sL1D\u2194L2 interface, divided by total duration. Note that sL1D\
-      \ writes and atomics are typically unused on current CDNA accelerators, so in\
-      \ the majority of cases this can be interpreted as an sL1D\u2192L2 read bandwidth."
+    L1I BW: >-
+      The percent of L1I requests that hit on a previously loaded line the
+      cache. Calculated as the ratio of the number of L1I requests that hit over
+      the number of all L1I requests.
+    Address Processing Unit Busy: >-
+      Percent of the total CU cycles the address processor was busy.
+    Data-Return Busy: >-
+      Percent of the total CU cycles the data-return unit was busy processing or
+      waiting on data to return to the CU.
+    L1I-L2 Bandwidth: >-
+      Total number of bytes transferred across L1I - L2 interface divided by
+      total duration.
+    sL1D-L2 BW: >-
+      The total number of bytes read from, written to, or atomically updated
+      across the sL1D↔L2 interface, divided by total duration. Note that sL1D
+      writes and atomics are typically unused on current CDNA accelerators, so
+      in the majority of cases this can be interpreted as an sL1D→L2 read
+      bandwidth.
   data source:
   - metric_table:
       id: 3401
@@ -64,99 +81,95 @@ Panel Config:
         pop: Pct of Peak
       metric:
         vL1D Cache BW:
-          value: AVG(((TCP_TOTAL_CACHE_ACCESSES_sum * 128) / (End_Timestamp - Start_Timestamp)))
+          value: SUM(TCP_TOTAL_CACHE_ACCESSES_sum * 128) / SUM(End_Timestamp - Start_Timestamp)
           unit: GB/s
-          peak: ((($max_sclk / 1000) * 128) * $cu_per_gpu)
-          pop: ((100 * AVG(((TCP_TOTAL_CACHE_ACCESSES_sum * 128) / (End_Timestamp
-            - Start_Timestamp)))) / ((($max_sclk / 1000) * 128) * $cu_per_gpu))
+          peak: $max_sclk / 1000 * 128 * $cu_per_gpu
+          pop: 100 * SUM(TCP_TOTAL_CACHE_ACCESSES_sum * 128) / SUM(End_Timestamp - Start_Timestamp)
+            / ($max_sclk / 1000 * 128 * $cu_per_gpu)
         vL1D Cache Utilization:
-          value: AVG((((TCP_GATE_EN2_sum * 100) / TCP_GATE_EN1_sum) if (TCP_GATE_EN1_sum
-            != 0) else None))
+          value: SUM(TCP_GATE_EN2_sum * 100) / SUM(TCP_GATE_EN1_sum)
           unit: Percent
           peak: 100
           pop: None
         Theoretical LDS Bandwidth:
-          value: AVG(((((SQ_LDS_IDX_ACTIVE - SQ_LDS_BANK_CONFLICT) * 4) * TO_INT($lds_banks_per_cu))
-            / (End_Timestamp - Start_Timestamp)))
+          value: SUM((SQ_LDS_IDX_ACTIVE - SQ_LDS_BANK_CONFLICT) * 4 * TO_INT($lds_banks_per_cu)) /
+            SUM(End_Timestamp - Start_Timestamp)
           unit: GB/s
-          peak: (($max_sclk * $cu_per_gpu) * 0.128)
-          pop: AVG((((((SQ_LDS_IDX_ACTIVE - SQ_LDS_BANK_CONFLICT) * 4) * TO_INT($lds_banks_per_cu))
-            / (End_Timestamp - Start_Timestamp)) / (($max_sclk * $cu_per_gpu) * 0.00128)))
+          peak: $max_sclk * $cu_per_gpu * 0.128
+          pop: 100 * SUM((SQ_LDS_IDX_ACTIVE - SQ_LDS_BANK_CONFLICT) * 4 * TO_INT($lds_banks_per_cu))
+            / SUM(End_Timestamp - Start_Timestamp) / ($max_sclk * $cu_per_gpu * 0.128)
         LDS Utilization:
-          value: AVG(((100 * SQ_LDS_IDX_ACTIVE) / ($GRBM_GUI_ACTIVE_PER_XCD * $cu_per_gpu)))
+          value: SUM(100 * SQ_LDS_IDX_ACTIVE) / SUM($GRBM_GUI_ACTIVE_PER_XCD * $cu_per_gpu)
           unit: Percent
           peak: 100
           pop: None
         L2 Cache Hit Rate:
-          value: AVG((((100 * TCC_HIT_sum) / (TCC_HIT_sum + TCC_MISS_sum)) if ((TCC_HIT_sum
-            + TCC_MISS_sum) != 0) else None))
+          value: SUM(100 * TCC_HIT_sum) / SUM(TCC_HIT_sum + TCC_MISS_sum)
           unit: Percent
           peak: 100
-          pop: AVG((((100 * TCC_HIT_sum) / (TCC_HIT_sum + TCC_MISS_sum)) if ((TCC_HIT_sum
-            + TCC_MISS_sum) != 0) else None))
+          pop: SUM(100 * TCC_HIT_sum) / SUM(TCC_HIT_sum + TCC_MISS_sum)
         L2 Cache BW:
-          value: AVG(((TCC_REQ_sum * 128) / (End_Timestamp - Start_Timestamp)))
+          value: SUM(TCC_REQ_sum * 128) / SUM(End_Timestamp - Start_Timestamp)
           unit: GB/s
-          peak: ((($max_sclk / 1000) * 128) * TO_INT($total_l2_chan))
-          pop: ((100 * AVG(((TCC_REQ_sum * 128) / (End_Timestamp - Start_Timestamp))))
-            / ((($max_sclk / 1000) * 128) * TO_INT($total_l2_chan)))
+          peak: $max_sclk / 1000 * 128 * TO_INT($total_l2_chan)
+          pop: 100 * SUM(TCC_REQ_sum * 128) / SUM(End_Timestamp - Start_Timestamp) / ($max_sclk /
+            1000 * 128 * TO_INT($total_l2_chan))
         L2 Cache Utilization:
-          value: AVG(((TCC_BUSY_sum * 100) / (TO_INT($total_l2_chan) * $GRBM_GUI_ACTIVE_PER_XCD)))
+          value: SUM(TCC_BUSY_sum * 100) / SUM(TO_INT($total_l2_chan) * $GRBM_GUI_ACTIVE_PER_XCD)
           unit: Percent
           peak: 100
           pop: None
         L2-Fabric Read BW:
-          value: AVG((128 * TCC_BUBBLE_sum + 64 * (TCC_EA0_RDREQ_sum - TCC_BUBBLE_sum
-            - TCC_EA0_RDREQ_32B_sum) + 32 * TCC_EA0_RDREQ_32B_sum) / (End_Timestamp
-            - Start_Timestamp))
+          value: SUM(128 * TCC_BUBBLE_sum + 64 * (TCC_EA0_RDREQ_sum - TCC_BUBBLE_sum -
+            TCC_EA0_RDREQ_32B_sum) + 32 * TCC_EA0_RDREQ_32B_sum) / SUM(End_Timestamp -
+            Start_Timestamp)
           unit: GB/s
           peak: $hbmBandwidth
-          pop: ((100 * (AVG((128 * TCC_BUBBLE_sum + 64 * (TCC_EA0_RDREQ_sum - TCC_BUBBLE_sum
-            - TCC_EA0_RDREQ_32B_sum) + 32 * TCC_EA0_RDREQ_32B_sum) / (End_Timestamp
-            - Start_Timestamp)))) / $hbmBandwidth)
+          pop: 100 * SUM(128 * TCC_BUBBLE_sum + 64 * (TCC_EA0_RDREQ_sum - TCC_BUBBLE_sum -
+            TCC_EA0_RDREQ_32B_sum) + 32 * TCC_EA0_RDREQ_32B_sum) / SUM(End_Timestamp -
+            Start_Timestamp) / $hbmBandwidth
         L2-Fabric Write BW:
-          value: AVG((((TCC_EA0_WRREQ_64B_sum * 64) + ((TCC_EA0_WRREQ_sum - TCC_EA0_WRREQ_64B_sum)
-            * 32)) / (End_Timestamp - Start_Timestamp)))
+          value: SUM(TCC_EA0_WRREQ_64B_sum * 64 + (TCC_EA0_WRREQ_sum - TCC_EA0_WRREQ_64B_sum) * 32)
+            / SUM(End_Timestamp - Start_Timestamp)
           unit: GB/s
           peak: $hbmBandwidth
-          pop: ((100 * AVG((((TCC_EA0_WRREQ_64B_sum * 64) + ((TCC_EA0_WRREQ_sum -
-            TCC_EA0_WRREQ_64B_sum) * 32)) / (End_Timestamp - Start_Timestamp)))) /
-            $hbmBandwidth)
+          pop: 100 * SUM(TCC_EA0_WRREQ_64B_sum * 64 + (TCC_EA0_WRREQ_sum - TCC_EA0_WRREQ_64B_sum) *
+            32) / SUM(End_Timestamp - Start_Timestamp) / $hbmBandwidth
         sL1D Cache BW:
-          value: AVG(((SQC_DCACHE_REQ / (End_Timestamp - Start_Timestamp)) * 64))
+          value: SUM(SQC_DCACHE_REQ * 64) / SUM(End_Timestamp - Start_Timestamp)
           unit: GB/s
-          peak: ((($max_sclk / 1000) * 64) * $sqc_per_gpu)
-          pop: ((100 * AVG(((SQC_DCACHE_REQ / (End_Timestamp - Start_Timestamp)) *
-            64))) / ((($max_sclk / 1000) * 64) * $sqc_per_gpu))
+          peak: $max_sclk / 1000 * 64 * $sqc_per_gpu
+          pop: 100 * SUM(SQC_DCACHE_REQ * 64) / SUM(End_Timestamp - Start_Timestamp) / ($max_sclk /
+            1000 * 64 * $sqc_per_gpu)
         L1I Hit Rate:
-          value: AVG(((100 * SQC_ICACHE_HITS) / (SQC_ICACHE_HITS + SQC_ICACHE_MISSES)))
+          value: SUM(100 * SQC_ICACHE_HITS) / SUM(SQC_ICACHE_HITS + SQC_ICACHE_MISSES)
           unit: Percent
           peak: 100
-          pop: AVG(((100 * SQC_ICACHE_HITS) / (SQC_ICACHE_HITS + SQC_ICACHE_MISSES)))
+          pop: SUM(100 * SQC_ICACHE_HITS) / SUM(SQC_ICACHE_HITS + SQC_ICACHE_MISSES)
         L1I BW:
-          value: AVG(((SQC_ICACHE_REQ / (End_Timestamp - Start_Timestamp)) * 64))
+          value: SUM(SQC_ICACHE_REQ * 64) / SUM(End_Timestamp - Start_Timestamp)
           unit: GB/s
-          peak: ((($max_sclk / 1000) * 64) * $sqc_per_gpu)
-          pop: ((100 * AVG(((SQC_ICACHE_REQ / (End_Timestamp - Start_Timestamp)) *
-            64))) / ((($max_sclk / 1000) * 64) * $sqc_per_gpu))
+          peak: $max_sclk / 1000 * 64 * $sqc_per_gpu
+          pop: 100 * SUM(SQC_ICACHE_REQ * 64) / SUM(End_Timestamp - Start_Timestamp) / ($max_sclk /
+            1000 * 64 * $sqc_per_gpu)
         Address Processing Unit Busy:
-          avg: AVG(((100 * TA_TA_BUSY_sum) / ($GRBM_GUI_ACTIVE_PER_XCD * $cu_per_gpu)))
+          avg: SUM(100 * TA_TA_BUSY_sum) / SUM($GRBM_GUI_ACTIVE_PER_XCD * $cu_per_gpu)
           unit: Percent
           peak: 100
           pop: N/A
         Data-Return Busy:
-          avg: AVG(((100 * TD_TD_BUSY_sum) / ($GRBM_GUI_ACTIVE_PER_XCD * $cu_per_gpu)))
+          avg: SUM(100 * TD_TD_BUSY_sum) / SUM($GRBM_GUI_ACTIVE_PER_XCD * $cu_per_gpu)
           unit: Percent
           peak: 100
           pop: N/A
         L1I-L2 Bandwidth:
-          avg: AVG(((SQC_TC_INST_REQ * 64) / (End_Timestamp - Start_Timestamp)))
+          avg: SUM(SQC_TC_INST_REQ * 64) / SUM(End_Timestamp - Start_Timestamp)
           unit: GB/s
           peak: N/A
           pop: N/A
         sL1D-L2 BW:
-          value: AVG(((((SQC_TC_DATA_READ_REQ + SQC_TC_DATA_WRITE_REQ + SQC_TC_DATA_ATOMIC_REQ)
-            * 64)) / (End_Timestamp - Start_Timestamp)))
+          value: SUM((SQC_TC_DATA_READ_REQ + SQC_TC_DATA_WRITE_REQ + SQC_TC_DATA_ATOMIC_REQ) * 64) /
+            SUM(End_Timestamp - Start_Timestamp)
           unit: GB/s
           peak: N/A
           pop: N/A

--- a/projects/rocprofiler-compute/src/rocprof_compute_tui/utils/gfx950/3200_system_speed_of_light.yaml
+++ b/projects/rocprofiler-compute/src/rocprof_compute_tui/utils/gfx950/3200_system_speed_of_light.yaml
@@ -4,34 +4,44 @@ Panel Config:
   id: 3200
   title: GPU Speed-of-Light
   metrics_description:
-    Theoretical LDS Bandwidth: Indicates the maximum amount of bytes that could have
-      been loaded from, stored to, or atomically updated in the LDS per unit time
-      (see LDS Bandwidth example for more detail).
-    vL1D Cache BW: The number of bytes looked up in the vL1D cache as a result of
-      VMEM instructions per unit time. The number of bytes is calculated as the number
-      of cache lines requested multiplied by the cache line size. This value does
-      not consider partial requests, so e.g., if only a single value is requested
-      in a cache line, the data movement will still be counted as a full cache line.
-      This is also presented as a percent of the peak theoretical bandwidth achievable
-      on the specific accelerator.
-    L2 Cache BW: The number of bytes looked up in the L2 cache per unit time. The
-      number of bytes is calculated as the number of cache lines requested multiplied
-      by the cache line size. This value does not consider partial requests, so e.g.,
-      if only a single value is requested in a cache line, the data movement will
-      still be counted as a full cache line. This is also presented as a percent of
-      the peak theoretical bandwidth achievable on the specific accelerator.
-    L2-Fabric Read BW: "The number of bytes read by the L2 over the Infinity Fabric\u2122\
-      \ interface per unit time. This is also presented as a percent of the peak theoretical\
-      \ bandwidth achievable on the specific accelerator."
-    L2-Fabric Write BW: The number of bytes sent by the L2 over the Infinity Fabric
-      interface by write and atomic operations per unit time. This is also presented
-      as a percent of the peak theoretical bandwidth achievable on the specific accelerator.
-    Kernel Time: The total duration of the executed kernel.
-    Kernel Time (Cycles): The total duration of the executed kernel in cycles.
-    SIMD Utilization: The percent of total SIMD cycles in the kernel where any SIMD
-      on a CU was actively doing any work, summed over all CUs. Low values (less than
-      100%) indicate that the accelerator was not fully saturated by the kernel, or
-      a potential load-imbalance issue.
+    Theoretical LDS Bandwidth: >-
+      Indicates the maximum amount of bytes that could have been loaded from,
+      stored to, or atomically updated in the LDS per unit time (see LDS
+      Bandwidth example for more detail).
+    vL1D Cache BW: >-
+      The number of bytes looked up in the vL1D cache as a result of VMEM
+      instructions per unit time. The number of bytes is calculated as the
+      number of cache lines requested multiplied by the cache line size. This
+      value does not consider partial requests, so e.g., if only a single value
+      is requested in a cache line, the data movement will still be counted as a
+      full cache line. This is also presented as a percent of the peak
+      theoretical bandwidth achievable on the specific accelerator.
+    L2 Cache BW: >-
+      The number of bytes looked up in the L2 cache per unit time. The number of
+      bytes is calculated as the number of cache lines requested multiplied by
+      the cache line size. This value does not consider partial requests, so
+      e.g., if only a single value is requested in a cache line, the data
+      movement will still be counted as a full cache line. This is also
+      presented as a percent of the peak theoretical bandwidth achievable on the
+      specific accelerator.
+    L2-Fabric Read BW: >-
+      The number of bytes read by the L2 over the Infinity Fabric™ interface per
+      unit time. This is also presented as a percent of the peak theoretical
+      bandwidth achievable on the specific accelerator.
+    L2-Fabric Write BW: >-
+      The number of bytes sent by the L2 over the Infinity Fabric interface by
+      write and atomic operations per unit time. This is also presented as a
+      percent of the peak theoretical bandwidth achievable on the specific
+      accelerator.
+    Kernel Time: >-
+      The total duration of the executed kernel.
+    Kernel Time (Cycles): >-
+      The total duration of the executed kernel in cycles.
+    SIMD Utilization: >-
+      The percent of total SIMD cycles in the kernel where any SIMD on a CU was
+      actively doing any work, summed over all CUs. Low values (less than 100%)
+      indicate that the accelerator was not fully saturated by the kernel, or a
+      potential load-imbalance issue.
     Clock Rate:
   data source:
   - metric_table:
@@ -45,43 +55,40 @@ Panel Config:
         pop: Pct of Peak
       metric:
         Theoretical LDS Bandwidth:
-          value: AVG(((((SQ_LDS_IDX_ACTIVE - SQ_LDS_BANK_CONFLICT) * 4) * TO_INT($lds_banks_per_cu))
-            / (End_Timestamp - Start_Timestamp)))
+          value: SUM((SQ_LDS_IDX_ACTIVE - SQ_LDS_BANK_CONFLICT) * 4 * TO_INT($lds_banks_per_cu)) /
+            SUM(End_Timestamp - Start_Timestamp)
           unit: GB/s
-          peak: (($max_sclk * $cu_per_gpu) * 0.128)
-          pop: AVG((((((SQ_LDS_IDX_ACTIVE - SQ_LDS_BANK_CONFLICT) * 4) * TO_INT($lds_banks_per_cu))
-            / (End_Timestamp - Start_Timestamp)) / (($max_sclk * $cu_per_gpu) * 0.00128)))
+          peak: $max_sclk * $cu_per_gpu * 0.128
+          pop: 100 * SUM((SQ_LDS_IDX_ACTIVE - SQ_LDS_BANK_CONFLICT) * 4 * TO_INT($lds_banks_per_cu))
+            / SUM(End_Timestamp - Start_Timestamp) / ($max_sclk * $cu_per_gpu * 0.128)
         vL1D Cache BW:
-          value: AVG(((TCP_TOTAL_CACHE_ACCESSES_sum * 128) / (End_Timestamp - Start_Timestamp)))
+          value: SUM(TCP_TOTAL_CACHE_ACCESSES_sum * 128) / SUM(End_Timestamp - Start_Timestamp)
           unit: GB/s
-          peak: ((($max_sclk / 1000) * 128) * $cu_per_gpu)
-          pop: ((100 * AVG(((TCP_TOTAL_CACHE_ACCESSES_sum * 128) / (End_Timestamp
-            - Start_Timestamp)))) / ((($max_sclk / 1000) * 128) * $cu_per_gpu))
+          peak: $max_sclk / 1000 * 128 * $cu_per_gpu
+          pop: 100 * SUM(TCP_TOTAL_CACHE_ACCESSES_sum * 128) / SUM(End_Timestamp - Start_Timestamp)
+            / ($max_sclk / 1000 * 128 * $cu_per_gpu)
         L2 Cache BW:
-          value: AVG(((TCC_REQ_sum * 128) / (End_Timestamp - Start_Timestamp)))
+          value: SUM(TCC_REQ_sum * 128) / SUM(End_Timestamp - Start_Timestamp)
           unit: GB/s
-          peak: ((($max_sclk / 1000) * 128) * TO_INT($total_l2_chan))
-          pop: ((100 * AVG(((TCC_REQ_sum * 128) / (End_Timestamp - Start_Timestamp))))
-            / ((($max_sclk / 1000) * 128) * TO_INT($total_l2_chan)))
+          peak: $max_sclk / 1000 * 128 * TO_INT($total_l2_chan)
+          pop: 100 * SUM(TCC_REQ_sum * 128) / SUM(End_Timestamp - Start_Timestamp) / ($max_sclk /
+            1000 * 128 * TO_INT($total_l2_chan))
         L2-Fabric Read BW:
-          value: AVG((128 * TCC_EA0_RDREQ_128B_sum + 64 * TCC_EA0_RDREQ_64B_sum
-            + 32 * TCC_EA0_RDREQ_32B_sum) / (End_Timestamp
-            - Start_Timestamp))
+          value: SUM(128 * TCC_EA0_RDREQ_128B_sum + 64 * TCC_EA0_RDREQ_64B_sum + 32 *
+            TCC_EA0_RDREQ_32B_sum) / SUM(End_Timestamp - Start_Timestamp)
           unit: GB/s
           peak: $hbmBandwidth
-          pop: ((100 * (AVG((128 * TCC_EA0_RDREQ_128B_sum + 64 * TCC_EA0_RDREQ_64B_sum
-            + 32 * TCC_EA0_RDREQ_32B_sum) / (End_Timestamp
-            - Start_Timestamp)))) / $hbmBandwidth)
+          pop: 100 * SUM(128 * TCC_EA0_RDREQ_128B_sum + 64 * TCC_EA0_RDREQ_64B_sum + 32 *
+            TCC_EA0_RDREQ_32B_sum) / SUM(End_Timestamp - Start_Timestamp) / $hbmBandwidth
         L2-Fabric Write BW:
-          value: AVG((((TCC_EA0_WRREQ_64B_sum * 64) + ((TCC_EA0_WRREQ_sum - TCC_EA0_WRREQ_64B_sum)
-            * 32)) / (End_Timestamp - Start_Timestamp)))
+          value: SUM(TCC_EA0_WRREQ_64B_sum * 64 + (TCC_EA0_WRREQ_sum - TCC_EA0_WRREQ_64B_sum) * 32)
+            / SUM(End_Timestamp - Start_Timestamp)
           unit: GB/s
           peak: $hbmBandwidth
-          pop: ((100 * AVG((((TCC_EA0_WRREQ_64B_sum * 64) + ((TCC_EA0_WRREQ_sum -
-            TCC_EA0_WRREQ_64B_sum) * 32)) / (End_Timestamp - Start_Timestamp)))) /
-            $hbmBandwidth)
+          pop: 100 * SUM(TCC_EA0_WRREQ_64B_sum * 64 + (TCC_EA0_WRREQ_sum - TCC_EA0_WRREQ_64B_sum) *
+            32) / SUM(End_Timestamp - Start_Timestamp) / $hbmBandwidth
         Kernel Time:
-          avg: AVG((End_Timestamp - Start_Timestamp))
+          avg: AVG(End_Timestamp - Start_Timestamp)
           unit: ns
           peak: N/A
           pop: N/A
@@ -91,12 +98,12 @@ Panel Config:
           peak: N/A
           pop: N/A
         SIMD Utilization:
-          value: AVG(100 * SQ_BUSY_CU_CYCLES / ($GRBM_GUI_ACTIVE_PER_XCD * $cu_per_gpu))
+          value: SUM(100 * SQ_BUSY_CU_CYCLES) / SUM($GRBM_GUI_ACTIVE_PER_XCD * $cu_per_gpu)
           unit: Percent
           peak: 100
-          pop: AVG(100 * SQ_BUSY_CU_CYCLES / ($GRBM_GUI_ACTIVE_PER_XCD * $cu_per_gpu))
+          pop: SUM(100 * SQ_BUSY_CU_CYCLES) / SUM($GRBM_GUI_ACTIVE_PER_XCD * $cu_per_gpu)
         Clock Rate:
-          value: (GRBM_GUI_ACTIVE_PER_XCD * $cu_per_gpu) / (End_Timestamp - Start_Timestamp)
-          unit: ns
+          value: GRBM_GUI_ACTIVE_PER_XCD * $cu_per_gpu / (End_Timestamp - Start_Timestamp)
+          unit: GHz
           peak: N/A
           pop: N/A

--- a/projects/rocprofiler-compute/src/rocprof_compute_tui/utils/gfx950/3300_compute_throughput.yaml
+++ b/projects/rocprofiler-compute/src/rocprof_compute_tui/utils/gfx950/3300_compute_throughput.yaml
@@ -4,61 +4,78 @@ Panel Config:
   id: 3300
   title: Compute Throughput
   metrics_description:
-    VALU FLOPs: 'The total floating-point operations executed per second on the VALU.
-      This is also presented as a percent of the peak theoretical FLOPs achievable
-      on the specific accelerator. Note: this does not include any floating-point
-      operations from MFMA instructions.'
-    VALU IOPs: 'The total integer operations executed per second on the VALU. This
-      is also presented as a percent of the peak theoretical IOPs achievable on the
-      specific accelerator. Note: this does not include any integer operations from
-      MFMA instructions.'
-    MFMA FLOPs (F8): The total number of 8-bit brain floating point MFMA operations
-      executed per second. This does not include any 16-bit brain floating point operations
-      from VALU instructions. This is also presented as a percent of the peak theoretical
-      F8 MFMA operations achievable on the specific accelerator. It is supported on
-      AMD Instinct MI300 series and later only.
-    MFMA FLOPs (BF16): 'The total number of 16-bit brain floating point MFMA operations
-      executed per second. Note: this does not include any 16-bit brain floating point
-      operations from VALU instructions. This is also presented as a percent of the
-      peak theoretical BF16 MFMA operations achievable on the specific accelerator.'
-    MFMA FLOPs (F16): 'The total number of 16-bit floating point MFMA operations executed
-      per second. Note: this does not include any 16-bit floating point operations
-      from VALU instructions. This is also presented as a percent of the peak theoretical
-      F16 MFMA operations achievable on the specific accelerator.'
-    MFMA FLOPs (F32): 'The total number of 32-bit floating point MFMA operations executed
-      per second. Note: this does not include any 32-bit floating point operations
-      from VALU instructions. This is also presented as a percent of the peak theoretical
-      F32 MFMA operations achievable on the specific accelerator.'
-    MFMA FLOPs (F64): 'The total number of 64-bit floating point MFMA operations executed
-      per second. Note: this does not include any 64-bit floating point operations
-      from VALU instructions. This is also presented as a percent of the peak theoretical
-      F64 MFMA operations achievable on the specific accelerator.'
-    MFMA IOPs (Int8): 'The total number of 8-bit integer MFMA operations executed
-      per second. Note: this does not include any 8-bit integer operations from VALU
-      instructions. This is also presented as a percent of the peak theoretical INT8
-      MFMA operations achievable on the specific accelerator.'
-    SALU Utilization: Indicates what percent of the kernel's duration the SALU was
-      busy executing instructions. Computed as the ratio of the total number of cycles
-      spent by the scheduler issuing SALU or SMEM instructions over the total CU cycles.
-    VALU Utilization: Indicates what percent of the kernel's duration the VALU was
-      busy executing instructions. Does not include VMEM operations. Computed as the
-      ratio of the total number of cycles spent by the scheduler issuing VALU instructions
-      over the total CU cycles.
-    MFMA Utilization: Indicates what percent of the kernel's duration the MFMA unit
-      was busy executing instructions. Computed as the ratio of the total number of
+    VALU FLOPs: >-
+      The total floating-point operations executed per second on the VALU. This
+      is also presented as a percent of the peak theoretical FLOPs achievable on
+      the specific accelerator. Note: this does not include any floating-point
+      operations from MFMA instructions.
+    VALU IOPs: >-
+      The total integer operations executed per second on the VALU. This is also
+      presented as a percent of the peak theoretical IOPs achievable on the
+      specific accelerator. Note: this does not include any integer operations
+      from MFMA instructions.
+    MFMA FLOPs (F8): >-
+      The total number of 8-bit brain floating point MFMA operations executed
+      per second. This does not include any 16-bit brain floating point
+      operations from VALU instructions. This is also presented as a percent of
+      the peak theoretical F8 MFMA operations achievable on the specific
+      accelerator. It is supported on AMD Instinct MI300 series and later only.
+    MFMA FLOPs (BF16): >-
+      The total number of 16-bit brain floating point MFMA operations executed
+      per second. Note: this does not include any 16-bit brain floating point
+      operations from VALU instructions. This is also presented as a percent of
+      the peak theoretical BF16 MFMA operations achievable on the specific
+      accelerator.
+    MFMA FLOPs (F16): >-
+      The total number of 16-bit floating point MFMA operations executed per
+      second. Note: this does not include any 16-bit floating point operations
+      from VALU instructions. This is also presented as a percent of the peak
+      theoretical F16 MFMA operations achievable on the specific accelerator.
+    MFMA FLOPs (F32): >-
+      The total number of 32-bit floating point MFMA operations executed per
+      second. Note: this does not include any 32-bit floating point operations
+      from VALU instructions. This is also presented as a percent of the peak
+      theoretical F32 MFMA operations achievable on the specific accelerator.
+    MFMA FLOPs (F64): >-
+      The total number of 64-bit floating point MFMA operations executed per
+      second. Note: this does not include any 64-bit floating point operations
+      from VALU instructions. This is also presented as a percent of the peak
+      theoretical F64 MFMA operations achievable on the specific accelerator.
+    MFMA IOPs (Int8): >-
+      The total number of 8-bit integer MFMA operations executed per second.
+      Note: this does not include any 8-bit integer operations from VALU
+      instructions. This is also presented as a percent of the peak theoretical
+      INT8 MFMA operations achievable on the specific accelerator.
+    SALU Utilization: >-
+      Indicates what percent of the kernel's duration the SALU was busy
+      executing instructions. Computed as the ratio of the total number of
+      cycles spent by the scheduler issuing SALU or SMEM instructions over the
+      total CU cycles.
+    VALU Utilization: >-
+      Indicates what percent of the kernel's duration the VALU was busy
+      executing instructions. Does not include VMEM operations. Computed as the
+      ratio of the total number of cycles spent by the scheduler issuing VALU
+      instructions over the total CU cycles.
+    MFMA Utilization: >-
+      Indicates what percent of the kernel's duration the MFMA unit was busy
+      executing instructions. Computed as the ratio of the total number of
       cycles the MFMA was busy over the total CU cycles.
-    VMEM Utilization: Indicates what percent of the kernel's duration the VMEM unit
-      was busy executing instructions, including both global/generic and spill/scratch
-      operations (see the VMEM instruction count metrics) for more detail). Does not
-      include VALU operations. Computed as the ratio of the total number of cycles
-      spent by the scheduler issuing VMEM instructions over the total CU cycles.
-    Branch Utilization: Indicates what percent of the kernel's duration the branch
-      unit was busy executing instructions. Computed as the ratio of the total number
-      of cycles spent by the scheduler issuing branch instructions over the total
+    VMEM Utilization: >-
+      Indicates what percent of the kernel's duration the VMEM unit was busy
+      executing instructions, including both global/generic and spill/scratch
+      operations (see the VMEM instruction count metrics) for more detail). Does
+      not include VALU operations. Computed as the ratio of the total number of
+      cycles spent by the scheduler issuing VMEM instructions over the total CU
+      cycles.
+    Branch Utilization: >-
+      Indicates what percent of the kernel's duration the branch unit was busy
+      executing instructions. Computed as the ratio of the total number of
+      cycles spent by the scheduler issuing branch instructions over the total
       CU cycles
-    IPC: The ratio of the total number of instructions executed on the CU over the
-      total active CU cycles. This is also presented as a percent of the peak theoretical
-      bandwidth achievable on the specific accelerator.
+    IPC: >-
+      The ratio of the total number of instructions executed on the CU over the
+      total active CU cycles. This is also presented as a percent of the peak
+      theoretical bandwidth achievable on the specific accelerator.
   data source:
   - metric_table:
       id: 3301
@@ -71,99 +88,98 @@ Panel Config:
         pop: Pct of Peak
       metric:
         VALU FLOPs:
-          value: AVG(((((64 * (((SQ_INSTS_VALU_ADD_F16 + SQ_INSTS_VALU_MUL_F16) +
-            SQ_INSTS_VALU_TRANS_F16) + (2 * SQ_INSTS_VALU_FMA_F16))) + (64 * (((SQ_INSTS_VALU_ADD_F32
-            + SQ_INSTS_VALU_MUL_F32) + SQ_INSTS_VALU_TRANS_F32) + (2 * SQ_INSTS_VALU_FMA_F32))))
-            + (64 * (((SQ_INSTS_VALU_ADD_F64 + SQ_INSTS_VALU_MUL_F64) + SQ_INSTS_VALU_TRANS_F64)
-            + (2 * SQ_INSTS_VALU_FMA_F64)))) / (End_Timestamp - Start_Timestamp)))
+          value: SUM(64 * (SQ_INSTS_VALU_ADD_F16 + SQ_INSTS_VALU_MUL_F16 + SQ_INSTS_VALU_TRANS_F16 +
+            2 * SQ_INSTS_VALU_FMA_F16) + 64 * (SQ_INSTS_VALU_ADD_F32 + SQ_INSTS_VALU_MUL_F32 +
+            SQ_INSTS_VALU_TRANS_F32 + 2 * SQ_INSTS_VALU_FMA_F32) + 64 * (SQ_INSTS_VALU_ADD_F64 +
+            SQ_INSTS_VALU_MUL_F64 + SQ_INSTS_VALU_TRANS_F64 + 2 * SQ_INSTS_VALU_FMA_F64)) /
+            SUM(End_Timestamp - Start_Timestamp)
           unit: GFLOP/s
-          peak: (((($max_sclk * $cu_per_gpu) * 64) * 2) / 1000)
-          pop: ((100 * AVG(((((64 * (((SQ_INSTS_VALU_ADD_F16 + SQ_INSTS_VALU_MUL_F16)
-            + SQ_INSTS_VALU_TRANS_F16) + (2 * SQ_INSTS_VALU_FMA_F16))) + (64 * (((SQ_INSTS_VALU_ADD_F32
-            + SQ_INSTS_VALU_MUL_F32) + SQ_INSTS_VALU_TRANS_F32) + (2 * SQ_INSTS_VALU_FMA_F32))))
-            + (64 * (((SQ_INSTS_VALU_ADD_F64 + SQ_INSTS_VALU_MUL_F64) + SQ_INSTS_VALU_TRANS_F64)
-            + (2 * SQ_INSTS_VALU_FMA_F64)))) / (End_Timestamp - Start_Timestamp))))
-            / (((($max_sclk * $cu_per_gpu) * 64) * 2) / 1000))
+          peak: $max_sclk * $cu_per_gpu * 64 * 2 / 1000
+          pop: 100 * SUM(64 * (SQ_INSTS_VALU_ADD_F16 + SQ_INSTS_VALU_MUL_F16 +
+            SQ_INSTS_VALU_TRANS_F16 + 2 * SQ_INSTS_VALU_FMA_F16) + 64 * (SQ_INSTS_VALU_ADD_F32 +
+            SQ_INSTS_VALU_MUL_F32 + SQ_INSTS_VALU_TRANS_F32 + 2 * SQ_INSTS_VALU_FMA_F32) + 64 *
+            (SQ_INSTS_VALU_ADD_F64 + SQ_INSTS_VALU_MUL_F64 + SQ_INSTS_VALU_TRANS_F64 + 2 *
+            SQ_INSTS_VALU_FMA_F64)) / SUM(End_Timestamp - Start_Timestamp) / ($max_sclk *
+            $cu_per_gpu * 64 * 2 / 1000)
         VALU IOPs:
-          value: AVG(((64 * (SQ_INSTS_VALU_INT32 + SQ_INSTS_VALU_INT64)) / (End_Timestamp
-            - Start_Timestamp)))
+          value: SUM(64 * (SQ_INSTS_VALU_INT32 + SQ_INSTS_VALU_INT64)) / SUM(End_Timestamp -
+            Start_Timestamp)
           unit: GIOP/s
-          peak: (((($max_sclk * $cu_per_gpu) * 64) * 2) / 1000)
-          pop: ((100 * AVG(((64 * (SQ_INSTS_VALU_INT32 + SQ_INSTS_VALU_INT64)) / (End_Timestamp
-            - Start_Timestamp)))) / (((($max_sclk * $cu_per_gpu) * 64) * 2) / 1000))
+          peak: $max_sclk * $cu_per_gpu * 64 * 2 / 1000
+          pop: 100 * SUM(64 * (SQ_INSTS_VALU_INT32 + SQ_INSTS_VALU_INT64)) / SUM(End_Timestamp -
+            Start_Timestamp) / ($max_sclk * $cu_per_gpu * 64 * 2 / 1000)
         MFMA FLOPs (F8):
-          value: AVG(((SQ_INSTS_VALU_MFMA_MOPS_F8 * 512) / (End_Timestamp - Start_Timestamp)))
+          value: SUM(SQ_INSTS_VALU_MFMA_MOPS_F8 * 512) / SUM(End_Timestamp - Start_Timestamp)
           unit: GFLOP/s
-          peak: ((($max_sclk * $cu_per_gpu) * 8192) / 1000)
-          pop: ((100 * AVG(((SQ_INSTS_VALU_MFMA_MOPS_F8 * 512) / (End_Timestamp -
-            Start_Timestamp)))) / ((($max_sclk * $cu_per_gpu) * 8192) / 1000))
+          peak: $max_sclk * $cu_per_gpu * 8192 / 1000
+          pop: 100 * SUM(SQ_INSTS_VALU_MFMA_MOPS_F8 * 512) / SUM(End_Timestamp - Start_Timestamp) /
+            ($max_sclk * $cu_per_gpu * 8192 / 1000)
         MFMA FLOPs (BF16):
-          value: AVG(((SQ_INSTS_VALU_MFMA_MOPS_BF16 * 512) / (End_Timestamp - Start_Timestamp)))
+          value: SUM(SQ_INSTS_VALU_MFMA_MOPS_BF16 * 512) / SUM(End_Timestamp - Start_Timestamp)
           unit: GFLOP/s
-          peak: ((($max_sclk * $cu_per_gpu) * 4096) / 1000)
-          pop: ((100 * AVG(((SQ_INSTS_VALU_MFMA_MOPS_BF16 * 512) / (End_Timestamp
-            - Start_Timestamp)))) / ((($max_sclk * $cu_per_gpu) * 4096) / 1000))
+          peak: $max_sclk * $cu_per_gpu * 4096 / 1000
+          pop: 100 * SUM(SQ_INSTS_VALU_MFMA_MOPS_BF16 * 512) / SUM(End_Timestamp - Start_Timestamp)
+            / ($max_sclk * $cu_per_gpu * 4096 / 1000)
         MFMA FLOPs (F16):
-          value: AVG(((SQ_INSTS_VALU_MFMA_MOPS_F16 * 512) / (End_Timestamp - Start_Timestamp)))
+          value: SUM(SQ_INSTS_VALU_MFMA_MOPS_F16 * 512) / SUM(End_Timestamp - Start_Timestamp)
           unit: GFLOP/s
-          peak: ((($max_sclk * $cu_per_gpu) * 4096) / 1000)
-          pop: ((100 * AVG(((SQ_INSTS_VALU_MFMA_MOPS_F16 * 512) / (End_Timestamp -
-            Start_Timestamp)))) / ((($max_sclk * $cu_per_gpu) * 4096) / 1000))
+          peak: $max_sclk * $cu_per_gpu * 4096 / 1000
+          pop: 100 * SUM(SQ_INSTS_VALU_MFMA_MOPS_F16 * 512) / SUM(End_Timestamp - Start_Timestamp) /
+            ($max_sclk * $cu_per_gpu * 4096 / 1000)
         MFMA FLOPs (F32):
-          value: AVG(((SQ_INSTS_VALU_MFMA_MOPS_F32 * 512) / (End_Timestamp - Start_Timestamp)))
+          value: SUM(SQ_INSTS_VALU_MFMA_MOPS_F32 * 512) / SUM(End_Timestamp - Start_Timestamp)
           unit: GFLOP/s
-          peak: ((($max_sclk * $cu_per_gpu) * 256) / 1000)
-          pop: ((100 * AVG(((SQ_INSTS_VALU_MFMA_MOPS_F32 * 512) / (End_Timestamp -
-            Start_Timestamp)))) / ((($max_sclk * $cu_per_gpu) * 256) / 1000))
+          peak: $max_sclk * $cu_per_gpu * 256 / 1000
+          pop: 100 * SUM(SQ_INSTS_VALU_MFMA_MOPS_F32 * 512) / SUM(End_Timestamp - Start_Timestamp) /
+            ($max_sclk * $cu_per_gpu * 256 / 1000)
         MFMA FLOPs (F64):
-          value: AVG(((SQ_INSTS_VALU_MFMA_MOPS_F64 * 512) / (End_Timestamp - Start_Timestamp)))
+          value: SUM(SQ_INSTS_VALU_MFMA_MOPS_F64 * 512) / SUM(End_Timestamp - Start_Timestamp)
           unit: GFLOP/s
-          peak: ((($max_sclk * $cu_per_gpu) * 128) / 1000)
-          pop: ((100 * AVG(((SQ_INSTS_VALU_MFMA_MOPS_F64 * 512) / (End_Timestamp -
-            Start_Timestamp)))) / ((($max_sclk * $cu_per_gpu) * 128) / 1000))
+          peak: $max_sclk * $cu_per_gpu * 128 / 1000
+          pop: 100 * SUM(SQ_INSTS_VALU_MFMA_MOPS_F64 * 512) / SUM(End_Timestamp - Start_Timestamp) /
+            ($max_sclk * $cu_per_gpu * 128 / 1000)
         MFMA FLOPs (F6F4):
-          value: AVG(((SQ_INSTS_VALU_MFMA_MOPS_F6F4 * 512) / (End_Timestamp - Start_Timestamp)))
+          value: SUM(SQ_INSTS_VALU_MFMA_MOPS_F6F4 * 512) / SUM(End_Timestamp - Start_Timestamp)
           unit: GFLOP/s
-          peak: ((($max_sclk * $cu_per_gpu) * 16834) / 1000)
-          pop: ((100 * AVG(((SQ_INSTS_VALU_MFMA_MOPS_F6F4 * 512) / (End_Timestamp
-            - Start_Timestamp)))) / ((($max_sclk * $cu_per_gpu) * 16834) / 1000))
+          peak: $max_sclk * $cu_per_gpu * 16834 / 1000
+          pop: 100 * SUM(SQ_INSTS_VALU_MFMA_MOPS_F6F4 * 512) / SUM(End_Timestamp - Start_Timestamp)
+            / ($max_sclk * $cu_per_gpu * 16834 / 1000)
         MFMA IOPs (Int8):
-          value: AVG(((SQ_INSTS_VALU_MFMA_MOPS_I8 * 512) / (End_Timestamp - Start_Timestamp)))
+          value: SUM(SQ_INSTS_VALU_MFMA_MOPS_I8 * 512) / SUM(End_Timestamp - Start_Timestamp)
           unit: GIOP/s
-          peak: ((($max_sclk * $cu_per_gpu) * 8192) / 1000)
-          pop: ((100 * AVG(((SQ_INSTS_VALU_MFMA_MOPS_I8 * 512) / (End_Timestamp -
-            Start_Timestamp)))) / ((($max_sclk * $cu_per_gpu) * 8192) / 1000))
+          peak: $max_sclk * $cu_per_gpu * 8192 / 1000
+          pop: 100 * SUM(SQ_INSTS_VALU_MFMA_MOPS_I8 * 512) / SUM(End_Timestamp - Start_Timestamp) /
+            ($max_sclk * $cu_per_gpu * 8192 / 1000)
         SALU Utilization:
-          value: AVG(((100 * SQ_ACTIVE_INST_SCA) / ($GRBM_GUI_ACTIVE_PER_XCD * $cu_per_gpu)))
+          value: SUM(100 * SQ_ACTIVE_INST_SCA) / SUM($GRBM_GUI_ACTIVE_PER_XCD * $cu_per_gpu)
           unit: Percent
           peak: 100
-          pop: AVG(((100 * SQ_ACTIVE_INST_SCA) / ($GRBM_GUI_ACTIVE_PER_XCD * $cu_per_gpu)))
+          pop: SUM(100 * SQ_ACTIVE_INST_SCA) / SUM($GRBM_GUI_ACTIVE_PER_XCD * $cu_per_gpu)
         VALU Utilization:
-          value: AVG(((100 * SQ_ACTIVE_INST_VALU) / ($GRBM_GUI_ACTIVE_PER_XCD * $cu_per_gpu)))
+          value: SUM(100 * SQ_ACTIVE_INST_VALU) / SUM($GRBM_GUI_ACTIVE_PER_XCD * $cu_per_gpu)
           unit: Percent
           peak: 100
-          pop: AVG(((100 * SQ_ACTIVE_INST_VALU) / ($GRBM_GUI_ACTIVE_PER_XCD * $cu_per_gpu)))
+          pop: SUM(100 * SQ_ACTIVE_INST_VALU) / SUM($GRBM_GUI_ACTIVE_PER_XCD * $cu_per_gpu)
         MFMA Utilization:
-          value: AVG(((100 * SQ_VALU_MFMA_BUSY_CYCLES) / (($GRBM_GUI_ACTIVE_PER_XCD
-            * $cu_per_gpu) * 4)))
+          value: SUM(100 * SQ_VALU_MFMA_BUSY_CYCLES) / SUM($GRBM_GUI_ACTIVE_PER_XCD * $cu_per_gpu *
+            4)
           unit: Percent
           peak: 100
-          pop: AVG(((100 * SQ_VALU_MFMA_BUSY_CYCLES) / (($GRBM_GUI_ACTIVE_PER_XCD
-            * $cu_per_gpu) * 4)))
+          pop: SUM(100 * SQ_VALU_MFMA_BUSY_CYCLES) / SUM($GRBM_GUI_ACTIVE_PER_XCD * $cu_per_gpu * 4)
         VMEM Utilization:
-          value: AVG((((100 * (SQ_ACTIVE_INST_FLAT+SQ_ACTIVE_INST_VMEM)) / $GRBM_GUI_ACTIVE_PER_XCD)
-            / $cu_per_gpu))
+          value: SUM(100 * (SQ_ACTIVE_INST_FLAT + SQ_ACTIVE_INST_VMEM)) /
+            SUM($GRBM_GUI_ACTIVE_PER_XCD * $cu_per_gpu)
           unit: Percent
           peak: 100
-          pop: AVG((((100 * (SQ_ACTIVE_INST_FLAT+SQ_ACTIVE_INST_VMEM)) / $GRBM_GUI_ACTIVE_PER_XCD)
-            / $cu_per_gpu))
+          pop: SUM(100 * (SQ_ACTIVE_INST_FLAT + SQ_ACTIVE_INST_VMEM)) / SUM($GRBM_GUI_ACTIVE_PER_XCD
+            * $cu_per_gpu)
         Branch Utilization:
-          value: AVG((((100 * SQ_ACTIVE_INST_MISC) / $GRBM_GUI_ACTIVE_PER_XCD) / $cu_per_gpu))
+          value: SUM(100 * SQ_ACTIVE_INST_MISC) / SUM($GRBM_GUI_ACTIVE_PER_XCD * $cu_per_gpu)
           unit: Percent
           peak: 100
-          pop: AVG((((100 * SQ_ACTIVE_INST_MISC) / $GRBM_GUI_ACTIVE_PER_XCD) / $cu_per_gpu))
+          pop: SUM(100 * SQ_ACTIVE_INST_MISC) / SUM($GRBM_GUI_ACTIVE_PER_XCD * $cu_per_gpu)
         IPC:
-          value: AVG((SQ_INSTS / SQ_BUSY_CU_CYCLES))
+          value: SUM(SQ_INSTS) / SUM(SQ_BUSY_CU_CYCLES)
           unit: Instr/cycle
           peak: 5
-          pop: ((100 * AVG((SQ_INSTS / SQ_BUSY_CU_CYCLES))) / 5)
+          pop: 100 * SUM(SQ_INSTS) / SUM(SQ_BUSY_CU_CYCLES) / 5

--- a/projects/rocprofiler-compute/src/rocprof_compute_tui/utils/gfx950/3400_memory_throughput.yaml
+++ b/projects/rocprofiler-compute/src/rocprof_compute_tui/utils/gfx950/3400_memory_throughput.yaml
@@ -4,53 +4,69 @@ Panel Config:
   id: 3400
   title: Memory Throughput
   metrics_description:
-    vL1D Cache BW: The number of bytes looked up in the vL1D cache as a result of
-      VMEM instructions per unit time. The number of bytes is calculated as the number
-      of cache lines requested multiplied by the cache line size. This value does
-      not consider partial requests, so e.g., if only a single value is requested
-      in a cache line, the data movement will still be counted as a full cache line.
-      This is also presented as a percent of the peak theoretical bandwidth achievable
+    vL1D Cache BW: >-
+      The number of bytes looked up in the vL1D cache as a result of VMEM
+      instructions per unit time. The number of bytes is calculated as the
+      number of cache lines requested multiplied by the cache line size. This
+      value does not consider partial requests, so e.g., if only a single value
+      is requested in a cache line, the data movement will still be counted as a
+      full cache line. This is also presented as a percent of the peak
+      theoretical bandwidth achievable on the specific accelerator.
+    vL1D Cache Utilization: >-
+      Indicates how busy the vL1D Cache RAM was during the kernel execution. The
+      number of cycles where the vL1D Cache RAM is actively processing any
+      request divided by the number of cycles where the vL1D is active.
+    Theoretical LDS Bandwidth: >-
+      Indicates the maximum amount of bytes that could have been loaded from,
+      stored to, or atomically updated in the LDS per unit time (see LDS
+      Bandwidth example for more detail).
+    LDS Utilization: >-
+      Indicates what percent of the kernel's duration the LDS was actively
+      executing instructions (including, but not limited to, load, store, atomic
+      and HIP's __shfl operations). Calculated as the ratio of the total number
+      of cycles LDS was active over the total CU cycles.
+    L2 Cache BW: >-
+      The number of bytes looked up in the L2 cache per unit time. The number of
+      bytes is calculated as the number of cache lines requested multiplied by
+      the cache line size. This value does not consider partial requests, so
+      e.g., if only a single value is requested in a cache line, the data
+      movement will still be counted as a full cache line. This is also
+      presented as a percent of the peak theoretical bandwidth achievable on the
+      specific accelerator.
+    L2 Cache Utilization: >-
+      The ratio of the number of cycles an L2 channel was active, summed over
+      all L2 channels on the accelerator over the total L2 cycles.
+    L2-Fabric Read BW: >-
+      The number of bytes read by the L2 over the Infinity Fabric™ interface per
+      unit time. This is also presented as a percent of the peak theoretical
+      bandwidth achievable on the specific accelerator.
+    L2-Fabric Write BW: >-
+      The number of bytes sent by the L2 over the Infinity Fabric interface by
+      write and atomic operations per unit time. This is also presented as a
+      percent of the peak theoretical bandwidth achievable on the specific
+      accelerator.
+    sL1D Cache BW: >-
+      The number of bytes looked up in the sL1D cache per unit time. This is
+      also presented as a percent of the peak theoretical bandwidth achievable
       on the specific accelerator.
-    vL1D Cache Utilization: Indicates how busy the vL1D Cache RAM was during the kernel execution.
-      The number of cycles where the vL1D Cache RAM is actively processing any request
-      divided by the number of cycles where the vL1D is active.
-    Theoretical LDS Bandwidth: Indicates the maximum amount of bytes that could have
-      been loaded from, stored to, or atomically updated in the LDS per unit time
-      (see LDS Bandwidth example for more detail).
-    LDS Utilization: Indicates what percent of the kernel's duration the LDS was actively
-      executing instructions (including, but not limited to, load, store, atomic and
-      HIP's __shfl operations). Calculated as the ratio of the total number of cycles
-      LDS was active over the total CU cycles.
-    L2 Cache BW: The number of bytes looked up in the L2 cache per unit time. The
-      number of bytes is calculated as the number of cache lines requested multiplied
-      by the cache line size. This value does not consider partial requests, so e.g.,
-      if only a single value is requested in a cache line, the data movement will
-      still be counted as a full cache line. This is also presented as a percent of
-      the peak theoretical bandwidth achievable on the specific accelerator.
-    L2 Cache Utilization: The ratio of the number of cycles an L2 channel was active, summed
-      over all L2 channels on the accelerator over the total L2 cycles.
-    L2-Fabric Read BW: "The number of bytes read by the L2 over the Infinity Fabric\u2122\
-      \ interface per unit time. This is also presented as a percent of the peak theoretical\
-      \ bandwidth achievable on the specific accelerator."
-    L2-Fabric Write BW: The number of bytes sent by the L2 over the Infinity Fabric
-      interface by write and atomic operations per unit time. This is also presented
-      as a percent of the peak theoretical bandwidth achievable on the specific accelerator.
-    sL1D Cache BW: The number of bytes looked up in the sL1D cache per unit time.
-      This is also presented as a percent of the peak theoretical bandwidth achievable
-      on the specific accelerator.
-    L1I BW: The percent of L1I requests that hit on a previously loaded line the cache.
-      Calculated as the ratio of the number of L1I requests that hit over the number
-      of all L1I requests.
-    Address Processing Unit Busy: Percent of the total CU cycles the address processor
-      was busy.
-    Data-Return Busy: Percent of the total CU cycles the data-return unit was busy
-      processing or waiting on data to return to the CU.
-    L1I-L2 Bandwidth: Total number of bytes transferred across L1I - L2 interface
-      divided by total duration.
-    sL1D-L2 BW: "The total number of bytes read from, written to, or atomically updated\
-      \ across the sL1D\u2194L2 interface, divided by total duration. Note that sL1D\
-      \ writes and atomics are typically unused on current CDNA accelerators, so in\
-      \ the majority of cases this can be interpreted as an sL1D\u2192L2 read bandwidth."
+    L1I BW: >-
+      The percent of L1I requests that hit on a previously loaded line the
+      cache. Calculated as the ratio of the number of L1I requests that hit over
+      the number of all L1I requests.
+    Address Processing Unit Busy: >-
+      Percent of the total CU cycles the address processor was busy.
+    Data-Return Busy: >-
+      Percent of the total CU cycles the data-return unit was busy processing or
+      waiting on data to return to the CU.
+    L1I-L2 Bandwidth: >-
+      Total number of bytes transferred across L1I - L2 interface divided by
+      total duration.
+    sL1D-L2 BW: >-
+      The total number of bytes read from, written to, or atomically updated
+      across the sL1D↔L2 interface, divided by total duration. Note that sL1D
+      writes and atomics are typically unused on current CDNA accelerators, so
+      in the majority of cases this can be interpreted as an sL1D→L2 read
+      bandwidth.
   data source:
   - metric_table:
       id: 3401
@@ -63,98 +79,94 @@ Panel Config:
         pop: Pct of Peak
       metric:
         vL1D Cache BW:
-          value: AVG(((TCP_TOTAL_CACHE_ACCESSES_sum * 128) / (End_Timestamp - Start_Timestamp)))
+          value: SUM(TCP_TOTAL_CACHE_ACCESSES_sum * 128) / SUM(End_Timestamp - Start_Timestamp)
           unit: GB/s
-          peak: ((($max_sclk / 1000) * 128) * $cu_per_gpu)
-          pop: ((100 * AVG(((TCP_TOTAL_CACHE_ACCESSES_sum * 128) / (End_Timestamp
-            - Start_Timestamp)))) / ((($max_sclk / 1000) * 128) * $cu_per_gpu))
+          peak: $max_sclk / 1000 * 128 * $cu_per_gpu
+          pop: 100 * SUM(TCP_TOTAL_CACHE_ACCESSES_sum * 128) / SUM(End_Timestamp - Start_Timestamp)
+            / ($max_sclk / 1000 * 128 * $cu_per_gpu)
         vL1D Cache Utilization:
-          value: AVG((((TCP_GATE_EN2_sum * 100) / TCP_GATE_EN1_sum) if (TCP_GATE_EN1_sum
-            != 0) else None))
+          value: SUM(TCP_GATE_EN2_sum * 100) / SUM(TCP_GATE_EN1_sum)
           unit: Percent
           peak: 100
           pop: None
         Theoretical LDS Bandwidth:
-          value: AVG(((((SQ_LDS_IDX_ACTIVE - SQ_LDS_BANK_CONFLICT) * 4) * TO_INT($lds_banks_per_cu))
-            / (End_Timestamp - Start_Timestamp)))
+          value: SUM((SQ_LDS_IDX_ACTIVE - SQ_LDS_BANK_CONFLICT) * 4 * TO_INT($lds_banks_per_cu)) /
+            SUM(End_Timestamp - Start_Timestamp)
           unit: GB/s
-          peak: (($max_sclk * $cu_per_gpu) * 0.128)
-          pop: AVG((((((SQ_LDS_IDX_ACTIVE - SQ_LDS_BANK_CONFLICT) * 4) * TO_INT($lds_banks_per_cu))
-            / (End_Timestamp - Start_Timestamp)) / (($max_sclk * $cu_per_gpu) * 0.00128)))
+          peak: $max_sclk * $cu_per_gpu * 0.128
+          pop: 100 * SUM((SQ_LDS_IDX_ACTIVE - SQ_LDS_BANK_CONFLICT) * 4 * TO_INT($lds_banks_per_cu))
+            / SUM(End_Timestamp - Start_Timestamp) / ($max_sclk * $cu_per_gpu * 0.128)
         LDS Utilization:
-          value: AVG(((100 * SQ_LDS_IDX_ACTIVE) / ($GRBM_GUI_ACTIVE_PER_XCD * $cu_per_gpu)))
+          value: SUM(100 * SQ_LDS_IDX_ACTIVE) / SUM($GRBM_GUI_ACTIVE_PER_XCD * $cu_per_gpu)
           unit: Percent
           peak: 100
           pop: None
         L2 Cache Hit Rate:
-          value: AVG((((100 * TCC_HIT_sum) / (TCC_HIT_sum + TCC_MISS_sum)) if ((TCC_HIT_sum
-            + TCC_MISS_sum) != 0) else None))
+          value: SUM(100 * TCC_HIT_sum) / SUM(TCC_HIT_sum + TCC_MISS_sum)
           unit: Percent
           peak: 100
-          pop: AVG((((100 * TCC_HIT_sum) / (TCC_HIT_sum + TCC_MISS_sum)) if ((TCC_HIT_sum
-            + TCC_MISS_sum) != 0) else None))
+          pop: SUM(100 * TCC_HIT_sum) / SUM(TCC_HIT_sum + TCC_MISS_sum)
         L2 Cache BW:
-          value: AVG(((TCC_REQ_sum * 128) / (End_Timestamp - Start_Timestamp)))
+          value: SUM(TCC_REQ_sum * 128) / SUM(End_Timestamp - Start_Timestamp)
           unit: GB/s
-          peak: ((($max_sclk / 1000) * 128) * TO_INT($total_l2_chan))
-          pop: ((100 * AVG(((TCC_REQ_sum * 128) / (End_Timestamp - Start_Timestamp))))
-            / ((($max_sclk / 1000) * 128) * TO_INT($total_l2_chan)))
+          peak: $max_sclk / 1000 * 128 * TO_INT($total_l2_chan)
+          pop: 100 * SUM(TCC_REQ_sum * 128) / SUM(End_Timestamp - Start_Timestamp) / ($max_sclk /
+            1000 * 128 * TO_INT($total_l2_chan))
         L2 Cache Utilization:
-          value: AVG(((TCC_BUSY_sum * 100) / (TO_INT($total_l2_chan) * $GRBM_GUI_ACTIVE_PER_XCD)))
+          value: SUM(TCC_BUSY_sum * 100) / SUM(TO_INT($total_l2_chan) * $GRBM_GUI_ACTIVE_PER_XCD)
           unit: Percent
           peak: 100
           pop: None
         L2-Fabric Read BW:
-          value: AVG((((TCC_EA0_RDREQ_32B_sum * 32) + (TCC_EA0_RDREQ_64B_sum * 64)
-            + (TCC_EA0_RDREQ_128B_sum * 128)) / (End_Timestamp - Start_Timestamp)))
+          value: SUM(TCC_EA0_RDREQ_32B_sum * 32 + TCC_EA0_RDREQ_64B_sum * 64 +
+            TCC_EA0_RDREQ_128B_sum * 128) / SUM(End_Timestamp - Start_Timestamp)
           unit: GB/s
           peak: $hbmBandwidth
-          pop: ((100 * (AVG((128 * TCC_BUBBLE_sum + 64 * (TCC_EA0_RDREQ_sum - TCC_BUBBLE_sum
-            - TCC_EA0_RDREQ_32B_sum) + 32 * TCC_EA0_RDREQ_32B_sum) / (End_Timestamp
-            - Start_Timestamp)))) / $hbmBandwidth)
+          pop: 100 * SUM(128 * TCC_BUBBLE_sum + 64 * (TCC_EA0_RDREQ_sum - TCC_BUBBLE_sum -
+            TCC_EA0_RDREQ_32B_sum) + 32 * TCC_EA0_RDREQ_32B_sum) / SUM(End_Timestamp -
+            Start_Timestamp) / $hbmBandwidth
         L2-Fabric Write BW:
-          value: AVG((((TCC_EA0_WRREQ_64B_sum * 64) + ((TCC_EA0_WRREQ_sum - TCC_EA0_WRREQ_64B_sum)
-            * 32)) / (End_Timestamp - Start_Timestamp)))
+          value: SUM(TCC_EA0_WRREQ_64B_sum * 64 + (TCC_EA0_WRREQ_sum - TCC_EA0_WRREQ_64B_sum) * 32)
+            / SUM(End_Timestamp - Start_Timestamp)
           unit: GB/s
           peak: $hbmBandwidth
-          pop: ((100 * AVG((((TCC_EA0_WRREQ_64B_sum * 64) + ((TCC_EA0_WRREQ_sum -
-            TCC_EA0_WRREQ_64B_sum) * 32)) / (End_Timestamp - Start_Timestamp)))) /
-            $hbmBandwidth)
+          pop: 100 * SUM(TCC_EA0_WRREQ_64B_sum * 64 + (TCC_EA0_WRREQ_sum - TCC_EA0_WRREQ_64B_sum) *
+            32) / SUM(End_Timestamp - Start_Timestamp) / $hbmBandwidth
         sL1D Cache BW:
-          value: AVG(((SQC_DCACHE_REQ / (End_Timestamp - Start_Timestamp)) * 64))
+          value: SUM(SQC_DCACHE_REQ * 64) / SUM(End_Timestamp - Start_Timestamp)
           unit: GB/s
-          peak: ((($max_sclk / 1000) * 64) * $sqc_per_gpu)
-          pop: ((100 * AVG(((SQC_DCACHE_REQ / (End_Timestamp - Start_Timestamp)) *
-            64))) / ((($max_sclk / 1000) * 64) * $sqc_per_gpu))
+          peak: $max_sclk / 1000 * 64 * $sqc_per_gpu
+          pop: 100 * SUM(SQC_DCACHE_REQ * 64) / SUM(End_Timestamp - Start_Timestamp) / ($max_sclk /
+            1000 * 64 * $sqc_per_gpu)
         L1I Hit Rate:
-          value: AVG(((100 * SQC_ICACHE_HITS) / (SQC_ICACHE_HITS + SQC_ICACHE_MISSES)))
+          value: SUM(100 * SQC_ICACHE_HITS) / SUM(SQC_ICACHE_HITS + SQC_ICACHE_MISSES)
           unit: Percent
           peak: 100
-          pop: AVG(((100 * SQC_ICACHE_HITS) / (SQC_ICACHE_HITS + SQC_ICACHE_MISSES)))
+          pop: SUM(100 * SQC_ICACHE_HITS) / SUM(SQC_ICACHE_HITS + SQC_ICACHE_MISSES)
         L1I BW:
-          value: AVG(((SQC_ICACHE_REQ / (End_Timestamp - Start_Timestamp)) * 64))
+          value: SUM(SQC_ICACHE_REQ * 64) / SUM(End_Timestamp - Start_Timestamp)
           unit: GB/s
-          peak: ((($max_sclk / 1000) * 64) * $sqc_per_gpu)
-          pop: ((100 * AVG(((SQC_ICACHE_REQ / (End_Timestamp - Start_Timestamp)) *
-            64))) / ((($max_sclk / 1000) * 64) * $sqc_per_gpu))
+          peak: $max_sclk / 1000 * 64 * $sqc_per_gpu
+          pop: 100 * SUM(SQC_ICACHE_REQ * 64) / SUM(End_Timestamp - Start_Timestamp) / ($max_sclk /
+            1000 * 64 * $sqc_per_gpu)
         Address Processing Unit Busy:
-          avg: AVG(((100 * TA_TA_BUSY_sum) / ($GRBM_GUI_ACTIVE_PER_XCD * $cu_per_gpu)))
+          avg: SUM(100 * TA_TA_BUSY_sum) / SUM($GRBM_GUI_ACTIVE_PER_XCD * $cu_per_gpu)
           unit: Percent
           peak: 100
           pop: N/A
         Data-Return Busy:
-          avg: AVG(((100 * TD_TD_BUSY_sum) / ($GRBM_GUI_ACTIVE_PER_XCD * $cu_per_gpu)))
+          avg: SUM(100 * TD_TD_BUSY_sum) / SUM($GRBM_GUI_ACTIVE_PER_XCD * $cu_per_gpu)
           unit: Percent
           peak: 100
           pop: N/A
         L1I-L2 Bandwidth:
-          avg: AVG(((SQC_TC_INST_REQ * 64) / (End_Timestamp - Start_Timestamp)))
+          avg: SUM(SQC_TC_INST_REQ * 64) / SUM(End_Timestamp - Start_Timestamp)
           unit: GB/s
           peak: N/A
           pop: N/A
         sL1D-L2 BW:
-          value: AVG(((((SQC_TC_DATA_READ_REQ + SQC_TC_DATA_WRITE_REQ + SQC_TC_DATA_ATOMIC_REQ)
-            * 64)) / (End_Timestamp - Start_Timestamp)))
+          value: SUM((SQC_TC_DATA_READ_REQ + SQC_TC_DATA_WRITE_REQ + SQC_TC_DATA_ATOMIC_REQ) * 64) /
+            SUM(End_Timestamp - Start_Timestamp)
           unit: GB/s
           peak: N/A
           pop: N/A


### PR DESCRIPTION
## Motivation

The TUI YAML files (`src/rocprof_compute_tui/utils/{gfx942,gfx950}/*.yaml`) had inconsistent description quoting, incorrect `AVG(A/B)` aggregation semantics, unnecessary `if X else None` guards, excessive parentheses, and wrong Clock Rate units.

## Technical Details

1. Metric descriptions: use `>-` block scalars
2. `AVG(A/B)` → `SUM(A)/SUM(B)`
3. Remove `if X else None`
4. Remove redundant brackets
5. Fix Clock Rate unit

## JIRA ID

AIPROFCOMP-168
AIPROFCOMP-485

## Test Plan

- [x] unit test passing

## Test Result

- [x] unit test passing

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
