### PR TITLE
[ROCR][NFC] Refactor `WaitRelaxed` methods

### DIFF
--- a/projects/rocr-runtime/runtime/hsa-runtime/core/inc/signal.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/inc/signal.h
@@ -93,18 +93,6 @@ inline timer::fast_clock::duration GetFastTimeout(uint64_t timeout) {
       double(timeout) / double(hsa_freq));
 }
 
-inline void CheckAbortTimeout(const timer::fast_clock::time_point& start_time,
-                            uint32_t signal_abort_timeout) {
-  if (signal_abort_timeout) {
-    const timer::fast_clock::duration abort_timeout =
-        std::chrono::seconds(signal_abort_timeout);
-    if (timer::fast_clock::now() - start_time > abort_timeout) {
-      throw AMD::hsa_exception(HSA_STATUS_ERROR_FATAL,
-                             "Signal wait abort timeout.\n");
-    }
-  }
-}
-
 inline void DoMwaitx(int64_t* addr, int64_t val_on_last_check, uint32_t timeout, bool timer_enable) {
 #if defined(__i386__) || defined(__x86_64__)
   _mm_monitorx(addr, 0, 0);

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/default_signal.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/default_signal.cpp
@@ -83,11 +83,12 @@ hsa_signal_value_t BusyWaitSignal::WaitRelaxed(hsa_signal_condition_t condition,
   waiting_++;
   MAKE_SCOPE_GUARD([&]() { waiting_--; });
 
-  const uint32_t &signal_abort_timeout =
-    core::Runtime::runtime_singleton_->flag().signal_abort_timeout();
-
+  static const uint32_t& signal_abort_timeout =
+      core::Runtime::runtime_singleton_->flag().signal_abort_timeout();
+  static const timer::fast_clock::duration abort_timeout =
+      std::chrono::seconds(signal_abort_timeout);
+  static const timer::fast_clock::duration fast_timeout = timer::GetFastTimeout(timeout);
   const timer::fast_clock::time_point start_time = timer::fast_clock::now();
-  const timer::fast_clock::duration fast_timeout = timer::GetFastTimeout(timeout);
 
   while (true) {
     if (!IsValid()) return 0;
@@ -98,11 +99,15 @@ hsa_signal_value_t BusyWaitSignal::WaitRelaxed(hsa_signal_condition_t condition,
       return value;
     }
 
-    if (timer::fast_clock::now() - start_time > fast_timeout) {
+    auto elapsed = timer::fast_clock::now() - start_time;
+    if (elapsed > fast_timeout) {
       return value;
     }
 
-    timer::CheckAbortTimeout(start_time, signal_abort_timeout);
+    if (signal_abort_timeout && elapsed > abort_timeout) {
+      throw AMD::hsa_exception(HSA_STATUS_ERROR_FATAL,
+                             "Signal wait abort timeout.\n");
+    }
 
     if (g_use_mwaitx) {
       // Use timer-enabled mwaitx for busy waiting

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/interrupt_signal.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/interrupt_signal.cpp
@@ -148,11 +148,13 @@ hsa_signal_value_t InterruptSignal::WaitRelaxed(hsa_signal_condition_t condition
   uint64_t event_age = core::Runtime::runtime_singleton_->KfdVersion().supports_event_age ? 1 : 0;
   if (!event_age && prior != 0) wait_hint = HSA_WAIT_STATE_ACTIVE;
 
-  const timer::fast_clock::time_point start_time = timer::fast_clock::now();
-  const timer::fast_clock::duration fast_timeout = timer::GetFastTimeout(timeout);
-  const timer::fast_clock::duration kMaxElapsed = std::chrono::microseconds(200);
-  const uint32_t &signal_abort_timeout =
+  static const timer::fast_clock::duration fast_timeout = timer::GetFastTimeout(timeout);
+  static const timer::fast_clock::duration kMaxElapsed = std::chrono::microseconds(200);
+  static const uint32_t &signal_abort_timeout =
     core::Runtime::runtime_singleton_->flag().signal_abort_timeout();
+  static const timer::fast_clock::duration abort_timeout =
+        std::chrono::seconds(signal_abort_timeout);
+  const timer::fast_clock::time_point start_time = timer::fast_clock::now();
 
   while (true) {
     if (!IsValid()) return 0;
@@ -163,12 +165,16 @@ hsa_signal_value_t InterruptSignal::WaitRelaxed(hsa_signal_condition_t condition
       return value;
     }
 
-    auto now = timer::fast_clock::now();
-    if (now - start_time > fast_timeout) {
+    auto elapsed = timer::fast_clock::now() - start_time;
+    if (elapsed > fast_timeout) {
       return value;
     }
 
-    timer::CheckAbortTimeout(start_time, signal_abort_timeout);
+    if (signal_abort_timeout && elapsed > abort_timeout) {
+      throw AMD::hsa_exception(HSA_STATUS_ERROR_FATAL,
+                             "Signal wait abort timeout.\n");
+    }
+
 
     if (wait_hint == HSA_WAIT_STATE_ACTIVE) {
       if (g_use_mwaitx) {
@@ -178,7 +184,7 @@ hsa_signal_value_t InterruptSignal::WaitRelaxed(hsa_signal_condition_t condition
       continue;
     }
 
-    if (now - start_time < kMaxElapsed) {
+    if (elapsed < kMaxElapsed) {
       if (g_use_mwaitx) {
         // Longer timeout with timer for passive waiting
         timer::DoMwaitx(const_cast<int64_t*>(&signal_.value), value, 60000, true);
@@ -187,7 +193,7 @@ hsa_signal_value_t InterruptSignal::WaitRelaxed(hsa_signal_condition_t condition
     }
 
     auto remaining_ms = timer::duration_cast<std::chrono::milliseconds>(
-      fast_timeout - (now - start_time)).count();
+      fast_timeout - elapsed).count();
 
     uint32_t wait_ms = std::min<uint32_t>(
       static_cast<uint32_t>(std::min<uint64_t>(remaining_ms, 0xFFFFFFFEUL)),

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/interrupt_signal.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/interrupt_signal.cpp
@@ -148,7 +148,7 @@ hsa_signal_value_t InterruptSignal::WaitRelaxed(hsa_signal_condition_t condition
   uint64_t event_age = core::Runtime::runtime_singleton_->KfdVersion().supports_event_age ? 1 : 0;
   if (!event_age && prior != 0) wait_hint = HSA_WAIT_STATE_ACTIVE;
 
-  static const timer::fast_clock::duration fast_timeout = timer::GetFastTimeout(timeout);
+  const timer::fast_clock::duration fast_timeout = timer::GetFastTimeout(timeout);
   static const timer::fast_clock::duration kMaxElapsed = std::chrono::microseconds(200);
   static const uint32_t &signal_abort_timeout =
     core::Runtime::runtime_singleton_->flag().signal_abort_timeout();


### PR DESCRIPTION
## Motivation

Performance optimizations

## Technical Details

All abort timeouts are constant throughout an application lifetime and as such we can avoid re-computing them on every call to the function. Also reduced amount of calls to `now()` in the busy-wait loop.

## JIRA ID

N/A

## Test Plan

N/A, this is a non-functional change

## Test Result

N/A, this is a non-functional change

## Submission Checklist

- [X] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
