### PR TITLE
[hipfile] Move CI from standalone repo

### DIFF
--- a/.github/workflows/hipfile-build-nvidia.yml
+++ b/.github/workflows/hipfile-build-nvidia.yml
@@ -1,0 +1,123 @@
+name: build-hipfile-NVIDIA
+run-name: Build hipFile for NVIDIA platforms
+
+env:
+  AIS_INPUT_CI_IMAGE: ${{ inputs.ci_image }}
+  AIS_INPUT_PLATFORM: ${{ inputs.platform }}
+  AIS_INPUT_ROCM_VERSION: ${{ inputs.rocm_version }}
+  AIS_MOUNT_PATH: /mnt/ais/ext4
+
+on:
+  workflow_call:
+    inputs:
+      ci_image:
+        required: true
+        type: string
+      platform:
+        required: true
+        type: string
+      rocm_version:
+        description: "Target ROCm MAJOR.MINOR.PATCH Version"
+        required: true
+        type: string
+
+permissions:
+  contents: read
+  packages: read
+
+jobs:
+
+  compile_on_NVIDIA:
+    env:
+      AIS_INPUT_CXX_COMPILER: ${{ matrix.supported_compilers }}
+    runs-on: [ubuntu-24.04]
+    strategy:
+      fail-fast: false
+      matrix:
+        supported_compilers:
+          - g++
+          - clang++
+    steps:
+      - name: Set early AIS CI environment variables
+        run: |
+          echo "AIS_PR_NUMBER=$(echo "${GITHUB_REF}" | sed 's|[^0-9]||g')" >> "${GITHUB_ENV}"
+          echo "AIS_SAFE_COMPILER_NAME=$(echo ${AIS_INPUT_CXX_COMPILER} | sed 's|[\+]|plus|g')" >> "${GITHUB_ENV}"
+      - name: Set AIS CI container name
+        run: |
+          echo "AIS_CONTAINER_NAME=${AIS_PR_NUMBER}_${GITHUB_JOB}_${AIS_INPUT_PLATFORM}_${AIS_INPUT_ROCM_VERSION}_${AIS_SAFE_COMPILER_NAME}" >> "${GITHUB_ENV}"
+      - name: Fetching code repository...
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+          path: rocm-systems
+          sparse-checkout: |
+            projects/hipfile
+            .github/workflows
+      - name: Authenticating to GitHub Container Registry
+        uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2 # v4.0.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      # Detach the container and run separate commands to it.
+      # Thus we can make separate explicit steps in the Github CI
+      # as if we were able to parameterize the container image in the first place.
+      - name: Starting Docker Container
+        run: |
+          docker run \
+            -dt \
+            --rm \
+            --pull always \
+            -v ${GITHUB_WORKSPACE}:/mnt/ais:ro \
+            -v "${AIS_MOUNT_PATH}:/mnt/ais-fs" \
+            --name "${AIS_CONTAINER_NAME}" \
+            "${AIS_INPUT_CI_IMAGE}"
+      - name: Make copy of the code repository and create build directories
+        run: |
+          docker exec \
+            -t \
+            "${AIS_CONTAINER_NAME}" \
+            /bin/bash -c '
+              cp -R /mnt/ais /ais
+              mkdir -p /ais/build/hipfile
+            '
+      - name: Generate build files for hipFile targeting the NVIDIA platform (${{ matrix.supported_compilers }})
+        run: |
+          docker exec \
+            -e "_AIS_INPUT_CXX_COMPILER=${AIS_INPUT_CXX_COMPILER}" \
+            -t \
+            -w /ais/build/hipfile \
+            "${AIS_CONTAINER_NAME}" \
+            /bin/bash -c '
+              cmake \
+                -DCMAKE_CXX_COMPILER="${_AIS_INPUT_CXX_COMPILER}" \
+                -DCMAKE_CXX_FLAGS="-Werror" \
+                -DCMAKE_HIP_PLATFORM=nvidia \
+                ../../rocm-systems/projects/hipfile
+            '
+      - name: Build hipFile for the NVIDIA platform (${{ matrix.supported_compilers }})
+        run: |
+          docker exec \
+            -t \
+            -w /ais/build/hipfile \
+            "${AIS_CONTAINER_NAME}" \
+            /bin/bash -c '
+              cmake --build . --parallel
+            '
+      - name: Clean CMake build directories
+        run: |
+          docker exec \
+            -t \
+            -w /ais/ \
+            "${AIS_CONTAINER_NAME}" \
+            /bin/bash -c '
+              rm -rf build/hipfile/
+            '
+      - name: Cleanup & Stop the Docker container
+        if: ${{ always() }}
+        run: |
+          if docker inspect "${AIS_CONTAINER_NAME}" >/dev/null 2>&1; then
+            docker stop "${AIS_CONTAINER_NAME}"
+          else
+            echo "Container ${AIS_CONTAINER_NAME} does not exist; skipping stop"
+          fi

--- a/.github/workflows/hipfile-build.yml
+++ b/.github/workflows/hipfile-build.yml
@@ -110,9 +110,6 @@ jobs:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      - name: Get list of docker images
-        run: |
-          docker images
       # Detach the container and run separate commands to it.
       # Thus we can make separate explicit steps in the Github CI
       # as if we were able to parameterize the container image in the first place.

