### PR TITLE
hip-tests catch fixes

### DIFF
--- a/projects/hip-tests/catch/CMakeLists.txt
+++ b/projects/hip-tests/catch/CMakeLists.txt
@@ -61,9 +61,8 @@ if(NOT DEFINED ROCM_PATH)
 endif()
 
 if(UNIX)
-  if(NOT ENABLE_SPIRV)
-    find_program(ROCM_AGENT_ENUMERATOR_EXEC rocm_agent_enumerator REQUIRED)
-  endif()
+  find_program(ROCM_AGENT_ENUMERATOR_EXEC rocm_agent_enumerator REQUIRED
+               PATHS ${ROCM_PATH}/bin ${ROCM_PATH})
   find_program(GCC_EXEC gcc)
   find_program(GXX_EXEC g++)
 else() # Win32
@@ -278,7 +277,7 @@ elseif(DEFINED GPU_TARGETS)
 elseif(NOT DEFINED OFFLOAD_ARCH_STR
    AND EXISTS "${ROCM_AGENT_ENUMERATOR_EXEC}"
    AND HIP_PLATFORM STREQUAL "amd" AND UNIX)
-  execute_process(COMMAND "${ROCM_PATH}/bin/rocm_agent_enumerator"
+  execute_process(COMMAND "${ROCM_AGENT_ENUMERATOR_EXEC}"
          OUTPUT_VARIABLE HIP_GPU_ARCH
          RESULT_VARIABLE ROCM_AGENT_ENUM_RESULT
          OUTPUT_STRIP_TRAILING_WHITESPACE)

--- a/projects/hip-tests/catch/config/CMakeLists.txt
+++ b/projects/hip-tests/catch/config/CMakeLists.txt
@@ -11,7 +11,13 @@ execute_process(
     ERROR_QUIET
 )
 if(NOT PY_YAML_RESULT EQUAL 0)
-    message(FATAL_ERROR "PyYAML is required in order to read the configuration file. Please install it")
+    execute_process(
+        COMMAND ${Python3_EXECUTABLE} -m pip install PyYAML
+        RESULT_VARIABLE PyYAML_INSTALL_RESULT
+    )
+    if(NOT PyYAML_INSTALL_RESULT EQUAL 0)
+        message(FATAL_ERROR "PyYAML is required in order to read the configuration file. Please install it")
+    endif()
 endif()
 
 if(WIN32)


### PR DESCRIPTION
- use rocm_agent_enumerator found program
- auto install PyYAML py package if not installed

## Motivation
rocm_agent_enumerator does not have path for find_program. Also pyYaml py package is not installed correctly so this change helps to have it installed automatically.

## Test Plan
hip-tests catch build going through correctly

## Test Result
hip-tests catch build going through correctly

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
