### PR TITLE
[rocprofiler-systems]: Update binutils to 2.46

### DIFF
--- a/projects/rocprofiler-systems/cmake/DyninstLibIberty.cmake
+++ b/projects/rocprofiler-systems/cmake/DyninstLibIberty.cmake
@@ -85,8 +85,8 @@ else()
         PREFIX ${_li_root}
         URL
             ${DYNINST_BINUTILS_DOWNLOAD_URL}
-            http://ftpmirror.gnu.org/gnu/binutils/binutils-2.46.0.tar.gz
-            http://mirrors.kernel.org/sourceware/binutils/releases/binutils-2.46.0.tar.gz
+            https://ftpmirror.gnu.org/gnu/binutils/binutils-2.46.0.tar.gz
+            https://mirrors.kernel.org/sourceware/binutils/releases/binutils-2.46.0.tar.gz
         BUILD_IN_SOURCE 1
         CONFIGURE_COMMAND
             ${CMAKE_COMMAND} -E env CC=${CMAKE_C_COMPILER} CFLAGS=-fPIC\ -O3\ -Wno-error

--- a/projects/rocprofiler-systems/cmake/DyninstLibIberty.cmake
+++ b/projects/rocprofiler-systems/cmake/DyninstLibIberty.cmake
@@ -89,10 +89,8 @@ else()
             http://mirrors.kernel.org/sourceware/binutils/releases/binutils-2.46.0.tar.gz
         BUILD_IN_SOURCE 1
         CONFIGURE_COMMAND
-            ${CMAKE_COMMAND} -E env CC=${CMAKE_C_COMPILER}
-            CFLAGS=-fPIC\ -O3\ -Wno-maybe-uninitialized\ -Wno-format-truncation
-            CXX=${CMAKE_CXX_COMPILER}
-            CXXFLAGS=-fPIC\ -O3\ -Wno-maybe-uninitialized\ -Wno-format-truncation
+            ${CMAKE_COMMAND} -E env CC=${CMAKE_C_COMPILER} CFLAGS=-fPIC\ -O3\ -Wno-error
+            CXX=${CMAKE_CXX_COMPILER} CXXFLAGS=-fPIC\ -O3\ -Wno-error
             <SOURCE_DIR>/configure --prefix=${_li_root}
         BUILD_COMMAND make
         INSTALL_COMMAND ""

--- a/projects/rocprofiler-systems/cmake/DyninstLibIberty.cmake
+++ b/projects/rocprofiler-systems/cmake/DyninstLibIberty.cmake
@@ -85,13 +85,15 @@ else()
         PREFIX ${_li_root}
         URL
             ${DYNINST_BINUTILS_DOWNLOAD_URL}
-            http://ftpmirror.gnu.org/gnu/binutils/binutils-with-gold-2.46.tar.gz
-            http://mirrors.kernel.org/sourceware/binutils/releases/binutils-with-gold-2.46.tar.gz
+            http://ftpmirror.gnu.org/gnu/binutils/binutils-2.46.0.tar.gz
+            http://mirrors.kernel.org/sourceware/binutils/releases/binutils-2.46.0.tar.gz
         BUILD_IN_SOURCE 1
         CONFIGURE_COMMAND
-            ${CMAKE_COMMAND} -E env CC=${CMAKE_C_COMPILER} CFLAGS=-fPIC\ -O3
-            CXX=${CMAKE_CXX_COMPILER} CXXFLAGS=-fPIC\ -O3 <SOURCE_DIR>/configure
-            --prefix=${_li_root}
+            ${CMAKE_COMMAND} -E env CC=${CMAKE_C_COMPILER}
+            CFLAGS=-fPIC\ -O3\ -Wno-maybe-uninitialized\ -Wno-format-truncation
+            CXX=${CMAKE_CXX_COMPILER}
+            CXXFLAGS=-fPIC\ -O3\ -Wno-maybe-uninitialized\ -Wno-format-truncation
+            <SOURCE_DIR>/configure --prefix=${_li_root}
         BUILD_COMMAND make
         INSTALL_COMMAND ""
     )

--- a/projects/rocprofiler-systems/cmake/DyninstLibIberty.cmake
+++ b/projects/rocprofiler-systems/cmake/DyninstLibIberty.cmake
@@ -85,8 +85,8 @@ else()
         PREFIX ${_li_root}
         URL
             ${DYNINST_BINUTILS_DOWNLOAD_URL}
-            http://ftpmirror.gnu.org/gnu/binutils/binutils-2.45.tar.gz
-            http://mirrors.kernel.org/sourceware/binutils/releases/binutils-2.45.tar.gz
+            http://ftpmirror.gnu.org/gnu/binutils/binutils-with-gold-2.46.tar.gz
+            http://mirrors.kernel.org/sourceware/binutils/releases/binutils-with-gold-2.46.tar.gz
         BUILD_IN_SOURCE 1
         CONFIGURE_COMMAND
             ${CMAKE_COMMAND} -E env CC=${CMAKE_C_COMPILER} CFLAGS=-fPIC\ -O3


### PR DESCRIPTION
## Motivation

Update binutils to 2.46

## Technical Details

- Update `DyninstLibIberty.cmake` to use binutils v2.46: http://ftpmirror.gnu.org/gnu/binutils/binutils-2.46.0.tar.gz.
- Updated `timemory` submodule to https://github.com/ROCm/timemory/commit/cfceb3061543f8782a4524f809bee9fceee54551.

## JIRA ID

- AIPROFSYST-357
- ROCM-20843

## Test Plan

Manual ctest validation.

## Test Result

Pass

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