--- a/.github/workflows/hipfile-build.yml
+++ b/.github/workflows/hipfile-build.yml
@@ -1,0 +1,348 @@
+name: build-test-hipfile
+run-name: Build, test, and analyze hipFile
+
+env:
+  AIS_GHA_CMD_FILES_DOCKER_DIR: /root/github
+  AIS_INPUT_BUILD_ID: ${{ inputs.build_id }}
+  AIS_INPUT_CI_IMAGE: ${{ inputs.ci_image }}
+  AIS_INPUT_CXX_COMPILER: ${{ inputs.cxx_compiler }}
+  AIS_INPUT_JOB_DESIGNATOR: ${{ inputs.job_designator }}
+  AIS_INPUT_PLATFORM: ${{ inputs.platform }}
+  AIS_INPUT_UPLOAD_ARTIFACTS: ${{ inputs.upload_artifacts }}
+  AIS_MOUNT_PATH: /mnt/ais/ext4
+  AIS_PKG_MGR: >-
+    ${{
+      inputs.platform == 'rocky' && 'dnf' ||
+      inputs.platform == 'suse' && 'zypper' ||
+      inputs.platform == 'ubuntu' && 'apt'
+    }}
+  AIS_PKG_TYPE: ${{ inputs.platform == 'ubuntu' && 'DEB' || 'RPM' }}
+  AIS_INPUT_ROCM_VERSION: ${{ inputs.rocm_version }}
+  # Code coverage report only vetted to work for amdclang++ on Ubuntu
+  AIS_USE_CODE_COVERAGE: ${{ inputs.cxx_compiler == 'amdclang++' && inputs.platform == 'ubuntu' }}
+  AIS_HIP_ARCHITECTURES: gfx950;gfx1201;gfx1200;gfx1101;gfx1100;gfx1030;gfx942;gfx90a;gfx908
+
+on:
+  workflow_call:
+    inputs:
+      build_id:
+        default: 9999
+        description: "Number assigned by the build orchestrator"
+        required: false
+        type: number
+      ci_image:
+        required: true
+        type: string
+      cxx_compiler:
+        required: true
+        type: string
+      job_designator:
+        description: "Qualifies the type of job building hipFile"
+        required: false
+        type: string
+      platform:
+        required: true
+        type: string
+      rocm_version:
+        description: "Target ROCm MAJOR.MINOR.PATCH Version"
+        required: true
+        type: string
+      upload_artifacts:
+        default: false
+        description: "Upload binaries and the build tree as artifacts to GitHub"
+        type: boolean
+    outputs:
+      ais_hipfile_pkg_dev_filename:
+        description: "Filename for the hipFile development DEB/RPM package"
+        value: ${{ jobs.compile_on_AMD.outputs.ais_hipfile_pkg_dev_filename }}
+      ais_hipfile_pkg_filename:
+        description: "Filename for the hipFile runtime DEB/RPM package"
+        value: ${{ jobs.compile_on_AMD.outputs.ais_hipfile_pkg_filename }}
+      ais_hipfile_pkg_version:
+        description: "Version for the hipFile DEB/RPM packages"
+        value: ${{ jobs.compile_on_AMD.outputs.ais_hipfile_pkg_version }}
+      ci_image:
+        description: "Echo ci_image for downstream jobs to consume"
+        value: ${{ inputs.ci_image }}
+
+permissions:
+  contents: read
+  packages: read
+
+jobs:
+
+  compile_on_AMD:
+    name: compile_on_AMD (${{ inputs.cxx_compiler }})
+    outputs:
+      ais_hipfile_pkg_dev_filename: ${{ steps.pkg-metadata.outputs.AIS_HIPFILE_PKG_DEV_FILENAME }}
+      ais_hipfile_pkg_filename: ${{ steps.pkg-metadata.outputs.AIS_HIPFILE_PKG_FILENAME }}
+      ais_hipfile_pkg_version: ${{ steps.pkg-metadata.outputs.AIS_HIPFILE_PKG_VERSION }}
+    runs-on: [ubuntu-24.04]
+    steps:
+      - name: Set early AIS CI environment variables
+        # ROCm Build Environment Args
+        # - JOB_DESIGNATOR
+        # - BUILD_ID
+        # - SLES_BUILD_ID_PREFIX (will be instead be set in SUSE based DOCKERFILE's)
+        # - CPACK_<TYPE>_PACKAGE_RELEASE (made up of the above)
+        # - ROCM_VERSION (set in DOCKERFILE)
+        # See: https://github.com/ROCm/ROCm/blob/8aa43d132f0d541eb5303dc532f5931cb80ad87a/tools/rocm-build/envsetup.sh#L25-L42
+        run: |
+          echo "AIS_PR_NUMBER=$(echo "${GITHUB_REF}" | sed 's|[^0-9]||g')" >> "${GITHUB_ENV}"
+          echo "AIS_GHA_CMD_FILES_DIR=${GITHUB_ENV%/*}" >> "${GITHUB_ENV}"
+          echo "AIS_SAFE_COMPILER_NAME=$(echo ${AIS_INPUT_CXX_COMPILER} | sed 's|[\+]|plus|g')" >> "${GITHUB_ENV}"
+      - name: Set AIS CI container name
+        # We should expect that there are multiple instances of this job with different cxx_compilers.
+        # On non-pull_request triggering workflows, AIS_PR_NUMBER may be empty.
+        run: |
+          echo "AIS_CONTAINER_NAME=${AIS_PR_NUMBER:=${GITHUB_RUN_ID}}_${GITHUB_JOB}_${AIS_INPUT_PLATFORM}_${AIS_INPUT_ROCM_VERSION}_${AIS_SAFE_COMPILER_NAME}" >> "${GITHUB_ENV}"
+      - name: Fetching code repository...
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+          path: rocm-systems
+          sparse-checkout: |
+            projects/hipfile
+            .github/workflows
+      - name: Authenticating to GitHub Container Registry
+        uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2 # v4.0.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Get list of docker images
+        run: |
+          docker images
+      # Detach the container and run separate commands to it.
+      # Thus we can make separate explicit steps in the Github CI
+      # as if we were able to parameterize the container image in the first place.
+      - name: Starting Docker Container
+        run: |
+          docker run \
+            -dt \
+            --rm \
+            --pull always \
+            -v ${GITHUB_WORKSPACE}:/mnt/ais:ro \
+            -v "${AIS_GHA_CMD_FILES_DIR}:${AIS_GHA_CMD_FILES_DOCKER_DIR}" \
+            -v "${AIS_MOUNT_PATH}:/mnt/ais-fs" \
+            --name "${AIS_CONTAINER_NAME}" \
+            "${AIS_INPUT_CI_IMAGE}"
+      - name: Make copy of the code repository and create build directories
+        # Single quotes necessary to ensure string/command substitutions happen
+        # in the container and not on the host.
+        run: |
+          docker exec \
+            -t \
+            "${AIS_CONTAINER_NAME}" \
+            /bin/bash -c '
+              cp -R /mnt/ais /ais
+              mkdir -p /ais/build/hipfile
+            '
+      - name: Generate build files for hipFile targeting the AMD platform (${{ inputs.cxx_compiler }})
+        # ${SLES_BUILD_ID} is mentioned for all platforms to match current ROCm build implementation.
+        run: |
+          docker exec \
+            -e "_AIS_INPUT_CXX_COMPILER=${AIS_INPUT_CXX_COMPILER}" \
+            -e "BUILD_ID=${AIS_INPUT_BUILD_ID}" \
+            -e "JOB_DESIGNATOR=${AIS_INPUT_JOB_DESIGNATOR}" \
+            -t \
+            -w /ais/build/hipfile \
+            "${AIS_CONTAINER_NAME}" \
+            /bin/bash -c '
+              export CPACK_DEBIAN_PACKAGE_RELEASE="${JOB_DESIGNATOR}${SLES_BUILD_ID_PREFIX}${BUILD_ID}~$(source /etc/os-release && echo ${VERSION_ID})"
+              export CPACK_RPM_PACKAGE_RELEASE="${JOB_DESIGNATOR}${SLES_BUILD_ID_PREFIX}${BUILD_ID}"
+              cmake \
+                -DCMAKE_BUILD_TYPE=Debug \
+                -DCMAKE_CXX_COMPILER="${_AIS_INPUT_CXX_COMPILER}" \
+                -DCMAKE_CXX_FLAGS="-Werror" \
+                -DCMAKE_HIP_ARCHITECTURES="${{ env.AIS_HIP_ARCHITECTURES }}" \
+                -DCMAKE_HIP_PLATFORM=amd \
+                -DAIS_BUILD_DOCS=ON \
+                -DAIS_USE_CODE_COVERAGE=${{ env.AIS_USE_CODE_COVERAGE == 'true' && 'ON' || 'OFF' }} \
+                -DROCM_VERSION="${ROCM_VERSION}" \
+                -DAIS_CAPABLE_DIR=/mnt/ais-fs \
+                ../../rocm-systems/projects/hipfile
+            '
+      - name: Build hipFile for the AMD platform (${{ inputs.cxx_compiler }})
+        run: |
+          docker exec \
+            -t \
+            -w /ais/build/hipfile \
+            "${AIS_CONTAINER_NAME}" \
+            /bin/bash -c '
+              cmake --build . --parallel
+            '
+      - name: Test hipFile for the AMD platform (${{ inputs.cxx_compiler }})
+        run: |
+          docker exec \
+            -t \
+            -w /ais/build/hipfile \
+            "${AIS_CONTAINER_NAME}" \
+            /bin/bash -c '
+              ctest -V -L "unit" --parallel
+            '
+      - name: Generate coverage summary (${{ inputs.cxx_compiler }})
+        if: ${{ env.AIS_USE_CODE_COVERAGE == 'true' }}
+        run: |
+          docker exec \
+            -t \
+            -w /ais/build/hipfile \
+            "${AIS_CONTAINER_NAME}" \
+            /bin/bash -c '
+              export PATH="/opt/rocm/llvm/bin:${PATH}"
+              ../../rocm-systems/projects/hipfile/util/llvm-coverage.sh
+              printf "# Code Coverage\n"
+              printf "\`\`\`\n"
+              cat coverage-report.txt
+              printf "\`\`\`\n"
+            ' >> ${GITHUB_STEP_SUMMARY}
+      - name: Create hipFile package
+        run: |
+          docker exec \
+            -e "_AIS_PKG_TYPE=${AIS_PKG_TYPE}" \
+            -t \
+            -w /ais/build/hipfile \
+            "${AIS_CONTAINER_NAME}" \
+            /bin/bash -c '
+              cpack -G "${_AIS_PKG_TYPE}"
+            '
+      # CI is unable to peer into CMake to capture this data ahead of time.
+      # We should only produce a single package so we can use a glob pattern
+      # to complete the relative path to select the package.
+      # For now, hardcode the glob pattern to the default DEV release package name.
+      # (We will also hardcode arch as well.)
+      - name: Capture package metadata
+        id: pkg-metadata
+        run: |
+          docker exec \
+            -e "AIS_GITHUB_OUTPUT=${{ env.AIS_GHA_CMD_FILES_DOCKER_DIR }}/${GITHUB_OUTPUT##*/}" \
+            -t \
+            -w /ais/build/hipfile \
+            "${AIS_CONTAINER_NAME}" \
+            /bin/bash -c '
+              shopt -s nullglob
+              AIS_HIPFILE_PKG_DEV_FILENAME="$(echo hipfile-de{v,vel}{-,_}[0-9]*.{deb,rpm})"
+              AIS_HIPFILE_PKG_FILENAME="$(echo hipfile{-,_}[0-9]*.{deb,rpm})"
+              echo "AIS_HIPFILE_PKG_DEV_FILENAME=${AIS_HIPFILE_PKG_DEV_FILENAME}" >> "${AIS_GITHUB_OUTPUT}"
+              echo "AIS_HIPFILE_PKG_FILENAME=${AIS_HIPFILE_PKG_FILENAME}" >> "${AIS_GITHUB_OUTPUT}"
+              echo "AIS_HIPFILE_PKG_VERSION=$(
+                ${{
+                  env.AIS_PKG_TYPE == 'DEB' &&
+                  'dpkg-deb -f "${AIS_HIPFILE_PKG_FILENAME}" "Version"' ||
+                  'rpm -qp --qf "%{VERSION}" "${AIS_HIPFILE_PKG_FILENAME}"'
+                }}
+              )" >> "${AIS_GITHUB_OUTPUT}"
+            '
+      # This information will be nice to have for debugging CPack configuration
+      - name: Print package metadata for debugging
+        run: |
+          docker exec \
+            -t \
+            -w /ais/build/hipfile \
+            "${AIS_CONTAINER_NAME}" \
+            /bin/bash -c '
+              echo "Runtime Package:"
+              ${{
+                format(
+                  env.AIS_PKG_TYPE == 'DEB' &&
+                    'dpkg-deb -I "{0}" && dpkg-deb -c "{0}"' ||
+                    'rpm -qpil --requires "{0}"',
+                  steps.pkg-metadata.outputs.AIS_HIPFILE_PKG_FILENAME
+                )
+              }}
+              echo -e "\n\nDevelopment Package:"
+              ${{
+                format(
+                  env.AIS_PKG_TYPE == 'DEB' &&
+                    'dpkg-deb -I "{0}" && dpkg-deb -c "{0}"' ||
+                    'rpm -qpil --requires "{0}"',
+                  steps.pkg-metadata.outputs.AIS_HIPFILE_PKG_DEV_FILENAME
+                )
+              }}
+            '
+      - name: Validate metadata was stored correctly
+        run: |
+          echo "hipFile package dev filename: ${{ steps.pkg-metadata.outputs.AIS_HIPFILE_PKG_DEV_FILENAME }}"
+          echo "hipFile package filename: ${{ steps.pkg-metadata.outputs.AIS_HIPFILE_PKG_FILENAME }}"
+          echo "hipFile package version: ${{ steps.pkg-metadata.outputs.AIS_HIPFILE_PKG_VERSION }}"
+          if [[ -z "${{ steps.pkg-metadata.outputs.AIS_HIPFILE_PKG_VERSION }}" ]]; then exit 1; fi
+      - name: Test installing the hipFile package.
+        run: |
+          docker exec \
+            -t \
+            -w /ais/build/hipfile \
+            "${AIS_CONTAINER_NAME}" \
+            /bin/bash -c '
+              ${{
+                format(
+                  env.AIS_PKG_MGR == 'apt' && 'apt install -y "./{0}" "./{1}"' ||
+                    env.AIS_PKG_MGR == 'dnf' && 'dnf install -y --cacheonly "./{0}" "./{1}"' ||
+                    env.AIS_PKG_MGR == 'zypper' && 'zypper --no-refresh install -y --allow-unsigned-rpm "./{0}" "./{1}"' ||
+                    'echo "Unknown platform."; exit 1',
+                  steps.pkg-metadata.outputs.AIS_HIPFILE_PKG_DEV_FILENAME,
+                  steps.pkg-metadata.outputs.AIS_HIPFILE_PKG_FILENAME
+                )
+              }}
+            '
+      - name: Copy hipFile packages out of the container
+        if: ${{ inputs.upload_artifacts }}
+        run: |
+          docker cp \
+            "${AIS_CONTAINER_NAME}:/ais/build/hipfile/${{ steps.pkg-metadata.outputs.AIS_HIPFILE_PKG_DEV_FILENAME }}" \
+            ${GITHUB_WORKSPACE}
+          docker cp \
+            "${AIS_CONTAINER_NAME}:/ais/build/hipfile/${{ steps.pkg-metadata.outputs.AIS_HIPFILE_PKG_FILENAME }}" \
+            ${GITHUB_WORKSPACE}
+      - name: Upload development hipFile Package as an Artifact
+        if: ${{ inputs.upload_artifacts }}
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        with:
+          name: ${{ steps.pkg-metadata.outputs.AIS_HIPFILE_PKG_DEV_FILENAME }}
+          path: ${{ format('{0}/{1}', github.workspace, steps.pkg-metadata.outputs.AIS_HIPFILE_PKG_DEV_FILENAME) }}
+          if-no-files-found: error
+          retention-days: 1
+          compression-level: 0
+      - name: Upload runtime hipFile Package as an Artifact
+        if: ${{ inputs.upload_artifacts }}
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        with:
+          name: ${{ steps.pkg-metadata.outputs.AIS_HIPFILE_PKG_FILENAME }}
+          path: ${{ format('{0}/{1}', github.workspace, steps.pkg-metadata.outputs.AIS_HIPFILE_PKG_FILENAME) }}
+          if-no-files-found: error
+          retention-days: 1
+          compression-level: 0
+      # CTestTestfiles.cmake hardcodes the absolute path of the GTest executables
+      # in the build directory. CTest relies on this metadata for execution. It is not
+      # trivial to modify this metadata, otherwise an installable test package could be
+      # used. For now, reuse the build directory.
+      - name: Copy hipFile build directory out of the container
+        if: ${{ inputs.upload_artifacts }}
+        run: |
+          docker cp \
+            "${AIS_CONTAINER_NAME}:/ais/build/hipfile" \
+            ${GITHUB_WORKSPACE}/hipfile-build-dir
+      - name: Upload runtime hipFile package as an artifact
+        if: ${{ inputs.upload_artifacts }}
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        with:
+          name: hipfile-build-dir-${{ inputs.platform }}
+          path: ${{ github.workspace }}/hipfile-build-dir
+          if-no-files-found: error
+          retention-days: 1
+      - name: Clean CMake build directories
+        run: |
+          docker exec \
+            -t \
+            -w /ais/build \
+            "${AIS_CONTAINER_NAME}" \
+            /bin/bash -c '
+              rm -rf hipfile
+            '
+      - name: Cleanup & Stop the Docker container
+        if: ${{ always() }}
+        run: |
+          if docker inspect "${AIS_CONTAINER_NAME}" >/dev/null 2>&1; then
+            docker stop "${AIS_CONTAINER_NAME}"
+          else
+            echo "Container ${AIS_CONTAINER_NAME} does not exist; skipping stop"
+          fi

