### PR TITLE
[CLR][NFC] Bypass initialization of managed variables

### DIFF
--- a/projects/clr/hipamd/src/hip_code_object.cpp
+++ b/projects/clr/hipamd/src/hip_code_object.cpp
@@ -594,6 +594,10 @@ void StatCO::ResizeForDevices(size_t device_count) {
 
 // ================================================================================================
 hipError_t StatCO::InitManagedVarDevicePtr(int deviceId) {
+  if (managedVars_.empty()) {
+    return hipSuccess;
+  }
+
   std::scoped_lock lock(sclock_);
   hipError_t err = hipSuccess;
   if (managedVarsDevicePtrInitalized_.find(deviceId) == managedVarsDevicePtrInitalized_.end() ||


### PR DESCRIPTION
## Motivation

Performance improvements.

## Technical Details

If there are no managed variables registered, there is no need to take a lock and do a hashtable search which otherwise would happen on every kernel submission.

## JIRA ID

N/A

## Test Plan

N/A, this is a non-functional change

## Test Result

N/A, this is a non-functional change

## Submission Checklist

- [X] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
