### PR TITLE
ROCM-1254 - fix cooperative_groups::reduce() triggering assertions in hip-tests

### DIFF
--- a/projects/hip-tests/catch/config/configs/unit/cooperativeGrps.yaml
+++ b/projects/hip-tests/catch/config/configs/unit/cooperativeGrps.yaml
@@ -202,7 +202,6 @@ cooperativeGrps:
   Unit_Thread_Block_Coalesced_Reduce_arithmetic: *level_2
   Unit_Thread_Block_Tile_Reduce_Basic: *level_2
   Unit_Thread_Block_Tile_Reduce_Custom_Op: *level_2
-  Unit_Thread_Block_Tile_Reduce_Non_Participating_Threads: *level_2
   Unit_Thread_Block_Tile_Reduce_Random_arithmetic: *level_2
   Unit_Thread_Block_Tile_Reduce_Random_boolean: *level_2
   Unit_Thread_Block_Coalesced_Reduce_arithmetic:
@@ -234,10 +233,6 @@ cooperativeGrps:
     # Rock_Window_Failures_on_gfx1151
     disabled: [amd_windows]
   Unit_Thread_Block_Tile_Reduce_All_Parameter_Sizes:
-    <<: *level_2
-    # Rock_Window_Failures_on_gfx1151
-    disabled: [amd_windows]
-  Unit_Thread_Block_Tile_Reduce_Non_Participating_Threads:
     <<: *level_2
     # Rock_Window_Failures_on_gfx1151
     disabled: [amd_windows]

--- a/projects/hip-tests/catch/unit/cooperativeGrps/thread_block_tile.cc
+++ b/projects/hip-tests/catch/unit/cooperativeGrps/thread_block_tile.cc
@@ -613,28 +613,6 @@ void __global__ partialSum(int* result)
   }
 }
 
-HIP_TEST_CASE(Unit_Thread_Block_Tile_Reduce_Non_Participating_Threads)
-{
-  LinearAllocGuard<int> h_result(LinearAllocs::malloc, sizeof(int));
-  LinearAllocGuard<int> d_result(LinearAllocs::hipMalloc, sizeof(int));
-  dim3 gridDim = { 1 };
-  dim3 blockDim = { static_cast<unsigned short>(getWarpSize()) };
-  void* devicePtr = d_result.ptr();
-  void* args[] = { &devicePtr };
-  void* kernelPtr = reinterpret_cast<void*>(getWarpSize() == 32?
-                    partialSum<32> :
-                    partialSum<64>);
-
-  HIP_CHECK(hipLaunchCooperativeKernel(kernelPtr, gridDim, blockDim, args, 0, nullptr));
-  HIP_CHECK(hipDeviceSynchronize());
-  HIP_CHECK(hipGetLastError());
-  HIP_CHECK(hipMemcpy(h_result.host_ptr(), d_result.ptr(),
-                      h_result.size_bytes(), hipMemcpyDeviceToHost));
-  // because a thread did not participate; we get a partial sum; note: this is undefined behaviour
-  // on Nvidia
-  REQUIRE(*h_result.host_ptr() == getWarpSize() - 1);
-}
-
 template <size_t TileSize, class Functor, class T>
 void __global__ reduceKernel(T* output, const T* input, unsigned long long* extraMasks)
 {

--- a/projects/hip-tests/catch/unit/cooperativeGrps/thread_block_tile.cc
+++ b/projects/hip-tests/catch/unit/cooperativeGrps/thread_block_tile.cc
@@ -783,7 +783,7 @@ void runReduceRandomForOps(const std::tuple<Op, Ops...>)
 }
 
 // for all the tile sizes and all input types, using random input values, calculates the reduce()
-// values. Additionally, randomly make some threads not participate
+// values. Additionally, randomly make some threads not participate for the coalesced_threads case
 HIP_TEMPLATE_TEST_CASE(Unit_Thread_Block_Tile_Reduce_Random_arithmetic, int, unsigned int, long long,
                    unsigned long long, float, half, double)
 {

--- a/projects/hip-tests/catch/unit/cooperativeGrps/thread_block_tile.cc
+++ b/projects/hip-tests/catch/unit/cooperativeGrps/thread_block_tile.cc
@@ -601,18 +601,6 @@ HIP_TEMPLATE_TEST_CASE(Unit_Thread_Block_Tile_Reduce_Basic, int)
   }
 }
 