--- a/.github/workflows/hipfile-ci-system.yml
+++ b/.github/workflows/hipfile-ci-system.yml
@@ -1,0 +1,403 @@
+name: hipfile-system-tests
+run-name: Run hipFile system tests
+
+env:
+  AIS_GHA_CMD_FILES_DOCKER_DIR: /root/github
+  AIS_INPUT_HIPFILE_PKG_DEV_FILENAME: ${{ inputs.ais_hipfile_pkg_dev_filename }}
+  AIS_INPUT_HIPFILE_PKG_FILENAME: ${{ inputs.ais_hipfile_pkg_filename }}
+  AIS_INPUT_CI_IMAGE: ${{ inputs.ci_image }}
+  AIS_INPUT_PLATFORM: ${{ inputs.platform }}
+  AIS_INPUT_ROCM_VERSION: ${{ inputs.rocm_version }}
+  AIS_MOUNT_PATH: /mnt/ais/ext4
+  AIS_PKG_INSTALL_CMD: >-
+    ${{
+      case(
+        inputs.platform == 'rocky', 'dnf install -y',
+        inputs.platform == 'suse', 'zypper install -y --allow-unsigned-rpm',
+        inputs.platform == 'ubuntu', 'apt update; apt install -y',
+        ''
+      )
+    }}
+  AIS_PKG_MGR: >-
+    ${{
+      inputs.platform == 'rocky' && 'dnf' ||
+      inputs.platform == 'suse' && 'zypper' ||
+      inputs.platform == 'ubuntu' && 'apt'
+    }}
+
+on:
+  workflow_call:
+    inputs:
+      ais_hipfile_pkg_dev_filename:
+        required: true
+        type: string
+      ais_hipfile_pkg_filename:
+        required: true
+        type: string
+      ci_image:
+        required: true
+        type: string
+      platform:
+        required: true
+        type: string
+      rocm_version:
+        description: "Target ROCm MAJOR.MINOR.PATCH Version"
+        required: true
+        type: string
+
+permissions:
+  contents: read
+  packages: read
+
+jobs:
+
+  run_system_tests:
+    runs-on: [AIS]
+    steps:
+      - name: Set early AIS CI environment variables
+        run: echo "AIS_PR_NUMBER=$(echo "${GITHUB_REF}" | sed 's|[^0-9]||g')" >> "${GITHUB_ENV}"
+      - name: Set AIS CI container name
+        run: |
+          echo "AIS_CONTAINER_NAME=${AIS_PR_NUMBER}_${GITHUB_JOB}_${AIS_INPUT_PLATFORM}_${AIS_INPUT_ROCM_VERSION}" >> "${GITHUB_ENV}"
+      - name: Fetching hipFile repository...
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+          path: rocm-systems
+          sparse-checkout: |
+            projects/hipfile
+            .github/workflows
+      - name: Download hipFile runtime package
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: ${{ inputs.ais_hipfile_pkg_filename }}
+      - name: Download hipFile development package
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: ${{ inputs.ais_hipfile_pkg_dev_filename }}
+      - name: Download hipFile build directory
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: hipfile-build-dir-${{ inputs.platform }}
+          path: ${{ github.workspace }}/hipfile-build-dir
+      - name: Authenticating to GitHub Container Registry
+        uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2 # v4.0.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      # Detach the container and run separate commands to it.
+      # Thus we can make separate explicit steps in the Github CI
+      # as if we were able to parameterize the container image in the first place.
+      - name: Starting Docker Container
+        run: |
+          docker run \
+            -dt \
+            --rm \
+            --device=/dev/kfd \
+            --device=/dev/dri \
+            --security-opt seccomp=unconfined \
+            --pull always \
+            -v ${GITHUB_WORKSPACE}:/mnt/ais:ro \
+            -v "${AIS_MOUNT_PATH}:/mnt/ais-fs" \
+            --name "${AIS_CONTAINER_NAME}" \
+            "${AIS_INPUT_CI_IMAGE}"
+      - name: Create hipfile IO test directory
+        run: |
+          docker exec -t "${AIS_CONTAINER_NAME}" /bin/bash -c "mkdir -p /mnt/ais-fs/${AIS_CONTAINER_NAME}"
+      - name: Make copy of the code repository and create build directories
+        run: |
+          docker exec \
+            -t \
+            "${AIS_CONTAINER_NAME}" \
+            /bin/bash -c '
+              cp -R /mnt/ais /ais
+              mkdir -p /ais/build/hipfile
+            '
+      - name: Copy the hipFile packages into the container
+        run: |
+          docker cp \
+            "${GITHUB_WORKSPACE}/${AIS_INPUT_HIPFILE_PKG_FILENAME}" \
+            "${AIS_CONTAINER_NAME}:/root"
+          docker cp \
+            "${GITHUB_WORKSPACE}/${AIS_INPUT_HIPFILE_PKG_DEV_FILENAME}" \
+            "${AIS_CONTAINER_NAME}:/root"
+      - name: Install the hipFile packages
+        run: |
+          docker exec \
+            -t \
+            -w /root \
+            "${AIS_CONTAINER_NAME}" \
+            /bin/bash -c '
+              ${{
+                format(
+                  env.AIS_PKG_MGR == 'apt' && 'apt install -y "./{0}" "./{1}"' ||
+                    env.AIS_PKG_MGR == 'dnf' && 'dnf install -y --cacheonly "./{0}" "./{1}"' ||
+                    env.AIS_PKG_MGR == 'zypper' && 'zypper --no-refresh install -y --allow-unsigned-rpm "./{0}" "./{1}"' ||
+                    'echo "Unknown platform."; exit 1',
+                  inputs.ais_hipfile_pkg_filename,
+                  inputs.ais_hipfile_pkg_dev_filename
+                )
+              }}
+            '
+      # GitHub Build Artifacts do not preserve file permissions, namely the executable bit.
+      - name: Fix file permissions on GTest executables
+        run: |
+          chmod a+x \
+            ${GITHUB_WORKSPACE}/hipfile-build-dir/test/hipfile_system_tests \
+            ${GITHUB_WORKSPACE}/hipfile-build-dir/test/amd_detail/batch_mt \
+            ${GITHUB_WORKSPACE}/hipfile-build-dir/test/amd_detail/state_mt \
+            ${GITHUB_WORKSPACE}/hipfile-build-dir/examples/aiscp/aiscp
+      - name: Copy the hipFile build directory into the container
+        run: |
+          docker cp \
+            ${GITHUB_WORKSPACE}/hipfile-build-dir/. \
+            "${AIS_CONTAINER_NAME}:/ais/build/hipfile"
+      - name: Run hipFile system tests for the AMD platform (amdclang++)
+        run: |
+          docker exec \
+            -t \
+            -w /ais/build/hipfile \
+            "${AIS_CONTAINER_NAME}" \
+            /bin/bash -c '
+              ctest -V -L "system" --parallel
+            '
+      - name: Stress tests for hipFile targeting the AMD platform (amdclang++)
+        run: |
+          docker exec \
+            -t \
+            -w /ais/build/hipfile \
+            "${AIS_CONTAINER_NAME}" \
+            /bin/bash -c '
+              ctest -V -L "stress" --parallel
+            '
+      - name: hipFile fallback/POSIX IO test using aiscp
+        run: |
+          docker exec \
+            -t \
+            -w "/mnt/ais-fs/${AIS_CONTAINER_NAME}" \
+            "${AIS_CONTAINER_NAME}" \
+            /bin/bash -c '
+              HIPFILE_FORCE_COMPAT_MODE=true
+                /ais/rocm-systems/projects/hipfile/util/ci-aiscp-test.sh \
+                /ais/build/hipfile/examples/aiscp/aiscp
+            '
+      - name: hipFile fastpath/AIS IO test using aiscp
+        run: |
+          docker exec \
+            -t \
+            -w "/mnt/ais-fs/${AIS_CONTAINER_NAME}" \
+            "${AIS_CONTAINER_NAME}" \
+            /bin/bash -c '
+              HIPFILE_ALLOW_COMPAT_MODE=false
+                /ais/rocm-systems/projects/hipfile/util/ci-aiscp-test.sh \
+                /ais/build/hipfile/examples/aiscp/aiscp
+            '
+      - name: Destroy hipfile IO test directory
+        if: ${{ always() }}
+        run: |
+          docker exec -t "${AIS_CONTAINER_NAME}" /bin/bash -c "rm -fr /mnt/ais-fs/${AIS_CONTAINER_NAME}"
+      - name: Cleanup & Stop the Docker container
+        if: ${{ always() }}
+        run: |
+          if docker inspect "${AIS_CONTAINER_NAME}" >/dev/null 2>&1; then
+            docker stop "${AIS_CONTAINER_NAME}"
+          else
+            echo "Container ${AIS_CONTAINER_NAME} does not exist; skipping stop"
+          fi
+      - name: Cleanup self-hosted runner workspace
+        if: ${{ always() }}
+        run: |
+          shopt -s dotglob
+          rm -rf ${GITHUB_WORKSPACE}/*
+
+#  build_FIO:
+#    uses: ROCm/fio/.github/workflows/build-fio.yml@hipFile
+#    with:
+#      ais_hipfile_pkg_filename: ${{ inputs.ais_hipfile_pkg_filename }}
+#      ais_hipfile_pkg_dev_filename: ${{ inputs.ais_hipfile_pkg_dev_filename }}
+#      platform: ${{ inputs.platform }}
+#
+#  run_FIO_tests:
+#    runs-on: [linux, AIS]
+#    needs: [build_FIO]
+#    env:
+#      FIO_RUNTIME_PKG_FILENAME: >-
+#        ${{
+#          case(
+#            inputs.platform == 'rocky', needs.build_FIO.outputs.fio_pkg_fedora_filename,
+#            inputs.platform == 'suse', needs.build_FIO.outputs.fio_pkg_suse_filename,
+#            inputs.platform == 'ubuntu', needs.build_FIO.outputs.fio_pkg_debian_filename,
+#            ''
+#          )
+#        }}
+#      FIO_HIPFILE_ENGINE_PKG_FILENAME: >-
+#        ${{
+#          case(
+#            inputs.platform == 'rocky', needs.build_FIO.outputs.fio_pkg_fedora_hipfile_engine_filename,
+#            ''
+#          )
+#        }}
+#    steps:
+#      - name: Set early hipFile CI environment variables
+#        run: echo "AIS_PR_NUMBER=$(echo "${GITHUB_REF}" | sed 's|[^0-9]||g')" >> "${GITHUB_ENV}"
+#      - name: Set AIS CI container name
+#        run: |
+#          echo "AIS_CONTAINER_NAME=${AIS_PR_NUMBER}_${GITHUB_JOB}_${AIS_INPUT_PLATFORM}_${AIS_INPUT_ROCM_VERSION}" >> "${GITHUB_ENV}"
+#      # hipFile repo needed for //util directory
+#      - name: Fetching hipFile repository...
+#        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+#        with:
+#          fetch-depth: 0
+#          path: rocm-systems
+#          sparse-checkout: |
+#            projects/hipfile
+#            .github/workflows
+#      - name: Download hipFile runtime package
+#        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+#        with:
+#          name: ${{ inputs.ais_hipfile_pkg_filename }}
+#      - name: Download hipFile development package
+#        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+#        with:
+#          name: ${{ inputs.ais_hipfile_pkg_dev_filename }}
+#      - name: Download FIO runtime package
+#        # Fedora-based distro's need to download multiple packages as the FIO IO engines
+#        # are dynamically linked instead of built into the FIO executable.
+#        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+#        with:
+#          artifact-ids: >-
+#            ${{
+#              case(
+#                inputs.platform == 'rocky',
+#                format(
+#                  '{0},{1}',
+#                  needs.build_FIO.outputs.fio_pkg_fedora_artifact_id,
+#                  needs.build_FIO.outputs.fio_pkg_fedora_hipfile_engine_artifact_id
+#                ),
+#                inputs.platform == 'suse', needs.build_FIO.outputs.fio_pkg_suse_artifact_id,
+#                inputs.platform == 'ubuntu', needs.build_FIO.outputs.fio_pkg_debian_artifact_id,
+#                format('Platform "{0}" is not supported by build_FIO.', inputs.platform)
+#              )
+#            }}
+#          merge-multiple: true
+#      - name: Authenticating to GitHub Container Registry
+#        uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2 # v4.0.0
+#        with:
+#          registry: ghcr.io
+#          username: ${{ github.actor }}
+#          password: ${{ secrets.GITHUB_TOKEN }}
+#      - name: Starting Docker Container
+#        run: |
+#          docker run \
+#            -dt \
+#            --rm \
+#            --device=/dev/kfd \
+#            --device=/dev/dri \
+#            --security-opt seccomp=unconfined \
+#            --pull always \
+#            -v ${GITHUB_WORKSPACE}:/mnt/ais:ro \
+#            -v "${AIS_MOUNT_PATH}:/mnt/ais-fs" \
+#            --name "${AIS_CONTAINER_NAME}" \
+#            "${AIS_INPUT_CI_IMAGE}"
+#      - name: Create hipfile IO test directory
+#        run: |
+#          docker exec -t "${AIS_CONTAINER_NAME}" /bin/bash -c "mkdir -p /mnt/ais-fs/${AIS_CONTAINER_NAME}"
+#      - name: Copy the hipFile packages into the container
+#        run: |
+#          docker cp \
+#            "${GITHUB_WORKSPACE}/${AIS_INPUT_HIPFILE_PKG_FILENAME}" \
+#            "${AIS_CONTAINER_NAME}:/root"
+#          docker cp \
+#            "${GITHUB_WORKSPACE}/${AIS_INPUT_HIPFILE_PKG_DEV_FILENAME}" \
+#            "${AIS_CONTAINER_NAME}:/root"
+#      - name: Install the hipFile packages
+#        # Note: We need to re-run the `ldconfig` post-install step.
+#        #       This really should just be done automatically by the ROCm package.
+#        run: |
+#          docker exec \
+#            -t \
+#            -w /root \
+#            "${AIS_CONTAINER_NAME}" \
+#            /bin/bash -c '
+#              ${{
+#                format(
+#                  env.AIS_PKG_MGR == 'apt' && 'apt update; apt install -y "./{0}" "./{1}"' ||
+#                    env.AIS_PKG_MGR == 'dnf' && 'dnf install -y --cacheonly "./{0}" "./{1}"' ||
+#                    env.AIS_PKG_MGR == 'zypper' && 'zypper --no-refresh install -y --allow-unsigned-rpm "./{0}" "./{1}"' ||
+#                    'echo "Unknown platform."; exit 1',
+#                  inputs.ais_hipfile_pkg_filename,
+#                  inputs.ais_hipfile_pkg_dev_filename
+#                )
+#              }}
+#              ldconfig
+#            '
+#      - name: Copy the FIO packages into the container
+#        run: |
+#          docker cp \
+#            "${GITHUB_WORKSPACE}/${FIO_RUNTIME_PKG_FILENAME}" \
+#            "${AIS_CONTAINER_NAME}:/root"
+#          ${{
+#            case(
+#              inputs.platform == 'rocky',
+#                'docker cp \
+#                  "${GITHUB_WORKSPACE}/${FIO_HIPFILE_ENGINE_PKG_FILENAME}" \
+#                  "${AIS_CONTAINER_NAME}:/root"
+#                ',
+#              ''
+#            )
+#          }}
+#      - name: Install the FIO packages
+#        run: |
+#          docker exec \
+#            -t \
+#            -w /root \
+#            "${AIS_CONTAINER_NAME}" \
+#            /bin/bash -c '
+#              ${{
+#                format(
+#                  '{0} {1}',
+#                  env.AIS_PKG_INSTALL_CMD,
+#                  case(
+#                    inputs.platform == 'rocky',
+#                      format('./{0} ./{1}', env.FIO_RUNTIME_PKG_FILENAME, env.FIO_HIPFILE_ENGINE_PKG_FILENAME),
+#                    format('./{0}', env.FIO_RUNTIME_PKG_FILENAME)
+#                  )
+#                )
+#              }}
+#            '
+#      - name: hipFile fallback/POSIX IO test using fio
+#        run: |
+#          docker exec \
+#            -t \
+#            -w /mnt/ais-fs/${AIS_CONTAINER_NAME} \
+#            "${AIS_CONTAINER_NAME}" \
+#            /bin/bash -c '
+#              HIPFILE_FORCE_COMPAT_MODE=true \
+#                fio \
+#                /mnt/ais/hipFile/util/fio/write-read-verify.fio
+#            '
+#      - name: hipFile AIS IO test using fio
+#        run: |
+#          docker exec \
+#            -t \
+#            -w /mnt/ais-fs/${AIS_CONTAINER_NAME} \
+#            "${AIS_CONTAINER_NAME}" \
+#            /bin/bash -c '
+#              HIPFILE_ALLOW_COMPAT_MODE=false \
+#                fio \
+#                /mnt/ais/hipFile/util/fio/write-read-verify.fio
+#            '
+#      - name: Destroy hipfile IO test directory
+#        if: ${{ always() }}
+#        run: |
+#          docker exec -t "${AIS_CONTAINER_NAME}" /bin/bash -c "rm -fr /mnt/ais-fs/${AIS_CONTAINER_NAME}"
+#      - name: Cleanup & Stop the Docker container
+#        if: ${{ always() }}
+#        run: |
+#          docker stop "${AIS_CONTAINER_NAME}"
+#      - name: Cleanup self-hosted runner workspace
+#        if: ${{ always() }}
+#        run: |
+#          shopt -s dotglob
+#          rm -rf ${GITHUB_WORKSPACE}/*

--- a/.github/workflows/hipfile-ci-toplevel.yml
+++ b/.github/workflows/hipfile-ci-toplevel.yml
@@ -1,0 +1,42 @@
+name: hipfile-toplevel
+run-name: Kicks off several hipFile CI workflows for various platforms
+
+# In particular, this root workflow's only purpose is to allow
+# us to put our entire CI in a matrix. It has the added benefit
+# of not needing to specify our supported_platforms in multiple
+# locations.
+# We can consider moving the Pre-Checks here and passing them into
+# the CI as an input.
+on:
+  pull_request:
+    types: [opened, synchronize, reopened] # Defaults
+    paths:
+      - 'projects/hipfile/**'
+      - '.github/workflows/hipfile-*.yml'
+      - '!**/*.md'
+      - '!**/*.rst'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+
+  hipfile-CI:
+    strategy:
+      fail-fast: false
+      matrix:
+        supported_platforms:
+          - rocky
+          - suse
+          - ubuntu
+        rocm_versions:
+          - 7.2.0
+    uses: ./.github/workflows/hipfile-ci.yml
+    with:
+      platform: ${{ matrix.supported_platforms }}
+      rocm_version: ${{ matrix.rocm_versions }}

