### PR TITLE
[rocprofiler-compute] Fix repeated configure failure from CMAKE_HIP_COMPILER cache invalidation

### DIFF
--- a/projects/rocprofiler-compute/tests/CMakeLists.txt
+++ b/projects/rocprofiler-compute/tests/CMakeLists.txt
@@ -1,6 +1,8 @@
 find_package(MPI COMPONENTS CXX)
 
-set(CMAKE_HIP_COMPILER "amdclang++" CACHE STRING "desired c++ compiler" FORCE)
+if(NOT CMAKE_HIP_COMPILER)
+    set(CMAKE_HIP_COMPILER "amdclang++" CACHE STRING "desired c++ compiler")
+endif()
 if(CMAKE_HIP_COMPILER_ID STREQUAL "Clang" OR CMAKE_HIP_COMPILER_ID STREQUAL "ROCMClang")
     message(STATUS "Using ${CMAKE_HIP_COMPILER} to build for amdgpu backend")
 else()


### PR DESCRIPTION
## Motivation

When rocprofiler-compute is enabled there is a problem that on repetitive `ninja` invocation there is a failure caused by cmake configuration re-trigger even though no files were changed anyhow

## Technical Details

The FORCE flag on `CMAKE_HIP_COMPILER` overwrote the toolchain-provided value with a bare `amdclang++`, causing CMake to detect a compiler change and delete the cache on the next ninja invocation. Guard the `set()` with `if(NOT CMAKE_HIP_COMPILER)` and drop `FORCE` so the value inherited from the top level project for `CMAKE_HIP_COMPILER` is preserved.

## JIRA ID

N/A

## Test Plan

Reproducible on TheRock:

```
$ cmake .. -DTHEROCK_ENABLE_ALL=OFF -DTHEROCK_ENABLE_HIP_RUNTIME=ON -DTHEROCK_ENABLE_OCL_RUNTIME=ON -DTHEROCK_ENABLE_CORE_RUNTIME=ON -DTHEROCK_ENABLE_COMPOSABLE_KERNEL=ON -DTHEROCK_ENABLE_RAND=ON -DTHEROCK_ENABLE_ROCPROFV3=ON -DTHEROCK_AMDGPU_FAMILIES=gfx90a -G Ninja -DTHEROCK_DEV_PROJECTS="amd-llvm"
$ ninja  # <- OK
$ ninja  # <- fails
```

## Test Result

Before the change there was a build failure on the 2nd `ninja` invocation, after the change, 2nd `ninja` invocation finishes successfully instantly

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.