### PR TITLE
fix(rocdecode): fix GetVideoFrame layer dispatch for 3-plane surfaces

### DIFF
--- a/projects/rocdecode/src/rocdecode/roc_decoder.cpp
+++ b/projects/rocdecode/src/rocdecode/roc_decoder.cpp
@@ -159,29 +159,23 @@ rocDecStatus RocDecoder::GetVideoFrame(int pic_idx, void *dev_mem_ptr[3], uint32
         hip_interop_[pic_idx].width = va_drm_prime_surface_desc.width;
         hip_interop_[pic_idx].height = va_drm_prime_surface_desc.height;
 
-        hip_interop_[pic_idx].offset[0] = va_drm_prime_surface_desc.layers[0].offset[0];
-        hip_interop_[pic_idx].offset[1] = va_drm_prime_surface_desc.layers[1].offset[0];
-        hip_interop_[pic_idx].offset[2] = va_drm_prime_surface_desc.layers[2].offset[0];
-
-        hip_interop_[pic_idx].pitch[0] = va_drm_prime_surface_desc.layers[0].pitch[0];
-        hip_interop_[pic_idx].pitch[1] = va_drm_prime_surface_desc.layers[1].pitch[0];
-        hip_interop_[pic_idx].pitch[2] = va_drm_prime_surface_desc.layers[2].pitch[0];
-
         hip_interop_[pic_idx].num_layers = va_drm_prime_surface_desc.num_layers;
+        for (uint32_t i = 0; i < va_drm_prime_surface_desc.num_layers && i < kMaxVideoLayers; i++) {
+            hip_interop_[pic_idx].offset[i] = va_drm_prime_surface_desc.layers[i].offset[0];
+            hip_interop_[pic_idx].pitch[i] = va_drm_prime_surface_desc.layers[i].pitch[0];
+        }
 
         for (auto i = 0; i < va_drm_prime_surface_desc.num_objects; ++i) {
             close(va_drm_prime_surface_desc.objects[i].fd);
         }
     }
 
