### PR TITLE
[hipFile] Use registered memory for fallback async IO objects and bounce buffer.

### DIFF
--- a/projects/hipfile/src/amd_detail/backend/asyncop-fallback.cpp
+++ b/projects/hipfile/src/amd_detail/backend/asyncop-fallback.cpp
@@ -9,6 +9,8 @@
 #include "buffer.h"
 #include "context.h"
 #include "hip.h"
+#include "hipfile.h"
+#include "stream.h"
 #include "sys.h"
 
 #include <memory>
@@ -28,14 +30,9 @@ enum class IoType;
 using namespace hipFile;
 
 static void
-hipHostDeleter(void *buffer)
+aligned_deleter(void *p)
 {
-    try {
-        Context<Hip>::get()->hipHostFree(buffer);
-    }
-    catch (...) {
-        Context<Sys>::get()->syslog(LOG_CRIT, "Error freeing pinned host memory.");
-    }
+    ::operator delete[](p, std::align_val_t{64});
 }
 
 AsyncOpFallback::AsyncOpFallback(IoType _io_type, std::shared_ptr<IFile> _file,
@@ -46,13 +43,14 @@ AsyncOpFallback::AsyncOpFallback(IoType _io_type, std::shared_ptr<IFile> _file,
               _size,    _file_offset,     _buffer_offset,     _bytes_transferred},
       submitted_size{std::min(*_size, hipFile::getMaxRwCount())}, bytes_transferred_internal{0},
       gpu_buffer{buffer->getBuffer()}, bounce_buffer_dev_ptr{nullptr},
-      bounce_buffer{nullptr, [](void *addr) { (void)addr; }}
+      bounce_buffer{new(std::align_val_t{64}) uint8_t[submitted_size], aligned_deleter}
 {
-    void *host_ptr = Context<Hip>::get()->hipHostMalloc(submitted_size, 0);
-    std::unique_ptr<void, decltype(&hipHostDeleter)> _bounce_buffer{host_ptr, hipHostDeleter};
-    std::swap(bounce_buffer, _bounce_buffer);
-    void *dev_ptr         = Context<Hip>::get()->hipHostGetDevicePointer(bounce_buffer.get(), 0);
-    bounce_buffer_dev_ptr = dev_ptr;
+    ScopedHipSetDevice    hsd{stream->getHipDevice()};
+    ScopedHipHostRegister bounce_reg{bounce_buffer.get(), submitted_size, hipHostRegisterDefault};
+    ScopedHipHostRegister this_reg{this, sizeof(AsyncOpFallback), hipHostRegisterDefault};
+    bounce_buffer_dev_ptr = Context<Hip>::get()->hipHostGetDevicePointer(bounce_buffer.get(), 0);
+    bounce_reg.release();
+    this_reg.release();
 }
 
 void *
@@ -64,31 +62,23 @@ AsyncOpFallback::bounceBufferHostPtr()
 void *
 AsyncOpFallback::devPtr()
 {
+    ScopedHipSetDevice hsd{stream->getHipDevice()};
     return Context<Hip>::get()->hipHostGetDevicePointer(this, 0);
 }
 
 AsyncOpFallback::~AsyncOpFallback()
 {
-}
-
-void *
-AsyncOpFallback::operator new(size_t size_)
-{
     try {
-        return Context<Hip>::get()->hipHostMalloc(size_, 0);
+        Context<Hip>::get()->hipHostUnregister(bounce_buffer.get());
     }
-    catch (...) {
-        throw std::bad_alloc{};
+    catch (Hip::RuntimeError &e) {
+        Context<Sys>::get()->syslog(LOG_CRIT, "Error unregistering bounce buffer.");
     }
-}
 
-void
-AsyncOpFallback::operator delete(void *ptr) noexcept
-{
     try {
-        Context<Hip>::get()->hipHostFree(ptr);
+        Context<Hip>::get()->hipHostUnregister(this);
     }
-    catch (...) {
-        Context<Sys>::get()->syslog(LOG_CRIT, "Freeing AsyncOpFallback failed.");
+    catch (Hip::RuntimeError &e) {
+        Context<Sys>::get()->syslog(LOG_CRIT, "Error unregistering AsyncOpFallback pointer.");
     }
 }

--- a/projects/hipfile/src/amd_detail/backend/asyncop-fallback.h
+++ b/projects/hipfile/src/amd_detail/backend/asyncop-fallback.h
@@ -25,14 +25,14 @@ enum class IoType;
 
 namespace hipFile {
 
-struct AsyncOpFallback : AsyncOp {
+struct alignas(64) AsyncOpFallback : AsyncOp {
     size_t      submitted_size;
     ssize_t     bytes_transferred_internal;
     void *const gpu_buffer;
     void       *bounce_buffer_dev_ptr;
 
 private:
-    std::unique_ptr<void, void (*)(void *)> bounce_buffer;
+    std::unique_ptr<uint8_t[], void (*)(void *)> bounce_buffer;
 
 public:
     AsyncOpFallback(IoType ioType, std::shared_ptr<IFile> file, std::shared_ptr<IBuffer> buffer,
@@ -43,8 +43,6 @@ public:
     void *devPtr();
 
     virtual ~AsyncOpFallback() override;
-    void  operator delete(void *ptr) noexcept;
-    void *operator new(size_t size);
 };
 
 }

--- a/projects/hipfile/src/amd_detail/hip.cpp
+++ b/projects/hipfile/src/amd_detail/hip.cpp
@@ -6,8 +6,10 @@
 #include "context.h"
 #include "hip.h"
 #include "static.h"
+#include "sys.h"
 
 #include <cstdlib>
+#include <syslog.h>
 #include <system_error>
 
 namespace hipFile {
@@ -233,4 +235,18 @@ Hip::hipHostUnregister(void *hostPtr) const
     (void)throwOnHipError<Hip::RuntimeError>(::hipHostUnregister(hostPtr));
 }
 
+ScopedHipSetDevice::ScopedHipSetDevice(int device) : original_device{Context<Hip>::get()->hipGetDevice()}
+{
+    Context<Hip>::get()->hipSetDevice(device);
+}
+
+ScopedHipSetDevice::~ScopedHipSetDevice()
+{
+    try {
+        Context<Hip>::get()->hipSetDevice(original_device);
+    }
+    catch (Hip::RuntimeError &e) {
+        Context<Sys>::get()->syslog(LOG_CRIT, "Error setting HIP device back to original.");
+    }
+}
 }

--- a/projects/hipfile/src/amd_detail/hip.cpp
+++ b/projects/hipfile/src/amd_detail/hip.cpp
@@ -214,4 +214,23 @@ Hip::hipGetDeviceCount() const
     (void)throwOnHipError<Hip::RuntimeError>(::hipGetDeviceCount(&device_count));
     return device_count;
 }
+
+void
+Hip::hipSetDevice(int device) const
+{
+    (void)throwOnHipError<Hip::RuntimeError>(::hipSetDevice(device));
+}
+
+void
+Hip::hipHostRegister(void *hostPtr, size_t sizeBytes, unsigned int flags) const
+{
+    (void)throwOnHipError<Hip::RuntimeError>(::hipHostRegister(hostPtr, sizeBytes, flags));
+}
+
+void
+Hip::hipHostUnregister(void *hostPtr) const
+{
+    (void)throwOnHipError<Hip::RuntimeError>(::hipHostUnregister(hostPtr));
+}
+
 }

--- a/projects/hipfile/src/amd_detail/hip.cpp
+++ b/projects/hipfile/src/amd_detail/hip.cpp
@@ -249,4 +249,28 @@ ScopedHipSetDevice::~ScopedHipSetDevice()
         Context<Sys>::get()->syslog(LOG_CRIT, "Error setting HIP device back to original.");
     }
 }
