### PR TITLE
[rocprofiler-sdk] Increase timeout in rocprofiler-sdk-continuous_integration.yml

### DIFF
--- a/.github/workflows/rocprofiler-sdk-continuous_integration.yml
+++ b/.github/workflows/rocprofiler-sdk-continuous_integration.yml
@@ -331,7 +331,7 @@ jobs:
         run: echo 'ROCPROFILER_PC_SAMPLING_BETA_ENABLED=1' >> $GITHUB_ENV
 
       - name: Configure, Build, and Test
-        timeout-minutes: 30
+        timeout-minutes: 45
         shell: bash
         working-directory: projects/rocprofiler-sdk
         run: |
@@ -647,7 +647,7 @@ jobs:
           ls -la
 
       - name: Configure, Build, and Test
-        timeout-minutes: 30
+        timeout-minutes: 45
         shell: bash
         working-directory: projects/rocprofiler-sdk
         run: |


### PR DESCRIPTION
## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->
Increase timeout in `Configure, Build, and Test` step from 30 minutes to 45 minutes due to intermittent timeouts since we are adding more tests and approaching a 30-minute runtime more frequently.

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->
- Updated `.github/workflows/rocprofiler-sdk-continuous_integration.yml`
  - Changed `timeout-minutes` from `30` to `40` in the `Configure, Build, and Test` step

## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->
Ensure new timeout value is working, tests pass with no new regressions

## Test Result

<!-- Briefly summarize test outcomes. -->
TBA

## Submission Checklist

- [X] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
