### PR TITLE
build(amdsmi): auto-detect amdclang++/clang++ as default compiler

### DIFF
--- a/projects/amdsmi/CMakeLists.txt
+++ b/projects/amdsmi/CMakeLists.txt
@@ -24,6 +24,177 @@
 #
 cmake_minimum_required(VERSION 3.20)
 
+#
+# --- Compiler detection (Clang family only) ---
+# Default: amdclang++ > clang++ (strict ROCm vs system separation)
+# GCC is not auto-selected. To build with GCC, use a toolchain file:
+#   cmake .. -DCMAKE_TOOLCHAIN_FILE=../cmake/toolchains/amdsmi-gcc-toolchain.cmake
+#
+# ROCm discovery:
+#   Uses hipconfig --path for tool-based discovery (per TheRock #3976)
+#   No hardcoded paths or ROCM_PATH fallback
+#
+# If ROCm installed (hipconfig found):
+#   Searches ONLY in ROCm paths (NO system PATH fallback):
+#     1. <rocm-path>/lib/llvm/bin/amdclang++  (current standard)
+#     2. <rocm-path>/llvm/bin/amdclang++      (legacy)
+#     3. <rocm-path>/lib/llvm/bin/clang++     (ROCm clang++)
+#     4. <rocm-path>/llvm/bin/clang++         (ROCm clang++ legacy)
+#
+# If ROCm NOT installed (hipconfig not found):
+#   Searches ONLY in system PATH:
+#     - /usr/bin/clang++ (or wherever system clang++ is)
+#
+# Build fails if no suitable compiler found.
+#
+# See: cmake/toolchains/amdsmi-gcc-toolchain.cmake
+# See also: https://github.com/ROCm/TheRock/issues/3976
+#
+if(NOT CMAKE_TOOLCHAIN_FILE AND NOT DEFINED CMAKE_CXX_COMPILER AND NOT DEFINED CMAKE_C_COMPILER)
+    # Determine ROCm installation path using tool-based discovery
+    # Uses hipconfig --path (per https://github.com/ROCm/TheRock/issues/3976)
+    set(ROCM_DIR "")
+
+    find_program(HIPCONFIG_EXECUTABLE hipconfig)
+    if(HIPCONFIG_EXECUTABLE)
+        execute_process(
+            COMMAND "${HIPCONFIG_EXECUTABLE}" --path
+            OUTPUT_VARIABLE HIPCONFIG_PATH
+            OUTPUT_STRIP_TRAILING_WHITESPACE
+            ERROR_QUIET
+        )
+        if(HIPCONFIG_PATH)
+            set(ROCM_DIR "${HIPCONFIG_PATH}")
+            message(STATUS "Found ROCm via hipconfig: ${ROCM_DIR}")
+        endif()
+    endif()
+
+    # Search for amdclang++ in ROCm installation
+    # Prefer lib/llvm/bin (current) over llvm/bin (legacy)
+    set(_AMDCLANG_HINTS "")
+    if(ROCM_DIR)
+        list(
+            APPEND _AMDCLANG_HINTS
+            "${ROCM_DIR}/lib/llvm/bin"
+            "${ROCM_DIR}/llvm/bin"
+        )
+    endif()
+
+    find_program(
+        AMDCLANG_CXX_COMPILER
+        NAMES amdclang++
+        HINTS ${_AMDCLANG_HINTS}
+        NO_DEFAULT_PATH
+    )
+    find_program(
+        AMDCLANG_C_COMPILER
+        NAMES amdclang
+        HINTS ${_AMDCLANG_HINTS}
+        NO_DEFAULT_PATH
+    )
+
+    # Helper function to validate compiler executability
+    function(validate_compiler COMPILER_PATH RESULT_VAR)
+        execute_process(
+            COMMAND "${COMPILER_PATH}" --version
+            RESULT_VARIABLE TEST_RESULT
+            OUTPUT_QUIET ERROR_QUIET
+        )
+        if(TEST_RESULT EQUAL 0)
+            set(${RESULT_VAR} TRUE PARENT_SCOPE)
+        else()
+            set(${RESULT_VAR} FALSE PARENT_SCOPE)
+        endif()
+    endfunction()
+
+    # Try compilers in priority order: amdclang++ > clang++
+    if(AMDCLANG_CXX_COMPILER AND AMDCLANG_C_COMPILER)
+        validate_compiler("${AMDCLANG_CXX_COMPILER}" AMDCLANG_CXX_VALID)
+        validate_compiler("${AMDCLANG_C_COMPILER}" AMDCLANG_C_VALID)
+        if(NOT AMDCLANG_CXX_VALID OR NOT AMDCLANG_C_VALID)
+            message(WARNING "Found amdclang compilers but one or both are not executable, trying clang")
+            unset(AMDCLANG_CXX_COMPILER CACHE)
+            unset(AMDCLANG_C_COMPILER CACHE)
+        endif()
+    endif()
+
+    if(AMDCLANG_CXX_COMPILER AND AMDCLANG_C_COMPILER)
+        set(CMAKE_CXX_COMPILER "${AMDCLANG_CXX_COMPILER}" CACHE FILEPATH "C++ compiler")
+        set(CMAKE_C_COMPILER "${AMDCLANG_C_COMPILER}" CACHE FILEPATH "C compiler")
+        message(STATUS "Using AMD Clang compiler: ${AMDCLANG_CXX_COMPILER}")
+    else()
+        # Fall back to clang++.
+        # ROCm installed -> ROCm paths only (no system fallback).
+        # ROCm absent     -> system PATH.
+        if(ROCM_DIR)
+            find_program(
+                CLANG_CXX_COMPILER
+                NAMES clang++
+                HINTS ${_AMDCLANG_HINTS}
+                NO_DEFAULT_PATH
+            )
+            find_program(
+                CLANG_C_COMPILER
+                NAMES clang
+                HINTS ${_AMDCLANG_HINTS}
+                NO_DEFAULT_PATH
+            )
+        else()
+            find_program(CLANG_CXX_COMPILER NAMES clang++)
+            find_program(CLANG_C_COMPILER NAMES clang)
+        endif()
+
+        if(CLANG_CXX_COMPILER AND CLANG_C_COMPILER)
+            validate_compiler("${CLANG_CXX_COMPILER}" CLANG_CXX_VALID)
+            validate_compiler("${CLANG_C_COMPILER}" CLANG_C_VALID)
+            if(NOT CLANG_CXX_VALID OR NOT CLANG_C_VALID)
+                message(WARNING "Found clang compilers but one or both are not executable")
+                unset(CLANG_CXX_COMPILER CACHE)
+                unset(CLANG_C_COMPILER CACHE)
+            endif()
+        endif()
+
+        if(CLANG_CXX_COMPILER AND CLANG_C_COMPILER)
+            set(CMAKE_CXX_COMPILER "${CLANG_CXX_COMPILER}" CACHE FILEPATH "C++ compiler")
+            set(CMAKE_C_COMPILER "${CLANG_C_COMPILER}" CACHE FILEPATH "C compiler")
+            if(ROCM_DIR)
+                message(STATUS "Using ROCm Clang compiler: ${CLANG_CXX_COMPILER}")
+            else()
+                message(STATUS "Using system Clang compiler: ${CLANG_CXX_COMPILER}")
+            endif()
+        else()
+            # No clang++ found in the searched location(s).
+            # ROCm installed -> only ROCm dirs were searched, so system clang won't help.
+            if(ROCM_DIR)
+                set(_COMPILER_FIX_HINT
+                    "  1. Install ROCm's LLVM/clang component under ${ROCM_DIR}\n")
+            else()
+                set(_COMPILER_FIX_HINT
+                    "  1. Install clang: sudo apt install clang (Ubuntu/Debian)\n"
+                    "  2. Or install ROCm from https://rocm.docs.amd.com/\n")
+            endif()
+            message(
+                FATAL_ERROR
+                "No suitable C++ compiler found (amdclang++ or clang++).\n"
+                "\n"
+                "Current search status:\n"
+                "  hipconfig found: ${HIPCONFIG_EXECUTABLE}\n"
+                "  ROCM_DIR: ${ROCM_DIR}\n"
+                "  ROCm search paths: ${_AMDCLANG_HINTS}\n"
+                "\n"
+                "To fix this:\n"
+                ${_COMPILER_FIX_HINT}
+                "\n"
+                "Alternative compiler options:\n"
+                "  - To build with GCC, use toolchain file:\n"
+                "      cmake .. -DCMAKE_TOOLCHAIN_FILE=../cmake/toolchains/amdsmi-gcc-toolchain.cmake\n"
+                "  - Or explicitly specify compiler:\n"
+                "      cmake .. -DCMAKE_CXX_COMPILER=g++ -DCMAKE_C_COMPILER=gcc"
+            )
+        endif()
+    endif()
+endif()
+
 set(AMD_SMI "amd_smi")
 set(AMD_SMI_LIBS_TARGET "${AMD_SMI}_lib")
 set(CPACK_PACKAGE_NAME amd-smi-lib CACHE STRING "")

--- a/projects/amdsmi/CMakeLists.txt
+++ b/projects/amdsmi/CMakeLists.txt
@@ -26,18 +26,46 @@ cmake_minimum_required(VERSION 3.20)
 
 #
 # --- Compiler detection (Clang family only) ---
