### PR TITLE
hip to look at <rocm_root>/lib/llvm/bin for llvm tools

### DIFF
--- a/projects/clr/hipamd/src/CMakeLists.txt
+++ b/projects/clr/hipamd/src/CMakeLists.txt
@@ -194,6 +194,10 @@ if(__HIP_ENABLE_PCH)
   # find_package(LLVM) returns the lib/cmake/llvm location. We require the root.
   if(NOT DEFINED HIP_LLVM_ROOT)
     set(HIP_LLVM_ROOT "${LLVM_DIR}/../../..")
+    if(NOT EXISTS "${HIP_LLVM_ROOT}/bin/clang")
+      # required because Rock installs llvm to /opt/rocm/lib/llvm
+      set(HIP_LLVM_ROOT "${LLVM_DIR}/../../llvm")
+    endif()
   endif()
 
   execute_process(COMMAND sh -c "${CMAKE_CURRENT_SOURCE_DIR}/hip_embed_pch.sh ${HIP_COMMON_INCLUDE_DIR} ${PROJECT_BINARY_DIR}/include ${PROJECT_SOURCE_DIR}/include ${HIP_LLVM_ROOT}" COMMAND_ECHO STDERR RESULT_VARIABLE EMBED_PCH_RC WORKING_DIRECTORY ${CMAKE_BINARY_DIR})


### PR DESCRIPTION
## Motivation
Rock llvm tools path has been changed. This causes build failures in HIP locally.

## Technical Details
previously llvm tools would be present in
<rocm_root>/llvm/bin but now with Rock it is
<rocm_root>/lib/llvm/bin


## JIRA ID
NA

## Test Plan
Local hip build passes with Rock as baseline. This only fixes HIP local build

## Test Result
Local hip build passes with Rock as baseline. This only fixes HIP local build

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