+
+ScopedHipHostRegister::ScopedHipHostRegister(void *_ptr, size_t size, unsigned int flags) : ptr{_ptr}
+{
+    Context<Hip>::get()->hipHostRegister(ptr, size, flags);
+}
+
+ScopedHipHostRegister::~ScopedHipHostRegister()
+{
+    if (ptr != nullptr) {
+        try {
+            Context<Hip>::get()->hipHostUnregister(ptr);
+        }
+        catch (Hip::RuntimeError &e) {
+            Context<Sys>::get()->syslog(LOG_CRIT, "Error unregistering host memory.");
+        }
+    }
+}
+
+void
+ScopedHipHostRegister::release()
+{
+    ptr = nullptr;
+}
+
 }

--- a/projects/hipfile/src/amd_detail/hip.h
+++ b/projects/hipfile/src/amd_detail/hip.h
@@ -96,4 +96,21 @@ struct Hip {
     };
 };
 
+class ScopedHipSetDevice {
+public:
+    ScopedHipSetDevice(int device_id);
+    ~ScopedHipSetDevice();
+
+    // Don't allow copying
+    ScopedHipSetDevice(const ScopedHipSetDevice &)            = delete;
+    ScopedHipSetDevice &operator=(const ScopedHipSetDevice &) = delete;
+
+    // Don't allow moving
+    ScopedHipSetDevice(ScopedHipSetDevice &&)            = delete;
+    ScopedHipSetDevice &operator=(ScopedHipSetDevice &&) = delete;
+
+private:
+    int original_device;
+};
+
 }

--- a/projects/hipfile/src/amd_detail/hip.h
+++ b/projects/hipfile/src/amd_detail/hip.h
@@ -77,6 +77,9 @@ struct Hip {
     virtual void        hipInit() const;
     virtual int         hipGetDevice() const;
     virtual int         hipGetDeviceCount() const;
+    virtual void        hipSetDevice(int device) const;
+    virtual void        hipHostRegister(void *hostPtr, size_t sizeBytes, unsigned int flags) const;
+    virtual void        hipHostUnregister(void *hostPtr) const;
 
     struct RuntimeError : public std::runtime_error {
         hipError_t error;

--- a/projects/hipfile/src/amd_detail/hip.h
+++ b/projects/hipfile/src/amd_detail/hip.h
@@ -113,4 +113,22 @@ private:
     int original_device;
 };
 
+class ScopedHipHostRegister {
+public:
+    ScopedHipHostRegister(void *ptr, size_t size, unsigned int flags);
+    ~ScopedHipHostRegister();
+    void release();
+
+    // Don't allow copying
+    ScopedHipHostRegister(const ScopedHipHostRegister &)            = delete;
+    ScopedHipHostRegister &operator=(const ScopedHipHostRegister &) = delete;
+
+    // Don't allow moving
+    ScopedHipHostRegister(ScopedHipHostRegister &&)            = delete;
+    ScopedHipHostRegister &operator=(ScopedHipHostRegister &&) = delete;
+
+private:
+    void *ptr;
+};
+
 }

--- a/projects/hipfile/test/amd_detail/async.cpp
+++ b/projects/hipfile/test/amd_detail/async.cpp
@@ -139,140 +139,144 @@ TEST_P(HipFileAsyncOpStreamParams, asyncOp_construction_has_correct_variants)
 }
 INSTANTIATE_TEST_SUITE_P(StreamSuite, HipFileAsyncOpStreamParams, hipfileFlagsPowerSet());
 
-TEST_F(HipFileAsyncOp, AsyncOpFallback_new_uses_pinned_host_memory)
-{
-    size_t  size              = 100;
-    hoff_t  file_offset       = 0;
-    hoff_t  buffer_offset     = 0;
-    ssize_t bytes_transferred = 0;
-    auto    op_data           = std::shared_ptr<void>(new uint8_t[sizeof(AsyncOpFallback)]);
-    auto    bounce_buffer     = std::shared_ptr<void>(new uint8_t[size]);
-    EXPECT_CALL(mhip, hipHostMalloc).WillOnce(Return(op_data.get())).WillOnce(Return(bounce_buffer.get()));
-    EXPECT_CALL(mhip, hipHostGetDevicePointer(Eq(bounce_buffer.get()), _));
-    EXPECT_CALL(mhip, hipHostFree(Eq(bounce_buffer.get())));
-    EXPECT_CALL(mhip, hipHostFree(Eq(op_data.get())));
-    auto op = std::shared_ptr<AsyncOpFallback>(new AsyncOpFallback{
-        IoType::Read, file, buffer, stream, &size, &file_offset, &buffer_offset, &bytes_transferred});
-}
-
 TEST_F(HipFileAsyncOp, AsyncOpFallbackLimitsMaxIoSize)
 {
     size_t  size              = 4_GiB;
     hoff_t  file_offset       = 0;
     hoff_t  buffer_offset     = 0;
     ssize_t bytes_transferred = 0;
-    auto    op_data           = std::shared_ptr<void>(new uint8_t[sizeof(AsyncOpFallback)]);
-    auto    bounce_buffer     = std::shared_ptr<void>(new uint8_t[1_KiB]);
-    EXPECT_CALL(mhip, hipHostMalloc(hipFile::getMaxRwCount(), _)).WillOnce(Return(bounce_buffer.get()));
-    EXPECT_CALL(mhip, hipHostMalloc(sizeof(AsyncOpFallback), _)).WillOnce(Return(op_data.get()));
-    EXPECT_CALL(mhip, hipHostGetDevicePointer(Eq(bounce_buffer.get()), _));
-    EXPECT_CALL(mhip, hipHostFree(Eq(bounce_buffer.get())));
-    EXPECT_CALL(mhip, hipHostFree(Eq(op_data.get())));
+    EXPECT_CALL(*stream, getHipDevice).WillOnce(Return(0));
+    EXPECT_CALL(mhip, hipGetDevice).WillOnce(Return(0));
+    EXPECT_CALL(mhip, hipSetDevice(0)).Times(2);
+    EXPECT_CALL(mhip, hipHostRegister(_, hipFile::getMaxRwCount(), _));
+    EXPECT_CALL(mhip, hipHostRegister(_, sizeof(AsyncOpFallback), _));
+    EXPECT_CALL(mhip, hipHostGetDevicePointer(_, _));
+    EXPECT_CALL(mhip, hipHostUnregister(_)).Times(2);
     auto op = std::shared_ptr<AsyncOpFallback>(new AsyncOpFallback{
         IoType::Read, file, buffer, stream, &size, &file_offset, &buffer_offset, &bytes_transferred});
     ASSERT_EQ(op->submitted_size, hipFile::getMaxRwCount());
 }
 
-TEST_F(HipFileAsyncOp, AsyncOpFallback_new_failure_throws_bad_alloc)
+TEST_F(HipFileAsyncOp, AsyncOpFallbackConstructorThrowsIfHipSetDeviceThrows)
 {
     size_t  size              = 100;
     hoff_t  file_offset       = 0;
     hoff_t  buffer_offset     = 0;
     ssize_t bytes_transferred = 0;
-    auto    op_data           = std::shared_ptr<void>(new uint8_t[sizeof(AsyncOpFallback)]);
-    EXPECT_CALL(mhip, hipHostMalloc).WillOnce(Throw(Hip::RuntimeError(hipErrorOutOfMemory)));
-    EXPECT_THROW(std::shared_ptr<AsyncOpFallback>(new AsyncOpFallback{IoType::Read, file, buffer, stream,
-                                                                      &size, &file_offset, &buffer_offset,
-                                                                      &bytes_transferred}),
-                 std::bad_alloc);
-}
-
-TEST_F(HipFileAsyncOp, AsyncOpFallback_bounce_alloc_failure_throws)
-{
-    size_t  size              = 100;
-    hoff_t  file_offset       = 0;
-    hoff_t  buffer_offset     = 0;
-    ssize_t bytes_transferred = 0;
-    auto    op_data           = std::shared_ptr<void>(new uint8_t[sizeof(AsyncOpFallback)]);
-    EXPECT_CALL(mhip, hipHostMalloc)
-        .WillOnce(Return(op_data.get()))
-        .WillOnce(Throw(Hip::RuntimeError(hipErrorOutOfMemory)));
-    EXPECT_CALL(mhip, hipHostFree(Eq(op_data.get())));
+    EXPECT_CALL(*stream, getHipDevice).WillOnce(Return(0));
+    EXPECT_CALL(mhip, hipGetDevice).WillOnce(Throw(Hip::RuntimeError(hipErrorInvalidDevice)));
     EXPECT_THROW(std::shared_ptr<AsyncOpFallback>(new AsyncOpFallback{IoType::Read, file, buffer, stream,
                                                                       &size, &file_offset, &buffer_offset,
                                                                       &bytes_transferred}),
                  Hip::RuntimeError);
 }
 
