### PR TITLE
FIx checks for help dispatch in rocprof-sys-sample

### DIFF
--- a/projects/rocprofiler-systems/source/bin/rocprof-sys-sample/rocprof-sys-sample.cpp
+++ b/projects/rocprofiler-systems/source/bin/rocprof-sys-sample/rocprof-sys-sample.cpp
@@ -37,9 +37,10 @@ main(int argc, char** argv)
     {
         auto _arg = std::string_view{ argv[i] };
         if(_arg == "--" || _arg == "-?" || _arg == "-h" || _arg == "--help" ||
-           _arg == "--version" || _arg == "--export-config" ||
-           _arg.find("--export-config=") == 0 || _arg == "--list-presets" ||
-           _arg == "--explain" || _arg.find("--explain=") == 0)
+           _arg.find("--help=") == 0 || _arg == "--version" ||
+           _arg == "--export-config" || _arg.find("--export-config=") == 0 ||
+           _arg == "--list-presets" || _arg == "--explain" ||
+           _arg.find("--explain=") == 0)
             _has_double_hyphen = true;
     }
 


### PR DESCRIPTION
## Motivation

With new added hierarchical help system, topic based search for help options didn't work for `rocprof-sys-sample` tool. The issue is that the app wasn't checking for added options for `--help` argument.

## Technical Details

Added check in main tool application for `--help=` which will trigger the corresponding dispatcher for selected help option.

## JIRA ID

AIPROFSYST-407
AIPROFSYST-408

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
