### PR TITLE
[rocprofiler-sdk] Add openmpi package to RHEL docker for CI

### DIFF
--- a/projects/rocprofiler-sdk/docker/Dockerfile.ci
+++ b/projects/rocprofiler-sdk/docker/Dockerfile.ci
@@ -58,11 +58,11 @@ RUN set -euo pipefail; \
             echo -e "[amdgpu]\nname=amdgpu\nbaseurl=https://repo.radeon.com/amdgpu/latest/rhel/9.6/main/x86_64/\nenabled=1\npriority=50\ngpgcheck=1\ngpgkey=https://repo.radeon.com/rocm/rocm.gpg.key" > /etc/yum.repos.d/amdgpu.repo; \
         fi; \
         dnf clean all; \
-        dnf install -y rocm-openmp rocm-openmp-sdk rocm-llvm-devel hipify-clang libsqlite3x-devel elfutils-devel; \
+        dnf install -y rocm-openmp rocm-openmp-sdk rocm-llvm-devel hipify-clang libsqlite3x-devel openmpi-devel elfutils-devel; \
         python3 -m pip install -U awscli pipx; \
         python3 -m venv rocprofiler-sdk; \
         source rocprofiler-sdk/bin/activate; \
-        export PATH=/opt/rh/gcc-toolset-11/root/usr/bin:${PATH}; \
+        export PATH=/opt/rh/gcc-toolset-11/root/usr/bin:/usr/lib64/openmpi/bin:${PATH}; \
         python3 -m pip install --upgrade pip; \
         python3 -m pip install --upgrade -r /root/requirements.txt; \
         echo -e 'PKG_CONFIG_PATH="/opt/amdgpu/lib64/pkgconfig:/opt/amdgpu/lib/pkgconfig:/opt/amdgpu/lib/$(uname -p)-linux-gnu/pkgconfig:${PKG_CONFIG_PATH}"\nexport PKG_CONFIG_PATH' > /etc/profile.d/amdgpu-pkg-config.sh; \

--- a/projects/rocprofiler-sdk/docker/Dockerfile.ci
+++ b/projects/rocprofiler-sdk/docker/Dockerfile.ci
@@ -14,7 +14,7 @@ ENV HIP_RUNTIME=rocclr
 ENV HIP_COMPILER=amdclang++
 ENV LLVM_PATH=/opt/rocm/llvm
 ENV CMAKE_PREFIX_PATH=/opt/rocm
-ENV PATH=/opt/rh/gcc-toolset-11/root/usr/bin:/opt/rocm/bin:/opt/rocm/llvm/bin:/usr/local/bin:~/.local/bin:${PATH}
+ENV PATH=/opt/rh/gcc-toolset-11/root/usr/bin:/usr/lib64/openmpi/bin:/opt/rocm/bin:/opt/rocm/llvm/bin:/usr/local/bin:~/.local/bin:${PATH}
 ENV LD_LIBRARY_PATH=/opt/rocm/lib:/opt/rocm/llvm/lib:${LD_LIBRARY_PATH}
 
 # Debian/Ubuntu
@@ -62,7 +62,7 @@ RUN set -euo pipefail; \
         python3 -m pip install -U awscli pipx; \
         python3 -m venv rocprofiler-sdk; \
         source rocprofiler-sdk/bin/activate; \
-        export PATH=/opt/rh/gcc-toolset-11/root/usr/bin:/usr/lib64/openmpi/bin:${PATH}; \
+        export PATH=/opt/rh/gcc-toolset-11/root/usr/bin:${PATH}; \
         python3 -m pip install --upgrade pip; \
         python3 -m pip install --upgrade -r /root/requirements.txt; \
         echo -e 'PKG_CONFIG_PATH="/opt/amdgpu/lib64/pkgconfig:/opt/amdgpu/lib/pkgconfig:/opt/amdgpu/lib/$(uname -p)-linux-gnu/pkgconfig:${PKG_CONFIG_PATH}"\nexport PKG_CONFIG_PATH' > /etc/profile.d/amdgpu-pkg-config.sh; \


### PR DESCRIPTION
## Motivation

Install openmpi package onto RHEL CI docker images

## Technical Details

This will allow MPI tests to be run on CI.  Seems like find_package(MPI) does work on the Ubuntu and SLES CI images.

## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