-template <size_t TileSize>
-void __global__ partialSum(int* result)
-{
-   int sum = 1;
-   cg::thread_block mygroup = cg::this_thread_block();
-   auto mytile = cg::tiled_partition<TileSize>(mygroup);
-
-  if (threadIdx.x != warpSize - 1) {
-     *result = cg::reduce(mytile, sum, cg::plus<int>());
-  }
-}
-
 template <size_t TileSize, class Functor, class T>
 void __global__ reduceKernel(T* output, const T* input, unsigned long long* extraMasks)
 {

--- a/projects/hip-tests/catch/unit/cooperativeGrps/thread_block_tile.cc
+++ b/projects/hip-tests/catch/unit/cooperativeGrps/thread_block_tile.cc
@@ -671,10 +671,16 @@ void reduceForTypeAndOp()
   void* kernelPtr;
 
   genRandomBuffers(d_input, h_input, distInput, gen, kNumReduces * wavefrontSize);
-  genRandomMasks(d_extraMasks,
-                 h_extraMasks,
-                 gen,
-                 kNumReduces);
+
+  if (TileSize) {
+    std::memset(h_extraMasks.host_ptr(), 0xFF, h_extraMasks.size_bytes());
+    HIP_CHECK(hipMemset(d_extraMasks.ptr(), 0xFF, d_extraMasks.size_bytes()));
+  } else {
+    genRandomMasks(d_extraMasks,
+                   h_extraMasks,
+                   gen,
+                   kNumReduces);
+  }
 
   std::array<void*, 3> devicePtrs = { d_result.ptr(), d_input.ptr(), d_extraMasks.ptr() };
   void* args[devicePtrs.size()];
@@ -906,7 +912,7 @@ template <size_t NumElems, class Functor>
 __global__ void applyFunctor(ArrayContainer<NumElems>* result)
 {
   cg::thread_block mygroup = cg::this_thread_block();
-  auto mytile = cg::tiled_partition<32>(mygroup);
+  auto mytile = cg::tiled_partition<NumElems>(mygroup);
   __shared__ ArrayContainer<NumElems> input;
   Functor op;
 
@@ -949,7 +955,7 @@ void testReduceSizes()
   }
 
   if constexpr (NumElems > 1) {
-    testReduceSizes<NumElems - 1, Functor>();
+    testReduceSizes<NumElems / 2, Functor>();
   }
 }
 

--- a/projects/hip-tests/catch/unit/cooperativeGrps/thread_block_tile.cc
+++ b/projects/hip-tests/catch/unit/cooperativeGrps/thread_block_tile.cc
@@ -602,7 +602,7 @@ HIP_TEMPLATE_TEST_CASE(Unit_Thread_Block_Tile_Reduce_Basic, int)
 }
 
 template <size_t TileSize, class Functor, class T>
-void __global__ reduceKernel(T* output, const T* input, unsigned long long* extraMasks)
+void __global__ reduceKernel(T* output, const T* input)
 {
   int tid = threadIdx.x;
   int laneId = tid % warpSize;
@@ -611,17 +611,13 @@ void __global__ reduceKernel(T* output, const T* input, unsigned long long* extr
 
   for (int i = 0; i < kNumReduces; i++) {
     int idx = warpSize * i + laneId;
-    unsigned long long mask = extraMasks[i];
     T& result = output[idx];
 
-    if ((1ull << laneId) & mask) {
-      result = cg::reduce(mytile, input[idx], Functor());
-    } else {
-      result = 0;
-    }
+    result = cg::reduce(mytile, input[idx], Functor());
   }
 }
 
+// @extraMasks  used to simulate divergence when using coalesced_threads
 template <class Functor, class T>
 void __global__ reduceKernelCoalesced(T* output, const T* input, unsigned long long* extraMasks)
 {
@@ -673,9 +669,11 @@ void reduceForTypeAndOp()
   genRandomBuffers(d_input, h_input, distInput, gen, kNumReduces * wavefrontSize);
 
   if (TileSize) {
+    // tile block case
     std::memset(h_extraMasks.host_ptr(), 0xFF, h_extraMasks.size_bytes());
     HIP_CHECK(hipMemset(d_extraMasks.ptr(), 0xFF, d_extraMasks.size_bytes()));
   } else {
+    // coalesced_threads case
     genRandomMasks(d_extraMasks,
                    h_extraMasks,
                    gen,


### PR DESCRIPTION

## Motivation

* In Unit_Thread_Block_Tile_Reduce_Non_Participating_Threads, a thread of a cooperative group tile block does not participate in a reduction. That is undefined behaviour in CUDA. 

* This causes an assertion to be triggered (__hip_check_mask()) when running the tests if the have been compiled in DEBUG mode (additionally, it is best to remove the test to not constraint the implementation by having to pass this test)

* The assertion was triggered in other tests because tiles of invalid size where being created (only power of 2 should be allowed)

* The PR also fixes that some masks that were meant only to be applied for coalesced_threads tests, were also being applied for thread_block_tiles

## Technical Details

Removes the test and its mentions in the YAML test files.

## JIRA ID

ROCM-1254

## Test Plan

Test that is now runs correctly on Navi48 on Debug and on Release on the CI

## Test Result

- Debug: passed on Navi48 locally
- Release: see CI results

## Submission Checklist

- [X] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
