### PR TITLE
ionic: add ionicdv_create_qp_ex extended QP creation support

### DIFF
--- a/projects/rccl/ext-src/rocm_netib.patch
+++ b/projects/rccl/ext-src/rocm_netib.patch
@@ -259,7 +259,7 @@
 +    qpInitAttrEx.comp_mask = IBV_QP_INIT_ATTR_PD;
 +    qpInitAttrEx.pd        = base->pd;
 +
-+    struct ionic_qp_init_attr_ex ionicQpAttr;
++    struct ionic_dv_qp_init_attr_ex ionicQpAttr;
 +    memset(&ionicQpAttr, 0, sizeof(ionicQpAttr));
 +    ionicQpAttr.comp_mask    = IONIC_DV_QP_INIT_ATTR_MASK_FLAGS;
 +    ionicQpAttr.ionic_flags  = IONIC_DV_CREATE_QP_TYPE_RCCL;

--- a/projects/rccl/ext-src/rocm_netib.patch
+++ b/projects/rccl/ext-src/rocm_netib.patch
@@ -187,7 +187,7 @@
  };
  static_assert((offsetof(struct ncclIbRecvComm, remFifo) % 32) == 0, "ncclIbRecvComm fifo must be 32-byte aligned");
  
-@@ -1446,20 +1531,87 @@ ncclResult_t ncclIbDestroyBase(struct ncclIbNetCommDevBase* base) {
+@@ -1446,20 +1531,89 @@ ncclResult_t ncclIbDestroyBase(struct ncclIbNetCommDevBase* base) {
    return ncclSuccess;
  }
  
@@ -252,21 +252,23 @@
 +    qpInitAttrEx.qp_context = qpInitAttr.qp_context;
 +    qpInitAttrEx.send_cq   = qpInitAttr.send_cq;
 +    qpInitAttrEx.recv_cq   = qpInitAttr.recv_cq;
++    qpInitAttrEx.srq       = qpInitAttr.srq;
 +    qpInitAttrEx.qp_type   = qpInitAttr.qp_type;
 +    qpInitAttrEx.cap       = qpInitAttr.cap;
++    qpInitAttrEx.sq_sig_all = qpInitAttr.sq_sig_all;
 +    qpInitAttrEx.comp_mask = IBV_QP_INIT_ATTR_PD;
 +    qpInitAttrEx.pd        = base->pd;
 +
 +    struct ionic_qp_init_attr_ex ionicQpAttr;
 +    memset(&ionicQpAttr, 0, sizeof(ionicQpAttr));
-+    ionicQpAttr.comp_mask    = IONIC_QP_INIT_ATTR_MASK_FLAGS;
-+    ionicQpAttr.ionic_flags  = IONIC_CREATE_QP_TYPE_RCCL;
++    ionicQpAttr.comp_mask    = IONIC_DV_QP_INIT_ATTR_MASK_FLAGS;
++    ionicQpAttr.ionic_flags  = IONIC_DV_CREATE_QP_TYPE_RCCL;
 +    if (data_qp) {
-+      ionicQpAttr.ionic_flags |= IONIC_CREATE_QP_RCCL_DATA;
++      ionicQpAttr.ionic_flags |= IONIC_DV_CREATE_QP_RCCL_DATA;
 +    }
-+    ionicQpAttr.ionic_flags |= IONIC_CREATE_QP_RCCL_RDFENCE;
++    ionicQpAttr.ionic_flags |= IONIC_DV_CREATE_QP_RCCL_RDFENCE;
 +    if (rcclCtsOffloadEnabled) {
-+      ionicQpAttr.ionic_flags |= IONIC_CREATE_QP_RCCL_RX_OFFLOAD;
++      ionicQpAttr.ionic_flags |= IONIC_DV_CREATE_QP_RCCL_RX_OFFLOAD;
 +    }
 +    NCCLCHECK(wrap_ionicdv_create_qp_ex(base->pd->context, &qpInitAttrEx, &ionicQpAttr, &qp->qp));
 +  } else {
@@ -278,7 +280,7 @@
    struct ibv_qp_attr qpAttr;
    memset(&qpAttr, 0, sizeof(struct ibv_qp_attr));
    qpAttr.qp_state = IBV_QPS_INIT;
-@@ -1469,6 +1621,9 @@ ncclResult_t ncclIbCreateQp(uint8_t ib_port, struct ncclIbNetCommDevBase* base,
+@@ -1469,6 +1623,9 @@ ncclResult_t ncclIbCreateQp(uint8_t ib_port, struct ncclIbNetCommDevBase* base,
    NCCLCHECK(wrap_ibv_modify_qp(qp->qp, &qpAttr, IBV_QP_STATE | IBV_QP_PKEY_INDEX | IBV_QP_PORT | IBV_QP_ACCESS_FLAGS));
    TRACE(NCCL_NET, "NET/IB : ncclIbCreateQp port=%d dev=%d devName=%s ndevs=%d nmdevs=%d qpn=%u pkey=%u pd=%p",
      ib_port, base->ibDevN, ncclIbDevs[base->ibDevN].devName, ncclNIbDevs, ncclNMergedIbDevs, qp->qp->qp_num, qpAttr.pkey_index, base->pd);
@@ -288,7 +290,7 @@
    return ncclSuccess;
  }
  
-@@ -1552,16 +1707,21 @@ fail:
+@@ -1552,16 +1709,21 @@ fail:
    goto exit;
  }
  
@@ -312,7 +314,7 @@
    if (stage->state == ncclIbCommStateConnect)      goto ib_connect_check;
    if (stage->state == ncclIbCommStateSendDevList)  goto ib_send_dev_list;
    if (stage->state == ncclIbCommStateRecvDevList)  goto ib_recv_dev_list;
-@@ -1622,7 +1782,8 @@ ib_recv_dev_list:
+@@ -1622,7 +1784,8 @@ ib_recv_dev_list:
  
    // Read isP2p from handle
    isP2p = handle->isP2p;
@@ -322,7 +324,7 @@
    comm->base.nqps = ncclIbCalculateNqps(isP2p, comm->base.vProps.ndevs, 
                                           remoteVProps.ndevs, __func__);
  
-@@ -1643,7 +1804,7 @@ ib_recv_dev_list:
+@@ -1643,7 +1806,7 @@ ib_recv_dev_list:
    for (int q = 0; q < comm->base.nqps; q++) {
      ncclIbSendCommDev* commDev = comm->devs + devIndex;
      ncclIbDev* ibDev = ncclIbDevs + commDev->base.ibDevN;
@@ -331,7 +333,7 @@
      comm->base.qps[q].devIndex = devIndex;
      meta.qpInfo[q].qpn      = comm->base.qps[q].qp->qp_num;
      meta.qpInfo[q].devIndex = comm->base.qps[q].devIndex;
-@@ -1668,7 +1829,11 @@ ib_recv_dev_list:
+@@ -1668,7 +1831,11 @@ ib_recv_dev_list:
      devInfo->lid           = ibDev->portAttr.lid;
      devInfo->ibv_dev_index = commDev->base.ibDevN;
      // Prepare my fifo
@@ -344,7 +346,7 @@
      devInfo->fifoRkey = commDev->fifoMr->rkey;
  
      // Pack local GID info
-@@ -1711,7 +1876,11 @@ ib_recv_dev_list:
+@@ -1711,7 +1878,11 @@ ib_recv_dev_list:
      }
    }
    config = (ncclNetCommConfig_t*)ctx;
@@ -357,7 +359,7 @@
    meta.sl = (ncclParamIbSl() != -1) ? ncclParamIbSl() : (config && config->trafficClass != NCCL_NET_TRAFFIC_CLASS_UNDEF) ? config->trafficClass : NCCL_IB_SL_DEFAULT;
    meta.tc = (ncclParamIbTc() != -1) ? ncclParamIbTc() : (config && config->trafficClass != NCCL_NET_TRAFFIC_CLASS_UNDEF) ? config->trafficClass : NCCL_IB_TC_DEFAULT;
    strncpy(meta.devName, mergedDev->devName, MAX_MERGED_DEV_NAME);
-@@ -1856,25 +2025,35 @@ ncclResult_t ncclIbCheckVProps(ncclNetVDeviceProps_t* vProps1, ncclNetVDevicePro
+@@ -1856,25 +2027,35 @@ ncclResult_t ncclIbCheckVProps(ncclNetVDeviceProps_t* vProps1, ncclNetVDevicePro
    return ncclSuccess;
  }
  
@@ -396,7 +398,7 @@
    if (stage->state == ncclIbCommStateAccept)   goto ib_accept_check;
    if (stage->state == ncclIbCommStateRecvDevList) goto ib_recv_dev_list;
    if (stage->state == ncclIbCommStateSendDevList) goto ib_send_dev_list;
-@@ -1916,7 +2095,6 @@ ib_recv_dev_list:
+@@ -1916,7 +2097,6 @@ ib_recv_dev_list:
    }
  
    // Reduce the physical device list and store in the connection base
@@ -404,7 +406,7 @@
    mergedDev = ncclIbMergedDevs + lComm->dev;
    NCCLCHECK(ncclIbCheckVProps(&mergedDev->vProps, &remoteVProps));
    rComm->base.vProps = mergedDev->vProps;