-TEST_F(HipFileAsyncOp, AsyncOpFallback_bounce_buffer_deleter_failure_calls_syslog)
+TEST_F(HipFileAsyncOp, AsyncOpFallbackConstructorThrowsIfFirstHipHostRegisterThrows)
 {
     size_t  size              = 100;
     hoff_t  file_offset       = 0;
     hoff_t  buffer_offset     = 0;
     ssize_t bytes_transferred = 0;
-    auto    op_data           = std::shared_ptr<void>(new uint8_t[sizeof(AsyncOpFallback)]);
-    auto    bounce_buffer     = std::shared_ptr<void>(new uint8_t[size]);
-    EXPECT_CALL(mhip, hipHostMalloc).WillOnce(Return(op_data.get())).WillOnce(Return(bounce_buffer.get()));
-    EXPECT_CALL(mhip, hipHostGetDevicePointer(Eq(bounce_buffer.get()), _));
-    EXPECT_CALL(mhip, hipHostFree(Eq(bounce_buffer.get())))
-        .WillOnce(Throw(Hip::RuntimeError(hipErrorInvalidValue)));
-    EXPECT_CALL(mhip, hipHostFree(Eq(op_data.get())));
-    EXPECT_CALL(msys, syslog);
-    auto op = std::shared_ptr<AsyncOpFallback>(new AsyncOpFallback{
-        IoType::Read, file, buffer, stream, &size, &file_offset, &buffer_offset, &bytes_transferred});
+    EXPECT_CALL(*stream, getHipDevice).WillOnce(Return(0));
+    EXPECT_CALL(mhip, hipGetDevice).WillOnce(Return(0));
+    EXPECT_CALL(mhip, hipSetDevice(0)).Times(2);
+    EXPECT_CALL(mhip, hipHostRegister(_, _, _)).WillOnce(Throw(Hip::RuntimeError(hipErrorInvalidValue)));
+    EXPECT_THROW(std::shared_ptr<AsyncOpFallback>(new AsyncOpFallback{IoType::Read, file, buffer, stream,
+                                                                      &size, &file_offset, &buffer_offset,
+                                                                      &bytes_transferred}),
+                 Hip::RuntimeError);
 }
 
-TEST_F(HipFileAsyncOp, AsyncOpFallback_delete_failure_calls_syslog)
+TEST_F(HipFileAsyncOp, AsyncOpFallbackConstructorThrowsAndUnregistersIfSecondHipHostRegisterThrows)
 {
     size_t  size              = 100;
     hoff_t  file_offset       = 0;
     hoff_t  buffer_offset     = 0;
     ssize_t bytes_transferred = 0;
-    auto    op_data           = std::shared_ptr<void>(new uint8_t[sizeof(AsyncOpFallback)]);
-    auto    bounce_buffer     = std::shared_ptr<void>(new uint8_t[size]);
-    EXPECT_CALL(mhip, hipHostMalloc).WillOnce(Return(op_data.get())).WillOnce(Return(bounce_buffer.get()));
-    EXPECT_CALL(mhip, hipHostGetDevicePointer(Eq(bounce_buffer.get()), _));
-    EXPECT_CALL(mhip, hipHostFree(Eq(bounce_buffer.get())));
-    EXPECT_CALL(mhip, hipHostFree(Eq(op_data.get())))
+    EXPECT_CALL(*stream, getHipDevice).WillOnce(Return(0));
+    EXPECT_CALL(mhip, hipGetDevice).WillOnce(Return(0));
+    EXPECT_CALL(mhip, hipSetDevice(0)).Times(2);
+    EXPECT_CALL(mhip, hipHostRegister(_, _, _))
+        .WillOnce(Return())
         .WillOnce(Throw(Hip::RuntimeError(hipErrorInvalidValue)));
-    EXPECT_CALL(msys, syslog);
-    auto op = std::shared_ptr<AsyncOpFallback>(new AsyncOpFallback{
-        IoType::Read, file, buffer, stream, &size, &file_offset, &buffer_offset, &bytes_transferred});
+    EXPECT_CALL(mhip, hipHostUnregister(_));
+    EXPECT_THROW(std::shared_ptr<AsyncOpFallback>(new AsyncOpFallback{IoType::Read, file, buffer, stream,
+                                                                      &size, &file_offset, &buffer_offset,
+                                                                      &bytes_transferred}),
+                 Hip::RuntimeError);
+}
+
+TEST_F(HipFileAsyncOp, AsyncOpFallbackConstructorThrowsAndUnregistersIfHipHostGetDevicePointerThrows)
+{
+    size_t  size              = 100;
+    hoff_t  file_offset       = 0;
+    hoff_t  buffer_offset     = 0;
+    ssize_t bytes_transferred = 0;
+    EXPECT_CALL(*stream, getHipDevice).WillOnce(Return(0));
+    EXPECT_CALL(mhip, hipGetDevice).WillOnce(Return(0));
+    EXPECT_CALL(mhip, hipSetDevice(0)).Times(2);
+    EXPECT_CALL(mhip, hipHostRegister(_, _, _)).Times(2);
+    EXPECT_CALL(mhip, hipHostUnregister(_)).Times(2);
+    EXPECT_CALL(mhip, hipHostGetDevicePointer(_, _)).WillOnce(Throw(Hip::RuntimeError(hipErrorInvalidValue)));
+    EXPECT_THROW(std::shared_ptr<AsyncOpFallback>(new AsyncOpFallback{IoType::Read, file, buffer, stream,
+                                                                      &size, &file_offset, &buffer_offset,
+                                                                      &bytes_transferred}),
+                 Hip::RuntimeError);
 }
 
 struct HipFileAsyncOpFallbackMethods : public HipFileAsyncOp {
-    HipFileAsyncOpFallbackMethods() : bounce_buffer{new uint8_t[size]}
+    HipFileAsyncOpFallbackMethods()
     {
-        //  make_shared uses placement new, which will not use hipHostMalloc/hipHostFree for
-        //  AsyncOpFallback
-        EXPECT_CALL(mhip, hipHostMalloc).WillOnce(Return(bounce_buffer.get()));
-        EXPECT_CALL(mhip, hipHostGetDevicePointer).WillOnce(Return(bounce_buffer_dev_ptr));
+        EXPECT_CALL(*stream, getHipDevice).WillOnce(Return(0));
+        EXPECT_CALL(mhip, hipGetDevice).WillOnce(Return(0));
+        EXPECT_CALL(mhip, hipSetDevice(0)).Times(2);
+        EXPECT_CALL(mhip, hipHostRegister(_, _, _)).Times(2);
+        EXPECT_CALL(mhip, hipHostGetDevicePointer(_, _)).WillOnce(Return(bounce_buffer_dev_ptr));
         op = std::make_shared<AsyncOpFallback>(IoType::Read, file, buffer, stream, &size, &file_offset,
                                                &buffer_offset, &bytes_transferred);
     }
     ~HipFileAsyncOpFallbackMethods() override
     {
-        EXPECT_CALL(mhip, hipHostFree(Eq(bounce_buffer.get())));
+        EXPECT_CALL(mhip, hipHostUnregister(_)).Times(2);
     }
     void                            *bounce_buffer_dev_ptr = reinterpret_cast<void *>(0xDECDECDE);
     size_t                           size                  = 100;
     hoff_t                           file_offset           = 0;
     hoff_t                           buffer_offset         = 0;
     ssize_t                          bytes_transferred     = 0;
-    std::shared_ptr<void>            bounce_buffer;
     std::shared_ptr<AsyncOpFallback> op;
 };
 
