### PR TITLE
rocrtst: Apply ROCRTST_LIMIT_POOL_SIZE to MaxSingleAllocationTest

### DIFF
--- a/projects/rocr-runtime/rocrtst/common/common.cc
+++ b/projects/rocr-runtime/rocrtst/common/common.cc
@@ -431,6 +431,11 @@ hsa_status_t AcquirePoolInfo(hsa_amd_memory_pool_t pool,
     pool_i->size = std::min(pool_i->size, max_pool_size);
   }
 
+  // ROCRTST_LIMIT_POOL_SIZE: Optional environment variable to speed up memory tests.
+  // When set (ROCRTST_LIMIT_POOL_SIZE=4294967296 for 4GB), it:
+  //   1. Overrides pool_i->size (typically to reduce it; value is applied directly)
+  //   2. Triggers relaxed OOM safety margin (90% vs 70%) for system RAM tests
+  // This significantly reduces test time on large-VRAM GPUs.
   pool_size_limit = 0;
   char *pool_size_limit_str = getenv("ROCRTST_LIMIT_POOL_SIZE");
   if (pool_size_limit_str) {

--- a/projects/rocr-runtime/rocrtst/suites/functional/memory_basic.cc
+++ b/projects/rocr-runtime/rocrtst/suites/functional/memory_basic.cc
@@ -239,11 +239,24 @@ void MemoryTest::MaxSingleAllocationTest(hsa_agent_t ag,
 
   // AIE agent's dev heap is advertised as HSA_HEAPTYPE_DEVICE_SVM, but
   // is limited to the actual pool size.
-  if (ag_type == HSA_DEVICE_TYPE_AIE && pool_i.alloc_rec_granule == 0) {
+  // Also use pool size when ROCRTST_LIMIT_POOL_SIZE is set to cap the search range.
+  if ((ag_type == HSA_DEVICE_TYPE_AIE && pool_i.alloc_rec_granule == 0) ||
+      rocrtst::pool_size_limit) {
     pool_sz = pool_i.size / gran_sz;
   }
 
+  // Skip if ROCRTST_LIMIT_POOL_SIZE is set below one allocation granule.
+  if (rocrtst::pool_size_limit && pool_sz == 0) {
+    if (verbosity() > 0) {
+      std::cout << "  Skipping: ROCRTST_LIMIT_POOL_SIZE < allocation granule" << std::endl;
+      std::cout << kSubTestSeparator << std::endl;
+    }
+    return;
+  }
+
   // Neg. test: Try to allocate more than the pool size
+  // Skip when ROCRTST_LIMIT_POOL_SIZE is set, since the artificial limit only affects
+  // the test's view of the pool, not the runtime's actual pool size.
 #ifdef ROCRTST_ASAN
   // Under ASAN, hsa_amd_memory_pool_allocate is intercepted by the ASAN runtime.
   // Requesting (max_size + granule) from ASANs heap allocator triggers
@@ -252,8 +265,14 @@ void MemoryTest::MaxSingleAllocationTest(hsa_agent_t ag,
     std::cout << "  Skipping over-max negative alloc under ASAN (abort risk)" << std::endl;
   }
 #else
-  err = TestAllocate(pool, pool_sz*gran_sz + gran_sz);
-  EXPECT_EQ(HSA_STATUS_ERROR_INVALID_ALLOCATION, err);
+  if (rocrtst::pool_size_limit) {
+    if (verbosity() > 0) {
+      std::cout << "  Skipping over-max negative alloc under pool size limit (false positive)" << std::endl;
+    }
+  } else {
+    err = TestAllocate(pool, pool_sz*gran_sz + gran_sz);
+    EXPECT_EQ(HSA_STATUS_ERROR_INVALID_ALLOCATION, err);
+  }
 #endif
 
   const bool is_system_ram = (ag_type == HSA_DEVICE_TYPE_CPU) || (ag_type == HSA_DEVICE_TYPE_AIE);


### PR DESCRIPTION
Use pool_i.size instead of aggregate_alloc_max when ROCRTST_LIMIT_POOL_SIZE
is set. Skip the over-max negative alloc test since the artificial limit
doesn't reflect the runtime's actual pool size.


## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
