### PR TITLE
[rccl-tests]: add ionic (AINIC) NIC support

### DIFF
--- a/projects/rccl-tests/src/collector.cu
+++ b/projects/rccl-tests/src/collector.cu
@@ -87,7 +87,12 @@ static void GetTable(NicType nic_type,
       size = ionic_table_size;
       break;
     case NIC_BNXT_RE:
-    default:
+      table = bnxt_re_table;
+      size = bnxt_re_table_size;
+      break;
+    case NIC_UNKNOWN:
+      fprintf(stderr,
+              "# Warning: NIC type unknown, defaulting to bnxt_re counter set\n");
       table = bnxt_re_table;
       size = bnxt_re_table_size;
       break;
@@ -112,6 +117,40 @@ static const char* NicPrefix() {
 // Public helpers
 // =====================================================================
 
+static const std::set<std::string>& RequestedCounterFilter() {
+  static std::set<std::string> filter;
+  static bool checked = false;
+  if (!checked) {
+    const char* env = getenv("RCCL_TESTS_NIC_COUNTER_LIST");
+    if (env && strlen(env) > 0) {
+      std::string list(env);
+      size_t pos = 0;
+      while (pos < list.size()) {
+        size_t comma = list.find(',', pos);
+        if (comma == std::string::npos) { comma = list.size(); }
+        std::string token = list.substr(pos, comma - pos);
+        while (!token.empty() && (token.front() == ' ' || token.front() == '\t')) {
+          token.erase(token.begin());
+        }
+        while (!token.empty() && (token.back() == ' ' || token.back() == '\t')) {
+          token.pop_back();
+        }
+        if (!token.empty()) { filter.insert(token); }
+        pos = comma + 1;
+      }
+    }
+    checked = true;
+  }
+  return filter;
+}
+
+static bool CounterMatchesRequestedFilter(const CounterTableEntry& entry) {
+  const std::set<std::string>& filter = RequestedCounterFilter();
+  if (filter.empty()) { return true; }
+  if (filter.count(entry.name) > 0) { return true; }
+  return entry.fallback_name != NULL && filter.count(entry.fallback_name) > 0;
+}
+
 bool NetCounterIsEnabled() {
   static int enabled = -1;
   if (enabled == -1) {
@@ -127,6 +166,7 @@ std::vector<CounterDescriptor> NetCounterGetCounterList(NicType nic_type) {
   int size;
   GetTable(nic_type, table, size);
   for (int i = 0; i < size; i++) {
+    if (!CounterMatchesRequestedFilter(table[i])) continue;
     result.push_back({table[i].name, table[i].source, table[i].is_prefix,
                       table[i].fallback_name ? table[i].fallback_name : ""});
   }

--- a/projects/rccl-tests/src/collector.cu
+++ b/projects/rccl-tests/src/collector.cu
@@ -19,52 +19,77 @@
 #include <unistd.h>
 
 // =====================================================================
-// Counter registry
+// Per-NIC-type counter tables
 // =====================================================================
+//
+// Each NIC type has its own table with actual hardware key names.
+// name      : counter key (used in sysfs paths and output headers)
+// source    : where to read the value
+// is_prefix : true → prefix-match (expands to name0..name7)
 
-struct CounterRegistryEntry {
+struct CounterTableEntry {
   const char*   name;
   CounterSource source;
   bool          is_prefix;
-  // bnxt_re (Thor2): actual hw_counters filename when it differs from name
-  //   NULL → use canonical name as-is
-  const char*   bnxt_key;
-  bool          bnxt_valid; // false → not displayed on bnxt_re
-  // ionic (AINIC): actual hw_counters filename, NULL → counter not on ionic
-  const char*   ionic_key;
-  CounterSource ionic_source;
 };
 
-static const CounterRegistryEntry counter_registry[] = {
-  //                                                                        --------- bnxt_re ---------   ----------- ionic -----------
-  // name                       source               prefix  bnxt_key         bnxt_valid  ionic_key               ionic_source
-  {"rx_pfc_ena_frames_pri",   COUNTER_SRC_ETHTOOL,  true,   NULL,            true,       "frames_rx_pripause",   COUNTER_SRC_ETHTOOL},
-  {"tx_pfc_ena_frames_pri",   COUNTER_SRC_ETHTOOL,  true,   NULL,            true,       "frames_tx_pripause",   COUNTER_SRC_ETHTOOL},
-  {"pfc_pri3_rx_transitions", COUNTER_SRC_ETHTOOL,  false,  NULL,            true,       NULL,                   COUNTER_SRC_ETHTOOL},
-  {"pfc_pri3_tx_transitions", COUNTER_SRC_ETHTOOL,  false,  NULL,            true,       NULL,                   COUNTER_SRC_ETHTOOL},
-  {"rx_cnp_pkts",             COUNTER_SRC_IB_HW,    false,  "rp_cnp_handled",            true,       "rx_rdma_cnp_pkts",     COUNTER_SRC_IB_HW},
-  {"tx_cnp_pkts",             COUNTER_SRC_IB_HW,    false,  "np_cnp_sent",               true,       "tx_rdma_cnp_pkts",     COUNTER_SRC_IB_HW},
-  {"rx_roce_discards",        COUNTER_SRC_IB_HW,    false,  NULL,            true,       "rx_rdma_mtu_discard_pkts", COUNTER_SRC_IB_HW},
-  {"rx_stat_discards",        COUNTER_SRC_DEBUGFS,  false,  NULL,            true,       "resp_rx_outof_buf",    COUNTER_SRC_IB_HW},
-  {"to_retransmits",          COUNTER_SRC_DEBUGFS,  false,  NULL,            true,       "tx_rdma_ack_timeout",  COUNTER_SRC_IB_HW},
-  {"max_retry_exceeded",      COUNTER_SRC_DEBUGFS,  false,  NULL,            true,       "req_tx_retry_excd_err",COUNTER_SRC_IB_HW},
-  {"oos_drop_count",          COUNTER_SRC_DEBUGFS,  false,  NULL,            true,       "resp_rx_outouf_seq",   COUNTER_SRC_IB_HW},
-  {"seq_err_naks_rcvd",       COUNTER_SRC_DEBUGFS,  false,  NULL,            true,       "req_rx_pkt_seq_err",   COUNTER_SRC_IB_HW},
-  // RDMA throughput – ionic (AINIC) only
-  {"tx_rdma_ucast_bytes",     COUNTER_SRC_IB_HW,    false,  NULL,            false,      "tx_rdma_ucast_bytes",  COUNTER_SRC_IB_HW},
-  {"rx_rdma_ucast_bytes",     COUNTER_SRC_IB_HW,    false,  NULL,            false,      "rx_rdma_ucast_bytes",  COUNTER_SRC_IB_HW},
-  {"tx_rdma_ucast_pkts",      COUNTER_SRC_IB_HW,    false,  NULL,            false,      "tx_rdma_ucast_pkts",   COUNTER_SRC_IB_HW},
-  {"rx_rdma_ucast_pkts",      COUNTER_SRC_IB_HW,    false,  NULL,            false,      "rx_rdma_ucast_pkts",   COUNTER_SRC_IB_HW},
+// ----- IONIC (AINIC) counter table -----
+static const CounterTableEntry ionic_table[] = {
+  // ethtool – PFC frame counters (prefix → expands to name0..name7)
+  {"frames_rx_pripause",       COUNTER_SRC_ETHTOOL,  true},
+  {"frames_tx_pripause",       COUNTER_SRC_ETHTOOL,  true},
+  // IB hw_counters – CNP
+  {"rx_rdma_cnp_pkts",         COUNTER_SRC_IB_HW,    false},
+  {"tx_rdma_cnp_pkts",         COUNTER_SRC_IB_HW,    false},
+  // IB hw_counters – errors & retransmits
+  {"rx_rdma_mtu_discard_pkts", COUNTER_SRC_IB_HW,    false},
+  {"resp_rx_outof_buf",        COUNTER_SRC_IB_HW,    false},
+  {"tx_rdma_ack_timeout",      COUNTER_SRC_IB_HW,    false},
+  {"req_tx_retry_excd_err",    COUNTER_SRC_IB_HW,    false},
+  {"resp_rx_outouf_seq",       COUNTER_SRC_IB_HW,    false},
+  {"req_rx_pkt_seq_err",       COUNTER_SRC_IB_HW,    false},
+  // IB hw_counters – RDMA throughput
+  {"tx_rdma_ucast_bytes",      COUNTER_SRC_IB_HW,    false},
+  {"rx_rdma_ucast_bytes",      COUNTER_SRC_IB_HW,    false},
+  {"tx_rdma_ucast_pkts",       COUNTER_SRC_IB_HW,    false},
+  {"rx_rdma_ucast_pkts",       COUNTER_SRC_IB_HW,    false},
 };
+static const int ionic_table_size = (int)(sizeof(ionic_table) / sizeof(ionic_table[0]));
 
-static const int counter_registry_size =
-    (int)(sizeof(counter_registry) / sizeof(counter_registry[0]));
+// ----- BNXT_RE (Thor2) counter table -----
+static const CounterTableEntry bnxt_re_table[] = {
+  // ethtool – PFC frame counters (prefix → expands to name0..name7)
+  {"rx_pfc_ena_frames_pri",   COUNTER_SRC_ETHTOOL,  true},
+  {"tx_pfc_ena_frames_pri",   COUNTER_SRC_ETHTOOL,  true},
+  // ethtool – PFC transition counters (exact)
+  {"pfc_pri3_rx_transitions", COUNTER_SRC_ETHTOOL,  false},
+  {"pfc_pri3_tx_transitions", COUNTER_SRC_ETHTOOL,  false},
+  // IB hw_counters
+  {"rp_cnp_handled",          COUNTER_SRC_IB_HW,    false},
+  {"np_cnp_sent",             COUNTER_SRC_IB_HW,    false},
+  {"rx_roce_discards",        COUNTER_SRC_IB_HW,    false},
+  // debugfs (bnxt_re info)
+  {"rx_stat_discards",        COUNTER_SRC_DEBUGFS,  false},
+  {"to_retransmits",          COUNTER_SRC_DEBUGFS,  false},
+  {"max_retry_exceeded",      COUNTER_SRC_DEBUGFS,  false},
+  {"oos_drop_count",          COUNTER_SRC_DEBUGFS,  false},
+  {"seq_err_naks_rcvd",       COUNTER_SRC_DEBUGFS,  false},
+};
+static const int bnxt_re_table_size = (int)(sizeof(bnxt_re_table) / sizeof(bnxt_re_table[0]));
 
-static const CounterRegistryEntry* FindInRegistry(const std::string& name) {
-  for (int i = 0; i < counter_registry_size; i++) {
-    if (name == counter_registry[i].name) return &counter_registry[i];
+static void GetTable(NicType nic_type,
+                     const CounterTableEntry*& table, int& size) {
+  switch (nic_type) {
+    case NIC_IONIC:
+      table = ionic_table;
+      size = ionic_table_size;
+      break;
+    case NIC_BNXT_RE:
+    default:
+      table = bnxt_re_table;
+      size = bnxt_re_table_size;
+      break;
   }
-  return NULL;
 }
 
 // =====================================================================
@@ -94,50 +119,13 @@ bool NetCounterIsEnabled() {
   return enabled == 1;
 }
 
-std::vector<CounterDescriptor> NetCounterParseCounterList() {
+std::vector<CounterDescriptor> NetCounterGetCounterList(NicType nic_type) {
   std::vector<CounterDescriptor> result;
-
-  const char* env = getenv("RCCL_TESTS_NIC_COUNTER_LIST");
-  if (!env || strlen(env) == 0) {
-    for (int i = 0; i < counter_registry_size; i++) {
-      result.push_back({counter_registry[i].name,
-                        counter_registry[i].source,
-                        counter_registry[i].is_prefix});
-    }
-    return result;
-  }
-
-  std::string list(env);
-
-  size_t pos = 0;
-  while (pos < list.size()) {
-    size_t comma = list.find(',', pos);
-    if (comma == std::string::npos) {
-      comma = list.size();
-    }
-
-    std::string token = list.substr(pos, comma - pos);
-
-    while (!token.empty() && (token.front() == ' ' || token.front() == '\t')) {
-      token.erase(token.begin());
-    }
-
-    while (!token.empty() && (token.back() == ' ' || token.back() == '\t')) {
-      token.pop_back();
-    }
-
-    if (!token.empty()) {
-      const CounterRegistryEntry* entry = FindInRegistry(token);
-      if (entry) {
-        result.push_back({entry->name, entry->source, entry->is_prefix});
-      } else {
-        fprintf(stderr,
-                "# Warning: counter \"%s\" not in registry, assuming ethtool\n",
-                token.c_str());
-        result.push_back({token, COUNTER_SRC_ETHTOOL, false});
-      }
-    }
-    pos = comma + 1;
+  const CounterTableEntry* table;
+  int size;
+  GetTable(nic_type, table, size);
+  for (int i = 0; i < size; i++) {
+    result.push_back({table[i].name, table[i].source, table[i].is_prefix});
   }
   return result;
 }
@@ -176,7 +164,7 @@ std::vector<std::string> NetCounterParseIbHcaList() {
 // IB device name parsing
 // =====================================================================
 
-// Split "rdma0:2" → base="rdma0", port=2.  Default port is 1.
+// Split "rdma0:2" -> base="rdma0", port=2.  Default port is 1.
 static void ParseIbDevice(const std::string& ib_device,
                            std::string& base, int& port) {
   size_t colon = ib_device.find(':');
@@ -313,34 +301,17 @@ NicType DetectNicTypeFromSnapshots(
 // Per-source collection
 // =====================================================================
 
-static const char* ResolveEthtoolKey(const CounterDescriptor& d,
-                                     NicType nic_type) {
-  const CounterRegistryEntry* e = FindInRegistry(d.name);
-  if (nic_type == NIC_IONIC && e && e->ionic_key &&
-      e->ionic_source == COUNTER_SRC_ETHTOOL) {
-    return e->ionic_key;
-  }
-  if (nic_type == NIC_BNXT_RE && e && e->bnxt_key) {
-    return e->bnxt_key;
-  }
-  return d.name.c_str();
-}
-
 static void CollectEthtoolCounters(const std::string& nic,
                                    const std::vector<CounterDescriptor>& selected,
-                                   NicType nic_type,
                                    std::map<std::string, uint64_t>& out) {
   std::set<std::string> exact;
-  std::map<std::string, std::string> key_to_canon;
-  std::vector<std::pair<std::string, std::string>> prefixes;
+  std::vector<std::string> prefixes;
   for (const auto& d : selected) {
     if (d.source != COUNTER_SRC_ETHTOOL) { continue; }
-    const char* ethtool_key = ResolveEthtoolKey(d, nic_type);
     if (d.is_prefix) {
-      prefixes.push_back({ethtool_key, d.name});
+      prefixes.push_back(d.name);
     } else {
-      exact.insert(ethtool_key);
-      key_to_canon[ethtool_key] = d.name;
+      exact.insert(d.name);
     }
   }
   if (exact.empty() && prefixes.empty()) { return; }
@@ -361,13 +332,12 @@ static void CollectEthtoolCounters(const std::string& nic,
       while (*start == ' ' || *start == '\t') { start++; }
       std::string k(start);
       if (exact.count(k)) {
-        out[key_to_canon.count(k) ? key_to_canon[k] : k] = value;
+        out[k] = value;
         continue;
       }
       for (const auto& pfx : prefixes) {
-        if (k.compare(0, pfx.first.size(), pfx.first) == 0) {
-          std::string canon_key = pfx.second + k.substr(pfx.first.size());
-          out[canon_key] = value;
+        if (k.compare(0, pfx.size(), pfx) == 0) {
+          out[k] = value;
           break;
         }
       }
@@ -376,49 +346,8 @@ static void CollectEthtoolCounters(const std::string& nic,
   pclose(fp);
 }
 
-static void CollectIbHwCountersIonic(
-    const std::vector<CounterDescriptor>& selected,
-    const std::string& base_port, const std::string& base_dev,
-    std::map<std::string, uint64_t>& out) {
-  for (const auto& d : selected) {
-    const CounterRegistryEntry* e = FindInRegistry(d.name);
-    if (!e || !e->ionic_key || e->ionic_source != COUNTER_SRC_IB_HW) continue;
-    std::string path = base_port + e->ionic_key;
-    FILE* fp = fopen(path.c_str(), "r");
-    if (!fp) fp = fopen((base_dev + e->ionic_key).c_str(), "r");
-    if (fp) {
-      unsigned long long tmp = 0;
-      if (fscanf(fp, "%llu", &tmp) == 1) out[d.name] = (uint64_t)tmp;
-      fclose(fp);
-    }
-  }
-}
-
-static void CollectIbHwCountersBnxtRe(
-    const std::vector<CounterDescriptor>& selected,
-    const std::string& base_port,
-    std::map<std::string, uint64_t>& out) {
-  for (const auto& d : selected) {
-    if (d.source != COUNTER_SRC_IB_HW) { continue; }
-    const CounterRegistryEntry* e = FindInRegistry(d.name);
-    const char* hw_key = d.name.c_str();
-    std::string path = base_port + hw_key;
-    FILE* fp = fopen(path.c_str(), "r");
-    if (!fp && e && e->bnxt_key) {
-      path = base_port + e->bnxt_key;
-      fp = fopen(path.c_str(), "r");
-    }
-    if (fp) {
-      unsigned long long tmp = 0;
-      if (fscanf(fp, "%llu", &tmp) == 1) out[d.name] = (uint64_t)tmp;
-      fclose(fp);
-    }
-  }
-}
-
 static void CollectIbHwCounters(const std::string& ib_device,
                                 const std::vector<CounterDescriptor>& selected,
-                                NicType nic_type,
                                 std::map<std::string, uint64_t>& out) {
   if (ib_device.empty()) { return; }
 
@@ -432,14 +361,16 @@ static void CollectIbHwCounters(const std::string& ib_device,
   std::string base_dev =
       "/sys/class/infiniband/" + ib_base + "/hw_counters/";
 
-  switch (nic_type) {
-    case NIC_IONIC:
-      CollectIbHwCountersIonic(selected, base_port, base_dev, out);
-      break;
-    case NIC_BNXT_RE:
-    default:
-      CollectIbHwCountersBnxtRe(selected, base_port, out);
-      break;
+  for (const auto& d : selected) {
+    if (d.source != COUNTER_SRC_IB_HW) continue;
+    std::string path = base_port + d.name;
+    FILE* fp = fopen(path.c_str(), "r");
+    if (!fp) fp = fopen((base_dev + d.name).c_str(), "r");
+    if (fp) {
+      unsigned long long tmp = 0;
+      if (fscanf(fp, "%llu", &tmp) == 1) out[d.name] = (uint64_t)tmp;
+      fclose(fp);
+    }
   }
 }
 
@@ -450,7 +381,9 @@ static void CollectDebugCounters(const std::string& ib_device,
 
   std::set<std::string> wanted;
   for (const auto& d : selected) {
-    if (d.source == COUNTER_SRC_DEBUGFS) { wanted.insert(d.name); }
+    if (d.source == COUNTER_SRC_DEBUGFS) {
+      wanted.insert(d.name);
+    }
   }
   if (wanted.empty()) { return; }
 
@@ -513,11 +446,9 @@ NetworkCounterSnapshot NetCounterCollectSnapshot(
   snap.timestamp_us = (int64_t)ts.tv_sec * 1000000 + ts.tv_nsec / 1000;
   snap.nic_type = NetCounterDetectNicType(ib_dev);
 
-  CollectEthtoolCounters(nic, selected, snap.nic_type, snap.counters);
-  CollectIbHwCounters(ib_dev, selected, snap.nic_type, snap.counters);
-  if (snap.nic_type != NIC_IONIC) {
-    CollectDebugCounters(ib_dev, selected, snap.counters);
-  }
+  CollectEthtoolCounters(nic, selected, snap.counters);
+  CollectIbHwCounters(ib_dev, selected, snap.counters);
+  CollectDebugCounters(ib_dev, selected, snap.counters);
 
   return snap;
 }
@@ -560,37 +491,6 @@ uint64_t NetCounterComputeDelta(
 }
 
 // =====================================================================
-// NIC-type-aware column filter
-// =====================================================================
-
-std::vector<CounterDescriptor> NetCounterFilterByNicType(
-    const std::vector<CounterDescriptor>& selected,
-    const std::vector<NetworkCounterSnapshot>& snapshots) {
-  if (snapshots.empty()) return selected;
-
-  bool mixed = false;
-  NicType nic_type = DetectNicTypeFromSnapshots(snapshots, mixed);
-
-  if (nic_type == NIC_UNKNOWN || mixed) {
-    if (mixed) {
-      fprintf(stderr,
-              "# Warning: mixed NIC types detected, showing all counters\n");
-    }
-    return selected;
-  }
-
-  std::vector<CounterDescriptor> result;
-  for (const auto& d : selected) {
-    const CounterRegistryEntry* e = FindInRegistry(d.name);
-    if (!e) { result.push_back(d); continue; }
-    if (nic_type == NIC_IONIC && !e->ionic_key) continue;   // not on ionic
-    if (nic_type == NIC_BNXT_RE && !e->bnxt_valid) continue;
-    result.push_back(d);
-  }
-  return result;
-}
-
-// =====================================================================
 // Table printer
 // =====================================================================
 
@@ -618,18 +518,6 @@ void NetCounterPrintTable(
     return;
   }
 
-  // Filter counters to those valid for the detected NIC type
-  std::vector<CounterDescriptor> active = NetCounterFilterByNicType(selected, before);
-  num_counters = active.size();
-
-  if (num_counters == 0) {
-    printf("NET_COUNTER_TABLE: node=%s rank=%d status=NO_DATA"
-           " (all counters filtered for detected NIC type)\n",
-           hostname, rank);
-    fflush(stdout);
-    return;
-  }
-
   bool mixed = false;
   NicType nic_type = DetectNicTypeFromSnapshots(before, mixed);
 
@@ -645,7 +533,7 @@ void NetCounterPrintTable(
   for (size_t n = 0; n < num_nics; n++) {
     dur_sec[n] = (after[n].timestamp_us - before[n].timestamp_us) / 1e6;
     for (size_t c = 0; c < num_counters; c++) {
-      deltas[n][c] = NetCounterComputeDelta(before[n], after[n], active[c]);
+      deltas[n][c] = NetCounterComputeDelta(before[n], after[n], selected[c]);
       rates[n][c] = (dur_sec[n] > 0.0)
                         ? (double)deltas[n][c] / dur_sec[n]
                         : 0.0;
@@ -685,7 +573,7 @@ void NetCounterPrintTable(
       snprintf(buf, sizeof(buf), "%.2f", rates[n][c]);
       rt_w[c] = std::max(rt_w[c], (int)strlen(buf));
     }
-    int name_len = (int)active[c].name.size();
+    int name_len = (int)selected[c].name.size();
     int pair_w   = cnt_w[c] + 2 + rt_w[c];
     if (name_len > pair_w) {
       rt_w[c] += (name_len - pair_w);
@@ -709,7 +597,7 @@ void NetCounterPrintTable(
   printf("%-*s", nic_w, "Device");
   for (size_t c = 0; c < num_counters; c++) {
     int pair_w = cnt_w[c] + 2 + rt_w[c];
-    printf("  %-*s", pair_w, active[c].name.c_str());
+    printf("  %-*s", pair_w, selected[c].name.c_str());
   }
   printf("\n");
 
@@ -723,7 +611,7 @@ void NetCounterPrintTable(
 
   for (size_t n = 0; n < num_nics; n++) {
     printf("%-*s", nic_w, labels[n].c_str());
-    for (size_t c = 0; c < active.size(); c++) {
+    for (size_t c = 0; c < num_counters; c++) {
       printf("  %*llu  %*.2f", cnt_w[c], (unsigned long long)deltas[n][c], rt_w[c], rates[n][c]);
     }
     printf("\n");

--- a/projects/rccl-tests/src/collector.cu
+++ b/projects/rccl-tests/src/collector.cu
@@ -23,57 +23,59 @@
 // =====================================================================
 //
 // Each NIC type has its own table with actual hardware key names.
-// name      : counter key (used in sysfs paths and output headers)
-// source    : where to read the value
-// is_prefix : true → prefix-match (expands to name0..name7)
+// name          : counter key (used in output headers and primary sysfs path)
+// source        : where to read the value
+// is_prefix     : true → prefix-match (expands to name0..name7)
+// fallback_name : alternative sysfs key to try if 'name' is not found (or NULL)
 
 struct CounterTableEntry {
   const char*   name;
   CounterSource source;
   bool          is_prefix;
+  const char*   fallback_name;  // NULL = no fallback
 };
 
 // ----- IONIC (AINIC) counter table -----
 static const CounterTableEntry ionic_table[] = {
   // ethtool – PFC frame counters (prefix → expands to name0..name7)
-  {"frames_rx_pripause",       COUNTER_SRC_ETHTOOL,  true},
-  {"frames_tx_pripause",       COUNTER_SRC_ETHTOOL,  true},
+  {"frames_rx_pripause",       COUNTER_SRC_ETHTOOL,  true,  NULL},
+  {"frames_tx_pripause",       COUNTER_SRC_ETHTOOL,  true,  NULL},
   // IB hw_counters – CNP
-  {"rx_rdma_cnp_pkts",         COUNTER_SRC_IB_HW,    false},
-  {"tx_rdma_cnp_pkts",         COUNTER_SRC_IB_HW,    false},
+  {"rx_rdma_cnp_pkts",         COUNTER_SRC_IB_HW,    false, NULL},
+  {"tx_rdma_cnp_pkts",         COUNTER_SRC_IB_HW,    false, NULL},
   // IB hw_counters – errors & retransmits
-  {"rx_rdma_mtu_discard_pkts", COUNTER_SRC_IB_HW,    false},
-  {"resp_rx_outof_buf",        COUNTER_SRC_IB_HW,    false},
-  {"tx_rdma_ack_timeout",      COUNTER_SRC_IB_HW,    false},
-  {"req_tx_retry_excd_err",    COUNTER_SRC_IB_HW,    false},
-  {"resp_rx_outouf_seq",       COUNTER_SRC_IB_HW,    false},
-  {"req_rx_pkt_seq_err",       COUNTER_SRC_IB_HW,    false},
+  {"rx_rdma_mtu_discard_pkts", COUNTER_SRC_IB_HW,    false, NULL},
+  {"resp_rx_outof_buf",        COUNTER_SRC_IB_HW,    false, NULL},
+  {"tx_rdma_ack_timeout",      COUNTER_SRC_IB_HW,    false, NULL},
+  {"req_tx_retry_excd_err",    COUNTER_SRC_IB_HW,    false, NULL},
+  {"resp_rx_outouf_seq",       COUNTER_SRC_IB_HW,    false, NULL},
+  {"req_rx_pkt_seq_err",       COUNTER_SRC_IB_HW,    false, NULL},
   // IB hw_counters – RDMA throughput
-  {"tx_rdma_ucast_bytes",      COUNTER_SRC_IB_HW,    false},
-  {"rx_rdma_ucast_bytes",      COUNTER_SRC_IB_HW,    false},
-  {"tx_rdma_ucast_pkts",       COUNTER_SRC_IB_HW,    false},
-  {"rx_rdma_ucast_pkts",       COUNTER_SRC_IB_HW,    false},
+  {"tx_rdma_ucast_bytes",      COUNTER_SRC_IB_HW,    false, NULL},
+  {"rx_rdma_ucast_bytes",      COUNTER_SRC_IB_HW,    false, NULL},
+  {"tx_rdma_ucast_pkts",       COUNTER_SRC_IB_HW,    false, NULL},
+  {"rx_rdma_ucast_pkts",       COUNTER_SRC_IB_HW,    false, NULL},
 };
 static const int ionic_table_size = (int)(sizeof(ionic_table) / sizeof(ionic_table[0]));
 
 // ----- BNXT_RE (Thor2) counter table -----
 static const CounterTableEntry bnxt_re_table[] = {
   // ethtool – PFC frame counters (prefix → expands to name0..name7)
-  {"rx_pfc_ena_frames_pri",   COUNTER_SRC_ETHTOOL,  true},
-  {"tx_pfc_ena_frames_pri",   COUNTER_SRC_ETHTOOL,  true},
+  {"rx_pfc_ena_frames_pri",   COUNTER_SRC_ETHTOOL,  true,  NULL},
+  {"tx_pfc_ena_frames_pri",   COUNTER_SRC_ETHTOOL,  true,  NULL},
   // ethtool – PFC transition counters (exact)
-  {"pfc_pri3_rx_transitions", COUNTER_SRC_ETHTOOL,  false},
-  {"pfc_pri3_tx_transitions", COUNTER_SRC_ETHTOOL,  false},
-  // IB hw_counters
-  {"rp_cnp_handled",          COUNTER_SRC_IB_HW,    false},
-  {"np_cnp_sent",             COUNTER_SRC_IB_HW,    false},
-  {"rx_roce_discards",        COUNTER_SRC_IB_HW,    false},
+  {"pfc_pri3_rx_transitions", COUNTER_SRC_ETHTOOL,  false, NULL},
+  {"pfc_pri3_tx_transitions", COUNTER_SRC_ETHTOOL,  false, NULL},
+  // IB hw_counters – CNP (try rx_cnp_pkts first, fall back to rp_cnp_handled)
+  {"rx_cnp_pkts",             COUNTER_SRC_IB_HW,    false, "rp_cnp_handled"},
+  {"tx_cnp_pkts",             COUNTER_SRC_IB_HW,    false, "np_cnp_sent"},
+  {"rx_roce_discards",        COUNTER_SRC_IB_HW,    false, NULL},
   // debugfs (bnxt_re info)
-  {"rx_stat_discards",        COUNTER_SRC_DEBUGFS,  false},
-  {"to_retransmits",          COUNTER_SRC_DEBUGFS,  false},
-  {"max_retry_exceeded",      COUNTER_SRC_DEBUGFS,  false},
-  {"oos_drop_count",          COUNTER_SRC_DEBUGFS,  false},
-  {"seq_err_naks_rcvd",       COUNTER_SRC_DEBUGFS,  false},
+  {"rx_stat_discards",        COUNTER_SRC_DEBUGFS,  false, NULL},
+  {"to_retransmits",          COUNTER_SRC_DEBUGFS,  false, NULL},
+  {"max_retry_exceeded",      COUNTER_SRC_DEBUGFS,  false, NULL},
+  {"oos_drop_count",          COUNTER_SRC_DEBUGFS,  false, NULL},
+  {"seq_err_naks_rcvd",       COUNTER_SRC_DEBUGFS,  false, NULL},
 };
 static const int bnxt_re_table_size = (int)(sizeof(bnxt_re_table) / sizeof(bnxt_re_table[0]));
 
@@ -125,7 +127,8 @@ std::vector<CounterDescriptor> NetCounterGetCounterList(NicType nic_type) {
   int size;
   GetTable(nic_type, table, size);
   for (int i = 0; i < size; i++) {
-    result.push_back({table[i].name, table[i].source, table[i].is_prefix});
+    result.push_back({table[i].name, table[i].source, table[i].is_prefix,
+                      table[i].fallback_name ? table[i].fallback_name : ""});
   }
   return result;
 }
@@ -366,6 +369,11 @@ static void CollectIbHwCounters(const std::string& ib_device,
     std::string path = base_port + d.name;
     FILE* fp = fopen(path.c_str(), "r");
     if (!fp) fp = fopen((base_dev + d.name).c_str(), "r");
+    // If primary name not found, try fallback
+    if (!fp && !d.fallback_name.empty()) {
+      fp = fopen((base_port + d.fallback_name).c_str(), "r");
+      if (!fp) fp = fopen((base_dev + d.fallback_name).c_str(), "r");
+    }
     if (fp) {
       unsigned long long tmp = 0;
       if (fscanf(fp, "%llu", &tmp) == 1) out[d.name] = (uint64_t)tmp;

--- a/projects/rccl-tests/src/collector.cu
+++ b/projects/rccl-tests/src/collector.cu
@@ -26,25 +26,35 @@ struct CounterRegistryEntry {
   const char*   name;
   CounterSource source;
   bool          is_prefix;
+  // bnxt_re (Thor2): actual hw_counters filename when it differs from name
+  //   NULL → use canonical name as-is
+  const char*   bnxt_key;
+  bool          bnxt_valid; // false → not displayed on bnxt_re
+  // ionic (AINIC): actual hw_counters filename, NULL → counter not on ionic
+  const char*   ionic_key;
+  CounterSource ionic_source;
 };
 
 static const CounterRegistryEntry counter_registry[] = {
-  // ethtool – PFC frame counters (prefix → expands to name0..name7)
-  {"rx_pfc_ena_frames_pri",   COUNTER_SRC_ETHTOOL,  true},
-  {"tx_pfc_ena_frames_pri",   COUNTER_SRC_ETHTOOL,  true},
-  // ethtool – PFC transition counters (exact)
-  {"pfc_pri3_rx_transitions", COUNTER_SRC_ETHTOOL,  false},
-  {"pfc_pri3_tx_transitions", COUNTER_SRC_ETHTOOL,  false},
-  // IB hw_counters
-  {"rx_cnp_pkts",             COUNTER_SRC_IB_HW,    false},
-  {"tx_cnp_pkts",             COUNTER_SRC_IB_HW,    false},
-  {"rx_roce_discards",        COUNTER_SRC_IB_HW,    false},
-  // debugfs (bnxt_re info)
-  {"rx_stat_discards",        COUNTER_SRC_DEBUGFS,   false},
-  {"to_retransmits",          COUNTER_SRC_DEBUGFS,   false},
-  {"max_retry_exceeded",      COUNTER_SRC_DEBUGFS,   false},
-  {"oos_drop_count",          COUNTER_SRC_DEBUGFS,   false},
-  {"seq_err_naks_rcvd",       COUNTER_SRC_DEBUGFS,   false},
+  //                                                                        --------- bnxt_re ---------   ----------- ionic -----------
+  // name                       source               prefix  bnxt_key         bnxt_valid  ionic_key               ionic_source
+  {"rx_pfc_ena_frames_pri",   COUNTER_SRC_ETHTOOL,  true,   NULL,            true,       "frames_rx_pripause",   COUNTER_SRC_ETHTOOL},
+  {"tx_pfc_ena_frames_pri",   COUNTER_SRC_ETHTOOL,  true,   NULL,            true,       "frames_tx_pripause",   COUNTER_SRC_ETHTOOL},
+  {"pfc_pri3_rx_transitions", COUNTER_SRC_ETHTOOL,  false,  NULL,            true,       NULL,                   COUNTER_SRC_ETHTOOL},
+  {"pfc_pri3_tx_transitions", COUNTER_SRC_ETHTOOL,  false,  NULL,            true,       NULL,                   COUNTER_SRC_ETHTOOL},
+  {"rx_cnp_pkts",             COUNTER_SRC_IB_HW,    false,  "rp_cnp_handled",            true,       "rx_rdma_cnp_pkts",     COUNTER_SRC_IB_HW},
+  {"tx_cnp_pkts",             COUNTER_SRC_IB_HW,    false,  "np_cnp_sent",               true,       "tx_rdma_cnp_pkts",     COUNTER_SRC_IB_HW},
+  {"rx_roce_discards",        COUNTER_SRC_IB_HW,    false,  NULL,            true,       "rx_rdma_mtu_discard_pkts", COUNTER_SRC_IB_HW},
+  {"rx_stat_discards",        COUNTER_SRC_DEBUGFS,  false,  NULL,            true,       "resp_rx_outof_buf",    COUNTER_SRC_IB_HW},
+  {"to_retransmits",          COUNTER_SRC_DEBUGFS,  false,  NULL,            true,       "tx_rdma_ack_timeout",  COUNTER_SRC_IB_HW},
+  {"max_retry_exceeded",      COUNTER_SRC_DEBUGFS,  false,  NULL,            true,       "req_tx_retry_excd_err",COUNTER_SRC_IB_HW},
+  {"oos_drop_count",          COUNTER_SRC_DEBUGFS,  false,  NULL,            true,       "resp_rx_outouf_seq",   COUNTER_SRC_IB_HW},
+  {"seq_err_naks_rcvd",       COUNTER_SRC_DEBUGFS,  false,  NULL,            true,       "req_rx_pkt_seq_err",   COUNTER_SRC_IB_HW},
+  // RDMA throughput – ionic (AINIC) only
+  {"tx_rdma_ucast_bytes",     COUNTER_SRC_IB_HW,    false,  NULL,            false,      "tx_rdma_ucast_bytes",  COUNTER_SRC_IB_HW},
+  {"rx_rdma_ucast_bytes",     COUNTER_SRC_IB_HW,    false,  NULL,            false,      "rx_rdma_ucast_bytes",  COUNTER_SRC_IB_HW},
+  {"tx_rdma_ucast_pkts",      COUNTER_SRC_IB_HW,    false,  NULL,            false,      "tx_rdma_ucast_pkts",   COUNTER_SRC_IB_HW},
+  {"rx_rdma_ucast_pkts",      COUNTER_SRC_IB_HW,    false,  NULL,            false,      "rx_rdma_ucast_pkts",   COUNTER_SRC_IB_HW},
 };
 
 static const int counter_registry_size =
@@ -163,6 +173,24 @@ std::vector<std::string> NetCounterParseIbHcaList() {
 }
 
 // =====================================================================
+// IB device name parsing
+// =====================================================================
+
+// Split "rdma0:2" → base="rdma0", port=2.  Default port is 1.
+static void ParseIbDevice(const std::string& ib_device,
+                           std::string& base, int& port) {
+  size_t colon = ib_device.find(':');
+  if (colon == std::string::npos) {
+    base = ib_device;
+    port = 1;
+  } else {
+    base = ib_device.substr(0, colon);
+    port = atoi(ib_device.c_str() + colon + 1);
+    if (port <= 0) port = 1;
+  }
+}
+
+// =====================================================================
 // Device lookup
 // =====================================================================
 
@@ -189,10 +217,14 @@ std::string NetCounterFindIbDeviceForNic(const std::string& nic) {
 }
 
 std::string NetCounterFindNicForIbDevice(const std::string& ib_device) {
+  std::string ib_base;
+  int port;
+  ParseIbDevice(ib_device, ib_base, port);
+  (void)port;
   char cmd[512] = {0};
   snprintf(cmd, sizeof(cmd),
            "ls /sys/class/infiniband/%s/device/net 2>/dev/null | head -1",
-           ib_device.c_str());
+           ib_base.c_str());
   return RunShellOneLiner(cmd);
 }
 
@@ -223,21 +255,92 @@ void NetCounterGetNetworkInterfaces(std::vector<std::string>& interfaces) {
 }
 
 // =====================================================================
+// NIC type detection
+// =====================================================================
+
+NicType NetCounterDetectNicType(const std::string& ib_device) {
+  if (ib_device.empty()) return NIC_UNKNOWN;
+
+  std::string ib_base;
+  int port;
+  ParseIbDevice(ib_device, ib_base, port);
+  (void)port;
+
+  if (ib_base.compare(0, 7, "bnxt_re") == 0) return NIC_BNXT_RE;
+
+  char link[4096] = {0};
+  std::string driver_path =
+      "/sys/class/infiniband/" + ib_base + "/device/driver";
+  ssize_t len = readlink(driver_path.c_str(), link, sizeof(link) - 1);
+  if (len <= 0) return NIC_UNKNOWN;
+  link[len] = '\0';
+
+  const char* drv = strrchr(link, '/');
+  drv = drv ? drv + 1 : link;
+
+  if (strcmp(drv, "bnxt_re") == 0 || strcmp(drv, "bnxt_en") == 0)
+    return NIC_BNXT_RE;
+  if (strcmp(drv, "ionic") == 0)
+    return NIC_IONIC;
+  return NIC_UNKNOWN;
+}
+
+const char* NicTypeStr(NicType t) {
+  switch (t) {
+    case NIC_BNXT_RE: return "BNXT_RE";
+    case NIC_IONIC:   return "IONIC";
+    default:          return "UNKNOWN";
+  }
+}
+
+NicType DetectNicTypeFromSnapshots(
+    const std::vector<NetworkCounterSnapshot>& snaps, bool& mixed) {
+  NicType nic_type = NIC_UNKNOWN;
+  mixed = false;
+  for (size_t i = 0; i < snaps.size(); i++) {
+    if (snaps[i].nic_type == NIC_UNKNOWN) continue;
+    if (nic_type == NIC_UNKNOWN) {
+      nic_type = snaps[i].nic_type;
+    } else if (snaps[i].nic_type != nic_type) {
+      mixed = true;
+      break;
+    }
+  }
+  return nic_type;
+}
+
+// =====================================================================
 // Per-source collection
 // =====================================================================
 
+static const char* ResolveEthtoolKey(const CounterDescriptor& d,
+                                     NicType nic_type) {
+  const CounterRegistryEntry* e = FindInRegistry(d.name);
+  if (nic_type == NIC_IONIC && e && e->ionic_key &&
+      e->ionic_source == COUNTER_SRC_ETHTOOL) {
+    return e->ionic_key;
+  }
+  if (nic_type == NIC_BNXT_RE && e && e->bnxt_key) {
+    return e->bnxt_key;
+  }
+  return d.name.c_str();
+}
+
 static void CollectEthtoolCounters(const std::string& nic,
                                    const std::vector<CounterDescriptor>& selected,
+                                   NicType nic_type,
                                    std::map<std::string, uint64_t>& out) {
   std::set<std::string> exact;
-  std::vector<std::string> prefixes;
+  std::map<std::string, std::string> key_to_canon;
+  std::vector<std::pair<std::string, std::string>> prefixes;
   for (const auto& d : selected) {
     if (d.source != COUNTER_SRC_ETHTOOL) { continue; }
-
+    const char* ethtool_key = ResolveEthtoolKey(d, nic_type);
     if (d.is_prefix) {
-      prefixes.push_back(d.name);
+      prefixes.push_back({ethtool_key, d.name});
     } else {
-      exact.insert(d.name);
+      exact.insert(ethtool_key);
+      key_to_canon[ethtool_key] = d.name;
     }
   }
   if (exact.empty() && prefixes.empty()) { return; }
@@ -251,39 +354,92 @@ static void CollectEthtoolCounters(const std::string& nic,
   char line[256] = {0};
   while (fgets(line, sizeof(line), fp)) {
     char key[256] = {0};
-    uint64_t value = 0;
-    if (sscanf(line, "%255[^:]: %lu", key, &value) == 2) {
+    unsigned long long tmp = 0;
+    if (sscanf(line, "%255[^:]: %llu", key, &tmp) == 2) {
+      uint64_t value = (uint64_t)tmp;
       char* start = key;
       while (*start == ' ' || *start == '\t') { start++; }
       std::string k(start);
-      if (exact.count(k)) { out[k] = value; continue; }
+      if (exact.count(k)) {
+        out[key_to_canon.count(k) ? key_to_canon[k] : k] = value;
+        continue;
+      }
       for (const auto& pfx : prefixes) {
-        if (k.compare(0, pfx.size(), pfx) == 0) { out[k] = value; break; }
+        if (k.compare(0, pfx.first.size(), pfx.first) == 0) {
+          std::string canon_key = pfx.second + k.substr(pfx.first.size());
+          out[canon_key] = value;
+          break;
+        }
       }
     }
   }
   pclose(fp);
 }
 
+static void CollectIbHwCountersIonic(
+    const std::vector<CounterDescriptor>& selected,
+    const std::string& base_port, const std::string& base_dev,
+    std::map<std::string, uint64_t>& out) {
+  for (const auto& d : selected) {
+    const CounterRegistryEntry* e = FindInRegistry(d.name);
+    if (!e || !e->ionic_key || e->ionic_source != COUNTER_SRC_IB_HW) continue;
+    std::string path = base_port + e->ionic_key;
+    FILE* fp = fopen(path.c_str(), "r");
+    if (!fp) fp = fopen((base_dev + e->ionic_key).c_str(), "r");
+    if (fp) {
+      unsigned long long tmp = 0;
+      if (fscanf(fp, "%llu", &tmp) == 1) out[d.name] = (uint64_t)tmp;
+      fclose(fp);
+    }
+  }
+}
+
+static void CollectIbHwCountersBnxtRe(
+    const std::vector<CounterDescriptor>& selected,
+    const std::string& base_port,
+    std::map<std::string, uint64_t>& out) {
+  for (const auto& d : selected) {
+    if (d.source != COUNTER_SRC_IB_HW) { continue; }
+    const CounterRegistryEntry* e = FindInRegistry(d.name);
+    const char* hw_key = d.name.c_str();
+    std::string path = base_port + hw_key;
+    FILE* fp = fopen(path.c_str(), "r");
+    if (!fp && e && e->bnxt_key) {
+      path = base_port + e->bnxt_key;
+      fp = fopen(path.c_str(), "r");
+    }
+    if (fp) {
+      unsigned long long tmp = 0;
+      if (fscanf(fp, "%llu", &tmp) == 1) out[d.name] = (uint64_t)tmp;
+      fclose(fp);
+    }
+  }
+}
+
 static void CollectIbHwCounters(const std::string& ib_device,
                                 const std::vector<CounterDescriptor>& selected,
+                                NicType nic_type,
                                 std::map<std::string, uint64_t>& out) {
   if (ib_device.empty()) { return; }
 
-  std::string base =
-      "/sys/class/infiniband/" + ib_device + "/ports/1/hw_counters/";
+  std::string ib_base;
+  int ib_port;
+  ParseIbDevice(ib_device, ib_base, ib_port);
+  char port_str[16];
+  snprintf(port_str, sizeof(port_str), "%d", ib_port);
+  std::string base_port =
+      "/sys/class/infiniband/" + ib_base + "/ports/" + port_str + "/hw_counters/";
+  std::string base_dev =
+      "/sys/class/infiniband/" + ib_base + "/hw_counters/";
 
-  for (const auto& d : selected) {
-    if (d.source != COUNTER_SRC_IB_HW) { continue; }
-    std::string path = base + d.name;
-    FILE* fp = fopen(path.c_str(), "r");
-    if (fp) {
-      uint64_t value = 0;
-      if (fscanf(fp, "%lu", &value) == 1) {
-        out[d.name] = value;
-      }
-      fclose(fp);
-    }
+  switch (nic_type) {
+    case NIC_IONIC:
+      CollectIbHwCountersIonic(selected, base_port, base_dev, out);
+      break;
+    case NIC_BNXT_RE:
+    default:
+      CollectIbHwCountersBnxtRe(selected, base_port, out);
+      break;
   }
 }
 
@@ -298,8 +454,12 @@ static void CollectDebugCounters(const std::string& ib_device,
   }
   if (wanted.empty()) { return; }
 
+  std::string ib_base;
+  int port;
+  ParseIbDevice(ib_device, ib_base, port);
+  (void)port;
   std::string info_path =
-      "/sys/kernel/debug/bnxt_re/" + ib_device + "/info";
+      "/sys/kernel/debug/bnxt_re/" + ib_base + "/info";
   FILE* fp = fopen(info_path.c_str(), "r");
   if (!fp) { return; }
 
@@ -307,10 +467,11 @@ static void CollectDebugCounters(const std::string& ib_device,
   while (fgets(line, sizeof(line), fp)) {
     for (const auto& name : wanted) {
       if (strstr(line, name.c_str())) {
-        uint64_t value = 0;
+        unsigned long long tmp = 0;
         char key[256] = {0};
-        if (sscanf(line, " %255[^:=] %*[:=] %lu", key, &value) == 2 ||
-            sscanf(line, " %255s %lu", key, &value) == 2) {
+        if (sscanf(line, " %255[^:=] %*[:=] %llu", key, &tmp) == 2 ||
+            sscanf(line, " %255s %llu", key, &tmp) == 2) {
+          uint64_t value = (uint64_t)tmp;
           char* start = key;
           while (*start == ' ' || *start == '\t') { start++; }
           char* end = start + strlen(start) - 1;
@@ -347,11 +508,16 @@ NetworkCounterSnapshot NetCounterCollectSnapshot(
     strncpy(snap.ib_device, ib_dev.c_str(), sizeof(snap.ib_device) - 1);
   }
 
-  snap.timestamp = time(NULL);
+  struct timespec ts;
+  clock_gettime(CLOCK_MONOTONIC, &ts);
+  snap.timestamp_us = (int64_t)ts.tv_sec * 1000000 + ts.tv_nsec / 1000;
+  snap.nic_type = NetCounterDetectNicType(ib_dev);
 
-  CollectEthtoolCounters(nic, selected, snap.counters);
-  CollectIbHwCounters(ib_dev, selected, snap.counters);
-  CollectDebugCounters(ib_dev, selected, snap.counters);
+  CollectEthtoolCounters(nic, selected, snap.nic_type, snap.counters);
+  CollectIbHwCounters(ib_dev, selected, snap.nic_type, snap.counters);
+  if (snap.nic_type != NIC_IONIC) {
+    CollectDebugCounters(ib_dev, selected, snap.counters);
+  }
 
   return snap;
 }
@@ -394,6 +560,37 @@ uint64_t NetCounterComputeDelta(
 }
 
 // =====================================================================
+// NIC-type-aware column filter
+// =====================================================================
+
+std::vector<CounterDescriptor> NetCounterFilterByNicType(
+    const std::vector<CounterDescriptor>& selected,
+    const std::vector<NetworkCounterSnapshot>& snapshots) {
+  if (snapshots.empty()) return selected;
+
+  bool mixed = false;
+  NicType nic_type = DetectNicTypeFromSnapshots(snapshots, mixed);
+
+  if (nic_type == NIC_UNKNOWN || mixed) {
+    if (mixed) {
+      fprintf(stderr,
+              "# Warning: mixed NIC types detected, showing all counters\n");
+    }
+    return selected;
+  }
+
+  std::vector<CounterDescriptor> result;
+  for (const auto& d : selected) {
+    const CounterRegistryEntry* e = FindInRegistry(d.name);
+    if (!e) { result.push_back(d); continue; }
+    if (nic_type == NIC_IONIC && !e->ionic_key) continue;   // not on ionic
+    if (nic_type == NIC_BNXT_RE && !e->bnxt_valid) continue;
+    result.push_back(d);
+  }
+  return result;
+}
+
+// =====================================================================
 // Table printer
 // =====================================================================
 
@@ -421,6 +618,21 @@ void NetCounterPrintTable(
     return;
   }
 
+  // Filter counters to those valid for the detected NIC type
+  std::vector<CounterDescriptor> active = NetCounterFilterByNicType(selected, before);
+  num_counters = active.size();
+
+  if (num_counters == 0) {
+    printf("NET_COUNTER_TABLE: node=%s rank=%d status=NO_DATA"
+           " (all counters filtered for detected NIC type)\n",
+           hostname, rank);
+    fflush(stdout);
+    return;
+  }
+
+  bool mixed = false;
+  NicType nic_type = DetectNicTypeFromSnapshots(before, mixed);
+
   // Pre-compute deltas, rates, durations
   std::vector<std::vector<uint64_t>> deltas(
       num_nics, std::vector<uint64_t>(num_counters, 0));
@@ -428,14 +640,14 @@ void NetCounterPrintTable(
   std::vector<std::vector<double>> rates(
       num_nics, std::vector<double>(num_counters, 0.0));
 
-  std::vector<long> durations(num_nics);
+  std::vector<double> dur_sec(num_nics);
 
   for (size_t n = 0; n < num_nics; n++) {
-    durations[n] = after[n].timestamp - before[n].timestamp;
+    dur_sec[n] = (after[n].timestamp_us - before[n].timestamp_us) / 1e6;
     for (size_t c = 0; c < num_counters; c++) {
-      deltas[n][c] = NetCounterComputeDelta(before[n], after[n], selected[c]);
-      rates[n][c] = (durations[n] > 0)
-                        ? (double)deltas[n][c] / durations[n]
+      deltas[n][c] = NetCounterComputeDelta(before[n], after[n], active[c]);
+      rates[n][c] = (dur_sec[n] > 0.0)
+                        ? (double)deltas[n][c] / dur_sec[n]
                         : 0.0;
     }
   }
@@ -468,12 +680,12 @@ void NetCounterPrintTable(
   for (size_t c = 0; c < num_counters; c++) {
     for (size_t n = 0; n < num_nics; n++) {
       char buf[32];
-      snprintf(buf, sizeof(buf), "%lu", deltas[n][c]);
+      snprintf(buf, sizeof(buf), "%llu", (unsigned long long)deltas[n][c]);
       cnt_w[c] = std::max(cnt_w[c], (int)strlen(buf));
       snprintf(buf, sizeof(buf), "%.2f", rates[n][c]);
       rt_w[c] = std::max(rt_w[c], (int)strlen(buf));
     }
-    int name_len = (int)selected[c].name.size();
+    int name_len = (int)active[c].name.size();
     int pair_w   = cnt_w[c] + 2 + rt_w[c];
     if (name_len > pair_w) {
       rt_w[c] += (name_len - pair_w);
@@ -490,14 +702,14 @@ void NetCounterPrintTable(
   }
 
   // Print
-  printf("\nNET_COUNTER_TABLE: node=%s  rank=%d  duration_sec=%ld\n",
-         hostname, rank, durations[0]);
+  printf("\nNET_COUNTER_TABLE: node=%s  rank=%d  duration_sec=%.3f  nic_type=%s\n",
+         hostname, rank, dur_sec[0], mixed ? "MIXED" : NicTypeStr(nic_type));
   printf("%s\n", sep.c_str());
 
   printf("%-*s", nic_w, "Device");
   for (size_t c = 0; c < num_counters; c++) {
     int pair_w = cnt_w[c] + 2 + rt_w[c];
-    printf("  %-*s", pair_w, selected[c].name.c_str());
+    printf("  %-*s", pair_w, active[c].name.c_str());
   }
   printf("\n");
 
@@ -511,8 +723,8 @@ void NetCounterPrintTable(
 
   for (size_t n = 0; n < num_nics; n++) {
     printf("%-*s", nic_w, labels[n].c_str());
-    for (size_t c = 0; c < num_counters; c++) {
-      printf("  %*lu  %*.2f", cnt_w[c], deltas[n][c], rt_w[c], rates[n][c]);
+    for (size_t c = 0; c < active.size(); c++) {
+      printf("  %*llu  %*.2f", cnt_w[c], (unsigned long long)deltas[n][c], rt_w[c], rates[n][c]);
     }
     printf("\n");
   }

--- a/projects/rccl-tests/src/collector.h
+++ b/projects/rccl-tests/src/collector.h
@@ -7,9 +7,10 @@
 /*************************************************************************
  * Network Counter Collector
  *
- * Self-contained library for collecting Thor2 NIC counters before/after
- * an operation and printing a summary table.  No dependency on NCCL,
- * RCCL, or any GPU runtime -- can be integrated into any application.
+ * Self-contained library for collecting Thor2 / AINIC NIC counters
+ * before/after an operation and printing a summary table.  No dependency
+ * on NCCL, RCCL, or any GPU runtime -- can be integrated into any
+ * application.
  *
  * Environment variables:
  *   RCCL_TESTS_NET_COUNTER_ENABLE=1   – enable collection
@@ -46,11 +47,14 @@ struct CounterDescriptor {
   bool is_prefix;   // true  → prefix match (expands to name0..name7)
 };
 
+typedef enum { NIC_UNKNOWN, NIC_BNXT_RE, NIC_IONIC } NicType;
+
 struct NetworkCounterSnapshot {
   std::map<std::string, uint64_t> counters;
-  char nic_name[256];
-  char ib_device[256];
-  long timestamp;
+  char    nic_name[256];
+  char    ib_device[256];
+  int64_t timestamp_us;
+  NicType nic_type;
 };
 
 struct NetworkCounterContext {
@@ -65,6 +69,16 @@ struct NetworkCounterContext {
 };
 
 // ---- public API ---------------------------------------------------------
+
+// Detect NIC type from IB device driver symlink
+NicType NetCounterDetectNicType(const std::string& ib_device);
+
+// Scan snapshots and return the dominant NIC type; sets mixed=true if types differ
+NicType DetectNicTypeFromSnapshots(
+    const std::vector<NetworkCounterSnapshot>& snaps, bool& mixed);
+
+// Human-readable NIC type string
+const char* NicTypeStr(NicType t);
 
 // Check RCCL_TESTS_NET_COUNTER_ENABLE=1
 bool NetCounterIsEnabled();
@@ -98,6 +112,11 @@ uint64_t NetCounterComputeDelta(
     const NetworkCounterSnapshot& before,
     const NetworkCounterSnapshot& after,
     const CounterDescriptor& desc);
+
+// Filter counter list to only those valid for the NIC types in snapshots
+std::vector<CounterDescriptor> NetCounterFilterByNicType(
+    const std::vector<CounterDescriptor>& selected,
+    const std::vector<NetworkCounterSnapshot>& snapshots);
 
 // Print one table per node to stdout
 void NetCounterPrintTable(

--- a/projects/rccl-tests/src/collector.h
+++ b/projects/rccl-tests/src/collector.h
@@ -40,9 +40,10 @@ enum CounterSource {
 };
 
 struct CounterDescriptor {
-  std::string name;      // actual hardware key name (unique per NIC type)
+  std::string name;           // actual hardware key name (unique per NIC type)
   CounterSource source;
-  bool is_prefix;        // true -> prefix match (expands to name0..name7)
+  bool is_prefix;             // true -> prefix match (expands to name0..name7)
+  std::string fallback_name;  // alternative sysfs key if 'name' not found
 };
 
 typedef enum { NIC_UNKNOWN, NIC_BNXT_RE, NIC_IONIC } NicType;

--- a/projects/rccl-tests/src/collector.h
+++ b/projects/rccl-tests/src/collector.h
@@ -14,12 +14,16 @@
  *
  * Environment variables:
  *   RCCL_TESTS_NET_COUNTER_ENABLE=1   – enable collection
+ *   RCCL_TESTS_NIC_COUNTER_LIST=a,b   – comma-separated counter subset
+ *                                        (default: all counters for detected NIC)
  *   NCCL_IB_HCA=ib0,ib1,...           – IB device list (primary)
  *   RCCL_TESTS_NET_COUNTER_NIC_PREFIX – NIC prefix filter for auto-discovery
  *
  * Counter sources (looked up automatically per NIC type):
  *   COUNTER_SRC_ETHTOOL  – ethtool -S <ethernet device>
- *   COUNTER_SRC_IB_HW    – /sys/class/infiniband/<dev>/ports/1/hw_counters/
+ *   COUNTER_SRC_IB_HW    – /sys/class/infiniband/<dev>/ports/<port>/hw_counters/
+ *                           (port parsed from NCCL_IB_HCA suffix, default 1;
+ *                            falls back to device-level hw_counters/ if needed)
  *   COUNTER_SRC_DEBUGFS  – /sys/kernel/debug/bnxt_re/<dev>/info
  *************************************************************************/
 #ifndef __COLLECTOR_H__
@@ -40,10 +44,10 @@ enum CounterSource {
 };
 
 struct CounterDescriptor {
-  std::string name;           // actual hardware key name (unique per NIC type)
+  std::string name;           // canonical/display key (also primary sysfs lookup name)
   CounterSource source;
   bool is_prefix;             // true -> prefix match (expands to name0..name7)
-  std::string fallback_name;  // alternative sysfs key if 'name' not found
+  std::string fallback_name;  // alternative sysfs key to try when 'name' is missing
 };
 
 typedef enum { NIC_UNKNOWN, NIC_BNXT_RE, NIC_IONIC } NicType;

--- a/projects/rccl-tests/src/collector.h
+++ b/projects/rccl-tests/src/collector.h
@@ -14,12 +14,10 @@
  *
  * Environment variables:
  *   RCCL_TESTS_NET_COUNTER_ENABLE=1   – enable collection
- *   RCCL_TESTS_NIC_COUNTER_LIST=a,b   – comma-separated counter names
- *                                        (default: all known counters)
  *   NCCL_IB_HCA=ib0,ib1,...           – IB device list (primary)
  *   RCCL_TESTS_NET_COUNTER_NIC_PREFIX – NIC prefix filter for auto-discovery
  *
- * Counter sources (looked up automatically from registry):
+ * Counter sources (looked up automatically per NIC type):
  *   COUNTER_SRC_ETHTOOL  – ethtool -S <ethernet device>
  *   COUNTER_SRC_IB_HW    – /sys/class/infiniband/<dev>/ports/1/hw_counters/
  *   COUNTER_SRC_DEBUGFS  – /sys/kernel/debug/bnxt_re/<dev>/info
@@ -42,9 +40,9 @@ enum CounterSource {
 };
 
 struct CounterDescriptor {
-  std::string name;
+  std::string name;      // actual hardware key name (unique per NIC type)
   CounterSource source;
-  bool is_prefix;   // true  → prefix match (expands to name0..name7)
+  bool is_prefix;        // true -> prefix match (expands to name0..name7)
 };
 
 typedef enum { NIC_UNKNOWN, NIC_BNXT_RE, NIC_IONIC } NicType;
@@ -83,8 +81,8 @@ const char* NicTypeStr(NicType t);
 // Check RCCL_TESTS_NET_COUNTER_ENABLE=1
 bool NetCounterIsEnabled();
 
-// Parse RCCL_TESTS_NIC_COUNTER_LIST (or return full registry)
-std::vector<CounterDescriptor> NetCounterParseCounterList();
+// Return counter list for the given NIC type
+std::vector<CounterDescriptor> NetCounterGetCounterList(NicType nic_type);
 
 // Parse NCCL_IB_HCA into IB device names (empty if unset)
 std::vector<std::string> NetCounterParseIbHcaList();
@@ -112,11 +110,6 @@ uint64_t NetCounterComputeDelta(
     const NetworkCounterSnapshot& before,
     const NetworkCounterSnapshot& after,
     const CounterDescriptor& desc);
-
-// Filter counter list to only those valid for the NIC types in snapshots
-std::vector<CounterDescriptor> NetCounterFilterByNicType(
-    const std::vector<CounterDescriptor>& selected,
-    const std::vector<NetworkCounterSnapshot>& snapshots);
 
 // Print one table per node to stdout
 void NetCounterPrintTable(

--- a/projects/rccl-tests/src/common.cu
+++ b/projects/rccl-tests/src/common.cu
@@ -1127,6 +1127,52 @@ static void getGPUMemoryInfo(int64_t* ptotalGpuMem, int64_t* pfreeGpuMem) {
 // The full implementation lives in collector.cu / collector.h
 // ============================================================
 
+static bool DiscoverRdmaNics(NetworkCounterContext& ctx) {
+  std::vector<std::string> ib_hca = NetCounterParseIbHcaList();
+  if (!ib_hca.empty()) {
+    for (const auto& ib : ib_hca) {
+      ctx.ib_names.push_back(ib);
+      ctx.nic_names.push_back(NetCounterFindNicForIbDevice(ib));
+    }
+    return true;
+  }
+  std::vector<std::string> all_nics;
+  NetCounterGetNetworkInterfaces(all_nics);
+  for (const auto& nic : all_nics) {
+    std::string ib = NetCounterFindIbDeviceForNic(nic);
+    if (ib.empty()) continue;
+    ctx.nic_names.push_back(nic);
+    ctx.ib_names.push_back(ib);
+  }
+  if (ctx.nic_names.empty()) {
+    fprintf(stderr,
+            "# Warning: no RDMA-capable NICs found, disabling net counter collection\n");
+    return false;
+  }
+  return true;
+}
+
+static NicType DetectNicTypeFromIbDevices(const std::vector<std::string>& ib_names,
+                                          bool& mixed) {
+  NicType nic_type = NIC_UNKNOWN;
+  mixed = false;
+  for (size_t i = 0; i < ib_names.size(); i++) {
+    NicType t = NetCounterDetectNicType(ib_names[i]);
+    if (t == NIC_UNKNOWN) continue;
+    if (nic_type == NIC_UNKNOWN) {
+      nic_type = t;
+    } else if (t != nic_type) {
+      mixed = true;
+      break;
+    }
+  }
+  if (mixed) {
+    fprintf(stderr,
+            "# Warning: mixed NIC types detected during counter table selection\n");
+  }
+  return nic_type;
+}
+
 NetworkCounterContext NetCounterCollectBefore(struct threadArgs* args) {
   NetworkCounterContext ctx;
   ctx.enabled = NetCounterIsEnabled();
@@ -1143,30 +1189,13 @@ NetworkCounterContext NetCounterCollectBefore(struct threadArgs* args) {
   ctx.nranks = args->nProcs * args->nThreads * args->nGpus;
   ctx.base_rank = args->proc * args->nThreads * args->nGpus;
 
-  // Discover devices: NCCL_IB_HCA (primary) or auto-discover NICs (fallback)
-  std::vector<std::string> ib_hca = NetCounterParseIbHcaList();
-  if (!ib_hca.empty()) {
-    for (const auto& ib : ib_hca) {
-      ctx.ib_names.push_back(ib);
-      ctx.nic_names.push_back(NetCounterFindNicForIbDevice(ib));
-    }
-  } else {
-    std::vector<std::string> all_nics;
-    NetCounterGetNetworkInterfaces(all_nics);
-    for (const auto& nic : all_nics) {
-      std::string ib = NetCounterFindIbDeviceForNic(nic);
-      if (ib.empty()) continue;
-      ctx.nic_names.push_back(nic);
-      ctx.ib_names.push_back(ib);
-    }
-    if (ctx.nic_names.empty()) { ctx.nic_names.push_back("eth0"); ctx.ib_names.push_back(""); }
+  if (!DiscoverRdmaNics(ctx)) {
+    ctx.enabled = false;
+    return ctx;
   }
 
-  // Detect NIC type from the first IB device and select the matching counter table
-  NicType nic_type = NIC_UNKNOWN;
-  for (size_t i = 0; i < ctx.ib_names.size() && nic_type == NIC_UNKNOWN; i++) {
-    nic_type = NetCounterDetectNicType(ctx.ib_names[i]);
-  }
+  bool mixed_detect = false;
+  NicType nic_type = DetectNicTypeFromIbDevices(ctx.ib_names, mixed_detect);
   ctx.selected_counters = NetCounterGetCounterList(nic_type);
 
   size_t ndevs = ctx.nic_names.size();
@@ -1180,7 +1209,8 @@ NetworkCounterContext NetCounterCollectBefore(struct threadArgs* args) {
   char hostname[256] = {0};
   gethostname(hostname, sizeof(hostname));
   printf("# Network counter collection enabled (RCCL_TESTS_NET_COUNTER_ENABLE=1)\n");
-  if (!ib_hca.empty()) {
+  const char* ib_hca_env = getenv("NCCL_IB_HCA");
+  if (ib_hca_env && strlen(ib_hca_env) > 0) {
     printf("# Device list from NCCL_IB_HCA\n");
   }
   printf("# Node %s: lead rank %d collecting %zu device(s):",
@@ -1193,7 +1223,7 @@ NetworkCounterContext NetCounterCollectBefore(struct threadArgs* args) {
     }
   }
   printf("\n");
-  printf("# NIC type: %s\n", NicTypeStr(nic_type));
+  printf("# NIC type: %s\n", mixed_detect ? "MIXED" : NicTypeStr(nic_type));
   printf("# Counters (%zu):", ctx.selected_counters.size());
   for (const auto& d : ctx.selected_counters) { printf(" %s", d.name.c_str()); }
   printf("\n");

--- a/projects/rccl-tests/src/common.cu
+++ b/projects/rccl-tests/src/common.cu
@@ -1139,13 +1139,11 @@ NetworkCounterContext NetCounterCollectBefore(struct threadArgs* args) {
     return ctx;
   }
 
-  ctx.selected_counters = NetCounterParseCounterList();
   ctx.nGpus = args->nGpus;
   ctx.nranks = args->nProcs * args->nThreads * args->nGpus;
   ctx.base_rank = args->proc * args->nThreads * args->nGpus;
 
-  // Primary: NCCL_IB_HCA → resolve ethernet NICs.
-  // Fallback: discover ethernet NICs → resolve IB device names.
+  // Discover devices: NCCL_IB_HCA (primary) or auto-discover NICs (fallback)
   std::vector<std::string> ib_hca = NetCounterParseIbHcaList();
   if (!ib_hca.empty()) {
     for (const auto& ib : ib_hca) {
@@ -1155,18 +1153,21 @@ NetworkCounterContext NetCounterCollectBefore(struct threadArgs* args) {
   } else {
     std::vector<std::string> all_nics;
     NetCounterGetNetworkInterfaces(all_nics);
-    // Get all NICs -> for each, check if it has an IB device -> only keep NICs that do
     for (const auto& nic : all_nics) {
       std::string ib = NetCounterFindIbDeviceForNic(nic);
-      // it skips non-RDMA interfaces. Only NICs that actually have
-      // an associated InfiniBand device are added
       if (ib.empty()) continue;
       ctx.nic_names.push_back(nic);
       ctx.ib_names.push_back(ib);
     }
-    // If no IB devices are found, use eth0 as a fallback.
     if (ctx.nic_names.empty()) { ctx.nic_names.push_back("eth0"); ctx.ib_names.push_back(""); }
   }
+
+  // Detect NIC type from the first IB device and select the matching counter table
+  NicType nic_type = NIC_UNKNOWN;
+  for (size_t i = 0; i < ctx.ib_names.size() && nic_type == NIC_UNKNOWN; i++) {
+    nic_type = NetCounterDetectNicType(ctx.ib_names[i]);
+  }
+  ctx.selected_counters = NetCounterGetCounterList(nic_type);
 
   size_t ndevs = ctx.nic_names.size();
   ctx.snapshots_before.resize(ndevs);
@@ -1175,9 +1176,6 @@ NetworkCounterContext NetCounterCollectBefore(struct threadArgs* args) {
         NetCounterCollectSnapshot(ctx.nic_names[i], ctx.ib_names[i],
                                   ctx.selected_counters);
   }
-
-  ctx.selected_counters =
-      NetCounterFilterByNicType(ctx.selected_counters, ctx.snapshots_before);
 
   char hostname[256] = {0};
   gethostname(hostname, sizeof(hostname));
@@ -1195,9 +1193,7 @@ NetworkCounterContext NetCounterCollectBefore(struct threadArgs* args) {
     }
   }
   printf("\n");
-  bool mixed_nics = false;
-  NicType detected_nic = DetectNicTypeFromSnapshots(ctx.snapshots_before, mixed_nics);
-  printf("# NIC type: %s\n", mixed_nics ? "MIXED" : NicTypeStr(detected_nic));
+  printf("# NIC type: %s\n", NicTypeStr(nic_type));
   printf("# Counters (%zu):", ctx.selected_counters.size());
   for (const auto& d : ctx.selected_counters) { printf(" %s", d.name.c_str()); }
   printf("\n");

--- a/projects/rccl-tests/src/common.cu
+++ b/projects/rccl-tests/src/common.cu
@@ -1153,12 +1153,19 @@ NetworkCounterContext NetCounterCollectBefore(struct threadArgs* args) {
       ctx.nic_names.push_back(NetCounterFindNicForIbDevice(ib));
     }
   } else {
-    NetCounterGetNetworkInterfaces(ctx.nic_names);
-    if (ctx.nic_names.empty()) { ctx.nic_names.push_back("eth0"); }
-    ctx.ib_names.resize(ctx.nic_names.size());
-    for (size_t i = 0; i < ctx.nic_names.size(); i++) {
-      ctx.ib_names[i] = NetCounterFindIbDeviceForNic(ctx.nic_names[i]);
+    std::vector<std::string> all_nics;
+    NetCounterGetNetworkInterfaces(all_nics);
+    // Get all NICs -> for each, check if it has an IB device -> only keep NICs that do
+    for (const auto& nic : all_nics) {
+      std::string ib = NetCounterFindIbDeviceForNic(nic);
+      // it skips non-RDMA interfaces. Only NICs that actually have
+      // an associated InfiniBand device are added
+      if (ib.empty()) continue;
+      ctx.nic_names.push_back(nic);
+      ctx.ib_names.push_back(ib);
     }
+    // If no IB devices are found, use eth0 as a fallback.
+    if (ctx.nic_names.empty()) { ctx.nic_names.push_back("eth0"); ctx.ib_names.push_back(""); }
   }
 
   size_t ndevs = ctx.nic_names.size();
@@ -1168,6 +1175,9 @@ NetworkCounterContext NetCounterCollectBefore(struct threadArgs* args) {
         NetCounterCollectSnapshot(ctx.nic_names[i], ctx.ib_names[i],
                                   ctx.selected_counters);
   }
+
+  ctx.selected_counters =
+      NetCounterFilterByNicType(ctx.selected_counters, ctx.snapshots_before);
 
   char hostname[256] = {0};
   gethostname(hostname, sizeof(hostname));
@@ -1185,6 +1195,9 @@ NetworkCounterContext NetCounterCollectBefore(struct threadArgs* args) {
     }
   }
   printf("\n");
+  bool mixed_nics = false;
+  NicType detected_nic = DetectNicTypeFromSnapshots(ctx.snapshots_before, mixed_nics);
+  printf("# NIC type: %s\n", mixed_nics ? "MIXED" : NicTypeStr(detected_nic));
   printf("# Counters (%zu):", ctx.selected_counters.size());
   for (const auto& d : ctx.selected_counters) { printf(" %s", d.name.c_str()); }
   printf("\n");


### PR DESCRIPTION
## Motivation
PR #3963 introduced a generalized network counter collector for Thor2 (bnxt_re) NIC diagnostics. This PR extends it with AINIC (ionic) NIC support, enabling the same congestion monitoring workflow on systems equipped with AMD Pensando ionic NICs.
## Technical Details
**NIC type auto-detection** - `NetCounterDetectNicType()` reads the kernel driver symlink at `/sys/class/infiniband/<dev>/device/driver` and returns `NIC_BNXT_RE` or `NIC_IONIC`. The detected type is stored in each `NetworkCounterSnapshot` and used to select the correct counter table. Mixed NIC types on the same node are detected and reported as `nic_type=MIXED`.
**Separate per-NIC-type counter tables** - Instead of a shared registry with NIC-specific key mappings, each NIC type has its own static table (`ionic_table[]`, `bnxt_re_table[]`) containing actual hardware counter names. This keeps the collection code simple and NIC-agnostic. `CounterDescriptor::fallback_name` provides an alternative sysfs key for Thor2 kernels that expose older counter names (e.g., `rp_cnp_handled` instead of `rx_cnp_pkts`).
Counter correspondence:
Function | BNXT_RE (Thor2) | IONIC (AINIC) |
---------|----------------|---------------|
PFC Rx frames | `rx_pfc_ena_frames_pri[0-7]` (ethtool) | `frames_rx_pripause[0-7]` (ethtool) |
PFC Tx frames | `tx_pfc_ena_frames_pri[0-7]` (ethtool) | `frames_tx_pripause[0-7]` (ethtool) |
PFC Rx transitions | `pfc_pri3_rx_transitions` (ethtool) | — (Thor2 only) |
PFC Tx transitions | `pfc_pri3_tx_transitions` (ethtool) | — (Thor2 only) |
CNP Rx | `rx_cnp_pkts` / `rp_cnp_handled` (hw_counters) | `rx_rdma_cnp_pkts` (hw_counters) |
CNP Tx | `tx_cnp_pkts` / `np_cnp_sent` (hw_counters) | `tx_rdma_cnp_pkts` (hw_counters) |
RoCE discards | `rx_roce_discards` (hw_counters) | `rx_rdma_mtu_discard_pkts` (hw_counters) |
Rx buffer overflow | `rx_stat_discards` (debugfs) | `resp_rx_outof_buf` (hw_counters) |
Retransmits | `to_retransmits` (debugfs) | `tx_rdma_ack_timeout` (hw_counters) |
Max retry exceeded | `max_retry_exceeded` (debugfs) | `req_tx_retry_excd_err` (hw_counters) |
Out-of-sequence | `oos_drop_count` (debugfs) | `resp_rx_outouf_seq` (hw_counters) |
Sequence errors | `seq_err_naks_rcvd` (debugfs) | `req_rx_pkt_seq_err` (hw_counters) |
RDMA Tx bytes | - (IONIC only) | `tx_rdma_ucast_bytes` (hw_counters) |
RDMA Rx bytes | - (IONIC only) | `rx_rdma_ucast_bytes` (hw_counters) |
RDMA Tx packets | - (IONIC only) | `tx_rdma_ucast_pkts` (hw_counters) |
RDMA Rx packets | - (IONIC only) | `rx_rdma_ucast_pkts` (hw_counters) |

**User-selectable counter subset** - `RCCL_TESTS_NIC_COUNTER_LIST=a,b,c` env var filters the NIC-specific table to a subset (matching by name or fallback_name). Default: all counters for the detected NIC.
**IB device port parsing** - `ParseIbDevice()` splits `rdma0:2` into base device + port, used in sysfs path construction (`/ports/<N>/hw_counters/`). Falls back to device-level hw_counters if port-level path doesn't exist.
**Microsecond timestamps** - `clock_gettime(CLOCK_MONOTONIC)` replaces `time(NULL)` for accurate rate computation on short-duration tests.
**Robustness improvements:**
- Fallback NIC discovery skips non-RDMA interfaces; disables collection (with warning) if no RDMA NICs found
- Mixed NIC type detection warns and reports `nic_type=MIXED` in output
- `NIC_UNKNOWN` falls back to bnxt_re counter set with a warning
**Files changed:**
- `collector.h` - `NicType` enum, `nic_type` + `timestamp_us` fields in `NetworkCounterSnapshot`, `fallback_name` in `CounterDescriptor`, updated API declarations
- `collector.cu` - Per-NIC counter tables, NIC detection, IB port parsing, counter filtering, collection, table printing
- `common.cu` - `DiscoverRdmaNics()`, `DetectNicTypeFromIbDevices()` helpers, startup logging
## JIRA ID
AICOMNET-162
## Test Plan
- [x] 2-node 16-GPU alltoall_perf with `RCCL_TESTS_NET_COUNTER_ENABLE=1` on AINIC (ionic) cluster — verify non-zero traffic and error counters, `nic_type=IONIC`, 14 columns displayed
- [x] Verify `NCCL_IB_HCA=rdma0,rdma2,rdma5` (explicit subset) — collector shows only 3 devices per node
- [x] Verify Thor2 (bnxt_re) counter table includes PFC transition counters and debugfs error counters
- [x] Verify CNP counter fallback (`rx_cnp_pkts` -> `rp_cnp_handled`) on Thor2
- [x] Run `analyze_counters.py` single-file and comparison reports — parser correctly handles IONIC output

## Test Result

2-node alltoall\_perf on Dell Thor2 cluster (MI300X, kernel 6.8, `rocep*` IB device naming):

```
NET_COUNTER_TABLE: node=dell300x-ccs-aus-k13-41  rank=0  duration_sec=1  nic_type=BNXT_RE
Device                     rx_pfc_ena_frames_pri  tx_pfc_ena_frames_pri  ...  rx_cnp_pkts     tx_cnp_pkts     ...
rocep28s0(enp28s0np0)          0            0.00      0            0.00  ...  371727    0.00  173221    0.00  ...
rocep62s0(enp62s0np0)          0            0.00      0            0.00  ...  369480    0.00  174699    0.00  ...
...
```
AINIC (ionic) - expected output on ionic-equipped systems (not yet tested on hardware):
```
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
Device            rx_pfc_ena_frames_pri  tx_pfc_ena_frames_pri  rx_cnp_pkts    tx_cnp_pkts    rx_roce_discards  rx_stat_discards  to_retransmits  max_retry_exceeded  oos_drop_count  seq_err_naks_rcvd  tx_rdma_ucast_bytes        rx_rdma_ucast_bytes        tx_rdma_ucast_pkts   rx_rdma_ucast_pkts 
                  count          rate/s  count          rate/s  count  rate/s  count  rate/s  count     rate/s  count     rate/s  count   rate/s  count       rate/s  count   rate/s  count      rate/s       count         rate/s       count         rate/s    count      rate/s    count      rate/s
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
rdma0(tw-eth0)        0            0.00      0            0.00      0    0.00      0    0.00      0       0.00      0       0.00     15    16.26      0         0.00     42    45.53    121      131.18  7165990672  7769106401.99  6980075520  7567543957.41  1829474  1983449.16  1783630  1933746.76
rdma1(tw-eth1)        0            0.00      0            0.00      0    0.00      0    0.00      0       0.00      0       0.00     16    17.33      0         0.00    130   140.77    121      131.02  7151516344  7743943510.44  6980915200  7559209873.76  1826141  1977417.38  1783937  1931717.23
rdma2(tw-eth2)        0            0.00      0            0.00      0    0.00      0    0.00      0       0.00      0       0.00     18    19.48      0         0.00     31    33.55    101      109.32  7140164264  7728111238.95  6980055040  7554818041.80  1823099  1973219.57  1783694  1930569.82
rdma3(tw-eth3)        0            0.00      0            0.00      0    0.00      0    0.00      0       0.00      0       0.00     15    16.23      0         0.00    153   165.57     93      100.64  7131303704  7717084431.98  6980468736  7553859553.10  1820975  1970553.83  1783801  1930326.28
....
```

## Tools

Here is analyzer tool: https://github.com/ROCm/hip-micro-benchmarks/tree/main/scripts/rccl-test-pfc

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.