-TEST_F(HipFileAsyncOpFallbackMethods, bounceBufferHostPtr_returns_pointer)
+TEST_F(HipFileAsyncOpFallbackMethods, bounceBufferHostPtrReturnsPointer)
 {
-    ASSERT_EQ(op->bounceBufferHostPtr(), bounce_buffer.get());
+    ASSERT_NE(op->bounceBufferHostPtr(), nullptr);
 }
 
-TEST_F(HipFileAsyncOpFallbackMethods, devPtr_calls_hipHostGetDevicePointer)
+TEST_F(HipFileAsyncOpFallbackMethods, devPtrCallsHipHostGetDevicePointer)
 {
     void *addr = reinterpret_cast<void *>(0xABACADBA);
-    EXPECT_CALL(mhip, hipHostGetDevicePointer).WillOnce(Return(addr));
+    EXPECT_CALL(*stream, getHipDevice).WillOnce(Return(0));
+    EXPECT_CALL(mhip, hipGetDevice).WillOnce(Return(0));
+    EXPECT_CALL(mhip, hipSetDevice(0)).Times(2);
+    EXPECT_CALL(mhip, hipHostGetDevicePointer(Eq(static_cast<void *>(op.get())), _)).WillOnce(Return(addr));
     ASSERT_EQ(op->devPtr(), addr);
+}
+
+TEST_F(HipFileAsyncOpFallbackMethods, devPtrThrowsIfHipSetDeviceThrows)
+{
+    EXPECT_CALL(*stream, getHipDevice).WillOnce(Return(0));
+    EXPECT_CALL(mhip, hipGetDevice).WillOnce(Throw(Hip::RuntimeError(hipErrorInvalidDevice)));
+    EXPECT_THROW(op->devPtr(), Hip::RuntimeError);
+}
+
+TEST_F(HipFileAsyncOpFallbackMethods, devPtrThrowsIfHipHostGetDevicePointerThrows)
+{
+    EXPECT_CALL(*stream, getHipDevice).WillOnce(Return(0));
+    EXPECT_CALL(mhip, hipGetDevice).WillOnce(Return(0));
+    EXPECT_CALL(mhip, hipSetDevice(0)).Times(2);
+    EXPECT_CALL(mhip, hipHostGetDevicePointer(Eq(static_cast<void *>(op.get())), _))
+        .WillOnce(Throw(Hip::RuntimeError(hipErrorInvalidValue)));
+    EXPECT_THROW(op->devPtr(), Hip::RuntimeError);
 }
 
 struct HipFileAsyncMonitor : HipFileAsyncOp {
@@ -478,31 +482,22 @@ TEST_P(FallbackAsyncIO, mismatchingGpuIdsThrows)
 
 TEST_P(FallbackAsyncIO, attemptToQueueCleanupOnStreamSubmissionFailure)
 {
-    /* This test will log some errors about async operations being outstanding and being unable to free
-     * memory. The outstanding operations occur because async_io_cleanup is not run. Some memory is unable to
-     * be freed, due to being alloced with malloc, and attempted to be freed with hipHostFree.  This happens
-     * because we mock the allocation of the pinned memory, but the mocks are destructed before the
-     * AsyncOpFallback destructor runs, so we can't mock the deallocation of the pinned memory.
-     */
     EXPECT_CALL(*mbuffer, getLength).WillOnce(Return(1024 * 1024));
     EXPECT_CALL(*mbuffer, getGpuId).Times(AnyNumber()).WillRepeatedly(Return(0));
     EXPECT_CALL(*mbuffer, getBuffer).WillOnce(Return(reinterpret_cast<hipStream_t>(0xBADBADBB)));
-    EXPECT_CALL(*mstream, getHipDevice).WillOnce(Return(0));
+    EXPECT_CALL(*mstream, getHipDevice).Times(AnyNumber()).WillRepeatedly(Return(0));
     EXPECT_CALL(*mstream, fixedIOSize).Times(AnyNumber()).WillRepeatedly(Return(false));
     EXPECT_CALL(*mstream, fixedFileOffset).Times(AnyNumber()).WillRepeatedly(Return(false));
     EXPECT_CALL(*mstream, fixedBufferOffset).Times(AnyNumber()).WillRepeatedly(Return(false));
 
-    auto op_data = malloc(sizeof(AsyncOpFallback));
-    ASSERT_NE(op_data, nullptr);
-    auto bounce_buffer = malloc(size);
-    ASSERT_NE(bounce_buffer, nullptr);
-    EXPECT_CALL(mhip, hipHostMalloc).WillOnce(Return(op_data)).WillOnce(Return(bounce_buffer));
-    EXPECT_CALL(mhip, hipHostGetDevicePointer(Eq(bounce_buffer), _))
-        .WillOnce(Return(reinterpret_cast<void *>(0xDEBBBBBB)));
-    EXPECT_CALL(mhip, hipHostGetDevicePointer(Eq(op_data), _))
+    EXPECT_CALL(mhip, hipGetDevice).Times(2).WillRepeatedly(Return(0));
+    EXPECT_CALL(mhip, hipSetDevice(0)).Times(4);
+    EXPECT_CALL(mhip, hipHostRegister(_, _, _)).Times(2);
+    EXPECT_CALL(mhip, hipHostGetDevicePointer(_, _))
+        .Times(2)
+        .WillOnce(Return(reinterpret_cast<void *>(0xDEBBBBBB)))
         .WillOnce(Return(reinterpret_cast<void *>(0xDE000000)));
-    // EXPECT_CALL(mhip, hipHostFree(Eq(bounce_buffer.get())));
-    // EXPECT_CALL(mhip, hipHostFree(Eq(op_data.get())));
+    EXPECT_CALL(mhip, hipHostUnregister(_)).Times(AnyNumber());
     EXPECT_CALL(mhip, hipDeviceGetAttribute).WillOnce(Return(1024));
     EXPECT_CALL(*mstream, getLock);
     EXPECT_CALL(*mstream, getHipStream).Times(AnyNumber());
@@ -526,14 +521,12 @@ struct AsyncIoOp : public ::testing::Test {
     }
     void SetUp() override
     {
-        op_data       = std::shared_ptr<void>(new uint8_t[sizeof(AsyncOpFallback)]);
-        bounce_buffer = std::shared_ptr<void>(new uint8_t[size]);
-        EXPECT_CALL(mhip, hipHostMalloc)
-            .WillOnce(Return(op_data.get()))
-            .WillOnce(Return(bounce_buffer.get()));
-        EXPECT_CALL(mhip, hipHostGetDevicePointer(Eq(bounce_buffer.get()), _));
-        EXPECT_CALL(mhip, hipHostFree(Eq(bounce_buffer.get())));
-        EXPECT_CALL(mhip, hipHostFree(Eq(op_data.get())));
+        EXPECT_CALL(*mstream, getHipDevice).WillOnce(Return(0));
+        EXPECT_CALL(mhip, hipGetDevice).WillOnce(Return(0));
+        EXPECT_CALL(mhip, hipSetDevice(0)).Times(2);
+        EXPECT_CALL(mhip, hipHostRegister(_, _, _)).Times(2);
+        EXPECT_CALL(mhip, hipHostGetDevicePointer(_, _));
+        EXPECT_CALL(mhip, hipHostUnregister(_)).Times(2);
         EXPECT_CALL(*mstream, fixedBufferOffset)
             .Times(AnyNumber())
             .WillRepeatedly(Return(fixed_buffer_offset));
@@ -558,8 +551,6 @@ struct AsyncIoOp : public ::testing::Test {
     bool                                 fixed_buffer_offset = false;
     bool                                 fixed_file_offset   = false;
     bool                                 fixed_io_size       = false;
-    std::shared_ptr<void>                op_data;
-    std::shared_ptr<void>                bounce_buffer;
     std::shared_ptr<AsyncOpFallback>     op;
 };
 

--- a/projects/hipfile/test/amd_detail/mhip.h
+++ b/projects/hipfile/test/amd_detail/mhip.h
@@ -51,5 +51,9 @@ struct MHip : Hip {
     MOCK_METHOD(void, hipInit, (), (const, override));
     MOCK_METHOD(int, hipGetDevice, (), (const, override));
     MOCK_METHOD(int, hipGetDeviceCount, (), (const, override));
+    MOCK_METHOD(void, hipSetDevice, (int device), (const, override));
+    MOCK_METHOD(void, hipHostRegister, (void *hostPtr, size_t sizeBytes, unsigned int flags),
+                (const, override));
+    MOCK_METHOD(void, hipHostUnregister, (void *hostPtr), (const, override));
 };
 }

--- a/projects/hipfile/test/system/async.cpp
+++ b/projects/hipfile/test/system/async.cpp
@@ -57,142 +57,164 @@ static std::array<AsyncIoFunction, 2> asyncIOFns{
     {{hipFileReadAsync, "hipFileReadAsync"}, {hipFileWriteAsync, "hipFileWriteAsync"}}};
 HIPFILE_WARN_NO_EXIT_DTOR_ON
 
-static bool
-isGpuMemory(void *mem)
-{
-    hipPointerAttribute_t attrs;
-    hipError_t            err = hipPointerGetAttributes(&attrs, mem);
+struct HipStream {
+    HipStream()
+    {
+        assert(hipStreamCreateWithFlags(&stream_, hipStreamNonBlocking) == hipSuccess);
+    }
+    ~HipStream()
+    {
+        assert(hipStreamDestroy(stream_) == hipSuccess);
+    }
+    hipStream_t stream() const
+    {
+        return stream_;
+    }
+
+private:
+    hipStream_t stream_;
+};
+
+struct HipFileDataOps {
+    static bool isGpuMemory(void *mem)
+    {
+        hipPointerAttribute_t attrs;
+        hipError_t            err = hipPointerGetAttributes(&attrs, mem);
 
 #ifdef __HIP_PLATFORM_NVIDIA__
-    // NVIDIA doesn't support pointers allocated outside of runtime
-    if (err == hipErrorInvalidValue) {
-        return false;
-    }
+        // NVIDIA doesn't support pointers allocated outside of runtime
+        if (err == hipErrorInvalidValue) {
+            return false;
+        }
 #endif
-    assert(err == hipSuccess);
-    return attrs.type == hipMemoryTypeDevice;
-}
-
-static std::vector<uint8_t>
-copyGpuMemory(void *gpu_mem, hoff_t gpu_mem_offset, size_t region_size)
-{
-    std::vector<uint8_t> mem_region(region_size);
-    assert(hipMemcpy(mem_region.data(),
-                     reinterpret_cast<void *>(reinterpret_cast<uintptr_t>(gpu_mem) +
-                                              static_cast<size_t>(gpu_mem_offset)),
-                     region_size, hipMemcpyDeviceToHost) == hipSuccess);
-    assert(hipStreamSynchronize(nullptr) == hipSuccess);
-    return mem_region;
-}
-
-static void
-assertMemoryRegionsMatch(void *mem1, hoff_t mem1_offset, void *mem2, hoff_t mem2_offset, size_t region_size)
-{
-    std::vector<uint8_t> mem1_v;
-    std::vector<uint8_t> mem2_v;
-    if (isGpuMemory(mem1)) {
-        mem1_v = copyGpuMemory(mem1, mem1_offset, region_size);
-        mem1   = mem1_v.data();
+        assert(err == hipSuccess);
+        return attrs.type == hipMemoryTypeDevice;
     }
-    if (isGpuMemory(mem2)) {
-        mem2_v = copyGpuMemory(mem2, mem2_offset, region_size);
-        mem2   = mem2_v.data();
+
+    static std::vector<uint8_t> copyGpuMemory(void *gpu_mem, hoff_t gpu_mem_offset, size_t region_size)
+    {
+        std::vector<uint8_t> mem_region(region_size);
+        assert(hipMemcpyAsync(mem_region.data(),
+                              reinterpret_cast<void *>(reinterpret_cast<uintptr_t>(gpu_mem) +
+                                                       static_cast<size_t>(gpu_mem_offset)),
+                              region_size, hipMemcpyDeviceToHost, staticHipStream()) == hipSuccess);
+        assert(hipStreamSynchronize(staticHipStream()) == hipSuccess);
+        return mem_region;
     }
-    assert(std::memcmp(mem1, mem2, region_size) == 0);
-}
 
-static void
-assertFileAndMemoryRegionsMatch(void *mem, hoff_t mem_offset, int fd, hoff_t fd_offset, size_t region_size)
-{
-    assert(fd_offset >= 0);
-    auto file_region = std::vector<uint8_t>(region_size);
-
-    ssize_t rv = pread(fd, file_region.data(), region_size, fd_offset);
-    assert(rv > 0 && static_cast<size_t>(rv) == region_size);
-
-    assertMemoryRegionsMatch(file_region.data(), 0, mem, mem_offset, region_size);
-}
-
-static void
-assertZeroedMemRegion(void *mem, hoff_t mem_offset, size_t region_size)
-{
-    std::vector<uint8_t> mem_v;
-    if (isGpuMemory(mem)) {
-        mem_v = copyGpuMemory(mem, mem_offset, region_size);
-        mem   = mem_v.data();
+    static void assertMemoryRegionsMatch(void *mem1, hoff_t mem1_offset, void *mem2, hoff_t mem2_offset,
+                                         size_t region_size)
+    {
+        std::vector<uint8_t> mem1_v;
+        std::vector<uint8_t> mem2_v;
+        if (isGpuMemory(mem1)) {
+            mem1_v = copyGpuMemory(mem1, mem1_offset, region_size);
+            mem1   = mem1_v.data();
+        }
+        if (isGpuMemory(mem2)) {
+            mem2_v = copyGpuMemory(mem2, mem2_offset, region_size);
+            mem2   = mem2_v.data();
+        }
+        assert(std::memcmp(mem1, mem2, region_size) == 0);
     }
-    for (size_t i = 0; i < region_size; ++i) {
-        assert(reinterpret_cast<uint8_t *>(mem)[i] == 0);
-    }
-}
 
-static void
-assertZeroedFileRegion(int fd, hoff_t fd_offset, size_t region_size)
-{
-    assert(fd_offset >= 0);
-    auto    file_region = std::vector<uint8_t>(region_size);
-    ssize_t rv          = pread(fd, file_region.data(), region_size, fd_offset);
-    assert(rv > 0 && static_cast<size_t>(rv) == region_size);
-    for (size_t i = 0; i < region_size; ++i) {
-        assert(file_region.data()[i] == 0);
-    }
-}
+    static void assertFileAndMemoryRegionsMatch(void *mem, hoff_t mem_offset, int fd, hoff_t fd_offset,
+                                                size_t region_size)
+    {
+        assert(fd_offset >= 0);
+        auto file_region = std::vector<uint8_t>(region_size);
 
-static void
-randomizeMemoryRegion(void *mem, hoff_t offset, size_t region_size)
-{
-    ssize_t rv;
-    int     rand_fd = open("/dev/urandom", O_RDONLY);
-    assert(rand_fd != -1);
-    if (isGpuMemory(mem)) {
-        std::vector<uint8_t> mem_v(region_size);
-        rv = read(rand_fd, mem_v.data(), region_size);
+        ssize_t rv = pread(fd, file_region.data(), region_size, fd_offset);
         assert(rv > 0 && static_cast<size_t>(rv) == region_size);
-        assert(hipMemcpy(
-                   reinterpret_cast<void *>(reinterpret_cast<uintptr_t>(mem) + static_cast<size_t>(offset)),
-                   mem_v.data(), region_size, hipMemcpyHostToDevice) == hipSuccess);
-        assert(hipStreamSynchronize(nullptr) == hipSuccess);
+
+        assertMemoryRegionsMatch(file_region.data(), 0, mem, mem_offset, region_size);
     }
-    else {
-        rv = read(rand_fd,
-                  reinterpret_cast<void *>(reinterpret_cast<uintptr_t>(mem) + static_cast<size_t>(offset)),
-                  region_size);
+
+    static void assertZeroedMemRegion(void *mem, hoff_t mem_offset, size_t region_size)
+    {
+        std::vector<uint8_t> mem_v;
+        if (isGpuMemory(mem)) {
+            mem_v = copyGpuMemory(mem, mem_offset, region_size);
+            mem   = mem_v.data();
+        }
+        for (size_t i = 0; i < region_size; ++i) {
+            assert(reinterpret_cast<uint8_t *>(mem)[i] == 0);
+        }
+    }
+
+    static void assertZeroedFileRegion(int fd, hoff_t fd_offset, size_t region_size)
+    {
+        assert(fd_offset >= 0);
+        auto    file_region = std::vector<uint8_t>(region_size);
+        ssize_t rv          = pread(fd, file_region.data(), region_size, fd_offset);
         assert(rv > 0 && static_cast<size_t>(rv) == region_size);
+        for (size_t i = 0; i < region_size; ++i) {
+            assert(file_region.data()[i] == 0);
+        }
     }
-    assert(close(rand_fd) == 0);
-}
 
-static void
-zeroMemoryRegion(void *mem, hoff_t offset, size_t region_size)
-{
-    if (isGpuMemory(mem)) {
-        assert(hipMemset(
-                   reinterpret_cast<void *>(reinterpret_cast<uintptr_t>(mem) + static_cast<size_t>(offset)),
-                   0, region_size) == hipSuccess);
-        assert(hipStreamSynchronize(nullptr) == hipSuccess);
+    static void randomizeMemoryRegion(void *mem, hoff_t offset, size_t region_size)
+    {
+        ssize_t rv;
+        int     rand_fd = open("/dev/urandom", O_RDONLY);
+        assert(rand_fd != -1);
+        if (isGpuMemory(mem)) {
+            std::vector<uint8_t> mem_v(region_size);
+            rv = read(rand_fd, mem_v.data(), region_size);
+            assert(rv > 0 && static_cast<size_t>(rv) == region_size);
+            assert(
+                hipMemcpyAsync(
+                    reinterpret_cast<void *>(reinterpret_cast<uintptr_t>(mem) + static_cast<size_t>(offset)),
+                    mem_v.data(), region_size, hipMemcpyHostToDevice, staticHipStream()) == hipSuccess);
+            assert(hipStreamSynchronize(staticHipStream()) == hipSuccess);
+        }
+        else {
+            rv =
+                read(rand_fd,
+                     reinterpret_cast<void *>(reinterpret_cast<uintptr_t>(mem) + static_cast<size_t>(offset)),
+                     region_size);
+            assert(rv > 0 && static_cast<size_t>(rv) == region_size);
+        }
+        assert(close(rand_fd) == 0);
     }
-    else {
-        memset(reinterpret_cast<void *>(reinterpret_cast<uintptr_t>(mem) + static_cast<size_t>(offset)), 0,
-               region_size);
+
+    static void zeroMemoryRegion(void *mem, hoff_t offset, size_t region_size)
+    {
+        if (isGpuMemory(mem)) {
+            assert(hipMemsetAsync(reinterpret_cast<void *>(reinterpret_cast<uintptr_t>(mem) +
+                                                           static_cast<size_t>(offset)),
+                                  0, region_size, staticHipStream()) == hipSuccess);
+            assert(hipStreamSynchronize(staticHipStream()) == hipSuccess);
+        }
+        else {
+            memset(reinterpret_cast<void *>(reinterpret_cast<uintptr_t>(mem) + static_cast<size_t>(offset)),
+                   0, region_size);
+        }
     }
-}
 
-static void
-zeroFileRegion(int fd, size_t size, hoff_t offset = 0)
-{
-    auto    vec = std::vector<uint8_t>(size, 0);
-    ssize_t rv  = pwrite(fd, vec.data(), size, offset);
-    assert(rv > 0 && static_cast<size_t>(rv) == size);
-}
+    static void zeroFileRegion(int fd, size_t size, hoff_t offset = 0)
+    {
+        auto    vec = std::vector<uint8_t>(size, 0);
+        ssize_t rv  = pwrite(fd, vec.data(), size, offset);
+        assert(rv > 0 && static_cast<size_t>(rv) == size);
+    }
 
-static void
-randomizeFileRegion(int fd, size_t size, hoff_t offset = 0)
-{
-    auto vec = std::vector<uint8_t>(size, 0);
-    randomizeMemoryRegion(vec.data(), 0, size);
-    ssize_t rv = pwrite(fd, vec.data(), size, offset);
-    assert(rv > 0 && static_cast<size_t>(rv) == size);
-}
+    static void randomizeFileRegion(int fd, size_t size, hoff_t offset = 0)
+    {
+        auto vec = std::vector<uint8_t>(size, 0);
+        randomizeMemoryRegion(vec.data(), 0, size);
+        ssize_t rv = pwrite(fd, vec.data(), size, offset);
+        assert(rv > 0 && static_cast<size_t>(rv) == size);
+    }
+
+    static hipStream_t staticHipStream()
+    {
+        HIPFILE_WARN_NO_EXIT_DTOR_OFF
+        static HipStream s;
+        HIPFILE_WARN_NO_EXIT_DTOR_ON
+        return s.stream();
+    }
+};
 
 #ifdef __HIP_PLATFORM_AMD__
 class HipAsyncMemcpyKernel : public ::testing::Test {
@@ -221,7 +243,7 @@ public:
             // For a read, bytes_transferred_internal needs to be set to simulate that the read from disk
             // occurred. We fill the source (CPU bounce buffer) with random data and memset the destination
             // (GPU buffer) to zero.
-            randomizeMemoryRegion(op->bounceBufferHostPtr(), 0, io_size);
+            HipFileDataOps::randomizeMemoryRegion(op->bounceBufferHostPtr(), 0, io_size);
             op->bytes_transferred_internal = static_cast<ssize_t>(io_size);
             ASSERT_EQ(hipMemset(op->gpu_buffer, 0, buffer_size), hipSuccess);
             ASSERT_EQ(hipStreamSynchronize(nullptr), hipSuccess);
@@ -229,7 +251,7 @@ public:
         else {
             // For a write, we fill the source (GPU bounce buffer) with random data and memset the destination
             // (CPU bounce buffer) to zero.
-            randomizeMemoryRegion(op->gpu_buffer, 0, buffer_size);
+            HipFileDataOps::randomizeMemoryRegion(op->gpu_buffer, 0, buffer_size);
             memset(op->bounceBufferHostPtr(), 0, io_size);
         }
         op_dev_ptr            = op->devPtr();
@@ -339,14 +361,15 @@ TEST_P(HipAsyncMemcpyKernelWithParams, verifyIoRegions)
     ASSERT_EQ(op->bytes_transferred_internal, bytes_transferred_result);
     if (op->bytes_transferred_internal > 0) {
         if (io_type == IoType::Read) {
-            assertZeroedMemRegion(op->gpu_buffer, 0, static_cast<size_t>(buffer_offset));
+            HipFileDataOps::assertZeroedMemRegion(op->gpu_buffer, 0, static_cast<size_t>(buffer_offset));
         }
-        assertMemoryRegionsMatch(op->bounceBufferHostPtr(), 0, op->gpu_buffer, buffer_offset,
-                                 static_cast<size_t>(op->bytes_transferred_internal));
+        HipFileDataOps::assertMemoryRegionsMatch(op->bounceBufferHostPtr(), 0, op->gpu_buffer, buffer_offset,
+                                                 static_cast<size_t>(op->bytes_transferred_internal));
         if (io_type == IoType::Read) {
             size_t end_length = buffer_size - (static_cast<size_t>(buffer_offset) +
                                                static_cast<size_t>(op->bytes_transferred_internal));
-            assertZeroedMemRegion(op->gpu_buffer, buffer_offset + op->bytes_transferred_internal, end_length);
+            HipFileDataOps::assertZeroedMemRegion(op->gpu_buffer,
+                                                  buffer_offset + op->bytes_transferred_internal, end_length);
         }
     }
 }
@@ -394,7 +417,7 @@ public:
         ASSERT_EQ(hipFileDriverOpen(), HIPFILE_SUCCESS);
         ASSERT_EQ(hipMalloc(&dev_ptr, buffer_size), hipSuccess);
 
-        randomizeFileRegion(tf.fd, file_size);
+        HipFileDataOps::randomizeFileRegion(tf.fd, file_size);
 
         ASSERT_EQ(hipFileBufRegister(dev_ptr, buffer_size, 0), HIPFILE_SUCCESS);
         hipFileDescr_t d{hipFileHandleTypeOpaqueFD, {tf.fd}, nullptr};
@@ -421,7 +444,7 @@ public:
     void SetUp() override
     {
         HipAsync::SetUp();
-        zeroFileRegion(tf.fd, file_size);
+        HipFileDataOps::zeroFileRegion(tf.fd, file_size);
         ASSERT_EQ(hipStreamCreateWithFlags(&stream, hipStreamNonBlocking), hipSuccess);
         ASSERT_EQ(hipFileStreamRegister(stream, 0xf), HIPFILE_SUCCESS);
     }
@@ -441,7 +464,8 @@ TEST_F(HipAsyncStreamFixed, readRegionPastEndOfFile)
         hipFileReadAsync(fh, dev_ptr, &io_size, &file_offset, &buffer_offset, &bytes_transferred, stream),
         HIPFILE_SUCCESS);
     ASSERT_EQ(hipStreamSynchronize(stream), hipSuccess);
-    assertFileAndMemoryRegionsMatch(dev_ptr, buffer_offset, tf.fd, file_offset, file_size - 4_KiB);
+    HipFileDataOps::assertFileAndMemoryRegionsMatch(dev_ptr, buffer_offset, tf.fd, file_offset,
+                                                    file_size - 4_KiB);
     ASSERT_EQ(bytes_transferred, file_size - 4_KiB);
 }
 
@@ -578,12 +602,12 @@ public:
         io_op        = op_info.function;
         name         = op_info.name;
         if (name == "hipFileReadAsync") {
-            zeroMemoryRegion(dev_ptr, 0, buffer_size);
-            randomizeFileRegion(tf.fd, file_size);
+            HipFileDataOps::zeroMemoryRegion(dev_ptr, 0, buffer_size);
+            HipFileDataOps::randomizeFileRegion(tf.fd, file_size);
         }
         else {
-            zeroFileRegion(tf.fd, file_size);
-            randomizeMemoryRegion(dev_ptr, 0, buffer_size);
+            HipFileDataOps::zeroFileRegion(tf.fd, file_size);
+            HipFileDataOps::randomizeMemoryRegion(dev_ptr, 0, buffer_size);
         }
         auto flags = std::get<1>(params) | std::get<2>(params) | std::get<3>(params);
         ASSERT_EQ(hipStreamCreateWithFlags(&stream, hipStreamNonBlocking), hipSuccess);
@@ -606,7 +630,7 @@ TEST_P(HipAsyncReadWriteParamsUnchanged, zeroOffsets)
               HIPFILE_SUCCESS);
     ASSERT_EQ(hipStreamSynchronize(stream), hipSuccess);
     ASSERT_EQ(bytes_transferred, io_size);
-    assertFileAndMemoryRegionsMatch(dev_ptr, buffer_offset, tf.fd, file_offset, io_size);
+    HipFileDataOps::assertFileAndMemoryRegionsMatch(dev_ptr, buffer_offset, tf.fd, file_offset, io_size);
 }
 
 TEST_P(HipAsyncReadWriteParamsUnchanged, ioSizeUnaligned)
@@ -616,12 +640,12 @@ TEST_P(HipAsyncReadWriteParamsUnchanged, ioSizeUnaligned)
               HIPFILE_SUCCESS);
     ASSERT_EQ(hipStreamSynchronize(stream), hipSuccess);
     ASSERT_EQ(bytes_transferred, io_size);
-    assertFileAndMemoryRegionsMatch(dev_ptr, buffer_offset, tf.fd, file_offset, io_size);
+    HipFileDataOps::assertFileAndMemoryRegionsMatch(dev_ptr, buffer_offset, tf.fd, file_offset, io_size);
     if (name == "hipFileReadAsync") {
-        assertZeroedMemRegion(dev_ptr, static_cast<hoff_t>(io_size), 1);
+        HipFileDataOps::assertZeroedMemRegion(dev_ptr, static_cast<hoff_t>(io_size), 1);
     }
     else {
-        assertZeroedFileRegion(tf.fd, static_cast<hoff_t>(io_size), 1);
+        HipFileDataOps::assertZeroedFileRegion(tf.fd, static_cast<hoff_t>(io_size), 1);
     }
 }
 
@@ -633,12 +657,12 @@ TEST_P(HipAsyncReadWriteParamsUnchanged, fileOffsetAndIoSizeUnaligned)
               HIPFILE_SUCCESS);
     ASSERT_EQ(hipStreamSynchronize(stream), hipSuccess);
     ASSERT_EQ(bytes_transferred, io_size);
-    assertFileAndMemoryRegionsMatch(dev_ptr, buffer_offset, tf.fd, file_offset, io_size);
+    HipFileDataOps::assertFileAndMemoryRegionsMatch(dev_ptr, buffer_offset, tf.fd, file_offset, io_size);
     if (name == "hipFileReadAsync") {
-        assertZeroedMemRegion(dev_ptr, static_cast<hoff_t>(io_size), 1);
+        HipFileDataOps::assertZeroedMemRegion(dev_ptr, static_cast<hoff_t>(io_size), 1);
     }
     else {
-        assertZeroedFileRegion(tf.fd, 0, 1);
+        HipFileDataOps::assertZeroedFileRegion(tf.fd, 0, 1);
     }
 }
 
@@ -650,12 +674,12 @@ TEST_P(HipAsyncReadWriteParamsUnchanged, bufferOffsetAndIoSizeUnaligned)
               HIPFILE_SUCCESS);
     ASSERT_EQ(hipStreamSynchronize(stream), hipSuccess);
     ASSERT_EQ(bytes_transferred, io_size);
