### PR TITLE
[rocjitsu] Handle LDS bit in buffer_load_dword for direct-to-LDS loads

### DIFF
--- a/experimental/rocjitsu/lib/python/amdisa/codegen.py
+++ b/experimental/rocjitsu/lib/python/amdisa/codegen.py
@@ -4178,6 +4178,34 @@ class CodeGenerator:
         esz, ne = sem.elem_size, sem.num_elems
         sc0, sc1, nt = self._coherency_exprs()
         addr_fn = 'mtbuf_calculate_addresses' if cls == 'tbuffer_load' else 'mubuf_calculate_addresses'
+        # Direct-to-LDS: when the lds bit is set, data goes to LDS instead of VGPRs.
+        if cls == 'buffer_load':
+            L.append('  if (inst_.lds) {')
+            L.append(f'    std::array<uint64_t, 64> addrs = {{}};')
+            L.append(f'    uint64_t lane_mask = 0;')
+            L.append(f'    {addr_fn}(inst_, wf, addrs, lane_mask);')
+            L.append(f'    uint32_t m0 = wf.m0();')
+            L.append(f'    auto &lds = wf.cu().lds();')
+            L.append(f'    auto *memory = wf.cu().memory();')
+            L.append(f'    for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {{')
+            L.append(f'      if (!(lane_mask & (1ULL << lane))) continue;')
+            L.append(f'      uint32_t voffset = wf.cu().read_vgpr(wf.vgpr_alloc().base + inst_.vdata, lane);')
+            L.append(f'      uint32_t lds_addr = m0 + voffset;')
+            for i in range(ne):
+                offset = i * esz
+                L.append(f'      {{')
+                L.append(f'        uint32_t val = memory->read32(addrs[lane] + {offset});')
+                L.append(f'        lds.write32(lds_addr + {offset}, val);')
+                L.append(f'      }}')
+            L.append(f'    }}')
+            L.append(f'    auto d = std::make_unique<amdgpu::VectorMemState>(amdgpu::GLOBAL_MEM);')
+            L.append(f'    d->lane_mask = 0;')
+            L.append(f'    d->is_load = true;')
+            L.append(f'    d->num_elems = 0;')
+            L.append(f'    d->elem_size = 0;')
+            L.append(f'    set_data(std::move(d));')
+            L.append(f'    return;')
+            L.append('  }')
         L.append('  auto d = std::make_unique<amdgpu::VectorMemState>(amdgpu::GLOBAL_MEM);')
         L.append(f'  d->dst_reg_base = wf.vgpr_alloc().base + inst_.vdata;')
         L.append(f'  d->elem_size = {esz};')

--- a/experimental/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/cdna4/mubuf.cpp
+++ b/experimental/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/cdna4/mubuf.cpp
@@ -468,6 +468,40 @@ BufferLoadDwordMubuf::BufferLoadDwordMubuf(const MachineInst *inst)
 }
 
 void BufferLoadDwordMubuf::execute_impl(amdgpu::Wavefront &wf) {
+  if (inst_.lds) {
+    std::array<uint64_t, 64> addrs = {};
+    uint64_t lane_mask = 0;
+    mubuf_calculate_addresses(inst_, wf, addrs, lane_mask);
+    uint32_t m0 = wf.m0();
+    auto &lds = wf.cu().lds();
+    auto *memory = wf.cu().memory();
+    for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
+      if (!(lane_mask & (1ULL << lane))) continue;
+      uint32_t voffset = wf.cu().read_vgpr(wf.vgpr_alloc().base + inst_.vdata, lane);
+      uint32_t lds_addr = m0 + voffset;
+      uint32_t val = memory->read32(addrs[lane]);
+      lds.write32(lds_addr, val);
+    }
+    // Register GLOBAL_TO_LDS event for race detection.
+    if (auto *rs = wf.race_state()) {
+      std::vector<uint32_t> ldsAddrs(wf.wf_size());
+      for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
+        uint32_t voff = wf.cu().read_vgpr(wf.vgpr_alloc().base + inst_.vdata, lane);
+        ldsAddrs[lane] = m0 + voff;
+      }
+      rs->registerLdsEvent(static_cast<int>(wf.pc),
+                           raceemulator::MemoryEventType::GLOBAL_TO_LDS,
+                           /*registers=*/{}, lane_mask, wf.wf_size(),
+                           ldsAddrs, /*bytesPerLane=*/4);
+    }
+    auto d = std::make_unique<amdgpu::VectorMemState>(amdgpu::GLOBAL_MEM);
+    d->lane_mask = 0;
+    d->is_load = true;
+    d->num_elems = 0;
+    d->elem_size = 0;
+    set_data(std::move(d));
+    return;
+  }
   auto d = std::make_unique<amdgpu::VectorMemState>(amdgpu::GLOBAL_MEM);
   d->dst_reg_base = wf.vgpr_alloc().base + inst_.vdata;
   d->elem_size = 4;


### PR DESCRIPTION
While testing race condition integration for buffer loads that go 'direct-to-lds' (DTL) from global memory, I found that the LDS bit was missing. 

Claude didn't run the python script, but actually updated the generated C++ directly. The reason given:
> The codegen script (python -m amdisa --gen-all) requires ISA XML spec files (e.g. amdgpu_isa_cdna4.xml) as input. These files aren't in the rocm-systems repo — the README shows path/to/amdgpu_isa_cdna4.xml as a placeholder. I searched the repo and found no .xml files under the lib/python/amdisa/ directory. They
  presumably come from an external source (AMD internal ISA spec database or a separate repo).
  
 Which I haven't verified. 