### PR TITLE
[AMD-SMI] Fix amdsmi linking by prioritizing /lib64 over /lib dir

### DIFF
--- a/projects/amdsmi/goamdsmi_shim/CMakeLists.txt
+++ b/projects/amdsmi/goamdsmi_shim/CMakeLists.txt
@@ -90,8 +90,11 @@ add_library(${GOAMDSMI_SHIM_TARGET} SHARED ${go_amd_smi_sources} ${go_amd_smi_he
 target_link_libraries(${GOAMDSMI_SHIM_TARGET} pthread rt m)
 
 target_link_libraries(${GOAMDSMI_SHIM_TARGET} amd_smi)
-target_link_libraries(${GOAMDSMI_SHIM_TARGET} -L${AMDSMI_DIR}/lib64)
-target_link_libraries(${GOAMDSMI_SHIM_TARGET} -L${AMDSMI_DIR}/lib)
+# Use GNUInstallDirs' CMAKE_INSTALL_LIBDIR so the search path follows the
+# system convention (lib64 on 64-bit RPM-based distros, lib elsewhere).
+# This avoids picking up 32-bit libraries from /lib on systems that have
+# both /lib and /lib64 populated.
+target_link_libraries(${GOAMDSMI_SHIM_TARGET} -L${AMDSMI_DIR}/${CMAKE_INSTALL_LIBDIR})
 
 ## Set the VERSION and SOVERSION values
 set_property(TARGET ${GOAMDSMI_SHIM_TARGET} PROPERTY SOVERSION "${VERSION_MAJOR}")

--- a/projects/amdsmi/goamdsmi_shim/CMakeLists.txt
+++ b/projects/amdsmi/goamdsmi_shim/CMakeLists.txt
@@ -89,12 +89,36 @@ add_library(${GOAMDSMI_SHIM_TARGET} SHARED ${go_amd_smi_sources} ${go_amd_smi_he
 
 target_link_libraries(${GOAMDSMI_SHIM_TARGET} pthread rt m)
 
+if(NOT TARGET amd_smi)
+    # Standalone build (not add_subdirectory'd by the parent project): consume
+    # the exported amd_smi CMake config package. The imported target records
+    # the actual installed library path and include dir, so there is no need to
+    # guess lib vs lib64 (which previously pulled in a 32-bit libamd_smi on
+    # systems where CMAKE_INSTALL_LIBDIR disagreed with the install layout).
+    find_package(
+        amd_smi
+        CONFIG
+        REQUIRED
+        HINTS ${AMDSMI_DIR} $ENV{ROCM_PATH} /opt/rocm
+        PATH_SUFFIXES lib/cmake/amd_smi lib64/cmake/amd_smi
+    )
+endif()
+
+# Link the amd_smi target (in-tree target or the config package's imported
+# target). It propagates both the link path and the public include dir.
 target_link_libraries(${GOAMDSMI_SHIM_TARGET} amd_smi)
-# Use GNUInstallDirs' CMAKE_INSTALL_LIBDIR so the search path follows the
-# system convention (lib64 on 64-bit RPM-based distros, lib elsewhere).
-# This avoids picking up 32-bit libraries from /lib on systems that have
-# both /lib and /lib64 populated.
-target_link_libraries(${GOAMDSMI_SHIM_TARGET} -L${AMDSMI_DIR}/${CMAKE_INSTALL_LIBDIR})
+
+# The smiwrapper OBJECT library compiles the same source and #includes
+# <amd_smi/amdsmi.h>. Cross-directory target_link_libraries requires CMP0079
+# (CMake 3.13+), so instead give it amd_smi's include dirs directly, which is
+# allowed cross-directory. In-tree builds also inherit these from the parent
+# project's directory-scope include_directories().
+if(TARGET go_amd_smi_)
+    get_target_property(_amd_smi_includes amd_smi INTERFACE_INCLUDE_DIRECTORIES)
+    if(_amd_smi_includes)
+        target_include_directories(go_amd_smi_ PRIVATE ${_amd_smi_includes})
+    endif()
+endif()
 
 ## Set the VERSION and SOVERSION values
 set_property(TARGET ${GOAMDSMI_SHIM_TARGET} PROPERTY SOVERSION "${VERSION_MAJOR}")

--- a/projects/amdsmi/goamdsmi_shim/CMakeLists.txt
+++ b/projects/amdsmi/goamdsmi_shim/CMakeLists.txt
@@ -90,8 +90,8 @@ add_library(${GOAMDSMI_SHIM_TARGET} SHARED ${go_amd_smi_sources} ${go_amd_smi_he
 target_link_libraries(${GOAMDSMI_SHIM_TARGET} pthread rt m)
 
 target_link_libraries(${GOAMDSMI_SHIM_TARGET} amd_smi)
-target_link_libraries(${GOAMDSMI_SHIM_TARGET} -L${AMDSMI_DIR}/lib)
 target_link_libraries(${GOAMDSMI_SHIM_TARGET} -L${AMDSMI_DIR}/lib64)
+target_link_libraries(${GOAMDSMI_SHIM_TARGET} -L${AMDSMI_DIR}/lib)
 
 ## Set the VERSION and SOVERSION values
 set_property(TARGET ${GOAMDSMI_SHIM_TARGET} PROPERTY SOVERSION "${VERSION_MAJOR}")


### PR DESCRIPTION
Linking of amdsmi can fail on systems which have both the 32 and 64 bit libraries installed
because amdsmi try to first link libraries from /lib-directory and only after that from the /lib64 directory.

In many Linux systems the 32 bit version of libraries are installed to /lib-directory and
64-bit versions to /lib64 directory. If lib-dir is specified before the lib64 dir then the
32-bit version of libraries are tried to be linked instead of the 64 bit versions of the libraries
on systems which have both library versions available.

Fix is simply the swap the order so that the llibraries from ib64 directory are tried to
be linked before the libraries in lib-directory.

This fixes a following type of amdsmi linking error:

0.1     : && /therock/build/compiler/amd-llvm/dist/lib/llvm/bin/clang
-fPIC -O3 -DNDEBUG  -L/therock/build/third-party/sysdeps/linux/libdrm/build/stage/lib/rocm_sysdeps/lib
-Wl,-rpath-link,/therock/build/third-party/sysdeps/linux/libdrm/build/stage/lib/rocm_sysdeps/lib
-L/therock/build/third-party/sysdeps/linux/libmnl/build/stage/lib/rocm_sysdeps/lib
-Wl,-rpath-link,/therock/build/third-party/sysdeps/linux/libmnl/build/stage/lib/rocm_sysdeps/lib
-L/therock/build/third-party/sysdeps/linux/libnl/build/stage/lib/rocm_sysdeps/lib
-Wl,-rpath-link,/therock/build/third-party/sysdeps/linux/libnl/build/stage/lib/rocm_sysdeps/lib -Wl,--build-id=sha1
-Xlinker --dependency-file=goamdsmi_shim/CMakeFiles/goamdsmi_shim64.dir/link.d -shared
-Wl,-soname,libgoamdsmi_shim64.so.1 -o goamdsmi_shim/libgoamdsmi_shim64.so.1.0
goamdsmi_shim/CMakeFiles/goamdsmi_shim64.dir/smiwrapper/amdsmi_go_shim.c.o
-Wl,-rpath,/therock/build/core/amdsmi/build/src:  -lpthread  -lrt  -lm
src/libamd_smi.so.26.4.0  -L/lib  -L/lib64 && :

0.1     ld.lld: error: /usr/lib/gcc/x86_64-linux-gnu/12/../../../../lib64/crti.o is incompatible with elf32-i386
0.1     ld.lld: error: /therock/build/compiler/amd-llvm/dist/lib/llvm/lib/clang/23/lib/linux/clang_rt.crtbegin-x86_64.o
        is incompatible with elf32-i386
