### PR TITLE
[CLR][NFCI] Bail out of posting VDI events earlier

### DIFF
--- a/projects/clr/rocclr/platform/agent.hpp
+++ b/projects/clr/rocclr/platform/agent.hpp
@@ -36,7 +36,9 @@ class Agent : public _vdi_agent {
   static vdi_agent_capabilities potentialCapabilities() { return potentialCapabilities_; }
 
 #define AGENT_FLAG(name)                                                                           \
-  inline static bool shouldPost##name() { return enabledCapabilities_.canGenerate##name != 0; }
+  inline static bool shouldPost##name() {                                                          \
+    return list_ && enabledCapabilities_.canGenerate##name != 0;                                   \
+  }
 
   AGENT_FLAG(ContextEvents);
   AGENT_FLAG(CommandQueueEvents);


### PR DESCRIPTION
## Motivation

Performance optimizations.

## Technical Details

VDI events are only posted if `CL_AGENT` environment variable is present which is probably not the case for most applications (especially HIP ones). As such, bailing out of posting VDI events earlier allows us to save us on multiple timestamp calculations happening during `hipDeviceSynchronize` (in `Event::setStatus`).

## JIRA ID

N/A

## Test Plan

N/A, this is intended to be a non-functional change

## Test Result

N/A, this is intended to be a non-functional change

## Submission Checklist

- [X] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
