### PR TITLE
fix(hsa-runtime): fix wrong sizeof in AddNoteIsa() allocation

### DIFF
--- a/projects/rocr-runtime/runtime/hsa-runtime/libamdhsacode/amd_hsa_code.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/libamdhsacode/amd_hsa_code.cpp
@@ -526,7 +526,8 @@ namespace code {
 
     void AmdHsaCode::AddNoteIsa(const std::string& vendor_name, const std::string& architecture_name, uint32_t major, uint32_t minor, uint32_t stepping)
     {
-      size_t size = sizeof(amdgpu_hsa_note_producer_t) + vendor_name.length() + architecture_name.length() + 1;
+      // note_isa_t (not note_producer_t): includes vendor_and_architecture_name[1]
+      size_t size = sizeof(amdgpu_hsa_note_isa_t) + vendor_name.length() + architecture_name.length() + 1;
       amdgpu_hsa_note_isa_t* desc = (amdgpu_hsa_note_isa_t*) _alloca(size);
       memset(desc, 0, size);
       desc->vendor_name_size = vendor_name.length()+1;


### PR DESCRIPTION
## Summary

- Fix `sizeof(amdgpu_hsa_note_producer_t)` → `sizeof(amdgpu_hsa_note_isa_t)` in `AddNoteIsa()` allocation
- The wrong struct type caused a 4-byte under-allocation (producer_t is 16 bytes, isa_t is 20 bytes)
- The subsequent `memset` and `memcpy` operations write past the end of the allocated buffer

## Details

In `amd_hsa_code.cpp:529`, the `AddNoteIsa()` function allocates stack memory using `_alloca()` with `sizeof(amdgpu_hsa_note_producer_t)` but then uses the buffer as `amdgpu_hsa_note_isa_t*`. These are different structs with different sizes:

- `amdgpu_hsa_note_isa_t`: 20 bytes (has `vendor_name_size`, `architecture_name_size`, `major`, `minor`, `stepping`, plus `char[1]`)
- `amdgpu_hsa_note_producer_t`: 16 bytes (has `producer_name_size`, `reserved`, `producer_major_version`, `producer_minor_version`, plus `char[1]`)

This is likely a copy-paste error from `AddNoteProducer()` (which correctly uses `sizeof(amdgpu_hsa_note_producer_t)`). The bug has been present since the original 2016 import (commit 67e6064a6a).

## Dead code note

No callers of `AddNoteIsa()` were found in this repository. However, it is a public method on `AmdHsaCode` declared in the header, so it could be called by downstream consumers. The fix is correct regardless of whether the function is currently called.

## Discovery

Found during manual audit of all 18 `alloca()` call sites in rocr-runtime, as part of the alloca cleanup tracked in ROCm/rocm-systems#5051. cppcheck flagged `alloca` as a non-standard function; human review of the flagged sites found the `sizeof` mismatch.

## Test plan

- [ ] Verify the fix compiles cleanly
- [ ] Confirm no other callers use the wrong sizeof pattern (audited — this was the only instance)


🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>