-@@ -1940,15 +2118,10 @@ ib_recv:
+@@ -1940,15 +2120,10 @@ ib_recv:
    memcpy(&remMeta, stage->buffer, sizeof(struct ncclIbConnectionMetadata));
  
    // IB setup
@@ -422,7 +424,7 @@
    rComm->base.nqps = ncclIbCalculateNqps(remMeta.isP2p, rComm->base.vProps.ndevs, 
                                            remMeta.ndevs, __func__);
    if (rComm->base.nRemDevs != rComm->base.vProps.ndevs) {
-@@ -2003,7 +2176,7 @@ ib_recv:
+@@ -2003,7 +2178,7 @@ ib_recv:
      // Local ibDevN
      ibDevN = rComm->devs[devIndex].base.ibDevN;
      ibDev = ncclIbDevs + ibDevN;
@@ -431,7 +433,7 @@
      qp->devIndex = devIndex;
      devIndex = (devIndex + 1) % rComm->base.vProps.ndevs;
  
-@@ -2057,16 +2230,23 @@ ib_recv:
+@@ -2057,16 +2232,23 @@ ib_recv:
    }
  
    rComm->flushEnabled = ((peermemAvailable || useDmaBuf)
@@ -458,7 +460,7 @@
  
      // Allocate Flush dummy buffer for GPU Direct RDMA
      if (rComm->flushEnabled) {
-@@ -2133,7 +2313,7 @@ flush_reg_done:
+@@ -2133,7 +2315,7 @@ flush_reg_done:
        rCommDev->gpuFlush.sge.addr = (uint64_t)&rComm->gpuFlushHostMem;
        rCommDev->gpuFlush.sge.length = 1;
        rCommDev->gpuFlush.sge.lkey = rCommDev->gpuFlush.hostMr->lkey;
@@ -467,7 +469,7 @@
        struct ncclIbDevInfo devInfo;
        devInfo.lid         = ibDev->portAttr.lid;
        devInfo.link_layer  = ibDev->portAttr.link_layer;
-@@ -2356,11 +2536,16 @@ ncclResult_t ncclIbDeregMr(void* comm, void* mhandle) {
+@@ -2356,11 +2538,16 @@ ncclResult_t ncclIbDeregMr(void* comm, void* mhandle) {
  NCCL_PARAM(IbSplitDataOnQps, "IB_SPLIT_DATA_ON_QPS", 0);
  RCCL_PARAM(IbSplitDataThreshold, "IB_SPLIT_DATA_THRESHOLD", 128);
  
@@ -486,7 +488,7 @@
    if (nreqs > NCCL_NET_IB_MAX_RECVS) return ncclInternalError;
  
    uint64_t wr_id = 0ULL;
-@@ -2372,7 +2557,11 @@ ncclResult_t ncclIbMultiSend(struct ncclIbSendComm* comm, int slot) {
+@@ -2372,7 +2559,11 @@ ncclResult_t ncclIbMultiSend(struct ncclIbSendComm* comm, int slot) {
      sge->addr=(uintptr_t)reqs[r]->send.data;
      wr->opcode = IBV_WR_RDMA_WRITE;
      wr->send_flags = 0;
@@ -499,7 +501,7 @@
      wr->next = wr + 1;
      wr_id += (reqs[r] - comm->base.reqs) << (r*8);
  #ifdef NCCL_ENABLE_NET_PROFILING
-@@ -2383,7 +2572,7 @@ ncclResult_t ncclIbMultiSend(struct ncclIbSendComm* comm, int slot) {
+@@ -2383,7 +2574,7 @@ ncclResult_t ncclIbMultiSend(struct ncclIbSendComm* comm, int slot) {
    // Write size as immediate data. In the case of multi-send, only write
    // 0 or 1 as size to indicate whether there was data sent or received.
    uint32_t immData = 0;
@@ -508,7 +510,7 @@
      immData = reqs[0]->send.size;
    } else {
      int* sizes = comm->remSizesFifo.elems[slot];
-@@ -2393,22 +2582,24 @@ ncclResult_t ncclIbMultiSend(struct ncclIbSendComm* comm, int slot) {
+@@ -2393,22 +2584,24 @@ ncclResult_t ncclIbMultiSend(struct ncclIbSendComm* comm, int slot) {
    }
  
    struct ibv_send_wr* lastWr = comm->wrs+nreqs-1;
@@ -546,7 +548,7 @@
    lastWr->next = NULL;
    lastWr->send_flags = IBV_SEND_SIGNALED;
  
-@@ -2430,7 +2621,11 @@ ncclResult_t ncclIbMultiSend(struct ncclIbSendComm* comm, int slot) {
+@@ -2430,7 +2623,11 @@ ncclResult_t ncclIbMultiSend(struct ncclIbSendComm* comm, int slot) {
        //ncclIbAddEvent(reqs[r], devIndex, &comm->devs[devIndex].base);
  
        // Select proper rkey (needed even for 0-size send)
@@ -559,7 +561,7 @@
  
        int chunkSize;
        if (reqs[r]->send.size < splitDataThreshold) {
-@@ -2451,7 +2646,7 @@ ncclResult_t ncclIbMultiSend(struct ncclIbSendComm* comm, int slot) {
+@@ -2451,7 +2648,7 @@ ncclResult_t ncclIbMultiSend(struct ncclIbSendComm* comm, int slot) {
        }
      }
  
@@ -568,7 +570,7 @@
        // Also make sure lastWr writes remote sizes using the right lkey
        comm->remSizesFifo.sge.lkey = comm->remSizesFifo.mrs[devIndex]->lkey;
        lastWr->wr.rdma.rkey = comm->remSizesFifo.rkeys[devIndex];
-@@ -2516,6 +2711,11 @@ ncclResult_t ncclIbIsend(void* sendComm, void* data, size_t size, int tag, void*
+@@ -2516,6 +2713,11 @@ ncclResult_t ncclIbIsend(void* sendComm, void* data, size_t size, int tag, void*
    ncclResult_t ret = ncclSuccess;
    struct ncclIbRequest* req = NULL;
    struct ncclIbMrHandle* mhandleWrapper = (struct ncclIbMrHandle*) mhandle;
@@ -580,7 +582,7 @@
    int nreqs = 0;
    volatile struct ncclIbSendFifo* slots = NULL;
    int slot = (comm->fifoHead) % MAX_REQUESTS;
-@@ -2529,26 +2729,36 @@ ncclResult_t ncclIbIsend(void* sendComm, void* data, size_t size, int tag, void*
+@@ -2529,26 +2731,36 @@ ncclResult_t ncclIbIsend(void* sendComm, void* data, size_t size, int tag, void*
    }
    NCCLCHECKGOTO(ncclIbStatsCheckFatalCount(&comm->base.stats,__func__), ret, fail);
  
@@ -635,7 +637,7 @@
      }
  
      NCCLCHECKGOTO(ncclIbGetRequest(&comm->base, &req), ret, fail);
-@@ -2591,10 +2801,12 @@ ncclResult_t ncclIbIsend(void* sendComm, void* data, size_t size, int tag, void*
+@@ -2591,10 +2803,12 @@ ncclResult_t ncclIbIsend(void* sendComm, void* data, size_t size, int tag, void*
      }
  
      TIME_START(0);
@@ -650,7 +652,7 @@
      memset(reqs, 0, NCCL_NET_IB_MAX_RECVS*sizeof(struct ncclIbRequest*));
      comm->fifoHead++;
      TIME_STOP(0);
-@@ -2629,39 +2841,79 @@ fail:
+@@ -2629,39 +2843,79 @@ fail:
  
  ncclResult_t ncclIbPostFifo(struct ncclIbRecvComm* comm, int n, void** data, size_t* sizes, int* tags, void** mhandles, struct ncclIbRequest* req) {
    struct ibv_send_wr wr;
@@ -746,7 +748,7 @@
    wr.sg_list = &comm->devs[ctsQp->devIndex].fifoSge;
    wr.num_sge = 1;
  
-@@ -2691,7 +2943,14 @@ ncclResult_t ncclIbPostFifo(struct ncclIbRecvComm* comm, int n, void** data, siz
+@@ -2691,7 +2945,14 @@ ncclResult_t ncclIbPostFifo(struct ncclIbRecvComm* comm, int n, void** data, siz
    //
    // slot == devIndex - When writing to fifo slot N, and this QP lives on device index N, it should send signalled.
    // This works out that each fifo posting QP gets drained
@@ -762,7 +764,7 @@
      wr.send_flags |= IBV_SEND_SIGNALED;
      wr.wr_id = req - comm->base.reqs;
      ncclIbAddEvent(req, ctsQp->devIndex, &comm->devs[ctsQp->devIndex].base);
-@@ -2712,10 +2971,16 @@ ncclResult_t ncclIbPostFifo(struct ncclIbRecvComm* comm, int n, void** data, siz
+@@ -2712,10 +2973,16 @@ ncclResult_t ncclIbPostFifo(struct ncclIbRecvComm* comm, int n, void** data, siz
  
    comm->remFifo.fifoTail++;
  
@@ -779,7 +781,7 @@
    struct ncclIbRecvComm* comm = (struct ncclIbRecvComm*)recvComm;
    ncclResult_t ret = ncclSuccess;
    struct ncclIbRequest* req = NULL;
-@@ -2731,6 +2996,11 @@ ncclResult_t ncclIbIrecv(void* recvComm, int n, void** data, size_t* sizes, int*
+@@ -2731,6 +2998,11 @@ ncclResult_t ncclIbIrecv(void* recvComm, int n, void** data, size_t* sizes, int*
    if (n > NCCL_NET_IB_MAX_RECVS) return ncclInternalError;
    NCCLCHECKGOTO(ncclIbStatsCheckFatalCount(&comm->base.stats,__func__), ret, fail);
  
@@ -791,7 +793,7 @@
    NCCLCHECKGOTO(ncclIbGetRequest(&comm->base, &req), ret, fail);
    req->type = NCCL_NET_IB_REQ_RECV;
    req->sock = &comm->base.sock;
-@@ -2743,40 +3013,50 @@ ncclResult_t ncclIbIrecv(void* recvComm, int n, void** data, size_t* sizes, int*
+@@ -2743,40 +3015,50 @@ ncclResult_t ncclIbIrecv(void* recvComm, int n, void** data, size_t* sizes, int*
      req->devBases[i] = &comm->devs[i].base;
    }
  
@@ -871,7 +873,7 @@
  
    // Post to FIFO to notify sender
    TIME_START(2);
-@@ -2905,6 +3185,8 @@ static int getReqQpIndex(struct ncclIbRequest* req, int request, int qpNumber) {
+@@ -2905,6 +3187,8 @@ static int getReqQpIndex(struct ncclIbRequest* req, int request, int qpNumber) {
  }
  #endif
  
@@ -880,7 +882,7 @@
  ncclResult_t ncclIbTest(void* request, int* done, int* sizes) {
    struct ncclIbRequest *r = (struct ncclIbRequest*)request;
    ncclResult_t ret = ncclSuccess;
-@@ -2948,13 +3230,17 @@ ncclResult_t ncclIbTest(void* request, int* done, int* sizes) {
+@@ -2948,13 +3232,17 @@ ncclResult_t ncclIbTest(void* request, int* done, int* sizes) {
  
      int totalWrDone = 0;
      int wrDone = 0;
@@ -900,7 +902,7 @@
          if (ret != ncclSuccess) {
            failDevIdx = i;
            goto fail;
-@@ -3131,7 +3417,7 @@ ncclResult_t rcclNetP2pPolicy(void* handle, int isP2p) {
+@@ -3131,7 +3419,7 @@ ncclResult_t rcclNetP2pPolicy(void* handle, int isP2p) {
  }
  
  ncclNet_t ncclNetIb = {

--- a/projects/rccl/ext-src/rocm_netib.patch
+++ b/projects/rccl/ext-src/rocm_netib.patch
@@ -8,7 +8,7 @@
  #include "graph/xml.h"
  
  #define MAXSUFFIXSIZE 16
-@@ -110,6 +111,25 @@
+@@ -110,6 +111,25 @@ struct ncclIbMergedDev ncclIbMergedDevs[MAX_IB_VDEVS];
  struct ncclIbDev ncclIbDevs[MAX_IB_DEVS];
  static std::mutex ncclIbMutex;
  static int ncclIbRelaxedOrderingEnabled = 0;
@@ -34,7 +34,7 @@
  
  // With ncclNet_v11_t the NCCL core initializes the network plugin per-communicator
  // rather than once for all communicators. However, the internal plugin implementation
-@@ -120,6 +140,8 @@
+@@ -120,6 +140,8 @@ static int netRefCount;
  
  #define NCCL_IB_LLSTR(ll) (((ll) == IBV_LINK_LAYER_INFINIBAND) ? "IB" : (((ll) == IBV_LINK_LAYER_ETHERNET) ? "RoCE" : "UNSPECIFIED"))
  
@@ -43,7 +43,7 @@
  #define NCCL_IB_SL_DEFAULT 0
  #define NCCL_IB_TC_DEFAULT 0
  
-@@ -141,6 +163,17 @@
+@@ -141,6 +163,17 @@ NCCL_PARAM(IbEceEnable,"IB_ECE_ENABLE",1);
  NCCL_PARAM(IbDataDirect,"IB_DATA_DIRECT",1);
  NCCL_PARAM(IbQpsPerConn, "IB_QPS_PER_CONNECTION", 1);
  RCCL_PARAM(IbQpsPerP2p, "IB_QPS_PER_P2P", 0);
@@ -61,7 +61,7 @@
  
  static ncclResult_t ncclIbStatsInit(struct ncclIbStats* stat) {
    __atomic_store_n(&stat->fatalErrorCount, 0, __ATOMIC_RELAXED);
-@@ -774,6 +807,16 @@
+@@ -774,6 +807,16 @@ ncclResult_t ncclIbMakeVDeviceInternal(int* d, ncclNetVDeviceProps_t* props) {
        break;
      }
    }
@@ -78,7 +78,7 @@
    ncclIbMergedDevs[ncclNMergedIbDevs] = tmp;
    *d = ncclNMergedIbDevs++;
    INFO(NCCL_NET, "NET/IB : Made virtual device [%d] name=%s speed=%d ndevs=%d", *d, tmp.devName, tmp.speed, tmp.vProps.ndevs);
-@@ -803,6 +846,10 @@
+@@ -803,6 +846,10 @@ ncclResult_t ncclIbInit(void** ctx, uint64_t commId, ncclNetCommConfig_t* config
    static int shownIbHcaEnv = 0;
    if(wrap_ibv_symbols() != ncclSuccess) { return ncclInternalError; }
    if(wrap_mlx5dv_symbols() != ncclSuccess) { INFO(NCCL_NET, "NET/IB : Failed to open mlx5dv symbols. Advance features like CX-8 Direct-NIC will be disabled."); }
@@ -89,7 +89,7 @@
  
    // Detect IB cards
    int nIbDevs = 0;
-@@ -966,6 +1013,26 @@
+@@ -966,6 +1013,26 @@ ncclResult_t ncclIbInit(void** ctx, uint64_t commId, ncclNetCommConfig_t* config
      INFO(NCCL_INIT|NCCL_NET, "NET/IB : Using%s %s; OOB %s:%s", line, ncclIbRelaxedOrderingEnabled ? "[RO]" : "",
            ncclIbIfName, ncclSocketToString(&ncclIbIfAddr, addrline));
  
@@ -116,7 +116,7 @@
    }
  exit:
    ibContext.trafficClass = config->trafficClass;
-@@ -1302,6 +1369,8 @@
+@@ -1302,6 +1369,8 @@ struct ncclIbListenComm {
    struct ncclIbCommStage stage;
  };
  
@@ -125,7 +125,7 @@
  struct alignas(64) ncclIbSendFifo {
    uint64_t addr;
    uint64_t size;
-@@ -1312,10 +1381,21 @@
+@@ -1312,10 +1381,21 @@ struct alignas(64) ncclIbSendFifo {
    char padding[16];
  };
  
@@ -147,7 +147,7 @@
  };
  
  struct ncclIbRemSizesFifo {
-@@ -1362,6 +1442,7 @@
+@@ -1362,6 +1442,7 @@ struct ncclIbSendComm {
    struct ncclIbNetCommBase base;
    // Start with fifo and ibv structs as they have alignment restrictions
    struct ncclIbSendFifo fifo[MAX_REQUESTS][NCCL_NET_IB_MAX_RECVS];
@@ -155,7 +155,7 @@
    struct ibv_sge sges[NCCL_NET_IB_MAX_RECVS];
    struct ibv_send_wr wrs[NCCL_NET_IB_MAX_RECVS + 1];
    // Each dev correlates to a mergedIbDev
-@@ -1370,6 +1451,7 @@
+@@ -1370,6 +1451,7 @@ struct ncclIbSendComm {
    struct ncclIbRemSizesFifo remSizesFifo;
    uint64_t fifoHead;
    int ar; // Use adaptive routing when all merged devices have it enabled
@@ -163,7 +163,7 @@
  };
  // The SendFifo needs to be 32-byte aligned and each element needs
  // to be a 32-byte multiple, so that an entry does not get split and
-@@ -1377,6 +1459,7 @@
+@@ -1377,6 +1459,7 @@ struct ncclIbSendComm {
  static_assert((sizeof(struct ncclIbNetCommBase) % 32) == 0, "ncclIbNetCommBase size must be 32-byte multiple to ensure fifo is at proper offset");
  static_assert((offsetof(struct ncclIbSendComm, fifo) % 32) == 0, "ncclIbSendComm fifo must be 32-byte aligned");
  static_assert((sizeof(struct ncclIbSendFifo) % 32) == 0, "ncclIbSendFifo element size must be 32-byte multiples");
@@ -171,7 +171,7 @@
  static_assert((offsetof(struct ncclIbSendComm, sges) % 32) == 0, "sges must be 32-byte aligned");
  static_assert((offsetof(struct ncclIbSendComm, wrs) % 32) == 0, "wrs must be 32-byte aligned");
  
-@@ -1391,6 +1474,7 @@
+@@ -1391,6 +1474,7 @@ struct ncclIbGpuFlush {
  
  struct ncclIbRemFifo {
    struct ncclIbSendFifo elems[MAX_REQUESTS][NCCL_NET_IB_MAX_RECVS];
@@ -179,7 +179,7 @@
    uint64_t fifoTail;
    uint64_t addr;
    uint32_t flags;
-@@ -1411,6 +1495,7 @@
+@@ -1411,6 +1495,7 @@ struct ncclIbRecvComm {
    int sizesFifo[MAX_REQUESTS][NCCL_NET_IB_MAX_RECVS];
    int gpuFlushHostMem;
    int flushEnabled;
@@ -187,7 +187,7 @@
  };
  static_assert((offsetof(struct ncclIbRecvComm, remFifo) % 32) == 0, "ncclIbRecvComm fifo must be 32-byte aligned");
  
-@@ -1446,20 +1531,60 @@
+@@ -1446,20 +1531,87 @@ ncclResult_t ncclIbDestroyBase(struct ncclIbNetCommDevBase* base) {
    return ncclSuccess;
  }
  
@@ -218,39 +218,67 @@
 +    } else {
 +        wrap_ionicdv_pd_set_udma_mask(base->pd, IONIC_UDMA_MASK_LOW);
 +    }
-+    qpInitAttr.sq_sig_all |= (1 << 16);
-+    if (data_qp) {
-+      qpInitAttr.sq_sig_all |= (1 << 17);
-+    } else {
-+      qpInitAttr.sq_sig_all &= (~(1 << 17));
-+    }
-+    qpInitAttr.sq_sig_all |= (1 << 18);
-+
-+    if (qpCtsOffload) {
-+      qpInitAttr.sq_sig_all |= (1 << 19);
-+    } else {
-+      qpInitAttr.sq_sig_all &= (~(1 << 19));
++    if (!ionicdvCreateQpExSupported) {
++      qpInitAttr.sq_sig_all |= (1 << 16);
++      if (data_qp) {
++        qpInitAttr.sq_sig_all |= (1 << 17);
++      } else {
++        qpInitAttr.sq_sig_all &= (~(1 << 17));
++      }
++      qpInitAttr.sq_sig_all |= (1 << 18);
++      if (qpCtsOffload) {
++        qpInitAttr.sq_sig_all |= (1 << 19);
++      } else {
++        qpInitAttr.sq_sig_all &= (~(1 << 19));
++      }
 +    }
 +  }
++
    // We might send 2 messages per send (RDMA and RDMA_WITH_IMM)
    qpInitAttr.cap.max_send_wr = 2*MAX_REQUESTS;
    qpInitAttr.cap.max_recv_wr = MAX_REQUESTS;
    qpInitAttr.cap.max_send_sge = 1;
    qpInitAttr.cap.max_recv_sge = 1;
 -  qpInitAttr.cap.max_inline_data = ncclParamIbUseInline() ? sizeof(struct ncclIbSendFifo) : 0;
+-  NCCLCHECK(wrap_ibv_create_qp(&qp->qp, base->pd, &qpInitAttr));
 +  if (qpCtsOffload) {
 +    qpInitAttr.cap.max_inline_data = MAX_INLINE_DATA_SIZE;
 +  } else {
 +    qpInitAttr.cap.max_inline_data = ncclIbUseInline ? sizeof(struct ncclIbSendFifo) : 0;
 +  }
-   NCCLCHECK(wrap_ibv_create_qp(&qp->qp, base->pd, &qpInitAttr));
++  if (rcclAinicRoce && ionicdvCreateQpExSupported) {
++    struct ibv_qp_init_attr_ex qpInitAttrEx;
++    memset(&qpInitAttrEx, 0, sizeof(qpInitAttrEx));
++    qpInitAttrEx.qp_context = qpInitAttr.qp_context;
++    qpInitAttrEx.send_cq   = qpInitAttr.send_cq;
++    qpInitAttrEx.recv_cq   = qpInitAttr.recv_cq;
++    qpInitAttrEx.qp_type   = qpInitAttr.qp_type;
++    qpInitAttrEx.cap       = qpInitAttr.cap;
++    qpInitAttrEx.comp_mask = IBV_QP_INIT_ATTR_PD;
++    qpInitAttrEx.pd        = base->pd;
++
++    struct ionic_qp_init_attr_ex ionicQpAttr;
++    memset(&ionicQpAttr, 0, sizeof(ionicQpAttr));
++    ionicQpAttr.comp_mask    = IONIC_QP_INIT_ATTR_MASK_FLAGS;
++    ionicQpAttr.ionic_flags  = IONIC_CREATE_QP_TYPE_RCCL;
++    if (data_qp) {
++      ionicQpAttr.ionic_flags |= IONIC_CREATE_QP_RCCL_DATA;
++    }
++    ionicQpAttr.ionic_flags |= IONIC_CREATE_QP_RCCL_RDFENCE;
++    if (rcclCtsOffloadEnabled) {
++      ionicQpAttr.ionic_flags |= IONIC_CREATE_QP_RCCL_RX_OFFLOAD;
++    }
++    NCCLCHECK(wrap_ionicdv_create_qp_ex(base->pd->context, &qpInitAttrEx, &ionicQpAttr, &qp->qp));
++  } else {
++    NCCLCHECK(wrap_ibv_create_qp(&qp->qp, base->pd, &qpInitAttr));
++  }
 +  if (rcclAinicRoce) {
 +    NCCLCHECK(wrap_ionicdv_qp_set_gda(qp->qp, false, true));
 +  }
    struct ibv_qp_attr qpAttr;
    memset(&qpAttr, 0, sizeof(struct ibv_qp_attr));
    qpAttr.qp_state = IBV_QPS_INIT;
-@@ -1469,6 +1594,9 @@
+@@ -1469,6 +1621,9 @@ ncclResult_t ncclIbCreateQp(uint8_t ib_port, struct ncclIbNetCommDevBase* base,
    NCCLCHECK(wrap_ibv_modify_qp(qp->qp, &qpAttr, IBV_QP_STATE | IBV_QP_PKEY_INDEX | IBV_QP_PORT | IBV_QP_ACCESS_FLAGS));
    TRACE(NCCL_NET, "NET/IB : ncclIbCreateQp port=%d dev=%d devName=%s ndevs=%d nmdevs=%d qpn=%u pkey=%u pd=%p",
      ib_port, base->ibDevN, ncclIbDevs[base->ibDevN].devName, ncclNIbDevs, ncclNMergedIbDevs, qp->qp->qp_num, qpAttr.pkey_index, base->pd);
@@ -260,7 +288,7 @@
    return ncclSuccess;
  }
  
-@@ -1552,16 +1680,21 @@
+@@ -1552,16 +1707,21 @@ fail:
    goto exit;
  }
  
@@ -284,7 +312,7 @@
    if (stage->state == ncclIbCommStateConnect)      goto ib_connect_check;
    if (stage->state == ncclIbCommStateSendDevList)  goto ib_send_dev_list;
    if (stage->state == ncclIbCommStateRecvDevList)  goto ib_recv_dev_list;
-@@ -1622,7 +1755,8 @@
+@@ -1622,7 +1782,8 @@ ib_recv_dev_list:
  
    // Read isP2p from handle
    isP2p = handle->isP2p;
@@ -294,7 +322,7 @@
    comm->base.nqps = ncclIbCalculateNqps(isP2p, comm->base.vProps.ndevs, 
                                           remoteVProps.ndevs, __func__);
  
-@@ -1643,7 +1777,7 @@
+@@ -1643,7 +1804,7 @@ ib_recv_dev_list:
    for (int q = 0; q < comm->base.nqps; q++) {
      ncclIbSendCommDev* commDev = comm->devs + devIndex;
      ncclIbDev* ibDev = ncclIbDevs + commDev->base.ibDevN;
@@ -303,7 +331,7 @@
      comm->base.qps[q].devIndex = devIndex;
      meta.qpInfo[q].qpn      = comm->base.qps[q].qp->qp_num;
      meta.qpInfo[q].devIndex = comm->base.qps[q].devIndex;
-@@ -1668,7 +1802,11 @@
+@@ -1668,7 +1829,11 @@ ib_recv_dev_list:
      devInfo->lid           = ibDev->portAttr.lid;
      devInfo->ibv_dev_index = commDev->base.ibDevN;
      // Prepare my fifo
@@ -316,7 +344,7 @@
      devInfo->fifoRkey = commDev->fifoMr->rkey;
  
      // Pack local GID info
-@@ -1711,7 +1849,11 @@
+@@ -1711,7 +1876,11 @@ ib_recv_dev_list:
      }
    }
    config = (ncclNetCommConfig_t*)ctx;
@@ -329,7 +357,7 @@
    meta.sl = (ncclParamIbSl() != -1) ? ncclParamIbSl() : (config && config->trafficClass != NCCL_NET_TRAFFIC_CLASS_UNDEF) ? config->trafficClass : NCCL_IB_SL_DEFAULT;
    meta.tc = (ncclParamIbTc() != -1) ? ncclParamIbTc() : (config && config->trafficClass != NCCL_NET_TRAFFIC_CLASS_UNDEF) ? config->trafficClass : NCCL_IB_TC_DEFAULT;
    strncpy(meta.devName, mergedDev->devName, MAX_MERGED_DEV_NAME);
-@@ -1856,25 +1998,35 @@
+@@ -1856,25 +2025,35 @@ ncclResult_t ncclIbCheckVProps(ncclNetVDeviceProps_t* vProps1, ncclNetVDevicePro
    return ncclSuccess;
  }
  
@@ -368,7 +396,7 @@
    if (stage->state == ncclIbCommStateAccept)   goto ib_accept_check;
    if (stage->state == ncclIbCommStateRecvDevList) goto ib_recv_dev_list;
    if (stage->state == ncclIbCommStateSendDevList) goto ib_send_dev_list;
-@@ -1916,7 +2068,6 @@
+@@ -1916,7 +2095,6 @@ ib_recv_dev_list:
    }
  
    // Reduce the physical device list and store in the connection base
@@ -376,7 +404,7 @@
    mergedDev = ncclIbMergedDevs + lComm->dev;
    NCCLCHECK(ncclIbCheckVProps(&mergedDev->vProps, &remoteVProps));
    rComm->base.vProps = mergedDev->vProps;
-@@ -1940,15 +2091,10 @@
+@@ -1940,15 +2118,10 @@ ib_recv:
    memcpy(&remMeta, stage->buffer, sizeof(struct ncclIbConnectionMetadata));
  
    // IB setup
@@ -394,7 +422,7 @@
    rComm->base.nqps = ncclIbCalculateNqps(remMeta.isP2p, rComm->base.vProps.ndevs, 
                                            remMeta.ndevs, __func__);
    if (rComm->base.nRemDevs != rComm->base.vProps.ndevs) {
-@@ -2003,7 +2149,7 @@
+@@ -2003,7 +2176,7 @@ ib_recv:
      // Local ibDevN
      ibDevN = rComm->devs[devIndex].base.ibDevN;
      ibDev = ncclIbDevs + ibDevN;
@@ -403,7 +431,7 @@
      qp->devIndex = devIndex;
      devIndex = (devIndex + 1) % rComm->base.vProps.ndevs;
  
-@@ -2057,16 +2203,23 @@
+@@ -2057,16 +2230,23 @@ ib_recv:
    }
  
    rComm->flushEnabled = ((peermemAvailable || useDmaBuf)
@@ -430,7 +458,7 @@
  
      // Allocate Flush dummy buffer for GPU Direct RDMA
      if (rComm->flushEnabled) {
-@@ -2133,7 +2286,7 @@
+@@ -2133,7 +2313,7 @@ flush_reg_done:
        rCommDev->gpuFlush.sge.addr = (uint64_t)&rComm->gpuFlushHostMem;
        rCommDev->gpuFlush.sge.length = 1;
        rCommDev->gpuFlush.sge.lkey = rCommDev->gpuFlush.hostMr->lkey;
@@ -439,7 +467,7 @@
        struct ncclIbDevInfo devInfo;
        devInfo.lid         = ibDev->portAttr.lid;
        devInfo.link_layer  = ibDev->portAttr.link_layer;
-@@ -2356,11 +2509,16 @@
+@@ -2356,11 +2536,16 @@ ncclResult_t ncclIbDeregMr(void* comm, void* mhandle) {
  NCCL_PARAM(IbSplitDataOnQps, "IB_SPLIT_DATA_ON_QPS", 0);
  RCCL_PARAM(IbSplitDataThreshold, "IB_SPLIT_DATA_THRESHOLD", 128);
  
@@ -458,7 +486,7 @@
    if (nreqs > NCCL_NET_IB_MAX_RECVS) return ncclInternalError;
  
    uint64_t wr_id = 0ULL;
-@@ -2372,7 +2530,11 @@
+@@ -2372,7 +2557,11 @@ ncclResult_t ncclIbMultiSend(struct ncclIbSendComm* comm, int slot) {
      sge->addr=(uintptr_t)reqs[r]->send.data;
      wr->opcode = IBV_WR_RDMA_WRITE;
      wr->send_flags = 0;
@@ -471,7 +499,7 @@
      wr->next = wr + 1;
      wr_id += (reqs[r] - comm->base.reqs) << (r*8);
  #ifdef NCCL_ENABLE_NET_PROFILING
-@@ -2383,7 +2545,7 @@
+@@ -2383,7 +2572,7 @@ ncclResult_t ncclIbMultiSend(struct ncclIbSendComm* comm, int slot) {
    // Write size as immediate data. In the case of multi-send, only write
    // 0 or 1 as size to indicate whether there was data sent or received.
    uint32_t immData = 0;
@@ -480,7 +508,7 @@
      immData = reqs[0]->send.size;
    } else {
      int* sizes = comm->remSizesFifo.elems[slot];
-@@ -2393,22 +2555,24 @@
+@@ -2393,22 +2582,24 @@ ncclResult_t ncclIbMultiSend(struct ncclIbSendComm* comm, int slot) {
    }
  
    struct ibv_send_wr* lastWr = comm->wrs+nreqs-1;
@@ -518,7 +546,7 @@
    lastWr->next = NULL;
    lastWr->send_flags = IBV_SEND_SIGNALED;
  
-@@ -2430,7 +2594,11 @@
+@@ -2430,7 +2621,11 @@ ncclResult_t ncclIbMultiSend(struct ncclIbSendComm* comm, int slot) {
        //ncclIbAddEvent(reqs[r], devIndex, &comm->devs[devIndex].base);
  
        // Select proper rkey (needed even for 0-size send)
@@ -531,7 +559,7 @@
  
        int chunkSize;
        if (reqs[r]->send.size < splitDataThreshold) {
-@@ -2451,7 +2619,7 @@
+@@ -2451,7 +2646,7 @@ ncclResult_t ncclIbMultiSend(struct ncclIbSendComm* comm, int slot) {
        }
      }
  
@@ -540,7 +568,7 @@
        // Also make sure lastWr writes remote sizes using the right lkey
        comm->remSizesFifo.sge.lkey = comm->remSizesFifo.mrs[devIndex]->lkey;
        lastWr->wr.rdma.rkey = comm->remSizesFifo.rkeys[devIndex];
-@@ -2516,6 +2684,11 @@
+@@ -2516,6 +2711,11 @@ ncclResult_t ncclIbIsend(void* sendComm, void* data, size_t size, int tag, void*
    ncclResult_t ret = ncclSuccess;
    struct ncclIbRequest* req = NULL;
    struct ncclIbMrHandle* mhandleWrapper = (struct ncclIbMrHandle*) mhandle;
@@ -552,7 +580,7 @@
    int nreqs = 0;
    volatile struct ncclIbSendFifo* slots = NULL;
    int slot = (comm->fifoHead) % MAX_REQUESTS;
-@@ -2529,26 +2702,36 @@
+@@ -2529,26 +2729,36 @@ ncclResult_t ncclIbIsend(void* sendComm, void* data, size_t size, int tag, void*
    }
    NCCLCHECKGOTO(ncclIbStatsCheckFatalCount(&comm->base.stats,__func__), ret, fail);
  
@@ -579,9 +607,7 @@
 +  }
    for (int r=0; r<nreqs; r++) {
 -    if (reqs[r] != NULL || slots[r].tag != tag) continue;
-+    if (!comm->useCtsOffload) {
-+      if (reqs[r] != NULL || slots[r].tag != tag) continue;
- 
+-
 -    if (size > slots[r].size) size = slots[r].size;
 -    // Sanity checks
 -    if (slots[r].size < 0 || slots[r].addr == 0 || slots[r].rkeys[0] == 0) {
@@ -591,6 +617,9 @@
 -      WARN("NET/IB : req %d/%d tag %x peer %s posted incorrect receive info: size %ld addr %lx rkeys[0]=%x",
 -        r, nreqs, tag, ncclSocketToString(&addr, line), slots[r].size, slots[r].addr, slots[r].rkeys[0]);
 -      return ncclInternalError;
++    if (!comm->useCtsOffload) {
++      if (reqs[r] != NULL || slots[r].tag != tag) continue;
++
 +      if (size > slots[r].size) size = slots[r].size;
 +      // Sanity checks
 +      if (slots[r].size < 0 || slots[r].addr == 0 || slots[r].rkeys[0] == 0) {
@@ -606,7 +635,7 @@
      }
  
      NCCLCHECKGOTO(ncclIbGetRequest(&comm->base, &req), ret, fail);
-@@ -2591,10 +2774,12 @@
+@@ -2591,10 +2801,12 @@ ncclResult_t ncclIbIsend(void* sendComm, void* data, size_t size, int tag, void*
      }
  
      TIME_START(0);
@@ -621,7 +650,7 @@
      memset(reqs, 0, NCCL_NET_IB_MAX_RECVS*sizeof(struct ncclIbRequest*));
      comm->fifoHead++;
      TIME_STOP(0);
-@@ -2629,39 +2814,79 @@
+@@ -2629,39 +2841,79 @@ fail:
  
  ncclResult_t ncclIbPostFifo(struct ncclIbRecvComm* comm, int n, void** data, size_t* sizes, int* tags, void** mhandles, struct ncclIbRequest* req) {
    struct ibv_send_wr wr;
@@ -667,17 +696,16 @@
 +      // Send all applicable rkeys
 +      for (int j = 0; j < comm->base.vProps.ndevs; j++)
 +        localElemCtsInline[i].rkeys[j] = mhandleWrapper->mrs[j]->rkey;
-+
+ 
+-    // Send all applicable rkeys
+-    for (int j = 0; j < comm->base.vProps.ndevs; j++)
+-      localElem[i].rkeys[j] = mhandleWrapper->mrs[j]->rkey;
 +      localElemCtsInline[i].nreqs = n;
 +      localElemCtsInline[i].size = sizes[i]; // Sanity/Debugging
 +      localElemCtsInline[i].tag = tags[i];
 +      localElemCtsInline[i].idx = comm->remFifo.fifoTail+1;
 +      localElemRef = (uint64_t)localElemCtsInline;
  
--    // Send all applicable rkeys
--    for (int j = 0; j < comm->base.vProps.ndevs; j++)
--      localElem[i].rkeys[j] = mhandleWrapper->mrs[j]->rkey;
--
 -    localElem[i].nreqs = n;
 -    localElem[i].size = sizes[i]; // Sanity/Debugging
 -    localElem[i].tag = tags[i];
@@ -718,7 +746,7 @@
    wr.sg_list = &comm->devs[ctsQp->devIndex].fifoSge;
    wr.num_sge = 1;
  
-@@ -2691,7 +2916,14 @@
+@@ -2691,7 +2943,14 @@ ncclResult_t ncclIbPostFifo(struct ncclIbRecvComm* comm, int n, void** data, siz
    //
    // slot == devIndex - When writing to fifo slot N, and this QP lives on device index N, it should send signalled.
    // This works out that each fifo posting QP gets drained
@@ -734,7 +762,7 @@
      wr.send_flags |= IBV_SEND_SIGNALED;
      wr.wr_id = req - comm->base.reqs;
      ncclIbAddEvent(req, ctsQp->devIndex, &comm->devs[ctsQp->devIndex].base);
-@@ -2712,10 +2944,16 @@
+@@ -2712,10 +2971,16 @@ ncclResult_t ncclIbPostFifo(struct ncclIbRecvComm* comm, int n, void** data, siz
  
    comm->remFifo.fifoTail++;
  
@@ -751,7 +779,7 @@
    struct ncclIbRecvComm* comm = (struct ncclIbRecvComm*)recvComm;
    ncclResult_t ret = ncclSuccess;
    struct ncclIbRequest* req = NULL;
-@@ -2731,6 +2969,11 @@
+@@ -2731,6 +2996,11 @@ ncclResult_t ncclIbIrecv(void* recvComm, int n, void** data, size_t* sizes, int*
    if (n > NCCL_NET_IB_MAX_RECVS) return ncclInternalError;
    NCCLCHECKGOTO(ncclIbStatsCheckFatalCount(&comm->base.stats,__func__), ret, fail);
  
@@ -763,7 +791,7 @@
    NCCLCHECKGOTO(ncclIbGetRequest(&comm->base, &req), ret, fail);
    req->type = NCCL_NET_IB_REQ_RECV;
    req->sock = &comm->base.sock;
-@@ -2743,40 +2986,50 @@
+@@ -2743,40 +3013,50 @@ ncclResult_t ncclIbIrecv(void* recvComm, int n, void** data, size_t* sizes, int*
      req->devBases[i] = &comm->devs[i].base;
    }
  
@@ -771,24 +799,23 @@
 -  wr.wr_id = req - comm->base.reqs;
 -  wr.sg_list = NULL;
 -  wr.num_sge = 0;
--
--  TIME_START(1);
--  // Select either all QPs, or one qp per-device
--  nqps = ncclParamIbSplitDataOnQps() ? comm->base.nqps : comm->base.nDataQps;
 +  if (!netOptRecvCompletionEnabled) {
 +    memset(&wr, 0, sizeof(wr));
 +    wr.wr_id = req - comm->base.reqs;
 +    wr.sg_list = NULL;
 +    wr.num_sge = 0;
  
+-  TIME_START(1);
+-  // Select either all QPs, or one qp per-device
+-  nqps = ncclParamIbSplitDataOnQps() ? comm->base.nqps : comm->base.nDataQps;
++    TIME_START(1);
++    // Select either all QPs, or one qp per-device
++    nqps = ncclParamIbSplitDataOnQps() ? comm->base.nqps : comm->base.nDataQps;
+ 
 -  // Post recvs
 -  for (int i = 0; i < nqps; i++) {
 -    struct ncclIbQp* qp = comm->base.qps + comm->base.qpIndex;
 -    ncclIbAddEvent(req, qp->devIndex, &comm->devs[qp->devIndex].base);
-+    TIME_START(1);
-+    // Select either all QPs, or one qp per-device
-+    nqps = ncclParamIbSplitDataOnQps() ? comm->base.nqps : comm->base.nDataQps;
-+
 +    // Post recvs
 +    int qpIndex = comm->base.qpIndex;
 +    for (int i = 0; i < nqps; i++) {
@@ -844,7 +871,7 @@
  
    // Post to FIFO to notify sender
    TIME_START(2);
-@@ -2905,6 +3158,8 @@
+@@ -2905,6 +3185,8 @@ static int getReqQpIndex(struct ncclIbRequest* req, int request, int qpNumber) {
  }
  #endif
  
@@ -853,7 +880,7 @@
  ncclResult_t ncclIbTest(void* request, int* done, int* sizes) {
    struct ncclIbRequest *r = (struct ncclIbRequest*)request;
    ncclResult_t ret = ncclSuccess;
-@@ -2948,13 +3203,17 @@
+@@ -2948,13 +3230,17 @@ ncclResult_t ncclIbTest(void* request, int* done, int* sizes) {
  
      int totalWrDone = 0;
      int wrDone = 0;
@@ -873,7 +900,7 @@
          if (ret != ncclSuccess) {
            failDevIdx = i;
            goto fail;
-@@ -3131,7 +3390,7 @@
+@@ -3131,7 +3417,7 @@ ncclResult_t rcclNetP2pPolicy(void* handle, int isP2p) {
  }
  
  ncclNet_t ncclNetIb = {

--- a/projects/rccl/src/include/ibvcore.h
+++ b/projects/rccl/src/include/ibvcore.h
@@ -491,6 +491,20 @@ struct ibv_srq_init_attr_ex {
 	struct ibv_cq	       *cq;
 };
 
+/*
+ * Receive Work Queue Indirection Table.
+ * It's used in order to distribute incoming packets between different
+ * Receive Work Queues. Associating Receive WQs with different CPU cores
+ * allows one to workload the traffic between different CPU cores.
+ * The Indirection Table can contain only WQs of type IBV_WQT_RQ.
+*/
+struct ibv_rwq_ind_table {
+	struct ibv_context *context;
+	int ind_tbl_handle;
+	int ind_tbl_num;
+	uint32_t comp_mask;
+};
+
 enum ibv_qp_type {
 	IBV_QPT_RC = 2,
 	IBV_QPT_UC,
@@ -535,6 +549,15 @@ enum ibv_qp_init_attr_mask {
 	IBV_QP_INIT_ATTR_RESERVED	= 1 << 2
 };
 
+struct ibv_rx_hash_conf {
+	/* enum ibv_rx_hash_function_flags */
+	uint8_t    rx_hash_function;
+	uint8_t    rx_hash_key_len;
+	uint8_t    *rx_hash_key;
+	/* enum ibv_rx_hash_fields */
+	uint64_t   rx_hash_fields_mask;
+};
+
 struct ibv_qp_init_attr_ex {
 	void		       *qp_context;
 	struct ibv_cq	       *send_cq;
@@ -547,6 +570,13 @@ struct ibv_qp_init_attr_ex {
 	uint32_t		comp_mask;
 	struct ibv_pd	       *pd;
 	struct ibv_xrcd	       *xrcd;
+	uint32_t                create_flags;
+	uint16_t		max_tso_header;
+	struct ibv_rwq_ind_table       *rwq_ind_tbl;
+	struct ibv_rx_hash_conf rx_hash_conf;
+	uint32_t		        source_qpn;
+	/* See enum ibv_qp_create_send_ops_flags */
+	uint64_t                send_ops_flags;
 };
 
 enum ibv_qp_open_attr_mask {

--- a/projects/rccl/src/include/ionic/ionicdvcore.h
+++ b/projects/rccl/src/include/ionic/ionicdvcore.h
@@ -36,11 +36,15 @@ enum ionic_dv_qp_transport_mode {
   IONIC_DV_QPT_TRANSPORT_MRC
 };
 
-struct ionic_qp_init_attr_ex {
+struct ionic_dv_qp_init_attr_ex {
   /* One or more flags of enum ionic_qp_init_attr_mask */
   uint32_t comp_mask;
   /* One or more flags of enum ionic_qp_init_attr_flags */
   uint32_t ionic_flags;
+  /* enum ionic_dv_qp_transport_mode */
+  enum ionic_dv_qp_transport_mode     transport_mode;
+  /* number of RCQ paths */
+  uint8_t     num_rcq_paths;
 };
 
 #endif  // NCCL_IONICDV_CORE_H_

--- a/projects/rccl/src/include/ionic/ionicdvcore.h
+++ b/projects/rccl/src/include/ionic/ionicdvcore.h
@@ -17,4 +17,22 @@ enum ionicdv_reg_udma_mask {
     IONIC_UDMA_MASK_HIGH   = 2
 };
 
+enum ionic_qp_init_attr_mask {
+  IONIC_QP_INIT_ATTR_MASK_FLAGS   = 1 << 0,
+};
+
+enum ionic_qp_init_attr_flags {
+  IONIC_CREATE_QP_TYPE_RCCL       = 1 << 16,
+  IONIC_CREATE_QP_RCCL_DATA       = 1 << 17,
+  IONIC_CREATE_QP_RCCL_RDFENCE    = 1 << 18,
+  IONIC_CREATE_QP_RCCL_RX_OFFLOAD = 1 << 19,
+};
+
+struct ionic_qp_init_attr_ex {
+  /* One or more flags of enum ionic_qp_init_attr_mask */
+  uint32_t comp_mask;
+  /* One or more flags of enum ionic_qp_init_attr_flags */
+  uint32_t ionic_flags;
+};
+
 #endif  // NCCL_IONICDV_CORE_H_

--- a/projects/rccl/src/include/ionic/ionicdvcore.h
+++ b/projects/rccl/src/include/ionic/ionicdvcore.h
@@ -13,19 +13,27 @@
 #include "ibvwrap.h"
 
 enum ionicdv_reg_udma_mask {
-    IONIC_UDMA_MASK_LOW    = 1,
-    IONIC_UDMA_MASK_HIGH   = 2
+  IONIC_UDMA_MASK_LOW    = 1,
+  IONIC_UDMA_MASK_HIGH   = 2
 };
 
-enum ionic_qp_init_attr_mask {
-  IONIC_QP_INIT_ATTR_MASK_FLAGS   = 1 << 0,
+enum ionic_dv_qp_init_attr_mask {
+  IONIC_DV_QP_INIT_ATTR_MASK_FLAGS            = 1 << 0,
+  IONIC_DV_QP_INIT_ATTR_MASK_TRANSPORT_MODE   = 1 << 1,
+  IONIC_DV_QP_INIT_ATTR_MASK_NUM_RCQ_PATHS    = 1 << 2
 };
 
-enum ionic_qp_init_attr_flags {
-  IONIC_CREATE_QP_TYPE_RCCL       = 1 << 16,
-  IONIC_CREATE_QP_RCCL_DATA       = 1 << 17,
-  IONIC_CREATE_QP_RCCL_RDFENCE    = 1 << 18,
-  IONIC_CREATE_QP_RCCL_RX_OFFLOAD = 1 << 19,
+enum ionic_dv_qp_init_attr_flags {
+  IONIC_DV_CREATE_QP_TYPE_RCCL        = 1 << 16,
+  IONIC_DV_CREATE_QP_RCCL_DATA        = 1 << 17,
+  IONIC_DV_CREATE_QP_RCCL_RDFENCE     = 1 << 18,
+  IONIC_DV_CREATE_QP_RCCL_RX_OFFLOAD  = 1 << 19
+};
+
+enum ionic_dv_qp_transport_mode {
+  IONIC_DV_QPT_TRANSPORT_DEFAULT,
+  IONIC_DV_QPT_TRANSPORT_ROCE_V2,
+  IONIC_DV_QPT_TRANSPORT_MRC
 };
 
 struct ionic_qp_init_attr_ex {

--- a/projects/rccl/src/include/ionic/ionicdvsymbols.h
+++ b/projects/rccl/src/include/ionic/ionicdvsymbols.h
@@ -8,7 +8,7 @@
 struct ncclIonicdvSymbols  {
   int (*ionicdv_internal_qp_set_gda)(struct ibv_qp *qp, bool enable_send, bool enable_recv);
   int (*ionicdv_internal_pd_set_udma_mask)(struct ibv_pd *ibpd, uint8_t udma_mask);
-  struct ibv_qp *(*ionicdv_internal_create_qp_ex)(struct ibv_context *context, struct ibv_qp_init_attr_ex *qp_attr, struct ionic_qp_init_attr_ex *ionic_qp_attr);
+  struct ibv_qp *(*ionicdv_internal_create_qp_ex)(struct ibv_context *context, struct ibv_qp_init_attr_ex *qp_attr, struct ionic_dv_qp_init_attr_ex *ionic_qp_attr);
 };
 
 /* Constructs ionic direct verbs symbols per rdma-core linking or dynamic loading mode */

--- a/projects/rccl/src/include/ionic/ionicdvsymbols.h
+++ b/projects/rccl/src/include/ionic/ionicdvsymbols.h
@@ -8,6 +8,7 @@
 struct ncclIonicdvSymbols  {
   int (*ionicdv_internal_qp_set_gda)(struct ibv_qp *qp, bool enable_send, bool enable_recv);
   int (*ionicdv_internal_pd_set_udma_mask)(struct ibv_pd *ibpd, uint8_t udma_mask);
+  struct ibv_qp *(*ionicdv_internal_create_qp_ex)(struct ibv_context *context, struct ibv_qp_init_attr_ex *qp_attr, struct ionic_qp_init_attr_ex *ionic_qp_attr);
 };
 
 /* Constructs ionic direct verbs symbols per rdma-core linking or dynamic loading mode */

--- a/projects/rccl/src/include/ionic/ionicdvwrap.h
+++ b/projects/rccl/src/include/ionic/ionicdvwrap.h
@@ -15,6 +15,6 @@ extern bool ionicdvCreateQpExSupported;
 /* NCCL wrappers of ionic direct verbs functions */
 ncclResult_t wrap_ionicdv_qp_set_gda(struct ibv_qp *ibqp, bool enable_send, bool enable_recv);
 ncclResult_t wrap_ionicdv_pd_set_udma_mask(struct ibv_pd *ibpd, uint8_t udma_mask);
-ncclResult_t wrap_ionicdv_create_qp_ex(struct ibv_context *context, struct ibv_qp_init_attr_ex *qp_attr, struct ionic_qp_init_attr_ex *ionic_qp_attr, struct ibv_qp **qp);
+ncclResult_t wrap_ionicdv_create_qp_ex(struct ibv_context *context, struct ibv_qp_init_attr_ex *qp_attr, struct ionic_dv_qp_init_attr_ex *ionic_qp_attr, struct ibv_qp **qp);
 
 #endif // NCCL_IONICDVWRAP_H_

--- a/projects/rccl/src/include/ionic/ionicdvwrap.h
+++ b/projects/rccl/src/include/ionic/ionicdvwrap.h
@@ -10,8 +10,11 @@
 #include <unistd.h>
 
 ncclResult_t wrap_ionicdv_symbols(void);
+/* Tracks whether ionic_dv_create_qp_ex is available in the loaded libionic version */
+extern bool ionicdvCreateQpExSupported;
 /* NCCL wrappers of ionic direct verbs functions */
 ncclResult_t wrap_ionicdv_qp_set_gda(struct ibv_qp *ibqp, bool enable_send, bool enable_recv);
 ncclResult_t wrap_ionicdv_pd_set_udma_mask(struct ibv_pd *ibpd, uint8_t udma_mask);
+ncclResult_t wrap_ionicdv_create_qp_ex(struct ibv_context *context, struct ibv_qp_init_attr_ex *qp_attr, struct ionic_qp_init_attr_ex *ionic_qp_attr, struct ibv_qp **qp);
 
 #endif // NCCL_IONICDVWRAP_H_

--- a/projects/rccl/src/misc/ionicdvsymbols.cc
+++ b/projects/rccl/src/misc/ionicdvsymbols.cc
@@ -47,6 +47,7 @@ ncclResult_t buildIonicdvSymbols(struct ncclIonicdvSymbols* ionicdvSymbols) {
 
   LOAD_SYM(ionicdvhandle, "ionic_dv_qp_set_gda", ionicdvSymbols->ionicdv_internal_qp_set_gda);
   LOAD_SYM(ionicdvhandle, "ionic_dv_pd_set_udma_mask", ionicdvSymbols->ionicdv_internal_pd_set_udma_mask);
+  LOAD_SYM_VERSION(ionicdvhandle, "ionic_dv_create_qp_ex", ionicdvSymbols->ionicdv_internal_create_qp_ex, IONIC_VERSION);
   INFO(NCCL_INIT, "Loaded dlvsym from libionic.so[.1]");
 
   return ncclSuccess;
@@ -54,6 +55,7 @@ ncclResult_t buildIonicdvSymbols(struct ncclIonicdvSymbols* ionicdvSymbols) {
 teardown:
   ionicdvSymbols->ionicdv_internal_qp_set_gda = NULL;
   ionicdvSymbols->ionicdv_internal_pd_set_udma_mask = NULL;
+  ionicdvSymbols->ionicdv_internal_create_qp_ex = NULL;
 
   if (ionicdvhandle != NULL) dlclose(ionicdvhandle);
   return ncclSystemError;

--- a/projects/rccl/src/misc/ionicdvsymbols.cc
+++ b/projects/rccl/src/misc/ionicdvsymbols.cc
@@ -9,6 +9,7 @@
 
 // IONICDV Library versioning
 #define IONIC_VERSION "IONIC_1.0"
+#define IONIC_EX_VERSION "IONIC_1.3"
 
 ncclResult_t buildIonicdvSymbols(struct ncclIonicdvSymbols* ionicdvSymbols) {
   static void* ionicdvhandle = NULL;
@@ -47,7 +48,7 @@ ncclResult_t buildIonicdvSymbols(struct ncclIonicdvSymbols* ionicdvSymbols) {
 
   LOAD_SYM(ionicdvhandle, "ionic_dv_qp_set_gda", ionicdvSymbols->ionicdv_internal_qp_set_gda);
   LOAD_SYM(ionicdvhandle, "ionic_dv_pd_set_udma_mask", ionicdvSymbols->ionicdv_internal_pd_set_udma_mask);
-  LOAD_SYM_VERSION(ionicdvhandle, "ionic_dv_create_qp_ex", ionicdvSymbols->ionicdv_internal_create_qp_ex, IONIC_VERSION);
+  LOAD_SYM_VERSION(ionicdvhandle, "ionic_dv_create_qp_ex", ionicdvSymbols->ionicdv_internal_create_qp_ex, IONIC_EX_VERSION);
   INFO(NCCL_INIT, "Loaded dlvsym from libionic.so[.1]");
 
   return ncclSuccess;

--- a/projects/rccl/src/misc/ionicdvwrap.cc
+++ b/projects/rccl/src/misc/ionicdvwrap.cc
@@ -64,7 +64,8 @@ ncclResult_t wrap_ionicdv_qp_set_gda(struct ibv_qp *qp, bool enable_send, bool e
   IONICDV_INT_CHECK_RET_ERRNO(ionicdvSymbols, ionicdv_internal_qp_set_gda, ionicdv_internal_qp_set_gda(qp, enable_send, enable_recv), 0, "ionic_dv_qp_set_gda");
 }
 
-ncclResult_t wrap_ionicdv_create_qp_ex(struct ibv_context *context, struct ibv_qp_init_attr_ex *qp_attr, struct ionic_qp_init_attr_ex *ionic_qp_attr, struct ibv_qp **qp) {
+ncclResult_t wrap_ionicdv_create_qp_ex(struct ibv_context *context, struct ibv_qp_init_attr_ex *qp_attr, struct ionic_dv_qp_init_attr_ex *ionic_qp_attr, struct ibv_qp **qp) {
+  INFO(NCCL_NET, "wrap_ionicdv_create_qp_ex: sz ibv_qp_init_attr_ex: %d, ionic_dv_qp_init_attr_ex: %d", sizeof(struct ibv_qp_init_attr_ex), sizeof(struct ionic_dv_qp_init_attr_ex));
   IONICDV_PTR_CHECK_ERRNO(ionicdvSymbols, ionicdv_internal_create_qp_ex, ionicdv_internal_create_qp_ex(context, qp_attr, ionic_qp_attr), *qp, NULL, "ionic_dv_create_qp_ex");
 }
 

--- a/projects/rccl/src/misc/ionicdvwrap.cc
+++ b/projects/rccl/src/misc/ionicdvwrap.cc
@@ -9,6 +9,7 @@
 static pthread_once_t initOnceControl = PTHREAD_ONCE_INIT;
 static ncclResult_t initResult;
 struct ncclIonicdvSymbols ionicdvSymbols;
+bool ionicdvCreateQpExSupported = false;
 
 extern bool rcclUseAinic();
 
@@ -17,6 +18,10 @@ ncclResult_t wrap_ionicdv_symbols(void) {
   if (rcclUseAinic()) {
     pthread_once(&initOnceControl,
                  [](){ initResult = buildIonicdvSymbols(&ionicdvSymbols); });
+    if (initResult == ncclSuccess) {
+      ionicdvCreateQpExSupported = (ionicdvSymbols.ionicdv_internal_create_qp_ex != NULL);
+      INFO(NCCL_NET, "ionic_dv_create_qp_ex support: %s", ionicdvCreateQpExSupported ? "yes" : "no");
+    }
     return initResult;
   }
 #endif
@@ -30,6 +35,15 @@ ncclResult_t wrap_ionicdv_symbols(void) {
      WARN("lib wrapper not initialized."); \
      return ncclInternalError; \
   }
+
+#define IONICDV_PTR_CHECK_ERRNO(container, internal_name, call, retval, error_retval, name) \
+  CHECK_NOT_NULL(container, internal_name); \
+  retval = container.call; \
+  if (retval == error_retval) { \
+    WARN("Call to " name " failed with error %s", strerror(errno)); \
+    return ncclSystemError; \
+  } \
+  return ncclSuccess;
 
 #define IONICDV_INT_CHECK_RET_ERRNO(container, internal_name, call, success_retval, name) \
   CHECK_NOT_NULL(container, internal_name); \
@@ -48,6 +62,10 @@ ncclResult_t wrap_ionicdv_qp_set_gda(struct ibv_qp *qp, bool enable_send, bool e
     return ncclSystemError;
   }
   IONICDV_INT_CHECK_RET_ERRNO(ionicdvSymbols, ionicdv_internal_qp_set_gda, ionicdv_internal_qp_set_gda(qp, enable_send, enable_recv), 0, "ionic_dv_qp_set_gda");
+}
+
+ncclResult_t wrap_ionicdv_create_qp_ex(struct ibv_context *context, struct ibv_qp_init_attr_ex *qp_attr, struct ionic_qp_init_attr_ex *ionic_qp_attr, struct ibv_qp **qp) {
+  IONICDV_PTR_CHECK_ERRNO(ionicdvSymbols, ionicdv_internal_create_qp_ex, ionicdv_internal_create_qp_ex(context, qp_attr, ionic_qp_attr), *qp, NULL, "ionic_dv_create_qp_ex");
 }
 
 ncclResult_t wrap_ionicdv_pd_set_udma_mask(struct ibv_pd *ibpd, uint8_t udma_mask) {


### PR DESCRIPTION
## Summary

- Add support for `ionic_dv_create_qp_ex`, a newer Ionic Direct Verbs API for creating Queue Pairs with Ionic-specific extended attributes, replacing the older `sq_sig_all` bitmask hack
- Detect capability at runtime via `ionicdvCreateQpExSupported` flag so the build stays compatible with older `libionic.so` versions that lack the new symbol
- Fall back to the existing `sq_sig_all` bitmask path when the symbol is unavailable

## Changes

- **`ionicdvcore.h`**: define `ionic_qp_init_attr_mask`, `ionic_qp_init_attr_flags` (`TYPE_RCCL`, `RCCL_DATA`, `RCCL_RDFENCE`, `RCCL_RX_OFFLOAD`), and `ionic_qp_init_attr_ex` struct
- **`ionicdvsymbols.h/.cc`**: add `ionicdv_internal_create_qp_ex` function pointer, loaded via `LOAD_SYM_VERSION` with `NULL` fallback on older libraries
- **`ionicdvwrap.h/.cc`**: expose `ionicdvCreateQpExSupported` global bool, add `IONICDV_PTR_CHECK_ERRNO` macro, implement `wrap_ionicdv_create_qp_ex()`
- **`rocm_netib.patch`**: in `ncclIbCreateQp`, use `ibv_qp_init_attr_ex` + `ionic_qp_init_attr_ex` via `wrap_ionicdv_create_qp_ex` when supported; fall back to `sq_sig_all` bitmask path otherwise; call `wrap_ionicdv_qp_set_gda` to enable GDA on the new QP

## Motivation
The existing Ionic QP creation path overloaded the sq_sig_all field of ibv_qp_init_attr to pass Ionic-specific flags — a fragile hack. libionic now provides ionic_dv_create_qp_ex, a proper extended API with a dedicated attribute struct. This change adopts the new API where available, with a runtime fallback to the legacy path for older libionic.so versions.

## Technical Details
- AINIC IONIC driver repo PR link for this support - https://github.com/pensando/rdma-core/pull/171
- This support will be upstreamed with upcoming release


## JIRA ID
<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan
- Build with a `libionic.so` that exports `ionic_dv_create_qp_ex` and verify the new path is taken (log shows `ionic_dv_create_qp_ex support: yes`)
- Build with an older `libionic.so` without the symbol and verify fallback to `sq_sig_all` path (log shows `ionic_dv_create_qp_ex support: no`)
- Run RCCL allreduce / alltoall tests on Ionic RoCE hardware for both paths

## Test Result
- Built with and without the new ionic driver dev api support
- Tested RCCL with and without the new ionic driver dev api support with the out-of-tree driver for AINIC Host-SW package.

## Submission Checklist
- [X] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
