### PR TITLE
rocdecode - remove unsupported code path

### DIFF
--- a/projects/rocdecode/src/rocdecode/roc_decoder.cpp
+++ b/projects/rocdecode/src/rocdecode/roc_decoder.cpp
@@ -174,11 +174,9 @@ rocDecStatus RocDecoder::GetVideoFrame(int pic_idx, void *dev_mem_ptr[3], uint32
         }
     }
 
-    *&dev_mem_ptr[0] = hip_interop_[pic_idx].hip_mapped_device_mem;
-    horizontal_pitch[0] = hip_interop_[pic_idx].pitch[0];
-    if (hip_interop_[pic_idx].num_layers == 2) {
-        *&dev_mem_ptr[1] = hip_interop_[pic_idx].hip_mapped_device_mem + hip_interop_[pic_idx].offset[1];
-        horizontal_pitch[1] = hip_interop_[pic_idx].pitch[1];
+    for (int i = 0; i < hip_interop_[pic_idx].num_layers; i++) {
+        dev_mem_ptr[i] = hip_interop_[pic_idx].hip_mapped_device_mem + hip_interop_[pic_idx].offset[i];
+        horizontal_pitch[i] = hip_interop_[pic_idx].pitch[i];
     }
     FunctionExitLog(g_rocdec_logger);
     return rocdec_status;

--- a/projects/rocdecode/src/rocdecode/roc_decoder.cpp
+++ b/projects/rocdecode/src/rocdecode/roc_decoder.cpp
@@ -179,9 +179,6 @@ rocDecStatus RocDecoder::GetVideoFrame(int pic_idx, void *dev_mem_ptr[3], uint32
     if (hip_interop_[pic_idx].num_layers == 2) {
         *&dev_mem_ptr[1] = hip_interop_[pic_idx].hip_mapped_device_mem + hip_interop_[pic_idx].offset[1];
         horizontal_pitch[1] = hip_interop_[pic_idx].pitch[1];
-    } else if (hip_interop_[pic_idx].num_layers == 3) {
-        *&dev_mem_ptr[2] = hip_interop_[pic_idx].hip_mapped_device_mem + hip_interop_[pic_idx].offset[2];
-        horizontal_pitch[2] = hip_interop_[pic_idx].pitch[2];
     }
     FunctionExitLog(g_rocdec_logger);
     return rocdec_status;


### PR DESCRIPTION
## Motivation

This PR removes the unsupported code path for VA-API/HIP interop for YUV output with 3 layers, which the VCN does not support. The VCN outputs the NV12 video format for decoding, which has only two layers. This addresses issue #5058 

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