-# Default: amdclang++ (ROCm) > system clang++/clang
+# Default: amdclang++ (ROCm) > clang++ (ROCm only)
 # GCC is not auto-selected. To build with GCC, use a toolchain file:
 #   cmake .. -DCMAKE_TOOLCHAIN_FILE=../cmake/toolchains/amdsmi-gcc-toolchain.cmake
 #
-# See: cmake/toolchains/amdsmi-gcc-toolchain.cmake
+# ROCm discovery:
+#   Uses hipconfig --path for tool-based discovery (per TheRock #3976)
+#   No hardcoded paths or ROCM_PATH fallback
 #
-if(NOT CMAKE_CXX_COMPILER OR NOT CMAKE_C_COMPILER)
-    # Determine ROCm installation path
-    if(DEFINED ENV{ROCM_PATH})
-        set(ROCM_DIR "$ENV{ROCM_PATH}")
-    elseif(EXISTS "/opt/rocm")
-        set(ROCM_DIR "/opt/rocm")
+# Once ROCm is located, searches for compilers in these paths (in order):
+#   1. <rocm-path>/lib/llvm/bin/amdclang++  (current standard location)
+#   2. <rocm-path>/llvm/bin/amdclang++      (legacy symlink location)
+#
+# If amdclang++ not found, searches for clang++ in the same ROCm paths:
+#   1. <rocm-path>/lib/llvm/bin/clang++
+#   2. <rocm-path>/llvm/bin/clang++
+#
+# Build fails if no ROCm compiler found.
+#
+# See: cmake/toolchains/amdsmi-gcc-toolchain.cmake
+# See also: https://github.com/ROCm/TheRock/issues/3976
+#
+if(NOT CMAKE_TOOLCHAIN_FILE AND (NOT DEFINED CMAKE_CXX_COMPILER OR NOT DEFINED CMAKE_C_COMPILER))
+    # Determine ROCm installation path using tool-based discovery
+    # Uses hipconfig --path (per https://github.com/ROCm/TheRock/issues/3976)
+    set(ROCM_DIR "")
+
+    find_program(HIPCONFIG_EXECUTABLE hipconfig)
+    if(HIPCONFIG_EXECUTABLE)
+        execute_process(
+            COMMAND "${HIPCONFIG_EXECUTABLE}" --path
+            OUTPUT_VARIABLE HIPCONFIG_PATH
+            OUTPUT_STRIP_TRAILING_WHITESPACE
+            ERROR_QUIET
+        )
+        if(HIPCONFIG_PATH)
+            set(ROCM_DIR "${HIPCONFIG_PATH}")
+            if(CMAKE_VERBOSE_MAKEFILE)
+                message(STATUS "Found ROCm via hipconfig: ${ROCM_DIR}")
+            endif()
+        endif()
     endif()
 
     if(CMAKE_VERBOSE_MAKEFILE)
@@ -45,13 +73,13 @@ if(NOT CMAKE_CXX_COMPILER OR NOT CMAKE_C_COMPILER)
     endif()
 
     # Search for amdclang++ in ROCm installation
+    # Prefer lib/llvm/bin (current) over llvm/bin (legacy)
     set(_AMDCLANG_HINTS "")
     if(ROCM_DIR)
         list(
             APPEND _AMDCLANG_HINTS
-            "${ROCM_DIR}/llvm/bin"
             "${ROCM_DIR}/lib/llvm/bin"
-            "${ROCM_DIR}/bin"
+            "${ROCM_DIR}/llvm/bin"
         )
     endif()
 
@@ -82,7 +110,7 @@ if(NOT CMAKE_CXX_COMPILER OR NOT CMAKE_C_COMPILER)
         endif()
     endfunction()
 
-    # Try compilers in priority order
+    # Try compilers in priority order: amdclang++ > clang++
     if(AMDCLANG_CXX_COMPILER AND AMDCLANG_C_COMPILER)
         validate_compiler("${AMDCLANG_CXX_COMPILER}" AMDCLANG_CXX_VALID)
         validate_compiler("${AMDCLANG_C_COMPILER}" AMDCLANG_C_VALID)
@@ -98,8 +126,19 @@ if(NOT CMAKE_CXX_COMPILER OR NOT CMAKE_C_COMPILER)
         set(CMAKE_C_COMPILER "${AMDCLANG_C_COMPILER}" CACHE FILEPATH "C compiler")
         message(STATUS "Using AMD Clang compiler: ${AMDCLANG_CXX_COMPILER}")
     else()
-        find_program(CLANG_CXX_COMPILER NAMES clang++)
-        find_program(CLANG_C_COMPILER NAMES clang)
+        # Search for clang++ in ROCm paths only (not system PATH)
+        find_program(
+            CLANG_CXX_COMPILER
+            NAMES clang++
+            HINTS ${_AMDCLANG_HINTS}
+            NO_DEFAULT_PATH
+        )
+        find_program(
+            CLANG_C_COMPILER
+            NAMES clang
+            HINTS ${_AMDCLANG_HINTS}
+            NO_DEFAULT_PATH
+        )
 
         if(CLANG_CXX_COMPILER AND CLANG_C_COMPILER)
             validate_compiler("${CLANG_CXX_COMPILER}" CLANG_CXX_VALID)
@@ -114,15 +153,28 @@ if(NOT CMAKE_CXX_COMPILER OR NOT CMAKE_C_COMPILER)
         if(CLANG_CXX_COMPILER AND CLANG_C_COMPILER)
             set(CMAKE_CXX_COMPILER "${CLANG_CXX_COMPILER}" CACHE FILEPATH "C++ compiler")
             set(CMAKE_C_COMPILER "${CLANG_C_COMPILER}" CACHE FILEPATH "C compiler")
-            message(STATUS "Using system Clang compiler: ${CLANG_CXX_COMPILER}")
+            message(STATUS "Using Clang compiler: ${CLANG_CXX_COMPILER}")
         else()
             message(
                 FATAL_ERROR
-                "No suitable C++ compiler found (amdclang++ or clang++).\n"
-                "To build with GCC, use a toolchain file:\n"
-                "  cmake .. -DCMAKE_TOOLCHAIN_FILE=../cmake/toolchains/amdsmi-gcc-toolchain.cmake\n"
+                "No suitable C++ compiler found in ROCm installation.\n"
+                "Neither amdclang++ nor clang++ found in ROCm paths.\n"
                 "\n"
-                "For ROCm compatibility, install ROCm from https://rocm.docs.amd.com/"
+                "Current search status:\n"
+                "  hipconfig found: ${HIPCONFIG_EXECUTABLE}\n"
+                "  ROCM_DIR: ${ROCM_DIR}\n"
+                "  Search paths tried: ${_AMDCLANG_HINTS}\n"
+                "\n"
+                "To fix this:\n"
+                "  1. Install ROCm from https://rocm.docs.amd.com/\n"
+                "  2. Ensure hipconfig is in your PATH:\n"
+                "       export PATH=\$PATH:/opt/rocm/bin\n"
+                "\n"
+                "Alternative compiler options:\n"
+                "  - To build with GCC, use toolchain file:\n"
+                "      cmake .. -DCMAKE_TOOLCHAIN_FILE=../cmake/toolchains/amdsmi-gcc-toolchain.cmake\n"
+                "  - To use system clang++, explicitly specify with full path:\n"
+                "      cmake .. -DCMAKE_CXX_COMPILER=/usr/bin/clang++ -DCMAKE_C_COMPILER=/usr/bin/clang"
             )
         endif()
     endif()

--- a/projects/amdsmi/CMakeLists.txt
+++ b/projects/amdsmi/CMakeLists.txt
@@ -24,6 +24,95 @@
 #
 cmake_minimum_required(VERSION 3.20)
 