--- a/.github/workflows/hipfile-ci-toplevel.yml
+++ b/.github/workflows/hipfile-ci-toplevel.yml
@@ -35,7 +35,7 @@ jobs:
           - suse
           - ubuntu
         rocm_versions:
-          - 7.2.0
+          - 7.2.2
     uses: ./.github/workflows/hipfile-ci.yml
     with:
       platform: ${{ matrix.supported_platforms }}

--- a/.github/workflows/hipfile-ci.yml
+++ b/.github/workflows/hipfile-ci.yml
@@ -1,0 +1,105 @@
+name: hipfile-ci
+run-name: Main hipFile CI workflow to coordinate jobs for a single platform
+
+on:
+  workflow_call:
+    inputs:
+      platform:
+        required: true
+        type: string
+      rocm_version:
+        description: "Target ROCm MAJOR.MINOR.PATCH Version"
+        required: true
+        type: string
+
+permissions:
+  contents: read
+  packages: read
+
+jobs:
+
+  AIS_CI_Pre-check:
+    outputs:
+      changed_dockerfile: ${{ steps.ci-flags.outputs.changed_dockerfile }}
+    runs-on: [ubuntu-24.04]
+    steps:
+      - name: Fetching code repository...
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+          path: rocm-systems
+          sparse-checkout: |
+            projects/hipfile
+            .github/workflows
+      - name: Git fetch base ref
+        working-directory: rocm-systems
+        run: git fetch origin "${GITHUB_BASE_REF}"
+      - name: Set CI Flags
+        working-directory: rocm-systems/projects/hipfile
+        id: ci-flags
+        run: |
+          echo "changed_dockerfile=$(./util/files-changed.sh "origin/${GITHUB_BASE_REF}" HEAD 'util/docker/DOCKERFILE.*')" >> "${GITHUB_OUTPUT}"
+
+  build_AIS_CI_image:
+    needs: AIS_CI_Pre-check
+    permissions:
+      contents: read
+      packages: write
+    uses: ./.github/workflows/hipfile-image-build.yml
+    with:
+      dockerfile_changed: ${{ needs.AIS_CI_Pre-check.outputs.changed_dockerfile == '1' }}
+      platform: ${{ inputs.platform }}
+      rocm_version: ${{ inputs.rocm_version }}
+
+  build_and_test:
+    # cancelled() needed. Otherwise success() implicitly added and fails if build_AIS_CI_image skipped.
+    if: ${{ !cancelled() && needs.build_AIS_CI_image.outputs.ci_image_build_satisfied == 'true' }}
+    needs: [AIS_CI_Pre-check, build_AIS_CI_image]
+    uses: ./.github/workflows/hipfile-build.yml
+    with:
+      ci_image: ${{ needs.build_AIS_CI_image.outputs.ci_image }}
+      cxx_compiler: amdclang++
+      platform: ${{ inputs.platform }}
+      rocm_version: ${{ inputs.rocm_version }}
+      upload_artifacts: true
+
+  build_and_test_other_compilers:
+    # Try building on other compilers, but keep as separate job.
+    # Removes issues regarding matrix job overwriting outputs and
+    # does not propagate failures.
+    if: ${{ !cancelled() && needs.build_AIS_CI_image.outputs.ci_image_build_satisfied == 'true' }}
+    needs: [AIS_CI_Pre-check, build_AIS_CI_image]
+    strategy:
+      fail-fast: false
+      matrix:
+        cxx_compiler:
+          - clang++
+          - g++
+    uses: ./.github/workflows/hipfile-build.yml
+    with:
+      ci_image: ${{ needs.build_AIS_CI_image.outputs.ci_image }}
+      cxx_compiler: ${{ matrix.cxx_compiler }}
+      platform: ${{ inputs.platform }}
+      rocm_version: ${{ inputs.rocm_version }}
+
+  AIS_system_tests:
+    # cancelled() needed. Otherwise success() implicitly added and fails if the chained
+    # dependency build_AIS_CI_image is skipped.
+    if: ${{ !cancelled() && needs.build_and_test.result == 'success'}}
+    needs: [build_and_test]
+    uses: ./.github/workflows/hipfile-ci-system.yml
+    with:
+      ais_hipfile_pkg_dev_filename: ${{ needs.build_and_test.outputs.ais_hipfile_pkg_dev_filename }}
+      ais_hipfile_pkg_filename: ${{ needs.build_and_test.outputs.ais_hipfile_pkg_filename }}
+      ci_image: ${{ needs.build_and_test.outputs.ci_image }}
+      platform: ${{ inputs.platform }}
+      rocm_version: ${{ inputs.rocm_version }}
+
+  build_and_test_NVIDIA:
+    if: ${{ !cancelled() && needs.build_AIS_CI_image.outputs.ci_image_build_satisfied == 'true' }}
+    needs: [AIS_CI_Pre-check, build_AIS_CI_image]
+    uses: ./.github/workflows/hipfile-build-nvidia.yml
+    with:
+      ci_image: ${{ needs.build_AIS_CI_image.outputs.ci_image }}
+      platform: ${{ inputs.platform }}
+      rocm_version: ${{ inputs.rocm_version }}