-    assertFileAndMemoryRegionsMatch(dev_ptr, buffer_offset, tf.fd, file_offset, io_size);
+    HipFileDataOps::assertFileAndMemoryRegionsMatch(dev_ptr, buffer_offset, tf.fd, file_offset, io_size);
     if (name == "hipFileReadAsync") {
-        assertZeroedMemRegion(dev_ptr, 0, 1);
+        HipFileDataOps::assertZeroedMemRegion(dev_ptr, 0, 1);
     }
     else {
-        assertZeroedFileRegion(tf.fd, static_cast<hoff_t>(io_size), 1);
+        HipFileDataOps::assertZeroedFileRegion(tf.fd, static_cast<hoff_t>(io_size), 1);
     }
 }
 
@@ -691,7 +715,8 @@ TEST_P(HipAsyncReadWriteParamsUnchanged, multipleOpsOnSameStreamAreSequential)
             if (i == num_ios - 1) {
                 region_size = 16_KiB;
             }
-            assertFileAndMemoryRegionsMatch(dev_ptr, static_cast<hoff_t>(i * 8_KiB), tf.fd, 0, region_size);
+            HipFileDataOps::assertFileAndMemoryRegionsMatch(dev_ptr, static_cast<hoff_t>(i * 8_KiB), tf.fd, 0,
+                                                            region_size);
         }
     }
     else {
@@ -709,7 +734,8 @@ TEST_P(HipAsyncReadWriteParamsUnchanged, multipleOpsOnSameStreamAreSequential)
             if (i == num_ios - 1) {
                 region_size = 16_KiB;
             }
-            assertFileAndMemoryRegionsMatch(dev_ptr, 0, tf.fd, static_cast<hoff_t>(i * 8_KiB), region_size);
+            HipFileDataOps::assertFileAndMemoryRegionsMatch(dev_ptr, 0, tf.fd, static_cast<hoff_t>(i * 8_KiB),
+                                                            region_size);
         }
     }
 }
