### PR TITLE
[CI] Add missing TEST_COMPONENT env var to test step in therock-test-component.yml

### DIFF
--- a/.github/scripts/therock_matrix.py
+++ b/.github/scripts/therock_matrix.py
@@ -74,7 +74,7 @@ project_map = {
     },
     "all": {
         "cmake_options": ["-DTHEROCK_ENABLE_ALL=ON"],
-        "projects_to_test": "hip-tests, rocrtst, aqlprofile, rocprofiler-compute, rocprofiler-sdk, rocprofiler-systems, rocr-debug-agent, rocgdb",
+        "projects_to_test": "hip-tests, rocrtst, aqlprofile, rocprofiler-compute, rocprofiler-sdk, rocprofiler-systems, rocr-debug-agent, rocgdb, miopen, rocblas",
     },
     # Same test coverage as TheRock submodule-bump PRs (rocm-systems scope).
     # Nightly (schedule) uses this entry explicitly for alignment.

--- a/.github/scripts/therock_matrix.py
+++ b/.github/scripts/therock_matrix.py
@@ -74,7 +74,7 @@ project_map = {
     },
     "all": {
         "cmake_options": ["-DTHEROCK_ENABLE_ALL=ON"],
-        "projects_to_test": "hip-tests, rocrtst, aqlprofile, rocprofiler-compute, rocprofiler-sdk, rocprofiler-systems, rocr-debug-agent, rocgdb, miopen, rocblas",
+        "projects_to_test": "hip-tests, rocrtst, aqlprofile, rocprofiler-compute, rocprofiler-sdk, rocprofiler-systems, rocr-debug-agent, rocgdb",
     },
     # Same test coverage as TheRock submodule-bump PRs (rocm-systems scope).
     # Nightly (schedule) uses this entry explicitly for alignment.

--- a/.github/workflows/therock-test-component.yml
+++ b/.github/workflows/therock-test-component.yml
@@ -108,6 +108,7 @@ jobs:
           SHARD_INDEX: ${{ matrix.shard }}
           TOTAL_SHARDS: ${{ fromJSON(inputs.component).total_shards }}
           TEST_TYPE: ${{ fromJSON(inputs.component).test_type }}
+          TEST_COMPONENT: ${{ fromJSON(inputs. Component).job_name }}
         run: |
           ${{ fromJSON(inputs.component).test_script }}
 


### PR DESCRIPTION
## Motivation

After #4202 expanded the nightly CI to include all projects (aligning with TheRock submodule bump PR coverage), components that use test_runner.py — namely rocblas and miopen — started failing with:
ERROR: TEST_COMPONENT environment variable is required but not set.

The test_runner.py script in TheRock requires TEST_COMPONENT to map the job name to the correct test directory (e.g., miopen → MIOpen, rocblas → rocblas). TheRock's own test_component.yml sets this variable, but the rocm-systems copy did not.

Previously this was not hit because the nightly workflow evaluated subtrees based on modified paths and never included rocblas or miopen. The nightly alignment change in #4202 now explicitly includes them.

## Technical Details

Added TEST_COMPONENT: ${{ fromJSON(inputs.component).job_name }} to the env block of the "Test" step in therock-test-component.yml, matching what TheRock's upstream workflow does.

## Test Plan

Verified the env var is passed through correctly by inspecting the workflow YAML.
Nightly CI jobs for rocblas and miopen (and any future components using test_runner.py will now receive the required TEST_COMPONENT value.

## Test Result

Will be updated later after the test.