+#
+# --- Compiler Detection and Selection ---
+# Priority: amdclang++ > clang++ > gcc (legacy, with warning)
+#
+if(NOT CMAKE_CXX_COMPILER)
+    # Determine ROCm installation path
+    if(DEFINED ENV{ROCM_PATH})
+        set(ROCM_DIR "$ENV{ROCM_PATH}")
+    elseif(EXISTS "/opt/rocm")
+        set(ROCM_DIR "/opt/rocm")
+    endif()
+
+    if(CMAKE_VERBOSE_MAKEFILE)
+        message(STATUS "Compiler auto-detection: ROCM_DIR=${ROCM_DIR}")
+    endif()
+
+    # Search for amdclang++ in ROCm installation
+    find_program(
+        AMDCLANG_CXX_COMPILER
+        NAMES amdclang++
+        HINTS "${ROCM_DIR}/llvm/bin" "${ROCM_DIR}/lib/llvm/bin" "${ROCM_DIR}/bin"
+        NO_DEFAULT_PATH
+    )
+    find_program(
+        AMDCLANG_C_COMPILER
+        NAMES amdclang
+        HINTS "${ROCM_DIR}/llvm/bin" "${ROCM_DIR}/lib/llvm/bin" "${ROCM_DIR}/bin"
+        NO_DEFAULT_PATH
+    )
+
+    # Try compilers in priority order
+    if(AMDCLANG_CXX_COMPILER AND AMDCLANG_C_COMPILER)
+        # Verify amdclang++ is executable
+        execute_process(
+            COMMAND "${AMDCLANG_CXX_COMPILER}" --version
+            RESULT_VARIABLE AMDCLANG_TEST_RESULT
+            OUTPUT_QUIET ERROR_QUIET
+        )
+        if(NOT AMDCLANG_TEST_RESULT EQUAL 0)
+            message(WARNING "Found amdclang++ but it's not executable, trying clang++")
+            unset(AMDCLANG_CXX_COMPILER)
+            unset(AMDCLANG_C_COMPILER)
+        endif()
+    endif()
+
+    if(AMDCLANG_CXX_COMPILER AND AMDCLANG_C_COMPILER)
+        set(CMAKE_CXX_COMPILER "${AMDCLANG_CXX_COMPILER}" CACHE FILEPATH "C++ compiler")
+        set(CMAKE_C_COMPILER "${AMDCLANG_C_COMPILER}" CACHE FILEPATH "C compiler")
+        message(STATUS "Using AMD Clang compiler: ${AMDCLANG_CXX_COMPILER}")
+    else()
+        find_program(CLANG_CXX_COMPILER NAMES clang++)
+        find_program(CLANG_C_COMPILER NAMES clang)
+
+        if(CLANG_CXX_COMPILER AND CLANG_C_COMPILER)
+            set(CMAKE_CXX_COMPILER "${CLANG_CXX_COMPILER}" CACHE FILEPATH "C++ compiler")
+            set(CMAKE_C_COMPILER "${CLANG_C_COMPILER}" CACHE FILEPATH "C compiler")
+            message(STATUS "Using system Clang compiler: ${CLANG_CXX_COMPILER}")
+        else()
+            find_program(GCC_CXX_COMPILER NAMES g++)
+            find_program(GCC_C_COMPILER NAMES gcc)
+
+            if(GCC_CXX_COMPILER AND GCC_C_COMPILER)
+                set(CMAKE_CXX_COMPILER "${GCC_CXX_COMPILER}" CACHE FILEPATH "C++ compiler")
+                set(CMAKE_C_COMPILER "${GCC_C_COMPILER}" CACHE FILEPATH "C compiler")
+                message(
+                    WARNING
+                    "===================================================================="
+                )
+                message(
+                    WARNING "Neither amdclang++ nor clang++ found. Falling back to GCC."
+                )
+                message(WARNING "For optimal ROCm compatibility:")
+                message(WARNING "  - Install ROCm from https://rocm.docs.amd.com/")
+                message(WARNING "  - Or set ROCM_PATH environment variable")
+                message(
+                    WARNING
+                    "===================================================================="
+                )
+                message(STATUS "Using GCC compiler (legacy): ${GCC_CXX_COMPILER}")
+            else()
+                message(
+                    FATAL_ERROR
+                    "No suitable C++ compiler found. Please install amdclang++, clang++, or g++"
+                )
+            endif()
+        endif()
+    endif()
+endif()
+
 set(AMD_SMI "amd_smi")
 set(AMD_SMI_LIBS_TARGET "${AMD_SMI}_lib")
 set(CPACK_PACKAGE_NAME amd-smi-lib CACHE STRING "")

--- a/projects/amdsmi/CMakeLists.txt
+++ b/projects/amdsmi/CMakeLists.txt
@@ -27,8 +27,8 @@ cmake_minimum_required(VERSION 3.20)
 #
 # --- Compiler detection (Clang family only) ---
 # Default: amdclang++ (ROCm) > system clang++/clang
-# GCC is not auto-selected. To build with GCC, use a toolchain file
-# cmake .. -DCMAKE_TOOLCHAIN_FILE="../cmake/toolchains/amdsmi-gcc-toolchain.cmake"
+# GCC is not auto-selected. To build with GCC, use a toolchain file:
+#   cmake .. -DCMAKE_TOOLCHAIN_FILE=../cmake/toolchains/amdsmi-gcc-toolchain.cmake
 #
 # See: cmake/toolchains/amdsmi-gcc-toolchain.cmake
 #
@@ -84,9 +84,10 @@ if(NOT CMAKE_CXX_COMPILER OR NOT CMAKE_C_COMPILER)
 
     # Try compilers in priority order
     if(AMDCLANG_CXX_COMPILER AND AMDCLANG_C_COMPILER)
-        validate_compiler("${AMDCLANG_CXX_COMPILER}" AMDCLANG_VALID)
-        if(NOT AMDCLANG_VALID)
-            message(WARNING "Found amdclang++ but it's not executable, trying clang++")
+        validate_compiler("${AMDCLANG_CXX_COMPILER}" AMDCLANG_CXX_VALID)
+        validate_compiler("${AMDCLANG_C_COMPILER}" AMDCLANG_C_VALID)
+        if(NOT AMDCLANG_CXX_VALID OR NOT AMDCLANG_C_VALID)
+            message(WARNING "Found amdclang compilers but one or both are not executable, trying clang")
             unset(AMDCLANG_CXX_COMPILER CACHE)
             unset(AMDCLANG_C_COMPILER CACHE)
         endif()
@@ -101,9 +102,10 @@ if(NOT CMAKE_CXX_COMPILER OR NOT CMAKE_C_COMPILER)
         find_program(CLANG_C_COMPILER NAMES clang)
 
         if(CLANG_CXX_COMPILER AND CLANG_C_COMPILER)
-            validate_compiler("${CLANG_CXX_COMPILER}" CLANG_VALID)
-            if(NOT CLANG_VALID)
-                message(WARNING "Found clang++ but it's not executable")
+            validate_compiler("${CLANG_CXX_COMPILER}" CLANG_CXX_VALID)
+            validate_compiler("${CLANG_C_COMPILER}" CLANG_C_VALID)
+            if(NOT CLANG_CXX_VALID OR NOT CLANG_C_VALID)
+                message(WARNING "Found clang compilers but one or both are not executable")
                 unset(CLANG_CXX_COMPILER CACHE)
                 unset(CLANG_C_COMPILER CACHE)
             endif()
@@ -118,7 +120,7 @@ if(NOT CMAKE_CXX_COMPILER OR NOT CMAKE_C_COMPILER)
                 FATAL_ERROR
                 "No suitable C++ compiler found (amdclang++ or clang++).\n"
                 "To build with GCC, use a toolchain file:\n"
-                "  cmake .. -DCMAKE_TOOLCHAIN_FILE=cmake/toolchains/amdsmi-gcc-toolchain.cmake\n"
+                "  cmake .. -DCMAKE_TOOLCHAIN_FILE=../cmake/toolchains/amdsmi-gcc-toolchain.cmake\n"
                 "\n"
                 "For ROCm compatibility, install ROCm from https://rocm.docs.amd.com/"
             )

--- a/projects/amdsmi/CMakeLists.txt
+++ b/projects/amdsmi/CMakeLists.txt
@@ -26,7 +26,7 @@ cmake_minimum_required(VERSION 3.20)
 
 #
 # --- Compiler detection (Clang family only) ---
-# Default: amdclang++ (ROCm) > clang++ (ROCm only)
+# Default: amdclang++ > clang++ (strict ROCm vs system separation)
 # GCC is not auto-selected. To build with GCC, use a toolchain file:
 #   cmake .. -DCMAKE_TOOLCHAIN_FILE=../cmake/toolchains/amdsmi-gcc-toolchain.cmake
 #
@@ -34,20 +34,23 @@ cmake_minimum_required(VERSION 3.20)
 #   Uses hipconfig --path for tool-based discovery (per TheRock #3976)
 #   No hardcoded paths or ROCM_PATH fallback
 #
-# Once ROCm is located, searches for compilers in these paths (in order):
-#   1. <rocm-path>/lib/llvm/bin/amdclang++  (current standard location)
-#   2. <rocm-path>/llvm/bin/amdclang++      (legacy symlink location)
+# If ROCm installed (hipconfig found):
+#   Searches ONLY in ROCm paths (NO system PATH fallback):
+#     1. <rocm-path>/lib/llvm/bin/amdclang++  (current standard)
+#     2. <rocm-path>/llvm/bin/amdclang++      (legacy)
+#     3. <rocm-path>/lib/llvm/bin/clang++     (ROCm clang++)
+#     4. <rocm-path>/llvm/bin/clang++         (ROCm clang++ legacy)
 #
-# If amdclang++ not found, searches for clang++ in the same ROCm paths:
-#   1. <rocm-path>/lib/llvm/bin/clang++
-#   2. <rocm-path>/llvm/bin/clang++
+# If ROCm NOT installed (hipconfig not found):
+#   Searches ONLY in system PATH:
+#     - /usr/bin/clang++ (or wherever system clang++ is)
 #
-# Build fails if no ROCm compiler found.
+# Build fails if no suitable compiler found.
 #
 # See: cmake/toolchains/amdsmi-gcc-toolchain.cmake
 # See also: https://github.com/ROCm/TheRock/issues/3976
 #
-if(NOT CMAKE_TOOLCHAIN_FILE AND (NOT DEFINED CMAKE_CXX_COMPILER OR NOT DEFINED CMAKE_C_COMPILER))
+if(NOT CMAKE_TOOLCHAIN_FILE AND NOT DEFINED CMAKE_CXX_COMPILER AND NOT DEFINED CMAKE_C_COMPILER)
     # Determine ROCm installation path using tool-based discovery
     # Uses hipconfig --path (per https://github.com/ROCm/TheRock/issues/3976)
     set(ROCM_DIR "")