@@ -773,12 +799,12 @@ public:
         io_op = GetParam().function;
         name  = GetParam().name;
         if (name == "hipFileReadAsync") {
-            zeroMemoryRegion(dev_ptr, 0, buffer_size);
-            randomizeFileRegion(tf.fd, file_size);
+            HipFileDataOps::zeroMemoryRegion(dev_ptr, 0, buffer_size);
+            HipFileDataOps::randomizeFileRegion(tf.fd, file_size);
         }
         else {
-            randomizeMemoryRegion(dev_ptr, 0, buffer_size);
-            zeroFileRegion(tf.fd, file_size);
+            HipFileDataOps::randomizeMemoryRegion(dev_ptr, 0, buffer_size);
+            HipFileDataOps::zeroFileRegion(tf.fd, file_size);
         }
     }
     void TearDown() override
@@ -797,12 +823,12 @@ TEST_P(HipAsyncStreamUnfixedPausedReadWrite, smallerIOSizeIsValid)
     updateFlag(1);
     ASSERT_EQ(hipStreamSynchronize(stream), hipSuccess);
     ASSERT_EQ(bytes_transferred, io_size);
-    assertFileAndMemoryRegionsMatch(dev_ptr, buffer_offset, tf.fd, file_offset, io_size);
+    HipFileDataOps::assertFileAndMemoryRegionsMatch(dev_ptr, buffer_offset, tf.fd, file_offset, io_size);
     if (name == "hipFileReadAsync") {
-        assertZeroedMemRegion(dev_ptr, static_cast<hoff_t>(io_size), 4_KiB);
+        HipFileDataOps::assertZeroedMemRegion(dev_ptr, static_cast<hoff_t>(io_size), 4_KiB);
     }
     else {
-        assertZeroedFileRegion(tf.fd, static_cast<hoff_t>(io_size), 4_KiB);
+        HipFileDataOps::assertZeroedFileRegion(tf.fd, static_cast<hoff_t>(io_size), 4_KiB);
     }
 }
 