--- a/.github/workflows/hipfile-ci.yml
+++ b/.github/workflows/hipfile-ci.yml
@@ -38,7 +38,7 @@ jobs:
         working-directory: rocm-systems/projects/hipfile
         id: ci-flags
         run: |
-          echo "changed_dockerfile=$(./util/files-changed.sh "origin/${GITHUB_BASE_REF}" HEAD 'util/docker/DOCKERFILE.*')" >> "${GITHUB_OUTPUT}"
+          echo "changed_dockerfile=$(./util/files-changed.sh "origin/${GITHUB_BASE_REF}" HEAD 'projects/hipfile/util/docker/DOCKERFILE.*')" >> "${GITHUB_OUTPUT}"
 
   build_AIS_CI_image:
     needs: AIS_CI_Pre-check

--- a/.github/workflows/hipfile-image-build.yml
+++ b/.github/workflows/hipfile-image-build.yml
@@ -1,0 +1,133 @@
+name: new_CI_image
+run-name: Build the Docker image for hipFile CI
+
+env:
+  AIS_CI_IMAGE_NAME: ais_ci_${{ inputs.platform }}
+  AIS_DOCKER_REGISTRY: ghcr.io/${{ github.repository_owner }}/hipfile
+  AIS_INPUT_ROCM_VERSION: ${{ inputs.rocm_version }}
+  AIS_PR_BASE_URL: ${{ github.server_url }}/${{ github.repository }}/pull
+
+on:
+  workflow_call:
+    inputs:
+      dockerfile_changed:
+        # While this seems like a smell to not make this check in this workflow,
+        # it allows us to skip the job entirely. This yields the benefit of
+        # letting downstream jobs start sooner and keeping the job result as
+        # 'skipped' if a new CI image is not needed.
+        description: Hint for if this workflow actually needs to run.
+        required: true
+        type: boolean
+      platform:
+        required: true
+        type: string
+      rocm_version:
+        description: "Target ROCm MAJOR.MINOR.PATCH Version"
+        required: true
+        type: string
+    outputs:
+      ci_image:
+        description: |
+          The full name & tag of the CI image to use.
+          If a new CI image is produced, returns the new CI image name & tag.
+          Otherwise, returns the current CI image name & tag.
+        value: >-
+          ${{ 
+            jobs.build_AIS_image.result == 'skipped' && jobs.get_latest_AIS_image.outputs.new_ci_image ||
+            jobs.build_AIS_image.result == 'success' && jobs.build_AIS_image.outputs.new_ci_image ||
+            null
+          }}
+      ci_image_build_satisfied:
+        description: |
+          Indicates if the CI image is in an acceptable state.
+          Set to 'true' if the CI image is unchanged, or if a new CI image was
+          built successfully. Otherwise 'false'.
+        value: >-
+          ${{
+            (
+              !inputs.dockerfile_changed &&
+              jobs.build_AIS_image.result == 'skipped'
+            ) ||
+            (
+              inputs.dockerfile_changed &&
+              jobs.build_AIS_image.result == 'success'
+            )
+          }}
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+
+  # GitHub Actions does not have a built-in toLower() function which has made a lot of
+  # people sad. https://github.com/orgs/community/discussions/25768
+  get_latest_AIS_image:
+    if: ${{ ! inputs.dockerfile_changed }}
+    runs-on: [ubuntu-24.04]
+    outputs:
+      new_ci_image: ${{ steps.ci-image.outputs.AIS_CI_IMAGE }}
+    steps:
+      - name: Set default CI image
+        id: ci-image
+        run: |
+          AIS_CI_IMAGE="${AIS_DOCKER_REGISTRY}/${AIS_CI_IMAGE_NAME}:latest-rocm${AIS_INPUT_ROCM_VERSION}"
+          echo "AIS_CI_IMAGE=$(printf '%s' "${AIS_CI_IMAGE}" | tr '[:upper:]' '[:lower:]')" >> "${GITHUB_OUTPUT}"
+
+  build_AIS_image:
+    if: ${{ inputs.dockerfile_changed }}
+    runs-on: [ubuntu-24.04]
+    container: docker:28.5
+    outputs:
+      new_ci_image: ${{ steps.ci-image.outputs.AIS_CI_IMAGE }}
+    steps:
+      - name: Set CI environment variables
+        run: |
+          echo "AIS_CI_IMAGE_TAG=$(echo "${GITHUB_REF}" | sed 's|[^a-zA-Z0-9]|-|g')-rocm${AIS_INPUT_ROCM_VERSION}" >> "${GITHUB_ENV}"
+          echo "AIS_PR_NUMBER=$(echo "${GITHUB_REF}" | sed 's|[^0-9]||g')" >> "${GITHUB_ENV}"
+
+      - name: Set target AIS CI Image
+        id: ci-image
+        run: |
+          AIS_CI_IMAGE="${AIS_DOCKER_REGISTRY}/${AIS_CI_IMAGE_NAME}:${AIS_CI_IMAGE_TAG}"
+          echo "AIS_CI_IMAGE=$(printf '%s' "${AIS_CI_IMAGE}" | tr '[:upper:]' '[:lower:]')" >> "${GITHUB_OUTPUT}"
+          AIS_CI_LATEST_CACHE="${AIS_DOCKER_REGISTRY}/${AIS_CI_IMAGE_NAME}:latest-rocm${AIS_INPUT_ROCM_VERSION}-cache"
+          echo "AIS_CI_LATEST_CACHE=$(printf '%s' "${AIS_CI_LATEST_CACHE}" | tr '[:upper:]' '[:lower:]')" >> "${GITHUB_OUTPUT}"
+
+      - name: Fetching code repository...
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+          sparse-checkout: |
+            projects/hipfile
+            .github/workflows
+
+      - name: Authenticating to GitHub Container Registry.
+        uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2 # v4.0.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Setup Docker Builder
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
+        with:
+          name: ais-builder
+          driver: docker-container
+          cache-binary: false # True uses the GHA Cache Backend
+
+      - name: Build base image for AIS CI
+        run: |
+          docker buildx build \
+            -f "${GITHUB_WORKSPACE}/projects/hipfile/util/docker/DOCKERFILE.${AIS_CI_IMAGE_NAME}" \
+            --label "org.opencontainers.image.description= \
+              ${AIS_CI_IMAGE_NAME} Development Image for AIS CI using branch \
+              ${GITHUB_HEAD_REF} for PR #${AIS_PR_NUMBER}. \
+              PR URL: ${AIS_PR_BASE_URL}/${AIS_PR_NUMBER}" \
+            --build-arg BUILDKIT_INLINE_CACHE=1 \
+            --build-arg ROCM_VERSION=${AIS_INPUT_ROCM_VERSION} \
+            --cache-from=type=registry,ref="${{ steps.ci-image.outputs.AIS_CI_IMAGE }}" \
+            --cache-from=type=registry,ref="${{ steps.ci-image.outputs.AIS_CI_LATEST_CACHE }}" \
+            --push \
+            -t "${{ steps.ci-image.outputs.AIS_CI_IMAGE }}" \
+            "${GITHUB_WORKSPACE}/projects/hipfile/util/docker"

