### PR TITLE
Fix output index calculation in transpose_a kernel

### DIFF
--- a/projects/rocprofiler-systems/examples/transpose/transpose.new.cpp
+++ b/projects/rocprofiler-systems/examples/transpose/transpose.new.cpp
@@ -83,7 +83,7 @@ transpose_a(int* in, int* out, int M, int N)
     int iidx = (blockIdx.x * blockDim.x + threadIdx.x) * N + blockIdx.y * blockDim.y +
                threadIdx.y;
     int oidx =
-        (blockIdx.y * blockDim.y + threadIdx.y) * +blockIdx.x * blockDim.x + threadIdx.x;
+        (blockIdx.y * blockDim.y + threadIdx.y) * M + (blockIdx.x * blockDim.x + threadIdx.x);
 
     out[oidx] = in[iidx];
 }


### PR DESCRIPTION
transpose_a kernel in transpose.new.cpp had a missing statement of int M, that caused a mismatch in the transpose calculation

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