@@ -835,12 +861,12 @@ TEST_P(HipAsyncStreamUnfixedPausedReadWrite, changedIOSizeAndFileOffset)
     updateFlag(1);
     ASSERT_EQ(hipStreamSynchronize(stream), hipSuccess);
     ASSERT_EQ(bytes_transferred, io_size);
-    assertFileAndMemoryRegionsMatch(dev_ptr, buffer_offset, tf.fd, file_offset, io_size);
+    HipFileDataOps::assertFileAndMemoryRegionsMatch(dev_ptr, buffer_offset, tf.fd, file_offset, io_size);
     if (name == "hipFileReadAsync") {
-        assertZeroedMemRegion(dev_ptr, static_cast<hoff_t>(io_size), 4_KiB);
+        HipFileDataOps::assertZeroedMemRegion(dev_ptr, static_cast<hoff_t>(io_size), 4_KiB);
     }
     else {
-        assertZeroedFileRegion(tf.fd, 0, 4_KiB);
+        HipFileDataOps::assertZeroedFileRegion(tf.fd, 0, 4_KiB);
     }
 }
 
@@ -853,12 +879,12 @@ TEST_P(HipAsyncStreamUnfixedPausedReadWrite, changedIOSizeAndBufferOffset)
     updateFlag(1);
     ASSERT_EQ(hipStreamSynchronize(stream), hipSuccess);
     ASSERT_EQ(bytes_transferred, io_size);
