### PR TITLE
Fix false queue-idle detection for first unsignaled packet

### DIFF
--- a/projects/clr/rocclr/device/rocm/rocvirtual.hpp
+++ b/projects/clr/rocclr/device/rocm/rocvirtual.hpp
@@ -680,7 +680,7 @@ class VirtualGPU : public device::VirtualDevice {
 
     // Make sure the last packet contained a completion signal
     if (last_packet_with_signal_index_ == last_write_index_) {
-      if ((last_write_index_ == 0) && (last_completion_signal_.handle == 0)) {
+      if ((last_write_index_ == std::numeric_limits<uint64_t>::max()) && (last_completion_signal_.handle == 0)) {
         return true;
       } else {
         return (Hsa::signal_load_relaxed(last_completion_signal_) == 0);
@@ -766,8 +766,8 @@ class VirtualGPU : public device::VirtualDevice {
                                        //!< kUnknown/kFlushedToDevice/kFlushedToSystem
   std::atomic<bool> fence_dirty_;      //!< Fence modified flag
 
-  uint64_t last_write_index_ = 0;             //!< The last HW queue write index for any packet
-  uint64_t last_packet_with_signal_index_ = 0;//!< The last HW queue write index for a packet
+  uint64_t last_write_index_ = std::numeric_limits<uint64_t>::max(); //!< The last HW queue write index for any packet
+  uint64_t last_packet_with_signal_index_ = std::numeric_limits<uint64_t>::max(); //!< The last HW queue write index for a packet
                                               //!< with a completion signal
   hsa_signal_t last_completion_signal_{};     //!< The last completion signal
 

--- a/projects/clr/rocclr/device/rocm/rocvirtual.hpp
+++ b/projects/clr/rocclr/device/rocm/rocvirtual.hpp
@@ -33,6 +33,7 @@ constexpr static hsa_signal_value_t kInitSignalValueOne = 1;
 // Timeouts for HSA signal wait
 constexpr static uint64_t kTimeout100us = 100 * K;
 constexpr static uint64_t kUnlimitedWait = std::numeric_limits<uint64_t>::max();
+constexpr static uint64_t kInvalidQueueIndex = std::numeric_limits<uint64_t>::max();
 
 constexpr static uint64_t kTimeout4Secs = 4 * M;
 
@@ -680,7 +681,7 @@ class VirtualGPU : public device::VirtualDevice {
 
     // Make sure the last packet contained a completion signal
     if (last_packet_with_signal_index_ == last_write_index_) {
-      if ((last_write_index_ == std::numeric_limits<uint64_t>::max()) && (last_completion_signal_.handle == 0)) {
+      if ((last_write_index_ == kInvalidQueueIndex) && (last_completion_signal_.handle == 0)) {
         return true;
       } else {
         return (Hsa::signal_load_relaxed(last_completion_signal_) == 0);
@@ -766,8 +767,8 @@ class VirtualGPU : public device::VirtualDevice {
                                        //!< kUnknown/kFlushedToDevice/kFlushedToSystem
   std::atomic<bool> fence_dirty_;      //!< Fence modified flag
 
-  uint64_t last_write_index_ = std::numeric_limits<uint64_t>::max(); //!< The last HW queue write index for any packet
-  uint64_t last_packet_with_signal_index_ = std::numeric_limits<uint64_t>::max(); //!< The last HW queue write index for a packet
+  uint64_t last_write_index_ = kInvalidQueueIndex; //!< The last HW queue write index for any packet
+  uint64_t last_packet_with_signal_index_ = kInvalidQueueIndex; //!< The last HW queue write index for a packet
                                               //!< with a completion signal
   hsa_signal_t last_completion_signal_{};     //!< The last completion signal
 


### PR DESCRIPTION
## Motivation

- `Unit_hipGetProcAddress_MemoryApisMemset` is failing because `hipStreamSynchronize` may return before `hipMemset*Async` operation has actually completed when it is the only operation enqueued on the stream.

## Technical Details

- If a single command is enqueued on a stream without an attached completion signal, `IsQueueIdle()` can incorrectly report the queue as idle. In the original logic, the write index starts at `0`, so an empty queue and a queue containing exactly one command at index `0` are indistinguishable.
- When `hipStreamSynchronize` is called on stream A, the finish path may call `ReleaseAllHwQueues()`, which can release an idle hardware queue belonging to stream B. If stream B has only a single enqueued command without a completion signal, that queue can be released prematurely. A later synchronization on stream B may then reacquire a different queue that is already idle, causing `hipStreamSynchronize` to return too early.
- `last_write_index_` and `last_packet_with_signal_index_` still starts counting from zero but are preinitialized with an invalid queue index.

## JIRA ID

ROCM-20999

## Test Plan

Run hip-tests.

## Test Result

All hip-tests passed.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
