### PR TITLE
Add progress bar when processing cached files for each output format

### DIFF
--- a/projects/rocprofiler-systems/source/lib/core/CMakeLists.txt
+++ b/projects/rocprofiler-systems/source/lib/core/CMakeLists.txt
@@ -18,6 +18,7 @@ set(core_sources
     ${CMAKE_CURRENT_LIST_DIR}/output_file_registry.cpp
     ${CMAKE_CURRENT_LIST_DIR}/perf.cpp
     ${CMAKE_CURRENT_LIST_DIR}/perfetto.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/progress_bar.cpp
     ${CMAKE_CURRENT_LIST_DIR}/rocprofiler-sdk.cpp
     ${CMAKE_CURRENT_LIST_DIR}/state.cpp
     ${CMAKE_CURRENT_LIST_DIR}/timemory.cpp
@@ -49,6 +50,7 @@ set(core_headers
     ${CMAKE_CURRENT_LIST_DIR}/output_file_registry.hpp
     ${CMAKE_CURRENT_LIST_DIR}/perf.hpp
     ${CMAKE_CURRENT_LIST_DIR}/perfetto.hpp
+    ${CMAKE_CURRENT_LIST_DIR}/progress_bar.hpp
     ${CMAKE_CURRENT_LIST_DIR}/rocprofiler-sdk.hpp
     ${CMAKE_CURRENT_LIST_DIR}/state.hpp
     ${CMAKE_CURRENT_LIST_DIR}/timemory.hpp

--- a/projects/rocprofiler-systems/source/lib/core/progress_bar.cpp
+++ b/projects/rocprofiler-systems/source/lib/core/progress_bar.cpp
@@ -1,0 +1,103 @@
+// Copyright (c) Advanced Micro Devices, Inc.
+// SPDX-License-Identifier:  MIT
+
+#include "progress_bar.hpp"
+
+#include <algorithm>
+#include <array>
+#include <cstddef>
+#include <ostream>
+#include <string>
+#include <utility>
+
+#include <spdlog/fmt/fmt.h>
+
+namespace rocprofsys
+{
+
+// Unicode block elements: space, 1/8 .. 7/8, full block
+static constexpr std::array<const char*, 9> BLOCK_CHARS = {
+    " ", "\u258f", "\u258e", "\u258d", "\u258c", "\u258b", "\u258a", "\u2589", "\u2588"
+};
+
+progress_bar::progress_bar(size_t bar_width, std::string prefix_text,
+                           std::string postfix_text, size_t max_progress,
+                           std::ostream& stream)
+: m_bar_width(bar_width)
+, m_prefix_text(std::move(prefix_text))
+, m_postfix_text(std::move(postfix_text))
+, m_max_progress(max_progress > 0 ? max_progress : 1)
+, m_os(stream)
+{}
+
+progress_bar::~progress_bar()
+{
+    if(!is_completed()) mark_as_completed();
+}
+
+void
+progress_bar::set_progress(size_t value)
+{
+    const std::lock_guard<std::mutex> lock(m_mutex);
+    auto                              clamped = std::min(value, m_max_progress);
+    if(clamped == m_progress) return;
+    m_progress = clamped;
+    render();
+    if(m_progress >= m_max_progress)
+    {
+        m_completed.store(true, std::memory_order_release);
+        m_os << '\n';
+    }
+}
+
+bool
+progress_bar::is_completed() const noexcept
+{
+    return m_completed.load(std::memory_order_acquire);
+}
+
+void
+progress_bar::mark_as_completed()
+{
+    const std::lock_guard<std::mutex> lock(m_mutex);
+    if(m_completed.load(std::memory_order_acquire)) return;
+    m_progress = m_max_progress;
+    m_completed.store(true, std::memory_order_release);
+    render();
+    m_os << '\n';
+}
+
+void
+progress_bar::render()
+{
+    const auto fraction = std::min(
+        static_cast<double>(m_progress) / static_cast<double>(m_max_progress), 1.0);
+
+    const auto total_eighths =
+        static_cast<size_t>(fraction * static_cast<double>(m_bar_width * PARTS_PER_CELL));
+    const auto full      = total_eighths / PARTS_PER_CELL;
+    const auto remainder = total_eighths % PARTS_PER_CELL;
+    const auto empty     = m_bar_width - full - (remainder > 0 ? 1 : 0);
+    const auto percent   = static_cast<size_t>(fraction * 100.0);
+
+    std::string bar_fill;
+    bar_fill.reserve(m_bar_width * 4);
+    for(size_t i = 0; i < full; ++i)
+    {
+        bar_fill += BLOCK_CHARS[PARTS_PER_CELL];
+    }
+    if(remainder > 0)
+    {
+        bar_fill += BLOCK_CHARS[remainder];
+    }
+    for(size_t i = 0; i < empty; ++i)
+    {
+        bar_fill += ' ';
+    }
+
+    m_os << fmt::format("\r{}[{}] {:>3}% {}", m_prefix_text, bar_fill, percent,
+                        m_postfix_text);
+    m_os.flush();
+}
+
+}  // namespace rocprofsys

--- a/projects/rocprofiler-systems/source/lib/core/progress_bar.hpp
+++ b/projects/rocprofiler-systems/source/lib/core/progress_bar.hpp
@@ -1,0 +1,62 @@
+// Copyright (c) Advanced Micro Devices, Inc.
+// SPDX-License-Identifier:  MIT
+
+#pragma once
+
+#include <atomic>
+#include <cstddef>
+#include <iosfwd>
+#include <mutex>
+#include <string>
+
+namespace rocprofsys
+{
+
+/**
+ * Thread-safe unicode block progress bar.
+ *
+ * Renders a bar like: Processing [████████▌       ] 53% output.proto
+ * Uses \r for in-place updates, emits \n on completion.
+ */
+class progress_bar
+{
+public:
+    /**
+     * @param bar_width    Number of character cells for the bar fill area.
+     * @param prefix_text  Text printed before the bar (e.g. "Processing ").
+     * @param postfix_text Text printed after the percentage (e.g. filename).
+     * @param max_progress Value at which the bar reaches 100%.
+     * @param stream       Output stream for rendering (typically std::cerr).
+     */
+    progress_bar(size_t bar_width, std::string prefix_text, std::string postfix_text,
+                 size_t max_progress, std::ostream& stream);
+
+    ~progress_bar();
+
+    progress_bar(const progress_bar&)            = delete;
+    progress_bar& operator=(const progress_bar&) = delete;
+    progress_bar(progress_bar&&)                 = delete;
+    progress_bar& operator=(progress_bar&&)      = delete;
+
+    void set_progress(size_t value);
+
+    [[nodiscard]] bool is_completed() const noexcept;
+
+    void mark_as_completed();
+
+private:
+    void render();
+
+    static constexpr size_t PARTS_PER_CELL = 8;
+
+    size_t            m_bar_width    = 0;
+    std::string       m_prefix_text  = {};
+    std::string       m_postfix_text = {};
+    size_t            m_max_progress = 0;
+    size_t            m_progress     = 0;
+    std::atomic<bool> m_completed{ false };
+    std::ostream&     m_os;
+    std::mutex        m_mutex;
+};
+
+}  // namespace rocprofsys

--- a/projects/rocprofiler-systems/source/lib/core/trace_cache/cache_manager.cpp
+++ b/projects/rocprofiler-systems/source/lib/core/trace_cache/cache_manager.cpp
@@ -30,17 +30,23 @@
 
 #include "core/agent_manager.hpp"
 #include "core/config.hpp"
+#include "core/progress_bar.hpp"
 #include "core/timemory.hpp"
 
 #include "library/runtime.hpp"
 #include "logger/debug.hpp"
 
+#include <sys/stat.h>
+#include <unistd.h>
+
 #include <algorithm>
+#include <atomic>
 #include <cstring>
 #include <fstream>
 #include <memory>
 #include <sstream>
 #include <stdexcept>
+#include <utility>
 #include <vector>
 
 namespace rocprofsys
@@ -401,6 +407,62 @@ merge_perfetto_files()
 
 namespace processing_utils
 {
+
+constexpr size_t PROGRESS_BAR_WIDTH = 40;
+
+std::shared_ptr<rocprofsys::progress_bar>
+make_progress_bar(std::string postfix, size_t max_progress)
+{
+    if(!isatty(STDERR_FILENO) || config::get_verbose() < 0 || max_progress == 0)
+    {
+        return nullptr;
+    }
+    return std::make_shared<rocprofsys::progress_bar>(
+        PROGRESS_BAR_WIDTH, "Generating ", std::move(postfix), max_progress, std::cerr);
+}
+
+progress_callback_t
+make_progress_callback(const std::shared_ptr<rocprofsys::progress_bar>& bar)
+{
+    if(!bar) return nullptr;
+    return [bar](size_t bytes_read, size_t /*total_bytes*/) {
+        if(!bar->is_completed())
+        {
+            bar->set_progress(bytes_read);
+        }
+    };
+}
+
+progress_callback_t
+make_shared_progress_callback(const std::shared_ptr<rocprofsys::progress_bar>& bar,
+                              std::shared_ptr<std::atomic<size_t>> total_bytes_read)
+{
+    if(!bar) return nullptr;
+    return [bar, total_bytes_read, last_pos = size_t{ 0 }](size_t pos,
+                                                           size_t /*file_size*/) mutable {
+        size_t delta = (pos >= last_pos) ? (pos - last_pos) : 0;
+        last_pos     = pos;
+        auto total =
+            total_bytes_read->fetch_add(delta, std::memory_order_relaxed) + delta;
+        bar->set_progress(total);
+    };
+}
+
+size_t
+get_total_cache_size(
+    const std::vector<std::shared_ptr<data::processor_config_t>>& configs)
+{
+    size_t total = 0;
+    for(const auto& config : configs)
+    {
+        auto fname = utility::get_buffered_storage_filename(config->_ppid, config->_pid);
+        struct stat file_stat;
+        if(stat(fname.c_str(), &file_stat) == 0 && file_stat.st_size > 0)
+            total += static_cast<size_t>(file_stat.st_size);
+    }
+    return total;
+}
+
 [[nodiscard]] data::processor_storage_t
 configure_processors(const std::shared_ptr<sample_processor_t>&       _type_processing,
                      const std::shared_ptr<data::processor_config_t>& _processor_config,
@@ -429,7 +491,7 @@ void
 process_buffered_storage(
     const std::shared_ptr<data::processor_config_t>& _processor_config,
     const std::string& _storage_filename, const data::enabled_formats_t& _enabled_formats,
-    output_file_registry& _output_registry)
+    output_file_registry& _output_registry, progress_callback_t _progress_cb)
 {
     LOG_DEBUG("Processing buffered storage: {} for pid={}", _storage_filename,
               _processor_config->_pid);
@@ -442,7 +504,7 @@ process_buffered_storage(
     _processor_coordinator->prepare_for_processing();
     try
     {
-        _parser.load(_processor_coordinator);
+        _parser.load(_processor_coordinator, std::move(_progress_cb));
         LOG_TRACE("Successfully loaded buffered storage: {}", _storage_filename);
     } catch(const std::runtime_error& exp)
     {
@@ -492,6 +554,20 @@ multithreaded_processing(
               _processor_configs.size());
     ROCPROFSYS_SCOPED_SAMPLING_ON_CHILD_THREADS(false);
 
+    auto total_file_size  = get_total_cache_size(_processor_configs);
+    auto total_bytes_read = std::make_shared<std::atomic<size_t>>(0);
+
+    std::vector<pid_t> pids;
+    pids.reserve(_processor_configs.size());
+    for(const auto& cfg : _processor_configs)
+    {
+        pids.push_back(cfg->_pid);
+    }
+
+    auto bar = make_progress_bar(fmt::format("rocpd output from {} process(es) [{}]",
+                                             pids.size(), fmt::join(pids, ", ")),
+                                 total_file_size);
+
     std::vector<std::thread> processing_threads;
     processing_threads.reserve(_processor_configs.size());
     for(const auto& processor_config : _processor_configs)
@@ -501,7 +577,8 @@ multithreaded_processing(
             process_buffered_storage, processor_config,
             utility::get_buffered_storage_filename(processor_config->_ppid,
                                                    processor_config->_pid),
-            _enabled_formats, std::ref(_output_registry));
+            _enabled_formats, std::ref(_output_registry),
+            make_shared_progress_callback(bar, total_bytes_read));
     }
 
     LOG_TRACE("Waiting for {} processing threads to complete", processing_threads.size());
@@ -509,6 +586,8 @@ multithreaded_processing(
     {
         thread.join();
     }
+    if(bar) bar->mark_as_completed();
+
     LOG_DEBUG("Multithreaded processing completed");
 }
 
@@ -520,13 +599,28 @@ sequential_processing(
 {
     LOG_DEBUG("Starting sequential processing with {} configs",
               _processor_configs.size());
+
     for(const auto& processor_config : _processor_configs)
     {
-        LOG_TRACE("Processing config for pid={}", processor_config->_pid);
-        process_buffered_storage(processor_config,
-                                 utility::get_buffered_storage_filename(
-                                     processor_config->_ppid, processor_config->_pid),
-                                 _enabled_formats, _output_registry);
+        auto pid  = processor_config->_pid;
+        auto ppid = processor_config->_ppid;
+
+        LOG_TRACE("Processing config for pid={}", pid);
+
+        auto cache_file = utility::get_buffered_storage_filename(ppid, pid);
+
+        struct stat file_stat = {};
+        size_t      file_size = 0;
+        if(stat(cache_file.c_str(), &file_stat) == 0 && file_stat.st_size > 0)
+        {
+            file_size = static_cast<size_t>(file_stat.st_size);
+        }
+
+        auto bar = make_progress_bar(
+            fmt::format("perfetto output from process [{}]", pid), file_size);
+
+        process_buffered_storage(processor_config, cache_file, _enabled_formats,
+                                 _output_registry, make_progress_callback(bar));
     }
     LOG_DEBUG("Sequential processing completed");
 }

--- a/projects/rocprofiler-systems/source/lib/core/trace_cache/storage_parser.hpp
+++ b/projects/rocprofiler-systems/source/lib/core/trace_cache/storage_parser.hpp
@@ -34,6 +34,7 @@
 #include <cstdlib>
 #include <cstring>
 #include <fstream>
+#include <functional>
 #include <memory>
 #include <string>
 
@@ -41,6 +42,10 @@ namespace rocprofsys
 {
 namespace trace_cache
 {
+
+/// Callback reporting parsing progress: (bytes_read, total_bytes)
+using progress_callback_t = std::function<void(size_t, size_t)>;
+
 template <typename TypeIdentifierEnum, typename... SupportedTypes>
 class storage_parser
 {
@@ -50,12 +55,13 @@ class storage_parser
     static_assert(sizeof...(SupportedTypes) != 0, "SupportedTypes must be non-empty");
 
 public:
-    storage_parser(std::string _filename)
+    explicit storage_parser(std::string _filename)
     : m_filename(std::move(_filename))
     {}
 
     template <typename TypeProcessing>
-    void load(std::shared_ptr<TypeProcessing> _type_processing)
+    void load(std::shared_ptr<TypeProcessing> _type_processing,
+              progress_callback_t             progress_cb = nullptr)
     {
         static_assert(
             type_traits::has_execute_processing<TypeProcessing, TypeIdentifierEnum,
@@ -77,6 +83,16 @@ public:
                 fmt::format("Error opening file for reading: {}", m_filename));
         }
 
+        size_t file_size = 0;
+        if(progress_cb)
+        {
+            ifs.seekg(0, std::ios::end);
+            auto end_pos = ifs.tellg();
+            file_size    = (end_pos > 0) ? static_cast<size_t>(end_pos) : 0;
+            ifs.seekg(0, std::ios::beg);
+            if(file_size == 0) progress_cb = nullptr;
+        }
+
         struct __attribute__((packed)) sample_header
         {
             TypeIdentifierEnum type;
@@ -89,6 +105,11 @@ public:
         sample.reserve(4096);
         size_t last_capacity = sample.capacity();
 
+        // Report progress every N samples to balance UI responsiveness vs. overhead
+        constexpr size_t PROGRESS_INTERVAL = 500;
+        size_t           samples_processed = 0;
+        size_t           bytes_read        = 0;
+
         while(!ifs.eof())
         {
             if(!ifs.good())
@@ -98,6 +119,7 @@ public:
             }
 
             ifs.read(reinterpret_cast<char*>(&header), sizeof(header));
+            if(ifs.gcount() < static_cast<std::streamsize>(sizeof(header))) break;
 
             if(header.sample_size == 0 || ifs.eof())
             {
@@ -118,7 +140,14 @@ public:
                 throw std::runtime_error(
                     fmt::format("Bad read while consuming buffered storage. Filename: {} "
                                 "Bytes read: {}",
-                                m_filename, static_cast<int>(ifs.tellg())));
+                                m_filename, static_cast<size_t>(ifs.tellg())));
+            }
+
+            bytes_read += sizeof(header) + header.sample_size;
+
+            if(progress_cb && ++samples_processed % PROGRESS_INTERVAL == 0)
+            {
+                progress_cb(bytes_read, file_size);
             }
 
             if(header.type == TypeIdentifierEnum::fragmented_space)
@@ -144,6 +173,11 @@ public:
                 LOG_TRACE("Unknown sample type encountered, skipping");
                 continue;
             }
+        }
+
+        if(progress_cb)
+        {
+            progress_cb(file_size, file_size);
         }
 
         ifs.close();


### PR DESCRIPTION
## Motivation

- Generating output files can take a long time, especially for large files. Users may mistakenly think the application has crashed and exit it prematurely

## Technical Details

- A self-contained, thread-safe progress bar that writes unicode block characters to a stream.
-  The parser knows nothing about progress bars. It has a single addition: an optional `progress_callback_t` parameter on `load()`.
- Small helper functions in the `processing_utils` namespace handle all progress bar concerns.
- For perfetto output we have one bar per file, created and destroyed within each loop iteration.
- For rocpd output there is one bar shared across all threads. Each thread's callback accumulates its own byte deltas into the shared atomic.

## JIRA ID

AIPROFSYST-372

## Test Plan

- Manually test with single and multiprocess runs.
- Test with existing test suites.

## Test Result

<img width="1767" height="262" alt="image" src="https://github.com/user-attachments/assets/080aa095-2a6f-4c51-bf58-a2ed765ca007" />

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
