### PR TITLE
[AMD-SMI] Update CPU APIs to use consistent types

### DIFF
--- a/projects/amdsmi/CHANGELOG.md
+++ b/projects/amdsmi/CHANGELOG.md
@@ -60,6 +60,17 @@ Full documentation for amd_smi_lib is available at [https://rocm.docs.amd.com/pr
 - **Fixed `cu_occupancy` displaying `0%` instead of `N/A` when file is unavailable**.  
   - Process `cu_occupancy` is now initialized to `INVALID` instead of zero, so `amd-smi process` displays `N/A` rather than a misleading `0%` when the sysfs file is not accessible.
 
+- **Fixed power APIs to have consistent inputs**.  
+  - Modified 6 cpu power API's to have consistent power type input values. All set and get API's have uint32_t input values.
+    - amdsmi_get_cpu_socket_power(amdsmi_processor_handle processor_handle, uint32_t* ppower);
+    - amdsmi_get_cpu_socket_power_cap(amdsmi_processor_handle processor_handle, uint32_t* pcap);
+    - amdsmi_get_cpu_socket_power_cap_max(amdsmi_processor_handle processor_handle, uint32_t* pmax);
+    - amdsmi_get_cpu_pwr_efficiency_mode(amdsmi_processor_handle processor_handle,
+                                         uint32_t* power_efficiency_mode,
+                                         uint32_t* utilization, uint32_t* ppt_limit);
+    - amdsmi_get_cpu_core_ccd_power(amdsmi_processor_handle processor_handle, uint32_t* power);
+    - amdsmi_get_cpu_sdps_limit(amdsmi_processor_handle processor_handle, uint32_t* sdps_limit);
+
 ### Changed
 
 - **Removed references to deprecated `amd-smi reset -r`**.  

--- a/projects/amdsmi/CHANGELOG.md
+++ b/projects/amdsmi/CHANGELOG.md
@@ -60,8 +60,15 @@ Full documentation for amd_smi_lib is available at [https://rocm.docs.amd.com/pr
 - **Fixed `cu_occupancy` displaying `0%` instead of `N/A` when file is unavailable**.  
   - Process `cu_occupancy` is now initialized to `INVALID` instead of zero, so `amd-smi process` displays `N/A` rather than a misleading `0%` when the sysfs file is not accessible.
 
-- **Fixed power APIs to have consistent inputs**.  
-  - Modified 6 cpu power API's to have consistent power type input values. All set and get API's have uint32_t input values.
+### Changed
+
+- **Removed references to deprecated `amd-smi reset -r`**.  
+  - CLI help text and memory partition change warnings no longer reference `amd-smi reset -r` for driver reloading.
+  - Users are now directed to use `sudo modprobe -r amdgpu && sudo modprobe amdgpu` to reload the driver after partition changes.
+
+- **Changed power APIs to have consistent output parameter types**.  
+  - Modified 6 cpu power API's to have consistent output power types. All set and get API's have uint32_t output values.
+  - Modified get and set API's that had double output types to have uint32_t output types.
     - amdsmi_get_cpu_socket_power(amdsmi_processor_handle processor_handle, uint32_t* ppower);
     - amdsmi_get_cpu_socket_power_cap(amdsmi_processor_handle processor_handle, uint32_t* pcap);
     - amdsmi_get_cpu_socket_power_cap_max(amdsmi_processor_handle processor_handle, uint32_t* pmax);
@@ -70,12 +77,6 @@ Full documentation for amd_smi_lib is available at [https://rocm.docs.amd.com/pr
                                          uint32_t* utilization, uint32_t* ppt_limit);
     - amdsmi_get_cpu_core_ccd_power(amdsmi_processor_handle processor_handle, uint32_t* power);
     - amdsmi_get_cpu_sdps_limit(amdsmi_processor_handle processor_handle, uint32_t* sdps_limit);
-
-### Changed
-
-- **Removed references to deprecated `amd-smi reset -r`**.  
-  - CLI help text and memory partition change warnings no longer reference `amd-smi reset -r` for driver reloading.
-  - Users are now directed to use `sudo modprobe -r amdgpu && sudo modprobe amdgpu` to reload the driver after partition changes.
 
 ## amd_smi_lib for ROCm 7.12.0
 

--- a/projects/amdsmi/amdsmi_cli/amdsmi_commands.py
+++ b/projects/amdsmi/amdsmi_cli/amdsmi_commands.py
@@ -4661,7 +4661,7 @@ class AMDSMICommands:
                 # Only show util and ppt_limit for modes 4 and 5
                 if mode in [4, 5]:
                     static_dict["pwr_eff_mode"]["util"] = f"{util}%"
-                    static_dict["pwr_eff_mode"]["ppt_limit"] = f"{ppt_limit:.3f} Watts"
+                    static_dict["pwr_eff_mode"]["ppt_limit"] = f"{ppt_limit} Watts"
                 else:
                     # For modes 0-3, util and ppt_limit are not displayed
                     pass
@@ -5078,7 +5078,7 @@ class AMDSMICommands:
             static_dict["ccd_power"] = {}
             try:
                 power = amdsmi_interface.amdsmi_get_cpu_core_ccd_power(args.core)
-                static_dict["ccd_power"]["value"] = f"{power:.3f} Watts"
+                static_dict["ccd_power"]["value"] = f"{power} Watts"
             except amdsmi_exception.AmdSmiLibraryException as e:
                 static_dict["ccd_power"]["value"] = "N/A"
                 logging.debug(
@@ -7851,7 +7851,7 @@ class AMDSMICommands:
                 if mode in [4, 5]:
                     ppt_limit_watts = updated_ppt_limit / 1000.0  # Convert milliwatts to watts
                     static_dict["pwr_eff_mode"]["util"] = f"{updated_util}%"
-                    static_dict["pwr_eff_mode"]["ppt_limit"] = f"{ppt_limit_watts:.3f} Watts"
+                    static_dict["pwr_eff_mode"]["ppt_limit"] = f"{ppt_limit_watts} Watts"
                 else:
                     # For modes 0-3, util and ppt_limit are not displayed
                     pass
@@ -9939,10 +9939,7 @@ class AMDSMICommands:
                 self.logger.clear_multiple_devices_output()
                 return
             if args.power_cap:
-                final_output = {
-                    "ppt0": "N/A",
-                    "ppt1": "N/A",
-                }
+                final_output = {"ppt0": "N/A", "ppt1": "N/A"}
                 power_limit_types = {}
                 for power_type in amdsmi_interface.AmdSmiPowerCapType:
                     # Strip 'AMDSMI_POWER_CAP_TYPE_' prefix and convert to lowercase

--- a/projects/amdsmi/docs/reference/amdsmi-py-api.md
+++ b/projects/amdsmi/docs/reference/amdsmi-py-api.md
@@ -4255,7 +4255,7 @@ Example:
 
 ```python
 try:
-    status_str = amdsmi_status_code_to_string(ctypes.c_uint32(0))
+    status_str = amdsmi_status_code_to_string(int(0))
     print(status_str)
 except AmdSmiException as e:
     print(e)
@@ -6126,7 +6126,7 @@ Input parameters:
 Output: Dictionary containing the power efficiency mode information:
 - `power_efficiency_mode` (int): Mode value
 - `utilization` (int): Utilization point for balanced core modes (0-100)(%), if applicable
-- `ppt_limit` (float): PPT Limit value in Watts if applicable
+- `ppt_limit` (int): PPT Limit value in Watts if applicable
 
 Exceptions that can be thrown by `amdsmi_set_cpu_pwr_efficiency_mode` function:
 
@@ -8431,7 +8431,7 @@ Description: Get the SDPS limit for a CPU socket. This function retrieves the cu
 Input parameters:
 - `processor_handle` (amdsmi_processor_handle): CPU socket handle to query
 
-Output: uint32 representing the SDPS limit value in Watts
+Output: int representing the SDPS limit value in Watts
 
 Exceptions that can be thrown by `amdsmi_get_cpu_sdps_limit` function:
 

--- a/projects/amdsmi/docs/reference/amdsmi-py-api.md
+++ b/projects/amdsmi/docs/reference/amdsmi-py-api.md
@@ -6225,7 +6225,7 @@ try:
                 # Only show utilization and ppt_limit for modes 4 and 5
                 if power_efficiency_mode in [4, 5]:
                     print(f"    	UTIL: {utilization}%")
-                    print(f"    	PPT_LIMIT: {ppt_limit:.3f} Watts")
+                    print(f"    	PPT_LIMIT: {ppt_limit} Watts")
                     print()
                 else:
                     # For modes 0-3, utilization and ppt_limit are not displayed
@@ -7813,7 +7813,7 @@ try:
         power = amdsmi_get_cpu_core_ccd_power(core0)
         print("CPU: 0")
         print("    CCD_POWER:")
-        print(f"        VALUE: {power:.3f} Watts")
+        print(f"        VALUE: {power} Watts")
 except AmdSmiException as e:
     print(e)
 ```
@@ -8431,7 +8431,7 @@ Description: Get the SDPS limit for a CPU socket. This function retrieves the cu
 Input parameters:
 - `processor_handle` (amdsmi_processor_handle): CPU socket handle to query
 
-Output: Double representing the SDPS limit value in Watts
+Output: uint32 representing the SDPS limit value in Watts
 
 Exceptions that can be thrown by `amdsmi_get_cpu_sdps_limit` function:
 

--- a/projects/amdsmi/example/amdsmi_esmi_intg_example.cc
+++ b/projects/amdsmi/example/amdsmi_esmi_intg_example.cc
@@ -188,7 +188,7 @@ int main([[maybe_unused]] int argc, [[maybe_unused]] char** argv) {
              << endl;
 
       if (!ret) {
-        cout << fixed << setprecision(3) << static_cast<double>(socket_power) / 1000 << "\t|";
+        cout << fixed << setprecision(3) << static_cast<double>(socket_power) << "\t|";
       } else {
         err_bits |= 1 << ret;
         cout << " NA (Err:" << ret << "     |";
@@ -203,7 +203,7 @@ int main([[maybe_unused]] int argc, [[maybe_unused]] char** argv) {
              << endl;
 
       if (!ret) {
-        cout << fixed << setprecision(3) << static_cast<double>(power_limit) / 1000 << "\t|";
+        cout << fixed << setprecision(3) << static_cast<double>(power_limit) << "\t|";
       } else {
         err_bits |= 1 << ret;
         cout << " NA (Err:" << ret << "     |";
@@ -218,7 +218,7 @@ int main([[maybe_unused]] int argc, [[maybe_unused]] char** argv) {
              << "] " << endl;
 
       if (!ret) {
-        cout << fixed << setprecision(3) << static_cast<double>(power_max) / 1000 << "\t|";
+        cout << fixed << setprecision(3) << static_cast<double>(power_max) << "\t|";
       } else {
         err_bits |= 1 << ret;
         cout << " NA (Err:" << ret << "     |";
@@ -238,7 +238,7 @@ int main([[maybe_unused]] int argc, [[maybe_unused]] char** argv) {
       if ((ret == AMDSMI_STATUS_SUCCESS) && (input_power > power_max)) {
         cout << "Input power is more than max power limit,"
                 " limiting to "
-             << static_cast<double>(power_max) / 1000 << "Watts\n";
+             << static_cast<double>(power_max) << "Watts\n";
         input_power = power_max;
       }
 
@@ -249,7 +249,7 @@ int main([[maybe_unused]] int argc, [[maybe_unused]] char** argv) {
 
       if (!ret) {
         cout << "CPU [" << index << "] power_limit set to " << fixed << setprecision(3)
-             << static_cast<double>(input_power) / 1000 << " Watts successfully\n";
+             << static_cast<double>(input_power) << " Watts successfully\n";
       }
 
       power_limit = 0;
@@ -261,7 +261,7 @@ int main([[maybe_unused]] int argc, [[maybe_unused]] char** argv) {
              << endl;
 
       if (!ret) {
-        cout << fixed << setprecision(3) << static_cast<double>(power_limit) / 1000 << "\t|";
+        cout << fixed << setprecision(3) << static_cast<double>(power_limit) << "\t|";
       } else {
         err_bits |= 1 << ret;
         cout << " NA (Err:" << ret << "     |";

--- a/projects/amdsmi/goamdsmi_shim/smiwrapper/amdsmi_go_shim.c
+++ b/projects/amdsmi/goamdsmi_shim/smiwrapper/amdsmi_go_shim.c
@@ -472,7 +472,7 @@ uint32_t goamdsmi_cpu_socket_power_get(uint32_t socket_index) {
            socket_index, socket_power_watts);
   }
 
-  return readSuccess ? (uint32_t)(socket_power_watts * 1000) : GOAMDSMI_UINT32_MAX;
+  return readSuccess ? socket_power_watts * 1000 : GOAMDSMI_UINT32_MAX;
 }
 
 uint32_t goamdsmi_cpu_socket_power_cap_get(uint32_t socket_index) {
@@ -487,7 +487,7 @@ uint32_t goamdsmi_cpu_socket_power_cap_get(uint32_t socket_index) {
            readSuccess ? "Success" : "Failed", socket_index, socket_power_cap_watts);
   }
 
-  return readSuccess ? (uint32_t)(socket_power_cap_watts * 1000) : GOAMDSMI_UINT32_MAX;
+  return readSuccess ? socket_power_cap_watts * 1000 : GOAMDSMI_UINT32_MAX;
 }
 
 uint32_t goamdsmi_cpu_core_boostlimit_get(uint32_t thread_index) {

--- a/projects/amdsmi/goamdsmi_shim/smiwrapper/amdsmi_go_shim.c
+++ b/projects/amdsmi/goamdsmi_shim/smiwrapper/amdsmi_go_shim.c
@@ -462,7 +462,7 @@ uint32_t goamdsmi_cpu_prochot_status_get(uint32_t socket_index) {
 
 uint32_t goamdsmi_cpu_socket_power_get(uint32_t socket_index) {
   bool readSuccess = false;
-  double socket_power_watts = 0;
+  uint32_t socket_power_watts = 0;
   if ((AMDSMI_STATUS_SUCCESS ==
        amdsmi_get_cpu_socket_power(amdsmi_processor_handle_all_cpu_across_socket[socket_index],
                                    &socket_power_watts)))
@@ -477,7 +477,7 @@ uint32_t goamdsmi_cpu_socket_power_get(uint32_t socket_index) {
 
 uint32_t goamdsmi_cpu_socket_power_cap_get(uint32_t socket_index) {
   bool readSuccess = false;
-  double socket_power_cap_watts = 0;
+  uint32_t socket_power_cap_watts = 0;
   if ((AMDSMI_STATUS_SUCCESS ==
        amdsmi_get_cpu_socket_power_cap(amdsmi_processor_handle_all_cpu_across_socket[socket_index],
                                        &socket_power_cap_watts)))

--- a/projects/amdsmi/goamdsmi_shim/smiwrapper/amdsmi_go_shim.c
+++ b/projects/amdsmi/goamdsmi_shim/smiwrapper/amdsmi_go_shim.c
@@ -468,8 +468,8 @@ uint32_t goamdsmi_cpu_socket_power_get(uint32_t socket_index) {
                                    &socket_power_watts)))
     readSuccess = true;
   if (enable_debug_level(GOAMDSMI_DEBUG_LEVEL_1)) {
-    printf("AMDSMI, %s for Socket:%d, CpuSocketPowerWatt:%.3f\n",
-           readSuccess ? "Success" : "Failed", socket_index, socket_power_watts);
+    printf("AMDSMI, %s for Socket:%d, CpuSocketPowerWatt:%u\n", readSuccess ? "Success" : "Failed",
+           socket_index, socket_power_watts);
   }
 
   return readSuccess ? (uint32_t)(socket_power_watts * 1000) : GOAMDSMI_UINT32_MAX;
@@ -483,7 +483,7 @@ uint32_t goamdsmi_cpu_socket_power_cap_get(uint32_t socket_index) {
                                        &socket_power_cap_watts)))
     readSuccess = true;
   if (enable_debug_level(GOAMDSMI_DEBUG_LEVEL_1)) {
-    printf("AMDSMI, %s for Socket:%d, CpuSocketPowerCapWatt:%.3f\n",
+    printf("AMDSMI, %s for Socket:%d, CpuSocketPowerCapWatt:%u\n",
            readSuccess ? "Success" : "Failed", socket_index, socket_power_cap_watts);
   }
 

--- a/projects/amdsmi/include/amd_smi/amdsmi.h
+++ b/projects/amdsmi/include/amd_smi/amdsmi.h
@@ -3736,7 +3736,7 @@ amdsmi_status_t amdsmi_get_cpu_socket_power_cap_max(amdsmi_processor_handle proc
  *  @return ::amdsmi_status_t | ::AMDSMI_STATUS_SUCCESS on success, non-zero on fail
  */
 amdsmi_status_t amdsmi_get_cpu_pwr_svi_telemetry_all_rails(amdsmi_processor_handle processor_handle,
-                                                           uint32_t* power);
+                                                           double* power);
 
 /**
  *  @brief Set the power cap value for a given socket.
@@ -3752,7 +3752,7 @@ amdsmi_status_t amdsmi_get_cpu_pwr_svi_telemetry_all_rails(amdsmi_processor_hand
  *  @return ::amdsmi_status_t | ::AMDSMI_STATUS_SUCCESS on success, non-zero on fail
  */
 amdsmi_status_t amdsmi_set_cpu_socket_power_cap(amdsmi_processor_handle processor_handle,
-                                                uint32_t pcap);
+                                                double pcap);
 
 /**
  *  @brief Set the power efficiency profile policy.
@@ -3773,7 +3773,7 @@ amdsmi_status_t amdsmi_set_cpu_socket_power_cap(amdsmi_processor_handle processo
  */
 amdsmi_status_t amdsmi_set_cpu_pwr_efficiency_mode(amdsmi_processor_handle processor_handle,
                                                    uint8_t power_efficiency_mode,
-                                                   uint32_t* utilization, uint32_t* ppt_limit);
+                                                   uint32_t* utilization, double* ppt_limit);
 
 /**
  *  @brief Get the power efficiency profile policy

--- a/projects/amdsmi/include/amd_smi/amdsmi.h
+++ b/projects/amdsmi/include/amd_smi/amdsmi.h
@@ -3688,7 +3688,7 @@ amdsmi_status_t amdsmi_get_supported_power_cap(amdsmi_processor_handle processor
  *  @return ::amdsmi_status_t | ::AMDSMI_STATUS_SUCCESS on success, non-zero on fail
  */
 amdsmi_status_t amdsmi_get_cpu_socket_power(amdsmi_processor_handle processor_handle,
-                                            double* ppower);
+                                            uint32_t* ppower);
 
 /**
  *  @brief Get the socket power cap.
@@ -3704,7 +3704,7 @@ amdsmi_status_t amdsmi_get_cpu_socket_power(amdsmi_processor_handle processor_ha
  *  @return ::amdsmi_status_t | ::AMDSMI_STATUS_SUCCESS on success, non-zero on fail
  */
 amdsmi_status_t amdsmi_get_cpu_socket_power_cap(amdsmi_processor_handle processor_handle,
-                                                double* pcap);
+                                                uint32_t* pcap);
 
 /**
  *  @brief Get the maximum power cap value for a given socket.
@@ -3720,7 +3720,7 @@ amdsmi_status_t amdsmi_get_cpu_socket_power_cap(amdsmi_processor_handle processo
  *  @return ::amdsmi_status_t | ::AMDSMI_STATUS_SUCCESS on success, non-zero on fail
  */
 amdsmi_status_t amdsmi_get_cpu_socket_power_cap_max(amdsmi_processor_handle processor_handle,
-                                                    double* pmax);
+                                                    uint32_t* pmax);
 
 /**
  *  @brief Get the SVI based power telemetry for all rails.
@@ -3736,7 +3736,7 @@ amdsmi_status_t amdsmi_get_cpu_socket_power_cap_max(amdsmi_processor_handle proc
  *  @return ::amdsmi_status_t | ::AMDSMI_STATUS_SUCCESS on success, non-zero on fail
  */
 amdsmi_status_t amdsmi_get_cpu_pwr_svi_telemetry_all_rails(amdsmi_processor_handle processor_handle,
-                                                           double* power);
+                                                           uint32_t* power);
 
 /**
  *  @brief Set the power cap value for a given socket.
@@ -3752,7 +3752,7 @@ amdsmi_status_t amdsmi_get_cpu_pwr_svi_telemetry_all_rails(amdsmi_processor_hand
  *  @return ::amdsmi_status_t | ::AMDSMI_STATUS_SUCCESS on success, non-zero on fail
  */
 amdsmi_status_t amdsmi_set_cpu_socket_power_cap(amdsmi_processor_handle processor_handle,
-                                                double pcap);
+                                                uint32_t pcap);
 
 /**
  *  @brief Set the power efficiency profile policy.
@@ -3773,7 +3773,7 @@ amdsmi_status_t amdsmi_set_cpu_socket_power_cap(amdsmi_processor_handle processo
  */
 amdsmi_status_t amdsmi_set_cpu_pwr_efficiency_mode(amdsmi_processor_handle processor_handle,
                                                    uint8_t power_efficiency_mode,
-                                                   uint32_t* utilization, double* ppt_limit);
+                                                   uint32_t* utilization, uint32_t* ppt_limit);
 
 /**
  *  @brief Get the power efficiency profile policy
@@ -3797,7 +3797,7 @@ amdsmi_status_t amdsmi_set_cpu_pwr_efficiency_mode(amdsmi_processor_handle proce
  */
 amdsmi_status_t amdsmi_get_cpu_pwr_efficiency_mode(amdsmi_processor_handle processor_handle,
                                                    uint32_t* power_efficiency_mode,
-                                                   uint32_t* utilization, double* ppt_limit);
+                                                   uint32_t* utilization, uint32_t* ppt_limit);
 
 /**
  *  @brief Read CCD (Core Complex Die) power consumption
@@ -3815,7 +3815,7 @@ amdsmi_status_t amdsmi_get_cpu_pwr_efficiency_mode(amdsmi_processor_handle proce
  *           ::AMDSMI_STATUS_SUCCESS on successful register read, non-zero on failure
  */
 amdsmi_status_t amdsmi_get_cpu_core_ccd_power(amdsmi_processor_handle processor_handle,
-                                              double* power);
+                                              uint32_t* power);
 
 /** @} End tagEsmiPowerControl */
 
@@ -7804,7 +7804,7 @@ amdsmi_status_t amdsmi_set_cpu_sdps_limit(amdsmi_processor_handle processor_hand
  *  @return ::amdsmi_status_t | ::AMDSMI_STATUS_SUCCESS on success, non-zero on fail
  */
 amdsmi_status_t amdsmi_get_cpu_sdps_limit(amdsmi_processor_handle processor_handle,
-                                          double* sdps_limit);
+                                          uint32_t* sdps_limit);
 
 /** @} End tagEsmiPerfControl */
 

--- a/projects/amdsmi/include/amd_smi/amdsmi.h
+++ b/projects/amdsmi/include/amd_smi/amdsmi.h
@@ -3681,9 +3681,9 @@ amdsmi_status_t amdsmi_get_supported_power_cap(amdsmi_processor_handle processor
  *
  *  @platform{cpu_bm}
  *
- *  @param[in]      processor_handle Cpu socket which to query
+ *  @param[in]   processor_handle Cpu socket which to query
  *
- *  @param[in,out]    ppower - Input buffer to return socket power
+ *  @param[out]  ppower - Input buffer to return socket power
  *
  *  @return ::amdsmi_status_t | ::AMDSMI_STATUS_SUCCESS on success, non-zero on fail
  */
@@ -3697,9 +3697,9 @@ amdsmi_status_t amdsmi_get_cpu_socket_power(amdsmi_processor_handle processor_ha
  *
  *  @platform{cpu_bm}
  *
- *  @param[in]      processor_handle Cpu socket which to query
+ *  @param[in]   processor_handle Cpu socket which to query
  *
- *  @param[in,out]    pcap - Input buffer to return power cap.
+ *  @param[out]  pcap - Input buffer to return power cap.
  *
  *  @return ::amdsmi_status_t | ::AMDSMI_STATUS_SUCCESS on success, non-zero on fail
  */
@@ -3713,9 +3713,9 @@ amdsmi_status_t amdsmi_get_cpu_socket_power_cap(amdsmi_processor_handle processo
  *
  *  @platform{cpu_bm}
  *
- *  @param[in]      processor_handle Cpu socket which to query
+ *  @param[in]   processor_handle Cpu socket which to query
  *
- *  @param[in,out]    pmax - Input buffer to return maximum power limit value
+ *  @param[out]  pmax - Input buffer to return maximum power limit value
  *
  *  @return ::amdsmi_status_t | ::AMDSMI_STATUS_SUCCESS on success, non-zero on fail
  */
@@ -3808,7 +3808,7 @@ amdsmi_status_t amdsmi_get_cpu_pwr_efficiency_mode(amdsmi_processor_handle proce
  *
  *  @platform{cpu_bm}
  *
- *  @param[in]  processor_handle Cpu core which to query
+ *  @param[in]   processor_handle Cpu core which to query
  *  @param[out]  power - Input buffer to store power consumption in watts
  *
  *   @return ::amdsmi_status_t
@@ -7798,7 +7798,7 @@ amdsmi_status_t amdsmi_set_cpu_sdps_limit(amdsmi_processor_handle processor_hand
  *
  *  @platform{cpu_bm}
  *
- *  @param[in]  processor_handle Processor handle for which to query the limit
+ *  @param[in]   processor_handle Processor handle for which to query the limit
  *  @param[out]  sdps_limit - Input buffer to receive the current SDPS limit value in watts
  *
  *  @return ::amdsmi_status_t | ::AMDSMI_STATUS_SUCCESS on success, non-zero on fail

--- a/projects/amdsmi/py-interface/amdsmi_interface.py
+++ b/projects/amdsmi/py-interface/amdsmi_interface.py
@@ -1380,7 +1380,7 @@ def amdsmi_get_cpu_core_ccd_power(processor_handle: processor_handle_t) -> float
     if not isinstance(processor_handle, amdsmi_wrapper.amdsmi_processor_handle):
         raise AmdSmiParameterException(processor_handle, amdsmi_wrapper.amdsmi_processor_handle)
 
-    power = ctypes.c_double()
+    power = ctypes.c_uint32()
 
     _check_res(amdsmi_wrapper.amdsmi_get_cpu_core_ccd_power(processor_handle, ctypes.byref(power)))
 
@@ -1499,7 +1499,7 @@ def amdsmi_get_cpu_socket_power(processor_handle: processor_handle_t) -> str:
     if not isinstance(processor_handle, amdsmi_wrapper.amdsmi_processor_handle):
         raise AmdSmiParameterException(processor_handle, amdsmi_wrapper.amdsmi_processor_handle)
 
-    ppower = ctypes.c_double()
+    ppower = ctypes.c_uint32()
     _check_res(amdsmi_wrapper.amdsmi_get_cpu_socket_power(processor_handle, ctypes.byref(ppower)))
 
     return f"{ppower.value} Watts"
@@ -1509,7 +1509,7 @@ def amdsmi_get_cpu_socket_power_cap(processor_handle: processor_handle_t) -> str
     if not isinstance(processor_handle, amdsmi_wrapper.amdsmi_processor_handle):
         raise AmdSmiParameterException(processor_handle, amdsmi_wrapper.amdsmi_processor_handle)
 
-    pcap = ctypes.c_double()
+    pcap = ctypes.c_uint32()
     _check_res(amdsmi_wrapper.amdsmi_get_cpu_socket_power_cap(processor_handle, ctypes.byref(pcap)))
 
     return f"{pcap.value} Watts"
@@ -1519,7 +1519,7 @@ def amdsmi_get_cpu_socket_power_cap_max(processor_handle: processor_handle_t) ->
     if not isinstance(processor_handle, amdsmi_wrapper.amdsmi_processor_handle):
         raise AmdSmiParameterException(processor_handle, amdsmi_wrapper.amdsmi_processor_handle)
 
-    pmax = ctypes.c_double()
+    pmax = ctypes.c_uint32()
     _check_res(
         amdsmi_wrapper.amdsmi_get_cpu_socket_power_cap_max(processor_handle, ctypes.byref(pmax))
     )
@@ -1531,7 +1531,7 @@ def amdsmi_get_cpu_pwr_svi_telemetry_all_rails(processor_handle: processor_handl
     if not isinstance(processor_handle, amdsmi_wrapper.amdsmi_processor_handle):
         raise AmdSmiParameterException(processor_handle, amdsmi_wrapper.amdsmi_processor_handle)
 
-    power = ctypes.c_double()
+    power = ctypes.c_uint32()
     _check_res(
         amdsmi_wrapper.amdsmi_get_cpu_pwr_svi_telemetry_all_rails(
             processor_handle, ctypes.byref(power)
@@ -1541,22 +1541,22 @@ def amdsmi_get_cpu_pwr_svi_telemetry_all_rails(processor_handle: processor_handl
     return f"{power.value} mW"
 
 
-def amdsmi_set_cpu_socket_power_cap(processor_handle: processor_handle_t, power_cap: float):
+def amdsmi_set_cpu_socket_power_cap(processor_handle: processor_handle_t, power_cap: int):
     if not isinstance(processor_handle, amdsmi_wrapper.amdsmi_processor_handle):
         raise AmdSmiParameterException(processor_handle, amdsmi_wrapper.amdsmi_processor_handle)
-    if not isinstance(power_cap, float):
-        raise AmdSmiParameterException(power_cap, float)
+    if not isinstance(power_cap, int):
+        raise AmdSmiParameterException(power_cap, int)
 
-    power_cap_double = ctypes.c_double(power_cap)
+    power_cap_32 = ctypes.c_uint32(power_cap)
 
-    _check_res(amdsmi_wrapper.amdsmi_set_cpu_socket_power_cap(processor_handle, power_cap_double))
+    _check_res(amdsmi_wrapper.amdsmi_set_cpu_socket_power_cap(processor_handle, power_cap_32))
 
 
 def amdsmi_set_cpu_pwr_efficiency_mode(
     processor_handle: processor_handle_t,
     mode: int,
     util: int = AMDSMI_MAX_UTIL,
-    ppt_limit: float = AMDSMI_MAX_PPT_LIMIT,
+    ppt_limit: int = AMDSMI_MAX_PPT_LIMIT,
 ) -> tuple:
     if not isinstance(processor_handle, amdsmi_wrapper.amdsmi_processor_handle):
         raise AmdSmiParameterException(processor_handle, amdsmi_wrapper.amdsmi_processor_handle)
@@ -1564,20 +1564,20 @@ def amdsmi_set_cpu_pwr_efficiency_mode(
         raise AmdSmiParameterException(mode, int)
     if not isinstance(util, int):
         raise AmdSmiParameterException(util, int)
-    if not isinstance(ppt_limit, float):
-        raise AmdSmiParameterException(ppt_limit, float)
+    if not isinstance(ppt_limit, int):
+        raise AmdSmiParameterException(ppt_limit, int)
 
     mode_8 = ctypes.c_uint8(mode)
     util_32 = ctypes.c_uint32(util)
-    ppt_limit_double = ctypes.c_double(ppt_limit)
+    ppt_limit_32 = ctypes.c_uint32(ppt_limit)
 
     _check_res(
         amdsmi_wrapper.amdsmi_set_cpu_pwr_efficiency_mode(
-            processor_handle, mode_8, ctypes.byref(util_32), ctypes.byref(ppt_limit_double)
+            processor_handle, mode_8, ctypes.byref(util_32), ctypes.byref(ppt_limit_32)
         )
     )
 
-    return (util_32.value, ppt_limit_double.value)
+    return (util_32.value, ppt_limit_32.value)
 
 
 def amdsmi_get_cpu_pwr_efficiency_mode(processor_handle: processor_handle_t) -> tuple:
@@ -1586,7 +1586,7 @@ def amdsmi_get_cpu_pwr_efficiency_mode(processor_handle: processor_handle_t) -> 
 
     mode = ctypes.c_uint32()
     util = ctypes.c_uint32()
-    ppt_limit = ctypes.c_double()
+    ppt_limit = ctypes.c_uint32()
 
     _check_res(
         amdsmi_wrapper.amdsmi_get_cpu_pwr_efficiency_mode(
@@ -2356,7 +2356,7 @@ def amdsmi_get_cpu_sdps_limit(processor_handle: processor_handle_t) -> str:
     if not isinstance(processor_handle, amdsmi_wrapper.amdsmi_processor_handle):
         raise AmdSmiParameterException(processor_handle, amdsmi_wrapper.amdsmi_processor_handle)
 
-    sdps_limit = ctypes.c_double()
+    sdps_limit = ctypes.c_uint32()
     _check_res(amdsmi_wrapper.amdsmi_get_cpu_sdps_limit(processor_handle, ctypes.byref(sdps_limit)))
 
     # In Watt

--- a/projects/amdsmi/py-interface/amdsmi_interface.py
+++ b/projects/amdsmi/py-interface/amdsmi_interface.py
@@ -1531,7 +1531,7 @@ def amdsmi_get_cpu_pwr_svi_telemetry_all_rails(processor_handle: processor_handl
     if not isinstance(processor_handle, amdsmi_wrapper.amdsmi_processor_handle):
         raise AmdSmiParameterException(processor_handle, amdsmi_wrapper.amdsmi_processor_handle)
 
-    power = ctypes.c_uint32()
+    power = ctypes.c_double()
     _check_res(
         amdsmi_wrapper.amdsmi_get_cpu_pwr_svi_telemetry_all_rails(
             processor_handle, ctypes.byref(power)
@@ -1541,22 +1541,22 @@ def amdsmi_get_cpu_pwr_svi_telemetry_all_rails(processor_handle: processor_handl
     return f"{power.value} mW"
 
 
-def amdsmi_set_cpu_socket_power_cap(processor_handle: processor_handle_t, power_cap: int):
+def amdsmi_set_cpu_socket_power_cap(processor_handle: processor_handle_t, power_cap: float):
     if not isinstance(processor_handle, amdsmi_wrapper.amdsmi_processor_handle):
         raise AmdSmiParameterException(processor_handle, amdsmi_wrapper.amdsmi_processor_handle)
-    if not isinstance(power_cap, int):
-        raise AmdSmiParameterException(power_cap, int)
+    if not isinstance(power_cap, float):
+        raise AmdSmiParameterException(power_cap, float)
 
-    power_cap_32 = ctypes.c_uint32(power_cap)
+    power_cap_double = ctypes.c_double(power_cap)
 
-    _check_res(amdsmi_wrapper.amdsmi_set_cpu_socket_power_cap(processor_handle, power_cap_32))
+    _check_res(amdsmi_wrapper.amdsmi_set_cpu_socket_power_cap(processor_handle, power_cap_double))
 
 
 def amdsmi_set_cpu_pwr_efficiency_mode(
     processor_handle: processor_handle_t,
     mode: int,
     util: int = AMDSMI_MAX_UTIL,
-    ppt_limit: int = AMDSMI_MAX_PPT_LIMIT,
+    ppt_limit: float = AMDSMI_MAX_PPT_LIMIT,
 ) -> tuple:
     if not isinstance(processor_handle, amdsmi_wrapper.amdsmi_processor_handle):
         raise AmdSmiParameterException(processor_handle, amdsmi_wrapper.amdsmi_processor_handle)
@@ -1564,20 +1564,20 @@ def amdsmi_set_cpu_pwr_efficiency_mode(
         raise AmdSmiParameterException(mode, int)
     if not isinstance(util, int):
         raise AmdSmiParameterException(util, int)
-    if not isinstance(ppt_limit, int):
-        raise AmdSmiParameterException(ppt_limit, int)
+    if not isinstance(ppt_limit, float):
+        raise AmdSmiParameterException(ppt_limit, float)
 
     mode_8 = ctypes.c_uint8(mode)
     util_32 = ctypes.c_uint32(util)
-    ppt_limit_32 = ctypes.c_uint32(ppt_limit)
+    ppt_limit_double = ctypes.c_double(ppt_limit)
 
     _check_res(
         amdsmi_wrapper.amdsmi_set_cpu_pwr_efficiency_mode(
-            processor_handle, mode_8, ctypes.byref(util_32), ctypes.byref(ppt_limit_32)
+            processor_handle, mode_8, ctypes.byref(util_32), ctypes.byref(ppt_limit_double)
         )
     )
 
-    return (util_32.value, ppt_limit_32.value)
+    return (util_32.value, ppt_limit_double.value)
 
 
 def amdsmi_get_cpu_pwr_efficiency_mode(processor_handle: processor_handle_t) -> tuple:
@@ -5148,7 +5148,7 @@ def amdsmi_set_gpu_clk_limit(
         clk_type_conversion = amdsmi_wrapper.AMDSMI_CLK_TYPE_DF
     else:
         raise AmdSmiParameterException(f"Unsupported clock type: {clk_type}", str)
-    
+
     if limit_type.lower() == "min":
         limit_type_conversion = amdsmi_wrapper.CLK_LIMIT_MIN
     elif limit_type.lower() == "max":

--- a/projects/amdsmi/py-interface/amdsmi_interface.py
+++ b/projects/amdsmi/py-interface/amdsmi_interface.py
@@ -1376,7 +1376,7 @@ def amdsmi_get_cpu_core_energy(processor_handle: processor_handle_t) -> str:
     return f"{float(penergy.value * pow(10, -6))} J"
 
 
-def amdsmi_get_cpu_core_ccd_power(processor_handle: processor_handle_t) -> float:
+def amdsmi_get_cpu_core_ccd_power(processor_handle: processor_handle_t) -> int:
     if not isinstance(processor_handle, amdsmi_wrapper.amdsmi_processor_handle):
         raise AmdSmiParameterException(processor_handle, amdsmi_wrapper.amdsmi_processor_handle)
 

--- a/projects/amdsmi/py-interface/amdsmi_wrapper.py
+++ b/projects/amdsmi/py-interface/amdsmi_wrapper.py
@@ -2932,50 +2932,50 @@ except AttributeError:
 try:
     amdsmi_get_cpu_socket_power = _libraries['libamd_smi.so'].amdsmi_get_cpu_socket_power
     amdsmi_get_cpu_socket_power.restype = amdsmi_status_t
-    amdsmi_get_cpu_socket_power.argtypes = [amdsmi_processor_handle, ctypes.POINTER(ctypes.c_double)]
+    amdsmi_get_cpu_socket_power.argtypes = [amdsmi_processor_handle, ctypes.POINTER(ctypes.c_uint32)]
 except AttributeError:
     pass
 try:
     amdsmi_get_cpu_socket_power_cap = _libraries['libamd_smi.so'].amdsmi_get_cpu_socket_power_cap
     amdsmi_get_cpu_socket_power_cap.restype = amdsmi_status_t
-    amdsmi_get_cpu_socket_power_cap.argtypes = [amdsmi_processor_handle, ctypes.POINTER(ctypes.c_double)]
+    amdsmi_get_cpu_socket_power_cap.argtypes = [amdsmi_processor_handle, ctypes.POINTER(ctypes.c_uint32)]
 except AttributeError:
     pass
 try:
     amdsmi_get_cpu_socket_power_cap_max = _libraries['libamd_smi.so'].amdsmi_get_cpu_socket_power_cap_max
     amdsmi_get_cpu_socket_power_cap_max.restype = amdsmi_status_t
-    amdsmi_get_cpu_socket_power_cap_max.argtypes = [amdsmi_processor_handle, ctypes.POINTER(ctypes.c_double)]
+    amdsmi_get_cpu_socket_power_cap_max.argtypes = [amdsmi_processor_handle, ctypes.POINTER(ctypes.c_uint32)]
 except AttributeError:
     pass
 try:
     amdsmi_get_cpu_pwr_svi_telemetry_all_rails = _libraries['libamd_smi.so'].amdsmi_get_cpu_pwr_svi_telemetry_all_rails
     amdsmi_get_cpu_pwr_svi_telemetry_all_rails.restype = amdsmi_status_t
-    amdsmi_get_cpu_pwr_svi_telemetry_all_rails.argtypes = [amdsmi_processor_handle, ctypes.POINTER(ctypes.c_double)]
+    amdsmi_get_cpu_pwr_svi_telemetry_all_rails.argtypes = [amdsmi_processor_handle, ctypes.POINTER(ctypes.c_uint32)]
 except AttributeError:
     pass
 try:
     amdsmi_set_cpu_socket_power_cap = _libraries['libamd_smi.so'].amdsmi_set_cpu_socket_power_cap
     amdsmi_set_cpu_socket_power_cap.restype = amdsmi_status_t
-    amdsmi_set_cpu_socket_power_cap.argtypes = [amdsmi_processor_handle, ctypes.c_double]
+    amdsmi_set_cpu_socket_power_cap.argtypes = [amdsmi_processor_handle, uint32_t]
 except AttributeError:
     pass
 uint8_t = ctypes.c_uint8
 try:
     amdsmi_set_cpu_pwr_efficiency_mode = _libraries['libamd_smi.so'].amdsmi_set_cpu_pwr_efficiency_mode
     amdsmi_set_cpu_pwr_efficiency_mode.restype = amdsmi_status_t
-    amdsmi_set_cpu_pwr_efficiency_mode.argtypes = [amdsmi_processor_handle, uint8_t, ctypes.POINTER(ctypes.c_uint32), ctypes.POINTER(ctypes.c_double)]
+    amdsmi_set_cpu_pwr_efficiency_mode.argtypes = [amdsmi_processor_handle, uint8_t, ctypes.POINTER(ctypes.c_uint32), ctypes.POINTER(ctypes.c_uint32)]
 except AttributeError:
     pass
 try:
     amdsmi_get_cpu_pwr_efficiency_mode = _libraries['libamd_smi.so'].amdsmi_get_cpu_pwr_efficiency_mode
     amdsmi_get_cpu_pwr_efficiency_mode.restype = amdsmi_status_t
-    amdsmi_get_cpu_pwr_efficiency_mode.argtypes = [amdsmi_processor_handle, ctypes.POINTER(ctypes.c_uint32), ctypes.POINTER(ctypes.c_uint32), ctypes.POINTER(ctypes.c_double)]
+    amdsmi_get_cpu_pwr_efficiency_mode.argtypes = [amdsmi_processor_handle, ctypes.POINTER(ctypes.c_uint32), ctypes.POINTER(ctypes.c_uint32), ctypes.POINTER(ctypes.c_uint32)]
 except AttributeError:
     pass
 try:
     amdsmi_get_cpu_core_ccd_power = _libraries['libamd_smi.so'].amdsmi_get_cpu_core_ccd_power
     amdsmi_get_cpu_core_ccd_power.restype = amdsmi_status_t
-    amdsmi_get_cpu_core_ccd_power.argtypes = [amdsmi_processor_handle, ctypes.POINTER(ctypes.c_double)]
+    amdsmi_get_cpu_core_ccd_power.argtypes = [amdsmi_processor_handle, ctypes.POINTER(ctypes.c_uint32)]
 except AttributeError:
     pass
 try:
@@ -3927,7 +3927,7 @@ except AttributeError:
 try:
     amdsmi_get_cpu_sdps_limit = _libraries['libamd_smi.so'].amdsmi_get_cpu_sdps_limit
     amdsmi_get_cpu_sdps_limit.restype = amdsmi_status_t
-    amdsmi_get_cpu_sdps_limit.argtypes = [amdsmi_processor_handle, ctypes.POINTER(ctypes.c_double)]
+    amdsmi_get_cpu_sdps_limit.argtypes = [amdsmi_processor_handle, ctypes.POINTER(ctypes.c_uint32)]
 except AttributeError:
     pass
 try:

--- a/projects/amdsmi/py-interface/amdsmi_wrapper.py
+++ b/projects/amdsmi/py-interface/amdsmi_wrapper.py
@@ -2080,8 +2080,10 @@ struct_amdsmi_od_volt_freq_data_t._pack_ = 1 # source:False
 struct_amdsmi_od_volt_freq_data_t._fields_ = [
     ('curr_sclk_range', amdsmi_range_t),
     ('curr_mclk_range', amdsmi_range_t),
+    ('curr_fclk_range', amdsmi_range_t),
     ('sclk_freq_limits', amdsmi_range_t),
     ('mclk_freq_limits', amdsmi_range_t),
+    ('fclk_freq_limits', amdsmi_range_t),
     ('curve', amdsmi_od_volt_curve_t),
     ('num_regions', ctypes.c_uint32),
     ('PADDING_0', ctypes.c_ubyte * 4),
@@ -2948,20 +2950,20 @@ except AttributeError:
 try:
     amdsmi_get_cpu_pwr_svi_telemetry_all_rails = _libraries['libamd_smi.so'].amdsmi_get_cpu_pwr_svi_telemetry_all_rails
     amdsmi_get_cpu_pwr_svi_telemetry_all_rails.restype = amdsmi_status_t
-    amdsmi_get_cpu_pwr_svi_telemetry_all_rails.argtypes = [amdsmi_processor_handle, ctypes.POINTER(ctypes.c_uint32)]
+    amdsmi_get_cpu_pwr_svi_telemetry_all_rails.argtypes = [amdsmi_processor_handle, ctypes.POINTER(ctypes.c_double)]
 except AttributeError:
     pass
 try:
     amdsmi_set_cpu_socket_power_cap = _libraries['libamd_smi.so'].amdsmi_set_cpu_socket_power_cap
     amdsmi_set_cpu_socket_power_cap.restype = amdsmi_status_t
-    amdsmi_set_cpu_socket_power_cap.argtypes = [amdsmi_processor_handle, uint32_t]
+    amdsmi_set_cpu_socket_power_cap.argtypes = [amdsmi_processor_handle, ctypes.c_double]
 except AttributeError:
     pass
 uint8_t = ctypes.c_uint8
 try:
     amdsmi_set_cpu_pwr_efficiency_mode = _libraries['libamd_smi.so'].amdsmi_set_cpu_pwr_efficiency_mode
     amdsmi_set_cpu_pwr_efficiency_mode.restype = amdsmi_status_t
-    amdsmi_set_cpu_pwr_efficiency_mode.argtypes = [amdsmi_processor_handle, uint8_t, ctypes.POINTER(ctypes.c_uint32), ctypes.POINTER(ctypes.c_uint32)]
+    amdsmi_set_cpu_pwr_efficiency_mode.argtypes = [amdsmi_processor_handle, uint8_t, ctypes.POINTER(ctypes.c_uint32), ctypes.POINTER(ctypes.c_double)]
 except AttributeError:
     pass
 try:

--- a/projects/amdsmi/rust-interface/src/amdsmi_wrapper.rs
+++ b/projects/amdsmi/rust-interface/src/amdsmi_wrapper.rs
@@ -3519,19 +3519,19 @@ extern "C" {
 extern "C" {
     pub fn amdsmi_get_cpu_socket_power(
         processor_handle: AmdsmiProcessorHandle,
-        ppower: *mut f64,
+        ppower: *mut u32,
     ) -> AmdsmiStatusT;
 }
 extern "C" {
     pub fn amdsmi_get_cpu_socket_power_cap(
         processor_handle: AmdsmiProcessorHandle,
-        pcap: *mut f64,
+        pcap: *mut u32,
     ) -> AmdsmiStatusT;
 }
 extern "C" {
     pub fn amdsmi_get_cpu_socket_power_cap_max(
         processor_handle: AmdsmiProcessorHandle,
-        pmax: *mut f64,
+        pmax: *mut u32,
     ) -> AmdsmiStatusT;
 }
 extern "C" {
@@ -3559,13 +3559,13 @@ extern "C" {
         processor_handle: AmdsmiProcessorHandle,
         power_efficiency_mode: *mut u32,
         utilization: *mut u32,
-        ppt_limit: *mut f64,
+        ppt_limit: *mut u32,
     ) -> AmdsmiStatusT;
 }
 extern "C" {
     pub fn amdsmi_get_cpu_core_ccd_power(
         processor_handle: AmdsmiProcessorHandle,
-        power: *mut f64,
+        power: *mut u32,
     ) -> AmdsmiStatusT;
 }
 extern "C" {

--- a/projects/amdsmi/src/amd_smi/amd_smi.cc
+++ b/projects/amdsmi/src/amd_smi/amd_smi.cc
@@ -6562,7 +6562,7 @@ amdsmi_status_t amdsmi_get_cpu_socket_power_cap_max(amdsmi_processor_handle proc
 }
 
 amdsmi_status_t amdsmi_get_cpu_pwr_svi_telemetry_all_rails(amdsmi_processor_handle processor_handle,
-                                                           uint32_t* power) {
+                                                           double* power) {
   amdsmi_status_t status;
   uint32_t pow;
   uint8_t sock_ind;
@@ -6579,15 +6579,16 @@ amdsmi_status_t amdsmi_get_cpu_pwr_svi_telemetry_all_rails(amdsmi_processor_hand
   status = static_cast<amdsmi_status_t>(esmi_pwr_svi_telemetry_all_rails_get(sock_ind, &pow));
   if (status != AMDSMI_STATUS_SUCCESS) return amdsmi_errno_to_esmi_status(status);
 
-  *power = pow;
+  *power = static_cast<double>(pow);
 
   return AMDSMI_STATUS_SUCCESS;
 }
 
 amdsmi_status_t amdsmi_set_cpu_socket_power_cap(amdsmi_processor_handle processor_handle,
-                                                uint32_t pcap) {
+                                                double _pcap) {
   amdsmi_status_t status;
   uint8_t sock_ind;
+  uint32_t pcap = static_cast<uint32_t>(_pcap);
 
   AMDSMI_CHECK_INIT();
 
@@ -6607,7 +6608,7 @@ amdsmi_status_t amdsmi_set_cpu_socket_power_cap(amdsmi_processor_handle processo
 
 amdsmi_status_t amdsmi_set_cpu_pwr_efficiency_mode(amdsmi_processor_handle processor_handle,
                                                    uint8_t power_efficiency_mode,
-                                                   uint32_t* utilization, uint32_t* ppt_limit) {
+                                                   uint32_t* utilization, double* ppt_limit) {
   amdsmi_status_t status;
   uint8_t sock_ind;
   uint32_t pwreffmode_util = 0;
@@ -6620,7 +6621,7 @@ amdsmi_status_t amdsmi_set_cpu_pwr_efficiency_mode(amdsmi_processor_handle proce
     return AMDSMI_STATUS_INVAL;
 
   pwreffmode_util = *utilization;
-  pwreffmode_pptlimit = *ppt_limit;
+  pwreffmode_pptlimit = static_cast<uint32_t>(*ppt_limit);
 
   if ((power_efficiency_mode == POWER_EFFICIENCY_MODE_4) ||
       (power_efficiency_mode == POWER_EFFICIENCY_MODE_5)) {
@@ -6662,7 +6663,7 @@ amdsmi_status_t amdsmi_set_cpu_pwr_efficiency_mode(amdsmi_processor_handle proce
   if (status != AMDSMI_STATUS_SUCCESS) return amdsmi_errno_to_esmi_status(status);
 
   *utilization = pwreffmode_util;
-  *ppt_limit = pwreffmode_pptlimit;
+  *ppt_limit = static_cast<double>(pwreffmode_pptlimit);
   return AMDSMI_STATUS_SUCCESS;
 }
 

--- a/projects/amdsmi/src/amd_smi/amd_smi.cc
+++ b/projects/amdsmi/src/amd_smi/amd_smi.cc
@@ -6490,7 +6490,7 @@ amdsmi_status_t amdsmi_get_cpu_core_current_freq_limit(amdsmi_processor_handle p
 }
 
 amdsmi_status_t amdsmi_get_cpu_socket_power(amdsmi_processor_handle processor_handle,
-                                            double* ppower) {
+                                            uint32_t* ppower) {
   amdsmi_status_t status;
   uint32_t avg_power;
   uint8_t sock_ind;
@@ -6508,13 +6508,13 @@ amdsmi_status_t amdsmi_get_cpu_socket_power(amdsmi_processor_handle processor_ha
   if (status != AMDSMI_STATUS_SUCCESS) return amdsmi_errno_to_esmi_status(status);
 
   // Convert milliwatts to watts
-  *ppower = static_cast<double>(avg_power) / 1000.0;
+  *ppower = avg_power / 1000;
 
   return AMDSMI_STATUS_SUCCESS;
 }
 
 amdsmi_status_t amdsmi_get_cpu_socket_power_cap(amdsmi_processor_handle processor_handle,
-                                                double* pcap) {
+                                                uint32_t* pcap) {
   amdsmi_status_t status;
   uint32_t p_cap;
   uint8_t sock_ind;
@@ -6532,13 +6532,13 @@ amdsmi_status_t amdsmi_get_cpu_socket_power_cap(amdsmi_processor_handle processo
   if (status != AMDSMI_STATUS_SUCCESS) return amdsmi_errno_to_esmi_status(status);
 
   // Convert milliwatts to watts
-  *pcap = static_cast<double>(p_cap) / 1000.0;
+  *pcap = p_cap / 1000;
 
   return AMDSMI_STATUS_SUCCESS;
 }
 
 amdsmi_status_t amdsmi_get_cpu_socket_power_cap_max(amdsmi_processor_handle processor_handle,
-                                                    double* pmax) {
+                                                    uint32_t* pmax) {
   amdsmi_status_t status;
   uint32_t p_max;
   uint8_t sock_ind;
@@ -6556,13 +6556,13 @@ amdsmi_status_t amdsmi_get_cpu_socket_power_cap_max(amdsmi_processor_handle proc
   if (status != AMDSMI_STATUS_SUCCESS) return amdsmi_errno_to_esmi_status(status);
 
   // Convert milliwatts to watts
-  *pmax = static_cast<double>(p_max) / 1000.0;
+  *pmax = p_max / 1000;
 
   return AMDSMI_STATUS_SUCCESS;
 }
 
 amdsmi_status_t amdsmi_get_cpu_pwr_svi_telemetry_all_rails(amdsmi_processor_handle processor_handle,
-                                                           double* power) {
+                                                           uint32_t* power) {
   amdsmi_status_t status;
   uint32_t pow;
   uint8_t sock_ind;
@@ -6579,16 +6579,15 @@ amdsmi_status_t amdsmi_get_cpu_pwr_svi_telemetry_all_rails(amdsmi_processor_hand
   status = static_cast<amdsmi_status_t>(esmi_pwr_svi_telemetry_all_rails_get(sock_ind, &pow));
   if (status != AMDSMI_STATUS_SUCCESS) return amdsmi_errno_to_esmi_status(status);
 
-  *power = static_cast<double>(pow);
+  *power = pow;
 
   return AMDSMI_STATUS_SUCCESS;
 }
 
 amdsmi_status_t amdsmi_set_cpu_socket_power_cap(amdsmi_processor_handle processor_handle,
-                                                double _pcap) {
+                                                uint32_t pcap) {
   amdsmi_status_t status;
   uint8_t sock_ind;
-  uint32_t pcap = static_cast<uint32_t>(_pcap);
 
   AMDSMI_CHECK_INIT();
 
@@ -6608,7 +6607,7 @@ amdsmi_status_t amdsmi_set_cpu_socket_power_cap(amdsmi_processor_handle processo
 
 amdsmi_status_t amdsmi_set_cpu_pwr_efficiency_mode(amdsmi_processor_handle processor_handle,
                                                    uint8_t power_efficiency_mode,
-                                                   uint32_t* utilization, double* ppt_limit) {
+                                                   uint32_t* utilization, uint32_t* ppt_limit) {
   amdsmi_status_t status;
   uint8_t sock_ind;
   uint32_t pwreffmode_util = 0;
@@ -6621,7 +6620,7 @@ amdsmi_status_t amdsmi_set_cpu_pwr_efficiency_mode(amdsmi_processor_handle proce
     return AMDSMI_STATUS_INVAL;
 
   pwreffmode_util = *utilization;
-  pwreffmode_pptlimit = static_cast<uint32_t>(*ppt_limit);
+  pwreffmode_pptlimit = *ppt_limit;
 
   if ((power_efficiency_mode == POWER_EFFICIENCY_MODE_4) ||
       (power_efficiency_mode == POWER_EFFICIENCY_MODE_5)) {
@@ -6663,13 +6662,13 @@ amdsmi_status_t amdsmi_set_cpu_pwr_efficiency_mode(amdsmi_processor_handle proce
   if (status != AMDSMI_STATUS_SUCCESS) return amdsmi_errno_to_esmi_status(status);
 
   *utilization = pwreffmode_util;
-  *ppt_limit = static_cast<double>(pwreffmode_pptlimit);
+  *ppt_limit = pwreffmode_pptlimit;
   return AMDSMI_STATUS_SUCCESS;
 }
 
 amdsmi_status_t amdsmi_get_cpu_pwr_efficiency_mode(amdsmi_processor_handle processor_handle,
                                                    uint32_t* power_efficiency_mode,
-                                                   uint32_t* utilization, double* ppt_limit) {
+                                                   uint32_t* utilization, uint32_t* ppt_limit) {
   amdsmi_status_t status;
   uint8_t sock_ind;
   uint8_t mode_uint8;
@@ -6692,7 +6691,7 @@ amdsmi_status_t amdsmi_get_cpu_pwr_efficiency_mode(amdsmi_processor_handle proce
   if (status != AMDSMI_STATUS_SUCCESS) return amdsmi_errno_to_esmi_status(status);
 
   *power_efficiency_mode = static_cast<uint32_t>(mode_uint8);
-  *ppt_limit = static_cast<double>(pptlimit_uint32) / 1000.0;
+  *ppt_limit = pptlimit_uint32 / 1000;
 
   return AMDSMI_STATUS_SUCCESS;
 }
@@ -7693,7 +7692,7 @@ amdsmi_status_t amdsmi_set_cpu_dimm_sb_reg(amdsmi_processor_handle processor_han
 }
 
 amdsmi_status_t amdsmi_get_cpu_core_ccd_power(amdsmi_processor_handle processor_handle,
-                                              double* power) {
+                                              uint32_t* power) {
   amdsmi_status_t status;
   uint8_t core_ind;
   char proc_id[SIZE];
@@ -7711,7 +7710,7 @@ amdsmi_status_t amdsmi_get_cpu_core_ccd_power(amdsmi_processor_handle processor_
   status = static_cast<amdsmi_status_t>(esmi_read_ccd_power(core_ind, &power_u32));
   if (status != AMDSMI_STATUS_SUCCESS) return amdsmi_errno_to_esmi_status(status);
 
-  *power = static_cast<double>(power_u32) / 1000.0;
+  *power = power_u32 / 1000;
   return AMDSMI_STATUS_SUCCESS;
 }
 
@@ -8063,7 +8062,7 @@ amdsmi_status_t amdsmi_set_cpu_sdps_limit(amdsmi_processor_handle processor_hand
 }
 
 amdsmi_status_t amdsmi_get_cpu_sdps_limit(amdsmi_processor_handle processor_handle,
-                                          double* sdps_limit) {
+                                          uint32_t* sdps_limit) {
   amdsmi_status_t status;
   uint8_t sock_ind;
   char proc_id[SIZE];
@@ -8083,7 +8082,7 @@ amdsmi_status_t amdsmi_get_cpu_sdps_limit(amdsmi_processor_handle processor_hand
   if (status != AMDSMI_STATUS_SUCCESS) return amdsmi_errno_to_esmi_status(status);
 
   // Convert milliwatts to watts
-  *sdps_limit = static_cast<double>(sdpslimit_u32) / 1000.0;
+  *sdps_limit = sdpslimit_u32 / 1000;
 
   return AMDSMI_STATUS_SUCCESS;
 }

--- a/projects/amdsmi/src/amd_smi/amd_smi.cc
+++ b/projects/amdsmi/src/amd_smi/amd_smi.cc
@@ -6498,6 +6498,7 @@ amdsmi_status_t amdsmi_get_cpu_socket_power(amdsmi_processor_handle processor_ha
   AMDSMI_CHECK_INIT();
 
   if (processor_handle == nullptr) return AMDSMI_STATUS_INVAL;
+  if (ppower == nullptr) return AMDSMI_STATUS_INVAL;
 
   amdsmi_status_t r = amdsmi_get_processor_info(processor_handle, SIZE, proc_id);
   if (r != AMDSMI_STATUS_SUCCESS) return r;
@@ -6508,7 +6509,7 @@ amdsmi_status_t amdsmi_get_cpu_socket_power(amdsmi_processor_handle processor_ha
   if (status != AMDSMI_STATUS_SUCCESS) return amdsmi_errno_to_esmi_status(status);
 
   // Convert milliwatts to watts
-  *ppower = avg_power / 1000;
+  *ppower = (avg_power + 500) / 1000;
 
   return AMDSMI_STATUS_SUCCESS;
 }
@@ -6532,7 +6533,7 @@ amdsmi_status_t amdsmi_get_cpu_socket_power_cap(amdsmi_processor_handle processo
   if (status != AMDSMI_STATUS_SUCCESS) return amdsmi_errno_to_esmi_status(status);
 
   // Convert milliwatts to watts
-  *pcap = p_cap / 1000;
+  *pcap = (p_cap + 500) / 1000;
 
   return AMDSMI_STATUS_SUCCESS;
 }
@@ -6556,7 +6557,7 @@ amdsmi_status_t amdsmi_get_cpu_socket_power_cap_max(amdsmi_processor_handle proc
   if (status != AMDSMI_STATUS_SUCCESS) return amdsmi_errno_to_esmi_status(status);
 
   // Convert milliwatts to watts
-  *pmax = p_max / 1000;
+  *pmax = (p_max + 500) / 1000;
 
   return AMDSMI_STATUS_SUCCESS;
 }
@@ -6691,7 +6692,7 @@ amdsmi_status_t amdsmi_get_cpu_pwr_efficiency_mode(amdsmi_processor_handle proce
   if (status != AMDSMI_STATUS_SUCCESS) return amdsmi_errno_to_esmi_status(status);
 
   *power_efficiency_mode = static_cast<uint32_t>(mode_uint8);
-  *ppt_limit = pptlimit_uint32 / 1000;
+  *ppt_limit = (pptlimit_uint32 + 500) / 1000;
 
   return AMDSMI_STATUS_SUCCESS;
 }
@@ -7710,7 +7711,7 @@ amdsmi_status_t amdsmi_get_cpu_core_ccd_power(amdsmi_processor_handle processor_
   status = static_cast<amdsmi_status_t>(esmi_read_ccd_power(core_ind, &power_u32));
   if (status != AMDSMI_STATUS_SUCCESS) return amdsmi_errno_to_esmi_status(status);
 
-  *power = power_u32 / 1000;
+  *power = (power_u32 + 500) / 1000;
   return AMDSMI_STATUS_SUCCESS;
 }
 
@@ -8082,7 +8083,7 @@ amdsmi_status_t amdsmi_get_cpu_sdps_limit(amdsmi_processor_handle processor_hand
   if (status != AMDSMI_STATUS_SUCCESS) return amdsmi_errno_to_esmi_status(status);
 
   // Convert milliwatts to watts
-  *sdps_limit = sdpslimit_u32 / 1000;
+  *sdps_limit = (sdpslimit_u32 + 500) / 1000;
 
   return AMDSMI_STATUS_SUCCESS;
 }

--- a/projects/amdsmi/tests/python_unittest/integration_test.py
+++ b/projects/amdsmi/tests/python_unittest/integration_test.py
@@ -744,7 +744,7 @@ class TestAmdSmiPython(unittest.TestCase):
                 self.common.check_ret("", "", self.common.PASS)
 
                 # Convert power_cap_max from string that has units to an integer
-                # Ex.  power_cap_max = "5000 mW"  to   power_cap_max = 5000
+                # Ex.  power_cap_max = "500 W"  to   power_cap_max = 500
                 power_cap_max = int(power_cap_max.split()[0])
             except (amdsmi.AmdSmiLibraryException, amdsmi.AmdSmiParameterException) as e:
                 if self.common.check_ret(msg, e, self.common.PASS):
@@ -767,7 +767,7 @@ class TestAmdSmiPython(unittest.TestCase):
             # Set cpu socket power back
             msg = f"\t### amdsmi_set_cpu_socket_power_cap(cpu={i}, power_cap={power_cap_orig}):"
             try:
-                ret = amdsmi.amdsmi_set_cpu_socket_power_cap(cpu, power_cap_orig)
+                ret = amdsmi.amdsmi_set_cpu_socket_power_cap(cpu, int(power_cap_orig.split()[0]))
                 self.common.print(msg, ret)
                 self.common.check_ret("", "", self.common.PASS)
             except (amdsmi.AmdSmiLibraryException, amdsmi.AmdSmiParameterException) as e:


### PR DESCRIPTION
## Motivation
Several of the get and set power API's were using different types.  
Changed all power API's that were using a double type to uint32 for consistency.

## Technical
All of the double* types were converted to uint32_t*
	- Consistency: Makes get/set APIs consistent (both use uint32_t)
	- Alignment: Matches underlying esmi library types
	- Coverage: Updates all language bindings systematically
	- Documentation: Python docs updated to remove float formatting