### PR TITLE
rocr/clr: Fix graph timestamps

### DIFF
--- a/projects/clr/rocclr/device/rocm/rocvirtual.cpp
+++ b/projects/clr/rocclr/device/rocm/rocvirtual.cpp
@@ -257,6 +257,14 @@ void Timestamp::checkGpuTime(ProfilingSignal* single_signal) {
 
     if (single_signal != nullptr) {
       process_signal(single_signal);
+      // Remove the signal from the list after extracting its timing.
+      // This prevents a stale entry when ActiveSignal() recycles and re-adds
+      // the same ProfilingSignal — without this, the recycled signal appears
+      // twice in signals_ and the first (stale) entry re-reads wrong HW timestamps.
+      auto it = std::find(signals_.begin(), signals_.end(), single_signal);
+      if (it != signals_.end()) {
+        signals_.erase(it);
+      }
     } else {
       for (auto it : signals_) {
         process_signal(it);
@@ -299,6 +307,16 @@ void Timestamp::ExtractSignalTiming(ProfilingSignal* signal,
   // Lock signal for accessing engine_ and flags_
   std::scoped_lock sig_lock(signal->LockSignalOps());
 
+  // Guard against invalid timestamps from GPU (e.g. HW didn't write start_ts/end_ts).
+  // TranslateTime returns 0 for these cases. Skip accumulation to avoid corrupting timing.
+  if (sig_start == 0 || sig_end == 0 || sig_end < sig_start) {
+    ClPrint(amd::LOG_WARNING, amd::LOG_TS,
+            "Invalid signal timing: start=%lu, end=%lu, signal=0x%lx",
+            sig_start, sig_end, signal->signal_.handle);
+    signal->flags_.done_ = true;
+    return;
+  }
+
   // Update appropriate accumulators based on engine type
   if (IsSdmaEngine(signal->engine_)) {
     sdmaStart = std::min(sig_start, sdmaStart);
@@ -308,9 +326,11 @@ void Timestamp::ExtractSignalTiming(ProfilingSignal* signal,
     end = std::max(sig_end, end);
   }
 
-  // Handle AccumulateCommand timestamps
+  // Handle AccumulateCommand timestamps (convert ticks to system time)
   if ((command().type() == CL_COMMAND_TASK) && (signal->flags_.isPacketDispatch_ == true)) {
-    static_cast<amd::AccumulateCommand&>(command()).addTimestamps(sig_start, sig_end);
+    static_cast<amd::AccumulateCommand&>(command()).addTimestamps(
+        static_cast<uint64_t>(sig_start * ticksToTime_),
+        static_cast<uint64_t>(sig_end * ticksToTime_));
   }
 
   signal->flags_.done_ = true;

--- a/projects/hip-tests/catch/config/configs/unit/graph.yaml
+++ b/projects/hip-tests/catch/config/configs/unit/graph.yaml
@@ -1075,6 +1075,21 @@ graph:
   Unit_hipGraphLaunch_Functional_MultipleLaunch:
     <<: *level_2
     tags: [exec]
+  Unit_hipGraphLaunch_ProfilingTimestamps_SmallGraph:
+    <<: *level_2
+    tags: [exec]
+  Unit_hipGraphLaunch_ProfilingTimestamps_LargeGraph:
+    <<: *level_2
+    tags: [exec]
+  Unit_hipGraphLaunch_PerKernelTiming_SmallGraph:
+    <<: *level_2
+    tags: [exec]
+  Unit_hipGraphLaunch_TimingConsistency_SmallGraph:
+    <<: *level_2
+    tags: [exec]
+  Unit_hipGraphLaunch_TimingConsistency_LargeGraph:
+    <<: *level_2
+    tags: [exec]
   Unit_hipGraphMemcpyNodeSetParams1D_Positive_Basic:
     <<: *level_2
     tags: [node]

--- a/projects/hip-tests/catch/unit/graph/CMakeLists.txt
+++ b/projects/hip-tests/catch/unit/graph/CMakeLists.txt
@@ -131,6 +131,7 @@ set(TEST_SRC
   hipGraphKernelNodeCopyAttributes.cc
   hipGraphCycle.cc
   hipGraphPerf.cc
+  hipGraphProfilingTimestamps.cc
   hipGraphKernelNodeGetAttribute.cc
   hipGraphKernelNodeSetAttribute.cc
   hipGraphMemAllocNodeGetParams.cc

--- a/projects/hip-tests/catch/unit/graph/hipGraphProfilingTimestamps.cc
+++ b/projects/hip-tests/catch/unit/graph/hipGraphProfilingTimestamps.cc
@@ -1,0 +1,293 @@
+/*
+ * Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+/**
+ * @addtogroup hipGraphLaunch hipGraphLaunch
+ * @{
+ * @ingroup GraphTest
+ * Tests that verify GPU profiling timestamps are correct when graph launches
+ * recycle profiling signals internally. Specifically targets the case where
+ * a graph has more kernels than the internal signal pool, forcing signal reuse.
+ *
+ * The bug: when a ProfilingSignal is recycled mid-graph, its stale entry in
+ * the Timestamp::signals_ list was re-read with wrong HW timestamps from the
+ * recycled dispatch, corrupting per-kernel timing.
+ */
+
+#include <hip_test_common.hh>
+
+#include <algorithm>
+#include <cstdint>
+#include <numeric>
+#include <vector>
+
+static constexpr int kN = 1024;
+
+static __global__ void busyKernel(float* out, const float* in, int n) {
+  int idx = blockIdx.x * blockDim.x + threadIdx.x;
+  if (idx < n) {
+    float val = in[idx];
+    for (int i = 0; i < 50; ++i) {
+      val = val * 1.001f + 0.001f;
+    }
+    out[idx] = val;
+  }
+}
+
+// Verify that elapsed time from a graph launch with many kernels (forcing
+// signal recycling) produces positive timestamps via hipEvent timing.
+// Events are recorded outside the captured graph, around the launch.
+static void GraphLaunchTimingWithEvents(int numKernels) {
+  hipStream_t stream;
+  HIP_CHECK(hipStreamCreate(&stream));
+
+  float* d_in;
+  float* d_out;
+  HIP_CHECK(hipMalloc(&d_in, kN * sizeof(float)));
+  HIP_CHECK(hipMalloc(&d_out, kN * sizeof(float)));
+
+  std::vector<float> h_in(kN);
+  std::iota(h_in.begin(), h_in.end(), 1.0f);
+  HIP_CHECK(hipMemcpy(d_in, h_in.data(), kN * sizeof(float), hipMemcpyHostToDevice));
+
+  hipEvent_t evStart, evEnd;
+  HIP_CHECK(hipEventCreate(&evStart));
+  HIP_CHECK(hipEventCreate(&evEnd));
+
+  hipGraph_t graph;
+  hipGraphExec_t graphExec;
+
+  HIP_CHECK(hipStreamBeginCapture(stream, hipStreamCaptureModeGlobal));
+  for (int i = 0; i < numKernels; ++i) {
+    busyKernel<<<dim3((kN + 255) / 256), dim3(256), 0, stream>>>(d_out, d_in, kN);
+  }
+  HIP_CHECK(hipStreamEndCapture(stream, &graph));
+  HIP_CHECK(hipGraphInstantiate(&graphExec, graph, nullptr, nullptr, 0));
+
+  constexpr int kIterations = 10;
+  for (int iter = 0; iter < kIterations; ++iter) {
+    HIP_CHECK(hipEventRecord(evStart, stream));
+    HIP_CHECK(hipGraphLaunch(graphExec, stream));
+    HIP_CHECK(hipEventRecord(evEnd, stream));
+    HIP_CHECK(hipStreamSynchronize(stream));
+
+    float elapsed = 0.0f;
+    HIP_CHECK(hipEventElapsedTime(&elapsed, evStart, evEnd));
+
+    INFO("Iteration " << iter << ": elapsed = " << elapsed << " ms, numKernels = " << numKernels);
+    REQUIRE(elapsed > 0.0f);
+    REQUIRE(elapsed < 60000.0f);
+  }
+
+  HIP_CHECK(hipEventDestroy(evStart));
+  HIP_CHECK(hipEventDestroy(evEnd));
+  HIP_CHECK(hipGraphExecDestroy(graphExec));
+  HIP_CHECK(hipGraphDestroy(graph));
+  HIP_CHECK(hipFree(d_in));
+  HIP_CHECK(hipFree(d_out));
+  HIP_CHECK(hipStreamDestroy(stream));
+}
+
+// Verify per-kernel timing using hipGraphAddEventRecordNode between kernel
+// nodes. Checks that individual kernel durations are non-negative and within
+// a sane range, and that the overall elapsed time is positive.
+static void GraphLaunchPerKernelTiming(int numKernels) {
+  hipStream_t stream;
+  HIP_CHECK(hipStreamCreate(&stream));
+
+  float* d_in;
+  float* d_out;
+  HIP_CHECK(hipMalloc(&d_in, kN * sizeof(float)));
+  HIP_CHECK(hipMalloc(&d_out, kN * sizeof(float)));
+
+  std::vector<float> h_in(kN);
+  std::iota(h_in.begin(), h_in.end(), 1.0f);
+  HIP_CHECK(hipMemcpy(d_in, h_in.data(), kN * sizeof(float), hipMemcpyHostToDevice));
+
+  int numEvents = numKernels + 1;
+  std::vector<hipEvent_t> events(numEvents);
+  for (int i = 0; i < numEvents; ++i) {
+    HIP_CHECK(hipEventCreate(&events[i]));
+  }
+
+  hipGraph_t graph;
+  HIP_CHECK(hipGraphCreate(&graph, 0));
+
+  hipKernelNodeParams kNodeParams = {};
+  kNodeParams.func = reinterpret_cast<void*>(busyKernel);
+  kNodeParams.gridDim = dim3((kN + 255) / 256);
+  kNodeParams.blockDim = dim3(256);
+  kNodeParams.sharedMemBytes = 0;
+  int n = kN;
+  void* kArgs[] = {&d_out, &d_in, &n};
+  kNodeParams.kernelParams = kArgs;
+  kNodeParams.extra = nullptr;
+
+  std::vector<hipGraphNode_t> eventNodes(numEvents);
+  std::vector<hipGraphNode_t> kernelNodes(numKernels);
+
+  HIP_CHECK(hipGraphAddEventRecordNode(&eventNodes[0], graph, nullptr, 0, events[0]));
+
+  for (int i = 0; i < numKernels; ++i) {
+    HIP_CHECK(hipGraphAddKernelNode(&kernelNodes[i], graph, &eventNodes[i], 1, &kNodeParams));
+    HIP_CHECK(hipGraphAddEventRecordNode(&eventNodes[i + 1], graph, &kernelNodes[i], 1,
+                                          events[i + 1]));
+  }
+
+  hipGraphExec_t graphExec;
+  HIP_CHECK(hipGraphInstantiate(&graphExec, graph, nullptr, nullptr, 0));
+
+  HIP_CHECK(hipGraphLaunch(graphExec, stream));
+  HIP_CHECK(hipStreamSynchronize(stream));
+
+  int negativeCount = 0;
+  for (int i = 0; i < numKernels; ++i) {
+    float elapsed = 0.0f;
+    HIP_CHECK(hipEventElapsedTime(&elapsed, events[i], events[i + 1]));
+    INFO("Kernel " << i << ": elapsed = " << elapsed << " ms");
+    REQUIRE(elapsed >= 0.0f);
+    REQUIRE(elapsed < 10000.0f);
+    if (elapsed < 0.0f) negativeCount++;
+  }
+  REQUIRE(negativeCount == 0);
+
+  float overallElapsed = 0.0f;
+  HIP_CHECK(hipEventElapsedTime(&overallElapsed, events[0], events[numKernels]));
+  INFO("Overall elapsed = " << overallElapsed << " ms");
+  REQUIRE(overallElapsed > 0.0f);
+  REQUIRE(overallElapsed < 60000.0f);
+
+  for (int i = 0; i < numEvents; ++i) {
+    HIP_CHECK(hipEventDestroy(events[i]));
+  }
+  HIP_CHECK(hipGraphExecDestroy(graphExec));
+  HIP_CHECK(hipGraphDestroy(graph));
+  HIP_CHECK(hipFree(d_in));
+  HIP_CHECK(hipFree(d_out));
+  HIP_CHECK(hipStreamDestroy(stream));
+}
+
+// Verify that repeated graph launches produce consistent timing
+// (no drift or corruption from signal reuse across launches)
+static void GraphLaunchTimingConsistency(int numKernels) {
+  hipStream_t stream;
+  HIP_CHECK(hipStreamCreate(&stream));
+
+  float* d_in;
+  float* d_out;
+  HIP_CHECK(hipMalloc(&d_in, kN * sizeof(float)));
+  HIP_CHECK(hipMalloc(&d_out, kN * sizeof(float)));
+
+  std::vector<float> h_in(kN);
+  std::iota(h_in.begin(), h_in.end(), 1.0f);
+  HIP_CHECK(hipMemcpy(d_in, h_in.data(), kN * sizeof(float), hipMemcpyHostToDevice));
+
+  hipEvent_t evStart, evEnd;
+  HIP_CHECK(hipEventCreate(&evStart));
+  HIP_CHECK(hipEventCreate(&evEnd));
+
+  hipGraph_t graph;
+  hipGraphExec_t graphExec;
+
+  HIP_CHECK(hipStreamBeginCapture(stream, hipStreamCaptureModeGlobal));
+  for (int i = 0; i < numKernels; ++i) {
+    busyKernel<<<dim3((kN + 255) / 256), dim3(256), 0, stream>>>(d_out, d_in, kN);
+  }
+  HIP_CHECK(hipStreamEndCapture(stream, &graph));
+  HIP_CHECK(hipGraphInstantiate(&graphExec, graph, nullptr, nullptr, 0));
+
+  // Warmup
+  HIP_CHECK(hipEventRecord(evStart, stream));
+  HIP_CHECK(hipGraphLaunch(graphExec, stream));
+  HIP_CHECK(hipEventRecord(evEnd, stream));
+  HIP_CHECK(hipStreamSynchronize(stream));
+
+  constexpr int kRuns = 20;
+  std::vector<float> timings(kRuns);
+  for (int i = 0; i < kRuns; ++i) {
+    HIP_CHECK(hipEventRecord(evStart, stream));
+    HIP_CHECK(hipGraphLaunch(graphExec, stream));
+    HIP_CHECK(hipEventRecord(evEnd, stream));
+    HIP_CHECK(hipStreamSynchronize(stream));
+
+    float elapsed = 0.0f;
+    HIP_CHECK(hipEventElapsedTime(&elapsed, evStart, evEnd));
+    timings[i] = elapsed;
+    REQUIRE(elapsed > 0.0f);
+  }
+
+  std::sort(timings.begin(), timings.end());
+  float median = timings[kRuns / 2];
+  INFO("Median timing = " << median << " ms for " << numKernels << " kernels");
+  REQUIRE(median > 0.0f);
+
+  for (int i = 0; i < kRuns; ++i) {
+    INFO("Run " << i << ": elapsed = " << timings[i] << " ms, median = " << median << " ms");
+    REQUIRE(timings[i] < median * 100.0f);
+    REQUIRE(timings[i] > median * 0.01f);
+  }
+
+  HIP_CHECK(hipEventDestroy(evStart));
+  HIP_CHECK(hipEventDestroy(evEnd));
+  HIP_CHECK(hipGraphExecDestroy(graphExec));
+  HIP_CHECK(hipGraphDestroy(graph));
+  HIP_CHECK(hipFree(d_in));
+  HIP_CHECK(hipFree(d_out));
+  HIP_CHECK(hipStreamDestroy(stream));
+}
+
+/**
+ * Test Description
+ * ------------------------
+ *  - Launch a graph with few kernels (no signal recycling) and verify
+ *    positive elapsed time via hipEvents.
+ */
+HIP_TEST_CASE(Unit_hipGraphLaunch_ProfilingTimestamps_SmallGraph) {
+  GraphLaunchTimingWithEvents(8);
+}
+
+/**
+ * Test Description
+ * ------------------------
+ *  - Launch a graph with many kernels (forces internal signal recycling)
+ *    and verify positive elapsed time via hipEvents. This is the scenario
+ *    where stale signal entries corrupted timestamps before the fix.
+ */
+HIP_TEST_CASE(Unit_hipGraphLaunch_ProfilingTimestamps_LargeGraph) {
+  GraphLaunchTimingWithEvents(320);
+}
+
+/**
+ * Test Description
+ * ------------------------
+ *  - Build a graph with interleaved event record nodes and kernel nodes.
+ *    Verify per-kernel timing is positive and consistent with the overall
+ *    graph elapsed time.
+ */
+HIP_TEST_CASE(Unit_hipGraphLaunch_PerKernelTiming_SmallGraph) {
+  GraphLaunchPerKernelTiming(8);
+}
+
+/**
+ * Test Description
+ * ------------------------
+ *  - Launch a graph many times and verify timing consistency across runs.
+ *    Catches timestamp corruption from signal reuse across successive launches.
+ */
+HIP_TEST_CASE(Unit_hipGraphLaunch_TimingConsistency_SmallGraph) {
+  GraphLaunchTimingConsistency(8);
+}
+
+/**
+ * Test Description
+ * ------------------------
+ *  - Same as above with large kernel count to stress signal recycling.
+ */
+HIP_TEST_CASE(Unit_hipGraphLaunch_TimingConsistency_LargeGraph) {
+  GraphLaunchTimingConsistency(320);
+}
+
+/** @} */

--- a/projects/hip-tests/catch/unit/graph/hipGraphProfilingTimestamps_standalone.cpp
+++ b/projects/hip-tests/catch/unit/graph/hipGraphProfilingTimestamps_standalone.cpp
@@ -1,0 +1,299 @@
+/*
+ * Standalone test for graph profiling timestamp correctness.
+ * Build: hipcc --offload-arch=gfx942 -o graphTimingTest hipGraphProfilingTimestamps_standalone.cpp
+ * Run:   ./graphTimingTest
+ */
+
+#include <hip/hip_runtime.h>
+
+#include <algorithm>
+#include <cassert>
+#include <cmath>
+#include <cstdio>
+#include <cstdlib>
+#include <numeric>
+#include <vector>
+
+#define HIP_CHECK(call)                                                        \
+  do {                                                                         \
+    hipError_t err = (call);                                                   \
+    if (err != hipSuccess) {                                                   \
+      fprintf(stderr, "HIP error %d (%s) at %s:%d\n", err,                    \
+              hipGetErrorString(err), __FILE__, __LINE__);                      \
+      exit(1);                                                                 \
+    }                                                                          \
+  } while (0)
+
+static constexpr int kN = 1024;
+
+__global__ void busyKernel(float* out, const float* in, int n) {
+  int idx = blockIdx.x * blockDim.x + threadIdx.x;
+  if (idx < n) {
+    float val = in[idx];
+    for (int i = 0; i < 50; ++i) {
+      val = val * 1.001f + 0.001f;
+    }
+    out[idx] = val;
+  }
+}
+
+// Test 1: Verify elapsed time from a graph launch with many kernels
+// Events are recorded OUTSIDE the graph (around the launch) to measure wall time.
+static bool testGraphTimingWithEvents(int numKernels) {
+  printf("  [GraphTimingWithEvents] numKernels=%d ... ", numKernels);
+
+  hipStream_t stream;
+  HIP_CHECK(hipStreamCreate(&stream));
+
+  float* d_in;
+  float* d_out;
+  HIP_CHECK(hipMalloc(&d_in, kN * sizeof(float)));
+  HIP_CHECK(hipMalloc(&d_out, kN * sizeof(float)));
+
+  std::vector<float> h_in(kN);
+  std::iota(h_in.begin(), h_in.end(), 1.0f);
+  HIP_CHECK(hipMemcpy(d_in, h_in.data(), kN * sizeof(float), hipMemcpyHostToDevice));
+
+  hipEvent_t evStart, evEnd;
+  HIP_CHECK(hipEventCreate(&evStart));
+  HIP_CHECK(hipEventCreate(&evEnd));
+
+  hipGraph_t graph;
+  hipGraphExec_t graphExec;
+
+  HIP_CHECK(hipStreamBeginCapture(stream, hipStreamCaptureModeGlobal));
+  for (int i = 0; i < numKernels; ++i) {
+    busyKernel<<<dim3((kN + 255) / 256), dim3(256), 0, stream>>>(d_out, d_in, kN);
+  }
+  HIP_CHECK(hipStreamEndCapture(stream, &graph));
+  HIP_CHECK(hipGraphInstantiate(&graphExec, graph, nullptr, nullptr, 0));
+
+  bool pass = true;
+  constexpr int kIterations = 10;
+  for (int iter = 0; iter < kIterations; ++iter) {
+    HIP_CHECK(hipEventRecord(evStart, stream));
+    HIP_CHECK(hipGraphLaunch(graphExec, stream));
+    HIP_CHECK(hipEventRecord(evEnd, stream));
+    HIP_CHECK(hipStreamSynchronize(stream));
+
+    float elapsed = 0.0f;
+    HIP_CHECK(hipEventElapsedTime(&elapsed, evStart, evEnd));
+
+    if (elapsed <= 0.0f || elapsed >= 60000.0f) {
+      printf("FAIL (iter %d: elapsed=%.4f ms)\n", iter, elapsed);
+      pass = false;
+      break;
+    }
+  }
+  if (pass) printf("PASS\n");
+
+  HIP_CHECK(hipEventDestroy(evStart));
+  HIP_CHECK(hipEventDestroy(evEnd));
+  HIP_CHECK(hipGraphExecDestroy(graphExec));
+  HIP_CHECK(hipGraphDestroy(graph));
+  HIP_CHECK(hipFree(d_in));
+  HIP_CHECK(hipFree(d_out));
+  HIP_CHECK(hipStreamDestroy(stream));
+  return pass;
+}
+
+// Test 2: Verify per-kernel timing using hipGraphAddEventRecordNode
+// Events are embedded as graph nodes between kernels.
+static bool testPerKernelTiming(int numKernels) {
+  printf("  [PerKernelTiming] numKernels=%d ... ", numKernels);
+
+  hipStream_t stream;
+  HIP_CHECK(hipStreamCreate(&stream));
+
+  float* d_in;
+  float* d_out;
+  HIP_CHECK(hipMalloc(&d_in, kN * sizeof(float)));
+  HIP_CHECK(hipMalloc(&d_out, kN * sizeof(float)));
+
+  std::vector<float> h_in(kN);
+  std::iota(h_in.begin(), h_in.end(), 1.0f);
+  HIP_CHECK(hipMemcpy(d_in, h_in.data(), kN * sizeof(float), hipMemcpyHostToDevice));
+
+  int numEvents = numKernels + 1;
+  std::vector<hipEvent_t> events(numEvents);
+  for (int i = 0; i < numEvents; ++i) {
+    HIP_CHECK(hipEventCreate(&events[i]));
+  }
+
+  // Build graph manually with interleaved event record nodes and kernel nodes
+  hipGraph_t graph;
+  HIP_CHECK(hipGraphCreate(&graph, 0));
+
+  hipKernelNodeParams kNodeParams = {};
+  kNodeParams.func = reinterpret_cast<void*>(busyKernel);
+  kNodeParams.gridDim = dim3((kN + 255) / 256);
+  kNodeParams.blockDim = dim3(256);
+  kNodeParams.sharedMemBytes = 0;
+  int n = kN;
+  void* kArgs[] = {&d_out, &d_in, &n};
+  kNodeParams.kernelParams = kArgs;
+  kNodeParams.extra = nullptr;
+
+  // Chain: eventRec[0] -> kernel[0] -> eventRec[1] -> kernel[1] -> ... -> eventRec[N]
+  std::vector<hipGraphNode_t> eventNodes(numEvents);
+  std::vector<hipGraphNode_t> kernelNodes(numKernels);
+
+  // First event node (no dependencies)
+  HIP_CHECK(hipGraphAddEventRecordNode(&eventNodes[0], graph, nullptr, 0, events[0]));
+
+  for (int i = 0; i < numKernels; ++i) {
+    // Kernel depends on previous event
+    HIP_CHECK(hipGraphAddKernelNode(&kernelNodes[i], graph, &eventNodes[i], 1, &kNodeParams));
+    // Event after kernel
+    HIP_CHECK(hipGraphAddEventRecordNode(&eventNodes[i + 1], graph, &kernelNodes[i], 1,
+                                          events[i + 1]));
+  }
+
+  hipGraphExec_t graphExec;
+  HIP_CHECK(hipGraphInstantiate(&graphExec, graph, nullptr, nullptr, 0));
+
+  HIP_CHECK(hipGraphLaunch(graphExec, stream));
+  HIP_CHECK(hipStreamSynchronize(stream));
+
+  bool pass = true;
+  int negativeCount = 0;
+  for (int i = 0; i < numKernels; ++i) {
+    float elapsed = 0.0f;
+    HIP_CHECK(hipEventElapsedTime(&elapsed, events[i], events[i + 1]));
+    if (elapsed < 0.0f) {
+      printf("FAIL (kernel %d: elapsed=%.4f ms < 0)\n", i, elapsed);
+      negativeCount++;
+    } else if (elapsed >= 10000.0f) {
+      printf("FAIL (kernel %d: elapsed=%.4f ms >= 10s)\n", i, elapsed);
+      pass = false;
+      break;
+    }
+  }
+  if (negativeCount > 0) pass = false;
+
+  if (pass) {
+    float overallElapsed = 0.0f;
+    HIP_CHECK(hipEventElapsedTime(&overallElapsed, events[0], events[numKernels]));
+    if (overallElapsed <= 0.0f || overallElapsed >= 60000.0f) {
+      printf("FAIL (overall=%.4f ms)\n", overallElapsed);
+      pass = false;
+    }
+  }
+  if (pass) printf("PASS\n");
+
+  for (int i = 0; i < numEvents; ++i) {
+    HIP_CHECK(hipEventDestroy(events[i]));
+  }
+  HIP_CHECK(hipGraphExecDestroy(graphExec));
+  HIP_CHECK(hipGraphDestroy(graph));
+  HIP_CHECK(hipFree(d_in));
+  HIP_CHECK(hipFree(d_out));
+  HIP_CHECK(hipStreamDestroy(stream));
+  return pass;
+}
+
+// Test 3: Verify timing consistency across repeated graph launches
+static bool testTimingConsistency(int numKernels) {
+  printf("  [TimingConsistency] numKernels=%d ... ", numKernels);
+
+  hipStream_t stream;
+  HIP_CHECK(hipStreamCreate(&stream));
+
+  float* d_in;
+  float* d_out;
+  HIP_CHECK(hipMalloc(&d_in, kN * sizeof(float)));
+  HIP_CHECK(hipMalloc(&d_out, kN * sizeof(float)));
+
+  std::vector<float> h_in(kN);
+  std::iota(h_in.begin(), h_in.end(), 1.0f);
+  HIP_CHECK(hipMemcpy(d_in, h_in.data(), kN * sizeof(float), hipMemcpyHostToDevice));
+
+  hipEvent_t evStart, evEnd;
+  HIP_CHECK(hipEventCreate(&evStart));
+  HIP_CHECK(hipEventCreate(&evEnd));
+
+  hipGraph_t graph;
+  hipGraphExec_t graphExec;
+
+  HIP_CHECK(hipStreamBeginCapture(stream, hipStreamCaptureModeGlobal));
+  for (int i = 0; i < numKernels; ++i) {
+    busyKernel<<<dim3((kN + 255) / 256), dim3(256), 0, stream>>>(d_out, d_in, kN);
+  }
+  HIP_CHECK(hipStreamEndCapture(stream, &graph));
+  HIP_CHECK(hipGraphInstantiate(&graphExec, graph, nullptr, nullptr, 0));
+
+  // Warmup
+  HIP_CHECK(hipEventRecord(evStart, stream));
+  HIP_CHECK(hipGraphLaunch(graphExec, stream));
+  HIP_CHECK(hipEventRecord(evEnd, stream));
+  HIP_CHECK(hipStreamSynchronize(stream));
+
+  constexpr int kRuns = 20;
+  std::vector<float> timings(kRuns);
+  bool pass = true;
+  for (int i = 0; i < kRuns; ++i) {
+    HIP_CHECK(hipEventRecord(evStart, stream));
+    HIP_CHECK(hipGraphLaunch(graphExec, stream));
+    HIP_CHECK(hipEventRecord(evEnd, stream));
+    HIP_CHECK(hipStreamSynchronize(stream));
+
+    float elapsed = 0.0f;
+    HIP_CHECK(hipEventElapsedTime(&elapsed, evStart, evEnd));
+    timings[i] = elapsed;
+    if (elapsed <= 0.0f) {
+      printf("FAIL (run %d: elapsed=%.4f ms <= 0)\n", i, elapsed);
+      pass = false;
+      break;
+    }
+  }
+
+  if (pass) {
+    std::sort(timings.begin(), timings.end());
+    float median = timings[kRuns / 2];
+    for (int i = 0; i < kRuns; ++i) {
+      if (timings[i] > median * 100.0f || timings[i] < median * 0.01f) {
+        printf("FAIL (run %d: %.4f ms, median=%.4f ms, ratio=%.2fx)\n",
+               i, timings[i], median, timings[i] / median);
+        pass = false;
+        break;
+      }
+    }
+    if (pass) printf("PASS (median=%.4f ms)\n", median);
+  }
+
+  HIP_CHECK(hipEventDestroy(evStart));
+  HIP_CHECK(hipEventDestroy(evEnd));
+  HIP_CHECK(hipGraphExecDestroy(graphExec));
+  HIP_CHECK(hipGraphDestroy(graph));
+  HIP_CHECK(hipFree(d_in));
+  HIP_CHECK(hipFree(d_out));
+  HIP_CHECK(hipStreamDestroy(stream));
+  return pass;
+}
+
+int main() {
+  printf("=== Graph Profiling Timestamp Tests ===\n\n");
+
+  int failures = 0;
+
+  printf("Test 1: Graph timing with events (small, no signal recycling)\n");
+  if (!testGraphTimingWithEvents(8)) failures++;
+
+  printf("Test 2: Graph timing with events (large, forces signal recycling)\n");
+  if (!testGraphTimingWithEvents(320)) failures++;
+
+  printf("Test 3: Per-kernel timing (small)\n");
+  if (!testPerKernelTiming(8)) failures++;
+
+  printf("Test 4: Per-kernel timing (large, forces signal recycling)\n");
+  if (!testPerKernelTiming(128)) failures++;
+
+  printf("Test 5: Timing consistency (small)\n");
+  if (!testTimingConsistency(8)) failures++;
+
+  printf("Test 6: Timing consistency (large, forces signal recycling)\n");
+  if (!testTimingConsistency(320)) failures++;
+
+  printf("\n=== Results: %d/%d passed ===\n", 6 - failures, 6);
+  return failures > 0 ? 1 : 0;
+}

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_gpu_agent.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_gpu_agent.cpp
@@ -2596,25 +2596,37 @@ hsa_status_t GpuAgent::SetAsyncScratchThresholds(size_t use_once_limit) {
 void GpuAgent::TranslateTime(core::Signal* signal, hsa_amd_profiling_dispatch_time_t& time) {
   uint64_t start, end;
   signal->GetRawTs(false, start, end);
+
+  if ((start == 0) || (end == 0) || (start < t0_.GPUClockCounter) || (end < t0_.GPUClockCounter)) {
+    debug_print("Signal %p time stamps may be invalid (start=%lu, end=%lu, t0=%lu).\n",
+                &signal->signal_, start, end, t0_.GPUClockCounter);
+    time.start = 0;
+    time.end = 0;
+    return;
+  }
+
   // Order is important, we want to translate the end time first to ensure that packet duration is
   // not impacted by clock measurement latency jitter.
   time.end = TranslateTime(end);
   time.start = TranslateTime(start);
-
-  if ((start == 0) || (end == 0) || (start < t0_.GPUClockCounter) || (end < t0_.GPUClockCounter))
-    debug_print("Signal %p time stamps may be invalid.\n", &signal->signal_);
 }
 
 void GpuAgent::TranslateTime(core::Signal* signal, hsa_amd_profiling_async_copy_time_t& time) {
   uint64_t start, end;
   signal->GetRawTs(true, start, end);
+
+  if ((start == 0) || (end == 0) || (start < t0_.GPUClockCounter) || (end < t0_.GPUClockCounter)) {
+    debug_print("Signal %p async copy time stamps may be invalid (start=%lu, end=%lu, t0=%lu).\n",
+                &signal->signal_, start, end, t0_.GPUClockCounter);
+    time.start = 0;
+    time.end = 0;
+    return;
+  }
+
   // Order is important, we want to translate the end time first to ensure that packet duration is
   // not impacted by clock measurement latency jitter.
   time.end = TranslateTime(end);
   time.start = TranslateTime(start);
-
-  if ((start == 0) || (end == 0) || (start < t0_.GPUClockCounter) || (end < t0_.GPUClockCounter))
-    debug_print("Signal %p time stamps may be invalid.\n", &signal->signal_);
 }
 
 /*


### PR DESCRIPTION
- Timestamps passed as kernel timings were not adjusted for clock drift
- Avoid translateTime in ROCr if rawTs are incorrect

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