-    assertFileAndMemoryRegionsMatch(dev_ptr, buffer_offset, tf.fd, file_offset, io_size);
+    HipFileDataOps::assertFileAndMemoryRegionsMatch(dev_ptr, buffer_offset, tf.fd, file_offset, io_size);
     if (name == "hipFileReadAsync") {
-        assertZeroedMemRegion(dev_ptr, 0, 4_KiB);
+        HipFileDataOps::assertZeroedMemRegion(dev_ptr, 0, 4_KiB);
     }
     else {
-        assertZeroedFileRegion(tf.fd, static_cast<hoff_t>(io_size), 4_KiB);
+        HipFileDataOps::assertZeroedFileRegion(tf.fd, static_cast<hoff_t>(io_size), 4_KiB);
     }
 }
 
@@ -872,12 +898,12 @@ TEST_P(HipAsyncStreamUnfixedPausedReadWrite, changedIOSizeAndBufferOffsetAndFile
     updateFlag(1);
     ASSERT_EQ(hipStreamSynchronize(stream), hipSuccess);
     ASSERT_EQ(bytes_transferred, io_size);
-    assertFileAndMemoryRegionsMatch(dev_ptr, buffer_offset, tf.fd, file_offset, io_size);
+    HipFileDataOps::assertFileAndMemoryRegionsMatch(dev_ptr, buffer_offset, tf.fd, file_offset, io_size);
     if (name == "hipFileReadAsync") {
-        assertZeroedMemRegion(dev_ptr, 0, 4_KiB);
+        HipFileDataOps::assertZeroedMemRegion(dev_ptr, 0, 4_KiB);
     }
     else {
-        assertZeroedFileRegion(tf.fd, 0, 4_KiB);
+        HipFileDataOps::assertZeroedFileRegion(tf.fd, 0, 4_KiB);
     }
 }
 

--- a/projects/hipfile/test/system/async.cpp
+++ b/projects/hipfile/test/system/async.cpp
@@ -211,11 +211,11 @@ public:
         ASSERT_EQ(hipFileStreamRegister(hip_stream, 0xf), HIPFILE_SUCCESS);
         auto [_file, _buffer, _stream] =
             Context<DriverState>::get()->getFileBufferAndStream(fh, dev_ptr, hip_stream);
-        file              = _file;
-        buffer            = _buffer;
-        stream            = _stream;
-        op                = std::shared_ptr<AsyncOpFallback>(new AsyncOpFallback(
-            io_type, file, buffer, stream, &io_size, &file_offset, &buffer_offset, &bytes_transferred));
+        file   = _file;
+        buffer = _buffer;
+        stream = _stream;
+        op     = std::make_shared<AsyncOpFallback>(io_type, file, buffer, stream, &io_size, &file_offset,
+                                                   &buffer_offset, &bytes_transferred);
         bytes_transferred = static_cast<ssize_t>(io_size);
         if (io_type == IoType::Read) {
             // For a read, bytes_transferred_internal needs to be set to simulate that the read from disk


### PR DESCRIPTION
Fallback async IO objects currently use hipHostRegister to get pinned host memory.  These are allocated on each IO and freed once it is complete.  hipHostFree synchronizes on the device, which we want to avoid.  ~~hipHostRegister and hipHostDeregister do not synchronize, so we use that instead.~~

Dropping this.  We need a memory pool for async to work properly.

AIHIPFILE-181