### PR TITLE
[rocprofiler-sdk]: correct memory copy direction classification

### DIFF
--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/hsa/async_copy.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/hsa/async_copy.cpp
@@ -41,6 +41,7 @@
 #include <rocprofiler-sdk/hsa/api_id.h>
 #include <rocprofiler-sdk/hsa/table_id.h>
 #include <rocprofiler-sdk/cxx/constants.hpp>
+#include <rocprofiler-sdk/cxx/operators.hpp>
 
 #include <glog/logging.h>
 #include <hsa/amd_hsa_signal.h>
@@ -577,7 +578,63 @@ async_copy_impl(Args... args)
                 if(_rocp_dst_agent->type == ROCPROFILER_AGENT_TYPE_CPU)
                     _direction = ROCPROFILER_MEMORY_COPY_DEVICE_TO_HOST;
                 else if(_rocp_dst_agent->type == ROCPROFILER_AGENT_TYPE_GPU)
-                    _direction = ROCPROFILER_MEMORY_COPY_DEVICE_TO_DEVICE;
+                {
+                    // When both agents are GPU type, the HSA agent handles alone are not
+                    // sufficient to determine the true transfer direction. OpenMP RTL (libomptarget)
+                    // pins host memory and registers it under a GPU agent, causing HSA to report
+                    // src_agent == dst_agent (both GPU) even for HOST<->DEVICE transfers.
+                    // Use hsa_amd_pointer_info to inspect the actual memory type of each pointer:
+                    //   HSA_EXT_POINTER_TYPE_UNKNOWN (0) = unregistered host memory (e.g. MI300X APU)
+                    //   HSA_EXT_POINTER_TYPE_LOCKED  (2) = pinned host memory (discrete GPU)
+                    //   HSA_EXT_POINTER_TYPE_HSA     (1) = true device (GPU) memory
+                    // This fixes ROCM-9863: OpenMP offload transfers incorrectly reported as
+                    // MEMORY_COPY_DEVICE_TO_DEVICE instead of HOST_TO_DEVICE / DEVICE_TO_HOST.
+                    constexpr auto dst_addr_idx_inner = arg_indices<OpIdx>::dst_address_idx;
+                    constexpr auto src_addr_idx_inner = arg_indices<OpIdx>::src_address_idx;
+                    const void* _src_ptr = compute_address(std::get<src_addr_idx_inner>(_tied_args)).ptr;
+                    const void* _dst_ptr = compute_address(std::get<dst_addr_idx_inner>(_tied_args)).ptr;
+
+                    auto _src_info = hsa_amd_pointer_info_t{};
+                    auto _dst_info = hsa_amd_pointer_info_t{};
+                    _src_info.size = sizeof(hsa_amd_pointer_info_t);
+                    _dst_info.size = sizeof(hsa_amd_pointer_info_t);
+
+                    auto* _ptr_info_fn = get_amd_ext_table()->hsa_amd_pointer_info_fn;
+
+                    // When both HSA agents are GPU type, the agent handles alone are not
+                    // sufficient to determine the true transfer direction. OpenMP RTL (libomptarget)
+                    // allocates a host-accessible staging buffer and registers it under the GPU
+                    // agent, making both src and dst appear as GPU-type agents.
+                    //
+                    // The hsa_amd_pointer_info_t::agentOwner field reveals which HSA agent
+                    // actually owns each allocation. Pinned host buffers created by OpenMP RTL
+                    // have a different agentOwner than the GPU agent used for the copy.
+                    //
+                    // Fix for ROCM-9863: compare agentOwner of src and dst against the GPU
+                    // agent handle to correctly classify HOST_TO_DEVICE and DEVICE_TO_HOST.
+                    bool _src_query_ok = false, _dst_query_ok = false;
+                    if(_ptr_info_fn)
+                    {
+                        _src_query_ok = (_ptr_info_fn(_src_ptr, &_src_info, nullptr, nullptr, nullptr)
+                                         == HSA_STATUS_SUCCESS);
+                        _dst_query_ok = (_ptr_info_fn(_dst_ptr, &_dst_info, nullptr, nullptr, nullptr)
+                                         == HSA_STATUS_SUCCESS);
+                    }
+
+                    // A pointer is considered GPU device memory if its agentOwner matches
+                    // the GPU agent handle passed to the copy operation.
+                    const bool _src_is_device = _src_query_ok &&
+                        (_src_info.agentOwner == _hsa_dst_agent);
+                    const bool _dst_is_device = _dst_query_ok &&
+                        (_dst_info.agentOwner == _hsa_dst_agent);
+
+                    if(!_src_is_device && _dst_is_device)
+                        _direction = ROCPROFILER_MEMORY_COPY_HOST_TO_DEVICE;
+                    else if(_src_is_device && !_dst_is_device)
+                        _direction = ROCPROFILER_MEMORY_COPY_DEVICE_TO_HOST;
+                    else
+                        _direction = ROCPROFILER_MEMORY_COPY_DEVICE_TO_DEVICE;
+                }
                 else
                 {
                     ROCP_CI_LOG(WARNING)


### PR DESCRIPTION
## Motivation
When both HSA agents are identified as GPU type, leverage hsa_amd_pointer_info() to determine the actual ownership of each pointer and accurately infer the transfer direction. This resolves ROCM-9863, where OpenMP offload memory copy operations were previously misclassified. Refer to ROCM-9863 for additional details.

## Technical Details

When both HSA agents appear as GPU type, use hsa_amd_pointer_info() to determine the true ownership of each pointer and classify the transfer direction accordingly.
For full technical details, please refer to ROCM-9863.

## JIRA ID

Resolves ROCM-9863

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
