### PR TITLE
[rocprofiler-sdk] Fix hang in roctx pause/resume with counter collection

### DIFF
--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/counters/core.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/counters/core.cpp
@@ -215,7 +215,25 @@ stop_context(const context::context* ctx)
         enabled = false;
     });
 
-    if(controller) controller->disable_serialization();
+    if(controller)
+    {
+        // When roctxProfilerPause or context stop is called, there may be instrumented kernels
+        // still executing on the GPU. The profiler serializer maintains state (block_signal,
+        // ready_signal, _dispatch_queue) that tracks which queue is currently executing.
+        //
+        // Calling queue_controller_sync() first, we wait for all in-flight kernels to complete
+        // and their completion handlers to run. This ensures the serializer state is properly
+        // cleaned up before we disable serialization.
+        hsa::queue_controller_sync();
+        controller->disable_serialization();
+
+        for(auto& cb : ctx->dispatch_counter_collection->callbacks)
+        {
+            if(cb->queue_id == rocprofiler::hsa::ClientID{-1}) continue;
+            controller->remove_callback(cb->queue_id);
+            cb->queue_id = rocprofiler::hsa::ClientID{-1};
+        }
+    }
 }
 
 rocprofiler_status_t


### PR DESCRIPTION
## Motivation

- Fix intermittent failure of roctx-pause-resume test 
- https://github.com/ROCm/rocm-systems/actions/runs/24363190377/job/71148000721?pr=4933 

## Technical Details

Race condition between profiler pause and kernel completion:

- Counter collection uses serialization - Only one kernel executes at a time for accurate HW counter reads
- Serializer uses barrier signals - block_signal (value 1 = blocked, 0 = can execute) controls kernel execution order
- When pause is called during in-flight kernel:
  - stop_context() immediately sets _serializer_status = DISABLED
  - Kernel completes, AsyncSignalHandler runs
  - kernel_completion_signal() checks status, sees DISABLED, returns early
  - Critical: block_signal never reset to 0
  - HIP's barrier packet waits on block_signal forever → HANG
## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