-    *&dev_mem_ptr[0] = hip_interop_[pic_idx].hip_mapped_device_mem;
-    horizontal_pitch[0] = hip_interop_[pic_idx].pitch[0];
-    if (hip_interop_[pic_idx].num_layers == 2) {
-        *&dev_mem_ptr[1] = hip_interop_[pic_idx].hip_mapped_device_mem + hip_interop_[pic_idx].offset[1];
-        horizontal_pitch[1] = hip_interop_[pic_idx].pitch[1];
-    } else if (hip_interop_[pic_idx].num_layers == 3) {
-        *&dev_mem_ptr[2] = hip_interop_[pic_idx].hip_mapped_device_mem + hip_interop_[pic_idx].offset[2];
-        horizontal_pitch[2] = hip_interop_[pic_idx].pitch[2];
+    rocdec_status = static_cast<rocDecStatus>(
+        PopulateLayerPointers(hip_interop_[pic_idx].AsLayerInfo(), dev_mem_ptr, horizontal_pitch));
+    if (rocdec_status != ROCDEC_SUCCESS) {
+        ErrorLog(g_rocdec_logger, "Invalid num_layers=" + TOSTR(hip_interop_[pic_idx].num_layers) + " for picture idx=" + TOSTR(pic_idx));
+        FunctionExitLog(g_rocdec_logger);
+        return rocdec_status;
     }
     FunctionExitLog(g_rocdec_logger);
     return rocdec_status;

--- a/projects/rocdecode/src/rocdecode/roc_decoder.h
+++ b/projects/rocdecode/src/rocdecode/roc_decoder.h
@@ -33,15 +33,28 @@ THE SOFTWARE.
 #include "../api/rocdecode/rocdecode.h"
 #include <hip/hip_runtime.h>
 #include "vaapi/vaapi_videodecoder.h"
+#include "video_layer_utils.h"
 
 struct HipInteropDeviceMem {
     hipExternalMemory_t hip_ext_mem; // Interface to the vaapi-hip interop
     uint8_t* hip_mapped_device_mem; // Mapped device memory for the YUV plane
     uint32_t width; // Width of the surface in pixels.
     uint32_t height; // Height of the surface in pixels.
-    uint32_t offset[3]; // Offset of each plane
-    uint32_t pitch[3]; // Pitch of each plane
+    uint32_t offset[kMaxVideoLayers]; // Offset of each plane
+    uint32_t pitch[kMaxVideoLayers]; // Pitch of each plane
     uint32_t num_layers; // Number of layers making up the surface
+
+    // Build a VideoLayerInfo suitable for PopulateLayerPointers().
+    VideoLayerInfo AsLayerInfo() const {
+        VideoLayerInfo info{};
+        info.base_ptr = hip_mapped_device_mem;
+        info.num_layers = num_layers;
+        for (uint32_t i = 0; i < kMaxVideoLayers; i++) {
+            info.offset[i] = offset[i];
+            info.pitch[i] = pitch[i];
+        }
+        return info;
+    }
 };
 
 class RocDecoder {

--- a/projects/rocdecode/src/rocdecode/video_layer_utils.h
+++ b/projects/rocdecode/src/rocdecode/video_layer_utils.h
@@ -1,0 +1,101 @@
+/*
+Copyright (c) 2023 - 2026 Advanced Micro Devices, Inc. All rights reserved.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+
+#pragma once
+
+#include <stdint.h>
+
+// Maximum number of planes in a video surface (Y, U/UV, V).
+static constexpr uint32_t kMaxVideoLayers = 3;
+
+// Return codes — mirrors rocDecStatus values so this header is self-contained
+// (no dependency on HIP or the full rocdecode API header).
+static constexpr int kVideoLayerSuccess = 0;           // ROCDEC_SUCCESS
+static constexpr int kVideoLayerInvalidParam = -5;     // ROCDEC_INVALID_PARAMETER
+
+// Minimal surface description for layer pointer dispatch.
+struct VideoLayerInfo {
+    uint8_t* base_ptr;                   // Mapped device memory base pointer
+    uint32_t offset[kMaxVideoLayers];    // Offset of each plane from base_ptr
+    uint32_t pitch[kMaxVideoLayers];     // Pitch (row stride) of each plane
+    uint32_t num_layers;                 // Number of layers making up the surface
+};
+
+// Populate output device memory pointers and pitches from a VideoLayerInfo.
+// Returns kVideoLayerSuccess on success, kVideoLayerInvalidParam if num_layers
+// is 0 or exceeds kMaxVideoLayers.
+//
+// Extracted from RocDecoder::GetVideoFrame() for testability.
+inline int PopulateLayerPointers(const VideoLayerInfo &layer_info,
+                                 void *dev_mem_ptr[kMaxVideoLayers],
+                                 uint32_t horizontal_pitch[kMaxVideoLayers]) {
+    if (layer_info.num_layers == 0 || layer_info.num_layers > kMaxVideoLayers) {
+        return kVideoLayerInvalidParam;
+    }
+    // Layer 0 (Y plane) — always present
+    dev_mem_ptr[0] = layer_info.base_ptr;
+    horizontal_pitch[0] = layer_info.pitch[0];
+    // Remaining layers (U/UV, V) — set for each layer present
+    for (uint32_t i = 1; i < layer_info.num_layers; i++) {
+        dev_mem_ptr[i] = layer_info.base_ptr + layer_info.offset[i];
+        horizontal_pitch[i] = layer_info.pitch[i];
+    }
+    return kVideoLayerSuccess;
+}
+
+// -------------------------------------------------------------------------
+// ORIGINAL CODE — preserved for testing only.  Can be removed once the fix
+// is accepted and the regression tests are established.
+//
+// This is a verbatim copy of the layer dispatch logic from
+// RocDecoder::GetVideoFrame() (roc_decoder.cpp lines 177-185, commit
+// 18f165e424, 2024-02-05).  It has the following bugs:
+//
+//   1. num_layers==3: the else-if means layer 1 (U plane) is NEVER set.
+//      The caller receives an uninitialized pointer for the U plane.
+//
+//   2. num_layers==0 or >3: no error is returned.  Layer 0 is
+//      unconditionally written and remaining slots are left uninitialized.
+//
+// The unit tests run BOTH this function and PopulateLayerPointers() against
+// the same table-driven inputs, so the behavioral difference is immediately
+// visible in the test output.
+// -------------------------------------------------------------------------
+inline void OriginalPopulateLayerPointers(const VideoLayerInfo &layer_info,
+                                          void *dev_mem_ptr[kMaxVideoLayers],
+                                          uint32_t horizontal_pitch[kMaxVideoLayers]) {
+    // Line 177-178: always set layer 0
+    dev_mem_ptr[0] = layer_info.base_ptr;
+    horizontal_pitch[0] = layer_info.pitch[0];
+
+    // Line 179-185: the if/else-if chain
+    if (layer_info.num_layers == 2) {
+        dev_mem_ptr[1] = layer_info.base_ptr + layer_info.offset[1];
+        horizontal_pitch[1] = layer_info.pitch[1];
+    } else if (layer_info.num_layers == 3) {
+        // BUG: enters this branch instead of the num_layers==2 branch,
+        //      so layer 1 (U plane) is NEVER set.
+        dev_mem_ptr[2] = layer_info.base_ptr + layer_info.offset[2];
+        horizontal_pitch[2] = layer_info.pitch[2];
+    }
+    // BUG: num_layers==0 or >3 — no error, caller gets partial output.
+}

--- a/projects/rocdecode/test/unit/.gitignore
+++ b/projects/rocdecode/test/unit/.gitignore
@@ -1,0 +1,2 @@
+# Build artifacts — tests should be rebuilt locally
+build/

--- a/projects/rocdecode/test/unit/CMakeLists.txt
+++ b/projects/rocdecode/test/unit/CMakeLists.txt
@@ -1,0 +1,53 @@
+################################################################################
+# Copyright (c) 2023 - 2026 Advanced Micro Devices, Inc.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
+################################################################################
+
+# Unit tests for rocdecode — pure logic tests that do NOT require GPU hardware.
+# These test extracted helper functions (e.g. PopulateLayerPointers) that were
+# previously embedded in hardware-dependent code paths.
+
+cmake_minimum_required(VERSION 3.10)
+project(rocdecode_unit_tests)
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+find_package(GTest REQUIRED)
+
+# video_layer_utils.h only needs the rocdecode public API header (for rocDecStatus).
+# No HIP, VA-API, or GPU hardware required.
+include_directories(
+    ${PROJECT_SOURCE_DIR}/../../src/rocdecode
+    ${PROJECT_SOURCE_DIR}/../../api
+)
+
+add_executable(rocdecode_unit_tests
+    populate_layer_pointers_test.cpp
+)
+
+target_link_libraries(rocdecode_unit_tests
+    GTest::gtest
+    GTest::gtest_main
+)
+
+include(GoogleTest)
+gtest_discover_tests(rocdecode_unit_tests)

--- a/projects/rocdecode/test/unit/populate_layer_pointers_test.cpp
+++ b/projects/rocdecode/test/unit/populate_layer_pointers_test.cpp
@@ -1,0 +1,289 @@
+/*
+Copyright (c) 2023 - 2026 Advanced Micro Devices, Inc. All rights reserved.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+
+// ==========================================================================
+// Unit tests for the video layer pointer dispatch logic in GetVideoFrame().
+//
+// These tests demonstrate bugs in the ORIGINAL code (roc_decoder.cpp lines
+// 177-185 as of commit 18f165e424) and verify the FIXED replacement.  Both
+// implementations are tested with the same table-driven inputs so the
+// behavioral difference is immediately visible in the test output.
+//
+// No GPU hardware is required — these test pure pointer arithmetic.
+//
+// To build and run:
+//
+//   cd projects/rocdecode/test/unit
+//   mkdir -p build && cd build
+//   cmake .. -DCMAKE_BUILD_TYPE=Debug
+//   make -j$(nproc)
+//   ./rocdecode_unit_tests
+//
+// Requires only cmake, a C++17 compiler, and googletest.
+// ==========================================================================
+
+#include <gtest/gtest.h>
+#include <cstdint>
+#include "../../src/rocdecode/video_layer_utils.h"
+
+// -------------------------------------------------------------------------
+// Sentinel values to detect untouched output slots
+// -------------------------------------------------------------------------
+static constexpr uintptr_t kSentinelPtr   = 0xDEADBEEFDEADBEEF;
+static constexpr uint32_t  kSentinelPitch = 0xCAFECAFE;
+
+// Both PopulateLayerPointers (fixed) and OriginalPopulateLayerPointers
+// (buggy, preserved for comparison) come from video_layer_utils.h.
+
+// -------------------------------------------------------------------------
+// Test helpers
+// -------------------------------------------------------------------------
+
+// Build a VideoLayerInfo with deterministic, non-zero test values.
+// Each layer gets offset = (layer+1)*0x1000, pitch = (layer+1)*256.
+static VideoLayerInfo makeTestLayerInfo(
+        uint32_t num_layers,
+        uint8_t *base_addr = reinterpret_cast<uint8_t*>(0x100000)) {
+    VideoLayerInfo info{};
+    info.base_ptr = base_addr;
+    info.num_layers = num_layers;
+    for (uint32_t i = 0; i < kMaxVideoLayers; i++) {
+        info.offset[i] = (i + 1) * 0x1000;
+        info.pitch[i]  = (i + 1) * 256;
+    }
+    return info;
+}
+
+// Fill output arrays with sentinel values so untouched slots are detectable.
+static void initOutputs(void *dev_mem_ptr[kMaxVideoLayers],
+                        uint32_t horizontal_pitch[kMaxVideoLayers]) {
+    for (uint32_t i = 0; i < kMaxVideoLayers; i++) {
+        dev_mem_ptr[i]      = reinterpret_cast<void*>(kSentinelPtr);
+        horizontal_pitch[i] = kSentinelPitch;
+    }
+}
+
+// =========================================================================
+// Unified test table
+//
+// Every test scenario is in ONE table.  To add a new layer count (e.g. when
+// hardware adds 4-plane support), add a row here — the test body handles
+// both valid and invalid cases automatically.
+//
+//   expect_success:
+//     true  = PopulateLayerPointers should return kVideoLayerSuccess and
+//             set exactly num_layers output slots.
+//     false = PopulateLayerPointers should return kVideoLayerInvalidParam
+//             and leave all output slots untouched.
+//
+//   original_bug:
+//     Brief description of what the original code does wrong for this case,
+//     or "" if the original code handles it correctly.  This field exists
+//     so a reviewer can see the before/after at a glance.
+// =========================================================================
+
+struct LayerTestCase {
+    const char *name;
+    uint32_t    num_layers;
+    bool        expect_success;
+    const char *description;
+    const char *original_bug;
+};
+
+// clang-format off
+static const LayerTestCase kAllTestCases[] = {
+    //  name                 layers  ok?    description                              original code behavior
+    // ----------------------------------------------------------------------------------------------------------------------------------------------------------
+    // Valid surface types — these are the real VA-API layer counts
+    {"monochrome_Y800",          1, true,  "Y plane only (grayscale)",              ""},
+    {"semi_planar_NV12",         2, true,  "Y + interleaved UV (most common: NV12, P010, P012)", ""},
+    {"planar_YUV444",            3, true,  "Y + U + V separate planes",             "layer 1 (U) never set — else-if skips it"},
+
+    // Invalid: below minimum
+    {"zero_layers",              0, false, "no layers — should never happen",       "silently writes layer 0 anyway, no error returned"},
+
+    // Invalid: above kMaxVideoLayers (currently 3)
+    // These ensure future layer counts are explicitly rejected until
+    // PopulateLayerPointers is updated to handle them.  Test failures here
+    // are a signal that the function AND these tests need updating.
+    {"four",                     4, false, "just above current max",                "silently ignored, no error returned"},
+    {"eight",                    8, false, "hypothetical multi-view",               "silently ignored, no error returned"},
+    {"sixteen",                 16, false, "generous headroom",                     "silently ignored, no error returned"},
+    {"max_uint8",              255, false, "uint8 boundary",                        "silently ignored, no error returned"},
+    {"max_uint32",      UINT32_MAX, false, "overflow guard",                        "silently ignored, no error returned"},
+};
+// clang-format on
+
+// =========================================================================
+// PART 1: Test PopulateLayerPointers() — bounded loop with validation
+// =========================================================================
+
+class BoundedLoopDispatchTest : public ::testing::TestWithParam<LayerTestCase> {};
+
+TEST_P(BoundedLoopDispatchTest, AllScenarios) {
+    const auto &tc = GetParam();
+    auto info = makeTestLayerInfo(tc.num_layers);
+
+    void *dev_mem_ptr[kMaxVideoLayers];
+    uint32_t horizontal_pitch[kMaxVideoLayers];
+    initOutputs(dev_mem_ptr, horizontal_pitch);
+
+    int status = PopulateLayerPointers(info, dev_mem_ptr, horizontal_pitch);
+
+    if (tc.expect_success) {
+        // --- Valid case: all num_layers slots must be correctly set ---
+        ASSERT_EQ(status, kVideoLayerSuccess)
+            << "num_layers=" << tc.num_layers << " (" << tc.description << ")";
+
+        // Layer 0 — always base address
+        EXPECT_EQ(dev_mem_ptr[0], info.base_ptr);
+        EXPECT_EQ(horizontal_pitch[0], info.pitch[0]);
+
+        // Layers 1..num_layers-1 — base + offset[i]
+        for (uint32_t i = 1; i < tc.num_layers; i++) {
+            EXPECT_EQ(dev_mem_ptr[i], info.base_ptr + info.offset[i])
+                << "Layer " << i << " pointer";
+            EXPECT_EQ(horizontal_pitch[i], info.pitch[i])
+                << "Layer " << i << " pitch";
+        }
+
+        // Slots beyond num_layers — untouched at sentinel
+        for (uint32_t i = tc.num_layers; i < kMaxVideoLayers; i++) {
+            EXPECT_EQ(dev_mem_ptr[i], reinterpret_cast<void*>(kSentinelPtr))
+                << "Layer " << i << " should be untouched";
+            EXPECT_EQ(horizontal_pitch[i], kSentinelPitch)
+                << "Pitch " << i << " should be untouched";
+        }
+    } else {
+        // --- Invalid case: must return error, all outputs untouched ---
+        EXPECT_EQ(status, kVideoLayerInvalidParam)
+            << "num_layers=" << tc.num_layers << " (" << tc.description
+            << ") must be rejected";
+
+        for (uint32_t i = 0; i < kMaxVideoLayers; i++) {
+            EXPECT_EQ(dev_mem_ptr[i], reinterpret_cast<void*>(kSentinelPtr))
+                << "Layer " << i << " pointer modified on error path";
+            EXPECT_EQ(horizontal_pitch[i], kSentinelPitch)
+                << "Pitch " << i << " modified on error path";
+        }
+    }
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    LayerDispatch,
+    BoundedLoopDispatchTest,
+    ::testing::ValuesIn(kAllTestCases),
+    [](const ::testing::TestParamInfo<LayerTestCase> &info) {
+        return info.param.name;
+    }
+);
+
+// =========================================================================
+// PART 2: Test OriginalPopulateLayerPointers() — if/else-if chain
+//         (original code from commit 18f165e424, preserved for comparison)
+//
+// These tests DEMONSTRATE the bugs.  They use EXPECT (not ASSERT) so all
+// failures are reported in a single run.  The original code has no return
+// value, so we can only check output state.
+// =========================================================================
+
+class IfElseChainDispatchTest : public ::testing::TestWithParam<LayerTestCase> {};
+
+TEST_P(IfElseChainDispatchTest, AllScenarios) {
+    const auto &tc = GetParam();
+    auto info = makeTestLayerInfo(tc.num_layers);
+
+    void *dev_mem_ptr[kMaxVideoLayers];
+    uint32_t horizontal_pitch[kMaxVideoLayers];
+    initOutputs(dev_mem_ptr, horizontal_pitch);
+
+    OriginalPopulateLayerPointers(info, dev_mem_ptr, horizontal_pitch);
+
+    if (tc.expect_success) {
+        // --- Valid case: check what the original code actually does ---
+
+        // Layer 0 — original code always sets this (correct)
+        EXPECT_EQ(dev_mem_ptr[0], info.base_ptr)
+            << "Layer 0 should be set for num_layers=" << tc.num_layers;
+
+        // Layers 1..num_layers-1
+        for (uint32_t i = 1; i < tc.num_layers; i++) {
+            if (tc.original_bug[0] != '\0') {
+                // This case has a known bug in the original code.
+                // We assert the bug EXISTS (sentinel = never written) so this
+                // test will FAIL if someone fixes the original code without
+                // updating this test — keeping the bug documentation honest.
+                //
+                // For num_layers==3: layer 1 is the missing one.
+                if (tc.num_layers == 3 && i == 1) {
+                    EXPECT_EQ(dev_mem_ptr[i], reinterpret_cast<void*>(kSentinelPtr))
+                        << "BUG CONFIRMED (original code): layer " << i
+                        << " never set for " << tc.name
+                        << ". " << tc.original_bug;
+                }
+            } else {
+                // No known bug — original code should handle this correctly
+                EXPECT_EQ(dev_mem_ptr[i], info.base_ptr + info.offset[i])
+                    << "Layer " << i << " pointer for " << tc.name;
+                EXPECT_EQ(horizontal_pitch[i], info.pitch[i])
+                    << "Layer " << i << " pitch for " << tc.name;
+            }
+        }
+    } else {
+        // --- Invalid case: original code has no error return ---
+        // It silently writes layer 0 regardless.  We confirm this behavior
+        // to document it, not to endorse it.
+        if (tc.num_layers != UINT32_MAX) {
+            // (skip UINT32_MAX — original code still writes layer 0)
+            EXPECT_NE(dev_mem_ptr[0], reinterpret_cast<void*>(kSentinelPtr))
+                << "BUG CONFIRMED (original code): layer 0 written even for "
+                << "invalid num_layers=" << tc.num_layers
+                << ", no error returned. " << tc.original_bug;
+        }
+    }
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    LayerDispatch,
+    IfElseChainDispatchTest,
+    ::testing::ValuesIn(kAllTestCases),
+    [](const ::testing::TestParamInfo<LayerTestCase> &info) {
+        return info.param.name;
+    }
+);
+
+// =========================================================================
+// Edge cases (not part of the main table)
+// =========================================================================
+
+TEST(BoundedLoopDispatch_Edge, NullBasePointerArithmeticIsCorrect) {
+    auto info = makeTestLayerInfo(2, nullptr);
+    void *dev_mem_ptr[kMaxVideoLayers] = {};
+    uint32_t horizontal_pitch[kMaxVideoLayers] = {};
+
+    int status = PopulateLayerPointers(info, dev_mem_ptr, horizontal_pitch);
+    ASSERT_EQ(status, kVideoLayerSuccess);
+
+    EXPECT_EQ(dev_mem_ptr[0], nullptr);
+    EXPECT_EQ(dev_mem_ptr[1],
+              reinterpret_cast<void*>(static_cast<uintptr_t>(info.offset[1])));
+}


### PR DESCRIPTION
## Summary

- Fix bug in `GetVideoFrame()` where 3-plane (YUV 4:4:4) surfaces get an uninitialized U plane pointer due to mutually exclusive `if/else-if`
- Fix secondary OOB read of `va_drm_prime_surface_desc.layers[2]` for 2-layer surfaces
- Extract layer dispatch into `video_layer_utils.h` for GPU-free testing
- Add 19 table-driven unit tests (no HIP/VA-API/GPU required)

## The Bug

The layer pointer dispatch (roc_decoder.cpp:177-185, commit 18f165e424) uses `if (num_layers == 2) ... else if (num_layers == 3)`. When `num_layers == 3`, the code enters the second branch and sets layer 2 but **never enters the first branch** to set layer 1 (U plane). The caller gets an uninitialized pointer that causes silent corruption or segfault.

| Layer | num_layers=1 | num_layers=2 | num_layers=3 |
|-------|:---:|:---:|:---:|
| 0 (Y)  | set | set | set |
| 1 (U)  | -   | set | **UNINITIALIZED** |
| 2 (V)  | -   | -   | set |

## Origin

This bug was introduced in commit `18f165e424` (2024-02-05, "Fix the performance issue introduced after PR#192 (#220)"). The `if/else-if` chain replaced what was likely a sequential assignment, creating the mutual exclusion between the 2-layer and 3-layer branches.

## Why this wasn't caught

YUV 4:4:4 planar decode (the only format that triggers num_layers==3) is extremely rare in practice. The vast majority of video content (H.264, H.265, VP9, AV1) uses 4:2:0 or 4:2:2 chroma subsampling, which maps to NV12/P010 — 2 layers. Fully planar 4:4:4 (where U and V are separate planes) is mainly used in professional lossless workflows and screen content coding, so it's likely that no rocdecode user has hit `num_layers==3` through this code path yet. The existing tests (`rocDecodeNegativeApiTests`) only test null parameters and invalid indices — they never exercise the layer dispatch logic.

## Preserving the original code for test comparison

`video_layer_utils.h` contains both the fixed `PopulateLayerPointers()` and the original `OriginalPopulateLayerPointers()` — a verbatim copy of the buggy if/else-if logic. Both functions are tested against the same table-driven inputs so the behavioral difference is immediately visible in the test output. `OriginalPopulateLayerPointers()` is marked as test-only and can be removed once the fix is accepted and the regression tests are established.

## Test output

```
Running main() from /build/source/googletest/src/gtest_main.cc
[==========] Running 19 tests from 3 test suites.
[----------] 1 test from BoundedLoopDispatch_Edge
[ RUN      ] BoundedLoopDispatch_Edge.NullBasePointerArithmeticIsCorrect
[       OK ] BoundedLoopDispatch_Edge.NullBasePointerArithmeticIsCorrect (0 ms)
[----------] 9 tests from LayerDispatch/BoundedLoopDispatchTest
[ RUN      ] LayerDispatch/BoundedLoopDispatchTest.AllScenarios/monochrome_Y800
[       OK ] LayerDispatch/BoundedLoopDispatchTest.AllScenarios/monochrome_Y800 (0 ms)
[ RUN      ] LayerDispatch/BoundedLoopDispatchTest.AllScenarios/semi_planar_NV12
[       OK ] LayerDispatch/BoundedLoopDispatchTest.AllScenarios/semi_planar_NV12 (0 ms)
[ RUN      ] LayerDispatch/BoundedLoopDispatchTest.AllScenarios/planar_YUV444
[       OK ] LayerDispatch/BoundedLoopDispatchTest.AllScenarios/planar_YUV444 (0 ms)
[ RUN      ] LayerDispatch/BoundedLoopDispatchTest.AllScenarios/zero_layers
[       OK ] LayerDispatch/BoundedLoopDispatchTest.AllScenarios/zero_layers (0 ms)
[ RUN      ] LayerDispatch/BoundedLoopDispatchTest.AllScenarios/four
[       OK ] LayerDispatch/BoundedLoopDispatchTest.AllScenarios/four (0 ms)
[ RUN      ] LayerDispatch/BoundedLoopDispatchTest.AllScenarios/eight
[       OK ] LayerDispatch/BoundedLoopDispatchTest.AllScenarios/eight (0 ms)
[ RUN      ] LayerDispatch/BoundedLoopDispatchTest.AllScenarios/sixteen
[       OK ] LayerDispatch/BoundedLoopDispatchTest.AllScenarios/sixteen (0 ms)
[ RUN      ] LayerDispatch/BoundedLoopDispatchTest.AllScenarios/max_uint8
[       OK ] LayerDispatch/BoundedLoopDispatchTest.AllScenarios/max_uint8 (0 ms)
[ RUN      ] LayerDispatch/BoundedLoopDispatchTest.AllScenarios/max_uint32
[       OK ] LayerDispatch/BoundedLoopDispatchTest.AllScenarios/max_uint32 (0 ms)
[----------] 9 tests from LayerDispatch/IfElseChainDispatchTest
[ RUN      ] LayerDispatch/IfElseChainDispatchTest.AllScenarios/monochrome_Y800
[       OK ] LayerDispatch/IfElseChainDispatchTest.AllScenarios/monochrome_Y800 (0 ms)
[ RUN      ] LayerDispatch/IfElseChainDispatchTest.AllScenarios/semi_planar_NV12
[       OK ] LayerDispatch/IfElseChainDispatchTest.AllScenarios/semi_planar_NV12 (0 ms)
[ RUN      ] LayerDispatch/IfElseChainDispatchTest.AllScenarios/planar_YUV444
[       OK ] LayerDispatch/IfElseChainDispatchTest.AllScenarios/planar_YUV444 (0 ms)
[ RUN      ] LayerDispatch/IfElseChainDispatchTest.AllScenarios/zero_layers
[       OK ] LayerDispatch/IfElseChainDispatchTest.AllScenarios/zero_layers (0 ms)
[ RUN      ] LayerDispatch/IfElseChainDispatchTest.AllScenarios/four
[       OK ] LayerDispatch/IfElseChainDispatchTest.AllScenarios/four (0 ms)
[ RUN      ] LayerDispatch/IfElseChainDispatchTest.AllScenarios/eight
[       OK ] LayerDispatch/IfElseChainDispatchTest.AllScenarios/eight (0 ms)
[ RUN      ] LayerDispatch/IfElseChainDispatchTest.AllScenarios/sixteen
[       OK ] LayerDispatch/IfElseChainDispatchTest.AllScenarios/sixteen (0 ms)
[ RUN      ] LayerDispatch/IfElseChainDispatchTest.AllScenarios/max_uint8
[       OK ] LayerDispatch/IfElseChainDispatchTest.AllScenarios/max_uint8 (0 ms)
[ RUN      ] LayerDispatch/IfElseChainDispatchTest.AllScenarios/max_uint32
[       OK ] LayerDispatch/IfElseChainDispatchTest.AllScenarios/max_uint32 (0 ms)
[==========] 19 tests from 3 test suites ran. (0 ms total)
[  PASSED  ] 19 tests.
```

## Test plan

- [x] 19 table-driven unit tests pass (no GPU required)
- [ ] Build rocdecode library with fix applied
- [ ] Run existing `rocDecodeNegativeApiTests` on GPU system

🤖 Generated with [Claude Code](https://claude.com/claude-code)