--- a/.github/workflows/hipfile-image-update.yml
+++ b/.github/workflows/hipfile-image-update.yml
@@ -48,7 +48,7 @@ jobs:
           - suse
           - ubuntu
         rocm_versions:
-          - 7.2.0
+          - 7.2.2
     steps:
       - name: Fetching code repository...
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/hipfile-image-update.yml
+++ b/.github/workflows/hipfile-image-update.yml
@@ -1,0 +1,106 @@
+name: update_CI_image
+run-name: Update latest hipFile CI image
+
+env:
+  AIS_DOCKER_REGISTRY: ghcr.io/${{ github.repository_owner }}/hipfile
+
+on:
+  pull_request_target: # A.K.A. This is a privileged action. See `pull_request`.
+    types:
+      - closed # CAUTION: Includes un-merged PRs
+    branches:
+      - develop
+    paths:
+      - projects/hipfile/util/docker/**
+      - projects/hipfile/util/files-changed.sh
+      - .github/workflows/hipfile-image-build.yml
+      - .github/workflows/hipfile-image-update.yml
+  workflow_dispatch:
+    # Requires write access to trigger
+    inputs:
+      pull_from_cache:
+        description: Build image with 'latest' cache
+        required: false
+        default: true
+        type: boolean
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request_target' && github.event.pull_request.base.ref || github.ref_name }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+
+  update_AIS_CI_image:
+    env:
+      AIS_CI_IMAGE_NAME: ais_ci_${{ matrix.supported_platforms }}
+      AIS_INPUT_PLATFORM: ${{ matrix.supported_platforms }}
+    if: ${{ github.event.pull_request.merged == true || github.event_name == 'workflow_dispatch' }}
+    runs-on: [ubuntu-24.04]
+    container: docker:28.5
+    strategy:
+      matrix:
+        supported_platforms:
+          - rocky
+          - suse
+          - ubuntu
+        rocm_versions:
+          - 7.2.0
+    steps:
+      - name: Fetching code repository...
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+          sparse-checkout: |
+            projects/hipfile
+            .github/workflows
+
+      - name: Authenticating to GitHub Container Registry.
+        uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2 # v4.0.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set target AIS CI Image
+        id: ci-image
+        run: |
+          AIS_CI_IMAGE="${AIS_DOCKER_REGISTRY}/${AIS_CI_IMAGE_NAME}:latest-rocm${{ matrix.rocm_versions }}"
+          echo "AIS_CI_IMAGE=$(printf '%s' "${AIS_CI_IMAGE}" | tr '[:upper:]' '[:lower:]')" >> "${GITHUB_OUTPUT}"
+
+      - name: Set Docker Cache Instruction
+        id: use-cache
+        # If triggered by a pull_request, pull_from_cache will be null. Note
+        # however `false == null` resolves to `true`. Use empty string to check
+        # for 'null'.
+        # See: https://docs.github.com/en/actions/reference/workflows-and-actions/expressions
+        # for how null gets converted when compared to non-null, and converted into a string.
+        run: >-
+          echo "CACHE_FROM_CMD=${{
+            ( format('{0}', inputs.pull_from_cache) == '' || inputs.pull_from_cache ) &&
+            format('--cache-from=type=registry,ref=\"{0}-cache\"', steps.ci-image.outputs.AIS_CI_IMAGE) ||
+            ''
+          }}" >> "${GITHUB_OUTPUT}"
+
+      - name: Setup Docker Builder
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
+        with:
+          name: ais-builder
+          driver: docker-container
+          cache-binary: false # True uses the GHA Cache Backend
+
+      - name: Build & Push latest image for AIS CI
+        run: |
+          docker buildx build \
+            -f "${GITHUB_WORKSPACE}/projects/hipfile/util/docker/DOCKERFILE.${AIS_CI_IMAGE_NAME}" \
+            --label "org.opencontainers.image.description= \
+              Latest AIS CI Image for ${AIS_INPUT_PLATFORM} using ROCm ${{ matrix.rocm_versions }}." \
+            --build-arg ROCM_VERSION=${{ matrix.rocm_versions }} \
+            --cache-to=type=registry,ref="${{ steps.ci-image.outputs.AIS_CI_IMAGE }}-cache" \
+            ${{ steps.use-cache.outputs.CACHE_FROM_CMD }} \
+            --push \
+            -t "${{ steps.ci-image.outputs.AIS_CI_IMAGE }}" \
+            "${GITHUB_WORKSPACE}/projects/hipfile/util/docker"

--- a/projects/hipfile/util/docker/DOCKERFILE.ais_ci_rocky
+++ b/projects/hipfile/util/docker/DOCKERFILE.ais_ci_rocky
@@ -9,7 +9,7 @@ LABEL org.opencontainers.image.source=https://github.com/ROCm/hipFile
 # Brings ROCKY_VERSION in-scope
 ARG ROCKY_MAJOR_VERSION
 ARG ROCKY_VERSION
-ARG ROCM_VERSION=7.2.0
+ARG ROCM_VERSION=7.2.2
 
 # If the target ROCm Version on the package repository is non-standard, you can forcibly
 # set the ROCm version used in the package repo URL.

--- a/projects/hipfile/util/docker/DOCKERFILE.ais_ci_suse
+++ b/projects/hipfile/util/docker/DOCKERFILE.ais_ci_suse
@@ -8,7 +8,7 @@ FROM opensuse/leap:${SUSE_MAJOR_VERSION}.${SUSE_MINOR_VERSION}
 LABEL org.opencontainers.image.source=https://github.com/ROCm/hipFile
 ARG SUSE_MAJOR_VERSION
 ARG SUSE_MINOR_VERSION
-ARG ROCM_VERSION=7.2.0
+ARG ROCM_VERSION=7.2.2
 
 # If the target ROCm Version on the package repository is non-standard, you can forcibly
 # set the ROCm version used in the package repo URL.

--- a/projects/hipfile/util/docker/DOCKERFILE.ais_ci_ubuntu
+++ b/projects/hipfile/util/docker/DOCKERFILE.ais_ci_ubuntu
@@ -8,7 +8,7 @@ LABEL org.opencontainers.image.source=https://github.com/ROCm/hipFile
 ARG UBUNTU_CODENAME
 ARG UBUNTU_MAJOR_VERSION=24
 ARG UBUNTU_MINOR_VERSION=04
-ARG ROCM_VERSION=7.2.0
+ARG ROCM_VERSION=7.2.2
 
 # If the target ROCm Version on the package repository is non-standard, you can forcibly
 # set the ROCm version used in the package repo URL.

--- a/projects/hipfile/util/files-changed.sh
+++ b/projects/hipfile/util/files-changed.sh
@@ -3,10 +3,13 @@
 #
 # SPDX-License-Identifier: MIT
 
-# CI Script
+# Checks if the a set of files (PATTERN) have changed in git. Used
+# in CI to check if the Docker images need to be rebuilt.
+#
 # ./files-changed.sh BASE_REF HEAD_REF PATTERN
+#
 # Prints 0 if no matching files have changed
-# Prints 1 if at least 1 matched file has changed.
+# Prints 1 if at least 1 matched file has changed
 
 set -eo pipefail
 
@@ -17,13 +20,13 @@ FILES_CHANGED=0
 
 changed_files=()
 if ! diff_output="$(git diff --name-only "${BASE_REF}" "${HEAD_REF}")"; then
-    echo "${diff_output}"
+    echo "BADNESS: ${diff_output}"
     exit 1
 fi
 mapfile -t changed_files <<< "${diff_output}"
 
 for changed_file in "${changed_files[@]}"; do
-    # This is intended behaviour to check for globbing.
+    # This is intended behaviour to check for globbing
     # shellcheck disable=SC2053
     if [[ "${changed_file}" == ${CHECK_PATTERN} ]]; then
         FILES_CHANGED=1


### PR DESCRIPTION
The CI has not fundamentally changed - we've just updated paths to reflect the new place in the monorepo and changed some names to better namespace hipFile CI from other actions. We also do sparse checkouts and only run the CI when our files change.

Many files were renamed:

    build-ais.yml           -->     hipfile-build.yml
    build-ais-nvidia.yml    -->     hipfile-build-nvidia.yml
    ais-ci.yml              -->     hipfile-ci.yml
    test-ais-system.yml     -->     hipfile-ci-system.yml
    root-ci.yml             -->     hipfile-ci-toplevel.yml
    build-ais-ci-image.yml  -->     hipfile-image-build.yml
    update-ais-ci-image.yml -->     hipfile-image-update.yml

The nightly build and run CI has not yet been brought over.

Part of AIHIPFILE-174
