### PR TITLE
[rocSHMEM] Replace flat_store instructions with their global_store counter parts

### DIFF
--- a/projects/rocshmem/src/assembly.hpp
+++ b/projects/rocshmem/src/assembly.hpp
@@ -207,7 +207,7 @@ __device__ __forceinline__ void store_asm(uint8_t* val, [[maybe_unused]] uint8_t
 #endif
 #if defined(__gfx942__) || defined(__gfx950__)
       int16_t val16{*(reinterpret_cast<int16_t*>(val))};
-      asm volatile("global_store_short %0, %1, off sc0 sc1" : : "v"(dst), "v"(val16));
+      asm volatile("global_store_short %0, %1, off sc0 sc1 nt" : : "v"(dst), "v"(val16));
 #endif
 #if defined(__gfx1100__)
       int32_t val32{*(reinterpret_cast<int32_t*>(val))};
@@ -215,7 +215,7 @@ __device__ __forceinline__ void store_asm(uint8_t* val, [[maybe_unused]] uint8_t
 #endif
 #if defined(__gfx1201__)
       int32_t val32{*(reinterpret_cast<int32_t*>(val))};
-      asm volatile("global_store_b16 %0, %1, off scope:SCOPE_SYS" : : "v"(dst), "v"(val32));
+      asm volatile("global_store_b16 %0, %1, off scope:SCOPE_SYS th:TH_STORE_NT" : : "v"(dst), "v"(val32));
 #endif
       break;
     }
@@ -225,10 +225,10 @@ __device__ __forceinline__ void store_asm(uint8_t* val, [[maybe_unused]] uint8_t
       asm volatile("global_store_dword %0, %1, off glc slc" : : "v"(dst), "v"(val32));
 #endif
 #if defined(__gfx942__) || defined(__gfx950__)
-      asm volatile("global_store_dword %0, %1, off sc0 sc1" : : "v"(dst), "v"(val32));
+      asm volatile("global_store_dword %0, %1, off sc0 sc1 nt" : : "v"(dst), "v"(val32));
 #endif
 #if defined(__gfx1201__)
-      asm volatile("global_store_b32 %0, %1, off scope:SCOPE_SYS" : : "v"(dst), "v"(val32));
+      asm volatile("global_store_b32 %0, %1, off scope:SCOPE_SYS th:TH_STORE_NT" : : "v"(dst), "v"(val32));
 #endif
       break;
     }
@@ -238,10 +238,10 @@ __device__ __forceinline__ void store_asm(uint8_t* val, [[maybe_unused]] uint8_t
       asm volatile("global_store_dwordx2 %0, %1, off glc slc" : : "v"(dst), "v"(val64));
 #endif
 #if defined(__gfx942__) || defined(__gfx950__)
-      asm volatile("global_store_dwordx2 %0, %1, off sc0 sc1" : : "v"(dst), "v"(val64));
+      asm volatile("global_store_dwordx2 %0, %1, off sc0 sc1 nt" : : "v"(dst), "v"(val64));
 #endif
 #if defined(__gfx1201__)
-      asm volatile("global_store_b64 %0, %1, off scope:SCOPE_SYS" : : "v"(dst), "v"(val64));
+      asm volatile("global_store_b64 %0, %1, off scope:SCOPE_SYS th:TH_STORE_NT" : : "v"(dst), "v"(val64));
 #endif
       break;
     }
@@ -251,10 +251,10 @@ __device__ __forceinline__ void store_asm(uint8_t* val, [[maybe_unused]] uint8_t
       asm volatile("global_store_dwordx4 %0, %1, off glc slc" : : "v"(dst), "v"(val128));
 #endif
 #if defined(__gfx942__) || defined(__gfx950__)
-      asm volatile("global_store_dwordx4 %0, %1, off sc0 sc1" : : "v"(dst), "v"(val128));
+      asm volatile("global_store_dwordx4 %0, %1, off sc0 sc1 nt" : : "v"(dst), "v"(val128));
 #endif
 #if defined(__gfx1201__)
-      asm volatile("global_store_b128 %0, %1, off scope:SCOPE_SYS" : : "v"(dst), "v"(val128));
+      asm volatile("global_store_b128 %0, %1, off scope:SCOPE_SYS th:TH_STORE_NT" : : "v"(dst), "v"(val128));
 #endif
       break;
     }

--- a/projects/rocshmem/src/assembly.hpp
+++ b/projects/rocshmem/src/assembly.hpp
@@ -203,58 +203,58 @@ __device__ __forceinline__ void store_asm(uint8_t* val, [[maybe_unused]] uint8_t
     case 2: {
 #if defined(__gfx90a__)
       int16_t val16{*(reinterpret_cast<int16_t*>(val))};
-      asm volatile("flat_store_short %0 %1 glc slc" : : "v"(dst), "v"(val16));
+      asm volatile("global_store_short %0, %1, off glc slc" : : "v"(dst), "v"(val16));
 #endif
 #if defined(__gfx942__) || defined(__gfx950__)
       int16_t val16{*(reinterpret_cast<int16_t*>(val))};
-      asm volatile("flat_store_short %0 %1 sc0 sc1" : : "v"(dst), "v"(val16));
+      asm volatile("global_store_short %0, %1, off sc0 sc1" : : "v"(dst), "v"(val16));
 #endif
 #if defined(__gfx1100__)
       int32_t val32{*(reinterpret_cast<int32_t*>(val))};
-      asm volatile("flat_store_short %0 %1 glc slc" : : "v"(dst), "v"(val32));
+      asm volatile("global_store_short %0, %1, off glc slc" : : "v"(dst), "v"(val32));
 #endif
 #if defined(__gfx1201__)
       int32_t val32{*(reinterpret_cast<int32_t*>(val))};
-      asm volatile("flat_store_b16 %0 %1 scope:SCOPE_SYS" : : "v"(dst), "v"(val32));
+      asm volatile("global_store_b16 %0, %1, off scope:SCOPE_SYS" : : "v"(dst), "v"(val32));
 #endif
       break;
     }
     case 4: {
       [[maybe_unused]] int32_t val32{*(reinterpret_cast<int32_t*>(val))};
 #if defined(__gfx90a__) || defined(__gfx1100__)
-      asm volatile("flat_store_dword %0 %1 glc slc" : : "v"(dst), "v"(val32));
+      asm volatile("global_store_dword %0, %1, off glc slc" : : "v"(dst), "v"(val32));
 #endif
 #if defined(__gfx942__) || defined(__gfx950__)
-      asm volatile("flat_store_dword %0 %1 sc0 sc1" : : "v"(dst), "v"(val32));
+      asm volatile("global_store_dword %0, %1, off sc0 sc1" : : "v"(dst), "v"(val32));
 #endif
 #if defined(__gfx1201__)
-      asm volatile("flat_store_b32 %0 %1 scope:SCOPE_SYS" : : "v"(dst), "v"(val32));
+      asm volatile("global_store_b32 %0, %1, off scope:SCOPE_SYS" : : "v"(dst), "v"(val32));
 #endif
       break;
     }
     case 8: {
       [[maybe_unused]] int64_t val64{*(reinterpret_cast<int64_t*>(val))};
 #if defined(__gfx90a__) || defined(__gfx1100__)
-      asm volatile("flat_store_dwordx2 %0 %1 glc slc" : : "v"(dst), "v"(val64));
+      asm volatile("global_store_dwordx2 %0, %1, off glc slc" : : "v"(dst), "v"(val64));
 #endif
 #if defined(__gfx942__) || defined(__gfx950__)
-      asm volatile("flat_store_dwordx2 %0 %1 sc0 sc1" : : "v"(dst), "v"(val64));
+      asm volatile("global_store_dwordx2 %0, %1, off sc0 sc1" : : "v"(dst), "v"(val64));
 #endif
 #if defined(__gfx1201__)
-      asm volatile("flat_store_b64 %0 %1 scope:SCOPE_SYS" : : "v"(dst), "v"(val64));
+      asm volatile("global_store_b64 %0, %1, off scope:SCOPE_SYS" : : "v"(dst), "v"(val64));
 #endif
       break;
     }
     case 16: {
       [[maybe_unused]] __int128_t val128{*(reinterpret_cast<__int128_t*>(val))};
 #if defined(__gfx90a__) || defined(__gfx1100__)
-      asm volatile("flat_store_dwordx4 %0 %1 glc slc" : : "v"(dst), "v"(val128));
+      asm volatile("global_store_dwordx4 %0, %1, off glc slc" : : "v"(dst), "v"(val128));
 #endif
 #if defined(__gfx942__) || defined(__gfx950__)
-      asm volatile("flat_store_dwordx4 %0 %1 sc0 sc1" : : "v"(dst), "v"(val128));
+      asm volatile("global_store_dwordx4 %0, %1, off sc0 sc1" : : "v"(dst), "v"(val128));
 #endif
 #if defined(__gfx1201__)
-      asm volatile("flat_store_b128 %0 %1 scope:SCOPE_SYS" : : "v"(dst), "v"(val128));
+      asm volatile("global_store_b128 %0, %1, off scope:SCOPE_SYS" : : "v"(dst), "v"(val128));
 #endif
       break;
     }

--- a/projects/rocshmem/src/assembly.hpp
+++ b/projects/rocshmem/src/assembly.hpp
@@ -207,7 +207,7 @@ __device__ __forceinline__ void store_asm(uint8_t* val, [[maybe_unused]] uint8_t
 #endif
 #if defined(__gfx942__) || defined(__gfx950__)
       int16_t val16{*(reinterpret_cast<int16_t*>(val))};
-      asm volatile("global_store_short %0, %1, off sc0 sc1 nt" : : "v"(dst), "v"(val16));
+      asm volatile("global_store_short %0, %1, off sc0 sc1" : : "v"(dst), "v"(val16));
 #endif
 #if defined(__gfx1100__)
       int32_t val32{*(reinterpret_cast<int32_t*>(val))};
@@ -215,7 +215,7 @@ __device__ __forceinline__ void store_asm(uint8_t* val, [[maybe_unused]] uint8_t
 #endif
 #if defined(__gfx1201__)
       int32_t val32{*(reinterpret_cast<int32_t*>(val))};
-      asm volatile("global_store_b16 %0, %1, off scope:SCOPE_SYS th:TH_STORE_NT" : : "v"(dst), "v"(val32));
+      asm volatile("global_store_b16 %0, %1, off scope:SCOPE_SYS" : : "v"(dst), "v"(val32));
 #endif
       break;
     }
@@ -225,10 +225,10 @@ __device__ __forceinline__ void store_asm(uint8_t* val, [[maybe_unused]] uint8_t
       asm volatile("global_store_dword %0, %1, off glc slc" : : "v"(dst), "v"(val32));
 #endif
 #if defined(__gfx942__) || defined(__gfx950__)
-      asm volatile("global_store_dword %0, %1, off sc0 sc1 nt" : : "v"(dst), "v"(val32));
+      asm volatile("global_store_dword %0, %1, off sc0 sc1" : : "v"(dst), "v"(val32));
 #endif
 #if defined(__gfx1201__)
-      asm volatile("global_store_b32 %0, %1, off scope:SCOPE_SYS th:TH_STORE_NT" : : "v"(dst), "v"(val32));
+      asm volatile("global_store_b32 %0, %1, off scope:SCOPE_SYS" : : "v"(dst), "v"(val32));
 #endif
       break;
     }
@@ -238,10 +238,10 @@ __device__ __forceinline__ void store_asm(uint8_t* val, [[maybe_unused]] uint8_t
       asm volatile("global_store_dwordx2 %0, %1, off glc slc" : : "v"(dst), "v"(val64));
 #endif
 #if defined(__gfx942__) || defined(__gfx950__)
-      asm volatile("global_store_dwordx2 %0, %1, off sc0 sc1 nt" : : "v"(dst), "v"(val64));
+      asm volatile("global_store_dwordx2 %0, %1, off sc0 sc1" : : "v"(dst), "v"(val64));
 #endif
 #if defined(__gfx1201__)
-      asm volatile("global_store_b64 %0, %1, off scope:SCOPE_SYS th:TH_STORE_NT" : : "v"(dst), "v"(val64));
+      asm volatile("global_store_b64 %0, %1, off scope:SCOPE_SYS" : : "v"(dst), "v"(val64));
 #endif
       break;
     }
@@ -251,10 +251,10 @@ __device__ __forceinline__ void store_asm(uint8_t* val, [[maybe_unused]] uint8_t
       asm volatile("global_store_dwordx4 %0, %1, off glc slc" : : "v"(dst), "v"(val128));
 #endif
 #if defined(__gfx942__) || defined(__gfx950__)
-      asm volatile("global_store_dwordx4 %0, %1, off sc0 sc1 nt" : : "v"(dst), "v"(val128));
+      asm volatile("global_store_dwordx4 %0, %1, off sc0 sc1" : : "v"(dst), "v"(val128));
 #endif
 #if defined(__gfx1201__)
-      asm volatile("global_store_b128 %0, %1, off scope:SCOPE_SYS th:TH_STORE_NT" : : "v"(dst), "v"(val128));
+      asm volatile("global_store_b128 %0, %1, off scope:SCOPE_SYS" : : "v"(dst), "v"(val128));
 #endif
       break;
     }

--- a/projects/rocshmem/src/assembly.hpp
+++ b/projects/rocshmem/src/assembly.hpp
@@ -201,20 +201,19 @@ __device__ __forceinline__ void store_asm(uint8_t* val, [[maybe_unused]] uint8_t
                                           int size) {
   switch (size) {
     case 2: {
+      [[maybe_unused]] int16_t val16{*(reinterpret_cast<int16_t*>(val))};
 #if defined(__gfx90a__)
-      int16_t val16{*(reinterpret_cast<int16_t*>(val))};
       asm volatile("global_store_short %0, %1, off glc slc" : : "v"(dst), "v"(val16));
 #endif
 #if defined(__gfx942__) || defined(__gfx950__)
-      int16_t val16{*(reinterpret_cast<int16_t*>(val))};
       asm volatile("global_store_short %0, %1, off sc0 sc1" : : "v"(dst), "v"(val16));
 #endif
 #if defined(__gfx1100__)
-      int32_t val32{*(reinterpret_cast<int32_t*>(val))};
+      int32_t val32{static_cast<int32_t>(val16)};
       asm volatile("global_store_short %0, %1, off glc slc" : : "v"(dst), "v"(val32));
 #endif
 #if defined(__gfx1201__)
-      int32_t val32{*(reinterpret_cast<int32_t*>(val))};
+      int32_t val32{static_cast<int32_t>(val16)};
       asm volatile("global_store_b16 %0, %1, off scope:SCOPE_SYS" : : "v"(dst), "v"(val32));
 #endif
       break;


### PR DESCRIPTION
## Motivation

Current store_asm implementations across gfx9 and gfx11/12 use `flat_store_*` instructions. While these work for global memory, they are technically not precise and mask potential bugs. This change migrates all architectures to explicit `global_store_*` instructions.

flat_store_* resolves the target address space (global, LDS, scratch) at runtime from the pointer tag. This means:

- A caller could accidentally pass an LDS or scratch pointer to `store_asm` (via memcpy_lane, memcpy_wg, or memcpy_wave, all of which accept unqualified void*) and the instruction would silently succeed.
- The cache-bypass modifiers (glc slc / sc0 sc1) applied by store_asm are meaningless for LDS, so such a call would carry the cost of a system-scope store.


This change will not introduce any behavioral change for the intended use case (global memory stores) and it provides with minor performance improvement: `global_store` skips the flat address-space disambiguation performed by `flat_store`

To the team:

Accidental LDS/scratch misuse will fault with this change. (which should be this way) Any memory arguments to store_asm should be located on global memory. 

## Technical Details

Also, I tested non-temporal hints for this PR, and for majority of the cases (roughly 60%), it resulted in slightly worse performance. So I removed those ones.

## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->
AIROCSHMEM-366

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

Put and get tests pass. DeepEP `LowLatency` test also passes
