### PR TITLE
[rocprofiler-compute] Add standalone perfmon_planner

### DIFF
--- a/projects/rocprofiler-compute/CMakeLists.txt
+++ b/projects/rocprofiler-compute/CMakeLists.txt
@@ -637,6 +637,18 @@ add_test(
 )
 
 # -----------------------------------
+# Perfmon planner tests
+# -----------------------------------
+
+add_test(
+    NAME test_perfmon_planner
+    COMMAND
+        ${PYTHON_TEST_COMMAND} -m pytest ${STANDALONEBINARY_TEST_OPTION}
+        --junitxml=tests/test_perfmon_planner.xml ${COV_OPTION}
+        tests/test_perfmon_planner.py ${WORKING_DIR_OPTION}
+)
+
+# -----------------------------------
 # Generate coverage tests
 # -----------------------------------
 

--- a/projects/rocprofiler-compute/src/utils/perfmon_planner.py
+++ b/projects/rocprofiler-compute/src/utils/perfmon_planner.py
@@ -1,0 +1,735 @@
+#!/usr/bin/env python3
+# Copyright (c) Advanced Micro Devices, Inc.
+# SPDX-License-Identifier:  MIT
+"""
+Standalone perfmon bucket planner for rocprofiler-compute.
+
+Parses GFX architecture YAML configs and outputs counter bucketing plan
+without requiring GPU, rocprofiler, or full rocprof-compute initialization.
+
+Usage:
+    ./src/utils/perfmon_planner.py --arch gfx942
+    ./src/utils/perfmon_planner.py --arch gfx942 --block 2 3 4
+    ./src/utils/perfmon_planner.py --arch gfx950 --config-dir ./custom_configs/
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from collections.abc import Iterator
+from pathlib import Path
+from typing import Any
+
+# Ensure src directory is in Python path for imports
+_src_dir = Path(__file__).resolve().parent.parent
+if str(_src_dir) not in sys.path:
+    sys.path.insert(0, str(_src_dir))
+
+# Import from existing modules to maintain single source of truth
+from rocprof_compute_soc.soc_base import (  # noqa: E402
+    CounterFile,
+    _flat_counters_in_perfmon_file,
+    is_tcc_channel_counter,
+)
+from utils.mi_gpu_spec import mi_gpu_specs  # noqa: E402
+from utils.utils_common import (  # noqa: E402
+    METRIC_ID_RE,
+    convert_metric_id_to_panel_info,
+    get_panel_alias,
+)
+from vendored import yaml  # noqa: E402
+
+
+def _counter_display_ip_prefix(counter: str) -> str:
+    """First IP-style token of a PMC name (column key for bucket tables)."""
+    if is_tcc_channel_counter(counter):
+        base = counter.split("[")[0]
+        return base.split("_", 1)[0] if "_" in base else base
+    if "_" not in counter:
+        return counter
+    return counter.split("_", 1)[0]
+
+
+def _counters_grouped_by_ip_sorted(counters: list[str]) -> dict[str, list[str]]:
+    by_ip: dict[str, list[str]] = {}
+    for ctr in counters:
+        ip = _counter_display_ip_prefix(ctr)
+        by_ip.setdefault(ip, []).append(ctr)
+    for names in by_ip.values():
+        names.sort()
+    return by_ip
+
+
+def parse_counters_from_text(text: str) -> tuple[set[str], set[str]]:
+    """Parse hardware counters and variables from YAML text."""
+    _blk = (
+        r"(?:CHA|CHC|CPC|CPF|GC_CANE|GC_EA_SE|GCR|GL1A|GL1C|GL2A|GL2C|"
+        r"GLARBA|GLARBC|GRBM|SDMA|SPI|SQ|SP|SQC|SQG|TX|UTCL1|"
+        r"TA|TD|TCP|TCC|GCEA)_[0-9A-Z_]*[0-9A-Z](?:\[|e|_sum|_avr|_max|_min)*"
+    )
+    hw_counter_regex = _blk
+    variable_regex = r"\$([0-9A-Za-z_]*[0-9A-Za-z])"
+    hw_counter_matches = set(re.findall(hw_counter_regex, text))
+    variable_matches = set(re.findall(variable_regex, text))
+    hw_counter_matches = hw_counter_matches - variable_matches
+    return hw_counter_matches, variable_matches
+
+
+def parse_counters(config_text: str) -> set[str]:
+    """Extract all hardware counters from config text."""
+    hw_counters, variables = parse_counters_from_text(config_text)
+
+    # Import BUILD_IN_VARS from utils_common for consistency
+    from utils.utils_common import BUILD_IN_VARS
+
+    while variables:
+        subvariables: set[str] = set()
+        for var in variables:
+            if var in BUILD_IN_VARS:
+                hw_new, var_new = parse_counters_from_text(BUILD_IN_VARS[var])
+                hw_counters.update(hw_new)
+                subvariables.update(var_new)
+        variables = subvariables - variables
+
+    return hw_counters
+
+
+def iter_yaml_metrics(
+    config_dir: Path,
+    arch: str,
+) -> Iterator[tuple[str, Any, int, str, str]]:
+    """Iterate over all metrics in analysis YAML files."""
+    config_root = config_dir / arch
+    if not config_root.is_dir():
+        return
+
+    for ypath in sorted(config_root.glob("*.yaml")):
+        stem_id = ypath.name.split("_")[0]
+        try:
+            with open(ypath, encoding="utf-8") as stream:
+                doc = yaml.safe_load(stream)
+        except (OSError, UnicodeError, yaml.YAMLError):
+            continue
+        if not isinstance(doc, dict):
+            continue
+        panel_cfg = doc.get("Panel Config")
+        if not isinstance(panel_cfg, dict):
+            continue
+        sources = panel_cfg.get("data source")
+        if not isinstance(sources, list):
+            continue
+        for section in sources:
+            if not isinstance(section, dict) or "metric_table" not in section:
+                continue
+            mt = section["metric_table"]
+            if not isinstance(mt, dict):
+                continue
+            metrics = mt.get("metric")
+            if not isinstance(metrics, dict):
+                continue
+            panel_id = mt.get("id")
+            for idx, (metric_name, metric_body) in enumerate(metrics.items()):
+                try:
+                    metric_text = yaml.dump(
+                        metric_body, sort_keys=False, allow_unicode=True
+                    )
+                except (TypeError, yaml.YAMLError):
+                    continue
+                yield stem_id, panel_id, idx, metric_name, metric_text
+
+
+def append_analysis_yaml_for_filter_token(
+    raw_token: str,
+    config_filename_dict: dict[str, Path],
+    config_root_dir: Path,
+    texts: list[str],
+    panel_alias_dict: dict[str, str],
+) -> None:
+    """Append YAML content for a filter token (metric ID or alias)."""
+    block_id = raw_token
+
+    # Check if it's a metric ID (x.x.x format)
+    if METRIC_ID_RE.match(block_id):
+        pass
+    elif block_id in panel_alias_dict:
+        # It's an alias like "lds", "l1i", etc.
+        block_id = panel_alias_dict[block_id]
+        print(f"alias: {raw_token} -> block id: {block_id}", file=sys.stderr)
+    else:
+        # Treat as file ID (like "0200")
+        if block_id in config_filename_dict:
+            with open(config_filename_dict[block_id]) as stream:
+                texts.append(stream.read())
+            return
+        print(
+            f"Warning: Unknown block/alias: {raw_token} not found in {config_root_dir}",
+            file=sys.stderr,
+        )
+        return
+
+    file_id, panel_id, metric_id = convert_metric_id_to_panel_info(block_id)
+
+    if file_id not in config_filename_dict:
+        print(
+            f"Warning: Skipping {block_id}: file id {file_id} not found in "
+            f"{config_root_dir}",
+            file=sys.stderr,
+        )
+        return
+
+    with open(config_filename_dict[file_id]) as stream:
+        file_config = yaml.safe_load(stream)
+
+    if panel_id is None:
+        texts.append(yaml.dump(file_config, sort_keys=False))
+        return
+
+    panel_dict = {
+        section["metric_table"]["id"]: section["metric_table"]
+        for section in file_config.get("Panel Config", {}).get("data source", [])
+        if "metric_table" in section
+    }
+
+    if panel_id not in panel_dict:
+        print(
+            f"Warning: Skipping {block_id}: metric table {panel_id} not found in "
+            f"{config_filename_dict[file_id]}",
+            file=sys.stderr,
+        )
+        return
+
+    if metric_id is None:
+        texts.append(yaml.dump(panel_dict[panel_id], sort_keys=False))
+        return
+
+    metrics = panel_dict[panel_id].get("metric", {})
+    metric_list = list(metrics.items())
+    if metric_id >= len(metric_list):
+        print(
+            f"Warning: Skipping {block_id}: metric id {metric_id} not found in "
+            f"panel id {panel_id}",
+            file=sys.stderr,
+        )
+        return
+
+    metric_name, metric_body = metric_list[metric_id]
+    texts.append(yaml.dump({metric_name: metric_body}, sort_keys=False))
+
+
+def detect_counters(
+    config_dir: Path,
+    arch: str,
+    filter_blocks: list[str] | None = None,
+) -> tuple[set[str], list[str]]:
+    """Detect all counters from YAML configs for the given architecture."""
+    config_root = config_dir / arch
+    if not config_root.is_dir():
+        print(f"Error: Config directory not found: {config_root}", file=sys.stderr)
+        sys.exit(1)
+
+    config_files = {f.name.split("_")[0]: f for f in config_root.glob("*.yaml")}
+    panel_alias_dict = get_panel_alias()
+
+    texts: list[str] = []
+    effective_blocks: list[str] = filter_blocks or []
+
+    if not effective_blocks:
+        for filename in config_files.values():
+            with open(filename) as stream:
+                texts.append(stream.read())
+    else:
+        for block_token in effective_blocks:
+            append_analysis_yaml_for_filter_token(
+                block_token,
+                config_files,
+                config_root,
+                texts,
+                panel_alias_dict,
+            )
+
+    counters = parse_counters("\n".join(texts))
+    counters.discard("SQ_ACCUM_PREV_HIRES")
+
+    return counters, effective_blocks
+
+
+def allocate_buckets(
+    counters: set[str],
+    perfmon_config: dict[str, int],
+) -> list[CounterFile]:
+    """Allocate counters to perfmon bucket files."""
+    output_files: list[CounterFile] = []
+    work = sorted(list(counters))
+
+    for counter in work.copy():
+        if (
+            "LEVEL" in counter
+            and not counter.endswith("_sum")
+            and not is_tcc_channel_counter(counter)
+        ):
+            work.remove(counter)
+            # CounterFile automatically adds "pmc_perf_" prefix
+            output_files.append(CounterFile(counter, perfmon_config))
+            output_files[-1].add(counter)
+
+    file_count = 0
+    for ctr in work:
+        added = False
+        for output_file in output_files:
+            if output_file.add(ctr):
+                added = True
+                break
+
+        if not added:
+            # CounterFile automatically adds "pmc_perf_" prefix
+            output_files.append(CounterFile(str(file_count), perfmon_config))
+            file_count += 1
+            output_files[-1].add(ctr)
+
+    return output_files
+
+
+def _global_ip_column_widths(
+    output_files: list[CounterFile],
+) -> tuple[list[str], dict[str, int]]:
+    """Column order and cell widths from the longest header or counter name."""
+    max_cell: dict[str, int] = {}
+    for counter_file in output_files:
+        flat = _flat_counters_in_perfmon_file(counter_file)
+        by_ip = _counters_grouped_by_ip_sorted(flat)
+        for ip, names in by_ip.items():
+            longest = max((len(n) for n in names), default=0)
+            max_cell[ip] = max(max_cell.get(ip, 0), longest, len(ip))
+    columns = sorted(max_cell.keys())
+    widths = {ip: max_cell[ip] for ip in columns}
+    return columns, widths
+
+
+def _format_bucket_markdown(
+    counters: list[str],
+    global_columns: list[str],
+    widths: dict[str, int],
+) -> str:
+    """GitHub-style pipe table with fixed column widths."""
+    by_ip = _counters_grouped_by_ip_sorted(counters)
+    height = max((len(by_ip.get(c, [])) for c in global_columns), default=0)
+
+    def pipe_row(cells: list[str]) -> str:
+        return "| " + " | ".join(cells) + " |"
+
+    lines = [
+        pipe_row([ip.ljust(widths[ip]) for ip in global_columns]),
+        pipe_row(["-" * widths[ip] for ip in global_columns]),
+    ]
+    for row_idx in range(height):
+        lines.append(
+            pipe_row([
+                (by_ip[c][row_idx] if row_idx < len(by_ip.get(c, [])) else "").ljust(
+                    widths[c]
+                )
+                for c in global_columns
+            ])
+        )
+    return "\n".join(lines)
+
+
+def generate_bucket_plan(
+    output_files: list[CounterFile],
+    arch: str,
+) -> tuple[str, int]:
+    """Generate the bucket allocation plan as markdown tables.
+
+    Returns:
+        Tuple of (output_string, total_assignments_count)
+    """
+    from io import StringIO
+
+    buf = StringIO()
+    buf.write(f"Perfmon bucket allocation plan (architecture: {arch})\n\n")
+
+    global_columns, col_widths = _global_ip_column_widths(output_files)
+    total_assignments = 0
+
+    for counter_file in output_files:
+        bucket_label = counter_file.file_name_txt.replace(".txt", "")
+        flat = _flat_counters_in_perfmon_file(counter_file)
+        total_assignments += len(flat)
+        buf.write(f"Bucket: {bucket_label}\n")
+        if not flat:
+            buf.write("(no PMC counters)\n\n")
+            continue
+        if not global_columns:
+            continue
+        buf.write(_format_bucket_markdown(flat, global_columns, col_widths))
+        buf.write("\n\n")
+
+    buf.write(
+        f"Summary: {len(output_files)} bucket(s), "
+        f"{total_assignments} counter assignment(s).\n\n"
+    )
+
+    return buf.getvalue(), total_assignments
+
+
+def print_bucket_plan(output_files: list[CounterFile], arch: str) -> None:
+    """Print the bucket allocation plan as markdown tables."""
+    output, _ = generate_bucket_plan(output_files, arch)
+    print(output, end="")
+
+
+def _counter_to_bucket_map(
+    output_files: list[CounterFile],
+) -> dict[str, str]:
+    """Map each PMC counter string to its perfmon bucket label."""
+    result: dict[str, str] = {}
+    for counter_file in output_files:
+        label = counter_file.file_name_txt.replace(".txt", "")
+        for ctr in _flat_counters_in_perfmon_file(counter_file):
+            result[ctr] = label
+    return result
+
+
+def generate_multi_bucket_metrics(
+    output_files: list[CounterFile],
+    config_dir: Path,
+    arch: str,
+) -> str:
+    """Generate metrics that span multiple buckets as a string."""
+    from io import StringIO
+
+    buf = StringIO()
+    counter_to_bucket = _counter_to_bucket_map(output_files)
+
+    multi_rows: list[tuple[str, str, int, str, int, str]] = []
+    single_rows: list[tuple[str, str, int, str, str]] = []
+    total_metrics = 0
+
+    for file_id, panel_id, metric_idx, metric_name, metric_yaml in iter_yaml_metrics(
+        config_dir, arch
+    ):
+        total_metrics += 1
+        hw = parse_counters(metric_yaml)
+        buckets: set[str] = set()
+        for c in hw:
+            b = counter_to_bucket.get(c)
+            if b is not None:
+                buckets.add(b)
+
+        panel_s = str(panel_id) if panel_id is not None else "-"
+        n_b = len(buckets)
+        if n_b > 1:
+            multi_rows.append((
+                file_id,
+                panel_s,
+                metric_idx,
+                metric_name,
+                n_b,
+                ", ".join(sorted(buckets)),
+            ))
+        elif n_b == 1:
+            single_rows.append((
+                file_id,
+                panel_s,
+                metric_idx,
+                metric_name,
+                next(iter(buckets)),
+            ))
+
+    multi_pct = (100.0 * len(multi_rows) / total_metrics) if total_metrics else 0.0
+    single_pct = (100.0 * len(single_rows) / total_metrics) if total_metrics else 0.0
+
+    buf.write(
+        f"Metrics with PMC counters assigned to more than one perfmon bucket "
+        f"({len(multi_rows)} of {total_metrics} metrics, {multi_pct:.1f}%)\n"
+    )
+    buf.write(
+        "All *.yaml under the arch are scanned. Listed rows are metrics where at "
+        "least one formula counter is in this plan's collection and those "
+        "counters map to 2+ buckets in the layout above.\n"
+    )
+    buf.write(f"Config tree: {config_dir / arch}\n")
+
+    if multi_rows:
+        # Calculate column widths
+        headers = ["File", "Panel", "Idx", "Metric name", "#Bkts", "Buckets"]
+        widths = [len(h) for h in headers]
+        str_rows = [[r[0], r[1], str(r[2]), r[3], str(r[4]), r[5]] for r in multi_rows]
+        for row in str_rows:
+            for i, cell in enumerate(row):
+                widths[i] = max(widths[i], len(cell))
+
+        def pipe_line(parts: list[str]) -> str:
+            return (
+                "| "
+                + " | ".join(parts[i].ljust(widths[i]) for i in range(len(parts)))
+                + " |"
+            )
+
+        buf.write(pipe_line(headers) + "\n")
+        buf.write(pipe_line(["-" * widths[i] for i in range(len(widths))]) + "\n")
+        for row in str_rows:
+            buf.write(pipe_line(row) + "\n")
+    else:
+        buf.write(
+            "(none listed — in-collection counters stay in one bucket per metric)\n"
+        )
+
+    buf.write("\n")
+    buf.write(
+        f"Metrics with PMC counters assigned to one perfmon bucket "
+        f"({len(single_rows)} of {total_metrics} metrics, {single_pct:.1f}%)\n"
+    )
+    buf.write(
+        "Listed rows are metrics where at least one formula counter is in this "
+        "plan's collection and every such counter maps to the same single "
+        "bucket above (metrics with no in-collection PMCs are omitted).\n"
+    )
+
+    if single_rows:
+        headers = ["File", "Panel", "Idx", "Metric name", "Bucket"]
+        widths = [len(h) for h in headers]
+        str_rows = [[r[0], r[1], str(r[2]), r[3], r[4]] for r in single_rows]
+        for row in str_rows:
+            for i, cell in enumerate(row):
+                widths[i] = max(widths[i], len(cell))
+
+        def pipe_line(parts: list[str]) -> str:
+            return (
+                "| "
+                + " | ".join(parts[i].ljust(widths[i]) for i in range(len(parts)))
+                + " |"
+            )
+
+        buf.write(pipe_line(headers) + "\n")
+        buf.write(pipe_line(["-" * widths[i] for i in range(len(widths))]) + "\n")
+        for row in str_rows:
+            buf.write(pipe_line(row) + "\n")
+    else:
+        buf.write(
+            "(none listed — no metric has in-collection PMCs confined to one bucket)\n"
+        )
+    buf.write("\n")
+
+    return buf.getvalue()
+
+
+def print_multi_bucket_metrics(
+    output_files: list[CounterFile],
+    config_dir: Path,
+    arch: str,
+) -> None:
+    """Print metrics that span multiple buckets."""
+    output = generate_multi_bucket_metrics(output_files, config_dir, arch)
+    print(output, end="")
+
+
+def render_perfmon_plan_svg(
+    output_files: list[CounterFile],
+    config_dir: Path,
+    arch: str,
+    title: str = "Perfmon Bucket Plan",
+) -> str:
+    """Render the perfmon plan as SVG using Rich's export_svg.
+
+    Uses markdown pipe-table style (same as CLI) with all columns aligned
+    across all buckets for consistent visual appearance.
+    """
+    from io import StringIO
+
+    try:
+        from rich.console import Console
+    except ImportError:
+        raise ImportError("Rich library required for SVG output: pip install rich")
+
+    # Calculate required width based on table content
+    global_columns, col_widths = _global_ip_column_widths(output_files)
+    total_width = sum(col_widths.values()) + len(col_widths) * 3 + 10
+    console_width = max(200, total_width)
+
+    # Create console with recording enabled
+    console = Console(
+        file=StringIO(),
+        force_terminal=True,
+        width=console_width,
+        height=500,
+        record=True,
+    )
+
+    # Print header
+    header = f"Perfmon bucket allocation plan (architecture: {arch})"
+    console.print(f"[bold cyan]{header}[/bold cyan]\n")
+
+    # Print each bucket using markdown pipe-table style with global column alignment
+    total_assignments = 0
+    for counter_file in output_files:
+        bucket_label = counter_file.file_name_txt.replace(".txt", "")
+        flat = _flat_counters_in_perfmon_file(counter_file)
+        total_assignments += len(flat)
+
+        console.print(f"[bold blue]Bucket: {bucket_label}[/bold blue]")
+
+        if not flat:
+            console.print("[dim](no PMC counters)[/dim]\n")
+            continue
+
+        if not global_columns:
+            continue
+
+        # Use markdown pipe-table format - plain text for consistency
+        by_ip = _counters_grouped_by_ip_sorted(flat)
+        height = max((len(by_ip.get(c, [])) for c in global_columns), default=0)
+
+        # Header row - use plain padding then wrap with color
+        header_parts = [col.ljust(col_widths[col]) for col in global_columns]
+        console.print("[bold cyan]| " + " | ".join(header_parts) + " |[/bold cyan]")
+
+        # Separator row
+        sep_parts = ["-" * col_widths[col] for col in global_columns]
+        console.print("[dim]| " + " | ".join(sep_parts) + " |[/dim]")
+
+        # Data rows - no special coloring, just consistent padding
+        for row_idx in range(height):
+            row_parts = []
+            for col in global_columns:
+                counters = by_ip.get(col, [])
+                cell = counters[row_idx] if row_idx < len(counters) else ""
+                row_parts.append(cell.ljust(col_widths[col]))
+            console.print("| " + " | ".join(row_parts) + " |")
+
+        console.print()
+
+    console.print(
+        f"[bold]Summary:[/bold] {len(output_files)} bucket(s), "
+        f"{total_assignments} counter assignment(s).\n"
+    )
+
+    # Add multi-bucket metrics section
+    metrics_output = generate_multi_bucket_metrics(output_files, config_dir, arch)
+    console.print(metrics_output)
+
+    return console.export_svg(title=title)
+
+
+def get_default_config_dir() -> Path:
+    """Get the default analysis configs directory."""
+    return Path(__file__).parent.parent / "rocprof_compute_soc" / "analysis_configs"
+
+
+def get_supported_archs() -> list[str]:
+    """Get list of supported architectures from mi_gpu_specs."""
+    return list(mi_gpu_specs.get_gpu_series_dict().keys())
+
+
+def main() -> None:
+    # Get supported architectures dynamically from mi_gpu_specs
+    supported_archs = get_supported_archs()
+
+    parser = argparse.ArgumentParser(
+        description="Perfmon bucket planner for rocprofiler-compute",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""
+Examples:
+  python -m utils.perfmon_planner --arch gfx942
+  python -m utils.perfmon_planner --arch gfx942 --block 0200 0400
+  python -m utils.perfmon_planner --arch gfx950 --config-dir ./custom_configs/
+""",
+    )
+    parser.add_argument(
+        "--arch",
+        required=True,
+        choices=sorted(supported_archs),
+        help="GPU architecture (e.g., gfx942, gfx950)",
+    )
+    parser.add_argument(
+        "--config-dir",
+        type=Path,
+        default=None,
+        help="Path to analysis_configs directory (default: auto-detect)",
+    )
+    parser.add_argument(
+        "--block",
+        "-b",
+        nargs="+",
+        default=None,
+        help=(
+            "Filter to specific metric IDs or aliases.\n"
+            "Metric ID format: x, x.x, x.x.x (e.g., 2, 2.1, 2.1.1)\n"
+            "Aliases: lds, l1i, sl1d, tcp, vl1d, l2, xgmi\n"
+            "File IDs: 0200, 0400, etc."
+        ),
+    )
+    parser.add_argument(
+        "--verbose",
+        "-v",
+        action="store_true",
+        help="Show detailed output",
+    )
+    parser.add_argument(
+        "--txt",
+        "-t",
+        type=Path,
+        default=None,
+        help="Output to plain text file",
+    )
+    parser.add_argument(
+        "--svg",
+        type=Path,
+        default=None,
+        help="Output to SVG image file (requires rich library)",
+    )
+
+    args = parser.parse_args()
+
+    config_dir = args.config_dir or get_default_config_dir()
+    if not config_dir.is_dir():
+        print(f"Error: Config directory not found: {config_dir}", file=sys.stderr)
+        sys.exit(1)
+
+    arch = args.arch
+
+    # Get perfmon config from mi_gpu_specs (single source of truth)
+    perfmon_config = mi_gpu_specs.get_perfmon_config(arch)
+    if not perfmon_config:
+        print(
+            f"Error: No perfmon config found for architecture: {arch}",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    counters, filter_blocks = detect_counters(config_dir, arch, args.block)
+
+    if not counters:
+        print("No counters found!", file=sys.stderr)
+        sys.exit(1)
+
+    if args.verbose:
+        print(f"Collected {len(counters)} unique counters:")
+        for c in sorted(counters):
+            print(f"  - {c}")
+        print()
+
+    output_files = allocate_buckets(counters, perfmon_config)
+
+    # Handle output formats
+    if args.svg:
+        try:
+            svg_content = render_perfmon_plan_svg(output_files, config_dir, arch)
+            args.svg.write_text(svg_content)
+            print(f"SVG saved to {args.svg}")
+        except ImportError as e:
+            print(f"Error: {e}", file=sys.stderr)
+            sys.exit(1)
+    elif args.txt:
+        bucket_output, _ = generate_bucket_plan(output_files, arch)
+        metrics_output = generate_multi_bucket_metrics(output_files, config_dir, arch)
+        args.txt.write_text(bucket_output + metrics_output)
+        print(f"Output written to {args.txt}")
+    else:
+        print_bucket_plan(output_files, arch)
+        print_multi_bucket_metrics(output_files, config_dir, arch)
+
+
+if __name__ == "__main__":
+    main()

--- a/projects/rocprofiler-compute/tests/test_perfmon_planner.py
+++ b/projects/rocprofiler-compute/tests/test_perfmon_planner.py
@@ -1,0 +1,131 @@
+#!/usr/bin/env python3
+# Copyright (c) Advanced Micro Devices, Inc.
+# SPDX-License-Identifier:  MIT
+
+"""Unit test for utils/perfmon_planner.py
+
+Single test that loops through all supported architectures and verifies:
+- Return code of perfmon_planner.py script is 0
+- Buckets and counter assignments are non-zero for each architecture
+"""
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+# Path to perfmon_planner.py script
+PERFMON_PLANNER_SCRIPT = (
+    Path(__file__).resolve().parent.parent / "src" / "utils" / "perfmon_planner.py"
+)
+
+# Ensure src directory is in Python path for imports
+_src_dir = Path(__file__).resolve().parent.parent / "src"
+if str(_src_dir) not in sys.path:
+    sys.path.insert(0, str(_src_dir))
+
+
+def test_perfmon_planner_all_supported_archs():
+    """Test perfmon_planner.py works correctly for all supported architectures.
+
+    For each supported architecture:
+    1. Run perfmon_planner.py --arch <arch> and verify return code is 0
+    2. Parse output to verify buckets > 0 and counter assignments > 0
+    """
+    from utils.perfmon_planner import get_supported_archs
+
+    supported_archs = get_supported_archs()
+    assert len(supported_archs) > 0, "Should have at least one supported architecture"
+
+    failed_archs = []
+    results = {}
+
+    for arch in supported_archs:
+        # Run the perfmon_planner.py script for this architecture
+        result = subprocess.run(
+            [sys.executable, str(PERFMON_PLANNER_SCRIPT), "--arch", arch],
+            capture_output=True,
+            text=True,
+            timeout=60,
+        )
+
+        # Check return code
+        if result.returncode != 0:
+            stderr_preview = result.stderr[:500] if result.stderr else "None"
+            failed_archs.append(
+                f"{arch}: Return code {result.returncode}\n"
+                f"  stderr: {stderr_preview}"
+            )
+            results[arch] = {
+                "return_code": result.returncode,
+                "buckets": 0,
+                "counter_assignments": 0,
+            }
+            continue
+
+        # Parse output to find bucket and counter assignment counts
+        # Look for "Summary: X bucket(s), Y counter assignment(s)." line
+        stdout = result.stdout
+        buckets = 0
+        counter_assignments = 0
+
+        for line in stdout.split("\n"):
+            if "Summary:" in line and "bucket" in line:
+                # Parse line like "Summary: 5 bucket(s), 120 counter assignment(s)."
+                parts = line.split()
+                for i, part in enumerate(parts):
+                    if "bucket" in part and i > 0:
+                        try:
+                            buckets = int(parts[i - 1])
+                        except ValueError:
+                            pass
+                    # Check for counter assignment pattern
+                    is_assignment = (
+                        i + 1 < len(parts) and "assignment" in parts[i + 1]
+                    )
+                    if "counter" in part and is_assignment:
+                        try:
+                            counter_assignments = int(parts[i - 1])
+                        except (ValueError, IndexError):
+                            pass
+
+        results[arch] = {
+            "return_code": result.returncode,
+            "buckets": buckets,
+            "counter_assignments": counter_assignments,
+        }
+
+        # Verify non-zero values
+        if buckets == 0:
+            failed_archs.append(f"{arch}: buckets = 0 (expected > 0)")
+        if counter_assignments == 0:
+            failed_archs.append(f"{arch}: counter_assignments = 0 (expected > 0)")
+
+    # Report results
+    print("\n" + "=" * 60)
+    print("Perfmon Planner Test Results:")
+    print("=" * 60)
+    for arch, data in results.items():
+        is_success = (
+            data["return_code"] == 0
+            and data["buckets"] > 0
+            and data["counter_assignments"] > 0
+        )
+        status = "✓" if is_success else "✗"
+        print(
+            f"  {status} {arch}: return_code={data['return_code']}, "
+            f"buckets={data['buckets']}, "
+            f"counter_assignments={data['counter_assignments']}"
+        )
+    print("=" * 60)
+
+    # Assert no failures
+    assert len(failed_archs) == 0, (
+        f"Perfmon planner failed for {len(failed_archs)} architecture(s):\n"
+        + "\n".join(f"  - {err}" for err in failed_archs)
+    )
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v", "-s"])


### PR DESCRIPTION
## Motivation
<!-- Explain the purpose of this PR and the goals it aims to achieve. -->
This is a debug feature to check perfmon counter grouping status in profiling stage. 
It was from the "--dry-run" option developed for Strix Halo debug option.
Per @vedithal-amd suggested, make a standalone script without inserting more option in the product.

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

    Usage:

    # CLI output
    ./src/utils/perfmon_planner.py --arch gfx942 
    
    # SVG output
    ./src/utils/perfmon_planner.py --arch gfx950 --block 2 --svg output.svg
    
    # TXT output
    ./src/utils/perfmon_planner.py --arch gfx950 --block 2 --txt output.txt
    

    ## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->
AIPROFCOMP-541

## Test Plan
Added one unit test to loop on all supported archs to guarantee grouping is working.
<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

    tests/test_perfmon_planner.py::test_perfmon_planner_all_supported_archs 
    ============================================================
    Perfmon Planner Test Results:
    ============================================================
      ✓ gfx908: return_code=0, buckets=12, counter_assignments=213
      ✓ gfx90a: return_code=0, buckets=12, counter_assignments=234
      ✓ gfx940: return_code=0, buckets=12, counter_assignments=230
      ✓ gfx941: return_code=0, buckets=12, counter_assignments=230
      ✓ gfx942: return_code=0, buckets=12, counter_assignments=230
      ✓ gfx950: return_code=0, buckets=30, counter_assignments=430
      ✓ gfx1151: return_code=0, buckets=10, counter_assignments=165
    ============================================================
    PASSED

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.


Partial sample output for gfx1151,
<img width="2008" height="1261" alt="image" src="https://github.com/user-attachments/assets/b1e82504-0d80-41f6-9b6c-45c246bbc28c" />
