### PR TITLE
fix(hsa-runtime): fix buffer overflow in signal.cpp WaitMultiple (Windows path)

### DIFF
--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/signal.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/signal.cpp
@@ -240,7 +240,7 @@ uint32_t Signal::WaitMultiple(uint32_t signal_count, const hsa_signal_t* hsa_sig
 #if defined(__linux__)
   uint64_t event_age[unique_evts];
 #else
-  auto event_age = reinterpret_cast<uint64_t*>(_alloca(unique_evts * sizeof(unique_evts)));
+  auto event_age = reinterpret_cast<uint64_t*>(_alloca(unique_evts * sizeof(uint64_t)));
 #endif
   memset(event_age, 0, unique_evts * sizeof(uint64_t));
   if (core::Runtime::runtime_singleton_->KfdVersion().supports_event_age)


### PR DESCRIPTION
## Summary

Fix stack buffer overflow in `Signal::WaitMultiple()` on the Windows code path.

## The Bug

[signal.cpp line 243](https://github.com/ROCm/rocm-systems/blob/develop/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/signal.cpp#L243):

```cpp
auto event_age = reinterpret_cast<uint64_t*>(_alloca(unique_evts * sizeof(unique_evts)));
```

`unique_evts` is `uint32_t` (4 bytes), but `event_age` is a `uint64_t*` array. `sizeof(unique_evts)` allocates 4 bytes per element instead of the 8 bytes needed. The `memset` on line 245 and the loop on lines 247-248 both write `uint64_t` values, overflowing the allocation by 2x.

[Line 379](https://github.com/ROCm/rocm-systems/blob/develop/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/signal.cpp#L379) in `WaitAny()` already has the correct version:

```cpp
auto event_age = reinterpret_cast<uint64_t*>(_alloca(unique_evts * sizeof(uint64_t)));
```

## Fix

`sizeof(unique_evts)` → `sizeof(uint64_t)` on line 243.

Only affects Windows builds — on Linux the `#if defined(__linux__)` branch uses a VLA instead.

## How it was found

cppcheck flagged `alloca` usage across `rocr-runtime` (see #5051). Manual review of each call site revealed this `sizeof` mismatch — cppcheck found the function, human analysis found the bug.

## Test plan

- [x] Code review — matches the correct pattern on line 379
- [ ] Windows build verification

🤖 Generated with [Claude Code](https://claude.com/claude-code)