### PR TITLE
thunk_loader: port dynamic symbol loading to Windows/MSVC

### DIFF
--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/thunk_loader.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/thunk_loader.cpp
@@ -57,7 +57,11 @@ namespace core {
     is_dtif_ = is_dxg_ = false;
     if (core::Runtime::runtime_singleton_->flag().enable_dtif()) {
       is_dtif_ = true;
+#if defined(_WIN32)
+      return "dtif64a.dll";
+#else
       return "libdtif.so";
+#endif
     }
 
 #if defined(__linux__)
@@ -105,355 +109,353 @@ namespace core {
 
   void ThunkLoader::LoadThunkApiTable() {
     if (IsSharedLibraryLoaded()) {
-#if defined(__linux__)
-      dlerror(); // Clear any existing error messages
+      rocr::os::DlError(); // Clear any existing error messages
 
-      HSAKMT_PFN(hsaKmtOpenKFD) = (HSAKMT_DEF(hsaKmtOpenKFD)*)dlsym(thunk_handle, "hsaKmtOpenKFD");
-      if (HSAKMT_PFN(hsaKmtOpenKFD) == nullptr) goto ERROR;
+      HSAKMT_PFN(hsaKmtOpenKFD) = (HSAKMT_DEF(hsaKmtOpenKFD)*)rocr::os::GetExportAddress(thunk_handle, "hsaKmtOpenKFD");
+      if (HSAKMT_PFN(hsaKmtOpenKFD) == nullptr) goto LOAD_ERROR;
 
-      HSAKMT_PFN(hsaKmtCloseKFD) = (HSAKMT_DEF(hsaKmtCloseKFD)*)dlsym(thunk_handle, "hsaKmtCloseKFD");
-      if (HSAKMT_PFN(hsaKmtCloseKFD) == nullptr) goto ERROR;
+      HSAKMT_PFN(hsaKmtCloseKFD) = (HSAKMT_DEF(hsaKmtCloseKFD)*)rocr::os::GetExportAddress(thunk_handle, "hsaKmtCloseKFD");
+      if (HSAKMT_PFN(hsaKmtCloseKFD) == nullptr) goto LOAD_ERROR;
 
-      HSAKMT_PFN(hsaKmtGetVersion) = (HSAKMT_DEF(hsaKmtGetVersion)*)dlsym(thunk_handle, "hsaKmtGetVersion");
-      if (HSAKMT_PFN(hsaKmtGetVersion) == nullptr) goto ERROR;
+      HSAKMT_PFN(hsaKmtGetVersion) = (HSAKMT_DEF(hsaKmtGetVersion)*)rocr::os::GetExportAddress(thunk_handle, "hsaKmtGetVersion");
+      if (HSAKMT_PFN(hsaKmtGetVersion) == nullptr) goto LOAD_ERROR;
 
-      HSAKMT_PFN(hsaKmtAcquireSystemProperties) = (HSAKMT_DEF(hsaKmtAcquireSystemProperties)*)dlsym(thunk_handle, "hsaKmtAcquireSystemProperties");
-      if (HSAKMT_PFN(hsaKmtAcquireSystemProperties) == nullptr) goto ERROR;
+      HSAKMT_PFN(hsaKmtAcquireSystemProperties) = (HSAKMT_DEF(hsaKmtAcquireSystemProperties)*)rocr::os::GetExportAddress(thunk_handle, "hsaKmtAcquireSystemProperties");
+      if (HSAKMT_PFN(hsaKmtAcquireSystemProperties) == nullptr) goto LOAD_ERROR;
 
-      HSAKMT_PFN(hsaKmtReleaseSystemProperties) = (HSAKMT_DEF(hsaKmtReleaseSystemProperties)*)dlsym(thunk_handle, "hsaKmtReleaseSystemProperties");
-      if (HSAKMT_PFN(hsaKmtReleaseSystemProperties) == nullptr) goto ERROR;
+      HSAKMT_PFN(hsaKmtReleaseSystemProperties) = (HSAKMT_DEF(hsaKmtReleaseSystemProperties)*)rocr::os::GetExportAddress(thunk_handle, "hsaKmtReleaseSystemProperties");
+      if (HSAKMT_PFN(hsaKmtReleaseSystemProperties) == nullptr) goto LOAD_ERROR;
 
-      HSAKMT_PFN(hsaKmtGetNodeProperties) = (HSAKMT_DEF(hsaKmtGetNodeProperties)*)dlsym(thunk_handle, "hsaKmtGetNodeProperties");
-      if (HSAKMT_PFN(hsaKmtGetNodeProperties) == nullptr) goto ERROR;
+      HSAKMT_PFN(hsaKmtGetNodeProperties) = (HSAKMT_DEF(hsaKmtGetNodeProperties)*)rocr::os::GetExportAddress(thunk_handle, "hsaKmtGetNodeProperties");
+      if (HSAKMT_PFN(hsaKmtGetNodeProperties) == nullptr) goto LOAD_ERROR;
 
-      HSAKMT_PFN(hsaKmtGetNodeMemoryProperties) = (HSAKMT_DEF(hsaKmtGetNodeMemoryProperties)*)dlsym(thunk_handle, "hsaKmtGetNodeMemoryProperties");
-      if (HSAKMT_PFN(hsaKmtGetNodeMemoryProperties) == nullptr) goto ERROR;
+      HSAKMT_PFN(hsaKmtGetNodeMemoryProperties) = (HSAKMT_DEF(hsaKmtGetNodeMemoryProperties)*)rocr::os::GetExportAddress(thunk_handle, "hsaKmtGetNodeMemoryProperties");
+      if (HSAKMT_PFN(hsaKmtGetNodeMemoryProperties) == nullptr) goto LOAD_ERROR;
 
-      HSAKMT_PFN(hsaKmtGetNodeCacheProperties) = (HSAKMT_DEF(hsaKmtGetNodeCacheProperties)*)dlsym(thunk_handle, "hsaKmtGetNodeCacheProperties");
-      if (HSAKMT_PFN(hsaKmtGetNodeCacheProperties) == nullptr) goto ERROR;
+      HSAKMT_PFN(hsaKmtGetNodeCacheProperties) = (HSAKMT_DEF(hsaKmtGetNodeCacheProperties)*)rocr::os::GetExportAddress(thunk_handle, "hsaKmtGetNodeCacheProperties");
+      if (HSAKMT_PFN(hsaKmtGetNodeCacheProperties) == nullptr) goto LOAD_ERROR;
 
-      HSAKMT_PFN(hsaKmtGetNodeIoLinkProperties) = (HSAKMT_DEF(hsaKmtGetNodeIoLinkProperties)*)dlsym(thunk_handle, "hsaKmtGetNodeIoLinkProperties");
-      if (HSAKMT_PFN(hsaKmtGetNodeIoLinkProperties) == nullptr) goto ERROR;
+      HSAKMT_PFN(hsaKmtGetNodeIoLinkProperties) = (HSAKMT_DEF(hsaKmtGetNodeIoLinkProperties)*)rocr::os::GetExportAddress(thunk_handle, "hsaKmtGetNodeIoLinkProperties");
+      if (HSAKMT_PFN(hsaKmtGetNodeIoLinkProperties) == nullptr) goto LOAD_ERROR;
 
-      HSAKMT_PFN(hsaKmtCreateEvent) = (HSAKMT_DEF(hsaKmtCreateEvent)*)dlsym(thunk_handle, "hsaKmtCreateEvent");
-      if (HSAKMT_PFN(hsaKmtCreateEvent) == nullptr) goto ERROR;
+      HSAKMT_PFN(hsaKmtCreateEvent) = (HSAKMT_DEF(hsaKmtCreateEvent)*)rocr::os::GetExportAddress(thunk_handle, "hsaKmtCreateEvent");
+      if (HSAKMT_PFN(hsaKmtCreateEvent) == nullptr) goto LOAD_ERROR;
 
-      HSAKMT_PFN(hsaKmtDestroyEvent) = (HSAKMT_DEF(hsaKmtDestroyEvent)*)dlsym(thunk_handle, "hsaKmtDestroyEvent");
-      if (HSAKMT_PFN(hsaKmtDestroyEvent) == nullptr) goto ERROR;
+      HSAKMT_PFN(hsaKmtDestroyEvent) = (HSAKMT_DEF(hsaKmtDestroyEvent)*)rocr::os::GetExportAddress(thunk_handle, "hsaKmtDestroyEvent");
+      if (HSAKMT_PFN(hsaKmtDestroyEvent) == nullptr) goto LOAD_ERROR;
 
-      HSAKMT_PFN(hsaKmtSetEvent) = (HSAKMT_DEF(hsaKmtSetEvent)*)dlsym(thunk_handle, "hsaKmtSetEvent");
-      if (HSAKMT_PFN(hsaKmtSetEvent) == nullptr) goto ERROR;
+      HSAKMT_PFN(hsaKmtSetEvent) = (HSAKMT_DEF(hsaKmtSetEvent)*)rocr::os::GetExportAddress(thunk_handle, "hsaKmtSetEvent");
+      if (HSAKMT_PFN(hsaKmtSetEvent) == nullptr) goto LOAD_ERROR;
 
-      HSAKMT_PFN(hsaKmtResetEvent) = (HSAKMT_DEF(hsaKmtResetEvent)*)dlsym(thunk_handle, "hsaKmtResetEvent");
-      if (HSAKMT_PFN(hsaKmtResetEvent) == nullptr) goto ERROR;
+      HSAKMT_PFN(hsaKmtResetEvent) = (HSAKMT_DEF(hsaKmtResetEvent)*)rocr::os::GetExportAddress(thunk_handle, "hsaKmtResetEvent");
+      if (HSAKMT_PFN(hsaKmtResetEvent) == nullptr) goto LOAD_ERROR;
 
-      HSAKMT_PFN(hsaKmtQueryEventState) = (HSAKMT_DEF(hsaKmtQueryEventState)*)dlsym(thunk_handle, "hsaKmtQueryEventState");
-      if (HSAKMT_PFN(hsaKmtQueryEventState) == nullptr) goto ERROR;
+      HSAKMT_PFN(hsaKmtQueryEventState) = (HSAKMT_DEF(hsaKmtQueryEventState)*)rocr::os::GetExportAddress(thunk_handle, "hsaKmtQueryEventState");
+      if (HSAKMT_PFN(hsaKmtQueryEventState) == nullptr) goto LOAD_ERROR;
 
-      HSAKMT_PFN(hsaKmtWaitOnEvent) = (HSAKMT_DEF(hsaKmtWaitOnEvent)*)dlsym(thunk_handle, "hsaKmtWaitOnEvent");
-      if (HSAKMT_PFN(hsaKmtWaitOnEvent) == nullptr) goto ERROR;
+      HSAKMT_PFN(hsaKmtWaitOnEvent) = (HSAKMT_DEF(hsaKmtWaitOnEvent)*)rocr::os::GetExportAddress(thunk_handle, "hsaKmtWaitOnEvent");
+      if (HSAKMT_PFN(hsaKmtWaitOnEvent) == nullptr) goto LOAD_ERROR;
 
-      HSAKMT_PFN(hsaKmtWaitOnMultipleEvents) = (HSAKMT_DEF(hsaKmtWaitOnMultipleEvents)*)dlsym(thunk_handle, "hsaKmtWaitOnMultipleEvents");
-      if (HSAKMT_PFN(hsaKmtWaitOnMultipleEvents) == nullptr) goto ERROR;
+      HSAKMT_PFN(hsaKmtWaitOnMultipleEvents) = (HSAKMT_DEF(hsaKmtWaitOnMultipleEvents)*)rocr::os::GetExportAddress(thunk_handle, "hsaKmtWaitOnMultipleEvents");
+      if (HSAKMT_PFN(hsaKmtWaitOnMultipleEvents) == nullptr) goto LOAD_ERROR;
 
-      HSAKMT_PFN(hsaKmtCreateQueue) = (HSAKMT_DEF(hsaKmtCreateQueue)*)dlsym(thunk_handle, "hsaKmtCreateQueue");
-      if (HSAKMT_PFN(hsaKmtCreateQueue) == nullptr) goto ERROR;
+      HSAKMT_PFN(hsaKmtCreateQueue) = (HSAKMT_DEF(hsaKmtCreateQueue)*)rocr::os::GetExportAddress(thunk_handle, "hsaKmtCreateQueue");
+      if (HSAKMT_PFN(hsaKmtCreateQueue) == nullptr) goto LOAD_ERROR;
 
-      HSAKMT_PFN(hsaKmtCreateQueueExt) = (HSAKMT_DEF(hsaKmtCreateQueueExt)*)dlsym(thunk_handle, "hsaKmtCreateQueueExt");
-      if (HSAKMT_PFN(hsaKmtCreateQueueExt) == nullptr) goto ERROR;
+      HSAKMT_PFN(hsaKmtCreateQueueExt) = (HSAKMT_DEF(hsaKmtCreateQueueExt)*)rocr::os::GetExportAddress(thunk_handle, "hsaKmtCreateQueueExt");
+      if (HSAKMT_PFN(hsaKmtCreateQueueExt) == nullptr) goto LOAD_ERROR;
 
-      HSAKMT_PFN(hsaKmtCreateQueueV2) = (HSAKMT_DEF(hsaKmtCreateQueueV2)*)dlsym(thunk_handle, "hsaKmtCreateQueueV2");
-      if (HSAKMT_PFN(hsaKmtCreateQueueV2) == NULL) goto ERROR;
+      HSAKMT_PFN(hsaKmtCreateQueueV2) = (HSAKMT_DEF(hsaKmtCreateQueueV2)*)rocr::os::GetExportAddress(thunk_handle, "hsaKmtCreateQueueV2");
+      if (HSAKMT_PFN(hsaKmtCreateQueueV2) == NULL) goto LOAD_ERROR;
 
-      HSAKMT_PFN(hsaKmtUpdateQueue) = (HSAKMT_DEF(hsaKmtUpdateQueue)*)dlsym(thunk_handle, "hsaKmtUpdateQueue");
-      if (HSAKMT_PFN(hsaKmtUpdateQueue) == nullptr) goto ERROR;
+      HSAKMT_PFN(hsaKmtUpdateQueue) = (HSAKMT_DEF(hsaKmtUpdateQueue)*)rocr::os::GetExportAddress(thunk_handle, "hsaKmtUpdateQueue");
+      if (HSAKMT_PFN(hsaKmtUpdateQueue) == nullptr) goto LOAD_ERROR;
 
-      HSAKMT_PFN(hsaKmtDestroyQueue) = (HSAKMT_DEF(hsaKmtDestroyQueue)*)dlsym(thunk_handle, "hsaKmtDestroyQueue");
-      if (HSAKMT_PFN(hsaKmtDestroyQueue) == nullptr) goto ERROR;
+      HSAKMT_PFN(hsaKmtDestroyQueue) = (HSAKMT_DEF(hsaKmtDestroyQueue)*)rocr::os::GetExportAddress(thunk_handle, "hsaKmtDestroyQueue");
+      if (HSAKMT_PFN(hsaKmtDestroyQueue) == nullptr) goto LOAD_ERROR;
 
-      HSAKMT_PFN(hsaKmtSetQueueCUMask) = (HSAKMT_DEF(hsaKmtSetQueueCUMask)*)dlsym(thunk_handle, "hsaKmtSetQueueCUMask");
-      if (HSAKMT_PFN(hsaKmtSetQueueCUMask) == nullptr) goto ERROR;
+      HSAKMT_PFN(hsaKmtSetQueueCUMask) = (HSAKMT_DEF(hsaKmtSetQueueCUMask)*)rocr::os::GetExportAddress(thunk_handle, "hsaKmtSetQueueCUMask");
+      if (HSAKMT_PFN(hsaKmtSetQueueCUMask) == nullptr) goto LOAD_ERROR;
 
-      HSAKMT_PFN(hsaKmtSetMemoryPolicy) = (HSAKMT_DEF(hsaKmtSetMemoryPolicy)*)dlsym(thunk_handle, "hsaKmtSetMemoryPolicy");
-      if (HSAKMT_PFN(hsaKmtSetMemoryPolicy) == nullptr) goto ERROR;
+      HSAKMT_PFN(hsaKmtSetMemoryPolicy) = (HSAKMT_DEF(hsaKmtSetMemoryPolicy)*)rocr::os::GetExportAddress(thunk_handle, "hsaKmtSetMemoryPolicy");
+      if (HSAKMT_PFN(hsaKmtSetMemoryPolicy) == nullptr) goto LOAD_ERROR;
 
-      HSAKMT_PFN(hsaKmtAllocMemory) = (HSAKMT_DEF(hsaKmtAllocMemory)*)dlsym(thunk_handle, "hsaKmtAllocMemory");
-      if (HSAKMT_PFN(hsaKmtAllocMemory) == nullptr) goto ERROR;
+      HSAKMT_PFN(hsaKmtAllocMemory) = (HSAKMT_DEF(hsaKmtAllocMemory)*)rocr::os::GetExportAddress(thunk_handle, "hsaKmtAllocMemory");
+      if (HSAKMT_PFN(hsaKmtAllocMemory) == nullptr) goto LOAD_ERROR;
 
-      HSAKMT_PFN(hsaKmtAllocMemoryAlign) = (HSAKMT_DEF(hsaKmtAllocMemoryAlign)*)dlsym(thunk_handle, "hsaKmtAllocMemoryAlign");
-      if (HSAKMT_PFN(hsaKmtAllocMemoryAlign) == nullptr) goto ERROR;
+      HSAKMT_PFN(hsaKmtAllocMemoryAlign) = (HSAKMT_DEF(hsaKmtAllocMemoryAlign)*)rocr::os::GetExportAddress(thunk_handle, "hsaKmtAllocMemoryAlign");
+      if (HSAKMT_PFN(hsaKmtAllocMemoryAlign) == nullptr) goto LOAD_ERROR;
 
-      HSAKMT_PFN(hsaKmtFreeMemory) = (HSAKMT_DEF(hsaKmtFreeMemory)*)dlsym(thunk_handle, "hsaKmtFreeMemory");
-      if (HSAKMT_PFN(hsaKmtFreeMemory) == nullptr) goto ERROR;
+      HSAKMT_PFN(hsaKmtFreeMemory) = (HSAKMT_DEF(hsaKmtFreeMemory)*)rocr::os::GetExportAddress(thunk_handle, "hsaKmtFreeMemory");
+      if (HSAKMT_PFN(hsaKmtFreeMemory) == nullptr) goto LOAD_ERROR;
 
-      HSAKMT_PFN(hsaKmtAvailableMemory) = (HSAKMT_DEF(hsaKmtAvailableMemory)*)dlsym(thunk_handle, "hsaKmtAvailableMemory");
-      if (HSAKMT_PFN(hsaKmtAvailableMemory) == nullptr) goto ERROR;
+      HSAKMT_PFN(hsaKmtAvailableMemory) = (HSAKMT_DEF(hsaKmtAvailableMemory)*)rocr::os::GetExportAddress(thunk_handle, "hsaKmtAvailableMemory");
+      if (HSAKMT_PFN(hsaKmtAvailableMemory) == nullptr) goto LOAD_ERROR;
 
-      HSAKMT_PFN(hsaKmtRegisterMemory) = (HSAKMT_DEF(hsaKmtRegisterMemory)*)dlsym(thunk_handle, "hsaKmtRegisterMemory");
-      if (HSAKMT_PFN(hsaKmtRegisterMemory) == nullptr) goto ERROR;
+      HSAKMT_PFN(hsaKmtRegisterMemory) = (HSAKMT_DEF(hsaKmtRegisterMemory)*)rocr::os::GetExportAddress(thunk_handle, "hsaKmtRegisterMemory");
+      if (HSAKMT_PFN(hsaKmtRegisterMemory) == nullptr) goto LOAD_ERROR;
 
-      HSAKMT_PFN(hsaKmtRegisterMemoryToNodes) = (HSAKMT_DEF(hsaKmtRegisterMemoryToNodes)*)dlsym(thunk_handle, "hsaKmtRegisterMemoryToNodes");
-      if (HSAKMT_PFN(hsaKmtRegisterMemoryToNodes) == nullptr) goto ERROR;
+      HSAKMT_PFN(hsaKmtRegisterMemoryToNodes) = (HSAKMT_DEF(hsaKmtRegisterMemoryToNodes)*)rocr::os::GetExportAddress(thunk_handle, "hsaKmtRegisterMemoryToNodes");
+      if (HSAKMT_PFN(hsaKmtRegisterMemoryToNodes) == nullptr) goto LOAD_ERROR;
 
-      HSAKMT_PFN(hsaKmtRegisterMemoryWithFlags) = (HSAKMT_DEF(hsaKmtRegisterMemoryWithFlags)*)dlsym(thunk_handle, "hsaKmtRegisterMemoryWithFlags");
-      if (HSAKMT_PFN(hsaKmtRegisterMemoryWithFlags) == nullptr) goto ERROR;
+      HSAKMT_PFN(hsaKmtRegisterMemoryWithFlags) = (HSAKMT_DEF(hsaKmtRegisterMemoryWithFlags)*)rocr::os::GetExportAddress(thunk_handle, "hsaKmtRegisterMemoryWithFlags");
+      if (HSAKMT_PFN(hsaKmtRegisterMemoryWithFlags) == nullptr) goto LOAD_ERROR;
 
-      HSAKMT_PFN(hsaKmtRegisterGraphicsHandleToNodes) = (HSAKMT_DEF(hsaKmtRegisterGraphicsHandleToNodes)*)dlsym(thunk_handle, "hsaKmtRegisterGraphicsHandleToNodes");
-      if (HSAKMT_PFN(hsaKmtRegisterGraphicsHandleToNodes) == nullptr) goto ERROR;
+      HSAKMT_PFN(hsaKmtRegisterGraphicsHandleToNodes) = (HSAKMT_DEF(hsaKmtRegisterGraphicsHandleToNodes)*)rocr::os::GetExportAddress(thunk_handle, "hsaKmtRegisterGraphicsHandleToNodes");
+      if (HSAKMT_PFN(hsaKmtRegisterGraphicsHandleToNodes) == nullptr) goto LOAD_ERROR;
 
-      HSAKMT_PFN(hsaKmtRegisterGraphicsHandleToNodesExt) = (HSAKMT_DEF(hsaKmtRegisterGraphicsHandleToNodesExt)*)dlsym(thunk_handle, "hsaKmtRegisterGraphicsHandleToNodesExt");
-      if (HSAKMT_PFN(hsaKmtRegisterGraphicsHandleToNodesExt) == nullptr) goto ERROR;
+      HSAKMT_PFN(hsaKmtRegisterGraphicsHandleToNodesExt) = (HSAKMT_DEF(hsaKmtRegisterGraphicsHandleToNodesExt)*)rocr::os::GetExportAddress(thunk_handle, "hsaKmtRegisterGraphicsHandleToNodesExt");
+      if (HSAKMT_PFN(hsaKmtRegisterGraphicsHandleToNodesExt) == nullptr) goto LOAD_ERROR;
 
-      HSAKMT_PFN(hsaKmtShareMemory) = (HSAKMT_DEF(hsaKmtShareMemory)*)dlsym(thunk_handle, "hsaKmtShareMemory");
-      if (HSAKMT_PFN(hsaKmtShareMemory) == nullptr) goto ERROR;
+      HSAKMT_PFN(hsaKmtShareMemory) = (HSAKMT_DEF(hsaKmtShareMemory)*)rocr::os::GetExportAddress(thunk_handle, "hsaKmtShareMemory");
+      if (HSAKMT_PFN(hsaKmtShareMemory) == nullptr) goto LOAD_ERROR;
 
-      HSAKMT_PFN(hsaKmtRegisterSharedHandle) = (HSAKMT_DEF(hsaKmtRegisterSharedHandle)*)dlsym(thunk_handle, "hsaKmtRegisterSharedHandle");
-      if (HSAKMT_PFN(hsaKmtRegisterSharedHandle) == nullptr) goto ERROR;
+      HSAKMT_PFN(hsaKmtRegisterSharedHandle) = (HSAKMT_DEF(hsaKmtRegisterSharedHandle)*)rocr::os::GetExportAddress(thunk_handle, "hsaKmtRegisterSharedHandle");
+      if (HSAKMT_PFN(hsaKmtRegisterSharedHandle) == nullptr) goto LOAD_ERROR;
 
-      HSAKMT_PFN(hsaKmtRegisterSharedHandleToNodes) = (HSAKMT_DEF(hsaKmtRegisterSharedHandleToNodes)*)dlsym(thunk_handle, "hsaKmtRegisterSharedHandleToNodes");
-      if (HSAKMT_PFN(hsaKmtRegisterSharedHandleToNodes) == nullptr) goto ERROR;
+      HSAKMT_PFN(hsaKmtRegisterSharedHandleToNodes) = (HSAKMT_DEF(hsaKmtRegisterSharedHandleToNodes)*)rocr::os::GetExportAddress(thunk_handle, "hsaKmtRegisterSharedHandleToNodes");
+      if (HSAKMT_PFN(hsaKmtRegisterSharedHandleToNodes) == nullptr) goto LOAD_ERROR;
 
-      HSAKMT_PFN(hsaKmtProcessVMRead) = (HSAKMT_DEF(hsaKmtProcessVMRead)*)dlsym(thunk_handle, "hsaKmtProcessVMRead");
-      if (HSAKMT_PFN(hsaKmtProcessVMRead) == nullptr) goto ERROR;
+      HSAKMT_PFN(hsaKmtProcessVMRead) = (HSAKMT_DEF(hsaKmtProcessVMRead)*)rocr::os::GetExportAddress(thunk_handle, "hsaKmtProcessVMRead");
+      if (HSAKMT_PFN(hsaKmtProcessVMRead) == nullptr) goto LOAD_ERROR;
 
-      HSAKMT_PFN(hsaKmtProcessVMWrite) = (HSAKMT_DEF(hsaKmtProcessVMWrite)*)dlsym(thunk_handle, "hsaKmtProcessVMWrite");
-      if (HSAKMT_PFN(hsaKmtProcessVMWrite) == nullptr) goto ERROR;
+      HSAKMT_PFN(hsaKmtProcessVMWrite) = (HSAKMT_DEF(hsaKmtProcessVMWrite)*)rocr::os::GetExportAddress(thunk_handle, "hsaKmtProcessVMWrite");
+      if (HSAKMT_PFN(hsaKmtProcessVMWrite) == nullptr) goto LOAD_ERROR;
 
-      HSAKMT_PFN(hsaKmtDeregisterMemory) = (HSAKMT_DEF(hsaKmtDeregisterMemory)*)dlsym(thunk_handle, "hsaKmtDeregisterMemory");
-      if (HSAKMT_PFN(hsaKmtDeregisterMemory) == nullptr) goto ERROR;
+      HSAKMT_PFN(hsaKmtDeregisterMemory) = (HSAKMT_DEF(hsaKmtDeregisterMemory)*)rocr::os::GetExportAddress(thunk_handle, "hsaKmtDeregisterMemory");
+      if (HSAKMT_PFN(hsaKmtDeregisterMemory) == nullptr) goto LOAD_ERROR;
 
-      HSAKMT_PFN(hsaKmtMapMemoryToGPU) = (HSAKMT_DEF(hsaKmtMapMemoryToGPU)*)dlsym(thunk_handle, "hsaKmtMapMemoryToGPU");
-      if (HSAKMT_PFN(hsaKmtMapMemoryToGPU) == nullptr) goto ERROR;
+      HSAKMT_PFN(hsaKmtMapMemoryToGPU) = (HSAKMT_DEF(hsaKmtMapMemoryToGPU)*)rocr::os::GetExportAddress(thunk_handle, "hsaKmtMapMemoryToGPU");
+      if (HSAKMT_PFN(hsaKmtMapMemoryToGPU) == nullptr) goto LOAD_ERROR;
 
-      HSAKMT_PFN(hsaKmtMapMemoryToGPUNodes) = (HSAKMT_DEF(hsaKmtMapMemoryToGPUNodes)*)dlsym(thunk_handle, "hsaKmtMapMemoryToGPUNodes");
-      if (HSAKMT_PFN(hsaKmtMapMemoryToGPUNodes) == nullptr) goto ERROR;
+      HSAKMT_PFN(hsaKmtMapMemoryToGPUNodes) = (HSAKMT_DEF(hsaKmtMapMemoryToGPUNodes)*)rocr::os::GetExportAddress(thunk_handle, "hsaKmtMapMemoryToGPUNodes");
+      if (HSAKMT_PFN(hsaKmtMapMemoryToGPUNodes) == nullptr) goto LOAD_ERROR;
 
-      HSAKMT_PFN(hsaKmtUnmapMemoryToGPU) = (HSAKMT_DEF(hsaKmtUnmapMemoryToGPU)*)dlsym(thunk_handle, "hsaKmtUnmapMemoryToGPU");
-      if (HSAKMT_PFN(hsaKmtUnmapMemoryToGPU) == nullptr) goto ERROR;
+      HSAKMT_PFN(hsaKmtUnmapMemoryToGPU) = (HSAKMT_DEF(hsaKmtUnmapMemoryToGPU)*)rocr::os::GetExportAddress(thunk_handle, "hsaKmtUnmapMemoryToGPU");
+      if (HSAKMT_PFN(hsaKmtUnmapMemoryToGPU) == nullptr) goto LOAD_ERROR;
 
-      HSAKMT_PFN(hsaKmtDbgRegister) = (HSAKMT_DEF(hsaKmtDbgRegister)*)dlsym(thunk_handle, "hsaKmtDbgRegister");
-      if (HSAKMT_PFN(hsaKmtDbgRegister) == nullptr) goto ERROR;
+      HSAKMT_PFN(hsaKmtDbgRegister) = (HSAKMT_DEF(hsaKmtDbgRegister)*)rocr::os::GetExportAddress(thunk_handle, "hsaKmtDbgRegister");
+      if (HSAKMT_PFN(hsaKmtDbgRegister) == nullptr) goto LOAD_ERROR;
 
-      HSAKMT_PFN(hsaKmtDbgUnregister) = (HSAKMT_DEF(hsaKmtDbgUnregister)*)dlsym(thunk_handle, "hsaKmtDbgUnregister");
-      if (HSAKMT_PFN(hsaKmtDbgUnregister) == nullptr) goto ERROR;
+      HSAKMT_PFN(hsaKmtDbgUnregister) = (HSAKMT_DEF(hsaKmtDbgUnregister)*)rocr::os::GetExportAddress(thunk_handle, "hsaKmtDbgUnregister");
+      if (HSAKMT_PFN(hsaKmtDbgUnregister) == nullptr) goto LOAD_ERROR;
 
-      HSAKMT_PFN(hsaKmtDbgWavefrontControl) = (HSAKMT_DEF(hsaKmtDbgWavefrontControl)*)dlsym(thunk_handle, "hsaKmtDbgWavefrontControl");
-      if (HSAKMT_PFN(hsaKmtDbgWavefrontControl) == nullptr) goto ERROR;
+      HSAKMT_PFN(hsaKmtDbgWavefrontControl) = (HSAKMT_DEF(hsaKmtDbgWavefrontControl)*)rocr::os::GetExportAddress(thunk_handle, "hsaKmtDbgWavefrontControl");
+      if (HSAKMT_PFN(hsaKmtDbgWavefrontControl) == nullptr) goto LOAD_ERROR;
 
-      HSAKMT_PFN(hsaKmtDbgAddressWatch) = (HSAKMT_DEF(hsaKmtDbgAddressWatch)*)dlsym(thunk_handle, "hsaKmtDbgAddressWatch");
-      if (HSAKMT_PFN(hsaKmtDbgAddressWatch) == nullptr) goto ERROR;
+      HSAKMT_PFN(hsaKmtDbgAddressWatch) = (HSAKMT_DEF(hsaKmtDbgAddressWatch)*)rocr::os::GetExportAddress(thunk_handle, "hsaKmtDbgAddressWatch");
+      if (HSAKMT_PFN(hsaKmtDbgAddressWatch) == nullptr) goto LOAD_ERROR;
 
-      HSAKMT_PFN(hsaKmtDbgEnable) = (HSAKMT_DEF(hsaKmtDbgEnable)*)dlsym(thunk_handle, "hsaKmtDbgEnable");
-      if (HSAKMT_PFN(hsaKmtDbgEnable) == nullptr) goto ERROR;
+      HSAKMT_PFN(hsaKmtDbgEnable) = (HSAKMT_DEF(hsaKmtDbgEnable)*)rocr::os::GetExportAddress(thunk_handle, "hsaKmtDbgEnable");
+      if (HSAKMT_PFN(hsaKmtDbgEnable) == nullptr) goto LOAD_ERROR;
 
-      HSAKMT_PFN(hsaKmtDbgDisable) = (HSAKMT_DEF(hsaKmtDbgDisable)*)dlsym(thunk_handle, "hsaKmtDbgDisable");
-      if (HSAKMT_PFN(hsaKmtDbgDisable) == nullptr) goto ERROR;
+      HSAKMT_PFN(hsaKmtDbgDisable) = (HSAKMT_DEF(hsaKmtDbgDisable)*)rocr::os::GetExportAddress(thunk_handle, "hsaKmtDbgDisable");
+      if (HSAKMT_PFN(hsaKmtDbgDisable) == nullptr) goto LOAD_ERROR;
 
-      HSAKMT_PFN(hsaKmtDbgGetDeviceData) = (HSAKMT_DEF(hsaKmtDbgGetDeviceData)*)dlsym(thunk_handle, "hsaKmtDbgGetDeviceData");
-      if (HSAKMT_PFN(hsaKmtDbgGetDeviceData) == nullptr) goto ERROR;
+      HSAKMT_PFN(hsaKmtDbgGetDeviceData) = (HSAKMT_DEF(hsaKmtDbgGetDeviceData)*)rocr::os::GetExportAddress(thunk_handle, "hsaKmtDbgGetDeviceData");
+      if (HSAKMT_PFN(hsaKmtDbgGetDeviceData) == nullptr) goto LOAD_ERROR;
 
-      HSAKMT_PFN(hsaKmtDbgGetQueueData) = (HSAKMT_DEF(hsaKmtDbgGetQueueData)*)dlsym(thunk_handle, "hsaKmtDbgGetQueueData");
-      if (HSAKMT_PFN(hsaKmtDbgGetQueueData) == nullptr) goto ERROR;
+      HSAKMT_PFN(hsaKmtDbgGetQueueData) = (HSAKMT_DEF(hsaKmtDbgGetQueueData)*)rocr::os::GetExportAddress(thunk_handle, "hsaKmtDbgGetQueueData");
+      if (HSAKMT_PFN(hsaKmtDbgGetQueueData) == nullptr) goto LOAD_ERROR;
 
-      HSAKMT_PFN(hsaKmtGetClockCounters) = (HSAKMT_DEF(hsaKmtGetClockCounters)*)dlsym(thunk_handle, "hsaKmtGetClockCounters");
-      if (HSAKMT_PFN(hsaKmtGetClockCounters) == nullptr) goto ERROR;
+      HSAKMT_PFN(hsaKmtGetClockCounters) = (HSAKMT_DEF(hsaKmtGetClockCounters)*)rocr::os::GetExportAddress(thunk_handle, "hsaKmtGetClockCounters");
+      if (HSAKMT_PFN(hsaKmtGetClockCounters) == nullptr) goto LOAD_ERROR;
 
-      HSAKMT_PFN(hsaKmtPmcGetCounterProperties) = (HSAKMT_DEF(hsaKmtPmcGetCounterProperties)*)dlsym(thunk_handle, "hsaKmtPmcGetCounterProperties");
-      if (HSAKMT_PFN(hsaKmtPmcGetCounterProperties) == nullptr) goto ERROR;
+      HSAKMT_PFN(hsaKmtPmcGetCounterProperties) = (HSAKMT_DEF(hsaKmtPmcGetCounterProperties)*)rocr::os::GetExportAddress(thunk_handle, "hsaKmtPmcGetCounterProperties");
+      if (HSAKMT_PFN(hsaKmtPmcGetCounterProperties) == nullptr) goto LOAD_ERROR;
 
-      HSAKMT_PFN(hsaKmtPmcRegisterTrace) = (HSAKMT_DEF(hsaKmtPmcRegisterTrace)*)dlsym(thunk_handle, "hsaKmtPmcRegisterTrace");
-      if (HSAKMT_PFN(hsaKmtPmcRegisterTrace) == nullptr) goto ERROR;
+      HSAKMT_PFN(hsaKmtPmcRegisterTrace) = (HSAKMT_DEF(hsaKmtPmcRegisterTrace)*)rocr::os::GetExportAddress(thunk_handle, "hsaKmtPmcRegisterTrace");
+      if (HSAKMT_PFN(hsaKmtPmcRegisterTrace) == nullptr) goto LOAD_ERROR;
 
-      HSAKMT_PFN(hsaKmtPmcUnregisterTrace) = (HSAKMT_DEF(hsaKmtPmcUnregisterTrace)*)dlsym(thunk_handle, "hsaKmtPmcUnregisterTrace");
-      if (HSAKMT_PFN(hsaKmtPmcUnregisterTrace) == nullptr) goto ERROR;
+      HSAKMT_PFN(hsaKmtPmcUnregisterTrace) = (HSAKMT_DEF(hsaKmtPmcUnregisterTrace)*)rocr::os::GetExportAddress(thunk_handle, "hsaKmtPmcUnregisterTrace");
+      if (HSAKMT_PFN(hsaKmtPmcUnregisterTrace) == nullptr) goto LOAD_ERROR;
 
-      HSAKMT_PFN(hsaKmtPmcAcquireTraceAccess) = (HSAKMT_DEF(hsaKmtPmcAcquireTraceAccess)*)dlsym(thunk_handle, "hsaKmtPmcAcquireTraceAccess");
-      if (HSAKMT_PFN(hsaKmtPmcAcquireTraceAccess) == nullptr) goto ERROR;
+      HSAKMT_PFN(hsaKmtPmcAcquireTraceAccess) = (HSAKMT_DEF(hsaKmtPmcAcquireTraceAccess)*)rocr::os::GetExportAddress(thunk_handle, "hsaKmtPmcAcquireTraceAccess");
+      if (HSAKMT_PFN(hsaKmtPmcAcquireTraceAccess) == nullptr) goto LOAD_ERROR;
 
-      HSAKMT_PFN(hsaKmtPmcReleaseTraceAccess) = (HSAKMT_DEF(hsaKmtPmcReleaseTraceAccess)*)dlsym(thunk_handle, "hsaKmtPmcReleaseTraceAccess");
-      if (HSAKMT_PFN(hsaKmtPmcReleaseTraceAccess) == nullptr) goto ERROR;
+      HSAKMT_PFN(hsaKmtPmcReleaseTraceAccess) = (HSAKMT_DEF(hsaKmtPmcReleaseTraceAccess)*)rocr::os::GetExportAddress(thunk_handle, "hsaKmtPmcReleaseTraceAccess");
+      if (HSAKMT_PFN(hsaKmtPmcReleaseTraceAccess) == nullptr) goto LOAD_ERROR;
 
-      HSAKMT_PFN(hsaKmtPmcStartTrace) = (HSAKMT_DEF(hsaKmtPmcStartTrace)*)dlsym(thunk_handle, "hsaKmtPmcStartTrace");
-      if (HSAKMT_PFN(hsaKmtPmcStartTrace) == nullptr) goto ERROR;
+      HSAKMT_PFN(hsaKmtPmcStartTrace) = (HSAKMT_DEF(hsaKmtPmcStartTrace)*)rocr::os::GetExportAddress(thunk_handle, "hsaKmtPmcStartTrace");
+      if (HSAKMT_PFN(hsaKmtPmcStartTrace) == nullptr) goto LOAD_ERROR;
 
-      HSAKMT_PFN(hsaKmtPmcQueryTrace) = (HSAKMT_DEF(hsaKmtPmcQueryTrace)*)dlsym(thunk_handle, "hsaKmtPmcQueryTrace");
-      if (HSAKMT_PFN(hsaKmtPmcQueryTrace) == nullptr) goto ERROR;
+      HSAKMT_PFN(hsaKmtPmcQueryTrace) = (HSAKMT_DEF(hsaKmtPmcQueryTrace)*)rocr::os::GetExportAddress(thunk_handle, "hsaKmtPmcQueryTrace");
+      if (HSAKMT_PFN(hsaKmtPmcQueryTrace) == nullptr) goto LOAD_ERROR;
 
-      HSAKMT_PFN(hsaKmtPmcStopTrace) = (HSAKMT_DEF(hsaKmtPmcStopTrace)*)dlsym(thunk_handle, "hsaKmtPmcStopTrace");
-      if (HSAKMT_PFN(hsaKmtPmcStopTrace) == nullptr) goto ERROR;
+      HSAKMT_PFN(hsaKmtPmcStopTrace) = (HSAKMT_DEF(hsaKmtPmcStopTrace)*)rocr::os::GetExportAddress(thunk_handle, "hsaKmtPmcStopTrace");
+      if (HSAKMT_PFN(hsaKmtPmcStopTrace) == nullptr) goto LOAD_ERROR;
 
-      HSAKMT_PFN(hsaKmtMapGraphicHandle) = (HSAKMT_DEF(hsaKmtMapGraphicHandle)*)dlsym(thunk_handle, "hsaKmtMapGraphicHandle");
-      if (HSAKMT_PFN(hsaKmtMapGraphicHandle) == nullptr) goto ERROR;
+      HSAKMT_PFN(hsaKmtMapGraphicHandle) = (HSAKMT_DEF(hsaKmtMapGraphicHandle)*)rocr::os::GetExportAddress(thunk_handle, "hsaKmtMapGraphicHandle");
+      if (HSAKMT_PFN(hsaKmtMapGraphicHandle) == nullptr) goto LOAD_ERROR;
 
-      HSAKMT_PFN(hsaKmtUnmapGraphicHandle) = (HSAKMT_DEF(hsaKmtUnmapGraphicHandle)*)dlsym(thunk_handle, "hsaKmtUnmapGraphicHandle");
-      if (HSAKMT_PFN(hsaKmtUnmapGraphicHandle) == nullptr) goto ERROR;
+      HSAKMT_PFN(hsaKmtUnmapGraphicHandle) = (HSAKMT_DEF(hsaKmtUnmapGraphicHandle)*)rocr::os::GetExportAddress(thunk_handle, "hsaKmtUnmapGraphicHandle");
+      if (HSAKMT_PFN(hsaKmtUnmapGraphicHandle) == nullptr) goto LOAD_ERROR;
 
-      HSAKMT_PFN(hsaKmtSetTrapHandler) = (HSAKMT_DEF(hsaKmtSetTrapHandler)*)dlsym(thunk_handle, "hsaKmtSetTrapHandler");
-      if (HSAKMT_PFN(hsaKmtSetTrapHandler) == nullptr) goto ERROR;
+      HSAKMT_PFN(hsaKmtSetTrapHandler) = (HSAKMT_DEF(hsaKmtSetTrapHandler)*)rocr::os::GetExportAddress(thunk_handle, "hsaKmtSetTrapHandler");
+      if (HSAKMT_PFN(hsaKmtSetTrapHandler) == nullptr) goto LOAD_ERROR;
 
-      HSAKMT_PFN(hsaKmtGetTileConfig) = (HSAKMT_DEF(hsaKmtGetTileConfig)*)dlsym(thunk_handle, "hsaKmtGetTileConfig");
-      if (HSAKMT_PFN(hsaKmtGetTileConfig) == nullptr) goto ERROR;
+      HSAKMT_PFN(hsaKmtGetTileConfig) = (HSAKMT_DEF(hsaKmtGetTileConfig)*)rocr::os::GetExportAddress(thunk_handle, "hsaKmtGetTileConfig");
+      if (HSAKMT_PFN(hsaKmtGetTileConfig) == nullptr) goto LOAD_ERROR;
 
-      HSAKMT_PFN(hsaKmtQueryPointerInfo) = (HSAKMT_DEF(hsaKmtQueryPointerInfo)*)dlsym(thunk_handle, "hsaKmtQueryPointerInfo");
-      if (HSAKMT_PFN(hsaKmtQueryPointerInfo) == nullptr) goto ERROR;
+      HSAKMT_PFN(hsaKmtQueryPointerInfo) = (HSAKMT_DEF(hsaKmtQueryPointerInfo)*)rocr::os::GetExportAddress(thunk_handle, "hsaKmtQueryPointerInfo");
+      if (HSAKMT_PFN(hsaKmtQueryPointerInfo) == nullptr) goto LOAD_ERROR;
 
-      HSAKMT_PFN(hsaKmtSetMemoryUserData) = (HSAKMT_DEF(hsaKmtSetMemoryUserData)*)dlsym(thunk_handle, "hsaKmtSetMemoryUserData");
-      if (HSAKMT_PFN(hsaKmtSetMemoryUserData) == nullptr) goto ERROR;
+      HSAKMT_PFN(hsaKmtSetMemoryUserData) = (HSAKMT_DEF(hsaKmtSetMemoryUserData)*)rocr::os::GetExportAddress(thunk_handle, "hsaKmtSetMemoryUserData");
+      if (HSAKMT_PFN(hsaKmtSetMemoryUserData) == nullptr) goto LOAD_ERROR;
 
-      HSAKMT_PFN(hsaKmtGetQueueInfo) = (HSAKMT_DEF(hsaKmtGetQueueInfo)*)dlsym(thunk_handle, "hsaKmtGetQueueInfo");
-      if (HSAKMT_PFN(hsaKmtGetQueueInfo) == nullptr) goto ERROR;
+      HSAKMT_PFN(hsaKmtGetQueueInfo) = (HSAKMT_DEF(hsaKmtGetQueueInfo)*)rocr::os::GetExportAddress(thunk_handle, "hsaKmtGetQueueInfo");
+      if (HSAKMT_PFN(hsaKmtGetQueueInfo) == nullptr) goto LOAD_ERROR;
 
-      HSAKMT_PFN(hsaKmtAllocQueueGWS) = (HSAKMT_DEF(hsaKmtAllocQueueGWS)*)dlsym(thunk_handle, "hsaKmtAllocQueueGWS");
-      if (HSAKMT_PFN(hsaKmtAllocQueueGWS) == nullptr) goto ERROR;
+      HSAKMT_PFN(hsaKmtAllocQueueGWS) = (HSAKMT_DEF(hsaKmtAllocQueueGWS)*)rocr::os::GetExportAddress(thunk_handle, "hsaKmtAllocQueueGWS");
+      if (HSAKMT_PFN(hsaKmtAllocQueueGWS) == nullptr) goto LOAD_ERROR;
 
-      HSAKMT_PFN(hsaKmtRuntimeEnable) = (HSAKMT_DEF(hsaKmtRuntimeEnable)*)dlsym(thunk_handle, "hsaKmtRuntimeEnable");
-      if (HSAKMT_PFN(hsaKmtRuntimeEnable) == nullptr) goto ERROR;
+      HSAKMT_PFN(hsaKmtRuntimeEnable) = (HSAKMT_DEF(hsaKmtRuntimeEnable)*)rocr::os::GetExportAddress(thunk_handle, "hsaKmtRuntimeEnable");
+      if (HSAKMT_PFN(hsaKmtRuntimeEnable) == nullptr) goto LOAD_ERROR;
 
-      HSAKMT_PFN(hsaKmtRuntimeDisable) = (HSAKMT_DEF(hsaKmtRuntimeDisable)*)dlsym(thunk_handle, "hsaKmtRuntimeDisable");
-      if (HSAKMT_PFN(hsaKmtRuntimeDisable) == nullptr) goto ERROR;
+      HSAKMT_PFN(hsaKmtRuntimeDisable) = (HSAKMT_DEF(hsaKmtRuntimeDisable)*)rocr::os::GetExportAddress(thunk_handle, "hsaKmtRuntimeDisable");
+      if (HSAKMT_PFN(hsaKmtRuntimeDisable) == nullptr) goto LOAD_ERROR;
 
-      HSAKMT_PFN(hsaKmtCheckRuntimeDebugSupport) = (HSAKMT_DEF(hsaKmtCheckRuntimeDebugSupport)*)dlsym(thunk_handle, "hsaKmtCheckRuntimeDebugSupport");
-      if (HSAKMT_PFN(hsaKmtCheckRuntimeDebugSupport) == nullptr) goto ERROR;
+      HSAKMT_PFN(hsaKmtCheckRuntimeDebugSupport) = (HSAKMT_DEF(hsaKmtCheckRuntimeDebugSupport)*)rocr::os::GetExportAddress(thunk_handle, "hsaKmtCheckRuntimeDebugSupport");
+      if (HSAKMT_PFN(hsaKmtCheckRuntimeDebugSupport) == nullptr) goto LOAD_ERROR;
 
-      HSAKMT_PFN(hsaKmtGetRuntimeCapabilities) = (HSAKMT_DEF(hsaKmtGetRuntimeCapabilities)*)dlsym(thunk_handle, "hsaKmtGetRuntimeCapabilities");
-      if (HSAKMT_PFN(hsaKmtGetRuntimeCapabilities) == nullptr) goto ERROR;
+      HSAKMT_PFN(hsaKmtGetRuntimeCapabilities) = (HSAKMT_DEF(hsaKmtGetRuntimeCapabilities)*)rocr::os::GetExportAddress(thunk_handle, "hsaKmtGetRuntimeCapabilities");
+      if (HSAKMT_PFN(hsaKmtGetRuntimeCapabilities) == nullptr) goto LOAD_ERROR;
 
-      HSAKMT_PFN(hsaKmtDebugTrapIoctl) = (HSAKMT_DEF(hsaKmtDebugTrapIoctl)*)dlsym(thunk_handle, "hsaKmtDebugTrapIoctl");
-      if (HSAKMT_PFN(hsaKmtDebugTrapIoctl) == nullptr) goto ERROR;
+      HSAKMT_PFN(hsaKmtDebugTrapIoctl) = (HSAKMT_DEF(hsaKmtDebugTrapIoctl)*)rocr::os::GetExportAddress(thunk_handle, "hsaKmtDebugTrapIoctl");
+      if (HSAKMT_PFN(hsaKmtDebugTrapIoctl) == nullptr) goto LOAD_ERROR;
 
-      HSAKMT_PFN(hsaKmtSPMAcquire) = (HSAKMT_DEF(hsaKmtSPMAcquire)*)dlsym(thunk_handle, "hsaKmtSPMAcquire");
-      if (HSAKMT_PFN(hsaKmtSPMAcquire) == nullptr) goto ERROR;
+      HSAKMT_PFN(hsaKmtSPMAcquire) = (HSAKMT_DEF(hsaKmtSPMAcquire)*)rocr::os::GetExportAddress(thunk_handle, "hsaKmtSPMAcquire");
+      if (HSAKMT_PFN(hsaKmtSPMAcquire) == nullptr) goto LOAD_ERROR;
 
-      HSAKMT_PFN(hsaKmtSPMRelease) = (HSAKMT_DEF(hsaKmtSPMRelease)*)dlsym(thunk_handle, "hsaKmtSPMRelease");
-      if (HSAKMT_PFN(hsaKmtSPMRelease) == nullptr) goto ERROR;
+      HSAKMT_PFN(hsaKmtSPMRelease) = (HSAKMT_DEF(hsaKmtSPMRelease)*)rocr::os::GetExportAddress(thunk_handle, "hsaKmtSPMRelease");
+      if (HSAKMT_PFN(hsaKmtSPMRelease) == nullptr) goto LOAD_ERROR;
 
-      HSAKMT_PFN(hsaKmtSPMSetDestBuffer) = (HSAKMT_DEF(hsaKmtSPMSetDestBuffer)*)dlsym(thunk_handle, "hsaKmtSPMSetDestBuffer");
-      if (HSAKMT_PFN(hsaKmtSPMSetDestBuffer) == nullptr) goto ERROR;
+      HSAKMT_PFN(hsaKmtSPMSetDestBuffer) = (HSAKMT_DEF(hsaKmtSPMSetDestBuffer)*)rocr::os::GetExportAddress(thunk_handle, "hsaKmtSPMSetDestBuffer");
+      if (HSAKMT_PFN(hsaKmtSPMSetDestBuffer) == nullptr) goto LOAD_ERROR;
 
-      HSAKMT_PFN(hsaKmtSVMSetAttr) = (HSAKMT_DEF(hsaKmtSVMSetAttr)*)dlsym(thunk_handle, "hsaKmtSVMSetAttr");
-      if (HSAKMT_PFN(hsaKmtSVMSetAttr) == nullptr) goto ERROR;
+      HSAKMT_PFN(hsaKmtSVMSetAttr) = (HSAKMT_DEF(hsaKmtSVMSetAttr)*)rocr::os::GetExportAddress(thunk_handle, "hsaKmtSVMSetAttr");
+      if (HSAKMT_PFN(hsaKmtSVMSetAttr) == nullptr) goto LOAD_ERROR;
 
-      HSAKMT_PFN(hsaKmtSVMGetAttr) = (HSAKMT_DEF(hsaKmtSVMGetAttr)*)dlsym(thunk_handle, "hsaKmtSVMGetAttr");
-      if (HSAKMT_PFN(hsaKmtSVMGetAttr) == nullptr) goto ERROR;
+      HSAKMT_PFN(hsaKmtSVMGetAttr) = (HSAKMT_DEF(hsaKmtSVMGetAttr)*)rocr::os::GetExportAddress(thunk_handle, "hsaKmtSVMGetAttr");
+      if (HSAKMT_PFN(hsaKmtSVMGetAttr) == nullptr) goto LOAD_ERROR;
 
-      HSAKMT_PFN(hsaKmtSetXNACKMode) = (HSAKMT_DEF(hsaKmtSetXNACKMode)*)dlsym(thunk_handle, "hsaKmtSetXNACKMode");
-      if (HSAKMT_PFN(hsaKmtSetXNACKMode) == nullptr) goto ERROR;
+      HSAKMT_PFN(hsaKmtSetXNACKMode) = (HSAKMT_DEF(hsaKmtSetXNACKMode)*)rocr::os::GetExportAddress(thunk_handle, "hsaKmtSetXNACKMode");
+      if (HSAKMT_PFN(hsaKmtSetXNACKMode) == nullptr) goto LOAD_ERROR;
 
-      HSAKMT_PFN(hsaKmtGetXNACKMode) = (HSAKMT_DEF(hsaKmtGetXNACKMode)*)dlsym(thunk_handle, "hsaKmtGetXNACKMode");
-      if (HSAKMT_PFN(hsaKmtGetXNACKMode) == nullptr) goto ERROR;
+      HSAKMT_PFN(hsaKmtGetXNACKMode) = (HSAKMT_DEF(hsaKmtGetXNACKMode)*)rocr::os::GetExportAddress(thunk_handle, "hsaKmtGetXNACKMode");
+      if (HSAKMT_PFN(hsaKmtGetXNACKMode) == nullptr) goto LOAD_ERROR;
 
-      HSAKMT_PFN(hsaKmtOpenSMI) = (HSAKMT_DEF(hsaKmtOpenSMI)*)dlsym(thunk_handle, "hsaKmtOpenSMI");
-      if (HSAKMT_PFN(hsaKmtOpenSMI) == nullptr) goto ERROR;
+      HSAKMT_PFN(hsaKmtOpenSMI) = (HSAKMT_DEF(hsaKmtOpenSMI)*)rocr::os::GetExportAddress(thunk_handle, "hsaKmtOpenSMI");
+      if (HSAKMT_PFN(hsaKmtOpenSMI) == nullptr) goto LOAD_ERROR;
 
-      HSAKMT_PFN(hsaKmtExportDMABufHandle) = (HSAKMT_DEF(hsaKmtExportDMABufHandle)*)dlsym(thunk_handle, "hsaKmtExportDMABufHandle");
-      if (HSAKMT_PFN(hsaKmtExportDMABufHandle) == nullptr) goto ERROR;
+      HSAKMT_PFN(hsaKmtExportDMABufHandle) = (HSAKMT_DEF(hsaKmtExportDMABufHandle)*)rocr::os::GetExportAddress(thunk_handle, "hsaKmtExportDMABufHandle");
+      if (HSAKMT_PFN(hsaKmtExportDMABufHandle) == nullptr) goto LOAD_ERROR;
 
-      HSAKMT_PFN(hsaKmtWaitOnEvent_Ext) = (HSAKMT_DEF(hsaKmtWaitOnEvent_Ext)*)dlsym(thunk_handle, "hsaKmtWaitOnEvent_Ext");
-      if (HSAKMT_PFN(hsaKmtWaitOnEvent_Ext) == nullptr) goto ERROR;
+      HSAKMT_PFN(hsaKmtWaitOnEvent_Ext) = (HSAKMT_DEF(hsaKmtWaitOnEvent_Ext)*)rocr::os::GetExportAddress(thunk_handle, "hsaKmtWaitOnEvent_Ext");
+      if (HSAKMT_PFN(hsaKmtWaitOnEvent_Ext) == nullptr) goto LOAD_ERROR;
 
-      HSAKMT_PFN(hsaKmtWaitOnMultipleEvents_Ext) = (HSAKMT_DEF(hsaKmtWaitOnMultipleEvents_Ext)*)dlsym(thunk_handle, "hsaKmtWaitOnMultipleEvents_Ext");
-      if (HSAKMT_PFN(hsaKmtWaitOnMultipleEvents_Ext) == nullptr) goto ERROR;
+      HSAKMT_PFN(hsaKmtWaitOnMultipleEvents_Ext) = (HSAKMT_DEF(hsaKmtWaitOnMultipleEvents_Ext)*)rocr::os::GetExportAddress(thunk_handle, "hsaKmtWaitOnMultipleEvents_Ext");
+      if (HSAKMT_PFN(hsaKmtWaitOnMultipleEvents_Ext) == nullptr) goto LOAD_ERROR;
 
-      HSAKMT_PFN(hsaKmtReplaceAsanHeaderPage) = (HSAKMT_DEF(hsaKmtReplaceAsanHeaderPage)*)dlsym(thunk_handle, "hsaKmtReplaceAsanHeaderPage");
-      if (HSAKMT_PFN(hsaKmtReplaceAsanHeaderPage) == nullptr) goto ERROR;
+      HSAKMT_PFN(hsaKmtReplaceAsanHeaderPage) = (HSAKMT_DEF(hsaKmtReplaceAsanHeaderPage)*)rocr::os::GetExportAddress(thunk_handle, "hsaKmtReplaceAsanHeaderPage");
+      if (HSAKMT_PFN(hsaKmtReplaceAsanHeaderPage) == nullptr) goto LOAD_ERROR;
 
-      HSAKMT_PFN(hsaKmtReturnAsanHeaderPage) = (HSAKMT_DEF(hsaKmtReturnAsanHeaderPage)*)dlsym(thunk_handle, "hsaKmtReturnAsanHeaderPage");
-      if (HSAKMT_PFN(hsaKmtReturnAsanHeaderPage) == nullptr) goto ERROR;
+      HSAKMT_PFN(hsaKmtReturnAsanHeaderPage) = (HSAKMT_DEF(hsaKmtReturnAsanHeaderPage)*)rocr::os::GetExportAddress(thunk_handle, "hsaKmtReturnAsanHeaderPage");
+      if (HSAKMT_PFN(hsaKmtReturnAsanHeaderPage) == nullptr) goto LOAD_ERROR;
 
-      HSAKMT_PFN(hsaKmtGetAMDGPUDeviceHandle) = (HSAKMT_DEF(hsaKmtGetAMDGPUDeviceHandle)*)dlsym(thunk_handle, "hsaKmtGetAMDGPUDeviceHandle");
-      if (HSAKMT_PFN(hsaKmtGetAMDGPUDeviceHandle) == nullptr) goto ERROR;
+      HSAKMT_PFN(hsaKmtGetAMDGPUDeviceHandle) = (HSAKMT_DEF(hsaKmtGetAMDGPUDeviceHandle)*)rocr::os::GetExportAddress(thunk_handle, "hsaKmtGetAMDGPUDeviceHandle");
+      if (HSAKMT_PFN(hsaKmtGetAMDGPUDeviceHandle) == nullptr) goto LOAD_ERROR;
 
-      HSAKMT_PFN(hsaKmtPcSamplingQueryCapabilities) = (HSAKMT_DEF(hsaKmtPcSamplingQueryCapabilities)*)dlsym(thunk_handle, "hsaKmtPcSamplingQueryCapabilities");
-      if (HSAKMT_PFN(hsaKmtPcSamplingQueryCapabilities) == nullptr) goto ERROR;
+      HSAKMT_PFN(hsaKmtPcSamplingQueryCapabilities) = (HSAKMT_DEF(hsaKmtPcSamplingQueryCapabilities)*)rocr::os::GetExportAddress(thunk_handle, "hsaKmtPcSamplingQueryCapabilities");
+      if (HSAKMT_PFN(hsaKmtPcSamplingQueryCapabilities) == nullptr) goto LOAD_ERROR;
 
-      HSAKMT_PFN(hsaKmtPcSamplingCreate) = (HSAKMT_DEF(hsaKmtPcSamplingCreate)*)dlsym(thunk_handle, "hsaKmtPcSamplingCreate");
-      if (HSAKMT_PFN(hsaKmtPcSamplingCreate) == nullptr) goto ERROR;
+      HSAKMT_PFN(hsaKmtPcSamplingCreate) = (HSAKMT_DEF(hsaKmtPcSamplingCreate)*)rocr::os::GetExportAddress(thunk_handle, "hsaKmtPcSamplingCreate");
+      if (HSAKMT_PFN(hsaKmtPcSamplingCreate) == nullptr) goto LOAD_ERROR;
 
-      HSAKMT_PFN(hsaKmtPcSamplingDestroy) = (HSAKMT_DEF(hsaKmtPcSamplingDestroy)*)dlsym(thunk_handle, "hsaKmtPcSamplingDestroy");
-      if (HSAKMT_PFN(hsaKmtPcSamplingDestroy) == nullptr) goto ERROR;
+      HSAKMT_PFN(hsaKmtPcSamplingDestroy) = (HSAKMT_DEF(hsaKmtPcSamplingDestroy)*)rocr::os::GetExportAddress(thunk_handle, "hsaKmtPcSamplingDestroy");
+      if (HSAKMT_PFN(hsaKmtPcSamplingDestroy) == nullptr) goto LOAD_ERROR;
 
-      HSAKMT_PFN(hsaKmtPcSamplingStart) = (HSAKMT_DEF(hsaKmtPcSamplingStart)*)dlsym(thunk_handle, "hsaKmtPcSamplingStart");
-      if (HSAKMT_PFN(hsaKmtPcSamplingStart) == nullptr) goto ERROR;
+      HSAKMT_PFN(hsaKmtPcSamplingStart) = (HSAKMT_DEF(hsaKmtPcSamplingStart)*)rocr::os::GetExportAddress(thunk_handle, "hsaKmtPcSamplingStart");
+      if (HSAKMT_PFN(hsaKmtPcSamplingStart) == nullptr) goto LOAD_ERROR;
 
-      HSAKMT_PFN(hsaKmtPcSamplingStop) = (HSAKMT_DEF(hsaKmtPcSamplingStop)*)dlsym(thunk_handle, "hsaKmtPcSamplingStop");
-      if (HSAKMT_PFN(hsaKmtPcSamplingStop) == nullptr) goto ERROR;
+      HSAKMT_PFN(hsaKmtPcSamplingStop) = (HSAKMT_DEF(hsaKmtPcSamplingStop)*)rocr::os::GetExportAddress(thunk_handle, "hsaKmtPcSamplingStop");
+      if (HSAKMT_PFN(hsaKmtPcSamplingStop) == nullptr) goto LOAD_ERROR;
 
-      HSAKMT_PFN(hsaKmtPcSamplingSupport) = (HSAKMT_DEF(hsaKmtPcSamplingSupport)*)dlsym(thunk_handle, "hsaKmtPcSamplingSupport");
-      if (HSAKMT_PFN(hsaKmtPcSamplingSupport) == nullptr) goto ERROR;
+      HSAKMT_PFN(hsaKmtPcSamplingSupport) = (HSAKMT_DEF(hsaKmtPcSamplingSupport)*)rocr::os::GetExportAddress(thunk_handle, "hsaKmtPcSamplingSupport");
+      if (HSAKMT_PFN(hsaKmtPcSamplingSupport) == nullptr) goto LOAD_ERROR;
 
-      HSAKMT_PFN(hsaKmtModelEnabled) = (HSAKMT_DEF(hsaKmtModelEnabled)*)dlsym(thunk_handle, "hsaKmtModelEnabled");
-      if (HSAKMT_PFN(hsaKmtModelEnabled) == nullptr) goto ERROR;
+      HSAKMT_PFN(hsaKmtModelEnabled) = (HSAKMT_DEF(hsaKmtModelEnabled)*)rocr::os::GetExportAddress(thunk_handle, "hsaKmtModelEnabled");
+      if (HSAKMT_PFN(hsaKmtModelEnabled) == nullptr) goto LOAD_ERROR;
 
-      HSAKMT_PFN(hsaKmtQueueRingDoorbell) = (HSAKMT_DEF(hsaKmtQueueRingDoorbell)*)dlsym(thunk_handle, "hsaKmtQueueRingDoorbell");
-      if (HSAKMT_PFN(hsaKmtQueueRingDoorbell) == nullptr) goto ERROR;
+      HSAKMT_PFN(hsaKmtQueueRingDoorbell) = (HSAKMT_DEF(hsaKmtQueueRingDoorbell)*)rocr::os::GetExportAddress(thunk_handle, "hsaKmtQueueRingDoorbell");
+      if (HSAKMT_PFN(hsaKmtQueueRingDoorbell) == nullptr) goto LOAD_ERROR;
 
-      DRM_PFN(amdgpu_device_initialize) = (DRM_DEF(amdgpu_device_initialize)*)dlsym(thunk_handle, "amdgpu_device_initialize");
-      if (DRM_PFN(amdgpu_device_initialize) == nullptr) goto ERROR;
+      DRM_PFN(amdgpu_device_initialize) = (DRM_DEF(amdgpu_device_initialize)*)rocr::os::GetExportAddress(thunk_handle, "amdgpu_device_initialize");
+      if (DRM_PFN(amdgpu_device_initialize) == nullptr) goto LOAD_ERROR;
 
-      HSAKMT_PFN(hsaKmtAisReadWriteFile) = (HSAKMT_DEF(hsaKmtAisReadWriteFile)*)dlsym(thunk_handle, "hsaKmtAisReadWriteFile");
-      if (HSAKMT_PFN(hsaKmtAisReadWriteFile) == nullptr) goto ERROR;
+      HSAKMT_PFN(hsaKmtAisReadWriteFile) = (HSAKMT_DEF(hsaKmtAisReadWriteFile)*)rocr::os::GetExportAddress(thunk_handle, "hsaKmtAisReadWriteFile");
+      if (HSAKMT_PFN(hsaKmtAisReadWriteFile) == nullptr) goto LOAD_ERROR;
 
 #if defined(_WIN32)
-      HSAKMT_PFN(hsaKmtGetMemoryHandle) = (HSAKMT_DEF(hsaKmtGetMemoryHandle)*)dlsym(thunk_handle, "hsaKmtGetMemoryHandle");
-      if (HSAKMT_PFN(hsaKmtGetMemoryHandle) == nullptr) goto ERROR;
+      HSAKMT_PFN(hsaKmtGetMemoryHandle) = (HSAKMT_DEF(hsaKmtGetMemoryHandle)*)rocr::os::GetExportAddress(thunk_handle, "hsaKmtGetMemoryHandle");
+      if (HSAKMT_PFN(hsaKmtGetMemoryHandle) == nullptr) goto LOAD_ERROR;
 #endif
 
-      HSAKMT_PFN(hsaKmtHandleImport) = (HSAKMT_DEF(hsaKmtHandleImport)*)dlsym(thunk_handle, "hsaKmtHandleImport");
-      if (HSAKMT_PFN(hsaKmtHandleImport) == nullptr) goto ERROR;
+      HSAKMT_PFN(hsaKmtHandleImport) = (HSAKMT_DEF(hsaKmtHandleImport)*)rocr::os::GetExportAddress(thunk_handle, "hsaKmtHandleImport");
+      if (HSAKMT_PFN(hsaKmtHandleImport) == nullptr) goto LOAD_ERROR;
 
-      HSAKMT_PFN(hsaKmtMemoryVaMap) = (HSAKMT_DEF(hsaKmtMemoryVaMap)*)dlsym(thunk_handle, "hsaKmtMemoryVaMap");
-      if (HSAKMT_PFN(hsaKmtMemoryVaMap) == nullptr) goto ERROR;
+      HSAKMT_PFN(hsaKmtMemoryVaMap) = (HSAKMT_DEF(hsaKmtMemoryVaMap)*)rocr::os::GetExportAddress(thunk_handle, "hsaKmtMemoryVaMap");
+      if (HSAKMT_PFN(hsaKmtMemoryVaMap) == nullptr) goto LOAD_ERROR;
 
-      HSAKMT_PFN(hsaKmtMemoryVaUnmap) = (HSAKMT_DEF(hsaKmtMemoryVaUnmap)*)dlsym(thunk_handle, "hsaKmtMemoryVaUnmap");
-      if (HSAKMT_PFN(hsaKmtMemoryVaUnmap) == nullptr) goto ERROR;
+      HSAKMT_PFN(hsaKmtMemoryVaUnmap) = (HSAKMT_DEF(hsaKmtMemoryVaUnmap)*)rocr::os::GetExportAddress(thunk_handle, "hsaKmtMemoryVaUnmap");
+      if (HSAKMT_PFN(hsaKmtMemoryVaUnmap) == nullptr) goto LOAD_ERROR;
 
-      HSAKMT_PFN(hsaKmtMemHandleFree) = (HSAKMT_DEF(hsaKmtMemHandleFree)*)dlsym(thunk_handle, "hsaKmtMemHandleFree");
-      if (HSAKMT_PFN(hsaKmtMemHandleFree) == nullptr) goto ERROR;
+      HSAKMT_PFN(hsaKmtMemHandleFree) = (HSAKMT_DEF(hsaKmtMemHandleFree)*)rocr::os::GetExportAddress(thunk_handle, "hsaKmtMemHandleFree");
+      if (HSAKMT_PFN(hsaKmtMemHandleFree) == nullptr) goto LOAD_ERROR;
 
-      HSAKMT_PFN(hsaKmtMemoryGetCpuAddr) = (HSAKMT_DEF(hsaKmtMemoryGetCpuAddr)*)dlsym(thunk_handle, "hsaKmtMemoryGetCpuAddr");
-      if (HSAKMT_PFN(hsaKmtMemoryGetCpuAddr) == nullptr) goto ERROR;
+      HSAKMT_PFN(hsaKmtMemoryGetCpuAddr) = (HSAKMT_DEF(hsaKmtMemoryGetCpuAddr)*)rocr::os::GetExportAddress(thunk_handle, "hsaKmtMemoryGetCpuAddr");
+      if (HSAKMT_PFN(hsaKmtMemoryGetCpuAddr) == nullptr) goto LOAD_ERROR;
 
-      HSAKMT_PFN(hsaKmtMemoryCpuMap) = (HSAKMT_DEF(hsaKmtMemoryCpuMap)*)dlsym(thunk_handle, "hsaKmtMemoryCpuMap");
-      if (HSAKMT_PFN(hsaKmtMemoryCpuMap) == nullptr) goto ERROR;
+      HSAKMT_PFN(hsaKmtMemoryCpuMap) = (HSAKMT_DEF(hsaKmtMemoryCpuMap)*)rocr::os::GetExportAddress(thunk_handle, "hsaKmtMemoryCpuMap");
+      if (HSAKMT_PFN(hsaKmtMemoryCpuMap) == nullptr) goto LOAD_ERROR;
 
-      HSAKMT_PFN(hsaKmtGetNodeWallclockFrequency) = (HSAKMT_DEF(hsaKmtGetNodeWallclockFrequency)*)dlsym(thunk_handle, "hsaKmtGetNodeWallclockFrequency");
-      if (HSAKMT_PFN(hsaKmtGetNodeWallclockFrequency) == nullptr) goto ERROR;
+      HSAKMT_PFN(hsaKmtGetNodeWallclockFrequency) = (HSAKMT_DEF(hsaKmtGetNodeWallclockFrequency)*)rocr::os::GetExportAddress(thunk_handle, "hsaKmtGetNodeWallclockFrequency");
+      if (HSAKMT_PFN(hsaKmtGetNodeWallclockFrequency) == nullptr) goto LOAD_ERROR;
 
-      DRM_PFN(amdgpu_device_deinitialize) = (DRM_DEF(amdgpu_device_deinitialize)*)dlsym(thunk_handle, "amdgpu_device_deinitialize");
-      if (DRM_PFN(amdgpu_device_deinitialize) == nullptr) goto ERROR;
+      DRM_PFN(amdgpu_device_deinitialize) = (DRM_DEF(amdgpu_device_deinitialize)*)rocr::os::GetExportAddress(thunk_handle, "amdgpu_device_deinitialize");
+      if (DRM_PFN(amdgpu_device_deinitialize) == nullptr) goto LOAD_ERROR;
 
-      DRM_PFN(amdgpu_query_gpu_info) = (DRM_DEF(amdgpu_query_gpu_info)*)dlsym(thunk_handle, "amdgpu_query_gpu_info");
-      if (DRM_PFN(amdgpu_query_gpu_info) == nullptr) goto ERROR;
+      DRM_PFN(amdgpu_query_gpu_info) = (DRM_DEF(amdgpu_query_gpu_info)*)rocr::os::GetExportAddress(thunk_handle, "amdgpu_query_gpu_info");
+      if (DRM_PFN(amdgpu_query_gpu_info) == nullptr) goto LOAD_ERROR;
 
-      DRM_PFN(amdgpu_bo_cpu_map) = (DRM_DEF(amdgpu_bo_cpu_map)*)dlsym(thunk_handle, "amdgpu_bo_cpu_map");
-      if (DRM_PFN(amdgpu_bo_cpu_map) == nullptr) goto ERROR;
+      DRM_PFN(amdgpu_bo_cpu_map) = (DRM_DEF(amdgpu_bo_cpu_map)*)rocr::os::GetExportAddress(thunk_handle, "amdgpu_bo_cpu_map");
+      if (DRM_PFN(amdgpu_bo_cpu_map) == nullptr) goto LOAD_ERROR;
 
-      DRM_PFN(amdgpu_bo_free) = (DRM_DEF(amdgpu_bo_free)*)dlsym(thunk_handle, "amdgpu_bo_free");
-      if (DRM_PFN(amdgpu_bo_free) == nullptr) goto ERROR;
+      DRM_PFN(amdgpu_bo_free) = (DRM_DEF(amdgpu_bo_free)*)rocr::os::GetExportAddress(thunk_handle, "amdgpu_bo_free");
+      if (DRM_PFN(amdgpu_bo_free) == nullptr) goto LOAD_ERROR;
 
-      DRM_PFN(amdgpu_bo_export) = (DRM_DEF(amdgpu_bo_export)*)dlsym(thunk_handle, "amdgpu_bo_export");
-      if (DRM_PFN(amdgpu_bo_export) == nullptr) goto ERROR;
+      DRM_PFN(amdgpu_bo_export) = (DRM_DEF(amdgpu_bo_export)*)rocr::os::GetExportAddress(thunk_handle, "amdgpu_bo_export");
+      if (DRM_PFN(amdgpu_bo_export) == nullptr) goto LOAD_ERROR;
 
-      DRM_PFN(amdgpu_bo_import) = (DRM_DEF(amdgpu_bo_import)*)dlsym(thunk_handle, "amdgpu_bo_import");
-      if (DRM_PFN(amdgpu_bo_import) == nullptr) goto ERROR;
+      DRM_PFN(amdgpu_bo_import) = (DRM_DEF(amdgpu_bo_import)*)rocr::os::GetExportAddress(thunk_handle, "amdgpu_bo_import");
+      if (DRM_PFN(amdgpu_bo_import) == nullptr) goto LOAD_ERROR;
 
-      DRM_PFN(amdgpu_bo_va_op) = (DRM_DEF(amdgpu_bo_va_op)*)dlsym(thunk_handle, "amdgpu_bo_va_op");
-      if (DRM_PFN(amdgpu_bo_va_op) == nullptr) goto ERROR;
+      DRM_PFN(amdgpu_bo_va_op) = (DRM_DEF(amdgpu_bo_va_op)*)rocr::os::GetExportAddress(thunk_handle, "amdgpu_bo_va_op");
+      if (DRM_PFN(amdgpu_bo_va_op) == nullptr) goto LOAD_ERROR;
 
-      DRM_PFN(amdgpu_bo_query_info) = (DRM_DEF(amdgpu_bo_query_info)*)dlsym(thunk_handle, "amdgpu_bo_query_info");
-      if (DRM_PFN(amdgpu_bo_query_info) == NULL) goto ERROR;
+      DRM_PFN(amdgpu_bo_query_info) = (DRM_DEF(amdgpu_bo_query_info)*)rocr::os::GetExportAddress(thunk_handle, "amdgpu_bo_query_info");
+      if (DRM_PFN(amdgpu_bo_query_info) == NULL) goto LOAD_ERROR;
 
-      DRM_PFN(amdgpu_bo_set_metadata) = (DRM_DEF(amdgpu_bo_set_metadata)*)dlsym(thunk_handle, "amdgpu_bo_set_metadata");
-      if (DRM_PFN(amdgpu_bo_set_metadata) == NULL) goto ERROR;
+      DRM_PFN(amdgpu_bo_set_metadata) = (DRM_DEF(amdgpu_bo_set_metadata)*)rocr::os::GetExportAddress(thunk_handle, "amdgpu_bo_set_metadata");
+      if (DRM_PFN(amdgpu_bo_set_metadata) == NULL) goto LOAD_ERROR;
 
-      DRM_PFN(drmCommandWriteRead) = (DRM_DEF(drmCommandWriteRead)*)dlsym(thunk_handle, "drmCommandWriteRead");
-      if (DRM_PFN(drmCommandWriteRead) == nullptr) goto ERROR;
+      DRM_PFN(drmCommandWriteRead) = (DRM_DEF(drmCommandWriteRead)*)rocr::os::GetExportAddress(thunk_handle, "drmCommandWriteRead");
+      if (DRM_PFN(drmCommandWriteRead) == nullptr) goto LOAD_ERROR;
       debug_print("Load all DTIF APIs OK!\n");
       return;
 
-ERROR:
-      fprintf(stderr, "dlsym failed: %s\n", dlerror());
-#endif
+LOAD_ERROR:
+      fprintf(stderr, "GetExportAddress failed: %s\n", rocr::os::DlError());
     } else {
       HSAKMT_PFN(hsaKmtOpenKFD) = (HSAKMT_DEF(hsaKmtOpenKFD)*)(&hsaKmtOpenKFD);
       HSAKMT_PFN(hsaKmtCloseKFD) = (HSAKMT_DEF(hsaKmtCloseKFD)*)(&hsaKmtCloseKFD);


### PR DESCRIPTION
The dynamic library loading path in ThunkLoader::LoadThunkApiTable() was gated behind #if defined(__linux__), making it dead code on Windows.

Replace all dlsym/dlerror calls with the cross-platform rocr::os wrappers GetExportAddress and DlError. Rename the ERROR goto label to LOAD_ERROR to avoid a collision with the Windows ERROR macro from <windows.h>. Add the Windows DTIF library name (dtif64a.dll) alongside the Linux one (libdtif.so).