@@ -62,14 +65,8 @@ if(NOT CMAKE_TOOLCHAIN_FILE AND (NOT DEFINED CMAKE_CXX_COMPILER OR NOT DEFINED C
         )
         if(HIPCONFIG_PATH)
             set(ROCM_DIR "${HIPCONFIG_PATH}")
-            if(CMAKE_VERBOSE_MAKEFILE)
-                message(STATUS "Found ROCm via hipconfig: ${ROCM_DIR}")
-            endif()
+            message(STATUS "Found ROCm via hipconfig: ${ROCM_DIR}")
         endif()
-    endif()
-
-    if(CMAKE_VERBOSE_MAKEFILE)
-        message(STATUS "Compiler auto-detection: ROCM_DIR=${ROCM_DIR}")
     endif()
 
     # Search for amdclang++ in ROCm installation
@@ -126,18 +123,17 @@ if(NOT CMAKE_TOOLCHAIN_FILE AND (NOT DEFINED CMAKE_CXX_COMPILER OR NOT DEFINED C
         set(CMAKE_C_COMPILER "${AMDCLANG_C_COMPILER}" CACHE FILEPATH "C compiler")
         message(STATUS "Using AMD Clang compiler: ${AMDCLANG_CXX_COMPILER}")
     else()
-        # Search for clang++ in ROCm paths only (not system PATH)
+        # Search for clang++ - prefer ROCm paths, fall back to system
+        # HINTS are checked first, then system PATH
         find_program(
             CLANG_CXX_COMPILER
             NAMES clang++
             HINTS ${_AMDCLANG_HINTS}
-            NO_DEFAULT_PATH
         )
         find_program(
             CLANG_C_COMPILER
             NAMES clang
             HINTS ${_AMDCLANG_HINTS}
-            NO_DEFAULT_PATH
         )
 
         if(CLANG_CXX_COMPILER AND CLANG_C_COMPILER)
@@ -153,28 +149,32 @@ if(NOT CMAKE_TOOLCHAIN_FILE AND (NOT DEFINED CMAKE_CXX_COMPILER OR NOT DEFINED C
         if(CLANG_CXX_COMPILER AND CLANG_C_COMPILER)
             set(CMAKE_CXX_COMPILER "${CLANG_CXX_COMPILER}" CACHE FILEPATH "C++ compiler")
             set(CMAKE_C_COMPILER "${CLANG_C_COMPILER}" CACHE FILEPATH "C compiler")
-            message(STATUS "Using Clang compiler: ${CLANG_CXX_COMPILER}")
+            # Detect if compiler is from ROCm or system by checking path
+            if(ROCM_DIR AND "${CLANG_CXX_COMPILER}" MATCHES "${ROCM_DIR}")
+                message(STATUS "Using ROCm Clang compiler: ${CLANG_CXX_COMPILER}")
+            else()
+                message(STATUS "Using system Clang compiler: ${CLANG_CXX_COMPILER}")
+            endif()
         else()
+            # No clang++ found anywhere (ROCm or system)
             message(
                 FATAL_ERROR
-                "No suitable C++ compiler found in ROCm installation.\n"
-                "Neither amdclang++ nor clang++ found in ROCm paths.\n"
+                "No suitable C++ compiler found (amdclang++ or clang++).\n"
                 "\n"
                 "Current search status:\n"
                 "  hipconfig found: ${HIPCONFIG_EXECUTABLE}\n"
                 "  ROCM_DIR: ${ROCM_DIR}\n"
-                "  Search paths tried: ${_AMDCLANG_HINTS}\n"
+                "  ROCm search paths: ${_AMDCLANG_HINTS}\n"
                 "\n"
                 "To fix this:\n"
-                "  1. Install ROCm from https://rocm.docs.amd.com/\n"
-                "  2. Ensure hipconfig is in your PATH:\n"
-                "       export PATH=\$PATH:/opt/rocm/bin\n"
+                "  1. Install clang: sudo apt install clang (Ubuntu/Debian)\n"
+                "  2. Or install ROCm from https://rocm.docs.amd.com/\n"
                 "\n"
                 "Alternative compiler options:\n"
                 "  - To build with GCC, use toolchain file:\n"
                 "      cmake .. -DCMAKE_TOOLCHAIN_FILE=../cmake/toolchains/amdsmi-gcc-toolchain.cmake\n"
-                "  - To use system clang++, explicitly specify with full path:\n"
-                "      cmake .. -DCMAKE_CXX_COMPILER=/usr/bin/clang++ -DCMAKE_C_COMPILER=/usr/bin/clang"
+                "  - Or explicitly specify compiler:\n"
+                "      cmake .. -DCMAKE_CXX_COMPILER=g++ -DCMAKE_C_COMPILER=gcc"
             )
         endif()
     endif()

--- a/projects/amdsmi/CMakeLists.txt
+++ b/projects/amdsmi/CMakeLists.txt
@@ -25,10 +25,14 @@
 cmake_minimum_required(VERSION 3.20)
 
 #
-# --- Compiler Detection and Selection ---
-# Priority: amdclang++ > clang++ > gcc (legacy, with warning)
+# --- Compiler detection (Clang family only) ---
+# Default: amdclang++ (ROCm) > system clang++/clang
+# GCC is not auto-selected. To build with GCC, use a toolchain file
+# cmake .. -DCMAKE_TOOLCHAIN_FILE="../cmake/toolchains/amdsmi-gcc-toolchain.cmake"
 #
-if(NOT CMAKE_CXX_COMPILER)
+# See: cmake/toolchains/amdsmi-gcc-toolchain.cmake
+#
+if(NOT CMAKE_CXX_COMPILER OR NOT CMAKE_C_COMPILER)
     # Determine ROCm installation path
     if(DEFINED ENV{ROCM_PATH})
         set(ROCM_DIR "$ENV{ROCM_PATH}")
@@ -41,31 +45,50 @@ if(NOT CMAKE_CXX_COMPILER)
     endif()
 
     # Search for amdclang++ in ROCm installation
+    set(_AMDCLANG_HINTS "")
+    if(ROCM_DIR)
+        list(
+            APPEND _AMDCLANG_HINTS
+            "${ROCM_DIR}/llvm/bin"
+            "${ROCM_DIR}/lib/llvm/bin"
+            "${ROCM_DIR}/bin"
+        )
+    endif()
+
     find_program(
         AMDCLANG_CXX_COMPILER
         NAMES amdclang++
-        HINTS "${ROCM_DIR}/llvm/bin" "${ROCM_DIR}/lib/llvm/bin" "${ROCM_DIR}/bin"
+        HINTS ${_AMDCLANG_HINTS}
         NO_DEFAULT_PATH
     )
     find_program(
         AMDCLANG_C_COMPILER
         NAMES amdclang
-        HINTS "${ROCM_DIR}/llvm/bin" "${ROCM_DIR}/lib/llvm/bin" "${ROCM_DIR}/bin"
+        HINTS ${_AMDCLANG_HINTS}
         NO_DEFAULT_PATH
     )
 
-    # Try compilers in priority order
-    if(AMDCLANG_CXX_COMPILER AND AMDCLANG_C_COMPILER)
-        # Verify amdclang++ is executable
+    # Helper function to validate compiler executability
+    function(validate_compiler COMPILER_PATH RESULT_VAR)
         execute_process(
-            COMMAND "${AMDCLANG_CXX_COMPILER}" --version
-            RESULT_VARIABLE AMDCLANG_TEST_RESULT
+            COMMAND "${COMPILER_PATH}" --version
+            RESULT_VARIABLE TEST_RESULT
             OUTPUT_QUIET ERROR_QUIET
         )
-        if(NOT AMDCLANG_TEST_RESULT EQUAL 0)
+        if(TEST_RESULT EQUAL 0)
+            set(${RESULT_VAR} TRUE PARENT_SCOPE)
+        else()
+            set(${RESULT_VAR} FALSE PARENT_SCOPE)
+        endif()
+    endfunction()
+
+    # Try compilers in priority order
+    if(AMDCLANG_CXX_COMPILER AND AMDCLANG_C_COMPILER)
+        validate_compiler("${AMDCLANG_CXX_COMPILER}" AMDCLANG_VALID)
+        if(NOT AMDCLANG_VALID)
             message(WARNING "Found amdclang++ but it's not executable, trying clang++")
-            unset(AMDCLANG_CXX_COMPILER)
-            unset(AMDCLANG_C_COMPILER)
+            unset(AMDCLANG_CXX_COMPILER CACHE)
+            unset(AMDCLANG_C_COMPILER CACHE)
         endif()
     endif()
 
@@ -78,37 +101,27 @@ if(NOT CMAKE_CXX_COMPILER)
         find_program(CLANG_C_COMPILER NAMES clang)
 
         if(CLANG_CXX_COMPILER AND CLANG_C_COMPILER)
+            validate_compiler("${CLANG_CXX_COMPILER}" CLANG_VALID)
+            if(NOT CLANG_VALID)
+                message(WARNING "Found clang++ but it's not executable")
+                unset(CLANG_CXX_COMPILER CACHE)
+                unset(CLANG_C_COMPILER CACHE)
+            endif()
+        endif()
+
+        if(CLANG_CXX_COMPILER AND CLANG_C_COMPILER)
             set(CMAKE_CXX_COMPILER "${CLANG_CXX_COMPILER}" CACHE FILEPATH "C++ compiler")
             set(CMAKE_C_COMPILER "${CLANG_C_COMPILER}" CACHE FILEPATH "C compiler")
             message(STATUS "Using system Clang compiler: ${CLANG_CXX_COMPILER}")
         else()
-            find_program(GCC_CXX_COMPILER NAMES g++)
-            find_program(GCC_C_COMPILER NAMES gcc)
-
-            if(GCC_CXX_COMPILER AND GCC_C_COMPILER)
-                set(CMAKE_CXX_COMPILER "${GCC_CXX_COMPILER}" CACHE FILEPATH "C++ compiler")
-                set(CMAKE_C_COMPILER "${GCC_C_COMPILER}" CACHE FILEPATH "C compiler")
-                message(
-                    WARNING
-                    "===================================================================="
-                )
-                message(
-                    WARNING "Neither amdclang++ nor clang++ found. Falling back to GCC."
-                )
-                message(WARNING "For optimal ROCm compatibility:")
-                message(WARNING "  - Install ROCm from https://rocm.docs.amd.com/")
-                message(WARNING "  - Or set ROCM_PATH environment variable")
-                message(
-                    WARNING
-                    "===================================================================="
-                )
-                message(STATUS "Using GCC compiler (legacy): ${GCC_CXX_COMPILER}")
-            else()
-                message(
-                    FATAL_ERROR
-                    "No suitable C++ compiler found. Please install amdclang++, clang++, or g++"
-                )
-            endif()
+            message(
+                FATAL_ERROR
+                "No suitable C++ compiler found (amdclang++ or clang++).\n"
+                "To build with GCC, use a toolchain file:\n"
+                "  cmake .. -DCMAKE_TOOLCHAIN_FILE=cmake/toolchains/amdsmi-gcc-toolchain.cmake\n"
+                "\n"
+                "For ROCm compatibility, install ROCm from https://rocm.docs.amd.com/"
+            )
         endif()
     endif()
 endif()

--- a/projects/amdsmi/README.md
+++ b/projects/amdsmi/README.md
@@ -37,6 +37,86 @@ The following are required to install and use the AMD SMI library through its la
   export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/opt/rocm/lib:/opt/rocm/lib64
   ```
 
+### Build requirements
+
+AMD SMI automatically selects the best available Clang compiler in the following priority order:
+
+1. **amdclang++** (recommended) - AMD's optimized Clang compiler from ROCm
+2. **clang++** - ROCm's clang++ if ROCm is installed, otherwise system clang++
+
+**GCC is supported but not auto-selected.** To build with GCC, use a toolchain file (see below).
+
+#### Standard build
+
+```bash
+mkdir -p build
+cd build
+cmake ..          # Automatically selects: amdclang++ → clang++
+make -j $(nproc)
+make install
+```
+
+#### How compilers are discovered
+
+The build uses **`hipconfig --path`** for tool-based ROCm discovery.
+
+**If ROCm is installed** (hipconfig found):
+- Searches **ONLY in ROCm paths** for compilers (in order):
+  1. `<rocm-path>/lib/llvm/bin/amdclang++` - Current standard location
+  2. `<rocm-path>/llvm/bin/amdclang++` - Legacy symlink location
+  3. `<rocm-path>/lib/llvm/bin/clang++` - ROCm clang++
+  4. `<rocm-path>/llvm/bin/clang++` - ROCm clang++ (legacy)
+- **Does NOT fall back to system clang++** - ensures ROCm compiler is used
+
+**If ROCm is NOT installed** (hipconfig not found):
+- Searches **ONLY in system PATH** for `clang++` (e.g., `/usr/bin/clang++`)
+- This allows builds on systems without ROCm
+
+**Note:** Hardcoded paths like `/opt/rocm` are intentionally not used to support multiple ROCm installations and relocatable builds.
+
+#### Building with GCC
+
+To build with GCC instead of Clang, use the provided toolchain file:
+
+```bash
+mkdir -p build
+cd build
+cmake .. -DCMAKE_TOOLCHAIN_FILE=../cmake/toolchains/amdsmi-gcc-toolchain.cmake
+make -j $(nproc)
+```
+
+To use a specific GCC version, edit `cmake/toolchains/amdsmi-gcc-toolchain.cmake` or create your own toolchain file.
+
+#### Troubleshooting
+
+**If cmake fails with "amdclang++ not found":**
+
+```bash
+# Check if ROCm is installed and hipconfig is available
+which hipconfig
+hipconfig --path
+
+# If hipconfig not found, add ROCm to PATH
+export PATH=$PATH:/opt/rocm/bin
+cmake ..
+```
+
+**To use a different compiler:**
+
+```bash
+# Use GCC via toolchain file (recommended)
+cmake .. -DCMAKE_TOOLCHAIN_FILE=../cmake/toolchains/amdsmi-gcc-toolchain.cmake
+
+# Or explicitly specify GCC
+cmake .. -DCMAKE_CXX_COMPILER=g++ -DCMAKE_C_COMPILER=gcc
+
+# Or explicitly specify ROCm clang++ (instead of amdclang++)
+cmake .. -DCMAKE_CXX_COMPILER=/opt/rocm-<version_number>/lib/llvm/bin/clang++ -DCMAKE_C_COMPILER=/opt/rocm-<version_number>/lib/llvm/bin/clang
+
+# Or explicitly specify system clang++ (requires clang installed: sudo apt install clang)
+cmake .. -DCMAKE_CXX_COMPILER=/usr/bin/clang++ -DCMAKE_C_COMPILER=/usr/bin/clang
+```
+
 ### Python interface and CLI tool prerequisites
 
 * Python 3.6.8+ (64-bit)

--- a/projects/amdsmi/README.md
+++ b/projects/amdsmi/README.md
@@ -39,20 +39,19 @@ The following are required to install and use the AMD SMI library through its la
 
 ### Build requirements
 
-AMD SMI automatically selects the best available compiler in the following priority order:
+AMD SMI automatically selects the best available Clang compiler in the following priority order:
 
 1. **amdclang++** (recommended) - AMD's optimized Clang compiler from ROCm installation
 2. **clang++** - System Clang compiler
-3. **g++** - GCC compiler (legacy, with warning)
 
-**No compiler flags are required.** The build system automatically detects and uses the best available compiler.
+**GCC is supported but not auto-selected.** To build with GCC, use a toolchain file (see below).
 
 #### Standard build
 
 ```bash
 mkdir -p build
 cd build
-cmake ..          # Automatically selects: amdclang++ → clang++ → gcc
+cmake ..          # Automatically selects: amdclang++ → clang++
 make -j $(nproc)
 make install
 ```
@@ -64,13 +63,26 @@ For optimal ROCm compatibility, install ROCm which includes `amdclang++`. The bu
 - `/opt/rocm/llvm/bin/amdclang++` (default ROCm installation path)
 - `$ROCM_PATH/lib/llvm/bin/amdclang++` (alternate location)
 
+#### Building with GCC
+
+To build with GCC instead of Clang, use the provided toolchain file:
+
+```bash
+mkdir -p build
+cd build
+cmake .. -DCMAKE_TOOLCHAIN_FILE=../cmake/toolchains/amdsmi-gcc-toolchain.cmake
+make -j $(nproc)
+```
+
+To use a specific GCC version, edit `cmake/toolchains/amdsmi-gcc-toolchain.cmake` or create your own toolchain file.
+
 #### Troubleshooting
 
 If automatic compiler detection fails or you want to use a specific compiler:
 
 ```bash
 # Check which compilers are available
-which amdclang++ clang++ g++
+which amdclang++ clang++
 
 # Explicitly specify compiler (overrides auto-detection)
 cmake -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_C_COMPILER=clang ..

--- a/projects/amdsmi/README.md
+++ b/projects/amdsmi/README.md
@@ -39,10 +39,10 @@ The following are required to install and use the AMD SMI library through its la
 
 ### Build requirements
 
-AMD SMI automatically selects the best available Clang compiler in the following priority order:
+AMD SMI automatically selects the best available Clang compiler from the ROCm installation in the following priority order:
 
-1. **amdclang++** (recommended) - AMD's optimized Clang compiler from ROCm installation
-2. **clang++** - System Clang compiler
+1. **amdclang++** (recommended) - AMD Clang compiler
+2. **clang++** - Standard Clang compiler from ROCm
 
 **GCC is supported but not auto-selected.** To build with GCC, use a toolchain file (see below).
 
@@ -51,17 +51,26 @@ AMD SMI automatically selects the best available Clang compiler in the following
 ```bash
 mkdir -p build
 cd build
-cmake ..          # Automatically selects: amdclang++ → clang++
+cmake ..          # Automatically selects: amdclang++ → ROCm clang++
 make -j $(nproc)
 make install
 ```
 
-#### Compiler search paths
+#### How compilers are discovered
 
-For optimal ROCm compatibility, install ROCm which includes `amdclang++`. The build automatically searches for amdclang++ in:
-- `$ROCM_PATH/llvm/bin/amdclang++` (if `ROCM_PATH` environment variable is set)
-- `/opt/rocm/llvm/bin/amdclang++` (default ROCm installation path)
-- `$ROCM_PATH/lib/llvm/bin/amdclang++` (alternate location)
+The build uses **`hipconfig --path`** for tool-based ROCm discovery.
+
+Once ROCm is located, the build searches for compilers in these paths (in order):
+1. `<rocm-path>/lib/llvm/bin/amdclang++` - Current standard location
+2. `<rocm-path>/llvm/bin/amdclang++` - Legacy symlink location
+
+If `amdclang++` is not found, searches for `clang++` in the same ROCm paths:
+1. `<rocm-path>/lib/llvm/bin/clang++`
+2. `<rocm-path>/llvm/bin/clang++`
+
+**Note:** Only ROCm compilers are auto-selected. System clang++ from `/usr/bin` is NOT used automatically. To use system clang++ or GCC, you must specify them explicitly (see below).
+
+**Note:** Hardcoded paths like `/opt/rocm` are intentionally not used to support multiple ROCm installations and relocatable builds.
 
 #### Building with GCC
 
@@ -78,18 +87,32 @@ To use a specific GCC version, edit `cmake/toolchains/amdsmi-gcc-toolchain.cmake
 
 #### Troubleshooting
 
-If automatic compiler detection fails or you want to use a specific compiler:
+**If cmake fails with "amdclang++ not found":**
 
 ```bash
-# Check which compilers are available
-which amdclang++ clang++
+# Check if ROCm is installed and hipconfig is available
+which hipconfig
+hipconfig --path
 
-# Explicitly specify compiler (overrides auto-detection)
-cmake -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_C_COMPILER=clang ..
-
-# Set custom ROCm path
-export ROCM_PATH=/custom/rocm/path
+# If hipconfig not found, add ROCm to PATH
+export PATH=$PATH:/opt/rocm/bin
 cmake ..
+```
+
+**To use a different compiler:**
+
+```bash
+# Use GCC via toolchain file (recommended)
+cmake .. -DCMAKE_TOOLCHAIN_FILE=../cmake/toolchains/amdsmi-gcc-toolchain.cmake
+
+# Or explicitly specify GCC
+cmake .. -DCMAKE_CXX_COMPILER=g++ -DCMAKE_C_COMPILER=gcc
+
+# Or explicitly specify ROCm clang++ (instead of amdclang++)
+cmake .. -DCMAKE_CXX_COMPILER=/opt/rocm-<version_number>/lib/llvm/bin/clang++ -DCMAKE_C_COMPILER=/opt/rocm-<version_number>/lib/llvm/bin/clang
+
+# Or explicitly specify system clang++ (requires clang installed: sudo apt install clang)
+cmake .. -DCMAKE_CXX_COMPILER=/usr/bin/clang++ -DCMAKE_C_COMPILER=/usr/bin/clang
 ```
 
 ### Python interface and CLI tool prerequisites

--- a/projects/amdsmi/README.md
+++ b/projects/amdsmi/README.md
@@ -39,10 +39,10 @@ The following are required to install and use the AMD SMI library through its la
 
 ### Build requirements
 
-AMD SMI automatically selects the best available Clang compiler from the ROCm installation in the following priority order:
+AMD SMI automatically selects the best available Clang compiler in the following priority order:
 
-1. **amdclang++** (recommended) - AMD Clang compiler
-2. **clang++** - Standard Clang compiler from ROCm
+1. **amdclang++** (recommended) - AMD's optimized Clang compiler from ROCm
+2. **clang++** - ROCm clang++ or system clang++ (fallback)
 
 **GCC is supported but not auto-selected.** To build with GCC, use a toolchain file (see below).
 
@@ -51,7 +51,7 @@ AMD SMI automatically selects the best available Clang compiler from the ROCm in
 ```bash
 mkdir -p build
 cd build
-cmake ..          # Automatically selects: amdclang++ → ROCm clang++
+cmake ..          # Automatically selects: amdclang++ → clang++
 make -j $(nproc)
 make install
 ```
@@ -60,15 +60,17 @@ make install
 
 The build uses **`hipconfig --path`** for tool-based ROCm discovery.
 
-Once ROCm is located, the build searches for compilers in these paths (in order):
-1. `<rocm-path>/lib/llvm/bin/amdclang++` - Current standard location
-2. `<rocm-path>/llvm/bin/amdclang++` - Legacy symlink location
+**If ROCm is installed** (hipconfig found):
+- Searches **ONLY in ROCm paths** for compilers (in order):
+  1. `<rocm-path>/lib/llvm/bin/amdclang++` - Current standard location
+  2. `<rocm-path>/llvm/bin/amdclang++` - Legacy symlink location
+  3. `<rocm-path>/lib/llvm/bin/clang++` - ROCm clang++
+  4. `<rocm-path>/llvm/bin/clang++` - ROCm clang++ (legacy)
+- **Does NOT fall back to system clang++** - ensures ROCm compiler is used
 
-If `amdclang++` is not found, searches for `clang++` in the same ROCm paths:
-1. `<rocm-path>/lib/llvm/bin/clang++`
-2. `<rocm-path>/llvm/bin/clang++`
-
-**Note:** Only ROCm compilers are auto-selected. System clang++ from `/usr/bin` is NOT used automatically. To use system clang++ or GCC, you must specify them explicitly (see below).
+**If ROCm is NOT installed** (hipconfig not found):
+- Searches **ONLY in system PATH** for `clang++` (e.g., `/usr/bin/clang++`)
+- This allows builds on systems without ROCm
 
 **Note:** Hardcoded paths like `/opt/rocm` are intentionally not used to support multiple ROCm installations and relocatable builds.
 

--- a/projects/amdsmi/README.md
+++ b/projects/amdsmi/README.md
@@ -37,6 +37,49 @@ The following are required to install and use the AMD SMI library through its la
   export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/opt/rocm/lib:/opt/rocm/lib64
   ```
 
+### Build requirements
+
+AMD SMI automatically selects the best available compiler in the following priority order:
+
+1. **amdclang++** (recommended) - AMD's optimized Clang compiler from ROCm installation
+2. **clang++** - System Clang compiler
+3. **g++** - GCC compiler (legacy, with warning)
+
+**No compiler flags are required.** The build system automatically detects and uses the best available compiler.
+
+#### Standard build
+
+```bash
+mkdir -p build
+cd build
+cmake ..          # Automatically selects: amdclang++ → clang++ → gcc
+make -j $(nproc)
+make install
+```
+
+#### Compiler search paths
+
+For optimal ROCm compatibility, install ROCm which includes `amdclang++`. The build automatically searches for amdclang++ in:
+- `$ROCM_PATH/llvm/bin/amdclang++` (if `ROCM_PATH` environment variable is set)
+- `/opt/rocm/llvm/bin/amdclang++` (default ROCm installation path)
+- `$ROCM_PATH/lib/llvm/bin/amdclang++` (alternate location)
+
+#### Troubleshooting
+
+If automatic compiler detection fails or you want to use a specific compiler:
+
+```bash
+# Check which compilers are available
+which amdclang++ clang++ g++
+
+# Explicitly specify compiler (overrides auto-detection)
+cmake -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_C_COMPILER=clang ..
+
+# Set custom ROCm path
+export ROCM_PATH=/custom/rocm/path
+cmake ..
+```
+
 ### Python interface and CLI tool prerequisites
 
 * Python 3.6.8+ (64-bit)

--- a/projects/amdsmi/cmake/toolchains/amdsmi-gcc-toolchain.cmake
+++ b/projects/amdsmi/cmake/toolchains/amdsmi-gcc-toolchain.cmake
@@ -1,0 +1,26 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) Advanced Micro Devices, Inc. All rights reserved.
+#
+# Example toolchain: build AMD SMI with GCC instead of the default
+# amdclang++/clang++ auto-detection.
+#
+# Usage:
+#   cmake .. -DCMAKE_TOOLCHAIN_FILE=../cmake/toolchains/amdsmi-gcc-toolchain.cmake
+#
+# To use a specific GCC version:
+#   1. Edit this file and change the compiler paths below
+#   2. Or copy this file and create your own custom toolchain
+#
+# Example with GCC 13:
+#   set(CMAKE_C_COMPILER /usr/bin/gcc-13 CACHE FILEPATH "C compiler" FORCE)
+#   set(CMAKE_CXX_COMPILER /usr/bin/g++-13 CACHE FILEPATH "C++ compiler" FORCE)
+#
+
+# Set the C and C++ compilers to GCC
+set(CMAKE_C_COMPILER gcc CACHE FILEPATH "C compiler" FORCE)
+set(CMAKE_CXX_COMPILER g++ CACHE FILEPATH "C++ compiler" FORCE)
+
+# Optional: Set compiler flags for GCC
+# Uncomment and customize as needed
+# set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall" CACHE STRING "C flags" FORCE)
+# set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall" CACHE STRING "C++ flags" FORCE)

--- a/projects/amdsmi/cmake/toolchains/amdsmi-gcc-toolchain.cmake
+++ b/projects/amdsmi/cmake/toolchains/amdsmi-gcc-toolchain.cmake
@@ -5,7 +5,7 @@
 # amdclang++/clang++ auto-detection.
 #
 # Usage:
-#   cmake .. -DCMAKE_TOOLCHAIN_FILE=cmake/toolchains/amdsmi-gcc-toolchain.cmake
+#   cmake .. -DCMAKE_TOOLCHAIN_FILE=../cmake/toolchains/amdsmi-gcc-toolchain.cmake
 #
 # To use a specific GCC version:
 #   1. Edit this file and change the compiler paths below

--- a/projects/amdsmi/cmake/toolchains/amdsmi-gcc-toolchain.cmake
+++ b/projects/amdsmi/cmake/toolchains/amdsmi-gcc-toolchain.cmake
@@ -1,0 +1,26 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) Advanced Micro Devices, Inc. All rights reserved.
+#
+# Example toolchain: build AMD SMI with GCC instead of the default
+# amdclang++/clang++ auto-detection.
+#
+# Usage:
+#   cmake .. -DCMAKE_TOOLCHAIN_FILE=cmake/toolchains/amdsmi-gcc-toolchain.cmake
+#
+# To use a specific GCC version:
+#   1. Edit this file and change the compiler paths below
+#   2. Or copy this file and create your own custom toolchain
+#
+# Example with GCC 13:
+#   set(CMAKE_C_COMPILER /usr/bin/gcc-13 CACHE FILEPATH "C compiler" FORCE)
+#   set(CMAKE_CXX_COMPILER /usr/bin/g++-13 CACHE FILEPATH "C++ compiler" FORCE)
+#
+
+# Set the C and C++ compilers to GCC
+set(CMAKE_C_COMPILER gcc CACHE FILEPATH "C compiler" FORCE)
+set(CMAKE_CXX_COMPILER g++ CACHE FILEPATH "C++ compiler" FORCE)
+
+# Optional: Set compiler flags for GCC
+# Uncomment and customize as needed
+# set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall" CACHE STRING "C flags" FORCE)
+# set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall" CACHE STRING "C++ flags" FORCE)

--- a/projects/amdsmi/docs/install/build.md
+++ b/projects/amdsmi/docs/install/build.md
@@ -38,6 +38,33 @@ Users that wish to also build the AMD SMI Rust interface will also need the foll
 
 * Rust (1.56 or later)
 
+## Compiler requirements
+
+AMD SMI automatically selects the best available Clang compiler in the following priority order:
+
+1. **amdclang++** (recommended) - AMD's optimized Clang compiler from ROCm
+2. **clang++** - ROCm's clang++ if ROCm is installed, otherwise system clang++
+
+**GCC is supported but not auto-selected.** To build with GCC, use a toolchain file (see below).
+
+### How compilers are discovered
+
+The build uses **`hipconfig --path`** for tool-based ROCm discovery.
+
+**If ROCm is installed** (hipconfig found):
+- Searches **ONLY in ROCm paths** for compilers (in order):
+  1. `<rocm-path>/lib/llvm/bin/amdclang++` - Current standard location
+  2. `<rocm-path>/llvm/bin/amdclang++` - Legacy symlink location
+  3. `<rocm-path>/lib/llvm/bin/clang++` - ROCm clang++
+  4. `<rocm-path>/llvm/bin/clang++` - ROCm clang++ (legacy)
+- **Does NOT fall back to system clang++** - ensures ROCm compiler is used
+
+**If ROCm is NOT installed** (hipconfig not found):
+- Searches **ONLY in system PATH** for `clang++` (e.g., `/usr/bin/clang++`)
+- This allows builds on systems without ROCm
+
+**Note:** Hardcoded paths like `/opt/rocm` are intentionally not used to support multiple ROCm installations and relocatable builds.
+
 ## Build steps
 
 1. Clone the rocm-systems repository to your local Linux machine
@@ -61,7 +88,7 @@ Users that wish to also build the AMD SMI Rust interface will also need the foll
    ```bash
    mkdir -p build
    cd build
-   cmake ..
+   cmake ..          # Discovers ROCm and uses amdclang++
    make -j $(nproc)
    make install
    ```
@@ -72,6 +99,70 @@ Users that wish to also build the AMD SMI Rust interface will also need the foll
    ```bash
    make package
    ```
+
+## Alternative compiler options
+
+### Building with GCC
+
+To build with GCC instead of amdclang++, use the provided toolchain file:
+
+```bash
+mkdir -p build
+cd build
+cmake .. -DCMAKE_TOOLCHAIN_FILE=../cmake/toolchains/amdsmi-gcc-toolchain.cmake
+make -j $(nproc)
+```
+
+To use a specific GCC version, edit `cmake/toolchains/amdsmi-gcc-toolchain.cmake` or create your own toolchain file.
+
+### Building with clang++
+
+To use clang++ instead of amdclang++, explicitly specify the compiler with full path.
+
+**Using ROCm's clang++:**
+
+```bash
+mkdir -p build
+cd build
+cmake .. -DCMAKE_CXX_COMPILER=/opt/rocm-<version_number>/lib/llvm/bin/clang++ -DCMAKE_C_COMPILER=/opt/rocm-<version_number>/lib/llvm/bin/clang
+make -j $(nproc)
+```
+
+**Using system clang++:**
+
+Requires clang to be installed (`sudo apt install clang` on Ubuntu/Debian).
+
+```bash
+mkdir -p build
+cd build
+cmake .. -DCMAKE_CXX_COMPILER=/usr/bin/clang++ -DCMAKE_C_COMPILER=/usr/bin/clang
+make -j $(nproc)
+```
+
+### Troubleshooting compiler detection
+
+**If cmake fails with "amdclang++ not found":**
+
+```bash
+# Check if ROCm is installed and hipconfig is available
+which hipconfig
+hipconfig --path
+
+# If hipconfig not found, add ROCm to PATH
+export PATH=$PATH:/opt/rocm/bin
+cmake ..
+```
+
+**To check what compiler will be used:**
+
+```bash
+# Check available compilers
+which amdclang++ clang++ g++ hipconfig
+
+# Run cmake with verbose output
+cmake .. -DCMAKE_VERBOSE_MAKEFILE=ON
+```
+
 
 (rebuild_py_wrapper)=
 ## Rebuild the Python wrapper

--- a/projects/amdsmi/docs/install/build.md
+++ b/projects/amdsmi/docs/install/build.md
@@ -27,60 +27,30 @@ required:
 * Python (3.6.8 or later)
 * virtualenv -- `python3 -m pip install virtualenv`
 
-### Compiler requirements
+## Compiler requirements
 
-AMD SMI automatically selects the best available Clang compiler in the following priority order:
+AMD SMI automatically selects the best available Clang compiler from the ROCm installation in the following priority order:
 
-1. **amdclang++** (recommended) - AMD's optimized Clang compiler from ROCm installation
-2. **clang++** - System Clang compiler
+1. **amdclang++** (recommended) - AMD's optimized Clang compiler
+2. **clang++** - Standard Clang compiler from ROCm
 
 **GCC is supported but not auto-selected.** To build with GCC, use a toolchain file (see below).
 
-#### Standard build
+### How compilers are discovered
 
-```bash
-mkdir -p build
-cd build
-cmake ..          # Automatically selects: amdclang++ → clang++
-make -j $(nproc)
-make install
-```
+The build uses **`hipconfig --path`** for tool-based ROCm discovery.
 
-#### Compiler search paths
+Once ROCm is located, the build searches for compilers in these paths (in order):
+1. `<rocm-path>/lib/llvm/bin/amdclang++` - Current standard location
+2. `<rocm-path>/llvm/bin/amdclang++` - Legacy symlink location
 
-For optimal ROCm compatibility, install ROCm which includes `amdclang++`. The build automatically searches for amdclang++ in:
-- `$ROCM_PATH/llvm/bin/amdclang++` (if `ROCM_PATH` environment variable is set)
-- `/opt/rocm/llvm/bin/amdclang++` (default ROCm installation path)
-- `$ROCM_PATH/lib/llvm/bin/amdclang++` (alternate location)
+If `amdclang++` is not found, searches for `clang++` in the same ROCm paths:
+1. `<rocm-path>/lib/llvm/bin/clang++`
+2. `<rocm-path>/llvm/bin/clang++`
 
-#### Building with GCC
+**Note:** Only ROCm compilers are auto-selected. System clang++ from `/usr/bin` is NOT used automatically. To use system clang++ or GCC, you must specify them explicitly (see alternative compiler options below).
 
-To build with GCC instead of Clang, use the provided toolchain file:
-
-```bash
-mkdir -p build
-cd build
-cmake .. -DCMAKE_TOOLCHAIN_FILE=../cmake/toolchains/amdsmi-gcc-toolchain.cmake
-make -j $(nproc)
-```
-
-To use a specific GCC version, edit `cmake/toolchains/amdsmi-gcc-toolchain.cmake` or create your own toolchain file.
-
-#### Troubleshooting
-
-If automatic compiler detection fails or you want to use a specific compiler:
-
-```bash
-# Check which compilers are available
-which amdclang++ clang++
-
-# Explicitly specify compiler (overrides auto-detection)
-cmake -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_C_COMPILER=clang ..
-
-# Set custom ROCm path
-export ROCM_PATH=/custom/rocm/path
-cmake ..
-```
+**Note:** Hardcoded paths like `/opt/rocm` are intentionally not used to support multiple ROCm installations and relocatable builds.
 
 ## Build steps
 
@@ -105,7 +75,7 @@ cmake ..
    ```bash
    mkdir -p build
    cd build
-   cmake ..
+   cmake ..          # Discovers ROCm and uses amdclang++
    make -j $(nproc)
    make install
    ```
@@ -116,6 +86,70 @@ cmake ..
    ```bash
    make package
    ```
+
+## Alternative compiler options
+
+### Building with GCC
+
+To build with GCC instead of amdclang++, use the provided toolchain file:
+
+```bash
+mkdir -p build
+cd build
+cmake .. -DCMAKE_TOOLCHAIN_FILE=../cmake/toolchains/amdsmi-gcc-toolchain.cmake
+make -j $(nproc)
+```
+
+To use a specific GCC version, edit `cmake/toolchains/amdsmi-gcc-toolchain.cmake` or create your own toolchain file.
+
+### Building with clang++
+
+To use clang++ instead of amdclang++, explicitly specify the compiler with full path.
+
+**Using ROCm's clang++:**
+
+```bash
+mkdir -p build
+cd build
+cmake .. -DCMAKE_CXX_COMPILER=/opt/rocm-<version_number>/lib/llvm/bin/clang++ -DCMAKE_C_COMPILER=/opt/rocm-<version_number>/lib/llvm/bin/clang
+make -j $(nproc)
+```
+
+**Using system clang++:**
+
+Requires clang to be installed (`sudo apt install clang` on Ubuntu/Debian).
+
+```bash
+mkdir -p build
+cd build
+cmake .. -DCMAKE_CXX_COMPILER=/usr/bin/clang++ -DCMAKE_C_COMPILER=/usr/bin/clang
+make -j $(nproc)
+```
+
+### Troubleshooting compiler detection
+
+**If cmake fails with "amdclang++ not found":**
+
+```bash
+# Check if ROCm is installed and hipconfig is available
+which hipconfig
+hipconfig --path
+
+# If hipconfig not found, add ROCm to PATH
+export PATH=$PATH:/opt/rocm/bin
+cmake ..
+```
+
+**To check what compiler will be used:**
+
+```bash
+# Check available compilers
+which amdclang++ clang++ g++ hipconfig
+
+# Run cmake with verbose output
+cmake .. -DCMAKE_VERBOSE_MAKEFILE=ON
+```
+
 
 (rebuild_py_wrapper)=
 ## Rebuild the Python wrapper

--- a/projects/amdsmi/docs/install/build.md
+++ b/projects/amdsmi/docs/install/build.md
@@ -27,6 +27,61 @@ required:
 * Python (3.6.8 or later)
 * virtualenv -- `python3 -m pip install virtualenv`
 
+### Compiler requirements
+
+AMD SMI automatically selects the best available Clang compiler in the following priority order:
+
+1. **amdclang++** (recommended) - AMD's optimized Clang compiler from ROCm installation
+2. **clang++** - System Clang compiler
+
+**GCC is supported but not auto-selected.** To build with GCC, use a toolchain file (see below).
+
+#### Standard build
+
+```bash
+mkdir -p build
+cd build
+cmake ..          # Automatically selects: amdclang++ → clang++
+make -j $(nproc)
+make install
+```
+
+#### Compiler search paths
+
+For optimal ROCm compatibility, install ROCm which includes `amdclang++`. The build automatically searches for amdclang++ in:
+- `$ROCM_PATH/llvm/bin/amdclang++` (if `ROCM_PATH` environment variable is set)
+- `/opt/rocm/llvm/bin/amdclang++` (default ROCm installation path)
+- `$ROCM_PATH/lib/llvm/bin/amdclang++` (alternate location)
+
+#### Building with GCC
+
+To build with GCC instead of Clang, use the provided toolchain file:
+
+```bash
+mkdir -p build
+cd build
+cmake .. -DCMAKE_TOOLCHAIN_FILE=../cmake/toolchains/amdsmi-gcc-toolchain.cmake
+make -j $(nproc)
+```
+
+To use a specific GCC version, edit `cmake/toolchains/amdsmi-gcc-toolchain.cmake` or create your own toolchain file.
+
+#### Troubleshooting
+
+If automatic compiler detection fails or you want to use a specific compiler:
+
+```bash
+# Check which compilers are available
+which amdclang++ clang++
+
+# Explicitly specify compiler (overrides auto-detection)
+cmake -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_C_COMPILER=clang ..
+
+# Set custom ROCm path
+export ROCM_PATH=/custom/rocm/path
+cmake ..
+```
+
 ## Build steps
 
 1. Clone the rocm-systems repository to your local Linux machine

--- a/projects/amdsmi/docs/install/build.md
+++ b/projects/amdsmi/docs/install/build.md
@@ -29,10 +29,10 @@ required:
 
 ## Compiler requirements
 
-AMD SMI automatically selects the best available Clang compiler from the ROCm installation in the following priority order:
+AMD SMI automatically selects the best available Clang compiler in the following priority order:
 
-1. **amdclang++** (recommended) - AMD's optimized Clang compiler
-2. **clang++** - Standard Clang compiler from ROCm
+1. **amdclang++** (recommended) - AMD's optimized Clang compiler from ROCm
+2. **clang++** - ROCm clang++ or system clang++ (fallback)
 
 **GCC is supported but not auto-selected.** To build with GCC, use a toolchain file (see below).
 
@@ -40,15 +40,17 @@ AMD SMI automatically selects the best available Clang compiler from the ROCm in
 
 The build uses **`hipconfig --path`** for tool-based ROCm discovery.
 
-Once ROCm is located, the build searches for compilers in these paths (in order):
-1. `<rocm-path>/lib/llvm/bin/amdclang++` - Current standard location
-2. `<rocm-path>/llvm/bin/amdclang++` - Legacy symlink location
+**If ROCm is installed** (hipconfig found):
+- Searches **ONLY in ROCm paths** for compilers (in order):
+  1. `<rocm-path>/lib/llvm/bin/amdclang++` - Current standard location
+  2. `<rocm-path>/llvm/bin/amdclang++` - Legacy symlink location
+  3. `<rocm-path>/lib/llvm/bin/clang++` - ROCm clang++
+  4. `<rocm-path>/llvm/bin/clang++` - ROCm clang++ (legacy)
+- **Does NOT fall back to system clang++** - ensures ROCm compiler is used
 
-If `amdclang++` is not found, searches for `clang++` in the same ROCm paths:
-1. `<rocm-path>/lib/llvm/bin/clang++`
-2. `<rocm-path>/llvm/bin/clang++`
-
-**Note:** Only ROCm compilers are auto-selected. System clang++ from `/usr/bin` is NOT used automatically. To use system clang++ or GCC, you must specify them explicitly (see alternative compiler options below).
+**If ROCm is NOT installed** (hipconfig not found):
+- Searches **ONLY in system PATH** for `clang++` (e.g., `/usr/bin/clang++`)
+- This allows builds on systems without ROCm
 
 **Note:** Hardcoded paths like `/opt/rocm` are intentionally not used to support multiple ROCm installations and relocatable builds.
 


### PR DESCRIPTION
Add automatic compiler selection: amdclang++ → clang++ → default clang++. Searches ROCm paths for amdclang++, falls back to system compilers. Shows warning when using gcc. Respects user override flag.

- CMakeLists.txt: Compiler detection with verification
- README.md: Build requirements and troubleshooting

## Motivation
Building amd-smi meant passing a compiler to CMake by hand. CMake now selects the 
compiler itself: it prefers ROCm's amdclang++, falls back to clang++, keeps ROCm
and system toolchains separate, and leaves GCC as an opt-in toolchain file.

## Technical Details

**Compiler detection** (`CMakeLists.txt`):
  - Selects the C/C++ compiler before `project()`; priority amdclang++ > clang++
  - Discovers ROCm via `hipconfig --path`; no hardcoded `/opt/rocm` or `ROCM_PATH`
  - ROCm present: searches ROCm llvm dirs only (`NO_DEFAULT_PATH`), never system PATH
  - ROCm absent: searches system PATH for clang++
  - Validates the chosen compiler runs (`--version`) before using it
  - Scopes the failure hint to whether ROCm is installed

**GCC toolchain** (`cmake/toolchains/amdsmi-gcc-toolchain.cmake`):
  - Adds an opt-in toolchain file for GCC builds

**Docs** (`README.md`, `docs/install/build.md`):
  - Document discovery order, ROCm/system separation, and GCC/clang++ alternatives

## JIRA ID

JIRA ID: AILITOOLS-280

## Test Plan

  - Configure on a ROCm host: `cmake -S . -B build` selects amdclang++
  - Configure with the GCC toolchain file builds with g++
  - Configure with `-DCMAKE_CXX_COMPILER=` skips detection and honors the override


## Test Result

Test 1: With everything (uses amdclang++)
cd rocm-systems/projects/amdsmi
rm -rf build && mkdir build && cd build
cmake .. 2>&1 | grep "Using.*compiler"
Output: Using AMD Clang compiler: /opt/rocm/llvm/bin/amdclang++

dev@dev:dev amdsmi ±|amdsmi_clang ✗|→ rm -rf build && mkdir build && cd build
cmake .. 2>&1 | grep "Using.*compiler"
mkdir: created directory 'build'
/rocm-systems/projects/amdsmi/build
-- Using AMD Clang compiler: /opt/rocm/llvm/bin/amdclang++

Test 2: No ROCm (uses clang++)  
rm -rf ../build && mkdir ../build && cd ../build
ROCM_PATH=/nonexistent cmake .. 2>&1 | grep "Using.*compiler"
 Output: Using system Clang compiler: /usr/bin/clang++

dev@dev: build ±|amdsmi_clang ✗|→ ROCM_PATH=/nonexistent cmake .. 2>&1 | grep "Using.*compiler"
-- Using system Clang compiler: /usr/bin/clang++

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
