### PR TITLE
rocr: Making bootstrap_lock a static member

### DIFF
--- a/projects/rocr-runtime/runtime/hsa-runtime/core/inc/runtime.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/inc/runtime.h
@@ -736,14 +736,7 @@ class Runtime {
     prefetch_map_t::iterator next;
   };
 
-  // Will be created before any user could call hsa_init but also could be
-  // destroyed before incorrectly written programs call hsa_shutdown.
-  static __forceinline std::mutex& bootstrap_lock() {
-    // This allocation is meant to last until the last thread has exited.
-    // It is intentionally not freed.
-    static std::mutex* bootstrap_lock_ = new std::mutex;
-    return *bootstrap_lock_;
-  }
+  static std::mutex bootstrap_lock_;
   Runtime();
 
   Runtime(const Runtime&);

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/runtime.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/runtime.cpp
@@ -110,8 +110,10 @@ bool g_use_interrupt_wait;
 bool g_use_mwaitx;
 Runtime* Runtime::runtime_singleton_ = NULL;
 
+std::mutex Runtime::bootstrap_lock_;
+
 hsa_status_t Runtime::Acquire() {
-  std::lock_guard<std::mutex> boot(bootstrap_lock());
+  std::lock_guard<std::mutex> boot(bootstrap_lock_);
 
   if (runtime_singleton_ == NULL) {
     memset(log_flags, 0, sizeof(log_flags));
@@ -138,7 +140,7 @@ hsa_status_t Runtime::Acquire() {
 }
 
 hsa_status_t Runtime::Release() {
-  std::lock_guard<std::mutex> boot(bootstrap_lock());
+  std::lock_guard<std::mutex> boot(bootstrap_lock_);
 
   if (runtime_singleton_ == nullptr) return HSA_STATUS_ERROR_NOT_INITIALIZED;
 


### PR DESCRIPTION
The bootstrap_lock() function used __forceinline with a function-local static mutex pointer. This results in different threads locking different mutexes, breaking mutual exclusion between Acquire() and Release(), which leads to concurrent Load()/Unload() execution and HSA_STATUS_ERROR_OUT_OF_RESOURCES failures in
rocrtstFunc.Concurrent_Init_Shutdown_Test.

Replace the function-local static with a plain static class member variable, which is initialized during program startup (single-threaded, before main) and requires no runtime guard.

## Motivation

ROCr Concurrent_Init_Test and Concurrent_Init_Shutdown_Test  intermittently fail

## Technical Details

There was an old commit by @dayatsin-amd on another branch, but not merged onto the develop branch. This change does exactly the same with the same motivation. https://github.com/ROCm/rocm-systems/commit/bed3e3dfc4d4d887b7492e1d57776e651290b0a0

## JIRA ID

ROCM-21574

## Test Plan

Concurrent_Init_Test and Concurrent_Init_Shutdown_Test  can pass without issue, and mutex should be exactly the same for these different threads.

## Test Result

Passed and confirmed

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
